### PR TITLE
Stop rebuilding runtime image on erun open without --snapshot

### DIFF
--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -22,7 +22,7 @@ const (
 
 var currentHostOS = func() common.HostOS { return common.DetectHost().OS }
 
-func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen func(common.OpenParams) (common.OpenResult, error), saveEnvConfig func(string, common.EnvConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateMCP MCPForwarder, activateAPI APIForwarder, activateSSHD SSHDActivator, launchVSCode VSCodeLauncher, launchIntelliJ IntelliJLauncher) *cobra.Command {
+func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen func(common.OpenParams) (common.OpenResult, error), saveEnvConfig func(string, common.EnvConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult, bool) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateMCP MCPForwarder, activateAPI APIForwarder, activateSSHD SSHDActivator, launchVSCode VSCodeLauncher, launchIntelliJ IntelliJLauncher) *cobra.Command {
 	var noShell bool
 	var vscode bool
 	var intellij bool
@@ -65,14 +65,16 @@ func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen 
 			if err != nil {
 				return err
 			}
+			allowLocalBuilds := snapshotOverride != nil && *snapshotOverride
 			return runResolvedOpenCommandWithAPI(ctx, result, openOptions{
-				NoShell:         noShell,
-				NoAliasPrompt:   noAliasPrompt,
-				VSCode:          vscode,
-				IntelliJ:        intellij,
-				VersionOverride: versionOverride,
-				RuntimeImage:    runtimeImage,
-				SaveEnvConfig:   saveEnvConfig,
+				NoShell:          noShell,
+				NoAliasPrompt:    noAliasPrompt,
+				VSCode:           vscode,
+				IntelliJ:         intellij,
+				VersionOverride:  versionOverride,
+				RuntimeImage:     runtimeImage,
+				AllowLocalBuilds: allowLocalBuilds,
+				SaveEnvConfig:    saveEnvConfig,
 			}, promptRunner, openShell, runManagedDeploy, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart, activateMCP, activateAPI, activateSSHD, launchVSCode, launchIntelliJ)
 		},
 	}
@@ -91,13 +93,14 @@ func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen 
 }
 
 type openOptions struct {
-	NoShell         bool
-	NoAliasPrompt   bool
-	VSCode          bool
-	IntelliJ        bool
-	VersionOverride string
-	RuntimeImage    string
-	SaveEnvConfig   func(string, common.EnvConfig) error
+	NoShell          bool
+	NoAliasPrompt    bool
+	VSCode           bool
+	IntelliJ         bool
+	VersionOverride  string
+	RuntimeImage     string
+	AllowLocalBuilds bool
+	SaveEnvConfig    func(string, common.EnvConfig) error
 }
 
 func applyOpenSnapshotPreference(result common.OpenResult, enabled *bool, saveEnvConfig func(string, common.EnvConfig) error) (common.OpenResult, error) {
@@ -122,19 +125,10 @@ func persistOpenRuntimeVersion(result common.OpenResult, version string, saveEnv
 	}
 
 	updated := result.EnvConfig
-	changed := false
-	if strings.TrimSpace(updated.RuntimeVersion) != version {
-		updated.RuntimeVersion = version
-		changed = true
-	}
-	snapshot := strings.Contains(version, "-snapshot-")
-	if updated.Snapshot == nil || *updated.Snapshot != snapshot {
-		updated.SetSnapshot(snapshot)
-		changed = true
-	}
-	if !changed {
+	if strings.TrimSpace(updated.RuntimeVersion) == version {
 		return result, nil
 	}
+	updated.RuntimeVersion = version
 
 	result.EnvConfig = updated
 	if err := saveEnvConfig(result.Tenant, updated); err != nil {
@@ -247,11 +241,11 @@ func resolveOpenWithInitRetryForParams(ctx common.Context, params common.OpenPar
 	return result, true, err
 }
 
-func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateMCP MCPForwarder, activateSSHD SSHDActivator, launchVSCode VSCodeLauncher, launchIntelliJ IntelliJLauncher) error {
+func runResolvedOpenCommand(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult, bool) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateMCP MCPForwarder, activateSSHD SSHDActivator, launchVSCode VSCodeLauncher, launchIntelliJ IntelliJLauncher) error {
 	return runResolvedOpenCommandWithAPI(ctx, result, options, promptRunner, openShell, runManagedDeploy, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart, activateMCP, nil, activateSSHD, launchVSCode, launchIntelliJ)
 }
 
-func runResolvedOpenCommandWithAPI(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateMCP MCPForwarder, activateAPI APIForwarder, activateSSHD SSHDActivator, launchVSCode VSCodeLauncher, launchIntelliJ IntelliJLauncher) error {
+func runResolvedOpenCommandWithAPI(ctx common.Context, result common.OpenResult, options openOptions, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.OpenResult, bool) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateMCP MCPForwarder, activateAPI APIForwarder, activateSSHD SSHDActivator, launchVSCode VSCodeLauncher, launchIntelliJ IntelliJLauncher) error {
 	runner := resolvedOpenRunner{
 		ctx:                       ctx,
 		result:                    result,
@@ -279,7 +273,7 @@ type resolvedOpenRunner struct {
 	openShell                 OpenShellRunner
 	runManagedDeploy          func(common.Context, common.OpenResult) error
 	checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc
-	resolveRuntimeDeploySpec  func(common.OpenResult) (common.DeploySpec, error)
+	resolveRuntimeDeploySpec  func(common.OpenResult, bool) (common.DeploySpec, error)
 	deployHelmChart           common.HelmChartDeployerFunc
 	activateMCP               MCPForwarder
 	activateAPI               APIForwarder
@@ -361,11 +355,11 @@ func (r *resolvedOpenRunner) maybeDeployRuntime(shellReq common.ShellLaunchParam
 }
 
 func (r *resolvedOpenRunner) resolveRuntimeExecution() (common.DeploySpec, error) {
-	execution, err := r.resolveRuntimeDeploySpec(r.result)
+	execution, err := r.resolveRuntimeDeploySpec(r.result, r.options.AllowLocalBuilds)
 	if err != nil {
 		return common.DeploySpec{}, err
 	}
-	execution, err = maybeCreateMissingRuntimeChart(r.ctx, r.result, r.promptRunner, r.resolveRuntimeDeploySpec, execution)
+	execution, err = maybeCreateMissingRuntimeChart(r.ctx, r.result, r.promptRunner, r.resolveRuntimeDeploySpec, r.options.AllowLocalBuilds, execution)
 	if err != nil {
 		return common.DeploySpec{}, err
 	}
@@ -553,7 +547,7 @@ func wrapOpenHelmDeployWithSpinner(ctx common.Context, releaseName string, deplo
 	}
 }
 
-func maybeCreateMissingRuntimeChart(ctx common.Context, result common.OpenResult, promptRunner PromptRunner, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), execution common.DeploySpec) (common.DeploySpec, error) {
+func maybeCreateMissingRuntimeChart(ctx common.Context, result common.OpenResult, promptRunner PromptRunner, resolveRuntimeDeploySpec func(common.OpenResult, bool) (common.DeploySpec, error), allowLocalBuilds bool, execution common.DeploySpec) (common.DeploySpec, error) {
 	if ctx.DryRun || promptRunner == nil || resolveRuntimeDeploySpec == nil {
 		return execution, nil
 	}
@@ -577,7 +571,7 @@ func maybeCreateMissingRuntimeChart(ctx common.Context, result common.OpenResult
 		return common.DeploySpec{}, err
 	}
 
-	return resolveRuntimeDeploySpec(result)
+	return resolveRuntimeDeploySpec(result, allowLocalBuilds)
 }
 
 func applyRuntimeDeployImageOverride(result common.OpenResult, execution common.DeploySpec, runtimeImage string) (common.DeploySpec, error) {

--- a/erun-cli/cmd/open_test.go
+++ b/erun-cli/cmd/open_test.go
@@ -449,7 +449,7 @@ func TestRunResolvedOpenCommandForcesSSHDEnabledOnRuntimeDeploy(t *testing.T) {
 		func(common.KubernetesDeploymentCheckParams) (bool, error) {
 			return false, nil
 		},
-		func(common.OpenResult) (common.DeploySpec, error) {
+		func(common.OpenResult, bool) (common.DeploySpec, error) {
 			return common.DeploySpec{
 				Deploy: common.HelmDeploySpec{
 					ReleaseName:       "tenant-a-devops",
@@ -527,7 +527,7 @@ func TestRunResolvedOpenCommandPersistsRuntimeVersionAfterDeploy(t *testing.T) {
 		func(common.KubernetesDeploymentCheckParams) (bool, error) {
 			return false, nil
 		},
-		func(common.OpenResult) (common.DeploySpec, error) {
+		func(common.OpenResult, bool) (common.DeploySpec, error) {
 			return common.DeploySpec{
 				Deploy: common.HelmDeploySpec{
 					ReleaseName:       "test-devops",
@@ -565,8 +565,8 @@ func TestRunResolvedOpenCommandPersistsRuntimeVersionAfterDeploy(t *testing.T) {
 	if saved.RuntimeVersion != deployedVersion {
 		t.Fatalf("expected persisted runtime version %q, got %q", deployedVersion, saved.RuntimeVersion)
 	}
-	if saved.Snapshot == nil || !*saved.Snapshot {
-		t.Fatalf("expected snapshot deployment to persist snapshot true, got %+v", saved)
+	if saved.Snapshot != nil {
+		t.Fatalf("expected persisted Snapshot to remain unchanged when deploying a snapshot tag, got %+v", saved)
 	}
 }
 
@@ -810,7 +810,7 @@ func TestRunResolvedOpenCommandRejectsIntelliJRuntimeRedeploy(t *testing.T) {
 			}
 			return false, nil
 		},
-		func(common.OpenResult) (common.DeploySpec, error) {
+		func(common.OpenResult, bool) (common.DeploySpec, error) {
 			return common.DeploySpec{
 				Deploy: common.HelmDeploySpec{
 					ReleaseName: "tenant-a-devops",
@@ -1201,7 +1201,7 @@ func TestOpenCommandDryRunRedeploysWhenRuntimeHasLocalBuilds(t *testing.T) {
 	})
 	cmd.SetOut(stdout)
 	cmd.SetErr(stderr)
-	cmd.SetArgs([]string{"-v", "open", "tenant-a", "local", "--dry-run"})
+	cmd.SetArgs([]string{"-v", "open", "tenant-a", "local", "--snapshot", "--dry-run"})
 
 	requireNoError(t, cmd.Execute(), "Execute failed")
 
@@ -1317,7 +1317,7 @@ func TestOpenCommandDryRunUsesConfiguredContextForLocalDeploy(t *testing.T) {
 	})
 	cmd.SetOut(stdout)
 	cmd.SetErr(stderr)
-	cmd.SetArgs([]string{"-v", "open", "erun", common.DefaultEnvironment, "--dry-run"})
+	cmd.SetArgs([]string{"-v", "open", "erun", common.DefaultEnvironment, "--snapshot", "--dry-run"})
 
 	requireNoError(t, cmd.Execute(), "Execute failed")
 
@@ -1408,6 +1408,75 @@ func TestOpenCommandUsesPersistedSnapshotPreferenceForLocalEnvironment(t *testin
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected dry-run output to contain %q, got %q", want, output)
+		}
+	}
+}
+
+func TestOpenCommandDoesNotBuildOrRedeployWhenPersistedSnapshotTrueWithoutFlag(t *testing.T) {
+	setupRootCmdTestConfigHome(t)
+	stubKubectlContexts(t, []string{"cluster-local"}, "cluster-local")
+
+	projectRoot := t.TempDir()
+	componentName := "tenant-a-devops"
+	componentRoot := filepath.Join(projectRoot, componentName)
+	chartPath := filepath.Join(componentRoot, "k8s", componentName)
+	requireNoError(t, os.MkdirAll(chartPath, 0o755), "mkdir chart dir")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "Chart.yaml"), []byte("apiVersion: v2\nname: "+componentName+"\nversion: 1.0.0\nappVersion: 1.0.0\n"), 0o644), "write Chart.yaml")
+	requireNoError(t, os.WriteFile(filepath.Join(chartPath, "values.local.yaml"), nil, 0o644), "write values.local.yaml")
+	workdir := filepath.Join(componentRoot, "docker", componentName)
+	requireNoError(t, os.MkdirAll(workdir, 0o755), "mkdir docker dir")
+	requireNoError(t, os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644), "write Dockerfile")
+	requireNoError(t, os.WriteFile(filepath.Join(componentRoot, "VERSION"), []byte("1.0.0\n"), 0o644), "write module VERSION")
+	requireNoError(t, common.SaveProjectConfig(projectRoot, projectConfigWithSingleRegistry("erunpaas")), "save project config")
+	snapshot := true
+	requireNoError(t, common.SaveTenantConfig(common.TenantConfig{
+		Name:               "tenant-a",
+		ProjectRoot:        projectRoot,
+		DefaultEnvironment: common.DefaultEnvironment,
+	}), "save tenant config")
+	requireNoError(t, common.SaveEnvConfig("tenant-a", common.EnvConfig{
+		Name:              common.DefaultEnvironment,
+		RepoPath:          projectRoot,
+		KubernetesContext: "cluster-local",
+		Snapshot:          &snapshot,
+	}), "save env config")
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	checkedDeployment := false
+	cmd := newTestRootCmd(testRootDeps{
+		Store: common.ConfigStore{},
+		CheckKubernetesDeployment: func(req common.KubernetesDeploymentCheckParams) (bool, error) {
+			checkedDeployment = true
+			return true, nil
+		},
+		DeployHelmChart: func(req common.HelmDeployParams) error {
+			t.Fatalf("did not expect runtime deployment when no --snapshot flag is passed: %+v", req)
+			return nil
+		},
+		LaunchShell: func(req common.ShellLaunchParams) error {
+			t.Fatalf("did not expect remote shell launch during dry-run: %+v", req)
+			return nil
+		},
+	})
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"-v", "open", "tenant-a", common.DefaultEnvironment, "--dry-run"})
+
+	requireNoError(t, cmd.Execute(), "Execute failed")
+	if !checkedDeployment {
+		t.Fatal("expected deployment existence check to gate redeploy decision")
+	}
+
+	output := stderr.String()
+	for _, unwanted := range []string{
+		"docker build -t",
+		"docker buildx build",
+		"docker push ",
+		"helm upgrade --install",
+	} {
+		if strings.Contains(output, unwanted) {
+			t.Fatalf("did not expect %q in dry-run output without --snapshot, got %q", unwanted, output)
 		}
 	}
 }

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -40,7 +40,7 @@ type rootDependencies struct {
 	runInitForOpen            func(common.Context, common.OpenParams) error
 	push                      common.DockerPushFunc
 	resolveOpen               func(common.OpenParams) (common.OpenResult, error)
-	resolveRuntimeDeploySpec  func(common.OpenResult) (common.DeploySpec, error)
+	resolveRuntimeDeploySpec  func(common.OpenResult, bool) (common.DeploySpec, error)
 	activateMCP               MCPForwarder
 	activateAPI               APIForwarder
 	activateSSHD              SSHDActivator
@@ -76,8 +76,8 @@ func (d rootDependencies) resolveOpenResult(params common.OpenParams) (common.Op
 	return common.ResolveOpen(d.store, params)
 }
 
-func (d rootDependencies) resolveRuntimeDeploySpecForOpenTarget(target common.OpenResult) (common.DeploySpec, error) {
-	return resolveRuntimeDeploySpecForOpen(d.store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, currentBuildInfo(), target)
+func (d rootDependencies) resolveRuntimeDeploySpecForOpenTarget(target common.OpenResult, allowLocalBuilds bool) (common.DeploySpec, error) {
+	return resolveRuntimeDeploySpecForOpen(d.store, common.FindProjectRoot, common.ResolveDockerBuildContext, common.ResolveKubernetesDeployContext, time.Now, currentBuildInfo(), target, allowLocalBuilds)
 }
 
 func (d rootDependencies) runManagedDeployForOpen(ctx common.Context, target common.OpenResult) error {

--- a/erun-cli/cmd/root_runtime.go
+++ b/erun-cli/cmd/root_runtime.go
@@ -112,8 +112,8 @@ func newRunInit(store common.BootstrapStore, findProjectRoot common.ProjectFinde
 	}
 }
 
-func resolveRuntimeDeploySpecForOpen(store common.DeployStore, findProjectRoot common.ProjectFinderFunc, resolveDockerBuildContext common.BuildContextResolverFunc, resolveKubernetesDeployContext common.DeployContextResolverFunc, now common.NowFunc, buildInfo common.BuildInfo, target common.OpenResult) (common.DeploySpec, error) {
-	spec, err := common.ResolveOpenRuntimeDeploySpec(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target)
+func resolveRuntimeDeploySpecForOpen(store common.DeployStore, findProjectRoot common.ProjectFinderFunc, resolveDockerBuildContext common.BuildContextResolverFunc, resolveKubernetesDeployContext common.DeployContextResolverFunc, now common.NowFunc, buildInfo common.BuildInfo, target common.OpenResult, allowLocalBuilds bool) (common.DeploySpec, error) {
+	spec, err := common.ResolveOpenRuntimeDeploySpec(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target, allowLocalBuilds)
 	if err != nil {
 		return common.DeploySpec{}, err
 	}

--- a/erun-cli/cmd/root_test.go
+++ b/erun-cli/cmd/root_test.go
@@ -50,6 +50,7 @@ func TestResolveRuntimeDeploySpecForOpenFallsBackToCurrentBuildVersionForRemoteR
 				Remote:            true,
 			},
 		},
+		false,
 	)
 	if err != nil {
 		t.Fatalf("resolveRuntimeDeploySpecForOpen failed: %v", err)

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -295,7 +295,7 @@ type testRootCmdParts struct {
 	now                            common.NowFunc
 	openDeployHelmChart            common.HelmChartDeployerFunc
 	resolveOpen                    func(common.OpenParams) (common.OpenResult, error)
-	resolveRuntimeDeploySpec       func(common.OpenResult) (common.DeploySpec, error)
+	resolveRuntimeDeploySpec       func(common.OpenResult, bool) (common.DeploySpec, error)
 	activateMCP                    MCPForwarder
 	activateAPI                    APIForwarder
 	activateSSHD                   SSHDActivator
@@ -335,8 +335,8 @@ func newTestRootCmd(deps testRootDeps) *cobra.Command {
 	resolveOpen := func(params common.OpenParams) (common.OpenResult, error) {
 		return common.ResolveOpen(store, params)
 	}
-	resolveRuntimeDeploySpec := func(target common.OpenResult) (common.DeploySpec, error) {
-		return resolveRuntimeDeploySpecForOpen(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, currentBuildInfo(), target)
+	resolveRuntimeDeploySpec := func(target common.OpenResult, allowLocalBuilds bool) (common.DeploySpec, error) {
+		return resolveRuntimeDeploySpecForOpen(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, currentBuildInfo(), target, allowLocalBuilds)
 	}
 	activateMCP := testMCPForwarderOrDefault(deps.ForwardMCP)
 	activateAPI := testAPIForwarderOrDefault(deps.ForwardAPI)

--- a/erun-cli/cmd/sshd.go
+++ b/erun-cli/cmd/sshd.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newSSHDCmd(prepareContext func(common.Context) common.Context, resolveOpen func(common.OpenParams) (common.OpenResult, error), saveEnvConfig func(string, common.EnvConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, findProjectRoot common.ProjectFinderFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, runRemoteCommand common.RemoteCommandRunnerFunc, writeLocalConfig SSHDLocalConfigWriter) *cobra.Command {
+func newSSHDCmd(prepareContext func(common.Context) common.Context, resolveOpen func(common.OpenParams) (common.OpenResult, error), saveEnvConfig func(string, common.EnvConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, findProjectRoot common.ProjectFinderFunc, resolveRuntimeDeploySpec func(common.OpenResult, bool) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, runRemoteCommand common.RemoteCommandRunnerFunc, writeLocalConfig SSHDLocalConfigWriter) *cobra.Command {
 	var publicKeyPath string
 	var localPort int
 	target := common.OpenParams{}
@@ -43,7 +43,7 @@ func newSSHDCmd(prepareContext func(common.Context) common.Context, resolveOpen 
 	return newCommandGroup("sshd", "Remote SSH utilities", initCmd)
 }
 
-func runSSHDInitCommand(ctx common.Context, result common.OpenResult, publicKeyPath string, localPort int, saveEnvConfig func(string, common.EnvConfig) error, findProjectRoot common.ProjectFinderFunc, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, runRemoteCommand common.RemoteCommandRunnerFunc, writeLocalConfig SSHDLocalConfigWriter) error {
+func runSSHDInitCommand(ctx common.Context, result common.OpenResult, publicKeyPath string, localPort int, saveEnvConfig func(string, common.EnvConfig) error, findProjectRoot common.ProjectFinderFunc, resolveRuntimeDeploySpec func(common.OpenResult, bool) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, runRemoteCommand common.RemoteCommandRunnerFunc, writeLocalConfig SSHDLocalConfigWriter) error {
 	if err := validateSSHDInitDependencies(result, saveEnvConfig, resolveRuntimeDeploySpec, deployHelmChart); err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func runSSHDInitCommand(ctx common.Context, result common.OpenResult, publicKeyP
 	return writeSSHDInitSummary(ctx, result, localConfig)
 }
 
-func validateSSHDInitDependencies(result common.OpenResult, saveEnvConfig func(string, common.EnvConfig) error, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) error {
+func validateSSHDInitDependencies(result common.OpenResult, saveEnvConfig func(string, common.EnvConfig) error, resolveRuntimeDeploySpec func(common.OpenResult, bool) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) error {
 	if err := common.ValidateSSHDTarget(result); err != nil {
 		return err
 	}
@@ -130,8 +130,8 @@ func saveSSHDEnvConfig(ctx common.Context, result common.OpenResult, updatedEnv 
 	return saveEnvConfig(result.Tenant, updatedEnv)
 }
 
-func deploySSHDConfig(ctx common.Context, result common.OpenResult, resolveRuntimeDeploySpec func(common.OpenResult) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) error {
-	spec, err := resolveRuntimeDeploySpec(result)
+func deploySSHDConfig(ctx common.Context, result common.OpenResult, resolveRuntimeDeploySpec func(common.OpenResult, bool) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc) error {
+	spec, err := resolveRuntimeDeploySpec(result, false)
 	if err != nil {
 		return err
 	}

--- a/erun-cli/cmd/sshd_test.go
+++ b/erun-cli/cmd/sshd_test.go
@@ -116,7 +116,7 @@ func TestRunSSHDInitCommandPersistsConfigAndDeploysRuntime(t *testing.T) {
 			return nil
 		},
 		func() (string, string, error) { return "tenant-a", t.TempDir(), nil },
-		func(target common.OpenResult) (common.DeploySpec, error) {
+		func(target common.OpenResult, _ bool) (common.DeploySpec, error) {
 			return common.DeploySpec{
 				Target: target,
 				Deploy: common.HelmDeploySpec{
@@ -234,7 +234,7 @@ func TestRunSSHDInitCommandUsesResolvedEnvironmentLocalPortByDefault(t *testing.
 			return nil
 		},
 		nil,
-		func(target common.OpenResult) (common.DeploySpec, error) {
+		func(target common.OpenResult, _ bool) (common.DeploySpec, error) {
 			return common.DeploySpec{
 				Target: target,
 				Deploy: common.HelmDeploySpec{

--- a/erun-common/default_devops_chart.go
+++ b/erun-common/default_devops_chart.go
@@ -85,12 +85,11 @@ func renderDefaultDevopsChartTemplate(assetPath, moduleName, imageName string, d
 	return []byte(content)
 }
 
-func resolveOpenRuntimeDeploySpec(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult) (DeploySpec, error) {
+func resolveOpenRuntimeDeploySpec(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, allowLocalBuilds bool) (DeploySpec, error) {
 	if target.RemoteRepo() {
 		return resolveDefaultDevopsDeploySpecWithImage(target, DevopsComponentName)
 	}
 
-	allowLocalBuilds := deployTargetSnapshotEnabled(target, nil)
 	for _, componentName := range openRuntimeComponentNames(target.Tenant) {
 		spec, err := resolveDeploySpecForOpenResult(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target, componentName, "", allowLocalBuilds)
 		if err == nil {

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -278,6 +278,10 @@ func resolveDeploySpecForContext(store DeployStore, findProjectRoot ProjectFinde
 		}
 	}
 
+	if strings.TrimSpace(versionOverride) == "" {
+		versionOverride = strings.TrimSpace(target.EnvConfig.RuntimeVersion)
+	}
+
 	deployInput, err := newHelmDeploySpec(target, deployContext, versionOverride)
 	if err != nil {
 		return DeploySpec{}, err
@@ -287,11 +291,13 @@ func resolveDeploySpecForContext(store DeployStore, findProjectRoot ProjectFinde
 		return DeploySpec{}, err
 	}
 
-	dependencyBuilds, err := resolveAdditionalDockerBuildsForDeploy(store, findProjectRoot, resolveDockerBuildContext, now, target.RepoPath, target.Environment, deployContext.ChartPath, deployInput.Version, builds)
-	if err != nil {
-		return DeploySpec{}, err
+	if allowLocalBuilds {
+		dependencyBuilds, err := resolveAdditionalDockerBuildsForDeploy(store, findProjectRoot, resolveDockerBuildContext, now, target.RepoPath, target.Environment, deployContext.ChartPath, deployInput.Version, builds)
+		if err != nil {
+			return DeploySpec{}, err
+		}
+		builds = append(builds, dependencyBuilds...)
 	}
-	builds = append(builds, dependencyBuilds...)
 	builds = configureDockerBuildsForDeploy(builds)
 
 	return DeploySpec{
@@ -386,9 +392,9 @@ func applyDeployKubernetesContext(store DeployStore, target OpenResult) OpenResu
 	return target
 }
 
-func ResolveOpenRuntimeDeploySpec(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult) (DeploySpec, error) {
+func ResolveOpenRuntimeDeploySpec(store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, allowLocalBuilds bool) (DeploySpec, error) {
 	store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now = normalizeDeployDependencies(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now)
-	return resolveOpenRuntimeDeploySpec(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target)
+	return resolveOpenRuntimeDeploySpec(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target, allowLocalBuilds)
 }
 
 type BuildDeployStore interface {

--- a/erun-common/deploy_test.go
+++ b/erun-common/deploy_test.go
@@ -660,7 +660,7 @@ func TestResolveOpenRuntimeDeploySpecUsesTenantSpecificComponentBeforeSharedDefa
 		Environment: DefaultEnvironment,
 		RepoPath:    projectRoot,
 		EnvConfig:   EnvConfig{KubernetesContext: "cluster-local"},
-	})
+	}, false)
 	if err != nil {
 		t.Fatalf("ResolveOpenRuntimeDeploySpec failed: %v", err)
 	}
@@ -675,7 +675,7 @@ func TestResolveOpenRuntimeDeploySpecUsesTenantSpecificComponentBeforeSharedDefa
 	}
 }
 
-func TestResolveOpenRuntimeDeploySpecSkipsLocalBuildsWhenSnapshotDisabled(t *testing.T) {
+func TestResolveOpenRuntimeDeploySpecSkipsLocalBuildsWhenAllowLocalBuildsFalse(t *testing.T) {
 	projectRoot := t.TempDir()
 	createComponentHelmChartFixture(t, projectRoot, "frs-devops")
 	workdir := filepath.Join(projectRoot, "frs-devops", "docker", "frs-devops")
@@ -692,16 +692,14 @@ func TestResolveOpenRuntimeDeploySpecSkipsLocalBuildsWhenSnapshotDisabled(t *tes
 		t.Fatalf("save project config: %v", err)
 	}
 
-	snapshot := false
 	spec, err := ResolveOpenRuntimeDeploySpec(ConfigStore{}, FindProjectRoot, ResolveDockerBuildContext, ResolveKubernetesDeployContext, nil, OpenResult{
 		Tenant:      "frs",
 		Environment: DefaultEnvironment,
 		RepoPath:    projectRoot,
 		EnvConfig: EnvConfig{
 			KubernetesContext: "cluster-local",
-			Snapshot:          &snapshot,
 		},
-	})
+	}, false)
 	if err != nil {
 		t.Fatalf("ResolveOpenRuntimeDeploySpec failed: %v", err)
 	}
@@ -713,7 +711,7 @@ func TestResolveOpenRuntimeDeploySpecSkipsLocalBuildsWhenSnapshotDisabled(t *tes
 	}
 }
 
-func TestResolveOpenRuntimeDeploySpecIgnoresTenantSnapshotSetting(t *testing.T) {
+func TestResolveOpenRuntimeDeploySpecIgnoresPersistedSnapshotFlagWhenAllowLocalBuildsFalse(t *testing.T) {
 	projectRoot := t.TempDir()
 	createComponentHelmChartFixture(t, projectRoot, "frs-devops")
 	workdir := filepath.Join(projectRoot, "frs-devops", "docker", "frs-devops")
@@ -730,25 +728,56 @@ func TestResolveOpenRuntimeDeploySpecIgnoresTenantSnapshotSetting(t *testing.T) 
 		t.Fatalf("save project config: %v", err)
 	}
 
-	tenantSnapshot := false
 	envSnapshot := true
 	spec, err := ResolveOpenRuntimeDeploySpec(ConfigStore{}, FindProjectRoot, ResolveDockerBuildContext, ResolveKubernetesDeployContext, nil, OpenResult{
 		Tenant:      "frs",
 		Environment: DefaultEnvironment,
 		RepoPath:    projectRoot,
-		TenantConfig: TenantConfig{
-			Snapshot: &tenantSnapshot,
-		},
 		EnvConfig: EnvConfig{
 			KubernetesContext: "cluster-local",
 			Snapshot:          &envSnapshot,
 		},
-	})
+	}, false)
+	if err != nil {
+		t.Fatalf("ResolveOpenRuntimeDeploySpec failed: %v", err)
+	}
+	if len(spec.Builds) != 0 {
+		t.Fatalf("expected no builds when allowLocalBuilds=false even with persisted snapshot=true, got %+v", spec.Builds)
+	}
+}
+
+func TestResolveOpenRuntimeDeploySpecBuildsLocalImageWhenAllowLocalBuildsTrue(t *testing.T) {
+	projectRoot := t.TempDir()
+	createComponentHelmChartFixture(t, projectRoot, "frs-devops")
+	workdir := filepath.Join(projectRoot, "frs-devops", "docker", "frs-devops")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("mkdir docker dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, "frs-devops", "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+		t.Fatalf("write module VERSION: %v", err)
+	}
+	if err := SaveProjectConfig(projectRoot, ProjectConfig{ContainerRegistry: "erunpaas"}); err != nil {
+		t.Fatalf("save project config: %v", err)
+	}
+
+	envSnapshot := false
+	spec, err := ResolveOpenRuntimeDeploySpec(ConfigStore{}, FindProjectRoot, ResolveDockerBuildContext, ResolveKubernetesDeployContext, nil, OpenResult{
+		Tenant:      "frs",
+		Environment: DefaultEnvironment,
+		RepoPath:    projectRoot,
+		EnvConfig: EnvConfig{
+			KubernetesContext: "cluster-local",
+			Snapshot:          &envSnapshot,
+		},
+	}, true)
 	if err != nil {
 		t.Fatalf("ResolveOpenRuntimeDeploySpec failed: %v", err)
 	}
 	if len(spec.Builds) == 0 {
-		t.Fatalf("expected tenant snapshot setting to be ignored, got %+v", spec.Builds)
+		t.Fatalf("expected local builds when allowLocalBuilds=true, got %+v", spec.Builds)
 	}
 }
 
@@ -760,7 +789,7 @@ func TestResolveOpenRuntimeDeploySpecFallsBackToEmbeddedDefaultChart(t *testing.
 		Environment: "dev",
 		RepoPath:    projectRoot,
 		EnvConfig:   EnvConfig{KubernetesContext: "cluster-dev"},
-	})
+	}, false)
 	if err != nil {
 		t.Fatalf("ResolveOpenRuntimeDeploySpec failed: %v", err)
 	}
@@ -830,7 +859,7 @@ func TestResolveOpenRuntimeDeploySpecUsesRemoteEnvRuntimeVersionForEmbeddedChart
 			Remote:            true,
 			RuntimeVersion:    "1.0.31",
 		},
-	})
+	}, false)
 	if err != nil {
 		t.Fatalf("ResolveOpenRuntimeDeploySpec failed: %v", err)
 	}
@@ -1385,6 +1414,192 @@ func TestResolveDeploySpecForContextSkipsChartImageWithUnresolvedPrintfVerb(t *t
 	if strings.Contains(build.Image.Tag, "%") {
 		t.Fatalf("build tag %q contains unresolved printf verb", build.Image.Tag)
 	}
+}
+
+func TestResolveDeploySpecForContextUsesPersistedSnapshotRuntimeVersionWhenSnapshotsDisabled(t *testing.T) {
+	projectRoot := t.TempDir()
+	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
+
+	const persistedVersion = "1.0.51-snapshot-20260506043656"
+
+	spec, err := resolveDeploySpecForContext(
+		ConfigStore{},
+		nil,
+		nil,
+		nil,
+		nil,
+		OpenResult{
+			Tenant:      "tenant-a",
+			Environment: DefaultEnvironment,
+			RepoPath:    projectRoot,
+			EnvConfig: EnvConfig{
+				Name:              DefaultEnvironment,
+				RepoPath:          projectRoot,
+				KubernetesContext: "erun",
+				RuntimeVersion:    persistedVersion,
+			},
+		},
+		KubernetesDeployContext{
+			ComponentName: "erun-devops",
+			ChartPath:     chartPath,
+		},
+		"",
+		false,
+		nil,
+	)
+	requireNoError(t, err, "resolveDeploySpecForContext failed")
+	requireEqual(t, spec.Deploy.Version, persistedVersion, "deploy version should fall back to persisted RuntimeVersion")
+	requireEqual(t, len(spec.Builds), 0, "snapshot disabled must not produce builds")
+}
+
+func TestResolveDeploySpecForContextUsesPersistedReleasedRuntimeVersionWhenSnapshotsDisabled(t *testing.T) {
+	projectRoot := t.TempDir()
+	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
+
+	const persistedVersion = "1.0.50"
+
+	spec, err := resolveDeploySpecForContext(
+		ConfigStore{},
+		nil,
+		nil,
+		nil,
+		nil,
+		OpenResult{
+			Tenant:      "tenant-a",
+			Environment: DefaultEnvironment,
+			RepoPath:    projectRoot,
+			EnvConfig: EnvConfig{
+				Name:              DefaultEnvironment,
+				RepoPath:          projectRoot,
+				KubernetesContext: "erun",
+				RuntimeVersion:    persistedVersion,
+			},
+		},
+		KubernetesDeployContext{
+			ComponentName: "erun-devops",
+			ChartPath:     chartPath,
+		},
+		"",
+		false,
+		nil,
+	)
+	requireNoError(t, err, "resolveDeploySpecForContext failed")
+	requireEqual(t, spec.Deploy.Version, persistedVersion, "deploy version should fall back to persisted RuntimeVersion")
+}
+
+func TestResolveDeploySpecForContextLeavesDeployVersionEmptyWithoutPersistedRuntimeVersion(t *testing.T) {
+	projectRoot := t.TempDir()
+	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
+
+	spec, err := resolveDeploySpecForContext(
+		ConfigStore{},
+		nil,
+		nil,
+		nil,
+		nil,
+		OpenResult{
+			Tenant:      "tenant-a",
+			Environment: DefaultEnvironment,
+			RepoPath:    projectRoot,
+			EnvConfig: EnvConfig{
+				Name:              DefaultEnvironment,
+				RepoPath:          projectRoot,
+				KubernetesContext: "erun",
+			},
+		},
+		KubernetesDeployContext{
+			ComponentName: "erun-devops",
+			ChartPath:     chartPath,
+		},
+		"",
+		false,
+		nil,
+	)
+	requireNoError(t, err, "resolveDeploySpecForContext failed")
+	requireEqual(t, spec.Deploy.Version, "", "deploy version must remain empty so chart default applies")
+}
+
+func TestResolveDeploySpecForContextSnapshotBuildVersionWinsOverPersistedRuntimeVersion(t *testing.T) {
+	projectRoot := t.TempDir()
+	componentRoot := filepath.Join(projectRoot, "tenant-a-devops")
+	chartPath := createComponentHelmChartFixture(t, projectRoot, "tenant-a-devops")
+
+	runtimeWorkdir := filepath.Join(componentRoot, "docker", "tenant-a-devops")
+	writeDockerBuildFixture(t, runtimeWorkdir)
+	writeVersionFileForTest(t, filepath.Join(componentRoot, "VERSION"), "1.0.0")
+
+	projectConfig := ProjectConfig{}
+	projectConfig.SetContainerRegistryForEnvironment(DefaultEnvironment, "erunpaas")
+	requireNoError(t, SaveProjectConfig(projectRoot, projectConfig), "save project config")
+
+	spec, err := resolveDeploySpecForContext(
+		ConfigStore{},
+		func() (string, string, error) { return "tenant-a", projectRoot, nil },
+		func() (DockerBuildContext, error) {
+			return DockerBuildContext{
+				Dir:            runtimeWorkdir,
+				DockerfilePath: filepath.Join(runtimeWorkdir, "Dockerfile"),
+			}, nil
+		},
+		nil,
+		func() time.Time { return time.Date(2026, time.April, 21, 18, 24, 44, 0, time.UTC) },
+		OpenResult{
+			Tenant:      "tenant-a",
+			Environment: DefaultEnvironment,
+			RepoPath:    projectRoot,
+			TenantConfig: TenantConfig{Name: "tenant-a", ProjectRoot: projectRoot},
+			EnvConfig: EnvConfig{
+				Name:              DefaultEnvironment,
+				RepoPath:          projectRoot,
+				KubernetesContext: "erun",
+				RuntimeVersion:    "1.0.50",
+			},
+		},
+		KubernetesDeployContext{
+			Dir:           runtimeWorkdir,
+			ComponentName: "tenant-a-devops",
+			ChartPath:     chartPath,
+		},
+		"",
+		true,
+		nil,
+	)
+	requireNoError(t, err, "resolveDeploySpecForContext failed")
+	requireCondition(t, spec.Deploy.Version != "1.0.50", "build-derived version must win over persisted RuntimeVersion, got %q", spec.Deploy.Version)
+	requireCondition(t, strings.Contains(spec.Deploy.Version, "-snapshot-"), "expected snapshot build version, got %q", spec.Deploy.Version)
+}
+
+func TestResolveDeploySpecForContextExplicitVersionOverrideWinsOverPersistedRuntimeVersion(t *testing.T) {
+	projectRoot := t.TempDir()
+	chartPath := createHelmChartFixture(t, projectRoot, "erun-devops")
+
+	spec, err := resolveDeploySpecForContext(
+		ConfigStore{},
+		nil,
+		nil,
+		nil,
+		nil,
+		OpenResult{
+			Tenant:      "tenant-a",
+			Environment: DefaultEnvironment,
+			RepoPath:    projectRoot,
+			EnvConfig: EnvConfig{
+				Name:              DefaultEnvironment,
+				RepoPath:          projectRoot,
+				KubernetesContext: "erun",
+				RuntimeVersion:    "1.0.50",
+			},
+		},
+		KubernetesDeployContext{
+			ComponentName: "erun-devops",
+			ChartPath:     chartPath,
+		},
+		"9.9.9",
+		false,
+		nil,
+	)
+	requireNoError(t, err, "resolveDeploySpecForContext failed")
+	requireEqual(t, spec.Deploy.Version, "9.9.9", "explicit version override must win over persisted RuntimeVersion")
 }
 
 func writeRuntimeDeploymentTemplate(t *testing.T, templatesPath string) {


### PR DESCRIPTION
## Summary

- `erun open` no longer triggers a Docker build just because the persisted `EnvConfig.Snapshot` field is true. Build-on-open now requires the explicit `--snapshot` flag.
- Without `--snapshot`, the open flow deploys the persisted `RuntimeVersion` (or chart default) and only redeploys on settings drift or a missing Deployment. `erun deploy` keeps its existing snapshot-mode default for the in-shell rebuild workflow.
- Stops chart-discovered dependency builds (e.g. base-image `SkipIfExists` entries) from sneaking back in when `allowLocalBuilds=false` and surprising users with a redeploy.
- Drops the auto-infer in `persistOpenRuntimeVersion` that flipped `EnvConfig.Snapshot` based on the deployed version string; the field is purely user-controlled now.

## Test plan

- [x] `go test ./...` in `erun-common`
- [x] `go test ./...` in `erun-cli`
- [x] `go test ./...` in `erun-mcp` (modulo two pre-existing failures on `main` related to registry name `erunpaas` vs `ghcr.io/sophium`, unrelated)
- [x] Manual: `erun open erun local --dry-run` with persisted `Snapshot: true` shows no `docker buildx`, no `docker manifest inspect`, no helm-deploy trace.
- [ ] Manual: `erun open erun local --snapshot` still produces a fresh `*-snapshot-TIMESTAMP` build + deploy and persists the new tag.
- [ ] Manual: `erun deploy erun-devops` from inside an opened shell still respects `EnvConfig.Snapshot` for build behavior.

Closes #203