### PR TITLE
UX polish: visible dialog descriptions, region humanization, sync visibility

### DIFF
--- a/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
@@ -40,7 +40,7 @@ export function GlobalConfigDialogView({ controller, state }: { controller: ERun
         >
           <DialogHeader>
             <DialogTitle>ERun settings</DialogTitle>
-            <DialogDescription className="sr-only">Manage default tenant and cloud aliases.</DialogDescription>
+            <DialogDescription>Default tenant, cloud aliases, and cloud contexts shared across the app.</DialogDescription>
           </DialogHeader>
           <GlobalConfigBody controller={controller} state={state} />
           <DialogError error={dialog.error} />
@@ -188,8 +188,8 @@ function CloudContextDraftForm({ controller, dialog }: { controller: ERunUIContr
           label="Region"
           value={dialog.cloudContextDraft.region || 'eu-west-2'}
           options={[
-            { value: 'eu-west-2', label: 'London' },
-            { value: 'eu-west-1', label: 'Ireland' },
+            { value: 'eu-west-2', label: cloudRegionLabel('eu-west-2') },
+            { value: 'eu-west-1', label: cloudRegionLabel('eu-west-1') },
           ]}
           disabled={dialog.busy}
           onChange={(region) => controller.updateCloudContextDraft({ region })}
@@ -348,15 +348,27 @@ function cloudContextSummary(context: { cloudProviderAlias: string; region: stri
   return parts.join(' - ');
 }
 
+const AWS_REGION_NAMES: Record<string, string> = {
+  'eu-west-1': 'Ireland',
+  'eu-west-2': 'London',
+  'eu-west-3': 'Paris',
+  'eu-central-1': 'Frankfurt',
+  'eu-north-1': 'Stockholm',
+  'eu-south-1': 'Milan',
+  'us-east-1': 'N. Virginia',
+  'us-east-2': 'Ohio',
+  'us-west-1': 'N. California',
+  'us-west-2': 'Oregon',
+  'ap-northeast-1': 'Tokyo',
+  'ap-northeast-2': 'Seoul',
+  'ap-south-1': 'Mumbai',
+  'ap-southeast-1': 'Singapore',
+  'ap-southeast-2': 'Sydney',
+};
+
 function cloudRegionLabel(region: string): string {
-  switch (region) {
-    case 'eu-west-2':
-      return 'London';
-    case 'eu-west-1':
-      return 'Ireland';
-    default:
-      return region;
-  }
+  const name = AWS_REGION_NAMES[region];
+  return name ? `${region} (${name})` : region;
 }
 
 function generatedContextName(provider: { alias: string; username?: string; accountId?: string } | undefined, region: string, contexts: Array<{ name: string; kubernetesContext: string }>): string {

--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -64,7 +64,7 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
         >
           <DialogHeader>
             <DialogTitle>{selection ? `${selection.tenant}-${selection.environment}` : 'Environment'}</DialogTitle>
-            <DialogDescription className="sr-only">Edit environment settings, run diagnostics, and delete the selected environment.</DialogDescription>
+            <DialogDescription>Edit environment configuration, deploy a different runtime version, run diagnostics, or delete the environment.</DialogDescription>
           </DialogHeader>
           <ManageDialogContent controller={controller} state={state} confirmationRef={confirmationRef} expected={expected} confirmingDelete={confirmingDelete} />
           <DialogError error={dialog.error} />
@@ -325,7 +325,7 @@ function LocalSyncFolderField({ controller, dialog, error }: { controller: ERunU
 function WorkspaceSyncStatus({ sshd }: { sshd: ManageDialog['config']['sshd'] }): React.ReactElement | null {
   const status = String(sshd.workspaceSyncStatus || '').trim();
   const message = String(sshd.workspaceSyncStatusMessage || '').trim();
-  if (!status || status === 'stopped') {
+  if (!status) {
     return null;
   }
   return (


### PR DESCRIPTION
## Summary

Final UX polish PR picking up small items from the audit's P2 list. Each item is independent.

- **Visible dialog descriptions** — ERun settings and Manage environment dialogs replace their `sr-only` descriptions with visible subtitles. Material `Dialogs` guidance: dialogs with multi-step content should have a one-line subtitle.
- **Region humanization** — the existing partial lookup (London / Ireland) is replaced with a full AWS-region table covering 15 common regions. The label format is now \"<region-code> (<city>)\" so the technical code and the friendly name are both visible. Unknown regions fall through to the raw code. The Region dropdown options use the same helper, so what's in the dropdown matches what's shown after selection.
- **Workspace sync status visibility** — the SSH sync status panel no longer hides on `stopped`. Users can now confirm the daemon is in fact stopped, not just \"silently nothing\".

## Out of scope (each is its own follow-up)

- **Doctor inline result line** — needs a public controller method and a stored last-doctor outcome on the manage state. Worth a small dedicated PR.
- **Refresh-button success toasts** — needs explicit success callbacks at each refresh path (sidebar, dashboard, GlobalConfig).
- **`.dark` token cleanup (Q3)** — `.dark` tokens exist in `theme.css` but no `.dark` class is ever applied. Decision deferred until product confirms whether dark theme is intentional. Removing the tokens is reversible if the answer is \"future use\".

## Principles

- NN/g #1 (Visibility of system status) — workspace sync visible when stopped.
- NN/g #2 (Match between system and the real world) — region codes paired with city names.
- NN/g #4 (Consistency & standards) — same humanization in dropdown options and after-selection display.
- Material `Dialogs` — visible subtitle.

## Test plan

- [ ] Open ERun settings: subtitle reads \"Default tenant, cloud aliases, and cloud contexts shared across the app.\"
- [ ] Open the Manage dialog on any environment: subtitle reads \"Edit environment configuration, deploy a different runtime version, run diagnostics, or delete the environment.\"
- [ ] Open ERun settings → cloud-context draft form: Region dropdown shows \"eu-west-2 (London)\" and \"eu-west-1 (Ireland)\". After selecting, the cloud-context list summary shows the same humanized format.
- [ ] In Manage dialog → SSH tab with workspace sync stopped: a small status panel is visible indicating \"stopped\" (was hidden before).
- [ ] `tsc --noEmit`, `yarn shadcn:check`, `go test ./...` all green at the same baseline as main.

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)