### PR TITLE
Match deployment env across all containers when deciding whether to redeploy

### DIFF
--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -1613,23 +1613,23 @@ func deploymentMatchesExpectedSettings(params KubernetesDeploymentCheckParams) (
 		return false, fmt.Errorf("failed to parse deployment %q: %w", params.Name, err)
 	}
 
-	for _, container := range deployment.Spec.Template.Spec.Containers {
-		if strings.TrimSpace(container.Name) != params.Name {
-			continue
-		}
-		return deploymentContainerMatchesExpectedSettings(params, container.Env, container.Resources.Limits), nil
-	}
-
-	return false, nil
-}
-
-func deploymentContainerMatchesExpectedSettings(params KubernetesDeploymentCheckParams, envs []deploymentEnvVar, limits RuntimePodResources) bool {
 	matches := expectedDeploymentMatches(params)
-	for _, env := range envs {
-		matches.apply(params, env.Name, env.Value)
+	var runtimeLimits RuntimePodResources
+	runtimeFound := false
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		for _, env := range container.Env {
+			matches.apply(params, env.Name, env.Value)
+		}
+		if strings.TrimSpace(container.Name) == params.Name {
+			runtimeLimits = container.Resources.Limits
+			runtimeFound = true
+		}
 	}
-	matches.runtimePod = matchesExpectedRuntimePod(limits, params.ExpectedRuntimePod)
-	return matches.ok()
+	if !runtimeFound {
+		return false, nil
+	}
+	matches.runtimePod = matchesExpectedRuntimePod(runtimeLimits, params.ExpectedRuntimePod)
+	return matches.ok(), nil
 }
 
 type deploymentExpectedMatches struct {

--- a/erun-common/deploy_test.go
+++ b/erun-common/deploy_test.go
@@ -1909,6 +1909,90 @@ exit 1
 	}
 }
 
+func TestCheckKubernetesDeploymentMatchesAcrossMultipleContainers(t *testing.T) {
+	kubectlDir := t.TempDir()
+	kubectlPath := filepath.Join(kubectlDir, "kubectl")
+	if err := os.WriteFile(kubectlPath, []byte(`#!/bin/sh
+if [ "$1" = "--context" ]; then shift 2; fi
+if [ "$1" = "--namespace" ]; then shift 2; fi
+if [ "$1" = "get" ] && [ "$2" = "deployment" ] && [ "$3" = "erun-devops" ] && [ "$4" = "-o" ] && [ "$5" = "name" ]; then
+  echo deployment/erun-devops
+  exit 0
+fi
+if [ "$1" = "get" ] && [ "$2" = "deployment" ] && [ "$3" = "erun-devops" ] && [ "$4" = "-o" ] && [ "$5" = "json" ]; then
+  cat <<'EOF'
+{"spec":{"template":{"spec":{"containers":[{"name":"erun-devops","env":[{"name":"ERUN_REPO_PATH","value":"/home/erun/git/erun"},{"name":"ERUN_SSHD_ENABLED","value":"false"},{"name":"ERUN_MCP_PORT","value":"17000"},{"name":"ERUN_SSHD_PORT","value":"17022"}]},{"name":"erun-mcp","env":[{"name":"ERUN_MCP_PORT","value":"17000"}]},{"name":"erun-backend-api","env":[{"name":"ERUN_API_PORT","value":"17033"}]}]}}}}
+EOF
+  exit 0
+fi
+echo "unexpected kubectl invocation: $@" >&2
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+	t.Setenv("PATH", kubectlDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	sshd := false
+	deployed, err := CheckKubernetesDeployment(KubernetesDeploymentCheckParams{
+		Name:              "erun-devops",
+		Namespace:         "erun-local",
+		KubernetesContext: "cluster-local",
+		ExpectedRepoPath:  "/home/erun/git/erun",
+		ExpectedSSHD:      &sshd,
+		ExpectedMCPPort:   17000,
+		ExpectedAPIPort:   17033,
+		ExpectedSSHPort:   17022,
+	})
+	if err != nil {
+		t.Fatalf("CheckKubernetesDeployment failed: %v", err)
+	}
+	if !deployed {
+		t.Fatalf("expected matcher to accept env vars spread across multiple containers")
+	}
+}
+
+func TestCheckKubernetesDeploymentReturnsFalseWhenAPIPortMissingAcrossAllContainers(t *testing.T) {
+	kubectlDir := t.TempDir()
+	kubectlPath := filepath.Join(kubectlDir, "kubectl")
+	if err := os.WriteFile(kubectlPath, []byte(`#!/bin/sh
+if [ "$1" = "--context" ]; then shift 2; fi
+if [ "$1" = "--namespace" ]; then shift 2; fi
+if [ "$1" = "get" ] && [ "$2" = "deployment" ] && [ "$3" = "erun-devops" ] && [ "$4" = "-o" ] && [ "$5" = "name" ]; then
+  echo deployment/erun-devops
+  exit 0
+fi
+if [ "$1" = "get" ] && [ "$2" = "deployment" ] && [ "$3" = "erun-devops" ] && [ "$4" = "-o" ] && [ "$5" = "json" ]; then
+  cat <<'EOF'
+{"spec":{"template":{"spec":{"containers":[{"name":"erun-devops","env":[{"name":"ERUN_REPO_PATH","value":"/home/erun/git/erun"},{"name":"ERUN_SSHD_ENABLED","value":"false"},{"name":"ERUN_MCP_PORT","value":"17000"},{"name":"ERUN_SSHD_PORT","value":"17022"}]},{"name":"erun-mcp","env":[{"name":"ERUN_MCP_PORT","value":"17000"}]}]}}}}
+EOF
+  exit 0
+fi
+echo "unexpected kubectl invocation: $@" >&2
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+	t.Setenv("PATH", kubectlDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	sshd := false
+	deployed, err := CheckKubernetesDeployment(KubernetesDeploymentCheckParams{
+		Name:              "erun-devops",
+		Namespace:         "erun-local",
+		KubernetesContext: "cluster-local",
+		ExpectedRepoPath:  "/home/erun/git/erun",
+		ExpectedSSHD:      &sshd,
+		ExpectedMCPPort:   17000,
+		ExpectedAPIPort:   17033,
+		ExpectedSSHPort:   17022,
+	})
+	if err != nil {
+		t.Fatalf("CheckKubernetesDeployment failed: %v", err)
+	}
+	if deployed {
+		t.Fatalf("expected missing API port across all containers to require redeploy")
+	}
+}
+
 func createHelmChartFixture(t *testing.T, projectRoot, componentName string) string {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- `deploymentMatchesExpectedSettings` only inspected the runtime container, so `ERUN_API_PORT` (emitted on the `erun-backend-api` sidecar since `f7ebc68`) was never observed; `shouldDeployRuntime` therefore reported settings drift on every `erun open` and helm reran every time.
- Aggregate env vars across all containers in the deployment; keep resource-limit checks scoped to the runtime container by name.
- Add regression tests covering env spread across multiple containers and a missing API port across all containers.

## Test plan
- [x] `cd erun-common && go test ./...`
- [x] `cd erun-cli && go test ./...`
- [x] `erun open erun local --dry-run` against an existing deployment skips the namespace-ensure and helm-upgrade steps and goes straight to `kubectl wait` + `kubectl exec`

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)