### PR TITLE
Restore docker login retry for release builds

### DIFF
--- a/erun-cli/cmd/build.go
+++ b/erun-cli/cmd/build.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/manifoldco/promptui"
@@ -17,7 +18,7 @@ const (
 
 var errVersionFileNotFound = common.ErrVersionFileNotFound
 
-func newBuildCmd(store common.DockerStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, resolveDeployContext common.DeployContextResolverFunc, now common.NowFunc, runBuildScript common.BuildScriptRunnerFunc, buildDockerImage common.DockerImageBuilderFunc, push common.DockerPushFunc, deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
+func newBuildCmd(store common.DockerStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, resolveDeployContext common.DeployContextResolverFunc, now common.NowFunc, runBuildScript common.BuildScriptRunnerFunc, buildDockerImage common.DockerImageBuilderFunc, loginToDockerRegistry common.DockerRegistryLoginFunc, selectRunner SelectRunner, push common.DockerPushFunc, deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
 	target := common.DockerCommandTarget{}
 	cmd := &cobra.Command{
 		Use:           "build",
@@ -26,7 +27,7 @@ func newBuildCmd(store common.DockerStore, findProjectRoot common.ProjectFinderF
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runBuildCommand(commandContext(cmd), store, findProjectRoot, resolveBuildContext, resolveDeployContext, now, target, runBuildScript, buildDockerImage, push, deployHelmChart)
+			return runBuildCommand(commandContext(cmd), store, findProjectRoot, resolveBuildContext, resolveDeployContext, now, target, runBuildScript, buildDockerImage, loginToDockerRegistry, selectRunner, push, deployHelmChart)
 		},
 	}
 	addDryRunFlag(cmd)
@@ -34,13 +35,29 @@ func newBuildCmd(store common.DockerStore, findProjectRoot common.ProjectFinderF
 	return cmd
 }
 
-func runBuildCommand(ctx common.Context, store common.DockerStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, resolveDeployContext common.DeployContextResolverFunc, now common.NowFunc, target common.DockerCommandTarget, runBuildScript common.BuildScriptRunnerFunc, buildDockerImage common.DockerImageBuilderFunc, push common.DockerPushFunc, deployHelmChart common.HelmChartDeployerFunc) error {
+func runBuildCommand(ctx common.Context, store common.DockerStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, resolveDeployContext common.DeployContextResolverFunc, now common.NowFunc, target common.DockerCommandTarget, runBuildScript common.BuildScriptRunnerFunc, buildDockerImage common.DockerImageBuilderFunc, loginToDockerRegistry common.DockerRegistryLoginFunc, selectRunner SelectRunner, push common.DockerPushFunc, deployHelmChart common.HelmChartDeployerFunc) error {
 	execution, err := common.ResolveBuildExecution(store, findProjectRoot, resolveBuildContext, now, target)
 	if err != nil {
 		return err
 	}
+	buildWithRetry := func(buildInput common.DockerBuildSpec, stdout, stderr io.Writer) error {
+		return runDockerBuildWithRetry(
+			ctx,
+			buildInput,
+			func(buildInput common.DockerBuildSpec, stdout, stderr io.Writer) error {
+				if buildDockerImage == nil {
+					return common.DockerImageBuilder(buildInput, stdout, stderr)
+				}
+				return buildDockerImage(buildInput, stdout, stderr)
+			},
+			loginToDockerRegistry,
+			selectRunner,
+			stdout,
+			stderr,
+		)
+	}
 	if !target.Deploy {
-		return common.RunBuildExecution(ctx, execution, runBuildScript, buildDockerImage, push)
+		return common.RunBuildExecution(ctx, execution, runBuildScript, buildWithRetry, push)
 	}
 	if common.BuildExecutionUsesBuildScript(execution) {
 		return errors.New("build deploy is not supported for project build scripts")
@@ -56,7 +73,7 @@ func runBuildCommand(ctx common.Context, store common.DockerStore, findProjectRo
 		return err
 	}
 
-	return common.RunBuildExecutionAndDeploy(ctx, execution, deploySpecs, runBuildScript, buildDockerImage, push, deployHelmChart)
+	return common.RunBuildExecutionAndDeploy(ctx, execution, deploySpecs, runBuildScript, buildWithRetry, push, deployHelmChart)
 }
 
 func newPushCmd(store common.DockerStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, now common.NowFunc, buildDockerImage common.DockerImageBuilderFunc, push common.DockerPushFunc) *cobra.Command {
@@ -110,6 +127,37 @@ func runDockerPushWithRetry(ctx common.Context, pushInput common.DockerPushSpec,
 	}
 
 	return push(ctx, pushInput)
+}
+
+func runDockerBuildWithRetry(ctx common.Context, buildInput common.DockerBuildSpec, build common.DockerImageBuilderFunc, loginToDockerRegistry common.DockerRegistryLoginFunc, selectRunner SelectRunner, stdout, stderr io.Writer) error {
+	err := build(buildInput, stdout, stderr)
+	if err == nil {
+		return nil
+	}
+
+	var authErr common.DockerRegistryAuthError
+	if !errors.As(err, &authErr) {
+		return err
+	}
+
+	retry, promptErr := promptDockerLoginRetry(selectRunner, authErr.Registry)
+	if promptErr != nil {
+		return promptErr
+	}
+	if !retry {
+		return err
+	}
+
+	loginArgs := []string{"login"}
+	if strings.TrimSpace(authErr.Registry) != "" {
+		loginArgs = append(loginArgs, authErr.Registry)
+	}
+	ctx.TraceCommand(buildInput.ContextDir, "docker", loginArgs...)
+	if loginErr := loginToDockerRegistry(authErr.Registry, ctx.Stdin, ctx.Stdout, ctx.Stderr); loginErr != nil {
+		return loginErr
+	}
+
+	return build(buildInput, stdout, stderr)
 }
 
 func addBuildCommandTargetFlags(cmd *cobra.Command, target *common.DockerCommandTarget) {

--- a/erun-cli/cmd/build_test.go
+++ b/erun-cli/cmd/build_test.go
@@ -1214,6 +1214,70 @@ func TestDevopsContainerPushPromptsLoginAndRetriesOnAuthError(t *testing.T) {
 	}
 }
 
+func TestBuildCommandReleasePromptsLoginAndRetriesOnAuthError(t *testing.T) {
+	projectRoot := createReleaseGitRepo(t, "main")
+	remoteRoot := filepath.Join(t.TempDir(), "release-remote.git")
+	if err := os.MkdirAll(remoteRoot, 0o755); err != nil {
+		t.Fatalf("mkdir remote root: %v", err)
+	}
+	runGitCommand(t, remoteRoot, "init", "--bare")
+	runGitCommand(t, projectRoot, "remote", "add", "origin", remoteRoot)
+	runGitCommand(t, projectRoot, "push", "-u", "origin", "main")
+	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
+		t.Fatalf("save project config: %v", err)
+	}
+	runGitCommand(t, projectRoot, "add", ".")
+	runGitCommand(t, projectRoot, "commit", "-m", "configure registry")
+	runGitCommand(t, projectRoot, "push", "origin", "main")
+
+	pushBuildCalls := 0
+	loginRegistry := "unexpected"
+	cmd := newTestRootCmd(testRootDeps{
+		FindProjectRoot: func() (string, string, error) {
+			return "erun", projectRoot, nil
+		},
+		OptionalBuildFindProjectRoot: func() (string, string, error) {
+			return "erun", projectRoot, nil
+		},
+		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
+			return common.DockerBuildContext{Dir: projectRoot}, nil
+		},
+		SelectRunner: func(prompt promptui.Select) (int, string, error) {
+			return 0, loginAndRetryPushOption, nil
+		},
+		BuildDockerImage: buildCallFunc(func(req dockerBuildCall) error {
+			if req.Push {
+				pushBuildCalls++
+				if pushBuildCalls == 1 {
+					return common.DockerRegistryAuthError{
+						Tag:      req.Tag,
+						Registry: "",
+						Message:  "push access denied: insufficient_scope: authorization failed",
+						Err:      errors.New("exit status 1"),
+					}
+				}
+			}
+			return nil
+		}),
+		LoginToDockerRegistry: loginCallFunc(func(req dockerLoginCall) error {
+			loginRegistry = req.Registry
+			return nil
+		}),
+	})
+	cmd.SetArgs([]string{"build", "--release"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if pushBuildCalls != 2 {
+		t.Fatalf("expected release build retry, got %d pushed build calls", pushBuildCalls)
+	}
+	if loginRegistry != "" {
+		t.Fatalf("expected Docker Hub login, got %q", loginRegistry)
+	}
+}
+
 func TestRootPushShorthandUsesResolvedImageTag(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
@@ -1743,6 +1807,8 @@ func TestRunContainerBuildCommandPropagatesBuildContextErrors(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		nil,
 	)
 	cmd.SetArgs([]string{})
 
@@ -1760,7 +1826,7 @@ func TestRunContainerPushCommandPropagatesBuildContextErrors(t *testing.T) {
 		newBuildCmd(common.ConfigStore{}, nil, func() (common.DockerBuildContext, error) {
 			t.Fatal("unexpected build execution")
 			return common.DockerBuildContext{}, nil
-		}, nil, nil, nil, nil, nil, nil),
+		}, nil, nil, nil, nil, nil, nil, nil, nil),
 		newPushCmd(common.ConfigStore{}, nil, func() (common.DockerBuildContext, error) {
 			return common.DockerBuildContext{}, expectedErr
 		}, nil, nil, nil),

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -75,7 +75,7 @@ func Execute() error {
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
-		newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, push, deployHelmChart),
+		newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, common.DockerRegistryLogin, runSelect, push, deployHelmChart),
 		newPushCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.DockerImageBuilder, push),
 	)
 	k8sCmd := newCommandGroup(
@@ -87,7 +87,7 @@ func Execute() error {
 
 	var buildCmd *cobra.Command
 	if hasOptionalBuildCmd(common.FindProjectRoot, common.ResolveDockerBuildContext) {
-		buildCmd = newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, push, deployHelmChart)
+		buildCmd = newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, common.DockerRegistryLogin, runSelect, push, deployHelmChart)
 		buildCmd.Short = optionalBuildCmdShort(common.FindProjectRoot, common.ResolveDockerBuildContext)
 	}
 	var pushCmd *cobra.Command

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -160,7 +160,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
-		newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, runBuildScript, buildDockerImage, push, deployHelmChart),
+		newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, runBuildScript, buildDockerImage, loginToDockerRegistry, selectRunner, push, deployHelmChart),
 		newPushCmd(store, findProjectRoot, resolveDockerBuildContext, now, buildDockerImage, push),
 	)
 	k8sCmd := newCommandGroup(
@@ -172,7 +172,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 
 	var buildCmd *cobra.Command
 	if hasOptionalBuildCmd(optionalBuildFindProjectRoot, resolveDockerBuildContext) {
-		buildCmd = newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, runBuildScript, buildDockerImage, push, deployHelmChart)
+		buildCmd = newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, runBuildScript, buildDockerImage, loginToDockerRegistry, selectRunner, push, deployHelmChart)
 		buildCmd.Short = optionalBuildCmdShort(optionalBuildFindProjectRoot, resolveDockerBuildContext)
 	}
 	var pushCmd *cobra.Command

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -1244,9 +1244,42 @@ func DockerImageBuilder(buildInput DockerBuildSpec, stdout, stderr io.Writer) er
 	}
 	cmd := exec.Command("docker", dockerBuildArgs(buildInput)...)
 	cmd.Dir = buildInput.ContextDir
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
-	return cmd.Run()
+	output := new(bytes.Buffer)
+	cmd.Stdout = dockerCommandOutputWriter(stdout, output)
+	cmd.Stderr = dockerCommandOutputWriter(stderr, output)
+	err := cmd.Run()
+	if err == nil {
+		return nil
+	}
+
+	message := output.String()
+	if buildInput.Push && IsDockerPushAuthorizationError(message) {
+		return DockerRegistryAuthError{
+			Tag:      buildInput.Image.Tag,
+			Registry: dockerRegistryFromImageTag(buildInput.Image.Tag),
+			Message:  strings.TrimSpace(message),
+			Err:      err,
+		}
+	}
+
+	return err
+}
+
+func dockerCommandOutputWriter(primary io.Writer, capture io.Writer) io.Writer {
+	writers := make([]io.Writer, 0, 2)
+	if primary != nil {
+		writers = append(writers, primary)
+	}
+	if capture != nil {
+		writers = append(writers, capture)
+	}
+	if len(writers) == 0 {
+		return io.Discard
+	}
+	if len(writers) == 1 {
+		return writers[0]
+	}
+	return io.MultiWriter(writers...)
 }
 
 func dockerBuildArgs(buildInput DockerBuildSpec) []string {
@@ -1385,8 +1418,8 @@ func BuildScriptRunner(dir, scriptPath string, env []string, stdin io.Reader, st
 func DockerImagePusher(tag string, stdout, stderr io.Writer) error {
 	pushCmd := exec.Command("docker", "push", tag)
 	output := new(bytes.Buffer)
-	pushCmd.Stdout = io.MultiWriter(stdout, output)
-	pushCmd.Stderr = io.MultiWriter(stderr, output)
+	pushCmd.Stdout = dockerCommandOutputWriter(stdout, output)
+	pushCmd.Stderr = dockerCommandOutputWriter(stderr, output)
 	err := pushCmd.Run()
 	if err == nil {
 		return nil

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -146,6 +146,57 @@ func TestDockerBuildTraceCommandsIncludeBuildxBootstrapForMultiPlatformBuilds(t 
 	}
 }
 
+func TestDockerImageBuilderReturnsRegistryAuthErrorForBuildxPushAuthFailure(t *testing.T) {
+	dockerDir := t.TempDir()
+	dockerPath := filepath.Join(dockerDir, "docker")
+	if err := os.WriteFile(dockerPath, []byte(`#!/bin/sh
+if [ "$1" = "buildx" ] && [ "$2" = "inspect" ] && [ "$3" = "erun-multiarch" ]; then
+  exit 0
+fi
+if [ "$1" = "buildx" ] && [ "$2" = "inspect" ] && [ "$3" = "--builder" ] && [ "$4" = "erun-multiarch" ] && [ "$5" = "--bootstrap" ]; then
+  cat <<'EOF'
+Name: erun-multiarch
+Driver: docker-container
+Platforms: linux/amd64, linux/arm64
+EOF
+  exit 0
+fi
+if [ "$1" = "buildx" ] && [ "$2" = "build" ]; then
+  echo "push access denied: insufficient_scope: authorization failed" >&2
+  exit 1
+fi
+echo "unexpected docker invocation: $@" >&2
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+	t.Setenv("PATH", dockerDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	err := DockerImageBuilder(DockerBuildSpec{
+		ContextDir:     t.TempDir(),
+		DockerfilePath: "/tmp/Dockerfile",
+		Image: DockerImageReference{
+			Tag: "erunpaas/erun-devops:1.4.2",
+		},
+		Platforms: []string{"linux/amd64", "linux/arm64"},
+		Push:      true,
+	}, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("expected auth error")
+	}
+
+	var authErr DockerRegistryAuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected DockerRegistryAuthError, got %T: %v", err, err)
+	}
+	if authErr.Tag != "erunpaas/erun-devops:1.4.2" {
+		t.Fatalf("unexpected auth error tag: %+v", authErr)
+	}
+	if authErr.Registry != "" {
+		t.Fatalf("expected Docker Hub registry, got %q", authErr.Registry)
+	}
+}
+
 func TestMissingBuildxPlatformsReportsRequiredPlatformsNotPresent(t *testing.T) {
 	output := `Name: erun-multiarch
 Driver: docker-container


### PR DESCRIPTION
## Summary
- wrap `docker buildx build --push` auth failures as docker registry auth errors
- reuse the existing CLI docker login prompt and retry flow for release builds
- add regression coverage for the common build path and CLI release path

## Validation
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-common && go test ./...
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-cli && go test ./...
- cd /Users/rihardsfreimanis/git/sophium/erun/erun-mcp && go test ./...

Closes #81
