### PR TITLE
Fix octal literal style to use 0o-prefix form

### DIFF
--- a/erun-cli/internal/claude_md.go
+++ b/erun-cli/internal/claude_md.go
@@ -30,7 +30,7 @@ func ensureGlobalCodexInstructionsWithHomeDir(homeDir string) error {
 }
 
 func ensureAgentInstructionsFile(dir, filename string) error {
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 	path := filepath.Join(dir, filename)
@@ -46,5 +46,5 @@ func ensureAgentInstructionsFile(dir, filename string) error {
 		content += "\n"
 	}
 	content += claudeMDBlock
-	return os.WriteFile(path, []byte(content), 0600)
+	return os.WriteFile(path, []byte(content), 0o600)
 }

--- a/erun-cli/internal/claude_md_test.go
+++ b/erun-cli/internal/claude_md_test.go
@@ -47,10 +47,10 @@ func TestEnsureGlobalAgentInstructionsAppendsWhenMissing(t *testing.T) {
 		{".codex", "instructions.md", ensureGlobalCodexInstructionsWithHomeDir},
 	} {
 		subDir := filepath.Join(dir, tc.dir)
-		if err := os.MkdirAll(subDir, 0700); err != nil {
+		if err := os.MkdirAll(subDir, 0o700); err != nil {
 			t.Fatalf("setup %s: %v", tc.dir, err)
 		}
-		if err := os.WriteFile(filepath.Join(subDir, tc.filename), []byte(existing), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(subDir, tc.filename), []byte(existing), 0o600); err != nil {
 			t.Fatalf("setup %s: %v", tc.dir, err)
 		}
 		if err := tc.ensureFn(dir); err != nil {

--- a/erun-cli/internal/claude_settings_test.go
+++ b/erun-cli/internal/claude_settings_test.go
@@ -26,11 +26,11 @@ func TestEnsureClaudeSettingsCreatesFile(t *testing.T) {
 func TestEnsureClaudeSettingsPreservesExistingContent(t *testing.T) {
 	dir := t.TempDir()
 	claudeDir := filepath.Join(dir, ".claude")
-	if err := os.MkdirAll(claudeDir, 0700); err != nil {
+	if err := os.MkdirAll(claudeDir, 0o700); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
 	existing := `{"theme":"dark"}` + "\n"
-	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(existing), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(existing), 0o600); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
 	if err := ensureClaudeSettingsWithHomeDir(dir); err != nil {
@@ -71,11 +71,11 @@ func TestEnsureClaudeSettingsIdempotent(t *testing.T) {
 func TestEnsureClaudeSettingsUpdatesPartialSettings(t *testing.T) {
 	dir := t.TempDir()
 	claudeDir := filepath.Join(dir, ".claude")
-	if err := os.MkdirAll(claudeDir, 0700); err != nil {
+	if err := os.MkdirAll(claudeDir, 0o700); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
 	partial := `{"permissions":{"defaultMode":"default"}}` + "\n"
-	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(partial), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(partial), 0o600); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
 	if err := ensureClaudeSettingsWithHomeDir(dir); err != nil {


### PR DESCRIPTION
## Summary
- Replace legacy `0700`/`0600` octal literals with modern `0o700`/`0o600` form in `claude_md.go`, `claude_md_test.go`, and `claude_settings_test.go`
- No behavior change

## Test plan
- [ ] Existing tests pass

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)