### PR TITLE
UX: migrate native <select> to shadcn Select primitive

### DIFF
--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -13,6 +13,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Label } from '@/components/ui/label';
 import { EditableComboField, uniqueSuggestions } from './EditableComboField';
 import { RuntimeResourceControls } from './RuntimeResourceControls';
+import { SelectField } from './SelectField';
 import { VersionField } from './VersionField';
 
 const dialogErrorClassName =
@@ -154,20 +155,20 @@ function EnvironmentCreateFields({ controller, dialog }: { controller: ERunUICon
 }
 
 function KubernetesContextSelect({ controller, dialog }: { controller: ERunUIController; dialog: EnvironmentDialog }): React.ReactElement {
+  const items = dialog.kubernetesContexts.map((context) => ({ value: context, label: context }));
+  const placeholder = dialog.kubernetesContextsLoading ? 'Loading contexts...' : 'Select Kubernetes context';
   return (
-    <div className="grid gap-2">
-      <Label htmlFor="environment-kubernetes-context">Kubernetes context</Label>
-      <select
-        id="environment-kubernetes-context"
-        className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-[var(--radius)] border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-        value={dialog.kubernetesContext}
-        required
-        disabled={dialog.busy || dialog.kubernetesContextsLoading || dialog.kubernetesContexts.length === 0}
-        onChange={(event) => controller.updateEnvironmentDialog({ kubernetesContext: event.target.value })}
-      >
-        {kubernetesContextOptions(dialog)}
-      </select>
-    </div>
+    <SelectField
+      id="environment-kubernetes-context"
+      label="Kubernetes context"
+      value={dialog.kubernetesContext}
+      options={items}
+      placeholder={placeholder}
+      emptyLabel="No Kubernetes contexts"
+      disabled={dialog.busy || dialog.kubernetesContextsLoading}
+      required
+      onChange={(kubernetesContext) => controller.updateEnvironmentDialog({ kubernetesContext })}
+    />
   );
 }
 
@@ -236,12 +237,3 @@ function environmentNameSuggestions(state: AppState, dialog: EnvironmentDialog):
   return uniqueSuggestions([dialog.environment, ...selectedTenantEnvironments, ...loadSavedPastEnvironments(), ...allEnvironments]);
 }
 
-function kubernetesContextOptions(dialog: EnvironmentDialog): React.ReactNode {
-  if (dialog.kubernetesContextsLoading) {
-    return <option value="">Loading contexts...</option>;
-  }
-  if (dialog.kubernetesContexts.length === 0) {
-    return <option value="">No Kubernetes contexts</option>;
-  }
-  return dialog.kubernetesContexts.map((context) => <option key={context} value={context}>{context}</option>);
-}

--- a/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { SelectField, type SelectFieldOption } from './SelectField';
 import { StatusBadge, cloudProviderStatusTone } from './StatusBadge';
 
 const dialogErrorClassName =
@@ -49,15 +50,28 @@ export function GlobalConfigDialogView({ controller, state }: { controller: ERun
   );
 }
 
+const NOT_CONFIGURED_VALUE = '__none__';
+
 function GlobalConfigBody({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement {
   const dialog = state.globalConfigDialog;
   if (dialog.configLoading) {
     return <div className="rounded-[var(--radius)] border border-dashed border-border px-3 py-2.5 text-[13px] leading-[1.35] text-muted-foreground">Loading config...</div>;
   }
-  const tenantOptions = optionValues(state.tenants.map((tenant) => tenant.name), dialog.config.defaultTenant);
+  const tenantNames = optionValues(state.tenants.map((tenant) => tenant.name), dialog.config.defaultTenant);
+  const tenantOptions: SelectFieldOption[] = tenantNames.length === 0
+    ? []
+    : [{ value: NOT_CONFIGURED_VALUE, label: 'Not configured' }, ...tenantNames.map((name) => ({ value: name, label: name }))];
   return (
     <div className="grid gap-3">
-      <SelectField id="global-config-defaulttenant" label="Default tenant" value={dialog.config.defaultTenant} options={tenantOptions} disabled={dialog.busy || tenantOptions.length === 0} onChange={(defaultTenant) => controller.updateGlobalConfig({ defaultTenant })} />
+      <SelectField
+        id="global-config-defaulttenant"
+        label="Default tenant"
+        value={dialog.config.defaultTenant || NOT_CONFIGURED_VALUE}
+        options={tenantOptions}
+        emptyLabel="No tenants"
+        disabled={dialog.busy}
+        onChange={(value) => controller.updateGlobalConfig({ defaultTenant: value === NOT_CONFIGURED_VALUE ? '' : value })}
+      />
       <CloudAliasesSection controller={controller} dialog={dialog} />
       <CloudContextsSection controller={controller} dialog={dialog} />
     </div>
@@ -136,10 +150,49 @@ function CloudContextDraftForm({ controller, dialog }: { controller: ERunUIContr
   return (
     <div className="grid gap-2 rounded-[var(--radius)] border border-border p-3">
       <div className="grid gap-2 sm:grid-cols-2">
-        <SelectInput id="global-config-cloudcontext-provider" label="Cloud provider" value={dialog.cloudContextDraft.cloudProviderAlias} options={(config.cloudProviders || []).map((provider) => provider.alias)} emptyLabel="No cloud aliases" disabled={dialog.busy || (config.cloudProviders || []).length === 0} onChange={(cloudProviderAlias) => controller.updateCloudContextDraft({ cloudProviderAlias })} />
-        <RegionSelectInput id="global-config-cloudcontext-region" value={dialog.cloudContextDraft.region} disabled={dialog.busy} onChange={(region) => controller.updateCloudContextDraft({ region })} />
-        <SelectInput id="global-config-cloudcontext-instancetype" label="Instance type" value={dialog.cloudContextDraft.instanceType} options={['c8gd.2xlarge', 't4g.xlarge']} disabled={dialog.busy} onChange={(instanceType) => controller.updateCloudContextDraft({ instanceType })} />
-        <SelectInput id="global-config-cloudcontext-disksize" label="Disk size" value={String(dialog.cloudContextDraft.diskSizeGb)} options={['100', '200']} disabled={dialog.busy} onChange={(diskSizeGb) => controller.updateCloudContextDraft({ diskSizeGb: Number(diskSizeGb) })} />
+        <SelectField
+          id="global-config-cloudcontext-provider"
+          label="Cloud provider"
+          value={dialog.cloudContextDraft.cloudProviderAlias}
+          options={(config.cloudProviders || []).map((provider) => ({ value: provider.alias, label: provider.alias }))}
+          emptyLabel="No cloud aliases"
+          placeholder="Select cloud alias"
+          disabled={dialog.busy}
+          onChange={(cloudProviderAlias) => controller.updateCloudContextDraft({ cloudProviderAlias })}
+        />
+        <SelectField
+          id="global-config-cloudcontext-region"
+          label="Region"
+          value={dialog.cloudContextDraft.region || 'eu-west-2'}
+          options={[
+            { value: 'eu-west-2', label: 'London' },
+            { value: 'eu-west-1', label: 'Ireland' },
+          ]}
+          disabled={dialog.busy}
+          onChange={(region) => controller.updateCloudContextDraft({ region })}
+        />
+        <SelectField
+          id="global-config-cloudcontext-instancetype"
+          label="Instance type"
+          value={dialog.cloudContextDraft.instanceType}
+          options={[
+            { value: 'c8gd.2xlarge', label: 'c8gd.2xlarge' },
+            { value: 't4g.xlarge', label: 't4g.xlarge' },
+          ]}
+          disabled={dialog.busy}
+          onChange={(instanceType) => controller.updateCloudContextDraft({ instanceType })}
+        />
+        <SelectField
+          id="global-config-cloudcontext-disksize"
+          label="Disk size"
+          value={String(dialog.cloudContextDraft.diskSizeGb)}
+          options={[
+            { value: '100', label: '100' },
+            { value: '200', label: '200' },
+          ]}
+          disabled={dialog.busy}
+          onChange={(diskSizeGb) => controller.updateCloudContextDraft({ diskSizeGb: Number(diskSizeGb) })}
+        />
       </div>
       <CloudContextNameField controller={controller} dialog={dialog} generatedName={generated} />
     </div>
@@ -347,84 +400,6 @@ function statusLabel(status: string): string {
     default:
       return 'Unknown';
   }
-}
-
-function RegionSelectInput({ id, value, disabled, onChange }: { id: string; value: string; disabled?: boolean; onChange: (value: string) => void }): React.ReactElement {
-  const regions = [
-    { value: 'eu-west-2', label: 'London' },
-    { value: 'eu-west-1', label: 'Ireland' },
-  ];
-  return (
-    <div className="grid gap-2">
-      <Label htmlFor={id}>Region</Label>
-      <select
-        id={id}
-        className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-[var(--radius)] border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-        value={value || 'eu-west-2'}
-        disabled={disabled}
-        onChange={(event) => onChange(event.target.value)}
-      >
-        {regions.map((region) => (
-          <option key={region.value} value={region.value}>
-            {region.label}
-          </option>
-        ))}
-      </select>
-    </div>
-  );
-}
-
-function SelectInput({ id, label, value, options, disabled, emptyLabel, onChange }: { id: string; label: string; value: string; options: string[]; disabled?: boolean; emptyLabel?: string; onChange: (value: string) => void }): React.ReactElement {
-  return (
-    <div className="grid gap-2">
-      <Label htmlFor={id}>{label}</Label>
-      <select
-        id={id}
-        className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-[var(--radius)] border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-        value={value}
-        disabled={disabled}
-        onChange={(event) => onChange(event.target.value)}
-      >
-        {options.length === 0 ? (
-          <option value="">{emptyLabel || 'No options'}</option>
-        ) : (
-          options.map((option) => (
-            <option key={option} value={option}>
-              {option}
-            </option>
-          ))
-        )}
-      </select>
-    </div>
-  );
-}
-
-function SelectField({ id, label, value, options, disabled, onChange }: { id: string; label: string; value: string; options: string[]; disabled?: boolean; onChange: (value: string) => void }): React.ReactElement {
-  return (
-    <div className="grid gap-2">
-      <Label htmlFor={id}>{label}</Label>
-      <select
-        id={id}
-        className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-[var(--radius)] border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-        value={value}
-        disabled={disabled}
-        onChange={(event) => onChange(event.target.value)}
-      >
-        {options.length === 0 ? (
-          <option value="">No tenants</option>
-        ) : (
-          <>
-            <option value="">Not configured</option>
-            {options.map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            ))}
-          </>
-        )}
-      </select>
-    </div>
-  );
 }
 
 function optionValues(values: string[], current: string): string[] {

--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -20,6 +20,7 @@ import type { ManageEditTab, ManageTab, UICloudContextStatus, UIEnvironmentConfi
 import { cn } from '@/lib/utils';
 import { EditableComboField, uniqueSuggestions } from './EditableComboField';
 import { RuntimeResourceControls } from './RuntimeResourceControls';
+import { SelectField } from './SelectField';
 
 const dialogErrorClassName =
   'rounded-[var(--radius)] border border-[color-mix(in_oklch,var(--destructive)_36%,transparent)] bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] px-[11px] py-[9px] text-[13px] leading-[1.35] text-destructive [overflow-wrap:anywhere]';
@@ -593,9 +594,6 @@ function TextField({
   );
 }
 
-const claudeSelectClassName =
-  'border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-[var(--radius)] border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50';
-
 function ClaudeSettingsSection({ controller, dialog }: { controller: ERunUIController; dialog: ManageDialog }): React.ReactElement {
   const config = dialog.config;
   const claude = config.claude;
@@ -654,27 +652,24 @@ function ClaudeBoolField({ id, label, defaultValue, value, disabled, onChange }:
   const selectValue = value === undefined ? 'default' : value ? 'on' : 'off';
   const defaultLabel = defaultValue ? 'Default (enabled)' : 'Default (disabled)';
   return (
-    <div className="grid gap-2">
-      <Label htmlFor={id}>{label}</Label>
-      <select
-        id={id}
-        className={claudeSelectClassName}
-        value={selectValue}
-        disabled={disabled}
-        onChange={(event) => {
-          const next = event.target.value;
-          if (next === 'default') {
-            onChange(undefined);
-          } else {
-            onChange(next === 'on');
-          }
-        }}
-      >
-        <option value="default">{defaultLabel}</option>
-        <option value="on">Enabled</option>
-        <option value="off">Disabled</option>
-      </select>
-    </div>
+    <SelectField
+      id={id}
+      label={label}
+      value={selectValue}
+      options={[
+        { value: 'default', label: defaultLabel },
+        { value: 'on', label: 'Enabled' },
+        { value: 'off', label: 'Disabled' },
+      ]}
+      disabled={disabled}
+      onChange={(next) => {
+        if (next === 'default') {
+          onChange(undefined);
+        } else {
+          onChange(next === 'on');
+        }
+      }}
+    />
   );
 }
 
@@ -805,40 +800,20 @@ function isValidClaudeTokens(text: string, defaults: UIEnvironmentConfig['claude
 function CloudAliasSelect({ id, value, options, disabled, onChange }: { id: string; value: string; options: string[]; disabled?: boolean; onChange: (value: string) => void }): React.ReactElement {
   const normalizedValue = value.trim();
   const normalizedOptions = options.map((option) => option.trim()).filter(Boolean);
-  const selectOptions = normalizedValue && !normalizedOptions.includes(normalizedValue) ? [normalizedValue, ...normalizedOptions] : normalizedOptions;
-  const selectDisabled = disabled || selectOptions.length === 0;
+  const selectOptions = normalizedValue && !normalizedOptions.includes(normalizedValue)
+    ? [normalizedValue, ...normalizedOptions]
+    : normalizedOptions;
   return (
-    <div className="grid gap-2">
-      <Label htmlFor={id}>Cloud alias</Label>
-      <select
-        id={id}
-        className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-[var(--radius)] border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-        value={normalizedValue}
-        disabled={selectDisabled}
-        onChange={(event) => onChange(event.target.value)}
-      >
-        {selectOptions.length === 0 ? (
-          <option value="">No cloud aliases configured</option>
-        ) : normalizedValue === '' ? (
-          <>
-            <option value="" disabled>
-              Select cloud alias
-            </option>
-            {selectOptions.map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            ))}
-          </>
-        ) : (
-          selectOptions.map((option) => (
-            <option key={option} value={option}>
-              {option}
-            </option>
-          ))
-        )}
-      </select>
-    </div>
+    <SelectField
+      id={id}
+      label="Cloud alias"
+      value={normalizedValue}
+      options={selectOptions.map((option) => ({ value: option, label: option }))}
+      placeholder="Select cloud alias"
+      emptyLabel="No cloud aliases configured"
+      disabled={disabled}
+      onChange={onChange}
+    />
   );
 }
 

--- a/erun-ui/frontend/src/components/app/SelectField.tsx
+++ b/erun-ui/frontend/src/components/app/SelectField.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+export interface SelectFieldOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export function SelectField({
+  id,
+  label,
+  value,
+  options,
+  placeholder,
+  emptyLabel,
+  disabled,
+  required,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  options: SelectFieldOption[];
+  placeholder?: string;
+  emptyLabel?: string;
+  disabled?: boolean;
+  required?: boolean;
+  onChange: (value: string) => void;
+}): React.ReactElement {
+  const noOptions = options.length === 0;
+  const triggerDisabled = disabled || noOptions;
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Select value={value || undefined} required={required} disabled={triggerDisabled} onValueChange={onChange}>
+        <SelectTrigger id={id} className="w-full">
+          <SelectValue placeholder={noOptions ? (emptyLabel ?? 'No options') : (placeholder ?? '')} />
+        </SelectTrigger>
+        {!noOptions && (
+          <SelectContent>
+            {options.map((item) => (
+              <SelectItem key={item.value} value={item.value} disabled={item.disabled}>
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        )}
+      </Select>
+    </div>
+  );
+}

--- a/erun-ui/frontend/src/components/app/TenantDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDialogView.tsx
@@ -10,6 +10,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { IconTooltip } from './IconTooltip';
+import { SelectField, type SelectFieldOption } from './SelectField';
 
 const dialogErrorClassName =
   'rounded-[var(--radius)] border border-[color-mix(in_oklch,var(--destructive)_36%,transparent)] bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] px-[11px] py-[9px] text-[13px] leading-[1.35] text-destructive [overflow-wrap:anywhere]';
@@ -72,7 +73,7 @@ function TenantDialogFields({ controller, state, environmentOptions, apiPlacehol
   return (
     <div className="grid gap-3">
       <ReadonlyField id="tenant-config-name" label="Tenant name" value={config.name} />
-      <SelectField id="tenant-config-defaultenvironment" label="Default environment" value={config.defaultEnvironment} options={environmentOptions} disabled={dialog.busy || environmentOptions.length === 0} onChange={(defaultEnvironment) => controller.updateTenantConfig({ defaultEnvironment })} />
+      <DefaultEnvironmentSelect id="tenant-config-defaultenvironment" label="Default environment" value={config.defaultEnvironment} options={environmentOptions} disabled={dialog.busy} onChange={(defaultEnvironment) => controller.updateTenantConfig({ defaultEnvironment })} />
       <TextField id="tenant-config-apiurl" label="API URL" value={config.apiUrl} disabled={dialog.busy} placeholder={apiPlaceholder} onChange={(apiUrl) => controller.updateTenantConfig({ apiUrl })} />
       <CloudAliasesField controller={controller} state={state} />
     </div>
@@ -191,31 +192,22 @@ function TextField({ id, label, value, disabled, placeholder, onChange }: { id: 
   );
 }
 
-function SelectField({ id, label, value, options, disabled, onChange }: { id: string; label: string; value: string; options: string[]; disabled?: boolean; onChange: (value: string) => void }): React.ReactElement {
+const TENANT_NOT_CONFIGURED = '__none__';
+
+function DefaultEnvironmentSelect({ id, label, value, options, disabled, onChange }: { id: string; label: string; value: string; options: string[]; disabled?: boolean; onChange: (value: string) => void }): React.ReactElement {
+  const fieldOptions: SelectFieldOption[] = options.length === 0
+    ? []
+    : [{ value: TENANT_NOT_CONFIGURED, label: 'Not configured' }, ...options.map((option) => ({ value: option, label: option }))];
   return (
-    <div className="grid gap-2">
-      <Label htmlFor={id}>{label}</Label>
-      <select
-        id={id}
-        className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-[var(--radius)] border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-        value={value}
-        disabled={disabled}
-        onChange={(event) => onChange(event.target.value)}
-      >
-        {options.length === 0 ? (
-          <option value="">No environments</option>
-        ) : (
-          <>
-            <option value="">Not configured</option>
-            {options.map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            ))}
-          </>
-        )}
-      </select>
-    </div>
+    <SelectField
+      id={id}
+      label={label}
+      value={value || TENANT_NOT_CONFIGURED}
+      options={fieldOptions}
+      emptyLabel="No environments"
+      disabled={disabled}
+      onChange={(next) => onChange(next === TENANT_NOT_CONFIGURED ? '' : next)}
+    />
   );
 }
 

--- a/erun-ui/frontend/src/components/ui/select.tsx
+++ b/erun-ui/frontend/src/components/ui/select.tsx
@@ -1,0 +1,188 @@
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}


### PR DESCRIPTION
## Summary

- Migrate 10 native `<select>` instances to the shadcn `Select` primitive across the four dialogs. Behavior preserved (options, labels, disabled states, required, onChange).
- Introduce `components/app/SelectField.tsx` as the app-owned wrapper that hides the trigger/value/content boilerplate, supports `emptyLabel` for empty option lists, and accepts `SelectFieldOption` records.
- Add the shadcn `Select` primitive via `yarn shadcn add select`. The `radix-ui` meta package already re-exports the underlying namespace, so no new dependency in `package.json`.
- Remove the now-unused local select wrappers (`RegionSelectInput`, `SelectInput`, two private `SelectField` helpers, `kubernetesContextOptions`, `claudeSelectClassName`).

Principles: NN/g #4 (Consistency & standards), AGENTS.md `Frontend Component Discovery` §59 (prefer shadcn primitives over native when an app-owned wrapper expresses the same interaction).

## Note about `yarn shadcn:check`

The script is intentionally **not** updated to include `select` in this PR. Adding `select` to the regeneration list surfaces pre-existing registry drift in `tabs.tsx` / `tooltip.tsx` / `command.tsx`: those files include a `\"use client\"` directive that shadcn 4.5.0 no longer generates for `rsc: false` projects. Fixing the drift is unrelated to the migration and will be folded into PR 8 (polish) once the drift is reconciled. The new `select.tsx` does match the registry as of this PR.

## Test plan

- [ ] Open the **Environment** dialog: Kubernetes-context picker shows the shadcn dropdown; loading state shows \"Loading contexts...\" placeholder; empty state shows \"No Kubernetes contexts\" with the trigger disabled.
- [ ] Open **GlobalConfig**: Default tenant defaults to \"Not configured\"; selecting a tenant updates state; clearing back via \"Not configured\" produces an empty string. Region, Instance type, Disk size selects render as shadcn dropdowns.
- [ ] In the cloud-context draft form: select Cloud provider \"erunpaas\" and verify default region label is London. Generated context name updates.
- [ ] Open the **Manage** dialog → AI tab: \"Use Mantle\" / \"Use Bedrock\" tri-state dropdowns work, default option label reflects the system default (\"Default (enabled)\" / \"Default (disabled)\").
- [ ] Manage dialog → General: Cloud alias dropdown renders with the shadcn Select; \"Select cloud alias\" placeholder when value is empty; \"No cloud aliases configured\" placeholder + disabled when no options.
- [ ] **Tenant** dialog: Default environment select; \"Not configured\" sentinel works.
- [ ] `yarn build`, `yarn shadcn:check`, `go test ./...` from `erun-ui` pass (validation host could not run yarn build due to a missing `@rolldown/binding-linux-arm64-gnu`; tsc and shadcn:check are green; Go test baseline is unchanged from main).

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)