### PR TITLE
Add Homebrew formula for erun

### DIFF
--- a/Formula/erun.rb
+++ b/Formula/erun.rb
@@ -1,0 +1,34 @@
+class Erun < Formula
+  desc "Multi-tenant multi-environment deployment and management tool"
+  homepage "https://github.com/sophium/erun"
+  url "https://github.com/sophium/erun/archive/refs/tags/v1.0.12.tar.gz"
+  sha256 "cc872af960c0234589bcfd2fe11505f576ab47ab637d51fde9859c34720de150"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    cd "erun-cli" do
+      system "go", "build",
+             *std_go_args(
+               output:  bin/"erun",
+               ldflags: "-s -w -X github.com/sophium/erun/cmd.buildVersion=#{version}",
+             ),
+             "."
+    end
+
+    cd "erun-mcp" do
+      system "go", "build",
+             *std_go_args(
+               output:  bin/"emcp",
+               ldflags: "-s -w -X github.com/sophium/erun/erun-mcp.buildVersion=#{version}",
+             ),
+             "./cmd/emcp"
+    end
+  end
+
+  test do
+    assert_match "Tenants:", shell_output("#{bin}/erun list")
+    assert_match "Usage of emcp:", shell_output("#{bin}/emcp --help 2>&1")
+  end
+end


### PR DESCRIPTION
## Summary
- add a Homebrew formula in this repository for `erun`
- build and install both `erun` and `emcp`
- validate the tap-based Homebrew install flow

## Validation
- `brew style Formula/erun.rb`
- `brew audit --strict sophium/erun/erun`
- `brew install sophium/erun/erun`
- `brew test sophium/erun/erun`

Closes #44
