### PR TITLE
Fix environment dialog tenant focus

### DIFF
--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -18,14 +18,15 @@ export function EnvironmentDialogView({ controller, state }: { controller: ERunU
 
   React.useEffect(() => {
     if (!dialog.open) {
-      return;
+      return undefined;
     }
-    window.setTimeout(() => {
+    const timeout = window.setTimeout(() => {
       const target = dialog.tenant ? environmentRef.current : tenantRef.current;
       target?.focus();
       target?.select();
     }, 0);
-  }, [dialog.open, dialog.tenant]);
+    return () => window.clearTimeout(timeout);
+  }, [dialog.open]);
 
   return (
     <Dialog open={dialog.open} onOpenChange={(open) => !open && controller.closeEnvironmentDialog()}>


### PR DESCRIPTION
## Summary
- keep the new environment dialog focus effect scoped to dialog open state
- preserve initial focus selection while preventing focus from moving during tenant edits
- clear the delayed focus timer when the effect is cleaned up

## Root cause
The focus effect depended on `dialog.tenant`, so each tenant keystroke reran the effect. Once the tenant value was non-empty, the effect selected the environment input.

## Validation
- `yarn build` via bundled Node runtime
- `go test ./...` in `erun-ui`

Closes #130