### PR TITLE
UX: empty states for sidebar, GlobalConfig, dashboard, and Kubernetes context picker

### DIFF
--- a/erun-ui/frontend/src/components/app/EmptyState.tsx
+++ b/erun-ui/frontend/src/components/app/EmptyState.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export function EmptyState({
+  icon,
+  heading,
+  body,
+  action,
+  className,
+}: {
+  icon?: React.ReactElement;
+  heading: string;
+  body?: React.ReactNode;
+  action?: React.ReactNode;
+  className?: string;
+}): React.ReactElement {
+  return (
+    <div
+      className={cn(
+        'grid gap-2 rounded-[var(--radius)] border border-dashed border-border bg-muted/20 px-4 py-5 text-center',
+        className,
+      )}
+      role="status"
+    >
+      {icon && (
+        <div className="flex justify-center text-muted-foreground [&_svg]:size-5" aria-hidden="true">
+          {icon}
+        </div>
+      )}
+      <div className="text-sm font-medium text-foreground">{heading}</div>
+      {body && <div className="text-[13px] leading-[1.4] text-muted-foreground">{body}</div>}
+      {action && <div className="flex justify-center pt-1">{action}</div>}
+    </div>
+  );
+}

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -12,6 +12,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { EditableComboField, uniqueSuggestions } from './EditableComboField';
+import { EmptyState } from './EmptyState';
 import { RuntimeResourceControls } from './RuntimeResourceControls';
 import { SelectField } from './SelectField';
 import { VersionField } from './VersionField';
@@ -157,6 +158,17 @@ function EnvironmentCreateFields({ controller, dialog }: { controller: ERunUICon
 function KubernetesContextSelect({ controller, dialog }: { controller: ERunUIController; dialog: EnvironmentDialog }): React.ReactElement {
   const items = dialog.kubernetesContexts.map((context) => ({ value: context, label: context }));
   const placeholder = dialog.kubernetesContextsLoading ? 'Loading contexts...' : 'Select Kubernetes context';
+  if (!dialog.kubernetesContextsLoading && dialog.kubernetesContexts.length === 0) {
+    return (
+      <div className="grid gap-2">
+        <Label htmlFor="environment-kubernetes-context">Kubernetes context</Label>
+        <EmptyState
+          heading="No Kubernetes contexts found"
+          body="ERun reads contexts from your kubeconfig (~/.kube/config). Add a context with kubectl, then close and reopen this dialog to refresh the list."
+        />
+      </div>
+    );
+  }
   return (
     <SelectField
       id="environment-kubernetes-context"

--- a/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { EmptyState } from './EmptyState';
 import { SelectField, type SelectFieldOption } from './SelectField';
 import { StatusBadge, cloudProviderStatusTone } from './StatusBadge';
 
@@ -94,7 +95,21 @@ function CloudAliasesSection({ controller, dialog }: { controller: ERunUIControl
           </Button>
         </div>
       </div>
-      {providers.length === 0 ? <div className="px-0.5 py-2 text-[13px] leading-[1.35] text-muted-foreground">No cloud aliases configured</div> : <CloudAliasList controller={controller} dialog={dialog} />}
+      {providers.length === 0 ? (
+        <EmptyState
+          icon={<Cloud />}
+          heading="No cloud aliases yet"
+          body="Add a cloud account so ERun can deploy environments to it. AWS is the only provider supported today."
+          action={
+            <Button type="button" variant="outline" size="sm" disabled={dialog.busy} onClick={() => void controller.startAWSCloudInit()}>
+              {dialog.busyAction === 'cloud-provider-init' ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <Plus aria-hidden="true" />}
+              Add AWS account
+            </Button>
+          }
+        />
+      ) : (
+        <CloudAliasList controller={controller} dialog={dialog} />
+      )}
     </div>
   );
 }
@@ -139,7 +154,15 @@ function CloudContextsSection({ controller, dialog }: { controller: ERunUIContro
         </Button>
       </div>
       <CloudContextDraftForm controller={controller} dialog={dialog} />
-      {contexts.length === 0 ? <div className="px-0.5 py-2 text-[13px] leading-[1.35] text-muted-foreground">No cloud contexts configured</div> : <CloudContextList controller={controller} dialog={dialog} />}
+      {contexts.length === 0 ? (
+        <EmptyState
+          icon={<Server />}
+          heading="No cloud contexts yet"
+          body="Pick a cloud alias and region above, then click Init to provision a new context. Contexts are reusable across environments."
+        />
+      ) : (
+        <CloudContextList controller={controller} dialog={dialog} />
+      )}
     </div>
   );
 }

--- a/erun-ui/frontend/src/components/app/Sidebar.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import type { UICloudProviderStatus, UITenant } from '@/types';
+import { EmptyState } from './EmptyState';
 import { IconTooltip } from './IconTooltip';
 import { cloudProviderStatusTone } from './StatusBadge';
 
@@ -50,7 +51,19 @@ export function Sidebar({ controller, state }: { controller: ERunUIController; s
       </div>
       <div className="min-h-0 flex-1 overflow-auto pr-1">
         {state.tenants.length === 0 ? (
-          <div className="px-3.5 py-[18px] text-[13px] font-medium text-muted-foreground">No environments</div>
+          <div className="px-2 py-2">
+            <EmptyState
+              icon={<Plus />}
+              heading="No environments yet"
+              body="Initialize a remote environment to start working. You can also import an existing one from your kubeconfig."
+              action={
+                <Button type="button" size="sm" onClick={() => controller.openInitializeDialog()}>
+                  <Plus aria-hidden="true" />
+                  Initialize environment
+                </Button>
+              }
+            />
+          </div>
         ) : (
           state.tenants.map((tenant, index) => (
             <TenantGroup

--- a/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
@@ -6,6 +6,7 @@ import type { AppState } from '@/app/state';
 import type { UITenant, UITenantDashboardBuild, UITenantDashboardReview, UITenantDashboardUser } from '@/types';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { EmptyState } from './EmptyState';
 import { StatusBadge } from './StatusBadge';
 
 export function TenantDashboardView({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement | null {
@@ -67,7 +68,12 @@ function TenantDashboardTabContent({ data }: { data: AppState['tenantDashboard']
         <BuildsTable builds={view.builds} apiError={view.apiError} />
       </TabsContent>
       <TabsContent value="audit" className="min-h-0 overflow-auto">
-        <DashboardMessage message={view.auditLogMessage} />
+        <div className="mt-4">
+          <EmptyState
+            heading="Audit log coming soon"
+            body="Tenant audit events will surface here once the backend ships them. Check back in a future release."
+          />
+        </div>
       </TabsContent>
       <TabsContent value="api-log" className="min-h-0 overflow-auto">
         <APILogPanel log={view.apiLog} error={view.apiLogError} apiError={view.apiError} />


### PR DESCRIPTION
## Summary

Material's empty-state pattern (heading + body + optional next-action) replaces five flat \"No X\" muted lines that the audit flagged as low-discoverability. Adds `components/app/EmptyState.tsx` and uses it in:

- **Sidebar first-run** — the \"Initialize environment\" CTA was hidden in a small icon button in the section header. Now a real `Button` is part of the empty state.
- **GlobalConfig → Cloud aliases** — promotes the AWS-init action into the empty surface.
- **GlobalConfig → Cloud contexts** — explains what the init form above does.
- **Tenant dashboard → Audit log tab** — per Q4 in the UX plan: \"Audit log coming soon\" rather than a fake \"No audit events\" placeholder.
- **Environment dialog → Kubernetes context** — when the kubeconfig has no contexts, a recovery hint replaces the dead disabled select.

## Stacking

Stacked on **#222** (the Kubernetes-context empty state builds on the SelectField version of that picker). After #222 merges, GitHub will retarget this PR to `main`.

## Principles

- Material `Empty states` — short heading + body + clear next action.
- NN/g #1 (Visibility of system status) and #10 (Help users recognize from problem & solution).

## Test plan

- [ ] Launch with no environments configured: Sidebar shows the empty state with \"Initialize environment\" button.
- [ ] Open ERun settings with no cloud aliases: empty state shows \"Add AWS account\".
- [ ] Open ERun settings with no cloud contexts: empty state explains the init form.
- [ ] Open the tenant dashboard → Audit log tab: \"Audit log coming soon\".
- [ ] Open the New environment dialog with an empty kubeconfig: empty state replaces the K8s context dropdown.
- [ ] `tsc --noEmit`, `yarn shadcn:check`, `go test ./...` all green at the same baseline as main (no new errors).

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)