### PR TITLE
Add strict linter settings across modules

### DIFF
--- a/erun-cli/.golangci.yml
+++ b/erun-cli/.golangci.yml
@@ -1,4 +1,4 @@
-version: 2
+version: "2"
 
 run:
   timeout: 3m
@@ -10,11 +10,20 @@ linters:
     - ineffassign
     - staticcheck
     - unused
+    - funlen
+    - gocyclo
+    - cyclop
+  settings:
+    funlen:
+      lines: 100
+      statements: 50
+    gocyclo:
+      min-complexity: 15
+    cyclop:
+      max-complexity: 10
 formatters:
   enable:
     - gofumpt
-formatters-settings:
-  gofumpt:
-    module-path: github.com/sophium/erun
-issues:
-  exclude-use-default: false
+  settings:
+    gofumpt:
+      module-path: github.com/sophium/erun

--- a/erun-cli/cmd/app.go
+++ b/erun-cli/cmd/app.go
@@ -75,25 +75,43 @@ func resolveAppExecutable() string {
 
 	executable, err := os.Executable()
 	if err == nil {
-		if runtime.GOOS == "darwin" {
-			siblingBundle := filepath.Join(filepath.Dir(executable), "ERun.app")
-			if info, statErr := os.Stat(siblingBundle); statErr == nil && info.IsDir() {
-				return siblingBundle
-			}
-			devBundle := filepath.Clean(filepath.Join(filepath.Dir(executable), "..", "..", "erun-ui", "bin", "ERun.app"))
-			if info, statErr := os.Stat(devBundle); statErr == nil && info.IsDir() {
-				return devBundle
-			}
-		}
-
-		sibling := filepath.Join(filepath.Dir(executable), executableName)
-		if info, statErr := os.Stat(sibling); statErr == nil && !info.IsDir() {
-			return sibling
-		}
-		devBinary := filepath.Clean(filepath.Join(filepath.Dir(executable), "..", "..", "erun-ui", "bin", executableName))
-		if info, statErr := os.Stat(devBinary); statErr == nil && !info.IsDir() {
-			return devBinary
+		if resolved := resolveAppExecutableNear(executable, executableName); resolved != "" {
+			return resolved
 		}
 	}
 	return executableName
+}
+
+func resolveAppExecutableNear(executable, executableName string) string {
+	executableDir := filepath.Dir(executable)
+	if runtime.GOOS == "darwin" {
+		if bundle := firstExistingDir(
+			filepath.Join(executableDir, "ERun.app"),
+			filepath.Clean(filepath.Join(executableDir, "..", "..", "erun-ui", "bin", "ERun.app")),
+		); bundle != "" {
+			return bundle
+		}
+	}
+	return firstExistingFile(
+		filepath.Join(executableDir, executableName),
+		filepath.Clean(filepath.Join(executableDir, "..", "..", "erun-ui", "bin", executableName)),
+	)
+}
+
+func firstExistingDir(paths ...string) string {
+	for _, path := range paths {
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
+			return path
+		}
+	}
+	return ""
+}
+
+func firstExistingFile(paths ...string) string {
+	for _, path := range paths {
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return path
+		}
+	}
+	return ""
 }

--- a/erun-cli/cmd/app_test.go
+++ b/erun-cli/cmd/app_test.go
@@ -21,9 +21,7 @@ func TestAppCommandLaunchesDesktopApp(t *testing.T) {
 	cmd.SetErr(buf)
 	cmd.SetArgs(nil)
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if !called {
 		t.Fatal("expected launcher to be called")
 	}
@@ -40,9 +38,7 @@ func TestAppCommandDryRunSkipsLaunch(t *testing.T) {
 	cmd.SetErr(buf)
 	cmd.SetArgs([]string{"--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if called {
 		t.Fatal("expected launcher not to be called in dry-run mode")
 	}

--- a/erun-cli/cmd/build_test.go
+++ b/erun-cli/cmd/build_test.go
@@ -489,20 +489,14 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDockerDire
 		filepath.Join(dockerDir, "erun-ubuntu"),
 	}
 	for _, dir := range componentDirs {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("mkdir component dir: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-			t.Fatalf("write Dockerfile: %v", err)
-		}
+		requireMkdirAll(t, dir, 0o755, "mkdir component dir")
+		requireWriteFile(t, filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644, "write Dockerfile")
 	}
-	if err := common.SaveTenantConfig(common.TenantConfig{
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{
 		Name:               "erun",
 		ProjectRoot:        projectRoot,
 		DefaultEnvironment: common.DefaultEnvironment,
-	}); err != nil {
-		t.Fatalf("save tenant config: %v", err)
-	}
+	}), "save tenant config")
 	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 	requireNoError(t, os.WriteFile(filepath.Join(componentDirs[0], "VERSION"), []byte("1.0.0\n"), 0o644), "write VERSION")
 	requireNoError(t, os.WriteFile(filepath.Join(componentDirs[1], "VERSION"), []byte("28.1.1\n"), 0o644), "write VERSION")
@@ -544,11 +538,7 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDockerDire
 		"erunpaas/erun-dind:28.1.1",
 		"erunpaas/erun-ubuntu:noble-20260217",
 	}
-	for i := range wantTags {
-		if gotTags[i] != wantTags[i] {
-			t.Fatalf("unexpected image tags: got %v want %v", gotTags, wantTags)
-		}
-	}
+	requireStringSlicesEqual(t, gotTags, wantTags, "unexpected image tags")
 	for _, req := range built {
 		if req.Dir != projectRoot {
 			t.Fatalf("expected project root build context, got %+v", req)

--- a/erun-cli/cmd/build_test.go
+++ b/erun-cli/cmd/build_test.go
@@ -116,18 +116,10 @@ func setupMultiDockerProject(t *testing.T, tenant string) (string, string, strin
 		}
 		componentDirs = append(componentDirs, componentDir)
 	}
-	if err := os.WriteFile(filepath.Join(moduleRoot, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentDirs[0], "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentDirs[1], "VERSION"), []byte("28.1.1\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentDirs[2], "VERSION"), []byte("noble-20260217\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
+	requireNoError(t, os.WriteFile(filepath.Join(moduleRoot, "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(componentDirs[0], "VERSION"), []byte("1.0.0\n"), 0o644), "write VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(componentDirs[1], "VERSION"), []byte("28.1.1\n"), 0o644), "write VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(componentDirs[2], "VERSION"), []byte("noble-20260217\n"), 0o644), "write VERSION")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               tenant,
 		ProjectRoot:        projectRoot,
@@ -135,9 +127,7 @@ func setupMultiDockerProject(t *testing.T, tenant string) (string, string, strin
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	tags := []string{
 		"erunpaas/" + componentNames[0] + ":1.0.0",
@@ -244,13 +234,9 @@ func TestNewRootCmdRegistersBuildShorthandWhenDockerfilePresent(t *testing.T) {
 func TestNewRootCmdRegistersBuildShorthandWhenProjectBuildScriptPresent(t *testing.T) {
 	projectRoot := t.TempDir()
 	scriptDir := filepath.Join(projectRoot, "scripts", "build")
-	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
-		t.Fatalf("mkdir script dir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(scriptDir, 0o755), "mkdir script dir")
 	scriptPath := filepath.Join(scriptDir, "build.sh")
-	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write build.sh: %v", err)
-	}
+	requireNoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755), "write build.sh")
 
 	cmd := newTestRootCmd(testRootDeps{
 		OptionalBuildFindProjectRoot: func() (string, string, error) {
@@ -282,18 +268,10 @@ func TestNewRootCmdRegistersBuildShorthandWhenProjectBuildScriptPresent(t *testi
 
 func TestNewRootCmdRegistersBuildShorthandWhenDockerDirectoryContainsDockerfiles(t *testing.T) {
 	dockerDir := filepath.Join(t.TempDir(), "erun-devops", "docker")
-	if err := os.MkdirAll(filepath.Join(dockerDir, "erun-devops"), 0o755); err != nil {
-		t.Fatalf("mkdir component dir: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Join(dockerDir, "erun-dind"), 0o755); err != nil {
-		t.Fatalf("mkdir component dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dockerDir, "erun-devops", "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dockerDir, "erun-dind", "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(filepath.Join(dockerDir, "erun-devops"), 0o755), "mkdir component dir")
+	requireNoError(t, os.MkdirAll(filepath.Join(dockerDir, "erun-dind"), 0o755), "mkdir component dir")
+	requireNoError(t, os.WriteFile(filepath.Join(dockerDir, "erun-devops", "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(dockerDir, "erun-dind", "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
 
 	cmd := newTestRootCmd(testRootDeps{
 		ResolveDockerBuildContext: func() (common.DockerBuildContext, error) {
@@ -367,18 +345,10 @@ func TestNewRootCmdOmitsBuildShorthandWhenDockerfileAbsent(t *testing.T) {
 func TestRootBuildShorthandRunsDockerBuild(t *testing.T) {
 	projectRoot := t.TempDir()
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-ubuntu")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("noble-20260217\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir build dir")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("noble-20260217\n"), 0o644), "write local VERSION")
 	buildContext := common.DockerBuildContext{
 		Dir:            workdir,
 		DockerfilePath: filepath.Join(workdir, "Dockerfile"),
@@ -411,9 +381,7 @@ func TestRootBuildShorthandRunsDockerBuild(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"build"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if received.Dir != projectRoot || received.DockerfilePath != buildContext.DockerfilePath {
 		t.Fatalf("unexpected build request: %+v", received)
@@ -429,27 +397,15 @@ func TestRootBuildShorthandRunsDockerBuild(t *testing.T) {
 func TestRootBuildShorthandPrefersDockerBuildOverNestedProjectBuildScript(t *testing.T) {
 	projectRoot := t.TempDir()
 	scriptDir := filepath.Join(projectRoot, "scripts", "build")
-	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
-		t.Fatalf("mkdir script dir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(scriptDir, 0o755), "mkdir script dir")
 	scriptPath := filepath.Join(scriptDir, "build.sh")
-	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write build.sh: %v", err)
-	}
+	requireNoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755), "write build.sh")
 
 	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(buildDir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(buildDir, 0o755), "mkdir build dir")
+	requireNoError(t, os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write VERSION")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	var received dockerBuildCall
 	cmd := newTestRootCmd(testRootDeps{
@@ -480,9 +436,7 @@ func TestRootBuildShorthandPrefersDockerBuildOverNestedProjectBuildScript(t *tes
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"build"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if received.Dir != projectRoot || received.DockerfilePath != filepath.Join(buildDir, "Dockerfile") {
 		t.Fatalf("unexpected docker build call: %+v", received)
@@ -494,14 +448,10 @@ func TestRootBuildShorthandPrefersDockerBuildOverNestedProjectBuildScript(t *tes
 
 func TestRootBuildShorthandDeployRejectsProjectBuildScript(t *testing.T) {
 	projectRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write build.sh: %v", err)
-	}
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755), "write build.sh")
 
 	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(buildDir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(buildDir, 0o755), "mkdir build dir")
 
 	cmd := newTestRootCmd(testRootDeps{
 		OptionalBuildFindProjectRoot: func() (string, string, error) {
@@ -553,18 +503,10 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDockerDire
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentDirs[0], "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentDirs[1], "VERSION"), []byte("28.1.1\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentDirs[2], "VERSION"), []byte("noble-20260217\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(componentDirs[0], "VERSION"), []byte("1.0.0\n"), 0o644), "write VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(componentDirs[1], "VERSION"), []byte("28.1.1\n"), 0o644), "write VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(componentDirs[2], "VERSION"), []byte("noble-20260217\n"), 0o644), "write VERSION")
 
 	var built []dockerBuildCall
 	var pushed []dockerPushCall
@@ -590,9 +532,7 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDockerDire
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"build"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if len(built) != 3 || len(pushed) != 0 {
 		t.Fatalf("unexpected build/push counts: builds=%d pushes=%d", len(built), len(pushed))
@@ -645,9 +585,7 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsProjectRoo
 	})
 	cmd.SetArgs([]string{"build"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if len(built) != len(wantTags) || len(pushed) != 0 {
 		t.Fatalf("unexpected build/push counts: builds=%d pushes=%d", len(built), len(pushed))
 	}
@@ -687,9 +625,7 @@ func TestRootBuildShorthandBuildsAllDockerImagesWhenCurrentDirectoryIsDevopsModu
 	})
 	cmd.SetArgs([]string{"build"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if len(built) != len(wantTags) || len(pushed) != 0 {
 		t.Fatalf("unexpected build/push counts: builds=%d pushes=%d", len(built), len(pushed))
 	}
@@ -708,9 +644,7 @@ func TestRootBuildShorthandUsesExactVersionFromCurrentBuildDirectoryForLocalEnvi
 
 	projectRoot := t.TempDir()
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir build dir")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "erun",
 		ProjectRoot:        projectRoot,
@@ -718,15 +652,9 @@ func TestRootBuildShorthandUsesExactVersionFromCurrentBuildDirectoryForLocalEnvi
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
 	fixedNow := time.Date(2026, time.April, 6, 12, 34, 56, 0, time.UTC)
 	var received dockerBuildCall
@@ -754,9 +682,7 @@ func TestRootBuildShorthandUsesExactVersionFromCurrentBuildDirectoryForLocalEnvi
 	})
 	cmd.SetArgs([]string{"build"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	wantVersion := "1.1.0"
 	if received.Tag != "erunpaas/erun-devops:"+wantVersion {
@@ -769,9 +695,7 @@ func TestRootBuildShorthandDryRunPrintsCommandWithoutExecuting(t *testing.T) {
 
 	projectRoot := t.TempDir()
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir build dir")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "erun",
 		ProjectRoot:        projectRoot,
@@ -779,15 +703,9 @@ func TestRootBuildShorthandDryRunPrintsCommandWithoutExecuting(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
 	stderr := new(bytes.Buffer)
 	cmd := newTestRootCmd(testRootDeps{
@@ -815,9 +733,7 @@ func TestRootBuildShorthandDryRunPrintsCommandWithoutExecuting(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"build", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := stderr.String(); !bytes.Contains([]byte(got), []byte("docker build -t erunpaas/erun-devops:1.1.0")) {
 		t.Fatalf("expected dry-run trace output, got %q", got)
@@ -853,9 +769,7 @@ func TestRootBuildShorthandDryRunPrintsBuildCommandsForProjectRoot(t *testing.T)
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"build", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	for _, tag := range wantTags {
@@ -871,13 +785,9 @@ func TestRootBuildShorthandDryRunPrintsBuildCommandsForProjectRoot(t *testing.T)
 func TestRootBuildShorthandDryRunPrintsBuildScriptCommandWithoutExecuting(t *testing.T) {
 	projectRoot := t.TempDir()
 	scriptDir := filepath.Join(projectRoot, "scripts", "build")
-	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
-		t.Fatalf("mkdir script dir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(scriptDir, 0o755), "mkdir script dir")
 	scriptPath := filepath.Join(scriptDir, "build.sh")
-	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write build.sh: %v", err)
-	}
+	requireNoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755), "write build.sh")
 
 	stderr := new(bytes.Buffer)
 	cmd := newTestRootCmd(testRootDeps{
@@ -898,9 +808,7 @@ func TestRootBuildShorthandDryRunPrintsBuildScriptCommandWithoutExecuting(t *tes
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"build", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := stderr.String(); !strings.Contains(got, "cd "+scriptDir+" && ./build.sh") {
 		t.Fatalf("expected build.sh dry-run trace, got %q", got)
@@ -910,24 +818,12 @@ func TestRootBuildShorthandDryRunPrintsBuildScriptCommandWithoutExecuting(t *tes
 func TestRootBuildShorthandIgnoresBuildScriptInDockerArtifactDirectory(t *testing.T) {
 	projectRoot := t.TempDir()
 	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(buildDir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(buildDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write artifact build.sh: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(buildDir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(buildDir, 0o755), "mkdir build dir")
+	requireNoError(t, os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(buildDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755), "write artifact build.sh")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(buildDir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
 	var built dockerBuildCall
 	cmd := newTestRootCmd(testRootDeps{
@@ -955,9 +851,7 @@ func TestRootBuildShorthandIgnoresBuildScriptInDockerArtifactDirectory(t *testin
 	})
 	cmd.SetArgs([]string{"build"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if built.Dir != projectRoot || built.Tag != "erunpaas/erun-devops:1.1.0" {
 		t.Fatalf("unexpected docker build request: %+v", built)
@@ -967,18 +861,10 @@ func TestRootBuildShorthandIgnoresBuildScriptInDockerArtifactDirectory(t *testin
 func TestRootBuildShorthandVerbosePrintsTraceBeforeExecuting(t *testing.T) {
 	projectRoot := t.TempDir()
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir build dir")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
 	stderr := new(bytes.Buffer)
 	cmd := newTestRootCmd(testRootDeps{
@@ -1002,9 +888,7 @@ func TestRootBuildShorthandVerbosePrintsTraceBeforeExecuting(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"-v", "build"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := stderr.String(); !strings.Contains(got, "docker build -t erunpaas/erun-devops:1.1.0") {
 		t.Fatalf("expected verbose build trace, got %q", got)
@@ -1017,18 +901,10 @@ func TestRootBuildShorthandVerbosePrintsTraceBeforeExecuting(t *testing.T) {
 func TestRootBuildShorthandDoubleVerbosePrintsBuildTraceBeforeExecuting(t *testing.T) {
 	projectRoot := t.TempDir()
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir build dir")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
 	stderr := new(bytes.Buffer)
 	cmd := newTestRootCmd(testRootDeps{
@@ -1052,9 +928,7 @@ func TestRootBuildShorthandDoubleVerbosePrintsBuildTraceBeforeExecuting(t *testi
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"-vv", "build"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	got := stderr.String()
 	if !strings.Contains(got, "docker build -t erunpaas/erun-devops:1.1.0") {
@@ -1094,9 +968,7 @@ func TestDevopsContainerPushUsesResolvedImageTag(t *testing.T) {
 
 	projectRoot := t.TempDir()
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir build dir")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "erun",
 		ProjectRoot:        projectRoot,
@@ -1104,15 +976,9 @@ func TestDevopsContainerPushUsesResolvedImageTag(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
 	var built dockerBuildCall
 	var received dockerPushCall
@@ -1141,9 +1007,7 @@ func TestDevopsContainerPushUsesResolvedImageTag(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"devops", "container", "push"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if built.Tag != "erunpaas/erun-devops:1.1.0" {
 		t.Fatalf("unexpected build tag: %+v", built)
@@ -1159,18 +1023,10 @@ func TestDevopsContainerPushUsesResolvedImageTag(t *testing.T) {
 func TestDevopsContainerPushPromptsLoginAndRetriesOnAuthError(t *testing.T) {
 	projectRoot := t.TempDir()
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir build dir")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
 	pushCalls := 0
 	loginRegistry := "unexpected"
@@ -1206,9 +1062,7 @@ func TestDevopsContainerPushPromptsLoginAndRetriesOnAuthError(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"devops", "container", "push"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if pushCalls != 2 {
 		t.Fatalf("expected push retry, got %d push calls", pushCalls)
@@ -1221,15 +1075,11 @@ func TestDevopsContainerPushPromptsLoginAndRetriesOnAuthError(t *testing.T) {
 func TestBuildCommandReleasePromptsLoginAndRetriesOnAuthError(t *testing.T) {
 	projectRoot := createReleaseGitRepo(t, "main")
 	remoteRoot := filepath.Join(t.TempDir(), "release-remote.git")
-	if err := os.MkdirAll(remoteRoot, 0o755); err != nil {
-		t.Fatalf("mkdir remote root: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(remoteRoot, 0o755), "mkdir remote root")
 	runGitCommand(t, remoteRoot, "init", "--bare")
 	runGitCommand(t, projectRoot, "remote", "add", "origin", remoteRoot)
 	runGitCommand(t, projectRoot, "push", "-u", "origin", "main")
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 	runGitCommand(t, projectRoot, "add", ".")
 	runGitCommand(t, projectRoot, "commit", "-m", "configure registry")
 	runGitCommand(t, projectRoot, "push", "origin", "main")
@@ -1270,9 +1120,7 @@ func TestBuildCommandReleasePromptsLoginAndRetriesOnAuthError(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"build", "--release"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if pushBuildCalls != 2 {
 		t.Fatalf("expected release build retry, got %d pushed build calls", pushBuildCalls)
@@ -1287,9 +1135,7 @@ func TestRootPushShorthandUsesResolvedImageTag(t *testing.T) {
 
 	projectRoot := t.TempDir()
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir build dir")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "erun",
 		ProjectRoot:        projectRoot,
@@ -1297,15 +1143,9 @@ func TestRootPushShorthandUsesResolvedImageTag(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
 	var built dockerBuildCall
 	var received dockerPushCall
@@ -1334,9 +1174,7 @@ func TestRootPushShorthandUsesResolvedImageTag(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"push"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if built.Tag != "erunpaas/erun-devops:1.1.0" {
 		t.Fatalf("unexpected build tag: %+v", built)
@@ -1354,9 +1192,7 @@ func TestRootPushShorthandBuildsAndPushesSameExactVersionFromCurrentBuildDirecto
 
 	projectRoot := t.TempDir()
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir build dir")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "erun",
 		ProjectRoot:        projectRoot,
@@ -1365,15 +1201,9 @@ func TestRootPushShorthandBuildsAndPushesSameExactVersionFromCurrentBuildDirecto
 		t.Fatalf("save tenant config: %v", err)
 	}
 
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
 	var built dockerBuildCall
 	var received dockerPushCall
@@ -1401,9 +1231,7 @@ func TestRootPushShorthandBuildsAndPushesSameExactVersionFromCurrentBuildDirecto
 	})
 	cmd.SetArgs([]string{"push"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if built.Tag != "erunpaas/erun-devops:1.1.0" {
 		t.Fatalf("unexpected build tag: %+v", built)
@@ -1517,9 +1345,7 @@ func TestRootBuildShorthandUsesSnapshotWhenVersionIsInheritedFromParentModule(t 
 
 	projectRoot := t.TempDir()
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir build dir")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "erun",
 		ProjectRoot:        projectRoot,
@@ -1527,12 +1353,8 @@ func TestRootBuildShorthandUsesSnapshotWhenVersionIsInheritedFromParentModule(t 
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
 
 	fixedNow := time.Date(2026, time.April, 6, 12, 34, 56, 0, time.UTC)
 	var received dockerBuildCall
@@ -1556,9 +1378,7 @@ func TestRootBuildShorthandUsesSnapshotWhenVersionIsInheritedFromParentModule(t 
 	})
 	cmd.SetArgs([]string{"build"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if received.Tag != "erunpaas/erun-devops:1.0.0-snapshot-20260406123456" {
 		t.Fatalf("unexpected image tag: %+v", received)
@@ -1570,9 +1390,7 @@ func TestRootPushShorthandDryRunPrintsCommandWithoutExecuting(t *testing.T) {
 
 	projectRoot := t.TempDir()
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir build dir")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "erun",
 		ProjectRoot:        projectRoot,
@@ -1580,15 +1398,9 @@ func TestRootPushShorthandDryRunPrintsCommandWithoutExecuting(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
 	stderr := new(bytes.Buffer)
 	cmd := newTestRootCmd(testRootDeps{
@@ -1613,9 +1425,7 @@ func TestRootPushShorthandDryRunPrintsCommandWithoutExecuting(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"push", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	got := stderr.String()
 	if !bytes.Contains([]byte(got), []byte("docker build -t erunpaas/erun-devops:1.1.0")) {
@@ -1653,18 +1463,10 @@ func TestDevopsContainerPushFailsWithoutDockerfile(t *testing.T) {
 func TestDevopsContainerPushReturnsOriginalAuthErrorWhenLoginCancelled(t *testing.T) {
 	projectRoot := t.TempDir()
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir build dir")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
 	expectedErr := common.DockerRegistryAuthError{
 		Tag:      "erunpaas/erun-devops:1.1.0",
@@ -1709,12 +1511,8 @@ func TestRootCommandTreatsBuildAsEnvironmentWhenDockerfileAbsent(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
 	projectRoot := filepath.Join(t.TempDir(), "tenant-a-build")
-	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
-		t.Fatalf("mkdir project root: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(projectRoot, 0o755), "mkdir project root")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -1722,9 +1520,7 @@ func TestRootCommandTreatsBuildAsEnvironmentWhenDockerfileAbsent(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "build", RepoPath: projectRoot, KubernetesContext: "cluster-build"}); err != nil {
-		t.Fatalf("save env config: %v", err)
-	}
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "build", RepoPath: projectRoot, KubernetesContext: "cluster-build"}), "save env config")
 
 	launched := common.ShellLaunchParams{}
 	cmd := newTestRootCmd(testRootDeps{
@@ -1742,9 +1538,7 @@ func TestRootCommandTreatsBuildAsEnvironmentWhenDockerfileAbsent(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"build"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if launched.Dir != projectRoot || launched.Title != "tenant-a-build" {
 		t.Fatalf("unexpected shell launch: %+v", launched)
@@ -1755,12 +1549,8 @@ func TestRootCommandTreatsPushAsEnvironmentWhenDockerfileAbsent(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
 	projectRoot := filepath.Join(t.TempDir(), "tenant-a-push")
-	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
-		t.Fatalf("mkdir project root: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(projectRoot, 0o755), "mkdir project root")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -1768,9 +1558,7 @@ func TestRootCommandTreatsPushAsEnvironmentWhenDockerfileAbsent(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "push", RepoPath: projectRoot, KubernetesContext: "cluster-push"}); err != nil {
-		t.Fatalf("save env config: %v", err)
-	}
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "push", RepoPath: projectRoot, KubernetesContext: "cluster-push"}), "save env config")
 
 	launched := common.ShellLaunchParams{}
 	cmd := newTestRootCmd(testRootDeps{
@@ -1788,9 +1576,7 @@ func TestRootCommandTreatsPushAsEnvironmentWhenDockerfileAbsent(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"push"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if launched.Dir != projectRoot || launched.Title != "tenant-a-push" {
 		t.Fatalf("unexpected shell launch: %+v", launched)
@@ -1855,18 +1641,10 @@ func TestRunContainerPushCommandPropagatesBuildContextErrors(t *testing.T) {
 func TestResolveDockerBuildTagPrefersCurrentDirectoryVersion(t *testing.T) {
 	projectRoot := t.TempDir()
 	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-ubuntu")
-	if err := os.MkdirAll(buildDir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("registry.example/team")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(buildDir, "VERSION"), []byte("noble-20260217\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(buildDir, 0o755), "mkdir build dir")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("registry.example/team")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(buildDir, "VERSION"), []byte("noble-20260217\n"), 0o644), "write local VERSION")
 
 	imageRef, err := func(buildDir string, target common.DockerCommandTarget) (common.DockerImageReference, error) {
 		return common.ResolveDockerImageReference(
@@ -1895,9 +1673,7 @@ func TestResolveDockerBuildTagUsesDefaultEnvironmentRegistry(t *testing.T) {
 
 	projectRoot := t.TempDir()
 	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-ubuntu")
-	if err := os.MkdirAll(buildDir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(buildDir, 0o755), "mkdir build dir")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "erun",
 		ProjectRoot:        projectRoot,
@@ -1913,12 +1689,8 @@ func TestResolveDockerBuildTagUsesDefaultEnvironmentRegistry(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save project config: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(buildDir, "VERSION"), []byte("noble-20260217\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(buildDir, "VERSION"), []byte("noble-20260217\n"), 0o644), "write local VERSION")
 
 	imageRef, err := func(buildDir string, target common.DockerCommandTarget) (common.DockerImageReference, error) {
 		return common.ResolveDockerImageReference(
@@ -1945,15 +1717,9 @@ func TestResolveDockerBuildTagUsesDefaultEnvironmentRegistry(t *testing.T) {
 func TestResolveDockerBuildTagUsesVersionOverrideInLocal(t *testing.T) {
 	projectRoot := t.TempDir()
 	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(buildDir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("registry.example/team")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(buildDir, 0o755), "mkdir build dir")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("registry.example/team")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
 
 	imageRef, err := common.ResolveDockerImageReference(
 		common.ConfigStore{},
@@ -1977,18 +1743,10 @@ func TestResolveDockerBuildTagUsesVersionOverrideInLocal(t *testing.T) {
 func TestResolveDockerBuildTagKeepsBuildDirVersionWhenOverrideIsSet(t *testing.T) {
 	projectRoot := t.TempDir()
 	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-ubuntu")
-	if err := os.MkdirAll(buildDir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("registry.example/team")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(buildDir, "VERSION"), []byte("noble-20260217\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(buildDir, 0o755), "mkdir build dir")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("registry.example/team")), "save project config")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(buildDir, "VERSION"), []byte("noble-20260217\n"), 0o644), "write local VERSION")
 
 	imageRef, err := common.ResolveDockerImageReference(
 		common.ConfigStore{},
@@ -2014,15 +1772,9 @@ func TestBuildCommandVersionOverrideAvoidsSnapshotTag(t *testing.T) {
 
 	projectRoot := t.TempDir()
 	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(buildDir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(buildDir, 0o755), "mkdir build dir")
+	requireNoError(t, os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write VERSION")
 
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
@@ -2042,9 +1794,7 @@ func TestBuildCommandVersionOverrideAvoidsSnapshotTag(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"build", "--dry-run", "--version", "1.0.0-pr.abc1234"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := stderr.String(); !strings.Contains(got, "erun-devops:1.0.0-pr.abc1234") || strings.Contains(got, "-snapshot-") {
 		t.Fatalf("unexpected dry-run output:\n%s", got)
@@ -2064,18 +1814,10 @@ func TestBuildCommandVersionOverrideDoesNotReplaceComponentLocalVersions(t *test
 			t.Fatalf("mkdir %s: %v", dir, err)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(devopsDir, "docker", "erun-devops", "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write devops Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(devopsDir, "docker", "erun-ubuntu", "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write ubuntu Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(devopsDir, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(devopsDir, "docker", "erun-ubuntu", "VERSION"), []byte("noble-20260217\n"), 0o644); err != nil {
-		t.Fatalf("write ubuntu VERSION: %v", err)
-	}
+	requireNoError(t, os.WriteFile(filepath.Join(devopsDir, "docker", "erun-devops", "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write devops Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(devopsDir, "docker", "erun-ubuntu", "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write ubuntu Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(devopsDir, "VERSION"), []byte("1.0.0\n"), 0o644), "write VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(devopsDir, "docker", "erun-ubuntu", "VERSION"), []byte("noble-20260217\n"), 0o644), "write ubuntu VERSION")
 
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
@@ -2095,9 +1837,7 @@ func TestBuildCommandVersionOverrideDoesNotReplaceComponentLocalVersions(t *test
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"build", "--dry-run", "--version", "1.0.0-pr.abc1234"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	if !strings.Contains(output, "erun-devops:1.0.0-pr.abc1234") {
@@ -2113,9 +1853,7 @@ func TestBuildCommandVersionOverrideDoesNotReplaceComponentLocalVersions(t *test
 
 func TestRootBuildCommandVersionOverrideBuildsWithoutPushing(t *testing.T) {
 	projectRoot, _, _, componentDirs, wantTags := setupMultiDockerProject(t, "tenant-a")
-	if err := os.Remove(filepath.Join(componentDirs[0], "VERSION")); err != nil {
-		t.Fatalf("remove runtime VERSION: %v", err)
-	}
+	requireNoError(t, os.Remove(filepath.Join(componentDirs[0], "VERSION")), "remove runtime VERSION")
 
 	var built []dockerBuildCall
 	cmd := newTestRootCmd(testRootDeps{
@@ -2139,9 +1877,7 @@ func TestRootBuildCommandVersionOverrideBuildsWithoutPushing(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"build", "--version", "1.0.7"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	gotTags := make([]string, 0, len(built))
 	for _, req := range built {
@@ -2163,18 +1899,10 @@ func TestRootBuildCommandDeployBuildsPushesAndDeploysOverriddenVersion(t *testin
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
 	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(buildDir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(buildDir, 0o755), "mkdir build dir")
+	requireNoError(t, os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write VERSION")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -2189,9 +1917,7 @@ func TestRootBuildCommandDeployBuildsPushesAndDeploysOverriddenVersion(t *testin
 	}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	var builds []dockerBuildCall
 	var pushes []dockerPushCall
@@ -2231,9 +1957,7 @@ func TestRootBuildCommandDeployBuildsPushesAndDeploysOverriddenVersion(t *testin
 	})
 	cmd.SetArgs([]string{"build", "--deploy", "--version", "1.0.7"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if len(builds) != 1 {
 		t.Fatalf("unexpected build requests: %+v", builds)
@@ -2260,15 +1984,9 @@ func TestBuildCommandHiddenEnvironmentOverrideUsesProvidedEnvironment(t *testing
 
 	projectRoot := t.TempDir()
 	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(buildDir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(buildDir, 0o755), "mkdir build dir")
+	requireNoError(t, os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -2303,9 +2021,7 @@ func TestBuildCommandHiddenEnvironmentOverrideUsesProvidedEnvironment(t *testing
 	})
 	cmd.SetArgs([]string{"build", "--environment", "prod", "--project-root", projectRoot})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if built.Tag != "prod-registry/erun-devops:1.0.0" {
 		t.Fatalf("unexpected build request: %+v", built)
@@ -2327,9 +2043,7 @@ func TestBuildCommandRejectsReleaseWithVersion(t *testing.T) {
 
 func TestBuildCommandDryRunReleaseShowsReleaseAndBuildVersionTrace(t *testing.T) {
 	projectRoot := createReleaseGitRepo(t, "develop")
-	if err := os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write build.sh: %v", err)
-	}
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "build.sh"), []byte("#!/bin/sh\n"), 0o755), "write build.sh")
 
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
@@ -2348,9 +2062,7 @@ func TestBuildCommandDryRunReleaseShowsReleaseAndBuildVersionTrace(t *testing.T)
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"build", "--dry-run", "--release"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	if !strings.Contains(output, "release: branch=develop mode=candidate version=1.4.2-rc.") {
@@ -2366,9 +2078,7 @@ func TestBuildCommandDryRunReleaseShowsReleaseAndBuildVersionTrace(t *testing.T)
 
 func TestBuildCommandDryRunReleaseShowsPushCommandsForReleaseTaggedDockerBuilds(t *testing.T) {
 	projectRoot := createReleaseGitRepo(t, "main")
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
@@ -2387,9 +2097,7 @@ func TestBuildCommandDryRunReleaseShowsPushCommandsForReleaseTaggedDockerBuilds(
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"build", "--dry-run", "--release"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	if !strings.Contains(output, "docker buildx inspect erun-multiarch") {
@@ -2423,9 +2131,7 @@ func TestBuildCommandDryRunReleaseForceIncludesTagDeletionForStaleReleaseTag(t *
 	runGitCommand(t, projectRoot, "push", "-u", "origin", "main")
 	runGitCommand(t, projectRoot, "tag", "-a", "v1.4.2", "-m", "Release 1.4.2")
 	runGitCommand(t, projectRoot, "push", "origin", "v1.4.2")
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "README.tmp"), []byte("change\n"), 0o644); err != nil {
-		t.Fatalf("write temp change: %v", err)
-	}
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "README.tmp"), []byte("change\n"), 0o644), "write temp change")
 	runGitCommand(t, projectRoot, "add", "erun-devops/README.tmp")
 	runGitCommand(t, projectRoot, "commit", "-m", "advance head")
 	runGitCommand(t, projectRoot, "push", "origin", "main")
@@ -2447,9 +2153,7 @@ func TestBuildCommandDryRunReleaseForceIncludesTagDeletionForStaleReleaseTag(t *
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"build", "--dry-run", "--release", "--force"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	for _, want := range []string{
@@ -2467,15 +2171,9 @@ func TestBuildCommandDryRunReleaseForceIncludesTagDeletionForStaleReleaseTag(t *
 func TestBuildCommandDryRunBuildsLinuxPackagesFromProjectRoot(t *testing.T) {
 	projectRoot := t.TempDir()
 	linuxComponentDir := filepath.Join(projectRoot, "erun-devops", "linux", "erun-cli")
-	if err := os.MkdirAll(linuxComponentDir, 0o755); err != nil {
-		t.Fatalf("mkdir linux component dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.2.3\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(linuxComponentDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write build.sh: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(linuxComponentDir, 0o755), "mkdir linux component dir")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.2.3\n"), 0o644), "write VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(linuxComponentDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755), "write build.sh")
 
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
@@ -2494,9 +2192,7 @@ func TestBuildCommandDryRunBuildsLinuxPackagesFromProjectRoot(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"build", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	if common.LinuxPackageBuildsSupported() {
@@ -2512,23 +2208,15 @@ func TestBuildCommandDryRunReleasePublishesLinuxPackagesWithoutDockerBuilds(t *t
 	projectRoot := t.TempDir()
 	releaseRoot := filepath.Join(projectRoot, "erun-devops")
 	linuxComponentDir := filepath.Join(releaseRoot, "linux", "erun-cli")
-	if err := os.MkdirAll(linuxComponentDir, 0o755); err != nil {
-		t.Fatalf("mkdir linux component dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(releaseRoot, "VERSION"), []byte("1.4.2\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(linuxComponentDir, "release.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write release.sh: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(linuxComponentDir, 0o755), "mkdir linux component dir")
+	requireNoError(t, os.WriteFile(filepath.Join(releaseRoot, "VERSION"), []byte("1.4.2\n"), 0o644), "write VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(linuxComponentDir, "release.sh"), []byte("#!/bin/sh\n"), 0o755), "write release.sh")
 	runGitCommand(t, projectRoot, "init", "-b", "develop")
 	runGitCommand(t, projectRoot, "config", "user.email", "codex@example.com")
 	runGitCommand(t, projectRoot, "config", "user.name", "Codex")
 	runGitCommand(t, projectRoot, "add", ".")
 	runGitCommand(t, projectRoot, "commit", "-m", "initial")
-	if err := common.SaveProjectConfig(projectRoot, common.ProjectConfig{}); err != nil {
-		t.Fatalf("SaveProjectConfig failed: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, common.ProjectConfig{}), "SaveProjectConfig failed")
 
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
@@ -2547,9 +2235,7 @@ func TestBuildCommandDryRunReleasePublishesLinuxPackagesWithoutDockerBuilds(t *t
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"build", "--dry-run", "--release"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	if !strings.Contains(output, "release: branch=develop mode=candidate version=1.4.2-rc.") {

--- a/erun-cli/cmd/cloud.go
+++ b/erun-cli/cmd/cloud.go
@@ -93,38 +93,36 @@ func promptAWSInitParams(promptRunner PromptRunner, params common.InitAWSCloudPr
 	if strings.TrimSpace(params.Profile) != "" {
 		return params, nil
 	}
+	return promptMissingAWSInitParams(promptRunner, params)
+}
+
+func promptMissingAWSInitParams(promptRunner PromptRunner, params common.InitAWSCloudProviderParams) (common.InitAWSCloudProviderParams, error) {
 	var err error
-	if strings.TrimSpace(params.SSOStartURL) == "" {
-		params.SSOStartURL, err = requiredCloudPrompt(promptRunner, "AWS SSO start URL", "")
-		if err != nil {
-			return params, err
-		}
+	params.SSOStartURL, err = promptCloudValueIfEmpty(promptRunner, params.SSOStartURL, "AWS SSO start URL", "")
+	if err != nil {
+		return params, err
 	}
-	if strings.TrimSpace(params.SSORegion) == "" {
-		params.SSORegion, err = requiredCloudPrompt(promptRunner, "AWS SSO region", "")
-		if err != nil {
-			return params, err
-		}
+	params.SSORegion, err = promptCloudValueIfEmpty(promptRunner, params.SSORegion, "AWS SSO region", "")
+	if err != nil {
+		return params, err
 	}
-	if strings.TrimSpace(params.AccountID) == "" {
-		params.AccountID, err = requiredCloudPrompt(promptRunner, "AWS account ID", "")
-		if err != nil {
-			return params, err
-		}
+	params.AccountID, err = promptCloudValueIfEmpty(promptRunner, params.AccountID, "AWS account ID", "")
+	if err != nil {
+		return params, err
 	}
-	if strings.TrimSpace(params.RoleName) == "" {
-		params.RoleName, err = requiredCloudPrompt(promptRunner, "AWS role name", "")
-		if err != nil {
-			return params, err
-		}
+	params.RoleName, err = promptCloudValueIfEmpty(promptRunner, params.RoleName, "AWS role name", "")
+	if err != nil {
+		return params, err
 	}
-	if strings.TrimSpace(params.Region) == "" {
-		params.Region, err = requiredCloudPrompt(promptRunner, "Default AWS region", strings.TrimSpace(params.SSORegion))
-		if err != nil {
-			return params, err
-		}
+	params.Region, err = promptCloudValueIfEmpty(promptRunner, params.Region, "Default AWS region", strings.TrimSpace(params.SSORegion))
+	return params, err
+}
+
+func promptCloudValueIfEmpty(promptRunner PromptRunner, value, label, defaultValue string) (string, error) {
+	if strings.TrimSpace(value) != "" {
+		return value, nil
 	}
-	return params, nil
+	return requiredCloudPrompt(promptRunner, label, defaultValue)
 }
 
 func requiredCloudPrompt(promptRunner PromptRunner, label, defaultValue string) (string, error) {

--- a/erun-cli/cmd/delete_test.go
+++ b/erun-cli/cmd/delete_test.go
@@ -14,12 +14,8 @@ import (
 func TestDeleteCommandDeletesRemoteNamespaceAndConfigAfterConfirmation(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", DefaultEnvironment: "dev"}); err != nil {
-		t.Fatalf("SaveTenantConfig failed: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "dev", KubernetesContext: "cluster-dev", Remote: true}); err != nil {
-		t.Fatalf("SaveEnvConfig failed: %v", err)
-	}
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", DefaultEnvironment: "dev"}), "SaveTenantConfig failed")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "dev", KubernetesContext: "cluster-dev", Remote: true}), "SaveEnvConfig failed")
 
 	var deletedContext string
 	var deletedNamespace string
@@ -41,9 +37,7 @@ func TestDeleteCommandDeletesRemoteNamespaceAndConfigAfterConfirmation(t *testin
 	cmd.SetErr(new(bytes.Buffer))
 	cmd.SetArgs([]string{"delete", "tenant-a", "dev"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if deletedContext != "cluster-dev" || deletedNamespace != "tenant-a-dev" {
 		t.Fatalf("unexpected namespace delete: context=%q namespace=%q", deletedContext, deletedNamespace)
 	}
@@ -58,12 +52,8 @@ func TestDeleteCommandDeletesRemoteNamespaceAndConfigAfterConfirmation(t *testin
 func TestDeleteCommandDeletesConfigWhenNamespaceDeleteFails(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", DefaultEnvironment: "dev"}); err != nil {
-		t.Fatalf("SaveTenantConfig failed: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "dev", KubernetesContext: "cluster-dev", Remote: true}); err != nil {
-		t.Fatalf("SaveEnvConfig failed: %v", err)
-	}
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", DefaultEnvironment: "dev"}), "SaveTenantConfig failed")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "dev", KubernetesContext: "cluster-dev", Remote: true}), "SaveEnvConfig failed")
 
 	stderr := new(bytes.Buffer)
 	cmd := newTestRootCmd(testRootDeps{
@@ -78,9 +68,7 @@ func TestDeleteCommandDeletesConfigWhenNamespaceDeleteFails(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"delete", "tenant-a", "dev"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if _, _, err := common.LoadEnvConfig("tenant-a", "dev"); !errors.Is(err, common.ErrNotInitialized) {
 		t.Fatalf("expected env config to be deleted, got %v", err)
 	}
@@ -92,12 +80,8 @@ func TestDeleteCommandDeletesConfigWhenNamespaceDeleteFails(t *testing.T) {
 func TestDeleteCommandRejectsMismatchedConfirmation(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", DefaultEnvironment: "dev"}); err != nil {
-		t.Fatalf("SaveTenantConfig failed: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "dev", KubernetesContext: "cluster-dev", Remote: true}); err != nil {
-		t.Fatalf("SaveEnvConfig failed: %v", err)
-	}
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", DefaultEnvironment: "dev"}), "SaveTenantConfig failed")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "dev", KubernetesContext: "cluster-dev", Remote: true}), "SaveEnvConfig failed")
 
 	deletedNamespace := false
 	cmd := newTestRootCmd(testRootDeps{
@@ -128,12 +112,8 @@ func TestDeleteCommandRejectsMismatchedConfirmation(t *testing.T) {
 func TestDeleteCommandDryRunSkipsPromptAndDeletion(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", DefaultEnvironment: "dev"}); err != nil {
-		t.Fatalf("SaveTenantConfig failed: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "dev", KubernetesContext: "cluster-dev", Remote: true}); err != nil {
-		t.Fatalf("SaveEnvConfig failed: %v", err)
-	}
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", DefaultEnvironment: "dev"}), "SaveTenantConfig failed")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "dev", KubernetesContext: "cluster-dev", Remote: true}), "SaveEnvConfig failed")
 
 	stderr := new(bytes.Buffer)
 	cmd := newTestRootCmd(testRootDeps{
@@ -150,9 +130,7 @@ func TestDeleteCommandDryRunSkipsPromptAndDeletion(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"delete", "tenant-a", "dev", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if _, _, err := common.LoadEnvConfig("tenant-a", "dev"); err != nil {
 		t.Fatalf("expected env config to remain during dry-run, got %v", err)
 	}

--- a/erun-cli/cmd/deploy_test.go
+++ b/erun-cli/cmd/deploy_test.go
@@ -164,20 +164,16 @@ func TestDevopsK8sDeployBuildsAndDeploysSameExactVersionFromCurrentBuildDirector
 	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
 	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
-	if err := common.SaveTenantConfig(common.TenantConfig{
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
 		DefaultEnvironment: "local",
-	}); err != nil {
-		t.Fatalf("save tenant config: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{
+	}), "save tenant config")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{
 		Name:              "local",
 		RepoPath:          projectRoot,
 		KubernetesContext: "cluster-local",
-	}); err != nil {
-		t.Fatalf("save env config: %v", err)
-	}
+	}), "save env config")
 	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	var built deployBuildCall
@@ -211,34 +207,7 @@ func TestDevopsK8sDeployBuildsAndDeploysSameExactVersionFromCurrentBuildDirector
 
 	requireNoError(t, cmd.Execute(), "Execute failed")
 
-	if received.ReleaseName != "erun-devops" {
-		t.Fatalf("unexpected release name: %+v", received)
-	}
-	if received.ChartPath != chartPath {
-		t.Fatalf("unexpected chart path: %+v", received)
-	}
-	if received.ValuesFilePath != filepath.Join(chartPath, "values.local.yaml") {
-		t.Fatalf("unexpected values file path: %+v", received)
-	}
-	if received.Tenant != "tenant-a" || received.Environment != "local" {
-		t.Fatalf("unexpected tenant/environment: %+v", received)
-	}
-	if received.Namespace != "tenant-a-local" {
-		t.Fatalf("unexpected namespace: %+v", received)
-	}
-	if received.KubernetesContext != "cluster-local" {
-		t.Fatalf("unexpected kubernetes context: %+v", received)
-	}
-	resolvedProjectRoot, err := filepath.EvalSymlinks(projectRoot)
-	if err != nil {
-		t.Fatalf("EvalSymlinks(projectRoot) failed: %v", err)
-	}
-	if received.WorktreeHostPath != resolvedProjectRoot {
-		t.Fatalf("unexpected worktree values: %+v", received)
-	}
-	if received.Timeout != common.DefaultHelmDeploymentTimeout {
-		t.Fatalf("unexpected timeout: %+v", received)
-	}
+	requireLocalDevopsDeployRequest(t, received, chartPath, projectRoot)
 	if built.Tag != "erunpaas/erun-devops:1.1.0" {
 		t.Fatalf("unexpected build request: %+v", built)
 	}
@@ -256,6 +225,27 @@ func TestDevopsK8sDeployBuildsAndDeploysSameExactVersionFromCurrentBuildDirector
 	}
 }
 
+func requireLocalDevopsDeployRequest(t *testing.T, received common.HelmDeployParams, chartPath, projectRoot string) {
+	t.Helper()
+	if received.ReleaseName != "erun-devops" || received.ChartPath != chartPath {
+		t.Fatalf("unexpected deploy request: %+v", received)
+	}
+	if received.ValuesFilePath != filepath.Join(chartPath, "values.local.yaml") {
+		t.Fatalf("unexpected values file path: %+v", received)
+	}
+	if received.Tenant != "tenant-a" || received.Environment != "local" {
+		t.Fatalf("unexpected tenant/environment: %+v", received)
+	}
+	if received.Namespace != "tenant-a-local" || received.KubernetesContext != "cluster-local" {
+		t.Fatalf("unexpected deployment target: %+v", received)
+	}
+	resolvedProjectRoot, err := filepath.EvalSymlinks(projectRoot)
+	requireNoError(t, err, "EvalSymlinks(projectRoot) failed")
+	if received.WorktreeHostPath != resolvedProjectRoot || received.Timeout != common.DefaultHelmDeploymentTimeout {
+		t.Fatalf("unexpected deploy request values: %+v", received)
+	}
+}
+
 func TestRootDeployShorthandUsesCurrentComponentContext(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
@@ -267,20 +257,16 @@ func TestRootDeployShorthandUsesCurrentComponentContext(t *testing.T) {
 	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
 	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
-	if err := common.SaveTenantConfig(common.TenantConfig{
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
 		DefaultEnvironment: "local",
-	}); err != nil {
-		t.Fatalf("save tenant config: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{
+	}), "save tenant config")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{
 		Name:              "local",
 		RepoPath:          projectRoot,
 		KubernetesContext: "cluster-local",
-	}); err != nil {
-		t.Fatalf("save env config: %v", err)
-	}
+	}), "save env config")
 	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	fixedNow := time.Date(2026, time.April, 6, 13, 16, 30, 0, time.UTC)
@@ -352,47 +338,33 @@ func TestRootDeployShorthandAtProjectRootDeploysAllComponents(t *testing.T) {
 	chartA := filepath.Join(moduleRoot, "k8s", "tenant-a-devops")
 	chartB := filepath.Join(moduleRoot, "k8s", "erun-dind")
 	for _, chartPath := range []string{chartA, chartB} {
-		if err := os.MkdirAll(chartPath, 0o755); err != nil {
-			t.Fatalf("mkdir chart dir: %v", err)
-		}
+		requireMkdirAll(t, chartPath, 0o755, "mkdir chart dir")
 		componentName := filepath.Base(chartPath)
-		if err := os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: "+componentName+"\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644); err != nil {
-			t.Fatalf("write Chart.yaml: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644); err != nil {
-			t.Fatalf("write values.local.yaml: %v", err)
-		}
+		requireWriteFile(t, filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: "+componentName+"\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644, "write Chart.yaml")
+		requireWriteFile(t, filepath.Join(chartPath, "values.local.yaml"), nil, 0o644, "write values.local.yaml")
 	}
 
 	componentA := filepath.Join(moduleRoot, "docker", "tenant-a-devops")
 	componentB := filepath.Join(moduleRoot, "docker", "erun-dind")
 	for _, componentDir := range []string{componentA, componentB} {
-		if err := os.MkdirAll(componentDir, 0o755); err != nil {
-			t.Fatalf("mkdir docker dir: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-			t.Fatalf("write Dockerfile: %v", err)
-		}
+		requireMkdirAll(t, componentDir, 0o755, "mkdir docker dir")
+		requireWriteFile(t, filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644, "write Dockerfile")
 	}
 	requireNoError(t, os.WriteFile(filepath.Join(moduleRoot, "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
 	requireNoError(t, os.WriteFile(filepath.Join(componentA, "VERSION"), []byte("1.1.0\n"), 0o644), "write component A VERSION")
 	requireNoError(t, os.WriteFile(filepath.Join(componentB, "VERSION"), []byte("28.1.1\n"), 0o644), "write component B VERSION")
 
 	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
-	if err := common.SaveTenantConfig(common.TenantConfig{
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
 		DefaultEnvironment: "local",
-	}); err != nil {
-		t.Fatalf("save tenant config: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{
+	}), "save tenant config")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{
 		Name:              "local",
 		RepoPath:          projectRoot,
 		KubernetesContext: "cluster-local",
-	}); err != nil {
-		t.Fatalf("save env config: %v", err)
-	}
+	}), "save env config")
 	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	var builds []deployBuildCall
@@ -425,9 +397,20 @@ func TestRootDeployShorthandAtProjectRootDeploysAllComponents(t *testing.T) {
 
 	requireNoError(t, cmd.Execute(), "Execute failed")
 
+	requireProjectRootDeployAllComponents(t, builds, pushes, deploys, chartA, chartB)
+}
+
+func requireProjectRootDeployAllComponents(t *testing.T, builds []deployBuildCall, pushes []deployPushCall, deploys []common.HelmDeployParams, chartA, chartB string) {
+	t.Helper()
 	if len(builds) != 2 || len(pushes) != 0 || len(deploys) != 2 {
 		t.Fatalf("unexpected execution counts: builds=%+v pushes=%+v deploys=%+v", builds, pushes, deploys)
 	}
+	requireProjectRootBuilds(t, builds)
+	requireProjectRootDeploys(t, deploys, chartA, chartB)
+}
+
+func requireProjectRootBuilds(t *testing.T, builds []deployBuildCall) {
+	t.Helper()
 	if builds[0].Tag != "erunpaas/erun-dind:28.1.1" || builds[1].Tag != "erunpaas/tenant-a-devops:1.1.0" {
 		t.Fatalf("unexpected builds: %+v", builds)
 	}
@@ -436,6 +419,10 @@ func TestRootDeployShorthandAtProjectRootDeploysAllComponents(t *testing.T) {
 			t.Fatalf("expected multi-platform buildx push request, got %+v", build)
 		}
 	}
+}
+
+func requireProjectRootDeploys(t *testing.T, deploys []common.HelmDeployParams, chartA, chartB string) {
+	t.Helper()
 	if deploys[0].ReleaseName != "erun-dind" || deploys[0].ChartPath != chartB {
 		t.Fatalf("unexpected first deploy: %+v", deploys[0])
 	}

--- a/erun-cli/cmd/deploy_test.go
+++ b/erun-cli/cmd/deploy_test.go
@@ -85,9 +85,7 @@ func TestDeployHelpShowsTenantAndEnvironmentFlags(t *testing.T) {
 	cmd.SetErr(new(bytes.Buffer))
 	cmd.SetArgs([]string{"deploy", "--help"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stdout.String()
 	for _, want := range []string{
@@ -123,15 +121,9 @@ func TestNewRootCmdRegistersDeployShorthandWhenKubernetesDeployContextPresent(t 
 func TestNewRootCmdRegistersDeployShorthandAtProjectRootWhenDevopsK8sScopePresent(t *testing.T) {
 	projectRoot := t.TempDir()
 	moduleRoot := filepath.Join(projectRoot, "tenant-a-devops", "k8s", "tenant-a-devops")
-	if err := os.MkdirAll(moduleRoot, 0o755); err != nil {
-		t.Fatalf("mkdir chart dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(moduleRoot, "Chart.yaml"), []byte("apiVersion: v2\nname: tenant-a-devops\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write Chart.yaml: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(moduleRoot, "values.local.yaml"), nil, 0o644); err != nil {
-		t.Fatalf("write values.local.yaml: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(moduleRoot, 0o755), "mkdir chart dir")
+	requireNoError(t, os.WriteFile(filepath.Join(moduleRoot, "Chart.yaml"), []byte("apiVersion: v2\nname: tenant-a-devops\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644), "write Chart.yaml")
+	requireNoError(t, os.WriteFile(filepath.Join(moduleRoot, "values.local.yaml"), nil, 0o644), "write values.local.yaml")
 
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
@@ -166,22 +158,12 @@ func TestDevopsK8sDeployBuildsAndDeploysSameExactVersionFromCurrentBuildDirector
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -196,9 +178,7 @@ func TestDevopsK8sDeployBuildsAndDeploysSameExactVersionFromCurrentBuildDirector
 	}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	var built deployBuildCall
 	var pushed deployPushCall
@@ -229,9 +209,7 @@ func TestDevopsK8sDeployBuildsAndDeploysSameExactVersionFromCurrentBuildDirector
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"devops", "k8s", "deploy", "erun-devops"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if received.ReleaseName != "erun-devops" {
 		t.Fatalf("unexpected release name: %+v", received)
@@ -284,19 +262,11 @@ func TestRootDeployShorthandUsesCurrentComponentContext(t *testing.T) {
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -311,9 +281,7 @@ func TestRootDeployShorthandUsesCurrentComponentContext(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	fixedNow := time.Date(2026, time.April, 6, 13, 16, 30, 0, time.UTC)
 	var built deployBuildCall
@@ -357,9 +325,7 @@ func TestRootDeployShorthandUsesCurrentComponentContext(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"deploy"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if built.Tag != "erunpaas/erun-devops:1.1.0" {
 		t.Fatalf("unexpected build request: %+v", built)
@@ -408,19 +374,11 @@ func TestRootDeployShorthandAtProjectRootDeploysAllComponents(t *testing.T) {
 			t.Fatalf("write Dockerfile: %v", err)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(moduleRoot, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentA, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write component A VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentB, "VERSION"), []byte("28.1.1\n"), 0o644); err != nil {
-		t.Fatalf("write component B VERSION: %v", err)
-	}
+	requireNoError(t, os.WriteFile(filepath.Join(moduleRoot, "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(componentA, "VERSION"), []byte("1.1.0\n"), 0o644), "write component A VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(componentB, "VERSION"), []byte("28.1.1\n"), 0o644), "write component B VERSION")
 
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -435,9 +393,7 @@ func TestRootDeployShorthandAtProjectRootDeploysAllComponents(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	var builds []deployBuildCall
 	var pushes []deployPushCall
@@ -467,9 +423,7 @@ func TestRootDeployShorthandAtProjectRootDeploysAllComponents(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"deploy"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if len(builds) != 2 || len(pushes) != 0 || len(deploys) != 2 {
 		t.Fatalf("unexpected execution counts: builds=%+v pushes=%+v deploys=%+v", builds, pushes, deploys)
@@ -495,22 +449,12 @@ func TestDeployCommandHiddenTargetOverrideUsesProvidedTenantEnvironment(t *testi
 
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
-	if err := os.WriteFile(filepath.Join(chartPath, "values.dev.yaml"), []byte("image:\n  repository: erunpaas/erun-devops\n  tag: latest\n"), 0o644); err != nil {
-		t.Fatalf("write values.dev.yaml: %v", err)
-	}
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "values.dev.yaml"), []byte("image:\n  repository: erunpaas/erun-devops\n  tag: latest\n"), 0o644), "write values.dev.yaml")
 	componentDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(componentDir, 0o755); err != nil {
-		t.Fatalf("mkdir docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(componentDir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write VERSION")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -561,9 +505,7 @@ func TestDeployCommandHiddenTargetOverrideUsesProvidedTenantEnvironment(t *testi
 	})
 	cmd.SetArgs([]string{"deploy", "--tenant", "tenant-a", "--environment", "dev", "--repo-path", projectRoot})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if deployed.Namespace != "tenant-a-dev" || deployed.KubernetesContext != "cluster-dev" {
 		t.Fatalf("unexpected deploy target: %+v", deployed)
@@ -582,18 +524,10 @@ func TestDeployCommandVersionOverrideUsesProvidedVersion(t *testing.T) {
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
 	componentDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(componentDir, 0o755); err != nil {
-		t.Fatalf("mkdir docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(componentDir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write VERSION")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -608,9 +542,7 @@ func TestDeployCommandVersionOverrideUsesProvidedVersion(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	var deployed common.HelmDeployParams
 	cmd := newTestRootCmd(testRootDeps{
@@ -645,9 +577,7 @@ func TestDeployCommandVersionOverrideUsesProvidedVersion(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"deploy", "--version", "1.0.7"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if deployed.Version != "1.0.7" {
 		t.Fatalf("unexpected deploy version: %+v", deployed)
@@ -660,21 +590,11 @@ func TestDeployCommandAcceptsTenantAndEnvironmentArgsWithVersionOverride(t *test
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
 	componentDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(componentDir, 0o755); err != nil {
-		t.Fatalf("mkdir docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(chartPath, "values.proxmox1.yaml"), nil, 0o644); err != nil {
-		t.Fatalf("write values.proxmox1.yaml: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(componentDir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "values.proxmox1.yaml"), nil, 0o644), "write values.proxmox1.yaml")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write VERSION")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -689,9 +609,7 @@ func TestDeployCommandAcceptsTenantAndEnvironmentArgsWithVersionOverride(t *test
 	}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	var deployed common.HelmDeployParams
 	cmd := newTestRootCmd(testRootDeps{
@@ -726,9 +644,7 @@ func TestDeployCommandAcceptsTenantAndEnvironmentArgsWithVersionOverride(t *test
 	})
 	cmd.SetArgs([]string{"deploy", "tenant-a", "proxmox1", "--version", "1.0.48"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if deployed.Tenant != "tenant-a" || deployed.Environment != "proxmox1" {
 		t.Fatalf("unexpected deploy target: %+v", deployed)
@@ -745,18 +661,10 @@ func TestDeployCommandUsesConfiguredKubernetesContextForLocalEnvironment(t *test
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
 	componentDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(componentDir, 0o755); err != nil {
-		t.Fatalf("mkdir docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(componentDir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write VERSION")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -771,9 +679,7 @@ func TestDeployCommandUsesConfiguredKubernetesContextForLocalEnvironment(t *test
 	}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	var deployed common.HelmDeployParams
 	cmd := newTestRootCmd(testRootDeps{
@@ -808,9 +714,7 @@ func TestDeployCommandUsesConfiguredKubernetesContextForLocalEnvironment(t *test
 	})
 	cmd.SetArgs([]string{"deploy", "--version", "1.0.7"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if deployed.KubernetesContext != "cluster-local" {
 		t.Fatalf("expected deploy to keep configured kubernetes context, got %+v", deployed)
@@ -824,18 +728,10 @@ func TestDeployCommandEnsuresNamespaceBeforeDeploy(t *testing.T) {
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
 	componentDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(componentDir, 0o755); err != nil {
-		t.Fatalf("mkdir docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(componentDir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(componentDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write VERSION")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -850,9 +746,7 @@ func TestDeployCommandEnsuresNamespaceBeforeDeploy(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	ensuredContext := ""
 	ensuredNamespace := ""
@@ -897,9 +791,7 @@ func TestDeployCommandEnsuresNamespaceBeforeDeploy(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"deploy", "--version", "1.0.7"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if ensuredContext != "cluster-local" || ensuredNamespace != "tenant-a-local" {
 		t.Fatalf("unexpected namespace ensure request: context=%q namespace=%q", ensuredContext, ensuredNamespace)
@@ -916,19 +808,11 @@ func TestRootDeployShorthandDryRunPrintsBuildAndDeployCommandsWithoutExecuting(t
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -943,9 +827,7 @@ func TestRootDeployShorthandDryRunPrintsBuildAndDeployCommandsWithoutExecuting(t
 	}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	stderr := new(bytes.Buffer)
 	cmd := newTestRootCmd(testRootDeps{
@@ -984,9 +866,7 @@ func TestRootDeployShorthandDryRunPrintsBuildAndDeployCommandsWithoutExecuting(t
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"deploy", "--dry-run", "-v"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	if !strings.Contains(output, "docker buildx build --builder erun-multiarch") {
@@ -1013,22 +893,12 @@ func TestRootDeployShorthandUsesPersistedSnapshotPreferenceForLocalEnvironment(t
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
 
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	snapshot := false
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
@@ -1045,9 +915,7 @@ func TestRootDeployShorthandUsesPersistedSnapshotPreferenceForLocalEnvironment(t
 	}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	stderr := new(bytes.Buffer)
 	cmd := newTestRootCmd(testRootDeps{
@@ -1083,9 +951,7 @@ func TestRootDeployShorthandUsesPersistedSnapshotPreferenceForLocalEnvironment(t
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"deploy", "--dry-run", "-v"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	if strings.Contains(output, "docker build -t") || strings.Contains(output, "docker push ") {
@@ -1102,41 +968,21 @@ func TestRootDeployShorthandBuildsAndPushesLiteralChartImageDependencies(t *test
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
 	templatePath := filepath.Join(chartPath, "templates", "deployment.yaml")
-	if err := os.MkdirAll(filepath.Dir(templatePath), 0o755); err != nil {
-		t.Fatalf("mkdir templates dir: %v", err)
-	}
-	if err := os.WriteFile(templatePath, []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: erun-devops\nspec:\n  template:\n    spec:\n      containers:\n        - image: erunpaas/erun-dind:28.1.1-dind\n          name: dind\n"), 0o644); err != nil {
-		t.Fatalf("write deployment template: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(filepath.Dir(templatePath), 0o755), "mkdir templates dir")
+	requireNoError(t, os.WriteFile(templatePath, []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: erun-devops\nspec:\n  template:\n    spec:\n      containers:\n        - image: erunpaas/erun-dind:28.1.1-dind\n          name: dind\n"), 0o644), "write deployment template")
 
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write main Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write main VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write main Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write main VERSION")
 
 	dindDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-dind")
-	if err := os.MkdirAll(dindDir, 0o755); err != nil {
-		t.Fatalf("mkdir dind dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dindDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write dind Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dindDir, "VERSION"), []byte("28.1.1-dind\n"), 0o644); err != nil {
-		t.Fatalf("write dind VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(dindDir, 0o755), "mkdir dind dir")
+	requireNoError(t, os.WriteFile(filepath.Join(dindDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write dind Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(dindDir, "VERSION"), []byte("28.1.1-dind\n"), 0o644), "write dind VERSION")
 
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -1151,9 +997,7 @@ func TestRootDeployShorthandBuildsAndPushesLiteralChartImageDependencies(t *test
 	}); err != nil {
 		t.Fatalf("save env config: %v", err)
 	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	var builds []deployBuildCall
 	var pushes []deployPushCall
@@ -1191,9 +1035,7 @@ func TestRootDeployShorthandBuildsAndPushesLiteralChartImageDependencies(t *test
 	})
 	cmd.SetArgs([]string{"deploy"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if len(builds) != 2 {
 		t.Fatalf("expected 2 builds, got %+v", builds)
@@ -1218,12 +1060,8 @@ func TestRootCommandTreatsDeployAsEnvironmentWhenDeployContextAbsent(t *testing.
 	setupRootCmdTestConfigHome(t)
 
 	projectRoot := filepath.Join(t.TempDir(), "tenant-a-deploy")
-	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
-		t.Fatalf("mkdir project root: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(projectRoot, 0o755), "mkdir project root")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -1261,9 +1099,7 @@ func TestRootCommandTreatsDeployAsEnvironmentWhenDeployContextAbsent(t *testing.
 	})
 	cmd.SetArgs([]string{"deploy"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if launched.Dir != projectRoot || launched.Title != "tenant-a-deploy" {
 		t.Fatalf("unexpected shell launch: %+v", launched)
@@ -1274,14 +1110,8 @@ func createHelmChartFixture(t *testing.T, projectRoot, componentName string) str
 	t.Helper()
 
 	chartPath := filepath.Join(projectRoot, "erun-devops", "k8s", componentName)
-	if err := os.MkdirAll(chartPath, 0o755); err != nil {
-		t.Fatalf("mkdir chart dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: "+componentName+"\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write Chart.yaml: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644); err != nil {
-		t.Fatalf("write values.local.yaml: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(chartPath, 0o755), "mkdir chart dir")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: "+componentName+"\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644), "write Chart.yaml")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644), "write values.local.yaml")
 	return chartPath
 }

--- a/erun-cli/cmd/doctor.go
+++ b/erun-cli/cmd/doctor.go
@@ -56,7 +56,6 @@ func runDoctorCommand(ctx common.Context, resolveOpen func(common.OpenParams) (c
 	if _, err := fmt.Fprintf(ctx.Stdout, "Target: %s/%s\n", result.Tenant, result.Environment); err != nil {
 		return err
 	}
-
 	repairedJetBrains, err := runSelectedJetBrainsGatewayRepair(ctx, promptRunner, result, options)
 	if err != nil {
 		return err
@@ -64,7 +63,10 @@ func runDoctorCommand(ctx common.Context, resolveOpen func(common.OpenParams) (c
 	if repairedJetBrains && doctorOnlySelectedJetBrainsGatewayRepair(options) {
 		return nil
 	}
+	return runDoctorCleanupActions(ctx, promptRunner, result, options)
+}
 
+func runDoctorCleanupActions(ctx common.Context, promptRunner PromptRunner, result common.OpenResult, options doctorOptions) error {
 	req := common.ShellLaunchParamsFromResult(result)
 	inspection, err := common.RunDoctorInspection(ctx, nil, req)
 	if err != nil {
@@ -81,31 +83,34 @@ func runDoctorCommand(ctx common.Context, resolveOpen func(common.OpenParams) (c
 		return err
 	}
 	if len(actions) == 0 {
-		if ctx.DryRun {
-			_, err := fmt.Fprintln(ctx.Stdout, "No cleanup actions selected.")
-			return err
-		}
-		if _, err := fmt.Fprintln(ctx.Stdout, "No cleanup actions selected."); err != nil {
-			return err
-		}
-		return nil
+		return writeNoDoctorActionsSelected(ctx)
 	}
 
 	for _, action := range actions {
-		if _, err := fmt.Fprintf(ctx.Stdout, "Running: %s\n", common.DoctorActionDescription(action)); err != nil {
+		if err := runSelectedDoctorAction(ctx, req, action); err != nil {
 			return err
-		}
-		output, err := common.RunDoctorAction(ctx, nil, req, action)
-		if err != nil {
-			return err
-		}
-		if !ctx.DryRun {
-			if err := writeDoctorCommandOutput(ctx, output.Stdout, output.Stderr); err != nil {
-				return err
-			}
 		}
 	}
 	return nil
+}
+
+func writeNoDoctorActionsSelected(ctx common.Context) error {
+	_, err := fmt.Fprintln(ctx.Stdout, "No cleanup actions selected.")
+	return err
+}
+
+func runSelectedDoctorAction(ctx common.Context, req common.ShellLaunchParams, action common.DoctorAction) error {
+	if _, err := fmt.Fprintf(ctx.Stdout, "Running: %s\n", common.DoctorActionDescription(action)); err != nil {
+		return err
+	}
+	output, err := common.RunDoctorAction(ctx, nil, req, action)
+	if err != nil {
+		return err
+	}
+	if ctx.DryRun {
+		return nil
+	}
+	return writeDoctorCommandOutput(ctx, output.Stdout, output.Stderr)
 }
 
 func runSelectedJetBrainsGatewayRepair(ctx common.Context, promptRunner PromptRunner, result common.OpenResult, options doctorOptions) (bool, error) {
@@ -121,17 +126,27 @@ func runSelectedJetBrainsGatewayRepair(ctx common.Context, promptRunner PromptRu
 		return false, nil
 	}
 
-	selected := options.repairJetBrainsGateway
-	if !selected && promptRunner != nil && !ctx.DryRun {
-		ok, err := confirmPrompt(promptRunner, fmt.Sprintf("Clear cached JetBrains Gateway backend metadata for %s/%s?", result.Tenant, result.Environment))
-		if err != nil {
-			return false, err
-		}
-		selected = ok
+	selected, err := shouldRepairJetBrainsGateway(ctx, promptRunner, result, options)
+	if err != nil {
+		return false, err
 	}
 	if !selected {
 		return false, nil
 	}
+	return runJetBrainsGatewayRepair(ctx, repair)
+}
+
+func shouldRepairJetBrainsGateway(ctx common.Context, promptRunner PromptRunner, result common.OpenResult, options doctorOptions) (bool, error) {
+	if options.repairJetBrainsGateway {
+		return true, nil
+	}
+	if promptRunner == nil || ctx.DryRun {
+		return false, nil
+	}
+	return confirmPrompt(promptRunner, fmt.Sprintf("Clear cached JetBrains Gateway backend metadata for %s/%s?", result.Tenant, result.Environment))
+}
+
+func runJetBrainsGatewayRepair(ctx common.Context, repair jetBrainsGatewayDoctorRepair) (bool, error) {
 	if _, err := fmt.Fprintf(ctx.Stdout, "Running: Clear cached JetBrains Gateway backend metadata\n"); err != nil {
 		return false, err
 	}

--- a/erun-cli/cmd/doctor_test.go
+++ b/erun-cli/cmd/doctor_test.go
@@ -17,18 +17,10 @@ func TestDoctorCommandPromptsAndRunsSelectedCleanup(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
 	projectRoot := filepath.Join(t.TempDir(), "project")
-	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
-		t.Fatalf("mkdir project root: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("SaveERunConfig failed: %v", err)
-	}
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: projectRoot, DefaultEnvironment: "local"}); err != nil {
-		t.Fatalf("SaveTenantConfig failed: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "local", RepoPath: projectRoot, KubernetesContext: "cluster-local"}); err != nil {
-		t.Fatalf("SaveEnvConfig failed: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(projectRoot, 0o755), "mkdir project root")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "SaveERunConfig failed")
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: projectRoot, DefaultEnvironment: "local"}), "SaveTenantConfig failed")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "local", RepoPath: projectRoot, KubernetesContext: "cluster-local"}), "SaveEnvConfig failed")
 
 	kubectlDir := t.TempDir()
 	kubectlPath := filepath.Join(kubectlDir, "kubectl")
@@ -58,9 +50,7 @@ fi
 echo "unexpected kubectl invocation: $@" >&2
 exit 1
 `
-	if err := os.WriteFile(kubectlPath, []byte(kubectlScript), 0o755); err != nil {
-		t.Fatalf("write kubectl stub: %v", err)
-	}
+	requireNoError(t, os.WriteFile(kubectlPath, []byte(kubectlScript), 0o755), "write kubectl stub")
 	t.Setenv("PATH", kubectlDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	prompts := make([]string, 0, 3)
@@ -80,9 +70,7 @@ exit 1
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"doctor"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stdout.String()
 	for _, want := range []string{
@@ -104,18 +92,10 @@ func TestDoctorCommandDryRunShowsDindTraceForSelectedAction(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
 	projectRoot := filepath.Join(t.TempDir(), "petios")
-	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
-		t.Fatalf("mkdir project root: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("SaveERunConfig failed: %v", err)
-	}
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: projectRoot, DefaultEnvironment: "local"}); err != nil {
-		t.Fatalf("SaveTenantConfig failed: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "local", RepoPath: projectRoot, KubernetesContext: "cluster-local"}); err != nil {
-		t.Fatalf("SaveEnvConfig failed: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(projectRoot, 0o755), "mkdir project root")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "SaveERunConfig failed")
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: projectRoot, DefaultEnvironment: "local"}), "SaveTenantConfig failed")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "local", RepoPath: projectRoot, KubernetesContext: "cluster-local"}), "SaveEnvConfig failed")
 	stubKubectlContexts(t, []string{"rancher-desktop"}, "rancher-desktop")
 
 	cmd := newTestRootCmd(testRootDeps{})
@@ -125,9 +105,7 @@ func TestDoctorCommandDryRunShowsDindTraceForSelectedAction(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"doctor", "--dry-run", "--prune-images"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	for _, want := range []string{
@@ -152,15 +130,9 @@ func TestDoctorCommandRepairsJetBrainsGatewayMetadata(t *testing.T) {
 	})
 
 	projectRoot := filepath.Join(t.TempDir(), "petios")
-	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
-		t.Fatalf("mkdir project root: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "petios"}); err != nil {
-		t.Fatalf("SaveERunConfig failed: %v", err)
-	}
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "petios", ProjectRoot: projectRoot, DefaultEnvironment: "rihards"}); err != nil {
-		t.Fatalf("SaveTenantConfig failed: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(projectRoot, 0o755), "mkdir project root")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "petios"}), "SaveERunConfig failed")
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "petios", ProjectRoot: projectRoot, DefaultEnvironment: "rihards"}), "SaveTenantConfig failed")
 	if err := common.SaveEnvConfig("petios", common.EnvConfig{
 		Name:              "rihards",
 		RepoPath:          projectRoot,
@@ -175,9 +147,7 @@ func TestDoctorCommandRepairsJetBrainsGatewayMetadata(t *testing.T) {
 
 	root := t.TempDir()
 	optionsDir := filepath.Join(root, "JetBrains", "IntelliJIdea2025.3", "options")
-	if err := os.MkdirAll(optionsDir, 0o700); err != nil {
-		t.Fatalf("mkdir options dir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(optionsDir, 0o700), "mkdir options dir")
 	configID := jetbrainsconfig.StableConfigID("erun-petios-rihards")
 	recentPath := filepath.Join(optionsDir, "sshRecentConnections.v2.xml")
 	if err := os.WriteFile(recentPath, []byte(`<application>
@@ -226,9 +196,7 @@ func TestDoctorCommandRepairsJetBrainsGatewayMetadata(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"doctor", "petios", "rihards", "--repair-jetbrains-gateway"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stdout.String()
 	for _, want := range []string{

--- a/erun-cli/cmd/exec_test.go
+++ b/erun-cli/cmd/exec_test.go
@@ -34,9 +34,7 @@ func TestExecDiffPrintsRawGitDiff(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"exec", "diff"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if stdout.String() != "diff --git a/a.txt b/a.txt\n" {
 		t.Fatalf("unexpected stdout: %q", stdout.String())
 	}
@@ -72,9 +70,7 @@ func TestExecRawRunsCommandFromProjectRootWithDefaultTrace(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"exec", "raw", "echo", "--token", "secret-value", "done"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if gotDir != "/tmp/project" || gotName != "echo" || strings.Join(gotArgs, " ") != "--token secret-value done" {
 		t.Fatalf("unexpected raw command call: dir=%q name=%q args=%+v", gotDir, gotName, gotArgs)

--- a/erun-cli/cmd/feedback_render_test.go
+++ b/erun-cli/cmd/feedback_render_test.go
@@ -25,9 +25,7 @@ func TestCommandContextEnablesTraceDuringDryRunWithoutVerboseFlag(t *testing.T) 
 	addDryRunFlag(cmd)
 	stderr := new(bytes.Buffer)
 	cmd.SetErr(stderr)
-	if err := cmd.Flags().Set("dry-run", "true"); err != nil {
-		t.Fatalf("set dry-run: %v", err)
-	}
+	requireNoError(t, cmd.Flags().Set("dry-run", "true"), "set dry-run")
 
 	ctx := commandContext(cmd)
 	ctx.TraceCommand("", "docker", "build", "-t", "example/image:1.0.0", ".")
@@ -45,9 +43,7 @@ func TestRootCommandAuditsOnlyWhenTraceEnabled(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs(nil)
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if got := stderr.String(); got != "" {
 		t.Fatalf("expected no audit without trace, got %q", got)
 	}
@@ -59,9 +55,7 @@ func TestRootCommandAuditsOnlyWhenTraceEnabled(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"-v"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if got := stderr.String(); got != "audit: erun\n" {
 		t.Fatalf("unexpected audit output: %q", got)
 	}
@@ -83,9 +77,7 @@ func TestExecCommandEnablesTraceByDefault(t *testing.T) {
 	root.SetErr(stderr)
 	root.SetArgs([]string{"exec", "noop"})
 
-	if err := root.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, root.Execute(), "Execute failed")
 	got := stderr.String()
 	if !bytes.Contains([]byte(got), []byte("audit: erun exec noop")) || !bytes.Contains([]byte(got), []byte("exec trace")) {
 		t.Fatalf("expected exec trace by default, got %q", got)

--- a/erun-cli/cmd/helm_recovery_test.go
+++ b/erun-cli/cmd/helm_recovery_test.go
@@ -16,16 +16,7 @@ func TestHelmDeployRecoveryClearsPendingMetadataAndRetries(t *testing.T) {
 	var recovered common.HelmReleaseRecoveryParams
 
 	deploy := wrapHelmDeployWithReleaseRecovery(
-		func(prompt promptui.Prompt) (string, error) {
-			if !prompt.IsConfirm {
-				t.Fatalf("expected confirm prompt, got %+v", prompt)
-			}
-			want := "clear pending Helm metadata for release erun-devops from namespace erun-local in context rancher-desktop and retry deploy"
-			if prompt.Label != want {
-				t.Fatalf("unexpected prompt label %q, want %q", prompt.Label, want)
-			}
-			return "y", nil
-		},
+		confirmHelmRecoveryPrompt(t),
 		func(params common.HelmDeployParams) error {
 			deployCalls++
 			if deployCalls == 1 {
@@ -45,15 +36,12 @@ func TestHelmDeployRecoveryClearsPendingMetadataAndRetries(t *testing.T) {
 		},
 	)
 
-	err := deploy(common.HelmDeployParams{
+	requireNoError(t, deploy(common.HelmDeployParams{
 		ReleaseName:       "erun-devops",
 		Namespace:         "erun-local",
 		KubernetesContext: "rancher-desktop",
 		Stderr:            stderr,
-	})
-	if err != nil {
-		t.Fatalf("deploy failed: %v", err)
-	}
+	}), "deploy failed")
 	if deployCalls != 2 {
 		t.Fatalf("expected deploy to retry once, got %d calls", deployCalls)
 	}
@@ -68,5 +56,19 @@ func TestHelmDeployRecoveryClearsPendingMetadataAndRetries(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "owner=helm,name=erun-devops,status in (pending-install,pending-upgrade,pending-rollback)") {
 		t.Fatalf("expected pending metadata selector in stderr, got %q", stderr.String())
+	}
+}
+
+func confirmHelmRecoveryPrompt(t *testing.T) PromptRunner {
+	t.Helper()
+	return func(prompt promptui.Prompt) (string, error) {
+		if !prompt.IsConfirm {
+			t.Fatalf("expected confirm prompt, got %+v", prompt)
+		}
+		want := "clear pending Helm metadata for release erun-devops from namespace erun-local in context rancher-desktop and retry deploy"
+		if prompt.Label != want {
+			t.Fatalf("unexpected prompt label %q, want %q", prompt.Label, want)
+		}
+		return "y", nil
 	}
 }

--- a/erun-cli/cmd/idle.go
+++ b/erun-cli/cmd/idle.go
@@ -55,27 +55,34 @@ func writeIdleStatus(ctx common.Context, status common.EnvironmentIdleStatus) er
 	if err := writeLabeledValue(ctx, "stop eligible", enabledDisabledLabel(status.StopEligible)); err != nil {
 		return err
 	}
-	if strings.TrimSpace(status.StopBlockedReason) != "" {
-		if err := writeLabeledValue(ctx, "stop blocked", status.StopBlockedReason); err != nil {
-			return err
-		}
+	if err := writeOptionalIdleValue(ctx, "stop blocked", status.StopBlockedReason); err != nil {
+		return err
 	}
-	if strings.TrimSpace(status.StopError) != "" {
-		if err := writeLabeledValue(ctx, "stop error", status.StopError); err != nil {
-			return err
-		}
+	if err := writeOptionalIdleValue(ctx, "stop error", status.StopError); err != nil {
+		return err
 	}
 	for _, marker := range status.Markers {
-		value := "active"
-		if marker.Idle {
-			value = "idle"
-		}
-		if marker.SecondsRemaining > 0 {
-			value += fmt.Sprintf(" (%ds)", marker.SecondsRemaining)
-		}
-		if err := writeLabeledValue(ctx, marker.Name, value); err != nil {
+		if err := writeLabeledValue(ctx, marker.Name, idleMarkerValue(marker)); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func writeOptionalIdleValue(ctx common.Context, label, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return writeLabeledValue(ctx, label, value)
+}
+
+func idleMarkerValue(marker common.EnvironmentIdleMarker) string {
+	value := "active"
+	if marker.Idle {
+		value = "idle"
+	}
+	if marker.SecondsRemaining > 0 {
+		value += fmt.Sprintf(" (%ds)", marker.SecondsRemaining)
+	}
+	return value
 }

--- a/erun-cli/cmd/init.go
+++ b/erun-cli/cmd/init.go
@@ -27,24 +27,9 @@ func newInitCmd(runInit func(common.Context, common.BootstrapInitParams) error) 
 		Args:         cobra.MaximumNArgs(2),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runParams := params
-			if runParams.Tenant == "" && len(args) > 0 {
-				runParams.Tenant = args[0]
-			}
-			if runParams.Environment == "" && len(args) > 1 {
-				runParams.Environment = args[1]
-			}
-			if runParams.Remote && runParams.Tenant == "" {
-				return fmt.Errorf("tenant is required with --remote")
-			}
-			if runParams.Remote && strings.TrimSpace(runParams.Environment) == "" {
-				return fmt.Errorf("environment is required with --remote")
-			}
-			if cmd.Flags().Changed("set-default-tenant") {
-				runParams.ConfirmTenant = &setDefaultTenant
-			}
-			if cmd.Flags().Changed("confirm-environment") {
-				runParams.ConfirmEnvironment = &confirmEnvironment
+			runParams, err := initRunParams(cmd, args, params, setDefaultTenant, confirmEnvironment)
+			if err != nil {
+				return err
 			}
 			return runInit(commandContext(cmd), runParams)
 		},
@@ -66,6 +51,36 @@ func newInitCmd(runInit func(common.Context, common.BootstrapInitParams) error) 
 	cmd.Flags().BoolVarP(&params.AutoApprove, "yes", "y", false, "Automatically approve initialization prompts")
 	addDryRunFlag(cmd)
 	return cmd
+}
+
+func initRunParams(cmd *cobra.Command, args []string, params common.BootstrapInitParams, setDefaultTenant, confirmEnvironment bool) (common.BootstrapInitParams, error) {
+	runParams := params
+	if runParams.Tenant == "" && len(args) > 0 {
+		runParams.Tenant = args[0]
+	}
+	if runParams.Environment == "" && len(args) > 1 {
+		runParams.Environment = args[1]
+	}
+	if err := validateInitRunParams(runParams); err != nil {
+		return common.BootstrapInitParams{}, err
+	}
+	if cmd.Flags().Changed("set-default-tenant") {
+		runParams.ConfirmTenant = &setDefaultTenant
+	}
+	if cmd.Flags().Changed("confirm-environment") {
+		runParams.ConfirmEnvironment = &confirmEnvironment
+	}
+	return runParams, nil
+}
+
+func validateInitRunParams(params common.BootstrapInitParams) error {
+	if params.Remote && params.Tenant == "" {
+		return fmt.Errorf("tenant is required with --remote")
+	}
+	if params.Remote && strings.TrimSpace(params.Environment) == "" {
+		return fmt.Errorf("environment is required with --remote")
+	}
+	return nil
 }
 
 func containerRegistryPrompt(run PromptRunner, label string) (string, error) {

--- a/erun-cli/cmd/init_test.go
+++ b/erun-cli/cmd/init_test.go
@@ -178,9 +178,7 @@ func TestInitCommandDryRunDoesNotPersistConfiguration(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"init", "--dry-run", "-v"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if namespaceEnsured {
 		t.Fatal("did not expect namespace creation during dry-run")
@@ -224,9 +222,7 @@ func TestInitCommandDryRunPrintsConcretePlannedActions(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"init", "--dry-run", "-v"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	rootConfigPath, err := xdg.ConfigFile(filepath.Join("erun", "config.yaml"))
 	if err != nil {
@@ -282,9 +278,7 @@ exit 1
 	}
 	t.Setenv("PATH", kubectlDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	if err := ensureKubernetesNamespace("cluster-local", "tenant-a-local"); err != nil {
-		t.Fatalf("ensureKubernetesNamespace failed: %v", err)
-	}
+	requireNoError(t, ensureKubernetesNamespace("cluster-local", "tenant-a-local"), "ensureKubernetesNamespace failed")
 }
 
 func TestEnsureKubernetesNamespaceCreatesWhenNamespaceMissing(t *testing.T) {
@@ -306,9 +300,7 @@ exit 1
 	}
 	t.Setenv("PATH", kubectlDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	if err := ensureKubernetesNamespace("cluster-local", "tenant-a-local"); err != nil {
-		t.Fatalf("ensureKubernetesNamespace failed: %v", err)
-	}
+	requireNoError(t, ensureKubernetesNamespace("cluster-local", "tenant-a-local"), "ensureKubernetesNamespace failed")
 }
 
 func TestInitCommandRemoteRequiresEnvironment(t *testing.T) {
@@ -331,9 +323,7 @@ func TestInitCommandMapsPositionalTenantAndEnvironmentArgs(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"erun", "rtest"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if got.Tenant != "erun" || got.Environment != "rtest" {
 		t.Fatalf("unexpected init params: %+v", got)
 	}
@@ -350,9 +340,7 @@ func TestInitCommandHelpShowsPositionalTenantAndEnvironment(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"--help"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stdout.String() + stderr.String()
 	if !strings.Contains(output, "Usage:\n  init [TENANT] [ENVIRONMENT] [flags]") {
@@ -368,9 +356,7 @@ func TestInitCommandAcceptsRuntimeVersionOverride(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"erun", "local", "--version", "1.0.19-snapshot-20260418141901", "--runtime-image", "erun-devops", "--no-git", "--bootstrap"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if got.RuntimeVersion != "1.0.19-snapshot-20260418141901" || got.RuntimeImage != "erun-devops" || !got.NoGit || !got.Bootstrap {
 		t.Fatalf("unexpected init params: %+v", got)
 	}
@@ -384,9 +370,7 @@ func TestInitCommandAcceptsDefaultSelectionOverrides(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"erun", "local", "--set-default-tenant=false", "--confirm-environment=true"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if got.ConfirmTenant == nil || *got.ConfirmTenant {
 		t.Fatalf("unexpected tenant confirmation: %+v", got.ConfirmTenant)
 	}

--- a/erun-cli/cmd/list.go
+++ b/erun-cli/cmd/list.go
@@ -44,39 +44,46 @@ func writeListResult(ctx common.Context, result common.ListResult) error {
 }
 
 func writeListHeaderSections(ctx common.Context, result common.ListResult) error {
+	if err := writeListConfigurationSection(ctx, result.ConfigDirectory); err != nil {
+		return err
+	}
+	if err := writeListDefaultsSection(ctx, result.Defaults); err != nil {
+		return err
+	}
+	return writeListCurrentDirectorySection(ctx, result.CurrentDirectory)
+}
+
+func writeListConfigurationSection(ctx common.Context, configDirectory string) error {
 	if _, err := fmt.Fprintln(ctx.Stdout, "Configuration:"); err != nil {
 		return err
 	}
-	if err := writeLabeledValue(ctx, "directory", valueOrNone(result.ConfigDirectory)); err != nil {
-		return err
-	}
+	return writeLabeledValue(ctx, "directory", valueOrNone(configDirectory))
+}
 
+func writeListDefaultsSection(ctx common.Context, defaults common.ListDefaultsResult) error {
 	if _, err := fmt.Fprintln(ctx.Stdout, "Defaults:"); err != nil {
 		return err
 	}
-	if err := writeLabeledValue(ctx, "tenant", valueOrNone(result.Defaults.Tenant)); err != nil {
+	if err := writeLabeledValue(ctx, "tenant", valueOrNone(defaults.Tenant)); err != nil {
 		return err
 	}
-	if err := writeLabeledValue(ctx, "environment", valueOrNone(result.Defaults.Environment)); err != nil {
-		return err
-	}
+	return writeLabeledValue(ctx, "environment", valueOrNone(defaults.Environment))
+}
 
+func writeListCurrentDirectorySection(ctx common.Context, current common.ListCurrentDirectoryResult) error {
 	if _, err := fmt.Fprintln(ctx.Stdout, "Current Directory:"); err != nil {
 		return err
 	}
-	if err := writeLabeledValue(ctx, "path", valueOrNone(result.CurrentDirectory.Path)); err != nil {
+	if err := writeLabeledValue(ctx, "path", valueOrNone(current.Path)); err != nil {
 		return err
 	}
-	if err := writeLabeledValue(ctx, "repo", valueOrNone(result.CurrentDirectory.Repo)); err != nil {
+	if err := writeLabeledValue(ctx, "repo", valueOrNone(current.Repo)); err != nil {
 		return err
 	}
-	if err := writeLabeledValue(ctx, "configured tenant", configuredCurrentTenantOrNone(result.CurrentDirectory.ConfiguredTenant)); err != nil {
+	if err := writeLabeledValue(ctx, "configured tenant", configuredCurrentTenantOrNone(current.ConfiguredTenant)); err != nil {
 		return err
 	}
-	if err := writeEffectiveOpen(ctx, result.CurrentDirectory); err != nil {
-		return err
-	}
-	return nil
+	return writeEffectiveOpen(ctx, current)
 }
 
 func writeListTenants(ctx common.Context, tenants []common.ListTenantResult) error {
@@ -152,18 +159,7 @@ func writeEffectiveOpenSSH(ctx common.Context, ssh common.ListSSHResult) error {
 }
 
 func writeTenantEntry(ctx common.Context, tenant common.ListTenantResult) error {
-	header := "  " + tenant.Name
-	tenantMarkers := make([]string, 0, 2)
-	if tenant.IsDefault {
-		tenantMarkers = append(tenantMarkers, "default")
-	}
-	if tenant.IsEffective {
-		tenantMarkers = append(tenantMarkers, "effective")
-	}
-	if len(tenantMarkers) > 0 {
-		header += " [" + strings.Join(tenantMarkers, ", ") + "]"
-	}
-	if _, err := fmt.Fprintln(ctx.Stdout, header); err != nil {
+	if _, err := fmt.Fprintln(ctx.Stdout, tenantHeaderLine(tenant)); err != nil {
 		return err
 	}
 	if err := writeIndentedValue(ctx, 4, "default environment", tenant.DefaultEnvironment); err != nil {
@@ -178,38 +174,64 @@ func writeTenantEntry(ctx common.Context, tenant common.ListTenantResult) error 
 		return err
 	}
 	for _, env := range tenant.Environments {
-		envLine := "      - " + env.Name
-		envMarkers := make([]string, 0, 2)
-		if env.IsDefault {
-			envMarkers = append(envMarkers, "default")
-		}
-		if env.IsEffective {
-			envMarkers = append(envMarkers, "effective")
-		}
-		if len(envMarkers) > 0 {
-			envLine += " [" + strings.Join(envMarkers, ", ") + "]"
-		}
-		envLine += " context=" + quotedValueOrNone(env.KubernetesContext)
-		if strings.TrimSpace(env.CloudProviderAlias) != "" {
-			envLine += " cloud=" + quotedValueOrNone(env.CloudProviderAlias)
-		}
-		envLine += " snapshot=" + enabledDisabledLabel(env.Snapshot)
-		envLine += " repo=" + quotedValueOrNone(env.RepoPath)
-		envLine += " ports=" + portRangeLabel(env.LocalPorts)
-		envLine += " mcp-port=" + fmt.Sprintf("%d", env.LocalPorts.MCP)
-		envLine += " ssh-port=" + fmt.Sprintf("%d", env.LocalPorts.SSH)
-		if env.SSH.Enabled {
-			envLine += " ssh=on"
-			envLine += " host=" + quotedValueOrNone(env.SSH.HostAlias)
-			envLine += " user=" + quotedValueOrNone(env.SSH.User)
-			envLine += " local-port=" + fmt.Sprintf("%d", env.SSH.LocalPort)
-			envLine += " workspace=" + quotedValueOrNone(env.SSH.WorkspacePath)
-		}
-		if _, err := fmt.Fprintln(ctx.Stdout, envLine); err != nil {
+		if _, err := fmt.Fprintln(ctx.Stdout, environmentLine(env)); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func tenantHeaderLine(tenant common.ListTenantResult) string {
+	header := "  " + tenant.Name
+	if markers := statusMarkers(tenant.IsDefault, tenant.IsEffective); len(markers) > 0 {
+		header += " [" + strings.Join(markers, ", ") + "]"
+	}
+	return header
+}
+
+func environmentLine(env common.ListEnvironmentResult) string {
+	envLine := "      - " + env.Name
+	if markers := statusMarkers(env.IsDefault, env.IsEffective); len(markers) > 0 {
+		envLine += " [" + strings.Join(markers, ", ") + "]"
+	}
+	envLine += " context=" + quotedValueOrNone(env.KubernetesContext)
+	if strings.TrimSpace(env.CloudProviderAlias) != "" {
+		envLine += " cloud=" + quotedValueOrNone(env.CloudProviderAlias)
+	}
+	envLine += environmentBaseFields(env)
+	if env.SSH.Enabled {
+		envLine += environmentSSHFields(env.SSH)
+	}
+	return envLine
+}
+
+func statusMarkers(isDefault, isEffective bool) []string {
+	markers := make([]string, 0, 2)
+	if isDefault {
+		markers = append(markers, "default")
+	}
+	if isEffective {
+		markers = append(markers, "effective")
+	}
+	return markers
+}
+
+func environmentBaseFields(env common.ListEnvironmentResult) string {
+	line := " snapshot=" + enabledDisabledLabel(env.Snapshot)
+	line += " repo=" + quotedValueOrNone(env.RepoPath)
+	line += " ports=" + portRangeLabel(env.LocalPorts)
+	line += " mcp-port=" + fmt.Sprintf("%d", env.LocalPorts.MCP)
+	line += " ssh-port=" + fmt.Sprintf("%d", env.LocalPorts.SSH)
+	return line
+}
+
+func environmentSSHFields(ssh common.ListSSHResult) string {
+	line := " ssh=on"
+	line += " host=" + quotedValueOrNone(ssh.HostAlias)
+	line += " user=" + quotedValueOrNone(ssh.User)
+	line += " local-port=" + fmt.Sprintf("%d", ssh.LocalPort)
+	line += " workspace=" + quotedValueOrNone(ssh.WorkspacePath)
+	return line
 }
 
 func writeCloudProviders(ctx common.Context, providers []common.CloudProviderStatus) error {

--- a/erun-cli/cmd/list.go
+++ b/erun-cli/cmd/list.go
@@ -34,6 +34,16 @@ func runListCommand(ctx common.Context, store common.ListStore, findProjectRoot 
 }
 
 func writeListResult(ctx common.Context, result common.ListResult) error {
+	if err := writeListHeaderSections(ctx, result); err != nil {
+		return err
+	}
+	if err := writeCloudProviders(ctx, result.CloudProviders); err != nil {
+		return err
+	}
+	return writeListTenants(ctx, result.Tenants)
+}
+
+func writeListHeaderSections(ctx common.Context, result common.ListResult) error {
 	if _, err := fmt.Fprintln(ctx.Stdout, "Configuration:"); err != nil {
 		return err
 	}
@@ -66,20 +76,19 @@ func writeListResult(ctx common.Context, result common.ListResult) error {
 	if err := writeEffectiveOpen(ctx, result.CurrentDirectory); err != nil {
 		return err
 	}
+	return nil
+}
 
-	if err := writeCloudProviders(ctx, result.CloudProviders); err != nil {
-		return err
-	}
-
+func writeListTenants(ctx common.Context, tenants []common.ListTenantResult) error {
 	if _, err := fmt.Fprintln(ctx.Stdout, "Tenants:"); err != nil {
 		return err
 	}
-	if len(result.Tenants) == 0 {
+	if len(tenants) == 0 {
 		_, err := fmt.Fprintln(ctx.Stdout, "  none")
 		return err
 	}
 
-	for _, tenant := range result.Tenants {
+	for _, tenant := range tenants {
 		if err := writeTenantEntry(ctx, tenant); err != nil {
 			return err
 		}
@@ -94,44 +103,52 @@ func writeEffectiveOpen(ctx common.Context, current common.ListCurrentDirectoryR
 		}
 		return writeLabeledValue(ctx, "effective target", "none")
 	}
-	if err := writeLabeledValue(ctx, "effective target", current.Effective.Tenant+"/"+current.Effective.Environment); err != nil {
-		return err
-	}
-	if err := writeLabeledValue(ctx, "kubernetes context", current.Effective.KubernetesContext); err != nil {
-		return err
-	}
-	if strings.TrimSpace(current.Effective.CloudProviderAlias) != "" {
-		if err := writeLabeledValue(ctx, "cloud provider", current.Effective.CloudProviderAlias); err != nil {
-			return err
-		}
-	}
-	if err := writeLabeledValue(ctx, "snapshot", enabledDisabledLabel(current.Effective.Snapshot)); err != nil {
-		return err
-	}
-	if err := writeLabeledValue(ctx, "assigned local port range", portRangeLabel(current.Effective.LocalPorts)); err != nil {
-		return err
-	}
-	if err := writeLabeledValue(ctx, "assigned mcp local port", fmt.Sprintf("%d (when MCP is running or forwarded)", current.Effective.LocalPorts.MCP)); err != nil {
-		return err
-	}
-	if err := writeLabeledValue(ctx, "assigned ssh local port", fmt.Sprintf("%d (when SSH port-forward is active)", current.Effective.LocalPorts.SSH)); err != nil {
+	if err := writeEffectiveOpenBase(ctx, *current.Effective); err != nil {
 		return err
 	}
 	if current.Effective.SSH.Enabled {
-		if err := writeLabeledValue(ctx, "sshd", "on"); err != nil {
-			return err
-		}
-		if err := writeLabeledValue(ctx, "ssh host", current.Effective.SSH.HostAlias); err != nil {
-			return err
-		}
-		if err := writeLabeledValue(ctx, "ssh user", current.Effective.SSH.User); err != nil {
-			return err
-		}
-		if err := writeLabeledValue(ctx, "ssh workspace", current.Effective.SSH.WorkspacePath); err != nil {
+		if err := writeEffectiveOpenSSH(ctx, current.Effective.SSH); err != nil {
 			return err
 		}
 	}
 	return writeLabeledValue(ctx, "repo path", current.Effective.RepoPath)
+}
+
+func writeEffectiveOpenBase(ctx common.Context, effective common.ListEffectiveTargetResult) error {
+	if err := writeLabeledValue(ctx, "effective target", effective.Tenant+"/"+effective.Environment); err != nil {
+		return err
+	}
+	if err := writeLabeledValue(ctx, "kubernetes context", effective.KubernetesContext); err != nil {
+		return err
+	}
+	if strings.TrimSpace(effective.CloudProviderAlias) != "" {
+		if err := writeLabeledValue(ctx, "cloud provider", effective.CloudProviderAlias); err != nil {
+			return err
+		}
+	}
+	if err := writeLabeledValue(ctx, "snapshot", enabledDisabledLabel(effective.Snapshot)); err != nil {
+		return err
+	}
+	if err := writeLabeledValue(ctx, "assigned local port range", portRangeLabel(effective.LocalPorts)); err != nil {
+		return err
+	}
+	if err := writeLabeledValue(ctx, "assigned mcp local port", fmt.Sprintf("%d (when MCP is running or forwarded)", effective.LocalPorts.MCP)); err != nil {
+		return err
+	}
+	return writeLabeledValue(ctx, "assigned ssh local port", fmt.Sprintf("%d (when SSH port-forward is active)", effective.LocalPorts.SSH))
+}
+
+func writeEffectiveOpenSSH(ctx common.Context, ssh common.ListSSHResult) error {
+	if err := writeLabeledValue(ctx, "sshd", "on"); err != nil {
+		return err
+	}
+	if err := writeLabeledValue(ctx, "ssh host", ssh.HostAlias); err != nil {
+		return err
+	}
+	if err := writeLabeledValue(ctx, "ssh user", ssh.User); err != nil {
+		return err
+	}
+	return writeLabeledValue(ctx, "ssh workspace", ssh.WorkspacePath)
 }
 
 func writeTenantEntry(ctx common.Context, tenant common.ListTenantResult) error {

--- a/erun-cli/cmd/list_test.go
+++ b/erun-cli/cmd/list_test.go
@@ -26,40 +26,22 @@ func TestListCommandPrintsDefaultsAndConfiguredTenants(t *testing.T) {
 		}
 	}
 
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: tenantAPath, DefaultEnvironment: "local"}); err != nil {
-		t.Fatalf("save tenant-a config: %v", err)
-	}
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-b", ProjectRoot: tenantBPath, DefaultEnvironment: "dev"}); err != nil {
-		t.Fatalf("save tenant-b config: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "local", RepoPath: tenantAPath, KubernetesContext: "cluster-local"}); err != nil {
-		t.Fatalf("save tenant-a local env: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "prod", RepoPath: tenantAPath, KubernetesContext: "cluster-prod"}); err != nil {
-		t.Fatalf("save tenant-a prod env: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-b", common.EnvConfig{Name: "dev", RepoPath: tenantBPath, KubernetesContext: "cluster-b"}); err != nil {
-		t.Fatalf("save tenant-b dev env: %v", err)
-	}
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: tenantAPath, DefaultEnvironment: "local"}), "save tenant-a config")
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "tenant-b", ProjectRoot: tenantBPath, DefaultEnvironment: "dev"}), "save tenant-b config")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "local", RepoPath: tenantAPath, KubernetesContext: "cluster-local"}), "save tenant-a local env")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "prod", RepoPath: tenantAPath, KubernetesContext: "cluster-prod"}), "save tenant-a prod env")
+	requireNoError(t, common.SaveEnvConfig("tenant-b", common.EnvConfig{Name: "dev", RepoPath: tenantBPath, KubernetesContext: "cluster-b"}), "save tenant-b dev env")
 
 	repoRoot := filepath.Join(t.TempDir(), "frs")
-	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
-		t.Fatalf("mkdir .git: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755), "mkdir .git")
 	subDir := filepath.Join(repoRoot, "nested")
-	if err := os.MkdirAll(subDir, 0o755); err != nil {
-		t.Fatalf("mkdir nested: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(subDir, 0o755), "mkdir nested")
 	prevWD, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	if err := os.Chdir(subDir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	requireNoError(t, os.Chdir(subDir), "chdir")
 	t.Cleanup(func() {
 		_ = os.Chdir(prevWD)
 	})
@@ -70,9 +52,7 @@ func TestListCommandPrintsDefaultsAndConfiguredTenants(t *testing.T) {
 	cmd.SetErr(new(bytes.Buffer))
 	cmd.SetArgs([]string{"list"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stdout.String()
 	for _, want := range []string{
@@ -122,36 +102,20 @@ func TestListCommandUsesConfiguredCurrentDirectoryTenantBeforeDefault(t *testing
 		}
 	}
 
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: tenantAPath, DefaultEnvironment: "local"}); err != nil {
-		t.Fatalf("save tenant-a config: %v", err)
-	}
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-b", ProjectRoot: tenantBPath, DefaultEnvironment: "dev"}); err != nil {
-		t.Fatalf("save tenant-b config: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "local", RepoPath: tenantAPath, KubernetesContext: "cluster-local"}); err != nil {
-		t.Fatalf("save tenant-a env: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-b", common.EnvConfig{Name: "dev", RepoPath: tenantBPath, KubernetesContext: "cluster-b"}); err != nil {
-		t.Fatalf("save tenant-b env: %v", err)
-	}
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: tenantAPath, DefaultEnvironment: "local"}), "save tenant-a config")
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "tenant-b", ProjectRoot: tenantBPath, DefaultEnvironment: "dev"}), "save tenant-b config")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "local", RepoPath: tenantAPath, KubernetesContext: "cluster-local"}), "save tenant-a env")
+	requireNoError(t, common.SaveEnvConfig("tenant-b", common.EnvConfig{Name: "dev", RepoPath: tenantBPath, KubernetesContext: "cluster-b"}), "save tenant-b env")
 
-	if err := os.MkdirAll(filepath.Join(tenantBPath, ".git"), 0o755); err != nil {
-		t.Fatalf("mkdir .git: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(filepath.Join(tenantBPath, ".git"), 0o755), "mkdir .git")
 	subDir := filepath.Join(tenantBPath, "nested")
-	if err := os.MkdirAll(subDir, 0o755); err != nil {
-		t.Fatalf("mkdir nested: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(subDir, 0o755), "mkdir nested")
 	prevWD, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	if err := os.Chdir(subDir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	requireNoError(t, os.Chdir(subDir), "chdir")
 	t.Cleanup(func() {
 		_ = os.Chdir(prevWD)
 	})
@@ -162,9 +126,7 @@ func TestListCommandUsesConfiguredCurrentDirectoryTenantBeforeDefault(t *testing
 	cmd.SetErr(new(bytes.Buffer))
 	cmd.SetArgs([]string{"list"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stdout.String()
 	for _, want := range []string{
@@ -195,16 +157,12 @@ func TestListCommandPrintsEmptyStateWhenNotInitialized(t *testing.T) {
 	}
 
 	repoRoot := filepath.Join(t.TempDir(), "erun")
-	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
-		t.Fatalf("mkdir .git: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755), "mkdir .git")
 	prevWD, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	if err := os.Chdir(repoRoot); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	requireNoError(t, os.Chdir(repoRoot), "chdir")
 	t.Cleanup(func() {
 		_ = os.Chdir(prevWD)
 	})
@@ -215,9 +173,7 @@ func TestListCommandPrintsEmptyStateWhenNotInitialized(t *testing.T) {
 	cmd.SetErr(new(bytes.Buffer))
 	cmd.SetArgs([]string{"list"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stdout.String()
 	for _, want := range []string{
@@ -244,27 +200,17 @@ func TestListCommandPrintsSnapshotPreference(t *testing.T) {
 	stubKubectlContexts(t, []string{"cluster-local"}, "cluster-local")
 
 	repoRoot := filepath.Join(t.TempDir(), "tenant-a")
-	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
-		t.Fatalf("mkdir .git: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755), "mkdir .git")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	snapshot := false
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: repoRoot, DefaultEnvironment: "local"}); err != nil {
-		t.Fatalf("save tenant config: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "local", RepoPath: repoRoot, KubernetesContext: "cluster-local", Snapshot: &snapshot}); err != nil {
-		t.Fatalf("save env config: %v", err)
-	}
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: repoRoot, DefaultEnvironment: "local"}), "save tenant config")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "local", RepoPath: repoRoot, KubernetesContext: "cluster-local", Snapshot: &snapshot}), "save env config")
 
 	prevWD, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	if err := os.Chdir(repoRoot); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	requireNoError(t, os.Chdir(repoRoot), "chdir")
 	t.Cleanup(func() {
 		_ = os.Chdir(prevWD)
 	})
@@ -275,9 +221,7 @@ func TestListCommandPrintsSnapshotPreference(t *testing.T) {
 	cmd.SetErr(new(bytes.Buffer))
 	cmd.SetArgs([]string{"list"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stdout.String()
 	for _, want := range []string{
@@ -297,15 +241,9 @@ func TestListCommandPrintsSSHDConfiguration(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
 	repoRoot := filepath.Join(t.TempDir(), "tenant-a")
-	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
-		t.Fatalf("mkdir repo root: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: repoRoot, DefaultEnvironment: "dev"}); err != nil {
-		t.Fatalf("save tenant config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(repoRoot, 0o755), "mkdir repo root")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: repoRoot, DefaultEnvironment: "dev"}), "save tenant config")
 	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{
 		Name:              "dev",
 		RepoPath:          repoRoot,
@@ -326,9 +264,7 @@ func TestListCommandPrintsSSHDConfiguration(t *testing.T) {
 	cmd.SetErr(new(bytes.Buffer))
 	cmd.SetArgs([]string{"list"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stdout.String()
 	for _, want := range []string{

--- a/erun-cli/cmd/mcp_port_forward.go
+++ b/erun-cli/cmd/mcp_port_forward.go
@@ -53,10 +53,7 @@ func ensureMCPPortForward(ctx common.Context, result common.OpenResult) (int, er
 	if stateMatchesMCPTarget(state, expectedState) && canReachLocalMCPEndpoint(localPort) {
 		return localPort, nil
 	}
-	if stateMatchesMCPTarget(state, expectedState) && state.ProcessID > 0 && canConnectLocalPort(localPort) {
-		_ = stopPortForwardProcess(state.ProcessID)
-		waitForLocalPortToClose(localPort)
-	}
+	stopStaleMCPPortForward(state, expectedState, localPort)
 	if canConnectLocalPort(localPort) {
 		return 0, fmt.Errorf("local MCP port %d is already in use", localPort)
 	}
@@ -67,6 +64,18 @@ func ensureMCPPortForward(ctx common.Context, result common.OpenResult) (int, er
 		return localPort, nil
 	}
 
+	return startMCPPortForward(statePath, expectedState, args, localPort)
+}
+
+func stopStaleMCPPortForward(state, expectedState mcpPortForwardState, localPort int) {
+	if !stateMatchesMCPTarget(state, expectedState) || state.ProcessID <= 0 || !canConnectLocalPort(localPort) {
+		return
+	}
+	_ = stopPortForwardProcess(state.ProcessID)
+	waitForLocalPortToClose(localPort)
+}
+
+func startMCPPortForward(statePath string, expectedState mcpPortForwardState, args []string, localPort int) (int, error) {
 	logPath := mcpPortForwardLogPath(statePath)
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
 		return 0, err
@@ -93,18 +102,25 @@ func ensureMCPPortForward(ctx common.Context, result common.OpenResult) (int, er
 		return 0, err
 	}
 
+	if err := waitForMCPPortForward(localPort, logPath); err != nil {
+		return 0, err
+	}
+	return localPort, nil
+}
+
+func waitForMCPPortForward(localPort int, logPath string) error {
 	deadline := time.Now().Add(mcpPortForwardStartupTimeout)
 	for time.Now().Before(deadline) {
 		if canReachLocalMCPEndpoint(localPort) {
-			return localPort, nil
+			return nil
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 
 	if detail := mcpPortForwardTimeoutDetail(logPath); detail != "" {
-		return 0, fmt.Errorf("timed out waiting for MCP port-forward on 127.0.0.1:%d: %s; see %s", localPort, detail, logPath)
+		return fmt.Errorf("timed out waiting for MCP port-forward on 127.0.0.1:%d: %s; see %s", localPort, detail, logPath)
 	}
-	return 0, fmt.Errorf("timed out waiting for MCP port-forward on 127.0.0.1:%d; see %s", localPort, logPath)
+	return fmt.Errorf("timed out waiting for MCP port-forward on 127.0.0.1:%d; see %s", localPort, logPath)
 }
 
 func kubectlMCPPortForwardArgs(result common.OpenResult, localPort int) []string {

--- a/erun-cli/cmd/mcp_test.go
+++ b/erun-cli/cmd/mcp_test.go
@@ -51,9 +51,7 @@ func TestMCPCmdDryRunPrintsTraceWithoutStartingServer(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"-v", "mcp", "--dry-run", "--host", "0.0.0.0", "--port", "17000", "--path", "/mcp"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := stdout.String(); got != "" {
 		t.Fatalf("expected no server output during dry-run, got %q", got)
@@ -81,9 +79,7 @@ func TestMCPCmdStartsEMCP(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"mcp", "tenant-a", "dev", "--host", "0.0.0.0", "--port", "17001", "--path", "custom"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if !started {
 		t.Fatal("expected emcp to be launched")
 	}
@@ -109,21 +105,11 @@ func TestMCPCmdUsesEnvironmentLocalPortByDefault(t *testing.T) {
 		}
 	}
 
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: tenantAPath, DefaultEnvironment: "local"}); err != nil {
-		t.Fatalf("save tenant-a config: %v", err)
-	}
-	if err := common.SaveTenantConfig(common.TenantConfig{Name: "tenant-b", ProjectRoot: tenantBPath, DefaultEnvironment: "dev"}); err != nil {
-		t.Fatalf("save tenant-b config: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "local", RepoPath: tenantAPath, KubernetesContext: "cluster-a"}); err != nil {
-		t.Fatalf("save tenant-a env: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-b", common.EnvConfig{Name: "dev", RepoPath: tenantBPath, KubernetesContext: "cluster-b"}); err != nil {
-		t.Fatalf("save tenant-b env: %v", err)
-	}
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "tenant-a", ProjectRoot: tenantAPath, DefaultEnvironment: "local"}), "save tenant-a config")
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{Name: "tenant-b", ProjectRoot: tenantBPath, DefaultEnvironment: "dev"}), "save tenant-b config")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "local", RepoPath: tenantAPath, KubernetesContext: "cluster-a"}), "save tenant-a env")
+	requireNoError(t, common.SaveEnvConfig("tenant-b", common.EnvConfig{Name: "dev", RepoPath: tenantBPath, KubernetesContext: "cluster-b"}), "save tenant-b env")
 
 	cmd := newTestRootCmd(testRootDeps{})
 	stderr := new(bytes.Buffer)
@@ -131,9 +117,7 @@ func TestMCPCmdUsesEnvironmentLocalPortByDefault(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"-v", "mcp", "tenant-b", "dev", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := stderr.String(); !bytes.Contains([]byte(got), []byte("--port 17100")) {
 		t.Fatalf("expected environment-scoped MCP port in trace, got %q", got)

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -513,15 +513,11 @@ func maybeConfigureOpenNoShellAlias(result common.OpenResult, promptRunner Promp
 	aliasName := openNoShellAliasName(result)
 	startupFile, aliasConfigured := detectOpenNoShellAliasStartupFile(result, shellPath)
 	if aliasConfigured {
-		for _, line := range openNoShellHintLines(result, shellPath) {
-			_, _ = fmt.Fprintln(stderr, line)
-		}
+		writeOpenNoShellHintLines(stderr, result, shellPath)
 		return nil
 	}
 	if startupFile == "" || promptRunner == nil || dialect == openNoShellDialectPowerShell {
-		for _, line := range openNoShellHintLines(result, shellPath) {
-			_, _ = fmt.Fprintln(stderr, line)
-		}
+		writeOpenNoShellHintLines(stderr, result, shellPath)
 		return nil
 	}
 
@@ -530,9 +526,7 @@ func maybeConfigureOpenNoShellAlias(result common.OpenResult, promptRunner Promp
 		return err
 	}
 	if !ok {
-		for _, line := range openNoShellHintLines(result, shellPath) {
-			_, _ = fmt.Fprintln(stderr, line)
-		}
+		writeOpenNoShellHintLines(stderr, result, shellPath)
 		return nil
 	}
 
@@ -542,6 +536,12 @@ func maybeConfigureOpenNoShellAlias(result common.OpenResult, promptRunner Promp
 	_, _ = fmt.Fprintf(stderr, "added %s to %s\n", aliasName, startupFile)
 	_, _ = fmt.Fprintf(stderr, "open a new shell to use %s\n", aliasName)
 	return nil
+}
+
+func writeOpenNoShellHintLines(stderr io.Writer, result common.OpenResult, shellPath string) {
+	for _, line := range openNoShellHintLines(result, shellPath) {
+		_, _ = fmt.Fprintln(stderr, line)
+	}
 }
 
 func openNoShellHintLines(result common.OpenResult, shellPath string) []string {

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -248,155 +248,252 @@ func resolveOpenWithInitRetryForParams(ctx common.Context, params common.OpenPar
 }
 
 func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateMCP MCPForwarder, activateSSHD SSHDActivator, launchVSCode VSCodeLauncher, launchIntelliJ IntelliJLauncher) error {
-	if err := ctx.EnsureKubernetesContext(result.EnvConfig.KubernetesContext); err != nil {
+	runner := resolvedOpenRunner{
+		ctx:                       ctx,
+		result:                    result,
+		options:                   options,
+		promptRunner:              promptRunner,
+		openShell:                 openShell,
+		runManagedDeploy:          runManagedDeploy,
+		checkKubernetesDeployment: checkKubernetesDeployment,
+		resolveRuntimeDeploySpec:  resolveRuntimeDeploySpec,
+		deployHelmChart:           deployHelmChart,
+		activateMCP:               activateMCP,
+		activateSSHD:              activateSSHD,
+		launchVSCode:              launchVSCode,
+		launchIntelliJ:            launchIntelliJ,
+	}
+	return runner.run()
+}
+
+type resolvedOpenRunner struct {
+	ctx                       common.Context
+	result                    common.OpenResult
+	options                   openOptions
+	promptRunner              PromptRunner
+	openShell                 OpenShellRunner
+	runManagedDeploy          func(common.Context, common.OpenResult) error
+	checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc
+	resolveRuntimeDeploySpec  func(common.OpenResult) (common.DeploySpec, error)
+	deployHelmChart           common.HelmChartDeployerFunc
+	activateMCP               MCPForwarder
+	activateSSHD              SSHDActivator
+	launchVSCode              VSCodeLauncher
+	launchIntelliJ            IntelliJLauncher
+}
+
+func (r *resolvedOpenRunner) run() error {
+	if err := r.ctx.EnsureKubernetesContext(r.result.EnvConfig.KubernetesContext); err != nil {
 		return err
 	}
-	if !ctx.DryRun && os.Getenv("ERUN_IDLE_PROBE") != "1" {
+	r.recordActivity()
+	if err := r.validateIDEOptions(); err != nil {
+		return err
+	}
+
+	shellReq := common.ShellLaunchParamsFromResult(r.result)
+	if err := r.maybeDeployRuntime(shellReq); err != nil {
+		return err
+	}
+	if err := r.activateForwarders(); err != nil {
+		return err
+	}
+	if launched, err := r.maybeLaunchIDE(); launched || err != nil {
+		return err
+	}
+	if r.options.NoShell {
+		return r.emitNoShellSetup()
+	}
+
+	r.traceShellPreview(shellReq)
+	if r.ctx.DryRun {
+		return nil
+	}
+	return r.runShellLoop(shellReq)
+}
+
+func (r *resolvedOpenRunner) recordActivity() {
+	if !r.ctx.DryRun && os.Getenv("ERUN_IDLE_PROBE") != "1" {
 		_ = common.RecordEnvironmentActivity(common.EnvironmentActivityParams{
-			Tenant:      result.Tenant,
-			Environment: result.Environment,
+			Tenant:      r.result.Tenant,
+			Environment: r.result.Environment,
 			Kind:        common.ActivityKindCLI,
 		})
 	}
-	namespace := common.KubernetesNamespaceName(result.Tenant, result.Environment)
-	if options.VSCode && options.IntelliJ {
+}
+
+func (r *resolvedOpenRunner) validateIDEOptions() error {
+	if r.options.VSCode && r.options.IntelliJ {
 		return fmt.Errorf("--vscode and --intellij cannot be used together")
 	}
-	if (options.VSCode || options.IntelliJ) && !result.EnvConfig.SSHD.Enabled {
+	if (r.options.VSCode || r.options.IntelliJ) && !r.result.EnvConfig.SSHD.Enabled {
 		flag := "--vscode"
-		if options.IntelliJ {
+		if r.options.IntelliJ {
 			flag = "--intellij"
 		}
-		return fmt.Errorf("%s requires sshd-enabled remote environment; run `erun sshd init %s %s` first", flag, result.Tenant, result.Environment)
+		return fmt.Errorf("%s requires sshd-enabled remote environment; run `erun sshd init %s %s` first", flag, r.result.Tenant, r.result.Environment)
 	}
-	shellReq := common.ShellLaunchParamsFromResult(result)
-	if resolveRuntimeDeploySpec != nil && deployHelmChart != nil {
-		execution, err := resolveRuntimeDeploySpec(result)
-		if err != nil {
+	return nil
+}
+
+func (r *resolvedOpenRunner) maybeDeployRuntime(shellReq common.ShellLaunchParams) error {
+	if r.resolveRuntimeDeploySpec == nil || r.deployHelmChart == nil {
+		return nil
+	}
+	execution, err := r.resolveRuntimeExecution()
+	if err != nil {
+		return err
+	}
+	shouldDeploy, err := r.shouldDeployRuntime(shellReq, execution)
+	if err != nil {
+		return err
+	}
+	if !shouldDeploy {
+		return nil
+	}
+	return r.deployRuntime(execution)
+}
+
+func (r *resolvedOpenRunner) resolveRuntimeExecution() (common.DeploySpec, error) {
+	execution, err := r.resolveRuntimeDeploySpec(r.result)
+	if err != nil {
+		return common.DeploySpec{}, err
+	}
+	execution, err = maybeCreateMissingRuntimeChart(r.ctx, r.result, r.promptRunner, r.resolveRuntimeDeploySpec, execution)
+	if err != nil {
+		return common.DeploySpec{}, err
+	}
+	execution, err = applyRuntimeDeployImageOverride(r.result, execution, r.options.RuntimeImage)
+	if err != nil {
+		return common.DeploySpec{}, err
+	}
+	return applyRuntimeDeployVersionOverride(execution, r.options.VersionOverride), nil
+}
+
+func (r *resolvedOpenRunner) shouldDeployRuntime(shellReq common.ShellLaunchParams, execution common.DeploySpec) (bool, error) {
+	if len(execution.Builds) > 0 || strings.TrimSpace(r.options.VersionOverride) != "" || strings.TrimSpace(r.options.RuntimeImage) != "" {
+		return true, nil
+	}
+	if r.checkKubernetesDeployment == nil {
+		return false, nil
+	}
+	deployed, err := r.checkKubernetesDeployment(common.KubernetesDeploymentCheckParams{
+		Name:              common.RuntimeReleaseName(r.result.Tenant),
+		Namespace:         common.KubernetesNamespaceName(r.result.Tenant, r.result.Environment),
+		KubernetesContext: r.result.EnvConfig.KubernetesContext,
+		ExpectedRepoPath:  common.RemoteShellWorktreePath(shellReq),
+		ExpectedSSHD:      sshdExpectationForDeployment(r.result),
+		ExpectedMCPPort:   common.MCPPortForResult(r.result),
+		ExpectedSSHPort:   common.SSHLocalPortForResult(r.result),
+	})
+	if err != nil {
+		return false, err
+	}
+	return !deployed, nil
+}
+
+func (r *resolvedOpenRunner) deployRuntime(execution common.DeploySpec) error {
+	if r.options.VSCode || r.options.IntelliJ {
+		return fmt.Errorf("opening %s requires updating the runtime deployment for %s/%s; run `erun sshd init %s %s` or `erun open %s %s` first, then retry", ideOpenLabel(r.options), r.result.Tenant, r.result.Environment, r.result.Tenant, r.result.Environment, r.result.Tenant, r.result.Environment)
+	}
+	if r.result.EnvConfig.SSHD.Enabled {
+		execution.Deploy.SSHDEnabled = true
+	}
+	r.ctx.Logger.Debug("deploying the devops runtime before opening the shell")
+	if err := common.RunDeploySpec(r.ctx, execution, common.DockerImageBuilder, runOpenDockerPush, r.openHelmDeployer(execution)); err != nil {
+		return err
+	}
+	return r.persistRuntimeVersion(execution.Deploy.Version)
+}
+
+func runOpenDockerPush(ctx common.Context, pushInput common.DockerPushSpec) error {
+	return common.RunDockerPush(ctx, pushInput, common.DockerImagePusher)
+}
+
+func (r *resolvedOpenRunner) openHelmDeployer(execution common.DeploySpec) common.HelmChartDeployerFunc {
+	return wrapHelmDeployWithReleaseRecovery(
+		r.promptRunner,
+		wrapOpenHelmDeployWithSpinner(r.ctx, execution.Deploy.ReleaseName, r.deployHelmChart),
+		common.ClearHelmReleasePendingOperation,
+	)
+}
+
+func (r *resolvedOpenRunner) persistRuntimeVersion(version string) error {
+	if r.ctx.DryRun {
+		return nil
+	}
+	result, err := persistOpenRuntimeVersion(r.result, version, r.options.SaveEnvConfig)
+	if err != nil {
+		return err
+	}
+	r.result = result
+	return nil
+}
+
+func (r *resolvedOpenRunner) activateForwarders() error {
+	if r.activateSSHD != nil && r.result.EnvConfig.SSHD.Enabled {
+		if err := r.activateSSHD(r.ctx, r.result); err != nil {
 			return err
 		}
-		execution, err = maybeCreateMissingRuntimeChart(ctx, result, promptRunner, resolveRuntimeDeploySpec, execution)
-		if err != nil {
-			return err
-		}
-		execution, err = applyRuntimeDeployImageOverride(result, execution, options.RuntimeImage)
-		if err != nil {
-			return err
-		}
-		execution = applyRuntimeDeployVersionOverride(execution, options.VersionOverride)
-
-		shouldDeploy := len(execution.Builds) > 0
-		if strings.TrimSpace(options.VersionOverride) != "" || strings.TrimSpace(options.RuntimeImage) != "" {
-			shouldDeploy = true
-		}
-		if !shouldDeploy && checkKubernetesDeployment != nil {
-			expectedSSHD := sshdExpectationForDeployment(result)
-			deployed, err := checkKubernetesDeployment(common.KubernetesDeploymentCheckParams{
-				Name:              common.RuntimeReleaseName(result.Tenant),
-				Namespace:         namespace,
-				KubernetesContext: result.EnvConfig.KubernetesContext,
-				ExpectedRepoPath:  common.RemoteShellWorktreePath(shellReq),
-				ExpectedSSHD:      expectedSSHD,
-				ExpectedMCPPort:   common.MCPPortForResult(result),
-				ExpectedSSHPort:   common.SSHLocalPortForResult(result),
-			})
-			if err != nil {
-				return err
-			}
-			shouldDeploy = !deployed
-		}
-
-		if shouldDeploy {
-			if options.VSCode || options.IntelliJ {
-				return fmt.Errorf("opening %s requires updating the runtime deployment for %s/%s; run `erun sshd init %s %s` or `erun open %s %s` first, then retry", ideOpenLabel(options), result.Tenant, result.Environment, result.Tenant, result.Environment, result.Tenant, result.Environment)
-			}
-			if result.EnvConfig.SSHD.Enabled {
-				execution.Deploy.SSHDEnabled = true
-			}
-			ctx.Logger.Debug("deploying the devops runtime before opening the shell")
-			if err := common.RunDeploySpec(
-				ctx,
-				execution,
-				common.DockerImageBuilder,
-				func(ctx common.Context, pushInput common.DockerPushSpec) error {
-					return common.RunDockerPush(ctx, pushInput, common.DockerImagePusher)
-				},
-				wrapHelmDeployWithReleaseRecovery(
-					promptRunner,
-					wrapOpenHelmDeployWithSpinner(ctx, execution.Deploy.ReleaseName, deployHelmChart),
-					common.ClearHelmReleasePendingOperation,
-				),
-			); err != nil {
-				return err
-			}
-			if !ctx.DryRun {
-				result, err = persistOpenRuntimeVersion(result, execution.Deploy.Version, options.SaveEnvConfig)
-				if err != nil {
-					return err
-				}
-			}
-		}
 	}
+	if r.activateMCP == nil {
+		return nil
+	}
+	return r.activateMCP(r.ctx, r.result)
+}
 
-	if activateSSHD != nil && result.EnvConfig.SSHD.Enabled {
-		if err := activateSSHD(ctx, result); err != nil {
-			return err
+func (r *resolvedOpenRunner) maybeLaunchIDE() (bool, error) {
+	if r.options.VSCode {
+		if r.launchVSCode == nil {
+			return true, fmt.Errorf("VS Code launcher is required")
 		}
+		return true, r.launchVSCode(r.ctx, r.result)
 	}
-	if activateMCP != nil {
-		if err := activateMCP(ctx, result); err != nil {
-			return err
+	if r.options.IntelliJ {
+		if r.launchIntelliJ == nil {
+			return true, fmt.Errorf("IntelliJ launcher is required")
 		}
+		return true, r.launchIntelliJ(r.ctx, r.result, r.promptRunner)
 	}
+	return false, nil
+}
 
-	if options.VSCode {
-		if launchVSCode == nil {
-			return fmt.Errorf("VS Code launcher is required")
-		}
-		return launchVSCode(ctx, result)
+func (r *resolvedOpenRunner) emitNoShellSetup() error {
+	namespace := common.KubernetesNamespaceName(r.result.Tenant, r.result.Environment)
+	r.ctx.TraceCommand("", "kubectl", "config", "use-context", strings.TrimSpace(r.result.EnvConfig.KubernetesContext))
+	r.ctx.TraceCommand("", "kubectl", "config", "set-context", "--current", "--namespace="+namespace)
+	r.ctx.TraceCommand("", "cd", r.result.RepoPath)
+	promptRunner := r.promptRunner
+	if r.options.NoAliasPrompt {
+		promptRunner = nil
 	}
-	if options.IntelliJ {
-		if launchIntelliJ == nil {
-			return fmt.Errorf("IntelliJ launcher is required")
-		}
-		return launchIntelliJ(ctx, result, promptRunner)
-	}
+	return emitLocalShellSetupForOpenResult(r.result, promptRunner, r.ctx.Stdout, r.ctx.Stderr)
+}
 
-	if options.NoShell {
-		ctx.TraceCommand("", "kubectl", "config", "use-context", strings.TrimSpace(result.EnvConfig.KubernetesContext))
-		ctx.TraceCommand("", "kubectl", "config", "set-context", "--current", "--namespace="+namespace)
-		ctx.TraceCommand("", "cd", result.RepoPath)
-		if options.NoAliasPrompt {
-			promptRunner = nil
-		}
-		return emitLocalShellSetupForOpenResult(result, promptRunner, ctx.Stdout, ctx.Stderr)
-	}
-
+func (r *resolvedOpenRunner) traceShellPreview(shellReq common.ShellLaunchParams) {
 	if preview, err := common.PreviewShellLaunch(shellReq); err == nil {
-		ctx.TraceCommand("", "kubectl", preview.WaitArgs...)
+		r.ctx.TraceCommand("", "kubectl", preview.WaitArgs...)
 		execArgs := append([]string{}, preview.ExecArgs...)
 		if len(execArgs) > 0 {
 			execArgs[len(execArgs)-1] = "<bootstrap-script>"
 		}
-		ctx.TraceCommand("", "kubectl", execArgs...)
-		ctx.TraceBlock("bootstrap-script", preview.Script)
+		r.ctx.TraceCommand("", "kubectl", execArgs...)
+		r.ctx.TraceBlock("bootstrap-script", preview.Script)
 	} else {
-		ctx.Logger.Debug("unable to render remote shell bootstrap trace: " + err.Error())
+		r.ctx.Logger.Debug("unable to render remote shell bootstrap trace: " + err.Error())
 	}
+}
 
-	if ctx.DryRun {
-		return nil
-	}
-
+func (r *resolvedOpenRunner) runShellLoop(shellReq common.ShellLaunchParams) error {
 	for {
-		err := openShell(ctx, shellReq)
+		err := r.openShell(r.ctx, shellReq)
 		if !errors.Is(err, common.ErrShellReattachDeploy) {
 			return err
 		}
-		if runManagedDeploy == nil {
+		if r.runManagedDeploy == nil {
 			return err
 		}
-		if err := runManagedDeploy(ctx, result); err != nil {
+		if err := r.runManagedDeploy(r.ctx, r.result); err != nil {
 			return err
 		}
 	}

--- a/erun-cli/cmd/open_ide.go
+++ b/erun-cli/cmd/open_ide.go
@@ -517,51 +517,15 @@ func lookPathBootstrapAttempts(candidates []string) []jetbrainsBootstrapAttempt 
 }
 
 func resolveIntelliJOptionsDir(hostOS common.HostOS) (string, error) {
-	homeDir, err := ideUserHomeDir()
+	baseDir, err := intelliJOptionsBaseDir(hostOS)
 	if err != nil {
 		return "", err
 	}
-
-	var baseDir string
-	switch hostOS {
-	case common.HostOSDarwin:
-		baseDir = filepath.Join(homeDir, "Library", "Application Support", "JetBrains")
-	case common.HostOSLinux:
-		baseDir = filepath.Join(homeDir, ".config", "JetBrains")
-	case common.HostOSWindows:
-		if appData := strings.TrimSpace(os.Getenv("APPDATA")); appData != "" {
-			baseDir = filepath.Join(appData, "JetBrains")
-		}
-	default:
-		return "", fmt.Errorf("unsupported host OS: %s", hostOS)
-	}
-	if strings.TrimSpace(baseDir) == "" {
-		return "", fmt.Errorf("JetBrains options directory base is not configured")
-	}
-
-	matches, err := ideGlob(filepath.Join(baseDir, "IntelliJIdea*", "options"))
+	candidates, err := intelliJOptionsCandidates(baseDir)
 	if err != nil {
 		return "", err
 	}
-	type candidate struct {
-		path    string
-		modTime time.Time
-	}
-	candidates := make([]candidate, 0, len(matches))
-	for _, match := range matches {
-		info, err := ideStat(match)
-		if err != nil {
-			continue
-		}
-		if !info.IsDir() {
-			continue
-		}
-		candidates = append(candidates, candidate{path: match, modTime: info.ModTime()})
-	}
-	if len(candidates) == 0 {
-		return "", fmt.Errorf("IntelliJ IDEA options directory not found under %s", baseDir)
-	}
-	slices.SortFunc(candidates, func(a, b candidate) int {
+	slices.SortFunc(candidates, func(a, b intelliJOptionsCandidate) int {
 		if a.modTime.Equal(b.modTime) {
 			return strings.Compare(b.path, a.path)
 		}
@@ -571,6 +535,53 @@ func resolveIntelliJOptionsDir(hostOS common.HostOS) (string, error) {
 		return 1
 	})
 	return candidates[0].path, nil
+}
+
+type intelliJOptionsCandidate struct {
+	path    string
+	modTime time.Time
+}
+
+func intelliJOptionsBaseDir(hostOS common.HostOS) (string, error) {
+	homeDir, err := ideUserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	switch hostOS {
+	case common.HostOSDarwin:
+		return filepath.Join(homeDir, "Library", "Application Support", "JetBrains"), nil
+	case common.HostOSLinux:
+		return filepath.Join(homeDir, ".config", "JetBrains"), nil
+	case common.HostOSWindows:
+		if appData := strings.TrimSpace(os.Getenv("APPDATA")); appData != "" {
+			return filepath.Join(appData, "JetBrains"), nil
+		}
+		return "", fmt.Errorf("JetBrains options directory base is not configured")
+	default:
+		return "", fmt.Errorf("unsupported host OS: %s", hostOS)
+	}
+}
+
+func intelliJOptionsCandidates(baseDir string) ([]intelliJOptionsCandidate, error) {
+	matches, err := ideGlob(filepath.Join(baseDir, "IntelliJIdea*", "options"))
+	if err != nil {
+		return nil, err
+	}
+	candidates := make([]intelliJOptionsCandidate, 0, len(matches))
+	for _, match := range matches {
+		info, err := ideStat(match)
+		if err != nil {
+			continue
+		}
+		if !info.IsDir() {
+			continue
+		}
+		candidates = append(candidates, intelliJOptionsCandidate{path: match, modTime: info.ModTime()})
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("IntelliJ IDEA options directory not found under %s", baseDir)
+	}
+	return candidates, nil
 }
 
 func resolveIntelliJGatewayOptionsDir(optionsDir string) (string, error) {

--- a/erun-cli/cmd/open_intellij_test.go
+++ b/erun-cli/cmd/open_intellij_test.go
@@ -34,39 +34,25 @@ func TestLaunchIntelliJEnsuresKnownHostBeforeOpening(t *testing.T) {
 	currentHostOS = func() common.HostOS { return common.HostOSDarwin }
 	ensureLocalSSHDKnownHostFunc = func(_ common.Context, result common.OpenResult) error {
 		callOrder = append(callOrder, "known_hosts")
-		if result.Tenant != "tenant-a" {
-			t.Fatalf("unexpected target: %+v", result)
-		}
+		requireIntelliJTarget(t, result)
 		return nil
 	}
 	registerIntelliJProjectFunc = func(_ common.Context, result common.OpenResult, hostOS common.HostOS) error {
 		callOrder = append(callOrder, "register_project")
-		if hostOS != common.HostOSDarwin {
-			t.Fatalf("unexpected host OS: %s", hostOS)
-		}
-		if result.Tenant != "tenant-a" {
-			t.Fatalf("unexpected target: %+v", result)
-		}
+		requireIntelliJHostOS(t, hostOS)
+		requireIntelliJTarget(t, result)
 		return nil
 	}
 	openIntelliJGatewayProjectFunc = func(_ common.Context, result common.OpenResult, hostOS common.HostOS) (bool, error) {
 		callOrder = append(callOrder, "open_gateway")
-		if hostOS != common.HostOSDarwin {
-			t.Fatalf("unexpected host OS: %s", hostOS)
-		}
-		if result.Tenant != "tenant-a" {
-			t.Fatalf("unexpected target: %+v", result)
-		}
+		requireIntelliJHostOS(t, hostOS)
+		requireIntelliJTarget(t, result)
 		return false, nil
 	}
 	openInstalledIntelliJAppFunc = func(_ common.Context, result common.OpenResult, hostOS common.HostOS) error {
 		callOrder = append(callOrder, "open_intellij")
-		if hostOS != common.HostOSDarwin {
-			t.Fatalf("unexpected host OS: %s", hostOS)
-		}
-		if result.Tenant != "tenant-a" {
-			t.Fatalf("unexpected target: %+v", result)
-		}
+		requireIntelliJHostOS(t, hostOS)
+		requireIntelliJTarget(t, result)
 		return nil
 	}
 
@@ -106,6 +92,20 @@ func TestLaunchIntelliJEnsuresKnownHostBeforeOpening(t *testing.T) {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("expected guidance to contain %q, got:\n%s", want, stderr.String())
 		}
+	}
+}
+
+func requireIntelliJTarget(t *testing.T, result common.OpenResult) {
+	t.Helper()
+	if result.Tenant != "tenant-a" {
+		t.Fatalf("unexpected target: %+v", result)
+	}
+}
+
+func requireIntelliJHostOS(t *testing.T, hostOS common.HostOS) {
+	t.Helper()
+	if hostOS != common.HostOSDarwin {
+		t.Fatalf("unexpected host OS: %s", hostOS)
 	}
 }
 
@@ -315,7 +315,7 @@ func TestOpenIntelliJGatewayProjectLaunchesRecentProjectURI(t *testing.T) {
 	requireNoError(t, os.WriteFile(filepath.Join(appContentsDir, "lib", "app.jar"), nil, 0o600), "write app jar")
 	requireNoError(t, os.WriteFile(filepath.Join(appContentsDir, "plugins", "gateway-plugin", "resources", "gateway.vmoptions"), []byte("-Xmx512m\n-Dapple.awt.application.name=Gateway\n"), 0o600), "write gateway vmoptions")
 	configID := jetbrainsconfig.StableConfigID("erun-tenant-a-remote")
-	if err := os.WriteFile(filepath.Join(optionsDir, "sshRecentConnections.v2.xml"), []byte(`<application>
+	requireWriteFile(t, filepath.Join(optionsDir, "sshRecentConnections.v2.xml"), []byte(`<application>
   <component name="SshLocalRecentConnectionsManager">
     <option name="connections">
       <list>
@@ -342,23 +342,10 @@ func TestOpenIntelliJGatewayProjectLaunchesRecentProjectURI(t *testing.T) {
     </option>
   </component>
 </application>
-`), 0o600); err != nil {
-		t.Fatalf("write recent projects: %v", err)
-	}
+`), 0o600, "write recent projects")
 
 	ideUserHomeDir = func() (string, error) { return root, nil }
-	ideGlob = func(pattern string) ([]string, error) {
-		if strings.Contains(pattern, "IntelliJIdea*") {
-			return []string{optionsDir}, nil
-		}
-		if strings.Contains(pattern, "IntelliJ IDEA*.app") {
-			return []string{appContentsDir}, nil
-		}
-		if strings.Contains(pattern, "lib/*.jar") {
-			return []string{filepath.Join(appContentsDir, "lib", "app.jar")}, nil
-		}
-		return nil, nil
-	}
+	ideGlob = gatewayProjectGlob(optionsDir, appContentsDir)
 	ideStat = os.Stat
 	ideRunTokenFunc = func() string { return "fixed-token" }
 	var launchedCommand string
@@ -386,9 +373,27 @@ func TestOpenIntelliJGatewayProjectLaunchesRecentProjectURI(t *testing.T) {
 		},
 		RepoPath: "/home/erun/git/tenant-a",
 	}, common.HostOSDarwin)
-	if err != nil {
-		t.Fatalf("openIntelliJGatewayProject failed: %v", err)
+	requireNoError(t, err, "openIntelliJGatewayProject failed")
+	requireGatewayProjectLaunch(t, opened, launchedCommand, launchedArgs, appContentsDir, configID)
+}
+
+func gatewayProjectGlob(optionsDir, appContentsDir string) func(string) ([]string, error) {
+	return func(pattern string) ([]string, error) {
+		if strings.Contains(pattern, "IntelliJIdea*") {
+			return []string{optionsDir}, nil
+		}
+		if strings.Contains(pattern, "IntelliJ IDEA*.app") {
+			return []string{appContentsDir}, nil
+		}
+		if strings.Contains(pattern, "lib/*.jar") {
+			return []string{filepath.Join(appContentsDir, "lib", "app.jar")}, nil
+		}
+		return nil, nil
 	}
+}
+
+func requireGatewayProjectLaunch(t *testing.T, opened bool, launchedCommand string, launchedArgs []string, appContentsDir, configID string) {
+	t.Helper()
 	if !opened {
 		t.Fatal("expected gateway project launch")
 	}
@@ -403,6 +408,11 @@ func TestOpenIntelliJGatewayProjectLaunchesRecentProjectURI(t *testing.T) {
 		values.Get("runFromIdeToken") != "fixed-token" {
 		t.Fatalf("unexpected gateway URI values: %s", uri)
 	}
+	requireGatewayLaunchArgs(t, launchedArgs, appContentsDir)
+}
+
+func requireGatewayLaunchArgs(t *testing.T, launchedArgs []string, appContentsDir string) {
+	t.Helper()
 	if !strings.Contains(strings.Join(launchedArgs, "\n"), "-Didea.platform.prefix=Gateway") {
 		t.Fatalf("expected Gateway platform launch args, got %+v", launchedArgs)
 	}

--- a/erun-cli/cmd/open_intellij_test.go
+++ b/erun-cli/cmd/open_intellij_test.go
@@ -308,22 +308,12 @@ func TestOpenIntelliJGatewayProjectLaunchesRecentProjectURI(t *testing.T) {
 
 	root := t.TempDir()
 	optionsDir := filepath.Join(root, "Library", "Application Support", "JetBrains", "IntelliJIdea2025.3", "options")
-	if err := os.MkdirAll(optionsDir, 0o700); err != nil {
-		t.Fatalf("mkdir optionsDir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(optionsDir, 0o700), "mkdir optionsDir")
 	appContentsDir := filepath.Join(root, "Applications", "IntelliJ IDEA.app", "Contents")
-	if err := os.MkdirAll(filepath.Join(appContentsDir, "plugins", "gateway-plugin", "resources"), 0o700); err != nil {
-		t.Fatalf("mkdir app contents: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Join(appContentsDir, "lib"), 0o700); err != nil {
-		t.Fatalf("mkdir app lib: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(appContentsDir, "lib", "app.jar"), nil, 0o600); err != nil {
-		t.Fatalf("write app jar: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(appContentsDir, "plugins", "gateway-plugin", "resources", "gateway.vmoptions"), []byte("-Xmx512m\n-Dapple.awt.application.name=Gateway\n"), 0o600); err != nil {
-		t.Fatalf("write gateway vmoptions: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(filepath.Join(appContentsDir, "plugins", "gateway-plugin", "resources"), 0o700), "mkdir app contents")
+	requireNoError(t, os.MkdirAll(filepath.Join(appContentsDir, "lib"), 0o700), "mkdir app lib")
+	requireNoError(t, os.WriteFile(filepath.Join(appContentsDir, "lib", "app.jar"), nil, 0o600), "write app jar")
+	requireNoError(t, os.WriteFile(filepath.Join(appContentsDir, "plugins", "gateway-plugin", "resources", "gateway.vmoptions"), []byte("-Xmx512m\n-Dapple.awt.application.name=Gateway\n"), 0o600), "write gateway vmoptions")
 	configID := jetbrainsconfig.StableConfigID("erun-tenant-a-remote")
 	if err := os.WriteFile(filepath.Join(optionsDir, "sshRecentConnections.v2.xml"), []byte(`<application>
   <component name="SshLocalRecentConnectionsManager">
@@ -521,20 +511,12 @@ func TestResolveIntelliJOptionsDirChoosesMostRecentlyModified(t *testing.T) {
 	root := t.TempDir()
 	oldDir := filepath.Join(root, "IntelliJIdea2025.2", "options")
 	newDir := filepath.Join(root, "IntelliJIdea2025.3", "options")
-	if err := os.MkdirAll(oldDir, 0o700); err != nil {
-		t.Fatalf("mkdir oldDir: %v", err)
-	}
-	if err := os.MkdirAll(newDir, 0o700); err != nil {
-		t.Fatalf("mkdir newDir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(oldDir, 0o700), "mkdir oldDir")
+	requireNoError(t, os.MkdirAll(newDir, 0o700), "mkdir newDir")
 	oldTime := time.Unix(100, 0)
 	newTime := time.Unix(200, 0)
-	if err := os.Chtimes(oldDir, oldTime, oldTime); err != nil {
-		t.Fatalf("chtimes oldDir: %v", err)
-	}
-	if err := os.Chtimes(newDir, newTime, newTime); err != nil {
-		t.Fatalf("chtimes newDir: %v", err)
-	}
+	requireNoError(t, os.Chtimes(oldDir, oldTime, oldTime), "chtimes oldDir")
+	requireNoError(t, os.Chtimes(newDir, newTime, newTime), "chtimes newDir")
 
 	ideUserHomeDir = func() (string, error) { return "/Users/test", nil }
 	ideGlob = func(pattern string) ([]string, error) { return []string{oldDir, newDir}, nil }
@@ -561,9 +543,7 @@ func TestResolveIntelliJOptionsDirWindowsUsesAppData(t *testing.T) {
 
 	root := t.TempDir()
 	optionsDir := filepath.Join(root, "JetBrains", "IntelliJIdea2025.3", "options")
-	if err := os.MkdirAll(optionsDir, 0o700); err != nil {
-		t.Fatalf("mkdir optionsDir: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(optionsDir, 0o700), "mkdir optionsDir")
 	t.Setenv("APPDATA", root)
 
 	ideUserHomeDir = func() (string, error) { return "/Users/ignored", nil }

--- a/erun-cli/cmd/open_test.go
+++ b/erun-cli/cmd/open_test.go
@@ -24,9 +24,7 @@ func TestOpenCommandLaunchesShell(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"open", "tenant-a", "dev"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if launched.Dir != repoPath || launched.Title != "tenant-a-dev" {
 		t.Fatalf("unexpected shell launch: %+v", launched)
 	}
@@ -42,9 +40,7 @@ func TestOpenHelpShowsTenantAndEnvironmentFlags(t *testing.T) {
 	cmd.SetErr(new(bytes.Buffer))
 	cmd.SetArgs([]string{"open", "--help"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stdout.String()
 	for _, want := range []string{
@@ -75,9 +71,7 @@ func TestOpenCommandAcceptsTenantAndEnvironmentFlags(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"open", "--tenant", "tenant-a", "--environment", "dev"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if launched.Dir != repoPath || launched.Title != "tenant-a-dev" {
 		t.Fatalf("unexpected shell launch: %+v", launched)
 	}
@@ -106,9 +100,7 @@ func TestOpenCommandVersionOverrideForcesRuntimeDeploy(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"open", "tenant-a", "dev", "--version", "1.0.48"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if deployed.Version != "1.0.48" {
 		t.Fatalf("unexpected deploy version: %+v", deployed)
@@ -140,9 +132,7 @@ func TestOpenCommandRuntimeImageOverrideUsesSelectedImage(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"open", "test", "env", "--no-shell", "--version", "1.0.48", "--runtime-image", "test-devops", "--no-alias-prompt"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	service, err := os.ReadFile(filepath.Join(deployed.ChartPath, "templates", "service.yaml"))
 	if err != nil {
@@ -522,9 +512,7 @@ func TestOpenCommandNoShellConfiguresLocalKubeconfig(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"open", "tenant-a", "dev", "--no-shell"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	expected := "kubectl config use-context 'cluster-dev' >/dev/null &&\n" +
 		"kubectl config set-context --current --namespace='tenant-a-dev' >/dev/null &&\n" +
 		"cd '" + repoPath + "'\n"
@@ -549,9 +537,7 @@ func TestOpenCommandNoShellAliasPromptFlagSkipsPrompt(t *testing.T) {
 	cmd.SetOut(stdout)
 	cmd.SetArgs([]string{"open", "tenant-a", "dev", "--no-shell", "--no-alias-prompt"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if !strings.Contains(stdout.String(), "kubectl config use-context") {
 		t.Fatalf("expected no-shell setup output, got %q", stdout.String())
 	}
@@ -921,9 +907,7 @@ func TestOpenNoShellHintLinesRecommendAliasWhenConfigured(t *testing.T) {
 	t.Setenv("HOME", homeDir)
 	result := common.OpenResult{Tenant: "frs", Environment: "local", Title: "frs-local"}
 	startupPath := filepath.Join(homeDir, ".zshrc")
-	if err := os.WriteFile(startupPath, []byte(`alias frs-local='eval "$(erun open frs local --no-shell)"'`+"\n"), 0o644); err != nil {
-		t.Fatalf("write startup file: %v", err)
-	}
+	requireNoError(t, os.WriteFile(startupPath, []byte(`alias frs-local='eval "$(erun open frs local --no-shell)"'`+"\n"), 0o644), "write startup file")
 
 	lines := openNoShellHintLines(result, "/bin/zsh")
 
@@ -973,9 +957,7 @@ func TestMaybeConfigureOpenNoShellAliasRecommendsConfiguredAliasWithoutPrompt(t 
 	t.Setenv("HOME", homeDir)
 	result := common.OpenResult{Tenant: "frs", Environment: "local", Title: "frs-local"}
 	startupPath := filepath.Join(homeDir, ".zshrc")
-	if err := os.WriteFile(startupPath, []byte(`alias frs-local='eval "$(erun open frs local --no-shell)"'`+"\n"), 0o644); err != nil {
-		t.Fatalf("write startup file: %v", err)
-	}
+	requireNoError(t, os.WriteFile(startupPath, []byte(`alias frs-local='eval "$(erun open frs local --no-shell)"'`+"\n"), 0o644), "write startup file")
 	stderr := new(bytes.Buffer)
 
 	err := maybeConfigureOpenNoShellAlias(result, func(prompt promptui.Prompt) (string, error) {
@@ -1015,9 +997,7 @@ func TestOpenCommandDryRunPrintsResolvedOpenTraceWithoutLaunchingShell(t *testin
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"-v", "open", "tenant-a", "dev", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := stdout.String(); got != "" {
 		t.Fatalf("did not expect stdout output during dry-run, got %q", got)
@@ -1040,25 +1020,13 @@ func TestOpenCommandDryRunPrintsDeployPlanWhenDevopsRuntimeIsMissing(t *testing.
 
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
-	if err := os.WriteFile(filepath.Join(chartPath, "values.dev.yaml"), nil, 0o644); err != nil {
-		t.Fatalf("write values.dev.yaml: %v", err)
-	}
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "values.dev.yaml"), nil, 0o644), "write values.dev.yaml")
 	workdir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write local VERSION: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("1.1.0\n"), 0o644), "write local VERSION")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
@@ -1097,9 +1065,7 @@ func TestOpenCommandDryRunPrintsDeployPlanWhenDevopsRuntimeIsMissing(t *testing.
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"-v", "open", "tenant-a", "dev", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	for _, want := range []string{
@@ -1120,28 +1086,14 @@ func TestOpenCommandDryRunRedeploysWhenRuntimeHasLocalBuilds(t *testing.T) {
 	componentName := "tenant-a-devops"
 	componentRoot := filepath.Join(projectRoot, componentName)
 	chartPath := filepath.Join(componentRoot, "k8s", componentName)
-	if err := os.MkdirAll(chartPath, 0o755); err != nil {
-		t.Fatalf("mkdir chart dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: "+componentName+"\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write Chart.yaml: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644); err != nil {
-		t.Fatalf("write values.local.yaml: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(chartPath, 0o755), "mkdir chart dir")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: "+componentName+"\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644), "write Chart.yaml")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644), "write values.local.yaml")
 	workdir := filepath.Join(componentRoot, "docker", componentName)
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentRoot, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(componentRoot, "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
@@ -1174,9 +1126,7 @@ func TestOpenCommandDryRunRedeploysWhenRuntimeHasLocalBuilds(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"-v", "open", "tenant-a", "local", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	for _, want := range []string{
@@ -1227,9 +1177,7 @@ func TestOpenCommandPersistsSnapshotPreferenceForLocalEnvironment(t *testing.T) 
 	})
 	cmd.SetArgs([]string{"open", "tenant-a", common.DefaultEnvironment, "--snapshot=false"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	envConfig, _, err := common.LoadEnvConfig("tenant-a", common.DefaultEnvironment)
 	if err != nil {
@@ -1248,28 +1196,14 @@ func TestOpenCommandDryRunUsesConfiguredContextForLocalDeploy(t *testing.T) {
 	componentName := "erun-devops"
 	componentRoot := filepath.Join(projectRoot, componentName)
 	chartPath := filepath.Join(componentRoot, "k8s", componentName)
-	if err := os.MkdirAll(chartPath, 0o755); err != nil {
-		t.Fatalf("mkdir chart dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: "+componentName+"\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write Chart.yaml: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644); err != nil {
-		t.Fatalf("write values.local.yaml: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(chartPath, 0o755), "mkdir chart dir")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: "+componentName+"\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644), "write Chart.yaml")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644), "write values.local.yaml")
 	workdir := filepath.Join(componentRoot, "docker", componentName)
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentRoot, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(componentRoot, "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "erun",
 		ProjectRoot:        projectRoot,
@@ -1308,9 +1242,7 @@ func TestOpenCommandDryRunUsesConfiguredContextForLocalDeploy(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"-v", "open", "erun", common.DefaultEnvironment, "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	for _, want := range []string{
@@ -1334,28 +1266,14 @@ func TestOpenCommandUsesPersistedSnapshotPreferenceForLocalEnvironment(t *testin
 	componentName := "tenant-a-devops"
 	componentRoot := filepath.Join(projectRoot, componentName)
 	chartPath := filepath.Join(componentRoot, "k8s", componentName)
-	if err := os.MkdirAll(chartPath, 0o755); err != nil {
-		t.Fatalf("mkdir chart dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: "+componentName+"\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write Chart.yaml: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644); err != nil {
-		t.Fatalf("write values.local.yaml: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(chartPath, 0o755), "mkdir chart dir")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: "+componentName+"\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644), "write Chart.yaml")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644), "write values.local.yaml")
 	workdir := filepath.Join(componentRoot, "docker", componentName)
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatalf("mkdir docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentRoot, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write module VERSION: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(componentRoot, "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 	snapshot := false
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
@@ -1398,9 +1316,7 @@ func TestOpenCommandUsesPersistedSnapshotPreferenceForLocalEnvironment(t *testin
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"-v", "open", "tenant-a", common.DefaultEnvironment, "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if !checkedDeployment {
 		t.Fatal("expected deployment existence check when snapshot preference is disabled")
 	}
@@ -1450,9 +1366,7 @@ func TestOpenCommandDryRunFallsBackToDefaultRuntimeChartWhenTenantRepoHasNoDevop
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"open", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	if strings.Contains(output, "docker build -t") || strings.Contains(output, "docker push ") {
@@ -1507,9 +1421,7 @@ func TestOpenCommandPromptsToCreateMissingRuntimeChartAndUsesCreatedChart(t *tes
 	})
 	cmd.SetArgs([]string{"open"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	chartPath := filepath.Join(repoPath, "frs-devops", "k8s", "frs-devops")
 	if deployed.ChartPath != chartPath {
@@ -1558,9 +1470,7 @@ func TestOpenCommandSkipsLocalRuntimeChartPromptForRemoteRepo(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"open"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if launched.Dir != "/home/erun/git/erun" || launched.Title != "erun-local" {
 		t.Fatalf("unexpected shell launch: %+v", launched)
 	}
@@ -1572,9 +1482,7 @@ func TestOpenCommandSkipsLocalRuntimeChartPromptForRemoteRepo(t *testing.T) {
 func TestOpenCommandRunsManagedDeployAndReattachesWhenShellRequestsHandoff(t *testing.T) {
 	projectRoot := t.TempDir()
 	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
-	if err := os.WriteFile(filepath.Join(chartPath, "values.dev.yaml"), nil, 0o644); err != nil {
-		t.Fatalf("write values.dev.yaml: %v", err)
-	}
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "values.dev.yaml"), nil, 0o644), "write values.dev.yaml")
 
 	launchCalls := 0
 	deployed := common.HelmDeployParams{}
@@ -1603,9 +1511,7 @@ func TestOpenCommandRunsManagedDeployAndReattachesWhenShellRequestsHandoff(t *te
 	})
 	cmd.SetArgs([]string{"open", "tenant-a", "dev"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if launchCalls != 2 {
 		t.Fatalf("expected shell to relaunch after handoff, got %d launches", launchCalls)
 	}
@@ -1629,9 +1535,7 @@ func TestOpenCommandLaunchesShellWithDefaults(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"open"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if launched.Dir != repoPath || launched.Title != "tenant-a-local" {
 		t.Fatalf("unexpected shell launch: %+v", launched)
 	}
@@ -1655,9 +1559,7 @@ func TestOpenCommandLaunchesShellWithDefaultTenantAndRequestedEnvironment(t *tes
 	})
 	cmd.SetArgs([]string{"open", "dev"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if launched.Dir != repoPath || launched.Title != "tenant-a-dev" {
 		t.Fatalf("unexpected shell launch: %+v", launched)
 	}
@@ -1670,9 +1572,7 @@ func TestOpenCommandRunsInitWhenKubernetesContextIsMissing(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
 	projectRoot := t.TempDir()
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -1715,9 +1615,7 @@ func TestOpenCommandRunsInitWhenKubernetesContextIsMissing(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"open", "tenant-a", "dev"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	envConfig, _, err := common.LoadEnvConfig("tenant-a", "dev")
 	if err != nil {
@@ -1773,9 +1671,7 @@ func TestOpenCommandRunsInitWhenEnvironmentIsMissing(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"open", "tenant-a", "dev"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	envConfig, _, err := common.LoadEnvConfig("tenant-a", "dev")
 	if err != nil {
@@ -1789,15 +1685,9 @@ func TestOpenCommandRunsInitWhenEnvironmentIsMissing(t *testing.T) {
 func TestOpenCommandDeploysDevopsWhenMissing(t *testing.T) {
 	repoPath := t.TempDir()
 	chartPath := filepath.Join(repoPath, "erun-devops", "k8s", "erun-devops")
-	if err := os.MkdirAll(chartPath, 0o755); err != nil {
-		t.Fatalf("mkdir chart path: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: erun-devops\n"), 0o644); err != nil {
-		t.Fatalf("write Chart.yaml: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(chartPath, "values.dev.yaml"), nil, 0o644); err != nil {
-		t.Fatalf("write values.dev.yaml: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(chartPath, 0o755), "mkdir chart path")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: erun-devops\n"), 0o644), "write Chart.yaml")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "values.dev.yaml"), nil, 0o644), "write values.dev.yaml")
 
 	launched := common.ShellLaunchParams{}
 	deployed := common.HelmDeployParams{}
@@ -1820,9 +1710,7 @@ func TestOpenCommandDeploysDevopsWhenMissing(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"open", "tenant-a", "dev"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if deployed.ReleaseName != "tenant-a-devops" || deployed.ChartPath != chartPath {
 		t.Fatalf("unexpected deploy request: %+v", deployed)

--- a/erun-cli/cmd/open_test.go
+++ b/erun-cli/cmd/open_test.go
@@ -1275,21 +1275,17 @@ func TestOpenCommandUsesPersistedSnapshotPreferenceForLocalEnvironment(t *testin
 	requireNoError(t, os.WriteFile(filepath.Join(componentRoot, "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
 	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
 	snapshot := false
-	if err := common.SaveTenantConfig(common.TenantConfig{
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
 		DefaultEnvironment: common.DefaultEnvironment,
-	}); err != nil {
-		t.Fatalf("save tenant config: %v", err)
-	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{
+	}), "save tenant config")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{
 		Name:              common.DefaultEnvironment,
 		RepoPath:          projectRoot,
 		KubernetesContext: "cluster-local",
 		Snapshot:          &snapshot,
-	}); err != nil {
-		t.Fatalf("save env config: %v", err)
-	}
+	}), "save env config")
 
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
@@ -1298,9 +1294,7 @@ func TestOpenCommandUsesPersistedSnapshotPreferenceForLocalEnvironment(t *testin
 		Store: common.ConfigStore{},
 		CheckKubernetesDeployment: func(req common.KubernetesDeploymentCheckParams) (bool, error) {
 			checkedDeployment = true
-			if req.Name != "tenant-a-devops" || req.Namespace != "tenant-a-local" || req.KubernetesContext != "cluster-local" {
-				t.Fatalf("unexpected deployment check: %+v", req)
-			}
+			requireDeploymentCheckTarget(t, req, "tenant-a-devops", "tenant-a-local", "cluster-local")
 			return true, nil
 		},
 		DeployHelmChart: func(req common.HelmDeployParams) error {
@@ -1694,9 +1688,7 @@ func TestOpenCommandDeploysDevopsWhenMissing(t *testing.T) {
 	cmd := newTestRootCmd(testRootDeps{
 		Store: openCommandStore{repoPath: repoPath},
 		CheckKubernetesDeployment: func(req common.KubernetesDeploymentCheckParams) (bool, error) {
-			if req.Name != "tenant-a-devops" || req.Namespace != "tenant-a-dev" || req.KubernetesContext != "cluster-dev" {
-				t.Fatalf("unexpected deployment check: %+v", req)
-			}
+			requireDeploymentCheckTarget(t, req, "tenant-a-devops", "tenant-a-dev", "cluster-dev")
 			return false, nil
 		},
 		DeployHelmChart: func(req common.HelmDeployParams) error {
@@ -1723,6 +1715,13 @@ func TestOpenCommandDeploysDevopsWhenMissing(t *testing.T) {
 	}
 	if launched.Namespace != "tenant-a-dev" || launched.KubernetesContext != "cluster-dev" {
 		t.Fatalf("unexpected shell launch: %+v", launched)
+	}
+}
+
+func requireDeploymentCheckTarget(t *testing.T, req common.KubernetesDeploymentCheckParams, name, namespace, kubernetesContext string) {
+	t.Helper()
+	if req.Name != name || req.Namespace != namespace || req.KubernetesContext != kubernetesContext {
+		t.Fatalf("unexpected deployment check: %+v", req)
 	}
 }
 

--- a/erun-cli/cmd/release_test.go
+++ b/erun-cli/cmd/release_test.go
@@ -14,9 +14,7 @@ import (
 
 func TestReleaseCommandDryRun(t *testing.T) {
 	projectRoot := createReleaseGitRepo(t, "develop")
-	if err := common.SaveProjectConfig(projectRoot, common.ProjectConfig{}); err != nil {
-		t.Fatalf("SaveProjectConfig failed: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, common.ProjectConfig{}), "SaveProjectConfig failed")
 
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
@@ -33,9 +31,7 @@ func TestReleaseCommandDryRun(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"release", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := strings.TrimSpace(stdout.String()); !strings.HasPrefix(got, "1.4.2-rc.") {
 		t.Fatalf("unexpected stdout: %q", got)
@@ -69,9 +65,7 @@ func TestReleaseCommandDryRun(t *testing.T) {
 func TestReleaseCommandDryRunStableIncludesSyncAndPush(t *testing.T) {
 	projectRoot := createReleaseGitRepo(t, "main")
 	runGitCommand(t, projectRoot, "branch", "develop")
-	if err := common.SaveProjectConfig(projectRoot, common.ProjectConfig{}); err != nil {
-		t.Fatalf("SaveProjectConfig failed: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, common.ProjectConfig{}), "SaveProjectConfig failed")
 
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
@@ -88,9 +82,7 @@ func TestReleaseCommandDryRunStableIncludesSyncAndPush(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"release", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := strings.TrimSpace(stdout.String()); got != "1.4.2" {
 		t.Fatalf("unexpected stdout: %q", got)
@@ -116,9 +108,7 @@ func TestReleaseCommandDryRunStableIncludesSyncAndPush(t *testing.T) {
 
 func TestReleaseCommandDryRunStableWithoutDevelopOnlyPushesMain(t *testing.T) {
 	projectRoot := createReleaseGitRepo(t, "main")
-	if err := common.SaveProjectConfig(projectRoot, common.ProjectConfig{}); err != nil {
-		t.Fatalf("SaveProjectConfig failed: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, common.ProjectConfig{}), "SaveProjectConfig failed")
 
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
@@ -135,9 +125,7 @@ func TestReleaseCommandDryRunStableWithoutDevelopOnlyPushesMain(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"release", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := strings.TrimSpace(stdout.String()); got != "1.4.2" {
 		t.Fatalf("unexpected stdout: %q", got)
@@ -171,9 +159,7 @@ func TestReleaseCommandDryRunForceIncludesTagDeletionForStaleReleaseTag(t *testi
 	runGitCommand(t, projectRoot, "push", "-u", "origin", "main")
 	runGitCommand(t, projectRoot, "tag", "-a", "v1.4.2", "-m", "Release 1.4.2")
 	runGitCommand(t, projectRoot, "push", "origin", "v1.4.2")
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "README.tmp"), []byte("change\n"), 0o644); err != nil {
-		t.Fatalf("write temp change: %v", err)
-	}
+	requireNoError(t, os.WriteFile(filepath.Join(projectRoot, "erun-devops", "README.tmp"), []byte("change\n"), 0o644), "write temp change")
 	runGitCommand(t, projectRoot, "add", "erun-devops/README.tmp")
 	runGitCommand(t, projectRoot, "commit", "-m", "advance head")
 	runGitCommand(t, projectRoot, "push", "origin", "main")
@@ -193,9 +179,7 @@ func TestReleaseCommandDryRunForceIncludesTagDeletionForStaleReleaseTag(t *testi
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"release", "--dry-run", "--force"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	for _, want := range []string{
@@ -211,9 +195,7 @@ func TestReleaseCommandDryRunForceIncludesTagDeletionForStaleReleaseTag(t *testi
 
 func TestReleaseCommandWritesOnlyVersionToStdoutDuringExecution(t *testing.T) {
 	projectRoot := createReleaseGitRepo(t, "develop")
-	if err := common.SaveProjectConfig(projectRoot, common.ProjectConfig{}); err != nil {
-		t.Fatalf("SaveProjectConfig failed: %v", err)
-	}
+	requireNoError(t, common.SaveProjectConfig(projectRoot, common.ProjectConfig{}), "SaveProjectConfig failed")
 	runGitCommand(t, projectRoot, "add", ".erun/config.yaml")
 	runGitCommand(t, projectRoot, "commit", "-m", "save config")
 
@@ -237,9 +219,7 @@ func TestReleaseCommandWritesOnlyVersionToStdoutDuringExecution(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"release"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := strings.TrimSpace(stdout.String()); !strings.HasPrefix(got, "1.4.2-rc.") || strings.Contains(got, "git-stdout") {
 		t.Fatalf("unexpected stdout: %q", got)
@@ -252,15 +232,9 @@ func TestReleaseCommandWritesOnlyVersionToStdoutDuringExecution(t *testing.T) {
 func TestReleaseCommandDryRunIncludesLinuxReleaseScripts(t *testing.T) {
 	projectRoot := createReleaseGitRepo(t, "develop")
 	linuxComponentDir := filepath.Join(projectRoot, "erun-devops", "linux", "erun-cli")
-	if err := os.MkdirAll(linuxComponentDir, 0o755); err != nil {
-		t.Fatalf("mkdir linux component dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(linuxComponentDir, "release.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write release.sh: %v", err)
-	}
-	if err := common.SaveProjectConfig(projectRoot, common.ProjectConfig{}); err != nil {
-		t.Fatalf("SaveProjectConfig failed: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(linuxComponentDir, 0o755), "mkdir linux component dir")
+	requireNoError(t, os.WriteFile(filepath.Join(linuxComponentDir, "release.sh"), []byte("#!/bin/sh\n"), 0o755), "write release.sh")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, common.ProjectConfig{}), "SaveProjectConfig failed")
 
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
@@ -277,9 +251,7 @@ func TestReleaseCommandDryRunIncludesLinuxReleaseScripts(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"release", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := stderr.String()
 	if common.LinuxPackageBuildsSupported() {
@@ -305,21 +277,11 @@ func createReleaseGitRepo(t *testing.T, branch string) string {
 			t.Fatalf("mkdir %s: %v", dir, err)
 		}
 	}
-	if err := os.WriteFile(filepath.Join(releaseRoot, "VERSION"), []byte("1.4.2\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(releaseRoot, "k8s", "api", "Chart.yaml"), []byte("apiVersion: v2\nname: api\nversion: 0.1.0\nappVersion: 0.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write Chart.yaml: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(releaseRoot, "docker", "api", "Dockerfile"), []byte("FROM alpine:3.22\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(releaseRoot, "docker", "base", "Dockerfile"), []byte("FROM alpine:3.22\n"), 0o644); err != nil {
-		t.Fatalf("write other Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(releaseRoot, "docker", "base", "VERSION"), []byte("9.9.9\n"), 0o644); err != nil {
-		t.Fatalf("write other VERSION: %v", err)
-	}
+	requireNoError(t, os.WriteFile(filepath.Join(releaseRoot, "VERSION"), []byte("1.4.2\n"), 0o644), "write VERSION")
+	requireNoError(t, os.WriteFile(filepath.Join(releaseRoot, "k8s", "api", "Chart.yaml"), []byte("apiVersion: v2\nname: api\nversion: 0.1.0\nappVersion: 0.1.0\n"), 0o644), "write Chart.yaml")
+	requireNoError(t, os.WriteFile(filepath.Join(releaseRoot, "docker", "api", "Dockerfile"), []byte("FROM alpine:3.22\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(releaseRoot, "docker", "base", "Dockerfile"), []byte("FROM alpine:3.22\n"), 0o644), "write other Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(releaseRoot, "docker", "base", "VERSION"), []byte("9.9.9\n"), 0o644), "write other VERSION")
 
 	runGitCommand(t, projectRoot, "init", "-b", branch)
 	runGitCommand(t, projectRoot, "config", "user.email", "codex@example.com")

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -25,122 +25,192 @@ func runSelect(prompt promptui.Select) (int, string, error) {
 }
 
 func Execute() error {
+	deps := newRootDependencies()
+	return deps.rootCommand().Execute()
+}
+
+type rootDependencies struct {
+	configStore               common.ConfigStore
+	store                     rootStore
+	deployHelmChart           common.HelmChartDeployerFunc
+	recoveringDeployHelmChart common.HelmChartDeployerFunc
+	runInit                   func(common.Context, common.BootstrapInitParams) error
+	runInitForArgs            func(common.Context, []string) error
+	runInitForOpen            func(common.Context, common.OpenParams) error
+	push                      common.DockerPushFunc
+	resolveOpen               func(common.OpenParams) (common.OpenResult, error)
+	resolveRuntimeDeploySpec  func(common.OpenResult) (common.DeploySpec, error)
+	activateMCP               MCPForwarder
+	activateSSHD              SSHDActivator
+	runManagedDeploy          func(common.Context, common.OpenResult) error
+}
+
+func newRootDependencies() rootDependencies {
 	configStore := common.ConfigStore{}
 	store := rootStore(configStore)
 	deployHelmChart := common.WrapHelmChartDeployerWithNamespaceEnsure(ensureKubernetesNamespace, common.DeployHelmChart)
 	recoveringDeployHelmChart := wrapHelmDeployWithReleaseRecovery(runPrompt, deployHelmChart, common.ClearHelmReleasePendingOperation)
 	runInit := newRunInit(store, common.FindProjectRoot, runPrompt, runSelect, listKubernetesContexts, ensureKubernetesNamespace, common.WaitForShellDeployment, common.RunRemoteCommand, recoveringDeployHelmChart)
-	runInitForArgs := newRunInitForArgs(store, runInit)
-	runInitForOpen := newRunInitForOpen(store, runInit)
-	push := newPushOperation(nil, common.DockerRegistryLogin, runSelect)
-	resolveOpen := func(params common.OpenParams) (common.OpenResult, error) {
-		return common.ResolveOpen(store, params)
+	deps := rootDependencies{
+		configStore:               configStore,
+		store:                     store,
+		deployHelmChart:           deployHelmChart,
+		recoveringDeployHelmChart: recoveringDeployHelmChart,
+		runInit:                   runInit,
+		runInitForArgs:            newRunInitForArgs(store, runInit),
+		runInitForOpen:            newRunInitForOpen(store, runInit),
+		push:                      newPushOperation(nil, common.DockerRegistryLogin, runSelect),
+		activateMCP:               newMCPForwarder(),
+		activateSSHD:              newSSHDActivator(common.RunRemoteCommand),
 	}
-	resolveRuntimeDeploySpec := func(target common.OpenResult) (common.DeploySpec, error) {
-		return resolveRuntimeDeploySpecForOpen(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, currentBuildInfo(), target)
-	}
-	activateMCP := newMCPForwarder()
-	activateSSHD := newSSHDActivator(common.RunRemoteCommand)
-	runManagedDeploy := func(ctx common.Context, target common.OpenResult) error {
-		ctx = withCloudContextPreflight(ctx, store)
-		specs, err := common.ResolveCurrentDeploySpecs(
-			store,
-			common.FindProjectRoot,
-			common.ResolveDockerBuildContext,
-			common.ResolveKubernetesDeployContext,
-			time.Now,
-			common.DeployTarget{
-				Tenant:      target.Tenant,
-				Environment: target.Environment,
-				RepoPath:    target.RepoPath,
-			},
-		)
-		if err != nil {
-			return err
-		}
-		return common.RunDeploySpecs(ctx, specs, common.DockerImageBuilder, push, recoveringDeployHelmChart)
-	}
+	deps.resolveOpen = deps.resolveOpenResult
+	deps.resolveRuntimeDeploySpec = deps.resolveRuntimeDeploySpecForOpenTarget
+	deps.runManagedDeploy = deps.runManagedDeployForOpen
+	return deps
+}
 
-	initCmd := newInitCmd(runInit)
-	openCmd := newOpenCmd(
-		func(ctx common.Context) common.Context {
-			return withCloudContextPreflight(ctx, store)
+func (d rootDependencies) resolveOpenResult(params common.OpenParams) (common.OpenResult, error) {
+	return common.ResolveOpen(d.store, params)
+}
+
+func (d rootDependencies) resolveRuntimeDeploySpecForOpenTarget(target common.OpenResult) (common.DeploySpec, error) {
+	return resolveRuntimeDeploySpecForOpen(d.store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, currentBuildInfo(), target)
+}
+
+func (d rootDependencies) runManagedDeployForOpen(ctx common.Context, target common.OpenResult) error {
+	ctx = withCloudContextPreflight(ctx, d.store)
+	specs, err := common.ResolveCurrentDeploySpecs(
+		d.store,
+		common.FindProjectRoot,
+		common.ResolveDockerBuildContext,
+		common.ResolveKubernetesDeployContext,
+		time.Now,
+		common.DeployTarget{
+			Tenant:      target.Tenant,
+			Environment: target.Environment,
+			RepoPath:    target.RepoPath,
 		},
-		resolveOpen,
-		store.SaveEnvConfig,
-		runInitForOpen,
+	)
+	if err != nil {
+		return err
+	}
+	return common.RunDeploySpecs(ctx, specs, common.DockerImageBuilder, d.push, d.recoveringDeployHelmChart)
+}
+
+func (d rootDependencies) rootCommand() *cobra.Command {
+	cmd := newRootCommand(d.runRoot)
+	addCommands(cmd, d.commands()...)
+	return cmd
+}
+
+func (d rootDependencies) commands() []*cobra.Command {
+	containerCmd := d.containerCommand()
+	k8sCmd := d.k8sCommand()
+	devopsCmd := newCommandGroup("devops", "DevOps utilities", containerCmd, k8sCmd)
+	return []*cobra.Command{
+		newInitCmd(d.runInit),
+		d.openCommand(),
+		d.sshdCommand(),
+		devopsCmd,
+		d.optionalBuildCommand(),
+		d.optionalPushCommand(),
+		d.optionalDeployCommand(),
+		newMCPCmd(d.resolveOpen, d.runInitForArgs, launchMCPProcess),
+		newAppCmd(launchAppProcess),
+		newExecCmd(common.FindProjectRoot, common.GitCommandRunner, nil),
+		newCloudCmd(d.configStore, runPrompt, runSelect, common.CloudDependencies{}),
+		newContextCmd(d.configStore, runPrompt, runSelect, common.CloudContextDependencies{}),
+		newListCmd(d.configStore, common.FindProjectRoot),
+		newDoctorCmd(d.resolveOpen, runPrompt),
+		newDeleteCmd(d.configStore, runPrompt, common.DeleteKubernetesNamespace),
+		newIdleCmd(d.configStore),
+		newReleaseCmd(common.FindProjectRoot, common.GitCommandRunner),
+		newVersionCmd(func() (common.BuildInfo, string, error) {
+			return resolveVersionCommandBuildInfo(common.FindProjectRoot)
+		}, common.ResolveDefaultRuntimeRegistryVersions),
+		newActivityCmd(d.configStore),
+	}
+}
+
+func (d rootDependencies) openCommand() *cobra.Command {
+	return newOpenCmd(
+		func(ctx common.Context) common.Context {
+			return withCloudContextPreflight(ctx, d.store)
+		},
+		d.resolveOpen,
+		d.store.SaveEnvConfig,
+		d.runInitForOpen,
 		runPrompt,
 		newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell),
-		runManagedDeploy,
+		d.runManagedDeploy,
 		common.CheckKubernetesDeployment,
-		resolveRuntimeDeploySpec,
-		deployHelmChart,
-		activateMCP,
-		activateSSHD,
+		d.resolveRuntimeDeploySpec,
+		d.deployHelmChart,
+		d.activateMCP,
+		d.activateSSHD,
 		launchVSCode,
 		launchIntelliJ,
 	)
-	sshdCmd := newSSHDCmd(func(ctx common.Context) common.Context {
-		return withCloudContextPreflight(ctx, store)
-	}, resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, recoveringDeployHelmChart, common.RunRemoteCommand, writeLocalSSHConfig)
-	containerCmd := newCommandGroup(
+}
+
+func (d rootDependencies) sshdCommand() *cobra.Command {
+	return newSSHDCmd(func(ctx common.Context) common.Context {
+		return withCloudContextPreflight(ctx, d.store)
+	}, d.resolveOpen, d.store.SaveEnvConfig, d.runInitForOpen, d.resolveRuntimeDeploySpec, d.recoveringDeployHelmChart, common.RunRemoteCommand, writeLocalSSHConfig)
+}
+
+func (d rootDependencies) containerCommand() *cobra.Command {
+	return newCommandGroup(
 		"container",
 		"Container utilities",
-		newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, common.DockerRegistryLogin, runSelect, push, recoveringDeployHelmChart),
-		newPushCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.DockerImageBuilder, push),
+		newBuildCmd(d.store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, common.DockerRegistryLogin, runSelect, d.push, d.recoveringDeployHelmChart),
+		newPushCmd(d.store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.DockerImageBuilder, d.push),
 	)
-	k8sCmd := newCommandGroup(
+}
+
+func (d rootDependencies) k8sCommand() *cobra.Command {
+	return newCommandGroup(
 		"k8s",
 		"Kubernetes utilities",
-		newK8sDeployCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.DockerImageBuilder, push, recoveringDeployHelmChart),
+		newK8sDeployCmd(d.store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.DockerImageBuilder, d.push, d.recoveringDeployHelmChart),
 	)
-	devopsCmd := newCommandGroup("devops", "DevOps utilities", containerCmd, k8sCmd)
+}
 
-	var buildCmd *cobra.Command
-	if hasOptionalBuildCmd(common.FindProjectRoot, common.ResolveDockerBuildContext) {
-		buildCmd = newBuildCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, common.DockerRegistryLogin, runSelect, push, recoveringDeployHelmChart)
-		buildCmd.Short = optionalBuildCmdShort(common.FindProjectRoot, common.ResolveDockerBuildContext)
+func (d rootDependencies) optionalBuildCommand() *cobra.Command {
+	if !hasOptionalBuildCmd(common.FindProjectRoot, common.ResolveDockerBuildContext) {
+		return nil
 	}
-	var pushCmd *cobra.Command
-	if hasOptionalPushCmd(common.FindProjectRoot, common.ResolveDockerBuildContext) {
-		pushCmd = newPushCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.DockerImageBuilder, push)
-		pushCmd.Short = optionalPushCmdShort(common.FindProjectRoot, common.ResolveDockerBuildContext)
-	}
-	var deployCmd *cobra.Command
-	if hasOptionalDeployCmd(common.ResolveKubernetesDeployContext) {
-		deployCmd = newDeployCmd(store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.DockerImageBuilder, push, recoveringDeployHelmChart)
-	}
+	buildCmd := newBuildCmd(d.store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, common.DockerRegistryLogin, runSelect, d.push, d.recoveringDeployHelmChart)
+	buildCmd.Short = optionalBuildCmdShort(common.FindProjectRoot, common.ResolveDockerBuildContext)
+	return buildCmd
+}
 
-	mcpCmd := newMCPCmd(resolveOpen, runInitForArgs, launchMCPProcess)
-	appCmd := newAppCmd(launchAppProcess)
-	execCmd := newExecCmd(common.FindProjectRoot, common.GitCommandRunner, nil)
-	cloudCmd := newCloudCmd(configStore, runPrompt, runSelect, common.CloudDependencies{})
-	contextCmd := newContextCmd(configStore, runPrompt, runSelect, common.CloudContextDependencies{})
-	listCmd := newListCmd(configStore, common.FindProjectRoot)
-	doctorCmd := newDoctorCmd(resolveOpen, runPrompt)
-	deleteCmd := newDeleteCmd(configStore, runPrompt, common.DeleteKubernetesNamespace)
-	idleCmd := newIdleCmd(configStore)
-	releaseCmd := newReleaseCmd(common.FindProjectRoot, common.GitCommandRunner)
-	versionCmd := newVersionCmd(func() (common.BuildInfo, string, error) {
-		return resolveVersionCommandBuildInfo(common.FindProjectRoot)
-	}, common.ResolveDefaultRuntimeRegistryVersions)
-	activityCmd := newActivityCmd(configStore)
-
-	runRoot := func(cmd *cobra.Command, args []string) error {
-		ctx := withCloudContextPreflight(commandContext(cmd), store)
-		result, initRan, err := resolveOpenWithInitStop(ctx, args, shouldInitRootCommand, resolveOpen, runInitForArgs)
-		if err != nil {
-			return err
-		}
-		if initRan {
-			return nil
-		}
-		return runResolvedOpenCommand(ctx, result, openOptions{}, runPrompt, newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell), runManagedDeploy, common.CheckKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart, activateMCP, activateSSHD, launchVSCode, launchIntelliJ)
+func (d rootDependencies) optionalPushCommand() *cobra.Command {
+	if !hasOptionalPushCmd(common.FindProjectRoot, common.ResolveDockerBuildContext) {
+		return nil
 	}
+	pushCmd := newPushCmd(d.store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.DockerImageBuilder, d.push)
+	pushCmd.Short = optionalPushCmdShort(common.FindProjectRoot, common.ResolveDockerBuildContext)
+	return pushCmd
+}
 
-	cmd := newRootCommand(runRoot)
-	addCommands(cmd, initCmd, openCmd, sshdCmd, devopsCmd, buildCmd, pushCmd, deployCmd, mcpCmd, appCmd, execCmd, cloudCmd, contextCmd, listCmd, doctorCmd, deleteCmd, idleCmd, releaseCmd, versionCmd, activityCmd)
-	return cmd.Execute()
+func (d rootDependencies) optionalDeployCommand() *cobra.Command {
+	if !hasOptionalDeployCmd(common.ResolveKubernetesDeployContext) {
+		return nil
+	}
+	return newDeployCmd(d.store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, common.DockerImageBuilder, d.push, d.recoveringDeployHelmChart)
+}
+
+func (d rootDependencies) runRoot(cmd *cobra.Command, args []string) error {
+	ctx := withCloudContextPreflight(commandContext(cmd), d.store)
+	result, initRan, err := resolveOpenWithInitStop(ctx, args, shouldInitRootCommand, d.resolveOpen, d.runInitForArgs)
+	if err != nil {
+		return err
+	}
+	if initRan {
+		return nil
+	}
+	return runResolvedOpenCommand(ctx, result, openOptions{}, runPrompt, newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell), d.runManagedDeploy, common.CheckKubernetesDeployment, d.resolveRuntimeDeploySpec, d.deployHelmChart, d.activateMCP, d.activateSSHD, launchVSCode, launchIntelliJ)
 }
 
 func withCloudContextPreflight(ctx common.Context, store any) common.Context {

--- a/erun-cli/cmd/root_runtime.go
+++ b/erun-cli/cmd/root_runtime.go
@@ -177,24 +177,13 @@ func optionalBuildCmdShort(findProjectRoot common.ProjectFinderFunc, resolveBuil
 		return "Build the project"
 	}
 
-	linuxContexts, linuxErr := common.ResolveCurrentLinuxPackageContexts(findProjectRoot, resolveBuildContext, common.DockerCommandTarget{})
-	if linuxErr == nil && len(linuxContexts) > 0 {
+	if hasLinuxPackageContexts(findProjectRoot, resolveBuildContext) {
 		return "Build the project"
 	}
 
 	buildContexts, err := common.ResolveCurrentDockerBuildContexts(findProjectRoot, resolveBuildContext, common.DockerCommandTarget{})
 	if err == nil && len(buildContexts) > 0 {
-		buildContext, buildContextErr := resolveBuildContext()
-		if buildContextErr == nil && strings.TrimSpace(buildContext.DockerfilePath) != "" && len(buildContexts) == 1 {
-			return "Build the container image in the current directory"
-		}
-
-		if projectRoot, projectRootErr := projectRootForHelp(findProjectRoot); projectRootErr == nil &&
-			projectRoot != "" &&
-			filepath.Clean(strings.TrimSpace(buildContext.Dir)) == projectRoot {
-			return "Build and push the project"
-		}
-		return "Build and push the devops container images for the current project"
+		return dockerBuildCmdShort(findProjectRoot, resolveBuildContext, buildContexts)
 	}
 
 	hasScript, err := common.HasProjectBuildScript(findProjectRoot, common.DockerCommandTarget{})
@@ -206,6 +195,27 @@ func optionalBuildCmdShort(findProjectRoot common.ProjectFinderFunc, resolveBuil
 	}
 
 	return "Build the container image in the current directory"
+}
+
+func hasLinuxPackageContexts(findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc) bool {
+	linuxContexts, err := common.ResolveCurrentLinuxPackageContexts(findProjectRoot, resolveBuildContext, common.DockerCommandTarget{})
+	return err == nil && len(linuxContexts) > 0
+}
+
+func dockerBuildCmdShort(findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, buildContexts []common.DockerBuildContext) string {
+	buildContext, err := resolveBuildContext()
+	if err == nil && strings.TrimSpace(buildContext.DockerfilePath) != "" && len(buildContexts) == 1 {
+		return "Build the container image in the current directory"
+	}
+	if currentBuildContextIsProjectRoot(findProjectRoot, buildContext) {
+		return "Build and push the project"
+	}
+	return "Build and push the devops container images for the current project"
+}
+
+func currentBuildContextIsProjectRoot(findProjectRoot common.ProjectFinderFunc, buildContext common.DockerBuildContext) bool {
+	projectRoot, err := projectRootForHelp(findProjectRoot)
+	return err == nil && projectRoot != "" && filepath.Clean(strings.TrimSpace(buildContext.Dir)) == projectRoot
 }
 
 func hasProjectRootBuildScript(findProjectRoot common.ProjectFinderFunc) (bool, error) {
@@ -267,15 +277,23 @@ func hasOptionalDeployCmd(resolveDeployContext common.DeployContextResolverFunc)
 	if strings.TrimSpace(deployContext.ChartPath) != "" {
 		return true
 	}
-	if deployContexts, err := common.ResolveKubernetesDeployContextsAtDir(deployContext.Dir); err == nil && len(deployContexts) > 0 {
+	if hasDeployContextsAtDir(deployContext.Dir) {
 		return true
 	}
 	k8sDir := filepath.Join(strings.TrimSpace(deployContext.Dir), "k8s")
-	if deployContexts, err := common.ResolveKubernetesDeployContextsAtDir(k8sDir); err == nil && len(deployContexts) > 0 {
+	if hasDeployContextsAtDir(k8sDir) {
 		return true
 	}
+	return hasSingleNestedDevopsDeployContext(deployContext.Dir)
+}
 
-	entries, err := os.ReadDir(strings.TrimSpace(deployContext.Dir))
+func hasDeployContextsAtDir(dir string) bool {
+	deployContexts, err := common.ResolveKubernetesDeployContextsAtDir(dir)
+	return err == nil && len(deployContexts) > 0
+}
+
+func hasSingleNestedDevopsDeployContext(dir string) bool {
+	entries, err := os.ReadDir(strings.TrimSpace(dir))
 	if err != nil {
 		return false
 	}
@@ -284,8 +302,8 @@ func hasOptionalDeployCmd(resolveDeployContext common.DeployContextResolverFunc)
 		if !entry.IsDir() || !strings.HasSuffix(entry.Name(), "-devops") {
 			continue
 		}
-		k8sDir := filepath.Join(strings.TrimSpace(deployContext.Dir), entry.Name(), "k8s")
-		if deployContexts, err := common.ResolveKubernetesDeployContextsAtDir(k8sDir); err == nil && len(deployContexts) > 0 {
+		k8sDir := filepath.Join(strings.TrimSpace(dir), entry.Name(), "k8s")
+		if hasDeployContextsAtDir(k8sDir) {
 			if found {
 				return false
 			}

--- a/erun-cli/cmd/root_test.go
+++ b/erun-cli/cmd/root_test.go
@@ -97,9 +97,7 @@ func TestRootCommandRunsInitWhenNoSubcommand(t *testing.T) {
 	cmd.SetErr(buf)
 	cmd.SetArgs([]string{})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := buf.String(); got != "" {
 		t.Fatalf("expected no command output, got %q", got)
@@ -168,12 +166,8 @@ func TestRootCommandRunsOpenWithDefaults(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
 	projectRoot := filepath.Join(t.TempDir(), "project")
-	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
-		t.Fatalf("mkdir project root: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(projectRoot, 0o755), "mkdir project root")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -181,9 +175,7 @@ func TestRootCommandRunsOpenWithDefaults(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "dev", RepoPath: projectRoot, KubernetesContext: "cluster-dev"}); err != nil {
-		t.Fatalf("save env config: %v", err)
-	}
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "dev", RepoPath: projectRoot, KubernetesContext: "cluster-dev"}), "save env config")
 
 	launched := common.ShellLaunchParams{}
 	cmd := newTestRootCmd(testRootDeps{
@@ -205,9 +197,7 @@ func TestRootCommandRunsOpenWithDefaults(t *testing.T) {
 	cmd.SetErr(buf)
 	cmd.SetArgs([]string{})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if launched.Dir != projectRoot || launched.Title != "tenant-a-dev" {
 		t.Fatalf("unexpected shell launch: %+v", launched)
@@ -221,12 +211,8 @@ func TestRootCommandRunsOpenWithDefaultTenantAndRequestedEnvironment(t *testing.
 	setupRootCmdTestConfigHome(t)
 
 	projectRoot := filepath.Join(t.TempDir(), "tenant-a-dev")
-	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
-		t.Fatalf("mkdir project root: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(projectRoot, 0o755), "mkdir project root")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -234,9 +220,7 @@ func TestRootCommandRunsOpenWithDefaultTenantAndRequestedEnvironment(t *testing.
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "dev", RepoPath: projectRoot, KubernetesContext: "cluster-dev"}); err != nil {
-		t.Fatalf("save env config: %v", err)
-	}
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "dev", RepoPath: projectRoot, KubernetesContext: "cluster-dev"}), "save env config")
 
 	launched := common.ShellLaunchParams{}
 	cmd := newTestRootCmd(testRootDeps{
@@ -258,9 +242,7 @@ func TestRootCommandRunsOpenWithDefaultTenantAndRequestedEnvironment(t *testing.
 	cmd.SetErr(buf)
 	cmd.SetArgs([]string{"dev"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if launched.Dir != projectRoot || launched.Title != "tenant-a-dev" {
 		t.Fatalf("unexpected shell launch: %+v", launched)
@@ -274,9 +256,7 @@ func TestRootCommandRunsOpenWithExplicitTenantAndEnvironment(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
 	projectRoot := filepath.Join(t.TempDir(), "dog-me")
-	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
-		t.Fatalf("mkdir project root: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(projectRoot, 0o755), "mkdir project root")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "dog",
 		ProjectRoot:        projectRoot,
@@ -284,9 +264,7 @@ func TestRootCommandRunsOpenWithExplicitTenantAndEnvironment(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveEnvConfig("dog", common.EnvConfig{Name: "me", RepoPath: projectRoot, KubernetesContext: "cluster-me"}); err != nil {
-		t.Fatalf("save env config: %v", err)
-	}
+	requireNoError(t, common.SaveEnvConfig("dog", common.EnvConfig{Name: "me", RepoPath: projectRoot, KubernetesContext: "cluster-me"}), "save env config")
 
 	launched := common.ShellLaunchParams{}
 	cmd := newTestRootCmd(testRootDeps{
@@ -300,9 +278,7 @@ func TestRootCommandRunsOpenWithExplicitTenantAndEnvironment(t *testing.T) {
 	cmd.SetErr(buf)
 	cmd.SetArgs([]string{"dog", "me"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if launched.Dir != projectRoot || launched.Title != "dog-me" {
 		t.Fatalf("unexpected shell launch: %+v", launched)
@@ -316,12 +292,8 @@ func TestRootCommandRunsInitWhenOpenEnvironmentLacksKubernetesContext(t *testing
 	setupRootCmdTestConfigHome(t)
 
 	projectRoot := filepath.Join(t.TempDir(), "tenant-a-dev")
-	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
-		t.Fatalf("mkdir project root: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(projectRoot, 0o755), "mkdir project root")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -367,9 +339,7 @@ func TestRootCommandRunsInitWhenOpenEnvironmentLacksKubernetesContext(t *testing
 	})
 	cmd.SetArgs([]string{})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	envConfig, _, err := common.LoadEnvConfig("tenant-a", "dev")
 	if err != nil {
@@ -405,9 +375,7 @@ func TestInitCommandPreservesExistingTenantDefaultEnvironmentWhenFlagOmitted(t *
 	setupRootCmdTestConfigHome(t)
 
 	projectRoot := filepath.Join(t.TempDir(), "project")
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -415,9 +383,7 @@ func TestInitCommandPreservesExistingTenantDefaultEnvironmentWhenFlagOmitted(t *
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "prod", RepoPath: projectRoot, KubernetesContext: "cluster-prod"}); err != nil {
-		t.Fatalf("save env config: %v", err)
-	}
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "prod", RepoPath: projectRoot, KubernetesContext: "cluster-prod"}), "save env config")
 
 	cmd := newTestRootCmd(testRootDeps{
 		FindProjectRoot: func() (string, string, error) {
@@ -433,9 +399,7 @@ func TestInitCommandPreservesExistingTenantDefaultEnvironmentWhenFlagOmitted(t *
 	cmd.SetErr(buf)
 	cmd.SetArgs([]string{"init", "-y"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := buf.String(); got != "" {
 		t.Fatalf("expected no command output, got %q", got)
@@ -500,9 +464,7 @@ func TestInitCommandDecliningDefaultTenantStillInitializes(t *testing.T) {
 	})
 	cmd.SetArgs([]string{"init", "--tenant", "petios", "--environment", "review"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if _, _, err := common.LoadERunConfig(); !errors.Is(err, common.ErrNotInitialized) {
 		t.Fatalf("expected erun config to remain absent, got %v", err)
@@ -543,9 +505,7 @@ func TestRootCommandHelpFlagPrintsHelp(t *testing.T) {
 	cmd.SetErr(buf)
 	cmd.SetArgs([]string{"--help"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	output := buf.String()
 	for _, want := range []string{"init", "open", "devops", "mcp", "version"} {
@@ -571,12 +531,8 @@ func TestRootCommandDryRunOpensByPlanningWithoutLaunchingShell(t *testing.T) {
 	setupRootCmdTestConfigHome(t)
 
 	projectRoot := filepath.Join(t.TempDir(), "project")
-	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
-		t.Fatalf("mkdir project root: %v", err)
-	}
-	if err := common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}); err != nil {
-		t.Fatalf("save erun config: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(projectRoot, 0o755), "mkdir project root")
+	requireNoError(t, common.SaveERunConfig(common.ERunConfig{DefaultTenant: "tenant-a"}), "save erun config")
 	if err := common.SaveTenantConfig(common.TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
@@ -584,9 +540,7 @@ func TestRootCommandDryRunOpensByPlanningWithoutLaunchingShell(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save tenant config: %v", err)
 	}
-	if err := common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "dev", RepoPath: projectRoot, KubernetesContext: "cluster-dev"}); err != nil {
-		t.Fatalf("save env config: %v", err)
-	}
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{Name: "dev", RepoPath: projectRoot, KubernetesContext: "cluster-dev"}), "save env config")
 
 	cmd := newTestRootCmd(testRootDeps{
 		CheckKubernetesDeployment: func(req common.KubernetesDeploymentCheckParams) (bool, error) {
@@ -603,9 +557,7 @@ func TestRootCommandDryRunOpensByPlanningWithoutLaunchingShell(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"-v", "--dry-run"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := stdout.String(); got != "" {
 		t.Fatalf("expected no stdout output during dry-run, got %q", got)
@@ -768,9 +720,7 @@ func setupRootCmdTestConfigHome(t *testing.T) {
 
 	dir := t.TempDir()
 	previousValue, hadPreviousValue := os.LookupEnv("XDG_CONFIG_HOME")
-	if err := os.Setenv("XDG_CONFIG_HOME", dir); err != nil {
-		t.Fatalf("set XDG_CONFIG_HOME: %v", err)
-	}
+	requireNoError(t, os.Setenv("XDG_CONFIG_HOME", dir), "set XDG_CONFIG_HOME")
 	xdg.Reload()
 	t.Cleanup(func() {
 		var err error

--- a/erun-cli/cmd/root_test.go
+++ b/erun-cli/cmd/root_test.go
@@ -71,14 +71,7 @@ func TestRootCommandRunsInitWhenNoSubcommand(t *testing.T) {
 		FindProjectRoot: func() (string, string, error) {
 			return "tenant-a", projectRoot, nil
 		},
-		PromptRunner: func(prompt promptui.Prompt) (string, error) {
-			label := fmt.Sprint(prompt.Label)
-			promptLabels = append(promptLabels, label)
-			if label == fmt.Sprintf("Container registry for environment %q in tenant %q", common.DefaultEnvironment, "tenant-a") {
-				return "", nil
-			}
-			return "y", nil
-		},
+		PromptRunner: defaultInitPromptRecorder(&promptLabels),
 		SelectRunner: func(prompt promptui.Select) (int, string, error) {
 			selectLabels = append(selectLabels, fmt.Sprint(prompt.Label))
 			return 0, "cluster-local", nil
@@ -103,63 +96,57 @@ func TestRootCommandRunsInitWhenNoSubcommand(t *testing.T) {
 		t.Fatalf("expected no command output, got %q", got)
 	}
 
-	erunConfig, _, err := common.LoadERunConfig()
-	if err != nil {
-		t.Fatalf("LoadERunConfig failed: %v", err)
-	}
-	if erunConfig.DefaultTenant != "tenant-a" {
-		t.Fatalf("unexpected default tenant: %+v", erunConfig)
-	}
-
-	tenantConfig, _, err := common.LoadTenantConfig("tenant-a")
-	if err != nil {
-		t.Fatalf("LoadTenantConfig failed: %v", err)
-	}
-	if tenantConfig.ProjectRoot != projectRoot || tenantConfig.DefaultEnvironment != common.DefaultEnvironment {
-		t.Fatalf("unexpected tenant config: %+v", tenantConfig)
-	}
-
-	envConfig, _, err := common.LoadEnvConfig("tenant-a", common.DefaultEnvironment)
-	if err != nil {
-		t.Fatalf("LoadEnvConfig failed: %v", err)
-	}
-	if envConfig.Name != common.DefaultEnvironment || envConfig.RepoPath != projectRoot {
-		t.Fatalf("unexpected env config: %+v", envConfig)
-	}
-	if envConfig.KubernetesContext != "cluster-local" {
-		t.Fatalf("unexpected kubernetes context: %+v", envConfig)
-	}
-
-	projectConfig, _, err := common.LoadProjectConfig(projectRoot)
-	if err != nil {
-		t.Fatalf("LoadProjectConfig failed: %v", err)
-	}
-	if got := projectConfig.ContainerRegistryForEnvironment(common.DefaultEnvironment); got != common.DefaultContainerRegistry {
-		t.Fatalf("unexpected project config: %+v", projectConfig)
-	}
-	if _, err := os.Stat(filepath.Join(projectRoot, "tenant-a-devops", "docker", "tenant-a-devops", "Dockerfile")); err != nil {
-		t.Fatalf("expected tenant devops module to be created: %v", err)
-	}
+	requireDefaultInitConfig(t, projectRoot)
 
 	wantPromptLabels := []string{
 		fmt.Sprintf("Initialize tenant %q (path: %s) as the default tenant", "tenant-a", projectRoot),
 		fmt.Sprintf("Initialize default environment %q for tenant %q", common.DefaultEnvironment, "tenant-a"),
 		fmt.Sprintf("Container registry for environment %q in tenant %q", common.DefaultEnvironment, "tenant-a"),
 	}
-	if len(promptLabels) != len(wantPromptLabels) {
-		t.Fatalf("unexpected prompts: %+v", promptLabels)
-	}
-	for i := range wantPromptLabels {
-		if promptLabels[i] != wantPromptLabels[i] {
-			t.Fatalf("unexpected prompt %d: got %q want %q", i, promptLabels[i], wantPromptLabels[i])
-		}
-	}
+	requireStringSlicesEqual(t, promptLabels, wantPromptLabels, "unexpected prompts")
 	if len(selectLabels) != 1 || selectLabels[0] != fmt.Sprintf("Kubernetes context for environment %q in tenant %q", common.DefaultEnvironment, "tenant-a") {
 		t.Fatalf("unexpected select prompts: %+v", selectLabels)
 	}
 	if ensuredContext != "cluster-local" || ensuredNamespace != "tenant-a-local" {
 		t.Fatalf("unexpected namespace ensure request: context=%q namespace=%q", ensuredContext, ensuredNamespace)
 	}
+}
+
+func defaultInitPromptRecorder(promptLabels *[]string) PromptRunner {
+	return func(prompt promptui.Prompt) (string, error) {
+		label := fmt.Sprint(prompt.Label)
+		*promptLabels = append(*promptLabels, label)
+		if label == fmt.Sprintf("Container registry for environment %q in tenant %q", common.DefaultEnvironment, "tenant-a") {
+			return "", nil
+		}
+		return "y", nil
+	}
+}
+
+func requireDefaultInitConfig(t *testing.T, projectRoot string) {
+	t.Helper()
+	erunConfig, _, err := common.LoadERunConfig()
+	requireNoError(t, err, "LoadERunConfig failed")
+	if erunConfig.DefaultTenant != "tenant-a" {
+		t.Fatalf("unexpected default tenant: %+v", erunConfig)
+	}
+	tenantConfig, _, err := common.LoadTenantConfig("tenant-a")
+	requireNoError(t, err, "LoadTenantConfig failed")
+	if tenantConfig.ProjectRoot != projectRoot || tenantConfig.DefaultEnvironment != common.DefaultEnvironment {
+		t.Fatalf("unexpected tenant config: %+v", tenantConfig)
+	}
+	envConfig, _, err := common.LoadEnvConfig("tenant-a", common.DefaultEnvironment)
+	requireNoError(t, err, "LoadEnvConfig failed")
+	if envConfig.Name != common.DefaultEnvironment || envConfig.RepoPath != projectRoot || envConfig.KubernetesContext != "cluster-local" {
+		t.Fatalf("unexpected env config: %+v", envConfig)
+	}
+	projectConfig, _, err := common.LoadProjectConfig(projectRoot)
+	requireNoError(t, err, "LoadProjectConfig failed")
+	if got := projectConfig.ContainerRegistryForEnvironment(common.DefaultEnvironment); got != common.DefaultContainerRegistry {
+		t.Fatalf("unexpected project config: %+v", projectConfig)
+	}
+	_, err = os.Stat(filepath.Join(projectRoot, "tenant-a-devops", "docker", "tenant-a-devops", "Dockerfile"))
+	requireNoError(t, err, "expected tenant devops module to be created")
 }
 
 func TestRootCommandRunsOpenWithDefaults(t *testing.T) {
@@ -435,30 +422,16 @@ func TestInitCommandDecliningDefaultTenantStillInitializes(t *testing.T) {
 		FindProjectRoot: func() (string, string, error) {
 			return "petios", projectRoot, nil
 		},
-		PromptRunner: func(prompt promptui.Prompt) (string, error) {
-			label := fmt.Sprint(prompt.Label)
-			promptLabels = append(promptLabels, label)
-			if label == fmt.Sprintf("Initialize tenant %q (path: %s) as the default tenant", "petios", projectRoot) {
-				return "n", nil
-			}
-			if prompt.Templates != nil {
-				return "y", nil
-			}
-			return "", nil
-		},
+		PromptRunner: decliningDefaultTenantPromptRecorder(&promptLabels, projectRoot),
 		SelectRunner: func(prompt promptui.Select) (int, string, error) {
-			if fmt.Sprint(prompt.Label) != fmt.Sprintf("Kubernetes context for environment %q in tenant %q", "review", "petios") {
-				t.Fatalf("unexpected select prompt: %+v", prompt)
-			}
+			requireReviewSelectPrompt(t, prompt)
 			return 0, "cluster-review", nil
 		},
 		ListKubernetesContexts: func() ([]string, error) {
 			return []string{"cluster-review"}, nil
 		},
 		EnsureKubernetesNamespace: func(contextName, namespace string) error {
-			if contextName != "cluster-review" || namespace != "petios-review" {
-				t.Fatalf("unexpected namespace ensure request: context=%q namespace=%q", contextName, namespace)
-			}
+			requireNamespaceEnsure(t, contextName, namespace, "cluster-review", "petios-review")
 			return nil
 		},
 	})
@@ -488,13 +461,34 @@ func TestInitCommandDecliningDefaultTenantStillInitializes(t *testing.T) {
 		fmt.Sprintf("Initialize default environment %q for tenant %q", "review", "petios"),
 		fmt.Sprintf("Container registry for environment %q in tenant %q", "review", "petios"),
 	}
-	if len(promptLabels) != len(wantPromptLabels) {
-		t.Fatalf("unexpected prompts: %+v", promptLabels)
-	}
-	for i := range wantPromptLabels {
-		if promptLabels[i] != wantPromptLabels[i] {
-			t.Fatalf("unexpected prompt %d: got %q want %q", i, promptLabels[i], wantPromptLabels[i])
+	requireStringSlicesEqual(t, promptLabels, wantPromptLabels, "unexpected prompts")
+}
+
+func decliningDefaultTenantPromptRecorder(promptLabels *[]string, projectRoot string) PromptRunner {
+	return func(prompt promptui.Prompt) (string, error) {
+		label := fmt.Sprint(prompt.Label)
+		*promptLabels = append(*promptLabels, label)
+		if label == fmt.Sprintf("Initialize tenant %q (path: %s) as the default tenant", "petios", projectRoot) {
+			return "n", nil
 		}
+		if prompt.Templates != nil {
+			return "y", nil
+		}
+		return "", nil
+	}
+}
+
+func requireReviewSelectPrompt(t *testing.T, prompt promptui.Select) {
+	t.Helper()
+	if fmt.Sprint(prompt.Label) != fmt.Sprintf("Kubernetes context for environment %q in tenant %q", "review", "petios") {
+		t.Fatalf("unexpected select prompt: %+v", prompt)
+	}
+}
+
+func requireNamespaceEnsure(t *testing.T, contextName, namespace, wantContext, wantNamespace string) {
+	t.Helper()
+	if contextName != wantContext || namespace != wantNamespace {
+		t.Fatalf("unexpected namespace ensure request: context=%q namespace=%q", contextName, namespace)
 	}
 }
 
@@ -653,25 +647,36 @@ func TestConfirmPromptDefaultAndErrors(t *testing.T) {
 		}
 	}
 
-	if ok, err := confirmPrompt(run("", nil), "label"); err != nil || !ok {
-		t.Fatalf("expected default confirmation, got %v %v", ok, err)
-	}
-
-	if ok, err := confirmPrompt(run("n", nil), "label"); err != nil || ok {
-		t.Fatalf("expected rejection, got %v %v", ok, err)
-	}
-
-	if ok, err := confirmPrompt(run("", promptui.ErrAbort), "label"); err != nil || ok {
-		t.Fatalf("expected abort to be treated as rejection, got %v %v", ok, err)
-	}
-
-	if ok, err := confirmPrompt(run("", promptui.ErrInterrupt), "label"); err == nil || ok {
-		t.Fatalf("expected interrupt error, got %v %v", ok, err)
-	}
-
+	ok, err := confirmPrompt(run("", nil), "label")
+	requireConfirmPromptResult(t, ok, err, true, nil, "expected default confirmation")
+	ok, err = confirmPrompt(run("n", nil), "label")
+	requireConfirmPromptResult(t, ok, err, false, nil, "expected rejection")
+	ok, err = confirmPrompt(run("", promptui.ErrAbort), "label")
+	requireConfirmPromptResult(t, ok, err, false, nil, "expected abort to be treated as rejection")
+	ok, err = confirmPrompt(run("", promptui.ErrInterrupt), "label")
+	requireConfirmPromptAnyError(t, ok, err, false, "expected interrupt error")
 	expectedErr := errors.New("boom")
-	if ok, err := confirmPrompt(run("", expectedErr), "label"); !errors.Is(err, expectedErr) || ok {
-		t.Fatalf("expected original error, got %v %v", ok, err)
+	ok, err = confirmPrompt(run("", expectedErr), "label")
+	requireConfirmPromptResult(t, ok, err, false, expectedErr, "expected original error")
+}
+
+func requireConfirmPromptResult(t *testing.T, ok bool, err error, wantOK bool, wantErr error, context string) {
+	t.Helper()
+	if ok != wantOK {
+		t.Fatalf("%s, got %v %v", context, ok, err)
+	}
+	if wantErr == nil && err != nil {
+		t.Fatalf("%s, got %v %v", context, ok, err)
+	}
+	if wantErr != nil && !errors.Is(err, wantErr) {
+		t.Fatalf("%s, got %v %v", context, ok, err)
+	}
+}
+
+func requireConfirmPromptAnyError(t *testing.T, ok bool, err error, wantOK bool, context string) {
+	t.Helper()
+	if ok != wantOK || err == nil {
+		t.Fatalf("%s, got %v %v", context, ok, err)
 	}
 }
 

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -43,6 +43,13 @@ type testRootDeps struct {
 	Now                            common.NowFunc
 }
 
+func requireNoError(t *testing.T, err error, context string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", context, err)
+	}
+}
+
 func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	store := deps.Store
 	if store == nil {
@@ -272,8 +279,6 @@ func stubKubectlContexts(t *testing.T, contexts []string, current string) {
 		"fi\n" +
 		"echo \"unexpected kubectl invocation: $@\" >&2\n" +
 		"exit 1\n"
-	if err := os.WriteFile(kubectlPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write kubectl stub: %v", err)
-	}
+	requireNoError(t, os.WriteFile(kubectlPath, []byte(script), 0o755), "write kubectl stub")
 	t.Setenv("PATH", kubectlDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -50,93 +50,268 @@ func requireNoError(t *testing.T, err error, context string) {
 	}
 }
 
-func newTestRootCmd(deps testRootDeps) *cobra.Command {
-	store := deps.Store
-	if store == nil {
-		store = rootStore(common.ConfigStore{})
+func requireMkdirAll(t *testing.T, path string, perm os.FileMode, context string) {
+	t.Helper()
+	requireNoError(t, os.MkdirAll(path, perm), context)
+}
+
+func requireWriteFile(t *testing.T, path string, data []byte, perm os.FileMode, context string) {
+	t.Helper()
+	requireNoError(t, os.WriteFile(path, data, perm), context)
+}
+
+func requireStringSlicesEqual(t *testing.T, got, want []string, context string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s: got %v want %v", context, got, want)
 	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s: got %v want %v", context, got, want)
+		}
+	}
+}
+
+func testRootStoreOrDefault(store rootStore) rootStore {
+	if store == nil {
+		return rootStore(common.ConfigStore{})
+	}
+	return store
+}
+
+func testListStoreOrDefault(store rootStore) common.ListStore {
 	listDataStore, ok := any(store).(common.ListStore)
 	if !ok {
-		listDataStore = common.ConfigStore{}
+		return common.ConfigStore{}
 	}
-	findProjectRoot := deps.FindProjectRoot
+	return listDataStore
+}
+
+func testCloudStoreOrDefault(store rootStore) cloudCommandStoreInterface {
+	cloudStore, ok := any(store).(cloudCommandStoreInterface)
+	if !ok {
+		return common.ConfigStore{}
+	}
+	return cloudStore
+}
+
+func testDeleteStoreOrDefault(store rootStore) common.DeleteStore {
+	deleteStore, ok := any(store).(common.DeleteStore)
+	if !ok {
+		return common.ConfigStore{}
+	}
+	return deleteStore
+}
+
+func testNamespaceDeleterOrDefault(deleteNamespace common.NamespaceDeleterFunc) common.NamespaceDeleterFunc {
+	if deleteNamespace == nil {
+		return common.DeleteKubernetesNamespace
+	}
+	return deleteNamespace
+}
+
+func testProjectFinderOrDefault(findProjectRoot common.ProjectFinderFunc) common.ProjectFinderFunc {
 	if findProjectRoot == nil {
-		findProjectRoot = common.FindProjectRoot
+		return common.FindProjectRoot
 	}
-	optionalBuildFindProjectRoot := deps.OptionalBuildFindProjectRoot
-	if optionalBuildFindProjectRoot == nil {
-		optionalBuildFindProjectRoot = func() (string, string, error) {
+	return findProjectRoot
+}
+
+func testOptionalProjectFinderOrDefault(findProjectRoot common.ProjectFinderFunc) common.ProjectFinderFunc {
+	if findProjectRoot == nil {
+		return func() (string, string, error) {
 			return "", "", common.ErrNotInGitRepository
 		}
 	}
-	promptRunner := deps.PromptRunner
-	if promptRunner == nil {
-		promptRunner = runPrompt
-	}
-	selectRunner := deps.SelectRunner
-	if selectRunner == nil {
-		selectRunner = runSelect
-	}
-	listKubernetesContexts := deps.ListKubernetesContexts
-	resolveDockerBuildContext := deps.ResolveDockerBuildContext
-	if resolveDockerBuildContext == nil {
-		resolveDockerBuildContext = common.ResolveDockerBuildContext
-	}
-	resolveKubernetesDeployContext := deps.ResolveKubernetesDeployContext
-	if resolveKubernetesDeployContext == nil {
-		resolveKubernetesDeployContext = common.ResolveKubernetesDeployContext
-	}
-	buildDockerImage := deps.BuildDockerImage
-	if buildDockerImage == nil {
-		buildDockerImage = common.DockerImageBuilder
-	}
-	runBuildScript := deps.RunBuildScript
-	if runBuildScript == nil {
-		runBuildScript = common.BuildScriptRunner
-	}
-	pushDockerImage := deps.PushDockerImage
-	if pushDockerImage == nil {
-		pushDockerImage = common.DockerImagePusher
-	}
-	loginToDockerRegistry := deps.LoginToDockerRegistry
-	if loginToDockerRegistry == nil {
-		loginToDockerRegistry = common.DockerRegistryLogin
-	}
-	deployHelmChart := deps.DeployHelmChart
-	if deployHelmChart == nil {
-		deployHelmChart = common.DeployHelmChart
-	}
-	if deps.EnsureKubernetesNamespace != nil {
-		deployHelmChart = common.WrapHelmChartDeployerWithNamespaceEnsure(deps.EnsureKubernetesNamespace, deployHelmChart)
-	}
-	recoveringDeployHelmChart := wrapHelmDeployWithReleaseRecovery(promptRunner, deployHelmChart, deps.RecoverHelmRelease)
-	launchMCP := deps.LaunchMCP
-	if launchMCP == nil {
-		launchMCP = launchMCPProcess
-	}
-	launchApp := deps.LaunchApp
-	if launchApp == nil {
-		launchApp = launchAppProcess
-	}
-	runGit := deps.RunGit
-	if runGit == nil {
-		runGit = common.GitCommandRunner
-	}
-	openShell := newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell)
-	if deps.LaunchShell != nil {
-		openShell = func(_ common.Context, req common.ShellLaunchParams) error {
-			return deps.LaunchShell(req)
-		}
-	}
-	now := deps.Now
-	if now == nil {
-		now = common.NowFunc(time.Now)
-	}
+	return findProjectRoot
+}
 
-	openDeployHelmChart := common.HelmChartDeployerFunc(nil)
-	if deps.DeployHelmChart != nil {
-		openDeployHelmChart = deployHelmChart
+func testPromptRunnerOrDefault(promptRunner PromptRunner) PromptRunner {
+	if promptRunner == nil {
+		return runPrompt
 	}
+	return promptRunner
+}
+
+func testSelectRunnerOrDefault(selectRunner SelectRunner) SelectRunner {
+	if selectRunner == nil {
+		return runSelect
+	}
+	return selectRunner
+}
+
+func testDockerBuildContextResolverOrDefault(resolve common.BuildContextResolverFunc) common.BuildContextResolverFunc {
+	if resolve == nil {
+		return common.ResolveDockerBuildContext
+	}
+	return resolve
+}
+
+func testKubernetesDeployContextResolverOrDefault(resolve common.DeployContextResolverFunc) common.DeployContextResolverFunc {
+	if resolve == nil {
+		return common.ResolveKubernetesDeployContext
+	}
+	return resolve
+}
+
+func testDockerImageBuilderOrDefault(build common.DockerImageBuilderFunc) common.DockerImageBuilderFunc {
+	if build == nil {
+		return common.DockerImageBuilder
+	}
+	return build
+}
+
+func testBuildScriptRunnerOrDefault(run common.BuildScriptRunnerFunc) common.BuildScriptRunnerFunc {
+	if run == nil {
+		return common.BuildScriptRunner
+	}
+	return run
+}
+
+func testDockerImagePusherOrDefault(push common.DockerImagePusherFunc) common.DockerImagePusherFunc {
+	if push == nil {
+		return common.DockerImagePusher
+	}
+	return push
+}
+
+func testDockerRegistryLoginOrDefault(login common.DockerRegistryLoginFunc) common.DockerRegistryLoginFunc {
+	if login == nil {
+		return common.DockerRegistryLogin
+	}
+	return login
+}
+
+func testHelmDeployerOrDefault(deploy common.HelmChartDeployerFunc, ensure common.NamespaceEnsurerFunc) common.HelmChartDeployerFunc {
+	if deploy == nil {
+		deploy = common.DeployHelmChart
+	}
+	if ensure != nil {
+		return common.WrapHelmChartDeployerWithNamespaceEnsure(ensure, deploy)
+	}
+	return deploy
+}
+
+func testMCPLauncherOrDefault(launch MCPLauncher) MCPLauncher {
+	if launch == nil {
+		return launchMCPProcess
+	}
+	return launch
+}
+
+func testAppLauncherOrDefault(launch AppLauncher) AppLauncher {
+	if launch == nil {
+		return launchAppProcess
+	}
+	return launch
+}
+
+func testGitRunnerOrDefault(runGit common.GitCommandRunnerFunc) common.GitCommandRunnerFunc {
+	if runGit == nil {
+		return common.GitCommandRunner
+	}
+	return runGit
+}
+
+func testOpenShellRunnerOrDefault(launchShell common.ShellLauncherFunc) OpenShellRunner {
+	if launchShell == nil {
+		return newOpenShellRunner(common.WaitForShellDeployment, common.ExecShell)
+	}
+	return func(_ common.Context, req common.ShellLaunchParams) error {
+		return launchShell(req)
+	}
+}
+
+func testNowOrDefault(now common.NowFunc) common.NowFunc {
+	if now == nil {
+		return common.NowFunc(time.Now)
+	}
+	return now
+}
+
+func testOpenHelmDeployer(deploy common.HelmChartDeployerFunc, openDeploy common.HelmChartDeployerFunc) common.HelmChartDeployerFunc {
+	if deploy == nil {
+		return nil
+	}
+	return openDeploy
+}
+
+func testMCPForwarderOrDefault(forward MCPForwarder) MCPForwarder {
+	if forward == nil {
+		return func(common.Context, common.OpenResult) error { return nil }
+	}
+	return forward
+}
+
+func testVSCodeLauncherOrDefault(launch VSCodeLauncher) VSCodeLauncher {
+	if launch == nil {
+		return launchVSCode
+	}
+	return launch
+}
+
+func testIntelliJLauncherOrDefault(launch IntelliJLauncher) IntelliJLauncher {
+	if launch == nil {
+		return launchIntelliJ
+	}
+	return launch
+}
+
+type testRootCmdParts struct {
+	deps                           testRootDeps
+	store                          rootStore
+	listDataStore                  common.ListStore
+	findProjectRoot                common.ProjectFinderFunc
+	optionalBuildFindProjectRoot   common.ProjectFinderFunc
+	promptRunner                   PromptRunner
+	selectRunner                   SelectRunner
+	resolveDockerBuildContext      common.BuildContextResolverFunc
+	resolveKubernetesDeployContext common.DeployContextResolverFunc
+	buildDockerImage               common.DockerImageBuilderFunc
+	runBuildScript                 common.BuildScriptRunnerFunc
+	loginToDockerRegistry          common.DockerRegistryLoginFunc
+	recoveringDeployHelmChart      common.HelmChartDeployerFunc
+	launchMCP                      MCPLauncher
+	launchApp                      AppLauncher
+	runGit                         common.GitCommandRunnerFunc
+	openShell                      OpenShellRunner
+	now                            common.NowFunc
+	openDeployHelmChart            common.HelmChartDeployerFunc
+	resolveOpen                    func(common.OpenParams) (common.OpenResult, error)
+	resolveRuntimeDeploySpec       func(common.OpenResult) (common.DeploySpec, error)
+	activateMCP                    MCPForwarder
+	activateSSHD                   SSHDActivator
+	launchVSCodeCmd                VSCodeLauncher
+	launchIntelliJCmd              IntelliJLauncher
+	push                           common.DockerPushFunc
+	runManagedDeploy               func(common.Context, common.OpenResult) error
+	runInit                        func(common.Context, common.BootstrapInitParams) error
+	runInitForArgs                 func(common.Context, []string) error
+	runInitForOpen                 func(common.Context, common.OpenParams) error
+}
+
+func newTestRootCmd(deps testRootDeps) *cobra.Command {
+	store := testRootStoreOrDefault(deps.Store)
+	listDataStore := testListStoreOrDefault(store)
+	findProjectRoot := testProjectFinderOrDefault(deps.FindProjectRoot)
+	optionalBuildFindProjectRoot := testOptionalProjectFinderOrDefault(deps.OptionalBuildFindProjectRoot)
+	promptRunner := testPromptRunnerOrDefault(deps.PromptRunner)
+	selectRunner := testSelectRunnerOrDefault(deps.SelectRunner)
+	listKubernetesContexts := deps.ListKubernetesContexts
+	resolveDockerBuildContext := testDockerBuildContextResolverOrDefault(deps.ResolveDockerBuildContext)
+	resolveKubernetesDeployContext := testKubernetesDeployContextResolverOrDefault(deps.ResolveKubernetesDeployContext)
+	buildDockerImage := testDockerImageBuilderOrDefault(deps.BuildDockerImage)
+	runBuildScript := testBuildScriptRunnerOrDefault(deps.RunBuildScript)
+	pushDockerImage := testDockerImagePusherOrDefault(deps.PushDockerImage)
+	loginToDockerRegistry := testDockerRegistryLoginOrDefault(deps.LoginToDockerRegistry)
+	deployHelmChart := testHelmDeployerOrDefault(deps.DeployHelmChart, deps.EnsureKubernetesNamespace)
+	recoveringDeployHelmChart := wrapHelmDeployWithReleaseRecovery(promptRunner, deployHelmChart, deps.RecoverHelmRelease)
+	launchMCP := testMCPLauncherOrDefault(deps.LaunchMCP)
+	launchApp := testAppLauncherOrDefault(deps.LaunchApp)
+	runGit := testGitRunnerOrDefault(deps.RunGit)
+	openShell := testOpenShellRunnerOrDefault(deps.LaunchShell)
+	now := testNowOrDefault(deps.Now)
+	openDeployHelmChart := testOpenHelmDeployer(deps.DeployHelmChart, deployHelmChart)
 
 	resolveOpen := func(params common.OpenParams) (common.OpenResult, error) {
 		return common.ResolveOpen(store, params)
@@ -144,19 +319,10 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	resolveRuntimeDeploySpec := func(target common.OpenResult) (common.DeploySpec, error) {
 		return resolveRuntimeDeploySpecForOpen(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, currentBuildInfo(), target)
 	}
-	activateMCP := deps.ForwardMCP
-	if activateMCP == nil {
-		activateMCP = func(common.Context, common.OpenResult) error { return nil }
-	}
+	activateMCP := testMCPForwarderOrDefault(deps.ForwardMCP)
 	activateSSHD := newSSHDActivator(deps.RunRemoteCommand)
-	launchVSCodeCmd := deps.LaunchVSCode
-	if launchVSCodeCmd == nil {
-		launchVSCodeCmd = launchVSCode
-	}
-	launchIntelliJCmd := deps.LaunchIntelliJ
-	if launchIntelliJCmd == nil {
-		launchIntelliJCmd = launchIntelliJ
-	}
+	launchVSCodeCmd := testVSCodeLauncherOrDefault(deps.LaunchVSCode)
+	launchIntelliJCmd := testIntelliJLauncherOrDefault(deps.LaunchIntelliJ)
 	push := newPushOperation(pushDockerImage, loginToDockerRegistry, selectRunner)
 	runManagedDeploy := func(ctx common.Context, target common.OpenResult) error {
 		ctx = withCloudContextPreflight(ctx, store)
@@ -187,80 +353,120 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	runInitForArgs := newRunInitForArgs(store, runInit)
 	runInitForOpen := newRunInitForOpen(store, runInit)
 
-	initCmd := newInitCmd(runInit)
+	return assembleTestRootCmd(testRootCmdParts{
+		deps:                           deps,
+		store:                          store,
+		listDataStore:                  listDataStore,
+		findProjectRoot:                findProjectRoot,
+		optionalBuildFindProjectRoot:   optionalBuildFindProjectRoot,
+		promptRunner:                   promptRunner,
+		selectRunner:                   selectRunner,
+		resolveDockerBuildContext:      resolveDockerBuildContext,
+		resolveKubernetesDeployContext: resolveKubernetesDeployContext,
+		buildDockerImage:               buildDockerImage,
+		runBuildScript:                 runBuildScript,
+		loginToDockerRegistry:          loginToDockerRegistry,
+		recoveringDeployHelmChart:      recoveringDeployHelmChart,
+		launchMCP:                      launchMCP,
+		launchApp:                      launchApp,
+		runGit:                         runGit,
+		openShell:                      openShell,
+		now:                            now,
+		openDeployHelmChart:            openDeployHelmChart,
+		resolveOpen:                    resolveOpen,
+		resolveRuntimeDeploySpec:       resolveRuntimeDeploySpec,
+		activateMCP:                    activateMCP,
+		activateSSHD:                   activateSSHD,
+		launchVSCodeCmd:                launchVSCodeCmd,
+		launchIntelliJCmd:              launchIntelliJCmd,
+		push:                           push,
+		runManagedDeploy:               runManagedDeploy,
+		runInit:                        runInit,
+		runInitForArgs:                 runInitForArgs,
+		runInitForOpen:                 runInitForOpen,
+	})
+}
+
+func assembleTestRootCmd(parts testRootCmdParts) *cobra.Command {
+	initCmd := newInitCmd(parts.runInit)
 	openCmd := newOpenCmd(func(ctx common.Context) common.Context {
-		return withCloudContextPreflight(ctx, store)
-	}, resolveOpen, store.SaveEnvConfig, runInitForOpen, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart, activateMCP, activateSSHD, launchVSCodeCmd, launchIntelliJCmd)
+		return withCloudContextPreflight(ctx, parts.store)
+	}, parts.resolveOpen, parts.store.SaveEnvConfig, parts.runInitForOpen, parts.promptRunner, parts.openShell, parts.runManagedDeploy, parts.deps.CheckKubernetesDeployment, parts.resolveRuntimeDeploySpec, parts.openDeployHelmChart, parts.activateMCP, parts.activateSSHD, parts.launchVSCodeCmd, parts.launchIntelliJCmd)
 	sshdCmd := newSSHDCmd(func(ctx common.Context) common.Context {
-		return withCloudContextPreflight(ctx, store)
-	}, resolveOpen, store.SaveEnvConfig, runInitForOpen, resolveRuntimeDeploySpec, openDeployHelmChart, deps.RunRemoteCommand, writeLocalSSHConfig)
+		return withCloudContextPreflight(ctx, parts.store)
+	}, parts.resolveOpen, parts.store.SaveEnvConfig, parts.runInitForOpen, parts.resolveRuntimeDeploySpec, parts.openDeployHelmChart, parts.deps.RunRemoteCommand, writeLocalSSHConfig)
 	containerCmd := newCommandGroup(
 		"container",
 		"Container utilities",
-		newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, runBuildScript, buildDockerImage, loginToDockerRegistry, selectRunner, push, recoveringDeployHelmChart),
-		newPushCmd(store, findProjectRoot, resolveDockerBuildContext, now, buildDockerImage, push),
+		newBuildCmd(parts.store, parts.findProjectRoot, parts.resolveDockerBuildContext, parts.resolveKubernetesDeployContext, parts.now, parts.runBuildScript, parts.buildDockerImage, parts.loginToDockerRegistry, parts.selectRunner, parts.push, parts.recoveringDeployHelmChart),
+		newPushCmd(parts.store, parts.findProjectRoot, parts.resolveDockerBuildContext, parts.now, parts.buildDockerImage, parts.push),
 	)
 	k8sCmd := newCommandGroup(
 		"k8s",
 		"Kubernetes utilities",
-		newK8sDeployCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, buildDockerImage, push, recoveringDeployHelmChart),
+		newK8sDeployCmd(parts.store, parts.findProjectRoot, parts.resolveDockerBuildContext, parts.resolveKubernetesDeployContext, parts.now, parts.buildDockerImage, parts.push, parts.recoveringDeployHelmChart),
 	)
 	devopsCmd := newCommandGroup("devops", "DevOps utilities", containerCmd, k8sCmd)
-
-	var buildCmd *cobra.Command
-	if hasOptionalBuildCmd(optionalBuildFindProjectRoot, resolveDockerBuildContext) {
-		buildCmd = newBuildCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, runBuildScript, buildDockerImage, loginToDockerRegistry, selectRunner, push, recoveringDeployHelmChart)
-		buildCmd.Short = optionalBuildCmdShort(optionalBuildFindProjectRoot, resolveDockerBuildContext)
-	}
-	var pushCmd *cobra.Command
-	if hasOptionalPushCmd(optionalBuildFindProjectRoot, resolveDockerBuildContext) {
-		pushCmd = newPushCmd(store, findProjectRoot, resolveDockerBuildContext, now, buildDockerImage, push)
-		pushCmd.Short = optionalPushCmdShort(optionalBuildFindProjectRoot, resolveDockerBuildContext)
-	}
-	var deployCmd *cobra.Command
-	if hasOptionalDeployCmd(resolveKubernetesDeployContext) {
-		deployCmd = newDeployCmd(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, buildDockerImage, push, recoveringDeployHelmChart)
-	}
-
-	mcpCmd := newMCPCmd(resolveOpen, runInitForArgs, launchMCP)
-	appCmd := newAppCmd(launchApp)
-	execCmd := newExecCmd(findProjectRoot, runGit, deps.RunRawCommand)
-	cloudStore, ok := any(store).(cloudCommandStoreInterface)
-	if !ok {
-		cloudStore = common.ConfigStore{}
-	}
-	cloudCmd := newCloudCmd(cloudStore, promptRunner, selectRunner, common.CloudDependencies{})
-	listCmd := newListCmd(listDataStore, findProjectRoot)
-	doctorCmd := newDoctorCmd(resolveOpen, promptRunner)
-	deleteNamespace := deps.DeleteKubernetesNamespace
-	if deleteNamespace == nil {
-		deleteNamespace = common.DeleteKubernetesNamespace
-	}
-	deleteStore, ok := any(store).(common.DeleteStore)
-	if !ok {
-		deleteStore = common.ConfigStore{}
-	}
-	deleteCmd := newDeleteCmd(deleteStore, promptRunner, deleteNamespace)
-	releaseCmd := newReleaseCmd(findProjectRoot, runGit)
+	buildCmd := optionalTestBuildCmd(parts)
+	pushCmd := optionalTestPushCmd(parts)
+	deployCmd := optionalTestDeployCmd(parts)
 	versionCmd := newVersionCmd(func() (common.BuildInfo, string, error) {
-		return resolveVersionCommandBuildInfo(findProjectRoot)
-	}, deps.ResolveRuntimeRegistryVersions)
+		return resolveVersionCommandBuildInfo(parts.findProjectRoot)
+	}, parts.deps.ResolveRuntimeRegistryVersions)
+	runRoot := testRootRunner(parts)
+	cmd := newRootCommand(runRoot)
+	addCommands(cmd,
+		initCmd, openCmd, sshdCmd, devopsCmd, buildCmd, pushCmd, deployCmd,
+		newMCPCmd(parts.resolveOpen, parts.runInitForArgs, parts.launchMCP),
+		newAppCmd(parts.launchApp),
+		newExecCmd(parts.findProjectRoot, parts.runGit, parts.deps.RunRawCommand),
+		newCloudCmd(testCloudStoreOrDefault(parts.store), parts.promptRunner, parts.selectRunner, common.CloudDependencies{}),
+		newListCmd(parts.listDataStore, parts.findProjectRoot),
+		newDoctorCmd(parts.resolveOpen, parts.promptRunner),
+		newDeleteCmd(testDeleteStoreOrDefault(parts.store), parts.promptRunner, testNamespaceDeleterOrDefault(parts.deps.DeleteKubernetesNamespace)),
+		newReleaseCmd(parts.findProjectRoot, parts.runGit),
+		versionCmd,
+	)
+	return cmd
+}
 
-	runRoot := func(cmd *cobra.Command, args []string) error {
-		ctx := withCloudContextPreflight(commandContext(cmd), store)
-		result, initRan, err := resolveOpenWithInitStop(ctx, args, shouldInitRootCommand, resolveOpen, runInitForArgs)
+func optionalTestBuildCmd(parts testRootCmdParts) *cobra.Command {
+	if !hasOptionalBuildCmd(parts.optionalBuildFindProjectRoot, parts.resolveDockerBuildContext) {
+		return nil
+	}
+	buildCmd := newBuildCmd(parts.store, parts.findProjectRoot, parts.resolveDockerBuildContext, parts.resolveKubernetesDeployContext, parts.now, parts.runBuildScript, parts.buildDockerImage, parts.loginToDockerRegistry, parts.selectRunner, parts.push, parts.recoveringDeployHelmChart)
+	buildCmd.Short = optionalBuildCmdShort(parts.optionalBuildFindProjectRoot, parts.resolveDockerBuildContext)
+	return buildCmd
+}
+
+func optionalTestPushCmd(parts testRootCmdParts) *cobra.Command {
+	if !hasOptionalPushCmd(parts.optionalBuildFindProjectRoot, parts.resolveDockerBuildContext) {
+		return nil
+	}
+	pushCmd := newPushCmd(parts.store, parts.findProjectRoot, parts.resolveDockerBuildContext, parts.now, parts.buildDockerImage, parts.push)
+	pushCmd.Short = optionalPushCmdShort(parts.optionalBuildFindProjectRoot, parts.resolveDockerBuildContext)
+	return pushCmd
+}
+
+func optionalTestDeployCmd(parts testRootCmdParts) *cobra.Command {
+	if !hasOptionalDeployCmd(parts.resolveKubernetesDeployContext) {
+		return nil
+	}
+	return newDeployCmd(parts.store, parts.findProjectRoot, parts.resolveDockerBuildContext, parts.resolveKubernetesDeployContext, parts.now, parts.buildDockerImage, parts.push, parts.recoveringDeployHelmChart)
+}
+
+func testRootRunner(parts testRootCmdParts) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		ctx := withCloudContextPreflight(commandContext(cmd), parts.store)
+		result, initRan, err := resolveOpenWithInitStop(ctx, args, shouldInitRootCommand, parts.resolveOpen, parts.runInitForArgs)
 		if err != nil {
 			return err
 		}
 		if initRan {
 			return nil
 		}
-		return runResolvedOpenCommand(ctx, result, openOptions{}, promptRunner, openShell, runManagedDeploy, deps.CheckKubernetesDeployment, resolveRuntimeDeploySpec, openDeployHelmChart, activateMCP, activateSSHD, launchVSCodeCmd, launchIntelliJCmd)
+		return runResolvedOpenCommand(ctx, result, openOptions{}, parts.promptRunner, parts.openShell, parts.runManagedDeploy, parts.deps.CheckKubernetesDeployment, parts.resolveRuntimeDeploySpec, parts.openDeployHelmChart, parts.activateMCP, parts.activateSSHD, parts.launchVSCodeCmd, parts.launchIntelliJCmd)
 	}
-
-	cmd := newRootCommand(runRoot)
-	addCommands(cmd, initCmd, openCmd, sshdCmd, devopsCmd, buildCmd, pushCmd, deployCmd, mcpCmd, appCmd, execCmd, cloudCmd, listCmd, doctorCmd, deleteCmd, releaseCmd, versionCmd)
-	return cmd
 }
 
 func stubKubectlContexts(t *testing.T, contexts []string, current string) {

--- a/erun-cli/cmd/sshd.go
+++ b/erun-cli/cmd/sshd.go
@@ -43,6 +43,32 @@ func newSSHDCmd(prepareContext func(common.Context) common.Context, resolveOpen 
 }
 
 func runSSHDInitCommand(ctx common.Context, result common.OpenResult, publicKeyPath string, localPort int, saveEnvConfig func(string, common.EnvConfig) error, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, runRemoteCommand common.RemoteCommandRunnerFunc, writeLocalConfig SSHDLocalConfigWriter) error {
+	if err := validateSSHDInitDependencies(result, saveEnvConfig, resolveRuntimeDeploySpec, deployHelmChart); err != nil {
+		return err
+	}
+	updatedEnv, err := resolveSSHDEnvConfig(result, publicKeyPath, localPort)
+	if err != nil {
+		return err
+	}
+	if err := saveSSHDEnvConfig(ctx, result, updatedEnv, saveEnvConfig); err != nil {
+		return err
+	}
+
+	result.EnvConfig = updatedEnv
+	if err := deploySSHDConfig(ctx, result, resolveRuntimeDeploySpec, deployHelmChart); err != nil {
+		return err
+	}
+	if _, err := syncRemoteSSHDKey(ctx, result, runRemoteCommand); err != nil {
+		return err
+	}
+	localConfig, err := writeSSHDLocalConfig(ctx, result, writeLocalConfig)
+	if err != nil {
+		return err
+	}
+	return writeSSHDInitSummary(ctx, result, localConfig)
+}
+
+func validateSSHDInitDependencies(result common.OpenResult, saveEnvConfig func(string, common.EnvConfig) error, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) error {
 	if err := common.ValidateSSHDTarget(result); err != nil {
 		return err
 	}
@@ -55,15 +81,17 @@ func runSSHDInitCommand(ctx common.Context, result common.OpenResult, publicKeyP
 	if deployHelmChart == nil {
 		return fmt.Errorf("helm deployer is required")
 	}
+	return nil
+}
 
+func resolveSSHDEnvConfig(result common.OpenResult, publicKeyPath string, localPort int) (common.EnvConfig, error) {
 	if publicKeyPath == "" {
 		publicKeyPath = result.EnvConfig.SSHD.PublicKeyPath
 	}
 	resolvedPublicKeyPath, _, err := resolveSSHDPublicKey(publicKeyPath)
 	if err != nil {
-		return err
+		return common.EnvConfig{}, err
 	}
-
 	updatedEnv := result.EnvConfig
 	updatedEnv.SSHD.Enabled = true
 	updatedEnv.SSHD.PublicKeyPath = resolvedPublicKeyPath
@@ -73,38 +101,38 @@ func runSSHDInitCommand(ctx common.Context, result common.OpenResult, publicKeyP
 	if updatedEnv.SSHD.LocalPort == 0 {
 		updatedEnv.SSHD.LocalPort = common.SSHLocalPortForResult(result)
 	}
+	return updatedEnv, nil
+}
+
+func saveSSHDEnvConfig(ctx common.Context, result common.OpenResult, updatedEnv common.EnvConfig, saveEnvConfig func(string, common.EnvConfig) error) error {
 	if ctx.DryRun {
 		ctx.Trace(fmt.Sprintf("save SSHD config for %s/%s", result.Tenant, result.Environment))
-	} else if err := saveEnvConfig(result.Tenant, updatedEnv); err != nil {
-		return err
+		return nil
 	}
+	return saveEnvConfig(result.Tenant, updatedEnv)
+}
 
-	result.EnvConfig = updatedEnv
+func deploySSHDConfig(ctx common.Context, result common.OpenResult, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) error {
 	spec, err := resolveRuntimeDeploySpec(result)
 	if err != nil {
 		return err
 	}
-	if err := common.RunDeploySpec(ctx, spec, nil, nil, deployHelmChart); err != nil {
-		return err
-	}
-	if _, err := syncRemoteSSHDKey(ctx, result, runRemoteCommand); err != nil {
-		return err
-	}
+	return common.RunDeploySpec(ctx, spec, nil, nil, deployHelmChart)
+}
 
-	localConfig := SSHDLocalConfigResult{}
-	if writeLocalConfig != nil {
-		if ctx.DryRun {
-			info := common.SSHConnectionInfoForResult(result)
-			ctx.Trace(fmt.Sprintf("write ssh config host %s for %s/%s", info.HostAlias, result.Tenant, result.Environment))
-		} else {
-			configResult, err := writeLocalConfig(result)
-			if err != nil {
-				return err
-			}
-			localConfig = configResult
-		}
+func writeSSHDLocalConfig(ctx common.Context, result common.OpenResult, writeLocalConfig SSHDLocalConfigWriter) (SSHDLocalConfigResult, error) {
+	if writeLocalConfig == nil {
+		return SSHDLocalConfigResult{}, nil
 	}
+	if ctx.DryRun {
+		info := common.SSHConnectionInfoForResult(result)
+		ctx.Trace(fmt.Sprintf("write ssh config host %s for %s/%s", info.HostAlias, result.Tenant, result.Environment))
+		return SSHDLocalConfigResult{}, nil
+	}
+	return writeLocalConfig(result)
+}
 
+func writeSSHDInitSummary(ctx common.Context, result common.OpenResult, localConfig SSHDLocalConfigResult) error {
 	if ctx.Stdout != nil {
 		info := common.SSHConnectionInfoForResult(result)
 		if _, err := fmt.Fprintf(

--- a/erun-cli/cmd/sshd_port_forward.go
+++ b/erun-cli/cmd/sshd_port_forward.go
@@ -45,13 +45,7 @@ func ensureSSHDPortForward(ctx common.Context, result common.OpenResult) (common
 	if stateMatchesSSHDTarget(state, expectedState) && !stateHasDeprecatedLocalProxy(state) && canReachLocalSSHEndpoint(info.Port) {
 		return info, nil
 	}
-	if stateMatchesSSHDTarget(state, expectedState) && state.ProcessID > 0 && canConnectLocalPort(info.Port) {
-		stopSSHDPortForwardState(state)
-		waitForLocalPortToClose(info.Port)
-		if state.ForwardPort > 0 {
-			waitForLocalPortToClose(state.ForwardPort)
-		}
-	}
+	stopStaleSSHDPortForward(state, expectedState, info.Port)
 	if canConnectLocalPort(info.Port) {
 		return common.SSHConnectionInfo{}, fmt.Errorf("local SSH port %d is already in use", info.Port)
 	}
@@ -62,6 +56,21 @@ func ensureSSHDPortForward(ctx common.Context, result common.OpenResult) (common
 		return info, nil
 	}
 
+	return startSSHDPortForward(statePath, expectedState, args, info)
+}
+
+func stopStaleSSHDPortForward(state, expectedState sshdPortForwardState, localPort int) {
+	if !stateMatchesSSHDTarget(state, expectedState) || state.ProcessID <= 0 || !canConnectLocalPort(localPort) {
+		return
+	}
+	stopSSHDPortForwardState(state)
+	waitForLocalPortToClose(localPort)
+	if state.ForwardPort > 0 {
+		waitForLocalPortToClose(state.ForwardPort)
+	}
+}
+
+func startSSHDPortForward(statePath string, expectedState sshdPortForwardState, args []string, info common.SSHConnectionInfo) (common.SSHConnectionInfo, error) {
 	logPath := sshdPortForwardLogPath(statePath)
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
 		return common.SSHConnectionInfo{}, err
@@ -88,15 +97,22 @@ func ensureSSHDPortForward(ctx common.Context, result common.OpenResult) (common
 		return common.SSHConnectionInfo{}, err
 	}
 
+	if err := waitForSSHDPortForward(info.Port, logPath); err != nil {
+		return common.SSHConnectionInfo{}, err
+	}
+	return info, nil
+}
+
+func waitForSSHDPortForward(port int, logPath string) error {
 	deadline := time.Now().Add(sshdPortForwardStartupTimeout)
 	for time.Now().Before(deadline) {
-		if canReachLocalSSHEndpoint(info.Port) {
-			return info, nil
+		if canReachLocalSSHEndpoint(port) {
+			return nil
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	return common.SSHConnectionInfo{}, fmt.Errorf("timed out waiting for SSH port-forward on 127.0.0.1:%d; see %s", info.Port, logPath)
+	return fmt.Errorf("timed out waiting for SSH port-forward on 127.0.0.1:%d; see %s", port, logPath)
 }
 
 func kubectlPortForwardArgs(result common.OpenResult, localPort int) []string {

--- a/erun-cli/cmd/sshd_test.go
+++ b/erun-cli/cmd/sshd_test.go
@@ -144,10 +144,28 @@ func TestRunSSHDInitCommandPersistsConfigAndDeploysRuntime(t *testing.T) {
 		},
 		writeLocalSSHConfig,
 	)
-	if err != nil {
-		t.Fatalf("runSSHDInitCommand failed: %v", err)
-	}
+	requireNoError(t, err, "runSSHDInitCommand failed")
 
+	requireSSHDInitConfig(t, savedTenant, savedEnv, deployed, remoteScript, publicKeyPath)
+	sshConfigData, err := os.ReadFile(filepath.Join(homeDir, ".ssh", "config"))
+	requireNoError(t, err, "read ssh config")
+	requireContainsAll(t, string(sshConfigData), []string{
+		"Host erun-tenant-a-dev",
+		"HostName 127.0.0.1",
+		"Port 64022",
+		"User erun",
+		"HostKeyAlias erun-tenant-a-dev",
+		"IdentityFile " + strings.TrimSuffix(publicKeyPath, ".pub"),
+	}, "ssh config")
+	stdout := ctx.Stdout.(*bytes.Buffer).String()
+	requireContainsAll(t, stdout, []string{
+		"host: erun-tenant-a-dev",
+		"config: " + filepath.Join(homeDir, ".ssh", "config"),
+	}, "stdout")
+}
+
+func requireSSHDInitConfig(t *testing.T, savedTenant string, savedEnv common.EnvConfig, deployed common.HelmDeployParams, remoteScript, publicKeyPath string) {
+	t.Helper()
 	if savedTenant != "tenant-a" {
 		t.Fatalf("unexpected saved tenant: %q", savedTenant)
 	}
@@ -160,29 +178,13 @@ func TestRunSSHDInitCommandPersistsConfigAndDeploysRuntime(t *testing.T) {
 	if !strings.Contains(remoteScript, "authorized_keys") || !strings.Contains(remoteScript, "ssh-ed25519 AAAATEST user@example") {
 		t.Fatalf("unexpected remote authorized_keys script:\n%s", remoteScript)
 	}
-	sshConfigData, err := os.ReadFile(filepath.Join(homeDir, ".ssh", "config"))
-	if err != nil {
-		t.Fatalf("read ssh config: %v", err)
-	}
-	for _, want := range []string{
-		"Host erun-tenant-a-dev",
-		"HostName 127.0.0.1",
-		"Port 64022",
-		"User erun",
-		"HostKeyAlias erun-tenant-a-dev",
-		"IdentityFile " + strings.TrimSuffix(publicKeyPath, ".pub"),
-	} {
-		if !strings.Contains(string(sshConfigData), want) {
-			t.Fatalf("expected ssh config to contain %q, got:\n%s", want, sshConfigData)
-		}
-	}
-	stdout := ctx.Stdout.(*bytes.Buffer).String()
-	for _, want := range []string{
-		"host: erun-tenant-a-dev",
-		"config: " + filepath.Join(homeDir, ".ssh", "config"),
-	} {
-		if !strings.Contains(stdout, want) {
-			t.Fatalf("expected stdout to contain %q, got:\n%s", want, stdout)
+}
+
+func requireContainsAll(t *testing.T, value string, wants []string, context string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(value, want) {
+			t.Fatalf("expected %s to contain %q, got:\n%s", context, want, value)
 		}
 	}
 }

--- a/erun-cli/cmd/sshd_test.go
+++ b/erun-cli/cmd/sshd_test.go
@@ -81,9 +81,7 @@ func TestRunSSHDInitCommandPersistsConfigAndDeploysRuntime(t *testing.T) {
 	t.Setenv("HOME", homeDir)
 
 	publicKeyPath := filepath.Join(t.TempDir(), "id_ed25519.pub")
-	if err := os.WriteFile(publicKeyPath, []byte("ssh-ed25519 AAAATEST user@example\n"), 0o644); err != nil {
-		t.Fatalf("write public key: %v", err)
-	}
+	requireNoError(t, os.WriteFile(publicKeyPath, []byte("ssh-ed25519 AAAATEST user@example\n"), 0o644), "write public key")
 
 	var savedTenant string
 	var savedEnv common.EnvConfig
@@ -194,9 +192,7 @@ func TestRunSSHDInitCommandUsesResolvedEnvironmentLocalPortByDefault(t *testing.
 	t.Setenv("HOME", homeDir)
 
 	publicKeyPath := filepath.Join(t.TempDir(), "id_ed25519.pub")
-	if err := os.WriteFile(publicKeyPath, []byte("ssh-ed25519 AAAATEST user@example\n"), 0o644); err != nil {
-		t.Fatalf("write public key: %v", err)
-	}
+	requireNoError(t, os.WriteFile(publicKeyPath, []byte("ssh-ed25519 AAAATEST user@example\n"), 0o644), "write public key")
 
 	var savedEnv common.EnvConfig
 	err := runSSHDInitCommand(
@@ -272,9 +268,7 @@ func TestSyncRemoteSSHDKeyRetriesWhenDeploymentIsNotReady(t *testing.T) {
 	})
 
 	publicKeyPath := filepath.Join(t.TempDir(), "id_ed25519.pub")
-	if err := os.WriteFile(publicKeyPath, []byte("ssh-ed25519 AAAATEST user@example\n"), 0o644); err != nil {
-		t.Fatalf("write public key: %v", err)
-	}
+	requireNoError(t, os.WriteFile(publicKeyPath, []byte("ssh-ed25519 AAAATEST user@example\n"), 0o644), "write public key")
 
 	var waited common.ShellLaunchParams
 	waitForSSHDRemoteDeployment = func(req common.ShellLaunchParams) error {
@@ -340,9 +334,7 @@ func TestSyncRemoteSSHDKeyRetriesWhenKubeletProxyIsStarting(t *testing.T) {
 	})
 
 	publicKeyPath := filepath.Join(t.TempDir(), "id_ed25519.pub")
-	if err := os.WriteFile(publicKeyPath, []byte("ssh-ed25519 AAAATEST user@example\n"), 0o644); err != nil {
-		t.Fatalf("write public key: %v", err)
-	}
+	requireNoError(t, os.WriteFile(publicKeyPath, []byte("ssh-ed25519 AAAATEST user@example\n"), 0o644), "write public key")
 
 	waits := 0
 	waitForSSHDRemoteDeployment = func(common.ShellLaunchParams) error {

--- a/erun-cli/cmd/version_test.go
+++ b/erun-cli/cmd/version_test.go
@@ -28,9 +28,7 @@ func TestVersionCommandOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	if err := os.Chdir(workdir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	requireNoError(t, os.Chdir(workdir), "chdir")
 	t.Cleanup(func() {
 		_ = os.Chdir(prevWD)
 	})
@@ -42,9 +40,7 @@ func TestVersionCommandOutput(t *testing.T) {
 	cmd.SetArgs([]string{"version"})
 
 	setBuildInfo("1.2.3", "abcdef", "2024-01-01")
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := buf.String(); got != "erun 1.2.3 (abcdef built 2024-01-01)\n" {
 		t.Fatalf("unexpected output: %q", got)
@@ -52,9 +48,7 @@ func TestVersionCommandOutput(t *testing.T) {
 
 	buf.Reset()
 	setBuildInfo("1.2.3", "", "")
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 	if got := buf.String(); got != "erun 1.2.3\n" {
 		t.Fatalf("unexpected tail-less output: %q", got)
 	}
@@ -67,9 +61,7 @@ func TestVersionCommandPrefersVersionFileInCurrentDirectory(t *testing.T) {
 	})
 
 	workdir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("9.9.9\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "VERSION"), []byte("9.9.9\n"), 0o644), "write VERSION")
 
 	cmd := newTestRootCmd(testRootDeps{})
 	buf := new(bytes.Buffer)
@@ -81,17 +73,13 @@ func TestVersionCommandPrefersVersionFileInCurrentDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	if err := os.Chdir(workdir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	requireNoError(t, os.Chdir(workdir), "chdir")
 	t.Cleanup(func() {
 		_ = os.Chdir(prevWD)
 	})
 
 	setBuildInfo("1.2.3", "abcdef", "2024-01-01")
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := buf.String(); got != "erun 9.9.9 (abcdef built 2024-01-01)\n" {
 		t.Fatalf("unexpected output: %q", got)
@@ -109,9 +97,7 @@ func TestVersionCommandPrintsRegistryVersions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	if err := os.Chdir(workdir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	requireNoError(t, os.Chdir(workdir), "chdir")
 	t.Cleanup(func() {
 		_ = os.Chdir(prevWD)
 	})
@@ -131,9 +117,7 @@ func TestVersionCommandPrintsRegistryVersions(t *testing.T) {
 	cmd.SetArgs([]string{"version"})
 
 	setBuildInfo("1.2.3", "abcdef", "2024-01-01")
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	want := "erun 1.2.3 (abcdef built 2024-01-01)\n" +
 		"latest stable: 1.0.50\n" +
@@ -154,9 +138,7 @@ func TestVersionCommandCanSkipRegistryVersions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	if err := os.Chdir(workdir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	requireNoError(t, os.Chdir(workdir), "chdir")
 	t.Cleanup(func() {
 		_ = os.Chdir(prevWD)
 	})
@@ -174,9 +156,7 @@ func TestVersionCommandCanSkipRegistryVersions(t *testing.T) {
 	cmd.SetArgs([]string{"version", "--no-registry"})
 
 	setBuildInfo("1.2.3", "", "")
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if called {
 		t.Fatal("registry resolver was called")
@@ -192,9 +172,7 @@ func TestVersionCommandDryRunPrintsTraceWithoutOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	if err := os.Chdir(workdir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	requireNoError(t, os.Chdir(workdir), "chdir")
 	t.Cleanup(func() {
 		_ = os.Chdir(prevWD)
 	})
@@ -206,9 +184,7 @@ func TestVersionCommandDryRunPrintsTraceWithoutOutput(t *testing.T) {
 	cmd.SetErr(stderr)
 	cmd.SetArgs([]string{"version", "--dry-run", "-v"})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := stdout.String(); got == "" {
 		t.Fatalf("expected version output during dry-run, got %q", got)
@@ -229,9 +205,7 @@ func TestVersionCommandTimeFlagPrintsElapsedTimeToStderr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	if err := os.Chdir(workdir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	requireNoError(t, os.Chdir(workdir), "chdir")
 	t.Cleanup(func() {
 		_ = os.Chdir(prevWD)
 	})
@@ -244,9 +218,7 @@ func TestVersionCommandTimeFlagPrintsElapsedTimeToStderr(t *testing.T) {
 	cmd.SetArgs([]string{"version", "--time"})
 
 	setBuildInfo("1.2.3", "", "")
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute failed: %v", err)
-	}
+	requireNoError(t, cmd.Execute(), "Execute failed")
 
 	if got := stdout.String(); got != "erun 1.2.3\n" {
 		t.Fatalf("unexpected stdout: %q", got)

--- a/erun-cli/internal/jetbrainsconfig/jetbrainsconfig.go
+++ b/erun-cli/internal/jetbrainsconfig/jetbrainsconfig.go
@@ -55,20 +55,9 @@ func UpsertOptionsFiles(optionsDir string, entry ProjectEntry) error {
 	if optionsDir == "" {
 		return fmt.Errorf("JetBrains options directory is required")
 	}
-	if strings.TrimSpace(entry.ConfigID) == "" {
-		return fmt.Errorf("JetBrains config ID is required")
-	}
-	if strings.TrimSpace(entry.HostAlias) == "" {
-		return fmt.Errorf("JetBrains host alias is required")
-	}
-	if strings.TrimSpace(entry.User) == "" {
-		return fmt.Errorf("JetBrains SSH user is required")
-	}
-	if strings.TrimSpace(entry.ProjectPath) == "" {
-		return fmt.Errorf("JetBrains project path is required")
-	}
-	if strings.TrimSpace(entry.ProductCode) == "" {
-		entry.ProductCode = "IU"
+	entry, err := normalizeProjectEntry(entry)
+	if err != nil {
+		return err
 	}
 	if err := os.MkdirAll(optionsDir, 0o700); err != nil {
 		return err
@@ -82,6 +71,32 @@ func UpsertOptionsFiles(optionsDir string, entry ProjectEntry) error {
 	}
 	if err := upsertSSHRecentConnectionsFile(filepath.Join(optionsDir, "sshRecentConnections.v2.xml"), entry); err != nil {
 		return err
+	}
+	return nil
+}
+
+func normalizeProjectEntry(entry ProjectEntry) (ProjectEntry, error) {
+	if err := validateProjectEntry(entry); err != nil {
+		return ProjectEntry{}, err
+	}
+	if strings.TrimSpace(entry.ProductCode) == "" {
+		entry.ProductCode = "IU"
+	}
+	return entry, nil
+}
+
+func validateProjectEntry(entry ProjectEntry) error {
+	if strings.TrimSpace(entry.ConfigID) == "" {
+		return fmt.Errorf("JetBrains config ID is required")
+	}
+	if strings.TrimSpace(entry.HostAlias) == "" {
+		return fmt.Errorf("JetBrains host alias is required")
+	}
+	if strings.TrimSpace(entry.User) == "" {
+		return fmt.Errorf("JetBrains SSH user is required")
+	}
+	if strings.TrimSpace(entry.ProjectPath) == "" {
+		return fmt.Errorf("JetBrains project path is required")
 	}
 	return nil
 }

--- a/erun-cli/internal/sshconfig/sshconfig.go
+++ b/erun-cli/internal/sshconfig/sshconfig.go
@@ -56,36 +56,58 @@ func UpsertConfig(path string, entry HostEntry) error {
 
 func UpsertConfigContent(existing string, entry HostEntry) string {
 	lines := splitConfigLines(existing)
-	replaced := false
-	updated := make([]string, 0, len(lines)+8)
-
-	for i := 0; i < len(lines); {
-		if hostLineHasAlias(lines[i], entry.Alias) {
-			if !replaced {
-				updated = appendEntryLines(updated, entry)
-				replaced = true
-			}
-			i++
-			for i < len(lines) && !isHostDirective(lines[i]) {
-				i++
-			}
-			if i < len(lines) && len(updated) > 0 && strings.TrimSpace(updated[len(updated)-1]) != "" {
-				updated = append(updated, "")
-			}
-			continue
-		}
-		updated = append(updated, lines[i])
-		i++
-	}
-
+	updated, replaced := replaceExistingHostEntries(lines, entry)
 	if !replaced {
-		if len(updated) > 0 && strings.TrimSpace(updated[len(updated)-1]) != "" {
-			updated = append(updated, "")
-		}
+		updated = appendBlankBeforeEntry(updated)
 		updated = appendEntryLines(updated, entry)
 	}
 
 	return strings.TrimRight(strings.Join(trimTrailingBlankLines(updated), "\n"), "\n") + "\n"
+}
+
+func replaceExistingHostEntries(lines []string, entry HostEntry) ([]string, bool) {
+	replaced := false
+	updated := make([]string, 0, len(lines)+8)
+	for i := 0; i < len(lines); {
+		if !hostLineHasAlias(lines[i], entry.Alias) {
+			updated = append(updated, lines[i])
+			i++
+			continue
+		}
+		updated = appendFirstReplacement(updated, entry, replaced)
+		replaced = true
+		i = skipHostEntry(lines, i+1)
+		updated = appendBlankBetweenEntries(lines, updated, i)
+	}
+	return updated, replaced
+}
+
+func appendFirstReplacement(lines []string, entry HostEntry, replaced bool) []string {
+	if replaced {
+		return lines
+	}
+	return appendEntryLines(lines, entry)
+}
+
+func skipHostEntry(lines []string, index int) int {
+	for index < len(lines) && !isHostDirective(lines[index]) {
+		index++
+	}
+	return index
+}
+
+func appendBlankBetweenEntries(source, updated []string, nextIndex int) []string {
+	if nextIndex >= len(source) || len(updated) == 0 || strings.TrimSpace(updated[len(updated)-1]) == "" {
+		return updated
+	}
+	return append(updated, "")
+}
+
+func appendBlankBeforeEntry(lines []string) []string {
+	if len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) != "" {
+		return append(lines, "")
+	}
+	return lines
 }
 
 func RenderEntry(entry HostEntry) string {

--- a/erun-common/activity.go
+++ b/erun-common/activity.go
@@ -136,40 +136,9 @@ func ResolveEnvironmentIdleStatus(config EnvironmentIdleConfig, activity map[str
 		return EnvironmentIdleStatus{}, err
 	}
 
-	markers := []EnvironmentIdleMarker{{
-		Name:             "working-hours",
-		Idle:             outsideWorkingHours,
-		Reason:           workingHoursReason(outsideWorkingHours, policy.WorkingHours),
-		SecondsRemaining: secondsUntilWorkingHoursEnd,
-	}}
-	for _, kind := range environmentActivityKinds {
-		snapshot := activity[kind]
-		markers = append(markers, activityIdleMarker(kind, snapshot, policy, now))
-	}
-
-	secondsUntilStop := int64(0)
-	stopEligible := outsideWorkingHours
-	if !outsideWorkingHours {
-		stopEligible = true
-		for _, marker := range markers {
-			if marker.Name == "working-hours" {
-				continue
-			}
-			if !marker.Idle {
-				stopEligible = false
-				if marker.SecondsRemaining > secondsUntilStop {
-					secondsUntilStop = marker.SecondsRemaining
-				}
-			}
-		}
-	}
-	if stopEligible {
-		secondsUntilStop = 0
-	}
-	stopBlockedReason := ""
-	if !stopEligible {
-		stopBlockedReason = environmentStopBlockedReason(markers)
-	}
+	markers := environmentIdleMarkers(activity, policy, now, outsideWorkingHours, secondsUntilWorkingHoursEnd)
+	stopEligible, secondsUntilStop := environmentStopEligibility(markers, outsideWorkingHours)
+	stopBlockedReason := environmentBlockedReason(markers, stopEligible)
 
 	return EnvironmentIdleStatus{
 		Policy:              policy,
@@ -180,6 +149,48 @@ func ResolveEnvironmentIdleStatus(config EnvironmentIdleConfig, activity map[str
 		Markers:             markers,
 		Activity:            activity,
 	}, nil
+}
+
+func environmentIdleMarkers(activity map[string]EnvironmentActivitySnapshot, policy EnvironmentIdlePolicy, now time.Time, outsideWorkingHours bool, secondsUntilWorkingHoursEnd int64) []EnvironmentIdleMarker {
+	markers := []EnvironmentIdleMarker{{
+		Name:             "working-hours",
+		Idle:             outsideWorkingHours,
+		Reason:           workingHoursReason(outsideWorkingHours, policy.WorkingHours),
+		SecondsRemaining: secondsUntilWorkingHoursEnd,
+	}}
+	for _, kind := range environmentActivityKinds {
+		snapshot := activity[kind]
+		markers = append(markers, activityIdleMarker(kind, snapshot, policy, now))
+	}
+	return markers
+}
+
+func environmentStopEligibility(markers []EnvironmentIdleMarker, outsideWorkingHours bool) (bool, int64) {
+	if outsideWorkingHours {
+		return true, 0
+	}
+	stopEligible := true
+	secondsUntilStop := int64(0)
+	for _, marker := range markers {
+		if marker.Name == "working-hours" || marker.Idle {
+			continue
+		}
+		stopEligible = false
+		if marker.SecondsRemaining > secondsUntilStop {
+			secondsUntilStop = marker.SecondsRemaining
+		}
+	}
+	if stopEligible {
+		return true, 0
+	}
+	return false, secondsUntilStop
+}
+
+func environmentBlockedReason(markers []EnvironmentIdleMarker, stopEligible bool) string {
+	if stopEligible {
+		return ""
+	}
+	return environmentStopBlockedReason(markers)
 }
 
 func ResolveStoredEnvironmentIdleStatus(store EnvironmentIdleStore, tenant, environment string, now time.Time) (EnvironmentIdleStatus, error) {

--- a/erun-common/assert_test.go
+++ b/erun-common/assert_test.go
@@ -1,0 +1,49 @@
+package eruncommon
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func requireNoError(t *testing.T, err error, message string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", message, err)
+	}
+}
+
+func requireEqual[T comparable](t *testing.T, got, want T, message string) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("%s: got %v want %v", message, got, want)
+	}
+}
+
+func requireDeepEqual(t *testing.T, got, want any, message string) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s: got %+v want %+v", message, got, want)
+	}
+}
+
+func requireStringContains(t *testing.T, got, want, message string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Fatalf("%s: %s", message, got)
+	}
+}
+
+func requireBytesContains(t *testing.T, got []byte, want string, message string) {
+	t.Helper()
+	if !strings.Contains(string(got), want) {
+		t.Fatalf("%s: %s", message, got)
+	}
+}
+
+func requireCondition(t *testing.T, ok bool, message string, args ...any) {
+	t.Helper()
+	if !ok {
+		t.Fatalf(message, args...)
+	}
+}

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -144,12 +144,7 @@ func ResolveCurrentDockerBuildSpecs(store DockerStore, findProjectRoot ProjectFi
 func ResolveBuildExecution(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, target DockerCommandTarget) (BuildExecutionSpec, error) {
 	store, findProjectRoot, resolveBuildContext, now = normalizeDockerDependencies(store, findProjectRoot, resolveBuildContext, now)
 
-	target, releaseSpec, err := ResolveDockerBuildTarget(findProjectRoot, target)
-	if err != nil {
-		return BuildExecutionSpec{}, err
-	}
-
-	script, err := resolveProjectRootBuildScript(findProjectRoot, target)
+	target, releaseSpec, script, err := resolveBuildExecutionTargetAndScript(findProjectRoot, target)
 	if err != nil {
 		return BuildExecutionSpec{}, err
 	}
@@ -158,17 +153,9 @@ func ResolveBuildExecution(store DockerStore, findProjectRoot ProjectFinderFunc,
 		return BuildExecutionSpec{release: releaseSpec, script: script}, nil
 	}
 
-	linuxBuilds := make([]scriptSpec, 0)
-	hadLinuxBuilds := false
-	if releaseSpec == nil {
-		linuxBuilds, err = ResolveCurrentLinuxBuildScripts(findProjectRoot, resolveBuildContext, target, target.VersionOverride)
-		if err != nil && !errors.Is(err, ErrLinuxPackageBuildNotFound) {
-			return BuildExecutionSpec{}, err
-		}
-		hadLinuxBuilds = len(linuxBuilds) > 0
-		if hadLinuxBuilds && !LinuxPackageBuildsSupported() {
-			linuxBuilds = nil
-		}
+	linuxBuilds, hadLinuxBuilds, err := resolveLinuxBuildsForExecution(findProjectRoot, resolveBuildContext, target, releaseSpec)
+	if err != nil {
+		return BuildExecutionSpec{}, err
 	}
 
 	builds, err := ResolveCurrentDockerBuildSpecs(store, findProjectRoot, resolveBuildContext, now, target)
@@ -176,19 +163,8 @@ func ResolveBuildExecution(store DockerStore, findProjectRoot ProjectFinderFunc,
 		return BuildExecutionSpec{}, err
 	}
 
-	if len(linuxBuilds) == 0 && len(builds) == 0 && releaseSpec == nil {
-		if hadLinuxBuilds {
-			return BuildExecutionSpec{skippedLinux: true}, nil
-		}
-		script, err := resolveNestedProjectBuildScript(findProjectRoot, target)
-		if err != nil {
-			return BuildExecutionSpec{}, err
-		}
-		if script != nil {
-			script.Env = buildScriptEnv(target.VersionOverride)
-			return BuildExecutionSpec{script: script}, nil
-		}
-		return BuildExecutionSpec{}, ErrDockerBuildContextNotFound
+	if buildExecutionHasNoBuilds(linuxBuilds, builds, releaseSpec) {
+		return resolveBuildExecutionWithoutBuilds(findProjectRoot, target, hadLinuxBuilds)
 	}
 
 	execution := BuildExecutionSpec{linuxBuilds: linuxBuilds, dockerBuilds: builds, skippedLinux: hadLinuxBuilds && len(linuxBuilds) == 0}
@@ -196,6 +172,52 @@ func ResolveBuildExecution(store DockerStore, findProjectRoot ProjectFinderFunc,
 		return BuildExecutionSpecWithRelease(execution, *releaseSpec), nil
 	}
 	return execution, nil
+}
+
+func resolveBuildExecutionTargetAndScript(findProjectRoot ProjectFinderFunc, target DockerCommandTarget) (DockerCommandTarget, *ReleaseSpec, *scriptSpec, error) {
+	target, releaseSpec, err := ResolveDockerBuildTarget(findProjectRoot, target)
+	if err != nil {
+		return DockerCommandTarget{}, nil, nil, err
+	}
+	script, err := resolveProjectRootBuildScript(findProjectRoot, target)
+	if err != nil {
+		return DockerCommandTarget{}, nil, nil, err
+	}
+	return target, releaseSpec, script, nil
+}
+
+func buildExecutionHasNoBuilds(linuxBuilds []scriptSpec, builds []DockerBuildSpec, releaseSpec *ReleaseSpec) bool {
+	return len(linuxBuilds) == 0 && len(builds) == 0 && releaseSpec == nil
+}
+
+func resolveLinuxBuildsForExecution(findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, target DockerCommandTarget, releaseSpec *ReleaseSpec) ([]scriptSpec, bool, error) {
+	if releaseSpec != nil {
+		return nil, false, nil
+	}
+	linuxBuilds, err := ResolveCurrentLinuxBuildScripts(findProjectRoot, resolveBuildContext, target, target.VersionOverride)
+	if err != nil && !errors.Is(err, ErrLinuxPackageBuildNotFound) {
+		return nil, false, err
+	}
+	hadLinuxBuilds := len(linuxBuilds) > 0
+	if hadLinuxBuilds && !LinuxPackageBuildsSupported() {
+		return nil, true, nil
+	}
+	return linuxBuilds, hadLinuxBuilds, nil
+}
+
+func resolveBuildExecutionWithoutBuilds(findProjectRoot ProjectFinderFunc, target DockerCommandTarget, hadLinuxBuilds bool) (BuildExecutionSpec, error) {
+	if hadLinuxBuilds {
+		return BuildExecutionSpec{skippedLinux: true}, nil
+	}
+	script, err := resolveNestedProjectBuildScript(findProjectRoot, target)
+	if err != nil {
+		return BuildExecutionSpec{}, err
+	}
+	if script == nil {
+		return BuildExecutionSpec{}, ErrDockerBuildContextNotFound
+	}
+	script.Env = buildScriptEnv(target.VersionOverride)
+	return BuildExecutionSpec{script: script}, nil
 }
 
 func BuildExecutionSpecFromDockerBuilds(builds []DockerBuildSpec) BuildExecutionSpec {
@@ -253,17 +275,8 @@ func expandLocalReleaseImageDependencies(builds []DockerBuildSpec, releaseTags m
 		return releaseTags
 	}
 
-	buildsByTag := make(map[string]DockerBuildSpec, len(builds))
-	for _, build := range builds {
-		buildsByTag[strings.TrimSpace(build.Image.Tag)] = build
-	}
-
-	expanded := make(map[string]struct{}, len(releaseTags))
-	queue := make([]string, 0, len(releaseTags))
-	for tag := range releaseTags {
-		expanded[tag] = struct{}{}
-		queue = append(queue, tag)
-	}
+	buildsByTag := dockerBuildsByTag(builds)
+	expanded, queue := queuedReleaseTags(releaseTags)
 
 	for len(queue) > 0 {
 		tag := queue[0]
@@ -290,6 +303,24 @@ func expandLocalReleaseImageDependencies(builds []DockerBuildSpec, releaseTags m
 	}
 
 	return expanded
+}
+
+func dockerBuildsByTag(builds []DockerBuildSpec) map[string]DockerBuildSpec {
+	buildsByTag := make(map[string]DockerBuildSpec, len(builds))
+	for _, build := range builds {
+		buildsByTag[strings.TrimSpace(build.Image.Tag)] = build
+	}
+	return buildsByTag
+}
+
+func queuedReleaseTags(releaseTags map[string]struct{}) (map[string]struct{}, []string) {
+	expanded := make(map[string]struct{}, len(releaseTags))
+	queue := make([]string, 0, len(releaseTags))
+	for tag := range releaseTags {
+		expanded[tag] = struct{}{}
+		queue = append(queue, tag)
+	}
+	return expanded, queue
 }
 
 func ResolveDockerBuildTarget(findProjectRoot ProjectFinderFunc, target DockerCommandTarget) (DockerCommandTarget, *ReleaseSpec, error) {
@@ -530,29 +561,15 @@ func resolveNestedProjectBuildScript(findProjectRoot ProjectFinderFunc, target D
 		return nil, nil
 	}
 
-	var script *scriptSpec
-	err = filepath.WalkDir(projectRoot, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			if d.Name() == ".git" || isProjectBuildArtifactDir(path, projectRoot) {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if d.Name() != "build.sh" {
-			return nil
-		}
-		if filepath.Dir(path) == projectRoot {
-			return nil
-		}
+	return findNestedProjectBuildScript(filepath.Clean(projectRoot))
+}
 
-		script = &scriptSpec{
-			Dir:  filepath.Dir(path),
-			Path: "./build.sh",
-		}
-		return fs.SkipAll
+func findNestedProjectBuildScript(projectRoot string) (*scriptSpec, error) {
+	var script *scriptSpec
+	err := filepath.WalkDir(projectRoot, func(path string, d fs.DirEntry, err error) error {
+		var walkErr error
+		script, walkErr = nestedProjectBuildScriptCandidate(projectRoot, path, d, err)
+		return walkErr
 	})
 	if err != nil {
 		if errors.Is(err, fs.SkipAll) {
@@ -561,6 +578,22 @@ func resolveNestedProjectBuildScript(findProjectRoot ProjectFinderFunc, target D
 		return nil, err
 	}
 	return script, nil
+}
+
+func nestedProjectBuildScriptCandidate(projectRoot, path string, d fs.DirEntry, err error) (*scriptSpec, error) {
+	if err != nil {
+		return nil, err
+	}
+	if d.IsDir() {
+		if d.Name() == ".git" || isProjectBuildArtifactDir(path, projectRoot) {
+			return nil, filepath.SkipDir
+		}
+		return nil, nil
+	}
+	if d.Name() != "build.sh" || filepath.Dir(path) == projectRoot {
+		return nil, nil
+	}
+	return &scriptSpec{Dir: filepath.Dir(path), Path: "./build.sh"}, fs.SkipAll
 }
 
 func isProjectBuildArtifactDir(path, projectRoot string) bool {
@@ -658,15 +691,9 @@ func resolveProjectRootDevopsDockerDir(findProjectRoot ProjectFinderFunc, projec
 		return "", false, nil
 	}
 
-	if tenant, detectedProjectRoot, err := findProjectRoot(); err == nil &&
-		filepath.Clean(strings.TrimSpace(detectedProjectRoot)) == projectRoot &&
-		strings.TrimSpace(tenant) != "" {
-		dockerDir := filepath.Join(projectRoot, RuntimeReleaseName(tenant), "docker")
-		if ok, err := isDockerBuildModuleDir(dockerDir); err != nil {
-			return "", false, err
-		} else if ok {
-			return dockerDir, true, nil
-		}
+	dockerDir, ok, err := detectedProjectRootDevopsDockerDir(findProjectRoot, projectRoot)
+	if err != nil || ok {
+		return dockerDir, ok, err
 	}
 
 	candidates, err := findDevopsDockerDirs(projectRoot)
@@ -681,6 +708,20 @@ func resolveProjectRootDevopsDockerDir(findProjectRoot ProjectFinderFunc, projec
 	default:
 		return "", false, fmt.Errorf("multiple devops docker directories found under project root")
 	}
+}
+
+func detectedProjectRootDevopsDockerDir(findProjectRoot ProjectFinderFunc, projectRoot string) (string, bool, error) {
+	tenant, detectedProjectRoot, err := findProjectRoot()
+	if err != nil || filepath.Clean(strings.TrimSpace(detectedProjectRoot)) != projectRoot || strings.TrimSpace(tenant) == "" {
+		return "", false, nil
+	}
+	dockerDir := filepath.Join(projectRoot, RuntimeReleaseName(tenant), "docker")
+	if ok, err := isDockerBuildModuleDir(dockerDir); err != nil {
+		return "", false, err
+	} else if ok {
+		return dockerDir, true, nil
+	}
+	return "", false, nil
 }
 
 func findDevopsDockerDirs(projectRoot string) ([]string, error) {
@@ -736,6 +777,14 @@ func resolveDockerBuildEnvironment(store DockerStore, findProjectRoot ProjectFin
 		return environment, nil
 	}
 
+	cleanProjectRoot := filepath.Clean(projectRoot)
+	if environment, err := dockerBuildEnvironmentFromTenantConfigs(store, cleanProjectRoot); environment != "" || err != nil {
+		return environment, err
+	}
+	return dockerBuildEnvironmentFromDetectedProject(store, findProjectRoot, cleanProjectRoot)
+}
+
+func dockerBuildEnvironmentFromTenantConfigs(store DockerStore, cleanProjectRoot string) (string, error) {
 	tenants, err := store.ListTenantConfigs()
 	if err != nil {
 		if errors.Is(err, ErrNotInitialized) {
@@ -744,14 +793,16 @@ func resolveDockerBuildEnvironment(store DockerStore, findProjectRoot ProjectFin
 		return "", err
 	}
 
-	cleanProjectRoot := filepath.Clean(projectRoot)
 	for _, tenantConfig := range tenants {
 		if filepath.Clean(tenantConfig.ProjectRoot) != cleanProjectRoot {
 			continue
 		}
 		return strings.TrimSpace(tenantConfig.DefaultEnvironment), nil
 	}
+	return "", nil
+}
 
+func dockerBuildEnvironmentFromDetectedProject(store DockerStore, findProjectRoot ProjectFinderFunc, cleanProjectRoot string) (string, error) {
 	tenant, detectedProjectRoot, err := findProjectRoot()
 	if err != nil {
 		if errors.Is(err, ErrNotInGitRepository) {
@@ -979,43 +1030,7 @@ func runBuildExecution(ctx Context, execution BuildExecutionSpec, deploySpecs []
 		ctx.Trace("skipping linux package scripts: host is not Linux or dpkg-deb is unavailable")
 	}
 
-	pushedTags := make(map[string]struct{}, len(execution.dockerBuilds)+len(execution.dockerPushes))
-	var err error
-	if execution.script != nil {
-		if len(deploySpecs) > 0 {
-			return fmt.Errorf("build deploy is not supported for project build scripts")
-		}
-		err = runScriptSpec(ctx, *execution.script, runScript)
-	} else {
-		if err = runScriptSpecs(ctx, execution.linuxBuilds, runScript); err != nil {
-			return err
-		}
-		if len(execution.dockerPushes) > 0 {
-			err = RunDockerPushExecution(ctx, DockerPushExecutionSpec{
-				builds: execution.dockerBuilds,
-				pushes: execution.dockerPushes,
-			}, build, push)
-			if err == nil {
-				for _, pushInput := range execution.dockerPushes {
-					pushedTags[pushInput.Image.Tag] = struct{}{}
-				}
-			}
-		} else if len(deploySpecs) > 0 {
-			err = RunDockerBuilds(ctx, execution.dockerBuilds, build)
-			if err == nil {
-				for _, buildInput := range execution.dockerBuilds {
-					pushInput := NewDockerPushSpec(buildInput.ContextDir, buildInput.Image)
-					if pushErr := RunDockerPushSpec(ctx, pushInput, nil, build, push); pushErr != nil {
-						err = pushErr
-						break
-					}
-					pushedTags[pushInput.Image.Tag] = struct{}{}
-				}
-			}
-		} else {
-			err = RunDockerBuilds(ctx, execution.dockerBuilds, build)
-		}
-	}
+	pushedTags, err := runBuildExecutionBuilds(ctx, execution, deploySpecs, runScript, build, push)
 	if err != nil {
 		return err
 	}
@@ -1029,6 +1044,55 @@ func runBuildExecution(ctx Context, execution BuildExecutionSpec, deploySpecs []
 	}
 	if version := deployedVersionForSpecs(deploySpecs); version != "" {
 		ctx.Info("deployed version: " + version)
+	}
+	return nil
+}
+
+func runBuildExecutionBuilds(ctx Context, execution BuildExecutionSpec, deploySpecs []DeploySpec, runScript BuildScriptRunnerFunc, build DockerImageBuilderFunc, push DockerPushFunc) (map[string]struct{}, error) {
+	pushedTags := make(map[string]struct{}, len(execution.dockerBuilds)+len(execution.dockerPushes))
+	if execution.script != nil {
+		if len(deploySpecs) > 0 {
+			return nil, fmt.Errorf("build deploy is not supported for project build scripts")
+		}
+		return pushedTags, runScriptSpec(ctx, *execution.script, runScript)
+	}
+	if err := runScriptSpecs(ctx, execution.linuxBuilds, runScript); err != nil {
+		return nil, err
+	}
+	return runDockerBuildExecutionPhase(ctx, execution, deploySpecs, build, push, pushedTags)
+}
+
+func runDockerBuildExecutionPhase(ctx Context, execution BuildExecutionSpec, deploySpecs []DeploySpec, build DockerImageBuilderFunc, push DockerPushFunc, pushedTags map[string]struct{}) (map[string]struct{}, error) {
+	if len(execution.dockerPushes) > 0 {
+		err := RunDockerPushExecution(ctx, DockerPushExecutionSpec{builds: execution.dockerBuilds, pushes: execution.dockerPushes}, build, push)
+		if err != nil {
+			return pushedTags, err
+		}
+		return recordDockerPushTags(pushedTags, execution.dockerPushes), nil
+	}
+	if len(deploySpecs) > 0 {
+		return pushedTags, buildAndPushDeployDockerImages(ctx, execution.dockerBuilds, build, push, pushedTags)
+	}
+	return pushedTags, RunDockerBuilds(ctx, execution.dockerBuilds, build)
+}
+
+func recordDockerPushTags(tags map[string]struct{}, pushes []DockerPushSpec) map[string]struct{} {
+	for _, pushInput := range pushes {
+		tags[pushInput.Image.Tag] = struct{}{}
+	}
+	return tags
+}
+
+func buildAndPushDeployDockerImages(ctx Context, builds []DockerBuildSpec, build DockerImageBuilderFunc, push DockerPushFunc, pushedTags map[string]struct{}) error {
+	if err := RunDockerBuilds(ctx, builds, build); err != nil {
+		return err
+	}
+	for _, buildInput := range builds {
+		pushInput := NewDockerPushSpec(buildInput.ContextDir, buildInput.Image)
+		if err := RunDockerPushSpec(ctx, pushInput, nil, build, push); err != nil {
+			return err
+		}
+		pushedTags[pushInput.Image.Tag] = struct{}{}
 	}
 	return nil
 }

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -1347,29 +1347,11 @@ func FindComponentDockerBuildContext(projectRoot, componentName string) (DockerB
 
 	matches := make([]DockerBuildContext, 0, 1)
 	err := filepath.WalkDir(projectRoot, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
+		context, ok, walkErr := componentDockerBuildContextCandidate(path, d, componentName, err)
+		if ok {
+			matches = append(matches, context)
 		}
-		if d.IsDir() {
-			if d.Name() == ".git" {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if d.Name() != "Dockerfile" {
-			return nil
-		}
-
-		dir := filepath.Dir(path)
-		if filepath.Base(dir) != componentName || filepath.Base(filepath.Dir(dir)) != "docker" {
-			return nil
-		}
-
-		matches = append(matches, DockerBuildContext{
-			Dir:            dir,
-			DockerfilePath: path,
-		})
-		return nil
+		return walkErr
 	})
 	if err != nil {
 		return DockerBuildContext{}, false, err
@@ -1381,6 +1363,26 @@ func FindComponentDockerBuildContext(projectRoot, componentName string) (DockerB
 		return DockerBuildContext{}, false, fmt.Errorf("multiple Docker build contexts found for component %q", componentName)
 	}
 	return matches[0], true, nil
+}
+
+func componentDockerBuildContextCandidate(path string, d os.DirEntry, componentName string, err error) (DockerBuildContext, bool, error) {
+	if err != nil {
+		return DockerBuildContext{}, false, err
+	}
+	if d.IsDir() {
+		if d.Name() == ".git" {
+			return DockerBuildContext{}, false, filepath.SkipDir
+		}
+		return DockerBuildContext{}, false, nil
+	}
+	if d.Name() != "Dockerfile" {
+		return DockerBuildContext{}, false, nil
+	}
+	dir := filepath.Dir(path)
+	if filepath.Base(dir) != componentName || filepath.Base(filepath.Dir(dir)) != "docker" {
+		return DockerBuildContext{}, false, nil
+	}
+	return DockerBuildContext{Dir: dir, DockerfilePath: path}, true, nil
 }
 
 func DockerImageBuilder(buildInput DockerBuildSpec, stdout, stderr io.Writer) error {
@@ -1813,29 +1815,11 @@ func FindComponentLinuxPackageContext(projectRoot, componentName string) (LinuxP
 
 	matches := make([]LinuxPackageContext, 0, 1)
 	err := filepath.WalkDir(projectRoot, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
+		context, ok, walkErr := componentLinuxPackageContextCandidate(path, d, componentName, err)
+		if ok {
+			matches = append(matches, context)
 		}
-		if d.IsDir() {
-			if d.Name() == ".git" {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if d.Name() != "build.sh" && d.Name() != "release.sh" {
-			return nil
-		}
-
-		dir := filepath.Dir(path)
-		if filepath.Base(dir) != componentName || filepath.Base(filepath.Dir(dir)) != "linux" {
-			return nil
-		}
-		context, ok, err := LinuxPackageContextAtDir(dir)
-		if err != nil || !ok {
-			return err
-		}
-		matches = append(matches, context)
-		return nil
+		return walkErr
 	})
 	if err != nil {
 		return LinuxPackageContext{}, false, err
@@ -1847,6 +1831,26 @@ func FindComponentLinuxPackageContext(projectRoot, componentName string) (LinuxP
 		return LinuxPackageContext{}, false, fmt.Errorf("multiple linux package contexts found for component %q", componentName)
 	}
 	return matches[0], true, nil
+}
+
+func componentLinuxPackageContextCandidate(path string, d os.DirEntry, componentName string, err error) (LinuxPackageContext, bool, error) {
+	if err != nil {
+		return LinuxPackageContext{}, false, err
+	}
+	if d.IsDir() {
+		if d.Name() == ".git" {
+			return LinuxPackageContext{}, false, filepath.SkipDir
+		}
+		return LinuxPackageContext{}, false, nil
+	}
+	if d.Name() != "build.sh" && d.Name() != "release.sh" {
+		return LinuxPackageContext{}, false, nil
+	}
+	dir := filepath.Dir(path)
+	if filepath.Base(dir) != componentName || filepath.Base(filepath.Dir(dir)) != "linux" {
+		return LinuxPackageContext{}, false, nil
+	}
+	return LinuxPackageContextAtDir(dir)
 }
 
 func resolveCurrentDevopsLinuxDir(findProjectRoot ProjectFinderFunc, dir string, target DockerCommandTarget) (string, bool, error) {
@@ -1881,15 +1885,9 @@ func resolveProjectRootDevopsLinuxDir(findProjectRoot ProjectFinderFunc, project
 		return "", false, nil
 	}
 
-	if tenant, detectedProjectRoot, err := findProjectRoot(); err == nil &&
-		filepath.Clean(strings.TrimSpace(detectedProjectRoot)) == projectRoot &&
-		strings.TrimSpace(tenant) != "" {
-		linuxDir := filepath.Join(projectRoot, RuntimeReleaseName(tenant), "linux")
-		if ok, err := isLinuxPackageModuleDir(linuxDir); err != nil {
-			return "", false, err
-		} else if ok {
-			return linuxDir, true, nil
-		}
+	linuxDir, ok, err := detectedProjectRootDevopsLinuxDir(findProjectRoot, projectRoot)
+	if err != nil || ok {
+		return linuxDir, ok, err
 	}
 
 	candidates, err := findDevopsLinuxDirs(projectRoot)
@@ -1904,6 +1902,20 @@ func resolveProjectRootDevopsLinuxDir(findProjectRoot ProjectFinderFunc, project
 	default:
 		return "", false, fmt.Errorf("multiple devops linux directories found under project root")
 	}
+}
+
+func detectedProjectRootDevopsLinuxDir(findProjectRoot ProjectFinderFunc, projectRoot string) (string, bool, error) {
+	tenant, detectedProjectRoot, err := findProjectRoot()
+	if err != nil || filepath.Clean(strings.TrimSpace(detectedProjectRoot)) != projectRoot || strings.TrimSpace(tenant) == "" {
+		return "", false, nil
+	}
+	linuxDir := filepath.Join(projectRoot, RuntimeReleaseName(tenant), "linux")
+	if ok, err := isLinuxPackageModuleDir(linuxDir); err != nil {
+		return "", false, err
+	} else if ok {
+		return linuxDir, true, nil
+	}
+	return "", false, nil
 }
 
 func findDevopsLinuxDirs(projectRoot string) ([]string, error) {
@@ -2064,44 +2076,12 @@ func ResolveDockerBuildVersion(buildDir, projectRoot string) (string, bool, stri
 func dockerBuildVersionCandidates(buildDir, projectRoot string) []string {
 	dirs := make([]string, 0, 4)
 	seen := make(map[string]struct{}, 4)
-	addDir := func(dir string) {
-		dir = filepath.Clean(dir)
-		if dir == "" {
-			return
-		}
-		if _, ok := seen[dir]; ok {
-			return
-		}
-		seen[dir] = struct{}{}
-		dirs = append(dirs, dir)
-	}
-
-	addDir(buildDir)
+	dirs = appendUniqueVersionDir(dirs, seen, buildDir)
 
 	if filepath.Base(filepath.Dir(buildDir)) == "docker" {
-		for dir := filepath.Dir(filepath.Dir(buildDir)); dir != ""; {
-			addDir(dir)
-			if projectRoot != "" && filepath.Clean(dir) == filepath.Clean(projectRoot) {
-				break
-			}
-			parent := filepath.Dir(dir)
-			if parent == dir {
-				break
-			}
-			dir = parent
-		}
+		dirs = appendVersionAncestorDirs(dirs, seen, filepath.Dir(filepath.Dir(buildDir)), projectRoot)
 	} else {
-		for dir := filepath.Dir(buildDir); dir != ""; {
-			addDir(dir)
-			if projectRoot != "" && filepath.Clean(dir) == filepath.Clean(projectRoot) {
-				break
-			}
-			parent := filepath.Dir(dir)
-			if parent == dir {
-				break
-			}
-			dir = parent
-		}
+		dirs = appendVersionAncestorDirs(dirs, seen, filepath.Dir(buildDir), projectRoot)
 	}
 
 	paths := make([]string, 0, len(dirs))
@@ -2109,6 +2089,37 @@ func dockerBuildVersionCandidates(buildDir, projectRoot string) []string {
 		paths = append(paths, filepath.Join(dir, "VERSION"))
 	}
 	return paths
+}
+
+func appendVersionAncestorDirs(dirs []string, seen map[string]struct{}, startDir, projectRoot string) []string {
+	for dir := startDir; dir != ""; {
+		dirs = appendUniqueVersionDir(dirs, seen, dir)
+		if reachedVersionRoot(dir, projectRoot) {
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return dirs
+}
+
+func appendUniqueVersionDir(dirs []string, seen map[string]struct{}, dir string) []string {
+	dir = filepath.Clean(dir)
+	if dir == "" {
+		return dirs
+	}
+	if _, ok := seen[dir]; ok {
+		return dirs
+	}
+	seen[dir] = struct{}{}
+	return append(dirs, dir)
+}
+
+func reachedVersionRoot(dir, projectRoot string) bool {
+	return projectRoot != "" && filepath.Clean(dir) == filepath.Clean(projectRoot)
 }
 
 func formatLocalSnapshotVersion(version string, now time.Time) string {

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -401,17 +401,6 @@ func ResolveDockerImageReference(store DockerStore, findProjectRoot ProjectFinde
 	return resolveDockerImageReferenceForProject(now, projectRoot, environment, buildDir, strings.TrimSpace(target.VersionOverride))
 }
 
-func resolveCurrentDockerBuildSpec(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, target DockerCommandTarget) (DockerBuildSpec, error) {
-	store, findProjectRoot, resolveBuildContext, now = normalizeDockerDependencies(store, findProjectRoot, resolveBuildContext, now)
-
-	buildContext, err := resolveSingleCurrentDockerBuildContext(findProjectRoot, resolveBuildContext, target)
-	if err != nil {
-		return DockerBuildSpec{}, err
-	}
-
-	return resolveDockerBuildSpec(store, findProjectRoot, resolveBuildContext, now, buildContext, target)
-}
-
 func ResolveDockerBuildForComponent(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, projectRoot, environment, componentName, versionOverride string) (*DockerBuildSpec, error) {
 	_, _, resolveBuildContext, now = normalizeDockerDependencies(store, findProjectRoot, resolveBuildContext, now)
 
@@ -419,20 +408,12 @@ func ResolveDockerBuildForComponent(store DockerStore, findProjectRoot ProjectFi
 		return nil, nil
 	}
 
-	if resolveBuildContext != nil {
-		buildContext, err := resolveBuildContext()
-		if err == nil {
-			dir := filepath.Clean(strings.TrimSpace(buildContext.Dir))
-			if filepath.Base(dir) == strings.TrimSpace(componentName) &&
-				filepath.Base(filepath.Dir(dir)) == "docker" &&
-				strings.TrimSpace(buildContext.DockerfilePath) != "" {
-				build, err := newDockerBuildSpec(now, projectRoot, environment, buildContext, versionOverride)
-				if err != nil {
-					return nil, err
-				}
-				return &build, nil
-			}
+	if buildContext, ok := currentComponentDockerBuildContext(resolveBuildContext, componentName); ok {
+		build, err := newDockerBuildSpec(now, projectRoot, environment, buildContext, versionOverride)
+		if err != nil {
+			return nil, err
 		}
+		return &build, nil
 	}
 
 	buildContext, ok, err := FindComponentDockerBuildContext(projectRoot, componentName)
@@ -445,6 +426,21 @@ func ResolveDockerBuildForComponent(store DockerStore, findProjectRoot ProjectFi
 		return nil, err
 	}
 	return &build, nil
+}
+
+func currentComponentDockerBuildContext(resolveBuildContext BuildContextResolverFunc, componentName string) (DockerBuildContext, bool) {
+	if resolveBuildContext == nil {
+		return DockerBuildContext{}, false
+	}
+	buildContext, err := resolveBuildContext()
+	if err != nil {
+		return DockerBuildContext{}, false
+	}
+	dir := filepath.Clean(strings.TrimSpace(buildContext.Dir))
+	if filepath.Base(dir) != strings.TrimSpace(componentName) || filepath.Base(filepath.Dir(dir)) != "docker" {
+		return DockerBuildContext{}, false
+	}
+	return buildContext, strings.TrimSpace(buildContext.DockerfilePath) != ""
 }
 
 func ResolveDockerBuildForImageReference(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, projectRoot, environment, image string) (DockerBuildSpec, bool, error) {
@@ -602,17 +598,6 @@ func normalizeDockerDependencies(store DockerStore, findProjectRoot ProjectFinde
 	return store, findProjectRoot, resolveBuildContext, now
 }
 
-func resolveSingleCurrentDockerBuildContext(findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, target DockerCommandTarget) (DockerBuildContext, error) {
-	buildContexts, err := ResolveCurrentDockerBuildContexts(findProjectRoot, resolveBuildContext, target)
-	if err != nil {
-		return DockerBuildContext{}, err
-	}
-	if len(buildContexts) != 1 {
-		return DockerBuildContext{}, fmt.Errorf("expected exactly one Docker build context, got %d", len(buildContexts))
-	}
-	return buildContexts[0], nil
-}
-
 func ResolveCurrentDockerBuildContexts(findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, target DockerCommandTarget) ([]DockerBuildContext, error) {
 	if resolveBuildContext == nil {
 		resolveBuildContext = ResolveDockerBuildContext
@@ -684,27 +669,10 @@ func resolveProjectRootDevopsDockerDir(findProjectRoot ProjectFinderFunc, projec
 		}
 	}
 
-	entries, err := os.ReadDir(projectRoot)
+	candidates, err := findDevopsDockerDirs(projectRoot)
 	if err != nil {
 		return "", false, err
 	}
-
-	candidates := make([]string, 0, 1)
-	for _, entry := range entries {
-		if !entry.IsDir() || !strings.HasSuffix(entry.Name(), "-devops") {
-			continue
-		}
-
-		dockerDir := filepath.Join(projectRoot, entry.Name(), "docker")
-		ok, err := isDockerBuildModuleDir(dockerDir)
-		if err != nil {
-			return "", false, err
-		}
-		if ok {
-			candidates = append(candidates, dockerDir)
-		}
-	}
-
 	switch len(candidates) {
 	case 0:
 		return "", false, nil
@@ -713,6 +681,28 @@ func resolveProjectRootDevopsDockerDir(findProjectRoot ProjectFinderFunc, projec
 	default:
 		return "", false, fmt.Errorf("multiple devops docker directories found under project root")
 	}
+}
+
+func findDevopsDockerDirs(projectRoot string) ([]string, error) {
+	entries, err := os.ReadDir(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	candidates := make([]string, 0, 1)
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasSuffix(entry.Name(), "-devops") {
+			continue
+		}
+		dockerDir := filepath.Join(projectRoot, entry.Name(), "docker")
+		ok, err := isDockerBuildModuleDir(dockerDir)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			candidates = append(candidates, dockerDir)
+		}
+	}
+	return candidates, nil
 }
 
 func isDockerBuildModuleDir(dir string) (bool, error) {
@@ -1838,27 +1828,10 @@ func resolveProjectRootDevopsLinuxDir(findProjectRoot ProjectFinderFunc, project
 		}
 	}
 
-	entries, err := os.ReadDir(projectRoot)
+	candidates, err := findDevopsLinuxDirs(projectRoot)
 	if err != nil {
 		return "", false, err
 	}
-
-	candidates := make([]string, 0, 1)
-	for _, entry := range entries {
-		if !entry.IsDir() || !strings.HasSuffix(entry.Name(), "-devops") {
-			continue
-		}
-
-		linuxDir := filepath.Join(projectRoot, entry.Name(), "linux")
-		ok, err := isLinuxPackageModuleDir(linuxDir)
-		if err != nil {
-			return "", false, err
-		}
-		if ok {
-			candidates = append(candidates, linuxDir)
-		}
-	}
-
 	switch len(candidates) {
 	case 0:
 		return "", false, nil
@@ -1867,6 +1840,28 @@ func resolveProjectRootDevopsLinuxDir(findProjectRoot ProjectFinderFunc, project
 	default:
 		return "", false, fmt.Errorf("multiple devops linux directories found under project root")
 	}
+}
+
+func findDevopsLinuxDirs(projectRoot string) ([]string, error) {
+	entries, err := os.ReadDir(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	candidates := make([]string, 0, 1)
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasSuffix(entry.Name(), "-devops") {
+			continue
+		}
+		linuxDir := filepath.Join(projectRoot, entry.Name(), "linux")
+		ok, err := isLinuxPackageModuleDir(linuxDir)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			candidates = append(candidates, linuxDir)
+		}
+	}
+	return candidates, nil
 }
 
 func isLinuxPackageModuleDir(dir string) (bool, error) {

--- a/erun-common/build_test.go
+++ b/erun-common/build_test.go
@@ -150,16 +150,9 @@ func TestDockerBuildTraceCommandsIncludeBuildxBootstrapForMultiPlatformBuilds(t 
 func TestResolveBuildExecutionMarksEnvironmentConfiguredBuildsSkippable(t *testing.T) {
 	projectRoot := t.TempDir()
 	buildDir := filepath.Join(projectRoot, "erun-devops", "docker", "erun-devops")
-	if err := os.MkdirAll(buildDir, 0o755); err != nil {
-		t.Fatalf("mkdir build dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectRoot, "erun-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := SaveProjectConfig(projectRoot, ProjectConfig{
+	writeDockerBuildFixture(t, buildDir)
+	writeVersionFileForTest(t, filepath.Join(projectRoot, "erun-devops", "VERSION"), "1.0.0")
+	requireNoError(t, SaveProjectConfig(projectRoot, ProjectConfig{
 		Environments: map[string]ProjectEnvironmentConfig{
 			DefaultEnvironment: {
 				ContainerRegistry: "erunpaas",
@@ -174,9 +167,7 @@ func TestResolveBuildExecutionMarksEnvironmentConfiguredBuildsSkippable(t *testi
 				},
 			},
 		},
-	}); err != nil {
-		t.Fatalf("SaveProjectConfig failed: %v", err)
-	}
+	}), "SaveProjectConfig failed")
 
 	localExecution, err := ResolveBuildExecution(
 		ConfigStore{},
@@ -189,12 +180,8 @@ func TestResolveBuildExecutionMarksEnvironmentConfiguredBuildsSkippable(t *testi
 		func() time.Time { return time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC) },
 		DockerCommandTarget{ProjectRoot: projectRoot, Environment: DefaultEnvironment},
 	)
-	if err != nil {
-		t.Fatalf("ResolveBuildExecution local failed: %v", err)
-	}
-	if len(localExecution.dockerBuilds) != 1 || !localExecution.dockerBuilds[0].SkipIfExists {
-		t.Fatalf("expected local build to be skippable, got %+v", localExecution.dockerBuilds)
-	}
+	requireNoError(t, err, "ResolveBuildExecution local failed")
+	requireSkippableBuild(t, localExecution)
 
 	frsExecution, err := ResolveBuildExecution(
 		ConfigStore{},
@@ -207,12 +194,31 @@ func TestResolveBuildExecutionMarksEnvironmentConfiguredBuildsSkippable(t *testi
 		func() time.Time { return time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC) },
 		DockerCommandTarget{ProjectRoot: projectRoot, Environment: "frs"},
 	)
-	if err != nil {
-		t.Fatalf("ResolveBuildExecution frs failed: %v", err)
-	}
-	if len(frsExecution.dockerBuilds) != 1 || frsExecution.dockerBuilds[0].SkipIfExists {
-		t.Fatalf("did not expect frs build to be skippable, got %+v", frsExecution.dockerBuilds)
-	}
+	requireNoError(t, err, "ResolveBuildExecution frs failed")
+	requireUnskippableBuild(t, frsExecution)
+}
+
+func writeDockerBuildFixture(t *testing.T, buildDir string) {
+	t.Helper()
+	requireNoError(t, os.MkdirAll(buildDir, 0o755), "mkdir build dir")
+	requireNoError(t, os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+}
+
+func writeVersionFileForTest(t *testing.T, path, version string) {
+	t.Helper()
+	requireNoError(t, os.WriteFile(path, []byte(version+"\n"), 0o644), "write VERSION")
+}
+
+func requireSkippableBuild(t *testing.T, execution BuildExecutionSpec) {
+	t.Helper()
+	requireEqual(t, len(execution.dockerBuilds), 1, "docker build count")
+	requireCondition(t, execution.dockerBuilds[0].SkipIfExists, "expected build to be skippable, got %+v", execution.dockerBuilds)
+}
+
+func requireUnskippableBuild(t *testing.T, execution BuildExecutionSpec) {
+	t.Helper()
+	requireEqual(t, len(execution.dockerBuilds), 1, "docker build count")
+	requireCondition(t, !execution.dockerBuilds[0].SkipIfExists, "did not expect build to be skippable, got %+v", execution.dockerBuilds)
 }
 
 func TestRunDockerBuildsSkipsConfiguredExistingLocalImages(t *testing.T) {
@@ -552,19 +558,9 @@ func TestResolveBuildExecutionPrefersProjectRootBuildScriptOverNestedScripts(t *
 func TestResolveBuildExecutionUsesFirstNestedProjectBuildScript(t *testing.T) {
 	projectRoot := t.TempDir()
 	firstDir := filepath.Join(projectRoot, "scripts", "alpha")
-	if err := os.MkdirAll(firstDir, 0o755); err != nil {
-		t.Fatalf("mkdir first dir: %v", err)
-	}
 	secondDir := filepath.Join(projectRoot, "scripts", "zeta")
-	if err := os.MkdirAll(secondDir, 0o755); err != nil {
-		t.Fatalf("mkdir second dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(firstDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write first build.sh: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(secondDir, "build.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write second build.sh: %v", err)
-	}
+	writeBuildScriptForTest(t, firstDir)
+	writeBuildScriptForTest(t, secondDir)
 
 	execution, err := ResolveBuildExecution(
 		ConfigStore{},
@@ -577,9 +573,7 @@ func TestResolveBuildExecutionUsesFirstNestedProjectBuildScript(t *testing.T) {
 		nil,
 		DockerCommandTarget{},
 	)
-	if err != nil {
-		t.Fatalf("ResolveBuildExecution failed: %v", err)
-	}
+	requireNoError(t, err, "ResolveBuildExecution failed")
 
 	var called bool
 	ctx := Context{
@@ -588,24 +582,23 @@ func TestResolveBuildExecutionUsesFirstNestedProjectBuildScript(t *testing.T) {
 		Stdout: new(bytes.Buffer),
 		Stderr: new(bytes.Buffer),
 	}
-	if err := RunBuildExecution(ctx, execution, func(dir, path string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	err = RunBuildExecution(ctx, execution, func(dir, path string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		called = true
-		if dir != firstDir || path != "./build.sh" {
-			t.Fatalf("unexpected script call: dir=%q path=%q", dir, path)
-		}
-		if len(env) != 0 {
-			t.Fatalf("unexpected script env: %+v", env)
-		}
+		requireCondition(t, dir == firstDir && path == "./build.sh", "unexpected script call: dir=%q path=%q", dir, path)
+		requireEqual(t, len(env), 0, "script env count")
 		return nil
 	}, func(DockerBuildSpec, io.Writer, io.Writer) error {
 		t.Fatal("unexpected docker build")
 		return nil
-	}, nil); err != nil {
-		t.Fatalf("RunBuildExecution failed: %v", err)
-	}
-	if !called {
-		t.Fatal("expected build script runner to be called")
-	}
+	}, nil)
+	requireNoError(t, err, "RunBuildExecution failed")
+	requireCondition(t, called, "expected build script runner to be called")
+}
+
+func writeBuildScriptForTest(t *testing.T, dir string) {
+	t.Helper()
+	requireNoError(t, os.MkdirAll(dir, 0o755), "mkdir build script dir")
+	requireNoError(t, os.WriteFile(filepath.Join(dir, "build.sh"), []byte("#!/bin/sh\n"), 0o755), "write build.sh")
 }
 
 func TestResolveBuildExecutionPrefersDockerBuildsOverNestedProjectBuildScript(t *testing.T) {
@@ -900,27 +893,15 @@ func TestResolveBuildExecutionBuildsWithoutPushesForProjectRootDevopsScope(t *te
 		filepath.Join(moduleRoot, "docker", "tenant-a-devops"),
 		filepath.Join(moduleRoot, "docker", "erun-dind"),
 	}
-	for _, dir := range componentDirs {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("mkdir component dir: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-			t.Fatalf("write Dockerfile: %v", err)
-		}
-	}
-	if err := os.WriteFile(filepath.Join(componentDirs[0], "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentDirs[1], "VERSION"), []byte("28.1.1\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-	if err := SaveProjectConfig(projectRoot, ProjectConfig{
+	writeDockerBuildFixture(t, componentDirs[0])
+	writeVersionFileForTest(t, filepath.Join(componentDirs[0], "VERSION"), "1.0.0")
+	writeDockerBuildFixture(t, componentDirs[1])
+	writeVersionFileForTest(t, filepath.Join(componentDirs[1], "VERSION"), "28.1.1")
+	requireNoError(t, SaveProjectConfig(projectRoot, ProjectConfig{
 		Environments: map[string]ProjectEnvironmentConfig{
 			DefaultEnvironment: {ContainerRegistry: "erunpaas"},
 		},
-	}); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	}), "save project config")
 
 	execution, err := ResolveBuildExecution(
 		ConfigStore{},
@@ -933,26 +914,23 @@ func TestResolveBuildExecutionBuildsWithoutPushesForProjectRootDevopsScope(t *te
 		nil,
 		DockerCommandTarget{Environment: DefaultEnvironment},
 	)
-	if err != nil {
-		t.Fatalf("ResolveBuildExecution failed: %v", err)
-	}
+	requireNoError(t, err, "ResolveBuildExecution failed")
 
-	if len(execution.dockerBuilds) != 2 || len(execution.dockerPushes) != 0 {
-		t.Fatalf("unexpected execution: %+v", execution)
-	}
+	requireProjectRootDevopsBuilds(t, execution)
+}
+
+func requireProjectRootDevopsBuilds(t *testing.T, execution BuildExecutionSpec) {
+	t.Helper()
+	requireEqual(t, len(execution.dockerBuilds), 2, "docker build count")
+	requireEqual(t, len(execution.dockerPushes), 0, "docker push count")
 	buildTags := []string{execution.dockerBuilds[0].Image.Tag, execution.dockerBuilds[1].Image.Tag}
-	wantTags := []string{"erunpaas/tenant-a-devops:1.0.0", "erunpaas/erun-dind:28.1.1"}
-	for _, want := range wantTags {
-		found := false
-		for _, got := range buildTags {
-			if got == want {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Fatalf("missing build tag %q in %+v", want, execution.dockerBuilds)
-		}
+	requireContainsAllStrings(t, buildTags, []string{"erunpaas/tenant-a-devops:1.0.0", "erunpaas/erun-dind:28.1.1"})
+}
+
+func requireContainsAllStrings(t *testing.T, got, want []string) {
+	t.Helper()
+	for _, value := range want {
+		requireCondition(t, containsString(got, value), "missing value %q in %+v", value, got)
 	}
 }
 
@@ -1004,34 +982,25 @@ func TestResolveBuildExecutionReleaseUsesResolvedVersionForDockerBuilds(t *testi
 		nil,
 		DockerCommandTarget{ProjectRoot: projectRoot, Environment: DefaultEnvironment, Release: true},
 	)
-	if err != nil {
-		t.Fatalf("ResolveBuildExecution failed: %v", err)
-	}
+	requireNoError(t, err, "ResolveBuildExecution failed")
+	requireReleaseDockerBuildExecution(t, execution)
+}
 
-	if execution.release == nil {
-		t.Fatalf("expected release spec, got %+v", execution)
-	}
-	if got := execution.release.Version; got != "1.4.2" {
-		t.Fatalf("unexpected release version: %q", got)
-	}
-	if len(execution.dockerBuilds) != 1 {
-		t.Fatalf("unexpected docker builds: %+v", execution.dockerBuilds)
-	}
-	if got := execution.dockerBuilds[0].Image.Tag; got != "erunpaas/api:1.4.2" {
-		t.Fatalf("unexpected docker build tag: %q", got)
-	}
-	if !execution.dockerBuilds[0].Push || !reflect.DeepEqual(execution.dockerBuilds[0].Platforms, []string{"linux/amd64", "linux/arm64"}) {
-		t.Fatalf("expected multi-platform release build spec, got %+v", execution.dockerBuilds[0])
-	}
-	if len(execution.dockerPushes) != 1 {
-		t.Fatalf("unexpected docker pushes: %+v", execution.dockerPushes)
-	}
-	if got := execution.dockerPushes[0].Image.Tag; got != "erunpaas/api:1.4.2" {
-		t.Fatalf("unexpected docker push tag: %q", got)
-	}
-	if got := execution.release.NextVersion; got != "1.4.3" {
-		t.Fatalf("unexpected next version: %q", got)
-	}
+func requireReleaseDockerBuildExecution(t *testing.T, execution BuildExecutionSpec) {
+	t.Helper()
+	requireCondition(t, execution.release != nil, "expected release spec, got %+v", execution)
+	requireEqual(t, execution.release.Version, "1.4.2", "release version")
+	requireEqual(t, execution.release.NextVersion, "1.4.3", "next version")
+	requireEqual(t, len(execution.dockerBuilds), 1, "docker build count")
+	requireEqual(t, execution.dockerBuilds[0].Image.Tag, "erunpaas/api:1.4.2", "docker build tag")
+	requireMultiPlatformPushedBuild(t, execution.dockerBuilds[0])
+	requireEqual(t, len(execution.dockerPushes), 1, "docker push count")
+	requireEqual(t, execution.dockerPushes[0].Image.Tag, "erunpaas/api:1.4.2", "docker push tag")
+}
+
+func requireMultiPlatformPushedBuild(t *testing.T, build DockerBuildSpec) {
+	t.Helper()
+	requireCondition(t, build.Push && reflect.DeepEqual(build.Platforms, []string{"linux/amd64", "linux/arm64"}), "expected multi-platform release build spec, got %+v", build)
 }
 
 func TestResolveBuildExecutionReleaseCarriesForceToReleaseSpec(t *testing.T) {
@@ -1093,20 +1062,12 @@ func TestResolveBuildExecutionReleasePushesLocalDockerDependenciesAndDind(t *tes
 	releaseRoot := filepath.Join(projectRoot, "erun-devops")
 
 	apiDockerfilePath := filepath.Join(releaseRoot, "docker", "api", "Dockerfile")
-	if err := os.WriteFile(apiDockerfilePath, []byte("FROM erunpaas/base:9.9.9\n"), 0o644); err != nil {
-		t.Fatalf("write api Dockerfile: %v", err)
-	}
+	requireNoError(t, os.WriteFile(apiDockerfilePath, []byte("FROM erunpaas/base:9.9.9\n"), 0o644), "write api Dockerfile")
 
 	dindDir := filepath.Join(releaseRoot, "docker", "erun-dind")
-	if err := os.MkdirAll(dindDir, 0o755); err != nil {
-		t.Fatalf("mkdir dind dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dindDir, "Dockerfile"), []byte("FROM docker:28.1.1-dind\n"), 0o644); err != nil {
-		t.Fatalf("write dind Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dindDir, "VERSION"), []byte("28.1.1\n"), 0o644); err != nil {
-		t.Fatalf("write dind VERSION: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(dindDir, 0o755), "mkdir dind dir")
+	requireNoError(t, os.WriteFile(filepath.Join(dindDir, "Dockerfile"), []byte("FROM docker:28.1.1-dind\n"), 0o644), "write dind Dockerfile")
+	writeVersionFileForTest(t, filepath.Join(dindDir, "VERSION"), "28.1.1")
 
 	execution, err := ResolveBuildExecution(
 		ConfigStore{},
@@ -1119,34 +1080,27 @@ func TestResolveBuildExecutionReleasePushesLocalDockerDependenciesAndDind(t *tes
 		nil,
 		DockerCommandTarget{ProjectRoot: projectRoot, Environment: DefaultEnvironment, Release: true},
 	)
-	if err != nil {
-		t.Fatalf("ResolveBuildExecution failed: %v", err)
-	}
+	requireNoError(t, err, "ResolveBuildExecution failed")
 
-	if len(execution.dockerPushes) != 3 {
-		t.Fatalf("unexpected docker pushes: %+v", execution.dockerPushes)
-	}
-	wantPushes := map[string]struct{}{
-		"erunpaas/api:1.4.2":        {},
-		"erunpaas/base:9.9.9":       {},
-		"erunpaas/erun-dind:28.1.1": {},
-	}
+	requireReleaseDependencyPushes(t, execution)
+}
+
+func requireReleaseDependencyPushes(t *testing.T, execution BuildExecutionSpec) {
+	t.Helper()
+	wantTags := []string{"erunpaas/api:1.4.2", "erunpaas/base:9.9.9", "erunpaas/erun-dind:28.1.1"}
+	pushTags := make([]string, 0, len(execution.dockerPushes))
 	for _, pushInput := range execution.dockerPushes {
-		if _, ok := wantPushes[pushInput.Image.Tag]; !ok {
-			t.Fatalf("unexpected docker push tag: %q", pushInput.Image.Tag)
-		}
-		delete(wantPushes, pushInput.Image.Tag)
+		pushTags = append(pushTags, pushInput.Image.Tag)
 	}
-	if len(wantPushes) != 0 {
-		t.Fatalf("missing docker pushes: %+v", wantPushes)
-	}
+	requireContainsAllStrings(t, pushTags, wantTags)
+	requireMultiPlatformReleaseBuilds(t, execution.dockerBuilds, wantTags)
+}
 
-	for _, build := range execution.dockerBuilds {
-		switch build.Image.Tag {
-		case "erunpaas/api:1.4.2", "erunpaas/base:9.9.9", "erunpaas/erun-dind:28.1.1":
-			if !build.Push || !reflect.DeepEqual(build.Platforms, []string{"linux/amd64", "linux/arm64"}) {
-				t.Fatalf("expected multi-platform release build for %q, got %+v", build.Image.Tag, build)
-			}
+func requireMultiPlatformReleaseBuilds(t *testing.T, builds []DockerBuildSpec, wantTags []string) {
+	t.Helper()
+	for _, build := range builds {
+		if containsString(wantTags, build.Image.Tag) {
+			requireMultiPlatformPushedBuild(t, build)
 		}
 	}
 }
@@ -1277,26 +1231,18 @@ func TestRunBuildExecutionReleasePublishesResolvedVersionAsMultiPlatformBuild(t 
 func TestRunBuildExecutionAndDeployDryRunReleaseReportsDeployedVersionLast(t *testing.T) {
 	projectRoot := setupReleaseProjectGitRepo(t, "develop")
 	chartPath := filepath.Join(projectRoot, "erun-devops", "k8s", "api")
-	if err := os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644); err != nil {
-		t.Fatalf("write values.local.yaml: %v", err)
-	}
-	if err := SaveTenantConfig(TenantConfig{
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644), "write values.local.yaml")
+	requireNoError(t, SaveTenantConfig(TenantConfig{
 		Name:               "tenant-a",
 		ProjectRoot:        projectRoot,
 		DefaultEnvironment: DefaultEnvironment,
-	}); err != nil {
-		t.Fatalf("save tenant config: %v", err)
-	}
-	if err := SaveEnvConfig("tenant-a", EnvConfig{
+	}), "save tenant config")
+	requireNoError(t, SaveEnvConfig("tenant-a", EnvConfig{
 		Name:              DefaultEnvironment,
 		RepoPath:          projectRoot,
 		KubernetesContext: "cluster-local",
-	}); err != nil {
-		t.Fatalf("save env config: %v", err)
-	}
-	if err := SaveProjectConfig(projectRoot, ProjectConfig{}); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	}), "save env config")
+	requireNoError(t, SaveProjectConfig(projectRoot, ProjectConfig{}), "save project config")
 
 	findProjectRoot := func() (string, string, error) {
 		return "tenant-a", projectRoot, nil
@@ -1310,9 +1256,7 @@ func TestRunBuildExecutionAndDeployDryRunReleaseReportsDeployedVersionLast(t *te
 		nil,
 		DockerCommandTarget{ProjectRoot: projectRoot, Environment: DefaultEnvironment, Release: true},
 	)
-	if err != nil {
-		t.Fatalf("ResolveBuildExecution failed: %v", err)
-	}
+	requireNoError(t, err, "ResolveBuildExecution failed")
 	deploySpec, err := ResolveDeploySpecForDockerTarget(
 		ConfigStore{},
 		findProjectRoot,
@@ -1326,12 +1270,8 @@ func TestRunBuildExecutionAndDeployDryRunReleaseReportsDeployedVersionLast(t *te
 		DockerCommandTarget{ProjectRoot: projectRoot, Environment: DefaultEnvironment, Release: true},
 		"api",
 	)
-	if err != nil {
-		t.Fatalf("ResolveDeploySpecForDockerTarget failed: %v", err)
-	}
-	if deploySpec.Deploy.Version != "1.4.2-rc.0000000" && !strings.HasPrefix(deploySpec.Deploy.Version, "1.4.2-rc.") {
-		t.Fatalf("unexpected deploy version: %+v", deploySpec.Deploy)
-	}
+	requireNoError(t, err, "ResolveDeploySpecForDockerTarget failed")
+	requireReleaseCandidateVersion(t, deploySpec.Deploy.Version, "deploy version")
 
 	stdout := new(bytes.Buffer)
 	ctx := Context{
@@ -1341,24 +1281,22 @@ func TestRunBuildExecutionAndDeployDryRunReleaseReportsDeployedVersionLast(t *te
 		Stdout: stdout,
 		Stderr: io.Discard,
 	}
-	if err := RunBuildExecutionAndDeploy(ctx, execution, []DeploySpec{deploySpec}, nil, nil, nil, func(HelmDeployParams) error {
+	err = RunBuildExecutionAndDeploy(ctx, execution, []DeploySpec{deploySpec}, nil, nil, nil, func(HelmDeployParams) error {
 		t.Fatal("unexpected deploy execution during dry-run")
 		return nil
-	}); err != nil {
-		t.Fatalf("RunBuildExecutionAndDeploy failed: %v", err)
-	}
+	})
+	requireNoError(t, err, "RunBuildExecutionAndDeploy failed")
 
 	output := strings.TrimSpace(stdout.String())
-	if !strings.Contains(output, "release version: 1.4.2-rc.") {
-		t.Fatalf("expected release version output, got:\n%s", output)
-	}
-	if !strings.Contains(output, "deployed version: 1.4.2-rc.") {
-		t.Fatalf("expected deployed version output, got:\n%s", output)
-	}
+	requireStringContains(t, output, "release version: 1.4.2-rc.", "expected release version output")
+	requireStringContains(t, output, "deployed version: 1.4.2-rc.", "expected deployed version output")
 	lines := strings.Split(output, "\n")
-	if !strings.Contains(lines[len(lines)-1], "deployed version: 1.4.2-rc.") {
-		t.Fatalf("expected deployed version last, got:\n%s", output)
-	}
+	requireStringContains(t, lines[len(lines)-1], "deployed version: 1.4.2-rc.", "expected deployed version last")
+}
+
+func requireReleaseCandidateVersion(t *testing.T, version, label string) {
+	t.Helper()
+	requireCondition(t, version == "1.4.2-rc.0000000" || strings.HasPrefix(version, "1.4.2-rc."), "unexpected %s: %s", label, version)
 }
 
 func setupReleaseProjectGitRepo(t *testing.T, branch string) string {

--- a/erun-common/cloud.go
+++ b/erun-common/cloud.go
@@ -150,28 +150,9 @@ func InitAWSCloudProvider(ctx Context, store CloudStore, params InitAWSCloudProv
 		return CloudProviderConfig{}, fmt.Errorf("store is required")
 	}
 	deps = normalizeCloudDependencies(deps)
-	profile := strings.TrimSpace(params.Profile)
-	configureProfile := profile == "" || hasAWSProfileConfig(params)
-	if profile == "" {
-		profile = generatedAWSProfileName()
-	}
-	if configureProfile {
-		profileConfig := AWSProfileConfig{
-			Profile:     profile,
-			SSOStartURL: params.SSOStartURL,
-			SSORegion:   params.SSORegion,
-			AccountID:   params.AccountID,
-			RoleName:    params.RoleName,
-			Region:      params.Region,
-		}
-		if err := deps.RunAWSConfigureSSO(ctx, profileConfig); err != nil {
-			return CloudProviderConfig{}, err
-		}
-	}
-	if !params.SkipLogin {
-		if err := deps.RunAWSLogin(ctx, profile); err != nil {
-			return CloudProviderConfig{}, err
-		}
+	profile, err := initAWSProfile(ctx, params, deps)
+	if err != nil {
+		return CloudProviderConfig{}, err
 	}
 
 	identity, err := deps.ResolveAWSIdentity(ctx, profile)
@@ -198,6 +179,36 @@ func InitAWSCloudProvider(ctx Context, store CloudStore, params InitAWSCloudProv
 		return CloudProviderConfig{}, fmt.Errorf("cloud provider alias cannot be resolved")
 	}
 	return SaveCloudProviderConfig(store, provider)
+}
+
+func initAWSProfile(ctx Context, params InitAWSCloudProviderParams, deps CloudDependencies) (string, error) {
+	profile := strings.TrimSpace(params.Profile)
+	configureProfile := profile == "" || hasAWSProfileConfig(params)
+	if profile == "" {
+		profile = generatedAWSProfileName()
+	}
+	if configureProfile {
+		if err := deps.RunAWSConfigureSSO(ctx, awsProfileConfig(profile, params)); err != nil {
+			return "", err
+		}
+	}
+	if !params.SkipLogin {
+		if err := deps.RunAWSLogin(ctx, profile); err != nil {
+			return "", err
+		}
+	}
+	return profile, nil
+}
+
+func awsProfileConfig(profile string, params InitAWSCloudProviderParams) AWSProfileConfig {
+	return AWSProfileConfig{
+		Profile:     profile,
+		SSOStartURL: params.SSOStartURL,
+		SSORegion:   params.SSORegion,
+		AccountID:   params.AccountID,
+		RoleName:    params.RoleName,
+		Region:      params.Region,
+	}
 }
 
 func hasAWSProfileConfig(params InitAWSCloudProviderParams) bool {
@@ -236,17 +247,9 @@ func SetEnvironmentCloudProviderAlias(ctx Context, store EnvironmentCloudAliasSt
 	if store == nil {
 		return EnvConfig{}, fmt.Errorf("store is required")
 	}
-	tenant := strings.TrimSpace(params.Tenant)
-	if tenant == "" {
-		return EnvConfig{}, fmt.Errorf("tenant is required")
-	}
-	environment := strings.TrimSpace(params.Environment)
-	if environment == "" {
-		return EnvConfig{}, fmt.Errorf("environment is required")
-	}
-	alias := strings.TrimSpace(params.Alias)
-	if alias == "" {
-		return EnvConfig{}, fmt.Errorf("cloud provider alias is required")
+	tenant, environment, alias, err := normalizeEnvironmentCloudProviderAliasParams(params)
+	if err != nil {
+		return EnvConfig{}, err
 	}
 
 	config, _, err := store.LoadEnvConfig(tenant, environment)
@@ -260,15 +263,7 @@ func SetEnvironmentCloudProviderAlias(ctx Context, store EnvironmentCloudAliasSt
 		config.Name = environment
 	}
 	if config.CloudProviderAlias == alias {
-		if config.Remote && !config.ManagedCloud {
-			config.ManagedCloud = true
-			if !ctx.DryRun {
-				if err := store.SaveEnvConfig(tenant, config); err != nil {
-					return EnvConfig{}, err
-				}
-			}
-		}
-		return config, nil
+		return saveManagedCloudAliasIfNeeded(ctx, store, tenant, config)
 	}
 	config.CloudProviderAlias = alias
 	if config.Remote {
@@ -276,6 +271,36 @@ func SetEnvironmentCloudProviderAlias(ctx Context, store EnvironmentCloudAliasSt
 	}
 	if ctx.DryRun {
 		ctx.Trace("write erun environment cloud provider alias " + tenant + "/" + environment)
+		return config, nil
+	}
+	if err := store.SaveEnvConfig(tenant, config); err != nil {
+		return EnvConfig{}, err
+	}
+	return config, nil
+}
+
+func normalizeEnvironmentCloudProviderAliasParams(params SetEnvironmentCloudAliasParams) (string, string, string, error) {
+	tenant := strings.TrimSpace(params.Tenant)
+	environment := strings.TrimSpace(params.Environment)
+	alias := strings.TrimSpace(params.Alias)
+	switch {
+	case tenant == "":
+		return "", "", "", fmt.Errorf("tenant is required")
+	case environment == "":
+		return "", "", "", fmt.Errorf("environment is required")
+	case alias == "":
+		return "", "", "", fmt.Errorf("cloud provider alias is required")
+	default:
+		return tenant, environment, alias, nil
+	}
+}
+
+func saveManagedCloudAliasIfNeeded(ctx Context, store EnvironmentCloudAliasStore, tenant string, config EnvConfig) (EnvConfig, error) {
+	if !config.Remote || config.ManagedCloud {
+		return config, nil
+	}
+	config.ManagedCloud = true
+	if ctx.DryRun {
 		return config, nil
 	}
 	if err := store.SaveEnvConfig(tenant, config); err != nil {

--- a/erun-common/cloud_context.go
+++ b/erun-common/cloud_context.go
@@ -849,11 +849,7 @@ func sanitizeIAMName(value string) string {
 	var b strings.Builder
 	lastDash := false
 	for _, r := range value {
-		valid := r >= 'a' && r <= 'z' ||
-			r >= 'A' && r <= 'Z' ||
-			r >= '0' && r <= '9' ||
-			r == '+' || r == '=' || r == ',' || r == '.' || r == '@' || r == '_' || r == '-'
-		if valid {
+		if isValidIAMNameRune(r) {
 			b.WriteRune(r)
 			lastDash = r == '-'
 			continue
@@ -864,6 +860,13 @@ func sanitizeIAMName(value string) string {
 		}
 	}
 	return strings.Trim(b.String(), "-")
+}
+
+func isValidIAMNameRune(r rune) bool {
+	return r >= 'a' && r <= 'z' ||
+		r >= 'A' && r <= 'Z' ||
+		r >= '0' && r <= '9' ||
+		strings.ContainsRune("+=,.@_-", r)
 }
 
 func truncateIAMName(value string) string {

--- a/erun-common/cloud_context.go
+++ b/erun-common/cloud_context.go
@@ -712,17 +712,12 @@ func ensureCloudContextInstanceProfile(ctx Context, deps CloudContextDependencie
 }
 
 func ensureCloudContextInstanceProfileRole(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, profileName, roleName string, createdProfile bool) error {
-	if !createdProfile {
-		existingRole, err := cloudContextInstanceProfileRoleName(ctx, deps, provider, region, profileName)
-		if err != nil {
-			return err
-		}
-		if existingRole == roleName {
-			return nil
-		}
-		if existingRole != "" {
-			return fmt.Errorf("instance profile %q already contains role %q; expected %q", profileName, existingRole, roleName)
-		}
+	addRole, err := shouldAddCloudContextProfileRole(ctx, deps, provider, region, profileName, roleName, createdProfile)
+	if err != nil {
+		return err
+	}
+	if !addRole {
+		return nil
 	}
 
 	if _, err := deps.RunAWS(ctx, provider, region, []string{"iam", "add-role-to-instance-profile", "--instance-profile-name", profileName, "--role-name", roleName}); err != nil {
@@ -742,6 +737,23 @@ func ensureCloudContextInstanceProfileRole(ctx Context, deps CloudContextDepende
 		return err
 	}
 	return nil
+}
+
+func shouldAddCloudContextProfileRole(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, profileName, roleName string, createdProfile bool) (bool, error) {
+	if createdProfile {
+		return true, nil
+	}
+	existingRole, err := cloudContextInstanceProfileRoleName(ctx, deps, provider, region, profileName)
+	if err != nil {
+		return false, err
+	}
+	if existingRole == roleName {
+		return false, nil
+	}
+	if existingRole != "" {
+		return false, fmt.Errorf("instance profile %q already contains role %q; expected %q", profileName, existingRole, roleName)
+	}
+	return true, nil
 }
 
 func cloudContextInstanceProfileRoleName(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, profileName string) (string, error) {

--- a/erun-common/cloud_context.go
+++ b/erun-common/cloud_context.go
@@ -695,6 +695,11 @@ type cloudContextInstanceProfile struct {
 	RoleName string
 }
 
+type cloudContextPolicyPaths struct {
+	Trust  string
+	Policy string
+}
+
 func ensureCloudContextInstanceProfile(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, name string) (cloudContextInstanceProfile, error) {
 	roleName := cloudContextInstanceRoleName(name)
 	profileName := cloudContextInstanceProfileName(name)
@@ -702,53 +707,60 @@ func ensureCloudContextInstanceProfile(ctx Context, deps CloudContextDependencie
 		return cloudContextInstanceProfile{}, fmt.Errorf("cloud context name is required")
 	}
 
-	trustPath, cleanupTrust, err := cloudContextPolicyFile(ctx, ec2AssumeRolePolicy())
+	policies, cleanup, err := cloudContextInstanceProfilePolicyPaths(ctx, provider, region, name)
 	if err != nil {
 		return cloudContextInstanceProfile{}, err
 	}
-	defer cleanupTrust()
-	policyPath, cleanupPolicy, err := cloudContextPolicyFile(ctx, cloudContextSelfStopPolicy(provider, region, name))
-	if err != nil {
-		return cloudContextInstanceProfile{}, err
-	}
-	defer cleanupPolicy()
+	defer cleanup()
 
 	if ctx.DryRun {
-		if _, err := deps.RunAWS(ctx, provider, region, []string{"iam", "create-role", "--role-name", roleName, "--assume-role-policy-document", "file://" + trustPath, "--query", "Role.RoleName", "--output", "text"}); err != nil {
-			return cloudContextInstanceProfile{}, err
-		}
-		if _, err := deps.RunAWS(ctx, provider, region, []string{"iam", "put-role-policy", "--role-name", roleName, "--policy-name", "erun-self-stop", "--policy-document", "file://" + policyPath}); err != nil {
-			return cloudContextInstanceProfile{}, err
-		}
-		if _, err := deps.RunAWS(ctx, provider, region, []string{"iam", "create-instance-profile", "--instance-profile-name", profileName, "--query", "InstanceProfile.Arn", "--output", "text"}); err != nil {
-			return cloudContextInstanceProfile{}, err
-		}
-		if _, err := deps.RunAWS(ctx, provider, region, []string{"iam", "add-role-to-instance-profile", "--instance-profile-name", profileName, "--role-name", roleName}); err != nil {
-			return cloudContextInstanceProfile{}, err
-		}
-		return cloudContextInstanceProfile{
-			Name:     profileName,
-			ARN:      cloudContextInstanceProfileARN(provider, profileName),
-			RoleName: roleName,
-		}, nil
+		return dryRunCloudContextInstanceProfile(ctx, deps, provider, region, profileName, roleName, policies)
 	}
+	return realCloudContextInstanceProfile(ctx, deps, provider, region, profileName, roleName, policies)
+}
 
-	if _, err := deps.RunAWS(ctx, provider, region, []string{"iam", "get-role", "--role-name", roleName, "--query", "Role.RoleName", "--output", "text"}); err != nil {
-		if _, err := deps.RunAWS(ctx, provider, region, []string{"iam", "create-role", "--role-name", roleName, "--assume-role-policy-document", "file://" + trustPath, "--query", "Role.RoleName", "--output", "text"}); err != nil {
+func cloudContextInstanceProfilePolicyPaths(ctx Context, provider CloudProviderConfig, region, name string) (cloudContextPolicyPaths, func(), error) {
+	trustPath, cleanupTrust, err := cloudContextPolicyFile(ctx, ec2AssumeRolePolicy())
+	if err != nil {
+		return cloudContextPolicyPaths{}, func() {}, err
+	}
+	policyPath, cleanupPolicy, err := cloudContextPolicyFile(ctx, cloudContextSelfStopPolicy(provider, region, name))
+	if err != nil {
+		cleanupTrust()
+		return cloudContextPolicyPaths{}, func() {}, err
+	}
+	cleanup := func() {
+		cleanupPolicy()
+		cleanupTrust()
+	}
+	return cloudContextPolicyPaths{Trust: trustPath, Policy: policyPath}, cleanup, nil
+}
+
+func dryRunCloudContextInstanceProfile(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, profileName, roleName string, policies cloudContextPolicyPaths) (cloudContextInstanceProfile, error) {
+	commands := [][]string{
+		{"iam", "create-role", "--role-name", roleName, "--assume-role-policy-document", "file://" + policies.Trust, "--query", "Role.RoleName", "--output", "text"},
+		{"iam", "put-role-policy", "--role-name", roleName, "--policy-name", "erun-self-stop", "--policy-document", "file://" + policies.Policy},
+		{"iam", "create-instance-profile", "--instance-profile-name", profileName, "--query", "InstanceProfile.Arn", "--output", "text"},
+		{"iam", "add-role-to-instance-profile", "--instance-profile-name", profileName, "--role-name", roleName},
+	}
+	for _, command := range commands {
+		if _, err := deps.RunAWS(ctx, provider, region, command); err != nil {
 			return cloudContextInstanceProfile{}, err
 		}
 	}
-	if _, err := deps.RunAWS(ctx, provider, region, []string{"iam", "put-role-policy", "--role-name", roleName, "--policy-name", "erun-self-stop", "--policy-document", "file://" + policyPath}); err != nil {
+	return cloudContextInstanceProfile{Name: profileName, ARN: cloudContextInstanceProfileARN(provider, profileName), RoleName: roleName}, nil
+}
+
+func realCloudContextInstanceProfile(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, profileName, roleName string, policies cloudContextPolicyPaths) (cloudContextInstanceProfile, error) {
+	if err := ensureCloudContextInstanceRole(ctx, deps, provider, region, roleName, policies.Trust); err != nil {
 		return cloudContextInstanceProfile{}, err
 	}
-	profileARN, err := deps.RunAWS(ctx, provider, region, []string{"iam", "get-instance-profile", "--instance-profile-name", profileName, "--query", "InstanceProfile.Arn", "--output", "text"})
-	createdProfile := false
+	if _, err := deps.RunAWS(ctx, provider, region, []string{"iam", "put-role-policy", "--role-name", roleName, "--policy-name", "erun-self-stop", "--policy-document", "file://" + policies.Policy}); err != nil {
+		return cloudContextInstanceProfile{}, err
+	}
+	profileARN, createdProfile, err := ensureCloudContextInstanceProfileExists(ctx, deps, provider, region, profileName)
 	if err != nil {
-		profileARN, err = deps.RunAWS(ctx, provider, region, []string{"iam", "create-instance-profile", "--instance-profile-name", profileName, "--query", "InstanceProfile.Arn", "--output", "text"})
-		if err != nil {
-			return cloudContextInstanceProfile{}, err
-		}
-		createdProfile = true
+		return cloudContextInstanceProfile{}, err
 	}
 	if err := ensureCloudContextInstanceProfileRole(ctx, deps, provider, region, profileName, roleName, createdProfile); err != nil {
 		return cloudContextInstanceProfile{}, err
@@ -763,6 +775,23 @@ func ensureCloudContextInstanceProfile(ctx Context, deps CloudContextDependencie
 		ARN:      profileARN,
 		RoleName: roleName,
 	}, nil
+}
+
+func ensureCloudContextInstanceRole(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, roleName, trustPath string) error {
+	if _, err := deps.RunAWS(ctx, provider, region, []string{"iam", "get-role", "--role-name", roleName, "--query", "Role.RoleName", "--output", "text"}); err == nil {
+		return nil
+	}
+	_, err := deps.RunAWS(ctx, provider, region, []string{"iam", "create-role", "--role-name", roleName, "--assume-role-policy-document", "file://" + trustPath, "--query", "Role.RoleName", "--output", "text"})
+	return err
+}
+
+func ensureCloudContextInstanceProfileExists(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, profileName string) (string, bool, error) {
+	profileARN, err := deps.RunAWS(ctx, provider, region, []string{"iam", "get-instance-profile", "--instance-profile-name", profileName, "--query", "InstanceProfile.Arn", "--output", "text"})
+	if err == nil {
+		return profileARN, false, nil
+	}
+	profileARN, err = deps.RunAWS(ctx, provider, region, []string{"iam", "create-instance-profile", "--instance-profile-name", profileName, "--query", "InstanceProfile.Arn", "--output", "text"})
+	return profileARN, true, err
 }
 
 func ensureCloudContextInstanceProfileRole(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, profileName, roleName string, createdProfile bool) error {

--- a/erun-common/cloud_context.go
+++ b/erun-common/cloud_context.go
@@ -418,12 +418,6 @@ func pendingCloudContextInstanceProfileAssociationID(ctx Context, deps CloudCont
 	})
 }
 
-func anyCloudContextInstanceProfileAssociationID(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, instanceID string) (string, error) {
-	return describeCloudContextInstanceProfileAssociationID(ctx, deps, provider, region, []string{
-		"Name=instance-id,Values=" + instanceID,
-	})
-}
-
 func describeCloudContextInstanceProfileAssociationID(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region string, filters []string) (string, error) {
 	args := []string{
 		"ec2", "describe-iam-instance-profile-associations",
@@ -902,14 +896,6 @@ func isExistingInstanceProfileAssociationError(err error) bool {
 	}
 	message := strings.ToLower(err.Error())
 	return strings.Contains(message, "incorrectstate") && strings.Contains(message, "existing association")
-}
-
-func isInactiveInstanceProfileAssociationError(err error) bool {
-	if err == nil {
-		return false
-	}
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "incorrectstate") && strings.Contains(message, "not the active association")
 }
 
 func describeCloudContextPublicIP(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, instanceID string) (string, error) {

--- a/erun-common/cloud_context.go
+++ b/erun-common/cloud_context.go
@@ -166,64 +166,124 @@ func InitCloudContext(ctx Context, store CloudContextStore, params InitCloudCont
 		return CloudContextStatus{}, fmt.Errorf("store is required")
 	}
 	deps = normalizeCloudContextDependencies(deps)
-	provider, err := ResolveCloudProvider(store, params.CloudProviderAlias)
+	provider, config, err := initCloudContextConfig(store, params, deps)
 	if err != nil {
 		return CloudContextStatus{}, err
 	}
+	if err := prepareInitCloudContextResources(ctx, deps, provider, params, &config); err != nil {
+		return CloudContextStatus{}, err
+	}
+
+	instanceID, err := runInitCloudContextInstance(ctx, deps, provider, params, &config)
+	if err != nil {
+		return CloudContextStatus{}, err
+	}
+	config.InstanceID = strings.TrimSpace(instanceID)
+	if config.InstanceID == "" {
+		config.InstanceID = "i-<new-instance>"
+	}
+	config.Status = CloudContextStatusPending
+
+	if err := finalizeInitCloudContext(ctx, deps, provider, &config); err != nil {
+		return CloudContextStatus{}, err
+	}
+	if ctx.DryRun {
+		return CloudContextStatus{CloudContextConfig: NormalizeCloudContextConfig(config)}, nil
+	}
+	if err := saveCloudContextConfig(store, config); err != nil {
+		return CloudContextStatus{}, err
+	}
+	return CloudContextStatus{CloudContextConfig: NormalizeCloudContextConfig(config)}, nil
+}
+
+func initCloudContextConfig(store CloudContextStore, params InitCloudContextParams, deps CloudContextDependencies) (CloudProviderConfig, CloudContextConfig, error) {
+	provider, err := ResolveCloudProvider(store, params.CloudProviderAlias)
+	if err != nil {
+		return CloudProviderConfig{}, CloudContextConfig{}, err
+	}
 	if provider.Provider != CloudProviderAWS {
-		return CloudContextStatus{}, fmt.Errorf("unsupported cloud provider %q", provider.Provider)
+		return CloudProviderConfig{}, CloudContextConfig{}, fmt.Errorf("unsupported cloud provider %q", provider.Provider)
 	}
 	existingContexts, err := ListCloudContexts(store)
 	if err != nil {
-		return CloudContextStatus{}, err
+		return CloudProviderConfig{}, CloudContextConfig{}, err
 	}
 	config, err := resolveInitCloudContextConfig(provider, params, deps.Now(), existingContexts)
 	if err != nil {
-		return CloudContextStatus{}, err
+		return CloudProviderConfig{}, CloudContextConfig{}, err
 	}
-	if existing, ok, err := findCloudContext(store, config.Name); err != nil {
-		return CloudContextStatus{}, err
-	} else if ok && existing.InstanceID != "" {
-		return CloudContextStatus{}, fmt.Errorf("cloud context %q already exists", config.Name)
+	if err := ensureInitCloudContextDoesNotExist(store, config.Name); err != nil {
+		return CloudProviderConfig{}, CloudContextConfig{}, err
 	}
+	return provider, config, nil
+}
 
-	ami, err := deps.RunAWS(ctx, provider, config.Region, []string{
+func ensureInitCloudContextDoesNotExist(store CloudContextStore, name string) error {
+	existing, ok, err := findCloudContext(store, name)
+	if err != nil {
+		return err
+	}
+	if ok && existing.InstanceID != "" {
+		return fmt.Errorf("cloud context %q already exists", name)
+	}
+	return nil
+}
+
+func prepareInitCloudContextResources(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, params InitCloudContextParams, config *CloudContextConfig) error {
+	securityGroupID, err := initCloudContextSecurityGroup(ctx, deps, provider, params, *config)
+	if err != nil {
+		return err
+	}
+	config.SecurityGroupID = securityGroupID
+	instanceProfile, err := ensureCloudContextInstanceProfile(ctx, deps, provider, config.Region, config.Name)
+	if err != nil {
+		return err
+	}
+	config.InstanceProfileName = instanceProfile.Name
+	config.InstanceProfileARN = instanceProfile.ARN
+	config.InstanceRoleName = instanceProfile.RoleName
+	return nil
+}
+
+func initCloudContextSecurityGroup(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, params InitCloudContextParams, config CloudContextConfig) (string, error) {
+	securityGroupID := strings.TrimSpace(params.SecurityGroupID)
+	if securityGroupID != "" {
+		return securityGroupID, nil
+	}
+	return createCloudContextSecurityGroup(ctx, deps, provider, config.Region, config.Name)
+}
+
+func runInitCloudContextInstance(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, params InitCloudContextParams, config *CloudContextConfig) (string, error) {
+	ami, err := initCloudContextAMI(ctx, deps, provider, config.Region)
+	if err != nil {
+		return "", err
+	}
+	config.AdminToken = deps.NewToken()
+	userDataPath, cleanup, err := cloudContextUserDataFile(ctx, config.AdminToken)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+	return deps.RunAWS(ctx, provider, config.Region, initCloudContextRunArgs(ami, userDataPath, params, *config))
+}
+
+func initCloudContextAMI(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region string) (string, error) {
+	ami, err := deps.RunAWS(ctx, provider, region, []string{
 		"ssm", "get-parameter",
 		"--name", "/aws/service/canonical/ubuntu/server/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id",
 		"--query", "Parameter.Value",
 		"--output", "text",
 	})
 	if err != nil {
-		return CloudContextStatus{}, err
+		return "", err
 	}
-	ami = strings.TrimSpace(ami)
-	if ami == "" {
-		ami = "ami-<latest-ubuntu-arm64>"
+	if ami = strings.TrimSpace(ami); ami != "" {
+		return ami, nil
 	}
+	return "ami-<latest-ubuntu-arm64>", nil
+}
 
-	securityGroupID := strings.TrimSpace(params.SecurityGroupID)
-	if securityGroupID == "" {
-		securityGroupID, err = createCloudContextSecurityGroup(ctx, deps, provider, config.Region, config.Name)
-		if err != nil {
-			return CloudContextStatus{}, err
-		}
-	}
-	config.SecurityGroupID = securityGroupID
-	instanceProfile, err := ensureCloudContextInstanceProfile(ctx, deps, provider, config.Region, config.Name)
-	if err != nil {
-		return CloudContextStatus{}, err
-	}
-	config.InstanceProfileName = instanceProfile.Name
-	config.InstanceProfileARN = instanceProfile.ARN
-	config.InstanceRoleName = instanceProfile.RoleName
-
-	config.AdminToken = deps.NewToken()
-	userDataPath, cleanup, err := cloudContextUserDataFile(ctx, config.AdminToken)
-	if err != nil {
-		return CloudContextStatus{}, err
-	}
-	defer cleanup()
-
+func initCloudContextRunArgs(ami, userDataPath string, params InitCloudContextParams, config CloudContextConfig) []string {
 	runArgs := []string{
 		"ec2", "run-instances",
 		"--image-id", ami,
@@ -236,50 +296,44 @@ func InitCloudContext(ctx Context, store CloudContextStore, params InitCloudCont
 		"--query", "Instances[0].InstanceId",
 		"--output", "text",
 	}
-	if config.SecurityGroupID != "" {
-		runArgs = append(runArgs, "--security-group-ids", config.SecurityGroupID)
-	}
-	if config.InstanceProfileARN != "" {
-		runArgs = append(runArgs, "--iam-instance-profile", "Arn="+config.InstanceProfileARN)
-	} else if config.InstanceProfileName != "" {
-		runArgs = append(runArgs, "--iam-instance-profile", "Name="+config.InstanceProfileName)
-	}
-	if subnetID := strings.TrimSpace(params.SubnetID); subnetID != "" {
-		runArgs = append(runArgs, "--subnet-id", subnetID)
-	}
-	if keyName := strings.TrimSpace(params.KeyName); keyName != "" {
-		runArgs = append(runArgs, "--key-name", keyName)
-	}
-	instanceID, err := deps.RunAWS(ctx, provider, config.Region, runArgs)
-	if err != nil {
-		return CloudContextStatus{}, err
-	}
-	config.InstanceID = strings.TrimSpace(instanceID)
-	if config.InstanceID == "" {
-		config.InstanceID = "i-<new-instance>"
-	}
-	config.Status = CloudContextStatusPending
+	runArgs = appendOptionalCloudContextRunArg(runArgs, "--security-group-ids", config.SecurityGroupID)
+	runArgs = appendCloudContextProfileRunArg(runArgs, config)
+	runArgs = appendOptionalCloudContextRunArg(runArgs, "--subnet-id", params.SubnetID)
+	return appendOptionalCloudContextRunArg(runArgs, "--key-name", params.KeyName)
+}
 
+func appendOptionalCloudContextRunArg(args []string, name, value string) []string {
+	if value = strings.TrimSpace(value); value != "" {
+		return append(args, name, value)
+	}
+	return args
+}
+
+func appendCloudContextProfileRunArg(args []string, config CloudContextConfig) []string {
+	if config.InstanceProfileARN != "" {
+		return append(args, "--iam-instance-profile", "Arn="+config.InstanceProfileARN)
+	}
+	if config.InstanceProfileName != "" {
+		return append(args, "--iam-instance-profile", "Name="+config.InstanceProfileName)
+	}
+	return args
+}
+
+func finalizeInitCloudContext(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, config *CloudContextConfig) error {
 	if _, err := deps.RunAWS(ctx, provider, config.Region, []string{"ec2", "wait", "instance-running", "--instance-ids", config.InstanceID}); err != nil {
-		return CloudContextStatus{}, err
+		return err
 	}
 	publicIP, err := describeCloudContextPublicIP(ctx, deps, provider, config.Region, config.InstanceID)
 	if err != nil {
-		return CloudContextStatus{}, err
+		return err
 	}
 	config.PublicIP = publicIP
-	if err := configureCloudKubeContext(ctx, deps, config); err != nil {
-		return CloudContextStatus{}, err
+	if err := configureCloudKubeContext(ctx, deps, *config); err != nil {
+		return err
 	}
 	config.Status = CloudContextStatusRunning
 	config.UpdatedAt = deps.Now().UTC().Format(time.RFC3339)
-	if ctx.DryRun {
-		return CloudContextStatus{CloudContextConfig: NormalizeCloudContextConfig(config)}, nil
-	}
-	if err := saveCloudContextConfig(store, config); err != nil {
-		return CloudContextStatus{}, err
-	}
-	return CloudContextStatus{CloudContextConfig: NormalizeCloudContextConfig(config)}, nil
+	return nil
 }
 
 func StopCloudContext(ctx Context, store CloudContextStore, params CloudContextParams, deps CloudContextDependencies) (CloudContextStatus, error) {

--- a/erun-common/cloud_context_test.go
+++ b/erun-common/cloud_context_test.go
@@ -26,49 +26,54 @@ func TestInitCloudContextUsesDefaultsAndStoresKubeContext(t *testing.T) {
 		NewToken: func() string { return "test-token" },
 		RunAWS: func(_ Context, _ CloudProviderConfig, _ string, args []string) (string, error) {
 			awsCommands = append(awsCommands, strings.Join(args, " "))
-			joined := strings.Join(args, " ")
-			switch {
-			case strings.Contains(joined, "ssm get-parameter"):
-				return "ami-test\n", nil
-			case strings.Contains(joined, "create-security-group"):
-				return "sg-test\n", nil
-			case strings.Contains(joined, "run-instances"):
-				return "i-test\n", nil
-			case strings.Contains(joined, "describe-instances"):
-				return "198.51.100.10\n", nil
-			default:
-				return "", nil
-			}
+			return cloudContextAWSOutput(args), nil
 		},
 		RunKubectl: func(_ Context, args []string) error {
 			kubectlCommands = append(kubectlCommands, strings.Join(args, " "))
 			return nil
 		},
 	})
-	if err != nil {
-		t.Fatalf("InitCloudContext failed: %v", err)
+	requireNoError(t, err, "InitCloudContext failed")
+	requireDefaultCloudContextStatus(t, status)
+	requireStoredCloudContext(t, store.config.CloudContexts)
+	requireCloudContextCommands(t, awsCommands, kubectlCommands)
+}
+
+func cloudContextAWSOutput(args []string) string {
+	joined := strings.Join(args, " ")
+	switch {
+	case strings.Contains(joined, "ssm get-parameter"):
+		return "ami-test\n"
+	case strings.Contains(joined, "create-security-group"):
+		return "sg-test\n"
+	case strings.Contains(joined, "run-instances"):
+		return "i-test\n"
+	case strings.Contains(joined, "describe-instances"):
+		return "198.51.100.10\n"
+	default:
+		return ""
 	}
-	if status.InstanceType != DefaultCloudContextInstanceType || status.DiskSizeGB != AlternateCloudContextDiskSizeGB || status.DiskType != DefaultCloudContextDiskType {
-		t.Fatalf("unexpected defaults/options: %+v", status)
-	}
-	if status.Region != DefaultCloudContextRegion || status.Status != CloudContextStatusRunning || status.KubernetesContext == "" {
-		t.Fatalf("unexpected stored context: %+v", status)
-	}
-	if status.Name != "erun-001-123456789012-eu-west-2" {
-		t.Fatalf("unexpected generated context name: %+v", status)
-	}
-	if status.InstanceProfileName != "erun-001-123456789012-eu-west-2-host-stop" || status.InstanceRoleName != "erun-001-123456789012-eu-west-2-host-stop" {
-		t.Fatalf("expected managed instance profile and role, got %+v", status)
-	}
-	if status.InstanceProfileARN != "arn:aws:iam::123456789012:instance-profile/erun-001-123456789012-eu-west-2-host-stop" {
-		t.Fatalf("expected managed instance profile ARN, got %+v", status)
-	}
-	if len(store.config.CloudContexts) != 1 || store.config.CloudContexts[0].InstanceID != "i-test" || store.config.CloudContexts[0].AdminToken != "test-token" || store.config.CloudContexts[0].InstanceProfileName == "" || store.config.CloudContexts[0].InstanceProfileARN == "" || store.config.CloudContexts[0].InstanceRoleName == "" {
-		t.Fatalf("expected context to be saved with instance/token metadata, got %+v", store.config.CloudContexts)
-	}
-	if len(awsCommands) == 0 || len(kubectlCommands) != 3 {
-		t.Fatalf("expected AWS and kubeconfig commands, got aws=%+v kubectl=%+v", awsCommands, kubectlCommands)
-	}
+}
+
+func requireDefaultCloudContextStatus(t *testing.T, status CloudContextStatus) {
+	t.Helper()
+	requireCondition(t, status.InstanceType == DefaultCloudContextInstanceType && status.DiskSizeGB == AlternateCloudContextDiskSizeGB && status.DiskType == DefaultCloudContextDiskType, "unexpected defaults/options: %+v", status)
+	requireCondition(t, status.Region == DefaultCloudContextRegion && status.Status == CloudContextStatusRunning && status.KubernetesContext != "", "unexpected stored context: %+v", status)
+	requireEqual(t, status.Name, "erun-001-123456789012-eu-west-2", "generated context name")
+	requireCondition(t, status.InstanceProfileName == "erun-001-123456789012-eu-west-2-host-stop" && status.InstanceRoleName == "erun-001-123456789012-eu-west-2-host-stop", "expected managed instance profile and role, got %+v", status)
+	requireEqual(t, status.InstanceProfileARN, "arn:aws:iam::123456789012:instance-profile/erun-001-123456789012-eu-west-2-host-stop", "managed instance profile ARN")
+}
+
+func requireStoredCloudContext(t *testing.T, contexts []CloudContextConfig) {
+	t.Helper()
+	requireCondition(t, len(contexts) == 1 && contexts[0].InstanceID == "i-test" && contexts[0].AdminToken == "test-token", "expected context to be saved with instance/token metadata, got %+v", contexts)
+	requireCondition(t, contexts[0].InstanceProfileName != "" && contexts[0].InstanceProfileARN != "" && contexts[0].InstanceRoleName != "", "expected context to include instance profile metadata, got %+v", contexts)
+}
+
+func requireCloudContextCommands(t *testing.T, awsCommands, kubectlCommands []string) {
+	t.Helper()
+	requireCondition(t, len(awsCommands) > 0 && len(kubectlCommands) == 3, "expected AWS and kubeconfig commands, got aws=%+v kubectl=%+v", awsCommands, kubectlCommands)
+	joined := strings.Join(awsCommands, "\n")
 	for _, want := range []string{
 		"iam put-role-policy --role-name erun-001-123456789012-eu-west-2-host-stop --policy-name erun-self-stop",
 		"iam add-role-to-instance-profile --instance-profile-name erun-001-123456789012-eu-west-2-host-stop --role-name erun-001-123456789012-eu-west-2-host-stop",
@@ -76,9 +81,7 @@ func TestInitCloudContextUsesDefaultsAndStoresKubeContext(t *testing.T) {
 		"--iam-instance-profile Arn=arn:aws:iam::123456789012:instance-profile/erun-001-123456789012-eu-west-2-host-stop",
 		"--metadata-options HttpEndpoint=enabled,HttpTokens=required,HttpPutResponseHopLimit=2",
 	} {
-		if !strings.Contains(strings.Join(awsCommands, "\n"), want) {
-			t.Fatalf("expected AWS commands to contain %q, got %+v", want, awsCommands)
-		}
+		requireStringContains(t, joined, want, "expected AWS commands to contain "+want)
 	}
 }
 

--- a/erun-common/cloud_test.go
+++ b/erun-common/cloud_test.go
@@ -83,9 +83,7 @@ func TestInitAWSCloudProviderCreatesProfileAndDerivesAliasFromLoginIdentity(t *t
 	}, CloudDependencies{
 		RunAWSConfigureSSO: func(_ Context, config AWSProfileConfig) error {
 			configuredProfile = config.Profile
-			if config.SSOStartURL != "https://example.awsapps.com/start" || config.SSORegion != "eu-west-1" || config.AccountID != "123456789012" || config.RoleName != "Admin" || config.Region != "eu-west-1" {
-				t.Fatalf("unexpected AWS profile config: %+v", config)
-			}
+			requireAWSProfileConfig(t, config)
 			return nil
 		},
 		RunAWSLogin: func(_ Context, profile string) error {
@@ -100,18 +98,20 @@ func TestInitAWSCloudProviderCreatesProfileAndDerivesAliasFromLoginIdentity(t *t
 			}, nil
 		},
 	})
-	if err != nil {
-		t.Fatalf("InitAWSCloudProvider failed: %v", err)
-	}
-	if configuredProfile == "" {
-		t.Fatal("expected AWS SSO profile to be created")
-	}
-	if loginProfile != configuredProfile || identityProfile != configuredProfile || provider.Profile != configuredProfile {
-		t.Fatalf("expected one generated profile through configure/login/identity/save, got configure=%q login=%q identity=%q provider=%q", configuredProfile, loginProfile, identityProfile, provider.Profile)
-	}
-	if provider.Alias != "rihards+123456789012@aws" {
-		t.Fatalf("expected alias from identity, got %+v", provider)
-	}
+	requireNoError(t, err, "InitAWSCloudProvider failed")
+	requireGeneratedAWSProfile(t, provider, configuredProfile, loginProfile, identityProfile)
+}
+
+func requireAWSProfileConfig(t *testing.T, config AWSProfileConfig) {
+	t.Helper()
+	requireCondition(t, config.SSOStartURL == "https://example.awsapps.com/start" && config.SSORegion == "eu-west-1" && config.AccountID == "123456789012" && config.RoleName == "Admin" && config.Region == "eu-west-1", "unexpected AWS profile config: %+v", config)
+}
+
+func requireGeneratedAWSProfile(t *testing.T, provider CloudProviderConfig, configuredProfile, loginProfile, identityProfile string) {
+	t.Helper()
+	requireCondition(t, configuredProfile != "", "expected AWS SSO profile to be created")
+	requireCondition(t, loginProfile == configuredProfile && identityProfile == configuredProfile && provider.Profile == configuredProfile, "expected one generated profile through configure/login/identity/save, got configure=%q login=%q identity=%q provider=%q", configuredProfile, loginProfile, identityProfile, provider.Profile)
+	requireEqual(t, provider.Alias, "rihards+123456789012@aws", "alias from identity")
 }
 
 func TestLoginCloudProviderAliasRunsLoginWhenStatusIsExpired(t *testing.T) {
@@ -191,17 +191,21 @@ func TestSetEnvironmentCloudProviderAliasUpdatesOnlyAlias(t *testing.T) {
 		Environment: " dev ",
 		Alias:       " team-cloud ",
 	})
-	if err != nil {
-		t.Fatalf("SetEnvironmentCloudProviderAlias failed: %v", err)
-	}
-	if updated.CloudProviderAlias != "team-cloud" {
-		t.Fatalf("unexpected updated config: %+v", updated)
-	}
-	if !updated.ManagedCloud {
-		t.Fatalf("expected remote cloud alias update to mark environment managed cloud: %+v", updated)
-	}
+	requireNoError(t, err, "SetEnvironmentCloudProviderAlias failed")
+	requireUpdatedCloudAlias(t, updated)
 	stored := store.envs["frs/dev"]
-	if stored.RepoPath != "/workspace/frs" || stored.KubernetesContext != "cluster-dev" || stored.ContainerRegistry != "registry.example.com/frs" || stored.RuntimeVersion != "1.0.0" || !stored.SSHD.Enabled || stored.SSHD.LocalPort != 60022 || stored.SSHD.PublicKeyPath != "/tmp/id.pub" || !stored.Remote || !stored.ManagedCloud || stored.Snapshot == nil || !*stored.Snapshot {
-		t.Fatalf("unexpected stored config: %+v", stored)
-	}
+	requireStoredCloudAliasConfig(t, stored)
+}
+
+func requireUpdatedCloudAlias(t *testing.T, updated EnvConfig) {
+	t.Helper()
+	requireEqual(t, updated.CloudProviderAlias, "team-cloud", "updated cloud provider alias")
+	requireCondition(t, updated.ManagedCloud, "expected remote cloud alias update to mark environment managed cloud: %+v", updated)
+}
+
+func requireStoredCloudAliasConfig(t *testing.T, stored EnvConfig) {
+	t.Helper()
+	requireCondition(t, stored.RepoPath == "/workspace/frs" && stored.KubernetesContext == "cluster-dev" && stored.ContainerRegistry == "registry.example.com/frs" && stored.RuntimeVersion == "1.0.0", "unexpected stored config: %+v", stored)
+	requireCondition(t, stored.SSHD.Enabled && stored.SSHD.LocalPort == 60022 && stored.SSHD.PublicKeyPath == "/tmp/id.pub", "unexpected stored SSH config: %+v", stored)
+	requireCondition(t, stored.Remote && stored.ManagedCloud && stored.Snapshot != nil && *stored.Snapshot, "unexpected stored flags: %+v", stored)
 }

--- a/erun-common/config_test.go
+++ b/erun-common/config_test.go
@@ -251,38 +251,38 @@ func TestSaveTenantConfigErrors(t *testing.T) {
 
 	tenant := "tenant-a"
 	configPath, err := xdg.ConfigFile(filepath.Join(testConfigRoot, tenant, configFile))
-	if err != nil {
-		t.Fatalf("xdg path: %v", err)
-	}
+	requireNoError(t, err, "xdg path")
 	dir := filepath.Dir(configPath)
 
-	if err := os.RemoveAll(dir); err != nil {
-		t.Fatalf("cleanup: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
-		t.Fatalf("mkdir parent: %v", err)
-	}
-	if err := os.WriteFile(dir, []byte(""), 0o644); err != nil {
-		t.Fatalf("write blocker: %v", err)
-	}
-	if err := SaveTenantConfig(TenantConfig{Name: tenant}); !errors.Is(err, ErrNoUserDataFolder) {
-		t.Fatalf("expected ErrNoUserDataFolder, got %v", err)
-	}
+	blockConfigDirWithFile(t, dir)
+	requireErrorIs(t, SaveTenantConfig(TenantConfig{Name: tenant}), ErrNoUserDataFolder)
 
-	if err := os.Remove(dir); err != nil {
-		t.Fatalf("remove blocker: %v", err)
-	}
-	if err := os.MkdirAll(dir, 0o555); err != nil {
-		t.Fatalf("mkdir dir: %v", err)
-	}
+	makeConfigDirReadOnly(t, dir)
+	requireErrorIs(t, SaveTenantConfig(TenantConfig{Name: tenant}), ErrFailedToSaveConfig)
+}
+
+func blockConfigDirWithFile(t *testing.T, dir string) {
+	t.Helper()
+	requireNoError(t, os.RemoveAll(dir), "cleanup")
+	requireNoError(t, os.MkdirAll(filepath.Dir(dir), 0o755), "mkdir parent")
+	requireNoError(t, os.WriteFile(dir, []byte(""), 0o644), "write blocker")
+}
+
+func makeConfigDirReadOnly(t *testing.T, dir string) {
+	t.Helper()
+	requireNoError(t, os.Remove(dir), "remove blocker")
+	requireNoError(t, os.MkdirAll(dir, 0o555), "mkdir dir")
 	t.Cleanup(func() {
 		if err := os.Chmod(dir, 0o755); err != nil && !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("reset chmod: %v", err)
 		}
 	})
+}
 
-	if err := SaveTenantConfig(TenantConfig{Name: tenant}); !errors.Is(err, ErrFailedToSaveConfig) {
-		t.Fatalf("expected ErrFailedToSaveConfig, got %v", err)
+func requireErrorIs(t *testing.T, err, target error) {
+	t.Helper()
+	if !errors.Is(err, target) {
+		t.Fatalf("expected %v, got %v", target, err)
 	}
 }
 
@@ -464,39 +464,14 @@ func TestSaveEnvConfigErrors(t *testing.T) {
 	setupConfigTestXDGConfigHome(t)
 
 	path, err := xdg.ConfigFile(filepath.Join(testConfigRoot, "tenant-a", "dev", configFile))
-	if err != nil {
-		t.Fatalf("xdg path: %v", err)
-	}
+	requireNoError(t, err, "xdg path")
 	dir := filepath.Dir(path)
 
-	if err := os.RemoveAll(dir); err != nil {
-		t.Fatalf("cleanup: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
-		t.Fatalf("mkdir parent: %v", err)
-	}
-	if err := os.WriteFile(dir, []byte(""), 0o644); err != nil {
-		t.Fatalf("write blocker: %v", err)
-	}
-	if err := SaveEnvConfig("tenant-a", EnvConfig{Name: "dev"}); !errors.Is(err, ErrNoUserDataFolder) {
-		t.Fatalf("expected ErrNoUserDataFolder, got %v", err)
-	}
+	blockConfigDirWithFile(t, dir)
+	requireErrorIs(t, SaveEnvConfig("tenant-a", EnvConfig{Name: "dev"}), ErrNoUserDataFolder)
 
-	if err := os.Remove(dir); err != nil {
-		t.Fatalf("remove blocker: %v", err)
-	}
-	if err := os.MkdirAll(dir, 0o555); err != nil {
-		t.Fatalf("mkdir dir: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chmod(dir, 0o755); err != nil && !errors.Is(err, os.ErrNotExist) {
-			t.Fatalf("reset chmod: %v", err)
-		}
-	})
-
-	if err := SaveEnvConfig("tenant-a", EnvConfig{Name: "dev"}); !errors.Is(err, ErrFailedToSaveConfig) {
-		t.Fatalf("expected ErrFailedToSaveConfig, got %v", err)
-	}
+	makeConfigDirReadOnly(t, dir)
+	requireErrorIs(t, SaveEnvConfig("tenant-a", EnvConfig{Name: "dev"}), ErrFailedToSaveConfig)
 }
 
 func TestFindProjectRoot(t *testing.T) {

--- a/erun-common/default_devops_module.go
+++ b/erun-common/default_devops_module.go
@@ -81,22 +81,8 @@ func defaultDevopsBaseTag(runtimeVersion string) string {
 }
 
 func ensureDefaultDevopsFile(ctx Context, path string, mode os.FileMode, content []byte) error {
-	info, err := os.Stat(path)
-	switch {
-	case err == nil && info.IsDir():
-		return fmt.Errorf("%q is a directory", path)
-	case err == nil:
-		existing, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		if bytes.Equal(existing, content) {
-			return nil
-		}
-		if !shouldReplaceDefaultDevopsFile(path, existing, content) {
-			return nil
-		}
-	case !os.IsNotExist(err):
+	replace, err := shouldWriteDefaultDevopsFile(path, content)
+	if err != nil || !replace {
 		return err
 	}
 
@@ -113,6 +99,31 @@ func ensureDefaultDevopsFile(ctx Context, path string, mode os.FileMode, content
 		return err
 	}
 	return os.Chmod(path, mode)
+}
+
+func shouldWriteDefaultDevopsFile(path string, content []byte) (bool, error) {
+	info, err := os.Stat(path)
+	switch {
+	case err == nil && info.IsDir():
+		return false, fmt.Errorf("%q is a directory", path)
+	case err == nil:
+		return shouldWriteExistingDefaultDevopsFile(path, content)
+	case os.IsNotExist(err):
+		return true, nil
+	default:
+		return false, err
+	}
+}
+
+func shouldWriteExistingDefaultDevopsFile(path string, content []byte) (bool, error) {
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	if bytes.Equal(existing, content) {
+		return false, nil
+	}
+	return shouldReplaceDefaultDevopsFile(path, existing, content), nil
 }
 
 func shouldReplaceDefaultDevopsFile(path string, existing, content []byte) bool {

--- a/erun-common/delete.go
+++ b/erun-common/delete.go
@@ -47,12 +47,7 @@ func DeleteEnvironmentConfirmation(tenant, environment string) string {
 }
 
 func RunDeleteEnvironment(ctx Context, params DeleteEnvironmentParams, store DeleteStore, deleteNamespace NamespaceDeleterFunc) (DeleteEnvironmentResult, error) {
-	if store == nil {
-		store = ConfigStore{}
-	}
-	if deleteNamespace == nil {
-		deleteNamespace = DeleteKubernetesNamespace
-	}
+	store, deleteNamespace = normalizeDeleteEnvironmentDependencies(store, deleteNamespace)
 
 	tenant := strings.TrimSpace(params.Tenant)
 	environment := strings.TrimSpace(params.Environment)
@@ -64,17 +59,7 @@ func RunDeleteEnvironment(ctx Context, params DeleteEnvironmentParams, store Del
 	if err != nil {
 		return DeleteEnvironmentResult{}, err
 	}
-	if envConfig.Name == "" {
-		envConfig.Name = environment
-	}
-
-	result := DeleteEnvironmentResult{
-		Tenant:            tenant,
-		Environment:       environment,
-		Remote:            envConfig.Remote,
-		KubernetesContext: strings.TrimSpace(envConfig.KubernetesContext),
-		ConfigDir:         filepath.Dir(configPath),
-	}
+	result := deleteEnvironmentResult(tenant, environment, envConfig, configPath)
 
 	if envConfig.Remote {
 		if err := deleteRemoteEnvironmentNamespace(ctx, deleteNamespace, &result); err != nil {
@@ -95,6 +80,26 @@ func RunDeleteEnvironment(ctx Context, params DeleteEnvironmentParams, store Del
 	}
 
 	return result, nil
+}
+
+func normalizeDeleteEnvironmentDependencies(store DeleteStore, deleteNamespace NamespaceDeleterFunc) (DeleteStore, NamespaceDeleterFunc) {
+	if store == nil {
+		store = ConfigStore{}
+	}
+	if deleteNamespace == nil {
+		deleteNamespace = DeleteKubernetesNamespace
+	}
+	return store, deleteNamespace
+}
+
+func deleteEnvironmentResult(tenant, environment string, envConfig EnvConfig, configPath string) DeleteEnvironmentResult {
+	return DeleteEnvironmentResult{
+		Tenant:            tenant,
+		Environment:       environment,
+		Remote:            envConfig.Remote,
+		KubernetesContext: strings.TrimSpace(envConfig.KubernetesContext),
+		ConfigDir:         filepath.Dir(configPath),
+	}
 }
 
 func deleteRemoteEnvironmentNamespace(ctx Context, deleteNamespace NamespaceDeleterFunc, result *DeleteEnvironmentResult) error {

--- a/erun-common/delete.go
+++ b/erun-common/delete.go
@@ -77,15 +77,8 @@ func RunDeleteEnvironment(ctx Context, params DeleteEnvironmentParams, store Del
 	}
 
 	if envConfig.Remote {
-		result.Namespace = KubernetesNamespaceName(tenant, environment)
-		if err := ctx.EnsureKubernetesContext(result.KubernetesContext); err != nil {
+		if err := deleteRemoteEnvironmentNamespace(ctx, deleteNamespace, &result); err != nil {
 			return result, err
-		}
-		TraceDeleteKubernetesNamespace(ctx, result.KubernetesContext, result.Namespace)
-		if !ctx.DryRun {
-			if err := deleteNamespace(result.KubernetesContext, result.Namespace); err != nil {
-				result.NamespaceDeleteError = err.Error()
-			}
 		}
 	}
 
@@ -102,6 +95,21 @@ func RunDeleteEnvironment(ctx Context, params DeleteEnvironmentParams, store Del
 	}
 
 	return result, nil
+}
+
+func deleteRemoteEnvironmentNamespace(ctx Context, deleteNamespace NamespaceDeleterFunc, result *DeleteEnvironmentResult) error {
+	result.Namespace = KubernetesNamespaceName(result.Tenant, result.Environment)
+	if err := ctx.EnsureKubernetesContext(result.KubernetesContext); err != nil {
+		return err
+	}
+	TraceDeleteKubernetesNamespace(ctx, result.KubernetesContext, result.Namespace)
+	if ctx.DryRun {
+		return nil
+	}
+	if err := deleteNamespace(result.KubernetesContext, result.Namespace); err != nil {
+		result.NamespaceDeleteError = err.Error()
+	}
+	return nil
 }
 
 func removeTenantWhenLastEnvironmentDeleted(ctx Context, store DeleteStore, tenant, deletedEnvironment string) error {

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -185,7 +185,7 @@ func RunDeploySpec(ctx Context, execution DeploySpec, build DockerImageBuilderFu
 }
 
 func ResolveDeploySpec(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target DeployTarget, componentName, versionOverride string) (DeploySpec, error) {
-	store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now = normalizeDeployDependencies(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now)
+	store, findProjectRoot, resolveDockerBuildContext, _, now = normalizeDeployDependencies(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now)
 	versionOverride = resolveDeployVersionOverride(target, versionOverride)
 
 	resolvedTarget, err := resolveDeployTarget(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target)
@@ -196,7 +196,7 @@ func ResolveDeploySpec(store DeployStore, findProjectRoot ProjectFinderFunc, res
 }
 
 func ResolveCurrentDeploySpecs(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target DeployTarget) ([]DeploySpec, error) {
-	store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now = normalizeDeployDependencies(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now)
+	store, findProjectRoot, resolveDockerBuildContext, _, now = normalizeDeployDependencies(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now)
 
 	resolvedTarget, err := resolveDeployTarget(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target)
 	if err != nil {
@@ -237,7 +237,7 @@ func resolveDeploySpecForOpenResult(store DeployStore, findProjectRoot ProjectFi
 }
 
 func resolveDeploySpecForContext(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, deployContext KubernetesDeployContext, versionOverride string, allowLocalBuilds bool) (DeploySpec, error) {
-	store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now = normalizeDeployDependencies(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now)
+	store, findProjectRoot, resolveDockerBuildContext, _, now = normalizeDeployDependencies(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now)
 	target = applyDeployKubernetesContext(store, target)
 
 	builds := make([]DockerBuildSpec, 0, 2)
@@ -571,17 +571,6 @@ func loadDefaultTenant(store DeployStore) (string, error) {
 		return "", ErrDefaultTenantNotConfigured
 	}
 	return toolConfig.DefaultTenant, nil
-}
-
-func loadDefaultEnvironment(store DeployStore, tenant string) (string, error) {
-	tenantConfig, _, err := store.LoadTenantConfig(tenant)
-	if err != nil {
-		return "", err
-	}
-	if tenantConfig.DefaultEnvironment == "" {
-		return "", ErrDefaultEnvironmentNotConfigured
-	}
-	return tenantConfig.DefaultEnvironment, nil
 }
 
 func newHelmDeploySpec(target OpenResult, deployContext KubernetesDeployContext, versionOverride string) (HelmDeploySpec, error) {

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -986,20 +986,43 @@ func resolveProjectRootDevopsK8sDir(findProjectRoot ProjectFinderFunc, projectRo
 		return "", false, nil
 	}
 
-	if tenant, detectedProjectRoot, err := findProjectRoot(); err == nil &&
-		filepath.Clean(strings.TrimSpace(detectedProjectRoot)) == projectRoot &&
-		strings.TrimSpace(tenant) != "" {
-		k8sDir := filepath.Join(projectRoot, RuntimeReleaseName(tenant), "k8s")
-		if ok, err := isKubernetesDeployModuleDir(k8sDir); err != nil {
-			return "", false, err
-		} else if ok {
-			return k8sDir, true, nil
-		}
+	k8sDir, ok, err := detectedProjectRootDevopsK8sDir(findProjectRoot, projectRoot)
+	if err != nil || ok {
+		return k8sDir, ok, err
 	}
 
-	entries, err := os.ReadDir(projectRoot)
+	candidates, err := findDevopsK8sDirs(projectRoot)
 	if err != nil {
 		return "", false, err
+	}
+	switch len(candidates) {
+	case 0:
+		return "", false, nil
+	case 1:
+		return candidates[0], true, nil
+	default:
+		return "", false, fmt.Errorf("multiple devops k8s directories found under project root")
+	}
+}
+
+func detectedProjectRootDevopsK8sDir(findProjectRoot ProjectFinderFunc, projectRoot string) (string, bool, error) {
+	tenant, detectedProjectRoot, err := findProjectRoot()
+	if err != nil || filepath.Clean(strings.TrimSpace(detectedProjectRoot)) != projectRoot || strings.TrimSpace(tenant) == "" {
+		return "", false, nil
+	}
+	k8sDir := filepath.Join(projectRoot, RuntimeReleaseName(tenant), "k8s")
+	if ok, err := isKubernetesDeployModuleDir(k8sDir); err != nil {
+		return "", false, err
+	} else if ok {
+		return k8sDir, true, nil
+	}
+	return "", false, nil
+}
+
+func findDevopsK8sDirs(projectRoot string) ([]string, error) {
+	entries, err := os.ReadDir(projectRoot)
+	if err != nil {
+		return nil, err
 	}
 
 	candidates := make([]string, 0, 1)
@@ -1011,21 +1034,13 @@ func resolveProjectRootDevopsK8sDir(findProjectRoot ProjectFinderFunc, projectRo
 		k8sDir := filepath.Join(projectRoot, entry.Name(), "k8s")
 		ok, err := isKubernetesDeployModuleDir(k8sDir)
 		if err != nil {
-			return "", false, err
+			return nil, err
 		}
 		if ok {
 			candidates = append(candidates, k8sDir)
 		}
 	}
-
-	switch len(candidates) {
-	case 0:
-		return "", false, nil
-	case 1:
-		return candidates[0], true, nil
-	default:
-		return "", false, fmt.Errorf("multiple devops k8s directories found under project root")
-	}
+	return candidates, nil
 }
 
 func isKubernetesDeployModuleDir(dir string) (bool, error) {
@@ -1219,7 +1234,7 @@ func CheckKubernetesDeployment(params KubernetesDeploymentCheckParams) (bool, er
 
 	output, err := exec.Command("kubectl", args...).CombinedOutput()
 	if err == nil {
-		if strings.TrimSpace(params.ExpectedRepoPath) == "" && params.ExpectedSSHD == nil && params.ExpectedMCPPort == 0 && params.ExpectedSSHPort == 0 {
+		if !hasExpectedDeploymentSettings(params) {
 			return true, nil
 		}
 		return deploymentMatchesExpectedSettings(params)
@@ -1231,6 +1246,15 @@ func CheckKubernetesDeployment(params KubernetesDeploymentCheckParams) (bool, er
 	}
 
 	return false, fmt.Errorf("failed to check deployment %q: %w", params.Name, err)
+}
+
+func hasExpectedDeploymentSettings(params KubernetesDeploymentCheckParams) bool {
+	return strings.TrimSpace(params.ExpectedRepoPath) != "" || params.ExpectedSSHD != nil || params.ExpectedMCPPort > 0 || params.ExpectedSSHPort > 0
+}
+
+type deploymentEnvVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 func deploymentMatchesExpectedSettings(params KubernetesDeploymentCheckParams) (bool, error) {
@@ -1253,11 +1277,8 @@ func deploymentMatchesExpectedSettings(params KubernetesDeploymentCheckParams) (
 			Template struct {
 				Spec struct {
 					Containers []struct {
-						Name string `json:"name"`
-						Env  []struct {
-							Name  string `json:"name"`
-							Value string `json:"value"`
-						} `json:"env"`
+						Name string             `json:"name"`
+						Env  []deploymentEnvVar `json:"env"`
 					} `json:"containers"`
 				} `json:"spec"`
 			} `json:"template"`
@@ -1267,39 +1288,76 @@ func deploymentMatchesExpectedSettings(params KubernetesDeploymentCheckParams) (
 		return false, fmt.Errorf("failed to parse deployment %q: %w", params.Name, err)
 	}
 
-	expectedRepoPath := strings.TrimSpace(params.ExpectedRepoPath)
 	for _, container := range deployment.Spec.Template.Spec.Containers {
 		if strings.TrimSpace(container.Name) != params.Name {
 			continue
 		}
-		matchesRepoPath := strings.TrimSpace(expectedRepoPath) == ""
-		matchesSSHD := params.ExpectedSSHD == nil
-		matchesMCPPort := params.ExpectedMCPPort <= 0
-		matchesSSHPort := params.ExpectedSSHPort <= 0
-		for _, env := range container.Env {
-			switch strings.TrimSpace(env.Name) {
-			case "ERUN_REPO_PATH":
-				if strings.TrimSpace(expectedRepoPath) != "" {
-					matchesRepoPath = filepath.Clean(strings.TrimSpace(env.Value)) == filepath.Clean(expectedRepoPath)
-				}
-			case "ERUN_SSHD_ENABLED":
-				if params.ExpectedSSHD != nil {
-					matchesSSHD = strings.EqualFold(strings.TrimSpace(env.Value), formatHelmBool(*params.ExpectedSSHD))
-				}
-			case "ERUN_MCP_PORT":
-				if params.ExpectedMCPPort > 0 {
-					matchesMCPPort = strings.TrimSpace(env.Value) == fmt.Sprintf("%d", params.ExpectedMCPPort)
-				}
-			case "ERUN_SSHD_PORT":
-				if params.ExpectedSSHPort > 0 {
-					matchesSSHPort = strings.TrimSpace(env.Value) == fmt.Sprintf("%d", params.ExpectedSSHPort)
-				}
-			}
-		}
-		return matchesRepoPath && matchesSSHD && matchesMCPPort && matchesSSHPort, nil
+		return deploymentContainerMatchesExpectedSettings(params, container.Env), nil
 	}
 
 	return false, nil
+}
+
+func deploymentContainerMatchesExpectedSettings(params KubernetesDeploymentCheckParams, envs []deploymentEnvVar) bool {
+	matches := expectedDeploymentMatches(params)
+	for _, env := range envs {
+		matches.apply(params, env.Name, env.Value)
+	}
+	return matches.ok()
+}
+
+type deploymentExpectedMatches struct {
+	repoPath bool
+	sshd     bool
+	mcpPort  bool
+	sshPort  bool
+}
+
+func expectedDeploymentMatches(params KubernetesDeploymentCheckParams) deploymentExpectedMatches {
+	return deploymentExpectedMatches{
+		repoPath: strings.TrimSpace(params.ExpectedRepoPath) == "",
+		sshd:     params.ExpectedSSHD == nil,
+		mcpPort:  params.ExpectedMCPPort <= 0,
+		sshPort:  params.ExpectedSSHPort <= 0,
+	}
+}
+
+func (m *deploymentExpectedMatches) apply(params KubernetesDeploymentCheckParams, name, value string) {
+	switch strings.TrimSpace(name) {
+	case "ERUN_REPO_PATH":
+		m.repoPath = matchesExpectedRepoPath(value, params.ExpectedRepoPath)
+	case "ERUN_SSHD_ENABLED":
+		m.sshd = matchesExpectedBool(value, params.ExpectedSSHD)
+	case "ERUN_MCP_PORT":
+		m.mcpPort = matchesExpectedPort(value, params.ExpectedMCPPort)
+	case "ERUN_SSHD_PORT":
+		m.sshPort = matchesExpectedPort(value, params.ExpectedSSHPort)
+	}
+}
+
+func (m deploymentExpectedMatches) ok() bool {
+	return m.repoPath && m.sshd && m.mcpPort && m.sshPort
+}
+
+func matchesExpectedRepoPath(value, expected string) bool {
+	if strings.TrimSpace(expected) == "" {
+		return true
+	}
+	return filepath.Clean(strings.TrimSpace(value)) == filepath.Clean(strings.TrimSpace(expected))
+}
+
+func matchesExpectedBool(value string, expected *bool) bool {
+	if expected == nil {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(value), formatHelmBool(*expected))
+}
+
+func matchesExpectedPort(value string, expected int) bool {
+	if expected <= 0 {
+		return true
+	}
+	return strings.TrimSpace(value) == fmt.Sprintf("%d", expected)
 }
 
 func resolveKubernetesDeployValuesFile(chartPath, environment string) (string, error) {
@@ -1325,26 +1383,11 @@ func findComponentHelmChartPath(projectRoot, componentName string) (string, erro
 
 	matches := make([]string, 0, 1)
 	err := filepath.WalkDir(projectRoot, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
+		chartPath, ok, walkErr := componentHelmChartCandidate(path, d, componentName, err)
+		if ok {
+			matches = append(matches, chartPath)
 		}
-		if d.IsDir() {
-			if d.Name() == ".git" {
-				return fs.SkipDir
-			}
-			return nil
-		}
-		if d.Name() != "Chart.yaml" {
-			return nil
-		}
-
-		chartPath := filepath.Dir(path)
-		if filepath.Base(chartPath) != componentName || filepath.Base(filepath.Dir(chartPath)) != "k8s" {
-			return nil
-		}
-
-		matches = append(matches, chartPath)
-		return nil
+		return walkErr
 	})
 	if err != nil {
 		return "", err
@@ -1357,6 +1400,26 @@ func findComponentHelmChartPath(projectRoot, componentName string) (string, erro
 		return "", fmt.Errorf("multiple Helm charts found for component %q", componentName)
 	}
 	return matches[0], nil
+}
+
+func componentHelmChartCandidate(path string, d fs.DirEntry, componentName string, err error) (string, bool, error) {
+	if err != nil {
+		return "", false, err
+	}
+	if d.IsDir() {
+		if d.Name() == ".git" {
+			return "", false, fs.SkipDir
+		}
+		return "", false, nil
+	}
+	if d.Name() != "Chart.yaml" {
+		return "", false, nil
+	}
+	chartPath := filepath.Dir(path)
+	if filepath.Base(chartPath) != componentName || filepath.Base(filepath.Dir(chartPath)) != "k8s" {
+		return "", false, nil
+	}
+	return chartPath, true, nil
 }
 
 func ValidateHelmChartPath(chartPath string) error {
@@ -1405,21 +1468,8 @@ func findLiteralDockerImagesInChart(chartPath string) ([]string, error) {
 		}
 
 		for _, line := range strings.Split(string(data), "\n") {
-			trimmed := strings.TrimSpace(line)
-			switch {
-			case strings.HasPrefix(trimmed, "image:"):
-				trimmed = strings.TrimPrefix(trimmed, "image:")
-			case strings.HasPrefix(trimmed, "- image:"):
-				trimmed = strings.TrimPrefix(trimmed, "- image:")
-			default:
-				continue
-			}
-			value := strings.TrimSpace(trimmed)
-			if idx := strings.Index(value, "#"); idx >= 0 {
-				value = strings.TrimSpace(value[:idx])
-			}
-			value = strings.Trim(value, `"'`)
-			if value == "" || strings.Contains(value, "{{") {
+			value := literalDockerImageFromChartLine(line)
+			if value == "" {
 				continue
 			}
 			if _, ok := seen[value]; ok {
@@ -1436,4 +1486,31 @@ func findLiteralDockerImagesInChart(chartPath string) ([]string, error) {
 	}
 
 	return images, nil
+}
+
+func literalDockerImageFromChartLine(line string) string {
+	value, ok := chartImageValue(line)
+	if !ok {
+		return ""
+	}
+	if idx := strings.Index(value, "#"); idx >= 0 {
+		value = strings.TrimSpace(value[:idx])
+	}
+	value = strings.Trim(strings.TrimSpace(value), `"'`)
+	if value == "" || strings.Contains(value, "{{") {
+		return ""
+	}
+	return value
+}
+
+func chartImageValue(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	switch {
+	case strings.HasPrefix(trimmed, "image:"):
+		return strings.TrimPrefix(trimmed, "image:"), true
+	case strings.HasPrefix(trimmed, "- image:"):
+		return strings.TrimPrefix(trimmed, "- image:"), true
+	default:
+		return "", false
+	}
 }

--- a/erun-common/deploy_test.go
+++ b/erun-common/deploy_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -97,18 +96,8 @@ func TestResolveCurrentKubernetesDeployContextsUsesProjectRootDevopsModule(t *te
 	moduleRoot := filepath.Join(projectRoot, "tenant-a-devops")
 	chartA := filepath.Join(moduleRoot, "k8s", "tenant-a-devops")
 	chartB := filepath.Join(moduleRoot, "k8s", "erun-dind")
-	for _, chartPath := range []string{chartA, chartB} {
-		if err := os.MkdirAll(chartPath, 0o755); err != nil {
-			t.Fatalf("mkdir chart dir: %v", err)
-		}
-		componentName := filepath.Base(chartPath)
-		if err := os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: "+componentName+"\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644); err != nil {
-			t.Fatalf("write Chart.yaml: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644); err != nil {
-			t.Fatalf("write values.local.yaml: %v", err)
-		}
-	}
+	writeDeployChartFixture(t, chartA)
+	writeDeployChartFixture(t, chartB)
 
 	deployContexts, err := ResolveCurrentKubernetesDeployContexts(
 		func() (string, string, error) {
@@ -119,18 +108,24 @@ func TestResolveCurrentKubernetesDeployContextsUsesProjectRootDevopsModule(t *te
 		},
 		"",
 	)
-	if err != nil {
-		t.Fatalf("ResolveCurrentKubernetesDeployContexts failed: %v", err)
-	}
-	if len(deployContexts) != 2 {
-		t.Fatalf("unexpected deploy contexts: %+v", deployContexts)
-	}
-	if deployContexts[0].ComponentName != "erun-dind" || deployContexts[0].ChartPath != chartB {
-		t.Fatalf("unexpected first deploy context: %+v", deployContexts[0])
-	}
-	if deployContexts[1].ComponentName != "tenant-a-devops" || deployContexts[1].ChartPath != chartA {
-		t.Fatalf("unexpected second deploy context: %+v", deployContexts[1])
-	}
+	requireNoError(t, err, "ResolveCurrentKubernetesDeployContexts failed")
+	requireDeployContexts(t, deployContexts, chartA, chartB)
+}
+
+func writeDeployChartFixture(t *testing.T, chartPath string) {
+	t.Helper()
+	requireNoError(t, os.MkdirAll(chartPath, 0o755), "mkdir chart dir")
+	componentName := filepath.Base(chartPath)
+	chart := []byte("apiVersion: v2\nname: " + componentName + "\nversion: 1.0.0\nappVersion: 1.0.0\n")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), chart, 0o644), "write Chart.yaml")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644), "write values.local.yaml")
+}
+
+func requireDeployContexts(t *testing.T, deployContexts []KubernetesDeployContext, chartA, chartB string) {
+	t.Helper()
+	requireEqual(t, len(deployContexts), 2, "deploy context count")
+	requireCondition(t, deployContexts[0].ComponentName == "erun-dind" && deployContexts[0].ChartPath == chartB, "unexpected first deploy context: %+v", deployContexts[0])
+	requireCondition(t, deployContexts[1].ComponentName == "tenant-a-devops" && deployContexts[1].ChartPath == chartA, "unexpected second deploy context: %+v", deployContexts[1])
 }
 
 func TestResolveDeployTargetUsesCurrentDirectoryTenantWhenTenantProjectRootDiffers(t *testing.T) {
@@ -734,31 +729,15 @@ func TestResolveDeploySpecForContextPublishesLocalRuntimeBuildsAsMultiPlatform(t
 	componentRoot := filepath.Join(projectRoot, "tenant-a-devops")
 	chartPath := createComponentHelmChartFixture(t, projectRoot, "tenant-a-devops")
 	templatesPath := filepath.Join(chartPath, "templates")
-	if err := os.MkdirAll(templatesPath, 0o755); err != nil {
-		t.Fatalf("mkdir templates dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(templatesPath, "deployment.yaml"), []byte("apiVersion: apps/v1\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers:\n        - name: tenant-a-devops\n          image: erunpaas/tenant-a-devops:{{ .Chart.AppVersion }}\n        - name: erun-dind\n          image: erunpaas/erun-dind:28.1.1\n"), 0o644); err != nil {
-		t.Fatalf("write deployment template: %v", err)
-	}
+	writeRuntimeDeploymentTemplate(t, templatesPath)
 
 	runtimeWorkdir := filepath.Join(componentRoot, "docker", "tenant-a-devops")
-	if err := os.MkdirAll(runtimeWorkdir, 0o755); err != nil {
-		t.Fatalf("mkdir runtime docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(runtimeWorkdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatalf("write runtime Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(componentRoot, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
-		t.Fatalf("write runtime VERSION: %v", err)
-	}
+	writeDockerBuildFixture(t, runtimeWorkdir)
+	writeVersionFileForTest(t, filepath.Join(componentRoot, "VERSION"), "1.0.0")
 
 	dindWorkdir := filepath.Join(componentRoot, "docker", "erun-dind")
-	if err := os.MkdirAll(dindWorkdir, 0o755); err != nil {
-		t.Fatalf("mkdir dind docker dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dindWorkdir, "Dockerfile"), []byte("FROM docker:28.1.1-dind\n"), 0o644); err != nil {
-		t.Fatalf("write dind Dockerfile: %v", err)
-	}
+	requireNoError(t, os.MkdirAll(dindWorkdir, 0o755), "mkdir dind docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(dindWorkdir, "Dockerfile"), []byte("FROM docker:28.1.1-dind\n"), 0o644), "write dind Dockerfile")
 	projectConfig := ProjectConfig{}
 	projectConfig.SetContainerRegistryForEnvironment(DefaultEnvironment, "erunpaas")
 	projectConfig.Environments[DefaultEnvironment] = ProjectEnvironmentConfig{
@@ -767,9 +746,7 @@ func TestResolveDeploySpecForContextPublishesLocalRuntimeBuildsAsMultiPlatform(t
 			SkipIfExists: []string{"erunpaas/erun-dind"},
 		},
 	}
-	if err := SaveProjectConfig(projectRoot, projectConfig); err != nil {
-		t.Fatalf("save project config: %v", err)
-	}
+	requireNoError(t, SaveProjectConfig(projectRoot, projectConfig), "save project config")
 
 	spec, err := resolveDeploySpecForContext(
 		ConfigStore{},
@@ -808,24 +785,25 @@ func TestResolveDeploySpecForContextPublishesLocalRuntimeBuildsAsMultiPlatform(t
 		"",
 		true,
 	)
-	if err != nil {
-		t.Fatalf("resolveDeploySpecForContext failed: %v", err)
-	}
+	requireNoError(t, err, "resolveDeploySpecForContext failed")
 
-	if len(spec.Builds) != 2 {
-		t.Fatalf("unexpected builds: %+v", spec.Builds)
-	}
-	for _, build := range spec.Builds {
-		if !build.Push {
-			t.Fatalf("expected deploy build to push via buildx, got %+v", build)
-		}
-		if !reflect.DeepEqual(build.Platforms, []string{"linux/amd64", "linux/arm64"}) {
-			t.Fatalf("expected deploy build to target both platforms, got %+v", build)
-		}
-	}
-	for _, build := range spec.Builds {
-		if build.Image.Tag == "erunpaas/erun-dind:28.1.1" && !build.SkipIfExists {
-			t.Fatalf("expected dind dependency build to be skippable, got %+v", build)
+	requireMultiPlatformDeployBuilds(t, spec.Builds)
+}
+
+func writeRuntimeDeploymentTemplate(t *testing.T, templatesPath string) {
+	t.Helper()
+	requireNoError(t, os.MkdirAll(templatesPath, 0o755), "mkdir templates dir")
+	template := []byte("apiVersion: apps/v1\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers:\n        - name: tenant-a-devops\n          image: erunpaas/tenant-a-devops:{{ .Chart.AppVersion }}\n        - name: erun-dind\n          image: erunpaas/erun-dind:28.1.1\n")
+	requireNoError(t, os.WriteFile(filepath.Join(templatesPath, "deployment.yaml"), template, 0o644), "write deployment template")
+}
+
+func requireMultiPlatformDeployBuilds(t *testing.T, builds []DockerBuildSpec) {
+	t.Helper()
+	requireEqual(t, len(builds), 2, "deploy build count")
+	for _, build := range builds {
+		requireMultiPlatformPushedBuild(t, build)
+		if build.Image.Tag == "erunpaas/erun-dind:28.1.1" {
+			requireCondition(t, build.SkipIfExists, "expected dind dependency build to be skippable, got %+v", build)
 		}
 	}
 }

--- a/erun-common/diff.go
+++ b/erun-common/diff.go
@@ -240,10 +240,7 @@ func parseGitDiffFiles(raw string) []DiffFile {
 					Content: line,
 				})
 			default:
-				content := line
-				if strings.HasPrefix(content, " ") {
-					content = strings.TrimPrefix(content, " ")
-				}
+				content := strings.TrimPrefix(line, " ")
 				currentHunk.Lines = append(currentHunk.Lines, DiffLine{
 					Kind:    "context",
 					Content: content,

--- a/erun-common/diff.go
+++ b/erun-common/diff.go
@@ -153,107 +153,128 @@ func ParseGitDiff(raw string) DiffResult {
 
 func parseGitDiffFiles(raw string) []DiffFile {
 	lines := strings.Split(raw, "\n")
-	files := make([]DiffFile, 0)
-	var current *DiffFile
-	var currentHunk *DiffHunk
-	oldLine := 0
-	newLine := 0
-
-	flush := func() {
-		if current == nil {
-			return
-		}
-		normalizeDiffFile(current)
-		files = append(files, *current)
-		current = nil
-		currentHunk = nil
-	}
+	parser := diffFileParser{}
 
 	for index, line := range lines {
 		if index == len(lines)-1 && line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "diff --git ") {
-			flush()
-			oldPath, newPath := parseDiffGitHeader(line)
-			current = &DiffFile{
-				Path:    firstNonEmptyDiffPath(newPath, oldPath),
-				OldPath: oldPath,
-				NewPath: newPath,
-				Status:  "modified",
-			}
-			continue
-		}
-		if current == nil {
-			continue
-		}
-
-		switch {
-		case strings.HasPrefix(line, "new file mode "):
-			current.Status = "added"
-		case strings.HasPrefix(line, "deleted file mode "):
-			current.Status = "deleted"
-		case strings.HasPrefix(line, "rename from "):
-			current.Status = "renamed"
-			current.OldPath = strings.TrimSpace(strings.TrimPrefix(line, "rename from "))
-		case strings.HasPrefix(line, "rename to "):
-			current.Status = "renamed"
-			current.NewPath = strings.TrimSpace(strings.TrimPrefix(line, "rename to "))
-			current.Path = current.NewPath
-		case strings.HasPrefix(line, "copy from "):
-			current.Status = "copied"
-			current.OldPath = strings.TrimSpace(strings.TrimPrefix(line, "copy from "))
-		case strings.HasPrefix(line, "copy to "):
-			current.Status = "copied"
-			current.NewPath = strings.TrimSpace(strings.TrimPrefix(line, "copy to "))
-			current.Path = current.NewPath
-		case strings.HasPrefix(line, "Binary files ") || strings.HasPrefix(line, "GIT binary patch"):
-			current.Binary = true
-			currentHunk = nil
-		case strings.HasPrefix(line, "@@ "):
-			hunk := parseDiffHunkHeader(line)
-			current.Hunks = append(current.Hunks, hunk)
-			currentHunk = &current.Hunks[len(current.Hunks)-1]
-			oldLine = currentHunk.OldStart
-			newLine = currentHunk.NewStart
-		case currentHunk != nil:
-			switch {
-			case strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++ "):
-				current.Additions++
-				currentHunk.Lines = append(currentHunk.Lines, DiffLine{
-					Kind:    "add",
-					Content: strings.TrimPrefix(line, "+"),
-					NewLine: newLine,
-				})
-				newLine++
-			case strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "--- "):
-				current.Deletions++
-				currentHunk.Lines = append(currentHunk.Lines, DiffLine{
-					Kind:    "delete",
-					Content: strings.TrimPrefix(line, "-"),
-					OldLine: oldLine,
-				})
-				oldLine++
-			case strings.HasPrefix(line, "\\"):
-				currentHunk.Lines = append(currentHunk.Lines, DiffLine{
-					Kind:    "meta",
-					Content: line,
-				})
-			default:
-				content := strings.TrimPrefix(line, " ")
-				currentHunk.Lines = append(currentHunk.Lines, DiffLine{
-					Kind:    "context",
-					Content: content,
-					OldLine: oldLine,
-					NewLine: newLine,
-				})
-				oldLine++
-				newLine++
-			}
-		}
+		parser.parseLine(line)
 	}
-	flush()
-	return files
+	parser.flush()
+	return parser.files
+}
+
+type diffFileParser struct {
+	files       []DiffFile
+	current     *DiffFile
+	currentHunk *DiffHunk
+	oldLine     int
+	newLine     int
+}
+
+func (p *diffFileParser) parseLine(line string) {
+	if strings.HasPrefix(line, "diff --git ") {
+		p.startFile(line)
+		return
+	}
+	if p.current == nil {
+		return
+	}
+	if p.parseFileMetadata(line) {
+		return
+	}
+	if strings.HasPrefix(line, "@@ ") {
+		p.startHunk(line)
+		return
+	}
+	if p.currentHunk != nil {
+		p.appendHunkLine(line)
+	}
+}
+
+func (p *diffFileParser) startFile(line string) {
+	p.flush()
+	oldPath, newPath := parseDiffGitHeader(line)
+	p.current = &DiffFile{Path: firstNonEmptyDiffPath(newPath, oldPath), OldPath: oldPath, NewPath: newPath, Status: "modified"}
+}
+
+func (p *diffFileParser) flush() {
+	if p.current == nil {
+		return
+	}
+	normalizeDiffFile(p.current)
+	p.files = append(p.files, *p.current)
+	p.current = nil
+	p.currentHunk = nil
+}
+
+func (p *diffFileParser) parseFileMetadata(line string) bool {
+	switch {
+	case strings.HasPrefix(line, "new file mode "):
+		p.current.Status = "added"
+	case strings.HasPrefix(line, "deleted file mode "):
+		p.current.Status = "deleted"
+	case strings.HasPrefix(line, "rename from "):
+		p.current.Status = "renamed"
+		p.current.OldPath = strings.TrimSpace(strings.TrimPrefix(line, "rename from "))
+	case strings.HasPrefix(line, "rename to "):
+		p.current.Status = "renamed"
+		p.current.NewPath = strings.TrimSpace(strings.TrimPrefix(line, "rename to "))
+		p.current.Path = p.current.NewPath
+	case strings.HasPrefix(line, "copy from "):
+		p.current.Status = "copied"
+		p.current.OldPath = strings.TrimSpace(strings.TrimPrefix(line, "copy from "))
+	case strings.HasPrefix(line, "copy to "):
+		p.current.Status = "copied"
+		p.current.NewPath = strings.TrimSpace(strings.TrimPrefix(line, "copy to "))
+		p.current.Path = p.current.NewPath
+	case strings.HasPrefix(line, "Binary files ") || strings.HasPrefix(line, "GIT binary patch"):
+		p.current.Binary = true
+		p.currentHunk = nil
+	default:
+		return false
+	}
+	return true
+}
+
+func (p *diffFileParser) startHunk(line string) {
+	hunk := parseDiffHunkHeader(line)
+	p.current.Hunks = append(p.current.Hunks, hunk)
+	p.currentHunk = &p.current.Hunks[len(p.current.Hunks)-1]
+	p.oldLine = p.currentHunk.OldStart
+	p.newLine = p.currentHunk.NewStart
+}
+
+func (p *diffFileParser) appendHunkLine(line string) {
+	switch {
+	case strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++ "):
+		p.appendAddedLine(line)
+	case strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "--- "):
+		p.appendDeletedLine(line)
+	case strings.HasPrefix(line, "\\"):
+		p.currentHunk.Lines = append(p.currentHunk.Lines, DiffLine{Kind: "meta", Content: line})
+	default:
+		p.appendContextLine(line)
+	}
+}
+
+func (p *diffFileParser) appendAddedLine(line string) {
+	p.current.Additions++
+	p.currentHunk.Lines = append(p.currentHunk.Lines, DiffLine{Kind: "add", Content: strings.TrimPrefix(line, "+"), NewLine: p.newLine})
+	p.newLine++
+}
+
+func (p *diffFileParser) appendDeletedLine(line string) {
+	p.current.Deletions++
+	p.currentHunk.Lines = append(p.currentHunk.Lines, DiffLine{Kind: "delete", Content: strings.TrimPrefix(line, "-"), OldLine: p.oldLine})
+	p.oldLine++
+}
+
+func (p *diffFileParser) appendContextLine(line string) {
+	p.currentHunk.Lines = append(p.currentHunk.Lines, DiffLine{Kind: "context", Content: strings.TrimPrefix(line, " "), OldLine: p.oldLine, NewLine: p.newLine})
+	p.oldLine++
+	p.newLine++
 }
 
 func parseDiffGitHeader(line string) (string, string) {

--- a/erun-common/diff_test.go
+++ b/erun-common/diff_test.go
@@ -29,41 +29,40 @@ func TestParseGitDiffBuildsFilesHunksAndTree(t *testing.T) {
 
 	result := ParseGitDiff(raw)
 
-	if result.Summary.FileCount != 2 || result.Summary.Additions != 2 || result.Summary.Deletions != 1 {
-		t.Fatalf("unexpected summary: %+v", result.Summary)
-	}
-	if len(result.Files) != 2 {
-		t.Fatalf("unexpected files: %+v", result.Files)
-	}
+	requireParsedGitDiffSummary(t, result)
+	requireParsedGitDiffFiles(t, result)
+	requireParsedGitDiffTree(t, result)
+}
 
+func requireParsedGitDiffSummary(t *testing.T, result DiffResult) {
+	t.Helper()
+	requireCondition(t, result.Summary.FileCount == 2 && result.Summary.Additions == 2 && result.Summary.Deletions == 1, "unexpected summary: %+v", result.Summary)
+	requireEqual(t, len(result.Files), 2, "file count")
+}
+
+func requireParsedGitDiffFiles(t *testing.T, result DiffResult) {
+	t.Helper()
 	app := result.Files[0]
-	if app.Path != "pkg/app.go" || app.Status != "modified" || app.Additions != 2 || app.Deletions != 1 {
-		t.Fatalf("unexpected app file: %+v", app)
-	}
-	if len(app.Hunks) != 1 {
-		t.Fatalf("unexpected hunks: %+v", app.Hunks)
-	}
+	requireCondition(t, app.Path == "pkg/app.go" && app.Status == "modified" && app.Additions == 2 && app.Deletions == 1, "unexpected app file: %+v", app)
+	requireEqual(t, len(app.Hunks), 1, "hunk count")
 	hunk := app.Hunks[0]
-	if hunk.OldStart != 1 || hunk.OldLines != 4 || hunk.NewStart != 1 || hunk.NewLines != 5 {
-		t.Fatalf("unexpected hunk range: %+v", hunk)
-	}
-	if got := hunk.Lines[1]; got.Kind != "delete" || got.OldLine != 2 || got.NewLine != 0 {
-		t.Fatalf("unexpected delete line: %+v", got)
-	}
-	if got := hunk.Lines[2]; got.Kind != "add" || got.NewLine != 2 || got.OldLine != 0 {
-		t.Fatalf("unexpected add line: %+v", got)
-	}
+	requireCondition(t, hunk.OldStart == 1 && hunk.OldLines == 4 && hunk.NewStart == 1 && hunk.NewLines == 5, "unexpected hunk range: %+v", hunk)
+	requireDiffLine(t, hunk.Lines[1], "delete", 2, 0)
+	requireDiffLine(t, hunk.Lines[2], "add", 0, 2)
 
 	logo := result.Files[1]
-	if logo.Path != "assets/logo.png" || logo.Status != "added" || !logo.Binary {
-		t.Fatalf("unexpected binary file: %+v", logo)
-	}
-	if len(result.Tree) != 4 {
-		t.Fatalf("unexpected tree: %+v", result.Tree)
-	}
-	if result.Tree[0].Name != "pkg" || result.Tree[1].Path != "pkg/app.go" || result.Tree[1].Depth != 1 {
-		t.Fatalf("unexpected first tree nodes: %+v", result.Tree[:2])
-	}
+	requireCondition(t, logo.Path == "assets/logo.png" && logo.Status == "added" && logo.Binary, "unexpected binary file: %+v", logo)
+}
+
+func requireDiffLine(t *testing.T, line DiffLine, kind string, oldLine, newLine int) {
+	t.Helper()
+	requireCondition(t, line.Kind == kind && line.OldLine == oldLine && line.NewLine == newLine, "unexpected %s line: %+v", kind, line)
+}
+
+func requireParsedGitDiffTree(t *testing.T, result DiffResult) {
+	t.Helper()
+	requireEqual(t, len(result.Tree), 4, "tree node count")
+	requireCondition(t, result.Tree[0].Name == "pkg" && result.Tree[1].Path == "pkg/app.go" && result.Tree[1].Depth == 1, "unexpected first tree nodes: %+v", result.Tree[:2])
 }
 
 func TestParseGitDiffDetectsDeletedAndRenamedFiles(t *testing.T) {
@@ -106,75 +105,72 @@ func TestResolveGitDiffRunsNoColorDiff(t *testing.T) {
 	result, err := ResolveGitDiff("/tmp/project", func(dir string, stdout, stderr io.Writer, args ...string) error {
 		gotDir = dir
 		calls = append(calls, strings.Join(args, " "))
-		switch len(calls) {
-		case 1:
-			_, _ = io.WriteString(stdout, "diff --git a/a.txt b/a.txt\n")
-		case 2:
-			_, _ = io.WriteString(stdout, "")
-		default:
-			t.Fatalf("unexpected git call: %v", args)
-		}
-		return nil
+		return writeResolveGitDiffOutput(t, stdout, calls, args)
 	})
-	if err != nil {
-		t.Fatalf("ResolveGitDiff failed: %v", err)
+	requireNoError(t, err, "ResolveGitDiff failed")
+	requireCondition(t, gotDir == "/tmp/project" && len(calls) == 2 && calls[0] == "diff --no-color --no-ext-diff" && calls[1] == "ls-files --others --exclude-standard -z", "unexpected git invocation: dir=%q calls=%+v", gotDir, calls)
+	requireCondition(t, result.WorkingDirectory == "/tmp/project" && result.RawDiff != "", "unexpected result: %+v", result)
+}
+
+func writeResolveGitDiffOutput(t *testing.T, stdout io.Writer, calls []string, args []string) error {
+	t.Helper()
+	switch len(calls) {
+	case 1:
+		_, _ = io.WriteString(stdout, "diff --git a/a.txt b/a.txt\n")
+	case 2:
+		_, _ = io.WriteString(stdout, "")
+	default:
+		t.Fatalf("unexpected git call: %v", args)
 	}
-	if gotDir != "/tmp/project" || len(calls) != 2 || calls[0] != "diff --no-color --no-ext-diff" || calls[1] != "ls-files --others --exclude-standard -z" {
-		t.Fatalf("unexpected git invocation: dir=%q calls=%+v", gotDir, calls)
-	}
-	if result.WorkingDirectory != "/tmp/project" || result.RawDiff == "" {
-		t.Fatalf("unexpected result: %+v", result)
-	}
+	return nil
 }
 
 func TestResolveGitDiffIncludesUntrackedFiles(t *testing.T) {
-	result, err := ResolveGitDiff("/tmp/project", func(dir string, stdout, stderr io.Writer, args ...string) error {
-		switch strings.Join(args, " ") {
-		case "diff --no-color --no-ext-diff":
-			_, _ = io.WriteString(stdout, "diff --git a/existing.txt b/existing.txt\n")
-			return nil
-		case "ls-files --others --exclude-standard -z":
-			_, _ = io.WriteString(stdout, "new.txt\x00nested/newer.txt\x00")
-			return nil
-		case "diff --no-color --no-ext-diff --no-index -- /dev/null new.txt":
-			_, _ = io.WriteString(stdout, strings.Join([]string{
-				"diff --git a/new.txt b/new.txt",
-				"new file mode 100644",
-				"--- /dev/null",
-				"+++ b/new.txt",
-				"@@ -0,0 +1 @@",
-				"+new",
-				"",
-			}, "\n"))
-			return fmt.Errorf("exit status 1")
-		case "diff --no-color --no-ext-diff --no-index -- /dev/null nested/newer.txt":
-			_, _ = io.WriteString(stdout, strings.Join([]string{
-				"diff --git a/nested/newer.txt b/nested/newer.txt",
-				"new file mode 100644",
-				"--- /dev/null",
-				"+++ b/nested/newer.txt",
-				"@@ -0,0 +1 @@",
-				"+newer",
-				"",
-			}, "\n"))
-			return fmt.Errorf("exit status 1")
-		default:
-			t.Fatalf("unexpected git call: %v", args)
-			return nil
-		}
-	})
-	if err != nil {
-		t.Fatalf("ResolveGitDiff failed: %v", err)
+	result, err := ResolveGitDiff("/tmp/project", resolveGitDiffWithUntrackedFiles(t))
+	requireNoError(t, err, "ResolveGitDiff failed")
+	requireCondition(t, result.Summary.FileCount == 3 && result.Summary.Additions == 2, "unexpected summary: %+v files=%+v", result.Summary, result.Files)
+	requireCondition(t, result.Files[1].Path == "new.txt" && result.Files[1].Status == "added", "expected untracked file in diff result, got %+v", result.Files)
+	requireCondition(t, result.Files[2].Path == "nested/newer.txt" && result.Files[2].Status == "added", "expected nested untracked file in diff result, got %+v", result.Files)
+}
+
+func resolveGitDiffWithUntrackedFiles(t *testing.T) GitCommandRunnerFunc {
+	t.Helper()
+	return func(dir string, stdout, stderr io.Writer, args ...string) error {
+		return writeGitDiffWithUntrackedOutput(t, stdout, args)
 	}
-	if result.Summary.FileCount != 3 || result.Summary.Additions != 2 {
-		t.Fatalf("unexpected summary: %+v files=%+v", result.Summary, result.Files)
+}
+
+func writeGitDiffWithUntrackedOutput(t *testing.T, stdout io.Writer, args []string) error {
+	t.Helper()
+	switch strings.Join(args, " ") {
+	case "diff --no-color --no-ext-diff":
+		_, _ = io.WriteString(stdout, "diff --git a/existing.txt b/existing.txt\n")
+		return nil
+	case "ls-files --others --exclude-standard -z":
+		_, _ = io.WriteString(stdout, "new.txt\x00nested/newer.txt\x00")
+		return nil
+	case "diff --no-color --no-ext-diff --no-index -- /dev/null new.txt":
+		_, _ = io.WriteString(stdout, untrackedFileDiff("new.txt", "+new"))
+		return fmt.Errorf("exit status 1")
+	case "diff --no-color --no-ext-diff --no-index -- /dev/null nested/newer.txt":
+		_, _ = io.WriteString(stdout, untrackedFileDiff("nested/newer.txt", "+newer"))
+		return fmt.Errorf("exit status 1")
+	default:
+		t.Fatalf("unexpected git call: %v", args)
+		return nil
 	}
-	if result.Files[1].Path != "new.txt" || result.Files[1].Status != "added" {
-		t.Fatalf("expected untracked file in diff result, got %+v", result.Files)
-	}
-	if result.Files[2].Path != "nested/newer.txt" || result.Files[2].Status != "added" {
-		t.Fatalf("expected nested untracked file in diff result, got %+v", result.Files)
-	}
+}
+
+func untrackedFileDiff(path, line string) string {
+	return strings.Join([]string{
+		"diff --git a/" + path + " b/" + path,
+		"new file mode 100644",
+		"--- /dev/null",
+		"+++ b/" + path,
+		"@@ -0,0 +1 @@",
+		line,
+		"",
+	}, "\n")
 }
 
 func TestWriteRawDiff(t *testing.T) {

--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -157,6 +157,25 @@ type bootstrapRunner struct {
 	Context Context
 }
 
+type bootstrapRunState struct {
+	runner                bootstrapRunner
+	params                BootstrapInitParams
+	result                BootstrapInitResult
+	detected              projectContext
+	tenants               []TenantConfig
+	tenantsLoaded         bool
+	setDefaultTenant      bool
+	defaultTenantResolved bool
+	toolConfig            ERunConfig
+	toolConfigMissing     bool
+	tenant                string
+	tenantConfig          TenantConfig
+	tenantConfigChanged   bool
+	envName               string
+	envConfig             EnvConfig
+	envConfigChanged      bool
+}
+
 func RunBootstrapInit(ctx Context, params BootstrapInitParams, store BootstrapStore, findProjectRoot ProjectFinderFunc, getWorkingDir WorkDirFunc, selectTenant SelectTenantFunc, confirm ConfirmFunc, promptKubernetesContext PromptValueFunc, promptContainerRegistry PromptValueFunc, ensureKubernetesNamespace NamespaceEnsurerFunc, loadProjectConfig ProjectConfigLoaderFunc, saveProjectConfig ProjectConfigSaverFunc) (BootstrapInitResult, error) {
 	return RunBootstrapInitWithDependencies(BootstrapInitDependencies{
 		Store:                     store,
@@ -290,422 +309,596 @@ func (s tracedBootstrapStore) ListEnvConfigs(tenant string) ([]EnvConfig, error)
 
 func (s bootstrapRunner) run(params BootstrapInitParams) (BootstrapInitResult, error) {
 	s = s.withDefaults()
-	params = normalizeBootstrapParams(params)
-	remoteMode := params.Remote
-
-	var result BootstrapInitResult
-	var detected projectContext
-	var tenants []TenantConfig
-	var tenantsLoaded bool
-	var setDefaultTenant bool
-	var defaultTenantResolved bool
-
-	if remoteMode {
-		if params.InitializeCurrentProject || params.ResolveTenant {
-			return result, fmt.Errorf("remote initialization requires an explicit tenant")
-		}
-		if params.Tenant == "" {
-			return result, fmt.Errorf("tenant is required with --remote")
-		}
-		if params.Environment == "" {
-			return result, fmt.Errorf("environment is required with --remote")
-		}
+	state := bootstrapRunState{
+		runner: s,
+		params: normalizeBootstrapParams(params),
 	}
-
-	findProject := func() (projectContext, error) {
-		if detected.loaded {
-			return detected, nil
-		}
-		tenant, root, err := s.FindProjectRoot()
-		if err != nil {
-			return projectContext{}, err
-		}
-		detected = projectContext{
-			tenant: tenant,
-			root:   root,
-			loaded: true,
-		}
-		return detected, nil
+	if err := state.run(); err != nil {
+		return state.result, err
 	}
+	return state.result, nil
+}
 
-	detectProject := func() (projectContext, error) {
-		s.Context.Trace("Trying to detect current project directory")
-		project, err := findProject()
-		if err != nil {
-			if errors.Is(err, ErrNotInGitRepository) {
-				s.Context.Logger.Error("erun config is not initialized. Run erun in project directory.")
-				return projectContext{}, err
-			}
-			return projectContext{}, err
-		}
+func (s *bootstrapRunState) run() error {
+	if err := s.validateRemoteParams(); err != nil {
+		return err
+	}
+	if err := s.loadBootstrapConfigs(); err != nil {
+		return err
+	}
+	if err := s.applyBootstrapConfigChanges(); err != nil {
+		return err
+	}
+	s.finish()
+	return nil
+}
+
+func (s *bootstrapRunState) loadBootstrapConfigs() error {
+	if err := s.loadToolConfig(); err != nil {
+		return err
+	}
+	if err := s.resolveTenant(); err != nil {
+		return err
+	}
+	if err := s.loadTenantConfig(); err != nil {
+		return err
+	}
+	if err := s.resolveEnvironmentName(); err != nil {
+		return err
+	}
+	return s.loadEnvConfig()
+}
+
+func (s *bootstrapRunState) applyBootstrapConfigChanges() error {
+	if err := s.updateEnvConfig(); err != nil {
+		return err
+	}
+	if err := s.ensureDevopsAssets(); err != nil {
+		return err
+	}
+	if err := s.saveEnvConfigIfChanged(); err != nil {
+		return err
+	}
+	return s.saveDefaultTenantIfNeeded()
+}
+
+func (s *bootstrapRunState) validateRemoteParams() error {
+	if !s.params.Remote {
+		return nil
+	}
+	if s.params.InitializeCurrentProject || s.params.ResolveTenant {
+		return fmt.Errorf("remote initialization requires an explicit tenant")
+	}
+	if s.params.Tenant == "" {
+		return fmt.Errorf("tenant is required with --remote")
+	}
+	if s.params.Environment == "" {
+		return fmt.Errorf("environment is required with --remote")
+	}
+	return nil
+}
+
+func (s *bootstrapRunState) findProject() (projectContext, error) {
+	if s.detected.loaded {
+		return s.detected, nil
+	}
+	tenant, root, err := s.runner.FindProjectRoot()
+	if err != nil {
+		return projectContext{}, err
+	}
+	s.detected = projectContext{
+		tenant: tenant,
+		root:   root,
+		loaded: true,
+	}
+	return s.detected, nil
+}
+
+func (s *bootstrapRunState) detectProject() (projectContext, error) {
+	s.runner.Context.Trace("Trying to detect current project directory")
+	project, err := s.findProject()
+	if err == nil {
 		return project, nil
 	}
-
-	loadTenants := func() ([]TenantConfig, error) {
-		if tenantsLoaded {
-			return tenants, nil
-		}
-		loadedTenants, err := s.Store.ListTenantConfigs()
-		if err != nil {
-			return nil, err
-		}
-		tenants = loadedTenants
-		tenantsLoaded = true
-		return tenants, nil
+	if errors.Is(err, ErrNotInGitRepository) {
+		s.runner.Context.Logger.Error("erun config is not initialized. Run erun in project directory.")
 	}
+	return projectContext{}, err
+}
 
-	resolveDefaultTenant := func(tenant, projectRoot string) error {
-		if defaultTenantResolved {
-			return nil
+func (s *bootstrapRunState) loadTenants() ([]TenantConfig, error) {
+	if s.tenantsLoaded {
+		return s.tenants, nil
+	}
+	tenants, err := s.runner.Store.ListTenantConfigs()
+	if err != nil {
+		return nil, err
+	}
+	s.tenants = tenants
+	s.tenantsLoaded = true
+	return s.tenants, nil
+}
+
+func (s *bootstrapRunState) resolveDefaultTenant(tenant, projectRoot string) error {
+	if s.defaultTenantResolved {
+		return nil
+	}
+	updateDefaultTenant, err := s.runner.confirmTenant(s.params, tenant, projectRoot)
+	if err != nil {
+		return err
+	}
+	s.setDefaultTenant = updateDefaultTenant
+	s.defaultTenantResolved = true
+	return nil
+}
+
+func (s *bootstrapRunState) loadToolConfig() error {
+	toolConfig, configPath, err := s.runner.Store.LoadERunConfig()
+	s.toolConfig = toolConfig
+	s.runner.Context.Trace("Loading erun tool configuration, configPath=" + configPath)
+	switch {
+	case err == nil:
+	case errors.Is(err, ErrNotInitialized):
+		if err := s.initializeMissingToolConfig(); err != nil {
+			return err
 		}
-		updateDefaultTenant, err := s.confirmTenant(params, tenant, projectRoot)
+	case err != nil:
+		return err
+	}
+	s.runner.Context.Trace("Loaded erun tool configuration")
+	return nil
+}
+
+func (s *bootstrapRunState) initializeMissingToolConfig() error {
+	s.toolConfigMissing = true
+	if s.params.ResolveTenant {
+		return nil
+	}
+	tenant, projectRoot, err := s.defaultTenantCandidate()
+	if err != nil {
+		return err
+	}
+	if err := s.resolveDefaultTenant(tenant, projectRoot); err != nil {
+		return err
+	}
+	if !s.setDefaultTenant {
+		return nil
+	}
+	s.runner.Context.Trace("Saving default config")
+	s.toolConfig = ERunConfig{DefaultTenant: tenant}
+	if err := s.runner.Store.SaveERunConfig(s.toolConfig); err != nil {
+		return err
+	}
+	s.result.CreatedERunConfig = true
+	s.toolConfigMissing = false
+	return nil
+}
+
+func (s *bootstrapRunState) defaultTenantCandidate() (string, string, error) {
+	tenant := s.params.Tenant
+	projectRoot := s.params.ProjectRoot
+	if s.params.Remote {
+		return tenant, RemoteWorktreePathForRepoName(tenant), nil
+	}
+	if tenant != "" && projectRoot != "" {
+		return tenant, projectRoot, nil
+	}
+	project, err := s.detectProject()
+	if err != nil {
+		return "", "", err
+	}
+	if tenant == "" {
+		tenant = project.tenant
+	}
+	if projectRoot == "" {
+		projectRoot = project.root
+	}
+	return tenant, projectRoot, nil
+}
+
+func (s *bootstrapRunState) resolveTenant() error {
+	s.tenant = s.params.Tenant
+	if err := s.resolveTenantFromProject(); err != nil {
+		return err
+	}
+	if err := s.resolveTenantFromDirectory(); err != nil {
+		return err
+	}
+	if s.tenant == "" && !s.params.Remote {
+		s.tenant = s.toolConfig.DefaultTenant
+	}
+	if err := s.resolveTenantFromSelection(); err != nil {
+		return err
+	}
+	if s.tenant == "" && !s.params.Remote {
+		project, err := s.detectProject()
 		if err != nil {
 			return err
 		}
-		setDefaultTenant = updateDefaultTenant
-		defaultTenantResolved = true
+		s.tenant = project.tenant
+	}
+	if s.params.Remote {
+		s.params.ProjectRoot = RemoteWorktreePathForRepoName(s.tenant)
+	}
+	return nil
+}
+
+func (s *bootstrapRunState) resolveTenantFromProject() error {
+	if s.tenant != "" || s.params.Remote {
 		return nil
 	}
-
-	toolConfig, configPath, err := s.Store.LoadERunConfig()
-	toolConfigMissing := false
-	s.Context.Trace("Loading erun tool configuration, configPath=" + configPath)
+	project, err := s.findProject()
 	switch {
 	case err == nil:
-	case errors.Is(err, ErrNotInitialized):
-		toolConfigMissing = true
-		if params.ResolveTenant {
-			break
-		}
-		tenant := params.Tenant
-		projectRoot := params.ProjectRoot
-		if remoteMode {
-			projectRoot = RemoteWorktreePathForRepoName(tenant)
-		} else if tenant == "" || projectRoot == "" {
-			project, detectErr := detectProject()
-			if detectErr != nil {
-				return result, detectErr
-			}
-			if tenant == "" {
-				tenant = project.tenant
-			}
-			if projectRoot == "" {
-				projectRoot = project.root
-			}
-		}
-
-		if err := resolveDefaultTenant(tenant, projectRoot); err != nil {
-			return result, err
-		}
-
-		if setDefaultTenant {
-			s.Context.Trace("Saving default config")
-			toolConfig = ERunConfig{DefaultTenant: tenant}
-			if err := s.Store.SaveERunConfig(toolConfig); err != nil {
-				return result, err
-			}
-			result.CreatedERunConfig = true
-			toolConfigMissing = false
-		}
+		s.tenant = project.tenant
+	case errors.Is(err, ErrNotInGitRepository):
 	case err != nil:
-		return result, err
+		return err
 	}
-	s.Context.Trace("Loaded erun tool configuration")
+	return nil
+}
 
-	tenant := params.Tenant
-	if tenant == "" && !remoteMode {
-		project, detectErr := findProject()
-		switch {
-		case detectErr == nil:
-			tenant = project.tenant
-		case errors.Is(detectErr, ErrNotInGitRepository):
-		case detectErr != nil:
-			return result, detectErr
-		}
+func (s *bootstrapRunState) resolveTenantFromDirectory() error {
+	if s.tenant != "" || !s.params.ResolveTenant {
+		return nil
 	}
-	if tenant == "" && params.ResolveTenant {
-		loadedTenants, err := loadTenants()
-		if err != nil {
-			return result, err
-		}
-		if len(loadedTenants) > 0 {
-			workingDir, err := s.GetWorkingDir()
-			if err != nil {
-				return result, err
-			}
-			if currentTenant, found := findTenantForDirectory(workingDir, loadedTenants); found {
-				tenant = currentTenant.Name
-			}
-		}
+	tenants, err := s.loadTenants()
+	if err != nil {
+		return err
 	}
-	if tenant == "" && !remoteMode {
-		tenant = toolConfig.DefaultTenant
+	if len(tenants) == 0 {
+		return nil
 	}
-	if tenant == "" && params.ResolveTenant {
-		loadedTenants, err := loadTenants()
-		if err != nil {
-			return result, err
-		}
-		if len(loadedTenants) > 0 {
-			selection, err := s.selectTenant(params, loadedTenants)
-			if err != nil {
-				return result, err
-			}
-			if !selection.Initialize {
-				tenant = selection.Tenant
-			}
-		}
+	workingDir, err := s.runner.GetWorkingDir()
+	if err != nil {
+		return err
 	}
-	if tenant == "" && !remoteMode {
-		project, detectErr := detectProject()
-		if detectErr != nil {
-			return result, detectErr
-		}
-		tenant = project.tenant
+	if currentTenant, found := findTenantForDirectory(workingDir, tenants); found {
+		s.tenant = currentTenant.Name
 	}
-	if remoteMode {
-		params.ProjectRoot = RemoteWorktreePathForRepoName(tenant)
-	}
+	return nil
+}
 
-	s.Context.Trace("Loading tenant configuration")
-	tenantConfig, _, err := s.Store.LoadTenantConfig(tenant)
-	tenantConfigChanged := false
+func (s *bootstrapRunState) resolveTenantFromSelection() error {
+	if s.tenant != "" || !s.params.ResolveTenant {
+		return nil
+	}
+	tenants, err := s.loadTenants()
+	if err != nil {
+		return err
+	}
+	if len(tenants) == 0 {
+		return nil
+	}
+	selection, err := s.runner.selectTenant(s.params, tenants)
+	if err != nil {
+		return err
+	}
+	if !selection.Initialize {
+		s.tenant = selection.Tenant
+	}
+	return nil
+}
+
+func (s *bootstrapRunState) loadTenantConfig() error {
+	s.runner.Context.Trace("Loading tenant configuration")
+	tenantConfig, _, err := s.runner.Store.LoadTenantConfig(s.tenant)
 	switch {
 	case err == nil:
+		s.tenantConfig = tenantConfig
 	case errors.Is(err, ErrNotInitialized):
-		projectRoot := params.ProjectRoot
-		if projectRoot == "" && !remoteMode {
-			project, detectErr := detectProject()
-			if detectErr != nil {
-				return result, detectErr
-			}
-			projectRoot = project.root
+		if err := s.createTenantConfig(); err != nil {
+			return err
 		}
-
-		if !defaultTenantResolved {
-			if err := resolveDefaultTenant(tenant, projectRoot); err != nil {
-				return result, err
-			}
-		}
-
-		defaultEnvironment := params.Environment
-		if defaultEnvironment == "" {
-			defaultEnvironment = DefaultEnvironment
-		}
-
-		s.Context.Trace("Adding new tenant")
-		tenantConfig = TenantConfig{
-			Name:               tenant,
-			ProjectRoot:        projectRoot,
-			DefaultEnvironment: defaultEnvironment,
-		}
-		if err := s.Store.SaveTenantConfig(tenantConfig); err != nil {
-			return result, err
-		}
-		result.CreatedTenantConfig = true
 	case err != nil:
-		return result, err
+		return err
 	}
+	s.normalizeTenantConfig()
+	s.runner.Context.Trace("Loaded tenant configuration")
+	return nil
+}
 
-	if tenantConfig.Name == "" {
-		tenantConfig.Name = tenant
-		tenantConfigChanged = true
+func (s *bootstrapRunState) createTenantConfig() error {
+	projectRoot, err := s.tenantProjectRoot()
+	if err != nil {
+		return err
 	}
-	if remoteMode {
-		if tenantConfig.ProjectRoot != params.ProjectRoot {
-			tenantConfig.ProjectRoot = params.ProjectRoot
-			tenantConfigChanged = true
-		}
+	if err := s.resolveDefaultTenant(s.tenant, projectRoot); err != nil {
+		return err
 	}
-	s.Context.Trace("Loaded tenant configuration")
+	s.runner.Context.Trace("Adding new tenant")
+	s.tenantConfig = TenantConfig{
+		Name:               s.tenant,
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: defaultBootstrapEnvironment(s.params.Environment),
+	}
+	if err := s.runner.Store.SaveTenantConfig(s.tenantConfig); err != nil {
+		return err
+	}
+	s.result.CreatedTenantConfig = true
+	return nil
+}
 
-	envName := params.Environment
-	if envName == "" {
-		envName = tenantConfig.DefaultEnvironment
+func (s *bootstrapRunState) tenantProjectRoot() (string, error) {
+	projectRoot := s.params.ProjectRoot
+	if projectRoot != "" || s.params.Remote {
+		return projectRoot, nil
 	}
-	if envName == "" {
-		envName = DefaultEnvironment
+	project, err := s.detectProject()
+	if err != nil {
+		return "", err
 	}
-	if tenantConfig.DefaultEnvironment == "" {
-		tenantConfig.DefaultEnvironment = envName
-		tenantConfigChanged = true
-	}
-	if tenantConfigChanged {
-		if err := s.Store.SaveTenantConfig(tenantConfig); err != nil {
-			return result, err
-		}
-	}
+	return project.root, nil
+}
 
-	s.Context.Trace("Loading environment configuration")
-	envConfig, _, err := s.Store.LoadEnvConfig(tenant, envName)
-	envConfigChanged := false
+func defaultBootstrapEnvironment(envName string) string {
+	if envName != "" {
+		return envName
+	}
+	return DefaultEnvironment
+}
+
+func (s *bootstrapRunState) normalizeTenantConfig() {
+	if s.tenantConfig.Name == "" {
+		s.tenantConfig.Name = s.tenant
+		s.tenantConfigChanged = true
+	}
+	if s.params.Remote && s.tenantConfig.ProjectRoot != s.params.ProjectRoot {
+		s.tenantConfig.ProjectRoot = s.params.ProjectRoot
+		s.tenantConfigChanged = true
+	}
+}
+
+func (s *bootstrapRunState) resolveEnvironmentName() error {
+	s.envName = s.params.Environment
+	if s.envName == "" {
+		s.envName = s.tenantConfig.DefaultEnvironment
+	}
+	if s.envName == "" {
+		s.envName = DefaultEnvironment
+	}
+	if s.tenantConfig.DefaultEnvironment == "" {
+		s.tenantConfig.DefaultEnvironment = s.envName
+		s.tenantConfigChanged = true
+	}
+	if !s.tenantConfigChanged {
+		return nil
+	}
+	return s.runner.Store.SaveTenantConfig(s.tenantConfig)
+}
+
+func (s *bootstrapRunState) loadEnvConfig() error {
+	s.runner.Context.Trace("Loading environment configuration")
+	envConfig, _, err := s.runner.Store.LoadEnvConfig(s.tenant, s.envName)
 	switch {
 	case err == nil:
+		s.envConfig = envConfig
 	case errors.Is(err, ErrNotInitialized):
-		envProjectRoot := params.ProjectRoot
-		if envProjectRoot == "" {
-			envProjectRoot = tenantConfig.ProjectRoot
-		}
-		if envProjectRoot == "" && !remoteMode {
-			project, detectErr := findProject()
-			if detectErr == nil {
-				envProjectRoot = project.root
-			} else if !errors.Is(detectErr, ErrNotInGitRepository) {
-				return result, detectErr
-			}
-		}
-
-		if err := s.confirmEnvironment(params, tenant, envName); err != nil {
-			return result, err
-		}
-
-		kubernetesContext, err := s.resolveKubernetesContext(params, tenant, envName, "")
-		if err != nil {
-			return result, err
-		}
-		if err := s.ensureKubernetesNamespace(tenant, envName, "", kubernetesContext); err != nil {
-			return result, err
-		}
-		cloudProviderAlias, err := s.resolveCloudProviderAlias(kubernetesContext, "")
-		if err != nil {
-			return result, err
-		}
-		managedCloud, err := managedCloudEnvironment(s.Store, EnvConfig{
-			KubernetesContext:  kubernetesContext,
-			CloudProviderAlias: cloudProviderAlias,
-			Remote:             remoteMode,
-		})
-		if err != nil {
-			return result, err
-		}
-		containerRegistry, err := s.resolveContainerRegistry(params, tenant, envName, envProjectRoot, "", true)
-		if err != nil {
-			return result, err
-		}
-		if err := s.saveProjectContainerRegistry(envProjectRoot, envName, containerRegistry, remoteMode); err != nil {
-			return result, err
-		}
-
-		s.Context.Trace("Adding new environment")
-		envConfig = EnvConfig{
-			Name:               envName,
-			RepoPath:           envProjectRoot,
-			KubernetesContext:  kubernetesContext,
-			CloudProviderAlias: cloudProviderAlias,
-			ManagedCloud:       managedCloud,
-			RuntimeVersion:     strings.TrimSpace(params.RuntimeVersion),
-			Remote:             remoteMode,
-		}
-		if err := saveEnvConfig(s.Store, tenant, envConfig); err != nil {
-			return result, err
-		}
-		envConfig.ContainerRegistry = containerRegistry
-		if remoteMode && containerRegistry != "" {
-			envConfigChanged = true
-		}
-		result.CreatedEnvConfig = true
+		return s.createEnvConfig()
 	case err != nil:
-		return result, err
+		return err
 	}
-	if remoteMode {
-		if envConfig.RepoPath != params.ProjectRoot {
-			envConfig.RepoPath = params.ProjectRoot
-			envConfigChanged = true
-		}
-		if runtimeVersion := strings.TrimSpace(params.RuntimeVersion); runtimeVersion != "" && envConfig.RuntimeVersion != runtimeVersion {
-			envConfig.RuntimeVersion = runtimeVersion
-			envConfigChanged = true
-		}
-		if !envConfig.Remote {
-			envConfig.Remote = true
-			envConfigChanged = true
-		}
-	}
+	return nil
+}
 
-	kubernetesContext, err := s.resolveKubernetesContext(params, tenant, envName, envConfig.KubernetesContext)
+func (s *bootstrapRunState) createEnvConfig() error {
+	envProjectRoot, err := s.envProjectRoot()
 	if err != nil {
-		return result, err
+		return err
 	}
-	if kubernetesContext != envConfig.KubernetesContext {
-		if err := s.ensureKubernetesNamespace(tenant, envName, envConfig.KubernetesContext, kubernetesContext); err != nil {
-			return result, err
-		}
-		envConfig.KubernetesContext = kubernetesContext
-		envConfigChanged = true
-	}
-	cloudProviderAlias, err := s.resolveCloudProviderAlias(kubernetesContext, envConfig.CloudProviderAlias)
+	kubernetesContext, cloudProviderAlias, managedCloud, err := s.resolveNewEnvCloudConfig()
 	if err != nil {
-		return result, err
+		return err
 	}
-	if cloudProviderAlias != envConfig.CloudProviderAlias {
-		envConfig.CloudProviderAlias = cloudProviderAlias
-		envConfigChanged = true
-	}
-	managedCloud, err := managedCloudEnvironment(s.Store, envConfig)
+	containerRegistry, err := s.runner.resolveContainerRegistry(s.params, s.tenant, s.envName, envProjectRoot, "", true)
 	if err != nil {
-		return result, err
+		return err
 	}
-	if managedCloud != envConfig.ManagedCloud {
-		envConfig.ManagedCloud = managedCloud
-		envConfigChanged = true
+	if err := s.runner.saveProjectContainerRegistry(envProjectRoot, s.envName, containerRegistry, s.params.Remote); err != nil {
+		return err
 	}
-	projectRoot := envConfig.RepoPath
+	s.runner.Context.Trace("Adding new environment")
+	s.envConfig = EnvConfig{
+		Name:               s.envName,
+		RepoPath:           envProjectRoot,
+		KubernetesContext:  kubernetesContext,
+		CloudProviderAlias: cloudProviderAlias,
+		ManagedCloud:       managedCloud,
+		RuntimeVersion:     strings.TrimSpace(s.params.RuntimeVersion),
+		Remote:             s.params.Remote,
+	}
+	if err := saveEnvConfig(s.runner.Store, s.tenant, s.envConfig); err != nil {
+		return err
+	}
+	s.envConfig.ContainerRegistry = containerRegistry
+	s.envConfigChanged = s.params.Remote && containerRegistry != ""
+	s.result.CreatedEnvConfig = true
+	return nil
+}
+
+func (s *bootstrapRunState) envProjectRoot() (string, error) {
+	envProjectRoot := s.params.ProjectRoot
+	if envProjectRoot == "" {
+		envProjectRoot = s.tenantConfig.ProjectRoot
+	}
+	if envProjectRoot != "" || s.params.Remote {
+		return envProjectRoot, nil
+	}
+	project, err := s.findProject()
+	if err == nil {
+		return project.root, nil
+	}
+	if errors.Is(err, ErrNotInGitRepository) {
+		return "", nil
+	}
+	return "", err
+}
+
+func (s *bootstrapRunState) resolveNewEnvCloudConfig() (string, string, bool, error) {
+	if err := s.runner.confirmEnvironment(s.params, s.tenant, s.envName); err != nil {
+		return "", "", false, err
+	}
+	kubernetesContext, err := s.runner.resolveKubernetesContext(s.params, s.tenant, s.envName, "")
+	if err != nil {
+		return "", "", false, err
+	}
+	if err := s.runner.ensureKubernetesNamespace(s.tenant, s.envName, "", kubernetesContext); err != nil {
+		return "", "", false, err
+	}
+	cloudProviderAlias, err := s.runner.resolveCloudProviderAlias(kubernetesContext, "")
+	if err != nil {
+		return "", "", false, err
+	}
+	managedCloud, err := managedCloudEnvironment(s.runner.Store, EnvConfig{
+		KubernetesContext:  kubernetesContext,
+		CloudProviderAlias: cloudProviderAlias,
+		Remote:             s.params.Remote,
+	})
+	return kubernetesContext, cloudProviderAlias, managedCloud, err
+}
+
+func (s *bootstrapRunState) updateEnvConfig() error {
+	s.updateRemoteEnvConfig()
+	kubernetesContext, err := s.updateEnvKubernetesContext()
+	if err != nil {
+		return err
+	}
+	if err := s.updateEnvCloudProvider(kubernetesContext); err != nil {
+		return err
+	}
+	return s.updateEnvContainerRegistry()
+}
+
+func (s *bootstrapRunState) updateRemoteEnvConfig() {
+	if !s.params.Remote {
+		return
+	}
+	if s.envConfig.RepoPath != s.params.ProjectRoot {
+		s.envConfig.RepoPath = s.params.ProjectRoot
+		s.envConfigChanged = true
+	}
+	if runtimeVersion := strings.TrimSpace(s.params.RuntimeVersion); runtimeVersion != "" && s.envConfig.RuntimeVersion != runtimeVersion {
+		s.envConfig.RuntimeVersion = runtimeVersion
+		s.envConfigChanged = true
+	}
+	if !s.envConfig.Remote {
+		s.envConfig.Remote = true
+		s.envConfigChanged = true
+	}
+}
+
+func (s *bootstrapRunState) updateEnvKubernetesContext() (string, error) {
+	kubernetesContext, err := s.runner.resolveKubernetesContext(s.params, s.tenant, s.envName, s.envConfig.KubernetesContext)
+	if err != nil {
+		return "", err
+	}
+	if kubernetesContext == s.envConfig.KubernetesContext {
+		return kubernetesContext, nil
+	}
+	if err := s.runner.ensureKubernetesNamespace(s.tenant, s.envName, s.envConfig.KubernetesContext, kubernetesContext); err != nil {
+		return "", err
+	}
+	s.envConfig.KubernetesContext = kubernetesContext
+	s.envConfigChanged = true
+	return kubernetesContext, nil
+}
+
+func (s *bootstrapRunState) updateEnvCloudProvider(kubernetesContext string) error {
+	cloudProviderAlias, err := s.runner.resolveCloudProviderAlias(kubernetesContext, s.envConfig.CloudProviderAlias)
+	if err != nil {
+		return err
+	}
+	if cloudProviderAlias != s.envConfig.CloudProviderAlias {
+		s.envConfig.CloudProviderAlias = cloudProviderAlias
+		s.envConfigChanged = true
+	}
+	managedCloud, err := managedCloudEnvironment(s.runner.Store, s.envConfig)
+	if err != nil {
+		return err
+	}
+	if managedCloud != s.envConfig.ManagedCloud {
+		s.envConfig.ManagedCloud = managedCloud
+		s.envConfigChanged = true
+	}
+	return nil
+}
+
+func (s *bootstrapRunState) updateEnvContainerRegistry() error {
+	projectRoot := s.projectRoot()
+	containerRegistry, err := s.runner.resolveContainerRegistry(s.params, s.tenant, s.envName, projectRoot, s.envConfig.ContainerRegistry, false)
+	if err != nil {
+		return err
+	}
+	if containerRegistry == "" {
+		return nil
+	}
+	if err := s.runner.saveProjectContainerRegistry(projectRoot, s.envName, containerRegistry, s.params.Remote); err != nil {
+		return err
+	}
+	if containerRegistry != s.envConfig.ContainerRegistry {
+		s.envConfig.ContainerRegistry = containerRegistry
+		s.envConfigChanged = true
+	}
+	return nil
+}
+
+func (s *bootstrapRunState) projectRoot() string {
+	projectRoot := s.envConfig.RepoPath
 	if projectRoot == "" {
-		projectRoot = tenantConfig.ProjectRoot
+		return s.tenantConfig.ProjectRoot
 	}
-	containerRegistry, err := s.resolveContainerRegistry(params, tenant, envName, projectRoot, envConfig.ContainerRegistry, false)
+	return projectRoot
+}
+
+func (s *bootstrapRunState) ensureDevopsAssets() error {
+	projectRoot := s.projectRoot()
+	if s.params.Remote {
+		return s.ensureRemoteDevopsAssets(projectRoot)
+	}
+	if err := EnsureDefaultDevopsModuleWithVersion(s.runner.Context, projectRoot, s.tenant, s.params.RuntimeVersion); err != nil {
+		return err
+	}
+	return EnsureDefaultDevopsChart(s.runner.Context, projectRoot, s.tenant, s.envName)
+}
+
+func (s *bootstrapRunState) ensureRemoteDevopsAssets(projectRoot string) error {
+	req, err := s.runner.ensureRemoteRepository(s.params, s.tenant, s.envName, s.envConfig.KubernetesContext, projectRoot)
 	if err != nil {
-		return result, err
+		return err
 	}
-	if containerRegistry != "" {
-		if err := s.saveProjectContainerRegistry(projectRoot, envName, containerRegistry, remoteMode); err != nil {
-			return result, err
-		}
+	if !s.params.Bootstrap {
+		return nil
 	}
-	if containerRegistry != "" && containerRegistry != envConfig.ContainerRegistry {
-		envConfig.ContainerRegistry = containerRegistry
-		envConfigChanged = true
-	}
-	if remoteMode {
-		req, err := s.ensureRemoteRepository(params, tenant, envName, kubernetesContext, projectRoot)
-		if err != nil {
-			return result, err
-		}
-		if params.Bootstrap {
-			if err := s.ensureRemoteDefaultDevopsBootstrap(req, projectRoot, tenant, envName, params.RuntimeVersion); err != nil {
-				return result, err
-			}
-		}
-	} else {
-		if err := EnsureDefaultDevopsModuleWithVersion(s.Context, projectRoot, tenant, params.RuntimeVersion); err != nil {
-			return result, err
-		}
-		if err := EnsureDefaultDevopsChart(s.Context, projectRoot, tenant, envName); err != nil {
-			return result, err
-		}
-	}
-	if envConfigChanged {
-		if err := saveEnvConfig(s.Store, tenant, envConfig); err != nil {
-			return result, err
-		}
-	}
+	return s.runner.ensureRemoteDefaultDevopsBootstrap(req, projectRoot, s.tenant, s.envName, s.params.RuntimeVersion)
+}
 
-	if setDefaultTenant && (toolConfigMissing || toolConfig.DefaultTenant != tenant) {
-		s.Context.Trace("Saving default config")
-		toolConfig.DefaultTenant = tenant
-		if err := s.Store.SaveERunConfig(toolConfig); err != nil {
-			return result, err
-		}
-		if toolConfigMissing {
-			result.CreatedERunConfig = true
-		}
+func (s *bootstrapRunState) saveEnvConfigIfChanged() error {
+	if !s.envConfigChanged {
+		return nil
 	}
+	return saveEnvConfig(s.runner.Store, s.tenant, s.envConfig)
+}
 
-	result.ERunConfig = toolConfig
-	result.TenantConfig = tenantConfig
-	result.EnvConfig = envConfig
-	s.Context.Trace("Configuration initialized OK")
-	return result, nil
+func (s *bootstrapRunState) saveDefaultTenantIfNeeded() error {
+	if !s.setDefaultTenant || (!s.toolConfigMissing && s.toolConfig.DefaultTenant == s.tenant) {
+		return nil
+	}
+	s.runner.Context.Trace("Saving default config")
+	s.toolConfig.DefaultTenant = s.tenant
+	if err := s.runner.Store.SaveERunConfig(s.toolConfig); err != nil {
+		return err
+	}
+	if s.toolConfigMissing {
+		s.result.CreatedERunConfig = true
+	}
+	return nil
+}
+
+func (s *bootstrapRunState) finish() {
+	s.result.ERunConfig = s.toolConfig
+	s.result.TenantConfig = s.tenantConfig
+	s.result.EnvConfig = s.envConfig
+	s.runner.Context.Trace("Configuration initialized OK")
 }
 
 func tenantConfirmationLabel(tenant, projectRoot string) string {

--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -759,6 +759,12 @@ func normalizeBootstrapParams(params BootstrapInitParams) BootstrapInitParams {
 }
 
 func (s bootstrapRunner) withDefaults() bootstrapRunner {
+	s = s.withStoreDefaults()
+	s = s.withRuntimeDefaults()
+	return s.withLoggerDefaults()
+}
+
+func (s bootstrapRunner) withStoreDefaults() bootstrapRunner {
 	if s.Store == nil {
 		s.Store = ConfigStore{}
 	}
@@ -774,6 +780,10 @@ func (s bootstrapRunner) withDefaults() bootstrapRunner {
 	if s.SaveProjectConfig == nil {
 		s.SaveProjectConfig = SaveProjectConfig
 	}
+	return s
+}
+
+func (s bootstrapRunner) withRuntimeDefaults() bootstrapRunner {
 	if s.WaitForRemoteRuntime == nil {
 		s.WaitForRemoteRuntime = WaitForShellDeployment
 	}
@@ -786,6 +796,10 @@ func (s bootstrapRunner) withDefaults() bootstrapRunner {
 	if s.Sleep == nil {
 		s.Sleep = time.Sleep
 	}
+	return s
+}
+
+func (s bootstrapRunner) withLoggerDefaults() bootstrapRunner {
 	if s.Context.Logger.verbosity == 0 && s.Context.Logger.stdout == nil && s.Context.Logger.stderr == nil {
 		s.Context.Logger = NewLoggerWithWriters(-1, io.Discard, io.Discard)
 	}

--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -886,17 +886,9 @@ func (s bootstrapRunner) resolveContainerRegistry(params BootstrapInitParams, te
 		return params.ContainerRegistry, nil
 	}
 
-	if projectRoot != "" && s.LoadProjectConfig != nil {
-		projectConfig, _, err := s.LoadProjectConfig(projectRoot)
-		if err != nil && !errors.Is(err, ErrNotInitialized) {
-			return "", err
-		}
-		if err == nil {
-			projectRegistry := projectConfig.ContainerRegistryForEnvironment(envName)
-			if projectRegistry != "" {
-				return projectRegistry, nil
-			}
-		}
+	projectRegistry, err := s.projectContainerRegistry(projectRoot, envName)
+	if err != nil || projectRegistry != "" {
+		return projectRegistry, err
 	}
 
 	current = strings.TrimSpace(current)
@@ -909,6 +901,24 @@ func (s bootstrapRunner) resolveContainerRegistry(params BootstrapInitParams, te
 	if params.AutoApprove {
 		return DefaultContainerRegistry, nil
 	}
+	return s.promptContainerRegistry(tenant, envName)
+}
+
+func (s bootstrapRunner) projectContainerRegistry(projectRoot, envName string) (string, error) {
+	if projectRoot == "" || s.LoadProjectConfig == nil {
+		return "", nil
+	}
+	projectConfig, _, err := s.LoadProjectConfig(projectRoot)
+	if err != nil {
+		if errors.Is(err, ErrNotInitialized) {
+			return "", nil
+		}
+		return "", err
+	}
+	return projectConfig.ContainerRegistryForEnvironment(envName), nil
+}
+
+func (s bootstrapRunner) promptContainerRegistry(tenant, envName string) (string, error) {
 	if s.PromptContainerRegistry == nil {
 		return "", BootstrapInitInteractionError{Interaction: BootstrapInitInteraction{
 			Type:         BootstrapInitInteractionContainerRegistry,
@@ -949,15 +959,9 @@ func (s bootstrapRunner) saveProjectContainerRegistry(projectRoot, envName, regi
 		return nil
 	}
 
-	projectConfig := ProjectConfig{}
-	if s.LoadProjectConfig != nil {
-		loadedConfig, _, err := s.LoadProjectConfig(projectRoot)
-		if err != nil && !errors.Is(err, ErrNotInitialized) {
-			return err
-		}
-		if err == nil {
-			projectConfig = loadedConfig
-		}
+	projectConfig, err := s.loadProjectConfigForContainerRegistry(projectRoot)
+	if err != nil {
+		return err
 	}
 
 	if projectConfig.ContainerRegistryForEnvironment(envName) == registry {
@@ -966,6 +970,20 @@ func (s bootstrapRunner) saveProjectContainerRegistry(projectRoot, envName, regi
 
 	projectConfig.SetContainerRegistryForEnvironment(envName, registry)
 	return s.SaveProjectConfig(projectRoot, projectConfig)
+}
+
+func (s bootstrapRunner) loadProjectConfigForContainerRegistry(projectRoot string) (ProjectConfig, error) {
+	if s.LoadProjectConfig == nil {
+		return ProjectConfig{}, nil
+	}
+	projectConfig, _, err := s.LoadProjectConfig(projectRoot)
+	if err != nil {
+		if errors.Is(err, ErrNotInitialized) {
+			return ProjectConfig{}, nil
+		}
+		return ProjectConfig{}, err
+	}
+	return projectConfig, nil
 }
 
 func (s bootstrapRunner) ensureKubernetesNamespace(tenant, envName, currentContext, nextContext string) error {

--- a/erun-common/init_remote.go
+++ b/erun-common/init_remote.go
@@ -274,14 +274,6 @@ func (s bootstrapRunner) resolveRemoteRepositoryURL(params BootstrapInitParams, 
 	return repositoryURL, nil
 }
 
-func (s bootstrapRunner) resolveRemoteRepositorySpec(params BootstrapInitParams, tenant, envName, repositoryURL, codeCommitPublicKey string) (remoteRepositorySpec, error) {
-	spec, err := parseRemoteRepositorySpec(repositoryURL)
-	if err != nil {
-		return remoteRepositorySpec{}, err
-	}
-	return s.resolveRemoteRepositoryCredentials(params, tenant, envName, spec, codeCommitPublicKey)
-}
-
 func (s bootstrapRunner) resolveRemoteRepositoryCredentials(params BootstrapInitParams, tenant, envName string, spec remoteRepositorySpec, codeCommitPublicKey string) (remoteRepositorySpec, error) {
 	if spec.CodeCommitHost == "" || spec.CodeCommitSSHKeyID != "" {
 		return spec, nil

--- a/erun-common/init_remote.go
+++ b/erun-common/init_remote.go
@@ -37,31 +37,7 @@ type remoteDefaultDevopsFile struct {
 }
 
 func (s bootstrapRunner) ensureRemoteRepository(params BootstrapInitParams, tenant, envName, kubernetesContext, projectRoot string) (ShellLaunchParams, error) {
-	ports := DefaultEnvironmentLocalPorts()
-	if portStore, ok := s.Store.(environmentPortStore); ok {
-		resolved, err := ResolveEnvironmentLocalPorts(portStore, tenant, envName)
-		if err == nil {
-			ports = resolved
-		}
-	}
-	target := OpenResult{
-		Tenant:      tenant,
-		Environment: envName,
-		TenantConfig: TenantConfig{
-			Name:               tenant,
-			ProjectRoot:        projectRoot,
-			DefaultEnvironment: envName,
-		},
-		EnvConfig: EnvConfig{
-			Name:              envName,
-			RepoPath:          projectRoot,
-			KubernetesContext: kubernetesContext,
-			Remote:            true,
-		},
-		LocalPorts: ports,
-		RepoPath:   projectRoot,
-		Title:      tenant + "-" + envName,
-	}
+	target := s.remoteRepositoryOpenResult(tenant, envName, kubernetesContext, projectRoot)
 	req := ShellLaunchParamsFromResult(target)
 
 	if err := s.ensureRemoteRuntime(target, req, params.RuntimeVersion, params.RuntimeImage); err != nil {
@@ -79,32 +55,78 @@ func (s bootstrapRunner) ensureRemoteRepository(params BootstrapInitParams, tena
 		return req, s.pullRemoteRepository(req, projectRoot)
 	}
 
-	repositoryURL, err := s.resolveRemoteRepositoryURL(params, tenant, envName)
+	repository, err := s.remoteRepositorySpecForClone(params, tenant, envName, req, state)
 	if err != nil {
 		return ShellLaunchParams{}, err
+	}
+	return req, s.cloneRemoteRepository(req, projectRoot, repository)
+}
+
+func (s bootstrapRunner) remoteRepositorySpecForClone(params BootstrapInitParams, tenant, envName string, req ShellLaunchParams, state remoteRepositoryState) (remoteRepositorySpec, error) {
+	repositoryURL, err := s.resolveRemoteRepositoryURL(params, tenant, envName)
+	if err != nil {
+		return remoteRepositorySpec{}, err
 	}
 	repository, err := parseRemoteRepositorySpec(repositoryURL)
 	if err != nil {
-		return ShellLaunchParams{}, err
+		return remoteRepositorySpec{}, err
 	}
 	repository, usingHostConfig, err := s.resolveExistingRemoteHostConfig(params, tenant, envName, req, state, repository)
 	if err != nil {
-		return ShellLaunchParams{}, err
+		return remoteRepositorySpec{}, err
 	}
 	if !usingHostConfig {
-		repository, err = s.resolveRemoteRepositoryCredentials(params, tenant, envName, repository, state.CodeCommitPublicKey)
-		if err != nil {
-			return ShellLaunchParams{}, err
-		}
-		publicKey := state.PublicKey
-		if repository.CodeCommitHost != "" {
-			publicKey = state.CodeCommitPublicKey
-		}
-		if err := s.waitForRemoteKeyImport(params, tenant, envName, req, repository, publicKey); err != nil {
-			return ShellLaunchParams{}, err
-		}
+		return s.remoteRepositorySpecWithCredentials(params, tenant, envName, req, state, repository)
 	}
-	return req, s.cloneRemoteRepository(req, projectRoot, repository)
+	return repository, nil
+}
+
+func (s bootstrapRunner) remoteRepositorySpecWithCredentials(params BootstrapInitParams, tenant, envName string, req ShellLaunchParams, state remoteRepositoryState, repository remoteRepositorySpec) (remoteRepositorySpec, error) {
+	repository, err := s.resolveRemoteRepositoryCredentials(params, tenant, envName, repository, state.CodeCommitPublicKey)
+	if err != nil {
+		return remoteRepositorySpec{}, err
+	}
+	publicKey := state.PublicKey
+	if repository.CodeCommitHost != "" {
+		publicKey = state.CodeCommitPublicKey
+	}
+	if err := s.waitForRemoteKeyImport(params, tenant, envName, req, repository, publicKey); err != nil {
+		return remoteRepositorySpec{}, err
+	}
+	return repository, nil
+}
+
+func (s bootstrapRunner) remoteRepositoryOpenResult(tenant, envName, kubernetesContext, projectRoot string) OpenResult {
+	return OpenResult{
+		Tenant:       tenant,
+		Environment:  envName,
+		TenantConfig: remoteRepositoryTenantConfig(tenant, envName, projectRoot),
+		EnvConfig:    remoteRepositoryEnvConfig(envName, kubernetesContext, projectRoot),
+		LocalPorts:   s.remoteRepositoryLocalPorts(tenant, envName),
+		RepoPath:     projectRoot,
+		Title:        tenant + "-" + envName,
+	}
+}
+
+func remoteRepositoryTenantConfig(tenant, envName, projectRoot string) TenantConfig {
+	return TenantConfig{Name: tenant, ProjectRoot: projectRoot, DefaultEnvironment: envName}
+}
+
+func remoteRepositoryEnvConfig(envName, kubernetesContext, projectRoot string) EnvConfig {
+	return EnvConfig{Name: envName, RepoPath: projectRoot, KubernetesContext: kubernetesContext, Remote: true}
+}
+
+func (s bootstrapRunner) remoteRepositoryLocalPorts(tenant, envName string) EnvironmentLocalPorts {
+	ports := DefaultEnvironmentLocalPorts()
+	portStore, ok := s.Store.(environmentPortStore)
+	if !ok {
+		return ports
+	}
+	resolved, err := ResolveEnvironmentLocalPorts(portStore, tenant, envName)
+	if err != nil {
+		return ports
+	}
+	return resolved
 }
 
 func (s bootstrapRunner) ensureRemoteWorktree(req ShellLaunchParams, projectRoot string) error {

--- a/erun-common/init_test.go
+++ b/erun-common/init_test.go
@@ -44,25 +44,7 @@ type bootstrapTestRunner struct {
 }
 
 func (r bootstrapTestRunner) Run(params BootstrapInitParams) (BootstrapInitResult, error) {
-	return RunBootstrapInitWithDependencies(BootstrapInitDependencies{
-		Store:                     r.Store,
-		FindProjectRoot:           r.FindProjectRoot,
-		GetWorkingDir:             r.GetWorkingDir,
-		SelectTenant:              r.SelectTenant,
-		Confirm:                   r.Confirm,
-		PromptKubernetesContext:   r.PromptKubernetesContext,
-		PromptContainerRegistry:   r.PromptContainerRegistry,
-		PromptRemoteRepositoryURL: r.PromptRemoteRepositoryURL,
-		PromptCodeCommitSSHKeyID:  r.PromptCodeCommitSSHKeyID,
-		EnsureKubernetesNamespace: r.EnsureKubernetesNamespace,
-		LoadProjectConfig:         r.LoadProjectConfig,
-		SaveProjectConfig:         r.SaveProjectConfig,
-		WaitForRemoteRuntime:      r.WaitForRemoteRuntime,
-		RunRemoteCommand:          r.RunRemoteCommand,
-		DeployHelmChart:           r.DeployHelmChart,
-		Sleep:                     r.Sleep,
-		Context:                   r.Context,
-	}, params)
+	return RunBootstrapInitWithDependencies(BootstrapInitDependencies(r), params)
 }
 
 func (r bootstrapTestRunner) saveProjectContainerRegistry(projectRoot, envName, registry string) error {

--- a/erun-common/init_test.go
+++ b/erun-common/init_test.go
@@ -303,35 +303,12 @@ func TestBootstrapRunCreatesTenantDevopsModuleAndChart(t *testing.T) {
 	}
 
 	moduleRoot := filepath.Join(projectRoot, "tenant-a-devops")
-	for _, path := range []string{
-		filepath.Join(moduleRoot, "VERSION"),
-		filepath.Join(moduleRoot, "docker", "tenant-a-devops", "Dockerfile"),
-		filepath.Join(moduleRoot, "k8s", "tenant-a-devops", "Chart.yaml"),
-		filepath.Join(moduleRoot, "k8s", "tenant-a-devops", "values.local.yaml"),
-		filepath.Join(moduleRoot, "k8s", "tenant-a-devops", "templates", "service.yaml"),
-	} {
-		if _, err := os.Stat(path); err != nil {
-			t.Fatalf("expected %s to exist: %v", path, err)
-		}
-	}
+	requireTenantDevopsFiles(t, moduleRoot)
 
 	dockerfilePath := filepath.Join(moduleRoot, "docker", "tenant-a-devops", "Dockerfile")
 	dockerfile, err := os.ReadFile(dockerfilePath)
-	if err != nil {
-		t.Fatalf("read Dockerfile: %v", err)
-	}
-	if !strings.Contains(string(dockerfile), "FROM ${ERUN_BASE_TAG}") {
-		t.Fatalf("expected thin wrapper Dockerfile, got %q", string(dockerfile))
-	}
-	if !strings.Contains(string(dockerfile), "ARG ERUN_BASE_TAG=erunpaas/erun-devops:1.2.3") {
-		t.Fatalf("expected Dockerfile base tag to match init runtime version, got %q", string(dockerfile))
-	}
-	if !strings.Contains(string(dockerfile), "ENTRYPOINT [\"erun-devops-entrypoint\"]") {
-		t.Fatalf("expected wrapper Dockerfile to delegate to base entrypoint, got %q", string(dockerfile))
-	}
-	if strings.Contains(string(dockerfile), "exec /bin/bash -i") || strings.Contains(string(dockerfile), "entrypoint.sh") || strings.Contains(string(dockerfile), "terraform") {
-		t.Fatalf("expected no duplicated runtime setup in Dockerfile, got %q", string(dockerfile))
-	}
+	requireNoError(t, err, "read Dockerfile")
+	requireTenantDevopsDockerfile(t, string(dockerfile))
 
 	chartPath := filepath.Join(moduleRoot, "k8s", "tenant-a-devops", "Chart.yaml")
 	chart, err := os.ReadFile(chartPath)
@@ -356,6 +333,28 @@ func TestBootstrapRunCreatesTenantDevopsModuleAndChart(t *testing.T) {
 	if !strings.Contains(string(serviceTemplate), "type: DirectoryOrCreate") {
 		t.Fatalf("expected repo worktree hostPath to allow missing directories, got %q", string(serviceTemplate))
 	}
+}
+
+func requireTenantDevopsFiles(t *testing.T, moduleRoot string) {
+	t.Helper()
+	for _, path := range []string{
+		filepath.Join(moduleRoot, "VERSION"),
+		filepath.Join(moduleRoot, "docker", "tenant-a-devops", "Dockerfile"),
+		filepath.Join(moduleRoot, "k8s", "tenant-a-devops", "Chart.yaml"),
+		filepath.Join(moduleRoot, "k8s", "tenant-a-devops", "values.local.yaml"),
+		filepath.Join(moduleRoot, "k8s", "tenant-a-devops", "templates", "service.yaml"),
+	} {
+		_, err := os.Stat(path)
+		requireNoError(t, err, "expected "+path+" to exist")
+	}
+}
+
+func requireTenantDevopsDockerfile(t *testing.T, dockerfile string) {
+	t.Helper()
+	requireStringContains(t, dockerfile, "FROM ${ERUN_BASE_TAG}", "expected thin wrapper Dockerfile")
+	requireStringContains(t, dockerfile, "ARG ERUN_BASE_TAG=erunpaas/erun-devops:1.2.3", "expected Dockerfile base tag to match init runtime version")
+	requireStringContains(t, dockerfile, "ENTRYPOINT [\"erun-devops-entrypoint\"]", "expected wrapper Dockerfile to delegate to base entrypoint")
+	requireCondition(t, !strings.Contains(dockerfile, "exec /bin/bash -i") && !strings.Contains(dockerfile, "entrypoint.sh") && !strings.Contains(dockerfile, "terraform"), "expected no duplicated runtime setup in Dockerfile, got %q", dockerfile)
 }
 
 func TestEnsureDefaultDevopsChartMigratesLegacyGeneratedServiceTemplate(t *testing.T) {
@@ -986,19 +985,9 @@ func TestBootstrapRunDecliningDefaultTenantStillInitializes(t *testing.T) {
 	}
 
 	result, err := service.Run(BootstrapInitParams{Environment: "review"})
-	if err != nil {
-		t.Fatalf("Run failed: %v", err)
-	}
+	requireNoError(t, err, "Run failed")
 
-	if result.CreatedERunConfig {
-		t.Fatalf("did not expect erun config to be created, got %+v", result)
-	}
-	if !result.CreatedTenantConfig || !result.CreatedEnvConfig {
-		t.Fatalf("expected tenant and environment config to be created, got %+v", result)
-	}
-	if result.TenantConfig.Name != "tenant-a" || result.EnvConfig.Name != "review" {
-		t.Fatalf("unexpected init result: %+v", result)
-	}
+	requireDeclinedDefaultTenantResult(t, result)
 	if _, _, err := LoadERunConfig(); !errors.Is(err, ErrNotInitialized) {
 		t.Fatalf("expected default tenant config to remain unset, got %v", err)
 	}
@@ -1006,14 +995,14 @@ func TestBootstrapRunDecliningDefaultTenantStillInitializes(t *testing.T) {
 		tenantConfirmationLabel("tenant-a", projectRoot),
 		environmentConfirmationLabel("tenant-a", "review"),
 	}
-	if len(prompts) != len(wantPrompts) {
-		t.Fatalf("unexpected prompts: %+v", prompts)
-	}
-	for i := range wantPrompts {
-		if prompts[i] != wantPrompts[i] {
-			t.Fatalf("unexpected prompt %d: got %q want %q", i, prompts[i], wantPrompts[i])
-		}
-	}
+	requireDeepEqual(t, prompts, wantPrompts, "unexpected prompts")
+}
+
+func requireDeclinedDefaultTenantResult(t *testing.T, result BootstrapInitResult) {
+	t.Helper()
+	requireCondition(t, !result.CreatedERunConfig, "did not expect erun config to be created, got %+v", result)
+	requireCondition(t, result.CreatedTenantConfig && result.CreatedEnvConfig, "expected tenant and environment config to be created, got %+v", result)
+	requireCondition(t, result.TenantConfig.Name == "tenant-a" && result.EnvConfig.Name == "review", "unexpected init result: %+v", result)
 }
 
 func TestBootstrapRunDecliningDefaultTenantViaParamStillInitializes(t *testing.T) {
@@ -1131,12 +1120,9 @@ func TestBootstrapRunRemoteInitializesTenantInPodWorktree(t *testing.T) {
 	var waited ShellLaunchParams
 	scripts := make([]string, 0, 3)
 	service := bootstrapTestRunner{
-		Context: testContextWithLogger(&testTraceLogger{}),
-		Store:   ConfigStore{},
-		FindProjectRoot: func() (string, string, error) {
-			t.Fatal("did not expect local project detection for remote init")
-			return "", "", nil
-		},
+		Context:         testContextWithLogger(&testTraceLogger{}),
+		Store:           ConfigStore{},
+		FindProjectRoot: unexpectedProjectDetection(t),
 		Confirm: func(string) (bool, error) {
 			return true, nil
 		},
@@ -1146,55 +1132,18 @@ func TestBootstrapRunRemoteInitializesTenantInPodWorktree(t *testing.T) {
 		PromptContainerRegistry: func(string) (string, error) {
 			return "registry.example.com/remote", nil
 		},
-		PromptRemoteRepositoryURL: func(label string) (string, error) {
-			if label != remoteRepositoryLabel("frs", "dev") {
-				t.Fatalf("unexpected repository label: %q", label)
-			}
-			return "git@github.com:sophium/frs.git", nil
-		},
-		EnsureKubernetesNamespace: func(contextName, namespace string) error {
-			if contextName != "cluster-remote" || namespace != "frs-dev" {
-				t.Fatalf("unexpected namespace ensure: %s %s", contextName, namespace)
-			}
-			return nil
-		},
-		DeployHelmChart: func(params HelmDeployParams) error {
-			if params.WorktreeStorage != WorktreeStoragePVC {
-				t.Fatalf("expected pvc worktree storage, got %+v", params)
-			}
-			if params.WorktreeRepoName != "frs" {
-				t.Fatalf("unexpected worktree repo name: %+v", params)
-			}
-			if params.Version != "1.2.3" {
-				t.Fatalf("expected remote runtime version override, got %+v", params)
-			}
-			service, err := os.ReadFile(filepath.Join(params.ChartPath, "templates", "service.yaml"))
-			if err != nil {
-				t.Fatalf("ReadFile failed: %v", err)
-			}
-			if !strings.Contains(string(service), "image: erunpaas/frs-devops:{{ .Chart.AppVersion }}") {
-				t.Fatalf("expected remote runtime image override, got:\n%s", service)
-			}
-			return nil
-		},
+		PromptRemoteRepositoryURL: remoteRepositoryPrompt(t, "frs", "dev", "git@github.com:sophium/frs.git"),
+		EnsureKubernetesNamespace: remoteNamespaceEnsurer(t, "cluster-remote", "frs-dev"),
+		DeployHelmChart:           remoteHelmDeployChecker(t, "frs", "1.2.3", "image: erunpaas/frs-devops:{{ .Chart.AppVersion }}"),
 		WaitForRemoteRuntime: func(req ShellLaunchParams) error {
 			waited = req
 			return nil
 		},
-		RunRemoteCommand: func(req ShellLaunchParams, script string) (RemoteCommandResult, error) {
-			scripts = append(scripts, script)
-			switch len(scripts) {
-			case 1:
-				return RemoteCommandResult{
-					Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n__ERUN_REMOTE_CODECOMMIT_PUBLIC_KEY__\nssh-rsa AAAACODECOMMITRSA remote\n",
-				}, nil
-			case 2, 3:
-				return RemoteCommandResult{}, nil
-			default:
-				t.Fatalf("unexpected remote command script:\n%s", script)
-				return RemoteCommandResult{}, nil
-			}
-		},
+		RunRemoteCommand: remoteCommandSequence(t, &scripts, []remoteCommandReply{
+			{result: RemoteCommandResult{Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n__ERUN_REMOTE_CODECOMMIT_PUBLIC_KEY__\nssh-rsa AAAACODECOMMITRSA remote\n"}},
+			{},
+			{},
+		}),
 	}
 
 	result, err := service.Run(BootstrapInitParams{
@@ -1204,78 +1153,111 @@ func TestBootstrapRunRemoteInitializesTenantInPodWorktree(t *testing.T) {
 		RuntimeVersion: "1.2.3",
 		RuntimeImage:   "frs-devops",
 	})
-	if err != nil {
-		t.Fatalf("Run failed: %v", err)
-	}
+	requireNoError(t, err, "Run failed")
 
 	remotePath := RemoteWorktreePathForRepoName("frs")
-	if result.TenantConfig.ProjectRoot != remotePath {
-		t.Fatalf("unexpected tenant config: %+v", result.TenantConfig)
-	}
-	if result.TenantConfig.Remote {
-		t.Fatalf("did not expect tenant config to be marked remote: %+v", result.TenantConfig)
-	}
-	if result.EnvConfig.RepoPath != remotePath || !result.EnvConfig.Remote {
-		t.Fatalf("unexpected env config: %+v", result.EnvConfig)
-	}
-	if result.EnvConfig.RuntimeVersion != "1.2.3" {
-		t.Fatalf("expected remote runtime version to be persisted, got %+v", result.EnvConfig)
-	}
-	if result.EnvConfig.ContainerRegistry != "registry.example.com/remote" {
-		t.Fatalf("expected remote container registry to be persisted, got %+v", result.EnvConfig)
-	}
-	if result.EnvConfig.CloudProviderAlias != "team-cloud" {
-		t.Fatalf("expected cloud provider alias to be persisted, got %+v", result.EnvConfig)
-	}
-	if waited.Dir != remotePath || waited.KubernetesContext != "cluster-remote" {
-		t.Fatalf("unexpected wait request: %+v", waited)
-	}
-	if len(scripts) != 3 {
-		t.Fatalf("expected state/access/clone remote commands, got %d", len(scripts))
-	}
+	requireRemoteInitResult(t, result, remotePath)
+	requireCondition(t, waited.Dir == remotePath && waited.KubernetesContext == "cluster-remote", "unexpected wait request: %+v", waited)
+	requireEqual(t, len(scripts), 3, "remote command count")
 
 	savedEnv, _, err := LoadEnvConfig("frs", "dev")
-	if err != nil {
-		t.Fatalf("LoadEnvConfig failed: %v", err)
+	requireNoError(t, err, "LoadEnvConfig failed")
+	requireSavedRemoteEnv(t, savedEnv)
+}
+
+type remoteCommandReply struct {
+	result RemoteCommandResult
+	err    error
+}
+
+func unexpectedProjectDetection(t *testing.T) ProjectFinderFunc {
+	t.Helper()
+	return func() (string, string, error) {
+		t.Fatal("did not expect local project detection for remote init")
+		return "", "", nil
 	}
-	if !savedEnv.Remote || savedEnv.ContainerRegistry != "registry.example.com/remote" {
-		t.Fatalf("unexpected saved env config: %+v", savedEnv)
+}
+
+func remoteRepositoryPrompt(t *testing.T, tenant, envName, repoURL string) PromptValueFunc {
+	t.Helper()
+	return func(label string) (string, error) {
+		requireEqual(t, label, remoteRepositoryLabel(tenant, envName), "repository label")
+		return repoURL, nil
 	}
-	if savedEnv.CloudProviderAlias != "team-cloud" {
-		t.Fatalf("unexpected saved cloud provider alias: %+v", savedEnv)
+}
+
+func remoteNamespaceEnsurer(t *testing.T, wantContext, wantNamespace string) NamespaceEnsurerFunc {
+	t.Helper()
+	return func(contextName, namespace string) error {
+		requireCondition(t, contextName == wantContext && namespace == wantNamespace, "unexpected namespace ensure: %s %s", contextName, namespace)
+		return nil
 	}
+}
+
+func remoteHelmDeployChecker(t *testing.T, repoName, version, imageLine string) HelmChartDeployerFunc {
+	t.Helper()
+	return func(params HelmDeployParams) error {
+		requireEqual(t, params.WorktreeStorage, WorktreeStoragePVC, "worktree storage")
+		requireEqual(t, params.WorktreeRepoName, repoName, "worktree repo name")
+		requireEqual(t, params.Version, version, "remote runtime version")
+		service, err := os.ReadFile(filepath.Join(params.ChartPath, "templates", "service.yaml"))
+		requireNoError(t, err, "ReadFile failed")
+		requireStringContains(t, string(service), imageLine, "expected remote runtime image override")
+		return nil
+	}
+}
+
+func remoteCommandSequence(t *testing.T, scripts *[]string, replies []remoteCommandReply) RemoteCommandRunnerFunc {
+	t.Helper()
+	return func(req ShellLaunchParams, script string) (RemoteCommandResult, error) {
+		*scripts = append(*scripts, script)
+		index := len(*scripts) - 1
+		if index >= len(replies) {
+			t.Fatalf("unexpected remote command script:\n%s", script)
+		}
+		return replies[index].result, replies[index].err
+	}
+}
+
+func requireRemoteInitResult(t *testing.T, result BootstrapInitResult, remotePath string) {
+	t.Helper()
+	requireEqual(t, result.TenantConfig.ProjectRoot, remotePath, "tenant project root")
+	requireCondition(t, !result.TenantConfig.Remote, "did not expect tenant config to be marked remote: %+v", result.TenantConfig)
+	requireCondition(t, result.EnvConfig.RepoPath == remotePath && result.EnvConfig.Remote, "unexpected env config: %+v", result.EnvConfig)
+	requireEqual(t, result.EnvConfig.RuntimeVersion, "1.2.3", "remote runtime version")
+	requireEqual(t, result.EnvConfig.ContainerRegistry, "registry.example.com/remote", "remote container registry")
+	requireEqual(t, result.EnvConfig.CloudProviderAlias, "team-cloud", "cloud provider alias")
+}
+
+func requireSavedRemoteEnv(t *testing.T, savedEnv EnvConfig) {
+	t.Helper()
+	requireCondition(t, savedEnv.Remote && savedEnv.ContainerRegistry == "registry.example.com/remote", "unexpected saved env config: %+v", savedEnv)
+	requireEqual(t, savedEnv.CloudProviderAlias, "team-cloud", "saved cloud provider alias")
 }
 
 func TestBootstrapRunRemoteNoGitCreatesWorktreeWithoutRepositoryPrompts(t *testing.T) {
 	setupXDGConfigHome(t)
 
-	if err := SaveTenantConfig(TenantConfig{
+	requireNoError(t, SaveTenantConfig(TenantConfig{
 		Name:               "erun",
 		ProjectRoot:        RemoteWorktreePathForRepoName("erun"),
 		DefaultEnvironment: "local",
-	}); err != nil {
-		t.Fatalf("SaveTenantConfig failed: %v", err)
-	}
+	}), "SaveTenantConfig failed")
 	for _, envName := range []string{"local", "proxmox1"} {
-		if err := SaveEnvConfig("erun", EnvConfig{
+		requireNoError(t, SaveEnvConfig("erun", EnvConfig{
 			Name:              envName,
 			RepoPath:          RemoteWorktreePathForRepoName("erun"),
 			KubernetesContext: "cluster-remote",
 			Remote:            true,
-		}); err != nil {
-			t.Fatalf("SaveEnvConfig failed: %v", err)
-		}
+		}), "SaveEnvConfig failed")
 	}
 
 	scripts := make([]string, 0, 1)
 	var deployed HelmDeployParams
 	service := bootstrapTestRunner{
-		Context: testContextWithLogger(&testTraceLogger{}),
-		Store:   ConfigStore{},
-		FindProjectRoot: func() (string, string, error) {
-			t.Fatal("did not expect local project detection for remote init")
-			return "", "", nil
-		},
+		Context:         testContextWithLogger(&testTraceLogger{}),
+		Store:           ConfigStore{},
+		FindProjectRoot: unexpectedProjectDetection(t),
 		Confirm: func(string) (bool, error) {
 			return true, nil
 		},
@@ -1285,10 +1267,7 @@ func TestBootstrapRunRemoteNoGitCreatesWorktreeWithoutRepositoryPrompts(t *testi
 		PromptContainerRegistry: func(string) (string, error) {
 			return "registry.example.com/remote", nil
 		},
-		PromptRemoteRepositoryURL: func(string) (string, error) {
-			t.Fatal("did not expect Git remote URL prompt")
-			return "", nil
-		},
+		PromptRemoteRepositoryURL: unexpectedPrompt(t, "Git remote URL prompt"),
 		EnsureKubernetesNamespace: func(string, string) error {
 			return nil
 		},
@@ -1311,27 +1290,33 @@ func TestBootstrapRunRemoteNoGitCreatesWorktreeWithoutRepositoryPrompts(t *testi
 		Remote:      true,
 		NoGit:       true,
 	})
-	if err != nil {
-		t.Fatalf("Run failed: %v", err)
-	}
+	requireNoError(t, err, "Run failed")
 
 	remotePath := RemoteWorktreePathForRepoName("erun")
-	if result.EnvConfig.RepoPath != remotePath || !result.EnvConfig.Remote {
-		t.Fatalf("unexpected env config: %+v", result.EnvConfig)
+	requireRemoteNoGitResult(t, result, deployed, scripts, remotePath)
+}
+
+func unexpectedPrompt(t *testing.T, name string) PromptValueFunc {
+	t.Helper()
+	return func(string) (string, error) {
+		t.Fatal("did not expect " + name)
+		return "", nil
 	}
-	if deployed.MCPPort != 17200 || deployed.SSHPort != 17222 {
-		t.Fatalf("expected remote init deploy to use allocated ports, got mcp=%d ssh=%d", deployed.MCPPort, deployed.SSHPort)
-	}
-	if len(scripts) != 1 {
-		t.Fatalf("expected only remote worktree command, got %d", len(scripts))
-	}
-	if !strings.Contains(scripts[0], "mkdir -p "+shellQuote(remotePath)) {
-		t.Fatalf("expected worktree directory creation, got:\n%s", scripts[0])
-	}
+}
+
+func requireRemoteNoGitResult(t *testing.T, result BootstrapInitResult, deployed HelmDeployParams, scripts []string, remotePath string) {
+	t.Helper()
+	requireCondition(t, result.EnvConfig.RepoPath == remotePath && result.EnvConfig.Remote, "unexpected env config: %+v", result.EnvConfig)
+	requireCondition(t, deployed.MCPPort == 17200 && deployed.SSHPort == 17222, "expected remote init deploy to use allocated ports, got mcp=%d ssh=%d", deployed.MCPPort, deployed.SSHPort)
+	requireEqual(t, len(scripts), 1, "remote command count")
+	requireStringContains(t, scripts[0], "mkdir -p "+shellQuote(remotePath), "expected worktree directory creation")
+	requireRemoteNoGitScript(t, scripts[0])
+}
+
+func requireRemoteNoGitScript(t *testing.T, script string) {
+	t.Helper()
 	for _, unexpected := range []string{"ssh-keygen", "git clone", "git -C"} {
-		if strings.Contains(scripts[0], unexpected) {
-			t.Fatalf("did not expect %q in no-git script:\n%s", unexpected, scripts[0])
-		}
+		requireCondition(t, !strings.Contains(script, unexpected), "did not expect %q in no-git script:\n%s", unexpected, script)
 	}
 }
 
@@ -1422,9 +1407,7 @@ func TestBootstrapRunRemoteConfiguresCodeCommitSSHRepository(t *testing.T) {
 			return "git-codecommit.eu-west-1.amazonaws.com/v1/repos/petios", nil
 		},
 		PromptCodeCommitSSHKeyID: func(label string) (string, error) {
-			if label != codeCommitSSHKeyIDLabel("petios", "dev") {
-				t.Fatalf("unexpected CodeCommit SSH key ID label: %q", label)
-			}
+			requireEqual(t, label, codeCommitSSHKeyIDLabel("petios", "dev"), "CodeCommit SSH key ID label")
 			promptedKeyID = true
 			return "APKATESTCODECOMMITKEY", nil
 		},
@@ -1437,59 +1420,45 @@ func TestBootstrapRunRemoteConfiguresCodeCommitSSHRepository(t *testing.T) {
 		WaitForRemoteRuntime: func(ShellLaunchParams) error {
 			return nil
 		},
-		RunRemoteCommand: func(req ShellLaunchParams, script string) (RemoteCommandResult, error) {
-			scripts = append(scripts, script)
-			switch len(scripts) {
-			case 1:
-				return RemoteCommandResult{
-					Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n",
-				}, nil
-			case 2, 3:
-				return RemoteCommandResult{}, nil
-			default:
-				t.Fatalf("unexpected remote command script:\n%s", script)
-				return RemoteCommandResult{}, nil
-			}
-		},
+		RunRemoteCommand: remoteCommandSequence(t, &scripts, []remoteCommandReply{
+			{result: RemoteCommandResult{Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n"}},
+			{},
+			{},
+		}),
 	}
 
-	if _, err := service.Run(BootstrapInitParams{
+	_, err := service.Run(BootstrapInitParams{
 		Tenant:      "petios",
 		Environment: "dev",
 		Remote:      true,
-	}); err != nil {
-		t.Fatalf("Run failed: %v", err)
-	}
+	})
+	requireNoError(t, err, "Run failed")
 
-	if !promptedKeyID {
-		t.Fatal("expected CodeCommit SSH key ID prompt")
+	requireCondition(t, promptedKeyID, "expected CodeCommit SSH key ID prompt")
+	requireCodeCommitRemoteScripts(t, scripts)
+}
+
+func requireCodeCommitRemoteScripts(t *testing.T, scripts []string) {
+	t.Helper()
+	requireEqual(t, len(scripts), 3, "remote script count")
+	for _, want := range []string{`ssh-keygen -t ed25519`, `ssh-keygen -t rsa -b 4096`, `id_rsa_codecommit`, `__ERUN_REMOTE_CODECOMMIT_PUBLIC_KEY__`} {
+		requireStringContains(t, scripts[0], want, "expected repository state script content")
 	}
-	if len(scripts) != 3 {
-		t.Fatalf("expected state/access/clone scripts, got %d", len(scripts))
+	for _, script := range scripts[1:] {
+		requireCodeCommitScript(t, script)
 	}
+}
+
+func requireCodeCommitScript(t *testing.T, script string) {
+	t.Helper()
 	for _, want := range []string{
-		`ssh-keygen -t ed25519`,
-		`ssh-keygen -t rsa -b 4096`,
-		`id_rsa_codecommit`,
-		`__ERUN_REMOTE_CODECOMMIT_PUBLIC_KEY__`,
+		"Host git-codecommit.eu-west-1.amazonaws.com",
+		"User APKATESTCODECOMMITKEY",
+		"IdentityFile ~/.ssh/id_rsa_codecommit",
+		`ssh_command='ssh -F "$HOME/.ssh/config"'`,
+		"ssh://git-codecommit.eu-west-1.amazonaws.com/v1/repos/petios",
 	} {
-		if !strings.Contains(scripts[0], want) {
-			t.Fatalf("expected repository state script to contain %q, got:\n%s", want, scripts[0])
-		}
-	}
-	for _, index := range []int{1, 2} {
-		script := scripts[index]
-		for _, want := range []string{
-			"Host git-codecommit.eu-west-1.amazonaws.com",
-			"User APKATESTCODECOMMITKEY",
-			"IdentityFile ~/.ssh/id_rsa_codecommit",
-			`ssh_command='ssh -F "$HOME/.ssh/config"'`,
-			"ssh://git-codecommit.eu-west-1.amazonaws.com/v1/repos/petios",
-		} {
-			if !strings.Contains(script, want) {
-				t.Fatalf("expected CodeCommit script to contain %q, got:\n%s", want, script)
-			}
-		}
+		requireStringContains(t, script, want, "expected CodeCommit script content")
 	}
 }
 
@@ -1523,29 +1492,16 @@ func TestBootstrapRunRemoteWaitsForSSHKeyImportAndRetries(t *testing.T) {
 		WaitForRemoteRuntime: func(ShellLaunchParams) error {
 			return nil
 		},
-		RunRemoteCommand: func(req ShellLaunchParams, script string) (RemoteCommandResult, error) {
-			scripts = append(scripts, script)
-			switch len(scripts) {
-			case 1:
-				return RemoteCommandResult{
-					Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n",
-				}, nil
-			case 2, 3:
-				return RemoteCommandResult{
-					Stderr: "Permission denied (publickey).",
-				}, fmt.Errorf("exit status 128")
-			case 4, 5:
-				return RemoteCommandResult{}, nil
-			default:
-				t.Fatalf("unexpected remote command script:\n%s", script)
-				return RemoteCommandResult{}, nil
-			}
-		},
+		RunRemoteCommand: remoteCommandSequence(t, &scripts, []remoteCommandReply{
+			{result: RemoteCommandResult{Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n"}},
+			{result: RemoteCommandResult{Stderr: "Permission denied (publickey)."}, err: fmt.Errorf("exit status 128")},
+			{result: RemoteCommandResult{Stderr: "Permission denied (publickey)."}, err: fmt.Errorf("exit status 128")},
+			{},
+			{},
+		}),
 		Sleep: func(duration time.Duration) {
 			sleepCalls++
-			if duration != remoteRepositoryAccessRetryInterval {
-				t.Fatalf("unexpected sleep duration: %s", duration)
-			}
+			requireEqual(t, duration, remoteRepositoryAccessRetryInterval, "sleep duration")
 		},
 	}
 
@@ -1554,25 +1510,18 @@ func TestBootstrapRunRemoteWaitsForSSHKeyImportAndRetries(t *testing.T) {
 		Environment: "dev",
 		Remote:      true,
 	})
-	if err != nil {
-		t.Fatalf("Run failed: %v", err)
-	}
+	requireNoError(t, err, "Run failed")
 
-	if sleepCalls != 2 {
-		t.Fatalf("expected 2 sleep calls, got %d", sleepCalls)
-	}
-	if len(scripts) != 5 {
-		t.Fatalf("expected state/access/access/access/clone remote commands, got %d", len(scripts))
-	}
-	if !logger.containsTrace("Waiting for the SSH key to be deployed to the git host. Rechecking every 2 seconds. Press Ctrl+C to cancel.") {
-		t.Fatalf("expected waiting message, got %+v", logger.traces)
-	}
-	if !logger.containsTrace("SSH key not active yet; retrying in 2 seconds...") {
-		t.Fatalf("expected retry message, got %+v", logger.traces)
-	}
-	if !logger.containsTrace("Remote repository access confirmed.") {
-		t.Fatalf("expected success message, got %+v", logger.traces)
-	}
+	requireRemoteRetryResult(t, logger, sleepCalls, scripts)
+}
+
+func requireRemoteRetryResult(t *testing.T, logger *testTraceLogger, sleepCalls int, scripts []string) {
+	t.Helper()
+	requireEqual(t, sleepCalls, 2, "sleep call count")
+	requireEqual(t, len(scripts), 5, "remote command count")
+	requireCondition(t, logger.containsTrace("Waiting for the SSH key to be deployed to the git host. Rechecking every 2 seconds. Press Ctrl+C to cancel."), "expected waiting message, got %+v", logger.traces)
+	requireCondition(t, logger.containsTrace("SSH key not active yet; retrying in 2 seconds..."), "expected retry message, got %+v", logger.traces)
+	requireCondition(t, logger.containsTrace("Remote repository access confirmed."), "expected success message, got %+v", logger.traces)
 }
 
 func TestBootstrapRunRemoteOffersExistingSSHHostConfigBeforeKeyImport(t *testing.T) {
@@ -1624,14 +1573,10 @@ func TestBootstrapRunRemoteOffersExistingSSHHostConfigBeforeKeyImport(t *testing
 					}, "\n") + "\n",
 				}, nil
 			case 2:
-				if !strings.Contains(script, `ssh -F "$HOME/.ssh/config"`) || strings.Contains(script, "id_ed25519") {
-					t.Fatalf("expected existing host config access check, got:\n%s", script)
-				}
+				requireExistingHostConfigScript(t, script, "access check")
 				return RemoteCommandResult{}, nil
 			case 3:
-				if !strings.Contains(script, `ssh -F "$HOME/.ssh/config"`) || strings.Contains(script, "id_ed25519") {
-					t.Fatalf("expected clone to use existing host config, got:\n%s", script)
-				}
+				requireExistingHostConfigScript(t, script, "clone")
 				return RemoteCommandResult{}, nil
 			default:
 				t.Fatalf("unexpected remote command script:\n%s", script)
@@ -1640,26 +1585,27 @@ func TestBootstrapRunRemoteOffersExistingSSHHostConfigBeforeKeyImport(t *testing
 		},
 	}
 
-	if _, err := service.Run(BootstrapInitParams{
+	_, err := service.Run(BootstrapInitParams{
 		Tenant:      "frs",
 		Environment: "dev",
 		Remote:      true,
-	}); err != nil {
-		t.Fatalf("Run failed: %v", err)
-	}
+	})
+	requireNoError(t, err, "Run failed")
 
-	if !promptedHostConfig {
-		t.Fatal("expected existing SSH host config confirmation")
-	}
-	if len(scripts) != 3 {
-		t.Fatalf("expected state/existing-host-config/clone remote commands, got %d", len(scripts))
-	}
-	if logger.containsTrace("Import this SSH public key into your git host before continuing:") {
-		t.Fatalf("did not expect SSH public key import instructions, got %+v", logger.traces)
-	}
-	if logger.containsTrace("Waiting for the SSH key to be deployed to the git host.") {
-		t.Fatalf("did not expect SSH key import wait, got %+v", logger.traces)
-	}
+	requireExistingHostConfigResult(t, logger, promptedHostConfig, scripts)
+}
+
+func requireExistingHostConfigScript(t *testing.T, script, label string) {
+	t.Helper()
+	requireCondition(t, strings.Contains(script, `ssh -F "$HOME/.ssh/config"`) && !strings.Contains(script, "id_ed25519"), "expected existing host config %s, got:\n%s", label, script)
+}
+
+func requireExistingHostConfigResult(t *testing.T, logger *testTraceLogger, promptedHostConfig bool, scripts []string) {
+	t.Helper()
+	requireCondition(t, promptedHostConfig, "expected existing SSH host config confirmation")
+	requireEqual(t, len(scripts), 3, "remote command count")
+	requireCondition(t, !logger.containsTrace("Import this SSH public key into your git host before continuing:"), "did not expect SSH public key import instructions, got %+v", logger.traces)
+	requireCondition(t, !logger.containsTrace("Waiting for the SSH key to be deployed to the git host."), "did not expect SSH key import wait, got %+v", logger.traces)
 }
 
 func TestBootstrapRunRemoteRequestsRepositoryURLWhenCheckoutMissing(t *testing.T) {

--- a/erun-common/list.go
+++ b/erun-common/list.go
@@ -95,37 +95,11 @@ func ResolveListResult(store ListStore, findProjectRoot ProjectFinderFunc, param
 
 	effectiveResult, effectiveErr := ResolveOpen(store, params)
 	configDir, configDirErr := ERunConfigDir()
-	result := ListResult{
-		ConfigDirectory: strings.TrimSpace(configDir),
-		Defaults: ListDefaultsResult{
-			Tenant:      defaultTenant,
-			Environment: defaultEnvironment,
-		},
-		CurrentDirectory: ListCurrentDirectoryResult{
-			Path:             currentRepoPath,
-			Repo:             currentRepoName,
-			ConfiguredTenant: configuredTenantForRepo(currentRepoName, tenants),
-		},
-		Tenants: make([]ListTenantResult, 0, len(tenants)),
-	}
 	if configDirErr != nil {
 		return ListResult{}, configDirErr
 	}
-
-	if effectiveErr != nil {
-		result.CurrentDirectory.EffectiveError = effectiveErr.Error()
-	} else {
-		result.CurrentDirectory.Effective = &ListEffectiveTargetResult{
-			Tenant:             effectiveResult.Tenant,
-			Environment:        effectiveResult.Environment,
-			KubernetesContext:  strings.TrimSpace(effectiveResult.EnvConfig.KubernetesContext),
-			CloudProviderAlias: strings.TrimSpace(effectiveResult.EnvConfig.CloudProviderAlias),
-			RepoPath:           effectiveResult.RepoPath,
-			Snapshot:           deployTargetSnapshotEnabled(effectiveResult, nil),
-			LocalPorts:         LocalPortsForResult(effectiveResult),
-			SSH:                listSSHResult(effectiveResult),
-		}
-	}
+	result := newListResult(configDir, defaultTenant, defaultEnvironment, currentRepoName, currentRepoPath, tenants)
+	result.CurrentDirectory = listCurrentDirectoryResult(result.CurrentDirectory, effectiveResult, effectiveErr)
 
 	portAllocations, err := ResolveAllEnvironmentLocalPorts(store)
 	if err != nil {
@@ -138,54 +112,106 @@ func ResolveListResult(store ListStore, findProjectRoot ProjectFinderFunc, param
 	result.CloudProviders = cloudProviders
 
 	for _, tenant := range tenants {
-		envs, err := store.ListEnvConfigs(tenant.Name)
+		tenantResult, err := listTenantResult(store, tenant, defaultTenant, effectiveResult, effectiveErr, portAllocations)
 		if err != nil {
 			return ListResult{}, err
-		}
-
-		tenantResult := ListTenantResult{
-			Name:               tenant.Name,
-			DefaultEnvironment: tenant.DefaultEnvironment,
-			IsDefault:          tenant.Name == defaultTenant,
-			IsEffective:        effectiveErr == nil && tenant.Name == effectiveResult.Tenant,
-			Environments:       make([]ListEnvironmentResult, 0, len(envs)),
-		}
-		for _, env := range envs {
-			localPorts := portAllocations[environmentPortKey(tenant.Name, env.Name)]
-			if localPorts.RangeStart == 0 {
-				localPorts = DefaultEnvironmentLocalPorts()
-				if env.SSHD.LocalPort > 0 {
-					localPorts.SSH = env.SSHD.LocalPort
-				}
-			}
-			tenantResult.Environments = append(tenantResult.Environments, ListEnvironmentResult{
-				Name:               env.Name,
-				KubernetesContext:  strings.TrimSpace(env.KubernetesContext),
-				CloudProviderAlias: strings.TrimSpace(env.CloudProviderAlias),
-				RepoPath:           strings.TrimSpace(env.RepoPath),
-				RuntimeVersion:     strings.TrimSpace(env.RuntimeVersion),
-				Snapshot:           env.SnapshotEnabled(),
-				IsActive:           listEnvironmentIsActive(store, env),
-				LocalPorts:         localPorts,
-				IsDefault:          env.Name == tenant.DefaultEnvironment,
-				IsEffective:        effectiveErr == nil && tenant.Name == effectiveResult.Tenant && env.Name == effectiveResult.Environment,
-				SSH: listSSHResult(OpenResult{
-					Tenant:      tenant.Name,
-					Environment: env.Name,
-					TenantConfig: TenantConfig{
-						Name:        tenant.Name,
-						ProjectRoot: tenant.ProjectRoot,
-					},
-					EnvConfig:  env,
-					LocalPorts: localPorts,
-					RepoPath:   env.RepoPath,
-				}),
-			})
 		}
 		result.Tenants = append(result.Tenants, tenantResult)
 	}
 
 	return result, nil
+}
+
+func newListResult(configDir, defaultTenant, defaultEnvironment, currentRepoName, currentRepoPath string, tenants []TenantConfig) ListResult {
+	return ListResult{
+		ConfigDirectory: strings.TrimSpace(configDir),
+		Defaults:        ListDefaultsResult{Tenant: defaultTenant, Environment: defaultEnvironment},
+		CurrentDirectory: ListCurrentDirectoryResult{
+			Path:             currentRepoPath,
+			Repo:             currentRepoName,
+			ConfiguredTenant: configuredTenantForRepo(currentRepoName, tenants),
+		},
+		Tenants: make([]ListTenantResult, 0, len(tenants)),
+	}
+}
+
+func listCurrentDirectoryResult(current ListCurrentDirectoryResult, effective OpenResult, effectiveErr error) ListCurrentDirectoryResult {
+	if effectiveErr != nil {
+		current.EffectiveError = effectiveErr.Error()
+		return current
+	}
+	current.Effective = &ListEffectiveTargetResult{
+		Tenant:             effective.Tenant,
+		Environment:        effective.Environment,
+		KubernetesContext:  strings.TrimSpace(effective.EnvConfig.KubernetesContext),
+		CloudProviderAlias: strings.TrimSpace(effective.EnvConfig.CloudProviderAlias),
+		RepoPath:           effective.RepoPath,
+		Snapshot:           deployTargetSnapshotEnabled(effective, nil),
+		LocalPorts:         LocalPortsForResult(effective),
+		SSH:                listSSHResult(effective),
+	}
+	return current
+}
+
+func listTenantResult(store ListStore, tenant TenantConfig, defaultTenant string, effective OpenResult, effectiveErr error, portAllocations map[string]EnvironmentLocalPorts) (ListTenantResult, error) {
+	envs, err := store.ListEnvConfigs(tenant.Name)
+	if err != nil {
+		return ListTenantResult{}, err
+	}
+	result := ListTenantResult{
+		Name:               tenant.Name,
+		DefaultEnvironment: tenant.DefaultEnvironment,
+		IsDefault:          tenant.Name == defaultTenant,
+		IsEffective:        effectiveErr == nil && tenant.Name == effective.Tenant,
+		Environments:       make([]ListEnvironmentResult, 0, len(envs)),
+	}
+	for _, env := range envs {
+		result.Environments = append(result.Environments, listEnvironmentResult(store, tenant, env, effective, effectiveErr, portAllocations))
+	}
+	return result, nil
+}
+
+func listEnvironmentResult(store ListStore, tenant TenantConfig, env EnvConfig, effective OpenResult, effectiveErr error, portAllocations map[string]EnvironmentLocalPorts) ListEnvironmentResult {
+	localPorts := listEnvironmentLocalPorts(tenant.Name, env, portAllocations)
+	return ListEnvironmentResult{
+		Name:               env.Name,
+		KubernetesContext:  strings.TrimSpace(env.KubernetesContext),
+		CloudProviderAlias: strings.TrimSpace(env.CloudProviderAlias),
+		RepoPath:           strings.TrimSpace(env.RepoPath),
+		RuntimeVersion:     strings.TrimSpace(env.RuntimeVersion),
+		Snapshot:           env.SnapshotEnabled(),
+		IsActive:           listEnvironmentIsActive(store, env),
+		LocalPorts:         localPorts,
+		IsDefault:          env.Name == tenant.DefaultEnvironment,
+		IsEffective:        effectiveErr == nil && tenant.Name == effective.Tenant && env.Name == effective.Environment,
+		SSH:                listSSHResult(listEnvironmentOpenResult(tenant, env, localPorts)),
+	}
+}
+
+func listEnvironmentLocalPorts(tenant string, env EnvConfig, portAllocations map[string]EnvironmentLocalPorts) EnvironmentLocalPorts {
+	localPorts := portAllocations[environmentPortKey(tenant, env.Name)]
+	if localPorts.RangeStart != 0 {
+		return localPorts
+	}
+	localPorts = DefaultEnvironmentLocalPorts()
+	if env.SSHD.LocalPort > 0 {
+		localPorts.SSH = env.SSHD.LocalPort
+	}
+	return localPorts
+}
+
+func listEnvironmentOpenResult(tenant TenantConfig, env EnvConfig, localPorts EnvironmentLocalPorts) OpenResult {
+	return OpenResult{
+		Tenant:      tenant.Name,
+		Environment: env.Name,
+		TenantConfig: TenantConfig{
+			Name:        tenant.Name,
+			ProjectRoot: tenant.ProjectRoot,
+		},
+		EnvConfig:  env,
+		LocalPorts: localPorts,
+		RepoPath:   env.RepoPath,
+	}
 }
 
 func listEnvironmentIsActive(store CloudReadStore, env EnvConfig) bool {

--- a/erun-common/list_test.go
+++ b/erun-common/list_test.go
@@ -20,34 +20,15 @@ func (s listStore) ListEnvConfigs(tenant string) ([]EnvConfig, error) {
 
 func TestResolveListResultUsesCurrentDirectoryTenantBeforeDefault(t *testing.T) {
 	configDir, err := ERunConfigDir()
-	if err != nil {
-		t.Fatalf("ERunConfigDir failed: %v", err)
-	}
+	requireNoError(t, err, "ERunConfigDir failed")
 
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(originalDir); err != nil {
-			t.Fatalf("restore working directory: %v", err)
-		}
-	})
+	restoreWorkingDirAfterTest(t)
 
 	tenantAPath := filepath.Join(t.TempDir(), "tenant-a")
 	tenantBPath := filepath.Join(t.TempDir(), "tenant-b")
 	subDir := filepath.Join(tenantBPath, "nested")
-	for _, dir := range []string{tenantAPath, tenantBPath, subDir} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("mkdir %q: %v", dir, err)
-		}
-	}
-	if err := os.MkdirAll(filepath.Join(tenantBPath, ".git"), 0o755); err != nil {
-		t.Fatalf("mkdir .git: %v", err)
-	}
-	if err := os.Chdir(subDir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	mkdirAllForTest(t, tenantAPath, tenantBPath, subDir, filepath.Join(tenantBPath, ".git"))
+	requireNoError(t, os.Chdir(subDir), "chdir")
 
 	store := listStore{
 		openStore: openStore{
@@ -75,54 +56,44 @@ func TestResolveListResultUsesCurrentDirectoryTenantBeforeDefault(t *testing.T) 
 		t.Fatalf("ResolveListResult failed: %v", err)
 	}
 
-	if result.Defaults.Tenant != "tenant-a" || result.Defaults.Environment != "local" {
-		t.Fatalf("unexpected defaults: %+v", result.Defaults)
-	}
-	if result.ConfigDirectory != configDir {
-		t.Fatalf("unexpected config directory: %+v", result)
-	}
-	if result.CurrentDirectory.Repo != "tenant-b" || result.CurrentDirectory.ConfiguredTenant != "tenant-b" {
-		t.Fatalf("unexpected current directory: %+v", result.CurrentDirectory)
-	}
-	if result.CurrentDirectory.Effective == nil {
-		t.Fatalf("expected effective target, got %+v", result.CurrentDirectory)
-	}
-	if result.CurrentDirectory.Effective.Tenant != "tenant-b" || result.CurrentDirectory.Effective.Environment != "dev" {
-		t.Fatalf("unexpected effective target: %+v", result.CurrentDirectory.Effective)
-	}
-	if result.CurrentDirectory.Effective.Snapshot {
-		t.Fatalf("expected effective snapshot to default off, got %+v", result.CurrentDirectory.Effective)
-	}
-	if len(result.Tenants) != 2 {
-		t.Fatalf("unexpected tenants: %+v", result.Tenants)
+	requireCurrentDirectoryListResult(t, result, configDir)
+}
+
+func restoreWorkingDirAfterTest(t *testing.T) {
+	t.Helper()
+	originalDir, err := os.Getwd()
+	requireNoError(t, err, "getwd")
+	t.Cleanup(func() {
+		requireNoError(t, os.Chdir(originalDir), "restore working directory")
+	})
+}
+
+func mkdirAllForTest(t *testing.T, dirs ...string) {
+	t.Helper()
+	for _, dir := range dirs {
+		requireNoError(t, os.MkdirAll(dir, 0o755), "mkdir "+dir)
 	}
 }
 
+func requireCurrentDirectoryListResult(t *testing.T, result ListResult, configDir string) {
+	t.Helper()
+	requireCondition(t, result.Defaults.Tenant == "tenant-a" && result.Defaults.Environment == "local", "unexpected defaults: %+v", result.Defaults)
+	requireEqual(t, result.ConfigDirectory, configDir, "config directory")
+	requireCondition(t, result.CurrentDirectory.Repo == "tenant-b" && result.CurrentDirectory.ConfiguredTenant == "tenant-b", "unexpected current directory: %+v", result.CurrentDirectory)
+	requireCondition(t, result.CurrentDirectory.Effective != nil, "expected effective target, got %+v", result.CurrentDirectory)
+	requireCondition(t, result.CurrentDirectory.Effective.Tenant == "tenant-b" && result.CurrentDirectory.Effective.Environment == "dev", "unexpected effective target: %+v", result.CurrentDirectory.Effective)
+	requireCondition(t, !result.CurrentDirectory.Effective.Snapshot, "expected effective snapshot to default off, got %+v", result.CurrentDirectory.Effective)
+	requireEqual(t, len(result.Tenants), 2, "tenant count")
+}
+
 func TestResolveListResultFallsBackToDefaultWhenRepoIsNotConfiguredTenant(t *testing.T) {
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(originalDir); err != nil {
-			t.Fatalf("restore working directory: %v", err)
-		}
-	})
+	restoreWorkingDirAfterTest(t)
 
 	repoRoot := filepath.Join(t.TempDir(), "frs")
 	subDir := filepath.Join(repoRoot, "nested")
 	defaultRepo := filepath.Join(t.TempDir(), "tenant-a")
-	for _, dir := range []string{defaultRepo, subDir} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("mkdir %q: %v", dir, err)
-		}
-	}
-	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
-		t.Fatalf("mkdir .git: %v", err)
-	}
-	if err := os.Chdir(subDir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	mkdirAllForTest(t, defaultRepo, subDir, filepath.Join(repoRoot, ".git"))
+	requireNoError(t, os.Chdir(subDir), "chdir")
 
 	store := listStore{
 		openStore: openStore{
@@ -143,42 +114,25 @@ func TestResolveListResultFallsBackToDefaultWhenRepoIsNotConfiguredTenant(t *tes
 		UseDefaultTenant:      true,
 		UseDefaultEnvironment: true,
 	})
-	if err != nil {
-		t.Fatalf("ResolveListResult failed: %v", err)
-	}
+	requireNoError(t, err, "ResolveListResult failed")
 
-	if result.CurrentDirectory.Repo != "frs" || result.CurrentDirectory.ConfiguredTenant != "" {
-		t.Fatalf("unexpected current directory: %+v", result.CurrentDirectory)
-	}
-	if result.CurrentDirectory.Effective == nil {
-		t.Fatalf("expected effective target, got %+v", result.CurrentDirectory)
-	}
-	if result.CurrentDirectory.Effective.Tenant != "tenant-a" || result.CurrentDirectory.Effective.Environment != "dev" {
-		t.Fatalf("unexpected effective target: %+v", result.CurrentDirectory.Effective)
-	}
-	if result.CurrentDirectory.Effective.Snapshot {
-		t.Fatalf("expected effective snapshot to default off, got %+v", result.CurrentDirectory.Effective)
-	}
+	requireFallbackListResult(t, result)
+}
+
+func requireFallbackListResult(t *testing.T, result ListResult) {
+	t.Helper()
+	requireCondition(t, result.CurrentDirectory.Repo == "frs" && result.CurrentDirectory.ConfiguredTenant == "", "unexpected current directory: %+v", result.CurrentDirectory)
+	requireCondition(t, result.CurrentDirectory.Effective != nil, "expected effective target, got %+v", result.CurrentDirectory)
+	requireCondition(t, result.CurrentDirectory.Effective.Tenant == "tenant-a" && result.CurrentDirectory.Effective.Environment == "dev", "unexpected effective target: %+v", result.CurrentDirectory.Effective)
+	requireCondition(t, !result.CurrentDirectory.Effective.Snapshot, "expected effective snapshot to default off, got %+v", result.CurrentDirectory.Effective)
 }
 
 func TestResolveListResultUsesEffectiveKubernetesContextForCurrentDirectoryTarget(t *testing.T) {
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(originalDir); err != nil {
-			t.Fatalf("restore working directory: %v", err)
-		}
-	})
+	restoreWorkingDirAfterTest(t)
 
 	repoRoot := filepath.Join(t.TempDir(), "tenant-a")
-	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
-		t.Fatalf("mkdir .git: %v", err)
-	}
-	if err := os.Chdir(repoRoot); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	mkdirAllForTest(t, filepath.Join(repoRoot, ".git"))
+	requireNoError(t, os.Chdir(repoRoot), "chdir")
 
 	store := listStore{
 		openStore: openStore{
@@ -205,21 +159,16 @@ func TestResolveListResultUsesEffectiveKubernetesContextForCurrentDirectoryTarge
 		UseDefaultTenant:      true,
 		UseDefaultEnvironment: true,
 	})
-	if err != nil {
-		t.Fatalf("ResolveListResult failed: %v", err)
-	}
-	if result.CurrentDirectory.Effective == nil {
-		t.Fatalf("expected effective target, got %+v", result.CurrentDirectory)
-	}
-	if result.CurrentDirectory.Effective.KubernetesContext != "docker-desktop" {
-		t.Fatalf("unexpected effective kubernetes context: %+v", result.CurrentDirectory.Effective)
-	}
-	if result.CurrentDirectory.Effective.Snapshot {
-		t.Fatalf("expected effective snapshot to default off, got %+v", result.CurrentDirectory.Effective)
-	}
-	if got := result.Tenants[0].Environments[0].KubernetesContext; got != "rancher-desktop" {
-		t.Fatalf("expected configured tenant environment context to remain unchanged, got %q", got)
-	}
+	requireNoError(t, err, "ResolveListResult failed")
+	requireEffectiveKubernetesListResult(t, result)
+}
+
+func requireEffectiveKubernetesListResult(t *testing.T, result ListResult) {
+	t.Helper()
+	requireCondition(t, result.CurrentDirectory.Effective != nil, "expected effective target, got %+v", result.CurrentDirectory)
+	requireEqual(t, result.CurrentDirectory.Effective.KubernetesContext, "docker-desktop", "effective kubernetes context")
+	requireCondition(t, !result.CurrentDirectory.Effective.Snapshot, "expected effective snapshot to default off, got %+v", result.CurrentDirectory.Effective)
+	requireEqual(t, result.Tenants[0].Environments[0].KubernetesContext, "rancher-desktop", "configured tenant environment context")
 }
 
 func TestResolveListResultIncludesSnapshotPreferenceForTenant(t *testing.T) {
@@ -306,25 +255,16 @@ func TestResolveListResultIncludesSSHDConfiguration(t *testing.T) {
 		Tenant:      "tenant-a",
 		Environment: "dev",
 	})
-	if err != nil {
-		t.Fatalf("ResolveListResult failed: %v", err)
-	}
-	if result.CurrentDirectory.Effective == nil || !result.CurrentDirectory.Effective.SSH.Enabled {
-		t.Fatalf("expected effective SSH details, got %+v", result.CurrentDirectory.Effective)
-	}
-	if result.CurrentDirectory.Effective.LocalPorts.RangeStart != 17000 || result.CurrentDirectory.Effective.LocalPorts.SSH != DefaultSSHLocalPort {
-		t.Fatalf("unexpected effective local ports: %+v", result.CurrentDirectory.Effective.LocalPorts)
-	}
-	if result.CurrentDirectory.Effective.SSH.HostAlias != "erun-tenant-a-dev" {
-		t.Fatalf("unexpected effective SSH host alias: %+v", result.CurrentDirectory.Effective.SSH)
-	}
-	if result.CurrentDirectory.Effective.SSH.User != DefaultSSHUser || result.CurrentDirectory.Effective.SSH.LocalPort != DefaultSSHLocalPort {
-		t.Fatalf("unexpected effective SSH info: %+v", result.CurrentDirectory.Effective.SSH)
-	}
-	if got := result.Tenants[0].Environments[0].LocalPorts.RangeEnd; got != 17099 {
-		t.Fatalf("unexpected environment local port range: %+v", result.Tenants[0].Environments[0].LocalPorts)
-	}
-	if got := result.Tenants[0].Environments[0].SSH.WorkspacePath; got != "/home/erun/git/tenant-a" {
-		t.Fatalf("unexpected SSH workspace path: %q", got)
-	}
+	requireNoError(t, err, "ResolveListResult failed")
+	requireSSHDListResult(t, result)
+}
+
+func requireSSHDListResult(t *testing.T, result ListResult) {
+	t.Helper()
+	requireCondition(t, result.CurrentDirectory.Effective != nil && result.CurrentDirectory.Effective.SSH.Enabled, "expected effective SSH details, got %+v", result.CurrentDirectory.Effective)
+	requireCondition(t, result.CurrentDirectory.Effective.LocalPorts.RangeStart == 17000 && result.CurrentDirectory.Effective.LocalPorts.SSH == DefaultSSHLocalPort, "unexpected effective local ports: %+v", result.CurrentDirectory.Effective.LocalPorts)
+	requireEqual(t, result.CurrentDirectory.Effective.SSH.HostAlias, "erun-tenant-a-dev", "effective SSH host alias")
+	requireCondition(t, result.CurrentDirectory.Effective.SSH.User == DefaultSSHUser && result.CurrentDirectory.Effective.SSH.LocalPort == DefaultSSHLocalPort, "unexpected effective SSH info: %+v", result.CurrentDirectory.Effective.SSH)
+	requireEqual(t, result.Tenants[0].Environments[0].LocalPorts.RangeEnd, 17099, "environment local port range")
+	requireEqual(t, result.Tenants[0].Environments[0].SSH.WorkspacePath, "/home/erun/git/tenant-a", "SSH workspace path")
 }

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -196,89 +196,29 @@ func resolveOpenWithFinder(store OpenStore, findProjectRoot ProjectFinderFunc, p
 		return OpenResult{}, fmt.Errorf("store is required")
 	}
 
-	tenant := params.Tenant
-	if tenant == "" && params.UseDefaultTenant {
-		if currentTenant, ok, err := loadCurrentDirectoryTenant(store, findProjectRoot); err != nil {
-			return OpenResult{}, err
-		} else if ok {
-			tenant = currentTenant
-		}
-	}
-	if tenant == "" && params.UseDefaultTenant {
-		toolConfig, _, err := store.LoadERunConfig()
-		if errors.Is(err, ErrNotInitialized) {
-			return OpenResult{}, ErrDefaultTenantNotConfigured
-		}
-		if err != nil {
-			return OpenResult{}, err
-		}
-		tenant = toolConfig.DefaultTenant
-		if tenant == "" {
-			return OpenResult{}, ErrDefaultTenantNotConfigured
-		}
-	}
-	if tenant == "" {
-		return OpenResult{}, fmt.Errorf("tenant is required")
-	}
-
-	tenantConfig, _, err := store.LoadTenantConfig(tenant)
-	if errors.Is(err, ErrNotInitialized) {
-		return OpenResult{}, fmt.Errorf("%w: %s", ErrTenantNotFound, tenant)
-	}
+	tenant, err := resolveOpenTenant(store, findProjectRoot, params)
 	if err != nil {
 		return OpenResult{}, err
 	}
-	if tenantConfig.Name == "" {
-		tenantConfig.Name = tenant
-	}
-
-	environment := params.Environment
-	if environment == "" && params.UseDefaultEnvironment {
-		environment = tenantConfig.DefaultEnvironment
-		if environment == "" {
-			return OpenResult{}, ErrDefaultEnvironmentNotConfigured
-		}
-	}
-	if environment == "" {
-		return OpenResult{}, fmt.Errorf("environment is required")
-	}
-
-	envConfig, _, err := store.LoadEnvConfig(tenant, environment)
-	if errors.Is(err, ErrNotInitialized) {
-		return OpenResult{}, fmt.Errorf("%w: %s", ErrEnvironmentNotFound, environment)
-	}
+	tenantConfig, err := loadOpenTenantConfig(store, tenant)
 	if err != nil {
 		return OpenResult{}, err
 	}
-	if envConfig.Name == "" {
-		envConfig.Name = environment
+	environment, err := resolveOpenEnvironment(params, tenantConfig)
+	if err != nil {
+		return OpenResult{}, err
 	}
-	if resolver, ok := store.(effectiveKubernetesContextResolver); ok {
-		envConfig.KubernetesContext = resolver.ResolveEffectiveKubernetesContext(environment, envConfig.KubernetesContext)
+	envConfig, err := loadOpenEnvConfig(store, tenant, environment)
+	if err != nil {
+		return OpenResult{}, err
 	}
-
-	repoPath := envConfig.RepoPath
-	if repoPath == "" {
-		repoPath = tenantConfig.ProjectRoot
+	repoPath, err := resolveOpenRepoPath(tenantConfig, envConfig)
+	if err != nil {
+		return OpenResult{}, err
 	}
-	if repoPath == "" {
-		return OpenResult{}, ErrRepoPathNotConfigured
+	if err := validateOpenTarget(tenant, environment, repoPath, envConfig); err != nil {
+		return OpenResult{}, err
 	}
-
-	repoPath = filepath.Clean(repoPath)
-	if !envConfig.Remote {
-		info, err := os.Stat(repoPath)
-		if err != nil {
-			return OpenResult{}, err
-		}
-		if !info.IsDir() {
-			return OpenResult{}, fmt.Errorf("%q is not a directory", repoPath)
-		}
-	}
-	if strings.TrimSpace(envConfig.KubernetesContext) == "" {
-		return OpenResult{}, fmt.Errorf("%w: %s/%s", ErrKubernetesContextNotConfigured, tenant, environment)
-	}
-
 	localPorts, err := environmentLocalPortsForTarget(store, tenant, envConfig)
 	if err != nil {
 		return OpenResult{}, err
@@ -293,6 +233,98 @@ func resolveOpenWithFinder(store OpenStore, findProjectRoot ProjectFinderFunc, p
 		RepoPath:     repoPath,
 		Title:        tenant + "-" + environment,
 	}, nil
+}
+
+func resolveOpenTenant(store OpenStore, findProjectRoot ProjectFinderFunc, params OpenParams) (string, error) {
+	tenant := params.Tenant
+	if tenant == "" && params.UseDefaultTenant {
+		currentTenant, ok, err := loadCurrentDirectoryTenant(store, findProjectRoot)
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			tenant = currentTenant
+		}
+	}
+	if tenant == "" && params.UseDefaultTenant {
+		return loadOpenDefaultTenant(store)
+	}
+	if tenant == "" {
+		return "", fmt.Errorf("tenant is required")
+	}
+	return tenant, nil
+}
+
+func loadOpenTenantConfig(store OpenStore, tenant string) (TenantConfig, error) {
+	tenantConfig, _, err := store.LoadTenantConfig(tenant)
+	if errors.Is(err, ErrNotInitialized) {
+		return TenantConfig{}, fmt.Errorf("%w: %s", ErrTenantNotFound, tenant)
+	}
+	if err != nil {
+		return TenantConfig{}, err
+	}
+	if tenantConfig.Name == "" {
+		tenantConfig.Name = tenant
+	}
+	return tenantConfig, nil
+}
+
+func resolveOpenEnvironment(params OpenParams, tenantConfig TenantConfig) (string, error) {
+	environment := params.Environment
+	if environment == "" && params.UseDefaultEnvironment {
+		environment = tenantConfig.DefaultEnvironment
+		if environment == "" {
+			return "", ErrDefaultEnvironmentNotConfigured
+		}
+	}
+	if environment == "" {
+		return "", fmt.Errorf("environment is required")
+	}
+	return environment, nil
+}
+
+func loadOpenEnvConfig(store OpenStore, tenant, environment string) (EnvConfig, error) {
+	envConfig, _, err := store.LoadEnvConfig(tenant, environment)
+	if errors.Is(err, ErrNotInitialized) {
+		return EnvConfig{}, fmt.Errorf("%w: %s", ErrEnvironmentNotFound, environment)
+	}
+	if err != nil {
+		return EnvConfig{}, err
+	}
+	if envConfig.Name == "" {
+		envConfig.Name = environment
+	}
+	if resolver, ok := store.(effectiveKubernetesContextResolver); ok {
+		envConfig.KubernetesContext = resolver.ResolveEffectiveKubernetesContext(environment, envConfig.KubernetesContext)
+	}
+	return envConfig, nil
+}
+
+func resolveOpenRepoPath(tenantConfig TenantConfig, envConfig EnvConfig) (string, error) {
+	repoPath := envConfig.RepoPath
+	if repoPath == "" {
+		repoPath = tenantConfig.ProjectRoot
+	}
+	if repoPath == "" {
+		return "", ErrRepoPathNotConfigured
+	}
+	return filepath.Clean(repoPath), nil
+}
+
+func validateOpenTarget(tenant, environment, repoPath string, envConfig EnvConfig) error {
+	if !envConfig.Remote {
+		info, err := os.Stat(repoPath)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%q is not a directory", repoPath)
+		}
+	}
+	if strings.TrimSpace(envConfig.KubernetesContext) == "" {
+		return fmt.Errorf("%w: %s/%s", ErrKubernetesContextNotConfigured, tenant, environment)
+	}
+	return nil
 }
 
 func loadCurrentDirectoryTenant(store OpenStore, findProjectRoot ProjectFinderFunc) (string, bool, error) {

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -28,8 +28,10 @@ var (
 	openUserHomeDir = os.UserHomeDir
 )
 
-const defaultShellLaunchWaitTimeout = "2m0s"
-const remoteShellReattachDeployExitCode = 75
+const (
+	defaultShellLaunchWaitTimeout     = "2m0s"
+	remoteShellReattachDeployExitCode = 75
+)
 
 type OpenStore interface {
 	LoadERunConfig() (ERunConfig, string, error)

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -146,29 +146,28 @@ func InitParamsForOpenTarget(store OpenStore, params OpenParams) (BootstrapInitP
 
 	switch {
 	case tenant != "" && environment != "":
-		return BootstrapInitParams{
-			Tenant:      tenant,
-			Environment: environment,
-		}, nil
+		return BootstrapInitParams{Tenant: tenant, Environment: environment}, nil
 	case tenant != "":
 		return BootstrapInitParams{Tenant: tenant}, nil
 	case environment != "":
-		resolvedTenant, err := loadOpenDefaultTenant(store)
-		if err != nil {
-			if errors.Is(err, ErrDefaultTenantNotConfigured) || errors.Is(err, ErrNotInitialized) {
-				return BootstrapInitParams{
-					Environment:   environment,
-					ResolveTenant: true,
-				}, nil
-			}
-			return BootstrapInitParams{}, err
-		}
-		return BootstrapInitParams{
-			Tenant:      resolvedTenant,
-			Environment: environment,
-		}, nil
+		return initParamsForOpenEnvironmentOnly(store, environment)
 	}
 
+	return initParamsForOpenDefaults(store)
+}
+
+func initParamsForOpenEnvironmentOnly(store OpenStore, environment string) (BootstrapInitParams, error) {
+	resolvedTenant, err := loadOpenDefaultTenant(store)
+	if err != nil {
+		if errors.Is(err, ErrDefaultTenantNotConfigured) || errors.Is(err, ErrNotInitialized) {
+			return BootstrapInitParams{Environment: environment, ResolveTenant: true}, nil
+		}
+		return BootstrapInitParams{}, err
+	}
+	return BootstrapInitParams{Tenant: resolvedTenant, Environment: environment}, nil
+}
+
+func initParamsForOpenDefaults(store OpenStore) (BootstrapInitParams, error) {
 	resolvedTenant, err := loadOpenDefaultTenant(store)
 	if err != nil {
 		if errors.Is(err, ErrDefaultTenantNotConfigured) || errors.Is(err, ErrNotInitialized) {
@@ -185,10 +184,7 @@ func InitParamsForOpenTarget(store OpenStore, params OpenParams) (BootstrapInitP
 		return BootstrapInitParams{}, err
 	}
 
-	return BootstrapInitParams{
-		Tenant:      resolvedTenant,
-		Environment: defaultEnvironment,
-	}, nil
+	return BootstrapInitParams{Tenant: resolvedTenant, Environment: defaultEnvironment}, nil
 }
 
 func ResolveOpen(store OpenStore, params OpenParams) (OpenResult, error) {
@@ -730,32 +726,7 @@ func loadKnownHostsLines(host string) ([]string, error) {
 }
 
 func loadPrivateKeyMaterial(entries []sshConfigEntry, redact bool) ([]string, error) {
-	keyPaths := make([]string, 0, 4)
-	seen := make(map[string]struct{}, 4)
-
-	addKeyPath := func(path string) {
-		path = strings.TrimSpace(path)
-		if path == "" {
-			return
-		}
-		if _, ok := seen[path]; ok {
-			return
-		}
-		seen[path] = struct{}{}
-		keyPaths = append(keyPaths, path)
-	}
-
-	for _, entry := range entries {
-		for _, identityFile := range entry.identityFiles {
-			addKeyPath(identityFile)
-		}
-	}
-
-	if len(keyPaths) == 0 {
-		for _, fallback := range []string{"id_rsa", "id_ed25519", "id_ecdsa"} {
-			addKeyPath(filepath.Join(resolveOpenUserHomeDir(), ".ssh", fallback))
-		}
-	}
+	keyPaths := privateKeyPaths(entries)
 
 	lines := make([]string, 0, len(keyPaths))
 	for _, keyPath := range keyPaths {
@@ -774,6 +745,35 @@ func loadPrivateKeyMaterial(entries []sshConfigEntry, redact bool) ([]string, er
 		lines = append(lines, string(data))
 	}
 	return lines, nil
+}
+
+func privateKeyPaths(entries []sshConfigEntry) []string {
+	keyPaths := make([]string, 0, 4)
+	seen := make(map[string]struct{}, 4)
+	for _, entry := range entries {
+		for _, identityFile := range entry.identityFiles {
+			keyPaths = appendUniquePrivateKeyPath(keyPaths, seen, identityFile)
+		}
+	}
+	if len(keyPaths) > 0 {
+		return keyPaths
+	}
+	for _, fallback := range []string{"id_rsa", "id_ed25519", "id_ecdsa"} {
+		keyPaths = appendUniquePrivateKeyPath(keyPaths, seen, filepath.Join(resolveOpenUserHomeDir(), ".ssh", fallback))
+	}
+	return keyPaths
+}
+
+func appendUniquePrivateKeyPath(keyPaths []string, seen map[string]struct{}, path string) []string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return keyPaths
+	}
+	if _, ok := seen[path]; ok {
+		return keyPaths
+	}
+	seen[path] = struct{}{}
+	return append(keyPaths, path)
 }
 
 type sshConfigEntry struct {

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -514,6 +514,30 @@ func kubectlTargetArgs(req ShellLaunchParams) []string {
 }
 
 func buildRemoteShellScript(req ShellLaunchParams, redactHostSecrets bool) (string, error) {
+	config, err := remoteShellConfigForRequest(req)
+	if err != nil {
+		return "", err
+	}
+	workdir := shellQuote(config.Workdir)
+	scriptLines := remoteShellBaseScriptLines(req, config, workdir, shellQuote(req.Title))
+	gitLines, err := remoteShellGitSeedLines(req, redactHostSecrets, workdir)
+	if err != nil {
+		return "", err
+	}
+	if len(gitLines) > 0 {
+		scriptLines = append(gitLines, scriptLines[1:]...)
+	}
+	return strings.Join(scriptLines, "\n"), nil
+}
+
+type remoteShellConfig struct {
+	Workdir    string
+	ToolYAML   string
+	TenantYAML string
+	EnvYAML    string
+}
+
+func remoteShellConfigForRequest(req ShellLaunchParams) (remoteShellConfig, error) {
 	remoteWorkdir := remoteWorktreePath(req)
 
 	tenantConfig, err := yaml.Marshal(TenantConfig{
@@ -522,13 +546,13 @@ func buildRemoteShellScript(req ShellLaunchParams, redactHostSecrets bool) (stri
 		DefaultEnvironment: req.Environment,
 	})
 	if err != nil {
-		return "", err
+		return remoteShellConfig{}, err
 	}
 	toolConfig, err := yaml.Marshal(ERunConfig{
 		DefaultTenant: req.Tenant,
 	})
 	if err != nil {
-		return "", err
+		return remoteShellConfig{}, err
 	}
 	envConfig, err := yaml.Marshal(EnvConfig{
 		Name:              req.Environment,
@@ -537,26 +561,29 @@ func buildRemoteShellScript(req ShellLaunchParams, redactHostSecrets bool) (stri
 		Remote:            req.RemoteRepo,
 	})
 	if err != nil {
-		return "", err
+		return remoteShellConfig{}, err
 	}
 
-	workdir := shellQuote(remoteWorkdir)
-	toolYAML := string(toolConfig)
-	tenantYAML := string(tenantConfig)
-	envYAML := string(envConfig)
-	title := shellQuote(req.Title)
+	return remoteShellConfig{
+		Workdir:    remoteWorkdir,
+		ToolYAML:   string(toolConfig),
+		TenantYAML: string(tenantConfig),
+		EnvYAML:    string(envConfig),
+	}, nil
+}
 
-	scriptLines := []string{
+func remoteShellBaseScriptLines(req ShellLaunchParams, config remoteShellConfig, workdir, title string) []string {
+	return []string{
 		"set -eu",
 		fmt.Sprintf("mkdir -p %s", workdir),
 		fmt.Sprintf("cd %s", workdir),
 		"config_home=\"${XDG_CONFIG_HOME:-$HOME/.config}\"",
 		"mkdir -p \"$config_home/erun\"",
-		fmt.Sprintf("cat > \"$config_home/erun/config.yaml\" <<'EOF'\n%s\nEOF", toolYAML),
+		fmt.Sprintf("cat > \"$config_home/erun/config.yaml\" <<'EOF'\n%s\nEOF", config.ToolYAML),
 		fmt.Sprintf("mkdir -p \"$config_home/erun/%s\"", req.Tenant),
-		fmt.Sprintf("cat > \"$config_home/erun/%s/config.yaml\" <<'EOF'\n%s\nEOF", req.Tenant, tenantYAML),
+		fmt.Sprintf("cat > \"$config_home/erun/%s/config.yaml\" <<'EOF'\n%s\nEOF", req.Tenant, config.TenantYAML),
 		fmt.Sprintf("mkdir -p \"$config_home/erun/%s/%s\"", req.Tenant, req.Environment),
-		fmt.Sprintf("cat > \"$config_home/erun/%s/%s/config.yaml\" <<'EOF'\n%s\nEOF", req.Tenant, req.Environment, envYAML),
+		fmt.Sprintf("cat > \"$config_home/erun/%s/%s/config.yaml\" <<'EOF'\n%s\nEOF", req.Tenant, req.Environment, config.EnvYAML),
 		fmt.Sprintf("cat > \"$HOME/.erun_bashrc\" <<'EOF'\nexport ERUN_SHELL_HOST=%s\nerun() {\n  if [ \"${1:-}\" = \"deploy\" ] && [ \"$#\" -eq 1 ] && [ -n \"${ERUN_SHELL_REQUEST_FILE:-}\" ]; then\n    : > \"$ERUN_SHELL_REQUEST_FILE\"\n    exit 0\n  fi\n  command erun \"$@\"\n}\nEOF", title),
 		fmt.Sprintf("printf '\\033]0;%s\\007'", title),
 		"request_file=\"$HOME/.erun-shell-request\"",
@@ -568,58 +595,55 @@ func buildRemoteShellScript(req ShellLaunchParams, redactHostSecrets bool) (stri
 		"rm -f \"$request_file\"",
 		"exit \"$shell_status\"",
 	}
+}
 
-	if !req.RemoteRepo {
-		if gitHost, gitUser, gitRepo, err := resolveGitRemote(req.Dir); err == nil {
-			hostConfigEntries, err := resolveSSHConfigEntries(gitHost)
-			if err != nil {
-				return "", err
-			}
-
-			knownHostsLines, err := loadKnownHostsLines(gitHost)
-			if err != nil {
-				return "", err
-			}
-
-			keyLines, err := loadPrivateKeyMaterial(hostConfigEntries, redactHostSecrets)
-			if err != nil {
-				return "", err
-			}
-
-			knownHosts := strings.Join(knownHostsLines, "\n")
-			keys := strings.Join(keyLines, "\n")
-			gitUser = shellQuote(gitUser)
-			gitRepo = shellQuote(gitRepo)
-			sshConfig := strings.Join([]string{
-				fmt.Sprintf("Host %s", gitHost),
-				fmt.Sprintf("  HostName %s", gitHost),
-				"  IdentityFile ~/.ssh/keys",
-				"  IdentitiesOnly yes",
-				"  UserKnownHostsFile ~/.ssh/known_hosts",
-			}, "\n")
-
-			scriptLines = append([]string{
-				"set -eu",
-				"mkdir -p \"$HOME/.ssh\"",
-				"chmod 700 \"$HOME/.ssh\"",
-				"rm -f \"$HOME/.ssh/known_hosts\" \"$HOME/.ssh/keys\" \"$HOME/.ssh/config\"",
-				"old_umask=\"$(umask)\"",
-				"umask 077",
-				fmt.Sprintf("cat > \"$HOME/.ssh/known_hosts\" <<'EOF'\n%s\nEOF", knownHosts),
-				fmt.Sprintf("cat > \"$HOME/.ssh/keys\" <<'EOF'\n%s\nEOF", keys),
-				fmt.Sprintf("cat > \"$HOME/.ssh/config\" <<'EOF'\n%s\nEOF", sshConfig),
-				"umask \"$old_umask\"",
-				"chmod 600 \"$HOME/.ssh/known_hosts\" \"$HOME/.ssh/keys\" \"$HOME/.ssh/config\"",
-				fmt.Sprintf("mkdir -p %s", workdir),
-				fmt.Sprintf("cd %s", workdir),
-				fmt.Sprintf("if command -v git >/dev/null 2>&1; then if [ ! -d .git ]; then git clone git@%s:%s/%s.git .; fi; git config --global --add safe.directory '*'; fi", gitHost, gitUser, gitRepo),
-			}, scriptLines[1:]...)
-		}
+func remoteShellGitSeedLines(req ShellLaunchParams, redactHostSecrets bool, workdir string) ([]string, error) {
+	if req.RemoteRepo {
+		return nil, nil
 	}
+	gitHost, gitUser, gitRepo, err := resolveGitRemote(req.Dir)
+	if err != nil {
+		return nil, nil
+	}
+	hostConfigEntries, err := resolveSSHConfigEntries(gitHost)
+	if err != nil {
+		return nil, err
+	}
+	knownHostsLines, err := loadKnownHostsLines(gitHost)
+	if err != nil {
+		return nil, err
+	}
+	keyLines, err := loadPrivateKeyMaterial(hostConfigEntries, redactHostSecrets)
+	if err != nil {
+		return nil, err
+	}
+	return remoteShellGitSeedScriptLines(workdir, gitHost, shellQuote(gitUser), shellQuote(gitRepo), strings.Join(knownHostsLines, "\n"), strings.Join(keyLines, "\n")), nil
+}
 
-	script := strings.Join(scriptLines, "\n")
-
-	return script, nil
+func remoteShellGitSeedScriptLines(workdir, gitHost, gitUser, gitRepo, knownHosts, keys string) []string {
+	sshConfig := strings.Join([]string{
+		fmt.Sprintf("Host %s", gitHost),
+		fmt.Sprintf("  HostName %s", gitHost),
+		"  IdentityFile ~/.ssh/keys",
+		"  IdentitiesOnly yes",
+		"  UserKnownHostsFile ~/.ssh/known_hosts",
+	}, "\n")
+	return []string{
+		"set -eu",
+		"mkdir -p \"$HOME/.ssh\"",
+		"chmod 700 \"$HOME/.ssh\"",
+		"rm -f \"$HOME/.ssh/known_hosts\" \"$HOME/.ssh/keys\" \"$HOME/.ssh/config\"",
+		"old_umask=\"$(umask)\"",
+		"umask 077",
+		fmt.Sprintf("cat > \"$HOME/.ssh/known_hosts\" <<'EOF'\n%s\nEOF", knownHosts),
+		fmt.Sprintf("cat > \"$HOME/.ssh/keys\" <<'EOF'\n%s\nEOF", keys),
+		fmt.Sprintf("cat > \"$HOME/.ssh/config\" <<'EOF'\n%s\nEOF", sshConfig),
+		"umask \"$old_umask\"",
+		"chmod 600 \"$HOME/.ssh/known_hosts\" \"$HOME/.ssh/keys\" \"$HOME/.ssh/config\"",
+		fmt.Sprintf("mkdir -p %s", workdir),
+		fmt.Sprintf("cd %s", workdir),
+		fmt.Sprintf("if command -v git >/dev/null 2>&1; then if [ ! -d .git ]; then git clone git@%s:%s/%s.git .; fi; git config --global --add safe.directory '*'; fi", gitHost, gitUser, gitRepo),
+	}
 }
 
 func remoteWorktreePath(req ShellLaunchParams) string {

--- a/erun-common/open_test.go
+++ b/erun-common/open_test.go
@@ -119,31 +119,13 @@ func TestOpenResolveIgnoresLegacyTenantRemoteFlagForLocalEnvironment(t *testing.
 }
 
 func TestOpenResolveUsesCurrentDirectoryTenantBeforeDefault(t *testing.T) {
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(originalDir); err != nil {
-			t.Fatalf("return to original dir: %v", err)
-		}
-	})
+	restoreWorkingDirAfterTest(t)
 
 	repoRoot := filepath.Join(t.TempDir(), "tenant-a")
 	subDir := filepath.Join(repoRoot, "nested")
 	defaultRepo := filepath.Join(t.TempDir(), "tenant-b")
-	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
-		t.Fatalf("mkdir .git: %v", err)
-	}
-	if err := os.MkdirAll(subDir, 0o755); err != nil {
-		t.Fatalf("mkdir nested dir: %v", err)
-	}
-	if err := os.MkdirAll(defaultRepo, 0o755); err != nil {
-		t.Fatalf("mkdir default repo: %v", err)
-	}
-	if err := os.Chdir(subDir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
+	mkdirAllForTest(t, filepath.Join(repoRoot, ".git"), subDir, defaultRepo)
+	requireNoError(t, os.Chdir(subDir), "chdir")
 
 	store := openStore{
 		toolConfig: ERunConfig{DefaultTenant: "tenant-b"},
@@ -161,15 +143,9 @@ func TestOpenResolveUsesCurrentDirectoryTenantBeforeDefault(t *testing.T) {
 		UseDefaultTenant:      true,
 		UseDefaultEnvironment: true,
 	})
-	if err != nil {
-		t.Fatalf("Resolve failed: %v", err)
-	}
-	if result.Tenant != "tenant-a" || result.Environment != "dev" {
-		t.Fatalf("expected current directory tenant to win, got %+v", result)
-	}
-	if result.LocalPorts.RangeStart != 17000 || result.LocalPorts.SSH != 17022 {
-		t.Fatalf("unexpected local ports: %+v", result.LocalPorts)
-	}
+	requireNoError(t, err, "Resolve failed")
+	requireCondition(t, result.Tenant == "tenant-a" && result.Environment == "dev", "expected current directory tenant to win, got %+v", result)
+	requireCondition(t, result.LocalPorts.RangeStart == 17000 && result.LocalPorts.SSH == 17022, "unexpected local ports: %+v", result.LocalPorts)
 }
 
 func TestOpenResolveAssignsEnvironmentLocalPortsFromSortedTenantEnvironmentOrder(t *testing.T) {
@@ -486,12 +462,18 @@ func TestRemoteShellScriptSeedsConfigsAndCloneCommand(t *testing.T) {
 		Title:             "tenant-a-local",
 		KubernetesContext: "in-cluster",
 	}, false)
-	if err != nil {
-		t.Fatalf("buildRemoteShellScript failed: %v", err)
-	}
+	requireNoError(t, err, "buildRemoteShellScript failed")
 
 	remoteWorkdir := "/home/erun/git/erun"
 
+	requireRemoteShellScriptPatterns(t, script, remoteWorkdir)
+	requireCondition(t, !strings.Contains(script, repoDir), "did not expect host repo path %q in remote bootstrap script, got:\n%s", repoDir, script)
+	requireCondition(t, !strings.Contains(script, "/etc/bash.bashrc"), "did not expect remote rcfile to source system bashrc twice, got:\n%s", script)
+	requireRemoteShellSeededConfigs(t, script, remoteWorkdir)
+}
+
+func requireRemoteShellScriptPatterns(t *testing.T, script, remoteWorkdir string) {
+	t.Helper()
 	for _, pattern := range []string{
 		"rm -f \"$HOME/.ssh/known_hosts\" \"$HOME/.ssh/keys\" \"$HOME/.ssh/config\"",
 		"old_umask=\"$(umask)\"",
@@ -522,43 +504,26 @@ func TestRemoteShellScriptSeedsConfigsAndCloneCommand(t *testing.T) {
 		fmt.Sprintf("if [ -e \"$request_file\" ]; then rm -f \"$request_file\"; exit %d; fi", remoteShellReattachDeployExitCode),
 		"exit \"$shell_status\"",
 	} {
-		if !strings.Contains(script, pattern) {
-			t.Fatalf("expected script to contain %q, got:\n%s", pattern, script)
-		}
+		requireStringContains(t, script, pattern, "expected script pattern")
 	}
-	if strings.Contains(script, repoDir) {
-		t.Fatalf("did not expect host repo path %q in remote bootstrap script, got:\n%s", repoDir, script)
-	}
-	if strings.Contains(script, "/etc/bash.bashrc") {
-		t.Fatalf("did not expect remote rcfile to source system bashrc twice, got:\n%s", script)
-	}
+}
 
+func requireRemoteShellSeededConfigs(t *testing.T, script, remoteWorkdir string) {
+	t.Helper()
 	toolConfigBody := extractHeredoc(t, script, `cat > "$config_home/erun/config.yaml" <<'EOF'`)
 	var toolConfig ERunConfig
-	if err := yaml.Unmarshal([]byte(toolConfigBody), &toolConfig); err != nil {
-		t.Fatalf("expected tool config heredoc to be valid yaml, got %v\n%s", err, toolConfigBody)
-	}
-	if toolConfig.DefaultTenant != "tenant-a" {
-		t.Fatalf("unexpected tool config: %+v", toolConfig)
-	}
+	requireNoError(t, yaml.Unmarshal([]byte(toolConfigBody), &toolConfig), "expected tool config heredoc to be valid yaml")
+	requireEqual(t, toolConfig.DefaultTenant, "tenant-a", "tool config default tenant")
 
 	tenantConfigBody := extractHeredoc(t, script, `cat > "$config_home/erun/tenant-a/config.yaml" <<'EOF'`)
 	var tenantConfig TenantConfig
-	if err := yaml.Unmarshal([]byte(tenantConfigBody), &tenantConfig); err != nil {
-		t.Fatalf("expected tenant config heredoc to be valid yaml, got %v\n%s", err, tenantConfigBody)
-	}
-	if tenantConfig.ProjectRoot != remoteWorkdir || tenantConfig.DefaultEnvironment != "local" {
-		t.Fatalf("unexpected tenant config: %+v", tenantConfig)
-	}
+	requireNoError(t, yaml.Unmarshal([]byte(tenantConfigBody), &tenantConfig), "expected tenant config heredoc to be valid yaml")
+	requireCondition(t, tenantConfig.ProjectRoot == remoteWorkdir && tenantConfig.DefaultEnvironment == "local", "unexpected tenant config: %+v", tenantConfig)
 
 	envConfigBody := extractHeredoc(t, script, `cat > "$config_home/erun/tenant-a/local/config.yaml" <<'EOF'`)
 	var envConfig EnvConfig
-	if err := yaml.Unmarshal([]byte(envConfigBody), &envConfig); err != nil {
-		t.Fatalf("expected env config heredoc to be valid yaml, got %v\n%s", err, envConfigBody)
-	}
-	if envConfig.RepoPath != remoteWorkdir || envConfig.KubernetesContext != "in-cluster" {
-		t.Fatalf("unexpected env config: %+v", envConfig)
-	}
+	requireNoError(t, yaml.Unmarshal([]byte(envConfigBody), &envConfig), "expected env config heredoc to be valid yaml")
+	requireCondition(t, envConfig.RepoPath == remoteWorkdir && envConfig.KubernetesContext == "in-cluster", "unexpected env config: %+v", envConfig)
 }
 
 func TestRemoteShellScriptUsesXDGConfigHomeWhenPresent(t *testing.T) {

--- a/erun-common/packaging_test.go
+++ b/erun-common/packaging_test.go
@@ -256,7 +256,9 @@ func releaseArchiveSHA256ForTest(t *testing.T, url string) string {
 	if err != nil {
 		t.Fatalf("download %s: %v", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("download %s: unexpected status %s", url, resp.Status)
 	}

--- a/erun-common/packaging_test.go
+++ b/erun-common/packaging_test.go
@@ -22,121 +22,90 @@ func TestPackageManagerDefinitionsTrackLatestStableTag(t *testing.T) {
 
 	formulaPath := filepath.Join(repoRoot, "Formula", "erun.rb")
 	formulaData, err := os.ReadFile(formulaPath)
-	if err != nil {
-		t.Fatalf("read formula: %v", err)
-	}
+	requireNoError(t, err, "read formula")
 	formula := string(formulaData)
-	if !strings.Contains(formula, `url "https://github.com/sophium/erun/archive/refs/tags/`+latestTag+`.tar.gz"`) {
-		t.Fatalf("formula does not target latest stable tag %s:\n%s", latestTag, formula)
-	}
-	if !strings.Contains(formula, `bin/"erun"`) || !strings.Contains(formula, `bin/"emcp"`) {
-		t.Fatalf("formula does not build both executables:\n%s", formula)
-	}
-	if !strings.Contains(formula, `depends_on "node" => :build`) {
-		t.Fatalf("formula missing node dependency for erun-app frontend build:\n%s", formula)
-	}
-	if !strings.Contains(formula, `depends_on "yarn" => :build`) {
-		t.Fatalf("formula missing yarn dependency for erun-app frontend build:\n%s", formula)
-	}
-	if !strings.Contains(formula, `system "yarn", "install", "--frozen-lockfile"`) {
-		t.Fatalf("formula does not install erun-app frontend dependencies:\n%s", formula)
-	}
-	if !strings.Contains(formula, `go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2`) {
-		t.Fatalf("formula does not resolve the Wails generator version from go.mod:\n%s", formula)
-	}
-	if !strings.Contains(formula, `system "go", "install", "github.com/wailsapp/wails/v2/cmd/wails@#{wails_version}"`) {
-		t.Fatalf("formula does not install the Wails generator:\n%s", formula)
-	}
-	if !strings.Contains(formula, `system wails_bin, "generate", "module"`) {
-		t.Fatalf("formula does not generate erun-app frontend bindings:\n%s", formula)
-	}
-	if !strings.Contains(formula, `system "yarn", "build"`) {
-		t.Fatalf("formula does not build erun-app frontend assets:\n%s", formula)
-	}
-	formulaSHA := regexp.MustCompile(`(?m)^  sha256 "([0-9a-f]+)"$`).FindStringSubmatch(formula)
-	if len(formulaSHA) != 2 {
-		t.Fatalf("formula sha256 not found:\n%s", formula)
-	}
-	gotFormulaSHA := releaseArchiveSHA256ForTest(t, "https://github.com/sophium/erun/archive/refs/tags/"+latestTag+".tar.gz")
-	if formulaSHA[1] != gotFormulaSHA {
-		t.Fatalf("formula sha256 = %q, want %q", formulaSHA[1], gotFormulaSHA)
-	}
+	requireHomebrewFormulaTracksLatestTag(t, formula, latestTag)
 
 	scoopPath := filepath.Join(repoRoot, "bucket", "erun.json")
 	scoopData, err := os.ReadFile(scoopPath)
-	if err != nil {
-		t.Fatalf("read scoop manifest: %v", err)
-	}
+	requireNoError(t, err, "read scoop manifest")
 
-	var manifest struct {
-		Version    string `json:"version"`
-		URL        string `json:"url"`
-		Hash       string `json:"hash"`
-		ExtractDir string `json:"extract_dir"`
-		Depends    []string
-		Bin        []string
-		Installer  struct {
-			Script []string `json:"script"`
-		} `json:"installer"`
-	}
-	if err := json.Unmarshal(scoopData, &manifest); err != nil {
-		t.Fatalf("unmarshal scoop manifest: %v", err)
-	}
+	manifest := unmarshalScoopManifest(t, scoopData)
+	requireScoopManifestTracksLatestTag(t, manifest, latestTag, latestVersion)
+	requireScoopInstallerBuildsDesktopApp(t, strings.Join(manifest.Installer.Script, "\n"))
+}
 
-	if manifest.Version != latestVersion {
-		t.Fatalf("scoop version = %q, want %q", manifest.Version, latestVersion)
-	}
+type scoopManifestForTest struct {
+	Version    string `json:"version"`
+	URL        string `json:"url"`
+	Hash       string `json:"hash"`
+	ExtractDir string `json:"extract_dir"`
+	Depends    []string
+	Bin        []string
+	Installer  struct {
+		Script []string `json:"script"`
+	} `json:"installer"`
+}
+
+func requireHomebrewFormulaTracksLatestTag(t *testing.T, formula, latestTag string) {
+	t.Helper()
+	requireStringContains(t, formula, `url "https://github.com/sophium/erun/archive/refs/tags/`+latestTag+`.tar.gz"`, "formula does not target latest stable tag "+latestTag)
+	requireStringContains(t, formula, `bin/"erun"`, "formula does not build erun")
+	requireStringContains(t, formula, `bin/"emcp"`, "formula does not build emcp")
+	requireStringContains(t, formula, `depends_on "node" => :build`, "formula missing node dependency")
+	requireStringContains(t, formula, `depends_on "yarn" => :build`, "formula missing yarn dependency")
+	requireStringContains(t, formula, `system "yarn", "install", "--frozen-lockfile"`, "formula does not install frontend dependencies")
+	requireStringContains(t, formula, `go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2`, "formula does not resolve Wails version")
+	requireStringContains(t, formula, `system "go", "install", "github.com/wailsapp/wails/v2/cmd/wails@#{wails_version}"`, "formula does not install Wails")
+	requireStringContains(t, formula, `system wails_bin, "generate", "module"`, "formula does not generate frontend bindings")
+	requireStringContains(t, formula, `system "yarn", "build"`, "formula does not build frontend assets")
+	requireFormulaChecksum(t, formula, latestTag)
+}
+
+func requireFormulaChecksum(t *testing.T, formula, latestTag string) {
+	t.Helper()
+	formulaSHA := regexp.MustCompile(`(?m)^  sha256 "([0-9a-f]+)"$`).FindStringSubmatch(formula)
+	requireEqual(t, len(formulaSHA), 2, "formula sha256 match count")
+	gotFormulaSHA := releaseArchiveSHA256ForTest(t, "https://github.com/sophium/erun/archive/refs/tags/"+latestTag+".tar.gz")
+	requireEqual(t, formulaSHA[1], gotFormulaSHA, "formula sha256")
+}
+
+func unmarshalScoopManifest(t *testing.T, data []byte) scoopManifestForTest {
+	t.Helper()
+	var manifest scoopManifestForTest
+	requireNoError(t, json.Unmarshal(data, &manifest), "unmarshal scoop manifest")
+	return manifest
+}
+
+func requireScoopManifestTracksLatestTag(t *testing.T, manifest scoopManifestForTest, latestTag, latestVersion string) {
+	t.Helper()
+	requireEqual(t, manifest.Version, latestVersion, "scoop version")
 	wantZipURL := "https://github.com/sophium/erun/archive/refs/tags/" + latestTag + ".zip"
-	if manifest.URL != wantZipURL {
-		t.Fatalf("scoop url = %q, want %q", manifest.URL, wantZipURL)
-	}
-	gotScoopSHA := releaseArchiveSHA256ForTest(t, manifest.URL)
-	if manifest.Hash != gotScoopSHA {
-		t.Fatalf("scoop hash = %q, want %q", manifest.Hash, gotScoopSHA)
-	}
-	if manifest.ExtractDir != "erun-"+latestVersion {
-		t.Fatalf("scoop extract_dir = %q, want %q", manifest.ExtractDir, "erun-"+latestVersion)
-	}
-	if !containsString(manifest.Depends, "go") {
-		t.Fatalf("scoop manifest missing go dependency: %+v", manifest.Depends)
-	}
-	if !containsString(manifest.Depends, "mingw") {
-		t.Fatalf("scoop manifest missing mingw dependency for erun-app.exe: %+v", manifest.Depends)
-	}
-	if !containsString(manifest.Depends, "nodejs") {
-		t.Fatalf("scoop manifest missing nodejs dependency for erun-app frontend build: %+v", manifest.Depends)
-	}
-	if !containsString(manifest.Depends, "yarn") {
-		t.Fatalf("scoop manifest missing yarn dependency for erun-app frontend build: %+v", manifest.Depends)
-	}
-	if !containsString(manifest.Bin, "erun.exe") || !containsString(manifest.Bin, "emcp.exe") {
-		t.Fatalf("scoop manifest does not shim both executables: %+v", manifest.Bin)
-	}
-	script := strings.Join(manifest.Installer.Script, "\n")
-	if !strings.Contains(script, `go build -trimpath -ldflags $cliLdflags -o "$dir\erun.exe" .`) {
-		t.Fatalf("scoop installer does not build erun.exe:\n%s", script)
-	}
-	if !strings.Contains(script, `go build -trimpath -ldflags $mcpLdflags -o "$dir\emcp.exe" ./cmd/emcp`) {
-		t.Fatalf("scoop installer does not build emcp.exe:\n%s", script)
-	}
-	if !strings.Contains(script, `building erun-app.exe requires a C compiler such as MinGW for the Wails CGO build`) {
-		t.Fatalf("scoop installer does not explain the Wails CGO compiler requirement:\n%s", script)
-	}
-	if !strings.Contains(script, `yarn install --frozen-lockfile`) {
-		t.Fatalf("scoop installer does not install erun-app frontend dependencies:\n%s", script)
-	}
-	if !strings.Contains(script, `go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2`) {
-		t.Fatalf("scoop installer does not resolve the Wails generator version from go.mod:\n%s", script)
-	}
-	if !strings.Contains(script, `go install "github.com/wailsapp/wails/v2/cmd/wails@$wailsVersion"`) {
-		t.Fatalf("scoop installer does not install the Wails generator:\n%s", script)
-	}
-	if !strings.Contains(script, `generate module`) {
-		t.Fatalf("scoop installer does not generate erun-app frontend bindings:\n%s", script)
-	}
-	if !strings.Contains(script, `yarn build`) {
-		t.Fatalf("scoop installer does not build erun-app frontend assets:\n%s", script)
-	}
+	requireEqual(t, manifest.URL, wantZipURL, "scoop url")
+	requireEqual(t, manifest.Hash, releaseArchiveSHA256ForTest(t, manifest.URL), "scoop hash")
+	requireEqual(t, manifest.ExtractDir, "erun-"+latestVersion, "scoop extract_dir")
+	requireScoopManifestCommands(t, manifest)
+}
+
+func requireScoopManifestCommands(t *testing.T, manifest scoopManifestForTest) {
+	t.Helper()
+	requireCondition(t, containsString(manifest.Depends, "go"), "scoop manifest missing go dependency: %+v", manifest.Depends)
+	requireCondition(t, containsString(manifest.Depends, "mingw"), "scoop manifest missing mingw dependency: %+v", manifest.Depends)
+	requireCondition(t, containsString(manifest.Depends, "nodejs"), "scoop manifest missing nodejs dependency: %+v", manifest.Depends)
+	requireCondition(t, containsString(manifest.Depends, "yarn"), "scoop manifest missing yarn dependency: %+v", manifest.Depends)
+	requireCondition(t, containsString(manifest.Bin, "erun.exe") && containsString(manifest.Bin, "emcp.exe"), "scoop manifest does not shim both executables: %+v", manifest.Bin)
+}
+
+func requireScoopInstallerBuildsDesktopApp(t *testing.T, script string) {
+	t.Helper()
+	requireStringContains(t, script, `go build -trimpath -ldflags $cliLdflags -o "$dir\erun.exe" .`, "scoop installer does not build erun.exe")
+	requireStringContains(t, script, `go build -trimpath -ldflags $mcpLdflags -o "$dir\emcp.exe" ./cmd/emcp`, "scoop installer does not build emcp.exe")
+	requireStringContains(t, script, `building erun-app.exe requires a C compiler such as MinGW for the Wails CGO build`, "scoop installer does not explain Wails CGO compiler requirement")
+	requireStringContains(t, script, `yarn install --frozen-lockfile`, "scoop installer does not install frontend dependencies")
+	requireStringContains(t, script, `go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2`, "scoop installer does not resolve Wails version")
+	requireStringContains(t, script, `go install "github.com/wailsapp/wails/v2/cmd/wails@$wailsVersion"`, "scoop installer does not install Wails")
+	requireStringContains(t, script, `generate module`, "scoop installer does not generate frontend bindings")
+	requireStringContains(t, script, `yarn build`, "scoop installer does not build frontend assets")
 }
 
 func TestAptBuildScriptBuildsDebianPackageForBothExecutables(t *testing.T) {
@@ -174,38 +143,23 @@ func TestLinuxReleaseScriptPromptsForGitHubLogin(t *testing.T) {
 	scriptPath := filepath.Join(repoRoot, "erun-devops", "linux", "erun-cli", "release.sh")
 
 	scriptData, err := os.ReadFile(scriptPath)
-	if err != nil {
-		t.Fatalf("read linux release script: %v", err)
-	}
+	requireNoError(t, err, "read linux release script")
 	script := string(scriptData)
 
-	if !strings.Contains(script, `if ! gh auth status >/dev/null 2>&1; then`) {
-		t.Fatalf("linux release script does not prompt for gh auth login when needed:\n%s", script)
-	}
-	if !strings.Contains(script, `gh auth login --hostname github.com --git-protocol ssh --web --skip-ssh-key --scopes admin:public_key`) {
-		t.Fatalf("linux release script does not request the admin:public_key scope during login:\n%s", script)
-	}
-	if !strings.Contains(script, `printf '%s-%s\n' "${ERUN_TENANT}" "${ERUN_ENVIRONMENT}"`) {
-		t.Fatalf("linux release script does not derive the SSH key title from tenant and environment:\n%s", script)
-	}
-	if !strings.Contains(script, `gh auth refresh --hostname github.com --scopes admin:public_key`) {
-		t.Fatalf("linux release script does not refresh the admin:public_key scope when needed:\n%s", script)
-	}
-	if !strings.Contains(script, `gh ssh-key add "$public_key_path" --title "$key_title"`) {
-		t.Fatalf("linux release script does not upload the SSH key with the resolved title:\n%s", script)
-	}
-	if !strings.Contains(script, `grep -Fq "$public_key_data" <<<"$uploaded_keys"`) {
-		t.Fatalf("linux release script does not skip SSH key upload when the key is already present:\n%s", script)
-	}
-	if !strings.Contains(script, `git -C "$repo_root" ls-remote --exit-code --tags origin "refs/tags/$tag"`) {
-		t.Fatalf("linux release script does not check whether the release tag already exists on origin:\n%s", script)
-	}
-	if !strings.Contains(script, `git -C "$repo_root" push origin "$tag"`) {
-		t.Fatalf("linux release script does not push a missing release tag to origin before creating the release:\n%s", script)
-	}
-	if !strings.Contains(script, `gh release upload "$tag" "$artifact_path" --clobber`) {
-		t.Fatalf("linux release script does not upload release artifacts:\n%s", script)
-	}
+	requireLinuxReleaseScriptGitHubFlow(t, script)
+}
+
+func requireLinuxReleaseScriptGitHubFlow(t *testing.T, script string) {
+	t.Helper()
+	requireStringContains(t, script, `if ! gh auth status >/dev/null 2>&1; then`, "linux release script does not prompt for gh auth login")
+	requireStringContains(t, script, `gh auth login --hostname github.com --git-protocol ssh --web --skip-ssh-key --scopes admin:public_key`, "linux release script does not request admin:public_key scope")
+	requireStringContains(t, script, `printf '%s-%s\n' "${ERUN_TENANT}" "${ERUN_ENVIRONMENT}"`, "linux release script does not derive SSH key title")
+	requireStringContains(t, script, `gh auth refresh --hostname github.com --scopes admin:public_key`, "linux release script does not refresh admin:public_key scope")
+	requireStringContains(t, script, `gh ssh-key add "$public_key_path" --title "$key_title"`, "linux release script does not upload SSH key")
+	requireStringContains(t, script, `grep -Fq "$public_key_data" <<<"$uploaded_keys"`, "linux release script does not skip existing SSH key")
+	requireStringContains(t, script, `git -C "$repo_root" ls-remote --exit-code --tags origin "refs/tags/$tag"`, "linux release script does not check origin tag")
+	requireStringContains(t, script, `git -C "$repo_root" push origin "$tag"`, "linux release script does not push missing tag")
+	requireStringContains(t, script, `gh release upload "$tag" "$artifact_path" --clobber`, "linux release script does not upload artifacts")
 }
 
 func repoRootForPackagingTest(t *testing.T) string {

--- a/erun-common/registry_versions.go
+++ b/erun-common/registry_versions.go
@@ -104,31 +104,21 @@ func fetchDockerHubTagPage(ctx context.Context, client *http.Client, endpoint st
 
 func latestRuntimeVersionsFromTags(tags []string) RuntimeRegistryVersions {
 	var latestStable semver
-	latestStableSet := false
 	latestSnapshot := ""
 	latestSnapshotTime := ""
+	latestStableSet := false
 	uniqueTags := make([]string, 0, len(tags))
 
 	for _, tag := range tags {
-		tag = strings.TrimSpace(tag)
-		if tag == "" {
+		if tag = strings.TrimSpace(tag); tag == "" {
 			continue
 		}
-		if !slices.Contains(uniqueTags, tag) {
-			uniqueTags = append(uniqueTags, tag)
+		uniqueTags = appendUniqueRuntimeTag(uniqueTags, tag)
+		if version, ok := newerRegistryStableVersion(tag, latestStable, latestStableSet); ok {
+			latestStable, latestStableSet = version, true
 		}
-		if version, ok := parseRegistryStableVersion(tag); ok {
-			if !latestStableSet || compareSemver(version, latestStable) > 0 {
-				latestStable = version
-				latestStableSet = true
-			}
-			continue
-		}
-		if snapshotTime, ok := parseRegistrySnapshotTime(tag); ok {
-			if latestSnapshotTime == "" || snapshotTime > latestSnapshotTime {
-				latestSnapshot = tag
-				latestSnapshotTime = snapshotTime
-			}
+		if snapshot, ok := newerRegistrySnapshotVersion(tag, latestSnapshotTime); ok {
+			latestSnapshot, latestSnapshotTime = tag, snapshot
 		}
 	}
 
@@ -140,6 +130,29 @@ func latestRuntimeVersionsFromTags(tags []string) RuntimeRegistryVersions {
 		result.LatestStable = formatSemver(latestStable)
 	}
 	return result
+}
+
+func appendUniqueRuntimeTag(tags []string, tag string) []string {
+	if slices.Contains(tags, tag) {
+		return tags
+	}
+	return append(tags, tag)
+}
+
+func newerRegistryStableVersion(tag string, latest semver, latestSet bool) (semver, bool) {
+	version, ok := parseRegistryStableVersion(tag)
+	if !ok || latestSet && compareSemver(version, latest) <= 0 {
+		return semver{}, false
+	}
+	return version, true
+}
+
+func newerRegistrySnapshotVersion(tag, latestSnapshotTime string) (string, bool) {
+	snapshotTime, ok := parseRegistrySnapshotTime(tag)
+	if !ok || latestSnapshotTime != "" && snapshotTime <= latestSnapshotTime {
+		return "", false
+	}
+	return snapshotTime, true
 }
 
 func (versions RuntimeRegistryVersions) HasVersion(version string) bool {

--- a/erun-common/registry_versions.go
+++ b/erun-common/registry_versions.go
@@ -87,7 +87,9 @@ func fetchDockerHubTagPage(ctx context.Context, client *http.Client, endpoint st
 	if err != nil {
 		return dockerHubTagPage{}, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return dockerHubTagPage{}, fmt.Errorf("docker hub tags request failed: %s", resp.Status)

--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -927,46 +927,63 @@ func syncReleasePackagingChecksums(ctx Context, spec ReleasePackagingSyncSpec) (
 	}
 
 	updates := make([]ReleaseFileUpdate, 0, 2)
-
-	if spec.FormulaPath != "" {
-		url := "https://github.com/sophium/erun/archive/refs/tags/v" + spec.Version + ".tar.gz"
-		ctx.TraceCommand("", "curl", "-fsSL", url)
-		ctx.TraceCommand("", "shasum", "-a", "256", "v"+spec.Version+".tar.gz")
-		if !ctx.DryRun {
-			checksum, err := releaseArchiveSHA256(url)
-			if err != nil {
-				return nil, err
-			}
-			content, changed, err := updateHomebrewFormulaReleaseChecksum(spec.FormulaPath, checksum)
-			if err != nil {
-				return nil, err
-			}
-			if changed {
-				updates = append(updates, ReleaseFileUpdate{Path: spec.FormulaPath, Content: content})
-			}
-		}
+	formulaUpdate, ok, err := syncHomebrewReleaseChecksum(ctx, spec)
+	if err != nil {
+		return nil, err
 	}
-
-	if spec.ScoopPath != "" {
-		url := "https://github.com/sophium/erun/archive/refs/tags/v" + spec.Version + ".zip"
-		ctx.TraceCommand("", "curl", "-fsSL", url)
-		ctx.TraceCommand("", "shasum", "-a", "256", "v"+spec.Version+".zip")
-		if !ctx.DryRun {
-			checksum, err := releaseArchiveSHA256(url)
-			if err != nil {
-				return nil, err
-			}
-			content, changed, err := updateScoopManifestReleaseChecksum(spec.ScoopPath, checksum)
-			if err != nil {
-				return nil, err
-			}
-			if changed {
-				updates = append(updates, ReleaseFileUpdate{Path: spec.ScoopPath, Content: content})
-			}
-		}
+	if ok {
+		updates = append(updates, formulaUpdate)
 	}
-
+	scoopUpdate, ok, err := syncScoopReleaseChecksum(ctx, spec)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		updates = append(updates, scoopUpdate)
+	}
 	return updates, nil
+}
+
+func syncHomebrewReleaseChecksum(ctx Context, spec ReleasePackagingSyncSpec) (ReleaseFileUpdate, bool, error) {
+	if spec.FormulaPath == "" {
+		return ReleaseFileUpdate{}, false, nil
+	}
+	url := "https://github.com/sophium/erun/archive/refs/tags/v" + spec.Version + ".tar.gz"
+	ctx.TraceCommand("", "curl", "-fsSL", url)
+	ctx.TraceCommand("", "shasum", "-a", "256", "v"+spec.Version+".tar.gz")
+	if ctx.DryRun {
+		return ReleaseFileUpdate{}, false, nil
+	}
+	checksum, err := releaseArchiveSHA256(url)
+	if err != nil {
+		return ReleaseFileUpdate{}, false, err
+	}
+	content, changed, err := updateHomebrewFormulaReleaseChecksum(spec.FormulaPath, checksum)
+	if err != nil || !changed {
+		return ReleaseFileUpdate{}, false, err
+	}
+	return ReleaseFileUpdate{Path: spec.FormulaPath, Content: content}, true, nil
+}
+
+func syncScoopReleaseChecksum(ctx Context, spec ReleasePackagingSyncSpec) (ReleaseFileUpdate, bool, error) {
+	if spec.ScoopPath == "" {
+		return ReleaseFileUpdate{}, false, nil
+	}
+	url := "https://github.com/sophium/erun/archive/refs/tags/v" + spec.Version + ".zip"
+	ctx.TraceCommand("", "curl", "-fsSL", url)
+	ctx.TraceCommand("", "shasum", "-a", "256", "v"+spec.Version+".zip")
+	if ctx.DryRun {
+		return ReleaseFileUpdate{}, false, nil
+	}
+	checksum, err := releaseArchiveSHA256(url)
+	if err != nil {
+		return ReleaseFileUpdate{}, false, err
+	}
+	content, changed, err := updateScoopManifestReleaseChecksum(spec.ScoopPath, checksum)
+	if err != nil || !changed {
+		return ReleaseFileUpdate{}, false, err
+	}
+	return ReleaseFileUpdate{Path: spec.ScoopPath, Content: content}, true, nil
 }
 
 func releaseArchiveSHA256(url string) (string, error) {
@@ -1244,42 +1261,56 @@ func resolveReleaseModuleRoot(projectRoot string) (string, error) {
 func findNestedReleaseRoots(projectRoot string) ([]string, error) {
 	matches := make([]string, 0, 2)
 	err := filepath.WalkDir(projectRoot, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
+		dir, ok, walkErr := nestedReleaseRootCandidate(projectRoot, path, d, err)
+		if ok {
+			matches = append(matches, dir)
 		}
-		if d.IsDir() {
-			if d.Name() == ".git" {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if d.Name() != "VERSION" {
-			return nil
-		}
-
-		dir := filepath.Dir(path)
-		if dir == projectRoot {
-			return nil
-		}
-		relative, err := filepath.Rel(projectRoot, dir)
-		if err != nil {
-			return err
-		}
-		parts := strings.Split(filepath.ToSlash(relative), "/")
-		for _, part := range parts {
-			if part == "assets" {
-				return nil
-			}
-		}
-		if len(parts) >= 2 && parts[1] == "docker" {
-			return nil
-		}
-		matches = append(matches, dir)
-		return nil
+		return walkErr
 	})
 	if err != nil {
 		return nil, err
 	}
 	sort.Strings(matches)
 	return matches, nil
+}
+
+func nestedReleaseRootCandidate(projectRoot, path string, d os.DirEntry, err error) (string, bool, error) {
+	if err != nil {
+		return "", false, err
+	}
+	if d.IsDir() {
+		if d.Name() == ".git" {
+			return "", false, filepath.SkipDir
+		}
+		return "", false, nil
+	}
+	if d.Name() != "VERSION" {
+		return "", false, nil
+	}
+	dir := filepath.Dir(path)
+	if dir == projectRoot {
+		return "", false, nil
+	}
+	parts, err := releaseRootRelativeParts(projectRoot, dir)
+	if err != nil || ignoredNestedReleaseRoot(parts) {
+		return "", false, err
+	}
+	return dir, true, nil
+}
+
+func releaseRootRelativeParts(projectRoot, dir string) ([]string, error) {
+	relative, err := filepath.Rel(projectRoot, dir)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(filepath.ToSlash(relative), "/"), nil
+}
+
+func ignoredNestedReleaseRoot(parts []string) bool {
+	for _, part := range parts {
+		if part == "assets" {
+			return true
+		}
+	}
+	return len(parts) >= 2 && parts[1] == "docker"
 }

--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -103,6 +103,28 @@ type ReleaseSpec struct {
 	SkippedLinux    bool `json:"-"`
 }
 
+type releaseInputs struct {
+	ProjectRoot         string
+	ReleaseRoot         string
+	ReleaseConfig       ReleaseConfig
+	Branch              string
+	Commit              string
+	BaseVersion         string
+	Version             string
+	VersionFilePath     string
+	Mode                ReleaseMode
+	DevelopBranchExists bool
+}
+
+type releaseArtifacts struct {
+	Charts        []ReleaseChartSpec
+	Images        []ReleaseDockerImageSpec
+	FileUpdates   []ReleaseFileUpdate
+	PackagingSync *ReleasePackagingSyncSpec
+	LinuxReleases []scriptSpec
+	SkippedLinux  bool
+}
+
 func ResolveReleaseSpec(findProjectRoot ProjectFinderFunc, params ReleaseParams) (ReleaseSpec, error) {
 	return resolveReleaseSpec(findProjectRoot, LoadProjectConfig, GitCurrentBranch, GitShortCommit, GitLocalBranchExists, params)
 }
@@ -110,138 +132,35 @@ func ResolveReleaseSpec(findProjectRoot ProjectFinderFunc, params ReleaseParams)
 func resolveReleaseSpec(findProjectRoot ProjectFinderFunc, loadProjectConfig ProjectConfigLoaderFunc, resolveBranch, resolveCommit GitValueResolverFunc, branchExists GitBranchCheckerFunc, params ReleaseParams) (ReleaseSpec, error) {
 	findProjectRoot, loadProjectConfig, resolveBranch, resolveCommit, branchExists = normalizeReleaseDependencies(findProjectRoot, loadProjectConfig, resolveBranch, resolveCommit, branchExists)
 
-	projectRoot, err := resolveReleaseProjectRoot(findProjectRoot, params)
+	inputs, err := resolveReleaseInputs(findProjectRoot, loadProjectConfig, resolveBranch, resolveCommit, branchExists, params)
 	if err != nil {
 		return ReleaseSpec{}, err
 	}
-	releaseRoot, err := resolveReleaseModuleRoot(projectRoot)
+	artifacts, err := discoverReleaseArtifacts(inputs)
 	if err != nil {
 		return ReleaseSpec{}, err
 	}
-
-	projectConfig, _, err := loadProjectConfig(projectRoot)
-	if err != nil && !errors.Is(err, ErrNotInitialized) {
-		return ReleaseSpec{}, err
-	}
-	releaseConfig := projectConfig.NormalizedReleaseConfig()
-
-	branch, err := resolveBranch(projectRoot)
+	nextVersion, stages, err := resolveReleaseStages(inputs, artifacts.FileUpdates, artifacts.PackagingSync)
 	if err != nil {
 		return ReleaseSpec{}, err
-	}
-	commit, err := resolveCommit(projectRoot)
-	if err != nil {
-		return ReleaseSpec{}, err
-	}
-
-	baseVersion, _, versionFilePath, err := ResolveDockerBuildVersion(releaseRoot, releaseRoot)
-	if err != nil {
-		return ReleaseSpec{}, err
-	}
-
-	mode := classifyReleaseMode(branch, releaseConfig)
-	version := resolveReleaseVersion(baseVersion, commit, mode)
-	developBranchExists, err := branchExists(projectRoot, releaseConfig.DevelopBranch)
-	if err != nil {
-		return ReleaseSpec{}, err
-	}
-
-	charts, chartUpdates, err := discoverReleaseCharts(releaseRoot, version)
-	if err != nil {
-		return ReleaseSpec{}, err
-	}
-	releaseFileUpdates := append([]ReleaseFileUpdate{}, chartUpdates...)
-	var packagingSync *ReleasePackagingSyncSpec
-	if mode == ReleaseModeStable {
-		packagingUpdates, syncSpec, err := discoverStableReleasePackaging(projectRoot, version)
-		if err != nil {
-			return ReleaseSpec{}, err
-		}
-		releaseFileUpdates = append(releaseFileUpdates, packagingUpdates...)
-		packagingSync = syncSpec
-	}
-
-	images, err := discoverReleaseDockerImages(projectRoot, releaseRoot, versionFilePath, version)
-	if err != nil {
-		return ReleaseSpec{}, err
-	}
-	linuxReleases, err := discoverReleaseLinuxScripts(releaseRoot, version)
-	if err != nil {
-		return ReleaseSpec{}, err
-	}
-	skippedLinux := false
-	if len(linuxReleases) > 0 && !LinuxPackageBuildsSupported() {
-		linuxReleases = nil
-		skippedLinux = true
-	}
-
-	stages := make([]ReleaseStage, 0, 2)
-	if syncStage := newSyncRemoteStage(projectRoot, branch); len(syncStage.GitCommands) > 0 {
-		stages = append(stages, syncStage)
-	}
-	releaseStage := newReleaseStage(projectRoot, releaseFileUpdates, version, mode)
-	if len(releaseStage.FileUpdates) > 0 || len(releaseStage.GitCommands) > 0 {
-		stages = append(stages, releaseStage)
-	}
-	if mode == ReleaseModeStable && packagingSync != nil {
-		tagPushStage := newPushReleaseTagStage(projectRoot, version)
-		if len(tagPushStage.GitCommands) > 0 {
-			stages = append(stages, tagPushStage)
-		}
-		packagingStage := newSyncPackagingStage(projectRoot, *packagingSync)
-		if packagingStage.PackagingSync != nil || len(packagingStage.GitCommands) > 0 {
-			stages = append(stages, packagingStage)
-		}
-	}
-
-	nextVersion := ""
-	if mode == ReleaseModeStable {
-		nextVersion, err = nextPatchVersion(baseVersion)
-		if err != nil {
-			return ReleaseSpec{}, err
-		}
-		if strings.TrimSpace(versionFilePath) != "" && nextVersion != baseVersion {
-			bumpUpdate := ReleaseFileUpdate{
-				Path:    versionFilePath,
-				Content: nextVersion + "\n",
-			}
-			bumpStage := newBumpStage(projectRoot, nextVersion, bumpUpdate)
-			if len(bumpStage.FileUpdates) > 0 || len(bumpStage.GitCommands) > 0 {
-				stages = append(stages, bumpStage)
-			}
-		}
-		syncStage := newSyncDevelopStage(projectRoot, releaseConfig, developBranchExists)
-		if len(syncStage.FileUpdates) > 0 || len(syncStage.GitCommands) > 0 {
-			stages = append(stages, syncStage)
-		}
-		pushStage := newPushReleaseStage(projectRoot, releaseConfig, developBranchExists)
-		if len(pushStage.FileUpdates) > 0 || len(pushStage.GitCommands) > 0 {
-			stages = append(stages, pushStage)
-		}
-	}
-	if mode == ReleaseModeCandidate {
-		pushStage := newPushCandidateReleaseStage(projectRoot, releaseConfig)
-		if len(pushStage.FileUpdates) > 0 || len(pushStage.GitCommands) > 0 {
-			stages = append(stages, pushStage)
-		}
 	}
 
 	return ReleaseSpec{
-		ProjectRoot:     projectRoot,
-		ReleaseRoot:     releaseRoot,
-		Branch:          branch,
-		Commit:          commit,
-		BaseVersion:     baseVersion,
-		Version:         version,
+		ProjectRoot:     inputs.ProjectRoot,
+		ReleaseRoot:     inputs.ReleaseRoot,
+		Branch:          inputs.Branch,
+		Commit:          inputs.Commit,
+		BaseVersion:     inputs.BaseVersion,
+		Version:         inputs.Version,
 		NextVersion:     nextVersion,
-		VersionFilePath: versionFilePath,
-		Mode:            mode,
+		VersionFilePath: inputs.VersionFilePath,
+		Mode:            inputs.Mode,
 		Force:           params.Force,
-		Charts:          charts,
-		DockerImages:    images,
+		Charts:          artifacts.Charts,
+		DockerImages:    artifacts.Images,
 		Stages:          stages,
-		LinuxReleases:   linuxReleases,
-		SkippedLinux:    skippedLinux,
+		LinuxReleases:   artifacts.LinuxReleases,
+		SkippedLinux:    artifacts.SkippedLinux,
 	}, nil
 }
 
@@ -259,6 +178,24 @@ func runReleaseSpec(ctx Context, spec ReleaseSpec, runGit GitCommandRunnerFunc, 
 		syncPackagingChecksums = syncReleasePackagingChecksums
 	}
 
+	traceReleaseSpec(ctx, spec)
+	if err := ensureReleaseWorktreeClean(ctx, spec.ProjectRoot); err != nil {
+		return err
+	}
+
+	for _, stage := range spec.Stages {
+		if err := runReleaseStage(ctx, spec, stage, runGit, syncPackagingChecksums); err != nil {
+			return err
+		}
+	}
+	if spec.SkippedLinux {
+		ctx.Trace("skipping linux package scripts: host is not Linux or dpkg-deb is unavailable")
+	}
+
+	return runScriptSpecs(ctx, spec.LinuxReleases, runScript)
+}
+
+func traceReleaseSpec(ctx Context, spec ReleaseSpec) {
 	ctx.Trace(fmt.Sprintf("release: branch=%s mode=%s version=%s", spec.Branch, spec.Mode, spec.Version))
 	if spec.NextVersion != "" {
 		ctx.Trace("next version: " + spec.NextVersion)
@@ -266,73 +203,90 @@ func runReleaseSpec(ctx Context, spec ReleaseSpec, runGit GitCommandRunnerFunc, 
 	for _, image := range spec.DockerImages {
 		ctx.Trace("docker image: " + image.Tag)
 	}
-	if !ctx.DryRun {
-		clean, err := gitWorktreeClean(spec.ProjectRoot)
+}
+
+func ensureReleaseWorktreeClean(ctx Context, projectRoot string) error {
+	if ctx.DryRun {
+		return nil
+	}
+	clean, err := gitWorktreeClean(projectRoot)
+	if err != nil {
+		return err
+	}
+	if !clean {
+		return fmt.Errorf("release requires a clean git worktree; commit or stash changes first")
+	}
+	return nil
+}
+
+func runReleaseStage(ctx Context, spec ReleaseSpec, stage ReleaseStage, runGit GitCommandRunnerFunc, syncPackagingChecksums ReleasePackagingSyncerFunc) error {
+	ctx.Trace("stage: " + stage.Name)
+	stageFileUpdates, err := releaseStageFileUpdates(ctx, stage, syncPackagingChecksums)
+	if err != nil {
+		return err
+	}
+	if err := writeReleaseFileUpdates(ctx, stageFileUpdates); err != nil {
+		return err
+	}
+	for _, command := range releaseStageCommands(ctx, stage, stageFileUpdates) {
+		if err := runReleaseCommand(ctx, spec, command, runGit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func releaseStageFileUpdates(ctx Context, stage ReleaseStage, syncPackagingChecksums ReleasePackagingSyncerFunc) ([]ReleaseFileUpdate, error) {
+	updates := append([]ReleaseFileUpdate{}, stage.FileUpdates...)
+	if stage.PackagingSync == nil {
+		return updates, nil
+	}
+	generatedUpdates, err := syncPackagingChecksums(ctx, *stage.PackagingSync)
+	if err != nil {
+		return nil, err
+	}
+	return append(updates, generatedUpdates...), nil
+}
+
+func writeReleaseFileUpdates(ctx Context, updates []ReleaseFileUpdate) error {
+	for _, update := range updates {
+		ctx.TraceBlock("write "+update.Path, strings.TrimRight(update.Content, "\n"))
+		if ctx.DryRun {
+			continue
+		}
+		if err := os.WriteFile(update.Path, []byte(update.Content), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func releaseStageCommands(ctx Context, stage ReleaseStage, updates []ReleaseFileUpdate) []ReleaseCommandSpec {
+	if !ctx.DryRun && stage.PackagingSync != nil && len(updates) == 0 {
+		return nil
+	}
+	return stage.GitCommands
+}
+
+func runReleaseCommand(ctx Context, spec ReleaseSpec, command ReleaseCommandSpec, runGit GitCommandRunnerFunc) error {
+	if command.Name == "git" && shouldSkipExistingReleaseTag(command.Args) {
+		skip, err := prepareReleaseTag(ctx, spec, runGit, command)
 		if err != nil {
 			return err
 		}
-		if !clean {
-			return fmt.Errorf("release requires a clean git worktree; commit or stash changes first")
+		if skip {
+			ctx.Trace("release tag already exists at HEAD; skipping " + command.Args[2])
+			return nil
 		}
 	}
-
-	for _, stage := range spec.Stages {
-		ctx.Trace("stage: " + stage.Name)
-		stageFileUpdates := append([]ReleaseFileUpdate{}, stage.FileUpdates...)
-		if stage.PackagingSync != nil {
-			generatedUpdates, err := syncPackagingChecksums(ctx, *stage.PackagingSync)
-			if err != nil {
-				return err
-			}
-			stageFileUpdates = append(stageFileUpdates, generatedUpdates...)
-		}
-
-		for _, update := range stageFileUpdates {
-			ctx.TraceBlock("write "+update.Path, strings.TrimRight(update.Content, "\n"))
-			if ctx.DryRun {
-				continue
-			}
-			if err := os.WriteFile(update.Path, []byte(update.Content), 0o644); err != nil {
-				return err
-			}
-		}
-
-		stageCommands := stage.GitCommands
-		if !ctx.DryRun && stage.PackagingSync != nil && len(stageFileUpdates) == 0 {
-			stageCommands = nil
-		}
-		for _, command := range stageCommands {
-			if command.Name == "git" && shouldSkipExistingReleaseTag(command.Args) {
-				skip, err := prepareReleaseTag(ctx, spec, runGit, command)
-				if err != nil {
-					return err
-				}
-				if skip {
-					ctx.Trace("release tag already exists at HEAD; skipping " + command.Args[2])
-					continue
-				}
-			}
-			ctx.TraceCommand(command.Dir, command.Name, command.Args...)
-			if ctx.DryRun {
-				continue
-			}
-			if command.Name != "git" {
-				return fmt.Errorf("unsupported release command %q", command.Name)
-			}
-			if err := runGit(command.Dir, ctx.Stdout, ctx.Stderr, command.Args...); err != nil {
-				return err
-			}
-		}
+	ctx.TraceCommand(command.Dir, command.Name, command.Args...)
+	if ctx.DryRun {
+		return nil
 	}
-	if spec.SkippedLinux {
-		ctx.Trace("skipping linux package scripts: host is not Linux or dpkg-deb is unavailable")
+	if command.Name != "git" {
+		return fmt.Errorf("unsupported release command %q", command.Name)
 	}
-
-	if err := runScriptSpecs(ctx, spec.LinuxReleases, runScript); err != nil {
-		return err
-	}
-
-	return nil
+	return runGit(command.Dir, ctx.Stdout, ctx.Stderr, command.Args...)
 }
 
 func shouldSkipExistingReleaseTag(args []string) bool {
@@ -592,6 +546,182 @@ func normalizeReleaseDependencies(findProjectRoot ProjectFinderFunc, loadProject
 		branchExists = GitLocalBranchExists
 	}
 	return findProjectRoot, loadProjectConfig, resolveBranch, resolveCommit, branchExists
+}
+
+func resolveReleaseInputs(findProjectRoot ProjectFinderFunc, loadProjectConfig ProjectConfigLoaderFunc, resolveBranch, resolveCommit GitValueResolverFunc, branchExists GitBranchCheckerFunc, params ReleaseParams) (releaseInputs, error) {
+	projectRoot, err := resolveReleaseProjectRoot(findProjectRoot, params)
+	if err != nil {
+		return releaseInputs{}, err
+	}
+	releaseRoot, err := resolveReleaseModuleRoot(projectRoot)
+	if err != nil {
+		return releaseInputs{}, err
+	}
+	releaseConfig, err := loadReleaseConfig(projectRoot, loadProjectConfig)
+	if err != nil {
+		return releaseInputs{}, err
+	}
+	branch, commit, err := resolveReleaseGitState(projectRoot, resolveBranch, resolveCommit)
+	if err != nil {
+		return releaseInputs{}, err
+	}
+	baseVersion, _, versionFilePath, err := ResolveDockerBuildVersion(releaseRoot, releaseRoot)
+	if err != nil {
+		return releaseInputs{}, err
+	}
+	mode := classifyReleaseMode(branch, releaseConfig)
+	developBranchExists, err := branchExists(projectRoot, releaseConfig.DevelopBranch)
+	if err != nil {
+		return releaseInputs{}, err
+	}
+	return releaseInputs{
+		ProjectRoot:         projectRoot,
+		ReleaseRoot:         releaseRoot,
+		ReleaseConfig:       releaseConfig,
+		Branch:              branch,
+		Commit:              commit,
+		BaseVersion:         baseVersion,
+		Version:             resolveReleaseVersion(baseVersion, commit, mode),
+		VersionFilePath:     versionFilePath,
+		Mode:                mode,
+		DevelopBranchExists: developBranchExists,
+	}, nil
+}
+
+func loadReleaseConfig(projectRoot string, loadProjectConfig ProjectConfigLoaderFunc) (ReleaseConfig, error) {
+	projectConfig, _, err := loadProjectConfig(projectRoot)
+	if err != nil && !errors.Is(err, ErrNotInitialized) {
+		return ReleaseConfig{}, err
+	}
+	return projectConfig.NormalizedReleaseConfig(), nil
+}
+
+func resolveReleaseGitState(projectRoot string, resolveBranch, resolveCommit GitValueResolverFunc) (string, string, error) {
+	branch, err := resolveBranch(projectRoot)
+	if err != nil {
+		return "", "", err
+	}
+	commit, err := resolveCommit(projectRoot)
+	if err != nil {
+		return "", "", err
+	}
+	return branch, commit, nil
+}
+
+func discoverReleaseArtifacts(inputs releaseInputs) (releaseArtifacts, error) {
+	charts, fileUpdates, err := discoverReleaseCharts(inputs.ReleaseRoot, inputs.Version)
+	if err != nil {
+		return releaseArtifacts{}, err
+	}
+	artifacts := releaseArtifacts{Charts: charts, FileUpdates: fileUpdates}
+	if err := discoverStableReleaseArtifacts(inputs, &artifacts); err != nil {
+		return releaseArtifacts{}, err
+	}
+	images, err := discoverReleaseDockerImages(inputs.ProjectRoot, inputs.ReleaseRoot, inputs.VersionFilePath, inputs.Version)
+	if err != nil {
+		return releaseArtifacts{}, err
+	}
+	artifacts.Images = images
+	linuxReleases, skippedLinux, err := discoverSupportedReleaseLinuxScripts(inputs.ReleaseRoot, inputs.Version)
+	if err != nil {
+		return releaseArtifacts{}, err
+	}
+	artifacts.LinuxReleases = linuxReleases
+	artifacts.SkippedLinux = skippedLinux
+	return artifacts, nil
+}
+
+func discoverStableReleaseArtifacts(inputs releaseInputs, artifacts *releaseArtifacts) error {
+	if inputs.Mode != ReleaseModeStable {
+		return nil
+	}
+	packagingUpdates, syncSpec, err := discoverStableReleasePackaging(inputs.ProjectRoot, inputs.Version)
+	if err != nil {
+		return err
+	}
+	artifacts.FileUpdates = append(artifacts.FileUpdates, packagingUpdates...)
+	artifacts.PackagingSync = syncSpec
+	return nil
+}
+
+func discoverSupportedReleaseLinuxScripts(releaseRoot, version string) ([]scriptSpec, bool, error) {
+	linuxReleases, err := discoverReleaseLinuxScripts(releaseRoot, version)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(linuxReleases) > 0 && !LinuxPackageBuildsSupported() {
+		return nil, true, nil
+	}
+	return linuxReleases, false, nil
+}
+
+func resolveReleaseStages(inputs releaseInputs, releaseFileUpdates []ReleaseFileUpdate, packagingSync *ReleasePackagingSyncSpec) (string, []ReleaseStage, error) {
+	stages := baseReleaseStages(inputs, releaseFileUpdates)
+	stages = append(stages, stablePackagingStages(inputs, packagingSync)...)
+	nextVersion, stableStages, err := stablePostReleaseStages(inputs)
+	if err != nil {
+		return "", nil, err
+	}
+	stages = append(stages, stableStages...)
+	stages = append(stages, candidatePostReleaseStages(inputs)...)
+	return nextVersion, stages, nil
+}
+
+func baseReleaseStages(inputs releaseInputs, releaseFileUpdates []ReleaseFileUpdate) []ReleaseStage {
+	stages := make([]ReleaseStage, 0, 2)
+	stages = appendReleaseStageIfActive(stages, newSyncRemoteStage(inputs.ProjectRoot, inputs.Branch))
+	stages = appendReleaseStageIfActive(stages, newReleaseStage(inputs.ProjectRoot, releaseFileUpdates, inputs.Version, inputs.Mode))
+	return stages
+}
+
+func stablePackagingStages(inputs releaseInputs, packagingSync *ReleasePackagingSyncSpec) []ReleaseStage {
+	if inputs.Mode != ReleaseModeStable || packagingSync == nil {
+		return nil
+	}
+	stages := make([]ReleaseStage, 0, 2)
+	stages = appendReleaseStageIfActive(stages, newPushReleaseTagStage(inputs.ProjectRoot, inputs.Version))
+	stages = appendReleaseStageIfActive(stages, newSyncPackagingStage(inputs.ProjectRoot, *packagingSync))
+	return stages
+}
+
+func stablePostReleaseStages(inputs releaseInputs) (string, []ReleaseStage, error) {
+	if inputs.Mode != ReleaseModeStable {
+		return "", nil, nil
+	}
+	nextVersion, err := nextPatchVersion(inputs.BaseVersion)
+	if err != nil {
+		return "", nil, err
+	}
+	stages := make([]ReleaseStage, 0, 3)
+	stages = appendReleaseStageIfActive(stages, newStableBumpStage(inputs, nextVersion))
+	stages = appendReleaseStageIfActive(stages, newSyncDevelopStage(inputs.ProjectRoot, inputs.ReleaseConfig, inputs.DevelopBranchExists))
+	stages = appendReleaseStageIfActive(stages, newPushReleaseStage(inputs.ProjectRoot, inputs.ReleaseConfig, inputs.DevelopBranchExists))
+	return nextVersion, stages, nil
+}
+
+func newStableBumpStage(inputs releaseInputs, nextVersion string) ReleaseStage {
+	if strings.TrimSpace(inputs.VersionFilePath) == "" || nextVersion == inputs.BaseVersion {
+		return ReleaseStage{}
+	}
+	bumpUpdate := ReleaseFileUpdate{
+		Path:    inputs.VersionFilePath,
+		Content: nextVersion + "\n",
+	}
+	return newBumpStage(inputs.ProjectRoot, nextVersion, bumpUpdate)
+}
+
+func candidatePostReleaseStages(inputs releaseInputs) []ReleaseStage {
+	if inputs.Mode != ReleaseModeCandidate {
+		return nil
+	}
+	return appendReleaseStageIfActive(nil, newPushCandidateReleaseStage(inputs.ProjectRoot, inputs.ReleaseConfig))
+}
+
+func appendReleaseStageIfActive(stages []ReleaseStage, stage ReleaseStage) []ReleaseStage {
+	if len(stage.FileUpdates) == 0 && len(stage.GitCommands) == 0 && stage.PackagingSync == nil {
+		return stages
+	}
+	return append(stages, stage)
 }
 
 func resolveReleaseProjectRoot(findProjectRoot ProjectFinderFunc, params ReleaseParams) (string, error) {

--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -994,7 +994,9 @@ func fetchReleaseArchiveSHA256(client *http.Client, url string) (string, bool, e
 	if err != nil {
 		return "", true, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		retry := resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError

--- a/erun-common/release_test.go
+++ b/erun-common/release_test.go
@@ -23,55 +23,33 @@ func TestResolveReleaseSpecStableRelease(t *testing.T) {
 		func(string, string) (bool, error) { return true, nil },
 		ReleaseParams{},
 	)
-	if err != nil {
-		t.Fatalf("resolveReleaseSpec failed: %v", err)
-	}
+	requireNoError(t, err, "resolveReleaseSpec failed")
 
-	if spec.Mode != ReleaseModeStable || spec.Version != "1.4.2" || spec.NextVersion != "1.4.3" {
-		t.Fatalf("unexpected release spec: %+v", spec)
-	}
-	if spec.ReleaseRoot != filepath.Join(projectRoot, "erun-devops") {
-		t.Fatalf("unexpected release root: %q", spec.ReleaseRoot)
-	}
-	if len(spec.Charts) != 1 || spec.Charts[0].Version != "1.4.2" || spec.Charts[0].AppVersion != "1.4.2" {
-		t.Fatalf("unexpected charts: %+v", spec.Charts)
-	}
-	if len(spec.DockerImages) != 1 || spec.DockerImages[0].Tag != "erunpaas/api:1.4.2" {
-		t.Fatalf("unexpected docker images: %+v", spec.DockerImages)
-	}
-	if len(spec.Stages) != 5 {
-		t.Fatalf("expected 5 stages, got %+v", spec.Stages)
-	}
-	if got := spec.Stages[0].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"fetch", "origin"}) {
-		t.Fatalf("unexpected sync fetch command: %+v", got)
-	}
-	if got := spec.Stages[0].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"rebase", "origin/main"}) {
-		t.Fatalf("unexpected sync rebase command: %+v", got)
-	}
-	if got := spec.Stages[1].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"add", filepath.Join("erun-devops", "k8s", "api", "Chart.yaml")}) {
-		t.Fatalf("unexpected release add command: %+v", got)
-	}
-	if got := spec.Stages[1].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"commit", "-m", "[skip ci] release 1.4.2"}) {
-		t.Fatalf("unexpected release commit command: %+v", got)
-	}
-	if got := spec.Stages[1].GitCommands[2].Args; !reflect.DeepEqual(got, []string{"tag", "-a", "v1.4.2", "-m", "Release 1.4.2"}) {
-		t.Fatalf("unexpected release tag command: %+v", got)
-	}
-	if got := spec.Stages[2].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"add", filepath.Join("erun-devops", "VERSION")}) {
-		t.Fatalf("unexpected bump add command: %+v", got)
-	}
-	if got := spec.Stages[3].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"checkout", "develop"}) {
-		t.Fatalf("unexpected sync checkout command: %+v", got)
-	}
-	if got := spec.Stages[3].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"merge", "--no-edit", "-X", "theirs", "main"}) {
-		t.Fatalf("unexpected sync merge command: %+v", got)
-	}
-	if got := spec.Stages[3].GitCommands[2].Args; !reflect.DeepEqual(got, []string{"checkout", "main"}) {
-		t.Fatalf("unexpected sync return command: %+v", got)
-	}
-	if got := spec.Stages[4].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "--follow-tags", "origin", "main", "develop"}) {
-		t.Fatalf("unexpected push command: %+v", got)
-	}
+	requireStableReleaseSpec(t, spec, projectRoot)
+}
+
+func requireStableReleaseSpec(t *testing.T, spec ReleaseSpec, projectRoot string) {
+	t.Helper()
+	requireCondition(t, spec.Mode == ReleaseModeStable && spec.Version == "1.4.2" && spec.NextVersion == "1.4.3", "unexpected release spec: %+v", spec)
+	requireEqual(t, spec.ReleaseRoot, filepath.Join(projectRoot, "erun-devops"), "unexpected release root")
+	requireCondition(t, len(spec.Charts) == 1 && spec.Charts[0].Version == "1.4.2" && spec.Charts[0].AppVersion == "1.4.2", "unexpected charts: %+v", spec.Charts)
+	requireCondition(t, len(spec.DockerImages) == 1 && spec.DockerImages[0].Tag == "erunpaas/api:1.4.2", "unexpected docker images: %+v", spec.DockerImages)
+	requireEqual(t, len(spec.Stages), 5, "stage count")
+	requireStableReleaseStageCommands(t, spec, projectRoot)
+}
+
+func requireStableReleaseStageCommands(t *testing.T, spec ReleaseSpec, projectRoot string) {
+	t.Helper()
+	requireDeepEqual(t, spec.Stages[0].GitCommands[0].Args, []string{"fetch", "origin"}, "unexpected sync fetch command")
+	requireDeepEqual(t, spec.Stages[0].GitCommands[1].Args, []string{"rebase", "origin/main"}, "unexpected sync rebase command")
+	requireDeepEqual(t, spec.Stages[1].GitCommands[0].Args, []string{"add", filepath.Join("erun-devops", "k8s", "api", "Chart.yaml")}, "unexpected release add command")
+	requireDeepEqual(t, spec.Stages[1].GitCommands[1].Args, []string{"commit", "-m", "[skip ci] release 1.4.2"}, "unexpected release commit command")
+	requireDeepEqual(t, spec.Stages[1].GitCommands[2].Args, []string{"tag", "-a", "v1.4.2", "-m", "Release 1.4.2"}, "unexpected release tag command")
+	requireDeepEqual(t, spec.Stages[2].GitCommands[0].Args, []string{"add", filepath.Join("erun-devops", "VERSION")}, "unexpected bump add command")
+	requireDeepEqual(t, spec.Stages[3].GitCommands[0].Args, []string{"checkout", "develop"}, "unexpected sync checkout command")
+	requireDeepEqual(t, spec.Stages[3].GitCommands[1].Args, []string{"merge", "--no-edit", "-X", "theirs", "main"}, "unexpected sync merge command")
+	requireDeepEqual(t, spec.Stages[3].GitCommands[2].Args, []string{"checkout", "main"}, "unexpected sync return command")
+	requireDeepEqual(t, spec.Stages[4].GitCommands[0].Args, []string{"push", "--follow-tags", "origin", "main", "develop"}, "unexpected push command")
 }
 
 func TestResolveReleaseSpecSkipsLinuxScriptsWhenUnsupported(t *testing.T) {
@@ -126,45 +104,31 @@ func TestResolveReleaseSpecStableReleaseIncludesPackagingUpdatesWhenPresent(t *t
 		t.Fatalf("resolveReleaseSpec failed: %v", err)
 	}
 
-	if len(spec.Stages) != 7 {
-		t.Fatalf("expected 7 stages, got %+v", spec.Stages)
-	}
-	if len(spec.Stages[1].FileUpdates) != 3 {
-		t.Fatalf("expected chart, formula, and scoop updates, got %+v", spec.Stages[1].FileUpdates)
-	}
-	if got := spec.Stages[1].GitCommands[0].Args; !reflect.DeepEqual(got, []string{
+	requireStablePackagingReleaseSpec(t, spec)
+}
+
+func requireStablePackagingReleaseSpec(t *testing.T, spec ReleaseSpec) {
+	t.Helper()
+	requireEqual(t, len(spec.Stages), 7, "stage count")
+	requireEqual(t, len(spec.Stages[1].FileUpdates), 3, "release file update count")
+	requireDeepEqual(t, spec.Stages[1].GitCommands[0].Args, []string{
 		"add",
 		filepath.Join("erun-devops", "k8s", "api", "Chart.yaml"),
 		filepath.Join("Formula", "erun.rb"),
 		filepath.Join("bucket", "erun.json"),
-	}) {
-		t.Fatalf("unexpected release add command: %+v", got)
-	}
-	if formula := spec.Stages[1].FileUpdates[1].Content; !strings.Contains(formula, `url "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.tar.gz"`) {
-		t.Fatalf("unexpected formula update: %s", formula)
-	}
-	if scoop := spec.Stages[1].FileUpdates[2].Content; !strings.Contains(scoop, `"version": "1.4.2"`) || !strings.Contains(scoop, `"extract_dir": "erun-1.4.2"`) {
-		t.Fatalf("unexpected scoop update: %s", scoop)
-	}
-	if spec.Stages[2].Name != "push-release-tag" {
-		t.Fatalf("unexpected tag push stage: %+v", spec.Stages[2])
-	}
-	if got := spec.Stages[2].GitCommands[0].Args; !reflect.DeepEqual(got, []string{"push", "origin", "v1.4.2"}) {
-		t.Fatalf("unexpected tag push command: %+v", got)
-	}
-	if spec.Stages[3].Name != "sync-packaging-checksums" || spec.Stages[3].PackagingSync == nil {
-		t.Fatalf("unexpected packaging sync stage: %+v", spec.Stages[3])
-	}
-	if got := spec.Stages[3].GitCommands[0].Args; !reflect.DeepEqual(got, []string{
+	}, "unexpected release add command")
+	requireStringContains(t, spec.Stages[1].FileUpdates[1].Content, `url "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.tar.gz"`, "unexpected formula update")
+	requireStringContains(t, spec.Stages[1].FileUpdates[2].Content, `"version": "1.4.2"`, "unexpected scoop version update")
+	requireStringContains(t, spec.Stages[1].FileUpdates[2].Content, `"extract_dir": "erun-1.4.2"`, "unexpected scoop extract dir update")
+	requireEqual(t, spec.Stages[2].Name, "push-release-tag", "unexpected tag push stage")
+	requireDeepEqual(t, spec.Stages[2].GitCommands[0].Args, []string{"push", "origin", "v1.4.2"}, "unexpected tag push command")
+	requireCondition(t, spec.Stages[3].Name == "sync-packaging-checksums" && spec.Stages[3].PackagingSync != nil, "unexpected packaging sync stage: %+v", spec.Stages[3])
+	requireDeepEqual(t, spec.Stages[3].GitCommands[0].Args, []string{
 		"add",
 		filepath.Join("Formula", "erun.rb"),
 		filepath.Join("bucket", "erun.json"),
-	}) {
-		t.Fatalf("unexpected packaging add command: %+v", got)
-	}
-	if got := spec.Stages[3].GitCommands[1].Args; !reflect.DeepEqual(got, []string{"commit", "-m", "[skip ci] sync package metadata 1.4.2"}) {
-		t.Fatalf("unexpected packaging commit command: %+v", got)
-	}
+	}, "unexpected packaging add command")
+	requireDeepEqual(t, spec.Stages[3].GitCommands[1].Args, []string{"commit", "-m", "[skip ci] sync package metadata 1.4.2"}, "unexpected packaging commit command")
 }
 
 func TestResolveReleaseSpecUsesConfiguredBranches(t *testing.T) {
@@ -292,7 +256,7 @@ func TestRunReleaseSpecRewritesStablePackagingMetadataWhenPresent(t *testing.T) 
 		Stdout: new(bytes.Buffer),
 		Stderr: new(bytes.Buffer),
 	}
-	if err := runReleaseSpec(ctx, spec, func(dir string, stdout, stderr io.Writer, args ...string) error {
+	err = runReleaseSpec(ctx, spec, func(dir string, stdout, stderr io.Writer, args ...string) error {
 		gitCalls = append(gitCalls, append([]string{dir}, args...))
 		return nil
 	}, nil, func(Context, ReleasePackagingSyncSpec) ([]ReleaseFileUpdate, error) {
@@ -334,51 +298,39 @@ end
 `,
 			},
 		}, nil
-	}); err != nil {
-		t.Fatalf("RunReleaseSpec failed: %v", err)
-	}
+	})
+	requireNoError(t, err, "RunReleaseSpec failed")
 
 	formulaData, err := os.ReadFile(filepath.Join(projectRoot, "Formula", "erun.rb"))
-	if err != nil {
-		t.Fatalf("read formula: %v", err)
-	}
-	if !strings.Contains(string(formulaData), `url "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.tar.gz"`) || !strings.Contains(string(formulaData), `sha256 "formula-checksum"`) {
-		t.Fatalf("unexpected formula content: %s", formulaData)
-	}
+	requireNoError(t, err, "read formula")
+	requireBytesContains(t, formulaData, `url "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.tar.gz"`, "unexpected formula URL")
+	requireBytesContains(t, formulaData, `sha256 "formula-checksum"`, "unexpected formula checksum")
 
 	scoopData, err := os.ReadFile(filepath.Join(projectRoot, "bucket", "erun.json"))
-	if err != nil {
-		t.Fatalf("read scoop manifest: %v", err)
-	}
+	requireNoError(t, err, "read scoop manifest")
 	scoop := string(scoopData)
-	if !strings.Contains(scoop, `"version": "1.4.2"`) || !strings.Contains(scoop, `"url": "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.zip"`) || !strings.Contains(scoop, `"extract_dir": "erun-1.4.2"`) || !strings.Contains(scoop, `"hash": "scoop-checksum"`) {
-		t.Fatalf("unexpected scoop content: %s", scoop)
-	}
+	requireStablePackagingFiles(t, scoop)
+	requireStablePackagingGitCalls(t, gitCalls, projectRoot)
+}
 
-	if got := gitCalls[5]; !reflect.DeepEqual(got, []string{
-		projectRoot,
-		"push",
-		"origin",
-		"v1.4.2",
-	}) {
-		t.Fatalf("unexpected tag push call: %+v", got)
-	}
-	if got := gitCalls[6]; !reflect.DeepEqual(got, []string{
+func requireStablePackagingFiles(t *testing.T, scoop string) {
+	t.Helper()
+	requireStringContains(t, scoop, `"version": "1.4.2"`, "unexpected scoop version")
+	requireStringContains(t, scoop, `"url": "https://github.com/sophium/erun/archive/refs/tags/v1.4.2.zip"`, "unexpected scoop URL")
+	requireStringContains(t, scoop, `"extract_dir": "erun-1.4.2"`, "unexpected scoop extract dir")
+	requireStringContains(t, scoop, `"hash": "scoop-checksum"`, "unexpected scoop checksum")
+}
+
+func requireStablePackagingGitCalls(t *testing.T, gitCalls [][]string, projectRoot string) {
+	t.Helper()
+	requireDeepEqual(t, gitCalls[5], []string{projectRoot, "push", "origin", "v1.4.2"}, "unexpected tag push call")
+	requireDeepEqual(t, gitCalls[6], []string{
 		projectRoot,
 		"add",
 		filepath.Join("Formula", "erun.rb"),
 		filepath.Join("bucket", "erun.json"),
-	}) {
-		t.Fatalf("unexpected packaging add call: %+v", got)
-	}
-	if got := gitCalls[7]; !reflect.DeepEqual(got, []string{
-		projectRoot,
-		"commit",
-		"-m",
-		"[skip ci] sync package metadata 1.4.2",
-	}) {
-		t.Fatalf("unexpected packaging commit call: %+v", got)
-	}
+	}, "unexpected packaging add call")
+	requireDeepEqual(t, gitCalls[7], []string{projectRoot, "commit", "-m", "[skip ci] sync package metadata 1.4.2"}, "unexpected packaging commit call")
 }
 
 func TestRunReleaseSpecSkipsPackagingCommitWhenChecksumsAreAlreadyCurrent(t *testing.T) {
@@ -884,63 +836,57 @@ func setupReleaseProject(t *testing.T, options releaseProjectOptions) string {
 
 	projectRoot := t.TempDir()
 	releaseRoot := filepath.Join(projectRoot, "erun-devops")
-	if err := os.MkdirAll(releaseRoot, 0o755); err != nil {
-		t.Fatalf("mkdir release root: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(releaseRoot, "VERSION"), []byte("1.4.2\n"), 0o644); err != nil {
-		t.Fatalf("write VERSION: %v", err)
-	}
-
-	chartPath := filepath.Join(releaseRoot, "k8s", "api")
-	if err := os.MkdirAll(chartPath, 0o755); err != nil {
-		t.Fatalf("mkdir chart path: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: api\nversion: 0.1.0\nappVersion: 0.1.0\n"), 0o644); err != nil {
-		t.Fatalf("write Chart.yaml: %v", err)
-	}
-
-	dockerPath := filepath.Join(releaseRoot, "docker", "api")
-	if err := os.MkdirAll(dockerPath, 0o755); err != nil {
-		t.Fatalf("mkdir docker path: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dockerPath, "Dockerfile"), []byte("FROM alpine:3.22\n"), 0o644); err != nil {
-		t.Fatalf("write Dockerfile: %v", err)
-	}
-	otherDockerPath := filepath.Join(releaseRoot, "docker", "base")
-	if err := os.MkdirAll(otherDockerPath, 0o755); err != nil {
-		t.Fatalf("mkdir other docker path: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(otherDockerPath, "Dockerfile"), []byte("FROM alpine:3.22\n"), 0o644); err != nil {
-		t.Fatalf("write other Dockerfile: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(otherDockerPath, "VERSION"), []byte("9.9.9\n"), 0o644); err != nil {
-		t.Fatalf("write other VERSION: %v", err)
-	}
-
-	if err := SaveProjectConfig(projectRoot, options.ProjectConfig); err != nil {
-		t.Fatalf("SaveProjectConfig failed: %v", err)
-	}
+	writeReleaseProjectScaffold(t, releaseRoot)
+	requireNoError(t, SaveProjectConfig(projectRoot, options.ProjectConfig), "SaveProjectConfig failed")
 	if options.WithPackaging {
-		formulaPath := filepath.Join(projectRoot, "Formula")
-		if err := os.MkdirAll(formulaPath, 0o755); err != nil {
-			t.Fatalf("mkdir Formula: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(formulaPath, "erun.rb"), []byte(`class Erun < Formula
+		writeReleasePackagingScaffold(t, projectRoot)
+	}
+
+	return projectRoot
+}
+
+func writeReleaseProjectScaffold(t *testing.T, releaseRoot string) {
+	t.Helper()
+	requireNoError(t, os.MkdirAll(releaseRoot, 0o755), "mkdir release root")
+	requireNoError(t, os.WriteFile(filepath.Join(releaseRoot, "VERSION"), []byte("1.4.2\n"), 0o644), "write VERSION")
+	writeReleaseChartScaffold(t, releaseRoot)
+	writeReleaseDockerScaffold(t, releaseRoot)
+}
+
+func writeReleaseChartScaffold(t *testing.T, releaseRoot string) {
+	t.Helper()
+	chartPath := filepath.Join(releaseRoot, "k8s", "api")
+	requireNoError(t, os.MkdirAll(chartPath, 0o755), "mkdir chart path")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: api\nversion: 0.1.0\nappVersion: 0.1.0\n"), 0o644), "write Chart.yaml")
+}
+
+func writeReleaseDockerScaffold(t *testing.T, releaseRoot string) {
+	t.Helper()
+	dockerPath := filepath.Join(releaseRoot, "docker", "api")
+	requireNoError(t, os.MkdirAll(dockerPath, 0o755), "mkdir docker path")
+	requireNoError(t, os.WriteFile(filepath.Join(dockerPath, "Dockerfile"), []byte("FROM alpine:3.22\n"), 0o644), "write Dockerfile")
+	otherDockerPath := filepath.Join(releaseRoot, "docker", "base")
+	requireNoError(t, os.MkdirAll(otherDockerPath, 0o755), "mkdir other docker path")
+	requireNoError(t, os.WriteFile(filepath.Join(otherDockerPath, "Dockerfile"), []byte("FROM alpine:3.22\n"), 0o644), "write other Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(otherDockerPath, "VERSION"), []byte("9.9.9\n"), 0o644), "write other VERSION")
+}
+
+func writeReleasePackagingScaffold(t *testing.T, projectRoot string) {
+	t.Helper()
+	formulaPath := filepath.Join(projectRoot, "Formula")
+	requireNoError(t, os.MkdirAll(formulaPath, 0o755), "mkdir Formula")
+	requireNoError(t, os.WriteFile(filepath.Join(formulaPath, "erun.rb"), []byte(`class Erun < Formula
   desc "Multi-tenant multi-environment deployment and management tool"
   homepage "https://github.com/sophium/erun"
   url "https://github.com/sophium/erun/archive/refs/tags/v1.4.1.tar.gz"
   sha256 "unchanged"
   license "MIT"
 end
-`), 0o644); err != nil {
-			t.Fatalf("write formula: %v", err)
-		}
+`), 0o644), "write formula")
 
-		bucketPath := filepath.Join(projectRoot, "bucket")
-		if err := os.MkdirAll(bucketPath, 0o755); err != nil {
-			t.Fatalf("mkdir bucket: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(bucketPath, "erun.json"), []byte(`{
+	bucketPath := filepath.Join(projectRoot, "bucket")
+	requireNoError(t, os.MkdirAll(bucketPath, 0o755), "mkdir bucket")
+	requireNoError(t, os.WriteFile(filepath.Join(bucketPath, "erun.json"), []byte(`{
   "version": "1.4.1",
   "description": "Multi-tenant multi-environment deployment and management tool",
   "homepage": "https://github.com/sophium/erun",
@@ -961,12 +907,7 @@ end
     "emcp.exe"
   ]
 }
-`), 0o644); err != nil {
-			t.Fatalf("write scoop manifest: %v", err)
-		}
-	}
-
-	return projectRoot
+`), 0o644), "write scoop manifest")
 }
 
 func setupReleaseProjectGitRepoWithOptions(t *testing.T, branch string, options releaseProjectOptions) string {

--- a/erun-mcp/.golangci.yml
+++ b/erun-mcp/.golangci.yml
@@ -1,4 +1,4 @@
-version: 2
+version: "2"
 
 run:
   timeout: 3m
@@ -10,11 +10,20 @@ linters:
     - ineffassign
     - staticcheck
     - unused
+    - funlen
+    - gocyclo
+    - cyclop
+  settings:
+    funlen:
+      lines: 100
+      statements: 50
+    gocyclo:
+      min-complexity: 15
+    cyclop:
+      max-complexity: 10
 formatters:
   enable:
     - gofumpt
-formatters-settings:
-  gofumpt:
-    module-path: github.com/sophium/erun/erun-mcp
-issues:
-  exclude-use-default: false
+  settings:
+    gofumpt:
+      module-path: github.com/sophium/erun/erun-mcp

--- a/erun-mcp/doctor.go
+++ b/erun-mcp/doctor.go
@@ -22,59 +22,73 @@ type DoctorInput struct {
 func doctorTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, DoctorInput) (*mcp.CallToolResult, CommandOutput, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input DoctorInput) (*mcp.CallToolResult, CommandOutput, error) {
 		output, err := runRuntimeCommand(runtime, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, _ string) error {
-			target, err := resolveDoctorOpenResult(runtime, input)
-			if err != nil {
-				return err
-			}
-			req := eruncommon.ShellLaunchParamsFromResult(target)
-			inspection, err := eruncommon.RunDoctorInspection(runCtx, nil, req)
-			if err != nil {
-				return err
-			}
-			if !runCtx.DryRun {
-				if _, err := fmt.Fprintf(runCtx.Stdout, "Target: %s/%s\n", target.Tenant, target.Environment); err != nil {
-					return err
-				}
-				if stdout := strings.TrimSpace(inspection.Stdout); stdout != "" {
-					if _, err := fmt.Fprintln(runCtx.Stdout, stdout); err != nil {
-						return err
-					}
-				}
-				if stderr := strings.TrimSpace(inspection.Stderr); stderr != "" {
-					if _, err := fmt.Fprintln(runCtx.Stderr, stderr); err != nil {
-						return err
-					}
-				}
-			}
-
-			for _, action := range doctorActionsFromInput(input) {
-				if !runCtx.DryRun {
-					if _, err := fmt.Fprintf(runCtx.Stdout, "Running: %s\n", eruncommon.DoctorActionDescription(action)); err != nil {
-						return err
-					}
-				}
-				output, err := eruncommon.RunDoctorAction(runCtx, nil, req, action)
-				if err != nil {
-					return err
-				}
-				if runCtx.DryRun {
-					continue
-				}
-				if stdout := strings.TrimSpace(output.Stdout); stdout != "" {
-					if _, err := fmt.Fprintln(runCtx.Stdout, stdout); err != nil {
-						return err
-					}
-				}
-				if stderr := strings.TrimSpace(output.Stderr); stderr != "" {
-					if _, err := fmt.Fprintln(runCtx.Stderr, stderr); err != nil {
-						return err
-					}
-				}
-			}
-			return nil
+			return runDoctorToolCommand(runtime, input, runCtx)
 		})
 		return nil, output, err
 	}
+}
+
+func runDoctorToolCommand(runtime RuntimeConfig, input DoctorInput, runCtx eruncommon.Context) error {
+	target, err := resolveDoctorOpenResult(runtime, input)
+	if err != nil {
+		return err
+	}
+	req := eruncommon.ShellLaunchParamsFromResult(target)
+	if err := writeDoctorInspection(runCtx, target, req); err != nil {
+		return err
+	}
+	return runDoctorToolActions(runCtx, input, req)
+}
+
+func writeDoctorInspection(runCtx eruncommon.Context, target eruncommon.OpenResult, req eruncommon.ShellLaunchParams) error {
+	inspection, err := eruncommon.RunDoctorInspection(runCtx, nil, req)
+	if err != nil || runCtx.DryRun {
+		return err
+	}
+	if _, err := fmt.Fprintf(runCtx.Stdout, "Target: %s/%s\n", target.Tenant, target.Environment); err != nil {
+		return err
+	}
+	return writeDoctorOutput(runCtx, inspection.Stdout, inspection.Stderr)
+}
+
+func runDoctorToolActions(runCtx eruncommon.Context, input DoctorInput, req eruncommon.ShellLaunchParams) error {
+	for _, action := range doctorActionsFromInput(input) {
+		if err := writeDoctorAction(runCtx, action); err != nil {
+			return err
+		}
+		output, err := eruncommon.RunDoctorAction(runCtx, nil, req, action)
+		if err != nil {
+			return err
+		}
+		if !runCtx.DryRun {
+			if err := writeDoctorOutput(runCtx, output.Stdout, output.Stderr); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeDoctorAction(runCtx eruncommon.Context, action eruncommon.DoctorAction) error {
+	if runCtx.DryRun {
+		return nil
+	}
+	_, err := fmt.Fprintf(runCtx.Stdout, "Running: %s\n", eruncommon.DoctorActionDescription(action))
+	return err
+}
+
+func writeDoctorOutput(runCtx eruncommon.Context, stdout, stderr string) error {
+	if trimmed := strings.TrimSpace(stdout); trimmed != "" {
+		if _, err := fmt.Fprintln(runCtx.Stdout, trimmed); err != nil {
+			return err
+		}
+	}
+	if trimmed := strings.TrimSpace(stderr); trimmed != "" {
+		if _, err := fmt.Fprintln(runCtx.Stderr, trimmed); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func resolveDoctorOpenResult(runtime RuntimeConfig, input DoctorInput) (eruncommon.OpenResult, error) {

--- a/erun-mcp/runtime.go
+++ b/erun-mcp/runtime.go
@@ -2,7 +2,6 @@ package erunmcp
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -153,40 +152,6 @@ func runRuntimeCommand(runtime RuntimeConfig, preview bool, verbosity int, run f
 		return run(runCtx, workDir)
 	})
 	return output, err
-}
-
-func resolveRuntimeOpenResult(runtime RuntimeConfig) (eruncommon.OpenResult, error) {
-	tenant := strings.TrimSpace(runtime.Context.Tenant)
-	environment := strings.TrimSpace(runtime.Context.Environment)
-	if tenant == "" || environment == "" {
-		return eruncommon.OpenResult{}, fmt.Errorf("server context is not configured; start emcp through `erun mcp [tenant] [environment]` or pass context flags")
-	}
-
-	repoPath := strings.TrimSpace(runtime.Context.RepoPath)
-	kubernetesContext := strings.TrimSpace(runtime.Context.KubernetesContext)
-	if repoPath != "" && kubernetesContext != "" {
-		return eruncommon.OpenResult{
-			Tenant:      tenant,
-			Environment: environment,
-			TenantConfig: eruncommon.TenantConfig{
-				Name:               tenant,
-				ProjectRoot:        repoPath,
-				DefaultEnvironment: environment,
-			},
-			EnvConfig: eruncommon.EnvConfig{
-				Name:              environment,
-				RepoPath:          repoPath,
-				KubernetesContext: kubernetesContext,
-			},
-			RepoPath: repoPath,
-			Title:    tenant + "-" + environment,
-		}, nil
-	}
-
-	return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{
-		Tenant:      tenant,
-		Environment: environment,
-	})
 }
 
 func runtimeFindProjectRoot(runtime RuntimeContext, workDir string) (string, string, error) {

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -281,6 +281,12 @@ func TestDiffToolReturnsStructuredGitDiff(t *testing.T) {
 		t.Fatalf("diffTool failed: %v", err)
 	}
 
+	assertStructuredDiffOutput(t, output, projectRoot)
+}
+
+func assertStructuredDiffOutput(t *testing.T, output eruncommon.DiffResult, projectRoot string) {
+	t.Helper()
+
 	if output.WorkingDirectory != projectRoot || output.RawDiff == "" {
 		t.Fatalf("unexpected output: %+v", output)
 	}
@@ -334,23 +340,35 @@ func TestListToolReturnsConfiguredTenantsAndEffectiveTarget(t *testing.T) {
 		t.Fatalf("listTool failed: %v", err)
 	}
 
+	assertListToolOutput(t, output)
+}
+
+func assertListToolOutput(t *testing.T, output eruncommon.ListResult) {
+	t.Helper()
+
 	if output.Defaults.Tenant != "tenant-a" || output.Defaults.Environment != "dev" {
 		t.Fatalf("unexpected defaults: %+v", output.Defaults)
 	}
 	if output.CurrentDirectory.Effective == nil {
 		t.Fatalf("expected effective target, got %+v", output.CurrentDirectory)
 	}
-	if output.CurrentDirectory.Effective.Tenant != "tenant-a" || output.CurrentDirectory.Effective.Environment != "dev" {
-		t.Fatalf("unexpected effective target: %+v", output.CurrentDirectory.Effective)
-	}
-	if output.CurrentDirectory.Effective.LocalPorts.RangeStart != 17000 || output.CurrentDirectory.Effective.LocalPorts.SSH != 17022 {
-		t.Fatalf("unexpected effective local ports: %+v", output.CurrentDirectory.Effective.LocalPorts)
-	}
+	assertListEffectiveTarget(t, *output.CurrentDirectory.Effective)
 	if len(output.Tenants) != 1 || output.Tenants[0].Name != "tenant-a" {
 		t.Fatalf("unexpected tenants: %+v", output.Tenants)
 	}
 	if output.Tenants[0].Environments[0].LocalPorts.RangeEnd != 17099 {
 		t.Fatalf("unexpected environment local ports: %+v", output.Tenants[0].Environments[0].LocalPorts)
+	}
+}
+
+func assertListEffectiveTarget(t *testing.T, target eruncommon.ListEffectiveTargetResult) {
+	t.Helper()
+
+	if target.Tenant != "tenant-a" || target.Environment != "dev" {
+		t.Fatalf("unexpected effective target: %+v", target)
+	}
+	if target.LocalPorts.RangeStart != 17000 || target.LocalPorts.SSH != 17022 {
+		t.Fatalf("unexpected effective local ports: %+v", target.LocalPorts)
 	}
 }
 
@@ -532,24 +550,32 @@ func TestBuildToolPreviewReleaseIncludesReleaseAndBuildTrace(t *testing.T) {
 	if !strings.Contains(output.Trace[0], "release: branch=develop mode=candidate version=1.4.2-rc.") {
 		t.Fatalf("unexpected release trace: %+v", output.Trace)
 	}
-	foundBuildTrace := false
-	foundVersionReport := false
-	for _, trace := range output.Trace {
+	if !hasReleaseBuildTrace(output.Trace) {
+		t.Fatalf("unexpected build trace: %+v", output.Trace)
+	}
+	if !hasReleaseVersionReport(output.Trace) {
+		t.Fatalf("expected final release version output, got %+v", output.Trace)
+	}
+}
+
+func hasReleaseBuildTrace(traces []string) bool {
+	for _, trace := range traces {
 		if strings.Contains(trace, "docker buildx build --builder erun-multiarch --platform 'linux/amd64,linux/arm64'") &&
 			strings.Contains(trace, "-t erunpaas/api:1.4.2-rc.") &&
 			strings.Contains(trace, "--push") {
-			foundBuildTrace = true
+			return true
 		}
+	}
+	return false
+}
+
+func hasReleaseVersionReport(traces []string) bool {
+	for _, trace := range traces {
 		if strings.Contains(trace, "release version: 1.4.2-rc.") {
-			foundVersionReport = true
+			return true
 		}
 	}
-	if !foundBuildTrace {
-		t.Fatalf("unexpected build trace: %+v", output.Trace)
-	}
-	if !foundVersionReport {
-		t.Fatalf("expected final release version output, got %+v", output.Trace)
-	}
+	return false
 }
 
 func TestBuildToolPreviewAtRepoRootIncludesBuildTrace(t *testing.T) {

--- a/erun-ui/.golangci.yml
+++ b/erun-ui/.golangci.yml
@@ -4,6 +4,9 @@ run:
   timeout: 3m
   tests: true
 linters:
+  exclusions:
+    paths:
+      - ^frontend/node_modules/
   enable:
     - errcheck
     - govet
@@ -26,4 +29,4 @@ formatters:
     - gofumpt
   settings:
     gofumpt:
-      module-path: github.com/sophium/erun/erun-common
+      module-path: github.com/sophium/erun/erun-ui

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -244,6 +244,18 @@ type pastedImageResult struct {
 }
 
 func NewApp(deps erunUIDeps) *App {
+	deps = withDefaultCoreDeps(deps)
+	deps = withDefaultRuntimeDeps(deps)
+	deps = withDefaultUIDeps(deps)
+	return &App{
+		deps:      deps,
+		sessions:  make(map[string]*managedTerminal),
+		idleStops: make(map[string]struct{}),
+		busyEnvs:  make(map[string]int),
+	}
+}
+
+func withDefaultCoreDeps(deps erunUIDeps) erunUIDeps {
 	if deps.store == nil {
 		deps.store = eruncommon.ConfigStore{}
 	}
@@ -264,6 +276,10 @@ func NewApp(deps erunUIDeps) *App {
 	if deps.deleteNamespace == nil {
 		deps.deleteNamespace = eruncommon.DeleteKubernetesNamespace
 	}
+	return deps
+}
+
+func withDefaultRuntimeDeps(deps erunUIDeps) erunUIDeps {
 	if deps.listKubeContexts == nil {
 		deps.listKubeContexts = listKubernetesContexts
 	}
@@ -284,6 +300,10 @@ func NewApp(deps erunUIDeps) *App {
 	if deps.runIDECommand == nil {
 		deps.runIDECommand = runIDECommand
 	}
+	return deps
+}
+
+func withDefaultUIDeps(deps erunUIDeps) erunUIDeps {
 	if deps.savePastedImage == nil {
 		deps.savePastedImage = savePastedImageToRuntime
 	}
@@ -307,12 +327,7 @@ func NewApp(deps erunUIDeps) *App {
 	if deps.windowMaximised == nil {
 		deps.windowMaximised = runtime.WindowIsMaximised
 	}
-	return &App{
-		deps:      deps,
-		sessions:  make(map[string]*managedTerminal),
-		idleStops: make(map[string]struct{}),
-		busyEnvs:  make(map[string]int),
-	}
+	return deps
 }
 
 func (a *App) startup(ctx context.Context) {
@@ -580,35 +595,12 @@ func (a *App) SaveEnvironmentConfig(selection uiSelection, config uiEnvironmentC
 	if err != nil {
 		return uiEnvironmentConfig{}, err
 	}
-	updated := environmentConfigFromUI(config, existing)
-	if _, err := updated.Idle.Resolve(); err != nil {
+	updated, err := a.updatedEnvironmentConfig(config, existing)
+	if err != nil {
 		return uiEnvironmentConfig{}, err
 	}
-	if updated.Remote && strings.TrimSpace(updated.CloudProviderAlias) != "" {
-		if _, ok, err := a.linkedCloudContext(updated); err != nil {
-			return uiEnvironmentConfig{}, err
-		} else if ok {
-			updated.ManagedCloud = true
-		}
-	}
-	if existing.Remote && strings.TrimSpace(updated.CloudProviderAlias) != strings.TrimSpace(existing.CloudProviderAlias) {
-		result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
-			Tenant:      selection.Tenant,
-			Environment: selection.Environment,
-		})
-		if err != nil {
-			return uiEnvironmentConfig{}, err
-		}
-		ctx := a.ctx
-		if ctx == nil {
-			ctx = context.Background()
-		}
-		if err := a.ensureMCPAvailable(ctx, result); err != nil {
-			return uiEnvironmentConfig{}, err
-		}
-		if _, err := a.deps.setRemoteCloudAlias(ctx, mcpEndpointForOpenResult(result), selection.Tenant, selection.Environment, updated.CloudProviderAlias); err != nil {
-			return uiEnvironmentConfig{}, err
-		}
+	if err := a.saveRemoteCloudAlias(selection, existing, updated); err != nil {
+		return uiEnvironmentConfig{}, err
 	}
 	if err := a.deps.store.SaveEnvConfig(selection.Tenant, updated); err != nil {
 		return uiEnvironmentConfig{}, err
@@ -618,6 +610,43 @@ func (a *App) SaveEnvironmentConfig(selection uiSelection, config uiEnvironmentC
 		return uiEnvironmentConfig{}, err
 	}
 	return a.environmentConfigToUI(updated, selection.Environment, ports)
+}
+
+func (a *App) updatedEnvironmentConfig(config uiEnvironmentConfig, existing eruncommon.EnvConfig) (eruncommon.EnvConfig, error) {
+	updated := environmentConfigFromUI(config, existing)
+	if _, err := updated.Idle.Resolve(); err != nil {
+		return eruncommon.EnvConfig{}, err
+	}
+	if updated.Remote && strings.TrimSpace(updated.CloudProviderAlias) != "" {
+		if _, ok, err := a.linkedCloudContext(updated); err != nil {
+			return eruncommon.EnvConfig{}, err
+		} else if ok {
+			updated.ManagedCloud = true
+		}
+	}
+	return updated, nil
+}
+
+func (a *App) saveRemoteCloudAlias(selection uiSelection, existing, updated eruncommon.EnvConfig) error {
+	if !existing.Remote || strings.TrimSpace(updated.CloudProviderAlias) == strings.TrimSpace(existing.CloudProviderAlias) {
+		return nil
+	}
+	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
+		Tenant:      selection.Tenant,
+		Environment: selection.Environment,
+	})
+	if err != nil {
+		return err
+	}
+	ctx := a.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := a.ensureMCPAvailable(ctx, result); err != nil {
+		return err
+	}
+	_, err = a.deps.setRemoteCloudAlias(ctx, mcpEndpointForOpenResult(result), selection.Tenant, selection.Environment, updated.CloudProviderAlias)
+	return err
 }
 
 func labelRuntimeVersionSuggestions(source, image string, suggestions []uiVersion) []uiVersion {

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -127,31 +127,8 @@ func TestLoadStateUsesTenantSpecificDeployableVersionSuggestions(t *testing.T) {
 
 func TestLoadVersionSuggestionsFiltersOutMissingTenantImageTags(t *testing.T) {
 	app := NewApp(erunUIDeps{
-		resolveBuildInfo: func() eruncommon.BuildInfo { return eruncommon.BuildInfo{Version: "1.0.50"} },
-		resolveImageRegistry: func(_ context.Context, namespace, repository string) (eruncommon.RuntimeRegistryVersions, error) {
-			if namespace != eruncommon.DefaultContainerRegistry {
-				t.Fatalf("unexpected registry namespace: %s", namespace)
-			}
-			switch repository {
-			case "frs-devops":
-				return eruncommon.RuntimeRegistryVersions{
-					Image:          namespace + "/" + repository,
-					Tags:           []string{"1.0.11", "1.0.10", "1.0.12-snapshot-20260414165809"},
-					LatestStable:   "1.0.11",
-					LatestSnapshot: "1.0.12-snapshot-20260414165809",
-				}, nil
-			case eruncommon.DefaultRuntimeImageName:
-				return eruncommon.RuntimeRegistryVersions{
-					Image:          namespace + "/" + repository,
-					Tags:           []string{"1.0.50", "1.0.49"},
-					LatestStable:   "1.0.50",
-					LatestSnapshot: "",
-				}, nil
-			default:
-				t.Fatalf("unexpected registry repository: %s", repository)
-			}
-			return eruncommon.RuntimeRegistryVersions{}, nil
-		},
+		resolveBuildInfo:     func() eruncommon.BuildInfo { return eruncommon.BuildInfo{Version: "1.0.50"} },
+		resolveImageRegistry: missingTenantImageRegistry(t),
 	})
 
 	suggestions, err := app.LoadVersionSuggestions(uiSelection{Tenant: " frs "})
@@ -165,6 +142,33 @@ func TestLoadVersionSuggestionsFiltersOutMissingTenantImageTags(t *testing.T) {
 	}
 	if suggestions[0].Label != "frs latest stable" || suggestions[0].Image != "frs-devops" || suggestions[3].Label != "ERun current" || suggestions[3].Image != eruncommon.DefaultRuntimeImageName {
 		t.Fatalf("unexpected suggestion metadata: %+v", suggestions)
+	}
+}
+
+func missingTenantImageRegistry(t *testing.T) func(context.Context, string, string) (eruncommon.RuntimeRegistryVersions, error) {
+	t.Helper()
+
+	return func(_ context.Context, namespace, repository string) (eruncommon.RuntimeRegistryVersions, error) {
+		if namespace != eruncommon.DefaultContainerRegistry {
+			t.Fatalf("unexpected registry namespace: %s", namespace)
+		}
+		if repository == "frs-devops" {
+			return eruncommon.RuntimeRegistryVersions{
+				Image:          namespace + "/" + repository,
+				Tags:           []string{"1.0.11", "1.0.10", "1.0.12-snapshot-20260414165809"},
+				LatestStable:   "1.0.11",
+				LatestSnapshot: "1.0.12-snapshot-20260414165809",
+			}, nil
+		}
+		if repository == eruncommon.DefaultRuntimeImageName {
+			return eruncommon.RuntimeRegistryVersions{
+				Image:        namespace + "/" + repository,
+				Tags:         []string{"1.0.50", "1.0.49"},
+				LatestStable: "1.0.50",
+			}, nil
+		}
+		t.Fatalf("unexpected registry repository: %s", repository)
+		return eruncommon.RuntimeRegistryVersions{}, nil
 	}
 }
 
@@ -1097,6 +1101,12 @@ func TestDeleteEnvironmentRequiresExactConfirmationAndDeletesConfig(t *testing.T
 	if err != nil {
 		t.Fatalf("DeleteEnvironment failed: %v", err)
 	}
+	assertDeletedEnvironment(t, store, result, deletedContext, deletedNamespace)
+}
+
+func assertDeletedEnvironment(t *testing.T, store stubUIStore, result deleteEnvironmentResult, deletedContext, deletedNamespace string) {
+	t.Helper()
+
 	if deletedContext != "cluster-prod" || deletedNamespace != "frs-prod" {
 		t.Fatalf("unexpected namespace deletion: context=%q namespace=%q", deletedContext, deletedNamespace)
 	}
@@ -1227,15 +1237,7 @@ func TestLoadAndSaveEnvironmentConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEnvironmentConfig failed: %v", err)
 	}
-	if loaded.Name != "prod" || loaded.RepoPath != projectRoot || loaded.KubernetesContext != "cluster-old" {
-		t.Fatalf("unexpected loaded config: %+v", loaded)
-	}
-	if loaded.CloudContext == nil || loaded.CloudContext.Name != "team-context" || loaded.CloudContext.Status != eruncommon.CloudContextStatusStopped {
-		t.Fatalf("expected linked cloud context, got %+v", loaded.CloudContext)
-	}
-	if loaded.LocalPorts.RangeStart != 17000 || loaded.LocalPorts.RangeEnd != 17099 || loaded.LocalPorts.MCP != 17000 || loaded.LocalPorts.SSH != 60022 {
-		t.Fatalf("unexpected loaded local ports: %+v", loaded.LocalPorts)
-	}
+	assertLoadedEnvironmentConfig(t, loaded, projectRoot)
 
 	saved, err := app.SaveEnvironmentConfig(uiSelection{Tenant: "frs", Environment: "prod"}, uiEnvironmentConfig{
 		Name:               "prod",
@@ -1255,13 +1257,43 @@ func TestLoadAndSaveEnvironmentConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SaveEnvironmentConfig failed: %v", err)
 	}
+	assertSavedEnvironmentConfig(t, saved, projectRoot)
+	stored := store.envs["frs/prod"]
+	assertStoredEnvironmentConfig(t, stored, projectRoot)
+}
+
+func assertLoadedEnvironmentConfig(t *testing.T, loaded uiEnvironmentConfig, projectRoot string) {
+	t.Helper()
+
+	if loaded.Name != "prod" || loaded.RepoPath != projectRoot || loaded.KubernetesContext != "cluster-old" {
+		t.Fatalf("unexpected loaded config: %+v", loaded)
+	}
+	if loaded.CloudContext == nil || loaded.CloudContext.Name != "team-context" || loaded.CloudContext.Status != eruncommon.CloudContextStatusStopped {
+		t.Fatalf("expected linked cloud context, got %+v", loaded.CloudContext)
+	}
+	assertLocalPorts(t, loaded.LocalPorts)
+}
+
+func assertSavedEnvironmentConfig(t *testing.T, saved uiEnvironmentConfig, projectRoot string) {
+	t.Helper()
+
 	if saved.RepoPath != projectRoot || saved.KubernetesContext != "cluster-old" || saved.ContainerRegistry != "registry.example/old" || saved.RuntimeVersion != "1.0.0" || saved.CloudProviderAlias != "other-cloud" {
 		t.Fatalf("unexpected saved config: %+v", saved)
 	}
-	if saved.LocalPorts.RangeStart != 17000 || saved.LocalPorts.RangeEnd != 17099 || saved.LocalPorts.MCP != 17000 || saved.LocalPorts.SSH != 60022 {
-		t.Fatalf("unexpected saved local ports: %+v", saved.LocalPorts)
+	assertLocalPorts(t, saved.LocalPorts)
+}
+
+func assertLocalPorts(t *testing.T, ports uiEnvironmentLocalPorts) {
+	t.Helper()
+
+	if ports.RangeStart != 17000 || ports.RangeEnd != 17099 || ports.MCP != 17000 || ports.SSH != 60022 {
+		t.Fatalf("unexpected local ports: %+v", ports)
 	}
-	stored := store.envs["frs/prod"]
+}
+
+func assertStoredEnvironmentConfig(t *testing.T, stored eruncommon.EnvConfig, projectRoot string) {
+	t.Helper()
+
 	if stored.RepoPath != projectRoot || stored.Remote || stored.RuntimeVersion != "1.0.0" || stored.CloudProviderAlias != "other-cloud" || stored.SSHD.Enabled || stored.SSHD.LocalPort != 60022 || stored.SSHD.PublicKeyPath != "/tmp/old.pub" || stored.Snapshot == nil || *stored.Snapshot {
 		t.Fatalf("unexpected stored config: %+v", stored)
 	}
@@ -1818,6 +1850,12 @@ func TestIdleStatusToUIIncludesBlockerDetails(t *testing.T) {
 		},
 	})
 
+	assertIdleStatusBlockers(t, status)
+}
+
+func assertIdleStatusBlockers(t *testing.T, status uiIdleStatus) {
+	t.Helper()
+
 	if status.TimeoutSeconds != 300 || status.SecondsUntilStop != 42 || !status.ManagedCloud || status.StopEligible {
 		t.Fatalf("unexpected idle status: %+v", status)
 	}
@@ -1827,8 +1865,14 @@ func TestIdleStatusToUIIncludesBlockerDetails(t *testing.T) {
 	if status.StopError != "failed to stop instance: access denied" {
 		t.Fatalf("unexpected stop error: %q", status.StopError)
 	}
-	if len(status.Markers) != 2 || status.Markers[0].Name != eruncommon.ActivityKindSSH || status.Markers[0].Reason != "recent activity" || status.Markers[0].SecondsRemaining != 42 {
-		t.Fatalf("unexpected markers: %+v", status.Markers)
+	assertIdleStatusMarkers(t, status.Markers)
+}
+
+func assertIdleStatusMarkers(t *testing.T, markers []uiIdleMarker) {
+	t.Helper()
+
+	if len(markers) != 2 || markers[0].Name != eruncommon.ActivityKindSSH || markers[0].Reason != "recent activity" || markers[0].SecondsRemaining != 42 {
+		t.Fatalf("unexpected markers: %+v", markers)
 	}
 }
 

--- a/erun-ui/frontend/eslint.config.mjs
+++ b/erun-ui/frontend/eslint.config.mjs
@@ -1,0 +1,32 @@
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: ["dist", "node_modules", "wailsjs"],
+  },
+  {
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      sourceType: "module",
+    },
+    rules: {
+      complexity: ["error", { max: 10 }],
+      "max-lines-per-function": [
+        "error",
+        {
+          max: 100,
+          skipBlankLines: true,
+          skipComments: true,
+          IIFEs: true,
+        },
+      ],
+    },
+  },
+);

--- a/erun-ui/frontend/package.json
+++ b/erun-ui/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "lint": "eslint .",
     "preview": "vite preview",
     "shadcn": "shadcn",
     "shadcn:check": "shadcn add button checkbox command dialog input label popover tabs tooltip --overwrite --yes && git diff --exit-code -- src/components/ui src/lib/utils.ts src/styles/theme.css components.json package.json yarn.lock"
@@ -27,10 +28,12 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "eslint": "^10.2.1",
     "shadcn": "4.5.0",
     "tailwindcss": "^4.2.4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.0",
+    "typescript-eslint": "^8.59.1",
     "vite": "^8.0.0"
   }
 }

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -130,6 +130,15 @@ interface DebugOpenFilter {
 
 type DebugSessionMode = 'open' | 'hidden';
 type IDEKind = 'vscode' | 'intellij';
+type HiddenSessionMode = 'sshd-init' | 'doctor';
+type TerminalExitSelections = {
+  initSelection?: UISelection;
+  deploySelection?: UISelection;
+  sshdInitSelection?: UISelection;
+  doctorSelection?: UISelection;
+  openSelection?: UISelection;
+  cloudInit: boolean;
+};
 
 export class ERunUIController {
   readonly state: AppState = {
@@ -275,25 +284,28 @@ export class ERunUIController {
     }
     this.scheduleIdleStatusPoll(0);
 
-    return () => {
-      window.removeEventListener('resize', this.queueTerminalResize);
-      this.resizeObserver?.disconnect();
-      this.terminalDataDisposable?.dispose();
-      this.terminalOutputOff?.();
-      this.terminalExitOff?.();
-      this.appStatusOff?.();
-      window.clearTimeout(this.notificationTimer);
-      window.clearTimeout(this.terminalCopyStatusTimer);
-      window.clearTimeout(this.idleStatusTimer);
-      if (this.pasteHandler && this.terminalRoot) {
-        this.terminalRoot.removeEventListener('paste', this.pasteHandler, true);
-      }
-      this.terminalOutputOff?.();
-      this.terminalExitOff?.();
-      this.terminal?.dispose();
-      this.terminal = null;
-      this.fitAddon = null;
-    };
+    return () => this.unmountTerminal();
+  }
+
+  private unmountTerminal(): void {
+    window.removeEventListener('resize', this.queueTerminalResize);
+    this.resizeObserver?.disconnect();
+    this.terminalDataDisposable?.dispose();
+    this.terminalOutputOff?.();
+    this.terminalExitOff?.();
+    this.appStatusOff?.();
+    window.clearTimeout(this.notificationTimer);
+    window.clearTimeout(this.terminalCopyStatusTimer);
+    window.clearTimeout(this.idleStatusTimer);
+    if (this.pasteHandler && this.terminalRoot) {
+      this.terminalRoot.removeEventListener('paste', this.pasteHandler, true);
+    }
+    this.terminalOutputOff = null;
+    this.terminalExitOff = null;
+    this.appStatusOff = null;
+    this.terminal?.dispose();
+    this.terminal = null;
+    this.fitAddon = null;
   }
 
   toggleSidebar(): void {
@@ -462,47 +474,11 @@ export class ERunUIController {
     const previousSessionId = this.state.sessionId;
     const previousKnownSessionId = this.selectionSessions.get(key) || 0;
 
-    this.state.selected = selection;
-    this.state.idleStatus = null;
-    if (this.state.debugOpen && (previousKnownSessionId === 0 || previousKnownSessionId !== previousSessionId)) {
-      this.state.debugOutput = `$ ${formatDebugCommand(runSelection)}\n`;
-    }
-    this.emit();
-    if (previousKnownSessionId === 0 || previousKnownSessionId !== previousSessionId) {
-      this.state.terminalCopyOutput = '';
-      this.state.terminalCopyStatus = '';
-      this.showTerminalMessage(`Opening ${selection.tenant} / ${selection.environment}...`, true);
-    }
-
+    this.prepareOpenSelection(selection, runSelection, previousSessionId, previousKnownSessionId);
     this.fitAddon?.fit();
     const result = (await StartSession(runSelection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
-    this.selectionSessions.set(key, result.sessionId);
-    this.openSessionSelections.set(result.sessionId, runSelection);
-    this.registerDebugSession(result.sessionId, runSelection, 'open');
-    this.rebuildTerminalDisplayBuffer(result.sessionId);
-    this.state.sessionId = result.sessionId;
-
-    if (result.sessionId !== previousSessionId) {
-      this.resetTerminal();
-      const buffer = this.sessionDisplayBuffers.get(result.sessionId);
-      if (buffer) {
-        this.writeTerminalBuffer(buffer);
-      }
-    }
-
-    const exitReason = this.sessionExitReasons.get(result.sessionId);
-    if (exitReason) {
-      this.state.terminalCopyOutput = this.sessionExitOutputs.get(result.sessionId) || '';
-      this.state.terminalCopyStatus = '';
-      this.showTerminalMessage(exitReason);
-    } else {
-      const buffer = this.sessionDisplayBuffers.get(result.sessionId);
-      if (buffer && buffer.length > 0) {
-        this.hideTerminalMessage();
-      } else {
-        this.showTerminalMessage(`Opening ${selection.tenant} / ${selection.environment}...`, true);
-      }
-    }
+    this.registerOpenSessionResult(key, result, runSelection, previousSessionId);
+    this.showOpenSelectionStatus(result.sessionId, selection);
 
     if (this.state.reviewOpen) {
       await this.loadReviewDiff();
@@ -510,6 +486,50 @@ export class ERunUIController {
     this.focusTerminalSoon();
     this.queueTerminalResize();
     this.emit();
+  }
+
+  private prepareOpenSelection(selection: UISelection, runSelection: UISelection, previousSessionId: number, previousKnownSessionId: number): void {
+    this.state.selected = selection;
+    this.state.idleStatus = null;
+    if (!isNewSessionSelection(previousSessionId, previousKnownSessionId)) {
+      this.emit();
+      return;
+    }
+    if (this.state.debugOpen) {
+      this.state.debugOutput = `$ ${formatDebugCommand(runSelection)}\n`;
+    }
+    this.state.terminalCopyOutput = '';
+    this.state.terminalCopyStatus = '';
+    this.showTerminalMessage(`Opening ${selection.tenant} / ${selection.environment}...`, true);
+    this.emit();
+  }
+
+  private registerOpenSessionResult(key: string, result: StartSessionResult, runSelection: UISelection, previousSessionId: number): void {
+    this.selectionSessions.set(key, result.sessionId);
+    this.openSessionSelections.set(result.sessionId, runSelection);
+    this.registerDebugSession(result.sessionId, runSelection, 'open');
+    this.rebuildTerminalDisplayBuffer(result.sessionId);
+    this.state.sessionId = result.sessionId;
+    if (result.sessionId !== previousSessionId) {
+      this.resetTerminal();
+      this.writeTerminalBuffer(this.sessionDisplayBuffers.get(result.sessionId) || []);
+    }
+  }
+
+  private showOpenSelectionStatus(sessionId: number, selection: UISelection): void {
+    const exitReason = this.sessionExitReasons.get(sessionId);
+    if (exitReason) {
+      this.state.terminalCopyOutput = this.sessionExitOutputs.get(sessionId) || '';
+      this.state.terminalCopyStatus = '';
+      this.showTerminalMessage(exitReason);
+      return;
+    }
+    const buffer = this.sessionDisplayBuffers.get(sessionId) || [];
+    if (buffer.length > 0) {
+      this.hideTerminalMessage();
+      return;
+    }
+    this.showTerminalMessage(`Opening ${selection.tenant} / ${selection.environment}...`, true);
   }
 
   async openIDE(selection: UISelection | null, ide: IDEKind): Promise<void> {
@@ -628,57 +648,19 @@ export class ERunUIController {
     if (dialog.busy) {
       return;
     }
-    const tenant = normalizeDialogValue(dialog.tenant);
-    const environment = normalizeDialogValue(dialog.environment);
-    const version = normalizeDialogValue(dialog.version);
-    const kubernetesContext = normalizeDialogValue(dialog.kubernetesContext);
-    const containerRegistry = normalizeDialogValue(dialog.containerRegistry);
-    const isInit = dialog.actionMode === 'init';
-
-    if (!tenant || !environment || (dialog.actionMode === 'deploy' && !version) || (isInit && (!kubernetesContext || !containerRegistry))) {
+    const selection = this.environmentDialogSelection(dialog);
+    if (!selection) {
       this.state.environmentDialog = { ...dialog, error: '' };
       this.emit();
       form.reportValidity();
       return;
     }
 
-    const selection = {
-      tenant,
-      environment,
-      version,
-      runtimeImage: this.resolveEnvironmentRuntimeImage(version),
-      kubernetesContext: isInit ? kubernetesContext : undefined,
-      containerRegistry: isInit ? containerRegistry : undefined,
-      noGit: dialog.noGit,
-      bootstrap: isInit ? dialog.bootstrap : undefined,
-      setDefaultTenant: isInit ? dialog.setDefaultTenant : undefined,
-    };
-    rememberPastTenant(tenant);
-    rememberPastEnvironment(environment);
-    if (isInit) {
-      rememberPastContainerRegistry(containerRegistry);
-    }
-
-    this.state.environmentDialog = {
-      ...dialog,
-      tenant,
-      environment,
-      version,
-      kubernetesContext,
-      containerRegistry,
-      busy: true,
-      error: '',
-      choicesOpen: false,
-    };
-    this.emit();
-
+    rememberEnvironmentDialogSelection(selection, dialog.actionMode);
+    this.beginEnvironmentDialogSubmit(dialog, selection);
     const previousSelected = this.state.selected;
     try {
-      if (dialog.actionMode === 'deploy') {
-        await this.startDeploySelection(selection);
-      } else {
-        await this.startInitSelection(selection);
-      }
+      await this.startEnvironmentDialogSelection(selection, dialog.actionMode);
       this.state.environmentDialog = defaultEnvironmentDialog();
       this.emit();
       this.focusTerminalSoon();
@@ -692,6 +674,48 @@ export class ERunUIController {
       };
       this.showTerminalMessage(message);
     }
+  }
+
+  private environmentDialogSelection(dialog: EnvironmentDialogState): UISelection | null {
+    const values = normalizedEnvironmentDialogValues(dialog);
+    if (!validEnvironmentDialogValues(values, dialog.actionMode)) {
+      return null;
+    }
+    const isInit = dialog.actionMode === 'init';
+    return {
+      tenant: values.tenant,
+      environment: values.environment,
+      version: values.version,
+      runtimeImage: this.resolveEnvironmentRuntimeImage(values.version),
+      kubernetesContext: isInit ? values.kubernetesContext : undefined,
+      containerRegistry: isInit ? values.containerRegistry : undefined,
+      noGit: dialog.noGit,
+      bootstrap: isInit ? dialog.bootstrap : undefined,
+      setDefaultTenant: isInit ? dialog.setDefaultTenant : undefined,
+    };
+  }
+
+  private beginEnvironmentDialogSubmit(dialog: EnvironmentDialogState, selection: UISelection): void {
+    this.state.environmentDialog = {
+      ...dialog,
+      tenant: selection.tenant,
+      environment: selection.environment,
+      version: selection.version || '',
+      kubernetesContext: selection.kubernetesContext || '',
+      containerRegistry: selection.containerRegistry || '',
+      busy: true,
+      error: '',
+      choicesOpen: false,
+    };
+    this.emit();
+  }
+
+  private async startEnvironmentDialogSelection(selection: UISelection, actionMode: EnvironmentDialogState['actionMode']): Promise<void> {
+    if (actionMode === 'deploy') {
+      await this.startDeploySelection(selection);
+      return;
+    }
+    await this.startInitSelection(selection);
   }
 
   openManageDialog(selection: UISelection): void {
@@ -894,25 +918,24 @@ export class ERunUIController {
   }
 
   async enableManageSSHD(): Promise<void> {
+    await this.startManageHiddenSession('sshd-init', StartSSHDInitSession);
+  }
+
+  async startManageDoctor(): Promise<void> {
+    await this.startManageHiddenSession('doctor', StartDoctorSession);
+  }
+
+  private async startManageHiddenSession(mode: HiddenSessionMode, starter: (selection: UISelection, cols: number, rows: number) => Promise<unknown>): Promise<void> {
     const dialog = this.state.manageDialog;
     const selection = dialog.selection;
     if (dialog.busy || dialog.configLoading || !selection) {
       return;
     }
     const runSelection = { ...selection, debug: this.state.debugOpen || undefined };
-    this.state.selected = selection;
-    this.state.manageDialog = defaultManageDialog();
-    if (this.state.debugOpen) {
-      this.state.debugOutput = `$ ${formatDebugCommand(runSelection, 'sshd-init')}\n`;
-    }
-    this.emit();
-    this.state.terminalCopyOutput = '';
-    this.state.terminalCopyStatus = '';
-    this.showTerminalMessage(`Enabling SSHD for ${selection.tenant} / ${selection.environment}...`, true);
-
+    this.prepareManageHiddenSession(selection, runSelection, mode);
     this.fitAddon?.fit();
-    const result = (await StartSSHDInitSession(runSelection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
-    this.sshdInitSessionSelections.set(result.sessionId, runSelection);
+    const result = (await starter(runSelection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
+    this.trackHiddenSession(mode, result.sessionId, runSelection);
     this.registerDebugSession(result.sessionId, runSelection, 'hidden');
     this.state.sessionId = result.sessionId;
 
@@ -922,33 +945,24 @@ export class ERunUIController {
     this.emit();
   }
 
-  async startManageDoctor(): Promise<void> {
-    const dialog = this.state.manageDialog;
-    const selection = dialog.selection;
-    if (dialog.busy || dialog.configLoading || !selection) {
-      return;
-    }
-    const runSelection = { ...selection, debug: this.state.debugOpen || undefined };
+  private prepareManageHiddenSession(selection: UISelection, runSelection: UISelection, mode: HiddenSessionMode): void {
     this.state.selected = selection;
     this.state.manageDialog = defaultManageDialog();
     if (this.state.debugOpen) {
-      this.state.debugOutput = `$ ${formatDebugCommand(runSelection, 'doctor')}\n`;
+      this.state.debugOutput = `$ ${formatDebugCommand(runSelection, mode)}\n`;
     }
     this.emit();
     this.state.terminalCopyOutput = '';
     this.state.terminalCopyStatus = '';
-    this.showTerminalMessage(`Running doctor for ${selection.tenant} / ${selection.environment}...`, true);
+    this.showTerminalMessage(hiddenSessionBusyMessage(selection, mode), true);
+  }
 
-    this.fitAddon?.fit();
-    const result = (await StartDoctorSession(runSelection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
-    this.doctorSessionSelections.set(result.sessionId, runSelection);
-    this.registerDebugSession(result.sessionId, runSelection, 'hidden');
-    this.state.sessionId = result.sessionId;
-
-    this.resetTerminal();
-    this.focusTerminalSoon();
-    this.queueTerminalResize();
-    this.emit();
+  private trackHiddenSession(mode: HiddenSessionMode, sessionId: number, selection: UISelection): void {
+    if (mode === 'sshd-init') {
+      this.sshdInitSessionSelections.set(sessionId, selection);
+      return;
+    }
+    this.doctorSessionSelections.set(sessionId, selection);
   }
 
   async stopManageCloudContext(name: string): Promise<void> {
@@ -1189,37 +1203,19 @@ export class ERunUIController {
   }
 
   async toggleIdleCloudContext(): Promise<void> {
-    const idleStatus = this.state.idleStatus;
-    const name = normalizeDialogValue(idleStatus?.cloudContextName || '');
-    if (!idleStatus || !idleStatus.managedCloud || !name || this.state.idleCloudContextBusy) {
+    const action = idleCloudContextAction(this.state.idleStatus, this.state.idleCloudContextBusy);
+    if (!action) {
       return;
     }
-    const running = normalizeDialogValue(idleStatus.cloudContextStatus || '').toLowerCase() === 'running';
-    const action = running ? StopCloudContext : StartCloudContext;
-    const label = running ? 'Stopped' : 'Started';
     this.state.idleCloudContextBusy = true;
     this.emit();
     try {
-      const context = (await action(name)) as UICloudContextStatus;
-      this.state.idleStatus = {
-        ...(this.state.idleStatus ?? idleStatus),
-        cloudContextName: context.name,
-        cloudContextStatus: context.status,
-        cloudContextLabel: context.kubernetesContext || context.name,
-      };
-      if (this.state.globalConfigDialog.open) {
-        this.state.globalConfigDialog = {
-          ...this.state.globalConfigDialog,
-          config: {
-            ...this.state.globalConfigDialog.config,
-            cloudContexts: replaceCloudContext(this.state.globalConfigDialog.config.cloudContexts || [], context),
-          },
-        };
-      }
+      const context = (await action.run(action.name)) as UICloudContextStatus;
+      this.applyIdleCloudContextResult(action.idleStatus, context);
       this.state.idleCloudContextBusy = false;
-      this.showNotification('success', `${label} cloud environment ${context.kubernetesContext || context.name}.`);
+      this.showNotification('success', `${action.label} cloud environment ${context.kubernetesContext || context.name}.`);
       this.emit();
-      if (!running) {
+      if (action.refreshKubernetesContexts) {
         void this.refreshKubernetesContexts();
       }
       void this.refreshIdleStatus();
@@ -1230,6 +1226,25 @@ export class ERunUIController {
       this.showTerminalMessage(message);
       this.emit();
     }
+  }
+
+  private applyIdleCloudContextResult(idleStatus: UIIdleStatus, context: UICloudContextStatus): void {
+    this.state.idleStatus = {
+      ...(this.state.idleStatus ?? idleStatus),
+      cloudContextName: context.name,
+      cloudContextStatus: context.status,
+      cloudContextLabel: context.kubernetesContext || context.name,
+    };
+    if (!this.state.globalConfigDialog.open) {
+      return;
+    }
+    this.state.globalConfigDialog = {
+      ...this.state.globalConfigDialog,
+      config: {
+        ...this.state.globalConfigDialog.config,
+        cloudContexts: replaceCloudContext(this.state.globalConfigDialog.config.cloudContexts || [], context),
+      },
+    };
   }
 
   private async updateCloudContextPower(name: string, action: (name: string) => Promise<unknown>, label: string): Promise<void> {
@@ -1727,30 +1742,42 @@ export class ERunUIController {
     const selection = this.state.selected;
     const request = ++this.idleStatusRequest;
     if (!selection) {
-      if (this.state.idleStatus) {
-        this.state.idleStatus = null;
-        this.emit();
-      }
+      this.clearIdleStatus();
       this.scheduleIdleStatusPoll();
       return;
     }
 
     try {
       const status = (await LoadIdleStatus(selection)) as UIIdleStatus;
-      if (request === this.idleStatusRequest && this.state.selected?.tenant === selection.tenant && this.state.selected.environment === selection.environment) {
+      if (this.isCurrentIdleStatusRequest(request, selection)) {
         this.state.idleStatus = status;
         this.emit();
       }
     } catch {
-      if (request === this.idleStatusRequest && this.state.idleStatus) {
-        this.state.idleStatus = null;
-        this.emit();
-      }
+      this.clearCurrentIdleStatusRequest(request);
     } finally {
       if (request === this.idleStatusRequest) {
         this.scheduleIdleStatusPoll();
       }
     }
+  }
+
+  private clearIdleStatus(): void {
+    if (!this.state.idleStatus) {
+      return;
+    }
+    this.state.idleStatus = null;
+    this.emit();
+  }
+
+  private clearCurrentIdleStatusRequest(request: number): void {
+    if (request === this.idleStatusRequest) {
+      this.clearIdleStatus();
+    }
+  }
+
+  private isCurrentIdleStatusRequest(request: number, selection: UISelection): boolean {
+    return request === this.idleStatusRequest && this.state.selected?.tenant === selection.tenant && this.state.selected.environment === selection.environment;
   }
 
   private async boot(): Promise<void> {
@@ -2021,104 +2048,90 @@ export class ERunUIController {
     if (!payload) {
       return;
     }
-    const initSelection = this.initSessionSelections.get(payload.sessionId);
-    const deploySelection = this.deploySessionSelections.get(payload.sessionId);
-    const sshdInitSelection = this.sshdInitSessionSelections.get(payload.sessionId);
-    const doctorSelection = this.doctorSessionSelections.get(payload.sessionId);
-    const openSelection = this.openSessionSelections.get(payload.sessionId);
-    const cloudInit = this.cloudInitSessions.has(payload.sessionId);
-    this.initSessionSelections.delete(payload.sessionId);
-    this.deploySessionSelections.delete(payload.sessionId);
-    this.sshdInitSessionSelections.delete(payload.sessionId);
-    this.doctorSessionSelections.delete(payload.sessionId);
-    this.openSessionSelections.delete(payload.sessionId);
-    if (openSelection) {
-      this.selectionSessions.delete(selectionKey(openSelection));
-    }
-    this.cloudInitSessions.delete(payload.sessionId);
-    this.debugSessionModes.delete(payload.sessionId);
+    const selections = this.takeTerminalExitSelections(payload.sessionId);
+    const reason = this.terminalExitReason(payload, selections);
+    const failedOutput = this.recordTerminalExit(payload, reason, selections);
 
-    const reason = this.terminalExitReason(payload, initSelection, deploySelection, sshdInitSelection, doctorSelection, openSelection, cloudInit);
-    this.sessionExitReasons.set(payload.sessionId, reason);
-    const failedOutput = payload.reason && (initSelection || deploySelection || sshdInitSelection || doctorSelection || openSelection || cloudInit)
-      ? this.failedTerminalOutput(payload.sessionId, reason)
-      : '';
-    if (failedOutput) {
-      this.sessionExitOutputs.set(payload.sessionId, failedOutput);
-    }
-    if (initSelection || deploySelection || sshdInitSelection) {
+    if (selections.initSelection || selections.deploySelection || selections.sshdInitSelection) {
       await this.reloadStateAfterEnvironmentChange();
     }
     if (payload.sessionId !== this.state.sessionId) {
       return;
     }
-    if (sshdInitSelection && !payload.reason) {
-      this.showTerminalMessage(reason);
+    if (await this.handleSuccessfulTerminalExit(payload, reason, selections)) {
       return;
     }
-    const completedSelection = initSelection || deploySelection;
-    if (completedSelection && !payload.reason) {
-      try {
-        await this.openSelection(completedSelection);
-      } catch (error) {
-        this.showTerminalMessage(readError(error));
-      }
-      return;
-    }
-    if (payload.reason && (initSelection || deploySelection || sshdInitSelection || doctorSelection || openSelection || cloudInit)) {
-      const failure = classifiedTerminalFailure(payload.reason, reason, failedOutput, openSelection);
+    if (payload.reason && terminalExitHasTrackedSelection(selections)) {
+      const failure = classifiedTerminalFailure(payload.reason, reason, failedOutput, selections.openSelection);
       this.showTerminalFailure(failure.message, failure.detail, failedOutput, failure.action, failure.retrySelection);
       return;
     }
     this.showTerminalMessage(reason);
   }
 
-  private terminalExitReason(
-    payload: TerminalExitPayload,
-    initSelection?: UISelection,
-    deploySelection?: UISelection,
-    sshdInitSelection?: UISelection,
-    doctorSelection?: UISelection,
-    openSelection?: UISelection,
-    cloudInit?: boolean,
-  ): string {
+  private takeTerminalExitSelections(sessionId: number): TerminalExitSelections {
+    const selections = {
+      initSelection: this.initSessionSelections.get(sessionId),
+      deploySelection: this.deploySessionSelections.get(sessionId),
+      sshdInitSelection: this.sshdInitSessionSelections.get(sessionId),
+      doctorSelection: this.doctorSessionSelections.get(sessionId),
+      openSelection: this.openSessionSelections.get(sessionId),
+      cloudInit: this.cloudInitSessions.has(sessionId),
+    };
+    this.initSessionSelections.delete(sessionId);
+    this.deploySessionSelections.delete(sessionId);
+    this.sshdInitSessionSelections.delete(sessionId);
+    this.doctorSessionSelections.delete(sessionId);
+    this.openSessionSelections.delete(sessionId);
+    this.cloudInitSessions.delete(sessionId);
+    this.debugSessionModes.delete(sessionId);
+    if (selections.openSelection) {
+      this.selectionSessions.delete(selectionKey(selections.openSelection));
+    }
+    return selections;
+  }
+
+  private recordTerminalExit(payload: TerminalExitPayload, reason: string, selections: TerminalExitSelections): string {
+    this.sessionExitReasons.set(payload.sessionId, reason);
+    if (!payload.reason || !terminalExitHasTrackedSelection(selections)) {
+      return '';
+    }
+    const failedOutput = this.failedTerminalOutput(payload.sessionId, reason);
+    if (failedOutput) {
+      this.sessionExitOutputs.set(payload.sessionId, failedOutput);
+    }
+    return failedOutput;
+  }
+
+  private async handleSuccessfulTerminalExit(payload: TerminalExitPayload, reason: string, selections: TerminalExitSelections): Promise<boolean> {
     if (payload.reason) {
-      if (initSelection) {
-        return `Failed to create ${initSelection.tenant} / ${initSelection.environment}: ${payload.reason}`;
-      }
-      if (deploySelection) {
-        return `Failed to deploy ${deploySelection.tenant} / ${deploySelection.environment}: ${payload.reason}`;
-      }
-      if (sshdInitSelection) {
-        return `Failed to enable SSHD for ${sshdInitSelection.tenant} / ${sshdInitSelection.environment}: ${payload.reason}`;
-      }
-      if (doctorSelection) {
-        return `Doctor failed for ${doctorSelection.tenant} / ${doctorSelection.environment}: ${payload.reason}`;
-      }
-      if (openSelection) {
-        return `Failed to open ${openSelection.tenant} / ${openSelection.environment}: ${payload.reason}`;
-      }
-      if (cloudInit) {
-        return `Failed to initialize AWS cloud alias: ${payload.reason}`;
-      }
-      return payload.reason;
+      return false;
     }
-    if (initSelection) {
-      return `Created ${initSelection.tenant} / ${initSelection.environment}.`;
+    if (selections.sshdInitSelection) {
+      this.showTerminalMessage(reason);
+      return true;
     }
-    if (deploySelection) {
-      return `Deployed ${deploySelection.tenant} / ${deploySelection.environment}.`;
+    const completedSelection = selections.initSelection || selections.deploySelection;
+    if (!completedSelection) {
+      return false;
     }
-    if (sshdInitSelection) {
-      return `Enabled SSHD for ${sshdInitSelection.tenant} / ${sshdInitSelection.environment}.`;
+    await this.openCompletedSelection(completedSelection);
+    return true;
+  }
+
+  private async openCompletedSelection(selection: UISelection): Promise<void> {
+    try {
+      await this.openSelection(selection);
+    } catch (error) {
+      this.showTerminalMessage(readError(error));
     }
-    if (doctorSelection) {
-      return `Doctor finished for ${doctorSelection.tenant} / ${doctorSelection.environment}.`;
+  }
+
+  private terminalExitReason(payload: TerminalExitPayload, selections: TerminalExitSelections): string {
+    if (payload.reason) {
+      return failedTerminalExitReason(payload.reason, selections);
     }
-    if (cloudInit) {
-      return 'AWS cloud alias setup ended.';
-    }
-    return 'Session ended.';
+    return successfulTerminalExitReason(selections);
   }
 
   private failedTerminalOutput(sessionId: number, fallback: string): string {
@@ -2142,21 +2155,27 @@ export class ERunUIController {
   private applyLayoutVars(): void {
     const root = document.documentElement;
     root.style.setProperty('--sidebar-width', `${this.state.sidebarHidden ? 0 : this.state.sidebarWidth}px`);
+    root.style.setProperty('--review-width', `${this.clampedReviewWidth()}px`);
+    root.style.setProperty('--files-width', `${this.clampedFilesWidth()}px`);
+    root.style.setProperty('--debug-height', `${this.clampedDebugHeight()}px`);
+  }
 
+  private clampedReviewWidth(): number {
     const paneWidth = this.terminalPane?.getBoundingClientRect().width || 0;
     const maxReviewForPane = paneWidth > 0 ? paneWidth - 370 : MAX_REVIEW_WIDTH;
-    const reviewMaximum = Math.max(MIN_REVIEW_WIDTH, Math.min(MAX_REVIEW_WIDTH, maxReviewForPane));
-    root.style.setProperty('--review-width', `${clamp(this.state.reviewWidth, MIN_REVIEW_WIDTH, reviewMaximum)}px`);
+    return clamp(this.state.reviewWidth, MIN_REVIEW_WIDTH, Math.max(MIN_REVIEW_WIDTH, Math.min(MAX_REVIEW_WIDTH, maxReviewForPane)));
+  }
 
+  private clampedFilesWidth(): number {
     const reviewWidth = this.reviewView?.getBoundingClientRect().width || this.state.reviewWidth;
     const maxFilesForReview = reviewWidth > 0 ? reviewWidth - 260 : MAX_FILES_WIDTH;
-    const filesMaximum = Math.max(MIN_FILES_WIDTH, Math.min(MAX_FILES_WIDTH, maxFilesForReview));
-    root.style.setProperty('--files-width', `${clamp(this.state.filesWidth, MIN_FILES_WIDTH, filesMaximum)}px`);
+    return clamp(this.state.filesWidth, MIN_FILES_WIDTH, Math.max(MIN_FILES_WIDTH, Math.min(MAX_FILES_WIDTH, maxFilesForReview)));
+  }
 
+  private clampedDebugHeight(): number {
     const paneHeight = this.terminalPane?.getBoundingClientRect().height || 0;
     const maxDebugForPane = paneHeight > 0 ? paneHeight - 120 : MAX_DEBUG_HEIGHT;
-    const debugMaximum = Math.max(MIN_DEBUG_HEIGHT, Math.min(MAX_DEBUG_HEIGHT, maxDebugForPane));
-    root.style.setProperty('--debug-height', `${clamp(this.state.debugHeight, MIN_DEBUG_HEIGHT, debugMaximum)}px`);
+    return clamp(this.state.debugHeight, MIN_DEBUG_HEIGHT, Math.max(MIN_DEBUG_HEIGHT, Math.min(MAX_DEBUG_HEIGHT, maxDebugForPane)));
   }
 
   private queueTerminalResize = (): void => {
@@ -2323,6 +2342,141 @@ export class ERunUIController {
   }
 }
 
+type NormalizedEnvironmentDialogValues = {
+  tenant: string;
+  environment: string;
+  version: string;
+  kubernetesContext: string;
+  containerRegistry: string;
+};
+
+type IdleCloudContextAction = {
+  idleStatus: UIIdleStatus;
+  name: string;
+  run: (name: string) => Promise<unknown>;
+  label: string;
+  refreshKubernetesContexts: boolean;
+};
+
+function isNewSessionSelection(previousSessionId: number, previousKnownSessionId: number): boolean {
+  return previousKnownSessionId === 0 || previousKnownSessionId !== previousSessionId;
+}
+
+function normalizedEnvironmentDialogValues(dialog: EnvironmentDialogState): NormalizedEnvironmentDialogValues {
+  return {
+    tenant: normalizeDialogValue(dialog.tenant),
+    environment: normalizeDialogValue(dialog.environment),
+    version: normalizeDialogValue(dialog.version),
+    kubernetesContext: normalizeDialogValue(dialog.kubernetesContext),
+    containerRegistry: normalizeDialogValue(dialog.containerRegistry),
+  };
+}
+
+function validEnvironmentDialogValues(values: NormalizedEnvironmentDialogValues, actionMode: EnvironmentDialogState['actionMode']): boolean {
+  if (!values.tenant || !values.environment) {
+    return false;
+  }
+  if (actionMode === 'deploy') {
+    return Boolean(values.version);
+  }
+  return Boolean(values.kubernetesContext && values.containerRegistry);
+}
+
+function rememberEnvironmentDialogSelection(selection: UISelection, actionMode: EnvironmentDialogState['actionMode']): void {
+  rememberPastTenant(selection.tenant);
+  rememberPastEnvironment(selection.environment);
+  if (actionMode === 'init' && selection.containerRegistry) {
+    rememberPastContainerRegistry(selection.containerRegistry);
+  }
+}
+
+function hiddenSessionBusyMessage(selection: UISelection, mode: HiddenSessionMode): string {
+  if (mode === 'sshd-init') {
+    return `Enabling SSHD for ${selection.tenant} / ${selection.environment}...`;
+  }
+  return `Running doctor for ${selection.tenant} / ${selection.environment}...`;
+}
+
+function idleCloudContextAction(idleStatus: UIIdleStatus | null, busy: boolean): IdleCloudContextAction | null {
+  const name = normalizeDialogValue(idleStatus?.cloudContextName || '');
+  if (!idleStatus || !idleStatus.managedCloud || !name || busy) {
+    return null;
+  }
+  const running = normalizeDialogValue(idleStatus.cloudContextStatus || '').toLowerCase() === 'running';
+  return {
+    idleStatus,
+    name,
+    run: running ? StopCloudContext : StartCloudContext,
+    label: running ? 'Stopped' : 'Started',
+    refreshKubernetesContexts: !running,
+  };
+}
+
+function terminalExitHasTrackedSelection(selections: TerminalExitSelections): boolean {
+  return Boolean(selections.initSelection || selections.deploySelection || selections.sshdInitSelection || selections.doctorSelection || selections.openSelection || selections.cloudInit);
+}
+
+function failedTerminalExitReason(reason: string, selections: TerminalExitSelections): string {
+  const selectionReason = failedSelectionExitReason(reason, selections);
+  if (selectionReason) {
+    return selectionReason;
+  }
+  if (selections.cloudInit) {
+    return `Failed to initialize AWS cloud alias: ${reason}`;
+  }
+  return reason;
+}
+
+function failedSelectionExitReason(reason: string, selections: TerminalExitSelections): string {
+  if (selections.initSelection) {
+    return `Failed to create ${selectionLabel(selections.initSelection)}: ${reason}`;
+  }
+  if (selections.deploySelection) {
+    return `Failed to deploy ${selectionLabel(selections.deploySelection)}: ${reason}`;
+  }
+  if (selections.sshdInitSelection) {
+    return `Failed to enable SSHD for ${selectionLabel(selections.sshdInitSelection)}: ${reason}`;
+  }
+  if (selections.doctorSelection) {
+    return `Doctor failed for ${selectionLabel(selections.doctorSelection)}: ${reason}`;
+  }
+  if (selections.openSelection) {
+    return `Failed to open ${selectionLabel(selections.openSelection)}: ${reason}`;
+  }
+  return '';
+}
+
+function successfulTerminalExitReason(selections: TerminalExitSelections): string {
+  const selectionReason = successfulSelectionExitReason(selections);
+  if (selectionReason) {
+    return selectionReason;
+  }
+  if (selections.cloudInit) {
+    return 'AWS cloud alias setup ended.';
+  }
+  return 'Session ended.';
+}
+
+function successfulSelectionExitReason(selections: TerminalExitSelections): string {
+  if (selections.initSelection) {
+    return `Created ${selectionLabel(selections.initSelection)}.`;
+  }
+  if (selections.deploySelection) {
+    return `Deployed ${selectionLabel(selections.deploySelection)}.`;
+  }
+  if (selections.sshdInitSelection) {
+    return `Enabled SSHD for ${selectionLabel(selections.sshdInitSelection)}.`;
+  }
+  if (selections.doctorSelection) {
+    return `Doctor finished for ${selectionLabel(selections.doctorSelection)}.`;
+  }
+  return '';
+}
+
+function selectionLabel(selection: UISelection): string {
+  return `${selection.tenant} / ${selection.environment}`;
+}
+
 function cleanTerminalOutput(value: string): string {
   return value
     .replace(/\x1B\][^\x07]*(?:\x07|\x1B\\)/g, '')
@@ -2398,31 +2552,30 @@ function mcpPortForwardDetail(value: string): string {
   return 'kubectl has not exposed a reachable MCP endpoint yet.';
 }
 
+type TerminalOutputStatusRule = {
+  matches: (lower: string) => boolean;
+  message: (output: string) => string;
+};
+
+const terminalOutputStatusRules: TerminalOutputStatusRule[] = [
+  { matches: (lower) => lower.includes('forwarding from 127.0.0.1:'), message: mcpForwardingStatusMessage },
+  { matches: (lower) => lower.includes('handling connection for'), message: () => 'Checking MCP endpoint readiness...' },
+  { matches: (lower) => lower.includes('connection refused'), message: () => 'Runtime pod is not accepting MCP connections yet...' },
+  { matches: (lower) => lower.includes('lost connection to pod') || lower.includes('network namespace'), message: () => 'Runtime pod connection changed. Reconnecting MCP port-forward...' },
+  { matches: (lower) => lower.includes('pod not found'), message: () => 'Runtime pod was replaced. Waiting for the new pod...' },
+  { matches: (lower) => lower.includes('context "') && lower.includes('modified'), message: () => 'Configuring Kubernetes context...' },
+  { matches: (lower) => lower.includes('cluster "') && lower.includes('set.'), message: () => 'Configuring Kubernetes cluster access...' },
+];
+
 function statusForTerminalOutput(output: string): string {
   const lower = output.toLowerCase();
-  if (lower.includes('forwarding from 127.0.0.1:')) {
-    const port = output.match(/Forwarding from 127\.0\.0\.1:(\d+)/)?.[1] || '';
-    return port ? `Waiting for MCP endpoint on 127.0.0.1:${port}...` : 'Waiting for MCP endpoint...';
-  }
-  if (lower.includes('handling connection for')) {
-    return 'Checking MCP endpoint readiness...';
-  }
-  if (lower.includes('connection refused')) {
-    return 'Runtime pod is not accepting MCP connections yet...';
-  }
-  if (lower.includes('lost connection to pod') || lower.includes('network namespace')) {
-    return 'Runtime pod connection changed. Reconnecting MCP port-forward...';
-  }
-  if (lower.includes('pod not found')) {
-    return 'Runtime pod was replaced. Waiting for the new pod...';
-  }
-  if (lower.includes('context "') && lower.includes('modified')) {
-    return 'Configuring Kubernetes context...';
-  }
-  if (lower.includes('cluster "') && lower.includes('set.')) {
-    return 'Configuring Kubernetes cluster access...';
-  }
-  return '';
+  const rule = terminalOutputStatusRules.find((candidate) => candidate.matches(lower));
+  return rule?.message(output) || '';
+}
+
+function mcpForwardingStatusMessage(output: string): string {
+  const port = output.match(/Forwarding from 127\.0\.0\.1:(\d+)/)?.[1] || '';
+  return port ? `Waiting for MCP endpoint on 127.0.0.1:${port}...` : 'Waiting for MCP endpoint...';
 }
 
 function decodeDebugOutput(data: Uint8Array): string {
@@ -2475,43 +2628,57 @@ function formatDebugCommand(selection: UISelection, mode: 'open' | 'init' | 'dep
   if (selection.debug) {
     args.push('-vv');
   }
-  if (mode === 'init') {
-    args.push('init', selection.tenant, selection.environment, '--remote');
-    if (selection.version) {
-      args.push('--version', selection.version);
-    }
-    if (selection.runtimeImage) {
-      args.push('--runtime-image', selection.runtimeImage);
-    }
-    if (selection.kubernetesContext) {
-      args.push('--kubernetes-context', selection.kubernetesContext);
-    }
-    if (selection.containerRegistry) {
-      args.push('--container-registry', selection.containerRegistry);
-    }
-    args.push(`--set-default-tenant=${selection.setDefaultTenant ? 'true' : 'false'}`, '--confirm-environment=true');
-    if (selection.noGit) {
-      args.push('--no-git');
-    }
-    if (selection.bootstrap) {
-      args.push('--bootstrap');
-    }
-  } else if (mode === 'sshd-init') {
-    args.push('sshd', 'init', selection.tenant, selection.environment);
-  } else if (mode === 'doctor') {
-    args.push('doctor', selection.tenant, selection.environment);
-  } else if (mode === 'deploy') {
-    args.push('open', selection.tenant, selection.environment, '--no-shell', '--no-alias-prompt');
-    if (selection.version) {
-      args.push('--version', selection.version);
-    }
-    if (selection.runtimeImage) {
-      args.push('--runtime-image', selection.runtimeImage);
-    }
-  } else {
-    args.push('open', selection.tenant, selection.environment);
-  }
+  appendDebugCommandArgs(args, selection, mode);
   return args.map(shellDebugArg).join(' ');
+}
+
+function appendDebugCommandArgs(args: string[], selection: UISelection, mode: 'open' | 'init' | 'deploy' | 'sshd-init' | 'doctor'): void {
+  if (mode === 'init') {
+    appendInitDebugArgs(args, selection);
+    return;
+  }
+  if (mode === 'deploy') {
+    appendDeployDebugArgs(args, selection);
+    return;
+  }
+  if (mode === 'sshd-init') {
+    args.push('sshd', 'init', selection.tenant, selection.environment);
+    return;
+  }
+  if (mode === 'doctor') {
+    args.push('doctor', selection.tenant, selection.environment);
+    return;
+  }
+  args.push('open', selection.tenant, selection.environment);
+}
+
+function appendInitDebugArgs(args: string[], selection: UISelection): void {
+  args.push('init', selection.tenant, selection.environment, '--remote');
+  appendOptionalDebugArg(args, '--version', selection.version);
+  appendOptionalDebugArg(args, '--runtime-image', selection.runtimeImage);
+  appendOptionalDebugArg(args, '--kubernetes-context', selection.kubernetesContext);
+  appendOptionalDebugArg(args, '--container-registry', selection.containerRegistry);
+  args.push(`--set-default-tenant=${selection.setDefaultTenant ? 'true' : 'false'}`, '--confirm-environment=true');
+  appendDebugFlag(args, '--no-git', selection.noGit);
+  appendDebugFlag(args, '--bootstrap', selection.bootstrap);
+}
+
+function appendDeployDebugArgs(args: string[], selection: UISelection): void {
+  args.push('open', selection.tenant, selection.environment, '--no-shell', '--no-alias-prompt');
+  appendOptionalDebugArg(args, '--version', selection.version);
+  appendOptionalDebugArg(args, '--runtime-image', selection.runtimeImage);
+}
+
+function appendOptionalDebugArg(args: string[], name: string, value: string | undefined): void {
+  if (value) {
+    args.push(name, value);
+  }
+}
+
+function appendDebugFlag(args: string[], name: string, enabled: boolean | undefined): void {
+  if (enabled) {
+    args.push(name);
+  }
 }
 
 function formatIDECommand(selection: UISelection, ide: IDEKind): string {

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -18,28 +18,12 @@ import { VersionField } from './VersionField';
 const dialogErrorClassName =
   'rounded-[var(--radius)] border border-[color-mix(in_oklch,var(--destructive)_36%,transparent)] bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] px-[11px] py-[9px] text-[13px] leading-[1.35] text-destructive [overflow-wrap:anywhere]';
 
+type EnvironmentDialog = AppState['environmentDialog'];
+
 export function EnvironmentDialogView({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement {
   const dialog = state.environmentDialog;
   const tenantRef = React.useRef<HTMLInputElement>(null);
   const environmentRef = React.useRef<HTMLInputElement>(null);
-  const isDeploy = dialog.actionMode === 'deploy';
-  const submitLabel = isDeploy ? 'Deploy' : 'Create';
-  const busyLabel = isDeploy ? 'Deploying...' : 'Creating...';
-  const createDisabled = dialog.busy || (!isDeploy && (dialog.kubernetesContextsLoading || dialog.kubernetesContexts.length === 0));
-  const tenantSuggestions = React.useMemo(
-    () => uniqueSuggestions([dialog.tenant, ...state.tenants.map((tenant) => tenant.name), ...loadSavedPastTenants()]),
-    [dialog.tenant, state.tenants],
-  );
-  const environmentSuggestions = React.useMemo(() => {
-    const selectedTenant = state.tenants.find((tenant) => tenant.name.toLowerCase() === dialog.tenant.trim().toLowerCase());
-    const selectedTenantEnvironments = selectedTenant?.environments.map((environment) => environment.name) || [];
-    const allEnvironments = state.tenants.flatMap((tenant) => tenant.environments.map((environment) => environment.name));
-    return uniqueSuggestions([dialog.environment, ...selectedTenantEnvironments, ...loadSavedPastEnvironments(), ...allEnvironments]);
-  }, [dialog.environment, dialog.tenant, state.tenants]);
-  const containerRegistrySuggestions = React.useMemo(
-    () => uniqueSuggestions([dialog.containerRegistry, ...loadSavedPastContainerRegistries(), 'erunpaas']),
-    [dialog.containerRegistry],
-  );
 
   React.useEffect(() => {
     if (!dialog.open) {
@@ -71,141 +55,180 @@ export function EnvironmentDialogView({ controller, state }: { controller: ERunU
             });
           }}
         >
-          <DialogHeader>
-            <DialogTitle>
-              {isDeploy ? 'Deploy environment' : 'New environment'}
-            </DialogTitle>
-            <DialogDescription>
-              {dialog.tenant && dialog.environment ? `${dialog.tenant} / ${dialog.environment}` : 'Enter the tenant and environment name.'}
-            </DialogDescription>
-          </DialogHeader>
-          <EditableComboField
-            id="environment-tenant"
-            inputRef={tenantRef}
-            label="Tenant"
-            value={dialog.tenant}
-            suggestions={tenantSuggestions}
-            required
-            disabled={dialog.busy || isDeploy}
-            onValueChange={(tenant) => controller.updateEnvironmentDialog({ tenant })}
-          />
-          <EditableComboField
-            id="environment-name"
-            inputRef={environmentRef}
-            label="Environment"
-            value={dialog.environment}
-            suggestions={environmentSuggestions}
-            required
-            disabled={dialog.busy || isDeploy}
-            onValueChange={(environment) => controller.updateEnvironmentDialog({ environment })}
-          />
-          <VersionField
-            id="environment-version"
-            value={dialog.version}
-            sourceText={selectedVersionSourceText(findVersionSuggestion(state.versionSuggestions, dialog.version, dialog.versionImage))}
-            suggestions={state.versionSuggestions}
-            choicesOpen={dialog.choicesOpen}
-            required={isDeploy}
-            disabled={dialog.busy}
-            onValueChange={(version) => controller.updateEnvironmentDialog({ version })}
-            onChoicesOpenChange={(open) => controller.setEnvironmentVersionChoicesOpen(open)}
-            onSelect={(suggestion) => controller.selectEnvironmentVersionSuggestion(suggestion)}
-          />
-          {!isDeploy && (
-            <>
-              <div className="grid gap-2">
-                <Label htmlFor="environment-kubernetes-context">Kubernetes context</Label>
-                <select
-                  id="environment-kubernetes-context"
-                  className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-[var(--radius)] border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-                  value={dialog.kubernetesContext}
-                  required
-                  disabled={dialog.busy || dialog.kubernetesContextsLoading || dialog.kubernetesContexts.length === 0}
-                  onChange={(event) => controller.updateEnvironmentDialog({ kubernetesContext: event.target.value })}
-                >
-                  {dialog.kubernetesContextsLoading ? (
-                    <option value="">Loading contexts...</option>
-                  ) : dialog.kubernetesContexts.length === 0 ? (
-                    <option value="">No Kubernetes contexts</option>
-                  ) : (
-                    dialog.kubernetesContexts.map((context) => (
-                      <option key={context} value={context}>
-                        {context}
-                      </option>
-                    ))
-                  )}
-                </select>
-              </div>
-              <EditableComboField
-                id="environment-container-registry"
-                label="Container registry"
-                value={dialog.containerRegistry}
-                suggestions={containerRegistrySuggestions}
-                required
-                disabled={dialog.busy}
-                onValueChange={(containerRegistry) => controller.updateEnvironmentDialog({ containerRegistry })}
-              />
-              <div className="grid gap-2">
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="environment-default-tenant"
-                    checked={dialog.setDefaultTenant}
-                    disabled={dialog.busy}
-                    onCheckedChange={(checked) => controller.updateEnvironmentDialog({ setDefaultTenant: checked === true })}
-                  />
-                  <Label htmlFor="environment-default-tenant" className="text-sm font-normal">
-                    Set as default tenant
-                  </Label>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="environment-no-git"
-                    checked={dialog.noGit}
-                    disabled={dialog.busy}
-                    onCheckedChange={(checked) => controller.updateEnvironmentDialog({ noGit: checked === true })}
-                  />
-                  <Label htmlFor="environment-no-git" className="text-sm font-normal">
-                    Initialize without Git checkout
-                  </Label>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="environment-bootstrap"
-                    checked={dialog.bootstrap}
-                    disabled={dialog.busy}
-                    onCheckedChange={(checked) => controller.updateEnvironmentDialog({ bootstrap: checked === true })}
-                  />
-                  <Label htmlFor="environment-bootstrap" className="text-sm font-normal">
-                    Create tenant devops module
-                  </Label>
-                </div>
-              </div>
-            </>
-          )}
-          {dialog.error && (
-            <div className={dialogErrorClassName} role="alert">
-              {dialog.error}
-            </div>
-          )}
-          <DialogFooter>
-            <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => controller.closeEnvironmentDialog()}>
-              Cancel
-            </Button>
-            <Button type="submit" size="sm" disabled={createDisabled}>
-              {dialog.busy ? (
-                <LoaderCircle className="animate-spin" aria-hidden="true" />
-              ) : isDeploy ? (
-                <Rocket aria-hidden="true" />
-              ) : (
-                <FolderPlus aria-hidden="true" />
-              )}
-              {dialog.busy ? busyLabel : submitLabel}
-            </Button>
-          </DialogFooter>
+          <EnvironmentDialogHeader dialog={dialog} />
+          <EnvironmentDialogFields controller={controller} state={state} tenantRef={tenantRef} environmentRef={environmentRef} />
+          <DialogError error={dialog.error} />
+          <EnvironmentDialogFooter controller={controller} dialog={dialog} />
         </form>
       </DialogContent>
     </Dialog>
   );
+}
+
+function EnvironmentDialogHeader({ dialog }: { dialog: EnvironmentDialog }): React.ReactElement {
+  const isDeploy = dialog.actionMode === 'deploy';
+  return (
+    <DialogHeader>
+      <DialogTitle>{isDeploy ? 'Deploy environment' : 'New environment'}</DialogTitle>
+      <DialogDescription>
+        {dialog.tenant && dialog.environment ? `${dialog.tenant} / ${dialog.environment}` : 'Enter the tenant and environment name.'}
+      </DialogDescription>
+    </DialogHeader>
+  );
+}
+
+function EnvironmentDialogFields({
+  controller,
+  state,
+  tenantRef,
+  environmentRef,
+}: {
+  controller: ERunUIController;
+  state: AppState;
+  tenantRef: React.Ref<HTMLInputElement>;
+  environmentRef: React.Ref<HTMLInputElement>;
+}): React.ReactElement {
+  const dialog = state.environmentDialog;
+  const isDeploy = dialog.actionMode === 'deploy';
+  return (
+    <>
+      <EnvironmentNameFields controller={controller} state={state} tenantRef={tenantRef} environmentRef={environmentRef} />
+      <VersionField
+        id="environment-version"
+        value={dialog.version}
+        sourceText={selectedVersionSourceText(findVersionSuggestion(state.versionSuggestions, dialog.version, dialog.versionImage))}
+        suggestions={state.versionSuggestions}
+        choicesOpen={dialog.choicesOpen}
+        required={isDeploy}
+        disabled={dialog.busy}
+        onValueChange={(version) => controller.updateEnvironmentDialog({ version })}
+        onChoicesOpenChange={(open) => controller.setEnvironmentVersionChoicesOpen(open)}
+        onSelect={(suggestion) => controller.selectEnvironmentVersionSuggestion(suggestion)}
+      />
+      {!isDeploy && <EnvironmentCreateFields controller={controller} dialog={dialog} />}
+    </>
+  );
+}
+
+function EnvironmentNameFields({
+  controller,
+  state,
+  tenantRef,
+  environmentRef,
+}: {
+  controller: ERunUIController;
+  state: AppState;
+  tenantRef: React.Ref<HTMLInputElement>;
+  environmentRef: React.Ref<HTMLInputElement>;
+}): React.ReactElement {
+  const dialog = state.environmentDialog;
+  const isDeploy = dialog.actionMode === 'deploy';
+  const tenantSuggestions = React.useMemo(
+    () => uniqueSuggestions([dialog.tenant, ...state.tenants.map((tenant) => tenant.name), ...loadSavedPastTenants()]),
+    [dialog.tenant, state.tenants],
+  );
+  const environmentSuggestions = React.useMemo(() => environmentNameSuggestions(state, dialog), [dialog, state]);
+
+  return (
+    <>
+      <EditableComboField id="environment-tenant" inputRef={tenantRef} label="Tenant" value={dialog.tenant} suggestions={tenantSuggestions} required disabled={dialog.busy || isDeploy} onValueChange={(tenant) => controller.updateEnvironmentDialog({ tenant })} />
+      <EditableComboField id="environment-name" inputRef={environmentRef} label="Environment" value={dialog.environment} suggestions={environmentSuggestions} required disabled={dialog.busy || isDeploy} onValueChange={(environment) => controller.updateEnvironmentDialog({ environment })} />
+    </>
+  );
+}
+
+function EnvironmentCreateFields({ controller, dialog }: { controller: ERunUIController; dialog: EnvironmentDialog }): React.ReactElement {
+  const containerRegistrySuggestions = React.useMemo(
+    () => uniqueSuggestions([dialog.containerRegistry, ...loadSavedPastContainerRegistries(), 'erunpaas']),
+    [dialog.containerRegistry],
+  );
+
+  return (
+    <>
+      <KubernetesContextSelect controller={controller} dialog={dialog} />
+      <EditableComboField id="environment-container-registry" label="Container registry" value={dialog.containerRegistry} suggestions={containerRegistrySuggestions} required disabled={dialog.busy} onValueChange={(containerRegistry) => controller.updateEnvironmentDialog({ containerRegistry })} />
+      <EnvironmentCreateChecks controller={controller} dialog={dialog} />
+    </>
+  );
+}
+
+function KubernetesContextSelect({ controller, dialog }: { controller: ERunUIController; dialog: EnvironmentDialog }): React.ReactElement {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="environment-kubernetes-context">Kubernetes context</Label>
+      <select
+        id="environment-kubernetes-context"
+        className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-[var(--radius)] border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        value={dialog.kubernetesContext}
+        required
+        disabled={dialog.busy || dialog.kubernetesContextsLoading || dialog.kubernetesContexts.length === 0}
+        onChange={(event) => controller.updateEnvironmentDialog({ kubernetesContext: event.target.value })}
+      >
+        {kubernetesContextOptions(dialog)}
+      </select>
+    </div>
+  );
+}
+
+function EnvironmentCreateChecks({ controller, dialog }: { controller: ERunUIController; dialog: EnvironmentDialog }): React.ReactElement {
+  return (
+    <div className="grid gap-2">
+      <CheckboxField id="environment-default-tenant" label="Set as default tenant" checked={dialog.setDefaultTenant} disabled={dialog.busy} onCheckedChange={(setDefaultTenant) => controller.updateEnvironmentDialog({ setDefaultTenant })} />
+      <CheckboxField id="environment-no-git" label="Initialize without Git checkout" checked={dialog.noGit} disabled={dialog.busy} onCheckedChange={(noGit) => controller.updateEnvironmentDialog({ noGit })} />
+      <CheckboxField id="environment-bootstrap" label="Create tenant devops module" checked={dialog.bootstrap} disabled={dialog.busy} onCheckedChange={(bootstrap) => controller.updateEnvironmentDialog({ bootstrap })} />
+    </div>
+  );
+}
+
+function CheckboxField({ id, label, checked, disabled, onCheckedChange }: { id: string; label: string; checked: boolean; disabled: boolean; onCheckedChange: (checked: boolean) => void }): React.ReactElement {
+  return (
+    <div className="flex items-center gap-2">
+      <Checkbox id={id} checked={checked} disabled={disabled} onCheckedChange={(value) => onCheckedChange(value === true)} />
+      <Label htmlFor={id} className="text-sm font-normal">{label}</Label>
+    </div>
+  );
+}
+
+function DialogError({ error }: { error: string }): React.ReactElement | null {
+  return error ? <div className={dialogErrorClassName} role="alert">{error}</div> : null;
+}
+
+function EnvironmentDialogFooter({ controller, dialog }: { controller: ERunUIController; dialog: EnvironmentDialog }): React.ReactElement {
+  const isDeploy = dialog.actionMode === 'deploy';
+  const disabled = dialog.busy || (!isDeploy && (dialog.kubernetesContextsLoading || dialog.kubernetesContexts.length === 0));
+  return (
+    <DialogFooter>
+      <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => controller.closeEnvironmentDialog()}>Cancel</Button>
+      <Button type="submit" size="sm" disabled={disabled}>
+        <EnvironmentSubmitIcon dialog={dialog} />
+        {dialog.busy ? (isDeploy ? 'Deploying...' : 'Creating...') : isDeploy ? 'Deploy' : 'Create'}
+      </Button>
+    </DialogFooter>
+  );
+}
+
+function EnvironmentSubmitIcon({ dialog }: { dialog: EnvironmentDialog }): React.ReactElement {
+  if (dialog.busy) {
+    return <LoaderCircle className="animate-spin" aria-hidden="true" />;
+  }
+  return dialog.actionMode === 'deploy' ? <Rocket aria-hidden="true" /> : <FolderPlus aria-hidden="true" />;
+}
+
+function environmentNameSuggestions(state: AppState, dialog: EnvironmentDialog): string[] {
+  const selectedTenant = state.tenants.find((tenant) => tenant.name.toLowerCase() === dialog.tenant.trim().toLowerCase());
+  const selectedTenantEnvironments = selectedTenant?.environments.map((environment) => environment.name) || [];
+  const allEnvironments = state.tenants.flatMap((tenant) => tenant.environments.map((environment) => environment.name));
+  return uniqueSuggestions([dialog.environment, ...selectedTenantEnvironments, ...loadSavedPastEnvironments(), ...allEnvironments]);
+}
+
+function kubernetesContextOptions(dialog: EnvironmentDialog): React.ReactNode {
+  if (dialog.kubernetesContextsLoading) {
+    return <option value="">Loading contexts...</option>;
+  }
+  if (dialog.kubernetesContexts.length === 0) {
+    return <option value="">No Kubernetes contexts</option>;
+  }
+  return dialog.kubernetesContexts.map((context) => <option key={context} value={context}>{context}</option>);
 }
 
 function EditableComboField({

--- a/erun-ui/frontend/src/components/app/FileIcon.tsx
+++ b/erun-ui/frontend/src/components/app/FileIcon.tsx
@@ -1,6 +1,33 @@
 import * as React from 'react';
 import { File, FileCode2, FileCog, FileJson, FileText, Gem } from 'lucide-react';
 
+const extensionIcons = new Map([
+  ['css', FileCode2],
+  ['go', FileCode2],
+  ['html', FileCode2],
+  ['java', FileCode2],
+  ['js', FileCode2],
+  ['jsx', FileCode2],
+  ['json', FileJson],
+  ['jsonc', FileJson],
+  ['md', FileText],
+  ['mdx', FileText],
+  ['py', FileCode2],
+  ['rb', Gem],
+  ['sh', FileCode2],
+  ['toml', FileCog],
+  ['ts', FileCode2],
+  ['tsx', FileCode2],
+  ['txt', FileText],
+  ['yaml', FileCog],
+  ['yml', FileCog],
+]);
+
+const filenameIcons = new Map([
+  ['dockerfile', FileCog],
+  ['makefile', FileCog],
+]);
+
 export function FileIcon({ filePath }: { filePath: string }): React.ReactElement {
   const Icon = fileIconForPath(filePath);
   return (
@@ -16,20 +43,5 @@ export function FileIcon({ filePath }: { filePath: string }): React.ReactElement
 function fileIconForPath(filePath: string): typeof File {
   const name = filePath.split('/').pop()?.toLowerCase() || '';
   const extension = filePath.split('.').pop()?.toLowerCase() || '';
-  if (['json', 'jsonc'].includes(extension)) {
-    return FileJson;
-  }
-  if (extension === 'rb') {
-    return Gem;
-  }
-  if (['yaml', 'yml', 'toml'].includes(extension) || name === 'dockerfile' || name === 'makefile') {
-    return FileCog;
-  }
-  if (['md', 'mdx', 'txt'].includes(extension)) {
-    return FileText;
-  }
-  if (['css', 'go', 'html', 'java', 'js', 'jsx', 'py', 'sh', 'ts', 'tsx'].includes(extension)) {
-    return FileCode2;
-  }
-  return File;
+  return filenameIcons.get(name) ?? extensionIcons.get(extension) ?? File;
 }

--- a/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
@@ -12,15 +12,10 @@ import { Label } from '@/components/ui/label';
 const dialogErrorClassName =
   'rounded-[var(--radius)] border border-[color-mix(in_oklch,var(--destructive)_36%,transparent)] bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] px-[11px] py-[9px] text-[13px] leading-[1.35] text-destructive [overflow-wrap:anywhere]';
 
+type GlobalConfigDialog = AppState['globalConfigDialog'];
+
 export function GlobalConfigDialogView({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement {
   const dialog = state.globalConfigDialog;
-  const config = dialog.config;
-  const tenantOptions = optionValues(state.tenants.map((tenant) => tenant.name), config.defaultTenant);
-  const selectedCloudProvider = (config.cloudProviders || []).find((provider) => provider.alias === dialog.cloudContextDraft.cloudProviderAlias);
-  const generatedCloudContextName = generatedContextName(selectedCloudProvider, dialog.cloudContextDraft.region, config.cloudContexts || []);
-  const saving = dialog.busyAction === 'save';
-  const initializingContext = dialog.busyAction === 'cloud-context-init';
-  const initializingCloudProvider = dialog.busyAction === 'cloud-provider-init';
 
   return (
     <Dialog open={dialog.open} onOpenChange={(open) => !open && controller.closeGlobalConfigDialog()}>
@@ -44,165 +39,171 @@ export function GlobalConfigDialogView({ controller, state }: { controller: ERun
             <DialogTitle>ERun settings</DialogTitle>
             <DialogDescription className="sr-only">Manage default tenant and cloud aliases.</DialogDescription>
           </DialogHeader>
-          {dialog.configLoading ? (
-            <div className="rounded-[var(--radius)] border border-dashed border-border px-3 py-2.5 text-[13px] leading-[1.35] text-muted-foreground">
-              Loading config...
-            </div>
-          ) : (
-            <div className="grid gap-3">
-              <SelectField id="global-config-defaulttenant" label="Default tenant" value={config.defaultTenant} options={tenantOptions} disabled={dialog.busy || tenantOptions.length === 0} onChange={(defaultTenant) => controller.updateGlobalConfig({ defaultTenant })} />
-              <div className="grid gap-2">
-                <div className="flex items-center justify-between gap-2">
-                  <Label>Cloud aliases</Label>
-                  <div className="flex gap-1.5">
-                    <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => void controller.startAWSCloudInit()}>
-                      {initializingCloudProvider ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Plus aria-hidden="true" />}
-                      AWS
-                    </Button>
-                    <Button type="button" variant="ghost" size="icon" disabled={dialog.busy} aria-label="Refresh cloud aliases" onClick={() => void controller.refreshCloudProviders()}>
-                      <RefreshCw aria-hidden="true" />
-                    </Button>
-                  </div>
-                </div>
-                {(config.cloudProviders || []).length === 0 ? (
-                  <div className="px-0.5 py-2 text-[13px] leading-[1.35] text-muted-foreground">No cloud aliases configured</div>
-                ) : (
-                  <div className="overflow-hidden rounded-[var(--radius)] border border-border">
-                    {(config.cloudProviders || []).map((provider, index) => (
-                      <div
-                        key={provider.alias}
-                        className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-border px-3 py-2.5 data-[border=true]:border-t"
-                        data-border={index > 0}
-                        data-cloud-alias={provider.alias}
-                        data-cloud-status={provider.status}
-                      >
-                        <div className="grid min-w-0 gap-1">
-                          <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
-                            <Cloud className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-                            <span className="truncate">{provider.alias}</span>
-                            <StatusBadge status={provider.status} />
-                          </div>
-                          <div className="truncate text-xs text-muted-foreground">
-                            {cloudProviderSummary(provider)}
-                            {provider.message ? ` - ${provider.message}` : ''}
-                          </div>
-                        </div>
-                        <CloudAliasAction status={provider.status} busy={dialog.busy} loading={dialog.busyAction === 'cloud-provider-login' && dialog.busyTarget === provider.alias} onLogin={() => void controller.loginCloudProvider(provider.alias)} />
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-              <div className="grid gap-2">
-                <div className="flex items-center justify-between gap-2">
-                  <Label>Cloud contexts</Label>
-                  <Button type="button" variant="ghost" size="icon" disabled={dialog.busy} aria-label="Refresh cloud contexts" onClick={() => void controller.refreshCloudContexts()}>
-                    <RefreshCw aria-hidden="true" />
-                  </Button>
-                </div>
-                <div className="grid gap-2 rounded-[var(--radius)] border border-border p-3">
-                  <div className="grid gap-2 sm:grid-cols-2">
-                    <SelectInput
-                      id="global-config-cloudcontext-provider"
-                      label="Cloud provider"
-                      value={dialog.cloudContextDraft.cloudProviderAlias}
-                      options={(config.cloudProviders || []).map((provider) => provider.alias)}
-                      emptyLabel="No cloud aliases"
-                      disabled={dialog.busy || (config.cloudProviders || []).length === 0}
-                      onChange={(cloudProviderAlias) => controller.updateCloudContextDraft({ cloudProviderAlias })}
-                    />
-                    <RegionSelectInput id="global-config-cloudcontext-region" value={dialog.cloudContextDraft.region} disabled={dialog.busy} onChange={(region) => controller.updateCloudContextDraft({ region })} />
-                    <SelectInput
-                      id="global-config-cloudcontext-instancetype"
-                      label="Instance type"
-                      value={dialog.cloudContextDraft.instanceType}
-                      options={['c8gd.2xlarge', 't4g.xlarge']}
-                      disabled={dialog.busy}
-                      onChange={(instanceType) => controller.updateCloudContextDraft({ instanceType })}
-                    />
-                    <SelectInput
-                      id="global-config-cloudcontext-disksize"
-                      label="Disk size"
-                      value={String(dialog.cloudContextDraft.diskSizeGb)}
-                      options={['100', '200']}
-                      disabled={dialog.busy}
-                      onChange={(diskSizeGb) => controller.updateCloudContextDraft({ diskSizeGb: Number(diskSizeGb) })}
-                    />
-                  </div>
-                  <div className="grid gap-2">
-                    <Label htmlFor="global-config-cloudcontext-name">Context name</Label>
-                    <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
-                      <Input
-                        id="global-config-cloudcontext-name"
-                        value={dialog.cloudContextDraft.name}
-                        disabled={dialog.busy}
-                        placeholder="Generated when empty"
-                        onChange={(event) => controller.updateCloudContextDraft({ name: event.target.value })}
-                      />
-                      <Button type="button" size="sm" disabled={dialog.busy || dialog.configLoading || !dialog.cloudContextDraft.cloudProviderAlias || !dialog.cloudContextDraft.region} onClick={() => void controller.initCloudContext()}>
-                        {initializingContext ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Plus aria-hidden="true" />}
-                        Init
-                      </Button>
-                    </div>
-                    {generatedCloudContextName && !dialog.cloudContextDraft.name && (
-                      <div className="px-0.5 text-xs leading-[1.35] text-muted-foreground [overflow-wrap:anywhere]">Generated: {generatedCloudContextName}</div>
-                    )}
-                  </div>
-                </div>
-                {(config.cloudContexts || []).length === 0 ? (
-                  <div className="px-0.5 py-2 text-[13px] leading-[1.35] text-muted-foreground">No cloud contexts configured</div>
-                ) : (
-                  <div className="overflow-hidden rounded-[var(--radius)] border border-border">
-                    {(config.cloudContexts || []).map((context, index) => (
-                      <div
-                        key={context.name}
-                        className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-border px-3 py-2.5 data-[border=true]:border-t"
-                        data-border={index > 0}
-                        data-cloud-context={context.name}
-                        data-cloud-context-status={context.status}
-                      >
-                        <div className="grid min-w-0 gap-1">
-                          <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
-                            <Server className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-                            <span className="truncate">{context.kubernetesContext || context.name}</span>
-                            <StatusBadge status={context.status} />
-                          </div>
-                          <div className="truncate text-xs text-muted-foreground">
-                            {cloudContextSummary(context)}
-                            {context.message ? ` - ${context.message}` : ''}
-                          </div>
-                        </div>
-                        <CloudContextAction
-                          status={context.status}
-                          busy={dialog.busy}
-                          loading={dialog.busyAction === 'cloud-context-power' && dialog.busyTarget === context.name}
-                          onStart={() => void controller.startCloudContext(context.name)}
-                          onStop={() => void controller.stopCloudContext(context.name)}
-                        />
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-          {dialog.error && (
-            <div className={dialogErrorClassName} role="alert">
-              {dialog.error}
-            </div>
-          )}
-          <DialogFooter>
-            <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => controller.closeGlobalConfigDialog()}>
-              Cancel
-            </Button>
-            <Button type="submit" size="sm" disabled={dialog.busy || dialog.configLoading}>
-              {saving ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Save aria-hidden="true" />}
-              {saving ? 'Saving...' : 'Save settings'}
-            </Button>
-          </DialogFooter>
+          <GlobalConfigBody controller={controller} state={state} />
+          <DialogError error={dialog.error} />
+          <GlobalConfigFooter controller={controller} dialog={dialog} />
         </form>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function GlobalConfigBody({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement {
+  const dialog = state.globalConfigDialog;
+  if (dialog.configLoading) {
+    return <div className="rounded-[var(--radius)] border border-dashed border-border px-3 py-2.5 text-[13px] leading-[1.35] text-muted-foreground">Loading config...</div>;
+  }
+  const tenantOptions = optionValues(state.tenants.map((tenant) => tenant.name), dialog.config.defaultTenant);
+  return (
+    <div className="grid gap-3">
+      <SelectField id="global-config-defaulttenant" label="Default tenant" value={dialog.config.defaultTenant} options={tenantOptions} disabled={dialog.busy || tenantOptions.length === 0} onChange={(defaultTenant) => controller.updateGlobalConfig({ defaultTenant })} />
+      <CloudAliasesSection controller={controller} dialog={dialog} />
+      <CloudContextsSection controller={controller} dialog={dialog} />
+    </div>
+  );
+}
+
+function CloudAliasesSection({ controller, dialog }: { controller: ERunUIController; dialog: GlobalConfigDialog }): React.ReactElement {
+  const providers = dialog.config.cloudProviders || [];
+  return (
+    <div className="grid gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <Label>Cloud aliases</Label>
+        <div className="flex gap-1.5">
+          <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => void controller.startAWSCloudInit()}>
+            {dialog.busyAction === 'cloud-provider-init' ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Plus aria-hidden="true" />}
+            AWS
+          </Button>
+          <Button type="button" variant="ghost" size="icon" disabled={dialog.busy} aria-label="Refresh cloud aliases" onClick={() => void controller.refreshCloudProviders()}>
+            <RefreshCw aria-hidden="true" />
+          </Button>
+        </div>
+      </div>
+      {providers.length === 0 ? <div className="px-0.5 py-2 text-[13px] leading-[1.35] text-muted-foreground">No cloud aliases configured</div> : <CloudAliasList controller={controller} dialog={dialog} />}
+    </div>
+  );
+}
+
+function CloudAliasList({ controller, dialog }: { controller: ERunUIController; dialog: GlobalConfigDialog }): React.ReactElement {
+  return (
+    <div className="overflow-hidden rounded-[var(--radius)] border border-border">
+      {(dialog.config.cloudProviders || []).map((provider, index) => (
+        <div key={provider.alias} className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-border px-3 py-2.5 data-[border=true]:border-t" data-border={index > 0} data-cloud-alias={provider.alias} data-cloud-status={provider.status}>
+          <CloudAliasSummary provider={provider} />
+          <CloudAliasAction status={provider.status} busy={dialog.busy} loading={dialog.busyAction === 'cloud-provider-login' && dialog.busyTarget === provider.alias} onLogin={() => void controller.loginCloudProvider(provider.alias)} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CloudAliasSummary({ provider }: { provider: GlobalConfigDialog['config']['cloudProviders'][number] }): React.ReactElement {
+  return (
+    <div className="grid min-w-0 gap-1">
+      <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+        <Cloud className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <span className="truncate">{provider.alias}</span>
+        <StatusBadge status={provider.status} />
+      </div>
+      <div className="truncate text-xs text-muted-foreground">
+        {cloudProviderSummary(provider)}
+        {provider.message ? ` - ${provider.message}` : ''}
+      </div>
+    </div>
+  );
+}
+
+function CloudContextsSection({ controller, dialog }: { controller: ERunUIController; dialog: GlobalConfigDialog }): React.ReactElement {
+  const contexts = dialog.config.cloudContexts || [];
+  return (
+    <div className="grid gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <Label>Cloud contexts</Label>
+        <Button type="button" variant="ghost" size="icon" disabled={dialog.busy} aria-label="Refresh cloud contexts" onClick={() => void controller.refreshCloudContexts()}>
+          <RefreshCw aria-hidden="true" />
+        </Button>
+      </div>
+      <CloudContextDraftForm controller={controller} dialog={dialog} />
+      {contexts.length === 0 ? <div className="px-0.5 py-2 text-[13px] leading-[1.35] text-muted-foreground">No cloud contexts configured</div> : <CloudContextList controller={controller} dialog={dialog} />}
+    </div>
+  );
+}
+
+function CloudContextDraftForm({ controller, dialog }: { controller: ERunUIController; dialog: GlobalConfigDialog }): React.ReactElement {
+  const config = dialog.config;
+  const generated = generatedContextName((config.cloudProviders || []).find((provider) => provider.alias === dialog.cloudContextDraft.cloudProviderAlias), dialog.cloudContextDraft.region, config.cloudContexts || []);
+  return (
+    <div className="grid gap-2 rounded-[var(--radius)] border border-border p-3">
+      <div className="grid gap-2 sm:grid-cols-2">
+        <SelectInput id="global-config-cloudcontext-provider" label="Cloud provider" value={dialog.cloudContextDraft.cloudProviderAlias} options={(config.cloudProviders || []).map((provider) => provider.alias)} emptyLabel="No cloud aliases" disabled={dialog.busy || (config.cloudProviders || []).length === 0} onChange={(cloudProviderAlias) => controller.updateCloudContextDraft({ cloudProviderAlias })} />
+        <RegionSelectInput id="global-config-cloudcontext-region" value={dialog.cloudContextDraft.region} disabled={dialog.busy} onChange={(region) => controller.updateCloudContextDraft({ region })} />
+        <SelectInput id="global-config-cloudcontext-instancetype" label="Instance type" value={dialog.cloudContextDraft.instanceType} options={['c8gd.2xlarge', 't4g.xlarge']} disabled={dialog.busy} onChange={(instanceType) => controller.updateCloudContextDraft({ instanceType })} />
+        <SelectInput id="global-config-cloudcontext-disksize" label="Disk size" value={String(dialog.cloudContextDraft.diskSizeGb)} options={['100', '200']} disabled={dialog.busy} onChange={(diskSizeGb) => controller.updateCloudContextDraft({ diskSizeGb: Number(diskSizeGb) })} />
+      </div>
+      <CloudContextNameField controller={controller} dialog={dialog} generatedName={generated} />
+    </div>
+  );
+}
+
+function CloudContextNameField({ controller, dialog, generatedName }: { controller: ERunUIController; dialog: GlobalConfigDialog; generatedName: string }): React.ReactElement {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="global-config-cloudcontext-name">Context name</Label>
+      <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+        <Input id="global-config-cloudcontext-name" value={dialog.cloudContextDraft.name} disabled={dialog.busy} placeholder="Generated when empty" onChange={(event) => controller.updateCloudContextDraft({ name: event.target.value })} />
+        <Button type="button" size="sm" disabled={dialog.busy || dialog.configLoading || !dialog.cloudContextDraft.cloudProviderAlias || !dialog.cloudContextDraft.region} onClick={() => void controller.initCloudContext()}>
+          {dialog.busyAction === 'cloud-context-init' ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Plus aria-hidden="true" />}
+          Init
+        </Button>
+      </div>
+      {generatedName && !dialog.cloudContextDraft.name && <div className="px-0.5 text-xs leading-[1.35] text-muted-foreground [overflow-wrap:anywhere]">Generated: {generatedName}</div>}
+    </div>
+  );
+}
+
+function CloudContextList({ controller, dialog }: { controller: ERunUIController; dialog: GlobalConfigDialog }): React.ReactElement {
+  return (
+    <div className="overflow-hidden rounded-[var(--radius)] border border-border">
+      {(dialog.config.cloudContexts || []).map((context, index) => (
+        <div key={context.name} className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-border px-3 py-2.5 data-[border=true]:border-t" data-border={index > 0} data-cloud-context={context.name} data-cloud-context-status={context.status}>
+          <CloudContextSummary context={context} />
+          <CloudContextAction status={context.status} busy={dialog.busy} loading={dialog.busyAction === 'cloud-context-power' && dialog.busyTarget === context.name} onStart={() => void controller.startCloudContext(context.name)} onStop={() => void controller.stopCloudContext(context.name)} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CloudContextSummary({ context }: { context: GlobalConfigDialog['config']['cloudContexts'][number] }): React.ReactElement {
+  return (
+    <div className="grid min-w-0 gap-1">
+      <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+        <Server className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <span className="truncate">{context.kubernetesContext || context.name}</span>
+        <StatusBadge status={context.status} />
+      </div>
+      <div className="truncate text-xs text-muted-foreground">
+        {cloudContextSummary(context)}
+        {context.message ? ` - ${context.message}` : ''}
+      </div>
+    </div>
+  );
+}
+
+function DialogError({ error }: { error: string }): React.ReactElement | null {
+  return error ? <div className={dialogErrorClassName} role="alert">{error}</div> : null;
+}
+
+function GlobalConfigFooter({ controller, dialog }: { controller: ERunUIController; dialog: GlobalConfigDialog }): React.ReactElement {
+  const saving = dialog.busyAction === 'save';
+  return (
+    <DialogFooter>
+      <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => controller.closeGlobalConfigDialog()}>Cancel</Button>
+      <Button type="submit" size="sm" disabled={dialog.busy || dialog.configLoading}>
+        {saving ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Save aria-hidden="true" />}
+        {saving ? 'Saving...' : 'Save settings'}
+      </Button>
+    </DialogFooter>
   );
 }
 

--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -18,14 +18,15 @@ import { cn } from '@/lib/utils';
 const dialogErrorClassName =
   'rounded-[var(--radius)] border border-[color-mix(in_oklch,var(--destructive)_36%,transparent)] bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] px-[11px] py-[9px] text-[13px] leading-[1.35] text-destructive [overflow-wrap:anywhere]';
 
+type ManageDialog = AppState['manageDialog'];
+
 export function ManageDialogView({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement {
   const dialog = state.manageDialog;
   const confirmationRef = React.useRef<HTMLInputElement>(null);
   const selection = dialog.selection;
-  const expected = selection ? deleteConfirmationValue(selection) : '';
   const confirmingDelete = dialog.tab === 'delete';
+  const expected = selection ? deleteConfirmationValue(selection) : '';
   const deleteEnabled = !dialog.busy && normalizeDialogValue(dialog.confirmation) === expected;
-  const config = dialog.config;
 
   React.useEffect(() => {
     if (!dialog.open || !confirmingDelete) {
@@ -57,172 +58,140 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
           <DialogHeader>
             <DialogTitle>{selection ? `${selection.tenant}-${selection.environment}` : 'Environment'}</DialogTitle>
           </DialogHeader>
-          <div className="-mx-1 min-h-0 overflow-auto px-1 pb-1">
-            {dialog.configLoading ? (
-              <div className="rounded-[var(--radius)] border border-dashed border-border px-3 py-2.5 text-[13px] leading-[1.35] text-muted-foreground">
-                Loading config...
-              </div>
-            ) : (
-              <div className="grid gap-3">
-                <ReadonlyField id="environment-config-repopath" label="Repository path" value={config.repoPath} />
-                <ReadonlyField id="environment-config-kubernetescontext" label="Kubernetes context" value={config.kubernetesContext} />
-                <ReadonlyField id="environment-config-containerregistry" label="Container registry" value={config.containerRegistry} />
-                <CloudAliasSelect
-                  id="environment-config-cloudprovideralias"
-                  value={config.cloudProviderAlias}
-                  options={config.cloudProviderAliases || []}
-                  disabled={dialog.busy}
-                  onChange={(cloudProviderAlias) => controller.updateManageConfig({ cloudProviderAlias })}
-                />
-                <CloudContextField
-                  context={config.cloudContext}
-                  cloudProviderAlias={config.cloudProviderAlias}
-                  disabled={dialog.busy || dialog.configLoading}
-                  onStart={(name) => void controller.startManageCloudContext(name)}
-                  onStop={(name) => void controller.stopManageCloudContext(name)}
-                />
-                <RuntimeDeployField
-                  configuredVersion={config.runtimeVersion}
-                  overrideVersion={dialog.version}
-                  suggestions={state.versionSuggestions}
-                  choicesOpen={dialog.choicesOpen}
-                  disabled={dialog.busy || dialog.configLoading}
-                  onValueChange={(version) => controller.updateManageDialog({ version })}
-                  onChoicesOpenChange={(open) => controller.setManageVersionChoicesOpen(open)}
-                  onSelect={(suggestion) => controller.selectManageVersionSuggestion(suggestion)}
-                  onDeploy={() => void controller.submitManageDeploy().catch((error: unknown) => controller.showTerminalMessage(readError(error)))}
-                />
-                <CheckboxField id="environment-config-remote" label="Remote environment" checked={config.remote} disabled onChange={() => {}} />
-                <CheckboxField id="environment-config-snapshot" label="Snapshot deploy" checked={config.snapshot} disabled={dialog.busy} onChange={(snapshot) => controller.updateManageConfig({ snapshot })} />
-                <div className="grid gap-3 rounded-[var(--radius)] border border-border p-3">
-                  <div className="text-xs leading-[1.2] font-semibold tracking-normal text-muted-foreground uppercase">Idle stop</div>
-                  <TextField
-                    id="environment-config-idle-timeout"
-                    label="Timeout"
-                    value={config.idle.timeout}
-                    disabled={dialog.busy}
-                    onChange={(timeout) => controller.updateManageConfig({ idle: { ...config.idle, timeout } })}
-                  />
-                  <TextField
-                    id="environment-config-idle-workinghours"
-                    label="Working hours"
-                    value={config.idle.workingHours}
-                    disabled={dialog.busy}
-                    onChange={(workingHours) => controller.updateManageConfig({ idle: { ...config.idle, workingHours } })}
-                  />
-                  <TextField
-                    id="environment-config-idle-traffic"
-                    label="Idle SSH bytes"
-                    value={String(config.idle.idleTrafficBytes)}
-                    inputMode="numeric"
-                    disabled={dialog.busy}
-                    onChange={(idleTrafficBytes) => controller.updateManageConfig({ idle: { ...config.idle, idleTrafficBytes: parseIdleTrafficBytes(idleTrafficBytes) } })}
-                  />
-                </div>
-                <ReadonlyField id="environment-config-localportrange" label="Assigned local port range" value={portRangeValue(config.localPorts.rangeStart, config.localPorts.rangeEnd)} />
-                <PortStatusTable
-                  rows={[
-                    { service: 'mcp', port: config.localPorts.mcp, status: config.localPorts.mcpStatus },
-                    { service: 'ssh', port: config.localPorts.ssh, status: config.localPorts.sshStatus },
-                  ]}
-                />
-                <div className="grid gap-2 rounded-[var(--radius)] border border-border p-3">
-                  <div className="flex items-center justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="text-xs leading-[1.2] font-semibold tracking-normal text-muted-foreground uppercase">Diagnostics</div>
-                    </div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      disabled={dialog.busy || dialog.configLoading}
-                      onClick={() => void controller.startManageDoctor().catch((error: unknown) => controller.showTerminalMessage(readError(error)))}
-                    >
-                      <Stethoscope aria-hidden="true" />
-                      Run Doctor
-                    </Button>
-                  </div>
-                </div>
-                <div className="grid gap-3 rounded-[var(--radius)] border border-border p-3">
-                  <div className="flex items-center justify-between gap-3">
-                    <div className="text-xs leading-[1.2] font-semibold tracking-normal text-muted-foreground uppercase">SSH access</div>
-                    {!config.sshd.enabled && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        disabled={dialog.busy || dialog.configLoading || !config.remote}
-                        onClick={() => void controller.enableManageSSHD().catch((error: unknown) => controller.showTerminalMessage(readError(error)))}
-                      >
-                        <Server aria-hidden="true" />
-                        Enable SSHD
-                      </Button>
-                    )}
-                  </div>
-                  <CheckboxField id="environment-config-sshd-enabled" label="Enabled" checked={config.sshd.enabled} disabled onChange={() => {}} />
-                  <ReadonlyField
-                    id="environment-config-sshd-localport"
-                    label="Local port"
-                    value={config.sshd.localPort > 0 ? String(config.sshd.localPort) : ''}
-                  />
-                  <ReadonlyField id="environment-config-sshd-publickeypath" label="Public key" value={config.sshd.publicKeyPath} />
-                </div>
-                {confirmingDelete && (
-                  <div className="grid gap-3">
-                    {selection && (
-                      <div className="grid grid-cols-[18px_minmax(0,1fr)] items-start gap-[9px] rounded-[var(--radius)] border border-[color-mix(in_oklch,var(--destructive)_30%,var(--border))] bg-[color-mix(in_oklch,var(--destructive)_7%,transparent)] px-[11px] py-2.5 text-[13px] leading-[1.35] text-foreground">
-                        <AlertTriangle className="mt-px size-[17px] text-destructive" aria-hidden="true" />
-                        <span>
-                          Type{' '}
-                          <code className="rounded-[calc(var(--radius)-4px)] bg-[color-mix(in_oklch,var(--destructive)_12%,transparent)] px-1 py-px font-mono text-xs text-destructive">
-                            {expected}
-                          </code>{' '}
-                          to confirm.
-                        </span>
-                      </div>
-                    )}
-                    <TextField id="manage-confirmation" label="Confirmation" value={dialog.confirmation} disabled={dialog.busy} inputRef={confirmationRef} onChange={(confirmation) => controller.updateManageDialog({ confirmation })} />
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-          {dialog.error && (
-            <div className={dialogErrorClassName} role="alert">
-              {dialog.error}
-            </div>
-          )}
-          <DialogFooter>
-            <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => controller.closeManageDialog()}>
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              variant={confirmingDelete ? 'destructive' : 'outline'}
-              size="sm"
-              disabled={dialog.busy || (confirmingDelete && !deleteEnabled)}
-              onClick={() => {
-                if (confirmingDelete) {
-                  void controller.submitManageDelete();
-                  return;
-                }
-                controller.updateManageDialog({ tab: 'delete', confirmation: '' });
-              }}
-            >
-              {dialog.busy && confirmingDelete ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Trash2 aria-hidden="true" />}
-              {dialog.busy && confirmingDelete ? 'Deleting...' : 'Delete'}
-            </Button>
-            {!confirmingDelete && (
-              <Button type="button" size="sm" disabled={dialog.busy || dialog.configLoading} onClick={() => void controller.submitManageConfig().catch((error: unknown) => controller.showTerminalMessage(readError(error)))}>
-                {dialog.busy ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Save aria-hidden="true" />}
-                {dialog.busy ? 'Saving...' : 'Save'}
-              </Button>
-            )}
-          </DialogFooter>
+          <ManageDialogContent controller={controller} state={state} confirmationRef={confirmationRef} expected={expected} confirmingDelete={confirmingDelete} />
+          <DialogError error={dialog.error} />
+          <ManageDialogFooter controller={controller} dialog={dialog} confirmingDelete={confirmingDelete} deleteEnabled={deleteEnabled} />
         </form>
       </DialogContent>
     </Dialog>
   );
+}
+
+function ManageDialogContent({ controller, state, confirmationRef, expected, confirmingDelete }: { controller: ERunUIController; state: AppState; confirmationRef: React.Ref<HTMLInputElement>; expected: string; confirmingDelete: boolean }): React.ReactElement {
+  const dialog = state.manageDialog;
+  if (dialog.configLoading) {
+    return <div className="-mx-1 min-h-0 overflow-auto px-1 pb-1"><div className="rounded-[var(--radius)] border border-dashed border-border px-3 py-2.5 text-[13px] leading-[1.35] text-muted-foreground">Loading config...</div></div>;
+  }
+  return (
+    <div className="-mx-1 min-h-0 overflow-auto px-1 pb-1">
+      <div className="grid gap-3">
+        <ManageConfigFields controller={controller} state={state} />
+        {confirmingDelete && <DeleteConfirmationFields controller={controller} dialog={dialog} confirmationRef={confirmationRef} expected={expected} />}
+      </div>
+    </div>
+  );
+}
+
+function ManageConfigFields({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement {
+  const dialog = state.manageDialog;
+  const config = dialog.config;
+  return (
+    <>
+      <ReadonlyField id="environment-config-repopath" label="Repository path" value={config.repoPath} />
+      <ReadonlyField id="environment-config-kubernetescontext" label="Kubernetes context" value={config.kubernetesContext} />
+      <ReadonlyField id="environment-config-containerregistry" label="Container registry" value={config.containerRegistry} />
+      <CloudAliasSelect id="environment-config-cloudprovideralias" value={config.cloudProviderAlias} options={config.cloudProviderAliases || []} disabled={dialog.busy} onChange={(cloudProviderAlias) => controller.updateManageConfig({ cloudProviderAlias })} />
+      <CloudContextField context={config.cloudContext} cloudProviderAlias={config.cloudProviderAlias} disabled={dialog.busy || dialog.configLoading} onStart={(name) => void controller.startManageCloudContext(name)} onStop={(name) => void controller.stopManageCloudContext(name)} />
+      <RuntimeDeployField configuredVersion={config.runtimeVersion} overrideVersion={dialog.version} suggestions={state.versionSuggestions} choicesOpen={dialog.choicesOpen} disabled={dialog.busy || dialog.configLoading} onValueChange={(version) => controller.updateManageDialog({ version })} onChoicesOpenChange={(open) => controller.setManageVersionChoicesOpen(open)} onSelect={(suggestion) => controller.selectManageVersionSuggestion(suggestion)} onDeploy={() => void controller.submitManageDeploy().catch((error: unknown) => controller.showTerminalMessage(readError(error)))} />
+      <CheckboxField id="environment-config-remote" label="Remote environment" checked={config.remote} disabled onChange={() => {}} />
+      <CheckboxField id="environment-config-snapshot" label="Snapshot deploy" checked={config.snapshot} disabled={dialog.busy} onChange={(snapshot) => controller.updateManageConfig({ snapshot })} />
+      <IdleStopFields controller={controller} dialog={dialog} />
+      <ReadonlyField id="environment-config-localportrange" label="Assigned local port range" value={portRangeValue(config.localPorts.rangeStart, config.localPorts.rangeEnd)} />
+      <PortStatusTable rows={[{ service: 'mcp', port: config.localPorts.mcp, status: config.localPorts.mcpStatus }, { service: 'ssh', port: config.localPorts.ssh, status: config.localPorts.sshStatus }]} />
+      <DiagnosticsSection controller={controller} dialog={dialog} />
+      <SSHAccessSection controller={controller} dialog={dialog} />
+    </>
+  );
+}
+
+function IdleStopFields({ controller, dialog }: { controller: ERunUIController; dialog: ManageDialog }): React.ReactElement {
+  const config = dialog.config;
+  return (
+    <div className="grid gap-3 rounded-[var(--radius)] border border-border p-3">
+      <div className="text-xs leading-[1.2] font-semibold tracking-normal text-muted-foreground uppercase">Idle stop</div>
+      <TextField id="environment-config-idle-timeout" label="Timeout" value={config.idle.timeout} disabled={dialog.busy} onChange={(timeout) => controller.updateManageConfig({ idle: { ...config.idle, timeout } })} />
+      <TextField id="environment-config-idle-workinghours" label="Working hours" value={config.idle.workingHours} disabled={dialog.busy} onChange={(workingHours) => controller.updateManageConfig({ idle: { ...config.idle, workingHours } })} />
+      <TextField id="environment-config-idle-traffic" label="Idle SSH bytes" value={String(config.idle.idleTrafficBytes)} inputMode="numeric" disabled={dialog.busy} onChange={(idleTrafficBytes) => controller.updateManageConfig({ idle: { ...config.idle, idleTrafficBytes: parseIdleTrafficBytes(idleTrafficBytes) } })} />
+    </div>
+  );
+}
+
+function DiagnosticsSection({ controller, dialog }: { controller: ERunUIController; dialog: ManageDialog }): React.ReactElement {
+  return (
+    <div className="grid gap-2 rounded-[var(--radius)] border border-border p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0"><div className="text-xs leading-[1.2] font-semibold tracking-normal text-muted-foreground uppercase">Diagnostics</div></div>
+        <Button type="button" variant="outline" size="sm" disabled={dialog.busy || dialog.configLoading} onClick={() => void controller.startManageDoctor().catch((error: unknown) => controller.showTerminalMessage(readError(error)))}>
+          <Stethoscope aria-hidden="true" />
+          Run Doctor
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function SSHAccessSection({ controller, dialog }: { controller: ERunUIController; dialog: ManageDialog }): React.ReactElement {
+  const config = dialog.config;
+  return (
+    <div className="grid gap-3 rounded-[var(--radius)] border border-border p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-xs leading-[1.2] font-semibold tracking-normal text-muted-foreground uppercase">SSH access</div>
+        {!config.sshd.enabled && <Button type="button" variant="outline" size="sm" disabled={dialog.busy || dialog.configLoading || !config.remote} onClick={() => void controller.enableManageSSHD().catch((error: unknown) => controller.showTerminalMessage(readError(error)))}><Server aria-hidden="true" />Enable SSHD</Button>}
+      </div>
+      <CheckboxField id="environment-config-sshd-enabled" label="Enabled" checked={config.sshd.enabled} disabled onChange={() => {}} />
+      <ReadonlyField id="environment-config-sshd-localport" label="Local port" value={config.sshd.localPort > 0 ? String(config.sshd.localPort) : ''} />
+      <ReadonlyField id="environment-config-sshd-publickeypath" label="Public key" value={config.sshd.publicKeyPath} />
+    </div>
+  );
+}
+
+function DeleteConfirmationFields({ controller, dialog, confirmationRef, expected }: { controller: ERunUIController; dialog: ManageDialog; confirmationRef: React.Ref<HTMLInputElement>; expected: string }): React.ReactElement {
+  return (
+    <div className="grid gap-3">
+      <DeleteWarning expected={expected} />
+      <TextField id="manage-confirmation" label="Confirmation" value={dialog.confirmation} disabled={dialog.busy} inputRef={confirmationRef} onChange={(confirmation) => controller.updateManageDialog({ confirmation })} />
+    </div>
+  );
+}
+
+function DeleteWarning({ expected }: { expected: string }): React.ReactElement {
+  return (
+    <div className="grid grid-cols-[18px_minmax(0,1fr)] items-start gap-[9px] rounded-[var(--radius)] border border-[color-mix(in_oklch,var(--destructive)_30%,var(--border))] bg-[color-mix(in_oklch,var(--destructive)_7%,transparent)] px-[11px] py-2.5 text-[13px] leading-[1.35] text-foreground">
+      <AlertTriangle className="mt-px size-[17px] text-destructive" aria-hidden="true" />
+      <span>Type <code className="rounded-[calc(var(--radius)-4px)] bg-[color-mix(in_oklch,var(--destructive)_12%,transparent)] px-1 py-px font-mono text-xs text-destructive">{expected}</code> to confirm.</span>
+    </div>
+  );
+}
+
+function DialogError({ error }: { error: string }): React.ReactElement | null {
+  return error ? <div className={dialogErrorClassName} role="alert">{error}</div> : null;
+}
+
+function ManageDialogFooter({ controller, dialog, confirmingDelete, deleteEnabled }: { controller: ERunUIController; dialog: ManageDialog; confirmingDelete: boolean; deleteEnabled: boolean }): React.ReactElement {
+  return (
+    <DialogFooter>
+      <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => controller.closeManageDialog()}>Cancel</Button>
+      <DeleteButton controller={controller} dialog={dialog} confirmingDelete={confirmingDelete} deleteEnabled={deleteEnabled} />
+      {!confirmingDelete && <Button type="button" size="sm" disabled={dialog.busy || dialog.configLoading} onClick={() => void controller.submitManageConfig().catch((error: unknown) => controller.showTerminalMessage(readError(error)))}>{dialog.busy ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Save aria-hidden="true" />}{dialog.busy ? 'Saving...' : 'Save'}</Button>}
+    </DialogFooter>
+  );
+}
+
+function DeleteButton({ controller, dialog, confirmingDelete, deleteEnabled }: { controller: ERunUIController; dialog: ManageDialog; confirmingDelete: boolean; deleteEnabled: boolean }): React.ReactElement {
+  return (
+    <Button type="button" variant={confirmingDelete ? 'destructive' : 'outline'} size="sm" disabled={dialog.busy || (confirmingDelete && !deleteEnabled)} onClick={() => submitOrStartDelete(controller, confirmingDelete)}>
+      {dialog.busy && confirmingDelete ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Trash2 aria-hidden="true" />}
+      {dialog.busy && confirmingDelete ? 'Deleting...' : 'Delete'}
+    </Button>
+  );
+}
+
+function submitOrStartDelete(controller: ERunUIController, confirmingDelete: boolean): void {
+  if (confirmingDelete) {
+    void controller.submitManageDelete();
+    return;
+  }
+  controller.updateManageDialog({ tab: 'delete', confirmation: '' });
 }
 
 function CloudContextField({

--- a/erun-ui/frontend/src/components/app/ReviewPanel.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewPanel.tsx
@@ -29,16 +29,11 @@ export function ReviewPanel({
   reviewMainRef: React.RefObject<HTMLDivElement | null>;
   diffListRef: React.RefObject<HTMLDivElement | null>;
 }): React.ReactElement {
+  const filesVisible = state.filesOpen && state.reviewOpen;
   return (
     <section
       ref={reviewViewRef}
-      className={cn(
-        'relative grid h-full min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground',
-        state.filesOpen
-          ? 'grid-cols-[minmax(260px,1fr)_10px_minmax(220px,var(--files-width))] max-[980px]:grid-cols-[minmax(0,1fr)]'
-          : 'grid-cols-[minmax(0,1fr)]',
-        !state.reviewOpen && 'hidden',
-      )}
+      className={reviewPanelClassName(state.reviewOpen, state.filesOpen)}
     >
       <div
         ref={reviewMainRef}
@@ -49,67 +44,92 @@ export function ReviewPanel({
           <DiffList controller={controller} state={state} />
         </div>
       </div>
-      <div
-        className={cn(filesSplitterClassName, (!state.filesOpen || !state.reviewOpen) && 'hidden', 'max-[980px]:hidden')}
-        role="separator"
-        aria-orientation="vertical"
-        aria-label="Resize changed files list"
-        onMouseDown={(event) => controller.startFilesResize(event)}
-      />
-      <aside
-        className={cn(
-          'box-border flex h-full min-h-0 min-w-0 flex-col overflow-hidden border-l bg-background px-[18px] py-5',
-          (!state.filesOpen || !state.reviewOpen) && 'hidden',
-          'max-[980px]:hidden',
-        )}
-      >
-        <div className="mb-3.5 flex min-w-0 items-center justify-between gap-3">
-          <button
-            className="inline-flex min-w-0 flex-1 cursor-pointer items-center gap-1 overflow-hidden border-0 bg-transparent p-0 text-sm font-semibold whitespace-nowrap text-foreground [&_svg]:size-4 [&_svg]:flex-none [&_svg]:text-muted-foreground"
-            type="button"
-          >
-            <FileDiff aria-hidden="true" />
-            Changed files <span className="flex-none text-muted-foreground">{state.diff?.summary?.fileCount || 0}</span>
-            <ChevronDown aria-hidden="true" />
-          </button>
-          <div className="flex min-w-0 flex-none items-center gap-2">
-            <IconTooltip label="Refresh diff">
-              <Button
-                className="size-7 cursor-pointer border-0 bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:cursor-default disabled:opacity-55 [&_svg]:size-[17px]"
-                type="button"
-                variant="ghost"
-                size="icon"
-                aria-label="Refresh diff"
-                disabled={state.diffLoading}
-                onClick={() => {
-                  void controller.loadReviewDiff();
-                }}
-              >
-                <RefreshCw />
-              </Button>
-            </IconTooltip>
-            <div className="flex gap-1.5 text-sm font-semibold whitespace-nowrap">
-              <span className="text-diff-add-foreground">+{state.diff?.summary?.additions || 0}</span>
-              <span className="text-diff-delete-foreground">-{state.diff?.summary?.deletions || 0}</span>
-            </div>
-          </div>
-        </div>
-        <Label className="box-border flex h-[38px] items-center gap-2 rounded-[var(--radius)] border border-input bg-background px-3 text-muted-foreground [&_svg]:size-[18px] [&_svg]:flex-none">
-          <Search aria-hidden="true" />
-          <Input
-            className="h-auto min-w-0 flex-1 border-0 bg-transparent p-0 text-sm text-foreground shadow-none outline-none placeholder:text-muted-foreground focus-visible:border-0 focus-visible:ring-0"
-            value={state.diffFilter}
-            type="search"
-            placeholder="Filter files..."
-            autoComplete="off"
-            onChange={(event) => controller.setDiffFilter(event.target.value)}
-          />
-        </Label>
-        <div className="min-h-0 flex-1 overflow-auto overscroll-contain pt-3.5">
-          <ChangedFileTree controller={controller} state={state} />
-        </div>
-      </aside>
+      <ChangedFilesSplitter visible={filesVisible} onMouseDown={(event) => controller.startFilesResize(event)} />
+      <ChangedFilesAside controller={controller} state={state} visible={filesVisible} />
     </section>
+  );
+}
+
+function reviewPanelClassName(reviewOpen: boolean, filesOpen: boolean): string {
+  const gridClassName = filesOpen
+    ? 'grid-cols-[minmax(260px,1fr)_10px_minmax(220px,var(--files-width))] max-[980px]:grid-cols-[minmax(0,1fr)]'
+    : 'grid-cols-[minmax(0,1fr)]';
+  return cn('relative grid h-full min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground', gridClassName, !reviewOpen && 'hidden');
+}
+
+function ChangedFilesSplitter({ visible, onMouseDown }: { visible: boolean; onMouseDown: React.MouseEventHandler<HTMLDivElement> }): React.ReactElement {
+  return (
+    <div
+      className={cn(filesSplitterClassName, !visible && 'hidden', 'max-[980px]:hidden')}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize changed files list"
+      onMouseDown={onMouseDown}
+    />
+  );
+}
+
+function ChangedFilesAside({ controller, state, visible }: { controller: ERunUIController; state: AppState; visible: boolean }): React.ReactElement {
+  return (
+    <aside
+      className={cn(
+        'box-border flex h-full min-h-0 min-w-0 flex-col overflow-hidden border-l bg-background px-[18px] py-5',
+        !visible && 'hidden',
+        'max-[980px]:hidden',
+      )}
+    >
+      <ChangedFilesHeader controller={controller} state={state} />
+      <Label className="box-border flex h-[38px] items-center gap-2 rounded-[var(--radius)] border border-input bg-background px-3 text-muted-foreground [&_svg]:size-[18px] [&_svg]:flex-none">
+        <Search aria-hidden="true" />
+        <Input
+          className="h-auto min-w-0 flex-1 border-0 bg-transparent p-0 text-sm text-foreground shadow-none outline-none placeholder:text-muted-foreground focus-visible:border-0 focus-visible:ring-0"
+          value={state.diffFilter}
+          type="search"
+          placeholder="Filter files..."
+          autoComplete="off"
+          onChange={(event) => controller.setDiffFilter(event.target.value)}
+        />
+      </Label>
+      <div className="min-h-0 flex-1 overflow-auto overscroll-contain pt-3.5">
+        <ChangedFileTree controller={controller} state={state} />
+      </div>
+    </aside>
+  );
+}
+
+function ChangedFilesHeader({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement {
+  return (
+    <div className="mb-3.5 flex min-w-0 items-center justify-between gap-3">
+      <button
+        className="inline-flex min-w-0 flex-1 cursor-pointer items-center gap-1 overflow-hidden border-0 bg-transparent p-0 text-sm font-semibold whitespace-nowrap text-foreground [&_svg]:size-4 [&_svg]:flex-none [&_svg]:text-muted-foreground"
+        type="button"
+      >
+        <FileDiff aria-hidden="true" />
+        Changed files <span className="flex-none text-muted-foreground">{state.diff?.summary?.fileCount || 0}</span>
+        <ChevronDown aria-hidden="true" />
+      </button>
+      <div className="flex min-w-0 flex-none items-center gap-2">
+        <IconTooltip label="Refresh diff">
+          <Button
+            className="size-7 cursor-pointer border-0 bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:cursor-default disabled:opacity-55 [&_svg]:size-[17px]"
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Refresh diff"
+            disabled={state.diffLoading}
+            onClick={() => {
+              void controller.loadReviewDiff();
+            }}
+          >
+            <RefreshCw />
+          </Button>
+        </IconTooltip>
+        <div className="flex gap-1.5 text-sm font-semibold whitespace-nowrap">
+          <span className="text-diff-add-foreground">+{state.diff?.summary?.additions || 0}</span>
+          <span className="text-diff-delete-foreground">-{state.diff?.summary?.deletions || 0}</span>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/erun-ui/frontend/src/components/app/Sidebar.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.tsx
@@ -112,59 +112,78 @@ function TenantGroup({
       </div>
       {!collapsed && (
         <div className="flex flex-col gap-0 pt-0">
-          {tenant.environments.map((environment) => {
-            const selected = state.selected?.tenant === tenant.name && state.selected?.environment === environment.name;
-            const selection = { tenant: tenant.name, environment: environment.name };
-            const busy = environmentIsBusy(state, tenant.name, environment.name);
-
-            return (
-              <div
-                key={environment.name}
-                className={cn(
-                  'group relative mr-1 ml-1 flex h-8 items-center rounded-md pr-1.5 text-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-                  selected && 'bg-primary text-primary-foreground shadow-sm hover:bg-primary hover:text-primary-foreground',
-                )}
-              >
-                <button
-                  type="button"
-                  className={cn(
-                    'flex h-8 min-w-0 flex-1 cursor-pointer items-center gap-1.5 border-0 bg-transparent py-0 pr-2 pl-10 text-left text-sm leading-[1.2] tracking-normal text-inherit',
-                    selected ? 'font-medium' : 'font-normal',
-                  )}
-                  title={`${tenant.name} / ${environment.name}`}
-                  aria-current={selected ? 'page' : undefined}
-                  onClick={() => {
-                    void controller.openSelection(selection).catch((error: unknown) => {
-                      controller.showTerminalMessage(readError(error));
-                    });
-                  }}
-                >
-                  <span className="min-w-0 truncate">{environment.name}</span>
-                  {busy && <LoaderCircle className="size-3.5 flex-none animate-spin text-current opacity-75" aria-hidden="true" />}
-                </button>
-                <IconTooltip label="Manage environment">
-                  <Button
-                    type="button"
-                    className={cn(
-                      'pointer-events-none size-[26px] flex-none cursor-pointer border-0 bg-transparent text-current opacity-0 transition-[opacity,background-color,color] duration-150 hover:bg-[color-mix(in_oklch,currentColor_12%,transparent)] hover:text-current group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 [&_svg]:size-4',
-                      selected && 'pointer-events-auto opacity-100',
-                    )}
-                    variant="ghost"
-                    size="icon"
-                    aria-label={`Manage ${tenant.name} / ${environment.name}`}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      controller.openManageDialog(selection);
-                    }}
-                  >
-                    <MoreHorizontal />
-                  </Button>
-                </IconTooltip>
-              </div>
-            );
-          })}
+          {tenant.environments.map((environment) => (
+            <EnvironmentRow
+              key={environment.name}
+              controller={controller}
+              state={state}
+              tenantName={tenant.name}
+              environmentName={environment.name}
+            />
+          ))}
         </div>
       )}
+    </div>
+  );
+}
+
+function EnvironmentRow({
+  controller,
+  state,
+  tenantName,
+  environmentName,
+}: {
+  controller: ERunUIController;
+  state: AppState;
+  tenantName: string;
+  environmentName: string;
+}): React.ReactElement {
+  const selected = state.selected?.tenant === tenantName && state.selected?.environment === environmentName;
+  const selection = { tenant: tenantName, environment: environmentName };
+  const busy = environmentIsBusy(state, tenantName, environmentName);
+
+  return (
+    <div
+      className={cn(
+        'group relative mr-1 ml-1 flex h-8 items-center rounded-md pr-1.5 text-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+        selected && 'bg-primary text-primary-foreground shadow-sm hover:bg-primary hover:text-primary-foreground',
+      )}
+    >
+      <button
+        type="button"
+        className={cn(
+          'flex h-8 min-w-0 flex-1 cursor-pointer items-center gap-1.5 border-0 bg-transparent py-0 pr-2 pl-10 text-left text-sm leading-[1.2] tracking-normal text-inherit',
+          selected ? 'font-medium' : 'font-normal',
+        )}
+        title={`${tenantName} / ${environmentName}`}
+        aria-current={selected ? 'page' : undefined}
+        onClick={() => {
+          void controller.openSelection(selection).catch((error: unknown) => {
+            controller.showTerminalMessage(readError(error));
+          });
+        }}
+      >
+        <span className="min-w-0 truncate">{environmentName}</span>
+        {busy && <LoaderCircle className="size-3.5 flex-none animate-spin text-current opacity-75" aria-hidden="true" />}
+      </button>
+      <IconTooltip label="Manage environment">
+        <Button
+          type="button"
+          className={cn(
+            'pointer-events-none size-[26px] flex-none cursor-pointer border-0 bg-transparent text-current opacity-0 transition-[opacity,background-color,color] duration-150 hover:bg-[color-mix(in_oklch,currentColor_12%,transparent)] hover:text-current group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 [&_svg]:size-4',
+            selected && 'pointer-events-auto opacity-100',
+          )}
+          variant="ghost"
+          size="icon"
+          aria-label={`Manage ${tenantName} / ${environmentName}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            controller.openManageDialog(selection);
+          }}
+        >
+          <MoreHorizontal />
+        </Button>
+      </IconTooltip>
     </div>
   );
 }

--- a/erun-ui/frontend/src/components/app/Titlebar.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.tsx
@@ -14,39 +14,31 @@ const titlebarButtonClassName =
 const activeTitlebarButtonClassName = 'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground';
 
 export function Titlebar({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement {
-  const SidebarIcon = state.sidebarHidden ? PanelLeftOpen : PanelLeftClose;
-  const ReviewIcon = state.reviewOpen ? PanelRightClose : PanelRightOpen;
-  const notification = state.notification;
-  const selected = state.selected;
-  const selectedEnvironment = selected ? state.tenants.find((tenant) => tenant.name === selected.tenant)?.environments.find((environment) => environment.name === selected.environment) : undefined;
-  const ideDisabled = !selected || selectedEnvironment?.sshdEnabled !== true;
-  const vscodeTooltip = ideTooltipLabel('VS Code', selected, ideDisabled);
-  const intellijTooltip = ideTooltipLabel('IntelliJ IDEA', selected, ideDisabled);
-  const terminalOverlayVisible = state.terminalBusy && Boolean(state.terminalMessage);
-  const terminalStatus = !notification && !terminalOverlayVisible && state.terminalMessage
-    ? {
-        kind: state.terminalStatusKind,
-        message: state.terminalMessage,
-        detail: state.terminalStatusDetail,
-        busy: state.terminalBusy,
-        copyOutput: state.terminalCopyOutput,
-        copyStatus: state.terminalCopyStatus,
-        action: state.terminalStatusAction,
-      }
-    : null;
-  const status = notification ? { ...notification, detail: '', busy: false, copyOutput: '', copyStatus: '', action: '' } : terminalStatus;
-  const NotificationIcon = status?.busy ? LoaderCircle : status?.kind === 'success' ? CheckCircle2 : status?.kind === 'warning' || status?.kind === 'error' ? AlertCircle : Info;
-  const idleStatus = state.idleStatus;
-  const idleBadge = idleStatus ? idleStatusBadge(idleStatus) : null;
-  const idleAction = idleStatus ? idleCloudAction(idleStatus, state.idleCloudContextBusy) : null;
-  const IdleActionIcon = idleAction?.busy ? LoaderCircle : idleAction?.action === 'start' ? Play : Power;
-
   return (
     <header
       className="relative box-border select-none border-b bg-[color-mix(in_oklch,var(--background)_94%,transparent)] [--wails-draggable:drag]"
       data-wails-drag
       onDoubleClick={(event) => controller.titlebarDoubleClick(event)}
     >
+      <TitlebarControls controller={controller} state={state} />
+      <IdleStatusWidget controller={controller} state={state} />
+      <TitlebarStatus controller={controller} state={state} />
+      <div className="absolute inset-0" data-wails-drag />
+    </header>
+  );
+}
+
+function TitlebarControls({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement {
+  const SidebarIcon = state.sidebarHidden ? PanelLeftOpen : PanelLeftClose;
+  const ReviewIcon = state.reviewOpen ? PanelRightClose : PanelRightOpen;
+  const selected = state.selected;
+  const selectedEnvironment = selected ? state.tenants.find((tenant) => tenant.name === selected.tenant)?.environments.find((environment) => environment.name === selected.environment) : undefined;
+  const ideDisabled = !selected || selectedEnvironment?.sshdEnabled !== true;
+  const vscodeTooltip = ideTooltipLabel('VS Code', selected, ideDisabled);
+  const intellijTooltip = ideTooltipLabel('IntelliJ IDEA', selected, ideDisabled);
+
+  return (
+    <>
       <IconTooltip label="Toggle sidebar">
         <Button
           className={titlebarButtonClassName}
@@ -77,7 +69,7 @@ export function Titlebar({ controller, state }: { controller: ERunUIController; 
           <ReviewIcon />
         </Button>
       </IconTooltip>
-      <IconTooltip label={vscodeTooltip}>
+      <IconTooltip label={ideTooltipLabel('VS Code', selected, ideDisabled)}>
         <span className={cn(titlebarButtonClassName, 'left-auto right-[122px] max-[980px]:left-auto max-[980px]:right-[108px]')}>
           <Button
             className="size-full border-0 bg-transparent text-inherit hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-[18px]"
@@ -94,7 +86,7 @@ export function Titlebar({ controller, state }: { controller: ERunUIController; 
           </Button>
         </span>
       </IconTooltip>
-      <IconTooltip label={intellijTooltip}>
+      <IconTooltip label={ideTooltipLabel('IntelliJ IDEA', selected, ideDisabled)}>
         <span className={cn(titlebarButtonClassName, 'left-auto right-[90px] max-[980px]:left-auto max-[980px]:right-[78px]')}>
           <Button
             className="size-full border-0 bg-transparent text-inherit hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-[18px]"
@@ -129,142 +121,196 @@ export function Titlebar({ controller, state }: { controller: ERunUIController; 
           <ListTree />
         </Button>
       </IconTooltip>
-      {idleStatus && (
-        <div
-          className={cn(
-            'absolute top-3 right-[168px] z-[1] flex h-7 items-center rounded-md border bg-background [--wails-draggable:no-drag] max-[980px]:right-[146px]',
-            idleBadge?.className,
-          )}
-        >
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div
-                className={cn(
-                  'flex h-full min-w-[64px] items-center justify-center rounded-l-md px-2 font-mono text-[12px] leading-none outline-none hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring',
-                  idleAction && 'border-r',
-                  idleBadge?.className,
-                )}
-                tabIndex={0}
-                aria-label={idleStatusAccessibleLabel(idleStatus)}
-              >
-                {idleBadge?.label}
-              </div>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" align="end" className="max-w-[360px] whitespace-normal text-left leading-5">
-              <div className="space-y-1">
-                {idleStatusTooltipLines(idleStatus).map((line, index) => (
-                  <div key={`${index}-${line}`} className={line.startsWith('- ') ? 'pl-2' : undefined}>
-                    {line}
-                  </div>
-                ))}
-              </div>
-            </TooltipContent>
-          </Tooltip>
-          {idleAction && (
-            <IconTooltip label={idleAction.label}>
-              <Button
-                className="h-full w-7 rounded-l-none rounded-r-md border-0 bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-60 [&_svg]:size-3.5"
-                type="button"
-                variant="ghost"
-                size="icon"
-                aria-label={idleAction.label}
-                disabled={idleAction.busy}
-                onClick={() => {
-                  void controller.toggleIdleCloudContext();
-                }}
-              >
-                <IdleActionIcon className={cn(idleAction.busy && 'animate-spin')} aria-hidden="true" />
-              </Button>
-            </IconTooltip>
-          )}
-        </div>
-      )}
-      {status && (
-        <div
-          className={cn(
-            'pointer-events-none absolute top-2.5 left-32 z-20 flex justify-center [--wails-draggable:no-drag] max-[980px]:left-[112px]',
-            idleStatus ? (idleAction ? 'right-[268px] max-[980px]:right-[246px]' : 'right-[236px] max-[980px]:right-[214px]') : 'right-[168px] max-[980px]:right-[146px]',
-          )}
-          role={status.kind === 'error' ? 'alert' : 'status'}
-          aria-live={status.kind === 'error' ? 'assertive' : 'polite'}
-        >
-          <div
-            className={cn(
-              'pointer-events-auto flex h-8 max-w-full items-center gap-2 rounded-md border bg-background px-2.5 text-[13px] leading-none shadow-sm',
-              status.kind === 'success' && 'border-[oklch(0.72_0.12_150)] text-foreground',
-              status.kind === 'warning' && 'border-[oklch(0.76_0.16_65)] text-foreground',
-              status.kind === 'error' && 'border-destructive/60 text-foreground',
-              status.kind === 'info' && 'border-border text-foreground',
-            )}
-          >
-            <NotificationIcon
-              className={cn(
-                'size-4 flex-none',
-                status.busy && 'animate-spin text-muted-foreground',
-                status.kind === 'success' && 'text-[oklch(0.52_0.15_150)]',
-                status.kind === 'warning' && 'text-[oklch(0.58_0.15_65)]',
-                status.kind === 'error' && 'text-destructive',
-                status.kind === 'info' && 'text-muted-foreground',
-              )}
-              aria-hidden="true"
-            />
-            <span className="min-w-0 truncate" title={status.detail ? `${status.message}. ${status.detail}` : status.message}>
-              {status.message}
-              {status.detail && <span className="text-muted-foreground"> - {status.detail}</span>}
-            </span>
-            {status.action === 'wait-longer' && (
-              <Button
-                className="h-6 flex-none rounded-md px-2 text-[12px] text-foreground hover:bg-accent hover:text-accent-foreground"
-                type="button"
-                variant="ghost"
-                size="xs"
-                onClick={() => {
-                  void controller.waitLongerForTerminalStatus();
-                }}
-              >
-                Wait longer
-              </Button>
-            )}
-            {status.copyOutput && (
-              <IconTooltip label="Copy terminal output">
-                <Button
-                  className="h-6 flex-none gap-1 rounded-md px-2 text-[12px] text-foreground hover:bg-accent hover:text-accent-foreground [&_svg]:size-3.5"
-                  type="button"
-                  variant="ghost"
-                  size="xs"
-                  onClick={() => {
-                    void controller.copyTerminalOutput();
-                  }}
-                >
-                  {status.copyStatus === 'Copied' ? <CheckCircle2 aria-hidden="true" /> : <Copy aria-hidden="true" />}
-                  {status.copyStatus || 'Copy output'}
-                </Button>
-              </IconTooltip>
-            )}
-            <IconTooltip label="Dismiss status">
-              <Button
-                className="-mr-1 size-6 flex-none text-muted-foreground hover:bg-accent hover:text-accent-foreground [&_svg]:size-3.5"
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                aria-label="Dismiss status"
-                onClick={() => {
-                  if (notification) {
-                    controller.dismissNotification();
-                    return;
-                  }
-                  controller.dismissTerminalStatus();
-                }}
-              >
-                <X />
-              </Button>
-            </IconTooltip>
-          </div>
-        </div>
-      )}
-      <div className="absolute inset-0" data-wails-drag />
-    </header>
+    </>
   );
+}
+
+function IdleStatusWidget({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement | null {
+  const idleStatus = state.idleStatus;
+  if (!idleStatus) {
+    return null;
+  }
+  const idleBadge = idleStatusBadge(idleStatus);
+  const idleAction = idleCloudAction(idleStatus, state.idleCloudContextBusy);
+
+  return (
+    <div className={cn('absolute top-3 right-[168px] z-[1] flex h-7 items-center rounded-md border bg-background [--wails-draggable:no-drag] max-[980px]:right-[146px]', idleBadge.className)}>
+      <IdleStatusBadge idleStatus={idleStatus} idleBadge={idleBadge} hasAction={Boolean(idleAction)} />
+      {idleAction && <IdleStatusAction controller={controller} idleAction={idleAction} />}
+    </div>
+  );
+}
+
+function IdleStatusBadge({ idleStatus, idleBadge, hasAction }: { idleStatus: IdleStatus; idleBadge: { label: string; className: string }; hasAction: boolean }): React.ReactElement {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className={cn('flex h-full min-w-[64px] items-center justify-center rounded-l-md px-2 font-mono text-[12px] leading-none outline-none hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring', hasAction && 'border-r', idleBadge.className)} tabIndex={0} aria-label={idleStatusAccessibleLabel(idleStatus)}>
+          {idleBadge.label}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" align="end" className="max-w-[360px] whitespace-normal text-left leading-5">
+        <div className="space-y-1">
+          {idleStatusTooltipLines(idleStatus).map((line, index) => <div key={`${index}-${line}`} className={line.startsWith('- ') ? 'pl-2' : undefined}>{line}</div>)}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function IdleStatusAction({ controller, idleAction }: { controller: ERunUIController; idleAction: { action: 'start' | 'stop'; label: string; busy: boolean } }): React.ReactElement {
+  const IdleActionIcon = idleAction.busy ? LoaderCircle : idleAction.action === 'start' ? Play : Power;
+  return (
+    <IconTooltip label={idleAction.label}>
+      <Button className="h-full w-7 rounded-l-none rounded-r-md border-0 bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-60 [&_svg]:size-3.5" type="button" variant="ghost" size="icon" aria-label={idleAction.label} disabled={idleAction.busy} onClick={() => { void controller.toggleIdleCloudContext(); }}>
+        <IdleActionIcon className={cn(idleAction.busy && 'animate-spin')} aria-hidden="true" />
+      </Button>
+    </IconTooltip>
+  );
+}
+
+type TitlebarStatusKind = NonNullable<AppState['notification']>['kind'] | AppState['terminalStatusKind'];
+
+type TitlebarStatusValue = {
+  source: 'notification' | 'terminal';
+  kind: TitlebarStatusKind;
+  message: string;
+  detail: string;
+  busy: boolean;
+  copyOutput: string;
+  copyStatus: string;
+  action: AppState['terminalStatusAction'];
+};
+
+const statusBorderClassNames: Record<TitlebarStatusKind, string> = {
+  success: 'border-[oklch(0.72_0.12_150)] text-foreground',
+  warning: 'border-[oklch(0.76_0.16_65)] text-foreground',
+  error: 'border-destructive/60 text-foreground',
+  info: 'border-border text-foreground',
+};
+
+const statusIconClassNames: Record<TitlebarStatusKind, string> = {
+  success: 'text-[oklch(0.52_0.15_150)]',
+  warning: 'text-[oklch(0.58_0.15_65)]',
+  error: 'text-destructive',
+  info: 'text-muted-foreground',
+};
+
+function TitlebarStatus({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement | null {
+  const status = titlebarStatus(state);
+  if (!status) {
+    return null;
+  }
+  const idleAction = state.idleStatus ? idleCloudAction(state.idleStatus, state.idleCloudContextBusy) : null;
+
+  return (
+    <div className={statusPositionClassName(state.idleStatus, Boolean(idleAction))} role={status.kind === 'error' ? 'alert' : 'status'} aria-live={status.kind === 'error' ? 'assertive' : 'polite'}>
+      <div className={cn('pointer-events-auto flex h-8 max-w-full items-center gap-2 rounded-md border bg-background px-2.5 text-[13px] leading-none shadow-sm', statusBorderClassNames[status.kind])}>
+        <StatusIcon status={status} />
+        <StatusMessage status={status} />
+        {status.action === 'wait-longer' && <StatusWaitAction controller={controller} />}
+        {status.copyOutput && <StatusCopyAction controller={controller} status={status} />}
+        <StatusDismissAction controller={controller} status={status} />
+      </div>
+    </div>
+  );
+}
+
+function titlebarStatus(state: AppState): TitlebarStatusValue | null {
+  if (state.notification) {
+    return { ...state.notification, source: 'notification', detail: '', busy: false, copyOutput: '', copyStatus: '', action: '' };
+  }
+  if (state.terminalBusy && state.terminalMessage) {
+    return null;
+  }
+  if (!state.terminalMessage) {
+    return null;
+  }
+  return {
+    source: 'terminal',
+    kind: state.terminalStatusKind,
+    message: state.terminalMessage,
+    detail: state.terminalStatusDetail,
+    busy: state.terminalBusy,
+    copyOutput: state.terminalCopyOutput,
+    copyStatus: state.terminalCopyStatus,
+    action: state.terminalStatusAction,
+  };
+}
+
+function statusPositionClassName(idleStatus: AppState['idleStatus'], hasIdleAction: boolean): string {
+  if (!idleStatus) {
+    return 'pointer-events-none absolute top-2.5 left-32 right-[168px] z-20 flex justify-center [--wails-draggable:no-drag] max-[980px]:left-[112px] max-[980px]:right-[146px]';
+  }
+  if (hasIdleAction) {
+    return 'pointer-events-none absolute top-2.5 left-32 right-[268px] z-20 flex justify-center [--wails-draggable:no-drag] max-[980px]:left-[112px] max-[980px]:right-[246px]';
+  }
+  return 'pointer-events-none absolute top-2.5 left-32 right-[236px] z-20 flex justify-center [--wails-draggable:no-drag] max-[980px]:left-[112px] max-[980px]:right-[214px]';
+}
+
+function StatusIcon({ status }: { status: TitlebarStatusValue }): React.ReactElement {
+  const NotificationIcon = statusIcon(status);
+  return <NotificationIcon className={cn('size-4 flex-none', status.busy && 'animate-spin text-muted-foreground', statusIconClassNames[status.kind])} aria-hidden="true" />;
+}
+
+function statusIcon(status: TitlebarStatusValue): typeof LoaderCircle {
+  if (status.busy) {
+    return LoaderCircle;
+  }
+  if (status.kind === 'success') {
+    return CheckCircle2;
+  }
+  if (status.kind === 'warning' || status.kind === 'error') {
+    return AlertCircle;
+  }
+  return Info;
+}
+
+function StatusMessage({ status }: { status: TitlebarStatusValue }): React.ReactElement {
+  const title = status.detail ? `${status.message}. ${status.detail}` : status.message;
+  return (
+    <span className="min-w-0 truncate" title={title}>
+      {status.message}
+      {status.detail && <span className="text-muted-foreground"> - {status.detail}</span>}
+    </span>
+  );
+}
+
+function StatusWaitAction({ controller }: { controller: ERunUIController }): React.ReactElement {
+  return (
+    <Button className="h-6 flex-none rounded-md px-2 text-[12px] text-foreground hover:bg-accent hover:text-accent-foreground" type="button" variant="ghost" size="xs" onClick={() => { void controller.waitLongerForTerminalStatus(); }}>
+      Wait longer
+    </Button>
+  );
+}
+
+function StatusCopyAction({ controller, status }: { controller: ERunUIController; status: TitlebarStatusValue }): React.ReactElement {
+  return (
+    <IconTooltip label="Copy terminal output">
+      <Button className="h-6 flex-none gap-1 rounded-md px-2 text-[12px] text-foreground hover:bg-accent hover:text-accent-foreground [&_svg]:size-3.5" type="button" variant="ghost" size="xs" onClick={() => { void controller.copyTerminalOutput(); }}>
+        {status.copyStatus === 'Copied' ? <CheckCircle2 aria-hidden="true" /> : <Copy aria-hidden="true" />}
+        {status.copyStatus || 'Copy output'}
+      </Button>
+    </IconTooltip>
+  );
+}
+
+function StatusDismissAction({ controller, status }: { controller: ERunUIController; status: TitlebarStatusValue }): React.ReactElement {
+  return (
+    <IconTooltip label="Dismiss status">
+      <Button className="-mr-1 size-6 flex-none text-muted-foreground hover:bg-accent hover:text-accent-foreground [&_svg]:size-3.5" type="button" variant="ghost" size="icon-xs" aria-label="Dismiss status" onClick={() => dismissTitlebarStatus(controller, status)}>
+        <X />
+      </Button>
+    </IconTooltip>
+  );
+}
+
+function dismissTitlebarStatus(controller: ERunUIController, status: TitlebarStatusValue): void {
+  if (status.source === 'notification') {
+    controller.dismissNotification();
+    return;
+  }
+  controller.dismissTerminalStatus();
 }
 
 function ideTooltipLabel(ide: string, selected: AppState['selected'], disabled: boolean): string {
@@ -336,36 +382,58 @@ function isPersistentIdleBlocker(reason: string): boolean {
 }
 
 function idleStatusTooltipLines(idleStatus: IdleStatus): string[] {
-  const lines = [
+  const lines = idleStatusSummaryLines(idleStatus);
+  appendIdleBlockerLine(lines, idleStatus);
+  appendIdleCloudContextLine(lines, idleStatus);
+  lines.push(...idleStatusActiveMarkerLines(idleStatus));
+  appendIdleStopOutcomeLines(lines, idleStatus);
+  return lines;
+}
+
+function idleStatusSummaryLines(idleStatus: IdleStatus): string[] {
+  return [
     `Idle timeout: ${idleStatus.timeoutSeconds}s`,
     `Seconds until stop: ${idleStatus.secondsUntilStop}s`,
     `Stop eligible: ${idleStatus.stopEligible ? 'yes' : 'no'}`,
     `Working hours: ${idleStatus.outsideWorkingHours ? 'outside; autostop overrides activity' : 'inside; idle timeout applies'}`,
   ];
+}
+
+function appendIdleBlockerLine(lines: string[], idleStatus: IdleStatus): void {
   if (idleStatus.stopBlockedReason) {
     lines.push(`Blocked: ${idleStatus.stopBlockedReason}`);
   } else if (!idleStatus.managedCloud) {
     lines.push('Blocked: environment is not cloud-managed');
   }
+}
+
+function appendIdleCloudContextLine(lines: string[], idleStatus: IdleStatus): void {
   if (idleStatus.cloudContextName) {
     const label = idleStatus.cloudContextLabel || idleStatus.cloudContextName;
     lines.push(`Cloud environment: ${label}${idleStatus.cloudContextStatus ? ` (${idleStatus.cloudContextStatus})` : ''}`);
   }
+}
+
+function idleStatusActiveMarkerLines(idleStatus: IdleStatus): string[] {
   const activeMarkers = (idleStatus.markers || []).filter((marker) => marker.name !== 'working-hours' && !marker.idle);
-  if (activeMarkers.length > 0) {
-    lines.push('Active markers:');
-    for (const marker of activeMarkers) {
-      const remaining = marker.secondsRemaining && marker.secondsRemaining > 0 ? `, ${marker.secondsRemaining}s remaining` : '';
-      lines.push(`- ${marker.name}${marker.reason ? `: ${marker.reason}` : ''}${remaining}`);
-    }
+  if (activeMarkers.length === 0) {
+    return [];
   }
+  return ['Active markers:', ...activeMarkers.map(idleStatusActiveMarkerLine)];
+}
+
+function idleStatusActiveMarkerLine(marker: NonNullable<IdleStatus['markers']>[number]): string {
+  const remaining = marker.secondsRemaining && marker.secondsRemaining > 0 ? `, ${marker.secondsRemaining}s remaining` : '';
+  return `- ${marker.name}${marker.reason ? `: ${marker.reason}` : ''}${remaining}`;
+}
+
+function appendIdleStopOutcomeLines(lines: string[], idleStatus: IdleStatus): void {
   if (idleStatus.stopEligible) {
     lines.push('Autostop is ready.');
   }
   if (idleStatus.stopError) {
     lines.push('Stop error:', idleStatus.stopError);
   }
-  return lines;
 }
 
 function idleStatusAccessibleLabel(idleStatus: IdleStatus): string {

--- a/erun-ui/frontend/yarn.lock
+++ b/erun-ui/frontend/yarn.lock
@@ -285,6 +285,54 @@
   dependencies:
     tslib "^2.4.0"
 
+"@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
+  integrity sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
+  dependencies:
+    eslint-visitor-keys "^3.4.3"
+
+"@eslint-community/regexpp@^4.12.2":
+  version "4.12.2"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.2.tgz#bccdf615bcf7b6e8db830ec0b8d21c9a25de597b"
+  integrity sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
+
+"@eslint/config-array@^0.23.5":
+  version "0.23.5"
+  resolved "https://registry.yarnpkg.com/@eslint/config-array/-/config-array-0.23.5.tgz#56e86d243049195d8acc0c06a1b3dfdc3fa3de95"
+  integrity sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==
+  dependencies:
+    "@eslint/object-schema" "^3.0.5"
+    debug "^4.3.1"
+    minimatch "^10.2.4"
+
+"@eslint/config-helpers@^0.5.5":
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/@eslint/config-helpers/-/config-helpers-0.5.5.tgz#ae16134e4792ac5fbdc533548a24ac1ea9f7f3ae"
+  integrity sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==
+  dependencies:
+    "@eslint/core" "^1.2.1"
+
+"@eslint/core@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@eslint/core/-/core-1.2.1.tgz#c1da7cd1b82fa8787f98b5629fb811848a1b63ce"
+  integrity sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==
+  dependencies:
+    "@types/json-schema" "^7.0.15"
+
+"@eslint/object-schema@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@eslint/object-schema/-/object-schema-3.0.5.tgz#88e9bf4d11d2b19c082e78ebe7ce88724a5eb091"
+  integrity sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==
+
+"@eslint/plugin-kit@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz#c4125fd015eceeb09b793109fdbcd4dd0a02d346"
+  integrity sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==
+  dependencies:
+    "@eslint/core" "^1.2.1"
+    levn "^0.4.1"
+
 "@floating-ui/core@^1.7.5":
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.7.5.tgz#d4af157a03330af5a60e69da7a4692507ada0622"
@@ -316,6 +364,37 @@
   version "1.19.14"
   resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.14.tgz#e30f844bc77e3ce7be442aac3b1f73ad8b58d181"
   integrity sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==
+
+"@humanfs/core@^0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.2.tgz#a8272ca03b2acf492670222b2320b6c421bfde60"
+  integrity sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==
+  dependencies:
+    "@humanfs/types" "^0.15.0"
+
+"@humanfs/node@^0.16.6":
+  version "0.16.8"
+  resolved "https://registry.yarnpkg.com/@humanfs/node/-/node-0.16.8.tgz#8f800cccc13f4f8cd3116e2d9c0a94939da3e3ed"
+  integrity sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==
+  dependencies:
+    "@humanfs/core" "^0.19.2"
+    "@humanfs/types" "^0.15.0"
+    "@humanwhocodes/retry" "^0.4.0"
+
+"@humanfs/types@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@humanfs/types/-/types-0.15.0.tgz#f2a09f62012390b2bff3fc6fb248ddec8c09a090"
+  integrity sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==
+
+"@humanwhocodes/module-importer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
+  integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
+
+"@humanwhocodes/retry@^0.4.0", "@humanwhocodes/retry@^0.4.2":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
+  integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
 "@inquirer/ansi@^2.0.5":
   version "2.0.5"
@@ -1396,6 +1475,21 @@
   dependencies:
     tslib "^2.4.0"
 
+"@types/esrecurse@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@types/esrecurse/-/esrecurse-4.3.1.tgz#6f636af962fbe6191b830bd676ba5986926bccec"
+  integrity sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==
+
+"@types/estree@^1.0.6", "@types/estree@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
+  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+
+"@types/json-schema@^7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
 "@types/node@*", "@types/node@^25.6.0":
   version "25.6.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-25.6.0.tgz#4e09bad9b469871f2d0f68140198cbd714f4edca"
@@ -1432,6 +1526,102 @@
   resolved "https://registry.yarnpkg.com/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz#df0f7dac25df7761f7476605ddac54cb1abda26e"
   integrity sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==
 
+"@typescript-eslint/eslint-plugin@8.59.1":
+  version "8.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz#781bc6f9002982cfaf75a185240e24ad7276628a"
+  integrity sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==
+  dependencies:
+    "@eslint-community/regexpp" "^4.12.2"
+    "@typescript-eslint/scope-manager" "8.59.1"
+    "@typescript-eslint/type-utils" "8.59.1"
+    "@typescript-eslint/utils" "8.59.1"
+    "@typescript-eslint/visitor-keys" "8.59.1"
+    ignore "^7.0.5"
+    natural-compare "^1.4.0"
+    ts-api-utils "^2.5.0"
+
+"@typescript-eslint/parser@8.59.1":
+  version "8.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.59.1.tgz#835d20a62350659a082a1ae2a60b822c40488905"
+  integrity sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "8.59.1"
+    "@typescript-eslint/types" "8.59.1"
+    "@typescript-eslint/typescript-estree" "8.59.1"
+    "@typescript-eslint/visitor-keys" "8.59.1"
+    debug "^4.4.3"
+
+"@typescript-eslint/project-service@8.59.1":
+  version "8.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.59.1.tgz#49efe87c37ef84262f23df8bf62fdc56698ca6fe"
+  integrity sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==
+  dependencies:
+    "@typescript-eslint/tsconfig-utils" "^8.59.1"
+    "@typescript-eslint/types" "^8.59.1"
+    debug "^4.4.3"
+
+"@typescript-eslint/scope-manager@8.59.1":
+  version "8.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz#ed90d054fc3db2d0c81464db3a953a94fb85bb58"
+  integrity sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==
+  dependencies:
+    "@typescript-eslint/types" "8.59.1"
+    "@typescript-eslint/visitor-keys" "8.59.1"
+
+"@typescript-eslint/tsconfig-utils@8.59.1", "@typescript-eslint/tsconfig-utils@^8.59.1":
+  version "8.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz#ba2a779a444f1d5cb92a606f9b209d239fd4cab1"
+  integrity sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==
+
+"@typescript-eslint/type-utils@8.59.1":
+  version "8.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz#9c83d3f2ed9187a815e8120f72c08317e513e409"
+  integrity sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==
+  dependencies:
+    "@typescript-eslint/types" "8.59.1"
+    "@typescript-eslint/typescript-estree" "8.59.1"
+    "@typescript-eslint/utils" "8.59.1"
+    debug "^4.4.3"
+    ts-api-utils "^2.5.0"
+
+"@typescript-eslint/types@8.59.1", "@typescript-eslint/types@^8.59.1":
+  version "8.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.59.1.tgz#c1d014d3f03a97e0113a8899fc9d4e45a7fb0ca9"
+  integrity sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==
+
+"@typescript-eslint/typescript-estree@8.59.1":
+  version "8.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz#4391fadf98a22c869c5b6522dbf4e491e53e351a"
+  integrity sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==
+  dependencies:
+    "@typescript-eslint/project-service" "8.59.1"
+    "@typescript-eslint/tsconfig-utils" "8.59.1"
+    "@typescript-eslint/types" "8.59.1"
+    "@typescript-eslint/visitor-keys" "8.59.1"
+    debug "^4.4.3"
+    minimatch "^10.2.2"
+    semver "^7.7.3"
+    tinyglobby "^0.2.15"
+    ts-api-utils "^2.5.0"
+
+"@typescript-eslint/utils@8.59.1":
+  version "8.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.59.1.tgz#cf6204d69701bbbc5b150f98c18aeef0a42c10bd"
+  integrity sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.9.1"
+    "@typescript-eslint/scope-manager" "8.59.1"
+    "@typescript-eslint/types" "8.59.1"
+    "@typescript-eslint/typescript-estree" "8.59.1"
+
+"@typescript-eslint/visitor-keys@8.59.1":
+  version "8.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz#b5cba576287a3eeb0b400b62813189abcc3f976a"
+  integrity sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==
+  dependencies:
+    "@typescript-eslint/types" "8.59.1"
+    eslint-visitor-keys "^5.0.0"
+
 "@vitejs/plugin-react@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz#d9113b71a0a592714913eafd9e5e63bcafd0ff15"
@@ -1457,6 +1647,16 @@ accepts@^2.0.0:
     mime-types "^3.0.0"
     negotiator "^1.0.0"
 
+acorn-jsx@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
+acorn@^8.16.0:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
+  integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
+
 agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
@@ -1468,6 +1668,16 @@ ajv-formats@^3.0.1:
   integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
   dependencies:
     ajv "^8.0.0"
+
+ajv@^6.14.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
+  integrity sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 ajv@^8.0.0, ajv@^8.17.1:
   version "8.20.0"
@@ -1755,7 +1965,7 @@ data-uri-to-buffer@^4.0.0:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
   integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
-debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.4.0, debug@^4.4.3:
+debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -1766,6 +1976,11 @@ dedent@^1.6.0:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.7.2.tgz#34e2264ab538301e27cf7b07bf2369c19baa8dd9"
   integrity sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==
+
+deep-is@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 deepmerge@^4.3.1:
   version "4.3.1"
@@ -1906,10 +2121,104 @@ escape-html@^1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+eslint-scope@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-9.1.2.tgz#b9de6ace2fab1cff24d2e58d85b74c8fcea39802"
+  integrity sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==
+  dependencies:
+    "@types/esrecurse" "^4.3.1"
+    "@types/estree" "^1.0.8"
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
+
+eslint-visitor-keys@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+
+eslint-visitor-keys@^5.0.0, eslint-visitor-keys@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz#9e3c9489697824d2d4ce3a8ad12628f91e9f59be"
+  integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
+
+eslint@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-10.2.1.tgz#224b2a6caeb34473eddcf918762363e2e063222a"
+  integrity sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.8.0"
+    "@eslint-community/regexpp" "^4.12.2"
+    "@eslint/config-array" "^0.23.5"
+    "@eslint/config-helpers" "^0.5.5"
+    "@eslint/core" "^1.2.1"
+    "@eslint/plugin-kit" "^0.7.1"
+    "@humanfs/node" "^0.16.6"
+    "@humanwhocodes/module-importer" "^1.0.1"
+    "@humanwhocodes/retry" "^0.4.2"
+    "@types/estree" "^1.0.6"
+    ajv "^6.14.0"
+    cross-spawn "^7.0.6"
+    debug "^4.3.2"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^9.1.2"
+    eslint-visitor-keys "^5.0.1"
+    espree "^11.2.0"
+    esquery "^1.7.0"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^8.0.0"
+    find-up "^5.0.0"
+    glob-parent "^6.0.2"
+    ignore "^5.2.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    minimatch "^10.2.4"
+    natural-compare "^1.4.0"
+    optionator "^0.9.3"
+
+espree@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-11.2.0.tgz#01d5e47dc332aaba3059008362454a8cc34ccaa5"
+  integrity sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==
+  dependencies:
+    acorn "^8.16.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^5.0.1"
+
 esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+esquery@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.7.0.tgz#08d048f261f0ddedb5bae95f46809463d9c9496d"
+  integrity sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==
+  dependencies:
+    estraverse "^5.1.0"
+
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+  dependencies:
+    estraverse "^5.2.0"
+
+estraverse@^5.1.0, estraverse@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+
+esutils@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 etag@^1.8.1:
   version "1.8.1"
@@ -2002,7 +2311,7 @@ express@^5.2.1:
     type-is "^2.0.1"
     vary "^1.1.2"
 
-fast-deep-equal@^3.1.3:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -2017,6 +2326,16 @@ fast-glob@^3.3.3:
     glob-parent "^5.1.2"
     merge2 "^1.3.0"
     micromatch "^4.0.8"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-levenshtein@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-string-truncated-width@^3.0.2:
   version "3.0.3"
@@ -2069,6 +2388,13 @@ figures@^6.1.0:
   dependencies:
     is-unicode-supported "^2.0.0"
 
+file-entry-cache@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz#7787bddcf1131bffb92636c69457bbc0edd6d81f"
+  integrity sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==
+  dependencies:
+    flat-cache "^4.0.0"
+
 fill-range@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
@@ -2087,6 +2413,27 @@ finalhandler@^2.1.0:
     on-finished "^2.4.1"
     parseurl "^1.3.3"
     statuses "^2.0.1"
+
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
+flat-cache@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-4.0.1.tgz#0ece39fcb14ee012f4b0410bd33dd9c1f011127c"
+  integrity sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==
+  dependencies:
+    flatted "^3.2.9"
+    keyv "^4.5.4"
+
+flatted@^3.2.9:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
+  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
 formdata-polyfill@^4.0.10:
   version "4.0.10"
@@ -2198,6 +2545,13 @@ glob-parent@^5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
+
 gopd@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
@@ -2274,10 +2628,15 @@ iconv-lite@^0.7.0, iconv-lite@~0.7.0:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-ignore@^5.3.0:
+ignore@^5.2.0, ignore@^5.3.0:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
+
+ignore@^7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
+  integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
 import-fresh@^3.3.0:
   version "3.3.1"
@@ -2286,6 +2645,11 @@ import-fresh@^3.3.0:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
 inherits@~2.0.4:
   version "2.0.4"
@@ -2322,7 +2686,7 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-is-glob@^4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -2440,10 +2804,20 @@ jsesc@^3.0.2:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json-schema-traverse@^1.0.0:
   version "1.0.0"
@@ -2454,6 +2828,11 @@ json-schema-typed@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz#e98ee7b1899ff4a184534d1f167c288c66bbeff4"
   integrity sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
 json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
@@ -2469,6 +2848,13 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+keyv@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
+  integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
+  dependencies:
+    json-buffer "3.0.1"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -2478,6 +2864,14 @@ kleur@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
   integrity sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
+
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
 
 lightningcss-android-arm64@1.32.0:
   version "1.32.0"
@@ -2557,6 +2951,13 @@ lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
 
 log-symbols@^6.0.0:
   version "6.0.0"
@@ -2640,7 +3041,7 @@ mimic-function@^5.0.0:
   resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
   integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
 
-minimatch@^10.0.1:
+minimatch@^10.0.1, minimatch@^10.2.2, minimatch@^10.2.4:
   version "10.2.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
   integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
@@ -2690,6 +3091,11 @@ nanoid@^3.3.11:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
 negotiator@^1.0.0:
   version "1.0.0"
@@ -2785,6 +3191,18 @@ open@^11.0.0:
     powershell-utils "^0.1.0"
     wsl-utils "^0.3.0"
 
+optionator@^0.9.3:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.4.tgz#7ea1c1a5d91d764fb282139c88fe11e182a3a734"
+  integrity sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.5"
+
 ora@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/ora/-/ora-8.2.0.tgz#8fbbb7151afe33b540dd153f171ffa8bd38e9861"
@@ -2804,6 +3222,20 @@ outvariant@^1.4.0, outvariant@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.3.tgz#221c1bfc093e8fec7075497e7799fdbf43d14873"
   integrity sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==
+
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -2836,6 +3268,11 @@ path-browserify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
   integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
@@ -2899,6 +3336,11 @@ powershell-utils@^0.1.0:
   resolved "https://registry.yarnpkg.com/powershell-utils/-/powershell-utils-0.1.0.tgz#5a42c9a824fb4f2f251ccb41aaae73314f5d6ac2"
   integrity sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==
 
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
 pretty-ms@^9.2.0:
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-9.3.0.tgz#dd2524fcb3c326b4931b2272dfd1e1a8ed9a9f5a"
@@ -2921,6 +3363,11 @@ proxy-addr@^2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+punycode@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 qs@^6.14.0, qs@^6.14.1:
   version "6.15.1"
@@ -3154,6 +3601,11 @@ semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.7.3:
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
 send@^1.1.0, send@^1.2.0:
   version "1.2.1"
@@ -3405,7 +3857,7 @@ tiny-invariant@^1.3.3:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
 
-tinyglobby@^0.2.16:
+tinyglobby@^0.2.15, tinyglobby@^0.2.16:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.16.tgz#1c3b7eb953fce42b226bc5a1ee06428281aff3d6"
   integrity sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==
@@ -3444,6 +3896,11 @@ tough-cookie@^6.0.1:
   dependencies:
     tldts "^7.0.5"
 
+ts-api-utils@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz#4acd4a155e22734990a5ed1fe9e97f113bcb37c1"
+  integrity sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
+
 ts-morph@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-26.0.0.tgz#d435ccac9421d4615fde8be86fee782f18cd9f73"
@@ -3471,6 +3928,13 @@ tw-animate-css@^1.4.0:
   resolved "https://registry.yarnpkg.com/tw-animate-css/-/tw-animate-css-1.4.0.tgz#b4a06f68244cba39428aa47e65e6e4c0babc21ee"
   integrity sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==
 
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
+
 type-fest@^5.5.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-5.6.0.tgz#502f7a003b7309e96a7e17052cc2ab2c7e5c7a31"
@@ -3486,6 +3950,16 @@ type-is@^2.0.1:
     content-type "^1.0.5"
     media-typer "^1.1.0"
     mime-types "^3.0.0"
+
+typescript-eslint@^8.59.1:
+  version "8.59.1"
+  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.59.1.tgz#244a9fcbf27057ebbc2281d408239f1861b55b78"
+  integrity sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==
+  dependencies:
+    "@typescript-eslint/eslint-plugin" "8.59.1"
+    "@typescript-eslint/parser" "8.59.1"
+    "@typescript-eslint/typescript-estree" "8.59.1"
+    "@typescript-eslint/utils" "8.59.1"
 
 typescript@^5.9.0:
   version "5.9.3"
@@ -3524,6 +3998,13 @@ update-browserslist-db@^1.2.3:
   dependencies:
     escalade "^3.2.0"
     picocolors "^1.1.1"
+
+uri-js@^4.2.2:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+  dependencies:
+    punycode "^2.1.0"
 
 use-callback-ref@^1.3.3:
   version "1.3.3"
@@ -3592,6 +4073,11 @@ which@^4.0.0:
   dependencies:
     isexe "^3.1.1"
 
+word-wrap@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
+  integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -3641,6 +4127,11 @@ yargs@^17.7.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
 yocto-spinner@^1.1.0:
   version "1.1.0"

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -112,37 +112,6 @@ func buildOpenNoShellArgs(tenant, environment string) []string {
 	return []string{"open", strings.TrimSpace(tenant), strings.TrimSpace(environment), "--no-shell", "--no-alias-prompt"}
 }
 
-func buildIDEShellLaunch(cliPath string, selection uiSelection, ide string) (string, []string, error) {
-	switch runtime.GOOS {
-	case "windows":
-		initCommand := buildPowerShellCommandInvocation(cliPath, buildSSHDInitArgs(selection))
-		openCommand := buildPowerShellCommandInvocation(cliPath, buildOpenIDEArgs(selection, ide))
-		return "powershell.exe", []string{"-NoLogo", "-NoProfile", "-Command", initCommand + "; if ($LASTEXITCODE -eq 0) { " + openCommand + " } else { exit $LASTEXITCODE }"}, nil
-	default:
-		initCommand := buildShellCommandInvocation(cliPath, buildSSHDInitArgs(selection))
-		openCommand := buildShellCommandInvocation(cliPath, buildOpenIDEArgs(selection, ide))
-		return "/bin/sh", []string{"-lc", initCommand + " && " + openCommand}, nil
-	}
-}
-
-func buildShellCommandInvocation(command string, args []string) string {
-	quoted := make([]string, 0, len(args)+1)
-	quoted = append(quoted, shellQuote(command))
-	for _, arg := range args {
-		quoted = append(quoted, shellQuote(arg))
-	}
-	return strings.Join(quoted, " ")
-}
-
-func buildPowerShellCommandInvocation(command string, args []string) string {
-	quoted := make([]string, 0, len(args)+1)
-	quoted = append(quoted, "& "+powerShellQuote(command))
-	for _, arg := range args {
-		quoted = append(quoted, powerShellQuote(arg))
-	}
-	return strings.Join(quoted, " ")
-}
-
 func ensureMCPViaOpenCommand(ctx context.Context, cliPath string, result eruncommon.OpenResult) error {
 	args := buildOpenNoShellArgs(result.Tenant, result.Environment)
 	cmd := exec.CommandContext(ctx, cliPath, args...)


### PR DESCRIPTION
## Summary
- Add strict Go linter thresholds across all Go modules.
- Add TypeScript lint coverage for the UI frontend.
- Fix resulting Go and TypeScript lint findings without suppressions.

## Validation
- erun-common: go test ./... && golangci-lint run
- erun-mcp: go test ./... && golangci-lint run
- erun-cli: go test ./... && golangci-lint run
- erun-ui: go test ./... && golangci-lint run
- erun-ui/frontend: yarn lint && yarn build

Closes #164
