### PR TITLE
Add desktop diff review layers

### DIFF
--- a/erun-common/diff.go
+++ b/erun-common/diff.go
@@ -15,6 +15,11 @@ type DiffResult struct {
 	Summary          DiffSummary    `json:"summary"`
 	Files            []DiffFile     `json:"files,omitempty"`
 	Tree             []DiffTreeNode `json:"tree,omitempty"`
+	ReviewBase       DiffReviewBase `json:"reviewBase,omitempty"`
+	ReviewCommits    []DiffCommit   `json:"reviewCommits,omitempty"`
+	Scope            string         `json:"scope,omitempty"`
+	SelectedCommit   string         `json:"selectedCommit,omitempty"`
+	IncludesWorktree bool           `json:"includesWorktree,omitempty"`
 }
 
 type DiffSummary struct {
@@ -61,6 +66,25 @@ type DiffTreeNode struct {
 	Deletions  int    `json:"deletions,omitempty"`
 }
 
+type DiffReviewBase struct {
+	Branch      string `json:"branch,omitempty"`
+	Commit      string `json:"commit,omitempty"`
+	ShortCommit string `json:"shortCommit,omitempty"`
+}
+
+type DiffCommit struct {
+	Hash      string `json:"hash"`
+	ShortHash string `json:"shortHash"`
+	Subject   string `json:"subject"`
+	Author    string `json:"author"`
+	Date      string `json:"date"`
+}
+
+type DiffOptions struct {
+	Scope          string `json:"scope,omitempty"`
+	SelectedCommit string `json:"selectedCommit,omitempty"`
+}
+
 type diffTreeBuildNode struct {
 	Name      string
 	Path      string
@@ -91,7 +115,158 @@ func ResolveGitDiff(projectRoot string, runGit GitCommandRunnerFunc) (DiffResult
 
 	result := ParseGitDiff(stdout.String())
 	result.WorkingDirectory = projectRoot
+	result.IncludesWorktree = true
 	return result, nil
+}
+
+func ResolveGitDiffWithOptions(projectRoot string, options DiffOptions, runGit GitCommandRunnerFunc) (DiffResult, error) {
+	projectRoot = strings.TrimSpace(projectRoot)
+	if projectRoot == "" {
+		return DiffResult{}, fmt.Errorf("project root is required")
+	}
+	if runGit == nil {
+		runGit = GitCommandRunner
+	}
+
+	base, baseFound, err := resolveGitDiffReviewBase(projectRoot, runGit)
+	if err != nil {
+		return DiffResult{}, err
+	}
+	commits, err := resolveGitDiffReviewCommits(projectRoot, base, baseFound, runGit)
+	if err != nil {
+		return DiffResult{}, err
+	}
+
+	scope := normalizeDiffScope(options.Scope)
+	selectedCommit := strings.TrimSpace(options.SelectedCommit)
+	stdout := new(bytes.Buffer)
+	diffArgs := gitDiffReviewArgs(base.Commit, baseFound, scope, selectedCommit)
+	stderr := new(bytes.Buffer)
+	if err := runGit(projectRoot, stdout, stderr, diffArgs...); err != nil {
+		return DiffResult{}, fmt.Errorf("git diff: %w%s", err, formatGitCommandStderr(stderr.String()))
+	}
+	if err := appendUntrackedGitDiff(projectRoot, stdout, runGit); err != nil {
+		return DiffResult{}, err
+	}
+
+	result := ParseGitDiff(stdout.String())
+	result.WorkingDirectory = projectRoot
+	result.ReviewBase = base
+	result.ReviewCommits = commits
+	result.Scope = scope
+	result.SelectedCommit = selectedCommit
+	result.IncludesWorktree = true
+	return result, nil
+}
+
+func normalizeDiffScope(scope string) string {
+	switch strings.TrimSpace(scope) {
+	case "all", "commit":
+		return strings.TrimSpace(scope)
+	default:
+		return "current"
+	}
+}
+
+func gitDiffReviewArgs(baseCommit string, baseFound bool, scope, selectedCommit string) []string {
+	args := []string{"diff", "--no-color", "--no-ext-diff"}
+	switch scope {
+	case "all":
+		if baseFound {
+			args = append(args, baseCommit)
+		}
+		return args
+	case "commit":
+		if selectedCommit != "" {
+			args = append(args, selectedCommit+"^")
+		}
+		return args
+	default:
+		return args
+	}
+}
+
+func resolveGitDiffReviewBase(projectRoot string, runGit GitCommandRunnerFunc) (DiffReviewBase, bool, error) {
+	var selected DiffReviewBase
+	selectedDistance := -1
+	for _, branch := range []string{"origin/HEAD", "origin/main", "origin/develop", "main", "develop"} {
+		commit, err := gitOutput(projectRoot, runGit, "merge-base", "HEAD", branch)
+		if err != nil || commit == "" {
+			continue
+		}
+		distance, err := gitOutput(projectRoot, runGit, "rev-list", "--count", commit+"..HEAD")
+		if err != nil {
+			continue
+		}
+		parsedDistance, err := strconv.Atoi(strings.TrimSpace(distance))
+		if err != nil {
+			continue
+		}
+		shortCommit, _ := gitOutput(projectRoot, runGit, "rev-parse", "--short", commit)
+		displayBranch := resolveGitDiffReviewBaseBranch(projectRoot, branch, runGit)
+		if selectedDistance < 0 || parsedDistance < selectedDistance {
+			selectedDistance = parsedDistance
+			selected = DiffReviewBase{Branch: displayBranch, Commit: commit, ShortCommit: shortCommit}
+		}
+	}
+	if selected.Commit != "" {
+		return selected, true, nil
+	}
+	return DiffReviewBase{}, false, nil
+}
+
+func resolveGitDiffReviewBaseBranch(projectRoot, branch string, runGit GitCommandRunnerFunc) string {
+	if branch != "origin/HEAD" {
+		return branch
+	}
+	resolved, err := gitOutput(projectRoot, runGit, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
+	if err != nil || resolved == "" {
+		return branch
+	}
+	return resolved
+}
+
+func resolveGitDiffReviewCommits(projectRoot string, base DiffReviewBase, baseFound bool, runGit GitCommandRunnerFunc) ([]DiffCommit, error) {
+	if !baseFound {
+		return nil, nil
+	}
+	output, err := gitOutput(projectRoot, runGit, "log", "--reverse", "--date=iso-strict", "--pretty=format:%H%x1f%h%x1f%an%x1f%aI%x1f%s%x1e", base.Commit+"..HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("git log: %w", err)
+	}
+	return parseGitDiffReviewCommits(output), nil
+}
+
+func gitOutput(projectRoot string, runGit GitCommandRunnerFunc, args ...string) (string, error) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	if err := runGit(projectRoot, stdout, stderr, args...); err != nil {
+		return "", fmt.Errorf("%w%s", err, formatGitCommandStderr(stderr.String()))
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func parseGitDiffReviewCommits(output string) []DiffCommit {
+	output = strings.TrimSuffix(output, "\x1e")
+	if output == "" {
+		return nil
+	}
+	records := strings.Split(output, "\x1e")
+	commits := make([]DiffCommit, 0, len(records))
+	for _, record := range records {
+		fields := strings.SplitN(strings.TrimSpace(record), "\x1f", 5)
+		if len(fields) != 5 {
+			continue
+		}
+		commits = append(commits, DiffCommit{
+			Hash:      fields[0],
+			ShortHash: fields[1],
+			Author:    fields[2],
+			Date:      fields[3],
+			Subject:   fields[4],
+		})
+	}
+	return commits
 }
 
 func appendUntrackedGitDiff(projectRoot string, rawDiff *bytes.Buffer, runGit GitCommandRunnerFunc) error {

--- a/erun-common/diff_test.go
+++ b/erun-common/diff_test.go
@@ -108,21 +108,185 @@ func TestResolveGitDiffRunsNoColorDiff(t *testing.T) {
 		return writeResolveGitDiffOutput(t, stdout, calls, args)
 	})
 	requireNoError(t, err, "ResolveGitDiff failed")
-	requireCondition(t, gotDir == "/tmp/project" && len(calls) == 2 && calls[0] == "diff --no-color --no-ext-diff" && calls[1] == "ls-files --others --exclude-standard -z", "unexpected git invocation: dir=%q calls=%+v", gotDir, calls)
+	wantCalls := []string{
+		"diff --no-color --no-ext-diff",
+		"ls-files --others --exclude-standard -z",
+	}
+	requireCondition(t, gotDir == "/tmp/project" && strings.Join(calls, "\n") == strings.Join(wantCalls, "\n"), "unexpected git invocation: dir=%q calls=%+v", gotDir, calls)
 	requireCondition(t, result.WorkingDirectory == "/tmp/project" && result.RawDiff != "", "unexpected result: %+v", result)
+	requireCondition(t, result.IncludesWorktree, "expected worktree diff by default")
 }
 
 func writeResolveGitDiffOutput(t *testing.T, stdout io.Writer, calls []string, args []string) error {
 	t.Helper()
-	switch len(calls) {
-	case 1:
+	switch strings.Join(args, " ") {
+	case "diff --no-color --no-ext-diff":
 		_, _ = io.WriteString(stdout, "diff --git a/a.txt b/a.txt\n")
-	case 2:
+	case "ls-files --others --exclude-standard -z":
 		_, _ = io.WriteString(stdout, "")
 	default:
 		t.Fatalf("unexpected git call: %v", args)
 	}
 	return nil
+}
+
+func TestResolveGitDiffWithOptionsRunsAllBranchReviewDiff(t *testing.T) {
+	var gotDir string
+	calls := make([]string, 0, 10)
+	result, err := ResolveGitDiffWithOptions("/tmp/project", DiffOptions{Scope: "all"}, func(dir string, stdout, stderr io.Writer, args ...string) error {
+		gotDir = dir
+		calls = append(calls, strings.Join(args, " "))
+		return writeResolveGitReviewDiffOutput(t, stdout, args)
+	})
+	requireNoError(t, err, "ResolveGitDiffWithOptions failed")
+	wantCalls := []string{
+		"merge-base HEAD origin/HEAD",
+		"rev-list --count abcdef1234567890..HEAD",
+		"rev-parse --short abcdef1234567890",
+		"symbolic-ref --quiet --short refs/remotes/origin/HEAD",
+		"merge-base HEAD origin/main",
+		"merge-base HEAD origin/develop",
+		"merge-base HEAD main",
+		"merge-base HEAD develop",
+		"log --reverse --date=iso-strict --pretty=format:%H%x1f%h%x1f%an%x1f%aI%x1f%s%x1e abcdef1234567890..HEAD",
+		"diff --no-color --no-ext-diff abcdef1234567890",
+		"ls-files --others --exclude-standard -z",
+	}
+	requireCondition(t, gotDir == "/tmp/project" && strings.Join(calls, "\n") == strings.Join(wantCalls, "\n"), "unexpected git invocation: dir=%q calls=%+v", gotDir, calls)
+	requireCondition(t, result.WorkingDirectory == "/tmp/project" && result.RawDiff != "", "unexpected result: %+v", result)
+	requireCondition(t, result.ReviewBase.Branch == "origin/develop" && result.ReviewBase.Commit == "abcdef1234567890" && result.ReviewBase.ShortCommit == "abcdef1", "unexpected review base: %+v", result.ReviewBase)
+	requireCondition(t, result.Scope == "all" && result.IncludesWorktree, "expected all worktree diff scope, got %+v", result)
+	requireCondition(t, len(result.ReviewCommits) == 1 && result.ReviewCommits[0].ShortHash == "1234567" && result.ReviewCommits[0].Subject == "add feature", "unexpected commits: %+v", result.ReviewCommits)
+}
+
+func writeResolveGitReviewDiffOutput(t *testing.T, stdout io.Writer, args []string) error {
+	t.Helper()
+	switch strings.Join(args, " ") {
+	case "merge-base HEAD origin/HEAD":
+		_, _ = io.WriteString(stdout, "abcdef1234567890\n")
+	case "merge-base HEAD origin/main", "merge-base HEAD origin/develop", "merge-base HEAD main", "merge-base HEAD develop":
+		return fmt.Errorf("unknown revision")
+	case "rev-list --count abcdef1234567890..HEAD":
+		_, _ = io.WriteString(stdout, "1\n")
+	case "rev-parse --short abcdef1234567890":
+		_, _ = io.WriteString(stdout, "abcdef1\n")
+	case "symbolic-ref --quiet --short refs/remotes/origin/HEAD":
+		_, _ = io.WriteString(stdout, "origin/develop\n")
+	case "log --reverse --date=iso-strict --pretty=format:%H%x1f%h%x1f%an%x1f%aI%x1f%s%x1e abcdef1234567890..HEAD":
+		_, _ = io.WriteString(stdout, "1234567890abcdef\x1f1234567\x1fPat Example\x1f2026-04-30T08:00:00+03:00\x1fadd feature\x1e")
+	case "diff --no-color --no-ext-diff abcdef1234567890":
+		_, _ = io.WriteString(stdout, "diff --git a/a.txt b/a.txt\n")
+	case "ls-files --others --exclude-standard -z":
+		_, _ = io.WriteString(stdout, "")
+	default:
+		t.Fatalf("unexpected git call: %v", args)
+	}
+	return nil
+}
+
+func TestResolveGitDiffSelectedCommitAccumulatesToWorktreeAndIncludesUntracked(t *testing.T) {
+	result, err := ResolveGitDiffWithOptions("/tmp/project", DiffOptions{Scope: "commit", SelectedCommit: "234567890abcdef1"}, func(dir string, stdout, stderr io.Writer, args ...string) error {
+		if dir != "/tmp/project" {
+			t.Fatalf("unexpected dir: %q", dir)
+		}
+		switch strings.Join(args, " ") {
+		case "merge-base HEAD origin/HEAD":
+			_, _ = io.WriteString(stdout, "abcdef1234567890\n")
+		case "merge-base HEAD origin/main", "merge-base HEAD origin/develop", "merge-base HEAD main", "merge-base HEAD develop":
+			return fmt.Errorf("unknown revision")
+		case "rev-list --count abcdef1234567890..HEAD":
+			_, _ = io.WriteString(stdout, "2\n")
+		case "rev-parse --short abcdef1234567890":
+			_, _ = io.WriteString(stdout, "abcdef1\n")
+		case "symbolic-ref --quiet --short refs/remotes/origin/HEAD":
+			_, _ = io.WriteString(stdout, "origin/develop\n")
+		case "log --reverse --date=iso-strict --pretty=format:%H%x1f%h%x1f%an%x1f%aI%x1f%s%x1e abcdef1234567890..HEAD":
+			_, _ = io.WriteString(stdout, "1234567890abcdef\x1f1234567\x1fPat Example\x1f2026-04-30T08:00:00+03:00\x1ffirst\x1e234567890abcdef1\x1f2345678\x1fPat Example\x1f2026-04-30T08:05:00+03:00\x1fsecond\x1e")
+		case "diff --no-color --no-ext-diff 234567890abcdef1^":
+			_, _ = io.WriteString(stdout, "diff --git a/a.txt b/a.txt\n")
+		case "ls-files --others --exclude-standard -z":
+			_, _ = io.WriteString(stdout, "notes.txt\x00")
+		case "diff --no-color --no-ext-diff --no-index -- /dev/null notes.txt":
+			_, _ = io.WriteString(stdout, untrackedFileDiff("notes.txt", "+notes"))
+			return fmt.Errorf("exit status 1")
+		default:
+			t.Fatalf("unexpected git call: %v", args)
+		}
+		return nil
+	})
+
+	requireNoError(t, err, "ResolveGitDiffWithOptions failed")
+	requireCondition(t, result.Scope == "commit" && result.SelectedCommit == "234567890abcdef1" && result.IncludesWorktree, "unexpected selected range metadata: %+v", result)
+	requireCondition(t, len(result.Files) == 2 && result.Files[1].Path == "notes.txt", "expected selected commit diff plus untracked file, got %+v", result.Files)
+	requireCondition(t, len(result.ReviewCommits) == 2, "unexpected commits: %+v", result.ReviewCommits)
+}
+
+func TestResolveGitDiffChoosesClosestMainOrDevelopBase(t *testing.T) {
+	result, err := ResolveGitDiffWithOptions("/tmp/project", DiffOptions{Scope: "all"}, func(dir string, stdout, stderr io.Writer, args ...string) error {
+		switch strings.Join(args, " ") {
+		case "merge-base HEAD origin/HEAD":
+			_, _ = io.WriteString(stdout, "mainbase\n")
+		case "rev-list --count mainbase..HEAD":
+			_, _ = io.WriteString(stdout, "5\n")
+		case "rev-parse --short mainbase":
+			_, _ = io.WriteString(stdout, "mainbas\n")
+		case "symbolic-ref --quiet --short refs/remotes/origin/HEAD":
+			_, _ = io.WriteString(stdout, "origin/main\n")
+		case "merge-base HEAD origin/main", "merge-base HEAD main":
+			_, _ = io.WriteString(stdout, "mainbase\n")
+		case "merge-base HEAD origin/develop":
+			_, _ = io.WriteString(stdout, "developbase\n")
+		case "rev-list --count developbase..HEAD":
+			_, _ = io.WriteString(stdout, "2\n")
+		case "rev-parse --short developbase":
+			_, _ = io.WriteString(stdout, "develop\n")
+		case "merge-base HEAD develop":
+			_, _ = io.WriteString(stdout, "developbase\n")
+		case "log --reverse --date=iso-strict --pretty=format:%H%x1f%h%x1f%an%x1f%aI%x1f%s%x1e developbase..HEAD":
+			_, _ = io.WriteString(stdout, "")
+		case "diff --no-color --no-ext-diff developbase":
+			_, _ = io.WriteString(stdout, "diff --git a/a.txt b/a.txt\n")
+		case "ls-files --others --exclude-standard -z":
+			_, _ = io.WriteString(stdout, "")
+		default:
+			t.Fatalf("unexpected git call: %v", args)
+		}
+		return nil
+	})
+
+	requireNoError(t, err, "ResolveGitDiffWithOptions failed")
+	requireCondition(t, result.ReviewBase.Branch == "origin/develop" && result.ReviewBase.Commit == "developbase", "unexpected review base: %+v", result.ReviewBase)
+}
+
+func TestResolveGitDiffFallsBackToWorkingDiffWithoutReviewBase(t *testing.T) {
+	calls := make([]string, 0, 8)
+	result, err := ResolveGitDiffWithOptions("/tmp/project", DiffOptions{Scope: "all"}, func(dir string, stdout, stderr io.Writer, args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		switch strings.Join(args, " ") {
+		case "merge-base HEAD origin/HEAD", "merge-base HEAD origin/main", "merge-base HEAD origin/develop", "merge-base HEAD main", "merge-base HEAD develop":
+			return fmt.Errorf("unknown revision")
+		case "diff --no-color --no-ext-diff":
+			_, _ = io.WriteString(stdout, "diff --git a/a.txt b/a.txt\n")
+		case "ls-files --others --exclude-standard -z":
+			_, _ = io.WriteString(stdout, "")
+		default:
+			t.Fatalf("unexpected git call: %v", args)
+		}
+		return nil
+	})
+
+	requireNoError(t, err, "ResolveGitDiffWithOptions failed")
+	wantCalls := []string{
+		"merge-base HEAD origin/HEAD",
+		"merge-base HEAD origin/main",
+		"merge-base HEAD origin/develop",
+		"merge-base HEAD main",
+		"merge-base HEAD develop",
+		"diff --no-color --no-ext-diff",
+		"ls-files --others --exclude-standard -z",
+	}
+	requireCondition(t, strings.Join(calls, "\n") == strings.Join(wantCalls, "\n"), "unexpected calls: %+v", calls)
+	requireCondition(t, result.ReviewBase.Commit == "" && result.RawDiff != "", "unexpected fallback result: %+v", result)
 }
 
 func TestResolveGitDiffIncludesUntrackedFiles(t *testing.T) {
@@ -143,6 +307,8 @@ func resolveGitDiffWithUntrackedFiles(t *testing.T) GitCommandRunnerFunc {
 func writeGitDiffWithUntrackedOutput(t *testing.T, stdout io.Writer, args []string) error {
 	t.Helper()
 	switch strings.Join(args, " ") {
+	case "merge-base HEAD origin/HEAD", "merge-base HEAD origin/main", "merge-base HEAD origin/develop", "merge-base HEAD main", "merge-base HEAD develop":
+		return fmt.Errorf("unknown revision")
 	case "diff --no-color --no-ext-diff":
 		_, _ = io.WriteString(stdout, "diff --git a/existing.txt b/existing.txt\n")
 		return nil

--- a/erun-mcp/diff.go
+++ b/erun-mcp/diff.go
@@ -9,7 +9,9 @@ import (
 )
 
 type DiffInput struct {
-	Verbosity int `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+	Verbosity      int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+	Scope          string `json:"scope,omitempty" jsonschema:"diff scope: current, commit, or all"`
+	SelectedCommit string `json:"selectedCommit,omitempty" jsonschema:"oldest commit hash to include when scope is commit"`
 }
 
 func diffTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, DiffInput) (*mcp.CallToolResult, eruncommon.DiffResult, error) {
@@ -21,7 +23,10 @@ func diffTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest,
 		traceOutput := new(strings.Builder)
 		ctx := runtimeCallContext(false, input.Verbosity, nil, traceOutput, traceOutput)
 		ctx.TraceCommand(workDir, "git", "diff", "--no-color", "--no-ext-diff")
-		result, err := eruncommon.ResolveGitDiff(workDir, eruncommon.GitCommandRunner)
+		result, err := eruncommon.ResolveGitDiffWithOptions(workDir, eruncommon.DiffOptions{
+			Scope:          input.Scope,
+			SelectedCommit: input.SelectedCommit,
+		}, eruncommon.GitCommandRunner)
 		return nil, result, err
 	}
 }

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -38,7 +38,7 @@ type erunUIDeps struct {
 	startTerminal        func(startTerminalSessionParams) (terminalSession, error)
 	runIDECommand        func(context.Context, startTerminalSessionParams) (string, error)
 	savePastedImage      func(pastedImageSaveParams) (string, error)
-	loadDiff             func(context.Context, string) (eruncommon.DiffResult, error)
+	loadDiff             func(context.Context, string, uiDiffOptions) (eruncommon.DiffResult, error)
 	loadIdleStatus       func(context.Context, string) (eruncommon.EnvironmentIdleStatus, error)
 	recordActivity       func(eruncommon.EnvironmentActivityParams) error
 	stopCloudContext     func(context.Context, string) (eruncommon.CloudContextStatus, error)

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -348,13 +348,16 @@ func TestLoadDiffUsesSelectedMCPPort(t *testing.T) {
 			ensured = result
 			return nil
 		},
-		loadDiff: func(_ context.Context, endpoint string) (eruncommon.DiffResult, error) {
+		loadDiff: func(_ context.Context, endpoint string, options uiDiffOptions) (eruncommon.DiffResult, error) {
 			gotEndpoint = endpoint
+			if options.Scope != "commit" || options.SelectedCommit != "abc123" {
+				t.Fatalf("unexpected diff options: %+v", options)
+			}
 			return eruncommon.DiffResult{RawDiff: "diff --git a/a.txt b/a.txt\n"}, nil
 		},
 	})
 
-	result, err := app.LoadDiff(uiSelection{Tenant: "erun", Environment: "local"})
+	result, err := app.LoadDiff(uiSelection{Tenant: "erun", Environment: "local"}, uiDiffOptions{Scope: " commit ", SelectedCommit: " abc123 "})
 	if err != nil {
 		t.Fatalf("LoadDiff failed: %v", err)
 	}
@@ -401,7 +404,7 @@ func TestLoadDiffReactivatesMCPAfterConnectionError(t *testing.T) {
 			}
 			return nil
 		},
-		loadDiff: func(_ context.Context, endpoint string) (eruncommon.DiffResult, error) {
+		loadDiff: func(_ context.Context, endpoint string, _ uiDiffOptions) (eruncommon.DiffResult, error) {
 			loadCalls++
 			if endpoint != "http://127.0.0.1:17000/mcp" {
 				t.Fatalf("unexpected endpoint: %q", endpoint)
@@ -413,7 +416,7 @@ func TestLoadDiffReactivatesMCPAfterConnectionError(t *testing.T) {
 		},
 	})
 
-	result, err := app.LoadDiff(uiSelection{Tenant: "erun", Environment: "test"})
+	result, err := app.LoadDiff(uiSelection{Tenant: "erun", Environment: "test"}, uiDiffOptions{})
 	if err != nil {
 		t.Fatalf("LoadDiff failed: %v", err)
 	}

--- a/erun-ui/diff_mcp.go
+++ b/erun-ui/diff_mcp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	eruncommon "github.com/sophium/erun/erun-common"
@@ -23,7 +24,7 @@ func (t idleProbeRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 	return base.RoundTrip(req)
 }
 
-func loadDiffFromMCP(ctx context.Context, endpoint string) (eruncommon.DiffResult, error) {
+func loadDiffFromMCP(ctx context.Context, endpoint string, options uiDiffOptions) (eruncommon.DiffResult, error) {
 	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
 	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
 		Endpoint:             endpoint,
@@ -36,7 +37,13 @@ func loadDiffFromMCP(ctx context.Context, endpoint string) (eruncommon.DiffResul
 		_ = session.Close()
 	}()
 
-	result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "diff"})
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "diff",
+		Arguments: map[string]any{
+			"scope":          strings.TrimSpace(options.Scope),
+			"selectedCommit": strings.TrimSpace(options.SelectedCommit),
+		},
+	})
 	if err != nil {
 		return eruncommon.DiffResult{}, err
 	}

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -133,10 +133,13 @@ export class ERunUIController {
     filesOpen: loadSavedFilesOpen(),
     sidebarHidden: false,
     reviewOpen: false,
+    changedFilesOpen: true,
     diff: null,
     diffLoading: false,
     diffError: '',
     selectedDiffPath: '',
+    selectedReviewScope: 'current',
+    selectedReviewCommit: '',
     diffFilter: '',
     collapsedDiffDirs: new Set<string>(),
     notification: null,
@@ -382,6 +385,11 @@ export class ERunUIController {
   }
 
   private prepareOpenSelection(selection: UISelection, runSelection: UISelection, previousSessionId: number, previousKnownSessionId: number): void {
+    if (selectionKey(selection) !== selectionKey(this.state.selected || { tenant: '', environment: '' })) {
+      this.state.selectedReviewScope = 'current';
+      this.state.selectedReviewCommit = '';
+      this.state.selectedDiffPath = '';
+    }
     this.state.selected = selection;
     this.state.idleStatus = null;
     if (!isNewSessionSelection(previousSessionId, previousKnownSessionId)) {
@@ -871,6 +879,21 @@ export class ERunUIController {
     this.emit();
   }
 
+  toggleChangedFiles(): void {
+    this.state.changedFilesOpen = !this.state.changedFilesOpen;
+    this.emit();
+  }
+
+  selectReviewRange(scope: AppState['selectedReviewScope'], hash = ''): void {
+    const selected = hash.trim();
+    if ((scope === this.state.selectedReviewScope && selected === this.state.selectedReviewCommit) || this.state.diffLoading) {
+      return;
+    }
+    this.state.selectedReviewScope = scope;
+    this.state.selectedReviewCommit = selected;
+    void this.loadReviewDiff();
+  }
+
   async loadReviewDiff(): Promise<void> {
     if (!this.state.selected) {
       return;
@@ -879,8 +902,13 @@ export class ERunUIController {
     this.state.diffError = '';
     this.emit();
     try {
-      const diff = (await LoadDiff(this.state.selected)) as DiffResult;
+      const diff = (await LoadDiff(this.state.selected, {
+        scope: this.state.selectedReviewScope,
+        selectedCommit: this.state.selectedReviewCommit,
+      })) as DiffResult;
       this.state.diff = diff;
+      this.state.selectedReviewScope = diff.scope || 'current';
+      this.state.selectedReviewCommit = diff.selectedCommit || '';
       this.state.selectedDiffPath = chooseSelectedDiffPath(diff, this.state.selectedDiffPath);
     } catch (error: unknown) {
       this.state.diff = null;

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -122,10 +122,13 @@ export interface AppState {
   filesOpen: boolean;
   sidebarHidden: boolean;
   reviewOpen: boolean;
+  changedFilesOpen: boolean;
   diff: DiffResult | null;
   diffLoading: boolean;
   diffError: string;
   selectedDiffPath: string;
+  selectedReviewScope: 'current' | 'commit' | 'all';
+  selectedReviewCommit: string;
   diffFilter: string;
   collapsedDiffDirs: Set<string>;
   notification: AppNotification | null;

--- a/erun-ui/frontend/src/components/app/ReviewPanel.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ChevronDown, ChevronRight, FileDiff, RefreshCw, Search } from 'lucide-react';
+import { ChevronDown, ChevronRight, FileDiff, GitBranch, GitCommitHorizontal, RefreshCw, Search } from 'lucide-react';
 
 import type { ERunUIController } from '@/app/ERunUIController';
 import { compactDiffError, filterDiffTree, visibleDiffTreeNodes } from '@/app/diffUtils';
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
-import type { DiffTreeNode } from '@/types';
+import type { DiffCommit, DiffTreeNode } from '@/types';
 import { DiffList, ReviewStatus } from './DiffList';
 import { FileIcon } from './FileIcon';
 import { IconTooltip } from './IconTooltip';
@@ -79,21 +79,115 @@ function ChangedFilesAside({ controller, state, visible }: { controller: ERunUIC
       )}
     >
       <ChangedFilesHeader controller={controller} state={state} />
-      <Label className="box-border flex h-[38px] items-center gap-2 rounded-[var(--radius)] border border-input bg-background px-3 text-muted-foreground [&_svg]:size-[18px] [&_svg]:flex-none">
-        <Search aria-hidden="true" />
-        <Input
-          className="h-auto min-w-0 flex-1 border-0 bg-transparent p-0 text-sm text-foreground shadow-none outline-none placeholder:text-muted-foreground focus-visible:border-0 focus-visible:ring-0"
-          value={state.diffFilter}
-          type="search"
-          placeholder="Filter files..."
-          autoComplete="off"
-          onChange={(event) => controller.setDiffFilter(event.target.value)}
-        />
-      </Label>
-      <div className="min-h-0 flex-1 overflow-auto overscroll-contain pt-3.5">
-        <ChangedFileTree controller={controller} state={state} />
-      </div>
+      <ReviewRangeControl controller={controller} state={state} />
+      {state.changedFilesOpen ? (
+        <>
+          <Label className="box-border flex h-[38px] items-center gap-2 rounded-[var(--radius)] border border-input bg-background px-3 text-muted-foreground [&_svg]:size-[18px] [&_svg]:flex-none">
+            <Search aria-hidden="true" />
+            <Input
+              className="h-auto min-w-0 flex-1 border-0 bg-transparent p-0 text-sm text-foreground shadow-none outline-none placeholder:text-muted-foreground focus-visible:border-0 focus-visible:ring-0"
+              value={state.diffFilter}
+              type="search"
+              placeholder="Filter files..."
+              autoComplete="off"
+              onChange={(event) => controller.setDiffFilter(event.target.value)}
+            />
+          </Label>
+          <div className="min-h-0 flex-1 overflow-auto overscroll-contain pt-3.5">
+            <ChangedFileTree controller={controller} state={state} />
+          </div>
+        </>
+      ) : null}
     </aside>
+  );
+}
+
+function ReviewRangeControl({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement | null {
+  const commits = [...(state.diff?.reviewCommits || [])].reverse();
+  const base = state.diff?.reviewBase;
+  if (!base?.commit && commits.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-3.5 flex min-h-0 flex-col gap-2 border-b border-border pb-3.5">
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <div className="text-xs font-semibold text-foreground">Review layers</div>
+        <div className="text-[11px] leading-4 text-muted-foreground">Newest changes first. Each lower layer includes more history.</div>
+      </div>
+      <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+        <GitBranch className="size-3.5 flex-none" aria-hidden="true" />
+        <span className="flex-none">Merge target</span>
+        <span className="min-w-0 truncate font-medium text-foreground">{base?.branch || 'branch base'}</span>
+        {base?.shortCommit ? <span className="flex-none font-mono">{base.shortCommit}</span> : null}
+      </div>
+      <div className="relative flex min-h-0 flex-col gap-1 before:absolute before:top-4 before:bottom-4 before:left-[15px] before:w-px before:bg-border">
+        <ReviewBoundaryButton
+          label="Current local changes"
+          detail="local only"
+          selected={state.selectedReviewScope === 'current'}
+          disabled={state.diffLoading}
+          onClick={() => controller.selectReviewRange('current')}
+        />
+        {commits.length > 0 ? (
+          <div className="flex max-h-[220px] min-h-0 flex-col gap-1 overflow-auto pr-1">
+            {commits.map((commit) => (
+              <ReviewCommitButton key={commit.hash} controller={controller} state={state} commit={commit} />
+            ))}
+          </div>
+        ) : null}
+        <ReviewBoundaryButton
+          label="All branch changes"
+          detail="base..current"
+          selected={state.selectedReviewScope === 'all'}
+          disabled={state.diffLoading}
+          onClick={() => controller.selectReviewRange('all')}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ReviewCommitButton({ controller, state, commit }: { controller: ERunUIController; state: AppState; commit: DiffCommit }): React.ReactElement {
+  return (
+    <ReviewBoundaryButton
+      label={commit.subject || commit.shortHash}
+      detail={`from ${commit.shortHash}`}
+      selected={state.selectedReviewScope === 'commit' && state.selectedReviewCommit === commit.hash}
+      disabled={state.diffLoading}
+      onClick={() => controller.selectReviewRange('commit', commit.hash)}
+    />
+  );
+}
+
+function ReviewBoundaryButton({
+  label,
+  detail,
+  selected,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  detail: string;
+  selected: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      className={cn(
+        'relative grid h-8 w-full cursor-pointer grid-cols-[16px_minmax(0,1fr)_auto] items-center gap-2 rounded-[var(--radius)] border-0 bg-background px-2 text-left text-xs text-foreground hover:bg-accent disabled:cursor-default disabled:opacity-60',
+        selected && 'bg-primary text-primary-foreground hover:bg-primary',
+      )}
+      disabled={disabled}
+      aria-pressed={selected}
+      onClick={onClick}
+    >
+      <GitCommitHorizontal className="size-3.5 flex-none" aria-hidden="true" />
+      <span className="min-w-0 truncate">{label}</span>
+      <span className={cn('flex-none font-mono text-[11px]', selected ? 'text-primary-foreground/80' : 'text-muted-foreground')}>{detail}</span>
+    </button>
   );
 }
 
@@ -103,10 +197,12 @@ function ChangedFilesHeader({ controller, state }: { controller: ERunUIControlle
       <button
         className="inline-flex min-w-0 flex-1 cursor-pointer items-center gap-1 overflow-hidden border-0 bg-transparent p-0 text-sm font-semibold whitespace-nowrap text-foreground [&_svg]:size-4 [&_svg]:flex-none [&_svg]:text-muted-foreground"
         type="button"
+        aria-expanded={state.changedFilesOpen}
+        onClick={() => controller.toggleChangedFiles()}
       >
         <FileDiff aria-hidden="true" />
         Changed files <span className="flex-none text-muted-foreground">{state.diff?.summary?.fileCount || 0}</span>
-        <ChevronDown aria-hidden="true" />
+        <ChevronDown className={cn('transition-transform', !state.changedFilesOpen && '-rotate-90')} aria-hidden="true" />
       </button>
       <div className="flex min-w-0 flex-none items-center gap-2">
         <IconTooltip label="Refresh diff">

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -230,6 +230,11 @@ export interface DiffResult {
   summary: DiffSummary;
   files?: DiffFile[];
   tree?: DiffTreeNode[];
+  reviewBase?: DiffReviewBase;
+  reviewCommits?: DiffCommit[];
+  scope?: 'current' | 'commit' | 'all';
+  selectedCommit?: string;
+  includesWorktree?: boolean;
 }
 
 export interface DiffSummary {
@@ -274,4 +279,18 @@ export interface DiffTreeNode {
   status?: string;
   additions?: number;
   deletions?: number;
+}
+
+export interface DiffReviewBase {
+  branch?: string;
+  commit?: string;
+  shortCommit?: string;
+}
+
+export interface DiffCommit {
+  hash: string;
+  shortHash: string;
+  subject: string;
+  author: string;
+  date: string;
 }

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -398,8 +398,10 @@ func (a *App) SavePastedImage(payload pastedImagePayload) (pastedImageResult, er
 	return pastedImageResult{Path: path}, nil
 }
 
-func (a *App) LoadDiff(selection uiSelection) (eruncommon.DiffResult, error) {
+func (a *App) LoadDiff(selection uiSelection, options uiDiffOptions) (eruncommon.DiffResult, error) {
 	selection = normalizeSelection(selection)
+	options.Scope = strings.TrimSpace(options.Scope)
+	options.SelectedCommit = strings.TrimSpace(options.SelectedCommit)
 	if selection.Tenant == "" || selection.Environment == "" {
 		return eruncommon.DiffResult{}, fmt.Errorf("tenant and environment are required")
 	}
@@ -418,14 +420,14 @@ func (a *App) LoadDiff(selection uiSelection) (eruncommon.DiffResult, error) {
 		return eruncommon.DiffResult{}, err
 	}
 	endpoint := mcpEndpointForOpenResult(result)
-	diff, err := a.deps.loadDiff(ctx, endpoint)
+	diff, err := a.deps.loadDiff(ctx, endpoint, options)
 	if err == nil || a.deps.ensureMCP == nil {
 		return diff, err
 	}
 	if ensureErr := a.deps.ensureMCP(ctx, result); ensureErr != nil {
 		return eruncommon.DiffResult{}, err
 	}
-	return a.deps.loadDiff(ctx, endpoint)
+	return a.deps.loadDiff(ctx, endpoint, options)
 }
 
 func (a *App) ensureMCPAvailable(ctx context.Context, result eruncommon.OpenResult) error {

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -39,6 +39,11 @@ type uiSelection struct {
 	Debug             bool   `json:"debug,omitempty"`
 }
 
+type uiDiffOptions struct {
+	Scope          string `json:"scope,omitempty"`
+	SelectedCommit string `json:"selectedCommit,omitempty"`
+}
+
 type uiBuildDetails struct {
 	Version string `json:"version"`
 	Commit  string `json:"commit,omitempty"`


### PR DESCRIPTION
## Summary

- add branch-aware diff review layers for the desktop diff panel
- expose diff scope and selected commit through MCP and desktop backend calls
- show review layers from current local changes through commit-based layers down to all branch changes
- label the merge target branch explicitly and keep untracked files visible in every layer

## Validation

- go test ./... in erun-common
- go test ./... in erun-mcp
- go test ./... in erun-ui
- go test ./... in erun-cli
- PATH=/opt/homebrew/opt/node@24/bin:$PATH yarn build in erun-ui/frontend
- PATH=/opt/homebrew/opt/node@24/bin:$PATH yarn shadcn:check in erun-ui/frontend
- git diff --check

Closes #175
