### PR TITLE
Fix local IDE opening and diff refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ Repository guidance for humans and coding agents working in this repo.
 ## Working Rules
 
 - Start each non-trivial change by identifying the smallest coherent outcome that would satisfy the request, the modules likely affected, and the validation scope needed for confidence.
-- When asking the user to confirm a plan, describe the actual intended changes, not just investigation steps. Name the behavior that will change, the user-visible outcome, the likely files or modules to edit, and the validation that will prove the change. Keep discovery-only steps out of the plan unless they materially affect the proposed implementation.
+- When asking the user to confirm a plan, show a plan only for the intended change, not for discovery by itself. Describe the actual changes to make: the behavior that will change, the user-visible outcome, the likely files or modules to edit, and the validation that will prove the change. Keep investigation or discovery steps out of the plan unless they materially affect the proposed implementation.
 - Prefer fast, evidence-driven iteration. Use existing behavior, failing symptoms, tests, and screenshots as the source of truth, then tighten the implementation around the observed problem.
 - Keep work centered on the current user goal. Avoid opportunistic cleanup, broad redesign, or unrelated polish unless it directly reduces risk for the requested change.
 - When a problem crosses module boundaries, solve it at the lowest shared layer that owns the behavior, then keep transport-specific code focused on adaptation and presentation.
@@ -145,6 +145,7 @@ Repository guidance for humans and coding agents working in this repo.
 - CLI prompts are acceptable in interactive flows, but MCP-exposed paths should receive all required input explicitly and fail clearly when input is missing.
 - Prefer deterministic command behavior so tool calls are safe to run repeatedly and concurrently.
 - Prefer safety and clarity over micro-optimizations.
+- For documentation-only guidance changes, do not change app behavior. Update the nearest applicable `AGENTS.md` and validate by reviewing the edited guidance for consistency.
 - Do not add new documentation files unless the user explicitly asks for them; add repository instructions to `AGENTS.md` instead.
 - Keep `AGENTS.md` focused on repository workflow and engineering guidance; do not document app behavior, command semantics, or end-user functionality in it.
 - Do not modify `README.md` unless the user explicitly asks for a README change.

--- a/erun-common/list.go
+++ b/erun-common/list.go
@@ -59,6 +59,7 @@ type ListEnvironmentResult struct {
 	CloudProviderAlias string                `json:"cloudProviderAlias,omitempty"`
 	RepoPath           string                `json:"repoPath,omitempty"`
 	RuntimeVersion     string                `json:"runtimeVersion,omitempty"`
+	Remote             bool                  `json:"remote,omitempty"`
 	Snapshot           bool                  `json:"snapshot"`
 	IsActive           bool                  `json:"isActive,omitempty"`
 	LocalPorts         EnvironmentLocalPorts `json:"localPorts,omitempty"`
@@ -179,6 +180,7 @@ func listEnvironmentResult(store ListStore, tenant TenantConfig, env EnvConfig, 
 		CloudProviderAlias: strings.TrimSpace(env.CloudProviderAlias),
 		RepoPath:           strings.TrimSpace(env.RepoPath),
 		RuntimeVersion:     strings.TrimSpace(env.RuntimeVersion),
+		Remote:             env.Remote,
 		Snapshot:           env.SnapshotEnabled(),
 		IsActive:           listEnvironmentIsActive(store, env),
 		LocalPorts:         localPorts,

--- a/erun-common/list_test.go
+++ b/erun-common/list_test.go
@@ -265,6 +265,7 @@ func requireSSHDListResult(t *testing.T, result ListResult) {
 	requireCondition(t, result.CurrentDirectory.Effective.LocalPorts.RangeStart == 17000 && result.CurrentDirectory.Effective.LocalPorts.SSH == DefaultSSHLocalPort, "unexpected effective local ports: %+v", result.CurrentDirectory.Effective.LocalPorts)
 	requireEqual(t, result.CurrentDirectory.Effective.SSH.HostAlias, "erun-tenant-a-dev", "effective SSH host alias")
 	requireCondition(t, result.CurrentDirectory.Effective.SSH.User == DefaultSSHUser && result.CurrentDirectory.Effective.SSH.LocalPort == DefaultSSHLocalPort, "unexpected effective SSH info: %+v", result.CurrentDirectory.Effective.SSH)
+	requireCondition(t, result.Tenants[0].Environments[0].Remote, "expected remote environment flag")
 	requireEqual(t, result.Tenants[0].Environments[0].LocalPorts.RangeEnd, 17099, "environment local port range")
 	requireEqual(t, result.Tenants[0].Environments[0].SSH.WorkspacePath, "/home/erun/git/tenant-a", "SSH workspace path")
 }

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ func TestStateFromListResultUsesEffectiveSelection(t *testing.T) {
 				Name: "erun",
 				Environments: []eruncommon.ListEnvironmentResult{
 					{Name: "local", RuntimeVersion: "1.0.19-snapshot-20260418141901", LocalPorts: eruncommon.EnvironmentLocalPorts{MCP: 17000}, SSH: eruncommon.ListSSHResult{Enabled: true}},
-					{Name: "remote", RuntimeVersion: "1.0.18", LocalPorts: eruncommon.EnvironmentLocalPorts{MCP: 17100}},
+					{Name: "remote", RuntimeVersion: "1.0.18", Remote: true, LocalPorts: eruncommon.EnvironmentLocalPorts{MCP: 17100}},
 				},
 			},
 		},
@@ -51,6 +52,9 @@ func TestStateFromListResultUsesEffectiveSelection(t *testing.T) {
 	}
 	if !state.Tenants[0].Environments[0].SSHDEnabled || state.Tenants[0].Environments[1].SSHDEnabled {
 		t.Fatalf("unexpected SSHD flags: %+v", state.Tenants[0].Environments)
+	}
+	if state.Tenants[0].Environments[0].Remote || !state.Tenants[0].Environments[1].Remote {
+		t.Fatalf("unexpected remote flags: %+v", state.Tenants[0].Environments)
 	}
 }
 
@@ -966,6 +970,7 @@ func TestOpenIDERunsWithoutConsumingTerminalWhenSSHDEnabled(t *testing.T) {
 				Name:              "remote",
 				RepoPath:          projectRoot,
 				KubernetesContext: "rancher-desktop",
+				Remote:            true,
 				SSHD: eruncommon.SSHDConfig{
 					Enabled: true,
 				},
@@ -1004,6 +1009,74 @@ func TestOpenIDERunsWithoutConsumingTerminalWhenSSHDEnabled(t *testing.T) {
 	}
 }
 
+func TestOpenIDEOpensLocalProjectWithoutSSHD(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {
+				Name:               "erun",
+				ProjectRoot:        projectRoot,
+				DefaultEnvironment: "local",
+			},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/local": {
+				Name:              "local",
+				RepoPath:          projectRoot,
+				KubernetesContext: "rancher-desktop",
+			},
+		},
+	}
+
+	var started startTerminalSessionParams
+	app := NewApp(erunUIDeps{
+		store:          store,
+		resolveCLIPath: func() string { return "/tmp/erun" },
+		runIDECommand: func(_ context.Context, params startTerminalSessionParams) (string, error) {
+			started = params
+			return "", nil
+		},
+	})
+	defer app.shutdown(context.Background())
+
+	if err := app.OpenIDE(uiSelection{Tenant: "erun", Environment: "local"}, "intellij"); err != nil {
+		t.Fatalf("OpenIDE failed: %v", err)
+	}
+	wantExecutable, wantArgs, err := localOpenIDECommand(runtime.GOOS, "intellij", projectRoot)
+	if err != nil {
+		t.Fatalf("localOpenIDECommand failed: %v", err)
+	}
+	if started.Dir != projectRoot {
+		t.Fatalf("unexpected dir: %q", started.Dir)
+	}
+	if started.Executable != wantExecutable {
+		t.Fatalf("unexpected executable: got %q want %q", started.Executable, wantExecutable)
+	}
+	if strings.Join(started.Args, "\n") != strings.Join(wantArgs, "\n") {
+		t.Fatalf("unexpected args: got %+v want %+v", started.Args, wantArgs)
+	}
+}
+
+func TestLocalOpenIDECommandBuildsDarwinCommands(t *testing.T) {
+	projectRoot := "/tmp/tenant-a"
+
+	executable, args, err := localOpenIDECommand("darwin", "vscode", projectRoot)
+	if err != nil {
+		t.Fatalf("localOpenIDECommand vscode failed: %v", err)
+	}
+	if executable != "open" || strings.Join(args, "\n") != strings.Join([]string{"-a", "Visual Studio Code", projectRoot}, "\n") {
+		t.Fatalf("unexpected VS Code command: %s %+v", executable, args)
+	}
+
+	executable, args, err = localOpenIDECommand("darwin", "intellij", projectRoot)
+	if err != nil {
+		t.Fatalf("localOpenIDECommand intellij failed: %v", err)
+	}
+	if executable != "open" || strings.Join(args, "\n") != strings.Join([]string{"-a", "IntelliJ IDEA", projectRoot}, "\n") {
+		t.Fatalf("unexpected IntelliJ command: %s %+v", executable, args)
+	}
+}
+
 func TestOpenIDERejectsMissingSSHDWithoutHiddenInit(t *testing.T) {
 	projectRoot := t.TempDir()
 	store := stubUIStore{
@@ -1019,6 +1092,7 @@ func TestOpenIDERejectsMissingSSHDWithoutHiddenInit(t *testing.T) {
 				Name:              "remote",
 				RepoPath:          projectRoot,
 				KubernetesContext: "rancher-desktop",
+				Remote:            true,
 			},
 		},
 	}

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -116,6 +116,8 @@ import type {
   UIVersionSuggestion,
 } from '@/types';
 
+const REVIEW_DIFF_REFRESH_INTERVAL_MS = 5000;
+
 export class ERunUIController {
   readonly state: AppState = {
     tenants: [],
@@ -173,6 +175,8 @@ export class ERunUIController {
   private notificationTimer = 0;
   private terminalCopyStatusTimer = 0;
   private idleStatusTimer = 0;
+  private reviewDiffRefreshTimer = 0;
+  private reviewDiffRequest = 0;
   private idleStatusRequest = 0;
   private versionSuggestionRequest = 0;
   private environmentResourceStatusRequest = 0;
@@ -306,6 +310,7 @@ export class ERunUIController {
     window.clearTimeout(this.notificationTimer);
     window.clearTimeout(this.terminalCopyStatusTimer);
     window.clearTimeout(this.idleStatusTimer);
+    this.stopReviewDiffRefresh();
     if (this.pasteHandler && this.terminalRoot) {
       this.terminalRoot.removeEventListener('paste', this.pasteHandler, true);
     }
@@ -340,6 +345,9 @@ export class ERunUIController {
 
   toggleReview(): void {
     toggleReviewPanel(this.state, { ...this.layoutCallbacks(), loadReviewDiff: () => { void this.loadReviewDiff(); } });
+    if (!this.state.reviewOpen) {
+      this.stopReviewDiffRefresh();
+    }
   }
 
   setFilesOpen(open: boolean, persist = true): void {
@@ -894,29 +902,81 @@ export class ERunUIController {
     void this.loadReviewDiff();
   }
 
-  async loadReviewDiff(): Promise<void> {
-    if (!this.state.selected) {
+  async loadReviewDiff(options: { silent?: boolean } = {}): Promise<void> {
+    const selection = this.state.selected;
+    if (!selection) {
       return;
     }
-    this.state.diffLoading = true;
-    this.state.diffError = '';
-    this.emit();
+    const request = ++this.reviewDiffRequest;
+    const selectedKey = selectionKey(selection);
+    const scope = this.state.selectedReviewScope;
+    const selectedCommit = this.state.selectedReviewCommit;
+    if (!options.silent) {
+      this.state.diffLoading = true;
+      this.state.diffError = '';
+      this.emit();
+    }
     try {
-      const diff = (await LoadDiff(this.state.selected, {
-        scope: this.state.selectedReviewScope,
-        selectedCommit: this.state.selectedReviewCommit,
+      const diff = (await LoadDiff(selection, {
+        scope,
+        selectedCommit,
       })) as DiffResult;
+      if (!this.isCurrentReviewDiffRequest(request, selectedKey)) {
+        return;
+      }
       this.state.diff = diff;
+      this.state.diffError = '';
       this.state.selectedReviewScope = diff.scope || 'current';
       this.state.selectedReviewCommit = diff.selectedCommit || '';
       this.state.selectedDiffPath = chooseSelectedDiffPath(diff, this.state.selectedDiffPath);
     } catch (error: unknown) {
-      this.state.diff = null;
+      if (!this.isCurrentReviewDiffRequest(request, selectedKey)) {
+        return;
+      }
+      if (options.silent && this.state.diff) {
+        return;
+      }
+      if (!options.silent || !this.state.diff) {
+        this.state.diff = null;
+      }
       this.state.diffError = readError(error);
     } finally {
-      this.state.diffLoading = false;
-      this.emit();
+      if (request === this.reviewDiffRequest) {
+        if (!options.silent) {
+          this.state.diffLoading = false;
+        }
+        this.emit();
+        this.scheduleReviewDiffRefresh();
+      }
     }
+  }
+
+  private isCurrentReviewDiffRequest(request: number, selectedKey: string): boolean {
+    return request === this.reviewDiffRequest && selectedKey === selectionKey(this.state.selected || { tenant: '', environment: '' });
+  }
+
+  private scheduleReviewDiffRefresh(delay = REVIEW_DIFF_REFRESH_INTERVAL_MS): void {
+    window.clearTimeout(this.reviewDiffRefreshTimer);
+    if (!this.state.reviewOpen || !this.state.selected) {
+      this.reviewDiffRefreshTimer = 0;
+      return;
+    }
+    this.reviewDiffRefreshTimer = window.setTimeout(() => {
+      if (!this.state.reviewOpen || !this.state.selected) {
+        this.stopReviewDiffRefresh();
+        return;
+      }
+      if (this.state.diffLoading) {
+        this.scheduleReviewDiffRefresh();
+        return;
+      }
+      void this.loadReviewDiff({ silent: true });
+    }, delay);
+  }
+
+  private stopReviewDiffRefresh(): void {
+    window.clearTimeout(this.reviewDiffRefreshTimer);
+    this.reviewDiffRefreshTimer = 0;
   }
 
   toggleDiffDirectory(path: string): void {

--- a/erun-ui/frontend/src/components/app/Titlebar.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.tsx
@@ -34,7 +34,7 @@ function TitlebarControls({ controller, state }: { controller: ERunUIController;
   const ReviewIcon = state.reviewOpen ? PanelRightClose : PanelRightOpen;
   const selected = state.selected;
   const selectedEnvironment = selected ? state.tenants.find((tenant) => tenant.name === selected.tenant)?.environments.find((environment) => environment.name === selected.environment) : undefined;
-  const ideDisabled = !selected || selectedEnvironment?.sshdEnabled !== true;
+  const ideDisabled = !selected || (selectedEnvironment?.remote !== false && selectedEnvironment?.sshdEnabled !== true);
   const vscodeTooltip = ideTooltipLabel('VS Code', selected, ideDisabled);
   const intellijTooltip = ideTooltipLabel('IntelliJ IDEA', selected, ideDisabled);
 

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -4,6 +4,7 @@ export interface UIEnvironment {
   runtimeVersion?: string;
   isActive?: boolean;
   sshdEnabled?: boolean;
+  remote: boolean;
 }
 
 export interface UITenant {

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -100,6 +100,80 @@ func buildOpenIDEArgs(selection uiSelection, ide string) []string {
 	}
 }
 
+func buildLocalOpenIDEParams(result eruncommon.OpenResult, ide string) (startTerminalSessionParams, error) {
+	projectPath := strings.TrimSpace(result.RepoPath)
+	if projectPath == "" {
+		return startTerminalSessionParams{}, fmt.Errorf("local project path is required")
+	}
+	executable, args, err := localOpenIDECommand(runtime.GOOS, strings.TrimSpace(ide), projectPath)
+	if err != nil {
+		return startTerminalSessionParams{}, err
+	}
+	return startTerminalSessionParams{
+		Dir:        projectPath,
+		Executable: executable,
+		Args:       args,
+	}, nil
+}
+
+func localOpenIDECommand(goos, ide, projectPath string) (string, []string, error) {
+	switch strings.TrimSpace(goos) {
+	case "darwin":
+		appName, err := localOpenIDEAppName(ide)
+		if err != nil {
+			return "", nil, err
+		}
+		return "open", []string{"-a", appName, projectPath}, nil
+	case "linux":
+		command, err := localOpenIDEExecutable(ide)
+		if err != nil {
+			return "", nil, err
+		}
+		return command, []string{projectPath}, nil
+	case "windows":
+		command, err := localOpenIDEWindowsCommand(ide)
+		if err != nil {
+			return "", nil, err
+		}
+		return "cmd", []string{"/c", "start", "", command, projectPath}, nil
+	default:
+		return "", nil, fmt.Errorf("opening local IDE projects is unsupported on %s", goos)
+	}
+}
+
+func localOpenIDEAppName(ide string) (string, error) {
+	switch strings.TrimSpace(ide) {
+	case "vscode":
+		return "Visual Studio Code", nil
+	case "intellij":
+		return "IntelliJ IDEA", nil
+	default:
+		return "", fmt.Errorf("unsupported IDE %q", ide)
+	}
+}
+
+func localOpenIDEExecutable(ide string) (string, error) {
+	switch strings.TrimSpace(ide) {
+	case "vscode":
+		return "code", nil
+	case "intellij":
+		return "idea", nil
+	default:
+		return "", fmt.Errorf("unsupported IDE %q", ide)
+	}
+}
+
+func localOpenIDEWindowsCommand(ide string) (string, error) {
+	switch strings.TrimSpace(ide) {
+	case "vscode":
+		return "code", nil
+	case "intellij":
+		return "idea64", nil
+	default:
+		return "", fmt.Errorf("unsupported IDE %q", ide)
+	}
+}
+
 func buildSSHDInitArgs(selection uiSelection) []string {
 	return erunArgs(selection.Debug, "sshd", "init", strings.TrimSpace(selection.Tenant), strings.TrimSpace(selection.Environment))
 }

--- a/erun-ui/state_handlers.go
+++ b/erun-ui/state_handlers.go
@@ -123,6 +123,7 @@ func stateFromListResult(result eruncommon.ListResult, info eruncommon.BuildInfo
 				RuntimeVersion: strings.TrimSpace(environment.RuntimeVersion),
 				IsActive:       environment.IsActive,
 				SSHDEnabled:    environment.SSH.Enabled,
+				Remote:         environment.Remote,
 			})
 		}
 		state.Tenants = append(state.Tenants, item)

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -149,10 +149,20 @@ func (a *App) OpenIDE(selection uiSelection, ide string) error {
 		return err
 	}
 
-	cliPath := a.deps.resolveCLIPath()
-	executable := cliPath
-	args := buildOpenIDEArgs(selection, ide)
-	if !result.EnvConfig.SSHD.Enabled {
+	params := startTerminalSessionParams{
+		Dir:        resolveDeployStartDir(a.deps.findProjectRoot, result),
+		Executable: a.deps.resolveCLIPath(),
+		Args:       buildOpenIDEArgs(selection, ide),
+		Env:        []string{appSessionEnvVar + "=1"},
+	}
+	if !result.RemoteRepo() {
+		localParams, err := buildLocalOpenIDEParams(result, ide)
+		if err != nil {
+			return err
+		}
+		params = localParams
+		params.Env = []string{appSessionEnvVar + "=1"}
+	} else if !result.EnvConfig.SSHD.Enabled {
 		return fmt.Errorf("open %s requires sshd-enabled remote environment; run `erun sshd init %s %s` first", ide, selection.Tenant, selection.Environment)
 	}
 
@@ -160,12 +170,7 @@ func (a *App) OpenIDE(selection uiSelection, ide string) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	output, err := a.deps.runIDECommand(ctx, startTerminalSessionParams{
-		Dir:        resolveDeployStartDir(a.deps.findProjectRoot, result),
-		Executable: executable,
-		Args:       args,
-		Env:        []string{appSessionEnvVar + "=1"},
-	})
+	output, err := a.deps.runIDECommand(ctx, params)
 	if err == nil {
 		return nil
 	}

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -21,6 +21,7 @@ type uiEnvironment struct {
 	RuntimeVersion string `json:"runtimeVersion,omitempty"`
 	IsActive       bool   `json:"isActive,omitempty"`
 	SSHDEnabled    bool   `json:"sshdEnabled,omitempty"`
+	Remote         bool   `json:"remote"`
 }
 
 type uiSelection struct {


### PR DESCRIPTION
## What changed

- Enables local environments to open VS Code and IntelliJ IDEA against the local project path without SSHD.
- Keeps remote IDE opening gated on SSHD.
- Adds automatic silent review-diff refresh while the review panel is open.
- Updates repository guidance so confirmation plans describe intended changes, and documents documentation-only guidance updates.

## Why

Local environments were incorrectly treated like remote SSHD environments in the desktop titlebar because the UI could not distinguish local from remote selections reliably. The review diff panel also required manual refresh to pick up changed files.

## Validation

- `go test ./...` in `erun-ui`
- `go test ./...` in `erun-common`
- `go test ./...` in `erun-cli`
- `go test ./...` in `erun-mcp`
- `yarn build` in `erun-ui/frontend` using bundled Node
- `wails generate module`
- `git diff --check`

Closes #177
