### PR TITLE
Report deployed version after release build deploy

### DIFF
--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -802,6 +802,9 @@ func runBuildExecution(ctx Context, execution BuildExecutionSpec, deploySpecs []
 	if execution.release != nil {
 		ctx.Info("release version: " + execution.release.Version)
 	}
+	if version := deployedVersionForSpecs(deploySpecs); version != "" {
+		ctx.Info("deployed version: " + version)
+	}
 	return nil
 }
 
@@ -832,6 +835,24 @@ func filterDockerBuildsForPushedTags(builds []DockerBuildSpec, pushedTags map[st
 		filtered = append(filtered, build)
 	}
 	return filtered
+}
+
+func deployedVersionForSpecs(specs []DeploySpec) string {
+	version := ""
+	for _, spec := range specs {
+		current := strings.TrimSpace(spec.Deploy.Version)
+		if current == "" {
+			return ""
+		}
+		if version == "" {
+			version = current
+			continue
+		}
+		if current != version {
+			return ""
+		}
+	}
+	return version
 }
 
 func RunDockerPush(ctx Context, pushInput DockerPushSpec, push DockerImagePusherFunc) error {

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -544,6 +544,93 @@ func TestRunBuildExecutionDryRunReleaseIncludesReleaseAndBuildTrace(t *testing.T
 	}
 }
 
+func TestRunBuildExecutionAndDeployDryRunReleaseReportsDeployedVersionLast(t *testing.T) {
+	projectRoot := setupReleaseProjectGitRepo(t, "develop")
+	chartPath := filepath.Join(projectRoot, "erun-devops", "k8s", "api")
+	if err := os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644); err != nil {
+		t.Fatalf("write values.local.yaml: %v", err)
+	}
+	if err := SaveTenantConfig(TenantConfig{
+		Name:               "tenant-a",
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: DefaultEnvironment,
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := SaveEnvConfig("tenant-a", EnvConfig{
+		Name:              DefaultEnvironment,
+		RepoPath:          projectRoot,
+		KubernetesContext: "cluster-local",
+	}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+	if err := SaveProjectConfig(projectRoot, ProjectConfig{}); err != nil {
+		t.Fatalf("save project config: %v", err)
+	}
+
+	findProjectRoot := func() (string, string, error) {
+		return "tenant-a", projectRoot, nil
+	}
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		findProjectRoot,
+		func() (DockerBuildContext, error) {
+			return DockerBuildContextAtDir(filepath.Join(projectRoot, "erun-devops", "docker", "api"))
+		},
+		nil,
+		DockerCommandTarget{ProjectRoot: projectRoot, Environment: DefaultEnvironment, Release: true},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+	deploySpec, err := ResolveDeploySpecForDockerTarget(
+		ConfigStore{},
+		findProjectRoot,
+		func() (DockerBuildContext, error) {
+			return DockerBuildContextAtDir(filepath.Join(projectRoot, "erun-devops", "docker", "api"))
+		},
+		func() (KubernetesDeployContext, error) {
+			return KubernetesDeployContextAtDir(filepath.Join(projectRoot, "erun-devops", "docker", "api")), nil
+		},
+		nil,
+		DockerCommandTarget{ProjectRoot: projectRoot, Environment: DefaultEnvironment, Release: true},
+		"api",
+	)
+	if err != nil {
+		t.Fatalf("ResolveDeploySpecForDockerTarget failed: %v", err)
+	}
+	if deploySpec.Deploy.Version != "1.4.2-rc.0000000" && !strings.HasPrefix(deploySpec.Deploy.Version, "1.4.2-rc.") {
+		t.Fatalf("unexpected deploy version: %+v", deploySpec.Deploy)
+	}
+
+	stdout := new(bytes.Buffer)
+	ctx := Context{
+		Logger: NewLoggerWithWriters(2, stdout, io.Discard),
+		DryRun: true,
+		Stdin:  new(bytes.Buffer),
+		Stdout: stdout,
+		Stderr: io.Discard,
+	}
+	if err := RunBuildExecutionAndDeploy(ctx, execution, []DeploySpec{deploySpec}, nil, nil, nil, func(HelmDeployParams) error {
+		t.Fatal("unexpected deploy execution during dry-run")
+		return nil
+	}); err != nil {
+		t.Fatalf("RunBuildExecutionAndDeploy failed: %v", err)
+	}
+
+	output := strings.TrimSpace(stdout.String())
+	if !strings.Contains(output, "release version: 1.4.2-rc.") {
+		t.Fatalf("expected release version output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "deployed version: 1.4.2-rc.") {
+		t.Fatalf("expected deployed version output, got:\n%s", output)
+	}
+	lines := strings.Split(output, "\n")
+	if !strings.Contains(lines[len(lines)-1], "deployed version: 1.4.2-rc.") {
+		t.Fatalf("expected deployed version last, got:\n%s", output)
+	}
+}
+
 func setupReleaseProjectGitRepo(t *testing.T, branch string) string {
 	t.Helper()
 


### PR DESCRIPTION
## What changed
- report the deployed version at the end of build-and-deploy runs when the deploy specs resolve to a single concrete version
- add regression coverage for the release build-and-deploy path so the deployed version is printed last

## Why
`erun build --release --deploy` already resolved one release version for both build and deploy, but the final output only reported the release version. This makes the successful deploy result less explicit than it should be.

## Impact
Users now get a final `deployed version:` line for the release build-and-deploy flow, matching the version that was built and deployed.

## Validation
- `go test ./...` in `erun-common`
- `go test ./...` in `erun-cli`
- `go test ./...` in `erun-mcp`

Closes #46
