### PR TITLE
UX: copy and jargon polish across dialogs

### DIFF
--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -186,19 +186,34 @@ function RuntimePodFields({ controller, dialog }: { controller: ERunUIController
 
 function EnvironmentCreateChecks({ controller, dialog }: { controller: ERunUIController; dialog: EnvironmentDialog }): React.ReactElement {
   return (
-    <div className="grid gap-2">
+    <div className="grid gap-3">
       <CheckboxField id="environment-default-tenant" label="Set as default tenant" checked={dialog.setDefaultTenant} disabled={dialog.busy} onCheckedChange={(setDefaultTenant) => controller.updateEnvironmentDialog({ setDefaultTenant })} />
       <CheckboxField id="environment-no-git" label="Initialize without Git checkout" checked={dialog.noGit} disabled={dialog.busy} onCheckedChange={(noGit) => controller.updateEnvironmentDialog({ noGit })} />
-      <CheckboxField id="environment-bootstrap" label="Create tenant devops module" checked={dialog.bootstrap} disabled={dialog.busy} onCheckedChange={(bootstrap) => controller.updateEnvironmentDialog({ bootstrap })} />
+      <CheckboxField
+        id="environment-bootstrap"
+        label="Create tenant DevOps repository"
+        helper="Generates the tenant's shared DevOps module — Helm values and deployment templates reused by every environment in this tenant."
+        checked={dialog.bootstrap}
+        disabled={dialog.busy}
+        onCheckedChange={(bootstrap) => controller.updateEnvironmentDialog({ bootstrap })}
+      />
     </div>
   );
 }
 
-function CheckboxField({ id, label, checked, disabled, onCheckedChange }: { id: string; label: string; checked: boolean; disabled: boolean; onCheckedChange: (checked: boolean) => void }): React.ReactElement {
+function CheckboxField({ id, label, helper, checked, disabled, onCheckedChange }: { id: string; label: string; helper?: string; checked: boolean; disabled: boolean; onCheckedChange: (checked: boolean) => void }): React.ReactElement {
+  const helperId = helper ? `${id}-helper` : undefined;
   return (
-    <div className="flex items-center gap-2">
-      <Checkbox id={id} checked={checked} disabled={disabled} onCheckedChange={(value) => onCheckedChange(value === true)} />
-      <Label htmlFor={id} className="text-sm font-normal">{label}</Label>
+    <div className="grid gap-1">
+      <div className="flex items-center gap-2">
+        <Checkbox id={id} checked={checked} disabled={disabled} onCheckedChange={(value) => onCheckedChange(value === true)} aria-describedby={helperId} />
+        <Label htmlFor={id} className="text-sm font-normal">{label}</Label>
+      </div>
+      {helper && (
+        <p id={helperId} className="text-[12px] leading-[1.4] text-muted-foreground pl-6">
+          {helper}
+        </p>
+      )}
     </div>
   );
 }

--- a/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
@@ -141,6 +141,7 @@ function CloudContextDraftForm({ controller, dialog }: { controller: ERunUIContr
         <SelectInput id="global-config-cloudcontext-instancetype" label="Instance type" value={dialog.cloudContextDraft.instanceType} options={['c8gd.2xlarge', 't4g.xlarge']} disabled={dialog.busy} onChange={(instanceType) => controller.updateCloudContextDraft({ instanceType })} />
         <SelectInput id="global-config-cloudcontext-disksize" label="Disk size" value={String(dialog.cloudContextDraft.diskSizeGb)} options={['100', '200']} disabled={dialog.busy} onChange={(diskSizeGb) => controller.updateCloudContextDraft({ diskSizeGb: Number(diskSizeGb) })} />
       </div>
+      <p className="text-[12px] leading-[1.4] text-muted-foreground">Region, instance type, and disk size are common choices vetted for ERun. Contact an admin to expand the list.</p>
       <CloudContextNameField controller={controller} dialog={dialog} generatedName={generated} />
     </div>
   );

--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -137,7 +137,7 @@ function GeneralTab({ controller, state }: { controller: ERunUIController; state
   const dialog = state.manageDialog;
   const config = dialog.config;
   const containerRegistrySuggestions = React.useMemo(
-    () => uniqueSuggestions([config.containerRegistry, ...loadSavedPastContainerRegistries(), 'ghcr.io/rihards-freimanis']),
+    () => uniqueSuggestions([config.containerRegistry, ...loadSavedPastContainerRegistries()]),
     [config.containerRegistry],
   );
   return (
@@ -242,7 +242,16 @@ function IdleStopFields({ controller, dialog }: { controller: ERunUIController; 
         helper="Format HH:MM-HH:MM. Default 08:00-20:00."
         onChange={(workingHours) => controller.updateManageConfig({ idle: { ...config.idle, workingHours } })}
       />
-      <TextField id="environment-config-idle-traffic" label="Idle SSH bytes" value={String(config.idle.idleTrafficBytes)} inputMode="numeric" disabled={dialog.busy} onChange={(idleTrafficBytes) => controller.updateManageConfig({ idle: { ...config.idle, idleTrafficBytes: parseIdleTrafficBytes(idleTrafficBytes) } })} />
+      <TextField
+        id="environment-config-idle-traffic"
+        label="Idle SSH activity threshold"
+        value={String(config.idle.idleTrafficBytes)}
+        inputMode="numeric"
+        disabled={dialog.busy}
+        placeholder="e.g. 0"
+        helper="SSH bytes per check below which the connection counts as idle. 0 disables the check."
+        onChange={(idleTrafficBytes) => controller.updateManageConfig({ idle: { ...config.idle, idleTrafficBytes: parseIdleTrafficBytes(idleTrafficBytes) } })}
+      />
     </div>
   );
 }

--- a/erun-ui/frontend/src/components/app/Sidebar.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.tsx
@@ -22,13 +22,13 @@ export function Sidebar({ controller, state }: { controller: ERunUIController; s
       <div className="flex items-center justify-between gap-2 pr-1.5 pb-2.5 pl-3.5">
         <span className="text-xs leading-[1.2] font-semibold tracking-normal text-muted-foreground uppercase">Environments</span>
         <div className="flex items-center gap-1">
-          <IconTooltip label="Manage ERun config">
+          <IconTooltip label="Open ERun settings">
             <Button
               className="size-[26px] flex-none text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground [&_svg]:size-4"
               type="button"
               variant="ghost"
               size="icon-xs"
-              aria-label="Manage ERun config"
+              aria-label="Open ERun settings"
               onClick={() => controller.openGlobalConfigDialog()}
             >
               <Settings />
@@ -291,7 +291,7 @@ function TenantSelectButton({ controller, tenantName, active, related }: { contr
 
 function TenantManageButton({ controller, tenantName, active }: { controller: ERunUIController; tenantName: string; active: boolean }): React.ReactElement {
   return (
-    <IconTooltip label="Manage tenant">
+    <IconTooltip label="Edit tenant settings">
       <Button
         type="button"
         className={cn(
@@ -301,7 +301,7 @@ function TenantManageButton({ controller, tenantName, active }: { controller: ER
         )}
         variant="ghost"
         size="icon"
-        aria-label={`Manage ${tenantName}`}
+        aria-label={`Edit ${tenantName} settings`}
         onClick={(event) => {
           event.stopPropagation();
           controller.openTenantDialog(tenantName);
@@ -352,7 +352,7 @@ function EnvironmentRow({
         <span className="min-w-0 truncate">{environmentName}</span>
         {busy && <LoaderCircle className="size-3.5 flex-none animate-spin text-current opacity-75" aria-hidden="true" />}
       </button>
-      <IconTooltip label="Manage environment">
+      <IconTooltip label="Edit environment settings">
         <Button
           type="button"
           className={cn(
@@ -361,7 +361,7 @@ function EnvironmentRow({
           )}
           variant="ghost"
           size="icon"
-          aria-label={`Manage ${tenantName} / ${environmentName}`}
+          aria-label={`Edit ${tenantName} / ${environmentName} settings`}
           onClick={(event) => {
             event.stopPropagation();
             controller.openManageDialog(selection);

--- a/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
@@ -236,7 +236,7 @@ function tenantDashboardSubtitle(tenant: UITenant | undefined, environmentName: 
   const parts = [
     environmentName,
     `${environmentCount} environment${environmentCount === 1 ? '' : 's'}`,
-    alias ? `primary ${alias}` : '',
+    alias ? `Primary cloud: ${alias}` : '',
   ].filter(Boolean);
   return parts.join(', ');
 }

--- a/erun-ui/frontend/src/components/app/TenantDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDialogView.tsx
@@ -129,7 +129,7 @@ function CloudAliasIdentity({ alias, issuer }: { alias: string; issuer: string }
         <Cloud className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
         <span className="truncate">{alias}</span>
       </div>
-      <div className="truncate text-xs text-muted-foreground">{hasIssuer ? issuer : 'OIDC issuer required before linking'}</div>
+      <div className="truncate text-xs text-muted-foreground">{hasIssuer ? issuer : 'No OIDC issuer yet — use the link button to set one up.'}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Rewrites implementation jargon as user-language across the dialogs and adds format hints where the current UI assumed users would already know the syntax. Each item maps to a finding from the UX audit.

- Container-registry suggestion list no longer ships with a personal handle baked in.
- Idle SSH activity threshold gets a clear label + helper text (zero disables the check). KiB unit conversion is deferred to keep this change focused on copy.
- "Create tenant devops module" → "Create tenant DevOps repository" with a helper line that explains what gets generated.
- Cloud-context draft form gains a one-line "Common choices vetted for ERun. Contact an admin to expand the list." hint, since Q2 in the UX plan confirmed the region/instance/disk allowlists are intentional.
- Tenant dashboard subtitle, OIDC-issuer empty hint, and three Sidebar tooltips/aria-labels are rewritten to the language users actually use ("Open ERun settings", "Edit tenant settings", etc.).
- `CheckboxField` in EnvironmentDialogView is extended with an optional `helper` prop, wired with `aria-describedby`. Same pattern PR #220 introduced for `TextField`.

## Stacking

This PR is stacked on **#220** (it reuses the TextField helper extension from that PR). After #220 merges, GitHub will retarget this PR to `main`. The Mantle/Bedrock helper-text item from the audit is **not** included here — it will land in a follow-up PR (#9 in the plan) once #222 (the Select migration) is on main, since that PR moves Mantle/Bedrock to the new SelectField wrapper.

## Principles applied

- NN/g #2 (Match between system and the real world) — implementation terms (\"Manage\", \"OIDC issuer required\", \"primary X\") replaced with action-oriented user-facing wording.
- NN/g #5 (Error prevention) — placeholder + helper text on the idle threshold field; \"common choices\" hint on the cloud draft form.
- AGENTS.md `Professional UX` §96 — keep internal provider, CLI, SDK, profile, session, or transport details out of the primary UI.

## Test plan

- [ ] Open the Environment dialog (\"Initialize new remote environment\"): the bootstrap checkbox now reads \"Create tenant DevOps repository\" with a helper line below.
- [ ] Open Manage dialog → Runtime → Idle stop: the third field now reads \"Idle SSH activity threshold\" with placeholder and helper text.
- [ ] Open the GlobalConfig dialog and create a cloud context: a small grey hint appears below the region/instance/disk grid.
- [ ] Open the tenant dashboard: subtitle ends with \"Primary cloud: <alias>\" instead of \"primary <alias>\".
- [ ] Open the Tenant dialog with a cloud alias missing OIDC issuer: the muted-text reads \"No OIDC issuer yet — use the link button to set one up.\"
- [ ] Hover sidebar gear icon: tooltip says \"Open ERun settings\". Hover tenant or environment row buttons: tooltip says \"Edit ... settings\".
- [ ] `tsc --noEmit`, `yarn shadcn:check`, `go test ./...` all green at the same baseline as main (no new errors introduced).

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)