### PR TITLE
Improve environment create and delete UX

### DIFF
--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -561,10 +561,7 @@ func (a *App) streamSession(managed *managedTerminal) {
 			a.emitEvent(terminalOutputEvent, payload)
 		}
 		if err != nil {
-			reason := ""
-			if !errors.Is(err, io.EOF) {
-				reason = err.Error()
-			}
+			reason := terminalSessionExitReason(managed.session, err)
 			a.mu.Lock()
 			managed.closed = true
 			if existing := a.sessions[managed.key]; existing == managed {
@@ -581,6 +578,19 @@ func (a *App) streamSession(managed *managedTerminal) {
 			return
 		}
 	}
+}
+
+func terminalSessionExitReason(session terminalSession, readErr error) string {
+	if session != nil {
+		if waitErr := session.Wait(); waitErr != nil {
+			return waitErr.Error()
+		}
+		return ""
+	}
+	if readErr != nil && !errors.Is(readErr, io.EOF) {
+		return readErr.Error()
+	}
+	return ""
 }
 
 func (a *App) emitEvent(name string, payload any) {

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -687,6 +687,23 @@ func TestStartDeploySessionUsesSeparateSessionKey(t *testing.T) {
 	}
 }
 
+func TestTerminalSessionExitReasonUsesProcessExitError(t *testing.T) {
+	session := newStubTerminalSession()
+	session.waitErr = io.ErrUnexpectedEOF
+
+	got := terminalSessionExitReason(session, io.EOF)
+	if got != io.ErrUnexpectedEOF.Error() {
+		t.Fatalf("unexpected exit reason: got %q want %q", got, io.ErrUnexpectedEOF.Error())
+	}
+}
+
+func TestTerminalSessionExitReasonIgnoresCleanEOF(t *testing.T) {
+	got := terminalSessionExitReason(newStubTerminalSession(), io.EOF)
+	if got != "" {
+		t.Fatalf("unexpected clean exit reason: %q", got)
+	}
+}
+
 func TestDeleteEnvironmentRequiresExactConfirmationAndDeletesConfig(t *testing.T) {
 	projectRoot := t.TempDir()
 	store := stubUIStore{
@@ -1004,6 +1021,7 @@ func (s stubUIStore) ListEnvConfigs(tenant string) ([]eruncommon.EnvConfig, erro
 
 type stubTerminalSession struct {
 	closeCh chan struct{}
+	waitErr error
 }
 
 func newStubTerminalSession() *stubTerminalSession {
@@ -1021,6 +1039,10 @@ func (s *stubTerminalSession) Write(buffer []byte) (int, error) {
 
 func (s *stubTerminalSession) Resize(int, int) error {
 	return nil
+}
+
+func (s *stubTerminalSession) Wait() error {
+	return s.waitErr
 }
 
 func (s *stubTerminalSession) Close() error {

--- a/erun-ui/frontend/src/App.tsx
+++ b/erun-ui/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Check, Copy } from 'lucide-react';
 
 import { ERunUIController } from '@/app/ERunUIController';
 import { useControllerState } from '@/app/useControllerState';
@@ -7,6 +8,7 @@ import { ManageDialogView } from '@/components/app/ManageDialogView';
 import { ReviewPanel } from '@/components/app/ReviewPanel';
 import { Sidebar } from '@/components/app/Sidebar';
 import { Titlebar } from '@/components/app/Titlebar';
+import { Button } from '@/components/ui/button';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
@@ -51,8 +53,24 @@ export function App(): React.ReactElement {
           >
             <div className="terminal-view">
               <div ref={terminalRootRef} className="terminal" />
-              <div className={cn('terminal-message', !state.terminalMessage && 'is-hidden')}>
-                {state.terminalMessage}
+              <div className={cn('terminal-message', state.terminalCopyOutput && 'has-copy-action', !state.terminalMessage && 'is-hidden')}>
+                <div className="terminal-message-content">
+                  <div>{state.terminalMessage}</div>
+                  {state.terminalCopyOutput && (
+                    <Button
+                      className="terminal-copy-button"
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        void controller.copyTerminalOutput();
+                      }}
+                    >
+                      {state.terminalCopyStatus === 'Copied' ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
+                      {state.terminalCopyStatus || 'Copy output'}
+                    </Button>
+                  )}
+                </div>
               </div>
             </div>
             <div

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -14,7 +14,7 @@ import {
   StartInitSession,
   StartSession,
 } from '../../wailsjs/go/main/App';
-import { EventsOn, WindowToggleMaximise } from '../../wailsjs/runtime/runtime';
+import { ClipboardSetText, EventsOn, WindowToggleMaximise } from '../../wailsjs/runtime/runtime';
 import { fileToBase64, decodeBase64Bytes, isTerminalPasteTarget, pastedImageFiles } from './clipboard';
 import { chooseSelectedDiffPath, cssEscape } from './diffUtils';
 import { readError } from './errors';
@@ -82,14 +82,18 @@ export class ERunUIController {
     diffFilter: '',
     collapsedDiffDirs: new Set<string>(),
     terminalMessage: '',
+    terminalCopyOutput: '',
+    terminalCopyStatus: '',
   };
 
   private readonly subscribers = new Set<() => void>();
-  private readonly initSessionIds = new Set<number>();
-  private readonly deploySessionIds = new Set<number>();
+  private readonly initSessionSelections = new Map<number, UISelection>();
+  private readonly deploySessionSelections = new Map<number, UISelection>();
+  private readonly openSessionSelections = new Map<number, UISelection>();
   private readonly selectionSessions = new Map<string, number>();
   private readonly sessionBuffers = new Map<number, Uint8Array[]>();
   private readonly sessionExitReasons = new Map<number, string>();
+  private readonly sessionExitOutputs = new Map<number, string>();
   private terminal: Terminal | null = null;
   private fitAddon: FitAddon | null = null;
   private terminalRoot: HTMLDivElement | null = null;
@@ -101,6 +105,7 @@ export class ERunUIController {
   private resizeTimer = 0;
   private reviewScrollFrame = 0;
   private versionSuggestionTimer = 0;
+  private terminalCopyStatusTimer = 0;
   private versionSuggestionRequest = 0;
   private bootStarted = false;
   private terminalDataDisposable: TerminalDataDisposable | null = null;
@@ -192,7 +197,7 @@ export class ERunUIController {
     this.applyLayoutVars();
     this.emit();
     this.queueTerminalResize();
-    window.setTimeout(() => this.terminal?.focus(), 0);
+    this.focusTerminalSoon();
   }
 
   startSidebarResize(event: React.MouseEvent<HTMLElement>): void {
@@ -282,7 +287,7 @@ export class ERunUIController {
     if (this.state.reviewOpen) {
       void this.loadReviewDiff();
     }
-    window.setTimeout(() => this.terminal?.focus(), 0);
+    this.focusTerminalSoon();
   }
 
   setFilesOpen(open: boolean, persist = true): void {
@@ -311,12 +316,15 @@ export class ERunUIController {
     this.state.selected = selection;
     this.emit();
     if (previousKnownSessionId === 0 || previousKnownSessionId !== previousSessionId) {
+      this.state.terminalCopyOutput = '';
+      this.state.terminalCopyStatus = '';
       this.showTerminalMessage(`Opening ${selection.tenant} / ${selection.environment}...`);
     }
 
     this.fitAddon?.fit();
     const result = (await StartSession(selection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
     this.selectionSessions.set(key, result.sessionId);
+    this.openSessionSelections.set(result.sessionId, selection);
     this.state.sessionId = result.sessionId;
 
     if (result.sessionId !== previousSessionId) {
@@ -329,6 +337,8 @@ export class ERunUIController {
 
     const exitReason = this.sessionExitReasons.get(result.sessionId);
     if (exitReason) {
+      this.state.terminalCopyOutput = this.sessionExitOutputs.get(result.sessionId) || '';
+      this.state.terminalCopyStatus = '';
       this.showTerminalMessage(exitReason);
     } else {
       this.hideTerminalMessage();
@@ -337,7 +347,7 @@ export class ERunUIController {
     if (this.state.reviewOpen) {
       await this.loadReviewDiff();
     }
-    this.terminal?.focus();
+    this.focusTerminalSoon();
     this.queueTerminalResize();
     this.emit();
   }
@@ -353,21 +363,30 @@ export class ERunUIController {
       noGit: false,
       versionImage: this.state.versionSuggestions[0]?.image || '',
       choicesOpen: false,
+      busy: false,
+      error: '',
     };
     this.emit();
     void this.refreshDialogVersionSuggestions(true);
   }
 
   closeEnvironmentDialog(): void {
+    if (this.state.environmentDialog.busy) {
+      return;
+    }
     this.state.environmentDialog = defaultEnvironmentDialog();
     this.emit();
-    window.setTimeout(() => this.terminal?.focus(), 0);
+    this.focusTerminalSoon();
   }
 
   updateEnvironmentDialog(values: Partial<EnvironmentDialogState>): void {
+    if (this.state.environmentDialog.busy) {
+      return;
+    }
     this.state.environmentDialog = {
       ...this.state.environmentDialog,
       ...values,
+      error: values.error ?? '',
     };
     if (values.version !== undefined) {
       this.state.environmentDialog.versionImage = '';
@@ -384,6 +403,9 @@ export class ERunUIController {
   }
 
   setEnvironmentVersionChoicesOpen(open: boolean): void {
+    if (this.state.environmentDialog.busy) {
+      return;
+    }
     this.state.environmentDialog = {
       ...this.state.environmentDialog,
       choicesOpen: open && this.state.versionSuggestions.length > 0,
@@ -392,6 +414,9 @@ export class ERunUIController {
   }
 
   selectEnvironmentVersionSuggestion(suggestion: UIVersionSuggestion | undefined): void {
+    if (this.state.environmentDialog.busy) {
+      return;
+    }
     this.state.environmentDialog = {
       ...this.state.environmentDialog,
       version: suggestion?.version || '',
@@ -403,16 +428,20 @@ export class ERunUIController {
 
   async submitEnvironmentDialog(form: HTMLFormElement): Promise<void> {
     const dialog = this.state.environmentDialog;
+    if (dialog.busy) {
+      return;
+    }
     const tenant = normalizeDialogValue(dialog.tenant);
     const environment = normalizeDialogValue(dialog.environment);
     const version = normalizeDialogValue(dialog.version);
 
     if (!tenant || !environment || (dialog.actionMode === 'deploy' && !version)) {
+      this.state.environmentDialog = { ...dialog, error: '' };
+      this.emit();
       form.reportValidity();
       return;
     }
 
-    this.closeEnvironmentDialog();
     const selection = {
       tenant,
       environment,
@@ -420,11 +449,38 @@ export class ERunUIController {
       runtimeImage: this.resolveEnvironmentRuntimeImage(version),
       noGit: dialog.noGit,
     };
-    if (dialog.actionMode === 'deploy') {
-      await this.startDeploySelection(selection);
-      return;
+
+    this.state.environmentDialog = {
+      ...dialog,
+      tenant,
+      environment,
+      version,
+      busy: true,
+      error: '',
+      choicesOpen: false,
+    };
+    this.emit();
+
+    const previousSelected = this.state.selected;
+    try {
+      if (dialog.actionMode === 'deploy') {
+        await this.startDeploySelection(selection);
+      } else {
+        await this.startInitSelection(selection);
+      }
+      this.state.environmentDialog = defaultEnvironmentDialog();
+      this.emit();
+      this.focusTerminalSoon();
+    } catch (error) {
+      const message = readError(error);
+      this.state.selected = previousSelected;
+      this.state.environmentDialog = {
+        ...this.state.environmentDialog,
+        busy: false,
+        error: message,
+      };
+      this.showTerminalMessage(message);
     }
-    await this.startInitSelection(selection);
   }
 
   openManageDialog(selection: UISelection): void {
@@ -438,6 +494,7 @@ export class ERunUIController {
       confirmation: '',
       busy: false,
       choicesOpen: false,
+      error: '',
     };
     this.emit();
     void this.refreshManageVersionSuggestions(true);
@@ -449,7 +506,7 @@ export class ERunUIController {
     }
     this.state.manageDialog = defaultManageDialog();
     this.emit();
-    window.setTimeout(() => this.terminal?.focus(), 0);
+    this.focusTerminalSoon();
   }
 
   setManageTab(tab: ManageTab): void {
@@ -460,14 +517,19 @@ export class ERunUIController {
       ...this.state.manageDialog,
       tab,
       choicesOpen: false,
+      error: '',
     };
     this.emit();
   }
 
   updateManageDialog(values: Partial<ManageDialogState>): void {
+    if (this.state.manageDialog.busy) {
+      return;
+    }
     this.state.manageDialog = {
       ...this.state.manageDialog,
       ...values,
+      error: values.error ?? '',
     };
     if (values.version !== undefined) {
       this.state.manageDialog.versionImage = '';
@@ -481,6 +543,9 @@ export class ERunUIController {
   }
 
   setManageVersionChoicesOpen(open: boolean): void {
+    if (this.state.manageDialog.busy) {
+      return;
+    }
     this.state.manageDialog = {
       ...this.state.manageDialog,
       choicesOpen: open && this.state.versionSuggestions.length > 0,
@@ -489,6 +554,9 @@ export class ERunUIController {
   }
 
   selectManageVersionSuggestion(suggestion: UIVersionSuggestion | undefined): void {
+    if (this.state.manageDialog.busy) {
+      return;
+    }
     this.state.manageDialog = {
       ...this.state.manageDialog,
       version: suggestion?.version || '',
@@ -533,19 +601,31 @@ export class ERunUIController {
       return;
     }
 
-    this.state.manageDialog = { ...dialog, busy: true };
+    this.state.manageDialog = { ...dialog, busy: true, error: '' };
+    this.state.terminalCopyOutput = '';
+    this.state.terminalCopyStatus = '';
     this.showTerminalMessage(`Deleting ${selection.tenant} / ${selection.environment}...`);
 
     try {
       const result = (await DeleteEnvironment(selection, confirmation)) as DeleteEnvironmentResult;
-      this.state.selected = null;
+      const deletedSelected = this.state.selected ? selectionKey(this.state.selected) === selectionKey(selection) : false;
+      if (deletedSelected) {
+        this.state.selected = null;
+        this.state.sessionId = 0;
+        this.resetTerminal();
+      }
       await this.reloadStateAfterEnvironmentChange();
       this.state.manageDialog = defaultManageDialog();
+      this.state.terminalCopyOutput = '';
+      this.state.terminalCopyStatus = '';
       const warning = result.namespaceDeleteError ? ` Namespace deletion failed: ${result.namespaceDeleteError}` : '';
       this.showTerminalMessage(`Deleted ${result.tenant} / ${result.environment}.${warning}`);
     } catch (error) {
-      this.state.manageDialog = { ...this.state.manageDialog, busy: false };
-      this.showTerminalMessage(readError(error));
+      const message = readError(error);
+      this.state.manageDialog = { ...this.state.manageDialog, busy: false, error: message };
+      this.state.terminalCopyOutput = `Failed to delete ${selection.tenant} / ${selection.environment}: ${message}`;
+      this.state.terminalCopyStatus = '';
+      this.showTerminalMessage(message);
       this.emit();
     }
   }
@@ -613,6 +693,32 @@ export class ERunUIController {
     this.emit();
   }
 
+  focusTerminalSoon(): void {
+    window.setTimeout(() => {
+      this.terminal?.focus();
+      window.requestAnimationFrame(() => this.terminal?.focus());
+      window.setTimeout(() => this.terminal?.focus(), 80);
+    }, 0);
+  }
+
+  async copyTerminalOutput(): Promise<void> {
+    if (!this.state.terminalCopyOutput) {
+      return;
+    }
+    try {
+      await ClipboardSetText(this.state.terminalCopyOutput);
+      this.state.terminalCopyStatus = 'Copied';
+    } catch (error) {
+      this.state.terminalCopyStatus = readError(error);
+    }
+    this.emit();
+    window.clearTimeout(this.terminalCopyStatusTimer);
+    this.terminalCopyStatusTimer = window.setTimeout(() => {
+      this.state.terminalCopyStatus = '';
+      this.emit();
+    }, 1400);
+  }
+
   private emit(): void {
     this.subscribers.forEach((subscriber) => subscriber());
   }
@@ -644,16 +750,18 @@ export class ERunUIController {
   private async startInitSelection(selection: UISelection): Promise<void> {
     this.state.selected = selection;
     this.emit();
+    this.state.terminalCopyOutput = '';
+    this.state.terminalCopyStatus = '';
     this.showTerminalMessage(`Initializing ${selection.tenant} / ${selection.environment}...`);
 
     this.fitAddon?.fit();
     const result = (await StartInitSession(selection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
-    this.initSessionIds.add(result.sessionId);
+    this.initSessionSelections.set(result.sessionId, selection);
     this.state.sessionId = result.sessionId;
 
     this.resetTerminal();
     this.hideTerminalMessage();
-    this.terminal?.focus();
+    this.focusTerminalSoon();
     this.queueTerminalResize();
     this.emit();
   }
@@ -661,16 +769,18 @@ export class ERunUIController {
   private async startDeploySelection(selection: UISelection): Promise<void> {
     this.state.selected = selection;
     this.emit();
+    this.state.terminalCopyOutput = '';
+    this.state.terminalCopyStatus = '';
     this.showTerminalMessage(`Deploying ${selection.tenant} / ${selection.environment}...`);
 
     this.fitAddon?.fit();
     const result = (await StartDeploySession(selection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
-    this.deploySessionIds.add(result.sessionId);
+    this.deploySessionSelections.set(result.sessionId, selection);
     this.state.sessionId = result.sessionId;
 
     this.resetTerminal();
     this.hideTerminalMessage();
-    this.terminal?.focus();
+    this.focusTerminalSoon();
     this.queueTerminalResize();
     this.emit();
   }
@@ -759,6 +869,8 @@ export class ERunUIController {
 
   private hideTerminalMessage(): void {
     this.state.terminalMessage = '';
+    this.state.terminalCopyOutput = '';
+    this.state.terminalCopyStatus = '';
     this.emit();
   }
 
@@ -780,16 +892,74 @@ export class ERunUIController {
     if (!payload) {
       return;
     }
-    this.sessionExitReasons.set(payload.sessionId, payload.reason || 'Session ended.');
-    const initSessionEnded = this.initSessionIds.delete(payload.sessionId);
-    const deploySessionEnded = this.deploySessionIds.delete(payload.sessionId);
-    if (initSessionEnded || deploySessionEnded) {
+    const initSelection = this.initSessionSelections.get(payload.sessionId);
+    const deploySelection = this.deploySessionSelections.get(payload.sessionId);
+    const openSelection = this.openSessionSelections.get(payload.sessionId);
+    this.initSessionSelections.delete(payload.sessionId);
+    this.deploySessionSelections.delete(payload.sessionId);
+    this.openSessionSelections.delete(payload.sessionId);
+
+    const reason = this.terminalExitReason(payload, initSelection, deploySelection, openSelection);
+    this.sessionExitReasons.set(payload.sessionId, reason);
+    const failedOutput = payload.reason && (initSelection || deploySelection || openSelection)
+      ? this.failedTerminalOutput(payload.sessionId, reason)
+      : '';
+    if (failedOutput) {
+      this.sessionExitOutputs.set(payload.sessionId, failedOutput);
+    }
+    if (initSelection || deploySelection) {
       await this.reloadStateAfterEnvironmentChange();
     }
     if (payload.sessionId !== this.state.sessionId) {
       return;
     }
-    this.showTerminalMessage(payload.reason || 'Session ended.');
+    if (initSelection && !payload.reason) {
+      try {
+        await this.openSelection(initSelection);
+      } catch (error) {
+        this.showTerminalMessage(readError(error));
+      }
+      return;
+    }
+    if (payload.reason && (initSelection || deploySelection || openSelection)) {
+      this.state.terminalCopyOutput = failedOutput;
+      this.state.terminalCopyStatus = '';
+    }
+    this.showTerminalMessage(reason);
+  }
+
+  private terminalExitReason(
+    payload: TerminalExitPayload,
+    initSelection?: UISelection,
+    deploySelection?: UISelection,
+    openSelection?: UISelection,
+  ): string {
+    if (payload.reason) {
+      if (initSelection) {
+        return `Failed to create ${initSelection.tenant} / ${initSelection.environment}: ${payload.reason}`;
+      }
+      if (deploySelection) {
+        return `Failed to deploy ${deploySelection.tenant} / ${deploySelection.environment}: ${payload.reason}`;
+      }
+      if (openSelection) {
+        return `Failed to open ${openSelection.tenant} / ${openSelection.environment}: ${payload.reason}`;
+      }
+      return payload.reason;
+    }
+    if (initSelection) {
+      return `Created ${initSelection.tenant} / ${initSelection.environment}.`;
+    }
+    if (deploySelection) {
+      return `Deployed ${deploySelection.tenant} / ${deploySelection.environment}.`;
+    }
+    return 'Session ended.';
+  }
+
+  private failedTerminalOutput(sessionId: number, fallback: string): string {
+    const chunks = this.sessionBuffers.get(sessionId) || [];
+    const decoder = new TextDecoder();
+    const output = chunks.map((chunk) => decoder.decode(chunk, { stream: true })).join('') + decoder.decode();
+    return cleanTerminalOutput(output) || fallback;
   }
 
   private applyLayoutVars(): void {
@@ -894,7 +1064,7 @@ export class ERunUIController {
       return;
     }
     await SendSessionInput(`${paths.join(' ')} `);
-    this.terminal?.focus();
+    this.focusTerminalSoon();
   }
 
   private writeTerminalBuffer(chunks: Uint8Array[]): void {
@@ -902,4 +1072,13 @@ export class ERunUIController {
       this.terminal?.write(chunk);
     }
   }
+}
+
+function cleanTerminalOutput(value: string): string {
+  return value
+    .replace(/\x1B\][^\x07]*(?:\x07|\x1B\\)/g, '')
+    .replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .trim();
 }

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -30,6 +30,8 @@ export interface EnvironmentDialogState {
   noGit: boolean;
   versionImage: string;
   choicesOpen: boolean;
+  busy: boolean;
+  error: string;
 }
 
 export interface ManageDialogState {
@@ -41,6 +43,7 @@ export interface ManageDialogState {
   confirmation: string;
   busy: boolean;
   choicesOpen: boolean;
+  error: string;
 }
 
 export interface AppState {
@@ -64,6 +67,8 @@ export interface AppState {
   diffFilter: string;
   collapsedDiffDirs: Set<string>;
   terminalMessage: string;
+  terminalCopyOutput: string;
+  terminalCopyStatus: string;
 }
 
 export const defaultEnvironmentDialog = (): EnvironmentDialogState => ({
@@ -75,6 +80,8 @@ export const defaultEnvironmentDialog = (): EnvironmentDialogState => ({
   noGit: false,
   versionImage: '',
   choicesOpen: false,
+  busy: false,
+  error: '',
 });
 
 export const defaultManageDialog = (): ManageDialogState => ({
@@ -86,4 +93,5 @@ export const defaultManageDialog = (): ManageDialogState => ({
   confirmation: '',
   busy: false,
   choicesOpen: false,
+  error: '',
 });

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { FolderPlus, LoaderCircle, Rocket } from 'lucide-react';
 
 import type { ERunUIController } from '@/app/ERunUIController';
 import { readError } from '@/app/errors';
@@ -6,7 +7,7 @@ import type { AppState } from '@/app/state';
 import { findVersionSuggestion, selectedVersionSourceText } from '@/app/versionSuggestions';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { VersionField } from './VersionField';
@@ -15,6 +16,9 @@ export function EnvironmentDialogView({ controller, state }: { controller: ERunU
   const dialog = state.environmentDialog;
   const tenantRef = React.useRef<HTMLInputElement>(null);
   const environmentRef = React.useRef<HTMLInputElement>(null);
+  const isDeploy = dialog.actionMode === 'deploy';
+  const submitLabel = isDeploy ? 'Deploy' : 'Create';
+  const busyLabel = isDeploy ? 'Deploying...' : 'Creating...';
 
   React.useEffect(() => {
     if (!dialog.open) {
@@ -30,7 +34,13 @@ export function EnvironmentDialogView({ controller, state }: { controller: ERunU
 
   return (
     <Dialog open={dialog.open} onOpenChange={(open) => !open && controller.closeEnvironmentDialog()}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        className="sm:max-w-md"
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          controller.focusTerminalSoon();
+        }}
+      >
         <form
           className="grid gap-4"
           onSubmit={(event) => {
@@ -42,8 +52,11 @@ export function EnvironmentDialogView({ controller, state }: { controller: ERunU
         >
           <DialogHeader>
             <DialogTitle>
-              {dialog.actionMode === 'deploy' ? 'Deploy environment' : 'New environment'}
+              {isDeploy ? 'Deploy environment' : 'New environment'}
             </DialogTitle>
+            <DialogDescription>
+              {dialog.tenant && dialog.environment ? `${dialog.tenant} / ${dialog.environment}` : 'Enter the tenant and environment name.'}
+            </DialogDescription>
           </DialogHeader>
           <div className="grid gap-2">
             <Label htmlFor="environment-tenant">Tenant</Label>
@@ -55,7 +68,7 @@ export function EnvironmentDialogView({ controller, state }: { controller: ERunU
               autoComplete="off"
               spellCheck={false}
               required
-              disabled={dialog.actionMode === 'deploy'}
+              disabled={dialog.busy || isDeploy}
               onChange={(event) => controller.updateEnvironmentDialog({ tenant: event.target.value })}
             />
           </div>
@@ -69,7 +82,7 @@ export function EnvironmentDialogView({ controller, state }: { controller: ERunU
               autoComplete="off"
               spellCheck={false}
               required
-              disabled={dialog.actionMode === 'deploy'}
+              disabled={dialog.busy || isDeploy}
               onChange={(event) => controller.updateEnvironmentDialog({ environment: event.target.value })}
             />
           </div>
@@ -79,7 +92,8 @@ export function EnvironmentDialogView({ controller, state }: { controller: ERunU
             sourceText={selectedVersionSourceText(findVersionSuggestion(state.versionSuggestions, dialog.version, dialog.versionImage))}
             suggestions={state.versionSuggestions}
             choicesOpen={dialog.choicesOpen}
-            required={dialog.actionMode === 'deploy'}
+            required={isDeploy}
+            disabled={dialog.busy}
             onValueChange={(version) => controller.updateEnvironmentDialog({ version })}
             onChoicesOpenChange={(open) => controller.setEnvironmentVersionChoicesOpen(open)}
             onSelect={(suggestion) => controller.selectEnvironmentVersionSuggestion(suggestion)}
@@ -88,18 +102,31 @@ export function EnvironmentDialogView({ controller, state }: { controller: ERunU
             <Checkbox
               id="environment-no-git"
               checked={dialog.noGit}
+              disabled={dialog.busy}
               onCheckedChange={(checked) => controller.updateEnvironmentDialog({ noGit: checked === true })}
             />
             <Label htmlFor="environment-no-git" className="text-sm font-normal">
               Initialize without Git checkout
             </Label>
           </div>
+          {dialog.error && (
+            <div className="dialog-error" role="alert">
+              {dialog.error}
+            </div>
+          )}
           <DialogFooter>
-            <Button type="button" variant="outline" size="sm" onClick={() => controller.closeEnvironmentDialog()}>
+            <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => controller.closeEnvironmentDialog()}>
               Cancel
             </Button>
-            <Button type="submit" size="sm">
-              Start enrollment
+            <Button type="submit" size="sm" disabled={dialog.busy}>
+              {dialog.busy ? (
+                <LoaderCircle className="animate-spin" aria-hidden="true" />
+              ) : isDeploy ? (
+                <Rocket aria-hidden="true" />
+              ) : (
+                <FolderPlus aria-hidden="true" />
+              )}
+              {dialog.busy ? busyLabel : submitLabel}
             </Button>
           </DialogFooter>
         </form>

--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Rocket, Trash2 } from 'lucide-react';
+import { AlertTriangle, LoaderCircle, Rocket, Trash2 } from 'lucide-react';
 
 import type { ERunUIController } from '@/app/ERunUIController';
 import { readError } from '@/app/errors';
@@ -37,7 +37,13 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
 
   return (
     <Dialog open={dialog.open} onOpenChange={(open) => !open && controller.closeManageDialog()}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        className="sm:max-w-md"
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          controller.focusTerminalSoon();
+        }}
+      >
         <form
           className="grid gap-4"
           onSubmit={(event) => {
@@ -85,9 +91,14 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
                 />
               </TabsContent>
               <TabsContent className="mt-0 grid gap-3" value="delete">
-                <p className="text-sm text-muted-foreground">
-                  {selection ? `Type ${expected} to delete ${selection.tenant} / ${selection.environment}.` : ''}
-                </p>
+                {selection && (
+                  <div className="delete-warning">
+                    <AlertTriangle aria-hidden="true" />
+                    <span>
+                      Delete <strong>{selection.tenant} / {selection.environment}</strong>. Type <code>{expected}</code> to confirm.
+                    </span>
+                  </div>
+                )}
                 <div className="grid gap-2">
                   <Label htmlFor="manage-confirmation">Confirmation</Label>
                   <Input
@@ -102,7 +113,9 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
                     onKeyDown={(event) => {
                       if (event.key === 'Enter') {
                         event.preventDefault();
-                        void controller.submitManageDelete();
+                        if (deleteEnabled) {
+                          void controller.submitManageDelete();
+                        }
                       }
                     }}
                   />
@@ -110,14 +123,19 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
               </TabsContent>
             </div>
           </Tabs>
+          {dialog.error && (
+            <div className="dialog-error" role="alert">
+              {dialog.error}
+            </div>
+          )}
           <DialogFooter>
             <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => controller.closeManageDialog()}>
               Cancel
             </Button>
             {dialog.tab === 'deploy' ? (
               <Button type="submit" size="sm" disabled={dialog.busy}>
-                <Rocket aria-hidden="true" />
-                Deploy
+                {dialog.busy ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Rocket aria-hidden="true" />}
+                {dialog.busy ? 'Deploying...' : 'Deploy'}
               </Button>
             ) : (
               <Button
@@ -129,7 +147,7 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
                   void controller.submitManageDelete();
                 }}
               >
-                <Trash2 aria-hidden="true" />
+                {dialog.busy ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Trash2 aria-hidden="true" />}
                 {dialog.busy ? 'Deleting...' : 'Delete'}
               </Button>
             )}

--- a/erun-ui/frontend/src/styles/layout.css
+++ b/erun-ui/frontend/src/styles/layout.css
@@ -293,3 +293,48 @@
 .sidebar-hidden .splitter {
   pointer-events: none;
 }
+
+.dialog-error {
+  border: 1px solid color-mix(in oklch, var(--destructive) 36%, transparent);
+  border-radius: var(--radius);
+  background: color-mix(in oklch, var(--destructive) 8%, transparent);
+  color: var(--destructive);
+  padding: 9px 11px;
+  font-size: 13px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.delete-warning {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 9px;
+  align-items: start;
+  border: 1px solid color-mix(in oklch, var(--destructive) 30%, var(--border));
+  border-radius: var(--radius);
+  background: color-mix(in oklch, var(--destructive) 7%, transparent);
+  color: var(--foreground);
+  padding: 10px 11px;
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.delete-warning svg {
+  width: 17px;
+  height: 17px;
+  margin-top: 1px;
+  color: var(--destructive);
+}
+
+.delete-warning strong {
+  font-weight: 650;
+}
+
+.delete-warning code {
+  border-radius: calc(var(--radius) - 4px);
+  background: color-mix(in oklch, var(--destructive) 12%, transparent);
+  color: var(--destructive);
+  padding: 1px 4px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}

--- a/erun-ui/frontend/src/styles/terminal.css
+++ b/erun-ui/frontend/src/styles/terminal.css
@@ -95,6 +95,39 @@
   pointer-events: none;
 }
 
+.terminal-message.has-copy-action {
+  pointer-events: auto;
+}
+
+.terminal-message-content {
+  display: flex;
+  max-width: min(680px, 100%);
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.terminal-copy-button {
+  border-color: oklch(0.92 0 0 / 0.55);
+  background: oklch(0.98 0 0);
+  color: oklch(0.18 0 0);
+  box-shadow: 0 10px 30px oklch(0 0 0 / 0.32);
+  cursor: pointer;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.terminal-copy-button:hover {
+  border-color: oklch(1 0 0 / 0.75);
+  background: oklch(1 0 0);
+  color: oklch(0.12 0 0);
+}
+
+.terminal-copy-button svg {
+  width: 15px;
+  height: 15px;
+}
+
 .terminal-message.is-hidden {
   display: none;
 }

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -14,6 +14,7 @@ import (
 type terminalSession interface {
 	io.ReadWriteCloser
 	Resize(cols, rows int) error
+	Wait() error
 }
 
 type startTerminalSessionParams struct {

--- a/erun-ui/session_unix.go
+++ b/erun-ui/session_unix.go
@@ -5,6 +5,7 @@ package main
 import (
 	"os"
 	"os/exec"
+	"sync"
 
 	"github.com/creack/pty"
 )
@@ -12,6 +13,8 @@ import (
 type unixTerminalSession struct {
 	ptyFile *os.File
 	cmd     *exec.Cmd
+	wait    sync.Once
+	waitErr error
 }
 
 func startTerminalSession(params startTerminalSessionParams) (terminalSession, error) {
@@ -49,13 +52,25 @@ func (s *unixTerminalSession) Resize(cols, rows int) error {
 	})
 }
 
+func (s *unixTerminalSession) Wait() error {
+	if s == nil {
+		return nil
+	}
+	s.wait.Do(func() {
+		if s.cmd != nil {
+			s.waitErr = s.cmd.Wait()
+		}
+	})
+	return s.waitErr
+}
+
 func (s *unixTerminalSession) Close() error {
 	if s == nil {
 		return nil
 	}
 	if s.cmd != nil && s.cmd.Process != nil {
 		_ = s.cmd.Process.Kill()
-		_, _ = s.cmd.Process.Wait()
+		_ = s.Wait()
 	}
 	if s.ptyFile != nil {
 		return s.ptyFile.Close()

--- a/erun-ui/session_windows.go
+++ b/erun-ui/session_windows.go
@@ -3,7 +3,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"sync"
 	"syscall"
 
 	"github.com/ActiveState/termtest/conpty"
@@ -13,6 +15,8 @@ type windowsTerminalSession struct {
 	pty     *conpty.ConPty
 	outPipe *os.File
 	process *os.Process
+	wait    sync.Once
+	waitErr error
 }
 
 func startTerminalSession(params startTerminalSessionParams) (terminalSession, error) {
@@ -60,13 +64,30 @@ func (s *windowsTerminalSession) Resize(cols, rows int) error {
 	return s.pty.Resize(uint16(cols), uint16(rows))
 }
 
+func (s *windowsTerminalSession) Wait() error {
+	if s == nil {
+		return nil
+	}
+	s.wait.Do(func() {
+		if s.process != nil {
+			state, err := s.process.Wait()
+			if err != nil {
+				s.waitErr = err
+			} else if state != nil && state.ExitCode() != 0 {
+				s.waitErr = fmt.Errorf("exit status %d", state.ExitCode())
+			}
+		}
+	})
+	return s.waitErr
+}
+
 func (s *windowsTerminalSession) Close() error {
 	if s == nil {
 		return nil
 	}
 	if s.process != nil {
 		_ = s.process.Kill()
-		_, _ = s.process.Wait()
+		_ = s.Wait()
 	}
 	if s.pty != nil {
 		return s.pty.Close()


### PR DESCRIPTION
## Summary
- improves create and delete environment dialogs with busy states, inline errors, and clearer destructive confirmation
- preserves real terminal exit status for action sessions and avoids false success messages
- opens newly created environments automatically, restores terminal focus after dialogs close, and adds copy output actions for failed create/delete/deploy/open flows

## Validation
- PATH=/Users/rihardsfreimanis/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH yarn build
- go test ./... (erun-ui)

Closes #136
