### PR TITLE
Persist tenant snapshot preference

### DIFF
--- a/erun-cli/cmd/deploy.go
+++ b/erun-cli/cmd/deploy.go
@@ -7,6 +7,8 @@ import (
 
 func newDeployCmd(store common.DeployStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, resolveDeployContext common.DeployContextResolverFunc, now common.NowFunc, buildDockerImage common.DockerImageBuilderFunc, push common.DockerPushFunc, deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
 	target := common.DeployTarget{}
+	var snapshot bool
+	var noSnapshot bool
 	cmd := &cobra.Command{
 		Use:           "deploy",
 		Short:         "Deploy the current Helm chart or all charts in the current devops k8s scope",
@@ -15,6 +17,11 @@ func newDeployCmd(store common.DeployStore, findProjectRoot common.ProjectFinder
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext(cmd)
+			snapshotOverride, err := resolveSnapshotFlagOverride(cmd, snapshot, noSnapshot)
+			if err != nil {
+				return err
+			}
+			target.Snapshot = snapshotOverride
 			deploySpecs, err := common.ResolveCurrentDeploySpecs(store, findProjectRoot, resolveBuildContext, resolveDeployContext, now, target)
 			if err != nil {
 				return err
@@ -23,12 +30,14 @@ func newDeployCmd(store common.DeployStore, findProjectRoot common.ProjectFinder
 		},
 	}
 	addDryRunFlag(cmd)
-	addDeployCommandTargetFlags(cmd, &target)
+	addDeployCommandTargetFlags(cmd, &target, &snapshot, &noSnapshot)
 	return cmd
 }
 
 func newK8sDeployCmd(store common.DeployStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, resolveDeployContext common.DeployContextResolverFunc, now common.NowFunc, buildDockerImage common.DockerImageBuilderFunc, push common.DockerPushFunc, deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
 	target := common.DeployTarget{}
+	var snapshot bool
+	var noSnapshot bool
 	cmd := &cobra.Command{
 		Use:           "deploy COMPONENT",
 		Short:         "Deploy a component Helm chart",
@@ -37,6 +46,11 @@ func newK8sDeployCmd(store common.DeployStore, findProjectRoot common.ProjectFin
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext(cmd)
+			snapshotOverride, err := resolveSnapshotFlagOverride(cmd, snapshot, noSnapshot)
+			if err != nil {
+				return err
+			}
+			target.Snapshot = snapshotOverride
 			deploySpec, err := common.ResolveDeploySpec(store, findProjectRoot, resolveBuildContext, resolveDeployContext, now, target, args[0], "")
 			if err != nil {
 				return err
@@ -45,12 +59,13 @@ func newK8sDeployCmd(store common.DeployStore, findProjectRoot common.ProjectFin
 		},
 	}
 	addDryRunFlag(cmd)
-	addDeployCommandTargetFlags(cmd, &target)
+	addDeployCommandTargetFlags(cmd, &target, &snapshot, &noSnapshot)
 	return cmd
 }
 
-func addDeployCommandTargetFlags(cmd *cobra.Command, target *common.DeployTarget) {
+func addDeployCommandTargetFlags(cmd *cobra.Command, target *common.DeployTarget, snapshot, noSnapshot *bool) {
 	cmd.Flags().StringVar(&target.VersionOverride, "version", "", "Override the deployed chart and image version")
+	addSnapshotFlags(cmd, snapshot, noSnapshot, "Build and deploy local snapshot images in the local environment")
 	cmd.Flags().StringVar(&target.Tenant, "tenant", "", "Tenant override for internal tooling")
 	cmd.Flags().StringVar(&target.Environment, "environment", "", "Environment override for internal tooling")
 	cmd.Flags().StringVar(&target.RepoPath, "repo-path", "", "Repo path override for internal tooling")

--- a/erun-cli/cmd/deploy_test.go
+++ b/erun-cli/cmd/deploy_test.go
@@ -698,6 +698,96 @@ func TestRootDeployShorthandDryRunPrintsBuildAndDeployCommandsWithoutExecuting(t
 	}
 }
 
+func TestRootDeployShorthandUsesPersistedSnapshotPreferenceForLocalEnvironment(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+	stubKubectlContexts(t, []string{"cluster-local"}, "cluster-local")
+
+	projectRoot := t.TempDir()
+	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
+	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("mkdir docker dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write module VERSION: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
+		t.Fatalf("write local VERSION: %v", err)
+	}
+
+	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
+		t.Fatalf("save erun config: %v", err)
+	}
+	snapshot := false
+	if err := common.SaveTenantConfig(common.TenantConfig{
+		Name:               "tenant-a",
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: "local",
+		Snapshot:           &snapshot,
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{
+		Name:              "local",
+		RepoPath:          projectRoot,
+		KubernetesContext: "cluster-local",
+	}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
+		t.Fatalf("save project config: %v", err)
+	}
+
+	stderr := new(bytes.Buffer)
+	cmd := newTestRootCmd(testRootDeps{
+		FindProjectRoot: func() (string, string, error) {
+			return "erun", projectRoot, nil
+		},
+		ResolveKubernetesDeployContext: func() (common.KubernetesDeployContext, error) {
+			return common.KubernetesDeployContext{
+				Dir:           workdir,
+				ComponentName: "erun-devops",
+				ChartPath:     chartPath,
+			}, nil
+		},
+		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
+			return common.DockerBuildContext{
+				Dir:            workdir,
+				DockerfilePath: filepath.Join(workdir, "Dockerfile"),
+			}, nil
+		},
+		BuildDockerImage: deployBuildCallFunc(func(req deployBuildCall) error {
+			t.Fatalf("unexpected build request during dry-run: %+v", req)
+			return nil
+		}),
+		PushDockerImage: deployPushCallFunc(func(req deployPushCall) error {
+			t.Fatalf("unexpected push request during dry-run: %+v", req)
+			return nil
+		}),
+		DeployHelmChart: func(req common.HelmDeployParams) error {
+			t.Fatalf("unexpected deploy request during dry-run: %+v", req)
+			return nil
+		},
+	})
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"deploy", "--dry-run", "-v"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	output := stderr.String()
+	if strings.Contains(output, "docker build -t") || strings.Contains(output, "docker push ") {
+		t.Fatalf("did not expect dry-run snapshot build or push, got %q", output)
+	}
+	if !strings.Contains(output, "helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace tenant-a-local --kube-context cluster-local -f "+filepath.Join(chartPath, "values.local.yaml")+" --set-string tenant=tenant-a --set-string environment=local") {
+		t.Fatalf("expected dry-run deploy trace, got %q", output)
+	}
+}
+
 func TestRootDeployShorthandBuildsAndPushesLiteralChartImageDependencies(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 

--- a/erun-cli/cmd/list.go
+++ b/erun-cli/cmd/list.go
@@ -89,6 +89,9 @@ func writeEffectiveOpen(ctx common.Context, current common.ListCurrentDirectoryR
 	if err := writeLabeledValue(ctx, "kubernetes context", current.Effective.KubernetesContext); err != nil {
 		return err
 	}
+	if err := writeLabeledValue(ctx, "snapshot", enabledDisabledLabel(current.Effective.Snapshot)); err != nil {
+		return err
+	}
 	return writeLabeledValue(ctx, "repo path", current.Effective.RepoPath)
 }
 
@@ -111,6 +114,9 @@ func writeTenantEntry(ctx common.Context, tenant common.ListTenantResult) error 
 		return err
 	}
 	if err := writeIndentedValue(ctx, 4, "default environment", tenant.DefaultEnvironment); err != nil {
+		return err
+	}
+	if err := writeIndentedValue(ctx, 4, "snapshot", enabledDisabledLabel(tenant.Snapshot)); err != nil {
 		return err
 	}
 
@@ -175,4 +181,11 @@ func configuredCurrentTenantOrNone(tenant string) string {
 		return "none"
 	}
 	return tenant
+}
+
+func enabledDisabledLabel(enabled bool) string {
+	if enabled {
+		return "on"
+	}
+	return "off"
 }

--- a/erun-cli/cmd/list_test.go
+++ b/erun-cli/cmd/list_test.go
@@ -80,12 +80,15 @@ func TestListCommandPrintsDefaultsAndConfiguredTenants(t *testing.T) {
 		"  configured tenant: none",
 		"  effective target: tenant-a/local",
 		"  kubernetes context: cluster-local",
+		"  snapshot: on",
 		"Tenants:",
 		"  tenant-a [default, effective]",
 		"    default environment: local",
+		"    snapshot: on",
 		"      - local [default, effective] context=cluster-local repo=" + tenantAPath,
 		"      - prod context=cluster-prod repo=" + tenantAPath,
 		"  tenant-b",
+		"    snapshot: on",
 		"      - dev [default] context=cluster-b repo=" + tenantBPath,
 	} {
 		if !strings.Contains(output, want) {
@@ -155,7 +158,9 @@ func TestListCommandUsesConfiguredCurrentDirectoryTenantBeforeDefault(t *testing
 		"  configured tenant: tenant-b",
 		"  effective target: tenant-b/dev",
 		"  kubernetes context: cluster-b",
+		"  snapshot: on",
 		"  tenant-b [effective]",
+		"    snapshot: on",
 		"      - dev [default, effective] context=cluster-b repo=" + tenantBPath,
 	} {
 		if !strings.Contains(output, want) {
@@ -203,6 +208,58 @@ func TestListCommandPrintsEmptyStateWhenNotInitialized(t *testing.T) {
 		"  effective target: unavailable (default tenant is not configured)",
 		"Tenants:",
 		"  none",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected list output to contain %q, got:\n%s", want, output)
+		}
+	}
+}
+
+func TestListCommandPrintsSnapshotPreference(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+	stubKubectlContexts(t, []string{"cluster-local"}, "cluster-local")
+
+	repoRoot := filepath.Join(t.TempDir(), "tenant-a")
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
+		t.Fatalf("save erun config: %v", err)
+	}
+	snapshot := false
+	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: repoRoot, DefaultEnvironment: "local", Snapshot: &snapshot}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "local", RepoPath: repoRoot, KubernetesContext: "cluster-local"}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(prevWD)
+	})
+
+	stdout := new(bytes.Buffer)
+	cmd := newTestRootCmd(testRootDeps{})
+	cmd.SetOut(stdout)
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{"list"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"  snapshot: off",
+		"    snapshot: off",
+		"      - local [default, effective] context=cluster-local repo=" + repoRoot,
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected list output to contain %q, got:\n%s", want, output)

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -13,8 +13,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), runInitForArgs func(common.Context, []string) error, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
+func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), saveTenantConfig func(common.TenantConfig) error, runInitForArgs func(common.Context, []string) error, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
 	var noShell bool
+	var snapshot bool
+	var noSnapshot bool
 
 	cmd := &cobra.Command{
 		Use:          "open [TENANT] [ENVIRONMENT]",
@@ -30,17 +32,41 @@ func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), 
 			if initRan {
 				return nil
 			}
+			snapshotOverride, err := resolveSnapshotFlagOverride(cmd, snapshot, noSnapshot)
+			if err != nil {
+				return err
+			}
+			result, err = applyOpenSnapshotPreference(result, snapshotOverride, saveTenantConfig)
+			if err != nil {
+				return err
+			}
 			return runResolvedOpenCommand(ctx, result, openOptions{NoShell: noShell}, promptRunner, openShell, runManagedDeploy, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart)
 		},
 	}
 
 	addDryRunFlag(cmd)
 	cmd.Flags().BoolVar(&noShell, "no-shell", false, "Print shell commands to switch kubectl context, namespace, and worktree locally")
+	addSnapshotFlags(cmd, &snapshot, &noSnapshot, "Build and deploy a local snapshot when opening the local environment")
 	return cmd
 }
 
 type openOptions struct {
 	NoShell bool
+}
+
+func applyOpenSnapshotPreference(result common.OpenResult, enabled *bool, saveTenantConfig func(common.TenantConfig) error) (common.OpenResult, error) {
+	if enabled == nil || !strings.EqualFold(strings.TrimSpace(result.Environment), common.DefaultEnvironment) {
+		return result, nil
+	}
+
+	result.TenantConfig.SetSnapshot(*enabled)
+	if saveTenantConfig == nil {
+		return result, nil
+	}
+	if err := saveTenantConfig(result.TenantConfig); err != nil {
+		return common.OpenResult{}, err
+	}
+	return result, nil
 }
 
 func resolveOpenArgs(args []string, resolveOpen func(common.OpenParams) (common.OpenResult, error)) (common.OpenParams, common.OpenResult, error) {

--- a/erun-cli/cmd/open_test.go
+++ b/erun-cli/cmd/open_test.go
@@ -350,6 +350,149 @@ func TestOpenCommandDryRunRedeploysWhenRuntimeHasLocalBuilds(t *testing.T) {
 	}
 }
 
+func TestOpenCommandPersistsSnapshotPreferenceForLocalEnvironment(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+	stubKubectlContexts(t, []string{"cluster-local"}, "cluster-local")
+
+	projectRoot := t.TempDir()
+	if err := common.SaveTenantConfig(common.TenantConfig{
+		Name:               "tenant-a",
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: common.DefaultEnvironment,
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{
+		Name:              common.DefaultEnvironment,
+		RepoPath:          projectRoot,
+		KubernetesContext: "cluster-local",
+	}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+
+	cmd := newTestRootCmd(testRootDeps{
+		Store: common.ConfigStore{},
+		CheckKubernetesDeployment: func(req common.KubernetesDeploymentCheckParams) (bool, error) {
+			return true, nil
+		},
+		LaunchShell: func(req common.ShellLaunchParams) error {
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"open", "tenant-a", common.DefaultEnvironment, "--snapshot=false"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	tenantConfig, _, err := common.LoadTenantConfig("tenant-a")
+	if err != nil {
+		t.Fatalf("LoadTenantConfig failed: %v", err)
+	}
+	if tenantConfig.Snapshot == nil || *tenantConfig.Snapshot {
+		t.Fatalf("expected snapshot preference to be saved as false, got %+v", tenantConfig)
+	}
+}
+
+func TestOpenCommandUsesPersistedSnapshotPreferenceForLocalEnvironment(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+	stubKubectlContexts(t, []string{"cluster-local"}, "cluster-local")
+
+	projectRoot := t.TempDir()
+	componentName := "tenant-a-devops"
+	componentRoot := filepath.Join(projectRoot, componentName)
+	chartPath := filepath.Join(componentRoot, "k8s", componentName)
+	if err := os.MkdirAll(chartPath, 0o755); err != nil {
+		t.Fatalf("mkdir chart dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: "+componentName+"\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write Chart.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644); err != nil {
+		t.Fatalf("write values.local.yaml: %v", err)
+	}
+	workdir := filepath.Join(componentRoot, "docker", componentName)
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("mkdir docker dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(componentRoot, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write module VERSION: %v", err)
+	}
+	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
+		t.Fatalf("save project config: %v", err)
+	}
+	snapshot := false
+	if err := common.SaveTenantConfig(common.TenantConfig{
+		Name:               "tenant-a",
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: common.DefaultEnvironment,
+		Snapshot:           &snapshot,
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{
+		Name:              common.DefaultEnvironment,
+		RepoPath:          projectRoot,
+		KubernetesContext: "cluster-local",
+	}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	checkedDeployment := false
+	cmd := newTestRootCmd(testRootDeps{
+		Store: common.ConfigStore{},
+		CheckKubernetesDeployment: func(req common.KubernetesDeploymentCheckParams) (bool, error) {
+			checkedDeployment = true
+			if req.Name != "tenant-a-devops" || req.Namespace != "tenant-a-local" || req.KubernetesContext != "cluster-local" {
+				t.Fatalf("unexpected deployment check: %+v", req)
+			}
+			return true, nil
+		},
+		DeployHelmChart: func(req common.HelmDeployParams) error {
+			t.Fatalf("did not expect runtime deployment during dry-run: %+v", req)
+			return nil
+		},
+		LaunchShell: func(req common.ShellLaunchParams) error {
+			t.Fatalf("did not expect remote shell launch during dry-run: %+v", req)
+			return nil
+		},
+	})
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"-v", "open", "tenant-a", common.DefaultEnvironment, "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if !checkedDeployment {
+		t.Fatal("expected deployment existence check when snapshot preference is disabled")
+	}
+
+	output := stderr.String()
+	for _, unwanted := range []string{
+		"docker build -t",
+		"docker push ",
+		"helm upgrade --install",
+	} {
+		if strings.Contains(output, unwanted) {
+			t.Fatalf("did not expect %q in dry-run output, got %q", unwanted, output)
+		}
+	}
+	for _, want := range []string{
+		"kubectl --context cluster-local --namespace tenant-a-local wait --for=condition=Available --timeout 2m0s deployment/tenant-a-devops",
+		"kubectl --context cluster-local --namespace tenant-a-local exec -it -c tenant-a-devops deployment/tenant-a-devops -- /bin/sh -lc '<bootstrap-script>'",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected dry-run output to contain %q, got %q", want, output)
+		}
+	}
+}
+
 func TestOpenCommandDryRunFallsBackToDefaultRuntimeChartWhenTenantRepoHasNoDevopsChart(t *testing.T) {
 	repoPath := t.TempDir()
 	stdout := new(bytes.Buffer)

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -58,6 +58,7 @@ func Execute() error {
 	initCmd := newInitCmd(runInit)
 	openCmd := newOpenCmd(
 		resolveOpen,
+		store.SaveTenantConfig,
 		runInitForArgs,
 		runPrompt,
 		newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell),

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -148,7 +148,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	runInitForArgs := newRunInitForArgs(store, runInit)
 
 	initCmd := newInitCmd(runInit)
-	openCmd := newOpenCmd(resolveOpen, runInitForArgs, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
+	openCmd := newOpenCmd(resolveOpen, store.SaveTenantConfig, runInitForArgs, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",

--- a/erun-cli/cmd/snapshot_flags.go
+++ b/erun-cli/cmd/snapshot_flags.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	snapshotFlagName   = "snapshot"
+	noSnapshotFlagName = "no-snapshot"
+)
+
+func addSnapshotFlags(cmd *cobra.Command, snapshot, noSnapshot *bool, usage string) {
+	if cmd == nil {
+		return
+	}
+	cmd.Flags().BoolVar(snapshot, snapshotFlagName, true, usage)
+	cmd.Flags().BoolVar(noSnapshot, noSnapshotFlagName, false, "Alias for --snapshot=false")
+}
+
+func resolveSnapshotFlagOverride(cmd *cobra.Command, snapshot, noSnapshot bool) (*bool, error) {
+	if cmd == nil {
+		return nil, nil
+	}
+
+	snapshotFlag := cmd.Flags().Lookup(snapshotFlagName)
+	noSnapshotFlag := cmd.Flags().Lookup(noSnapshotFlagName)
+	snapshotChanged := snapshotFlag != nil && snapshotFlag.Changed
+	noSnapshotChanged := noSnapshotFlag != nil && noSnapshotFlag.Changed
+	if !snapshotChanged && !noSnapshotChanged {
+		return nil, nil
+	}
+
+	value := snapshot
+	if noSnapshotChanged {
+		inverted := !noSnapshot
+		if snapshotChanged && value != inverted {
+			return nil, fmt.Errorf("cannot use --%s and --%s with conflicting values", snapshotFlagName, noSnapshotFlagName)
+		}
+		value = inverted
+	}
+	return &value, nil
+}

--- a/erun-cli/cmd/snapshot_flags_test.go
+++ b/erun-cli/cmd/snapshot_flags_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestResolveSnapshotFlagOverride(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    *bool
+		wantErr string
+	}{
+		{name: "unchanged", args: nil},
+		{name: "snapshot false", args: []string{"--snapshot=false"}, want: boolPtr(false)},
+		{name: "snapshot true", args: []string{"--snapshot"}, want: boolPtr(true)},
+		{name: "no snapshot", args: []string{"--no-snapshot"}, want: boolPtr(false)},
+		{name: "no snapshot false", args: []string{"--no-snapshot=false"}, want: boolPtr(true)},
+		{name: "same false via both flags", args: []string{"--snapshot=false", "--no-snapshot"}, want: boolPtr(false)},
+		{name: "conflict", args: []string{"--snapshot", "--no-snapshot"}, wantErr: "cannot use --snapshot and --no-snapshot with conflicting values"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var snapshot bool
+			var noSnapshot bool
+			cmd := &cobra.Command{Use: "test"}
+			addSnapshotFlags(cmd, &snapshot, &noSnapshot, "test usage")
+			if err := cmd.Flags().Parse(tt.args); err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+			got, err := resolveSnapshotFlagOverride(cmd, snapshot, noSnapshot)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("expected error %q, got %v", tt.wantErr, err)
+				}
+			} else if err != nil {
+				t.Fatalf("resolveSnapshotFlagOverride failed: %v", err)
+			}
+			if !equalBoolPointer(got, tt.want) {
+				t.Fatalf("unexpected override: got=%v want=%v", got, tt.want)
+			}
+		})
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func equalBoolPointer(left, right *bool) bool {
+	switch {
+	case left == nil && right == nil:
+		return true
+	case left == nil || right == nil:
+		return false
+	default:
+		return *left == *right
+	}
+}

--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -25,6 +25,7 @@ type TenantConfig struct {
 	ProjectRoot        string
 	Name               string
 	DefaultEnvironment string
+	Snapshot           *bool `yaml:"snapshot,omitempty"`
 }
 
 type EnvConfig struct {
@@ -32,6 +33,37 @@ type EnvConfig struct {
 	RepoPath          string
 	KubernetesContext string
 	ContainerRegistry string
+	Snapshot          *bool `yaml:"snapshot,omitempty"`
+}
+
+func (c TenantConfig) SnapshotEnabled() bool {
+	if c.Snapshot == nil {
+		return true
+	}
+	return *c.Snapshot
+}
+
+func (c *TenantConfig) SetSnapshot(enabled bool) {
+	if c == nil {
+		return
+	}
+	value := enabled
+	c.Snapshot = &value
+}
+
+func (c EnvConfig) SnapshotEnabled() bool {
+	if c.Snapshot == nil {
+		return true
+	}
+	return *c.Snapshot
+}
+
+func (c *EnvConfig) SetSnapshot(enabled bool) {
+	if c == nil {
+		return
+	}
+	value := enabled
+	c.Snapshot = &value
 }
 
 type ProjectEnvironmentConfig struct {

--- a/erun-common/config_test.go
+++ b/erun-common/config_test.go
@@ -127,7 +127,8 @@ func TestSaveERunConfigWriteFailure(t *testing.T) {
 func TestTenantConfigRoundTrip(t *testing.T) {
 	setupConfigTestXDGConfigHome(t)
 
-	cfg := TenantConfig{ProjectRoot: "/tmp/project", Name: "tenant-a", DefaultEnvironment: "dev"}
+	snapshot := false
+	cfg := TenantConfig{ProjectRoot: "/tmp/project", Name: "tenant-a", DefaultEnvironment: "dev", Snapshot: &snapshot}
 	if err := SaveTenantConfig(cfg); err != nil {
 		t.Fatalf("SaveTenantConfig failed: %v", err)
 	}
@@ -137,7 +138,7 @@ func TestTenantConfigRoundTrip(t *testing.T) {
 		t.Fatalf("LoadTenantConfig failed: %v", err)
 	}
 
-	if loaded != cfg {
+	if !reflect.DeepEqual(loaded, cfg) {
 		t.Fatalf("unexpected tenant config: %+v", loaded)
 	}
 }
@@ -303,7 +304,7 @@ func TestEnvConfigRoundTrip(t *testing.T) {
 		t.Fatalf("LoadEnvConfig failed: %v", err)
 	}
 
-	if loaded != cfg {
+	if !reflect.DeepEqual(loaded, cfg) {
 		t.Fatalf("unexpected env config: %+v", loaded)
 	}
 }

--- a/erun-common/default_devops_chart.go
+++ b/erun-common/default_devops_chart.go
@@ -81,8 +81,12 @@ func renderDefaultDevopsChartTemplate(assetPath, moduleName string, data []byte)
 }
 
 func resolveOpenRuntimeDeploySpec(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult) (DeploySpec, error) {
+	allowLocalBuilds := target.TenantConfig.SnapshotEnabled()
+	if target.TenantConfig.Snapshot == nil {
+		allowLocalBuilds = target.EnvConfig.SnapshotEnabled()
+	}
 	for _, componentName := range openRuntimeComponentNames(target.Tenant) {
-		spec, err := ResolveDeploySpecForOpenResult(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target, componentName, "")
+		spec, err := resolveDeploySpecForOpenResult(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target, componentName, "", allowLocalBuilds)
 		if err == nil {
 			spec.Deploy.ReleaseName = RuntimeReleaseName(target.Tenant)
 			return spec, nil

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -75,6 +75,7 @@ type DeployTarget struct {
 	Environment     string
 	RepoPath        string
 	VersionOverride string
+	Snapshot        *bool
 }
 
 type DeploySpec struct {
@@ -132,7 +133,7 @@ func ResolveDeploySpec(store DeployStore, findProjectRoot ProjectFinderFunc, res
 	if err != nil {
 		return DeploySpec{}, err
 	}
-	return ResolveDeploySpecForOpenResult(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, resolvedTarget, componentName, versionOverride)
+	return resolveDeploySpecForOpenResult(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, resolvedTarget, componentName, versionOverride, deployTargetSnapshotEnabled(resolvedTarget, target.Snapshot))
 }
 
 func ResolveCurrentDeploySpecs(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target DeployTarget) ([]DeploySpec, error) {
@@ -149,8 +150,9 @@ func ResolveCurrentDeploySpecs(store DeployStore, findProjectRoot ProjectFinderF
 	}
 
 	specs := make([]DeploySpec, 0, len(deployContexts))
+	allowLocalBuilds := deployTargetSnapshotEnabled(resolvedTarget, target.Snapshot)
 	for _, deployContext := range deployContexts {
-		spec, err := resolveDeploySpecForContext(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, resolvedTarget, deployContext, target.VersionOverride)
+		spec, err := resolveDeploySpecForContext(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, resolvedTarget, deployContext, target.VersionOverride, allowLocalBuilds)
 		if err != nil {
 			return nil, err
 		}
@@ -161,6 +163,10 @@ func ResolveCurrentDeploySpecs(store DeployStore, findProjectRoot ProjectFinderF
 }
 
 func ResolveDeploySpecForOpenResult(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, componentName, versionOverride string) (DeploySpec, error) {
+	return resolveDeploySpecForOpenResult(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target, componentName, versionOverride, true)
+}
+
+func resolveDeploySpecForOpenResult(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, componentName, versionOverride string, allowLocalBuilds bool) (DeploySpec, error) {
 	store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now = normalizeDeployDependencies(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now)
 
 	deployContext, err := resolveDeployContextForTarget(findProjectRoot, resolveKubernetesDeployContext, target, componentName)
@@ -168,14 +174,14 @@ func ResolveDeploySpecForOpenResult(store DeployStore, findProjectRoot ProjectFi
 		return DeploySpec{}, err
 	}
 
-	return resolveDeploySpecForContext(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target, deployContext, versionOverride)
+	return resolveDeploySpecForContext(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target, deployContext, versionOverride, allowLocalBuilds)
 }
 
-func resolveDeploySpecForContext(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, deployContext KubernetesDeployContext, versionOverride string) (DeploySpec, error) {
+func resolveDeploySpecForContext(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, deployContext KubernetesDeployContext, versionOverride string, allowLocalBuilds bool) (DeploySpec, error) {
 	store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now = normalizeDeployDependencies(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now)
 
 	builds := make([]DockerBuildSpec, 0, 2)
-	if strings.TrimSpace(versionOverride) == "" {
+	if allowLocalBuilds && strings.TrimSpace(versionOverride) == "" {
 		buildInput, err := ResolveDockerBuildForComponent(store, findProjectRoot, resolveDockerBuildContext, now, target.RepoPath, target.Environment, deployContext.ComponentName, "")
 		if err != nil {
 			return DeploySpec{}, err
@@ -362,6 +368,16 @@ func resolveDeployVersionOverride(target DeployTarget, versionOverride string) s
 		return versionOverride
 	}
 	return strings.TrimSpace(target.VersionOverride)
+}
+
+func deployTargetSnapshotEnabled(target OpenResult, override *bool) bool {
+	if override != nil {
+		return *override
+	}
+	if target.TenantConfig.Snapshot != nil {
+		return target.TenantConfig.SnapshotEnabled()
+	}
+	return target.EnvConfig.SnapshotEnabled()
 }
 
 func resolveDeployContextForTarget(findProjectRoot ProjectFinderFunc, resolveKubernetesDeployContext DeployContextResolverFunc, target OpenResult, componentName string) (KubernetesDeployContext, error) {

--- a/erun-common/deploy_test.go
+++ b/erun-common/deploy_test.go
@@ -241,6 +241,81 @@ func TestResolveOpenRuntimeDeploySpecUsesTenantSpecificComponentBeforeSharedDefa
 	}
 }
 
+func TestResolveOpenRuntimeDeploySpecSkipsLocalBuildsWhenSnapshotDisabled(t *testing.T) {
+	projectRoot := t.TempDir()
+	createComponentHelmChartFixture(t, projectRoot, "frs-devops")
+	workdir := filepath.Join(projectRoot, "frs-devops", "docker", "frs-devops")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("mkdir docker dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, "frs-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write module VERSION: %v", err)
+	}
+	if err := SaveProjectConfig(projectRoot, ProjectConfig{ContainerRegistry: "erunpaas"}); err != nil {
+		t.Fatalf("save project config: %v", err)
+	}
+
+	snapshot := false
+	spec, err := ResolveOpenRuntimeDeploySpec(ConfigStore{}, FindProjectRoot, ResolveDockerBuildContext, ResolveKubernetesDeployContext, nil, OpenResult{
+		Tenant:      "frs",
+		Environment: DefaultEnvironment,
+		RepoPath:    projectRoot,
+		TenantConfig: TenantConfig{
+			Snapshot: &snapshot,
+		},
+		EnvConfig: EnvConfig{
+			KubernetesContext: "cluster-local",
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveOpenRuntimeDeploySpec failed: %v", err)
+	}
+	if len(spec.Builds) != 0 {
+		t.Fatalf("expected local runtime builds to be skipped, got %+v", spec.Builds)
+	}
+	if spec.Deploy.Version != "" {
+		t.Fatalf("expected deploy version override to remain empty, got %+v", spec.Deploy)
+	}
+}
+
+func TestResolveOpenRuntimeDeploySpecFallsBackToLegacyEnvironmentSnapshotSetting(t *testing.T) {
+	projectRoot := t.TempDir()
+	createComponentHelmChartFixture(t, projectRoot, "frs-devops")
+	workdir := filepath.Join(projectRoot, "frs-devops", "docker", "frs-devops")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("mkdir docker dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, "frs-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write module VERSION: %v", err)
+	}
+	if err := SaveProjectConfig(projectRoot, ProjectConfig{ContainerRegistry: "erunpaas"}); err != nil {
+		t.Fatalf("save project config: %v", err)
+	}
+
+	snapshot := false
+	spec, err := ResolveOpenRuntimeDeploySpec(ConfigStore{}, FindProjectRoot, ResolveDockerBuildContext, ResolveKubernetesDeployContext, nil, OpenResult{
+		Tenant:      "frs",
+		Environment: DefaultEnvironment,
+		RepoPath:    projectRoot,
+		EnvConfig: EnvConfig{
+			KubernetesContext: "cluster-local",
+			Snapshot:          &snapshot,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveOpenRuntimeDeploySpec failed: %v", err)
+	}
+	if len(spec.Builds) != 0 {
+		t.Fatalf("expected legacy environment snapshot setting to skip builds, got %+v", spec.Builds)
+	}
+}
+
 func TestResolveOpenRuntimeDeploySpecFallsBackToEmbeddedDefaultChart(t *testing.T) {
 	projectRoot := t.TempDir()
 

--- a/erun-common/list.go
+++ b/erun-common/list.go
@@ -37,12 +37,14 @@ type ListEffectiveTargetResult struct {
 	Environment       string `json:"environment"`
 	KubernetesContext string `json:"kubernetesContext"`
 	RepoPath          string `json:"repoPath"`
+	Snapshot          bool   `json:"snapshot"`
 }
 
 type ListTenantResult struct {
 	Name               string                  `json:"name"`
 	ProjectRoot        string                  `json:"projectRoot,omitempty"`
 	DefaultEnvironment string                  `json:"defaultEnvironment,omitempty"`
+	Snapshot           bool                    `json:"snapshot,omitempty"`
 	IsDefault          bool                    `json:"isDefault,omitempty"`
 	IsEffective        bool                    `json:"isEffective,omitempty"`
 	Environments       []ListEnvironmentResult `json:"environments,omitempty"`
@@ -96,6 +98,7 @@ func ResolveListResult(store ListStore, findProjectRoot ProjectFinderFunc, param
 			Environment:       effectiveResult.Environment,
 			KubernetesContext: strings.TrimSpace(effectiveResult.EnvConfig.KubernetesContext),
 			RepoPath:          effectiveResult.RepoPath,
+			Snapshot:          deployTargetSnapshotEnabled(effectiveResult, nil),
 		}
 	}
 
@@ -109,6 +112,7 @@ func ResolveListResult(store ListStore, findProjectRoot ProjectFinderFunc, param
 			Name:               tenant.Name,
 			ProjectRoot:        tenant.ProjectRoot,
 			DefaultEnvironment: tenant.DefaultEnvironment,
+			Snapshot:           tenant.SnapshotEnabled(),
 			IsDefault:          tenant.Name == defaultTenant,
 			IsEffective:        effectiveErr == nil && tenant.Name == effectiveResult.Tenant,
 			Environments:       make([]ListEnvironmentResult, 0, len(envs)),

--- a/erun-common/list_test.go
+++ b/erun-common/list_test.go
@@ -82,6 +82,9 @@ func TestResolveListResultUsesCurrentDirectoryTenantBeforeDefault(t *testing.T) 
 	if result.CurrentDirectory.Effective.Tenant != "tenant-b" || result.CurrentDirectory.Effective.Environment != "dev" {
 		t.Fatalf("unexpected effective target: %+v", result.CurrentDirectory.Effective)
 	}
+	if !result.CurrentDirectory.Effective.Snapshot {
+		t.Fatalf("expected effective snapshot to default on, got %+v", result.CurrentDirectory.Effective)
+	}
 	if len(result.Tenants) != 2 {
 		t.Fatalf("unexpected tenants: %+v", result.Tenants)
 	}
@@ -145,6 +148,9 @@ func TestResolveListResultFallsBackToDefaultWhenRepoIsNotConfiguredTenant(t *tes
 	if result.CurrentDirectory.Effective.Tenant != "tenant-a" || result.CurrentDirectory.Effective.Environment != "dev" {
 		t.Fatalf("unexpected effective target: %+v", result.CurrentDirectory.Effective)
 	}
+	if !result.CurrentDirectory.Effective.Snapshot {
+		t.Fatalf("expected effective snapshot to default on, got %+v", result.CurrentDirectory.Effective)
+	}
 }
 
 func TestResolveListResultUsesEffectiveKubernetesContextForCurrentDirectoryTarget(t *testing.T) {
@@ -200,7 +206,48 @@ func TestResolveListResultUsesEffectiveKubernetesContextForCurrentDirectoryTarge
 	if result.CurrentDirectory.Effective.KubernetesContext != "docker-desktop" {
 		t.Fatalf("unexpected effective kubernetes context: %+v", result.CurrentDirectory.Effective)
 	}
+	if !result.CurrentDirectory.Effective.Snapshot {
+		t.Fatalf("expected effective snapshot to default on, got %+v", result.CurrentDirectory.Effective)
+	}
 	if got := result.Tenants[0].Environments[0].KubernetesContext; got != "rancher-desktop" {
 		t.Fatalf("expected configured tenant environment context to remain unchanged, got %q", got)
+	}
+}
+
+func TestResolveListResultIncludesSnapshotPreferenceForTenant(t *testing.T) {
+	repoRoot := filepath.Join(t.TempDir(), "tenant-a")
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	snapshot := false
+	store := listStore{
+		openStore: openStore{
+			toolConfig: ERunConfig{DefaultTenant: "tenant-a"},
+			tenantConfigs: map[string]TenantConfig{
+				"tenant-a": {Name: "tenant-a", ProjectRoot: repoRoot, DefaultEnvironment: DefaultEnvironment, Snapshot: &snapshot},
+			},
+			envConfigs: map[string]EnvConfig{
+				"tenant-a/local": {Name: DefaultEnvironment, RepoPath: repoRoot, KubernetesContext: "cluster-local"},
+			},
+		},
+		envsByTenant: map[string][]EnvConfig{
+			"tenant-a": {{Name: DefaultEnvironment, RepoPath: repoRoot, KubernetesContext: "cluster-local"}},
+		},
+	}
+
+	result, err := ResolveListResult(store, func() (string, string, error) {
+		return "tenant-a", repoRoot, nil
+	}, OpenParams{
+		UseDefaultTenant:      true,
+		UseDefaultEnvironment: true,
+	})
+	if err != nil {
+		t.Fatalf("ResolveListResult failed: %v", err)
+	}
+	if result.CurrentDirectory.Effective == nil || result.CurrentDirectory.Effective.Snapshot {
+		t.Fatalf("expected effective snapshot off, got %+v", result.CurrentDirectory.Effective)
+	}
+	if len(result.Tenants) != 1 || len(result.Tenants[0].Environments) != 1 || result.Tenants[0].Snapshot {
+		t.Fatalf("expected environment snapshot off, got %+v", result.Tenants)
 	}
 }

--- a/erun-mcp/deploy.go
+++ b/erun-mcp/deploy.go
@@ -12,6 +12,7 @@ import (
 type DeployInput struct {
 	Component string `json:"component,omitempty" jsonschema:"component name for the devops k8s deploy COMPONENT command"`
 	Version   string `json:"version,omitempty" jsonschema:"optional explicit version override for the deployed chart"`
+	Snapshot  *bool  `json:"snapshot,omitempty" jsonschema:"optional local snapshot override; when false, skips local snapshot builds in the local environment"`
 	Preview   bool   `json:"preview,omitempty" jsonschema:"when true, resolve and print the planned actions without executing them"`
 	Verbosity int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
 }
@@ -39,6 +40,7 @@ func deployTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReques
 				Environment:     strings.TrimSpace(runtime.Context.Environment),
 				RepoPath:        workDir,
 				VersionOverride: strings.TrimSpace(input.Version),
+				Snapshot:        input.Snapshot,
 			}, component, strings.TrimSpace(input.Version))
 			if err != nil {
 				return err


### PR DESCRIPTION
Closes #59

## What changed
- persist snapshot preference on tenant config instead of environment config
- make `open` and `deploy` honor the same tenant-level snapshot setting
- add `--snapshot` and `--no-snapshot` overrides for the relevant CLI deploy/open flows
- surface snapshot state in `erun list`
- expose deploy snapshot override in MCP and keep compatibility with older environment-level snapshot values during transition

## Why
Snapshot behavior needed to be consistent across open and deploy, and the setting is tenant-scoped rather than environment-scoped.

## Impact
Users can disable snapshot behavior once per tenant and see the effective setting in list output, while still overriding it explicitly per command when needed.

## Validation
- `go test ./cmd ./internal ./...` in `erun-cli`
- targeted `erun-common` snapshot/list/config tests
- `go test ./...` in `erun-mcp`
- full `go test ./...` in `erun-common` still has the pre-existing packaging metadata failure against `v1.0.18`
