### PR TITLE
Fix remote init and desktop review

### DIFF
--- a/erun-cli/cmd/delete.go
+++ b/erun-cli/cmd/delete.go
@@ -17,7 +17,7 @@ func newDeleteCmd(store common.DeleteStore, promptRunner PromptRunner, deleteNam
 		Args:         cobra.ExactArgs(2),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDeleteCommand(commandContext(cmd), store, promptRunner, deleteNamespace, args[0], args[1])
+			return runDeleteCommand(withCloudContextPreflight(commandContext(cmd), store), store, promptRunner, deleteNamespace, args[0], args[1])
 		},
 	}
 	addDryRunFlag(cmd)

--- a/erun-cli/cmd/deploy.go
+++ b/erun-cli/cmd/deploy.go
@@ -16,7 +16,7 @@ func newDeployCmd(store common.DeployStore, findProjectRoot common.ProjectFinder
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext(cmd)
+			ctx := withCloudContextPreflight(commandContext(cmd), store)
 			deployTarget, err := resolveDeployTargetArgs(args, target)
 			if err != nil {
 				return err
@@ -52,7 +52,7 @@ func newK8sDeployCmd(store common.DeployStore, findProjectRoot common.ProjectFin
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := commandContext(cmd)
+			ctx := withCloudContextPreflight(commandContext(cmd), store)
 			snapshotOverride, err := resolveSnapshotFlagOverride(cmd, snapshot, noSnapshot)
 			if err != nil {
 				return err

--- a/erun-cli/cmd/exec_test.go
+++ b/erun-cli/cmd/exec_test.go
@@ -18,10 +18,13 @@ func TestExecDiffPrintsRawGitDiff(t *testing.T) {
 			if dir != "/tmp/project" {
 				t.Fatalf("unexpected git dir: %q", dir)
 			}
-			if strings.Join(args, " ") != "diff --no-color --no-ext-diff" {
+			switch strings.Join(args, " ") {
+			case "diff --no-color --no-ext-diff":
+				_, _ = io.WriteString(stdout, "diff --git a/a.txt b/a.txt\n")
+			case "ls-files --others --exclude-standard -z":
+			default:
 				t.Fatalf("unexpected git args: %+v", args)
 			}
-			_, _ = io.WriteString(stdout, "diff --git a/a.txt b/a.txt\n")
 			return nil
 		},
 	})

--- a/erun-cli/cmd/init.go
+++ b/erun-cli/cmd/init.go
@@ -57,6 +57,8 @@ func newInitCmd(runInit func(common.Context, common.BootstrapInitParams) error) 
 	cmd.Flags().StringVar(&params.RuntimeImage, "runtime-image", "", "Runtime image repository to initialize and deploy")
 	cmd.Flags().StringVar(&params.KubernetesContext, "kubernetes-context", "", "Kubernetes context to associate with the environment")
 	cmd.Flags().StringVar(&params.ContainerRegistry, "container-registry", "", "Container registry to associate with the environment")
+	cmd.Flags().StringVar(&params.CodeCommitSSHKeyID, "codecommit-ssh-key-id", "", "CodeCommit SSH public key ID to use for remote repository access")
+	cmd.Flags().BoolVar(&params.Bootstrap, "bootstrap", false, "Create the tenant devops module and chart during initialization")
 	cmd.Flags().BoolVar(&params.Remote, "remote", false, "Initialize the tenant repository inside the runtime pod instead of the local host")
 	cmd.Flags().BoolVar(&params.NoGit, "no-git", false, "Skip remote Git checkout setup when used with --remote")
 	cmd.Flags().BoolVar(&setDefaultTenant, "set-default-tenant", false, "Set the initialized tenant as the default tenant")
@@ -96,6 +98,24 @@ func remoteRepositoryURLPrompt(run PromptRunner, label string) (string, error) {
 		Validate: func(input string) error {
 			if strings.TrimSpace(input) == "" {
 				return fmt.Errorf("repository remote URL is required")
+			}
+			return nil
+		},
+	}
+
+	result, err := run(prompt)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result), nil
+}
+
+func codeCommitSSHKeyIDPrompt(run PromptRunner, label string) (string, error) {
+	prompt := promptui.Prompt{
+		Label: label,
+		Validate: func(input string) error {
+			if strings.TrimSpace(input) == "" {
+				return fmt.Errorf("CodeCommit SSH public key ID is required")
 			}
 			return nil
 		},

--- a/erun-cli/cmd/init_test.go
+++ b/erun-cli/cmd/init_test.go
@@ -366,12 +366,12 @@ func TestInitCommandAcceptsRuntimeVersionOverride(t *testing.T) {
 		got = params
 		return nil
 	})
-	cmd.SetArgs([]string{"erun", "local", "--version", "1.0.19-snapshot-20260418141901", "--runtime-image", "erun-devops", "--no-git"})
+	cmd.SetArgs([]string{"erun", "local", "--version", "1.0.19-snapshot-20260418141901", "--runtime-image", "erun-devops", "--no-git", "--bootstrap"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
-	if got.RuntimeVersion != "1.0.19-snapshot-20260418141901" || got.RuntimeImage != "erun-devops" || !got.NoGit {
+	if got.RuntimeVersion != "1.0.19-snapshot-20260418141901" || got.RuntimeImage != "erun-devops" || !got.NoGit || !got.Bootstrap {
 		t.Fatalf("unexpected init params: %+v", got)
 	}
 }

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -22,7 +22,7 @@ const (
 
 var currentHostOS = func() common.HostOS { return common.DetectHost().OS }
 
-func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), saveEnvConfig func(string, common.EnvConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateMCP MCPForwarder, activateSSHD SSHDActivator, launchVSCode VSCodeLauncher, launchIntelliJ IntelliJLauncher) *cobra.Command {
+func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen func(common.OpenParams) (common.OpenResult, error), saveEnvConfig func(string, common.EnvConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateMCP MCPForwarder, activateSSHD SSHDActivator, launchVSCode VSCodeLauncher, launchIntelliJ IntelliJLauncher) *cobra.Command {
 	var noShell bool
 	var vscode bool
 	var intellij bool
@@ -40,6 +40,9 @@ func newOpenCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), 
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext(cmd)
+			if prepareContext != nil {
+				ctx = prepareContext(ctx)
+			}
 			if vscode && intellij {
 				return fmt.Errorf("--vscode and --intellij cannot be used together")
 			}
@@ -245,6 +248,9 @@ func resolveOpenWithInitRetryForParams(ctx common.Context, params common.OpenPar
 }
 
 func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateMCP MCPForwarder, activateSSHD SSHDActivator, launchVSCode VSCodeLauncher, launchIntelliJ IntelliJLauncher) error {
+	if err := ctx.EnsureKubernetesContext(result.EnvConfig.KubernetesContext); err != nil {
+		return err
+	}
 	namespace := common.KubernetesNamespaceName(result.Tenant, result.Environment)
 	if options.VSCode && options.IntelliJ {
 		return fmt.Errorf("--vscode and --intellij cannot be used together")

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -42,6 +42,7 @@ func Execute() error {
 	activateMCP := newMCPForwarder()
 	activateSSHD := newSSHDActivator(common.RunRemoteCommand)
 	runManagedDeploy := func(ctx common.Context, target common.OpenResult) error {
+		ctx = withCloudContextPreflight(ctx, store)
 		specs, err := common.ResolveCurrentDeploySpecs(
 			store,
 			common.FindProjectRoot,
@@ -62,6 +63,9 @@ func Execute() error {
 
 	initCmd := newInitCmd(runInit)
 	openCmd := newOpenCmd(
+		func(ctx common.Context) common.Context {
+			return withCloudContextPreflight(ctx, store)
+		},
 		resolveOpen,
 		store.SaveEnvConfig,
 		runInitForOpen,
@@ -76,7 +80,9 @@ func Execute() error {
 		launchVSCode,
 		launchIntelliJ,
 	)
-	sshdCmd := newSSHDCmd(resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, recoveringDeployHelmChart, common.RunRemoteCommand, writeLocalSSHConfig)
+	sshdCmd := newSSHDCmd(func(ctx common.Context) common.Context {
+		return withCloudContextPreflight(ctx, store)
+	}, resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, recoveringDeployHelmChart, common.RunRemoteCommand, writeLocalSSHConfig)
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
@@ -119,7 +125,7 @@ func Execute() error {
 	}, common.ResolveDefaultRuntimeRegistryVersions)
 
 	runRoot := func(cmd *cobra.Command, args []string) error {
-		ctx := commandContext(cmd)
+		ctx := withCloudContextPreflight(commandContext(cmd), store)
 		result, initRan, err := resolveOpenWithInitStop(ctx, args, shouldInitRootCommand, resolveOpen, runInitForArgs)
 		if err != nil {
 			return err
@@ -133,4 +139,13 @@ func Execute() error {
 	cmd := newRootCommand(runRoot)
 	addCommands(cmd, initCmd, openCmd, sshdCmd, devopsCmd, buildCmd, pushCmd, deployCmd, mcpCmd, appCmd, execCmd, cloudCmd, contextCmd, listCmd, doctorCmd, deleteCmd, releaseCmd, versionCmd)
 	return cmd.Execute()
+}
+
+func withCloudContextPreflight(ctx common.Context, store any) common.Context {
+	cloudStore, ok := store.(common.CloudContextStore)
+	if !ok {
+		return ctx
+	}
+	ctx.KubernetesContextPreflight = common.CloudContextPreflight(cloudStore, common.CloudContextDependencies{})
+	return ctx
 }

--- a/erun-cli/cmd/root_runtime.go
+++ b/erun-cli/cmd/root_runtime.go
@@ -63,6 +63,7 @@ func newRootCommand(runRoot func(*cobra.Command, []string) error) *cobra.Command
 
 func newRunInit(store common.BootstrapStore, findProjectRoot common.ProjectFinderFunc, promptRunner PromptRunner, selectRunner SelectRunner, listKubernetesContexts KubernetesContextsLister, ensureKubernetesNamespace common.NamespaceEnsurerFunc, waitForRemoteRuntime common.RemoteRuntimeWaitFunc, runRemoteCommand common.RemoteCommandRunnerFunc, deployHelmChart common.HelmChartDeployerFunc) func(common.Context, common.BootstrapInitParams) error {
 	return func(ctx common.Context, params common.BootstrapInitParams) error {
+		ctx = withCloudContextPreflight(ctx, store)
 		if strings.TrimSpace(params.RuntimeVersion) == "" {
 			params.RuntimeVersion = currentBuildInfo().Version
 		}
@@ -83,6 +84,9 @@ func newRunInit(store common.BootstrapStore, findProjectRoot common.ProjectFinde
 			},
 			PromptRemoteRepositoryURL: func(label string) (string, error) {
 				return remoteRepositoryURLPrompt(promptRunner, label)
+			},
+			PromptCodeCommitSSHKeyID: func(label string) (string, error) {
+				return codeCommitSSHKeyIDPrompt(promptRunner, label)
 			},
 			EnsureKubernetesNamespace: common.TraceNamespaceEnsurer(ctx, ensureKubernetesNamespace),
 			LoadProjectConfig:         common.LoadProjectConfig,

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -152,6 +152,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	}
 	push := newPushOperation(pushDockerImage, loginToDockerRegistry, selectRunner)
 	runManagedDeploy := func(ctx common.Context, target common.OpenResult) error {
+		ctx = withCloudContextPreflight(ctx, store)
 		specs, err := common.ResolveCurrentDeploySpecs(
 			store,
 			findProjectRoot,
@@ -180,8 +181,12 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	runInitForOpen := newRunInitForOpen(store, runInit)
 
 	initCmd := newInitCmd(runInit)
-	openCmd := newOpenCmd(resolveOpen, store.SaveEnvConfig, runInitForOpen, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart, activateMCP, activateSSHD, launchVSCodeCmd, launchIntelliJCmd)
-	sshdCmd := newSSHDCmd(resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, openDeployHelmChart, deps.RunRemoteCommand, writeLocalSSHConfig)
+	openCmd := newOpenCmd(func(ctx common.Context) common.Context {
+		return withCloudContextPreflight(ctx, store)
+	}, resolveOpen, store.SaveEnvConfig, runInitForOpen, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart, activateMCP, activateSSHD, launchVSCodeCmd, launchIntelliJCmd)
+	sshdCmd := newSSHDCmd(func(ctx common.Context) common.Context {
+		return withCloudContextPreflight(ctx, store)
+	}, resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, openDeployHelmChart, deps.RunRemoteCommand, writeLocalSSHConfig)
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
@@ -235,7 +240,7 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	}, deps.ResolveRuntimeRegistryVersions)
 
 	runRoot := func(cmd *cobra.Command, args []string) error {
-		ctx := commandContext(cmd)
+		ctx := withCloudContextPreflight(commandContext(cmd), store)
 		result, initRan, err := resolveOpenWithInitStop(ctx, args, shouldInitRootCommand, resolveOpen, runInitForArgs)
 		if err != nil {
 			return err

--- a/erun-cli/cmd/sshd.go
+++ b/erun-cli/cmd/sshd.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newSSHDCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), saveEnvConfig func(string, common.EnvConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, runRemoteCommand common.RemoteCommandRunnerFunc, writeLocalConfig SSHDLocalConfigWriter) *cobra.Command {
+func newSSHDCmd(prepareContext func(common.Context) common.Context, resolveOpen func(common.OpenParams) (common.OpenResult, error), saveEnvConfig func(string, common.EnvConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, runRemoteCommand common.RemoteCommandRunnerFunc, writeLocalConfig SSHDLocalConfigWriter) *cobra.Command {
 	var publicKeyPath string
 	var localPort int
 	target := common.OpenParams{}
@@ -19,6 +19,9 @@ func newSSHDCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), 
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := commandContext(cmd)
+			if prepareContext != nil {
+				ctx = prepareContext(ctx)
+			}
 			params, err := resolveOpenParams(args, target)
 			if err != nil {
 				return err

--- a/erun-common/cloud_context.go
+++ b/erun-common/cloud_context.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -293,6 +294,62 @@ func StartCloudContext(ctx Context, store CloudContextStore, params CloudContext
 		return CloudContextStatus{}, err
 	}
 	return status, nil
+}
+
+func CloudContextPreflight(store CloudContextStore, deps CloudContextDependencies) KubernetesContextPreflightFunc {
+	var mu sync.Mutex
+	started := make(map[string]struct{})
+	return func(ctx Context, kubernetesContext string) error {
+		kubernetesContext = strings.TrimSpace(kubernetesContext)
+		if kubernetesContext == "" || store == nil {
+			return nil
+		}
+
+		mu.Lock()
+		if _, ok := started[kubernetesContext]; ok {
+			mu.Unlock()
+			return nil
+		}
+		mu.Unlock()
+
+		status, ok, err := findCloudContextForKubernetesContext(store, kubernetesContext)
+		if err != nil || !ok {
+			return err
+		}
+		if strings.TrimSpace(status.Status) == CloudContextStatusRunning {
+			return nil
+		}
+
+		if _, err := StartCloudContext(ctx, store, CloudContextParams{Name: status.Name}, deps); err != nil {
+			return err
+		}
+
+		mu.Lock()
+		started[kubernetesContext] = struct{}{}
+		if name := strings.TrimSpace(status.Name); name != "" {
+			started[name] = struct{}{}
+		}
+		mu.Unlock()
+		return nil
+	}
+}
+
+func findCloudContextForKubernetesContext(store CloudReadStore, kubernetesContext string) (CloudContextStatus, bool, error) {
+	kubernetesContext = strings.TrimSpace(kubernetesContext)
+	if kubernetesContext == "" {
+		return CloudContextStatus{}, false, nil
+	}
+	contexts, err := ListCloudContexts(store)
+	if err != nil {
+		return CloudContextStatus{}, false, err
+	}
+	for _, context := range contexts {
+		context = NormalizeCloudContextConfig(context)
+		if strings.TrimSpace(context.KubernetesContext) == kubernetesContext || strings.TrimSpace(context.Name) == kubernetesContext {
+			return CloudContextStatus{CloudContextConfig: context}, true, nil
+		}
+	}
+	return CloudContextStatus{}, false, nil
 }
 
 func changeCloudContextPowerState(ctx Context, store CloudContextStore, params CloudContextParams, deps CloudContextDependencies, awsAction, status string) (CloudContextStatus, error) {

--- a/erun-common/cloud_context_test.go
+++ b/erun-common/cloud_context_test.go
@@ -1,6 +1,7 @@
 package eruncommon
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 	"time"
@@ -60,6 +61,89 @@ func TestInitCloudContextUsesDefaultsAndStoresKubeContext(t *testing.T) {
 	}
 	if len(awsCommands) == 0 || len(kubectlCommands) != 3 {
 		t.Fatalf("expected AWS and kubeconfig commands, got aws=%+v kubectl=%+v", awsCommands, kubectlCommands)
+	}
+}
+
+func TestCloudContextPreflightDryRunTracesStartForStoppedContext(t *testing.T) {
+	store := &memoryCloudStore{config: ERunConfig{
+		CloudProviders: []CloudProviderConfig{{
+			Alias:    "team-cloud",
+			Provider: CloudProviderAWS,
+			Profile:  "erun-sso",
+		}},
+		CloudContexts: []CloudContextConfig{{
+			Name:               "team-context",
+			Provider:           CloudProviderAWS,
+			CloudProviderAlias: "team-cloud",
+			Region:             DefaultCloudContextRegion,
+			InstanceID:         "i-test",
+			PublicIP:           "198.51.100.10",
+			InstanceType:       DefaultCloudContextInstanceType,
+			DiskType:           DefaultCloudContextDiskType,
+			DiskSizeGB:         DefaultCloudContextDiskSizeGB,
+			KubernetesContext:  "cluster-prod",
+			AdminToken:         "test-token",
+			Status:             CloudContextStatusStopped,
+		}},
+	}}
+	trace := new(bytes.Buffer)
+	ctx := Context{
+		DryRun: true,
+		Logger: NewLoggerWithWriters(2, trace, trace),
+	}
+	ctx.KubernetesContextPreflight = CloudContextPreflight(store, CloudContextDependencies{})
+
+	if err := ctx.EnsureKubernetesContext("cluster-prod"); err != nil {
+		t.Fatalf("EnsureKubernetesContext failed: %v", err)
+	}
+
+	output := trace.String()
+	for _, want := range []string{
+		"aws ec2 start-instances --instance-ids i-test --region eu-west-2 --profile erun-sso",
+		"aws ec2 wait instance-running --instance-ids i-test --region eu-west-2 --profile erun-sso",
+		"aws ec2 describe-instances --instance-ids i-test --query 'Reservations[0].Instances[0].PublicIpAddress' --output text --region eu-west-2 --profile erun-sso",
+		"kubectl config set-cluster cluster-prod --server https://203.0.113.10:6443 --insecure-skip-tls-verify=true",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected dry-run trace to contain %q, got:\n%s", want, output)
+		}
+	}
+	if store.config.CloudContexts[0].Status != CloudContextStatusStopped {
+		t.Fatalf("dry-run should not persist cloud context start, got %+v", store.config.CloudContexts[0])
+	}
+}
+
+func TestCloudContextPreflightSkipsRunningContext(t *testing.T) {
+	store := &memoryCloudStore{config: ERunConfig{
+		CloudProviders: []CloudProviderConfig{{
+			Alias:    "team-cloud",
+			Provider: CloudProviderAWS,
+		}},
+		CloudContexts: []CloudContextConfig{{
+			Name:               "team-context",
+			Provider:           CloudProviderAWS,
+			CloudProviderAlias: "team-cloud",
+			Region:             DefaultCloudContextRegion,
+			InstanceID:         "i-test",
+			KubernetesContext:  "cluster-prod",
+			AdminToken:         "test-token",
+			Status:             CloudContextStatusRunning,
+		}},
+	}}
+	ctx := Context{}
+	ctx.KubernetesContextPreflight = CloudContextPreflight(store, CloudContextDependencies{
+		RunAWS: func(Context, CloudProviderConfig, string, []string) (string, error) {
+			t.Fatal("did not expect AWS command for running cloud context")
+			return "", nil
+		},
+		RunKubectl: func(Context, []string) error {
+			t.Fatal("did not expect kubectl command for running cloud context")
+			return nil
+		},
+	})
+
+	if err := ctx.EnsureKubernetesContext("cluster-prod"); err != nil {
+		t.Fatalf("EnsureKubernetesContext failed: %v", err)
 	}
 }
 

--- a/erun-common/context.go
+++ b/erun-common/context.go
@@ -7,12 +7,15 @@ import (
 )
 
 type Context struct {
-	Logger Logger
-	DryRun bool
-	Stdin  io.Reader
-	Stdout io.Writer
-	Stderr io.Writer
+	Logger                     Logger
+	DryRun                     bool
+	Stdin                      io.Reader
+	Stdout                     io.Writer
+	Stderr                     io.Writer
+	KubernetesContextPreflight KubernetesContextPreflightFunc
 }
+
+type KubernetesContextPreflightFunc func(Context, string) error
 
 func (c Context) Trace(message string) {
 	c.Logger.Trace(message)
@@ -24,6 +27,14 @@ func (c Context) Info(message string) {
 
 func (c Context) TraceCommand(dir, name string, args ...string) {
 	c.Logger.Trace(formatShellCommand(dir, name, args...))
+}
+
+func (c Context) EnsureKubernetesContext(contextName string) error {
+	contextName = strings.TrimSpace(contextName)
+	if contextName == "" || c.KubernetesContextPreflight == nil {
+		return nil
+	}
+	return c.KubernetesContextPreflight(c, contextName)
 }
 
 func (c Context) TraceBlock(label, body string) {

--- a/erun-common/default_devops_module.go
+++ b/erun-common/default_devops_module.go
@@ -116,23 +116,27 @@ func ensureDefaultDevopsFile(ctx Context, path string, mode os.FileMode, content
 }
 
 func shouldReplaceDefaultDevopsFile(path string, existing, content []byte) bool {
-	legacy := []string{
-		"ARG ERUN_BASE_IMAGE=erunpaas/erun-devops\nARG ERUN_BASE_VERSION=1.0.0\n\nFROM ${ERUN_BASE_IMAGE}:${ERUN_BASE_VERSION}\n",
-		"ARG ERUN_BASE_TAG=erunpaas/erun-devops:1.0.0\n\nFROM ${ERUN_BASE_TAG}\n",
-		"ARG ERUN_BASE_TAG=erunpaas/erun-devops:1.0.0\n\nFROM ${ERUN_BASE_TAG}\n\nENTRYPOINT [\"/bin/sh\", \"-lc\", \"if [ \\\"${1:-}\\\" = shell ]; then shift; repo_dir=\\\"${ERUN_REPO_PATH:-${HOME}/git/erun}\\\"; [ -d \\\"$repo_dir\\\" ] && cd \\\"$repo_dir\\\"; exec /bin/bash -i; fi; exec erun-devops-entrypoint \\\"$@\\\"\", \"erun-devops-wrapper\"]\n",
-	}
 	current := strings.TrimSpace(string(existing))
-	switch filepath.Base(path) {
-	case "Dockerfile":
-		for _, candidate := range legacy {
-			if current == strings.TrimSpace(candidate) {
-				return true
-			}
+	for _, candidate := range defaultDevopsLegacyContents(path, content) {
+		if current == strings.TrimSpace(candidate) {
+			return true
 		}
-	case "service.yaml":
-		return current == strings.TrimSpace(legacyDefaultDevopsServiceTemplate(content))
 	}
 	return false
+}
+
+func defaultDevopsLegacyContents(path string, content []byte) []string {
+	switch filepath.Base(path) {
+	case "Dockerfile":
+		return []string{
+			"ARG ERUN_BASE_IMAGE=erunpaas/erun-devops\nARG ERUN_BASE_VERSION=1.0.0\n\nFROM ${ERUN_BASE_IMAGE}:${ERUN_BASE_VERSION}\n",
+			"ARG ERUN_BASE_TAG=erunpaas/erun-devops:1.0.0\n\nFROM ${ERUN_BASE_TAG}\n",
+			"ARG ERUN_BASE_TAG=erunpaas/erun-devops:1.0.0\n\nFROM ${ERUN_BASE_TAG}\n\nENTRYPOINT [\"/bin/sh\", \"-lc\", \"if [ \\\"${1:-}\\\" = shell ]; then shift; repo_dir=\\\"${ERUN_REPO_PATH:-${HOME}/git/erun}\\\"; [ -d \\\"$repo_dir\\\" ] && cd \\\"$repo_dir\\\"; exec /bin/bash -i; fi; exec erun-devops-entrypoint \\\"$@\\\"\", \"erun-devops-wrapper\"]\n",
+		}
+	case "service.yaml":
+		return []string{legacyDefaultDevopsServiceTemplate(content)}
+	}
+	return nil
 }
 
 func legacyDefaultDevopsServiceTemplate(content []byte) string {

--- a/erun-common/delete.go
+++ b/erun-common/delete.go
@@ -78,6 +78,9 @@ func RunDeleteEnvironment(ctx Context, params DeleteEnvironmentParams, store Del
 
 	if envConfig.Remote {
 		result.Namespace = KubernetesNamespaceName(tenant, environment)
+		if err := ctx.EnsureKubernetesContext(result.KubernetesContext); err != nil {
+			return result, err
+		}
 		TraceDeleteKubernetesNamespace(ctx, result.KubernetesContext, result.Namespace)
 		if !ctx.DryRun {
 			if err := deleteNamespace(result.KubernetesContext, result.Namespace); err != nil {

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -138,6 +138,9 @@ func RunHelmDeploy(ctx Context, deployInput HelmDeploySpec, deploy HelmChartDepl
 	if deploy == nil {
 		return fmt.Errorf("helm deployer is required")
 	}
+	if err := ctx.EnsureKubernetesContext(deployInput.KubernetesContext); err != nil {
+		return err
+	}
 	TraceEnsureKubernetesNamespace(ctx, deployInput.KubernetesContext, deployInput.Namespace)
 	command := deployInput.command()
 	ctx.TraceCommand(command.Dir, command.Name, command.Args...)

--- a/erun-common/diff.go
+++ b/erun-common/diff.go
@@ -85,10 +85,56 @@ func ResolveGitDiff(projectRoot string, runGit GitCommandRunnerFunc) (DiffResult
 	if err := runGit(projectRoot, stdout, stderr, "diff", "--no-color", "--no-ext-diff"); err != nil {
 		return DiffResult{}, fmt.Errorf("git diff: %w%s", err, formatGitCommandStderr(stderr.String()))
 	}
+	if err := appendUntrackedGitDiff(projectRoot, stdout, runGit); err != nil {
+		return DiffResult{}, err
+	}
 
 	result := ParseGitDiff(stdout.String())
 	result.WorkingDirectory = projectRoot
 	return result, nil
+}
+
+func appendUntrackedGitDiff(projectRoot string, rawDiff *bytes.Buffer, runGit GitCommandRunnerFunc) error {
+	untrackedOutput := new(bytes.Buffer)
+	untrackedStderr := new(bytes.Buffer)
+	if err := runGit(projectRoot, untrackedOutput, untrackedStderr, "ls-files", "--others", "--exclude-standard", "-z"); err != nil {
+		return fmt.Errorf("git ls-files: %w%s", err, formatGitCommandStderr(untrackedStderr.String()))
+	}
+	for _, file := range splitNULTerminated(untrackedOutput.String()) {
+		file = strings.TrimSpace(file)
+		if file == "" {
+			continue
+		}
+		fileDiff := new(bytes.Buffer)
+		fileStderr := new(bytes.Buffer)
+		err := runGit(projectRoot, fileDiff, fileStderr, "diff", "--no-color", "--no-ext-diff", "--no-index", "--", "/dev/null", file)
+		if err != nil && fileDiff.Len() == 0 {
+			return fmt.Errorf("git diff untracked %s: %w%s", file, err, formatGitCommandStderr(fileStderr.String()))
+		}
+		appendRawDiff(rawDiff, fileDiff.String())
+	}
+	return nil
+}
+
+func splitNULTerminated(value string) []string {
+	value = strings.TrimSuffix(value, "\x00")
+	if value == "" {
+		return nil
+	}
+	return strings.Split(value, "\x00")
+}
+
+func appendRawDiff(rawDiff *bytes.Buffer, diff string) {
+	if diff == "" {
+		return
+	}
+	if rawDiff.Len() > 0 && !strings.HasSuffix(rawDiff.String(), "\n") {
+		rawDiff.WriteString("\n")
+	}
+	rawDiff.WriteString(diff)
+	if !strings.HasSuffix(diff, "\n") {
+		rawDiff.WriteString("\n")
+	}
 }
 
 func ParseGitDiff(raw string) DiffResult {

--- a/erun-common/diff_test.go
+++ b/erun-common/diff_test.go
@@ -2,6 +2,7 @@ package eruncommon
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -101,21 +102,78 @@ func TestParseGitDiffDetectsDeletedAndRenamedFiles(t *testing.T) {
 
 func TestResolveGitDiffRunsNoColorDiff(t *testing.T) {
 	var gotDir string
-	var gotArgs []string
+	calls := make([]string, 0, 2)
 	result, err := ResolveGitDiff("/tmp/project", func(dir string, stdout, stderr io.Writer, args ...string) error {
 		gotDir = dir
-		gotArgs = append([]string{}, args...)
-		_, _ = io.WriteString(stdout, "diff --git a/a.txt b/a.txt\n")
+		calls = append(calls, strings.Join(args, " "))
+		switch len(calls) {
+		case 1:
+			_, _ = io.WriteString(stdout, "diff --git a/a.txt b/a.txt\n")
+		case 2:
+			_, _ = io.WriteString(stdout, "")
+		default:
+			t.Fatalf("unexpected git call: %v", args)
+		}
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("ResolveGitDiff failed: %v", err)
 	}
-	if gotDir != "/tmp/project" || strings.Join(gotArgs, " ") != "diff --no-color --no-ext-diff" {
-		t.Fatalf("unexpected git invocation: dir=%q args=%+v", gotDir, gotArgs)
+	if gotDir != "/tmp/project" || len(calls) != 2 || calls[0] != "diff --no-color --no-ext-diff" || calls[1] != "ls-files --others --exclude-standard -z" {
+		t.Fatalf("unexpected git invocation: dir=%q calls=%+v", gotDir, calls)
 	}
 	if result.WorkingDirectory != "/tmp/project" || result.RawDiff == "" {
 		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestResolveGitDiffIncludesUntrackedFiles(t *testing.T) {
+	result, err := ResolveGitDiff("/tmp/project", func(dir string, stdout, stderr io.Writer, args ...string) error {
+		switch strings.Join(args, " ") {
+		case "diff --no-color --no-ext-diff":
+			_, _ = io.WriteString(stdout, "diff --git a/existing.txt b/existing.txt\n")
+			return nil
+		case "ls-files --others --exclude-standard -z":
+			_, _ = io.WriteString(stdout, "new.txt\x00nested/newer.txt\x00")
+			return nil
+		case "diff --no-color --no-ext-diff --no-index -- /dev/null new.txt":
+			_, _ = io.WriteString(stdout, strings.Join([]string{
+				"diff --git a/new.txt b/new.txt",
+				"new file mode 100644",
+				"--- /dev/null",
+				"+++ b/new.txt",
+				"@@ -0,0 +1 @@",
+				"+new",
+				"",
+			}, "\n"))
+			return fmt.Errorf("exit status 1")
+		case "diff --no-color --no-ext-diff --no-index -- /dev/null nested/newer.txt":
+			_, _ = io.WriteString(stdout, strings.Join([]string{
+				"diff --git a/nested/newer.txt b/nested/newer.txt",
+				"new file mode 100644",
+				"--- /dev/null",
+				"+++ b/nested/newer.txt",
+				"@@ -0,0 +1 @@",
+				"+newer",
+				"",
+			}, "\n"))
+			return fmt.Errorf("exit status 1")
+		default:
+			t.Fatalf("unexpected git call: %v", args)
+			return nil
+		}
+	})
+	if err != nil {
+		t.Fatalf("ResolveGitDiff failed: %v", err)
+	}
+	if result.Summary.FileCount != 3 || result.Summary.Additions != 2 {
+		t.Fatalf("unexpected summary: %+v files=%+v", result.Summary, result.Files)
+	}
+	if result.Files[1].Path != "new.txt" || result.Files[1].Status != "added" {
+		t.Fatalf("expected untracked file in diff result, got %+v", result.Files)
+	}
+	if result.Files[2].Path != "nested/newer.txt" || result.Files[2].Status != "added" {
+		t.Fatalf("expected nested untracked file in diff result, got %+v", result.Files)
 	}
 }
 

--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -75,6 +75,8 @@ type BootstrapInitParams struct {
 	ContainerRegistry        string
 	Remote                   bool
 	RemoteRepositoryURL      string
+	CodeCommitSSHKeyID       string
+	Bootstrap                bool
 	ConfirmTenant            *bool
 	ConfirmEnvironment       *bool
 	ConfirmRemoteKeyImport   *bool
@@ -91,6 +93,7 @@ const (
 	BootstrapInitInteractionKubernetesContext  BootstrapInitInteractionType = "input_kubernetes_context"
 	BootstrapInitInteractionContainerRegistry  BootstrapInitInteractionType = "input_container_registry"
 	BootstrapInitInteractionRemoteRepository   BootstrapInitInteractionType = "input_remote_repository"
+	BootstrapInitInteractionCodeCommitSSHKeyID BootstrapInitInteractionType = "input_codecommit_ssh_key_id"
 	BootstrapInitInteractionConfirmRemoteKey   BootstrapInitInteractionType = "confirm_remote_key"
 )
 
@@ -136,6 +139,7 @@ type BootstrapInitDependencies struct {
 	PromptKubernetesContext   PromptValueFunc
 	PromptContainerRegistry   PromptValueFunc
 	PromptRemoteRepositoryURL PromptValueFunc
+	PromptCodeCommitSSHKeyID  PromptValueFunc
 	EnsureKubernetesNamespace NamespaceEnsurerFunc
 	LoadProjectConfig         ProjectConfigLoaderFunc
 	SaveProjectConfig         ProjectConfigSaverFunc
@@ -631,8 +635,14 @@ func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, e
 		envConfigChanged = true
 	}
 	if remoteMode {
-		if err := s.ensureRemoteRepository(params, tenant, envName, kubernetesContext, projectRoot); err != nil {
+		req, err := s.ensureRemoteRepository(params, tenant, envName, kubernetesContext, projectRoot)
+		if err != nil {
 			return result, err
+		}
+		if params.Bootstrap {
+			if err := s.ensureRemoteDefaultDevopsBootstrap(req, projectRoot, tenant, envName, params.RuntimeVersion); err != nil {
+				return result, err
+			}
 		}
 	} else {
 		if err := EnsureDefaultDevopsModuleWithVersion(s.Context, projectRoot, tenant, params.RuntimeVersion); err != nil {
@@ -686,6 +696,10 @@ func remoteRepositoryLabel(tenant, envName string) string {
 	return fmt.Sprintf("Git remote URL for environment %q in tenant %q", envName, tenant)
 }
 
+func codeCommitSSHKeyIDLabel(tenant, envName string) string {
+	return fmt.Sprintf("CodeCommit SSH public key ID for environment %q in tenant %q", envName, tenant)
+}
+
 func remoteKeyImportLabel(tenant, envName string) string {
 	return fmt.Sprintf("Import the SSH public key above for environment %q in tenant %q and continue", envName, tenant)
 }
@@ -704,6 +718,7 @@ func normalizeBootstrapParams(params BootstrapInitParams) BootstrapInitParams {
 	params.KubernetesContext = strings.TrimSpace(params.KubernetesContext)
 	params.ContainerRegistry = strings.TrimSpace(params.ContainerRegistry)
 	params.RemoteRepositoryURL = strings.TrimSpace(params.RemoteRepositoryURL)
+	params.CodeCommitSSHKeyID = strings.TrimSpace(params.CodeCommitSSHKeyID)
 	return params
 }
 
@@ -898,6 +913,9 @@ func (s bootstrapRunner) ensureKubernetesNamespace(tenant, envName, currentConte
 	nextContext = strings.TrimSpace(nextContext)
 	if nextContext == "" || nextContext == strings.TrimSpace(currentContext) {
 		return nil
+	}
+	if err := s.Context.EnsureKubernetesContext(nextContext); err != nil {
+		return err
 	}
 
 	namespace := KubernetesNamespaceName(tenant, envName)

--- a/erun-common/init_remote.go
+++ b/erun-common/init_remote.go
@@ -3,20 +3,38 @@ package eruncommon
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"os/exec"
 	"path"
+	"regexp"
 	"strings"
 	"time"
 )
 
 type remoteRepositoryState struct {
-	Exists    bool
-	PublicKey string
+	Exists              bool
+	PublicKey           string
+	CodeCommitPublicKey string
+}
+
+type remoteRepositorySpec struct {
+	URL                string
+	CodeCommitHost     string
+	CodeCommitSSHKeyID string
 }
 
 const remoteRepositoryAccessRetryInterval = 2 * time.Second
 
-func (s bootstrapRunner) ensureRemoteRepository(params BootstrapInitParams, tenant, envName, kubernetesContext, projectRoot string) error {
+var codeCommitHostPattern = regexp.MustCompile(`^git-codecommit\.[a-z0-9-]+\.amazonaws\.com(?:\.cn)?$`)
+
+type remoteDefaultDevopsFile struct {
+	Path    string
+	Mode    string
+	Content []byte
+	Legacy  []string
+}
+
+func (s bootstrapRunner) ensureRemoteRepository(params BootstrapInitParams, tenant, envName, kubernetesContext, projectRoot string) (ShellLaunchParams, error) {
 	ports := DefaultEnvironmentLocalPorts()
 	if portStore, ok := s.Store.(environmentPortStore); ok {
 		resolved, err := ResolveEnvironmentLocalPorts(portStore, tenant, envName)
@@ -45,28 +63,36 @@ func (s bootstrapRunner) ensureRemoteRepository(params BootstrapInitParams, tena
 	req := ShellLaunchParamsFromResult(target)
 
 	if err := s.ensureRemoteRuntime(target, req, params.RuntimeVersion, params.RuntimeImage); err != nil {
-		return err
+		return ShellLaunchParams{}, err
 	}
 	if params.NoGit {
-		return s.ensureRemoteWorktree(req, projectRoot)
+		return req, s.ensureRemoteWorktree(req, projectRoot)
 	}
 
 	state, err := s.remoteRepositoryState(req, projectRoot)
 	if err != nil {
-		return err
+		return ShellLaunchParams{}, err
 	}
 	if state.Exists {
-		return s.pullRemoteRepository(req, projectRoot)
+		return req, s.pullRemoteRepository(req, projectRoot)
 	}
 
 	repositoryURL, err := s.resolveRemoteRepositoryURL(params, tenant, envName)
 	if err != nil {
-		return err
+		return ShellLaunchParams{}, err
 	}
-	if err := s.waitForRemoteKeyImport(params, tenant, envName, req, repositoryURL, state.PublicKey); err != nil {
-		return err
+	repository, err := s.resolveRemoteRepositorySpec(params, tenant, envName, repositoryURL, state.CodeCommitPublicKey)
+	if err != nil {
+		return ShellLaunchParams{}, err
 	}
-	return s.cloneRemoteRepository(req, projectRoot, repositoryURL)
+	publicKey := state.PublicKey
+	if repository.CodeCommitHost != "" {
+		publicKey = state.CodeCommitPublicKey
+	}
+	if err := s.waitForRemoteKeyImport(params, tenant, envName, req, repository, publicKey); err != nil {
+		return ShellLaunchParams{}, err
+	}
+	return req, s.cloneRemoteRepository(req, projectRoot, repository)
 }
 
 func (s bootstrapRunner) ensureRemoteWorktree(req ShellLaunchParams, projectRoot string) error {
@@ -103,6 +129,117 @@ func (s bootstrapRunner) ensureRemoteRuntime(target OpenResult, req ShellLaunchP
 	return s.WaitForRemoteRuntime(req)
 }
 
+func (s bootstrapRunner) ensureRemoteDefaultDevopsBootstrap(req ShellLaunchParams, projectRoot, tenant, envName, runtimeVersion string) error {
+	files, err := remoteDefaultDevopsBootstrapFiles(projectRoot, tenant, envName, runtimeVersion)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return nil
+	}
+
+	lines := []string{"set -eu"}
+	for index, file := range files {
+		lines = append(lines, remoteDefaultDevopsFileScript(index, file)...)
+	}
+
+	output, err := s.runRemoteScript(req, "remote-default-devops-bootstrap", strings.Join(lines, "\n"))
+	if err != nil {
+		return fmt.Errorf("bootstrap remote devops module: %w%s", err, formatRemoteCommandStderr(output.Stderr))
+	}
+	return nil
+}
+
+func remoteDefaultDevopsBootstrapFiles(projectRoot, tenant, envName, runtimeVersion string) ([]remoteDefaultDevopsFile, error) {
+	projectRoot = strings.TrimSpace(projectRoot)
+	tenant = strings.TrimSpace(tenant)
+	if projectRoot == "" || tenant == "" {
+		return nil, nil
+	}
+	projectRoot = path.Clean(projectRoot)
+	moduleName := RuntimeReleaseName(tenant)
+	files := make([]remoteDefaultDevopsFile, 0, len(defaultDevopsModuleTemplates)+len(defaultDevopsChartTemplates)+1)
+	for _, templateFile := range defaultDevopsModuleTemplates {
+		data, err := defaultDevopsModuleFiles.ReadFile(templateFile.AssetPath)
+		if err != nil {
+			return nil, err
+		}
+		targetPath := strings.ReplaceAll(templateFile.TargetPath, "__MODULE_NAME__", moduleName)
+		resolvedPath := path.Join(projectRoot, targetPath)
+		content := renderDefaultDevopsModuleTemplate(templateFile.AssetPath, moduleName, runtimeVersion, data)
+		files = append(files, remoteDefaultDevopsFile{
+			Path:    resolvedPath,
+			Mode:    fmt.Sprintf("%o", templateFile.Mode.Perm()),
+			Content: content,
+			Legacy:  defaultDevopsLegacyContents(resolvedPath, content),
+		})
+	}
+
+	replacer := strings.NewReplacer("__MODULE_NAME__", moduleName)
+	for _, templateFile := range defaultDevopsChartTemplates {
+		data, err := defaultDevopsChartFiles.ReadFile(templateFile.AssetPath)
+		if err != nil {
+			return nil, err
+		}
+		targetPath := replacer.Replace(templateFile.TargetPath)
+		resolvedPath := path.Join(projectRoot, targetPath)
+		content := renderDefaultDevopsChartTemplate(templateFile.AssetPath, moduleName, moduleName, data)
+		files = append(files, remoteDefaultDevopsFile{
+			Path:    resolvedPath,
+			Mode:    fmt.Sprintf("%o", templateFile.Mode.Perm()),
+			Content: content,
+			Legacy:  defaultDevopsLegacyContents(resolvedPath, content),
+		})
+	}
+
+	if strings.TrimSpace(envName) != "" && !isLocalEnvironment(envName) {
+		resolvedPath := path.Join(projectRoot, moduleName, "k8s", moduleName, "values."+strings.ToLower(strings.TrimSpace(envName))+".yaml")
+		files = append(files, remoteDefaultDevopsFile{
+			Path: resolvedPath,
+			Mode: "644",
+		})
+	}
+	return files, nil
+}
+
+func remoteDefaultDevopsFileScript(index int, file remoteDefaultDevopsFile) []string {
+	tmp := fmt.Sprintf("erun_bootstrap_tmp_%d", index)
+	lines := []string{
+		fmt.Sprintf("mkdir -p %s", shellQuote(path.Dir(file.Path))),
+		fmt.Sprintf("if [ -d %s ]; then echo %s >&2; exit 1; fi", shellQuote(file.Path), shellQuote(fmt.Sprintf("%q is a directory", file.Path))),
+		fmt.Sprintf("%s=$(mktemp)", tmp),
+		fmt.Sprintf("printf %%s %s > \"$%s\"", shellQuote(string(file.Content)), tmp),
+		"replace=false",
+		fmt.Sprintf("if [ ! -e %s ]; then", shellQuote(file.Path)),
+		"  replace=true",
+		fmt.Sprintf("elif cmp -s \"$%s\" %s; then", tmp, shellQuote(file.Path)),
+		"  replace=false",
+	}
+	if len(file.Legacy) > 0 {
+		lines = append(lines, "else")
+		for legacyIndex, legacy := range file.Legacy {
+			legacyTmp := fmt.Sprintf("erun_bootstrap_legacy_%d_%d", index, legacyIndex)
+			lines = append(lines,
+				fmt.Sprintf("  %s=$(mktemp)", legacyTmp),
+				fmt.Sprintf("  printf %%s %s > \"$%s\"", shellQuote(legacy), legacyTmp),
+				fmt.Sprintf("  if cmp -s \"$%s\" %s; then replace=true; fi", legacyTmp, shellQuote(file.Path)),
+				fmt.Sprintf("  rm -f \"$%s\"", legacyTmp),
+			)
+		}
+	} else {
+		lines = append(lines,
+			"else",
+			"  replace=false",
+		)
+	}
+	lines = append(lines,
+		"fi",
+		fmt.Sprintf("if [ \"$replace\" = true ]; then cp \"$%s\" %s; chmod %s %s; fi", tmp, shellQuote(file.Path), shellQuote(file.Mode), shellQuote(file.Path)),
+		fmt.Sprintf("rm -f \"$%s\"", tmp),
+	)
+	return lines
+}
+
 func (s bootstrapRunner) resolveRemoteRepositoryURL(params BootstrapInitParams, tenant, envName string) (string, error) {
 	if params.RemoteRepositoryURL != "" {
 		return params.RemoteRepositoryURL, nil
@@ -125,11 +262,51 @@ func (s bootstrapRunner) resolveRemoteRepositoryURL(params BootstrapInitParams, 
 	return repositoryURL, nil
 }
 
-func (s bootstrapRunner) waitForRemoteKeyImport(params BootstrapInitParams, tenant, envName string, req ShellLaunchParams, repositoryURL, publicKey string) error {
+func (s bootstrapRunner) resolveRemoteRepositorySpec(params BootstrapInitParams, tenant, envName, repositoryURL, codeCommitPublicKey string) (remoteRepositorySpec, error) {
+	spec, err := parseRemoteRepositorySpec(repositoryURL)
+	if err != nil {
+		return remoteRepositorySpec{}, err
+	}
+	if spec.CodeCommitHost == "" || spec.CodeCommitSSHKeyID != "" {
+		return spec, nil
+	}
+	keyID := strings.TrimSpace(params.CodeCommitSSHKeyID)
+	details := codeCommitSetupDetails(spec, codeCommitPublicKey, "<SSH public key ID>")
+	if keyID == "" {
+		s.Context.Info(details)
+		if s.PromptCodeCommitSSHKeyID == nil {
+			return remoteRepositorySpec{}, BootstrapInitInteractionError{Interaction: BootstrapInitInteraction{
+				Type:    BootstrapInitInteractionCodeCommitSSHKeyID,
+				Label:   codeCommitSSHKeyIDLabel(tenant, envName),
+				Details: details,
+			}}
+		}
+		prompted, err := s.PromptCodeCommitSSHKeyID(codeCommitSSHKeyIDLabel(tenant, envName))
+		if err != nil {
+			return remoteRepositorySpec{}, err
+		}
+		keyID = strings.TrimSpace(prompted)
+	}
+	if keyID == "" {
+		return remoteRepositorySpec{}, BootstrapInitInteractionError{Interaction: BootstrapInitInteraction{
+			Type:    BootstrapInitInteractionCodeCommitSSHKeyID,
+			Label:   codeCommitSSHKeyIDLabel(tenant, envName),
+			Details: details,
+		}}
+	}
+	spec.CodeCommitSSHKeyID = keyID
+	return spec, nil
+}
+
+func (s bootstrapRunner) waitForRemoteKeyImport(params BootstrapInitParams, tenant, envName string, req ShellLaunchParams, repository remoteRepositorySpec, publicKey string) error {
 	publicKey = strings.TrimSpace(publicKey)
 	if publicKey != "" {
-		s.Context.Info("Import this SSH public key into your git host before continuing:")
-		s.Context.Info(publicKey)
+		if repository.CodeCommitHost != "" {
+			s.Context.Info(codeCommitSetupDetails(repository, publicKey, repository.CodeCommitSSHKeyID))
+		} else {
+			s.Context.Info("Import this SSH public key into your git host before continuing:")
+			s.Context.Info(publicKey)
+		}
 	}
 	if params.ConfirmRemoteKeyImport != nil {
 		if !*params.ConfirmRemoteKeyImport {
@@ -145,7 +322,7 @@ func (s bootstrapRunner) waitForRemoteKeyImport(params BootstrapInitParams, tena
 
 	s.Context.Info("Waiting for the SSH key to be deployed to the git host. Rechecking every 2 seconds. Press Ctrl+C to cancel.")
 	for attempts := 0; ; attempts++ {
-		if err := s.verifyRemoteRepositoryAccess(req, repositoryURL); err == nil {
+		if err := s.verifyRemoteRepositoryAccess(req, repository); err == nil {
 			if attempts > 0 {
 				s.Context.Info("Remote repository access confirmed.")
 			}
@@ -168,10 +345,16 @@ func (s bootstrapRunner) remoteRepositoryState(req ShellLaunchParams, projectRoo
 		"if [ ! -f \"$key\" ]; then ssh-keygen -t ed25519 -N '' -f \"$key\" >/dev/null 2>&1; fi",
 		"chmod 600 \"$key\"",
 		"chmod 644 \"$key.pub\"",
+		"codecommit_key=\"$HOME/.ssh/id_rsa_codecommit\"",
+		"if [ ! -f \"$codecommit_key\" ]; then ssh-keygen -t rsa -b 4096 -N '' -f \"$codecommit_key\" >/dev/null 2>&1; fi",
+		"chmod 600 \"$codecommit_key\"",
+		"chmod 644 \"$codecommit_key.pub\"",
 		fmt.Sprintf("mkdir -p %s", shellQuote(projectRoot)),
 		fmt.Sprintf("if [ -d %s/.git ]; then printf 'repo_exists\\n'; else printf 'repo_missing\\n'; fi", shellQuote(projectRoot)),
 		"printf '__ERUN_REMOTE_PUBLIC_KEY__\\n'",
 		"cat \"$key.pub\"",
+		"printf '\\n__ERUN_REMOTE_CODECOMMIT_PUBLIC_KEY__\\n'",
+		"cat \"$codecommit_key.pub\"",
 	}, "\n")
 
 	output, err := s.runRemoteScript(req, "remote-repository-state", script)
@@ -179,7 +362,11 @@ func (s bootstrapRunner) remoteRepositoryState(req ShellLaunchParams, projectRoo
 		return remoteRepositoryState{}, err
 	}
 	if s.Context.DryRun {
-		return remoteRepositoryState{PublicKey: "<remote-public-key>", Exists: false}, nil
+		return remoteRepositoryState{
+			PublicKey:           "<remote-public-key>",
+			CodeCommitPublicKey: "<remote-codecommit-rsa-public-key>",
+			Exists:              false,
+		}, nil
 	}
 
 	lines := strings.Split(strings.TrimSpace(output.Stdout), "\n")
@@ -187,21 +374,34 @@ func (s bootstrapRunner) remoteRepositoryState(req ShellLaunchParams, projectRoo
 		return remoteRepositoryState{}, fmt.Errorf("remote repository state command returned no output")
 	}
 	state := remoteRepositoryState{Exists: strings.TrimSpace(lines[0]) == "repo_exists"}
-	for index, line := range lines {
-		if strings.TrimSpace(line) != "__ERUN_REMOTE_PUBLIC_KEY__" {
-			continue
-		}
-		state.PublicKey = strings.TrimSpace(strings.Join(lines[index+1:], "\n"))
-		break
-	}
+	state.PublicKey = remoteRepositoryStateSection(lines, "__ERUN_REMOTE_PUBLIC_KEY__")
+	state.CodeCommitPublicKey = remoteRepositoryStateSection(lines, "__ERUN_REMOTE_CODECOMMIT_PUBLIC_KEY__")
 	return state, nil
 }
 
-func (s bootstrapRunner) verifyRemoteRepositoryAccess(req ShellLaunchParams, repositoryURL string) error {
+func remoteRepositoryStateSection(lines []string, marker string) string {
+	for index, line := range lines {
+		if strings.TrimSpace(line) != marker {
+			continue
+		}
+		section := make([]string, 0, len(lines)-index-1)
+		for _, value := range lines[index+1:] {
+			if strings.HasPrefix(strings.TrimSpace(value), "__ERUN_REMOTE_") {
+				break
+			}
+			section = append(section, value)
+		}
+		return strings.TrimSpace(strings.Join(section, "\n"))
+	}
+	return ""
+}
+
+func (s bootstrapRunner) verifyRemoteRepositoryAccess(req ShellLaunchParams, repository remoteRepositorySpec) error {
 	script := strings.Join([]string{
 		"set -eu",
-		"ssh_command='ssh -i \"$HOME/.ssh/id_ed25519\" -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new'",
-		fmt.Sprintf("git -c core.sshCommand=\"$ssh_command\" ls-remote %s HEAD >/dev/null", shellQuote(repositoryURL)),
+		remoteRepositorySSHConfigScript(repository),
+		fmt.Sprintf("ssh_command=%s", shellQuote(remoteRepositorySSHCommand(repository))),
+		fmt.Sprintf("git -c core.sshCommand=\"$ssh_command\" ls-remote %s HEAD >/dev/null", shellQuote(repository.URL)),
 	}, "\n")
 	output, err := s.runRemoteScript(req, "remote-repository-access", script)
 	if err != nil {
@@ -210,14 +410,15 @@ func (s bootstrapRunner) verifyRemoteRepositoryAccess(req ShellLaunchParams, rep
 	return nil
 }
 
-func (s bootstrapRunner) cloneRemoteRepository(req ShellLaunchParams, projectRoot, repositoryURL string) error {
+func (s bootstrapRunner) cloneRemoteRepository(req ShellLaunchParams, projectRoot string, repository remoteRepositorySpec) error {
 	script := strings.Join([]string{
 		"set -eu",
-		"ssh_command='ssh -i \"$HOME/.ssh/id_ed25519\" -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new'",
+		remoteRepositorySSHConfigScript(repository),
+		fmt.Sprintf("ssh_command=%s", shellQuote(remoteRepositorySSHCommand(repository))),
 		fmt.Sprintf("mkdir -p %s", shellQuote(path.Dir(projectRoot))),
 		fmt.Sprintf("mkdir -p %s", shellQuote(projectRoot)),
 		fmt.Sprintf("if [ -n \"$(ls -A %s 2>/dev/null)\" ] && [ ! -d %s/.git ]; then echo 'remote worktree directory exists and is not empty' >&2; exit 1; fi", shellQuote(projectRoot), shellQuote(projectRoot)),
-		fmt.Sprintf("git -c core.sshCommand=\"$ssh_command\" clone %s %s", shellQuote(repositoryURL), shellQuote(projectRoot)),
+		fmt.Sprintf("git -c core.sshCommand=\"$ssh_command\" clone %s %s", shellQuote(repository.URL), shellQuote(projectRoot)),
 	}, "\n")
 	output, err := s.runRemoteScript(req, "remote-repository-clone", script)
 	if err != nil {
@@ -237,6 +438,85 @@ func (s bootstrapRunner) pullRemoteRepository(req ShellLaunchParams, projectRoot
 		return fmt.Errorf("pull remote repository: %w%s", err, formatRemoteCommandStderr(output.Stderr))
 	}
 	return nil
+}
+
+func parseRemoteRepositorySpec(repositoryURL string) (remoteRepositorySpec, error) {
+	repositoryURL = strings.TrimSpace(repositoryURL)
+	if repositoryURL == "" {
+		return remoteRepositorySpec{}, fmt.Errorf("git remote URL is required")
+	}
+	parseURL := repositoryURL
+	codeCommitBareURL := strings.HasPrefix(parseURL, "git-codecommit.")
+	if codeCommitBareURL {
+		parseURL = "ssh://" + parseURL
+	}
+	if !codeCommitBareURL && !strings.Contains(parseURL, "://") {
+		return remoteRepositorySpec{URL: repositoryURL}, nil
+	}
+	parsed, err := url.Parse(parseURL)
+	if err != nil {
+		return remoteRepositorySpec{}, err
+	}
+	host := strings.TrimSpace(parsed.Hostname())
+	if !codeCommitHostPattern.MatchString(host) {
+		return remoteRepositorySpec{URL: repositoryURL}, nil
+	}
+	if parsed.Scheme == "" {
+		parsed.Scheme = "ssh"
+	}
+	keyID := ""
+	if parsed.User != nil {
+		keyID = parsed.User.Username()
+		parsed.User = nil
+	}
+	return remoteRepositorySpec{
+		URL:                parsed.String(),
+		CodeCommitHost:     host,
+		CodeCommitSSHKeyID: keyID,
+	}, nil
+}
+
+func remoteRepositorySSHConfigScript(repository remoteRepositorySpec) string {
+	if repository.CodeCommitHost == "" {
+		return ":"
+	}
+	return strings.Join([]string{
+		"cat > \"$HOME/.ssh/config\" <<'EOF'",
+		codeCommitSSHConfig(repository, repository.CodeCommitSSHKeyID),
+		"EOF",
+		"chmod 600 \"$HOME/.ssh/config\"",
+	}, "\n")
+}
+
+func remoteRepositorySSHCommand(repository remoteRepositorySpec) string {
+	if repository.CodeCommitHost != "" {
+		return `ssh -F "$HOME/.ssh/config"`
+	}
+	return `ssh -i "$HOME/.ssh/id_ed25519" -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new`
+}
+
+func codeCommitSSHConfig(repository remoteRepositorySpec, keyID string) string {
+	keyID = strings.TrimSpace(keyID)
+	if keyID == "" {
+		keyID = "<SSH public key ID>"
+	}
+	return strings.Join([]string{
+		"Host " + repository.CodeCommitHost,
+		"  User " + keyID,
+		"  IdentityFile ~/.ssh/id_rsa_codecommit",
+		"  IdentitiesOnly yes",
+		"  StrictHostKeyChecking accept-new",
+	}, "\n")
+}
+
+func codeCommitSetupDetails(repository remoteRepositorySpec, publicKey, keyID string) string {
+	return strings.Join([]string{
+		"Upload this SSH public key to the IAM user that should access CodeCommit:",
+		strings.TrimSpace(publicKey),
+		"",
+		"Use the SSH public key ID returned by IAM in this SSH host config:",
+		codeCommitSSHConfig(repository, keyID),
+	}, "\n")
 }
 
 func (s bootstrapRunner) runRemoteScript(req ShellLaunchParams, label, script string) (RemoteCommandResult, error) {

--- a/erun-common/init_test.go
+++ b/erun-common/init_test.go
@@ -32,6 +32,7 @@ type bootstrapTestRunner struct {
 	PromptKubernetesContext   PromptValueFunc
 	PromptContainerRegistry   PromptValueFunc
 	PromptRemoteRepositoryURL PromptValueFunc
+	PromptCodeCommitSSHKeyID  PromptValueFunc
 	EnsureKubernetesNamespace NamespaceEnsurerFunc
 	LoadProjectConfig         ProjectConfigLoaderFunc
 	SaveProjectConfig         ProjectConfigSaverFunc
@@ -52,6 +53,7 @@ func (r bootstrapTestRunner) Run(params BootstrapInitParams) (BootstrapInitResul
 		PromptKubernetesContext:   r.PromptKubernetesContext,
 		PromptContainerRegistry:   r.PromptContainerRegistry,
 		PromptRemoteRepositoryURL: r.PromptRemoteRepositoryURL,
+		PromptCodeCommitSSHKeyID:  r.PromptCodeCommitSSHKeyID,
 		EnsureKubernetesNamespace: r.EnsureKubernetesNamespace,
 		LoadProjectConfig:         r.LoadProjectConfig,
 		SaveProjectConfig:         r.SaveProjectConfig,
@@ -73,6 +75,35 @@ func (r bootstrapTestRunner) saveProjectContainerRegistry(projectRoot, envName, 
 		},
 		Context: r.Context,
 	}.saveProjectContainerRegistry(projectRoot, envName, registry, false)
+}
+
+func TestBootstrapEnsureKubernetesNamespaceRunsContextPreflightFirst(t *testing.T) {
+	var actions []string
+	runner := bootstrapRunner{
+		BootstrapInitDependencies: BootstrapInitDependencies{
+			EnsureKubernetesNamespace: func(contextName, namespace string) error {
+				actions = append(actions, "namespace "+contextName+" "+namespace)
+				return nil
+			},
+		},
+		Context: Context{
+			KubernetesContextPreflight: func(_ Context, contextName string) error {
+				actions = append(actions, "preflight "+contextName)
+				return nil
+			},
+		},
+	}
+	runner.BootstrapInitDependencies.Context = runner.Context
+
+	if err := runner.ensureKubernetesNamespace("tenant-a", "dev", "", "cluster-dev"); err != nil {
+		t.Fatalf("ensureKubernetesNamespace failed: %v", err)
+	}
+
+	got := strings.Join(actions, "\n")
+	want := "preflight cluster-dev\nnamespace cluster-dev tenant-a-dev"
+	if got != want {
+		t.Fatalf("unexpected action order:\n%s", got)
+	}
 }
 
 func TestBootstrapRunLoadsExistingConfiguration(t *testing.T) {
@@ -1154,7 +1185,7 @@ func TestBootstrapRunRemoteInitializesTenantInPodWorktree(t *testing.T) {
 			switch len(scripts) {
 			case 1:
 				return RemoteCommandResult{
-					Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n",
+					Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n__ERUN_REMOTE_CODECOMMIT_PUBLIC_KEY__\nssh-rsa AAAACODECOMMITRSA remote\n",
 				}, nil
 			case 2, 3:
 				return RemoteCommandResult{}, nil
@@ -1293,6 +1324,164 @@ func TestBootstrapRunRemoteNoGitCreatesWorktreeWithoutRepositoryPrompts(t *testi
 	for _, unexpected := range []string{"ssh-keygen", "git clone", "git -C"} {
 		if strings.Contains(scripts[0], unexpected) {
 			t.Fatalf("did not expect %q in no-git script:\n%s", unexpected, scripts[0])
+		}
+	}
+}
+
+func TestBootstrapRunRemoteBootstrapCreatesTenantDevopsModuleAndChart(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	scripts := make([]string, 0, 2)
+	projectRoot := RemoteWorktreePathForRepoName("frs")
+	service := bootstrapTestRunner{
+		Context: testContextWithLogger(&testTraceLogger{}),
+		Store:   ConfigStore{},
+		Confirm: func(string) (bool, error) {
+			return true, nil
+		},
+		PromptKubernetesContext: func(string) (string, error) {
+			return "cluster-remote", nil
+		},
+		PromptContainerRegistry: func(string) (string, error) {
+			return DefaultContainerRegistry, nil
+		},
+		PromptRemoteRepositoryURL: func(string) (string, error) {
+			t.Fatal("did not expect Git remote URL prompt")
+			return "", nil
+		},
+		EnsureKubernetesNamespace: func(string, string) error {
+			return nil
+		},
+		DeployHelmChart: func(HelmDeployParams) error {
+			return nil
+		},
+		WaitForRemoteRuntime: func(ShellLaunchParams) error {
+			return nil
+		},
+		RunRemoteCommand: func(_ ShellLaunchParams, script string) (RemoteCommandResult, error) {
+			scripts = append(scripts, script)
+			return RemoteCommandResult{}, nil
+		},
+	}
+
+	if _, err := service.Run(BootstrapInitParams{
+		Tenant:         "frs",
+		Environment:    "dev",
+		Remote:         true,
+		NoGit:          true,
+		Bootstrap:      true,
+		RuntimeVersion: "1.2.3",
+	}); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	if len(scripts) != 2 {
+		t.Fatalf("expected worktree and bootstrap scripts, got %d: %#v", len(scripts), scripts)
+	}
+	bootstrapScript := scripts[1]
+	for _, path := range []string{
+		filepath.Join(projectRoot, "frs-devops", "VERSION"),
+		filepath.Join(projectRoot, "frs-devops", "docker", "frs-devops", "Dockerfile"),
+		filepath.Join(projectRoot, "frs-devops", "k8s", "frs-devops", "Chart.yaml"),
+		filepath.Join(projectRoot, "frs-devops", "k8s", "frs-devops", "values.dev.yaml"),
+	} {
+		if !strings.Contains(bootstrapScript, shellQuote(path)) {
+			t.Fatalf("expected bootstrap script to write %s, got:\n%s", path, bootstrapScript)
+		}
+	}
+	if !strings.Contains(bootstrapScript, "ARG ERUN_BASE_TAG=erunpaas/erun-devops:1.2.3") {
+		t.Fatalf("expected runtime version in bootstrap Dockerfile, got:\n%s", bootstrapScript)
+	}
+}
+
+func TestBootstrapRunRemoteConfiguresCodeCommitSSHRepository(t *testing.T) {
+	setupXDGConfigHome(t)
+
+	var promptedKeyID bool
+	scripts := make([]string, 0, 3)
+	service := bootstrapTestRunner{
+		Context: testContextWithLogger(&testTraceLogger{}),
+		Store:   ConfigStore{},
+		Confirm: func(string) (bool, error) {
+			return true, nil
+		},
+		PromptKubernetesContext: func(string) (string, error) {
+			return "cluster-remote", nil
+		},
+		PromptContainerRegistry: func(string) (string, error) {
+			return DefaultContainerRegistry, nil
+		},
+		PromptRemoteRepositoryURL: func(string) (string, error) {
+			return "git-codecommit.eu-west-1.amazonaws.com/v1/repos/petios", nil
+		},
+		PromptCodeCommitSSHKeyID: func(label string) (string, error) {
+			if label != codeCommitSSHKeyIDLabel("petios", "dev") {
+				t.Fatalf("unexpected CodeCommit SSH key ID label: %q", label)
+			}
+			promptedKeyID = true
+			return "APKATESTCODECOMMITKEY", nil
+		},
+		EnsureKubernetesNamespace: func(string, string) error {
+			return nil
+		},
+		DeployHelmChart: func(HelmDeployParams) error {
+			return nil
+		},
+		WaitForRemoteRuntime: func(ShellLaunchParams) error {
+			return nil
+		},
+		RunRemoteCommand: func(req ShellLaunchParams, script string) (RemoteCommandResult, error) {
+			scripts = append(scripts, script)
+			switch len(scripts) {
+			case 1:
+				return RemoteCommandResult{
+					Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n",
+				}, nil
+			case 2, 3:
+				return RemoteCommandResult{}, nil
+			default:
+				t.Fatalf("unexpected remote command script:\n%s", script)
+				return RemoteCommandResult{}, nil
+			}
+		},
+	}
+
+	if _, err := service.Run(BootstrapInitParams{
+		Tenant:      "petios",
+		Environment: "dev",
+		Remote:      true,
+	}); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	if !promptedKeyID {
+		t.Fatal("expected CodeCommit SSH key ID prompt")
+	}
+	if len(scripts) != 3 {
+		t.Fatalf("expected state/access/clone scripts, got %d", len(scripts))
+	}
+	for _, want := range []string{
+		`ssh-keygen -t ed25519`,
+		`ssh-keygen -t rsa -b 4096`,
+		`id_rsa_codecommit`,
+		`__ERUN_REMOTE_CODECOMMIT_PUBLIC_KEY__`,
+	} {
+		if !strings.Contains(scripts[0], want) {
+			t.Fatalf("expected repository state script to contain %q, got:\n%s", want, scripts[0])
+		}
+	}
+	for _, index := range []int{1, 2} {
+		script := scripts[index]
+		for _, want := range []string{
+			"Host git-codecommit.eu-west-1.amazonaws.com",
+			"User APKATESTCODECOMMITKEY",
+			"IdentityFile ~/.ssh/id_rsa_codecommit",
+			`ssh_command='ssh -F "$HOME/.ssh/config"'`,
+			"ssh://git-codecommit.eu-west-1.amazonaws.com/v1/repos/petios",
+		} {
+			if !strings.Contains(script, want) {
+				t.Fatalf("expected CodeCommit script to contain %q, got:\n%s", want, script)
+			}
 		}
 	}
 }

--- a/erun-common/kubernetes_namespace.go
+++ b/erun-common/kubernetes_namespace.go
@@ -24,6 +24,8 @@ func TraceEnsureKubernetesNamespace(ctx Context, contextName, namespace string) 
 }
 
 func EnsureKubernetesNamespace(contextName, namespace string) error {
+	contextName = strings.TrimSpace(contextName)
+	namespace = strings.TrimSpace(namespace)
 	if exists, err := kubernetesNamespaceExists(contextName, namespace); err != nil {
 		return err
 	} else if exists {
@@ -31,7 +33,7 @@ func EnsureKubernetesNamespace(contextName, namespace string) error {
 	}
 
 	args := []string{}
-	if strings.TrimSpace(contextName) != "" {
+	if contextName != "" {
 		args = append(args, "--context", contextName)
 	}
 	args = append(args, "create", "namespace", namespace)

--- a/erun-mcp/build.go
+++ b/erun-mcp/build.go
@@ -27,7 +27,7 @@ type PushInput struct {
 
 func buildTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, BuildInput) (*mcp.CallToolResult, CommandOutput, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input BuildInput) (*mcp.CallToolResult, CommandOutput, error) {
-		output, err := runRuntimeCommand(runtime.Context, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, workDir string) error {
+		output, err := runRuntimeCommand(runtime, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, workDir string) error {
 			component := strings.TrimSpace(input.Component)
 			version := strings.TrimSpace(input.Version)
 			execution, err := resolveRuntimeBuildExecution(runtime, workDir, component, version, input.Release)
@@ -53,7 +53,7 @@ func buildTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest
 
 func pushTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, PushInput) (*mcp.CallToolResult, CommandOutput, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input PushInput) (*mcp.CallToolResult, CommandOutput, error) {
-		output, err := runRuntimeCommand(runtime.Context, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, workDir string) error {
+		output, err := runRuntimeCommand(runtime, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, workDir string) error {
 			execution, err := resolveRuntimePushExecution(runtime, workDir, strings.TrimSpace(input.Component), strings.TrimSpace(input.Version))
 			if err != nil {
 				return err

--- a/erun-mcp/delete.go
+++ b/erun-mcp/delete.go
@@ -34,7 +34,7 @@ func deleteTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReques
 			deleteStore = eruncommon.ConfigStore{}
 		}
 
-		output, err := runRuntimeCommand(runtime.Context, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, _ string) error {
+		output, err := runRuntimeCommand(runtime, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, _ string) error {
 			result, err := eruncommon.RunDeleteEnvironment(runCtx, eruncommon.DeleteEnvironmentParams{
 				Tenant:      tenant,
 				Environment: environment,

--- a/erun-mcp/deploy.go
+++ b/erun-mcp/deploy.go
@@ -19,7 +19,7 @@ type DeployInput struct {
 
 func deployTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, DeployInput) (*mcp.CallToolResult, CommandOutput, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input DeployInput) (*mcp.CallToolResult, CommandOutput, error) {
-		output, err := runRuntimeCommand(runtime.Context, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, workDir string) error {
+		output, err := runRuntimeCommand(runtime, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, workDir string) error {
 			component := strings.TrimSpace(input.Component)
 			if component == "" {
 				return fmt.Errorf("component is required")

--- a/erun-mcp/doctor.go
+++ b/erun-mcp/doctor.go
@@ -21,7 +21,7 @@ type DoctorInput struct {
 
 func doctorTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, DoctorInput) (*mcp.CallToolResult, CommandOutput, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input DoctorInput) (*mcp.CallToolResult, CommandOutput, error) {
-		output, err := runRuntimeCommand(runtime.Context, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, _ string) error {
+		output, err := runRuntimeCommand(runtime, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, _ string) error {
 			target, err := resolveDoctorOpenResult(runtime, input)
 			if err != nil {
 				return err

--- a/erun-mcp/init.go
+++ b/erun-mcp/init.go
@@ -21,6 +21,8 @@ type InitInput struct {
 	Remote                   bool   `json:"remote,omitempty" jsonschema:"when true, initialize the repository inside the runtime pod"`
 	NoGit                    bool   `json:"noGit,omitempty" jsonschema:"when true with remote initialization, create the remote worktree directory without configuring a Git checkout"`
 	RemoteRepositoryURL      string `json:"remoteRepositoryURL,omitempty" jsonschema:"optional SSH repository URL used when creating the remote checkout"`
+	CodeCommitSSHKeyID       string `json:"codeCommitSSHKeyID,omitempty" jsonschema:"optional AWS CodeCommit SSH public key ID used when the remote repository URL is a CodeCommit SSH URL"`
+	Bootstrap                bool   `json:"bootstrap,omitempty" jsonschema:"when true, create the tenant devops module and chart during initialization"`
 	ConfirmTenant            *bool  `json:"confirmTenant,omitempty" jsonschema:"response to a prior tenant confirmation interaction"`
 	ConfirmEnvironment       *bool  `json:"confirmEnvironment,omitempty" jsonschema:"response to a prior environment confirmation interaction"`
 	ConfirmRemoteKeyImport   *bool  `json:"confirmRemoteKeyImport,omitempty" jsonschema:"response to a prior remote SSH key import confirmation interaction"`
@@ -43,6 +45,7 @@ func initTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest,
 
 		traceOutput := new(bytes.Buffer)
 		ctx := runtimeCallContext(input.Preview, input.Verbosity, nil, traceOutput, traceOutput)
+		ctx.KubernetesContextPreflight = eruncommon.CloudContextPreflight(runtime.Store, eruncommon.CloudContextDependencies{})
 
 		params := eruncommon.BootstrapInitParams{
 			Tenant:                   firstNonEmpty(strings.TrimSpace(input.Tenant), strings.TrimSpace(runtime.Context.Tenant)),
@@ -52,6 +55,7 @@ func initTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest,
 			Environment:              firstNonEmpty(strings.TrimSpace(input.Environment), strings.TrimSpace(runtime.Context.Environment)),
 			RuntimeVersion:           firstNonEmpty(strings.TrimSpace(input.Version), CurrentBuildInfo().Version),
 			NoGit:                    input.NoGit,
+			Bootstrap:                input.Bootstrap,
 			KubernetesContext:        firstNonEmpty(strings.TrimSpace(input.KubernetesContext), strings.TrimSpace(runtime.Context.KubernetesContext)),
 			ContainerRegistry:        strings.TrimSpace(input.ContainerRegistry),
 			ConfirmTenant:            input.ConfirmTenant,
@@ -61,6 +65,7 @@ func initTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest,
 
 		params.Remote = input.Remote
 		params.RemoteRepositoryURL = strings.TrimSpace(input.RemoteRepositoryURL)
+		params.CodeCommitSSHKeyID = strings.TrimSpace(input.CodeCommitSSHKeyID)
 		params.ConfirmRemoteKeyImport = input.ConfirmRemoteKeyImport
 
 		_, err = eruncommon.RunBootstrapInitWithDependencies(eruncommon.BootstrapInitDependencies{

--- a/erun-mcp/release.go
+++ b/erun-mcp/release.go
@@ -32,7 +32,7 @@ func releaseTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReque
 			return nil, ReleaseOutput{}, err
 		}
 
-		commandOutput, err := runRuntimeCommand(runtime.Context, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, _ string) error {
+		commandOutput, err := runRuntimeCommand(runtime, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, _ string) error {
 			return eruncommon.RunReleaseSpec(runCtx, spec, eruncommon.GitCommandRunner, eruncommon.BuildScriptRunner)
 		})
 		if err != nil {

--- a/erun-mcp/runtime.go
+++ b/erun-mcp/runtime.go
@@ -139,11 +139,12 @@ func runCommandOutput(ctx eruncommon.Context, workDir string, traceOutput *bytes
 	}, nil
 }
 
-func runRuntimeCommand(runtime RuntimeContext, preview bool, verbosity int, run func(eruncommon.Context, string) error) (CommandOutput, error) {
+func runRuntimeCommand(runtime RuntimeConfig, preview bool, verbosity int, run func(eruncommon.Context, string) error) (CommandOutput, error) {
 	traceOutput := new(bytes.Buffer)
 	ctx := runtimeCallContext(preview, verbosity, nil, traceOutput, traceOutput)
+	ctx.KubernetesContextPreflight = eruncommon.CloudContextPreflight(runtime.Store, eruncommon.CloudContextDependencies{})
 
-	workDir, err := runtimeRepoPath(runtime)
+	workDir, err := runtimeRepoPath(runtime.Context)
 	if err != nil {
 		return CommandOutput{}, err
 	}

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -85,6 +85,7 @@ type uiSelection struct {
 	KubernetesContext string `json:"kubernetesContext,omitempty"`
 	ContainerRegistry string `json:"containerRegistry,omitempty"`
 	NoGit             bool   `json:"noGit,omitempty"`
+	Bootstrap         bool   `json:"bootstrap,omitempty"`
 	SetDefaultTenant  bool   `json:"setDefaultTenant,omitempty"`
 	Action            string `json:"action,omitempty"`
 	Debug             bool   `json:"debug,omitempty"`
@@ -805,9 +806,6 @@ func (a *App) StartSession(selection uiSelection, cols, rows int) (startSessionR
 	if err != nil {
 		return startSessionResult{}, err
 	}
-	if _, _, err := a.ensureLinkedCloudContextRunning(result.EnvConfig); err != nil {
-		return startSessionResult{}, err
-	}
 
 	a.mu.Lock()
 	if existing := a.sessions[key]; existing != nil && !existing.closed && existing.session != nil {
@@ -1367,6 +1365,7 @@ func normalizeSelection(selection uiSelection) uiSelection {
 		KubernetesContext: strings.TrimSpace(selection.KubernetesContext),
 		ContainerRegistry: strings.TrimSpace(selection.ContainerRegistry),
 		NoGit:             selection.NoGit,
+		Bootstrap:         selection.Bootstrap,
 		SetDefaultTenant:  selection.SetDefaultTenant,
 		Action:            strings.TrimSpace(selection.Action),
 		Debug:             selection.Debug,
@@ -1405,7 +1404,7 @@ func selectionKey(selection uiSelection) string {
 
 func initSelectionKey(selection uiSelection) string {
 	selection = normalizeSelection(selection)
-	return "init\x00" + selection.Tenant + "\x00" + selection.Environment + "\x00" + selection.Version + "\x00" + selection.RuntimeImage + "\x00" + selection.KubernetesContext + "\x00" + selection.ContainerRegistry + "\x00" + fmt.Sprintf("%t", selection.SetDefaultTenant) + "\x00" + fmt.Sprintf("%t", selection.NoGit) + "\x00" + fmt.Sprintf("%t", selection.Debug)
+	return "init\x00" + selection.Tenant + "\x00" + selection.Environment + "\x00" + selection.Version + "\x00" + selection.RuntimeImage + "\x00" + selection.KubernetesContext + "\x00" + selection.ContainerRegistry + "\x00" + fmt.Sprintf("%t", selection.SetDefaultTenant) + "\x00" + fmt.Sprintf("%t", selection.NoGit) + "\x00" + fmt.Sprintf("%t", selection.Bootstrap) + "\x00" + fmt.Sprintf("%t", selection.Debug)
 }
 
 func deploySelectionKey(selection uiSelection) string {

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -481,9 +481,10 @@ func TestBuildInitArgsIncludesRuntimeVersion(t *testing.T) {
 		KubernetesContext: " orbstack ",
 		ContainerRegistry: " erunpaas ",
 		NoGit:             true,
+		Bootstrap:         true,
 		SetDefaultTenant:  true,
 	})
-	want := []string{"init", "erun", "remote", "--remote", "--version", "1.0.19", "--runtime-image", "erun-devops", "--kubernetes-context", "orbstack", "--container-registry", "erunpaas", "--set-default-tenant=true", "--confirm-environment=true", "--no-git"}
+	want := []string{"init", "erun", "remote", "--remote", "--version", "1.0.19", "--runtime-image", "erun-devops", "--kubernetes-context", "orbstack", "--container-registry", "erunpaas", "--set-default-tenant=true", "--confirm-environment=true", "--no-git", "--bootstrap"}
 	if len(got) != len(want) {
 		t.Fatalf("unexpected args length: got %+v want %+v", got, want)
 	}
@@ -1043,7 +1044,7 @@ func TestLoadAndSaveEnvironmentConfig(t *testing.T) {
 	}
 }
 
-func TestStartSessionStartsLinkedCloudContextBeforeOpen(t *testing.T) {
+func TestStartSessionLeavesCloudContextStartupToErunCommand(t *testing.T) {
 	projectRoot := t.TempDir()
 	rootConfig := &eruncommon.ERunConfig{
 		CloudProviders: []eruncommon.CloudProviderConfig{
@@ -1095,21 +1096,11 @@ func TestStartSessionStartsLinkedCloudContextBeforeOpen(t *testing.T) {
 	}
 
 	got := strings.Join(actions, "\n")
-	for _, want := range []string{
-		"aws ec2 start-instances --instance-ids i-test",
-		"aws ec2 wait instance-running --instance-ids i-test",
-		"kubectl config set-context cluster-prod --cluster cluster-prod --user cluster-prod",
-		"terminal open frs prod",
-	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("expected action %q in:\n%s", want, got)
-		}
+	if got != "terminal open frs prod" {
+		t.Fatalf("expected only terminal start action, got:\n%s", got)
 	}
-	if strings.Index(got, "aws ec2 start-instances") > strings.Index(got, "terminal open") {
-		t.Fatalf("expected cloud context start before terminal open, got:\n%s", got)
-	}
-	if rootConfig.CloudContexts[0].Status != eruncommon.CloudContextStatusRunning {
-		t.Fatalf("expected cloud context to be running, got %+v", rootConfig.CloudContexts[0])
+	if rootConfig.CloudContexts[0].Status != eruncommon.CloudContextStatusStopped {
+		t.Fatalf("expected cloud context startup to be left to erun, got %+v", rootConfig.CloudContexts[0])
 	}
 }
 

--- a/erun-ui/frontend/src/App.tsx
+++ b/erun-ui/frontend/src/App.tsx
@@ -177,7 +177,7 @@ function DebugPanel({ controller, open, output }: { controller: ERunUIController
           ref={outputRef}
           className="min-h-0 overflow-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-[11px] leading-[1.35] text-[oklch(0.82_0_0)]"
         >
-          {output || 'Open an environment while Debug is expanded to run erun with -vv and stream output here.'}
+          {output || 'Run an environment command while Debug is expanded to stream erun -vv output here.'}
         </pre>
       )}
     </section>

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -101,6 +101,8 @@ interface DebugOpenFilter {
   pending: string;
 }
 
+type DebugSessionMode = 'open' | 'hidden';
+
 export class ERunUIController {
   readonly state: AppState = {
     tenants: [],
@@ -144,6 +146,7 @@ export class ERunUIController {
   private readonly sessionExitReasons = new Map<number, string>();
   private readonly sessionExitOutputs = new Map<number, string>();
   private readonly debugOpenFilters = new Map<number, DebugOpenFilter>();
+  private readonly debugSessionModes = new Map<number, DebugSessionMode>();
   private terminal: Terminal | null = null;
   private fitAddon: FitAddon | null = null;
   private terminalRoot: HTMLDivElement | null = null;
@@ -430,6 +433,7 @@ export class ERunUIController {
     const result = (await StartSession(runSelection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
     this.selectionSessions.set(key, result.sessionId);
     this.openSessionSelections.set(result.sessionId, runSelection);
+    this.registerDebugSession(result.sessionId, runSelection, 'open');
     this.rebuildTerminalDisplayBuffer(result.sessionId);
     this.state.sessionId = result.sessionId;
 
@@ -476,6 +480,7 @@ export class ERunUIController {
       kubernetesContextsLoading: true,
       containerRegistry: 'erunpaas',
       noGit: false,
+      bootstrap: false,
       setDefaultTenant: true,
       versionImage: this.state.versionSuggestions[0]?.image || '',
       choicesOpen: false,
@@ -570,6 +575,7 @@ export class ERunUIController {
       kubernetesContext: isInit ? kubernetesContext : undefined,
       containerRegistry: isInit ? containerRegistry : undefined,
       noGit: dialog.noGit,
+      bootstrap: isInit ? dialog.bootstrap : undefined,
       setDefaultTenant: isInit ? dialog.setDefaultTenant : undefined,
     };
 
@@ -1492,6 +1498,7 @@ export class ERunUIController {
     this.fitAddon?.fit();
     const result = (await StartInitSession(runSelection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
     this.initSessionSelections.set(result.sessionId, runSelection);
+    this.registerDebugSession(result.sessionId, runSelection, 'hidden');
     this.state.sessionId = result.sessionId;
 
     this.resetTerminal();
@@ -1515,6 +1522,7 @@ export class ERunUIController {
     this.fitAddon?.fit();
     const result = (await StartDeploySession(runSelection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
     this.deploySessionSelections.set(result.sessionId, runSelection);
+    this.registerDebugSession(result.sessionId, runSelection, 'hidden');
     this.state.sessionId = result.sessionId;
 
     this.resetTerminal();
@@ -1722,6 +1730,7 @@ export class ERunUIController {
     this.deploySessionSelections.delete(payload.sessionId);
     this.openSessionSelections.delete(payload.sessionId);
     this.cloudInitSessions.delete(payload.sessionId);
+    this.debugSessionModes.delete(payload.sessionId);
 
     const reason = this.terminalExitReason(payload, initSelection, deploySelection, openSelection, cloudInit);
     this.sessionExitReasons.set(payload.sessionId, reason);
@@ -1922,9 +1931,27 @@ export class ERunUIController {
   }
 
   private filterTerminalDisplayData(sessionId: number, data: Uint8Array): TerminalWriteData | null {
-    const selection = this.openSessionSelections.get(sessionId);
-    if (!selection?.debug) {
+    const debugMode = this.debugSessionModes.get(sessionId);
+    if (!debugMode) {
       return data;
+    }
+    if (debugMode === 'hidden') {
+      const filter = this.debugOpenFilters.get(sessionId) || { released: false, pending: '' };
+      if (filter.released) {
+        return data;
+      }
+      const text = new TextDecoder().decode(data);
+      const output = filter.pending + text;
+      const promptIndex = interactivePromptIndex(output);
+      if (promptIndex === -1) {
+        filter.pending = output.slice(-512);
+        this.debugOpenFilters.set(sessionId, filter);
+        return null;
+      }
+      filter.released = true;
+      filter.pending = '';
+      this.debugOpenFilters.set(sessionId, filter);
+      return output.slice(promptIndex);
     }
     const filter = this.debugOpenFilters.get(sessionId) || { released: false, pending: '' };
     if (filter.released) {
@@ -1944,6 +1971,13 @@ export class ERunUIController {
     filter.pending = '';
     this.debugOpenFilters.set(sessionId, filter);
     return output.slice(titleIndex);
+  }
+
+  private registerDebugSession(sessionId: number, selection: UISelection, mode: DebugSessionMode): void {
+    if (!selection.debug) {
+      return;
+    }
+    this.debugSessionModes.set(sessionId, mode);
   }
 
   private writeTerminalBuffer(chunks: TerminalWriteData[]): void {
@@ -1968,6 +2002,30 @@ function decodeDebugOutput(data: Uint8Array): string {
     .replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '')
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n');
+}
+
+function interactivePromptIndex(output: string): number {
+  const promptLabels = [
+    'Git remote URL for environment',
+    'CodeCommit SSH public key ID for environment',
+    'Import the SSH public key above',
+    'Kubernetes context for environment',
+    'Container registry for environment',
+    'Initialize default environment',
+    'Initialize tenant',
+    'Select tenant',
+  ];
+  let match = -1;
+  for (const label of promptLabels) {
+    const index = output.lastIndexOf(label);
+    if (index > match) {
+      match = index;
+    }
+  }
+  if (match === -1) {
+    return -1;
+  }
+  return Math.max(output.lastIndexOf('\n', match), output.lastIndexOf('\r', match)) + 1;
 }
 
 function trimDebugOutput(value: string): string {
@@ -2000,6 +2058,9 @@ function formatDebugCommand(selection: UISelection, mode: 'open' | 'init' | 'dep
     args.push(`--set-default-tenant=${selection.setDefaultTenant ? 'true' : 'false'}`, '--confirm-environment=true');
     if (selection.noGit) {
       args.push('--no-git');
+    }
+    if (selection.bootstrap) {
+      args.push('--bootstrap');
     }
   } else if (mode === 'deploy') {
     args.push('open', selection.tenant, selection.environment, '--no-shell', '--no-alias-prompt');

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -41,6 +41,7 @@ export interface EnvironmentDialogState {
   kubernetesContextsLoading: boolean;
   containerRegistry: string;
   noGit: boolean;
+  bootstrap: boolean;
   setDefaultTenant: boolean;
   versionImage: string;
   choicesOpen: boolean;
@@ -124,6 +125,7 @@ export const defaultEnvironmentDialog = (): EnvironmentDialogState => ({
   kubernetesContextsLoading: false,
   containerRegistry: 'erunpaas',
   noGit: false,
+  bootstrap: false,
   setDefaultTenant: true,
   versionImage: '',
   choicesOpen: false,

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -163,6 +163,17 @@ export function EnvironmentDialogView({ controller, state }: { controller: ERunU
                     Initialize without Git checkout
                   </Label>
                 </div>
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="environment-bootstrap"
+                    checked={dialog.bootstrap}
+                    disabled={dialog.busy}
+                    onCheckedChange={(checked) => controller.updateEnvironmentDialog({ bootstrap: checked === true })}
+                  />
+                  <Label htmlFor="environment-bootstrap" className="text-sm font-normal">
+                    Create tenant devops module
+                  </Label>
+                </div>
               </div>
             </>
           )}

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -20,6 +20,7 @@ export interface UISelection {
   kubernetesContext?: string;
   containerRegistry?: string;
   noGit?: boolean;
+  bootstrap?: boolean;
   setDefaultTenant?: boolean;
   action?: EnvironmentActionMode;
   debug?: boolean;

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -118,6 +118,9 @@ func buildInitArgs(selection uiSelection) []string {
 	if selection.NoGit {
 		args = append(args, "--no-git")
 	}
+	if selection.Bootstrap {
+		args = append(args, "--bootstrap")
+	}
 	return args
 }
 


### PR DESCRIPTION
## Summary

- start configured cloud Kubernetes contexts before shared Kubernetes operations
- fix namespace tracing and route verbose desktop init/deploy output into the debug panel without blocking prompts
- add remote init CodeCommit RSA SSH setup and optional --bootstrap tenant devops generation
- include untracked files in the shared diff result so the desktop changed-files panel shows newly created files

## Validation

- go test ./... in erun-common
- go test ./... in erun-cli
- go test ./... in erun-mcp
- go test ./... in erun-ui
- yarn build in erun-ui/frontend
- git diff --check

Closes #154
