### PR TITLE
UX: surface Local tag on sidebar environment rows

### DIFF
--- a/erun-ui/frontend/src/components/app/Sidebar.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.tsx
@@ -305,6 +305,10 @@ function EnvironmentRow({
   const selected = state.selected?.tenant === tenantName && state.selected?.environment === environmentName;
   const selection = { tenant: tenantName, environment: environmentName };
   const busy = environmentIsBusy(state, tenantName, environmentName);
+  const environment = state.tenants
+    .find((tenant) => tenant.name === tenantName)
+    ?.environments.find((env) => env.name === environmentName);
+  const isLocal = environment?.remote === false;
 
   return (
     <div
@@ -319,7 +323,7 @@ function EnvironmentRow({
           'flex h-8 min-w-0 flex-1 cursor-pointer items-center gap-1.5 border-0 bg-transparent py-0 pr-2 pl-10 text-left text-sm leading-[1.2] tracking-normal text-inherit',
           selected ? 'font-medium' : 'font-normal',
         )}
-        title={`${tenantName} / ${environmentName}`}
+        title={`${tenantName} / ${environmentName}${isLocal ? ' (local)' : ''}`}
         aria-current={selected ? 'page' : undefined}
         onClick={() => {
           void controller.openSelection(selection).catch((error: unknown) => {
@@ -328,6 +332,19 @@ function EnvironmentRow({
         }}
       >
         <span className="min-w-0 truncate">{environmentName}</span>
+        {isLocal && (
+          <span
+            className={cn(
+              'flex-none rounded-[calc(var(--radius)-4px)] border px-1 py-px text-[10px] font-medium uppercase leading-none tracking-wide',
+              selected
+                ? 'border-primary-foreground/40 text-primary-foreground/85'
+                : 'border-border text-muted-foreground',
+            )}
+            aria-label="Local environment"
+          >
+            Local
+          </span>
+        )}
         {busy && <LoaderCircle className="size-3.5 flex-none animate-spin text-current opacity-75" aria-hidden="true" />}
       </button>
       <IconTooltip label="Manage environment">


### PR DESCRIPTION
## Summary

Adds a small \"LOCAL\" tag to environment rows in the sidebar whose `remote` field is false. Remote environments stay unmarked (the common case). Users can now tell local from remote at a glance.

Tag styling: small uppercase pill, border-only, muted color in the unselected state, lighter border in the selected (primary-background) state to stay readable. Sits inline at the right end of the row name; busy spinner stays where it was.

Scope is intentionally small. Richer per-row metadata (cloud-context running/stopped, login expired) needs additional state plumbed through to the sidebar — left for a follow-up.

## Principles

- AGENTS.md `Professional UX` §91 — collection rows should show the object name plus relevant metadata.
- NN/g #1 (Visibility of system status).

## Test plan

- [ ] Configure a local environment (no kubeconfig needed): the row shows a `LOCAL` tag.
- [ ] Configure a remote environment: no tag.
- [ ] Select a local environment: tag stays readable on the primary-color background.
- [ ] Trigger the busy spinner (e.g. by clicking deploy): the spinner appears next to the tag, layout doesn't break.
- [ ] `tsc --noEmit`, `yarn shadcn:check`, `go test ./...` all green at the same baseline as main.

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)