### PR TITLE
UX: doctor inline result line + remove leftover personal handle

### DIFF
--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -177,6 +177,7 @@ export class ERunUIController {
     debugOpen: loadSavedDebugOpen(),
     debugHeight: loadSavedDebugHeight(),
     debugOutput: '',
+    lastDoctorBySelection: {},
   };
 
   private readonly subscribers = new Set<() => void>();
@@ -676,7 +677,7 @@ export class ERunUIController {
 
   openInitializeDialog(): void {
     const tenantDefault = this.state.selected?.tenant || this.state.tenants[0]?.name || '';
-    const containerRegistryDefault = loadSavedPastContainerRegistries()[0] || 'ghcr.io/rihards-freimanis';
+    const containerRegistryDefault = loadSavedPastContainerRegistries()[0] || '';
     this.state.environmentDialog = {
       open: true,
       actionMode: 'init',
@@ -1826,6 +1827,7 @@ export class ERunUIController {
     const reason = this.terminalExitReason(payload, selections);
     const failedOutput = this.recordTerminalExit(payload, reason, selections);
     this.dropExitedSessionFromTabs(payload.sessionId, selections.openSelection);
+    this.recordDoctorOutcome(payload, selections);
 
     if (selections.initSelection || selections.deploySelection || selections.sshdInitSelection) {
       await this.reloadStateAfterEnvironmentChange();
@@ -1842,6 +1844,24 @@ export class ERunUIController {
       return;
     }
     this.showTerminalMessage(reason);
+  }
+
+  private recordDoctorOutcome(payload: TerminalExitPayload, selections: TerminalExitSelections): void {
+    const selection = selections.doctorSelection;
+    if (!selection) {
+      return;
+    }
+    const key = selectionKey(selection);
+    const reason = (payload.reason || '').trim();
+    this.state.lastDoctorBySelection = {
+      ...this.state.lastDoctorBySelection,
+      [key]: {
+        ranAt: Date.now(),
+        success: !reason,
+        message: reason,
+      },
+    };
+    this.emit();
   }
 
   private takeTerminalExitSelections(sessionId: number): TerminalExitSelections {

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -127,6 +127,12 @@ export interface TerminalTab {
   slot: number;
 }
 
+export interface DoctorOutcome {
+  ranAt: number;
+  success: boolean;
+  message: string;
+}
+
 export interface AppState {
   tenants: UITenant[];
   cloudProviders: UICloudProviderStatus[];
@@ -170,6 +176,7 @@ export interface AppState {
   debugOpen: boolean;
   debugHeight: number;
   debugOutput: string;
+  lastDoctorBySelection: Record<string, DoctorOutcome>;
 }
 
 export const defaultEnvironmentDialog = (): EnvironmentDialogState => ({
@@ -184,7 +191,7 @@ export const defaultEnvironmentDialog = (): EnvironmentDialogState => ({
   resourceStatus: null,
   resourceStatusLoading: false,
   runtimePod: defaultRuntimePodConfig(),
-  containerRegistry: 'ghcr.io/rihards-freimanis',
+  containerRegistry: '',
   noGit: false,
   bootstrap: false,
   setDefaultTenant: true,

--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -6,7 +6,7 @@ import { readError } from '@/app/errors';
 import { runtimeResourceLimitMessage } from '@/app/runtimeResources';
 import type { AppState } from '@/app/state';
 import { loadSavedPastContainerRegistries } from '@/app/storage';
-import { deleteConfirmationValue, normalizeDialogValue, versionChoiceImage, versionChoiceKind, versionChoiceLabel } from '@/app/versionSuggestions';
+import { deleteConfirmationValue, normalizeDialogValue, selectionKey, versionChoiceImage, versionChoiceKind, versionChoiceLabel } from '@/app/versionSuggestions';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
@@ -114,7 +114,7 @@ function ManageDialogContent({ controller, state, confirmationRef, expected, con
           </TabsContent>
           <TabsContent value="ssh" className="grid gap-3">
             <SSHAccessSection controller={controller} dialog={dialog} />
-            <DiagnosticsSection controller={controller} dialog={dialog} />
+            <DiagnosticsSection controller={controller} dialog={dialog} state={state} />
           </TabsContent>
         </div>
       </Tabs>
@@ -257,7 +257,8 @@ function IdleStopFields({ controller, dialog }: { controller: ERunUIController; 
   );
 }
 
-function DiagnosticsSection({ controller, dialog }: { controller: ERunUIController; dialog: ManageDialog }): React.ReactElement {
+function DiagnosticsSection({ controller, dialog, state }: { controller: ERunUIController; dialog: ManageDialog; state: AppState }): React.ReactElement {
+  const lastDoctor = dialog.selection ? state.lastDoctorBySelection[selectionKey(dialog.selection)] : undefined;
   return (
     <div className="grid gap-2 rounded-[var(--radius)] border border-border p-3">
       <div className="flex items-center justify-between gap-3">
@@ -267,8 +268,49 @@ function DiagnosticsSection({ controller, dialog }: { controller: ERunUIControll
           Run Doctor
         </Button>
       </div>
+      {lastDoctor && <DoctorLastRun outcome={lastDoctor} />}
     </div>
   );
+}
+
+function DoctorLastRun({ outcome }: { outcome: AppState['lastDoctorBySelection'][string] }): React.ReactElement {
+  const ago = relativeTimeFromNow(outcome.ranAt);
+  const tone: 'success' | 'destructive' = outcome.success ? 'success' : 'destructive';
+  const summary = outcome.success ? 'all checks passed' : (outcome.message || 'doctor failed');
+  return (
+    <div
+      role={outcome.success ? 'status' : 'alert'}
+      className={cn(
+        'grid grid-cols-[auto_minmax(0,1fr)] items-start gap-2 rounded-[var(--radius)] border px-3 py-2 text-[13px] leading-[1.4]',
+        tone === 'success'
+          ? 'border-green-600/35 bg-green-600/10 text-foreground'
+          : 'border-destructive/40 bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] text-foreground',
+      )}
+    >
+      <span className={cn('mt-px size-1.5 rounded-full', tone === 'success' ? 'bg-green-600' : 'bg-destructive')} aria-hidden="true" />
+      <span className="min-w-0 [overflow-wrap:anywhere]">
+        <span className="font-medium">Last run {ago}</span>
+        <span className="text-muted-foreground"> — {summary}</span>
+      </span>
+    </div>
+  );
+}
+
+function relativeTimeFromNow(timestamp: number): string {
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (seconds < 60) {
+    return 'just now';
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes} min ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours} h ago`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days} d ago`;
 }
 
 function SSHAccessSection({ controller, dialog }: { controller: ERunUIController; dialog: ManageDialog }): React.ReactElement {


### PR DESCRIPTION
## Summary

Closes the last meaningful UX audit P2 item: doctor diagnostics result is now visible inside the Manage dialog, not just in the transient titlebar banner.

When a doctor session exits (via the controller's existing `handleTerminalExit` pipeline), `recordDoctorOutcome` stores `{ ranAt, success, message }` keyed by selection in a new in-memory `AppState.lastDoctorBySelection` map. The Diagnostics section in the Manage dialog renders the entry as a small status line:

- ✓ green: `Last run 2 min ago — all checks passed`
- ✕ red:   `Last run 5 min ago — doctor failed: <reason>`

The state is in-memory (per-app-process) so it's wiped on app restart, which is the right scope for a \"last run\" hint.

## Bonus

Two instances of a personal handle (`ghcr.io/rihards-freimanis`) survived PR #235's cleanup:

- `state.ts` default for `environmentDialog.containerRegistry`
- `ERunUIController.openInitializeDialog` fallback when no past registries exist

Both replaced with an empty string. The New environment dialog now starts with a blank container registry on first use, with saved-past values populating subsequent uses (the suggestion list still works as before).

## Principles

- NN/g #1 (Visibility of system status).
- AGENTS.md `Professional UX` §92 — \"Diagnostic state must explain the current outcome directly where the user is looking.\"

## Test plan

- [ ] Open Manage dialog → SSH tab on an environment that has never run doctor: no last-run line.
- [ ] Click \"Run Doctor\". Dialog closes; doctor runs in terminal.
- [ ] Reopen Manage dialog → SSH tab. Last-run line shows green or red with time-ago.
- [ ] Confirm the line is keyed per environment (run on env A, reopen for env B: A's line not shown for B).
- [ ] Open the New environment dialog: container-registry field is empty (was previously prefilled with a personal handle).
- [ ] `tsc --noEmit`, `yarn shadcn:check`, `go test ./...` baseline-clean.

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)