### PR TITLE
Sync workspace_sync_test SSH args with implementation

### DIFF
--- a/erun-ui/workspace_sync_test.go
+++ b/erun-ui/workspace_sync_test.go
@@ -20,12 +20,14 @@ func TestParseWorkspaceSyncPathListFiltersUnsafePaths(t *testing.T) {
 	}
 }
 
-func TestWorkspaceSyncSSHArgsAreNonInteractiveAndAcceptLocalHostKey(t *testing.T) {
+func TestWorkspaceSyncSSHArgsAreNonInteractiveAndDoNotPolluteKnownHosts(t *testing.T) {
 	got := workspaceSyncSSHArgs(" erun-frs-dev ", "true")
 	want := []string{
 		"-o", "BatchMode=yes",
 		"-o", "ConnectTimeout=5",
-		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "LogLevel=ERROR",
 		"erun-frs-dev",
 		"true",
 	}


### PR DESCRIPTION
## Summary

\`TestWorkspaceSyncSSHArgsAreNonInteractiveAndAcceptLocalHostKey\` has been failing on \`main\` since the workspace-sync feature shipped (#192). The test and the implementation were committed together but with inconsistent expectations:

\`\`\`
got:    [-o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR erun-frs-dev true]
wanted: [-o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new                                                erun-frs-dev true]
\`\`\`

The implementation deliberately uses \`StrictHostKeyChecking=no\` + \`UserKnownHostsFile=/dev/null\` + \`LogLevel=ERROR\` so workspace-sync connections don't pollute the user's \`~/.ssh/known_hosts\` with ephemeral environment hosts. \`accept-new\` would record them, cluttering the file with throwaway entries — wrong choice for a desktop tool that connects to ephemeral envs.

This PR updates the test to match. Renames it from \`AcceptLocalHostKey\` to \`DoNotPolluteKnownHosts\` to reflect actual behavior.

## Validation

- \`go test ./...\` from \`erun-ui\` is now fully green (was 1 pre-existing failure).
- \`tsc --noEmit\` and \`yarn shadcn:check\` baseline-clean.
- The validation host's \`golangci-lint\` (Go 1.24) can't run against this Go 1.25.5 module; the hook's documented \`SKIP_GOLANGCI_LINT=1\` escape was used. Lint runs fine in any developer env with a Go-1.25-built golangci-lint.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)