### PR TITLE
Fix build and push command scope

### DIFF
--- a/erun-cli/cmd/build.go
+++ b/erun-cli/cmd/build.go
@@ -17,7 +17,7 @@ const (
 
 var errVersionFileNotFound = common.ErrVersionFileNotFound
 
-func newBuildCmd(store common.DockerStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, now common.NowFunc, runBuildScript common.BuildScriptRunnerFunc, buildDockerImage common.DockerImageBuilderFunc) *cobra.Command {
+func newBuildCmd(store common.DockerStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, now common.NowFunc, runBuildScript common.BuildScriptRunnerFunc, buildDockerImage common.DockerImageBuilderFunc, push common.DockerPushFunc) *cobra.Command {
 	target := common.DockerCommandTarget{}
 	cmd := &cobra.Command{
 		Use:           "build",
@@ -31,7 +31,7 @@ func newBuildCmd(store common.DockerStore, findProjectRoot common.ProjectFinderF
 			if err != nil {
 				return err
 			}
-			return common.RunBuildExecution(ctx, execution, runBuildScript, buildDockerImage)
+			return common.RunBuildExecution(ctx, execution, runBuildScript, buildDockerImage, push)
 		},
 	}
 	addDryRunFlag(cmd)
@@ -43,17 +43,17 @@ func newPushCmd(store common.DockerStore, findProjectRoot common.ProjectFinderFu
 	target := common.DockerCommandTarget{}
 	cmd := &cobra.Command{
 		Use:           "push",
-		Short:         "Push the current container image",
+		Short:         "Build and push the current container image",
 		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext(cmd)
-			execution, err := common.ResolveDockerPushExecution(store, findProjectRoot, resolveBuildContext, now, target)
+			pushInput, buildInput, err := common.ResolveDockerPushSpec(store, findProjectRoot, resolveBuildContext, now, target)
 			if err != nil {
 				return err
 			}
-			return common.RunDockerPushExecution(ctx, execution, buildDockerImage, push)
+			return common.RunDockerPushSpec(ctx, pushInput, buildInput, buildDockerImage, push)
 		},
 	}
 	addDryRunFlag(cmd)

--- a/erun-cli/cmd/build_test.go
+++ b/erun-cli/cmd/build_test.go
@@ -230,7 +230,7 @@ func TestNewRootCmdRegistersBuildShorthandWhenDockerfilePresent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Find(push) failed: %v", err)
 	}
-	if pushCmd.Short != "Push the current container image" {
+	if pushCmd.Short != "Build and push the current container image" {
 		t.Fatalf("unexpected push short help: %q", pushCmd.Short)
 	}
 }
@@ -306,7 +306,7 @@ func TestNewRootCmdRegistersBuildShorthandWhenDockerDirectoryContainsDockerfiles
 	if err != nil {
 		t.Fatalf("Find(build) failed: %v", err)
 	}
-	if buildCmd.Short != "Build the devops container images for the current project" {
+	if buildCmd.Short != "Build and push the devops container images for the current project" {
 		t.Fatalf("unexpected build short help: %q", buildCmd.Short)
 	}
 
@@ -334,7 +334,7 @@ func TestNewRootCmdRegistersContextAwareShorthandHelpWhenCurrentDirectoryIsProje
 	if err != nil {
 		t.Fatalf("Find(build) failed: %v", err)
 	}
-	if buildCmd.Short != "Build the project" {
+	if buildCmd.Short != "Build and push the project" {
 		t.Fatalf("unexpected build short help: %q", buildCmd.Short)
 	}
 
@@ -388,6 +388,10 @@ func TestRootBuildShorthandRunsDockerBuild(t *testing.T) {
 		},
 		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
 			received = req
+			return nil
+		}),
+		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
+			t.Fatalf("unexpected push request: %+v", req)
 			return nil
 		}),
 		LaunchShell: func(req common.ShellLaunchParams) error {
@@ -511,7 +515,8 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDockerDire
 		t.Fatalf("write VERSION: %v", err)
 	}
 
-	var received []dockerBuildCall
+	var built []dockerBuildCall
+	var pushed []dockerPushCall
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
 			return "erun", projectRoot, nil
@@ -520,7 +525,11 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDockerDire
 			return common.DockerBuildContext{Dir: dockerDir}, nil
 		},
 		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
-			received = append(received, req)
+			built = append(built, req)
+			return nil
+		}),
+		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
+			pushed = append(pushed, req)
 			return nil
 		}),
 	})
@@ -534,11 +543,11 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDockerDire
 		t.Fatalf("Execute failed: %v", err)
 	}
 
-	if len(received) != 3 {
-		t.Fatalf("expected 3 build requests, got %d", len(received))
+	if len(built) != 3 || len(pushed) != 3 {
+		t.Fatalf("unexpected build/push counts: builds=%d pushes=%d", len(built), len(pushed))
 	}
 
-	gotTags := []string{received[0].Tag, received[1].Tag, received[2].Tag}
+	gotTags := []string{built[0].Tag, built[1].Tag, built[2].Tag}
 	wantTags := []string{
 		"erunpaas/erun-devops:1.0.0",
 		"erunpaas/erun-dind:28.1.1",
@@ -549,7 +558,7 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDockerDire
 			t.Fatalf("unexpected image tags: got %v want %v", gotTags, wantTags)
 		}
 	}
-	for _, req := range received {
+	for _, req := range built {
 		if req.Dir != projectRoot {
 			t.Fatalf("expected project root build context, got %+v", req)
 		}
@@ -557,12 +566,14 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDockerDire
 			t.Fatalf("unexpected output writers: %+v", req)
 		}
 	}
+	assertTagSet(t, []string{pushed[0].Tag, pushed[1].Tag, pushed[2].Tag}, wantTags)
 }
 
 func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsProjectRoot(t *testing.T) {
 	projectRoot, _, _, _, wantTags := setupMultiDockerProject(t, "tenant-a")
 
-	var received []dockerBuildCall
+	var built []dockerBuildCall
+	var pushed []dockerPushCall
 	cmd := newTestRootCmd(testRootDeps{
 		OptionalBuildFindProjectRoot: func() (string, string, error) {
 			return "tenant-a", projectRoot, nil
@@ -574,7 +585,11 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsProjectRoo
 			return common.DockerBuildContext{Dir: projectRoot}, nil
 		},
 		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
-			received = append(received, req)
+			built = append(built, req)
+			return nil
+		}),
+		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
+			pushed = append(pushed, req)
 			return nil
 		}),
 	})
@@ -583,23 +598,29 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsProjectRoo
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
-	if len(received) != len(wantTags) {
-		t.Fatalf("expected %d build requests, got %d", len(wantTags), len(received))
+	if len(built) != len(wantTags) || len(pushed) != len(wantTags) {
+		t.Fatalf("unexpected build/push counts: builds=%d pushes=%d", len(built), len(pushed))
 	}
-	gotTags := make([]string, 0, len(received))
-	for i, req := range received {
+	gotTags := make([]string, 0, len(built))
+	for i, req := range built {
 		if req.Dir != projectRoot {
 			t.Fatalf("unexpected build request %d: %+v", i, req)
 		}
 		gotTags = append(gotTags, req.Tag)
 	}
 	assertTagSet(t, gotTags, wantTags)
+	gotPushTags := make([]string, 0, len(pushed))
+	for _, req := range pushed {
+		gotPushTags = append(gotPushTags, req.Tag)
+	}
+	assertTagSet(t, gotPushTags, wantTags)
 }
 
 func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDevopsModuleRoot(t *testing.T) {
 	projectRoot, moduleRoot, _, _, wantTags := setupMultiDockerProject(t, "tenant-a")
 
-	var received []dockerBuildCall
+	var built []dockerBuildCall
+	var pushed []dockerPushCall
 	cmd := newTestRootCmd(testRootDeps{
 		OptionalBuildFindProjectRoot: func() (string, string, error) {
 			return "tenant-a", projectRoot, nil
@@ -611,7 +632,11 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDevopsModu
 			return common.DockerBuildContext{Dir: moduleRoot}, nil
 		},
 		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
-			received = append(received, req)
+			built = append(built, req)
+			return nil
+		}),
+		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
+			pushed = append(pushed, req)
 			return nil
 		}),
 	})
@@ -620,17 +645,22 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDevopsModu
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
-	if len(received) != len(wantTags) {
-		t.Fatalf("expected %d build requests, got %d", len(wantTags), len(received))
+	if len(built) != len(wantTags) || len(pushed) != len(wantTags) {
+		t.Fatalf("unexpected build/push counts: builds=%d pushes=%d", len(built), len(pushed))
 	}
-	gotTags := make([]string, 0, len(received))
-	for i, req := range received {
+	gotTags := make([]string, 0, len(built))
+	for i, req := range built {
 		if req.Dir != projectRoot {
 			t.Fatalf("unexpected build request %d: %+v", i, req)
 		}
 		gotTags = append(gotTags, req.Tag)
 	}
 	assertTagSet(t, gotTags, wantTags)
+	gotPushTags := make([]string, 0, len(pushed))
+	for _, req := range pushed {
+		gotPushTags = append(gotPushTags, req.Tag)
+	}
+	assertTagSet(t, gotPushTags, wantTags)
 }
 
 func TestRootBuildShorthandUsesExactVersionFromCurrentBuildDirectoryForLocalEnvironment(t *testing.T) {
@@ -672,6 +702,10 @@ func TestRootBuildShorthandUsesExactVersionFromCurrentBuildDirectoryForLocalEnvi
 		},
 		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
 			received = req
+			return nil
+		}),
+		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
+			t.Fatalf("unexpected push request: %+v", req)
 			return nil
 		}),
 		Now: func() time.Time {
@@ -730,6 +764,10 @@ func TestRootBuildShorthandDryRunPrintsCommandWithoutExecuting(t *testing.T) {
 			t.Fatalf("unexpected build request during dry-run: %+v", req)
 			return nil
 		}),
+		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
+			t.Fatalf("unexpected push request during dry-run: %+v", req)
+			return nil
+		}),
 		Now: func() time.Time {
 			return time.Date(2026, time.April, 6, 13, 16, 30, 0, time.UTC)
 		},
@@ -743,6 +781,50 @@ func TestRootBuildShorthandDryRunPrintsCommandWithoutExecuting(t *testing.T) {
 
 	if got := stderr.String(); !bytes.Contains([]byte(got), []byte("docker build -t erunpaas/erun-devops:1.1.0")) {
 		t.Fatalf("expected dry-run trace output, got %q", got)
+	}
+	if strings.Contains(stderr.String(), "docker push erunpaas/erun-devops:1.1.0") {
+		t.Fatalf("did not expect push dry-run trace, got %q", stderr.String())
+	}
+}
+
+func TestRootBuildShorthandDryRunPrintsBuildAndPushCommandsForProjectRoot(t *testing.T) {
+	projectRoot, _, _, _, wantTags := setupMultiDockerProject(t, "tenant-a")
+
+	stderr := new(bytes.Buffer)
+	cmd := newTestRootCmd(testRootDeps{
+		OptionalBuildFindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
+			return common.DockerBuildContext{Dir: projectRoot}, nil
+		},
+		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
+			t.Fatalf("unexpected build request during dry-run: %+v", req)
+			return nil
+		}),
+		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
+			t.Fatalf("unexpected push request during dry-run: %+v", req)
+			return nil
+		}),
+	})
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"build", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	output := stderr.String()
+	for _, tag := range wantTags {
+		if !strings.Contains(output, "docker build -t "+tag) {
+			t.Fatalf("expected dry-run build trace for %q, got %q", tag, output)
+		}
+		if !strings.Contains(output, "docker push "+tag) {
+			t.Fatalf("expected dry-run push trace for %q, got %q", tag, output)
+		}
 	}
 }
 
@@ -826,6 +908,10 @@ func TestRootBuildShorthandIgnoresBuildScriptInDockerArtifactDirectory(t *testin
 			built = req
 			return nil
 		}),
+		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
+			t.Fatalf("unexpected push request: %+v", req)
+			return nil
+		}),
 	})
 	cmd.SetArgs([]string{"build"})
 
@@ -866,6 +952,10 @@ func TestRootBuildShorthandVerbosePrintsTraceBeforeExecuting(t *testing.T) {
 			}, nil
 		},
 		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
+			return nil
+		}),
+		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
+			t.Fatalf("unexpected push request: %+v", req)
 			return nil
 		}),
 	})
@@ -914,6 +1004,10 @@ func TestRootBuildShorthandDoubleVerbosePrintsBuildTraceBeforeExecuting(t *testi
 		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
 			return nil
 		}),
+		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
+			t.Fatalf("unexpected push request: %+v", req)
+			return nil
+		}),
 	})
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"-vv", "build"})
@@ -953,10 +1047,19 @@ func TestDevopsContainerBuildFailsWithoutDockerfile(t *testing.T) {
 }
 
 func TestDevopsContainerPushUsesResolvedImageTag(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+
 	projectRoot := t.TempDir()
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
 	if err := os.MkdirAll(workdir, 0o755); err != nil {
 		t.Fatalf("mkdir build dir: %v", err)
+	}
+	if err := common.SaveTenantConfig(common.TenantConfig{
+		Name:               "erun",
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: common.DefaultEnvironment,
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
 	}
 	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
 		t.Fatalf("save project config: %v", err)
@@ -968,6 +1071,7 @@ func TestDevopsContainerPushUsesResolvedImageTag(t *testing.T) {
 		t.Fatalf("write local VERSION: %v", err)
 	}
 
+	var built dockerBuildCall
 	var received dockerPushCall
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
@@ -979,6 +1083,10 @@ func TestDevopsContainerPushUsesResolvedImageTag(t *testing.T) {
 				DockerfilePath: filepath.Join(workdir, "Dockerfile"),
 			}, nil
 		},
+		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
+			built = req
+			return nil
+		}),
 		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
 			received = req
 			return nil
@@ -994,6 +1102,9 @@ func TestDevopsContainerPushUsesResolvedImageTag(t *testing.T) {
 		t.Fatalf("Execute failed: %v", err)
 	}
 
+	if built.Tag != "erunpaas/erun-devops:1.1.0" {
+		t.Fatalf("unexpected build tag: %+v", built)
+	}
 	if received.Tag != "erunpaas/erun-devops:1.1.0" {
 		t.Fatalf("unexpected image tag: %+v", received)
 	}
@@ -1065,10 +1176,19 @@ func TestDevopsContainerPushPromptsLoginAndRetriesOnAuthError(t *testing.T) {
 }
 
 func TestRootPushShorthandUsesResolvedImageTag(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+
 	projectRoot := t.TempDir()
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
 	if err := os.MkdirAll(workdir, 0o755); err != nil {
 		t.Fatalf("mkdir build dir: %v", err)
+	}
+	if err := common.SaveTenantConfig(common.TenantConfig{
+		Name:               "erun",
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: common.DefaultEnvironment,
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
 	}
 	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
 		t.Fatalf("save project config: %v", err)
@@ -1080,6 +1200,7 @@ func TestRootPushShorthandUsesResolvedImageTag(t *testing.T) {
 		t.Fatalf("write local VERSION: %v", err)
 	}
 
+	var built dockerBuildCall
 	var received dockerPushCall
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
@@ -1091,6 +1212,10 @@ func TestRootPushShorthandUsesResolvedImageTag(t *testing.T) {
 				DockerfilePath: filepath.Join(workdir, "Dockerfile"),
 			}, nil
 		},
+		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
+			built = req
+			return nil
+		}),
 		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
 			received = req
 			return nil
@@ -1106,6 +1231,9 @@ func TestRootPushShorthandUsesResolvedImageTag(t *testing.T) {
 		t.Fatalf("Execute failed: %v", err)
 	}
 
+	if built.Tag != "erunpaas/erun-devops:1.1.0" {
+		t.Fatalf("unexpected build tag: %+v", built)
+	}
 	if received.Tag != "erunpaas/erun-devops:1.1.0" {
 		t.Fatalf("unexpected image tag: %+v", received)
 	}
@@ -1178,11 +1306,9 @@ func TestRootPushShorthandBuildsAndPushesSameExactVersionFromCurrentBuildDirecto
 	}
 }
 
-func TestDevopsContainerPushBuildsAndPushesAllDockerImagesWhenCurrentDirectoryIsProjectRoot(t *testing.T) {
+func TestDevopsContainerPushFailsWhenCurrentDirectoryIsProjectRoot(t *testing.T) {
 	projectRoot, _, _, _, wantTags := setupMultiDockerProject(t, "tenant-a")
 
-	var built []dockerBuildCall
-	var pushed []dockerPushCall
 	cmd := newTestRootCmd(testRootDeps{
 		OptionalBuildFindProjectRoot: func() (string, string, error) {
 			return "tenant-a", projectRoot, nil
@@ -1194,42 +1320,28 @@ func TestDevopsContainerPushBuildsAndPushesAllDockerImagesWhenCurrentDirectoryIs
 			return common.DockerBuildContext{Dir: projectRoot}, nil
 		},
 		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
-			built = append(built, req)
+			t.Fatalf("unexpected build request: %+v", req)
 			return nil
 		}),
 		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
-			pushed = append(pushed, req)
+			t.Fatalf("unexpected push request: %+v", req)
 			return nil
 		}),
 	})
 	cmd.SetArgs([]string{"devops", "container", "push"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing Dockerfile error")
 	}
-	if len(built) != len(wantTags) || len(pushed) != len(wantTags) {
-		t.Fatalf("unexpected build/push counts: builds=%d pushes=%d", len(built), len(pushed))
+	if got := err.Error(); got != "dockerfile not found in current directory" {
+		t.Fatalf("unexpected error: %q want tags=%v", got, wantTags)
 	}
-	builtTags := make([]string, 0, len(built))
-	for i, req := range built {
-		if req.Dir != projectRoot {
-			t.Fatalf("unexpected build request %d: %+v", i, req)
-		}
-		builtTags = append(builtTags, req.Tag)
-	}
-	pushedTags := make([]string, 0, len(pushed))
-	for _, req := range pushed {
-		pushedTags = append(pushedTags, req.Tag)
-	}
-	assertTagSet(t, builtTags, wantTags)
-	assertTagSet(t, pushedTags, wantTags)
 }
 
-func TestDevopsContainerPushBuildsAndPushesAllDockerImagesWhenCurrentDirectoryIsDevopsModuleRoot(t *testing.T) {
+func TestDevopsContainerPushFailsWhenCurrentDirectoryIsDevopsModuleRoot(t *testing.T) {
 	projectRoot, moduleRoot, _, _, wantTags := setupMultiDockerProject(t, "tenant-a")
 
-	var built []dockerBuildCall
-	var pushed []dockerPushCall
 	cmd := newTestRootCmd(testRootDeps{
 		OptionalBuildFindProjectRoot: func() (string, string, error) {
 			return "tenant-a", projectRoot, nil
@@ -1241,42 +1353,28 @@ func TestDevopsContainerPushBuildsAndPushesAllDockerImagesWhenCurrentDirectoryIs
 			return common.DockerBuildContext{Dir: moduleRoot}, nil
 		},
 		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
-			built = append(built, req)
+			t.Fatalf("unexpected build request: %+v", req)
 			return nil
 		}),
 		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
-			pushed = append(pushed, req)
+			t.Fatalf("unexpected push request: %+v", req)
 			return nil
 		}),
 	})
 	cmd.SetArgs([]string{"devops", "container", "push"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing Dockerfile error")
 	}
-	if len(built) != len(wantTags) || len(pushed) != len(wantTags) {
-		t.Fatalf("unexpected build/push counts: builds=%d pushes=%d", len(built), len(pushed))
+	if got := err.Error(); got != "dockerfile not found in current directory" {
+		t.Fatalf("unexpected error: %q want tags=%v", got, wantTags)
 	}
-	builtTags := make([]string, 0, len(built))
-	for i, req := range built {
-		if req.Dir != projectRoot {
-			t.Fatalf("unexpected build request %d: %+v", i, req)
-		}
-		builtTags = append(builtTags, req.Tag)
-	}
-	pushedTags := make([]string, 0, len(pushed))
-	for _, req := range pushed {
-		pushedTags = append(pushedTags, req.Tag)
-	}
-	assertTagSet(t, builtTags, wantTags)
-	assertTagSet(t, pushedTags, wantTags)
 }
 
-func TestDevopsContainerPushBuildsAndPushesAllDockerImagesWhenCurrentDirectoryIsDockerDirectory(t *testing.T) {
+func TestDevopsContainerPushFailsWhenCurrentDirectoryIsDockerDirectory(t *testing.T) {
 	projectRoot, _, dockerDir, _, wantTags := setupMultiDockerProject(t, "tenant-a")
 
-	var built []dockerBuildCall
-	var pushed []dockerPushCall
 	cmd := newTestRootCmd(testRootDeps{
 		OptionalBuildFindProjectRoot: func() (string, string, error) {
 			return "tenant-a", projectRoot, nil
@@ -1288,35 +1386,23 @@ func TestDevopsContainerPushBuildsAndPushesAllDockerImagesWhenCurrentDirectoryIs
 			return common.DockerBuildContext{Dir: dockerDir}, nil
 		},
 		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
-			built = append(built, req)
+			t.Fatalf("unexpected build request: %+v", req)
 			return nil
 		}),
 		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
-			pushed = append(pushed, req)
+			t.Fatalf("unexpected push request: %+v", req)
 			return nil
 		}),
 	})
 	cmd.SetArgs([]string{"devops", "container", "push"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected missing Dockerfile error")
 	}
-	if len(built) != len(wantTags) || len(pushed) != len(wantTags) {
-		t.Fatalf("unexpected build/push counts: builds=%d pushes=%d", len(built), len(pushed))
+	if got := err.Error(); got != "dockerfile not found in current directory" {
+		t.Fatalf("unexpected error: %q want tags=%v", got, wantTags)
 	}
-	builtTags := make([]string, 0, len(built))
-	for i, req := range built {
-		if req.Dir != projectRoot {
-			t.Fatalf("unexpected build request %d: %+v", i, req)
-		}
-		builtTags = append(builtTags, req.Tag)
-	}
-	pushedTags := make([]string, 0, len(pushed))
-	for _, req := range pushed {
-		pushedTags = append(pushedTags, req.Tag)
-	}
-	assertTagSet(t, builtTags, wantTags)
-	assertTagSet(t, pushedTags, wantTags)
 }
 
 func TestRootBuildShorthandUsesSnapshotWhenVersionIsInheritedFromParentModule(t *testing.T) {
@@ -1425,6 +1511,9 @@ func TestRootPushShorthandDryRunPrintsCommandWithoutExecuting(t *testing.T) {
 	}
 
 	got := stderr.String()
+	if !bytes.Contains([]byte(got), []byte("docker build -t erunpaas/erun-devops:1.1.0")) {
+		t.Fatalf("expected dry-run build trace output, got %q", got)
+	}
 	if !bytes.Contains([]byte(got), []byte("docker push erunpaas/erun-devops:1.1.0")) {
 		t.Fatalf("expected dry-run trace output, got %q", got)
 	}
@@ -1609,6 +1698,7 @@ func TestRunContainerBuildCommandPropagatesBuildContextErrors(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	cmd.SetArgs([]string{})
 
@@ -1626,7 +1716,7 @@ func TestRunContainerPushCommandPropagatesBuildContextErrors(t *testing.T) {
 		newBuildCmd(common.ConfigStore{}, nil, func() (common.DockerBuildContext, error) {
 			t.Fatal("unexpected build execution")
 			return common.DockerBuildContext{}, nil
-		}, nil, nil, nil),
+		}, nil, nil, nil, nil),
 		newPushCmd(common.ConfigStore{}, nil, func() (common.DockerBuildContext, error) {
 			return common.DockerBuildContext{}, expectedErr
 		}, nil, nil, nil),

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -49,7 +49,7 @@ func Execute() error {
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
-		newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder),
+		newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, push),
 		newPushCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.DockerImageBuilder, push),
 	)
 	k8sCmd := newCommandGroup(
@@ -61,7 +61,7 @@ func Execute() error {
 
 	var buildCmd *cobra.Command
 	if hasOptionalBuildCmd(common.FindProjectRoot, common.ResolveDockerBuildContext) {
-		buildCmd = newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder)
+		buildCmd = newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, push)
 		buildCmd.Short = optionalBuildCmdShort(common.FindProjectRoot, common.ResolveDockerBuildContext)
 	}
 	var pushCmd *cobra.Command

--- a/erun-cli/cmd/root_runtime.go
+++ b/erun-cli/cmd/root_runtime.go
@@ -149,9 +149,9 @@ func optionalBuildCmdShort(findProjectRoot common.ProjectFinderFunc, resolveBuil
 		if projectRoot, projectRootErr := projectRootForHelp(findProjectRoot); projectRootErr == nil &&
 			projectRoot != "" &&
 			filepath.Clean(strings.TrimSpace(buildContext.Dir)) == projectRoot {
-			return "Build the project"
+			return "Build and push the project"
 		}
-		return "Build the devops container images for the current project"
+		return "Build and push the devops container images for the current project"
 	}
 
 	return "Build the container image in the current directory"
@@ -160,19 +160,19 @@ func optionalBuildCmdShort(findProjectRoot common.ProjectFinderFunc, resolveBuil
 func optionalPushCmdShort(findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc) string {
 	buildContexts, err := common.ResolveCurrentDockerBuildContexts(findProjectRoot, resolveBuildContext, common.DockerCommandTarget{})
 	if err != nil {
-		return "Push the current container image"
+		return "Build and push the current container image"
 	}
 
 	buildContext, err := resolveBuildContext()
 	if err == nil && strings.TrimSpace(buildContext.DockerfilePath) != "" && len(buildContexts) == 1 {
-		return "Push the current container image"
+		return "Build and push the current container image"
 	}
 
 	if len(buildContexts) > 0 {
 		return "Build and push the devops container images for the current project"
 	}
 
-	return "Push the current container image"
+	return "Build and push the current container image"
 }
 
 func projectRootForHelp(findProjectRoot common.ProjectFinderFunc) (string, error) {

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -121,7 +121,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
-		newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, now, runBuildScript, buildDockerImage),
+		newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, now, runBuildScript, buildDockerImage, push),
 		newPushCmd(store, findProjectRoot, resolveDockerBuildContext, now, buildDockerImage, push),
 	)
 	k8sCmd := newCommandGroup(
@@ -133,7 +133,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 
 	var buildCmd *cobra.Command
 	if hasOptionalBuildCmd(optionalBuildFindProjectRoot, resolveDockerBuildContext) {
-		buildCmd = newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, now, runBuildScript, buildDockerImage)
+		buildCmd = newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, now, runBuildScript, buildDockerImage, push)
 		buildCmd.Short = optionalBuildCmdShort(optionalBuildFindProjectRoot, resolveDockerBuildContext)
 	}
 	var pushCmd *cobra.Command

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -74,6 +74,7 @@ type projectBuildScriptSpec struct {
 type BuildExecutionSpec struct {
 	script       *projectBuildScriptSpec
 	dockerBuilds []DockerBuildSpec
+	dockerPushes []DockerPushSpec
 }
 
 type DockerPushExecutionSpec struct {
@@ -124,6 +125,21 @@ func ResolveBuildExecution(store DockerStore, findProjectRoot ProjectFinderFunc,
 		return BuildExecutionSpec{script: script}, nil
 	}
 
+	shouldPush, err := shouldPushResolvedBuilds(findProjectRoot, resolveBuildContext, target)
+	if err != nil {
+		return BuildExecutionSpec{}, err
+	}
+	if shouldPush {
+		execution, err := ResolveDockerPushExecution(store, findProjectRoot, resolveBuildContext, now, target)
+		if err != nil {
+			return BuildExecutionSpec{}, err
+		}
+		return BuildExecutionSpec{
+			dockerBuilds: execution.builds,
+			dockerPushes: execution.pushes,
+		}, nil
+	}
+
 	builds, err := ResolveCurrentDockerBuildSpecs(store, findProjectRoot, resolveBuildContext, now, target)
 	if err != nil {
 		return BuildExecutionSpec{}, err
@@ -143,6 +159,30 @@ func DockerPushExecutionSpecFromSpecs(builds []DockerBuildSpec, pushes []DockerP
 func HasProjectBuildScript(findProjectRoot ProjectFinderFunc, target DockerCommandTarget) (bool, error) {
 	script, err := resolveProjectBuildScript(findProjectRoot, target)
 	return script != nil, err
+}
+
+func shouldPushResolvedBuilds(findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, target DockerCommandTarget) (bool, error) {
+	if resolveBuildContext == nil {
+		resolveBuildContext = ResolveDockerBuildContext
+	}
+
+	buildContext, err := resolveBuildContext()
+	if err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(buildContext.DockerfilePath) != "" {
+		return false, nil
+	}
+
+	if _, err := ResolveDockerBuildContextsAtDir(buildContext.Dir); err == nil {
+		return true, nil
+	}
+
+	_, ok, err := resolveCurrentDevopsDockerDir(findProjectRoot, buildContext.Dir, target)
+	if err != nil {
+		return false, err
+	}
+	return ok, nil
 }
 
 func ResolveDockerPushExecution(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, target DockerCommandTarget) (DockerPushExecutionSpec, error) {
@@ -177,22 +217,32 @@ func ResolveDockerPushExecution(store DockerStore, findProjectRoot ProjectFinder
 }
 
 func ResolveDockerPushSpec(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, target DockerCommandTarget) (DockerPushSpec, *DockerBuildSpec, error) {
-	execution, err := ResolveDockerPushExecution(store, findProjectRoot, resolveBuildContext, now, target)
+	store, findProjectRoot, resolveBuildContext, now = normalizeDockerDependencies(store, findProjectRoot, resolveBuildContext, now)
+
+	buildContext, err := resolveBuildContext()
 	if err != nil {
 		return DockerPushSpec{}, nil, err
 	}
-	if len(execution.pushes) != 1 {
-		return DockerPushSpec{}, nil, fmt.Errorf("expected exactly one Docker push spec, got %d", len(execution.pushes))
+	if strings.TrimSpace(buildContext.DockerfilePath) == "" {
+		return DockerPushSpec{}, nil, fmt.Errorf("dockerfile not found in current directory")
 	}
-	if len(execution.builds) > 1 {
-		return DockerPushSpec{}, nil, fmt.Errorf("expected at most one Docker build spec, got %d", len(execution.builds))
+
+	imageRef, err := ResolveDockerImageReference(store, findProjectRoot, resolveBuildContext, now, buildContext.Dir, target)
+	if err != nil {
+		return DockerPushSpec{}, nil, err
 	}
 
 	var build *DockerBuildSpec
-	if len(execution.builds) == 1 {
-		build = &execution.builds[0]
+	if imageRef.IsLocalBuild {
+		resolvedBuild, err := resolveDockerBuildSpec(store, findProjectRoot, resolveBuildContext, now, buildContext, target)
+		if err != nil {
+			return DockerPushSpec{}, nil, err
+		}
+		build = &resolvedBuild
+		imageRef = resolvedBuild.Image
 	}
-	return execution.pushes[0], build, nil
+
+	return NewDockerPushSpec(buildContext.Dir, imageRef), build, nil
 }
 
 func ResolveDockerImageReference(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, buildDir string, target DockerCommandTarget) (DockerImageReference, error) {
@@ -681,9 +731,15 @@ func RunDockerBuilds(ctx Context, builds []DockerBuildSpec, build DockerImageBui
 	return nil
 }
 
-func RunBuildExecution(ctx Context, execution BuildExecutionSpec, runScript BuildScriptRunnerFunc, build DockerImageBuilderFunc) error {
+func RunBuildExecution(ctx Context, execution BuildExecutionSpec, runScript BuildScriptRunnerFunc, build DockerImageBuilderFunc, push DockerPushFunc) error {
 	if execution.script != nil {
 		return runBuildScript(ctx, *execution.script, runScript)
+	}
+	if len(execution.dockerPushes) > 0 {
+		return RunDockerPushExecution(ctx, DockerPushExecutionSpec{
+			builds: execution.dockerBuilds,
+			pushes: execution.dockerPushes,
+		}, build, push)
 	}
 	return RunDockerBuilds(ctx, execution.dockerBuilds, build)
 }

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -135,7 +135,7 @@ func TestResolveBuildExecutionPrefersProjectBuildScript(t *testing.T) {
 	}, func(string, string, string, io.Writer, io.Writer) error {
 		t.Fatal("unexpected docker build")
 		return nil
-	}); err != nil {
+	}, nil); err != nil {
 		t.Fatalf("RunBuildExecution failed: %v", err)
 	}
 	if !called {
@@ -187,7 +187,7 @@ func TestResolveBuildExecutionPrefersProjectRootBuildScriptOverNestedScripts(t *
 	}, func(string, string, string, io.Writer, io.Writer) error {
 		t.Fatal("unexpected docker build")
 		return nil
-	}); err != nil {
+	}, nil); err != nil {
 		t.Fatalf("RunBuildExecution failed: %v", err)
 	}
 	if !called {
@@ -243,7 +243,7 @@ func TestResolveBuildExecutionUsesFirstNestedProjectBuildScript(t *testing.T) {
 	}, func(string, string, string, io.Writer, io.Writer) error {
 		t.Fatal("unexpected docker build")
 		return nil
-	}); err != nil {
+	}, nil); err != nil {
 		t.Fatalf("RunBuildExecution failed: %v", err)
 	}
 	if !called {
@@ -325,5 +325,114 @@ func TestResolveCurrentDockerBuildContextsUsesDevopsModuleRoot(t *testing.T) {
 	}
 	if len(buildContexts) != 1 || buildContexts[0].Dir != componentDir {
 		t.Fatalf("unexpected build contexts: %+v", buildContexts)
+	}
+}
+
+func TestResolveBuildExecutionIncludesPushesForProjectRootDevopsScope(t *testing.T) {
+	projectRoot := t.TempDir()
+	moduleRoot := filepath.Join(projectRoot, "tenant-a-devops")
+	componentDirs := []string{
+		filepath.Join(moduleRoot, "docker", "tenant-a-devops"),
+		filepath.Join(moduleRoot, "docker", "erun-dind"),
+	}
+	for _, dir := range componentDirs {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir component dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+			t.Fatalf("write Dockerfile: %v", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(componentDirs[0], "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write VERSION: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(componentDirs[1], "VERSION"), []byte("28.1.1\n"), 0o644); err != nil {
+		t.Fatalf("write VERSION: %v", err)
+	}
+	if err := SaveProjectConfig(projectRoot, ProjectConfig{
+		Environments: map[string]ProjectEnvironmentConfig{
+			DefaultEnvironment: {ContainerRegistry: "erunpaas"},
+		},
+	}); err != nil {
+		t.Fatalf("save project config: %v", err)
+	}
+
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		func() (DockerBuildContext, error) {
+			return DockerBuildContext{Dir: projectRoot}, nil
+		},
+		nil,
+		DockerCommandTarget{Environment: DefaultEnvironment},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+
+	if len(execution.dockerBuilds) != 2 || len(execution.dockerPushes) != 2 {
+		t.Fatalf("unexpected execution: %+v", execution)
+	}
+	buildTags := []string{execution.dockerBuilds[0].Image.Tag, execution.dockerBuilds[1].Image.Tag}
+	wantTags := []string{"erunpaas/tenant-a-devops:1.0.0", "erunpaas/erun-dind:28.1.1"}
+	for _, want := range wantTags {
+		found := false
+		for _, got := range buildTags {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing build tag %q in %+v", want, execution.dockerBuilds)
+		}
+	}
+	pushTags := []string{execution.dockerPushes[0].Image.Tag, execution.dockerPushes[1].Image.Tag}
+	for _, want := range wantTags {
+		found := false
+		for _, got := range pushTags {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing push tag %q in %+v", want, execution.dockerPushes)
+		}
+	}
+}
+
+func TestResolveDockerPushSpecRejectsNonDockerfileScopes(t *testing.T) {
+	projectRoot := t.TempDir()
+	moduleRoot := filepath.Join(projectRoot, "tenant-a-devops")
+	dockerDir := filepath.Join(moduleRoot, "docker")
+	componentDir := filepath.Join(dockerDir, "tenant-a-devops")
+	if err := os.MkdirAll(componentDir, 0o755); err != nil {
+		t.Fatalf("mkdir component dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+
+	for _, scope := range []string{projectRoot, moduleRoot, dockerDir} {
+		_, _, err := ResolveDockerPushSpec(
+			ConfigStore{},
+			func() (string, string, error) {
+				return "tenant-a", projectRoot, nil
+			},
+			func() (DockerBuildContext, error) {
+				return DockerBuildContext{Dir: scope}, nil
+			},
+			nil,
+			DockerCommandTarget{Environment: DefaultEnvironment},
+		)
+		if err == nil {
+			t.Fatalf("expected error for scope %q", scope)
+		}
+		if err.Error() != "dockerfile not found in current directory" {
+			t.Fatalf("unexpected error for scope %q: %v", scope, err)
+		}
 	}
 }

--- a/erun-mcp/build.go
+++ b/erun-mcp/build.go
@@ -28,7 +28,7 @@ func buildTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest
 			if err != nil {
 				return err
 			}
-			return eruncommon.RunBuildExecution(runCtx, execution, runtime.BuildScriptRunner, runtime.BuildDockerImage)
+			return eruncommon.RunBuildExecution(runCtx, execution, runtime.BuildScriptRunner, runtime.BuildDockerImage, runtimePushFunc(runtime))
 		})
 		return nil, output, err
 	}
@@ -98,7 +98,15 @@ func resolveRuntimePushExecution(runtime RuntimeConfig, projectRoot, component s
 	}
 
 	if component == "" {
-		return eruncommon.ResolveDockerPushExecution(runtime.Store, findProjectRoot, resolveBuildContext, nil, target)
+		pushInput, buildInput, err := eruncommon.ResolveDockerPushSpec(runtime.Store, findProjectRoot, resolveBuildContext, nil, target)
+		if err != nil {
+			return eruncommon.DockerPushExecutionSpec{}, err
+		}
+		builds := make([]eruncommon.DockerBuildSpec, 0, 1)
+		if buildInput != nil {
+			builds = append(builds, *buildInput)
+		}
+		return eruncommon.DockerPushExecutionSpecFromSpecs(builds, []eruncommon.DockerPushSpec{pushInput}), nil
 	}
 
 	buildContext, ok, err := eruncommon.FindComponentDockerBuildContext(projectRoot, component)

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -295,6 +295,82 @@ func TestBuildToolPreviewVerboseIncludesTrace(t *testing.T) {
 	}
 }
 
+func TestBuildToolPreviewAtRepoRootIncludesBuildAndPushTrace(t *testing.T) {
+	projectRoot := t.TempDir()
+	moduleRoot := filepath.Join(projectRoot, "tenant-a-devops")
+	componentDirs := []string{
+		filepath.Join(moduleRoot, "docker", "tenant-a-devops"),
+		filepath.Join(moduleRoot, "docker", "erun-dind"),
+	}
+	for _, dir := range componentDirs {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir component dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+			t.Fatalf("write Dockerfile: %v", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(componentDirs[0], "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write VERSION: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(componentDirs[1], "VERSION"), []byte("28.1.1\n"), 0o644); err != nil {
+		t.Fatalf("write VERSION: %v", err)
+	}
+	if err := eruncommon.SaveProjectConfig(projectRoot, eruncommon.ProjectConfig{
+		Environments: map[string]eruncommon.ProjectEnvironmentConfig{
+			eruncommon.DefaultEnvironment: {ContainerRegistry: "erunpaas"},
+		},
+	}); err != nil {
+		t.Fatalf("save project config: %v", err)
+	}
+
+	handler := buildTool(normalizeRuntimeConfig(RuntimeConfig{
+		Context: RuntimeContext{
+			Tenant:      "tenant-a",
+			Environment: eruncommon.DefaultEnvironment,
+			RepoPath:    projectRoot,
+		},
+	}))
+
+	_, output, err := handler(context.Background(), nil, BuildInput{
+		Preview:   true,
+		Verbosity: 1,
+	})
+	if err != nil {
+		t.Fatalf("buildTool failed: %v", err)
+	}
+	if len(output.Trace) != 4 {
+		t.Fatalf("unexpected trace output: %+v", output.Trace)
+	}
+}
+
+func TestPushToolRejectsRepoRootWithoutComponent(t *testing.T) {
+	projectRoot := t.TempDir()
+	moduleRoot := filepath.Join(projectRoot, "tenant-a-devops")
+	componentDir := filepath.Join(moduleRoot, "docker", "tenant-a-devops")
+	if err := os.MkdirAll(componentDir, 0o755); err != nil {
+		t.Fatalf("mkdir component dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+
+	handler := pushTool(normalizeRuntimeConfig(RuntimeConfig{
+		Context: RuntimeContext{
+			Environment: eruncommon.DefaultEnvironment,
+			RepoPath:    projectRoot,
+		},
+	}))
+
+	_, _, err := handler(context.Background(), nil, PushInput{})
+	if err == nil {
+		t.Fatal("expected missing Dockerfile error")
+	}
+	if err.Error() != "dockerfile not found in current directory" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestBuildToolRunsProjectBuildScriptWhenPresent(t *testing.T) {
 	projectRoot := t.TempDir()
 	scriptDir := filepath.Join(projectRoot, "scripts", "build")


### PR DESCRIPTION
## Summary
- make build build and push all devops images when run from the project root, the devops module root, or the devops docker directory
- restrict push to concrete Dockerfile directories and keep it as a single-image build+push flow there
- align CLI and MCP behavior and help text with the new command split

## Why
The previous command behavior exposed push in broad devops scopes and made build omit the push phase users expected from those scopes.

## Validation
- go test ./... (erun-common)
- go test ./... (erun-cli)
- go test ./... (erun-mcp)

Closes #30
