### PR TITLE
Local tab logs every command the desktop runs for the env

### DIFF
--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -3053,6 +3053,85 @@ func TestStartSessionAutoReconnectsOnExit(t *testing.T) {
 	}
 }
 
+func TestStartSessionLogsOpenCommandToLocal(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", ProjectRoot: projectRoot, DefaultEnvironment: "remote"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {Name: "remote", RepoPath: projectRoot, KubernetesContext: "ctx"},
+		},
+	}
+
+	app := NewApp(erunUIDeps{
+		store:           store,
+		findProjectRoot: func() (string, string, error) { return "erun", projectRoot, nil },
+		resolveCLIPath:  func() string { return "/tmp/erun" },
+		startTerminal: func(startTerminalSessionParams) (terminalSession, error) {
+			return newStubTerminalSession(), nil
+		},
+	})
+	defer app.shutdown(context.Background())
+
+	if _, err := app.StartLocalSession(uiSelection{Tenant: "erun", Environment: "remote"}, 0, 80, 24); err != nil {
+		t.Fatalf("StartLocalSession failed: %v", err)
+	}
+	if _, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "remote"}, 0, 80, 24); err != nil {
+		t.Fatalf("StartSession failed: %v", err)
+	}
+	if _, err := app.StartAISession(uiSelection{Tenant: "erun", Environment: "remote"}, 0, 80, 24); err != nil {
+		t.Fatalf("StartAISession failed: %v", err)
+	}
+
+	app.mu.Lock()
+	defer app.mu.Unlock()
+	var local *managedTerminal
+	for _, m := range app.sessions {
+		if m != nil && m.kind == sessionKindLocal {
+			local = m
+			break
+		}
+	}
+	if local == nil {
+		t.Fatalf("Local session not found")
+	}
+	if _, ok := local.loggedCommands["erun"]; !ok {
+		t.Fatalf("expected ERun command logged to Local, got %+v", local.loggedCommands)
+	}
+	if _, ok := local.loggedCommands["ai"]; !ok {
+		t.Fatalf("expected AI command logged to Local, got %+v", local.loggedCommands)
+	}
+}
+
+func TestStartSessionDoesNotLogWhenLocalAbsent(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", ProjectRoot: projectRoot, DefaultEnvironment: "remote"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {Name: "remote", RepoPath: projectRoot, KubernetesContext: "ctx"},
+		},
+	}
+
+	app := NewApp(erunUIDeps{
+		store:           store,
+		findProjectRoot: func() (string, string, error) { return "erun", projectRoot, nil },
+		resolveCLIPath:  func() string { return "/tmp/erun" },
+		startTerminal: func(startTerminalSessionParams) (terminalSession, error) {
+			return newStubTerminalSession(), nil
+		},
+	})
+	defer app.shutdown(context.Background())
+
+	// No StartLocalSession — Local does not exist.
+	if _, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "remote"}, 0, 80, 24); err != nil {
+		t.Fatalf("StartSession failed: %v", err)
+	}
+	// Should not crash. No assertion required beyond that.
+}
+
 func TestStartLocalSessionDoesNotAutoReconnect(t *testing.T) {
 	projectRoot := t.TempDir()
 	store := stubUIStore{

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -521,8 +521,17 @@ export class ERunUIController {
 
     this.prepareOpenSelection(selection, runSelection, previousSessionId, previousKnownSessionId);
     this.fitAddon?.fit();
+    const cols = this.terminal?.cols || 80;
+    const rows = this.terminal?.rows || 24;
+
+    // Spawn Local first so subsequent ERun/AI spawns can log into it.
+    const tabs = this.state.tabsByEnv[key] || [];
+    if (!tabs.some((tab) => tab.kind === 'local')) {
+      await this.spawnDefaultTab(key, runSelection, 'local', 'Local', cols, rows);
+    }
+
     const slot = this.activeSlotForSelection(runSelection);
-    const result = (await StartSession(runSelection, slot, this.terminal?.cols || 80, this.terminal?.rows || 24)) as StartSessionResult;
+    const result = (await StartSession(runSelection, slot, cols, rows)) as StartSessionResult;
     this.registerOpenSessionResult(key, result, runSelection, previousSessionId);
     this.showOpenSelectionStatus(result.sessionId, selection);
 

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -334,6 +334,25 @@ func resolveAIToolCommand(configured string) string {
 	return defaultAITool
 }
 
+func formatLaunchCommand(params startTerminalSessionParams) string {
+	parts := make([]string, 0, len(params.Args)+1)
+	parts = append(parts, params.Executable)
+	parts = append(parts, params.Args...)
+	return strings.Join(parts, " ")
+}
+
+func formatLocalCommandLog(command, label string) string {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return ""
+	}
+	suffix := ""
+	if label = strings.TrimSpace(label); label != "" {
+		suffix = "  \x1b[2;3m(running in " + label + ")\x1b[0m"
+	}
+	return "\x1b[2m$ " + command + "\x1b[0m" + suffix + "\r\n"
+}
+
 func localSessionBanner(selection uiSelection) []byte {
 	tenant := strings.TrimSpace(selection.Tenant)
 	environment := strings.TrimSpace(selection.Environment)

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -85,6 +85,8 @@ func (a *App) StartSession(selection uiSelection, slot, cols, rows int) (startSe
 	go a.streamSession(managed)
 	go a.startWorkspaceSyncForSelection(selection)
 
+	a.logSpawnedCommandToLocal(selection, "erun", formatLocalCommandLog(formatLaunchCommand(openParams), "ERun tab"))
+
 	return startSessionResult{
 		SessionID: serial,
 		Selection: selection,
@@ -237,6 +239,9 @@ func (a *App) StartAISession(selection uiSelection, slot, cols, rows int) (start
 	a.mu.Unlock()
 
 	go a.streamSession(managed)
+
+	a.logSpawnedCommandToLocal(selection, "ai", formatLocalCommandLog(formatLaunchCommand(params)+" && "+shellQuoteIfNeeded(tool), "AI tab"))
+
 	return startSessionResult{
 		SessionID: serial,
 		Selection: selection,
@@ -812,6 +817,39 @@ func (a *App) tryReconnect(managed *managedTerminal, exitReason string) bool {
 	return true
 }
 
+func (a *App) logSpawnedCommandToLocal(selection uiSelection, dedupKey, line string) {
+	a.mu.Lock()
+	var local *managedTerminal
+	for _, m := range a.sessions {
+		if m == nil || m.closed || m.kind != sessionKindLocal {
+			continue
+		}
+		if normalizeSelection(m.selection) != selection {
+			continue
+		}
+		local = m
+		break
+	}
+	if local == nil {
+		a.mu.Unlock()
+		return
+	}
+	if local.loggedCommands == nil {
+		local.loggedCommands = make(map[string]struct{})
+	}
+	if _, ok := local.loggedCommands[dedupKey]; ok {
+		a.mu.Unlock()
+		return
+	}
+	local.loggedCommands[dedupKey] = struct{}{}
+	serial := local.serial
+	a.mu.Unlock()
+	a.emitEvent(terminalOutputEvent, terminalOutputPayload{
+		SessionID: serial,
+		Data:      base64.StdEncoding.EncodeToString([]byte(line)),
+	})
+}
+
 func (a *App) emitReconnectMarker(sessionID int, exitReason string) {
 	suffix := ""
 	if reason := strings.TrimSpace(exitReason); reason != "" {
@@ -916,6 +954,7 @@ type managedTerminal struct {
 	blocksIdleStop         bool
 	clearIdleBlockOnOutput bool
 	respawn                func() (terminalSession, error)
+	loggedCommands         map[string]struct{}
 }
 
 type sessionKind string


### PR DESCRIPTION
## Summary
- Local now shows a styled `$ <command>  (running in <Tab> tab)` entry the moment ERun and AI tabs spawn, so Local is a single audit trail of every command erun-ui launches locally for the active env.
- Deploy/init/doctor/sshd-init entries continue to be typed into Local's pty so they execute and stream output as today.
- Synthetic log entries are emitted via `terminal-output` events (same path as the auto-reconnect marker) so they bypass the shell — no `zsh: command not found` regressions.
- Frontend `openSelection` now spawns Local *before* ERun so the log entry has somewhere to land.
- Per-Local-session dedup set prevents re-logging the same command on env-switch round-trips.

Closes #256

## Test plan
- [x] `go test -run TestStartSessionLogsOpenCommandToLocal -v ./...` — green
- [x] `go test -count=1 ./...` — full erun-ui sweep green
- [x] `tsc --noEmit` — clean
- [ ] Desktop smoke test: opening any env shows two dim `$ … erun open …  (running in ERun tab)` / `… (running in AI tab)` lines in Local before the host prompt; clicking Deploy still appends a real, executing deploy command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)