### PR TITLE
Guard release flow preflight

### DIFF
--- a/erun-cli/cmd/release_test.go
+++ b/erun-cli/cmd/release_test.go
@@ -43,6 +43,9 @@ func TestReleaseCommandDryRun(t *testing.T) {
 	output := stderr.String()
 	for _, want := range []string{
 		"release: branch=develop mode=candidate version=1.4.2-rc.",
+		"stage: sync-remote",
+		"git fetch origin",
+		"git rebase origin/develop",
 		"docker image: erunpaas/api:1.4.2-rc.",
 		"git commit -m '[skip ci] release 1.4.2-rc.",
 		"git tag -a",
@@ -96,6 +99,9 @@ func TestReleaseCommandDryRunStableIncludesSyncAndPush(t *testing.T) {
 	for _, want := range []string{
 		"release: branch=main mode=stable version=1.4.2",
 		"next version: 1.4.3",
+		"stage: sync-remote",
+		"git fetch origin",
+		"git rebase origin/main",
 		"stage: sync-develop",
 		"git checkout develop",
 		"git merge --no-edit -X theirs main",
@@ -139,6 +145,15 @@ func TestReleaseCommandDryRunStableWithoutDevelopOnlyPushesMain(t *testing.T) {
 	output := stderr.String()
 	if strings.Contains(output, "stage: sync-develop") || strings.Contains(output, "git checkout develop") {
 		t.Fatalf("did not expect develop sync in output:\n%s", output)
+	}
+	for _, want := range []string{
+		"stage: sync-remote",
+		"git fetch origin",
+		"git rebase origin/main",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected main sync in output to contain %q, got:\n%s", want, output)
+		}
 	}
 	if !strings.Contains(output, "stage: push") || !strings.Contains(output, "git push --follow-tags origin main") {
 		t.Fatalf("expected main-only push in output, got:\n%s", output)

--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -145,6 +145,9 @@ func resolveReleaseSpec(findProjectRoot ProjectFinderFunc, loadProjectConfig Pro
 	}
 
 	stages := make([]ReleaseStage, 0, 2)
+	if syncStage := newSyncRemoteStage(projectRoot, branch); len(syncStage.GitCommands) > 0 {
+		stages = append(stages, syncStage)
+	}
 	releaseStage := newReleaseStage(projectRoot, chartUpdates, version, mode)
 	if len(releaseStage.FileUpdates) > 0 || len(releaseStage.GitCommands) > 0 {
 		stages = append(stages, releaseStage)
@@ -210,6 +213,15 @@ func RunReleaseSpec(ctx Context, spec ReleaseSpec, runGit GitCommandRunnerFunc, 
 	}
 	for _, image := range spec.DockerImages {
 		ctx.Trace("docker image: " + image.Tag)
+	}
+	if !ctx.DryRun {
+		clean, err := gitWorktreeClean(spec.ProjectRoot)
+		if err != nil {
+			return err
+		}
+		if !clean {
+			return fmt.Errorf("release requires a clean git worktree; commit or stash changes first")
+		}
 	}
 
 	for _, stage := range spec.Stages {
@@ -342,6 +354,14 @@ func GitCommandRunner(dir string, stdout, stderr io.Writer, args ...string) erro
 	cmd.Stderr = stderr
 	cmd.Env = gitCommandEnv(dir)
 	return cmd.Run()
+}
+
+func gitWorktreeClean(projectRoot string) (bool, error) {
+	output, err := exec.Command("git", "-C", projectRoot, "status", "--porcelain").CombinedOutput()
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(output)) == "", nil
 }
 
 func gitCommandEnv(dir string) []string {
@@ -640,6 +660,21 @@ func newBumpStage(projectRoot, nextVersion string, fileUpdate ReleaseFileUpdate)
 		GitCommands: []ReleaseCommandSpec{
 			releaseGitCommand(projectRoot, "add", releaseGitPath(projectRoot, fileUpdate.Path)),
 			releaseGitCommand(projectRoot, "commit", "-m", "[skip ci] prepare "+nextVersion),
+		},
+	}
+}
+
+func newSyncRemoteStage(projectRoot, branch string) ReleaseStage {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return ReleaseStage{}
+	}
+
+	return ReleaseStage{
+		Name: "sync-remote",
+		GitCommands: []ReleaseCommandSpec{
+			releaseGitCommand(projectRoot, "fetch", "origin"),
+			releaseGitCommand(projectRoot, "rebase", "origin/"+branch),
 		},
 	}
 }

--- a/erun-common/release_test.go
+++ b/erun-common/release_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestResolveReleaseSpecStableRelease(t *testing.T) {
-	projectRoot := setupReleaseProject(t, releaseProjectOptions{})
+	projectRoot := setupReleaseProjectGitRepo(t, "main")
 
 	spec, err := resolveReleaseSpec(
 		func() (string, string, error) { return "tenant-a", projectRoot, nil },
@@ -38,31 +38,37 @@ func TestResolveReleaseSpecStableRelease(t *testing.T) {
 	if len(spec.DockerImages) != 1 || spec.DockerImages[0].Tag != "erunpaas/api:1.4.2" {
 		t.Fatalf("unexpected docker images: %+v", spec.DockerImages)
 	}
-	if len(spec.Stages) != 4 {
-		t.Fatalf("expected 4 stages, got %+v", spec.Stages)
+	if len(spec.Stages) != 5 {
+		t.Fatalf("expected 5 stages, got %+v", spec.Stages)
 	}
-	if got := spec.Stages[0].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"add", filepath.Join("erun-devops", "k8s", "api", "Chart.yaml")}) {
+	if got := spec.Stages[0].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"fetch", "origin"}) {
+		t.Fatalf("unexpected sync fetch command: %+v", got)
+	}
+	if got := spec.Stages[0].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"rebase", "origin/main"}) {
+		t.Fatalf("unexpected sync rebase command: %+v", got)
+	}
+	if got := spec.Stages[1].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"add", filepath.Join("erun-devops", "k8s", "api", "Chart.yaml")}) {
 		t.Fatalf("unexpected release add command: %+v", got)
 	}
-	if got := spec.Stages[0].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"commit", "-m", "[skip ci] release 1.4.2"}) {
+	if got := spec.Stages[1].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"commit", "-m", "[skip ci] release 1.4.2"}) {
 		t.Fatalf("unexpected release commit command: %+v", got)
 	}
-	if got := spec.Stages[0].GitCommands[2].Args; !reflect.DeepEqual(got, []string{"tag", "-a", "v1.4.2", "-m", "Release 1.4.2"}) {
+	if got := spec.Stages[1].GitCommands[2].Args; !reflect.DeepEqual(got, []string{"tag", "-a", "v1.4.2", "-m", "Release 1.4.2"}) {
 		t.Fatalf("unexpected release tag command: %+v", got)
 	}
-	if got := spec.Stages[1].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"add", filepath.Join("erun-devops", "VERSION")}) {
+	if got := spec.Stages[2].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"add", filepath.Join("erun-devops", "VERSION")}) {
 		t.Fatalf("unexpected bump add command: %+v", got)
 	}
-	if got := spec.Stages[2].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"checkout", "develop"}) {
+	if got := spec.Stages[3].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"checkout", "develop"}) {
 		t.Fatalf("unexpected sync checkout command: %+v", got)
 	}
-	if got := spec.Stages[2].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"merge", "--no-edit", "-X", "theirs", "main"}) {
+	if got := spec.Stages[3].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"merge", "--no-edit", "-X", "theirs", "main"}) {
 		t.Fatalf("unexpected sync merge command: %+v", got)
 	}
-	if got := spec.Stages[2].GitCommands[2].Args; !reflect.DeepEqual(got, []string{"checkout", "main"}) {
+	if got := spec.Stages[3].GitCommands[2].Args; !reflect.DeepEqual(got, []string{"checkout", "main"}) {
 		t.Fatalf("unexpected sync return command: %+v", got)
 	}
-	if got := spec.Stages[3].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "main", "develop"}) {
+	if got := spec.Stages[4].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "main", "develop"}) {
 		t.Fatalf("unexpected push command: %+v", got)
 	}
 }
@@ -92,19 +98,25 @@ func TestResolveReleaseSpecUsesConfiguredBranches(t *testing.T) {
 	if spec.Mode != ReleaseModeCandidate || spec.Version != "1.4.2-rc.abc1234" || spec.NextVersion != "" {
 		t.Fatalf("unexpected release spec: %+v", spec)
 	}
-	if len(spec.Stages) != 2 {
-		t.Fatalf("expected 2 stages, got %+v", spec.Stages)
+	if len(spec.Stages) != 3 {
+		t.Fatalf("expected 3 stages, got %+v", spec.Stages)
 	}
-	if got := spec.Stages[0].GitCommands[2].Args; !reflect.DeepEqual(got, []string{"tag", "-a", "v1.4.2-rc.abc1234", "-m", "Release candidate 1.4.2-rc.abc1234"}) {
+	if got := spec.Stages[0].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"fetch", "origin"}) {
+		t.Fatalf("unexpected candidate sync fetch command: %+v", got)
+	}
+	if got := spec.Stages[0].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"rebase", "origin/integration"}) {
+		t.Fatalf("unexpected candidate sync rebase command: %+v", got)
+	}
+	if got := spec.Stages[1].GitCommands[2].Args; !reflect.DeepEqual(got, []string{"tag", "-a", "v1.4.2-rc.abc1234", "-m", "Release candidate 1.4.2-rc.abc1234"}) {
 		t.Fatalf("unexpected candidate tag command: %+v", got)
 	}
-	if got := spec.Stages[1].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "integration"}) {
+	if got := spec.Stages[2].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "integration"}) {
 		t.Fatalf("unexpected candidate push command: %+v", got)
 	}
 }
 
 func TestRunReleaseSpecWritesFilesAndRunsGitStages(t *testing.T) {
-	projectRoot := setupReleaseProject(t, releaseProjectOptions{})
+	projectRoot := setupReleaseProjectGitRepo(t, "develop")
 
 	spec, err := resolveReleaseSpec(
 		func() (string, string, error) { return "tenant-a", projectRoot, nil },
@@ -148,6 +160,8 @@ func TestRunReleaseSpecWritesFilesAndRunsGitStages(t *testing.T) {
 	}
 
 	wantCalls := [][]string{
+		{projectRoot, "fetch", "origin"},
+		{projectRoot, "rebase", "origin/main"},
 		{projectRoot, "add", filepath.Join("erun-devops", "k8s", "api", "Chart.yaml")},
 		{projectRoot, "commit", "-m", "[skip ci] release 1.4.2"},
 		{projectRoot, "tag", "-a", "v1.4.2", "-m", "Release 1.4.2"},
@@ -164,7 +178,7 @@ func TestRunReleaseSpecWritesFilesAndRunsGitStages(t *testing.T) {
 }
 
 func TestRunReleaseSpecCandidateRunsTagAndPush(t *testing.T) {
-	projectRoot := setupReleaseProject(t, releaseProjectOptions{})
+	projectRoot := setupReleaseProjectGitRepo(t, "main")
 
 	spec, err := resolveReleaseSpec(
 		func() (string, string, error) { return "tenant-a", projectRoot, nil },
@@ -192,6 +206,8 @@ func TestRunReleaseSpecCandidateRunsTagAndPush(t *testing.T) {
 	}
 
 	wantCalls := [][]string{
+		{projectRoot, "fetch", "origin"},
+		{projectRoot, "rebase", "origin/develop"},
 		{projectRoot, "add", filepath.Join("erun-devops", "k8s", "api", "Chart.yaml")},
 		{projectRoot, "commit", "-m", "[skip ci] release 1.4.2-rc.abc1234"},
 		{projectRoot, "tag", "-a", "v1.4.2-rc.abc1234", "-m", "Release candidate 1.4.2-rc.abc1234"},
@@ -203,7 +219,7 @@ func TestRunReleaseSpecCandidateRunsTagAndPush(t *testing.T) {
 }
 
 func TestRunReleaseSpecCandidateSkipsExistingTagAtHead(t *testing.T) {
-	projectRoot := setupReleaseProject(t, releaseProjectOptions{})
+	projectRoot := setupReleaseProjectGitRepo(t, "main")
 	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "k8s", "api", "Chart.yaml"), []byte("apiVersion: v2\nname: api\nversion: 1.4.2-rc.abc1234\nappVersion: 1.4.2-rc.abc1234\n"), 0o644); err != nil {
 		t.Fatalf("write Chart.yaml: %v", err)
 	}
@@ -258,6 +274,8 @@ func TestRunReleaseSpecCandidateSkipsExistingTagAtHead(t *testing.T) {
 	}
 
 	wantCalls := [][]string{
+		{projectRoot, "fetch", "origin"},
+		{projectRoot, "rebase", "origin/develop"},
 		{projectRoot, "push", "--follow-tags", "origin", "develop"},
 	}
 	if !reflect.DeepEqual(gitCalls, wantCalls) {
@@ -338,6 +356,42 @@ func TestRunReleaseSpecReturnsErrorWhenExistingTagPointsElsewhere(t *testing.T) 
 	}
 }
 
+func TestRunReleaseSpecReturnsErrorWhenWorktreeIsDirty(t *testing.T) {
+	projectRoot := setupReleaseProjectGitRepo(t, "main")
+
+	spec, err := resolveReleaseSpec(
+		func() (string, string, error) { return "tenant-a", projectRoot, nil },
+		LoadProjectConfig,
+		func(string) (string, error) { return "main", nil },
+		func(string) (string, error) { return "abc1234", nil },
+		func(string, string) (bool, error) { return true, nil },
+		ReleaseParams{},
+	)
+	if err != nil {
+		t.Fatalf("resolveReleaseSpec failed: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(projectRoot, "README.md"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	ctx := Context{
+		Logger: NewLoggerWithWriters(2, new(bytes.Buffer), new(bytes.Buffer)),
+		Stdout: new(bytes.Buffer),
+		Stderr: new(bytes.Buffer),
+	}
+	err = RunReleaseSpec(ctx, spec, func(dir string, stdout, stderr io.Writer, args ...string) error {
+		t.Fatalf("did not expect git command %v", args)
+		return nil
+	}, nil)
+	if err == nil {
+		t.Fatal("expected dirty worktree error")
+	}
+	if err.Error() != "release requires a clean git worktree; commit or stash changes first" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestResolveReleaseSpecStableReleaseUsesConfiguredDevelopBranchForSyncAndPush(t *testing.T) {
 	projectRoot := setupReleaseProject(t, releaseProjectOptions{
 		ProjectConfig: ProjectConfig{
@@ -360,16 +414,16 @@ func TestResolveReleaseSpecStableReleaseUsesConfiguredDevelopBranchForSyncAndPus
 		t.Fatalf("resolveReleaseSpec failed: %v", err)
 	}
 
-	if got := spec.Stages[2].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"checkout", "integration"}) {
+	if got := spec.Stages[3].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"checkout", "integration"}) {
 		t.Fatalf("unexpected configured sync checkout command: %+v", got)
 	}
-	if got := spec.Stages[2].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"merge", "--no-edit", "-X", "theirs", "trunk"}) {
+	if got := spec.Stages[3].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"merge", "--no-edit", "-X", "theirs", "trunk"}) {
 		t.Fatalf("unexpected configured sync merge command: %+v", got)
 	}
-	if got := spec.Stages[2].GitCommands[2].Args; !reflect.DeepEqual(got, []string{"checkout", "trunk"}) {
+	if got := spec.Stages[3].GitCommands[2].Args; !reflect.DeepEqual(got, []string{"checkout", "trunk"}) {
 		t.Fatalf("unexpected configured sync return command: %+v", got)
 	}
-	if got := spec.Stages[3].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "trunk", "integration"}) {
+	if got := spec.Stages[4].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "trunk", "integration"}) {
 		t.Fatalf("unexpected configured push command: %+v", got)
 	}
 }
@@ -389,13 +443,13 @@ func TestResolveReleaseSpecStableReleaseSkipsDevelopSyncWhenBranchMissing(t *tes
 		t.Fatalf("resolveReleaseSpec failed: %v", err)
 	}
 
-	if len(spec.Stages) != 3 {
-		t.Fatalf("expected 3 stages without develop sync, got %+v", spec.Stages)
+	if len(spec.Stages) != 4 {
+		t.Fatalf("expected 4 stages without develop sync, got %+v", spec.Stages)
 	}
-	if spec.Stages[2].Name != "push" {
-		t.Fatalf("unexpected final stage: %+v", spec.Stages[2])
+	if spec.Stages[3].Name != "push" {
+		t.Fatalf("unexpected final stage: %+v", spec.Stages[3])
 	}
-	if got := spec.Stages[2].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "main"}) {
+	if got := spec.Stages[3].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "main"}) {
 		t.Fatalf("unexpected main-only push command: %+v", got)
 	}
 }


### PR DESCRIPTION
## Summary
- fail `erun build --release` early when the git worktree is dirty
- sync the current release branch with `origin/<branch>` before creating release commits or tags
- update shared release tests and CLI dry-run expectations for the new preflight stage

## Why
Release previously failed late with raw git errors when `main` was stale or dirty, which left the checkout in a bad state for retrying.

## Validation
- `cd erun-common && go test . -run 'TestResolveReleaseSpecStableRelease|TestResolveReleaseSpecUsesConfiguredBranches|TestRunReleaseSpecWritesFilesAndRunsGitStages|TestRunReleaseSpecCandidateRunsTagAndPush|TestRunReleaseSpecCandidateSkipsExistingTagAtHead|TestResolveReleaseSpecStableReleaseUsesConfiguredDevelopBranchForSyncAndPush|TestResolveReleaseSpecStableReleaseSkipsDevelopSyncWhenBranchMissing|TestRunReleaseSpecReturnsErrorWhenWorktreeIsDirty|TestRunBuildExecutionReleaseBuildsAndPushesResolvedVersion'`
- `cd erun-cli && go test ./cmd -run 'TestReleaseCommandDryRun|TestReleaseCommandDryRunStableIncludesSyncAndPush|TestReleaseCommandDryRunStableWithoutDevelopOnlyPushesMain'`

Closes #63
