### PR TITLE
Avoid destructive Helm pending recovery

### DIFF
--- a/erun-cli/cmd/helm_recovery.go
+++ b/erun-cli/cmd/helm_recovery.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+	common "github.com/sophium/erun/erun-common"
+)
+
+func wrapHelmDeployWithReleaseRecovery(promptRunner PromptRunner, deploy common.HelmChartDeployerFunc, recover common.HelmReleaseRecovererFunc) common.HelmChartDeployerFunc {
+	if deploy == nil {
+		return nil
+	}
+	if recover == nil {
+		recover = common.ClearHelmReleasePendingOperation
+	}
+
+	return func(params common.HelmDeployParams) error {
+		err := deploy(params)
+		if err == nil {
+			return nil
+		}
+
+		var pending *common.HelmReleasePendingOperationError
+		if !errors.As(err, &pending) || promptRunner == nil {
+			return err
+		}
+
+		ok, promptErr := confirmHelmReleaseRecovery(promptRunner, pending)
+		if promptErr != nil {
+			return promptErr
+		}
+		if !ok {
+			return err
+		}
+
+		if params.Stderr != nil {
+			_, _ = fmt.Fprintf(params.Stderr, "clearing pending helm metadata: %s\n", pending.RecoveryCommand())
+		}
+		if err := recover(pending.RecoveryParams(params.Stdout, params.Stderr)); err != nil {
+			return err
+		}
+		return deploy(params)
+	}
+}
+
+func confirmHelmReleaseRecovery(run PromptRunner, pending *common.HelmReleasePendingOperationError) (bool, error) {
+	prompt := promptui.Prompt{
+		Label:     helmReleaseRecoveryPromptLabel(pending),
+		IsConfirm: true,
+		Default:   "y",
+	}
+
+	result, err := run(prompt)
+	if err != nil {
+		if errors.Is(err, promptui.ErrInterrupt) {
+			return false, fmt.Errorf("helm release recovery interrupted")
+		}
+		if errors.Is(err, promptui.ErrAbort) {
+			return false, nil
+		}
+		return false, err
+	}
+	if strings.TrimSpace(result) == "" {
+		return true, nil
+	}
+	return strings.EqualFold(strings.TrimSpace(result), "y"), nil
+}
+
+func helmReleaseRecoveryPromptLabel(pending *common.HelmReleasePendingOperationError) string {
+	if pending == nil {
+		return "clear pending Helm release metadata and retry deploy"
+	}
+	label := fmt.Sprintf("clear pending Helm metadata for release %s", pending.ReleaseName)
+	if strings.TrimSpace(pending.Namespace) != "" {
+		label += " from namespace " + strings.TrimSpace(pending.Namespace)
+	}
+	if strings.TrimSpace(pending.KubernetesContext) != "" {
+		label += " in context " + strings.TrimSpace(pending.KubernetesContext)
+	}
+	return label + " and retry deploy"
+}

--- a/erun-cli/cmd/helm_recovery_test.go
+++ b/erun-cli/cmd/helm_recovery_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/manifoldco/promptui"
+	common "github.com/sophium/erun/erun-common"
+)
+
+func TestHelmDeployRecoveryClearsPendingMetadataAndRetries(t *testing.T) {
+	stderr := new(bytes.Buffer)
+	deployCalls := 0
+	var recovered common.HelmReleaseRecoveryParams
+
+	deploy := wrapHelmDeployWithReleaseRecovery(
+		func(prompt promptui.Prompt) (string, error) {
+			if !prompt.IsConfirm {
+				t.Fatalf("expected confirm prompt, got %+v", prompt)
+			}
+			want := "clear pending Helm metadata for release erun-devops from namespace erun-local in context rancher-desktop and retry deploy"
+			if prompt.Label != want {
+				t.Fatalf("unexpected prompt label %q, want %q", prompt.Label, want)
+			}
+			return "y", nil
+		},
+		func(params common.HelmDeployParams) error {
+			deployCalls++
+			if deployCalls == 1 {
+				return &common.HelmReleasePendingOperationError{
+					ReleaseName:       params.ReleaseName,
+					Namespace:         params.Namespace,
+					KubernetesContext: params.KubernetesContext,
+					Message:           "Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress",
+					Err:               errors.New("exit status 1"),
+				}
+			}
+			return nil
+		},
+		func(params common.HelmReleaseRecoveryParams) error {
+			recovered = params
+			return nil
+		},
+	)
+
+	err := deploy(common.HelmDeployParams{
+		ReleaseName:       "erun-devops",
+		Namespace:         "erun-local",
+		KubernetesContext: "rancher-desktop",
+		Stderr:            stderr,
+	})
+	if err != nil {
+		t.Fatalf("deploy failed: %v", err)
+	}
+	if deployCalls != 2 {
+		t.Fatalf("expected deploy to retry once, got %d calls", deployCalls)
+	}
+	if recovered.ReleaseName != "erun-devops" || recovered.Namespace != "erun-local" || recovered.KubernetesContext != "rancher-desktop" {
+		t.Fatalf("unexpected recovery params: %+v", recovered)
+	}
+	if strings.Contains(stderr.String(), "helm uninstall") {
+		t.Fatalf("did not expect destructive uninstall command, got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "kubectl --context rancher-desktop --namespace erun-local delete 'secrets,configmaps'") {
+		t.Fatalf("expected recovery command in stderr, got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "owner=helm,name=erun-devops,status in (pending-install,pending-upgrade,pending-rollback)") {
+		t.Fatalf("expected pending metadata selector in stderr, got %q", stderr.String())
+	}
+}

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -266,7 +266,11 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 				func(ctx common.Context, pushInput common.DockerPushSpec) error {
 					return common.RunDockerPush(ctx, pushInput, common.DockerImagePusher)
 				},
-				wrapOpenHelmDeployWithSpinner(ctx, execution.Deploy.ReleaseName, deployHelmChart),
+				wrapHelmDeployWithReleaseRecovery(
+					promptRunner,
+					wrapOpenHelmDeployWithSpinner(ctx, execution.Deploy.ReleaseName, deployHelmChart),
+					common.ClearHelmReleasePendingOperation,
+				),
 			); err != nil {
 				return err
 			}

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -28,7 +28,8 @@ func Execute() error {
 	configStore := common.ConfigStore{}
 	store := rootStore(configStore)
 	deployHelmChart := common.WrapHelmChartDeployerWithNamespaceEnsure(ensureKubernetesNamespace, common.DeployHelmChart)
-	runInit := newRunInit(store, common.FindProjectRoot, runPrompt, runSelect, listKubernetesContexts, ensureKubernetesNamespace, common.WaitForShellDeployment, common.RunRemoteCommand, deployHelmChart)
+	recoveringDeployHelmChart := wrapHelmDeployWithReleaseRecovery(runPrompt, deployHelmChart, common.ClearHelmReleasePendingOperation)
+	runInit := newRunInit(store, common.FindProjectRoot, runPrompt, runSelect, listKubernetesContexts, ensureKubernetesNamespace, common.WaitForShellDeployment, common.RunRemoteCommand, recoveringDeployHelmChart)
 	runInitForArgs := newRunInitForArgs(store, runInit)
 	runInitForOpen := newRunInitForOpen(store, runInit)
 	push := newPushOperation(nil, common.DockerRegistryLogin, runSelect)
@@ -56,7 +57,7 @@ func Execute() error {
 		if err != nil {
 			return err
 		}
-		return common.RunDeploySpecs(ctx, specs, common.DockerImageBuilder, push, deployHelmChart)
+		return common.RunDeploySpecs(ctx, specs, common.DockerImageBuilder, push, recoveringDeployHelmChart)
 	}
 
 	initCmd := newInitCmd(runInit)
@@ -75,23 +76,23 @@ func Execute() error {
 		launchVSCode,
 		launchIntelliJ,
 	)
-	sshdCmd := newSSHDCmd(resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, deployHelmChart, common.RunRemoteCommand, writeLocalSSHConfig)
+	sshdCmd := newSSHDCmd(resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, recoveringDeployHelmChart, common.RunRemoteCommand, writeLocalSSHConfig)
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
-		newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, common.DockerRegistryLogin, runSelect, push, deployHelmChart),
+		newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, common.DockerRegistryLogin, runSelect, push, recoveringDeployHelmChart),
 		newPushCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.DockerImageBuilder, push),
 	)
 	k8sCmd := newCommandGroup(
 		"k8s",
 		"Kubernetes utilities",
-		newK8sDeployCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.DockerImageBuilder, push, deployHelmChart),
+		newK8sDeployCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.DockerImageBuilder, push, recoveringDeployHelmChart),
 	)
 	devopsCmd := newCommandGroup("devops", "DevOps utilities", containerCmd, k8sCmd)
 
 	var buildCmd *cobra.Command
 	if hasOptionalBuildCmd(common.FindProjectRoot, common.ResolveDockerBuildContext) {
-		buildCmd = newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, common.DockerRegistryLogin, runSelect, push, deployHelmChart)
+		buildCmd = newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, common.DockerRegistryLogin, runSelect, push, recoveringDeployHelmChart)
 		buildCmd.Short = optionalBuildCmdShort(common.FindProjectRoot, common.ResolveDockerBuildContext)
 	}
 	var pushCmd *cobra.Command
@@ -101,7 +102,7 @@ func Execute() error {
 	}
 	var deployCmd *cobra.Command
 	if hasOptionalDeployCmd(common.ResolveKubernetesDeployContext) {
-		deployCmd = newDeployCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.DockerImageBuilder, push, deployHelmChart)
+		deployCmd = newDeployCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.DockerImageBuilder, push, recoveringDeployHelmChart)
 	}
 
 	mcpCmd := newMCPCmd(resolveOpen, runInitForArgs, launchMCPProcess)

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -30,6 +30,7 @@ type testRootDeps struct {
 	PushDockerImage                common.DockerImagePusherFunc
 	LoginToDockerRegistry          common.DockerRegistryLoginFunc
 	DeployHelmChart                common.HelmChartDeployerFunc
+	RecoverHelmRelease             common.HelmReleaseRecovererFunc
 	LaunchMCP                      MCPLauncher
 	ForwardMCP                     MCPForwarder
 	LaunchApp                      AppLauncher
@@ -101,6 +102,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	if deps.EnsureKubernetesNamespace != nil {
 		deployHelmChart = common.WrapHelmChartDeployerWithNamespaceEnsure(deps.EnsureKubernetesNamespace, deployHelmChart)
 	}
+	recoveringDeployHelmChart := wrapHelmDeployWithReleaseRecovery(promptRunner, deployHelmChart, deps.RecoverHelmRelease)
 	launchMCP := deps.LaunchMCP
 	if launchMCP == nil {
 		launchMCP = launchMCPProcess
@@ -165,7 +167,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 		if err != nil {
 			return err
 		}
-		return common.RunDeploySpecs(ctx, specs, buildDockerImage, push, deployHelmChart)
+		return common.RunDeploySpecs(ctx, specs, buildDockerImage, push, recoveringDeployHelmChart)
 	}
 	ensureKubernetesNamespace := func(contextName, namespace string) error {
 		if deps.EnsureKubernetesNamespace == nil {
@@ -173,7 +175,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 		}
 		return deps.EnsureKubernetesNamespace(contextName, namespace)
 	}
-	runInit := newRunInit(store, findProjectRoot, promptRunner, selectRunner, listKubernetesContexts, ensureKubernetesNamespace, deps.WaitForRemoteRuntime, deps.RunRemoteCommand, deployHelmChart)
+	runInit := newRunInit(store, findProjectRoot, promptRunner, selectRunner, listKubernetesContexts, ensureKubernetesNamespace, deps.WaitForRemoteRuntime, deps.RunRemoteCommand, recoveringDeployHelmChart)
 	runInitForArgs := newRunInitForArgs(store, runInit)
 	runInitForOpen := newRunInitForOpen(store, runInit)
 
@@ -183,19 +185,19 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
-		newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, runBuildScript, buildDockerImage, loginToDockerRegistry, selectRunner, push, deployHelmChart),
+		newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, runBuildScript, buildDockerImage, loginToDockerRegistry, selectRunner, push, recoveringDeployHelmChart),
 		newPushCmd(store, findProjectRoot, resolveDockerBuildContext, now, buildDockerImage, push),
 	)
 	k8sCmd := newCommandGroup(
 		"k8s",
 		"Kubernetes utilities",
-		newK8sDeployCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, buildDockerImage, push, deployHelmChart),
+		newK8sDeployCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, buildDockerImage, push, recoveringDeployHelmChart),
 	)
 	devopsCmd := newCommandGroup("devops", "DevOps utilities", containerCmd, k8sCmd)
 
 	var buildCmd *cobra.Command
 	if hasOptionalBuildCmd(optionalBuildFindProjectRoot, resolveDockerBuildContext) {
-		buildCmd = newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, runBuildScript, buildDockerImage, loginToDockerRegistry, selectRunner, push, deployHelmChart)
+		buildCmd = newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, runBuildScript, buildDockerImage, loginToDockerRegistry, selectRunner, push, recoveringDeployHelmChart)
 		buildCmd.Short = optionalBuildCmdShort(optionalBuildFindProjectRoot, resolveDockerBuildContext)
 	}
 	var pushCmd *cobra.Command
@@ -205,7 +207,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	}
 	var deployCmd *cobra.Command
 	if hasOptionalDeployCmd(resolveKubernetesDeployContext) {
-		deployCmd = newDeployCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, buildDockerImage, push, deployHelmChart)
+		deployCmd = newDeployCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, buildDockerImage, push, recoveringDeployHelmChart)
 	}
 
 	mcpCmd := newMCPCmd(resolveOpen, runInitForArgs, launchMCP)

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -33,6 +33,7 @@ type (
 	DeployContextResolverFunc       func() (KubernetesDeployContext, error)
 	KubernetesDeploymentCheckerFunc func(KubernetesDeploymentCheckParams) (bool, error)
 	HelmChartDeployerFunc           func(HelmDeployParams) error
+	HelmReleaseRecovererFunc        func(HelmReleaseRecoveryParams) error
 )
 
 type deployKubernetesContextResolver interface {
@@ -77,6 +78,22 @@ type HelmDeploySpec struct {
 	SSHDEnabled       bool
 	Version           string
 	Timeout           string
+}
+
+type HelmReleaseRecoveryParams struct {
+	ReleaseName       string
+	Namespace         string
+	KubernetesContext string
+	Stdout            io.Writer
+	Stderr            io.Writer
+}
+
+type HelmReleasePendingOperationError struct {
+	ReleaseName       string
+	Namespace         string
+	KubernetesContext string
+	Message           string
+	Err               error
 }
 
 type KubernetesDeploymentCheckParams struct {
@@ -644,6 +661,71 @@ func (d HelmDeploySpec) command() commandSpec {
 	}
 }
 
+func (p HelmReleaseRecoveryParams) command() commandSpec {
+	args := []string{}
+	if strings.TrimSpace(p.KubernetesContext) != "" {
+		args = append(args, "--context", p.KubernetesContext)
+	}
+	args = append(args,
+		"--namespace", p.Namespace,
+		"delete",
+		"secrets,configmaps",
+		"-l", helmPendingReleaseOperationSelector(p.ReleaseName),
+		"--ignore-not-found",
+	)
+
+	return commandSpec{
+		Name: "kubectl",
+		Args: args,
+	}
+}
+
+func helmPendingReleaseOperationSelector(releaseName string) string {
+	return "owner=helm,name=" + releaseName + ",status in (pending-install,pending-upgrade,pending-rollback)"
+}
+
+func (e *HelmReleasePendingOperationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	message := strings.TrimSpace(e.Message)
+	if message == "" && e.Err != nil {
+		message = e.Err.Error()
+	}
+	if message == "" {
+		message = "helm release operation is already in progress"
+	}
+	return fmt.Sprintf("%s; recover with: %s", message, e.RecoveryCommand())
+}
+
+func (e *HelmReleasePendingOperationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *HelmReleasePendingOperationError) RecoveryParams(stdout, stderr io.Writer) HelmReleaseRecoveryParams {
+	if e == nil {
+		return HelmReleaseRecoveryParams{Stdout: stdout, Stderr: stderr}
+	}
+	return HelmReleaseRecoveryParams{
+		ReleaseName:       e.ReleaseName,
+		Namespace:         e.Namespace,
+		KubernetesContext: e.KubernetesContext,
+		Stdout:            stdout,
+		Stderr:            stderr,
+	}
+}
+
+func (e *HelmReleasePendingOperationError) RecoveryCommand() string {
+	if e == nil {
+		return ""
+	}
+	command := e.RecoveryParams(nil, nil).command()
+	return formatShellCommand(command.Dir, command.Name, command.Args...)
+}
+
 func formatHelmBool(value bool) string {
 	if value {
 		return "true"
@@ -896,8 +978,45 @@ func DeployHelmChart(params HelmDeployParams) error {
 	cmd := exec.Command(command.Name, command.Args...)
 	cmd.Dir = command.Dir
 	cmd.Stdout = params.Stdout
+	stderr := new(strings.Builder)
+	if params.Stderr != nil {
+		cmd.Stderr = io.MultiWriter(params.Stderr, stderr)
+	} else {
+		cmd.Stderr = stderr
+	}
+	err := cmd.Run()
+	if err != nil && isHelmReleasePendingOperationMessage(stderr.String()) {
+		return &HelmReleasePendingOperationError{
+			ReleaseName:       params.ReleaseName,
+			Namespace:         params.Namespace,
+			KubernetesContext: params.KubernetesContext,
+			Message:           stderr.String(),
+			Err:               err,
+		}
+	}
+	return err
+}
+
+func ClearHelmReleasePendingOperation(params HelmReleaseRecoveryParams) error {
+	if strings.TrimSpace(params.ReleaseName) == "" {
+		return fmt.Errorf("helm release name is required")
+	}
+	if strings.TrimSpace(params.Namespace) == "" {
+		return fmt.Errorf("helm release namespace is required")
+	}
+
+	command := params.command()
+	cmd := exec.Command(command.Name, command.Args...)
+	cmd.Stdout = params.Stdout
 	cmd.Stderr = params.Stderr
 	return cmd.Run()
+}
+
+func isHelmReleasePendingOperationMessage(message string) bool {
+	message = strings.ToLower(message)
+	return strings.Contains(message, "another operation") &&
+		strings.Contains(message, "install/upgrade/rollback") &&
+		strings.Contains(message, "in progress")
 }
 
 func prepareHelmChartForDeploy(chartPath, version string) (string, func(), error) {

--- a/erun-common/deploy_test.go
+++ b/erun-common/deploy_test.go
@@ -2,6 +2,7 @@ package eruncommon
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -811,6 +812,85 @@ printf '%s
 	args := string(data)
 	if !strings.Contains(args, "--set\nsshdEnabled=true\n") {
 		t.Fatalf("expected helm args to include sshdEnabled=true, got:\n%s", args)
+	}
+}
+
+func TestDeployHelmChartReturnsPendingOperationError(t *testing.T) {
+	helmDir := t.TempDir()
+	helmPath := filepath.Join(helmDir, "helm")
+	if err := os.WriteFile(helmPath, []byte(`#!/bin/sh
+echo "Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress" >&2
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write helm stub: %v", err)
+	}
+	t.Setenv("PATH", helmDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	chartPath := createHelmChartFixture(t, t.TempDir(), "erun-devops")
+	stderr := new(bytes.Buffer)
+	err := DeployHelmChart(HelmDeployParams{
+		ReleaseName:       "erun-devops",
+		ChartPath:         chartPath,
+		ValuesFilePath:    filepath.Join(chartPath, "values.local.yaml"),
+		Tenant:            "erun",
+		Environment:       "local",
+		Namespace:         "erun-local",
+		KubernetesContext: "rancher-desktop",
+		WorktreeStorage:   WorktreeStorageHost,
+		WorktreeRepoName:  "erun",
+		WorktreeHostPath:  "/home/erun/git/erun",
+		Timeout:           DefaultHelmDeploymentTimeout,
+		Stderr:            stderr,
+	})
+
+	var pending *HelmReleasePendingOperationError
+	if !errors.As(err, &pending) {
+		t.Fatalf("expected pending operation error, got %T: %v", err, err)
+	}
+	if pending.ReleaseName != "erun-devops" || pending.Namespace != "erun-local" || pending.KubernetesContext != "rancher-desktop" {
+		t.Fatalf("unexpected pending operation details: %+v", pending)
+	}
+	if !strings.Contains(stderr.String(), "another operation") {
+		t.Fatalf("expected helm stderr to remain streamed, got %q", stderr.String())
+	}
+	wantCommand := "kubectl --context rancher-desktop --namespace erun-local delete 'secrets,configmaps' -l 'owner=helm,name=erun-devops,status in (pending-install,pending-upgrade,pending-rollback)' --ignore-not-found"
+	if pending.RecoveryCommand() != wantCommand {
+		t.Fatalf("unexpected recovery command %q, want %q", pending.RecoveryCommand(), wantCommand)
+	}
+}
+
+func TestClearHelmReleasePendingOperationDeletesOnlyPendingMetadata(t *testing.T) {
+	kubectlDir := t.TempDir()
+	argsPath := filepath.Join(kubectlDir, "kubectl-args.txt")
+	kubectlPath := filepath.Join(kubectlDir, "kubectl")
+	if err := os.WriteFile(kubectlPath, []byte(`#!/bin/sh
+printf '%s
+' "$@" > "$ERUN_KUBECTL_ARGS_FILE"
+`), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+	t.Setenv("ERUN_KUBECTL_ARGS_FILE", argsPath)
+	t.Setenv("PATH", kubectlDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := ClearHelmReleasePendingOperation(HelmReleaseRecoveryParams{
+		ReleaseName:       "erun-devops",
+		Namespace:         "erun-local",
+		KubernetesContext: "rancher-desktop",
+	}); err != nil {
+		t.Fatalf("ClearHelmReleasePendingOperation failed: %v", err)
+	}
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read kubectl args: %v", err)
+	}
+	args := string(data)
+	if strings.Contains(args, "uninstall\n") {
+		t.Fatalf("did not expect helm uninstall args:\n%s", args)
+	}
+	want := "--context\nrancher-desktop\n--namespace\nerun-local\ndelete\nsecrets,configmaps\n-l\nowner=helm,name=erun-devops,status in (pending-install,pending-upgrade,pending-rollback)\n--ignore-not-found\n"
+	if args != want {
+		t.Fatalf("unexpected kubectl recovery args:\n%s", args)
 	}
 }
 


### PR DESCRIPTION
## Summary

- detect Helm pending-operation upgrade failures and return structured recovery details
- prompt CLI users to clear only pending Helm release metadata before retrying deploy once
- avoid destructive `helm uninstall` recovery so chart-managed resources such as PVCs are not removed
- keep MCP non-interactive by returning recovery details through the deploy error

## Validation

- `go test ./...` in `erun-common`
- `go test ./...` in `erun-cli`
- `go test ./...` in `erun-mcp`
- `git diff --check`

Closes #142
