### PR TITLE
Rewrite Brew and Scoop metadata during stable release

### DIFF
--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -1,12 +1,14 @@
 package eruncommon
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -134,6 +136,14 @@ func resolveReleaseSpec(findProjectRoot ProjectFinderFunc, loadProjectConfig Pro
 	if err != nil {
 		return ReleaseSpec{}, err
 	}
+	releaseFileUpdates := append([]ReleaseFileUpdate{}, chartUpdates...)
+	if mode == ReleaseModeStable {
+		packagingUpdates, err := discoverStableReleasePackaging(projectRoot, version)
+		if err != nil {
+			return ReleaseSpec{}, err
+		}
+		releaseFileUpdates = append(releaseFileUpdates, packagingUpdates...)
+	}
 
 	images, err := discoverReleaseDockerImages(projectRoot, releaseRoot, versionFilePath, version)
 	if err != nil {
@@ -148,7 +158,7 @@ func resolveReleaseSpec(findProjectRoot ProjectFinderFunc, loadProjectConfig Pro
 	if syncStage := newSyncRemoteStage(projectRoot, branch); len(syncStage.GitCommands) > 0 {
 		stages = append(stages, syncStage)
 	}
-	releaseStage := newReleaseStage(projectRoot, chartUpdates, version, mode)
+	releaseStage := newReleaseStage(projectRoot, releaseFileUpdates, version, mode)
 	if len(releaseStage.FileUpdates) > 0 || len(releaseStage.GitCommands) > 0 {
 		stages = append(stages, releaseStage)
 	}
@@ -592,6 +602,36 @@ func discoverReleaseLinuxScripts(releaseRoot, version string) ([]scriptSpec, err
 	return scripts, nil
 }
 
+func discoverStableReleasePackaging(projectRoot, version string) ([]ReleaseFileUpdate, error) {
+	updates := make([]ReleaseFileUpdate, 0, 2)
+
+	formulaPath := filepath.Join(projectRoot, "Formula", "erun.rb")
+	formulaContent, formulaChanged, err := updateHomebrewFormulaReleaseVersion(formulaPath, version)
+	if err != nil {
+		return nil, err
+	}
+	if formulaChanged {
+		updates = append(updates, ReleaseFileUpdate{
+			Path:    formulaPath,
+			Content: formulaContent,
+		})
+	}
+
+	scoopPath := filepath.Join(projectRoot, "bucket", "erun.json")
+	scoopContent, scoopChanged, err := updateScoopManifestReleaseVersion(scoopPath, version)
+	if err != nil {
+		return nil, err
+	}
+	if scoopChanged {
+		updates = append(updates, ReleaseFileUpdate{
+			Path:    scoopPath,
+			Content: scoopContent,
+		})
+	}
+
+	return updates, nil
+}
+
 func updateHelmChartReleaseVersion(chartFilePath, version string) (string, bool, ReleaseChartSpec, error) {
 	data, err := os.ReadFile(chartFilePath)
 	if err != nil {
@@ -626,6 +666,71 @@ func updateHelmChartReleaseVersion(chartFilePath, version string) (string, bool,
 		Version:    version,
 		AppVersion: version,
 	}, nil
+}
+
+func updateHomebrewFormulaReleaseVersion(formulaPath, version string) (string, bool, error) {
+	data, err := os.ReadFile(formulaPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+
+	content := string(data)
+	wantURL := `url "https://github.com/sophium/erun/archive/refs/tags/v` + version + `.tar.gz"`
+	urlPattern := regexp.MustCompile(`(?m)^  url "https://github\.com/sophium/erun/archive/refs/tags/v[^"]+\.tar\.gz"$`)
+	updated := urlPattern.ReplaceAllString(content, "  "+wantURL)
+	if updated == content {
+		return "", false, nil
+	}
+
+	return updated, true, nil
+}
+
+func updateScoopManifestReleaseVersion(manifestPath, version string) (string, bool, error) {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+
+	var manifest struct {
+		Version     string   `json:"version"`
+		Description string   `json:"description"`
+		Homepage    string   `json:"homepage"`
+		License     string   `json:"license"`
+		Depends     []string `json:"depends,omitempty"`
+		URL         string   `json:"url"`
+		Hash        string   `json:"hash"`
+		ExtractDir  string   `json:"extract_dir"`
+		Installer   struct {
+			Script []string `json:"script,omitempty"`
+		} `json:"installer,omitempty"`
+		Bin []string `json:"bin,omitempty"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return "", false, err
+	}
+
+	wantURL := "https://github.com/sophium/erun/archive/refs/tags/v" + version + ".zip"
+	wantExtractDir := "erun-" + version
+	if manifest.Version == version && manifest.URL == wantURL && manifest.ExtractDir == wantExtractDir {
+		return "", false, nil
+	}
+
+	manifest.Version = version
+	manifest.URL = wantURL
+	manifest.ExtractDir = wantExtractDir
+
+	updated, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return "", false, err
+	}
+
+	return string(updated) + "\n", true, nil
 }
 
 func newReleaseStage(projectRoot string, fileUpdates []ReleaseFileUpdate, version string, mode ReleaseMode) ReleaseStage {

--- a/erun-common/release_test.go
+++ b/erun-common/release_test.go
@@ -73,6 +73,43 @@ func TestResolveReleaseSpecStableRelease(t *testing.T) {
 	}
 }
 
+func TestResolveReleaseSpecStableReleaseIncludesPackagingUpdatesWhenPresent(t *testing.T) {
+	projectRoot := setupReleaseProject(t, releaseProjectOptions{WithPackaging: true})
+
+	spec, err := resolveReleaseSpec(
+		func() (string, string, error) { return "tenant-a", projectRoot, nil },
+		LoadProjectConfig,
+		func(string) (string, error) { return "main", nil },
+		func(string) (string, error) { return "abc1234", nil },
+		func(string, string) (bool, error) { return true, nil },
+		ReleaseParams{},
+	)
+	if err != nil {
+		t.Fatalf("resolveReleaseSpec failed: %v", err)
+	}
+
+	if len(spec.Stages) != 5 {
+		t.Fatalf("expected 5 stages, got %+v", spec.Stages)
+	}
+	if len(spec.Stages[1].FileUpdates) != 3 {
+		t.Fatalf("expected chart, formula, and scoop updates, got %+v", spec.Stages[1].FileUpdates)
+	}
+	if got := spec.Stages[1].GitCommands[0].Args; !reflect.DeepEqual(got, []string{
+		"add",
+		filepath.Join("erun-devops", "k8s", "api", "Chart.yaml"),
+		filepath.Join("Formula", "erun.rb"),
+		filepath.Join("bucket", "erun.json"),
+	}) {
+		t.Fatalf("unexpected release add command: %+v", got)
+	}
+	if formula := spec.Stages[1].FileUpdates[1].Content; !strings.Contains(formula, `url "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.tar.gz"`) {
+		t.Fatalf("unexpected formula update: %s", formula)
+	}
+	if scoop := spec.Stages[1].FileUpdates[2].Content; !strings.Contains(scoop, `"version": "1.4.2"`) || !strings.Contains(scoop, `"extract_dir": "erun-1.4.2"`) {
+		t.Fatalf("unexpected scoop update: %s", scoop)
+	}
+}
+
 func TestResolveReleaseSpecUsesConfiguredBranches(t *testing.T) {
 	projectRoot := setupReleaseProject(t, releaseProjectOptions{
 		ProjectConfig: ProjectConfig{
@@ -174,6 +211,62 @@ func TestRunReleaseSpecWritesFilesAndRunsGitStages(t *testing.T) {
 	}
 	if !reflect.DeepEqual(gitCalls, wantCalls) {
 		t.Fatalf("unexpected git calls: got %+v want %+v", gitCalls, wantCalls)
+	}
+}
+
+func TestRunReleaseSpecRewritesStablePackagingMetadataWhenPresent(t *testing.T) {
+	projectRoot := setupReleaseProjectGitRepoWithOptions(t, "main", releaseProjectOptions{WithPackaging: true})
+
+	spec, err := resolveReleaseSpec(
+		func() (string, string, error) { return "tenant-a", projectRoot, nil },
+		LoadProjectConfig,
+		func(string) (string, error) { return "main", nil },
+		func(string) (string, error) { return "abc1234", nil },
+		func(string, string) (bool, error) { return true, nil },
+		ReleaseParams{},
+	)
+	if err != nil {
+		t.Fatalf("resolveReleaseSpec failed: %v", err)
+	}
+
+	var gitCalls [][]string
+	ctx := Context{
+		Logger: NewLoggerWithWriters(2, new(bytes.Buffer), new(bytes.Buffer)),
+		Stdout: new(bytes.Buffer),
+		Stderr: new(bytes.Buffer),
+	}
+	if err := RunReleaseSpec(ctx, spec, func(dir string, stdout, stderr io.Writer, args ...string) error {
+		gitCalls = append(gitCalls, append([]string{dir}, args...))
+		return nil
+	}, nil); err != nil {
+		t.Fatalf("RunReleaseSpec failed: %v", err)
+	}
+
+	formulaData, err := os.ReadFile(filepath.Join(projectRoot, "Formula", "erun.rb"))
+	if err != nil {
+		t.Fatalf("read formula: %v", err)
+	}
+	if !strings.Contains(string(formulaData), `url "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.tar.gz"`) {
+		t.Fatalf("unexpected formula content: %s", formulaData)
+	}
+
+	scoopData, err := os.ReadFile(filepath.Join(projectRoot, "bucket", "erun.json"))
+	if err != nil {
+		t.Fatalf("read scoop manifest: %v", err)
+	}
+	scoop := string(scoopData)
+	if !strings.Contains(scoop, `"version": "1.4.2"`) || !strings.Contains(scoop, `"url": "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.zip"`) || !strings.Contains(scoop, `"extract_dir": "erun-1.4.2"`) {
+		t.Fatalf("unexpected scoop content: %s", scoop)
+	}
+
+	if got := gitCalls[2]; !reflect.DeepEqual(got, []string{
+		projectRoot,
+		"add",
+		filepath.Join("erun-devops", "k8s", "api", "Chart.yaml"),
+		filepath.Join("Formula", "erun.rb"),
+		filepath.Join("bucket", "erun.json"),
+	}) {
+		t.Fatalf("unexpected release add call: %+v", got)
 	}
 }
 
@@ -512,6 +605,7 @@ func TestGitCommandRunnerUsesFallbackIdentityWhenGitConfigIsMissing(t *testing.T
 
 type releaseProjectOptions struct {
 	ProjectConfig ProjectConfig
+	WithPackaging bool
 }
 
 func setupReleaseProject(t *testing.T, options releaseProjectOptions) string {
@@ -555,7 +649,64 @@ func setupReleaseProject(t *testing.T, options releaseProjectOptions) string {
 	if err := SaveProjectConfig(projectRoot, options.ProjectConfig); err != nil {
 		t.Fatalf("SaveProjectConfig failed: %v", err)
 	}
+	if options.WithPackaging {
+		formulaPath := filepath.Join(projectRoot, "Formula")
+		if err := os.MkdirAll(formulaPath, 0o755); err != nil {
+			t.Fatalf("mkdir Formula: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(formulaPath, "erun.rb"), []byte(`class Erun < Formula
+  desc "Multi-tenant multi-environment deployment and management tool"
+  homepage "https://github.com/sophium/erun"
+  url "https://github.com/sophium/erun/archive/refs/tags/v1.4.1.tar.gz"
+  sha256 "unchanged"
+  license "MIT"
+end
+`), 0o644); err != nil {
+			t.Fatalf("write formula: %v", err)
+		}
 
+		bucketPath := filepath.Join(projectRoot, "bucket")
+		if err := os.MkdirAll(bucketPath, 0o755); err != nil {
+			t.Fatalf("mkdir bucket: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(bucketPath, "erun.json"), []byte(`{
+  "version": "1.4.1",
+  "description": "Multi-tenant multi-environment deployment and management tool",
+  "homepage": "https://github.com/sophium/erun",
+  "license": "MIT",
+  "depends": [
+    "go"
+  ],
+  "url": "https://github.com/sophium/erun/archive/refs/tags/v1.4.1.zip",
+  "hash": "unchanged",
+  "extract_dir": "erun-1.4.1",
+  "installer": {
+    "script": [
+      "go build"
+    ]
+  },
+  "bin": [
+    "erun.exe",
+    "emcp.exe"
+  ]
+}
+`), 0o644); err != nil {
+			t.Fatalf("write scoop manifest: %v", err)
+		}
+	}
+
+	return projectRoot
+}
+
+func setupReleaseProjectGitRepoWithOptions(t *testing.T, branch string, options releaseProjectOptions) string {
+	t.Helper()
+
+	projectRoot := setupReleaseProject(t, options)
+	runGitWithEnv(t, projectRoot, nil, "init", "-b", branch)
+	runGitWithEnv(t, projectRoot, nil, "config", "user.email", "codex@example.com")
+	runGitWithEnv(t, projectRoot, nil, "config", "user.name", "Codex")
+	runGitWithEnv(t, projectRoot, nil, "add", ".")
+	runGitWithEnv(t, projectRoot, nil, "commit", "-m", "initial")
 	return projectRoot
 }
 


### PR DESCRIPTION
## Summary
- rewrite stable release planning to update Homebrew and Scoop metadata when those files exist
- include Formula and Scoop updates in the release stage commit alongside chart updates
- add release regressions for the packaging stage and rewritten file contents

## Why
Stable releases were leaving package manager metadata stale, so packaging drift had to be fixed manually after release planning.

## Validation
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-common && go test . -run 'TestResolveReleaseSpecStableRelease|TestResolveReleaseSpecStableReleaseIncludesPackagingUpdatesWhenPresent|TestRunReleaseSpecWritesFilesAndRunsGitStages|TestRunReleaseSpecRewritesStablePackagingMetadataWhenPresent|TestResolveReleaseSpecUsesConfiguredBranches|TestRunReleaseSpecCandidateRunsTagAndPush|TestRunReleaseSpecCandidateSkipsExistingTagAtHead|TestResolveReleaseSpecStableReleaseUsesConfiguredDevelopBranchForSyncAndPush|TestResolveReleaseSpecStableReleaseSkipsDevelopSyncWhenBranchMissing|TestRunReleaseSpecReturnsErrorWhenWorktreeIsDirty'
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-cli && go test ./cmd -run 'TestReleaseCommandDryRun|TestReleaseCommandDryRunStableIncludesSyncAndPush|TestReleaseCommandDryRunStableWithoutDevelopOnlyPushesMain'
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-cli && go test ./...
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-mcp && go test ./...

Closes #65
