### PR TITLE
Add managed cloud k3s contexts

### DIFF
--- a/erun-cli/cmd/cloud.go
+++ b/erun-cli/cmd/cloud.go
@@ -1,0 +1,241 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+	common "github.com/sophium/erun/erun-common"
+	"github.com/spf13/cobra"
+)
+
+func newCloudCmd(store common.CloudStore, promptRunner PromptRunner, selectRunner SelectRunner, deps common.CloudDependencies) *cobra.Command {
+	return newCommandGroup(
+		"cloud",
+		"Cloud provider utilities",
+		newCloudInitCmd(store, promptRunner, deps),
+		newCloudLoginCmd(store, promptRunner, selectRunner, deps),
+	)
+}
+
+func newCloudInitCmd(store common.CloudStore, promptRunner PromptRunner, deps common.CloudDependencies) *cobra.Command {
+	return newCommandGroup(
+		"init",
+		"Initialize cloud provider configuration",
+		newCloudInitAWSCmd(store, promptRunner, deps),
+	)
+}
+
+func newCloudInitAWSCmd(store common.CloudStore, promptRunner PromptRunner, deps common.CloudDependencies) *cobra.Command {
+	var params common.InitAWSCloudProviderParams
+	cmd := &cobra.Command{
+		Use:          "aws",
+		Short:        "Initialize an AWS SSO cloud provider alias",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCloudInitAWSCommand(commandContext(cmd), store, promptRunner, params, deps)
+		},
+	}
+	cmd.Flags().StringVar(&params.SSOStartURL, "sso-start-url", "", "AWS IAM Identity Center start URL")
+	cmd.Flags().StringVar(&params.SSORegion, "sso-region", "", "AWS IAM Identity Center region")
+	cmd.Flags().StringVar(&params.AccountID, "account-id", "", "AWS account ID to use for SSO login")
+	cmd.Flags().StringVar(&params.RoleName, "role-name", "", "AWS role name to use for SSO login")
+	cmd.Flags().StringVar(&params.Region, "region", "", "Default AWS region for the generated configuration")
+	addDryRunFlag(cmd)
+	return cmd
+}
+
+func runCloudInitAWSCommand(ctx common.Context, store common.CloudStore, promptRunner PromptRunner, params common.InitAWSCloudProviderParams, deps common.CloudDependencies) error {
+	var err error
+	params, err = promptAWSInitParams(promptRunner, params)
+	if err != nil {
+		return err
+	}
+	if ctx.DryRun {
+		if strings.TrimSpace(params.Profile) == "" {
+			traceAWSConfigureSetPlan(ctx, params, "erun-sso-<timestamp>")
+		}
+		args := []string{"sso", "login"}
+		if strings.TrimSpace(params.Profile) != "" {
+			args = append(args, "--profile", strings.TrimSpace(params.Profile))
+		} else {
+			args = append(args, "--profile", "erun-sso-<timestamp>")
+		}
+		if !params.SkipLogin {
+			ctx.TraceCommand("", "aws", args...)
+		}
+		identityArgs := []string{"sts", "get-caller-identity", "--output", "json"}
+		if strings.TrimSpace(params.Profile) != "" {
+			identityArgs = append(identityArgs, "--profile", strings.TrimSpace(params.Profile))
+		} else {
+			identityArgs = append(identityArgs, "--profile", "erun-sso-<timestamp>")
+		}
+		ctx.TraceCommand("", "aws", identityArgs...)
+		ctx.Trace("write erun root cloud provider alias")
+		_, err := fmt.Fprintln(ctx.Stdout, "Dry run: AWS cloud provider initialization planned.")
+		return err
+	}
+	provider, err := common.InitAWSCloudProvider(ctx, store, params, deps)
+	if err != nil {
+		return err
+	}
+	return writeCloudProviderSaved(ctx, provider)
+}
+
+func promptAWSInitParams(promptRunner PromptRunner, params common.InitAWSCloudProviderParams) (common.InitAWSCloudProviderParams, error) {
+	if strings.TrimSpace(params.Profile) != "" {
+		return params, nil
+	}
+	var err error
+	if strings.TrimSpace(params.SSOStartURL) == "" {
+		params.SSOStartURL, err = requiredCloudPrompt(promptRunner, "AWS SSO start URL", "")
+		if err != nil {
+			return params, err
+		}
+	}
+	if strings.TrimSpace(params.SSORegion) == "" {
+		params.SSORegion, err = requiredCloudPrompt(promptRunner, "AWS SSO region", "")
+		if err != nil {
+			return params, err
+		}
+	}
+	if strings.TrimSpace(params.AccountID) == "" {
+		params.AccountID, err = requiredCloudPrompt(promptRunner, "AWS account ID", "")
+		if err != nil {
+			return params, err
+		}
+	}
+	if strings.TrimSpace(params.RoleName) == "" {
+		params.RoleName, err = requiredCloudPrompt(promptRunner, "AWS role name", "")
+		if err != nil {
+			return params, err
+		}
+	}
+	if strings.TrimSpace(params.Region) == "" {
+		params.Region, err = requiredCloudPrompt(promptRunner, "Default AWS region", strings.TrimSpace(params.SSORegion))
+		if err != nil {
+			return params, err
+		}
+	}
+	return params, nil
+}
+
+func requiredCloudPrompt(promptRunner PromptRunner, label, defaultValue string) (string, error) {
+	prompt := promptui.Prompt{
+		Label:   label,
+		Default: defaultValue,
+		Validate: func(input string) error {
+			if strings.TrimSpace(input) == "" {
+				return fmt.Errorf("%s is required", label)
+			}
+			return nil
+		},
+	}
+	value, err := promptRunner(prompt)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(value), nil
+}
+
+func traceAWSConfigureSetPlan(ctx common.Context, params common.InitAWSCloudProviderParams, profile string) {
+	region := strings.TrimSpace(params.Region)
+	if region == "" {
+		region = strings.TrimSpace(params.SSORegion)
+	}
+	settings := []struct {
+		key   string
+		value string
+	}{
+		{key: "sso_start_url", value: strings.TrimSpace(params.SSOStartURL)},
+		{key: "sso_region", value: strings.TrimSpace(params.SSORegion)},
+		{key: "sso_account_id", value: strings.TrimSpace(params.AccountID)},
+		{key: "sso_role_name", value: strings.TrimSpace(params.RoleName)},
+		{key: "region", value: region},
+		{key: "output", value: "json"},
+	}
+	for _, setting := range settings {
+		ctx.TraceCommand("", "aws", "configure", "set", setting.key, setting.value, "--profile", profile)
+	}
+}
+
+func newCloudLoginCmd(store common.CloudStore, promptRunner PromptRunner, selectRunner SelectRunner, deps common.CloudDependencies) *cobra.Command {
+	var alias string
+	cmd := &cobra.Command{
+		Use:          "login",
+		Short:        "Login to a configured cloud provider alias",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCloudLoginCommand(commandContext(cmd), store, promptRunner, selectRunner, common.CloudLoginParams{Alias: alias}, deps)
+		},
+	}
+	cmd.Flags().StringVar(&alias, "alias", "", "Cloud provider alias to login")
+	addDryRunFlag(cmd)
+	return cmd
+}
+
+func runCloudLoginCommand(ctx common.Context, store common.CloudStore, promptRunner PromptRunner, selectRunner SelectRunner, params common.CloudLoginParams, deps common.CloudDependencies) error {
+	alias := strings.TrimSpace(params.Alias)
+	if alias == "" {
+		selected, err := selectCloudAliasPrompt(store, selectRunner)
+		if err != nil {
+			return err
+		}
+		alias = selected
+	}
+	provider, err := common.ResolveCloudProvider(store, alias)
+	if err != nil {
+		return err
+	}
+	status := common.CloudProviderTokenStatus(provider, deps)
+	if status.Status == common.CloudTokenStatusActive {
+		return writeCloudStatus(ctx, status)
+	}
+	login, err := confirmPrompt(promptRunner, fmt.Sprintf("Login to %s", provider.Alias))
+	if err != nil {
+		return err
+	}
+	if !login {
+		return writeCloudStatus(ctx, status)
+	}
+	status, err = common.LoginCloudProviderAlias(ctx, store, common.CloudLoginParams{Alias: alias, Force: true}, deps)
+	if err != nil {
+		return err
+	}
+	return writeCloudStatus(ctx, status)
+}
+
+func selectCloudAliasPrompt(store common.CloudStore, selectRunner SelectRunner) (string, error) {
+	providers, err := common.ListCloudProviders(store)
+	if err != nil {
+		return "", err
+	}
+	if len(providers) == 0 {
+		return "", fmt.Errorf("no cloud provider aliases are configured")
+	}
+	items := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		items = append(items, provider.Alias)
+	}
+	_, alias, err := selectRunner(promptui.Select{
+		Label: "Cloud provider",
+		Items: items,
+	})
+	return alias, err
+}
+
+func writeCloudProviderSaved(ctx common.Context, provider common.CloudProviderConfig) error {
+	_, err := fmt.Fprintf(ctx.Stdout, "Saved cloud provider alias %s\n", provider.Alias)
+	return err
+}
+
+func writeCloudStatus(ctx common.Context, status common.CloudProviderStatus) error {
+	line := fmt.Sprintf("%s: %s", status.Alias, status.Status)
+	if strings.TrimSpace(status.Message) != "" {
+		line += " (" + strings.TrimSpace(status.Message) + ")"
+	}
+	_, err := fmt.Fprintln(ctx.Stdout, line)
+	return err
+}

--- a/erun-cli/cmd/cloud_test.go
+++ b/erun-cli/cmd/cloud_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/manifoldco/promptui"
+	common "github.com/sophium/erun/erun-common"
+)
+
+type cloudCommandStore struct {
+	config common.ERunConfig
+}
+
+func (s *cloudCommandStore) LoadERunConfig() (common.ERunConfig, string, error) {
+	return s.config, "", nil
+}
+
+func (s *cloudCommandStore) SaveERunConfig(config common.ERunConfig) error {
+	s.config = config
+	return nil
+}
+
+func TestRunCloudInitAWSCommandStoresAlias(t *testing.T) {
+	store := &cloudCommandStore{}
+	stdout := new(bytes.Buffer)
+	loginCalled := false
+	err := runCloudInitAWSCommand(common.Context{Stdout: stdout}, store, func(prompt promptui.Prompt) (string, error) {
+		return "y", nil
+	}, common.InitAWSCloudProviderParams{Profile: "dev"}, common.CloudDependencies{
+		RunAWSLogin: func(common.Context, string) error {
+			loginCalled = true
+			return nil
+		},
+		ResolveAWSIdentity: func(common.Context, string) (common.AWSIdentity, error) {
+			return common.AWSIdentity{Account: "123456789012", Arn: "arn:aws:iam::123456789012:user/rihards"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCloudInitAWSCommand failed: %v", err)
+	}
+	if !loginCalled {
+		t.Fatal("expected AWS login to run")
+	}
+	if len(store.config.CloudProviders) != 1 || store.config.CloudProviders[0].Alias != "rihards+123456789012@aws" {
+		t.Fatalf("unexpected stored config: %+v", store.config)
+	}
+	if got := stdout.String(); got != "Saved cloud provider alias rihards+123456789012@aws\n" {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+}
+
+func TestRunCloudInitAWSCommandCreatesProfileWithoutPromptingForAlias(t *testing.T) {
+	store := &cloudCommandStore{}
+	stdout := new(bytes.Buffer)
+	var configuredProfile string
+	prompts := map[string]string{
+		"AWS SSO start URL":  "https://example.awsapps.com/start",
+		"AWS SSO region":     "eu-west-1",
+		"AWS account ID":     "123456789012",
+		"AWS role name":      "Admin",
+		"Default AWS region": "eu-west-1",
+	}
+	err := runCloudInitAWSCommand(common.Context{Stdout: stdout}, store, func(prompt promptui.Prompt) (string, error) {
+		return prompts[fmt.Sprint(prompt.Label)], nil
+	}, common.InitAWSCloudProviderParams{}, common.CloudDependencies{
+		RunAWSConfigureSSO: func(_ common.Context, config common.AWSProfileConfig) error {
+			configuredProfile = config.Profile
+			if config.SSOStartURL != "https://example.awsapps.com/start" || config.SSORegion != "eu-west-1" || config.AccountID != "123456789012" || config.RoleName != "Admin" || config.Region != "eu-west-1" {
+				t.Fatalf("unexpected AWS profile config: %+v", config)
+			}
+			return nil
+		},
+		RunAWSLogin: func(common.Context, string) error {
+			return nil
+		},
+		ResolveAWSIdentity: func(common.Context, string) (common.AWSIdentity, error) {
+			return common.AWSIdentity{Account: "123456789012", Arn: "arn:aws:iam::123456789012:user/rihards"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCloudInitAWSCommand failed: %v", err)
+	}
+	if configuredProfile == "" {
+		t.Fatal("expected command to create an AWS SSO profile")
+	}
+	if len(store.config.CloudProviders) != 1 || store.config.CloudProviders[0].Alias != "rihards+123456789012@aws" {
+		t.Fatalf("unexpected stored config: %+v", store.config)
+	}
+}
+
+func TestRunCloudLoginCommandPromptsWhenExpired(t *testing.T) {
+	store := &cloudCommandStore{config: common.ERunConfig{CloudProviders: []common.CloudProviderConfig{{
+		Alias:    "rihards+123456789012@aws",
+		Provider: common.CloudProviderAWS,
+		Profile:  "dev",
+	}}}}
+	stdout := new(bytes.Buffer)
+	loginCalled := false
+	checks := 0
+	err := runCloudLoginCommand(common.Context{Stdout: stdout}, store, func(promptui.Prompt) (string, error) {
+		return "y", nil
+	}, nil, common.CloudLoginParams{Alias: "rihards+123456789012@aws"}, common.CloudDependencies{
+		RunAWSLogin: func(common.Context, string) error {
+			loginCalled = true
+			return nil
+		},
+		CheckAWSStatus: func(_ common.Context, provider common.CloudProviderConfig) common.CloudProviderStatus {
+			checks++
+			if checks == 1 {
+				return common.CloudProviderStatus{CloudProviderConfig: provider, Status: common.CloudTokenStatusExpired}
+			}
+			return common.CloudProviderStatus{CloudProviderConfig: provider, Status: common.CloudTokenStatusActive}
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCloudLoginCommand failed: %v", err)
+	}
+	if !loginCalled {
+		t.Fatal("expected AWS login to run")
+	}
+	if got := stdout.String(); got != "rihards+123456789012@aws: active\n" {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+}

--- a/erun-cli/cmd/context.go
+++ b/erun-cli/cmd/context.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+	common "github.com/sophium/erun/erun-common"
+	"github.com/spf13/cobra"
+)
+
+func newContextCmd(store common.CloudContextStore, promptRunner PromptRunner, selectRunner SelectRunner, deps common.CloudContextDependencies) *cobra.Command {
+	return newCommandGroup(
+		"context",
+		"Manage ERun cloud Kubernetes contexts",
+		newContextListCmd(store),
+		newContextInitCmd(store, promptRunner, selectRunner, deps),
+		newContextStopCmd(store, deps),
+		newContextStartCmd(store, deps),
+	)
+}
+
+func newContextListCmd(store common.CloudContextStore) *cobra.Command {
+	return &cobra.Command{
+		Use:          "list",
+		Short:        "List managed ERun cloud contexts",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runContextListCommand(commandContext(cmd), store)
+		},
+	}
+}
+
+func runContextListCommand(ctx common.Context, store common.CloudContextStore) error {
+	contexts, err := common.ListCloudContextStatuses(store)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(ctx.Stdout, "Cloud Contexts:"); err != nil {
+		return err
+	}
+	if len(contexts) == 0 {
+		_, err := fmt.Fprintln(ctx.Stdout, "  none")
+		return err
+	}
+	for _, context := range contexts {
+		if err := writeCloudContext(ctx, context); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func newContextInitCmd(store common.CloudContextStore, promptRunner PromptRunner, selectRunner SelectRunner, deps common.CloudContextDependencies) *cobra.Command {
+	var params common.InitCloudContextParams
+	cmd := &cobra.Command{
+		Use:          "init",
+		Short:        "Initialize a managed cloud k3s context",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runContextInitCommand(commandContext(cmd), store, promptRunner, selectRunner, params, deps)
+		},
+	}
+	cmd.Flags().StringVar(&params.CloudProviderAlias, "alias", "", "Cloud provider alias to use")
+	cmd.Flags().StringVar(&params.Name, "context", "", "Kubernetes context name to create")
+	cmd.Flags().StringVar(&params.Region, "region", common.DefaultCloudContextRegion, "Cloud region for the context")
+	cmd.Flags().StringVar(&params.InstanceType, "instance-type", common.DefaultCloudContextInstanceType, "EC2 instance type")
+	cmd.Flags().IntVar(&params.DiskSizeGB, "disk-size", common.DefaultCloudContextDiskSizeGB, "Root disk size in GB")
+	cmd.Flags().StringVar(&params.DiskType, "disk-type", common.DefaultCloudContextDiskType, "Root disk type")
+	cmd.Flags().StringVar(&params.SubnetID, "subnet-id", "", "Optional EC2 subnet ID")
+	cmd.Flags().StringVar(&params.SecurityGroupID, "security-group-id", "", "Optional EC2 security group ID")
+	cmd.Flags().StringVar(&params.KeyName, "key-name", "", "Optional EC2 key pair name")
+	addDryRunFlag(cmd)
+	return cmd
+}
+
+func runContextInitCommand(ctx common.Context, store common.CloudContextStore, promptRunner PromptRunner, selectRunner SelectRunner, params common.InitCloudContextParams, deps common.CloudContextDependencies) error {
+	var err error
+	params.CloudProviderAlias, err = contextProviderAlias(store, selectRunner, params.CloudProviderAlias)
+	if err != nil {
+		return err
+	}
+	params, err = promptContextInitParams(promptRunner, selectRunner, params)
+	if err != nil {
+		return err
+	}
+	status, err := common.InitCloudContext(ctx, store, params, deps)
+	if err != nil {
+		return err
+	}
+	if ctx.DryRun {
+		_, err = fmt.Fprintln(ctx.Stdout, "Dry run: cloud context initialization planned.")
+		if err != nil {
+			return err
+		}
+	}
+	return writeCloudContext(ctx, status)
+}
+
+func newContextStopCmd(store common.CloudContextStore, deps common.CloudContextDependencies) *cobra.Command {
+	return newContextPowerCmd("stop", "Stop a managed ERun cloud context", store, deps, common.StopCloudContext)
+}
+
+func newContextStartCmd(store common.CloudContextStore, deps common.CloudContextDependencies) *cobra.Command {
+	return newContextPowerCmd("start", "Start a managed ERun cloud context", store, deps, common.StartCloudContext)
+}
+
+func newContextPowerCmd(use, short string, store common.CloudContextStore, deps common.CloudContextDependencies, run func(common.Context, common.CloudContextStore, common.CloudContextParams, common.CloudContextDependencies) (common.CloudContextStatus, error)) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          use + " CONTEXT",
+		Short:        short,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := commandContext(cmd)
+			status, err := run(ctx, store, common.CloudContextParams{Name: args[0]}, deps)
+			if err != nil {
+				return err
+			}
+			return writeCloudContext(ctx, status)
+		},
+	}
+	addDryRunFlag(cmd)
+	return cmd
+}
+
+func contextProviderAlias(store common.CloudContextStore, selectRunner SelectRunner, alias string) (string, error) {
+	alias = strings.TrimSpace(alias)
+	if alias != "" {
+		return alias, nil
+	}
+	return selectCloudAliasPrompt(store, selectRunner)
+}
+
+func promptContextInitParams(promptRunner PromptRunner, selectRunner SelectRunner, params common.InitCloudContextParams) (common.InitCloudContextParams, error) {
+	var err error
+	if strings.TrimSpace(params.Region) == "" {
+		params.Region, err = selectOrKeepString(selectRunner, "Cloud region", common.CloudContextRegions(), params.Region)
+		if err != nil {
+			return params, err
+		}
+	}
+	params.InstanceType, err = selectOrKeepString(selectRunner, "Instance type", common.CloudContextInstanceTypes(), params.InstanceType)
+	if err != nil {
+		return params, err
+	}
+	params.DiskSizeGB, err = selectOrKeepInt(selectRunner, "Disk size", common.CloudContextDiskSizesGB(), params.DiskSizeGB)
+	if err != nil {
+		return params, err
+	}
+	return params, nil
+}
+
+func selectOrKeepString(selectRunner SelectRunner, label string, options []string, current string) (string, error) {
+	current = strings.TrimSpace(current)
+	if current != "" {
+		return current, nil
+	}
+	_, value, err := selectRunner(promptui.Select{Label: label, Items: options})
+	return value, err
+}
+
+func selectOrKeepInt(selectRunner SelectRunner, label string, options []int, current int) (int, error) {
+	if current > 0 {
+		return current, nil
+	}
+	items := make([]string, 0, len(options))
+	for _, option := range options {
+		items = append(items, strconv.Itoa(option))
+	}
+	_, value, err := selectRunner(promptui.Select{Label: label, Items: items})
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(value)
+}
+
+func writeCloudContext(ctx common.Context, status common.CloudContextStatus) error {
+	context := status.CloudContextConfig
+	line := "  - " + context.Name
+	line += " provider=" + quotedValueOrNone(context.Provider)
+	line += " alias=" + quotedValueOrNone(context.CloudProviderAlias)
+	line += " region=" + quotedValueOrNone(context.Region)
+	line += " instance=" + quotedValueOrNone(context.InstanceID)
+	line += " type=" + quotedValueOrNone(context.InstanceType)
+	line += " disk=" + fmt.Sprintf("%dGB/%s", context.DiskSizeGB, context.DiskType)
+	line += " kube-context=" + quotedValueOrNone(context.KubernetesContext)
+	line += " status=" + quotedValueOrNone(context.Status)
+	if strings.TrimSpace(context.PublicIP) != "" {
+		line += " public-ip=" + quotedValueOrNone(context.PublicIP)
+	}
+	if strings.TrimSpace(status.Message) != "" {
+		line += " message=" + quotedValueOrNone(status.Message)
+	}
+	_, err := fmt.Fprintln(ctx.Stdout, line)
+	return err
+}

--- a/erun-cli/cmd/list.go
+++ b/erun-cli/cmd/list.go
@@ -67,6 +67,10 @@ func writeListResult(ctx common.Context, result common.ListResult) error {
 		return err
 	}
 
+	if err := writeCloudProviders(ctx, result.CloudProviders); err != nil {
+		return err
+	}
+
 	if _, err := fmt.Fprintln(ctx.Stdout, "Tenants:"); err != nil {
 		return err
 	}
@@ -95,6 +99,11 @@ func writeEffectiveOpen(ctx common.Context, current common.ListCurrentDirectoryR
 	}
 	if err := writeLabeledValue(ctx, "kubernetes context", current.Effective.KubernetesContext); err != nil {
 		return err
+	}
+	if strings.TrimSpace(current.Effective.CloudProviderAlias) != "" {
+		if err := writeLabeledValue(ctx, "cloud provider", current.Effective.CloudProviderAlias); err != nil {
+			return err
+		}
 	}
 	if err := writeLabeledValue(ctx, "snapshot", enabledDisabledLabel(current.Effective.Snapshot)); err != nil {
 		return err
@@ -164,6 +173,9 @@ func writeTenantEntry(ctx common.Context, tenant common.ListTenantResult) error 
 			envLine += " [" + strings.Join(envMarkers, ", ") + "]"
 		}
 		envLine += " context=" + quotedValueOrNone(env.KubernetesContext)
+		if strings.TrimSpace(env.CloudProviderAlias) != "" {
+			envLine += " cloud=" + quotedValueOrNone(env.CloudProviderAlias)
+		}
 		envLine += " snapshot=" + enabledDisabledLabel(env.Snapshot)
 		envLine += " repo=" + quotedValueOrNone(env.RepoPath)
 		envLine += " ports=" + portRangeLabel(env.LocalPorts)
@@ -177,6 +189,29 @@ func writeTenantEntry(ctx common.Context, tenant common.ListTenantResult) error 
 			envLine += " workspace=" + quotedValueOrNone(env.SSH.WorkspacePath)
 		}
 		if _, err := fmt.Fprintln(ctx.Stdout, envLine); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeCloudProviders(ctx common.Context, providers []common.CloudProviderStatus) error {
+	if _, err := fmt.Fprintln(ctx.Stdout, "Cloud Providers:"); err != nil {
+		return err
+	}
+	if len(providers) == 0 {
+		_, err := fmt.Fprintln(ctx.Stdout, "  none")
+		return err
+	}
+	for _, provider := range providers {
+		line := "  - " + provider.Alias
+		line += " provider=" + quotedValueOrNone(provider.Provider)
+		line += " account=" + quotedValueOrNone(provider.AccountID)
+		line += " status=" + quotedValueOrNone(provider.Status)
+		if strings.TrimSpace(provider.Message) != "" {
+			line += " message=" + quotedValueOrNone(provider.Message)
+		}
+		if _, err := fmt.Fprintln(ctx.Stdout, line); err != nil {
 			return err
 		}
 	}

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -108,6 +108,8 @@ func Execute() error {
 	mcpCmd := newMCPCmd(resolveOpen, runInitForArgs, launchMCPProcess)
 	appCmd := newAppCmd(launchAppProcess)
 	execCmd := newExecCmd(common.FindProjectRoot, common.GitCommandRunner, nil)
+	cloudCmd := newCloudCmd(configStore, runPrompt, runSelect, common.CloudDependencies{})
+	contextCmd := newContextCmd(configStore, runPrompt, runSelect, common.CloudContextDependencies{})
 	listCmd := newListCmd(configStore, common.FindProjectRoot)
 	doctorCmd := newDoctorCmd(resolveOpen, runPrompt)
 	deleteCmd := newDeleteCmd(configStore, runPrompt, common.DeleteKubernetesNamespace)
@@ -129,6 +131,6 @@ func Execute() error {
 	}
 
 	cmd := newRootCommand(runRoot)
-	addCommands(cmd, initCmd, openCmd, sshdCmd, devopsCmd, buildCmd, pushCmd, deployCmd, mcpCmd, appCmd, execCmd, listCmd, doctorCmd, deleteCmd, releaseCmd, versionCmd)
+	addCommands(cmd, initCmd, openCmd, sshdCmd, devopsCmd, buildCmd, pushCmd, deployCmd, mcpCmd, appCmd, execCmd, cloudCmd, contextCmd, listCmd, doctorCmd, deleteCmd, releaseCmd, versionCmd)
 	return cmd.Execute()
 }

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -213,6 +213,11 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	mcpCmd := newMCPCmd(resolveOpen, runInitForArgs, launchMCP)
 	appCmd := newAppCmd(launchApp)
 	execCmd := newExecCmd(findProjectRoot, runGit, deps.RunRawCommand)
+	cloudStore, ok := any(store).(common.CloudStore)
+	if !ok {
+		cloudStore = common.ConfigStore{}
+	}
+	cloudCmd := newCloudCmd(cloudStore, promptRunner, selectRunner, common.CloudDependencies{})
 	listCmd := newListCmd(listDataStore, findProjectRoot)
 	doctorCmd := newDoctorCmd(resolveOpen, promptRunner)
 	deleteNamespace := deps.DeleteKubernetesNamespace
@@ -242,7 +247,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	}
 
 	cmd := newRootCommand(runRoot)
-	addCommands(cmd, initCmd, openCmd, sshdCmd, devopsCmd, buildCmd, pushCmd, deployCmd, mcpCmd, appCmd, execCmd, listCmd, doctorCmd, deleteCmd, releaseCmd, versionCmd)
+	addCommands(cmd, initCmd, openCmd, sshdCmd, devopsCmd, buildCmd, pushCmd, deployCmd, mcpCmd, appCmd, execCmd, cloudCmd, listCmd, doctorCmd, deleteCmd, releaseCmd, versionCmd)
 	return cmd
 }
 

--- a/erun-common/cloud.go
+++ b/erun-common/cloud.go
@@ -1,0 +1,495 @@
+package eruncommon
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	CloudProviderAWS = "aws"
+
+	CloudTokenStatusActive        = "active"
+	CloudTokenStatusExpired       = "expired"
+	CloudTokenStatusNotConfigured = "not_configured"
+	CloudTokenStatusUnknown       = "unknown"
+)
+
+type CloudStore interface {
+	CloudReadStore
+	SaveERunConfig(ERunConfig) error
+}
+
+type CloudReadStore interface {
+	LoadERunConfig() (ERunConfig, string, error)
+}
+
+type CloudProviderConfig struct {
+	Alias       string `json:"alias" yaml:"alias"`
+	Provider    string `json:"provider" yaml:"provider"`
+	Username    string `json:"username,omitempty" yaml:"username,omitempty"`
+	AccountID   string `json:"accountId,omitempty" yaml:"accountid,omitempty"`
+	Profile     string `json:"profile,omitempty" yaml:"profile,omitempty"`
+	SSORegion   string `json:"ssoRegion,omitempty" yaml:"ssoregion,omitempty"`
+	SSOStartURL string `json:"ssoStartUrl,omitempty" yaml:"ssostarturl,omitempty"`
+}
+
+type CloudProviderStatus struct {
+	CloudProviderConfig `json:",inline" yaml:",inline"`
+	Status              string `json:"status" yaml:"status"`
+	Message             string `json:"message,omitempty" yaml:"message,omitempty"`
+}
+
+type AWSIdentity struct {
+	Account string `json:"Account"`
+	Arn     string `json:"Arn"`
+	UserID  string `json:"UserId"`
+}
+
+type InitAWSCloudProviderParams struct {
+	Profile     string
+	Username    string
+	AccountID   string
+	RoleName    string
+	Region      string
+	SSORegion   string
+	SSOStartURL string
+	SkipLogin   bool
+}
+
+type CloudLoginParams struct {
+	Alias string
+	Force bool
+}
+
+type CloudDependencies struct {
+	RunAWSConfigureSSO func(Context, AWSProfileConfig) error
+	RunAWSLogin        func(Context, string) error
+	ResolveAWSIdentity func(Context, string) (AWSIdentity, error)
+	CheckAWSStatus     func(Context, CloudProviderConfig) CloudProviderStatus
+}
+
+type AWSProfileConfig struct {
+	Profile     string
+	SSOStartURL string
+	SSORegion   string
+	AccountID   string
+	RoleName    string
+	Region      string
+}
+
+func NormalizeCloudProviderConfig(config CloudProviderConfig) CloudProviderConfig {
+	config.Alias = strings.TrimSpace(config.Alias)
+	config.Provider = strings.ToLower(strings.TrimSpace(config.Provider))
+	config.Username = strings.TrimSpace(config.Username)
+	config.AccountID = strings.TrimSpace(config.AccountID)
+	config.Profile = strings.TrimSpace(config.Profile)
+	config.SSORegion = strings.TrimSpace(config.SSORegion)
+	config.SSOStartURL = strings.TrimSpace(config.SSOStartURL)
+	if config.Alias == "" && config.Provider != "" && config.Username != "" && config.AccountID != "" {
+		config.Alias = CloudProviderAlias(config.Username, config.AccountID, config.Provider)
+	}
+	return config
+}
+
+func CloudProviderAlias(username, accountID, provider string) string {
+	username = strings.TrimSpace(username)
+	accountID = strings.TrimSpace(accountID)
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if username == "" || accountID == "" || provider == "" {
+		return ""
+	}
+	return username + "+" + accountID + "@" + provider
+}
+
+func ListCloudProviders(store CloudReadStore) ([]CloudProviderConfig, error) {
+	if store == nil {
+		return nil, fmt.Errorf("store is required")
+	}
+	config, _, err := store.LoadERunConfig()
+	if errors.Is(err, ErrNotInitialized) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return normalizedCloudProviders(config.CloudProviders), nil
+}
+
+func ListCloudProviderStatuses(store CloudReadStore, deps CloudDependencies) ([]CloudProviderStatus, error) {
+	providers, err := ListCloudProviders(store)
+	if err != nil {
+		return nil, err
+	}
+	statuses := make([]CloudProviderStatus, 0, len(providers))
+	for _, provider := range providers {
+		statuses = append(statuses, CloudProviderTokenStatus(provider, deps))
+	}
+	return statuses, nil
+}
+
+func InitAWSCloudProvider(ctx Context, store CloudStore, params InitAWSCloudProviderParams, deps CloudDependencies) (CloudProviderConfig, error) {
+	if store == nil {
+		return CloudProviderConfig{}, fmt.Errorf("store is required")
+	}
+	deps = normalizeCloudDependencies(deps)
+	profile := strings.TrimSpace(params.Profile)
+	configureProfile := profile == "" || hasAWSProfileConfig(params)
+	if profile == "" {
+		profile = generatedAWSProfileName()
+	}
+	if configureProfile {
+		profileConfig := AWSProfileConfig{
+			Profile:     profile,
+			SSOStartURL: params.SSOStartURL,
+			SSORegion:   params.SSORegion,
+			AccountID:   params.AccountID,
+			RoleName:    params.RoleName,
+			Region:      params.Region,
+		}
+		if err := deps.RunAWSConfigureSSO(ctx, profileConfig); err != nil {
+			return CloudProviderConfig{}, err
+		}
+	}
+	if !params.SkipLogin {
+		if err := deps.RunAWSLogin(ctx, profile); err != nil {
+			return CloudProviderConfig{}, err
+		}
+	}
+
+	identity, err := deps.ResolveAWSIdentity(ctx, profile)
+	if err != nil {
+		return CloudProviderConfig{}, err
+	}
+	username := AWSUsernameFromARN(identity.Arn)
+	if username == "" {
+		username = strings.TrimSpace(params.Username)
+	}
+	accountID := strings.TrimSpace(identity.Account)
+	if accountID == "" {
+		accountID = strings.TrimSpace(params.AccountID)
+	}
+	provider := NormalizeCloudProviderConfig(CloudProviderConfig{
+		Provider:    CloudProviderAWS,
+		Username:    username,
+		AccountID:   accountID,
+		Profile:     profile,
+		SSORegion:   params.SSORegion,
+		SSOStartURL: params.SSOStartURL,
+	})
+	if provider.Alias == "" {
+		return CloudProviderConfig{}, fmt.Errorf("cloud provider alias cannot be resolved")
+	}
+	return SaveCloudProviderConfig(store, provider)
+}
+
+func hasAWSProfileConfig(params InitAWSCloudProviderParams) bool {
+	return strings.TrimSpace(params.SSOStartURL) != "" ||
+		strings.TrimSpace(params.SSORegion) != "" ||
+		strings.TrimSpace(params.AccountID) != "" ||
+		strings.TrimSpace(params.RoleName) != "" ||
+		strings.TrimSpace(params.Region) != ""
+}
+
+func LoginCloudProviderAlias(ctx Context, store CloudStore, params CloudLoginParams, deps CloudDependencies) (CloudProviderStatus, error) {
+	provider, err := ResolveCloudProvider(store, params.Alias)
+	if err != nil {
+		return CloudProviderStatus{}, err
+	}
+	deps = normalizeCloudDependencies(deps)
+	status := CloudProviderStatus{CloudProviderConfig: provider, Status: CloudTokenStatusUnknown}
+	if !params.Force {
+		status = CloudProviderTokenStatus(provider, deps)
+		if status.Status == CloudTokenStatusActive {
+			return status, nil
+		}
+	}
+	switch provider.Provider {
+	case CloudProviderAWS:
+		if err := deps.RunAWSLogin(ctx, provider.Profile); err != nil {
+			return status, err
+		}
+	default:
+		return status, fmt.Errorf("unsupported cloud provider %q", provider.Provider)
+	}
+	return CloudProviderTokenStatus(provider, deps), nil
+}
+
+func ResolveCloudProvider(store CloudStore, alias string) (CloudProviderConfig, error) {
+	alias = strings.TrimSpace(alias)
+	if alias == "" {
+		return CloudProviderConfig{}, fmt.Errorf("cloud provider alias is required")
+	}
+	providers, err := ListCloudProviders(store)
+	if err != nil {
+		return CloudProviderConfig{}, err
+	}
+	for _, provider := range providers {
+		if provider.Alias == alias {
+			return provider, nil
+		}
+	}
+	return CloudProviderConfig{}, fmt.Errorf("cloud provider alias %q is not configured", alias)
+}
+
+func SaveCloudProviderConfig(store CloudStore, provider CloudProviderConfig) (CloudProviderConfig, error) {
+	if store == nil {
+		return CloudProviderConfig{}, fmt.Errorf("store is required")
+	}
+	provider = NormalizeCloudProviderConfig(provider)
+	if provider.Alias == "" {
+		return CloudProviderConfig{}, fmt.Errorf("cloud provider alias is required")
+	}
+	config, _, err := store.LoadERunConfig()
+	if errors.Is(err, ErrNotInitialized) {
+		config = ERunConfig{}
+	} else if err != nil {
+		return CloudProviderConfig{}, err
+	}
+	config.CloudProviders = upsertCloudProvider(config.CloudProviders, provider)
+	if err := store.SaveERunConfig(config); err != nil {
+		return CloudProviderConfig{}, err
+	}
+	return provider, nil
+}
+
+func CloudProviderTokenStatus(provider CloudProviderConfig, deps CloudDependencies) CloudProviderStatus {
+	provider = NormalizeCloudProviderConfig(provider)
+	deps = normalizeCloudDependencies(deps)
+	if provider.Provider == "" {
+		return CloudProviderStatus{CloudProviderConfig: provider, Status: CloudTokenStatusNotConfigured, Message: "provider is not configured"}
+	}
+	if deps.CheckAWSStatus != nil && provider.Provider == CloudProviderAWS {
+		return deps.CheckAWSStatus(Context{}, provider)
+	}
+	if provider.Provider != CloudProviderAWS {
+		return CloudProviderStatus{CloudProviderConfig: provider, Status: CloudTokenStatusUnknown, Message: "unsupported provider"}
+	}
+	return defaultCheckAWSStatus(Context{}, provider)
+}
+
+func AWSUsernameFromARN(arn string) string {
+	arn = strings.TrimSpace(arn)
+	if arn == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(arn, "/"); idx >= 0 && idx+1 < len(arn) {
+		return arn[idx+1:]
+	}
+	if idx := strings.LastIndex(arn, ":"); idx >= 0 && idx+1 < len(arn) {
+		return arn[idx+1:]
+	}
+	return arn
+}
+
+func upsertCloudProvider(providers []CloudProviderConfig, provider CloudProviderConfig) []CloudProviderConfig {
+	provider = NormalizeCloudProviderConfig(provider)
+	updated := false
+	result := make([]CloudProviderConfig, 0, len(providers)+1)
+	for _, existing := range providers {
+		existing = NormalizeCloudProviderConfig(existing)
+		if existing.Alias == "" {
+			continue
+		}
+		if existing.Alias == provider.Alias {
+			result = append(result, provider)
+			updated = true
+			continue
+		}
+		result = append(result, existing)
+	}
+	if !updated {
+		result = append(result, provider)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Alias < result[j].Alias
+	})
+	return result
+}
+
+func normalizedCloudProviders(providers []CloudProviderConfig) []CloudProviderConfig {
+	result := make([]CloudProviderConfig, 0, len(providers))
+	for _, provider := range providers {
+		provider = NormalizeCloudProviderConfig(provider)
+		if provider.Alias == "" {
+			continue
+		}
+		result = append(result, provider)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Alias < result[j].Alias
+	})
+	return result
+}
+
+func normalizeCloudDependencies(deps CloudDependencies) CloudDependencies {
+	if deps.RunAWSConfigureSSO == nil {
+		deps.RunAWSConfigureSSO = defaultRunAWSConfigureSSO
+	}
+	if deps.RunAWSLogin == nil {
+		deps.RunAWSLogin = defaultRunAWSLogin
+	}
+	if deps.ResolveAWSIdentity == nil {
+		deps.ResolveAWSIdentity = defaultResolveAWSIdentity
+	}
+	if deps.CheckAWSStatus == nil {
+		deps.CheckAWSStatus = defaultCheckAWSStatus
+	}
+	return deps
+}
+
+func defaultRunAWSConfigureSSO(ctx Context, config AWSProfileConfig) error {
+	config = normalizeAWSProfileConfig(config)
+	if err := validateAWSProfileConfig(config); err != nil {
+		return err
+	}
+	settings := []struct {
+		key   string
+		value string
+	}{
+		{key: "sso_start_url", value: config.SSOStartURL},
+		{key: "sso_region", value: config.SSORegion},
+		{key: "sso_account_id", value: config.AccountID},
+		{key: "sso_role_name", value: config.RoleName},
+		{key: "region", value: config.Region},
+		{key: "output", value: "json"},
+	}
+	for _, setting := range settings {
+		args := []string{"configure", "set", setting.key, setting.value, "--profile", config.Profile}
+		ctx.TraceCommand("", "aws", args...)
+		if ctx.DryRun {
+			continue
+		}
+		stdout, _ := captureWriter(ctx.Stdout)
+		stderr, stderrBuffer := captureWriter(ctx.Stderr)
+		if err := RawCommandRunner("", "aws", args, nil, stdout, stderr); err != nil {
+			return fmt.Errorf("aws configure set %s: %s", setting.key, commandErrorMessage(err, stderrBuffer.String(), "AWS SSO setup failed"))
+		}
+	}
+	return nil
+}
+
+func normalizeAWSProfileConfig(config AWSProfileConfig) AWSProfileConfig {
+	config.Profile = strings.TrimSpace(config.Profile)
+	config.SSOStartURL = strings.TrimSpace(config.SSOStartURL)
+	config.SSORegion = strings.TrimSpace(config.SSORegion)
+	config.AccountID = strings.TrimSpace(config.AccountID)
+	config.RoleName = strings.TrimSpace(config.RoleName)
+	config.Region = strings.TrimSpace(config.Region)
+	if config.Region == "" {
+		config.Region = config.SSORegion
+	}
+	return config
+}
+
+func validateAWSProfileConfig(config AWSProfileConfig) error {
+	switch {
+	case config.Profile == "":
+		return fmt.Errorf("AWS profile name is required")
+	case config.SSOStartURL == "":
+		return fmt.Errorf("AWS SSO start URL is required")
+	case config.SSORegion == "":
+		return fmt.Errorf("AWS SSO region is required")
+	case config.AccountID == "":
+		return fmt.Errorf("AWS account ID is required")
+	case config.RoleName == "":
+		return fmt.Errorf("AWS role name is required")
+	case config.Region == "":
+		return fmt.Errorf("AWS region is required")
+	default:
+		return nil
+	}
+}
+
+func defaultRunAWSLogin(ctx Context, profile string) error {
+	args := []string{"sso", "login"}
+	if strings.TrimSpace(profile) != "" {
+		args = append(args, "--profile", strings.TrimSpace(profile))
+	}
+	ctx.TraceCommand("", "aws", args...)
+	if ctx.DryRun {
+		return nil
+	}
+	stdout, _ := captureWriter(ctx.Stdout)
+	stderr, stderrBuffer := captureWriter(ctx.Stderr)
+	if err := RawCommandRunner("", "aws", args, ctx.Stdin, stdout, stderr); err != nil {
+		return fmt.Errorf("aws sso login: %s", commandErrorMessage(err, stderrBuffer.String(), "AWS SSO login failed"))
+	}
+	return nil
+}
+
+func generatedAWSProfileName() string {
+	return "erun-sso-" + time.Now().UTC().Format("20060102150405")
+}
+
+func defaultResolveAWSIdentity(ctx Context, profile string) (AWSIdentity, error) {
+	args := []string{"sts", "get-caller-identity", "--output", "json"}
+	if strings.TrimSpace(profile) != "" {
+		args = append(args, "--profile", strings.TrimSpace(profile))
+	}
+	ctx.TraceCommand("", "aws", args...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if err := RawCommandRunner("", "aws", args, nil, &stdout, &stderr); err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = err.Error()
+		}
+		return AWSIdentity{}, fmt.Errorf("resolve AWS identity: %s", message)
+	}
+	var identity AWSIdentity
+	if err := json.Unmarshal(stdout.Bytes(), &identity); err != nil {
+		return AWSIdentity{}, fmt.Errorf("parse AWS identity: %w", err)
+	}
+	return identity, nil
+}
+
+func defaultCheckAWSStatus(_ Context, provider CloudProviderConfig) CloudProviderStatus {
+	args := []string{"sts", "get-caller-identity", "--output", "json"}
+	if provider.Profile != "" {
+		args = append(args, "--profile", provider.Profile)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := RawCommandRunner("", "aws", args, nil, &stdout, &stderr)
+	if err == nil {
+		return CloudProviderStatus{CloudProviderConfig: provider, Status: CloudTokenStatusActive}
+	}
+	message := strings.TrimSpace(stderr.String())
+	if message == "" {
+		message = strings.TrimSpace(err.Error())
+	}
+	if errors.Is(err, exec.ErrNotFound) {
+		return CloudProviderStatus{CloudProviderConfig: provider, Status: CloudTokenStatusUnknown, Message: "aws CLI is not installed"}
+	}
+	status := CloudTokenStatusExpired
+	if strings.Contains(strings.ToLower(message), "could not be found") || strings.Contains(strings.ToLower(message), "not found") {
+		status = CloudTokenStatusNotConfigured
+	}
+	return CloudProviderStatus{CloudProviderConfig: provider, Status: status, Message: message}
+}
+
+func captureWriter(writer io.Writer) (io.Writer, *bytes.Buffer) {
+	buffer := new(bytes.Buffer)
+	if writer == nil {
+		return buffer, buffer
+	}
+	return io.MultiWriter(writer, buffer), buffer
+}
+
+func commandErrorMessage(err error, stderr, fallback string) string {
+	message := strings.TrimSpace(stderr)
+	if message != "" {
+		return message
+	}
+	if fallback != "" {
+		return fallback + ": " + err.Error()
+	}
+	return err.Error()
+}

--- a/erun-common/cloud_context.go
+++ b/erun-common/cloud_context.go
@@ -1,0 +1,711 @@
+package eruncommon
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultCloudContextInstanceType   = "c8gd.2xlarge"
+	AlternateCloudContextInstanceType = "t4g.xlarge"
+	DefaultCloudContextDiskType       = "gp3"
+	DefaultCloudContextDiskSizeGB     = 100
+	AlternateCloudContextDiskSizeGB   = 200
+	DefaultCloudContextRegion         = "eu-west-2"
+	AlternateCloudContextRegion       = "eu-west-1"
+
+	CloudContextStatusPending = "pending"
+	CloudContextStatusRunning = "running"
+	CloudContextStatusStopped = "stopped"
+	CloudContextStatusUnknown = "unknown"
+)
+
+type CloudContextStore interface {
+	CloudStore
+}
+
+type CloudContextConfig struct {
+	Name               string `json:"name" yaml:"name"`
+	Provider           string `json:"provider" yaml:"provider"`
+	CloudProviderAlias string `json:"cloudProviderAlias" yaml:"cloudprovideralias"`
+	Region             string `json:"region" yaml:"region"`
+	InstanceID         string `json:"instanceId,omitempty" yaml:"instanceid,omitempty"`
+	PublicIP           string `json:"publicIp,omitempty" yaml:"publicip,omitempty"`
+	InstanceType       string `json:"instanceType" yaml:"instancetype"`
+	DiskType           string `json:"diskType" yaml:"disktype"`
+	DiskSizeGB         int    `json:"diskSizeGb" yaml:"disksizegb"`
+	KubernetesContext  string `json:"kubernetesContext" yaml:"kubernetescontext"`
+	SecurityGroupID    string `json:"securityGroupId,omitempty" yaml:"securitygroupid,omitempty"`
+	AdminToken         string `json:"-" yaml:"admintoken,omitempty"`
+	Status             string `json:"status" yaml:"status"`
+	CreatedAt          string `json:"createdAt,omitempty" yaml:"createdat,omitempty"`
+	UpdatedAt          string `json:"updatedAt,omitempty" yaml:"updatedat,omitempty"`
+}
+
+type CloudContextStatus struct {
+	CloudContextConfig `json:",inline" yaml:",inline"`
+	Message            string `json:"message,omitempty" yaml:"message,omitempty"`
+}
+
+type InitCloudContextParams struct {
+	Name               string
+	CloudProviderAlias string
+	Region             string
+	InstanceType       string
+	DiskType           string
+	DiskSizeGB         int
+	SubnetID           string
+	SecurityGroupID    string
+	KeyName            string
+}
+
+type CloudContextParams struct {
+	Name string
+}
+
+type CloudContextDependencies struct {
+	RunAWS     func(Context, CloudProviderConfig, string, []string) (string, error)
+	RunKubectl func(Context, []string) error
+	Now        func() time.Time
+	NewToken   func() string
+}
+
+func CloudContextInstanceTypes() []string {
+	return []string{DefaultCloudContextInstanceType, AlternateCloudContextInstanceType}
+}
+
+func CloudContextDiskSizesGB() []int {
+	return []int{DefaultCloudContextDiskSizeGB, AlternateCloudContextDiskSizeGB}
+}
+
+func CloudContextRegions() []string {
+	return []string{DefaultCloudContextRegion, AlternateCloudContextRegion}
+}
+
+func NormalizeCloudContextConfig(config CloudContextConfig) CloudContextConfig {
+	config.Name = strings.TrimSpace(config.Name)
+	config.Provider = strings.ToLower(strings.TrimSpace(config.Provider))
+	config.CloudProviderAlias = strings.TrimSpace(config.CloudProviderAlias)
+	config.Region = strings.TrimSpace(config.Region)
+	config.InstanceID = strings.TrimSpace(config.InstanceID)
+	config.PublicIP = strings.TrimSpace(config.PublicIP)
+	config.InstanceType = strings.TrimSpace(config.InstanceType)
+	config.DiskType = strings.TrimSpace(config.DiskType)
+	config.KubernetesContext = strings.TrimSpace(config.KubernetesContext)
+	if config.Name == "" {
+		config.Name = config.KubernetesContext
+	}
+	config.SecurityGroupID = strings.TrimSpace(config.SecurityGroupID)
+	config.AdminToken = strings.TrimSpace(config.AdminToken)
+	config.Status = strings.TrimSpace(config.Status)
+	config.CreatedAt = strings.TrimSpace(config.CreatedAt)
+	config.UpdatedAt = strings.TrimSpace(config.UpdatedAt)
+	if config.InstanceType == "" {
+		config.InstanceType = DefaultCloudContextInstanceType
+	}
+	if config.DiskType == "" {
+		config.DiskType = DefaultCloudContextDiskType
+	}
+	if config.DiskSizeGB == 0 {
+		config.DiskSizeGB = DefaultCloudContextDiskSizeGB
+	}
+	if config.KubernetesContext == "" {
+		config.KubernetesContext = config.Name
+	}
+	if config.Status == "" {
+		config.Status = CloudContextStatusUnknown
+	}
+	return config
+}
+
+func ListCloudContexts(store CloudReadStore) ([]CloudContextConfig, error) {
+	if store == nil {
+		return nil, fmt.Errorf("store is required")
+	}
+	config, _, err := store.LoadERunConfig()
+	if err == ErrNotInitialized {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return normalizedCloudContexts(config.CloudContexts), nil
+}
+
+func ListCloudContextStatuses(store CloudReadStore) ([]CloudContextStatus, error) {
+	contexts, err := ListCloudContexts(store)
+	if err != nil {
+		return nil, err
+	}
+	statuses := make([]CloudContextStatus, 0, len(contexts))
+	for _, context := range contexts {
+		statuses = append(statuses, CloudContextStatus{CloudContextConfig: context})
+	}
+	return statuses, nil
+}
+
+func InitCloudContext(ctx Context, store CloudContextStore, params InitCloudContextParams, deps CloudContextDependencies) (CloudContextStatus, error) {
+	if store == nil {
+		return CloudContextStatus{}, fmt.Errorf("store is required")
+	}
+	deps = normalizeCloudContextDependencies(deps)
+	provider, err := ResolveCloudProvider(store, params.CloudProviderAlias)
+	if err != nil {
+		return CloudContextStatus{}, err
+	}
+	if provider.Provider != CloudProviderAWS {
+		return CloudContextStatus{}, fmt.Errorf("unsupported cloud provider %q", provider.Provider)
+	}
+	existingContexts, err := ListCloudContexts(store)
+	if err != nil {
+		return CloudContextStatus{}, err
+	}
+	config, err := resolveInitCloudContextConfig(provider, params, deps.Now(), existingContexts)
+	if err != nil {
+		return CloudContextStatus{}, err
+	}
+	if existing, ok, err := findCloudContext(store, config.Name); err != nil {
+		return CloudContextStatus{}, err
+	} else if ok && existing.InstanceID != "" {
+		return CloudContextStatus{}, fmt.Errorf("cloud context %q already exists", config.Name)
+	}
+
+	ami, err := deps.RunAWS(ctx, provider, config.Region, []string{
+		"ssm", "get-parameter",
+		"--name", "/aws/service/canonical/ubuntu/server/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id",
+		"--query", "Parameter.Value",
+		"--output", "text",
+	})
+	if err != nil {
+		return CloudContextStatus{}, err
+	}
+	ami = strings.TrimSpace(ami)
+	if ami == "" {
+		ami = "ami-<latest-ubuntu-arm64>"
+	}
+
+	securityGroupID := strings.TrimSpace(params.SecurityGroupID)
+	if securityGroupID == "" {
+		securityGroupID, err = createCloudContextSecurityGroup(ctx, deps, provider, config.Region, config.Name)
+		if err != nil {
+			return CloudContextStatus{}, err
+		}
+	}
+	config.SecurityGroupID = securityGroupID
+
+	config.AdminToken = deps.NewToken()
+	userDataPath, cleanup, err := cloudContextUserDataFile(ctx, config.AdminToken)
+	if err != nil {
+		return CloudContextStatus{}, err
+	}
+	defer cleanup()
+
+	runArgs := []string{
+		"ec2", "run-instances",
+		"--image-id", ami,
+		"--instance-type", config.InstanceType,
+		"--count", "1",
+		"--block-device-mappings", fmt.Sprintf("DeviceName=/dev/sda1,Ebs={VolumeSize=%d,VolumeType=%s,DeleteOnTermination=true}", config.DiskSizeGB, config.DiskType),
+		"--user-data", "file://" + userDataPath,
+		"--tag-specifications", fmt.Sprintf("ResourceType=instance,Tags=[{Key=Name,Value=%s},{Key=erun:context,Value=%s}]", config.Name, config.Name),
+		"--query", "Instances[0].InstanceId",
+		"--output", "text",
+	}
+	if config.SecurityGroupID != "" {
+		runArgs = append(runArgs, "--security-group-ids", config.SecurityGroupID)
+	}
+	if subnetID := strings.TrimSpace(params.SubnetID); subnetID != "" {
+		runArgs = append(runArgs, "--subnet-id", subnetID)
+	}
+	if keyName := strings.TrimSpace(params.KeyName); keyName != "" {
+		runArgs = append(runArgs, "--key-name", keyName)
+	}
+	instanceID, err := deps.RunAWS(ctx, provider, config.Region, runArgs)
+	if err != nil {
+		return CloudContextStatus{}, err
+	}
+	config.InstanceID = strings.TrimSpace(instanceID)
+	if config.InstanceID == "" {
+		config.InstanceID = "i-<new-instance>"
+	}
+	config.Status = CloudContextStatusPending
+
+	if _, err := deps.RunAWS(ctx, provider, config.Region, []string{"ec2", "wait", "instance-running", "--instance-ids", config.InstanceID}); err != nil {
+		return CloudContextStatus{}, err
+	}
+	publicIP, err := describeCloudContextPublicIP(ctx, deps, provider, config.Region, config.InstanceID)
+	if err != nil {
+		return CloudContextStatus{}, err
+	}
+	config.PublicIP = publicIP
+	if err := configureCloudKubeContext(ctx, deps, config); err != nil {
+		return CloudContextStatus{}, err
+	}
+	config.Status = CloudContextStatusRunning
+	config.UpdatedAt = deps.Now().UTC().Format(time.RFC3339)
+	if ctx.DryRun {
+		return CloudContextStatus{CloudContextConfig: NormalizeCloudContextConfig(config)}, nil
+	}
+	if err := saveCloudContextConfig(store, config); err != nil {
+		return CloudContextStatus{}, err
+	}
+	return CloudContextStatus{CloudContextConfig: NormalizeCloudContextConfig(config)}, nil
+}
+
+func StopCloudContext(ctx Context, store CloudContextStore, params CloudContextParams, deps CloudContextDependencies) (CloudContextStatus, error) {
+	return changeCloudContextPowerState(ctx, store, params, deps, "stop-instances", CloudContextStatusStopped)
+}
+
+func StartCloudContext(ctx Context, store CloudContextStore, params CloudContextParams, deps CloudContextDependencies) (CloudContextStatus, error) {
+	status, err := changeCloudContextPowerState(ctx, store, params, deps, "start-instances", CloudContextStatusRunning)
+	if err != nil {
+		return CloudContextStatus{}, err
+	}
+	deps = normalizeCloudContextDependencies(deps)
+	provider, err := ResolveCloudProvider(store, status.CloudProviderAlias)
+	if err != nil {
+		return CloudContextStatus{}, err
+	}
+	if _, err := deps.RunAWS(ctx, provider, status.Region, []string{"ec2", "wait", "instance-running", "--instance-ids", status.InstanceID}); err != nil {
+		return CloudContextStatus{}, err
+	}
+	publicIP, err := describeCloudContextPublicIP(ctx, deps, provider, status.Region, status.InstanceID)
+	if err != nil {
+		return CloudContextStatus{}, err
+	}
+	status.PublicIP = publicIP
+	if err := configureCloudKubeContext(ctx, deps, status.CloudContextConfig); err != nil {
+		return CloudContextStatus{}, err
+	}
+	status.UpdatedAt = deps.Now().UTC().Format(time.RFC3339)
+	if ctx.DryRun {
+		return status, nil
+	}
+	if err := saveCloudContextConfig(store, status.CloudContextConfig); err != nil {
+		return CloudContextStatus{}, err
+	}
+	return status, nil
+}
+
+func changeCloudContextPowerState(ctx Context, store CloudContextStore, params CloudContextParams, deps CloudContextDependencies, awsAction, status string) (CloudContextStatus, error) {
+	if store == nil {
+		return CloudContextStatus{}, fmt.Errorf("store is required")
+	}
+	deps = normalizeCloudContextDependencies(deps)
+	config, ok, err := findCloudContext(store, params.Name)
+	if err != nil {
+		return CloudContextStatus{}, err
+	}
+	if !ok {
+		return CloudContextStatus{}, fmt.Errorf("cloud context %q is not configured", strings.TrimSpace(params.Name))
+	}
+	if config.InstanceID == "" {
+		return CloudContextStatus{}, fmt.Errorf("cloud context %q has no instance ID", config.Name)
+	}
+	provider, err := ResolveCloudProvider(store, config.CloudProviderAlias)
+	if err != nil {
+		return CloudContextStatus{}, err
+	}
+	if _, err := deps.RunAWS(ctx, provider, config.Region, []string{"ec2", awsAction, "--instance-ids", config.InstanceID}); err != nil {
+		return CloudContextStatus{}, err
+	}
+	config.Status = status
+	config.UpdatedAt = deps.Now().UTC().Format(time.RFC3339)
+	if ctx.DryRun {
+		return CloudContextStatus{CloudContextConfig: NormalizeCloudContextConfig(config)}, nil
+	}
+	if err := saveCloudContextConfig(store, config); err != nil {
+		return CloudContextStatus{}, err
+	}
+	return CloudContextStatus{CloudContextConfig: NormalizeCloudContextConfig(config)}, nil
+}
+
+func resolveInitCloudContextConfig(provider CloudProviderConfig, params InitCloudContextParams, now time.Time, existingContexts []CloudContextConfig) (CloudContextConfig, error) {
+	config := CloudContextConfig{
+		Name:               strings.TrimSpace(params.Name),
+		Provider:           CloudProviderAWS,
+		CloudProviderAlias: provider.Alias,
+		Region:             strings.TrimSpace(params.Region),
+		InstanceType:       strings.TrimSpace(params.InstanceType),
+		DiskType:           strings.TrimSpace(params.DiskType),
+		DiskSizeGB:         params.DiskSizeGB,
+		Status:             CloudContextStatusPending,
+		CreatedAt:          now.UTC().Format(time.RFC3339),
+		UpdatedAt:          now.UTC().Format(time.RFC3339),
+	}
+	if config.Region == "" {
+		config.Region = DefaultCloudContextRegion
+	}
+	if config.Name == "" {
+		config.Name = generatedCloudContextName(provider, config.Region, existingContexts)
+	}
+	config = NormalizeCloudContextConfig(config)
+	if config.CloudProviderAlias == "" {
+		return CloudContextConfig{}, fmt.Errorf("cloud provider alias is required")
+	}
+	if config.Region == "" {
+		return CloudContextConfig{}, fmt.Errorf("cloud context region is required")
+	}
+	if !validCloudContextRegion(config.Region) {
+		return CloudContextConfig{}, fmt.Errorf("unsupported cloud context region %q", config.Region)
+	}
+	if !validCloudContextInstanceType(config.InstanceType) {
+		return CloudContextConfig{}, fmt.Errorf("unsupported cloud context instance type %q", config.InstanceType)
+	}
+	if !validCloudContextDiskSize(config.DiskSizeGB) {
+		return CloudContextConfig{}, fmt.Errorf("unsupported cloud context disk size %d", config.DiskSizeGB)
+	}
+	if config.DiskType != DefaultCloudContextDiskType {
+		return CloudContextConfig{}, fmt.Errorf("unsupported cloud context disk type %q", config.DiskType)
+	}
+	return config, nil
+}
+
+func createCloudContextSecurityGroup(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, name string) (string, error) {
+	groupName := name + "-k3s"
+	groupID, err := deps.RunAWS(ctx, provider, region, []string{
+		"ec2", "create-security-group",
+		"--group-name", groupName,
+		"--description", "ERun managed k3s API access for " + name,
+		"--query", "GroupId",
+		"--output", "text",
+	})
+	if err != nil {
+		return "", err
+	}
+	groupID = strings.TrimSpace(groupID)
+	if groupID == "" {
+		groupID = "sg-<" + name + ">"
+	}
+	_, err = deps.RunAWS(ctx, provider, region, []string{
+		"ec2", "authorize-security-group-ingress",
+		"--group-id", groupID,
+		"--protocol", "tcp",
+		"--port", "6443",
+		"--cidr", "0.0.0.0/0",
+	})
+	return groupID, err
+}
+
+func describeCloudContextPublicIP(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, instanceID string) (string, error) {
+	publicIP, err := deps.RunAWS(ctx, provider, region, []string{
+		"ec2", "describe-instances",
+		"--instance-ids", instanceID,
+		"--query", "Reservations[0].Instances[0].PublicIpAddress",
+		"--output", "text",
+	})
+	if err != nil {
+		return "", err
+	}
+	publicIP = strings.TrimSpace(publicIP)
+	if publicIP == "" || strings.EqualFold(publicIP, "none") {
+		if ctx.DryRun {
+			return "203.0.113.10", nil
+		}
+		return "", fmt.Errorf("cloud context instance %q does not have a public IP yet", instanceID)
+	}
+	return publicIP, nil
+}
+
+func configureCloudKubeContext(ctx Context, deps CloudContextDependencies, config CloudContextConfig) error {
+	config = NormalizeCloudContextConfig(config)
+	if config.PublicIP == "" {
+		return fmt.Errorf("cloud context public IP is required")
+	}
+	if config.AdminToken == "" {
+		return fmt.Errorf("cloud context admin token is required")
+	}
+	commands := [][]string{
+		{"config", "set-cluster", config.KubernetesContext, "--server", "https://" + config.PublicIP + ":6443", "--insecure-skip-tls-verify=true"},
+		{"config", "set-credentials", config.KubernetesContext, "--token", config.AdminToken},
+		{"config", "set-context", config.KubernetesContext, "--cluster", config.KubernetesContext, "--user", config.KubernetesContext},
+	}
+	for _, args := range commands {
+		if err := deps.RunKubectl(ctx, args); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func cloudContextUserDataFile(ctx Context, adminToken string) (string, func(), error) {
+	if ctx.DryRun {
+		return "<generated-k3s-user-data>", func() {}, nil
+	}
+	file, err := os.CreateTemp("", "erun-k3s-user-data-*.sh")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() {
+		_ = os.Remove(file.Name())
+	}
+	userData := `#!/bin/sh
+set -eu
+mkdir -p /etc/rancher/k3s
+cat >/etc/rancher/k3s/token-auth.csv <<'EOF'
+` + adminToken + `,erun-admin,erun-admin,"system:masters"
+EOF
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --kube-apiserver-arg=token-auth-file=/etc/rancher/k3s/token-auth.csv" sh -
+`
+	if _, err := file.WriteString(userData); err != nil {
+		_ = file.Close()
+		cleanup()
+		return "", nil, err
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return file.Name(), cleanup, nil
+}
+
+func saveCloudContextConfig(store CloudContextStore, context CloudContextConfig) error {
+	context = NormalizeCloudContextConfig(context)
+	config, _, err := store.LoadERunConfig()
+	if err == ErrNotInitialized {
+		config = ERunConfig{}
+	} else if err != nil {
+		return err
+	}
+	config.CloudContexts = upsertCloudContext(config.CloudContexts, context)
+	return store.SaveERunConfig(config)
+}
+
+func findCloudContext(store CloudReadStore, name string) (CloudContextConfig, bool, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return CloudContextConfig{}, false, fmt.Errorf("cloud context name is required")
+	}
+	contexts, err := ListCloudContexts(store)
+	if err != nil {
+		return CloudContextConfig{}, false, err
+	}
+	for _, context := range contexts {
+		if context.Name == name || context.KubernetesContext == name {
+			return context, true, nil
+		}
+	}
+	return CloudContextConfig{}, false, nil
+}
+
+func upsertCloudContext(contexts []CloudContextConfig, context CloudContextConfig) []CloudContextConfig {
+	context = NormalizeCloudContextConfig(context)
+	updated := false
+	result := make([]CloudContextConfig, 0, len(contexts)+1)
+	for _, existing := range contexts {
+		existing = NormalizeCloudContextConfig(existing)
+		if existing.Name == "" {
+			continue
+		}
+		if existing.Name == context.Name {
+			result = append(result, context)
+			updated = true
+			continue
+		}
+		result = append(result, existing)
+	}
+	if !updated {
+		result = append(result, context)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+func normalizedCloudContexts(contexts []CloudContextConfig) []CloudContextConfig {
+	result := make([]CloudContextConfig, 0, len(contexts))
+	for _, context := range contexts {
+		context = NormalizeCloudContextConfig(context)
+		if context.Name == "" {
+			continue
+		}
+		result = append(result, context)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+func validCloudContextInstanceType(value string) bool {
+	for _, option := range CloudContextInstanceTypes() {
+		if value == option {
+			return true
+		}
+	}
+	return false
+}
+
+func validCloudContextDiskSize(value int) bool {
+	for _, option := range CloudContextDiskSizesGB() {
+		if value == option {
+			return true
+		}
+	}
+	return false
+}
+
+func validCloudContextRegion(value string) bool {
+	for _, option := range CloudContextRegions() {
+		if value == option {
+			return true
+		}
+	}
+	return false
+}
+
+func generatedCloudContextName(provider CloudProviderConfig, region string, existingContexts []CloudContextConfig) string {
+	parts := make([]string, 0, 2)
+	if provider.AccountID != "" {
+		parts = append(parts, provider.AccountID)
+	} else if provider.Username != "" {
+		parts = append(parts, provider.Username)
+	} else {
+		parts = append(parts, provider.Alias)
+	}
+	if region != "" {
+		parts = append(parts, region)
+	}
+	tail := sanitizeCloudContextName(strings.Join(parts, "-"))
+	return nextCloudContextName(tail, existingContexts)
+}
+
+func nextCloudContextName(tail string, existingContexts []CloudContextConfig) string {
+	tail = sanitizeCloudContextName(tail)
+	if tail == "" {
+		tail = "context"
+	}
+	prefix := "erun-"
+	suffix := "-" + tail
+	next := 1
+	for _, context := range existingContexts {
+		for _, name := range []string{context.Name, context.KubernetesContext} {
+			name = strings.TrimSpace(name)
+			if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
+				continue
+			}
+			counter := strings.TrimSuffix(strings.TrimPrefix(name, prefix), suffix)
+			if len(counter) != 3 {
+				continue
+			}
+			value, err := strconv.Atoi(counter)
+			if err == nil && value >= next {
+				next = value + 1
+			}
+		}
+	}
+	return fmt.Sprintf("erun-%03d-%s", next, tail)
+}
+
+func sanitizeCloudContextName(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	lastDash := false
+	for _, r := range value {
+		ok := r >= 'a' && r <= 'z' || r >= '0' && r <= '9'
+		if ok {
+			builder.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			builder.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func normalizeCloudContextDependencies(deps CloudContextDependencies) CloudContextDependencies {
+	if deps.RunAWS == nil {
+		deps.RunAWS = defaultRunCloudContextAWS
+	}
+	if deps.RunKubectl == nil {
+		deps.RunKubectl = defaultRunCloudContextKubectl
+	}
+	if deps.Now == nil {
+		deps.Now = time.Now
+	}
+	if deps.NewToken == nil {
+		deps.NewToken = newCloudContextToken
+	}
+	return deps
+}
+
+func defaultRunCloudContextAWS(ctx Context, provider CloudProviderConfig, region string, args []string) (string, error) {
+	fullArgs := append([]string(nil), args...)
+	if region = strings.TrimSpace(region); region != "" && !containsAWSFlag(fullArgs, "--region") {
+		fullArgs = append(fullArgs, "--region", region)
+	}
+	if profile := strings.TrimSpace(provider.Profile); profile != "" && !containsAWSFlag(fullArgs, "--profile") {
+		fullArgs = append(fullArgs, "--profile", profile)
+	}
+	ctx.TraceCommand("", "aws", fullArgs...)
+	if ctx.DryRun {
+		return dryRunAWSOutput(args), nil
+	}
+	var stdout bytes.Buffer
+	stderr, stderrBuffer := captureWriter(ctx.Stderr)
+	if err := RawCommandRunner("", "aws", fullArgs, nil, &stdout, stderr); err != nil {
+		return "", fmt.Errorf("aws %s: %s", strings.Join(args, " "), commandErrorMessage(err, stderrBuffer.String(), "AWS command failed"))
+	}
+	return stdout.String(), nil
+}
+
+func defaultRunCloudContextKubectl(ctx Context, args []string) error {
+	ctx.TraceCommand("", "kubectl", args...)
+	if ctx.DryRun {
+		return nil
+	}
+	stdout, _ := captureWriter(ctx.Stdout)
+	stderr, stderrBuffer := captureWriter(ctx.Stderr)
+	if err := RawCommandRunner("", "kubectl", args, nil, stdout, stderr); err != nil {
+		return fmt.Errorf("kubectl %s: %s", strings.Join(args, " "), commandErrorMessage(err, stderrBuffer.String(), "kubectl command failed"))
+	}
+	return nil
+}
+
+func containsAWSFlag(args []string, flag string) bool {
+	for i, arg := range args {
+		if arg == flag || strings.HasPrefix(arg, flag+"=") {
+			return true
+		}
+		if i > 0 && args[i-1] == flag {
+			return true
+		}
+	}
+	return false
+}
+
+func dryRunAWSOutput(args []string) string {
+	joined := strings.Join(args, " ")
+	switch {
+	case strings.Contains(joined, "ssm get-parameter"):
+		return "ami-<latest-ubuntu-arm64>\n"
+	case strings.Contains(joined, "ec2 create-security-group"):
+		return "sg-<cloud-context>\n"
+	case strings.Contains(joined, "ec2 run-instances"):
+		return "i-<new-instance>\n"
+	case strings.Contains(joined, "ec2 describe-instances"):
+		return "203.0.113.10\n"
+	default:
+		return ""
+	}
+}
+
+func newCloudContextToken() string {
+	token := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, token); err != nil {
+		return "erun-" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return base64.RawURLEncoding.EncodeToString(token)
+}

--- a/erun-common/cloud_context_test.go
+++ b/erun-common/cloud_context_test.go
@@ -1,0 +1,130 @@
+package eruncommon
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInitCloudContextUsesDefaultsAndStoresKubeContext(t *testing.T) {
+	store := &memoryCloudStore{config: ERunConfig{CloudProviders: []CloudProviderConfig{{
+		Alias:     "rihards+123456789012@aws",
+		Provider:  CloudProviderAWS,
+		Profile:   "erun-sso",
+		SSORegion: "eu-central-1",
+		AccountID: "123456789012",
+	}}}}
+	var awsCommands []string
+	var kubectlCommands []string
+	status, err := InitCloudContext(Context{}, store, InitCloudContextParams{
+		CloudProviderAlias: "rihards+123456789012@aws",
+		DiskSizeGB:         AlternateCloudContextDiskSizeGB,
+	}, CloudContextDependencies{
+		Now:      func() time.Time { return time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC) },
+		NewToken: func() string { return "test-token" },
+		RunAWS: func(_ Context, _ CloudProviderConfig, _ string, args []string) (string, error) {
+			awsCommands = append(awsCommands, strings.Join(args, " "))
+			joined := strings.Join(args, " ")
+			switch {
+			case strings.Contains(joined, "ssm get-parameter"):
+				return "ami-test\n", nil
+			case strings.Contains(joined, "create-security-group"):
+				return "sg-test\n", nil
+			case strings.Contains(joined, "run-instances"):
+				return "i-test\n", nil
+			case strings.Contains(joined, "describe-instances"):
+				return "198.51.100.10\n", nil
+			default:
+				return "", nil
+			}
+		},
+		RunKubectl: func(_ Context, args []string) error {
+			kubectlCommands = append(kubectlCommands, strings.Join(args, " "))
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("InitCloudContext failed: %v", err)
+	}
+	if status.InstanceType != DefaultCloudContextInstanceType || status.DiskSizeGB != AlternateCloudContextDiskSizeGB || status.DiskType != DefaultCloudContextDiskType {
+		t.Fatalf("unexpected defaults/options: %+v", status)
+	}
+	if status.Region != DefaultCloudContextRegion || status.Status != CloudContextStatusRunning || status.KubernetesContext == "" {
+		t.Fatalf("unexpected stored context: %+v", status)
+	}
+	if status.Name != "erun-001-123456789012-eu-west-2" {
+		t.Fatalf("unexpected generated context name: %+v", status)
+	}
+	if len(store.config.CloudContexts) != 1 || store.config.CloudContexts[0].InstanceID != "i-test" || store.config.CloudContexts[0].AdminToken != "test-token" {
+		t.Fatalf("expected context to be saved with instance/token metadata, got %+v", store.config.CloudContexts)
+	}
+	if len(awsCommands) == 0 || len(kubectlCommands) != 3 {
+		t.Fatalf("expected AWS and kubeconfig commands, got aws=%+v kubectl=%+v", awsCommands, kubectlCommands)
+	}
+}
+
+func TestInitCloudContextDryRunDoesNotSave(t *testing.T) {
+	store := &memoryCloudStore{config: ERunConfig{CloudProviders: []CloudProviderConfig{{
+		Alias:    "rihards+123456789012@aws",
+		Provider: CloudProviderAWS,
+		Profile:  "erun-sso",
+	}}}}
+	_, err := InitCloudContext(Context{DryRun: true}, store, InitCloudContextParams{
+		CloudProviderAlias: "rihards+123456789012@aws",
+		Region:             "eu-west-1",
+	}, CloudContextDependencies{
+		Now:      func() time.Time { return time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC) },
+		NewToken: func() string { return "test-token" },
+		RunAWS: func(_ Context, _ CloudProviderConfig, _ string, args []string) (string, error) {
+			joined := strings.Join(args, " ")
+			switch {
+			case strings.Contains(joined, "ssm get-parameter"):
+				return "ami-test\n", nil
+			case strings.Contains(joined, "create-security-group"):
+				return "sg-test\n", nil
+			case strings.Contains(joined, "run-instances"):
+				return "i-test\n", nil
+			case strings.Contains(joined, "describe-instances"):
+				return "198.51.100.10\n", nil
+			default:
+				return "", nil
+			}
+		},
+		RunKubectl: func(Context, []string) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("InitCloudContext dry-run failed: %v", err)
+	}
+	if len(store.config.CloudContexts) != 0 {
+		t.Fatalf("dry-run should not save cloud contexts, got %+v", store.config.CloudContexts)
+	}
+}
+
+func TestInitCloudContextGeneratedNameIncrementsForExistingContexts(t *testing.T) {
+	store := &memoryCloudStore{config: ERunConfig{
+		CloudProviders: []CloudProviderConfig{{
+			Alias:     "rihards+123456789012@aws",
+			Provider:  CloudProviderAWS,
+			Profile:   "erun-sso",
+			AccountID: "123456789012",
+		}},
+		CloudContexts: []CloudContextConfig{
+			{Name: "erun-001-123456789012-eu-west-2"},
+			{KubernetesContext: "erun-002-123456789012-eu-west-2"},
+		},
+	}}
+	status, err := InitCloudContext(Context{DryRun: true}, store, InitCloudContextParams{
+		CloudProviderAlias: "rihards+123456789012@aws",
+	}, CloudContextDependencies{
+		Now:        func() time.Time { return time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC) },
+		NewToken:   func() string { return "test-token" },
+		RunAWS:     func(Context, CloudProviderConfig, string, []string) (string, error) { return "", nil },
+		RunKubectl: func(Context, []string) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("InitCloudContext failed: %v", err)
+	}
+	if status.Name != "erun-003-123456789012-eu-west-2" {
+		t.Fatalf("expected incremented generated context name, got %+v", status)
+	}
+}

--- a/erun-common/cloud_test.go
+++ b/erun-common/cloud_test.go
@@ -1,0 +1,150 @@
+package eruncommon
+
+import (
+	"errors"
+	"testing"
+)
+
+type memoryCloudStore struct {
+	config ERunConfig
+	err    error
+}
+
+func (s *memoryCloudStore) LoadERunConfig() (ERunConfig, string, error) {
+	if s.err != nil {
+		return ERunConfig{}, "", s.err
+	}
+	return s.config, "", nil
+}
+
+func (s *memoryCloudStore) SaveERunConfig(config ERunConfig) error {
+	s.config = config
+	s.err = nil
+	return nil
+}
+
+func TestInitAWSCloudProviderStoresAliasInRootConfig(t *testing.T) {
+	store := &memoryCloudStore{err: ErrNotInitialized}
+	loginCalled := false
+	provider, err := InitAWSCloudProvider(Context{}, store, InitAWSCloudProviderParams{Profile: "dev"}, CloudDependencies{
+		RunAWSLogin: func(Context, string) error {
+			loginCalled = true
+			return nil
+		},
+		ResolveAWSIdentity: func(Context, string) (AWSIdentity, error) {
+			return AWSIdentity{
+				Account: "123456789012",
+				Arn:     "arn:aws:sts::123456789012:assumed-role/Admin/rihards",
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("InitAWSCloudProvider failed: %v", err)
+	}
+	if !loginCalled {
+		t.Fatal("expected AWS login to run")
+	}
+	if provider.Alias != "rihards+123456789012@aws" {
+		t.Fatalf("unexpected alias: %+v", provider)
+	}
+	if len(store.config.CloudProviders) != 1 || store.config.CloudProviders[0].Alias != provider.Alias {
+		t.Fatalf("expected provider to be saved in root config, got %+v", store.config)
+	}
+}
+
+func TestInitAWSCloudProviderCreatesProfileAndDerivesAliasFromLoginIdentity(t *testing.T) {
+	store := &memoryCloudStore{err: ErrNotInitialized}
+	var configuredProfile string
+	var loginProfile string
+	var identityProfile string
+	provider, err := InitAWSCloudProvider(Context{}, store, InitAWSCloudProviderParams{
+		SSOStartURL: "https://example.awsapps.com/start",
+		SSORegion:   "eu-west-1",
+		AccountID:   "123456789012",
+		RoleName:    "Admin",
+		Region:      "eu-west-1",
+	}, CloudDependencies{
+		RunAWSConfigureSSO: func(_ Context, config AWSProfileConfig) error {
+			configuredProfile = config.Profile
+			if config.SSOStartURL != "https://example.awsapps.com/start" || config.SSORegion != "eu-west-1" || config.AccountID != "123456789012" || config.RoleName != "Admin" || config.Region != "eu-west-1" {
+				t.Fatalf("unexpected AWS profile config: %+v", config)
+			}
+			return nil
+		},
+		RunAWSLogin: func(_ Context, profile string) error {
+			loginProfile = profile
+			return nil
+		},
+		ResolveAWSIdentity: func(_ Context, profile string) (AWSIdentity, error) {
+			identityProfile = profile
+			return AWSIdentity{
+				Account: "123456789012",
+				Arn:     "arn:aws:sts::123456789012:assumed-role/Admin/rihards",
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("InitAWSCloudProvider failed: %v", err)
+	}
+	if configuredProfile == "" {
+		t.Fatal("expected AWS SSO profile to be created")
+	}
+	if loginProfile != configuredProfile || identityProfile != configuredProfile || provider.Profile != configuredProfile {
+		t.Fatalf("expected one generated profile through configure/login/identity/save, got configure=%q login=%q identity=%q provider=%q", configuredProfile, loginProfile, identityProfile, provider.Profile)
+	}
+	if provider.Alias != "rihards+123456789012@aws" {
+		t.Fatalf("expected alias from identity, got %+v", provider)
+	}
+}
+
+func TestLoginCloudProviderAliasRunsLoginWhenStatusIsExpired(t *testing.T) {
+	store := &memoryCloudStore{config: ERunConfig{CloudProviders: []CloudProviderConfig{{
+		Alias:    "rihards+123456789012@aws",
+		Provider: CloudProviderAWS,
+		Profile:  "dev",
+	}}}}
+	loginCalled := false
+	checks := 0
+	status, err := LoginCloudProviderAlias(Context{}, store, CloudLoginParams{Alias: "rihards+123456789012@aws"}, CloudDependencies{
+		RunAWSLogin: func(Context, string) error {
+			loginCalled = true
+			return nil
+		},
+		CheckAWSStatus: func(_ Context, provider CloudProviderConfig) CloudProviderStatus {
+			checks++
+			if checks == 1 {
+				return CloudProviderStatus{CloudProviderConfig: provider, Status: CloudTokenStatusExpired}
+			}
+			return CloudProviderStatus{CloudProviderConfig: provider, Status: CloudTokenStatusActive}
+		},
+	})
+	if err != nil {
+		t.Fatalf("LoginCloudProviderAlias failed: %v", err)
+	}
+	if !loginCalled {
+		t.Fatal("expected AWS login to run")
+	}
+	if status.Status != CloudTokenStatusActive {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+}
+
+func TestListCloudProvidersTreatsMissingRootConfigAsEmpty(t *testing.T) {
+	providers, err := ListCloudProviders(&memoryCloudStore{err: ErrNotInitialized})
+	if err != nil {
+		t.Fatalf("ListCloudProviders failed: %v", err)
+	}
+	if len(providers) != 0 {
+		t.Fatalf("expected no providers, got %+v", providers)
+	}
+}
+
+func TestResolveCloudProviderRequiresConfiguredAlias(t *testing.T) {
+	_, err := ResolveCloudProvider(&memoryCloudStore{}, "missing@aws")
+	if err == nil {
+		t.Fatal("expected missing alias error")
+	}
+	if errors.Is(err, ErrNotInitialized) {
+		t.Fatalf("expected missing alias error, got %v", err)
+	}
+}

--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -18,7 +18,9 @@ const (
 )
 
 type ERunConfig struct {
-	DefaultTenant string
+	DefaultTenant  string
+	CloudProviders []CloudProviderConfig `yaml:"cloudproviders,omitempty"`
+	CloudContexts  []CloudContextConfig  `yaml:"cloudcontexts,omitempty"`
 }
 
 type SSHDConfig struct {
@@ -43,14 +45,15 @@ type TenantConfig struct {
 }
 
 type EnvConfig struct {
-	Name              string
-	RepoPath          string
-	KubernetesContext string
-	ContainerRegistry string
-	RuntimeVersion    string     `yaml:"runtimeversion,omitempty"`
-	SSHD              SSHDConfig `yaml:"sshd,omitempty"`
-	Remote            bool       `yaml:"remote,omitempty"`
-	Snapshot          *bool      `yaml:"snapshot,omitempty"`
+	Name               string
+	RepoPath           string
+	KubernetesContext  string
+	ContainerRegistry  string
+	CloudProviderAlias string     `yaml:"cloudprovideralias,omitempty"`
+	RuntimeVersion     string     `yaml:"runtimeversion,omitempty"`
+	SSHD               SSHDConfig `yaml:"sshd,omitempty"`
+	Remote             bool       `yaml:"remote,omitempty"`
+	Snapshot           *bool      `yaml:"snapshot,omitempty"`
 }
 
 func (c TenantConfig) SnapshotEnabled() bool {

--- a/erun-common/config_test.go
+++ b/erun-common/config_test.go
@@ -36,7 +36,7 @@ func TestSaveAndLoadERunConfig(t *testing.T) {
 		t.Fatalf("LoadERunConfig failed: %v", err)
 	}
 
-	if cfg != expected {
+	if !reflect.DeepEqual(cfg, expected) {
 		t.Fatalf("unexpected config: %+v", cfg)
 	}
 

--- a/erun-common/list.go
+++ b/erun-common/list.go
@@ -17,6 +17,7 @@ type ListResult struct {
 	ConfigDirectory  string                     `json:"configDirectory,omitempty"`
 	Defaults         ListDefaultsResult         `json:"defaults"`
 	CurrentDirectory ListCurrentDirectoryResult `json:"currentDirectory"`
+	CloudProviders   []CloudProviderStatus      `json:"cloudProviders,omitempty"`
 	Tenants          []ListTenantResult         `json:"tenants,omitempty"`
 }
 
@@ -34,13 +35,14 @@ type ListCurrentDirectoryResult struct {
 }
 
 type ListEffectiveTargetResult struct {
-	Tenant            string                `json:"tenant"`
-	Environment       string                `json:"environment"`
-	KubernetesContext string                `json:"kubernetesContext"`
-	RepoPath          string                `json:"repoPath"`
-	Snapshot          bool                  `json:"snapshot"`
-	LocalPorts        EnvironmentLocalPorts `json:"localPorts,omitempty"`
-	SSH               ListSSHResult         `json:"ssh,omitempty"`
+	Tenant             string                `json:"tenant"`
+	Environment        string                `json:"environment"`
+	KubernetesContext  string                `json:"kubernetesContext"`
+	CloudProviderAlias string                `json:"cloudProviderAlias,omitempty"`
+	RepoPath           string                `json:"repoPath"`
+	Snapshot           bool                  `json:"snapshot"`
+	LocalPorts         EnvironmentLocalPorts `json:"localPorts,omitempty"`
+	SSH                ListSSHResult         `json:"ssh,omitempty"`
 }
 
 type ListTenantResult struct {
@@ -52,15 +54,16 @@ type ListTenantResult struct {
 }
 
 type ListEnvironmentResult struct {
-	Name              string                `json:"name"`
-	KubernetesContext string                `json:"kubernetesContext,omitempty"`
-	RepoPath          string                `json:"repoPath,omitempty"`
-	RuntimeVersion    string                `json:"runtimeVersion,omitempty"`
-	Snapshot          bool                  `json:"snapshot"`
-	LocalPorts        EnvironmentLocalPorts `json:"localPorts,omitempty"`
-	IsDefault         bool                  `json:"isDefault,omitempty"`
-	IsEffective       bool                  `json:"isEffective,omitempty"`
-	SSH               ListSSHResult         `json:"ssh,omitempty"`
+	Name               string                `json:"name"`
+	KubernetesContext  string                `json:"kubernetesContext,omitempty"`
+	CloudProviderAlias string                `json:"cloudProviderAlias,omitempty"`
+	RepoPath           string                `json:"repoPath,omitempty"`
+	RuntimeVersion     string                `json:"runtimeVersion,omitempty"`
+	Snapshot           bool                  `json:"snapshot"`
+	LocalPorts         EnvironmentLocalPorts `json:"localPorts,omitempty"`
+	IsDefault          bool                  `json:"isDefault,omitempty"`
+	IsEffective        bool                  `json:"isEffective,omitempty"`
+	SSH                ListSSHResult         `json:"ssh,omitempty"`
 }
 
 type ListSSHResult struct {
@@ -112,13 +115,14 @@ func ResolveListResult(store ListStore, findProjectRoot ProjectFinderFunc, param
 		result.CurrentDirectory.EffectiveError = effectiveErr.Error()
 	} else {
 		result.CurrentDirectory.Effective = &ListEffectiveTargetResult{
-			Tenant:            effectiveResult.Tenant,
-			Environment:       effectiveResult.Environment,
-			KubernetesContext: strings.TrimSpace(effectiveResult.EnvConfig.KubernetesContext),
-			RepoPath:          effectiveResult.RepoPath,
-			Snapshot:          deployTargetSnapshotEnabled(effectiveResult, nil),
-			LocalPorts:        LocalPortsForResult(effectiveResult),
-			SSH:               listSSHResult(effectiveResult),
+			Tenant:             effectiveResult.Tenant,
+			Environment:        effectiveResult.Environment,
+			KubernetesContext:  strings.TrimSpace(effectiveResult.EnvConfig.KubernetesContext),
+			CloudProviderAlias: strings.TrimSpace(effectiveResult.EnvConfig.CloudProviderAlias),
+			RepoPath:           effectiveResult.RepoPath,
+			Snapshot:           deployTargetSnapshotEnabled(effectiveResult, nil),
+			LocalPorts:         LocalPortsForResult(effectiveResult),
+			SSH:                listSSHResult(effectiveResult),
 		}
 	}
 
@@ -126,6 +130,11 @@ func ResolveListResult(store ListStore, findProjectRoot ProjectFinderFunc, param
 	if err != nil {
 		return ListResult{}, err
 	}
+	cloudProviders, err := ListCloudProviderStatuses(store, CloudDependencies{})
+	if err != nil {
+		return ListResult{}, err
+	}
+	result.CloudProviders = cloudProviders
 
 	for _, tenant := range tenants {
 		envs, err := store.ListEnvConfigs(tenant.Name)
@@ -149,14 +158,15 @@ func ResolveListResult(store ListStore, findProjectRoot ProjectFinderFunc, param
 				}
 			}
 			tenantResult.Environments = append(tenantResult.Environments, ListEnvironmentResult{
-				Name:              env.Name,
-				KubernetesContext: strings.TrimSpace(env.KubernetesContext),
-				RepoPath:          strings.TrimSpace(env.RepoPath),
-				RuntimeVersion:    strings.TrimSpace(env.RuntimeVersion),
-				Snapshot:          env.SnapshotEnabled(),
-				LocalPorts:        localPorts,
-				IsDefault:         env.Name == tenant.DefaultEnvironment,
-				IsEffective:       effectiveErr == nil && tenant.Name == effectiveResult.Tenant && env.Name == effectiveResult.Environment,
+				Name:               env.Name,
+				KubernetesContext:  strings.TrimSpace(env.KubernetesContext),
+				CloudProviderAlias: strings.TrimSpace(env.CloudProviderAlias),
+				RepoPath:           strings.TrimSpace(env.RepoPath),
+				RuntimeVersion:     strings.TrimSpace(env.RuntimeVersion),
+				Snapshot:           env.SnapshotEnabled(),
+				LocalPorts:         localPorts,
+				IsDefault:          env.Name == tenant.DefaultEnvironment,
+				IsEffective:        effectiveErr == nil && tenant.Name == effectiveResult.Tenant && env.Name == effectiveResult.Environment,
 				SSH: listSSHResult(OpenResult{
 					Tenant:      tenant.Name,
 					Environment: env.Name,

--- a/erun-mcp/cloud.go
+++ b/erun-mcp/cloud.go
@@ -1,0 +1,103 @@
+package erunmcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+type CloudListInput struct {
+	Verbosity int `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+}
+
+type CloudInitAWSInput struct {
+	SSOStartURL string `json:"ssoStartUrl" jsonschema:"AWS IAM Identity Center start URL"`
+	SSORegion   string `json:"ssoRegion" jsonschema:"AWS IAM Identity Center region"`
+	AccountID   string `json:"accountId" jsonschema:"AWS account ID to use for SSO login"`
+	RoleName    string `json:"roleName" jsonschema:"AWS role name to use for SSO login"`
+	Region      string `json:"region,omitempty" jsonschema:"default AWS region for the generated configuration; defaults to ssoRegion"`
+	Preview     bool   `json:"preview,omitempty" jsonschema:"when true, return the planned operation without executing login or saving config"`
+	Verbosity   int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+}
+
+type CloudLoginInput struct {
+	Alias     string `json:"alias" jsonschema:"configured cloud provider alias to login"`
+	Preview   bool   `json:"preview,omitempty" jsonschema:"when true, return the planned operation without executing login"`
+	Verbosity int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+}
+
+type CloudListResult struct {
+	CloudProviders []eruncommon.CloudProviderStatus `json:"cloudProviders,omitempty"`
+}
+
+type CloudActionResult struct {
+	Preview  bool                           `json:"preview"`
+	Alias    string                         `json:"alias,omitempty"`
+	Provider eruncommon.CloudProviderStatus `json:"provider,omitempty"`
+	Trace    []string                       `json:"trace,omitempty"`
+	Plan     []string                       `json:"plan,omitempty"`
+}
+
+func cloudListTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, CloudListInput) (*mcp.CallToolResult, CloudListResult, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input CloudListInput) (*mcp.CallToolResult, CloudListResult, error) {
+		statuses, err := eruncommon.ListCloudProviderStatuses(runtime.Store, eruncommon.CloudDependencies{})
+		if err != nil {
+			return nil, CloudListResult{}, err
+		}
+		return nil, CloudListResult{CloudProviders: statuses}, nil
+	}
+}
+
+func cloudInitAWSTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, CloudInitAWSInput) (*mcp.CallToolResult, CloudActionResult, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input CloudInitAWSInput) (*mcp.CallToolResult, CloudActionResult, error) {
+		traceOutput := strings.Builder{}
+		ctx := runtimeCallContext(input.Preview, input.Verbosity, nil, &traceOutput, &traceOutput)
+		params := eruncommon.InitAWSCloudProviderParams{
+			SSOStartURL: input.SSOStartURL,
+			SSORegion:   input.SSORegion,
+			AccountID:   input.AccountID,
+			RoleName:    input.RoleName,
+			Region:      input.Region,
+		}
+		if input.Preview {
+			plan := []string{
+				"aws configure set sso_start_url " + strings.TrimSpace(input.SSOStartURL) + " --profile erun-sso-<timestamp>",
+				"aws configure set sso_region " + strings.TrimSpace(input.SSORegion) + " --profile erun-sso-<timestamp>",
+				"aws configure set sso_account_id " + strings.TrimSpace(input.AccountID) + " --profile erun-sso-<timestamp>",
+				"aws configure set sso_role_name " + strings.TrimSpace(input.RoleName) + " --profile erun-sso-<timestamp>",
+				"aws sso login --profile erun-sso-<timestamp>",
+				"aws sts get-caller-identity --profile erun-sso-<timestamp>",
+				"save root cloud provider alias resolved from AWS identity",
+			}
+			return nil, CloudActionResult{Preview: true, Plan: plan}, nil
+		}
+		provider, err := eruncommon.InitAWSCloudProvider(ctx, runtime.Store, params, eruncommon.CloudDependencies{})
+		if err != nil {
+			return nil, CloudActionResult{}, err
+		}
+		status := eruncommon.CloudProviderTokenStatus(provider, eruncommon.CloudDependencies{})
+		return nil, CloudActionResult{Alias: provider.Alias, Provider: status, Trace: normalizeTraceLines(traceOutput.String())}, nil
+	}
+}
+
+func cloudLoginTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, CloudLoginInput) (*mcp.CallToolResult, CloudActionResult, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input CloudLoginInput) (*mcp.CallToolResult, CloudActionResult, error) {
+		alias := strings.TrimSpace(input.Alias)
+		if alias == "" {
+			return nil, CloudActionResult{}, fmt.Errorf("cloud provider alias is required")
+		}
+		traceOutput := strings.Builder{}
+		ctx := runtimeCallContext(input.Preview, input.Verbosity, nil, &traceOutput, &traceOutput)
+		if input.Preview {
+			return nil, CloudActionResult{Preview: true, Alias: alias, Plan: []string{"check cloud provider token status", "run provider login if token is expired"}}, nil
+		}
+		status, err := eruncommon.LoginCloudProviderAlias(ctx, runtime.Store, eruncommon.CloudLoginParams{Alias: alias}, eruncommon.CloudDependencies{})
+		if err != nil {
+			return nil, CloudActionResult{}, err
+		}
+		return nil, CloudActionResult{Alias: alias, Provider: status, Trace: normalizeTraceLines(traceOutput.String())}, nil
+	}
+}

--- a/erun-mcp/context.go
+++ b/erun-mcp/context.go
@@ -1,0 +1,102 @@
+package erunmcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+type ContextListInput struct {
+	Verbosity int `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+}
+
+type ContextInitInput struct {
+	Name               string `json:"name,omitempty" jsonschema:"Kubernetes context name to create"`
+	CloudProviderAlias string `json:"cloudProviderAlias" jsonschema:"cloud provider alias to use"`
+	Region             string `json:"region" jsonschema:"cloud region for the context"`
+	InstanceType       string `json:"instanceType,omitempty" jsonschema:"EC2 instance type; defaults to c8gd.2xlarge"`
+	DiskType           string `json:"diskType,omitempty" jsonschema:"root disk type; defaults to gp3"`
+	DiskSizeGB         int    `json:"diskSizeGb,omitempty" jsonschema:"root disk size in GB; supported values are 100 and 200"`
+	SubnetID           string `json:"subnetId,omitempty" jsonschema:"optional EC2 subnet ID"`
+	SecurityGroupID    string `json:"securityGroupId,omitempty" jsonschema:"optional EC2 security group ID"`
+	KeyName            string `json:"keyName,omitempty" jsonschema:"optional EC2 key pair name"`
+	Preview            bool   `json:"preview,omitempty" jsonschema:"when true, return the planned operation without creating cloud resources"`
+	Verbosity          int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+}
+
+type ContextActionInput struct {
+	Name      string `json:"name" jsonschema:"managed cloud context name"`
+	Preview   bool   `json:"preview,omitempty" jsonschema:"when true, return the planned operation without changing cloud resources"`
+	Verbosity int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+}
+
+type ContextListResult struct {
+	CloudContexts []eruncommon.CloudContextStatus `json:"cloudContexts,omitempty"`
+}
+
+type ContextActionResult struct {
+	Preview bool                          `json:"preview"`
+	Context eruncommon.CloudContextStatus `json:"context,omitempty"`
+	Trace   []string                      `json:"trace,omitempty"`
+}
+
+func contextListTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, ContextListInput) (*mcp.CallToolResult, ContextListResult, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input ContextListInput) (*mcp.CallToolResult, ContextListResult, error) {
+		contexts, err := eruncommon.ListCloudContextStatuses(runtime.Store)
+		if err != nil {
+			return nil, ContextListResult{}, err
+		}
+		return nil, ContextListResult{CloudContexts: contexts}, nil
+	}
+}
+
+func contextInitTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, ContextInitInput) (*mcp.CallToolResult, ContextActionResult, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input ContextInitInput) (*mcp.CallToolResult, ContextActionResult, error) {
+		if strings.TrimSpace(input.CloudProviderAlias) == "" {
+			return nil, ContextActionResult{}, fmt.Errorf("cloud provider alias is required")
+		}
+		traceOutput := strings.Builder{}
+		ctx := runtimeCallContext(input.Preview, input.Verbosity, nil, &traceOutput, &traceOutput)
+		status, err := eruncommon.InitCloudContext(ctx, runtime.Store, eruncommon.InitCloudContextParams{
+			Name:               input.Name,
+			CloudProviderAlias: input.CloudProviderAlias,
+			Region:             input.Region,
+			InstanceType:       input.InstanceType,
+			DiskType:           input.DiskType,
+			DiskSizeGB:         input.DiskSizeGB,
+			SubnetID:           input.SubnetID,
+			SecurityGroupID:    input.SecurityGroupID,
+			KeyName:            input.KeyName,
+		}, eruncommon.CloudContextDependencies{})
+		if err != nil {
+			return nil, ContextActionResult{}, err
+		}
+		return nil, ContextActionResult{Preview: input.Preview, Context: status, Trace: normalizeTraceLines(traceOutput.String())}, nil
+	}
+}
+
+func contextStopTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, ContextActionInput) (*mcp.CallToolResult, ContextActionResult, error) {
+	return contextPowerTool(runtime, eruncommon.StopCloudContext)
+}
+
+func contextStartTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, ContextActionInput) (*mcp.CallToolResult, ContextActionResult, error) {
+	return contextPowerTool(runtime, eruncommon.StartCloudContext)
+}
+
+func contextPowerTool(runtime RuntimeConfig, run func(eruncommon.Context, eruncommon.CloudContextStore, eruncommon.CloudContextParams, eruncommon.CloudContextDependencies) (eruncommon.CloudContextStatus, error)) func(context.Context, *mcp.CallToolRequest, ContextActionInput) (*mcp.CallToolResult, ContextActionResult, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input ContextActionInput) (*mcp.CallToolResult, ContextActionResult, error) {
+		if strings.TrimSpace(input.Name) == "" {
+			return nil, ContextActionResult{}, fmt.Errorf("cloud context name is required")
+		}
+		traceOutput := strings.Builder{}
+		ctx := runtimeCallContext(input.Preview, input.Verbosity, nil, &traceOutput, &traceOutput)
+		status, err := run(ctx, runtime.Store, eruncommon.CloudContextParams{Name: input.Name}, eruncommon.CloudContextDependencies{})
+		if err != nil {
+			return nil, ContextActionResult{}, err
+		}
+		return nil, ContextActionResult{Preview: input.Preview, Context: status, Trace: normalizeTraceLines(traceOutput.String())}, nil
+	}
+}

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -114,6 +114,34 @@ func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig) *mcp.Server {
 		Description: "List configured tenants and environments, defaults, and the effective target for the current runtime directory",
 	}, listTool(runtime))
 	mcp.AddTool(server, &mcp.Tool{
+		Name:        "cloud_list",
+		Description: "List configured root-level cloud provider aliases and token status",
+	}, cloudListTool(runtime))
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "cloud_init_aws",
+		Description: "Initialize an AWS SSO cloud provider alias in root ERun config, with preview support",
+	}, cloudInitAWSTool(runtime))
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "cloud_login",
+		Description: "Login to a configured cloud provider alias, with preview support",
+	}, cloudLoginTool(runtime))
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "context_list",
+		Description: "List managed ERun cloud Kubernetes contexts",
+	}, contextListTool(runtime))
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "context_init",
+		Description: "Initialize a managed cloud k3s Kubernetes context, with preview support",
+	}, contextInitTool(runtime))
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "context_stop",
+		Description: "Stop a managed ERun cloud Kubernetes context, with preview support",
+	}, contextStopTool(runtime))
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "context_start",
+		Description: "Start a managed ERun cloud Kubernetes context, with preview support",
+	}, contextStartTool(runtime))
+	mcp.AddTool(server, &mcp.Tool{
 		Name:        "init",
 		Description: "Run `erun init` using the shared init flow; when more input is needed, return a structured interaction request for the caller to answer in a follow-up tool call",
 	}, initTool(runtime))

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -157,7 +157,7 @@ func TestHTTPHandlerExposesVersionTool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTools failed: %v", err)
 	}
-	if len(tools.Tools) != 11 {
+	if len(tools.Tools) != 18 {
 		t.Fatalf("unexpected tools: %+v", tools.Tools)
 	}
 

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -96,7 +96,9 @@ type uiBuildDetails struct {
 type uiVersion = eruncommon.RuntimeVersionSuggestion
 
 type uiERunConfig struct {
-	DefaultTenant string `json:"defaultTenant"`
+	DefaultTenant  string                  `json:"defaultTenant"`
+	CloudProviders []uiCloudProviderStatus `json:"cloudProviders,omitempty"`
+	CloudContexts  []uiCloudContextStatus  `json:"cloudContexts,omitempty"`
 }
 
 type uiTenantConfig struct {
@@ -125,15 +127,59 @@ type uiPortStatus struct {
 }
 
 type uiEnvironmentConfig struct {
-	Name              string                  `json:"name"`
-	RepoPath          string                  `json:"repoPath"`
-	KubernetesContext string                  `json:"kubernetesContext"`
-	ContainerRegistry string                  `json:"containerRegistry"`
-	RuntimeVersion    string                  `json:"runtimeVersion"`
-	SSHD              uiSSHDConfig            `json:"sshd"`
-	LocalPorts        uiEnvironmentLocalPorts `json:"localPorts"`
-	Remote            bool                    `json:"remote"`
-	Snapshot          bool                    `json:"snapshot"`
+	Name               string                  `json:"name"`
+	RepoPath           string                  `json:"repoPath"`
+	KubernetesContext  string                  `json:"kubernetesContext"`
+	ContainerRegistry  string                  `json:"containerRegistry"`
+	CloudProviderAlias string                  `json:"cloudProviderAlias"`
+	RuntimeVersion     string                  `json:"runtimeVersion"`
+	SSHD               uiSSHDConfig            `json:"sshd"`
+	LocalPorts         uiEnvironmentLocalPorts `json:"localPorts"`
+	Remote             bool                    `json:"remote"`
+	Snapshot           bool                    `json:"snapshot"`
+}
+
+type uiCloudProviderStatus struct {
+	Alias     string `json:"alias"`
+	Provider  string `json:"provider"`
+	Username  string `json:"username,omitempty"`
+	AccountID string `json:"accountId,omitempty"`
+	Profile   string `json:"profile,omitempty"`
+	Status    string `json:"status"`
+	Message   string `json:"message,omitempty"`
+}
+
+type uiCloudContextStatus struct {
+	Name               string `json:"name"`
+	Provider           string `json:"provider"`
+	CloudProviderAlias string `json:"cloudProviderAlias"`
+	Region             string `json:"region"`
+	InstanceID         string `json:"instanceId,omitempty"`
+	PublicIP           string `json:"publicIp,omitempty"`
+	InstanceType       string `json:"instanceType"`
+	DiskType           string `json:"diskType"`
+	DiskSizeGB         int    `json:"diskSizeGb"`
+	KubernetesContext  string `json:"kubernetesContext"`
+	Status             string `json:"status"`
+	Message            string `json:"message,omitempty"`
+}
+
+type uiAWSCloudAliasInput struct {
+	Alias       string `json:"alias,omitempty"`
+	Username    string `json:"username,omitempty"`
+	AccountID   string `json:"accountId,omitempty"`
+	Profile     string `json:"profile,omitempty"`
+	SSORegion   string `json:"ssoRegion,omitempty"`
+	SSOStartURL string `json:"ssoStartUrl,omitempty"`
+}
+
+type uiCloudContextInitInput struct {
+	Name               string `json:"name,omitempty"`
+	CloudProviderAlias string `json:"cloudProviderAlias"`
+	Region             string `json:"region"`
+	InstanceType       string `json:"instanceType"`
+	DiskType           string `json:"diskType"`
+	DiskSizeGB         int    `json:"diskSizeGb"`
 }
 
 type startSessionResult struct {
@@ -325,13 +371,105 @@ func (a *App) LoadERunConfig() (uiERunConfig, error) {
 }
 
 func (a *App) SaveERunConfig(config uiERunConfig) (uiERunConfig, error) {
+	existing, _, err := a.deps.store.LoadERunConfig()
+	if errors.Is(err, eruncommon.ErrNotInitialized) {
+		existing = eruncommon.ERunConfig{}
+	} else if err != nil {
+		return uiERunConfig{}, err
+	}
 	updated := eruncommon.ERunConfig{
-		DefaultTenant: strings.TrimSpace(config.DefaultTenant),
+		DefaultTenant:  strings.TrimSpace(config.DefaultTenant),
+		CloudProviders: existing.CloudProviders,
+		CloudContexts:  existing.CloudContexts,
 	}
 	if err := a.deps.store.SaveERunConfig(updated); err != nil {
 		return uiERunConfig{}, err
 	}
 	return erunConfigToUI(updated), nil
+}
+
+func (a *App) LoadCloudProviderStatuses() ([]uiCloudProviderStatus, error) {
+	statuses, err := eruncommon.ListCloudProviderStatuses(a.deps.store, eruncommon.CloudDependencies{})
+	if err != nil {
+		return nil, err
+	}
+	return cloudProviderStatusesToUI(statuses), nil
+}
+
+func (a *App) LoadCloudContextStatuses() ([]uiCloudContextStatus, error) {
+	statuses, err := eruncommon.ListCloudContextStatuses(a.deps.store)
+	if err != nil {
+		return nil, err
+	}
+	return cloudContextStatusesToUI(statuses), nil
+}
+
+func (a *App) InitCloudContext(input uiCloudContextInitInput) (uiCloudContextStatus, error) {
+	status, err := eruncommon.InitCloudContext(eruncommon.Context{}, a.deps.store, eruncommon.InitCloudContextParams{
+		Name:               strings.TrimSpace(input.Name),
+		CloudProviderAlias: strings.TrimSpace(input.CloudProviderAlias),
+		Region:             strings.TrimSpace(input.Region),
+		InstanceType:       strings.TrimSpace(input.InstanceType),
+		DiskType:           strings.TrimSpace(input.DiskType),
+		DiskSizeGB:         input.DiskSizeGB,
+	}, eruncommon.CloudContextDependencies{})
+	if err != nil {
+		return uiCloudContextStatus{}, err
+	}
+	return cloudContextStatusToUI(status), nil
+}
+
+func (a *App) StopCloudContext(name string) (uiCloudContextStatus, error) {
+	status, err := eruncommon.StopCloudContext(eruncommon.Context{}, a.deps.store, eruncommon.CloudContextParams{Name: name}, eruncommon.CloudContextDependencies{})
+	if err != nil {
+		return uiCloudContextStatus{}, err
+	}
+	return cloudContextStatusToUI(status), nil
+}
+
+func (a *App) StartCloudContext(name string) (uiCloudContextStatus, error) {
+	status, err := eruncommon.StartCloudContext(eruncommon.Context{}, a.deps.store, eruncommon.CloudContextParams{Name: name}, eruncommon.CloudContextDependencies{})
+	if err != nil {
+		return uiCloudContextStatus{}, err
+	}
+	return cloudContextStatusToUI(status), nil
+}
+
+func (a *App) SaveAWSCloudProviderAlias(input uiAWSCloudAliasInput) (uiCloudProviderStatus, error) {
+	provider, err := eruncommon.SaveCloudProviderConfig(a.deps.store, eruncommon.CloudProviderConfig{
+		Alias:       strings.TrimSpace(input.Alias),
+		Provider:    eruncommon.CloudProviderAWS,
+		Username:    strings.TrimSpace(input.Username),
+		AccountID:   strings.TrimSpace(input.AccountID),
+		Profile:     strings.TrimSpace(input.Profile),
+		SSORegion:   strings.TrimSpace(input.SSORegion),
+		SSOStartURL: strings.TrimSpace(input.SSOStartURL),
+	})
+	if err != nil {
+		return uiCloudProviderStatus{}, err
+	}
+	return cloudProviderStatusToUI(eruncommon.CloudProviderTokenStatus(provider, eruncommon.CloudDependencies{})), nil
+}
+
+func (a *App) InitAWSCloudProvider(input uiAWSCloudAliasInput) (uiCloudProviderStatus, error) {
+	if strings.TrimSpace(input.Username) != "" || strings.TrimSpace(input.AccountID) != "" {
+		return a.SaveAWSCloudProviderAlias(input)
+	}
+	provider, err := eruncommon.InitAWSCloudProvider(eruncommon.Context{}, a.deps.store, eruncommon.InitAWSCloudProviderParams{
+		Profile: strings.TrimSpace(input.Profile),
+	}, eruncommon.CloudDependencies{})
+	if err != nil {
+		return uiCloudProviderStatus{}, err
+	}
+	return cloudProviderStatusToUI(eruncommon.CloudProviderTokenStatus(provider, eruncommon.CloudDependencies{})), nil
+}
+
+func (a *App) LoginCloudProvider(alias string) (uiCloudProviderStatus, error) {
+	status, err := eruncommon.LoginCloudProviderAlias(eruncommon.Context{}, a.deps.store, eruncommon.CloudLoginParams{Alias: alias}, eruncommon.CloudDependencies{})
+	if err != nil {
+		return uiCloudProviderStatus{}, err
+	}
+	return cloudProviderStatusToUI(status), nil
 }
 
 func (a *App) LoadTenantConfig(tenant string) (uiTenantConfig, error) {
@@ -421,7 +559,9 @@ func labelRuntimeVersionSuggestions(source, image string, suggestions []uiVersio
 
 func erunConfigToUI(config eruncommon.ERunConfig) uiERunConfig {
 	return uiERunConfig{
-		DefaultTenant: strings.TrimSpace(config.DefaultTenant),
+		DefaultTenant:  strings.TrimSpace(config.DefaultTenant),
+		CloudProviders: cloudProviderStatusesToUI(statusesForCloudProviders(config.CloudProviders)),
+		CloudContexts:  cloudContextStatusesToUI(statusesForCloudContexts(config.CloudContexts)),
 	}
 }
 
@@ -453,11 +593,12 @@ func environmentConfigToUI(config eruncommon.EnvConfig, fallbackName string, por
 		LocalPorts: ports,
 	})
 	result := uiEnvironmentConfig{
-		Name:              name,
-		RepoPath:          strings.TrimSpace(config.RepoPath),
-		KubernetesContext: strings.TrimSpace(config.KubernetesContext),
-		ContainerRegistry: strings.TrimSpace(config.ContainerRegistry),
-		RuntimeVersion:    strings.TrimSpace(config.RuntimeVersion),
+		Name:               name,
+		RepoPath:           strings.TrimSpace(config.RepoPath),
+		KubernetesContext:  strings.TrimSpace(config.KubernetesContext),
+		ContainerRegistry:  strings.TrimSpace(config.ContainerRegistry),
+		CloudProviderAlias: strings.TrimSpace(config.CloudProviderAlias),
+		RuntimeVersion:     strings.TrimSpace(config.RuntimeVersion),
 		SSHD: uiSSHDConfig{
 			Enabled:       config.SSHD.Enabled,
 			LocalPort:     config.SSHD.LocalPort,
@@ -501,8 +642,71 @@ func canConnectLocalTCP(port int) bool {
 
 func environmentConfigFromUI(config uiEnvironmentConfig, existing eruncommon.EnvConfig) eruncommon.EnvConfig {
 	existing.Name = strings.TrimSpace(config.Name)
+	existing.CloudProviderAlias = strings.TrimSpace(config.CloudProviderAlias)
 	existing.SetSnapshot(config.Snapshot)
 	return existing
+}
+
+func statusesForCloudProviders(providers []eruncommon.CloudProviderConfig) []eruncommon.CloudProviderStatus {
+	statuses := make([]eruncommon.CloudProviderStatus, 0, len(providers))
+	for _, provider := range providers {
+		statuses = append(statuses, eruncommon.CloudProviderTokenStatus(provider, eruncommon.CloudDependencies{}))
+	}
+	return statuses
+}
+
+func cloudProviderStatusesToUI(statuses []eruncommon.CloudProviderStatus) []uiCloudProviderStatus {
+	result := make([]uiCloudProviderStatus, 0, len(statuses))
+	for _, status := range statuses {
+		result = append(result, cloudProviderStatusToUI(status))
+	}
+	return result
+}
+
+func cloudProviderStatusToUI(status eruncommon.CloudProviderStatus) uiCloudProviderStatus {
+	return uiCloudProviderStatus{
+		Alias:     strings.TrimSpace(status.Alias),
+		Provider:  strings.TrimSpace(status.Provider),
+		Username:  strings.TrimSpace(status.Username),
+		AccountID: strings.TrimSpace(status.AccountID),
+		Profile:   strings.TrimSpace(status.Profile),
+		Status:    strings.TrimSpace(status.Status),
+		Message:   strings.TrimSpace(status.Message),
+	}
+}
+
+func statusesForCloudContexts(contexts []eruncommon.CloudContextConfig) []eruncommon.CloudContextStatus {
+	statuses := make([]eruncommon.CloudContextStatus, 0, len(contexts))
+	for _, context := range contexts {
+		statuses = append(statuses, eruncommon.CloudContextStatus{CloudContextConfig: eruncommon.NormalizeCloudContextConfig(context)})
+	}
+	return statuses
+}
+
+func cloudContextStatusesToUI(statuses []eruncommon.CloudContextStatus) []uiCloudContextStatus {
+	result := make([]uiCloudContextStatus, 0, len(statuses))
+	for _, status := range statuses {
+		result = append(result, cloudContextStatusToUI(status))
+	}
+	return result
+}
+
+func cloudContextStatusToUI(status eruncommon.CloudContextStatus) uiCloudContextStatus {
+	context := eruncommon.NormalizeCloudContextConfig(status.CloudContextConfig)
+	return uiCloudContextStatus{
+		Name:               strings.TrimSpace(context.Name),
+		Provider:           strings.TrimSpace(context.Provider),
+		CloudProviderAlias: strings.TrimSpace(context.CloudProviderAlias),
+		Region:             strings.TrimSpace(context.Region),
+		InstanceID:         strings.TrimSpace(context.InstanceID),
+		PublicIP:           strings.TrimSpace(context.PublicIP),
+		InstanceType:       strings.TrimSpace(context.InstanceType),
+		DiskType:           strings.TrimSpace(context.DiskType),
+		DiskSizeGB:         context.DiskSizeGB,
+		KubernetesContext:  strings.TrimSpace(context.KubernetesContext),
+		Status:             strings.TrimSpace(context.Status),
+		Message:            strings.TrimSpace(status.Message),
+	}
 }
 
 func (a *App) StartSession(selection uiSelection, cols, rows int) (startSessionResult, error) {
@@ -589,6 +793,55 @@ func (a *App) StartDeploySession(selection uiSelection, cols, rows int) (startSe
 		return startSessionResult{}, err
 	}
 	return a.startCommandSession(selection, cols, rows, deploySelectionKey(selection), buildDeployArgs(selection.Tenant, selection.Environment, selection.Version, selection.RuntimeImage), resolveDeployStartDir(a.deps.findProjectRoot, result), []string{appSessionEnvVar + "=1"})
+}
+
+func (a *App) StartCloudInitAWSSession(cols, rows int) (startSessionResult, error) {
+	if cols <= 0 {
+		cols = 120
+	}
+	if rows <= 0 {
+		rows = 34
+	}
+	key := "cloud/init/aws"
+
+	a.mu.Lock()
+	if existing := a.sessions[key]; existing != nil && !existing.closed && existing.session != nil {
+		a.current = existing
+		a.mu.Unlock()
+		return startSessionResult{
+			SessionID: existing.serial,
+			Selection: existing.selection,
+		}, nil
+	}
+	a.mu.Unlock()
+
+	session, err := a.deps.startTerminal(startTerminalSessionParams{
+		Dir:        resolveTerminalStartDir(""),
+		Executable: a.deps.resolveCLIPath(),
+		Args:       buildCloudInitAWSArgs(),
+		Env:        []string{appSessionEnvVar + "=1"},
+		Cols:       cols,
+		Rows:       rows,
+	})
+	if err != nil {
+		return startSessionResult{}, err
+	}
+
+	a.mu.Lock()
+	a.nextSerial++
+	serial := a.nextSerial
+	managed := &managedTerminal{
+		session: session,
+		key:     key,
+		serial:  serial,
+	}
+	a.sessions[key] = managed
+	a.current = managed
+	a.mu.Unlock()
+
+	go a.streamSession(managed)
+
+	return startSessionResult{SessionID: serial}, nil
 }
 
 func (a *App) DeleteEnvironment(selection uiSelection, confirmation string) (deleteEnvironmentResult, error) {

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -4,7 +4,10 @@ import { Terminal } from '@xterm/xterm';
 
 import {
   DeleteEnvironment,
+  InitCloudContext,
   LoadDiff,
+  LoadCloudContextStatuses,
+  LoadCloudProviderStatuses,
   LoadEnvironmentConfig,
   LoadERunConfig,
   LoadKubernetesContexts,
@@ -12,14 +15,18 @@ import {
   LoadTenantConfig,
   LoadVersionSuggestions,
   ResizeSession,
+  LoginCloudProvider,
   SavePastedImage,
   SaveEnvironmentConfig,
   SaveERunConfig,
   SaveTenantConfig,
   SendSessionInput,
+  StartCloudContext,
+  StartCloudInitAWSSession,
   StartDeploySession,
   StartInitSession,
   StartSession,
+  StopCloudContext,
 } from '../../wailsjs/go/main/App';
 import { ClipboardSetText, EventsOn, WindowToggleMaximise } from '../../wailsjs/runtime/runtime';
 import { fileToBase64, decodeBase64Bytes, isTerminalPasteTarget, pastedImageFiles } from './clipboard';
@@ -38,6 +45,7 @@ import {
   SIDEBAR_WIDTH_STORAGE_KEY,
   defaultEnvironmentConfig,
   defaultEnvironmentDialog,
+  defaultCloudContextInitInput,
   defaultGlobalConfigDialog,
   defaultManageDialog,
   defaultTenantDialog,
@@ -57,6 +65,9 @@ import type {
   StartSessionResult,
   TerminalExitPayload,
   TerminalOutputPayload,
+  UICloudContextInitInput,
+  UICloudContextStatus,
+  UICloudProviderStatus,
   UIERunConfig,
   UIEnvironmentConfig,
   UISelection,
@@ -107,6 +118,7 @@ export class ERunUIController {
   private readonly initSessionSelections = new Map<number, UISelection>();
   private readonly deploySessionSelections = new Map<number, UISelection>();
   private readonly openSessionSelections = new Map<number, UISelection>();
+  private readonly cloudInitSessions = new Set<number>();
   private readonly selectionSessions = new Map<string, number>();
   private readonly sessionBuffers = new Map<number, Uint8Array[]>();
   private readonly sessionExitReasons = new Map<number, string>();
@@ -709,7 +721,10 @@ export class ERunUIController {
       open: true,
       config: {
         defaultTenant: '',
+        cloudProviders: [],
+        cloudContexts: [],
       },
+      cloudContextDraft: defaultCloudContextInitInput(),
       configLoading: true,
       busy: false,
       error: '',
@@ -751,6 +766,18 @@ export class ERunUIController {
     });
   }
 
+  updateCloudContextDraft(values: Partial<UICloudContextInitInput>): void {
+    if (this.state.globalConfigDialog.busy || this.state.globalConfigDialog.configLoading) {
+      return;
+    }
+    this.updateGlobalConfigDialog({
+      cloudContextDraft: {
+        ...this.state.globalConfigDialog.cloudContextDraft,
+        ...values,
+      },
+    });
+  }
+
   async loadGlobalConfig(): Promise<void> {
     const dialog = this.state.globalConfigDialog;
     if (!dialog.open) {
@@ -767,6 +794,7 @@ export class ERunUIController {
       this.state.globalConfigDialog = {
         ...this.state.globalConfigDialog,
         config: result,
+        cloudContextDraft: cloudContextDraftForConfig(result, this.state.globalConfigDialog.cloudContextDraft),
         configLoading: false,
         error: '',
       };
@@ -781,6 +809,203 @@ export class ERunUIController {
     }
   }
 
+  async refreshCloudProviders(): Promise<void> {
+    const dialog = this.state.globalConfigDialog;
+    if (!dialog.open || dialog.busy) {
+      return;
+    }
+    try {
+      const cloudProviders = await LoadCloudProviderStatuses();
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        config: {
+          ...this.state.globalConfigDialog.config,
+          cloudProviders,
+        },
+        error: '',
+      };
+      this.emit();
+    } catch (error) {
+      const message = readError(error);
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        error: message,
+      };
+      this.showTerminalMessage(message);
+      this.emit();
+    }
+  }
+
+  async refreshCloudContexts(): Promise<void> {
+    const dialog = this.state.globalConfigDialog;
+    if (!dialog.open || dialog.busy) {
+      return;
+    }
+    try {
+      const cloudContexts = await LoadCloudContextStatuses();
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        config: {
+          ...this.state.globalConfigDialog.config,
+          cloudContexts,
+        },
+        error: '',
+      };
+      this.emit();
+    } catch (error) {
+      const message = readError(error);
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        error: message,
+      };
+      this.showTerminalMessage(message);
+      this.emit();
+    }
+  }
+
+  async initCloudContext(): Promise<void> {
+    const dialog = this.state.globalConfigDialog;
+    if (dialog.busy || dialog.configLoading) {
+      return;
+    }
+    this.state.globalConfigDialog = { ...dialog, busy: true, error: '' };
+    this.emit();
+    try {
+      const context = (await InitCloudContext(dialog.cloudContextDraft)) as UICloudContextStatus;
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        config: {
+          ...this.state.globalConfigDialog.config,
+          cloudContexts: replaceCloudContext(this.state.globalConfigDialog.config.cloudContexts || [], context),
+        },
+        cloudContextDraft: cloudContextDraftForConfig(this.state.globalConfigDialog.config, {
+          ...defaultCloudContextInitInput(),
+          cloudProviderAlias: dialog.cloudContextDraft.cloudProviderAlias,
+          region: dialog.cloudContextDraft.region,
+        }),
+        busy: false,
+        error: '',
+      };
+      this.showTerminalMessage(`Initialized cloud context ${context.kubernetesContext}.`);
+      void this.refreshKubernetesContexts();
+      this.emit();
+    } catch (error) {
+      const message = readError(error);
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        busy: false,
+        error: message,
+      };
+      this.showTerminalMessage(message);
+      this.emit();
+    }
+  }
+
+  async stopCloudContext(name: string): Promise<void> {
+    await this.updateCloudContextPower(name, StopCloudContext, 'Stopped');
+  }
+
+  async startCloudContext(name: string): Promise<void> {
+    await this.updateCloudContextPower(name, StartCloudContext, 'Started');
+    void this.refreshKubernetesContexts();
+  }
+
+  private async updateCloudContextPower(name: string, action: (name: string) => Promise<unknown>, label: string): Promise<void> {
+    const dialog = this.state.globalConfigDialog;
+    if (dialog.busy || dialog.configLoading) {
+      return;
+    }
+    this.state.globalConfigDialog = { ...dialog, busy: true, error: '' };
+    this.emit();
+    try {
+      const context = (await action(name)) as UICloudContextStatus;
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        config: {
+          ...this.state.globalConfigDialog.config,
+          cloudContexts: replaceCloudContext(this.state.globalConfigDialog.config.cloudContexts || [], context),
+        },
+        busy: false,
+        error: '',
+      };
+      this.showTerminalMessage(`${label} cloud context ${context.kubernetesContext}.`);
+      this.emit();
+    } catch (error) {
+      const message = readError(error);
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        busy: false,
+        error: message,
+      };
+      this.showTerminalMessage(message);
+      this.emit();
+    }
+  }
+
+  async startAWSCloudInit(): Promise<void> {
+    const dialog = this.state.globalConfigDialog;
+    if (dialog.busy || dialog.configLoading) {
+      return;
+    }
+    this.state.globalConfigDialog = { ...dialog, busy: true, error: '' };
+    this.emit();
+    try {
+      this.fitAddon?.fit();
+      const result = (await StartCloudInitAWSSession(this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
+      this.cloudInitSessions.add(result.sessionId);
+      this.state.globalConfigDialog = defaultGlobalConfigDialog();
+      this.state.sessionId = result.sessionId;
+      this.state.terminalCopyOutput = '';
+      this.state.terminalCopyStatus = '';
+      this.resetTerminal();
+      this.hideTerminalMessage();
+      this.focusTerminalSoon();
+      this.queueTerminalResize();
+      this.emit();
+    } catch (error) {
+      const message = readError(error);
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        busy: false,
+        error: message,
+      };
+      this.showTerminalMessage(message);
+      this.emit();
+    }
+  }
+
+  async loginCloudProvider(alias: string): Promise<void> {
+    const dialog = this.state.globalConfigDialog;
+    if (dialog.busy || dialog.configLoading) {
+      return;
+    }
+    this.state.globalConfigDialog = { ...dialog, busy: true, error: '' };
+    this.emit();
+    try {
+      const provider = await LoginCloudProvider(alias);
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        config: {
+          ...this.state.globalConfigDialog.config,
+          cloudProviders: replaceCloudProvider(this.state.globalConfigDialog.config.cloudProviders || [], provider),
+        },
+        busy: false,
+        error: '',
+      };
+      this.showTerminalMessage(`${provider.alias}: ${provider.status}`);
+      this.emit();
+    } catch (error) {
+      const message = readError(error);
+      this.state.globalConfigDialog = {
+        ...this.state.globalConfigDialog,
+        busy: false,
+        error: message,
+      };
+      this.showTerminalMessage(message);
+      this.emit();
+    }
+  }
+
   async submitGlobalConfig(): Promise<void> {
     const dialog = this.state.globalConfigDialog;
     if (dialog.busy || dialog.configLoading) {
@@ -789,7 +1014,7 @@ export class ERunUIController {
     this.state.globalConfigDialog = { ...dialog, busy: true, error: '' };
     this.emit();
     try {
-      const result = (await SaveERunConfig(dialog.config)) as UIERunConfig;
+      const result = (await SaveERunConfig(dialog.config as Parameters<typeof SaveERunConfig>[0])) as UIERunConfig;
       this.state.globalConfigDialog = {
         ...this.state.globalConfigDialog,
         config: result,
@@ -1300,13 +1525,15 @@ export class ERunUIController {
     const initSelection = this.initSessionSelections.get(payload.sessionId);
     const deploySelection = this.deploySessionSelections.get(payload.sessionId);
     const openSelection = this.openSessionSelections.get(payload.sessionId);
+    const cloudInit = this.cloudInitSessions.has(payload.sessionId);
     this.initSessionSelections.delete(payload.sessionId);
     this.deploySessionSelections.delete(payload.sessionId);
     this.openSessionSelections.delete(payload.sessionId);
+    this.cloudInitSessions.delete(payload.sessionId);
 
-    const reason = this.terminalExitReason(payload, initSelection, deploySelection, openSelection);
+    const reason = this.terminalExitReason(payload, initSelection, deploySelection, openSelection, cloudInit);
     this.sessionExitReasons.set(payload.sessionId, reason);
-    const failedOutput = payload.reason && (initSelection || deploySelection || openSelection)
+    const failedOutput = payload.reason && (initSelection || deploySelection || openSelection || cloudInit)
       ? this.failedTerminalOutput(payload.sessionId, reason)
       : '';
     if (failedOutput) {
@@ -1327,7 +1554,7 @@ export class ERunUIController {
       }
       return;
     }
-    if (payload.reason && (initSelection || deploySelection || openSelection)) {
+    if (payload.reason && (initSelection || deploySelection || openSelection || cloudInit)) {
       this.state.terminalCopyOutput = failedOutput;
       this.state.terminalCopyStatus = '';
     }
@@ -1339,6 +1566,7 @@ export class ERunUIController {
     initSelection?: UISelection,
     deploySelection?: UISelection,
     openSelection?: UISelection,
+    cloudInit?: boolean,
   ): string {
     if (payload.reason) {
       if (initSelection) {
@@ -1350,6 +1578,9 @@ export class ERunUIController {
       if (openSelection) {
         return `Failed to open ${openSelection.tenant} / ${openSelection.environment}: ${payload.reason}`;
       }
+      if (cloudInit) {
+        return `Failed to initialize AWS cloud alias: ${payload.reason}`;
+      }
       return payload.reason;
     }
     if (initSelection) {
@@ -1357,6 +1588,9 @@ export class ERunUIController {
     }
     if (deploySelection) {
       return `Deployed ${deploySelection.tenant} / ${deploySelection.environment}.`;
+    }
+    if (cloudInit) {
+      return 'AWS cloud alias setup ended.';
     }
     return 'Session ended.';
   }
@@ -1487,4 +1721,30 @@ function cleanTerminalOutput(value: string): string {
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')
     .trim();
+}
+
+function replaceCloudProvider(providers: UICloudProviderStatus[], provider: UICloudProviderStatus): UICloudProviderStatus[] {
+  const next = providers.filter((item) => item.alias !== provider.alias);
+  next.push(provider);
+  next.sort((left, right) => left.alias.localeCompare(right.alias));
+  return next;
+}
+
+function replaceCloudContext(contexts: UICloudContextStatus[], context: UICloudContextStatus): UICloudContextStatus[] {
+  const next = contexts.filter((item) => item.name !== context.name);
+  next.push(context);
+  next.sort((left, right) => left.name.localeCompare(right.name));
+  return next;
+}
+
+function cloudContextDraftForConfig(config: UIERunConfig, current: UICloudContextInitInput): UICloudContextInitInput {
+  const draft = {
+    ...defaultCloudContextInitInput(),
+    ...current,
+  };
+  const providers = config.cloudProviders || [];
+  if (!draft.cloudProviderAlias || !providers.some((provider) => provider.alias === draft.cloudProviderAlias)) {
+    draft.cloudProviderAlias = providers[0]?.alias || '';
+  }
+  return draft;
 }

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -4,6 +4,7 @@ import type {
   ManageTab,
   UIERunConfig,
   UIEnvironmentConfig,
+  UICloudContextInitInput,
   UISelection,
   UITenantConfig,
   UITenant,
@@ -68,6 +69,7 @@ export interface TenantDialogState {
 export interface GlobalConfigDialogState {
   open: boolean;
   config: UIERunConfig;
+  cloudContextDraft: UICloudContextInitInput;
   configLoading: boolean;
   busy: boolean;
   error: string;
@@ -144,6 +146,7 @@ export const defaultTenantDialog = (): TenantDialogState => ({
 export const defaultGlobalConfigDialog = (): GlobalConfigDialogState => ({
   open: false,
   config: defaultERunConfig(),
+  cloudContextDraft: defaultCloudContextInitInput(),
   configLoading: false,
   busy: false,
   error: '',
@@ -151,6 +154,17 @@ export const defaultGlobalConfigDialog = (): GlobalConfigDialogState => ({
 
 export const defaultERunConfig = (): UIERunConfig => ({
   defaultTenant: '',
+  cloudProviders: [],
+  cloudContexts: [],
+});
+
+export const defaultCloudContextInitInput = (): UICloudContextInitInput => ({
+  name: '',
+  cloudProviderAlias: '',
+  region: 'eu-west-2',
+  instanceType: 'c8gd.2xlarge',
+  diskType: 'gp3',
+  diskSizeGb: 100,
 });
 
 export const defaultTenantConfig = (): UITenantConfig => ({
@@ -163,6 +177,7 @@ export const defaultEnvironmentConfig = (): UIEnvironmentConfig => ({
   repoPath: '',
   kubernetesContext: '',
   containerRegistry: '',
+  cloudProviderAlias: '',
   runtimeVersion: '',
   sshd: {
     enabled: false,

--- a/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { LoaderCircle, Save } from 'lucide-react';
+import { CheckCircle2, Cloud, LoaderCircle, LogIn, Play, Plus, Power, RefreshCw, Save, Server } from 'lucide-react';
 
 import type { ERunUIController } from '@/app/ERunUIController';
 import { readError } from '@/app/errors';
 import type { AppState } from '@/app/state';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
 const dialogErrorClassName =
@@ -15,6 +16,8 @@ export function GlobalConfigDialogView({ controller, state }: { controller: ERun
   const dialog = state.globalConfigDialog;
   const config = dialog.config;
   const tenantOptions = optionValues(state.tenants.map((tenant) => tenant.name), config.defaultTenant);
+  const selectedCloudProvider = (config.cloudProviders || []).find((provider) => provider.alias === dialog.cloudContextDraft.cloudProviderAlias);
+  const generatedCloudContextName = generatedContextName(selectedCloudProvider, dialog.cloudContextDraft.region, config.cloudContexts || []);
 
   return (
     <Dialog open={dialog.open} onOpenChange={(open) => !open && controller.closeGlobalConfigDialog()}>
@@ -35,7 +38,8 @@ export function GlobalConfigDialogView({ controller, state }: { controller: ERun
           }}
         >
           <DialogHeader>
-            <DialogTitle>Manage ERun config</DialogTitle>
+            <DialogTitle>ERun settings</DialogTitle>
+            <DialogDescription className="sr-only">Manage default tenant and cloud aliases.</DialogDescription>
           </DialogHeader>
           {dialog.configLoading ? (
             <div className="rounded-[var(--radius)] border border-dashed border-border px-3 py-2.5 text-[13px] leading-[1.35] text-muted-foreground">
@@ -43,7 +47,134 @@ export function GlobalConfigDialogView({ controller, state }: { controller: ERun
             </div>
           ) : (
             <div className="grid gap-3">
-              <SelectField id="global-config-defaulttenant" label="defaulttenant" value={config.defaultTenant} options={tenantOptions} disabled={dialog.busy || tenantOptions.length === 0} onChange={(defaultTenant) => controller.updateGlobalConfig({ defaultTenant })} />
+              <SelectField id="global-config-defaulttenant" label="Default tenant" value={config.defaultTenant} options={tenantOptions} disabled={dialog.busy || tenantOptions.length === 0} onChange={(defaultTenant) => controller.updateGlobalConfig({ defaultTenant })} />
+              <div className="grid gap-2">
+                <div className="flex items-center justify-between gap-2">
+                  <Label>Cloud aliases</Label>
+                  <div className="flex gap-1.5">
+                    <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => void controller.startAWSCloudInit()}>
+                      <Plus aria-hidden="true" />
+                      AWS
+                    </Button>
+                    <Button type="button" variant="ghost" size="icon" disabled={dialog.busy} aria-label="Refresh cloud aliases" onClick={() => void controller.refreshCloudProviders()}>
+                      <RefreshCw aria-hidden="true" />
+                    </Button>
+                  </div>
+                </div>
+                {(config.cloudProviders || []).length === 0 ? (
+                  <div className="px-0.5 py-2 text-[13px] leading-[1.35] text-muted-foreground">No cloud aliases configured</div>
+                ) : (
+                  <div className="overflow-hidden rounded-[var(--radius)] border border-border">
+                    {(config.cloudProviders || []).map((provider, index) => (
+                      <div
+                        key={provider.alias}
+                        className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-border px-3 py-2.5 data-[border=true]:border-t"
+                        data-border={index > 0}
+                        data-cloud-alias={provider.alias}
+                        data-cloud-status={provider.status}
+                      >
+                        <div className="grid min-w-0 gap-1">
+                          <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+                            <Cloud className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                            <span className="truncate">{provider.alias}</span>
+                            <StatusBadge status={provider.status} />
+                          </div>
+                          <div className="truncate text-xs text-muted-foreground">
+                            {cloudProviderSummary(provider)}
+                            {provider.message ? ` - ${provider.message}` : ''}
+                          </div>
+                        </div>
+                        <CloudAliasAction status={provider.status} busy={dialog.busy} onLogin={() => void controller.loginCloudProvider(provider.alias)} />
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="grid gap-2">
+                <div className="flex items-center justify-between gap-2">
+                  <Label>Cloud contexts</Label>
+                  <Button type="button" variant="ghost" size="icon" disabled={dialog.busy} aria-label="Refresh cloud contexts" onClick={() => void controller.refreshCloudContexts()}>
+                    <RefreshCw aria-hidden="true" />
+                  </Button>
+                </div>
+                <div className="grid gap-2 rounded-[var(--radius)] border border-border p-3">
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <SelectInput
+                      id="global-config-cloudcontext-provider"
+                      label="Cloud provider"
+                      value={dialog.cloudContextDraft.cloudProviderAlias}
+                      options={(config.cloudProviders || []).map((provider) => provider.alias)}
+                      emptyLabel="No cloud aliases"
+                      disabled={dialog.busy || (config.cloudProviders || []).length === 0}
+                      onChange={(cloudProviderAlias) => controller.updateCloudContextDraft({ cloudProviderAlias })}
+                    />
+                    <RegionSelectInput id="global-config-cloudcontext-region" value={dialog.cloudContextDraft.region} disabled={dialog.busy} onChange={(region) => controller.updateCloudContextDraft({ region })} />
+                    <SelectInput
+                      id="global-config-cloudcontext-instancetype"
+                      label="Instance type"
+                      value={dialog.cloudContextDraft.instanceType}
+                      options={['c8gd.2xlarge', 't4g.xlarge']}
+                      disabled={dialog.busy}
+                      onChange={(instanceType) => controller.updateCloudContextDraft({ instanceType })}
+                    />
+                    <SelectInput
+                      id="global-config-cloudcontext-disksize"
+                      label="Disk size"
+                      value={String(dialog.cloudContextDraft.diskSizeGb)}
+                      options={['100', '200']}
+                      disabled={dialog.busy}
+                      onChange={(diskSizeGb) => controller.updateCloudContextDraft({ diskSizeGb: Number(diskSizeGb) })}
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="global-config-cloudcontext-name">Context name</Label>
+                    <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+                      <Input
+                        id="global-config-cloudcontext-name"
+                        value={dialog.cloudContextDraft.name}
+                        disabled={dialog.busy}
+                        placeholder="Generated when empty"
+                        onChange={(event) => controller.updateCloudContextDraft({ name: event.target.value })}
+                      />
+                      <Button type="button" size="sm" disabled={dialog.busy || dialog.configLoading || !dialog.cloudContextDraft.cloudProviderAlias || !dialog.cloudContextDraft.region} onClick={() => void controller.initCloudContext()}>
+                        {dialog.busy ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Plus aria-hidden="true" />}
+                        Init
+                      </Button>
+                    </div>
+                    {generatedCloudContextName && !dialog.cloudContextDraft.name && (
+                      <div className="px-0.5 text-xs leading-[1.35] text-muted-foreground [overflow-wrap:anywhere]">Generated: {generatedCloudContextName}</div>
+                    )}
+                  </div>
+                </div>
+                {(config.cloudContexts || []).length === 0 ? (
+                  <div className="px-0.5 py-2 text-[13px] leading-[1.35] text-muted-foreground">No cloud contexts configured</div>
+                ) : (
+                  <div className="overflow-hidden rounded-[var(--radius)] border border-border">
+                    {(config.cloudContexts || []).map((context, index) => (
+                      <div
+                        key={context.name}
+                        className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-border px-3 py-2.5 data-[border=true]:border-t"
+                        data-border={index > 0}
+                        data-cloud-context={context.name}
+                        data-cloud-context-status={context.status}
+                      >
+                        <div className="grid min-w-0 gap-1">
+                          <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+                            <Server className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                            <span className="truncate">{context.kubernetesContext || context.name}</span>
+                            <StatusBadge status={context.status} />
+                          </div>
+                          <div className="truncate text-xs text-muted-foreground">
+                            {cloudContextSummary(context)}
+                            {context.message ? ` - ${context.message}` : ''}
+                          </div>
+                        </div>
+                        <CloudContextAction status={context.status} busy={dialog.busy} onStart={() => void controller.startCloudContext(context.name)} onStop={() => void controller.stopCloudContext(context.name)} />
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
           )}
           {dialog.error && (
@@ -57,12 +188,213 @@ export function GlobalConfigDialogView({ controller, state }: { controller: ERun
             </Button>
             <Button type="submit" size="sm" disabled={dialog.busy || dialog.configLoading}>
               {dialog.busy ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Save aria-hidden="true" />}
-              {dialog.busy ? 'Saving...' : 'Save'}
+              {dialog.busy ? 'Saving...' : 'Save settings'}
             </Button>
           </DialogFooter>
         </form>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function StatusBadge({ status }: { status: string }): React.ReactElement {
+  const normalized = status.trim() || 'unknown';
+  const className =
+    normalized === 'active' || normalized === 'running'
+      ? 'border-green-600/35 bg-green-600/10 text-green-700 dark:text-green-400'
+      : normalized === 'expired' || normalized === 'not_configured'
+        ? 'border-[color-mix(in_oklch,var(--destructive)_35%,var(--border))] bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] text-destructive'
+        : 'border-border bg-muted/40 text-muted-foreground';
+  return (
+    <span className={`shrink-0 rounded-[calc(var(--radius)-2px)] border px-1.5 py-0.5 text-[11px] leading-none font-medium ${className}`}>
+      {statusLabel(normalized)}
+    </span>
+  );
+}
+
+function CloudAliasAction({ status, busy, onLogin }: { status: string; busy: boolean; onLogin: () => void }): React.ReactElement {
+  if (status.trim() === 'active') {
+    return (
+      <div className="inline-flex items-center gap-1.5 px-1 text-xs font-medium text-green-700 dark:text-green-400" aria-label="Connected">
+        <CheckCircle2 className="size-4" aria-hidden="true" />
+        Connected
+      </div>
+    );
+  }
+  return (
+    <Button type="button" variant="outline" size="sm" disabled={busy} onClick={onLogin}>
+      <LogIn aria-hidden="true" />
+      Login
+    </Button>
+  );
+}
+
+function CloudContextAction({ status, busy, onStart, onStop }: { status: string; busy: boolean; onStart: () => void; onStop: () => void }): React.ReactElement {
+  if (status.trim() === 'running') {
+    return (
+      <Button type="button" variant="outline" size="sm" disabled={busy} onClick={onStop}>
+        <Power aria-hidden="true" />
+        Stop
+      </Button>
+    );
+  }
+  return (
+    <Button type="button" variant="outline" size="sm" disabled={busy} onClick={onStart}>
+      <Play aria-hidden="true" />
+      Start
+    </Button>
+  );
+}
+
+function cloudProviderSummary(provider: { provider: string; username?: string; accountId?: string }): string {
+  const providerName = provider.provider.toUpperCase();
+  if (provider.accountId && provider.username) {
+    return `${providerName} account ${provider.accountId} - ${provider.username}`;
+  }
+  if (provider.accountId) {
+    return `${providerName} account ${provider.accountId}`;
+  }
+  return providerName;
+}
+
+function cloudContextSummary(context: { cloudProviderAlias: string; region: string; instanceType: string; diskSizeGb: number; diskType: string; instanceId?: string }): string {
+  const parts = [
+    context.cloudProviderAlias,
+    cloudRegionLabel(context.region),
+    context.instanceType,
+    `${context.diskSizeGb} GB ${context.diskType}`,
+  ].filter(Boolean);
+  if (context.instanceId) {
+    parts.push(context.instanceId);
+  }
+  return parts.join(' - ');
+}
+
+function cloudRegionLabel(region: string): string {
+  switch (region) {
+    case 'eu-west-2':
+      return 'London';
+    case 'eu-west-1':
+      return 'Ireland';
+    default:
+      return region;
+  }
+}
+
+function generatedContextName(provider: { alias: string; username?: string; accountId?: string } | undefined, region: string, contexts: Array<{ name: string; kubernetesContext: string }>): string {
+  if (!provider) {
+    return '';
+  }
+  const identity = provider.accountId || provider.username || provider.alias;
+  const tail = sanitizeContextName([identity, region || 'eu-west-2'].filter(Boolean).join('-'));
+  return nextGeneratedContextName(tail, contexts);
+}
+
+function nextGeneratedContextName(tail: string, contexts: Array<{ name: string; kubernetesContext: string }>): string {
+  const normalizedTail = sanitizeContextName(tail) || 'context';
+  const suffix = `-${normalizedTail}`;
+  let next = 1;
+  for (const context of contexts) {
+    for (const name of [context.name, context.kubernetesContext]) {
+      if (!name.startsWith('erun-') || !name.endsWith(suffix)) {
+        continue;
+      }
+      const counter = name.slice('erun-'.length, name.length - suffix.length);
+      if (!/^\d{3}$/.test(counter)) {
+        continue;
+      }
+      const value = Number(counter);
+      if (value >= next) {
+        next = value + 1;
+      }
+    }
+  }
+  return `erun-${String(next).padStart(3, '0')}-${normalizedTail}`;
+}
+
+function sanitizeContextName(value: string): string {
+  let result = '';
+  let lastDash = false;
+  for (const char of value.trim().toLowerCase()) {
+    if ((char >= 'a' && char <= 'z') || (char >= '0' && char <= '9')) {
+      result += char;
+      lastDash = false;
+      continue;
+    }
+    if (!lastDash) {
+      result += '-';
+      lastDash = true;
+    }
+  }
+  return result.replace(/^-+|-+$/g, '');
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case 'active':
+      return 'Active';
+    case 'running':
+      return 'Running';
+    case 'stopped':
+      return 'Stopped';
+    case 'pending':
+      return 'Pending';
+    case 'expired':
+      return 'Expired';
+    case 'not_configured':
+      return 'Not configured';
+    default:
+      return 'Unknown';
+  }
+}
+
+function RegionSelectInput({ id, value, disabled, onChange }: { id: string; value: string; disabled?: boolean; onChange: (value: string) => void }): React.ReactElement {
+  const regions = [
+    { value: 'eu-west-2', label: 'London' },
+    { value: 'eu-west-1', label: 'Ireland' },
+  ];
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={id}>Region</Label>
+      <select
+        id={id}
+        className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-[var(--radius)] border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        value={value || 'eu-west-2'}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {regions.map((region) => (
+          <option key={region.value} value={region.value}>
+            {region.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function SelectInput({ id, label, value, options, disabled, emptyLabel, onChange }: { id: string; label: string; value: string; options: string[]; disabled?: boolean; emptyLabel?: string; onChange: (value: string) => void }): React.ReactElement {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={id}>{label}</Label>
+      <select
+        id={id}
+        className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-[var(--radius)] border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {options.length === 0 ? (
+          <option value="">{emptyLabel || 'No options'}</option>
+        ) : (
+          options.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))
+        )}
+      </select>
+    </div>
   );
 }
 

--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -64,9 +64,10 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
               </div>
             ) : (
               <div className="grid gap-3">
-                <ReadonlyField id="environment-config-repopath" label="repopath" value={config.repoPath} />
-                <ReadonlyField id="environment-config-kubernetescontext" label="kubernetescontext" value={config.kubernetesContext} />
-                <ReadonlyField id="environment-config-containerregistry" label="containerregistry" value={config.containerRegistry} />
+                <ReadonlyField id="environment-config-repopath" label="Repository path" value={config.repoPath} />
+                <ReadonlyField id="environment-config-kubernetescontext" label="Kubernetes context" value={config.kubernetesContext} />
+                <ReadonlyField id="environment-config-containerregistry" label="Container registry" value={config.containerRegistry} />
+                <TextField id="environment-config-cloudprovideralias" label="Cloud alias" value={config.cloudProviderAlias} disabled={dialog.busy} onChange={(cloudProviderAlias) => controller.updateManageConfig({ cloudProviderAlias })} />
                 <RuntimeDeployField
                   configuredVersion={config.runtimeVersion}
                   overrideVersion={dialog.version}
@@ -78,9 +79,9 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
                   onSelect={(suggestion) => controller.selectManageVersionSuggestion(suggestion)}
                   onDeploy={() => void controller.submitManageDeploy().catch((error: unknown) => controller.showTerminalMessage(readError(error)))}
                 />
-                <CheckboxField id="environment-config-remote" label="remote" checked={config.remote} disabled onChange={() => {}} />
-                <CheckboxField id="environment-config-snapshot" label="snapshot" checked={config.snapshot} disabled={dialog.busy} onChange={(snapshot) => controller.updateManageConfig({ snapshot })} />
-                <ReadonlyField id="environment-config-localportrange" label="assigned local port range" value={portRangeValue(config.localPorts.rangeStart, config.localPorts.rangeEnd)} />
+                <CheckboxField id="environment-config-remote" label="Remote environment" checked={config.remote} disabled onChange={() => {}} />
+                <CheckboxField id="environment-config-snapshot" label="Snapshot deploy" checked={config.snapshot} disabled={dialog.busy} onChange={(snapshot) => controller.updateManageConfig({ snapshot })} />
+                <ReadonlyField id="environment-config-localportrange" label="Assigned local port range" value={portRangeValue(config.localPorts.rangeStart, config.localPorts.rangeEnd)} />
                 <PortStatusTable
                   rows={[
                     { service: 'mcp', port: config.localPorts.mcp, status: config.localPorts.mcpStatus },
@@ -88,14 +89,14 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
                   ]}
                 />
                 <div className="grid gap-3 rounded-[var(--radius)] border border-border p-3">
-                  <div className="text-xs leading-[1.2] font-semibold tracking-normal text-muted-foreground uppercase">sshd</div>
-                  <CheckboxField id="environment-config-sshd-enabled" label="enabled" checked={config.sshd.enabled} disabled onChange={() => {}} />
+                  <div className="text-xs leading-[1.2] font-semibold tracking-normal text-muted-foreground uppercase">SSH access</div>
+                  <CheckboxField id="environment-config-sshd-enabled" label="Enabled" checked={config.sshd.enabled} disabled onChange={() => {}} />
                   <ReadonlyField
                     id="environment-config-sshd-localport"
-                    label="localport"
+                    label="Local port"
                     value={config.sshd.localPort > 0 ? String(config.sshd.localPort) : ''}
                   />
-                  <ReadonlyField id="environment-config-sshd-publickeypath" label="publickeypath" value={config.sshd.publicKeyPath} />
+                  <ReadonlyField id="environment-config-sshd-publickeypath" label="Public key" value={config.sshd.publicKeyPath} />
                 </div>
                 {confirmingDelete && (
                   <div className="grid gap-3">
@@ -111,7 +112,7 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
                         </span>
                       </div>
                     )}
-                    <TextField id="manage-confirmation" label="confirmation" value={dialog.confirmation} disabled={dialog.busy} inputRef={confirmationRef} onChange={(confirmation) => controller.updateManageDialog({ confirmation })} />
+                    <TextField id="manage-confirmation" label="Confirmation" value={dialog.confirmation} disabled={dialog.busy} inputRef={confirmationRef} onChange={(confirmation) => controller.updateManageDialog({ confirmation })} />
                   </div>
                 )}
               </div>
@@ -178,9 +179,14 @@ function RuntimeDeployField({
 }): React.ReactElement {
   return (
     <div className="grid gap-2">
-      <Label htmlFor="environment-config-runtimeversion">runtimeversion</Label>
+      <div className="text-sm font-medium leading-none">Runtime version</div>
       <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-2">
-        <Input id="environment-config-runtimeversion" value={configuredVersion} type="text" autoComplete="off" spellCheck={false} disabled onChange={() => {}} />
+        <div
+          id="environment-config-runtimeversion"
+          className="min-h-10 rounded-[var(--radius)] border border-border bg-muted/35 px-3 py-2 text-sm leading-[1.35] text-muted-foreground [overflow-wrap:anywhere]"
+        >
+          {configuredVersion || 'Not configured'}
+        </div>
         <div className="relative min-w-0">
           <Input
             id="manage-version"
@@ -189,7 +195,7 @@ function RuntimeDeployField({
             type="text"
             autoComplete="off"
             spellCheck={false}
-            placeholder="deploy override"
+            placeholder="Version to deploy"
             disabled={disabled}
             onChange={(event) => onValueChange(event.target.value)}
           />
@@ -258,7 +264,7 @@ function ReadonlyField({ id, label, value }: { id: string; label: string; value:
         className="min-h-9 rounded-[var(--radius)] border border-border bg-muted/35 px-3 py-2 text-sm leading-[1.35] text-muted-foreground [overflow-wrap:anywhere]"
         aria-labelledby={id}
       >
-        {value || 'none'}
+        {value || 'Not configured'}
       </div>
     </div>
   );
@@ -267,16 +273,16 @@ function ReadonlyField({ id, label, value }: { id: string; label: string; value:
 function PortStatusTable({ rows }: { rows: { service: string; port: number; status: UIPortStatus }[] }): React.ReactElement {
   return (
     <div className="grid gap-2">
-      <div className="text-sm font-medium leading-none">ports</div>
+      <div className="text-sm font-medium leading-none">Local ports</div>
       <div className="overflow-hidden rounded-[var(--radius)] border border-border bg-muted/35 text-xs leading-[1.3]">
         <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-3 border-b border-border px-3 py-2 text-[11px] font-semibold uppercase leading-[1.2] text-muted-foreground">
-          <div>port</div>
-          <div>service</div>
-          <div>available</div>
+          <div>Port</div>
+          <div>Service</div>
+          <div>Status</div>
         </div>
         {rows.map((row) => (
           <div key={row.service} className="grid min-h-8 grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] items-center gap-3 border-b border-border px-3 py-1 last:border-b-0">
-            <div className="font-mono text-xs text-foreground">{row.port > 0 ? row.port : 'none'}</div>
+            <div className="font-mono text-xs text-foreground">{row.port > 0 ? row.port : 'Not configured'}</div>
             <div className="text-foreground">{row.service}</div>
             <AvailabilityDot status={row.status} />
           </div>

--- a/erun-ui/frontend/src/components/app/TenantDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDialogView.tsx
@@ -6,7 +6,6 @@ import { readError } from '@/app/errors';
 import type { AppState } from '@/app/state';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
 const dialogErrorClassName =
@@ -46,8 +45,8 @@ export function TenantDialogView({ controller, state }: { controller: ERunUICont
             </div>
           ) : (
             <div className="grid gap-3">
-              <TextField id="tenant-config-name" label="name" value={config.name} disabled onChange={() => {}} />
-              <SelectField id="tenant-config-defaultenvironment" label="defaultenvironment" value={config.defaultEnvironment} options={environmentOptions} disabled={dialog.busy || environmentOptions.length === 0} onChange={(defaultEnvironment) => controller.updateTenantConfig({ defaultEnvironment })} />
+              <ReadonlyField id="tenant-config-name" label="Tenant name" value={config.name} />
+              <SelectField id="tenant-config-defaultenvironment" label="Default environment" value={config.defaultEnvironment} options={environmentOptions} disabled={dialog.busy || environmentOptions.length === 0} onChange={(defaultEnvironment) => controller.updateTenantConfig({ defaultEnvironment })} />
             </div>
           )}
           {dialog.error && (
@@ -98,11 +97,18 @@ function SelectField({ id, label, value, options, disabled, onChange }: { id: st
   );
 }
 
-function TextField({ id, label, value, disabled, onChange }: { id: string; label: string; value: string; disabled?: boolean; onChange: (value: string) => void }): React.ReactElement {
+function ReadonlyField({ id, label, value }: { id: string; label: string; value: string }): React.ReactElement {
   return (
     <div className="grid gap-2">
-      <Label htmlFor={id}>{label}</Label>
-      <Input id={id} value={value} type="text" autoComplete="off" spellCheck={false} disabled={disabled} onChange={(event) => onChange(event.target.value)} />
+      <div id={id} className="text-sm font-medium leading-none">
+        {label}
+      </div>
+      <div
+        className="min-h-9 rounded-[var(--radius)] border border-border bg-muted/35 px-3 py-2 text-sm leading-[1.35] text-muted-foreground [overflow-wrap:anywhere]"
+        aria-labelledby={id}
+      >
+        {value || 'Not configured'}
+      </div>
     </div>
   );
 }

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -48,6 +48,51 @@ export interface UIVersionSuggestion {
 
 export interface UIERunConfig {
   defaultTenant: string;
+  cloudProviders?: UICloudProviderStatus[];
+  cloudContexts?: UICloudContextStatus[];
+}
+
+export interface UICloudProviderStatus {
+  alias: string;
+  provider: string;
+  username?: string;
+  accountId?: string;
+  profile?: string;
+  status: string;
+  message?: string;
+}
+
+export interface UIAWSCloudAliasInput {
+  alias: string;
+  username: string;
+  accountId: string;
+  profile: string;
+  ssoRegion: string;
+  ssoStartUrl: string;
+}
+
+export interface UICloudContextStatus {
+  name: string;
+  provider: string;
+  cloudProviderAlias: string;
+  region: string;
+  instanceId?: string;
+  publicIp?: string;
+  instanceType: string;
+  diskType: string;
+  diskSizeGb: number;
+  kubernetesContext: string;
+  status: string;
+  message?: string;
+}
+
+export interface UICloudContextInitInput {
+  name: string;
+  cloudProviderAlias: string;
+  region: string;
+  instanceType: string;
+  diskType: string;
+  diskSizeGb: number;
 }
 
 export interface UITenantConfig {
@@ -80,6 +125,7 @@ export interface UIEnvironmentConfig {
   repoPath: string;
   kubernetesContext: string;
   containerRegistry: string;
+  cloudProviderAlias: string;
   runtimeVersion: string;
   sshd: UISSHDConfig;
   localPorts: UIEnvironmentLocalPorts;

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -132,6 +132,10 @@ func buildDeployArgs(tenant, environment, version, runtimeImage string) []string
 	return args
 }
 
+func buildCloudInitAWSArgs() []string {
+	return []string{"cloud", "init", "aws"}
+}
+
 func resolveTerminalStartDir(preferred string) string {
 	candidates := []string{strings.TrimSpace(preferred)}
 


### PR DESCRIPTION
## Summary
- add root-level AWS cloud provider alias management
- add managed cloud k3s context lifecycle in shared common logic
- expose context list/init/start/stop through CLI, MCP, and desktop UI
- make cloud contexts selectable as Kubernetes contexts for new ERun environments

## Validation
- go test ./... in erun-common
- go test ./... in erun-cli
- go test ./... in erun-mcp
- go test ./... in erun-ui
- tsc -b && vite build in erun-ui/frontend using bundled Node runtime

Closes #150
