### PR TITLE
Fix build and open runtime regressions

### DIFF
--- a/erun-cli/cmd/build_test.go
+++ b/erun-cli/cmd/build_test.go
@@ -543,7 +543,7 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDockerDire
 		t.Fatalf("Execute failed: %v", err)
 	}
 
-	if len(built) != 3 || len(pushed) != 3 {
+	if len(built) != 3 || len(pushed) != 0 {
 		t.Fatalf("unexpected build/push counts: builds=%d pushes=%d", len(built), len(pushed))
 	}
 
@@ -566,7 +566,6 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDockerDire
 			t.Fatalf("unexpected output writers: %+v", req)
 		}
 	}
-	assertTagSet(t, []string{pushed[0].Tag, pushed[1].Tag, pushed[2].Tag}, wantTags)
 }
 
 func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsProjectRoot(t *testing.T) {
@@ -598,7 +597,7 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsProjectRoo
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
-	if len(built) != len(wantTags) || len(pushed) != len(wantTags) {
+	if len(built) != len(wantTags) || len(pushed) != 0 {
 		t.Fatalf("unexpected build/push counts: builds=%d pushes=%d", len(built), len(pushed))
 	}
 	gotTags := make([]string, 0, len(built))
@@ -609,11 +608,6 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsProjectRoo
 		gotTags = append(gotTags, req.Tag)
 	}
 	assertTagSet(t, gotTags, wantTags)
-	gotPushTags := make([]string, 0, len(pushed))
-	for _, req := range pushed {
-		gotPushTags = append(gotPushTags, req.Tag)
-	}
-	assertTagSet(t, gotPushTags, wantTags)
 }
 
 func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDevopsModuleRoot(t *testing.T) {
@@ -645,7 +639,7 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDevopsModu
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
-	if len(built) != len(wantTags) || len(pushed) != len(wantTags) {
+	if len(built) != len(wantTags) || len(pushed) != 0 {
 		t.Fatalf("unexpected build/push counts: builds=%d pushes=%d", len(built), len(pushed))
 	}
 	gotTags := make([]string, 0, len(built))
@@ -656,11 +650,6 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDevopsModu
 		gotTags = append(gotTags, req.Tag)
 	}
 	assertTagSet(t, gotTags, wantTags)
-	gotPushTags := make([]string, 0, len(pushed))
-	for _, req := range pushed {
-		gotPushTags = append(gotPushTags, req.Tag)
-	}
-	assertTagSet(t, gotPushTags, wantTags)
 }
 
 func TestRootBuildShorthandUsesExactVersionFromCurrentBuildDirectoryForLocalEnvironment(t *testing.T) {
@@ -787,7 +776,7 @@ func TestRootBuildShorthandDryRunPrintsCommandWithoutExecuting(t *testing.T) {
 	}
 }
 
-func TestRootBuildShorthandDryRunPrintsBuildAndPushCommandsForProjectRoot(t *testing.T) {
+func TestRootBuildShorthandDryRunPrintsBuildCommandsForProjectRoot(t *testing.T) {
 	projectRoot, _, _, _, wantTags := setupMultiDockerProject(t, "tenant-a")
 
 	stderr := new(bytes.Buffer)
@@ -822,8 +811,8 @@ func TestRootBuildShorthandDryRunPrintsBuildAndPushCommandsForProjectRoot(t *tes
 		if !strings.Contains(output, "docker build -t "+tag) {
 			t.Fatalf("expected dry-run build trace for %q, got %q", tag, output)
 		}
-		if !strings.Contains(output, "docker push "+tag) {
-			t.Fatalf("expected dry-run push trace for %q, got %q", tag, output)
+		if strings.Contains(output, "docker push "+tag) {
+			t.Fatalf("did not expect dry-run push trace for %q, got %q", tag, output)
 		}
 	}
 }
@@ -1994,6 +1983,52 @@ func TestBuildCommandVersionOverrideDoesNotReplaceComponentLocalVersions(t *test
 	}
 	if strings.Contains(output, "erun-ubuntu:1.0.0-pr.abc1234") {
 		t.Fatalf("did not expect ubuntu tag override:\n%s", output)
+	}
+}
+
+func TestRootBuildCommandVersionOverrideBuildsWithoutPushing(t *testing.T) {
+	projectRoot, _, _, componentDirs, wantTags := setupMultiDockerProject(t, "tenant-a")
+	if err := os.Remove(filepath.Join(componentDirs[0], "VERSION")); err != nil {
+		t.Fatalf("remove runtime VERSION: %v", err)
+	}
+
+	var built []dockerBuildCall
+	cmd := newTestRootCmd(testRootDeps{
+		OptionalBuildFindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
+			return common.DockerBuildContext{Dir: projectRoot}, nil
+		},
+		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
+			built = append(built, req)
+			return nil
+		}),
+		PushDockerImage: pushCallFunc(func(req dockerPushCall) error {
+			t.Fatalf("unexpected push request: %+v", req)
+			return nil
+		}),
+	})
+	cmd.SetArgs([]string{"build", "--version", "1.0.7"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	gotTags := make([]string, 0, len(built))
+	for _, req := range built {
+		gotTags = append(gotTags, req.Tag)
+	}
+	assertTagSet(t, gotTags, []string{
+		"erunpaas/tenant-a-devops:1.0.7",
+		"erunpaas/erun-dind:28.1.1",
+		"erunpaas/erun-ubuntu:noble-20260217",
+	})
+	if len(gotTags) != len(wantTags) {
+		t.Fatalf("unexpected build count: got %d want %d", len(gotTags), len(wantTags))
 	}
 }
 

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -94,22 +94,28 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 	}
 
 	shellReq := common.ShellLaunchParamsFromResult(result)
-	if checkKubernetesDeployment != nil && deployHelmChart != nil {
-		deployed, err := checkKubernetesDeployment(common.KubernetesDeploymentCheckParams{
-			Name:              common.RuntimeReleaseName(result.Tenant),
-			Namespace:         namespace,
-			KubernetesContext: result.EnvConfig.KubernetesContext,
-			ExpectedRepoPath:  common.RemoteShellWorktreePath(shellReq),
-		})
+	if resolveRuntimeDeploySpec != nil && deployHelmChart != nil {
+		execution, err := resolveRuntimeDeploySpec(result)
 		if err != nil {
 			return err
 		}
-		if !deployed {
-			ctx.Logger.Debug("deploying the devops runtime before opening the shell")
-			execution, err := resolveRuntimeDeploySpec(result)
+
+		shouldDeploy := len(execution.Builds) > 0
+		if !shouldDeploy && checkKubernetesDeployment != nil {
+			deployed, err := checkKubernetesDeployment(common.KubernetesDeploymentCheckParams{
+				Name:              common.RuntimeReleaseName(result.Tenant),
+				Namespace:         namespace,
+				KubernetesContext: result.EnvConfig.KubernetesContext,
+				ExpectedRepoPath:  common.RemoteShellWorktreePath(shellReq),
+			})
 			if err != nil {
 				return err
 			}
+			shouldDeploy = !deployed
+		}
+
+		if shouldDeploy {
+			ctx.Logger.Debug("deploying the devops runtime before opening the shell")
 			if err := common.RunDeploySpec(
 				ctx,
 				execution,

--- a/erun-cli/cmd/open_test.go
+++ b/erun-cli/cmd/open_test.go
@@ -184,6 +184,77 @@ func TestOpenCommandDryRunPrintsDeployPlanWhenDevopsRuntimeIsMissing(t *testing.
 	}
 }
 
+func TestOpenCommandDryRunRedeploysWhenRuntimeHasLocalBuilds(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+
+	projectRoot := t.TempDir()
+	componentName := "tenant-a-devops"
+	componentRoot := filepath.Join(projectRoot, componentName)
+	chartPath := filepath.Join(componentRoot, "k8s", componentName)
+	if err := os.MkdirAll(chartPath, 0o755); err != nil {
+		t.Fatalf("mkdir chart dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: "+componentName+"\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write Chart.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644); err != nil {
+		t.Fatalf("write values.local.yaml: %v", err)
+	}
+	workdir := filepath.Join(componentRoot, "docker", componentName)
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("mkdir docker dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(componentRoot, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write module VERSION: %v", err)
+	}
+	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
+		t.Fatalf("save project config: %v", err)
+	}
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd := newTestRootCmd(testRootDeps{
+		Store: openCommandStore{
+			repoPath:   projectRoot,
+			toolConfig: common.ERunConfig{DefaultTenant: "tenant-a"},
+		},
+		CheckKubernetesDeployment: func(req common.KubernetesDeploymentCheckParams) (bool, error) {
+			t.Fatalf("did not expect deployment check when local runtime builds exist: %+v", req)
+			return true, nil
+		},
+		DeployHelmChart: func(req common.HelmDeployParams) error {
+			t.Fatalf("did not expect runtime deployment execution during dry-run: %+v", req)
+			return nil
+		},
+		LaunchShell: func(req common.ShellLaunchParams) error {
+			t.Fatalf("did not expect remote shell launch during dry-run: %+v", req)
+			return nil
+		},
+	})
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"-v", "open", "tenant-a", "local", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	output := stderr.String()
+	for _, want := range []string{
+		"docker build -t erunpaas/tenant-a-devops:1.0.0",
+		"docker push erunpaas/tenant-a-devops:1.0.0",
+		"helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace tenant-a-local --kube-context cluster-dev -f " + filepath.Join(chartPath, "values.local.yaml") + " --set-string tenant=tenant-a --set-string environment=local",
+		"kubectl --context cluster-dev --namespace tenant-a-local wait --for=condition=Available --timeout 2m0s deployment/tenant-a-devops",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected dry-run output to contain %q, got %q", want, output)
+		}
+	}
+}
+
 func TestOpenCommandDryRunFallsBackToDefaultRuntimeChartWhenTenantRepoHasNoDevopsChart(t *testing.T) {
 	repoPath := t.TempDir()
 	stdout := new(bytes.Buffer)

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -126,21 +126,6 @@ func ResolveBuildExecution(store DockerStore, findProjectRoot ProjectFinderFunc,
 		return BuildExecutionSpec{script: script}, nil
 	}
 
-	shouldPush, err := shouldPushResolvedBuilds(findProjectRoot, resolveBuildContext, target)
-	if err != nil {
-		return BuildExecutionSpec{}, err
-	}
-	if shouldPush {
-		execution, err := ResolveDockerPushExecution(store, findProjectRoot, resolveBuildContext, now, target)
-		if err != nil {
-			return BuildExecutionSpec{}, err
-		}
-		return BuildExecutionSpec{
-			dockerBuilds: execution.builds,
-			dockerPushes: execution.pushes,
-		}, nil
-	}
-
 	builds, err := ResolveCurrentDockerBuildSpecs(store, findProjectRoot, resolveBuildContext, now, target)
 	if err != nil {
 		return BuildExecutionSpec{}, err
@@ -160,30 +145,6 @@ func DockerPushExecutionSpecFromSpecs(builds []DockerBuildSpec, pushes []DockerP
 func HasProjectBuildScript(findProjectRoot ProjectFinderFunc, target DockerCommandTarget) (bool, error) {
 	script, err := resolveProjectBuildScript(findProjectRoot, target)
 	return script != nil, err
-}
-
-func shouldPushResolvedBuilds(findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, target DockerCommandTarget) (bool, error) {
-	if resolveBuildContext == nil {
-		resolveBuildContext = ResolveDockerBuildContext
-	}
-
-	buildContext, err := resolveBuildContext()
-	if err != nil {
-		return false, err
-	}
-	if strings.TrimSpace(buildContext.DockerfilePath) != "" {
-		return false, nil
-	}
-
-	if _, err := ResolveDockerBuildContextsAtDir(buildContext.Dir); err == nil {
-		return true, nil
-	}
-
-	_, ok, err := resolveCurrentDevopsDockerDir(findProjectRoot, buildContext.Dir, target)
-	if err != nil {
-		return false, err
-	}
-	return ok, nil
 }
 
 func ResolveDockerPushExecution(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, target DockerCommandTarget) (DockerPushExecutionSpec, error) {

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -328,7 +328,7 @@ func TestResolveCurrentDockerBuildContextsUsesDevopsModuleRoot(t *testing.T) {
 	}
 }
 
-func TestResolveBuildExecutionIncludesPushesForProjectRootDevopsScope(t *testing.T) {
+func TestResolveBuildExecutionBuildsWithoutPushesForProjectRootDevopsScope(t *testing.T) {
 	projectRoot := t.TempDir()
 	moduleRoot := filepath.Join(projectRoot, "tenant-a-devops")
 	componentDirs := []string{
@@ -372,7 +372,7 @@ func TestResolveBuildExecutionIncludesPushesForProjectRootDevopsScope(t *testing
 		t.Fatalf("ResolveBuildExecution failed: %v", err)
 	}
 
-	if len(execution.dockerBuilds) != 2 || len(execution.dockerPushes) != 2 {
+	if len(execution.dockerBuilds) != 2 || len(execution.dockerPushes) != 0 {
 		t.Fatalf("unexpected execution: %+v", execution)
 	}
 	buildTags := []string{execution.dockerBuilds[0].Image.Tag, execution.dockerBuilds[1].Image.Tag}
@@ -387,19 +387,6 @@ func TestResolveBuildExecutionIncludesPushesForProjectRootDevopsScope(t *testing
 		}
 		if !found {
 			t.Fatalf("missing build tag %q in %+v", want, execution.dockerBuilds)
-		}
-	}
-	pushTags := []string{execution.dockerPushes[0].Image.Tag, execution.dockerPushes[1].Image.Tag}
-	for _, want := range wantTags {
-		found := false
-		for _, got := range pushTags {
-			if got == want {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Fatalf("missing push tag %q in %+v", want, execution.dockerPushes)
 		}
 	}
 }

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -373,7 +373,7 @@ func TestBuildToolPreviewVerboseIncludesTrace(t *testing.T) {
 	}
 }
 
-func TestBuildToolPreviewAtRepoRootIncludesBuildAndPushTrace(t *testing.T) {
+func TestBuildToolPreviewAtRepoRootIncludesBuildTrace(t *testing.T) {
 	projectRoot := t.TempDir()
 	moduleRoot := filepath.Join(projectRoot, "tenant-a-devops")
 	componentDirs := []string{
@@ -417,7 +417,7 @@ func TestBuildToolPreviewAtRepoRootIncludesBuildAndPushTrace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildTool failed: %v", err)
 	}
-	if len(output.Trace) != 4 {
+	if len(output.Trace) != 2 {
 		t.Fatalf("unexpected trace output: %+v", output.Trace)
 	}
 }


### PR DESCRIPTION
Closes #37

## What changed
- made `erun build` stay build-only at project and devops root scopes instead of implicitly pushing images
- made `erun open` redeploy the runtime when the resolved runtime plan includes local Docker builds so stale pods are not reused
- updated CLI, shared, and MCP preview tests to match the corrected behavior

## Why
- `build --version` from root could fail by trying to push a tag that had only been planned, not built
- `open` could skip redeploy and exec into an existing runtime even when the local runtime build plan had changed

## Validation
- go test ./... in erun-common
- go test ./... in erun-cli
- go test ./... in erun-mcp
