### PR TITLE
Ignore local Codex workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ profile.cov
 # Editor/IDE
 # .idea/
 # .vscode/
+/.codex
 
 # Delve debug binaries
 __debug_bin*


### PR DESCRIPTION
Closes #118

## Summary
- Ignore the local .codex workspace directory so agent-local files do not appear as repository changes.

## Validation
- git diff --check