### PR TITLE
UX: tighten ports table column layout

### DIFF
--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -892,13 +892,13 @@ function PortStatusTable({ rows }: { rows: { service: string; port: number; stat
     <div className="grid gap-2">
       <div className="text-sm font-medium leading-none">Local ports</div>
       <div className="overflow-hidden rounded-[var(--radius)] border border-border bg-muted/35 text-xs leading-[1.3]">
-        <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-3 border-b border-border px-3 py-2 text-[11px] font-semibold uppercase leading-[1.2] text-muted-foreground">
+        <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] gap-3 border-b border-border px-3 py-2 text-[11px] font-semibold uppercase leading-[1.2] text-muted-foreground">
           <div>Port</div>
           <div>Service</div>
           <div>Status</div>
         </div>
         {rows.map((row) => (
-          <div key={row.service} className="grid min-h-8 grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] items-center gap-3 border-b border-border px-3 py-1 last:border-b-0">
+          <div key={row.service} className="grid min-h-8 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 border-b border-border px-3 py-1 last:border-b-0">
             <div className="font-mono text-xs text-foreground">{row.port > 0 ? row.port : 'Not configured'}</div>
             <div className="text-foreground">{row.service}</div>
             <PortAvailability status={row.status} />


### PR DESCRIPTION
## Summary

- Switch the **Local ports** table grid from `[minmax(0,1fr)_minmax(0,1fr)_auto]` to `[auto_minmax(0,1fr)_auto]` so PORT hugs left, SERVICE flows next to it, and STATUS pins right.
- Matches the established codebase pattern at `ManageDialogView.tsx:184` and `TenantDialogView.tsx:116`.
- Header and value rows updated together so column tracks stay aligned.

## Test plan

- [x] `yarn build` (erun-ui/frontend)
- [x] `yarn shadcn:check` (no drift)
- [x] `go test ./...` (erun-ui)
- [ ] Visual check in the desktop app: open environment manage dialog → Ports tab → confirm PORT/SERVICE columns sit next to each other and STATUS pins right.

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)