### PR TITLE
Add IDE open buttons for remote environments

### DIFF
--- a/erun-cli/cmd/background_process_unix.go
+++ b/erun-cli/cmd/background_process_unix.go
@@ -13,7 +13,7 @@ func detachBackgroundProcess(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
-func isMCPPortForwardProcess(pid int) bool {
+func isPortForwardProcess(pid int) bool {
 	output, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "command=").Output()
 	if err != nil {
 		return false

--- a/erun-cli/cmd/background_process_windows.go
+++ b/erun-cli/cmd/background_process_windows.go
@@ -6,6 +6,6 @@ import "os/exec"
 
 func detachBackgroundProcess(*exec.Cmd) {}
 
-func isMCPPortForwardProcess(int) bool {
+func isPortForwardProcess(int) bool {
 	return false
 }

--- a/erun-cli/cmd/mcp_port_forward.go
+++ b/erun-cli/cmd/mcp_port_forward.go
@@ -54,7 +54,7 @@ func ensureMCPPortForward(ctx common.Context, result common.OpenResult) (int, er
 		return localPort, nil
 	}
 	if stateMatchesMCPTarget(state, expectedState) && state.ProcessID > 0 && canConnectLocalPort(localPort) {
-		_ = stopMCPPortForwardProcess(state.ProcessID)
+		_ = stopPortForwardProcess(state.ProcessID)
 		waitForLocalPortToClose(localPort)
 	}
 	if canConnectLocalPort(localPort) {
@@ -210,11 +210,11 @@ func mcpPortForwardTimeoutDetail(logPath string) string {
 	}
 }
 
-func stopMCPPortForwardProcess(pid int) error {
+func stopPortForwardProcess(pid int) error {
 	if pid <= 0 {
 		return nil
 	}
-	if !isMCPPortForwardProcess(pid) {
+	if !isPortForwardProcess(pid) {
 		return nil
 	}
 	process, err := os.FindProcess(pid)

--- a/erun-cli/cmd/open_ide.go
+++ b/erun-cli/cmd/open_ide.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"net/url"
@@ -23,10 +24,16 @@ var (
 	ideUserHomeDir                   = os.UserHomeDir
 	ideGlob                          = filepath.Glob
 	ideStat                          = os.Stat
+	ideReadFile                      = os.ReadFile
+	ideWriteFile                     = os.WriteFile
+	ideMkdirAll                      = os.MkdirAll
 	ideOpenURIFunc                   = openIDEURICommand
+	ideStartURIFunc                  = startIDEURICommand
 	runJetBrainsBootstrapAttemptFunc = runJetBrainsBootstrapAttempt
 	openInstalledIntelliJAppFunc     = openInstalledIntelliJApp
+	openIntelliJGatewayProjectFunc   = openIntelliJGatewayProject
 	registerIntelliJProjectFunc      = registerIntelliJProject
+	ideRunTokenFunc                  = newIDEOpenToken
 )
 
 type (
@@ -39,14 +46,20 @@ func launchVSCode(ctx common.Context, result common.OpenResult) error {
 }
 
 func launchIntelliJ(ctx common.Context, result common.OpenResult, _ PromptRunner) error {
+	hostOS := currentHostOS()
 	if err := ensureLocalSSHDKnownHostFunc(ctx, result); err != nil {
 		return err
 	}
-	if err := registerIntelliJProjectFunc(ctx, result, currentHostOS()); err != nil {
+	if err := registerIntelliJProjectFunc(ctx, result, hostOS); err != nil {
 		return err
 	}
-	if openErr := openInstalledIntelliJAppFunc(ctx, result, currentHostOS()); openErr != nil {
-		return formatIDEOpenError("IntelliJ IDEA", currentHostOS(), result, "", openErr, "")
+	if opened, openErr := openIntelliJGatewayProjectFunc(ctx, result, hostOS); openErr != nil {
+		return openErr
+	} else if opened {
+		return nil
+	}
+	if openErr := openInstalledIntelliJAppFunc(ctx, result, hostOS); openErr != nil {
+		return formatIDEOpenError("IntelliJ IDEA", hostOS, result, "", openErr, "")
 	}
 	emitIntelliJManualOpenGuidance(ctx, result)
 	return nil
@@ -105,6 +118,30 @@ func openIDEURICommand(ctx common.Context, command string, args []string) (strin
 		technical = err.Error()
 	}
 	return technical, err
+}
+
+func startIDEURICommand(ctx common.Context, command string, args []string) (string, error) {
+	cmd := ideExecCommand(command, args...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdin = nil
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Start()
+	technical := strings.TrimSpace(strings.Join([]string{
+		strings.TrimSpace(stderr.String()),
+		strings.TrimSpace(stdout.String()),
+	}, "\n"))
+	if technical == "" && err != nil {
+		technical = err.Error()
+	}
+	if err != nil {
+		return technical, err
+	}
+	if cmd.Process != nil {
+		_ = cmd.Process.Release()
+	}
+	return "", nil
 }
 
 func formatIDEOpenError(ideName string, hostOS common.HostOS, result common.OpenResult, technical string, err error, extra string) error {
@@ -175,6 +212,181 @@ func openInstalledIntelliJApp(ctx common.Context, _ common.OpenResult, hostOS co
 	return runJetBrainsBootstrapAttemptFunc(ctx, attempt)
 }
 
+func openIntelliJGatewayProject(ctx common.Context, result common.OpenResult, hostOS common.HostOS) (bool, error) {
+	optionsDir, err := resolveIntelliJOptionsDir(hostOS)
+	if err != nil {
+		return false, nil
+	}
+	info := common.SSHConnectionInfoForResult(result)
+	recent, found, err := jetbrainsconfig.FindRecentProject(optionsDir, jetbrainsconfig.StableConfigID(info.HostAlias), info.WorkspacePath)
+	if err != nil {
+		return false, err
+	}
+	uri, ok := intelliJGatewayProjectURI(recent)
+	if !found || !ok {
+		return false, nil
+	}
+	command, args, err := intelliJGatewayLaunchCommand(hostOS, optionsDir, uri)
+	if err != nil {
+		return true, formatIDEOpenError("IntelliJ IDEA", hostOS, result, "", err, "")
+	}
+	ctx.TraceCommand("", command, args...)
+	if ctx.DryRun {
+		return true, nil
+	}
+	technical, err := ideStartURIFunc(ctx, command, args)
+	if err != nil {
+		return true, formatIDEOpenError("IntelliJ IDEA", hostOS, result, technical, err, "")
+	}
+	return true, nil
+}
+
+func intelliJGatewayLaunchCommand(hostOS common.HostOS, optionsDir string, uri string) (string, []string, error) {
+	switch hostOS {
+	case common.HostOSDarwin:
+		return intelliJGatewayDarwinLaunchCommand(optionsDir, uri)
+	default:
+		return ideLaunchCommand(hostOS, uri)
+	}
+}
+
+func intelliJGatewayDarwinLaunchCommand(optionsDir string, uri string) (string, []string, error) {
+	contentsDir, err := resolveInstalledIntelliJContentsDir(common.HostOSDarwin)
+	if err != nil {
+		return "", nil, err
+	}
+	gatewayConfigDir, err := ensureIntelliJGatewayConfigDir(optionsDir)
+	if err != nil {
+		return "", nil, err
+	}
+	gatewaySystemDir := filepath.Join(filepath.Dir(gatewayConfigDir), "system")
+	if err := ideMkdirAll(gatewaySystemDir, 0o700); err != nil {
+		return "", nil, err
+	}
+	logDir, err := intelliJGatewayLogDir(optionsDir)
+	if err != nil {
+		return "", nil, err
+	}
+	if err := ideMkdirAll(logDir, 0o700); err != nil {
+		return "", nil, err
+	}
+
+	java := filepath.Join(contentsDir, "jbr", "Contents", "Home", "bin", "java")
+	pluginDir := filepath.Join(contentsDir, "plugins", "gateway-plugin")
+	gatewayClassPath := strings.Join(intelliJGatewayStandaloneJars(pluginDir), string(os.PathListSeparator))
+	classPath, err := intelliJGatewayClassPath(contentsDir, pluginDir)
+	if err != nil {
+		return "", nil, err
+	}
+	args := []string{
+		"-Didea.application.info.value=" + filepath.Join(gatewayConfigDir, "info.xml"),
+		"-Dcom.jetbrains.gateway.plugin.path.for.remote.dev.workers=" + pluginDir,
+		"-Didea.additional.classpath=" + gatewayClassPath,
+	}
+	args = append(args, intelliJGatewayVMOptions(filepath.Join(pluginDir, "resources", "gateway.vmoptions"))...)
+	args = append(args,
+		"-Didea.platform.prefix=Gateway",
+		"-Didea.parent.product=idea",
+		"-Didea.config.path="+gatewayConfigDir,
+		"-Didea.system.path="+gatewaySystemDir,
+		"-Didea.log.path="+logDir,
+		"-Dgateway.trusted.host.ui.not.changeable=true",
+		"-Djna.boot.library.path="+filepath.Join(contentsDir, "lib", "jna", "aarch64"),
+		"-Dpty4j.preferred.native.folder="+filepath.Join(contentsDir, "lib", "pty4j"),
+		"-Dintellij.platform.runtime.repository.path="+filepath.Join(contentsDir, "modules", "module-descriptors.dat"),
+		"-Dskiko.library.path="+filepath.Join(contentsDir, "lib", "skiko-awt-runtime-all"),
+		"-Dfile.encoding=UTF-8",
+		"-Dsun.stdout.encoding=UTF-8",
+		"-Dsun.stderr.encoding=UTF-8",
+		"-classpath",
+		classPath,
+		"com.intellij.idea.Main",
+		uri,
+	)
+	return java, args, nil
+}
+
+func intelliJGatewayClassPath(contentsDir string, pluginDir string) (string, error) {
+	entries := intelliJGatewayStandaloneJars(pluginDir)
+	libJars, err := ideGlob(filepath.Join(contentsDir, "lib", "*.jar"))
+	if err != nil {
+		return "", err
+	}
+	slices.Sort(libJars)
+	if len(libJars) == 0 {
+		return "", fmt.Errorf("IntelliJ IDEA lib jars were not found under %s", filepath.Join(contentsDir, "lib"))
+	}
+	entries = append(entries, libJars...)
+	return strings.Join(entries, string(os.PathListSeparator)), nil
+}
+
+func intelliJGatewayStandaloneJars(pluginDir string) []string {
+	return []string{
+		filepath.Join(pluginDir, "lib", "gateway-standalone", "gateway.core.jar"),
+		filepath.Join(pluginDir, "lib", "gateway-standalone", "gateway.jar"),
+	}
+}
+
+func intelliJGatewayVMOptions(path string) []string {
+	data, err := ideReadFile(path)
+	if err != nil {
+		return nil
+	}
+	lines := strings.Split(string(data), "\n")
+	options := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		options = append(options, strings.TrimRight(line, "'"))
+	}
+	return options
+}
+
+func intelliJGatewayProjectURI(recent jetbrainsconfig.RecentProject) (string, bool) {
+	if strings.TrimSpace(recent.ConfigID) == "" ||
+		strings.TrimSpace(recent.ProjectPath) == "" ||
+		strings.TrimSpace(recent.LatestUsedIDE.PathToIDE) == "" ||
+		strings.TrimSpace(recent.LatestUsedIDE.BuildNumber) == "" {
+		return "", false
+	}
+	productCode := strings.TrimSpace(recent.LatestUsedIDE.ProductCode)
+	if productCode == "" {
+		productCode = strings.TrimSpace(recent.ProductCode)
+	}
+	if productCode == "" {
+		productCode = "IU"
+	}
+	values := url.Values{}
+	values.Set("type", "ssh")
+	values.Set("ssh", recent.ConfigID)
+	values.Set("projectPath", recent.ProjectPath)
+	values.Set("deploy", "false")
+	values.Set("idePath", recent.LatestUsedIDE.PathToIDE)
+	values.Set("buildNumber", recent.LatestUsedIDE.BuildNumber)
+	values.Set("productCode", productCode)
+	values.Set("runFromIdeToken", ideRunTokenFunc())
+	return "jetbrains-gateway://connect#" + values.Encode(), true
+}
+
+func newIDEOpenToken() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf(
+		"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+		b[0], b[1], b[2], b[3],
+		b[4], b[5],
+		b[6], b[7],
+		b[8], b[9],
+		b[10], b[11], b[12], b[13], b[14], b[15],
+	)
+}
+
 func registerIntelliJProject(ctx common.Context, result common.OpenResult, hostOS common.HostOS) error {
 	optionsDir, err := resolveIntelliJOptionsDir(hostOS)
 	if err != nil {
@@ -195,7 +407,18 @@ func registerIntelliJProject(ctx common.Context, result common.OpenResult, hostO
 	if ctx.DryRun {
 		return nil
 	}
-	return jetbrainsconfig.UpsertOptionsFiles(optionsDir, entry)
+	if err := jetbrainsconfig.UpsertOptionsFiles(optionsDir, entry); err != nil {
+		return err
+	}
+	if hostOS == common.HostOSDarwin {
+		gatewayOptionsDir, err := resolveIntelliJGatewayOptionsDir(optionsDir)
+		if err == nil {
+			if err := jetbrainsconfig.UpsertOptionsFiles(gatewayOptionsDir, entry); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func resolveInstalledIntelliJAttempt(hostOS common.HostOS) (jetbrainsBootstrapAttempt, bool) {
@@ -218,6 +441,35 @@ func resolveInstalledIntelliJAttempt(hostOS common.HostOS) (jetbrainsBootstrapAt
 		}
 	}
 	return jetbrainsBootstrapAttempt{}, false
+}
+
+func resolveInstalledIntelliJContentsDir(hostOS common.HostOS) (string, error) {
+	switch hostOS {
+	case common.HostOSDarwin:
+		homeDir, _ := ideUserHomeDir()
+		patterns := []string{
+			"/Applications/IntelliJ IDEA*.app/Contents",
+		}
+		if strings.TrimSpace(homeDir) != "" {
+			patterns = append(patterns, filepath.Join(homeDir, "Applications", "IntelliJ IDEA*.app", "Contents"))
+		}
+		for _, pattern := range patterns {
+			matches, err := ideGlob(pattern)
+			if err != nil {
+				continue
+			}
+			slices.Sort(matches)
+			for _, match := range matches {
+				info, err := ideStat(match)
+				if err == nil && info.IsDir() {
+					return match, nil
+				}
+			}
+		}
+		return "", fmt.Errorf("IntelliJ IDEA.app was not found")
+	default:
+		return "", fmt.Errorf("IntelliJ IDEA app discovery is unsupported on %s", hostOS)
+	}
 }
 
 func emitIntelliJManualOpenGuidance(ctx common.Context, result common.OpenResult) {
@@ -319,4 +571,62 @@ func resolveIntelliJOptionsDir(hostOS common.HostOS) (string, error) {
 		return 1
 	})
 	return candidates[0].path, nil
+}
+
+func resolveIntelliJGatewayOptionsDir(optionsDir string) (string, error) {
+	optionsDir = filepath.Clean(strings.TrimSpace(optionsDir))
+	if filepath.Base(optionsDir) != "options" {
+		return "", fmt.Errorf("IntelliJ options directory must end with options: %s", optionsDir)
+	}
+	versionDir := filepath.Base(filepath.Dir(optionsDir))
+	if strings.TrimSpace(versionDir) == "" || versionDir == "." || versionDir == string(filepath.Separator) {
+		return "", fmt.Errorf("IntelliJ version directory not found for %s", optionsDir)
+	}
+	homeDir, err := ideUserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, "Library", "Caches", "JetBrains", versionDir, "tmp", "JetBrainsGateway", "config", "options"), nil
+}
+
+func ensureIntelliJGatewayConfigDir(optionsDir string) (string, error) {
+	gatewayOptionsDir, err := resolveIntelliJGatewayOptionsDir(optionsDir)
+	if err != nil {
+		return "", err
+	}
+	gatewayConfigDir := filepath.Dir(gatewayOptionsDir)
+	if err := ideMkdirAll(gatewayOptionsDir, 0o700); err != nil {
+		return "", err
+	}
+	infoPath := filepath.Join(gatewayConfigDir, "info.xml")
+	if _, err := ideStat(infoPath); err == nil {
+		return gatewayConfigDir, nil
+	}
+	if err := ideWriteFile(infoPath, []byte(intelliJGatewayInfoXML()), 0o600); err != nil {
+		return "", err
+	}
+	return gatewayConfigDir, nil
+}
+
+func intelliJGatewayLogDir(optionsDir string) (string, error) {
+	versionDir := filepath.Base(filepath.Dir(filepath.Clean(optionsDir)))
+	homeDir, err := ideUserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, "Library", "Logs", "JetBrains", versionDir, "gateway", time.Now().Format("20060102-150405")), nil
+}
+
+func intelliJGatewayInfoXML() string {
+	return `<component xmlns="http://jetbrains.org/intellij/schema/application-info">
+  <version major="2025" minor="3.2" eap="false"/>
+  <build number="GW-253.30387.90"/>
+  <company name="JetBrains s.r.o." url="https://www.jetbrains.com/"/>
+  <names product="Gateway" fullname="JetBrains Gateway" script="gateway" motto="Develop together with pleasure!"/>
+  <productUrl url="https://www.jetbrains.com/remote-development/gateway/"/>
+  <logo url="/splash.png"/>
+  <icon svg="/gateway.svg" svg-small="/gateway_16.svg"/>
+  <icon-eap svg="/gateway_EAP.svg" svg-small="/gateway_16_EAP.svg"/>
+</component>
+`
 }

--- a/erun-cli/cmd/open_intellij_test.go
+++ b/erun-cli/cmd/open_intellij_test.go
@@ -3,24 +3,29 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	common "github.com/sophium/erun/erun-common"
+	jetbrainsconfig "github.com/sophium/erun/internal/jetbrainsconfig"
 )
 
 func TestLaunchIntelliJEnsuresKnownHostBeforeOpening(t *testing.T) {
 	prevEnsure := ensureLocalSSHDKnownHostFunc
 	prevOpenInstalled := openInstalledIntelliJAppFunc
+	prevOpenGateway := openIntelliJGatewayProjectFunc
 	prevRegister := registerIntelliJProjectFunc
 	prevHostOS := currentHostOS
 	t.Cleanup(func() {
 		ensureLocalSSHDKnownHostFunc = prevEnsure
 		openInstalledIntelliJAppFunc = prevOpenInstalled
+		openIntelliJGatewayProjectFunc = prevOpenGateway
 		registerIntelliJProjectFunc = prevRegister
 		currentHostOS = prevHostOS
 	})
@@ -43,6 +48,16 @@ func TestLaunchIntelliJEnsuresKnownHostBeforeOpening(t *testing.T) {
 			t.Fatalf("unexpected target: %+v", result)
 		}
 		return nil
+	}
+	openIntelliJGatewayProjectFunc = func(_ common.Context, result common.OpenResult, hostOS common.HostOS) (bool, error) {
+		callOrder = append(callOrder, "open_gateway")
+		if hostOS != common.HostOSDarwin {
+			t.Fatalf("unexpected host OS: %s", hostOS)
+		}
+		if result.Tenant != "tenant-a" {
+			t.Fatalf("unexpected target: %+v", result)
+		}
+		return false, nil
 	}
 	openInstalledIntelliJAppFunc = func(_ common.Context, result common.OpenResult, hostOS common.HostOS) error {
 		callOrder = append(callOrder, "open_intellij")
@@ -77,7 +92,7 @@ func TestLaunchIntelliJEnsuresKnownHostBeforeOpening(t *testing.T) {
 	if err != nil {
 		t.Fatalf("launchIntelliJ failed: %v", err)
 	}
-	if got := strings.Join(callOrder, ","); got != "known_hosts,register_project,open_intellij" {
+	if got := strings.Join(callOrder, ","); got != "known_hosts,register_project,open_gateway,open_intellij" {
 		t.Fatalf("unexpected call order: %s", got)
 	}
 	for _, want := range []string{
@@ -97,10 +112,12 @@ func TestLaunchIntelliJEnsuresKnownHostBeforeOpening(t *testing.T) {
 func TestLaunchIntelliJReturnsKnownHostError(t *testing.T) {
 	prevEnsure := ensureLocalSSHDKnownHostFunc
 	prevOpenInstalled := openInstalledIntelliJAppFunc
+	prevOpenGateway := openIntelliJGatewayProjectFunc
 	prevRegister := registerIntelliJProjectFunc
 	t.Cleanup(func() {
 		ensureLocalSSHDKnownHostFunc = prevEnsure
 		openInstalledIntelliJAppFunc = prevOpenInstalled
+		openIntelliJGatewayProjectFunc = prevOpenGateway
 		registerIntelliJProjectFunc = prevRegister
 	})
 
@@ -110,6 +127,10 @@ func TestLaunchIntelliJReturnsKnownHostError(t *testing.T) {
 	openInstalledIntelliJAppFunc = func(common.Context, common.OpenResult, common.HostOS) error {
 		t.Fatal("did not expect IntelliJ launch when known_hosts update fails")
 		return nil
+	}
+	openIntelliJGatewayProjectFunc = func(common.Context, common.OpenResult, common.HostOS) (bool, error) {
+		t.Fatal("did not expect gateway project launch when known_hosts update fails")
+		return false, nil
 	}
 	registerIntelliJProjectFunc = func(common.Context, common.OpenResult, common.HostOS) error {
 		t.Fatal("did not expect JetBrains config registration when known_hosts update fails")
@@ -125,11 +146,13 @@ func TestLaunchIntelliJReturnsKnownHostError(t *testing.T) {
 func TestLaunchIntelliJReturnsInstalledIDEAError(t *testing.T) {
 	prevEnsure := ensureLocalSSHDKnownHostFunc
 	prevOpenInstalled := openInstalledIntelliJAppFunc
+	prevOpenGateway := openIntelliJGatewayProjectFunc
 	prevRegister := registerIntelliJProjectFunc
 	prevHostOS := currentHostOS
 	t.Cleanup(func() {
 		ensureLocalSSHDKnownHostFunc = prevEnsure
 		openInstalledIntelliJAppFunc = prevOpenInstalled
+		openIntelliJGatewayProjectFunc = prevOpenGateway
 		registerIntelliJProjectFunc = prevRegister
 		currentHostOS = prevHostOS
 	})
@@ -137,6 +160,9 @@ func TestLaunchIntelliJReturnsInstalledIDEAError(t *testing.T) {
 	currentHostOS = func() common.HostOS { return common.HostOSDarwin }
 	ensureLocalSSHDKnownHostFunc = func(common.Context, common.OpenResult) error { return nil }
 	registerIntelliJProjectFunc = func(common.Context, common.OpenResult, common.HostOS) error { return nil }
+	openIntelliJGatewayProjectFunc = func(common.Context, common.OpenResult, common.HostOS) (bool, error) {
+		return false, nil
+	}
 	openInstalledIntelliJAppFunc = func(common.Context, common.OpenResult, common.HostOS) error {
 		return errors.New("IntelliJ IDEA is not available on this host")
 	}
@@ -170,6 +196,245 @@ func TestLaunchIntelliJReturnsInstalledIDEAError(t *testing.T) {
 			t.Fatalf("expected error to contain %q, got:\n%s", want, err.Error())
 		}
 	}
+}
+
+func TestLaunchIntelliJOpensGatewayProjectBeforeFallback(t *testing.T) {
+	prevEnsure := ensureLocalSSHDKnownHostFunc
+	prevOpenInstalled := openInstalledIntelliJAppFunc
+	prevOpenGateway := openIntelliJGatewayProjectFunc
+	prevRegister := registerIntelliJProjectFunc
+	prevHostOS := currentHostOS
+	t.Cleanup(func() {
+		ensureLocalSSHDKnownHostFunc = prevEnsure
+		openInstalledIntelliJAppFunc = prevOpenInstalled
+		openIntelliJGatewayProjectFunc = prevOpenGateway
+		registerIntelliJProjectFunc = prevRegister
+		currentHostOS = prevHostOS
+	})
+
+	currentHostOS = func() common.HostOS { return common.HostOSDarwin }
+	callOrder := make([]string, 0, 3)
+	ensureLocalSSHDKnownHostFunc = func(common.Context, common.OpenResult) error {
+		callOrder = append(callOrder, "known_hosts")
+		return nil
+	}
+	registerIntelliJProjectFunc = func(common.Context, common.OpenResult, common.HostOS) error {
+		callOrder = append(callOrder, "register_project")
+		return nil
+	}
+	openIntelliJGatewayProjectFunc = func(common.Context, common.OpenResult, common.HostOS) (bool, error) {
+		callOrder = append(callOrder, "open_gateway")
+		return true, nil
+	}
+	openInstalledIntelliJAppFunc = func(common.Context, common.OpenResult, common.HostOS) error {
+		t.Fatal("did not expect local IntelliJ fallback after gateway project launch")
+		return nil
+	}
+
+	stderr := new(bytes.Buffer)
+	err := launchIntelliJ(common.Context{Stderr: stderr}, common.OpenResult{}, nil)
+	if err != nil {
+		t.Fatalf("launchIntelliJ failed: %v", err)
+	}
+	if got := strings.Join(callOrder, ","); got != "known_hosts,register_project,open_gateway" {
+		t.Fatalf("unexpected call order: %s", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("did not expect manual guidance after gateway project launch, got:\n%s", stderr.String())
+	}
+}
+
+func TestIntelliJGatewayProjectURI(t *testing.T) {
+	prevToken := ideRunTokenFunc
+	t.Cleanup(func() {
+		ideRunTokenFunc = prevToken
+	})
+	ideRunTokenFunc = func() string { return "fixed-token" }
+
+	got, ok := intelliJGatewayProjectURI(jetbrainsconfig.RecentProject{
+		ConfigID:    "14feee13-47cc-53b1-957a-326051d70e86",
+		ProjectPath: "/home/erun/git/petios",
+		ProductCode: "IU",
+		LatestUsedIDE: jetbrainsconfig.RecentProjectIDE{
+			BuildNumber: "261.23567.71",
+			PathToIDE:   "/home/erun/.cache/JetBrains/RemoteDev/dist/fd6f0251cd1fc_idea-261.23567.71-aarch64",
+			ProductCode: "IU",
+		},
+	})
+	if !ok {
+		t.Fatal("expected gateway URI to be available")
+	}
+	parsed, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse URI: %v", err)
+	}
+	if parsed.Scheme != "jetbrains-gateway" || parsed.Host != "connect" {
+		t.Fatalf("unexpected gateway URI: %s", got)
+	}
+	values, err := url.ParseQuery(parsed.Fragment)
+	if err != nil {
+		t.Fatalf("parse gateway fragment: %v", err)
+	}
+	wants := map[string]string{
+		"type":            "ssh",
+		"ssh":             "14feee13-47cc-53b1-957a-326051d70e86",
+		"projectPath":     "/home/erun/git/petios",
+		"deploy":          "false",
+		"idePath":         "/home/erun/.cache/JetBrains/RemoteDev/dist/fd6f0251cd1fc_idea-261.23567.71-aarch64",
+		"buildNumber":     "261.23567.71",
+		"productCode":     "IU",
+		"runFromIdeToken": "fixed-token",
+	}
+	for name, want := range wants {
+		if values.Get(name) != want {
+			t.Fatalf("unexpected %s: want %q, got %q in %s", name, want, values.Get(name), got)
+		}
+	}
+}
+
+func TestOpenIntelliJGatewayProjectLaunchesRecentProjectURI(t *testing.T) {
+	prevHome := ideUserHomeDir
+	prevGlob := ideGlob
+	prevStat := ideStat
+	prevStartURI := ideStartURIFunc
+	prevToken := ideRunTokenFunc
+	t.Cleanup(func() {
+		ideUserHomeDir = prevHome
+		ideGlob = prevGlob
+		ideStat = prevStat
+		ideStartURIFunc = prevStartURI
+		ideRunTokenFunc = prevToken
+	})
+
+	root := t.TempDir()
+	optionsDir := filepath.Join(root, "Library", "Application Support", "JetBrains", "IntelliJIdea2025.3", "options")
+	if err := os.MkdirAll(optionsDir, 0o700); err != nil {
+		t.Fatalf("mkdir optionsDir: %v", err)
+	}
+	appContentsDir := filepath.Join(root, "Applications", "IntelliJ IDEA.app", "Contents")
+	if err := os.MkdirAll(filepath.Join(appContentsDir, "plugins", "gateway-plugin", "resources"), 0o700); err != nil {
+		t.Fatalf("mkdir app contents: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(appContentsDir, "lib"), 0o700); err != nil {
+		t.Fatalf("mkdir app lib: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(appContentsDir, "lib", "app.jar"), nil, 0o600); err != nil {
+		t.Fatalf("write app jar: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(appContentsDir, "plugins", "gateway-plugin", "resources", "gateway.vmoptions"), []byte("-Xmx512m\n-Dapple.awt.application.name=Gateway\n"), 0o600); err != nil {
+		t.Fatalf("write gateway vmoptions: %v", err)
+	}
+	configID := jetbrainsconfig.StableConfigID("erun-tenant-a-remote")
+	if err := os.WriteFile(filepath.Join(optionsDir, "sshRecentConnections.v2.xml"), []byte(`<application>
+  <component name="SshLocalRecentConnectionsManager">
+    <option name="connections">
+      <list>
+        <LocalRecentConnectionState>
+          <option name="configId" value="`+configID+`"></option>
+          <option name="projects">
+            <list>
+              <RecentProjectState>
+                <option name="date" value="1777362254961"></option>
+                <option name="latestUsedIde">
+                  <RecentProjectInstalledIde>
+                    <option name="buildNumber" value="261.23567.71"></option>
+                    <option name="pathToIde" value="/home/erun/.cache/JetBrains/RemoteDev/dist/fd6f0251cd1fc_idea-261.23567.71-aarch64"></option>
+                    <option name="productCode" value="IU"></option>
+                  </RecentProjectInstalledIde>
+                </option>
+                <option name="productCode" value="IU"></option>
+                <option name="projectPath" value="/home/erun/git/tenant-a"></option>
+              </RecentProjectState>
+            </list>
+          </option>
+        </LocalRecentConnectionState>
+      </list>
+    </option>
+  </component>
+</application>
+`), 0o600); err != nil {
+		t.Fatalf("write recent projects: %v", err)
+	}
+
+	ideUserHomeDir = func() (string, error) { return root, nil }
+	ideGlob = func(pattern string) ([]string, error) {
+		if strings.Contains(pattern, "IntelliJIdea*") {
+			return []string{optionsDir}, nil
+		}
+		if strings.Contains(pattern, "IntelliJ IDEA*.app") {
+			return []string{appContentsDir}, nil
+		}
+		if strings.Contains(pattern, "lib/*.jar") {
+			return []string{filepath.Join(appContentsDir, "lib", "app.jar")}, nil
+		}
+		return nil, nil
+	}
+	ideStat = os.Stat
+	ideRunTokenFunc = func() string { return "fixed-token" }
+	var launchedCommand string
+	var launchedArgs []string
+	ideStartURIFunc = func(_ common.Context, command string, args []string) (string, error) {
+		launchedCommand = command
+		launchedArgs = append([]string(nil), args...)
+		return "", nil
+	}
+
+	opened, err := openIntelliJGatewayProject(common.Context{}, common.OpenResult{
+		Tenant:      "tenant-a",
+		Environment: "remote",
+		TenantConfig: common.TenantConfig{
+			Name: "tenant-a",
+		},
+		EnvConfig: common.EnvConfig{
+			Name:     "remote",
+			Remote:   true,
+			RepoPath: "/home/erun/git/tenant-a",
+			SSHD: common.SSHDConfig{
+				Enabled:   true,
+				LocalPort: 62222,
+			},
+		},
+		RepoPath: "/home/erun/git/tenant-a",
+	}, common.HostOSDarwin)
+	if err != nil {
+		t.Fatalf("openIntelliJGatewayProject failed: %v", err)
+	}
+	if !opened {
+		t.Fatal("expected gateway project launch")
+	}
+	if launchedCommand != filepath.Join(appContentsDir, "jbr", "Contents", "Home", "bin", "java") {
+		t.Fatalf("unexpected launch command: %s %+v", launchedCommand, launchedArgs)
+	}
+	uri := launchedArgs[len(launchedArgs)-1]
+	values := parseGatewayFragment(t, uri)
+	if values.Get("ssh") != configID ||
+		values.Get("projectPath") != "/home/erun/git/tenant-a" ||
+		values.Get("idePath") != "/home/erun/.cache/JetBrains/RemoteDev/dist/fd6f0251cd1fc_idea-261.23567.71-aarch64" ||
+		values.Get("runFromIdeToken") != "fixed-token" {
+		t.Fatalf("unexpected gateway URI values: %s", uri)
+	}
+	if !strings.Contains(strings.Join(launchedArgs, "\n"), "-Didea.platform.prefix=Gateway") {
+		t.Fatalf("expected Gateway platform launch args, got %+v", launchedArgs)
+	}
+	if !slices.Contains(launchedArgs, "-classpath") || !strings.Contains(strings.Join(launchedArgs, "\n"), filepath.Join(appContentsDir, "lib", "app.jar")) {
+		t.Fatalf("expected IntelliJ app jars on Gateway classpath, got %+v", launchedArgs)
+	}
+}
+
+func parseGatewayFragment(t *testing.T, uri string) url.Values {
+	t.Helper()
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		t.Fatalf("parse gateway URI: %v", err)
+	}
+	if parsed.Scheme != "jetbrains-gateway" || parsed.Host != "connect" {
+		t.Fatalf("unexpected gateway URI: %s", uri)
+	}
+	values, err := url.ParseQuery(parsed.Fragment)
+	if err != nil {
+		t.Fatalf("parse gateway fragment: %v", err)
+	}
+	return values
 }
 
 func TestOpenInstalledIntelliJAppDryRunTracesLaunch(t *testing.T) {

--- a/erun-cli/cmd/sshd_activation.go
+++ b/erun-cli/cmd/sshd_activation.go
@@ -11,6 +11,8 @@ import (
 
 type SSHDActivator func(common.Context, common.OpenResult) error
 
+var waitForSSHDRemoteDeployment = common.WaitForShellDeployment
+
 func newSSHDActivator(runRemoteCommand common.RemoteCommandRunnerFunc) SSHDActivator {
 	return func(ctx common.Context, result common.OpenResult) error {
 		if !result.EnvConfig.SSHD.Enabled {
@@ -41,9 +43,26 @@ func syncRemoteSSHDKey(ctx common.Context, result common.OpenResult, runRemoteCo
 	script := common.BuildRemoteAuthorizedKeysSyncScript(publicKey)
 	output, err := common.RunTracedRemoteCommand(ctx, runRemoteCommand, req, "remote-ssh-authorized-keys", script)
 	if err != nil {
+		if sshdRemoteExecPodWasReplaced(output.Stderr) {
+			ctx.Trace("runtime pod was replaced while syncing SSH authorized_keys; waiting for deployment and retrying")
+			if waitErr := waitForSSHDRemoteDeployment(req); waitErr != nil {
+				return "", fmt.Errorf("wait for runtime deployment after SSH authorized_keys sync failed: %w", waitErr)
+			}
+			output, err = common.RunTracedRemoteCommand(ctx, runRemoteCommand, req, "remote-ssh-authorized-keys", script)
+			if err == nil {
+				return publicKeyPath, nil
+			}
+		}
 		return "", fmt.Errorf("sync remote authorized_keys from %s: %w%s", publicKeyPath, err, formatRemoteCommandStderr(output.Stderr))
 	}
 	return publicKeyPath, nil
+}
+
+func sshdRemoteExecPodWasReplaced(stderr string) bool {
+	value := strings.ToLower(stderr)
+	return strings.Contains(value, "pod does not exist") ||
+		strings.Contains(value, "pod not found") ||
+		strings.Contains(value, "lost connection to pod")
 }
 
 func resolveSSHDPublicKey(path string) (string, string, error) {

--- a/erun-cli/cmd/sshd_port_forward.go
+++ b/erun-cli/cmd/sshd_port_forward.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +22,7 @@ type sshdPortForwardState struct {
 	Namespace         string `json:"namespace"`
 	LocalPort         int    `json:"localPort"`
 	LogPath           string `json:"logPath,omitempty"`
+	ProcessID         int    `json:"processId,omitempty"`
 }
 
 func ensureSSHDPortForward(ctx common.Context, result common.OpenResult) (common.SSHConnectionInfo, error) {
@@ -38,8 +40,12 @@ func ensureSSHDPortForward(ctx common.Context, result common.OpenResult) (common
 		LocalPort:         info.Port,
 	}
 
-	if stateMatchesSSHDTarget(state, expectedState) && canConnectLocalPort(info.Port) {
+	if stateMatchesSSHDTarget(state, expectedState) && canReachLocalSSHEndpoint(info.Port) {
 		return info, nil
+	}
+	if stateMatchesSSHDTarget(state, expectedState) && state.ProcessID > 0 && canConnectLocalPort(info.Port) {
+		_ = stopPortForwardProcess(state.ProcessID)
+		waitForLocalPortToClose(info.Port)
 	}
 	if canConnectLocalPort(info.Port) {
 		return common.SSHConnectionInfo{}, fmt.Errorf("local SSH port %d is already in use", info.Port)
@@ -66,18 +72,20 @@ func ensureSSHDPortForward(ctx common.Context, result common.OpenResult) (common
 	cmd := exec.Command("kubectl", args...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
+	detachBackgroundProcess(cmd)
 	if err := cmd.Start(); err != nil {
 		return common.SSHConnectionInfo{}, err
 	}
 
 	expectedState.LogPath = logPath
+	expectedState.ProcessID = cmd.Process.Pid
 	if err := saveSSHDPortForwardState(statePath, expectedState); err != nil {
 		return common.SSHConnectionInfo{}, err
 	}
 
 	deadline := time.Now().Add(sshdPortForwardStartupTimeout)
 	for time.Now().Before(deadline) {
-		if canConnectLocalPort(info.Port) {
+		if canReachLocalSSHEndpoint(info.Port) {
 			return info, nil
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -145,4 +153,23 @@ func stateMatchesSSHDTarget(state, expected sshdPortForwardState) bool {
 		state.KubernetesContext == expected.KubernetesContext &&
 		state.Namespace == expected.Namespace &&
 		state.LocalPort == expected.LocalPort
+}
+
+func canReachLocalSSHEndpoint(port int) bool {
+	if port <= 0 {
+		return false
+	}
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 500*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+	if err := conn.SetDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
+		return false
+	}
+	buffer := make([]byte, 4)
+	n, err := conn.Read(buffer)
+	return err == nil && n >= 4 && string(buffer[:4]) == "SSH-"
 }

--- a/erun-cli/cmd/sshd_test.go
+++ b/erun-cli/cmd/sshd_test.go
@@ -2,9 +2,12 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -36,6 +39,39 @@ func TestKubectlSSHDPortForwardArgs(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected args:\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestCanReachLocalSSHEndpointRequiresSSHBanner(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+		_, _ = conn.Write([]byte("SSH-2.0-test\r\n"))
+	}()
+
+	_, portValue, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+	port, err := strconv.Atoi(portValue)
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+	if !canReachLocalSSHEndpoint(port) {
+		t.Fatal("expected SSH endpoint to be reachable")
 	}
 }
 
@@ -223,5 +259,82 @@ func TestRunSSHDInitCommandUsesResolvedEnvironmentLocalPortByDefault(t *testing.
 	}
 	if savedEnv.SSHD.LocalPort != 17122 {
 		t.Fatalf("expected resolved environment SSH port, got %+v", savedEnv.SSHD)
+	}
+}
+
+func TestSyncRemoteSSHDKeyRetriesWhenPodWasReplaced(t *testing.T) {
+	prevWait := waitForSSHDRemoteDeployment
+	t.Cleanup(func() {
+		waitForSSHDRemoteDeployment = prevWait
+	})
+
+	publicKeyPath := filepath.Join(t.TempDir(), "id_ed25519.pub")
+	if err := os.WriteFile(publicKeyPath, []byte("ssh-ed25519 AAAATEST user@example\n"), 0o644); err != nil {
+		t.Fatalf("write public key: %v", err)
+	}
+
+	var waited common.ShellLaunchParams
+	waitForSSHDRemoteDeployment = func(req common.ShellLaunchParams) error {
+		waited = req
+		return nil
+	}
+
+	attempts := 0
+	got, err := syncRemoteSSHDKey(
+		common.Context{
+			Logger: common.NewLoggerWithWriters(1, new(bytes.Buffer), new(bytes.Buffer)),
+		},
+		common.OpenResult{
+			Tenant:      "tenant-a",
+			Environment: "dev",
+			RepoPath:    "/home/erun/git/tenant-a",
+			TenantConfig: common.TenantConfig{
+				Name: "tenant-a",
+			},
+			EnvConfig: common.EnvConfig{
+				Name:              "dev",
+				RepoPath:          "/home/erun/git/tenant-a",
+				KubernetesContext: "cluster-dev",
+				Remote:            true,
+				SSHD: common.SSHDConfig{
+					Enabled:       true,
+					PublicKeyPath: publicKeyPath,
+				},
+			},
+		},
+		func(_ common.ShellLaunchParams, _ string) (common.RemoteCommandResult, error) {
+			attempts++
+			if attempts == 1 {
+				return common.RemoteCommandResult{
+					Stderr: "error: Internal error occurred: unable to upgrade connection: pod does not exist",
+				}, errors.New("exit status 1")
+			}
+			return common.RemoteCommandResult{}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("syncRemoteSSHDKey failed: %v", err)
+	}
+	if got != publicKeyPath {
+		t.Fatalf("unexpected key path: %q", got)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected retry after pod replacement, got %d attempts", attempts)
+	}
+	if waited.Namespace != "tenant-a-dev" || waited.KubernetesContext != "cluster-dev" {
+		t.Fatalf("unexpected wait params: %+v", waited)
+	}
+}
+
+func TestSSHDRemoteExecPodWasReplaced(t *testing.T) {
+	tests := []string{
+		"error: Internal error occurred: unable to upgrade connection: pod does not exist",
+		`error: error upgrading connection: unable to upgrade connection: pod not found ("petios-devops-123")`,
+		"error: lost connection to pod",
+	}
+	for _, stderr := range tests {
+		if !sshdRemoteExecPodWasReplaced(stderr) {
+			t.Fatalf("expected stderr to be classified as pod replacement: %s", stderr)
+		}
 	}
 }

--- a/erun-cli/internal/jetbrainsconfig/jetbrainsconfig.go
+++ b/erun-cli/internal/jetbrainsconfig/jetbrainsconfig.go
@@ -21,6 +21,20 @@ type ProjectEntry struct {
 	TimestampMilli int64
 }
 
+type RecentProject struct {
+	ConfigID       string
+	ProjectPath    string
+	ProductCode    string
+	LatestUsedIDE  RecentProjectIDE
+	TimestampMilli string
+}
+
+type RecentProjectIDE struct {
+	BuildNumber string
+	PathToIDE   string
+	ProductCode string
+}
+
 func StableConfigID(hostAlias string) string {
 	sum := sha1.Sum([]byte(strings.TrimSpace(hostAlias)))
 	b := sum[:16]
@@ -70,6 +84,44 @@ func UpsertOptionsFiles(optionsDir string, entry ProjectEntry) error {
 		return err
 	}
 	return nil
+}
+
+func FindRecentProject(optionsDir string, configID string, projectPath string) (RecentProject, bool, error) {
+	optionsDir = filepath.Clean(strings.TrimSpace(optionsDir))
+	configID = strings.TrimSpace(configID)
+	projectPath = strings.TrimSpace(projectPath)
+	if optionsDir == "" {
+		return RecentProject{}, false, fmt.Errorf("JetBrains options directory is required")
+	}
+	if configID == "" {
+		return RecentProject{}, false, fmt.Errorf("JetBrains config ID is required")
+	}
+	if projectPath == "" {
+		return RecentProject{}, false, fmt.Errorf("JetBrains project path is required")
+	}
+
+	doc := sshRecentConnectionsApplication{}
+	if err := readXMLFile(filepath.Join(optionsDir, "sshRecentConnections.v2.xml"), &doc); err != nil {
+		return RecentProject{}, false, err
+	}
+	for _, connection := range doc.Component.Connections.List.States {
+		if connection.ConfigID() != configID {
+			continue
+		}
+		for _, project := range connection.Projects() {
+			if project.ProjectPath() != projectPath {
+				continue
+			}
+			return RecentProject{
+				ConfigID:       configID,
+				ProjectPath:    project.ProjectPath(),
+				ProductCode:    project.OptionValue("productCode"),
+				LatestUsedIDE:  project.LatestUsedIDE(),
+				TimestampMilli: project.OptionValue("date"),
+			}, true, nil
+		}
+	}
+	return RecentProject{}, false, nil
 }
 
 func upsertSSHConfigsFile(path string, entry ProjectEntry) error {
@@ -312,7 +364,7 @@ func (state *localRecentConnectionState) UpsertProject(project recentProjectStat
 		}
 		for j := range state.Options[i].List.Projects {
 			if state.Options[i].List.Projects[j].ProjectPath() == projectPath {
-				state.Options[i].List.Projects[j] = project
+				state.Options[i].List.Projects[j].MergeMetadata(project)
 				return
 			}
 		}
@@ -351,7 +403,74 @@ func (state recentProjectState) ProjectPath() string {
 	return ""
 }
 
+func (state localRecentConnectionState) Projects() []recentProjectState {
+	for _, option := range state.Options {
+		if option.Name == "projects" && option.List != nil {
+			return option.List.Projects
+		}
+	}
+	return nil
+}
+
 type recentProjectOption struct {
+	Name          string                     `xml:"name,attr"`
+	Value         string                     `xml:"value,attr,omitempty"`
+	LatestUsedIDE *recentProjectInstalledIDE `xml:"RecentProjectInstalledIde,omitempty"`
+}
+
+type recentProjectInstalledIDE struct {
+	Options []installedIDEOption `xml:"option"`
+}
+
+func (state recentProjectState) OptionValue(name string) string {
+	for _, option := range state.Options {
+		if option.Name == name {
+			return option.Value
+		}
+	}
+	return ""
+}
+
+func (state recentProjectState) LatestUsedIDE() RecentProjectIDE {
+	for _, option := range state.Options {
+		if option.Name != "latestUsedIde" || option.LatestUsedIDE == nil {
+			continue
+		}
+		return RecentProjectIDE{
+			BuildNumber: option.LatestUsedIDE.OptionValue("buildNumber"),
+			PathToIDE:   option.LatestUsedIDE.OptionValue("pathToIde"),
+			ProductCode: option.LatestUsedIDE.OptionValue("productCode"),
+		}
+	}
+	return RecentProjectIDE{}
+}
+
+func (state *recentProjectState) MergeMetadata(project recentProjectState) {
+	state.upsertOptionValue("date", project.OptionValue("date"))
+	state.upsertOptionValue("productCode", project.OptionValue("productCode"))
+	state.upsertOptionValue("projectPath", project.ProjectPath())
+}
+
+func (state *recentProjectState) upsertOptionValue(name string, value string) {
+	for i := range state.Options {
+		if state.Options[i].Name == name {
+			state.Options[i].Value = value
+			return
+		}
+	}
+	state.Options = append(state.Options, recentProjectOption{Name: name, Value: value})
+}
+
+type installedIDEOption struct {
 	Name  string `xml:"name,attr"`
 	Value string `xml:"value,attr,omitempty"`
+}
+
+func (ide recentProjectInstalledIDE) OptionValue(name string) string {
+	for _, option := range ide.Options {
+		if option.Name == name {
+			return option.Value
+		}
+	}
+	return ""
 }

--- a/erun-cli/internal/jetbrainsconfig/jetbrainsconfig_test.go
+++ b/erun-cli/internal/jetbrainsconfig/jetbrainsconfig_test.go
@@ -94,6 +94,114 @@ func TestUpsertOptionsFilesUpdatesExistingEntriesWithoutDuplicates(t *testing.T)
 	}
 }
 
+func TestUpsertOptionsFilesPreservesLatestUsedIDE(t *testing.T) {
+	optionsDir := t.TempDir()
+	configID := StableConfigID("erun-petios-rihards-develop")
+	recentPath := filepath.Join(optionsDir, "sshRecentConnections.v2.xml")
+	if err := os.WriteFile(recentPath, []byte(`<application>
+  <component name="SshLocalRecentConnectionsManager">
+    <option name="connections">
+      <list>
+        <LocalRecentConnectionState>
+          <option name="configId" value="`+configID+`"></option>
+          <option name="projects">
+            <list>
+              <RecentProjectState>
+                <option name="date" value="1777362254961"></option>
+                <option name="latestUsedIde">
+                  <RecentProjectInstalledIde>
+                    <option name="buildNumber" value="261.23567.71"></option>
+                    <option name="pathToIde" value="/home/erun/.cache/JetBrains/RemoteDev/dist/fd6f0251cd1fc_idea-261.23567.71-aarch64"></option>
+                    <option name="productCode" value="IU"></option>
+                  </RecentProjectInstalledIde>
+                </option>
+                <option name="productCode" value="IU"></option>
+                <option name="projectPath" value="/home/erun/git/petios"></option>
+              </RecentProjectState>
+            </list>
+          </option>
+        </LocalRecentConnectionState>
+      </list>
+    </option>
+  </component>
+</application>
+`), 0o600); err != nil {
+		t.Fatalf("write recent projects: %v", err)
+	}
+
+	err := UpsertOptionsFiles(optionsDir, ProjectEntry{
+		ConfigID:       configID,
+		HostAlias:      "erun-petios-rihards-develop",
+		User:           "erun",
+		IdentityFile:   "/Users/test/.ssh/id_ed25519",
+		ProjectPath:    "/home/erun/git/petios",
+		Port:           17422,
+		ProductCode:    "IU",
+		TimestampMilli: 1777362255000,
+	})
+	if err != nil {
+		t.Fatalf("UpsertOptionsFiles failed: %v", err)
+	}
+
+	assertFileContains(t, recentPath,
+		`<option name="latestUsedIde">`,
+		`<option name="buildNumber" value="261.23567.71"></option>`,
+		`<option name="pathToIde" value="/home/erun/.cache/JetBrains/RemoteDev/dist/fd6f0251cd1fc_idea-261.23567.71-aarch64"></option>`,
+		`<option name="date" value="1777362255000"></option>`,
+	)
+}
+
+func TestFindRecentProjectReturnsLatestUsedIDE(t *testing.T) {
+	optionsDir := t.TempDir()
+	configID := StableConfigID("erun-petios-rihards-develop")
+	if err := os.WriteFile(filepath.Join(optionsDir, "sshRecentConnections.v2.xml"), []byte(`<application>
+  <component name="SshLocalRecentConnectionsManager">
+    <option name="connections">
+      <list>
+        <LocalRecentConnectionState>
+          <option name="configId" value="`+configID+`"></option>
+          <option name="projects">
+            <list>
+              <RecentProjectState>
+                <option name="date" value="1777362254961"></option>
+                <option name="latestUsedIde">
+                  <RecentProjectInstalledIde>
+                    <option name="buildNumber" value="261.23567.71"></option>
+                    <option name="pathToIde" value="/home/erun/.cache/JetBrains/RemoteDev/dist/fd6f0251cd1fc_idea-261.23567.71-aarch64"></option>
+                    <option name="productCode" value="IU"></option>
+                  </RecentProjectInstalledIde>
+                </option>
+                <option name="productCode" value="IU"></option>
+                <option name="projectPath" value="/home/erun/git/petios"></option>
+              </RecentProjectState>
+            </list>
+          </option>
+        </LocalRecentConnectionState>
+      </list>
+    </option>
+  </component>
+</application>
+`), 0o600); err != nil {
+		t.Fatalf("write recent projects: %v", err)
+	}
+
+	got, found, err := FindRecentProject(optionsDir, configID, "/home/erun/git/petios")
+	if err != nil {
+		t.Fatalf("FindRecentProject failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected recent project to be found")
+	}
+	if got.ConfigID != configID || got.ProjectPath != "/home/erun/git/petios" || got.ProductCode != "IU" {
+		t.Fatalf("unexpected recent project: %+v", got)
+	}
+	if got.LatestUsedIDE.BuildNumber != "261.23567.71" ||
+		got.LatestUsedIDE.PathToIDE != "/home/erun/.cache/JetBrains/RemoteDev/dist/fd6f0251cd1fc_idea-261.23567.71-aarch64" ||
+		got.LatestUsedIDE.ProductCode != "IU" {
+		t.Fatalf("unexpected latest IDE metadata: %+v", got.LatestUsedIDE)
+	}
+}
+
 func assertFileContains(t *testing.T, path string, wants ...string) {
 	t.Helper()
 	data := readFile(t, path)

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -43,6 +43,7 @@ type erunUIDeps struct {
 	canConnectLocalPort  func(int) bool
 	setRemoteCloudAlias  func(context.Context, string, string, string, string) (eruncommon.EnvConfig, error)
 	startTerminal        func(startTerminalSessionParams) (terminalSession, error)
+	runIDECommand        func(context.Context, startTerminalSessionParams) (string, error)
 	savePastedImage      func(pastedImageSaveParams) (string, error)
 	loadDiff             func(context.Context, string) (eruncommon.DiffResult, error)
 	windowStatePath      string
@@ -265,6 +266,9 @@ func NewApp(deps erunUIDeps) *App {
 	}
 	if deps.startTerminal == nil {
 		deps.startTerminal = startTerminalSession
+	}
+	if deps.runIDECommand == nil {
+		deps.runIDECommand = runIDECommand
 	}
 	if deps.savePastedImage == nil {
 		deps.savePastedImage = savePastedImageToRuntime
@@ -922,6 +926,52 @@ func (a *App) StartDeploySession(selection uiSelection, cols, rows int) (startSe
 	return a.startCommandSession(selection, cols, rows, deploySelectionKey(selection), buildDeployArgs(selection), resolveDeployStartDir(a.deps.findProjectRoot, result), []string{appSessionEnvVar + "=1"})
 }
 
+func (a *App) OpenIDE(selection uiSelection, ide string) error {
+	selection = normalizeSelection(selection)
+	ide = strings.TrimSpace(ide)
+	if selection.Tenant == "" || selection.Environment == "" {
+		return fmt.Errorf("tenant and environment are required")
+	}
+	if ide != "vscode" && ide != "intellij" {
+		return fmt.Errorf("unsupported IDE %q", ide)
+	}
+	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
+		Tenant:      selection.Tenant,
+		Environment: selection.Environment,
+	})
+	if err != nil {
+		return err
+	}
+
+	cliPath := a.deps.resolveCLIPath()
+	executable := cliPath
+	args := buildOpenIDEArgs(selection, ide)
+	if !result.EnvConfig.SSHD.Enabled {
+		executable, args, err = buildIDEShellLaunch(cliPath, selection, ide)
+		if err != nil {
+			return err
+		}
+	}
+
+	ctx := a.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	output, err := a.deps.runIDECommand(ctx, startTerminalSessionParams{
+		Dir:        resolveDeployStartDir(a.deps.findProjectRoot, result),
+		Executable: executable,
+		Args:       args,
+		Env:        []string{appSessionEnvVar + "=1"},
+	})
+	if err == nil {
+		return nil
+	}
+	if detail := strings.TrimSpace(output); detail != "" {
+		return fmt.Errorf("open %s: %w: %s", ide, err, detail)
+	}
+	return fmt.Errorf("open %s: %w", ide, err)
+}
+
 func (a *App) StartCloudInitAWSSession(cols, rows int) (startSessionResult, error) {
 	if cols <= 0 {
 		cols = 120
@@ -1019,6 +1069,10 @@ func (a *App) DeleteEnvironment(selection uiSelection, confirmation string) (del
 }
 
 func (a *App) startCommandSession(selection uiSelection, cols, rows int, key string, args []string, dir string, env []string) (startSessionResult, error) {
+	return a.startCommandSessionWithExecutable(selection, cols, rows, key, a.deps.resolveCLIPath(), args, dir, env)
+}
+
+func (a *App) startCommandSessionWithExecutable(selection uiSelection, cols, rows int, key string, executable string, args []string, dir string, env []string) (startSessionResult, error) {
 	selection = normalizeSelection(selection)
 	if selection.Tenant == "" || selection.Environment == "" {
 		return startSessionResult{}, fmt.Errorf("tenant and environment are required")
@@ -1043,7 +1097,7 @@ func (a *App) startCommandSession(selection uiSelection, cols, rows int, key str
 
 	session, err := a.deps.startTerminal(startTerminalSessionParams{
 		Dir:        dir,
-		Executable: a.deps.resolveCLIPath(),
+		Executable: executable,
 		Args:       args,
 		Env:        env,
 		Cols:       cols,

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -446,6 +446,20 @@ func TestBuildOpenArgsIncludesDebugVerbosity(t *testing.T) {
 	}
 }
 
+func TestBuildOpenIDEArgsAddsIDEFlag(t *testing.T) {
+	got := buildOpenIDEArgs(uiSelection{Tenant: " erun ", Environment: " remote ", Debug: true}, "vscode")
+	want := []string{"-vv", "open", "erun", "remote", "--vscode"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected VS Code args: got %+v want %+v", got, want)
+	}
+
+	got = buildOpenIDEArgs(uiSelection{Tenant: "erun", Environment: "remote"}, "intellij")
+	want = []string{"open", "erun", "remote", "--intellij"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("unexpected IntelliJ args: got %+v want %+v", got, want)
+	}
+}
+
 func TestBuildOpenNoShellArgsTrimsTenantAndEnvironment(t *testing.T) {
 	got := buildOpenNoShellArgs(" erun ", " local ")
 	want := []string{"open", "erun", "local", "--no-shell", "--no-alias-prompt"}
@@ -811,6 +825,103 @@ func TestStartDeploySessionUsesSeparateSessionKey(t *testing.T) {
 	}
 	if startCalls != 3 {
 		t.Fatalf("start terminal called %d times, want 3", startCalls)
+	}
+}
+
+func TestOpenIDERunsWithoutConsumingTerminalWhenSSHDEnabled(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {
+				Name:               "erun",
+				ProjectRoot:        projectRoot,
+				DefaultEnvironment: "remote",
+			},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {
+				Name:              "remote",
+				RepoPath:          projectRoot,
+				KubernetesContext: "rancher-desktop",
+				SSHD: eruncommon.SSHDConfig{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	startCalls := 0
+	var started startTerminalSessionParams
+	app := NewApp(erunUIDeps{
+		store:          store,
+		resolveCLIPath: func() string { return "/tmp/erun" },
+		startTerminal: func(params startTerminalSessionParams) (terminalSession, error) {
+			startCalls++
+			return newStubTerminalSession(), nil
+		},
+		runIDECommand: func(_ context.Context, params startTerminalSessionParams) (string, error) {
+			started = params
+			return "", nil
+		},
+	})
+	defer app.shutdown(context.Background())
+
+	if err := app.OpenIDE(uiSelection{Tenant: " erun ", Environment: " remote "}, "vscode"); err != nil {
+		t.Fatalf("OpenIDE failed: %v", err)
+	}
+	if startCalls != 0 {
+		t.Fatalf("expected IDE open not to start a managed terminal, got %d calls", startCalls)
+	}
+	if started.Executable != "/tmp/erun" {
+		t.Fatalf("unexpected executable: %q", started.Executable)
+	}
+	wantArgs := []string{"open", "erun", "remote", "--vscode"}
+	if strings.Join(started.Args, "\n") != strings.Join(wantArgs, "\n") {
+		t.Fatalf("unexpected args: got %+v want %+v", started.Args, wantArgs)
+	}
+}
+
+func TestOpenIDEInitializesSSHDWhenMissing(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {
+				Name:               "erun",
+				ProjectRoot:        projectRoot,
+				DefaultEnvironment: "remote",
+			},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {
+				Name:              "remote",
+				RepoPath:          projectRoot,
+				KubernetesContext: "rancher-desktop",
+			},
+		},
+	}
+
+	var started startTerminalSessionParams
+	app := NewApp(erunUIDeps{
+		store:          store,
+		resolveCLIPath: func() string { return "/tmp/erun" },
+		runIDECommand: func(_ context.Context, params startTerminalSessionParams) (string, error) {
+			started = params
+			return "", nil
+		},
+	})
+	defer app.shutdown(context.Background())
+
+	if err := app.OpenIDE(uiSelection{Tenant: "erun", Environment: "remote"}, "intellij"); err != nil {
+		t.Fatalf("OpenIDE failed: %v", err)
+	}
+	if started.Executable == "/tmp/erun" {
+		t.Fatalf("expected shell wrapper executable when SSHD is missing, got %q", started.Executable)
+	}
+	args := strings.Join(started.Args, "\n")
+	for _, want := range []string{"sshd", "init", "erun", "remote", "open", "--intellij"} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("expected shell args to contain %q, got %+v", want, started.Args)
+		}
 	}
 }
 

--- a/erun-ui/frontend/src/App.tsx
+++ b/erun-ui/frontend/src/App.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { ChevronDown, ChevronUp, Trash2 } from 'lucide-react';
+import { CheckCircle2, ChevronDown, ChevronUp, Copy, Trash2 } from 'lucide-react';
 
 import { ERunUIController } from '@/app/ERunUIController';
+import { readError } from '@/app/errors';
 import { useControllerState } from '@/app/useControllerState';
 import { EnvironmentDialogView } from '@/components/app/EnvironmentDialogView';
 import { GlobalConfigDialogView } from '@/components/app/GlobalConfigDialogView';
@@ -13,6 +14,7 @@ import { Titlebar } from '@/components/app/Titlebar';
 import { Button } from '@/components/ui/button';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
+import { ClipboardSetText } from '../wailsjs/runtime/runtime';
 
 const splitterClassName =
   'relative cursor-col-resize bg-transparent before:absolute before:top-0 before:bottom-0 before:left-1 before:w-px before:bg-transparent before:transition-colors hover:before:bg-border [.is-resizing_&]:before:bg-border';
@@ -109,12 +111,30 @@ export function App(): React.ReactElement {
 
 function DebugPanel({ controller, open, output }: { controller: ERunUIController; open: boolean; output: string }): React.ReactElement {
   const outputRef = React.useRef<HTMLPreElement>(null);
+  const [copyStatus, setCopyStatus] = React.useState('');
+  const canCopy = output.trim().length > 0;
 
   React.useEffect(() => {
     if (open && outputRef.current) {
       outputRef.current.scrollTop = outputRef.current.scrollHeight;
     }
   }, [open, output]);
+
+  React.useEffect(() => {
+    setCopyStatus('');
+  }, [output]);
+
+  const copyDebugOutput = React.useCallback(() => {
+    if (!canCopy) {
+      return;
+    }
+    void ClipboardSetText(output)
+      .then(() => {
+        setCopyStatus('Copied');
+        window.setTimeout(() => setCopyStatus(''), 1400);
+      })
+      .catch((error: unknown) => setCopyStatus(readError(error)));
+  }, [canCopy, output]);
 
   return (
     <section className={cn('grid min-h-0 border-t border-[oklch(0.26_0_0)] bg-[oklch(0.06_0_0)] text-[oklch(0.86_0_0)]', open ? 'grid-rows-[6px_34px_minmax(0,1fr)]' : 'grid-rows-[34px]')}>
@@ -138,10 +158,16 @@ function DebugPanel({ controller, open, output }: { controller: ERunUIController
           <span className="text-[11px] font-normal text-[oklch(0.56_0_0)]">{open ? 'erun -vv output' : 'collapsed'}</span>
         </button>
         {open && (
-          <Button className="h-6 px-2 text-[11px] [&_svg]:size-3.5" type="button" variant="ghost" size="sm" onClick={() => controller.clearDebugOutput()}>
-            <Trash2 aria-hidden="true" />
-            Clear
-          </Button>
+          <div className="flex items-center gap-1">
+            <Button className="h-6 px-2 text-[11px] [&_svg]:size-3.5" type="button" variant="ghost" size="sm" disabled={!canCopy} onClick={copyDebugOutput}>
+              {copyStatus === 'Copied' ? <CheckCircle2 aria-hidden="true" /> : <Copy aria-hidden="true" />}
+              {copyStatus || 'Copy'}
+            </Button>
+            <Button className="h-6 px-2 text-[11px] [&_svg]:size-3.5" type="button" variant="ghost" size="sm" onClick={() => controller.clearDebugOutput()}>
+              <Trash2 aria-hidden="true" />
+              Clear
+            </Button>
+          </div>
         )}
       </div>
       {open && (

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -14,6 +14,7 @@ import {
   LoadState,
   LoadTenantConfig,
   LoadVersionSuggestions,
+  OpenIDE,
   ResizeSession,
   LoginCloudProvider,
   SavePastedImage,
@@ -110,6 +111,7 @@ interface DebugOpenFilter {
 }
 
 type DebugSessionMode = 'open' | 'hidden';
+type IDEKind = 'vscode' | 'intellij';
 
 export class ERunUIController {
   readonly state: AppState = {
@@ -481,6 +483,34 @@ export class ERunUIController {
     this.focusTerminalSoon();
     this.queueTerminalResize();
     this.emit();
+  }
+
+  async openIDE(selection: UISelection | null, ide: IDEKind): Promise<void> {
+    if (!selection) {
+      this.showTerminalMessage('Choose an environment from the left pane.');
+      return;
+    }
+    const runSelection = { ...selection, debug: this.state.debugOpen || undefined };
+    const label = ideLabel(ide);
+    this.state.selected = selection;
+    if (this.state.debugOpen) {
+      this.state.debugOutput = `$ ${formatIDECommand(runSelection, ide)}\n`;
+    }
+    this.emit();
+    this.state.terminalCopyOutput = '';
+    this.state.terminalCopyStatus = '';
+    this.showTerminalMessage(`Opening ${label} for ${selection.tenant} / ${selection.environment}...`, true);
+
+    try {
+      await OpenIDE(runSelection, ide);
+    } catch (error: unknown) {
+      const failure = ideOpenFailure(selection, label, readError(error));
+      this.appendDebugOutput(debugOutputBlock(failure.copyOutput));
+      this.dismissNotification();
+      this.showTerminalFailure(failure.message, failure.detail, failure.copyOutput, '', null);
+      return;
+    }
+    this.showNotification('success', `Opened ${label} for ${selection.tenant} / ${selection.environment}.`);
   }
 
   openInitializeDialog(): void {
@@ -2109,6 +2139,37 @@ function cleanTerminalOutput(value: string): string {
     .trim();
 }
 
+function ideOpenFailure(selection: UISelection, label: string, rawError: string): ClassifiedTerminalFailure & { copyOutput: string } {
+  const output = cleanTerminalOutput(rawError) || rawError.trim() || 'Unexpected error';
+  return {
+    message: `Failed to open ${label} for ${selection.tenant} / ${selection.environment}`,
+    detail: shortIDEOpenFailureDetail(output),
+    copyOutput: output,
+    action: '',
+    retrySelection: null,
+  };
+}
+
+function debugOutputBlock(output: string): string {
+  const trimmed = output.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return `${trimmed}\n`;
+}
+
+function shortIDEOpenFailureDetail(output: string): string {
+  const firstLine = output.split('\n').map((line) => line.trim()).find(Boolean) || '';
+  const exitStatus = firstLine.match(/exit status \d+/)?.[0];
+  if (exitStatus) {
+    return exitStatus;
+  }
+  if (firstLine.length <= 80) {
+    return firstLine;
+  }
+  return `${firstLine.slice(0, 77)}...`;
+}
+
 function classifiedTerminalFailure(rawReason: string, displayReason: string, output: string, openSelection?: UISelection): ClassifiedTerminalFailure {
   const combined = `${rawReason}\n${output}`.toLowerCase();
   if (combined.includes('timed out waiting for mcp port-forward')) {
@@ -2249,6 +2310,19 @@ function formatDebugCommand(selection: UISelection, mode: 'open' | 'init' | 'dep
     args.push('open', selection.tenant, selection.environment);
   }
   return args.map(shellDebugArg).join(' ');
+}
+
+function formatIDECommand(selection: UISelection, ide: IDEKind): string {
+  const args = ['erun'];
+  if (selection.debug) {
+    args.push('-vv');
+  }
+  args.push('open', selection.tenant, selection.environment, ide === 'vscode' ? '--vscode' : '--intellij');
+  return args.map(shellDebugArg).join(' ');
+}
+
+function ideLabel(ide: IDEKind): string {
+  return ide === 'vscode' ? 'VS Code' : 'IntelliJ IDEA';
 }
 
 function shellDebugArg(value: string): string {

--- a/erun-ui/frontend/src/components/app/Titlebar.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AlertCircle, CheckCircle2, Copy, Info, ListTree, LoaderCircle, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, X } from 'lucide-react';
+import { AlertCircle, Blocks, CheckCircle2, Code2, Copy, Info, ListTree, LoaderCircle, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, X } from 'lucide-react';
 
 import type { ERunUIController } from '@/app/ERunUIController';
 import type { AppState } from '@/app/state';
@@ -16,6 +16,7 @@ export function Titlebar({ controller, state }: { controller: ERunUIController; 
   const SidebarIcon = state.sidebarHidden ? PanelLeftOpen : PanelLeftClose;
   const ReviewIcon = state.reviewOpen ? PanelRightClose : PanelRightOpen;
   const notification = state.notification;
+  const selected = state.selected;
   const terminalStatus = !notification && state.terminalMessage
     ? {
         kind: state.terminalStatusKind,
@@ -66,6 +67,42 @@ export function Titlebar({ controller, state }: { controller: ERunUIController; 
           <ReviewIcon />
         </Button>
       </IconTooltip>
+      <IconTooltip label="Open in VS Code">
+        <Button
+          className={cn(
+            titlebarButtonClassName,
+            'left-auto right-[122px] max-[980px]:left-auto max-[980px]:right-[108px]',
+          )}
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Open selected environment in VS Code"
+          disabled={!selected}
+          onClick={() => {
+            void controller.openIDE(selected ?? null, 'vscode');
+          }}
+        >
+          <Code2 />
+        </Button>
+      </IconTooltip>
+      <IconTooltip label="Open in IntelliJ IDEA">
+        <Button
+          className={cn(
+            titlebarButtonClassName,
+            'left-auto right-[90px] max-[980px]:left-auto max-[980px]:right-[78px]',
+          )}
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Open selected environment in IntelliJ IDEA"
+          disabled={!selected}
+          onClick={() => {
+            void controller.openIDE(selected ?? null, 'intellij');
+          }}
+        >
+          <Blocks />
+        </Button>
+      </IconTooltip>
       <IconTooltip label="Toggle changed files list">
         <Button
           className={cn(
@@ -86,7 +123,7 @@ export function Titlebar({ controller, state }: { controller: ERunUIController; 
       </IconTooltip>
       {status && (
         <div
-          className="pointer-events-none absolute top-2.5 right-24 left-32 z-20 flex justify-center [--wails-draggable:no-drag] max-[980px]:right-[84px] max-[980px]:left-[112px]"
+          className="pointer-events-none absolute top-2.5 right-[168px] left-32 z-20 flex justify-center [--wails-draggable:no-drag] max-[980px]:right-[146px] max-[980px]:left-[112px]"
           role={status.kind === 'error' ? 'alert' : 'status'}
           aria-live={status.kind === 'error' ? 'assertive' : 'polite'}
         >

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -67,6 +67,16 @@ func resolveCLIExecutableFromPath(goos, appExecutable, executableName string) st
 	return ""
 }
 
+func runIDECommand(ctx context.Context, params startTerminalSessionParams) (string, error) {
+	cmd := exec.CommandContext(ctx, params.Executable, params.Args...)
+	cmd.Dir = resolveTerminalStartDir(params.Dir)
+	if len(params.Env) > 0 {
+		cmd.Env = append(os.Environ(), params.Env...)
+	}
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
 func buildOpenCommand(cliPath, tenant, environment string) string {
 	if runtime.GOOS == "windows" {
 		return "& " + powerShellQuote(cliPath) + " open " + powerShellQuote(strings.TrimSpace(tenant)) + " " + powerShellQuote(strings.TrimSpace(environment))
@@ -78,8 +88,55 @@ func buildOpenArgs(tenant, environment string, debug ...bool) []string {
 	return erunArgs(debugEnabled(debug...), "open", strings.TrimSpace(tenant), strings.TrimSpace(environment))
 }
 
+func buildOpenIDEArgs(selection uiSelection, ide string) []string {
+	args := erunArgs(selection.Debug, "open", strings.TrimSpace(selection.Tenant), strings.TrimSpace(selection.Environment))
+	switch strings.TrimSpace(ide) {
+	case "vscode":
+		return append(args, "--vscode")
+	case "intellij":
+		return append(args, "--intellij")
+	default:
+		return args
+	}
+}
+
+func buildSSHDInitArgs(selection uiSelection) []string {
+	return erunArgs(selection.Debug, "sshd", "init", strings.TrimSpace(selection.Tenant), strings.TrimSpace(selection.Environment))
+}
+
 func buildOpenNoShellArgs(tenant, environment string) []string {
 	return []string{"open", strings.TrimSpace(tenant), strings.TrimSpace(environment), "--no-shell", "--no-alias-prompt"}
+}
+
+func buildIDEShellLaunch(cliPath string, selection uiSelection, ide string) (string, []string, error) {
+	switch runtime.GOOS {
+	case "windows":
+		initCommand := buildPowerShellCommandInvocation(cliPath, buildSSHDInitArgs(selection))
+		openCommand := buildPowerShellCommandInvocation(cliPath, buildOpenIDEArgs(selection, ide))
+		return "powershell.exe", []string{"-NoLogo", "-NoProfile", "-Command", initCommand + "; if ($LASTEXITCODE -eq 0) { " + openCommand + " } else { exit $LASTEXITCODE }"}, nil
+	default:
+		initCommand := buildShellCommandInvocation(cliPath, buildSSHDInitArgs(selection))
+		openCommand := buildShellCommandInvocation(cliPath, buildOpenIDEArgs(selection, ide))
+		return "/bin/sh", []string{"-lc", initCommand + " && " + openCommand}, nil
+	}
+}
+
+func buildShellCommandInvocation(command string, args []string) string {
+	quoted := make([]string, 0, len(args)+1)
+	quoted = append(quoted, shellQuote(command))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuote(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func buildPowerShellCommandInvocation(command string, args []string) string {
+	quoted := make([]string, 0, len(args)+1)
+	quoted = append(quoted, "& "+powerShellQuote(command))
+	for _, arg := range args {
+		quoted = append(quoted, powerShellQuote(arg))
+	}
+	return strings.Join(quoted, " ")
 }
 
 func ensureMCPViaOpenCommand(ctx context.Context, cliPath string, result eruncommon.OpenResult) error {


### PR DESCRIPTION
## Summary
- add desktop titlebar buttons to open the selected environment in VS Code or IntelliJ IDEA
- run IDE opens through a separate backend command so the active terminal session is not consumed
- initialize SSHD when needed before opening IDEs, improve SSHD readiness checks, and retry key sync when pods roll during setup
- preserve JetBrains SSH recent-project metadata and launch existing IntelliJ remote projects through the Gateway runtime directly on macOS
- add copy support for debug output and include IDE launch failures in the debug panel

## Validation
- go test ./... in erun-cli
- go test ./... in erun-ui
- yarn build in erun-ui/frontend
- yarn shadcn:check in erun-ui/frontend
- git diff --check

Closes #160
