### PR TITLE
Expand build.sh discovery outside Docker artefacts

### DIFF
--- a/erun-cli/cmd/build.go
+++ b/erun-cli/cmd/build.go
@@ -17,7 +17,7 @@ const (
 
 var errVersionFileNotFound = common.ErrVersionFileNotFound
 
-func newBuildCmd(store common.DockerStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, now common.NowFunc, buildDockerImage common.DockerImageBuilderFunc) *cobra.Command {
+func newBuildCmd(store common.DockerStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, now common.NowFunc, runBuildScript common.BuildScriptRunnerFunc, buildDockerImage common.DockerImageBuilderFunc) *cobra.Command {
 	target := common.DockerCommandTarget{}
 	cmd := &cobra.Command{
 		Use:           "build",
@@ -27,11 +27,11 @@ func newBuildCmd(store common.DockerStore, findProjectRoot common.ProjectFinderF
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext(cmd)
-			builds, err := common.ResolveCurrentDockerBuildSpecs(store, findProjectRoot, resolveBuildContext, now, target)
+			execution, err := common.ResolveBuildExecution(store, findProjectRoot, resolveBuildContext, now, target)
 			if err != nil {
 				return err
 			}
-			return common.RunDockerBuilds(ctx, builds, buildDockerImage)
+			return common.RunBuildExecution(ctx, execution, runBuildScript, buildDockerImage)
 		},
 	}
 	addDryRunFlag(cmd)

--- a/erun-cli/cmd/build_test.go
+++ b/erun-cli/cmd/build_test.go
@@ -36,6 +36,14 @@ type dockerLoginCall struct {
 	Stderr   io.Writer
 }
 
+type buildScriptCall struct {
+	Dir    string
+	Path   string
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
 func buildCallFunc(run func(dockerBuildCall) error) common.DockerImageBuilderFunc {
 	return func(dir, dockerfilePath, tag string, stdout, stderr io.Writer) error {
 		return run(dockerBuildCall{
@@ -44,6 +52,18 @@ func buildCallFunc(run func(dockerBuildCall) error) common.DockerImageBuilderFun
 			Tag:            tag,
 			Stdout:         stdout,
 			Stderr:         stderr,
+		})
+	}
+}
+
+func buildScriptCallFunc(run func(buildScriptCall) error) common.BuildScriptRunnerFunc {
+	return func(dir, path string, stdin io.Reader, stdout, stderr io.Writer) error {
+		return run(buildScriptCall{
+			Dir:    dir,
+			Path:   path,
+			Stdin:  stdin,
+			Stdout: stdout,
+			Stderr: stderr,
 		})
 	}
 }
@@ -103,6 +123,9 @@ func TestNewRootCmdRegistersDevopsContainerPushCommand(t *testing.T) {
 
 func TestNewRootCmdRegistersBuildShorthandWhenDockerfilePresent(t *testing.T) {
 	cmd := newTestRootCmd(testRootDeps{
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", t.TempDir(), nil
+		},
 		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
 			dir := t.TempDir()
 			return common.DockerBuildContext{
@@ -117,6 +140,33 @@ func TestNewRootCmdRegistersBuildShorthandWhenDockerfilePresent(t *testing.T) {
 	}
 	if !hasSubcommand(cmd, "push") {
 		t.Fatal("expected push shorthand command to be registered")
+	}
+}
+
+func TestNewRootCmdRegistersBuildShorthandWhenProjectBuildScriptPresent(t *testing.T) {
+	projectRoot := t.TempDir()
+	scriptPath := filepath.Join(projectRoot, "build.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write build.sh: %v", err)
+	}
+
+	cmd := newTestRootCmd(testRootDeps{
+		OptionalBuildFindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
+			return common.DockerBuildContext{Dir: projectRoot}, nil
+		},
+	})
+
+	if !hasSubcommand(cmd, "build") {
+		t.Fatal("expected build shorthand command to be registered")
+	}
+	if hasSubcommand(cmd, "push") {
+		t.Fatal("did not expect push shorthand command to be registered")
 	}
 }
 
@@ -216,6 +266,59 @@ func TestRootBuildShorthandRunsDockerBuild(t *testing.T) {
 	}
 	if received.Tag != "erunpaas/erun-ubuntu:noble-20260217" {
 		t.Fatalf("unexpected image tag: %+v", received)
+	}
+	if received.Stdout != stdout || received.Stderr != stderr {
+		t.Fatalf("unexpected output writers: %+v", received)
+	}
+}
+
+func TestRootBuildShorthandRunsProjectBuildScriptWhenPresent(t *testing.T) {
+	projectRoot := t.TempDir()
+	scriptPath := filepath.Join(projectRoot, "build.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write build.sh: %v", err)
+	}
+
+	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
+	if err := os.MkdirAll(buildDir, 0o755); err != nil {
+		t.Fatalf("mkdir build dir: %v", err)
+	}
+
+	var received buildScriptCall
+	cmd := newTestRootCmd(testRootDeps{
+		OptionalBuildFindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
+			return common.DockerBuildContext{
+				Dir:            buildDir,
+				DockerfilePath: filepath.Join(buildDir, "Dockerfile"),
+			}, nil
+		},
+		RunBuildScript: buildScriptCallFunc(func(req buildScriptCall) error {
+			received = req
+			return nil
+		}),
+		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
+			t.Fatalf("unexpected docker build request: %+v", req)
+			return nil
+		}),
+	})
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"build"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if received.Dir != projectRoot || received.Path != "./build.sh" {
+		t.Fatalf("unexpected build script call: %+v", received)
 	}
 	if received.Stdout != stdout || received.Stderr != stderr {
 		t.Fatalf("unexpected output writers: %+v", received)
@@ -418,6 +521,98 @@ func TestRootBuildShorthandDryRunPrintsCommandWithoutExecuting(t *testing.T) {
 
 	if got := stderr.String(); !bytes.Contains([]byte(got), []byte("docker build -t erunpaas/erun-devops:1.1.0")) {
 		t.Fatalf("expected dry-run trace output, got %q", got)
+	}
+}
+
+func TestRootBuildShorthandDryRunPrintsBuildScriptCommandWithoutExecuting(t *testing.T) {
+	projectRoot := t.TempDir()
+	scriptPath := filepath.Join(projectRoot, "build.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write build.sh: %v", err)
+	}
+
+	stderr := new(bytes.Buffer)
+	cmd := newTestRootCmd(testRootDeps{
+		OptionalBuildFindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
+			return common.DockerBuildContext{Dir: projectRoot}, nil
+		},
+		RunBuildScript: buildScriptCallFunc(func(req buildScriptCall) error {
+			t.Fatalf("unexpected build script execution during dry-run: %+v", req)
+			return nil
+		}),
+	})
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"build", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if got := stderr.String(); !strings.Contains(got, "cd "+projectRoot+" && ./build.sh") {
+		t.Fatalf("expected build.sh dry-run trace, got %q", got)
+	}
+}
+
+func TestRootBuildShorthandIgnoresNestedBuildScript(t *testing.T) {
+	projectRoot := t.TempDir()
+	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
+	if err := os.MkdirAll(buildDir, 0o755); err != nil {
+		t.Fatalf("mkdir build dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	scriptDir := filepath.Join(projectRoot, "scripts")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write nested build.sh: %v", err)
+	}
+	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
+		t.Fatalf("save project config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write module VERSION: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(buildDir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
+		t.Fatalf("write local VERSION: %v", err)
+	}
+
+	var built dockerBuildCall
+	cmd := newTestRootCmd(testRootDeps{
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
+			return common.DockerBuildContext{
+				Dir:            buildDir,
+				DockerfilePath: filepath.Join(buildDir, "Dockerfile"),
+			}, nil
+		},
+		RunBuildScript: buildScriptCallFunc(func(req buildScriptCall) error {
+			t.Fatalf("unexpected build script call: %+v", req)
+			return nil
+		}),
+		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
+			built = req
+			return nil
+		}),
+	})
+	cmd.SetArgs([]string{"build"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if built.Dir != projectRoot || built.Tag != "erunpaas/erun-devops:1.1.0" {
+		t.Fatalf("unexpected docker build request: %+v", built)
 	}
 }
 
@@ -1050,6 +1245,7 @@ func TestRunContainerBuildCommandPropagatesBuildContextErrors(t *testing.T) {
 		},
 		nil,
 		nil,
+		nil,
 	)
 	cmd.SetArgs([]string{})
 
@@ -1067,7 +1263,7 @@ func TestRunContainerPushCommandPropagatesBuildContextErrors(t *testing.T) {
 		newBuildCmd(common.ConfigStore{}, nil, func() (common.DockerBuildContext, error) {
 			t.Fatal("unexpected build execution")
 			return common.DockerBuildContext{}, nil
-		}, nil, nil),
+		}, nil, nil, nil),
 		newPushCmd(common.ConfigStore{}, nil, func() (common.DockerBuildContext, error) {
 			return common.DockerBuildContext{}, expectedErr
 		}, nil, nil, nil),

--- a/erun-cli/cmd/build_test.go
+++ b/erun-cli/cmd/build_test.go
@@ -145,7 +145,11 @@ func TestNewRootCmdRegistersBuildShorthandWhenDockerfilePresent(t *testing.T) {
 
 func TestNewRootCmdRegistersBuildShorthandWhenProjectBuildScriptPresent(t *testing.T) {
 	projectRoot := t.TempDir()
-	scriptPath := filepath.Join(projectRoot, "build.sh")
+	scriptDir := filepath.Join(projectRoot, "scripts", "build")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
+	}
+	scriptPath := filepath.Join(scriptDir, "build.sh")
 	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("write build.sh: %v", err)
 	}
@@ -274,7 +278,11 @@ func TestRootBuildShorthandRunsDockerBuild(t *testing.T) {
 
 func TestRootBuildShorthandRunsProjectBuildScriptWhenPresent(t *testing.T) {
 	projectRoot := t.TempDir()
-	scriptPath := filepath.Join(projectRoot, "build.sh")
+	scriptDir := filepath.Join(projectRoot, "scripts", "build")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
+	}
+	scriptPath := filepath.Join(scriptDir, "build.sh")
 	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("write build.sh: %v", err)
 	}
@@ -317,7 +325,7 @@ func TestRootBuildShorthandRunsProjectBuildScriptWhenPresent(t *testing.T) {
 		t.Fatalf("Execute failed: %v", err)
 	}
 
-	if received.Dir != projectRoot || received.Path != "./build.sh" {
+	if received.Dir != scriptDir || received.Path != "./build.sh" {
 		t.Fatalf("unexpected build script call: %+v", received)
 	}
 	if received.Stdout != stdout || received.Stderr != stderr {
@@ -526,7 +534,11 @@ func TestRootBuildShorthandDryRunPrintsCommandWithoutExecuting(t *testing.T) {
 
 func TestRootBuildShorthandDryRunPrintsBuildScriptCommandWithoutExecuting(t *testing.T) {
 	projectRoot := t.TempDir()
-	scriptPath := filepath.Join(projectRoot, "build.sh")
+	scriptDir := filepath.Join(projectRoot, "scripts", "build")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
+	}
+	scriptPath := filepath.Join(scriptDir, "build.sh")
 	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("write build.sh: %v", err)
 	}
@@ -554,12 +566,12 @@ func TestRootBuildShorthandDryRunPrintsBuildScriptCommandWithoutExecuting(t *tes
 		t.Fatalf("Execute failed: %v", err)
 	}
 
-	if got := stderr.String(); !strings.Contains(got, "cd "+projectRoot+" && ./build.sh") {
+	if got := stderr.String(); !strings.Contains(got, "cd "+scriptDir+" && ./build.sh") {
 		t.Fatalf("expected build.sh dry-run trace, got %q", got)
 	}
 }
 
-func TestRootBuildShorthandIgnoresNestedBuildScript(t *testing.T) {
+func TestRootBuildShorthandIgnoresBuildScriptInDockerArtifactDirectory(t *testing.T) {
 	projectRoot := t.TempDir()
 	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
 	if err := os.MkdirAll(buildDir, 0o755); err != nil {
@@ -568,12 +580,8 @@ func TestRootBuildShorthandIgnoresNestedBuildScript(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
 		t.Fatalf("write Dockerfile: %v", err)
 	}
-	scriptDir := filepath.Join(projectRoot, "scripts")
-	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
-		t.Fatalf("mkdir script dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(scriptDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write nested build.sh: %v", err)
+	if err := os.WriteFile(filepath.Join(buildDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write artifact build.sh: %v", err)
 	}
 	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
 		t.Fatalf("save project config: %v", err)

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -55,7 +55,7 @@ func Execute() error {
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
-		newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.DockerImageBuilder),
+		newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder),
 		newPushCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.DockerImageBuilder, push),
 	)
 	k8sCmd := newCommandGroup(
@@ -66,8 +66,8 @@ func Execute() error {
 	devopsCmd := newCommandGroup("devops", "DevOps utilities", containerCmd, k8sCmd)
 
 	var buildCmd *cobra.Command
-	if hasOptionalBuildCmd(common.ResolveDockerBuildContext) {
-		buildCmd = newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.DockerImageBuilder)
+	if hasOptionalBuildCmd(common.FindProjectRoot, common.ResolveDockerBuildContext) {
+		buildCmd = newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder)
 	}
 	var pushCmd *cobra.Command
 	if hasOptionalPushCmd(common.ResolveDockerBuildContext) {

--- a/erun-cli/cmd/root_runtime.go
+++ b/erun-cli/cmd/root_runtime.go
@@ -113,7 +113,12 @@ func newPushOperation(pushDockerImage common.DockerImagePusherFunc, loginToDocke
 	}
 }
 
-func hasOptionalBuildCmd(resolveBuildContext common.BuildContextResolverFunc) bool {
+func hasOptionalBuildCmd(findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc) bool {
+	hasScript, err := common.HasProjectBuildScript(findProjectRoot, common.DockerCommandTarget{})
+	if err == nil && hasScript {
+		return true
+	}
+
 	buildContext, err := resolveBuildContext()
 	if err != nil {
 		return false

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -10,6 +10,7 @@ import (
 type testRootDeps struct {
 	Store                          rootStore
 	FindProjectRoot                common.ProjectFinderFunc
+	OptionalBuildFindProjectRoot   common.ProjectFinderFunc
 	PromptRunner                   PromptRunner
 	SelectRunner                   SelectRunner
 	ListKubernetesContexts         KubernetesContextsLister
@@ -17,6 +18,7 @@ type testRootDeps struct {
 	ResolveDockerBuildContext      common.BuildContextResolverFunc
 	ResolveKubernetesDeployContext common.DeployContextResolverFunc
 	CheckKubernetesDeployment      common.KubernetesDeploymentCheckerFunc
+	RunBuildScript                 common.BuildScriptRunnerFunc
 	BuildDockerImage               common.DockerImageBuilderFunc
 	PushDockerImage                common.DockerImagePusherFunc
 	LoginToDockerRegistry          common.DockerRegistryLoginFunc
@@ -40,6 +42,10 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	if findProjectRoot == nil {
 		findProjectRoot = common.FindProjectRoot
 	}
+	optionalBuildFindProjectRoot := deps.OptionalBuildFindProjectRoot
+	if optionalBuildFindProjectRoot == nil {
+		optionalBuildFindProjectRoot = common.FindProjectRoot
+	}
 	promptRunner := deps.PromptRunner
 	if promptRunner == nil {
 		promptRunner = runPrompt
@@ -60,6 +66,10 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	buildDockerImage := deps.BuildDockerImage
 	if buildDockerImage == nil {
 		buildDockerImage = common.DockerImageBuilder
+	}
+	runBuildScript := deps.RunBuildScript
+	if runBuildScript == nil {
+		runBuildScript = common.BuildScriptRunner
 	}
 	pushDockerImage := deps.PushDockerImage
 	if pushDockerImage == nil {
@@ -119,7 +129,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
-		newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, now, buildDockerImage),
+		newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, now, runBuildScript, buildDockerImage),
 		newPushCmd(store, findProjectRoot, resolveDockerBuildContext, now, buildDockerImage, push),
 	)
 	k8sCmd := newCommandGroup(
@@ -130,8 +140,8 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	devopsCmd := newCommandGroup("devops", "DevOps utilities", containerCmd, k8sCmd)
 
 	var buildCmd *cobra.Command
-	if hasOptionalBuildCmd(resolveDockerBuildContext) {
-		buildCmd = newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, now, buildDockerImage)
+	if hasOptionalBuildCmd(optionalBuildFindProjectRoot, resolveDockerBuildContext) {
+		buildCmd = newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, now, runBuildScript, buildDockerImage)
 	}
 	var pushCmd *cobra.Command
 	if hasOptionalPushCmd(resolveDockerBuildContext) {

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -28,6 +28,7 @@ type (
 	DockerImageBuilderFunc   func(string, string, string, io.Writer, io.Writer) error
 	DockerImagePusherFunc    func(string, io.Writer, io.Writer) error
 	DockerRegistryLoginFunc  func(string, io.Reader, io.Writer, io.Writer) error
+	BuildScriptRunnerFunc    func(string, string, io.Reader, io.Writer, io.Writer) error
 	DockerPushFunc           func(Context, DockerPushSpec) error
 )
 
@@ -64,6 +65,16 @@ type DockerPushSpec struct {
 	Image DockerImageReference
 }
 
+type projectBuildScriptSpec struct {
+	Dir  string
+	Path string
+}
+
+type BuildExecutionSpec struct {
+	script       *projectBuildScriptSpec
+	dockerBuilds []DockerBuildSpec
+}
+
 type DockerCommandTarget struct {
 	ProjectRoot string
 	Environment string
@@ -94,6 +105,34 @@ func ResolveCurrentDockerBuildSpecs(store DockerStore, findProjectRoot ProjectFi
 	}
 
 	return builds, nil
+}
+
+func ResolveBuildExecution(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, target DockerCommandTarget) (BuildExecutionSpec, error) {
+	store, findProjectRoot, resolveBuildContext, now = normalizeDockerDependencies(store, findProjectRoot, resolveBuildContext, now)
+
+	script, err := resolveProjectBuildScript(findProjectRoot, target)
+	if err != nil {
+		return BuildExecutionSpec{}, err
+	}
+	if script != nil {
+		return BuildExecutionSpec{script: script}, nil
+	}
+
+	builds, err := ResolveCurrentDockerBuildSpecs(store, findProjectRoot, resolveBuildContext, now, target)
+	if err != nil {
+		return BuildExecutionSpec{}, err
+	}
+
+	return BuildExecutionSpec{dockerBuilds: builds}, nil
+}
+
+func BuildExecutionSpecFromDockerBuilds(builds []DockerBuildSpec) BuildExecutionSpec {
+	return BuildExecutionSpec{dockerBuilds: builds}
+}
+
+func HasProjectBuildScript(findProjectRoot ProjectFinderFunc, target DockerCommandTarget) (bool, error) {
+	script, err := resolveProjectBuildScript(findProjectRoot, target)
+	return script != nil, err
 }
 
 func ResolveDockerPushSpec(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, target DockerCommandTarget) (DockerPushSpec, *DockerBuildSpec, error) {
@@ -218,6 +257,33 @@ func ResolveDockerBuildForImageReference(store DockerStore, findProjectRoot Proj
 			Tag:         image,
 		},
 	}, true, nil
+}
+
+func resolveProjectBuildScript(findProjectRoot ProjectFinderFunc, target DockerCommandTarget) (*projectBuildScriptSpec, error) {
+	projectRoot, err := resolveDockerBuildProjectRoot(findProjectRoot, target)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(projectRoot) == "" {
+		return nil, nil
+	}
+
+	projectRoot = filepath.Clean(projectRoot)
+	scriptPath := filepath.Join(projectRoot, "build.sh")
+	info, err := os.Stat(scriptPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, nil
+	}
+	return &projectBuildScriptSpec{
+		Dir:  projectRoot,
+		Path: "./build.sh",
+	}, nil
 }
 
 func normalizeDockerDependencies(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc) (DockerStore, ProjectFinderFunc, BuildContextResolverFunc, NowFunc) {
@@ -436,6 +502,13 @@ func RunDockerBuilds(ctx Context, builds []DockerBuildSpec, build DockerImageBui
 	return nil
 }
 
+func RunBuildExecution(ctx Context, execution BuildExecutionSpec, runScript BuildScriptRunnerFunc, build DockerImageBuilderFunc) error {
+	if execution.script != nil {
+		return runBuildScript(ctx, *execution.script, runScript)
+	}
+	return RunDockerBuilds(ctx, execution.dockerBuilds, build)
+}
+
 func RunDockerPush(ctx Context, pushInput DockerPushSpec, push DockerImagePusherFunc) error {
 	if push == nil {
 		push = DockerImagePusher
@@ -581,6 +654,15 @@ func DockerImageBuilder(dir, dockerfilePath, tag string, stdout, stderr io.Write
 	return cmd.Run()
 }
 
+func BuildScriptRunner(dir, scriptPath string, stdin io.Reader, stdout, stderr io.Writer) error {
+	cmd := exec.Command(scriptPath)
+	cmd.Dir = dir
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
 func DockerImagePusher(tag string, stdout, stderr io.Writer) error {
 	pushCmd := exec.Command("docker", "push", tag)
 	output := new(bytes.Buffer)
@@ -615,6 +697,21 @@ func DockerRegistryLogin(registry string, stdin io.Reader, stdout, stderr io.Wri
 	loginCmd.Stdout = stdout
 	loginCmd.Stderr = stderr
 	return loginCmd.Run()
+}
+
+func runBuildScript(ctx Context, script projectBuildScriptSpec, run BuildScriptRunnerFunc) error {
+	if run == nil {
+		run = BuildScriptRunner
+	}
+	command := commandSpec{
+		Dir:  script.Dir,
+		Name: script.Path,
+	}
+	ctx.TraceCommand(command.Dir, command.Name, command.Args...)
+	if ctx.DryRun {
+		return nil
+	}
+	return run(script.Dir, script.Path, ctx.Stdin, ctx.Stdout, ctx.Stderr)
 }
 
 func resolveDockerBuildRegistryForEnvironment(projectRoot, environment string) (string, error) {

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -269,21 +270,64 @@ func resolveProjectBuildScript(findProjectRoot ProjectFinderFunc, target DockerC
 	}
 
 	projectRoot = filepath.Clean(projectRoot)
-	scriptPath := filepath.Join(projectRoot, "build.sh")
-	info, err := os.Stat(scriptPath)
+	rootScriptPath := filepath.Join(projectRoot, "build.sh")
+	info, err := os.Stat(rootScriptPath)
+	if err == nil && !info.IsDir() {
+		return &projectBuildScriptSpec{
+			Dir:  projectRoot,
+			Path: "./build.sh",
+		}, nil
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	var script *projectBuildScriptSpec
+	err = filepath.WalkDir(projectRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" || isProjectBuildArtifactDir(path, projectRoot) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() != "build.sh" {
+			return nil
+		}
+
+		script = &projectBuildScriptSpec{
+			Dir:  filepath.Dir(path),
+			Path: "./build.sh",
+		}
+		return fs.SkipAll
+	})
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
+		if errors.Is(err, fs.SkipAll) {
+			return script, nil
 		}
 		return nil, err
 	}
-	if info.IsDir() {
-		return nil, nil
+	return script, nil
+}
+
+func isProjectBuildArtifactDir(path, projectRoot string) bool {
+	path = filepath.Clean(strings.TrimSpace(path))
+	projectRoot = filepath.Clean(strings.TrimSpace(projectRoot))
+	if path == "" || projectRoot == "" || path == projectRoot {
+		return false
 	}
-	return &projectBuildScriptSpec{
-		Dir:  projectRoot,
-		Path: "./build.sh",
-	}, nil
+
+	relative, err := filepath.Rel(projectRoot, path)
+	if err != nil {
+		return false
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return false
+	}
+
+	return filepath.Base(filepath.Dir(path)) == "docker"
 }
 
 func normalizeDockerDependencies(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc) (DockerStore, ProjectFinderFunc, BuildContextResolverFunc, NowFunc) {

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -143,14 +143,122 @@ func TestResolveBuildExecutionPrefersProjectBuildScript(t *testing.T) {
 	}
 }
 
-func TestHasProjectBuildScriptIgnoresNestedBuildScripts(t *testing.T) {
+func TestResolveBuildExecutionPrefersProjectRootBuildScriptOverNestedScripts(t *testing.T) {
 	projectRoot := t.TempDir()
-	nestedDir := filepath.Join(projectRoot, "scripts")
+	if err := os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write root build.sh: %v", err)
+	}
+	nestedDir := filepath.Join(projectRoot, "scripts", "alpha")
 	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
 		t.Fatalf("mkdir nested dir: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(nestedDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write build.sh: %v", err)
+		t.Fatalf("write nested build.sh: %v", err)
+	}
+
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		func() (DockerBuildContext, error) {
+			return DockerBuildContext{}, errors.New("docker build context should not be resolved")
+		},
+		nil,
+		DockerCommandTarget{},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+
+	var called bool
+	ctx := Context{
+		Logger: NewLoggerWithWriters(2, io.Discard, io.Discard),
+		Stdin:  new(bytes.Buffer),
+		Stdout: new(bytes.Buffer),
+		Stderr: new(bytes.Buffer),
+	}
+	if err := RunBuildExecution(ctx, execution, func(dir, path string, stdin io.Reader, stdout, stderr io.Writer) error {
+		called = true
+		if dir != projectRoot || path != "./build.sh" {
+			t.Fatalf("unexpected script call: dir=%q path=%q", dir, path)
+		}
+		return nil
+	}, func(string, string, string, io.Writer, io.Writer) error {
+		t.Fatal("unexpected docker build")
+		return nil
+	}); err != nil {
+		t.Fatalf("RunBuildExecution failed: %v", err)
+	}
+	if !called {
+		t.Fatal("expected build script runner to be called")
+	}
+}
+
+func TestResolveBuildExecutionUsesFirstNestedProjectBuildScript(t *testing.T) {
+	projectRoot := t.TempDir()
+	firstDir := filepath.Join(projectRoot, "scripts", "alpha")
+	if err := os.MkdirAll(firstDir, 0o755); err != nil {
+		t.Fatalf("mkdir first dir: %v", err)
+	}
+	secondDir := filepath.Join(projectRoot, "scripts", "zeta")
+	if err := os.MkdirAll(secondDir, 0o755); err != nil {
+		t.Fatalf("mkdir second dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(firstDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write first build.sh: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(secondDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write second build.sh: %v", err)
+	}
+
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		func() (DockerBuildContext, error) {
+			return DockerBuildContext{}, errors.New("docker build context should not be resolved")
+		},
+		nil,
+		DockerCommandTarget{},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+
+	var called bool
+	ctx := Context{
+		Logger: NewLoggerWithWriters(2, io.Discard, io.Discard),
+		Stdin:  new(bytes.Buffer),
+		Stdout: new(bytes.Buffer),
+		Stderr: new(bytes.Buffer),
+	}
+	if err := RunBuildExecution(ctx, execution, func(dir, path string, stdin io.Reader, stdout, stderr io.Writer) error {
+		called = true
+		if dir != firstDir || path != "./build.sh" {
+			t.Fatalf("unexpected script call: dir=%q path=%q", dir, path)
+		}
+		return nil
+	}, func(string, string, string, io.Writer, io.Writer) error {
+		t.Fatal("unexpected docker build")
+		return nil
+	}); err != nil {
+		t.Fatalf("RunBuildExecution failed: %v", err)
+	}
+	if !called {
+		t.Fatal("expected build script runner to be called")
+	}
+}
+
+func TestHasProjectBuildScriptIgnoresDockerArtifactBuildScripts(t *testing.T) {
+	projectRoot := t.TempDir()
+	artifactDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(artifactDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write artifact build.sh: %v", err)
 	}
 
 	hasScript, err := HasProjectBuildScript(func() (string, string, error) {
@@ -160,6 +268,6 @@ func TestHasProjectBuildScriptIgnoresNestedBuildScripts(t *testing.T) {
 		t.Fatalf("HasProjectBuildScript failed: %v", err)
 	}
 	if hasScript {
-		t.Fatal("did not expect nested build.sh to be selected")
+		t.Fatal("did not expect docker artifact build.sh to be selected")
 	}
 }

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -1,6 +1,9 @@
 package eruncommon
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -92,5 +95,71 @@ func TestResolveDockerBuildContextIgnoresMissingDockerfile(t *testing.T) {
 	}
 	if result.DockerfilePath != "" {
 		t.Fatalf("expected empty Dockerfile path, got %+v", result)
+	}
+}
+
+func TestResolveBuildExecutionPrefersProjectBuildScript(t *testing.T) {
+	projectRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write build.sh: %v", err)
+	}
+
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		func() (DockerBuildContext, error) {
+			return DockerBuildContext{}, errors.New("docker build context should not be resolved")
+		},
+		nil,
+		DockerCommandTarget{},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+
+	var called bool
+	ctx := Context{
+		Logger: NewLoggerWithWriters(2, io.Discard, io.Discard),
+		Stdin:  new(bytes.Buffer),
+		Stdout: new(bytes.Buffer),
+		Stderr: new(bytes.Buffer),
+	}
+	if err := RunBuildExecution(ctx, execution, func(dir, path string, stdin io.Reader, stdout, stderr io.Writer) error {
+		called = true
+		if dir != projectRoot || path != "./build.sh" {
+			t.Fatalf("unexpected script call: dir=%q path=%q", dir, path)
+		}
+		return nil
+	}, func(string, string, string, io.Writer, io.Writer) error {
+		t.Fatal("unexpected docker build")
+		return nil
+	}); err != nil {
+		t.Fatalf("RunBuildExecution failed: %v", err)
+	}
+	if !called {
+		t.Fatal("expected build script runner to be called")
+	}
+}
+
+func TestHasProjectBuildScriptIgnoresNestedBuildScripts(t *testing.T) {
+	projectRoot := t.TempDir()
+	nestedDir := filepath.Join(projectRoot, "scripts")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write build.sh: %v", err)
+	}
+
+	hasScript, err := HasProjectBuildScript(func() (string, string, error) {
+		return "tenant-a", projectRoot, nil
+	}, DockerCommandTarget{})
+	if err != nil {
+		t.Fatalf("HasProjectBuildScript failed: %v", err)
+	}
+	if hasScript {
+		t.Fatal("did not expect nested build.sh to be selected")
 	}
 }

--- a/erun-mcp/build.go
+++ b/erun-mcp/build.go
@@ -25,11 +25,11 @@ type PushInput struct {
 func buildTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, BuildInput) (*mcp.CallToolResult, CommandOutput, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input BuildInput) (*mcp.CallToolResult, CommandOutput, error) {
 		output, err := runRuntimeCommand(runtime.Context, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, workDir string) error {
-			builds, err := resolveRuntimeBuilds(runtime, workDir, strings.TrimSpace(input.Component))
+			execution, err := resolveRuntimeBuildExecution(runtime, workDir, strings.TrimSpace(input.Component))
 			if err != nil {
 				return err
 			}
-			return eruncommon.RunDockerBuilds(runCtx, builds, runtime.BuildDockerImage)
+			return eruncommon.RunBuildExecution(runCtx, execution, runtime.BuildScriptRunner, runtime.BuildDockerImage)
 		})
 		return nil, output, err
 	}
@@ -54,8 +54,12 @@ func pushTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest,
 	}
 }
 
-func resolveRuntimeBuilds(runtime RuntimeConfig, projectRoot, component string) ([]eruncommon.DockerBuildSpec, error) {
+func resolveRuntimeBuildExecution(runtime RuntimeConfig, projectRoot, component string) (eruncommon.BuildExecutionSpec, error) {
 	environment := strings.TrimSpace(runtime.Context.Environment)
+	target := eruncommon.DockerCommandTarget{
+		ProjectRoot: projectRoot,
+		Environment: environment,
+	}
 	findProjectRoot := func() (string, string, error) {
 		return runtimeFindProjectRoot(runtime.Context, projectRoot)
 	}
@@ -66,44 +70,46 @@ func resolveRuntimeBuilds(runtime RuntimeConfig, projectRoot, component string) 
 	if component != "" {
 		buildContext, ok, err := eruncommon.FindComponentDockerBuildContext(projectRoot, component)
 		if err != nil {
-			return nil, err
+			return eruncommon.BuildExecutionSpec{}, err
 		}
 		if !ok {
-			return nil, fmt.Errorf("docker build context not found for component %q", component)
+			return eruncommon.BuildExecutionSpec{}, fmt.Errorf("docker build context not found for component %q", component)
 		}
 		imageRef, err := eruncommon.ResolveDockerImageReference(runtime.Store, findProjectRoot, resolveBuildContext, nil, buildContext.Dir, eruncommon.DockerCommandTarget{
 			ProjectRoot: projectRoot,
 			Environment: environment,
 		})
 		if err != nil {
-			return nil, err
+			return eruncommon.BuildExecutionSpec{}, err
 		}
-		return []eruncommon.DockerBuildSpec{{
+		return eruncommon.BuildExecutionSpecFromDockerBuilds([]eruncommon.DockerBuildSpec{{
 			ContextDir:     eruncommon.ResolveDockerBuildContextDirForProject(buildContext.Dir, projectRoot),
 			DockerfilePath: buildContext.DockerfilePath,
 			Image:          imageRef,
-		}}, nil
+		}}), nil
 	}
 
 	rootBuildContext, err := eruncommon.DockerBuildContextAtDir(projectRoot)
 	if err != nil {
-		return nil, err
+		return eruncommon.BuildExecutionSpec{}, err
 	}
-	if strings.TrimSpace(rootBuildContext.DockerfilePath) != "" {
-		return eruncommon.ResolveCurrentDockerBuildSpecs(runtime.Store, findProjectRoot, resolveBuildContext, nil, eruncommon.DockerCommandTarget{
-			ProjectRoot: projectRoot,
-			Environment: environment,
-		})
+	hasScript, err := eruncommon.HasProjectBuildScript(findProjectRoot, target)
+	if err != nil {
+		return eruncommon.BuildExecutionSpec{}, err
+	}
+	if hasScript || strings.TrimSpace(rootBuildContext.DockerfilePath) != "" {
+		return eruncommon.ResolveBuildExecution(runtime.Store, findProjectRoot, resolveBuildContext, nil, target)
 	}
 
 	dockerModuleDir := filepath.Join(projectRoot, "docker")
 	resolveDockerModuleContext := func() (eruncommon.DockerBuildContext, error) {
 		return eruncommon.DockerBuildContext{Dir: dockerModuleDir}, nil
 	}
-	return eruncommon.ResolveCurrentDockerBuildSpecs(runtime.Store, findProjectRoot, resolveDockerModuleContext, nil, eruncommon.DockerCommandTarget{
-		ProjectRoot: projectRoot,
-		Environment: environment,
-	})
+	builds, err := eruncommon.ResolveCurrentDockerBuildSpecs(runtime.Store, findProjectRoot, resolveDockerModuleContext, nil, target)
+	if err != nil {
+		return eruncommon.BuildExecutionSpec{}, err
+	}
+	return eruncommon.BuildExecutionSpecFromDockerBuilds(builds), nil
 }
 
 func resolveRuntimePushExecution(runtime RuntimeConfig, projectRoot, component string) (eruncommon.DockerPushSpec, *eruncommon.DockerBuildSpec, error) {

--- a/erun-mcp/runtime.go
+++ b/erun-mcp/runtime.go
@@ -30,6 +30,7 @@ type runtimeStore interface {
 type RuntimeConfig struct {
 	Context                   RuntimeContext
 	Store                     runtimeStore
+	BuildScriptRunner         eruncommon.BuildScriptRunnerFunc
 	BuildDockerImage          eruncommon.DockerImageBuilderFunc
 	PushDockerImage           eruncommon.DockerImagePusherFunc
 	DeployHelmChart           eruncommon.HelmChartDeployerFunc
@@ -49,6 +50,9 @@ var ansiRegexp = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 func normalizeRuntimeConfig(cfg RuntimeConfig) RuntimeConfig {
 	if cfg.Store == nil {
 		cfg.Store = eruncommon.ConfigStore{}
+	}
+	if cfg.BuildScriptRunner == nil {
+		cfg.BuildScriptRunner = eruncommon.BuildScriptRunner
 	}
 	if cfg.BuildDockerImage == nil {
 		cfg.BuildDockerImage = eruncommon.DockerImageBuilder

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -3,6 +3,7 @@ package erunmcp
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -290,6 +291,71 @@ func TestBuildToolPreviewVerboseIncludesTrace(t *testing.T) {
 	}
 	want := "docker build -t erunpaas/erun-devops:1.1.0 -f " + filepath.Join(componentDir, "Dockerfile") + " ."
 	if output.Trace[0] != "cd "+projectRoot+" && "+want {
+		t.Fatalf("unexpected trace output: %+v", output.Trace)
+	}
+}
+
+func TestBuildToolRunsProjectBuildScriptWhenPresent(t *testing.T) {
+	projectRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write build.sh: %v", err)
+	}
+
+	var called bool
+	handler := buildTool(normalizeRuntimeConfig(RuntimeConfig{
+		Context: RuntimeContext{
+			Environment: "dev",
+			RepoPath:    projectRoot,
+		},
+		BuildScriptRunner: func(dir, path string, stdin io.Reader, stdout, stderr io.Writer) error {
+			called = true
+			if dir != projectRoot || path != "./build.sh" {
+				t.Fatalf("unexpected build script call: dir=%q path=%q", dir, path)
+			}
+			return nil
+		},
+		BuildDockerImage: func(string, string, string, io.Writer, io.Writer) error {
+			t.Fatal("unexpected docker build")
+			return nil
+		},
+	}))
+
+	_, output, err := handler(context.Background(), nil, BuildInput{})
+	if err != nil {
+		t.Fatalf("buildTool failed: %v", err)
+	}
+	if !output.Executed {
+		t.Fatalf("expected execution output, got %+v", output)
+	}
+	if !called {
+		t.Fatal("expected build script runner to be called")
+	}
+}
+
+func TestBuildToolPreviewVerboseIncludesBuildScriptTrace(t *testing.T) {
+	projectRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write build.sh: %v", err)
+	}
+
+	handler := buildTool(normalizeRuntimeConfig(RuntimeConfig{
+		Context: RuntimeContext{
+			Environment: "dev",
+			RepoPath:    projectRoot,
+		},
+	}))
+
+	_, output, err := handler(context.Background(), nil, BuildInput{
+		Preview:   true,
+		Verbosity: 1,
+	})
+	if err != nil {
+		t.Fatalf("buildTool failed: %v", err)
+	}
+	if len(output.Trace) == 0 {
+		t.Fatalf("expected trace output, got %+v", output)
+	}
+	if output.Trace[0] != "cd "+projectRoot+" && ./build.sh" {
 		t.Fatalf("unexpected trace output: %+v", output.Trace)
 	}
 }

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -297,7 +297,11 @@ func TestBuildToolPreviewVerboseIncludesTrace(t *testing.T) {
 
 func TestBuildToolRunsProjectBuildScriptWhenPresent(t *testing.T) {
 	projectRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+	scriptDir := filepath.Join(projectRoot, "scripts", "build")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("write build.sh: %v", err)
 	}
 
@@ -309,7 +313,7 @@ func TestBuildToolRunsProjectBuildScriptWhenPresent(t *testing.T) {
 		},
 		BuildScriptRunner: func(dir, path string, stdin io.Reader, stdout, stderr io.Writer) error {
 			called = true
-			if dir != projectRoot || path != "./build.sh" {
+			if dir != scriptDir || path != "./build.sh" {
 				t.Fatalf("unexpected build script call: dir=%q path=%q", dir, path)
 			}
 			return nil
@@ -334,7 +338,11 @@ func TestBuildToolRunsProjectBuildScriptWhenPresent(t *testing.T) {
 
 func TestBuildToolPreviewVerboseIncludesBuildScriptTrace(t *testing.T) {
 	projectRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+	scriptDir := filepath.Join(projectRoot, "scripts", "build")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("write build.sh: %v", err)
 	}
 
@@ -355,7 +363,7 @@ func TestBuildToolPreviewVerboseIncludesBuildScriptTrace(t *testing.T) {
 	if len(output.Trace) == 0 {
 		t.Fatalf("expected trace output, got %+v", output)
 	}
-	if output.Trace[0] != "cd "+projectRoot+" && ./build.sh" {
+	if output.Trace[0] != "cd "+scriptDir+" && ./build.sh" {
 		t.Fatalf("unexpected trace output: %+v", output.Trace)
 	}
 }


### PR DESCRIPTION
## Summary
- add recursive tenant `build.sh` discovery while preserving project-root precedence
- skip Docker artefact directories such as `docker/<component>` when searching for override scripts
- update shared, CLI, and MCP tests for nested script execution and trace behavior

## Why
The existing build override only checked `<projectRoot>/build.sh`. This follow-up keeps that behavior as the first choice, but also supports nested tenant build scripts without letting scripts inside Docker artefact directories override `erun build`.

## Validation
- `cd erun-common && go test ./...`
- `cd erun-cli && go test ./...`
- `cd erun-mcp && go test ./...`

Follow-up to #8.
