### PR TITLE
Add cloud context startup and debug panel

### DIFF
--- a/erun-ui/AGENTS.md
+++ b/erun-ui/AGENTS.md
@@ -35,6 +35,29 @@ Module-specific guidance for `erun-ui`. Follow the repository root `AGENTS.md` f
 - Avoid reintroducing broad semantic CSS class files for ordinary component styling. If a selector is only used by one React component and does not require a true global rule, keep the styling beside that component in `className`.
 - For frontend styling changes, run `yarn build`, `yarn shadcn:check`, and `go test ./...` from the relevant module paths unless the change is documentation-only.
 
+## Professional UX
+
+- Treat the referenced UX standards in this section as normative, not inspirational. When designing or reviewing UI, apply the underlying principles from those sources directly, even when this file does not list the exact case. Local bullets are examples and repository-specific emphasis, not the full rule set.
+- Before considering a UI change complete, do a heuristic pass against the referenced standards: visibility of system status, match with user language, consistency and standards, error prevention, recognition over recall, user control, accessible operation, and component-appropriate behavior. If a control, label, status color, disabled state, or action would violate those principles, fix it even if no local bullet names that exact problem.
+- Model user-facing settings around the domain objects users actually manage. Do not expose implementation details such as hidden local profiles, process state, transport-specific names, generated IDs, or implementation caches as primary concepts unless the user must explicitly choose them.
+- Use familiar operational patterns: lists or tables for collections, badges for status, icon buttons for compact actions, forms for editable details, and explicit primary/secondary actions for side effects.
+- Make object state visible where users act on it. Collection rows should show the object name, relevant metadata, current status, and the most likely action without requiring users to open a detail view.
+- Keep state, color, and available actions semantically consistent. A success/ready state should look successful and should not present an action that implies the opposite state; warning/error/expired states should clearly show that attention is needed and offer the relevant recovery action.
+- Empty states must not look like disabled inputs or editable fields. Use plain text or a purpose-built empty-state surface, and reserve bordered input styling for controls that accept input.
+- Labels and messages must use user-language, not implementation-language. Prefer terms that describe the object or action the user understands, and keep internal provider, CLI, SDK, profile, session, or transport details out of the primary UI.
+- Status refresh, login, deploy, delete, and other side-effecting actions must be explicit user actions. Do not run them implicitly when opening, rendering, or refreshing a settings view unless that behavior is clearly named by the control.
+- Design destructive, publishing, login, and external side-effect flows with clear action boundaries: users should understand what will happen before the action starts, be able to cancel before commitment, and see completion or failure status afterward.
+- Keep forms focused on values the user can know and intentionally provide. Do not ask users to invent derived values; compute aliases, IDs, labels, summaries, and status from authoritative data after the relevant operation completes.
+- Keep settings saves scoped to edited fields. Saving one setting must not remove or rewrite unrelated configuration.
+- Preserve accessibility basics in every UI change: semantic buttons and labels, keyboard-reachable controls, visible focus, sufficient contrast, non-color-only status communication, and error text associated with the relevant control or action.
+- Validate UI work with an actual rendered surface, using a Wails runtime or a browser harness with Wails mocks when the plain Vite page cannot run standalone. Include the relevant visual state in validation: empty, populated, loading, error, disabled, and narrow viewport when the change can affect those states.
+
+References:
+- Nielsen Norman Group, "10 Usability Heuristics for User Interface Design": https://www.nngroup.com/articles/ten-usability-heuristics/
+- W3C, "Web Content Accessibility Guidelines (WCAG) 2.2": https://www.w3.org/TR/WCAG22/
+- Material Design, "Empty states": https://m1.material.io/patterns/empty-states.html
+- Material Design, "Dialogs": https://m1.material.io/components/dialogs.html
+
 ## Build And Packaging
 
 - Keep the module build script as the canonical local and release-facing desktop build entrypoint.

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -19,6 +19,7 @@ import (
 const (
 	terminalOutputEvent = "terminal-output"
 	terminalExitEvent   = "terminal-exit"
+	appStatusEvent      = "app-status"
 	appSessionEnvVar    = "ERUN_UI_SESSION"
 )
 
@@ -35,6 +36,7 @@ type erunUIDeps struct {
 	resolveCLIPath       func() string
 	resolveBuildInfo     func() eruncommon.BuildInfo
 	resolveImageRegistry func(context.Context, string, string) (eruncommon.RuntimeRegistryVersions, error)
+	cloudContextDeps     eruncommon.CloudContextDependencies
 	deleteNamespace      eruncommon.NamespaceDeleterFunc
 	listKubeContexts     func() ([]string, error)
 	ensureMCP            func(context.Context, eruncommon.OpenResult) error
@@ -85,6 +87,7 @@ type uiSelection struct {
 	NoGit             bool   `json:"noGit,omitempty"`
 	SetDefaultTenant  bool   `json:"setDefaultTenant,omitempty"`
 	Action            string `json:"action,omitempty"`
+	Debug             bool   `json:"debug,omitempty"`
 }
 
 type uiBuildDetails struct {
@@ -132,6 +135,7 @@ type uiEnvironmentConfig struct {
 	KubernetesContext  string                  `json:"kubernetesContext"`
 	ContainerRegistry  string                  `json:"containerRegistry"`
 	CloudProviderAlias string                  `json:"cloudProviderAlias"`
+	CloudContext       *uiCloudContextStatus   `json:"cloudContext,omitempty"`
 	RuntimeVersion     string                  `json:"runtimeVersion"`
 	SSHD               uiSSHDConfig            `json:"sshd"`
 	LocalPorts         uiEnvironmentLocalPorts `json:"localPorts"`
@@ -188,11 +192,12 @@ type startSessionResult struct {
 }
 
 type deleteEnvironmentResult struct {
-	Tenant               string `json:"tenant"`
-	Environment          string `json:"environment"`
-	Namespace            string `json:"namespace,omitempty"`
-	KubernetesContext    string `json:"kubernetesContext,omitempty"`
-	NamespaceDeleteError string `json:"namespaceDeleteError,omitempty"`
+	Tenant                string `json:"tenant"`
+	Environment           string `json:"environment"`
+	Namespace             string `json:"namespace,omitempty"`
+	KubernetesContext     string `json:"kubernetesContext,omitempty"`
+	NamespaceDeleteError  string `json:"namespaceDeleteError,omitempty"`
+	CloudContextStopError string `json:"cloudContextStopError,omitempty"`
 }
 
 type terminalOutputPayload struct {
@@ -203,6 +208,11 @@ type terminalOutputPayload struct {
 type terminalExitPayload struct {
 	SessionID int    `json:"sessionId"`
 	Reason    string `json:"reason,omitempty"`
+}
+
+type appStatusPayload struct {
+	Message string `json:"message"`
+	Busy    bool   `json:"busy"`
 }
 
 type pastedImagePayload struct {
@@ -420,7 +430,7 @@ func (a *App) InitCloudContext(input uiCloudContextInitInput) (uiCloudContextSta
 }
 
 func (a *App) StopCloudContext(name string) (uiCloudContextStatus, error) {
-	status, err := eruncommon.StopCloudContext(eruncommon.Context{}, a.deps.store, eruncommon.CloudContextParams{Name: name}, eruncommon.CloudContextDependencies{})
+	status, err := eruncommon.StopCloudContext(eruncommon.Context{}, a.deps.store, eruncommon.CloudContextParams{Name: name}, a.deps.cloudContextDeps)
 	if err != nil {
 		return uiCloudContextStatus{}, err
 	}
@@ -428,7 +438,7 @@ func (a *App) StopCloudContext(name string) (uiCloudContextStatus, error) {
 }
 
 func (a *App) StartCloudContext(name string) (uiCloudContextStatus, error) {
-	status, err := eruncommon.StartCloudContext(eruncommon.Context{}, a.deps.store, eruncommon.CloudContextParams{Name: name}, eruncommon.CloudContextDependencies{})
+	status, err := eruncommon.StartCloudContext(eruncommon.Context{}, a.deps.store, eruncommon.CloudContextParams{Name: name}, a.deps.cloudContextDeps)
 	if err != nil {
 		return uiCloudContextStatus{}, err
 	}
@@ -516,7 +526,7 @@ func (a *App) LoadEnvironmentConfig(selection uiSelection) (uiEnvironmentConfig,
 	if err != nil {
 		return uiEnvironmentConfig{}, err
 	}
-	return environmentConfigToUI(config, selection.Environment, ports), nil
+	return a.environmentConfigToUI(config, selection.Environment, ports)
 }
 
 func (a *App) SaveEnvironmentConfig(selection uiSelection, config uiEnvironmentConfig) (uiEnvironmentConfig, error) {
@@ -537,7 +547,7 @@ func (a *App) SaveEnvironmentConfig(selection uiSelection, config uiEnvironmentC
 	if err != nil {
 		return uiEnvironmentConfig{}, err
 	}
-	return environmentConfigToUI(updated, selection.Environment, ports), nil
+	return a.environmentConfigToUI(updated, selection.Environment, ports)
 }
 
 func labelRuntimeVersionSuggestions(source, image string, suggestions []uiVersion) []uiVersion {
@@ -583,7 +593,7 @@ func tenantConfigFromUI(config uiTenantConfig, existing eruncommon.TenantConfig)
 	return existing
 }
 
-func environmentConfigToUI(config eruncommon.EnvConfig, fallbackName string, ports eruncommon.EnvironmentLocalPorts) uiEnvironmentConfig {
+func (a *App) environmentConfigToUI(config eruncommon.EnvConfig, fallbackName string, ports eruncommon.EnvironmentLocalPorts) (uiEnvironmentConfig, error) {
 	name := strings.TrimSpace(config.Name)
 	if name == "" {
 		name = strings.TrimSpace(fallbackName)
@@ -615,7 +625,13 @@ func environmentConfigToUI(config eruncommon.EnvConfig, fallbackName string, por
 		Remote:   config.Remote,
 		Snapshot: config.SnapshotEnabled(),
 	}
-	return result
+	if cloudContext, ok, err := a.linkedCloudContext(config); err != nil {
+		return uiEnvironmentConfig{}, err
+	} else if ok {
+		status := cloudContextStatusToUI(cloudContext)
+		result.CloudContext = &status
+	}
+	return result, nil
 }
 
 func localPortStatus(port int) uiPortStatus {
@@ -709,6 +725,65 @@ func cloudContextStatusToUI(status eruncommon.CloudContextStatus) uiCloudContext
 	}
 }
 
+func (a *App) linkedCloudContext(config eruncommon.EnvConfig) (eruncommon.CloudContextStatus, bool, error) {
+	cloudProviderAlias := strings.TrimSpace(config.CloudProviderAlias)
+	kubernetesContext := strings.TrimSpace(config.KubernetesContext)
+	if kubernetesContext == "" {
+		return eruncommon.CloudContextStatus{}, false, nil
+	}
+	statuses, err := eruncommon.ListCloudContextStatuses(a.deps.store)
+	if err != nil {
+		return eruncommon.CloudContextStatus{}, false, err
+	}
+	for _, status := range statuses {
+		context := eruncommon.NormalizeCloudContextConfig(status.CloudContextConfig)
+		if cloudProviderAlias != "" && strings.TrimSpace(context.CloudProviderAlias) != cloudProviderAlias {
+			continue
+		}
+		if strings.TrimSpace(context.KubernetesContext) == kubernetesContext || strings.TrimSpace(context.Name) == kubernetesContext {
+			status.CloudContextConfig = context
+			return status, true, nil
+		}
+	}
+	return eruncommon.CloudContextStatus{}, false, nil
+}
+
+func (a *App) ensureLinkedCloudContextRunning(config eruncommon.EnvConfig) (eruncommon.CloudContextStatus, bool, error) {
+	status, ok, err := a.linkedCloudContext(config)
+	if err != nil || !ok {
+		return status, ok, err
+	}
+	if strings.TrimSpace(status.Status) == eruncommon.CloudContextStatusRunning {
+		a.emitAppStatus(fmt.Sprintf("Cloud context %s is running. Opening environment...", cloudContextDisplayName(status)), true)
+		return status, true, nil
+	}
+	a.emitAppStatus(fmt.Sprintf("Starting cloud context %s and waiting for Kubernetes access...", cloudContextDisplayName(status)), true)
+	status, err = eruncommon.StartCloudContext(eruncommon.Context{}, a.deps.store, eruncommon.CloudContextParams{Name: status.Name}, a.deps.cloudContextDeps)
+	if err != nil {
+		return eruncommon.CloudContextStatus{}, true, err
+	}
+	a.emitAppStatus(fmt.Sprintf("Cloud context %s is running. Opening environment...", cloudContextDisplayName(status)), true)
+	return status, true, nil
+}
+
+func (a *App) stopCloudContext(name string) (eruncommon.CloudContextStatus, error) {
+	return eruncommon.StopCloudContext(eruncommon.Context{}, a.deps.store, eruncommon.CloudContextParams{Name: name}, a.deps.cloudContextDeps)
+}
+
+func (a *App) emitAppStatus(message string, busy bool) {
+	if a.ctx == nil || strings.TrimSpace(message) == "" {
+		return
+	}
+	runtime.EventsEmit(a.ctx, appStatusEvent, appStatusPayload{Message: message, Busy: busy})
+}
+
+func cloudContextDisplayName(status eruncommon.CloudContextStatus) string {
+	if name := strings.TrimSpace(status.KubernetesContext); name != "" {
+		return name
+	}
+	return strings.TrimSpace(status.Name)
+}
+
 func (a *App) StartSession(selection uiSelection, cols, rows int) (startSessionResult, error) {
 	selection = normalizeSelection(selection)
 	if selection.Tenant == "" || selection.Environment == "" {
@@ -723,6 +798,16 @@ func (a *App) StartSession(selection uiSelection, cols, rows int) (startSessionR
 	}
 
 	key := selectionKey(selection)
+	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
+		Tenant:      selection.Tenant,
+		Environment: selection.Environment,
+	})
+	if err != nil {
+		return startSessionResult{}, err
+	}
+	if _, _, err := a.ensureLinkedCloudContextRunning(result.EnvConfig); err != nil {
+		return startSessionResult{}, err
+	}
 
 	a.mu.Lock()
 	if existing := a.sessions[key]; existing != nil && !existing.closed && existing.session != nil {
@@ -735,18 +820,10 @@ func (a *App) StartSession(selection uiSelection, cols, rows int) (startSessionR
 	}
 	a.mu.Unlock()
 
-	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
-		Tenant:      selection.Tenant,
-		Environment: selection.Environment,
-	})
-	if err != nil {
-		return startSessionResult{}, err
-	}
-
 	session, err := a.deps.startTerminal(startTerminalSessionParams{
 		Dir:        resolveTerminalStartDir(result.RepoPath),
 		Executable: a.deps.resolveCLIPath(),
-		Args:       buildOpenArgs(result.Tenant, result.Environment),
+		Args:       buildOpenArgs(result.Tenant, result.Environment, selection.Debug),
 		Env:        []string{appSessionEnvVar + "=1"},
 		Cols:       cols,
 		Rows:       rows,
@@ -792,7 +869,7 @@ func (a *App) StartDeploySession(selection uiSelection, cols, rows int) (startSe
 	if err != nil {
 		return startSessionResult{}, err
 	}
-	return a.startCommandSession(selection, cols, rows, deploySelectionKey(selection), buildDeployArgs(selection.Tenant, selection.Environment, selection.Version, selection.RuntimeImage), resolveDeployStartDir(a.deps.findProjectRoot, result), []string{appSessionEnvVar + "=1"})
+	return a.startCommandSession(selection, cols, rows, deploySelectionKey(selection), buildDeployArgs(selection), resolveDeployStartDir(a.deps.findProjectRoot, result), []string{appSessionEnvVar + "=1"})
 }
 
 func (a *App) StartCloudInitAWSSession(cols, rows int) (startSessionResult, error) {
@@ -858,21 +935,36 @@ func (a *App) DeleteEnvironment(selection uiSelection, confirmation string) (del
 	if !ok {
 		return deleteEnvironmentResult{}, fmt.Errorf("environment deletion is not supported by the configured store")
 	}
+	envConfig, _, err := store.LoadEnvConfig(selection.Tenant, selection.Environment)
+	if err != nil {
+		return deleteEnvironmentResult{}, err
+	}
+	linkedContext, hasLinkedContext, err := a.ensureLinkedCloudContextRunning(envConfig)
+	if err != nil {
+		return deleteEnvironmentResult{}, err
+	}
 
 	result, err := eruncommon.RunDeleteEnvironment(eruncommon.Context{}, eruncommon.DeleteEnvironmentParams{
 		Tenant:      selection.Tenant,
 		Environment: selection.Environment,
 	}, store, a.deps.deleteNamespace)
+	stopError := ""
+	if hasLinkedContext {
+		if _, stopErr := a.stopCloudContext(linkedContext.Name); stopErr != nil {
+			stopError = stopErr.Error()
+		}
+	}
 	if err != nil {
 		return deleteEnvironmentResult{}, err
 	}
 	a.closeSessionsForSelection(selection)
 	return deleteEnvironmentResult{
-		Tenant:               result.Tenant,
-		Environment:          result.Environment,
-		Namespace:            result.Namespace,
-		KubernetesContext:    result.KubernetesContext,
-		NamespaceDeleteError: result.NamespaceDeleteError,
+		Tenant:                result.Tenant,
+		Environment:           result.Environment,
+		Namespace:             result.Namespace,
+		KubernetesContext:     result.KubernetesContext,
+		NamespaceDeleteError:  result.NamespaceDeleteError,
+		CloudContextStopError: stopError,
 	}, nil
 }
 
@@ -1277,6 +1369,7 @@ func normalizeSelection(selection uiSelection) uiSelection {
 		NoGit:             selection.NoGit,
 		SetDefaultTenant:  selection.SetDefaultTenant,
 		Action:            strings.TrimSpace(selection.Action),
+		Debug:             selection.Debug,
 	}
 }
 
@@ -1307,15 +1400,15 @@ func (s *managedTerminal) Close() error {
 
 func selectionKey(selection uiSelection) string {
 	selection = normalizeSelection(selection)
-	return selection.Tenant + "\x00" + selection.Environment
+	return selection.Tenant + "\x00" + selection.Environment + "\x00" + fmt.Sprintf("%t", selection.Debug)
 }
 
 func initSelectionKey(selection uiSelection) string {
 	selection = normalizeSelection(selection)
-	return "init\x00" + selection.Tenant + "\x00" + selection.Environment + "\x00" + selection.Version + "\x00" + selection.RuntimeImage + "\x00" + selection.KubernetesContext + "\x00" + selection.ContainerRegistry + "\x00" + fmt.Sprintf("%t", selection.SetDefaultTenant) + "\x00" + fmt.Sprintf("%t", selection.NoGit)
+	return "init\x00" + selection.Tenant + "\x00" + selection.Environment + "\x00" + selection.Version + "\x00" + selection.RuntimeImage + "\x00" + selection.KubernetesContext + "\x00" + selection.ContainerRegistry + "\x00" + fmt.Sprintf("%t", selection.SetDefaultTenant) + "\x00" + fmt.Sprintf("%t", selection.NoGit) + "\x00" + fmt.Sprintf("%t", selection.Debug)
 }
 
 func deploySelectionKey(selection uiSelection) string {
 	selection = normalizeSelection(selection)
-	return "deploy\x00" + selection.Tenant + "\x00" + selection.Environment + "\x00" + selection.Version + "\x00" + selection.RuntimeImage
+	return "deploy\x00" + selection.Tenant + "\x00" + selection.Environment + "\x00" + selection.Version + "\x00" + selection.RuntimeImage + "\x00" + fmt.Sprintf("%t", selection.Debug)
 }

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -438,6 +438,14 @@ func TestBuildOpenArgsTrimsTenantAndEnvironment(t *testing.T) {
 	}
 }
 
+func TestBuildOpenArgsIncludesDebugVerbosity(t *testing.T) {
+	got := buildOpenArgs(" erun ", " local ", true)
+	want := []string{"-vv", "open", "erun", "local"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected args: got %+v want %+v", got, want)
+	}
+}
+
 func TestBuildOpenNoShellArgsTrimsTenantAndEnvironment(t *testing.T) {
 	got := buildOpenNoShellArgs(" erun ", " local ")
 	want := []string{"open", "erun", "local", "--no-shell", "--no-alias-prompt"}
@@ -487,7 +495,7 @@ func TestBuildInitArgsIncludesRuntimeVersion(t *testing.T) {
 }
 
 func TestBuildDeployArgsIncludesRuntimeVersion(t *testing.T) {
-	got := buildDeployArgs(" erun ", " remote ", " 1.0.19 ", " erun-devops ")
+	got := buildDeployArgs(uiSelection{Tenant: " erun ", Environment: " remote ", Version: " 1.0.19 ", RuntimeImage: " erun-devops "})
 	want := []string{"open", "erun", "remote", "--no-shell", "--no-alias-prompt", "--version", "1.0.19", "--runtime-image", "erun-devops"}
 	if len(got) != len(want) {
 		t.Fatalf("unexpected args length: got %+v want %+v", got, want)
@@ -944,7 +952,27 @@ func TestLoadAndSaveERunConfig(t *testing.T) {
 func TestLoadAndSaveEnvironmentConfig(t *testing.T) {
 	projectRoot := t.TempDir()
 	snapshot := true
+	rootConfig := &eruncommon.ERunConfig{
+		CloudProviders: []eruncommon.CloudProviderConfig{
+			{Alias: "team-cloud", Provider: eruncommon.CloudProviderAWS},
+		},
+		CloudContexts: []eruncommon.CloudContextConfig{
+			{
+				Name:               "team-context",
+				Provider:           eruncommon.CloudProviderAWS,
+				CloudProviderAlias: "team-cloud",
+				Region:             eruncommon.DefaultCloudContextRegion,
+				InstanceID:         "i-test",
+				InstanceType:       eruncommon.DefaultCloudContextInstanceType,
+				DiskType:           eruncommon.DefaultCloudContextDiskType,
+				DiskSizeGB:         eruncommon.DefaultCloudContextDiskSizeGB,
+				KubernetesContext:  "cluster-old",
+				Status:             eruncommon.CloudContextStatusStopped,
+			},
+		},
+	}
 	store := stubUIStore{
+		config: rootConfig,
 		tenants: map[string]eruncommon.TenantConfig{
 			"frs": {
 				Name:        "frs",
@@ -953,11 +981,12 @@ func TestLoadAndSaveEnvironmentConfig(t *testing.T) {
 		},
 		envs: map[string]eruncommon.EnvConfig{
 			"frs/prod": {
-				Name:              "prod",
-				RepoPath:          projectRoot,
-				KubernetesContext: "cluster-old",
-				ContainerRegistry: "registry.example/old",
-				RuntimeVersion:    "1.0.0",
+				Name:               "prod",
+				RepoPath:           projectRoot,
+				KubernetesContext:  "cluster-old",
+				ContainerRegistry:  "registry.example/old",
+				CloudProviderAlias: "team-cloud",
+				RuntimeVersion:     "1.0.0",
 				SSHD: eruncommon.SSHDConfig{
 					Enabled:       false,
 					LocalPort:     60022,
@@ -977,16 +1006,20 @@ func TestLoadAndSaveEnvironmentConfig(t *testing.T) {
 	if loaded.Name != "prod" || loaded.RepoPath != projectRoot || loaded.KubernetesContext != "cluster-old" {
 		t.Fatalf("unexpected loaded config: %+v", loaded)
 	}
+	if loaded.CloudContext == nil || loaded.CloudContext.Name != "team-context" || loaded.CloudContext.Status != eruncommon.CloudContextStatusStopped {
+		t.Fatalf("expected linked cloud context, got %+v", loaded.CloudContext)
+	}
 	if loaded.LocalPorts.RangeStart != 17000 || loaded.LocalPorts.RangeEnd != 17099 || loaded.LocalPorts.MCP != 17000 || loaded.LocalPorts.SSH != 60022 {
 		t.Fatalf("unexpected loaded local ports: %+v", loaded.LocalPorts)
 	}
 
 	saved, err := app.SaveEnvironmentConfig(uiSelection{Tenant: "frs", Environment: "prod"}, uiEnvironmentConfig{
-		Name:              "prod",
-		RepoPath:          " /tmp/repo ",
-		KubernetesContext: " cluster-new ",
-		ContainerRegistry: " registry.example/team ",
-		RuntimeVersion:    " 1.2.3 ",
+		Name:               "prod",
+		RepoPath:           " /tmp/repo ",
+		KubernetesContext:  " cluster-new ",
+		ContainerRegistry:  " registry.example/team ",
+		CloudProviderAlias: " other-cloud ",
+		RuntimeVersion:     " 1.2.3 ",
 		SSHD: uiSSHDConfig{
 			Enabled:       true,
 			LocalPort:     62222,
@@ -998,15 +1031,160 @@ func TestLoadAndSaveEnvironmentConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SaveEnvironmentConfig failed: %v", err)
 	}
-	if saved.RepoPath != projectRoot || saved.KubernetesContext != "cluster-old" || saved.ContainerRegistry != "registry.example/old" || saved.RuntimeVersion != "1.0.0" {
+	if saved.RepoPath != projectRoot || saved.KubernetesContext != "cluster-old" || saved.ContainerRegistry != "registry.example/old" || saved.RuntimeVersion != "1.0.0" || saved.CloudProviderAlias != "other-cloud" {
 		t.Fatalf("unexpected saved config: %+v", saved)
 	}
 	if saved.LocalPorts.RangeStart != 17000 || saved.LocalPorts.RangeEnd != 17099 || saved.LocalPorts.MCP != 17000 || saved.LocalPorts.SSH != 60022 {
 		t.Fatalf("unexpected saved local ports: %+v", saved.LocalPorts)
 	}
 	stored := store.envs["frs/prod"]
-	if stored.RepoPath != projectRoot || stored.Remote || stored.RuntimeVersion != "1.0.0" || stored.SSHD.Enabled || stored.SSHD.LocalPort != 60022 || stored.SSHD.PublicKeyPath != "/tmp/old.pub" || stored.Snapshot == nil || *stored.Snapshot {
+	if stored.RepoPath != projectRoot || stored.Remote || stored.RuntimeVersion != "1.0.0" || stored.CloudProviderAlias != "other-cloud" || stored.SSHD.Enabled || stored.SSHD.LocalPort != 60022 || stored.SSHD.PublicKeyPath != "/tmp/old.pub" || stored.Snapshot == nil || *stored.Snapshot {
 		t.Fatalf("unexpected stored config: %+v", stored)
+	}
+}
+
+func TestStartSessionStartsLinkedCloudContextBeforeOpen(t *testing.T) {
+	projectRoot := t.TempDir()
+	rootConfig := &eruncommon.ERunConfig{
+		CloudProviders: []eruncommon.CloudProviderConfig{
+			{Alias: "team-cloud", Provider: eruncommon.CloudProviderAWS},
+		},
+		CloudContexts: []eruncommon.CloudContextConfig{
+			{
+				Name:               "team-context",
+				Provider:           eruncommon.CloudProviderAWS,
+				CloudProviderAlias: "team-cloud",
+				Region:             eruncommon.DefaultCloudContextRegion,
+				InstanceID:         "i-test",
+				InstanceType:       eruncommon.DefaultCloudContextInstanceType,
+				DiskType:           eruncommon.DefaultCloudContextDiskType,
+				DiskSizeGB:         eruncommon.DefaultCloudContextDiskSizeGB,
+				KubernetesContext:  "cluster-prod",
+				AdminToken:         "test-token",
+				Status:             eruncommon.CloudContextStatusStopped,
+			},
+		},
+	}
+	var actions []string
+	app := NewApp(erunUIDeps{
+		store: stubUIStore{
+			config: rootConfig,
+			tenants: map[string]eruncommon.TenantConfig{
+				"frs": {Name: "frs", ProjectRoot: projectRoot, DefaultEnvironment: "prod"},
+			},
+			envs: map[string]eruncommon.EnvConfig{
+				"frs/prod": {
+					Name:              "prod",
+					RepoPath:          projectRoot,
+					KubernetesContext: "cluster-prod",
+					Remote:            true,
+				},
+			},
+		},
+		resolveCLIPath:   func() string { return "/tmp/erun" },
+		cloudContextDeps: testCloudContextDeps(&actions),
+		startTerminal: func(params startTerminalSessionParams) (terminalSession, error) {
+			actions = append(actions, "terminal "+strings.Join(params.Args, " "))
+			return newStubTerminalSession(), nil
+		},
+	})
+	defer app.shutdown(context.Background())
+
+	if _, err := app.StartSession(uiSelection{Tenant: "frs", Environment: "prod"}, 80, 24); err != nil {
+		t.Fatalf("StartSession failed: %v", err)
+	}
+
+	got := strings.Join(actions, "\n")
+	for _, want := range []string{
+		"aws ec2 start-instances --instance-ids i-test",
+		"aws ec2 wait instance-running --instance-ids i-test",
+		"kubectl config set-context cluster-prod --cluster cluster-prod --user cluster-prod",
+		"terminal open frs prod",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected action %q in:\n%s", want, got)
+		}
+	}
+	if strings.Index(got, "aws ec2 start-instances") > strings.Index(got, "terminal open") {
+		t.Fatalf("expected cloud context start before terminal open, got:\n%s", got)
+	}
+	if rootConfig.CloudContexts[0].Status != eruncommon.CloudContextStatusRunning {
+		t.Fatalf("expected cloud context to be running, got %+v", rootConfig.CloudContexts[0])
+	}
+}
+
+func TestDeleteEnvironmentStartsLinkedContextThenStopsIt(t *testing.T) {
+	projectRoot := t.TempDir()
+	rootConfig := &eruncommon.ERunConfig{
+		DefaultTenant: "frs",
+		CloudProviders: []eruncommon.CloudProviderConfig{
+			{Alias: "team-cloud", Provider: eruncommon.CloudProviderAWS},
+		},
+		CloudContexts: []eruncommon.CloudContextConfig{
+			{
+				Name:               "team-context",
+				Provider:           eruncommon.CloudProviderAWS,
+				CloudProviderAlias: "team-cloud",
+				Region:             eruncommon.DefaultCloudContextRegion,
+				InstanceID:         "i-test",
+				InstanceType:       eruncommon.DefaultCloudContextInstanceType,
+				DiskType:           eruncommon.DefaultCloudContextDiskType,
+				DiskSizeGB:         eruncommon.DefaultCloudContextDiskSizeGB,
+				KubernetesContext:  "cluster-prod",
+				AdminToken:         "test-token",
+				Status:             eruncommon.CloudContextStatusStopped,
+			},
+		},
+	}
+	store := stubUIStore{
+		config: rootConfig,
+		tenants: map[string]eruncommon.TenantConfig{
+			"frs": {Name: "frs", ProjectRoot: projectRoot, DefaultEnvironment: "prod"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"frs/prod": {
+				Name:              "prod",
+				RepoPath:          projectRoot,
+				KubernetesContext: "cluster-prod",
+				Remote:            true,
+			},
+		},
+	}
+	var actions []string
+	app := NewApp(erunUIDeps{
+		store:            store,
+		cloudContextDeps: testCloudContextDeps(&actions),
+		deleteNamespace: func(context, namespace string) error {
+			actions = append(actions, "delete-namespace "+context+" "+namespace)
+			return nil
+		},
+	})
+
+	result, err := app.DeleteEnvironment(uiSelection{Tenant: "frs", Environment: "prod"}, "frs-prod")
+	if err != nil {
+		t.Fatalf("DeleteEnvironment failed: %v", err)
+	}
+	if result.CloudContextStopError != "" {
+		t.Fatalf("unexpected cloud context stop error: %+v", result)
+	}
+	got := strings.Join(actions, "\n")
+	for _, want := range []string{
+		"aws ec2 start-instances --instance-ids i-test",
+		"delete-namespace cluster-prod frs-prod",
+		"aws ec2 stop-instances --instance-ids i-test",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected action %q in:\n%s", want, got)
+		}
+	}
+	if strings.Index(got, "aws ec2 start-instances") > strings.Index(got, "delete-namespace") || strings.Index(got, "delete-namespace") > strings.Index(got, "aws ec2 stop-instances") {
+		t.Fatalf("unexpected delete ordering:\n%s", got)
+	}
+	if _, _, err := store.LoadEnvConfig("frs", "prod"); !errors.Is(err, eruncommon.ErrNotInitialized) {
+		t.Fatalf("expected environment config to be deleted, got %v", err)
+	}
+	if rootConfig.CloudContexts[0].Status != eruncommon.CloudContextStatusStopped {
+		t.Fatalf("expected cloud context to be stopped, got %+v", rootConfig.CloudContexts[0])
 	}
 }
 
@@ -1228,6 +1406,22 @@ type stubUIStore struct {
 	config  *eruncommon.ERunConfig
 	tenants map[string]eruncommon.TenantConfig
 	envs    map[string]eruncommon.EnvConfig
+}
+
+func testCloudContextDeps(actions *[]string) eruncommon.CloudContextDependencies {
+	return eruncommon.CloudContextDependencies{
+		RunAWS: func(_ eruncommon.Context, _ eruncommon.CloudProviderConfig, _ string, args []string) (string, error) {
+			*actions = append(*actions, "aws "+strings.Join(args, " "))
+			if strings.Join(args, " ") == "ec2 describe-instances --instance-ids i-test --query Reservations[0].Instances[0].PublicIpAddress --output text" {
+				return "203.0.113.10", nil
+			}
+			return "", nil
+		},
+		RunKubectl: func(_ eruncommon.Context, args []string) error {
+			*actions = append(*actions, "kubectl "+strings.Join(args, " "))
+			return nil
+		},
+	}
 }
 
 func (s stubUIStore) LoadERunConfig() (eruncommon.ERunConfig, string, error) {

--- a/erun-ui/frontend/src/App.tsx
+++ b/erun-ui/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Check, Copy } from 'lucide-react';
+import { Check, ChevronDown, ChevronUp, Copy, LoaderCircle, Trash2 } from 'lucide-react';
 
 import { ERunUIController } from '@/app/ERunUIController';
 import { useControllerState } from '@/app/useControllerState';
@@ -19,6 +19,9 @@ const splitterClassName =
 
 const reviewSplitterClassName =
   'relative cursor-col-resize border-l bg-background before:absolute before:top-0 before:bottom-0 before:left-1 before:w-px before:bg-transparent before:transition-colors hover:before:bg-border [.is-resizing-review_&]:before:bg-border';
+
+const debugSplitterClassName =
+  'relative cursor-row-resize bg-[oklch(0.06_0_0)] before:absolute before:left-0 before:right-0 before:top-1 before:h-px before:bg-transparent before:transition-colors hover:before:bg-[oklch(0.36_0_0)] [.is-resizing-debug_&]:before:bg-[oklch(0.46_0_0)]';
 
 export function App(): React.ReactElement {
   const controller = React.useMemo(() => new ERunUIController(), []);
@@ -63,53 +66,64 @@ export function App(): React.ReactElement {
           <main
             ref={terminalPaneRef}
             className={cn(
-              'grid h-full min-h-0 min-w-0 grid-cols-[minmax(360px,1fr)] overflow-hidden bg-terminal',
-              state.reviewOpen &&
-                'grid-cols-[minmax(360px,1fr)_10px_minmax(420px,var(--review-width))] max-[980px]:grid-cols-[minmax(260px,1fr)_10px_minmax(360px,min(var(--review-width),58vw))]',
+              'grid h-full min-h-0 min-w-0 overflow-hidden bg-terminal',
+              state.debugOpen ? 'grid-rows-[minmax(0,1fr)_var(--debug-height)]' : 'grid-rows-[minmax(0,1fr)_34px]',
             )}
           >
-            <div className="relative h-full min-h-0 min-w-0 overflow-hidden">
-              <div ref={terminalRootRef} className="terminal h-full min-h-0 min-w-0 w-full box-border px-4 py-3.5" />
-              <div
-                className={cn(
-                  'pointer-events-none absolute inset-0 flex items-center justify-center bg-[oklch(0_0_0/0.68)] p-10 text-center text-lg leading-[1.45] text-[oklch(0.92_0_0)]',
-                  state.terminalCopyOutput && 'pointer-events-auto',
-                  !state.terminalMessage && 'hidden',
-                )}
-              >
-                <div className="flex max-w-[min(680px,100%)] flex-col items-center gap-3.5">
-                  <div>{state.terminalMessage}</div>
-                  {state.terminalCopyOutput && (
-                    <Button
-                      className="pointer-events-auto cursor-pointer border-[oklch(0.92_0_0/0.55)] bg-[oklch(0.98_0_0)] text-[oklch(0.18_0_0)] opacity-100 shadow-[0_10px_30px_oklch(0_0_0/0.32)] hover:border-[oklch(1_0_0/0.75)] hover:bg-[oklch(1_0_0)] hover:text-[oklch(0.12_0_0)] [&_svg]:size-[15px]"
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() => {
-                        void controller.copyTerminalOutput();
-                      }}
-                    >
-                      {state.terminalCopyStatus === 'Copied' ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
-                      {state.terminalCopyStatus || 'Copy output'}
-                    </Button>
+            <div
+              className={cn(
+                'grid min-h-0 min-w-0 grid-cols-[minmax(360px,1fr)] overflow-hidden',
+                state.reviewOpen &&
+                  'grid-cols-[minmax(360px,1fr)_10px_minmax(420px,var(--review-width))] max-[980px]:grid-cols-[minmax(260px,1fr)_10px_minmax(360px,min(var(--review-width),58vw))]',
+              )}
+            >
+              <div className="relative h-full min-h-0 min-w-0 overflow-hidden">
+                <div ref={terminalRootRef} className="terminal h-full min-h-0 min-w-0 w-full box-border px-4 py-3.5" />
+                <div
+                  className={cn(
+                    'pointer-events-none absolute inset-0 flex items-center justify-center bg-[oklch(0_0_0/0.68)] p-10 text-center text-lg leading-[1.45] text-[oklch(0.92_0_0)]',
+                    state.terminalCopyOutput && 'pointer-events-auto',
+                    !state.terminalMessage && 'hidden',
                   )}
+                >
+                  <div className="flex max-w-[min(680px,100%)] flex-col items-center gap-3.5">
+                    <div className="flex items-center justify-center gap-3">
+                      {state.terminalBusy && <LoaderCircle className="size-5 shrink-0 animate-spin" aria-hidden="true" />}
+                      <span>{state.terminalMessage}</span>
+                    </div>
+                    {state.terminalCopyOutput && (
+                      <Button
+                        className="pointer-events-auto cursor-pointer border-[oklch(0.92_0_0/0.55)] bg-[oklch(0.98_0_0)] text-[oklch(0.18_0_0)] opacity-100 shadow-[0_10px_30px_oklch(0_0_0/0.32)] hover:border-[oklch(1_0_0/0.75)] hover:bg-[oklch(1_0_0)] hover:text-[oklch(0.12_0_0)] [&_svg]:size-[15px]"
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          void controller.copyTerminalOutput();
+                        }}
+                      >
+                        {state.terminalCopyStatus === 'Copied' ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
+                        {state.terminalCopyStatus || 'Copy output'}
+                      </Button>
+                    )}
+                  </div>
                 </div>
               </div>
+              <div
+                className={cn(reviewSplitterClassName, !state.reviewOpen && 'hidden')}
+                role="separator"
+                aria-orientation="vertical"
+                aria-label="Resize diff panel"
+                onMouseDown={(event) => controller.startReviewResize(event)}
+              />
+              <ReviewPanel
+                controller={controller}
+                state={state}
+                reviewViewRef={reviewViewRef}
+                reviewMainRef={reviewMainRef}
+                diffListRef={diffListRef}
+              />
             </div>
-            <div
-              className={cn(reviewSplitterClassName, !state.reviewOpen && 'hidden')}
-              role="separator"
-              aria-orientation="vertical"
-              aria-label="Resize diff panel"
-              onMouseDown={(event) => controller.startReviewResize(event)}
-            />
-            <ReviewPanel
-              controller={controller}
-              state={state}
-              reviewViewRef={reviewViewRef}
-              reviewMainRef={reviewMainRef}
-              diffListRef={diffListRef}
-            />
+            <DebugPanel controller={controller} open={state.debugOpen} output={state.debugOutput} />
           </main>
         </div>
       </div>
@@ -118,5 +132,54 @@ export function App(): React.ReactElement {
       <ManageDialogView controller={controller} state={state} />
       <TenantDialogView controller={controller} state={state} />
     </TooltipProvider>
+  );
+}
+
+function DebugPanel({ controller, open, output }: { controller: ERunUIController; open: boolean; output: string }): React.ReactElement {
+  const outputRef = React.useRef<HTMLPreElement>(null);
+
+  React.useEffect(() => {
+    if (open && outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight;
+    }
+  }, [open, output]);
+
+  return (
+    <section className={cn('grid min-h-0 border-t border-[oklch(0.26_0_0)] bg-[oklch(0.06_0_0)] text-[oklch(0.86_0_0)]', open ? 'grid-rows-[6px_34px_minmax(0,1fr)]' : 'grid-rows-[34px]')}>
+      {open && (
+        <div
+          className={debugSplitterClassName}
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label="Resize debug panel"
+          onMouseDown={(event) => controller.startDebugResize(event)}
+        />
+      )}
+      <div className="flex h-[34px] items-center justify-between gap-2 border-b border-[oklch(0.18_0_0)] px-3">
+        <button
+          type="button"
+          className="flex min-w-0 items-center gap-2 border-0 bg-transparent p-0 text-xs font-medium tracking-normal text-[oklch(0.76_0_0)]"
+          onClick={() => controller.setDebugOpen(!open)}
+        >
+          {open ? <ChevronDown className="size-4" aria-hidden="true" /> : <ChevronUp className="size-4" aria-hidden="true" />}
+          <span>Debug</span>
+          <span className="text-[11px] font-normal text-[oklch(0.56_0_0)]">{open ? 'erun -vv output' : 'collapsed'}</span>
+        </button>
+        {open && (
+          <Button className="h-6 px-2 text-[11px] [&_svg]:size-3.5" type="button" variant="ghost" size="sm" onClick={() => controller.clearDebugOutput()}>
+            <Trash2 aria-hidden="true" />
+            Clear
+          </Button>
+        )}
+      </div>
+      {open && (
+        <pre
+          ref={outputRef}
+          className="min-h-0 overflow-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-[11px] leading-[1.35] text-[oklch(0.82_0_0)]"
+        >
+          {output || 'Open an environment while Debug is expanded to run erun with -vv and stream output here.'}
+        </pre>
+      )}
+    </section>
   );
 }

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -33,11 +33,15 @@ import { fileToBase64, decodeBase64Bytes, isTerminalPasteTarget, pastedImageFile
 import { chooseSelectedDiffPath, cssEscape } from './diffUtils';
 import { readError } from './errors';
 import {
+  DEBUG_HEIGHT_STORAGE_KEY,
+  DEBUG_OPEN_STORAGE_KEY,
   FILES_OPEN_STORAGE_KEY,
   FILES_WIDTH_STORAGE_KEY,
+  MAX_DEBUG_HEIGHT,
   MAX_FILES_WIDTH,
   MAX_REVIEW_WIDTH,
   MAX_SIDEBAR_WIDTH,
+  MIN_DEBUG_HEIGHT,
   MIN_FILES_WIDTH,
   MIN_REVIEW_WIDTH,
   MIN_SIDEBAR_WIDTH,
@@ -55,7 +59,7 @@ import {
   type ManageDialogState,
   type TenantDialogState,
 } from './state';
-import { clamp, loadSavedFilesOpen, loadSavedFilesWidth, loadSavedReviewWidth, loadSavedSidebarWidth, saveBoolean, saveNumber } from './storage';
+import { clamp, loadSavedDebugHeight, loadSavedDebugOpen, loadSavedFilesOpen, loadSavedFilesWidth, loadSavedReviewWidth, loadSavedSidebarWidth, saveBoolean, saveNumber } from './storage';
 import { deleteConfirmationValue, normalizeDialogValue, normalizeVersionSuggestions, selectionKey } from './versionSuggestions';
 import type {
   DeleteEnvironmentResult,
@@ -85,6 +89,17 @@ export interface MountElements {
 }
 
 type TerminalDataDisposable = ReturnType<Terminal['onData']>;
+type TerminalWriteData = string | Uint8Array;
+
+interface AppStatusPayload {
+  message?: string;
+  busy?: boolean;
+}
+
+interface DebugOpenFilter {
+  released: boolean;
+  pending: string;
+}
 
 export class ERunUIController {
   readonly state: AppState = {
@@ -110,8 +125,12 @@ export class ERunUIController {
     diffFilter: '',
     collapsedDiffDirs: new Set<string>(),
     terminalMessage: '',
+    terminalBusy: false,
     terminalCopyOutput: '',
     terminalCopyStatus: '',
+    debugOpen: loadSavedDebugOpen(),
+    debugHeight: loadSavedDebugHeight(),
+    debugOutput: '',
   };
 
   private readonly subscribers = new Set<() => void>();
@@ -121,8 +140,10 @@ export class ERunUIController {
   private readonly cloudInitSessions = new Set<number>();
   private readonly selectionSessions = new Map<string, number>();
   private readonly sessionBuffers = new Map<number, Uint8Array[]>();
+  private readonly sessionDisplayBuffers = new Map<number, TerminalWriteData[]>();
   private readonly sessionExitReasons = new Map<number, string>();
   private readonly sessionExitOutputs = new Map<number, string>();
+  private readonly debugOpenFilters = new Map<number, DebugOpenFilter>();
   private terminal: Terminal | null = null;
   private fitAddon: FitAddon | null = null;
   private terminalRoot: HTMLDivElement | null = null;
@@ -140,6 +161,7 @@ export class ERunUIController {
   private terminalDataDisposable: TerminalDataDisposable | null = null;
   private terminalOutputOff: (() => void) | null = null;
   private terminalExitOff: (() => void) | null = null;
+  private appStatusOff: (() => void) | null = null;
   private pasteHandler: ((event: ClipboardEvent) => void) | null = null;
 
   subscribe = (subscriber: () => void): (() => void) => {
@@ -200,6 +222,9 @@ export class ERunUIController {
     this.terminalExitOff = EventsOn('terminal-exit', (payload: TerminalExitPayload) => {
       void this.handleTerminalExit(payload);
     });
+    this.appStatusOff = EventsOn('app-status', (payload: AppStatusPayload) => {
+      this.handleAppStatus(payload);
+    });
 
     if (!this.bootStarted) {
       this.bootStarted = true;
@@ -210,6 +235,9 @@ export class ERunUIController {
       window.removeEventListener('resize', this.queueTerminalResize);
       this.resizeObserver?.disconnect();
       this.terminalDataDisposable?.dispose();
+      this.terminalOutputOff?.();
+      this.terminalExitOff?.();
+      this.appStatusOff?.();
       if (this.pasteHandler && this.terminalRoot) {
         this.terminalRoot.removeEventListener('paste', this.pasteHandler, true);
       }
@@ -307,6 +335,35 @@ export class ERunUIController {
     window.addEventListener('mouseup', stop);
   }
 
+  startDebugResize(event: React.MouseEvent<HTMLElement>): void {
+    if (!this.state.debugOpen) {
+      return;
+    }
+    event.preventDefault();
+    document.body.classList.add('is-resizing-debug');
+
+    const move = (moveEvent: MouseEvent) => {
+      const paneRect = this.terminalPane?.getBoundingClientRect();
+      if (!paneRect) {
+        return;
+      }
+      const maxForPane = Math.max(MIN_DEBUG_HEIGHT, Math.min(MAX_DEBUG_HEIGHT, paneRect.height - 120));
+      this.state.debugHeight = clamp(paneRect.bottom - moveEvent.clientY, MIN_DEBUG_HEIGHT, maxForPane);
+      this.applyLayoutVars();
+      this.emit();
+      this.queueTerminalResize();
+    };
+    const stop = () => {
+      document.body.classList.remove('is-resizing-debug');
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', stop);
+      saveNumber(DEBUG_HEIGHT_STORAGE_KEY, this.state.debugHeight);
+    };
+
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', stop);
+  }
+
   toggleReview(): void {
     this.state.reviewOpen = !this.state.reviewOpen;
     this.applyLayoutVars();
@@ -328,6 +385,21 @@ export class ERunUIController {
     this.emit();
   }
 
+  setDebugOpen(open: boolean): void {
+    this.state.debugOpen = open;
+    saveBoolean(DEBUG_OPEN_STORAGE_KEY, open);
+    if (open && !this.state.debugOutput) {
+      this.state.debugOutput = 'Debug output will appear here for new erun sessions started while this panel is open.\n';
+    }
+    this.emit();
+    this.queueTerminalResize();
+  }
+
+  clearDebugOutput(): void {
+    this.state.debugOutput = '';
+    this.emit();
+  }
+
   toggleTenant(tenant: string): void {
     if (this.state.collapsedTenants.has(tenant)) {
       this.state.collapsedTenants.delete(tenant);
@@ -338,27 +410,32 @@ export class ERunUIController {
   }
 
   async openSelection(selection: UISelection): Promise<void> {
-    const key = selectionKey(selection);
+    const runSelection = { ...selection, debug: this.state.debugOpen || undefined };
+    const key = selectionKey(runSelection);
     const previousSessionId = this.state.sessionId;
     const previousKnownSessionId = this.selectionSessions.get(key) || 0;
 
     this.state.selected = selection;
+    if (this.state.debugOpen && (previousKnownSessionId === 0 || previousKnownSessionId !== previousSessionId)) {
+      this.state.debugOutput = `$ ${formatDebugCommand(runSelection)}\n`;
+    }
     this.emit();
     if (previousKnownSessionId === 0 || previousKnownSessionId !== previousSessionId) {
       this.state.terminalCopyOutput = '';
       this.state.terminalCopyStatus = '';
-      this.showTerminalMessage(`Opening ${selection.tenant} / ${selection.environment}...`);
+      this.showTerminalMessage(`Opening ${selection.tenant} / ${selection.environment}...`, true);
     }
 
     this.fitAddon?.fit();
-    const result = (await StartSession(selection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
+    const result = (await StartSession(runSelection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
     this.selectionSessions.set(key, result.sessionId);
-    this.openSessionSelections.set(result.sessionId, selection);
+    this.openSessionSelections.set(result.sessionId, runSelection);
+    this.rebuildTerminalDisplayBuffer(result.sessionId);
     this.state.sessionId = result.sessionId;
 
     if (result.sessionId !== previousSessionId) {
       this.resetTerminal();
-      const buffer = this.sessionBuffers.get(result.sessionId);
+      const buffer = this.sessionDisplayBuffers.get(result.sessionId);
       if (buffer) {
         this.writeTerminalBuffer(buffer);
       }
@@ -370,7 +447,12 @@ export class ERunUIController {
       this.state.terminalCopyStatus = '';
       this.showTerminalMessage(exitReason);
     } else {
-      this.hideTerminalMessage();
+      const buffer = this.sessionDisplayBuffers.get(result.sessionId);
+      if (buffer && buffer.length > 0) {
+        this.hideTerminalMessage();
+      } else {
+        this.showTerminalMessage(`Opening ${selection.tenant} / ${selection.environment}...`, true);
+      }
     }
 
     if (this.state.reviewOpen) {
@@ -621,12 +703,16 @@ export class ERunUIController {
     if (this.state.manageDialog.busy || this.state.manageDialog.configLoading) {
       return;
     }
+    const config = {
+      ...this.state.manageDialog.config,
+      ...values,
+    };
+    if (values.cloudProviderAlias !== undefined) {
+      config.cloudContext = undefined;
+    }
     this.state.manageDialog = {
       ...this.state.manageDialog,
-      config: {
-        ...this.state.manageDialog.config,
-        ...values,
-      },
+      config,
       error: '',
     };
     this.emit();
@@ -716,6 +802,48 @@ export class ERunUIController {
     }
   }
 
+  async startManageCloudContext(name: string): Promise<void> {
+    await this.updateManageCloudContextPower(name, StartCloudContext, 'Started');
+    void this.refreshKubernetesContexts();
+  }
+
+  async stopManageCloudContext(name: string): Promise<void> {
+    await this.updateManageCloudContextPower(name, StopCloudContext, 'Stopped');
+  }
+
+  private async updateManageCloudContextPower(name: string, action: (name: string) => Promise<unknown>, label: string): Promise<void> {
+    const contextName = normalizeDialogValue(name);
+    const dialog = this.state.manageDialog;
+    if (dialog.busy || dialog.configLoading || !dialog.selection || !contextName) {
+      return;
+    }
+    this.state.manageDialog = { ...dialog, busy: true, error: '' };
+    this.emit();
+    try {
+      const context = (await action(contextName)) as UICloudContextStatus;
+      this.state.manageDialog = {
+        ...this.state.manageDialog,
+        config: {
+          ...this.state.manageDialog.config,
+          cloudContext: context,
+        },
+        busy: false,
+        error: '',
+      };
+      this.showTerminalMessage(`${label} cloud context ${context.kubernetesContext || context.name}.`);
+      this.emit();
+    } catch (error) {
+      const message = readError(error);
+      this.state.manageDialog = {
+        ...this.state.manageDialog,
+        busy: false,
+        error: message,
+      };
+      this.showTerminalMessage(message);
+      this.emit();
+    }
+  }
+
   openGlobalConfigDialog(): void {
     this.state.globalConfigDialog = {
       open: true,
@@ -727,6 +855,8 @@ export class ERunUIController {
       cloudContextDraft: defaultCloudContextInitInput(),
       configLoading: true,
       busy: false,
+      busyAction: '',
+      busyTarget: '',
       error: '',
     };
     this.emit();
@@ -868,7 +998,7 @@ export class ERunUIController {
     if (dialog.busy || dialog.configLoading) {
       return;
     }
-    this.state.globalConfigDialog = { ...dialog, busy: true, error: '' };
+    this.state.globalConfigDialog = { ...dialog, busy: true, busyAction: 'cloud-context-init', busyTarget: '', error: '' };
     this.emit();
     try {
       const context = (await InitCloudContext(dialog.cloudContextDraft)) as UICloudContextStatus;
@@ -884,6 +1014,8 @@ export class ERunUIController {
           region: dialog.cloudContextDraft.region,
         }),
         busy: false,
+        busyAction: '',
+        busyTarget: '',
         error: '',
       };
       this.showTerminalMessage(`Initialized cloud context ${context.kubernetesContext}.`);
@@ -894,6 +1026,8 @@ export class ERunUIController {
       this.state.globalConfigDialog = {
         ...this.state.globalConfigDialog,
         busy: false,
+        busyAction: '',
+        busyTarget: '',
         error: message,
       };
       this.showTerminalMessage(message);
@@ -915,7 +1049,7 @@ export class ERunUIController {
     if (dialog.busy || dialog.configLoading) {
       return;
     }
-    this.state.globalConfigDialog = { ...dialog, busy: true, error: '' };
+    this.state.globalConfigDialog = { ...dialog, busy: true, busyAction: 'cloud-context-power', busyTarget: name, error: '' };
     this.emit();
     try {
       const context = (await action(name)) as UICloudContextStatus;
@@ -926,6 +1060,8 @@ export class ERunUIController {
           cloudContexts: replaceCloudContext(this.state.globalConfigDialog.config.cloudContexts || [], context),
         },
         busy: false,
+        busyAction: '',
+        busyTarget: '',
         error: '',
       };
       this.showTerminalMessage(`${label} cloud context ${context.kubernetesContext}.`);
@@ -935,6 +1071,8 @@ export class ERunUIController {
       this.state.globalConfigDialog = {
         ...this.state.globalConfigDialog,
         busy: false,
+        busyAction: '',
+        busyTarget: '',
         error: message,
       };
       this.showTerminalMessage(message);
@@ -947,7 +1085,7 @@ export class ERunUIController {
     if (dialog.busy || dialog.configLoading) {
       return;
     }
-    this.state.globalConfigDialog = { ...dialog, busy: true, error: '' };
+    this.state.globalConfigDialog = { ...dialog, busy: true, busyAction: 'cloud-provider-init', busyTarget: '', error: '' };
     this.emit();
     try {
       this.fitAddon?.fit();
@@ -967,6 +1105,8 @@ export class ERunUIController {
       this.state.globalConfigDialog = {
         ...this.state.globalConfigDialog,
         busy: false,
+        busyAction: '',
+        busyTarget: '',
         error: message,
       };
       this.showTerminalMessage(message);
@@ -979,7 +1119,7 @@ export class ERunUIController {
     if (dialog.busy || dialog.configLoading) {
       return;
     }
-    this.state.globalConfigDialog = { ...dialog, busy: true, error: '' };
+    this.state.globalConfigDialog = { ...dialog, busy: true, busyAction: 'cloud-provider-login', busyTarget: alias, error: '' };
     this.emit();
     try {
       const provider = await LoginCloudProvider(alias);
@@ -990,6 +1130,8 @@ export class ERunUIController {
           cloudProviders: replaceCloudProvider(this.state.globalConfigDialog.config.cloudProviders || [], provider),
         },
         busy: false,
+        busyAction: '',
+        busyTarget: '',
         error: '',
       };
       this.showTerminalMessage(`${provider.alias}: ${provider.status}`);
@@ -999,6 +1141,8 @@ export class ERunUIController {
       this.state.globalConfigDialog = {
         ...this.state.globalConfigDialog,
         busy: false,
+        busyAction: '',
+        busyTarget: '',
         error: message,
       };
       this.showTerminalMessage(message);
@@ -1011,7 +1155,7 @@ export class ERunUIController {
     if (dialog.busy || dialog.configLoading) {
       return;
     }
-    this.state.globalConfigDialog = { ...dialog, busy: true, error: '' };
+    this.state.globalConfigDialog = { ...dialog, busy: true, busyAction: 'save', busyTarget: '', error: '' };
     this.emit();
     try {
       const result = (await SaveERunConfig(dialog.config as Parameters<typeof SaveERunConfig>[0])) as UIERunConfig;
@@ -1019,6 +1163,8 @@ export class ERunUIController {
         ...this.state.globalConfigDialog,
         config: result,
         busy: false,
+        busyAction: '',
+        busyTarget: '',
         error: '',
       };
       this.showTerminalMessage('Saved ERun config.');
@@ -1028,6 +1174,8 @@ export class ERunUIController {
       this.state.globalConfigDialog = {
         ...this.state.globalConfigDialog,
         busy: false,
+        busyAction: '',
+        busyTarget: '',
         error: message,
       };
       this.showTerminalMessage(message);
@@ -1195,7 +1343,11 @@ export class ERunUIController {
       this.state.manageDialog = defaultManageDialog();
       this.state.terminalCopyOutput = '';
       this.state.terminalCopyStatus = '';
-      const warning = result.namespaceDeleteError ? ` Namespace deletion failed: ${result.namespaceDeleteError}` : '';
+      const warnings = [
+        result.namespaceDeleteError ? `Namespace deletion failed: ${result.namespaceDeleteError}` : '',
+        result.cloudContextStopError ? `Cloud context stop failed: ${result.cloudContextStopError}` : '',
+      ].filter(Boolean).join(' ');
+      const warning = warnings ? ` ${warnings}` : '';
       this.showTerminalMessage(`Deleted ${result.tenant} / ${result.environment}.${warning}`);
     } catch (error) {
       const message = readError(error);
@@ -1265,8 +1417,9 @@ export class ERunUIController {
     WindowToggleMaximise();
   }
 
-  showTerminalMessage(message: string): void {
+  showTerminalMessage(message: string, busy = false): void {
     this.state.terminalMessage = message;
+    this.state.terminalBusy = busy;
     this.emit();
   }
 
@@ -1326,15 +1479,19 @@ export class ERunUIController {
   }
 
   private async startInitSelection(selection: UISelection): Promise<void> {
+    const runSelection = { ...selection, debug: this.state.debugOpen || undefined };
     this.state.selected = selection;
+    if (this.state.debugOpen) {
+      this.state.debugOutput = `$ ${formatDebugCommand(runSelection, 'init')}\n`;
+    }
     this.emit();
     this.state.terminalCopyOutput = '';
     this.state.terminalCopyStatus = '';
     this.showTerminalMessage(`Initializing ${selection.tenant} / ${selection.environment}...`);
 
     this.fitAddon?.fit();
-    const result = (await StartInitSession(selection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
-    this.initSessionSelections.set(result.sessionId, selection);
+    const result = (await StartInitSession(runSelection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
+    this.initSessionSelections.set(result.sessionId, runSelection);
     this.state.sessionId = result.sessionId;
 
     this.resetTerminal();
@@ -1345,15 +1502,19 @@ export class ERunUIController {
   }
 
   private async startDeploySelection(selection: UISelection): Promise<void> {
+    const runSelection = { ...selection, debug: this.state.debugOpen || undefined };
     this.state.selected = selection;
+    if (this.state.debugOpen) {
+      this.state.debugOutput = `$ ${formatDebugCommand(runSelection, 'deploy')}\n`;
+    }
     this.emit();
     this.state.terminalCopyOutput = '';
     this.state.terminalCopyStatus = '';
     this.showTerminalMessage(`Deploying ${selection.tenant} / ${selection.environment}...`);
 
     this.fitAddon?.fit();
-    const result = (await StartDeploySession(selection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
-    this.deploySessionSelections.set(result.sessionId, selection);
+    const result = (await StartDeploySession(runSelection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
+    this.deploySessionSelections.set(result.sessionId, runSelection);
     this.state.sessionId = result.sessionId;
 
     this.resetTerminal();
@@ -1499,8 +1660,26 @@ export class ERunUIController {
 
   private hideTerminalMessage(): void {
     this.state.terminalMessage = '';
+    this.state.terminalBusy = false;
     this.state.terminalCopyOutput = '';
     this.state.terminalCopyStatus = '';
+    this.emit();
+  }
+
+  private handleAppStatus(payload: AppStatusPayload): void {
+    const message = String(payload?.message || '').trim();
+    if (!message) {
+      return;
+    }
+    this.appendDebugOutput(`[status] ${message}\n`);
+    this.showTerminalMessage(message, payload.busy === true);
+  }
+
+  private appendDebugOutput(text: string): void {
+    if (!this.state.debugOpen || !text) {
+      return;
+    }
+    this.state.debugOutput = trimDebugOutput(this.state.debugOutput + text);
     this.emit();
   }
 
@@ -1512,10 +1691,23 @@ export class ERunUIController {
     const existing = this.sessionBuffers.get(payload.sessionId) || [];
     existing.push(data);
     this.sessionBuffers.set(payload.sessionId, existing);
+    this.appendDebugOutput(decodeDebugOutput(data));
+    const displayData = this.filterTerminalDisplayData(payload.sessionId, data);
+    if (displayData) {
+      const displayBuffer = this.sessionDisplayBuffers.get(payload.sessionId) || [];
+      displayBuffer.push(displayData);
+      this.sessionDisplayBuffers.set(payload.sessionId, displayBuffer);
+    }
     if (payload.sessionId !== this.state.sessionId) {
       return;
     }
-    this.terminal?.write(data);
+    if (!displayData) {
+      return;
+    }
+    if (this.state.terminalMessage && !this.state.terminalCopyOutput) {
+      this.hideTerminalMessage();
+    }
+    this.terminal?.write(displayData);
   }
 
   private async handleTerminalExit(payload: TerminalExitPayload): Promise<void> {
@@ -1615,6 +1807,11 @@ export class ERunUIController {
     const maxFilesForReview = reviewWidth > 0 ? reviewWidth - 260 : MAX_FILES_WIDTH;
     const filesMaximum = Math.max(MIN_FILES_WIDTH, Math.min(MAX_FILES_WIDTH, maxFilesForReview));
     root.style.setProperty('--files-width', `${clamp(this.state.filesWidth, MIN_FILES_WIDTH, filesMaximum)}px`);
+
+    const paneHeight = this.terminalPane?.getBoundingClientRect().height || 0;
+    const maxDebugForPane = paneHeight > 0 ? paneHeight - 120 : MAX_DEBUG_HEIGHT;
+    const debugMaximum = Math.max(MIN_DEBUG_HEIGHT, Math.min(MAX_DEBUG_HEIGHT, maxDebugForPane));
+    root.style.setProperty('--debug-height', `${clamp(this.state.debugHeight, MIN_DEBUG_HEIGHT, debugMaximum)}px`);
   }
 
   private queueTerminalResize = (): void => {
@@ -1707,7 +1904,49 @@ export class ERunUIController {
     this.focusTerminalSoon();
   }
 
-  private writeTerminalBuffer(chunks: Uint8Array[]): void {
+  private rebuildTerminalDisplayBuffer(sessionId: number): void {
+    this.debugOpenFilters.delete(sessionId);
+    const chunks = this.sessionBuffers.get(sessionId) || [];
+    const displayBuffer: TerminalWriteData[] = [];
+    for (const chunk of chunks) {
+      const displayData = this.filterTerminalDisplayData(sessionId, chunk);
+      if (displayData) {
+        displayBuffer.push(displayData);
+      }
+    }
+    if (displayBuffer.length > 0) {
+      this.sessionDisplayBuffers.set(sessionId, displayBuffer);
+    } else {
+      this.sessionDisplayBuffers.delete(sessionId);
+    }
+  }
+
+  private filterTerminalDisplayData(sessionId: number, data: Uint8Array): TerminalWriteData | null {
+    const selection = this.openSessionSelections.get(sessionId);
+    if (!selection?.debug) {
+      return data;
+    }
+    const filter = this.debugOpenFilters.get(sessionId) || { released: false, pending: '' };
+    if (filter.released) {
+      return data;
+    }
+
+    const text = new TextDecoder().decode(data);
+    const output = filter.pending + text;
+    const titleIndex = output.indexOf('\x1B]0;');
+    if (titleIndex === -1) {
+      filter.pending = output.slice(-16);
+      this.debugOpenFilters.set(sessionId, filter);
+      return null;
+    }
+
+    filter.released = true;
+    filter.pending = '';
+    this.debugOpenFilters.set(sessionId, filter);
+    return output.slice(titleIndex);
+  }
+
+  private writeTerminalBuffer(chunks: TerminalWriteData[]): void {
     for (const chunk of chunks) {
       this.terminal?.write(chunk);
     }
@@ -1721,6 +1960,66 @@ function cleanTerminalOutput(value: string): string {
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')
     .trim();
+}
+
+function decodeDebugOutput(data: Uint8Array): string {
+  return new TextDecoder()
+    .decode(data)
+    .replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n');
+}
+
+function trimDebugOutput(value: string): string {
+  const maxLength = 80_000;
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return value.slice(value.length - maxLength);
+}
+
+function formatDebugCommand(selection: UISelection, mode: 'open' | 'init' | 'deploy' = 'open'): string {
+  const args = ['erun'];
+  if (selection.debug) {
+    args.push('-vv');
+  }
+  if (mode === 'init') {
+    args.push('init', selection.tenant, selection.environment, '--remote');
+    if (selection.version) {
+      args.push('--version', selection.version);
+    }
+    if (selection.runtimeImage) {
+      args.push('--runtime-image', selection.runtimeImage);
+    }
+    if (selection.kubernetesContext) {
+      args.push('--kubernetes-context', selection.kubernetesContext);
+    }
+    if (selection.containerRegistry) {
+      args.push('--container-registry', selection.containerRegistry);
+    }
+    args.push(`--set-default-tenant=${selection.setDefaultTenant ? 'true' : 'false'}`, '--confirm-environment=true');
+    if (selection.noGit) {
+      args.push('--no-git');
+    }
+  } else if (mode === 'deploy') {
+    args.push('open', selection.tenant, selection.environment, '--no-shell', '--no-alias-prompt');
+    if (selection.version) {
+      args.push('--version', selection.version);
+    }
+    if (selection.runtimeImage) {
+      args.push('--runtime-image', selection.runtimeImage);
+    }
+  } else {
+    args.push('open', selection.tenant, selection.environment);
+  }
+  return args.map(shellDebugArg).join(' ');
+}
+
+function shellDebugArg(value: string): string {
+  if (/^[A-Za-z0-9._/:=-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function replaceCloudProvider(providers: UICloudProviderStatus[], provider: UICloudProviderStatus): UICloudProviderStatus[] {

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -20,10 +20,15 @@ export const DEFAULT_REVIEW_WIDTH = 620;
 export const MIN_FILES_WIDTH = 220;
 export const MAX_FILES_WIDTH = 460;
 export const DEFAULT_FILES_WIDTH = 300;
+export const MIN_DEBUG_HEIGHT = 120;
+export const MAX_DEBUG_HEIGHT = 520;
+export const DEFAULT_DEBUG_HEIGHT = 220;
 export const SIDEBAR_WIDTH_STORAGE_KEY = 'erun.sidebarWidth';
 export const REVIEW_WIDTH_STORAGE_KEY = 'erun.reviewWidth';
 export const FILES_WIDTH_STORAGE_KEY = 'erun.filesWidth';
 export const FILES_OPEN_STORAGE_KEY = 'erun.filesOpen';
+export const DEBUG_OPEN_STORAGE_KEY = 'erun.debugOpen';
+export const DEBUG_HEIGHT_STORAGE_KEY = 'erun.debugHeight';
 
 export interface EnvironmentDialogState {
   open: boolean;
@@ -72,6 +77,8 @@ export interface GlobalConfigDialogState {
   cloudContextDraft: UICloudContextInitInput;
   configLoading: boolean;
   busy: boolean;
+  busyAction: '' | 'save' | 'cloud-context-init' | 'cloud-context-power' | 'cloud-provider-init' | 'cloud-provider-login';
+  busyTarget: string;
   error: string;
 }
 
@@ -98,8 +105,12 @@ export interface AppState {
   diffFilter: string;
   collapsedDiffDirs: Set<string>;
   terminalMessage: string;
+  terminalBusy: boolean;
   terminalCopyOutput: string;
   terminalCopyStatus: string;
+  debugOpen: boolean;
+  debugHeight: number;
+  debugOutput: string;
 }
 
 export const defaultEnvironmentDialog = (): EnvironmentDialogState => ({
@@ -149,6 +160,8 @@ export const defaultGlobalConfigDialog = (): GlobalConfigDialogState => ({
   cloudContextDraft: defaultCloudContextInitInput(),
   configLoading: false,
   busy: false,
+  busyAction: '',
+  busyTarget: '',
   error: '',
 });
 

--- a/erun-ui/frontend/src/app/storage.ts
+++ b/erun-ui/frontend/src/app/storage.ts
@@ -1,13 +1,18 @@
 import {
   DEFAULT_FILES_WIDTH,
+  DEFAULT_DEBUG_HEIGHT,
   DEFAULT_REVIEW_WIDTH,
   DEFAULT_SIDEBAR_WIDTH,
+  DEBUG_HEIGHT_STORAGE_KEY,
+  DEBUG_OPEN_STORAGE_KEY,
   FILES_OPEN_STORAGE_KEY,
   FILES_WIDTH_STORAGE_KEY,
   MAX_FILES_WIDTH,
+  MAX_DEBUG_HEIGHT,
   MAX_REVIEW_WIDTH,
   MAX_SIDEBAR_WIDTH,
   MIN_FILES_WIDTH,
+  MIN_DEBUG_HEIGHT,
   MIN_REVIEW_WIDTH,
   MIN_SIDEBAR_WIDTH,
   REVIEW_WIDTH_STORAGE_KEY,
@@ -26,11 +31,23 @@ export function loadSavedFilesWidth(): number {
   return loadSavedNumber(FILES_WIDTH_STORAGE_KEY, DEFAULT_FILES_WIDTH, MIN_FILES_WIDTH, MAX_FILES_WIDTH);
 }
 
+export function loadSavedDebugHeight(): number {
+  return loadSavedNumber(DEBUG_HEIGHT_STORAGE_KEY, DEFAULT_DEBUG_HEIGHT, MIN_DEBUG_HEIGHT, MAX_DEBUG_HEIGHT);
+}
+
 export function loadSavedFilesOpen(): boolean {
   try {
     return window.localStorage.getItem(FILES_OPEN_STORAGE_KEY) !== 'false';
   } catch {
     return true;
+  }
+}
+
+export function loadSavedDebugOpen(): boolean {
+  try {
+    return window.localStorage.getItem(DEBUG_OPEN_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
   }
 }
 

--- a/erun-ui/frontend/src/app/versionSuggestions.ts
+++ b/erun-ui/frontend/src/app/versionSuggestions.ts
@@ -108,5 +108,5 @@ export function deleteConfirmationValue(selection: UISelection): string {
 }
 
 export function selectionKey(selection: UISelection): string {
-  return `${selection.tenant}\u0000${selection.environment}`;
+  return `${selection.tenant}\u0000${selection.environment}\u0000${selection.debug === true ? 'debug' : 'normal'}`;
 }

--- a/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
@@ -18,6 +18,9 @@ export function GlobalConfigDialogView({ controller, state }: { controller: ERun
   const tenantOptions = optionValues(state.tenants.map((tenant) => tenant.name), config.defaultTenant);
   const selectedCloudProvider = (config.cloudProviders || []).find((provider) => provider.alias === dialog.cloudContextDraft.cloudProviderAlias);
   const generatedCloudContextName = generatedContextName(selectedCloudProvider, dialog.cloudContextDraft.region, config.cloudContexts || []);
+  const saving = dialog.busyAction === 'save';
+  const initializingContext = dialog.busyAction === 'cloud-context-init';
+  const initializingCloudProvider = dialog.busyAction === 'cloud-provider-init';
 
   return (
     <Dialog open={dialog.open} onOpenChange={(open) => !open && controller.closeGlobalConfigDialog()}>
@@ -53,7 +56,7 @@ export function GlobalConfigDialogView({ controller, state }: { controller: ERun
                   <Label>Cloud aliases</Label>
                   <div className="flex gap-1.5">
                     <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => void controller.startAWSCloudInit()}>
-                      <Plus aria-hidden="true" />
+                      {initializingCloudProvider ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Plus aria-hidden="true" />}
                       AWS
                     </Button>
                     <Button type="button" variant="ghost" size="icon" disabled={dialog.busy} aria-label="Refresh cloud aliases" onClick={() => void controller.refreshCloudProviders()}>
@@ -84,7 +87,7 @@ export function GlobalConfigDialogView({ controller, state }: { controller: ERun
                             {provider.message ? ` - ${provider.message}` : ''}
                           </div>
                         </div>
-                        <CloudAliasAction status={provider.status} busy={dialog.busy} onLogin={() => void controller.loginCloudProvider(provider.alias)} />
+                        <CloudAliasAction status={provider.status} busy={dialog.busy} loading={dialog.busyAction === 'cloud-provider-login' && dialog.busyTarget === provider.alias} onLogin={() => void controller.loginCloudProvider(provider.alias)} />
                       </div>
                     ))}
                   </div>
@@ -137,7 +140,7 @@ export function GlobalConfigDialogView({ controller, state }: { controller: ERun
                         onChange={(event) => controller.updateCloudContextDraft({ name: event.target.value })}
                       />
                       <Button type="button" size="sm" disabled={dialog.busy || dialog.configLoading || !dialog.cloudContextDraft.cloudProviderAlias || !dialog.cloudContextDraft.region} onClick={() => void controller.initCloudContext()}>
-                        {dialog.busy ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Plus aria-hidden="true" />}
+                        {initializingContext ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Plus aria-hidden="true" />}
                         Init
                       </Button>
                     </div>
@@ -169,7 +172,13 @@ export function GlobalConfigDialogView({ controller, state }: { controller: ERun
                             {context.message ? ` - ${context.message}` : ''}
                           </div>
                         </div>
-                        <CloudContextAction status={context.status} busy={dialog.busy} onStart={() => void controller.startCloudContext(context.name)} onStop={() => void controller.stopCloudContext(context.name)} />
+                        <CloudContextAction
+                          status={context.status}
+                          busy={dialog.busy}
+                          loading={dialog.busyAction === 'cloud-context-power' && dialog.busyTarget === context.name}
+                          onStart={() => void controller.startCloudContext(context.name)}
+                          onStop={() => void controller.stopCloudContext(context.name)}
+                        />
                       </div>
                     ))}
                   </div>
@@ -187,8 +196,8 @@ export function GlobalConfigDialogView({ controller, state }: { controller: ERun
               Cancel
             </Button>
             <Button type="submit" size="sm" disabled={dialog.busy || dialog.configLoading}>
-              {dialog.busy ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Save aria-hidden="true" />}
-              {dialog.busy ? 'Saving...' : 'Save settings'}
+              {saving ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Save aria-hidden="true" />}
+              {saving ? 'Saving...' : 'Save settings'}
             </Button>
           </DialogFooter>
         </form>
@@ -212,7 +221,7 @@ function StatusBadge({ status }: { status: string }): React.ReactElement {
   );
 }
 
-function CloudAliasAction({ status, busy, onLogin }: { status: string; busy: boolean; onLogin: () => void }): React.ReactElement {
+function CloudAliasAction({ status, busy, loading, onLogin }: { status: string; busy: boolean; loading: boolean; onLogin: () => void }): React.ReactElement {
   if (status.trim() === 'active') {
     return (
       <div className="inline-flex items-center gap-1.5 px-1 text-xs font-medium text-green-700 dark:text-green-400" aria-label="Connected">
@@ -223,25 +232,25 @@ function CloudAliasAction({ status, busy, onLogin }: { status: string; busy: boo
   }
   return (
     <Button type="button" variant="outline" size="sm" disabled={busy} onClick={onLogin}>
-      <LogIn aria-hidden="true" />
-      Login
+      {loading ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <LogIn aria-hidden="true" />}
+      {loading ? 'Logging in...' : 'Login'}
     </Button>
   );
 }
 
-function CloudContextAction({ status, busy, onStart, onStop }: { status: string; busy: boolean; onStart: () => void; onStop: () => void }): React.ReactElement {
+function CloudContextAction({ status, busy, loading, onStart, onStop }: { status: string; busy: boolean; loading: boolean; onStart: () => void; onStop: () => void }): React.ReactElement {
   if (status.trim() === 'running') {
     return (
       <Button type="button" variant="outline" size="sm" disabled={busy} onClick={onStop}>
-        <Power aria-hidden="true" />
-        Stop
+        {loading ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Power aria-hidden="true" />}
+        {loading ? 'Stopping...' : 'Stop'}
       </Button>
     );
   }
   return (
     <Button type="button" variant="outline" size="sm" disabled={busy} onClick={onStart}>
-      <Play aria-hidden="true" />
-      Start
+      {loading ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Play aria-hidden="true" />}
+      {loading ? 'Starting...' : 'Start'}
     </Button>
   );
 }

--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AlertTriangle, Check, ChevronsUpDown, LoaderCircle, Rocket, Save, Trash2 } from 'lucide-react';
+import { AlertTriangle, Check, ChevronsUpDown, LoaderCircle, Play, Power, Rocket, Save, Server, Trash2 } from 'lucide-react';
 
 import type { ERunUIController } from '@/app/ERunUIController';
 import { readError } from '@/app/errors';
@@ -12,7 +12,7 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import type { UIPortStatus, UIVersionSuggestion } from '@/types';
+import type { UICloudContextStatus, UIPortStatus, UIVersionSuggestion } from '@/types';
 import { cn } from '@/lib/utils';
 
 const dialogErrorClassName =
@@ -68,6 +68,13 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
                 <ReadonlyField id="environment-config-kubernetescontext" label="Kubernetes context" value={config.kubernetesContext} />
                 <ReadonlyField id="environment-config-containerregistry" label="Container registry" value={config.containerRegistry} />
                 <TextField id="environment-config-cloudprovideralias" label="Cloud alias" value={config.cloudProviderAlias} disabled={dialog.busy} onChange={(cloudProviderAlias) => controller.updateManageConfig({ cloudProviderAlias })} />
+                <CloudContextField
+                  context={config.cloudContext}
+                  cloudProviderAlias={config.cloudProviderAlias}
+                  disabled={dialog.busy || dialog.configLoading}
+                  onStart={(name) => void controller.startManageCloudContext(name)}
+                  onStop={(name) => void controller.stopManageCloudContext(name)}
+                />
                 <RuntimeDeployField
                   configuredVersion={config.runtimeVersion}
                   overrideVersion={dialog.version}
@@ -153,6 +160,61 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
         </form>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function CloudContextField({
+  context,
+  cloudProviderAlias,
+  disabled,
+  onStart,
+  onStop,
+}: {
+  context: UICloudContextStatus | undefined;
+  cloudProviderAlias: string;
+  disabled?: boolean;
+  onStart: (name: string) => void;
+  onStop: (name: string) => void;
+}): React.ReactElement {
+  if (!context) {
+    return (
+      <div className="grid gap-2">
+        <div className="text-sm font-medium leading-none">Cloud context</div>
+        <div className="rounded-[var(--radius)] border border-dashed border-border px-3 py-2.5 text-[13px] leading-[1.35] text-muted-foreground">
+          {cloudProviderAlias.trim() ? 'No linked cloud context' : 'Not linked'}
+        </div>
+      </div>
+    );
+  }
+  const running = context.status.trim() === 'running';
+  return (
+    <div className="grid gap-2">
+      <div className="text-sm font-medium leading-none">Cloud context</div>
+      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-[var(--radius)] border border-border px-3 py-2.5">
+        <div className="grid min-w-0 gap-1">
+          <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+            <Server className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+            <span className="truncate">{context.kubernetesContext || context.name}</span>
+            <StatusBadge status={context.status} />
+          </div>
+          <div className="truncate text-xs text-muted-foreground">
+            {[context.cloudProviderAlias, context.region, context.instanceType, context.instanceId].filter(Boolean).join(' | ')}
+            {context.message ? ` - ${context.message}` : ''}
+          </div>
+        </div>
+        {running ? (
+          <Button type="button" variant="outline" size="sm" disabled={disabled} onClick={() => onStop(context.name)}>
+            <Power aria-hidden="true" />
+            Stop
+          </Button>
+        ) : (
+          <Button type="button" variant="outline" size="sm" disabled={disabled} onClick={() => onStart(context.name)}>
+            <Play aria-hidden="true" />
+            Start
+          </Button>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -242,6 +304,21 @@ function RuntimeDeployField({
         </Button>
       </div>
     </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }): React.ReactElement {
+  const normalized = status.trim() || 'unknown';
+  const className =
+    normalized === 'running'
+      ? 'border-green-600/35 bg-green-600/10 text-green-700 dark:text-green-400'
+      : normalized === 'stopped'
+        ? 'border-border bg-muted/40 text-muted-foreground'
+        : 'border-[color-mix(in_oklch,var(--destructive)_35%,var(--border))] bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] text-destructive';
+  return (
+    <span className={`shrink-0 rounded-[calc(var(--radius)-2px)] border px-1.5 py-0.5 text-[11px] leading-none font-medium ${className}`}>
+      {normalized.replace(/_/g, ' ')}
+    </span>
   );
 }
 

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -22,6 +22,7 @@ export interface UISelection {
   noGit?: boolean;
   setDefaultTenant?: boolean;
   action?: EnvironmentActionMode;
+  debug?: boolean;
 }
 
 export interface UIBuildDetails {
@@ -126,6 +127,7 @@ export interface UIEnvironmentConfig {
   kubernetesContext: string;
   containerRegistry: string;
   cloudProviderAlias: string;
+  cloudContext?: UICloudContextStatus;
   runtimeVersion: string;
   sshd: UISSHDConfig;
   localPorts: UIEnvironmentLocalPorts;
@@ -158,6 +160,7 @@ export interface DeleteEnvironmentResult {
   namespace?: string;
   kubernetesContext?: string;
   namespaceDeleteError?: string;
+  cloudContextStopError?: string;
 }
 
 export interface DiffResult {

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -74,8 +74,8 @@ func buildOpenCommand(cliPath, tenant, environment string) string {
 	return shellQuote(cliPath) + " open " + shellQuote(strings.TrimSpace(tenant)) + " " + shellQuote(strings.TrimSpace(environment))
 }
 
-func buildOpenArgs(tenant, environment string) []string {
-	return []string{"open", strings.TrimSpace(tenant), strings.TrimSpace(environment)}
+func buildOpenArgs(tenant, environment string, debug ...bool) []string {
+	return erunArgs(debugEnabled(debug...), "open", strings.TrimSpace(tenant), strings.TrimSpace(environment))
 }
 
 func buildOpenNoShellArgs(tenant, environment string) []string {
@@ -97,7 +97,7 @@ func ensureMCPViaOpenCommand(ctx context.Context, cliPath string, result eruncom
 }
 
 func buildInitArgs(selection uiSelection) []string {
-	args := []string{"init", strings.TrimSpace(selection.Tenant), strings.TrimSpace(selection.Environment), "--remote"}
+	args := erunArgs(selection.Debug, "init", strings.TrimSpace(selection.Tenant), strings.TrimSpace(selection.Environment), "--remote")
 	if version := strings.TrimSpace(selection.Version); version != "" {
 		args = append(args, "--version", version)
 	}
@@ -121,8 +121,10 @@ func buildInitArgs(selection uiSelection) []string {
 	return args
 }
 
-func buildDeployArgs(tenant, environment, version, runtimeImage string) []string {
-	args := []string{"open", strings.TrimSpace(tenant), strings.TrimSpace(environment), "--no-shell", "--no-alias-prompt"}
+func buildDeployArgs(selection uiSelection) []string {
+	args := erunArgs(selection.Debug, "open", strings.TrimSpace(selection.Tenant), strings.TrimSpace(selection.Environment), "--no-shell", "--no-alias-prompt")
+	version := selection.Version
+	runtimeImage := selection.RuntimeImage
 	if version = strings.TrimSpace(version); version != "" {
 		args = append(args, "--version", version)
 	}
@@ -130,6 +132,20 @@ func buildDeployArgs(tenant, environment, version, runtimeImage string) []string
 		args = append(args, "--runtime-image", runtimeImage)
 	}
 	return args
+}
+
+func erunArgs(debug bool, args ...string) []string {
+	if !debug {
+		return args
+	}
+	result := make([]string, 0, len(args)+1)
+	result = append(result, "-vv")
+	result = append(result, args...)
+	return result
+}
+
+func debugEnabled(values ...bool) bool {
+	return len(values) > 0 && values[0]
 }
 
 func buildCloudInitAWSArgs() []string {


### PR DESCRIPTION
## Summary
- start linked cloud provider contexts before opening or deleting managed environments
- add environment settings controls for starting and stopping linked cloud contexts
- add visible progress/status output and a resizable debug panel that runs erun with -vv while expanded
- include desktop UX guidance for status visibility and action boundaries

## Validation
- go test ./... in erun-ui
- PATH=/opt/homebrew/opt/node@24/bin:$PATH yarn build in erun-ui/frontend
- PATH=/opt/homebrew/opt/node@24/bin:$PATH yarn shadcn:check in erun-ui/frontend
- git diff --check

Closes #152