### PR TITLE
Refine desktop environment config management

### DIFF
--- a/erun-cli/cmd/deploy.go
+++ b/erun-cli/cmd/deploy.go
@@ -25,6 +25,9 @@ func newDeployCmd(store common.DeployStore, findProjectRoot common.ProjectFinder
 			if err != nil {
 				return err
 			}
+			if snapshotOverride == nil {
+				snapshotOverride = &snapshot
+			}
 			deployTarget.Snapshot = snapshotOverride
 			deploySpecs, err := common.ResolveCurrentDeploySpecs(store, findProjectRoot, resolveBuildContext, resolveDeployContext, now, deployTarget)
 			if err != nil {
@@ -53,6 +56,9 @@ func newK8sDeployCmd(store common.DeployStore, findProjectRoot common.ProjectFin
 			snapshotOverride, err := resolveSnapshotFlagOverride(cmd, snapshot, noSnapshot)
 			if err != nil {
 				return err
+			}
+			if snapshotOverride == nil {
+				snapshotOverride = &snapshot
 			}
 			target.Snapshot = snapshotOverride
 			deploySpec, err := common.ResolveDeploySpec(store, findProjectRoot, resolveBuildContext, resolveDeployContext, now, target, args[0], "")

--- a/erun-cli/cmd/list_test.go
+++ b/erun-cli/cmd/list_test.go
@@ -86,17 +86,17 @@ func TestListCommandPrintsDefaultsAndConfiguredTenants(t *testing.T) {
 		"  configured tenant: none",
 		"  effective target: tenant-a/local",
 		"  kubernetes context: cluster-local",
-		"  snapshot: on",
+		"  snapshot: off",
 		"  assigned local port range: 17000-17099",
 		"  assigned mcp local port: 17000 (when MCP is running or forwarded)",
 		"  assigned ssh local port: 17022 (when SSH port-forward is active)",
 		"Tenants:",
 		"  tenant-a [default, effective]",
 		"    default environment: local",
-		"      - local [default, effective] context=cluster-local snapshot=on repo=" + tenantAPath + " ports=17000-17099 mcp-port=17000 ssh-port=17022",
-		"      - prod context=cluster-prod snapshot=on repo=" + tenantAPath + " ports=17100-17199 mcp-port=17100 ssh-port=17122",
+		"      - local [default, effective] context=cluster-local snapshot=off repo=" + tenantAPath + " ports=17000-17099 mcp-port=17000 ssh-port=17022",
+		"      - prod context=cluster-prod snapshot=off repo=" + tenantAPath + " ports=17100-17199 mcp-port=17100 ssh-port=17122",
 		"  tenant-b",
-		"      - dev [default] context=cluster-b snapshot=on repo=" + tenantBPath + " ports=17200-17299 mcp-port=17200 ssh-port=17222",
+		"      - dev [default] context=cluster-b snapshot=off repo=" + tenantBPath + " ports=17200-17299 mcp-port=17200 ssh-port=17222",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected list output to contain %q, got:\n%s", want, output)
@@ -174,12 +174,12 @@ func TestListCommandUsesConfiguredCurrentDirectoryTenantBeforeDefault(t *testing
 		"  configured tenant: tenant-b",
 		"  effective target: tenant-b/dev",
 		"  kubernetes context: cluster-b",
-		"  snapshot: on",
+		"  snapshot: off",
 		"  assigned local port range: 17100-17199",
 		"  assigned mcp local port: 17100 (when MCP is running or forwarded)",
 		"  assigned ssh local port: 17122 (when SSH port-forward is active)",
 		"  tenant-b [effective]",
-		"      - dev [default, effective] context=cluster-b snapshot=on repo=" + tenantBPath + " ports=17100-17199 mcp-port=17100 ssh-port=17122",
+		"      - dev [default, effective] context=cluster-b snapshot=off repo=" + tenantBPath + " ports=17100-17199 mcp-port=17100 ssh-port=17122",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected list output to contain %q, got:\n%s", want, output)

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -62,7 +62,15 @@ func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), 
 			if err != nil {
 				return err
 			}
-			return runResolvedOpenCommand(ctx, result, openOptions{NoShell: noShell, NoAliasPrompt: noAliasPrompt, VSCode: vscode, IntelliJ: intellij, VersionOverride: versionOverride, RuntimeImage: runtimeImage}, promptRunner, openShell, runManagedDeploy, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart, activateMCP, activateSSHD, launchVSCode, launchIntelliJ)
+			return runResolvedOpenCommand(ctx, result, openOptions{
+				NoShell:         noShell,
+				NoAliasPrompt:   noAliasPrompt,
+				VSCode:          vscode,
+				IntelliJ:        intellij,
+				VersionOverride: versionOverride,
+				RuntimeImage:    runtimeImage,
+				SaveEnvConfig:   saveEnvConfig,
+			}, promptRunner, openShell, runManagedDeploy, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart, activateMCP, activateSSHD, launchVSCode, launchIntelliJ)
 		},
 	}
 
@@ -86,6 +94,7 @@ type openOptions struct {
 	IntelliJ        bool
 	VersionOverride string
 	RuntimeImage    string
+	SaveEnvConfig   func(string, common.EnvConfig) error
 }
 
 func applyOpenSnapshotPreference(result common.OpenResult, enabled *bool, saveEnvConfig func(string, common.EnvConfig) error) (common.OpenResult, error) {
@@ -98,6 +107,34 @@ func applyOpenSnapshotPreference(result common.OpenResult, enabled *bool, saveEn
 		return result, nil
 	}
 	if err := saveEnvConfig(result.Tenant, result.EnvConfig); err != nil {
+		return common.OpenResult{}, err
+	}
+	return result, nil
+}
+
+func persistOpenRuntimeVersion(result common.OpenResult, version string, saveEnvConfig func(string, common.EnvConfig) error) (common.OpenResult, error) {
+	version = strings.TrimSpace(version)
+	if version == "" || saveEnvConfig == nil {
+		return result, nil
+	}
+
+	updated := result.EnvConfig
+	changed := false
+	if strings.TrimSpace(updated.RuntimeVersion) != version {
+		updated.RuntimeVersion = version
+		changed = true
+	}
+	snapshot := strings.Contains(version, "-snapshot-")
+	if updated.Snapshot == nil || *updated.Snapshot != snapshot {
+		updated.SetSnapshot(snapshot)
+		changed = true
+	}
+	if !changed {
+		return result, nil
+	}
+
+	result.EnvConfig = updated
+	if err := saveEnvConfig(result.Tenant, updated); err != nil {
 		return common.OpenResult{}, err
 	}
 	return result, nil
@@ -273,6 +310,12 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 				),
 			); err != nil {
 				return err
+			}
+			if !ctx.DryRun {
+				result, err = persistOpenRuntimeVersion(result, execution.Deploy.Version, options.SaveEnvConfig)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/erun-cli/cmd/open_test.go
+++ b/erun-cli/cmd/open_test.go
@@ -420,6 +420,92 @@ func TestRunResolvedOpenCommandForcesSSHDEnabledOnRuntimeDeploy(t *testing.T) {
 	}
 }
 
+func TestRunResolvedOpenCommandPersistsRuntimeVersionAfterDeploy(t *testing.T) {
+	const deployedVersion = "1.0.50-snapshot-20260426163200"
+
+	var saved common.EnvConfig
+	savedTenant := ""
+	err := runResolvedOpenCommand(
+		common.Context{
+			Logger: common.NewLoggerWithWriters(0, new(bytes.Buffer), new(bytes.Buffer)),
+			Stdout: new(bytes.Buffer),
+			Stderr: new(bytes.Buffer),
+		},
+		common.OpenResult{
+			Tenant:      "test",
+			Environment: "env",
+			RepoPath:    "/home/erun/git/test",
+			TenantConfig: common.TenantConfig{
+				Name: "test",
+			},
+			EnvConfig: common.EnvConfig{
+				Name:              "env",
+				RepoPath:          "/home/erun/git/test",
+				KubernetesContext: "erun",
+				RuntimeVersion:    "1.0.48",
+				Remote:            true,
+			},
+		},
+		openOptions{
+			NoShell: true,
+			SaveEnvConfig: func(tenant string, env common.EnvConfig) error {
+				savedTenant = tenant
+				saved = env
+				return nil
+			},
+		},
+		nil,
+		func(_ common.Context, _ common.ShellLaunchParams) error {
+			t.Fatal("did not expect shell launch")
+			return nil
+		},
+		nil,
+		func(common.KubernetesDeploymentCheckParams) (bool, error) {
+			return false, nil
+		},
+		func(common.OpenResult) (common.DeploySpec, error) {
+			return common.DeploySpec{
+				Deploy: common.HelmDeploySpec{
+					ReleaseName:       "test-devops",
+					ChartPath:         "/tmp/chart",
+					ValuesFilePath:    "/tmp/chart/values.env.yaml",
+					Tenant:            "test",
+					Environment:       "env",
+					Namespace:         "test-env",
+					KubernetesContext: "erun",
+					WorktreeStorage:   common.WorktreeStoragePVC,
+					WorktreeRepoName:  "test",
+					WorktreeHostPath:  "/tmp/ignored",
+					Version:           deployedVersion,
+					Timeout:           common.DefaultHelmDeploymentTimeout,
+				},
+			}, nil
+		},
+		func(params common.HelmDeployParams) error {
+			if params.Version != deployedVersion {
+				t.Fatalf("unexpected deployed version: %+v", params)
+			}
+			return nil
+		},
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("runResolvedOpenCommand failed: %v", err)
+	}
+	if savedTenant != "test" {
+		t.Fatalf("expected env config saved for test tenant, got %q", savedTenant)
+	}
+	if saved.RuntimeVersion != deployedVersion {
+		t.Fatalf("expected persisted runtime version %q, got %q", deployedVersion, saved.RuntimeVersion)
+	}
+	if saved.Snapshot == nil || !*saved.Snapshot {
+		t.Fatalf("expected snapshot deployment to persist snapshot true, got %+v", saved)
+	}
+}
+
 func TestOpenCommandNoShellConfiguresLocalKubeconfig(t *testing.T) {
 	repoPath := t.TempDir()
 	stdout := new(bytes.Buffer)
@@ -911,10 +997,17 @@ func TestOpenCommandDryRunPrintsDeployPlanWhenDevopsRuntimeIsMissing(t *testing.
 
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
+	snapshot := true
 	cmd := newTestRootCmd(testRootDeps{
 		Store: openCommandStore{
 			repoPath:   projectRoot,
 			toolConfig: common.ERunConfig{DefaultTenant: "tenant-a"},
+			env: &common.EnvConfig{
+				Name:              common.DefaultEnvironment,
+				RepoPath:          projectRoot,
+				KubernetesContext: "cluster-dev",
+				Snapshot:          &snapshot,
+			},
 		},
 		CheckKubernetesDeployment: func(req common.KubernetesDeploymentCheckParams) (bool, error) {
 			return false, nil
@@ -987,10 +1080,17 @@ func TestOpenCommandDryRunRedeploysWhenRuntimeHasLocalBuilds(t *testing.T) {
 
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
+	snapshot := true
 	cmd := newTestRootCmd(testRootDeps{
 		Store: openCommandStore{
 			repoPath:   projectRoot,
 			toolConfig: common.ERunConfig{DefaultTenant: "tenant-a"},
+			env: &common.EnvConfig{
+				Name:              common.DefaultEnvironment,
+				RepoPath:          projectRoot,
+				KubernetesContext: "cluster-dev",
+				Snapshot:          &snapshot,
+			},
 		},
 		CheckKubernetesDeployment: func(req common.KubernetesDeploymentCheckParams) (bool, error) {
 			t.Fatalf("did not expect deployment check when local runtime builds exist: %+v", req)
@@ -1112,10 +1212,12 @@ func TestOpenCommandDryRunUsesConfiguredContextForLocalDeploy(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
+	snapshot := true
 	if err := common.SaveEnvConfig("erun", common.EnvConfig{
 		Name:              common.DefaultEnvironment,
 		RepoPath:          projectRoot,
 		KubernetesContext: "erun",
+		Snapshot:          &snapshot,
 	}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}

--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -55,7 +55,7 @@ type EnvConfig struct {
 
 func (c TenantConfig) SnapshotEnabled() bool {
 	if c.Snapshot == nil {
-		return true
+		return false
 	}
 	return *c.Snapshot
 }
@@ -70,7 +70,7 @@ func (c *TenantConfig) SetSnapshot(enabled bool) {
 
 func (c EnvConfig) SnapshotEnabled() bool {
 	if c.Snapshot == nil {
-		return true
+		return false
 	}
 	return *c.Snapshot
 }

--- a/erun-common/deploy_test.go
+++ b/erun-common/deploy_test.go
@@ -437,16 +437,18 @@ func TestResolveOpenRuntimeDeploySpecIgnoresTenantSnapshotSetting(t *testing.T) 
 		t.Fatalf("save project config: %v", err)
 	}
 
-	snapshot := false
+	tenantSnapshot := false
+	envSnapshot := true
 	spec, err := ResolveOpenRuntimeDeploySpec(ConfigStore{}, FindProjectRoot, ResolveDockerBuildContext, ResolveKubernetesDeployContext, nil, OpenResult{
 		Tenant:      "frs",
 		Environment: DefaultEnvironment,
 		RepoPath:    projectRoot,
 		TenantConfig: TenantConfig{
-			Snapshot: &snapshot,
+			Snapshot: &tenantSnapshot,
 		},
 		EnvConfig: EnvConfig{
 			KubernetesContext: "cluster-local",
+			Snapshot:          &envSnapshot,
 		},
 	})
 	if err != nil {

--- a/erun-common/list_test.go
+++ b/erun-common/list_test.go
@@ -90,8 +90,8 @@ func TestResolveListResultUsesCurrentDirectoryTenantBeforeDefault(t *testing.T) 
 	if result.CurrentDirectory.Effective.Tenant != "tenant-b" || result.CurrentDirectory.Effective.Environment != "dev" {
 		t.Fatalf("unexpected effective target: %+v", result.CurrentDirectory.Effective)
 	}
-	if !result.CurrentDirectory.Effective.Snapshot {
-		t.Fatalf("expected effective snapshot to default on, got %+v", result.CurrentDirectory.Effective)
+	if result.CurrentDirectory.Effective.Snapshot {
+		t.Fatalf("expected effective snapshot to default off, got %+v", result.CurrentDirectory.Effective)
 	}
 	if len(result.Tenants) != 2 {
 		t.Fatalf("unexpected tenants: %+v", result.Tenants)
@@ -156,8 +156,8 @@ func TestResolveListResultFallsBackToDefaultWhenRepoIsNotConfiguredTenant(t *tes
 	if result.CurrentDirectory.Effective.Tenant != "tenant-a" || result.CurrentDirectory.Effective.Environment != "dev" {
 		t.Fatalf("unexpected effective target: %+v", result.CurrentDirectory.Effective)
 	}
-	if !result.CurrentDirectory.Effective.Snapshot {
-		t.Fatalf("expected effective snapshot to default on, got %+v", result.CurrentDirectory.Effective)
+	if result.CurrentDirectory.Effective.Snapshot {
+		t.Fatalf("expected effective snapshot to default off, got %+v", result.CurrentDirectory.Effective)
 	}
 }
 
@@ -214,8 +214,8 @@ func TestResolveListResultUsesEffectiveKubernetesContextForCurrentDirectoryTarge
 	if result.CurrentDirectory.Effective.KubernetesContext != "docker-desktop" {
 		t.Fatalf("unexpected effective kubernetes context: %+v", result.CurrentDirectory.Effective)
 	}
-	if !result.CurrentDirectory.Effective.Snapshot {
-		t.Fatalf("expected effective snapshot to default on, got %+v", result.CurrentDirectory.Effective)
+	if result.CurrentDirectory.Effective.Snapshot {
+		t.Fatalf("expected effective snapshot to default off, got %+v", result.CurrentDirectory.Effective)
 	}
 	if got := result.Tenants[0].Environments[0].KubernetesContext; got != "rancher-desktop" {
 		t.Fatalf("expected configured tenant environment context to remain unchanged, got %q", got)

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -21,6 +21,9 @@ const (
 
 type erunUIStore interface {
 	eruncommon.ListStore
+	SaveERunConfig(eruncommon.ERunConfig) error
+	SaveTenantConfig(eruncommon.TenantConfig) error
+	SaveEnvConfig(string, eruncommon.EnvConfig) error
 }
 
 type erunUIDeps struct {
@@ -82,6 +85,32 @@ type uiBuildDetails struct {
 }
 
 type uiVersion = eruncommon.RuntimeVersionSuggestion
+
+type uiERunConfig struct {
+	DefaultTenant string `json:"defaultTenant"`
+}
+
+type uiTenantConfig struct {
+	Name               string `json:"name"`
+	DefaultEnvironment string `json:"defaultEnvironment"`
+}
+
+type uiSSHDConfig struct {
+	Enabled       bool   `json:"enabled"`
+	LocalPort     int    `json:"localPort"`
+	PublicKeyPath string `json:"publicKeyPath"`
+}
+
+type uiEnvironmentConfig struct {
+	Name              string       `json:"name"`
+	RepoPath          string       `json:"repoPath"`
+	KubernetesContext string       `json:"kubernetesContext"`
+	ContainerRegistry string       `json:"containerRegistry"`
+	RuntimeVersion    string       `json:"runtimeVersion"`
+	SSHD              uiSSHDConfig `json:"sshd"`
+	Remote            bool         `json:"remote"`
+	Snapshot          bool         `json:"snapshot"`
+}
 
 type startSessionResult struct {
 	SessionID int         `json:"sessionId"`
@@ -244,6 +273,84 @@ func (a *App) LoadVersionSuggestions(selection uiSelection) ([]uiVersion, error)
 	return a.runtimeVersionSuggestions(a.deps.resolveBuildInfo(), selection.Tenant), nil
 }
 
+func (a *App) LoadERunConfig() (uiERunConfig, error) {
+	config, _, err := a.deps.store.LoadERunConfig()
+	if err != nil {
+		return uiERunConfig{}, err
+	}
+	return erunConfigToUI(config), nil
+}
+
+func (a *App) SaveERunConfig(config uiERunConfig) (uiERunConfig, error) {
+	updated := eruncommon.ERunConfig{
+		DefaultTenant: strings.TrimSpace(config.DefaultTenant),
+	}
+	if err := a.deps.store.SaveERunConfig(updated); err != nil {
+		return uiERunConfig{}, err
+	}
+	return erunConfigToUI(updated), nil
+}
+
+func (a *App) LoadTenantConfig(tenant string) (uiTenantConfig, error) {
+	tenant = strings.TrimSpace(tenant)
+	if tenant == "" {
+		return uiTenantConfig{}, fmt.Errorf("tenant is required")
+	}
+
+	config, _, err := a.deps.store.LoadTenantConfig(tenant)
+	if err != nil {
+		return uiTenantConfig{}, err
+	}
+	return tenantConfigToUI(config, tenant), nil
+}
+
+func (a *App) SaveTenantConfig(config uiTenantConfig) (uiTenantConfig, error) {
+	tenant := strings.TrimSpace(config.Name)
+	if tenant == "" {
+		return uiTenantConfig{}, fmt.Errorf("tenant is required")
+	}
+
+	existing, _, err := a.deps.store.LoadTenantConfig(tenant)
+	if err != nil {
+		return uiTenantConfig{}, err
+	}
+	updated := tenantConfigFromUI(config, existing)
+	if err := a.deps.store.SaveTenantConfig(updated); err != nil {
+		return uiTenantConfig{}, err
+	}
+	return tenantConfigToUI(updated, tenant), nil
+}
+
+func (a *App) LoadEnvironmentConfig(selection uiSelection) (uiEnvironmentConfig, error) {
+	selection = normalizeSelection(selection)
+	if selection.Tenant == "" || selection.Environment == "" {
+		return uiEnvironmentConfig{}, fmt.Errorf("tenant and environment are required")
+	}
+
+	config, _, err := a.deps.store.LoadEnvConfig(selection.Tenant, selection.Environment)
+	if err != nil {
+		return uiEnvironmentConfig{}, err
+	}
+	return environmentConfigToUI(config, selection.Environment), nil
+}
+
+func (a *App) SaveEnvironmentConfig(selection uiSelection, config uiEnvironmentConfig) (uiEnvironmentConfig, error) {
+	selection = normalizeSelection(selection)
+	if selection.Tenant == "" || selection.Environment == "" {
+		return uiEnvironmentConfig{}, fmt.Errorf("tenant and environment are required")
+	}
+
+	existing, _, err := a.deps.store.LoadEnvConfig(selection.Tenant, selection.Environment)
+	if err != nil {
+		return uiEnvironmentConfig{}, err
+	}
+	updated := environmentConfigFromUI(config, existing)
+	if err := a.deps.store.SaveEnvConfig(selection.Tenant, updated); err != nil {
+		return uiEnvironmentConfig{}, err
+	}
+	return environmentConfigToUI(updated, selection.Environment), nil
+}
+
 func labelRuntimeVersionSuggestions(source, image string, suggestions []uiVersion) []uiVersion {
 	source = strings.TrimSpace(source)
 	image = strings.TrimSpace(image)
@@ -259,6 +366,58 @@ func labelRuntimeVersionSuggestions(source, image string, suggestions []uiVersio
 		labeled = append(labeled, suggestion)
 	}
 	return labeled
+}
+
+func erunConfigToUI(config eruncommon.ERunConfig) uiERunConfig {
+	return uiERunConfig{
+		DefaultTenant: strings.TrimSpace(config.DefaultTenant),
+	}
+}
+
+func tenantConfigToUI(config eruncommon.TenantConfig, fallbackName string) uiTenantConfig {
+	name := strings.TrimSpace(config.Name)
+	if name == "" {
+		name = strings.TrimSpace(fallbackName)
+	}
+	result := uiTenantConfig{
+		Name:               name,
+		DefaultEnvironment: strings.TrimSpace(config.DefaultEnvironment),
+	}
+	return result
+}
+
+func tenantConfigFromUI(config uiTenantConfig, existing eruncommon.TenantConfig) eruncommon.TenantConfig {
+	existing.Name = strings.TrimSpace(config.Name)
+	existing.DefaultEnvironment = strings.TrimSpace(config.DefaultEnvironment)
+	return existing
+}
+
+func environmentConfigToUI(config eruncommon.EnvConfig, fallbackName string) uiEnvironmentConfig {
+	name := strings.TrimSpace(config.Name)
+	if name == "" {
+		name = strings.TrimSpace(fallbackName)
+	}
+	result := uiEnvironmentConfig{
+		Name:              name,
+		RepoPath:          strings.TrimSpace(config.RepoPath),
+		KubernetesContext: strings.TrimSpace(config.KubernetesContext),
+		ContainerRegistry: strings.TrimSpace(config.ContainerRegistry),
+		RuntimeVersion:    strings.TrimSpace(config.RuntimeVersion),
+		SSHD: uiSSHDConfig{
+			Enabled:       config.SSHD.Enabled,
+			LocalPort:     config.SSHD.LocalPort,
+			PublicKeyPath: strings.TrimSpace(config.SSHD.PublicKeyPath),
+		},
+		Remote:   config.Remote,
+		Snapshot: config.SnapshotEnabled(),
+	}
+	return result
+}
+
+func environmentConfigFromUI(config uiEnvironmentConfig, existing eruncommon.EnvConfig) eruncommon.EnvConfig {
+	existing.Name = strings.TrimSpace(config.Name)
+	existing.SetSnapshot(config.Snapshot)
+	return existing
 }
 
 func (a *App) StartSession(selection uiSelection, cols, rows int) (startSessionResult, error) {
@@ -329,7 +488,7 @@ func (a *App) StartSession(selection uiSelection, cols, rows int) (startSessionR
 }
 
 func (a *App) StartInitSession(selection uiSelection, cols, rows int) (startSessionResult, error) {
-	return a.startCommandSession(selection, cols, rows, initSelectionKey(selection), buildInitArgs(selection.Tenant, selection.Environment, selection.Version, selection.RuntimeImage, selection.NoGit), resolveInitStartDir(a.deps.findProjectRoot))
+	return a.startCommandSession(selection, cols, rows, initSelectionKey(selection), buildInitArgs(selection.Tenant, selection.Environment, selection.Version, selection.RuntimeImage, selection.NoGit), resolveInitStartDir(a.deps.findProjectRoot), []string{appSessionEnvVar + "=1"})
 }
 
 func (a *App) StartDeploySession(selection uiSelection, cols, rows int) (startSessionResult, error) {
@@ -344,7 +503,7 @@ func (a *App) StartDeploySession(selection uiSelection, cols, rows int) (startSe
 	if err != nil {
 		return startSessionResult{}, err
 	}
-	return a.startCommandSession(selection, cols, rows, deploySelectionKey(selection), buildDeployArgs(selection.Tenant, selection.Environment, selection.Version, selection.RuntimeImage), resolveDeployStartDir(a.deps.findProjectRoot, result))
+	return a.startCommandSession(selection, cols, rows, deploySelectionKey(selection), buildDeployArgs(selection.Tenant, selection.Environment, selection.Version, selection.RuntimeImage), resolveDeployStartDir(a.deps.findProjectRoot, result), []string{appSessionEnvVar + "=1"})
 }
 
 func (a *App) DeleteEnvironment(selection uiSelection, confirmation string) (deleteEnvironmentResult, error) {
@@ -379,7 +538,7 @@ func (a *App) DeleteEnvironment(selection uiSelection, confirmation string) (del
 	}, nil
 }
 
-func (a *App) startCommandSession(selection uiSelection, cols, rows int, key string, args []string, dir string) (startSessionResult, error) {
+func (a *App) startCommandSession(selection uiSelection, cols, rows int, key string, args []string, dir string, env []string) (startSessionResult, error) {
 	selection = normalizeSelection(selection)
 	if selection.Tenant == "" || selection.Environment == "" {
 		return startSessionResult{}, fmt.Errorf("tenant and environment are required")
@@ -406,7 +565,7 @@ func (a *App) startCommandSession(selection uiSelection, cols, rows int, key str
 		Dir:        dir,
 		Executable: a.deps.resolveCLIPath(),
 		Args:       args,
-		Env:        []string{appSessionEnvVar + "=1"},
+		Env:        env,
 		Cols:       cols,
 		Rows:       rows,
 	})

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -761,6 +761,131 @@ func TestDeleteEnvironmentRequiresExactConfirmationAndDeletesConfig(t *testing.T
 	}
 }
 
+func TestLoadAndSaveTenantConfig(t *testing.T) {
+	snapshot := false
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"frs": {
+				Name:               "frs",
+				ProjectRoot:        "/tmp/old",
+				DefaultEnvironment: "dev",
+				Remote:             true,
+				Snapshot:           &snapshot,
+			},
+		},
+	}
+	app := NewApp(erunUIDeps{store: store})
+
+	loaded, err := app.LoadTenantConfig(" frs ")
+	if err != nil {
+		t.Fatalf("LoadTenantConfig failed: %v", err)
+	}
+	if loaded.Name != "frs" || loaded.DefaultEnvironment != "dev" {
+		t.Fatalf("unexpected loaded config: %+v", loaded)
+	}
+
+	saved, err := app.SaveTenantConfig(uiTenantConfig{
+		Name:               "frs",
+		DefaultEnvironment: " prod ",
+	})
+	if err != nil {
+		t.Fatalf("SaveTenantConfig failed: %v", err)
+	}
+	if saved.DefaultEnvironment != "prod" {
+		t.Fatalf("unexpected saved config: %+v", saved)
+	}
+	if store.tenants["frs"].ProjectRoot != "/tmp/old" || !store.tenants["frs"].Remote || store.tenants["frs"].Snapshot == nil || *store.tenants["frs"].Snapshot {
+		t.Fatalf("expected tenant project root/remote/snapshot to be preserved, got %+v", store.tenants["frs"])
+	}
+}
+
+func TestLoadAndSaveERunConfig(t *testing.T) {
+	config := eruncommon.ERunConfig{DefaultTenant: "old-tenant"}
+	store := stubUIStore{
+		config: &config,
+	}
+	app := NewApp(erunUIDeps{store: store})
+
+	loaded, err := app.LoadERunConfig()
+	if err != nil {
+		t.Fatalf("LoadERunConfig failed: %v", err)
+	}
+	if loaded.DefaultTenant != "old-tenant" {
+		t.Fatalf("unexpected loaded config: %+v", loaded)
+	}
+
+	saved, err := app.SaveERunConfig(uiERunConfig{DefaultTenant: " new-tenant "})
+	if err != nil {
+		t.Fatalf("SaveERunConfig failed: %v", err)
+	}
+	if saved.DefaultTenant != "new-tenant" || config.DefaultTenant != "new-tenant" {
+		t.Fatalf("unexpected saved config: result=%+v stored=%+v", saved, config)
+	}
+}
+
+func TestLoadAndSaveEnvironmentConfig(t *testing.T) {
+	projectRoot := t.TempDir()
+	snapshot := true
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"frs": {
+				Name:        "frs",
+				ProjectRoot: projectRoot,
+			},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"frs/prod": {
+				Name:              "prod",
+				RepoPath:          projectRoot,
+				KubernetesContext: "cluster-old",
+				ContainerRegistry: "registry.example/old",
+				RuntimeVersion:    "1.0.0",
+				SSHD: eruncommon.SSHDConfig{
+					Enabled:       false,
+					LocalPort:     60022,
+					PublicKeyPath: "/tmp/old.pub",
+				},
+				Remote:   false,
+				Snapshot: &snapshot,
+			},
+		},
+	}
+	app := NewApp(erunUIDeps{store: store})
+
+	loaded, err := app.LoadEnvironmentConfig(uiSelection{Tenant: " frs ", Environment: " prod "})
+	if err != nil {
+		t.Fatalf("LoadEnvironmentConfig failed: %v", err)
+	}
+	if loaded.Name != "prod" || loaded.RepoPath != projectRoot || loaded.KubernetesContext != "cluster-old" {
+		t.Fatalf("unexpected loaded config: %+v", loaded)
+	}
+
+	saved, err := app.SaveEnvironmentConfig(uiSelection{Tenant: "frs", Environment: "prod"}, uiEnvironmentConfig{
+		Name:              "prod",
+		RepoPath:          " /tmp/repo ",
+		KubernetesContext: " cluster-new ",
+		ContainerRegistry: " registry.example/team ",
+		RuntimeVersion:    " 1.2.3 ",
+		SSHD: uiSSHDConfig{
+			Enabled:       true,
+			LocalPort:     62222,
+			PublicKeyPath: " /tmp/id_ed25519.pub ",
+		},
+		Remote:   true,
+		Snapshot: false,
+	})
+	if err != nil {
+		t.Fatalf("SaveEnvironmentConfig failed: %v", err)
+	}
+	if saved.RepoPath != projectRoot || saved.KubernetesContext != "cluster-old" || saved.ContainerRegistry != "registry.example/old" || saved.RuntimeVersion != "1.0.0" {
+		t.Fatalf("unexpected saved config: %+v", saved)
+	}
+	stored := store.envs["frs/prod"]
+	if stored.RepoPath != projectRoot || stored.Remote || stored.RuntimeVersion != "1.0.0" || stored.SSHD.Enabled || stored.SSHD.LocalPort != 60022 || stored.SSHD.PublicKeyPath != "/tmp/old.pub" || stored.Snapshot == nil || *stored.Snapshot {
+		t.Fatalf("unexpected stored config: %+v", stored)
+	}
+}
+
 func TestStartSessionReusesExistingSessionForSelection(t *testing.T) {
 	projectRoot := t.TempDir()
 	store := stubUIStore{
@@ -955,15 +1080,22 @@ func TestBuildPastedImageCopyCommandTargetsRuntimeDeployment(t *testing.T) {
 }
 
 type stubUIStore struct {
+	config  *eruncommon.ERunConfig
 	tenants map[string]eruncommon.TenantConfig
 	envs    map[string]eruncommon.EnvConfig
 }
 
 func (s stubUIStore) LoadERunConfig() (eruncommon.ERunConfig, string, error) {
-	return eruncommon.ERunConfig{}, "", nil
+	if s.config == nil {
+		return eruncommon.ERunConfig{}, "", nil
+	}
+	return *s.config, "", nil
 }
 
-func (s stubUIStore) SaveERunConfig(eruncommon.ERunConfig) error {
+func (s stubUIStore) SaveERunConfig(config eruncommon.ERunConfig) error {
+	if s.config != nil {
+		*s.config = config
+	}
 	return nil
 }
 
@@ -994,6 +1126,14 @@ func (s stubUIStore) LoadEnvConfig(tenant, environment string) (eruncommon.EnvCo
 		return eruncommon.EnvConfig{}, "", eruncommon.ErrNotInitialized
 	}
 	return config, "", nil
+}
+
+func (s stubUIStore) SaveEnvConfig(tenant string, config eruncommon.EnvConfig) error {
+	if s.envs == nil {
+		s.envs = make(map[string]eruncommon.EnvConfig)
+	}
+	s.envs[tenant+"/"+config.Name] = config
+	return nil
 }
 
 func (s stubUIStore) DeleteEnvConfig(tenant, environment string) error {

--- a/erun-ui/frontend/src/App.tsx
+++ b/erun-ui/frontend/src/App.tsx
@@ -4,9 +4,11 @@ import { Check, Copy } from 'lucide-react';
 import { ERunUIController } from '@/app/ERunUIController';
 import { useControllerState } from '@/app/useControllerState';
 import { EnvironmentDialogView } from '@/components/app/EnvironmentDialogView';
+import { GlobalConfigDialogView } from '@/components/app/GlobalConfigDialogView';
 import { ManageDialogView } from '@/components/app/ManageDialogView';
 import { ReviewPanel } from '@/components/app/ReviewPanel';
 import { Sidebar } from '@/components/app/Sidebar';
+import { TenantDialogView } from '@/components/app/TenantDialogView';
 import { Titlebar } from '@/components/app/Titlebar';
 import { Button } from '@/components/ui/button';
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -112,7 +114,9 @@ export function App(): React.ReactElement {
         </div>
       </div>
       <EnvironmentDialogView controller={controller} state={state} />
+      <GlobalConfigDialogView controller={controller} state={state} />
       <ManageDialogView controller={controller} state={state} />
+      <TenantDialogView controller={controller} state={state} />
     </TooltipProvider>
   );
 }

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -5,10 +5,16 @@ import { Terminal } from '@xterm/xterm';
 import {
   DeleteEnvironment,
   LoadDiff,
+  LoadEnvironmentConfig,
+  LoadERunConfig,
   LoadState,
+  LoadTenantConfig,
   LoadVersionSuggestions,
   ResizeSession,
   SavePastedImage,
+  SaveEnvironmentConfig,
+  SaveERunConfig,
+  SaveTenantConfig,
   SendSessionInput,
   StartDeploySession,
   StartInitSession,
@@ -30,10 +36,14 @@ import {
   REVIEW_WIDTH_STORAGE_KEY,
   SIDEBAR_WIDTH_STORAGE_KEY,
   defaultEnvironmentDialog,
+  defaultGlobalConfigDialog,
   defaultManageDialog,
+  defaultTenantDialog,
   type AppState,
   type EnvironmentDialogState,
+  type GlobalConfigDialogState,
   type ManageDialogState,
+  type TenantDialogState,
 } from './state';
 import { clamp, loadSavedFilesOpen, loadSavedFilesWidth, loadSavedReviewWidth, loadSavedSidebarWidth, saveBoolean, saveNumber } from './storage';
 import { deleteConfirmationValue, normalizeDialogValue, normalizeVersionSuggestions, selectionKey } from './versionSuggestions';
@@ -45,8 +55,11 @@ import type {
   StartSessionResult,
   TerminalExitPayload,
   TerminalOutputPayload,
+  UIERunConfig,
+  UIEnvironmentConfig,
   UISelection,
   UIState,
+  UITenantConfig,
   UIVersionSuggestion,
 } from '@/types';
 
@@ -67,6 +80,8 @@ export class ERunUIController {
     versionSuggestions: [],
     environmentDialog: defaultEnvironmentDialog(),
     manageDialog: defaultManageDialog(),
+    tenantDialog: defaultTenantDialog(),
+    globalConfigDialog: defaultGlobalConfigDialog(),
     collapsedTenants: new Set<string>(),
     sessionId: 0,
     sidebarWidth: loadSavedSidebarWidth(),
@@ -484,20 +499,31 @@ export class ERunUIController {
   }
 
   openManageDialog(selection: UISelection): void {
-    const suggestion = this.state.versionSuggestions[0];
     this.state.manageDialog = {
       open: true,
-      tab: 'deploy',
+      tab: 'config',
       selection,
-      version: suggestion?.version || '',
-      versionImage: suggestion?.image || '',
+      version: '',
+      versionImage: '',
+      config: {
+        name: selection.environment,
+        repoPath: '',
+        kubernetesContext: '',
+        containerRegistry: '',
+        runtimeVersion: '',
+        sshd: { enabled: false, localPort: 0, publicKeyPath: '' },
+        remote: false,
+        snapshot: true,
+      },
+      configLoading: true,
       confirmation: '',
       busy: false,
       choicesOpen: false,
       error: '',
     };
     this.emit();
-    void this.refreshManageVersionSuggestions(true);
+    void this.refreshManageVersionSuggestions(false);
+    void this.loadManageConfig();
   }
 
   closeManageDialog(): void {
@@ -520,6 +546,9 @@ export class ERunUIController {
       error: '',
     };
     this.emit();
+    if (tab === 'config' && !this.state.manageDialog.configLoading && this.state.manageDialog.selection) {
+      void this.loadManageConfig();
+    }
   }
 
   updateManageDialog(values: Partial<ManageDialogState>): void {
@@ -566,7 +595,324 @@ export class ERunUIController {
     this.emit();
   }
 
-  async submitManageDeploy(form?: HTMLFormElement): Promise<void> {
+  updateManageConfig(values: Partial<UIEnvironmentConfig>): void {
+    if (this.state.manageDialog.busy || this.state.manageDialog.configLoading) {
+      return;
+    }
+    this.state.manageDialog = {
+      ...this.state.manageDialog,
+      config: {
+        ...this.state.manageDialog.config,
+        ...values,
+      },
+      error: '',
+    };
+    this.emit();
+  }
+
+  updateManageSSHDConfig(values: Partial<UIEnvironmentConfig['sshd']>): void {
+    if (this.state.manageDialog.busy || this.state.manageDialog.configLoading) {
+      return;
+    }
+    this.state.manageDialog = {
+      ...this.state.manageDialog,
+      config: {
+        ...this.state.manageDialog.config,
+        sshd: {
+          ...this.state.manageDialog.config.sshd,
+          ...values,
+        },
+      },
+      error: '',
+    };
+    this.emit();
+  }
+
+  async loadManageConfig(): Promise<void> {
+    const dialog = this.state.manageDialog;
+    const selection = dialog.selection;
+    if (!dialog.open || !selection) {
+      return;
+    }
+    this.state.manageDialog = {
+      ...dialog,
+      configLoading: true,
+      error: '',
+    };
+    this.emit();
+    try {
+      const result = (await LoadEnvironmentConfig(selection)) as UIEnvironmentConfig;
+      this.state.manageDialog = {
+        ...this.state.manageDialog,
+        config: result,
+        configLoading: false,
+        error: '',
+      };
+      this.emit();
+    } catch (error) {
+      this.state.manageDialog = {
+        ...this.state.manageDialog,
+        configLoading: false,
+        error: readError(error),
+      };
+      this.emit();
+    }
+  }
+
+  async submitManageConfig(): Promise<void> {
+    const dialog = this.state.manageDialog;
+    if (dialog.busy || dialog.configLoading) {
+      return;
+    }
+    const selection = dialog.selection;
+    if (!selection) {
+      this.closeManageDialog();
+      return;
+    }
+
+    this.state.manageDialog = { ...dialog, busy: true, error: '' };
+    this.emit();
+    try {
+      const result = (await SaveEnvironmentConfig(selection, dialog.config)) as UIEnvironmentConfig;
+      this.state.manageDialog = {
+        ...this.state.manageDialog,
+        config: result,
+        busy: false,
+        error: '',
+      };
+      this.showTerminalMessage(`Saved config for ${selection.tenant} / ${selection.environment}.`);
+      this.closeManageDialog();
+    } catch (error) {
+      const message = readError(error);
+      this.state.manageDialog = {
+        ...this.state.manageDialog,
+        busy: false,
+        error: message,
+      };
+      this.showTerminalMessage(message);
+      this.emit();
+    }
+  }
+
+  openGlobalConfigDialog(): void {
+    this.state.globalConfigDialog = {
+      open: true,
+      config: {
+        defaultTenant: '',
+      },
+      configLoading: true,
+      busy: false,
+      error: '',
+    };
+    this.emit();
+    void this.loadGlobalConfig();
+  }
+
+  closeGlobalConfigDialog(): void {
+    if (this.state.globalConfigDialog.busy) {
+      return;
+    }
+    this.state.globalConfigDialog = defaultGlobalConfigDialog();
+    this.emit();
+    this.focusTerminalSoon();
+  }
+
+  updateGlobalConfigDialog(values: Partial<GlobalConfigDialogState>): void {
+    if (this.state.globalConfigDialog.busy) {
+      return;
+    }
+    this.state.globalConfigDialog = {
+      ...this.state.globalConfigDialog,
+      ...values,
+      error: values.error ?? '',
+    };
+    this.emit();
+  }
+
+  updateGlobalConfig(values: Partial<UIERunConfig>): void {
+    if (this.state.globalConfigDialog.busy || this.state.globalConfigDialog.configLoading) {
+      return;
+    }
+    this.updateGlobalConfigDialog({
+      config: {
+        ...this.state.globalConfigDialog.config,
+        ...values,
+      },
+    });
+  }
+
+  async loadGlobalConfig(): Promise<void> {
+    const dialog = this.state.globalConfigDialog;
+    if (!dialog.open) {
+      return;
+    }
+    this.state.globalConfigDialog = {
+      ...dialog,
+      configLoading: true,
+      error: '',
+    };
+    this.emit();
+    try {
+      const result = (await LoadERunConfig()) as UIERunConfig;
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        config: result,
+        configLoading: false,
+        error: '',
+      };
+      this.emit();
+    } catch (error) {
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        configLoading: false,
+        error: readError(error),
+      };
+      this.emit();
+    }
+  }
+
+  async submitGlobalConfig(): Promise<void> {
+    const dialog = this.state.globalConfigDialog;
+    if (dialog.busy || dialog.configLoading) {
+      return;
+    }
+    this.state.globalConfigDialog = { ...dialog, busy: true, error: '' };
+    this.emit();
+    try {
+      const result = (await SaveERunConfig(dialog.config)) as UIERunConfig;
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        config: result,
+        busy: false,
+        error: '',
+      };
+      this.showTerminalMessage('Saved ERun config.');
+      this.closeGlobalConfigDialog();
+    } catch (error) {
+      const message = readError(error);
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        busy: false,
+        error: message,
+      };
+      this.showTerminalMessage(message);
+      this.emit();
+    }
+  }
+
+  openTenantDialog(tenant: string): void {
+    this.state.tenantDialog = {
+      open: true,
+      tenant,
+      config: {
+        name: tenant,
+        defaultEnvironment: '',
+      },
+      configLoading: true,
+      busy: false,
+      error: '',
+    };
+    this.emit();
+    void this.loadTenantConfig();
+  }
+
+  closeTenantDialog(): void {
+    if (this.state.tenantDialog.busy) {
+      return;
+    }
+    this.state.tenantDialog = defaultTenantDialog();
+    this.emit();
+    this.focusTerminalSoon();
+  }
+
+  updateTenantDialog(values: Partial<TenantDialogState>): void {
+    if (this.state.tenantDialog.busy) {
+      return;
+    }
+    this.state.tenantDialog = {
+      ...this.state.tenantDialog,
+      ...values,
+      error: values.error ?? '',
+    };
+    this.emit();
+  }
+
+  updateTenantConfig(values: Partial<UITenantConfig>): void {
+    if (this.state.tenantDialog.busy || this.state.tenantDialog.configLoading) {
+      return;
+    }
+    this.updateTenantDialog({
+      config: {
+        ...this.state.tenantDialog.config,
+        ...values,
+      },
+    });
+  }
+
+  async loadTenantConfig(): Promise<void> {
+    const dialog = this.state.tenantDialog;
+    if (!dialog.open || !dialog.tenant) {
+      return;
+    }
+    this.state.tenantDialog = {
+      ...dialog,
+      configLoading: true,
+      error: '',
+    };
+    this.emit();
+    try {
+      const result = (await LoadTenantConfig(dialog.tenant)) as UITenantConfig;
+      this.state.tenantDialog = {
+        ...this.state.tenantDialog,
+        config: result,
+        configLoading: false,
+        error: '',
+      };
+      this.emit();
+    } catch (error) {
+      this.state.tenantDialog = {
+        ...this.state.tenantDialog,
+        configLoading: false,
+        error: readError(error),
+      };
+      this.emit();
+    }
+  }
+
+  async submitTenantConfig(): Promise<void> {
+    const dialog = this.state.tenantDialog;
+    if (dialog.busy || dialog.configLoading) {
+      return;
+    }
+    if (!dialog.tenant) {
+      this.closeTenantDialog();
+      return;
+    }
+    this.state.tenantDialog = { ...dialog, busy: true, error: '' };
+    this.emit();
+    try {
+      const result = (await SaveTenantConfig(dialog.config)) as UITenantConfig;
+      this.state.tenantDialog = {
+        ...this.state.tenantDialog,
+        config: result,
+        busy: false,
+        error: '',
+      };
+      this.showTerminalMessage(`Saved config for ${result.name}.`);
+      this.closeTenantDialog();
+    } catch (error) {
+      const message = readError(error);
+      this.state.tenantDialog = {
+        ...this.state.tenantDialog,
+        busy: false,
+        error: message,
+      };
+      this.showTerminalMessage(message);
+      this.emit();
+    }
+  }
+
+  async submitManageDeploy(): Promise<void> {
     const dialog = this.state.manageDialog;
     if (dialog.busy) {
       return;
@@ -577,12 +923,8 @@ export class ERunUIController {
       return;
     }
     const version = normalizeDialogValue(dialog.version);
-    if (!version) {
-      form?.reportValidity();
-      return;
-    }
     this.closeManageDialog();
-    await this.startDeploySelection({ ...selection, version, runtimeImage: this.resolveManageRuntimeImage(version) });
+    await this.startDeploySelection({ ...selection, version, runtimeImage: version ? this.resolveManageRuntimeImage(version) : '' });
   }
 
   async submitManageDelete(): Promise<void> {
@@ -839,7 +1181,9 @@ export class ERunUIController {
 
     this.state.versionSuggestions = suggestions;
     const currentVersion = normalizeDialogValue(this.state.manageDialog.version);
-    if (selectDefault || !suggestions.some((suggestion) => suggestion.version === currentVersion)) {
+    if (!currentVersion && !selectDefault) {
+      this.emit();
+    } else if (selectDefault || !suggestions.some((suggestion) => suggestion.version === currentVersion)) {
       this.selectManageVersionSuggestion(suggestions[0]);
     } else {
       this.emit();
@@ -913,9 +1257,9 @@ export class ERunUIController {
     if (payload.sessionId !== this.state.sessionId) {
       return;
     }
-    if (initSelection && !payload.reason) {
+    if ((initSelection || deploySelection) && !payload.reason) {
       try {
-        await this.openSelection(initSelection);
+        await this.openSelection(initSelection || deploySelection);
       } catch (error) {
         this.showTerminalMessage(readError(error));
       }

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -2,7 +2,10 @@ import type {
   DiffResult,
   EnvironmentActionMode,
   ManageTab,
+  UIERunConfig,
+  UIEnvironmentConfig,
   UISelection,
+  UITenantConfig,
   UITenant,
   UIVersionSuggestion,
 } from '@/types';
@@ -40,9 +43,28 @@ export interface ManageDialogState {
   selection: UISelection | null;
   version: string;
   versionImage: string;
+  config: UIEnvironmentConfig;
+  configLoading: boolean;
   confirmation: string;
   busy: boolean;
   choicesOpen: boolean;
+  error: string;
+}
+
+export interface TenantDialogState {
+  open: boolean;
+  tenant: string;
+  config: UITenantConfig;
+  configLoading: boolean;
+  busy: boolean;
+  error: string;
+}
+
+export interface GlobalConfigDialogState {
+  open: boolean;
+  config: UIERunConfig;
+  configLoading: boolean;
+  busy: boolean;
   error: string;
 }
 
@@ -52,6 +74,8 @@ export interface AppState {
   versionSuggestions: UIVersionSuggestion[];
   environmentDialog: EnvironmentDialogState;
   manageDialog: ManageDialogState;
+  tenantDialog: TenantDialogState;
+  globalConfigDialog: GlobalConfigDialogState;
   collapsedTenants: Set<string>;
   sessionId: number;
   sidebarWidth: number;
@@ -86,12 +110,55 @@ export const defaultEnvironmentDialog = (): EnvironmentDialogState => ({
 
 export const defaultManageDialog = (): ManageDialogState => ({
   open: false,
-  tab: 'deploy',
+  tab: 'config',
   selection: null,
   version: '',
   versionImage: '',
+  config: defaultEnvironmentConfig(),
+  configLoading: false,
   confirmation: '',
   busy: false,
   choicesOpen: false,
   error: '',
+});
+
+export const defaultTenantDialog = (): TenantDialogState => ({
+  open: false,
+  tenant: '',
+  config: defaultTenantConfig(),
+  configLoading: false,
+  busy: false,
+  error: '',
+});
+
+export const defaultGlobalConfigDialog = (): GlobalConfigDialogState => ({
+  open: false,
+  config: defaultERunConfig(),
+  configLoading: false,
+  busy: false,
+  error: '',
+});
+
+export const defaultERunConfig = (): UIERunConfig => ({
+  defaultTenant: '',
+});
+
+export const defaultTenantConfig = (): UITenantConfig => ({
+  name: '',
+  defaultEnvironment: '',
+});
+
+export const defaultEnvironmentConfig = (): UIEnvironmentConfig => ({
+  name: '',
+  repoPath: '',
+  kubernetesContext: '',
+  containerRegistry: '',
+  runtimeVersion: '',
+  sshd: {
+    enabled: false,
+    localPort: 0,
+    publicKeyPath: '',
+  },
+  remote: false,
+  snapshot: true,
 });

--- a/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { LoaderCircle, Save } from 'lucide-react';
+
+import type { ERunUIController } from '@/app/ERunUIController';
+import { readError } from '@/app/errors';
+import type { AppState } from '@/app/state';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+
+const dialogErrorClassName =
+  'rounded-[var(--radius)] border border-[color-mix(in_oklch,var(--destructive)_36%,transparent)] bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] px-[11px] py-[9px] text-[13px] leading-[1.35] text-destructive [overflow-wrap:anywhere]';
+
+export function GlobalConfigDialogView({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement {
+  const dialog = state.globalConfigDialog;
+  const config = dialog.config;
+  const tenantOptions = optionValues(state.tenants.map((tenant) => tenant.name), config.defaultTenant);
+
+  return (
+    <Dialog open={dialog.open} onOpenChange={(open) => !open && controller.closeGlobalConfigDialog()}>
+      <DialogContent
+        className="sm:max-w-xl"
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          controller.focusTerminalSoon();
+        }}
+      >
+        <form
+          className="grid gap-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void controller.submitGlobalConfig().catch((error: unknown) => {
+              controller.showTerminalMessage(readError(error));
+            });
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Manage ERun config</DialogTitle>
+          </DialogHeader>
+          {dialog.configLoading ? (
+            <div className="rounded-[var(--radius)] border border-dashed border-border px-3 py-2.5 text-[13px] leading-[1.35] text-muted-foreground">
+              Loading config...
+            </div>
+          ) : (
+            <div className="grid gap-3">
+              <SelectField id="global-config-defaulttenant" label="defaulttenant" value={config.defaultTenant} options={tenantOptions} disabled={dialog.busy || tenantOptions.length === 0} onChange={(defaultTenant) => controller.updateGlobalConfig({ defaultTenant })} />
+            </div>
+          )}
+          {dialog.error && (
+            <div className={dialogErrorClassName} role="alert">
+              {dialog.error}
+            </div>
+          )}
+          <DialogFooter>
+            <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => controller.closeGlobalConfigDialog()}>
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={dialog.busy || dialog.configLoading}>
+              {dialog.busy ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Save aria-hidden="true" />}
+              {dialog.busy ? 'Saving...' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SelectField({ id, label, value, options, disabled, onChange }: { id: string; label: string; value: string; options: string[]; disabled?: boolean; onChange: (value: string) => void }): React.ReactElement {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={id}>{label}</Label>
+      <select
+        id={id}
+        className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-[var(--radius)] border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {options.length === 0 ? (
+          <option value="">No tenants</option>
+        ) : (
+          <>
+            <option value="">Not configured</option>
+            {options.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </>
+        )}
+      </select>
+    </div>
+  );
+}
+
+function optionValues(values: string[], current: string): string[] {
+  const seen = new Set<string>();
+  return [current, ...values]
+    .map((value) => value.trim())
+    .filter((value) => {
+      if (!value || seen.has(value)) {
+        return false;
+      }
+      seen.add(value);
+      return true;
+    });
+}

--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -1,135 +1,118 @@
 import * as React from 'react';
-import { AlertTriangle, LoaderCircle, Rocket, Trash2 } from 'lucide-react';
+import { AlertTriangle, Check, ChevronsUpDown, LoaderCircle, Rocket, Save, Trash2 } from 'lucide-react';
 
 import type { ERunUIController } from '@/app/ERunUIController';
 import { readError } from '@/app/errors';
 import type { AppState } from '@/app/state';
-import { deleteConfirmationValue, findVersionSuggestion, normalizeDialogValue, selectedVersionSourceText } from '@/app/versionSuggestions';
+import { deleteConfirmationValue, normalizeDialogValue, versionChoiceImage, versionChoiceKind, versionChoiceLabel } from '@/app/versionSuggestions';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import type { ManageTab } from '@/types';
-import { VersionField } from './VersionField';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import type { UIVersionSuggestion } from '@/types';
+import { cn } from '@/lib/utils';
 
 const dialogErrorClassName =
   'rounded-[var(--radius)] border border-[color-mix(in_oklch,var(--destructive)_36%,transparent)] bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] px-[11px] py-[9px] text-[13px] leading-[1.35] text-destructive [overflow-wrap:anywhere]';
 
 export function ManageDialogView({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement {
   const dialog = state.manageDialog;
-  const versionRef = React.useRef<HTMLInputElement>(null);
   const confirmationRef = React.useRef<HTMLInputElement>(null);
   const selection = dialog.selection;
   const expected = selection ? deleteConfirmationValue(selection) : '';
+  const confirmingDelete = dialog.tab === 'delete';
   const deleteEnabled = !dialog.busy && normalizeDialogValue(dialog.confirmation) === expected;
+  const config = dialog.config;
 
   React.useEffect(() => {
-    if (!dialog.open) {
+    if (!dialog.open || !confirmingDelete) {
       return;
     }
     window.setTimeout(() => {
-      if (dialog.tab === 'deploy') {
-        versionRef.current?.focus();
-        versionRef.current?.select();
-        return;
-      }
       confirmationRef.current?.focus();
     }, 0);
-  }, [dialog.open, dialog.tab]);
+  }, [dialog.open, confirmingDelete]);
 
   return (
     <Dialog open={dialog.open} onOpenChange={(open) => !open && controller.closeManageDialog()}>
       <DialogContent
-        className="sm:max-w-md"
+        className="max-h-[min(88vh,900px)] sm:max-w-2xl"
         onCloseAutoFocus={(event) => {
           event.preventDefault();
           controller.focusTerminalSoon();
         }}
       >
         <form
-          className="grid gap-4"
+          className="flex max-h-[calc(min(88vh,900px)-3rem)] min-h-0 flex-col gap-4"
           onSubmit={(event) => {
             event.preventDefault();
-            if (dialog.tab === 'deploy') {
-              void controller.submitManageDeploy(event.currentTarget).catch((error: unknown) => {
-                controller.showTerminalMessage(readError(error));
-              });
+            if (confirmingDelete && deleteEnabled) {
+              void controller.submitManageDelete();
             }
           }}
         >
           <DialogHeader>
-            <DialogTitle>Manage environment</DialogTitle>
-            <DialogDescription>
-              {selection ? `${selection.tenant} / ${selection.environment}` : ''}
-            </DialogDescription>
+            <DialogTitle>{selection ? `${selection.tenant}-${selection.environment}` : 'Environment'}</DialogTitle>
           </DialogHeader>
-          <Tabs
-            className="gap-3"
-            value={dialog.tab}
-            onValueChange={(value) => controller.setManageTab(value as ManageTab)}
-          >
-            <TabsList className="grid w-full grid-cols-2" aria-label="Environment actions">
-              <TabsTrigger value="deploy" disabled={dialog.busy}>
-                Deploy
-              </TabsTrigger>
-              <TabsTrigger value="delete" disabled={dialog.busy}>
-                Delete
-              </TabsTrigger>
-            </TabsList>
-            <div className="min-h-20">
-              <TabsContent className="mt-0 grid gap-3" value="deploy">
-                <VersionField
-                  id="manage-version"
-                  inputRef={versionRef}
-                  value={dialog.version}
-                  sourceText={selectedVersionSourceText(findVersionSuggestion(state.versionSuggestions, dialog.version, dialog.versionImage))}
+          <div className="-mx-1 min-h-0 overflow-auto px-1 pb-1">
+            {dialog.configLoading ? (
+              <div className="rounded-[var(--radius)] border border-dashed border-border px-3 py-2.5 text-[13px] leading-[1.35] text-muted-foreground">
+                Loading config...
+              </div>
+            ) : (
+              <div className="grid gap-3">
+                <ReadonlyField id="environment-config-repopath" label="repopath" value={config.repoPath} />
+                <ReadonlyField id="environment-config-kubernetescontext" label="kubernetescontext" value={config.kubernetesContext} />
+                <ReadonlyField id="environment-config-containerregistry" label="containerregistry" value={config.containerRegistry} />
+                <RuntimeDeployField
+                  configuredVersion={config.runtimeVersion}
+                  overrideVersion={dialog.version}
                   suggestions={state.versionSuggestions}
                   choicesOpen={dialog.choicesOpen}
-                  required
-                  disabled={dialog.busy}
+                  disabled={dialog.busy || dialog.configLoading}
                   onValueChange={(version) => controller.updateManageDialog({ version })}
                   onChoicesOpenChange={(open) => controller.setManageVersionChoicesOpen(open)}
                   onSelect={(suggestion) => controller.selectManageVersionSuggestion(suggestion)}
+                  onDeploy={() => void controller.submitManageDeploy().catch((error: unknown) => controller.showTerminalMessage(readError(error)))}
                 />
-              </TabsContent>
-              <TabsContent className="mt-0 grid gap-3" value="delete">
-                {selection && (
-                  <div className="grid grid-cols-[18px_minmax(0,1fr)] items-start gap-[9px] rounded-[var(--radius)] border border-[color-mix(in_oklch,var(--destructive)_30%,var(--border))] bg-[color-mix(in_oklch,var(--destructive)_7%,transparent)] px-[11px] py-2.5 text-[13px] leading-[1.35] text-foreground">
-                    <AlertTriangle className="mt-px size-[17px] text-destructive" aria-hidden="true" />
-                    <span>
-                      Delete <strong className="font-semibold">{selection.tenant} / {selection.environment}</strong>. Type{' '}
-                      <code className="rounded-[calc(var(--radius)-4px)] bg-[color-mix(in_oklch,var(--destructive)_12%,transparent)] px-1 py-px font-mono text-xs text-destructive">
-                        {expected}
-                      </code>{' '}
-                      to confirm.
-                    </span>
+                <CheckboxField id="environment-config-remote" label="remote" checked={config.remote} disabled onChange={() => {}} />
+                <CheckboxField id="environment-config-snapshot" label="snapshot" checked={config.snapshot} disabled={dialog.busy} onChange={(snapshot) => controller.updateManageConfig({ snapshot })} />
+                <div className="grid gap-3 rounded-[var(--radius)] border border-border p-3">
+                  <div className="text-xs leading-[1.2] font-semibold tracking-normal text-muted-foreground uppercase">sshd</div>
+                  <CheckboxField id="environment-config-sshd-enabled" label="enabled" checked={config.sshd.enabled} disabled onChange={() => {}} />
+                  <TextField
+                    id="environment-config-sshd-localport"
+                    label="localport"
+                    value={config.sshd.localPort > 0 ? String(config.sshd.localPort) : ''}
+                    disabled
+                    inputMode="numeric"
+                    onChange={() => {}}
+                  />
+                  <TextField id="environment-config-sshd-publickeypath" label="publickeypath" value={config.sshd.publicKeyPath} disabled onChange={() => {}} />
+                </div>
+                {confirmingDelete && (
+                  <div className="grid gap-3">
+                    {selection && (
+                      <div className="grid grid-cols-[18px_minmax(0,1fr)] items-start gap-[9px] rounded-[var(--radius)] border border-[color-mix(in_oklch,var(--destructive)_30%,var(--border))] bg-[color-mix(in_oklch,var(--destructive)_7%,transparent)] px-[11px] py-2.5 text-[13px] leading-[1.35] text-foreground">
+                        <AlertTriangle className="mt-px size-[17px] text-destructive" aria-hidden="true" />
+                        <span>
+                          Type{' '}
+                          <code className="rounded-[calc(var(--radius)-4px)] bg-[color-mix(in_oklch,var(--destructive)_12%,transparent)] px-1 py-px font-mono text-xs text-destructive">
+                            {expected}
+                          </code>{' '}
+                          to confirm.
+                        </span>
+                      </div>
+                    )}
+                    <TextField id="manage-confirmation" label="confirmation" value={dialog.confirmation} disabled={dialog.busy} inputRef={confirmationRef} onChange={(confirmation) => controller.updateManageDialog({ confirmation })} />
                   </div>
                 )}
-                <div className="grid gap-2">
-                  <Label htmlFor="manage-confirmation">Confirmation</Label>
-                  <Input
-                    id="manage-confirmation"
-                    ref={confirmationRef}
-                    value={dialog.confirmation}
-                    type="text"
-                    autoComplete="off"
-                    spellCheck={false}
-                    disabled={dialog.busy}
-                    onChange={(event) => controller.updateManageDialog({ confirmation: event.target.value })}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Enter') {
-                        event.preventDefault();
-                        if (deleteEnabled) {
-                          void controller.submitManageDelete();
-                        }
-                      }
-                    }}
-                  />
-                </div>
-              </TabsContent>
-            </div>
-          </Tabs>
+              </div>
+            )}
+          </div>
           {dialog.error && (
             <div className={dialogErrorClassName} role="alert">
               {dialog.error}
@@ -139,28 +122,139 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
             <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => controller.closeManageDialog()}>
               Cancel
             </Button>
-            {dialog.tab === 'deploy' ? (
-              <Button type="submit" size="sm" disabled={dialog.busy}>
-                {dialog.busy ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Rocket aria-hidden="true" />}
-                {dialog.busy ? 'Deploying...' : 'Deploy'}
-              </Button>
-            ) : (
-              <Button
-                type="button"
-                variant={deleteEnabled || dialog.busy ? 'destructive' : 'outline'}
-                size="sm"
-                disabled={!deleteEnabled}
-                onClick={() => {
+            <Button
+              type="button"
+              variant={confirmingDelete ? 'destructive' : 'outline'}
+              size="sm"
+              disabled={dialog.busy || (confirmingDelete && !deleteEnabled)}
+              onClick={() => {
+                if (confirmingDelete) {
                   void controller.submitManageDelete();
-                }}
-              >
-                {dialog.busy ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Trash2 aria-hidden="true" />}
-                {dialog.busy ? 'Deleting...' : 'Delete'}
+                  return;
+                }
+                controller.updateManageDialog({ tab: 'delete', confirmation: '' });
+              }}
+            >
+              {dialog.busy && confirmingDelete ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Trash2 aria-hidden="true" />}
+              {dialog.busy && confirmingDelete ? 'Deleting...' : 'Delete'}
+            </Button>
+            {!confirmingDelete && (
+              <Button type="button" size="sm" disabled={dialog.busy || dialog.configLoading} onClick={() => void controller.submitManageConfig().catch((error: unknown) => controller.showTerminalMessage(readError(error)))}>
+                {dialog.busy ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Save aria-hidden="true" />}
+                {dialog.busy ? 'Saving...' : 'Save'}
               </Button>
             )}
           </DialogFooter>
         </form>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function RuntimeDeployField({
+  configuredVersion,
+  overrideVersion,
+  suggestions,
+  choicesOpen,
+  disabled,
+  onValueChange,
+  onChoicesOpenChange,
+  onSelect,
+  onDeploy,
+}: {
+  configuredVersion: string;
+  overrideVersion: string;
+  suggestions: UIVersionSuggestion[];
+  choicesOpen: boolean;
+  disabled?: boolean;
+  onValueChange: (version: string) => void;
+  onChoicesOpenChange: (open: boolean) => void;
+  onSelect: (suggestion: UIVersionSuggestion | undefined) => void;
+  onDeploy: () => void;
+}): React.ReactElement {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="environment-config-runtimeversion">runtimeversion</Label>
+      <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-2">
+        <Input id="environment-config-runtimeversion" value={configuredVersion} type="text" autoComplete="off" spellCheck={false} disabled onChange={() => {}} />
+        <div className="relative min-w-0">
+          <Input
+            id="manage-version"
+            className="pr-10"
+            value={overrideVersion}
+            type="text"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="deploy override"
+            disabled={disabled}
+            onChange={(event) => onValueChange(event.target.value)}
+          />
+          <Popover open={choicesOpen} onOpenChange={onChoicesOpenChange}>
+            <PopoverTrigger asChild>
+              <Button className="absolute right-1 top-1 size-7 text-muted-foreground" type="button" variant="ghost" size="icon" aria-label="Show version choices" disabled={disabled}>
+                <ChevronsUpDown />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-80 p-0" align="start">
+              <Command>
+                <CommandInput placeholder="Search versions..." />
+                <CommandList>
+                  <CommandEmpty>No version found.</CommandEmpty>
+                  <CommandGroup>
+                    {suggestions.map((suggestion) => {
+                      const selected = suggestion.version === overrideVersion;
+                      return (
+                        <CommandItem
+                          className="min-w-0"
+                          key={`${suggestion.version}:${suggestion.image || ''}:${suggestion.source || ''}:${suggestion.label || ''}`}
+                          value={versionChoiceLabel(suggestion)}
+                          onSelect={() => onSelect(suggestion)}
+                        >
+                          <Check className={cn('size-4 shrink-0 opacity-0', selected && 'opacity-100')} />
+                          <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                            <span className="truncate text-sm font-medium leading-tight">{suggestion.version}</span>
+                            <span className="truncate text-xs leading-tight text-muted-foreground">
+                              {[versionChoiceImage(suggestion), versionChoiceKind(suggestion)].filter(Boolean).join(' | ')}
+                            </span>
+                          </span>
+                        </CommandItem>
+                      );
+                    })}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+        </div>
+        <Button type="button" size="sm" disabled={disabled} onClick={onDeploy}>
+          <Rocket aria-hidden="true" />
+          Deploy
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function TextField({ id, label, value, disabled, inputMode, inputRef, onChange }: { id: string; label: string; value: string; disabled?: boolean; inputMode?: React.HTMLAttributes<HTMLInputElement>['inputMode']; inputRef?: React.Ref<HTMLInputElement>; onChange: (value: string) => void }): React.ReactElement {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Input id={id} ref={inputRef} value={value} type="text" inputMode={inputMode} autoComplete="off" spellCheck={false} disabled={disabled} onChange={(event) => onChange(event.target.value)} />
+    </div>
+  );
+}
+
+function ReadonlyField({ id, label, value }: { id: string; label: string; value: string }): React.ReactElement {
+  return <TextField id={id} label={label} value={value} disabled onChange={() => {}} />;
+}
+
+function CheckboxField({ id, label, checked, disabled, onChange }: { id: string; label: string; checked: boolean; disabled?: boolean; onChange: (checked: boolean) => void }): React.ReactElement {
+  return (
+    <div className="flex items-center gap-2">
+      <Checkbox id={id} checked={checked} disabled={disabled} onCheckedChange={(value) => onChange(value === true)} />
+      <Label htmlFor={id} className="text-sm font-normal">
+        {label}
+      </Label>
+    </div>
   );
 }

--- a/erun-ui/frontend/src/components/app/Sidebar.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Folder, FolderOpen, MoreHorizontal, Plus } from 'lucide-react';
+import { Folder, FolderOpen, MoreHorizontal, Plus, Settings } from 'lucide-react';
 
 import type { ERunUIController } from '@/app/ERunUIController';
 import { readError } from '@/app/errors';
@@ -19,18 +19,32 @@ export function Sidebar({ controller, state }: { controller: ERunUIController; s
     >
       <div className="flex items-center justify-between gap-2 pr-1.5 pb-2.5 pl-3.5">
         <span className="text-xs leading-[1.2] font-semibold tracking-normal text-muted-foreground uppercase">Environments</span>
-        <IconTooltip label="Initialize new remote environment">
-          <Button
-            className="size-[26px] flex-none text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground [&_svg]:size-4"
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            aria-label="Initialize new remote environment"
-            onClick={() => controller.openInitializeDialog()}
-          >
-            <Plus />
-          </Button>
-        </IconTooltip>
+        <div className="flex items-center gap-1">
+          <IconTooltip label="Manage ERun config">
+            <Button
+              className="size-[26px] flex-none text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground [&_svg]:size-4"
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Manage ERun config"
+              onClick={() => controller.openGlobalConfigDialog()}
+            >
+              <Settings />
+            </Button>
+          </IconTooltip>
+          <IconTooltip label="Initialize new remote environment">
+            <Button
+              className="size-[26px] flex-none text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground [&_svg]:size-4"
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Initialize new remote environment"
+              onClick={() => controller.openInitializeDialog()}
+            >
+              <Plus />
+            </Button>
+          </IconTooltip>
+        </div>
       </div>
       <div className="min-h-0 overflow-auto pr-1">
         {state.tenants.length === 0 ? (
@@ -66,18 +80,35 @@ function TenantGroup({
 
   return (
     <div className={cn('flex flex-col', spaced && 'mt-2.5')}>
-      <button
-        className="flex cursor-pointer items-center gap-[9px] border-0 bg-transparent px-3 py-[4px] pb-1.5 text-left text-[15px] leading-[1.25] font-medium tracking-normal text-muted-foreground hover:text-foreground"
-        type="button"
-        onClick={() => controller.toggleTenant(tenant.name)}
-      >
-        {collapsed ? (
-          <Folder className="size-[18px] flex-none" aria-hidden="true" />
-        ) : (
-          <FolderOpen className="size-[18px] flex-none" aria-hidden="true" />
-        )}
-        <span>{tenant.name}</span>
-      </button>
+      <div className="group/tenant flex items-center pr-1">
+        <button
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-[9px] border-0 bg-transparent px-3 py-[4px] pb-1.5 text-left text-[15px] leading-[1.25] font-medium tracking-normal text-muted-foreground hover:text-foreground"
+          type="button"
+          onClick={() => controller.toggleTenant(tenant.name)}
+        >
+          {collapsed ? (
+            <Folder className="size-[18px] flex-none" aria-hidden="true" />
+          ) : (
+            <FolderOpen className="size-[18px] flex-none" aria-hidden="true" />
+          )}
+          <span className="truncate">{tenant.name}</span>
+        </button>
+        <IconTooltip label="Manage tenant">
+          <Button
+            type="button"
+            className="pointer-events-none size-[26px] flex-none cursor-pointer text-muted-foreground opacity-0 transition-[opacity,background-color,color] duration-150 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group-hover/tenant:pointer-events-auto group-hover/tenant:opacity-100 group-focus-within/tenant:pointer-events-auto group-focus-within/tenant:opacity-100 [&_svg]:size-4"
+            variant="ghost"
+            size="icon"
+            aria-label={`Manage ${tenant.name}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              controller.openTenantDialog(tenant.name);
+            }}
+          >
+            <MoreHorizontal />
+          </Button>
+        </IconTooltip>
+      </div>
       {!collapsed && (
         <div className="flex flex-col gap-0 pt-0">
           {tenant.environments.map((environment) => {

--- a/erun-ui/frontend/src/components/app/TenantDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDialogView.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { LoaderCircle, Save } from 'lucide-react';
+
+import type { ERunUIController } from '@/app/ERunUIController';
+import { readError } from '@/app/errors';
+import type { AppState } from '@/app/state';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+const dialogErrorClassName =
+  'rounded-[var(--radius)] border border-[color-mix(in_oklch,var(--destructive)_36%,transparent)] bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] px-[11px] py-[9px] text-[13px] leading-[1.35] text-destructive [overflow-wrap:anywhere]';
+
+export function TenantDialogView({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement {
+  const dialog = state.tenantDialog;
+  const config = dialog.config;
+  const tenant = state.tenants.find((candidate) => candidate.name === dialog.tenant);
+  const environmentOptions = optionValues((tenant?.environments || []).map((environment) => environment.name), config.defaultEnvironment);
+
+  return (
+    <Dialog open={dialog.open} onOpenChange={(open) => !open && controller.closeTenantDialog()}>
+      <DialogContent
+        className="sm:max-w-xl"
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          controller.focusTerminalSoon();
+        }}
+      >
+        <form
+          className="grid gap-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void controller.submitTenantConfig().catch((error: unknown) => {
+              controller.showTerminalMessage(readError(error));
+            });
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Manage tenant</DialogTitle>
+            <DialogDescription>{dialog.tenant}</DialogDescription>
+          </DialogHeader>
+          {dialog.configLoading ? (
+            <div className="rounded-[var(--radius)] border border-dashed border-border px-3 py-2.5 text-[13px] leading-[1.35] text-muted-foreground">
+              Loading config...
+            </div>
+          ) : (
+            <div className="grid gap-3">
+              <TextField id="tenant-config-name" label="name" value={config.name} disabled onChange={() => {}} />
+              <SelectField id="tenant-config-defaultenvironment" label="defaultenvironment" value={config.defaultEnvironment} options={environmentOptions} disabled={dialog.busy || environmentOptions.length === 0} onChange={(defaultEnvironment) => controller.updateTenantConfig({ defaultEnvironment })} />
+            </div>
+          )}
+          {dialog.error && (
+            <div className={dialogErrorClassName} role="alert">
+              {dialog.error}
+            </div>
+          )}
+          <DialogFooter>
+            <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => controller.closeTenantDialog()}>
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={dialog.busy || dialog.configLoading}>
+              {dialog.busy ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Save aria-hidden="true" />}
+              {dialog.busy ? 'Saving...' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SelectField({ id, label, value, options, disabled, onChange }: { id: string; label: string; value: string; options: string[]; disabled?: boolean; onChange: (value: string) => void }): React.ReactElement {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={id}>{label}</Label>
+      <select
+        id={id}
+        className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-[var(--radius)] border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {options.length === 0 ? (
+          <option value="">No environments</option>
+        ) : (
+          <>
+            <option value="">Not configured</option>
+            {options.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </>
+        )}
+      </select>
+    </div>
+  );
+}
+
+function TextField({ id, label, value, disabled, onChange }: { id: string; label: string; value: string; disabled?: boolean; onChange: (value: string) => void }): React.ReactElement {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Input id={id} value={value} type="text" autoComplete="off" spellCheck={false} disabled={disabled} onChange={(event) => onChange(event.target.value)} />
+    </div>
+  );
+}
+
+function optionValues(values: string[], current: string): string[] {
+  const seen = new Set<string>();
+  return [current, ...values]
+    .map((value) => value.trim())
+    .filter((value) => {
+      if (!value || seen.has(value)) {
+        return false;
+      }
+      seen.add(value);
+      return true;
+    });
+}

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -10,7 +10,7 @@ export interface UITenant {
 }
 
 export type EnvironmentActionMode = 'init' | 'deploy';
-export type ManageTab = 'deploy' | 'delete';
+export type ManageTab = 'deploy' | 'config' | 'delete';
 
 export interface UISelection {
   tenant: string;
@@ -40,6 +40,32 @@ export interface UIVersionSuggestion {
   version: string;
   source?: string;
   image?: string;
+}
+
+export interface UIERunConfig {
+  defaultTenant: string;
+}
+
+export interface UITenantConfig {
+  name: string;
+  defaultEnvironment: string;
+}
+
+export interface UISSHDConfig {
+  enabled: boolean;
+  localPort: number;
+  publicKeyPath: string;
+}
+
+export interface UIEnvironmentConfig {
+  name: string;
+  repoPath: string;
+  kubernetesContext: string;
+  containerRegistry: string;
+  runtimeVersion: string;
+  sshd: UISSHDConfig;
+  remote: boolean;
+  snapshot: boolean;
 }
 
 export interface StartSessionResult {


### PR DESCRIPTION
## Summary
- Rework desktop environment management around direct ERun config editing, inline deploy, delete confirmation, and post-deploy reopening.
- Add tenant and global config dialogs for editable tenant/default settings.
- Make snapshot default false unless explicitly enabled, and persist snapshot state from the deployed runtime version.
- Keep resolved/runtime-managed environment fields readonly while preserving them in saves.

## Validation
- go test ./... in erun-common
- go test ./... in erun-cli
- go test ./... in erun-mcp
- go test ./... in erun-ui
- PATH="/opt/homebrew/opt/node@24/bin:/Users/rihardsfreimanis/.codex/tmp/arg0/codex-arg0paUxO6:/Users/rihardsfreimanis/.rd/bin:/opt/homebrew/opt/node@24/bin:/opt/homebrew/opt/postgresql@16/bin:/opt/homebrew/opt/node@22/bin:/opt/homebrew/opt/node@20/bin:/Users/rihardsfreimanis/.jenv/shims:/Users/rihardsfreimanis/.jenv/bin:/opt/homebrew/opt/node@16/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/CyberArk EPM.app/Contents/Helpers:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/sbin:/usr/local/munki:/Users/rihardsfreimanis/.orbstack/bin:/Users/rihardsfreimanis/Library/Application Support/JetBrains/Toolbox/scripts:/Applications/Codex.app/Contents/Resources" yarn build in erun-ui/frontend
- git diff --check

Closes #146