### PR TITLE
Fix release flow and no-shell alias guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ Repository guidance for humans and coding agents working in this repo.
 - When the PR is intended to close the issue, include `Closes #<issue-number>` in the PR body.
 - A pushed branch or an open PR does not close the issue by itself. The issue closes after the PR is merged or if it is closed manually.
 - If the user asks for `push, accept`, treat that as completing the full publish flow rather than stopping after the branch push.
-- If the user asks to `close`, treat that as the full publish flow: push the branch, open the PR, merge it with squash unless they asked otherwise, close the PR via merge, and close the linked issue.
+- If the user asks to `close`, always treat that as the repository publish flow in this repo: push the branch, open the PR, merge it with squash unless they asked otherwise, close the PR via merge, and close the linked issue.
+- Do not interpret `close` as a request to end or archive the conversation in this repository.
 
 ## Project Structure
 

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	common "github.com/sophium/erun/erun-common"
@@ -12,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), runInitForArgs func(common.Context, []string) error, launchShell common.ShellLauncherFunc, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
+func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), runInitForArgs func(common.Context, []string) error, promptRunner PromptRunner, launchShell common.ShellLauncherFunc, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
 	var noShell bool
 
 	cmd := &cobra.Command{
@@ -29,7 +30,7 @@ func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), 
 			if initRan {
 				return nil
 			}
-			return runResolvedOpenCommand(ctx, result, openOptions{NoShell: noShell}, launchShell, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart)
+			return runResolvedOpenCommand(ctx, result, openOptions{NoShell: noShell}, promptRunner, launchShell, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart)
 		},
 	}
 
@@ -84,13 +85,13 @@ func resolveOpenWithInitRetry(ctx common.Context, args []string, shouldRunInit f
 	return result, true, err
 }
 
-func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, options openOptions, launchShell common.ShellLauncherFunc, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) error {
+func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, launchShell common.ShellLauncherFunc, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) error {
 	namespace := common.KubernetesNamespaceName(result.Tenant, result.Environment)
 	if options.NoShell {
 		ctx.TraceCommand("", "kubectl", "config", "use-context", strings.TrimSpace(result.EnvConfig.KubernetesContext))
 		ctx.TraceCommand("", "kubectl", "config", "set-context", "--current", "--namespace="+namespace)
 		ctx.TraceCommand("", "cd", result.RepoPath)
-		return emitLocalShellSetupForOpenResult(result, ctx.Stdout, ctx.Stderr)
+		return emitLocalShellSetupForOpenResult(result, promptRunner, ctx.Stdout, ctx.Stderr)
 	}
 
 	shellReq := common.ShellLaunchParamsFromResult(result)
@@ -149,7 +150,7 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 	return launchShell(shellReq)
 }
 
-func emitLocalShellSetupForOpenResult(result common.OpenResult, stdout, stderr io.Writer) error {
+func emitLocalShellSetupForOpenResult(result common.OpenResult, promptRunner PromptRunner, stdout, stderr io.Writer) error {
 	if stdout == nil {
 		stdout = io.Discard
 	}
@@ -159,12 +160,159 @@ func emitLocalShellSetupForOpenResult(result common.OpenResult, stdout, stderr i
 
 	if file, ok := stdout.(*os.File); ok {
 		if info, err := file.Stat(); err == nil && (info.Mode()&os.ModeCharDevice) != 0 {
-			_, _ = fmt.Fprintln(stderr, `run this to update the current shell: eval "$(erun open --no-shell)"`)
+			if err := maybeConfigureOpenNoShellAlias(result, promptRunner, os.Getenv("SHELL"), stderr); err != nil {
+				return err
+			}
 		}
 	}
 
 	_, err := io.WriteString(stdout, common.LocalShellSetupScript(result))
 	return err
+}
+
+func maybeConfigureOpenNoShellAlias(result common.OpenResult, promptRunner PromptRunner, shellPath string, stderr io.Writer) error {
+	aliasName := openNoShellAliasName(result)
+	startupFile, aliasConfigured := detectOpenNoShellAliasStartupFile(result, shellPath)
+	if aliasConfigured {
+		for _, line := range openNoShellHintLines(result, shellPath) {
+			_, _ = fmt.Fprintln(stderr, line)
+		}
+		return nil
+	}
+	if startupFile == "" || promptRunner == nil {
+		for _, line := range openNoShellHintLines(result, shellPath) {
+			_, _ = fmt.Fprintln(stderr, line)
+		}
+		return nil
+	}
+
+	ok, err := confirmPrompt(promptRunner, fmt.Sprintf("add %s to %s", aliasName, startupFile))
+	if err != nil {
+		return err
+	}
+	if !ok {
+		for _, line := range openNoShellHintLines(result, shellPath) {
+			_, _ = fmt.Fprintln(stderr, line)
+		}
+		return nil
+	}
+
+	if err := appendOpenNoShellAlias(startupFile, openNoShellAliasCommand(result, shellPath)); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stderr, "added %s to %s\n", aliasName, startupFile)
+	_, _ = fmt.Fprintf(stderr, "open a new shell to use %s\n", aliasName)
+	return nil
+}
+
+func openNoShellHintLines(result common.OpenResult, shellPath string) []string {
+	aliasName := openNoShellAliasName(result)
+	aliasCommand := openNoShellAliasCommand(result, shellPath)
+	startupFile, aliasConfigured := detectOpenNoShellAliasStartupFile(result, shellPath)
+	if aliasConfigured {
+		return []string{
+			fmt.Sprintf("configured in your shell startup file: open a new shell to use %s", aliasName),
+		}
+	}
+	if startupFile == "" {
+		return []string{
+			"one-liner alias:",
+			aliasCommand,
+		}
+	}
+	return []string{
+		"one-liner alias:",
+		aliasCommand,
+	}
+}
+
+func openNoShellAliasName(result common.OpenResult) string {
+	if strings.TrimSpace(result.Title) != "" {
+		return strings.TrimSpace(result.Title)
+	}
+	return strings.TrimSpace(result.Tenant) + "-" + strings.TrimSpace(result.Environment)
+}
+
+func openNoShellAliasCommand(result common.OpenResult, shellPath string) string {
+	aliasName := openNoShellAliasName(result)
+	command := fmt.Sprintf("erun open %s %s --no-shell", result.Tenant, result.Environment)
+	if filepath.Base(strings.TrimSpace(shellPath)) == "fish" {
+		return "alias " + aliasName + " 'eval (" + command + ")'"
+	}
+	return "alias " + aliasName + `='eval "$(` + command + `)"'`
+}
+
+func detectOpenNoShellAliasStartupFile(result common.OpenResult, shellPath string) (string, bool) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(homeDir) == "" {
+		return "", false
+	}
+
+	preferred, candidates := openNoShellStartupFiles(homeDir, shellPath)
+	for _, candidate := range candidates {
+		configured, err := startupFileHasAlias(candidate, openNoShellAliasName(result))
+		if err != nil {
+			continue
+		}
+		if configured {
+			return candidate, true
+		}
+	}
+	return preferred, false
+}
+
+func openNoShellStartupFiles(homeDir, shellPath string) (string, []string) {
+	switch filepath.Base(strings.TrimSpace(shellPath)) {
+	case "bash":
+		preferred := filepath.Join(homeDir, ".bashrc")
+		return preferred, []string{
+			preferred,
+			filepath.Join(homeDir, ".bash_profile"),
+			filepath.Join(homeDir, ".profile"),
+		}
+	case "fish":
+		preferred := filepath.Join(homeDir, ".config", "fish", "config.fish")
+		return preferred, []string{preferred}
+	default:
+		preferred := filepath.Join(homeDir, ".zshrc")
+		return preferred, []string{preferred}
+	}
+}
+
+func startupFileHasAlias(path, aliasName string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "alias "+aliasName+"=") || strings.HasPrefix(trimmed, "alias "+aliasName+" ") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func appendOpenNoShellAlias(path, aliasCommand string) error {
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if strings.Contains(string(data), aliasCommand) {
+		return nil
+	}
+
+	content := string(data)
+	if strings.TrimSpace(content) != "" && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += aliasCommand + "\n"
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
 }
 
 func openerIsDefaultError(err error) bool {

--- a/erun-cli/cmd/open_test.go
+++ b/erun-cli/cmd/open_test.go
@@ -68,6 +68,101 @@ func TestOpenCommandNoShellConfiguresLocalKubeconfig(t *testing.T) {
 	}
 }
 
+func TestOpenNoShellHintLinesSuggestAliasAndStartupFileWhenMissing(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	result := common.OpenResult{Tenant: "frs", Environment: "local", Title: "frs-local"}
+
+	lines := openNoShellHintLines(result, "/bin/zsh")
+
+	if len(lines) != 2 {
+		t.Fatalf("unexpected hint lines: %+v", lines)
+	}
+	if lines[0] != "one-liner alias:" {
+		t.Fatalf("unexpected intro line: %q", lines[0])
+	}
+	if lines[1] != `alias frs-local='eval "$(erun open frs local --no-shell)"'` {
+		t.Fatalf("unexpected alias line: %q", lines[1])
+	}
+}
+
+func TestOpenNoShellHintLinesRecommendAliasWhenConfigured(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	result := common.OpenResult{Tenant: "frs", Environment: "local", Title: "frs-local"}
+	startupPath := filepath.Join(homeDir, ".zshrc")
+	if err := os.WriteFile(startupPath, []byte(`alias frs-local='eval "$(erun open frs local --no-shell)"'`+"\n"), 0o644); err != nil {
+		t.Fatalf("write startup file: %v", err)
+	}
+
+	lines := openNoShellHintLines(result, "/bin/zsh")
+
+	if len(lines) != 1 {
+		t.Fatalf("unexpected hint lines: %+v", lines)
+	}
+	if lines[0] != "configured in your shell startup file: open a new shell to use frs-local" {
+		t.Fatalf("unexpected recommendation: %q", lines[0])
+	}
+}
+
+func TestMaybeConfigureOpenNoShellAliasPromptsAndAppendsToStartupFile(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	result := common.OpenResult{Tenant: "frs", Environment: "local", Title: "frs-local"}
+	startupPath := filepath.Join(homeDir, ".zshrc")
+	stderr := new(bytes.Buffer)
+
+	err := maybeConfigureOpenNoShellAlias(result, func(prompt promptui.Prompt) (string, error) {
+		if !prompt.IsConfirm {
+			t.Fatalf("expected confirm prompt, got %+v", prompt)
+		}
+		if prompt.Label != fmt.Sprintf("add frs-local to %s", startupPath) {
+			t.Fatalf("unexpected prompt label: %q", prompt.Label)
+		}
+		return "", nil
+	}, "/bin/zsh", stderr)
+	if err != nil {
+		t.Fatalf("maybeConfigureOpenNoShellAlias failed: %v", err)
+	}
+
+	data, err := os.ReadFile(startupPath)
+	if err != nil {
+		t.Fatalf("read startup file: %v", err)
+	}
+	if string(data) != "alias frs-local='eval \"$(erun open frs local --no-shell)\"'\n" {
+		t.Fatalf("unexpected startup file contents: %q", string(data))
+	}
+	output := stderr.String()
+	if strings.Contains(output, "one-liner alias:") {
+		t.Fatalf("did not expect one-liner output after successful add: %q", output)
+	}
+	if !strings.Contains(output, "added frs-local to "+startupPath) || !strings.Contains(output, "open a new shell to use frs-local") {
+		t.Fatalf("unexpected stderr output: %q", output)
+	}
+}
+
+func TestMaybeConfigureOpenNoShellAliasRecommendsConfiguredAliasWithoutPrompt(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	result := common.OpenResult{Tenant: "frs", Environment: "local", Title: "frs-local"}
+	startupPath := filepath.Join(homeDir, ".zshrc")
+	if err := os.WriteFile(startupPath, []byte(`alias frs-local='eval "$(erun open frs local --no-shell)"'`+"\n"), 0o644); err != nil {
+		t.Fatalf("write startup file: %v", err)
+	}
+	stderr := new(bytes.Buffer)
+
+	err := maybeConfigureOpenNoShellAlias(result, func(prompt promptui.Prompt) (string, error) {
+		t.Fatalf("did not expect prompt when alias is already configured: %+v", prompt)
+		return "", nil
+	}, "/bin/zsh", stderr)
+	if err != nil {
+		t.Fatalf("maybeConfigureOpenNoShellAlias failed: %v", err)
+	}
+	if got := strings.TrimSpace(stderr.String()); got != "configured in your shell startup file: open a new shell to use frs-local" {
+		t.Fatalf("unexpected stderr output: %q", got)
+	}
+}
+
 func TestOpenCommandDryRunPrintsResolvedOpenTraceWithoutLaunchingShell(t *testing.T) {
 	repoPath := t.TempDir()
 	stdout := new(bytes.Buffer)

--- a/erun-cli/cmd/release_test.go
+++ b/erun-cli/cmd/release_test.go
@@ -65,6 +65,7 @@ func TestReleaseCommandDryRun(t *testing.T) {
 
 func TestReleaseCommandDryRunStableIncludesSyncAndPush(t *testing.T) {
 	projectRoot := createReleaseGitRepo(t, "main")
+	runGitCommand(t, projectRoot, "branch", "develop")
 	if err := common.SaveProjectConfig(projectRoot, common.ProjectConfig{}); err != nil {
 		t.Fatalf("SaveProjectConfig failed: %v", err)
 	}
@@ -104,6 +105,46 @@ func TestReleaseCommandDryRunStableIncludesSyncAndPush(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected dry-run output to contain %q, got:\n%s", want, output)
 		}
+	}
+}
+
+func TestReleaseCommandDryRunStableWithoutDevelopOnlyPushesMain(t *testing.T) {
+	projectRoot := createReleaseGitRepo(t, "main")
+	if err := common.SaveProjectConfig(projectRoot, common.ProjectConfig{}); err != nil {
+		t.Fatalf("SaveProjectConfig failed: %v", err)
+	}
+
+	cmd := newTestRootCmd(testRootDeps{
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		RunGit: func(string, io.Writer, io.Writer, ...string) error {
+			t.Fatal("unexpected git execution during dry-run")
+			return nil
+		},
+	})
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"release", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if got := strings.TrimSpace(stdout.String()); got != "1.4.2" {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+	output := stderr.String()
+	if strings.Contains(output, "stage: sync-develop") || strings.Contains(output, "git checkout develop") {
+		t.Fatalf("did not expect develop sync in output:\n%s", output)
+	}
+	if !strings.Contains(output, "stage: push") || !strings.Contains(output, "git push --follow-tags origin main") {
+		t.Fatalf("expected main-only push in output, got:\n%s", output)
+	}
+	if strings.Contains(output, "git push --follow-tags origin main develop") {
+		t.Fatalf("did not expect develop push target in output:\n%s", output)
 	}
 }
 

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -41,6 +41,7 @@ func Execute() error {
 	openCmd := newOpenCmd(
 		resolveOpen,
 		runInitForArgs,
+		runPrompt,
 		common.LaunchShell,
 		common.CheckKubernetesDeployment,
 		resolveRuntimeDeploySpec,
@@ -90,7 +91,7 @@ func Execute() error {
 		if initRan {
 			return nil
 		}
-		return runResolvedOpenCommand(ctx, result, openOptions{}, common.LaunchShell, common.CheckKubernetesDeployment, resolveRuntimeDeploySpec, common.DeployHelmChart)
+		return runResolvedOpenCommand(ctx, result, openOptions{}, runPrompt, common.LaunchShell, common.CheckKubernetesDeployment, resolveRuntimeDeploySpec, common.DeployHelmChart)
 	}
 
 	cmd := newRootCommand(runRoot)

--- a/erun-cli/cmd/root_runtime.go
+++ b/erun-cli/cmd/root_runtime.go
@@ -45,7 +45,7 @@ func newRootCommand(runRoot func(*cobra.Command, []string) error) *cobra.Command
 		Use:              "erun",
 		Short:            "Environment Runner",
 		Long:             "erun helps to run and manage multiple tenants/environments.\n\nVerbosity levels:\n  -v    print trace logs for command flow and side effects\n\nDry-run:\n  --dry-run runs the same resolution flow but skips mutating operations",
-		Example:          "  erun deploy --dry-run\n  erun -v deploy --dry-run\n  erun -vv init -y\n  eval \"$(erun open --no-shell)\"",
+		Example:          "  erun deploy --dry-run\n  erun -v deploy --dry-run\n  erun -vv init -y\n  alias tenant-environment='eval \"$(erun open tenant environment --no-shell)\"'",
 		Args:             cobra.MaximumNArgs(2),
 		SilenceUsage:     true,
 		SilenceErrors:    true,

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -122,7 +122,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	push := newPushOperation(pushDockerImage, loginToDockerRegistry, selectRunner)
 
 	initCmd := newInitCmd(runInit)
-	openCmd := newOpenCmd(resolveOpen, runInitForArgs, launchShell, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
+	openCmd := newOpenCmd(resolveOpen, runInitForArgs, promptRunner, launchShell, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
@@ -167,7 +167,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 		if initRan {
 			return nil
 		}
-		return runResolvedOpenCommand(ctx, result, openOptions{}, launchShell, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
+		return runResolvedOpenCommand(ctx, result, openOptions{}, promptRunner, launchShell, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
 	}
 
 	cmd := newRootCommand(runRoot)

--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -24,6 +24,7 @@ const (
 type (
 	GitValueResolverFunc func(string) (string, error)
 	GitCommandRunnerFunc func(string, io.Writer, io.Writer, ...string) error
+	GitBranchCheckerFunc func(string, string) (bool, error)
 )
 
 type ReleaseMode string
@@ -86,11 +87,11 @@ type ReleaseSpec struct {
 }
 
 func ResolveReleaseSpec(findProjectRoot ProjectFinderFunc, params ReleaseParams) (ReleaseSpec, error) {
-	return resolveReleaseSpec(findProjectRoot, LoadProjectConfig, GitCurrentBranch, GitShortCommit, params)
+	return resolveReleaseSpec(findProjectRoot, LoadProjectConfig, GitCurrentBranch, GitShortCommit, GitLocalBranchExists, params)
 }
 
-func resolveReleaseSpec(findProjectRoot ProjectFinderFunc, loadProjectConfig ProjectConfigLoaderFunc, resolveBranch, resolveCommit GitValueResolverFunc, params ReleaseParams) (ReleaseSpec, error) {
-	findProjectRoot, loadProjectConfig, resolveBranch, resolveCommit = normalizeReleaseDependencies(findProjectRoot, loadProjectConfig, resolveBranch, resolveCommit)
+func resolveReleaseSpec(findProjectRoot ProjectFinderFunc, loadProjectConfig ProjectConfigLoaderFunc, resolveBranch, resolveCommit GitValueResolverFunc, branchExists GitBranchCheckerFunc, params ReleaseParams) (ReleaseSpec, error) {
+	findProjectRoot, loadProjectConfig, resolveBranch, resolveCommit, branchExists = normalizeReleaseDependencies(findProjectRoot, loadProjectConfig, resolveBranch, resolveCommit, branchExists)
 
 	projectRoot, err := resolveReleaseProjectRoot(findProjectRoot, params)
 	if err != nil {
@@ -123,6 +124,10 @@ func resolveReleaseSpec(findProjectRoot ProjectFinderFunc, loadProjectConfig Pro
 
 	mode := classifyReleaseMode(branch, releaseConfig)
 	version := resolveReleaseVersion(baseVersion, commit, mode)
+	developBranchExists, err := branchExists(projectRoot, releaseConfig.DevelopBranch)
+	if err != nil {
+		return ReleaseSpec{}, err
+	}
 
 	charts, chartUpdates, err := discoverReleaseCharts(releaseRoot, version)
 	if err != nil {
@@ -156,11 +161,11 @@ func resolveReleaseSpec(findProjectRoot ProjectFinderFunc, loadProjectConfig Pro
 				stages = append(stages, bumpStage)
 			}
 		}
-		syncStage := newSyncDevelopStage(projectRoot, releaseConfig)
+		syncStage := newSyncDevelopStage(projectRoot, releaseConfig, developBranchExists)
 		if len(syncStage.FileUpdates) > 0 || len(syncStage.GitCommands) > 0 {
 			stages = append(stages, syncStage)
 		}
-		pushStage := newPushReleaseStage(projectRoot, releaseConfig)
+		pushStage := newPushReleaseStage(projectRoot, releaseConfig, developBranchExists)
 		if len(pushStage.FileUpdates) > 0 || len(pushStage.GitCommands) > 0 {
 			stages = append(stages, pushStage)
 		}
@@ -244,6 +249,25 @@ func GitShortCommit(projectRoot string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+func GitLocalBranchExists(projectRoot, branch string) (bool, error) {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return false, nil
+	}
+
+	cmd := exec.Command("git", "-C", projectRoot, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, err
 }
 
 func GitCommandRunner(dir string, stdout, stderr io.Writer, args ...string) error {
@@ -335,7 +359,7 @@ func appendOrReplaceEnv(env []string, key, value string) []string {
 	return append(env, prefix+value)
 }
 
-func normalizeReleaseDependencies(findProjectRoot ProjectFinderFunc, loadProjectConfig ProjectConfigLoaderFunc, resolveBranch, resolveCommit GitValueResolverFunc) (ProjectFinderFunc, ProjectConfigLoaderFunc, GitValueResolverFunc, GitValueResolverFunc) {
+func normalizeReleaseDependencies(findProjectRoot ProjectFinderFunc, loadProjectConfig ProjectConfigLoaderFunc, resolveBranch, resolveCommit GitValueResolverFunc, branchExists GitBranchCheckerFunc) (ProjectFinderFunc, ProjectConfigLoaderFunc, GitValueResolverFunc, GitValueResolverFunc, GitBranchCheckerFunc) {
 	if findProjectRoot == nil {
 		findProjectRoot = FindProjectRoot
 	}
@@ -348,7 +372,10 @@ func normalizeReleaseDependencies(findProjectRoot ProjectFinderFunc, loadProject
 	if resolveCommit == nil {
 		resolveCommit = GitShortCommit
 	}
-	return findProjectRoot, loadProjectConfig, resolveBranch, resolveCommit
+	if branchExists == nil {
+		branchExists = GitLocalBranchExists
+	}
+	return findProjectRoot, loadProjectConfig, resolveBranch, resolveCommit, branchExists
 }
 
 func resolveReleaseProjectRoot(findProjectRoot ProjectFinderFunc, params ReleaseParams) (string, error) {
@@ -532,10 +559,10 @@ func newBumpStage(projectRoot, nextVersion string, fileUpdate ReleaseFileUpdate)
 	}
 }
 
-func newSyncDevelopStage(projectRoot string, config ReleaseConfig) ReleaseStage {
+func newSyncDevelopStage(projectRoot string, config ReleaseConfig, developBranchExists bool) ReleaseStage {
 	mainBranch := strings.TrimSpace(config.MainBranch)
 	developBranch := strings.TrimSpace(config.DevelopBranch)
-	if mainBranch == "" || developBranch == "" {
+	if mainBranch == "" || developBranch == "" || !developBranchExists {
 		return ReleaseStage{}
 	}
 
@@ -549,17 +576,22 @@ func newSyncDevelopStage(projectRoot string, config ReleaseConfig) ReleaseStage 
 	}
 }
 
-func newPushReleaseStage(projectRoot string, config ReleaseConfig) ReleaseStage {
+func newPushReleaseStage(projectRoot string, config ReleaseConfig, developBranchExists bool) ReleaseStage {
 	mainBranch := strings.TrimSpace(config.MainBranch)
 	developBranch := strings.TrimSpace(config.DevelopBranch)
-	if mainBranch == "" || developBranch == "" {
+	if mainBranch == "" {
 		return ReleaseStage{}
+	}
+
+	args := []string{"push", "--follow-tags", "origin", mainBranch}
+	if developBranchExists && developBranch != "" {
+		args = append(args, developBranch)
 	}
 
 	return ReleaseStage{
 		Name: "push",
 		GitCommands: []ReleaseCommandSpec{
-			releaseGitCommand(projectRoot, "push", "--follow-tags", "origin", mainBranch, developBranch),
+			releaseGitCommand(projectRoot, args...),
 		},
 	}
 }

--- a/erun-common/release_test.go
+++ b/erun-common/release_test.go
@@ -19,6 +19,7 @@ func TestResolveReleaseSpecStableRelease(t *testing.T) {
 		LoadProjectConfig,
 		func(string) (string, error) { return "main", nil },
 		func(string) (string, error) { return "abc1234", nil },
+		func(string, string) (bool, error) { return true, nil },
 		ReleaseParams{},
 	)
 	if err != nil {
@@ -81,6 +82,7 @@ func TestResolveReleaseSpecUsesConfiguredBranches(t *testing.T) {
 		LoadProjectConfig,
 		func(string) (string, error) { return "integration", nil },
 		func(string) (string, error) { return "abc1234", nil },
+		func(string, string) (bool, error) { return true, nil },
 		ReleaseParams{},
 	)
 	if err != nil {
@@ -109,6 +111,7 @@ func TestRunReleaseSpecWritesFilesAndRunsGitStages(t *testing.T) {
 		LoadProjectConfig,
 		func(string) (string, error) { return "main", nil },
 		func(string) (string, error) { return "abc1234", nil },
+		func(string, string) (bool, error) { return true, nil },
 		ReleaseParams{},
 	)
 	if err != nil {
@@ -168,6 +171,7 @@ func TestRunReleaseSpecCandidateRunsTagAndPush(t *testing.T) {
 		LoadProjectConfig,
 		func(string) (string, error) { return "develop", nil },
 		func(string) (string, error) { return "abc1234", nil },
+		func(string, string) (bool, error) { return true, nil },
 		ReleaseParams{},
 	)
 	if err != nil {
@@ -213,6 +217,7 @@ func TestResolveReleaseSpecStableReleaseUsesConfiguredDevelopBranchForSyncAndPus
 		LoadProjectConfig,
 		func(string) (string, error) { return "trunk", nil },
 		func(string) (string, error) { return "abc1234", nil },
+		func(string, string) (bool, error) { return true, nil },
 		ReleaseParams{},
 	)
 	if err != nil {
@@ -230,6 +235,32 @@ func TestResolveReleaseSpecStableReleaseUsesConfiguredDevelopBranchForSyncAndPus
 	}
 	if got := spec.Stages[3].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "trunk", "integration"}) {
 		t.Fatalf("unexpected configured push command: %+v", got)
+	}
+}
+
+func TestResolveReleaseSpecStableReleaseSkipsDevelopSyncWhenBranchMissing(t *testing.T) {
+	projectRoot := setupReleaseProject(t, releaseProjectOptions{})
+
+	spec, err := resolveReleaseSpec(
+		func() (string, string, error) { return "tenant-a", projectRoot, nil },
+		LoadProjectConfig,
+		func(string) (string, error) { return "main", nil },
+		func(string) (string, error) { return "abc1234", nil },
+		func(string, string) (bool, error) { return false, nil },
+		ReleaseParams{},
+	)
+	if err != nil {
+		t.Fatalf("resolveReleaseSpec failed: %v", err)
+	}
+
+	if len(spec.Stages) != 3 {
+		t.Fatalf("expected 3 stages without develop sync, got %+v", spec.Stages)
+	}
+	if spec.Stages[2].Name != "push" {
+		t.Fatalf("unexpected final stage: %+v", spec.Stages[2])
+	}
+	if got := spec.Stages[2].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "main"}) {
+		t.Fatalf("unexpected main-only push command: %+v", got)
 	}
 }
 


### PR DESCRIPTION
Closes #48

## Summary
- skip develop sync/push for stable releases when the configured develop branch does not exist locally
- improve `erun open --no-shell` alias installation and shell guidance for explicit tenant-environment aliases
- clarify repository instructions so `close` is treated as repository publish flow in this repo

## Validation
- `cd erun-common && go test ./...`
- `cd erun-cli && go test ./...`
- `cd erun-cli && golangci-lint run`
- `cd erun-mcp && go test ./...`

## Notes
- `cd erun-common && golangci-lint run` still reports pre-existing unrelated issues from `main`
- `cd erun-mcp && golangci-lint run` still reports a pre-existing unrelated issue from `main`
