### PR TITLE
Publish release images during build --release

### DIFF
--- a/erun-cli/cmd/build.go
+++ b/erun-cli/cmd/build.go
@@ -115,7 +115,7 @@ func runDockerPushWithRetry(ctx common.Context, pushInput common.DockerPushSpec,
 func addBuildCommandTargetFlags(cmd *cobra.Command, target *common.DockerCommandTarget) {
 	addPushCommandTargetFlags(cmd, target)
 	cmd.Flags().BoolVar(&target.Deploy, "deploy", false, "Deploy the built version after the build completes")
-	cmd.Flags().BoolVar(&target.Release, "release", false, "Run release first and build with the released version")
+	cmd.Flags().BoolVar(&target.Release, "release", false, "Run release first and publish the release-tagged images")
 }
 
 func addPushCommandTargetFlags(cmd *cobra.Command, target *common.DockerCommandTarget) {

--- a/erun-cli/cmd/build_test.go
+++ b/erun-cli/cmd/build_test.go
@@ -2287,6 +2287,48 @@ func TestBuildCommandDryRunReleaseShowsReleaseAndBuildVersionTrace(t *testing.T)
 	}
 }
 
+func TestBuildCommandDryRunReleaseShowsPushCommandsForReleaseTaggedDockerBuilds(t *testing.T) {
+	projectRoot := createReleaseGitRepo(t, "main")
+	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
+		t.Fatalf("save project config: %v", err)
+	}
+
+	cmd := newTestRootCmd(testRootDeps{
+		FindProjectRoot: func() (string, string, error) {
+			return "erun", projectRoot, nil
+		},
+		OptionalBuildFindProjectRoot: func() (string, string, error) {
+			return "erun", projectRoot, nil
+		},
+		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
+			return common.DockerBuildContext{Dir: projectRoot}, nil
+		},
+	})
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"build", "--dry-run", "--release"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	output := stderr.String()
+	if !strings.Contains(output, "docker build -t erunpaas/api:1.4.2") {
+		t.Fatalf("expected release build trace, got:\n%s", output)
+	}
+	if !strings.Contains(output, "docker build -t erunpaas/base:9.9.9") {
+		t.Fatalf("expected component-local build trace, got:\n%s", output)
+	}
+	if !strings.Contains(output, "docker push erunpaas/api:1.4.2") {
+		t.Fatalf("expected release push trace, got:\n%s", output)
+	}
+	if strings.Contains(output, "docker push erunpaas/base:9.9.9") {
+		t.Fatalf("did not expect push trace for non-release-tagged image, got:\n%s", output)
+	}
+}
+
 func projectConfigWithSingleRegistry(registry string) common.ProjectConfig {
 	return common.ProjectConfig{
 		Environments: map[string]common.ProjectEnvironmentConfig{

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -141,7 +141,11 @@ func ResolveBuildExecution(store DockerStore, findProjectRoot ProjectFinderFunc,
 		return BuildExecutionSpec{}, err
 	}
 
-	return BuildExecutionSpec{release: releaseSpec, dockerBuilds: builds}, nil
+	execution := BuildExecutionSpec{dockerBuilds: builds}
+	if releaseSpec != nil {
+		return BuildExecutionSpecWithRelease(execution, *releaseSpec), nil
+	}
+	return execution, nil
 }
 
 func BuildExecutionSpecFromDockerBuilds(builds []DockerBuildSpec) BuildExecutionSpec {
@@ -150,11 +154,34 @@ func BuildExecutionSpecFromDockerBuilds(builds []DockerBuildSpec) BuildExecution
 
 func BuildExecutionSpecWithRelease(execution BuildExecutionSpec, release ReleaseSpec) BuildExecutionSpec {
 	execution.release = &release
+	if len(execution.dockerBuilds) > 0 && len(execution.dockerPushes) == 0 {
+		execution.dockerPushes = releaseDockerPushSpecs(execution.dockerBuilds, release.DockerImages)
+	}
 	return execution
 }
 
 func BuildExecutionUsesBuildScript(execution BuildExecutionSpec) bool {
 	return execution.script != nil
+}
+
+func releaseDockerPushSpecs(builds []DockerBuildSpec, images []ReleaseDockerImageSpec) []DockerPushSpec {
+	if len(builds) == 0 || len(images) == 0 {
+		return nil
+	}
+
+	releaseTags := make(map[string]struct{}, len(images))
+	for _, image := range images {
+		releaseTags[strings.TrimSpace(image.Tag)] = struct{}{}
+	}
+
+	pushes := make([]DockerPushSpec, 0, len(builds))
+	for _, build := range builds {
+		if _, ok := releaseTags[strings.TrimSpace(build.Image.Tag)]; !ok {
+			continue
+		}
+		pushes = append(pushes, NewDockerPushSpec(build.ContextDir, build.Image))
+	}
+	return pushes
 }
 
 func ResolveDockerBuildTarget(findProjectRoot ProjectFinderFunc, target DockerCommandTarget) (DockerCommandTarget, *ReleaseSpec, error) {

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -465,8 +465,43 @@ func TestResolveBuildExecutionReleaseUsesResolvedVersionForDockerBuilds(t *testi
 	if got := execution.dockerBuilds[0].Image.Tag; got != "erunpaas/api:1.4.2" {
 		t.Fatalf("unexpected docker build tag: %q", got)
 	}
+	if len(execution.dockerPushes) != 1 {
+		t.Fatalf("unexpected docker pushes: %+v", execution.dockerPushes)
+	}
+	if got := execution.dockerPushes[0].Image.Tag; got != "erunpaas/api:1.4.2" {
+		t.Fatalf("unexpected docker push tag: %q", got)
+	}
 	if got := execution.release.NextVersion; got != "1.4.3" {
 		t.Fatalf("unexpected next version: %q", got)
+	}
+}
+
+func TestResolveBuildExecutionReleaseOnlyPushesReleaseTaggedDockerBuilds(t *testing.T) {
+	projectRoot := setupReleaseProjectGitRepo(t, "main")
+
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		func() (string, string, error) {
+			return "erun", projectRoot, nil
+		},
+		func() (DockerBuildContext, error) {
+			return DockerBuildContext{Dir: projectRoot}, nil
+		},
+		nil,
+		DockerCommandTarget{ProjectRoot: projectRoot, Environment: DefaultEnvironment, Release: true},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+
+	if len(execution.dockerBuilds) != 2 {
+		t.Fatalf("unexpected docker builds: %+v", execution.dockerBuilds)
+	}
+	if len(execution.dockerPushes) != 1 {
+		t.Fatalf("unexpected docker pushes: %+v", execution.dockerPushes)
+	}
+	if got := execution.dockerPushes[0].Image.Tag; got != "erunpaas/api:1.4.2" {
+		t.Fatalf("unexpected docker push tag: %q", got)
 	}
 }
 
@@ -541,6 +576,52 @@ func TestRunBuildExecutionDryRunReleaseIncludesReleaseAndBuildTrace(t *testing.T
 	}
 	if !strings.Contains(output, "release version: 1.4.2-rc.") {
 		t.Fatalf("expected final release version output, got:\n%s", output)
+	}
+}
+
+func TestRunBuildExecutionReleaseBuildsAndPushesResolvedVersion(t *testing.T) {
+	projectRoot := setupReleaseProjectGitRepo(t, "main")
+	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "api")
+
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		func() (string, string, error) {
+			return "erun", projectRoot, nil
+		},
+		func() (DockerBuildContext, error) {
+			return DockerBuildContextAtDir(buildDir)
+		},
+		nil,
+		DockerCommandTarget{ProjectRoot: projectRoot, Environment: DefaultEnvironment, Release: true},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+	execution.release = nil
+
+	var buildCalls []string
+	var pushCalls []string
+	ctx := Context{
+		Logger: NewLoggerWithWriters(2, io.Discard, io.Discard),
+		Stdin:  new(bytes.Buffer),
+		Stdout: new(bytes.Buffer),
+		Stderr: new(bytes.Buffer),
+	}
+	if err := RunBuildExecution(ctx, execution, nil, func(dir, dockerfilePath, tag string, stdout, stderr io.Writer) error {
+		buildCalls = append(buildCalls, tag)
+		return nil
+	}, func(ctx Context, pushInput DockerPushSpec) error {
+		pushCalls = append(pushCalls, pushInput.Image.Tag)
+		return nil
+	}); err != nil {
+		t.Fatalf("RunBuildExecution failed: %v", err)
+	}
+
+	if len(buildCalls) != 1 || buildCalls[0] != "erunpaas/api:1.4.2" {
+		t.Fatalf("unexpected build calls: %+v", buildCalls)
+	}
+	if len(pushCalls) != 1 || pushCalls[0] != "erunpaas/api:1.4.2" {
+		t.Fatalf("unexpected push calls: %+v", pushCalls)
 	}
 }
 

--- a/erun-devops/k8s/erun-devops/Chart.yaml
+++ b/erun-devops/k8s/erun-devops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.16
+appVersion: 1.0.17-pr.8e6ad5f
 description: ERun DevOps
 name: erun-devops
 type: application
-version: 1.0.16
+version: 1.0.17-pr.8e6ad5f

--- a/erun-mcp/build.go
+++ b/erun-mcp/build.go
@@ -13,7 +13,7 @@ type BuildInput struct {
 	Component string `json:"component,omitempty" jsonschema:"optional component name to build from the runtime repo root; when empty, build all Docker component images"`
 	Version   string `json:"version,omitempty" jsonschema:"optional explicit image version override; disables local snapshot tagging when set"`
 	Deploy    bool   `json:"deploy,omitempty" jsonschema:"when true, push the built images and deploy the resolved Helm chart(s) using the built version"`
-	Release   bool   `json:"release,omitempty" jsonschema:"when true, run release first and build with the resolved release version"`
+	Release   bool   `json:"release,omitempty" jsonschema:"when true, run release first and publish the resolved release-tagged images"`
 	Preview   bool   `json:"preview,omitempty" jsonschema:"when true, resolve and print the planned actions without executing them"`
 	Verbosity int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
 }


### PR DESCRIPTION
## Summary
- publish release-tagged images during `erun build --release`
- only auto-push images that are part of the resolved release image set
- document and test the release publish behavior in CLI and MCP surfaces

## Why
`erun build --release` previously updated release metadata and built the release-tagged images locally, but it did not publish them. A later `erun deploy` on another machine could resolve the released tag and fail to pull it from the registry because the tag was never pushed.

## Impact
Release builds now publish the release-tagged runtime images as part of the build flow, so the released chart/image version can be deployed from another machine immediately after the release completes.

## Validation
- `go test ./...` in `erun-common`
- `go test ./...` in `erun-cli`
- `go test ./...` in `erun-mcp`

Closes #50
