### PR TITLE
Build release images for amd64 and arm64

### DIFF
--- a/erun-cli/cmd/build_test.go
+++ b/erun-cli/cmd/build_test.go
@@ -19,6 +19,8 @@ type dockerBuildCall struct {
 	Dir            string
 	DockerfilePath string
 	Tag            string
+	Platforms      []string
+	Push           bool
 	Stdout         io.Writer
 	Stderr         io.Writer
 }
@@ -46,11 +48,13 @@ type buildScriptCall struct {
 }
 
 func buildCallFunc(run func(dockerBuildCall) error) common.DockerImageBuilderFunc {
-	return func(dir, dockerfilePath, tag string, stdout, stderr io.Writer) error {
+	return func(buildInput common.DockerBuildSpec, stdout, stderr io.Writer) error {
 		return run(dockerBuildCall{
-			Dir:            dir,
-			DockerfilePath: dockerfilePath,
-			Tag:            tag,
+			Dir:            buildInput.ContextDir,
+			DockerfilePath: buildInput.DockerfilePath,
+			Tag:            buildInput.Image.Tag,
+			Platforms:      append([]string{}, buildInput.Platforms...),
+			Push:           buildInput.Push,
 			Stdout:         stdout,
 			Stderr:         stderr,
 		})
@@ -1957,8 +1961,8 @@ func TestBuildCommandVersionOverrideAvoidsSnapshotTag(t *testing.T) {
 		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
 			return common.DockerBuildContextAtDir(buildDir)
 		},
-		BuildDockerImage: func(dir, dockerfilePath, tag string, stdout, stderr io.Writer) error {
-			t.Fatalf("unexpected build execution: %s", tag)
+		BuildDockerImage: func(buildInput common.DockerBuildSpec, stdout, stderr io.Writer) error {
+			t.Fatalf("unexpected build execution: %s", buildInput.Image.Tag)
 			return nil
 		},
 	})
@@ -2010,8 +2014,8 @@ func TestBuildCommandVersionOverrideDoesNotReplaceComponentLocalVersions(t *test
 		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
 			return common.DockerBuildContext{Dir: filepath.Join(devopsDir, "docker")}, nil
 		},
-		BuildDockerImage: func(dir, dockerfilePath, tag string, stdout, stderr io.Writer) error {
-			t.Fatalf("unexpected build execution: %s", tag)
+		BuildDockerImage: func(buildInput common.DockerBuildSpec, stdout, stderr io.Writer) error {
+			t.Fatalf("unexpected build execution: %s", buildInput.Image.Tag)
 			return nil
 		},
 	})
@@ -2318,17 +2322,17 @@ func TestBuildCommandDryRunReleaseShowsPushCommandsForReleaseTaggedDockerBuilds(
 	}
 
 	output := stderr.String()
-	if !strings.Contains(output, "docker build -t erunpaas/api:1.4.2") {
+	if !strings.Contains(output, "docker buildx build --platform 'linux/amd64,linux/arm64' -t erunpaas/api:1.4.2") {
 		t.Fatalf("expected release build trace, got:\n%s", output)
 	}
 	if !strings.Contains(output, "docker build -t erunpaas/base:9.9.9") {
 		t.Fatalf("expected component-local build trace, got:\n%s", output)
 	}
-	if !strings.Contains(output, "docker push erunpaas/api:1.4.2") {
-		t.Fatalf("expected release push trace, got:\n%s", output)
+	if !strings.Contains(output, "--push") {
+		t.Fatalf("expected multi-platform release push trace, got:\n%s", output)
 	}
-	if strings.Contains(output, "docker push erunpaas/base:9.9.9") {
-		t.Fatalf("did not expect push trace for non-release-tagged image, got:\n%s", output)
+	if strings.Contains(output, "docker push erunpaas/api:1.4.2") || strings.Contains(output, "docker push erunpaas/base:9.9.9") {
+		t.Fatalf("did not expect separate docker push trace, got:\n%s", output)
 	}
 }
 

--- a/erun-cli/cmd/deploy_test.go
+++ b/erun-cli/cmd/deploy_test.go
@@ -18,6 +18,8 @@ type deployBuildCall struct {
 	Dir            string
 	DockerfilePath string
 	Tag            string
+	Platforms      []string
+	Push           bool
 	Stdout         io.Writer
 	Stderr         io.Writer
 }
@@ -29,11 +31,13 @@ type deployPushCall struct {
 }
 
 func deployBuildCallFunc(run func(deployBuildCall) error) common.DockerImageBuilderFunc {
-	return func(dir, dockerfilePath, tag string, stdout, stderr io.Writer) error {
+	return func(buildInput common.DockerBuildSpec, stdout, stderr io.Writer) error {
 		return run(deployBuildCall{
-			Dir:            dir,
-			DockerfilePath: dockerfilePath,
-			Tag:            tag,
+			Dir:            buildInput.ContextDir,
+			DockerfilePath: buildInput.DockerfilePath,
+			Tag:            buildInput.Image.Tag,
+			Platforms:      append([]string{}, buildInput.Platforms...),
+			Push:           buildInput.Push,
 			Stdout:         stdout,
 			Stderr:         stderr,
 		})

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -30,7 +30,7 @@ type commandSpec struct {
 type (
 	BuildContextResolverFunc func() (DockerBuildContext, error)
 	NowFunc                  func() time.Time
-	DockerImageBuilderFunc   func(string, string, string, io.Writer, io.Writer) error
+	DockerImageBuilderFunc   func(DockerBuildSpec, io.Writer, io.Writer) error
 	DockerImagePusherFunc    func(string, io.Writer, io.Writer) error
 	DockerRegistryLoginFunc  func(string, io.Reader, io.Writer, io.Writer) error
 	BuildScriptRunnerFunc    func(string, string, []string, io.Reader, io.Writer, io.Writer) error
@@ -63,6 +63,8 @@ type DockerBuildSpec struct {
 	ContextDir     string
 	DockerfilePath string
 	Image          DockerImageReference
+	Platforms      []string
+	Push           bool
 }
 
 type DockerPushSpec struct {
@@ -179,6 +181,19 @@ func BuildExecutionSpecWithRelease(execution BuildExecutionSpec, release Release
 	execution.release = &release
 	if len(execution.dockerBuilds) > 0 && len(execution.dockerPushes) == 0 {
 		execution.dockerPushes = releaseDockerPushSpecs(execution.dockerBuilds, release.DockerImages)
+	}
+	if len(execution.dockerBuilds) > 0 && len(execution.dockerPushes) > 0 {
+		releaseTags := make(map[string]struct{}, len(execution.dockerPushes))
+		for _, pushInput := range execution.dockerPushes {
+			releaseTags[strings.TrimSpace(pushInput.Image.Tag)] = struct{}{}
+		}
+		for i := range execution.dockerBuilds {
+			if _, ok := releaseTags[strings.TrimSpace(execution.dockerBuilds[i].Image.Tag)]; !ok {
+				continue
+			}
+			execution.dockerBuilds[i].Platforms = []string{"linux/amd64", "linux/arm64"}
+			execution.dockerBuilds[i].Push = true
+		}
 	}
 	return execution
 }
@@ -758,7 +773,7 @@ func (b DockerBuildSpec) command() commandSpec {
 	return commandSpec{
 		Dir:  b.ContextDir,
 		Name: "docker",
-		Args: dockerBuildArgs(b.Image.Tag, b.DockerfilePath),
+		Args: dockerBuildArgs(b),
 	}
 }
 
@@ -783,7 +798,7 @@ func RunDockerBuild(ctx Context, buildInput DockerBuildSpec, build DockerImageBu
 	if ctx.DryRun {
 		return nil
 	}
-	return build(buildInput.ContextDir, buildInput.DockerfilePath, buildInput.Image.Tag, ctx.Stdout, ctx.Stderr)
+	return build(buildInput, ctx.Stdout, ctx.Stderr)
 }
 
 func RunDockerBuilds(ctx Context, builds []DockerBuildSpec, build DockerImageBuilderFunc) error {
@@ -928,6 +943,9 @@ func RunDockerPushSpec(ctx Context, pushInput DockerPushSpec, buildInput *Docker
 		if err := RunDockerBuild(ctx, *buildInput, build); err != nil {
 			return err
 		}
+		if buildInput.Push {
+			return nil
+		}
 	}
 	if push == nil {
 		push = func(ctx Context, pushInput DockerPushSpec) error {
@@ -941,7 +959,17 @@ func RunDockerPushExecution(ctx Context, execution DockerPushExecutionSpec, buil
 	if err := RunDockerBuilds(ctx, execution.builds, build); err != nil {
 		return err
 	}
+	builtAndPushedTags := make(map[string]struct{}, len(execution.builds))
+	for _, buildInput := range execution.builds {
+		if !buildInput.Push {
+			continue
+		}
+		builtAndPushedTags[buildInput.Image.Tag] = struct{}{}
+	}
 	for _, pushInput := range execution.pushes {
+		if _, ok := builtAndPushedTags[pushInput.Image.Tag]; ok {
+			continue
+		}
 		if err := RunDockerPushSpec(ctx, pushInput, nil, build, push); err != nil {
 			return err
 		}
@@ -1063,20 +1091,28 @@ func FindComponentDockerBuildContext(projectRoot, componentName string) (DockerB
 	return matches[0], true, nil
 }
 
-func DockerImageBuilder(dir, dockerfilePath, tag string, stdout, stderr io.Writer) error {
-	cmd := exec.Command("docker", dockerBuildArgs(tag, dockerfilePath)...)
-	cmd.Dir = dir
+func DockerImageBuilder(buildInput DockerBuildSpec, stdout, stderr io.Writer) error {
+	cmd := exec.Command("docker", dockerBuildArgs(buildInput)...)
+	cmd.Dir = buildInput.ContextDir
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	return cmd.Run()
 }
 
-func dockerBuildArgs(tag, dockerfilePath string) []string {
-	args := []string{"build", "-t", tag}
+func dockerBuildArgs(buildInput DockerBuildSpec) []string {
+	tag := strings.TrimSpace(buildInput.Image.Tag)
+	args := []string{"build"}
+	if len(buildInput.Platforms) > 0 {
+		args = []string{"buildx", "build", "--platform", strings.Join(buildInput.Platforms, ",")}
+	}
+	args = append(args, "-t", tag)
 	if version := dockerImageTagVersion(tag); version != "" {
 		args = append(args, "--build-arg", "ERUN_VERSION="+version)
 	}
-	args = append(args, "-f", dockerfilePath, ".")
+	if buildInput.Push {
+		args = append(args, "--push")
+	}
+	args = append(args, "-f", buildInput.DockerfilePath, ".")
 	return args
 }
 

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -72,7 +73,12 @@ func TestDockerRegistryFromImageTag(t *testing.T) {
 }
 
 func TestDockerBuildArgsIncludeImageVersionAsBuildArg(t *testing.T) {
-	args := dockerBuildArgs("erunpaas/erun-devops:1.0.0-snapshot-20260406123456", "/tmp/Dockerfile")
+	args := dockerBuildArgs(DockerBuildSpec{
+		DockerfilePath: "/tmp/Dockerfile",
+		Image: DockerImageReference{
+			Tag: "erunpaas/erun-devops:1.0.0-snapshot-20260406123456",
+		},
+	})
 	got := strings.Join(args, " ")
 	for _, want := range []string{
 		"build",
@@ -82,6 +88,30 @@ func TestDockerBuildArgsIncludeImageVersionAsBuildArg(t *testing.T) {
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected docker build args to contain %q, got %q", want, got)
+		}
+	}
+}
+
+func TestDockerBuildArgsUseBuildxForMultiPlatformPush(t *testing.T) {
+	args := dockerBuildArgs(DockerBuildSpec{
+		DockerfilePath: "/tmp/Dockerfile",
+		Image: DockerImageReference{
+			Tag: "erunpaas/erun-devops:1.0.0",
+		},
+		Platforms: []string{"linux/amd64", "linux/arm64"},
+		Push:      true,
+	})
+	got := strings.Join(args, " ")
+	for _, want := range []string{
+		"buildx build",
+		"--platform linux/amd64,linux/arm64",
+		"-t erunpaas/erun-devops:1.0.0",
+		"--build-arg ERUN_VERSION=1.0.0",
+		"--push",
+		"-f /tmp/Dockerfile .",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected docker buildx args to contain %q, got %q", want, got)
 		}
 	}
 }
@@ -151,7 +181,7 @@ func TestResolveBuildExecutionPrefersProjectBuildScript(t *testing.T) {
 			t.Fatalf("unexpected script env: %+v", env)
 		}
 		return nil
-	}, func(string, string, string, io.Writer, io.Writer) error {
+	}, func(DockerBuildSpec, io.Writer, io.Writer) error {
 		t.Fatal("unexpected docker build")
 		return nil
 	}, nil); err != nil {
@@ -206,7 +236,7 @@ func TestResolveBuildExecutionPrefersProjectRootBuildScriptOverNestedScripts(t *
 			t.Fatalf("unexpected script env: %+v", env)
 		}
 		return nil
-	}, func(string, string, string, io.Writer, io.Writer) error {
+	}, func(DockerBuildSpec, io.Writer, io.Writer) error {
 		t.Fatal("unexpected docker build")
 		return nil
 	}, nil); err != nil {
@@ -265,7 +295,7 @@ func TestResolveBuildExecutionUsesFirstNestedProjectBuildScript(t *testing.T) {
 			t.Fatalf("unexpected script env: %+v", env)
 		}
 		return nil
-	}, func(string, string, string, io.Writer, io.Writer) error {
+	}, func(DockerBuildSpec, io.Writer, io.Writer) error {
 		t.Fatal("unexpected docker build")
 		return nil
 	}, nil); err != nil {
@@ -359,7 +389,7 @@ func TestRunBuildExecutionRunsLinuxBuildScripts(t *testing.T) {
 			t.Fatalf("unexpected script env: %+v", env)
 		}
 		return nil
-	}, func(string, string, string, io.Writer, io.Writer) error {
+	}, func(DockerBuildSpec, io.Writer, io.Writer) error {
 		t.Fatal("unexpected docker build")
 		return nil
 	}, nil); err != nil {
@@ -553,6 +583,9 @@ func TestResolveBuildExecutionReleaseUsesResolvedVersionForDockerBuilds(t *testi
 	if got := execution.dockerBuilds[0].Image.Tag; got != "erunpaas/api:1.4.2" {
 		t.Fatalf("unexpected docker build tag: %q", got)
 	}
+	if !execution.dockerBuilds[0].Push || !reflect.DeepEqual(execution.dockerBuilds[0].Platforms, []string{"linux/amd64", "linux/arm64"}) {
+		t.Fatalf("expected multi-platform release build spec, got %+v", execution.dockerBuilds[0])
+	}
 	if len(execution.dockerPushes) != 1 {
 		t.Fatalf("unexpected docker pushes: %+v", execution.dockerPushes)
 	}
@@ -667,7 +700,7 @@ func TestRunBuildExecutionDryRunReleaseIncludesReleaseAndBuildTrace(t *testing.T
 	}
 }
 
-func TestRunBuildExecutionReleaseBuildsAndPushesResolvedVersion(t *testing.T) {
+func TestRunBuildExecutionReleasePublishesResolvedVersionAsMultiPlatformBuild(t *testing.T) {
 	projectRoot := setupReleaseProjectGitRepo(t, "main")
 	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "api")
 
@@ -687,7 +720,7 @@ func TestRunBuildExecutionReleaseBuildsAndPushesResolvedVersion(t *testing.T) {
 	}
 	execution.release = nil
 
-	var buildCalls []string
+	var buildCalls []DockerBuildSpec
 	var pushCalls []string
 	ctx := Context{
 		Logger: NewLoggerWithWriters(2, io.Discard, io.Discard),
@@ -695,8 +728,8 @@ func TestRunBuildExecutionReleaseBuildsAndPushesResolvedVersion(t *testing.T) {
 		Stdout: new(bytes.Buffer),
 		Stderr: new(bytes.Buffer),
 	}
-	if err := RunBuildExecution(ctx, execution, nil, func(dir, dockerfilePath, tag string, stdout, stderr io.Writer) error {
-		buildCalls = append(buildCalls, tag)
+	if err := RunBuildExecution(ctx, execution, nil, func(buildInput DockerBuildSpec, stdout, stderr io.Writer) error {
+		buildCalls = append(buildCalls, buildInput)
 		return nil
 	}, func(ctx Context, pushInput DockerPushSpec) error {
 		pushCalls = append(pushCalls, pushInput.Image.Tag)
@@ -705,11 +738,14 @@ func TestRunBuildExecutionReleaseBuildsAndPushesResolvedVersion(t *testing.T) {
 		t.Fatalf("RunBuildExecution failed: %v", err)
 	}
 
-	if len(buildCalls) != 1 || buildCalls[0] != "erunpaas/api:1.4.2" {
+	if len(buildCalls) != 1 || buildCalls[0].Image.Tag != "erunpaas/api:1.4.2" {
 		t.Fatalf("unexpected build calls: %+v", buildCalls)
 	}
-	if len(pushCalls) != 1 || pushCalls[0] != "erunpaas/api:1.4.2" {
-		t.Fatalf("unexpected push calls: %+v", pushCalls)
+	if !buildCalls[0].Push || !reflect.DeepEqual(buildCalls[0].Platforms, []string{"linux/amd64", "linux/arm64"}) {
+		t.Fatalf("expected multi-platform pushed release build, got %+v", buildCalls[0])
+	}
+	if len(pushCalls) != 0 {
+		t.Fatalf("did not expect separate push calls: %+v", pushCalls)
 	}
 }
 

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -405,7 +405,7 @@ func TestBuildToolPreviewReleaseIncludesReleaseAndBuildTrace(t *testing.T) {
 	foundBuildTrace := false
 	foundVersionReport := false
 	for _, trace := range output.Trace {
-		if strings.Contains(trace, "docker build -t erunpaas/api:1.4.2-rc.") {
+		if strings.Contains(trace, "docker buildx build --platform 'linux/amd64,linux/arm64' -t erunpaas/api:1.4.2-rc.") && strings.Contains(trace, "--push") {
 			foundBuildTrace = true
 		}
 		if strings.Contains(trace, "release version: 1.4.2-rc.") {
@@ -522,7 +522,7 @@ func TestBuildToolRunsProjectBuildScriptWhenPresent(t *testing.T) {
 			}
 			return nil
 		},
-		BuildDockerImage: func(string, string, string, io.Writer, io.Writer) error {
+		BuildDockerImage: func(eruncommon.DockerBuildSpec, io.Writer, io.Writer) error {
 			t.Fatal("unexpected docker build")
 			return nil
 		},


### PR DESCRIPTION
## Summary
- publish release-tagged container images with buildx for linux/amd64 and linux/arm64
- keep ordinary non-release local docker builds unchanged
- update release dry-run and runtime tests for the new multi-arch publish path

## Why
`erun build --release` was using plain `docker build` and `docker push`, which only published a single-architecture image from the local Docker daemon.

## Validation
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-common && go test ./...
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-cli && go test ./...
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-mcp && go test ./...

Closes #69
