### PR TITLE
Bootstrap buildx builder for release builds

### DIFF
--- a/erun-cli/cmd/build_test.go
+++ b/erun-cli/cmd/build_test.go
@@ -2322,7 +2322,16 @@ func TestBuildCommandDryRunReleaseShowsPushCommandsForReleaseTaggedDockerBuilds(
 	}
 
 	output := stderr.String()
-	if !strings.Contains(output, "docker buildx build --platform 'linux/amd64,linux/arm64' -t erunpaas/api:1.4.2") {
+	if !strings.Contains(output, "docker buildx inspect erun-multiarch") {
+		t.Fatalf("expected buildx inspect trace, got:\n%s", output)
+	}
+	if !strings.Contains(output, "docker buildx create --name erun-multiarch --driver docker-container") {
+		t.Fatalf("expected buildx create trace, got:\n%s", output)
+	}
+	if !strings.Contains(output, "docker buildx inspect --builder erun-multiarch --bootstrap") {
+		t.Fatalf("expected buildx bootstrap trace, got:\n%s", output)
+	}
+	if !strings.Contains(output, "docker buildx build --builder erun-multiarch --platform 'linux/amd64,linux/arm64' -t erunpaas/api:1.4.2") {
 		t.Fatalf("expected release build trace, got:\n%s", output)
 	}
 	if !strings.Contains(output, "docker build -t erunpaas/base:9.9.9") {

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -15,6 +15,8 @@ import (
 
 const localSnapshotTimestampFormat = "20060102150405"
 
+const multiPlatformBuildxBuilderName = "erun-multiarch"
+
 var (
 	ErrVersionFileNotFound        = errors.New("version file not found for current module")
 	ErrDockerBuildContextNotFound = errors.New("dockerfile not found in current directory")
@@ -770,11 +772,20 @@ func newDockerBuildSpec(now NowFunc, projectRoot, environment string, buildConte
 }
 
 func (b DockerBuildSpec) command() commandSpec {
+	args := dockerBuildArgs(b)
 	return commandSpec{
 		Dir:  b.ContextDir,
 		Name: "docker",
-		Args: dockerBuildArgs(b),
+		Args: args,
 	}
+}
+
+func (b DockerBuildSpec) traceCommands() []commandSpec {
+	if len(b.Platforms) == 0 {
+		return []commandSpec{b.command()}
+	}
+
+	return append(dockerBuildxSetupCommands(b.ContextDir), b.command())
 }
 
 func (p DockerPushSpec) command() commandSpec {
@@ -793,8 +804,9 @@ func RunDockerBuild(ctx Context, buildInput DockerBuildSpec, build DockerImageBu
 	if build == nil {
 		build = DockerImageBuilder
 	}
-	command := buildInput.command()
-	ctx.TraceCommand(command.Dir, command.Name, command.Args...)
+	for _, command := range buildInput.traceCommands() {
+		ctx.TraceCommand(command.Dir, command.Name, command.Args...)
+	}
 	if ctx.DryRun {
 		return nil
 	}
@@ -1092,6 +1104,11 @@ func FindComponentDockerBuildContext(projectRoot, componentName string) (DockerB
 }
 
 func DockerImageBuilder(buildInput DockerBuildSpec, stdout, stderr io.Writer) error {
+	if len(buildInput.Platforms) > 0 {
+		if err := ensureDockerBuildxBuilder(buildInput.ContextDir, stdout, stderr); err != nil {
+			return err
+		}
+	}
 	cmd := exec.Command("docker", dockerBuildArgs(buildInput)...)
 	cmd.Dir = buildInput.ContextDir
 	cmd.Stdout = stdout
@@ -1103,7 +1120,7 @@ func dockerBuildArgs(buildInput DockerBuildSpec) []string {
 	tag := strings.TrimSpace(buildInput.Image.Tag)
 	args := []string{"build"}
 	if len(buildInput.Platforms) > 0 {
-		args = []string{"buildx", "build", "--platform", strings.Join(buildInput.Platforms, ",")}
+		args = []string{"buildx", "build", "--builder", multiPlatformBuildxBuilderName, "--platform", strings.Join(buildInput.Platforms, ",")}
 	}
 	args = append(args, "-t", tag)
 	if version := dockerImageTagVersion(tag); version != "" {
@@ -1114,6 +1131,48 @@ func dockerBuildArgs(buildInput DockerBuildSpec) []string {
 	}
 	args = append(args, "-f", buildInput.DockerfilePath, ".")
 	return args
+}
+
+func dockerBuildxSetupCommands(dir string) []commandSpec {
+	return []commandSpec{
+		{
+			Dir:  dir,
+			Name: "docker",
+			Args: []string{"buildx", "inspect", multiPlatformBuildxBuilderName},
+		},
+		{
+			Dir:  dir,
+			Name: "docker",
+			Args: []string{"buildx", "create", "--name", multiPlatformBuildxBuilderName, "--driver", "docker-container"},
+		},
+		{
+			Dir:  dir,
+			Name: "docker",
+			Args: []string{"buildx", "inspect", "--builder", multiPlatformBuildxBuilderName, "--bootstrap"},
+		},
+	}
+}
+
+func ensureDockerBuildxBuilder(dir string, stdout, stderr io.Writer) error {
+	inspect := exec.Command("docker", "buildx", "inspect", multiPlatformBuildxBuilderName)
+	inspect.Dir = dir
+	inspect.Stdout = io.Discard
+	inspect.Stderr = io.Discard
+	if err := inspect.Run(); err != nil {
+		create := exec.Command("docker", "buildx", "create", "--name", multiPlatformBuildxBuilderName, "--driver", "docker-container")
+		create.Dir = dir
+		create.Stdout = stdout
+		create.Stderr = stderr
+		if err := create.Run(); err != nil {
+			return err
+		}
+	}
+
+	bootstrap := exec.Command("docker", "buildx", "inspect", "--builder", multiPlatformBuildxBuilderName, "--bootstrap")
+	bootstrap.Dir = dir
+	bootstrap.Stdout = stdout
+	bootstrap.Stderr = stderr
+	return bootstrap.Run()
 }
 
 func dockerImageTagVersion(tag string) string {

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -104,6 +104,7 @@ func TestDockerBuildArgsUseBuildxForMultiPlatformPush(t *testing.T) {
 	got := strings.Join(args, " ")
 	for _, want := range []string{
 		"buildx build",
+		"--builder erun-multiarch",
 		"--platform linux/amd64,linux/arm64",
 		"-t erunpaas/erun-devops:1.0.0",
 		"--build-arg ERUN_VERSION=1.0.0",
@@ -113,6 +114,35 @@ func TestDockerBuildArgsUseBuildxForMultiPlatformPush(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected docker buildx args to contain %q, got %q", want, got)
 		}
+	}
+}
+
+func TestDockerBuildTraceCommandsIncludeBuildxBootstrapForMultiPlatformBuilds(t *testing.T) {
+	buildInput := DockerBuildSpec{
+		ContextDir:     "/tmp/project",
+		DockerfilePath: "/tmp/project/Dockerfile",
+		Image: DockerImageReference{
+			Tag: "erunpaas/erun-devops:1.0.0",
+		},
+		Platforms: []string{"linux/amd64", "linux/arm64"},
+		Push:      true,
+	}
+
+	commands := buildInput.traceCommands()
+	if len(commands) != 4 {
+		t.Fatalf("unexpected trace commands: %+v", commands)
+	}
+	if got := strings.Join(commands[0].Args, " "); got != "buildx inspect erun-multiarch" {
+		t.Fatalf("unexpected inspect command: %q", got)
+	}
+	if got := strings.Join(commands[1].Args, " "); got != "buildx create --name erun-multiarch --driver docker-container" {
+		t.Fatalf("unexpected create command: %q", got)
+	}
+	if got := strings.Join(commands[2].Args, " "); got != "buildx inspect --builder erun-multiarch --bootstrap" {
+		t.Fatalf("unexpected bootstrap command: %q", got)
+	}
+	if got := strings.Join(commands[3].Args, " "); !strings.Contains(got, "buildx build --builder erun-multiarch --platform linux/amd64,linux/arm64") {
+		t.Fatalf("unexpected build command: %q", got)
 	}
 }
 

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -405,7 +405,7 @@ func TestBuildToolPreviewReleaseIncludesReleaseAndBuildTrace(t *testing.T) {
 	foundBuildTrace := false
 	foundVersionReport := false
 	for _, trace := range output.Trace {
-		if strings.Contains(trace, "docker buildx build --platform 'linux/amd64,linux/arm64' -t erunpaas/api:1.4.2-rc.") && strings.Contains(trace, "--push") {
+		if strings.Contains(trace, "docker buildx build --builder erun-multiarch --platform 'linux/amd64,linux/arm64' -t erunpaas/api:1.4.2-rc.") && strings.Contains(trace, "--push") {
 			foundBuildTrace = true
 		}
 		if strings.Contains(trace, "release version: 1.4.2-rc.") {


### PR DESCRIPTION
## Summary
- bootstrap a docker-container buildx builder for multi-platform release builds
- use that named builder for release-tagged linux/amd64 and linux/arm64 image publishes
- update dry-run and runtime tests for the new builder bootstrap trace

## Why
`erun build --release` was switching to `docker buildx build` but still failing on Docker setups using the default docker driver because no compatible buildx builder was prepared first.

## Validation
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-common && go test ./...
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-cli && go test ./...
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-mcp && go test ./...

Closes #71
