### PR TITLE
Deduplicate runtime version suggestions

### DIFF
--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -229,6 +229,9 @@ func (a *App) runtimeVersionSuggestions(info eruncommon.BuildInfo, tenant string
 	suggestions := make([]uiVersion, 0, 8)
 	tenantImage := eruncommon.RuntimeReleaseName(tenant)
 	suggestions = append(suggestions, labelRuntimeVersionSuggestions(tenant, tenantImage, eruncommon.RuntimeDeployVersionSuggestions(info, a.resolveRuntimeRegistryVersionsForTenant(tenant)))...)
+	if tenantImage == eruncommon.DefaultRuntimeImageName {
+		return suggestions
+	}
 	suggestions = append(suggestions, labelRuntimeVersionSuggestions("ERun", eruncommon.DefaultRuntimeImageName, eruncommon.RuntimeDeployVersionSuggestions(info, a.resolveRuntimeRegistryVersionsForTenant("")))...)
 	return suggestions
 }

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -162,6 +162,41 @@ func TestLoadVersionSuggestionsFiltersOutMissingTenantImageTags(t *testing.T) {
 	}
 }
 
+func TestLoadVersionSuggestionsDoesNotDuplicateDefaultRuntimeForErunTenant(t *testing.T) {
+	var repositories []string
+	app := NewApp(erunUIDeps{
+		resolveBuildInfo: func() eruncommon.BuildInfo { return eruncommon.BuildInfo{Version: "1.0.50"} },
+		resolveImageRegistry: func(_ context.Context, namespace, repository string) (eruncommon.RuntimeRegistryVersions, error) {
+			if namespace != eruncommon.DefaultContainerRegistry {
+				t.Fatalf("unexpected registry namespace: %s", namespace)
+			}
+			repositories = append(repositories, repository)
+			if repository != eruncommon.DefaultRuntimeImageName {
+				t.Fatalf("unexpected registry repository: %s", repository)
+			}
+			return eruncommon.RuntimeRegistryVersions{
+				Image:          namespace + "/" + repository,
+				Tags:           []string{"1.0.48", "1.0.47", "1.0.50-snapshot-20260426090832"},
+				LatestStable:   "1.0.48",
+				LatestSnapshot: "1.0.50-snapshot-20260426090832",
+			}, nil
+		},
+	})
+
+	suggestions, err := app.LoadVersionSuggestions(uiSelection{Tenant: " erun "})
+	if err != nil {
+		t.Fatalf("LoadVersionSuggestions failed: %v", err)
+	}
+	got := versionValues(suggestions)
+	want := []string{"1.0.48", "1.0.47", "1.0.50-snapshot-20260426090832"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected suggestions: got %+v want %+v", suggestions, want)
+	}
+	if strings.Join(repositories, "\n") != eruncommon.DefaultRuntimeImageName {
+		t.Fatalf("expected one registry lookup for default runtime image, got %+v", repositories)
+	}
+}
+
 func TestLoadVersionSuggestionsFallsBackToDefaultRuntimeTagsWhenTenantImageMissing(t *testing.T) {
 	app := NewApp(erunUIDeps{
 		resolveBuildInfo: func() eruncommon.BuildInfo { return eruncommon.BuildInfo{Version: "1.0.50"} },


### PR DESCRIPTION
## Summary

Fix duplicate runtime version suggestions in the desktop app when the selected tenant resolves to the default runtime image.

## Root cause

Tenant `erun` resolves to `erun-devops`, which is also the default ERun runtime image. The desktop backend appended tenant-specific suggestions and then appended default ERun suggestions, producing duplicate dropdown entries for the same image/version set.

## Changes

- Return tenant suggestions directly when the tenant runtime image is already `erun-devops`.
- Add a regression test for the `erun` tenant duplicate suggestion case.

## Validation

- `go test ./...` from `erun-ui`

Closes #134
