### PR TITLE
Persist desktop maximized window state

### DIFF
--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -29,6 +29,8 @@ type erunUIDeps struct {
 	resolveCLIPath  func() string
 	startTerminal   func(startTerminalSessionParams) (terminalSession, error)
 	savePastedImage func(pastedImageSaveParams) (string, error)
+	windowStatePath string
+	windowMaximised func(context.Context) bool
 }
 
 type App struct {
@@ -109,6 +111,12 @@ func NewApp(deps erunUIDeps) *App {
 	if deps.savePastedImage == nil {
 		deps.savePastedImage = savePastedImageToRuntime
 	}
+	if deps.windowStatePath == "" {
+		deps.windowStatePath = defaultAppWindowStatePath()
+	}
+	if deps.windowMaximised == nil {
+		deps.windowMaximised = runtime.WindowIsMaximised
+	}
 	return &App{
 		deps:     deps,
 		sessions: make(map[string]*managedTerminal),
@@ -124,6 +132,13 @@ func (a *App) shutdown(context.Context) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.closeAllSessionsLocked()
+}
+
+func (a *App) beforeClose(ctx context.Context) bool {
+	_ = saveAppWindowState(a.deps.windowStatePath, appWindowState{
+		Maximised: a.deps.windowMaximised(ctx),
+	})
+	return false
 }
 
 func (a *App) LoadState() (uiState, error) {

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -237,6 +237,38 @@ func TestSavePastedImageCopiesIntoCurrentRuntime(t *testing.T) {
 	}
 }
 
+func TestBeforeClosePersistsMaximisedWindowState(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "window-state.json")
+	app := NewApp(erunUIDeps{
+		windowStatePath: statePath,
+		windowMaximised: func(context.Context) bool {
+			return true
+		},
+	})
+
+	if prevent := app.beforeClose(context.Background()); prevent {
+		t.Fatal("beforeClose should not prevent shutdown")
+	}
+
+	state := loadAppWindowState(statePath)
+	if !state.Maximised {
+		t.Fatalf("expected maximised state to be persisted: %+v", state)
+	}
+}
+
+func TestSaveAndLoadAppWindowState(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "nested", "window-state.json")
+
+	if err := saveAppWindowState(statePath, appWindowState{Maximised: true}); err != nil {
+		t.Fatalf("saveAppWindowState failed: %v", err)
+	}
+
+	state := loadAppWindowState(statePath)
+	if !state.Maximised {
+		t.Fatalf("unexpected loaded window state: %+v", state)
+	}
+}
+
 func TestDecodePastedImagePayloadAcceptsDataURL(t *testing.T) {
 	imageData := []byte("png-data")
 	got, mimeType, err := decodePastedImagePayload(pastedImagePayload{

--- a/erun-ui/app_window_state.go
+++ b/erun-ui/app_window_state.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+const appWindowStateFileName = "window-state.json"
+
+type appWindowState struct {
+	Maximised bool `json:"maximised"`
+}
+
+func defaultAppWindowStatePath() string {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(configDir, "ERun", appWindowStateFileName)
+}
+
+func loadAppWindowState(path string) appWindowState {
+	if path == "" {
+		return appWindowState{}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return appWindowState{}
+	}
+
+	var state appWindowState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return appWindowState{}
+	}
+	return state
+}
+
+func saveAppWindowState(path string, state appWindowState) error {
+	if path == "" {
+		return nil
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/erun-ui/main.go
+++ b/erun-ui/main.go
@@ -4,11 +4,11 @@ import (
 	"embed"
 	"log"
 
+	eruncommon "github.com/sophium/erun/erun-common"
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
-	eruncommon "github.com/sophium/erun/erun-common"
 )
 
 //go:embed all:frontend/dist
@@ -17,23 +17,32 @@ var assets embed.FS
 func main() {
 	setAppIdentity("ERun")
 
+	windowStatePath := defaultAppWindowStatePath()
+	windowStartState := options.Normal
+	if loadAppWindowState(windowStatePath).Maximised {
+		windowStartState = options.Maximised
+	}
+
 	app := NewApp(erunUIDeps{
 		store:           eruncommon.ConfigStore{},
 		findProjectRoot: eruncommon.FindProjectRoot,
 		resolveCLIPath:  resolveCLIExecutable,
+		windowStatePath: windowStatePath,
 	})
 
 	err := wails.Run(&options.App{
-		Title:     "ERun",
-		Width:     1320,
-		Height:    860,
-		MinWidth:  960,
-		MinHeight: 640,
+		Title:            "ERun",
+		Width:            1320,
+		Height:           860,
+		MinWidth:         960,
+		MinHeight:        640,
+		WindowStartState: windowStartState,
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},
 		BackgroundColour: options.NewRGB(245, 245, 247),
 		OnStartup:        app.startup,
+		OnBeforeClose:    app.beforeClose,
 		OnShutdown:       app.shutdown,
 		Mac: &mac.Options{
 			TitleBar: mac.TitleBarHiddenInset(),


### PR DESCRIPTION
## Summary
- persist whether the desktop window is maximized during Wails shutdown
- restore the Wails window start state from the saved desktop config
- cover save/load and before-close persistence behavior

## Validation
- go test ./...
- ./build.sh (fails locally: pkg-config is not installed, required by github.com/wailsapp/wails/v2/pkg/assetserver/webview)

Closes #115