### PR TITLE
Confirm default worktree branch during init

### DIFF
--- a/erun-cli/cmd/init.go
+++ b/erun-cli/cmd/init.go
@@ -15,7 +15,7 @@ import (
 const initializeCurrentProjectOption = "Initialize current project"
 
 func NewInitCmd(deps Dependencies, verbosity *int) *cobra.Command {
-	req := bootstrap.InitRequest{}
+	req := bootstrap.InitRequest{DetectEnvironmentBranch: true}
 
 	cmd := &cobra.Command{
 		Use:          "init",
@@ -34,6 +34,7 @@ func NewInitCmd(deps Dependencies, verbosity *int) *cobra.Command {
 	cmd.Flags().StringVar(&req.Tenant, "tenant", "", "Tenant name to initialize")
 	cmd.Flags().StringVar(&req.ProjectRoot, "project-root", "", "Project root to bind to the tenant")
 	cmd.Flags().StringVar(&req.Environment, "environment", "", "Default environment name")
+	cmd.Flags().StringVar(&req.Branch, "branch", "", "Branch name for the environment worktree")
 	cmd.Flags().BoolVarP(&req.AutoApprove, "yes", "y", false, "Automatically approve initialization prompts")
 	return cmd
 }
@@ -41,8 +42,9 @@ func NewInitCmd(deps Dependencies, verbosity *int) *cobra.Command {
 func runInitCommand(cmd *cobra.Command, deps Dependencies, verbosity *int, req bootstrap.InitRequest) error {
 	logger := eruncommon.NewLoggerWithWriters(valueOrZero(verbosity), cmd.OutOrStdout(), cmd.ErrOrStderr())
 	service := bootstrap.Service{
-		Store:           deps.Store,
-		FindProjectRoot: deps.FindProjectRoot,
+		Store:             deps.Store,
+		FindProjectRoot:   deps.FindProjectRoot,
+		FindCurrentBranch: deps.FindCurrentBranch,
 		SelectTenant: func(tenants []internal.TenantConfig) (bootstrap.TenantSelectionResult, error) {
 			return selectTenantPrompt(deps.SelectRunner, tenants)
 		},

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -16,19 +16,21 @@ type (
 )
 
 type Dependencies struct {
-	Store           bootstrap.Store
-	FindProjectRoot bootstrap.ProjectFinder
-	PromptRunner    PromptRunner
-	SelectRunner    SelectRunner
-	LaunchShell     opener.ShellLauncher
+	Store             bootstrap.Store
+	FindProjectRoot   bootstrap.ProjectFinder
+	FindCurrentBranch bootstrap.CurrentBranchFinder
+	PromptRunner      PromptRunner
+	SelectRunner      SelectRunner
+	LaunchShell       opener.ShellLauncher
 }
 
 func DefaultDependencies() Dependencies {
 	return Dependencies{
-		Store:           bootstrap.ConfigStore{},
-		FindProjectRoot: internal.FindProjectRoot,
-		PromptRunner:    defaultPromptRunner,
-		LaunchShell:     opener.DefaultShellLauncher,
+		Store:             bootstrap.ConfigStore{},
+		FindProjectRoot:   internal.FindProjectRoot,
+		FindCurrentBranch: internal.FindCurrentBranch,
+		PromptRunner:      defaultPromptRunner,
+		LaunchShell:       opener.DefaultShellLauncher,
 	}
 }
 
@@ -120,6 +122,9 @@ func withDependencyDefaults(deps Dependencies) Dependencies {
 	if deps.FindProjectRoot == nil {
 		deps.FindProjectRoot = internal.FindProjectRoot
 	}
+	if deps.FindCurrentBranch == nil {
+		deps.FindCurrentBranch = internal.FindCurrentBranch
+	}
 	if deps.PromptRunner == nil {
 		deps.PromptRunner = defaultPromptRunner
 	}
@@ -146,8 +151,9 @@ func initRequestForRootCommand(deps Dependencies, args []string) (bootstrap.Init
 	if err != nil {
 		if errors.Is(err, opener.ErrDefaultTenantNotConfigured) || errors.Is(err, internal.ErrNotInitialized) {
 			return bootstrap.InitRequest{
-				Environment:   envName,
-				ResolveTenant: true,
+				Environment:             envName,
+				DetectEnvironmentBranch: true,
+				ResolveTenant:           true,
 			}, nil
 		}
 		return bootstrap.InitRequest{}, err
@@ -155,22 +161,24 @@ func initRequestForRootCommand(deps Dependencies, args []string) (bootstrap.Init
 
 	if envName != "" {
 		return bootstrap.InitRequest{
-			Tenant:      tenant,
-			Environment: envName,
+			Tenant:                  tenant,
+			Environment:             envName,
+			DetectEnvironmentBranch: true,
 		}, nil
 	}
 
 	defaultEnvironment, err := loadDefaultEnvironment(deps.Store, tenant)
 	if err != nil {
 		if errors.Is(err, opener.ErrDefaultEnvironmentNotConfigured) || errors.Is(err, internal.ErrNotInitialized) {
-			return bootstrap.InitRequest{Tenant: tenant}, nil
+			return bootstrap.InitRequest{Tenant: tenant, DetectEnvironmentBranch: true}, nil
 		}
 		return bootstrap.InitRequest{}, err
 	}
 
 	return bootstrap.InitRequest{
-		Tenant:      tenant,
-		Environment: defaultEnvironment,
+		Tenant:                  tenant,
+		Environment:             defaultEnvironment,
+		DetectEnvironmentBranch: true,
 	}, nil
 }
 

--- a/erun-cli/cmd/root_test.go
+++ b/erun-cli/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,11 +33,19 @@ func TestRootCommandRunsInitWhenNoSubcommand(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
 	projectRoot := filepath.Join(t.TempDir(), "project")
+	var labels []string
 	cmd := NewRootCmd(Dependencies{
 		FindProjectRoot: func() (string, string, error) {
 			return "tenant-a", projectRoot, nil
 		},
-		PromptRunner: func(promptui.Prompt) (string, error) {
+		FindCurrentBranch: func(root string) (string, error) {
+			if root != projectRoot {
+				t.Fatalf("unexpected project root: %s", root)
+			}
+			return "develop", nil
+		},
+		PromptRunner: func(prompt promptui.Prompt) (string, error) {
+			labels = append(labels, fmt.Sprint(prompt.Label))
 			return "y", nil
 		},
 	})
@@ -73,8 +82,21 @@ func TestRootCommandRunsInitWhenNoSubcommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEnvConfig failed: %v", err)
 	}
-	if envConfig.Name != bootstrap.DefaultEnvironment || envConfig.RepoPath != projectRoot {
+	if envConfig.Name != bootstrap.DefaultEnvironment || envConfig.RepoPath != projectRoot || envConfig.Branch != "develop" {
 		t.Fatalf("unexpected env config: %+v", envConfig)
+	}
+
+	wantLabels := []string{
+		bootstrap.TenantConfirmationLabel("tenant-a", projectRoot),
+		bootstrap.EnvironmentConfirmationLabelWithBranch("tenant-a", bootstrap.DefaultEnvironment, "develop"),
+	}
+	if len(labels) != len(wantLabels) {
+		t.Fatalf("unexpected confirmation labels: %+v", labels)
+	}
+	for i := range wantLabels {
+		if labels[i] != wantLabels[i] {
+			t.Fatalf("unexpected confirmation label %d: got %q want %q", i, labels[i], wantLabels[i])
+		}
 	}
 }
 
@@ -296,6 +318,74 @@ func TestInitCommandPreservesExistingTenantDefaultEnvironmentWhenFlagOmitted(t *
 
 	if _, _, err := internal.LoadEnvConfig("tenant-a", bootstrap.DefaultEnvironment); !errors.Is(err, internal.ErrNotInitialized) {
 		t.Fatalf("expected no implicit %q env config, got %v", bootstrap.DefaultEnvironment, err)
+	}
+}
+
+func TestInitCommandStoresEnvironmentBranchFlag(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+
+	projectRoot := filepath.Join(t.TempDir(), "project")
+	cmd := NewRootCmd(Dependencies{
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		PromptRunner: func(promptui.Prompt) (string, error) {
+			t.Fatal("unexpected prompt")
+			return "", nil
+		},
+	})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"init", "--branch", "develop", "-y"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	envConfig, _, err := internal.LoadEnvConfig("tenant-a", bootstrap.DefaultEnvironment)
+	if err != nil {
+		t.Fatalf("LoadEnvConfig failed: %v", err)
+	}
+	if envConfig.Branch != "develop" {
+		t.Fatalf("expected branch to be stored, got %+v", envConfig)
+	}
+}
+
+func TestInitCommandDetectsEnvironmentBranch(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+
+	projectRoot := filepath.Join(t.TempDir(), "project")
+	cmd := NewRootCmd(Dependencies{
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		FindCurrentBranch: func(root string) (string, error) {
+			if root != projectRoot {
+				t.Fatalf("unexpected project root: %s", root)
+			}
+			return "develop", nil
+		},
+		PromptRunner: func(promptui.Prompt) (string, error) {
+			t.Fatal("unexpected prompt")
+			return "", nil
+		},
+	})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"init", "-y"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	envConfig, _, err := internal.LoadEnvConfig("tenant-a", bootstrap.DefaultEnvironment)
+	if err != nil {
+		t.Fatalf("LoadEnvConfig failed: %v", err)
+	}
+	if envConfig.Branch != "develop" {
+		t.Fatalf("expected detected branch to be stored, got %+v", envConfig)
 	}
 }
 

--- a/erun-cli/internal/bootstrap/service.go
+++ b/erun-cli/internal/bootstrap/service.go
@@ -29,9 +29,10 @@ type Store interface {
 }
 
 type (
-	ProjectFinder    func() (string, string, error)
-	WorkDirFunc      func() (string, error)
-	SelectTenantFunc func([]internal.TenantConfig) (TenantSelectionResult, error)
+	ProjectFinder       func() (string, string, error)
+	CurrentBranchFinder func(string) (string, error)
+	WorkDirFunc         func() (string, error)
+	SelectTenantFunc    func([]internal.TenantConfig) (TenantSelectionResult, error)
 )
 
 type (
@@ -77,11 +78,13 @@ func (ConfigStore) SaveEnvConfig(tenant string, config internal.EnvConfig) error
 }
 
 type InitRequest struct {
-	Tenant        string
-	ProjectRoot   string
-	Environment   string
-	AutoApprove   bool
-	ResolveTenant bool
+	Tenant                  string
+	ProjectRoot             string
+	Environment             string
+	Branch                  string
+	DetectEnvironmentBranch bool
+	AutoApprove             bool
+	ResolveTenant           bool
 }
 
 type InitResult struct {
@@ -94,12 +97,13 @@ type InitResult struct {
 }
 
 type Service struct {
-	Store           Store
-	FindProjectRoot ProjectFinder
-	GetWorkingDir   WorkDirFunc
-	SelectTenant    SelectTenantFunc
-	Confirm         ConfirmFunc
-	Logger          Logger
+	Store             Store
+	FindProjectRoot   ProjectFinder
+	FindCurrentBranch CurrentBranchFinder
+	GetWorkingDir     WorkDirFunc
+	SelectTenant      SelectTenantFunc
+	Confirm           ConfirmFunc
+	Logger            Logger
 }
 
 func (s Service) Run(req InitRequest) (InitResult, error) {
@@ -314,7 +318,16 @@ func (s Service) Run(req InitRequest) (InitResult, error) {
 			}
 		}
 
-		if err := s.confirmEnvironment(req.AutoApprove, tenant, envName); err != nil {
+		envBranch := req.Branch
+		if envBranch == "" && req.DetectEnvironmentBranch {
+			detectedBranch, detectErr := s.FindCurrentBranch(envProjectRoot)
+			if detectErr != nil && !errors.Is(detectErr, internal.ErrNotInGitRepository) {
+				return result, detectErr
+			}
+			envBranch = detectedBranch
+		}
+
+		if err := s.confirmEnvironment(req.AutoApprove, tenant, envName, envBranch); err != nil {
 			return result, err
 		}
 
@@ -322,6 +335,7 @@ func (s Service) Run(req InitRequest) (InitResult, error) {
 		envConfig = internal.EnvConfig{
 			Name:     envName,
 			RepoPath: envProjectRoot,
+			Branch:   envBranch,
 		}
 		if err := s.Store.SaveEnvConfig(tenant, envConfig); err != nil {
 			return result, err
@@ -329,6 +343,16 @@ func (s Service) Run(req InitRequest) (InitResult, error) {
 		result.CreatedEnvConfig = true
 	case err != nil:
 		return result, err
+	}
+
+	if envConfig.Name == "" {
+		envConfig.Name = envName
+	}
+	if req.Branch != "" && envConfig.Branch != req.Branch {
+		envConfig.Branch = req.Branch
+		if err := s.Store.SaveEnvConfig(tenant, envConfig); err != nil {
+			return result, err
+		}
 	}
 
 	if toolConfig.DefaultTenant == "" {
@@ -362,10 +386,22 @@ func TenantConfirmationLabel(tenant, projectRoot string) string {
 }
 
 func EnvironmentConfirmationLabel(tenant, envName string) string {
+	return EnvironmentConfirmationLabelWithBranch(tenant, envName, "")
+}
+
+func EnvironmentConfirmationLabelWithBranch(tenant, envName, branch string) string {
+	if branch == "" {
+		return fmt.Sprintf(
+			"Initialize default environment %q for tenant %q?",
+			envName,
+			tenant,
+		)
+	}
 	return fmt.Sprintf(
-		"Initialize default environment %q for tenant %q?",
+		"Initialize default environment %q for tenant %q with default worktree branch %q?",
 		envName,
 		tenant,
+		branch,
 	)
 }
 
@@ -375,6 +411,9 @@ func (s Service) withDefaults() Service {
 	}
 	if s.FindProjectRoot == nil {
 		s.FindProjectRoot = internal.FindProjectRoot
+	}
+	if s.FindCurrentBranch == nil {
+		s.FindCurrentBranch = internal.FindCurrentBranch
 	}
 	if s.GetWorkingDir == nil {
 		s.GetWorkingDir = os.Getwd
@@ -392,11 +431,11 @@ func (s Service) confirmTenant(autoApprove bool, tenant, projectRoot string) err
 	return s.confirm(TenantConfirmationLabel(tenant, projectRoot), ErrTenantInitializationCancelled)
 }
 
-func (s Service) confirmEnvironment(autoApprove bool, tenant, envName string) error {
+func (s Service) confirmEnvironment(autoApprove bool, tenant, envName, branch string) error {
 	if autoApprove {
 		return nil
 	}
-	return s.confirm(EnvironmentConfirmationLabel(tenant, envName), ErrEnvironmentInitializationCancelled)
+	return s.confirm(EnvironmentConfirmationLabelWithBranch(tenant, envName, branch), ErrEnvironmentInitializationCancelled)
 }
 
 func (s Service) confirm(label string, cancelled error) error {

--- a/erun-cli/internal/bootstrap/service_test.go
+++ b/erun-cli/internal/bootstrap/service_test.go
@@ -251,6 +251,141 @@ func TestRunResolveTenantCanInitializeCurrentProjectFromSelection(t *testing.T) 
 	}
 }
 
+func TestRunStoresConfiguredEnvironmentBranch(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	service := Service{
+		Store: ConfigStore{},
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", "/tmp/project", nil
+		},
+	}
+
+	result, err := service.Run(InitRequest{AutoApprove: true, Branch: "develop"})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.EnvConfig.Branch != "develop" {
+		t.Fatalf("expected branch to be saved, got %+v", result.EnvConfig)
+	}
+
+	loaded, _, err := internal.LoadEnvConfig("tenant-a", DefaultEnvironment)
+	if err != nil {
+		t.Fatalf("LoadEnvConfig failed: %v", err)
+	}
+	if loaded.Branch != "develop" {
+		t.Fatalf("expected persisted branch, got %+v", loaded)
+	}
+}
+
+func TestRunDetectsCurrentBranchForNewEnvironment(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	service := Service{
+		Store: ConfigStore{},
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", "/tmp/project", nil
+		},
+		FindCurrentBranch: func(string) (string, error) {
+			return "develop", nil
+		},
+	}
+
+	result, err := service.Run(InitRequest{AutoApprove: true, DetectEnvironmentBranch: true})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.EnvConfig.Branch != "develop" {
+		t.Fatalf("expected detected branch to be saved, got %+v", result.EnvConfig)
+	}
+}
+
+func TestRunPreservesExistingEnvironmentBranchWhenFlagOmitted(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	tenant := "tenant-a"
+	projectRoot := filepath.Join(t.TempDir(), "project")
+	if err := internal.SaveERunConfig(internal.ERunConfig{DefaultTenant: tenant}); err != nil {
+		t.Fatalf("save erun config: %v", err)
+	}
+	if err := internal.SaveTenantConfig(internal.TenantConfig{
+		Name:               tenant,
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: DefaultEnvironment,
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := internal.SaveEnvConfig(tenant, internal.EnvConfig{
+		Name:     DefaultEnvironment,
+		RepoPath: projectRoot,
+		Branch:   "release",
+	}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+
+	service := Service{
+		Store: ConfigStore{},
+		FindProjectRoot: func() (string, string, error) {
+			return tenant, projectRoot, nil
+		},
+	}
+
+	result, err := service.Run(InitRequest{})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.EnvConfig.Branch != "release" {
+		t.Fatalf("expected branch to remain unchanged, got %+v", result.EnvConfig)
+	}
+}
+
+func TestRunUpdatesExistingEnvironmentBranchWhenFlagProvided(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	tenant := "tenant-a"
+	projectRoot := filepath.Join(t.TempDir(), "project")
+	if err := internal.SaveERunConfig(internal.ERunConfig{DefaultTenant: tenant}); err != nil {
+		t.Fatalf("save erun config: %v", err)
+	}
+	if err := internal.SaveTenantConfig(internal.TenantConfig{
+		Name:               tenant,
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: DefaultEnvironment,
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := internal.SaveEnvConfig(tenant, internal.EnvConfig{
+		Name:     DefaultEnvironment,
+		RepoPath: projectRoot,
+		Branch:   "release",
+	}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+
+	service := Service{
+		Store: ConfigStore{},
+		FindProjectRoot: func() (string, string, error) {
+			return tenant, projectRoot, nil
+		},
+	}
+
+	result, err := service.Run(InitRequest{Branch: "develop"})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.EnvConfig.Branch != "develop" {
+		t.Fatalf("expected branch to be updated, got %+v", result.EnvConfig)
+	}
+
+	loaded, _, err := internal.LoadEnvConfig(tenant, DefaultEnvironment)
+	if err != nil {
+		t.Fatalf("LoadEnvConfig failed: %v", err)
+	}
+	if loaded.Branch != "develop" {
+		t.Fatalf("expected persisted branch update, got %+v", loaded)
+	}
+}
+
 func TestRunResolveTenantSelectionCancelled(t *testing.T) {
 	setupXDGConfigHome(t)
 
@@ -415,12 +550,19 @@ func TestRunEnvironmentConfirmationRejected(t *testing.T) {
 		FindProjectRoot: func() (string, string, error) {
 			return tenant, "/tmp/project", nil
 		},
+		FindCurrentBranch: func(string) (string, error) {
+			return "develop", nil
+		},
 		Confirm: func(label string) (bool, error) {
+			want := EnvironmentConfirmationLabelWithBranch(tenant, DefaultEnvironment, "develop")
+			if label != want {
+				t.Fatalf("unexpected confirmation label: %q", label)
+			}
 			return false, nil
 		},
 	}
 
-	if _, err := service.Run(InitRequest{}); !errors.Is(err, ErrEnvironmentInitializationCancelled) {
+	if _, err := service.Run(InitRequest{DetectEnvironmentBranch: true}); !errors.Is(err, ErrEnvironmentInitializationCancelled) {
 		t.Fatalf("expected environment cancellation, got %v", err)
 	}
 }

--- a/erun-cli/internal/config.go
+++ b/erun-cli/internal/config.go
@@ -28,6 +28,7 @@ type TenantConfig struct {
 type EnvConfig struct {
 	Name     string
 	RepoPath string
+	Branch   string
 }
 
 var (

--- a/erun-cli/internal/config_test.go
+++ b/erun-cli/internal/config_test.go
@@ -230,7 +230,7 @@ func TestSaveTenantConfigErrors(t *testing.T) {
 func TestEnvConfigRoundTrip(t *testing.T) {
 	setupXDGConfigHome(t)
 
-	cfg := EnvConfig{Name: "dev", RepoPath: "/tmp/project-dev"}
+	cfg := EnvConfig{Name: "dev", RepoPath: "/tmp/project-dev", Branch: "develop"}
 	if err := SaveEnvConfig("tenant-a", cfg); err != nil {
 		t.Fatalf("SaveEnvConfig failed: %v", err)
 	}

--- a/erun-cli/internal/git.go
+++ b/erun-cli/internal/git.go
@@ -1,0 +1,21 @@
+package internal
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+)
+
+func FindCurrentBranch(repoRoot string) (string, error) {
+	cmd := exec.Command("git", "-C", repoRoot, "branch", "--show-current")
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", ErrNotInGitRepository
+		}
+		return "", err
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}

--- a/erun-cli/internal/git_test.go
+++ b/erun-cli/internal/git_test.go
@@ -1,0 +1,37 @@
+package internal
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+func TestFindCurrentBranch(t *testing.T) {
+	repoRoot := t.TempDir()
+
+	for _, args := range [][]string{
+		{"init"},
+		{"checkout", "-b", "develop"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoRoot
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v (%s)", args, err, output)
+		}
+	}
+
+	branch, err := FindCurrentBranch(repoRoot)
+	if err != nil {
+		t.Fatalf("FindCurrentBranch failed: %v", err)
+	}
+	if branch != "develop" {
+		t.Fatalf("expected develop, got %q", branch)
+	}
+}
+
+func TestFindCurrentBranchOutsideRepository(t *testing.T) {
+	_, err := FindCurrentBranch(t.TempDir())
+	if !errors.Is(err, ErrNotInGitRepository) {
+		t.Fatalf("expected ErrNotInGitRepository, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add an environment config field for the default worktree branch
- detect the current Git branch during init and confirm it with the user before saving
- keep explicit branch overrides supported through `erun init --branch`

## Why
The default environment/worktree setup did not persist or confirm which branch it should point to, which made initialization ambiguous.

## Impact
Users initializing a tenant environment now see the detected default worktree branch during init and that branch is stored in config for the environment.

## Validation
- `go test ./...`

Closes #16
