### PR TITLE
Add traced raw exec command

### DIFF
--- a/erun-cli/cmd/exec.go
+++ b/erun-cli/cmd/exec.go
@@ -5,11 +5,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newExecCmd(findProjectRoot common.ProjectFinderFunc, runGit common.GitCommandRunnerFunc) *cobra.Command {
+func newExecCmd(findProjectRoot common.ProjectFinderFunc, runGit common.GitCommandRunnerFunc, runRaw common.RawCommandRunnerFunc) *cobra.Command {
 	return newCommandGroup(
 		"exec",
 		"Repository execution utilities",
 		newExecDiffCmd(findProjectRoot, runGit),
+		newExecRawCmd(findProjectRoot, runRaw),
 	)
 }
 
@@ -26,6 +27,20 @@ func newExecDiffCmd(findProjectRoot common.ProjectFinderFunc, runGit common.GitC
 	return cmd
 }
 
+func newExecRawCmd(findProjectRoot common.ProjectFinderFunc, runRaw common.RawCommandRunnerFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "raw COMMAND [ARG...]",
+		Short:              "Run a raw command from the project root",
+		Args:               cobra.MinimumNArgs(1),
+		SilenceUsage:       true,
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExecRawCommand(commandContext(cmd), findProjectRoot, runRaw, args)
+		},
+	}
+	return cmd
+}
+
 func runExecDiffCommand(ctx common.Context, findProjectRoot common.ProjectFinderFunc, runGit common.GitCommandRunnerFunc) error {
 	if findProjectRoot == nil {
 		findProjectRoot = common.FindProjectRoot
@@ -34,9 +49,24 @@ func runExecDiffCommand(ctx common.Context, findProjectRoot common.ProjectFinder
 	if err != nil {
 		return err
 	}
+	ctx.TraceCommand(projectRoot, "git", "diff", "--no-color", "--no-ext-diff")
 	result, err := common.ResolveGitDiff(projectRoot, runGit)
 	if err != nil {
 		return err
 	}
 	return common.WriteRawDiff(ctx.Stdout, result)
+}
+
+func runExecRawCommand(ctx common.Context, findProjectRoot common.ProjectFinderFunc, runRaw common.RawCommandRunnerFunc, args []string) error {
+	if findProjectRoot == nil {
+		findProjectRoot = common.FindProjectRoot
+	}
+	_, projectRoot, err := findProjectRoot()
+	if err != nil {
+		return err
+	}
+	return common.RunRawCommand(ctx, common.RawCommandSpec{
+		Dir:  projectRoot,
+		Args: args,
+	}, runRaw)
 }

--- a/erun-cli/cmd/exec_test.go
+++ b/erun-cli/cmd/exec_test.go
@@ -37,8 +37,50 @@ func TestExecDiffPrintsRawGitDiff(t *testing.T) {
 	if stdout.String() != "diff --git a/a.txt b/a.txt\n" {
 		t.Fatalf("unexpected stdout: %q", stdout.String())
 	}
-	if stderr.String() != "" {
-		t.Fatalf("unexpected stderr: %q", stderr.String())
+	for _, want := range []string{
+		"audit: erun exec diff",
+		"cd /tmp/project && git diff --no-color --no-ext-diff",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("expected stderr to contain %q, got %q", want, stderr.String())
+		}
+	}
+}
+
+func TestExecRawRunsCommandFromProjectRootWithDefaultTrace(t *testing.T) {
+	var gotDir string
+	var gotName string
+	var gotArgs []string
+	cmd := newTestRootCmd(testRootDeps{
+		FindProjectRoot: func() (string, string, error) {
+			return "project", "/tmp/project", nil
+		},
+		RunRawCommand: func(dir, name string, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+			gotDir = dir
+			gotName = name
+			gotArgs = append([]string(nil), args...)
+			_, _ = io.WriteString(stdout, "ok\n")
+			return nil
+		},
+	})
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"exec", "raw", "echo", "--token", "secret-value", "done"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if gotDir != "/tmp/project" || gotName != "echo" || strings.Join(gotArgs, " ") != "--token secret-value done" {
+		t.Fatalf("unexpected raw command call: dir=%q name=%q args=%+v", gotDir, gotName, gotArgs)
+	}
+	if stdout.String() != "ok\n" {
+		t.Fatalf("unexpected stdout: %q", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "audit: erun exec raw echo --token <redacted> done") || !strings.Contains(got, "cd /tmp/project && echo --token '<redacted>' done") {
+		t.Fatalf("unexpected stderr: %q", got)
 	}
 }
 

--- a/erun-cli/cmd/feedback_render.go
+++ b/erun-cli/cmd/feedback_render.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	common "github.com/sophium/erun/erun-common"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 const (
@@ -39,6 +41,9 @@ func commandVerbosity(cmd *cobra.Command) int {
 	if err != nil {
 		return 0
 	}
+	if verbosity == 0 && isExecCommand(cmd) {
+		return 1
+	}
 	return verbosity
 }
 
@@ -54,6 +59,77 @@ func commandContext(cmd *cobra.Command) common.Context {
 		Stdout: cmd.OutOrStdout(),
 		Stderr: cmd.ErrOrStderr(),
 	}
+}
+
+func auditCommand(cmd *cobra.Command, args []string) {
+	ctx := commandContext(cmd)
+	ctx.Trace("audit: " + formatAuditCommand(cmd, args))
+}
+
+func formatAuditCommand(cmd *cobra.Command, args []string) string {
+	parts := strings.Fields(cmd.CommandPath())
+	if len(parts) == 0 {
+		parts = []string{"erun"}
+	}
+	parts = append(parts, changedFlagArgs(cmd)...)
+	parts = append(parts, args...)
+	return strings.Join(redactAuditArgs(parts), " ")
+}
+
+func changedFlagArgs(cmd *cobra.Command) []string {
+	args := make([]string, 0)
+	cmd.Flags().Visit(func(flag *pflag.Flag) {
+		if flag.Name == "help" || flag.Name == "verbose" {
+			return
+		}
+		name := "--" + flag.Name
+		if flag.Value.Type() == "bool" {
+			args = append(args, name)
+			return
+		}
+		args = append(args, name, flag.Value.String())
+	})
+	return args
+}
+
+func redactAuditArgs(args []string) []string {
+	redacted := make([]string, 0, len(args))
+	redactNext := false
+	for _, arg := range args {
+		if redactNext {
+			redacted = append(redacted, "<redacted>")
+			redactNext = false
+			continue
+		}
+		if name, _, ok := strings.Cut(arg, "="); ok && isSensitiveName(name) {
+			redacted = append(redacted, name+"=<redacted>")
+			continue
+		}
+		redacted = append(redacted, arg)
+		if isSensitiveName(arg) {
+			redactNext = true
+		}
+	}
+	return redacted
+}
+
+func isSensitiveName(value string) bool {
+	normalized := strings.ToLower(strings.TrimLeft(value, "-"))
+	for _, token := range []string{"password", "passwd", "secret", "token", "apikey", "api-key", "access-key", "private-key"} {
+		if strings.Contains(normalized, token) {
+			return true
+		}
+	}
+	return false
+}
+
+func isExecCommand(cmd *cobra.Command) bool {
+	for current := cmd; current != nil; current = current.Parent() {
+		if current.Name() == "exec" {
+			return true
+		}
+	}
+	return false
 }
 
 func wrapCommandTreeWithElapsedTime(cmd *cobra.Command) {

--- a/erun-cli/cmd/feedback_render_test.go
+++ b/erun-cli/cmd/feedback_render_test.go
@@ -37,6 +37,74 @@ func TestCommandContextEnablesTraceDuringDryRunWithoutVerboseFlag(t *testing.T) 
 	}
 }
 
+func TestRootCommandAuditsOnlyWhenTraceEnabled(t *testing.T) {
+	cmd := newRootCommand(func(_ *cobra.Command, _ []string) error {
+		return nil
+	})
+	stderr := new(bytes.Buffer)
+	cmd.SetErr(stderr)
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("expected no audit without trace, got %q", got)
+	}
+
+	cmd = newRootCommand(func(_ *cobra.Command, _ []string) error {
+		return nil
+	})
+	stderr = new(bytes.Buffer)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"-v"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if got := stderr.String(); got != "audit: erun\n" {
+		t.Fatalf("unexpected audit output: %q", got)
+	}
+}
+
+func TestExecCommandEnablesTraceByDefault(t *testing.T) {
+	root := newRootCommand(func(_ *cobra.Command, _ []string) error {
+		return nil
+	})
+	execCmd := newCommandGroup("exec", "Repository execution utilities", &cobra.Command{
+		Use: "noop",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			commandContext(cmd).Trace("exec trace")
+			return nil
+		},
+	})
+	addCommands(root, execCmd)
+	stderr := new(bytes.Buffer)
+	root.SetErr(stderr)
+	root.SetArgs([]string{"exec", "noop"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	got := stderr.String()
+	if !bytes.Contains([]byte(got), []byte("audit: erun exec noop")) || !bytes.Contains([]byte(got), []byte("exec trace")) {
+		t.Fatalf("expected exec trace by default, got %q", got)
+	}
+}
+
+func TestAuditCommandRedactsSensitiveArgs(t *testing.T) {
+	cmd := &cobra.Command{Use: "raw"}
+	parent := newCommandGroup("exec", "Repository execution utilities", cmd)
+	root := newRootCommand(func(_ *cobra.Command, _ []string) error { return nil })
+	addCommands(root, parent)
+
+	got := formatAuditCommand(cmd, []string{"deploy", "--token", "secret-value", "--password=hidden", "ok"})
+	want := "erun exec raw deploy --token <redacted> --password=<redacted> ok"
+	if got != want {
+		t.Fatalf("unexpected audit command: got %q want %q", got, want)
+	}
+}
+
 func TestRootCommandPrintsElapsedTimeOnError(t *testing.T) {
 	cmd := newRootCommand(func(_ *cobra.Command, _ []string) error {
 		return bytes.ErrTooLarge

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -106,7 +106,7 @@ func Execute() error {
 
 	mcpCmd := newMCPCmd(resolveOpen, runInitForArgs, launchMCPProcess)
 	appCmd := newAppCmd(launchAppProcess)
-	execCmd := newExecCmd(common.FindProjectRoot, common.GitCommandRunner)
+	execCmd := newExecCmd(common.FindProjectRoot, common.GitCommandRunner, nil)
 	listCmd := newListCmd(configStore, common.FindProjectRoot)
 	doctorCmd := newDoctorCmd(resolveOpen, runPrompt)
 	releaseCmd := newReleaseCmd(common.FindProjectRoot, common.GitCommandRunner)

--- a/erun-cli/cmd/root_runtime.go
+++ b/erun-cli/cmd/root_runtime.go
@@ -51,6 +51,7 @@ func newRootCommand(runRoot func(*cobra.Command, []string) error) *cobra.Command
 		SilenceUsage:     true,
 		SilenceErrors:    true,
 		TraverseChildren: true,
+		PersistentPreRun: auditCommand,
 		RunE:             runRoot,
 	}
 	addDryRunFlag(cmd)

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -23,6 +23,7 @@ type testRootDeps struct {
 	ResolveKubernetesDeployContext common.DeployContextResolverFunc
 	CheckKubernetesDeployment      common.KubernetesDeploymentCheckerFunc
 	RunGit                         common.GitCommandRunnerFunc
+	RunRawCommand                  common.RawCommandRunnerFunc
 	RunBuildScript                 common.BuildScriptRunnerFunc
 	BuildDockerImage               common.DockerImageBuilderFunc
 	PushDockerImage                common.DockerImagePusherFunc
@@ -207,7 +208,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 
 	mcpCmd := newMCPCmd(resolveOpen, runInitForArgs, launchMCP)
 	appCmd := newAppCmd(launchApp)
-	execCmd := newExecCmd(findProjectRoot, runGit)
+	execCmd := newExecCmd(findProjectRoot, runGit, deps.RunRawCommand)
 	listCmd := newListCmd(listDataStore, findProjectRoot)
 	doctorCmd := newDoctorCmd(resolveOpen, promptRunner)
 	releaseCmd := newReleaseCmd(findProjectRoot, runGit)

--- a/erun-common/exec.go
+++ b/erun-common/exec.go
@@ -1,0 +1,73 @@
+package eruncommon
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+type RawCommandRunnerFunc func(dir, name string, args []string, stdin io.Reader, stdout, stderr io.Writer) error
+
+type RawCommandSpec struct {
+	Dir  string   `json:"dir,omitempty"`
+	Args []string `json:"args,omitempty"`
+}
+
+func RunRawCommand(ctx Context, spec RawCommandSpec, run RawCommandRunnerFunc) error {
+	if len(spec.Args) == 0 || strings.TrimSpace(spec.Args[0]) == "" {
+		return fmt.Errorf("raw command is required")
+	}
+	if run == nil {
+		run = RawCommandRunner
+	}
+
+	name := spec.Args[0]
+	args := append([]string(nil), spec.Args[1:]...)
+	traceArgs := redactRawCommandArgs(spec.Args)
+	ctx.TraceCommand(spec.Dir, traceArgs[0], traceArgs[1:]...)
+	if ctx.DryRun {
+		return nil
+	}
+	return run(spec.Dir, name, args, ctx.Stdin, ctx.Stdout, ctx.Stderr)
+}
+
+func RawCommandRunner(dir, name string, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+func redactRawCommandArgs(args []string) []string {
+	redacted := make([]string, 0, len(args))
+	redactNext := false
+	for _, arg := range args {
+		if redactNext {
+			redacted = append(redacted, "<redacted>")
+			redactNext = false
+			continue
+		}
+		if name, _, ok := strings.Cut(arg, "="); ok && isRawCommandSensitiveName(name) {
+			redacted = append(redacted, name+"=<redacted>")
+			continue
+		}
+		redacted = append(redacted, arg)
+		if isRawCommandSensitiveName(arg) {
+			redactNext = true
+		}
+	}
+	return redacted
+}
+
+func isRawCommandSensitiveName(value string) bool {
+	normalized := strings.ToLower(strings.TrimLeft(value, "-"))
+	for _, token := range []string{"password", "passwd", "secret", "token", "apikey", "api-key", "access-key", "private-key"} {
+		if strings.Contains(normalized, token) {
+			return true
+		}
+	}
+	return false
+}

--- a/erun-common/sshd_test.go
+++ b/erun-common/sshd_test.go
@@ -108,6 +108,25 @@ func TestRuntimeEntrypointDisablesStrictModesForPVCBackedHome(t *testing.T) {
 	}
 }
 
+func TestRuntimeEntrypointConfiguresCodexMCP(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "erun-devops", "docker", "erun-devops", "entrypoint.sh"))
+	if err != nil {
+		t.Fatalf("read runtime entrypoint: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		`initialize_codex_config`,
+		`[mcp_servers.erun]`,
+		`url = "${mcp_url}"`,
+		`tool_timeout_sec = 600`,
+		`http://127.0.0.1:${ERUN_MCP_PORT:-17000}${ERUN_MCP_PATH:-/mcp}`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("expected runtime entrypoint to contain %q, got:\n%s", want, content)
+		}
+	}
+}
+
 func TestRuntimeEntrypointWritesRemoteOnlyToEnvironmentConfig(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "erun-devops", "docker", "erun-devops", "entrypoint.sh"))
 	if err != nil {

--- a/erun-devops/docker/erun-devops/entrypoint.sh
+++ b/erun-devops/docker/erun-devops/entrypoint.sh
@@ -120,6 +120,30 @@ ${env_remote_line}
 EOF
 }
 
+initialize_codex_config() {
+    codex_dir="${HOME}/.codex"
+    codex_config="${codex_dir}/config.toml"
+    mcp_url="http://127.0.0.1:${ERUN_MCP_PORT:-17000}${ERUN_MCP_PATH:-/mcp}"
+
+    mkdir -p "${codex_dir}"
+    touch "${codex_config}"
+
+    tmp_config="${codex_config}.tmp"
+    awk '
+        /^\[mcp_servers\.erun\]$/ { skip = 1; next }
+        /^\[/ && skip { skip = 0 }
+        !skip { print }
+    ' "${codex_config}" >"${tmp_config}"
+    mv "${tmp_config}" "${codex_config}"
+
+    cat >>"${codex_config}" <<EOF
+
+[mcp_servers.erun]
+url = "${mcp_url}"
+tool_timeout_sec = 600
+EOF
+}
+
 start_sshd() {
     if ! runtime_sshd_enabled; then
         return
@@ -183,10 +207,12 @@ start_sshd
 if [ "${1:-}" = "shell" ]; then
     shift
     initialize_erun_config
+    initialize_codex_config
     run_shell "$@"
 fi
 
 initialize_erun_config
+initialize_codex_config
 
 set -- emcp "$@" \
     --host "${ERUN_MCP_HOST:-0.0.0.0}" \

--- a/erun-mcp/exec.go
+++ b/erun-mcp/exec.go
@@ -1,0 +1,37 @@
+package erunmcp
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+type RawInput struct {
+	Command   []string `json:"command" jsonschema:"command and arguments to execute from the runtime repo root"`
+	Stdin     string   `json:"stdin,omitempty" jsonschema:"optional stdin to pass to the command"`
+	Preview   bool     `json:"preview,omitempty" jsonschema:"when true, trace the command without executing it"`
+	Verbosity int      `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+}
+
+func rawTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, RawInput) (*mcp.CallToolResult, CommandOutput, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input RawInput) (*mcp.CallToolResult, CommandOutput, error) {
+		traceOutput := new(bytes.Buffer)
+		ctx := runtimeCallContext(input.Preview, input.Verbosity, strings.NewReader(input.Stdin), traceOutput, traceOutput)
+
+		workDir, err := runtimeRepoPath(runtime.Context)
+		if err != nil {
+			return nil, CommandOutput{}, err
+		}
+
+		output, err := runCommandOutput(ctx, workDir, traceOutput, func(runCtx eruncommon.Context) error {
+			return eruncommon.RunRawCommand(runCtx, eruncommon.RawCommandSpec{
+				Dir:  workDir,
+				Args: input.Command,
+			}, nil)
+		})
+		return nil, output, err
+	}
+}

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -138,6 +138,10 @@ func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig) *mcp.Server {
 		Description: "Return the current git diff from the runtime repo root as raw text plus structured file, hunk, line, and tree data",
 	}, diffTool(runtime))
 	mcp.AddTool(server, &mcp.Tool{
+		Name:        "raw",
+		Description: "Run an arbitrary command from the runtime repo root and return captured stdout, stderr, and trace output",
+	}, rawTool(runtime))
+	mcp.AddTool(server, &mcp.Tool{
 		Name:        "release",
 		Description: "Plan and execute a project release from the runtime repo root using .erun/config.yaml branch policy",
 	}, releaseTool(runtime))

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -157,7 +157,7 @@ func TestHTTPHandlerExposesVersionTool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTools failed: %v", err)
 	}
-	if len(tools.Tools) != 9 {
+	if len(tools.Tools) != 10 {
 		t.Fatalf("unexpected tools: %+v", tools.Tools)
 	}
 
@@ -168,6 +168,54 @@ func TestHTTPHandlerExposesVersionTool(t *testing.T) {
 	version := decodeStructuredVersion(t, result.StructuredContent)
 	if got := version["version"]; got != "1.2.3" {
 		t.Fatalf("unexpected structured content: %+v", version)
+	}
+}
+
+func TestRawToolRunsCommandFromRuntimeRepoRoot(t *testing.T) {
+	projectRoot := t.TempDir()
+	handler := rawTool(normalizeRuntimeConfig(RuntimeConfig{
+		Context: RuntimeContext{RepoPath: projectRoot},
+	}))
+
+	_, output, err := handler(context.Background(), nil, RawInput{
+		Command:   []string{"/bin/sh", "-c", "printf '%s:%s' \"$PWD\" \"$(cat)\""},
+		Stdin:     "input",
+		Verbosity: 1,
+	})
+	if err != nil {
+		t.Fatalf("rawTool failed: %v", err)
+	}
+	if !output.Executed || output.WorkingDirectory != projectRoot {
+		t.Fatalf("unexpected output metadata: %+v", output)
+	}
+	if output.Stdout != projectRoot+":input" {
+		t.Fatalf("unexpected stdout: %q", output.Stdout)
+	}
+	if len(output.Trace) != 1 || !strings.Contains(output.Trace[0], "cd "+projectRoot+" && /bin/sh -c") {
+		t.Fatalf("unexpected trace: %+v", output.Trace)
+	}
+}
+
+func TestRawToolPreviewRedactsTraceWithoutExecuting(t *testing.T) {
+	projectRoot := t.TempDir()
+	handler := rawTool(normalizeRuntimeConfig(RuntimeConfig{
+		Context: RuntimeContext{RepoPath: projectRoot},
+	}))
+
+	_, output, err := handler(context.Background(), nil, RawInput{
+		Command:   []string{"/bin/sh", "-c", "exit 1", "--token", "secret-value"},
+		Preview:   true,
+		Verbosity: 1,
+	})
+	if err != nil {
+		t.Fatalf("rawTool preview failed: %v", err)
+	}
+	if output.Executed {
+		t.Fatalf("expected preview output, got %+v", output)
+	}
+	joined := strings.Join(output.Trace, "\n")
+	if !strings.Contains(joined, "--token '<redacted>'") || strings.Contains(joined, "secret-value") {
+		t.Fatalf("unexpected trace: %+v", output.Trace)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `erun exec raw COMMAND [ARG...]` for traced arbitrary command execution from the project root.
- Audit `erun` invocations when trace is enabled, and enable trace by default for `erun exec ...` commands.
- Expose raw execution through the runtime MCP server and configure Codex in the runtime environment to discover the erun MCP server.

## Validation

- `go test -count=1 ./...` in `erun-common`
- `go test -count=1 ./...` in `erun-cli`
- `go test -count=1 ./...` in `erun-mcp`
- `git diff --check`

Closes #120
