### PR TITLE
Add tenant environment open command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ Repository guidance for humans and coding agents working in this repo.
 - Use `bug/<issue-number>-<short-kebab-case-description>` for bug fixes.
 - Include the issue number in the branch name for traceability, for example `feature/12-add-mcp-server-entrypoint`.
 - Open pull requests back into `main` and reference the issue in the PR body, for example `Closes #12`.
+- Treat `push, accept` as a request to complete the full publish flow: push the branch, create the pull request, and leave the PR in a non-draft accepted/ready-for-review state. Do not stop after the branch push alone.
 
 ## Pull Request Titles
 

--- a/erun-cli/cmd/init.go
+++ b/erun-cli/cmd/init.go
@@ -7,9 +7,12 @@ import (
 
 	"github.com/manifoldco/promptui"
 	eruncommon "github.com/sophium/erun/erun-common"
+	"github.com/sophium/erun/internal"
 	"github.com/sophium/erun/internal/bootstrap"
 	"github.com/spf13/cobra"
 )
+
+const initializeCurrentProjectOption = "Initialize current project"
 
 func NewInitCmd(deps Dependencies, verbosity *int) *cobra.Command {
 	req := bootstrap.InitRequest{}
@@ -17,9 +20,14 @@ func NewInitCmd(deps Dependencies, verbosity *int) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "init",
 		Short:        "Initialize configuration for the current project",
+		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInitCommand(cmd, deps, verbosity, req)
+			request := req
+			if request.Tenant == "" && len(args) > 0 {
+				request.Tenant = args[0]
+			}
+			return runInitCommand(cmd, deps, verbosity, request)
 		},
 	}
 
@@ -35,6 +43,9 @@ func runInitCommand(cmd *cobra.Command, deps Dependencies, verbosity *int, req b
 	service := bootstrap.Service{
 		Store:           deps.Store,
 		FindProjectRoot: deps.FindProjectRoot,
+		SelectTenant: func(tenants []internal.TenantConfig) (bootstrap.TenantSelectionResult, error) {
+			return selectTenantPrompt(deps.SelectRunner, tenants)
+		},
 		Confirm: func(label string) (bool, error) {
 			return confirmPrompt(deps.PromptRunner, label)
 		},
@@ -77,4 +88,34 @@ func confirmPrompt(run PromptRunner, label string) (bool, error) {
 	}
 
 	return strings.EqualFold(result, "y"), nil
+}
+
+func selectTenantPrompt(run SelectRunner, tenants []internal.TenantConfig) (bootstrap.TenantSelectionResult, error) {
+	items := make([]string, 0, len(tenants)+1)
+	for _, tenant := range tenants {
+		items = append(items, tenant.Name)
+	}
+	items = append(items, initializeCurrentProjectOption)
+
+	prompt := promptui.Select{
+		Label: "Select tenant",
+		Items: items,
+	}
+
+	_, result, err := run(prompt)
+	if err != nil {
+		if errors.Is(err, promptui.ErrInterrupt) {
+			return bootstrap.TenantSelectionResult{}, fmt.Errorf("tenant selection interrupted")
+		}
+		if errors.Is(err, promptui.ErrAbort) {
+			return bootstrap.TenantSelectionResult{}, nil
+		}
+		return bootstrap.TenantSelectionResult{}, err
+	}
+
+	if result == initializeCurrentProjectOption {
+		return bootstrap.TenantSelectionResult{Initialize: true}, nil
+	}
+
+	return bootstrap.TenantSelectionResult{Tenant: result}, nil
 }

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/sophium/erun/internal"
+	"github.com/sophium/erun/internal/opener"
+	"github.com/spf13/cobra"
+)
+
+func NewOpenCmd(deps Dependencies) *cobra.Command {
+	return &cobra.Command{
+		Use:          "open TENANT ENVIRONMENT",
+		Short:        "Open a shell in the tenant environment worktree",
+		Args:         cobra.ExactArgs(2),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOpenCommand(deps, opener.Request{
+				Tenant:      args[0],
+				Environment: args[1],
+			})
+		},
+	}
+}
+
+func runOpenCommand(deps Dependencies, req opener.Request) error {
+	_, err := newOpenService(deps).Run(req)
+	return err
+}
+
+func resolveOpenCommand(deps Dependencies, req opener.Request) (opener.Result, error) {
+	return newOpenService(deps).Resolve(req)
+}
+
+func launchOpenResult(deps Dependencies, result opener.Result) error {
+	launcher := deps.LaunchShell
+	if launcher == nil {
+		launcher = opener.DefaultShellLauncher
+	}
+	return launcher(opener.ShellLaunchRequest{
+		Dir:   result.RepoPath,
+		Title: result.Title,
+	})
+}
+
+func newOpenService(deps Dependencies) opener.Service {
+	deps = withDependencyDefaults(deps)
+	return opener.Service{
+		Store:       deps.Store,
+		LaunchShell: deps.LaunchShell,
+	}
+}
+
+func openerIsDefaultError(err error) bool {
+	return errors.Is(err, opener.ErrDefaultTenantNotConfigured) ||
+		errors.Is(err, opener.ErrDefaultEnvironmentNotConfigured) ||
+		errors.Is(err, internal.ErrNotInitialized)
+}

--- a/erun-cli/cmd/open_test.go
+++ b/erun-cli/cmd/open_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/sophium/erun/internal"
+	"github.com/sophium/erun/internal/opener"
+)
+
+func TestOpenCommandLaunchesShell(t *testing.T) {
+	repoPath := t.TempDir()
+	launched := opener.ShellLaunchRequest{}
+	cmd := NewOpenCmd(Dependencies{
+		Store: openCommandStore{repoPath: repoPath},
+		LaunchShell: func(req opener.ShellLaunchRequest) error {
+			launched = req
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"tenant-a", "dev"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if launched.Dir != repoPath || launched.Title != "tenant-a-dev" {
+		t.Fatalf("unexpected shell launch: %+v", launched)
+	}
+}
+
+type openCommandStore struct {
+	repoPath string
+}
+
+func (openCommandStore) LoadERunConfig() (internal.ERunConfig, string, error) {
+	return internal.ERunConfig{}, "", nil
+}
+
+func (openCommandStore) SaveERunConfig(internal.ERunConfig) error {
+	return nil
+}
+
+func (openCommandStore) ListTenantConfigs() ([]internal.TenantConfig, error) {
+	return nil, nil
+}
+
+func (s openCommandStore) LoadTenantConfig(tenant string) (internal.TenantConfig, string, error) {
+	return internal.TenantConfig{
+		Name:               tenant,
+		ProjectRoot:        s.repoPath,
+		DefaultEnvironment: "local",
+	}, "", nil
+}
+
+func (openCommandStore) SaveTenantConfig(internal.TenantConfig) error {
+	return nil
+}
+
+func (s openCommandStore) LoadEnvConfig(tenant, env string) (internal.EnvConfig, string, error) {
+	return internal.EnvConfig{
+		Name:     env,
+		RepoPath: s.repoPath,
+	}, "", nil
+}
+
+func (openCommandStore) SaveEnvConfig(string, internal.EnvConfig) error {
+	return nil
+}

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -1,18 +1,26 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/manifoldco/promptui"
 	"github.com/sophium/erun/internal"
 	"github.com/sophium/erun/internal/bootstrap"
+	"github.com/sophium/erun/internal/opener"
 	"github.com/spf13/cobra"
 )
 
-type PromptRunner func(promptui.Prompt) (string, error)
+type (
+	PromptRunner func(promptui.Prompt) (string, error)
+	SelectRunner func(promptui.Select) (int, string, error)
+)
 
 type Dependencies struct {
 	Store           bootstrap.Store
 	FindProjectRoot bootstrap.ProjectFinder
 	PromptRunner    PromptRunner
+	SelectRunner    SelectRunner
+	LaunchShell     opener.ShellLauncher
 }
 
 func DefaultDependencies() Dependencies {
@@ -20,10 +28,15 @@ func DefaultDependencies() Dependencies {
 		Store:           bootstrap.ConfigStore{},
 		FindProjectRoot: internal.FindProjectRoot,
 		PromptRunner:    defaultPromptRunner,
+		LaunchShell:     opener.DefaultShellLauncher,
 	}
 }
 
 var defaultPromptRunner = func(prompt promptui.Prompt) (string, error) {
+	return prompt.Run()
+}
+
+var defaultSelectRunner = func(prompt promptui.Select) (int, string, error) {
 	return prompt.Run()
 }
 
@@ -32,18 +45,65 @@ func NewRootCmd(deps Dependencies) *cobra.Command {
 	var verbosity int
 
 	cmd := &cobra.Command{
-		Use:           "erun",
-		Short:         "Environment Runner",
-		Long:          `erun helps to run and manage multiple tenants/environments.`,
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Use:              "erun",
+		Short:            "Environment Runner",
+		Long:             `erun helps to run and manage multiple tenants/environments.`,
+		Args:             cobra.MaximumNArgs(2),
+		SilenceUsage:     true,
+		SilenceErrors:    true,
+		TraverseChildren: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInitCommand(cmd, deps, &verbosity, bootstrap.InitRequest{})
+			switch len(args) {
+			case 0:
+				result, err := resolveOpenCommand(deps, opener.Request{
+					UseDefaultTenant:      true,
+					UseDefaultEnvironment: true,
+				})
+				if err != nil {
+					if shouldInitRootCommand(err) {
+						initReq, initErr := initRequestForRootCommand(deps, args)
+						if initErr != nil {
+							return initErr
+						}
+						return runInitCommand(cmd, deps, &verbosity, initReq)
+					}
+					return err
+				}
+				return launchOpenResult(deps, result)
+			case 1:
+				result, err := resolveOpenCommand(deps, opener.Request{
+					Environment:      args[0],
+					UseDefaultTenant: true,
+				})
+				if err != nil {
+					if shouldInitRootCommand(err) {
+						initReq, initErr := initRequestForRootCommand(deps, args)
+						if initErr != nil {
+							return initErr
+						}
+						return runInitCommand(cmd, deps, &verbosity, initReq)
+					}
+					return err
+				}
+				return launchOpenResult(deps, result)
+			case 2:
+				result, err := resolveOpenCommand(deps, opener.Request{
+					Tenant:      args[0],
+					Environment: args[1],
+				})
+				if err != nil {
+					return err
+				}
+				return launchOpenResult(deps, result)
+			default:
+				return cobra.MaximumNArgs(2)(cmd, args)
+			}
 		},
 	}
 
 	cmd.PersistentFlags().CountVarP(&verbosity, "verbose", "v", "Increase logging verbosity. Repeat for more detail.")
 	cmd.AddCommand(NewInitCmd(deps, &verbosity))
+	cmd.AddCommand(NewOpenCmd(deps))
 	cmd.AddCommand(NewMCPCmd(deps))
 	cmd.AddCommand(NewVersionCmd())
 	return cmd
@@ -63,5 +123,78 @@ func withDependencyDefaults(deps Dependencies) Dependencies {
 	if deps.PromptRunner == nil {
 		deps.PromptRunner = defaultPromptRunner
 	}
+	if deps.SelectRunner == nil {
+		deps.SelectRunner = defaultSelectRunner
+	}
+	if deps.LaunchShell == nil {
+		deps.LaunchShell = opener.DefaultShellLauncher
+	}
 	return deps
+}
+
+func shouldInitRootCommand(err error) bool {
+	return openerIsDefaultError(err) || internal.IsReported(err)
+}
+
+func initRequestForRootCommand(deps Dependencies, args []string) (bootstrap.InitRequest, error) {
+	envName := ""
+	if len(args) == 1 {
+		envName = args[0]
+	}
+
+	tenant, err := loadDefaultTenant(deps.Store)
+	if err != nil {
+		if errors.Is(err, opener.ErrDefaultTenantNotConfigured) || errors.Is(err, internal.ErrNotInitialized) {
+			return bootstrap.InitRequest{
+				Environment:   envName,
+				ResolveTenant: true,
+			}, nil
+		}
+		return bootstrap.InitRequest{}, err
+	}
+
+	if envName != "" {
+		return bootstrap.InitRequest{
+			Tenant:      tenant,
+			Environment: envName,
+		}, nil
+	}
+
+	defaultEnvironment, err := loadDefaultEnvironment(deps.Store, tenant)
+	if err != nil {
+		if errors.Is(err, opener.ErrDefaultEnvironmentNotConfigured) || errors.Is(err, internal.ErrNotInitialized) {
+			return bootstrap.InitRequest{Tenant: tenant}, nil
+		}
+		return bootstrap.InitRequest{}, err
+	}
+
+	return bootstrap.InitRequest{
+		Tenant:      tenant,
+		Environment: defaultEnvironment,
+	}, nil
+}
+
+func loadDefaultTenant(store bootstrap.Store) (string, error) {
+	toolConfig, _, err := store.LoadERunConfig()
+	if errors.Is(err, internal.ErrNotInitialized) {
+		return "", opener.ErrDefaultTenantNotConfigured
+	}
+	if err != nil {
+		return "", err
+	}
+	if toolConfig.DefaultTenant == "" {
+		return "", opener.ErrDefaultTenantNotConfigured
+	}
+	return toolConfig.DefaultTenant, nil
+}
+
+func loadDefaultEnvironment(store bootstrap.Store, tenant string) (string, error) {
+	tenantConfig, _, err := store.LoadTenantConfig(tenant)
+	if err != nil {
+		return "", err
+	}
+	if tenantConfig.DefaultEnvironment == "" {
+		return "", opener.ErrDefaultEnvironmentNotConfigured
+	}
+	return tenantConfig.DefaultEnvironment, nil
 }

--- a/erun-cli/cmd/root_test.go
+++ b/erun-cli/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -10,12 +11,13 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/sophium/erun/internal"
 	"github.com/sophium/erun/internal/bootstrap"
+	"github.com/sophium/erun/internal/opener"
 )
 
 func TestNewRootCmdRegistersCommands(t *testing.T) {
 	cmd := NewRootCmd(Dependencies{})
 
-	for _, name := range []string{"init", "mcp", "version"} {
+	for _, name := range []string{"init", "open", "mcp", "version"} {
 		found, _, err := cmd.Find([]string{name})
 		if err != nil {
 			t.Fatalf("Find(%q) failed: %v", name, err)
@@ -41,6 +43,7 @@ func TestRootCommandRunsInitWhenNoSubcommand(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
+	cmd.SetArgs([]string{})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute failed: %v", err)
@@ -70,8 +73,168 @@ func TestRootCommandRunsInitWhenNoSubcommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEnvConfig failed: %v", err)
 	}
-	if envConfig.Name != bootstrap.DefaultEnvironment {
+	if envConfig.Name != bootstrap.DefaultEnvironment || envConfig.RepoPath != projectRoot {
 		t.Fatalf("unexpected env config: %+v", envConfig)
+	}
+}
+
+func TestRootCommandRunsOpenWithDefaults(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+
+	projectRoot := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
+		t.Fatalf("mkdir project root: %v", err)
+	}
+	if err := internal.SaveERunConfig(internal.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
+		t.Fatalf("save erun config: %v", err)
+	}
+	if err := internal.SaveTenantConfig(internal.TenantConfig{
+		Name:               "tenant-a",
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: "dev",
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := internal.SaveEnvConfig("tenant-a", internal.EnvConfig{Name: "dev", RepoPath: projectRoot}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+
+	launched := opener.ShellLaunchRequest{}
+	cmd := NewRootCmd(Dependencies{
+		FindProjectRoot: func() (string, string, error) {
+			t.Fatal("unexpected project detection")
+			return "", "", nil
+		},
+		PromptRunner: func(promptui.Prompt) (string, error) {
+			t.Fatal("unexpected prompt")
+			return "", nil
+		},
+		LaunchShell: func(req opener.ShellLaunchRequest) error {
+			launched = req
+			return nil
+		},
+	})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if launched.Dir != projectRoot || launched.Title != "tenant-a-dev" {
+		t.Fatalf("unexpected shell launch: %+v", launched)
+	}
+}
+
+func TestRootCommandRunsOpenWithDefaultTenantAndRequestedEnvironment(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+
+	projectRoot := filepath.Join(t.TempDir(), "tenant-a-dev")
+	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
+		t.Fatalf("mkdir project root: %v", err)
+	}
+	if err := internal.SaveERunConfig(internal.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
+		t.Fatalf("save erun config: %v", err)
+	}
+	if err := internal.SaveTenantConfig(internal.TenantConfig{
+		Name:               "tenant-a",
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: bootstrap.DefaultEnvironment,
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := internal.SaveEnvConfig("tenant-a", internal.EnvConfig{Name: "dev", RepoPath: projectRoot}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+
+	launched := opener.ShellLaunchRequest{}
+	cmd := NewRootCmd(Dependencies{
+		FindProjectRoot: func() (string, string, error) {
+			t.Fatal("unexpected project detection")
+			return "", "", nil
+		},
+		PromptRunner: func(prompt promptui.Prompt) (string, error) {
+			t.Fatalf("unexpected confirmation: %+v", prompt)
+			return "", nil
+		},
+		LaunchShell: func(req opener.ShellLaunchRequest) error {
+			launched = req
+			return nil
+		},
+	})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"dev"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if launched.Dir != projectRoot || launched.Title != "tenant-a-dev" {
+		t.Fatalf("unexpected shell launch: %+v", launched)
+	}
+}
+
+func TestRootCommandRunsOpenWithExplicitTenantAndEnvironment(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+
+	projectRoot := filepath.Join(t.TempDir(), "dog-me")
+	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
+		t.Fatalf("mkdir project root: %v", err)
+	}
+	if err := internal.SaveTenantConfig(internal.TenantConfig{
+		Name:               "dog",
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: "local",
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := internal.SaveEnvConfig("dog", internal.EnvConfig{Name: "me", RepoPath: projectRoot}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+
+	launched := opener.ShellLaunchRequest{}
+	cmd := NewRootCmd(Dependencies{
+		LaunchShell: func(req opener.ShellLaunchRequest) error {
+			launched = req
+			return nil
+		},
+	})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"dog", "me"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if launched.Dir != projectRoot || launched.Title != "dog-me" {
+		t.Fatalf("unexpected shell launch: %+v", launched)
+	}
+}
+
+func TestRootCommandExplicitTenantFailsWhenMissing(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+
+	cmd := NewRootCmd(Dependencies{})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"dog", "me"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing tenant error")
+	}
+	if !errors.Is(err, opener.ErrTenantNotFound) {
+		t.Fatalf("expected ErrTenantNotFound, got %v", err)
+	}
+	if got := err.Error(); !bytes.Contains([]byte(got), []byte("no such tenant exists")) {
+		t.Fatalf("expected missing tenant message, got %q", got)
 	}
 }
 
@@ -89,7 +252,7 @@ func TestInitCommandPreservesExistingTenantDefaultEnvironmentWhenFlagOmitted(t *
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := internal.SaveEnvConfig("tenant-a", internal.EnvConfig{Name: "prod"}); err != nil {
+	if err := internal.SaveEnvConfig("tenant-a", internal.EnvConfig{Name: "prod", RepoPath: projectRoot}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}
 
@@ -148,7 +311,7 @@ func TestRootCommandHelpFlagPrintsHelp(t *testing.T) {
 	}
 
 	output := buf.String()
-	for _, want := range []string{"init", "mcp", "version"} {
+	for _, want := range []string{"init", "open", "mcp", "version"} {
 		if !bytes.Contains([]byte(output), []byte(want)) {
 			t.Fatalf("expected help output to mention %q, got %q", want, output)
 		}
@@ -166,6 +329,7 @@ func TestRootCommandInitErrorsDoNotPrintHelp(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
+	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
 	if !errors.Is(err, internal.ErrNotInGitRepository) {
@@ -217,6 +381,7 @@ func TestRootCommandInitErrorsDoNotPrintErrorTwice(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
+	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
 	if !errors.Is(err, internal.ErrNotInGitRepository) {
@@ -270,11 +435,15 @@ func TestExecuteReturnsUnderlyingError(t *testing.T) {
 		defaultPromptRunner = previous
 	})
 
-	err := NewRootCmd(Dependencies{
+	cmd := NewRootCmd(Dependencies{
 		FindProjectRoot: func() (string, string, error) {
 			return "", "", internal.ErrNotInGitRepository
 		},
-	}).Execute()
+	})
+	cmd.SetArgs([]string{})
+	err := func() error {
+		return cmd.Execute()
+	}()
 	if !errors.Is(err, internal.ErrNotInGitRepository) {
 		t.Fatalf("expected ErrNotInGitRepository, got %v", err)
 	}

--- a/erun-cli/internal/bootstrap/service.go
+++ b/erun-cli/internal/bootstrap/service.go
@@ -3,6 +3,9 @@ package bootstrap
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/sophium/erun/internal"
 )
@@ -12,22 +15,32 @@ const DefaultEnvironment = "local"
 var (
 	ErrTenantInitializationCancelled      = errors.New("tenant initialization cancelled by user")
 	ErrEnvironmentInitializationCancelled = errors.New("environment initialization cancelled by user")
+	ErrTenantSelectionCancelled           = errors.New("tenant selection cancelled by user")
 )
 
 type Store interface {
 	LoadERunConfig() (internal.ERunConfig, string, error)
 	SaveERunConfig(internal.ERunConfig) error
+	ListTenantConfigs() ([]internal.TenantConfig, error)
 	LoadTenantConfig(string) (internal.TenantConfig, string, error)
 	SaveTenantConfig(internal.TenantConfig) error
 	LoadEnvConfig(string, string) (internal.EnvConfig, string, error)
 	SaveEnvConfig(string, internal.EnvConfig) error
 }
 
-type ProjectFinder func() (string, string, error)
+type (
+	ProjectFinder    func() (string, string, error)
+	WorkDirFunc      func() (string, error)
+	SelectTenantFunc func([]internal.TenantConfig) (TenantSelectionResult, error)
+)
 
 type (
-	ConfirmFunc func(label string) (bool, error)
-	Logger      interface {
+	ConfirmFunc           func(label string) (bool, error)
+	TenantSelectionResult struct {
+		Tenant     string
+		Initialize bool
+	}
+	Logger interface {
 		Trace(string)
 		Error(string)
 	}
@@ -41,6 +54,10 @@ func (ConfigStore) LoadERunConfig() (internal.ERunConfig, string, error) {
 
 func (ConfigStore) SaveERunConfig(config internal.ERunConfig) error {
 	return internal.SaveERunConfig(config)
+}
+
+func (ConfigStore) ListTenantConfigs() ([]internal.TenantConfig, error) {
+	return internal.ListTenantConfigs()
 }
 
 func (ConfigStore) LoadTenantConfig(tenant string) (internal.TenantConfig, string, error) {
@@ -60,10 +77,11 @@ func (ConfigStore) SaveEnvConfig(tenant string, config internal.EnvConfig) error
 }
 
 type InitRequest struct {
-	Tenant      string
-	ProjectRoot string
-	Environment string
-	AutoApprove bool
+	Tenant        string
+	ProjectRoot   string
+	Environment   string
+	AutoApprove   bool
+	ResolveTenant bool
 }
 
 type InitResult struct {
@@ -78,6 +96,8 @@ type InitResult struct {
 type Service struct {
 	Store           Store
 	FindProjectRoot ProjectFinder
+	GetWorkingDir   WorkDirFunc
+	SelectTenant    SelectTenantFunc
 	Confirm         ConfirmFunc
 	Logger          Logger
 }
@@ -88,18 +108,16 @@ func (s Service) Run(req InitRequest) (InitResult, error) {
 
 	var result InitResult
 	var detected projectContext
+	var tenants []internal.TenantConfig
+	var tenantsLoaded bool
+	var tenantConfirmed bool
 
-	detectProject := func() (projectContext, error) {
+	findProject := func() (projectContext, error) {
 		if detected.loaded {
 			return detected, nil
 		}
-		s.Logger.Trace("Trying to detect current project directory")
 		tenant, root, err := s.FindProjectRoot()
 		if err != nil {
-			if errors.Is(err, internal.ErrNotInGitRepository) {
-				s.Logger.Error("erun config is not initialized. Run erun in project directory.")
-				return projectContext{}, internal.MarkReported(err)
-			}
 			return projectContext{}, err
 		}
 		detected = projectContext{
@@ -110,11 +128,42 @@ func (s Service) Run(req InitRequest) (InitResult, error) {
 		return detected, nil
 	}
 
+	detectProject := func() (projectContext, error) {
+		s.Logger.Trace("Trying to detect current project directory")
+		project, err := findProject()
+		if err != nil {
+			if errors.Is(err, internal.ErrNotInGitRepository) {
+				s.Logger.Error("erun config is not initialized. Run erun in project directory.")
+				return projectContext{}, internal.MarkReported(err)
+			}
+			return projectContext{}, err
+		}
+		return project, nil
+	}
+
+	loadTenants := func() ([]internal.TenantConfig, error) {
+		if tenantsLoaded {
+			return tenants, nil
+		}
+		loadedTenants, err := s.Store.ListTenantConfigs()
+		if err != nil {
+			return nil, err
+		}
+		tenants = loadedTenants
+		tenantsLoaded = true
+		return tenants, nil
+	}
+
 	toolConfig, configPath, err := s.Store.LoadERunConfig()
+	toolConfigMissing := false
 	s.Logger.Trace("Loading erun tool configuration, configPath=" + configPath)
 	switch {
 	case err == nil:
 	case errors.Is(err, internal.ErrNotInitialized):
+		toolConfigMissing = true
+		if req.ResolveTenant {
+			break
+		}
 		tenant := req.Tenant
 		projectRoot := req.ProjectRoot
 		if tenant == "" || projectRoot == "" {
@@ -133,6 +182,7 @@ func (s Service) Run(req InitRequest) (InitResult, error) {
 		if err := s.confirmTenant(req.AutoApprove, tenant, projectRoot); err != nil {
 			return result, err
 		}
+		tenantConfirmed = true
 
 		s.Logger.Trace("Saving default config")
 		toolConfig = internal.ERunConfig{DefaultTenant: tenant}
@@ -140,14 +190,45 @@ func (s Service) Run(req InitRequest) (InitResult, error) {
 			return result, err
 		}
 		result.CreatedERunConfig = true
+		toolConfigMissing = false
 	case err != nil:
 		return result, err
 	}
 	s.Logger.Trace("Loaded erun tool configuration")
 
 	tenant := req.Tenant
+	if tenant == "" && req.ResolveTenant {
+		loadedTenants, err := loadTenants()
+		if err != nil {
+			return result, err
+		}
+		if len(loadedTenants) > 0 {
+			workingDir, err := s.GetWorkingDir()
+			if err != nil {
+				return result, err
+			}
+			if currentTenant, found := findTenantForDirectory(workingDir, loadedTenants); found {
+				tenant = currentTenant.Name
+			}
+		}
+	}
 	if tenant == "" {
 		tenant = toolConfig.DefaultTenant
+	}
+	if tenant == "" && req.ResolveTenant {
+		loadedTenants, err := loadTenants()
+		if err != nil {
+			return result, err
+		}
+		if len(loadedTenants) > 0 {
+			selection, err := s.selectTenant(loadedTenants)
+			if err != nil {
+				return result, err
+			}
+			if !selection.Initialize {
+				tenant = selection.Tenant
+			}
+		}
 	}
 	if tenant == "" {
 		project, detectErr := detectProject()
@@ -169,6 +250,12 @@ func (s Service) Run(req InitRequest) (InitResult, error) {
 				return result, detectErr
 			}
 			projectRoot = project.root
+		}
+
+		if !tenantConfirmed {
+			if err := s.confirmTenant(req.AutoApprove, tenant, projectRoot); err != nil {
+				return result, err
+			}
 		}
 
 		defaultEnvironment := req.Environment
@@ -214,12 +301,28 @@ func (s Service) Run(req InitRequest) (InitResult, error) {
 	switch {
 	case err == nil:
 	case errors.Is(err, internal.ErrNotInitialized):
+		envProjectRoot := req.ProjectRoot
+		if envProjectRoot == "" {
+			envProjectRoot = tenantConfig.ProjectRoot
+		}
+		if envProjectRoot == "" {
+			project, detectErr := findProject()
+			if detectErr == nil {
+				envProjectRoot = project.root
+			} else if !errors.Is(detectErr, internal.ErrNotInGitRepository) {
+				return result, detectErr
+			}
+		}
+
 		if err := s.confirmEnvironment(req.AutoApprove, tenant, envName); err != nil {
 			return result, err
 		}
 
 		s.Logger.Trace("Adding new environment")
-		envConfig = internal.EnvConfig{Name: envName}
+		envConfig = internal.EnvConfig{
+			Name:     envName,
+			RepoPath: envProjectRoot,
+		}
 		if err := s.Store.SaveEnvConfig(tenant, envConfig); err != nil {
 			return result, err
 		}
@@ -229,7 +332,14 @@ func (s Service) Run(req InitRequest) (InitResult, error) {
 	}
 
 	if toolConfig.DefaultTenant == "" {
+		s.Logger.Trace("Saving default config")
 		toolConfig.DefaultTenant = tenant
+		if err := s.Store.SaveERunConfig(toolConfig); err != nil {
+			return result, err
+		}
+		if toolConfigMissing {
+			result.CreatedERunConfig = true
+		}
 	}
 
 	result.ERunConfig = toolConfig
@@ -266,6 +376,9 @@ func (s Service) withDefaults() Service {
 	if s.FindProjectRoot == nil {
 		s.FindProjectRoot = internal.FindProjectRoot
 	}
+	if s.GetWorkingDir == nil {
+		s.GetWorkingDir = os.Getwd
+	}
 	if s.Logger == nil {
 		s.Logger = noopLogger{}
 	}
@@ -298,6 +411,56 @@ func (s Service) confirm(label string, cancelled error) error {
 		return cancelled
 	}
 	return nil
+}
+
+func (s Service) selectTenant(tenants []internal.TenantConfig) (TenantSelectionResult, error) {
+	if s.SelectTenant == nil {
+		return TenantSelectionResult{}, fmt.Errorf("tenant selection required")
+	}
+	selection, err := s.SelectTenant(tenants)
+	if err != nil {
+		return TenantSelectionResult{}, err
+	}
+	if selection.Initialize {
+		return selection, nil
+	}
+	if selection.Tenant == "" {
+		return TenantSelectionResult{}, ErrTenantSelectionCancelled
+	}
+	return selection, nil
+}
+
+func findTenantForDirectory(dir string, tenants []internal.TenantConfig) (internal.TenantConfig, bool) {
+	cleanDir := filepath.Clean(dir)
+	bestIndex := -1
+
+	for i, tenant := range tenants {
+		if tenant.ProjectRoot == "" {
+			continue
+		}
+		if !isWithinDirectory(cleanDir, filepath.Clean(tenant.ProjectRoot)) {
+			continue
+		}
+		if bestIndex == -1 || len(tenant.ProjectRoot) > len(tenants[bestIndex].ProjectRoot) {
+			bestIndex = i
+		}
+	}
+
+	if bestIndex == -1 {
+		return internal.TenantConfig{}, false
+	}
+	return tenants[bestIndex], true
+}
+
+func isWithinDirectory(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
 }
 
 type projectContext struct {

--- a/erun-cli/internal/bootstrap/service_test.go
+++ b/erun-cli/internal/bootstrap/service_test.go
@@ -37,7 +37,7 @@ func TestRunLoadsExistingConfiguration(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := internal.SaveEnvConfig(tenant, internal.EnvConfig{Name: DefaultEnvironment}); err != nil {
+	if err := internal.SaveEnvConfig(tenant, internal.EnvConfig{Name: DefaultEnvironment, RepoPath: projectRoot}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}
 
@@ -80,7 +80,7 @@ func TestRunRespectsExistingTenantDefaultEnvironment(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := internal.SaveEnvConfig(tenant, internal.EnvConfig{Name: "prod"}); err != nil {
+	if err := internal.SaveEnvConfig(tenant, internal.EnvConfig{Name: "prod", RepoPath: projectRoot}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}
 
@@ -104,6 +104,183 @@ func TestRunRespectsExistingTenantDefaultEnvironment(t *testing.T) {
 	}
 }
 
+func TestRunResolveTenantUsesCurrentDirectoryTenantBeforeDefault(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	projectRootA := filepath.Join(t.TempDir(), "tenant-a")
+	projectRootB := filepath.Join(t.TempDir(), "tenant-b")
+	for _, tenant := range []struct {
+		name        string
+		projectRoot string
+	}{
+		{name: "tenant-a", projectRoot: projectRootA},
+		{name: "tenant-b", projectRoot: projectRootB},
+	} {
+		if err := internal.SaveTenantConfig(internal.TenantConfig{
+			Name:               tenant.name,
+			ProjectRoot:        tenant.projectRoot,
+			DefaultEnvironment: DefaultEnvironment,
+		}); err != nil {
+			t.Fatalf("save tenant config: %v", err)
+		}
+		if err := internal.SaveEnvConfig(tenant.name, internal.EnvConfig{Name: DefaultEnvironment, RepoPath: tenant.projectRoot}); err != nil {
+			t.Fatalf("save env config: %v", err)
+		}
+	}
+	if err := internal.SaveERunConfig(internal.ERunConfig{DefaultTenant: "tenant-b"}); err != nil {
+		t.Fatalf("save erun config: %v", err)
+	}
+
+	service := Service{
+		Store: ConfigStore{},
+		GetWorkingDir: func() (string, error) {
+			return filepath.Join(projectRootA, "nested"), nil
+		},
+		SelectTenant: func([]internal.TenantConfig) (TenantSelectionResult, error) {
+			t.Fatal("unexpected tenant selection")
+			return TenantSelectionResult{}, nil
+		},
+		FindProjectRoot: func() (string, string, error) {
+			t.Fatal("unexpected project detection")
+			return "", "", nil
+		},
+		Confirm: func(label string) (bool, error) {
+			t.Fatalf("unexpected confirmation: %s", label)
+			return false, nil
+		},
+	}
+
+	result, err := service.Run(InitRequest{ResolveTenant: true})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.TenantConfig.Name != "tenant-a" {
+		t.Fatalf("expected current directory tenant to win, got %+v", result.TenantConfig)
+	}
+}
+
+func TestRunResolveTenantSelectsConfiguredTenantWhenOutsideTenantDirectory(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	projectRoot := filepath.Join(t.TempDir(), "tenant-a")
+	if err := internal.SaveTenantConfig(internal.TenantConfig{
+		Name:               "tenant-a",
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: DefaultEnvironment,
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := internal.SaveEnvConfig("tenant-a", internal.EnvConfig{Name: DefaultEnvironment, RepoPath: projectRoot}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+
+	service := Service{
+		Store: ConfigStore{},
+		GetWorkingDir: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		SelectTenant: func(tenants []internal.TenantConfig) (TenantSelectionResult, error) {
+			if len(tenants) != 1 || tenants[0].Name != "tenant-a" {
+				t.Fatalf("unexpected tenant options: %+v", tenants)
+			}
+			return TenantSelectionResult{Tenant: "tenant-a"}, nil
+		},
+		FindProjectRoot: func() (string, string, error) {
+			t.Fatal("unexpected project detection")
+			return "", "", nil
+		},
+		Confirm: func(label string) (bool, error) {
+			t.Fatalf("unexpected confirmation: %s", label)
+			return false, nil
+		},
+	}
+
+	result, err := service.Run(InitRequest{ResolveTenant: true})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if !result.CreatedERunConfig || result.CreatedTenantConfig || result.CreatedEnvConfig {
+		t.Fatalf("unexpected init result: %+v", result)
+	}
+	if result.TenantConfig.Name != "tenant-a" {
+		t.Fatalf("unexpected tenant config: %+v", result.TenantConfig)
+	}
+}
+
+func TestRunResolveTenantCanInitializeCurrentProjectFromSelection(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	existingProjectRoot := filepath.Join(t.TempDir(), "tenant-b")
+	if err := internal.SaveTenantConfig(internal.TenantConfig{
+		Name:               "tenant-b",
+		ProjectRoot:        existingProjectRoot,
+		DefaultEnvironment: DefaultEnvironment,
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := internal.SaveEnvConfig("tenant-b", internal.EnvConfig{Name: DefaultEnvironment, RepoPath: existingProjectRoot}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+
+	projectRoot := filepath.Join(t.TempDir(), "project")
+	service := Service{
+		Store: ConfigStore{},
+		GetWorkingDir: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		SelectTenant: func([]internal.TenantConfig) (TenantSelectionResult, error) {
+			return TenantSelectionResult{Initialize: true}, nil
+		},
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+	}
+
+	result, err := service.Run(InitRequest{ResolveTenant: true, AutoApprove: true})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if !result.CreatedERunConfig || !result.CreatedTenantConfig || !result.CreatedEnvConfig {
+		t.Fatalf("expected selection to initialize current project, got %+v", result)
+	}
+	if result.TenantConfig.Name != "tenant-a" || result.TenantConfig.ProjectRoot != projectRoot {
+		t.Fatalf("unexpected tenant config: %+v", result.TenantConfig)
+	}
+	if result.EnvConfig.RepoPath != projectRoot {
+		t.Fatalf("unexpected env config: %+v", result.EnvConfig)
+	}
+}
+
+func TestRunResolveTenantSelectionCancelled(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	projectRoot := filepath.Join(t.TempDir(), "tenant-a")
+	if err := internal.SaveTenantConfig(internal.TenantConfig{
+		Name:               "tenant-a",
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: DefaultEnvironment,
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := internal.SaveEnvConfig("tenant-a", internal.EnvConfig{Name: DefaultEnvironment, RepoPath: projectRoot}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+
+	service := Service{
+		Store: ConfigStore{},
+		GetWorkingDir: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		SelectTenant: func([]internal.TenantConfig) (TenantSelectionResult, error) {
+			return TenantSelectionResult{}, nil
+		},
+	}
+
+	if _, err := service.Run(InitRequest{ResolveTenant: true}); !errors.Is(err, ErrTenantSelectionCancelled) {
+		t.Fatalf("expected ErrTenantSelectionCancelled, got %v", err)
+	}
+}
+
 func TestRunBootstrapsNewProjectWithAutoApprove(t *testing.T) {
 	setupXDGConfigHome(t)
 
@@ -122,7 +299,7 @@ func TestRunBootstrapsNewProjectWithAutoApprove(t *testing.T) {
 	if !result.CreatedERunConfig || !result.CreatedTenantConfig || !result.CreatedEnvConfig {
 		t.Fatalf("expected all configs to be created, got %+v", result)
 	}
-	if result.TenantConfig.Name != "tenant-a" || result.EnvConfig.Name != DefaultEnvironment {
+	if result.TenantConfig.Name != "tenant-a" || result.EnvConfig.Name != DefaultEnvironment || result.EnvConfig.RepoPath != "/tmp/project" {
 		t.Fatalf("unexpected init result: %+v", result)
 	}
 }

--- a/erun-cli/internal/config.go
+++ b/erun-cli/internal/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/adrg/xdg"
 	"gopkg.in/yaml.v3"
@@ -25,7 +26,8 @@ type TenantConfig struct {
 }
 
 type EnvConfig struct {
-	Name string
+	Name     string
+	RepoPath string
 }
 
 var (
@@ -118,6 +120,43 @@ func LoadTenantConfig(tenant string) (TenantConfig, string, error) {
 	return config, configFilePath, nil
 }
 
+func ListTenantConfigs() ([]TenantConfig, error) {
+	configFilePath, err := xdg.ConfigFile(filepath.Join(configRoot, configFile))
+	if err != nil {
+		return nil, ErrNoUserDataFolder
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(configFilePath))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	tenants := make([]TenantConfig, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		tenantConfig, _, err := LoadTenantConfig(entry.Name())
+		if err != nil {
+			return nil, err
+		}
+		if tenantConfig.Name == "" {
+			tenantConfig.Name = entry.Name()
+		}
+		tenants = append(tenants, tenantConfig)
+	}
+
+	sort.Slice(tenants, func(i, j int) bool {
+		return tenants[i].Name < tenants[j].Name
+	})
+
+	return tenants, nil
+}
+
 func SaveEnvConfig(tenant string, config EnvConfig) error {
 	configFilePath, err := xdg.ConfigFile(filepath.Join(configRoot, tenant, config.Name, configFile))
 	if err != nil {
@@ -167,7 +206,7 @@ func FindProjectRoot() (string, string, error) {
 
 	for {
 		gitDir := filepath.Join(dir, ".git")
-		if info, err := os.Stat(gitDir); err == nil && info.IsDir() {
+		if _, err := os.Stat(gitDir); err == nil {
 			repoName := filepath.Base(dir)
 			return repoName, dir, nil
 		}

--- a/erun-cli/internal/config_test.go
+++ b/erun-cli/internal/config_test.go
@@ -141,6 +141,31 @@ func TestTenantConfigRoundTrip(t *testing.T) {
 	}
 }
 
+func TestListTenantConfigs(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	for _, cfg := range []TenantConfig{
+		{Name: "tenant-b", ProjectRoot: "/tmp/b", DefaultEnvironment: "prod"},
+		{Name: "tenant-a", ProjectRoot: "/tmp/a", DefaultEnvironment: "dev"},
+	} {
+		if err := SaveTenantConfig(cfg); err != nil {
+			t.Fatalf("SaveTenantConfig(%q) failed: %v", cfg.Name, err)
+		}
+	}
+
+	tenants, err := ListTenantConfigs()
+	if err != nil {
+		t.Fatalf("ListTenantConfigs failed: %v", err)
+	}
+
+	if len(tenants) != 2 {
+		t.Fatalf("expected 2 tenants, got %+v", tenants)
+	}
+	if tenants[0].Name != "tenant-a" || tenants[1].Name != "tenant-b" {
+		t.Fatalf("expected tenants to be sorted by name, got %+v", tenants)
+	}
+}
+
 func TestLoadTenantConfigErrors(t *testing.T) {
 	setupXDGConfigHome(t)
 
@@ -205,7 +230,7 @@ func TestSaveTenantConfigErrors(t *testing.T) {
 func TestEnvConfigRoundTrip(t *testing.T) {
 	setupXDGConfigHome(t)
 
-	cfg := EnvConfig{Name: "dev"}
+	cfg := EnvConfig{Name: "dev", RepoPath: "/tmp/project-dev"}
 	if err := SaveEnvConfig("tenant-a", cfg); err != nil {
 		t.Fatalf("SaveEnvConfig failed: %v", err)
 	}
@@ -313,6 +338,45 @@ func TestFindProjectRoot(t *testing.T) {
 	}
 
 	if name != "project" {
+		t.Fatalf("unexpected repo name: %s", name)
+	}
+	if path != realRepoRoot {
+		t.Fatalf("unexpected path: %s", path)
+	}
+}
+
+func TestFindProjectRootInWorktree(t *testing.T) {
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalDir); err != nil {
+			t.Fatalf("return to original dir: %v", err)
+		}
+	})
+
+	repoRoot := filepath.Join(t.TempDir(), "project-dev")
+	subDir := filepath.Join(repoRoot, "nested")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("mkdir subdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, ".git"), []byte("gitdir: /tmp/worktree"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+	realRepoRoot, err := filepath.EvalSymlinks(repoRoot)
+	if err != nil {
+		t.Fatalf("eval symlinks: %v", err)
+	}
+	if err := os.Chdir(subDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	name, path, err := FindProjectRoot()
+	if err != nil {
+		t.Fatalf("FindProjectRoot failed: %v", err)
+	}
+	if name != "project-dev" {
 		t.Fatalf("unexpected repo name: %s", name)
 	}
 	if path != realRepoRoot {

--- a/erun-cli/internal/opener/service.go
+++ b/erun-cli/internal/opener/service.go
@@ -1,0 +1,182 @@
+package opener
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sophium/erun/internal"
+)
+
+var (
+	ErrDefaultTenantNotConfigured      = errors.New("default tenant is not configured")
+	ErrDefaultEnvironmentNotConfigured = errors.New("default environment is not configured")
+	ErrTenantNotFound                  = errors.New("no such tenant exists")
+	ErrEnvironmentNotFound             = errors.New("no such environment exists")
+	ErrRepoPathNotConfigured           = errors.New("repo path is not configured")
+)
+
+type Store interface {
+	LoadERunConfig() (internal.ERunConfig, string, error)
+	LoadTenantConfig(string) (internal.TenantConfig, string, error)
+	LoadEnvConfig(string, string) (internal.EnvConfig, string, error)
+}
+
+type Request struct {
+	Tenant                string
+	Environment           string
+	UseDefaultTenant      bool
+	UseDefaultEnvironment bool
+}
+
+type Result struct {
+	Tenant       string
+	Environment  string
+	TenantConfig internal.TenantConfig
+	EnvConfig    internal.EnvConfig
+	RepoPath     string
+	Title        string
+}
+
+type ShellLaunchRequest struct {
+	Dir   string
+	Title string
+}
+
+type ShellLauncher func(ShellLaunchRequest) error
+
+type Service struct {
+	Store       Store
+	LaunchShell ShellLauncher
+}
+
+func (s Service) Resolve(req Request) (Result, error) {
+	if s.Store == nil {
+		return Result{}, fmt.Errorf("store is required")
+	}
+
+	tenant := req.Tenant
+	if tenant == "" && req.UseDefaultTenant {
+		toolConfig, _, err := s.Store.LoadERunConfig()
+		if errors.Is(err, internal.ErrNotInitialized) {
+			return Result{}, ErrDefaultTenantNotConfigured
+		}
+		if err != nil {
+			return Result{}, err
+		}
+		tenant = toolConfig.DefaultTenant
+		if tenant == "" {
+			return Result{}, ErrDefaultTenantNotConfigured
+		}
+	}
+	if tenant == "" {
+		return Result{}, fmt.Errorf("tenant is required")
+	}
+
+	tenantConfig, _, err := s.Store.LoadTenantConfig(tenant)
+	if errors.Is(err, internal.ErrNotInitialized) {
+		return Result{}, fmt.Errorf("%w: %s", ErrTenantNotFound, tenant)
+	}
+	if err != nil {
+		return Result{}, err
+	}
+	if tenantConfig.Name == "" {
+		tenantConfig.Name = tenant
+	}
+
+	environment := req.Environment
+	if environment == "" && req.UseDefaultEnvironment {
+		environment = tenantConfig.DefaultEnvironment
+		if environment == "" {
+			return Result{}, ErrDefaultEnvironmentNotConfigured
+		}
+	}
+	if environment == "" {
+		return Result{}, fmt.Errorf("environment is required")
+	}
+
+	envConfig, _, err := s.Store.LoadEnvConfig(tenant, environment)
+	if errors.Is(err, internal.ErrNotInitialized) {
+		return Result{}, fmt.Errorf("%w: %s", ErrEnvironmentNotFound, environment)
+	}
+	if err != nil {
+		return Result{}, err
+	}
+	if envConfig.Name == "" {
+		envConfig.Name = environment
+	}
+
+	repoPath := envConfig.RepoPath
+	if repoPath == "" {
+		repoPath = tenantConfig.ProjectRoot
+	}
+	if repoPath == "" {
+		return Result{}, ErrRepoPathNotConfigured
+	}
+
+	repoPath = filepath.Clean(repoPath)
+	info, err := os.Stat(repoPath)
+	if err != nil {
+		return Result{}, err
+	}
+	if !info.IsDir() {
+		return Result{}, fmt.Errorf("%q is not a directory", repoPath)
+	}
+
+	return Result{
+		Tenant:       tenant,
+		Environment:  environment,
+		TenantConfig: tenantConfig,
+		EnvConfig:    envConfig,
+		RepoPath:     repoPath,
+		Title:        tenant + "-" + environment,
+	}, nil
+}
+
+func (s Service) Run(req Request) (Result, error) {
+	result, err := s.Resolve(req)
+	if err != nil {
+		return Result{}, err
+	}
+
+	launcher := s.LaunchShell
+	if launcher == nil {
+		launcher = DefaultShellLauncher
+	}
+
+	if err := launcher(ShellLaunchRequest{
+		Dir:   result.RepoPath,
+		Title: result.Title,
+	}); err != nil {
+		return Result{}, err
+	}
+
+	return result, nil
+}
+
+func DefaultShellLauncher(req ShellLaunchRequest) error {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/sh"
+	}
+
+	script := fmt.Sprintf(
+		"printf '\\033]0;%%s\\007' %s; exec %s -i",
+		shellQuote(req.Title),
+		shellQuote(shell),
+	)
+
+	cmd := exec.Command("/bin/sh", "-lc", script)
+	cmd.Dir = req.Dir
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}

--- a/erun-cli/internal/opener/service_test.go
+++ b/erun-cli/internal/opener/service_test.go
@@ -1,0 +1,179 @@
+package opener
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sophium/erun/internal"
+)
+
+func TestResolveUsesDefaultTenantAndEnvironment(t *testing.T) {
+	repoPath := t.TempDir()
+	service := Service{
+		Store: openerStore{
+			toolConfig: internal.ERunConfig{DefaultTenant: "tenant-a"},
+			tenantConfigs: map[string]internal.TenantConfig{
+				"tenant-a": {
+					Name:               "tenant-a",
+					ProjectRoot:        filepath.Join(t.TempDir(), "fallback"),
+					DefaultEnvironment: "dev",
+				},
+			},
+			envConfigs: map[string]internal.EnvConfig{
+				"tenant-a/dev": {
+					Name:     "dev",
+					RepoPath: repoPath,
+				},
+			},
+		},
+	}
+
+	result, err := service.Resolve(Request{
+		UseDefaultTenant:      true,
+		UseDefaultEnvironment: true,
+	})
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if result.Tenant != "tenant-a" || result.Environment != "dev" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if result.RepoPath != repoPath || result.Title != "tenant-a-dev" {
+		t.Fatalf("unexpected shell target: %+v", result)
+	}
+}
+
+func TestResolveFallsBackToTenantProjectRoot(t *testing.T) {
+	repoPath := t.TempDir()
+	service := Service{
+		Store: openerStore{
+			tenantConfigs: map[string]internal.TenantConfig{
+				"tenant-a": {
+					Name:               "tenant-a",
+					ProjectRoot:        repoPath,
+					DefaultEnvironment: "dev",
+				},
+			},
+			envConfigs: map[string]internal.EnvConfig{
+				"tenant-a/dev": {Name: "dev"},
+			},
+		},
+	}
+
+	result, err := service.Resolve(Request{
+		Tenant:      "tenant-a",
+		Environment: "dev",
+	})
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if result.RepoPath != repoPath {
+		t.Fatalf("expected tenant project root fallback, got %+v", result)
+	}
+}
+
+func TestResolveRequiresDefaultTenant(t *testing.T) {
+	service := Service{Store: openerStore{loadERunErr: internal.ErrNotInitialized}}
+
+	if _, err := service.Resolve(Request{UseDefaultTenant: true}); !errors.Is(err, ErrDefaultTenantNotConfigured) {
+		t.Fatalf("expected ErrDefaultTenantNotConfigured, got %v", err)
+	}
+}
+
+func TestResolveRequiresDefaultEnvironment(t *testing.T) {
+	service := Service{
+		Store: openerStore{
+			toolConfig: internal.ERunConfig{DefaultTenant: "tenant-a"},
+			tenantConfigs: map[string]internal.TenantConfig{
+				"tenant-a": {Name: "tenant-a"},
+			},
+		},
+	}
+
+	if _, err := service.Resolve(Request{
+		UseDefaultTenant:      true,
+		UseDefaultEnvironment: true,
+	}); !errors.Is(err, ErrDefaultEnvironmentNotConfigured) {
+		t.Fatalf("expected ErrDefaultEnvironmentNotConfigured, got %v", err)
+	}
+}
+
+func TestResolveReportsMissingTenant(t *testing.T) {
+	service := Service{Store: openerStore{}}
+
+	_, err := service.Resolve(Request{
+		Tenant:      "dog",
+		Environment: "me",
+	})
+	if !errors.Is(err, ErrTenantNotFound) {
+		t.Fatalf("expected ErrTenantNotFound, got %v", err)
+	}
+	if got := err.Error(); got == "" || !strings.Contains(got, "no such tenant exists") {
+		t.Fatalf("expected missing tenant message, got %q", got)
+	}
+}
+
+func TestRunLaunchesShell(t *testing.T) {
+	repoPath := t.TempDir()
+	launched := ShellLaunchRequest{}
+	service := Service{
+		Store: openerStore{
+			tenantConfigs: map[string]internal.TenantConfig{
+				"tenant-a": {
+					Name:               "tenant-a",
+					ProjectRoot:        repoPath,
+					DefaultEnvironment: "dev",
+				},
+			},
+			envConfigs: map[string]internal.EnvConfig{
+				"tenant-a/dev": {
+					Name:     "dev",
+					RepoPath: repoPath,
+				},
+			},
+		},
+		LaunchShell: func(req ShellLaunchRequest) error {
+			launched = req
+			return nil
+		},
+	}
+
+	if _, err := service.Run(Request{Tenant: "tenant-a", Environment: "dev"}); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if launched.Dir != repoPath || launched.Title != "tenant-a-dev" {
+		t.Fatalf("unexpected shell launch: %+v", launched)
+	}
+}
+
+type openerStore struct {
+	toolConfig    internal.ERunConfig
+	loadERunErr   error
+	tenantConfigs map[string]internal.TenantConfig
+	envConfigs    map[string]internal.EnvConfig
+}
+
+func (s openerStore) LoadERunConfig() (internal.ERunConfig, string, error) {
+	if s.loadERunErr != nil {
+		return internal.ERunConfig{}, "", s.loadERunErr
+	}
+	return s.toolConfig, "", nil
+}
+
+func (s openerStore) LoadTenantConfig(tenant string) (internal.TenantConfig, string, error) {
+	config, ok := s.tenantConfigs[tenant]
+	if !ok {
+		return internal.TenantConfig{}, "", internal.ErrNotInitialized
+	}
+	return config, "", nil
+}
+
+func (s openerStore) LoadEnvConfig(tenant, environment string) (internal.EnvConfig, string, error) {
+	config, ok := s.envConfigs[tenant+"/"+environment]
+	if !ok {
+		return internal.EnvConfig{}, "", internal.ErrNotInitialized
+	}
+	return config, "", nil
+}


### PR DESCRIPTION
## Summary
- add an `open` command that resolves tenant and environment repo paths and launches a shell with the terminal title set to `tenant-env`
- make root command default to opening the configured tenant/environment while falling back to init when defaults are missing
- persist environment repo paths during init and support git worktree detection

## Validation
- go test ./... (erun-cli)
- go test ./... (erun-common)
- go test ./... (erun-mcp)

Closes #5
