### PR TITLE
Clean up pre-existing TypeScript baseline errors

### DIFF
--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -1111,7 +1111,7 @@ export class ERunUIController {
     this.state.tenantDialog = { ...dialog, busy: true, busyAction: 'save', busyTarget: '', error: '' };
     this.emit();
     try {
-      const result = (await SaveTenantConfig(dialog.config)) as UITenantConfig;
+      const result = (await SaveTenantConfig(dialog.config as Parameters<typeof SaveTenantConfig>[0])) as UITenantConfig;
       this.applySavedTenantConfig(result);
       this.state.tenantDialog = {
         ...this.state.tenantDialog,

--- a/erun-ui/frontend/src/app/globalConfigWorkflow.ts
+++ b/erun-ui/frontend/src/app/globalConfigWorkflow.ts
@@ -24,6 +24,7 @@ import type {
   UICloudContextInitInput,
   UICloudContextStatus,
   UIERunConfig,
+  UISelection,
 } from '@/types';
 
 interface TerminalSize {

--- a/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
@@ -127,7 +127,7 @@ function CloudAliasList({ controller, dialog }: { controller: ERunUIController; 
   );
 }
 
-function CloudAliasSummary({ provider }: { provider: GlobalConfigDialog['config']['cloudProviders'][number] }): React.ReactElement {
+function CloudAliasSummary({ provider }: { provider: NonNullable<GlobalConfigDialog['config']['cloudProviders']>[number] }): React.ReactElement {
   return (
     <div className="grid min-w-0 gap-1">
       <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
@@ -252,7 +252,7 @@ function CloudContextList({ controller, dialog }: { controller: ERunUIController
   );
 }
 
-function CloudContextSummary({ context }: { context: GlobalConfigDialog['config']['cloudContexts'][number] }): React.ReactElement {
+function CloudContextSummary({ context }: { context: NonNullable<GlobalConfigDialog['config']['cloudContexts']>[number] }): React.ReactElement {
   return (
     <div className="grid min-w-0 gap-1">
       <div className="flex min-w-0 items-center gap-2 text-sm font-medium">

--- a/erun-ui/frontend/src/components/app/Sidebar.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.tsx
@@ -164,7 +164,7 @@ function primaryCloudProviderStatus(state: AppState, alias: string): UICloudProv
   return state.cloudProviders.find((candidate) => candidate.alias === alias) || { alias, provider: '', status: 'unknown' };
 }
 
-function CloudAliasPopoverRow({ icon, label, muted }: { icon: React.ReactElement; label: string; muted?: boolean }): React.ReactElement {
+function CloudAliasPopoverRow({ icon, label, muted }: { icon: React.ReactElement<{ className?: string; 'aria-hidden'?: boolean }>; label: string; muted?: boolean }): React.ReactElement {
   return (
     <div className={cn('flex min-w-0 items-center gap-2 rounded-sm px-2 py-1.5 text-sm', muted && 'text-muted-foreground')}>
       {React.cloneElement(icon, { className: 'size-4 shrink-0', 'aria-hidden': true })}

--- a/erun-ui/frontend/src/components/app/TenantDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDialogView.tsx
@@ -108,7 +108,7 @@ function CloudAliasesField({ controller, state }: { controller: ERunUIController
   );
 }
 
-function CloudAliasRow({ controller, dialog, config, provider, checked, primary, withBorder }: { controller: ERunUIController; dialog: AppState['tenantDialog']; config: AppState['tenantDialog']['config']; provider: AppState['tenantDialog']['config']['cloudProviders'][number]; checked: boolean; primary: string; withBorder: boolean }): React.ReactElement {
+function CloudAliasRow({ controller, dialog, config, provider, checked, primary, withBorder }: { controller: ERunUIController; dialog: AppState['tenantDialog']; config: AppState['tenantDialog']['config']; provider: NonNullable<AppState['tenantDialog']['config']['cloudProviders']>[number]; checked: boolean; primary: string; withBorder: boolean }): React.ReactElement {
   const alias = provider.alias.trim();
   const hasIssuer = Boolean(provider.oidcIssuerUrl?.trim());
   const oidcBusy = dialog.busy && dialog.busyAction === 'cloud-oidc' && dialog.busyTarget === alias;


### PR DESCRIPTION
## Summary

Fixes the six tsc errors that have been baseline-clean on `main` since I started this session. They don't break the bundler — vite/rolldown isn't a strict type-checker — but they hide real regressions during local validation.

| File | Fix |
|---|---|
| `ERunUIController.ts:1114` | Cast `dialog.config` to `Parameters<typeof SaveTenantConfig>[0]`, mirroring the existing pattern at `manageEnvironmentWorkflow.ts:329` |
| `globalConfigWorkflow.ts:43` | Add missing `UISelection` import |
| `GlobalConfigDialogView.tsx:130, :255` | Wrap `cloudProviders[number]` / `cloudContexts[number]` with `NonNullable<...>` |
| `TenantDialogView.tsx:111` | Same `NonNullable<...>` wrap |
| `Sidebar.tsx:170` | Tighten `icon` prop on `CloudAliasPopoverRow` to `React.ReactElement<{ className?, 'aria-hidden'? }>` so React 19's stricter `cloneElement` overload signatures accept the call |

No app behavior changes. The Wails-generated `uiTenantConfig` is a class with a `convertValues` helper; the hand-defined `UITenantConfig` interface lacks that method. At runtime Wails serializes plain objects so the cast is purely a TS-level fix.

## Validation

- `tsc --noEmit`: now exits 0.
- `yarn shadcn:check`: passes.
- `go test ./...`: same pre-existing workspace-sync failure as `main` (unrelated to TS changes).

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)