### PR TITLE
Show progress while open waits for runtime deployment

### DIFF
--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), runInitForArgs func(common.Context, []string) error, promptRunner PromptRunner, launchShell common.ShellLauncherFunc, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
+func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), runInitForArgs func(common.Context, []string) error, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
 	var noShell bool
 
 	cmd := &cobra.Command{
@@ -30,7 +30,7 @@ func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), 
 			if initRan {
 				return nil
 			}
-			return runResolvedOpenCommand(ctx, result, openOptions{NoShell: noShell}, promptRunner, launchShell, runManagedDeploy, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart)
+			return runResolvedOpenCommand(ctx, result, openOptions{NoShell: noShell}, promptRunner, openShell, runManagedDeploy, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart)
 		},
 	}
 
@@ -85,7 +85,7 @@ func resolveOpenWithInitRetry(ctx common.Context, args []string, shouldRunInit f
 	return result, true, err
 }
 
-func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, launchShell common.ShellLauncherFunc, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) error {
+func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) error {
 	namespace := common.KubernetesNamespaceName(result.Tenant, result.Environment)
 	if options.NoShell {
 		ctx.TraceCommand("", "kubectl", "config", "use-context", strings.TrimSpace(result.EnvConfig.KubernetesContext))
@@ -128,7 +128,7 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 				func(ctx common.Context, pushInput common.DockerPushSpec) error {
 					return common.RunDockerPush(ctx, pushInput, common.DockerImagePusher)
 				},
-				deployHelmChart,
+				wrapOpenHelmDeployWithSpinner(ctx, execution.Deploy.ReleaseName, deployHelmChart),
 			); err != nil {
 				return err
 			}
@@ -152,7 +152,7 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 	}
 
 	for {
-		err := launchShell(shellReq)
+		err := openShell(ctx, shellReq)
 		if !errors.Is(err, common.ErrShellReattachDeploy) {
 			return err
 		}
@@ -162,6 +162,22 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 		if err := runManagedDeploy(ctx, result); err != nil {
 			return err
 		}
+	}
+}
+
+func wrapOpenHelmDeployWithSpinner(ctx common.Context, releaseName string, deployHelmChart common.HelmChartDeployerFunc) common.HelmChartDeployerFunc {
+	if deployHelmChart == nil {
+		return nil
+	}
+	return func(params common.HelmDeployParams) error {
+		return runWithSpinner(
+			ctx,
+			" deploying "+releaseName+" with helm",
+			"deployment updated: "+releaseName+"\n",
+			func() error {
+				return deployHelmChart(params)
+			},
+		)
 	}
 }
 

--- a/erun-cli/cmd/open_shell.go
+++ b/erun-cli/cmd/open_shell.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/briandowns/spinner"
+	common "github.com/sophium/erun/erun-common"
+	"golang.org/x/term"
+)
+
+type OpenShellRunner func(common.Context, common.ShellLaunchParams) error
+
+func newOpenShellRunner(waitForShellDeployment func(common.ShellLaunchParams) error, execShell common.ShellLauncherFunc) OpenShellRunner {
+	if waitForShellDeployment == nil {
+		waitForShellDeployment = common.WaitForShellDeployment
+	}
+	if execShell == nil {
+		execShell = common.ExecShell
+	}
+
+	return func(ctx common.Context, req common.ShellLaunchParams) error {
+		if err := runOpenShellWait(ctx, req, waitForShellDeployment); err != nil {
+			return err
+		}
+		return execShell(req)
+	}
+}
+
+func runOpenShellWait(ctx common.Context, req common.ShellLaunchParams, waitForShellDeployment func(common.ShellLaunchParams) error) error {
+	if waitForShellDeployment == nil {
+		return fmt.Errorf("wait for shell deployment is required")
+	}
+	return runWithSpinner(
+		ctx,
+		" waiting for "+common.RuntimeReleaseName(req.Tenant)+" in "+req.Namespace,
+		"deployment available: "+common.RuntimeReleaseName(req.Tenant)+"\n",
+		func() error {
+			return waitForShellDeployment(req)
+		},
+	)
+}
+
+func isTerminalWriter(w io.Writer) bool {
+	file, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(file.Fd()))
+}
+
+func runWithSpinner(ctx common.Context, suffix, finalMessage string, run func() error) error {
+	if run == nil {
+		return fmt.Errorf("run function is required")
+	}
+	if !isTerminalWriter(ctx.Stderr) {
+		return run()
+	}
+
+	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriter(ctx.Stderr))
+	s.Suffix = suffix
+	s.Start()
+
+	err := run()
+	if err == nil {
+		s.FinalMSG = finalMessage
+	}
+	s.Stop()
+	return err
+}

--- a/erun-cli/cmd/open_shell_test.go
+++ b/erun-cli/cmd/open_shell_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	common "github.com/sophium/erun/erun-common"
+)
+
+func TestNewOpenShellRunnerWaitsBeforeExec(t *testing.T) {
+	steps := []string{}
+	req := common.ShellLaunchParams{Tenant: "tenant-a", Namespace: "tenant-a-dev"}
+	run := newOpenShellRunner(
+		func(got common.ShellLaunchParams) error {
+			if !reflect.DeepEqual(got, req) {
+				t.Fatalf("unexpected wait request: %+v", got)
+			}
+			steps = append(steps, "wait")
+			return nil
+		},
+		func(got common.ShellLaunchParams) error {
+			if !reflect.DeepEqual(got, req) {
+				t.Fatalf("unexpected exec request: %+v", got)
+			}
+			steps = append(steps, "exec")
+			return nil
+		},
+	)
+
+	err := run(common.Context{Stderr: new(bytes.Buffer)}, req)
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !reflect.DeepEqual(steps, []string{"wait", "exec"}) {
+		t.Fatalf("unexpected call order: %#v", steps)
+	}
+}
+
+func TestNewOpenShellRunnerSkipsExecOnWaitError(t *testing.T) {
+	waitErr := common.ErrShellReattachDeploy
+	run := newOpenShellRunner(
+		func(common.ShellLaunchParams) error {
+			return waitErr
+		},
+		func(common.ShellLaunchParams) error {
+			t.Fatal("did not expect exec after wait failure")
+			return nil
+		},
+	)
+
+	err := run(common.Context{Stderr: new(bytes.Buffer)}, common.ShellLaunchParams{})
+	if err != waitErr {
+		t.Fatalf("expected %v, got %v", waitErr, err)
+	}
+}

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -60,7 +60,7 @@ func Execute() error {
 		resolveOpen,
 		runInitForArgs,
 		runPrompt,
-		common.LaunchShell,
+		newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell),
 		runManagedDeploy,
 		common.CheckKubernetesDeployment,
 		resolveRuntimeDeploySpec,
@@ -110,7 +110,7 @@ func Execute() error {
 		if initRan {
 			return nil
 		}
-		return runResolvedOpenCommand(ctx, result, openOptions{}, runPrompt, common.LaunchShell, runManagedDeploy, common.CheckKubernetesDeployment, resolveRuntimeDeploySpec, common.DeployHelmChart)
+		return runResolvedOpenCommand(ctx, result, openOptions{}, runPrompt, newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell), runManagedDeploy, common.CheckKubernetesDeployment, resolveRuntimeDeploySpec, common.DeployHelmChart)
 	}
 
 	cmd := newRootCommand(runRoot)

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -97,9 +97,11 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	if runGit == nil {
 		runGit = common.GitCommandRunner
 	}
-	launchShell := deps.LaunchShell
-	if launchShell == nil {
-		launchShell = common.LaunchShell
+	openShell := newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell)
+	if deps.LaunchShell != nil {
+		openShell = func(_ common.Context, req common.ShellLaunchParams) error {
+			return deps.LaunchShell(req)
+		}
 	}
 	now := deps.Now
 	if now == nil {
@@ -146,7 +148,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	runInitForArgs := newRunInitForArgs(store, runInit)
 
 	initCmd := newInitCmd(runInit)
-	openCmd := newOpenCmd(resolveOpen, runInitForArgs, promptRunner, launchShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
+	openCmd := newOpenCmd(resolveOpen, runInitForArgs, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
@@ -191,7 +193,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 		if initRan {
 			return nil
 		}
-		return runResolvedOpenCommand(ctx, result, openOptions{}, promptRunner, launchShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
+		return runResolvedOpenCommand(ctx, result, openOptions{}, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
 	}
 
 	cmd := newRootCommand(runRoot)

--- a/erun-cli/go.mod
+++ b/erun-cli/go.mod
@@ -4,18 +4,22 @@ go 1.25.5
 
 require (
 	github.com/adrg/xdg v0.5.3
+	github.com/briandowns/spinner v1.23.2
 	github.com/manifoldco/promptui v0.9.0
 	github.com/sophium/erun/erun-common v0.0.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/term v0.33.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	github.com/fatih/color v1.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/mattn/go-isatty v0.0.8 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/sys v0.40.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/sophium/erun/erun-common => ../erun-common

--- a/erun-cli/go.sum
+++ b/erun-cli/go.sum
@@ -1,5 +1,7 @@
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
+github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=
+github.com/briandowns/spinner v1.23.2/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
@@ -9,10 +11,16 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -24,6 +32,7 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
 golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.33.0 h1:NuFncQrRcaRvVmgRkvM3j/F00gWIAlcmlB8ACEKmGIg=

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -387,13 +387,20 @@ func LocalShellSetupScript(result OpenResult) string {
 }
 
 func LaunchShell(req ShellLaunchParams) error {
+	if err := WaitForShellDeployment(req); err != nil {
+		return err
+	}
+	return ExecShell(req)
+}
+
+func WaitForShellDeployment(req ShellLaunchParams) error {
 	waitCmd := exec.Command("kubectl", kubectlDeploymentWaitArgs(req)...)
 	waitCmd.Stdout = io.Discard
 	waitCmd.Stderr = os.Stderr
-	if err := waitCmd.Run(); err != nil {
-		return err
-	}
+	return waitCmd.Run()
+}
 
+func ExecShell(req ShellLaunchParams) error {
 	script, err := buildRemoteShellScript(req, false)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- add CLI spinner feedback while `erun open` is deploying the runtime with Helm
- keep terminal rendering in `erun-cli` while splitting shared shell launch into explicit wait and exec phases
- add focused tests for the new open shell runner wiring

## Why
`erun open` could spend noticeable time inside `helm upgrade --install --wait`, but the CLI looked idle during that blocking step.

## Impact
Users now get visible progress feedback while `open` is waiting on runtime deployment work, instead of only seeing output once Helm finishes.

## Root cause
The blocking time was primarily in the Helm deploy path, while progress indication had been attached to the later shell attach wait.

## Validation
- `cd erun-cli && go test ./...`
- `cd erun-mcp && go test ./...`
- `cd erun-common && go test ./... -run 'TestKubectlDeploymentWaitArgs|TestPreviewShellLaunchRedactsHostCredentialContents'`
- `cd erun-common && go test ./...` still has a pre-existing packaging failure because the formula targets `v1.0.17` while the latest stable tag is `v1.0.18`

Closes #57
