### PR TITLE
Add VS Code SSH open flow for remote envs

### DIFF
--- a/erun-cli/cmd/list.go
+++ b/erun-cli/cmd/list.go
@@ -103,6 +103,9 @@ func writeEffectiveOpen(ctx common.Context, current common.ListCurrentDirectoryR
 		if err := writeLabeledValue(ctx, "sshd", "on"); err != nil {
 			return err
 		}
+		if err := writeLabeledValue(ctx, "ssh host", current.Effective.SSH.HostAlias); err != nil {
+			return err
+		}
 		if err := writeLabeledValue(ctx, "ssh user", current.Effective.SSH.User); err != nil {
 			return err
 		}
@@ -161,6 +164,7 @@ func writeTenantEntry(ctx common.Context, tenant common.ListTenantResult) error 
 		envLine += " repo=" + quotedValueOrNone(env.RepoPath)
 		if env.SSH.Enabled {
 			envLine += " ssh=on"
+			envLine += " host=" + quotedValueOrNone(env.SSH.HostAlias)
 			envLine += " user=" + quotedValueOrNone(env.SSH.User)
 			envLine += " local-port=" + fmt.Sprintf("%d", env.SSH.LocalPort)
 			envLine += " workspace=" + quotedValueOrNone(env.SSH.WorkspacePath)

--- a/erun-cli/cmd/list_test.go
+++ b/erun-cli/cmd/list_test.go
@@ -328,10 +328,11 @@ func TestListCommandPrintsSSHDConfiguration(t *testing.T) {
 	output := stdout.String()
 	for _, want := range []string{
 		"  sshd: on",
+		"  ssh host: erun-tenant-a-dev",
 		"  ssh user: erun",
 		"  ssh local port: 62222 (after erun open)",
 		"  ssh workspace: /home/erun/git/tenant-a",
-		"ssh=on user=erun local-port=62222 workspace=/home/erun/git/tenant-a",
+		"ssh=on host=erun-tenant-a-dev user=erun local-port=62222 workspace=/home/erun/git/tenant-a",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected list output to contain %q, got:\n%s", want, output)

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -22,8 +22,9 @@ const (
 
 var currentHostOS = func() common.HostOS { return common.DetectHost().OS }
 
-func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), saveTenantConfig func(common.TenantConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateSSHD SSHDActivator) *cobra.Command {
+func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), saveTenantConfig func(common.TenantConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateSSHD SSHDActivator, launchVSCode VSCodeLauncher) *cobra.Command {
 	var noShell bool
+	var vscode bool
 	var snapshot bool
 	var noSnapshot bool
 	target := common.OpenParams{}
@@ -54,7 +55,7 @@ func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), 
 			if err != nil {
 				return err
 			}
-			return runResolvedOpenCommand(ctx, result, openOptions{NoShell: noShell}, promptRunner, openShell, runManagedDeploy, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart, activateSSHD)
+			return runResolvedOpenCommand(ctx, result, openOptions{NoShell: noShell, VSCode: vscode}, promptRunner, openShell, runManagedDeploy, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart, activateSSHD, launchVSCode)
 		},
 	}
 
@@ -62,12 +63,14 @@ func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), 
 	cmd.Flags().StringVar(&target.Tenant, "tenant", "", "Open a specific tenant")
 	cmd.Flags().StringVar(&target.Environment, "environment", "", "Open a specific environment")
 	cmd.Flags().BoolVar(&noShell, "no-shell", false, "Print shell commands to switch kubectl context, namespace, and worktree locally")
+	cmd.Flags().BoolVar(&vscode, "vscode", false, "Open the remote environment in VS Code instead of a shell")
 	addSnapshotFlags(cmd, &snapshot, &noSnapshot, "Build and deploy a local snapshot when opening the local environment")
 	return cmd
 }
 
 type openOptions struct {
 	NoShell bool
+	VSCode  bool
 }
 
 func applyOpenSnapshotPreference(result common.OpenResult, enabled *bool, saveTenantConfig func(common.TenantConfig) error) (common.OpenResult, error) {
@@ -189,9 +192,12 @@ func resolveOpenWithInitRetryForParams(ctx common.Context, params common.OpenPar
 	return result, true, err
 }
 
-func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateSSHD SSHDActivator) error {
+func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateSSHD SSHDActivator, launchVSCode VSCodeLauncher) error {
 	namespace := common.KubernetesNamespaceName(result.Tenant, result.Environment)
-	if options.NoShell && !result.EnvConfig.SSHD.Enabled {
+	if options.VSCode && !result.EnvConfig.SSHD.Enabled {
+		return fmt.Errorf("--vscode requires sshd-enabled remote environment; run `erun sshd init %s %s` first", result.Tenant, result.Environment)
+	}
+	if options.NoShell && !options.VSCode && !result.EnvConfig.SSHD.Enabled {
 		ctx.TraceCommand("", "kubectl", "config", "use-context", strings.TrimSpace(result.EnvConfig.KubernetesContext))
 		ctx.TraceCommand("", "kubectl", "config", "set-context", "--current", "--namespace="+namespace)
 		ctx.TraceCommand("", "cd", result.RepoPath)
@@ -248,6 +254,13 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 		if err := activateSSHD(ctx, result); err != nil {
 			return err
 		}
+	}
+
+	if options.VSCode {
+		if launchVSCode == nil {
+			return fmt.Errorf("VS Code launcher is required")
+		}
+		return launchVSCode(ctx, result)
 	}
 
 	if options.NoShell {

--- a/erun-cli/cmd/open_known_hosts.go
+++ b/erun-cli/cmd/open_known_hosts.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+
+	common "github.com/sophium/erun/erun-common"
+	sshknownhosts "github.com/sophium/erun/internal/sshknownhosts"
+)
+
+var ensureLocalSSHDKnownHostFunc = ensureLocalSSHDKnownHost
+
+func ensureLocalSSHDKnownHost(ctx common.Context, result common.OpenResult) error {
+	info := common.SSHConnectionInfoForResult(result)
+	ctx.TraceCommand("", "ssh-keyscan", "-p", fmt.Sprintf("%d", info.Port), info.Host)
+	if ctx.DryRun {
+		return nil
+	}
+	if _, err := sshknownhosts.UpsertDefaultKnownHost(info.HostAlias, info.Host, info.Port); err != nil {
+		return fmt.Errorf("update local known_hosts: %w", err)
+	}
+	return nil
+}

--- a/erun-cli/cmd/open_test.go
+++ b/erun-cli/cmd/open_test.go
@@ -52,6 +52,8 @@ func TestOpenHelpShowsTenantAndEnvironmentFlags(t *testing.T) {
 		"Open a specific tenant",
 		"--environment string",
 		"Open a specific environment",
+		"--vscode",
+		"Open the remote environment in VS Code instead of a shell",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected open help to contain %q, got:\n%s", want, output)
@@ -122,6 +124,7 @@ func TestRunResolvedOpenCommandActivatesSSHDWhenEnabled(t *testing.T) {
 			}
 			return nil
 		},
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("runResolvedOpenCommand failed: %v", err)
@@ -131,6 +134,29 @@ func TestRunResolvedOpenCommandActivatesSSHDWhenEnabled(t *testing.T) {
 	}
 	if !launched {
 		t.Fatal("expected shell launch after SSHD activation")
+	}
+}
+
+func TestEmitSSHDConnectionInfoIncludesHostAlias(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	err := emitSSHDConnectionInfo(common.Context{Stdout: stdout}, common.SSHConnectionInfo{
+		User:          "erun",
+		Host:          "127.0.0.1",
+		HostAlias:     "erun-tenant-a-dev",
+		Port:          62222,
+		WorkspacePath: "/home/erun/git/tenant-a",
+	})
+	if err != nil {
+		t.Fatalf("emitSSHDConnectionInfo failed: %v", err)
+	}
+	for _, want := range []string{
+		"host: 127.0.0.1",
+		"alias: erun-tenant-a-dev",
+		"workspace: /home/erun/git/tenant-a",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected SSH output to contain %q, got:\n%s", want, stdout.String())
+		}
 	}
 }
 
@@ -188,6 +214,7 @@ func TestRunResolvedOpenCommandForcesSSHDEnabledOnRuntimeDeploy(t *testing.T) {
 			return nil
 		},
 		func(_ common.Context, _ common.OpenResult) error { return nil },
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("runResolvedOpenCommand failed: %v", err)
@@ -227,6 +254,100 @@ func TestOpenCommandNoShellConfiguresLocalKubeconfig(t *testing.T) {
 	}
 	if stderr.String() != "" {
 		t.Fatalf("did not expect stderr output in buffered mode, got %q", stderr.String())
+	}
+}
+
+func TestRunResolvedOpenCommandLaunchesVSCodeWhenRequested(t *testing.T) {
+	activated := false
+	launched := false
+	err := runResolvedOpenCommand(
+		common.Context{
+			Logger: common.NewLoggerWithWriters(0, new(bytes.Buffer), new(bytes.Buffer)),
+			Stdout: new(bytes.Buffer),
+			Stderr: new(bytes.Buffer),
+		},
+		common.OpenResult{
+			Tenant:      "tenant-a",
+			Environment: "dev",
+			RepoPath:    "/home/erun/git/tenant-a",
+			TenantConfig: common.TenantConfig{
+				Name:   "tenant-a",
+				Remote: true,
+			},
+			EnvConfig: common.EnvConfig{
+				Name:              "dev",
+				RepoPath:          "/home/erun/git/tenant-a",
+				KubernetesContext: "cluster-dev",
+				Remote:            true,
+				SSHD:              common.SSHDConfig{Enabled: true},
+			},
+		},
+		openOptions{VSCode: true},
+		nil,
+		func(_ common.Context, _ common.ShellLaunchParams) error {
+			t.Fatal("did not expect shell launch")
+			return nil
+		},
+		nil,
+		nil,
+		nil,
+		nil,
+		func(_ common.Context, _ common.OpenResult) error {
+			activated = true
+			return nil
+		},
+		func(_ common.Context, result common.OpenResult) error {
+			launched = true
+			if result.Tenant != "tenant-a" || result.Environment != "dev" {
+				t.Fatalf("unexpected VS Code target: %+v", result)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runResolvedOpenCommand failed: %v", err)
+	}
+	if !activated {
+		t.Fatal("expected SSH activation before launching VS Code")
+	}
+	if !launched {
+		t.Fatal("expected VS Code launch")
+	}
+}
+
+func TestRunResolvedOpenCommandRejectsVSCodeWithoutSSHD(t *testing.T) {
+	err := runResolvedOpenCommand(
+		common.Context{
+			Logger: common.NewLoggerWithWriters(0, new(bytes.Buffer), new(bytes.Buffer)),
+			Stdout: new(bytes.Buffer),
+			Stderr: new(bytes.Buffer),
+		},
+		common.OpenResult{
+			Tenant:      "tenant-a",
+			Environment: "dev",
+			RepoPath:    "/home/erun/git/tenant-a",
+			EnvConfig: common.EnvConfig{
+				Name:              "dev",
+				RepoPath:          "/home/erun/git/tenant-a",
+				KubernetesContext: "cluster-dev",
+				Remote:            true,
+			},
+		},
+		openOptions{VSCode: true},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected VS Code SSH error")
+	}
+	if got := err.Error(); !strings.Contains(got, "run `erun sshd init tenant-a dev` first") {
+		t.Fatalf("unexpected error: %q", got)
 	}
 }
 

--- a/erun-cli/cmd/open_vscode.go
+++ b/erun-cli/cmd/open_vscode.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"os/exec"
+
+	common "github.com/sophium/erun/erun-common"
+)
+
+var vscodeExecCommand = exec.Command
+
+type VSCodeLauncher func(common.Context, common.OpenResult) error
+
+func launchVSCode(ctx common.Context, result common.OpenResult) error {
+	if err := ensureLocalSSHDKnownHostFunc(ctx, result); err != nil {
+		return err
+	}
+	command, args, err := vscodeLaunchCommand(currentHostOS(), vscodeRemoteFolderURI(result))
+	if err != nil {
+		return err
+	}
+	ctx.TraceCommand("", command, args...)
+	if ctx.DryRun {
+		return nil
+	}
+
+	cmd := vscodeExecCommand(command, args...)
+	cmd.Stdin = ctx.Stdin
+	cmd.Stdout = ctx.Stdout
+	cmd.Stderr = ctx.Stderr
+	return cmd.Run()
+}
+
+func vscodeRemoteFolderURI(result common.OpenResult) string {
+	info := common.SSHConnectionInfoForResult(result)
+	return "vscode://vscode-remote/ssh-remote+" + url.PathEscape(info.HostAlias) + (&url.URL{Path: info.WorkspacePath}).EscapedPath()
+}
+
+func vscodeLaunchCommand(hostOS common.HostOS, uri string) (string, []string, error) {
+	switch hostOS {
+	case common.HostOSDarwin:
+		return "open", []string{uri}, nil
+	case common.HostOSLinux:
+		return "xdg-open", []string{uri}, nil
+	case common.HostOSWindows:
+		return "cmd", []string{"/c", "start", "", uri}, nil
+	default:
+		return "", nil, fmt.Errorf("opening VS Code is unsupported on %s", hostOS)
+	}
+}

--- a/erun-cli/cmd/open_vscode_test.go
+++ b/erun-cli/cmd/open_vscode_test.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	common "github.com/sophium/erun/erun-common"
+)
+
+func TestVSCodeRemoteFolderURI(t *testing.T) {
+	got := vscodeRemoteFolderURI(common.OpenResult{
+		Tenant:      "tenant-a",
+		Environment: "remote",
+		TenantConfig: common.TenantConfig{
+			Name:   "tenant-a",
+			Remote: true,
+		},
+		EnvConfig: common.EnvConfig{
+			Name:     "remote",
+			Remote:   true,
+			RepoPath: "/home/erun/git/tenant-a",
+			SSHD: common.SSHDConfig{
+				Enabled:   true,
+				LocalPort: 62222,
+			},
+		},
+		RepoPath: "/home/erun/git/tenant-a",
+	})
+	want := "vscode://vscode-remote/ssh-remote+erun-tenant-a-remote/home/erun/git/tenant-a"
+	if got != want {
+		t.Fatalf("unexpected VS Code URI:\nwant: %s\ngot:  %s", want, got)
+	}
+}
+
+func TestVSCodeLaunchCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		hostOS  common.HostOS
+		command string
+		args    []string
+	}{
+		{name: "darwin", hostOS: common.HostOSDarwin, command: "open", args: []string{"vscode://example"}},
+		{name: "linux", hostOS: common.HostOSLinux, command: "xdg-open", args: []string{"vscode://example"}},
+		{name: "windows", hostOS: common.HostOSWindows, command: "cmd", args: []string{"/c", "start", "", "vscode://example"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			command, args, err := vscodeLaunchCommand(tt.hostOS, "vscode://example")
+			if err != nil {
+				t.Fatalf("vscodeLaunchCommand failed: %v", err)
+			}
+			if command != tt.command {
+				t.Fatalf("unexpected command: %q", command)
+			}
+			if len(args) != len(tt.args) {
+				t.Fatalf("unexpected args: %+v", args)
+			}
+			for i := range args {
+				if args[i] != tt.args[i] {
+					t.Fatalf("unexpected args: %+v", args)
+				}
+			}
+		})
+	}
+}
+
+func TestLaunchVSCodeEnsuresKnownHostBeforeOpening(t *testing.T) {
+	prevEnsure := ensureLocalSSHDKnownHostFunc
+	prevExec := vscodeExecCommand
+	t.Cleanup(func() {
+		ensureLocalSSHDKnownHostFunc = prevEnsure
+		vscodeExecCommand = prevExec
+	})
+
+	callOrder := make([]string, 0, 2)
+	ensureLocalSSHDKnownHostFunc = func(_ common.Context, result common.OpenResult) error {
+		callOrder = append(callOrder, "known_hosts")
+		if result.Tenant != "tenant-a" {
+			t.Fatalf("unexpected target: %+v", result)
+		}
+		return nil
+	}
+	vscodeExecCommand = func(name string, args ...string) *exec.Cmd {
+		callOrder = append(callOrder, "launch")
+		if name != "open" {
+			t.Fatalf("unexpected command: %q", name)
+		}
+		return exec.Command("true")
+	}
+
+	err := launchVSCode(common.Context{}, common.OpenResult{
+		Tenant:      "tenant-a",
+		Environment: "remote",
+		TenantConfig: common.TenantConfig{
+			Name:   "tenant-a",
+			Remote: true,
+		},
+		EnvConfig: common.EnvConfig{
+			Name:     "remote",
+			Remote:   true,
+			RepoPath: "/home/erun/git/tenant-a",
+			SSHD: common.SSHDConfig{
+				Enabled:   true,
+				LocalPort: 62222,
+			},
+		},
+		RepoPath: "/home/erun/git/tenant-a",
+	})
+	if err != nil {
+		t.Fatalf("launchVSCode failed: %v", err)
+	}
+	if got := strings.Join(callOrder, ","); got != "known_hosts,launch" {
+		t.Fatalf("unexpected call order: %s", got)
+	}
+}
+
+func TestLaunchVSCodeReturnsKnownHostError(t *testing.T) {
+	prevEnsure := ensureLocalSSHDKnownHostFunc
+	prevExec := vscodeExecCommand
+	t.Cleanup(func() {
+		ensureLocalSSHDKnownHostFunc = prevEnsure
+		vscodeExecCommand = prevExec
+	})
+
+	ensureLocalSSHDKnownHostFunc = func(common.Context, common.OpenResult) error {
+		return errors.New("known host failed")
+	}
+	vscodeExecCommand = func(name string, args ...string) *exec.Cmd {
+		t.Fatal("did not expect VS Code launch when known_hosts update fails")
+		return nil
+	}
+
+	err := launchVSCode(common.Context{}, common.OpenResult{})
+	if err == nil || err.Error() != "known host failed" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureLocalSSHDKnownHostDryRunTracesKeyscan(t *testing.T) {
+	stderr := new(bytes.Buffer)
+	err := ensureLocalSSHDKnownHost(common.Context{
+		Logger: common.NewLoggerWithWriters(2, stderr, stderr),
+		Stderr: stderr,
+		DryRun: true,
+	}, common.OpenResult{
+		Tenant:      "tenant-a",
+		Environment: "remote",
+		TenantConfig: common.TenantConfig{
+			Name:   "tenant-a",
+			Remote: true,
+		},
+		EnvConfig: common.EnvConfig{
+			Name:     "remote",
+			Remote:   true,
+			RepoPath: "/home/erun/git/tenant-a",
+			SSHD: common.SSHDConfig{
+				Enabled:   true,
+				LocalPort: 62222,
+			},
+		},
+		RepoPath: "/home/erun/git/tenant-a",
+	})
+	if err != nil {
+		t.Fatalf("ensureLocalSSHDKnownHost failed: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "ssh-keyscan -p 62222 127.0.0.1") {
+		t.Fatalf("expected dry-run trace to contain ssh-keyscan, got:\n%s", stderr.String())
+	}
+}

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -70,8 +70,9 @@ func Execute() error {
 		resolveRuntimeDeploySpec,
 		deployHelmChart,
 		activateSSHD,
+		launchVSCode,
 	)
-	sshdCmd := newSSHDCmd(resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, deployHelmChart, common.RunRemoteCommand)
+	sshdCmd := newSSHDCmd(resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, deployHelmChart, common.RunRemoteCommand, writeLocalSSHConfig)
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
@@ -116,7 +117,7 @@ func Execute() error {
 		if initRan {
 			return nil
 		}
-		return runResolvedOpenCommand(ctx, result, openOptions{}, runPrompt, newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell), runManagedDeploy, common.CheckKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart, activateSSHD)
+		return runResolvedOpenCommand(ctx, result, openOptions{}, runPrompt, newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell), runManagedDeploy, common.CheckKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart, activateSSHD, launchVSCode)
 	}
 
 	cmd := newRootCommand(runRoot)

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -32,6 +32,7 @@ type testRootDeps struct {
 	LaunchShell                    common.ShellLauncherFunc
 	WaitForRemoteRuntime           common.RemoteRuntimeWaitFunc
 	RunRemoteCommand               common.RemoteCommandRunnerFunc
+	LaunchVSCode                   VSCodeLauncher
 	Now                            common.NowFunc
 }
 
@@ -125,6 +126,10 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 		return resolveRuntimeDeploySpecForOpen(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, currentBuildInfo(), target)
 	}
 	activateSSHD := newSSHDActivator(deps.RunRemoteCommand)
+	launchVSCodeCmd := deps.LaunchVSCode
+	if launchVSCodeCmd == nil {
+		launchVSCodeCmd = launchVSCode
+	}
 	push := newPushOperation(pushDockerImage, loginToDockerRegistry, selectRunner)
 	runManagedDeploy := func(ctx common.Context, target common.OpenResult) error {
 		specs, err := common.ResolveCurrentDeploySpecs(
@@ -155,8 +160,8 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	runInitForOpen := newRunInitForOpen(store, runInit)
 
 	initCmd := newInitCmd(runInit)
-	openCmd := newOpenCmd(resolveOpen, store.SaveTenantConfig, runInitForOpen, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart, activateSSHD)
-	sshdCmd := newSSHDCmd(resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, openDeployHelmChart, deps.RunRemoteCommand)
+	openCmd := newOpenCmd(resolveOpen, store.SaveTenantConfig, runInitForOpen, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart, activateSSHD, launchVSCodeCmd)
+	sshdCmd := newSSHDCmd(resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, openDeployHelmChart, deps.RunRemoteCommand, writeLocalSSHConfig)
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
@@ -201,7 +206,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 		if initRan {
 			return nil
 		}
-		return runResolvedOpenCommand(ctx, result, openOptions{}, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart, activateSSHD)
+		return runResolvedOpenCommand(ctx, result, openOptions{}, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart, activateSSHD, launchVSCodeCmd)
 	}
 
 	cmd := newRootCommand(runRoot)

--- a/erun-cli/cmd/sshd.go
+++ b/erun-cli/cmd/sshd.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newSSHDCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), saveEnvConfig func(string, common.EnvConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, runRemoteCommand common.RemoteCommandRunnerFunc) *cobra.Command {
+func newSSHDCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), saveEnvConfig func(string, common.EnvConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, runRemoteCommand common.RemoteCommandRunnerFunc, writeLocalConfig SSHDLocalConfigWriter) *cobra.Command {
 	var publicKeyPath string
 	var localPort int
 	target := common.OpenParams{}
@@ -27,7 +27,7 @@ func newSSHDCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), 
 			if err != nil {
 				return err
 			}
-			return runSSHDInitCommand(ctx, result, publicKeyPath, localPort, saveEnvConfig, resolveRuntimeDeploySpec, deployHelmChart, runRemoteCommand)
+			return runSSHDInitCommand(ctx, result, publicKeyPath, localPort, saveEnvConfig, resolveRuntimeDeploySpec, deployHelmChart, runRemoteCommand, writeLocalConfig)
 		},
 	}
 	addDryRunFlag(initCmd)
@@ -39,7 +39,7 @@ func newSSHDCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), 
 	return newCommandGroup("sshd", "Remote SSH utilities", initCmd)
 }
 
-func runSSHDInitCommand(ctx common.Context, result common.OpenResult, publicKeyPath string, localPort int, saveEnvConfig func(string, common.EnvConfig) error, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, runRemoteCommand common.RemoteCommandRunnerFunc) error {
+func runSSHDInitCommand(ctx common.Context, result common.OpenResult, publicKeyPath string, localPort int, saveEnvConfig func(string, common.EnvConfig) error, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, runRemoteCommand common.RemoteCommandRunnerFunc, writeLocalConfig SSHDLocalConfigWriter) error {
 	if err := common.ValidateSSHDTarget(result); err != nil {
 		return err
 	}
@@ -88,13 +88,29 @@ func runSSHDInitCommand(ctx common.Context, result common.OpenResult, publicKeyP
 		return err
 	}
 
+	localConfig := SSHDLocalConfigResult{}
+	if writeLocalConfig != nil {
+		if ctx.DryRun {
+			info := common.SSHConnectionInfoForResult(result)
+			ctx.Trace(fmt.Sprintf("write ssh config host %s for %s/%s", info.HostAlias, result.Tenant, result.Environment))
+		} else {
+			configResult, err := writeLocalConfig(result)
+			if err != nil {
+				return err
+			}
+			localConfig = configResult
+		}
+	}
+
 	if ctx.Stdout != nil {
 		info := common.SSHConnectionInfoForResult(result)
 		if _, err := fmt.Fprintf(
 			ctx.Stdout,
-			"SSHD enabled for %s/%s\n  user: %s\n  local port: %d\n  workspace: %s\n",
+			"SSHD enabled for %s/%s\n  host: %s\n  config: %s\n  user: %s\n  local port: %d\n  workspace: %s\n",
 			result.Tenant,
 			result.Environment,
+			valueOrNone(localConfig.HostAlias),
+			valueOrNone(localConfig.ConfigPath),
 			info.User,
 			info.Port,
 			info.WorkspacePath,

--- a/erun-cli/cmd/sshd_activation.go
+++ b/erun-cli/cmd/sshd_activation.go
@@ -95,8 +95,9 @@ func emitSSHDConnectionInfo(ctx common.Context, info common.SSHConnectionInfo) e
 	}
 	_, err := fmt.Fprintf(
 		ctx.Stdout,
-		"SSH:\n  host: %s\n  port: %d\n  user: %s\n  workspace: %s\n",
+		"SSH:\n  host: %s\n  alias: %s\n  port: %d\n  user: %s\n  workspace: %s\n",
 		info.Host,
+		info.HostAlias,
 		info.Port,
 		info.User,
 		info.WorkspacePath,

--- a/erun-cli/cmd/sshd_local_config.go
+++ b/erun-cli/cmd/sshd_local_config.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+
+	common "github.com/sophium/erun/erun-common"
+	sshconfig "github.com/sophium/erun/internal/sshconfig"
+)
+
+type SSHDLocalConfigResult struct {
+	HostAlias  string
+	ConfigPath string
+}
+
+type SSHDLocalConfigWriter func(common.OpenResult) (SSHDLocalConfigResult, error)
+
+func writeLocalSSHConfig(result common.OpenResult) (SSHDLocalConfigResult, error) {
+	info := common.SSHConnectionInfoForResult(result)
+	path, err := sshconfig.UpsertDefaultConfig(sshconfig.HostEntry{
+		Alias:        info.HostAlias,
+		HostKeyAlias: info.HostAlias,
+		HostName:     info.Host,
+		Port:         info.Port,
+		User:         info.User,
+		IdentityFile: common.SSHPrivateKeyPath(result.EnvConfig.SSHD.PublicKeyPath),
+	})
+	if err != nil {
+		return SSHDLocalConfigResult{}, fmt.Errorf("write local ssh config: %w", err)
+	}
+	return SSHDLocalConfigResult{
+		HostAlias:  info.HostAlias,
+		ConfigPath: path,
+	}, nil
+}

--- a/erun-cli/cmd/sshd_test.go
+++ b/erun-cli/cmd/sshd_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestRunSSHDInitCommandPersistsConfigAndDeploysRuntime(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
 	publicKeyPath := filepath.Join(t.TempDir(), "id_ed25519.pub")
 	if err := os.WriteFile(publicKeyPath, []byte("ssh-ed25519 AAAATEST user@example\n"), 0o644); err != nil {
 		t.Fatalf("write public key: %v", err)
@@ -76,6 +79,7 @@ func TestRunSSHDInitCommandPersistsConfigAndDeploysRuntime(t *testing.T) {
 			remoteScript = script
 			return common.RemoteCommandResult{}, nil
 		},
+		writeLocalSSHConfig,
 	)
 	if err != nil {
 		t.Fatalf("runSSHDInitCommand failed: %v", err)
@@ -92,5 +96,30 @@ func TestRunSSHDInitCommandPersistsConfigAndDeploysRuntime(t *testing.T) {
 	}
 	if !strings.Contains(remoteScript, "authorized_keys") || !strings.Contains(remoteScript, "ssh-ed25519 AAAATEST user@example") {
 		t.Fatalf("unexpected remote authorized_keys script:\n%s", remoteScript)
+	}
+	sshConfigData, err := os.ReadFile(filepath.Join(homeDir, ".ssh", "config"))
+	if err != nil {
+		t.Fatalf("read ssh config: %v", err)
+	}
+	for _, want := range []string{
+		"Host erun-tenant-a-dev",
+		"HostName 127.0.0.1",
+		"Port 64022",
+		"User erun",
+		"HostKeyAlias erun-tenant-a-dev",
+		"IdentityFile " + strings.TrimSuffix(publicKeyPath, ".pub"),
+	} {
+		if !strings.Contains(string(sshConfigData), want) {
+			t.Fatalf("expected ssh config to contain %q, got:\n%s", want, sshConfigData)
+		}
+	}
+	stdout := ctx.Stdout.(*bytes.Buffer).String()
+	for _, want := range []string{
+		"host: erun-tenant-a-dev",
+		"config: " + filepath.Join(homeDir, ".ssh", "config"),
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected stdout to contain %q, got:\n%s", want, stdout)
+		}
 	}
 }

--- a/erun-cli/internal/sshconfig/sshconfig.go
+++ b/erun-cli/internal/sshconfig/sshconfig.go
@@ -1,0 +1,146 @@
+package sshconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var userHomeDir = os.UserHomeDir
+
+type HostEntry struct {
+	Alias        string
+	HostKeyAlias string
+	HostName     string
+	Port         int
+	User         string
+	IdentityFile string
+}
+
+func DefaultConfigPath() (string, error) {
+	homeDir, err := userHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".ssh", "config"), nil
+}
+
+func UpsertDefaultConfig(entry HostEntry) (string, error) {
+	path, err := DefaultConfigPath()
+	if err != nil {
+		return "", err
+	}
+	return path, UpsertConfig(path, entry)
+}
+
+func UpsertConfig(path string, entry HostEntry) error {
+	path = filepath.Clean(strings.TrimSpace(path))
+	if path == "" {
+		return fmt.Errorf("ssh config path is required")
+	}
+	if strings.TrimSpace(entry.Alias) == "" {
+		return fmt.Errorf("ssh host alias is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	updated := UpsertConfigContent(string(data), entry)
+	return os.WriteFile(path, []byte(updated), 0o600)
+}
+
+func UpsertConfigContent(existing string, entry HostEntry) string {
+	lines := splitConfigLines(existing)
+	replaced := false
+	updated := make([]string, 0, len(lines)+8)
+
+	for i := 0; i < len(lines); {
+		if hostLineHasAlias(lines[i], entry.Alias) {
+			if !replaced {
+				updated = appendEntryLines(updated, entry)
+				replaced = true
+			}
+			i++
+			for i < len(lines) && !isHostDirective(lines[i]) {
+				i++
+			}
+			if i < len(lines) && len(updated) > 0 && strings.TrimSpace(updated[len(updated)-1]) != "" {
+				updated = append(updated, "")
+			}
+			continue
+		}
+		updated = append(updated, lines[i])
+		i++
+	}
+
+	if !replaced {
+		if len(updated) > 0 && strings.TrimSpace(updated[len(updated)-1]) != "" {
+			updated = append(updated, "")
+		}
+		updated = appendEntryLines(updated, entry)
+	}
+
+	return strings.TrimRight(strings.Join(trimTrailingBlankLines(updated), "\n"), "\n") + "\n"
+}
+
+func RenderEntry(entry HostEntry) string {
+	lines := []string{
+		"Host " + entry.Alias,
+		"  HostName " + entry.HostName,
+		fmt.Sprintf("  Port %d", entry.Port),
+		"  User " + entry.User,
+	}
+	if strings.TrimSpace(entry.HostKeyAlias) != "" {
+		lines = append(lines, "  HostKeyAlias "+entry.HostKeyAlias)
+	}
+	if strings.TrimSpace(entry.IdentityFile) != "" {
+		lines = append(lines, "  IdentityFile "+entry.IdentityFile)
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func appendEntryLines(lines []string, entry HostEntry) []string {
+	return append(lines, splitConfigLines(RenderEntry(entry))...)
+}
+
+func splitConfigLines(content string) []string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.TrimRight(content, "\n")
+	if content == "" {
+		return nil
+	}
+	return strings.Split(content, "\n")
+}
+
+func trimTrailingBlankLines(lines []string) []string {
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+func isHostDirective(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "Host ")
+}
+
+func hostLineHasAlias(line, alias string) bool {
+	if !isHostDirective(line) {
+		return false
+	}
+	fields := strings.Fields(strings.TrimSpace(line))
+	if len(fields) < 2 {
+		return false
+	}
+	for _, field := range fields[1:] {
+		if field == alias {
+			return true
+		}
+	}
+	return false
+}

--- a/erun-cli/internal/sshconfig/sshconfig_test.go
+++ b/erun-cli/internal/sshconfig/sshconfig_test.go
@@ -1,0 +1,84 @@
+package sshconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpsertConfigContentAddsEntry(t *testing.T) {
+	got := UpsertConfigContent("", HostEntry{
+		Alias:        "erun-tenant-a-remote",
+		HostKeyAlias: "erun-tenant-a-remote",
+		HostName:     "127.0.0.1",
+		Port:         62222,
+		User:         "erun",
+		IdentityFile: "/tmp/id_ed25519",
+	})
+
+	for _, want := range []string{
+		"Host erun-tenant-a-remote",
+		"HostName 127.0.0.1",
+		"Port 62222",
+		"User erun",
+		"HostKeyAlias erun-tenant-a-remote",
+		"IdentityFile /tmp/id_ed25519",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected config to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestUpsertConfigContentReplacesExistingHostBlock(t *testing.T) {
+	existing := "Host github.com\n  HostName github.com\n\nHost erun-tenant-a-remote\n  HostName old\n  Port 22\n\nHost other\n  HostName other\n"
+	got := UpsertConfigContent(existing, HostEntry{
+		Alias:        "erun-tenant-a-remote",
+		HostKeyAlias: "erun-tenant-a-remote",
+		HostName:     "127.0.0.1",
+		Port:         62222,
+		User:         "erun",
+	})
+
+	if strings.Contains(got, "HostName old") {
+		t.Fatalf("expected old host block to be replaced, got:\n%s", got)
+	}
+	for _, want := range []string{
+		"Host github.com",
+		"Host other",
+		"Host erun-tenant-a-remote",
+		"HostName 127.0.0.1",
+		"Port 62222",
+		"User erun",
+		"HostKeyAlias erun-tenant-a-remote",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected config to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestUpsertDefaultConfigUsesUserHomeDir(t *testing.T) {
+	homeDir := t.TempDir()
+	prev := userHomeDir
+	userHomeDir = func() (string, error) { return homeDir, nil }
+	t.Cleanup(func() { userHomeDir = prev })
+
+	path, err := UpsertDefaultConfig(HostEntry{
+		Alias:        "erun-tenant-a-remote",
+		HostKeyAlias: "erun-tenant-a-remote",
+		HostName:     "127.0.0.1",
+		Port:         62222,
+		User:         "erun",
+	})
+	if err != nil {
+		t.Fatalf("UpsertDefaultConfig failed: %v", err)
+	}
+	if path != filepath.Join(homeDir, ".ssh", "config") {
+		t.Fatalf("unexpected config path: %q", path)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected ssh config to be written: %v", err)
+	}
+}

--- a/erun-cli/internal/sshknownhosts/sshknownhosts.go
+++ b/erun-cli/internal/sshknownhosts/sshknownhosts.go
@@ -1,0 +1,124 @@
+package sshknownhosts
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+var userHomeDir = os.UserHomeDir
+
+func DefaultKnownHostsPath() (string, error) {
+	homeDir, err := userHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".ssh", "known_hosts"), nil
+}
+
+func UpsertDefaultKnownHost(alias, host string, port int) (string, error) {
+	path, err := DefaultKnownHostsPath()
+	if err != nil {
+		return "", err
+	}
+	return path, UpsertKnownHost(path, alias, host, port)
+}
+
+func UpsertKnownHost(path, alias, host string, port int) error {
+	path = filepath.Clean(strings.TrimSpace(path))
+	alias = strings.TrimSpace(alias)
+	host = strings.TrimSpace(host)
+	if path == "" {
+		return fmt.Errorf("known_hosts path is required")
+	}
+	if alias == "" {
+		return fmt.Errorf("known_hosts alias is required")
+	}
+	if host == "" {
+		return fmt.Errorf("known_hosts host is required")
+	}
+	if port <= 0 {
+		return fmt.Errorf("known_hosts port is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	scannedLines, err := scanHostKeys(host, port)
+	if err != nil {
+		return err
+	}
+	updated := upsertKnownHostsContent(string(data), alias, hostPortToken(host, port), scannedLines)
+	return os.WriteFile(path, []byte(updated), 0o600)
+}
+
+func scanHostKeys(host string, port int) ([]string, error) {
+	cmd := exec.Command("ssh-keyscan", "-p", fmt.Sprintf("%d", port), host)
+	output := new(bytes.Buffer)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	err := cmd.Run()
+
+	lines := make([]string, 0, 3)
+	for _, line := range strings.Split(strings.ReplaceAll(output.String(), "\r\n", "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	if len(lines) == 0 {
+		if err != nil {
+			return nil, fmt.Errorf("scan ssh host key: %w: %s", err, strings.TrimSpace(output.String()))
+		}
+		return nil, fmt.Errorf("scan ssh host key: no host keys returned")
+	}
+	return lines, nil
+}
+
+func upsertKnownHostsContent(existing, alias, hostToken string, scannedLines []string) string {
+	lines := splitKnownHostsLines(existing)
+	filtered := make([]string, 0, len(lines)+(len(scannedLines)*2))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		first, _, _ := strings.Cut(trimmed, " ")
+		if first == alias || first == hostToken {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+
+	for _, line := range scannedLines {
+		_, rest, ok := strings.Cut(strings.TrimSpace(line), " ")
+		if !ok {
+			continue
+		}
+		filtered = append(filtered, hostToken+" "+rest)
+		filtered = append(filtered, alias+" "+rest)
+	}
+
+	return strings.TrimRight(strings.Join(filtered, "\n"), "\n") + "\n"
+}
+
+func splitKnownHostsLines(content string) []string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.TrimRight(content, "\n")
+	if content == "" {
+		return nil
+	}
+	return strings.Split(content, "\n")
+}
+
+func hostPortToken(host string, port int) string {
+	return fmt.Sprintf("[%s]:%d", strings.TrimSpace(host), port)
+}

--- a/erun-cli/internal/sshknownhosts/sshknownhosts_test.go
+++ b/erun-cli/internal/sshknownhosts/sshknownhosts_test.go
@@ -1,0 +1,94 @@
+package sshknownhosts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpsertKnownHostsContentReplacesAliasAndHostEntries(t *testing.T) {
+	existing := "github.com ssh-ed25519 AAAA\n[127.0.0.1]:62222 ssh-ed25519 OLD\nerun-tenant-a-remote ssh-ed25519 OLDALIAS\n"
+	got := upsertKnownHostsContent(existing, "erun-tenant-a-remote", "[127.0.0.1]:62222", []string{
+		"[127.0.0.1]:62222 ssh-ed25519 NEW",
+	})
+
+	if strings.Contains(got, "OLD") {
+		t.Fatalf("expected old host entry to be removed, got:\n%s", got)
+	}
+	for _, want := range []string{
+		"github.com ssh-ed25519 AAAA",
+		"[127.0.0.1]:62222 ssh-ed25519 NEW",
+		"erun-tenant-a-remote ssh-ed25519 NEW",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected known_hosts to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestUpsertDefaultKnownHostUsesUserHomeDir(t *testing.T) {
+	homeDir := t.TempDir()
+	binDir := t.TempDir()
+	prevHome := userHomeDir
+	userHomeDir = func() (string, error) { return homeDir, nil }
+	t.Cleanup(func() { userHomeDir = prevHome })
+
+	keyscanPath := filepath.Join(binDir, "ssh-keyscan")
+	if err := os.WriteFile(keyscanPath, []byte(`#!/bin/sh
+echo "[127.0.0.1]:62222 ssh-ed25519 AAAATEST"
+`), 0o755); err != nil {
+		t.Fatalf("write ssh-keyscan stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	path, err := UpsertDefaultKnownHost("erun-tenant-a-remote", "127.0.0.1", 62222)
+	if err != nil {
+		t.Fatalf("UpsertDefaultKnownHost failed: %v", err)
+	}
+	if path != filepath.Join(homeDir, ".ssh", "known_hosts") {
+		t.Fatalf("unexpected known_hosts path: %q", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read known_hosts: %v", err)
+	}
+	for _, want := range []string{
+		"[127.0.0.1]:62222 ssh-ed25519 AAAATEST",
+		"erun-tenant-a-remote ssh-ed25519 AAAATEST",
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("unexpected known_hosts content:\n%s", data)
+		}
+	}
+}
+
+func TestUpsertDefaultKnownHostAcceptsScannedKeyOnNonZeroExit(t *testing.T) {
+	homeDir := t.TempDir()
+	binDir := t.TempDir()
+	prevHome := userHomeDir
+	userHomeDir = func() (string, error) { return homeDir, nil }
+	t.Cleanup(func() { userHomeDir = prevHome })
+
+	keyscanPath := filepath.Join(binDir, "ssh-keyscan")
+	if err := os.WriteFile(keyscanPath, []byte(`#!/bin/sh
+echo "[127.0.0.1]:62222 ssh-ed25519 AAAATEST"
+echo "write (127.0.0.1): Broken pipe" >&2
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write ssh-keyscan stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	path, err := UpsertDefaultKnownHost("erun-tenant-a-remote", "127.0.0.1", 62222)
+	if err != nil {
+		t.Fatalf("UpsertDefaultKnownHost failed: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read known_hosts: %v", err)
+	}
+	if !strings.Contains(string(data), "erun-tenant-a-remote ssh-ed25519 AAAATEST") {
+		t.Fatalf("unexpected known_hosts content:\n%s", data)
+	}
+}

--- a/erun-common/list.go
+++ b/erun-common/list.go
@@ -62,6 +62,7 @@ type ListEnvironmentResult struct {
 
 type ListSSHResult struct {
 	Enabled       bool   `json:"enabled,omitempty"`
+	HostAlias     string `json:"hostAlias,omitempty"`
 	User          string `json:"user,omitempty"`
 	LocalPort     int    `json:"localPort,omitempty"`
 	WorkspacePath string `json:"workspacePath,omitempty"`
@@ -165,6 +166,7 @@ func listSSHResult(result OpenResult) ListSSHResult {
 	info := SSHConnectionInfoForResult(result)
 	return ListSSHResult{
 		Enabled:       true,
+		HostAlias:     info.HostAlias,
 		User:          info.User,
 		LocalPort:     info.Port,
 		WorkspacePath: info.WorkspacePath,

--- a/erun-common/list_test.go
+++ b/erun-common/list_test.go
@@ -309,6 +309,9 @@ func TestResolveListResultIncludesSSHDConfiguration(t *testing.T) {
 	if result.CurrentDirectory.Effective == nil || !result.CurrentDirectory.Effective.SSH.Enabled {
 		t.Fatalf("expected effective SSH details, got %+v", result.CurrentDirectory.Effective)
 	}
+	if result.CurrentDirectory.Effective.SSH.HostAlias != "erun-tenant-a-dev" {
+		t.Fatalf("unexpected effective SSH host alias: %+v", result.CurrentDirectory.Effective.SSH)
+	}
 	if result.CurrentDirectory.Effective.SSH.User != DefaultSSHUser || result.CurrentDirectory.Effective.SSH.LocalPort != DefaultSSHLocalPort {
 		t.Fatalf("unexpected effective SSH info: %+v", result.CurrentDirectory.Effective.SSH)
 	}

--- a/erun-common/sshd.go
+++ b/erun-common/sshd.go
@@ -2,6 +2,8 @@ package eruncommon
 
 import (
 	"fmt"
+	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -16,6 +18,7 @@ type SSHConnectionInfo struct {
 	Host          string
 	Port          int
 	WorkspacePath string
+	HostAlias     string
 }
 
 func SSHConnectionInfoForResult(result OpenResult) SSHConnectionInfo {
@@ -25,7 +28,46 @@ func SSHConnectionInfoForResult(result OpenResult) SSHConnectionInfo {
 		Host:          "127.0.0.1",
 		Port:          result.EnvConfig.SSHD.ResolvedLocalPort(),
 		WorkspacePath: RemoteShellWorktreePath(req),
+		HostAlias:     SSHHostAlias(result.Tenant, result.Environment),
 	}
+}
+
+var sshHostAliasSanitizer = regexp.MustCompile(`[^a-z0-9]+`)
+
+func SSHHostAlias(tenant, environment string) string {
+	parts := []string{"erun", sanitizeSSHHostAliasToken(tenant), sanitizeSSHHostAliasToken(environment)}
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			continue
+		}
+		filtered = append(filtered, part)
+	}
+	if len(filtered) == 0 {
+		return "erun"
+	}
+	return strings.Join(filtered, "-")
+}
+
+func SSHPrivateKeyPath(publicKeyPath string) string {
+	publicKeyPath = strings.TrimSpace(publicKeyPath)
+	if publicKeyPath == "" {
+		return ""
+	}
+	if strings.HasSuffix(publicKeyPath, ".pub") {
+		return strings.TrimSuffix(filepath.Clean(publicKeyPath), ".pub")
+	}
+	return ""
+}
+
+func sanitizeSSHHostAliasToken(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return ""
+	}
+	value = sshHostAliasSanitizer.ReplaceAllString(value, "-")
+	value = strings.Trim(value, "-")
+	return value
 }
 
 func ValidateSSHDTarget(result OpenResult) error {

--- a/erun-common/sshd_test.go
+++ b/erun-common/sshd_test.go
@@ -1,0 +1,44 @@
+package eruncommon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSSHHostAlias(t *testing.T) {
+	if got := SSHHostAlias("Tenant_A", "Remote Dev"); got != "erun-tenant-a-remote-dev" {
+		t.Fatalf("unexpected SSH host alias: %q", got)
+	}
+}
+
+func TestSSHPrivateKeyPath(t *testing.T) {
+	if got := SSHPrivateKeyPath("/tmp/id_ed25519.pub"); got != "/tmp/id_ed25519" {
+		t.Fatalf("unexpected private key path: %q", got)
+	}
+	if got := SSHPrivateKeyPath("/tmp/custom-key"); got != "" {
+		t.Fatalf("expected empty private key path, got %q", got)
+	}
+}
+
+func TestRuntimeDockerfileUnlocksSSHUserAccount(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "erun-devops", "docker", "erun-devops", "Dockerfile"))
+	if err != nil {
+		t.Fatalf("read runtime Dockerfile: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "passwd -d erun") {
+		t.Fatalf("expected runtime Dockerfile to unlock erun account for SSH public-key auth, got:\n%s", content)
+	}
+}
+
+func TestRuntimeEntrypointDisablesStrictModesForPVCBackedHome(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "erun-devops", "docker", "erun-devops", "entrypoint.sh"))
+	if err != nil {
+		t.Fatalf("read runtime entrypoint: %v", err)
+	}
+	if !strings.Contains(string(data), "StrictModes no") {
+		t.Fatalf("expected runtime entrypoint to disable sshd strict modes for PVC-backed home directory, got:\n%s", string(data))
+	}
+}

--- a/erun-devops/docker/erun-devops/Dockerfile
+++ b/erun-devops/docker/erun-devops/Dockerfile
@@ -86,6 +86,7 @@ RUN apt-get update && \
     rm -rf /tmp/helm.tar.gz /tmp/terraform.zip /tmp/k9s.tar.gz /tmp/difft.tar.gz /tmp/gh.tar.gz /tmp/golangci-lint.tar.gz /tmp/docker.tgz "/tmp/linux-${arch}" "/tmp/gh_${GH_VERSION}_linux_${arch}" "/tmp/golangci-lint-${GOLANGCI_LINT_VERSION#v}-linux-${arch}" /tmp/terraform /tmp/k9s /tmp/difft /tmp/docker && \
     groupmod -n erun ubuntu && \
     usermod -l erun -d /home/erun -m -g erun ubuntu && \
+    passwd -d erun && \
     mkdir -p /home/erun/git /home/erun/.kube /home/erun/.config/k9s /etc/erun /etc/bash_completion.d && \
     printf '\n[ -r /usr/share/bash-completion/bash_completion ] && . /usr/share/bash-completion/bash_completion\n[ -r /etc/bash_completion.d/erun ] && . /etc/bash_completion.d/erun\n[ -r /etc/erun/bash_prompt.sh ] && . /etc/erun/bash_prompt.sh\n' >> /etc/bash.bashrc && \
     chown -R erun:erun /home/erun && \

--- a/erun-devops/docker/erun-devops/entrypoint.sh
+++ b/erun-devops/docker/erun-devops/entrypoint.sh
@@ -154,6 +154,7 @@ PasswordAuthentication no
 KbdInteractiveAuthentication no
 ChallengeResponseAuthentication no
 PubkeyAuthentication yes
+StrictModes no
 PermitRootLogin no
 UsePAM no
 PidFile ${pid_file}


### PR DESCRIPTION
## Summary
- generate reusable SSH config and known_hosts entries for sshd-enabled remote envs
- add `erun open --vscode` so remote envs can launch directly into VS Code over SSH
- harden the runtime SSH setup so public-key auth works inside the remote pod

Closes #83