### PR TITLE
Improve environment open status UX

### DIFF
--- a/erun-cli/cmd/mcp_port_forward.go
+++ b/erun-cli/cmd/mcp_port_forward.go
@@ -101,6 +101,9 @@ func ensureMCPPortForward(ctx common.Context, result common.OpenResult) (int, er
 		time.Sleep(100 * time.Millisecond)
 	}
 
+	if detail := mcpPortForwardTimeoutDetail(logPath); detail != "" {
+		return 0, fmt.Errorf("timed out waiting for MCP port-forward on 127.0.0.1:%d: %s; see %s", localPort, detail, logPath)
+	}
 	return 0, fmt.Errorf("timed out waiting for MCP port-forward on 127.0.0.1:%d; see %s", localPort, logPath)
 }
 
@@ -185,6 +188,26 @@ func canReachLocalMCPEndpoint(port int) bool {
 	}
 	_ = resp.Body.Close()
 	return true
+}
+
+func mcpPortForwardTimeoutDetail(logPath string) string {
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return ""
+	}
+	value := strings.ToLower(string(data))
+	switch {
+	case strings.Contains(value, "pod not found"):
+		return "runtime pod was replaced while connecting"
+	case strings.Contains(value, "lost connection to pod") ||
+		strings.Contains(value, "network namespace") ||
+		strings.Contains(value, "sandbox"):
+		return "runtime pod connection was lost, likely because the pod restarted"
+	case strings.Contains(value, "connection refused"):
+		return "runtime pod exists but MCP is not accepting connections yet"
+	default:
+		return ""
+	}
 }
 
 func stopMCPPortForwardProcess(pid int) error {

--- a/erun-cli/cmd/mcp_port_forward_test.go
+++ b/erun-cli/cmd/mcp_port_forward_test.go
@@ -4,6 +4,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"testing"
@@ -58,5 +60,41 @@ func TestCanReachLocalMCPEndpointRequiresHTTPResponse(t *testing.T) {
 	}
 	if !canReachLocalMCPEndpoint(port) {
 		t.Fatal("expected HTTP endpoint to be reachable")
+	}
+}
+
+func TestMCPPortForwardTimeoutDetailClassifiesRecentLog(t *testing.T) {
+	tests := []struct {
+		name string
+		log  string
+		want string
+	}{
+		{
+			name: "connection refused",
+			log:  `failed to connect to localhost:17400, IPv4: dial tcp4 127.0.0.1:17400: connect: connection refused`,
+			want: "runtime pod exists but MCP is not accepting connections yet",
+		},
+		{
+			name: "lost connection",
+			log:  "error: lost connection to pod",
+			want: "runtime pod connection was lost, likely because the pod restarted",
+		},
+		{
+			name: "pod not found",
+			log:  `error: error upgrading connection: unable to upgrade connection: pod not found ("petios-devops-123")`,
+			want: "runtime pod was replaced while connecting",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "mcp.log")
+			if err := os.WriteFile(path, []byte(tt.log), 0o644); err != nil {
+				t.Fatalf("write log: %v", err)
+			}
+			if got := mcpPortForwardTimeoutDetail(path); got != tt.want {
+				t.Fatalf("unexpected detail:\ngot:  %q\nwant: %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/erun-ui/frontend/src/App.tsx
+++ b/erun-ui/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Check, ChevronDown, ChevronUp, Copy, LoaderCircle, Trash2 } from 'lucide-react';
+import { ChevronDown, ChevronUp, Trash2 } from 'lucide-react';
 
 import { ERunUIController } from '@/app/ERunUIController';
 import { useControllerState } from '@/app/useControllerState';
@@ -79,34 +79,6 @@ export function App(): React.ReactElement {
             >
               <div className="relative h-full min-h-0 min-w-0 overflow-hidden">
                 <div ref={terminalRootRef} className="terminal h-full min-h-0 min-w-0 w-full box-border px-4 py-3.5" />
-                <div
-                  className={cn(
-                    'pointer-events-none absolute inset-0 flex items-center justify-center bg-[oklch(0_0_0/0.68)] p-10 text-center text-lg leading-[1.45] text-[oklch(0.92_0_0)]',
-                    state.terminalCopyOutput && 'pointer-events-auto',
-                    !state.terminalMessage && 'hidden',
-                  )}
-                >
-                  <div className="flex max-w-[min(680px,100%)] flex-col items-center gap-3.5">
-                    <div className="flex items-center justify-center gap-3">
-                      {state.terminalBusy && <LoaderCircle className="size-5 shrink-0 animate-spin" aria-hidden="true" />}
-                      <span>{state.terminalMessage}</span>
-                    </div>
-                    {state.terminalCopyOutput && (
-                      <Button
-                        className="pointer-events-auto cursor-pointer border-[oklch(0.92_0_0/0.55)] bg-[oklch(0.98_0_0)] text-[oklch(0.18_0_0)] opacity-100 shadow-[0_10px_30px_oklch(0_0_0/0.32)] hover:border-[oklch(1_0_0/0.75)] hover:bg-[oklch(1_0_0)] hover:text-[oklch(0.12_0_0)] [&_svg]:size-[15px]"
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          void controller.copyTerminalOutput();
-                        }}
-                      >
-                        {state.terminalCopyStatus === 'Copied' ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
-                        {state.terminalCopyStatus || 'Copy output'}
-                      </Button>
-                    )}
-                  </div>
-                </div>
               </div>
               <div
                 className={cn(reviewSplitterClassName, !state.reviewOpen && 'hidden')}

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -58,6 +58,8 @@ import {
   type GlobalConfigDialogState,
   type ManageDialogState,
   type TenantDialogState,
+  type TerminalStatusAction,
+  type TerminalStatusKind,
 } from './state';
 import { clamp, loadSavedDebugHeight, loadSavedDebugOpen, loadSavedFilesOpen, loadSavedFilesWidth, loadSavedReviewWidth, loadSavedSidebarWidth, saveBoolean, saveNumber } from './storage';
 import { deleteConfirmationValue, normalizeDialogValue, normalizeVersionSuggestions, selectionKey } from './versionSuggestions';
@@ -90,6 +92,12 @@ export interface MountElements {
 
 type TerminalDataDisposable = ReturnType<Terminal['onData']>;
 type TerminalWriteData = string | Uint8Array;
+type ClassifiedTerminalFailure = {
+  message: string;
+  detail: string;
+  action: TerminalStatusAction;
+  retrySelection: UISelection | null;
+};
 
 interface AppStatusPayload {
   message?: string;
@@ -126,7 +134,11 @@ export class ERunUIController {
     selectedDiffPath: '',
     diffFilter: '',
     collapsedDiffDirs: new Set<string>(),
+    notification: null,
     terminalMessage: '',
+    terminalStatusKind: 'info',
+    terminalStatusDetail: '',
+    terminalStatusAction: '',
     terminalBusy: false,
     terminalCopyOutput: '',
     terminalCopyStatus: '',
@@ -158,6 +170,7 @@ export class ERunUIController {
   private resizeTimer = 0;
   private reviewScrollFrame = 0;
   private versionSuggestionTimer = 0;
+  private notificationTimer = 0;
   private terminalCopyStatusTimer = 0;
   private versionSuggestionRequest = 0;
   private bootStarted = false;
@@ -166,6 +179,7 @@ export class ERunUIController {
   private terminalExitOff: (() => void) | null = null;
   private appStatusOff: (() => void) | null = null;
   private pasteHandler: ((event: ClipboardEvent) => void) | null = null;
+  private terminalStatusRetrySelection: UISelection | null = null;
 
   subscribe = (subscriber: () => void): (() => void) => {
     this.subscribers.add(subscriber);
@@ -241,6 +255,8 @@ export class ERunUIController {
       this.terminalOutputOff?.();
       this.terminalExitOff?.();
       this.appStatusOff?.();
+      window.clearTimeout(this.notificationTimer);
+      window.clearTimeout(this.terminalCopyStatusTimer);
       if (this.pasteHandler && this.terminalRoot) {
         this.terminalRoot.removeEventListener('paste', this.pasteHandler, true);
       }
@@ -794,7 +810,7 @@ export class ERunUIController {
         busy: false,
         error: '',
       };
-      this.showTerminalMessage(`Saved config for ${selection.tenant} / ${selection.environment}.`);
+      this.showNotification('success', `Saved config for ${selection.tenant} / ${selection.environment}.`);
       this.closeManageDialog();
     } catch (error) {
       const message = readError(error);
@@ -1173,7 +1189,7 @@ export class ERunUIController {
         busyTarget: '',
         error: '',
       };
-      this.showTerminalMessage('Saved ERun config.');
+      this.showNotification('success', 'Saved ERun config.');
       this.closeGlobalConfigDialog();
     } catch (error) {
       const message = readError(error);
@@ -1287,7 +1303,7 @@ export class ERunUIController {
         busy: false,
         error: '',
       };
-      this.showTerminalMessage(`Saved config for ${result.name}.`);
+      this.showNotification('success', `Saved config for ${result.name}.`);
       this.closeTenantDialog();
     } catch (error) {
       const message = readError(error);
@@ -1425,8 +1441,83 @@ export class ERunUIController {
 
   showTerminalMessage(message: string, busy = false): void {
     this.state.terminalMessage = message;
+    this.state.terminalStatusKind = 'info';
+    this.state.terminalStatusDetail = '';
+    this.state.terminalStatusAction = '';
     this.state.terminalBusy = busy;
+    if (busy) {
+      this.state.terminalCopyOutput = '';
+      this.state.terminalCopyStatus = '';
+    }
+    this.terminalStatusRetrySelection = null;
     this.emit();
+  }
+
+  showTerminalFailure(message: string, detail: string, copyOutput: string, action: TerminalStatusAction, retrySelection: UISelection | null): void {
+    this.state.terminalMessage = message;
+    this.state.terminalStatusKind = action === 'wait-longer' ? 'warning' : 'error';
+    this.state.terminalStatusDetail = detail;
+    this.state.terminalStatusAction = action;
+    this.state.terminalBusy = false;
+    this.state.terminalCopyOutput = copyOutput;
+    this.state.terminalCopyStatus = '';
+    this.terminalStatusRetrySelection = action === 'wait-longer' ? retrySelection : null;
+    this.emit();
+  }
+
+  showNotification(kind: NonNullable<AppState['notification']>['kind'], message: string): void {
+    const trimmed = message.trim();
+    if (!trimmed) {
+      return;
+    }
+    window.clearTimeout(this.notificationTimer);
+    this.state.notification = {
+      kind,
+      message: trimmed,
+    };
+    this.emit();
+
+    if (kind === 'success' || kind === 'info') {
+      this.notificationTimer = window.setTimeout(() => {
+        this.dismissNotification();
+      }, 3200);
+    }
+  }
+
+  dismissNotification(): void {
+    window.clearTimeout(this.notificationTimer);
+    if (!this.state.notification) {
+      return;
+    }
+    this.state.notification = null;
+    this.emit();
+  }
+
+  dismissTerminalStatus(): void {
+    if (!this.state.terminalMessage && !this.state.terminalStatusDetail && !this.state.terminalCopyOutput && !this.state.terminalCopyStatus) {
+      return;
+    }
+    this.state.terminalMessage = '';
+    this.state.terminalStatusKind = 'info';
+    this.state.terminalStatusDetail = '';
+    this.state.terminalStatusAction = '';
+    this.state.terminalBusy = false;
+    this.state.terminalCopyOutput = '';
+    this.state.terminalCopyStatus = '';
+    this.terminalStatusRetrySelection = null;
+    this.emit();
+  }
+
+  async waitLongerForTerminalStatus(): Promise<void> {
+    const selection = this.terminalStatusRetrySelection;
+    if (!selection) {
+      return;
+    }
+    this.state.terminalStatusAction = '';
+    this.state.terminalCopyOutput = '';
+    this.state.terminalCopyStatus = '';
+    this.showTerminalMessage(`Waiting longer for ${selection.tenant} / ${selection.environment}...`, true);
+    await this.openSelection(selection);
   }
 
   focusTerminalSoon(): void {
@@ -1461,6 +1552,7 @@ export class ERunUIController {
 
   private async boot(): Promise<void> {
     try {
+      this.showTerminalMessage('Loading environments...', true);
       const loaded = (await LoadState()) as UIState;
       this.state.tenants = loaded.tenants || [];
       this.state.selected = loaded.selected || null;
@@ -1493,7 +1585,7 @@ export class ERunUIController {
     this.emit();
     this.state.terminalCopyOutput = '';
     this.state.terminalCopyStatus = '';
-    this.showTerminalMessage(`Initializing ${selection.tenant} / ${selection.environment}...`);
+    this.showTerminalMessage(`Creating remote environment ${selection.tenant} / ${selection.environment}...`, true);
 
     this.fitAddon?.fit();
     const result = (await StartInitSession(runSelection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
@@ -1517,7 +1609,7 @@ export class ERunUIController {
     this.emit();
     this.state.terminalCopyOutput = '';
     this.state.terminalCopyStatus = '';
-    this.showTerminalMessage(`Deploying ${selection.tenant} / ${selection.environment}...`);
+    this.showTerminalMessage(`Deploying runtime for ${selection.tenant} / ${selection.environment}...`, true);
 
     this.fitAddon?.fit();
     const result = (await StartDeploySession(runSelection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
@@ -1668,9 +1760,13 @@ export class ERunUIController {
 
   private hideTerminalMessage(): void {
     this.state.terminalMessage = '';
+    this.state.terminalStatusKind = 'info';
+    this.state.terminalStatusDetail = '';
+    this.state.terminalStatusAction = '';
     this.state.terminalBusy = false;
     this.state.terminalCopyOutput = '';
     this.state.terminalCopyStatus = '';
+    this.terminalStatusRetrySelection = null;
     this.emit();
   }
 
@@ -1699,7 +1795,9 @@ export class ERunUIController {
     const existing = this.sessionBuffers.get(payload.sessionId) || [];
     existing.push(data);
     this.sessionBuffers.set(payload.sessionId, existing);
-    this.appendDebugOutput(decodeDebugOutput(data));
+    const debugOutput = decodeDebugOutput(data);
+    this.appendDebugOutput(debugOutput);
+    this.updateOpenStatusFromOutput(payload.sessionId, debugOutput);
     const displayData = this.filterTerminalDisplayData(payload.sessionId, data);
     if (displayData) {
       const displayBuffer = this.sessionDisplayBuffers.get(payload.sessionId) || [];
@@ -1729,6 +1827,9 @@ export class ERunUIController {
     this.initSessionSelections.delete(payload.sessionId);
     this.deploySessionSelections.delete(payload.sessionId);
     this.openSessionSelections.delete(payload.sessionId);
+    if (openSelection) {
+      this.selectionSessions.delete(selectionKey(openSelection));
+    }
     this.cloudInitSessions.delete(payload.sessionId);
     this.debugSessionModes.delete(payload.sessionId);
 
@@ -1756,8 +1857,9 @@ export class ERunUIController {
       return;
     }
     if (payload.reason && (initSelection || deploySelection || openSelection || cloudInit)) {
-      this.state.terminalCopyOutput = failedOutput;
-      this.state.terminalCopyStatus = '';
+      const failure = classifiedTerminalFailure(payload.reason, reason, failedOutput, openSelection);
+      this.showTerminalFailure(failure.message, failure.detail, failedOutput, failure.action, failure.retrySelection);
+      return;
     }
     this.showTerminalMessage(reason);
   }
@@ -1801,6 +1903,17 @@ export class ERunUIController {
     const decoder = new TextDecoder();
     const output = chunks.map((chunk) => decoder.decode(chunk, { stream: true })).join('') + decoder.decode();
     return cleanTerminalOutput(output) || fallback;
+  }
+
+  private updateOpenStatusFromOutput(sessionId: number, output: string): void {
+    if (!output || !this.openSessionSelections.has(sessionId) || this.state.terminalCopyOutput) {
+      return;
+    }
+    const status = statusForTerminalOutput(output);
+    if (!status) {
+      return;
+    }
+    this.showTerminalMessage(status, true);
   }
 
   private applyLayoutVars(): void {
@@ -1994,6 +2107,68 @@ function cleanTerminalOutput(value: string): string {
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')
     .trim();
+}
+
+function classifiedTerminalFailure(rawReason: string, displayReason: string, output: string, openSelection?: UISelection): ClassifiedTerminalFailure {
+  const combined = `${rawReason}\n${output}`.toLowerCase();
+  if (combined.includes('timed out waiting for mcp port-forward')) {
+    const port = rawReason.match(/127\.0\.0\.1:(\d+)/)?.[1] || output.match(/127\.0\.0\.1:(\d+)/)?.[1] || '';
+    return {
+      message: port ? `MCP port-forward on 127.0.0.1:${port} is still not ready` : 'MCP port-forward is still not ready',
+      detail: mcpPortForwardDetail(combined),
+      action: openSelection ? 'wait-longer' : '',
+      retrySelection: openSelection || null,
+    };
+  }
+  return {
+    message: displayReason,
+    detail: '',
+    action: '',
+    retrySelection: null,
+  };
+}
+
+function mcpPortForwardDetail(value: string): string {
+  if (value.includes('local mcp port') && value.includes('already in use')) {
+    return 'Another local process is using the MCP port.';
+  }
+  if (value.includes('pod not found')) {
+    return 'The runtime pod was replaced while the app was connecting.';
+  }
+  if (value.includes('lost connection to pod') || value.includes('network namespace') || value.includes('sandbox')) {
+    return 'The runtime pod connection was lost, likely because the pod restarted.';
+  }
+  if (value.includes('connection refused') || value.includes('not accepting')) {
+    return 'The runtime pod exists, but MCP is not accepting connections yet.';
+  }
+  return 'kubectl has not exposed a reachable MCP endpoint yet.';
+}
+
+function statusForTerminalOutput(output: string): string {
+  const lower = output.toLowerCase();
+  if (lower.includes('forwarding from 127.0.0.1:')) {
+    const port = output.match(/Forwarding from 127\.0\.0\.1:(\d+)/)?.[1] || '';
+    return port ? `Waiting for MCP endpoint on 127.0.0.1:${port}...` : 'Waiting for MCP endpoint...';
+  }
+  if (lower.includes('handling connection for')) {
+    return 'Checking MCP endpoint readiness...';
+  }
+  if (lower.includes('connection refused')) {
+    return 'Runtime pod is not accepting MCP connections yet...';
+  }
+  if (lower.includes('lost connection to pod') || lower.includes('network namespace')) {
+    return 'Runtime pod connection changed. Reconnecting MCP port-forward...';
+  }
+  if (lower.includes('pod not found')) {
+    return 'Runtime pod was replaced. Waiting for the new pod...';
+  }
+  if (lower.includes('context "') && lower.includes('modified')) {
+    return 'Configuring Kubernetes context...';
+  }
+  if (lower.includes('cluster "') && lower.includes('set.')) {
+    return 'Configuring Kubernetes cluster access...';
+  }
+  return '';
 }
 
 function decodeDebugOutput(data: Uint8Array): string {

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -83,6 +83,14 @@ export interface GlobalConfigDialogState {
   error: string;
 }
 
+export interface AppNotification {
+  kind: 'success' | 'warning' | 'error' | 'info';
+  message: string;
+}
+
+export type TerminalStatusKind = 'info' | 'warning' | 'error';
+export type TerminalStatusAction = '' | 'wait-longer';
+
 export interface AppState {
   tenants: UITenant[];
   selected: UISelection | null;
@@ -105,7 +113,11 @@ export interface AppState {
   selectedDiffPath: string;
   diffFilter: string;
   collapsedDiffDirs: Set<string>;
+  notification: AppNotification | null;
   terminalMessage: string;
+  terminalStatusKind: TerminalStatusKind;
+  terminalStatusDetail: string;
+  terminalStatusAction: TerminalStatusAction;
   terminalBusy: boolean;
   terminalCopyOutput: string;
   terminalCopyStatus: string;

--- a/erun-ui/frontend/src/components/app/Sidebar.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.tsx
@@ -84,6 +84,7 @@ function TenantGroup({
         <button
           className="flex min-w-0 flex-1 cursor-pointer items-center gap-[9px] border-0 bg-transparent px-3 py-[4px] pb-1.5 text-left text-[15px] leading-[1.25] font-medium tracking-normal text-muted-foreground hover:text-foreground"
           type="button"
+          title={tenant.name}
           onClick={() => controller.toggleTenant(tenant.name)}
         >
           {collapsed ? (
@@ -119,13 +120,18 @@ function TenantGroup({
               <div
                 key={environment.name}
                 className={cn(
-                  'group relative mr-0 ml-0.5 flex h-[34px] items-center rounded-[var(--radius)] pr-1.5 text-foreground hover:bg-accent',
-                  selected && 'bg-primary text-primary-foreground hover:bg-primary',
+                  'group relative mr-1 ml-1 flex h-8 items-center rounded-md pr-1.5 text-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+                  selected && 'bg-primary text-primary-foreground shadow-sm hover:bg-primary hover:text-primary-foreground',
                 )}
               >
                 <button
                   type="button"
-                  className="h-[34px] min-w-0 flex-1 cursor-pointer truncate border-0 bg-transparent py-0 pr-2 pl-[42px] text-left text-sm leading-[1.2] font-normal tracking-normal text-inherit"
+                  className={cn(
+                    'h-8 min-w-0 flex-1 cursor-pointer truncate border-0 bg-transparent py-0 pr-2 pl-10 text-left text-sm leading-[1.2] tracking-normal text-inherit',
+                    selected ? 'font-medium' : 'font-normal',
+                  )}
+                  title={`${tenant.name} / ${environment.name}`}
+                  aria-current={selected ? 'page' : undefined}
                   onClick={() => {
                     void controller.openSelection(selection).catch((error: unknown) => {
                       controller.showTerminalMessage(readError(error));

--- a/erun-ui/frontend/src/components/app/Titlebar.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ListTree, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen } from 'lucide-react';
+import { AlertCircle, CheckCircle2, Copy, Info, ListTree, LoaderCircle, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, X } from 'lucide-react';
 
 import type { ERunUIController } from '@/app/ERunUIController';
 import type { AppState } from '@/app/state';
@@ -15,6 +15,20 @@ const activeTitlebarButtonClassName = 'bg-primary text-primary-foreground hover:
 export function Titlebar({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement {
   const SidebarIcon = state.sidebarHidden ? PanelLeftOpen : PanelLeftClose;
   const ReviewIcon = state.reviewOpen ? PanelRightClose : PanelRightOpen;
+  const notification = state.notification;
+  const terminalStatus = !notification && state.terminalMessage
+    ? {
+        kind: state.terminalStatusKind,
+        message: state.terminalMessage,
+        detail: state.terminalStatusDetail,
+        busy: state.terminalBusy,
+        copyOutput: state.terminalCopyOutput,
+        copyStatus: state.terminalCopyStatus,
+        action: state.terminalStatusAction,
+      }
+    : null;
+  const status = notification ? { ...notification, detail: '', busy: false, copyOutput: '', copyStatus: '', action: '' } : terminalStatus;
+  const NotificationIcon = status?.busy ? LoaderCircle : status?.kind === 'success' ? CheckCircle2 : status?.kind === 'warning' || status?.kind === 'error' ? AlertCircle : Info;
 
   return (
     <header
@@ -70,6 +84,86 @@ export function Titlebar({ controller, state }: { controller: ERunUIController; 
           <ListTree />
         </Button>
       </IconTooltip>
+      {status && (
+        <div
+          className="pointer-events-none absolute top-2.5 right-24 left-32 z-20 flex justify-center [--wails-draggable:no-drag] max-[980px]:right-[84px] max-[980px]:left-[112px]"
+          role={status.kind === 'error' ? 'alert' : 'status'}
+          aria-live={status.kind === 'error' ? 'assertive' : 'polite'}
+        >
+          <div
+            className={cn(
+              'pointer-events-auto flex h-8 max-w-full items-center gap-2 rounded-md border bg-background px-2.5 text-[13px] leading-none shadow-sm',
+              status.kind === 'success' && 'border-[oklch(0.72_0.12_150)] text-foreground',
+              status.kind === 'warning' && 'border-[oklch(0.76_0.16_65)] text-foreground',
+              status.kind === 'error' && 'border-destructive/60 text-foreground',
+              status.kind === 'info' && 'border-border text-foreground',
+            )}
+          >
+            <NotificationIcon
+              className={cn(
+                'size-4 flex-none',
+                status.busy && 'animate-spin text-muted-foreground',
+                status.kind === 'success' && 'text-[oklch(0.52_0.15_150)]',
+                status.kind === 'warning' && 'text-[oklch(0.58_0.15_65)]',
+                status.kind === 'error' && 'text-destructive',
+                status.kind === 'info' && 'text-muted-foreground',
+              )}
+              aria-hidden="true"
+            />
+            <span className="min-w-0 truncate" title={status.detail ? `${status.message}. ${status.detail}` : status.message}>
+              {status.message}
+              {status.detail && <span className="text-muted-foreground"> - {status.detail}</span>}
+            </span>
+            {status.action === 'wait-longer' && (
+              <Button
+                className="h-6 flex-none rounded-md px-2 text-[12px] text-foreground hover:bg-accent hover:text-accent-foreground"
+                type="button"
+                variant="ghost"
+                size="xs"
+                onClick={() => {
+                  void controller.waitLongerForTerminalStatus();
+                }}
+              >
+                Wait longer
+              </Button>
+            )}
+            {status.copyOutput && (
+              <IconTooltip label="Copy terminal output">
+                <Button
+                  className="h-6 flex-none gap-1 rounded-md px-2 text-[12px] text-foreground hover:bg-accent hover:text-accent-foreground [&_svg]:size-3.5"
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => {
+                    void controller.copyTerminalOutput();
+                  }}
+                >
+                  {status.copyStatus === 'Copied' ? <CheckCircle2 aria-hidden="true" /> : <Copy aria-hidden="true" />}
+                  {status.copyStatus || 'Copy output'}
+                </Button>
+              </IconTooltip>
+            )}
+            <IconTooltip label="Dismiss status">
+              <Button
+                className="-mr-1 size-6 flex-none text-muted-foreground hover:bg-accent hover:text-accent-foreground [&_svg]:size-3.5"
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Dismiss status"
+                onClick={() => {
+                  if (notification) {
+                    controller.dismissNotification();
+                    return;
+                  }
+                  controller.dismissTerminalStatus();
+                }}
+              >
+                <X />
+              </Button>
+            </IconTooltip>
+          </div>
+        </div>
+      )}
       <div className="absolute inset-0" data-wails-drag />
     </header>
   );


### PR DESCRIPTION
## What changed
- Move desktop open/save/status feedback into compact titlebar status instead of terminal overlays.
- Add phase-aware environment opening messages and retryable MCP timeout UX with Wait longer and Copy output actions.
- Classify MCP port-forward timeout details from kubectl logs so users see whether the pod restarted, was replaced, or refused MCP connections.

## Why
Opening an environment could leave a stale spinner and generic timeout while the terminal was already usable. MCP port-forward failures also hid the underlying stuck action behind a raw timeout.

## Validation
- `vite build` using bundled Node
- `yarn shadcn:check`
- `go test ./...` in `erun-cli`
- `go test ./...` in `erun-ui`

Closes #158
