### PR TITLE
Improve remote init and runtime shell handling

### DIFF
--- a/erun-cli/cmd/build_test.go
+++ b/erun-cli/cmd/build_test.go
@@ -1549,6 +1549,9 @@ func TestRootPushShorthandDryRunPrintsCommandWithoutExecuting(t *testing.T) {
 	if !bytes.Contains([]byte(got), []byte("docker build -t erunpaas/erun-devops:1.1.0")) {
 		t.Fatalf("expected dry-run build trace output, got %q", got)
 	}
+	if !bytes.Contains([]byte(got), []byte("--build-arg ERUN_VERSION=1.1.0")) {
+		t.Fatalf("expected dry-run build arg output, got %q", got)
+	}
 	if !bytes.Contains([]byte(got), []byte("docker push erunpaas/erun-devops:1.1.0")) {
 		t.Fatalf("expected dry-run trace output, got %q", got)
 	}

--- a/erun-cli/cmd/init.go
+++ b/erun-cli/cmd/init.go
@@ -20,14 +20,23 @@ func newInitCmd(runInit func(common.Context, common.BootstrapInitParams) error) 
 	params := common.BootstrapInitParams{}
 
 	cmd := &cobra.Command{
-		Use:          "init",
+		Use:          "init [TENANT] [ENVIRONMENT]",
 		Short:        "Initialize configuration for the current project",
-		Args:         cobra.MaximumNArgs(1),
+		Args:         cobra.MaximumNArgs(2),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runParams := params
 			if runParams.Tenant == "" && len(args) > 0 {
 				runParams.Tenant = args[0]
+			}
+			if runParams.Environment == "" && len(args) > 1 {
+				runParams.Environment = args[1]
+			}
+			if runParams.Remote && runParams.Tenant == "" {
+				return fmt.Errorf("tenant is required with --remote")
+			}
+			if runParams.Remote && strings.TrimSpace(runParams.Environment) == "" {
+				return fmt.Errorf("environment is required with --remote")
 			}
 			return runInit(commandContext(cmd), runParams)
 		},
@@ -36,8 +45,10 @@ func newInitCmd(runInit func(common.Context, common.BootstrapInitParams) error) 
 	cmd.Flags().StringVar(&params.Tenant, "tenant", "", "Tenant name to initialize")
 	cmd.Flags().StringVar(&params.ProjectRoot, "project-root", "", "Project root to bind to the tenant")
 	cmd.Flags().StringVar(&params.Environment, "environment", "", "Environment name")
+	cmd.Flags().StringVar(&params.RuntimeVersion, "version", "", "Runtime image version to initialize and deploy")
 	cmd.Flags().StringVar(&params.KubernetesContext, "kubernetes-context", "", "Kubernetes context to associate with the environment")
 	cmd.Flags().StringVar(&params.ContainerRegistry, "container-registry", "", "Container registry to associate with the environment")
+	cmd.Flags().BoolVar(&params.Remote, "remote", false, "Initialize the tenant repository inside the runtime pod instead of the local host")
 	cmd.Flags().BoolVarP(&params.AutoApprove, "yes", "y", false, "Automatically approve initialization prompts")
 	addDryRunFlag(cmd)
 	return cmd
@@ -65,6 +76,24 @@ func containerRegistryPrompt(run PromptRunner, label string) (string, error) {
 		return common.DefaultContainerRegistry, nil
 	}
 	return result, nil
+}
+
+func remoteRepositoryURLPrompt(run PromptRunner, label string) (string, error) {
+	prompt := promptui.Prompt{
+		Label: label,
+		Validate: func(input string) error {
+			if strings.TrimSpace(input) == "" {
+				return fmt.Errorf("repository remote URL is required")
+			}
+			return nil
+		},
+	}
+
+	result, err := run(prompt)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result), nil
 }
 
 func confirmPrompt(run PromptRunner, label string) (bool, error) {

--- a/erun-cli/cmd/init_test.go
+++ b/erun-cli/cmd/init_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/adrg/xdg"
@@ -307,5 +308,70 @@ exit 1
 
 	if err := ensureKubernetesNamespace("cluster-local", "tenant-a-local"); err != nil {
 		t.Fatalf("ensureKubernetesNamespace failed: %v", err)
+	}
+}
+
+func TestInitCommandRemoteRequiresEnvironment(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+
+	cmd := newTestRootCmd(testRootDeps{})
+	cmd.SetArgs([]string{"init", "--remote", "--tenant", "frs"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "environment is required with --remote") {
+		t.Fatalf("expected remote environment validation error, got %v", err)
+	}
+}
+
+func TestInitCommandMapsPositionalTenantAndEnvironmentArgs(t *testing.T) {
+	var got common.BootstrapInitParams
+	cmd := newInitCmd(func(_ common.Context, params common.BootstrapInitParams) error {
+		got = params
+		return nil
+	})
+	cmd.SetArgs([]string{"erun", "rtest"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if got.Tenant != "erun" || got.Environment != "rtest" {
+		t.Fatalf("unexpected init params: %+v", got)
+	}
+}
+
+func TestInitCommandHelpShowsPositionalTenantAndEnvironment(t *testing.T) {
+	cmd := newInitCmd(func(common.Context, common.BootstrapInitParams) error {
+		t.Fatal("did not expect init execution")
+		return nil
+	})
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	output := stdout.String() + stderr.String()
+	if !strings.Contains(output, "Usage:\n  init [TENANT] [ENVIRONMENT] [flags]") {
+		t.Fatalf("unexpected help output: %q", output)
+	}
+}
+
+func TestInitCommandAcceptsRuntimeVersionOverride(t *testing.T) {
+	var got common.BootstrapInitParams
+	cmd := newInitCmd(func(_ common.Context, params common.BootstrapInitParams) error {
+		got = params
+		return nil
+	})
+	cmd.SetArgs([]string{"erun", "local", "--version", "1.0.19-snapshot-20260418141901"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if got.RuntimeVersion != "1.0.19-snapshot-20260418141901" {
+		t.Fatalf("unexpected init params: %+v", got)
 	}
 }

--- a/erun-cli/cmd/list.go
+++ b/erun-cli/cmd/list.go
@@ -34,6 +34,13 @@ func runListCommand(ctx common.Context, store common.ListStore, findProjectRoot 
 }
 
 func writeListResult(ctx common.Context, result common.ListResult) error {
+	if _, err := fmt.Fprintln(ctx.Stdout, "Configuration:"); err != nil {
+		return err
+	}
+	if err := writeLabeledValue(ctx, "directory", valueOrNone(result.ConfigDirectory)); err != nil {
+		return err
+	}
+
 	if _, err := fmt.Fprintln(ctx.Stdout, "Defaults:"); err != nil {
 		return err
 	}

--- a/erun-cli/cmd/list_test.go
+++ b/erun-cli/cmd/list_test.go
@@ -13,6 +13,10 @@ import (
 func TestListCommandPrintsDefaultsAndConfiguredTenants(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 	stubKubectlContexts(t, []string{"cluster-local"}, "cluster-local")
+	configDir, err := common.ERunConfigDir()
+	if err != nil {
+		t.Fatalf("ERunConfigDir failed: %v", err)
+	}
 
 	tenantAPath := filepath.Join(t.TempDir(), "tenant-a")
 	tenantBPath := filepath.Join(t.TempDir(), "tenant-b")
@@ -72,6 +76,8 @@ func TestListCommandPrintsDefaultsAndConfiguredTenants(t *testing.T) {
 
 	output := stdout.String()
 	for _, want := range []string{
+		"Configuration:",
+		"  directory: " + configDir,
 		"Defaults:",
 		"  tenant: tenant-a",
 		"  environment: local",
@@ -99,6 +105,10 @@ func TestListCommandPrintsDefaultsAndConfiguredTenants(t *testing.T) {
 
 func TestListCommandUsesConfiguredCurrentDirectoryTenantBeforeDefault(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
+	configDir, err := common.ERunConfigDir()
+	if err != nil {
+		t.Fatalf("ERunConfigDir failed: %v", err)
+	}
 
 	tenantAPath := filepath.Join(t.TempDir(), "tenant-a")
 	tenantBPath := filepath.Join(t.TempDir(), "tenant-b")
@@ -154,6 +164,8 @@ func TestListCommandUsesConfiguredCurrentDirectoryTenantBeforeDefault(t *testing
 
 	output := stdout.String()
 	for _, want := range []string{
+		"Configuration:",
+		"  directory: " + configDir,
 		"  repo: tenant-b",
 		"  configured tenant: tenant-b",
 		"  effective target: tenant-b/dev",
@@ -171,6 +183,10 @@ func TestListCommandUsesConfiguredCurrentDirectoryTenantBeforeDefault(t *testing
 
 func TestListCommandPrintsEmptyStateWhenNotInitialized(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
+	configDir, err := common.ERunConfigDir()
+	if err != nil {
+		t.Fatalf("ERunConfigDir failed: %v", err)
+	}
 
 	repoRoot := filepath.Join(t.TempDir(), "erun")
 	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
@@ -199,6 +215,8 @@ func TestListCommandPrintsEmptyStateWhenNotInitialized(t *testing.T) {
 
 	output := stdout.String()
 	for _, want := range []string{
+		"Configuration:",
+		"  directory: " + configDir,
 		"Defaults:",
 		"  tenant: none",
 		"  environment: none",

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -13,6 +13,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type openNoShellDialect string
+
+const (
+	openNoShellDialectPOSIX      openNoShellDialect = "posix"
+	openNoShellDialectPowerShell openNoShellDialect = "powershell"
+)
+
+var currentHostOS = func() common.HostOS { return common.DetectHost().OS }
+
 func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), saveTenantConfig func(common.TenantConfig) error, runInitForArgs func(common.Context, []string) error, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
 	var noShell bool
 	var snapshot bool
@@ -211,6 +220,9 @@ func maybeCreateMissingRuntimeChart(ctx common.Context, result common.OpenResult
 	if ctx.DryRun || promptRunner == nil || resolveRuntimeDeploySpec == nil {
 		return execution, nil
 	}
+	if result.RemoteRepo() {
+		return execution, nil
+	}
 	if !common.IsDefaultDevopsChartPath(execution.Deploy.ChartPath) {
 		return execution, nil
 	}
@@ -239,6 +251,7 @@ func emitLocalShellSetupForOpenResult(result common.OpenResult, promptRunner Pro
 		stderr = io.Discard
 	}
 
+	dialect := openNoShellDialectForShell(os.Getenv("SHELL"))
 	if file, ok := stdout.(*os.File); ok {
 		if info, err := file.Stat(); err == nil && (info.Mode()&os.ModeCharDevice) != 0 {
 			if err := maybeConfigureOpenNoShellAlias(result, promptRunner, os.Getenv("SHELL"), stderr); err != nil {
@@ -247,11 +260,12 @@ func emitLocalShellSetupForOpenResult(result common.OpenResult, promptRunner Pro
 		}
 	}
 
-	_, err := io.WriteString(stdout, common.LocalShellSetupScript(result))
+	_, err := io.WriteString(stdout, localShellSetupScript(result, dialect))
 	return err
 }
 
 func maybeConfigureOpenNoShellAlias(result common.OpenResult, promptRunner PromptRunner, shellPath string, stderr io.Writer) error {
+	dialect := openNoShellDialectForShell(shellPath)
 	aliasName := openNoShellAliasName(result)
 	startupFile, aliasConfigured := detectOpenNoShellAliasStartupFile(result, shellPath)
 	if aliasConfigured {
@@ -260,7 +274,7 @@ func maybeConfigureOpenNoShellAlias(result common.OpenResult, promptRunner Promp
 		}
 		return nil
 	}
-	if startupFile == "" || promptRunner == nil {
+	if startupFile == "" || promptRunner == nil || dialect == openNoShellDialectPowerShell {
 		for _, line := range openNoShellHintLines(result, shellPath) {
 			_, _ = fmt.Fprintln(stderr, line)
 		}
@@ -287,6 +301,7 @@ func maybeConfigureOpenNoShellAlias(result common.OpenResult, promptRunner Promp
 }
 
 func openNoShellHintLines(result common.OpenResult, shellPath string) []string {
+	dialect := openNoShellDialectForShell(shellPath)
 	aliasName := openNoShellAliasName(result)
 	aliasCommand := openNoShellAliasCommand(result, shellPath)
 	startupFile, aliasConfigured := detectOpenNoShellAliasStartupFile(result, shellPath)
@@ -295,14 +310,14 @@ func openNoShellHintLines(result common.OpenResult, shellPath string) []string {
 			fmt.Sprintf("configured in your shell startup file: open a new shell to use %s", aliasName),
 		}
 	}
-	if startupFile == "" {
+	if startupFile == "" || dialect == openNoShellDialectPowerShell {
 		return []string{
-			"one-liner alias:",
+			openNoShellHintPrefix(dialect),
 			aliasCommand,
 		}
 	}
 	return []string{
-		"one-liner alias:",
+		openNoShellHintPrefix(dialect),
 		aliasCommand,
 	}
 }
@@ -317,6 +332,10 @@ func openNoShellAliasName(result common.OpenResult) string {
 func openNoShellAliasCommand(result common.OpenResult, shellPath string) string {
 	aliasName := openNoShellAliasName(result)
 	command := fmt.Sprintf("erun open %s %s --no-shell", result.Tenant, result.Environment)
+	dialect := openNoShellDialectForShell(shellPath)
+	if dialect == openNoShellDialectPowerShell {
+		return "function " + aliasName + " { " + command + " | Invoke-Expression }"
+	}
 	if filepath.Base(strings.TrimSpace(shellPath)) == "fish" {
 		return "alias " + aliasName + " 'eval (" + command + ")'"
 	}
@@ -324,6 +343,9 @@ func openNoShellAliasCommand(result common.OpenResult, shellPath string) string 
 }
 
 func detectOpenNoShellAliasStartupFile(result common.OpenResult, shellPath string) (string, bool) {
+	if openNoShellDialectForShell(shellPath) == openNoShellDialectPowerShell {
+		return "", false
+	}
 	homeDir, err := os.UserHomeDir()
 	if err != nil || strings.TrimSpace(homeDir) == "" {
 		return "", false
@@ -394,6 +416,48 @@ func appendOpenNoShellAlias(path, aliasCommand string) error {
 		return err
 	}
 	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func openNoShellDialectForShell(shellPath string) openNoShellDialect {
+	return detectOpenNoShellDialect(currentHostOS(), shellPath)
+}
+
+func detectOpenNoShellDialect(hostOS common.HostOS, shellPath string) openNoShellDialect {
+	switch strings.ToLower(filepath.Base(strings.TrimSpace(shellPath))) {
+	case "pwsh", "pwsh.exe", "powershell", "powershell.exe":
+		return openNoShellDialectPowerShell
+	case "bash", "bash.exe", "zsh", "zsh.exe", "sh", "sh.exe", "fish", "fish.exe":
+		return openNoShellDialectPOSIX
+	}
+	if hostOS == common.HostOSWindows {
+		return openNoShellDialectPowerShell
+	}
+	return openNoShellDialectPOSIX
+}
+
+func localShellSetupScript(result common.OpenResult, dialect openNoShellDialect) string {
+	switch dialect {
+	case openNoShellDialectPowerShell:
+		commands := []string{
+			"kubectl config use-context " + powerShellQuote(strings.TrimSpace(result.EnvConfig.KubernetesContext)) + " | Out-Null",
+			"kubectl config set-context --current " + powerShellQuote("--namespace="+common.KubernetesNamespaceName(result.Tenant, result.Environment)) + " | Out-Null",
+			"Set-Location -LiteralPath " + powerShellQuote(result.RepoPath),
+		}
+		return strings.Join(commands, "\n") + "\n"
+	default:
+		return common.LocalShellSetupScript(result)
+	}
+}
+
+func openNoShellHintPrefix(dialect openNoShellDialect) string {
+	if dialect == openNoShellDialectPowerShell {
+		return "one-liner function:"
+	}
+	return "one-liner alias:"
+}
+
+func powerShellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
 
 func openerIsDefaultError(err error) bool {

--- a/erun-cli/cmd/open_test.go
+++ b/erun-cli/cmd/open_test.go
@@ -68,6 +68,25 @@ func TestOpenCommandNoShellConfiguresLocalKubeconfig(t *testing.T) {
 	}
 }
 
+func TestLocalShellSetupScriptUsesPowerShellOnWindows(t *testing.T) {
+	result := common.OpenResult{
+		Tenant:      "tenant-a",
+		Environment: "dev",
+		RepoPath:    `C:\Users\john\src\tenant-a`,
+		EnvConfig: common.EnvConfig{
+			KubernetesContext: "cluster-dev",
+		},
+	}
+
+	got := localShellSetupScript(result, openNoShellDialectPowerShell)
+	want := "kubectl config use-context 'cluster-dev' | Out-Null\n" +
+		"kubectl config set-context --current '--namespace=tenant-a-dev' | Out-Null\n" +
+		"Set-Location -LiteralPath 'C:\\Users\\john\\src\\tenant-a'\n"
+	if got != want {
+		t.Fatalf("unexpected PowerShell setup script:\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
 func TestOpenNoShellHintLinesSuggestAliasAndStartupFileWhenMissing(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
@@ -83,6 +102,27 @@ func TestOpenNoShellHintLinesSuggestAliasAndStartupFileWhenMissing(t *testing.T)
 	}
 	if lines[1] != `alias frs-local='eval "$(erun open frs local --no-shell)"'` {
 		t.Fatalf("unexpected alias line: %q", lines[1])
+	}
+}
+
+func TestOpenNoShellHintLinesUsePowerShellFunctionOnWindows(t *testing.T) {
+	previousHostOS := currentHostOS
+	currentHostOS = func() common.HostOS { return common.HostOSWindows }
+	t.Cleanup(func() {
+		currentHostOS = previousHostOS
+	})
+
+	result := common.OpenResult{Tenant: "frs", Environment: "local", Title: "frs-local"}
+	lines := openNoShellHintLines(result, "")
+
+	if len(lines) != 2 {
+		t.Fatalf("unexpected hint lines: %+v", lines)
+	}
+	if lines[0] != "one-liner function:" {
+		t.Fatalf("unexpected intro line: %q", lines[0])
+	}
+	if lines[1] != "function frs-local { erun open frs local --no-shell | Invoke-Expression }" {
+		t.Fatalf("unexpected function line: %q", lines[1])
 	}
 }
 
@@ -340,6 +380,7 @@ func TestOpenCommandDryRunRedeploysWhenRuntimeHasLocalBuilds(t *testing.T) {
 	output := stderr.String()
 	for _, want := range []string{
 		"docker build -t erunpaas/tenant-a-devops:1.0.0",
+		"--build-arg ERUN_VERSION=1.0.0",
 		"docker push erunpaas/tenant-a-devops:1.0.0",
 		"helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace tenant-a-local --kube-context cluster-dev -f " + filepath.Join(chartPath, "values.local.yaml") + " --set-string tenant=tenant-a --set-string environment=local",
 		"kubectl --context cluster-dev --namespace tenant-a-local wait --for=condition=Available --timeout 2m0s deployment/tenant-a-devops",
@@ -594,6 +635,50 @@ func TestOpenCommandPromptsToCreateMissingRuntimeChartAndUsesCreatedChart(t *tes
 	}
 	if launched.Namespace != "frs-local" || launched.KubernetesContext != "cluster-dev" {
 		t.Fatalf("unexpected shell launch: %+v", launched)
+	}
+}
+
+func TestOpenCommandSkipsLocalRuntimeChartPromptForRemoteRepo(t *testing.T) {
+	launched := common.ShellLaunchParams{}
+	cmd := newTestRootCmd(testRootDeps{
+		Store: openCommandStore{
+			repoPath:   "/home/erun/git/erun",
+			toolConfig: common.ERunConfig{DefaultTenant: "erun"},
+			tenant: &common.TenantConfig{
+				Name:               "erun",
+				ProjectRoot:        "/home/erun/git/erun",
+				DefaultEnvironment: "local",
+				Remote:             true,
+			},
+			env: &common.EnvConfig{
+				Name:              "local",
+				RepoPath:          "/home/erun/git/erun",
+				KubernetesContext: "cluster-dev",
+				Remote:            true,
+			},
+		},
+		PromptRunner: func(prompt promptui.Prompt) (string, error) {
+			t.Fatalf("did not expect chart creation prompt for remote repo: %+v", prompt)
+			return "", nil
+		},
+		CheckKubernetesDeployment: func(req common.KubernetesDeploymentCheckParams) (bool, error) {
+			return true, nil
+		},
+		LaunchShell: func(req common.ShellLaunchParams) error {
+			launched = req
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"open"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if launched.Dir != "/home/erun/git/erun" || launched.Title != "erun-local" {
+		t.Fatalf("unexpected shell launch: %+v", launched)
+	}
+	if !launched.RemoteRepo {
+		t.Fatalf("expected remote shell launch params, got %+v", launched)
 	}
 }
 
@@ -869,6 +954,8 @@ func TestOpenCommandDeploysDevopsWhenMissing(t *testing.T) {
 type openCommandStore struct {
 	repoPath   string
 	toolConfig common.ERunConfig
+	tenant     *common.TenantConfig
+	env        *common.EnvConfig
 }
 
 func (s openCommandStore) LoadERunConfig() (common.ERunConfig, string, error) {
@@ -884,6 +971,13 @@ func (openCommandStore) ListTenantConfigs() ([]common.TenantConfig, error) {
 }
 
 func (s openCommandStore) LoadTenantConfig(tenant string) (common.TenantConfig, string, error) {
+	if s.tenant != nil {
+		config := *s.tenant
+		if config.Name == "" {
+			config.Name = tenant
+		}
+		return config, "", nil
+	}
 	return common.TenantConfig{
 		Name:               tenant,
 		ProjectRoot:        s.repoPath,
@@ -896,6 +990,13 @@ func (openCommandStore) SaveTenantConfig(common.TenantConfig) error {
 }
 
 func (s openCommandStore) LoadEnvConfig(tenant, env string) (common.EnvConfig, string, error) {
+	if s.env != nil {
+		config := *s.env
+		if config.Name == "" {
+			config.Name = env
+		}
+		return config, "", nil
+	}
 	return common.EnvConfig{
 		Name:              env,
 		RepoPath:          s.repoPath,

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -27,7 +27,7 @@ func runSelect(prompt promptui.Select) (int, string, error) {
 func Execute() error {
 	configStore := common.ConfigStore{}
 	store := rootStore(configStore)
-	runInit := newRunInit(store, common.FindProjectRoot, runPrompt, runSelect, listKubernetesContexts, ensureKubernetesNamespace)
+	runInit := newRunInit(store, common.FindProjectRoot, runPrompt, runSelect, listKubernetesContexts, ensureKubernetesNamespace, common.WaitForShellDeployment, common.RunRemoteCommand, common.DeployHelmChart)
 	runInitForArgs := newRunInitForArgs(store, runInit)
 	push := newPushOperation(nil, common.DockerRegistryLogin, runSelect)
 	resolveOpen := func(params common.OpenParams) (common.OpenResult, error) {

--- a/erun-cli/cmd/root_runtime.go
+++ b/erun-cli/cmd/root_runtime.go
@@ -57,33 +57,37 @@ func newRootCommand(runRoot func(*cobra.Command, []string) error) *cobra.Command
 	return cmd
 }
 
-func newRunInit(store common.BootstrapStore, findProjectRoot common.ProjectFinderFunc, promptRunner PromptRunner, selectRunner SelectRunner, listKubernetesContexts KubernetesContextsLister, ensureKubernetesNamespace common.NamespaceEnsurerFunc) func(common.Context, common.BootstrapInitParams) error {
+func newRunInit(store common.BootstrapStore, findProjectRoot common.ProjectFinderFunc, promptRunner PromptRunner, selectRunner SelectRunner, listKubernetesContexts KubernetesContextsLister, ensureKubernetesNamespace common.NamespaceEnsurerFunc, waitForRemoteRuntime common.RemoteRuntimeWaitFunc, runRemoteCommand common.RemoteCommandRunnerFunc, deployHelmChart common.HelmChartDeployerFunc) func(common.Context, common.BootstrapInitParams) error {
 	return func(ctx common.Context, params common.BootstrapInitParams) error {
 		if strings.TrimSpace(params.RuntimeVersion) == "" {
 			params.RuntimeVersion = currentBuildInfo().Version
 		}
-		_, err := common.RunBootstrapInit(
-			ctx,
-			params,
-			common.TraceBootstrapStore(ctx, store),
-			findProjectRoot,
-			nil,
-			func(tenants []common.TenantConfig) (common.TenantSelectionResult, error) {
+		_, err := common.RunBootstrapInitWithDependencies(common.BootstrapInitDependencies{
+			Store:           common.TraceBootstrapStore(ctx, store),
+			FindProjectRoot: findProjectRoot,
+			SelectTenant: func(tenants []common.TenantConfig) (common.TenantSelectionResult, error) {
 				return selectTenantPrompt(selectRunner, tenants)
 			},
-			func(label string) (bool, error) {
+			Confirm: func(label string) (bool, error) {
 				return confirmPrompt(promptRunner, label)
 			},
-			func(label string) (string, error) {
+			PromptKubernetesContext: func(label string) (string, error) {
 				return kubernetesContextPrompt(promptRunner, selectRunner, listKubernetesContexts, label)
 			},
-			func(label string) (string, error) {
+			PromptContainerRegistry: func(label string) (string, error) {
 				return containerRegistryPrompt(promptRunner, label)
 			},
-			common.TraceNamespaceEnsurer(ctx, ensureKubernetesNamespace),
-			common.LoadProjectConfig,
-			common.TraceProjectConfigSaver(ctx, common.SaveProjectConfig),
-		)
+			PromptRemoteRepositoryURL: func(label string) (string, error) {
+				return remoteRepositoryURLPrompt(promptRunner, label)
+			},
+			EnsureKubernetesNamespace: common.TraceNamespaceEnsurer(ctx, ensureKubernetesNamespace),
+			LoadProjectConfig:         common.LoadProjectConfig,
+			SaveProjectConfig:         common.TraceProjectConfigSaver(ctx, common.SaveProjectConfig),
+			WaitForRemoteRuntime:      waitForRemoteRuntime,
+			RunRemoteCommand:          runRemoteCommand,
+			DeployHelmChart:           deployHelmChart,
+			Context:                   ctx,
+		}, params)
 		if err != nil {
 			if errors.Is(err, common.ErrNotInGitRepository) {
 				return internal.MarkReported(common.ErrNotInGitRepository)

--- a/erun-cli/cmd/root_test.go
+++ b/erun-cli/cmd/root_test.go
@@ -430,6 +430,80 @@ func TestInitCommandPreservesExistingTenantDefaultEnvironmentWhenFlagOmitted(t *
 	}
 }
 
+func TestInitCommandDecliningDefaultTenantStillInitializes(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+
+	projectRoot := filepath.Join(t.TempDir(), "project")
+	promptLabels := make([]string, 0, 3)
+	cmd := newTestRootCmd(testRootDeps{
+		FindProjectRoot: func() (string, string, error) {
+			return "petios", projectRoot, nil
+		},
+		PromptRunner: func(prompt promptui.Prompt) (string, error) {
+			label := fmt.Sprint(prompt.Label)
+			promptLabels = append(promptLabels, label)
+			if prompt.IsConfirm && label == fmt.Sprintf("Initialize tenant %q (path: %s) as the default tenant?", "petios", projectRoot) {
+				return "n", nil
+			}
+			if prompt.IsConfirm {
+				return "y", nil
+			}
+			return "", nil
+		},
+		SelectRunner: func(prompt promptui.Select) (int, string, error) {
+			if fmt.Sprint(prompt.Label) != fmt.Sprintf("Kubernetes context for environment %q in tenant %q", "review", "petios") {
+				t.Fatalf("unexpected select prompt: %+v", prompt)
+			}
+			return 0, "cluster-review", nil
+		},
+		ListKubernetesContexts: func() ([]string, error) {
+			return []string{"cluster-review"}, nil
+		},
+		EnsureKubernetesNamespace: func(contextName, namespace string) error {
+			if contextName != "cluster-review" || namespace != "petios-review" {
+				t.Fatalf("unexpected namespace ensure request: context=%q namespace=%q", contextName, namespace)
+			}
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"init", "--tenant", "petios", "--environment", "review"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if _, _, err := common.LoadERunConfig(); !errors.Is(err, common.ErrNotInitialized) {
+		t.Fatalf("expected erun config to remain absent, got %v", err)
+	}
+	tenantConfig, _, err := common.LoadTenantConfig("petios")
+	if err != nil {
+		t.Fatalf("LoadTenantConfig failed: %v", err)
+	}
+	if tenantConfig.ProjectRoot != projectRoot || tenantConfig.DefaultEnvironment != "review" {
+		t.Fatalf("unexpected tenant config: %+v", tenantConfig)
+	}
+	envConfig, _, err := common.LoadEnvConfig("petios", "review")
+	if err != nil {
+		t.Fatalf("LoadEnvConfig failed: %v", err)
+	}
+	if envConfig.KubernetesContext != "cluster-review" || envConfig.RepoPath != projectRoot {
+		t.Fatalf("unexpected env config: %+v", envConfig)
+	}
+	wantPromptLabels := []string{
+		fmt.Sprintf("Initialize tenant %q (path: %s) as the default tenant?", "petios", projectRoot),
+		fmt.Sprintf("Initialize default environment %q for tenant %q?", "review", "petios"),
+		fmt.Sprintf("Container registry for environment %q in tenant %q", "review", "petios"),
+	}
+	if len(promptLabels) != len(wantPromptLabels) {
+		t.Fatalf("unexpected prompts: %+v", promptLabels)
+	}
+	for i := range wantPromptLabels {
+		if promptLabels[i] != wantPromptLabels[i] {
+			t.Fatalf("unexpected prompt %d: got %q want %q", i, promptLabels[i], wantPromptLabels[i])
+		}
+	}
+}
+
 func TestRootCommandHelpFlagPrintsHelp(t *testing.T) {
 	cmd := newTestRootCmd(testRootDeps{})
 	buf := new(bytes.Buffer)

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -30,6 +30,8 @@ type testRootDeps struct {
 	DeployHelmChart                common.HelmChartDeployerFunc
 	LaunchMCP                      MCPLauncher
 	LaunchShell                    common.ShellLauncherFunc
+	WaitForRemoteRuntime           common.RemoteRuntimeWaitFunc
+	RunRemoteCommand               common.RemoteCommandRunnerFunc
 	Now                            common.NowFunc
 }
 
@@ -144,7 +146,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 		}
 		return deps.EnsureKubernetesNamespace(contextName, namespace)
 	}
-	runInit := newRunInit(store, findProjectRoot, promptRunner, selectRunner, listKubernetesContexts, ensureKubernetesNamespace)
+	runInit := newRunInit(store, findProjectRoot, promptRunner, selectRunner, listKubernetesContexts, ensureKubernetesNamespace, deps.WaitForRemoteRuntime, deps.RunRemoteCommand, deployHelmChart)
 	runInitForArgs := newRunInitForArgs(store, runInit)
 
 	initCmd := newInitCmd(runInit)

--- a/erun-common/assets/default-devops-chart/templates/service.yaml
+++ b/erun-common/assets/default-devops-chart/templates/service.yaml
@@ -1,3 +1,6 @@
+{{- $worktreeStorage := default "host" .Values.worktreeStorage -}}
+{{- $worktreeRepoName := required "worktreeRepoName is required" .Values.worktreeRepoName -}}
+{{- $worktreePath := printf "/home/erun/git/%s" $worktreeRepoName -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -81,13 +84,19 @@ spec:
             - name: DOCKER_BUILDKIT
               value: "1"
             - name: ERUN_REPO_PATH
-              value: {{ printf "/home/erun/git/%s" (base (required "worktreeHostPath is required" .Values.worktreeHostPath)) | quote }}
+              value: {{ $worktreePath | quote }}
+            - name: ERUN_REPO_REMOTE
+              value: {{ if eq $worktreeStorage "pvc" }}"true"{{ else }}"false"{{ end }}
             - name: ERUN_KUBERNETES_CONTEXT
               value: in-cluster
             - name: ERUN_TENANT
               value: {{ required "tenant is required" .Values.tenant | quote }}
             - name: ERUN_ENVIRONMENT
               value: {{ required "environment is required" .Values.environment | quote }}
+            - name: ERUN_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -101,8 +110,10 @@ spec:
           volumeMounts:
             - name: erun-home
               mountPath: /home/erun
+{{- if eq $worktreeStorage "host" }}
             - name: repo-worktree
-              mountPath: {{ printf "/home/erun/git/%s" (base (required "worktreeHostPath is required" .Values.worktreeHostPath)) | quote }}
+              mountPath: {{ $worktreePath | quote }}
+{{- end }}
             - name: docker-socket
               mountPath: /var/run
         - image: erunpaas/erun-dind:28.1.1
@@ -138,10 +149,12 @@ spec:
         - name: erun-home
           persistentVolumeClaim:
             claimName: __MODULE_NAME__-home
+{{- if eq $worktreeStorage "host" }}
         - name: repo-worktree
           hostPath:
             path: {{ required "worktreeHostPath is required" .Values.worktreeHostPath | quote }}
             type: DirectoryOrCreate
+{{- end }}
         - name: docker-socket
           emptyDir: {}
         - name: docker-state

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -758,7 +758,7 @@ func (b DockerBuildSpec) command() commandSpec {
 	return commandSpec{
 		Dir:  b.ContextDir,
 		Name: "docker",
-		Args: []string{"build", "-t", b.Image.Tag, "-f", b.DockerfilePath, "."},
+		Args: dockerBuildArgs(b.Image.Tag, b.DockerfilePath),
 	}
 }
 
@@ -1064,11 +1064,32 @@ func FindComponentDockerBuildContext(projectRoot, componentName string) (DockerB
 }
 
 func DockerImageBuilder(dir, dockerfilePath, tag string, stdout, stderr io.Writer) error {
-	cmd := exec.Command("docker", "build", "-t", tag, "-f", dockerfilePath, ".")
+	cmd := exec.Command("docker", dockerBuildArgs(tag, dockerfilePath)...)
 	cmd.Dir = dir
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	return cmd.Run()
+}
+
+func dockerBuildArgs(tag, dockerfilePath string) []string {
+	args := []string{"build", "-t", tag}
+	if version := dockerImageTagVersion(tag); version != "" {
+		args = append(args, "--build-arg", "ERUN_VERSION="+version)
+	}
+	args = append(args, "-f", dockerfilePath, ".")
+	return args
+}
+
+func dockerImageTagVersion(tag string) string {
+	tag = strings.TrimSpace(tag)
+	if tag == "" {
+		return ""
+	}
+	index := strings.LastIndex(tag, ":")
+	if index < 0 || index == len(tag)-1 {
+		return ""
+	}
+	return tag[index+1:]
 }
 
 func BuildScriptRunner(dir, scriptPath string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -71,6 +71,21 @@ func TestDockerRegistryFromImageTag(t *testing.T) {
 	}
 }
 
+func TestDockerBuildArgsIncludeImageVersionAsBuildArg(t *testing.T) {
+	args := dockerBuildArgs("erunpaas/erun-devops:1.0.0-snapshot-20260406123456", "/tmp/Dockerfile")
+	got := strings.Join(args, " ")
+	for _, want := range []string{
+		"build",
+		"-t erunpaas/erun-devops:1.0.0-snapshot-20260406123456",
+		"--build-arg ERUN_VERSION=1.0.0-snapshot-20260406123456",
+		"-f /tmp/Dockerfile .",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected docker build args to contain %q, got %q", want, got)
+		}
+	}
+}
+
 func TestResolveDockerBuildContextIgnoresMissingDockerfile(t *testing.T) {
 	workdir := t.TempDir()
 

--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -25,6 +25,7 @@ type TenantConfig struct {
 	ProjectRoot        string
 	Name               string
 	DefaultEnvironment string
+	Remote             bool  `yaml:"remote,omitempty"`
 	Snapshot           *bool `yaml:"snapshot,omitempty"`
 }
 
@@ -33,6 +34,7 @@ type EnvConfig struct {
 	RepoPath          string
 	KubernetesContext string
 	ContainerRegistry string
+	Remote            bool  `yaml:"remote,omitempty"`
 	Snapshot          *bool `yaml:"snapshot,omitempty"`
 }
 
@@ -150,6 +152,14 @@ var (
 	ErrFailedToSaveConfig = errors.New("could not save struct to yaml file")
 	ErrNotInGitRepository = errors.New("cannot find git project")
 )
+
+func ERunConfigDir() (string, error) {
+	configHome := strings.TrimSpace(xdg.ConfigHome)
+	if configHome == "" {
+		return "", ErrNoUserDataFolder
+	}
+	return filepath.Join(configHome, configRoot), nil
+}
 
 type ConfigStore struct{}
 

--- a/erun-common/default_devops_chart.go
+++ b/erun-common/default_devops_chart.go
@@ -81,6 +81,10 @@ func renderDefaultDevopsChartTemplate(assetPath, moduleName string, data []byte)
 }
 
 func resolveOpenRuntimeDeploySpec(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult) (DeploySpec, error) {
+	if target.RemoteRepo() {
+		return resolveDefaultDevopsDeploySpec(target)
+	}
+
 	allowLocalBuilds := target.TenantConfig.SnapshotEnabled()
 	if target.TenantConfig.Snapshot == nil {
 		allowLocalBuilds = target.EnvConfig.SnapshotEnabled()

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -18,6 +18,11 @@ const DefaultHelmDeploymentTimeout = "2m0s"
 
 const DevopsComponentName = "erun-devops"
 
+const (
+	WorktreeStorageHost = "host"
+	WorktreeStoragePVC  = "pvc"
+)
+
 type DeployStore interface {
 	OpenStore
 	ListTenantConfigs() ([]TenantConfig, error)
@@ -43,6 +48,8 @@ type HelmDeployParams struct {
 	Environment       string
 	Namespace         string
 	KubernetesContext string
+	WorktreeStorage   string
+	WorktreeRepoName  string
 	WorktreeHostPath  string
 	Version           string
 	Timeout           string
@@ -58,6 +65,8 @@ type HelmDeploySpec struct {
 	Environment       string
 	Namespace         string
 	KubernetesContext string
+	WorktreeStorage   string
+	WorktreeRepoName  string
 	WorktreeHostPath  string
 	Version           string
 	Timeout           string
@@ -537,10 +546,27 @@ func newHelmDeploySpec(target OpenResult, deployContext KubernetesDeployContext,
 		Environment:       target.Environment,
 		Namespace:         KubernetesNamespaceName(target.Tenant, target.Environment),
 		KubernetesContext: target.EnvConfig.KubernetesContext,
+		WorktreeStorage:   resolveWorktreeStorage(target),
+		WorktreeRepoName:  resolveWorktreeRepoName(target.RepoPath),
 		WorktreeHostPath:  resolveWorktreeHostPath(target.RepoPath),
 		Version:           version,
 		Timeout:           DefaultHelmDeploymentTimeout,
 	}, nil
+}
+
+func resolveWorktreeStorage(target OpenResult) string {
+	if target.RemoteRepo() {
+		return WorktreeStoragePVC
+	}
+	return WorktreeStorageHost
+}
+
+func resolveWorktreeRepoName(repoPath string) string {
+	repoName := strings.TrimSpace(filepath.Base(strings.TrimSpace(repoPath)))
+	if repoName == "" || repoName == "." || repoName == string(filepath.Separator) {
+		return "worktree"
+	}
+	return repoName
 }
 
 func resolveWorktreeHostPath(repoPath string) string {
@@ -567,6 +593,8 @@ func (d HelmDeploySpec) Params(stdout, stderr io.Writer) HelmDeployParams {
 		Environment:       d.Environment,
 		Namespace:         d.Namespace,
 		KubernetesContext: d.KubernetesContext,
+		WorktreeStorage:   d.WorktreeStorage,
+		WorktreeRepoName:  d.WorktreeRepoName,
 		WorktreeHostPath:  d.WorktreeHostPath,
 		Version:           d.Version,
 		Timeout:           d.Timeout,
@@ -591,6 +619,8 @@ func (d HelmDeploySpec) command() commandSpec {
 		"-f", d.ValuesFilePath,
 		"--set-string", "tenant="+d.Tenant,
 		"--set-string", "environment="+d.Environment,
+		"--set-string", "worktreeStorage="+d.WorktreeStorage,
+		"--set-string", "worktreeRepoName="+d.WorktreeRepoName,
 		"--set-string", "worktreeHostPath="+d.WorktreeHostPath,
 		d.ReleaseName,
 		d.ChartPath,
@@ -827,6 +857,8 @@ func DeployHelmChart(params HelmDeployParams) error {
 		"-f", params.ValuesFilePath,
 		"--set-string", "tenant="+params.Tenant,
 		"--set-string", "environment="+params.Environment,
+		"--set-string", "worktreeStorage="+params.WorktreeStorage,
+		"--set-string", "worktreeRepoName="+params.WorktreeRepoName,
 		"--set-string", "worktreeHostPath="+params.WorktreeHostPath,
 		params.ReleaseName,
 		chartPath,

--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/adrg/xdg"
 	"gopkg.in/yaml.v3"
@@ -44,6 +45,9 @@ type (
 	NamespaceEnsurerFunc    func(string, string) error
 	ProjectConfigLoaderFunc func(string) (ProjectConfig, string, error)
 	ProjectConfigSaverFunc  func(string, ProjectConfig) error
+	RemoteRuntimeWaitFunc   func(ShellLaunchParams) error
+	RemoteCommandRunnerFunc func(ShellLaunchParams, string) (RemoteCommandResult, error)
+	SleepFunc               func(time.Duration)
 )
 
 type (
@@ -51,6 +55,10 @@ type (
 	TenantSelectionResult struct {
 		Tenant     string
 		Initialize bool
+	}
+	RemoteCommandResult struct {
+		Stdout string
+		Stderr string
 	}
 )
 
@@ -63,8 +71,11 @@ type BootstrapInitParams struct {
 	RuntimeVersion           string
 	KubernetesContext        string
 	ContainerRegistry        string
+	Remote                   bool
+	RemoteRepositoryURL      string
 	ConfirmTenant            *bool
 	ConfirmEnvironment       *bool
+	ConfirmRemoteKeyImport   *bool
 	AutoApprove              bool
 	ResolveTenant            bool
 }
@@ -77,6 +88,8 @@ const (
 	BootstrapInitInteractionConfirmEnvironment BootstrapInitInteractionType = "confirm_environment"
 	BootstrapInitInteractionKubernetesContext  BootstrapInitInteractionType = "input_kubernetes_context"
 	BootstrapInitInteractionContainerRegistry  BootstrapInitInteractionType = "input_container_registry"
+	BootstrapInitInteractionRemoteRepository   BootstrapInitInteractionType = "input_remote_repository"
+	BootstrapInitInteractionConfirmRemoteKey   BootstrapInitInteractionType = "confirm_remote_key"
 )
 
 type BootstrapInitInteraction struct {
@@ -84,6 +97,7 @@ type BootstrapInitInteraction struct {
 	Label        string                       `json:"label"`
 	Options      []string                     `json:"options,omitempty"`
 	DefaultValue string                       `json:"defaultValue,omitempty"`
+	Details      string                       `json:"details,omitempty"`
 }
 
 type BootstrapInitInteractionError struct {
@@ -111,7 +125,7 @@ type BootstrapInitResult struct {
 	CreatedEnvConfig    bool
 }
 
-type bootstrapRunner struct {
+type BootstrapInitDependencies struct {
 	Store                     BootstrapStore
 	FindProjectRoot           ProjectFinderFunc
 	GetWorkingDir             WorkDirFunc
@@ -119,14 +133,24 @@ type bootstrapRunner struct {
 	Confirm                   ConfirmFunc
 	PromptKubernetesContext   PromptValueFunc
 	PromptContainerRegistry   PromptValueFunc
+	PromptRemoteRepositoryURL PromptValueFunc
 	EnsureKubernetesNamespace NamespaceEnsurerFunc
 	LoadProjectConfig         ProjectConfigLoaderFunc
 	SaveProjectConfig         ProjectConfigSaverFunc
+	WaitForRemoteRuntime      RemoteRuntimeWaitFunc
+	RunRemoteCommand          RemoteCommandRunnerFunc
+	DeployHelmChart           HelmChartDeployerFunc
+	Sleep                     SleepFunc
 	Context                   Context
 }
 
+type bootstrapRunner struct {
+	BootstrapInitDependencies
+	Context Context
+}
+
 func RunBootstrapInit(ctx Context, params BootstrapInitParams, store BootstrapStore, findProjectRoot ProjectFinderFunc, getWorkingDir WorkDirFunc, selectTenant SelectTenantFunc, confirm ConfirmFunc, promptKubernetesContext PromptValueFunc, promptContainerRegistry PromptValueFunc, ensureKubernetesNamespace NamespaceEnsurerFunc, loadProjectConfig ProjectConfigLoaderFunc, saveProjectConfig ProjectConfigSaverFunc) (BootstrapInitResult, error) {
-	return bootstrapRunner{
+	return RunBootstrapInitWithDependencies(BootstrapInitDependencies{
 		Store:                     store,
 		FindProjectRoot:           findProjectRoot,
 		GetWorkingDir:             getWorkingDir,
@@ -138,6 +162,13 @@ func RunBootstrapInit(ctx Context, params BootstrapInitParams, store BootstrapSt
 		LoadProjectConfig:         loadProjectConfig,
 		SaveProjectConfig:         saveProjectConfig,
 		Context:                   ctx,
+	}, params)
+}
+
+func RunBootstrapInitWithDependencies(deps BootstrapInitDependencies, params BootstrapInitParams) (BootstrapInitResult, error) {
+	return bootstrapRunner{
+		BootstrapInitDependencies: deps,
+		Context:                   deps.Context,
 	}.run(params)
 }
 
@@ -243,12 +274,26 @@ func (s tracedBootstrapStore) SaveEnvConfig(tenant string, config EnvConfig) err
 func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, error) {
 	s = s.withDefaults()
 	params = normalizeBootstrapParams(params)
+	remoteMode := params.Remote
 
 	var result BootstrapInitResult
 	var detected projectContext
 	var tenants []TenantConfig
 	var tenantsLoaded bool
 	var setDefaultTenant bool
+	var defaultTenantResolved bool
+
+	if remoteMode {
+		if params.InitializeCurrentProject || params.ResolveTenant {
+			return result, fmt.Errorf("remote initialization requires an explicit tenant")
+		}
+		if params.Tenant == "" {
+			return result, fmt.Errorf("tenant is required with --remote")
+		}
+		if params.Environment == "" {
+			return result, fmt.Errorf("environment is required with --remote")
+		}
+	}
 
 	findProject := func() (projectContext, error) {
 		if detected.loaded {
@@ -292,6 +337,19 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 		return tenants, nil
 	}
 
+	resolveDefaultTenant := func(tenant, projectRoot string) error {
+		if defaultTenantResolved {
+			return nil
+		}
+		updateDefaultTenant, err := s.confirmTenant(params, tenant, projectRoot)
+		if err != nil {
+			return err
+		}
+		setDefaultTenant = updateDefaultTenant
+		defaultTenantResolved = true
+		return nil
+	}
+
 	toolConfig, configPath, err := s.Store.LoadERunConfig()
 	toolConfigMissing := false
 	s.Context.Trace("Loading erun tool configuration, configPath=" + configPath)
@@ -304,7 +362,9 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 		}
 		tenant := params.Tenant
 		projectRoot := params.ProjectRoot
-		if tenant == "" || projectRoot == "" {
+		if remoteMode {
+			projectRoot = RemoteWorktreePathForRepoName(tenant)
+		} else if tenant == "" || projectRoot == "" {
 			project, detectErr := detectProject()
 			if detectErr != nil {
 				return result, detectErr
@@ -317,25 +377,26 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 			}
 		}
 
-		if err := s.confirmTenant(params, tenant, projectRoot); err != nil {
+		if err := resolveDefaultTenant(tenant, projectRoot); err != nil {
 			return result, err
 		}
-		setDefaultTenant = true
 
-		s.Context.Trace("Saving default config")
-		toolConfig = ERunConfig{DefaultTenant: tenant}
-		if err := s.Store.SaveERunConfig(toolConfig); err != nil {
-			return result, err
+		if setDefaultTenant {
+			s.Context.Trace("Saving default config")
+			toolConfig = ERunConfig{DefaultTenant: tenant}
+			if err := s.Store.SaveERunConfig(toolConfig); err != nil {
+				return result, err
+			}
+			result.CreatedERunConfig = true
+			toolConfigMissing = false
 		}
-		result.CreatedERunConfig = true
-		toolConfigMissing = false
 	case err != nil:
 		return result, err
 	}
 	s.Context.Trace("Loaded erun tool configuration")
 
 	tenant := params.Tenant
-	if tenant == "" {
+	if tenant == "" && !remoteMode {
 		project, detectErr := findProject()
 		switch {
 		case detectErr == nil:
@@ -360,7 +421,7 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 			}
 		}
 	}
-	if tenant == "" {
+	if tenant == "" && !remoteMode {
 		tenant = toolConfig.DefaultTenant
 	}
 	if tenant == "" && params.ResolveTenant {
@@ -378,21 +439,25 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 			}
 		}
 	}
-	if tenant == "" {
+	if tenant == "" && !remoteMode {
 		project, detectErr := detectProject()
 		if detectErr != nil {
 			return result, detectErr
 		}
 		tenant = project.tenant
 	}
+	if remoteMode {
+		params.ProjectRoot = RemoteWorktreePathForRepoName(tenant)
+	}
 
 	s.Context.Trace("Loading tenant configuration")
 	tenantConfig, _, err := s.Store.LoadTenantConfig(tenant)
+	tenantConfigChanged := false
 	switch {
 	case err == nil:
 	case errors.Is(err, ErrNotInitialized):
 		projectRoot := params.ProjectRoot
-		if projectRoot == "" {
+		if projectRoot == "" && !remoteMode {
 			project, detectErr := detectProject()
 			if detectErr != nil {
 				return result, detectErr
@@ -400,11 +465,10 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 			projectRoot = project.root
 		}
 
-		if !setDefaultTenant {
-			if err := s.confirmTenant(params, tenant, projectRoot); err != nil {
+		if !defaultTenantResolved {
+			if err := resolveDefaultTenant(tenant, projectRoot); err != nil {
 				return result, err
 			}
-			setDefaultTenant = true
 		}
 
 		defaultEnvironment := params.Environment
@@ -417,6 +481,7 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 			Name:               tenant,
 			ProjectRoot:        projectRoot,
 			DefaultEnvironment: defaultEnvironment,
+			Remote:             remoteMode,
 		}
 		if err := s.Store.SaveTenantConfig(tenantConfig); err != nil {
 			return result, err
@@ -428,6 +493,17 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 
 	if tenantConfig.Name == "" {
 		tenantConfig.Name = tenant
+		tenantConfigChanged = true
+	}
+	if remoteMode {
+		if tenantConfig.ProjectRoot != params.ProjectRoot {
+			tenantConfig.ProjectRoot = params.ProjectRoot
+			tenantConfigChanged = true
+		}
+		if !tenantConfig.Remote {
+			tenantConfig.Remote = true
+			tenantConfigChanged = true
+		}
 	}
 	s.Context.Trace("Loaded tenant configuration")
 
@@ -440,6 +516,9 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 	}
 	if tenantConfig.DefaultEnvironment == "" {
 		tenantConfig.DefaultEnvironment = envName
+		tenantConfigChanged = true
+	}
+	if tenantConfigChanged {
 		if err := s.Store.SaveTenantConfig(tenantConfig); err != nil {
 			return result, err
 		}
@@ -447,6 +526,7 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 
 	s.Context.Trace("Loading environment configuration")
 	envConfig, _, err := s.Store.LoadEnvConfig(tenant, envName)
+	envConfigChanged := false
 	switch {
 	case err == nil:
 	case errors.Is(err, ErrNotInitialized):
@@ -454,7 +534,7 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 		if envProjectRoot == "" {
 			envProjectRoot = tenantConfig.ProjectRoot
 		}
-		if envProjectRoot == "" {
+		if envProjectRoot == "" && !remoteMode {
 			project, detectErr := findProject()
 			if detectErr == nil {
 				envProjectRoot = project.root
@@ -478,7 +558,7 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 		if err != nil {
 			return result, err
 		}
-		if err := s.saveProjectContainerRegistry(envProjectRoot, envName, containerRegistry); err != nil {
+		if err := s.saveProjectContainerRegistry(envProjectRoot, envName, containerRegistry, remoteMode); err != nil {
 			return result, err
 		}
 
@@ -487,14 +567,28 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 			Name:              envName,
 			RepoPath:          envProjectRoot,
 			KubernetesContext: kubernetesContext,
+			Remote:            remoteMode,
 		}
 		if err := saveEnvConfig(s.Store, tenant, envConfig); err != nil {
 			return result, err
 		}
 		envConfig.ContainerRegistry = containerRegistry
+		if remoteMode && containerRegistry != "" {
+			envConfigChanged = true
+		}
 		result.CreatedEnvConfig = true
 	case err != nil:
 		return result, err
+	}
+	if remoteMode {
+		if envConfig.RepoPath != params.ProjectRoot {
+			envConfig.RepoPath = params.ProjectRoot
+			envConfigChanged = true
+		}
+		if !envConfig.Remote {
+			envConfig.Remote = true
+			envConfigChanged = true
+		}
 	}
 
 	kubernetesContext, err := s.resolveKubernetesContext(params, tenant, envName, envConfig.KubernetesContext)
@@ -506,9 +600,7 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 			return result, err
 		}
 		envConfig.KubernetesContext = kubernetesContext
-		if err := saveEnvConfig(s.Store, tenant, envConfig); err != nil {
-			return result, err
-		}
+		envConfigChanged = true
 	}
 	projectRoot := envConfig.RepoPath
 	if projectRoot == "" {
@@ -519,24 +611,33 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 		return result, err
 	}
 	if containerRegistry != "" {
-		if err := s.saveProjectContainerRegistry(projectRoot, envName, containerRegistry); err != nil {
+		if err := s.saveProjectContainerRegistry(projectRoot, envName, containerRegistry, remoteMode); err != nil {
 			return result, err
 		}
 	}
 	if containerRegistry != "" && containerRegistry != envConfig.ContainerRegistry {
 		envConfig.ContainerRegistry = containerRegistry
+		envConfigChanged = true
+	}
+	if remoteMode {
+		if err := s.ensureRemoteRepository(params, tenant, envName, kubernetesContext, projectRoot); err != nil {
+			return result, err
+		}
+	} else {
+		if err := EnsureDefaultDevopsModuleWithVersion(s.Context, projectRoot, tenant, params.RuntimeVersion); err != nil {
+			return result, err
+		}
+		if err := EnsureDefaultDevopsChart(s.Context, projectRoot, tenant, envName); err != nil {
+			return result, err
+		}
+	}
+	if envConfigChanged {
 		if err := saveEnvConfig(s.Store, tenant, envConfig); err != nil {
 			return result, err
 		}
 	}
-	if err := EnsureDefaultDevopsModuleWithVersion(s.Context, projectRoot, tenant, params.RuntimeVersion); err != nil {
-		return result, err
-	}
-	if err := EnsureDefaultDevopsChart(s.Context, projectRoot, tenant, envName); err != nil {
-		return result, err
-	}
 
-	if toolConfig.DefaultTenant == "" || (setDefaultTenant && toolConfig.DefaultTenant != tenant) {
+	if setDefaultTenant && (toolConfigMissing || toolConfig.DefaultTenant != tenant) {
 		s.Context.Trace("Saving default config")
 		toolConfig.DefaultTenant = tenant
 		if err := s.Store.SaveERunConfig(toolConfig); err != nil {
@@ -570,6 +671,14 @@ func containerRegistryLabel(tenant, envName string) string {
 	return fmt.Sprintf("Container registry for environment %q in tenant %q", envName, tenant)
 }
 
+func remoteRepositoryLabel(tenant, envName string) string {
+	return fmt.Sprintf("Git remote URL for environment %q in tenant %q", envName, tenant)
+}
+
+func remoteKeyImportLabel(tenant, envName string) string {
+	return fmt.Sprintf("Import the SSH public key above for environment %q in tenant %q and continue?", envName, tenant)
+}
+
 func KubernetesNamespaceName(tenant, envName string) string {
 	return normalizeNamespaceName(tenant + "-" + envName)
 }
@@ -582,6 +691,7 @@ func normalizeBootstrapParams(params BootstrapInitParams) BootstrapInitParams {
 	params.RuntimeVersion = strings.TrimSpace(params.RuntimeVersion)
 	params.KubernetesContext = strings.TrimSpace(params.KubernetesContext)
 	params.ContainerRegistry = strings.TrimSpace(params.ContainerRegistry)
+	params.RemoteRepositoryURL = strings.TrimSpace(params.RemoteRepositoryURL)
 	return params
 }
 
@@ -601,26 +711,35 @@ func (s bootstrapRunner) withDefaults() bootstrapRunner {
 	if s.SaveProjectConfig == nil {
 		s.SaveProjectConfig = SaveProjectConfig
 	}
+	if s.WaitForRemoteRuntime == nil {
+		s.WaitForRemoteRuntime = WaitForShellDeployment
+	}
+	if s.RunRemoteCommand == nil {
+		s.RunRemoteCommand = RunRemoteCommand
+	}
+	if s.DeployHelmChart == nil {
+		s.DeployHelmChart = DeployHelmChart
+	}
+	if s.Sleep == nil {
+		s.Sleep = time.Sleep
+	}
 	if s.Context.Logger.verbosity == 0 && s.Context.Logger.stdout == nil && s.Context.Logger.stderr == nil {
 		s.Context.Logger = NewLoggerWithWriters(-1, io.Discard, io.Discard)
 	}
 	return s
 }
 
-func (s bootstrapRunner) confirmTenant(params BootstrapInitParams, tenant, projectRoot string) error {
+func (s bootstrapRunner) confirmTenant(params BootstrapInitParams, tenant, projectRoot string) (bool, error) {
 	if params.AutoApprove {
-		return nil
+		return true, nil
 	}
 	if params.ConfirmTenant != nil {
-		if *params.ConfirmTenant {
-			return nil
-		}
-		return ErrTenantInitializationCancelled
+		return *params.ConfirmTenant, nil
 	}
 	return s.confirm(BootstrapInitInteraction{
 		Type:  BootstrapInitInteractionConfirmTenant,
 		Label: tenantConfirmationLabel(tenant, projectRoot),
-	}, ErrTenantInitializationCancelled)
+	})
 }
 
 func (s bootstrapRunner) confirmEnvironment(params BootstrapInitParams, tenant, envName string) error {
@@ -633,24 +752,28 @@ func (s bootstrapRunner) confirmEnvironment(params BootstrapInitParams, tenant, 
 		}
 		return ErrEnvironmentInitializationCancelled
 	}
-	return s.confirm(BootstrapInitInteraction{
+	confirmed, err := s.confirm(BootstrapInitInteraction{
 		Type:  BootstrapInitInteractionConfirmEnvironment,
 		Label: environmentConfirmationLabel(tenant, envName),
-	}, ErrEnvironmentInitializationCancelled)
-}
-
-func (s bootstrapRunner) confirm(interaction BootstrapInitInteraction, cancelled error) error {
-	if s.Confirm == nil {
-		return BootstrapInitInteractionError{Interaction: interaction}
-	}
-	confirmed, err := s.Confirm(interaction.Label)
+	})
 	if err != nil {
 		return err
 	}
 	if !confirmed {
-		return cancelled
+		return ErrEnvironmentInitializationCancelled
 	}
 	return nil
+}
+
+func (s bootstrapRunner) confirm(interaction BootstrapInitInteraction) (bool, error) {
+	if s.Confirm == nil {
+		return false, BootstrapInitInteractionError{Interaction: interaction}
+	}
+	confirmed, err := s.Confirm(interaction.Label)
+	if err != nil {
+		return false, err
+	}
+	return confirmed, nil
 }
 
 func (s bootstrapRunner) resolveKubernetesContext(params BootstrapInitParams, tenant, envName, current string) (string, error) {
@@ -728,7 +851,10 @@ func (s bootstrapRunner) resolveContainerRegistry(params BootstrapInitParams, te
 	return registry, nil
 }
 
-func (s bootstrapRunner) saveProjectContainerRegistry(projectRoot, envName, registry string) error {
+func (s bootstrapRunner) saveProjectContainerRegistry(projectRoot, envName, registry string, remote bool) error {
+	if remote {
+		return nil
+	}
 	if projectRoot == "" || envName == "" || registry == "" || s.SaveProjectConfig == nil {
 		return nil
 	}
@@ -859,7 +985,9 @@ func normalizeNamespaceName(value string) string {
 
 func saveEnvConfig(store BootstrapStore, tenant string, config EnvConfig) error {
 	stored := config
-	stored.ContainerRegistry = ""
+	if !stored.Remote {
+		stored.ContainerRegistry = ""
+	}
 	return store.SaveEnvConfig(tenant, stored)
 }
 

--- a/erun-common/init_remote.go
+++ b/erun-common/init_remote.go
@@ -1,0 +1,255 @@
+package eruncommon
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+)
+
+type remoteRepositoryState struct {
+	Exists    bool
+	PublicKey string
+}
+
+const remoteRepositoryAccessRetryInterval = 2 * time.Second
+
+func (s bootstrapRunner) ensureRemoteRepository(params BootstrapInitParams, tenant, envName, kubernetesContext, projectRoot string) error {
+	target := OpenResult{
+		Tenant:      tenant,
+		Environment: envName,
+		TenantConfig: TenantConfig{
+			Name:               tenant,
+			ProjectRoot:        projectRoot,
+			DefaultEnvironment: envName,
+			Remote:             true,
+		},
+		EnvConfig: EnvConfig{
+			Name:              envName,
+			RepoPath:          projectRoot,
+			KubernetesContext: kubernetesContext,
+			Remote:            true,
+		},
+		RepoPath: projectRoot,
+		Title:    tenant + "-" + envName,
+	}
+	req := ShellLaunchParamsFromResult(target)
+
+	if err := s.ensureRemoteRuntime(target, req, params.RuntimeVersion); err != nil {
+		return err
+	}
+
+	state, err := s.remoteRepositoryState(req, projectRoot)
+	if err != nil {
+		return err
+	}
+	if state.Exists {
+		return s.pullRemoteRepository(req, projectRoot)
+	}
+
+	repositoryURL, err := s.resolveRemoteRepositoryURL(params, tenant, envName)
+	if err != nil {
+		return err
+	}
+	if err := s.waitForRemoteKeyImport(params, tenant, envName, req, repositoryURL, state.PublicKey); err != nil {
+		return err
+	}
+	return s.cloneRemoteRepository(req, projectRoot, repositoryURL)
+}
+
+func (s bootstrapRunner) ensureRemoteRuntime(target OpenResult, req ShellLaunchParams, runtimeVersion string) error {
+	spec, err := resolveDefaultDevopsDeploySpec(target)
+	if err != nil {
+		return err
+	}
+	spec.Deploy.ReleaseName = RuntimeReleaseName(target.Tenant)
+	spec.Deploy.Version = strings.TrimSpace(runtimeVersion)
+	if err := RunDeploySpec(s.Context, spec, nil, nil, s.DeployHelmChart); err != nil {
+		return err
+	}
+
+	s.Context.TraceCommand("", "kubectl", kubectlDeploymentWaitArgs(req)...)
+	if s.Context.DryRun || s.WaitForRemoteRuntime == nil {
+		return nil
+	}
+	return s.WaitForRemoteRuntime(req)
+}
+
+func (s bootstrapRunner) resolveRemoteRepositoryURL(params BootstrapInitParams, tenant, envName string) (string, error) {
+	if params.RemoteRepositoryURL != "" {
+		return params.RemoteRepositoryURL, nil
+	}
+	interaction := BootstrapInitInteraction{
+		Type:  BootstrapInitInteractionRemoteRepository,
+		Label: remoteRepositoryLabel(tenant, envName),
+	}
+	if s.PromptRemoteRepositoryURL == nil {
+		return "", BootstrapInitInteractionError{Interaction: interaction}
+	}
+	repositoryURL, err := s.PromptRemoteRepositoryURL(interaction.Label)
+	if err != nil {
+		return "", err
+	}
+	repositoryURL = strings.TrimSpace(repositoryURL)
+	if repositoryURL == "" {
+		return "", BootstrapInitInteractionError{Interaction: interaction}
+	}
+	return repositoryURL, nil
+}
+
+func (s bootstrapRunner) waitForRemoteKeyImport(params BootstrapInitParams, tenant, envName string, req ShellLaunchParams, repositoryURL, publicKey string) error {
+	publicKey = strings.TrimSpace(publicKey)
+	if publicKey != "" {
+		s.Context.Info("Import this SSH public key into your git host before continuing:")
+		s.Context.Info(publicKey)
+	}
+	if params.ConfirmRemoteKeyImport != nil {
+		if !*params.ConfirmRemoteKeyImport {
+			return fmt.Errorf("remote SSH key import cancelled")
+		}
+	} else if s.Confirm == nil {
+		return BootstrapInitInteractionError{Interaction: BootstrapInitInteraction{
+			Type:    BootstrapInitInteractionConfirmRemoteKey,
+			Label:   remoteKeyImportLabel(tenant, envName),
+			Details: publicKey,
+		}}
+	}
+
+	s.Context.Info("Waiting for the SSH key to be deployed to the git host. Rechecking every 2 seconds. Press Ctrl+C to cancel.")
+	for attempts := 0; ; attempts++ {
+		if err := s.verifyRemoteRepositoryAccess(req, repositoryURL); err == nil {
+			if attempts > 0 {
+				s.Context.Info("Remote repository access confirmed.")
+			}
+			return nil
+		}
+
+		s.Context.Info("SSH key not active yet; retrying in 2 seconds...")
+		if s.Sleep != nil {
+			s.Sleep(remoteRepositoryAccessRetryInterval)
+		}
+	}
+}
+
+func (s bootstrapRunner) remoteRepositoryState(req ShellLaunchParams, projectRoot string) (remoteRepositoryState, error) {
+	script := strings.Join([]string{
+		"set -eu",
+		"mkdir -p \"$HOME/.ssh\"",
+		"chmod 700 \"$HOME/.ssh\"",
+		"key=\"$HOME/.ssh/id_ed25519\"",
+		"if [ ! -f \"$key\" ]; then ssh-keygen -t ed25519 -N '' -f \"$key\" >/dev/null 2>&1; fi",
+		"chmod 600 \"$key\"",
+		"chmod 644 \"$key.pub\"",
+		fmt.Sprintf("mkdir -p %s", shellQuote(projectRoot)),
+		fmt.Sprintf("if [ -d %s/.git ]; then printf 'repo_exists\\n'; else printf 'repo_missing\\n'; fi", shellQuote(projectRoot)),
+		"printf '__ERUN_REMOTE_PUBLIC_KEY__\\n'",
+		"cat \"$key.pub\"",
+	}, "\n")
+
+	output, err := s.runRemoteScript(req, "remote-repository-state", script)
+	if err != nil {
+		return remoteRepositoryState{}, err
+	}
+	if s.Context.DryRun {
+		return remoteRepositoryState{PublicKey: "<remote-public-key>", Exists: false}, nil
+	}
+
+	lines := strings.Split(strings.TrimSpace(output.Stdout), "\n")
+	if len(lines) == 0 {
+		return remoteRepositoryState{}, fmt.Errorf("remote repository state command returned no output")
+	}
+	state := remoteRepositoryState{Exists: strings.TrimSpace(lines[0]) == "repo_exists"}
+	for index, line := range lines {
+		if strings.TrimSpace(line) != "__ERUN_REMOTE_PUBLIC_KEY__" {
+			continue
+		}
+		state.PublicKey = strings.TrimSpace(strings.Join(lines[index+1:], "\n"))
+		break
+	}
+	return state, nil
+}
+
+func (s bootstrapRunner) verifyRemoteRepositoryAccess(req ShellLaunchParams, repositoryURL string) error {
+	script := strings.Join([]string{
+		"set -eu",
+		"ssh_command='ssh -i \"$HOME/.ssh/id_ed25519\" -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new'",
+		fmt.Sprintf("git -c core.sshCommand=\"$ssh_command\" ls-remote %s HEAD >/dev/null", shellQuote(repositoryURL)),
+	}, "\n")
+	output, err := s.runRemoteScript(req, "remote-repository-access", script)
+	if err != nil {
+		return fmt.Errorf("verify remote repository access: %w%s", err, formatRemoteCommandStderr(output.Stderr))
+	}
+	return nil
+}
+
+func (s bootstrapRunner) cloneRemoteRepository(req ShellLaunchParams, projectRoot, repositoryURL string) error {
+	script := strings.Join([]string{
+		"set -eu",
+		"ssh_command='ssh -i \"$HOME/.ssh/id_ed25519\" -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new'",
+		fmt.Sprintf("mkdir -p %s", shellQuote(path.Dir(projectRoot))),
+		fmt.Sprintf("mkdir -p %s", shellQuote(projectRoot)),
+		fmt.Sprintf("if [ -n \"$(ls -A %s 2>/dev/null)\" ] && [ ! -d %s/.git ]; then echo 'remote worktree directory exists and is not empty' >&2; exit 1; fi", shellQuote(projectRoot), shellQuote(projectRoot)),
+		fmt.Sprintf("git -c core.sshCommand=\"$ssh_command\" clone %s %s", shellQuote(repositoryURL), shellQuote(projectRoot)),
+	}, "\n")
+	output, err := s.runRemoteScript(req, "remote-repository-clone", script)
+	if err != nil {
+		return fmt.Errorf("clone remote repository: %w%s", err, formatRemoteCommandStderr(output.Stderr))
+	}
+	return nil
+}
+
+func (s bootstrapRunner) pullRemoteRepository(req ShellLaunchParams, projectRoot string) error {
+	script := strings.Join([]string{
+		"set -eu",
+		"ssh_command='ssh -i \"$HOME/.ssh/id_ed25519\" -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new'",
+		fmt.Sprintf("git -C %s -c core.sshCommand=\"$ssh_command\" pull --ff-only", shellQuote(projectRoot)),
+	}, "\n")
+	output, err := s.runRemoteScript(req, "remote-repository-pull", script)
+	if err != nil {
+		return fmt.Errorf("pull remote repository: %w%s", err, formatRemoteCommandStderr(output.Stderr))
+	}
+	return nil
+}
+
+func (s bootstrapRunner) runRemoteScript(req ShellLaunchParams, label, script string) (RemoteCommandResult, error) {
+	traceArgs := append([]string{}, kubectlRemoteExecArgs(req, script)...)
+	if len(traceArgs) > 0 {
+		traceArgs[len(traceArgs)-1] = "<remote-script>"
+	}
+	s.Context.TraceCommand("", "kubectl", traceArgs...)
+	s.Context.TraceBlock(label, script)
+	if s.Context.DryRun {
+		return RemoteCommandResult{}, nil
+	}
+	return s.RunRemoteCommand(req, script)
+}
+
+func kubectlRemoteExecArgs(req ShellLaunchParams, script string) []string {
+	args := kubectlTargetArgs(req)
+	args = append(args, "exec", "-c", RuntimeReleaseName(req.Tenant))
+	args = append(args, "deployment/"+RuntimeReleaseName(req.Tenant), "--", "/bin/sh", "-lc", script)
+	return args
+}
+
+func RunRemoteCommand(req ShellLaunchParams, script string) (RemoteCommandResult, error) {
+	cmd := exec.Command("kubectl", kubectlRemoteExecArgs(req, script)...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return RemoteCommandResult{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}, err
+}
+
+func formatRemoteCommandStderr(stderr string) string {
+	stderr = strings.TrimSpace(stderr)
+	if stderr == "" {
+		return ""
+	}
+	return ": " + stderr
+}

--- a/erun-common/init_test.go
+++ b/erun-common/init_test.go
@@ -2,10 +2,12 @@ package eruncommon
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/adrg/xdg"
 )
@@ -29,31 +31,48 @@ type bootstrapTestRunner struct {
 	Confirm                   ConfirmFunc
 	PromptKubernetesContext   PromptValueFunc
 	PromptContainerRegistry   PromptValueFunc
+	PromptRemoteRepositoryURL PromptValueFunc
 	EnsureKubernetesNamespace NamespaceEnsurerFunc
 	LoadProjectConfig         ProjectConfigLoaderFunc
 	SaveProjectConfig         ProjectConfigSaverFunc
+	WaitForRemoteRuntime      RemoteRuntimeWaitFunc
+	RunRemoteCommand          RemoteCommandRunnerFunc
+	DeployHelmChart           HelmChartDeployerFunc
+	Sleep                     SleepFunc
 	Context                   Context
 }
 
 func (r bootstrapTestRunner) Run(params BootstrapInitParams) (BootstrapInitResult, error) {
-	return RunBootstrapInit(
-		r.Context,
-		params,
-		r.Store,
-		r.FindProjectRoot,
-		r.GetWorkingDir,
-		r.SelectTenant,
-		r.Confirm,
-		r.PromptKubernetesContext,
-		r.PromptContainerRegistry,
-		r.EnsureKubernetesNamespace,
-		r.LoadProjectConfig,
-		r.SaveProjectConfig,
-	)
+	return RunBootstrapInitWithDependencies(BootstrapInitDependencies{
+		Store:                     r.Store,
+		FindProjectRoot:           r.FindProjectRoot,
+		GetWorkingDir:             r.GetWorkingDir,
+		SelectTenant:              r.SelectTenant,
+		Confirm:                   r.Confirm,
+		PromptKubernetesContext:   r.PromptKubernetesContext,
+		PromptContainerRegistry:   r.PromptContainerRegistry,
+		PromptRemoteRepositoryURL: r.PromptRemoteRepositoryURL,
+		EnsureKubernetesNamespace: r.EnsureKubernetesNamespace,
+		LoadProjectConfig:         r.LoadProjectConfig,
+		SaveProjectConfig:         r.SaveProjectConfig,
+		WaitForRemoteRuntime:      r.WaitForRemoteRuntime,
+		RunRemoteCommand:          r.RunRemoteCommand,
+		DeployHelmChart:           r.DeployHelmChart,
+		Sleep:                     r.Sleep,
+		Context:                   r.Context,
+	}, params)
 }
 
 func (r bootstrapTestRunner) saveProjectContainerRegistry(projectRoot, envName, registry string) error {
-	return bootstrapRunner(r).saveProjectContainerRegistry(projectRoot, envName, registry)
+	return bootstrapRunner{
+		BootstrapInitDependencies: BootstrapInitDependencies{
+			Store:             r.Store,
+			LoadProjectConfig: r.LoadProjectConfig,
+			SaveProjectConfig: r.SaveProjectConfig,
+			Context:           r.Context,
+		},
+		Context: r.Context,
+	}.saveProjectContainerRegistry(projectRoot, envName, registry, false)
 }
 
 func TestBootstrapRunLoadsExistingConfiguration(t *testing.T) {
@@ -851,7 +870,63 @@ func TestBootstrapRunLogsOutsideGitRepository(t *testing.T) {
 	}
 }
 
-func TestBootstrapRunTenantConfirmationRejected(t *testing.T) {
+func TestBootstrapRunDecliningDefaultTenantStillInitializes(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	projectRoot := t.TempDir()
+	prompts := make([]string, 0, 2)
+	service := bootstrapTestRunner{
+		Store: ConfigStore{},
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		Confirm: func(label string) (bool, error) {
+			prompts = append(prompts, label)
+			return label != tenantConfirmationLabel("tenant-a", projectRoot), nil
+		},
+		PromptKubernetesContext: func(string) (string, error) {
+			return "cluster-review", nil
+		},
+		PromptContainerRegistry: func(string) (string, error) {
+			return DefaultContainerRegistry, nil
+		},
+		EnsureKubernetesNamespace: func(string, string) error {
+			return nil
+		},
+	}
+
+	result, err := service.Run(BootstrapInitParams{Environment: "review"})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	if result.CreatedERunConfig {
+		t.Fatalf("did not expect erun config to be created, got %+v", result)
+	}
+	if !result.CreatedTenantConfig || !result.CreatedEnvConfig {
+		t.Fatalf("expected tenant and environment config to be created, got %+v", result)
+	}
+	if result.TenantConfig.Name != "tenant-a" || result.EnvConfig.Name != "review" {
+		t.Fatalf("unexpected init result: %+v", result)
+	}
+	if _, _, err := LoadERunConfig(); !errors.Is(err, ErrNotInitialized) {
+		t.Fatalf("expected default tenant config to remain unset, got %v", err)
+	}
+	wantPrompts := []string{
+		tenantConfirmationLabel("tenant-a", projectRoot),
+		environmentConfirmationLabel("tenant-a", "review"),
+	}
+	if len(prompts) != len(wantPrompts) {
+		t.Fatalf("unexpected prompts: %+v", prompts)
+	}
+	for i := range wantPrompts {
+		if prompts[i] != wantPrompts[i] {
+			t.Fatalf("unexpected prompt %d: got %q want %q", i, prompts[i], wantPrompts[i])
+		}
+	}
+}
+
+func TestBootstrapRunDecliningDefaultTenantViaParamStillInitializes(t *testing.T) {
 	setupXDGConfigHome(t)
 
 	projectRoot := t.TempDir()
@@ -860,13 +935,32 @@ func TestBootstrapRunTenantConfirmationRejected(t *testing.T) {
 		FindProjectRoot: func() (string, string, error) {
 			return "tenant-a", projectRoot, nil
 		},
-		Confirm: func(string) (bool, error) {
-			return false, nil
+		PromptKubernetesContext: func(string) (string, error) {
+			return "cluster-review", nil
+		},
+		PromptContainerRegistry: func(string) (string, error) {
+			return DefaultContainerRegistry, nil
+		},
+		EnsureKubernetesNamespace: func(string, string) error {
+			return nil
 		},
 	}
 
-	if _, err := service.Run(BootstrapInitParams{}); !errors.Is(err, ErrTenantInitializationCancelled) {
-		t.Fatalf("expected tenant cancellation, got %v", err)
+	confirmTenant := false
+	confirmEnvironment := true
+	result, err := service.Run(BootstrapInitParams{
+		Environment:        "review",
+		ConfirmTenant:      &confirmTenant,
+		ConfirmEnvironment: &confirmEnvironment,
+	})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.CreatedERunConfig {
+		t.Fatalf("did not expect erun config to be created, got %+v", result)
+	}
+	if _, _, err := LoadERunConfig(); !errors.Is(err, ErrNotInitialized) {
+		t.Fatalf("expected default tenant config to remain unset, got %v", err)
 	}
 }
 
@@ -927,6 +1021,231 @@ func TestBootstrapRunPropagatesSaveErrors(t *testing.T) {
 
 	if _, err := service.Run(BootstrapInitParams{}); !errors.Is(err, ErrFailedToSaveConfig) {
 		t.Fatalf("expected save error, got %v", err)
+	}
+}
+
+func TestBootstrapRunRemoteInitializesTenantInPodWorktree(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	var waited ShellLaunchParams
+	scripts := make([]string, 0, 3)
+	service := bootstrapTestRunner{
+		Context: testContextWithLogger(&testTraceLogger{}),
+		Store:   ConfigStore{},
+		FindProjectRoot: func() (string, string, error) {
+			t.Fatal("did not expect local project detection for remote init")
+			return "", "", nil
+		},
+		Confirm: func(string) (bool, error) {
+			return true, nil
+		},
+		PromptKubernetesContext: func(string) (string, error) {
+			return "cluster-remote", nil
+		},
+		PromptContainerRegistry: func(string) (string, error) {
+			return "registry.example.com/remote", nil
+		},
+		PromptRemoteRepositoryURL: func(label string) (string, error) {
+			if label != remoteRepositoryLabel("frs", "dev") {
+				t.Fatalf("unexpected repository label: %q", label)
+			}
+			return "git@github.com:sophium/frs.git", nil
+		},
+		EnsureKubernetesNamespace: func(contextName, namespace string) error {
+			if contextName != "cluster-remote" || namespace != "frs-dev" {
+				t.Fatalf("unexpected namespace ensure: %s %s", contextName, namespace)
+			}
+			return nil
+		},
+		DeployHelmChart: func(params HelmDeployParams) error {
+			if params.WorktreeStorage != WorktreeStoragePVC {
+				t.Fatalf("expected pvc worktree storage, got %+v", params)
+			}
+			if params.WorktreeRepoName != "frs" {
+				t.Fatalf("unexpected worktree repo name: %+v", params)
+			}
+			if params.Version != "1.2.3" {
+				t.Fatalf("expected remote runtime version override, got %+v", params)
+			}
+			return nil
+		},
+		WaitForRemoteRuntime: func(req ShellLaunchParams) error {
+			waited = req
+			return nil
+		},
+		RunRemoteCommand: func(req ShellLaunchParams, script string) (RemoteCommandResult, error) {
+			scripts = append(scripts, script)
+			switch len(scripts) {
+			case 1:
+				return RemoteCommandResult{
+					Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n",
+				}, nil
+			case 2, 3:
+				return RemoteCommandResult{}, nil
+			default:
+				t.Fatalf("unexpected remote command script:\n%s", script)
+				return RemoteCommandResult{}, nil
+			}
+		},
+	}
+
+	result, err := service.Run(BootstrapInitParams{
+		Tenant:         "frs",
+		Environment:    "dev",
+		Remote:         true,
+		RuntimeVersion: "1.2.3",
+	})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	remotePath := RemoteWorktreePathForRepoName("frs")
+	if result.TenantConfig.ProjectRoot != remotePath || !result.TenantConfig.Remote {
+		t.Fatalf("unexpected tenant config: %+v", result.TenantConfig)
+	}
+	if result.EnvConfig.RepoPath != remotePath || !result.EnvConfig.Remote {
+		t.Fatalf("unexpected env config: %+v", result.EnvConfig)
+	}
+	if result.EnvConfig.ContainerRegistry != "registry.example.com/remote" {
+		t.Fatalf("expected remote container registry to be persisted, got %+v", result.EnvConfig)
+	}
+	if waited.Dir != remotePath || waited.KubernetesContext != "cluster-remote" {
+		t.Fatalf("unexpected wait request: %+v", waited)
+	}
+	if len(scripts) != 3 {
+		t.Fatalf("expected state/access/clone remote commands, got %d", len(scripts))
+	}
+
+	savedEnv, _, err := LoadEnvConfig("frs", "dev")
+	if err != nil {
+		t.Fatalf("LoadEnvConfig failed: %v", err)
+	}
+	if !savedEnv.Remote || savedEnv.ContainerRegistry != "registry.example.com/remote" {
+		t.Fatalf("unexpected saved env config: %+v", savedEnv)
+	}
+}
+
+func TestBootstrapRunRemoteWaitsForSSHKeyImportAndRetries(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	logger := &testTraceLogger{}
+	var sleepCalls int
+	scripts := make([]string, 0, 5)
+	service := bootstrapTestRunner{
+		Context: testContextWithLogger(logger),
+		Store:   ConfigStore{},
+		Confirm: func(string) (bool, error) {
+			return true, nil
+		},
+		PromptKubernetesContext: func(string) (string, error) {
+			return "cluster-remote", nil
+		},
+		PromptContainerRegistry: func(string) (string, error) {
+			return DefaultContainerRegistry, nil
+		},
+		PromptRemoteRepositoryURL: func(string) (string, error) {
+			return "git@github.com:sophium/frs.git", nil
+		},
+		EnsureKubernetesNamespace: func(string, string) error {
+			return nil
+		},
+		DeployHelmChart: func(HelmDeployParams) error {
+			return nil
+		},
+		WaitForRemoteRuntime: func(ShellLaunchParams) error {
+			return nil
+		},
+		RunRemoteCommand: func(req ShellLaunchParams, script string) (RemoteCommandResult, error) {
+			scripts = append(scripts, script)
+			switch len(scripts) {
+			case 1:
+				return RemoteCommandResult{
+					Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n",
+				}, nil
+			case 2, 3:
+				return RemoteCommandResult{
+					Stderr: "Permission denied (publickey).",
+				}, fmt.Errorf("exit status 128")
+			case 4, 5:
+				return RemoteCommandResult{}, nil
+			default:
+				t.Fatalf("unexpected remote command script:\n%s", script)
+				return RemoteCommandResult{}, nil
+			}
+		},
+		Sleep: func(duration time.Duration) {
+			sleepCalls++
+			if duration != remoteRepositoryAccessRetryInterval {
+				t.Fatalf("unexpected sleep duration: %s", duration)
+			}
+		},
+	}
+
+	_, err := service.Run(BootstrapInitParams{
+		Tenant:      "frs",
+		Environment: "dev",
+		Remote:      true,
+	})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	if sleepCalls != 2 {
+		t.Fatalf("expected 2 sleep calls, got %d", sleepCalls)
+	}
+	if len(scripts) != 5 {
+		t.Fatalf("expected state/access/access/access/clone remote commands, got %d", len(scripts))
+	}
+	if !logger.containsTrace("Waiting for the SSH key to be deployed to the git host. Rechecking every 2 seconds. Press Ctrl+C to cancel.") {
+		t.Fatalf("expected waiting message, got %+v", logger.traces)
+	}
+	if !logger.containsTrace("SSH key not active yet; retrying in 2 seconds...") {
+		t.Fatalf("expected retry message, got %+v", logger.traces)
+	}
+	if !logger.containsTrace("Remote repository access confirmed.") {
+		t.Fatalf("expected success message, got %+v", logger.traces)
+	}
+}
+
+func TestBootstrapRunRemoteRequestsRepositoryURLWhenCheckoutMissing(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	service := bootstrapTestRunner{
+		Context: testContextWithLogger(&testTraceLogger{}),
+		Store:   ConfigStore{},
+		Confirm: func(string) (bool, error) {
+			return true, nil
+		},
+		PromptKubernetesContext: func(string) (string, error) {
+			return "cluster-remote", nil
+		},
+		PromptContainerRegistry: func(string) (string, error) {
+			return DefaultContainerRegistry, nil
+		},
+		DeployHelmChart: func(HelmDeployParams) error {
+			return nil
+		},
+		WaitForRemoteRuntime: func(ShellLaunchParams) error {
+			return nil
+		},
+		RunRemoteCommand: func(req ShellLaunchParams, script string) (RemoteCommandResult, error) {
+			return RemoteCommandResult{
+				Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n",
+			}, nil
+		},
+	}
+
+	_, err := service.Run(BootstrapInitParams{
+		Tenant:      "frs",
+		Environment: "dev",
+		Remote:      true,
+	})
+	interaction, ok := AsBootstrapInitInteraction(err)
+	if !ok {
+		t.Fatalf("expected interaction, got %v", err)
+	}
+	if interaction.Type != BootstrapInitInteractionRemoteRepository {
+		t.Fatalf("unexpected interaction: %+v", interaction)
 	}
 }
 

--- a/erun-common/list.go
+++ b/erun-common/list.go
@@ -14,6 +14,7 @@ type ListStore interface {
 }
 
 type ListResult struct {
+	ConfigDirectory  string                     `json:"configDirectory,omitempty"`
 	Defaults         ListDefaultsResult         `json:"defaults"`
 	CurrentDirectory ListCurrentDirectoryResult `json:"currentDirectory"`
 	Tenants          []ListTenantResult         `json:"tenants,omitempty"`
@@ -77,7 +78,9 @@ func ResolveListResult(store ListStore, findProjectRoot ProjectFinderFunc, param
 	}
 
 	effectiveResult, effectiveErr := ResolveOpen(store, params)
+	configDir, configDirErr := ERunConfigDir()
 	result := ListResult{
+		ConfigDirectory: strings.TrimSpace(configDir),
 		Defaults: ListDefaultsResult{
 			Tenant:      defaultTenant,
 			Environment: defaultEnvironment,
@@ -88,6 +91,9 @@ func ResolveListResult(store ListStore, findProjectRoot ProjectFinderFunc, param
 			ConfiguredTenant: configuredTenantForRepo(currentRepoName, tenants),
 		},
 		Tenants: make([]ListTenantResult, 0, len(tenants)),
+	}
+	if configDirErr != nil {
+		return ListResult{}, configDirErr
 	}
 
 	if effectiveErr != nil {

--- a/erun-common/list_test.go
+++ b/erun-common/list_test.go
@@ -19,6 +19,11 @@ func (s listStore) ListEnvConfigs(tenant string) ([]EnvConfig, error) {
 }
 
 func TestResolveListResultUsesCurrentDirectoryTenantBeforeDefault(t *testing.T) {
+	configDir, err := ERunConfigDir()
+	if err != nil {
+		t.Fatalf("ERunConfigDir failed: %v", err)
+	}
+
 	originalDir, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
@@ -72,6 +77,9 @@ func TestResolveListResultUsesCurrentDirectoryTenantBeforeDefault(t *testing.T) 
 
 	if result.Defaults.Tenant != "tenant-a" || result.Defaults.Environment != "local" {
 		t.Fatalf("unexpected defaults: %+v", result.Defaults)
+	}
+	if result.ConfigDirectory != configDir {
+		t.Fatalf("unexpected config directory: %+v", result)
 	}
 	if result.CurrentDirectory.Repo != "tenant-b" || result.CurrentDirectory.ConfiguredTenant != "tenant-b" {
 		t.Fatalf("unexpected current directory: %+v", result.CurrentDirectory)

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -24,6 +24,8 @@ var (
 	ErrKubernetesContextNotConfigured  = errors.New("kubernetes context is not configured")
 	ErrRepoPathNotConfigured           = errors.New("repo path is not configured")
 	ErrShellReattachDeploy             = errors.New("remote shell requested deploy handoff and reattach")
+
+	openUserHomeDir = os.UserHomeDir
 )
 
 const defaultShellLaunchWaitTimeout = "2m0s"
@@ -55,6 +57,10 @@ type OpenResult struct {
 	Title        string
 }
 
+func (r OpenResult) RemoteRepo() bool {
+	return r.EnvConfig.Remote || r.TenantConfig.Remote
+}
+
 type ShellLaunchParams struct {
 	Dir               string
 	Tenant            string
@@ -62,6 +68,7 @@ type ShellLaunchParams struct {
 	Title             string
 	Namespace         string
 	KubernetesContext string
+	RemoteRepo        bool
 }
 
 type ShellLaunchPreview struct {
@@ -242,12 +249,14 @@ func ResolveOpen(store OpenStore, params OpenParams) (OpenResult, error) {
 	}
 
 	repoPath = filepath.Clean(repoPath)
-	info, err := os.Stat(repoPath)
-	if err != nil {
-		return OpenResult{}, err
-	}
-	if !info.IsDir() {
-		return OpenResult{}, fmt.Errorf("%q is not a directory", repoPath)
+	if !(envConfig.Remote || tenantConfig.Remote) {
+		info, err := os.Stat(repoPath)
+		if err != nil {
+			return OpenResult{}, err
+		}
+		if !info.IsDir() {
+			return OpenResult{}, fmt.Errorf("%q is not a directory", repoPath)
+		}
 	}
 	if strings.TrimSpace(envConfig.KubernetesContext) == "" {
 		return OpenResult{}, fmt.Errorf("%w: %s/%s", ErrKubernetesContextNotConfigured, tenant, environment)
@@ -374,6 +383,7 @@ func ShellLaunchParamsFromResult(result OpenResult) ShellLaunchParams {
 		Title:             result.Title,
 		Namespace:         KubernetesNamespaceName(result.Tenant, result.Environment),
 		KubernetesContext: strings.TrimSpace(result.EnvConfig.KubernetesContext),
+		RemoteRepo:        result.RemoteRepo(),
 	}
 }
 
@@ -436,6 +446,14 @@ func RemoteShellWorktreePath(req ShellLaunchParams) string {
 	return remoteWorktreePath(req)
 }
 
+func RemoteWorktreePathForRepoName(repoName string) string {
+	repoName = strings.TrimSpace(repoName)
+	if repoName == "" {
+		repoName = "worktree"
+	}
+	return path.Join("/home", "erun", "git", repoName)
+}
+
 func RuntimeReleaseName(tenant string) string {
 	tenant = strings.TrimSpace(tenant)
 	if tenant == "" {
@@ -475,6 +493,7 @@ func buildRemoteShellScript(req ShellLaunchParams, redactHostSecrets bool) (stri
 		Name:               req.Tenant,
 		ProjectRoot:        remoteWorkdir,
 		DefaultEnvironment: req.Environment,
+		Remote:             req.RemoteRepo,
 	})
 	if err != nil {
 		return "", err
@@ -489,6 +508,7 @@ func buildRemoteShellScript(req ShellLaunchParams, redactHostSecrets bool) (stri
 		Name:              req.Environment,
 		RepoPath:          remoteWorkdir,
 		KubernetesContext: req.KubernetesContext,
+		Remote:            req.RemoteRepo,
 	})
 	if err != nil {
 		return "", err
@@ -523,48 +543,50 @@ func buildRemoteShellScript(req ShellLaunchParams, redactHostSecrets bool) (stri
 		"exit \"$shell_status\"",
 	}
 
-	if gitHost, gitUser, gitRepo, err := resolveGitRemote(req.Dir); err == nil {
-		hostConfigEntries, err := resolveSSHConfigEntries(gitHost)
-		if err != nil {
-			return "", err
+	if !req.RemoteRepo {
+		if gitHost, gitUser, gitRepo, err := resolveGitRemote(req.Dir); err == nil {
+			hostConfigEntries, err := resolveSSHConfigEntries(gitHost)
+			if err != nil {
+				return "", err
+			}
+
+			knownHostsLines, err := loadKnownHostsLines(gitHost)
+			if err != nil {
+				return "", err
+			}
+
+			keyLines, err := loadPrivateKeyMaterial(hostConfigEntries, redactHostSecrets)
+			if err != nil {
+				return "", err
+			}
+
+			knownHosts := strings.Join(knownHostsLines, "\n")
+			keys := strings.Join(keyLines, "\n")
+			gitUser = shellQuote(gitUser)
+			gitRepo = shellQuote(gitRepo)
+			sshConfig := strings.Join([]string{
+				fmt.Sprintf("Host %s", gitHost),
+				fmt.Sprintf("  HostName %s", gitHost),
+				"  IdentityFile ~/.ssh/keys",
+				"  IdentitiesOnly yes",
+				"  UserKnownHostsFile ~/.ssh/known_hosts",
+			}, "\n")
+
+			scriptLines = append([]string{
+				"set -eu",
+				"mkdir -p \"$HOME/.ssh\"",
+				"chmod 700 \"$HOME/.ssh\"",
+				fmt.Sprintf("cat > \"$HOME/.ssh/known_hosts\" <<'EOF'\n%s\nEOF", knownHosts),
+				"chmod 600 \"$HOME/.ssh/known_hosts\"",
+				fmt.Sprintf("cat > \"$HOME/.ssh/keys\" <<'EOF'\n%s\nEOF", keys),
+				"chmod 600 \"$HOME/.ssh/keys\"",
+				fmt.Sprintf("cat > \"$HOME/.ssh/config\" <<'EOF'\n%s\nEOF", sshConfig),
+				"chmod 600 \"$HOME/.ssh/config\"",
+				fmt.Sprintf("mkdir -p %s", workdir),
+				fmt.Sprintf("cd %s", workdir),
+				fmt.Sprintf("if command -v git >/dev/null 2>&1; then if [ ! -d .git ]; then git clone git@%s:%s/%s.git .; fi; git config --global --add safe.directory '*'; fi", gitHost, gitUser, gitRepo),
+			}, scriptLines[1:]...)
 		}
-
-		knownHostsLines, err := loadKnownHostsLines(gitHost)
-		if err != nil {
-			return "", err
-		}
-
-		keyLines, err := loadPrivateKeyMaterial(hostConfigEntries, redactHostSecrets)
-		if err != nil {
-			return "", err
-		}
-
-		knownHosts := strings.Join(knownHostsLines, "\n")
-		keys := strings.Join(keyLines, "\n")
-		gitUser = shellQuote(gitUser)
-		gitRepo = shellQuote(gitRepo)
-		sshConfig := strings.Join([]string{
-			fmt.Sprintf("Host %s", gitHost),
-			fmt.Sprintf("  HostName %s", gitHost),
-			"  IdentityFile ~/.ssh/keys",
-			"  IdentitiesOnly yes",
-			"  UserKnownHostsFile ~/.ssh/known_hosts",
-		}, "\n")
-
-		scriptLines = append([]string{
-			"set -eu",
-			"mkdir -p \"$HOME/.ssh\"",
-			"chmod 700 \"$HOME/.ssh\"",
-			fmt.Sprintf("cat > \"$HOME/.ssh/known_hosts\" <<'EOF'\n%s\nEOF", knownHosts),
-			"chmod 600 \"$HOME/.ssh/known_hosts\"",
-			fmt.Sprintf("cat > \"$HOME/.ssh/keys\" <<'EOF'\n%s\nEOF", keys),
-			"chmod 600 \"$HOME/.ssh/keys\"",
-			fmt.Sprintf("cat > \"$HOME/.ssh/config\" <<'EOF'\n%s\nEOF", sshConfig),
-			"chmod 600 \"$HOME/.ssh/config\"",
-			fmt.Sprintf("mkdir -p %s", workdir),
-			fmt.Sprintf("cd %s", workdir),
-			fmt.Sprintf("if command -v git >/dev/null 2>&1; then if [ ! -d .git ]; then git clone git@%s:%s/%s.git .; fi; git config --global --add safe.directory '*'; fi", gitHost, gitUser, gitRepo),
-		}, scriptLines[1:]...)
 	}
 
 	script := strings.Join(scriptLines, "\n")
@@ -573,7 +595,7 @@ func buildRemoteShellScript(req ShellLaunchParams, redactHostSecrets bool) (stri
 }
 
 func remoteWorktreePath(req ShellLaunchParams) string {
-	return path.Join("/home", "erun", "git", remoteWorktreeRepoName(req))
+	return RemoteWorktreePathForRepoName(remoteWorktreeRepoName(req))
 }
 
 func remoteWorktreeRepoName(req ShellLaunchParams) string {
@@ -631,7 +653,7 @@ func splitRepoPath(repoPath string) (string, string) {
 }
 
 func resolveSSHConfigEntries(host string) ([]sshConfigEntry, error) {
-	sshConfigPath := filepath.Join(os.Getenv("HOME"), ".ssh", "config")
+	sshConfigPath := filepath.Join(resolveOpenUserHomeDir(), ".ssh", "config")
 	data, err := os.ReadFile(sshConfigPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -651,7 +673,7 @@ func resolveSSHConfigEntries(host string) ([]sshConfigEntry, error) {
 }
 
 func loadKnownHostsLines(host string) ([]string, error) {
-	knownHostsPath := filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts")
+	knownHostsPath := filepath.Join(resolveOpenUserHomeDir(), ".ssh", "known_hosts")
 	data, err := os.ReadFile(knownHostsPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -699,7 +721,7 @@ func loadPrivateKeyMaterial(entries []sshConfigEntry, redact bool) ([]string, er
 
 	if len(keyPaths) == 0 {
 		for _, fallback := range []string{"id_rsa", "id_ed25519", "id_ecdsa"} {
-			addKeyPath(filepath.Join(os.Getenv("HOME"), ".ssh", fallback))
+			addKeyPath(filepath.Join(resolveOpenUserHomeDir(), ".ssh", fallback))
 		}
 	}
 
@@ -779,7 +801,15 @@ func parseSSHConfig(contents string) []sshConfigEntry {
 func expandSSHPath(value string) string {
 	value = strings.TrimSpace(value)
 	if strings.HasPrefix(value, "~/") {
-		return filepath.Join(os.Getenv("HOME"), strings.TrimPrefix(value, "~/"))
+		return filepath.Join(resolveOpenUserHomeDir(), strings.TrimPrefix(value, "~/"))
 	}
 	return value
+}
+
+func resolveOpenUserHomeDir() string {
+	homeDir, err := openUserHomeDir()
+	if err == nil && strings.TrimSpace(homeDir) != "" {
+		return homeDir
+	}
+	return strings.TrimSpace(os.Getenv("HOME"))
 }

--- a/erun-common/open_test.go
+++ b/erun-common/open_test.go
@@ -47,6 +47,42 @@ func TestOpenResolveUsesDefaultTenantAndEnvironment(t *testing.T) {
 	}
 }
 
+func TestOpenResolveAllowsRemoteRepoPathWithoutLocalCheckout(t *testing.T) {
+	store := openStore{
+		toolConfig: ERunConfig{DefaultTenant: "frs"},
+		tenantConfigs: map[string]TenantConfig{
+			"frs": {
+				Name:               "frs",
+				ProjectRoot:        "/home/erun/git/frs",
+				DefaultEnvironment: "dev",
+				Remote:             true,
+			},
+		},
+		envConfigs: map[string]EnvConfig{
+			"frs/dev": {
+				Name:              "dev",
+				RepoPath:          "/home/erun/git/frs",
+				KubernetesContext: "cluster-dev",
+				Remote:            true,
+			},
+		},
+	}
+
+	result, err := ResolveOpen(store, OpenParams{
+		UseDefaultTenant:      true,
+		UseDefaultEnvironment: true,
+	})
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if !result.RemoteRepo() {
+		t.Fatalf("expected remote repo result, got %+v", result)
+	}
+	if result.RepoPath != "/home/erun/git/frs" {
+		t.Fatalf("unexpected repo path: %+v", result)
+	}
+}
+
 func TestOpenResolveUsesCurrentDirectoryTenantBeforeDefault(t *testing.T) {
 	originalDir, err := os.Getwd()
 	if err != nil {
@@ -474,6 +510,42 @@ func TestRemoteShellScriptUsesRepoBasenameForRemoteWorkdir(t *testing.T) {
 	}
 }
 
+func TestRemoteShellScriptMarksRemoteConfigsAndSkipsHostGitBootstrap(t *testing.T) {
+	script, err := buildRemoteShellScript(ShellLaunchParams{
+		Dir:               "/home/erun/git/erun",
+		Tenant:            "erun",
+		Environment:       "remote",
+		Title:             "erun-remote",
+		KubernetesContext: "in-cluster",
+		RemoteRepo:        true,
+	}, true)
+	if err != nil {
+		t.Fatalf("buildRemoteShellScript failed: %v", err)
+	}
+
+	if strings.Contains(script, "git clone git@") {
+		t.Fatalf("did not expect host git bootstrap in remote repo shell script, got:\n%s", script)
+	}
+
+	tenantConfigBody := extractHeredoc(t, script, `cat > "$config_home/erun/erun/config.yaml" <<'EOF'`)
+	var tenantConfig TenantConfig
+	if err := yaml.Unmarshal([]byte(tenantConfigBody), &tenantConfig); err != nil {
+		t.Fatalf("expected tenant config heredoc to be valid yaml, got %v\n%s", err, tenantConfigBody)
+	}
+	if !tenantConfig.Remote {
+		t.Fatalf("expected remote tenant config, got %+v", tenantConfig)
+	}
+
+	envConfigBody := extractHeredoc(t, script, `cat > "$config_home/erun/erun/remote/config.yaml" <<'EOF'`)
+	var envConfig EnvConfig
+	if err := yaml.Unmarshal([]byte(envConfigBody), &envConfig); err != nil {
+		t.Fatalf("expected env config heredoc to be valid yaml, got %v\n%s", err, envConfigBody)
+	}
+	if !envConfig.Remote {
+		t.Fatalf("expected remote env config, got %+v", envConfig)
+	}
+}
+
 func TestRemoteShellScriptUsesOnlySSHCredentialsRelevantToRepoRemote(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
@@ -509,6 +581,43 @@ func TestRemoteShellScriptUsesOnlySSHCredentialsRelevantToRepoRemote(t *testing.
 	}
 	if strings.Contains(script, "OTHER PRIVATE KEY") {
 		t.Fatalf("did not expect unrelated private key in script, got:\n%s", script)
+	}
+}
+
+func TestRemoteShellScriptLoadsSSHConfigFromUserHomeDirWhenHOMEIsUnset(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", "")
+	previousUserHomeDir := openUserHomeDir
+	openUserHomeDir = func() (string, error) { return homeDir, nil }
+	t.Cleanup(func() {
+		openUserHomeDir = previousUserHomeDir
+	})
+
+	repoDir := createGitRepoWithRemote(t, "git@github.com:sophium/erun.git")
+	sshDir := filepath.Join(homeDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o755); err != nil {
+		t.Fatalf("mkdir .ssh: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sshDir, "config"), []byte("Host github.com\n  IdentityFile ~/.ssh/id_ed25519\n"), 0o600); err != nil {
+		t.Fatalf("write ssh config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sshDir, "id_ed25519"), []byte("PRIVATE KEY"), 0o600); err != nil {
+		t.Fatalf("write ssh key: %v", err)
+	}
+
+	script, err := buildRemoteShellScript(ShellLaunchParams{
+		Dir:               repoDir,
+		Tenant:            "tenant-a",
+		Environment:       "local",
+		Title:             "tenant-a-local",
+		KubernetesContext: "in-cluster",
+	}, false)
+	if err != nil {
+		t.Fatalf("buildRemoteShellScript failed: %v", err)
+	}
+
+	if !strings.Contains(script, "PRIVATE KEY") {
+		t.Fatalf("expected private key to be loaded from user home dir, got:\n%s", script)
 	}
 }
 

--- a/erun-devops/docker/erun-devops/entrypoint.sh
+++ b/erun-devops/docker/erun-devops/entrypoint.sh
@@ -54,15 +54,41 @@ runtime_repo_dir() {
     printf '%s\n' "${ERUN_REPO_PATH:-${HOME}/git/erun}"
 }
 
+runtime_repo_is_remote() {
+    case "${ERUN_REPO_REMOTE:-}" in
+        1|true|TRUE|True|yes|YES|on|ON)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+runtime_namespace() {
+    if [ -n "${ERUN_NAMESPACE:-}" ]; then
+        printf '%s\n' "${ERUN_NAMESPACE}"
+        return
+    fi
+
+    namespace_file=/var/run/secrets/kubernetes.io/serviceaccount/namespace
+    if [ -r "${namespace_file}" ]; then
+        cat "${namespace_file}"
+    fi
+}
+
 initialize_erun_config() {
     repo_dir=$(runtime_repo_dir)
     tenant="${ERUN_TENANT:-}"
     environment="${ERUN_ENVIRONMENT:-}"
     config_home="${XDG_CONFIG_HOME:-${HOME}/.config}"
     config_dir="${config_home}/erun"
+    remote_line=""
 
     if [ -z "${tenant}" ] || [ -z "${environment}" ]; then
         return
+    fi
+
+    if runtime_repo_is_remote; then
+        remote_line="remote: true"
     fi
 
     mkdir -p "${config_dir}/${tenant}/${environment}"
@@ -75,12 +101,14 @@ EOF
 projectroot: ${repo_dir}
 name: ${tenant}
 defaultenvironment: ${environment}
+${remote_line}
 EOF
 
     cat >"${config_dir}/${tenant}/${environment}/config.yaml" <<EOF
 name: ${environment}
 repopath: ${repo_dir}
 kubernetescontext: ${ERUN_KUBERNETES_CONTEXT:-in-cluster}
+${remote_line}
 EOF
 }
 
@@ -104,4 +132,15 @@ fi
 
 initialize_erun_config
 
-exec erun mcp "$@"
+set -- emcp "$@" \
+    --tenant "${ERUN_TENANT:-}" \
+    --environment "${ERUN_ENVIRONMENT:-}" \
+    --repo-path "$(runtime_repo_dir)" \
+    --kubernetes-context "${ERUN_KUBERNETES_CONTEXT:-in-cluster}"
+
+namespace=$(runtime_namespace)
+if [ -n "${namespace}" ]; then
+    set -- "$@" --namespace "${namespace}"
+fi
+
+exec "$@"

--- a/erun-devops/k8s/erun-devops/templates/service.yaml
+++ b/erun-devops/k8s/erun-devops/templates/service.yaml
@@ -82,12 +82,18 @@ spec:
               value: "1"
             - name: ERUN_REPO_PATH
               value: {{ printf "/home/erun/git/%s" (base (required "worktreeHostPath is required" .Values.worktreeHostPath)) | quote }}
+            - name: ERUN_REPO_REMOTE
+              value: "false"
             - name: ERUN_KUBERNETES_CONTEXT
               value: in-cluster
             - name: ERUN_TENANT
               value: {{ required "tenant is required" .Values.tenant | quote }}
             - name: ERUN_ENVIRONMENT
               value: {{ required "environment is required" .Values.environment | quote }}
+            - name: ERUN_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/erun-mcp/init.go
+++ b/erun-mcp/init.go
@@ -15,10 +15,14 @@ type InitInput struct {
 	InitializeCurrentProject bool   `json:"initializeCurrentProject,omitempty" jsonschema:"when true, answer the tenant selection interaction by choosing the current project"`
 	ProjectRoot              string `json:"projectRoot,omitempty" jsonschema:"optional project root to bind to the tenant"`
 	Environment              string `json:"environment,omitempty" jsonschema:"optional environment name to initialize"`
+	Version                  string `json:"version,omitempty" jsonschema:"optional runtime image version to initialize and deploy"`
 	KubernetesContext        string `json:"kubernetesContext,omitempty" jsonschema:"optional kubernetes context to associate with the environment"`
 	ContainerRegistry        string `json:"containerRegistry,omitempty" jsonschema:"optional container registry to associate with the environment"`
+	Remote                   bool   `json:"remote,omitempty" jsonschema:"when true, initialize the repository inside the runtime pod"`
+	RemoteRepositoryURL      string `json:"remoteRepositoryURL,omitempty" jsonschema:"optional SSH repository URL used when creating the remote checkout"`
 	ConfirmTenant            *bool  `json:"confirmTenant,omitempty" jsonschema:"response to a prior tenant confirmation interaction"`
 	ConfirmEnvironment       *bool  `json:"confirmEnvironment,omitempty" jsonschema:"response to a prior environment confirmation interaction"`
+	ConfirmRemoteKeyImport   *bool  `json:"confirmRemoteKeyImport,omitempty" jsonschema:"response to a prior remote SSH key import confirmation interaction"`
 	AutoApprove              bool   `json:"autoApprove,omitempty" jsonschema:"when true, automatically approve initialization prompts"`
 	Preview                  bool   `json:"preview,omitempty" jsonschema:"when true, resolve and print the planned actions without executing them"`
 	Verbosity                int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
@@ -45,7 +49,7 @@ func initTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest,
 			InitializeCurrentProject: input.InitializeCurrentProject,
 			ProjectRoot:              firstNonEmpty(strings.TrimSpace(input.ProjectRoot), strings.TrimSpace(runtime.Context.RepoPath)),
 			Environment:              firstNonEmpty(strings.TrimSpace(input.Environment), strings.TrimSpace(runtime.Context.Environment)),
-			RuntimeVersion:           CurrentBuildInfo().Version,
+			RuntimeVersion:           firstNonEmpty(strings.TrimSpace(input.Version), CurrentBuildInfo().Version),
 			KubernetesContext:        firstNonEmpty(strings.TrimSpace(input.KubernetesContext), strings.TrimSpace(runtime.Context.KubernetesContext)),
 			ContainerRegistry:        strings.TrimSpace(input.ContainerRegistry),
 			ConfirmTenant:            input.ConfirmTenant,
@@ -53,24 +57,26 @@ func initTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest,
 			AutoApprove:              input.AutoApprove,
 		}
 
-		_, err = eruncommon.RunBootstrapInit(
-			ctx,
-			params,
-			eruncommon.TraceBootstrapStore(ctx, runtime.Store),
-			func() (string, string, error) {
+		params.Remote = input.Remote
+		params.RemoteRepositoryURL = strings.TrimSpace(input.RemoteRepositoryURL)
+		params.ConfirmRemoteKeyImport = input.ConfirmRemoteKeyImport
+
+		_, err = eruncommon.RunBootstrapInitWithDependencies(eruncommon.BootstrapInitDependencies{
+			Store: eruncommon.TraceBootstrapStore(ctx, runtime.Store),
+			FindProjectRoot: func() (string, string, error) {
 				return eruncommon.FindProjectRootFromDir(workDir)
 			},
-			func() (string, error) {
+			GetWorkingDir: func() (string, error) {
 				return workDir, nil
 			},
-			nil,
-			nil,
-			nil,
-			nil,
-			eruncommon.TraceNamespaceEnsurer(ctx, runtime.EnsureKubernetesNamespace),
-			eruncommon.LoadProjectConfig,
-			eruncommon.TraceProjectConfigSaver(ctx, eruncommon.SaveProjectConfig),
-		)
+			EnsureKubernetesNamespace: eruncommon.TraceNamespaceEnsurer(ctx, runtime.EnsureKubernetesNamespace),
+			LoadProjectConfig:         eruncommon.LoadProjectConfig,
+			SaveProjectConfig:         eruncommon.TraceProjectConfigSaver(ctx, eruncommon.SaveProjectConfig),
+			WaitForRemoteRuntime:      runtime.WaitForRemoteRuntime,
+			RunRemoteCommand:          runtime.RunRemoteCommand,
+			DeployHelmChart:           runtime.DeployHelmChart,
+			Context:                   ctx,
+		}, params)
 		if err != nil {
 			if interaction, ok := eruncommon.AsBootstrapInitInteraction(err); ok {
 				return nil, InitOutput{

--- a/erun-mcp/runtime.go
+++ b/erun-mcp/runtime.go
@@ -35,6 +35,8 @@ type RuntimeConfig struct {
 	PushDockerImage           eruncommon.DockerImagePusherFunc
 	DeployHelmChart           eruncommon.HelmChartDeployerFunc
 	EnsureKubernetesNamespace eruncommon.NamespaceEnsurerFunc
+	WaitForRemoteRuntime      eruncommon.RemoteRuntimeWaitFunc
+	RunRemoteCommand          eruncommon.RemoteCommandRunnerFunc
 }
 
 type CommandOutput struct {
@@ -62,6 +64,12 @@ func normalizeRuntimeConfig(cfg RuntimeConfig) RuntimeConfig {
 	}
 	if cfg.DeployHelmChart == nil {
 		cfg.DeployHelmChart = eruncommon.DeployHelmChart
+	}
+	if cfg.WaitForRemoteRuntime == nil {
+		cfg.WaitForRemoteRuntime = eruncommon.WaitForShellDeployment
+	}
+	if cfg.RunRemoteCommand == nil {
+		cfg.RunRemoteCommand = eruncommon.RunRemoteCommand
 	}
 	return cfg
 }

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -368,7 +368,7 @@ func TestBuildToolPreviewVerboseIncludesTrace(t *testing.T) {
 	if len(output.Trace) == 0 {
 		t.Fatalf("expected trace output at preview verbosity 1, got %+v", output)
 	}
-	want := "docker build -t erunpaas/erun-devops:1.1.0 -f " + filepath.Join(componentDir, "Dockerfile") + " ."
+	want := "docker build -t erunpaas/erun-devops:1.1.0 --build-arg ERUN_VERSION=1.1.0 -f " + filepath.Join(componentDir, "Dockerfile") + " ."
 	if output.Trace[0] != "cd "+projectRoot+" && "+want {
 		t.Fatalf("unexpected trace output: %+v", output.Trace)
 	}
@@ -599,6 +599,87 @@ func TestInitToolReturnsInteractionWhenSharedInitNeedsInput(t *testing.T) {
 	if output.Executed {
 		t.Fatalf("expected non-executed interaction output, got %+v", output)
 	}
+}
+
+func TestInitToolReturnsRepositoryInteractionForRemoteInit(t *testing.T) {
+	handler := initTool(normalizeRuntimeConfig(RuntimeConfig{
+		Context: RuntimeContext{},
+		Store:   initInteractionStore{},
+		DeployHelmChart: func(eruncommon.HelmDeployParams) error {
+			return nil
+		},
+		WaitForRemoteRuntime: func(eruncommon.ShellLaunchParams) error {
+			return nil
+		},
+		RunRemoteCommand: func(eruncommon.ShellLaunchParams, string) (eruncommon.RemoteCommandResult, error) {
+			return eruncommon.RemoteCommandResult{
+				Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n",
+			}, nil
+		},
+	}))
+
+	_, output, err := handler(context.Background(), nil, InitInput{
+		Tenant:             "frs",
+		Environment:        "dev",
+		Remote:             true,
+		KubernetesContext:  "cluster-remote",
+		ContainerRegistry:  eruncommon.DefaultContainerRegistry,
+		ConfirmTenant:      boolPtr(true),
+		ConfirmEnvironment: boolPtr(true),
+	})
+	if err != nil {
+		t.Fatalf("initTool failed: %v", err)
+	}
+	if output.Interaction == nil {
+		t.Fatalf("expected interaction output, got %+v", output)
+	}
+	if output.Interaction.Type != eruncommon.BootstrapInitInteractionRemoteRepository {
+		t.Fatalf("unexpected interaction: %+v", output.Interaction)
+	}
+}
+
+func TestInitToolUsesExplicitRuntimeVersionOverride(t *testing.T) {
+	var deployedVersion string
+	handler := initTool(normalizeRuntimeConfig(RuntimeConfig{
+		Context: RuntimeContext{},
+		Store:   initInteractionStore{},
+		DeployHelmChart: func(params eruncommon.HelmDeployParams) error {
+			deployedVersion = params.Version
+			return nil
+		},
+		WaitForRemoteRuntime: func(eruncommon.ShellLaunchParams) error {
+			return nil
+		},
+		RunRemoteCommand: func(eruncommon.ShellLaunchParams, string) (eruncommon.RemoteCommandResult, error) {
+			return eruncommon.RemoteCommandResult{
+				Stdout: "repo_exists\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n",
+			}, nil
+		},
+	}))
+
+	_, output, err := handler(context.Background(), nil, InitInput{
+		Tenant:             "tenant-a",
+		Environment:        "dev",
+		Version:            "1.0.19-snapshot-20260418141901",
+		Remote:             true,
+		KubernetesContext:  "cluster-dev",
+		ContainerRegistry:  eruncommon.DefaultContainerRegistry,
+		ConfirmTenant:      boolPtr(true),
+		ConfirmEnvironment: boolPtr(true),
+	})
+	if err != nil {
+		t.Fatalf("initTool failed: %v", err)
+	}
+	if output.Interaction != nil {
+		t.Fatalf("unexpected interaction output: %+v", output)
+	}
+	if deployedVersion != "1.0.19-snapshot-20260418141901" {
+		t.Fatalf("unexpected deployed version %q", deployedVersion)
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }
 
 func decodeStructuredVersion(t *testing.T, content any) map[string]any {


### PR DESCRIPTION
## Summary
- add remote-aware `init` support that can provision pod-backed repositories, honor explicit runtime versions, and accept positional tenant/environment arguments
- surface the resolved erun config directory in `list` and keep remote runtime startup/shell handling aligned with PVC-backed repos
- update tests across CLI, shared logic, and MCP for remote init, snapshot/runtime version handling, and remote shell behavior

## Root Cause
`init` and remote runtime startup still assumed a host-backed checkout and interactive confirmation flow, which broke pod-only repository bootstrapping and left `open` on the wrong local-chart path for remote repos.

## Impact
Remote init now creates and validates pod-backed repositories end to end, remote shells attach without prompting for host-side chart creation, and callers can pin the runtime version during init.

## Validation
- `cd erun-cli && go test ./...`
- `cd erun-mcp && go test ./...`
- `cd erun-common && go test . -run 'TestBootstrapRunRemoteInitializesTenantInPodWorktree|TestBootstrapRunRemoteWaitsForSSHKeyImportAndRetries|TestBootstrapRunRemoteRequestsRepositoryURLWhenCheckoutMissing'`
- `cd erun-common && go test . -run 'TestRemoteShellScriptSeedsConfigsAndCloneCommand|TestRemoteShellScriptUsesRepoBasenameForRemoteWorkdir|TestRemoteShellScriptMarksRemoteConfigsAndSkipsHostGitBootstrap'`

## Notes
- `cd erun-common && go test ./...` still hits the existing packaging mismatch in `Formula/erun.rb` targeting `v1.0.17` instead of latest stable `v1.0.18`.

Closes #61
