### PR TITLE
Fix release stdout for command substitution

### DIFF
--- a/erun-cli/cmd/release.go
+++ b/erun-cli/cmd/release.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 
 	common "github.com/sophium/erun/erun-common"
 	"github.com/spf13/cobra"
@@ -23,7 +24,12 @@ func newReleaseCmd(findProjectRoot common.ProjectFinderFunc, runGit common.GitCo
 			if _, err := fmt.Fprintln(ctx.Stdout, spec.Version); err != nil {
 				return err
 			}
-			return common.RunReleaseSpec(ctx, spec, runGit)
+			return common.RunReleaseSpec(ctx, spec, func(dir string, stdout, stderr io.Writer, args ...string) error {
+				if runGit == nil {
+					runGit = common.GitCommandRunner
+				}
+				return runGit(dir, ctx.Stderr, stderr, args...)
+			})
 		},
 	}
 	addDryRunFlag(cmd)

--- a/erun-cli/cmd/release_test.go
+++ b/erun-cli/cmd/release_test.go
@@ -107,6 +107,44 @@ func TestReleaseCommandDryRunStableIncludesSyncAndPush(t *testing.T) {
 	}
 }
 
+func TestReleaseCommandWritesOnlyVersionToStdoutDuringExecution(t *testing.T) {
+	projectRoot := createReleaseGitRepo(t, "develop")
+	if err := common.SaveProjectConfig(projectRoot, common.ProjectConfig{}); err != nil {
+		t.Fatalf("SaveProjectConfig failed: %v", err)
+	}
+
+	cmd := newTestRootCmd(testRootDeps{
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		RunGit: func(_ string, stdout, stderr io.Writer, _ ...string) error {
+			if _, err := io.WriteString(stdout, "git-stdout\n"); err != nil {
+				return err
+			}
+			if _, err := io.WriteString(stderr, "git-stderr\n"); err != nil {
+				return err
+			}
+			return nil
+		},
+	})
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"release"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if got := strings.TrimSpace(stdout.String()); !strings.HasPrefix(got, "1.4.2-rc.") || strings.Contains(got, "git-stdout") {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "git-stdout") || !strings.Contains(got, "git-stderr") {
+		t.Fatalf("expected git command output on stderr, got %q", got)
+	}
+}
+
 func createReleaseGitRepo(t *testing.T, branch string) string {
 	t.Helper()
 

--- a/erun-devops/k8s/erun-devops/Chart.yaml
+++ b/erun-devops/k8s/erun-devops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.9
+appVersion: 1.0.10-pr.b73a60c
 description: ERun DevOps
 name: erun-devops
 type: application
-version: 1.0.9
+version: 1.0.10-pr.b73a60c


### PR DESCRIPTION
Closes #39

## What changed
- kept `erun release` stdout machine-safe for command substitution by routing Git command stdout to stderr
- added CLI regression coverage to ensure `release` writes only the resolved version to stdout during execution

## Why
`VERSION="$(erun release)"` was capturing commit and push output in addition to the version line, which then broke `erun build --version "$VERSION"` with an invalid Docker tag.

## Validation
- go test ./... in erun-cli
