### PR TITLE
Open multiple terminal tabs per environment with Claude auto-resume

### DIFF
--- a/erun-devops/docker/erun-devops/Dockerfile
+++ b/erun-devops/docker/erun-devops/Dockerfile
@@ -96,6 +96,7 @@ RUN apt-get update && \
     /tmp/aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli && \
     npm install -g "@openai/codex@${CODEX_VERSION}" "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" && \
     mv /usr/local/bin/codex /usr/local/bin/codex-real && \
+    mv /usr/local/bin/claude /usr/local/bin/claude-real && \
     npm cache clean --force && \
     mkdir -p /usr/local/lib/docker/cli-plugins /usr/local/libexec/docker/cli-plugins && \
     curl -fsSL -o /usr/local/lib/docker/cli-plugins/docker-buildx "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${arch}" && \
@@ -115,6 +116,7 @@ COPY --from=builder --chmod=0755 /out/emcp /usr/local/bin/emcp
 COPY --from=builder --chmod=0755 /out/eapi /usr/local/bin/eapi
 COPY --chmod=0755 erun-devops/docker/erun-devops/entrypoint.sh /usr/local/bin/erun-devops-entrypoint
 COPY --chmod=0755 erun-devops/docker/erun-devops/codex-wrapper.sh /usr/local/bin/codex
+COPY --chmod=0755 erun-devops/docker/erun-devops/claude-wrapper.sh /usr/local/bin/claude
 COPY --chmod=0644 erun-devops/docker/erun-devops/bash_prompt.sh /etc/erun/bash_prompt.sh
 
 RUN /usr/local/bin/erun completion bash > /etc/bash_completion.d/erun && \

--- a/erun-devops/docker/erun-devops/claude-wrapper.sh
+++ b/erun-devops/docker/erun-devops/claude-wrapper.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -eu
+
+# Resume the most recent conversation by default so a fresh terminal in a
+# fresh pod picks up where the previous pod left off. Subcommands and
+# explicit-mode flags bypass the resume injection.
+for arg in "$@"; do
+    case "${arg}" in
+        --continue|-c|--resume|-r|--print|-p|--new|--no-resume| \
+        --help|-h|--version|-v| \
+        mcp|update|migrate-installer|setup-token|config|doctor)
+            exec claude-real "$@"
+            ;;
+    esac
+done
+
+project_key="$(pwd | tr / -)"
+if [ -d "${HOME}/.claude/projects/${project_key}" ]; then
+    exec claude-real --continue "$@"
+fi
+exec claude-real "$@"

--- a/erun-devops/docker/erun-devops/claude-wrapper_test.sh
+++ b/erun-devops/docker/erun-devops/claude-wrapper_test.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+# Tests for claude-wrapper.sh. Stubs claude-real, exercises arg combinations,
+# and asserts the recorded invocation matches expectations.
+
+set -eu
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+wrapper="${script_dir}/claude-wrapper.sh"
+if [ ! -x "${wrapper}" ]; then
+    chmod +x "${wrapper}"
+fi
+
+work_root="$(mktemp -d 2>/dev/null || mktemp -d -t claude-wrapper-test)"
+trap 'rm -rf "${work_root}"' EXIT INT TERM
+
+stub_dir="${work_root}/bin"
+fake_home="${work_root}/home"
+fake_cwd="${work_root}/cwd"
+record_file="${work_root}/record"
+mkdir -p "${stub_dir}" "${fake_home}" "${fake_cwd}"
+
+cat >"${stub_dir}/claude-real" <<EOF
+#!/bin/sh
+{
+    printf '%s' "claude-real"
+    for a in "\$@"; do
+        printf ' [%s]' "\${a}"
+    done
+    printf '\n'
+} >>"${record_file}"
+EOF
+chmod 0755 "${stub_dir}/claude-real"
+
+failures=0
+
+run_case() {
+    label="$1"
+    expected="$2"
+    shift 2
+    : >"${record_file}"
+    (
+        cd "${fake_cwd}"
+        HOME="${fake_home}" PATH="${stub_dir}:${PATH}" "${wrapper}" "$@"
+    )
+    actual="$(cat "${record_file}")"
+    if [ "${actual}" = "${expected}" ]; then
+        printf 'ok  %s\n' "${label}"
+    else
+        printf 'FAIL %s\n  expected: %s\n  actual:   %s\n' "${label}" "${expected}" "${actual}"
+        failures=$((failures + 1))
+    fi
+}
+
+# Project directory absent → fresh session.
+rm -rf "${fake_home}/.claude/projects"
+run_case "no project dir runs fresh" "claude-real"
+
+# Project directory absent → flags still pass through.
+run_case "fresh session with positional prompt" "claude-real [hello]" hello
+
+# Project directory present → resume injected.
+project_key="$(printf '%s' "${fake_cwd}" | tr / -)"
+mkdir -p "${fake_home}/.claude/projects/${project_key}"
+run_case "project dir triggers resume" "claude-real [--continue]"
+
+# Resume with extra args.
+run_case "resume preserves user args" "claude-real [--continue] [hello]" hello
+
+# Bypass flags must not get --continue.
+for flag in --continue -c --resume -r --print -p --new --no-resume \
+            --help -h --version -v; do
+    run_case "bypass flag ${flag}" "claude-real [${flag}]" "${flag}"
+done
+
+# Bypass flag with extra args preserves order.
+run_case "bypass flag with arg" "claude-real [--resume] [abc123]" --resume abc123
+
+# Subcommands bypass.
+for sub in mcp update migrate-installer setup-token config doctor; do
+    run_case "bypass subcommand ${sub}" "claude-real [${sub}]" "${sub}"
+done
+
+# Subcommand with arg.
+run_case "config set passes through" "claude-real [config] [set] [theme] [dark]" config set theme dark
+
+if [ "${failures}" -eq 0 ]; then
+    printf '\nall tests passed\n'
+    exit 0
+fi
+printf '\n%d test(s) failed\n' "${failures}"
+exit 1

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -62,7 +62,6 @@ type App struct {
 	deps erunUIDeps
 
 	mu             sync.Mutex
-	current        *managedTerminal
 	nextSerial     int
 	sessions       map[string]*managedTerminal
 	idleStops      map[string]struct{}

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -695,7 +696,7 @@ func TestStartInitSessionUsesSeparateSessionKey(t *testing.T) {
 	if _, err := app.StartInitSession(uiSelection{Tenant: "erun", Environment: "remote"}, 80, 24); err != nil {
 		t.Fatalf("StartInitSession failed: %v", err)
 	}
-	if _, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "remote"}, 80, 24); err != nil {
+	if _, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "remote"}, 0, 80, 24); err != nil {
 		t.Fatalf("StartSession failed: %v", err)
 	}
 	if startCalls != 2 {
@@ -953,7 +954,7 @@ func TestStartDeploySessionUsesSeparateSessionKey(t *testing.T) {
 	if _, err := app.StartDeploySession(uiSelection{Tenant: "erun", Environment: "remote", Version: "1.0.19"}, 80, 24); err != nil {
 		t.Fatalf("StartDeploySession failed: %v", err)
 	}
-	if _, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "remote"}, 80, 24); err != nil {
+	if _, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "remote"}, 0, 80, 24); err != nil {
 		t.Fatalf("StartSession failed: %v", err)
 	}
 	if startCalls != 3 {
@@ -1866,7 +1867,7 @@ func TestStartSessionLeavesCloudContextStartupToErunCommand(t *testing.T) {
 	})
 	defer app.shutdown(context.Background())
 
-	if _, err := app.StartSession(uiSelection{Tenant: "frs", Environment: "prod"}, 80, 24); err != nil {
+	if _, err := app.StartSession(uiSelection{Tenant: "frs", Environment: "prod"}, 0, 80, 24); err != nil {
 		t.Fatalf("StartSession failed: %v", err)
 	}
 
@@ -1975,6 +1976,115 @@ func TestLocalPortStatusReportsAvailability(t *testing.T) {
 	}
 }
 
+func TestStartSessionAllocatesIndependentSlots(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {
+				Name:               "erun",
+				ProjectRoot:        projectRoot,
+				DefaultEnvironment: "local",
+			},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/local": {
+				Name:              "local",
+				RepoPath:          projectRoot,
+				KubernetesContext: "rancher-desktop",
+			},
+		},
+	}
+
+	startCalls := 0
+	app := NewApp(erunUIDeps{
+		store:           store,
+		findProjectRoot: func() (string, string, error) { return "", "", eruncommon.ErrNotInGitRepository },
+		resolveCLIPath:  func() string { return "/tmp/erun" },
+		startTerminal: func(startTerminalSessionParams) (terminalSession, error) {
+			startCalls++
+			return newStubTerminalSession(), nil
+		},
+	})
+	defer app.shutdown(context.Background())
+
+	first, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "local"}, 0, 80, 24)
+	if err != nil {
+		t.Fatalf("first StartSession failed: %v", err)
+	}
+	second, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "local"}, 1, 80, 24)
+	if err != nil {
+		t.Fatalf("second StartSession failed: %v", err)
+	}
+	reuse, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "local"}, 0, 80, 24)
+	if err != nil {
+		t.Fatalf("third StartSession failed: %v", err)
+	}
+
+	if startCalls != 2 {
+		t.Fatalf("start terminal called %d times, want 2", startCalls)
+	}
+	if first.SessionID == second.SessionID {
+		t.Fatalf("expected distinct session ids for different slots, got %d for both", first.SessionID)
+	}
+	if reuse.SessionID != first.SessionID {
+		t.Fatalf("expected slot 0 to reuse session %d, got %d", first.SessionID, reuse.SessionID)
+	}
+	if first.Slot != 0 || second.Slot != 1 {
+		t.Fatalf("unexpected slot values: first=%d second=%d", first.Slot, second.Slot)
+	}
+}
+
+func TestSendSessionInputRoutesPerSession(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", ProjectRoot: projectRoot, DefaultEnvironment: "local"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/local": {Name: "local", RepoPath: projectRoot, KubernetesContext: "rancher-desktop"},
+		},
+	}
+
+	var stubs []*stubTerminalSession
+	app := NewApp(erunUIDeps{
+		store:           store,
+		findProjectRoot: func() (string, string, error) { return "", "", eruncommon.ErrNotInGitRepository },
+		resolveCLIPath:  func() string { return "/tmp/erun" },
+		startTerminal: func(startTerminalSessionParams) (terminalSession, error) {
+			s := newStubTerminalSession()
+			stubs = append(stubs, s)
+			return s, nil
+		},
+	})
+	defer app.shutdown(context.Background())
+
+	first, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "local"}, 0, 80, 24)
+	if err != nil {
+		t.Fatalf("first StartSession failed: %v", err)
+	}
+	second, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "local"}, 1, 80, 24)
+	if err != nil {
+		t.Fatalf("second StartSession failed: %v", err)
+	}
+
+	if err := app.SendSessionInput(first.SessionID, "alpha"); err != nil {
+		t.Fatalf("SendSessionInput first failed: %v", err)
+	}
+	if err := app.SendSessionInput(second.SessionID, "beta"); err != nil {
+		t.Fatalf("SendSessionInput second failed: %v", err)
+	}
+
+	if len(stubs) != 2 {
+		t.Fatalf("expected two terminal stubs, got %d", len(stubs))
+	}
+	if got := stubs[0].WrittenString(); got != "alpha" {
+		t.Fatalf("slot 0 received %q, want %q", got, "alpha")
+	}
+	if got := stubs[1].WrittenString(); got != "beta" {
+		t.Fatalf("slot 1 received %q, want %q", got, "beta")
+	}
+}
+
 func TestStartSessionReusesExistingSessionForSelection(t *testing.T) {
 	projectRoot := t.TempDir()
 	store := stubUIStore{
@@ -2006,12 +2116,12 @@ func TestStartSessionReusesExistingSessionForSelection(t *testing.T) {
 	})
 	defer app.shutdown(context.Background())
 
-	first, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "local"}, 80, 24)
+	first, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "local"}, 0, 80, 24)
 	if err != nil {
 		t.Fatalf("first StartSession failed: %v", err)
 	}
 
-	second, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "local"}, 80, 24)
+	second, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "local"}, 0, 80, 24)
 	if err != nil {
 		t.Fatalf("second StartSession failed: %v", err)
 	}
@@ -2057,10 +2167,11 @@ func TestSendSessionInputRecordsCLIActivityForCurrentEnvironment(t *testing.T) {
 	})
 	defer app.shutdown(context.Background())
 
-	if _, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "local"}, 80, 24); err != nil {
+	started, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "local"}, 0, 80, 24)
+	if err != nil {
 		t.Fatalf("StartSession failed: %v", err)
 	}
-	if err := app.SendSessionInput("date\r"); err != nil {
+	if err := app.SendSessionInput(started.SessionID, "date\r"); err != nil {
 		t.Fatalf("SendSessionInput failed: %v", err)
 	}
 
@@ -2433,14 +2544,20 @@ func TestSavePastedImageCopiesIntoCurrentRuntime(t *testing.T) {
 	})
 	defer app.shutdown(context.Background())
 
+	selection := uiSelection{Tenant: "erun", Environment: "local"}
 	app.mu.Lock()
-	app.current = &managedTerminal{
+	app.nextSerial++
+	serial := app.nextSerial
+	managed := &managedTerminal{
 		session:   newStubTerminalSession(),
-		selection: uiSelection{Tenant: "erun", Environment: "local"},
+		selection: selection,
+		key:       openSessionKey(selection, 0),
+		serial:    serial,
 	}
+	app.sessions[managed.key] = managed
 	app.mu.Unlock()
 
-	result, err := app.SavePastedImage(pastedImagePayload{
+	result, err := app.SavePastedImage(serial, pastedImagePayload{
 		Data:     base64.StdEncoding.EncodeToString(imageData),
 		MIMEType: "image/png",
 		Name:     "screenshot.png",
@@ -2655,6 +2772,8 @@ func (s stubUIStore) ListEnvConfigs(tenant string) ([]eruncommon.EnvConfig, erro
 type stubTerminalSession struct {
 	closeCh chan struct{}
 	waitErr error
+	mu      sync.Mutex
+	written []byte
 }
 
 func newStubTerminalSession() *stubTerminalSession {
@@ -2667,7 +2786,16 @@ func (s *stubTerminalSession) Read([]byte) (int, error) {
 }
 
 func (s *stubTerminalSession) Write(buffer []byte) (int, error) {
+	s.mu.Lock()
+	s.written = append(s.written, buffer...)
+	s.mu.Unlock()
 	return len(buffer), nil
+}
+
+func (s *stubTerminalSession) WrittenString() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return string(s.written)
 }
 
 func (s *stubTerminalSession) Resize(int, int) error {

--- a/erun-ui/frontend/src/App.tsx
+++ b/erun-ui/frontend/src/App.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { CheckCircle2, ChevronDown, ChevronUp, Copy, LoaderCircle, Plus, Trash2, X } from 'lucide-react';
+import { CheckCircle2, ChevronDown, ChevronUp, Copy, LoaderCircle, Trash2 } from 'lucide-react';
 
 import { ERunUIController } from '@/app/ERunUIController';
 import { readError } from '@/app/errors';
 import { useControllerState } from '@/app/useControllerState';
-import { selectionKey } from '@/app/versionSuggestions';
+import { TerminalTabStrip } from '@/components/app/TerminalTabStrip';
 import { EnvironmentDialogView } from '@/components/app/EnvironmentDialogView';
 import { GlobalConfigDialogView } from '@/components/app/GlobalConfigDialogView';
 import { ManageDialogView } from '@/components/app/ManageDialogView';
@@ -145,72 +145,15 @@ function TerminalPane({
           'grid-cols-[minmax(360px,1fr)_10px_minmax(420px,var(--review-width))] max-[980px]:grid-cols-[minmax(260px,1fr)_10px_minmax(360px,min(var(--review-width),58vw))]',
       )}
     >
-      <div className="grid h-full min-h-0 min-w-0 grid-rows-[28px_minmax(0,1fr)] overflow-hidden">
-        <TerminalTabs controller={controller} state={state} />
-        <div className="relative h-full min-h-0 min-w-0 overflow-hidden">
+      <div className="grid h-full min-h-0 min-w-0 grid-rows-[32px_minmax(0,1fr)] overflow-hidden">
+        <TerminalTabStrip controller={controller} state={state} />
+        <div id="erun-terminal-pane" className="relative h-full min-h-0 min-w-0 overflow-hidden">
           <div ref={terminalRootRef} className="terminal h-full min-h-0 min-w-0 w-full box-border px-4 py-3.5" />
           <TerminalBusyOverlay message={state.terminalBusy ? state.terminalMessage : ''} />
         </div>
       </div>
       <div className={cn(reviewSplitterClassName, !state.reviewOpen && 'hidden')} role="separator" aria-orientation="vertical" aria-label="Resize diff panel" onMouseDown={(event) => controller.startReviewResize(event)} />
       <ReviewPanel controller={controller} state={state} reviewViewRef={reviewViewRef} reviewMainRef={reviewMainRef} diffListRef={diffListRef} />
-    </div>
-  );
-}
-
-function TerminalTabs({ controller, state }: { controller: ERunUIController; state: ReturnType<typeof useControllerState> }): React.ReactElement | null {
-  const selection = state.selected;
-  if (!selection) {
-    return <div className="border-b border-[oklch(0.18_0_0)] bg-[oklch(0.06_0_0)]" />;
-  }
-  const tabs = state.tabsByEnv[selectionKey(selection)] || [];
-  return (
-    <div className="flex h-7 items-stretch gap-1 border-b border-[oklch(0.18_0_0)] bg-[oklch(0.06_0_0)] px-2">
-      {tabs.map((tab, index) => {
-        const active = tab.sessionId === state.sessionId;
-        return (
-          <div
-            key={tab.sessionId}
-            className={cn(
-              'group flex items-center gap-1 rounded-t-sm border-x border-t px-2 text-[11px] leading-none transition-colors',
-              active
-                ? 'border-[oklch(0.32_0_0)] bg-[oklch(0.12_0_0)] text-[oklch(0.96_0_0)]'
-                : 'border-transparent text-[oklch(0.66_0_0)] hover:text-[oklch(0.92_0_0)]',
-            )}
-          >
-            <button
-              type="button"
-              className="bg-transparent p-0 text-inherit"
-              aria-pressed={active}
-              onClick={() => controller.selectTerminalTab(tab.sessionId)}
-            >
-              Terminal {index + 1}
-            </button>
-            {tabs.length > 1 && (
-              <button
-                type="button"
-                className="ml-0.5 flex size-3.5 items-center justify-center rounded text-[oklch(0.56_0_0)] hover:bg-[oklch(0.18_0_0)] hover:text-[oklch(0.96_0_0)]"
-                aria-label={`Close terminal ${index + 1}`}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  void controller.closeTerminalTab(tab.sessionId);
-                }}
-              >
-                <X className="size-3" aria-hidden="true" />
-              </button>
-            )}
-          </div>
-        );
-      })}
-      <button
-        type="button"
-        className="flex h-6 items-center gap-1 self-end rounded-t-sm px-1.5 text-[11px] leading-none text-[oklch(0.66_0_0)] hover:bg-[oklch(0.12_0_0)] hover:text-[oklch(0.96_0_0)]"
-        aria-label="Open new terminal"
-        onClick={() => { void controller.addTerminalTab(); }}
-      >
-        <Plus className="size-3.5" aria-hidden="true" />
-        <span className="sr-only">New terminal</span>
-      </button>
     </div>
   );
 }

--- a/erun-ui/frontend/src/App.tsx
+++ b/erun-ui/frontend/src/App.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { CheckCircle2, ChevronDown, ChevronUp, Copy, LoaderCircle, Trash2 } from 'lucide-react';
+import { CheckCircle2, ChevronDown, ChevronUp, Copy, LoaderCircle, Plus, Trash2, X } from 'lucide-react';
 
 import { ERunUIController } from '@/app/ERunUIController';
 import { readError } from '@/app/errors';
 import { useControllerState } from '@/app/useControllerState';
+import { selectionKey } from '@/app/versionSuggestions';
 import { EnvironmentDialogView } from '@/components/app/EnvironmentDialogView';
 import { GlobalConfigDialogView } from '@/components/app/GlobalConfigDialogView';
 import { ManageDialogView } from '@/components/app/ManageDialogView';
@@ -144,12 +145,72 @@ function TerminalPane({
           'grid-cols-[minmax(360px,1fr)_10px_minmax(420px,var(--review-width))] max-[980px]:grid-cols-[minmax(260px,1fr)_10px_minmax(360px,min(var(--review-width),58vw))]',
       )}
     >
-      <div className="relative h-full min-h-0 min-w-0 overflow-hidden">
-        <div ref={terminalRootRef} className="terminal h-full min-h-0 min-w-0 w-full box-border px-4 py-3.5" />
-        <TerminalBusyOverlay message={state.terminalBusy ? state.terminalMessage : ''} />
+      <div className="grid h-full min-h-0 min-w-0 grid-rows-[28px_minmax(0,1fr)] overflow-hidden">
+        <TerminalTabs controller={controller} state={state} />
+        <div className="relative h-full min-h-0 min-w-0 overflow-hidden">
+          <div ref={terminalRootRef} className="terminal h-full min-h-0 min-w-0 w-full box-border px-4 py-3.5" />
+          <TerminalBusyOverlay message={state.terminalBusy ? state.terminalMessage : ''} />
+        </div>
       </div>
       <div className={cn(reviewSplitterClassName, !state.reviewOpen && 'hidden')} role="separator" aria-orientation="vertical" aria-label="Resize diff panel" onMouseDown={(event) => controller.startReviewResize(event)} />
       <ReviewPanel controller={controller} state={state} reviewViewRef={reviewViewRef} reviewMainRef={reviewMainRef} diffListRef={diffListRef} />
+    </div>
+  );
+}
+
+function TerminalTabs({ controller, state }: { controller: ERunUIController; state: ReturnType<typeof useControllerState> }): React.ReactElement | null {
+  const selection = state.selected;
+  if (!selection) {
+    return <div className="border-b border-[oklch(0.18_0_0)] bg-[oklch(0.06_0_0)]" />;
+  }
+  const tabs = state.tabsByEnv[selectionKey(selection)] || [];
+  return (
+    <div className="flex h-7 items-stretch gap-1 border-b border-[oklch(0.18_0_0)] bg-[oklch(0.06_0_0)] px-2">
+      {tabs.map((tab, index) => {
+        const active = tab.sessionId === state.sessionId;
+        return (
+          <div
+            key={tab.sessionId}
+            className={cn(
+              'group flex items-center gap-1 rounded-t-sm border-x border-t px-2 text-[11px] leading-none transition-colors',
+              active
+                ? 'border-[oklch(0.32_0_0)] bg-[oklch(0.12_0_0)] text-[oklch(0.96_0_0)]'
+                : 'border-transparent text-[oklch(0.66_0_0)] hover:text-[oklch(0.92_0_0)]',
+            )}
+          >
+            <button
+              type="button"
+              className="bg-transparent p-0 text-inherit"
+              aria-pressed={active}
+              onClick={() => controller.selectTerminalTab(tab.sessionId)}
+            >
+              Terminal {index + 1}
+            </button>
+            {tabs.length > 1 && (
+              <button
+                type="button"
+                className="ml-0.5 flex size-3.5 items-center justify-center rounded text-[oklch(0.56_0_0)] hover:bg-[oklch(0.18_0_0)] hover:text-[oklch(0.96_0_0)]"
+                aria-label={`Close terminal ${index + 1}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  void controller.closeTerminalTab(tab.sessionId);
+                }}
+              >
+                <X className="size-3" aria-hidden="true" />
+              </button>
+            )}
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        className="flex h-6 items-center gap-1 self-end rounded-t-sm px-1.5 text-[11px] leading-none text-[oklch(0.66_0_0)] hover:bg-[oklch(0.12_0_0)] hover:text-[oklch(0.96_0_0)]"
+        aria-label="Open new terminal"
+        onClick={() => { void controller.addTerminalTab(); }}
+      >
+        <Plus className="size-3.5" aria-hidden="true" />
+        <span className="sr-only">New terminal</span>
+      </button>
     </div>
   );
 }

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -4,6 +4,7 @@ import { Terminal, type IDisposable } from '@xterm/xterm';
 
 import { TerminalSessionRegistry } from './TerminalSessionRegistry';
 import {
+  CloseSession,
   LoadDiff,
   LoadIdleStatus,
   LoadKubernetesContexts,
@@ -79,6 +80,7 @@ import {
   type TenantDashboardTab,
   type TenantDialogState,
   type TerminalStatusAction,
+  type TerminalTab,
 } from './state';
 import {
   clamp,
@@ -144,6 +146,7 @@ export class ERunUIController {
     globalConfigDialog: defaultGlobalConfigDialog(),
     collapsedTenants: new Set<string>(),
     sessionId: 0,
+    tabsByEnv: {},
     sidebarWidth: loadSavedSidebarWidth(),
     reviewWidth: loadSavedReviewWidth(),
     filesWidth: loadSavedFilesWidth(),
@@ -273,11 +276,11 @@ export class ERunUIController {
 
     this.terminalQueryResponseDisposables = registerTerminalQueryResponseHandlers(
       this.terminal,
-      SendSessionInput,
+      (data) => SendSessionInput(this.state.sessionId, data),
       (error) => this.showTerminalMessage(readError(error)),
     );
     this.terminalDataDisposable = this.terminal.onData((data) => {
-      SendSessionInput(data).catch((error: unknown) => {
+      SendSessionInput(this.state.sessionId, data).catch((error: unknown) => {
         this.showTerminalMessage(readError(error));
       });
     });
@@ -462,7 +465,8 @@ export class ERunUIController {
 
     this.prepareOpenSelection(selection, runSelection, previousSessionId, previousKnownSessionId);
     this.fitAddon?.fit();
-    const result = (await StartSession(runSelection, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
+    const slot = this.activeSlotForSelection(runSelection);
+    const result = (await StartSession(runSelection, slot, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
     this.registerOpenSessionResult(key, result, runSelection, previousSessionId);
     this.showOpenSelectionStatus(result.sessionId, selection);
 
@@ -500,10 +504,121 @@ export class ERunUIController {
     this.registerDebugSession(result.sessionId, runSelection, 'open');
     rebuildTerminalDisplayBuffer(this.sessions, result.sessionId);
     this.state.sessionId = result.sessionId;
+    this.recordTab(key, result.sessionId, result.slot ?? 0);
     if (result.sessionId !== previousSessionId) {
       this.resetTerminal();
       this.writeTerminalBuffer(this.sessions.displayBuffer(result.sessionId));
     }
+  }
+
+  private activeSlotForSelection(selection: UISelection): number {
+    const tabs = this.state.tabsByEnv[selectionKey(selection)] || [];
+    if (tabs.length === 0) {
+      return 0;
+    }
+    const active = tabs.find((tab) => tab.sessionId === this.state.sessionId);
+    return (active ?? tabs[0]).slot;
+  }
+
+  private recordTab(key: string, sessionId: number, slot: number): void {
+    const tabs = this.state.tabsByEnv[key] ? [...this.state.tabsByEnv[key]] : [];
+    const existingIndex = tabs.findIndex((tab) => tab.slot === slot);
+    if (existingIndex >= 0) {
+      tabs[existingIndex] = { sessionId, slot };
+    } else {
+      tabs.push({ sessionId, slot });
+      tabs.sort((a, b) => a.slot - b.slot);
+    }
+    this.state.tabsByEnv = { ...this.state.tabsByEnv, [key]: tabs };
+  }
+
+  private removeTab(key: string, sessionId: number): TerminalTab[] {
+    const tabs = this.state.tabsByEnv[key];
+    if (!tabs || tabs.length === 0) {
+      return [];
+    }
+    const remaining = tabs.filter((tab) => tab.sessionId !== sessionId);
+    const next = { ...this.state.tabsByEnv };
+    if (remaining.length === 0) {
+      delete next[key];
+    } else {
+      next[key] = remaining;
+    }
+    this.state.tabsByEnv = next;
+    return remaining;
+  }
+
+  async addTerminalTab(): Promise<void> {
+    const selection = this.state.selected;
+    if (!selection) {
+      return;
+    }
+    const runSelection = { ...selection, debug: this.state.debugOpen || undefined };
+    const key = selectionKey(runSelection);
+    const tabs = this.state.tabsByEnv[key] || [];
+    const nextSlot = tabs.reduce((max, tab) => (tab.slot >= max ? tab.slot + 1 : max), 0);
+    const previousSessionId = this.state.sessionId;
+    try {
+      const result = (await StartSession(runSelection, nextSlot, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
+      this.registerOpenSessionResult(key, result, runSelection, previousSessionId);
+      this.focusTerminalSoon();
+      this.queueTerminalResize();
+      this.emit();
+    } catch (error: unknown) {
+      this.showTerminalMessage(readError(error));
+    }
+  }
+
+  selectTerminalTab(sessionId: number): void {
+    if (sessionId <= 0 || sessionId === this.state.sessionId) {
+      return;
+    }
+    this.state.sessionId = sessionId;
+    rebuildTerminalDisplayBuffer(this.sessions, sessionId);
+    this.resetTerminal();
+    this.writeTerminalBuffer(this.sessions.displayBuffer(sessionId));
+    const exitReason = this.sessions.exitReason(sessionId);
+    if (exitReason) {
+      this.state.terminalCopyOutput = this.sessions.exitOutput(sessionId);
+      this.state.terminalCopyStatus = '';
+      this.showTerminalMessage(exitReason);
+    } else {
+      this.hideTerminalMessage();
+    }
+    this.focusTerminalSoon();
+    this.queueTerminalResize();
+    this.emit();
+  }
+
+  async closeTerminalTab(sessionId: number): Promise<void> {
+    if (sessionId <= 0) {
+      return;
+    }
+    const selection = this.state.selected;
+    if (!selection) {
+      return;
+    }
+    const runSelection = { ...selection, debug: this.state.debugOpen || undefined };
+    const key = selectionKey(runSelection);
+    try {
+      await CloseSession(sessionId);
+    } catch (error: unknown) {
+      this.showTerminalMessage(readError(error));
+      return;
+    }
+    const remaining = this.removeTab(key, sessionId);
+    if (this.state.sessionId === sessionId) {
+      const next = remaining[remaining.length - 1];
+      if (next) {
+        this.selectTerminalTab(next.sessionId);
+      } else {
+        this.state.sessionId = 0;
+        this.resetTerminal();
+        this.emit();
+      }
+      return;
+    }
+    this.emit();
   }
 
   private showOpenSelectionStatus(sessionId: number, selection: UISelection): void {
@@ -1688,6 +1803,7 @@ export class ERunUIController {
     const selections = this.takeTerminalExitSelections(payload.sessionId);
     const reason = this.terminalExitReason(payload, selections);
     const failedOutput = this.recordTerminalExit(payload, reason, selections);
+    this.dropExitedSessionFromTabs(payload.sessionId, selections.openSelection);
 
     if (selections.initSelection || selections.deploySelection || selections.sshdInitSelection) {
       await this.reloadStateAfterEnvironmentChange();
@@ -1708,6 +1824,21 @@ export class ERunUIController {
 
   private takeTerminalExitSelections(sessionId: number): TerminalExitSelections {
     return this.sessions.takeExitSelections(sessionId);
+  }
+
+  private dropExitedSessionFromTabs(sessionId: number, openSelection: UISelection | undefined): void {
+    if (!openSelection) {
+      return;
+    }
+    const key = selectionKey(openSelection);
+    const remaining = this.removeTab(key, sessionId);
+    if (this.state.sessionId !== sessionId) {
+      return;
+    }
+    const next = remaining[remaining.length - 1];
+    if (next) {
+      this.selectTerminalTab(next.sessionId);
+    }
   }
 
   private recordTerminalExit(payload: TerminalExitPayload, reason: string, selections: TerminalExitSelections): string {
@@ -1810,7 +1941,7 @@ export class ERunUIController {
       this.applyLayoutVars();
       this.fitAddon?.fit();
       if (this.state.sessionId > 0 && this.terminal) {
-        ResizeSession(this.terminal.cols, this.terminal.rows).catch(() => {
+        ResizeSession(this.state.sessionId, this.terminal.cols, this.terminal.rows).catch(() => {
         });
       }
     }, 40);
@@ -1840,9 +1971,13 @@ export class ERunUIController {
     }
 
     event.preventDefault();
+    const sessionId = this.state.sessionId;
+    if (sessionId <= 0) {
+      return;
+    }
     const paths: string[] = [];
     for (const image of images) {
-      const result = (await SavePastedImage({
+      const result = (await SavePastedImage(sessionId, {
         data: await fileToBase64(image),
         mimeType: image.type,
         name: image.name,
@@ -1854,7 +1989,7 @@ export class ERunUIController {
     if (paths.length === 0) {
       return;
     }
-    await SendSessionInput(`${paths.join(' ')} `);
+    await SendSessionInput(sessionId, `${paths.join(' ')} `);
     this.focusTerminalSoon();
   }
 

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -120,6 +120,11 @@ export interface AppNotification {
 export type TerminalStatusKind = 'info' | 'warning' | 'error';
 export type TerminalStatusAction = '' | 'wait-longer';
 
+export interface TerminalTab {
+  sessionId: number;
+  slot: number;
+}
+
 export interface AppState {
   tenants: UITenant[];
   cloudProviders: UICloudProviderStatus[];
@@ -132,6 +137,7 @@ export interface AppState {
   globalConfigDialog: GlobalConfigDialogState;
   collapsedTenants: Set<string>;
   sessionId: number;
+  tabsByEnv: Record<string, TerminalTab[]>;
   sidebarWidth: number;
   reviewWidth: number;
   filesWidth: number;

--- a/erun-ui/frontend/src/components/app/TerminalTabStrip.tsx
+++ b/erun-ui/frontend/src/components/app/TerminalTabStrip.tsx
@@ -1,0 +1,162 @@
+import * as React from 'react';
+import { Plus, X } from 'lucide-react';
+
+import type { ERunUIController } from '@/app/ERunUIController';
+import { selectionKey } from '@/app/versionSuggestions';
+import type { AppState } from '@/app/state';
+import { IconTooltip } from '@/components/app/IconTooltip';
+import { cn } from '@/lib/utils';
+
+export function TerminalTabStrip({
+  controller,
+  state,
+}: {
+  controller: ERunUIController;
+  state: AppState;
+}): React.ReactElement {
+  const selection = state.selected;
+  const stripBaseClass = 'flex h-8 items-end border-b border-[oklch(0.18_0_0)] bg-[oklch(0.05_0_0)] pl-2 pr-1';
+
+  if (!selection) {
+    return <div className={stripBaseClass} aria-hidden="true" />;
+  }
+
+  const tabs = state.tabsByEnv[selectionKey(selection)] || [];
+  const activeId = state.sessionId;
+  const tabRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
+  tabRefs.current.length = tabs.length;
+
+  const focusTab = (index: number) => {
+    const node = tabRefs.current[index];
+    node?.focus();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number, sessionId: number) => {
+    switch (event.key) {
+      case 'ArrowRight': {
+        event.preventDefault();
+        const next = (index + 1) % tabs.length;
+        controller.selectTerminalTab(tabs[next].sessionId);
+        focusTab(next);
+        break;
+      }
+      case 'ArrowLeft': {
+        event.preventDefault();
+        const next = (index - 1 + tabs.length) % tabs.length;
+        controller.selectTerminalTab(tabs[next].sessionId);
+        focusTab(next);
+        break;
+      }
+      case 'Home': {
+        event.preventDefault();
+        controller.selectTerminalTab(tabs[0].sessionId);
+        focusTab(0);
+        break;
+      }
+      case 'End': {
+        event.preventDefault();
+        const last = tabs.length - 1;
+        controller.selectTerminalTab(tabs[last].sessionId);
+        focusTab(last);
+        break;
+      }
+      case 'Delete':
+      case 'Backspace': {
+        if (event.metaKey || event.ctrlKey) {
+          event.preventDefault();
+          void controller.closeTerminalTab(sessionId);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className={stripBaseClass} role="tablist" aria-label="Open terminals">
+      {tabs.map((tab, index) => (
+        <Tab
+          key={tab.sessionId}
+          index={index}
+          active={tab.sessionId === activeId}
+          ref={(node) => {
+            tabRefs.current[index] = node;
+          }}
+          onSelect={() => controller.selectTerminalTab(tab.sessionId)}
+          onClose={() => controller.closeTerminalTab(tab.sessionId)}
+          onKeyDown={(event) => handleKeyDown(event, index, tab.sessionId)}
+        />
+      ))}
+      <IconTooltip label="New terminal">
+        <button
+          type="button"
+          className="ml-1 mb-[-1px] flex h-7 items-center justify-center rounded-md px-2 text-[oklch(0.66_0_0)] transition-colors hover:bg-[oklch(0.13_0_0)] hover:text-[oklch(0.96_0_0)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[oklch(0.62_0_0)]"
+          aria-label="Open a new terminal"
+          onClick={() => { void controller.addTerminalTab(); }}
+        >
+          <Plus className="size-4" aria-hidden="true" />
+        </button>
+      </IconTooltip>
+    </div>
+  );
+}
+
+interface TabProps {
+  index: number;
+  active: boolean;
+  onSelect: () => void;
+  onClose: () => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
+}
+
+const Tab = React.forwardRef<HTMLButtonElement, TabProps>(function Tab(
+  { index, active, onSelect, onClose, onKeyDown },
+  ref,
+) {
+  const label = `Terminal ${index + 1}`;
+  return (
+    <div
+      className={cn(
+        'group relative -mb-px flex h-7 items-stretch overflow-hidden rounded-t-md border border-b-0 transition-colors',
+        active
+          ? 'border-[oklch(0.22_0_0)] bg-terminal text-[oklch(0.96_0_0)]'
+          : 'border-transparent bg-transparent text-[oklch(0.66_0_0)] hover:bg-[oklch(0.10_0_0)] hover:text-[oklch(0.92_0_0)]',
+      )}
+    >
+      <button
+        ref={ref}
+        type="button"
+        role="tab"
+        aria-selected={active}
+        aria-controls="erun-terminal-pane"
+        tabIndex={active ? 0 : -1}
+        className={cn(
+          'flex items-center pl-3 pr-1.5 text-[12px] leading-none font-medium tracking-tight bg-transparent border-0 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[oklch(0.62_0_0)]',
+          active ? 'cursor-default' : 'cursor-pointer',
+        )}
+        onClick={onSelect}
+        onKeyDown={onKeyDown}
+      >
+        {label}
+      </button>
+      <IconTooltip label={`Close ${label}`}>
+        <button
+          type="button"
+          tabIndex={-1}
+          className={cn(
+            'mr-1 flex size-5 items-center justify-center rounded text-[oklch(0.56_0_0)] transition-opacity transition-colors hover:bg-[oklch(0.18_0_0)] hover:text-[oklch(0.96_0_0)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[oklch(0.62_0_0)]',
+            active ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100',
+          )}
+          aria-label={`Close ${label}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            onClose();
+          }}
+        >
+          <X className="size-3" aria-hidden="true" />
+        </button>
+      </IconTooltip>
+    </div>
+  );
+});

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -293,6 +293,7 @@ export interface UIRuntimeResourceNode {
 export interface StartSessionResult {
   sessionId: number;
   selection: UISelection;
+  slot?: number;
 }
 
 export interface TerminalOutputPayload {

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -13,7 +13,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
-func (a *App) StartSession(selection uiSelection, cols, rows int) (startSessionResult, error) {
+func (a *App) StartSession(selection uiSelection, slot, cols, rows int) (startSessionResult, error) {
 	selection = normalizeSelection(selection)
 	if selection.Tenant == "" || selection.Environment == "" {
 		return startSessionResult{}, fmt.Errorf("tenant and environment are required")
@@ -26,7 +26,7 @@ func (a *App) StartSession(selection uiSelection, cols, rows int) (startSessionR
 		rows = 34
 	}
 
-	key := selectionKey(selection)
+	key := openSessionKey(selection, slot)
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
 		Tenant:      selection.Tenant,
 		Environment: selection.Environment,
@@ -37,12 +37,12 @@ func (a *App) StartSession(selection uiSelection, cols, rows int) (startSessionR
 
 	a.mu.Lock()
 	if existing := a.sessions[key]; existing != nil && !existing.closed && existing.session != nil {
-		a.current = existing
 		a.mu.Unlock()
 		go a.startWorkspaceSyncForSelection(selection)
 		return startSessionResult{
 			SessionID: existing.serial,
 			Selection: existing.selection,
+			Slot:      slot,
 		}, nil
 	}
 	a.mu.Unlock()
@@ -67,11 +67,11 @@ func (a *App) StartSession(selection uiSelection, cols, rows int) (startSessionR
 		selection:              selection,
 		key:                    key,
 		serial:                 serial,
+		slot:                   slot,
 		blocksIdleStop:         true,
 		clearIdleBlockOnOutput: true,
 	}
 	a.sessions[key] = managed
-	a.current = managed
 	a.busyEnvs[environmentBusyKey(selection)]++
 	a.mu.Unlock()
 
@@ -82,6 +82,7 @@ func (a *App) StartSession(selection uiSelection, cols, rows int) (startSessionR
 	return startSessionResult{
 		SessionID: serial,
 		Selection: selection,
+		Slot:      slot,
 	}, nil
 }
 
@@ -193,7 +194,6 @@ func (a *App) StartCloudInitAWSSession(cols, rows int) (startSessionResult, erro
 
 	a.mu.Lock()
 	if existing := a.sessions[key]; existing != nil && !existing.closed && existing.session != nil {
-		a.current = existing
 		a.mu.Unlock()
 		return startSessionResult{
 			SessionID: existing.serial,
@@ -223,7 +223,6 @@ func (a *App) StartCloudInitAWSSession(cols, rows int) (startSessionResult, erro
 		serial:  serial,
 	}
 	a.sessions[key] = managed
-	a.current = managed
 	a.mu.Unlock()
 
 	go a.streamSession(managed)
@@ -296,7 +295,6 @@ func (a *App) startCommandSessionWithExecutable(selection uiSelection, cols, row
 
 	a.mu.Lock()
 	if existing := a.sessions[key]; existing != nil && !existing.closed && existing.session != nil {
-		a.current = existing
 		a.mu.Unlock()
 		return startSessionResult{
 			SessionID: existing.serial,
@@ -328,7 +326,6 @@ func (a *App) startCommandSessionWithExecutable(selection uiSelection, cols, row
 		blocksIdleStop: true,
 	}
 	a.sessions[key] = managed
-	a.current = managed
 	a.busyEnvs[environmentBusyKey(selection)]++
 	a.mu.Unlock()
 
@@ -341,22 +338,22 @@ func (a *App) startCommandSessionWithExecutable(selection uiSelection, cols, row
 	}, nil
 }
 
-func (a *App) SendSessionInput(data string) error {
+func (a *App) SendSessionInput(sessionID int, data string) error {
 	if data == "" {
 		return nil
 	}
 
 	a.mu.Lock()
-	current := a.current
+	managed := a.sessionBySerialLocked(sessionID)
 	a.mu.Unlock()
-	if current == nil || current.session == nil {
+	if managed == nil || managed.session == nil {
 		return nil
 	}
 
-	if _, err := io.WriteString(current.session, data); err != nil {
+	if _, err := io.WriteString(managed.session, data); err != nil {
 		return err
 	}
-	a.recordTerminalActivity(current.selection)
+	a.recordTerminalActivity(managed.selection)
 	return nil
 }
 
@@ -372,22 +369,22 @@ func (a *App) recordTerminalActivity(selection uiSelection) {
 	})
 }
 
-func (a *App) SavePastedImage(payload pastedImagePayload) (pastedImageResult, error) {
+func (a *App) SavePastedImage(sessionID int, payload pastedImagePayload) (pastedImageResult, error) {
 	data, mimeType, err := decodePastedImagePayload(payload)
 	if err != nil {
 		return pastedImageResult{}, err
 	}
 
 	a.mu.Lock()
-	current := a.current
+	managed := a.sessionBySerialLocked(sessionID)
 	a.mu.Unlock()
-	if current == nil || current.session == nil {
+	if managed == nil || managed.session == nil {
 		return pastedImageResult{}, fmt.Errorf("no active terminal session")
 	}
 
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
-		Tenant:      current.selection.Tenant,
-		Environment: current.selection.Environment,
+		Tenant:      managed.selection.Tenant,
+		Environment: managed.selection.Environment,
 	})
 	if err != nil {
 		return pastedImageResult{}, err
@@ -449,19 +446,41 @@ func (a *App) ensureMCPAvailable(ctx context.Context, result eruncommon.OpenResu
 	return nil
 }
 
-func (a *App) ResizeSession(cols, rows int) error {
+func (a *App) ResizeSession(sessionID, cols, rows int) error {
 	if cols <= 0 || rows <= 0 {
 		return nil
 	}
 
 	a.mu.Lock()
-	current := a.current
+	managed := a.sessionBySerialLocked(sessionID)
 	a.mu.Unlock()
-	if current == nil || current.session == nil {
+	if managed == nil || managed.session == nil {
 		return nil
 	}
 
-	return current.session.Resize(cols, rows)
+	return managed.session.Resize(cols, rows)
+}
+
+func (a *App) CloseSession(sessionID int) error {
+	a.mu.Lock()
+	managed := a.sessionBySerialLocked(sessionID)
+	a.mu.Unlock()
+	if managed == nil || managed.session == nil {
+		return nil
+	}
+	return managed.session.Close()
+}
+
+func (a *App) sessionBySerialLocked(sessionID int) *managedTerminal {
+	if sessionID <= 0 {
+		return nil
+	}
+	for _, managed := range a.sessions {
+		if managed != nil && managed.serial == sessionID {
+			return managed
+		}
+	}
+	return nil
 }
 
 func decodePastedImagePayload(payload pastedImagePayload) ([]byte, string, error) {
@@ -524,9 +543,6 @@ func (a *App) streamSession(managed *managedTerminal) {
 				delete(a.sessions, managed.key)
 			}
 			a.releaseIdleBlockLocked(managed)
-			if a.current == managed {
-				a.current = nil
-			}
 			a.mu.Unlock()
 			a.emitEvent(terminalExitEvent, terminalExitPayload{
 				SessionID: managed.serial,
@@ -561,30 +577,19 @@ func (a *App) emitEvent(name string, payload any) {
 }
 
 func (a *App) closeAllSessionsLocked() {
-	closed := make(map[*managedTerminal]struct{}, len(a.sessions))
 	for _, session := range a.sessions {
 		if session == nil {
 			continue
 		}
-		if _, seen := closed[session]; seen {
-			continue
-		}
-		closed[session] = struct{}{}
 		_ = session.Close()
 	}
-	if a.current != nil {
-		if _, seen := closed[a.current]; !seen {
-			_ = a.current.Close()
-		}
-	}
 	a.sessions = make(map[string]*managedTerminal)
-	a.current = nil
 }
 
 func (a *App) closeSessionsForSelection(selection uiSelection) {
 	selection = normalizeSelection(selection)
 	prefixes := []string{
-		selectionKey(selection),
+		selectionKey(selection) + "\x00",
 		"init\x00" + selection.Tenant + "\x00" + selection.Environment + "\x00",
 		"deploy\x00" + selection.Tenant + "\x00" + selection.Environment + "\x00",
 	}
@@ -597,7 +602,7 @@ func (a *App) closeSessionsForSelection(selection uiSelection) {
 		}
 		matches := false
 		for _, prefix := range prefixes {
-			if key == prefix || strings.HasPrefix(key, prefix) {
+			if strings.HasPrefix(key, prefix) {
 				matches = true
 				break
 			}
@@ -607,9 +612,6 @@ func (a *App) closeSessionsForSelection(selection uiSelection) {
 		}
 		_ = session.Close()
 		delete(a.sessions, key)
-		if a.current == session {
-			a.current = nil
-		}
 	}
 }
 
@@ -627,6 +629,7 @@ type managedTerminal struct {
 	selection              uiSelection
 	key                    string
 	serial                 int
+	slot                   int
 	closed                 bool
 	blocksIdleStop         bool
 	clearIdleBlockOnOutput bool
@@ -643,6 +646,10 @@ func (s *managedTerminal) Close() error {
 func selectionKey(selection uiSelection) string {
 	selection = normalizeSelection(selection)
 	return selection.Tenant + "\x00" + selection.Environment + "\x00" + fmt.Sprintf("%t", selection.Debug)
+}
+
+func openSessionKey(selection uiSelection, slot int) string {
+	return selectionKey(selection) + "\x00" + fmt.Sprintf("%d", slot)
 }
 
 func environmentBusyKey(selection uiSelection) string {

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -280,6 +280,7 @@ type uiCloudContextInitInput struct {
 type startSessionResult struct {
 	SessionID int         `json:"sessionId"`
 	Selection uiSelection `json:"selection"`
+	Slot      int         `json:"slot,omitempty"`
 }
 
 type deleteEnvironmentResult struct {

--- a/erun-ui/workspace_sync_test.go
+++ b/erun-ui/workspace_sync_test.go
@@ -137,7 +137,7 @@ func TestStartSessionStartsConfiguredWorkspaceSync(t *testing.T) {
 	})
 	defer app.shutdown(context.Background())
 
-	if _, err := app.StartSession(uiSelection{Tenant: "frs", Environment: "dev"}, 80, 24); err != nil {
+	if _, err := app.StartSession(uiSelection{Tenant: "frs", Environment: "dev"}, 0, 80, 24); err != nil {
 		t.Fatalf("StartSession failed: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

- Wrap the bundled `claude` CLI in the runtime image so a fresh terminal in a fresh pod resumes the most recent conversation for the current directory; pod restart is already handled by the home-directory PVC.
- Make `erun open` support multiple terminal tabs per environment by routing input, resize, paste, and close by sessionID instead of an implicit current-terminal pointer; the desktop UI renders a tab strip above the terminal pane.

## Test plan
- [x] `claude-wrapper_test.sh` covers project-dir present/absent, all bypass flags, all subcommands (24 cases).
- [x] `go test ./...` in `erun-ui` and `erun-common`. The single failure (`TestWorkspaceSyncSSHArgsAreNonInteractiveAndAcceptLocalHostKey`) is pre-existing on main and unrelated.
- [x] `yarn build` and `yarn shadcn:check` from `erun-ui/frontend`.
- [x] `golangci-lint` reports the same set of warnings as main; no new findings.
- [ ] Manual: open env in erun-ui, click `+` to open a second tab, run `claude` in tab 2, exchange a message, `kubectl delete pod -l app=runtime`, wait for new pod, reopen env, `claude` in any tab → prior conversation resumes.

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)