### PR TITLE
Add --release support to build

### DIFF
--- a/erun-cli/cmd/build.go
+++ b/erun-cli/cmd/build.go
@@ -35,7 +35,7 @@ func newBuildCmd(store common.DockerStore, findProjectRoot common.ProjectFinderF
 		},
 	}
 	addDryRunFlag(cmd)
-	addDockerCommandTargetFlags(cmd, &target)
+	addBuildCommandTargetFlags(cmd, &target)
 	return cmd
 }
 
@@ -57,7 +57,7 @@ func newPushCmd(store common.DockerStore, findProjectRoot common.ProjectFinderFu
 		},
 	}
 	addDryRunFlag(cmd)
-	addDockerCommandTargetFlags(cmd, &target)
+	addPushCommandTargetFlags(cmd, &target)
 	return cmd
 }
 
@@ -92,7 +92,12 @@ func runDockerPushWithRetry(ctx common.Context, pushInput common.DockerPushSpec,
 	return push(ctx, pushInput)
 }
 
-func addDockerCommandTargetFlags(cmd *cobra.Command, target *common.DockerCommandTarget) {
+func addBuildCommandTargetFlags(cmd *cobra.Command, target *common.DockerCommandTarget) {
+	addPushCommandTargetFlags(cmd, target)
+	cmd.Flags().BoolVar(&target.Release, "release", false, "Run release first and build with the released version")
+}
+
+func addPushCommandTargetFlags(cmd *cobra.Command, target *common.DockerCommandTarget) {
 	cmd.Flags().StringVar(&target.ProjectRoot, "project-root", "", "Project root override for internal tooling")
 	cmd.Flags().StringVar(&target.Environment, "environment", "", "Environment override for internal tooling")
 	cmd.Flags().StringVar(&target.VersionOverride, "version", "", "Override the resolved image version")

--- a/erun-cli/cmd/build_test.go
+++ b/erun-cli/cmd/build_test.go
@@ -39,6 +39,7 @@ type dockerLoginCall struct {
 type buildScriptCall struct {
 	Dir    string
 	Path   string
+	Env    []string
 	Stdin  io.Reader
 	Stdout io.Writer
 	Stderr io.Writer
@@ -57,10 +58,11 @@ func buildCallFunc(run func(dockerBuildCall) error) common.DockerImageBuilderFun
 }
 
 func buildScriptCallFunc(run func(buildScriptCall) error) common.BuildScriptRunnerFunc {
-	return func(dir, path string, stdin io.Reader, stdout, stderr io.Writer) error {
+	return func(dir, path string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return run(buildScriptCall{
 			Dir:    dir,
 			Path:   path,
+			Env:    append([]string{}, env...),
 			Stdin:  stdin,
 			Stdout: stdout,
 			Stderr: stderr,
@@ -2086,6 +2088,58 @@ func TestBuildCommandHiddenEnvironmentOverrideUsesProvidedEnvironment(t *testing
 
 	if built.Tag != "prod-registry/erun-devops:1.0.0" {
 		t.Fatalf("unexpected build request: %+v", built)
+	}
+}
+
+func TestBuildCommandRejectsReleaseWithVersion(t *testing.T) {
+	cmd := newTestRootCmd(testRootDeps{})
+	cmd.SetArgs([]string{"devops", "container", "build", "--release", "--version", "1.0.7"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if err.Error() != "release build cannot be combined with explicit version override" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildCommandDryRunReleaseShowsReleaseAndBuildVersionTrace(t *testing.T) {
+	projectRoot := createReleaseGitRepo(t, "develop")
+	if err := os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write build.sh: %v", err)
+	}
+
+	cmd := newTestRootCmd(testRootDeps{
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		OptionalBuildFindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
+			return common.DockerBuildContext{Dir: projectRoot}, nil
+		},
+	})
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"build", "--dry-run", "--release"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	output := stderr.String()
+	if !strings.Contains(output, "release: branch=develop mode=candidate version=1.4.2-rc.") {
+		t.Fatalf("expected release trace, got:\n%s", output)
+	}
+	if !strings.Contains(output, "ERUN_BUILD_VERSION=1.4.2-rc.") || !strings.Contains(output, "./build.sh") {
+		t.Fatalf("expected build trace with release version env, got:\n%s", output)
+	}
+	if !strings.Contains(output, "release version: 1.4.2-rc.") {
+		t.Fatalf("expected final release version output, got:\n%s", output)
 	}
 }
 

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -29,7 +29,7 @@ type (
 	DockerImageBuilderFunc   func(string, string, string, io.Writer, io.Writer) error
 	DockerImagePusherFunc    func(string, io.Writer, io.Writer) error
 	DockerRegistryLoginFunc  func(string, io.Reader, io.Writer, io.Writer) error
-	BuildScriptRunnerFunc    func(string, string, io.Reader, io.Writer, io.Writer) error
+	BuildScriptRunnerFunc    func(string, string, []string, io.Reader, io.Writer, io.Writer) error
 	DockerPushFunc           func(Context, DockerPushSpec) error
 )
 
@@ -69,9 +69,11 @@ type DockerPushSpec struct {
 type projectBuildScriptSpec struct {
 	Dir  string
 	Path string
+	Env  []string
 }
 
 type BuildExecutionSpec struct {
+	release      *ReleaseSpec
 	script       *projectBuildScriptSpec
 	dockerBuilds []DockerBuildSpec
 	dockerPushes []DockerPushSpec
@@ -86,6 +88,7 @@ type DockerCommandTarget struct {
 	ProjectRoot     string
 	Environment     string
 	VersionOverride string
+	Release         bool
 }
 
 type DockerRegistryAuthError struct {
@@ -118,12 +121,18 @@ func ResolveCurrentDockerBuildSpecs(store DockerStore, findProjectRoot ProjectFi
 func ResolveBuildExecution(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, target DockerCommandTarget) (BuildExecutionSpec, error) {
 	store, findProjectRoot, resolveBuildContext, now = normalizeDockerDependencies(store, findProjectRoot, resolveBuildContext, now)
 
+	target, releaseSpec, err := ResolveDockerBuildTarget(findProjectRoot, target)
+	if err != nil {
+		return BuildExecutionSpec{}, err
+	}
+
 	script, err := resolveProjectBuildScript(findProjectRoot, target)
 	if err != nil {
 		return BuildExecutionSpec{}, err
 	}
 	if script != nil {
-		return BuildExecutionSpec{script: script}, nil
+		script.Env = buildScriptEnv(target.VersionOverride)
+		return BuildExecutionSpec{release: releaseSpec, script: script}, nil
 	}
 
 	builds, err := ResolveCurrentDockerBuildSpecs(store, findProjectRoot, resolveBuildContext, now, target)
@@ -131,11 +140,35 @@ func ResolveBuildExecution(store DockerStore, findProjectRoot ProjectFinderFunc,
 		return BuildExecutionSpec{}, err
 	}
 
-	return BuildExecutionSpec{dockerBuilds: builds}, nil
+	return BuildExecutionSpec{release: releaseSpec, dockerBuilds: builds}, nil
 }
 
 func BuildExecutionSpecFromDockerBuilds(builds []DockerBuildSpec) BuildExecutionSpec {
 	return BuildExecutionSpec{dockerBuilds: builds}
+}
+
+func BuildExecutionSpecWithRelease(execution BuildExecutionSpec, release ReleaseSpec) BuildExecutionSpec {
+	execution.release = &release
+	return execution
+}
+
+func ResolveDockerBuildTarget(findProjectRoot ProjectFinderFunc, target DockerCommandTarget) (DockerCommandTarget, *ReleaseSpec, error) {
+	target.VersionOverride = strings.TrimSpace(target.VersionOverride)
+	if !target.Release {
+		return target, nil, nil
+	}
+	if target.VersionOverride != "" {
+		return DockerCommandTarget{}, nil, fmt.Errorf("release build cannot be combined with explicit version override")
+	}
+
+	releaseSpec, err := ResolveReleaseSpec(findProjectRoot, ReleaseParams{ProjectRoot: target.ProjectRoot})
+	if err != nil {
+		return DockerCommandTarget{}, nil, err
+	}
+
+	target.Release = false
+	target.VersionOverride = releaseSpec.Version
+	return target, &releaseSpec, nil
 }
 
 func DockerPushExecutionSpecFromSpecs(builds []DockerBuildSpec, pushes []DockerPushSpec) DockerPushExecutionSpec {
@@ -209,6 +242,11 @@ func ResolveDockerPushSpec(store DockerStore, findProjectRoot ProjectFinderFunc,
 
 func ResolveDockerImageReference(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, buildDir string, target DockerCommandTarget) (DockerImageReference, error) {
 	store, findProjectRoot, _, now = normalizeDockerDependencies(store, findProjectRoot, resolveBuildContext, now)
+
+	target, _, err := ResolveDockerBuildTarget(findProjectRoot, target)
+	if err != nil {
+		return DockerImageReference{}, err
+	}
 
 	projectRoot, err := resolveDockerBuildProjectRoot(findProjectRoot, target)
 	if err != nil {
@@ -702,16 +740,30 @@ func RunDockerBuilds(ctx Context, builds []DockerBuildSpec, build DockerImageBui
 }
 
 func RunBuildExecution(ctx Context, execution BuildExecutionSpec, runScript BuildScriptRunnerFunc, build DockerImageBuilderFunc, push DockerPushFunc) error {
-	if execution.script != nil {
-		return runBuildScript(ctx, *execution.script, runScript)
+	if execution.release != nil {
+		if err := RunReleaseSpec(ctx, *execution.release, nil); err != nil {
+			return err
+		}
 	}
-	if len(execution.dockerPushes) > 0 {
-		return RunDockerPushExecution(ctx, DockerPushExecutionSpec{
+
+	var err error
+	if execution.script != nil {
+		err = runBuildScript(ctx, *execution.script, runScript)
+	} else if len(execution.dockerPushes) > 0 {
+		err = RunDockerPushExecution(ctx, DockerPushExecutionSpec{
 			builds: execution.dockerBuilds,
 			pushes: execution.dockerPushes,
 		}, build, push)
+	} else {
+		err = RunDockerBuilds(ctx, execution.dockerBuilds, build)
 	}
-	return RunDockerBuilds(ctx, execution.dockerBuilds, build)
+	if err != nil {
+		return err
+	}
+	if execution.release != nil {
+		ctx.Info("release version: " + execution.release.Version)
+	}
+	return nil
 }
 
 func RunDockerPush(ctx Context, pushInput DockerPushSpec, push DockerImagePusherFunc) error {
@@ -871,9 +923,10 @@ func DockerImageBuilder(dir, dockerfilePath, tag string, stdout, stderr io.Write
 	return cmd.Run()
 }
 
-func BuildScriptRunner(dir, scriptPath string, stdin io.Reader, stdout, stderr io.Writer) error {
+func BuildScriptRunner(dir, scriptPath string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	cmd := exec.Command(scriptPath)
 	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), env...)
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
@@ -920,15 +973,30 @@ func runBuildScript(ctx Context, script projectBuildScriptSpec, run BuildScriptR
 	if run == nil {
 		run = BuildScriptRunner
 	}
-	command := commandSpec{
-		Dir:  script.Dir,
-		Name: script.Path,
-	}
-	ctx.TraceCommand(command.Dir, command.Name, command.Args...)
+	name, args := buildScriptTraceCommand(script)
+	ctx.TraceCommand(script.Dir, name, args...)
 	if ctx.DryRun {
 		return nil
 	}
-	return run(script.Dir, script.Path, ctx.Stdin, ctx.Stdout, ctx.Stderr)
+	return run(script.Dir, script.Path, script.Env, ctx.Stdin, ctx.Stdout, ctx.Stderr)
+}
+
+func buildScriptEnv(version string) []string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return nil
+	}
+	return []string{"ERUN_BUILD_VERSION=" + version}
+}
+
+func buildScriptTraceCommand(script projectBuildScriptSpec) (string, []string) {
+	if len(script.Env) == 0 {
+		return script.Path, nil
+	}
+
+	args := append([]string{}, script.Env...)
+	args = append(args, script.Path)
+	return args[0], args[1:]
 }
 
 func resolveDockerBuildRegistryForEnvironment(projectRoot, environment string) (string, error) {

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -126,10 +127,13 @@ func TestResolveBuildExecutionPrefersProjectBuildScript(t *testing.T) {
 		Stdout: new(bytes.Buffer),
 		Stderr: new(bytes.Buffer),
 	}
-	if err := RunBuildExecution(ctx, execution, func(dir, path string, stdin io.Reader, stdout, stderr io.Writer) error {
+	if err := RunBuildExecution(ctx, execution, func(dir, path string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		called = true
 		if dir != projectRoot || path != "./build.sh" {
 			t.Fatalf("unexpected script call: dir=%q path=%q", dir, path)
+		}
+		if len(env) != 0 {
+			t.Fatalf("unexpected script env: %+v", env)
 		}
 		return nil
 	}, func(string, string, string, io.Writer, io.Writer) error {
@@ -178,10 +182,13 @@ func TestResolveBuildExecutionPrefersProjectRootBuildScriptOverNestedScripts(t *
 		Stdout: new(bytes.Buffer),
 		Stderr: new(bytes.Buffer),
 	}
-	if err := RunBuildExecution(ctx, execution, func(dir, path string, stdin io.Reader, stdout, stderr io.Writer) error {
+	if err := RunBuildExecution(ctx, execution, func(dir, path string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		called = true
 		if dir != projectRoot || path != "./build.sh" {
 			t.Fatalf("unexpected script call: dir=%q path=%q", dir, path)
+		}
+		if len(env) != 0 {
+			t.Fatalf("unexpected script env: %+v", env)
 		}
 		return nil
 	}, func(string, string, string, io.Writer, io.Writer) error {
@@ -234,10 +241,13 @@ func TestResolveBuildExecutionUsesFirstNestedProjectBuildScript(t *testing.T) {
 		Stdout: new(bytes.Buffer),
 		Stderr: new(bytes.Buffer),
 	}
-	if err := RunBuildExecution(ctx, execution, func(dir, path string, stdin io.Reader, stdout, stderr io.Writer) error {
+	if err := RunBuildExecution(ctx, execution, func(dir, path string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		called = true
 		if dir != firstDir || path != "./build.sh" {
 			t.Fatalf("unexpected script call: dir=%q path=%q", dir, path)
+		}
+		if len(env) != 0 {
+			t.Fatalf("unexpected script env: %+v", env)
 		}
 		return nil
 	}, func(string, string, string, io.Writer, io.Writer) error {
@@ -422,4 +432,126 @@ func TestResolveDockerPushSpecRejectsNonDockerfileScopes(t *testing.T) {
 			t.Fatalf("unexpected error for scope %q: %v", scope, err)
 		}
 	}
+}
+
+func TestResolveBuildExecutionReleaseUsesResolvedVersionForDockerBuilds(t *testing.T) {
+	projectRoot := setupReleaseProjectGitRepo(t, "main")
+	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "api")
+
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		func() (DockerBuildContext, error) {
+			return DockerBuildContextAtDir(buildDir)
+		},
+		nil,
+		DockerCommandTarget{ProjectRoot: projectRoot, Environment: DefaultEnvironment, Release: true},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+
+	if execution.release == nil {
+		t.Fatalf("expected release spec, got %+v", execution)
+	}
+	if got := execution.release.Version; got != "1.4.2" {
+		t.Fatalf("unexpected release version: %q", got)
+	}
+	if len(execution.dockerBuilds) != 1 {
+		t.Fatalf("unexpected docker builds: %+v", execution.dockerBuilds)
+	}
+	if got := execution.dockerBuilds[0].Image.Tag; got != "erunpaas/api:1.4.2" {
+		t.Fatalf("unexpected docker build tag: %q", got)
+	}
+	if got := execution.release.NextVersion; got != "1.4.3" {
+		t.Fatalf("unexpected next version: %q", got)
+	}
+}
+
+func TestResolveBuildExecutionReleasePassesVersionToProjectBuildScript(t *testing.T) {
+	projectRoot := setupReleaseProjectGitRepo(t, "develop")
+	if err := os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write build.sh: %v", err)
+	}
+
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		func() (DockerBuildContext, error) {
+			return DockerBuildContext{}, errors.New("docker build context should not be resolved")
+		},
+		nil,
+		DockerCommandTarget{ProjectRoot: projectRoot, Environment: DefaultEnvironment, Release: true},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+
+	if execution.release == nil || execution.script == nil {
+		t.Fatalf("unexpected execution: %+v", execution)
+	}
+	if got := execution.script.Env; len(got) != 1 || !strings.HasPrefix(got[0], "ERUN_BUILD_VERSION=1.4.2-rc.") {
+		t.Fatalf("unexpected script env: %+v", got)
+	}
+}
+
+func TestRunBuildExecutionDryRunReleaseIncludesReleaseAndBuildTrace(t *testing.T) {
+	projectRoot := setupReleaseProjectGitRepo(t, "develop")
+	if err := os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write build.sh: %v", err)
+	}
+
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		func() (DockerBuildContext, error) {
+			return DockerBuildContext{}, errors.New("docker build context should not be resolved")
+		},
+		nil,
+		DockerCommandTarget{ProjectRoot: projectRoot, Environment: DefaultEnvironment, Release: true},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+
+	stdout := new(bytes.Buffer)
+	ctx := Context{
+		Logger: NewLoggerWithWriters(2, stdout, io.Discard),
+		DryRun: true,
+		Stdin:  new(bytes.Buffer),
+		Stdout: stdout,
+		Stderr: io.Discard,
+	}
+	if err := RunBuildExecution(ctx, execution, nil, nil, nil); err != nil {
+		t.Fatalf("RunBuildExecution failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "release: branch=develop mode=candidate version=1.4.2-rc.") {
+		t.Fatalf("expected release trace, got:\n%s", output)
+	}
+	if !strings.Contains(output, "ERUN_BUILD_VERSION=1.4.2-rc.") || !strings.Contains(output, "./build.sh") {
+		t.Fatalf("expected build script trace with version env, got:\n%s", output)
+	}
+	if !strings.Contains(output, "release version: 1.4.2-rc.") {
+		t.Fatalf("expected final release version output, got:\n%s", output)
+	}
+}
+
+func setupReleaseProjectGitRepo(t *testing.T, branch string) string {
+	t.Helper()
+
+	projectRoot := setupReleaseProject(t, releaseProjectOptions{})
+	runGitWithEnv(t, projectRoot, nil, "init", "-b", branch)
+	runGitWithEnv(t, projectRoot, nil, "config", "user.email", "codex@example.com")
+	runGitWithEnv(t, projectRoot, nil, "config", "user.name", "Codex")
+	runGitWithEnv(t, projectRoot, nil, "add", ".")
+	runGitWithEnv(t, projectRoot, nil, "commit", "-m", "initial")
+	return projectRoot
 }

--- a/erun-common/context.go
+++ b/erun-common/context.go
@@ -18,6 +18,10 @@ func (c Context) Trace(message string) {
 	c.Logger.Trace(message)
 }
 
+func (c Context) Info(message string) {
+	c.Logger.Info(message)
+}
+
 func (c Context) TraceCommand(dir, name string, args ...string) {
 	c.Logger.Trace(formatShellCommand(dir, name, args...))
 }

--- a/erun-mcp/build.go
+++ b/erun-mcp/build.go
@@ -12,6 +12,7 @@ import (
 type BuildInput struct {
 	Component string `json:"component,omitempty" jsonschema:"optional component name to build from the runtime repo root; when empty, build all Docker component images"`
 	Version   string `json:"version,omitempty" jsonschema:"optional explicit image version override; disables local snapshot tagging when set"`
+	Release   bool   `json:"release,omitempty" jsonschema:"when true, run release first and build with the resolved release version"`
 	Preview   bool   `json:"preview,omitempty" jsonschema:"when true, resolve and print the planned actions without executing them"`
 	Verbosity int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
 }
@@ -26,7 +27,7 @@ type PushInput struct {
 func buildTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, BuildInput) (*mcp.CallToolResult, CommandOutput, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input BuildInput) (*mcp.CallToolResult, CommandOutput, error) {
 		output, err := runRuntimeCommand(runtime.Context, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, workDir string) error {
-			execution, err := resolveRuntimeBuildExecution(runtime, workDir, strings.TrimSpace(input.Component), strings.TrimSpace(input.Version))
+			execution, err := resolveRuntimeBuildExecution(runtime, workDir, strings.TrimSpace(input.Component), strings.TrimSpace(input.Version), input.Release)
 			if err != nil {
 				return err
 			}
@@ -49,12 +50,13 @@ func pushTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest,
 	}
 }
 
-func resolveRuntimeBuildExecution(runtime RuntimeConfig, projectRoot, component, versionOverride string) (eruncommon.BuildExecutionSpec, error) {
+func resolveRuntimeBuildExecution(runtime RuntimeConfig, projectRoot, component, versionOverride string, release bool) (eruncommon.BuildExecutionSpec, error) {
 	environment := strings.TrimSpace(runtime.Context.Environment)
 	target := eruncommon.DockerCommandTarget{
 		ProjectRoot:     projectRoot,
 		Environment:     environment,
 		VersionOverride: versionOverride,
+		Release:         release,
 	}
 	findProjectRoot := func() (string, string, error) {
 		return runtimeFindProjectRoot(runtime.Context, projectRoot)
@@ -64,6 +66,11 @@ func resolveRuntimeBuildExecution(runtime RuntimeConfig, projectRoot, component,
 	}
 
 	if component != "" {
+		target, releaseSpec, err := eruncommon.ResolveDockerBuildTarget(findProjectRoot, target)
+		if err != nil {
+			return eruncommon.BuildExecutionSpec{}, err
+		}
+
 		buildContext, ok, err := eruncommon.FindComponentDockerBuildContext(projectRoot, component)
 		if err != nil {
 			return eruncommon.BuildExecutionSpec{}, err
@@ -71,19 +78,19 @@ func resolveRuntimeBuildExecution(runtime RuntimeConfig, projectRoot, component,
 		if !ok {
 			return eruncommon.BuildExecutionSpec{}, fmt.Errorf("docker build context not found for component %q", component)
 		}
-		imageRef, err := eruncommon.ResolveDockerImageReference(runtime.Store, findProjectRoot, resolveBuildContext, nil, buildContext.Dir, eruncommon.DockerCommandTarget{
-			ProjectRoot:     projectRoot,
-			Environment:     environment,
-			VersionOverride: versionOverride,
-		})
+		imageRef, err := eruncommon.ResolveDockerImageReference(runtime.Store, findProjectRoot, resolveBuildContext, nil, buildContext.Dir, target)
 		if err != nil {
 			return eruncommon.BuildExecutionSpec{}, err
 		}
-		return eruncommon.BuildExecutionSpecFromDockerBuilds([]eruncommon.DockerBuildSpec{{
+		execution := eruncommon.BuildExecutionSpecFromDockerBuilds([]eruncommon.DockerBuildSpec{{
 			ContextDir:     eruncommon.ResolveDockerBuildContextDirForProject(buildContext.Dir, projectRoot),
 			DockerfilePath: buildContext.DockerfilePath,
 			Image:          imageRef,
-		}}), nil
+		}})
+		if releaseSpec != nil {
+			return eruncommon.BuildExecutionSpecWithRelease(execution, *releaseSpec), nil
+		}
+		return execution, nil
 	}
 
 	return eruncommon.ResolveBuildExecution(runtime.Store, findProjectRoot, resolveBuildContext, nil, target)

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -373,6 +374,52 @@ func TestBuildToolPreviewVerboseIncludesTrace(t *testing.T) {
 	}
 }
 
+func TestBuildToolPreviewReleaseIncludesReleaseAndBuildTrace(t *testing.T) {
+	projectRoot := createReleaseRuntimeRepo(t, "develop")
+	if err := eruncommon.SaveProjectConfig(projectRoot, eruncommon.ProjectConfig{}); err != nil {
+		t.Fatalf("SaveProjectConfig failed: %v", err)
+	}
+
+	handler := buildTool(normalizeRuntimeConfig(RuntimeConfig{
+		Context: RuntimeContext{
+			Environment: eruncommon.DefaultEnvironment,
+			RepoPath:    projectRoot,
+		},
+	}))
+
+	_, output, err := handler(context.Background(), nil, BuildInput{
+		Component: "api",
+		Release:   true,
+		Preview:   true,
+		Verbosity: 1,
+	})
+	if err != nil {
+		t.Fatalf("buildTool failed: %v", err)
+	}
+	if len(output.Trace) < 2 {
+		t.Fatalf("expected release and build trace, got %+v", output.Trace)
+	}
+	if !strings.Contains(output.Trace[0], "release: branch=develop mode=candidate version=1.4.2-rc.") {
+		t.Fatalf("unexpected release trace: %+v", output.Trace)
+	}
+	foundBuildTrace := false
+	foundVersionReport := false
+	for _, trace := range output.Trace {
+		if strings.Contains(trace, "docker build -t erunpaas/api:1.4.2-rc.") {
+			foundBuildTrace = true
+		}
+		if strings.Contains(trace, "release version: 1.4.2-rc.") {
+			foundVersionReport = true
+		}
+	}
+	if !foundBuildTrace {
+		t.Fatalf("unexpected build trace: %+v", output.Trace)
+	}
+	if !foundVersionReport {
+		t.Fatalf("expected final release version output, got %+v", output.Trace)
+	}
+}
+
 func TestBuildToolPreviewAtRepoRootIncludesBuildTrace(t *testing.T) {
 	projectRoot := t.TempDir()
 	moduleRoot := filepath.Join(projectRoot, "tenant-a-devops")
@@ -465,10 +512,13 @@ func TestBuildToolRunsProjectBuildScriptWhenPresent(t *testing.T) {
 			Environment: "dev",
 			RepoPath:    projectRoot,
 		},
-		BuildScriptRunner: func(dir, path string, stdin io.Reader, stdout, stderr io.Writer) error {
+		BuildScriptRunner: func(dir, path string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 			called = true
 			if dir != scriptDir || path != "./build.sh" {
 				t.Fatalf("unexpected build script call: dir=%q path=%q", dir, path)
+			}
+			if len(env) != 0 {
+				t.Fatalf("unexpected build script env: %+v", env)
 			}
 			return nil
 		},


### PR DESCRIPTION
## Summary
- add a `--release` build mode that runs release first and freezes the resolved release version for the subsequent build
- pass the resolved release version into script-backed builds and report it at the end of the build flow
- extend CLI and MCP tests to cover release-backed build execution and version reporting

## Validation
- go test ./...  (erun-common)
- go test ./...  (erun-cli)
- go test ./...  (erun-mcp)

Closes #41
