### PR TITLE
Adjust release sync and push flow

### DIFF
--- a/erun-cli/cmd/release_test.go
+++ b/erun-cli/cmd/release_test.go
@@ -46,6 +46,8 @@ func TestReleaseCommandDryRun(t *testing.T) {
 		"docker image: erunpaas/api:1.4.2-rc.",
 		"git commit -m '[skip ci] release 1.4.2-rc.",
 		"git tag -a",
+		"stage: push",
+		"git push --follow-tags origin develop",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected dry-run output to contain %q, got:\n%s", want, output)
@@ -58,6 +60,50 @@ func TestReleaseCommandDryRun(t *testing.T) {
 	}
 	if got := string(versionData); got != "1.4.2\n" {
 		t.Fatalf("unexpected VERSION content after dry-run: %q", got)
+	}
+}
+
+func TestReleaseCommandDryRunStableIncludesSyncAndPush(t *testing.T) {
+	projectRoot := createReleaseGitRepo(t, "main")
+	if err := common.SaveProjectConfig(projectRoot, common.ProjectConfig{}); err != nil {
+		t.Fatalf("SaveProjectConfig failed: %v", err)
+	}
+
+	cmd := newTestRootCmd(testRootDeps{
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		RunGit: func(string, io.Writer, io.Writer, ...string) error {
+			t.Fatal("unexpected git execution during dry-run")
+			return nil
+		},
+	})
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"release", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if got := strings.TrimSpace(stdout.String()); got != "1.4.2" {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+	output := stderr.String()
+	for _, want := range []string{
+		"release: branch=main mode=stable version=1.4.2",
+		"next version: 1.4.3",
+		"stage: sync-develop",
+		"git checkout develop",
+		"git merge --no-edit -X theirs main",
+		"stage: push",
+		"git push --follow-tags origin main develop",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected dry-run output to contain %q, got:\n%s", want, output)
+		}
 	}
 }
 

--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -154,6 +154,20 @@ func resolveReleaseSpec(findProjectRoot ProjectFinderFunc, loadProjectConfig Pro
 				stages = append(stages, bumpStage)
 			}
 		}
+		syncStage := newSyncDevelopStage(projectRoot, releaseConfig)
+		if len(syncStage.FileUpdates) > 0 || len(syncStage.GitCommands) > 0 {
+			stages = append(stages, syncStage)
+		}
+		pushStage := newPushReleaseStage(projectRoot, releaseConfig)
+		if len(pushStage.FileUpdates) > 0 || len(pushStage.GitCommands) > 0 {
+			stages = append(stages, pushStage)
+		}
+	}
+	if mode == ReleaseModeCandidate {
+		pushStage := newPushCandidateReleaseStage(projectRoot, releaseConfig)
+		if len(pushStage.FileUpdates) > 0 || len(pushStage.GitCommands) > 0 {
+			stages = append(stages, pushStage)
+		}
 	}
 
 	return ReleaseSpec{
@@ -431,6 +445,52 @@ func newBumpStage(projectRoot, nextVersion string, fileUpdate ReleaseFileUpdate)
 		GitCommands: []ReleaseCommandSpec{
 			releaseGitCommand(projectRoot, "add", releaseGitPath(projectRoot, fileUpdate.Path)),
 			releaseGitCommand(projectRoot, "commit", "-m", "[skip ci] prepare "+nextVersion),
+		},
+	}
+}
+
+func newSyncDevelopStage(projectRoot string, config ReleaseConfig) ReleaseStage {
+	mainBranch := strings.TrimSpace(config.MainBranch)
+	developBranch := strings.TrimSpace(config.DevelopBranch)
+	if mainBranch == "" || developBranch == "" {
+		return ReleaseStage{}
+	}
+
+	return ReleaseStage{
+		Name: "sync-develop",
+		GitCommands: []ReleaseCommandSpec{
+			releaseGitCommand(projectRoot, "checkout", developBranch),
+			releaseGitCommand(projectRoot, "merge", "--no-edit", "-X", "theirs", mainBranch),
+			releaseGitCommand(projectRoot, "checkout", mainBranch),
+		},
+	}
+}
+
+func newPushReleaseStage(projectRoot string, config ReleaseConfig) ReleaseStage {
+	mainBranch := strings.TrimSpace(config.MainBranch)
+	developBranch := strings.TrimSpace(config.DevelopBranch)
+	if mainBranch == "" || developBranch == "" {
+		return ReleaseStage{}
+	}
+
+	return ReleaseStage{
+		Name: "push",
+		GitCommands: []ReleaseCommandSpec{
+			releaseGitCommand(projectRoot, "push", "--follow-tags", "origin", mainBranch, developBranch),
+		},
+	}
+}
+
+func newPushCandidateReleaseStage(projectRoot string, config ReleaseConfig) ReleaseStage {
+	developBranch := strings.TrimSpace(config.DevelopBranch)
+	if developBranch == "" {
+		return ReleaseStage{}
+	}
+
+	return ReleaseStage{
+		Name: "push",
+		GitCommands: []ReleaseCommandSpec{
+			releaseGitCommand(projectRoot, "push", "--follow-tags", "origin", developBranch),
 		},
 	}
 }

--- a/erun-common/release_test.go
+++ b/erun-common/release_test.go
@@ -35,8 +35,8 @@ func TestResolveReleaseSpecStableRelease(t *testing.T) {
 	if len(spec.DockerImages) != 1 || spec.DockerImages[0].Tag != "erunpaas/api:1.4.2" {
 		t.Fatalf("unexpected docker images: %+v", spec.DockerImages)
 	}
-	if len(spec.Stages) != 2 {
-		t.Fatalf("expected 2 stages, got %+v", spec.Stages)
+	if len(spec.Stages) != 4 {
+		t.Fatalf("expected 4 stages, got %+v", spec.Stages)
 	}
 	if got := spec.Stages[0].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"add", filepath.Join("erun-devops", "k8s", "api", "Chart.yaml")}) {
 		t.Fatalf("unexpected release add command: %+v", got)
@@ -49,6 +49,18 @@ func TestResolveReleaseSpecStableRelease(t *testing.T) {
 	}
 	if got := spec.Stages[1].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"add", filepath.Join("erun-devops", "VERSION")}) {
 		t.Fatalf("unexpected bump add command: %+v", got)
+	}
+	if got := spec.Stages[2].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"checkout", "develop"}) {
+		t.Fatalf("unexpected sync checkout command: %+v", got)
+	}
+	if got := spec.Stages[2].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"merge", "--no-edit", "-X", "theirs", "main"}) {
+		t.Fatalf("unexpected sync merge command: %+v", got)
+	}
+	if got := spec.Stages[2].GitCommands[2].Args; !reflect.DeepEqual(got, []string{"checkout", "main"}) {
+		t.Fatalf("unexpected sync return command: %+v", got)
+	}
+	if got := spec.Stages[3].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "main", "develop"}) {
+		t.Fatalf("unexpected push command: %+v", got)
 	}
 }
 
@@ -76,8 +88,14 @@ func TestResolveReleaseSpecUsesConfiguredBranches(t *testing.T) {
 	if spec.Mode != ReleaseModeCandidate || spec.Version != "1.4.2-rc.abc1234" || spec.NextVersion != "" {
 		t.Fatalf("unexpected release spec: %+v", spec)
 	}
+	if len(spec.Stages) != 2 {
+		t.Fatalf("expected 2 stages, got %+v", spec.Stages)
+	}
 	if got := spec.Stages[0].GitCommands[2].Args; !reflect.DeepEqual(got, []string{"tag", "-a", "v1.4.2-rc.abc1234", "-m", "Release candidate 1.4.2-rc.abc1234"}) {
 		t.Fatalf("unexpected candidate tag command: %+v", got)
+	}
+	if got := spec.Stages[1].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "integration"}) {
+		t.Fatalf("unexpected candidate push command: %+v", got)
 	}
 }
 
@@ -130,9 +148,86 @@ func TestRunReleaseSpecWritesFilesAndRunsGitStages(t *testing.T) {
 		{projectRoot, "tag", "-a", "v1.4.2", "-m", "Release 1.4.2"},
 		{projectRoot, "add", filepath.Join("erun-devops", "VERSION")},
 		{projectRoot, "commit", "-m", "[skip ci] prepare 1.4.3"},
+		{projectRoot, "checkout", "develop"},
+		{projectRoot, "merge", "--no-edit", "-X", "theirs", "main"},
+		{projectRoot, "checkout", "main"},
+		{projectRoot, "push", "--follow-tags", "origin", "main", "develop"},
 	}
 	if !reflect.DeepEqual(gitCalls, wantCalls) {
 		t.Fatalf("unexpected git calls: got %+v want %+v", gitCalls, wantCalls)
+	}
+}
+
+func TestRunReleaseSpecCandidateRunsTagAndPush(t *testing.T) {
+	projectRoot := setupReleaseProject(t, releaseProjectOptions{})
+
+	spec, err := resolveReleaseSpec(
+		func() (string, string, error) { return "tenant-a", projectRoot, nil },
+		LoadProjectConfig,
+		func(string) (string, error) { return "develop", nil },
+		func(string) (string, error) { return "abc1234", nil },
+		ReleaseParams{},
+	)
+	if err != nil {
+		t.Fatalf("resolveReleaseSpec failed: %v", err)
+	}
+
+	var gitCalls [][]string
+	ctx := Context{
+		Logger: NewLoggerWithWriters(2, new(bytes.Buffer), new(bytes.Buffer)),
+		Stdout: new(bytes.Buffer),
+		Stderr: new(bytes.Buffer),
+	}
+	if err := RunReleaseSpec(ctx, spec, func(dir string, stdout, stderr io.Writer, args ...string) error {
+		gitCalls = append(gitCalls, append([]string{dir}, args...))
+		return nil
+	}); err != nil {
+		t.Fatalf("RunReleaseSpec failed: %v", err)
+	}
+
+	wantCalls := [][]string{
+		{projectRoot, "add", filepath.Join("erun-devops", "k8s", "api", "Chart.yaml")},
+		{projectRoot, "commit", "-m", "[skip ci] release 1.4.2-rc.abc1234"},
+		{projectRoot, "tag", "-a", "v1.4.2-rc.abc1234", "-m", "Release candidate 1.4.2-rc.abc1234"},
+		{projectRoot, "push", "--follow-tags", "origin", "develop"},
+	}
+	if !reflect.DeepEqual(gitCalls, wantCalls) {
+		t.Fatalf("unexpected git calls: got %+v want %+v", gitCalls, wantCalls)
+	}
+}
+
+func TestResolveReleaseSpecStableReleaseUsesConfiguredDevelopBranchForSyncAndPush(t *testing.T) {
+	projectRoot := setupReleaseProject(t, releaseProjectOptions{
+		ProjectConfig: ProjectConfig{
+			Release: ReleaseConfig{
+				MainBranch:    "trunk",
+				DevelopBranch: "integration",
+			},
+		},
+	})
+
+	spec, err := resolveReleaseSpec(
+		func() (string, string, error) { return "tenant-a", projectRoot, nil },
+		LoadProjectConfig,
+		func(string) (string, error) { return "trunk", nil },
+		func(string) (string, error) { return "abc1234", nil },
+		ReleaseParams{},
+	)
+	if err != nil {
+		t.Fatalf("resolveReleaseSpec failed: %v", err)
+	}
+
+	if got := spec.Stages[2].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"checkout", "integration"}) {
+		t.Fatalf("unexpected configured sync checkout command: %+v", got)
+	}
+	if got := spec.Stages[2].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"merge", "--no-edit", "-X", "theirs", "trunk"}) {
+		t.Fatalf("unexpected configured sync merge command: %+v", got)
+	}
+	if got := spec.Stages[2].GitCommands[2].Args; !reflect.DeepEqual(got, []string{"checkout", "trunk"}) {
+		t.Fatalf("unexpected configured sync return command: %+v", got)
+	}
+	if got := spec.Stages[3].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "trunk", "integration"}) {
+		t.Fatalf("unexpected configured push command: %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- sync stable releases from `main` into `develop` before the final push
- resolve sync conflicts in favor of `main` and push both branches with tags at the end
- push candidate releases from `develop` after tagging and extend release tests

## Why
The release flow stopped before branch synchronization and publishing, which left the configured release branches out of sync and required manual follow-up after running `erun release`.

## Validation
- `cd /Users/rihardsfreimanis/git/sophium/erun/erun-common && go test ./...`
- `cd /Users/rihardsfreimanis/git/sophium/erun/erun-cli && go test ./...`
- `cd /Users/rihardsfreimanis/git/sophium/erun/erun-mcp && go test ./...`

Closes #35