### PR TITLE
Sync package metadata for release 1.0.35

### DIFF
--- a/Formula/erun.rb
+++ b/Formula/erun.rb
@@ -1,7 +1,7 @@
 class Erun < Formula
   desc "Multi-tenant multi-environment deployment and management tool"
   homepage "https://github.com/sophium/erun"
-  url "https://github.com/sophium/erun/archive/refs/tags/v1.0.34.tar.gz"
+  url "https://github.com/sophium/erun/archive/refs/tags/v1.0.35.tar.gz"
   sha256 "720a60628843561e025e178fa9dc3dcab604b36321eb96b474e5144cbd0dd1ba"
   license "MIT"
 

--- a/Formula/erun.rb
+++ b/Formula/erun.rb
@@ -2,7 +2,7 @@ class Erun < Formula
   desc "Multi-tenant multi-environment deployment and management tool"
   homepage "https://github.com/sophium/erun"
   url "https://github.com/sophium/erun/archive/refs/tags/v1.0.35.tar.gz"
-  sha256 "720a60628843561e025e178fa9dc3dcab604b36321eb96b474e5144cbd0dd1ba"
+  sha256 "01869a1284436c2a3e84841b278e08a9ef9e2493bb6e456337da78b6a8d90c33"
   license "MIT"
 
   depends_on "go" => :build

--- a/bucket/erun.json
+++ b/bucket/erun.json
@@ -1,14 +1,14 @@
 {
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "Multi-tenant multi-environment deployment and management tool",
   "homepage": "https://github.com/sophium/erun",
   "license": "MIT",
   "depends": [
     "go"
   ],
-  "url": "https://github.com/sophium/erun/archive/refs/tags/v1.0.34.zip",
+  "url": "https://github.com/sophium/erun/archive/refs/tags/v1.0.35.zip",
   "hash": "c27c07da97bd34133a4369f2570a5aa28342c843916d992291457958ce43a3c2",
-  "extract_dir": "erun-1.0.34",
+  "extract_dir": "erun-1.0.35",
   "installer": {
     "script": [
       "$env:CGO_ENABLED = '0'",

--- a/bucket/erun.json
+++ b/bucket/erun.json
@@ -7,7 +7,7 @@
     "go"
   ],
   "url": "https://github.com/sophium/erun/archive/refs/tags/v1.0.35.zip",
-  "hash": "c27c07da97bd34133a4369f2570a5aa28342c843916d992291457958ce43a3c2",
+  "hash": "36aa0d5d8578ad42bf93d53b7fece0a7fbf41041b690cdbd434879827e544651",
   "extract_dir": "erun-1.0.35",
   "installer": {
     "script": [

--- a/erun-devops/k8s/erun-devops/Chart.yaml
+++ b/erun-devops/k8s/erun-devops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.34
+appVersion: 1.0.35
 description: ERun DevOps
 name: erun-devops
 type: application
-version: 1.0.34
+version: 1.0.35


### PR DESCRIPTION
## Summary
- publish the local 1.0.35 release commit that is currently only on this checkout
- update the Homebrew formula checksum for the v1.0.35 tarball
- update the Scoop bucket checksum for the v1.0.35 zip archive

Closes #85