### PR TITLE
Detect host OS and k3s runtime for local shells

### DIFF
--- a/erun-common/host_runtime.go
+++ b/erun-common/host_runtime.go
@@ -1,0 +1,224 @@
+package eruncommon
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"unicode"
+)
+
+type HostOS string
+
+const (
+	HostOSDarwin  HostOS = "darwin"
+	HostOSLinux   HostOS = "linux"
+	HostOSWindows HostOS = "windows"
+	HostOSUnknown HostOS = "unknown"
+)
+
+type ContainerRuntime string
+
+const (
+	ContainerRuntimeDocker         ContainerRuntime = "docker"
+	ContainerRuntimeContainerd     ContainerRuntime = "containerd"
+	ContainerRuntimePodman         ContainerRuntime = "podman"
+	ContainerRuntimeRancherDesktop ContainerRuntime = "rancher-desktop"
+	ContainerRuntimeUnknown        ContainerRuntime = "unknown"
+)
+
+type KubernetesInstallationType string
+
+const (
+	KubernetesInstallationNone KubernetesInstallationType = "none"
+	KubernetesInstallationK3s  KubernetesInstallationType = "k3s"
+)
+
+const defaultK3sKubeconfigPath = "/etc/rancher/k3s/k3s.yaml"
+
+type HostInfo struct {
+	OS      HostOS
+	Arch    string
+	HomeDir string
+}
+
+type KubernetesInstallation struct {
+	Type           KubernetesInstallationType
+	BinaryPath     string
+	KubeconfigPath string
+}
+
+type HostRuntime struct {
+	Host                   HostInfo
+	ContainerRuntime       ContainerRuntime
+	ContainerSocketPath    string
+	KubernetesInstallation KubernetesInstallation
+}
+
+var (
+	currentGOOS     = func() string { return runtime.GOOS }
+	currentGOARCH   = func() string { return runtime.GOARCH }
+	hostUserHomeDir = os.UserHomeDir
+	hostPathExists  = func(path string) bool {
+		_, err := os.Stat(path)
+		return err == nil
+	}
+	hostLookPath = exec.LookPath
+)
+
+func DetectHost() HostInfo {
+	homeDir, _ := hostUserHomeDir()
+	return HostInfo{
+		OS:      classifyHostOS(currentGOOS()),
+		Arch:    currentGOARCH(),
+		HomeDir: homeDir,
+	}
+}
+
+func DetectHostRuntime() HostRuntime {
+	host := DetectHost()
+	containerRuntime, socketPath, ok := DetectContainerRuntime(host)
+	if !ok {
+		containerRuntime = ContainerRuntimeUnknown
+		socketPath = ""
+	}
+	return HostRuntime{
+		Host:                   host,
+		ContainerRuntime:       containerRuntime,
+		ContainerSocketPath:    socketPath,
+		KubernetesInstallation: DetectKubernetesInstallation(host),
+	}
+}
+
+func DetectContainerRuntime(host HostInfo) (ContainerRuntime, string, bool) {
+	for _, candidate := range containerRuntimeSocketCandidates(host) {
+		if hostPathExists(candidate.path) {
+			return candidate.runtime, candidate.path, true
+		}
+	}
+	return ContainerRuntimeUnknown, "", false
+}
+
+func DetectKubernetesInstallation(host HostInfo) KubernetesInstallation {
+	if host.OS != HostOSLinux {
+		return KubernetesInstallation{Type: KubernetesInstallationNone}
+	}
+
+	installation := KubernetesInstallation{Type: KubernetesInstallationNone}
+	if binaryPath, err := hostLookPath("k3s"); err == nil {
+		installation.Type = KubernetesInstallationK3s
+		installation.BinaryPath = binaryPath
+	}
+	if hostPathExists(defaultK3sKubeconfigPath) {
+		installation.Type = KubernetesInstallationK3s
+		installation.KubeconfigPath = defaultK3sKubeconfigPath
+	}
+	return installation
+}
+
+func (h HostInfo) DockerMountPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	if h.OS != HostOSWindows {
+		return filepath.Clean(path)
+	}
+
+	normalized := strings.ReplaceAll(path, "\\", "/")
+	if len(normalized) >= 2 && normalized[1] == ':' {
+		drive := unicode.ToLower(rune(normalized[0]))
+		remainder := strings.TrimPrefix(normalized[2:], "/")
+		if remainder != "" {
+			remainder = "/" + remainder
+		}
+		return "/" + string(drive) + remainder
+	}
+	return normalized
+}
+
+func (h HostInfo) DockerVolumeSource(path string) string {
+	if path == "" {
+		return ""
+	}
+	if h.OS == HostOSWindows && strings.HasPrefix(path, `\\.\`) {
+		return strings.ReplaceAll(path, "\\", "/")
+	}
+	return h.DockerMountPath(path)
+}
+
+func (h HostInfo) JoinPath(elem ...string) string {
+	if h.OS != HostOSWindows {
+		return filepath.Join(elem...)
+	}
+
+	parts := make([]string, 0, len(elem))
+	for index, part := range elem {
+		if part == "" {
+			continue
+		}
+		if index == 0 {
+			part = strings.TrimRight(part, `\/`)
+		} else {
+			part = strings.Trim(part, `\/`)
+		}
+		if part == "" {
+			continue
+		}
+		parts = append(parts, part)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+
+	path := parts[0]
+	for _, part := range parts[1:] {
+		path += `\` + part
+	}
+	return path
+}
+
+type containerRuntimeSocketCandidate struct {
+	runtime ContainerRuntime
+	path    string
+}
+
+func containerRuntimeSocketCandidates(host HostInfo) []containerRuntimeSocketCandidate {
+	homeDir := strings.TrimSpace(host.HomeDir)
+
+	switch host.OS {
+	case HostOSWindows:
+		return []containerRuntimeSocketCandidate{
+			{runtime: ContainerRuntimeDocker, path: `\\.\pipe\docker_engine`},
+			{runtime: ContainerRuntimeRancherDesktop, path: `\\.\pipe\docker_engine`},
+			{runtime: ContainerRuntimeContainerd, path: `\\.\pipe\containerd-containerd`},
+		}
+	case HostOSDarwin:
+		return []containerRuntimeSocketCandidate{
+			{runtime: ContainerRuntimeDocker, path: "/var/run/docker.sock"},
+			{runtime: ContainerRuntimeRancherDesktop, path: host.JoinPath(homeDir, ".rd", "docker.sock")},
+			{runtime: ContainerRuntimeContainerd, path: host.JoinPath(homeDir, ".rd", "containerd", "containerd.sock")},
+			{runtime: ContainerRuntimePodman, path: host.JoinPath(homeDir, ".local", "share", "containers", "podman", "machine", "podman.sock")},
+		}
+	default:
+		return []containerRuntimeSocketCandidate{
+			{runtime: ContainerRuntimeDocker, path: "/var/run/docker.sock"},
+			{runtime: ContainerRuntimeRancherDesktop, path: host.JoinPath(homeDir, ".rd", "docker.sock")},
+			{runtime: ContainerRuntimeContainerd, path: "/run/containerd/containerd.sock"},
+			{runtime: ContainerRuntimePodman, path: "/run/podman/podman.sock"},
+		}
+	}
+}
+
+func classifyHostOS(goos string) HostOS {
+	switch goos {
+	case "darwin":
+		return HostOSDarwin
+	case "linux":
+		return HostOSLinux
+	case "windows":
+		return HostOSWindows
+	default:
+		return HostOSUnknown
+	}
+}

--- a/erun-common/host_runtime_test.go
+++ b/erun-common/host_runtime_test.go
@@ -1,0 +1,141 @@
+package eruncommon
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestHostInfoDockerMountPathWindows(t *testing.T) {
+	host := HostInfo{OS: HostOSWindows}
+	got := host.DockerMountPath(`C:\Users\john\project`)
+	want := "/c/Users/john/project"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestHostInfoDockerVolumeSourceWindowsPipe(t *testing.T) {
+	host := HostInfo{OS: HostOSWindows}
+	got := host.DockerVolumeSource(`\\.\pipe\docker_engine`)
+	want := "//./pipe/docker_engine"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestHostInfoJoinPathWindows(t *testing.T) {
+	host := HostInfo{OS: HostOSWindows}
+	got := host.JoinPath(`C:\Users\john`, ".kube")
+	want := `C:\Users\john\.kube`
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestClassifyHostOS(t *testing.T) {
+	if classifyHostOS("darwin") != HostOSDarwin {
+		t.Fatalf("expected darwin classification")
+	}
+	if classifyHostOS("linux") != HostOSLinux {
+		t.Fatalf("expected linux classification")
+	}
+	if classifyHostOS("windows") != HostOSWindows {
+		t.Fatalf("expected windows classification")
+	}
+	if classifyHostOS("plan9") != HostOSUnknown {
+		t.Fatalf("expected unknown classification")
+	}
+}
+
+func TestDetectHostUsesOverrides(t *testing.T) {
+	prevGOOS := currentGOOS
+	prevGOARCH := currentGOARCH
+	prevHomeDir := hostUserHomeDir
+	t.Cleanup(func() {
+		currentGOOS = prevGOOS
+		currentGOARCH = prevGOARCH
+		hostUserHomeDir = prevHomeDir
+	})
+
+	currentGOOS = func() string { return "windows" }
+	currentGOARCH = func() string { return "arm64" }
+	hostUserHomeDir = func() (string, error) { return `C:\Users\john`, nil }
+
+	host := DetectHost()
+	if host.OS != HostOSWindows || host.Arch != "arm64" || host.HomeDir != `C:\Users\john` {
+		t.Fatalf("unexpected host: %+v", host)
+	}
+}
+
+func TestDetectContainerRuntimePrefersMatchingSocket(t *testing.T) {
+	prevPathExists := hostPathExists
+	t.Cleanup(func() {
+		hostPathExists = prevPathExists
+	})
+
+	hostPathExists = func(path string) bool {
+		return path == "/run/containerd/containerd.sock"
+	}
+
+	runtime, socketPath, ok := DetectContainerRuntime(HostInfo{
+		OS:      HostOSLinux,
+		HomeDir: "/home/test",
+	})
+	if !ok {
+		t.Fatalf("expected runtime detection to succeed")
+	}
+	if runtime != ContainerRuntimeContainerd || socketPath != "/run/containerd/containerd.sock" {
+		t.Fatalf("unexpected runtime detection: %q %q", runtime, socketPath)
+	}
+}
+
+func TestDetectKubernetesInstallationFindsK3sBinaryAndConfig(t *testing.T) {
+	prevLookPath := hostLookPath
+	prevPathExists := hostPathExists
+	t.Cleanup(func() {
+		hostLookPath = prevLookPath
+		hostPathExists = prevPathExists
+	})
+
+	hostLookPath = func(file string) (string, error) {
+		if file == "k3s" {
+			return "/usr/local/bin/k3s", nil
+		}
+		return "", errors.New("not found")
+	}
+	hostPathExists = func(path string) bool {
+		return path == defaultK3sKubeconfigPath
+	}
+
+	installation := DetectKubernetesInstallation(HostInfo{OS: HostOSLinux})
+	if installation.Type != KubernetesInstallationK3s {
+		t.Fatalf("expected k3s installation, got %+v", installation)
+	}
+	if installation.BinaryPath != "/usr/local/bin/k3s" {
+		t.Fatalf("unexpected k3s binary path: %+v", installation)
+	}
+	if installation.KubeconfigPath != defaultK3sKubeconfigPath {
+		t.Fatalf("unexpected k3s kubeconfig path: %+v", installation)
+	}
+}
+
+func TestDetectKubernetesInstallationIgnoresK3sOutsideLinux(t *testing.T) {
+	prevLookPath := hostLookPath
+	prevPathExists := hostPathExists
+	t.Cleanup(func() {
+		hostLookPath = prevLookPath
+		hostPathExists = prevPathExists
+	})
+
+	hostLookPath = func(file string) (string, error) {
+		return "/usr/local/bin/k3s", nil
+	}
+	hostPathExists = func(path string) bool {
+		return true
+	}
+
+	installation := DetectKubernetesInstallation(HostInfo{OS: HostOSDarwin})
+	if installation.Type != KubernetesInstallationNone {
+		t.Fatalf("expected no k3s detection on darwin, got %+v", installation)
+	}
+}

--- a/erun-common/open_runtime.go
+++ b/erun-common/open_runtime.go
@@ -3,7 +3,6 @@ package eruncommon
 import (
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -30,6 +29,14 @@ type dockerContainerMount struct {
 	Target   string
 	ReadOnly bool
 }
+
+const (
+	openRuntimeContainerHome       = "/home/erun"
+	openRuntimeContainerKubeconfig = openRuntimeContainerHome + "/.kube/config"
+	openRuntimeContainerK3sConfig  = openRuntimeContainerHome + "/.kube/k3s.yaml"
+)
+
+var detectOpenRuntimeHost = DetectHostRuntime
 
 func ResolveOpenRuntimeSpec(store OpenRuntimeStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, target OpenResult) (OpenRuntimeSpec, bool, error) {
 	if !isLocalEnvironment(target.Environment) {
@@ -152,43 +159,69 @@ func DockerContainerRunner(args []string, stdin io.Reader, stdout, stderr io.Wri
 }
 
 func openRuntimeDockerArgs(target OpenResult, worktreePath, imageTag string) []string {
+	hostRuntime := detectOpenRuntimeHost()
 	args := []string{"run", "--rm", "-it"}
+	args = append(args, openRuntimeDockerExtraArgs(hostRuntime)...)
 
-	for _, entry := range []struct {
-		Name  string
-		Value string
-	}{
-		{Name: "ERUN_REPO_PATH", Value: worktreePath},
-		{Name: "ERUN_KUBERNETES_CONTEXT", Value: strings.TrimSpace(target.EnvConfig.KubernetesContext)},
-		{Name: "ERUN_SHELL_HOST", Value: target.Title},
-	} {
+	for _, entry := range openRuntimeDockerEnv(target, worktreePath, hostRuntime) {
 		if strings.TrimSpace(entry.Value) == "" {
 			continue
 		}
 		args = append(args, "-e", entry.Name+"="+entry.Value)
 	}
 
-	for _, mount := range openRuntimeDockerMounts(target.RepoPath, worktreePath) {
-		args = append(args, "-v", dockerContainerMountArg(mount))
+	for _, mount := range openRuntimeDockerMounts(target.RepoPath, worktreePath, hostRuntime) {
+		args = append(args, "-v", dockerContainerMountArg(hostRuntime.Host, mount))
 	}
 
 	args = append(args, "-w", worktreePath, imageTag, "shell")
 	return args
 }
 
-func openRuntimeDockerMounts(repoPath, worktreePath string) []dockerContainerMount {
+func openRuntimeDockerEnv(target OpenResult, worktreePath string, hostRuntime HostRuntime) []struct {
+	Name  string
+	Value string
+} {
+	entries := []struct {
+		Name  string
+		Value string
+	}{
+		{Name: "ERUN_REPO_PATH", Value: worktreePath},
+		{Name: "ERUN_KUBERNETES_CONTEXT", Value: strings.TrimSpace(target.EnvConfig.KubernetesContext)},
+		{Name: "ERUN_SHELL_HOST", Value: target.Title},
+	}
+	if hostRuntime.KubernetesInstallation.KubeconfigPath != "" {
+		entries = append(entries, struct {
+			Name  string
+			Value string
+		}{
+			Name:  "KUBECONFIG",
+			Value: strings.Join([]string{openRuntimeContainerKubeconfig, openRuntimeContainerK3sConfig}, ":"),
+		})
+	}
+	return entries
+}
+
+func openRuntimeDockerExtraArgs(hostRuntime HostRuntime) []string {
+	if hostRuntime.Host.OS == HostOSLinux && hostRuntime.KubernetesInstallation.Type == KubernetesInstallationK3s {
+		return []string{"--network", "host"}
+	}
+	return nil
+}
+
+func openRuntimeDockerMounts(repoPath, worktreePath string, hostRuntime HostRuntime) []dockerContainerMount {
 	mounts := []dockerContainerMount{{
 		Source: filepath.Clean(repoPath),
 		Target: worktreePath,
 	}}
 
-	homeDir, err := os.UserHomeDir()
-	if err == nil {
+	homeDir := strings.TrimSpace(hostRuntime.Host.HomeDir)
+	if homeDir != "" {
 		for _, mount := range []dockerContainerMount{
-			{Source: filepath.Join(homeDir, ".kube"), Target: "/home/erun/.kube", ReadOnly: true},
-			{Source: filepath.Join(homeDir, ".ssh"), Target: "/home/erun/.ssh", ReadOnly: true},
-			{Source: filepath.Join(homeDir, ".gitconfig"), Target: "/home/erun/.gitconfig", ReadOnly: true},
-			{Source: filepath.Join(homeDir, ".docker"), Target: "/home/erun/.docker", ReadOnly: true},
+			{Source: hostRuntime.Host.JoinPath(homeDir, ".kube"), Target: openRuntimeContainerHome + "/.kube", ReadOnly: true},
+			{Source: hostRuntime.Host.JoinPath(homeDir, ".ssh"), Target: openRuntimeContainerHome + "/.ssh", ReadOnly: true},
+			{Source: hostRuntime.Host.JoinPath(homeDir, ".gitconfig"), Target: openRuntimeContainerHome + "/.gitconfig", ReadOnly: true},
+			{Source: hostRuntime.Host.JoinPath(homeDir, ".docker"), Target: openRuntimeContainerHome + "/.docker", ReadOnly: true},
 		} {
 			if openRuntimeHostPathExists(mount.Source) {
 				mounts = append(mounts, mount)
@@ -196,9 +229,17 @@ func openRuntimeDockerMounts(repoPath, worktreePath string) []dockerContainerMou
 		}
 	}
 
-	if openRuntimeHostPathExists("/var/run/docker.sock") {
+	if hostRuntime.KubernetesInstallation.KubeconfigPath != "" && openRuntimeHostPathExists(hostRuntime.KubernetesInstallation.KubeconfigPath) {
 		mounts = append(mounts, dockerContainerMount{
-			Source: "/var/run/docker.sock",
+			Source:   hostRuntime.KubernetesInstallation.KubeconfigPath,
+			Target:   openRuntimeContainerK3sConfig,
+			ReadOnly: true,
+		})
+	}
+
+	if hostRuntime.ContainerSocketPath != "" && openRuntimeHostPathExists(hostRuntime.ContainerSocketPath) {
+		mounts = append(mounts, dockerContainerMount{
+			Source: hostRuntime.ContainerSocketPath,
 			Target: "/var/run/docker.sock",
 		})
 	}
@@ -207,12 +248,11 @@ func openRuntimeDockerMounts(repoPath, worktreePath string) []dockerContainerMou
 }
 
 func openRuntimeHostPathExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
+	return hostPathExists(path)
 }
 
-func dockerContainerMountArg(mount dockerContainerMount) string {
-	value := filepath.Clean(mount.Source) + ":" + mount.Target
+func dockerContainerMountArg(host HostInfo, mount dockerContainerMount) string {
+	value := host.DockerVolumeSource(mount.Source) + ":" + mount.Target
 	if mount.ReadOnly {
 		value += ":ro"
 	}

--- a/erun-common/open_runtime_test.go
+++ b/erun-common/open_runtime_test.go
@@ -1,0 +1,109 @@
+package eruncommon
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOpenRuntimeDockerArgsIncludeK3sSupportOnLinux(t *testing.T) {
+	prevDetectHost := detectOpenRuntimeHost
+	prevPathExists := hostPathExists
+	t.Cleanup(func() {
+		detectOpenRuntimeHost = prevDetectHost
+		hostPathExists = prevPathExists
+	})
+
+	detectOpenRuntimeHost = func() HostRuntime {
+		return HostRuntime{
+			Host: HostInfo{
+				OS:      HostOSLinux,
+				HomeDir: "/home/tester",
+			},
+			ContainerRuntime:    ContainerRuntimeDocker,
+			ContainerSocketPath: "/var/run/docker.sock",
+			KubernetesInstallation: KubernetesInstallation{
+				Type:           KubernetesInstallationK3s,
+				KubeconfigPath: defaultK3sKubeconfigPath,
+			},
+		}
+	}
+	hostPathExists = func(path string) bool {
+		switch path {
+		case "/home/tester/.kube", "/home/tester/.ssh", "/home/tester/.gitconfig", "/home/tester/.docker", "/var/run/docker.sock", defaultK3sKubeconfigPath:
+			return true
+		default:
+			return false
+		}
+	}
+
+	args := openRuntimeDockerArgs(OpenResult{
+		RepoPath: "/repo",
+		Title:    "tenant-a-local",
+		EnvConfig: EnvConfig{
+			KubernetesContext: "cluster-local",
+		},
+	}, "/home/erun/git/repo", "erunpaas/tenant-a-devops:1.1.0")
+
+	command := strings.Join(args, " ")
+	for _, want := range []string{
+		"run --rm -it --network host",
+		"-e ERUN_KUBERNETES_CONTEXT=cluster-local",
+		"-e ERUN_SHELL_HOST=tenant-a-local",
+		"-e KUBECONFIG=" + openRuntimeContainerKubeconfig + ":" + openRuntimeContainerK3sConfig,
+		"-v /repo:/home/erun/git/repo",
+		"-v /var/run/docker.sock:/var/run/docker.sock",
+		"-v " + defaultK3sKubeconfigPath + ":" + openRuntimeContainerK3sConfig + ":ro",
+		"erunpaas/tenant-a-devops:1.1.0 shell",
+	} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("expected runtime args to contain %q, got %q", want, command)
+		}
+	}
+}
+
+func TestOpenRuntimeDockerArgsConvertWindowsMounts(t *testing.T) {
+	prevDetectHost := detectOpenRuntimeHost
+	prevPathExists := hostPathExists
+	t.Cleanup(func() {
+		detectOpenRuntimeHost = prevDetectHost
+		hostPathExists = prevPathExists
+	})
+
+	detectOpenRuntimeHost = func() HostRuntime {
+		return HostRuntime{
+			Host: HostInfo{
+				OS:      HostOSWindows,
+				HomeDir: `C:\Users\john`,
+			},
+			ContainerRuntime:    ContainerRuntimeDocker,
+			ContainerSocketPath: `\\.\pipe\docker_engine`,
+		}
+	}
+	hostPathExists = func(path string) bool {
+		switch path {
+		case `C:\Users\john\.kube`, `C:\Users\john\.ssh`, `C:\Users\john\.gitconfig`, `C:\Users\john\.docker`, `\\.\pipe\docker_engine`:
+			return true
+		default:
+			return false
+		}
+	}
+
+	args := openRuntimeDockerArgs(OpenResult{
+		RepoPath: `C:\Users\john\project`,
+		Title:    "tenant-a-local",
+		EnvConfig: EnvConfig{
+			KubernetesContext: "cluster-local",
+		},
+	}, "/home/erun/git/project", "erunpaas/tenant-a-devops:1.1.0")
+
+	command := strings.Join(args, " ")
+	for _, want := range []string{
+		"-v /c/Users/john/project:/home/erun/git/project",
+		"-v //./pipe/docker_engine:/var/run/docker.sock",
+		"-v /c/Users/john/.kube:/home/erun/.kube:ro",
+	} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("expected runtime args to contain %q, got %q", want, command)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared host runtime detection API in `erun-common` for host OS, container sockets, and local k3s installs
- use that shared detection when building local `erun open` Docker args so mounts work across Windows, macOS, and Linux
- add regression coverage for Windows path conversion, container runtime socket detection, and Linux k3s runtime setup

## Why
- local runtime launch previously assumed Linux-style host paths and a fixed `/var/run/docker.sock`
- Linux hosts with local k3s installs were not surfaced through a shared API or wired into the runtime shell setup

## Validation
- `go test ./...` in `erun-common`
- `go test ./...` in `erun-cli`
- `go test ./...` in `erun-mcp`

Closes #9
