### PR TITLE
Fix new environment MCP access

### DIFF
--- a/erun-cli/cmd/background_process_unix.go
+++ b/erun-cli/cmd/background_process_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+func detachBackgroundProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func isMCPPortForwardProcess(pid int) bool {
+	output, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "command=").Output()
+	if err != nil {
+		return false
+	}
+	command := string(output)
+	return strings.Contains(command, "kubectl") && strings.Contains(command, "port-forward")
+}

--- a/erun-cli/cmd/background_process_windows.go
+++ b/erun-cli/cmd/background_process_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package cmd
+
+import "os/exec"
+
+func detachBackgroundProcess(*exec.Cmd) {}
+
+func isMCPPortForwardProcess(int) bool {
+	return false
+}

--- a/erun-cli/cmd/deploy_test.go
+++ b/erun-cli/cmd/deploy_test.go
@@ -1245,9 +1245,6 @@ func TestRootCommandTreatsDeployAsEnvironmentWhenDeployContextAbsent(t *testing.
 			return common.KubernetesDeployContext{Dir: t.TempDir()}, nil
 		},
 		PromptRunner: func(prompt promptui.Prompt) (string, error) {
-			if !prompt.IsConfirm {
-				t.Fatalf("expected confirm prompt, got %+v", prompt)
-			}
 			if prompt.Label != fmt.Sprintf("create tenant-a-devops chart in %s", projectRoot) {
 				t.Fatalf("unexpected prompt label: %q", prompt.Label)
 			}

--- a/erun-cli/cmd/init.go
+++ b/erun-cli/cmd/init.go
@@ -18,6 +18,8 @@ const (
 
 func newInitCmd(runInit func(common.Context, common.BootstrapInitParams) error) *cobra.Command {
 	params := common.BootstrapInitParams{}
+	setDefaultTenant := false
+	confirmEnvironment := false
 
 	cmd := &cobra.Command{
 		Use:          "init [TENANT] [ENVIRONMENT]",
@@ -38,6 +40,12 @@ func newInitCmd(runInit func(common.Context, common.BootstrapInitParams) error) 
 			if runParams.Remote && strings.TrimSpace(runParams.Environment) == "" {
 				return fmt.Errorf("environment is required with --remote")
 			}
+			if cmd.Flags().Changed("set-default-tenant") {
+				runParams.ConfirmTenant = &setDefaultTenant
+			}
+			if cmd.Flags().Changed("confirm-environment") {
+				runParams.ConfirmEnvironment = &confirmEnvironment
+			}
 			return runInit(commandContext(cmd), runParams)
 		},
 	}
@@ -51,6 +59,8 @@ func newInitCmd(runInit func(common.Context, common.BootstrapInitParams) error) 
 	cmd.Flags().StringVar(&params.ContainerRegistry, "container-registry", "", "Container registry to associate with the environment")
 	cmd.Flags().BoolVar(&params.Remote, "remote", false, "Initialize the tenant repository inside the runtime pod instead of the local host")
 	cmd.Flags().BoolVar(&params.NoGit, "no-git", false, "Skip remote Git checkout setup when used with --remote")
+	cmd.Flags().BoolVar(&setDefaultTenant, "set-default-tenant", false, "Set the initialized tenant as the default tenant")
+	cmd.Flags().BoolVar(&confirmEnvironment, "confirm-environment", false, "Confirm environment initialization without prompting")
 	cmd.Flags().BoolVarP(&params.AutoApprove, "yes", "y", false, "Automatically approve initialization prompts")
 	addDryRunFlag(cmd)
 	return cmd
@@ -99,10 +109,23 @@ func remoteRepositoryURLPrompt(run PromptRunner, label string) (string, error) {
 }
 
 func confirmPrompt(run PromptRunner, label string) (bool, error) {
+	label = strings.TrimRight(strings.TrimSpace(label), "?")
 	prompt := promptui.Prompt{
-		Label:     label,
-		IsConfirm: true,
-		Default:   "y",
+		Label: label,
+		Templates: &promptui.PromptTemplates{
+			Prompt:  `{{ "?" | blue }} {{ . | bold }}? {{ "[Y/n]" | faint }} `,
+			Valid:   `{{ "?" | blue }} {{ . | bold }}? {{ "[Y/n]" | faint }} `,
+			Invalid: `{{ "?" | blue }} {{ . | bold }}? {{ "[Y/n]" | faint }} `,
+			Success: `{{ . | faint }}? `,
+		},
+		Validate: func(input string) error {
+			switch strings.ToLower(strings.TrimSpace(input)) {
+			case "", "y", "n":
+				return nil
+			default:
+				return fmt.Errorf("enter y or n")
+			}
+		},
 	}
 
 	result, err := run(prompt)
@@ -120,7 +143,7 @@ func confirmPrompt(run PromptRunner, label string) (bool, error) {
 		return true, nil
 	}
 
-	return strings.EqualFold(result, "y"), nil
+	return strings.EqualFold(strings.TrimSpace(result), "y"), nil
 }
 
 func kubernetesContextPrompt(run PromptRunner, selectRun SelectRunner, list KubernetesContextsLister, label string) (string, error) {

--- a/erun-cli/cmd/init_test.go
+++ b/erun-cli/cmd/init_test.go
@@ -375,3 +375,22 @@ func TestInitCommandAcceptsRuntimeVersionOverride(t *testing.T) {
 		t.Fatalf("unexpected init params: %+v", got)
 	}
 }
+
+func TestInitCommandAcceptsDefaultSelectionOverrides(t *testing.T) {
+	var got common.BootstrapInitParams
+	cmd := newInitCmd(func(_ common.Context, params common.BootstrapInitParams) error {
+		got = params
+		return nil
+	})
+	cmd.SetArgs([]string{"erun", "local", "--set-default-tenant=false", "--confirm-environment=true"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if got.ConfirmTenant == nil || *got.ConfirmTenant {
+		t.Fatalf("unexpected tenant confirmation: %+v", got.ConfirmTenant)
+	}
+	if got.ConfirmEnvironment == nil || !*got.ConfirmEnvironment {
+		t.Fatalf("unexpected environment confirmation: %+v", got.ConfirmEnvironment)
+	}
+}

--- a/erun-cli/cmd/mcp_port_forward.go
+++ b/erun-cli/cmd/mcp_port_forward.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,6 +25,7 @@ type mcpPortForwardState struct {
 	Namespace         string `json:"namespace"`
 	LocalPort         int    `json:"localPort"`
 	LogPath           string `json:"logPath,omitempty"`
+	ProcessID         int    `json:"processId,omitempty"`
 }
 
 func newMCPForwarder() MCPForwarder {
@@ -48,8 +50,12 @@ func ensureMCPPortForward(ctx common.Context, result common.OpenResult) (int, er
 		LocalPort:         localPort,
 	}
 
-	if stateMatchesMCPTarget(state, expectedState) && canConnectLocalPort(localPort) {
+	if stateMatchesMCPTarget(state, expectedState) && canReachLocalMCPEndpoint(localPort) {
 		return localPort, nil
+	}
+	if stateMatchesMCPTarget(state, expectedState) && state.ProcessID > 0 && canConnectLocalPort(localPort) {
+		_ = stopMCPPortForwardProcess(state.ProcessID)
+		waitForLocalPortToClose(localPort)
 	}
 	if canConnectLocalPort(localPort) {
 		return 0, fmt.Errorf("local MCP port %d is already in use", localPort)
@@ -76,18 +82,20 @@ func ensureMCPPortForward(ctx common.Context, result common.OpenResult) (int, er
 	cmd := exec.Command("kubectl", args...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
+	detachBackgroundProcess(cmd)
 	if err := cmd.Start(); err != nil {
 		return 0, err
 	}
 
 	expectedState.LogPath = logPath
+	expectedState.ProcessID = cmd.Process.Pid
 	if err := saveMCPPortForwardState(statePath, expectedState); err != nil {
 		return 0, err
 	}
 
 	deadline := time.Now().Add(mcpPortForwardStartupTimeout)
 	for time.Now().Before(deadline) {
-		if canConnectLocalPort(localPort) {
+		if canReachLocalMCPEndpoint(localPort) {
 			return localPort, nil
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -108,7 +116,7 @@ func kubectlMCPPortForwardArgs(result common.OpenResult, localPort int) []string
 	args = append(args,
 		"port-forward",
 		"deployment/"+common.RuntimeReleaseName(result.Tenant),
-		fmt.Sprintf("%d:%d", localPort, common.MCPServicePort),
+		fmt.Sprintf("%d:%d", localPort, common.MCPPortForResult(result)),
 		"--address", "127.0.0.1",
 	)
 	return args
@@ -164,4 +172,41 @@ func canConnectLocalPort(port int) bool {
 	}
 	_ = conn.Close()
 	return true
+}
+
+func canReachLocalMCPEndpoint(port int) bool {
+	if port <= 0 {
+		return false
+	}
+	client := http.Client{Timeout: 500 * time.Millisecond}
+	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/mcp", port))
+	if err != nil {
+		return false
+	}
+	_ = resp.Body.Close()
+	return true
+}
+
+func stopMCPPortForwardProcess(pid int) error {
+	if pid <= 0 {
+		return nil
+	}
+	if !isMCPPortForwardProcess(pid) {
+		return nil
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Kill()
+}
+
+func waitForLocalPortToClose(port int) {
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if !canConnectLocalPort(port) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }

--- a/erun-cli/cmd/mcp_port_forward_test.go
+++ b/erun-cli/cmd/mcp_port_forward_test.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strconv"
 	"testing"
 
 	common "github.com/sophium/erun/erun-common"
@@ -27,10 +31,32 @@ func TestKubectlMCPPortForwardArgs(t *testing.T) {
 		"--namespace", "tenant-a-dev",
 		"port-forward",
 		"deployment/tenant-a-devops",
-		"17100:17000",
+		"17100:17100",
 		"--address", "127.0.0.1",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected args:\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestCanReachLocalMCPEndpointRequiresHTTPResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	host, portValue, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split address: %v", err)
+	}
+	if host == "" {
+		t.Fatal("expected listener host")
+	}
+	port, err := strconv.Atoi(portValue)
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+	if !canReachLocalMCPEndpoint(port) {
+		t.Fatal("expected HTTP endpoint to be reachable")
 	}
 }

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -284,6 +284,8 @@ func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, option
 				KubernetesContext: result.EnvConfig.KubernetesContext,
 				ExpectedRepoPath:  common.RemoteShellWorktreePath(shellReq),
 				ExpectedSSHD:      expectedSSHD,
+				ExpectedMCPPort:   common.MCPPortForResult(result),
+				ExpectedSSHPort:   common.SSHLocalPortForResult(result),
 			})
 			if err != nil {
 				return err

--- a/erun-cli/cmd/open_test.go
+++ b/erun-cli/cmd/open_test.go
@@ -90,9 +90,6 @@ func TestOpenCommandVersionOverrideForcesRuntimeDeploy(t *testing.T) {
 	cmd := newTestRootCmd(testRootDeps{
 		Store: openCommandStore{repoPath: repoPath},
 		PromptRunner: func(prompt promptui.Prompt) (string, error) {
-			if !prompt.IsConfirm {
-				t.Fatalf("expected confirm prompt, got %+v", prompt)
-			}
 			return "n", nil
 		},
 		CheckKubernetesDeployment: func(req common.KubernetesDeploymentCheckParams) (bool, error) {
@@ -875,9 +872,6 @@ func TestMaybeConfigureOpenNoShellAliasPromptsAndAppendsToStartupFile(t *testing
 	stderr := new(bytes.Buffer)
 
 	err := maybeConfigureOpenNoShellAlias(result, func(prompt promptui.Prompt) (string, error) {
-		if !prompt.IsConfirm {
-			t.Fatalf("expected confirm prompt, got %+v", prompt)
-		}
 		if prompt.Label != fmt.Sprintf("add frs-local to %s", startupPath) {
 			t.Fatalf("unexpected prompt label: %q", prompt.Label)
 		}
@@ -1423,9 +1417,6 @@ func TestOpenCommandPromptsToCreateMissingRuntimeChartAndUsesCreatedChart(t *tes
 			toolConfig: common.ERunConfig{DefaultTenant: "frs"},
 		},
 		PromptRunner: func(prompt promptui.Prompt) (string, error) {
-			if !prompt.IsConfirm {
-				t.Fatalf("expected confirm prompt, got %+v", prompt)
-			}
 			if prompt.Label != fmt.Sprintf("create frs-devops chart in %s", repoPath) {
 				t.Fatalf("unexpected prompt label: %q", prompt.Label)
 			}

--- a/erun-cli/cmd/root_test.go
+++ b/erun-cli/cmd/root_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/adrg/xdg"
@@ -143,8 +144,8 @@ func TestRootCommandRunsInitWhenNoSubcommand(t *testing.T) {
 	}
 
 	wantPromptLabels := []string{
-		fmt.Sprintf("Initialize tenant %q (path: %s) as the default tenant?", "tenant-a", projectRoot),
-		fmt.Sprintf("Initialize default environment %q for tenant %q?", common.DefaultEnvironment, "tenant-a"),
+		fmt.Sprintf("Initialize tenant %q (path: %s) as the default tenant", "tenant-a", projectRoot),
+		fmt.Sprintf("Initialize default environment %q for tenant %q", common.DefaultEnvironment, "tenant-a"),
 		fmt.Sprintf("Container registry for environment %q in tenant %q", common.DefaultEnvironment, "tenant-a"),
 	}
 	if len(promptLabels) != len(wantPromptLabels) {
@@ -473,10 +474,10 @@ func TestInitCommandDecliningDefaultTenantStillInitializes(t *testing.T) {
 		PromptRunner: func(prompt promptui.Prompt) (string, error) {
 			label := fmt.Sprint(prompt.Label)
 			promptLabels = append(promptLabels, label)
-			if prompt.IsConfirm && label == fmt.Sprintf("Initialize tenant %q (path: %s) as the default tenant?", "petios", projectRoot) {
+			if label == fmt.Sprintf("Initialize tenant %q (path: %s) as the default tenant", "petios", projectRoot) {
 				return "n", nil
 			}
-			if prompt.IsConfirm {
+			if prompt.Templates != nil {
 				return "y", nil
 			}
 			return "", nil
@@ -521,8 +522,8 @@ func TestInitCommandDecliningDefaultTenantStillInitializes(t *testing.T) {
 		t.Fatalf("unexpected env config: %+v", envConfig)
 	}
 	wantPromptLabels := []string{
-		fmt.Sprintf("Initialize tenant %q (path: %s) as the default tenant?", "petios", projectRoot),
-		fmt.Sprintf("Initialize default environment %q for tenant %q?", "review", "petios"),
+		fmt.Sprintf("Initialize tenant %q (path: %s) as the default tenant", "petios", projectRoot),
+		fmt.Sprintf("Initialize default environment %q for tenant %q", "review", "petios"),
 		fmt.Sprintf("Container registry for environment %q in tenant %q", "review", "petios"),
 	}
 	if len(promptLabels) != len(wantPromptLabels) {
@@ -719,6 +720,26 @@ func TestConfirmPromptDefaultAndErrors(t *testing.T) {
 	expectedErr := errors.New("boom")
 	if ok, err := confirmPrompt(run("", expectedErr), "label"); !errors.Is(err, expectedErr) || ok {
 		t.Fatalf("expected original error, got %v %v", ok, err)
+	}
+}
+
+func TestConfirmPromptUsesNormalPromptWithOwnQuestionMarker(t *testing.T) {
+	var captured promptui.Prompt
+	ok, err := confirmPrompt(func(prompt promptui.Prompt) (string, error) {
+		captured = prompt
+		return "n", nil
+	}, "label?")
+	if err != nil || ok {
+		t.Fatalf("expected rejection, got %v %v", ok, err)
+	}
+	if captured.IsConfirm {
+		t.Fatalf("expected normal prompt to avoid promptui confirm abort behavior: %+v", captured)
+	}
+	if captured.Label != "label" {
+		t.Fatalf("expected trailing question mark to be removed from label, got %q", captured.Label)
+	}
+	if captured.Templates == nil || !strings.Contains(captured.Templates.Prompt, "[Y/n]") {
+		t.Fatalf("expected explicit confirm prompt template, got %+v", captured.Templates)
 	}
 }
 

--- a/erun-cli/cmd/sshd_port_forward.go
+++ b/erun-cli/cmd/sshd_port_forward.go
@@ -98,7 +98,7 @@ func kubectlPortForwardArgs(result common.OpenResult, localPort int) []string {
 	args = append(args,
 		"port-forward",
 		"deployment/"+common.RuntimeReleaseName(result.Tenant),
-		fmt.Sprintf("%d:%d", localPort, common.RemoteSSHDPort),
+		fmt.Sprintf("%d:%d", localPort, common.SSHLocalPortForResult(result)),
 		"--address", "127.0.0.1",
 	)
 	return args

--- a/erun-cli/cmd/sshd_test.go
+++ b/erun-cli/cmd/sshd_test.go
@@ -4,11 +4,40 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	common "github.com/sophium/erun/erun-common"
 )
+
+func TestKubectlSSHDPortForwardArgs(t *testing.T) {
+	got := kubectlPortForwardArgs(common.OpenResult{
+		Tenant:      "tenant-a",
+		Environment: "dev",
+		EnvConfig: common.EnvConfig{
+			KubernetesContext: "cluster-dev",
+		},
+		LocalPorts: common.EnvironmentLocalPorts{
+			RangeStart: 17100,
+			RangeEnd:   17199,
+			MCP:        17100,
+			SSH:        17122,
+		},
+	}, 17122)
+
+	want := []string{
+		"--context", "cluster-dev",
+		"--namespace", "tenant-a-dev",
+		"port-forward",
+		"deployment/tenant-a-devops",
+		"17122:17122",
+		"--address", "127.0.0.1",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected args:\ngot:  %v\nwant: %v", got, want)
+	}
+}
 
 func TestRunSSHDInitCommandPersistsConfigAndDeploysRuntime(t *testing.T) {
 	homeDir := t.TempDir()

--- a/erun-common/assets/default-devops-chart/templates/service.yaml
+++ b/erun-common/assets/default-devops-chart/templates/service.yaml
@@ -1,6 +1,8 @@
 {{- $worktreeStorage := default "host" .Values.worktreeStorage -}}
 {{- $worktreeRepoName := required "worktreeRepoName is required" .Values.worktreeRepoName -}}
 {{- $worktreePath := printf "/home/erun/git/%s" $worktreeRepoName -}}
+{{- $mcpPort := default 17000 .Values.mcpPort -}}
+{{- $sshPort := default 17022 .Values.sshPort -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -152,6 +154,10 @@ spec:
               value: {{ required "environment is required" .Values.environment | quote }}
             - name: ERUN_SSHD_ENABLED
               value: {{ if .Values.sshdEnabled }}"true"{{ else }}"false"{{ end }}
+            - name: ERUN_MCP_PORT
+              value: {{ $mcpPort | quote }}
+            - name: ERUN_SSHD_PORT
+              value: {{ $sshPort | quote }}
             - name: ERUN_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -160,9 +166,9 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
           ports:
-            - containerPort: 17000
+            - containerPort: {{ $mcpPort }}
               name: mcp
-            - containerPort: 2222
+            - containerPort: {{ $sshPort }}
               name: ssh
           resources:
             limits:

--- a/erun-common/default_devops_module.go
+++ b/erun-common/default_devops_module.go
@@ -93,7 +93,7 @@ func ensureDefaultDevopsFile(ctx Context, path string, mode os.FileMode, content
 		if bytes.Equal(existing, content) {
 			return nil
 		}
-		if !shouldReplaceDefaultDevopsFile(path, existing) {
+		if !shouldReplaceDefaultDevopsFile(path, existing, content) {
 			return nil
 		}
 	case !os.IsNotExist(err):
@@ -115,21 +115,33 @@ func ensureDefaultDevopsFile(ctx Context, path string, mode os.FileMode, content
 	return os.Chmod(path, mode)
 }
 
-func shouldReplaceDefaultDevopsFile(path string, existing []byte) bool {
-	if filepath.Base(path) != "Dockerfile" {
-		return false
-	}
-
+func shouldReplaceDefaultDevopsFile(path string, existing, content []byte) bool {
 	legacy := []string{
 		"ARG ERUN_BASE_IMAGE=erunpaas/erun-devops\nARG ERUN_BASE_VERSION=1.0.0\n\nFROM ${ERUN_BASE_IMAGE}:${ERUN_BASE_VERSION}\n",
 		"ARG ERUN_BASE_TAG=erunpaas/erun-devops:1.0.0\n\nFROM ${ERUN_BASE_TAG}\n",
 		"ARG ERUN_BASE_TAG=erunpaas/erun-devops:1.0.0\n\nFROM ${ERUN_BASE_TAG}\n\nENTRYPOINT [\"/bin/sh\", \"-lc\", \"if [ \\\"${1:-}\\\" = shell ]; then shift; repo_dir=\\\"${ERUN_REPO_PATH:-${HOME}/git/erun}\\\"; [ -d \\\"$repo_dir\\\" ] && cd \\\"$repo_dir\\\"; exec /bin/bash -i; fi; exec erun-devops-entrypoint \\\"$@\\\"\", \"erun-devops-wrapper\"]\n",
 	}
 	current := strings.TrimSpace(string(existing))
-	for _, candidate := range legacy {
-		if current == strings.TrimSpace(candidate) {
-			return true
+	switch filepath.Base(path) {
+	case "Dockerfile":
+		for _, candidate := range legacy {
+			if current == strings.TrimSpace(candidate) {
+				return true
+			}
 		}
+	case "service.yaml":
+		return current == strings.TrimSpace(legacyDefaultDevopsServiceTemplate(content))
 	}
 	return false
+}
+
+func legacyDefaultDevopsServiceTemplate(content []byte) string {
+	return strings.NewReplacer(
+		"{{- $mcpPort := default 17000 .Values.mcpPort -}}\n{{- $sshPort := default 17022 .Values.sshPort -}}\n",
+		"",
+		"            - name: ERUN_MCP_PORT\n              value: {{ $mcpPort | quote }}\n            - name: ERUN_SSHD_PORT\n              value: {{ $sshPort | quote }}\n",
+		"",
+		"            - containerPort: {{ $mcpPort }}\n              name: mcp\n            - containerPort: {{ $sshPort }}\n              name: ssh",
+		"            - containerPort: 17000\n              name: mcp\n            - containerPort: 2222\n              name: ssh",
+	).Replace(string(content))
 }

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -58,6 +58,8 @@ type HelmDeployParams struct {
 	WorktreeRepoName  string
 	WorktreeHostPath  string
 	SSHDEnabled       bool
+	MCPPort           int
+	SSHPort           int
 	Version           string
 	Timeout           string
 	Stdout            io.Writer
@@ -76,6 +78,8 @@ type HelmDeploySpec struct {
 	WorktreeRepoName  string
 	WorktreeHostPath  string
 	SSHDEnabled       bool
+	MCPPort           int
+	SSHPort           int
 	Version           string
 	Timeout           string
 }
@@ -102,6 +106,8 @@ type KubernetesDeploymentCheckParams struct {
 	KubernetesContext string
 	ExpectedRepoPath  string
 	ExpectedSSHD      *bool
+	ExpectedMCPPort   int
+	ExpectedSSHPort   int
 }
 
 type DeployTarget struct {
@@ -562,6 +568,7 @@ func newHelmDeploySpec(target OpenResult, deployContext KubernetesDeployContext,
 	}
 
 	version := strings.TrimSpace(versionOverride)
+	ports := LocalPortsForResult(target)
 
 	return HelmDeploySpec{
 		ReleaseName:       deployContext.ComponentName,
@@ -575,6 +582,8 @@ func newHelmDeploySpec(target OpenResult, deployContext KubernetesDeployContext,
 		WorktreeRepoName:  resolveWorktreeRepoName(target.RepoPath),
 		WorktreeHostPath:  resolveWorktreeHostPath(target.RepoPath),
 		SSHDEnabled:       target.EnvConfig.SSHD.Enabled,
+		MCPPort:           ports.MCP,
+		SSHPort:           ports.SSH,
 		Version:           version,
 		Timeout:           DefaultHelmDeploymentTimeout,
 	}, nil
@@ -623,6 +632,8 @@ func (d HelmDeploySpec) Params(stdout, stderr io.Writer) HelmDeployParams {
 		WorktreeRepoName:  d.WorktreeRepoName,
 		WorktreeHostPath:  d.WorktreeHostPath,
 		SSHDEnabled:       d.SSHDEnabled,
+		MCPPort:           d.MCPPort,
+		SSHPort:           d.SSHPort,
 		Version:           d.Version,
 		Timeout:           d.Timeout,
 		Stdout:            stdout,
@@ -650,6 +661,8 @@ func (d HelmDeploySpec) command() commandSpec {
 		"--set-string", "worktreeRepoName="+d.WorktreeRepoName,
 		"--set-string", "worktreeHostPath="+d.WorktreeHostPath,
 		"--set", "sshdEnabled="+formatHelmBool(d.SSHDEnabled),
+		"--set", "mcpPort="+formatHelmPort(d.MCPPort, MCPServicePort),
+		"--set", "sshPort="+formatHelmPort(d.SSHPort, DefaultSSHLocalPort),
 		d.ReleaseName,
 		d.ChartPath,
 	)
@@ -731,6 +744,13 @@ func formatHelmBool(value bool) string {
 		return "true"
 	}
 	return "false"
+}
+
+func formatHelmPort(value, fallback int) string {
+	if value <= 0 {
+		value = fallback
+	}
+	return fmt.Sprintf("%d", value)
 }
 
 func resolveDeployKubernetesContext(environment, configured string, currentContext func() (string, error)) string {
@@ -972,6 +992,8 @@ func DeployHelmChart(params HelmDeployParams) error {
 		WorktreeRepoName:  params.WorktreeRepoName,
 		WorktreeHostPath:  params.WorktreeHostPath,
 		SSHDEnabled:       params.SSHDEnabled,
+		MCPPort:           params.MCPPort,
+		SSHPort:           params.SSHPort,
 		Timeout:           params.Timeout,
 	}.command()
 
@@ -1120,7 +1142,7 @@ func CheckKubernetesDeployment(params KubernetesDeploymentCheckParams) (bool, er
 
 	output, err := exec.Command("kubectl", args...).CombinedOutput()
 	if err == nil {
-		if strings.TrimSpace(params.ExpectedRepoPath) == "" && params.ExpectedSSHD == nil {
+		if strings.TrimSpace(params.ExpectedRepoPath) == "" && params.ExpectedSSHD == nil && params.ExpectedMCPPort == 0 && params.ExpectedSSHPort == 0 {
 			return true, nil
 		}
 		return deploymentMatchesExpectedSettings(params)
@@ -1175,6 +1197,8 @@ func deploymentMatchesExpectedSettings(params KubernetesDeploymentCheckParams) (
 		}
 		matchesRepoPath := strings.TrimSpace(expectedRepoPath) == ""
 		matchesSSHD := params.ExpectedSSHD == nil
+		matchesMCPPort := params.ExpectedMCPPort <= 0
+		matchesSSHPort := params.ExpectedSSHPort <= 0
 		for _, env := range container.Env {
 			switch strings.TrimSpace(env.Name) {
 			case "ERUN_REPO_PATH":
@@ -1185,9 +1209,17 @@ func deploymentMatchesExpectedSettings(params KubernetesDeploymentCheckParams) (
 				if params.ExpectedSSHD != nil {
 					matchesSSHD = strings.EqualFold(strings.TrimSpace(env.Value), formatHelmBool(*params.ExpectedSSHD))
 				}
+			case "ERUN_MCP_PORT":
+				if params.ExpectedMCPPort > 0 {
+					matchesMCPPort = strings.TrimSpace(env.Value) == fmt.Sprintf("%d", params.ExpectedMCPPort)
+				}
+			case "ERUN_SSHD_PORT":
+				if params.ExpectedSSHPort > 0 {
+					matchesSSHPort = strings.TrimSpace(env.Value) == fmt.Sprintf("%d", params.ExpectedSSHPort)
+				}
 			}
 		}
-		return matchesRepoPath && matchesSSHD, nil
+		return matchesRepoPath && matchesSSHD && matchesMCPPort && matchesSSHPort, nil
 	}
 
 	return false, nil

--- a/erun-common/deploy_test.go
+++ b/erun-common/deploy_test.go
@@ -260,9 +260,13 @@ func TestRuntimeChartsExposeMCPAndSSHPorts(t *testing.T) {
 		}
 		content := string(data)
 		for _, want := range []string{
-			"containerPort: 17000",
+			`{{- $mcpPort := default 17000 .Values.mcpPort -}}`,
+			`{{- $sshPort := default 17022 .Values.sshPort -}}`,
+			"name: ERUN_MCP_PORT",
+			"name: ERUN_SSHD_PORT",
+			"containerPort: {{ $mcpPort }}",
 			"name: mcp",
-			"containerPort: 2222",
+			"containerPort: {{ $sshPort }}",
 			"name: ssh",
 		} {
 			if !strings.Contains(content, want) {
@@ -339,6 +343,41 @@ func TestNewHelmDeploySpecCanonicalizesWorktreeHostPath(t *testing.T) {
 	}
 	if spec.WorktreeHostPath != resolvedRepoRoot {
 		t.Fatalf("expected canonical worktree host path %q, got %q", resolvedRepoRoot, spec.WorktreeHostPath)
+	}
+}
+
+func TestNewHelmDeploySpecUsesResolvedEnvironmentPorts(t *testing.T) {
+	projectRoot := t.TempDir()
+	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
+	spec, err := newHelmDeploySpec(
+		OpenResult{
+			Tenant:      "tenant-a",
+			Environment: DefaultEnvironment,
+			RepoPath:    projectRoot,
+			EnvConfig: EnvConfig{
+				Name: DefaultEnvironment,
+				SSHD: SSHDConfig{
+					LocalPort: 62222,
+				},
+			},
+			LocalPorts: EnvironmentLocalPorts{
+				RangeStart: 17100,
+				RangeEnd:   17199,
+				MCP:        17100,
+				SSH:        17122,
+			},
+		},
+		KubernetesDeployContext{
+			ComponentName: "erun-devops",
+			ChartPath:     chartPath,
+		},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("newHelmDeploySpec failed: %v", err)
+	}
+	if spec.MCPPort != 17100 || spec.SSHPort != 62222 {
+		t.Fatalf("expected resolved ports to be preserved, got mcp=%d ssh=%d", spec.MCPPort, spec.SSHPort)
 	}
 }
 
@@ -802,6 +841,8 @@ printf '%s
 		WorktreeRepoName:  "erun",
 		WorktreeHostPath:  "/home/erun/git/erun",
 		SSHDEnabled:       true,
+		MCPPort:           17100,
+		SSHPort:           17122,
 		Timeout:           DefaultHelmDeploymentTimeout,
 	}); err != nil {
 		t.Fatalf("DeployHelmChart failed: %v", err)
@@ -814,6 +855,12 @@ printf '%s
 	args := string(data)
 	if !strings.Contains(args, "--set\nsshdEnabled=true\n") {
 		t.Fatalf("expected helm args to include sshdEnabled=true, got:\n%s", args)
+	}
+	if !strings.Contains(args, "--set\nmcpPort=17100\n") {
+		t.Fatalf("expected helm args to include mcpPort=17100, got:\n%s", args)
+	}
+	if !strings.Contains(args, "--set\nsshPort=17122\n") {
+		t.Fatalf("expected helm args to include sshPort=17122, got:\n%s", args)
 	}
 }
 
@@ -930,6 +977,47 @@ exit 1
 	}
 	if deployed {
 		t.Fatalf("expected repo-path mismatch to require redeploy")
+	}
+}
+
+func TestCheckKubernetesDeploymentReturnsFalseWhenRuntimePortDiffers(t *testing.T) {
+	kubectlDir := t.TempDir()
+	kubectlPath := filepath.Join(kubectlDir, "kubectl")
+	if err := os.WriteFile(kubectlPath, []byte(`#!/bin/sh
+if [ "$1" = "--context" ]; then shift 2; fi
+if [ "$1" = "--namespace" ]; then shift 2; fi
+if [ "$1" = "get" ] && [ "$2" = "deployment" ] && [ "$3" = "erun-devops" ] && [ "$4" = "-o" ] && [ "$5" = "name" ]; then
+  echo deployment/erun-devops
+  exit 0
+fi
+if [ "$1" = "get" ] && [ "$2" = "deployment" ] && [ "$3" = "erun-devops" ] && [ "$4" = "-o" ] && [ "$5" = "json" ]; then
+  cat <<'EOF'
+{"spec":{"template":{"spec":{"containers":[{"name":"erun-devops","env":[{"name":"ERUN_REPO_PATH","value":"/home/erun/git/erun"},{"name":"ERUN_SSHD_ENABLED","value":"false"},{"name":"ERUN_MCP_PORT","value":"17000"},{"name":"ERUN_SSHD_PORT","value":"17022"}]}]}}}}
+EOF
+  exit 0
+fi
+echo "unexpected kubectl invocation: $@" >&2
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+	t.Setenv("PATH", kubectlDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	sshd := false
+	deployed, err := CheckKubernetesDeployment(KubernetesDeploymentCheckParams{
+		Name:              "erun-devops",
+		Namespace:         "erun-test",
+		KubernetesContext: "cluster-local",
+		ExpectedRepoPath:  "/home/erun/git/erun",
+		ExpectedSSHD:      &sshd,
+		ExpectedMCPPort:   17200,
+		ExpectedSSHPort:   17222,
+	})
+	if err != nil {
+		t.Fatalf("CheckKubernetesDeployment failed: %v", err)
+	}
+	if deployed {
+		t.Fatalf("expected port mismatch to require redeploy")
 	}
 }
 

--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -272,6 +272,16 @@ func (s tracedBootstrapStore) SaveEnvConfig(tenant string, config EnvConfig) err
 	return s.BootstrapStore.SaveEnvConfig(tenant, config)
 }
 
+func (s tracedBootstrapStore) ListEnvConfigs(tenant string) ([]EnvConfig, error) {
+	portStore, ok := s.BootstrapStore.(interface {
+		ListEnvConfigs(string) ([]EnvConfig, error)
+	})
+	if !ok {
+		return nil, ErrNotInitialized
+	}
+	return portStore.ListEnvConfigs(tenant)
+}
+
 func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, error) {
 	s = s.withDefaults()
 	params = normalizeBootstrapParams(params)
@@ -657,11 +667,11 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 }
 
 func tenantConfirmationLabel(tenant, projectRoot string) string {
-	return fmt.Sprintf("Initialize tenant %q (path: %s) as the default tenant?", tenant, projectRoot)
+	return fmt.Sprintf("Initialize tenant %q (path: %s) as the default tenant", tenant, projectRoot)
 }
 
 func environmentConfirmationLabel(tenant, envName string) string {
-	return fmt.Sprintf("Initialize default environment %q for tenant %q?", envName, tenant)
+	return fmt.Sprintf("Initialize default environment %q for tenant %q", envName, tenant)
 }
 
 func kubernetesContextLabel(tenant, envName string) string {
@@ -677,7 +687,7 @@ func remoteRepositoryLabel(tenant, envName string) string {
 }
 
 func remoteKeyImportLabel(tenant, envName string) string {
-	return fmt.Sprintf("Import the SSH public key above for environment %q in tenant %q and continue?", envName, tenant)
+	return fmt.Sprintf("Import the SSH public key above for environment %q in tenant %q and continue", envName, tenant)
 }
 
 func KubernetesNamespaceName(tenant, envName string) string {

--- a/erun-common/init_remote.go
+++ b/erun-common/init_remote.go
@@ -17,6 +17,13 @@ type remoteRepositoryState struct {
 const remoteRepositoryAccessRetryInterval = 2 * time.Second
 
 func (s bootstrapRunner) ensureRemoteRepository(params BootstrapInitParams, tenant, envName, kubernetesContext, projectRoot string) error {
+	ports := DefaultEnvironmentLocalPorts()
+	if portStore, ok := s.Store.(environmentPortStore); ok {
+		resolved, err := ResolveEnvironmentLocalPorts(portStore, tenant, envName)
+		if err == nil {
+			ports = resolved
+		}
+	}
 	target := OpenResult{
 		Tenant:      tenant,
 		Environment: envName,
@@ -31,8 +38,9 @@ func (s bootstrapRunner) ensureRemoteRepository(params BootstrapInitParams, tena
 			KubernetesContext: kubernetesContext,
 			Remote:            true,
 		},
-		RepoPath: projectRoot,
-		Title:    tenant + "-" + envName,
+		LocalPorts: ports,
+		RepoPath:   projectRoot,
+		Title:      tenant + "-" + envName,
 	}
 	req := ShellLaunchParamsFromResult(target)
 

--- a/erun-common/init_test.go
+++ b/erun-common/init_test.go
@@ -345,6 +345,75 @@ func TestBootstrapRunCreatesTenantDevopsModuleAndChart(t *testing.T) {
 	}
 }
 
+func TestEnsureDefaultDevopsChartMigratesLegacyGeneratedServiceTemplate(t *testing.T) {
+	projectRoot := t.TempDir()
+	moduleName := "tenant-a-devops"
+	serviceTemplatePath := filepath.Join(projectRoot, moduleName, "k8s", moduleName, "templates", "service.yaml")
+	current, err := defaultDevopsChartFiles.ReadFile("assets/default-devops-chart/templates/service.yaml")
+	if err != nil {
+		t.Fatalf("read embedded service template: %v", err)
+	}
+	rendered := renderDefaultDevopsChartTemplate("assets/default-devops-chart/templates/service.yaml", moduleName, moduleName, current)
+	if err := os.MkdirAll(filepath.Dir(serviceTemplatePath), 0o755); err != nil {
+		t.Fatalf("mkdir service template dir: %v", err)
+	}
+	if err := os.WriteFile(serviceTemplatePath, []byte(legacyDefaultDevopsServiceTemplate(rendered)), 0o644); err != nil {
+		t.Fatalf("write legacy service template: %v", err)
+	}
+
+	if err := EnsureDefaultDevopsChart(Context{}, projectRoot, "tenant-a", DefaultEnvironment); err != nil {
+		t.Fatalf("EnsureDefaultDevopsChart failed: %v", err)
+	}
+
+	migrated, err := os.ReadFile(serviceTemplatePath)
+	if err != nil {
+		t.Fatalf("read migrated service template: %v", err)
+	}
+	content := string(migrated)
+	for _, want := range []string{
+		`{{- $mcpPort := default 17000 .Values.mcpPort -}}`,
+		`{{- $sshPort := default 17022 .Values.sshPort -}}`,
+		"name: ERUN_MCP_PORT",
+		"name: ERUN_SSHD_PORT",
+		"containerPort: {{ $mcpPort }}",
+		"containerPort: {{ $sshPort }}",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("expected migrated service template to contain %q, got:\n%s", want, content)
+		}
+	}
+}
+
+func TestEnsureDefaultDevopsChartPreservesModifiedServiceTemplate(t *testing.T) {
+	projectRoot := t.TempDir()
+	moduleName := "tenant-a-devops"
+	serviceTemplatePath := filepath.Join(projectRoot, moduleName, "k8s", moduleName, "templates", "service.yaml")
+	current, err := defaultDevopsChartFiles.ReadFile("assets/default-devops-chart/templates/service.yaml")
+	if err != nil {
+		t.Fatalf("read embedded service template: %v", err)
+	}
+	rendered := renderDefaultDevopsChartTemplate("assets/default-devops-chart/templates/service.yaml", moduleName, moduleName, current)
+	modified := legacyDefaultDevopsServiceTemplate(rendered) + "\n# tenant customization\n"
+	if err := os.MkdirAll(filepath.Dir(serviceTemplatePath), 0o755); err != nil {
+		t.Fatalf("mkdir service template dir: %v", err)
+	}
+	if err := os.WriteFile(serviceTemplatePath, []byte(modified), 0o644); err != nil {
+		t.Fatalf("write modified service template: %v", err)
+	}
+
+	if err := EnsureDefaultDevopsChart(Context{}, projectRoot, "tenant-a", DefaultEnvironment); err != nil {
+		t.Fatalf("EnsureDefaultDevopsChart failed: %v", err)
+	}
+
+	preserved, err := os.ReadFile(serviceTemplatePath)
+	if err != nil {
+		t.Fatalf("read service template: %v", err)
+	}
+	if string(preserved) != modified {
+		t.Fatalf("expected modified service template to be preserved, got:\n%s", preserved)
+	}
+}
+
 func TestBootstrapRunCreatesTenantDevopsEnvironmentValuesFile(t *testing.T) {
 	setupXDGConfigHome(t)
 
@@ -1142,7 +1211,26 @@ func TestBootstrapRunRemoteInitializesTenantInPodWorktree(t *testing.T) {
 func TestBootstrapRunRemoteNoGitCreatesWorktreeWithoutRepositoryPrompts(t *testing.T) {
 	setupXDGConfigHome(t)
 
+	if err := SaveTenantConfig(TenantConfig{
+		Name:               "erun",
+		ProjectRoot:        RemoteWorktreePathForRepoName("erun"),
+		DefaultEnvironment: "local",
+	}); err != nil {
+		t.Fatalf("SaveTenantConfig failed: %v", err)
+	}
+	for _, envName := range []string{"local", "proxmox1"} {
+		if err := SaveEnvConfig("erun", EnvConfig{
+			Name:              envName,
+			RepoPath:          RemoteWorktreePathForRepoName("erun"),
+			KubernetesContext: "cluster-remote",
+			Remote:            true,
+		}); err != nil {
+			t.Fatalf("SaveEnvConfig failed: %v", err)
+		}
+	}
+
 	scripts := make([]string, 0, 1)
+	var deployed HelmDeployParams
 	service := bootstrapTestRunner{
 		Context: testContextWithLogger(&testTraceLogger{}),
 		Store:   ConfigStore{},
@@ -1166,7 +1254,8 @@ func TestBootstrapRunRemoteNoGitCreatesWorktreeWithoutRepositoryPrompts(t *testi
 		EnsureKubernetesNamespace: func(string, string) error {
 			return nil
 		},
-		DeployHelmChart: func(HelmDeployParams) error {
+		DeployHelmChart: func(params HelmDeployParams) error {
+			deployed = params
 			return nil
 		},
 		WaitForRemoteRuntime: func(ShellLaunchParams) error {
@@ -1179,8 +1268,8 @@ func TestBootstrapRunRemoteNoGitCreatesWorktreeWithoutRepositoryPrompts(t *testi
 	}
 
 	result, err := service.Run(BootstrapInitParams{
-		Tenant:      "frs",
-		Environment: "dev",
+		Tenant:      "erun",
+		Environment: "test",
 		Remote:      true,
 		NoGit:       true,
 	})
@@ -1188,9 +1277,12 @@ func TestBootstrapRunRemoteNoGitCreatesWorktreeWithoutRepositoryPrompts(t *testi
 		t.Fatalf("Run failed: %v", err)
 	}
 
-	remotePath := RemoteWorktreePathForRepoName("frs")
+	remotePath := RemoteWorktreePathForRepoName("erun")
 	if result.EnvConfig.RepoPath != remotePath || !result.EnvConfig.Remote {
 		t.Fatalf("unexpected env config: %+v", result.EnvConfig)
+	}
+	if deployed.MCPPort != 17200 || deployed.SSHPort != 17222 {
+		t.Fatalf("expected remote init deploy to use allocated ports, got mcp=%d ssh=%d", deployed.MCPPort, deployed.SSHPort)
 	}
 	if len(scripts) != 1 {
 		t.Fatalf("expected only remote worktree command, got %d", len(scripts))

--- a/erun-common/sshd.go
+++ b/erun-common/sshd.go
@@ -7,10 +7,7 @@ import (
 	"strings"
 )
 
-const (
-	DefaultSSHUser = "erun"
-	RemoteSSHDPort = 2222
-)
+const DefaultSSHUser = "erun"
 
 type SSHConnectionInfo struct {
 	User           string

--- a/erun-common/sshd_test.go
+++ b/erun-common/sshd_test.go
@@ -103,8 +103,12 @@ func TestRuntimeEntrypointDisablesStrictModesForPVCBackedHome(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read runtime entrypoint: %v", err)
 	}
-	if !strings.Contains(string(data), "StrictModes no") {
+	content := string(data)
+	if !strings.Contains(content, "StrictModes no") {
 		t.Fatalf("expected runtime entrypoint to disable sshd strict modes for PVC-backed home directory, got:\n%s", string(data))
+	}
+	if !strings.Contains(content, "Port ${ERUN_SSHD_PORT:-17022}") {
+		t.Fatalf("expected runtime entrypoint to configure sshd from ERUN_SSHD_PORT, got:\n%s", content)
 	}
 }
 

--- a/erun-devops/docker/erun-devops/Dockerfile
+++ b/erun-devops/docker/erun-devops/Dockerfile
@@ -115,7 +115,7 @@ WORKDIR /home/erun
 
 USER erun
 
-EXPOSE 17000
+EXPOSE 17000 17022
 
 ENTRYPOINT ["erun-devops-entrypoint"]
 CMD ["--host", "0.0.0.0"]

--- a/erun-devops/docker/erun-devops/entrypoint.sh
+++ b/erun-devops/docker/erun-devops/entrypoint.sh
@@ -169,7 +169,7 @@ start_sshd() {
     chmod 644 "${host_key}.pub"
 
     cat >"${config_file}" <<EOF
-Port 2222
+Port ${ERUN_SSHD_PORT:-17022}
 ListenAddress 0.0.0.0
 HostKey ${host_key}
 AuthorizedKeysFile ${HOME}/.ssh/authorized_keys

--- a/erun-devops/k8s/erun-devops/templates/service.yaml
+++ b/erun-devops/k8s/erun-devops/templates/service.yaml
@@ -1,3 +1,5 @@
+{{- $mcpPort := default 17000 .Values.mcpPort -}}
+{{- $sshPort := default 17022 .Values.sshPort -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -149,6 +151,10 @@ spec:
               value: {{ required "environment is required" .Values.environment | quote }}
             - name: ERUN_SSHD_ENABLED
               value: {{ if .Values.sshdEnabled }}"true"{{ else }}"false"{{ end }}
+            - name: ERUN_MCP_PORT
+              value: {{ $mcpPort | quote }}
+            - name: ERUN_SSHD_PORT
+              value: {{ $sshPort | quote }}
             - name: ERUN_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -157,9 +163,9 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
           ports:
-            - containerPort: 17000
+            - containerPort: {{ $mcpPort }}
               name: mcp
-            - containerPort: 2222
+            - containerPort: {{ $sshPort }}
               name: ssh
           resources:
             limits:

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	eruncommon "github.com/sophium/erun/erun-common"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
@@ -33,6 +36,9 @@ type erunUIDeps struct {
 	resolveBuildInfo     func() eruncommon.BuildInfo
 	resolveImageRegistry func(context.Context, string, string) (eruncommon.RuntimeRegistryVersions, error)
 	deleteNamespace      eruncommon.NamespaceDeleterFunc
+	listKubeContexts     func() ([]string, error)
+	ensureMCP            func(context.Context, eruncommon.OpenResult) error
+	canConnectLocalPort  func(int) bool
 	startTerminal        func(startTerminalSessionParams) (terminalSession, error)
 	savePastedImage      func(pastedImageSaveParams) (string, error)
 	loadDiff             func(context.Context, string) (eruncommon.DiffResult, error)
@@ -70,12 +76,15 @@ type uiEnvironment struct {
 }
 
 type uiSelection struct {
-	Tenant       string `json:"tenant"`
-	Environment  string `json:"environment"`
-	Version      string `json:"version,omitempty"`
-	RuntimeImage string `json:"runtimeImage,omitempty"`
-	NoGit        bool   `json:"noGit,omitempty"`
-	Action       string `json:"action,omitempty"`
+	Tenant            string `json:"tenant"`
+	Environment       string `json:"environment"`
+	Version           string `json:"version,omitempty"`
+	RuntimeImage      string `json:"runtimeImage,omitempty"`
+	KubernetesContext string `json:"kubernetesContext,omitempty"`
+	ContainerRegistry string `json:"containerRegistry,omitempty"`
+	NoGit             bool   `json:"noGit,omitempty"`
+	SetDefaultTenant  bool   `json:"setDefaultTenant,omitempty"`
+	Action            string `json:"action,omitempty"`
 }
 
 type uiBuildDetails struct {
@@ -101,15 +110,30 @@ type uiSSHDConfig struct {
 	PublicKeyPath string `json:"publicKeyPath"`
 }
 
+type uiEnvironmentLocalPorts struct {
+	RangeStart int          `json:"rangeStart"`
+	RangeEnd   int          `json:"rangeEnd"`
+	MCP        int          `json:"mcp"`
+	SSH        int          `json:"ssh"`
+	MCPStatus  uiPortStatus `json:"mcpStatus"`
+	SSHStatus  uiPortStatus `json:"sshStatus"`
+}
+
+type uiPortStatus struct {
+	Available bool   `json:"available"`
+	Status    string `json:"status"`
+}
+
 type uiEnvironmentConfig struct {
-	Name              string       `json:"name"`
-	RepoPath          string       `json:"repoPath"`
-	KubernetesContext string       `json:"kubernetesContext"`
-	ContainerRegistry string       `json:"containerRegistry"`
-	RuntimeVersion    string       `json:"runtimeVersion"`
-	SSHD              uiSSHDConfig `json:"sshd"`
-	Remote            bool         `json:"remote"`
-	Snapshot          bool         `json:"snapshot"`
+	Name              string                  `json:"name"`
+	RepoPath          string                  `json:"repoPath"`
+	KubernetesContext string                  `json:"kubernetesContext"`
+	ContainerRegistry string                  `json:"containerRegistry"`
+	RuntimeVersion    string                  `json:"runtimeVersion"`
+	SSHD              uiSSHDConfig            `json:"sshd"`
+	LocalPorts        uiEnvironmentLocalPorts `json:"localPorts"`
+	Remote            bool                    `json:"remote"`
+	Snapshot          bool                    `json:"snapshot"`
 }
 
 type startSessionResult struct {
@@ -165,6 +189,17 @@ func NewApp(deps erunUIDeps) *App {
 	}
 	if deps.deleteNamespace == nil {
 		deps.deleteNamespace = eruncommon.DeleteKubernetesNamespace
+	}
+	if deps.listKubeContexts == nil {
+		deps.listKubeContexts = listKubernetesContexts
+	}
+	if deps.ensureMCP == nil {
+		deps.ensureMCP = func(ctx context.Context, result eruncommon.OpenResult) error {
+			return ensureMCPViaOpenCommand(ctx, deps.resolveCLIPath(), result)
+		}
+	}
+	if deps.canConnectLocalPort == nil {
+		deps.canConnectLocalPort = canConnectLocalTCP
 	}
 	if deps.startTerminal == nil {
 		deps.startTerminal = startTerminalSession
@@ -273,6 +308,14 @@ func (a *App) LoadVersionSuggestions(selection uiSelection) ([]uiVersion, error)
 	return a.runtimeVersionSuggestions(a.deps.resolveBuildInfo(), selection.Tenant), nil
 }
 
+func (a *App) LoadKubernetesContexts() ([]string, error) {
+	contexts, err := a.deps.listKubeContexts()
+	if err != nil {
+		return nil, err
+	}
+	return normalizeKubernetesContexts(contexts), nil
+}
+
 func (a *App) LoadERunConfig() (uiERunConfig, error) {
 	config, _, err := a.deps.store.LoadERunConfig()
 	if err != nil {
@@ -331,7 +374,11 @@ func (a *App) LoadEnvironmentConfig(selection uiSelection) (uiEnvironmentConfig,
 	if err != nil {
 		return uiEnvironmentConfig{}, err
 	}
-	return environmentConfigToUI(config, selection.Environment), nil
+	ports, err := eruncommon.ResolveEnvironmentLocalPorts(a.deps.store, selection.Tenant, selection.Environment)
+	if err != nil {
+		return uiEnvironmentConfig{}, err
+	}
+	return environmentConfigToUI(config, selection.Environment, ports), nil
 }
 
 func (a *App) SaveEnvironmentConfig(selection uiSelection, config uiEnvironmentConfig) (uiEnvironmentConfig, error) {
@@ -348,7 +395,11 @@ func (a *App) SaveEnvironmentConfig(selection uiSelection, config uiEnvironmentC
 	if err := a.deps.store.SaveEnvConfig(selection.Tenant, updated); err != nil {
 		return uiEnvironmentConfig{}, err
 	}
-	return environmentConfigToUI(updated, selection.Environment), nil
+	ports, err := eruncommon.ResolveEnvironmentLocalPorts(a.deps.store, selection.Tenant, selection.Environment)
+	if err != nil {
+		return uiEnvironmentConfig{}, err
+	}
+	return environmentConfigToUI(updated, selection.Environment, ports), nil
 }
 
 func labelRuntimeVersionSuggestions(source, image string, suggestions []uiVersion) []uiVersion {
@@ -392,11 +443,15 @@ func tenantConfigFromUI(config uiTenantConfig, existing eruncommon.TenantConfig)
 	return existing
 }
 
-func environmentConfigToUI(config eruncommon.EnvConfig, fallbackName string) uiEnvironmentConfig {
+func environmentConfigToUI(config eruncommon.EnvConfig, fallbackName string, ports eruncommon.EnvironmentLocalPorts) uiEnvironmentConfig {
 	name := strings.TrimSpace(config.Name)
 	if name == "" {
 		name = strings.TrimSpace(fallbackName)
 	}
+	ports = eruncommon.LocalPortsForResult(eruncommon.OpenResult{
+		EnvConfig:  config,
+		LocalPorts: ports,
+	})
 	result := uiEnvironmentConfig{
 		Name:              name,
 		RepoPath:          strings.TrimSpace(config.RepoPath),
@@ -408,10 +463,40 @@ func environmentConfigToUI(config eruncommon.EnvConfig, fallbackName string) uiE
 			LocalPort:     config.SSHD.LocalPort,
 			PublicKeyPath: strings.TrimSpace(config.SSHD.PublicKeyPath),
 		},
+		LocalPorts: uiEnvironmentLocalPorts{
+			RangeStart: ports.RangeStart,
+			RangeEnd:   ports.RangeEnd,
+			MCP:        ports.MCP,
+			SSH:        ports.SSH,
+			MCPStatus:  localPortStatus(ports.MCP),
+			SSHStatus:  localPortStatus(ports.SSH),
+		},
 		Remote:   config.Remote,
 		Snapshot: config.SnapshotEnabled(),
 	}
 	return result
+}
+
+func localPortStatus(port int) uiPortStatus {
+	if port <= 0 {
+		return uiPortStatus{Status: "Not assigned"}
+	}
+	if !canConnectLocalTCP(port) {
+		return uiPortStatus{Status: "No"}
+	}
+	return uiPortStatus{Available: true, Status: "Yes"}
+}
+
+func canConnectLocalTCP(port int) bool {
+	if port <= 0 {
+		return false
+	}
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
 }
 
 func environmentConfigFromUI(config uiEnvironmentConfig, existing eruncommon.EnvConfig) eruncommon.EnvConfig {
@@ -488,7 +573,7 @@ func (a *App) StartSession(selection uiSelection, cols, rows int) (startSessionR
 }
 
 func (a *App) StartInitSession(selection uiSelection, cols, rows int) (startSessionResult, error) {
-	return a.startCommandSession(selection, cols, rows, initSelectionKey(selection), buildInitArgs(selection.Tenant, selection.Environment, selection.Version, selection.RuntimeImage, selection.NoGit), resolveInitStartDir(a.deps.findProjectRoot), []string{appSessionEnvVar + "=1"})
+	return a.startCommandSession(selection, cols, rows, initSelectionKey(selection), buildInitArgs(selection), resolveInitStartDir(a.deps.findProjectRoot), []string{appSessionEnvVar + "=1"})
 }
 
 func (a *App) StartDeploySession(selection uiSelection, cols, rows int) (startSessionResult, error) {
@@ -659,7 +744,23 @@ func (a *App) LoadDiff(selection uiSelection) (eruncommon.DiffResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return a.deps.loadDiff(ctx, mcpEndpointForOpenResult(result))
+	mcpPort := eruncommon.MCPPortForResult(result)
+	if a.deps.ensureMCP != nil && !a.deps.canConnectLocalPort(mcpPort) {
+		if err := a.deps.ensureMCP(ctx, result); err != nil {
+			if !a.deps.canConnectLocalPort(mcpPort) {
+				return eruncommon.DiffResult{}, err
+			}
+		}
+	}
+	endpoint := mcpEndpointForOpenResult(result)
+	diff, err := a.deps.loadDiff(ctx, endpoint)
+	if err == nil || a.deps.ensureMCP == nil {
+		return diff, err
+	}
+	if ensureErr := a.deps.ensureMCP(ctx, result); ensureErr != nil {
+		return eruncommon.DiffResult{}, err
+	}
+	return a.deps.loadDiff(ctx, endpoint)
 }
 
 func (a *App) ResizeSession(cols, rows int) error {
@@ -863,14 +964,66 @@ func buildDetailsFrom(info eruncommon.BuildInfo) uiBuildDetails {
 	}
 }
 
+func listKubernetesContexts() ([]string, error) {
+	output, err := exec.Command("kubectl", "config", "get-contexts", "-o=name").Output()
+	if err != nil {
+		return nil, err
+	}
+	contexts := strings.Split(string(output), "\n")
+
+	currentOutput, err := exec.Command("kubectl", "config", "current-context").Output()
+	if err == nil {
+		contexts = preferCurrentKubernetesContext(contexts, string(currentOutput))
+	}
+
+	return contexts, nil
+}
+
+func normalizeKubernetesContexts(contexts []string) []string {
+	seen := make(map[string]struct{}, len(contexts))
+	result := make([]string, 0, len(contexts))
+	for _, context := range contexts {
+		context = strings.TrimSpace(context)
+		if context == "" {
+			continue
+		}
+		if _, ok := seen[context]; ok {
+			continue
+		}
+		seen[context] = struct{}{}
+		result = append(result, context)
+	}
+	return result
+}
+
+func preferCurrentKubernetesContext(contexts []string, current string) []string {
+	current = strings.TrimSpace(current)
+	if current == "" {
+		return contexts
+	}
+
+	result := make([]string, 0, len(contexts)+1)
+	result = append(result, current)
+	for _, context := range contexts {
+		if strings.TrimSpace(context) == current {
+			continue
+		}
+		result = append(result, context)
+	}
+	return result
+}
+
 func normalizeSelection(selection uiSelection) uiSelection {
 	return uiSelection{
-		Tenant:       strings.TrimSpace(selection.Tenant),
-		Environment:  strings.TrimSpace(selection.Environment),
-		Version:      strings.TrimSpace(selection.Version),
-		RuntimeImage: strings.TrimSpace(selection.RuntimeImage),
-		NoGit:        selection.NoGit,
-		Action:       strings.TrimSpace(selection.Action),
+		Tenant:            strings.TrimSpace(selection.Tenant),
+		Environment:       strings.TrimSpace(selection.Environment),
+		Version:           strings.TrimSpace(selection.Version),
+		RuntimeImage:      strings.TrimSpace(selection.RuntimeImage),
+		KubernetesContext: strings.TrimSpace(selection.KubernetesContext),
+		ContainerRegistry: strings.TrimSpace(selection.ContainerRegistry),
+		NoGit:             selection.NoGit,
+		SetDefaultTenant:  selection.SetDefaultTenant,
+		Action:            strings.TrimSpace(selection.Action),
 	}
 }
 
@@ -906,7 +1059,7 @@ func selectionKey(selection uiSelection) string {
 
 func initSelectionKey(selection uiSelection) string {
 	selection = normalizeSelection(selection)
-	return "init\x00" + selection.Tenant + "\x00" + selection.Environment + "\x00" + selection.Version + "\x00" + selection.RuntimeImage + "\x00" + fmt.Sprintf("%t", selection.NoGit)
+	return "init\x00" + selection.Tenant + "\x00" + selection.Environment + "\x00" + selection.Version + "\x00" + selection.RuntimeImage + "\x00" + selection.KubernetesContext + "\x00" + selection.ContainerRegistry + "\x00" + fmt.Sprintf("%t", selection.SetDefaultTenant) + "\x00" + fmt.Sprintf("%t", selection.NoGit)
 }
 
 func deploySelectionKey(selection uiSelection) string {

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -272,6 +274,25 @@ func TestLoadVersionSuggestionsForInitUsesAvailableRuntimeImageTags(t *testing.T
 	}
 }
 
+func TestLoadKubernetesContextsNormalizesContexts(t *testing.T) {
+	app := NewApp(erunUIDeps{
+		listKubeContexts: func() ([]string, error) {
+			return []string{" cluster-b ", "cluster-a", "cluster-b", ""}, nil
+		},
+	})
+	defer app.shutdown(context.Background())
+
+	contexts, err := app.LoadKubernetesContexts()
+	if err != nil {
+		t.Fatalf("LoadKubernetesContexts failed: %v", err)
+	}
+
+	want := []string{"cluster-b", "cluster-a"}
+	if strings.Join(contexts, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected contexts: got %+v want %+v", contexts, want)
+	}
+}
+
 func TestParseVersionOutputUsesLastVersionLine(t *testing.T) {
 	info, ok := parseVersionOutput("trace line\nerun 1.0.50 (03ce970142a1 built 2026-04-24T17:38:53Z)\n")
 	if !ok {
@@ -309,8 +330,16 @@ func TestLoadDiffUsesSelectedMCPPort(t *testing.T) {
 		},
 	}
 	var gotEndpoint string
+	var ensured eruncommon.OpenResult
 	app := NewApp(erunUIDeps{
 		store: store,
+		canConnectLocalPort: func(int) bool {
+			return false
+		},
+		ensureMCP: func(_ context.Context, result eruncommon.OpenResult) error {
+			ensured = result
+			return nil
+		},
 		loadDiff: func(_ context.Context, endpoint string) (eruncommon.DiffResult, error) {
 			gotEndpoint = endpoint
 			return eruncommon.DiffResult{RawDiff: "diff --git a/a.txt b/a.txt\n"}, nil
@@ -323,6 +352,65 @@ func TestLoadDiffUsesSelectedMCPPort(t *testing.T) {
 	}
 	if gotEndpoint != "http://127.0.0.1:17000/mcp" {
 		t.Fatalf("unexpected endpoint: %q", gotEndpoint)
+	}
+	if ensured.Tenant != "erun" || ensured.Environment != "local" {
+		t.Fatalf("expected MCP forward to be ensured before diff, got %+v", ensured)
+	}
+	if result.RawDiff == "" {
+		t.Fatalf("unexpected diff result: %+v", result)
+	}
+}
+
+func TestLoadDiffReactivatesMCPAfterConnectionError(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {
+				Name:               "erun",
+				ProjectRoot:        projectRoot,
+				DefaultEnvironment: "test",
+			},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/test": {
+				Name:              "test",
+				RepoPath:          projectRoot,
+				KubernetesContext: "orbstack",
+			},
+		},
+	}
+	ensureCalls := 0
+	loadCalls := 0
+	app := NewApp(erunUIDeps{
+		store: store,
+		canConnectLocalPort: func(int) bool {
+			return true
+		},
+		ensureMCP: func(_ context.Context, result eruncommon.OpenResult) error {
+			ensureCalls++
+			if result.Tenant != "erun" || result.Environment != "test" {
+				t.Fatalf("unexpected MCP target: %+v", result)
+			}
+			return nil
+		},
+		loadDiff: func(_ context.Context, endpoint string) (eruncommon.DiffResult, error) {
+			loadCalls++
+			if endpoint != "http://127.0.0.1:17000/mcp" {
+				t.Fatalf("unexpected endpoint: %q", endpoint)
+			}
+			if loadCalls == 1 {
+				return eruncommon.DiffResult{}, errors.New("EOF")
+			}
+			return eruncommon.DiffResult{RawDiff: "diff --git a/a.txt b/a.txt\n"}, nil
+		},
+	})
+
+	result, err := app.LoadDiff(uiSelection{Tenant: "erun", Environment: "test"})
+	if err != nil {
+		t.Fatalf("LoadDiff failed: %v", err)
+	}
+	if ensureCalls != 1 || loadCalls != 2 {
+		t.Fatalf("expected one MCP reactivation and retry, got ensure=%d load=%d", ensureCalls, loadCalls)
 	}
 	if result.RawDiff == "" {
 		t.Fatalf("unexpected diff result: %+v", result)
@@ -350,9 +438,22 @@ func TestBuildOpenArgsTrimsTenantAndEnvironment(t *testing.T) {
 	}
 }
 
+func TestBuildOpenNoShellArgsTrimsTenantAndEnvironment(t *testing.T) {
+	got := buildOpenNoShellArgs(" erun ", " local ")
+	want := []string{"open", "erun", "local", "--no-shell", "--no-alias-prompt"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected args length: got %+v want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected arg[%d]: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestBuildInitArgsTrimsTenantAndEnvironment(t *testing.T) {
-	got := buildInitArgs(" erun ", " remote ", "", "", false)
-	want := []string{"init", "erun", "remote", "--remote"}
+	got := buildInitArgs(uiSelection{Tenant: " erun ", Environment: " remote "})
+	want := []string{"init", "erun", "remote", "--remote", "--set-default-tenant=false", "--confirm-environment=true"}
 	if len(got) != len(want) {
 		t.Fatalf("unexpected args length: got %+v want %+v", got, want)
 	}
@@ -364,8 +465,17 @@ func TestBuildInitArgsTrimsTenantAndEnvironment(t *testing.T) {
 }
 
 func TestBuildInitArgsIncludesRuntimeVersion(t *testing.T) {
-	got := buildInitArgs(" erun ", " remote ", " 1.0.19 ", " erun-devops ", true)
-	want := []string{"init", "erun", "remote", "--remote", "--version", "1.0.19", "--runtime-image", "erun-devops", "--no-git"}
+	got := buildInitArgs(uiSelection{
+		Tenant:            " erun ",
+		Environment:       " remote ",
+		Version:           " 1.0.19 ",
+		RuntimeImage:      " erun-devops ",
+		KubernetesContext: " orbstack ",
+		ContainerRegistry: " erunpaas ",
+		NoGit:             true,
+		SetDefaultTenant:  true,
+	})
+	want := []string{"init", "erun", "remote", "--remote", "--version", "1.0.19", "--runtime-image", "erun-devops", "--kubernetes-context", "orbstack", "--container-registry", "erunpaas", "--set-default-tenant=true", "--confirm-environment=true", "--no-git"}
 	if len(got) != len(want) {
 		t.Fatalf("unexpected args length: got %+v want %+v", got, want)
 	}
@@ -469,7 +579,15 @@ func TestStartInitSessionStartsRemoteInitCommand(t *testing.T) {
 	})
 	defer app.shutdown(context.Background())
 
-	result, err := app.StartInitSession(uiSelection{Tenant: " erun ", Environment: " remote ", Version: " 1.0.19 ", NoGit: true}, 80, 24)
+	result, err := app.StartInitSession(uiSelection{
+		Tenant:            " erun ",
+		Environment:       " remote ",
+		Version:           " 1.0.19 ",
+		KubernetesContext: " orbstack ",
+		ContainerRegistry: " erunpaas ",
+		NoGit:             true,
+		SetDefaultTenant:  true,
+	}, 80, 24)
 	if err != nil {
 		t.Fatalf("StartInitSession failed: %v", err)
 	}
@@ -483,7 +601,7 @@ func TestStartInitSessionStartsRemoteInitCommand(t *testing.T) {
 	if started.Executable != "/tmp/erun" {
 		t.Fatalf("unexpected executable: %q", started.Executable)
 	}
-	wantArgs := []string{"init", "erun", "remote", "--remote", "--version", "1.0.19", "--no-git"}
+	wantArgs := []string{"init", "erun", "remote", "--remote", "--version", "1.0.19", "--kubernetes-context", "orbstack", "--container-registry", "erunpaas", "--set-default-tenant=true", "--confirm-environment=true", "--no-git"}
 	if strings.Join(started.Args, "\n") != strings.Join(wantArgs, "\n") {
 		t.Fatalf("unexpected args: got %+v want %+v", started.Args, wantArgs)
 	}
@@ -859,6 +977,9 @@ func TestLoadAndSaveEnvironmentConfig(t *testing.T) {
 	if loaded.Name != "prod" || loaded.RepoPath != projectRoot || loaded.KubernetesContext != "cluster-old" {
 		t.Fatalf("unexpected loaded config: %+v", loaded)
 	}
+	if loaded.LocalPorts.RangeStart != 17000 || loaded.LocalPorts.RangeEnd != 17099 || loaded.LocalPorts.MCP != 17000 || loaded.LocalPorts.SSH != 60022 {
+		t.Fatalf("unexpected loaded local ports: %+v", loaded.LocalPorts)
+	}
 
 	saved, err := app.SaveEnvironmentConfig(uiSelection{Tenant: "frs", Environment: "prod"}, uiEnvironmentConfig{
 		Name:              "prod",
@@ -880,9 +1001,33 @@ func TestLoadAndSaveEnvironmentConfig(t *testing.T) {
 	if saved.RepoPath != projectRoot || saved.KubernetesContext != "cluster-old" || saved.ContainerRegistry != "registry.example/old" || saved.RuntimeVersion != "1.0.0" {
 		t.Fatalf("unexpected saved config: %+v", saved)
 	}
+	if saved.LocalPorts.RangeStart != 17000 || saved.LocalPorts.RangeEnd != 17099 || saved.LocalPorts.MCP != 17000 || saved.LocalPorts.SSH != 60022 {
+		t.Fatalf("unexpected saved local ports: %+v", saved.LocalPorts)
+	}
 	stored := store.envs["frs/prod"]
 	if stored.RepoPath != projectRoot || stored.Remote || stored.RuntimeVersion != "1.0.0" || stored.SSHD.Enabled || stored.SSHD.LocalPort != 60022 || stored.SSHD.PublicKeyPath != "/tmp/old.pub" || stored.Snapshot == nil || *stored.Snapshot {
 		t.Fatalf("unexpected stored config: %+v", stored)
+	}
+}
+
+func TestLocalPortStatusReportsAvailability(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on ephemeral port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	connectable := localPortStatus(port)
+	if !connectable.Available || connectable.Status != "Yes" {
+		t.Fatalf("expected connectable status, got %+v", connectable)
+	}
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	unreachable := localPortStatus(port)
+	if unreachable.Available || unreachable.Status != "No" {
+		t.Fatalf("expected unreachable status, got %+v", unreachable)
 	}
 }
 

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -7,6 +7,7 @@ import {
   LoadDiff,
   LoadEnvironmentConfig,
   LoadERunConfig,
+  LoadKubernetesContexts,
   LoadState,
   LoadTenantConfig,
   LoadVersionSuggestions,
@@ -35,6 +36,7 @@ import {
   MIN_SIDEBAR_WIDTH,
   REVIEW_WIDTH_STORAGE_KEY,
   SIDEBAR_WIDTH_STORAGE_KEY,
+  defaultEnvironmentConfig,
   defaultEnvironmentDialog,
   defaultGlobalConfigDialog,
   defaultManageDialog,
@@ -375,13 +377,19 @@ export class ERunUIController {
       tenant: tenantDefault,
       environment: '',
       version: this.state.versionSuggestions[0]?.version || '',
+      kubernetesContext: '',
+      kubernetesContexts: [],
+      kubernetesContextsLoading: true,
+      containerRegistry: 'erunpaas',
       noGit: false,
+      setDefaultTenant: true,
       versionImage: this.state.versionSuggestions[0]?.image || '',
       choicesOpen: false,
       busy: false,
       error: '',
     };
     this.emit();
+    void this.refreshKubernetesContexts();
     void this.refreshDialogVersionSuggestions(true);
   }
 
@@ -449,8 +457,11 @@ export class ERunUIController {
     const tenant = normalizeDialogValue(dialog.tenant);
     const environment = normalizeDialogValue(dialog.environment);
     const version = normalizeDialogValue(dialog.version);
+    const kubernetesContext = normalizeDialogValue(dialog.kubernetesContext);
+    const containerRegistry = normalizeDialogValue(dialog.containerRegistry);
+    const isInit = dialog.actionMode === 'init';
 
-    if (!tenant || !environment || (dialog.actionMode === 'deploy' && !version)) {
+    if (!tenant || !environment || (dialog.actionMode === 'deploy' && !version) || (isInit && (!kubernetesContext || !containerRegistry))) {
       this.state.environmentDialog = { ...dialog, error: '' };
       this.emit();
       form.reportValidity();
@@ -462,7 +473,10 @@ export class ERunUIController {
       environment,
       version,
       runtimeImage: this.resolveEnvironmentRuntimeImage(version),
+      kubernetesContext: isInit ? kubernetesContext : undefined,
+      containerRegistry: isInit ? containerRegistry : undefined,
       noGit: dialog.noGit,
+      setDefaultTenant: isInit ? dialog.setDefaultTenant : undefined,
     };
 
     this.state.environmentDialog = {
@@ -470,6 +484,8 @@ export class ERunUIController {
       tenant,
       environment,
       version,
+      kubernetesContext,
+      containerRegistry,
       busy: true,
       error: '',
       choicesOpen: false,
@@ -506,14 +522,8 @@ export class ERunUIController {
       version: '',
       versionImage: '',
       config: {
+        ...defaultEnvironmentConfig(),
         name: selection.environment,
-        repoPath: '',
-        kubernetesContext: '',
-        containerRegistry: '',
-        runtimeVersion: '',
-        sshd: { enabled: false, localPort: 0, publicKeyPath: '' },
-        remote: false,
-        snapshot: true,
       },
       configLoading: true,
       confirmation: '',
@@ -673,7 +683,7 @@ export class ERunUIController {
     this.state.manageDialog = { ...dialog, busy: true, error: '' };
     this.emit();
     try {
-      const result = (await SaveEnvironmentConfig(selection, dialog.config)) as UIEnvironmentConfig;
+      const result = (await SaveEnvironmentConfig(selection, dialog.config as Parameters<typeof SaveEnvironmentConfig>[1])) as UIEnvironmentConfig;
       this.state.manageDialog = {
         ...this.state.manageDialog,
         config: result,
@@ -1071,6 +1081,7 @@ export class ERunUIController {
       this.state.tenants = loaded.tenants || [];
       this.state.selected = loaded.selected || null;
       this.state.versionSuggestions = normalizeVersionSuggestions(loaded.versionSuggestions || []);
+      this.selectLoadedKubernetesContexts(loaded.kubernetesContexts || []);
       this.emit();
 
       if (loaded.message) {
@@ -1132,9 +1143,59 @@ export class ERunUIController {
       const loaded = (await LoadState()) as UIState;
       this.state.tenants = loaded.tenants || [];
       this.state.versionSuggestions = normalizeVersionSuggestions(loaded.versionSuggestions || this.state.versionSuggestions);
+      this.selectLoadedKubernetesContexts(loaded.kubernetesContexts || []);
       this.emit();
     } catch {
     }
+  }
+
+  private async refreshKubernetesContexts(): Promise<void> {
+    try {
+      const contexts = ((await LoadKubernetesContexts()) as string[]).map((context) => context.trim()).filter(Boolean);
+      if (!this.state.environmentDialog.open || this.state.environmentDialog.actionMode !== 'init') {
+        return;
+      }
+      this.state.environmentDialog = {
+        ...this.state.environmentDialog,
+        kubernetesContexts: contexts,
+        kubernetesContext: this.resolveDialogKubernetesContext(contexts),
+        kubernetesContextsLoading: false,
+      };
+      this.emit();
+    } catch (error) {
+      if (!this.state.environmentDialog.open || this.state.environmentDialog.actionMode !== 'init') {
+        return;
+      }
+      this.state.environmentDialog = {
+        ...this.state.environmentDialog,
+        kubernetesContexts: [],
+        kubernetesContext: '',
+        kubernetesContextsLoading: false,
+        error: readError(error),
+      };
+      this.emit();
+    }
+  }
+
+  private resolveDialogKubernetesContext(contexts: string[]): string {
+    const current = normalizeDialogValue(this.state.environmentDialog.kubernetesContext);
+    if (current && contexts.includes(current)) {
+      return current;
+    }
+    return contexts[0] || '';
+  }
+
+  private selectLoadedKubernetesContexts(contexts: string[]): void {
+    if (!this.state.environmentDialog.open || this.state.environmentDialog.actionMode !== 'init') {
+      return;
+    }
+    const normalized = contexts.map((context) => context.trim()).filter(Boolean);
+    this.state.environmentDialog = {
+      ...this.state.environmentDialog,
+      kubernetesContexts: normalized,
+      kubernetesContext: this.resolveDialogKubernetesContext(normalized),
+      kubernetesContextsLoading: false,
+    };
   }
 
   private scheduleDialogVersionSuggestionRefresh(selectDefault: boolean): void {
@@ -1257,9 +1318,10 @@ export class ERunUIController {
     if (payload.sessionId !== this.state.sessionId) {
       return;
     }
-    if ((initSelection || deploySelection) && !payload.reason) {
+    const completedSelection = initSelection || deploySelection;
+    if (completedSelection && !payload.reason) {
       try {
-        await this.openSelection(initSelection || deploySelection);
+        await this.openSelection(completedSelection);
       } catch (error) {
         this.showTerminalMessage(readError(error));
       }

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -30,7 +30,12 @@ export interface EnvironmentDialogState {
   tenant: string;
   environment: string;
   version: string;
+  kubernetesContext: string;
+  kubernetesContexts: string[];
+  kubernetesContextsLoading: boolean;
+  containerRegistry: string;
   noGit: boolean;
+  setDefaultTenant: boolean;
   versionImage: string;
   choicesOpen: boolean;
   busy: boolean;
@@ -101,7 +106,12 @@ export const defaultEnvironmentDialog = (): EnvironmentDialogState => ({
   tenant: '',
   environment: '',
   version: '',
+  kubernetesContext: '',
+  kubernetesContexts: [],
+  kubernetesContextsLoading: false,
+  containerRegistry: 'erunpaas',
   noGit: false,
+  setDefaultTenant: true,
   versionImage: '',
   choicesOpen: false,
   busy: false,
@@ -158,6 +168,20 @@ export const defaultEnvironmentConfig = (): UIEnvironmentConfig => ({
     enabled: false,
     localPort: 0,
     publicKeyPath: '',
+  },
+  localPorts: {
+    rangeStart: 0,
+    rangeEnd: 0,
+    mcp: 0,
+    ssh: 0,
+    mcpStatus: {
+      available: false,
+      status: '',
+    },
+    sshStatus: {
+      available: false,
+      status: '',
+    },
   },
   remote: false,
   snapshot: true,

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -22,6 +22,7 @@ export function EnvironmentDialogView({ controller, state }: { controller: ERunU
   const isDeploy = dialog.actionMode === 'deploy';
   const submitLabel = isDeploy ? 'Deploy' : 'Create';
   const busyLabel = isDeploy ? 'Deploying...' : 'Creating...';
+  const createDisabled = dialog.busy || (!isDeploy && (dialog.kubernetesContextsLoading || dialog.kubernetesContexts.length === 0));
 
   React.useEffect(() => {
     if (!dialog.open) {
@@ -101,17 +102,70 @@ export function EnvironmentDialogView({ controller, state }: { controller: ERunU
             onChoicesOpenChange={(open) => controller.setEnvironmentVersionChoicesOpen(open)}
             onSelect={(suggestion) => controller.selectEnvironmentVersionSuggestion(suggestion)}
           />
-          <div className="flex items-center gap-2">
-            <Checkbox
-              id="environment-no-git"
-              checked={dialog.noGit}
-              disabled={dialog.busy}
-              onCheckedChange={(checked) => controller.updateEnvironmentDialog({ noGit: checked === true })}
-            />
-            <Label htmlFor="environment-no-git" className="text-sm font-normal">
-              Initialize without Git checkout
-            </Label>
-          </div>
+          {!isDeploy && (
+            <>
+              <div className="grid gap-2">
+                <Label htmlFor="environment-kubernetes-context">Kubernetes context</Label>
+                <select
+                  id="environment-kubernetes-context"
+                  className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-[var(--radius)] border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  value={dialog.kubernetesContext}
+                  required
+                  disabled={dialog.busy || dialog.kubernetesContextsLoading || dialog.kubernetesContexts.length === 0}
+                  onChange={(event) => controller.updateEnvironmentDialog({ kubernetesContext: event.target.value })}
+                >
+                  {dialog.kubernetesContextsLoading ? (
+                    <option value="">Loading contexts...</option>
+                  ) : dialog.kubernetesContexts.length === 0 ? (
+                    <option value="">No Kubernetes contexts</option>
+                  ) : (
+                    dialog.kubernetesContexts.map((context) => (
+                      <option key={context} value={context}>
+                        {context}
+                      </option>
+                    ))
+                  )}
+                </select>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="environment-container-registry">Container registry</Label>
+                <Input
+                  id="environment-container-registry"
+                  value={dialog.containerRegistry}
+                  type="text"
+                  autoComplete="off"
+                  spellCheck={false}
+                  required
+                  disabled={dialog.busy}
+                  onChange={(event) => controller.updateEnvironmentDialog({ containerRegistry: event.target.value })}
+                />
+              </div>
+              <div className="grid gap-2">
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="environment-default-tenant"
+                    checked={dialog.setDefaultTenant}
+                    disabled={dialog.busy}
+                    onCheckedChange={(checked) => controller.updateEnvironmentDialog({ setDefaultTenant: checked === true })}
+                  />
+                  <Label htmlFor="environment-default-tenant" className="text-sm font-normal">
+                    Set as default tenant
+                  </Label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="environment-no-git"
+                    checked={dialog.noGit}
+                    disabled={dialog.busy}
+                    onCheckedChange={(checked) => controller.updateEnvironmentDialog({ noGit: checked === true })}
+                  />
+                  <Label htmlFor="environment-no-git" className="text-sm font-normal">
+                    Initialize without Git checkout
+                  </Label>
+                </div>
+              </div>
+            </>
+          )}
           {dialog.error && (
             <div className={dialogErrorClassName} role="alert">
               {dialog.error}
@@ -121,7 +175,7 @@ export function EnvironmentDialogView({ controller, state }: { controller: ERunU
             <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => controller.closeEnvironmentDialog()}>
               Cancel
             </Button>
-            <Button type="submit" size="sm" disabled={dialog.busy}>
+            <Button type="submit" size="sm" disabled={createDisabled}>
               {dialog.busy ? (
                 <LoaderCircle className="animate-spin" aria-hidden="true" />
               ) : isDeploy ? (

--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -12,7 +12,7 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import type { UIVersionSuggestion } from '@/types';
+import type { UIPortStatus, UIVersionSuggestion } from '@/types';
 import { cn } from '@/lib/utils';
 
 const dialogErrorClassName =
@@ -80,18 +80,22 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
                 />
                 <CheckboxField id="environment-config-remote" label="remote" checked={config.remote} disabled onChange={() => {}} />
                 <CheckboxField id="environment-config-snapshot" label="snapshot" checked={config.snapshot} disabled={dialog.busy} onChange={(snapshot) => controller.updateManageConfig({ snapshot })} />
+                <ReadonlyField id="environment-config-localportrange" label="assigned local port range" value={portRangeValue(config.localPorts.rangeStart, config.localPorts.rangeEnd)} />
+                <PortStatusTable
+                  rows={[
+                    { service: 'mcp', port: config.localPorts.mcp, status: config.localPorts.mcpStatus },
+                    { service: 'ssh', port: config.localPorts.ssh, status: config.localPorts.sshStatus },
+                  ]}
+                />
                 <div className="grid gap-3 rounded-[var(--radius)] border border-border p-3">
                   <div className="text-xs leading-[1.2] font-semibold tracking-normal text-muted-foreground uppercase">sshd</div>
                   <CheckboxField id="environment-config-sshd-enabled" label="enabled" checked={config.sshd.enabled} disabled onChange={() => {}} />
-                  <TextField
+                  <ReadonlyField
                     id="environment-config-sshd-localport"
                     label="localport"
                     value={config.sshd.localPort > 0 ? String(config.sshd.localPort) : ''}
-                    disabled
-                    inputMode="numeric"
-                    onChange={() => {}}
                   />
-                  <TextField id="environment-config-sshd-publickeypath" label="publickeypath" value={config.sshd.publicKeyPath} disabled onChange={() => {}} />
+                  <ReadonlyField id="environment-config-sshd-publickeypath" label="publickeypath" value={config.sshd.publicKeyPath} />
                 </div>
                 {confirmingDelete && (
                   <div className="grid gap-3">
@@ -245,7 +249,57 @@ function TextField({ id, label, value, disabled, inputMode, inputRef, onChange }
 }
 
 function ReadonlyField({ id, label, value }: { id: string; label: string; value: string }): React.ReactElement {
-  return <TextField id={id} label={label} value={value} disabled onChange={() => {}} />;
+  return (
+    <div className="grid gap-2">
+      <div id={id} className="text-sm font-medium leading-none">
+        {label}
+      </div>
+      <div
+        className="min-h-9 rounded-[var(--radius)] border border-border bg-muted/35 px-3 py-2 text-sm leading-[1.35] text-muted-foreground [overflow-wrap:anywhere]"
+        aria-labelledby={id}
+      >
+        {value || 'none'}
+      </div>
+    </div>
+  );
+}
+
+function PortStatusTable({ rows }: { rows: { service: string; port: number; status: UIPortStatus }[] }): React.ReactElement {
+  return (
+    <div className="grid gap-2">
+      <div className="text-sm font-medium leading-none">ports</div>
+      <div className="overflow-hidden rounded-[var(--radius)] border border-border bg-muted/35 text-xs leading-[1.3]">
+        <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-3 border-b border-border px-3 py-2 text-[11px] font-semibold uppercase leading-[1.2] text-muted-foreground">
+          <div>port</div>
+          <div>service</div>
+          <div>available</div>
+        </div>
+        {rows.map((row) => (
+          <div key={row.service} className="grid min-h-8 grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] items-center gap-3 border-b border-border px-3 py-1 last:border-b-0">
+            <div className="font-mono text-xs text-foreground">{row.port > 0 ? row.port : 'none'}</div>
+            <div className="text-foreground">{row.service}</div>
+            <AvailabilityDot status={row.status} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AvailabilityDot({ status }: { status: UIPortStatus }): React.ReactElement {
+  const label = status.available ? 'available' : 'unavailable';
+  return (
+    <span className="inline-flex justify-end" aria-label={label} title={label}>
+      <span className={cn('size-2.5 rounded-full', status.available ? 'bg-green-600' : 'bg-destructive')} aria-hidden="true" />
+    </span>
+  );
+}
+
+function portRangeValue(rangeStart: number, rangeEnd: number): string {
+  if (rangeStart <= 0 || rangeEnd <= 0) {
+    return '';
+  }
+  return `${rangeStart}-${rangeEnd}`;
 }
 
 function CheckboxField({ id, label, checked, disabled, onChange }: { id: string; label: string; checked: boolean; disabled?: boolean; onChange: (checked: boolean) => void }): React.ReactElement {

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -17,7 +17,10 @@ export interface UISelection {
   environment: string;
   version?: string;
   runtimeImage?: string;
+  kubernetesContext?: string;
+  containerRegistry?: string;
   noGit?: boolean;
+  setDefaultTenant?: boolean;
   action?: EnvironmentActionMode;
 }
 
@@ -33,6 +36,7 @@ export interface UIState {
   message?: string;
   build?: UIBuildDetails;
   versionSuggestions?: UIVersionSuggestion[];
+  kubernetesContexts?: string[];
 }
 
 export interface UIVersionSuggestion {
@@ -57,6 +61,20 @@ export interface UISSHDConfig {
   publicKeyPath: string;
 }
 
+export interface UIEnvironmentLocalPorts {
+  rangeStart: number;
+  rangeEnd: number;
+  mcp: number;
+  ssh: number;
+  mcpStatus: UIPortStatus;
+  sshStatus: UIPortStatus;
+}
+
+export interface UIPortStatus {
+  available: boolean;
+  status: string;
+}
+
 export interface UIEnvironmentConfig {
   name: string;
   repoPath: string;
@@ -64,6 +82,7 @@ export interface UIEnvironmentConfig {
   containerRegistry: string;
   runtimeVersion: string;
   sshd: UISSHDConfig;
+  localPorts: UIEnvironmentLocalPorts;
   remote: boolean;
   snapshot: boolean;
 }

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -76,15 +78,44 @@ func buildOpenArgs(tenant, environment string) []string {
 	return []string{"open", strings.TrimSpace(tenant), strings.TrimSpace(environment)}
 }
 
-func buildInitArgs(tenant, environment, version, runtimeImage string, noGit bool) []string {
-	args := []string{"init", strings.TrimSpace(tenant), strings.TrimSpace(environment), "--remote"}
-	if version = strings.TrimSpace(version); version != "" {
+func buildOpenNoShellArgs(tenant, environment string) []string {
+	return []string{"open", strings.TrimSpace(tenant), strings.TrimSpace(environment), "--no-shell", "--no-alias-prompt"}
+}
+
+func ensureMCPViaOpenCommand(ctx context.Context, cliPath string, result eruncommon.OpenResult) error {
+	args := buildOpenNoShellArgs(result.Tenant, result.Environment)
+	cmd := exec.CommandContext(ctx, cliPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	detail := strings.TrimSpace(string(output))
+	if detail == "" {
+		return fmt.Errorf("activate MCP port-forward: %w", err)
+	}
+	return fmt.Errorf("activate MCP port-forward: %w: %s", err, detail)
+}
+
+func buildInitArgs(selection uiSelection) []string {
+	args := []string{"init", strings.TrimSpace(selection.Tenant), strings.TrimSpace(selection.Environment), "--remote"}
+	if version := strings.TrimSpace(selection.Version); version != "" {
 		args = append(args, "--version", version)
 	}
-	if runtimeImage = strings.TrimSpace(runtimeImage); runtimeImage != "" {
+	if runtimeImage := strings.TrimSpace(selection.RuntimeImage); runtimeImage != "" {
 		args = append(args, "--runtime-image", runtimeImage)
 	}
-	if noGit {
+	if kubernetesContext := strings.TrimSpace(selection.KubernetesContext); kubernetesContext != "" {
+		args = append(args, "--kubernetes-context", kubernetesContext)
+	}
+	if containerRegistry := strings.TrimSpace(selection.ContainerRegistry); containerRegistry != "" {
+		args = append(args, "--container-registry", containerRegistry)
+	}
+	args = append(
+		args,
+		"--set-default-tenant="+boolArg(selection.SetDefaultTenant),
+		"--confirm-environment=true",
+	)
+	if selection.NoGit {
 		args = append(args, "--no-git")
 	}
 	return args
@@ -143,4 +174,11 @@ func shellQuote(value string) string {
 
 func powerShellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+func boolArg(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
 }


### PR DESCRIPTION
## Summary
- assign and display per-environment local port ranges in the desktop UI
- deploy remote runtimes with MCP/SSH ports matching the assigned local ports
- make desktop init pass explicit non-interactive defaults and Kubernetes context selection
- repair stale MCP port-forwards and retry UI diff loading when the MCP endpoint is unreachable

## Root cause
New remote environments could be deployed with default runtime ports while the desktop UI and MCP client used the allocated local port range. Existing port-forward readiness also accepted a bare TCP connection, so stale or broken forwards could still leave MCP calls failing with EOF.

## Validation
- go test ./... in erun-common
- go test ./... in erun-cli
- go test ./... in erun-mcp
- go test ./... in erun-ui
- yarn tsc --noEmit
- yarn build
- git diff --check
- live check: erun open erun test --no-shell --no-alias-prompt and curl http://127.0.0.1:17200/mcp returned the MCP HTTP response

Closes #148