### PR TITLE
Expand build.sh discovery outside Docker artefacts

### DIFF
--- a/erun-cli/cmd/build_test.go
+++ b/erun-cli/cmd/build_test.go
@@ -145,7 +145,11 @@ func TestNewRootCmdRegistersBuildShorthandWhenDockerfilePresent(t *testing.T) {
 
 func TestNewRootCmdRegistersBuildShorthandWhenProjectBuildScriptPresent(t *testing.T) {
 	projectRoot := t.TempDir()
-	scriptPath := filepath.Join(projectRoot, "build.sh")
+	scriptDir := filepath.Join(projectRoot, "scripts", "build")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
+	}
+	scriptPath := filepath.Join(scriptDir, "build.sh")
 	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("write build.sh: %v", err)
 	}
@@ -274,7 +278,11 @@ func TestRootBuildShorthandRunsDockerBuild(t *testing.T) {
 
 func TestRootBuildShorthandRunsProjectBuildScriptWhenPresent(t *testing.T) {
 	projectRoot := t.TempDir()
-	scriptPath := filepath.Join(projectRoot, "build.sh")
+	scriptDir := filepath.Join(projectRoot, "scripts", "build")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
+	}
+	scriptPath := filepath.Join(scriptDir, "build.sh")
 	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("write build.sh: %v", err)
 	}
@@ -317,7 +325,7 @@ func TestRootBuildShorthandRunsProjectBuildScriptWhenPresent(t *testing.T) {
 		t.Fatalf("Execute failed: %v", err)
 	}
 
-	if received.Dir != projectRoot || received.Path != "./build.sh" {
+	if received.Dir != scriptDir || received.Path != "./build.sh" {
 		t.Fatalf("unexpected build script call: %+v", received)
 	}
 	if received.Stdout != stdout || received.Stderr != stderr {
@@ -526,7 +534,11 @@ func TestRootBuildShorthandDryRunPrintsCommandWithoutExecuting(t *testing.T) {
 
 func TestRootBuildShorthandDryRunPrintsBuildScriptCommandWithoutExecuting(t *testing.T) {
 	projectRoot := t.TempDir()
-	scriptPath := filepath.Join(projectRoot, "build.sh")
+	scriptDir := filepath.Join(projectRoot, "scripts", "build")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
+	}
+	scriptPath := filepath.Join(scriptDir, "build.sh")
 	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("write build.sh: %v", err)
 	}
@@ -554,12 +566,12 @@ func TestRootBuildShorthandDryRunPrintsBuildScriptCommandWithoutExecuting(t *tes
 		t.Fatalf("Execute failed: %v", err)
 	}
 
-	if got := stderr.String(); !strings.Contains(got, "cd "+projectRoot+" && ./build.sh") {
+	if got := stderr.String(); !strings.Contains(got, "cd "+scriptDir+" && ./build.sh") {
 		t.Fatalf("expected build.sh dry-run trace, got %q", got)
 	}
 }
 
-func TestRootBuildShorthandIgnoresNestedBuildScript(t *testing.T) {
+func TestRootBuildShorthandIgnoresBuildScriptInDockerArtifactDirectory(t *testing.T) {
 	projectRoot := t.TempDir()
 	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
 	if err := os.MkdirAll(buildDir, 0o755); err != nil {
@@ -568,12 +580,8 @@ func TestRootBuildShorthandIgnoresNestedBuildScript(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
 		t.Fatalf("write Dockerfile: %v", err)
 	}
-	scriptDir := filepath.Join(projectRoot, "scripts")
-	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
-		t.Fatalf("mkdir script dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(scriptDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write nested build.sh: %v", err)
+	if err := os.WriteFile(filepath.Join(buildDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write artifact build.sh: %v", err)
 	}
 	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
 		t.Fatalf("save project config: %v", err)

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -269,21 +270,64 @@ func resolveProjectBuildScript(findProjectRoot ProjectFinderFunc, target DockerC
 	}
 
 	projectRoot = filepath.Clean(projectRoot)
-	scriptPath := filepath.Join(projectRoot, "build.sh")
-	info, err := os.Stat(scriptPath)
+	rootScriptPath := filepath.Join(projectRoot, "build.sh")
+	info, err := os.Stat(rootScriptPath)
+	if err == nil && !info.IsDir() {
+		return &projectBuildScriptSpec{
+			Dir:  projectRoot,
+			Path: "./build.sh",
+		}, nil
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	var script *projectBuildScriptSpec
+	err = filepath.WalkDir(projectRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" || isProjectBuildArtifactDir(path, projectRoot) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() != "build.sh" {
+			return nil
+		}
+
+		script = &projectBuildScriptSpec{
+			Dir:  filepath.Dir(path),
+			Path: "./build.sh",
+		}
+		return fs.SkipAll
+	})
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
+		if errors.Is(err, fs.SkipAll) {
+			return script, nil
 		}
 		return nil, err
 	}
-	if info.IsDir() {
-		return nil, nil
+	return script, nil
+}
+
+func isProjectBuildArtifactDir(path, projectRoot string) bool {
+	path = filepath.Clean(strings.TrimSpace(path))
+	projectRoot = filepath.Clean(strings.TrimSpace(projectRoot))
+	if path == "" || projectRoot == "" || path == projectRoot {
+		return false
 	}
-	return &projectBuildScriptSpec{
-		Dir:  projectRoot,
-		Path: "./build.sh",
-	}, nil
+
+	relative, err := filepath.Rel(projectRoot, path)
+	if err != nil {
+		return false
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return false
+	}
+
+	return filepath.Base(filepath.Dir(path)) == "docker"
 }
 
 func normalizeDockerDependencies(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc) (DockerStore, ProjectFinderFunc, BuildContextResolverFunc, NowFunc) {

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -143,14 +143,122 @@ func TestResolveBuildExecutionPrefersProjectBuildScript(t *testing.T) {
 	}
 }
 
-func TestHasProjectBuildScriptIgnoresNestedBuildScripts(t *testing.T) {
+func TestResolveBuildExecutionPrefersProjectRootBuildScriptOverNestedScripts(t *testing.T) {
 	projectRoot := t.TempDir()
-	nestedDir := filepath.Join(projectRoot, "scripts")
+	if err := os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write root build.sh: %v", err)
+	}
+	nestedDir := filepath.Join(projectRoot, "scripts", "alpha")
 	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
 		t.Fatalf("mkdir nested dir: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(nestedDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write build.sh: %v", err)
+		t.Fatalf("write nested build.sh: %v", err)
+	}
+
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		func() (DockerBuildContext, error) {
+			return DockerBuildContext{}, errors.New("docker build context should not be resolved")
+		},
+		nil,
+		DockerCommandTarget{},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+
+	var called bool
+	ctx := Context{
+		Logger: NewLoggerWithWriters(2, io.Discard, io.Discard),
+		Stdin:  new(bytes.Buffer),
+		Stdout: new(bytes.Buffer),
+		Stderr: new(bytes.Buffer),
+	}
+	if err := RunBuildExecution(ctx, execution, func(dir, path string, stdin io.Reader, stdout, stderr io.Writer) error {
+		called = true
+		if dir != projectRoot || path != "./build.sh" {
+			t.Fatalf("unexpected script call: dir=%q path=%q", dir, path)
+		}
+		return nil
+	}, func(string, string, string, io.Writer, io.Writer) error {
+		t.Fatal("unexpected docker build")
+		return nil
+	}); err != nil {
+		t.Fatalf("RunBuildExecution failed: %v", err)
+	}
+	if !called {
+		t.Fatal("expected build script runner to be called")
+	}
+}
+
+func TestResolveBuildExecutionUsesFirstNestedProjectBuildScript(t *testing.T) {
+	projectRoot := t.TempDir()
+	firstDir := filepath.Join(projectRoot, "scripts", "alpha")
+	if err := os.MkdirAll(firstDir, 0o755); err != nil {
+		t.Fatalf("mkdir first dir: %v", err)
+	}
+	secondDir := filepath.Join(projectRoot, "scripts", "zeta")
+	if err := os.MkdirAll(secondDir, 0o755); err != nil {
+		t.Fatalf("mkdir second dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(firstDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write first build.sh: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(secondDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write second build.sh: %v", err)
+	}
+
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		func() (DockerBuildContext, error) {
+			return DockerBuildContext{}, errors.New("docker build context should not be resolved")
+		},
+		nil,
+		DockerCommandTarget{},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+
+	var called bool
+	ctx := Context{
+		Logger: NewLoggerWithWriters(2, io.Discard, io.Discard),
+		Stdin:  new(bytes.Buffer),
+		Stdout: new(bytes.Buffer),
+		Stderr: new(bytes.Buffer),
+	}
+	if err := RunBuildExecution(ctx, execution, func(dir, path string, stdin io.Reader, stdout, stderr io.Writer) error {
+		called = true
+		if dir != firstDir || path != "./build.sh" {
+			t.Fatalf("unexpected script call: dir=%q path=%q", dir, path)
+		}
+		return nil
+	}, func(string, string, string, io.Writer, io.Writer) error {
+		t.Fatal("unexpected docker build")
+		return nil
+	}); err != nil {
+		t.Fatalf("RunBuildExecution failed: %v", err)
+	}
+	if !called {
+		t.Fatal("expected build script runner to be called")
+	}
+}
+
+func TestHasProjectBuildScriptIgnoresDockerArtifactBuildScripts(t *testing.T) {
+	projectRoot := t.TempDir()
+	artifactDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(artifactDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write artifact build.sh: %v", err)
 	}
 
 	hasScript, err := HasProjectBuildScript(func() (string, string, error) {
@@ -160,6 +268,6 @@ func TestHasProjectBuildScriptIgnoresNestedBuildScripts(t *testing.T) {
 		t.Fatalf("HasProjectBuildScript failed: %v", err)
 	}
 	if hasScript {
-		t.Fatal("did not expect nested build.sh to be selected")
+		t.Fatal("did not expect docker artifact build.sh to be selected")
 	}
 }

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -297,7 +297,11 @@ func TestBuildToolPreviewVerboseIncludesTrace(t *testing.T) {
 
 func TestBuildToolRunsProjectBuildScriptWhenPresent(t *testing.T) {
 	projectRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+	scriptDir := filepath.Join(projectRoot, "scripts", "build")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("write build.sh: %v", err)
 	}
 
@@ -309,7 +313,7 @@ func TestBuildToolRunsProjectBuildScriptWhenPresent(t *testing.T) {
 		},
 		BuildScriptRunner: func(dir, path string, stdin io.Reader, stdout, stderr io.Writer) error {
 			called = true
-			if dir != projectRoot || path != "./build.sh" {
+			if dir != scriptDir || path != "./build.sh" {
 				t.Fatalf("unexpected build script call: dir=%q path=%q", dir, path)
 			}
 			return nil
@@ -334,7 +338,11 @@ func TestBuildToolRunsProjectBuildScriptWhenPresent(t *testing.T) {
 
 func TestBuildToolPreviewVerboseIncludesBuildScriptTrace(t *testing.T) {
 	projectRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+	scriptDir := filepath.Join(projectRoot, "scripts", "build")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("write build.sh: %v", err)
 	}
 
@@ -355,7 +363,7 @@ func TestBuildToolPreviewVerboseIncludesBuildScriptTrace(t *testing.T) {
 	if len(output.Trace) == 0 {
 		t.Fatalf("expected trace output, got %+v", output)
 	}
-	if output.Trace[0] != "cd "+projectRoot+" && ./build.sh" {
+	if output.Trace[0] != "cd "+scriptDir+" && ./build.sh" {
 		t.Fatalf("unexpected trace output: %+v", output.Trace)
 	}
 }


### PR DESCRIPTION
## Summary
- add recursive tenant `build.sh` discovery while preserving project-root precedence
- skip Docker artefact directories such as `docker/<component>` when searching for override scripts
- update shared, CLI, and MCP tests for nested script execution and trace behavior

## Why
The existing build override only checked `<projectRoot>/build.sh`. This follow-up keeps that behavior as the first choice, but also supports nested tenant build scripts without letting scripts inside Docker artefact directories override `erun build`.

## Validation
- `cd erun-common && go test ./...`
- `cd erun-cli && go test ./...`
- `cd erun-mcp && go test ./...`

Follow-up to #8.
