### PR TITLE
Fix local runtime deployment and remote SSH workflow

### DIFF
--- a/erun-cli/cmd/deploy_test.go
+++ b/erun-cli/cmd/deploy_test.go
@@ -642,6 +642,177 @@ func TestDeployCommandVersionOverrideUsesProvidedVersion(t *testing.T) {
 	}
 }
 
+func TestDeployCommandUsesCurrentKubernetesContextForLocalEnvironment(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+	stubKubectlContexts(t, []string{"cluster-local", "cluster-selected"}, "cluster-selected")
+
+	projectRoot := t.TempDir()
+	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
+	componentDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
+	if err := os.MkdirAll(componentDir, 0o755); err != nil {
+		t.Fatalf("mkdir docker dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write VERSION: %v", err)
+	}
+	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
+		t.Fatalf("save erun config: %v", err)
+	}
+	if err := common.SaveTenantConfig(common.TenantConfig{
+		Name:               "tenant-a",
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: "local",
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{
+		Name:              "local",
+		RepoPath:          projectRoot,
+		KubernetesContext: "cluster-local",
+	}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
+		t.Fatalf("save project config: %v", err)
+	}
+
+	var deployed common.HelmDeployParams
+	cmd := newTestRootCmd(testRootDeps{
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		ResolveKubernetesDeployContext: func() (common.KubernetesDeployContext, error) {
+			return common.KubernetesDeployContext{
+				Dir:           componentDir,
+				ComponentName: "erun-devops",
+				ChartPath:     chartPath,
+			}, nil
+		},
+		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
+			return common.DockerBuildContext{
+				Dir:            componentDir,
+				DockerfilePath: filepath.Join(componentDir, "Dockerfile"),
+			}, nil
+		},
+		BuildDockerImage: deployBuildCallFunc(func(req deployBuildCall) error {
+			t.Fatalf("unexpected build request: %+v", req)
+			return nil
+		}),
+		PushDockerImage: deployPushCallFunc(func(req deployPushCall) error {
+			t.Fatalf("unexpected push request: %+v", req)
+			return nil
+		}),
+		DeployHelmChart: func(req common.HelmDeployParams) error {
+			deployed = req
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"deploy", "--version", "1.0.7"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if deployed.KubernetesContext != "cluster-selected" {
+		t.Fatalf("expected deploy to use current kubernetes context, got %+v", deployed)
+	}
+}
+
+func TestDeployCommandEnsuresNamespaceBeforeDeploy(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+	stubKubectlContexts(t, []string{"cluster-local"}, "cluster-local")
+
+	projectRoot := t.TempDir()
+	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
+	componentDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
+	if err := os.MkdirAll(componentDir, 0o755); err != nil {
+		t.Fatalf("mkdir docker dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write VERSION: %v", err)
+	}
+	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
+		t.Fatalf("save erun config: %v", err)
+	}
+	if err := common.SaveTenantConfig(common.TenantConfig{
+		Name:               "tenant-a",
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: "local",
+	}); err != nil {
+		t.Fatalf("save tenant config: %v", err)
+	}
+	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{
+		Name:              "local",
+		RepoPath:          projectRoot,
+		KubernetesContext: "cluster-local",
+	}); err != nil {
+		t.Fatalf("save env config: %v", err)
+	}
+	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
+		t.Fatalf("save project config: %v", err)
+	}
+
+	ensuredContext := ""
+	ensuredNamespace := ""
+	deployed := false
+	cmd := newTestRootCmd(testRootDeps{
+		FindProjectRoot: func() (string, string, error) {
+			return "tenant-a", projectRoot, nil
+		},
+		ResolveKubernetesDeployContext: func() (common.KubernetesDeployContext, error) {
+			return common.KubernetesDeployContext{
+				Dir:           componentDir,
+				ComponentName: "erun-devops",
+				ChartPath:     chartPath,
+			}, nil
+		},
+		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
+			return common.DockerBuildContext{
+				Dir:            componentDir,
+				DockerfilePath: filepath.Join(componentDir, "Dockerfile"),
+			}, nil
+		},
+		EnsureKubernetesNamespace: func(contextName, namespace string) error {
+			ensuredContext = contextName
+			ensuredNamespace = namespace
+			return nil
+		},
+		BuildDockerImage: deployBuildCallFunc(func(req deployBuildCall) error {
+			t.Fatalf("unexpected build request: %+v", req)
+			return nil
+		}),
+		PushDockerImage: deployPushCallFunc(func(req deployPushCall) error {
+			t.Fatalf("unexpected push request: %+v", req)
+			return nil
+		}),
+		DeployHelmChart: func(req common.HelmDeployParams) error {
+			if ensuredContext == "" || ensuredNamespace == "" {
+				t.Fatalf("expected namespace ensure before deploy, got context=%q namespace=%q", ensuredContext, ensuredNamespace)
+			}
+			deployed = true
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"deploy", "--version", "1.0.7"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if ensuredContext != "cluster-local" || ensuredNamespace != "tenant-a-local" {
+		t.Fatalf("unexpected namespace ensure request: context=%q namespace=%q", ensuredContext, ensuredNamespace)
+	}
+	if !deployed {
+		t.Fatal("expected deploy to run")
+	}
+}
+
 func TestRootDeployShorthandDryRunPrintsBuildAndDeployCommandsWithoutExecuting(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 	stubKubectlContexts(t, []string{"cluster-local"}, "cluster-local")

--- a/erun-cli/cmd/init.go
+++ b/erun-cli/cmd/init.go
@@ -228,51 +228,7 @@ func listKubernetesContexts() ([]string, error) {
 }
 
 func ensureKubernetesNamespace(contextName, namespace string) error {
-	if exists, err := kubernetesNamespaceExists(contextName, namespace); err != nil {
-		return err
-	} else if exists {
-		return nil
-	}
-
-	output, err := exec.Command("kubectl", "--context", contextName, "create", "namespace", namespace).CombinedOutput()
-	if err != nil {
-		message := strings.TrimSpace(string(output))
-		if kubernetesNamespaceAlreadyExists(message) {
-			return nil
-		}
-		if message == "" {
-			return fmt.Errorf("failed to ensure kubernetes namespace %q in context %q: %w", namespace, contextName, err)
-		}
-		return fmt.Errorf("failed to ensure kubernetes namespace %q in context %q: %w: %s", namespace, contextName, err, message)
-	}
-
-	return nil
-}
-
-func kubernetesNamespaceExists(contextName, namespace string) (bool, error) {
-	output, err := exec.Command("kubectl", "--context", contextName, "get", "namespace", namespace, "-o", "name").CombinedOutput()
-	if err == nil {
-		return true, nil
-	}
-
-	message := strings.TrimSpace(string(output))
-	if kubernetesNamespaceNotFound(message) {
-		return false, nil
-	}
-	if message == "" {
-		return false, fmt.Errorf("failed to check kubernetes namespace %q in context %q: %w", namespace, contextName, err)
-	}
-	return false, fmt.Errorf("failed to check kubernetes namespace %q in context %q: %w: %s", namespace, contextName, err, message)
-}
-
-func kubernetesNamespaceNotFound(message string) bool {
-	message = strings.ToLower(strings.TrimSpace(message))
-	return strings.Contains(message, "notfound") || strings.Contains(message, "not found")
-}
-
-func kubernetesNamespaceAlreadyExists(message string) bool {
-	message = strings.ToLower(strings.TrimSpace(message))
-	return strings.Contains(message, "alreadyexists") || strings.Contains(message, "already exists")
+	return common.EnsureKubernetesNamespace(contextName, namespace)
 }
 
 func preferCurrentKubernetesContext(contexts []string, current string) []string {

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -226,6 +226,9 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 		}
 
 		if shouldDeploy {
+			if result.EnvConfig.SSHD.Enabled {
+				execution.Deploy.SSHDEnabled = true
+			}
 			ctx.Logger.Debug("deploying the devops runtime before opening the shell")
 			if err := common.RunDeploySpec(
 				ctx,

--- a/erun-cli/cmd/open_test.go
+++ b/erun-cli/cmd/open_test.go
@@ -134,6 +134,69 @@ func TestRunResolvedOpenCommandActivatesSSHDWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestRunResolvedOpenCommandForcesSSHDEnabledOnRuntimeDeploy(t *testing.T) {
+	deployed := common.HelmDeployParams{}
+	err := runResolvedOpenCommand(
+		common.Context{
+			Logger: common.NewLoggerWithWriters(0, new(bytes.Buffer), new(bytes.Buffer)),
+			Stdout: new(bytes.Buffer),
+			Stderr: new(bytes.Buffer),
+		},
+		common.OpenResult{
+			Tenant:      "tenant-a",
+			Environment: "dev",
+			RepoPath:    "/home/erun/git/tenant-a",
+			TenantConfig: common.TenantConfig{
+				Name:   "tenant-a",
+				Remote: true,
+			},
+			EnvConfig: common.EnvConfig{
+				Name:              "dev",
+				RepoPath:          "/home/erun/git/tenant-a",
+				KubernetesContext: "cluster-dev",
+				Remote:            true,
+				SSHD:              common.SSHDConfig{Enabled: true},
+			},
+		},
+		openOptions{},
+		nil,
+		func(_ common.Context, _ common.ShellLaunchParams) error { return nil },
+		nil,
+		func(common.KubernetesDeploymentCheckParams) (bool, error) {
+			return false, nil
+		},
+		func(common.OpenResult) (common.DeploySpec, error) {
+			return common.DeploySpec{
+				Deploy: common.HelmDeploySpec{
+					ReleaseName:       "tenant-a-devops",
+					ChartPath:         "/tmp/chart",
+					ValuesFilePath:    "/tmp/chart/values.dev.yaml",
+					Tenant:            "tenant-a",
+					Environment:       "dev",
+					Namespace:         "tenant-a-dev",
+					KubernetesContext: "cluster-dev",
+					WorktreeStorage:   common.WorktreeStoragePVC,
+					WorktreeRepoName:  "tenant-a",
+					WorktreeHostPath:  "/tmp/ignored",
+					SSHDEnabled:       false,
+					Timeout:           common.DefaultHelmDeploymentTimeout,
+				},
+			}, nil
+		},
+		func(params common.HelmDeployParams) error {
+			deployed = params
+			return nil
+		},
+		func(_ common.Context, _ common.OpenResult) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("runResolvedOpenCommand failed: %v", err)
+	}
+	if !deployed.SSHDEnabled {
+		t.Fatalf("expected runtime deploy to force SSHD enabled, got %+v", deployed)
+	}
+}
+
 func TestOpenCommandNoShellConfiguresLocalKubeconfig(t *testing.T) {
 	repoPath := t.TempDir()
 	stdout := new(bytes.Buffer)

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -27,7 +27,8 @@ func runSelect(prompt promptui.Select) (int, string, error) {
 func Execute() error {
 	configStore := common.ConfigStore{}
 	store := rootStore(configStore)
-	runInit := newRunInit(store, common.FindProjectRoot, runPrompt, runSelect, listKubernetesContexts, ensureKubernetesNamespace, common.WaitForShellDeployment, common.RunRemoteCommand, common.DeployHelmChart)
+	deployHelmChart := common.WrapHelmChartDeployerWithNamespaceEnsure(ensureKubernetesNamespace, common.DeployHelmChart)
+	runInit := newRunInit(store, common.FindProjectRoot, runPrompt, runSelect, listKubernetesContexts, ensureKubernetesNamespace, common.WaitForShellDeployment, common.RunRemoteCommand, deployHelmChart)
 	runInitForArgs := newRunInitForArgs(store, runInit)
 	runInitForOpen := newRunInitForOpen(store, runInit)
 	push := newPushOperation(nil, common.DockerRegistryLogin, runSelect)
@@ -54,7 +55,7 @@ func Execute() error {
 		if err != nil {
 			return err
 		}
-		return common.RunDeploySpecs(ctx, specs, common.DockerImageBuilder, push, common.DeployHelmChart)
+		return common.RunDeploySpecs(ctx, specs, common.DockerImageBuilder, push, deployHelmChart)
 	}
 
 	initCmd := newInitCmd(runInit)
@@ -67,26 +68,26 @@ func Execute() error {
 		runManagedDeploy,
 		common.CheckKubernetesDeployment,
 		resolveRuntimeDeploySpec,
-		common.DeployHelmChart,
+		deployHelmChart,
 		activateSSHD,
 	)
-	sshdCmd := newSSHDCmd(resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, common.DeployHelmChart, common.RunRemoteCommand)
+	sshdCmd := newSSHDCmd(resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, deployHelmChart, common.RunRemoteCommand)
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
-		newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, push, common.DeployHelmChart),
+		newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, push, deployHelmChart),
 		newPushCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.DockerImageBuilder, push),
 	)
 	k8sCmd := newCommandGroup(
 		"k8s",
 		"Kubernetes utilities",
-		newK8sDeployCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.DockerImageBuilder, push, common.DeployHelmChart),
+		newK8sDeployCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.DockerImageBuilder, push, deployHelmChart),
 	)
 	devopsCmd := newCommandGroup("devops", "DevOps utilities", containerCmd, k8sCmd)
 
 	var buildCmd *cobra.Command
 	if hasOptionalBuildCmd(common.FindProjectRoot, common.ResolveDockerBuildContext) {
-		buildCmd = newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, push, common.DeployHelmChart)
+		buildCmd = newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, push, deployHelmChart)
 		buildCmd.Short = optionalBuildCmdShort(common.FindProjectRoot, common.ResolveDockerBuildContext)
 	}
 	var pushCmd *cobra.Command
@@ -96,7 +97,7 @@ func Execute() error {
 	}
 	var deployCmd *cobra.Command
 	if hasOptionalDeployCmd(common.ResolveKubernetesDeployContext) {
-		deployCmd = newDeployCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.DockerImageBuilder, push, common.DeployHelmChart)
+		deployCmd = newDeployCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.DockerImageBuilder, push, deployHelmChart)
 	}
 
 	mcpCmd := newMCPCmd(resolveOpen, runInitForArgs, launchMCPProcess)
@@ -115,7 +116,7 @@ func Execute() error {
 		if initRan {
 			return nil
 		}
-		return runResolvedOpenCommand(ctx, result, openOptions{}, runPrompt, newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell), runManagedDeploy, common.CheckKubernetesDeployment, resolveRuntimeDeploySpec, common.DeployHelmChart, activateSSHD)
+		return runResolvedOpenCommand(ctx, result, openOptions{}, runPrompt, newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell), runManagedDeploy, common.CheckKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart, activateSSHD)
 	}
 
 	cmd := newRootCommand(runRoot)

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -91,6 +91,9 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	if deployHelmChart == nil {
 		deployHelmChart = common.DeployHelmChart
 	}
+	if deps.EnsureKubernetesNamespace != nil {
+		deployHelmChart = common.WrapHelmChartDeployerWithNamespaceEnsure(deps.EnsureKubernetesNamespace, deployHelmChart)
+	}
 	launchMCP := deps.LaunchMCP
 	if launchMCP == nil {
 		launchMCP = launchMCPProcess

--- a/erun-common/assets/default-devops-chart/templates/service.yaml
+++ b/erun-common/assets/default-devops-chart/templates/service.yaml
@@ -48,6 +48,54 @@ roleRef:
   kind: ClusterRole
   name: admin
 ---
+{{- if eq (required "environment is required" .Values.environment) "local" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: __MODULE_NAME__-namespace-manager
+  labels:
+    app: __MODULE_NAME__
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: __MODULE_NAME__
+  labels:
+    app: __MODULE_NAME__
+subjects:
+  - kind: ServiceAccount
+    name: __MODULE_NAME__
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: __MODULE_NAME__-namespace-manager
+  labels:
+    app: __MODULE_NAME__
+subjects:
+  - kind: ServiceAccount
+    name: __MODULE_NAME__
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: __MODULE_NAME__-namespace-manager
+---
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -206,6 +206,10 @@ func (ConfigStore) ResolveEffectiveKubernetesContext(environment, configured str
 	return resolveEffectiveKubernetesContext(environment, configured, listKubernetesContextNames, currentKubernetesContextName)
 }
 
+func (ConfigStore) ResolveDeployKubernetesContext(environment, configured string) string {
+	return resolveDeployKubernetesContext(environment, configured, currentKubernetesContextName)
+}
+
 func (ConfigStore) ListEnvConfigs(tenant string) ([]EnvConfig, error) {
 	return ListEnvConfigs(tenant)
 }

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -34,6 +34,10 @@ type (
 	HelmChartDeployerFunc           func(HelmDeployParams) error
 )
 
+type deployKubernetesContextResolver interface {
+	ResolveDeployKubernetesContext(environment, configured string) string
+}
+
 type KubernetesDeployContext struct {
 	Dir           string
 	ComponentName string
@@ -110,6 +114,7 @@ func RunHelmDeploy(ctx Context, deployInput HelmDeploySpec, deploy HelmChartDepl
 	if deploy == nil {
 		return fmt.Errorf("helm deployer is required")
 	}
+	TraceEnsureKubernetesNamespace(ctx, deployInput.KubernetesContext, deployInput.Namespace)
 	command := deployInput.command()
 	ctx.TraceCommand(command.Dir, command.Name, command.Args...)
 	if ctx.DryRun {
@@ -191,6 +196,7 @@ func resolveDeploySpecForOpenResult(store DeployStore, findProjectRoot ProjectFi
 
 func resolveDeploySpecForContext(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, deployContext KubernetesDeployContext, versionOverride string, allowLocalBuilds bool) (DeploySpec, error) {
 	store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now = normalizeDeployDependencies(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now)
+	target = applyDeployKubernetesContext(store, target)
 
 	builds := make([]DockerBuildSpec, 0, 2)
 	if allowLocalBuilds && strings.TrimSpace(versionOverride) == "" {
@@ -221,6 +227,13 @@ func resolveDeploySpecForContext(store DeployStore, findProjectRoot ProjectFinde
 		Builds:        builds,
 		Deploy:        deployInput,
 	}, nil
+}
+
+func applyDeployKubernetesContext(store DeployStore, target OpenResult) OpenResult {
+	if resolver, ok := store.(deployKubernetesContextResolver); ok {
+		target.EnvConfig.KubernetesContext = resolver.ResolveDeployKubernetesContext(target.Environment, target.EnvConfig.KubernetesContext)
+	}
+	return target
 }
 
 func ResolveOpenRuntimeDeploySpec(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult) (DeploySpec, error) {
@@ -628,6 +641,24 @@ func formatHelmBool(value bool) string {
 	return "false"
 }
 
+func resolveDeployKubernetesContext(environment, configured string, currentContext func() (string, error)) string {
+	environment = strings.TrimSpace(environment)
+	configured = strings.TrimSpace(configured)
+	if environment != DefaultEnvironment || currentContext == nil {
+		return configured
+	}
+
+	current, err := currentContext()
+	if err != nil {
+		return configured
+	}
+	current = strings.TrimSpace(current)
+	if current == "" {
+		return configured
+	}
+	return current
+}
+
 func ResolveKubernetesDeployContext() (KubernetesDeployContext, error) {
 	dir, err := os.Getwd()
 	if err != nil {
@@ -837,30 +868,23 @@ func DeployHelmChart(params HelmDeployParams) error {
 		defer cleanup()
 	}
 
-	args := []string{
-		"upgrade",
-		"--install",
-		"--wait",
-		"--wait-for-jobs",
-		"--timeout", params.Timeout,
-		"--namespace", params.Namespace,
-	}
-	if strings.TrimSpace(params.KubernetesContext) != "" {
-		args = append(args, "--kube-context", params.KubernetesContext)
-	}
-	args = append(args,
-		"-f", params.ValuesFilePath,
-		"--set-string", "tenant="+params.Tenant,
-		"--set-string", "environment="+params.Environment,
-		"--set-string", "worktreeStorage="+params.WorktreeStorage,
-		"--set-string", "worktreeRepoName="+params.WorktreeRepoName,
-		"--set-string", "worktreeHostPath="+params.WorktreeHostPath,
-		params.ReleaseName,
-		chartPath,
-	)
+	command := HelmDeploySpec{
+		ReleaseName:       params.ReleaseName,
+		ChartPath:         chartPath,
+		ValuesFilePath:    params.ValuesFilePath,
+		Tenant:            params.Tenant,
+		Environment:       params.Environment,
+		Namespace:         params.Namespace,
+		KubernetesContext: params.KubernetesContext,
+		WorktreeStorage:   params.WorktreeStorage,
+		WorktreeRepoName:  params.WorktreeRepoName,
+		WorktreeHostPath:  params.WorktreeHostPath,
+		SSHDEnabled:       params.SSHDEnabled,
+		Timeout:           params.Timeout,
+	}.command()
 
-	cmd := exec.Command("helm", args...)
-	cmd.Dir = chartPath
+	cmd := exec.Command(command.Name, command.Args...)
+	cmd.Dir = command.Dir
 	cmd.Stdout = params.Stdout
 	cmd.Stderr = params.Stderr
 	return cmd.Run()

--- a/erun-common/deploy_test.go
+++ b/erun-common/deploy_test.go
@@ -242,6 +242,34 @@ func TestRuntimeChartsInstallBinfmtForMultiArchBuilds(t *testing.T) {
 	}
 }
 
+func TestRuntimeChartsGrantLocalRuntimeCrossNamespaceBootstrapAccess(t *testing.T) {
+	paths := []string{
+		filepath.Join("..", "erun-devops", "k8s", "erun-devops", "templates", "service.yaml"),
+		filepath.Join("assets", "default-devops-chart", "templates", "service.yaml"),
+	}
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %q: %v", path, err)
+		}
+		content := string(data)
+		for _, want := range []string{
+			`{{- if eq (required "environment is required" .Values.environment) "local" }}`,
+			"kind: ClusterRole",
+			"resources:",
+			"      - namespaces",
+			"      - list",
+			"      - create",
+			"kind: ClusterRoleBinding",
+		} {
+			if !strings.Contains(content, want) {
+				t.Fatalf("expected %q to include %q, got:\n%s", path, want, content)
+			}
+		}
+	}
+}
+
 func TestNewHelmDeploySpecCanonicalizesWorktreeHostPath(t *testing.T) {
 	projectRoot := t.TempDir()
 	repoRoot := filepath.Join(projectRoot, "repo")
@@ -452,6 +480,87 @@ func TestResolveOpenRuntimeDeploySpecUsesRemoteEnvRuntimeVersionForEmbeddedChart
 	}
 	if len(spec.Builds) != 0 {
 		t.Fatalf("expected no local builds for remote embedded chart, got %+v", spec.Builds)
+	}
+}
+
+func TestResolveDeploySpecForContextUsesSelectedKubernetesContextForLocalEnvironment(t *testing.T) {
+	projectRoot := t.TempDir()
+	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
+
+	spec, err := resolveDeploySpecForContext(
+		openStore{
+			resolveDeployKubernetesContext: func(environment, configured string) string {
+				if environment != DefaultEnvironment || configured != "cluster-configured" {
+					t.Fatalf("unexpected deploy context resolution inputs: environment=%q configured=%q", environment, configured)
+				}
+				return "cluster-selected"
+			},
+		},
+		nil,
+		nil,
+		nil,
+		nil,
+		OpenResult{
+			Tenant:      "tenant-a",
+			Environment: DefaultEnvironment,
+			RepoPath:    projectRoot,
+			EnvConfig: EnvConfig{
+				KubernetesContext: "cluster-configured",
+			},
+		},
+		KubernetesDeployContext{
+			ComponentName: "erun-devops",
+			ChartPath:     chartPath,
+		},
+		"",
+		false,
+	)
+	if err != nil {
+		t.Fatalf("resolveDeploySpecForContext failed: %v", err)
+	}
+	if spec.Deploy.KubernetesContext != "cluster-selected" {
+		t.Fatalf("expected selected kubernetes context, got %+v", spec.Deploy)
+	}
+}
+
+func TestDeployHelmChartPassesSSHDEnabledValue(t *testing.T) {
+	helmDir := t.TempDir()
+	argsPath := filepath.Join(helmDir, "helm-args.txt")
+	helmPath := filepath.Join(helmDir, "helm")
+	if err := os.WriteFile(helmPath, []byte(`#!/bin/sh
+printf '%s
+' "$@" > "$ERUN_HELM_ARGS_FILE"
+`), 0o755); err != nil {
+		t.Fatalf("write helm stub: %v", err)
+	}
+	t.Setenv("ERUN_HELM_ARGS_FILE", argsPath)
+	t.Setenv("PATH", helmDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	chartPath := createHelmChartFixture(t, t.TempDir(), "erun-devops")
+	if err := DeployHelmChart(HelmDeployParams{
+		ReleaseName:       "erun-devops",
+		ChartPath:         chartPath,
+		ValuesFilePath:    filepath.Join(chartPath, "values.local.yaml"),
+		Tenant:            "erun",
+		Environment:       "remote",
+		Namespace:         "erun-remote",
+		KubernetesContext: "rancher-desktop",
+		WorktreeStorage:   WorktreeStoragePVC,
+		WorktreeRepoName:  "erun",
+		WorktreeHostPath:  "/home/erun/git/erun",
+		SSHDEnabled:       true,
+		Timeout:           DefaultHelmDeploymentTimeout,
+	}); err != nil {
+		t.Fatalf("DeployHelmChart failed: %v", err)
+	}
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read helm args: %v", err)
+	}
+	args := string(data)
+	if !strings.Contains(args, "--set\nsshdEnabled=true\n") {
+		t.Fatalf("expected helm args to include sshdEnabled=true, got:\n%s", args)
 	}
 }
 

--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -206,8 +206,7 @@ func TraceNamespaceEnsurer(ctx Context, ensure NamespaceEnsurerFunc) NamespaceEn
 		return nil
 	}
 	return func(contextName, namespace string) error {
-		ctx.TraceCommand("", "kubectl", "--context", contextName, "get", "namespace", namespace, "-o", "name")
-		ctx.TraceCommand("", "kubectl", "--context", contextName, "create", "namespace", namespace)
+		TraceEnsureKubernetesNamespace(ctx, contextName, namespace)
 		if ctx.DryRun {
 			return nil
 		}

--- a/erun-common/kubernetes_namespace.go
+++ b/erun-common/kubernetes_namespace.go
@@ -1,0 +1,100 @@
+package eruncommon
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func TraceEnsureKubernetesNamespace(ctx Context, contextName, namespace string) {
+	contextName = strings.TrimSpace(contextName)
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return
+	}
+
+	if contextName != "" {
+		ctx.TraceCommand("", "kubectl", "--context", contextName, "get", "namespace", namespace, "-o", "name")
+		ctx.TraceCommand("", "kubectl", "--context", contextName, "create", "namespace", namespace)
+		return
+	}
+
+	ctx.TraceCommand("", "kubectl", "get", "namespace", namespace, "-o", "name")
+	ctx.TraceCommand("", "kubectl", "create", "namespace", namespace)
+}
+
+func EnsureKubernetesNamespace(contextName, namespace string) error {
+	if exists, err := kubernetesNamespaceExists(contextName, namespace); err != nil {
+		return err
+	} else if exists {
+		return nil
+	}
+
+	args := []string{}
+	if strings.TrimSpace(contextName) != "" {
+		args = append(args, "--context", contextName)
+	}
+	args = append(args, "create", "namespace", namespace)
+
+	output, err := exec.Command("kubectl", args...).CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if kubernetesNamespaceAlreadyExists(message) {
+			return nil
+		}
+		if message == "" {
+			return fmt.Errorf("failed to ensure kubernetes namespace %q in context %q: %w", namespace, contextName, err)
+		}
+		return fmt.Errorf("failed to ensure kubernetes namespace %q in context %q: %w: %s", namespace, contextName, err, message)
+	}
+
+	return nil
+}
+
+func WrapHelmChartDeployerWithNamespaceEnsure(ensure NamespaceEnsurerFunc, deploy HelmChartDeployerFunc) HelmChartDeployerFunc {
+	if deploy == nil {
+		deploy = DeployHelmChart
+	}
+	if ensure == nil {
+		return deploy
+	}
+
+	return func(params HelmDeployParams) error {
+		if err := ensure(params.KubernetesContext, params.Namespace); err != nil {
+			return err
+		}
+		return deploy(params)
+	}
+}
+
+func kubernetesNamespaceExists(contextName, namespace string) (bool, error) {
+	args := []string{}
+	if strings.TrimSpace(contextName) != "" {
+		args = append(args, "--context", contextName)
+	}
+	args = append(args, "get", "namespace", namespace, "-o", "name")
+
+	output, err := exec.Command("kubectl", args...).CombinedOutput()
+	if err == nil {
+		return true, nil
+	}
+
+	message := strings.TrimSpace(string(output))
+	if kubernetesNamespaceNotFound(message) {
+		return false, nil
+	}
+	if message == "" {
+		return false, fmt.Errorf("failed to check kubernetes namespace %q in context %q: %w", namespace, contextName, err)
+	}
+	return false, fmt.Errorf("failed to check kubernetes namespace %q in context %q: %w: %s", namespace, contextName, err, message)
+}
+
+func kubernetesNamespaceNotFound(message string) bool {
+	message = strings.ToLower(strings.TrimSpace(message))
+	return strings.Contains(message, "notfound") || strings.Contains(message, "not found")
+}
+
+func kubernetesNamespaceAlreadyExists(message string) bool {
+	message = strings.ToLower(strings.TrimSpace(message))
+	return strings.Contains(message, "alreadyexists") || strings.Contains(message, "already exists")
+}

--- a/erun-common/open_test.go
+++ b/erun-common/open_test.go
@@ -749,6 +749,7 @@ type openStore struct {
 	tenantConfigs                     map[string]TenantConfig
 	envConfigs                        map[string]EnvConfig
 	resolveEffectiveKubernetesContext func(environment, configured string) string
+	resolveDeployKubernetesContext    func(environment, configured string) string
 }
 
 func (s openStore) LoadERunConfig() (ERunConfig, string, error) {
@@ -779,6 +780,13 @@ func (s openStore) ResolveEffectiveKubernetesContext(environment, configured str
 		return configured
 	}
 	return s.resolveEffectiveKubernetesContext(environment, configured)
+}
+
+func (s openStore) ResolveDeployKubernetesContext(environment, configured string) string {
+	if s.resolveDeployKubernetesContext == nil {
+		return configured
+	}
+	return s.resolveDeployKubernetesContext(environment, configured)
 }
 
 func (s openStore) LoadEnvConfig(tenant, environment string) (EnvConfig, string, error) {

--- a/erun-devops/k8s/erun-devops/templates/service.yaml
+++ b/erun-devops/k8s/erun-devops/templates/service.yaml
@@ -45,6 +45,54 @@ roleRef:
   kind: ClusterRole
   name: admin
 ---
+{{- if eq (required "environment is required" .Values.environment) "local" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: erun-devops-namespace-manager
+  labels:
+    app: erun-devops
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: erun-devops
+  labels:
+    app: erun-devops
+subjects:
+  - kind: ServiceAccount
+    name: erun-devops
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: erun-devops-namespace-manager
+  labels:
+    app: erun-devops
+subjects:
+  - kind: ServiceAccount
+    name: erun-devops
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: erun-devops-namespace-manager
+---
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/erun-mcp/runtime.go
+++ b/erun-mcp/runtime.go
@@ -65,6 +65,11 @@ func normalizeRuntimeConfig(cfg RuntimeConfig) RuntimeConfig {
 	if cfg.DeployHelmChart == nil {
 		cfg.DeployHelmChart = eruncommon.DeployHelmChart
 	}
+	namespaceEnsurer := cfg.EnsureKubernetesNamespace
+	if namespaceEnsurer == nil {
+		namespaceEnsurer = eruncommon.EnsureKubernetesNamespace
+	}
+	cfg.DeployHelmChart = eruncommon.WrapHelmChartDeployerWithNamespaceEnsure(namespaceEnsurer, cfg.DeployHelmChart)
 	if cfg.WaitForRemoteRuntime == nil {
 		cfg.WaitForRemoteRuntime = eruncommon.WaitForShellDeployment
 	}

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -605,6 +605,9 @@ func TestInitToolReturnsRepositoryInteractionForRemoteInit(t *testing.T) {
 	handler := initTool(normalizeRuntimeConfig(RuntimeConfig{
 		Context: RuntimeContext{},
 		Store:   initInteractionStore{},
+		EnsureKubernetesNamespace: func(string, string) error {
+			return nil
+		},
 		DeployHelmChart: func(eruncommon.HelmDeployParams) error {
 			return nil
 		},
@@ -643,6 +646,9 @@ func TestInitToolUsesExplicitRuntimeVersionOverride(t *testing.T) {
 	handler := initTool(normalizeRuntimeConfig(RuntimeConfig{
 		Context: RuntimeContext{},
 		Store:   initInteractionStore{},
+		EnsureKubernetesNamespace: func(string, string) error {
+			return nil
+		},
 		DeployHelmChart: func(params eruncommon.HelmDeployParams) error {
 			deployedVersion = params.Version
 			return nil


### PR DESCRIPTION
## Summary
- fix SSH-enabled remote runtime deployment so Helm execution matches the traced plan
- use the current kubectl context for local deploys and ensure target namespaces exist before Helm runs
- let local runtime pods bootstrap other tenant namespaces by granting the required cluster-scope RBAC

## Validation
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-common && go test ./...
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-cli && go test ./...
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-mcp && go test ./...

Closes #79