### PR TITLE
Add SSH-enabled remote runtime access

### DIFF
--- a/erun-cli/cmd/build_test.go
+++ b/erun-cli/cmd/build_test.go
@@ -2380,8 +2380,12 @@ func TestBuildCommandDryRunBuildsLinuxPackagesFromProjectRoot(t *testing.T) {
 	}
 
 	output := stderr.String()
-	if !strings.Contains(output, "./build.sh") {
-		t.Fatalf("expected linux build trace, got:\n%s", output)
+	if common.LinuxPackageBuildsSupported() {
+		if !strings.Contains(output, "./build.sh") {
+			t.Fatalf("expected linux build trace, got:\n%s", output)
+		}
+	} else if !strings.Contains(output, "skipping linux package scripts: host is not Linux or dpkg-deb is unavailable") {
+		t.Fatalf("expected linux build skip trace, got:\n%s", output)
 	}
 }
 
@@ -2432,8 +2436,12 @@ func TestBuildCommandDryRunReleasePublishesLinuxPackagesWithoutDockerBuilds(t *t
 	if !strings.Contains(output, "release: branch=develop mode=candidate version=1.4.2-rc.") {
 		t.Fatalf("expected release trace, got:\n%s", output)
 	}
-	if !strings.Contains(output, "ERUN_BUILD_VERSION=1.4.2-rc.") || !strings.Contains(output, "./release.sh") {
-		t.Fatalf("expected linux release trace, got:\n%s", output)
+	if common.LinuxPackageBuildsSupported() {
+		if !strings.Contains(output, "ERUN_BUILD_VERSION=1.4.2-rc.") || !strings.Contains(output, "./release.sh") {
+			t.Fatalf("expected linux release trace, got:\n%s", output)
+		}
+	} else if !strings.Contains(output, "skipping linux package scripts: host is not Linux or dpkg-deb is unavailable") {
+		t.Fatalf("expected linux release skip trace, got:\n%s", output)
 	}
 }
 

--- a/erun-cli/cmd/deploy.go
+++ b/erun-cli/cmd/deploy.go
@@ -66,10 +66,8 @@ func newK8sDeployCmd(store common.DeployStore, findProjectRoot common.ProjectFin
 func addDeployCommandTargetFlags(cmd *cobra.Command, target *common.DeployTarget, snapshot, noSnapshot *bool) {
 	cmd.Flags().StringVar(&target.VersionOverride, "version", "", "Override the deployed chart and image version")
 	addSnapshotFlags(cmd, snapshot, noSnapshot, "Build and deploy local snapshot images in the local environment")
-	cmd.Flags().StringVar(&target.Tenant, "tenant", "", "Tenant override for internal tooling")
-	cmd.Flags().StringVar(&target.Environment, "environment", "", "Environment override for internal tooling")
+	cmd.Flags().StringVar(&target.Tenant, "tenant", "", "Deploy for a specific tenant")
+	cmd.Flags().StringVar(&target.Environment, "environment", "", "Deploy for a specific environment; requires --tenant")
 	cmd.Flags().StringVar(&target.RepoPath, "repo-path", "", "Repo path override for internal tooling")
-	_ = cmd.Flags().MarkHidden("tenant")
-	_ = cmd.Flags().MarkHidden("environment")
 	_ = cmd.Flags().MarkHidden("repo-path")
 }

--- a/erun-cli/cmd/deploy_test.go
+++ b/erun-cli/cmd/deploy_test.go
@@ -70,6 +70,40 @@ func TestNewRootCmdRegistersDevopsK8sDeployCommand(t *testing.T) {
 	}
 }
 
+func TestDeployHelpShowsTenantAndEnvironmentFlags(t *testing.T) {
+	cmd := newTestRootCmd(testRootDeps{
+		ResolveKubernetesDeployContext: func() (common.KubernetesDeployContext, error) {
+			return common.KubernetesDeployContext{
+				ComponentName: "erun-devops",
+				ChartPath:     filepath.Join(t.TempDir(), "erun-devops", "k8s", "erun-devops"),
+			}, nil
+		},
+	})
+	stdout := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{"deploy", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"--tenant string",
+		"Deploy for a specific tenant",
+		"--environment string",
+		"Deploy for a specific environment; requires --tenant",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected deploy help to contain %q, got:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "--repo-path") {
+		t.Fatalf("expected repo-path to remain hidden, got:\n%s", output)
+	}
+}
+
 func TestNewRootCmdRegistersDeployShorthandWhenKubernetesDeployContextPresent(t *testing.T) {
 	cmd := newTestRootCmd(testRootDeps{
 		ResolveKubernetesDeployContext: func() (common.KubernetesDeployContext, error) {

--- a/erun-cli/cmd/list.go
+++ b/erun-cli/cmd/list.go
@@ -99,6 +99,20 @@ func writeEffectiveOpen(ctx common.Context, current common.ListCurrentDirectoryR
 	if err := writeLabeledValue(ctx, "snapshot", enabledDisabledLabel(current.Effective.Snapshot)); err != nil {
 		return err
 	}
+	if current.Effective.SSH.Enabled {
+		if err := writeLabeledValue(ctx, "sshd", "on"); err != nil {
+			return err
+		}
+		if err := writeLabeledValue(ctx, "ssh user", current.Effective.SSH.User); err != nil {
+			return err
+		}
+		if err := writeLabeledValue(ctx, "ssh local port", fmt.Sprintf("%d (after erun open)", current.Effective.SSH.LocalPort)); err != nil {
+			return err
+		}
+		if err := writeLabeledValue(ctx, "ssh workspace", current.Effective.SSH.WorkspacePath); err != nil {
+			return err
+		}
+	}
 	return writeLabeledValue(ctx, "repo path", current.Effective.RepoPath)
 }
 
@@ -115,9 +129,6 @@ func writeTenantEntry(ctx common.Context, tenant common.ListTenantResult) error 
 		header += " [" + strings.Join(tenantMarkers, ", ") + "]"
 	}
 	if _, err := fmt.Fprintln(ctx.Stdout, header); err != nil {
-		return err
-	}
-	if err := writeIndentedValue(ctx, 4, "project root", tenant.ProjectRoot); err != nil {
 		return err
 	}
 	if err := writeIndentedValue(ctx, 4, "default environment", tenant.DefaultEnvironment); err != nil {
@@ -148,6 +159,12 @@ func writeTenantEntry(ctx common.Context, tenant common.ListTenantResult) error 
 		}
 		envLine += " context=" + quotedValueOrNone(env.KubernetesContext)
 		envLine += " repo=" + quotedValueOrNone(env.RepoPath)
+		if env.SSH.Enabled {
+			envLine += " ssh=on"
+			envLine += " user=" + quotedValueOrNone(env.SSH.User)
+			envLine += " local-port=" + fmt.Sprintf("%d", env.SSH.LocalPort)
+			envLine += " workspace=" + quotedValueOrNone(env.SSH.WorkspacePath)
+		}
 		if _, err := fmt.Fprintln(ctx.Stdout, envLine); err != nil {
 			return err
 		}

--- a/erun-cli/cmd/list_test.go
+++ b/erun-cli/cmd/list_test.go
@@ -101,6 +101,9 @@ func TestListCommandPrintsDefaultsAndConfiguredTenants(t *testing.T) {
 			t.Fatalf("expected list output to contain %q, got:\n%s", want, output)
 		}
 	}
+	if strings.Contains(output, "project root:") {
+		t.Fatalf("expected list output to omit tenant-level project root, got:\n%s", output)
+	}
 }
 
 func TestListCommandUsesConfiguredCurrentDirectoryTenantBeforeDefault(t *testing.T) {
@@ -278,6 +281,57 @@ func TestListCommandPrintsSnapshotPreference(t *testing.T) {
 		"  snapshot: off",
 		"    snapshot: off",
 		"      - local [default, effective] context=cluster-local repo=" + repoRoot,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected list output to contain %q, got:\n%s", want, output)
+		}
+	}
+}
+
+func TestListCommandPrintsSSHDConfiguration(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+
+	repoRoot := filepath.Join(t.TempDir(), "tenant-a")
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatalf("mkdir repo root: %v", err)
+	}
+	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
+		t.Fatalf("save erun config: %v", err)
+	}
+	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: repoRoot, DefaultEnvironment: "dev", Remote: true}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{
+		Name:              "dev",
+		RepoPath:          repoRoot,
+		KubernetesContext: "cluster-dev",
+		Remote:            true,
+		SSHD: common.SSHDConfig{
+			Enabled:       true,
+			LocalPort:     common.DefaultSSHLocalPort,
+			PublicKeyPath: "/tmp/id_ed25519.pub",
+		},
+	}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+
+	stdout := new(bytes.Buffer)
+	cmd := newTestRootCmd(testRootDeps{})
+	cmd.SetOut(stdout)
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{"list"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"  sshd: on",
+		"  ssh user: erun",
+		"  ssh local port: 62222 (after erun open)",
+		"  ssh workspace: /home/erun/git/tenant-a",
+		"ssh=on user=erun local-port=62222 workspace=/home/erun/git/tenant-a",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected list output to contain %q, got:\n%s", want, output)

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -22,10 +22,11 @@ const (
 
 var currentHostOS = func() common.HostOS { return common.DetectHost().OS }
 
-func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), saveTenantConfig func(common.TenantConfig) error, runInitForArgs func(common.Context, []string) error, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
+func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), saveTenantConfig func(common.TenantConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateSSHD SSHDActivator) *cobra.Command {
 	var noShell bool
 	var snapshot bool
 	var noSnapshot bool
+	target := common.OpenParams{}
 
 	cmd := &cobra.Command{
 		Use:          "open [TENANT] [ENVIRONMENT]",
@@ -34,7 +35,11 @@ func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), 
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext(cmd)
-			result, initRan, err := resolveOpenWithInitStop(ctx, args, shouldRunInitForOpenCommand, resolveOpen, runInitForArgs)
+			params, err := resolveOpenParams(args, target)
+			if err != nil {
+				return err
+			}
+			result, initRan, err := resolveOpenWithInitStopForParams(ctx, params, shouldRunInitForOpenCommand, resolveOpen, runInitForOpen)
 			if err != nil {
 				return err
 			}
@@ -49,11 +54,13 @@ func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), 
 			if err != nil {
 				return err
 			}
-			return runResolvedOpenCommand(ctx, result, openOptions{NoShell: noShell}, promptRunner, openShell, runManagedDeploy, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart)
+			return runResolvedOpenCommand(ctx, result, openOptions{NoShell: noShell}, promptRunner, openShell, runManagedDeploy, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart, activateSSHD)
 		},
 	}
 
 	addDryRunFlag(cmd)
+	cmd.Flags().StringVar(&target.Tenant, "tenant", "", "Open a specific tenant")
+	cmd.Flags().StringVar(&target.Environment, "environment", "", "Open a specific environment")
 	cmd.Flags().BoolVar(&noShell, "no-shell", false, "Print shell commands to switch kubectl context, namespace, and worktree locally")
 	addSnapshotFlags(cmd, &snapshot, &noSnapshot, "Build and deploy a local snapshot when opening the local environment")
 	return cmd
@@ -88,9 +95,44 @@ func resolveOpenArgs(args []string, resolveOpen func(common.OpenParams) (common.
 	return params, result, err
 }
 
+func resolveOpenParams(args []string, overrides common.OpenParams) (common.OpenParams, error) {
+	params, err := common.OpenParamsForArgs(args)
+	if err != nil {
+		return common.OpenParams{}, err
+	}
+	if tenant := strings.TrimSpace(overrides.Tenant); tenant != "" {
+		params.Tenant = tenant
+	}
+	if environment := strings.TrimSpace(overrides.Environment); environment != "" {
+		params.Environment = environment
+	}
+
+	switch {
+	case strings.TrimSpace(params.Tenant) == "" && strings.TrimSpace(params.Environment) == "":
+		params.UseDefaultTenant = true
+		params.UseDefaultEnvironment = true
+	case strings.TrimSpace(params.Tenant) == "":
+		params.UseDefaultTenant = true
+		params.UseDefaultEnvironment = false
+	case strings.TrimSpace(params.Environment) == "":
+		params.UseDefaultTenant = false
+		params.UseDefaultEnvironment = true
+	default:
+		params.UseDefaultTenant = false
+		params.UseDefaultEnvironment = false
+	}
+
+	return params, nil
+}
+
 func runInitBeforeOpen(ctx common.Context, args []string, runInitForArgs func(common.Context, []string) error) error {
 	ctx.Logger.Debug("running init before resolving open target")
 	return runInitForArgs(ctx, args)
+}
+
+func runInitBeforeOpenForParams(ctx common.Context, params common.OpenParams, runInitForOpen func(common.Context, common.OpenParams) error) error {
+	ctx.Logger.Debug("running init before resolving open target")
+	return runInitForOpen(ctx, params)
 }
 
 func resolveOpenWithInitStop(ctx common.Context, args []string, shouldRunInit func(error) bool, resolveOpen func(common.OpenParams) (common.OpenResult, error), runInitForArgs func(common.Context, []string) error) (common.OpenResult, bool, error) {
@@ -120,9 +162,36 @@ func resolveOpenWithInitRetry(ctx common.Context, args []string, shouldRunInit f
 	return result, true, err
 }
 
-func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) error {
+func resolveOpenWithInitStopForParams(ctx common.Context, params common.OpenParams, shouldRunInit func(error) bool, resolveOpen func(common.OpenParams) (common.OpenResult, error), runInitForOpen func(common.Context, common.OpenParams) error) (common.OpenResult, bool, error) {
+	result, err := resolveOpen(params)
+	if !shouldRunInit(err) {
+		return result, false, err
+	}
+
+	if initErr := runInitBeforeOpenForParams(ctx, params, runInitForOpen); initErr != nil {
+		return common.OpenResult{}, true, initErr
+	}
+
+	return common.OpenResult{}, true, nil
+}
+
+func resolveOpenWithInitRetryForParams(ctx common.Context, params common.OpenParams, shouldRunInit func(error) bool, resolveOpen func(common.OpenParams) (common.OpenResult, error), runInitForOpen func(common.Context, common.OpenParams) error) (common.OpenResult, bool, error) {
+	result, err := resolveOpen(params)
+	if !shouldRunInit(err) {
+		return result, false, err
+	}
+
+	if initErr := runInitBeforeOpenForParams(ctx, params, runInitForOpen); initErr != nil {
+		return common.OpenResult{}, true, initErr
+	}
+
+	result, err = resolveOpen(params)
+	return result, true, err
+}
+
+func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateSSHD SSHDActivator) error {
 	namespace := common.KubernetesNamespaceName(result.Tenant, result.Environment)
-	if options.NoShell {
+	if options.NoShell && !result.EnvConfig.SSHD.Enabled {
 		ctx.TraceCommand("", "kubectl", "config", "use-context", strings.TrimSpace(result.EnvConfig.KubernetesContext))
 		ctx.TraceCommand("", "kubectl", "config", "set-context", "--current", "--namespace="+namespace)
 		ctx.TraceCommand("", "cd", result.RepoPath)
@@ -142,11 +211,13 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 
 		shouldDeploy := len(execution.Builds) > 0
 		if !shouldDeploy && checkKubernetesDeployment != nil {
+			expectedSSHD := sshdExpectationForDeployment(result)
 			deployed, err := checkKubernetesDeployment(common.KubernetesDeploymentCheckParams{
 				Name:              common.RuntimeReleaseName(result.Tenant),
 				Namespace:         namespace,
 				KubernetesContext: result.EnvConfig.KubernetesContext,
 				ExpectedRepoPath:  common.RemoteShellWorktreePath(shellReq),
+				ExpectedSSHD:      expectedSSHD,
 			})
 			if err != nil {
 				return err
@@ -168,6 +239,19 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 				return err
 			}
 		}
+	}
+
+	if activateSSHD != nil && result.EnvConfig.SSHD.Enabled {
+		if err := activateSSHD(ctx, result); err != nil {
+			return err
+		}
+	}
+
+	if options.NoShell {
+		ctx.TraceCommand("", "kubectl", "config", "use-context", strings.TrimSpace(result.EnvConfig.KubernetesContext))
+		ctx.TraceCommand("", "kubectl", "config", "set-context", "--current", "--namespace="+namespace)
+		ctx.TraceCommand("", "cd", result.RepoPath)
+		return emitLocalShellSetupForOpenResult(result, promptRunner, ctx.Stdout, ctx.Stderr)
 	}
 
 	if preview, err := common.PreviewShellLaunch(shellReq); err == nil {
@@ -198,6 +282,14 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 			return err
 		}
 	}
+}
+
+func sshdExpectationForDeployment(result common.OpenResult) *bool {
+	if !result.EnvConfig.SSHD.Enabled {
+		return nil
+	}
+	expected := true
+	return &expected
 }
 
 func wrapOpenHelmDeployWithSpinner(ctx common.Context, releaseName string, deployHelmChart common.HelmChartDeployerFunc) common.HelmChartDeployerFunc {

--- a/erun-cli/cmd/open_test.go
+++ b/erun-cli/cmd/open_test.go
@@ -35,6 +35,105 @@ func TestOpenCommandLaunchesShell(t *testing.T) {
 	}
 }
 
+func TestOpenHelpShowsTenantAndEnvironmentFlags(t *testing.T) {
+	cmd := newTestRootCmd(testRootDeps{})
+	stdout := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{"open", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"--tenant string",
+		"Open a specific tenant",
+		"--environment string",
+		"Open a specific environment",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected open help to contain %q, got:\n%s", want, output)
+		}
+	}
+}
+
+func TestOpenCommandAcceptsTenantAndEnvironmentFlags(t *testing.T) {
+	repoPath := t.TempDir()
+	launched := common.ShellLaunchParams{}
+	cmd := newTestRootCmd(testRootDeps{
+		Store: openCommandStore{repoPath: repoPath},
+		LaunchShell: func(req common.ShellLaunchParams) error {
+			launched = req
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"open", "--tenant", "tenant-a", "--environment", "dev"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if launched.Dir != repoPath || launched.Title != "tenant-a-dev" {
+		t.Fatalf("unexpected shell launch: %+v", launched)
+	}
+}
+
+func TestRunResolvedOpenCommandActivatesSSHDWhenEnabled(t *testing.T) {
+	activated := false
+	launched := false
+	err := runResolvedOpenCommand(
+		common.Context{
+			Logger: common.NewLoggerWithWriters(0, new(bytes.Buffer), new(bytes.Buffer)),
+			Stdout: new(bytes.Buffer),
+			Stderr: new(bytes.Buffer),
+		},
+		common.OpenResult{
+			Tenant:      "tenant-a",
+			Environment: "dev",
+			RepoPath:    "/home/erun/git/tenant-a",
+			TenantConfig: common.TenantConfig{
+				Name:     "tenant-a",
+				Remote:   true,
+				Snapshot: nil,
+			},
+			EnvConfig: common.EnvConfig{
+				Name:              "dev",
+				RepoPath:          "/home/erun/git/tenant-a",
+				KubernetesContext: "cluster-dev",
+				Remote:            true,
+				SSHD:              common.SSHDConfig{Enabled: true},
+			},
+		},
+		openOptions{},
+		nil,
+		func(_ common.Context, _ common.ShellLaunchParams) error {
+			launched = true
+			return nil
+		},
+		nil,
+		nil,
+		nil,
+		nil,
+		func(_ common.Context, result common.OpenResult) error {
+			activated = true
+			if !result.EnvConfig.SSHD.Enabled {
+				t.Fatalf("expected SSHD-enabled target, got %+v", result.EnvConfig.SSHD)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runResolvedOpenCommand failed: %v", err)
+	}
+	if !activated {
+		t.Fatal("expected SSHD activator to run")
+	}
+	if !launched {
+		t.Fatal("expected shell launch after SSHD activation")
+	}
+}
+
 func TestOpenCommandNoShellConfiguresLocalKubeconfig(t *testing.T) {
 	repoPath := t.TempDir()
 	stdout := new(bytes.Buffer)

--- a/erun-cli/cmd/release_test.go
+++ b/erun-cli/cmd/release_test.go
@@ -236,8 +236,12 @@ func TestReleaseCommandDryRunIncludesLinuxReleaseScripts(t *testing.T) {
 	}
 
 	output := stderr.String()
-	if !strings.Contains(output, "ERUN_BUILD_VERSION=1.4.2-rc.") || !strings.Contains(output, "./release.sh") {
-		t.Fatalf("expected linux release trace, got:\n%s", output)
+	if common.LinuxPackageBuildsSupported() {
+		if !strings.Contains(output, "ERUN_BUILD_VERSION=1.4.2-rc.") || !strings.Contains(output, "./release.sh") {
+			t.Fatalf("expected linux release trace, got:\n%s", output)
+		}
+	} else if !strings.Contains(output, "skipping linux package scripts: host is not Linux or dpkg-deb is unavailable") {
+		t.Fatalf("expected linux release skip trace, got:\n%s", output)
 	}
 }
 

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -29,13 +29,15 @@ func Execute() error {
 	store := rootStore(configStore)
 	runInit := newRunInit(store, common.FindProjectRoot, runPrompt, runSelect, listKubernetesContexts, ensureKubernetesNamespace, common.WaitForShellDeployment, common.RunRemoteCommand, common.DeployHelmChart)
 	runInitForArgs := newRunInitForArgs(store, runInit)
+	runInitForOpen := newRunInitForOpen(store, runInit)
 	push := newPushOperation(nil, common.DockerRegistryLogin, runSelect)
 	resolveOpen := func(params common.OpenParams) (common.OpenResult, error) {
 		return common.ResolveOpen(store, params)
 	}
 	resolveRuntimeDeploySpec := func(target common.OpenResult) (common.DeploySpec, error) {
-		return common.ResolveOpenRuntimeDeploySpec(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, target)
+		return resolveRuntimeDeploySpecForOpen(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, currentBuildInfo(), target)
 	}
+	activateSSHD := newSSHDActivator(common.RunRemoteCommand)
 	runManagedDeploy := func(ctx common.Context, target common.OpenResult) error {
 		specs, err := common.ResolveCurrentDeploySpecs(
 			store,
@@ -59,14 +61,16 @@ func Execute() error {
 	openCmd := newOpenCmd(
 		resolveOpen,
 		store.SaveTenantConfig,
-		runInitForArgs,
+		runInitForOpen,
 		runPrompt,
 		newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell),
 		runManagedDeploy,
 		common.CheckKubernetesDeployment,
 		resolveRuntimeDeploySpec,
 		common.DeployHelmChart,
+		activateSSHD,
 	)
+	sshdCmd := newSSHDCmd(resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, common.DeployHelmChart, common.RunRemoteCommand)
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
@@ -111,10 +115,10 @@ func Execute() error {
 		if initRan {
 			return nil
 		}
-		return runResolvedOpenCommand(ctx, result, openOptions{}, runPrompt, newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell), runManagedDeploy, common.CheckKubernetesDeployment, resolveRuntimeDeploySpec, common.DeployHelmChart)
+		return runResolvedOpenCommand(ctx, result, openOptions{}, runPrompt, newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell), runManagedDeploy, common.CheckKubernetesDeployment, resolveRuntimeDeploySpec, common.DeployHelmChart, activateSSHD)
 	}
 
 	cmd := newRootCommand(runRoot)
-	addCommands(cmd, initCmd, openCmd, devopsCmd, buildCmd, pushCmd, deployCmd, mcpCmd, listCmd, releaseCmd, versionCmd)
+	addCommands(cmd, initCmd, openCmd, sshdCmd, devopsCmd, buildCmd, pushCmd, deployCmd, mcpCmd, listCmd, releaseCmd, versionCmd)
 	return cmd.Execute()
 }

--- a/erun-cli/cmd/root_runtime.go
+++ b/erun-cli/cmd/root_runtime.go
@@ -98,6 +98,17 @@ func newRunInit(store common.BootstrapStore, findProjectRoot common.ProjectFinde
 	}
 }
 
+func resolveRuntimeDeploySpecForOpen(store common.DeployStore, findProjectRoot common.ProjectFinderFunc, resolveDockerBuildContext common.BuildContextResolverFunc, resolveKubernetesDeployContext common.DeployContextResolverFunc, now common.NowFunc, buildInfo common.BuildInfo, target common.OpenResult) (common.DeploySpec, error) {
+	spec, err := common.ResolveOpenRuntimeDeploySpec(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target)
+	if err != nil {
+		return common.DeploySpec{}, err
+	}
+	if target.RemoteRepo() && strings.TrimSpace(spec.Deploy.Version) == "" {
+		spec.Deploy.Version = common.NormalizeBuildInfo(buildInfo).Version
+	}
+	return spec, nil
+}
+
 func newRunInitForArgs(store common.OpenStore, runInit func(common.Context, common.BootstrapInitParams) error) func(common.Context, []string) error {
 	return func(ctx common.Context, args []string) error {
 		params, err := common.InitParamsForOpenArgs(store, args)
@@ -105,6 +116,16 @@ func newRunInitForArgs(store common.OpenStore, runInit func(common.Context, comm
 			return err
 		}
 		return runInit(ctx, params)
+	}
+}
+
+func newRunInitForOpen(store common.OpenStore, runInit func(common.Context, common.BootstrapInitParams) error) func(common.Context, common.OpenParams) error {
+	return func(ctx common.Context, params common.OpenParams) error {
+		initParams, err := common.InitParamsForOpenTarget(store, params)
+		if err != nil {
+			return err
+		}
+		return runInit(ctx, initParams)
 	}
 }
 

--- a/erun-cli/cmd/root_test.go
+++ b/erun-cli/cmd/root_test.go
@@ -27,6 +27,38 @@ func TestNewRootCmdRegistersCommands(t *testing.T) {
 	}
 }
 
+func TestResolveRuntimeDeploySpecForOpenFallsBackToCurrentBuildVersionForRemoteRepo(t *testing.T) {
+	spec, err := resolveRuntimeDeploySpecForOpen(
+		common.ConfigStore{},
+		common.FindProjectRoot,
+		common.ResolveDockerBuildContext,
+		common.ResolveKubernetesDeployContext,
+		nil,
+		common.BuildInfo{Version: "1.0.31"},
+		common.OpenResult{
+			Tenant:      "erun",
+			Environment: "remote",
+			RepoPath:    "/home/erun/git/erun",
+			TenantConfig: common.TenantConfig{
+				Name:   "erun",
+				Remote: true,
+			},
+			EnvConfig: common.EnvConfig{
+				Name:              "remote",
+				RepoPath:          "/home/erun/git/erun",
+				KubernetesContext: "rancher-desktop",
+				Remote:            true,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolveRuntimeDeploySpecForOpen failed: %v", err)
+	}
+	if spec.Deploy.Version != "1.0.31" {
+		t.Fatalf("expected remote default runtime deploy version fallback, got %+v", spec.Deploy)
+	}
+}
+
 func TestRootCommandRunsInitWhenNoSubcommand(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -119,8 +119,9 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 		return common.ResolveOpen(store, params)
 	}
 	resolveRuntimeDeploySpec := func(target common.OpenResult) (common.DeploySpec, error) {
-		return common.ResolveOpenRuntimeDeploySpec(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target)
+		return resolveRuntimeDeploySpecForOpen(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, currentBuildInfo(), target)
 	}
+	activateSSHD := newSSHDActivator(deps.RunRemoteCommand)
 	push := newPushOperation(pushDockerImage, loginToDockerRegistry, selectRunner)
 	runManagedDeploy := func(ctx common.Context, target common.OpenResult) error {
 		specs, err := common.ResolveCurrentDeploySpecs(
@@ -148,9 +149,11 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	}
 	runInit := newRunInit(store, findProjectRoot, promptRunner, selectRunner, listKubernetesContexts, ensureKubernetesNamespace, deps.WaitForRemoteRuntime, deps.RunRemoteCommand, deployHelmChart)
 	runInitForArgs := newRunInitForArgs(store, runInit)
+	runInitForOpen := newRunInitForOpen(store, runInit)
 
 	initCmd := newInitCmd(runInit)
-	openCmd := newOpenCmd(resolveOpen, store.SaveTenantConfig, runInitForArgs, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
+	openCmd := newOpenCmd(resolveOpen, store.SaveTenantConfig, runInitForOpen, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart, activateSSHD)
+	sshdCmd := newSSHDCmd(resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, openDeployHelmChart, deps.RunRemoteCommand)
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
@@ -195,11 +198,11 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 		if initRan {
 			return nil
 		}
-		return runResolvedOpenCommand(ctx, result, openOptions{}, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart)
+		return runResolvedOpenCommand(ctx, result, openOptions{}, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart, activateSSHD)
 	}
 
 	cmd := newRootCommand(runRoot)
-	addCommands(cmd, initCmd, openCmd, devopsCmd, buildCmd, pushCmd, deployCmd, mcpCmd, listCmd, releaseCmd, versionCmd)
+	addCommands(cmd, initCmd, openCmd, sshdCmd, devopsCmd, buildCmd, pushCmd, deployCmd, mcpCmd, listCmd, releaseCmd, versionCmd)
 	return cmd
 }
 

--- a/erun-cli/cmd/sshd.go
+++ b/erun-cli/cmd/sshd.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"fmt"
+
+	common "github.com/sophium/erun/erun-common"
+	"github.com/spf13/cobra"
+)
+
+func newSSHDCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), saveEnvConfig func(string, common.EnvConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, runRemoteCommand common.RemoteCommandRunnerFunc) *cobra.Command {
+	var publicKeyPath string
+	var localPort int
+	target := common.OpenParams{}
+
+	initCmd := &cobra.Command{
+		Use:          "init [TENANT] [ENVIRONMENT]",
+		Short:        "Enable SSH access for a remote environment",
+		Args:         cobra.MaximumNArgs(2),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := commandContext(cmd)
+			params, err := resolveOpenParams(args, target)
+			if err != nil {
+				return err
+			}
+			result, _, err := resolveOpenWithInitRetryForParams(ctx, params, shouldRunInitForOpenCommand, resolveOpen, runInitForOpen)
+			if err != nil {
+				return err
+			}
+			return runSSHDInitCommand(ctx, result, publicKeyPath, localPort, saveEnvConfig, resolveRuntimeDeploySpec, deployHelmChart, runRemoteCommand)
+		},
+	}
+	addDryRunFlag(initCmd)
+	initCmd.Flags().StringVar(&target.Tenant, "tenant", "", "Enable SSH for a specific tenant")
+	initCmd.Flags().StringVar(&target.Environment, "environment", "", "Enable SSH for a specific environment")
+	initCmd.Flags().StringVar(&publicKeyPath, "public-key", "", "Public key to authorize for remote SSH access")
+	initCmd.Flags().IntVar(&localPort, "local-port", 0, "Fixed local port to use for kubectl port-forward")
+
+	return newCommandGroup("sshd", "Remote SSH utilities", initCmd)
+}
+
+func runSSHDInitCommand(ctx common.Context, result common.OpenResult, publicKeyPath string, localPort int, saveEnvConfig func(string, common.EnvConfig) error, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, runRemoteCommand common.RemoteCommandRunnerFunc) error {
+	if err := common.ValidateSSHDTarget(result); err != nil {
+		return err
+	}
+	if saveEnvConfig == nil {
+		return fmt.Errorf("environment config saver is required")
+	}
+	if resolveRuntimeDeploySpec == nil {
+		return fmt.Errorf("runtime deploy spec resolver is required")
+	}
+	if deployHelmChart == nil {
+		return fmt.Errorf("helm deployer is required")
+	}
+
+	if publicKeyPath == "" {
+		publicKeyPath = result.EnvConfig.SSHD.PublicKeyPath
+	}
+	resolvedPublicKeyPath, _, err := resolveSSHDPublicKey(publicKeyPath)
+	if err != nil {
+		return err
+	}
+
+	updatedEnv := result.EnvConfig
+	updatedEnv.SSHD.Enabled = true
+	updatedEnv.SSHD.PublicKeyPath = resolvedPublicKeyPath
+	if localPort > 0 {
+		updatedEnv.SSHD.LocalPort = localPort
+	}
+	if updatedEnv.SSHD.LocalPort == 0 {
+		updatedEnv.SSHD.LocalPort = common.DefaultSSHLocalPort
+	}
+	if ctx.DryRun {
+		ctx.Trace(fmt.Sprintf("save SSHD config for %s/%s", result.Tenant, result.Environment))
+	} else if err := saveEnvConfig(result.Tenant, updatedEnv); err != nil {
+		return err
+	}
+
+	result.EnvConfig = updatedEnv
+	spec, err := resolveRuntimeDeploySpec(result)
+	if err != nil {
+		return err
+	}
+	if err := common.RunDeploySpec(ctx, spec, nil, nil, deployHelmChart); err != nil {
+		return err
+	}
+	if _, err := syncRemoteSSHDKey(ctx, result, runRemoteCommand); err != nil {
+		return err
+	}
+
+	if ctx.Stdout != nil {
+		info := common.SSHConnectionInfoForResult(result)
+		if _, err := fmt.Fprintf(
+			ctx.Stdout,
+			"SSHD enabled for %s/%s\n  user: %s\n  local port: %d\n  workspace: %s\n",
+			result.Tenant,
+			result.Environment,
+			info.User,
+			info.Port,
+			info.WorkspacePath,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/erun-cli/cmd/sshd_activation.go
+++ b/erun-cli/cmd/sshd_activation.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	common "github.com/sophium/erun/erun-common"
+)
+
+type SSHDActivator func(common.Context, common.OpenResult) error
+
+func newSSHDActivator(runRemoteCommand common.RemoteCommandRunnerFunc) SSHDActivator {
+	return func(ctx common.Context, result common.OpenResult) error {
+		if !result.EnvConfig.SSHD.Enabled {
+			return nil
+		}
+		if err := common.ValidateSSHDTarget(result); err != nil {
+			return err
+		}
+
+		if _, err := syncRemoteSSHDKey(ctx, result, runRemoteCommand); err != nil {
+			return err
+		}
+
+		info, err := ensureSSHDPortForward(ctx, result)
+		if err != nil {
+			return err
+		}
+		return emitSSHDConnectionInfo(ctx, info)
+	}
+}
+
+func syncRemoteSSHDKey(ctx common.Context, result common.OpenResult, runRemoteCommand common.RemoteCommandRunnerFunc) (string, error) {
+	publicKeyPath, publicKey, err := resolveSSHDPublicKey(result.EnvConfig.SSHD.PublicKeyPath)
+	if err != nil {
+		return "", err
+	}
+	req := common.ShellLaunchParamsFromResult(result)
+	script := common.BuildRemoteAuthorizedKeysSyncScript(publicKey)
+	output, err := common.RunTracedRemoteCommand(ctx, runRemoteCommand, req, "remote-ssh-authorized-keys", script)
+	if err != nil {
+		return "", fmt.Errorf("sync remote authorized_keys from %s: %w%s", publicKeyPath, err, formatRemoteCommandStderr(output.Stderr))
+	}
+	return publicKeyPath, nil
+}
+
+func resolveSSHDPublicKey(path string) (string, string, error) {
+	if strings.TrimSpace(path) != "" {
+		publicKey, err := readSSHDPublicKey(path)
+		if err != nil {
+			return "", "", err
+		}
+		return filepath.Clean(path), publicKey, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", "", err
+	}
+	candidates := []string{
+		filepath.Join(homeDir, ".ssh", "id_ed25519.pub"),
+		filepath.Join(homeDir, ".ssh", "id_ecdsa.pub"),
+		filepath.Join(homeDir, ".ssh", "id_rsa.pub"),
+	}
+	for _, candidate := range candidates {
+		publicKey, err := readSSHDPublicKey(candidate)
+		if err == nil {
+			return candidate, publicKey, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", "", err
+		}
+	}
+
+	return "", "", fmt.Errorf("no SSH public key found; use --public-key to choose one")
+}
+
+func readSSHDPublicKey(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	publicKey := strings.TrimSpace(string(data))
+	if publicKey == "" {
+		return "", fmt.Errorf("SSH public key is empty: %s", path)
+	}
+	return publicKey, nil
+}
+
+func emitSSHDConnectionInfo(ctx common.Context, info common.SSHConnectionInfo) error {
+	if ctx.Stdout == nil {
+		return nil
+	}
+	_, err := fmt.Fprintf(
+		ctx.Stdout,
+		"SSH:\n  host: %s\n  port: %d\n  user: %s\n  workspace: %s\n",
+		info.Host,
+		info.Port,
+		info.User,
+		info.WorkspacePath,
+	)
+	return err
+}
+
+func formatRemoteCommandStderr(stderr string) string {
+	stderr = strings.TrimSpace(stderr)
+	if stderr == "" {
+		return ""
+	}
+	return ": " + stderr
+}

--- a/erun-cli/cmd/sshd_port_forward.go
+++ b/erun-cli/cmd/sshd_port_forward.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	common "github.com/sophium/erun/erun-common"
+)
+
+const sshdPortForwardStartupTimeout = 5 * time.Second
+
+type sshdPortForwardState struct {
+	Tenant            string `json:"tenant"`
+	Environment       string `json:"environment"`
+	KubernetesContext string `json:"kubernetesContext"`
+	Namespace         string `json:"namespace"`
+	LocalPort         int    `json:"localPort"`
+	LogPath           string `json:"logPath,omitempty"`
+}
+
+func ensureSSHDPortForward(ctx common.Context, result common.OpenResult) (common.SSHConnectionInfo, error) {
+	info := common.SSHConnectionInfoForResult(result)
+	statePath, err := sshdPortForwardStatePath(result.Tenant, result.Environment)
+	if err != nil {
+		return common.SSHConnectionInfo{}, err
+	}
+	state, _ := loadSSHDPortForwardState(statePath)
+	expectedState := sshdPortForwardState{
+		Tenant:            result.Tenant,
+		Environment:       result.Environment,
+		KubernetesContext: strings.TrimSpace(result.EnvConfig.KubernetesContext),
+		Namespace:         common.KubernetesNamespaceName(result.Tenant, result.Environment),
+		LocalPort:         info.Port,
+	}
+
+	if stateMatchesSSHDTarget(state, expectedState) && canConnectLocalPort(info.Port) {
+		return info, nil
+	}
+	if canConnectLocalPort(info.Port) {
+		return common.SSHConnectionInfo{}, fmt.Errorf("local SSH port %d is already in use", info.Port)
+	}
+
+	args := kubectlPortForwardArgs(result, info.Port)
+	ctx.TraceCommand("", "kubectl", args...)
+	if ctx.DryRun {
+		return info, nil
+	}
+
+	logPath := sshdPortForwardLogPath(statePath)
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return common.SSHConnectionInfo{}, err
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return common.SSHConnectionInfo{}, err
+	}
+	defer func() {
+		_ = logFile.Close()
+	}()
+
+	cmd := exec.Command("kubectl", args...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		return common.SSHConnectionInfo{}, err
+	}
+
+	expectedState.LogPath = logPath
+	if err := saveSSHDPortForwardState(statePath, expectedState); err != nil {
+		return common.SSHConnectionInfo{}, err
+	}
+
+	deadline := time.Now().Add(sshdPortForwardStartupTimeout)
+	for time.Now().Before(deadline) {
+		if canConnectLocalPort(info.Port) {
+			return info, nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return common.SSHConnectionInfo{}, fmt.Errorf("timed out waiting for SSH port-forward on 127.0.0.1:%d; see %s", info.Port, logPath)
+}
+
+func kubectlPortForwardArgs(result common.OpenResult, localPort int) []string {
+	args := make([]string, 0, 8)
+	if strings.TrimSpace(result.EnvConfig.KubernetesContext) != "" {
+		args = append(args, "--context", result.EnvConfig.KubernetesContext)
+	}
+	namespace := common.KubernetesNamespaceName(result.Tenant, result.Environment)
+	if namespace != "" {
+		args = append(args, "--namespace", namespace)
+	}
+	args = append(args,
+		"port-forward",
+		"deployment/"+common.RuntimeReleaseName(result.Tenant),
+		fmt.Sprintf("%d:%d", localPort, common.RemoteSSHDPort),
+		"--address", "127.0.0.1",
+	)
+	return args
+}
+
+func sshdPortForwardStatePath(tenant, environment string) (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cacheDir, "erun", "sshd", tenant, environment+".json"), nil
+}
+
+func sshdPortForwardLogPath(statePath string) string {
+	return strings.TrimSuffix(statePath, filepath.Ext(statePath)) + ".log"
+}
+
+func loadSSHDPortForwardState(path string) (sshdPortForwardState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return sshdPortForwardState{}, err
+	}
+	var state sshdPortForwardState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return sshdPortForwardState{}, err
+	}
+	return state, nil
+}
+
+func saveSSHDPortForwardState(path string, state sshdPortForwardState) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func stateMatchesSSHDTarget(state, expected sshdPortForwardState) bool {
+	return state.Tenant == expected.Tenant &&
+		state.Environment == expected.Environment &&
+		state.KubernetesContext == expected.KubernetesContext &&
+		state.Namespace == expected.Namespace &&
+		state.LocalPort == expected.LocalPort
+}
+
+func canConnectLocalPort(port int) bool {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/erun-cli/cmd/sshd_test.go
+++ b/erun-cli/cmd/sshd_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	common "github.com/sophium/erun/erun-common"
+)
+
+func TestRunSSHDInitCommandPersistsConfigAndDeploysRuntime(t *testing.T) {
+	publicKeyPath := filepath.Join(t.TempDir(), "id_ed25519.pub")
+	if err := os.WriteFile(publicKeyPath, []byte("ssh-ed25519 AAAATEST user@example\n"), 0o644); err != nil {
+		t.Fatalf("write public key: %v", err)
+	}
+
+	var savedTenant string
+	var savedEnv common.EnvConfig
+	var deployed common.HelmDeployParams
+	var remoteScript string
+	ctx := common.Context{
+		Logger: common.NewLoggerWithWriters(1, new(bytes.Buffer), new(bytes.Buffer)),
+		Stdout: new(bytes.Buffer),
+		Stderr: new(bytes.Buffer),
+	}
+	err := runSSHDInitCommand(
+		ctx,
+		common.OpenResult{
+			Tenant:      "tenant-a",
+			Environment: "dev",
+			RepoPath:    "/home/erun/git/tenant-a",
+			TenantConfig: common.TenantConfig{
+				Name:   "tenant-a",
+				Remote: true,
+			},
+			EnvConfig: common.EnvConfig{
+				Name:              "dev",
+				RepoPath:          "/home/erun/git/tenant-a",
+				KubernetesContext: "cluster-dev",
+				Remote:            true,
+			},
+		},
+		publicKeyPath,
+		64022,
+		func(tenant string, config common.EnvConfig) error {
+			savedTenant = tenant
+			savedEnv = config
+			return nil
+		},
+		func(target common.OpenResult) (common.DeploySpec, error) {
+			return common.DeploySpec{
+				Target: target,
+				Deploy: common.HelmDeploySpec{
+					ReleaseName:       common.RuntimeReleaseName(target.Tenant),
+					ChartPath:         "/tmp/chart",
+					ValuesFilePath:    "/tmp/chart/values.dev.yaml",
+					Tenant:            target.Tenant,
+					Environment:       target.Environment,
+					Namespace:         common.KubernetesNamespaceName(target.Tenant, target.Environment),
+					KubernetesContext: target.EnvConfig.KubernetesContext,
+					WorktreeStorage:   common.WorktreeStoragePVC,
+					WorktreeRepoName:  "tenant-a",
+					WorktreeHostPath:  "/tmp/ignored",
+					SSHDEnabled:       target.EnvConfig.SSHD.Enabled,
+					Timeout:           common.DefaultHelmDeploymentTimeout,
+				},
+			}, nil
+		},
+		func(params common.HelmDeployParams) error {
+			deployed = params
+			return nil
+		},
+		func(_ common.ShellLaunchParams, script string) (common.RemoteCommandResult, error) {
+			remoteScript = script
+			return common.RemoteCommandResult{}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runSSHDInitCommand failed: %v", err)
+	}
+
+	if savedTenant != "tenant-a" {
+		t.Fatalf("unexpected saved tenant: %q", savedTenant)
+	}
+	if !savedEnv.SSHD.Enabled || savedEnv.SSHD.LocalPort != 64022 || savedEnv.SSHD.PublicKeyPath != publicKeyPath {
+		t.Fatalf("unexpected saved env config: %+v", savedEnv)
+	}
+	if !deployed.SSHDEnabled {
+		t.Fatalf("expected deployment params to enable SSHD, got %+v", deployed)
+	}
+	if !strings.Contains(remoteScript, "authorized_keys") || !strings.Contains(remoteScript, "ssh-ed25519 AAAATEST user@example") {
+		t.Fatalf("unexpected remote authorized_keys script:\n%s", remoteScript)
+	}
+}

--- a/erun-common/assets/default-devops-chart/templates/service.yaml
+++ b/erun-common/assets/default-devops-chart/templates/service.yaml
@@ -102,6 +102,8 @@ spec:
               value: {{ required "tenant is required" .Values.tenant | quote }}
             - name: ERUN_ENVIRONMENT
               value: {{ required "environment is required" .Values.environment | quote }}
+            - name: ERUN_SSHD_ENABLED
+              value: {{ if .Values.sshdEnabled }}"true"{{ else }}"false"{{ end }}
             - name: ERUN_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -109,6 +111,9 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
+          ports:
+            - containerPort: 2222
+              name: ssh
           resources:
             limits:
               cpu: "4"

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -88,6 +88,7 @@ type BuildExecutionSpec struct {
 	linuxBuilds  []scriptSpec
 	dockerBuilds []DockerBuildSpec
 	dockerPushes []DockerPushSpec
+	skippedLinux bool
 }
 
 type DockerPushExecutionSpec struct {
@@ -154,10 +155,15 @@ func ResolveBuildExecution(store DockerStore, findProjectRoot ProjectFinderFunc,
 	}
 
 	linuxBuilds := make([]scriptSpec, 0)
+	hadLinuxBuilds := false
 	if releaseSpec == nil {
 		linuxBuilds, err = ResolveCurrentLinuxBuildScripts(findProjectRoot, resolveBuildContext, target, target.VersionOverride)
 		if err != nil && !errors.Is(err, ErrLinuxPackageBuildNotFound) {
 			return BuildExecutionSpec{}, err
+		}
+		hadLinuxBuilds = len(linuxBuilds) > 0
+		if hadLinuxBuilds && !LinuxPackageBuildsSupported() {
+			linuxBuilds = nil
 		}
 	}
 
@@ -167,10 +173,13 @@ func ResolveBuildExecution(store DockerStore, findProjectRoot ProjectFinderFunc,
 	}
 
 	if len(linuxBuilds) == 0 && len(builds) == 0 && releaseSpec == nil {
+		if hadLinuxBuilds {
+			return BuildExecutionSpec{skippedLinux: true}, nil
+		}
 		return BuildExecutionSpec{}, ErrDockerBuildContextNotFound
 	}
 
-	execution := BuildExecutionSpec{linuxBuilds: linuxBuilds, dockerBuilds: builds}
+	execution := BuildExecutionSpec{linuxBuilds: linuxBuilds, dockerBuilds: builds, skippedLinux: hadLinuxBuilds && len(linuxBuilds) == 0}
 	if releaseSpec != nil {
 		return BuildExecutionSpecWithRelease(execution, *releaseSpec), nil
 	}
@@ -882,6 +891,9 @@ func runBuildExecution(ctx Context, execution BuildExecutionSpec, deploySpecs []
 		if err := RunReleaseSpec(ctx, *execution.release, nil, runScript); err != nil {
 			return err
 		}
+	}
+	if execution.skippedLinux {
+		ctx.Trace("skipping linux package scripts: host is not Linux or dpkg-deb is unavailable")
 	}
 
 	pushedTags := make(map[string]struct{}, len(execution.dockerBuilds)+len(execution.dockerPushes))

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -411,6 +411,15 @@ func TestHasProjectBuildScriptIgnoresDockerArtifactBuildScripts(t *testing.T) {
 }
 
 func TestResolveBuildExecutionIncludesLinuxBuildScriptsAtProjectRoot(t *testing.T) {
+	prevGOOS := currentGOOS
+	prevLookPath := hostLookPath
+	currentGOOS = func() string { return "linux" }
+	hostLookPath = func(file string) (string, error) { return "/usr/bin/" + file, nil }
+	t.Cleanup(func() {
+		currentGOOS = prevGOOS
+		hostLookPath = prevLookPath
+	})
+
 	projectRoot := t.TempDir()
 	linuxComponentDir := filepath.Join(projectRoot, "erun-devops", "linux", "erun-cli")
 	if err := os.MkdirAll(linuxComponentDir, 0o755); err != nil {
@@ -443,6 +452,90 @@ func TestResolveBuildExecutionIncludesLinuxBuildScriptsAtProjectRoot(t *testing.
 	}
 	if execution.linuxBuilds[0].Dir != linuxComponentDir || execution.linuxBuilds[0].Path != "./build.sh" {
 		t.Fatalf("unexpected linux build script: %+v", execution.linuxBuilds[0])
+	}
+}
+
+func TestResolveBuildExecutionSkipsLinuxBuildScriptsWhenHostIsNotLinux(t *testing.T) {
+	prevGOOS := currentGOOS
+	prevLookPath := hostLookPath
+	currentGOOS = func() string { return "darwin" }
+	hostLookPath = func(file string) (string, error) { return "/usr/bin/" + file, nil }
+	t.Cleanup(func() {
+		currentGOOS = prevGOOS
+		hostLookPath = prevLookPath
+	})
+
+	projectRoot := t.TempDir()
+	linuxComponentDir := filepath.Join(projectRoot, "erun-devops", "linux", "erun-cli")
+	if err := os.MkdirAll(linuxComponentDir, 0o755); err != nil {
+		t.Fatalf("mkdir linux component dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.2.3\n"), 0o644); err != nil {
+		t.Fatalf("write VERSION: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(linuxComponentDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write build.sh: %v", err)
+	}
+
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		func() (DockerBuildContext, error) {
+			return DockerBuildContext{Dir: projectRoot}, nil
+		},
+		nil,
+		DockerCommandTarget{},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+	if len(execution.linuxBuilds) != 0 || !execution.skippedLinux {
+		t.Fatalf("expected linux build scripts to be skipped, got %+v", execution)
+	}
+}
+
+func TestResolveBuildExecutionSkipsLinuxBuildScriptsWhenDpkgDebUnavailable(t *testing.T) {
+	prevGOOS := currentGOOS
+	prevLookPath := hostLookPath
+	currentGOOS = func() string { return "linux" }
+	hostLookPath = func(file string) (string, error) {
+		return "", errors.New("not found")
+	}
+	t.Cleanup(func() {
+		currentGOOS = prevGOOS
+		hostLookPath = prevLookPath
+	})
+
+	projectRoot := t.TempDir()
+	linuxComponentDir := filepath.Join(projectRoot, "erun-devops", "linux", "erun-cli")
+	if err := os.MkdirAll(linuxComponentDir, 0o755); err != nil {
+		t.Fatalf("mkdir linux component dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.2.3\n"), 0o644); err != nil {
+		t.Fatalf("write VERSION: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(linuxComponentDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write build.sh: %v", err)
+	}
+
+	execution, err := ResolveBuildExecution(
+		ConfigStore{},
+		func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		func() (DockerBuildContext, error) {
+			return DockerBuildContext{Dir: projectRoot}, nil
+		},
+		nil,
+		DockerCommandTarget{},
+	)
+	if err != nil {
+		t.Fatalf("ResolveBuildExecution failed: %v", err)
+	}
+	if len(execution.linuxBuilds) != 0 || !execution.skippedLinux {
+		t.Fatalf("expected linux build scripts to be skipped, got %+v", execution)
 	}
 }
 

--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -21,6 +21,19 @@ type ERunConfig struct {
 	DefaultTenant string
 }
 
+type SSHDConfig struct {
+	Enabled       bool   `yaml:"enabled,omitempty"`
+	LocalPort     int    `yaml:"localport,omitempty"`
+	PublicKeyPath string `yaml:"publickeypath,omitempty"`
+}
+
+func (c SSHDConfig) ResolvedLocalPort() int {
+	if c.LocalPort > 0 {
+		return c.LocalPort
+	}
+	return DefaultSSHLocalPort
+}
+
 type TenantConfig struct {
 	ProjectRoot        string
 	Name               string
@@ -34,8 +47,10 @@ type EnvConfig struct {
 	RepoPath          string
 	KubernetesContext string
 	ContainerRegistry string
-	Remote            bool  `yaml:"remote,omitempty"`
-	Snapshot          *bool `yaml:"snapshot,omitempty"`
+	RuntimeVersion    string     `yaml:"runtimeversion,omitempty"`
+	SSHD              SSHDConfig `yaml:"sshd,omitempty"`
+	Remote            bool       `yaml:"remote,omitempty"`
+	Snapshot          *bool      `yaml:"snapshot,omitempty"`
 }
 
 func (c TenantConfig) SnapshotEnabled() bool {

--- a/erun-common/config_test.go
+++ b/erun-common/config_test.go
@@ -294,6 +294,12 @@ func TestEnvConfigRoundTrip(t *testing.T) {
 		RepoPath:          "/tmp/project-dev",
 		KubernetesContext: "cluster-dev",
 		ContainerRegistry: "erunpaas",
+		RuntimeVersion:    "1.2.3",
+		SSHD: SSHDConfig{
+			Enabled:       true,
+			LocalPort:     62222,
+			PublicKeyPath: "/tmp/id_ed25519.pub",
+		},
 	}
 	if err := SaveEnvConfig("tenant-a", cfg); err != nil {
 		t.Fatalf("SaveEnvConfig failed: %v", err)

--- a/erun-common/default_devops_chart.go
+++ b/erun-common/default_devops_chart.go
@@ -141,6 +141,9 @@ func resolveDefaultDevopsDeploySpec(target OpenResult) (DeploySpec, error) {
 		return DeploySpec{}, err
 	}
 	deployInput.ReleaseName = moduleName
+	if runtimeVersion := strings.TrimSpace(target.EnvConfig.RuntimeVersion); runtimeVersion != "" {
+		deployInput.Version = runtimeVersion
+	}
 
 	return DeploySpec{
 		Target:        target,

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -51,6 +51,7 @@ type HelmDeployParams struct {
 	WorktreeStorage   string
 	WorktreeRepoName  string
 	WorktreeHostPath  string
+	SSHDEnabled       bool
 	Version           string
 	Timeout           string
 	Stdout            io.Writer
@@ -68,6 +69,7 @@ type HelmDeploySpec struct {
 	WorktreeStorage   string
 	WorktreeRepoName  string
 	WorktreeHostPath  string
+	SSHDEnabled       bool
 	Version           string
 	Timeout           string
 }
@@ -77,6 +79,7 @@ type KubernetesDeploymentCheckParams struct {
 	Namespace         string
 	KubernetesContext string
 	ExpectedRepoPath  string
+	ExpectedSSHD      *bool
 }
 
 type DeployTarget struct {
@@ -270,7 +273,7 @@ func resolveDeployTarget(store DeployStore, findProjectRoot ProjectFinderFunc, r
 			return OpenResult{}, fmt.Errorf("tenant and environment overrides are required together")
 		}
 
-		result, err := ResolveOpen(store, OpenParams{
+		result, err := resolveOpenWithFinder(store, findProjectRoot, OpenParams{
 			Tenant:      strings.TrimSpace(target.Tenant),
 			Environment: strings.TrimSpace(target.Environment),
 		})
@@ -283,27 +286,9 @@ func resolveDeployTarget(store DeployStore, findProjectRoot ProjectFinderFunc, r
 		return result, nil
 	}
 
-	projectRoot, err := resolveDockerBuildProjectRoot(findProjectRoot, DockerCommandTarget{})
-	if err != nil {
-		return OpenResult{}, err
-	}
-	if projectRoot == "" {
-		return OpenResult{}, fmt.Errorf("cannot determine project root for Helm deployment")
-	}
-
-	tenant, err := resolveProjectTenantForRoot(store, projectRoot)
-	if err != nil {
-		return OpenResult{}, err
-	}
-
-	environment, err := loadDefaultEnvironment(store, tenant)
-	if err != nil {
-		return OpenResult{}, err
-	}
-
-	return ResolveOpen(store, OpenParams{
-		Tenant:      tenant,
-		Environment: environment,
+	return resolveOpenWithFinder(store, findProjectRoot, OpenParams{
+		UseDefaultTenant:      true,
+		UseDefaultEnvironment: true,
 	})
 }
 
@@ -549,6 +534,7 @@ func newHelmDeploySpec(target OpenResult, deployContext KubernetesDeployContext,
 		WorktreeStorage:   resolveWorktreeStorage(target),
 		WorktreeRepoName:  resolveWorktreeRepoName(target.RepoPath),
 		WorktreeHostPath:  resolveWorktreeHostPath(target.RepoPath),
+		SSHDEnabled:       target.EnvConfig.SSHD.Enabled,
 		Version:           version,
 		Timeout:           DefaultHelmDeploymentTimeout,
 	}, nil
@@ -596,6 +582,7 @@ func (d HelmDeploySpec) Params(stdout, stderr io.Writer) HelmDeployParams {
 		WorktreeStorage:   d.WorktreeStorage,
 		WorktreeRepoName:  d.WorktreeRepoName,
 		WorktreeHostPath:  d.WorktreeHostPath,
+		SSHDEnabled:       d.SSHDEnabled,
 		Version:           d.Version,
 		Timeout:           d.Timeout,
 		Stdout:            stdout,
@@ -622,6 +609,7 @@ func (d HelmDeploySpec) command() commandSpec {
 		"--set-string", "worktreeStorage="+d.WorktreeStorage,
 		"--set-string", "worktreeRepoName="+d.WorktreeRepoName,
 		"--set-string", "worktreeHostPath="+d.WorktreeHostPath,
+		"--set", "sshdEnabled="+formatHelmBool(d.SSHDEnabled),
 		d.ReleaseName,
 		d.ChartPath,
 	)
@@ -631,6 +619,13 @@ func (d HelmDeploySpec) command() commandSpec {
 		Name: "helm",
 		Args: args,
 	}
+}
+
+func formatHelmBool(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
 }
 
 func ResolveKubernetesDeployContext() (KubernetesDeployContext, error) {
@@ -972,10 +967,10 @@ func CheckKubernetesDeployment(params KubernetesDeploymentCheckParams) (bool, er
 
 	output, err := exec.Command("kubectl", args...).CombinedOutput()
 	if err == nil {
-		if strings.TrimSpace(params.ExpectedRepoPath) == "" {
+		if strings.TrimSpace(params.ExpectedRepoPath) == "" && params.ExpectedSSHD == nil {
 			return true, nil
 		}
-		return deploymentUsesExpectedRepoPath(params)
+		return deploymentMatchesExpectedSettings(params)
 	}
 
 	message := strings.ToLower(string(output))
@@ -986,7 +981,7 @@ func CheckKubernetesDeployment(params KubernetesDeploymentCheckParams) (bool, er
 	return false, fmt.Errorf("failed to check deployment %q: %w", params.Name, err)
 }
 
-func deploymentUsesExpectedRepoPath(params KubernetesDeploymentCheckParams) (bool, error) {
+func deploymentMatchesExpectedSettings(params KubernetesDeploymentCheckParams) (bool, error) {
 	args := make([]string, 0, 8)
 	if strings.TrimSpace(params.KubernetesContext) != "" {
 		args = append(args, "--context", params.KubernetesContext)
@@ -1025,12 +1020,21 @@ func deploymentUsesExpectedRepoPath(params KubernetesDeploymentCheckParams) (boo
 		if strings.TrimSpace(container.Name) != params.Name {
 			continue
 		}
+		matchesRepoPath := strings.TrimSpace(expectedRepoPath) == ""
+		matchesSSHD := params.ExpectedSSHD == nil
 		for _, env := range container.Env {
-			if strings.TrimSpace(env.Name) == "ERUN_REPO_PATH" {
-				return filepath.Clean(strings.TrimSpace(env.Value)) == filepath.Clean(expectedRepoPath), nil
+			switch strings.TrimSpace(env.Name) {
+			case "ERUN_REPO_PATH":
+				if strings.TrimSpace(expectedRepoPath) != "" {
+					matchesRepoPath = filepath.Clean(strings.TrimSpace(env.Value)) == filepath.Clean(expectedRepoPath)
+				}
+			case "ERUN_SSHD_ENABLED":
+				if params.ExpectedSSHD != nil {
+					matchesSSHD = strings.EqualFold(strings.TrimSpace(env.Value), formatHelmBool(*params.ExpectedSSHD))
+				}
 			}
 		}
-		return false, nil
+		return matchesRepoPath && matchesSSHD, nil
 	}
 
 	return false, nil

--- a/erun-common/deploy_test.go
+++ b/erun-common/deploy_test.go
@@ -128,6 +128,65 @@ func TestResolveCurrentKubernetesDeployContextsUsesProjectRootDevopsModule(t *te
 	}
 }
 
+func TestResolveDeployTargetUsesCurrentDirectoryTenantWhenTenantProjectRootDiffers(t *testing.T) {
+	projectRoot := filepath.Join(t.TempDir(), "tenant-a")
+	defaultRepo := filepath.Join(t.TempDir(), "tenant-b")
+	for _, dir := range []string{projectRoot, defaultRepo} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir repo: %v", err)
+		}
+	}
+
+	store := openStore{
+		toolConfig: ERunConfig{DefaultTenant: "tenant-b"},
+		tenantConfigs: map[string]TenantConfig{
+			"tenant-a": {
+				Name:               "tenant-a",
+				ProjectRoot:        "/home/erun/git/tenant-a",
+				DefaultEnvironment: "dev",
+				Remote:             true,
+			},
+			"tenant-b": {
+				Name:               "tenant-b",
+				ProjectRoot:        defaultRepo,
+				DefaultEnvironment: "prod",
+			},
+		},
+		envConfigs: map[string]EnvConfig{
+			"tenant-a/dev": {
+				Name:              "dev",
+				RepoPath:          projectRoot,
+				KubernetesContext: "cluster-a",
+			},
+			"tenant-b/prod": {
+				Name:              "prod",
+				RepoPath:          defaultRepo,
+				KubernetesContext: "cluster-b",
+			},
+		},
+	}
+
+	result, err := resolveDeployTarget(
+		store,
+		func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		nil,
+		nil,
+		nil,
+		DeployTarget{},
+	)
+	if err != nil {
+		t.Fatalf("resolveDeployTarget failed: %v", err)
+	}
+	if result.Tenant != "tenant-a" || result.Environment != "dev" {
+		t.Fatalf("expected current directory tenant target, got %+v", result)
+	}
+	if result.RepoPath != projectRoot {
+		t.Fatalf("expected repo path %q, got %+v", projectRoot, result)
+	}
+}
+
 func TestPrepareHelmChartForDeployOverridesVersionAndAppVersion(t *testing.T) {
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
@@ -366,6 +425,33 @@ func TestResolveOpenRuntimeDeploySpecFallsBackToEmbeddedDefaultChart(t *testing.
 	}
 	if got := filepath.Base(spec.Deploy.ValuesFilePath); got != "values.dev.yaml" {
 		t.Fatalf("expected values.dev.yaml fallback, got %q", got)
+	}
+}
+
+func TestResolveOpenRuntimeDeploySpecUsesRemoteEnvRuntimeVersionForEmbeddedChart(t *testing.T) {
+	spec, err := ResolveOpenRuntimeDeploySpec(ConfigStore{}, FindProjectRoot, ResolveDockerBuildContext, ResolveKubernetesDeployContext, nil, OpenResult{
+		Tenant:      "frs",
+		Environment: "remote",
+		RepoPath:    "/home/erun/git/frs",
+		TenantConfig: TenantConfig{
+			Name:   "frs",
+			Remote: true,
+		},
+		EnvConfig: EnvConfig{
+			KubernetesContext: "cluster-remote",
+			RepoPath:          "/home/erun/git/frs",
+			Remote:            true,
+			RuntimeVersion:    "1.0.31",
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveOpenRuntimeDeploySpec failed: %v", err)
+	}
+	if spec.Deploy.Version != "1.0.31" {
+		t.Fatalf("expected embedded chart deploy version override, got %+v", spec.Deploy)
+	}
+	if len(spec.Builds) != 0 {
+		t.Fatalf("expected no local builds for remote embedded chart, got %+v", spec.Builds)
 	}
 }
 

--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -567,6 +567,7 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 			Name:              envName,
 			RepoPath:          envProjectRoot,
 			KubernetesContext: kubernetesContext,
+			RuntimeVersion:    strings.TrimSpace(params.RuntimeVersion),
 			Remote:            remoteMode,
 		}
 		if err := saveEnvConfig(s.Store, tenant, envConfig); err != nil {
@@ -583,6 +584,10 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 	if remoteMode {
 		if envConfig.RepoPath != params.ProjectRoot {
 			envConfig.RepoPath = params.ProjectRoot
+			envConfigChanged = true
+		}
+		if runtimeVersion := strings.TrimSpace(params.RuntimeVersion); runtimeVersion != "" && envConfig.RuntimeVersion != runtimeVersion {
+			envConfig.RuntimeVersion = runtimeVersion
 			envConfigChanged = true
 		}
 		if !envConfig.Remote {

--- a/erun-common/init_test.go
+++ b/erun-common/init_test.go
@@ -1106,6 +1106,9 @@ func TestBootstrapRunRemoteInitializesTenantInPodWorktree(t *testing.T) {
 	if result.EnvConfig.RepoPath != remotePath || !result.EnvConfig.Remote {
 		t.Fatalf("unexpected env config: %+v", result.EnvConfig)
 	}
+	if result.EnvConfig.RuntimeVersion != "1.2.3" {
+		t.Fatalf("expected remote runtime version to be persisted, got %+v", result.EnvConfig)
+	}
 	if result.EnvConfig.ContainerRegistry != "registry.example.com/remote" {
 		t.Fatalf("expected remote container registry to be persisted, got %+v", result.EnvConfig)
 	}

--- a/erun-common/linux_package_support.go
+++ b/erun-common/linux_package_support.go
@@ -1,0 +1,9 @@
+package eruncommon
+
+func LinuxPackageBuildsSupported() bool {
+	if DetectHost().OS != HostOSLinux {
+		return false
+	}
+	_, err := hostLookPath("dpkg-deb")
+	return err == nil
+}

--- a/erun-common/list.go
+++ b/erun-common/list.go
@@ -34,16 +34,16 @@ type ListCurrentDirectoryResult struct {
 }
 
 type ListEffectiveTargetResult struct {
-	Tenant            string `json:"tenant"`
-	Environment       string `json:"environment"`
-	KubernetesContext string `json:"kubernetesContext"`
-	RepoPath          string `json:"repoPath"`
-	Snapshot          bool   `json:"snapshot"`
+	Tenant            string        `json:"tenant"`
+	Environment       string        `json:"environment"`
+	KubernetesContext string        `json:"kubernetesContext"`
+	RepoPath          string        `json:"repoPath"`
+	Snapshot          bool          `json:"snapshot"`
+	SSH               ListSSHResult `json:"ssh,omitempty"`
 }
 
 type ListTenantResult struct {
 	Name               string                  `json:"name"`
-	ProjectRoot        string                  `json:"projectRoot,omitempty"`
 	DefaultEnvironment string                  `json:"defaultEnvironment,omitempty"`
 	Snapshot           bool                    `json:"snapshot,omitempty"`
 	IsDefault          bool                    `json:"isDefault,omitempty"`
@@ -52,11 +52,19 @@ type ListTenantResult struct {
 }
 
 type ListEnvironmentResult struct {
-	Name              string `json:"name"`
-	KubernetesContext string `json:"kubernetesContext,omitempty"`
-	RepoPath          string `json:"repoPath,omitempty"`
-	IsDefault         bool   `json:"isDefault,omitempty"`
-	IsEffective       bool   `json:"isEffective,omitempty"`
+	Name              string        `json:"name"`
+	KubernetesContext string        `json:"kubernetesContext,omitempty"`
+	RepoPath          string        `json:"repoPath,omitempty"`
+	IsDefault         bool          `json:"isDefault,omitempty"`
+	IsEffective       bool          `json:"isEffective,omitempty"`
+	SSH               ListSSHResult `json:"ssh,omitempty"`
+}
+
+type ListSSHResult struct {
+	Enabled       bool   `json:"enabled,omitempty"`
+	User          string `json:"user,omitempty"`
+	LocalPort     int    `json:"localPort,omitempty"`
+	WorkspacePath string `json:"workspacePath,omitempty"`
 }
 
 func ResolveListResult(store ListStore, findProjectRoot ProjectFinderFunc, params OpenParams) (ListResult, error) {
@@ -105,6 +113,7 @@ func ResolveListResult(store ListStore, findProjectRoot ProjectFinderFunc, param
 			KubernetesContext: strings.TrimSpace(effectiveResult.EnvConfig.KubernetesContext),
 			RepoPath:          effectiveResult.RepoPath,
 			Snapshot:          deployTargetSnapshotEnabled(effectiveResult, nil),
+			SSH:               listSSHResult(effectiveResult),
 		}
 	}
 
@@ -116,7 +125,6 @@ func ResolveListResult(store ListStore, findProjectRoot ProjectFinderFunc, param
 
 		tenantResult := ListTenantResult{
 			Name:               tenant.Name,
-			ProjectRoot:        tenant.ProjectRoot,
 			DefaultEnvironment: tenant.DefaultEnvironment,
 			Snapshot:           tenant.SnapshotEnabled(),
 			IsDefault:          tenant.Name == defaultTenant,
@@ -130,12 +138,37 @@ func ResolveListResult(store ListStore, findProjectRoot ProjectFinderFunc, param
 				RepoPath:          strings.TrimSpace(env.RepoPath),
 				IsDefault:         env.Name == tenant.DefaultEnvironment,
 				IsEffective:       effectiveErr == nil && tenant.Name == effectiveResult.Tenant && env.Name == effectiveResult.Environment,
+				SSH: listSSHResult(OpenResult{
+					Tenant:      tenant.Name,
+					Environment: env.Name,
+					TenantConfig: TenantConfig{
+						Name:        tenant.Name,
+						ProjectRoot: tenant.ProjectRoot,
+						Remote:      tenant.Remote,
+					},
+					EnvConfig: env,
+					RepoPath:  env.RepoPath,
+				}),
 			})
 		}
 		result.Tenants = append(result.Tenants, tenantResult)
 	}
 
 	return result, nil
+}
+
+func listSSHResult(result OpenResult) ListSSHResult {
+	if !result.EnvConfig.SSHD.Enabled {
+		return ListSSHResult{}
+	}
+
+	info := SSHConnectionInfoForResult(result)
+	return ListSSHResult{
+		Enabled:       true,
+		User:          info.User,
+		LocalPort:     info.Port,
+		WorkspacePath: info.WorkspacePath,
+	}
 }
 
 func configuredTenantForRepo(repoName string, tenants []TenantConfig) string {

--- a/erun-common/list_test.go
+++ b/erun-common/list_test.go
@@ -259,3 +259,60 @@ func TestResolveListResultIncludesSnapshotPreferenceForTenant(t *testing.T) {
 		t.Fatalf("expected environment snapshot off, got %+v", result.Tenants)
 	}
 }
+
+func TestResolveListResultIncludesSSHDConfiguration(t *testing.T) {
+	repoRoot := filepath.Join(t.TempDir(), "tenant-a")
+	store := listStore{
+		openStore: openStore{
+			toolConfig: ERunConfig{DefaultTenant: "tenant-a"},
+			tenantConfigs: map[string]TenantConfig{
+				"tenant-a": {Name: "tenant-a", ProjectRoot: repoRoot, DefaultEnvironment: "dev", Remote: true},
+			},
+			envConfigs: map[string]EnvConfig{
+				"tenant-a/dev": {
+					Name:              "dev",
+					RepoPath:          repoRoot,
+					KubernetesContext: "cluster-dev",
+					Remote:            true,
+					SSHD: SSHDConfig{
+						Enabled:       true,
+						LocalPort:     DefaultSSHLocalPort,
+						PublicKeyPath: "/tmp/id_ed25519.pub",
+					},
+				},
+			},
+		},
+		envsByTenant: map[string][]EnvConfig{
+			"tenant-a": {{
+				Name:              "dev",
+				RepoPath:          repoRoot,
+				KubernetesContext: "cluster-dev",
+				Remote:            true,
+				SSHD: SSHDConfig{
+					Enabled:       true,
+					LocalPort:     DefaultSSHLocalPort,
+					PublicKeyPath: "/tmp/id_ed25519.pub",
+				},
+			}},
+		},
+	}
+
+	result, err := ResolveListResult(store, func() (string, string, error) {
+		return "", "", ErrNotInGitRepository
+	}, OpenParams{
+		Tenant:      "tenant-a",
+		Environment: "dev",
+	})
+	if err != nil {
+		t.Fatalf("ResolveListResult failed: %v", err)
+	}
+	if result.CurrentDirectory.Effective == nil || !result.CurrentDirectory.Effective.SSH.Enabled {
+		t.Fatalf("expected effective SSH details, got %+v", result.CurrentDirectory.Effective)
+	}
+	if result.CurrentDirectory.Effective.SSH.User != DefaultSSHUser || result.CurrentDirectory.Effective.SSH.LocalPort != DefaultSSHLocalPort {
+		t.Fatalf("unexpected effective SSH info: %+v", result.CurrentDirectory.Effective.SSH)
+	}
+	if got := result.Tenants[0].Environments[0].SSH.WorkspacePath; got != "/home/erun/git/tenant-a" {
+		t.Fatalf("unexpected SSH workspace path: %q", got)
+	}
+}

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -130,58 +130,76 @@ func loadOpenDefaultEnvironment(store OpenStore, tenant string) (string, error) 
 }
 
 func InitParamsForOpenArgs(store OpenStore, args []string) (BootstrapInitParams, error) {
-	if len(args) == 2 {
+	params, err := OpenParamsForArgs(args)
+	if err != nil {
+		return BootstrapInitParams{}, err
+	}
+	return InitParamsForOpenTarget(store, params)
+}
+
+func InitParamsForOpenTarget(store OpenStore, params OpenParams) (BootstrapInitParams, error) {
+	tenant := strings.TrimSpace(params.Tenant)
+	environment := strings.TrimSpace(params.Environment)
+
+	switch {
+	case tenant != "" && environment != "":
 		return BootstrapInitParams{
-			Tenant:      args[0],
-			Environment: args[1],
+			Tenant:      tenant,
+			Environment: environment,
+		}, nil
+	case tenant != "":
+		return BootstrapInitParams{Tenant: tenant}, nil
+	case environment != "":
+		resolvedTenant, err := loadOpenDefaultTenant(store)
+		if err != nil {
+			if errors.Is(err, ErrDefaultTenantNotConfigured) || errors.Is(err, ErrNotInitialized) {
+				return BootstrapInitParams{
+					Environment:   environment,
+					ResolveTenant: true,
+				}, nil
+			}
+			return BootstrapInitParams{}, err
+		}
+		return BootstrapInitParams{
+			Tenant:      resolvedTenant,
+			Environment: environment,
 		}, nil
 	}
 
-	envName := ""
-	if len(args) == 1 {
-		envName = args[0]
-	}
-
-	tenant, err := loadOpenDefaultTenant(store)
+	resolvedTenant, err := loadOpenDefaultTenant(store)
 	if err != nil {
 		if errors.Is(err, ErrDefaultTenantNotConfigured) || errors.Is(err, ErrNotInitialized) {
-			return BootstrapInitParams{
-				Environment:   envName,
-				ResolveTenant: true,
-			}, nil
+			return BootstrapInitParams{ResolveTenant: true}, nil
 		}
 		return BootstrapInitParams{}, err
 	}
 
-	if envName != "" {
-		return BootstrapInitParams{
-			Tenant:      tenant,
-			Environment: envName,
-		}, nil
-	}
-
-	defaultEnvironment, err := loadOpenDefaultEnvironment(store, tenant)
+	defaultEnvironment, err := loadOpenDefaultEnvironment(store, resolvedTenant)
 	if err != nil {
 		if errors.Is(err, ErrDefaultEnvironmentNotConfigured) || errors.Is(err, ErrNotInitialized) {
-			return BootstrapInitParams{Tenant: tenant}, nil
+			return BootstrapInitParams{Tenant: resolvedTenant}, nil
 		}
 		return BootstrapInitParams{}, err
 	}
 
 	return BootstrapInitParams{
-		Tenant:      tenant,
+		Tenant:      resolvedTenant,
 		Environment: defaultEnvironment,
 	}, nil
 }
 
 func ResolveOpen(store OpenStore, params OpenParams) (OpenResult, error) {
+	return resolveOpenWithFinder(store, FindProjectRoot, params)
+}
+
+func resolveOpenWithFinder(store OpenStore, findProjectRoot ProjectFinderFunc, params OpenParams) (OpenResult, error) {
 	if store == nil {
 		return OpenResult{}, fmt.Errorf("store is required")
 	}
 
 	tenant := params.Tenant
 	if tenant == "" && params.UseDefaultTenant {
-		if currentTenant, ok, err := loadCurrentDirectoryTenant(store); err != nil {
+		if currentTenant, ok, err := loadCurrentDirectoryTenant(store, findProjectRoot); err != nil {
 			return OpenResult{}, err
 		} else if ok {
 			tenant = currentTenant
@@ -272,7 +290,7 @@ func ResolveOpen(store OpenStore, params OpenParams) (OpenResult, error) {
 	}, nil
 }
 
-func loadCurrentDirectoryTenant(store OpenStore) (string, bool, error) {
+func loadCurrentDirectoryTenant(store OpenStore, findProjectRoot ProjectFinderFunc) (string, bool, error) {
 	tenantLister, ok := store.(interface {
 		ListTenantConfigs() ([]TenantConfig, error)
 	})
@@ -280,7 +298,11 @@ func loadCurrentDirectoryTenant(store OpenStore) (string, bool, error) {
 		return "", false, nil
 	}
 
-	tenant, _, err := FindProjectRoot()
+	if findProjectRoot == nil {
+		findProjectRoot = FindProjectRoot
+	}
+
+	tenant, _, err := findProjectRoot()
 	if errors.Is(err, ErrNotInGitRepository) {
 		return "", false, nil
 	}

--- a/erun-common/open_test.go
+++ b/erun-common/open_test.go
@@ -210,6 +210,34 @@ func TestOpenResolveFallsBackToTenantProjectRoot(t *testing.T) {
 	}
 }
 
+func TestInitParamsForOpenTargetUsesExplicitTenantAndDefaultEnvironment(t *testing.T) {
+	params, err := InitParamsForOpenTarget(openStore{}, OpenParams{
+		Tenant:                "tenant-a",
+		UseDefaultEnvironment: true,
+	})
+	if err != nil {
+		t.Fatalf("InitParamsForOpenTarget failed: %v", err)
+	}
+	if params.Tenant != "tenant-a" || params.Environment != "" || params.ResolveTenant {
+		t.Fatalf("unexpected init params: %+v", params)
+	}
+}
+
+func TestInitParamsForOpenTargetUsesDefaultTenantForExplicitEnvironment(t *testing.T) {
+	params, err := InitParamsForOpenTarget(openStore{
+		toolConfig: ERunConfig{DefaultTenant: "tenant-a"},
+	}, OpenParams{
+		Environment:      "dev",
+		UseDefaultTenant: true,
+	})
+	if err != nil {
+		t.Fatalf("InitParamsForOpenTarget failed: %v", err)
+	}
+	if params.Tenant != "tenant-a" || params.Environment != "dev" || params.ResolveTenant {
+		t.Fatalf("unexpected init params: %+v", params)
+	}
+}
+
 func TestOpenResolveRequiresDefaultTenant(t *testing.T) {
 	if _, err := ResolveOpen(openStore{loadERunErr: ErrNotInitialized}, OpenParams{UseDefaultTenant: true}); !errors.Is(err, ErrDefaultTenantNotConfigured) {
 		t.Fatalf("expected ErrDefaultTenantNotConfigured, got %v", err)

--- a/erun-common/packaging_test.go
+++ b/erun-common/packaging_test.go
@@ -113,6 +113,9 @@ func TestAptBuildScriptBuildsDebianPackageForBothExecutables(t *testing.T) {
 	if !strings.Contains(script, `dpkg-deb --build --root-owner-group "$package_root" "$output_path"`) {
 		t.Fatalf("apt build script does not emit a .deb package:\n%s", script)
 	}
+	if !strings.Contains(script, `dpkg-deb is required to build Debian packages; install dpkg or run this build in a Debian-compatible environment`) {
+		t.Fatalf("apt build script does not explain missing dpkg-deb prerequisite:\n%s", script)
+	}
 	if !regexp.MustCompile(`(?m)^Package: erun$`).MatchString(script) {
 		t.Fatalf("apt build script does not define erun package metadata:\n%s", script)
 	}

--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -98,6 +98,7 @@ type ReleaseSpec struct {
 	DockerImages    []ReleaseDockerImageSpec `json:"dockerImages,omitempty"`
 	Stages          []ReleaseStage           `json:"stages,omitempty"`
 	LinuxReleases   []scriptSpec
+	SkippedLinux    bool `json:"-"`
 }
 
 func ResolveReleaseSpec(findProjectRoot ProjectFinderFunc, params ReleaseParams) (ReleaseSpec, error) {
@@ -166,6 +167,11 @@ func resolveReleaseSpec(findProjectRoot ProjectFinderFunc, loadProjectConfig Pro
 	if err != nil {
 		return ReleaseSpec{}, err
 	}
+	skippedLinux := false
+	if len(linuxReleases) > 0 && !LinuxPackageBuildsSupported() {
+		linuxReleases = nil
+		skippedLinux = true
+	}
 
 	stages := make([]ReleaseStage, 0, 2)
 	if syncStage := newSyncRemoteStage(projectRoot, branch); len(syncStage.GitCommands) > 0 {
@@ -232,6 +238,7 @@ func resolveReleaseSpec(findProjectRoot ProjectFinderFunc, loadProjectConfig Pro
 		DockerImages:    images,
 		Stages:          stages,
 		LinuxReleases:   linuxReleases,
+		SkippedLinux:    skippedLinux,
 	}, nil
 }
 
@@ -313,6 +320,9 @@ func runReleaseSpec(ctx Context, spec ReleaseSpec, runGit GitCommandRunnerFunc, 
 				return err
 			}
 		}
+	}
+	if spec.SkippedLinux {
+		ctx.Trace("skipping linux package scripts: host is not Linux or dpkg-deb is unavailable")
 	}
 
 	if err := runScriptSpecs(ctx, spec.LinuxReleases, runScript); err != nil {

--- a/erun-common/release_test.go
+++ b/erun-common/release_test.go
@@ -2,6 +2,7 @@ package eruncommon
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"os/exec"
@@ -70,6 +71,43 @@ func TestResolveReleaseSpecStableRelease(t *testing.T) {
 	}
 	if got := spec.Stages[4].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "main", "develop"}) {
 		t.Fatalf("unexpected push command: %+v", got)
+	}
+}
+
+func TestResolveReleaseSpecSkipsLinuxScriptsWhenUnsupported(t *testing.T) {
+	prevGOOS := currentGOOS
+	prevLookPath := hostLookPath
+	currentGOOS = func() string { return "darwin" }
+	hostLookPath = func(file string) (string, error) {
+		return "", errors.New("not found")
+	}
+	t.Cleanup(func() {
+		currentGOOS = prevGOOS
+		hostLookPath = prevLookPath
+	})
+
+	projectRoot := setupReleaseProjectGitRepo(t, "main")
+	linuxDir := filepath.Join(projectRoot, "erun-devops", "linux", "erun-cli")
+	if err := os.MkdirAll(linuxDir, 0o755); err != nil {
+		t.Fatalf("mkdir linux dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(linuxDir, "release.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write release.sh: %v", err)
+	}
+
+	spec, err := resolveReleaseSpec(
+		func() (string, string, error) { return "tenant-a", projectRoot, nil },
+		LoadProjectConfig,
+		func(string) (string, error) { return "main", nil },
+		func(string) (string, error) { return "abc1234", nil },
+		func(string, string) (bool, error) { return true, nil },
+		ReleaseParams{},
+	)
+	if err != nil {
+		t.Fatalf("resolveReleaseSpec failed: %v", err)
+	}
+	if len(spec.LinuxReleases) != 0 || !spec.SkippedLinux {
+		t.Fatalf("expected linux releases to be skipped, got %+v", spec)
 	}
 }
 

--- a/erun-common/remote_exec.go
+++ b/erun-common/remote_exec.go
@@ -1,0 +1,30 @@
+package eruncommon
+
+type RemoteCommandPreview struct {
+	Args   []string
+	Script string
+}
+
+func PreviewRemoteCommand(req ShellLaunchParams, script string) RemoteCommandPreview {
+	return RemoteCommandPreview{
+		Args:   kubectlRemoteExecArgs(req, script),
+		Script: script,
+	}
+}
+
+func RunTracedRemoteCommand(ctx Context, runner RemoteCommandRunnerFunc, req ShellLaunchParams, label, script string) (RemoteCommandResult, error) {
+	preview := PreviewRemoteCommand(req, script)
+	traceArgs := append([]string{}, preview.Args...)
+	if len(traceArgs) > 0 {
+		traceArgs[len(traceArgs)-1] = "<remote-script>"
+	}
+	ctx.TraceCommand("", "kubectl", traceArgs...)
+	ctx.TraceBlock(label, script)
+	if ctx.DryRun {
+		return RemoteCommandResult{}, nil
+	}
+	if runner == nil {
+		runner = RunRemoteCommand
+	}
+	return runner(req, script)
+}

--- a/erun-common/sshd.go
+++ b/erun-common/sshd.go
@@ -1,0 +1,59 @@
+package eruncommon
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	DefaultSSHUser      = "erun"
+	DefaultSSHLocalPort = 62222
+	RemoteSSHDPort      = 2222
+)
+
+type SSHConnectionInfo struct {
+	User          string
+	Host          string
+	Port          int
+	WorkspacePath string
+}
+
+func SSHConnectionInfoForResult(result OpenResult) SSHConnectionInfo {
+	req := ShellLaunchParamsFromResult(result)
+	return SSHConnectionInfo{
+		User:          DefaultSSHUser,
+		Host:          "127.0.0.1",
+		Port:          result.EnvConfig.SSHD.ResolvedLocalPort(),
+		WorkspacePath: RemoteShellWorktreePath(req),
+	}
+}
+
+func ValidateSSHDTarget(result OpenResult) error {
+	if !result.RemoteRepo() {
+		return fmt.Errorf("sshd requires a remote environment initialized with --remote")
+	}
+	if strings.TrimSpace(result.EnvConfig.KubernetesContext) == "" {
+		return fmt.Errorf("%w: %s/%s", ErrKubernetesContextNotConfigured, result.Tenant, result.Environment)
+	}
+	return nil
+}
+
+func BuildRemoteAuthorizedKeysSyncScript(publicKey string) string {
+	publicKey = strings.TrimSpace(publicKey)
+	return strings.Join([]string{
+		"set -eu",
+		"mkdir -p \"$HOME/.ssh\"",
+		"chmod 700 \"$HOME/.ssh\"",
+		"key_file=\"$HOME/.ssh/authorized_keys\"",
+		"tmp_keys=\"$(mktemp)\"",
+		"tmp_new=\"$(mktemp)\"",
+		"touch \"$key_file\"",
+		"chmod 600 \"$key_file\"",
+		"cat > \"$tmp_new\" <<'EOF'\n" + publicKey + "\nEOF",
+		"grep -Fvx -f \"$tmp_new\" \"$key_file\" > \"$tmp_keys\" || true",
+		"cat \"$tmp_new\" >> \"$tmp_keys\"",
+		"mv \"$tmp_keys\" \"$key_file\"",
+		"rm -f \"$tmp_new\"",
+		"chmod 600 \"$key_file\"",
+	}, "\n")
+}

--- a/erun-devops/docker/erun-devops/entrypoint.sh
+++ b/erun-devops/docker/erun-devops/entrypoint.sh
@@ -75,6 +75,15 @@ runtime_namespace() {
     fi
 }
 
+runtime_sshd_enabled() {
+    case "${ERUN_SSHD_ENABLED:-}" in
+        1|true|TRUE|True|yes|YES|on|ON)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
 initialize_erun_config() {
     repo_dir=$(runtime_repo_dir)
     tenant="${ERUN_TENANT:-}"
@@ -112,6 +121,52 @@ ${remote_line}
 EOF
 }
 
+start_sshd() {
+    if ! runtime_sshd_enabled; then
+        return
+    fi
+
+    sshd_dir="${HOME}/.sshd"
+    host_key_dir="${sshd_dir}/host_keys"
+    pid_file="${sshd_dir}/sshd.pid"
+    config_file="${sshd_dir}/sshd_config"
+    mkdir -p "${HOME}/.ssh" "${host_key_dir}"
+    chmod 700 "${HOME}/.ssh" "${sshd_dir}" "${host_key_dir}"
+
+    if [ -r "${pid_file}" ] && kill -0 "$(cat "${pid_file}")" 2>/dev/null; then
+        return
+    fi
+    rm -f "${pid_file}"
+
+    host_key="${host_key_dir}/ssh_host_ed25519_key"
+    if [ ! -f "${host_key}" ]; then
+        ssh-keygen -q -t ed25519 -N "" -f "${host_key}" >/dev/null 2>&1
+    fi
+    chmod 600 "${host_key}"
+    chmod 644 "${host_key}.pub"
+
+    cat >"${config_file}" <<EOF
+Port 2222
+ListenAddress 0.0.0.0
+HostKey ${host_key}
+AuthorizedKeysFile ${HOME}/.ssh/authorized_keys
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+PubkeyAuthentication yes
+PermitRootLogin no
+UsePAM no
+PidFile ${pid_file}
+PrintMotd no
+Subsystem sftp internal-sftp
+EOF
+    chmod 600 "${config_file}"
+    touch "${HOME}/.ssh/authorized_keys"
+    chmod 600 "${HOME}/.ssh/authorized_keys"
+
+    /usr/sbin/sshd -f "${config_file}" -E "${sshd_dir}/sshd.log"
+}
+
 run_shell() {
     repo_dir=$(runtime_repo_dir)
 
@@ -123,6 +178,7 @@ run_shell() {
 }
 
 write_kubeconfig
+start_sshd
 
 if [ "${1:-}" = "shell" ]; then
     shift

--- a/erun-devops/k8s/erun-devops/templates/service.yaml
+++ b/erun-devops/k8s/erun-devops/templates/service.yaml
@@ -99,6 +99,8 @@ spec:
               value: {{ required "tenant is required" .Values.tenant | quote }}
             - name: ERUN_ENVIRONMENT
               value: {{ required "environment is required" .Values.environment | quote }}
+            - name: ERUN_SSHD_ENABLED
+              value: {{ if .Values.sshdEnabled }}"true"{{ else }}"false"{{ end }}
             - name: ERUN_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -106,6 +108,9 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
+          ports:
+            - containerPort: 2222
+              name: ssh
           resources:
             limits:
               cpu: "4"

--- a/packaging/apt/build-deb.sh
+++ b/packaging/apt/build-deb.sh
@@ -40,6 +40,11 @@ arm64 | aarch64)
   ;;
 esac
 
+if ! command -v dpkg-deb >/dev/null 2>&1; then
+  echo "dpkg-deb is required to build Debian packages; install dpkg or run this build in a Debian-compatible environment" >&2
+  exit 1
+fi
+
 staging_dir=$(mktemp -d)
 trap 'rm -rf "$staging_dir"' EXIT
 


### PR DESCRIPTION
## What changed
- added SSHD-based remote runtime access with local port-forward activation and persisted SSH config
- aligned open, deploy, and list target resolution around environment repo paths and current effective target resolution
- persisted remote runtime version and used it when deploying the embedded remote runtime chart
- made tenant/environment targeting visible and consistent across open and deploy
- skipped Linux packaging steps on unsupported hosts or when `dpkg-deb` is unavailable

## Why
Remote development and release preparation were blocked by a few related issues:
- remote runtime opens could redeploy an old pinned runtime image
- deploy and list resolved targets differently once repo paths became environment-specific
- target selection was inconsistent across commands
- macOS hosts failed on Linux packaging-only build steps

## Validation
- `cd /Users/rihardsfreimanis/git/sophium/erun/erun-common && go test ./...`
- `cd /Users/rihardsfreimanis/git/sophium/erun/erun-cli && go test ./...`
- `cd /Users/rihardsfreimanis/git/sophium/erun/erun-mcp && go test ./...`

Closes #77
