### PR TITLE
Fix shadcn registry drift; add select to shadcn:check

### DIFF
--- a/erun-ui/frontend/package.json
+++ b/erun-ui/frontend/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "shadcn": "shadcn",
-    "shadcn:check": "shadcn add button checkbox command dialog input label popover tabs tooltip --overwrite --yes && git diff --exit-code -- src/components/ui src/lib/utils.ts src/styles/theme.css components.json package.json yarn.lock"
+    "shadcn:check": "shadcn add button checkbox command dialog input label popover select tabs tooltip --overwrite --yes && git diff --exit-code -- src/components/ui src/lib/utils.ts src/styles/theme.css components.json package.json yarn.lock"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.10.0",

--- a/erun-ui/frontend/src/components/ui/command.tsx
+++ b/erun-ui/frontend/src/components/ui/command.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 import { Command as CommandPrimitive } from "cmdk"
 import { SearchIcon } from "lucide-react"

--- a/erun-ui/frontend/src/components/ui/tabs.tsx
+++ b/erun-ui/frontend/src/components/ui/tabs.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Tabs as TabsPrimitive } from "radix-ui"

--- a/erun-ui/frontend/src/components/ui/tooltip.tsx
+++ b/erun-ui/frontend/src/components/ui/tooltip.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import { Tooltip as TooltipPrimitive } from "radix-ui"
 


### PR DESCRIPTION
## Summary

Realigns three shadcn-generated components with the pinned shadcn 4.5 registry and finally adds `select` to the `yarn shadcn:check` script.

- `tabs.tsx` and `command.tsx` gain a leading \`\"use client\"\` directive (shadcn 4.5 emits it).
- `tooltip.tsx` loses its leading \`\"use client\"\` directive (shadcn 4.5 no longer emits it for `rsc: false` projects).
- `package.json` script now includes `select` in the regeneration list, so the primitive introduced in #222 is validated.

The \`\"use client\"\` directive is a Next.js RSC affordance with no effect in this Vite/non-RSC project — this is a behavior-preserving cleanup.

## Why now

PR #222 (Select migration) deferred the script update because adding `select` to the regeneration list surfaced this drift on every clean `yarn shadcn:check` run. Now that the drift is resolved, `select` can join the validation list.

## Test plan

- [ ] `yarn shadcn:check` from `erun-ui/frontend` exits 0 on a clean tree.
- [ ] App renders with no visual change (the \`\"use client\"\` directive has no effect at runtime in this project).
- [ ] `tsc --noEmit` baseline-clean.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)