### PR TITLE
Sync package-manager checksums during stable release

### DIFF
--- a/Formula/erun.rb
+++ b/Formula/erun.rb
@@ -2,7 +2,7 @@ class Erun < Formula
   desc "Multi-tenant multi-environment deployment and management tool"
   homepage "https://github.com/sophium/erun"
   url "https://github.com/sophium/erun/archive/refs/tags/v1.0.26.tar.gz"
-  sha256 "a81ef3675d4a37d88832073ee465ad1f5bb0ff6a5341de116d94925ce0c3e611"
+  sha256 "2518cc882b2d36775f5b979338ca99cd6b3147e3e19753be05aafa81764d7389"
   license "MIT"
 
   depends_on "go" => :build

--- a/bucket/erun.json
+++ b/bucket/erun.json
@@ -7,7 +7,7 @@
     "go"
   ],
   "url": "https://github.com/sophium/erun/archive/refs/tags/v1.0.26.zip",
-  "hash": "ebb6b98c7cde86500d27c505554ed7a9251d306c50b5dfc909001293b90e0661",
+  "hash": "284fd28d47eb4daa0b3bcad3b443a4567b1aa540687d5c1d1eb390ba9ff03420",
   "extract_dir": "erun-1.0.26",
   "installer": {
     "script": [

--- a/erun-cli/cmd/release_test.go
+++ b/erun-cli/cmd/release_test.go
@@ -168,6 +168,8 @@ func TestReleaseCommandWritesOnlyVersionToStdoutDuringExecution(t *testing.T) {
 	if err := common.SaveProjectConfig(projectRoot, common.ProjectConfig{}); err != nil {
 		t.Fatalf("SaveProjectConfig failed: %v", err)
 	}
+	runGitCommand(t, projectRoot, "add", ".erun/config.yaml")
+	runGitCommand(t, projectRoot, "commit", "-m", "save config")
 
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {

--- a/erun-common/packaging_test.go
+++ b/erun-common/packaging_test.go
@@ -1,13 +1,18 @@
 package eruncommon
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestPackageManagerDefinitionsTrackLatestStableTag(t *testing.T) {
@@ -27,6 +32,14 @@ func TestPackageManagerDefinitionsTrackLatestStableTag(t *testing.T) {
 	if !strings.Contains(formula, `bin/"erun"`) || !strings.Contains(formula, `bin/"emcp"`) {
 		t.Fatalf("formula does not build both executables:\n%s", formula)
 	}
+	formulaSHA := regexp.MustCompile(`(?m)^  sha256 "([0-9a-f]+)"$`).FindStringSubmatch(formula)
+	if len(formulaSHA) != 2 {
+		t.Fatalf("formula sha256 not found:\n%s", formula)
+	}
+	gotFormulaSHA := releaseArchiveSHA256ForTest(t, "https://github.com/sophium/erun/archive/refs/tags/"+latestTag+".tar.gz")
+	if formulaSHA[1] != gotFormulaSHA {
+		t.Fatalf("formula sha256 = %q, want %q", formulaSHA[1], gotFormulaSHA)
+	}
 
 	scoopPath := filepath.Join(repoRoot, "bucket", "erun.json")
 	scoopData, err := os.ReadFile(scoopPath)
@@ -37,6 +50,7 @@ func TestPackageManagerDefinitionsTrackLatestStableTag(t *testing.T) {
 	var manifest struct {
 		Version    string `json:"version"`
 		URL        string `json:"url"`
+		Hash       string `json:"hash"`
 		ExtractDir string `json:"extract_dir"`
 		Depends    []string
 		Bin        []string
@@ -54,6 +68,10 @@ func TestPackageManagerDefinitionsTrackLatestStableTag(t *testing.T) {
 	wantZipURL := "https://github.com/sophium/erun/archive/refs/tags/" + latestTag + ".zip"
 	if manifest.URL != wantZipURL {
 		t.Fatalf("scoop url = %q, want %q", manifest.URL, wantZipURL)
+	}
+	gotScoopSHA := releaseArchiveSHA256ForTest(t, manifest.URL)
+	if manifest.Hash != gotScoopSHA {
+		t.Fatalf("scoop hash = %q, want %q", manifest.Hash, gotScoopSHA)
 	}
 	if manifest.ExtractDir != "erun-"+latestVersion {
 		t.Fatalf("scoop extract_dir = %q, want %q", manifest.ExtractDir, "erun-"+latestVersion)
@@ -177,4 +195,23 @@ func containsString(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func releaseArchiveSHA256ForTest(t *testing.T, url string) string {
+	t.Helper()
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("download %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("download %s: unexpected status %s", url, resp.Status)
+	}
+	sum := sha256.New()
+	if _, err := io.Copy(sum, resp.Body); err != nil {
+		t.Fatalf("hash %s: %v", url, err)
+	}
+	return hex.EncodeToString(sum.Sum(nil))
 }

--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -1,10 +1,13 @@
 package eruncommon
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -68,9 +72,16 @@ type ReleaseCommandSpec struct {
 }
 
 type ReleaseStage struct {
-	Name        string               `json:"name"`
-	FileUpdates []ReleaseFileUpdate  `json:"fileUpdates,omitempty"`
-	GitCommands []ReleaseCommandSpec `json:"gitCommands,omitempty"`
+	Name          string                    `json:"name"`
+	FileUpdates   []ReleaseFileUpdate       `json:"fileUpdates,omitempty"`
+	GitCommands   []ReleaseCommandSpec      `json:"gitCommands,omitempty"`
+	PackagingSync *ReleasePackagingSyncSpec `json:"packagingSync,omitempty"`
+}
+
+type ReleasePackagingSyncSpec struct {
+	Version     string `json:"version"`
+	FormulaPath string `json:"formulaPath,omitempty"`
+	ScoopPath   string `json:"scoopPath,omitempty"`
 }
 
 type ReleaseSpec struct {
@@ -137,12 +148,14 @@ func resolveReleaseSpec(findProjectRoot ProjectFinderFunc, loadProjectConfig Pro
 		return ReleaseSpec{}, err
 	}
 	releaseFileUpdates := append([]ReleaseFileUpdate{}, chartUpdates...)
+	var packagingSync *ReleasePackagingSyncSpec
 	if mode == ReleaseModeStable {
-		packagingUpdates, err := discoverStableReleasePackaging(projectRoot, version)
+		packagingUpdates, syncSpec, err := discoverStableReleasePackaging(projectRoot, version)
 		if err != nil {
 			return ReleaseSpec{}, err
 		}
 		releaseFileUpdates = append(releaseFileUpdates, packagingUpdates...)
+		packagingSync = syncSpec
 	}
 
 	images, err := discoverReleaseDockerImages(projectRoot, releaseRoot, versionFilePath, version)
@@ -161,6 +174,16 @@ func resolveReleaseSpec(findProjectRoot ProjectFinderFunc, loadProjectConfig Pro
 	releaseStage := newReleaseStage(projectRoot, releaseFileUpdates, version, mode)
 	if len(releaseStage.FileUpdates) > 0 || len(releaseStage.GitCommands) > 0 {
 		stages = append(stages, releaseStage)
+	}
+	if mode == ReleaseModeStable && packagingSync != nil {
+		tagPushStage := newPushReleaseTagStage(projectRoot, version)
+		if len(tagPushStage.GitCommands) > 0 {
+			stages = append(stages, tagPushStage)
+		}
+		packagingStage := newSyncPackagingStage(projectRoot, *packagingSync)
+		if packagingStage.PackagingSync != nil || len(packagingStage.GitCommands) > 0 {
+			stages = append(stages, packagingStage)
+		}
 	}
 
 	nextVersion := ""
@@ -212,9 +235,18 @@ func resolveReleaseSpec(findProjectRoot ProjectFinderFunc, loadProjectConfig Pro
 	}, nil
 }
 
+type ReleasePackagingSyncerFunc func(Context, ReleasePackagingSyncSpec) ([]ReleaseFileUpdate, error)
+
 func RunReleaseSpec(ctx Context, spec ReleaseSpec, runGit GitCommandRunnerFunc, runScript BuildScriptRunnerFunc) error {
+	return runReleaseSpec(ctx, spec, runGit, runScript, syncReleasePackagingChecksums)
+}
+
+func runReleaseSpec(ctx Context, spec ReleaseSpec, runGit GitCommandRunnerFunc, runScript BuildScriptRunnerFunc, syncPackagingChecksums ReleasePackagingSyncerFunc) error {
 	if runGit == nil {
 		runGit = GitCommandRunner
+	}
+	if syncPackagingChecksums == nil {
+		syncPackagingChecksums = syncReleasePackagingChecksums
 	}
 
 	ctx.Trace(fmt.Sprintf("release: branch=%s mode=%s version=%s", spec.Branch, spec.Mode, spec.Version))
@@ -236,7 +268,16 @@ func RunReleaseSpec(ctx Context, spec ReleaseSpec, runGit GitCommandRunnerFunc, 
 
 	for _, stage := range spec.Stages {
 		ctx.Trace("stage: " + stage.Name)
-		for _, update := range stage.FileUpdates {
+		stageFileUpdates := append([]ReleaseFileUpdate{}, stage.FileUpdates...)
+		if stage.PackagingSync != nil {
+			generatedUpdates, err := syncPackagingChecksums(ctx, *stage.PackagingSync)
+			if err != nil {
+				return err
+			}
+			stageFileUpdates = append(stageFileUpdates, generatedUpdates...)
+		}
+
+		for _, update := range stageFileUpdates {
 			ctx.TraceBlock("write "+update.Path, strings.TrimRight(update.Content, "\n"))
 			if ctx.DryRun {
 				continue
@@ -246,7 +287,11 @@ func RunReleaseSpec(ctx Context, spec ReleaseSpec, runGit GitCommandRunnerFunc, 
 			}
 		}
 
-		for _, command := range stage.GitCommands {
+		stageCommands := stage.GitCommands
+		if !ctx.DryRun && stage.PackagingSync != nil && len(stageFileUpdates) == 0 {
+			stageCommands = nil
+		}
+		for _, command := range stageCommands {
 			ctx.TraceCommand(command.Dir, command.Name, command.Args...)
 			if ctx.DryRun {
 				continue
@@ -602,13 +647,14 @@ func discoverReleaseLinuxScripts(releaseRoot, version string) ([]scriptSpec, err
 	return scripts, nil
 }
 
-func discoverStableReleasePackaging(projectRoot, version string) ([]ReleaseFileUpdate, error) {
+func discoverStableReleasePackaging(projectRoot, version string) ([]ReleaseFileUpdate, *ReleasePackagingSyncSpec, error) {
 	updates := make([]ReleaseFileUpdate, 0, 2)
+	syncSpec := &ReleasePackagingSyncSpec{Version: version}
 
 	formulaPath := filepath.Join(projectRoot, "Formula", "erun.rb")
 	formulaContent, formulaChanged, err := updateHomebrewFormulaReleaseVersion(formulaPath, version)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if formulaChanged {
 		updates = append(updates, ReleaseFileUpdate{
@@ -616,11 +662,14 @@ func discoverStableReleasePackaging(projectRoot, version string) ([]ReleaseFileU
 			Content: formulaContent,
 		})
 	}
+	if fileExists(formulaPath) {
+		syncSpec.FormulaPath = formulaPath
+	}
 
 	scoopPath := filepath.Join(projectRoot, "bucket", "erun.json")
 	scoopContent, scoopChanged, err := updateScoopManifestReleaseVersion(scoopPath, version)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if scoopChanged {
 		updates = append(updates, ReleaseFileUpdate{
@@ -628,8 +677,14 @@ func discoverStableReleasePackaging(projectRoot, version string) ([]ReleaseFileU
 			Content: scoopContent,
 		})
 	}
+	if fileExists(scoopPath) {
+		syncSpec.ScoopPath = scoopPath
+	}
+	if syncSpec.FormulaPath == "" && syncSpec.ScoopPath == "" {
+		return updates, nil, nil
+	}
 
-	return updates, nil
+	return updates, syncSpec, nil
 }
 
 func updateHelmChartReleaseVersion(chartFilePath, version string) (string, bool, ReleaseChartSpec, error) {
@@ -733,6 +788,150 @@ func updateScoopManifestReleaseVersion(manifestPath, version string) (string, bo
 	return string(updated) + "\n", true, nil
 }
 
+func updateHomebrewFormulaReleaseChecksum(formulaPath, checksum string) (string, bool, error) {
+	data, err := os.ReadFile(formulaPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+
+	content := string(data)
+	want := `sha256 "` + checksum + `"`
+	pattern := regexp.MustCompile(`(?m)^  sha256 "[0-9a-f]+"$`)
+	updated := pattern.ReplaceAllString(content, "  "+want)
+	if updated == content {
+		return "", false, nil
+	}
+
+	return updated, true, nil
+}
+
+func updateScoopManifestReleaseChecksum(manifestPath, checksum string) (string, bool, error) {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+
+	var manifest struct {
+		Version     string   `json:"version"`
+		Description string   `json:"description"`
+		Homepage    string   `json:"homepage"`
+		License     string   `json:"license"`
+		Depends     []string `json:"depends,omitempty"`
+		URL         string   `json:"url"`
+		Hash        string   `json:"hash"`
+		ExtractDir  string   `json:"extract_dir"`
+		Installer   struct {
+			Script []string `json:"script,omitempty"`
+		} `json:"installer,omitempty"`
+		Bin []string `json:"bin,omitempty"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return "", false, err
+	}
+	if manifest.Hash == checksum {
+		return "", false, nil
+	}
+	manifest.Hash = checksum
+	updated, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return "", false, err
+	}
+	return string(updated) + "\n", true, nil
+}
+
+func syncReleasePackagingChecksums(ctx Context, spec ReleasePackagingSyncSpec) ([]ReleaseFileUpdate, error) {
+	if spec.FormulaPath == "" && spec.ScoopPath == "" {
+		return nil, nil
+	}
+
+	updates := make([]ReleaseFileUpdate, 0, 2)
+
+	if spec.FormulaPath != "" {
+		url := "https://github.com/sophium/erun/archive/refs/tags/v" + spec.Version + ".tar.gz"
+		ctx.TraceCommand("", "curl", "-fsSL", url)
+		ctx.TraceCommand("", "shasum", "-a", "256", "v"+spec.Version+".tar.gz")
+		if !ctx.DryRun {
+			checksum, err := releaseArchiveSHA256(url)
+			if err != nil {
+				return nil, err
+			}
+			content, changed, err := updateHomebrewFormulaReleaseChecksum(spec.FormulaPath, checksum)
+			if err != nil {
+				return nil, err
+			}
+			if changed {
+				updates = append(updates, ReleaseFileUpdate{Path: spec.FormulaPath, Content: content})
+			}
+		}
+	}
+
+	if spec.ScoopPath != "" {
+		url := "https://github.com/sophium/erun/archive/refs/tags/v" + spec.Version + ".zip"
+		ctx.TraceCommand("", "curl", "-fsSL", url)
+		ctx.TraceCommand("", "shasum", "-a", "256", "v"+spec.Version+".zip")
+		if !ctx.DryRun {
+			checksum, err := releaseArchiveSHA256(url)
+			if err != nil {
+				return nil, err
+			}
+			content, changed, err := updateScoopManifestReleaseChecksum(spec.ScoopPath, checksum)
+			if err != nil {
+				return nil, err
+			}
+			if changed {
+				updates = append(updates, ReleaseFileUpdate{Path: spec.ScoopPath, Content: content})
+			}
+		}
+	}
+
+	return updates, nil
+}
+
+func releaseArchiveSHA256(url string) (string, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	var lastErr error
+	for attempt := 0; attempt < 10; attempt++ {
+		checksum, retry, err := fetchReleaseArchiveSHA256(client, url)
+		if err == nil {
+			return checksum, nil
+		}
+		lastErr = err
+		if !retry {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("failed to download release archive %q", url)
+	}
+	return "", lastErr
+}
+
+func fetchReleaseArchiveSHA256(client *http.Client, url string) (string, bool, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", true, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		retry := resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError
+		return "", retry, fmt.Errorf("download %q failed: %s", url, resp.Status)
+	}
+
+	sum := sha256.New()
+	if _, err := io.Copy(sum, resp.Body); err != nil {
+		return "", true, err
+	}
+	return hex.EncodeToString(sum.Sum(nil)), false, nil
+}
+
 func newReleaseStage(projectRoot string, fileUpdates []ReleaseFileUpdate, version string, mode ReleaseMode) ReleaseStage {
 	stage := ReleaseStage{
 		Name:        "release",
@@ -756,6 +955,44 @@ func newReleaseStage(projectRoot string, fileUpdates []ReleaseFileUpdate, versio
 	}
 	stage.GitCommands = append(stage.GitCommands, releaseGitCommand(projectRoot, "tag", "-a", "v"+version, "-m", tagMessage))
 	return stage
+}
+
+func newPushReleaseTagStage(projectRoot, version string) ReleaseStage {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return ReleaseStage{}
+	}
+
+	return ReleaseStage{
+		Name: "push-release-tag",
+		GitCommands: []ReleaseCommandSpec{
+			releaseGitCommand(projectRoot, "push", "origin", "v"+version),
+		},
+	}
+}
+
+func newSyncPackagingStage(projectRoot string, spec ReleasePackagingSyncSpec) ReleaseStage {
+	if spec.FormulaPath == "" && spec.ScoopPath == "" {
+		return ReleaseStage{}
+	}
+
+	updates := make([]ReleaseFileUpdate, 0, 2)
+	if spec.FormulaPath != "" {
+		updates = append(updates, ReleaseFileUpdate{Path: spec.FormulaPath})
+	}
+	if spec.ScoopPath != "" {
+		updates = append(updates, ReleaseFileUpdate{Path: spec.ScoopPath})
+	}
+
+	addArgs := append([]string{"add"}, releaseUpdatedPaths(projectRoot, updates)...)
+	return ReleaseStage{
+		Name:          "sync-packaging-checksums",
+		PackagingSync: &spec,
+		GitCommands: []ReleaseCommandSpec{
+			releaseGitCommand(projectRoot, addArgs...),
+			releaseGitCommand(projectRoot, "commit", "-m", "[skip ci] sync package metadata "+spec.Version),
+		},
+	}
 }
 
 func newBumpStage(projectRoot, nextVersion string, fileUpdate ReleaseFileUpdate) ReleaseStage {
@@ -871,6 +1108,11 @@ func releaseGitPath(projectRoot, path string) string {
 		return path
 	}
 	return filepath.Clean(relative)
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }
 
 func findReleaseChartPaths(projectRoot string) ([]string, error) {

--- a/erun-common/release_test.go
+++ b/erun-common/release_test.go
@@ -88,8 +88,8 @@ func TestResolveReleaseSpecStableReleaseIncludesPackagingUpdatesWhenPresent(t *t
 		t.Fatalf("resolveReleaseSpec failed: %v", err)
 	}
 
-	if len(spec.Stages) != 5 {
-		t.Fatalf("expected 5 stages, got %+v", spec.Stages)
+	if len(spec.Stages) != 7 {
+		t.Fatalf("expected 7 stages, got %+v", spec.Stages)
 	}
 	if len(spec.Stages[1].FileUpdates) != 3 {
 		t.Fatalf("expected chart, formula, and scoop updates, got %+v", spec.Stages[1].FileUpdates)
@@ -107,6 +107,25 @@ func TestResolveReleaseSpecStableReleaseIncludesPackagingUpdatesWhenPresent(t *t
 	}
 	if scoop := spec.Stages[1].FileUpdates[2].Content; !strings.Contains(scoop, `"version": "1.4.2"`) || !strings.Contains(scoop, `"extract_dir": "erun-1.4.2"`) {
 		t.Fatalf("unexpected scoop update: %s", scoop)
+	}
+	if spec.Stages[2].Name != "push-release-tag" {
+		t.Fatalf("unexpected tag push stage: %+v", spec.Stages[2])
+	}
+	if got := spec.Stages[2].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "origin", "v1.4.2"}) {
+		t.Fatalf("unexpected tag push command: %+v", got)
+	}
+	if spec.Stages[3].Name != "sync-packaging-checksums" || spec.Stages[3].PackagingSync == nil {
+		t.Fatalf("unexpected packaging sync stage: %+v", spec.Stages[3])
+	}
+	if got := spec.Stages[3].GitCommands[0].Args; !reflect.DeepEqual(got, []string{
+		"add",
+		filepath.Join("Formula", "erun.rb"),
+		filepath.Join("bucket", "erun.json"),
+	}) {
+		t.Fatalf("unexpected packaging add command: %+v", got)
+	}
+	if got := spec.Stages[3].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"commit", "-m", "[skip ci] sync package metadata 1.4.2"}) {
+		t.Fatalf("unexpected packaging commit command: %+v", got)
 	}
 }
 
@@ -235,10 +254,49 @@ func TestRunReleaseSpecRewritesStablePackagingMetadataWhenPresent(t *testing.T) 
 		Stdout: new(bytes.Buffer),
 		Stderr: new(bytes.Buffer),
 	}
-	if err := RunReleaseSpec(ctx, spec, func(dir string, stdout, stderr io.Writer, args ...string) error {
+	if err := runReleaseSpec(ctx, spec, func(dir string, stdout, stderr io.Writer, args ...string) error {
 		gitCalls = append(gitCalls, append([]string{dir}, args...))
 		return nil
-	}, nil); err != nil {
+	}, nil, func(Context, ReleasePackagingSyncSpec) ([]ReleaseFileUpdate, error) {
+		return []ReleaseFileUpdate{
+			{
+				Path: filepath.Join(projectRoot, "Formula", "erun.rb"),
+				Content: `class Erun < Formula
+  desc "Multi-tenant multi-environment deployment and management tool"
+  homepage "https://github.com/sophium/erun"
+  url "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.tar.gz"
+  sha256 "formula-checksum"
+  license "MIT"
+end
+`,
+			},
+			{
+				Path: filepath.Join(projectRoot, "bucket", "erun.json"),
+				Content: `{
+  "version": "1.4.2",
+  "description": "Multi-tenant multi-environment deployment and management tool",
+  "homepage": "https://github.com/sophium/erun",
+  "license": "MIT",
+  "depends": [
+    "go"
+  ],
+  "url": "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.zip",
+  "hash": "scoop-checksum",
+  "extract_dir": "erun-1.4.2",
+  "installer": {
+    "script": [
+      "go build"
+    ]
+  },
+  "bin": [
+    "erun.exe",
+    "emcp.exe"
+  ]
+}
+`,
+			},
+		}, nil
+	}); err != nil {
 		t.Fatalf("RunReleaseSpec failed: %v", err)
 	}
 
@@ -246,7 +304,7 @@ func TestRunReleaseSpecRewritesStablePackagingMetadataWhenPresent(t *testing.T) 
 	if err != nil {
 		t.Fatalf("read formula: %v", err)
 	}
-	if !strings.Contains(string(formulaData), `url "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.tar.gz"`) {
+	if !strings.Contains(string(formulaData), `url "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.tar.gz"`) || !strings.Contains(string(formulaData), `sha256 "formula-checksum"`) {
 		t.Fatalf("unexpected formula content: %s", formulaData)
 	}
 
@@ -255,18 +313,140 @@ func TestRunReleaseSpecRewritesStablePackagingMetadataWhenPresent(t *testing.T) 
 		t.Fatalf("read scoop manifest: %v", err)
 	}
 	scoop := string(scoopData)
-	if !strings.Contains(scoop, `"version": "1.4.2"`) || !strings.Contains(scoop, `"url": "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.zip"`) || !strings.Contains(scoop, `"extract_dir": "erun-1.4.2"`) {
+	if !strings.Contains(scoop, `"version": "1.4.2"`) || !strings.Contains(scoop, `"url": "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.zip"`) || !strings.Contains(scoop, `"extract_dir": "erun-1.4.2"`) || !strings.Contains(scoop, `"hash": "scoop-checksum"`) {
 		t.Fatalf("unexpected scoop content: %s", scoop)
 	}
 
-	if got := gitCalls[2]; !reflect.DeepEqual(got, []string{
+	if got := gitCalls[5]; !reflect.DeepEqual(got, []string{
+		projectRoot,
+		"push",
+		"origin",
+		"v1.4.2",
+	}) {
+		t.Fatalf("unexpected tag push call: %+v", got)
+	}
+	if got := gitCalls[6]; !reflect.DeepEqual(got, []string{
 		projectRoot,
 		"add",
-		filepath.Join("erun-devops", "k8s", "api", "Chart.yaml"),
 		filepath.Join("Formula", "erun.rb"),
 		filepath.Join("bucket", "erun.json"),
 	}) {
-		t.Fatalf("unexpected release add call: %+v", got)
+		t.Fatalf("unexpected packaging add call: %+v", got)
+	}
+	if got := gitCalls[7]; !reflect.DeepEqual(got, []string{
+		projectRoot,
+		"commit",
+		"-m",
+		"[skip ci] sync package metadata 1.4.2",
+	}) {
+		t.Fatalf("unexpected packaging commit call: %+v", got)
+	}
+}
+
+func TestRunReleaseSpecSkipsPackagingCommitWhenChecksumsAreAlreadyCurrent(t *testing.T) {
+	projectRoot := setupReleaseProjectGitRepoWithOptions(t, "main", releaseProjectOptions{WithPackaging: true})
+
+	spec, err := resolveReleaseSpec(
+		func() (string, string, error) { return "tenant-a", projectRoot, nil },
+		LoadProjectConfig,
+		func(string) (string, error) { return "main", nil },
+		func(string) (string, error) { return "abc1234", nil },
+		func(string, string) (bool, error) { return true, nil },
+		ReleaseParams{},
+	)
+	if err != nil {
+		t.Fatalf("resolveReleaseSpec failed: %v", err)
+	}
+
+	var gitCalls [][]string
+	ctx := Context{
+		Logger: NewLoggerWithWriters(2, new(bytes.Buffer), new(bytes.Buffer)),
+		Stdout: new(bytes.Buffer),
+		Stderr: new(bytes.Buffer),
+	}
+	if err := runReleaseSpec(ctx, spec, func(dir string, stdout, stderr io.Writer, args ...string) error {
+		gitCalls = append(gitCalls, append([]string{dir}, args...))
+		return nil
+	}, nil, func(Context, ReleasePackagingSyncSpec) ([]ReleaseFileUpdate, error) {
+		return nil, nil
+	}); err != nil {
+		t.Fatalf("RunReleaseSpec failed: %v", err)
+	}
+
+	for _, call := range gitCalls {
+		if len(call) >= 4 && call[1] == "commit" && call[3] == "[skip ci] sync package metadata 1.4.2" {
+			t.Fatalf("did not expect packaging commit when checksum updates are empty: %+v", call)
+		}
+	}
+	if got := gitCalls[6]; !reflect.DeepEqual(got, []string{
+		projectRoot,
+		"add",
+		filepath.Join("erun-devops", "VERSION"),
+	}) {
+		t.Fatalf("expected version bump to follow tag push when checksum updates are empty, got %+v", got)
+	}
+}
+
+func TestUpdateHomebrewFormulaReleaseChecksum(t *testing.T) {
+	projectRoot := t.TempDir()
+	formulaPath := filepath.Join(projectRoot, "Formula", "erun.rb")
+	if err := os.MkdirAll(filepath.Dir(formulaPath), 0o755); err != nil {
+		t.Fatalf("mkdir formula dir: %v", err)
+	}
+	if err := os.WriteFile(formulaPath, []byte(`class Erun < Formula
+  url "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.tar.gz"
+  sha256 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+end
+`), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+
+	content, changed, err := updateHomebrewFormulaReleaseChecksum(formulaPath, "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd")
+	if err != nil {
+		t.Fatalf("updateHomebrewFormulaReleaseChecksum failed: %v", err)
+	}
+	if !changed || !strings.Contains(content, `sha256 "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"`) {
+		t.Fatalf("unexpected checksum update: changed=%v content=%s", changed, content)
+	}
+}
+
+func TestUpdateScoopManifestReleaseChecksum(t *testing.T) {
+	projectRoot := t.TempDir()
+	manifestPath := filepath.Join(projectRoot, "bucket", "erun.json")
+	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		t.Fatalf("mkdir bucket dir: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, []byte(`{
+  "version": "1.4.2",
+  "description": "Multi-tenant multi-environment deployment and management tool",
+  "homepage": "https://github.com/sophium/erun",
+  "license": "MIT",
+  "depends": [
+    "go"
+  ],
+  "url": "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.zip",
+  "hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "extract_dir": "erun-1.4.2",
+  "installer": {
+    "script": [
+      "go build"
+    ]
+  },
+  "bin": [
+    "erun.exe",
+    "emcp.exe"
+  ]
+}
+`), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	content, changed, err := updateScoopManifestReleaseChecksum(manifestPath, "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd")
+	if err != nil {
+		t.Fatalf("updateScoopManifestReleaseChecksum failed: %v", err)
+	}
+	if !changed || !strings.Contains(content, `"hash": "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"`) {
+		t.Fatalf("unexpected checksum update: changed=%v content=%s", changed, content)
 	}
 }
 


### PR DESCRIPTION
## Summary
- push stable release tags early enough to fetch the real GitHub source archives
- sync Homebrew and Scoop checksums from the published tag tarball and zip before the final branch push
- tighten packaging validation and update the current stable package-manager hashes on main

## Why
Stable release was updating package-manager versions and URLs without refreshing archive checksums, which left Scoop and Brew installs broken after release.

## Validation
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-common && go test ./...
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-cli && go test ./...
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-mcp && go test ./...

Closes #67
