### PR TITLE
UX: success toasts for refresh-style buttons

### DIFF
--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -456,6 +456,14 @@ export class ERunUIController {
     }
   }
 
+  async refreshTenantDashboard(): Promise<void> {
+    const tenant = this.state.tenantDashboard.tenant;
+    await this.loadTenantDashboard(tenant);
+    if (this.state.tenantDashboard.tenant === tenant && !this.state.tenantDashboard.error) {
+      this.showNotification('success', 'Dashboard refreshed.');
+    }
+  }
+
   async openSelection(selection: UISelection): Promise<void> {
     this.state.tenantDashboard = defaultTenantDashboard();
     const runSelection = { ...selection, debug: this.state.debugOpen || undefined };
@@ -1288,6 +1296,16 @@ export class ERunUIController {
         this.emit();
         this.scheduleReviewDiffRefresh();
       }
+    }
+  }
+
+  async refreshReviewDiff(): Promise<void> {
+    if (!this.state.selected) {
+      return;
+    }
+    await this.loadReviewDiff();
+    if (!this.state.diffError) {
+      this.showNotification('success', 'Diff refreshed.');
     }
   }
 

--- a/erun-ui/frontend/src/app/globalConfigWorkflow.ts
+++ b/erun-ui/frontend/src/app/globalConfigWorkflow.ts
@@ -162,6 +162,7 @@ export class GlobalConfigWorkflow {
         error: '',
       };
       this.deps.emit();
+      this.deps.showNotification('success', 'Cloud aliases refreshed.');
     } catch (error) {
       const message = readError(error);
       this.state.globalConfigDialog = {
@@ -189,6 +190,7 @@ export class GlobalConfigWorkflow {
         error: '',
       };
       this.deps.emit();
+      this.deps.showNotification('success', 'Cloud contexts refreshed.');
     } catch (error) {
       const message = readError(error);
       this.state.globalConfigDialog = {

--- a/erun-ui/frontend/src/components/app/ReviewPanel.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewPanel.tsx
@@ -214,7 +214,7 @@ function ChangedFilesHeader({ controller, state }: { controller: ERunUIControlle
             aria-label="Refresh diff"
             disabled={state.diffLoading}
             onClick={() => {
-              void controller.loadReviewDiff();
+              void controller.refreshReviewDiff();
             }}
           >
             <RefreshCw />

--- a/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
@@ -24,7 +24,7 @@ export function TenantDashboardView({ controller, state }: { controller: ERunUIC
             <h1 className="truncate text-[20px] font-semibold leading-tight tracking-normal">{dashboard.tenant}</h1>
             <p className="truncate text-sm text-muted-foreground">{tenantDashboardSubtitle(tenant, environmentName)}</p>
           </div>
-          <Button type="button" variant="outline" size="sm" disabled={dashboard.loading} onClick={() => { void controller.loadTenantDashboard(); }}>
+          <Button type="button" variant="outline" size="sm" disabled={dashboard.loading} onClick={() => { void controller.refreshTenantDashboard(); }}>
             {dashboard.loading ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <RefreshCw aria-hidden="true" />}
             Refresh
           </Button>


### PR DESCRIPTION
## Summary

Refresh actions in four places now confirm success with a short toast (auto-dismissing after 3.2s) using the existing `showNotification` channel.

| Surface | Toast |
|---|---|
| ERun settings → Cloud aliases Refresh | \"Cloud aliases refreshed.\" |
| ERun settings → Cloud contexts Refresh | \"Cloud contexts refreshed.\" |
| Tenant dashboard Refresh | \"Dashboard refreshed.\" |
| Review panel Refresh icon | \"Diff refreshed.\" |

Auto-loads (opening the dashboard, opening a selection while review is open) do **not** toast — only explicit Refresh clicks do. This is achieved by:

- `globalConfigWorkflow.refreshCloud*` are only called from the Refresh icon → toast added inline.
- `loadTenantDashboard` keeps its silent semantics; a new `refreshTenantDashboard()` wraps it for the user-facing button.
- `loadReviewDiff` keeps its `silent` semantics; a new `refreshReviewDiff()` wraps it for the user-facing button. The in-error \"Retry\" button on the diff alert keeps calling `loadReviewDiff` directly because that's recovery, not refresh.

## Principles

- NN/g #1 (Visibility of system status).
- Reuses existing notification infrastructure; no new UI primitives.

## Test plan

- [ ] Open ERun settings, click the Refresh icon next to Cloud aliases → toast appears, auto-dismisses.
- [ ] Same with Cloud contexts.
- [ ] Open the tenant dashboard, click Refresh → toast appears.
- [ ] Confirm that *opening* the tenant dashboard does NOT toast (auto-load).
- [ ] Open the review panel, click the Refresh icon in the changed-files header → toast appears.
- [ ] Confirm switching between environments while review is open does NOT toast.
- [ ] Force a diff load error and click Retry on the alert → no toast (it's recovery, not refresh).
- [ ] `tsc --noEmit`, `yarn shadcn:check`, `go test ./...` baseline-clean.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)