### PR TITLE
Escape commas in Helm --set-string values

### DIFF
--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -959,7 +959,7 @@ func (d HelmDeploySpec) command() commandSpec {
 		"--set-string", "cloudContext.providerAlias="+d.CloudProviderAlias,
 		"--set-string", "cloudContext.region="+d.CloudRegion,
 		"--set-string", "cloudContext.instanceId="+d.CloudInstanceID,
-		"--set-string", "api.oidcAllowedIssuers="+d.OIDCAllowedIssuers,
+		"--set-string", "api.oidcAllowedIssuers="+escapeHelmSetValue(d.OIDCAllowedIssuers),
 		"--set", "api.postgres.reset="+formatHelmBool(d.ResetDatabase),
 	)
 	if registry := strings.TrimSpace(d.ContainerRegistry); registry != "" {
@@ -1120,7 +1120,7 @@ func helmClaudeSetArgs(config EnvironmentClaudeConfig) []string {
 	args = append(args, "--set-string", "claude.useMantle="+claudeFlagValue(resolveClaudeBool(config.UseMantle, DefaultClaudeUseMantle)))
 	args = append(args, "--set-string", "claude.useBedrock="+claudeFlagValue(resolveClaudeBool(config.UseBedrock, DefaultClaudeUseBedrock)))
 	if models := formatClaudeModels(config.Models); models != "" {
-		args = append(args, "--set-string", "claude.availableModels="+models)
+		args = append(args, "--set-string", "claude.availableModels="+escapeHelmSetValue(models))
 	}
 	if config.MaxOutputTokens != nil {
 		args = append(args, "--set-string", "claude.maxOutputTokens="+strconv.Itoa(*config.MaxOutputTokens))
@@ -1142,6 +1142,14 @@ func claudeFlagValue(value bool) string {
 		return "1"
 	}
 	return "0"
+}
+
+// escapeHelmSetValue escapes characters that Helm's --set/--set-string parser
+// treats as structural so the input is preserved as a literal scalar value.
+// Helm splits values on commas, so a comma inside the value must be backslash-escaped.
+func escapeHelmSetValue(value string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `,`, `\,`)
+	return replacer.Replace(value)
 }
 
 func resolveDeployKubernetesContext(environment, configured string, currentContext func() (string, error)) string {

--- a/erun-common/deploy_test.go
+++ b/erun-common/deploy_test.go
@@ -607,7 +607,7 @@ func TestHelmDeploySpecEmitsClaudeSetArgsWhenConfigured(t *testing.T) {
 	for _, want := range []string{
 		"claude.useMantle=0",
 		"claude.useBedrock=1",
-		"claude.availableModels=opus,sonnet",
+		`claude.availableModels=opus\,sonnet`,
 		"claude.maxOutputTokens=8192",
 	} {
 		if !strings.Contains(args, want) {
@@ -1832,7 +1832,7 @@ printf '%s
 		"--set-string\ncloudContext.providerAlias=team-cloud\n",
 		"--set-string\ncloudContext.region=eu-west-2\n",
 		"--set-string\ncloudContext.instanceId=i-073c3338f26fbb000\n",
-		"--set-string\napi.oidcAllowedIssuers=https://issuer.one.example,https://issuer.two.example\n",
+		"--set-string\napi.oidcAllowedIssuers=https://issuer.one.example\\,https://issuer.two.example\n",
 		"--set\napi.postgres.reset=true\n",
 		"--set-string\nimageOverrides.erun-backend-api=erunpaas/erun-backend-api:1.0.0-snapshot-20260503093000\n",
 	} {
@@ -1888,7 +1888,7 @@ printf '%s
 		"--set-string\ncontainerRegistry=ghcr.io/sophium\n",
 		"--set-string\nclaude.useMantle=1\n",
 		"--set-string\nclaude.useBedrock=0\n",
-		"--set-string\nclaude.availableModels=opus,sonnet\n",
+		"--set-string\nclaude.availableModels=opus\\,sonnet\n",
 		"--set-string\nclaude.maxOutputTokens=8192\n",
 	} {
 		if !strings.Contains(args, want) {


### PR DESCRIPTION
## Summary

- Helm's `--set-string` parser splits on commas as key=value separators, so passing `claude.availableModels=opus,sonnet,haiku` was parsed as one value plus two bare keys, failing the deploy with `key "sonnet" has no value`.
- Added `escapeHelmSetValue` helper (escapes `\` then `,`) and applied it to `claude.availableModels` and `api.oidcAllowedIssuers` (same latent bug — issuers are also joined with commas).
- Updated affected test expectations to match the escaped form.

Closes #215

## Test plan

- [x] `go test ./...` in `erun-common` (only the pre-existing unrelated `TestRuntimeDockerfileInstallsPinnedCodexCLI` fails on `main` too)
- [x] `go test ./...` in `erun-cli`
- [x] `go test ./...` in `erun-mcp`