### PR TITLE
Fix desktop terminal and idle controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,7 @@ Repository guidance for humans and coding agents working in this repo.
 ## Working Rules
 
 - Start each non-trivial change by identifying the smallest coherent outcome that would satisfy the request, the modules likely affected, and the validation scope needed for confidence.
+- When asking the user to confirm a plan, describe the actual intended changes, not just investigation steps. Name the behavior that will change, the user-visible outcome, the likely files or modules to edit, and the validation that will prove the change. Keep discovery-only steps out of the plan unless they materially affect the proposed implementation.
 - Prefer fast, evidence-driven iteration. Use existing behavior, failing symptoms, tests, and screenshots as the source of truth, then tighten the implementation around the observed problem.
 - Keep work centered on the current user goal. Avoid opportunistic cleanup, broad redesign, or unrelated polish unless it directly reduces risk for the requested change.
 - When a problem crosses module boundaries, solve it at the lowest shared layer that owns the behavior, then keep transport-specific code focused on adaptation and presentation.

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -1659,6 +1659,34 @@ func TestMergeNewerActivityMarkersPrefersLocalTerminalActivity(t *testing.T) {
 	}
 }
 
+func TestMergeNewerActivityMarkersAddsMissingLocalTerminalActivity(t *testing.T) {
+	now := time.Now()
+	remote := eruncommon.EnvironmentIdleStatus{
+		ManagedCloud: true,
+		Markers: []eruncommon.EnvironmentIdleMarker{
+			{Name: "working-hours", LastActivity: now},
+			{Name: eruncommon.ActivityKindMCP, Idle: true, LastActivity: now.Add(-10 * time.Minute), SecondsRemaining: 0},
+		},
+	}
+	local := eruncommon.EnvironmentIdleStatus{
+		ManagedCloud: true,
+		Markers: []eruncommon.EnvironmentIdleMarker{
+			{Name: eruncommon.ActivityKindCLI, Idle: false, LastActivity: now, SecondsRemaining: 60},
+		},
+	}
+
+	merged := mergeNewerActivityMarkers(remote, local)
+	if merged.StopEligible {
+		t.Fatal("expected local CLI activity to block idle stop")
+	}
+	if got := activitySecondsUntilIdle(merged); got != 60 {
+		t.Fatalf("activitySecondsUntilIdle = %d, want 60", got)
+	}
+	if merged.StopBlockedReason != eruncommon.ActivityKindCLI {
+		t.Fatalf("StopBlockedReason = %q, want %q", merged.StopBlockedReason, eruncommon.ActivityKindCLI)
+	}
+}
+
 func TestMergeLocalIdleActivityUsesSavedPolicyWithRemoteActivity(t *testing.T) {
 	now := time.Now()
 	store := stubUIStore{
@@ -1776,6 +1804,44 @@ func TestLoadIdleStatusStopsLinkedCloudContextWhenStopEligible(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for cloud context stop")
+	}
+}
+
+func TestStartCloudContextClearsPreviousIdleStop(t *testing.T) {
+	store := stubUIStore{
+		config: &eruncommon.ERunConfig{
+			CloudContexts: []eruncommon.CloudContextConfig{{
+				Name:               "cloud-ctx",
+				CloudProviderAlias: "team-cloud",
+				KubernetesContext:  "cluster-cloud",
+				Status:             eruncommon.CloudContextStatusRunning,
+			}},
+		},
+		tenants: map[string]eruncommon.TenantConfig{
+			"team-stop": {
+				Name:               "team-stop",
+				DefaultEnvironment: "dev-stop",
+			},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"team-stop/dev-stop": {
+				Name:               "dev-stop",
+				KubernetesContext:  "cluster-cloud",
+				CloudProviderAlias: "team-cloud",
+				ManagedCloud:       true,
+				Remote:             true,
+			},
+		},
+	}
+	key := selectionKey(uiSelection{Tenant: "team-stop", Environment: "dev-stop"})
+	app := NewApp(erunUIDeps{store: store})
+	defer app.shutdown(context.Background())
+
+	app.idleStops[key] = struct{}{}
+	app.clearIdleStopsForCloudContext("cloud-ctx")
+
+	if _, exists := app.idleStops[key]; exists {
+		t.Fatal("expected previous idle stop marker to be cleared")
 	}
 }
 

--- a/erun-ui/config_handlers.go
+++ b/erun-ui/config_handlers.go
@@ -84,6 +84,7 @@ func (a *App) StartCloudContext(name string) (uiCloudContextStatus, error) {
 	if err != nil {
 		return uiCloudContextStatus{}, err
 	}
+	a.clearIdleStopsForCloudContext(status.Name)
 	return cloudContextStatusToUI(status), nil
 }
 

--- a/erun-ui/environment_config.go
+++ b/erun-ui/environment_config.go
@@ -264,6 +264,7 @@ func (a *App) ensureLinkedCloudContextRunning(config eruncommon.EnvConfig) (erun
 	if err != nil {
 		return eruncommon.CloudContextStatus{}, true, err
 	}
+	a.clearIdleStopsForCloudContext(status.Name)
 	a.emitAppStatus(fmt.Sprintf("Cloud context %s is running. Opening environment...", cloudContextDisplayName(status)), true)
 	return status, true, nil
 }

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -1,6 +1,6 @@
 import type * as React from 'react';
 import { FitAddon } from '@xterm/addon-fit';
-import { Terminal } from '@xterm/xterm';
+import { Terminal, type IDisposable } from '@xterm/xterm';
 
 import { TerminalSessionRegistry } from './TerminalSessionRegistry';
 import {
@@ -43,6 +43,7 @@ import {
 import { readError } from './errors';
 import { runtimePodConfigToKubernetes, runtimeResourceLimitMessage } from './runtimeResources';
 import { scrollSelectedDiffIntoView, visibleDiffPath } from './reviewDiffNavigation';
+import { registerTerminalQueryResponseHandlers } from './terminalQueryResponses';
 import type {
   AppStatusPayload,
   DebugSessionMode,
@@ -174,6 +175,7 @@ export class ERunUIController {
   private environmentResourceStatusRequest = 0;
   private bootStarted = false;
   private terminalDataDisposable: TerminalDataDisposable | null = null;
+  private terminalQueryResponseDisposables: IDisposable[] = [];
   private terminalOutputOff: (() => void) | null = null;
   private terminalExitOff: (() => void) | null = null;
   private appStatusOff: (() => void) | null = null;
@@ -188,6 +190,7 @@ export class ERunUIController {
     emit: () => this.emit(),
     focusTerminalSoon: () => this.focusTerminalSoon(),
     queueTerminalResize: () => this.queueTerminalResize(),
+    openSelection: (selection) => this.openSelection(selection),
     refreshIdleStatus: () => { void this.refreshIdleStatus(); },
     refreshKubernetesContexts: () => { void this.refreshKubernetesContexts(); },
     hideTerminalMessage: () => this.hideTerminalMessage(),
@@ -244,6 +247,11 @@ export class ERunUIController {
     this.terminal.open(elements.terminalRoot);
     this.fitAddon.fit();
 
+    this.terminalQueryResponseDisposables = registerTerminalQueryResponseHandlers(
+      this.terminal,
+      SendSessionInput,
+      (error) => this.showTerminalMessage(readError(error)),
+    );
     this.terminalDataDisposable = this.terminal.onData((data) => {
       SendSessionInput(data).catch((error: unknown) => {
         this.showTerminalMessage(readError(error));
@@ -286,6 +294,9 @@ export class ERunUIController {
     window.removeEventListener('resize', this.queueTerminalResize);
     this.resizeObserver?.disconnect();
     this.terminalDataDisposable?.dispose();
+    for (const disposable of this.terminalQueryResponseDisposables) {
+      disposable.dispose();
+    }
     this.terminalOutputOff?.();
     this.terminalExitOff?.();
     this.appStatusOff?.();
@@ -298,6 +309,7 @@ export class ERunUIController {
     this.terminalOutputOff = null;
     this.terminalExitOff = null;
     this.appStatusOff = null;
+    this.terminalQueryResponseDisposables = [];
     this.terminal?.dispose();
     this.terminal = null;
     this.fitAddon = null;

--- a/erun-ui/frontend/src/app/cloudContextState.ts
+++ b/erun-ui/frontend/src/app/cloudContextState.ts
@@ -6,16 +6,27 @@ import type { UICloudContextInitInput, UICloudContextStatus, UICloudProviderStat
 
 export function idleCloudContextAction(idleStatus: UIIdleStatus | null, busy: boolean): IdleCloudContextAction | null {
   const name = normalizeDialogValue(idleStatus?.cloudContextName || '');
-  if (!idleStatus || !idleStatus.managedCloud || !name || busy) {
+  if (!idleStatus?.managedCloud || !name || busy) {
     return null;
   }
   const running = normalizeDialogValue(idleStatus.cloudContextStatus || '').toLowerCase() === 'running';
+  if (running) {
+    return {
+      idleStatus,
+      operation: 'stop',
+      name,
+      run: StopCloudContext,
+      label: 'Stopped',
+      refreshKubernetesContexts: false,
+    };
+  }
   return {
     idleStatus,
+    operation: 'start',
     name,
-    run: running ? StopCloudContext : StartCloudContext,
-    label: running ? 'Stopped' : 'Started',
-    refreshKubernetesContexts: !running,
+    run: StartCloudContext,
+    label: 'Started',
+    refreshKubernetesContexts: true,
   };
 }
 

--- a/erun-ui/frontend/src/app/globalConfigWorkflow.ts
+++ b/erun-ui/frontend/src/app/globalConfigWorkflow.ts
@@ -40,6 +40,7 @@ interface GlobalConfigWorkflowDeps {
   emit: () => void;
   focusTerminalSoon: () => void;
   queueTerminalResize: () => void;
+  openSelection: (selection: UISelection) => Promise<void>;
   refreshIdleStatus: () => void;
   refreshKubernetesContexts: () => void;
   hideTerminalMessage: () => void;
@@ -255,6 +256,7 @@ export class GlobalConfigWorkflow {
     if (!action) {
       return;
     }
+    const selection = this.state.selected ? { ...this.state.selected } : null;
     this.state.idleCloudContextBusy = true;
     this.deps.emit();
     try {
@@ -265,6 +267,9 @@ export class GlobalConfigWorkflow {
       this.deps.emit();
       if (action.refreshKubernetesContexts) {
         this.deps.refreshKubernetesContexts();
+      }
+      if (action.operation === 'start' && selection) {
+        await this.deps.openSelection(selection);
       }
       this.deps.refreshIdleStatus();
     } catch (error) {

--- a/erun-ui/frontend/src/app/idleStatusEligibility.ts
+++ b/erun-ui/frontend/src/app/idleStatusEligibility.ts
@@ -1,0 +1,12 @@
+import type { UIIdleStatus } from '@/types';
+
+export function displayableIdleStatus(status: UIIdleStatus | null): UIIdleStatus | null {
+  return isIdleStatusDisplayEligible(status) ? status : null;
+}
+
+export function isIdleStatusDisplayEligible(status: UIIdleStatus | null): status is UIIdleStatus {
+  if (!status?.managedCloud) {
+    return false;
+  }
+  return (status.cloudContextStatus || '').trim().toLowerCase() === 'running';
+}

--- a/erun-ui/frontend/src/app/model/idleCloudContextAction.ts
+++ b/erun-ui/frontend/src/app/model/idleCloudContextAction.ts
@@ -2,6 +2,7 @@ import type { UIIdleStatus } from '@/types';
 
 export type IdleCloudContextAction = {
   idleStatus: UIIdleStatus;
+  operation: 'start' | 'stop';
   name: string;
   run: (name: string) => Promise<unknown>;
   label: string;

--- a/erun-ui/frontend/src/app/terminalQueryResponses.ts
+++ b/erun-ui/frontend/src/app/terminalQueryResponses.ts
@@ -1,0 +1,153 @@
+import type { IDisposable, Terminal } from '@xterm/xterm';
+
+type TerminalInputSender = (data: string) => Promise<unknown>;
+type TerminalInputErrorHandler = (error: unknown) => void;
+
+const ESC = '\x1B';
+const ST = `${ESC}\\`;
+
+const foregroundColor = 'rgb:ffff/ffff/ffff';
+const backgroundColor = 'rgb:0000/0000/0000';
+const cursorColor = foregroundColor;
+
+export function registerTerminalQueryResponseHandlers(
+  terminal: Terminal,
+  sendInput: TerminalInputSender,
+  onError: TerminalInputErrorHandler,
+): IDisposable[] {
+  const sendResponse = async (data: string): Promise<boolean> => {
+    if (!data) {
+      return true;
+    }
+    try {
+      await sendInput(data);
+    } catch (error: unknown) {
+      onError(error);
+    }
+    return true;
+  };
+
+  return [
+    terminal.parser.registerCsiHandler({ final: 'c' }, (params) => {
+      if (firstParam(params) > 0) {
+        return true;
+      }
+      return sendResponse(`${ESC}[?1;2c`);
+    }),
+    terminal.parser.registerCsiHandler({ prefix: '>', final: 'c' }, (params) => {
+      if (firstParam(params) > 0) {
+        return true;
+      }
+      return sendResponse(`${ESC}[>0;276;0c`);
+    }),
+    terminal.parser.registerCsiHandler({ final: 'n' }, (params) => {
+      switch (firstParam(params)) {
+        case 5:
+          return sendResponse(`${ESC}[0n`);
+        case 6:
+          return sendResponse(cursorPositionReport(terminal, ''));
+        default:
+          return true;
+      }
+    }),
+    terminal.parser.registerCsiHandler({ prefix: '?', final: 'n' }, (params) => {
+      if (firstParam(params) !== 6) {
+        return true;
+      }
+      return sendResponse(cursorPositionReport(terminal, '?'));
+    }),
+    terminal.parser.registerDcsHandler({ intermediates: '$', final: 'q' }, (data) => {
+      return sendResponse(statusStringReport(terminal, data));
+    }),
+    terminal.parser.registerOscHandler(10, (data) => {
+      const response = colorReportData(10, data);
+      return response === null ? false : sendResponse(response);
+    }),
+    terminal.parser.registerOscHandler(11, (data) => {
+      const response = colorReportData(11, data);
+      return response === null ? false : sendResponse(response);
+    }),
+    terminal.parser.registerOscHandler(12, (data) => {
+      const response = colorReportData(12, data);
+      return response === null ? false : sendResponse(response);
+    }),
+  ];
+}
+
+function firstParam(params: (number | number[])[]): number {
+  const value = params[0];
+  if (Array.isArray(value)) {
+    return value[0] || 0;
+  }
+  return value || 0;
+}
+
+function cursorPositionReport(terminal: Terminal, prefix: string): string {
+  const buffer = terminal.buffer.active;
+  return `${ESC}[${prefix}${buffer.cursorY + 1};${buffer.cursorX + 1}R`;
+}
+
+function statusStringReport(terminal: Terminal, data: string): string {
+  switch (data) {
+    case '"q':
+      return `${ESC}P1$r0"q${ST}`;
+    case '"p':
+      return `${ESC}P1$r61;1"p${ST}`;
+    case 'r':
+      return `${ESC}P1$r1;${terminal.rows}r${ST}`;
+    case 'm':
+      return `${ESC}P1$r0m${ST}`;
+    case ' q':
+      return `${ESC}P1$r${cursorStyleReport(terminal)} q${ST}`;
+    default:
+      return `${ESC}P0$r${ST}`;
+  }
+}
+
+function cursorStyleReport(terminal: Terminal): number {
+  const style = terminal.options.cursorStyle;
+  const blink = terminal.options.cursorBlink === true;
+  if (style === 'underline') {
+    return blink ? 3 : 4;
+  }
+  if (style === 'bar') {
+    return blink ? 5 : 6;
+  }
+  return blink ? 1 : 2;
+}
+
+function colorReportData(start: number, data: string): string | null {
+  if (data.split(';').some((slot) => slot !== '?')) {
+    return null;
+  }
+  return colorReports(start, data).join('');
+}
+
+function colorReports(start: number, data: string): string[] {
+  const reports: string[] = [];
+  const slots = data.split(';');
+  for (let index = 0; index < slots.length; index++) {
+    if (slots[index] !== '?') {
+      continue;
+    }
+    const colorIndex = start + index;
+    const color = specialColor(colorIndex);
+    if (color) {
+      reports.push(`${ESC}]${colorIndex};${color}${ST}`);
+    }
+  }
+  return reports;
+}
+
+function specialColor(index: number): string {
+  switch (index) {
+    case 10:
+      return foregroundColor;
+    case 11:
+      return backgroundColor;
+    case 12:
+      return cursorColor;
+    default:
+      return '';
+  }
+}

--- a/erun-ui/frontend/src/components/app/Titlebar.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { AlertCircle, Blocks, CheckCircle2, Code2, Copy, Info, ListTree, LoaderCircle, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, Play, Power, X } from 'lucide-react';
 
 import type { ERunUIController } from '@/app/ERunUIController';
+import { displayableIdleStatus } from '@/app/idleStatusEligibility';
 import type { AppState } from '@/app/state';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -126,17 +127,18 @@ function TitlebarControls({ controller, state }: { controller: ERunUIController;
 }
 
 function IdleStatusWidget({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement | null {
-  const idleStatus = state.idleStatus;
-  if (!idleStatus) {
+  const rawIdleStatus = state.idleStatus;
+  const idleStatus = displayableIdleStatus(rawIdleStatus);
+  const idleAction = rawIdleStatus ? idleCloudAction(rawIdleStatus, state.idleCloudContextBusy) : null;
+  if (!idleStatus && !idleAction) {
     return null;
   }
-  const idleBadge = idleStatusBadge(idleStatus);
-  const idleAction = idleCloudAction(idleStatus, state.idleCloudContextBusy);
+  const idleBadge = idleStatus ? idleStatusBadge(idleStatus) : null;
 
   return (
-    <div className={cn('absolute top-3 right-[168px] z-[1] flex h-7 items-center rounded-md border bg-background [--wails-draggable:no-drag] max-[980px]:right-[146px]', idleBadge.className)}>
-      <IdleStatusBadge idleStatus={idleStatus} idleBadge={idleBadge} hasAction={Boolean(idleAction)} />
-      {idleAction && <IdleStatusAction controller={controller} idleAction={idleAction} />}
+    <div className={cn('absolute top-3 right-[168px] z-[1] flex h-7 items-center rounded-md border bg-background [--wails-draggable:no-drag] max-[980px]:right-[146px]', idleBadge?.className)}>
+      {idleStatus && idleBadge && <IdleStatusBadge idleStatus={idleStatus} idleBadge={idleBadge} hasAction={Boolean(idleAction)} />}
+      {idleAction && <IdleStatusAction controller={controller} idleAction={idleAction} hasBadge={Boolean(idleStatus)} />}
     </div>
   );
 }
@@ -158,11 +160,11 @@ function IdleStatusBadge({ idleStatus, idleBadge, hasAction }: { idleStatus: Idl
   );
 }
 
-function IdleStatusAction({ controller, idleAction }: { controller: ERunUIController; idleAction: { action: 'start' | 'stop'; label: string; busy: boolean } }): React.ReactElement {
+function IdleStatusAction({ controller, idleAction, hasBadge }: { controller: ERunUIController; idleAction: { action: 'start' | 'stop'; label: string; busy: boolean }; hasBadge: boolean }): React.ReactElement {
   const IdleActionIcon = idleAction.busy ? LoaderCircle : idleAction.action === 'start' ? Play : Power;
   return (
     <IconTooltip label={idleAction.label}>
-      <Button className="h-full w-7 rounded-l-none rounded-r-md border-0 bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-60 [&_svg]:size-3.5" type="button" variant="ghost" size="icon" aria-label={idleAction.label} disabled={idleAction.busy} onClick={() => { void controller.toggleIdleCloudContext(); }}>
+      <Button className={cn('h-full w-7 border-0 bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-60 [&_svg]:size-3.5', hasBadge ? 'rounded-l-none rounded-r-md' : 'rounded-md')} type="button" variant="ghost" size="icon" aria-label={idleAction.label} disabled={idleAction.busy} onClick={() => { void controller.toggleIdleCloudContext(); }}>
         <IdleActionIcon className={cn(idleAction.busy && 'animate-spin')} aria-hidden="true" />
       </Button>
     </IconTooltip>
@@ -201,10 +203,11 @@ function TitlebarStatus({ controller, state }: { controller: ERunUIController; s
   if (!status) {
     return null;
   }
+  const idleStatus = displayableIdleStatus(state.idleStatus);
   const idleAction = state.idleStatus ? idleCloudAction(state.idleStatus, state.idleCloudContextBusy) : null;
 
   return (
-    <div className={statusPositionClassName(state.idleStatus, Boolean(idleAction))} role={status.kind === 'error' ? 'alert' : 'status'} aria-live={status.kind === 'error' ? 'assertive' : 'polite'}>
+    <div className={statusPositionClassName(idleStatus, Boolean(idleAction))} role={status.kind === 'error' ? 'alert' : 'status'} aria-live={status.kind === 'error' ? 'assertive' : 'polite'}>
       <div className={cn('pointer-events-auto flex h-8 max-w-full items-center gap-2 rounded-md border bg-background px-2.5 text-[13px] leading-none shadow-sm', statusBorderClassNames[status.kind])}>
         <StatusIcon status={status} />
         <StatusMessage status={status} />
@@ -240,6 +243,9 @@ function titlebarStatus(state: AppState): TitlebarStatusValue | null {
 
 function statusPositionClassName(idleStatus: AppState['idleStatus'], hasIdleAction: boolean): string {
   if (!idleStatus) {
+    if (hasIdleAction) {
+      return 'pointer-events-none absolute top-2.5 left-32 right-[204px] z-20 flex justify-center [--wails-draggable:no-drag] max-[980px]:left-[112px] max-[980px]:right-[182px]';
+    }
     return 'pointer-events-none absolute top-2.5 left-32 right-[168px] z-20 flex justify-center [--wails-draggable:no-drag] max-[980px]:left-[112px] max-[980px]:right-[146px]';
   }
   if (hasIdleAction) {

--- a/erun-ui/idle_status.go
+++ b/erun-ui/idle_status.go
@@ -117,10 +117,19 @@ func mergeNewerActivityMarkers(status, local eruncommon.EnvironmentIdleStatus) e
 		if localMarker.Name == "working-hours" || localMarker.LastActivity.IsZero() {
 			continue
 		}
+		found := false
 		for index, marker := range status.Markers {
-			if marker.Name == localMarker.Name && localMarker.LastActivity.After(marker.LastActivity) {
-				status.Markers[index] = localMarker
+			if marker.Name != localMarker.Name {
+				continue
 			}
+			found = true
+			if localMarker.LastActivity.After(marker.LastActivity) {
+				status.Markers[index] = localMarker
+				break
+			}
+		}
+		if !found {
+			status.Markers = append(status.Markers, localMarker)
 		}
 	}
 	return recomputeStopEligible(status)
@@ -209,6 +218,39 @@ func (a *App) maybeStopIdleCloudEnvironment(result eruncommon.OpenResult, status
 		}
 		a.emitAppStatus(fmt.Sprintf("Stopped idle cloud context %s.", cloudContextDisplayName(cloudContext)), false)
 	}()
+}
+
+func (a *App) clearIdleStopsForCloudContext(name string) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	tenants, err := a.deps.store.ListTenantConfigs()
+	if err != nil {
+		return
+	}
+	cleared := make([]string, 0)
+	for _, tenant := range tenants {
+		envs, err := a.deps.store.ListEnvConfigs(tenant.Name)
+		if err != nil {
+			continue
+		}
+		for _, env := range envs {
+			cloudContext, ok, err := a.linkedCloudContext(env)
+			if err != nil || !ok || strings.TrimSpace(cloudContext.Name) != name {
+				continue
+			}
+			cleared = append(cleared, selectionKey(uiSelection{Tenant: tenant.Name, Environment: env.Name}))
+		}
+	}
+	if len(cleared) == 0 {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, key := range cleared {
+		delete(a.idleStops, key)
+	}
 }
 
 func activitySecondsUntilIdle(status eruncommon.EnvironmentIdleStatus) int64 {


### PR DESCRIPTION
## What changed

- Handle xterm terminal query responses in the desktop frontend so terminal replies do not leak into the shell prompt.
- Hide idle countdown badges for non-running cloud contexts while keeping the toolbar power action available to start stopped contexts.
- Reopen the selected shell after starting a stopped cloud context from the toolbar.
- Preserve local CLI activity when merging remote idle status and clear stale autostop markers when cloud contexts restart.
- Add repository guidance that confirmation plans should describe actual intended changes.

## Validation

- `go test ./...` from `erun-ui`
- `yarn eslint src/app/ERunUIController.ts src/app/globalConfigWorkflow.ts src/app/cloudContextState.ts src/app/model/idleCloudContextAction.ts src/app/idleStatusEligibility.ts src/components/app/Titlebar.tsx` from `erun-ui/frontend`
- `yarn build` from `erun-ui/frontend`
- `git diff --check`

Closes #170
Closes #171
