### PR TITLE
Fix multi-arch release image dependencies

### DIFF
--- a/erun-common/assets/default-devops-chart/templates/service.yaml
+++ b/erun-common/assets/default-devops-chart/templates/service.yaml
@@ -70,6 +70,15 @@ spec:
       serviceAccountName: __MODULE_NAME__
       securityContext:
         fsGroup: 1000
+      initContainers:
+        - image: tonistiigi/binfmt:qemu-v10.0.4-56
+          name: install-binfmt
+          imagePullPolicy: IfNotPresent
+          args:
+            - --install
+            - amd64,arm64
+          securityContext:
+            privileged: true
       containers:
         - image: erunpaas/erun-devops:{{ .Chart.AppVersion }}
           name: __MODULE_NAME__

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"slices"
 	"strings"
 	"time"
 )
@@ -205,7 +207,7 @@ func BuildExecutionUsesBuildScript(execution BuildExecutionSpec) bool {
 }
 
 func releaseDockerPushSpecs(builds []DockerBuildSpec, images []ReleaseDockerImageSpec) []DockerPushSpec {
-	if len(builds) == 0 || len(images) == 0 {
+	if len(builds) == 0 {
 		return nil
 	}
 
@@ -213,8 +215,9 @@ func releaseDockerPushSpecs(builds []DockerBuildSpec, images []ReleaseDockerImag
 	for _, image := range images {
 		releaseTags[strings.TrimSpace(image.Tag)] = struct{}{}
 	}
+	releaseTags = expandLocalReleaseImageDependencies(builds, releaseTags)
 
-	pushes := make([]DockerPushSpec, 0, len(builds))
+	pushes := make([]DockerPushSpec, 0, len(releaseTags))
 	for _, build := range builds {
 		if _, ok := releaseTags[strings.TrimSpace(build.Image.Tag)]; !ok {
 			continue
@@ -222,6 +225,50 @@ func releaseDockerPushSpecs(builds []DockerBuildSpec, images []ReleaseDockerImag
 		pushes = append(pushes, NewDockerPushSpec(build.ContextDir, build.Image))
 	}
 	return pushes
+}
+
+func expandLocalReleaseImageDependencies(builds []DockerBuildSpec, releaseTags map[string]struct{}) map[string]struct{} {
+	if len(builds) == 0 || len(releaseTags) == 0 {
+		return releaseTags
+	}
+
+	buildsByTag := make(map[string]DockerBuildSpec, len(builds))
+	for _, build := range builds {
+		buildsByTag[strings.TrimSpace(build.Image.Tag)] = build
+	}
+
+	expanded := make(map[string]struct{}, len(releaseTags))
+	queue := make([]string, 0, len(releaseTags))
+	for tag := range releaseTags {
+		expanded[tag] = struct{}{}
+		queue = append(queue, tag)
+	}
+
+	for len(queue) > 0 {
+		tag := queue[0]
+		queue = queue[1:]
+
+		build, ok := buildsByTag[tag]
+		if !ok {
+			continue
+		}
+		for _, dependencyTag := range dockerfileLocalBaseImageTags(build.DockerfilePath, buildsByTag) {
+			if _, exists := expanded[dependencyTag]; exists {
+				continue
+			}
+			expanded[dependencyTag] = struct{}{}
+			queue = append(queue, dependencyTag)
+		}
+	}
+
+	for _, build := range builds {
+		if !strings.Contains(strings.TrimSpace(build.Image.ImageName), "dind") {
+			continue
+		}
+		expanded[strings.TrimSpace(build.Image.Tag)] = struct{}{}
+	}
+
+	return expanded
 }
 
 func ResolveDockerBuildTarget(findProjectRoot ProjectFinderFunc, target DockerCommandTarget) (DockerCommandTarget, *ReleaseSpec, error) {
@@ -814,7 +861,7 @@ func RunDockerBuild(ctx Context, buildInput DockerBuildSpec, build DockerImageBu
 }
 
 func RunDockerBuilds(ctx Context, builds []DockerBuildSpec, build DockerImageBuilderFunc) error {
-	for _, buildInput := range builds {
+	for _, buildInput := range orderedDockerBuildSpecs(builds) {
 		if err := RunDockerBuild(ctx, buildInput, build); err != nil {
 			return err
 		}
@@ -1012,6 +1059,80 @@ func DockerBuildContextAtDir(dir string) (DockerBuildContext, error) {
 	return DockerBuildContext{Dir: dir, DockerfilePath: dockerfilePath}, nil
 }
 
+func orderedDockerBuildSpecs(builds []DockerBuildSpec) []DockerBuildSpec {
+	if len(builds) < 2 {
+		return builds
+	}
+
+	buildsByTag := make(map[string]DockerBuildSpec, len(builds))
+	orderIndex := make(map[string]int, len(builds))
+	for i, build := range builds {
+		tag := strings.TrimSpace(build.Image.Tag)
+		buildsByTag[tag] = build
+		orderIndex[tag] = i
+	}
+
+	tags := make([]string, 0, len(builds))
+	seen := make(map[string]bool, len(builds))
+	var visit func(string)
+	visit = func(tag string) {
+		if seen[tag] {
+			return
+		}
+		seen[tag] = true
+		build, ok := buildsByTag[tag]
+		if ok {
+			for _, dependencyTag := range dockerfileLocalBaseImageTags(build.DockerfilePath, buildsByTag) {
+				visit(dependencyTag)
+			}
+		}
+		tags = append(tags, tag)
+	}
+
+	inputTags := make([]string, 0, len(builds))
+	for _, build := range builds {
+		inputTags = append(inputTags, strings.TrimSpace(build.Image.Tag))
+	}
+	slices.SortStableFunc(inputTags, func(a, b string) int {
+		return orderIndex[a] - orderIndex[b]
+	})
+	for _, tag := range inputTags {
+		visit(tag)
+	}
+
+	ordered := make([]DockerBuildSpec, 0, len(builds))
+	for _, tag := range tags {
+		ordered = append(ordered, buildsByTag[tag])
+	}
+	return ordered
+}
+
+var dockerfileFromPattern = regexp.MustCompile(`(?im)^\s*FROM(?:\s+--platform=\S+)?\s+([^\s]+)`)
+
+func dockerfileLocalBaseImageTags(dockerfilePath string, buildsByTag map[string]DockerBuildSpec) []string {
+	data, err := os.ReadFile(dockerfilePath)
+	if err != nil {
+		return nil
+	}
+
+	matches := dockerfileFromPattern.FindAllStringSubmatch(string(data), -1)
+	dependencies := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		imageRef := strings.TrimSpace(match[1])
+		if imageRef == "" || strings.HasPrefix(imageRef, "${") {
+			continue
+		}
+		if _, ok := buildsByTag[imageRef]; !ok {
+			continue
+		}
+		dependencies = append(dependencies, imageRef)
+	}
+	return dependencies
+}
+
 func ResolveDockerBuildContextsAtDir(dir string) ([]DockerBuildContext, error) {
 	dir = filepath.Clean(strings.TrimSpace(dir))
 	if dir == "" || filepath.Base(dir) != "docker" {
@@ -1105,7 +1226,7 @@ func FindComponentDockerBuildContext(projectRoot, componentName string) (DockerB
 
 func DockerImageBuilder(buildInput DockerBuildSpec, stdout, stderr io.Writer) error {
 	if len(buildInput.Platforms) > 0 {
-		if err := ensureDockerBuildxBuilder(buildInput.ContextDir, stdout, stderr); err != nil {
+		if err := ensureDockerBuildxBuilder(buildInput.ContextDir, buildInput.Platforms, stdout, stderr); err != nil {
 			return err
 		}
 	}
@@ -1153,7 +1274,9 @@ func dockerBuildxSetupCommands(dir string) []commandSpec {
 	}
 }
 
-func ensureDockerBuildxBuilder(dir string, stdout, stderr io.Writer) error {
+var buildxPlatformsPattern = regexp.MustCompile(`(?m)^\s*Platforms:\s*(.+)$`)
+
+func ensureDockerBuildxBuilder(dir string, requiredPlatforms []string, stdout, stderr io.Writer) error {
 	inspect := exec.Command("docker", "buildx", "inspect", multiPlatformBuildxBuilderName)
 	inspect.Dir = dir
 	inspect.Stdout = io.Discard
@@ -1170,9 +1293,59 @@ func ensureDockerBuildxBuilder(dir string, stdout, stderr io.Writer) error {
 
 	bootstrap := exec.Command("docker", "buildx", "inspect", "--builder", multiPlatformBuildxBuilderName, "--bootstrap")
 	bootstrap.Dir = dir
-	bootstrap.Stdout = stdout
-	bootstrap.Stderr = stderr
-	return bootstrap.Run()
+	output := new(bytes.Buffer)
+	bootstrap.Stdout = io.MultiWriter(stdout, output)
+	bootstrap.Stderr = io.MultiWriter(stderr, output)
+	if err := bootstrap.Run(); err != nil {
+		return err
+	}
+	if missingPlatforms := missingBuildxPlatforms(output.String(), requiredPlatforms); len(missingPlatforms) > 0 {
+		availablePlatforms := buildxPlatforms(output.String())
+		if len(availablePlatforms) == 0 {
+			return fmt.Errorf("multi-platform release builder %q did not report supported platforms after bootstrap", multiPlatformBuildxBuilderName)
+		}
+		return fmt.Errorf("multi-platform release builder %q does not support required platforms: %s (available: %s)", multiPlatformBuildxBuilderName, strings.Join(missingPlatforms, ", "), strings.Join(availablePlatforms, ", "))
+	}
+	return nil
+}
+
+func buildxPlatforms(output string) []string {
+	match := buildxPlatformsPattern.FindStringSubmatch(output)
+	if len(match) < 2 {
+		return nil
+	}
+	rawPlatforms := strings.Split(match[1], ",")
+	platforms := make([]string, 0, len(rawPlatforms))
+	for _, platform := range rawPlatforms {
+		platform = strings.TrimSpace(platform)
+		if platform == "" {
+			continue
+		}
+		platforms = append(platforms, platform)
+	}
+	return platforms
+}
+
+func missingBuildxPlatforms(output string, requiredPlatforms []string) []string {
+	if len(requiredPlatforms) == 0 {
+		return nil
+	}
+	supported := make(map[string]struct{}, len(requiredPlatforms))
+	for _, platform := range buildxPlatforms(output) {
+		supported[platform] = struct{}{}
+	}
+	missing := make([]string, 0, len(requiredPlatforms))
+	for _, platform := range requiredPlatforms {
+		platform = strings.TrimSpace(platform)
+		if platform == "" {
+			continue
+		}
+		if _, ok := supported[platform]; ok {
+			continue
+		}
+		missing = append(missing, platform)
+	}
+	return missing
 }
 
 func dockerImageTagVersion(tag string) string {

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -146,6 +146,59 @@ func TestDockerBuildTraceCommandsIncludeBuildxBootstrapForMultiPlatformBuilds(t 
 	}
 }
 
+func TestMissingBuildxPlatformsReportsRequiredPlatformsNotPresent(t *testing.T) {
+	output := `Name: erun-multiarch
+Driver: docker-container
+Platforms: linux/arm64
+`
+
+	missing := missingBuildxPlatforms(output, []string{"linux/amd64", "linux/arm64"})
+	if !reflect.DeepEqual(missing, []string{"linux/amd64"}) {
+		t.Fatalf("unexpected missing platforms: %+v", missing)
+	}
+}
+
+func TestOrderedDockerBuildSpecsBuildsLocalBaseImagesBeforeDependents(t *testing.T) {
+	workdir := t.TempDir()
+	baseDir := filepath.Join(workdir, "base")
+	appDir := filepath.Join(workdir, "app")
+	for _, dir := range []string{baseDir, appDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %q: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "Dockerfile"), []byte("FROM alpine:3.22\n"), 0o644); err != nil {
+		t.Fatalf("write base Dockerfile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(appDir, "Dockerfile"), []byte("FROM erunpaas/base:1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write app Dockerfile: %v", err)
+	}
+
+	builds := []DockerBuildSpec{
+		{
+			ContextDir:     appDir,
+			DockerfilePath: filepath.Join(appDir, "Dockerfile"),
+			Image: DockerImageReference{
+				Tag: "erunpaas/app:1.0.0",
+			},
+		},
+		{
+			ContextDir:     baseDir,
+			DockerfilePath: filepath.Join(baseDir, "Dockerfile"),
+			Image: DockerImageReference{
+				Tag: "erunpaas/base:1.0.0",
+			},
+		},
+	}
+
+	ordered := orderedDockerBuildSpecs(builds)
+	got := []string{ordered[0].Image.Tag, ordered[1].Image.Tag}
+	want := []string{"erunpaas/base:1.0.0", "erunpaas/app:1.0.0"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected build order: got %+v want %+v", got, want)
+	}
+}
+
 func TestResolveDockerBuildContextIgnoresMissingDockerfile(t *testing.T) {
 	workdir := t.TempDir()
 
@@ -653,6 +706,69 @@ func TestResolveBuildExecutionReleaseOnlyPushesReleaseTaggedDockerBuilds(t *test
 	}
 	if got := execution.dockerPushes[0].Image.Tag; got != "erunpaas/api:1.4.2" {
 		t.Fatalf("unexpected docker push tag: %q", got)
+	}
+}
+
+func TestResolveBuildExecutionReleasePushesLocalDockerDependenciesAndDind(t *testing.T) {
+	projectRoot := setupReleaseProjectGitRepo(t, "main")
+	releaseRoot := filepath.Join(projectRoot, "erun-devops")
+
+	apiDockerfilePath := filepath.Join(releaseRoot, "docker", "api", "Dockerfile")
+	if err := os.WriteFile(apiDockerfilePath, []byte("FROM erunpaas/base:9.9.9\n"), 0o644); err != nil {
+		t.Fatalf("write api Dockerfile: %v", err)
+	}
+
+	dindDir := filepath.Join(releaseRoot, "docker", "erun-dind")
+	if err := os.MkdirAll(dindDir, 0o755); err != nil {
+		t.Fatalf("mkdir dind dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dindDir, "Dockerfile"), []byte("FROM docker:28.1.1-dind\n"), 0o644); err != nil {
+		t.Fatalf("write dind Dockerfile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dindDir, "VERSION"), []byte("28.1.1\n"), 0o644); err != nil {
+		t.Fatalf("write dind VERSION: %v", err)
+	}
+
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		func() (string, string, error) {
+			return "erun", projectRoot, nil
+		},
+		func() (DockerBuildContext, error) {
+			return DockerBuildContext{Dir: projectRoot}, nil
+		},
+		nil,
+		DockerCommandTarget{ProjectRoot: projectRoot, Environment: DefaultEnvironment, Release: true},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+
+	if len(execution.dockerPushes) != 3 {
+		t.Fatalf("unexpected docker pushes: %+v", execution.dockerPushes)
+	}
+	wantPushes := map[string]struct{}{
+		"erunpaas/api:1.4.2":        {},
+		"erunpaas/base:9.9.9":       {},
+		"erunpaas/erun-dind:28.1.1": {},
+	}
+	for _, pushInput := range execution.dockerPushes {
+		if _, ok := wantPushes[pushInput.Image.Tag]; !ok {
+			t.Fatalf("unexpected docker push tag: %q", pushInput.Image.Tag)
+		}
+		delete(wantPushes, pushInput.Image.Tag)
+	}
+	if len(wantPushes) != 0 {
+		t.Fatalf("missing docker pushes: %+v", wantPushes)
+	}
+
+	for _, build := range execution.dockerBuilds {
+		switch build.Image.Tag {
+		case "erunpaas/api:1.4.2", "erunpaas/base:9.9.9", "erunpaas/erun-dind:28.1.1":
+			if !build.Push || !reflect.DeepEqual(build.Platforms, []string{"linux/amd64", "linux/arm64"}) {
+				t.Fatalf("expected multi-platform release build for %q, got %+v", build.Image.Tag, build)
+			}
+		}
 	}
 }
 

--- a/erun-common/deploy_test.go
+++ b/erun-common/deploy_test.go
@@ -159,6 +159,30 @@ func TestPrepareHelmChartForDeployOverridesVersionAndAppVersion(t *testing.T) {
 	}
 }
 
+func TestRuntimeChartsInstallBinfmtForMultiArchBuilds(t *testing.T) {
+	paths := []string{
+		filepath.Join("..", "erun-devops", "k8s", "erun-devops", "templates", "service.yaml"),
+		filepath.Join("assets", "default-devops-chart", "templates", "service.yaml"),
+	}
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %q: %v", path, err)
+		}
+		content := string(data)
+		if !strings.Contains(content, "tonistiigi/binfmt:qemu-v10.0.4-56") {
+			t.Fatalf("expected %q to install binfmt, got:\n%s", path, content)
+		}
+		if !strings.Contains(content, "name: install-binfmt") {
+			t.Fatalf("expected %q to define install-binfmt init container, got:\n%s", path, content)
+		}
+		if !strings.Contains(content, "amd64,arm64") {
+			t.Fatalf("expected %q to install amd64 and arm64 binfmt support, got:\n%s", path, content)
+		}
+	}
+}
+
 func TestNewHelmDeploySpecCanonicalizesWorktreeHostPath(t *testing.T) {
 	projectRoot := t.TempDir()
 	repoRoot := filepath.Join(projectRoot, "repo")

--- a/erun-devops/k8s/erun-devops/templates/service.yaml
+++ b/erun-devops/k8s/erun-devops/templates/service.yaml
@@ -67,6 +67,15 @@ spec:
       serviceAccountName: erun-devops
       securityContext:
         fsGroup: 1000
+      initContainers:
+        - image: tonistiigi/binfmt:qemu-v10.0.4-56
+          name: install-binfmt
+          imagePullPolicy: IfNotPresent
+          args:
+            - --install
+            - amd64,arm64
+          securityContext:
+            privileged: true
       containers:
         - image: erunpaas/erun-devops:{{ .Chart.AppVersion }}
           name: erun-devops


### PR DESCRIPTION
## Summary
- build and push local Docker release dependencies before dependent images
- fail fast when the runtime buildx builder is missing required release platforms
- install binfmt in both runtime charts so the dind-backed builder exposes amd64 and arm64

## Root cause
Multi-platform release builds were only publishing the top-level release image and assumed the runtime buildx builder already supported both target platforms. In the dind-backed runtime, that left local base images unpublished for amd64 and left the builder arm64-only, so release builds failed during image resolution.

## Validation
- `cd /Users/rihardsfreimanis/git/sophium/erun/erun-common && go test ./...`
- `cd /Users/rihardsfreimanis/git/sophium/erun/erun-cli && go test ./...`
- `cd /Users/rihardsfreimanis/git/sophium/erun/erun-mcp && go test ./...`

Closes #73
