### PR TITLE
UX: helper text for Mantle / Bedrock Claude backend selectors

### DIFF
--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -619,6 +619,7 @@ function ClaudeSettingsSection({ controller, dialog }: { controller: ERunUIContr
       <ClaudeBoolField
         id="environment-config-claude-mantle"
         label="Use Mantle"
+        helper="When enabled, Claude requests for this environment are routed through Mantle. Default uses the global setting."
         defaultValue={defaults.useMantle}
         value={claude.useMantle}
         disabled={disabled}
@@ -627,6 +628,7 @@ function ClaudeSettingsSection({ controller, dialog }: { controller: ERunUIContr
       <ClaudeBoolField
         id="environment-config-claude-bedrock"
         label="Use Bedrock"
+        helper="When enabled, Claude requests are routed through AWS Bedrock. Mantle and Bedrock can both be enabled; the runtime decides which to use per request."
         defaultValue={defaults.useBedrock}
         value={claude.useBedrock}
         disabled={disabled}
@@ -648,7 +650,7 @@ function ClaudeSettingsSection({ controller, dialog }: { controller: ERunUIContr
   );
 }
 
-function ClaudeBoolField({ id, label, defaultValue, value, disabled, onChange }: { id: string; label: string; defaultValue: boolean; value: boolean | undefined; disabled?: boolean; onChange: (value: boolean | undefined) => void }): React.ReactElement {
+function ClaudeBoolField({ id, label, defaultValue, value, helper, disabled, onChange }: { id: string; label: string; defaultValue: boolean; value: boolean | undefined; helper?: string; disabled?: boolean; onChange: (value: boolean | undefined) => void }): React.ReactElement {
   const selectValue = value === undefined ? 'default' : value ? 'on' : 'off';
   const defaultLabel = defaultValue ? 'Default (enabled)' : 'Default (disabled)';
   return (
@@ -661,6 +663,7 @@ function ClaudeBoolField({ id, label, defaultValue, value, disabled, onChange }:
         { value: 'on', label: 'Enabled' },
         { value: 'off', label: 'Disabled' },
       ]}
+      helper={helper}
       disabled={disabled}
       onChange={(next) => {
         if (next === 'default') {

--- a/erun-ui/frontend/src/components/app/SelectField.tsx
+++ b/erun-ui/frontend/src/components/app/SelectField.tsx
@@ -16,6 +16,7 @@ export function SelectField({
   options,
   placeholder,
   emptyLabel,
+  helper,
   disabled,
   required,
   onChange,
@@ -26,17 +27,19 @@ export function SelectField({
   options: SelectFieldOption[];
   placeholder?: string;
   emptyLabel?: string;
+  helper?: string;
   disabled?: boolean;
   required?: boolean;
   onChange: (value: string) => void;
 }): React.ReactElement {
   const noOptions = options.length === 0;
   const triggerDisabled = disabled || noOptions;
+  const helperId = helper ? `${id}-helper` : undefined;
   return (
     <div className="grid gap-2">
       <Label htmlFor={id}>{label}</Label>
       <Select value={value || undefined} required={required} disabled={triggerDisabled} onValueChange={onChange}>
-        <SelectTrigger id={id} className="w-full">
+        <SelectTrigger id={id} className="w-full" aria-describedby={helperId}>
           <SelectValue placeholder={noOptions ? (emptyLabel ?? 'No options') : (placeholder ?? '')} />
         </SelectTrigger>
         {!noOptions && (
@@ -49,6 +52,11 @@ export function SelectField({
           </SelectContent>
         )}
       </Select>
+      {helper && (
+        <p id={helperId} className="text-[12px] leading-[1.4] text-muted-foreground">
+          {helper}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a short helper line under the \"Use Mantle\" and \"Use Bedrock\" tri-state selects in the Manage dialog → AI tab. Per Q1 in the UX plan, the two backends are stackable, so the existing two-select shape stays — only the explanation is added.

Extends `components/app/SelectField` with an optional `helper` prop wired with `aria-describedby`. Same pattern PR #220 introduced for `TextField`.

## Stacking

Stacked on **#222** (the `SelectField` wrapper lives there). After #222 merges, GitHub will retarget this PR to `main`.

## Wording

Helper text is intentionally minimal — it describes what the toggle does without making claims about runtime priority that I don't have product-confirmed details on. If you have specific wording (\"Mantle takes priority over Bedrock when both are on\", or similar), I'll fold it in.

## Principles

- NN/g #2 (Match between system and the real world) — \"Use Mantle\" / \"Use Bedrock\" labels are implementation-flavored; helper text reframes them in terms of what they do.
- AGENTS.md `Professional UX` §96.

## Test plan

- [ ] Open Manage dialog → AI tab. Each of the two tri-state selects has a small grey help line below it.
- [ ] Tab to one of the selects: screen readers announce both label and helper (via `aria-describedby`).
- [ ] `tsc --noEmit`, `yarn shadcn:check`, `go test ./...` baseline-clean.

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)