### PR TITLE
Fix local runtime deploy fallbacks and shell reattach

### DIFF
--- a/erun-cli/cmd/deploy_test.go
+++ b/erun-cli/cmd/deploy_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/manifoldco/promptui"
 	common "github.com/sophium/erun/erun-common"
 )
 
@@ -120,6 +122,7 @@ func TestNewRootCmdOmitsDeployShorthandWhenKubernetesDeployContextAbsent(t *test
 
 func TestDevopsK8sDeployBuildsAndDeploysSameExactVersionFromCurrentBuildDirectoryForLocalEnvironment(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
+	stubKubectlContexts(t, []string{"cluster-local"}, "cluster-local")
 
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
@@ -209,7 +212,11 @@ func TestDevopsK8sDeployBuildsAndDeploysSameExactVersionFromCurrentBuildDirector
 	if received.KubernetesContext != "cluster-local" {
 		t.Fatalf("unexpected kubernetes context: %+v", received)
 	}
-	if received.WorktreeHostPath != projectRoot {
+	resolvedProjectRoot, err := filepath.EvalSymlinks(projectRoot)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(projectRoot) failed: %v", err)
+	}
+	if received.WorktreeHostPath != resolvedProjectRoot {
 		t.Fatalf("unexpected worktree values: %+v", received)
 	}
 	if received.Timeout != common.DefaultHelmDeploymentTimeout {
@@ -599,6 +606,7 @@ func TestDeployCommandVersionOverrideUsesProvidedVersion(t *testing.T) {
 
 func TestRootDeployShorthandDryRunPrintsBuildAndDeployCommandsWithoutExecuting(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
+	stubKubectlContexts(t, []string{"cluster-local"}, "cluster-local")
 
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
@@ -835,6 +843,15 @@ func TestRootCommandTreatsDeployAsEnvironmentWhenDeployContextAbsent(t *testing.
 	cmd := newTestRootCmd(testRootDeps{
 		ResolveKubernetesDeployContext: func() (common.KubernetesDeployContext, error) {
 			return common.KubernetesDeployContext{Dir: t.TempDir()}, nil
+		},
+		PromptRunner: func(prompt promptui.Prompt) (string, error) {
+			if !prompt.IsConfirm {
+				t.Fatalf("expected confirm prompt, got %+v", prompt)
+			}
+			if prompt.Label != fmt.Sprintf("create tenant-a-devops chart in %s", projectRoot) {
+				t.Fatalf("unexpected prompt label: %q", prompt.Label)
+			}
+			return "n", nil
 		},
 		DeployHelmChart: func(req common.HelmDeployParams) error {
 			t.Fatalf("unexpected deploy request: %+v", req)

--- a/erun-cli/cmd/list_test.go
+++ b/erun-cli/cmd/list_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestListCommandPrintsDefaultsAndConfiguredTenants(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
+	stubKubectlContexts(t, []string{"cluster-local"}, "cluster-local")
 
 	tenantAPath := filepath.Join(t.TempDir(), "tenant-a")
 	tenantBPath := filepath.Join(t.TempDir(), "tenant-b")

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), runInitForArgs func(common.Context, []string) error, promptRunner PromptRunner, launchShell common.ShellLauncherFunc, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
+func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), runInitForArgs func(common.Context, []string) error, promptRunner PromptRunner, launchShell common.ShellLauncherFunc, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
 	var noShell bool
 
 	cmd := &cobra.Command{
@@ -30,7 +30,7 @@ func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), 
 			if initRan {
 				return nil
 			}
-			return runResolvedOpenCommand(ctx, result, openOptions{NoShell: noShell}, promptRunner, launchShell, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart)
+			return runResolvedOpenCommand(ctx, result, openOptions{NoShell: noShell}, promptRunner, launchShell, runManagedDeploy, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart)
 		},
 	}
 
@@ -85,7 +85,7 @@ func resolveOpenWithInitRetry(ctx common.Context, args []string, shouldRunInit f
 	return result, true, err
 }
 
-func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, launchShell common.ShellLauncherFunc, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) error {
+func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, launchShell common.ShellLauncherFunc, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) error {
 	namespace := common.KubernetesNamespaceName(result.Tenant, result.Environment)
 	if options.NoShell {
 		ctx.TraceCommand("", "kubectl", "config", "use-context", strings.TrimSpace(result.EnvConfig.KubernetesContext))
@@ -97,6 +97,10 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 	shellReq := common.ShellLaunchParamsFromResult(result)
 	if resolveRuntimeDeploySpec != nil && deployHelmChart != nil {
 		execution, err := resolveRuntimeDeploySpec(result)
+		if err != nil {
+			return err
+		}
+		execution, err = maybeCreateMissingRuntimeChart(ctx, result, promptRunner, resolveRuntimeDeploySpec, execution)
 		if err != nil {
 			return err
 		}
@@ -147,7 +151,42 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 		return nil
 	}
 
-	return launchShell(shellReq)
+	for {
+		err := launchShell(shellReq)
+		if !errors.Is(err, common.ErrShellReattachDeploy) {
+			return err
+		}
+		if runManagedDeploy == nil {
+			return err
+		}
+		if err := runManagedDeploy(ctx, result); err != nil {
+			return err
+		}
+	}
+}
+
+func maybeCreateMissingRuntimeChart(ctx common.Context, result common.OpenResult, promptRunner PromptRunner, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), execution common.DeploySpec) (common.DeploySpec, error) {
+	if ctx.DryRun || promptRunner == nil || resolveRuntimeDeploySpec == nil {
+		return execution, nil
+	}
+	if !common.IsDefaultDevopsChartPath(execution.Deploy.ChartPath) {
+		return execution, nil
+	}
+
+	moduleName := common.RuntimeReleaseName(result.Tenant)
+	ok, err := confirmPrompt(promptRunner, fmt.Sprintf("create %s chart in %s", moduleName, result.RepoPath))
+	if err != nil {
+		return common.DeploySpec{}, err
+	}
+	if !ok {
+		return execution, nil
+	}
+
+	if err := common.EnsureDefaultDevopsChart(ctx, result.RepoPath, result.Tenant, result.Environment); err != nil {
+		return common.DeploySpec{}, err
+	}
+
+	return resolveRuntimeDeploySpec(result)
 }
 
 func emitLocalShellSetupForOpenResult(result common.OpenResult, promptRunner PromptRunner, stdout, stderr io.Writer) error {

--- a/erun-cli/cmd/open_test.go
+++ b/erun-cli/cmd/open_test.go
@@ -402,6 +402,103 @@ func TestOpenCommandDryRunFallsBackToDefaultRuntimeChartWhenTenantRepoHasNoDevop
 	}
 }
 
+func TestOpenCommandPromptsToCreateMissingRuntimeChartAndUsesCreatedChart(t *testing.T) {
+	repoPath := t.TempDir()
+	deployed := common.HelmDeployParams{}
+	launched := common.ShellLaunchParams{}
+
+	cmd := newTestRootCmd(testRootDeps{
+		Store: openCommandStore{
+			repoPath:   repoPath,
+			toolConfig: common.ERunConfig{DefaultTenant: "frs"},
+		},
+		PromptRunner: func(prompt promptui.Prompt) (string, error) {
+			if !prompt.IsConfirm {
+				t.Fatalf("expected confirm prompt, got %+v", prompt)
+			}
+			if prompt.Label != fmt.Sprintf("create frs-devops chart in %s", repoPath) {
+				t.Fatalf("unexpected prompt label: %q", prompt.Label)
+			}
+			return "", nil
+		},
+		CheckKubernetesDeployment: func(req common.KubernetesDeploymentCheckParams) (bool, error) {
+			return false, nil
+		},
+		DeployHelmChart: func(req common.HelmDeployParams) error {
+			deployed = req
+			return nil
+		},
+		LaunchShell: func(req common.ShellLaunchParams) error {
+			launched = req
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"open"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	chartPath := filepath.Join(repoPath, "frs-devops", "k8s", "frs-devops")
+	if deployed.ChartPath != chartPath {
+		t.Fatalf("expected created local chart path, got %+v", deployed)
+	}
+	if deployed.ReleaseName != "frs-devops" {
+		t.Fatalf("unexpected release name: %+v", deployed)
+	}
+	if _, err := os.Stat(filepath.Join(chartPath, "Chart.yaml")); err != nil {
+		t.Fatalf("expected generated chart to exist: %v", err)
+	}
+	if launched.Namespace != "frs-local" || launched.KubernetesContext != "cluster-dev" {
+		t.Fatalf("unexpected shell launch: %+v", launched)
+	}
+}
+
+func TestOpenCommandRunsManagedDeployAndReattachesWhenShellRequestsHandoff(t *testing.T) {
+	projectRoot := t.TempDir()
+	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
+	if err := os.WriteFile(filepath.Join(chartPath, "values.dev.yaml"), nil, 0o644); err != nil {
+		t.Fatalf("write values.dev.yaml: %v", err)
+	}
+
+	launchCalls := 0
+	deployed := common.HelmDeployParams{}
+	cmd := newTestRootCmd(testRootDeps{
+		Store: openCommandStore{
+			repoPath:   projectRoot,
+			toolConfig: common.ERunConfig{DefaultTenant: "tenant-a"},
+		},
+		ResolveKubernetesDeployContext: func() (common.KubernetesDeployContext, error) {
+			return common.KubernetesDeployContext{Dir: projectRoot}, nil
+		},
+		CheckKubernetesDeployment: func(req common.KubernetesDeploymentCheckParams) (bool, error) {
+			return true, nil
+		},
+		DeployHelmChart: func(req common.HelmDeployParams) error {
+			deployed = req
+			return nil
+		},
+		LaunchShell: func(req common.ShellLaunchParams) error {
+			launchCalls++
+			if launchCalls == 1 {
+				return common.ErrShellReattachDeploy
+			}
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"open", "tenant-a", "dev"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if launchCalls != 2 {
+		t.Fatalf("expected shell to relaunch after handoff, got %d launches", launchCalls)
+	}
+	if deployed.ChartPath != chartPath || deployed.ReleaseName != "erun-devops" {
+		t.Fatalf("expected managed deploy before reattach, got %+v", deployed)
+	}
+}
+
 func TestOpenCommandLaunchesShellWithDefaults(t *testing.T) {
 	repoPath := t.TempDir()
 	launched := common.ShellLaunchParams{}

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -36,6 +36,24 @@ func Execute() error {
 	resolveRuntimeDeploySpec := func(target common.OpenResult) (common.DeploySpec, error) {
 		return common.ResolveOpenRuntimeDeploySpec(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, target)
 	}
+	runManagedDeploy := func(ctx common.Context, target common.OpenResult) error {
+		specs, err := common.ResolveCurrentDeploySpecs(
+			store,
+			common.FindProjectRoot,
+			common.ResolveDockerBuildContext,
+			common.ResolveKubernetesDeployContext,
+			time.Now,
+			common.DeployTarget{
+				Tenant:      target.Tenant,
+				Environment: target.Environment,
+				RepoPath:    target.RepoPath,
+			},
+		)
+		if err != nil {
+			return err
+		}
+		return common.RunDeploySpecs(ctx, specs, common.DockerImageBuilder, push, common.DeployHelmChart)
+	}
 
 	initCmd := newInitCmd(runInit)
 	openCmd := newOpenCmd(
@@ -43,6 +61,7 @@ func Execute() error {
 		runInitForArgs,
 		runPrompt,
 		common.LaunchShell,
+		runManagedDeploy,
 		common.CheckKubernetesDeployment,
 		resolveRuntimeDeploySpec,
 		common.DeployHelmChart,
@@ -91,7 +110,7 @@ func Execute() error {
 		if initRan {
 			return nil
 		}
-		return runResolvedOpenCommand(ctx, result, openOptions{}, runPrompt, common.LaunchShell, common.CheckKubernetesDeployment, resolveRuntimeDeploySpec, common.DeployHelmChart)
+		return runResolvedOpenCommand(ctx, result, openOptions{}, runPrompt, common.LaunchShell, runManagedDeploy, common.CheckKubernetesDeployment, resolveRuntimeDeploySpec, common.DeployHelmChart)
 	}
 
 	cmd := newRootCommand(runRoot)

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
 	"time"
 
 	common "github.com/sophium/erun/erun-common"
@@ -111,6 +115,25 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	resolveRuntimeDeploySpec := func(target common.OpenResult) (common.DeploySpec, error) {
 		return common.ResolveOpenRuntimeDeploySpec(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target)
 	}
+	push := newPushOperation(pushDockerImage, loginToDockerRegistry, selectRunner)
+	runManagedDeploy := func(ctx common.Context, target common.OpenResult) error {
+		specs, err := common.ResolveCurrentDeploySpecs(
+			store,
+			findProjectRoot,
+			resolveDockerBuildContext,
+			resolveKubernetesDeployContext,
+			now,
+			common.DeployTarget{
+				Tenant:      target.Tenant,
+				Environment: target.Environment,
+				RepoPath:    target.RepoPath,
+			},
+		)
+		if err != nil {
+			return err
+		}
+		return common.RunDeploySpecs(ctx, specs, buildDockerImage, push, deployHelmChart)
+	}
 	ensureKubernetesNamespace := func(contextName, namespace string) error {
 		if deps.EnsureKubernetesNamespace == nil {
 			return nil
@@ -119,10 +142,9 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	}
 	runInit := newRunInit(store, findProjectRoot, promptRunner, selectRunner, listKubernetesContexts, ensureKubernetesNamespace)
 	runInitForArgs := newRunInitForArgs(store, runInit)
-	push := newPushOperation(pushDockerImage, loginToDockerRegistry, selectRunner)
 
 	initCmd := newInitCmd(runInit)
-	openCmd := newOpenCmd(resolveOpen, runInitForArgs, promptRunner, launchShell, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
+	openCmd := newOpenCmd(resolveOpen, runInitForArgs, promptRunner, launchShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
@@ -167,10 +189,32 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 		if initRan {
 			return nil
 		}
-		return runResolvedOpenCommand(ctx, result, openOptions{}, promptRunner, launchShell, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
+		return runResolvedOpenCommand(ctx, result, openOptions{}, promptRunner, launchShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
 	}
 
 	cmd := newRootCommand(runRoot)
 	addCommands(cmd, initCmd, openCmd, devopsCmd, buildCmd, pushCmd, deployCmd, mcpCmd, listCmd, releaseCmd, versionCmd)
 	return cmd
+}
+
+func stubKubectlContexts(t *testing.T, contexts []string, current string) {
+	t.Helper()
+
+	kubectlDir := t.TempDir()
+	kubectlPath := filepath.Join(kubectlDir, "kubectl")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"config\" ] && [ \"$2\" = \"get-contexts\" ] && [ \"$3\" = \"-o=name\" ]; then\n" +
+		"  cat <<'EOF'\n" + strings.Join(contexts, "\n") + "\nEOF\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = \"config\" ] && [ \"$2\" = \"current-context\" ]; then\n" +
+		"  printf '%s\\n' '" + current + "'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo \"unexpected kubectl invocation: $@\" >&2\n" +
+		"exit 1\n"
+	if err := os.WriteFile(kubectlPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+	t.Setenv("PATH", kubectlDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/erun-common/assets/default-devops-chart/templates/service.yaml
+++ b/erun-common/assets/default-devops-chart/templates/service.yaml
@@ -141,7 +141,7 @@ spec:
         - name: repo-worktree
           hostPath:
             path: {{ required "worktreeHostPath is required" .Values.worktreeHostPath | quote }}
-            type: Directory
+            type: DirectoryOrCreate
         - name: docker-socket
           emptyDir: {}
         - name: docker-state

--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -145,6 +145,10 @@ func (ConfigStore) LoadEnvConfig(tenant, envName string) (EnvConfig, string, err
 	return LoadEnvConfig(tenant, envName)
 }
 
+func (ConfigStore) ResolveEffectiveKubernetesContext(environment, configured string) string {
+	return resolveEffectiveKubernetesContext(environment, configured, listKubernetesContextNames, currentKubernetesContextName)
+}
+
 func (ConfigStore) ListEnvConfigs(tenant string) ([]EnvConfig, error) {
 	return ListEnvConfigs(tenant)
 }

--- a/erun-common/default_devops_chart.go
+++ b/erun-common/default_devops_chart.go
@@ -141,6 +141,15 @@ func resolveDefaultDevopsDeploySpec(target OpenResult) (DeploySpec, error) {
 	}, nil
 }
 
+func IsDefaultDevopsChartPath(chartPath string) bool {
+	chartPath = filepath.Clean(strings.TrimSpace(chartPath))
+	if chartPath == "" {
+		return false
+	}
+
+	return strings.HasPrefix(filepath.Base(chartPath), "erun-default-devops-chart-")
+}
+
 func materializeDefaultDevopsChart(moduleName string) (string, error) {
 	hash, err := defaultDevopsChartHash()
 	if err != nil {

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -521,10 +521,25 @@ func newHelmDeploySpec(target OpenResult, deployContext KubernetesDeployContext,
 		Environment:       target.Environment,
 		Namespace:         KubernetesNamespaceName(target.Tenant, target.Environment),
 		KubernetesContext: target.EnvConfig.KubernetesContext,
-		WorktreeHostPath:  target.RepoPath,
+		WorktreeHostPath:  resolveWorktreeHostPath(target.RepoPath),
 		Version:           version,
 		Timeout:           DefaultHelmDeploymentTimeout,
 	}, nil
+}
+
+func resolveWorktreeHostPath(repoPath string) string {
+	repoPath = strings.TrimSpace(repoPath)
+	if repoPath == "" {
+		return ""
+	}
+
+	cleaned := filepath.Clean(repoPath)
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil || strings.TrimSpace(resolved) == "" {
+		return cleaned
+	}
+
+	return resolved
 }
 
 func (d HelmDeploySpec) Params(stdout, stderr io.Writer) HelmDeployParams {

--- a/erun-common/deploy_test.go
+++ b/erun-common/deploy_test.go
@@ -159,6 +159,48 @@ func TestPrepareHelmChartForDeployOverridesVersionAndAppVersion(t *testing.T) {
 	}
 }
 
+func TestNewHelmDeploySpecCanonicalizesWorktreeHostPath(t *testing.T) {
+	projectRoot := t.TempDir()
+	repoRoot := filepath.Join(projectRoot, "repo")
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatalf("mkdir repo root: %v", err)
+	}
+
+	linkParent := filepath.Join(projectRoot, "links")
+	if err := os.MkdirAll(linkParent, 0o755); err != nil {
+		t.Fatalf("mkdir link parent: %v", err)
+	}
+	linkPath := filepath.Join(linkParent, "repo-link")
+	if err := os.Symlink(repoRoot, linkPath); err != nil {
+		t.Fatalf("symlink repo root: %v", err)
+	}
+
+	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
+	spec, err := newHelmDeploySpec(
+		OpenResult{
+			Tenant:      "tenant-a",
+			Environment: DefaultEnvironment,
+			RepoPath:    linkPath,
+			EnvConfig:   EnvConfig{KubernetesContext: "cluster-local"},
+		},
+		KubernetesDeployContext{
+			ComponentName: "erun-devops",
+			ChartPath:     chartPath,
+		},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("newHelmDeploySpec failed: %v", err)
+	}
+	resolvedRepoRoot, err := filepath.EvalSymlinks(repoRoot)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(repoRoot) failed: %v", err)
+	}
+	if spec.WorktreeHostPath != resolvedRepoRoot {
+		t.Fatalf("expected canonical worktree host path %q, got %q", resolvedRepoRoot, spec.WorktreeHostPath)
+	}
+}
+
 func TestResolveOpenRuntimeDeploySpecUsesTenantSpecificComponentBeforeSharedDefault(t *testing.T) {
 	projectRoot := t.TempDir()
 	chartPath := createComponentHelmChartFixture(t, projectRoot, "frs-devops")

--- a/erun-common/init_test.go
+++ b/erun-common/init_test.go
@@ -321,6 +321,9 @@ func TestBootstrapRunCreatesTenantDevopsModuleAndChart(t *testing.T) {
 	if !strings.Contains(string(serviceTemplate), "name: tenant-a-devops") {
 		t.Fatalf("expected tenant container name, got %q", string(serviceTemplate))
 	}
+	if !strings.Contains(string(serviceTemplate), "type: DirectoryOrCreate") {
+		t.Fatalf("expected repo worktree hostPath to allow missing directories, got %q", string(serviceTemplate))
+	}
 }
 
 func TestBootstrapRunCreatesTenantDevopsEnvironmentValuesFile(t *testing.T) {

--- a/erun-common/list_test.go
+++ b/erun-common/list_test.go
@@ -146,3 +146,61 @@ func TestResolveListResultFallsBackToDefaultWhenRepoIsNotConfiguredTenant(t *tes
 		t.Fatalf("unexpected effective target: %+v", result.CurrentDirectory.Effective)
 	}
 }
+
+func TestResolveListResultUsesEffectiveKubernetesContextForCurrentDirectoryTarget(t *testing.T) {
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalDir); err != nil {
+			t.Fatalf("restore working directory: %v", err)
+		}
+	})
+
+	repoRoot := filepath.Join(t.TempDir(), "tenant-a")
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	store := listStore{
+		openStore: openStore{
+			toolConfig: ERunConfig{DefaultTenant: "tenant-a"},
+			tenantConfigs: map[string]TenantConfig{
+				"tenant-a": {Name: "tenant-a", ProjectRoot: repoRoot, DefaultEnvironment: DefaultEnvironment},
+			},
+			envConfigs: map[string]EnvConfig{
+				"tenant-a/local": {Name: DefaultEnvironment, RepoPath: repoRoot, KubernetesContext: "rancher-desktop"},
+			},
+			resolveEffectiveKubernetesContext: func(environment, configured string) string {
+				if environment != DefaultEnvironment || configured != "rancher-desktop" {
+					t.Fatalf("unexpected resolver inputs: environment=%q configured=%q", environment, configured)
+				}
+				return "docker-desktop"
+			},
+		},
+		envsByTenant: map[string][]EnvConfig{
+			"tenant-a": {{Name: DefaultEnvironment, RepoPath: repoRoot, KubernetesContext: "rancher-desktop"}},
+		},
+	}
+
+	result, err := ResolveListResult(store, nil, OpenParams{
+		UseDefaultTenant:      true,
+		UseDefaultEnvironment: true,
+	})
+	if err != nil {
+		t.Fatalf("ResolveListResult failed: %v", err)
+	}
+	if result.CurrentDirectory.Effective == nil {
+		t.Fatalf("expected effective target, got %+v", result.CurrentDirectory)
+	}
+	if result.CurrentDirectory.Effective.KubernetesContext != "docker-desktop" {
+		t.Fatalf("unexpected effective kubernetes context: %+v", result.CurrentDirectory.Effective)
+	}
+	if got := result.Tenants[0].Environments[0].KubernetesContext; got != "rancher-desktop" {
+		t.Fatalf("expected configured tenant environment context to remain unchanged, got %q", got)
+	}
+}

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -23,14 +23,20 @@ var (
 	ErrEnvironmentNotFound             = errors.New("no such environment exists")
 	ErrKubernetesContextNotConfigured  = errors.New("kubernetes context is not configured")
 	ErrRepoPathNotConfigured           = errors.New("repo path is not configured")
+	ErrShellReattachDeploy             = errors.New("remote shell requested deploy handoff and reattach")
 )
 
 const defaultShellLaunchWaitTimeout = "2m0s"
+const remoteShellReattachDeployExitCode = 75
 
 type OpenStore interface {
 	LoadERunConfig() (ERunConfig, string, error)
 	LoadTenantConfig(string) (TenantConfig, string, error)
 	LoadEnvConfig(string, string) (EnvConfig, string, error)
+}
+
+type effectiveKubernetesContextResolver interface {
+	ResolveEffectiveKubernetesContext(environment, configured string) string
 }
 
 type OpenParams struct {
@@ -223,6 +229,9 @@ func ResolveOpen(store OpenStore, params OpenParams) (OpenResult, error) {
 	if envConfig.Name == "" {
 		envConfig.Name = environment
 	}
+	if resolver, ok := store.(effectiveKubernetesContextResolver); ok {
+		envConfig.KubernetesContext = resolver.ResolveEffectiveKubernetesContext(environment, envConfig.KubernetesContext)
+	}
 
 	repoPath := envConfig.RepoPath
 	if repoPath == "" {
@@ -288,6 +297,75 @@ func loadCurrentDirectoryTenant(store OpenStore) (string, bool, error) {
 	return "", false, nil
 }
 
+func resolveEffectiveKubernetesContext(environment, configured string, listContexts func() ([]string, error), currentContext func() (string, error)) string {
+	environment = strings.TrimSpace(environment)
+	configured = strings.TrimSpace(configured)
+	if configured == "" || environment != DefaultEnvironment {
+		return configured
+	}
+	if listContexts == nil || currentContext == nil {
+		return configured
+	}
+
+	contexts, err := listContexts()
+	if err != nil {
+		return configured
+	}
+	if containsTrimmedString(contexts, configured) {
+		return configured
+	}
+
+	current, err := currentContext()
+	if err != nil {
+		return configured
+	}
+	current = strings.TrimSpace(current)
+	if current == "" || !containsTrimmedString(contexts, current) {
+		return configured
+	}
+
+	return current
+}
+
+func listKubernetesContextNames() ([]string, error) {
+	output, err := exec.Command("kubectl", "config", "get-contexts", "-o=name").Output()
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(output), "\n")
+	contexts := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		contexts = append(contexts, line)
+	}
+	return contexts, nil
+}
+
+func currentKubernetesContextName() (string, error) {
+	output, err := exec.Command("kubectl", "config", "current-context").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func containsTrimmedString(values []string, target string) bool {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return false
+	}
+	for _, value := range values {
+		if strings.TrimSpace(value) == target {
+			return true
+		}
+	}
+	return false
+}
+
 func ShellLaunchParamsFromResult(result OpenResult) ShellLaunchParams {
 	return ShellLaunchParams{
 		Dir:               result.RepoPath,
@@ -325,7 +403,13 @@ func LaunchShell(req ShellLaunchParams) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		if isShellReattachDeployExit(err) {
+			return ErrShellReattachDeploy
+		}
+		return err
+	}
+	return nil
 }
 
 func PreviewShellLaunch(req ShellLaunchParams) (ShellLaunchPreview, error) {
@@ -420,9 +504,16 @@ func buildRemoteShellScript(req ShellLaunchParams, redactHostSecrets bool) (stri
 		fmt.Sprintf("cat > \"$config_home/erun/%s/config.yaml\" <<'EOF'\n%s\nEOF", req.Tenant, tenantYAML),
 		fmt.Sprintf("mkdir -p \"$config_home/erun/%s/%s\"", req.Tenant, req.Environment),
 		fmt.Sprintf("cat > \"$config_home/erun/%s/%s/config.yaml\" <<'EOF'\n%s\nEOF", req.Tenant, req.Environment, envYAML),
-		fmt.Sprintf("cat > \"$HOME/.erun_bashrc\" <<'EOF'\nexport ERUN_SHELL_HOST=%s\n[ -r /etc/bash.bashrc ] && . /etc/bash.bashrc\nEOF", title),
+		fmt.Sprintf("cat > \"$HOME/.erun_bashrc\" <<'EOF'\nexport ERUN_SHELL_HOST=%s\nerun() {\n  if [ \"${1:-}\" = \"deploy\" ] && [ \"$#\" -eq 1 ] && [ -n \"${ERUN_SHELL_REQUEST_FILE:-}\" ]; then\n    : > \"$ERUN_SHELL_REQUEST_FILE\"\n    exit 0\n  fi\n  command erun \"$@\"\n}\n[ -r /etc/bash.bashrc ] && . /etc/bash.bashrc\nEOF", title),
 		fmt.Sprintf("printf '\\033]0;%s\\007'", title),
-		"exec /bin/bash --rcfile \"$HOME/.erun_bashrc\" -i",
+		"request_file=\"$HOME/.erun-shell-request\"",
+		"rm -f \"$request_file\"",
+		"export ERUN_SHELL_REQUEST_FILE=\"$request_file\"",
+		"shell_status=0",
+		"/bin/bash --rcfile \"$HOME/.erun_bashrc\" -i || shell_status=$?",
+		fmt.Sprintf("if [ -e \"$request_file\" ]; then rm -f \"$request_file\"; exit %d; fi", remoteShellReattachDeployExitCode),
+		"rm -f \"$request_file\"",
+		"exit \"$shell_status\"",
 	}
 
 	if gitHost, gitUser, gitRepo, err := resolveGitRemote(req.Dir); err == nil {
@@ -488,6 +579,14 @@ func remoteWorktreeRepoName(req ShellLaunchParams) string {
 
 func shellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}
+
+func isShellReattachDeployExit(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	return exitErr.ExitCode() == remoteShellReattachDeployExitCode
 }
 
 func resolveGitRemote(repoPath string) (string, string, string, error) {

--- a/erun-common/open_test.go
+++ b/erun-common/open_test.go
@@ -2,6 +2,7 @@ package eruncommon
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -235,6 +236,83 @@ func TestOpenResolveRequiresKubernetesContextAssociation(t *testing.T) {
 	}
 }
 
+func TestResolveEffectiveKubernetesContextFallsBackToCurrentContextForLocalEnvironment(t *testing.T) {
+	got := resolveEffectiveKubernetesContext(
+		DefaultEnvironment,
+		"rancher-desktop",
+		func() ([]string, error) {
+			return []string{"docker-desktop"}, nil
+		},
+		func() (string, error) {
+			return "docker-desktop", nil
+		},
+	)
+	if got != "docker-desktop" {
+		t.Fatalf("expected current context fallback, got %q", got)
+	}
+}
+
+func TestResolveEffectiveKubernetesContextKeepsConfiguredContextOutsideLocalEnvironment(t *testing.T) {
+	listCalled := false
+	currentCalled := false
+
+	got := resolveEffectiveKubernetesContext(
+		"dev",
+		"cluster-dev",
+		func() ([]string, error) {
+			listCalled = true
+			return []string{"other-context"}, nil
+		},
+		func() (string, error) {
+			currentCalled = true
+			return "other-context", nil
+		},
+	)
+	if got != "cluster-dev" {
+		t.Fatalf("expected configured context to be preserved, got %q", got)
+	}
+	if listCalled || currentCalled {
+		t.Fatalf("did not expect kubectl lookup for non-local environment")
+	}
+}
+
+func TestOpenResolveUsesEffectiveKubernetesContextFromStore(t *testing.T) {
+	repoPath := t.TempDir()
+	store := openStore{
+		tenantConfigs: map[string]TenantConfig{
+			"tenant-a": {
+				Name:               "tenant-a",
+				ProjectRoot:        repoPath,
+				DefaultEnvironment: DefaultEnvironment,
+			},
+		},
+		envConfigs: map[string]EnvConfig{
+			"tenant-a/local": {
+				Name:              DefaultEnvironment,
+				RepoPath:          repoPath,
+				KubernetesContext: "rancher-desktop",
+			},
+		},
+		resolveEffectiveKubernetesContext: func(environment, configured string) string {
+			if environment != DefaultEnvironment || configured != "rancher-desktop" {
+				t.Fatalf("unexpected resolver inputs: environment=%q configured=%q", environment, configured)
+			}
+			return "docker-desktop"
+		},
+	}
+
+	result, err := ResolveOpen(store, OpenParams{
+		Tenant:      "tenant-a",
+		Environment: DefaultEnvironment,
+	})
+	if err != nil {
+		t.Fatalf("ResolveOpen failed: %v", err)
+	}
+	if result.EnvConfig.KubernetesContext != "docker-desktop" {
+		t.Fatalf("expected effective context override, got %+v", result.EnvConfig)
+	}
+}
+
 func TestOpenRunLaunchesShell(t *testing.T) {
 	repoPath := t.TempDir()
 	store := openStore{
@@ -301,10 +379,17 @@ func TestRemoteShellScriptSeedsConfigsAndCloneCommand(t *testing.T) {
 		"repopath: " + remoteWorkdir,
 		"kubernetescontext: in-cluster",
 		"cat > \"$HOME/.erun_bashrc\" <<'EOF'\nexport ERUN_SHELL_HOST='tenant-a-local'",
+		"if [ \"${1:-}\" = \"deploy\" ] && [ \"$#\" -eq 1 ] && [ -n \"${ERUN_SHELL_REQUEST_FILE:-}\" ]; then",
+		": > \"$ERUN_SHELL_REQUEST_FILE\"",
+		"exit 0",
 		"printf '\\033]0;'tenant-a-local'\\007'",
+		"request_file=\"$HOME/.erun-shell-request\"",
+		"export ERUN_SHELL_REQUEST_FILE=\"$request_file\"",
 		"IdentityFile ~/.ssh/keys",
 		"if command -v git >/dev/null 2>&1; then if [ ! -d .git ]; then git clone git@github.com:'sophium'/'erun'.git .; fi; git config --global --add safe.directory '*'; fi",
-		"exec /bin/bash --rcfile \"$HOME/.erun_bashrc\" -i",
+		"/bin/bash --rcfile \"$HOME/.erun_bashrc\" -i || shell_status=$?",
+		fmt.Sprintf("if [ -e \"$request_file\" ]; then rm -f \"$request_file\"; exit %d; fi", remoteShellReattachDeployExitCode),
+		"exit \"$shell_status\"",
 	} {
 		if !strings.Contains(script, pattern) {
 			t.Fatalf("expected script to contain %q, got:\n%s", pattern, script)
@@ -522,10 +607,11 @@ func extractHeredoc(t *testing.T, script, header string) string {
 }
 
 type openStore struct {
-	toolConfig    ERunConfig
-	loadERunErr   error
-	tenantConfigs map[string]TenantConfig
-	envConfigs    map[string]EnvConfig
+	toolConfig                        ERunConfig
+	loadERunErr                       error
+	tenantConfigs                     map[string]TenantConfig
+	envConfigs                        map[string]EnvConfig
+	resolveEffectiveKubernetesContext func(environment, configured string) string
 }
 
 func (s openStore) LoadERunConfig() (ERunConfig, string, error) {
@@ -549,6 +635,13 @@ func (s openStore) ListTenantConfigs() ([]TenantConfig, error) {
 		tenants = append(tenants, config)
 	}
 	return tenants, nil
+}
+
+func (s openStore) ResolveEffectiveKubernetesContext(environment, configured string) string {
+	if s.resolveEffectiveKubernetesContext == nil {
+		return configured
+	}
+	return s.resolveEffectiveKubernetesContext(environment, configured)
 }
 
 func (s openStore) LoadEnvConfig(tenant, environment string) (EnvConfig, string, error) {

--- a/erun-devops/k8s/erun-devops/Chart.yaml
+++ b/erun-devops/k8s/erun-devops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.18-pr.e13675d
+appVersion: 1.0.18-pr.445e790
 description: ERun DevOps
 name: erun-devops
 type: application
-version: 1.0.18-pr.e13675d
+version: 1.0.18-pr.445e790

--- a/erun-devops/k8s/erun-devops/Chart.yaml
+++ b/erun-devops/k8s/erun-devops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.17
+appVersion: 1.0.18-pr.4c037c4
 description: ERun DevOps
 name: erun-devops
 type: application
-version: 1.0.17
+version: 1.0.18-pr.4c037c4

--- a/erun-devops/k8s/erun-devops/Chart.yaml
+++ b/erun-devops/k8s/erun-devops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.18-pr.4c037c4
+appVersion: 1.0.18-pr.7feabdb
 description: ERun DevOps
 name: erun-devops
 type: application
-version: 1.0.18-pr.4c037c4
+version: 1.0.18-pr.7feabdb

--- a/erun-devops/k8s/erun-devops/Chart.yaml
+++ b/erun-devops/k8s/erun-devops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.18-pr.ec5e696
+appVersion: 1.0.18-pr.2f0d4ac
 description: ERun DevOps
 name: erun-devops
 type: application
-version: 1.0.18-pr.ec5e696
+version: 1.0.18-pr.2f0d4ac

--- a/erun-devops/k8s/erun-devops/Chart.yaml
+++ b/erun-devops/k8s/erun-devops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.18-pr.7feabdb
+appVersion: 1.0.18-pr.ec5e696
 description: ERun DevOps
 name: erun-devops
 type: application
-version: 1.0.18-pr.7feabdb
+version: 1.0.18-pr.ec5e696

--- a/erun-devops/k8s/erun-devops/Chart.yaml
+++ b/erun-devops/k8s/erun-devops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.18-pr.2f0d4ac
+appVersion: 1.0.18-pr.e13675d
 description: ERun DevOps
 name: erun-devops
 type: application
-version: 1.0.18-pr.2f0d4ac
+version: 1.0.18-pr.e13675d

--- a/erun-devops/k8s/erun-devops/templates/service.yaml
+++ b/erun-devops/k8s/erun-devops/templates/service.yaml
@@ -141,7 +141,7 @@ spec:
         - name: repo-worktree
           hostPath:
             path: {{ required "worktreeHostPath is required" .Values.worktreeHostPath | quote }}
-            type: Directory
+            type: DirectoryOrCreate
         - name: docker-socket
           emptyDir: {}
         - name: docker-state


### PR DESCRIPTION
## Summary
- fall back to the current kubectl context when the configured local context is missing for local environments
- canonicalize local worktree host paths, allow missing hostPath directories, and prompt to materialize a tenant runtime chart when one does not exist
- hand off in-pod `erun deploy` back to the host-side `erun open` process and reattach after the runtime rollout completes

## Root Cause
- local runtime resolution assumed the configured kubectl context still existed and assumed hostPath values were already canonical, so local deploys could fail after context changes or when the repo path was symlinked or absent on the node
- running `erun deploy` from inside the managed runtime shell upgraded the pod that owned the current shell without a coordinated handoff path

## Validation
- `go test ./...` in `erun-common`
- `go test ./...` in `erun-cli`
- `go test ./...` in `erun-mcp`

Closes #52
Closes #53
