### PR TITLE
UX: review panel error recovery + tree a11y

### DIFF
--- a/erun-ui/frontend/src/components/app/DiffList.tsx
+++ b/erun-ui/frontend/src/components/app/DiffList.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
+import { AlertCircle, RefreshCw } from 'lucide-react';
 
 import type { ERunUIController } from '@/app/ERunUIController';
 import { compactDiffError, diffLineMark } from '@/app/diffUtils';
 import type { AppState } from '@/app/state';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import type { DiffFile, DiffHunk } from '@/types';
 
@@ -11,7 +13,7 @@ export function DiffList({ controller, state }: { controller: ERunUIController; 
     return <ReviewStatus>Loading diff...</ReviewStatus>;
   }
   if (state.diffError) {
-    return <ReviewStatus>{compactDiffError(state.diffError)}</ReviewStatus>;
+    return <DiffErrorAlert message={compactDiffError(state.diffError)} loading={state.diffLoading} onRetry={() => { void controller.loadReviewDiff(); }} />;
   }
   const files = state.diff?.files || [];
   if (files.length === 0) {
@@ -24,6 +26,25 @@ export function DiffList({ controller, state }: { controller: ERunUIController; 
       ))}
       <span className="sr-only">{controller.state.selectedDiffPath}</span>
     </>
+  );
+}
+
+export function DiffErrorAlert({ message, loading, onRetry }: { message: string; loading: boolean; onRetry: () => void }): React.ReactElement {
+  return (
+    <div
+      role="alert"
+      className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3 rounded-[var(--radius)] border border-destructive/40 bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] px-3 py-2.5 text-[13px] leading-[1.4]"
+    >
+      <AlertCircle className="mt-px size-[18px] flex-none text-destructive" aria-hidden="true" />
+      <div className="min-w-0 [overflow-wrap:anywhere] text-foreground">
+        <div className="font-semibold text-destructive">Could not load diff</div>
+        <div className="text-muted-foreground">{message}</div>
+      </div>
+      <Button type="button" variant="outline" size="sm" disabled={loading} onClick={onRetry}>
+        <RefreshCw aria-hidden="true" />
+        Retry
+      </Button>
+    </div>
   );
 }
 

--- a/erun-ui/frontend/src/components/app/ReviewPanel.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewPanel.tsx
@@ -9,7 +9,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
 import type { DiffCommit, DiffTreeNode } from '@/types';
-import { DiffList, ReviewStatus } from './DiffList';
+import { DiffErrorAlert, DiffList, ReviewStatus } from './DiffList';
 import { FileIcon } from './FileIcon';
 import { IconTooltip } from './IconTooltip';
 
@@ -234,7 +234,13 @@ function ChangedFileTree({ controller, state }: { controller: ERunUIController; 
     return <ReviewStatus>Loading...</ReviewStatus>;
   }
   if (state.diffError) {
-    return <ReviewStatus>{compactDiffError(state.diffError)}</ReviewStatus>;
+    return (
+      <DiffErrorAlert
+        message={compactDiffError(state.diffError)}
+        loading={state.diffLoading}
+        onRetry={() => { void controller.loadReviewDiff(); }}
+      />
+    );
   }
 
   const tree = visibleDiffTreeNodes(filterDiffTree(state.diff?.tree || [], state.diffFilter), state.collapsedDiffDirs);
@@ -270,6 +276,8 @@ function ChangedFileNode({
           type="button"
           className="flex h-[34px] w-full cursor-pointer items-center gap-2 rounded-[var(--radius)] border-0 bg-transparent py-0 pr-2.5 pl-[calc(8px+(var(--depth)*18px))] text-left text-sm leading-[1.2] font-medium text-foreground hover:bg-accent"
           style={style}
+          aria-expanded={!collapsed}
+          aria-label={`${node.name} directory`}
           onClick={() => controller.toggleDiffDirectory(node.path)}
         >
           <ChevronRight className={cn('size-4 flex-none text-current', !collapsed && 'rotate-90')} aria-hidden="true" />
@@ -279,16 +287,18 @@ function ChangedFileNode({
     );
   }
 
+  const selected = node.path === state.selectedDiffPath;
   return (
     <div className="flex flex-col">
       <button
         type="button"
         className={cn(
           'flex h-[34px] w-full cursor-pointer items-center gap-2 rounded-[var(--radius)] border-0 bg-transparent py-0 pr-2.5 pl-[calc(8px+(var(--depth)*18px))] text-left text-sm leading-[1.2] text-foreground hover:bg-accent',
-          node.path === state.selectedDiffPath && 'bg-primary text-primary-foreground hover:bg-primary',
+          selected && 'bg-primary text-primary-foreground hover:bg-primary',
         )}
         style={style}
         data-path={node.path}
+        aria-current={selected ? 'true' : undefined}
         onClick={() => controller.selectDiffPath(node.path)}
       >
         <FileIcon filePath={node.path} />


### PR DESCRIPTION
## Summary

- **Diff error recovery** — when `loadReviewDiff` fails, both the diff body and the changed-files tree now show a colocated alert with a Retry button (`controller.loadReviewDiff()`) instead of muted text.
- **Tree a11y** — directory rows expose `aria-expanded`; selected file button exposes `aria-current=\"true\"`. Previously expand/collapse and selection were communicated only by chevron rotation and primary-color background.

## Principles

- NN/g #9 (Help users recognize, diagnose, and recover from errors) — Retry button next to the error, not in the header.
- WCAG 4.1.2 (Name, Role, Value) — `aria-expanded` and `aria-current` make state observable to assistive tech.

## Test plan

- [ ] Force a diff load error (e.g. by checking out a branch and breaking git): the review pane shows an alert with a Retry button. Click → re-runs the load.
- [ ] Toggle a directory in the changed-files tree: `aria-expanded` flips between `true` and `false` (visible in DevTools).
- [ ] Click a file in the changed-files tree: `aria-current` is `\"true\"` on that button only.
- [ ] `tsc --noEmit`, `yarn shadcn:check`, `go test ./...` all green at the same baseline as main.

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)