### PR TITLE
Fix deploy for remote envs and surface progress + config

### DIFF
--- a/erun-cli/cmd/feedback_render.go
+++ b/erun-cli/cmd/feedback_render.go
@@ -41,7 +41,7 @@ func commandVerbosity(cmd *cobra.Command) int {
 	if err != nil {
 		return 0
 	}
-	if verbosity == 0 && isExecCommand(cmd) {
+	if verbosity == 0 && (isExecCommand(cmd) || isActionCommand(cmd)) {
 		return 1
 	}
 	return verbosity
@@ -126,6 +126,23 @@ func isSensitiveName(value string) bool {
 func isExecCommand(cmd *cobra.Command) bool {
 	for current := cmd; current != nil; current = current.Parent() {
 		if current.Name() == "exec" {
+			return true
+		}
+	}
+	return false
+}
+
+// isActionCommand reports whether cmd is a mutating top-level command whose
+// traced steps should be visible by default. Otherwise the user runs e.g.
+// `erun deploy <tenant> <env> --version X` and sees a blank screen for
+// minutes while helm waits, with no audit line, no helm command, no
+// kubectl-context prep printed. Visibility of system status is mandatory
+// for action flows (Nielsen heuristic #1), so we lift the verbosity floor
+// to 1 for these commands the same way exec already does.
+func isActionCommand(cmd *cobra.Command) bool {
+	for current := cmd; current != nil; current = current.Parent() {
+		switch current.Name() {
+		case "deploy", "build", "push", "release", "init", "delete":
 			return true
 		}
 	}

--- a/erun-cli/cmd/list.go
+++ b/erun-cli/cmd/list.go
@@ -185,7 +185,19 @@ func writeTenantEntry(ctx common.Context, tenant common.ListTenantResult) error 
 		return err
 	}
 	for _, env := range tenant.Environments {
-		if _, err := fmt.Fprintln(ctx.Stdout, environmentLine(env)); err != nil {
+		if err := writeEnvironmentEntry(ctx, env); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeEnvironmentEntry(ctx common.Context, env common.ListEnvironmentResult) error {
+	if _, err := fmt.Fprintln(ctx.Stdout, environmentHeaderLine(env)); err != nil {
+		return err
+	}
+	for _, line := range environmentDetailLines(env) {
+		if _, err := fmt.Fprintln(ctx.Stdout, line); err != nil {
 			return err
 		}
 	}
@@ -200,7 +212,7 @@ func tenantHeaderLine(tenant common.ListTenantResult) string {
 	return header
 }
 
-func environmentLine(env common.ListEnvironmentResult) string {
+func environmentHeaderLine(env common.ListEnvironmentResult) string {
 	envLine := "      - " + env.Name
 	if markers := statusMarkers(env.IsDefault, env.IsEffective); len(markers) > 0 {
 		envLine += " [" + strings.Join(markers, ", ") + "]"
@@ -209,11 +221,97 @@ func environmentLine(env common.ListEnvironmentResult) string {
 	if strings.TrimSpace(env.CloudProviderAlias) != "" {
 		envLine += " cloud=" + quotedValueOrNone(env.CloudProviderAlias)
 	}
-	envLine += environmentBaseFields(env)
-	if env.SSH.Enabled {
-		envLine += environmentSSHFields(env.SSH)
-	}
 	return envLine
+}
+
+func environmentDetailLines(env common.ListEnvironmentResult) []string {
+	const indent = "          "
+	lines := []string{
+		indent + "remote: " + enabledDisabledLabel(env.Remote),
+		indent + "snapshot: " + enabledDisabledLabel(env.Snapshot),
+		indent + "repo: " + valueOrNone(env.RepoPath),
+		indent + "ports: " + portRangeLabel(env.LocalPorts),
+		indent + "mcp-port: " + fmt.Sprintf("%d", env.LocalPorts.MCP),
+		indent + "api-port: " + fmt.Sprintf("%d", env.LocalPorts.API),
+		indent + "api-url: " + valueOrNone(env.APIURL),
+		indent + "ssh-port: " + fmt.Sprintf("%d", env.LocalPorts.SSH),
+		indent + "container-registry: " + valueOrNone(env.ContainerRegistry),
+		indent + "runtime-version: " + valueOrNone(env.RuntimeVersion),
+		indent + "runtime-pod: " + runtimePodLabel(env.RuntimePod),
+		indent + "managed-cloud: " + enabledDisabledLabel(env.ManagedCloud),
+		indent + "ai-tool: " + valueOrNone(env.AITool),
+		indent + "claude: " + claudeLabel(env.Claude),
+		indent + "idle: " + idleLabel(env.Idle),
+	}
+	if env.SSH.Enabled {
+		lines = append(lines, environmentSSHDetailLines(env.SSH, indent)...)
+	} else {
+		lines = append(lines, indent+"sshd: off")
+	}
+	return lines
+}
+
+func environmentSSHDetailLines(ssh common.ListSSHResult, indent string) []string {
+	return []string{
+		indent + "sshd: on",
+		indent + "ssh-host: " + valueOrNone(ssh.HostAlias),
+		indent + "ssh-user: " + valueOrNone(ssh.User),
+		indent + "ssh-local-port: " + fmt.Sprintf("%d", ssh.LocalPort),
+		indent + "ssh-workspace: " + valueOrNone(ssh.WorkspacePath),
+		indent + "ssh-public-key-path: " + valueOrNone(ssh.PublicKeyPath),
+		indent + "ssh-workspace-sync: " + enabledDisabledLabel(ssh.WorkspaceSyncEnabled),
+		indent + "ssh-workspace-sync-local-path: " + valueOrNone(ssh.WorkspaceSyncLocalPath),
+	}
+}
+
+func runtimePodLabel(pod common.RuntimePodResources) string {
+	cpu := strings.TrimSpace(pod.CPU)
+	memory := strings.TrimSpace(pod.Memory)
+	if cpu == "" && memory == "" {
+		return "none"
+	}
+	return fmt.Sprintf("cpu=%s memory=%s", valueOrNone(cpu), valueOrNone(memory))
+}
+
+func claudeLabel(c common.EnvironmentClaudeConfig) string {
+	if c.IsZero() {
+		return "none"
+	}
+	parts := make([]string, 0, 4)
+	parts = append(parts, "use-mantle="+optionalBoolLabel(c.UseMantle))
+	parts = append(parts, "use-bedrock="+optionalBoolLabel(c.UseBedrock))
+	models := "none"
+	if len(c.Models) > 0 {
+		models = strings.Join(c.Models, ",")
+	}
+	parts = append(parts, "models="+models)
+	tokens := "unset"
+	if c.MaxOutputTokens != nil {
+		tokens = fmt.Sprintf("%d", *c.MaxOutputTokens)
+	}
+	parts = append(parts, "max-output-tokens="+tokens)
+	return strings.Join(parts, " ")
+}
+
+func idleLabel(idle common.EnvironmentIdleConfig) string {
+	timeout := strings.TrimSpace(idle.Timeout)
+	hours := strings.TrimSpace(idle.WorkingHours)
+	tz := strings.TrimSpace(idle.Timezone)
+	if timeout == "" && hours == "" && tz == "" && idle.IdleTrafficBytes == 0 {
+		return "none"
+	}
+	return fmt.Sprintf("timeout=%s working-hours=%s timezone=%s idle-traffic-bytes=%d",
+		valueOrNone(timeout), valueOrNone(hours), valueOrNone(tz), idle.IdleTrafficBytes)
+}
+
+func optionalBoolLabel(b *bool) string {
+	if b == nil {
+		return "unset"
+	}
+	if *b {
+		return "true"
+	}
+	return "false"
 }
 
 func statusMarkers(isDefault, isEffective bool) []string {
@@ -225,26 +323,6 @@ func statusMarkers(isDefault, isEffective bool) []string {
 		markers = append(markers, "effective")
 	}
 	return markers
-}
-
-func environmentBaseFields(env common.ListEnvironmentResult) string {
-	line := " snapshot=" + enabledDisabledLabel(env.Snapshot)
-	line += " repo=" + quotedValueOrNone(env.RepoPath)
-	line += " ports=" + portRangeLabel(env.LocalPorts)
-	line += " mcp-port=" + fmt.Sprintf("%d", env.LocalPorts.MCP)
-	line += " api-port=" + fmt.Sprintf("%d", env.LocalPorts.API)
-	line += " api-url=" + quotedValueOrNone(env.APIURL)
-	line += " ssh-port=" + fmt.Sprintf("%d", env.LocalPorts.SSH)
-	return line
-}
-
-func environmentSSHFields(ssh common.ListSSHResult) string {
-	line := " ssh=on"
-	line += " host=" + quotedValueOrNone(ssh.HostAlias)
-	line += " user=" + quotedValueOrNone(ssh.User)
-	line += " local-port=" + fmt.Sprintf("%d", ssh.LocalPort)
-	line += " workspace=" + quotedValueOrNone(ssh.WorkspacePath)
-	return line
 }
 
 func writeCloudProviders(ctx common.Context, providers []common.CloudProviderStatus) error {

--- a/erun-cli/cmd/root_test.go
+++ b/erun-cli/cmd/root_test.go
@@ -386,10 +386,6 @@ func TestInitCommandPreservesExistingTenantDefaultEnvironmentWhenFlagOmitted(t *
 
 	requireNoError(t, cmd.Execute(), "Execute failed")
 
-	if got := buf.String(); got != "" {
-		t.Fatalf("expected no command output, got %q", got)
-	}
-
 	tenantConfig, _, err := common.LoadTenantConfig("tenant-a")
 	if err != nil {
 		t.Fatalf("LoadTenantConfig failed: %v", err)

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -221,6 +221,20 @@ func ResolveCurrentDeploySpecs(store DeployStore, findProjectRoot ProjectFinderF
 		return nil, err
 	}
 
+	if resolvedTarget.RemoteRepo() {
+		spec, err := resolveDefaultDevopsDeploySpecWithImage(resolvedTarget, DevopsComponentName)
+		if err != nil {
+			return nil, err
+		}
+		if versionOverride := strings.TrimSpace(target.VersionOverride); versionOverride != "" {
+			spec.Deploy.Version = versionOverride
+		}
+		if err := configureDeployInputMetadata(store, resolvedTarget, &spec.Deploy); err != nil {
+			return nil, err
+		}
+		return []DeploySpec{spec}, nil
+	}
+
 	deployContexts, err := ResolveCurrentKubernetesDeployContexts(findProjectRoot, resolveKubernetesDeployContext, resolvedTarget.RepoPath)
 	if err != nil {
 		return nil, err

--- a/erun-common/list.go
+++ b/erun-common/list.go
@@ -58,27 +58,36 @@ type ListTenantResult struct {
 }
 
 type ListEnvironmentResult struct {
-	Name               string                `json:"name"`
-	APIURL             string                `json:"apiUrl,omitempty"`
-	KubernetesContext  string                `json:"kubernetesContext,omitempty"`
-	CloudProviderAlias string                `json:"cloudProviderAlias,omitempty"`
-	RepoPath           string                `json:"repoPath,omitempty"`
-	RuntimeVersion     string                `json:"runtimeVersion,omitempty"`
-	Remote             bool                  `json:"remote,omitempty"`
-	Snapshot           bool                  `json:"snapshot"`
-	IsActive           bool                  `json:"isActive,omitempty"`
-	LocalPorts         EnvironmentLocalPorts `json:"localPorts,omitempty"`
-	IsDefault          bool                  `json:"isDefault,omitempty"`
-	IsEffective        bool                  `json:"isEffective,omitempty"`
-	SSH                ListSSHResult         `json:"ssh,omitempty"`
+	Name               string                  `json:"name"`
+	APIURL             string                  `json:"apiUrl,omitempty"`
+	KubernetesContext  string                  `json:"kubernetesContext,omitempty"`
+	CloudProviderAlias string                  `json:"cloudProviderAlias,omitempty"`
+	RepoPath           string                  `json:"repoPath,omitempty"`
+	ContainerRegistry  string                  `json:"containerRegistry,omitempty"`
+	RuntimeVersion     string                  `json:"runtimeVersion,omitempty"`
+	RuntimePod         RuntimePodResources     `json:"runtimePod,omitempty"`
+	Remote             bool                    `json:"remote,omitempty"`
+	ManagedCloud       bool                    `json:"managedCloud,omitempty"`
+	AITool             string                  `json:"aiTool,omitempty"`
+	Claude             EnvironmentClaudeConfig `json:"claude,omitempty"`
+	Idle               EnvironmentIdleConfig   `json:"idle,omitempty"`
+	Snapshot           bool                    `json:"snapshot"`
+	IsActive           bool                    `json:"isActive,omitempty"`
+	LocalPorts         EnvironmentLocalPorts   `json:"localPorts,omitempty"`
+	IsDefault          bool                    `json:"isDefault,omitempty"`
+	IsEffective        bool                    `json:"isEffective,omitempty"`
+	SSH                ListSSHResult           `json:"ssh,omitempty"`
 }
 
 type ListSSHResult struct {
-	Enabled       bool   `json:"enabled,omitempty"`
-	HostAlias     string `json:"hostAlias,omitempty"`
-	User          string `json:"user,omitempty"`
-	LocalPort     int    `json:"localPort,omitempty"`
-	WorkspacePath string `json:"workspacePath,omitempty"`
+	Enabled               bool   `json:"enabled,omitempty"`
+	HostAlias             string `json:"hostAlias,omitempty"`
+	User                  string `json:"user,omitempty"`
+	LocalPort             int    `json:"localPort,omitempty"`
+	WorkspacePath         string `json:"workspacePath,omitempty"`
+	PublicKeyPath         string `json:"publicKeyPath,omitempty"`
+	WorkspaceSyncEnabled  bool   `json:"workspaceSyncEnabled,omitempty"`
+	WorkspaceSyncLocalPath string `json:"workspaceSyncLocalPath,omitempty"`
 }
 
 func ResolveListResult(store ListStore, findProjectRoot ProjectFinderFunc, params OpenParams) (ListResult, error) {
@@ -189,8 +198,14 @@ func listEnvironmentResult(store ListStore, tenant TenantConfig, env EnvConfig, 
 		KubernetesContext:  strings.TrimSpace(env.KubernetesContext),
 		CloudProviderAlias: strings.TrimSpace(env.CloudProviderAlias),
 		RepoPath:           strings.TrimSpace(env.RepoPath),
+		ContainerRegistry:  strings.TrimSpace(env.ContainerRegistry),
 		RuntimeVersion:     strings.TrimSpace(env.RuntimeVersion),
+		RuntimePod:         env.RuntimePod,
 		Remote:             env.Remote,
+		ManagedCloud:       env.ManagedCloud,
+		AITool:             strings.TrimSpace(env.AITool),
+		Claude:             env.Claude,
+		Idle:               env.Idle,
 		Snapshot:           env.SnapshotEnabled(),
 		IsActive:           listEnvironmentIsActive(store, env),
 		LocalPorts:         localPorts,
@@ -254,12 +269,16 @@ func listSSHResult(result OpenResult) ListSSHResult {
 	}
 
 	info := SSHConnectionInfoForResult(result)
+	sync := result.EnvConfig.SSHD.WorkspaceSync
 	return ListSSHResult{
-		Enabled:       true,
-		HostAlias:     info.HostAlias,
-		User:          info.User,
-		LocalPort:     info.Port,
-		WorkspacePath: info.WorkspacePath,
+		Enabled:                true,
+		HostAlias:              info.HostAlias,
+		User:                   info.User,
+		LocalPort:              info.Port,
+		WorkspacePath:          info.WorkspacePath,
+		PublicKeyPath:          strings.TrimSpace(result.EnvConfig.SSHD.PublicKeyPath),
+		WorkspaceSyncEnabled:   sync.Enabled,
+		WorkspaceSyncLocalPath: strings.TrimSpace(sync.LocalPath),
 	}
 }
 

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -73,6 +73,27 @@ func TestDeploy(t *testing.T) {
 		golden.Equal(t, "deploy/dry_run_outside_devops_with_tenant_env", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_remote_env_uses_embedded_chart", func(t *testing.T) {
+		// Regression: a remote env (Remote=true) has its repopath on the
+		// remote host's filesystem (e.g. proxmox1: /home/erun/git/erun) and
+		// has no local checkout at all. Deploy from any cwd must still
+		// work: the embedded default-devops chart is materialized to a
+		// temp dir and used for the helm install. Pre-fix, deploy stat'd
+		// the remote repopath locally and failed with
+		// "open <remote-path>: no such file or directory".
+		setup := env.New(t)
+		fixture.SeedRemoteRepoPathTenantEnv(t, setup, "team", "dev", "/nonexistent-remote/team")
+		// Note: no SeedDevopsRepo — there is no local checkout anywhere.
+		result := erun.Run(t, []string{"deploy", "team", "dev", "--version", "1.0.0", "--dry-run"}, erun.RunOptions{Cwd: setup.Home, Env: setup.Env()})
+		if strings.Contains(result.Combined, "no such file or directory") {
+			t.Fatalf("regression: deploy stat'd remote repopath locally:\n%s", result.Combined)
+		}
+		if strings.Contains(result.Combined, "helm chart not found") {
+			t.Fatalf("regression: deploy did not fall back to embedded chart for remote env:\n%s", result.Combined)
+		}
+		golden.Equal(t, "deploy/dry_run_remote_env_uses_embedded_chart", normalize.Apply(result.Combined))
+	})
+
 	t.Run("snapshot_conflict_errors", func(t *testing.T) {
 		setup := env.New(t)
 		fixture.SeedTenantEnv(t, setup, "team", "dev")

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -89,6 +89,39 @@ func SeedRemoteTenantEnv(t testing.TB, setup env.Setup, tenant, environment stri
 	)
 }
 
+// SeedRemoteRepoPathTenantEnv writes a tenant/env tree where the env's
+// repopath points to a path that does not exist locally and the env is
+// flagged remote: true. The tenant projectroot still points at setup.Cwd so
+// chart resolution finds the local <tenant>-devops module via cwd-based
+// detection. Use this for regression scenarios where deploy must not
+// readdir() the env's remote-host path.
+func SeedRemoteRepoPathTenantEnv(t testing.TB, setup env.Setup, tenant, environment, remoteRepoPath string) {
+	t.Helper()
+	root := filepath.Join(setup.ConfigHome, "erun")
+	tenantDir := filepath.Join(root, tenant)
+	envDir := filepath.Join(tenantDir, environment)
+	for _, dir := range []string{root, tenantDir, envDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	mustWrite(t, filepath.Join(root, "config.yaml"), "defaulttenant: "+tenant+"\n")
+	mustWrite(t, filepath.Join(tenantDir, "config.yaml"),
+		"projectroot: "+setup.Cwd+"\n"+
+			"name: "+tenant+"\n"+
+			"defaultenvironment: "+environment+"\n",
+	)
+	mustWrite(t, filepath.Join(envDir, "config.yaml"),
+		"name: "+environment+"\n"+
+			"repopath: "+remoteRepoPath+"\n"+
+			"kubernetescontext: test-context\n"+
+			"containerregistry: registry.example/test\n"+
+			"runtimeversion: 1.0.0\n"+
+			"remote: true\n",
+	)
+}
+
 // SeedReleaseRepo materializes a minimal erun-devops layout (chart, two
 // dockerfiles, VERSION file) inside dir, runs `git init -b <branch>`, and
 // produces one initial commit. Use this for `release` scenarios that need

--- a/erun-integration/testdata/deploy/dry_run_remote_env_uses_embedded_chart.txt
+++ b/erun-integration/testdata/deploy/dry_run_remote_env_uses_embedded_chart.txt
@@ -1,0 +1,6 @@
+audit: erun deploy --dry-run --version <VERSION> team dev
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true
+deploy: resolved 1 spec(s)
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=pvc --set-string worktreeRepoName=team --set-string worktreeHostPath=/nonexistent-remote/team --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>

--- a/erun-integration/testdata/deploy/real_run_via_stubs.txt
+++ b/erun-integration/testdata/deploy/real_run_via_stubs.txt
@@ -1,1 +1,7 @@
 
+audit: erun deploy --no-snapshot --version <VERSION> team dev
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=false
+deploy: resolved 1 spec(s)
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>

--- a/erun-integration/testdata/init/real_run_via_stubs.txt
+++ b/erun-integration/testdata/init/real_run_via_stubs.txt
@@ -1,1 +1,1095 @@
 
+audit: erun init --bootstrap --confirm-environment --container-registry registry.example/test --kubernetes-context test-context --no-git --remote --set-default-tenant --version <VERSION> team dev
+Loading erun tool configuration, configPath=<TMP>
+Saving default config
+mkdir -p <TMP>
+write-yaml <TMP>
+Loaded erun tool configuration
+Loading tenant configuration
+Adding new tenant
+mkdir -p <TMP>
+write-yaml <TMP>
+Loaded tenant configuration
+Loading environment configuration
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+Adding new environment
+mkdir -p <TMP>
+write-yaml <TMP>
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=pvc --set-string worktreeRepoName=team --set-string worktreeHostPath=<HOME>/git/team --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+kubectl --context test-context --namespace team-dev wait --for=condition=Available --timeout 2m0s deployment/team-devops
+kubectl --context test-context --namespace team-dev exec deployment/team-devops -- /bin/sh -lc '<remote-script>'
+remote-worktree:
+  set -eu
+  mkdir -p '<HOME>/git/team'
+kubectl --context test-context --namespace team-dev exec deployment/team-devops -- /bin/sh -lc '<remote-script>'
+remote-default-devops-bootstrap:
+  set -eu
+  mkdir -p '<HOME>/git/team/team-devops'
+  if [ -d '<HOME>/git/team/team-devops/VERSION' ]; then echo '"<HOME>/git/team/team-devops/VERSION" is a directory' >&2; exit 1; fi
+  erun_bootstrap_tmp_0=$(mktemp)
+  printf %s '<VERSION>
+  ' > "$erun_bootstrap_tmp_0"
+  replace=false
+  if [ ! -e '<HOME>/git/team/team-devops/VERSION' ]; then
+    replace=true
+  elif cmp -s "$erun_bootstrap_tmp_0" '<HOME>/git/team/team-devops/VERSION'; then
+    replace=false
+  else
+    replace=false
+  fi
+  if [ "$replace" = true ]; then cp "$erun_bootstrap_tmp_0" '<HOME>/git/team/team-devops/VERSION'; chmod '644' '<HOME>/git/team/team-devops/VERSION'; fi
+  rm -f "$erun_bootstrap_tmp_0"
+  mkdir -p '<HOME>/git/team/team-devops/docker/team-devops'
+  if [ -d '<HOME>/git/team/team-devops/docker/team-devops/Dockerfile' ]; then echo '"<HOME>/git/team/team-devops/docker/team-devops/Dockerfile" is a directory' >&2; exit 1; fi
+  erun_bootstrap_tmp_1=$(mktemp)
+  printf %s 'ARG ERUN_BASE_TAG=ghcr.io/sophium/erun-devops:<VERSION>
+
+  FROM ${ERUN_BASE_TAG}
+
+  ENTRYPOINT ["erun-devops-entrypoint"]
+  ' > "$erun_bootstrap_tmp_1"
+  replace=false
+  if [ ! -e '<HOME>/git/team/team-devops/docker/team-devops/Dockerfile' ]; then
+    replace=true
+  elif cmp -s "$erun_bootstrap_tmp_1" '<HOME>/git/team/team-devops/docker/team-devops/Dockerfile'; then
+    replace=false
+  else
+    erun_bootstrap_legacy_1_0=$(mktemp)
+    printf %s 'ARG ERUN_BASE_IMAGE=erunpaas/erun-devops
+  ARG ERUN_BASE_VERSION=<VERSION>
+
+  FROM ${ERUN_BASE_IMAGE}:${ERUN_BASE_VERSION}
+  ' > "$erun_bootstrap_legacy_1_0"
+    if cmp -s "$erun_bootstrap_legacy_1_0" '<HOME>/git/team/team-devops/docker/team-devops/Dockerfile'; then replace=true; fi
+    rm -f "$erun_bootstrap_legacy_1_0"
+    erun_bootstrap_legacy_1_1=$(mktemp)
+    printf %s 'ARG ERUN_BASE_TAG=erunpaas/erun-devops:<VERSION>
+
+  FROM ${ERUN_BASE_TAG}
+  ' > "$erun_bootstrap_legacy_1_1"
+    if cmp -s "$erun_bootstrap_legacy_1_1" '<HOME>/git/team/team-devops/docker/team-devops/Dockerfile'; then replace=true; fi
+    rm -f "$erun_bootstrap_legacy_1_1"
+    erun_bootstrap_legacy_1_2=$(mktemp)
+    printf %s 'ARG ERUN_BASE_TAG=erunpaas/erun-devops:<VERSION>
+
+  FROM ${ERUN_BASE_TAG}
+
+  ENTRYPOINT ["/bin/sh", "-lc", "if [ \"${1:-}\" = shell ]; then shift; repo_dir=\"${ERUN_REPO_PATH:-${HOME}/git/erun}\"; [ -d \"$repo_dir\" ] && cd \"$repo_dir\"; exec /bin/bash -i; fi; exec erun-devops-entrypoint \"$@\"", "erun-devops-wrapper"]
+  ' > "$erun_bootstrap_legacy_1_2"
+    if cmp -s "$erun_bootstrap_legacy_1_2" '<HOME>/git/team/team-devops/docker/team-devops/Dockerfile'; then replace=true; fi
+    rm -f "$erun_bootstrap_legacy_1_2"
+  fi
+  if [ "$replace" = true ]; then cp "$erun_bootstrap_tmp_1" '<HOME>/git/team/team-devops/docker/team-devops/Dockerfile'; chmod '644' '<HOME>/git/team/team-devops/docker/team-devops/Dockerfile'; fi
+  rm -f "$erun_bootstrap_tmp_1"
+  mkdir -p '<HOME>/git/team/team-devops/k8s/team-devops'
+  if [ -d '<HOME>/git/team/team-devops/k8s/team-devops/Chart.yaml' ]; then echo '"<HOME>/git/team/team-devops/k8s/team-devops/Chart.yaml" is a directory' >&2; exit 1; fi
+  erun_bootstrap_tmp_2=$(mktemp)
+  printf %s 'apiVersion: v2
+  name: team-devops
+  description: ERun DevOps
+  type: application
+  version: "<VERSION>"
+  appVersion: "<VERSION>"
+  ' > "$erun_bootstrap_tmp_2"
+  replace=false
+  if [ ! -e '<HOME>/git/team/team-devops/k8s/team-devops/Chart.yaml' ]; then
+    replace=true
+  elif cmp -s "$erun_bootstrap_tmp_2" '<HOME>/git/team/team-devops/k8s/team-devops/Chart.yaml'; then
+    replace=false
+  else
+    replace=false
+  fi
+  if [ "$replace" = true ]; then cp "$erun_bootstrap_tmp_2" '<HOME>/git/team/team-devops/k8s/team-devops/Chart.yaml'; chmod '644' '<HOME>/git/team/team-devops/k8s/team-devops/Chart.yaml'; fi
+  rm -f "$erun_bootstrap_tmp_2"
+  mkdir -p '<HOME>/git/team/team-devops/k8s/team-devops'
+  if [ -d '<HOME>/git/team/team-devops/k8s/team-devops/values.local.yaml' ]; then echo '"<HOME>/git/team/team-devops/k8s/team-devops/values.local.yaml" is a directory' >&2; exit 1; fi
+  erun_bootstrap_tmp_3=$(mktemp)
+  printf %s '# default local values
+  ' > "$erun_bootstrap_tmp_3"
+  replace=false
+  if [ ! -e '<HOME>/git/team/team-devops/k8s/team-devops/values.local.yaml' ]; then
+    replace=true
+  elif cmp -s "$erun_bootstrap_tmp_3" '<HOME>/git/team/team-devops/k8s/team-devops/values.local.yaml'; then
+    replace=false
+  else
+    replace=false
+  fi
+  if [ "$replace" = true ]; then cp "$erun_bootstrap_tmp_3" '<HOME>/git/team/team-devops/k8s/team-devops/values.local.yaml'; chmod '644' '<HOME>/git/team/team-devops/k8s/team-devops/values.local.yaml'; fi
+  rm -f "$erun_bootstrap_tmp_3"
+  mkdir -p '<HOME>/git/team/team-devops/k8s/team-devops/templates'
+  if [ -d '<HOME>/git/team/team-devops/k8s/team-devops/templates/service.yaml' ]; then echo '"<HOME>/git/team/team-devops/k8s/team-devops/templates/service.yaml" is a directory' >&2; exit 1; fi
+  erun_bootstrap_tmp_4=$(mktemp)
+  printf %s '{{- $worktreeStorage := default "host" .Values.worktreeStorage -}}
+  {{- $worktreeRepoName := required "worktreeRepoName is required" .Values.worktreeRepoName -}}
+  {{- $worktreePath := printf "<HOME>/git/%s" $worktreeRepoName -}}
+  {{- $mcpPort := default 17000 .Values.mcpPort -}}
+  {{- $apiPort := default 17033 .Values.apiPort -}}
+  {{- $sshPort := default 17022 .Values.sshPort -}}
+  {{- $idle := default dict .Values.idle -}}
+  {{- $idleTimeout := default "5m0s" $idle.timeout -}}
+  {{- $idleWorkingHours := default "08:00-20:00" $idle.workingHours -}}
+  {{- $idleTimezone := default "" $idle.timezone -}}
+  {{- $idleTrafficBytes := default 0 $idle.trafficBytes -}}
+  {{- $runtime := default dict .Values.runtime -}}
+  {{- $runtimeResources := default dict $runtime.resources -}}
+  {{- $runtimeLimits := default dict $runtimeResources.limits -}}
+  {{- $runtimeRequests := default dict $runtimeResources.requests -}}
+  {{- $runtimeCPU := default "4" $runtimeLimits.cpu -}}
+  {{- $runtimeMemory := default "8916Mi" $runtimeLimits.memory -}}
+  {{- $runtimeRequestCPU := default "0.25" $runtimeRequests.cpu -}}
+  {{- $runtimeRequestMemory := default "1024Mi" $runtimeRequests.memory -}}
+  {{- $managedCloud := default false .Values.managedCloud -}}
+  {{- $api := default dict .Values.api -}}
+  {{- $oidcAllowedIssuers := default "" $api.oidcAllowedIssuers -}}
+  {{- $awsIdentityStoreID := default "" $api.awsIdentityStoreID -}}
+  {{- $awsIdentityStoreRegion := default "" $api.awsIdentityStoreRegion -}}
+  {{- $postgres := default dict $api.postgres -}}
+  {{- $postgresDatabase := default "erun" $postgres.database -}}
+  {{- $postgresUser := default "erun" $postgres.user -}}
+  {{- $postgresPort := default 5432 $postgres.port -}}
+  {{- $postgresPasswordSecretName := default "erun-backend-postgres" $postgres.passwordSecretName -}}
+  {{- $postgresPasswordSecretKey := default "password" $postgres.passwordSecretKey -}}
+  {{- $postgresPassword := default "" $postgres.password -}}
+  {{- $postgresReset := default false $postgres.reset -}}
+  {{- $existingPostgresSecret := lookup "v1" "Secret" .Release.Namespace $postgresPasswordSecretName -}}
+  {{- if and (eq $postgresPassword "") $existingPostgresSecret (hasKey $existingPostgresSecret.data $postgresPasswordSecretKey) -}}
+  {{- $postgresPassword = (index $existingPostgresSecret.data $postgresPasswordSecretKey | b64dec) -}}
+  {{- end -}}
+  {{- if eq $postgresPassword "" -}}
+  {{- $postgresPassword = randAlphaNum 32 -}}
+  {{- end -}}
+  {{- $postgresDataSubPath := default ".erun/postgres" $postgres.dataSubPath -}}
+  {{- $databaseURL := default (printf "postgres://%s:$(ERUN_POSTGRES_PASSWORD)@<VERSION>.1:%v/%s?sslmode=disable" $postgresUser $postgresPort $postgresDatabase) $api.databaseURL -}}
+  {{- $imageOverrides := default dict .Values.imageOverrides -}}
+  {{- $backendDBImage := default (printf "ghcr.io/sophium/erun-backend-db:%s" .Chart.AppVersion) (index $imageOverrides "erun-backend-db") -}}
+  {{- $devopsImage := default (printf "ghcr.io/sophium/team-devops:%s" .Chart.AppVersion) (index $imageOverrides "team-devops") -}}
+  {{- $mcpImage := default (printf "ghcr.io/sophium/erun-mcp:%s" .Chart.AppVersion) (index $imageOverrides "erun-mcp") -}}
+  {{- $backendAPIImage := default (printf "ghcr.io/sophium/erun-backend-api:%s" .Chart.AppVersion) (index $imageOverrides "erun-backend-api") -}}
+  {{- $postgresImage := default "postgres:18" (index $imageOverrides "postgres") -}}
+  {{- $dindImage := default "ghcr.io/sophium/erun-dind:<VERSION>" (index $imageOverrides "erun-dind") -}}
+  {{- $cloudContext := default dict .Values.cloudContext -}}
+  {{- $cloudContextName := default "" $cloudContext.name -}}
+  {{- $cloudProvider := default "" $cloudContext.provider -}}
+  {{- $cloudProviderAlias := default "" $cloudContext.providerAlias -}}
+  {{- $cloudRegion := default "" $cloudContext.region -}}
+  {{- $cloudInstanceID := default "" $cloudContext.instanceId -}}
+  {{- $claude := default dict .Values.claude -}}
+  {{- $claudeUseBedrock := default "0" $claude.useBedrock -}}
+  {{- $claudeUseMantle := default "0" $claude.useMantle -}}
+  {{- $claudeSmallFastRegion := default $cloudRegion $claude.smallFastModelAWSRegion -}}
+  {{- $claudeAvailableModels := default "sonnet,haiku" $claude.availableModels -}}
+  {{- $claudeModel := default "" $claude.model -}}
+  {{- $claudeDefaultOpusModel := default "" $claude.defaultOpusModel -}}
+  {{- $claudeDefaultSonnetModel := default "" $claude.defaultSonnetModel -}}
+  {{- $claudeDefaultHaikuModel := default "" $claude.defaultHaikuModel -}}
+  {{- $claudeBedrockBaseURL := default "" $claude.bedrockBaseURL -}}
+  {{- $claudeMantleBaseURL := default "" $claude.mantleBaseURL -}}
+  {{- $claudeBedrockServiceTier := default "" $claude.bedrockServiceTier -}}
+  {{- $claudeSkipMantleAuth := default "" $claude.skipMantleAuth -}}
+  {{- $claudeDisablePromptCaching := default "" $claude.disablePromptCaching -}}
+  {{- $claudeEnablePromptCaching1H := default "" $claude.enablePromptCaching1H -}}
+  {{- $claudeMaxOutputTokens := default "4096" $claude.maxOutputTokens -}}
+  {{- $claudeMaxThinkingTokens := default "1024" $claude.maxThinkingTokens -}}
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: {{ $postgresPasswordSecretName }}
+    labels:
+      app: team-devops
+  type: Opaque
+  stringData:
+    {{ $postgresPasswordSecretKey }}: {{ $postgresPassword | quote }}
+  ---
+  apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: team-devops-home
+    labels:
+      app: team-devops
+  spec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 2Gi
+  ---
+  apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: team-devops-docker
+    labels:
+      app: team-devops
+  spec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 50Gi
+  ---
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: team-devops
+    labels:
+      app: team-devops
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: team-devops
+    labels:
+      app: team-devops
+  subjects:
+    - kind: ServiceAccount
+      name: team-devops
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: admin
+  ---
+  {{- if eq (required "environment is required" .Values.environment) "local" }}
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: team-devops-namespace-manager
+    labels:
+      app: team-devops
+  rules:
+    - apiGroups:
+        - ""
+      resources:
+        - namespaces
+      verbs:
+        - get
+        - list
+        - create
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: team-devops
+    labels:
+      app: team-devops
+  subjects:
+    - kind: ServiceAccount
+      name: team-devops
+      namespace: {{ .Release.Namespace }}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: admin
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: team-devops-namespace-manager
+    labels:
+      app: team-devops
+  subjects:
+    - kind: ServiceAccount
+      name: team-devops
+      namespace: {{ .Release.Namespace }}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: team-devops-namespace-manager
+  ---
+  {{- end }}
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: team-devops
+    labels:
+      app: team-devops
+  spec:
+    strategy:
+      type: Recreate
+    selector:
+      matchLabels:
+        app: team-devops
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: team-devops
+      spec:
+        automountServiceAccountToken: true
+        serviceAccountName: team-devops
+        securityContext:
+          fsGroup: 1000
+        initContainers:
+          - image: tonistiigi/binfmt:qemu-v10.0.4-56
+            name: install-binfmt
+            imagePullPolicy: IfNotPresent
+            args:
+              - --install
+              - amd64,arm64
+            securityContext:
+              privileged: true
+  {{- if $postgresReset }}
+          - image: {{ $postgresImage }}
+            name: erun-backend-postgres-reset
+            imagePullPolicy: IfNotPresent
+            command:
+              - sh
+              - -lc
+              - rm -rf <HOME>/.erun/postgres && mkdir -p <HOME>/.erun/postgres
+            volumeMounts:
+              - name: erun-home
+                mountPath: <HOME>
+  {{- end }}
+          - image: {{ $postgresImage }}
+            name: erun-backend-postgres
+            imagePullPolicy: IfNotPresent
+            restartPolicy: Always
+            env:
+              - name: POSTGRES_DB
+                value: {{ $postgresDatabase | quote }}
+              - name: POSTGRES_USER
+                value: {{ $postgresUser | quote }}
+              - name: POSTGRES_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $postgresPasswordSecretName }}
+                    key: {{ $postgresPasswordSecretKey }}
+              - name: PGDATA
+                value: /var/lib/postgresql/data/pgdata
+            ports:
+              - containerPort: {{ $postgresPort }}
+                name: postgres
+            startupProbe:
+              exec:
+                command:
+                  - sh
+                  - -lc
+                  - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h <VERSION>.1 -p {{ $postgresPort }}
+              periodSeconds: 2
+              timeoutSeconds: 2
+              failureThreshold: 60
+            volumeMounts:
+              - name: erun-home
+                mountPath: /var/lib/postgresql/data
+                subPath: {{ $postgresDataSubPath | quote }}
+          - image: {{ $backendDBImage }}
+            name: erun-backend-db
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: HOME
+                value: <HOME>
+              - name: ERUN_POSTGRES_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $postgresPasswordSecretName }}
+                    key: {{ $postgresPasswordSecretKey }}
+              - name: ERUN_DATABASE_URL
+                value: {{ $databaseURL | quote }}
+            volumeMounts:
+              - name: erun-home
+                mountPath: <HOME>
+        containers:
+          - image: {{ $devopsImage }}
+            name: team-devops
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: HOME
+                value: <HOME>
+              - name: KUBECONFIG
+                value: <HOME>/.kube/config
+              - name: DOCKER_HOST
+                value: unix:///var/run/docker.sock
+              - name: DOCKER_BUILDKIT
+                value: "1"
+              - name: ERUN_REPO_PATH
+                value: {{ $worktreePath | quote }}
+              - name: ERUN_REPO_REMOTE
+                value: {{ if eq $worktreeStorage "pvc" }}"true"{{ else }}"false"{{ end }}
+              - name: ERUN_CLOUD_ENVIRONMENT
+                value: {{ if $managedCloud }}"true"{{ else }}"false"{{ end }}
+              - name: ERUN_CLOUD_CONTEXT_NAME
+                value: {{ $cloudContextName | quote }}
+              - name: ERUN_CLOUD_PROVIDER
+                value: {{ $cloudProvider | quote }}
+              - name: ERUN_CLOUD_PROVIDER_ALIAS
+                value: {{ $cloudProviderAlias | quote }}
+              - name: ERUN_CLOUD_REGION
+                value: {{ $cloudRegion | quote }}
+              - name: ERUN_CLOUD_INSTANCE_ID
+                value: {{ $cloudInstanceID | quote }}
+              {{ if eq $cloudProvider "aws" }}
+              - name: CLAUDE_CODE_USE_BEDROCK
+                value: {{ $claudeUseBedrock | quote }}
+              - name: CLAUDE_CODE_USE_MANTLE
+                value: {{ $claudeUseMantle | quote }}
+              - name: AWS_REGION
+                value: {{ $cloudRegion | quote }}
+              - name: ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION
+                value: {{ $claudeSmallFastRegion | quote }}
+              - name: ERUN_CLAUDE_AVAILABLE_MODELS
+                value: {{ $claudeAvailableModels | quote }}
+              - name: CLAUDE_CODE_MAX_OUTPUT_TOKENS
+                value: {{ $claudeMaxOutputTokens | quote }}
+              - name: MAX_THINKING_TOKENS
+                value: {{ $claudeMaxThinkingTokens | quote }}
+              {{ if $claudeModel }}
+              - name: ANTHROPIC_MODEL
+                value: {{ $claudeModel | quote }}
+              {{ end }}
+              {{ if $claudeDefaultOpusModel }}
+              - name: ANTHROPIC_DEFAULT_OPUS_MODEL
+                value: {{ $claudeDefaultOpusModel | quote }}
+              {{ end }}
+              {{ if $claudeDefaultSonnetModel }}
+              - name: ANTHROPIC_DEFAULT_SONNET_MODEL
+                value: {{ $claudeDefaultSonnetModel | quote }}
+              {{ end }}
+              {{ if $claudeDefaultHaikuModel }}
+              - name: ANTHROPIC_DEFAULT_HAIKU_MODEL
+                value: {{ $claudeDefaultHaikuModel | quote }}
+              {{ end }}
+              {{ if $claudeBedrockBaseURL }}
+              - name: ANTHROPIC_BEDROCK_BASE_URL
+                value: {{ $claudeBedrockBaseURL | quote }}
+              {{ end }}
+              {{ if $claudeMantleBaseURL }}
+              - name: ANTHROPIC_BEDROCK_MANTLE_BASE_URL
+                value: {{ $claudeMantleBaseURL | quote }}
+              {{ end }}
+              {{ if $claudeBedrockServiceTier }}
+              - name: ANTHROPIC_BEDROCK_SERVICE_TIER
+                value: {{ $claudeBedrockServiceTier | quote }}
+              {{ end }}
+              {{ if $claudeSkipMantleAuth }}
+              - name: CLAUDE_CODE_SKIP_MANTLE_AUTH
+                value: {{ $claudeSkipMantleAuth | quote }}
+              {{ end }}
+              {{ if $claudeDisablePromptCaching }}
+              - name: DISABLE_PROMPT_CACHING
+                value: {{ $claudeDisablePromptCaching | quote }}
+              {{ end }}
+              {{ if $claudeEnablePromptCaching1H }}
+              - name: ENABLE_PROMPT_CACHING_1H
+                value: {{ $claudeEnablePromptCaching1H | quote }}
+              {{ end }}
+              {{ end }}
+              - name: ERUN_KUBERNETES_CONTEXT
+                value: in-cluster
+              - name: ERUN_TENANT
+                value: {{ required "tenant is required" .Values.tenant | quote }}
+              - name: ERUN_ENVIRONMENT
+                value: {{ required "environment is required" .Values.environment | quote }}
+              - name: ERUN_SSHD_ENABLED
+                value: {{ if .Values.sshdEnabled }}"true"{{ else }}"false"{{ end }}
+              - name: ERUN_MCP_PORT
+                value: {{ $mcpPort | quote }}
+              - name: ERUN_SSHD_PORT
+                value: {{ $sshPort | quote }}
+              - name: ERUN_IDLE_TIMEOUT
+                value: {{ $idleTimeout | quote }}
+              - name: ERUN_IDLE_WORKING_HOURS
+                value: {{ $idleWorkingHours | quote }}
+              - name: ERUN_IDLE_TIMEZONE
+                value: {{ $idleTimezone | quote }}
+              - name: ERUN_IDLE_TRAFFIC_BYTES
+                value: {{ $idleTrafficBytes | quote }}
+              - name: ERUN_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+            securityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
+            ports:
+              - containerPort: {{ $sshPort }}
+                name: ssh
+            resources:
+              limits:
+                cpu: {{ $runtimeCPU | quote }}
+                memory: {{ $runtimeMemory | quote }}
+              requests:
+                cpu: {{ $runtimeRequestCPU | quote }}
+                memory: {{ $runtimeRequestMemory | quote }}
+            volumeMounts:
+              - name: erun-home
+                mountPath: <HOME>
+  {{- if eq $worktreeStorage "host" }}
+              - name: repo-worktree
+                mountPath: {{ $worktreePath | quote }}
+  {{- end }}
+              - name: docker-socket
+                mountPath: /var/run
+          - image: {{ $mcpImage }}
+            name: erun-mcp
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: HOME
+                value: <HOME>
+              - name: KUBECONFIG
+                value: <HOME>/.kube/config
+              - name: DOCKER_HOST
+                value: unix:///var/run/docker.sock
+              - name: DOCKER_BUILDKIT
+                value: "1"
+              - name: ERUN_REPO_PATH
+                value: {{ $worktreePath | quote }}
+              - name: ERUN_REPO_REMOTE
+                value: {{ if eq $worktreeStorage "pvc" }}"true"{{ else }}"false"{{ end }}
+              - name: ERUN_KUBERNETES_CONTEXT
+                value: in-cluster
+              - name: ERUN_TENANT
+                value: {{ required "tenant is required" .Values.tenant | quote }}
+              - name: ERUN_ENVIRONMENT
+                value: {{ required "environment is required" .Values.environment | quote }}
+              - name: ERUN_MCP_PORT
+                value: {{ $mcpPort | quote }}
+              - name: ERUN_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+            ports:
+              - containerPort: {{ $mcpPort }}
+                name: mcp
+            volumeMounts:
+              - name: erun-home
+                mountPath: <HOME>
+  {{- if eq $worktreeStorage "host" }}
+              - name: repo-worktree
+                mountPath: {{ $worktreePath | quote }}
+  {{- end }}
+              - name: docker-socket
+                mountPath: /var/run
+          - image: {{ $backendAPIImage }}
+            name: erun-backend-api
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: HOME
+                value: <HOME>
+              - name: ERUN_API_HOST
+                value: <VERSION>.0
+              - name: ERUN_API_PORT
+                value: {{ $apiPort | quote }}
+              - name: ERUN_POSTGRES_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $postgresPasswordSecretName }}
+                    key: {{ $postgresPasswordSecretKey }}
+              - name: ERUN_DATABASE_URL
+                value: {{ $databaseURL | quote }}
+              - name: ERUN_OIDC_ALLOWED_ISSUERS
+                value: {{ $oidcAllowedIssuers | quote }}
+              - name: ERUN_AWS_IDENTITY_STORE_ID
+                value: {{ $awsIdentityStoreID | quote }}
+              - name: ERUN_AWS_IDENTITY_STORE_REGION
+                value: {{ $awsIdentityStoreRegion | quote }}
+              - name: ERUN_TENANT
+                value: {{ required "tenant is required" .Values.tenant | quote }}
+              - name: ERUN_ENVIRONMENT
+                value: {{ required "environment is required" .Values.environment | quote }}
+            ports:
+              - containerPort: {{ $apiPort }}
+                name: api
+            volumeMounts:
+              - name: erun-home
+                mountPath: <HOME>
+          - image: {{ $dindImage }}
+            name: erun-dind
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: DOCKER_TLS_CERTDIR
+                value: ""
+            securityContext:
+              privileged: true
+            readinessProbe:
+              exec:
+                command:
+                  - sh
+                  - -lc
+                  - docker info >/dev/null 2>&1
+              periodSeconds: 2
+              timeoutSeconds: 2
+              failureThreshold: 30
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                    - sh
+                    - -lc
+                    - while [ ! -S /var/run/docker.sock ]; do sleep 1; done; chmod 0666 /var/run/docker.sock
+            volumeMounts:
+              - name: docker-socket
+                mountPath: /var/run
+              - name: docker-state
+                mountPath: /var/lib/docker
+        volumes:
+          - name: erun-home
+            persistentVolumeClaim:
+              claimName: team-devops-home
+  {{- if eq $worktreeStorage "host" }}
+          - name: repo-worktree
+            hostPath:
+              path: {{ required "worktreeHostPath is required" .Values.worktreeHostPath | quote }}
+              type: DirectoryOrCreate
+  {{- end }}
+          - name: docker-socket
+            emptyDir: {}
+          - name: docker-state
+            persistentVolumeClaim:
+              claimName: team-devops-docker
+        restartPolicy: Always
+  ' > "$erun_bootstrap_tmp_4"
+  replace=false
+  if [ ! -e '<HOME>/git/team/team-devops/k8s/team-devops/templates/service.yaml' ]; then
+    replace=true
+  elif cmp -s "$erun_bootstrap_tmp_4" '<HOME>/git/team/team-devops/k8s/team-devops/templates/service.yaml'; then
+    replace=false
+  else
+    erun_bootstrap_legacy_4_0=$(mktemp)
+    printf %s '{{- $worktreeStorage := default "host" .Values.worktreeStorage -}}
+  {{- $worktreeRepoName := required "worktreeRepoName is required" .Values.worktreeRepoName -}}
+  {{- $worktreePath := printf "<HOME>/git/%s" $worktreeRepoName -}}
+  {{- $idle := default dict .Values.idle -}}
+  {{- $idleTimeout := default "5m0s" $idle.timeout -}}
+  {{- $idleWorkingHours := default "08:00-20:00" $idle.workingHours -}}
+  {{- $idleTimezone := default "" $idle.timezone -}}
+  {{- $idleTrafficBytes := default 0 $idle.trafficBytes -}}
+  {{- $runtime := default dict .Values.runtime -}}
+  {{- $runtimeResources := default dict $runtime.resources -}}
+  {{- $runtimeLimits := default dict $runtimeResources.limits -}}
+  {{- $runtimeRequests := default dict $runtimeResources.requests -}}
+  {{- $runtimeCPU := default "4" $runtimeLimits.cpu -}}
+  {{- $runtimeMemory := default "8916Mi" $runtimeLimits.memory -}}
+  {{- $runtimeRequestCPU := default "0.25" $runtimeRequests.cpu -}}
+  {{- $runtimeRequestMemory := default "1024Mi" $runtimeRequests.memory -}}
+  {{- $managedCloud := default false .Values.managedCloud -}}
+  {{- $awsIdentityStoreID := default "" $api.awsIdentityStoreID -}}
+  {{- $awsIdentityStoreRegion := default "" $api.awsIdentityStoreRegion -}}
+  {{- $postgres := default dict $api.postgres -}}
+  {{- $postgresDatabase := default "erun" $postgres.database -}}
+  {{- $postgresUser := default "erun" $postgres.user -}}
+  {{- $postgresPort := default 5432 $postgres.port -}}
+  {{- $postgresPasswordSecretName := default "erun-backend-postgres" $postgres.passwordSecretName -}}
+  {{- $postgresPasswordSecretKey := default "password" $postgres.passwordSecretKey -}}
+  {{- $postgresPassword := default "" $postgres.password -}}
+  {{- $postgresReset := default false $postgres.reset -}}
+  {{- $existingPostgresSecret := lookup "v1" "Secret" .Release.Namespace $postgresPasswordSecretName -}}
+  {{- if and (eq $postgresPassword "") $existingPostgresSecret (hasKey $existingPostgresSecret.data $postgresPasswordSecretKey) -}}
+  {{- $postgresPassword = (index $existingPostgresSecret.data $postgresPasswordSecretKey | b64dec) -}}
+  {{- end -}}
+  {{- if eq $postgresPassword "" -}}
+  {{- $postgresPassword = randAlphaNum 32 -}}
+  {{- end -}}
+  {{- $postgresDataSubPath := default ".erun/postgres" $postgres.dataSubPath -}}
+  {{- $databaseURL := default (printf "postgres://%s:$(ERUN_POSTGRES_PASSWORD)@<VERSION>.1:%v/%s?sslmode=disable" $postgresUser $postgresPort $postgresDatabase) $api.databaseURL -}}
+  {{- $imageOverrides := default dict .Values.imageOverrides -}}
+  {{- $backendDBImage := default (printf "ghcr.io/sophium/erun-backend-db:%s" .Chart.AppVersion) (index $imageOverrides "erun-backend-db") -}}
+  {{- $devopsImage := default (printf "ghcr.io/sophium/team-devops:%s" .Chart.AppVersion) (index $imageOverrides "team-devops") -}}
+  {{- $mcpImage := default (printf "ghcr.io/sophium/erun-mcp:%s" .Chart.AppVersion) (index $imageOverrides "erun-mcp") -}}
+  {{- $backendAPIImage := default (printf "ghcr.io/sophium/erun-backend-api:%s" .Chart.AppVersion) (index $imageOverrides "erun-backend-api") -}}
+  {{- $postgresImage := default "postgres:18" (index $imageOverrides "postgres") -}}
+  {{- $dindImage := default "ghcr.io/sophium/erun-dind:<VERSION>" (index $imageOverrides "erun-dind") -}}
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: {{ $postgresPasswordSecretName }}
+    labels:
+      app: team-devops
+  type: Opaque
+  stringData:
+    {{ $postgresPasswordSecretKey }}: {{ $postgresPassword | quote }}
+  ---
+  apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: team-devops-home
+    labels:
+      app: team-devops
+  spec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 2Gi
+  ---
+  apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: team-devops-docker
+    labels:
+      app: team-devops
+  spec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 50Gi
+  ---
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: team-devops
+    labels:
+      app: team-devops
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: team-devops
+    labels:
+      app: team-devops
+  subjects:
+    - kind: ServiceAccount
+      name: team-devops
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: admin
+  ---
+  {{- if eq (required "environment is required" .Values.environment) "local" }}
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: team-devops-namespace-manager
+    labels:
+      app: team-devops
+  rules:
+    - apiGroups:
+        - ""
+      resources:
+        - namespaces
+      verbs:
+        - get
+        - list
+        - create
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: team-devops
+    labels:
+      app: team-devops
+  subjects:
+    - kind: ServiceAccount
+      name: team-devops
+      namespace: {{ .Release.Namespace }}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: admin
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: team-devops-namespace-manager
+    labels:
+      app: team-devops
+  subjects:
+    - kind: ServiceAccount
+      name: team-devops
+      namespace: {{ .Release.Namespace }}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: team-devops-namespace-manager
+  ---
+  {{- end }}
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: team-devops
+    labels:
+      app: team-devops
+  spec:
+    strategy:
+      type: Recreate
+    selector:
+      matchLabels:
+        app: team-devops
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: team-devops
+      spec:
+        automountServiceAccountToken: true
+        serviceAccountName: team-devops
+        securityContext:
+          fsGroup: 1000
+        initContainers:
+          - image: tonistiigi/binfmt:qemu-v10.0.4-56
+            name: install-binfmt
+            imagePullPolicy: IfNotPresent
+            args:
+              - --install
+              - amd64,arm64
+            securityContext:
+              privileged: true
+  {{- if $postgresReset }}
+          - image: {{ $postgresImage }}
+            name: erun-backend-postgres-reset
+            imagePullPolicy: IfNotPresent
+            command:
+              - sh
+              - -lc
+              - rm -rf <HOME>/.erun/postgres && mkdir -p <HOME>/.erun/postgres
+            volumeMounts:
+              - name: erun-home
+                mountPath: <HOME>
+  {{- end }}
+          - image: {{ $postgresImage }}
+            name: erun-backend-postgres
+            imagePullPolicy: IfNotPresent
+            restartPolicy: Always
+            env:
+              - name: POSTGRES_DB
+                value: {{ $postgresDatabase | quote }}
+              - name: POSTGRES_USER
+                value: {{ $postgresUser | quote }}
+              - name: POSTGRES_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $postgresPasswordSecretName }}
+                    key: {{ $postgresPasswordSecretKey }}
+              - name: PGDATA
+                value: /var/lib/postgresql/data/pgdata
+            ports:
+              - containerPort: {{ $postgresPort }}
+                name: postgres
+            startupProbe:
+              exec:
+                command:
+                  - sh
+                  - -lc
+                  - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h <VERSION>.1 -p {{ $postgresPort }}
+              periodSeconds: 2
+              timeoutSeconds: 2
+              failureThreshold: 60
+            volumeMounts:
+              - name: erun-home
+                mountPath: /var/lib/postgresql/data
+                subPath: {{ $postgresDataSubPath | quote }}
+          - image: {{ $backendDBImage }}
+            name: erun-backend-db
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: HOME
+                value: <HOME>
+              - name: ERUN_POSTGRES_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $postgresPasswordSecretName }}
+                    key: {{ $postgresPasswordSecretKey }}
+              - name: ERUN_DATABASE_URL
+                value: {{ $databaseURL | quote }}
+            volumeMounts:
+              - name: erun-home
+                mountPath: <HOME>
+        containers:
+          - image: {{ $devopsImage }}
+            name: team-devops
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: HOME
+                value: <HOME>
+              - name: KUBECONFIG
+                value: <HOME>/.kube/config
+              - name: DOCKER_HOST
+                value: unix:///var/run/docker.sock
+              - name: DOCKER_BUILDKIT
+                value: "1"
+              - name: ERUN_REPO_PATH
+                value: {{ $worktreePath | quote }}
+              - name: ERUN_REPO_REMOTE
+                value: {{ if eq $worktreeStorage "pvc" }}"true"{{ else }}"false"{{ end }}
+              - name: ERUN_CLOUD_ENVIRONMENT
+                value: {{ if $managedCloud }}"true"{{ else }}"false"{{ end }}
+              - name: ERUN_KUBERNETES_CONTEXT
+                value: in-cluster
+              - name: ERUN_TENANT
+                value: {{ required "tenant is required" .Values.tenant | quote }}
+              - name: ERUN_ENVIRONMENT
+                value: {{ required "environment is required" .Values.environment | quote }}
+              - name: ERUN_SSHD_ENABLED
+                value: {{ if .Values.sshdEnabled }}"true"{{ else }}"false"{{ end }}
+              - name: ERUN_MCP_PORT
+                value: {{ $mcpPort | quote }}
+              - name: ERUN_SSHD_PORT
+                value: {{ $sshPort | quote }}
+              - name: ERUN_IDLE_TIMEOUT
+                value: {{ $idleTimeout | quote }}
+              - name: ERUN_IDLE_WORKING_HOURS
+                value: {{ $idleWorkingHours | quote }}
+              - name: ERUN_IDLE_TIMEZONE
+                value: {{ $idleTimezone | quote }}
+              - name: ERUN_IDLE_TRAFFIC_BYTES
+                value: {{ $idleTrafficBytes | quote }}
+              - name: ERUN_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+            securityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
+            ports:
+              - containerPort: {{ $sshPort }}
+                name: ssh
+            resources:
+              limits:
+                cpu: {{ $runtimeCPU | quote }}
+                memory: {{ $runtimeMemory | quote }}
+              requests:
+                cpu: {{ $runtimeRequestCPU | quote }}
+                memory: {{ $runtimeRequestMemory | quote }}
+            volumeMounts:
+              - name: erun-home
+                mountPath: <HOME>
+  {{- if eq $worktreeStorage "host" }}
+              - name: repo-worktree
+                mountPath: {{ $worktreePath | quote }}
+  {{- end }}
+              - name: docker-socket
+                mountPath: /var/run
+          - image: {{ $mcpImage }}
+            name: erun-mcp
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: HOME
+                value: <HOME>
+              - name: KUBECONFIG
+                value: <HOME>/.kube/config
+              - name: DOCKER_HOST
+                value: unix:///var/run/docker.sock
+              - name: DOCKER_BUILDKIT
+                value: "1"
+              - name: ERUN_REPO_PATH
+                value: {{ $worktreePath | quote }}
+              - name: ERUN_REPO_REMOTE
+                value: {{ if eq $worktreeStorage "pvc" }}"true"{{ else }}"false"{{ end }}
+              - name: ERUN_KUBERNETES_CONTEXT
+                value: in-cluster
+              - name: ERUN_TENANT
+                value: {{ required "tenant is required" .Values.tenant | quote }}
+              - name: ERUN_ENVIRONMENT
+                value: {{ required "environment is required" .Values.environment | quote }}
+              - name: ERUN_MCP_PORT
+                value: {{ $mcpPort | quote }}
+              - name: ERUN_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+            ports:
+              - containerPort: {{ $mcpPort }}
+                name: mcp
+            volumeMounts:
+              - name: erun-home
+                mountPath: <HOME>
+  {{- if eq $worktreeStorage "host" }}
+              - name: repo-worktree
+                mountPath: {{ $worktreePath | quote }}
+  {{- end }}
+              - name: docker-socket
+                mountPath: /var/run
+          - image: {{ $backendAPIImage }}
+            name: erun-backend-api
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: HOME
+                value: <HOME>
+              - name: ERUN_API_HOST
+                value: <VERSION>.0
+              - name: ERUN_API_PORT
+                value: {{ $apiPort | quote }}
+              - name: ERUN_POSTGRES_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $postgresPasswordSecretName }}
+                    key: {{ $postgresPasswordSecretKey }}
+              - name: ERUN_DATABASE_URL
+                value: {{ $databaseURL | quote }}
+              - name: ERUN_OIDC_ALLOWED_ISSUERS
+                value: {{ $oidcAllowedIssuers | quote }}
+              - name: ERUN_AWS_IDENTITY_STORE_ID
+                value: {{ $awsIdentityStoreID | quote }}
+              - name: ERUN_AWS_IDENTITY_STORE_REGION
+                value: {{ $awsIdentityStoreRegion | quote }}
+              - name: ERUN_TENANT
+                value: {{ required "tenant is required" .Values.tenant | quote }}
+              - name: ERUN_ENVIRONMENT
+                value: {{ required "environment is required" .Values.environment | quote }}
+            ports:
+              - containerPort: {{ $apiPort }}
+                name: api
+            volumeMounts:
+              - name: erun-home
+                mountPath: <HOME>
+          - image: {{ $dindImage }}
+            name: erun-dind
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: DOCKER_TLS_CERTDIR
+                value: ""
+            securityContext:
+              privileged: true
+            readinessProbe:
+              exec:
+                command:
+                  - sh
+                  - -lc
+                  - docker info >/dev/null 2>&1
+              periodSeconds: 2
+              timeoutSeconds: 2
+              failureThreshold: 30
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                    - sh
+                    - -lc
+                    - while [ ! -S /var/run/docker.sock ]; do sleep 1; done; chmod 0666 /var/run/docker.sock
+            volumeMounts:
+              - name: docker-socket
+                mountPath: /var/run
+              - name: docker-state
+                mountPath: /var/lib/docker
+        volumes:
+          - name: erun-home
+            persistentVolumeClaim:
+              claimName: team-devops-home
+  {{- if eq $worktreeStorage "host" }}
+          - name: repo-worktree
+            hostPath:
+              path: {{ required "worktreeHostPath is required" .Values.worktreeHostPath | quote }}
+              type: DirectoryOrCreate
+  {{- end }}
+          - name: docker-socket
+            emptyDir: {}
+          - name: docker-state
+            persistentVolumeClaim:
+              claimName: team-devops-docker
+        restartPolicy: Always
+  ' > "$erun_bootstrap_legacy_4_0"
+    if cmp -s "$erun_bootstrap_legacy_4_0" '<HOME>/git/team/team-devops/k8s/team-devops/templates/service.yaml'; then replace=true; fi
+    rm -f "$erun_bootstrap_legacy_4_0"
+  fi
+  if [ "$replace" = true ]; then cp "$erun_bootstrap_tmp_4" '<HOME>/git/team/team-devops/k8s/team-devops/templates/service.yaml'; chmod '644' '<HOME>/git/team/team-devops/k8s/team-devops/templates/service.yaml'; fi
+  rm -f "$erun_bootstrap_tmp_4"
+  mkdir -p '<HOME>/git/team/team-devops/k8s/team-devops'
+  if [ -d '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml' ]; then echo '"<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml" is a directory' >&2; exit 1; fi
+  erun_bootstrap_tmp_5=$(mktemp)
+  printf %s '' > "$erun_bootstrap_tmp_5"
+  replace=false
+  if [ ! -e '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml' ]; then
+    replace=true
+  elif cmp -s "$erun_bootstrap_tmp_5" '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml'; then
+    replace=false
+  else
+    replace=false
+  fi
+  if [ "$replace" = true ]; then cp "$erun_bootstrap_tmp_5" '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml'; chmod '644' '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml'; fi
+  rm -f "$erun_bootstrap_tmp_5"
+mkdir -p <TMP>
+write-yaml <TMP>
+Configuration initialized OK
+ensure-agent-instructions
+ensure-claude-settings

--- a/erun-integration/testdata/list/cwd_overrides_default_tenant.txt
+++ b/erun-integration/testdata/list/cwd_overrides_default_tenant.txt
@@ -22,9 +22,57 @@ Tenants:
   tenant-a [default]
     default environment: local
     environments:
-      - local [default] context=cluster-local snapshot=off repo=<TMP> ports=17000-17099 mcp-port=17000 api-port=17033 api-url=http://<VERSION>.1:17033 ssh-port=17022
-      - prod context=cluster-prod snapshot=off repo=<TMP> ports=17100-17199 mcp-port=17100 api-port=17133 api-url=http://<VERSION>.1:17133 ssh-port=17122
+      - local [default] context=cluster-local
+          remote: off
+          snapshot: off
+          repo: <TMP>
+          ports: 17000-17099
+          mcp-port: 17000
+          api-port: 17033
+          api-url: http://<VERSION>.1:17033
+          ssh-port: 17022
+          container-registry: none
+          runtime-version: none
+          runtime-pod: none
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: off
+      - prod context=cluster-prod
+          remote: off
+          snapshot: off
+          repo: <TMP>
+          ports: 17100-17199
+          mcp-port: 17100
+          api-port: 17133
+          api-url: http://<VERSION>.1:17133
+          ssh-port: 17122
+          container-registry: none
+          runtime-version: none
+          runtime-pod: none
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: off
   tenant-b [effective]
     default environment: dev
     environments:
-      - dev [default, effective] context=cluster-b snapshot=off repo=<TMP> ports=17200-17299 mcp-port=17200 api-port=17233 api-url=http://<VERSION>.1:17233 ssh-port=17222
+      - dev [default, effective] context=cluster-b
+          remote: off
+          snapshot: off
+          repo: <TMP>
+          ports: 17200-17299
+          mcp-port: 17200
+          api-port: 17233
+          api-url: http://<VERSION>.1:17233
+          ssh-port: 17222
+          container-registry: none
+          runtime-version: none
+          runtime-pod: none
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: off

--- a/erun-integration/testdata/list/multi_tenant_with_multiple_envs.txt
+++ b/erun-integration/testdata/list/multi_tenant_with_multiple_envs.txt
@@ -22,9 +22,57 @@ Tenants:
   tenant-a [default, effective]
     default environment: local
     environments:
-      - local [default, effective] context=cluster-local snapshot=off repo=<TMP> ports=17000-17099 mcp-port=17000 api-port=17033 api-url=http://<VERSION>.1:17033 ssh-port=17022
-      - prod context=cluster-prod snapshot=off repo=<TMP> ports=17100-17199 mcp-port=17100 api-port=17133 api-url=http://<VERSION>.1:17133 ssh-port=17122
+      - local [default, effective] context=cluster-local
+          remote: off
+          snapshot: off
+          repo: <TMP>
+          ports: 17000-17099
+          mcp-port: 17000
+          api-port: 17033
+          api-url: http://<VERSION>.1:17033
+          ssh-port: 17022
+          container-registry: none
+          runtime-version: none
+          runtime-pod: none
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: off
+      - prod context=cluster-prod
+          remote: off
+          snapshot: off
+          repo: <TMP>
+          ports: 17100-17199
+          mcp-port: 17100
+          api-port: 17133
+          api-url: http://<VERSION>.1:17133
+          ssh-port: 17122
+          container-registry: none
+          runtime-version: none
+          runtime-pod: none
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: off
   tenant-b
     default environment: dev
     environments:
-      - dev [default] context=cluster-b snapshot=off repo=<TMP> ports=17200-17299 mcp-port=17200 api-port=17233 api-url=http://<VERSION>.1:17233 ssh-port=17222
+      - dev [default] context=cluster-b
+          remote: off
+          snapshot: off
+          repo: <TMP>
+          ports: 17200-17299
+          mcp-port: 17200
+          api-port: 17233
+          api-url: http://<VERSION>.1:17233
+          ssh-port: 17222
+          container-registry: none
+          runtime-version: none
+          runtime-pod: none
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: off

--- a/erun-integration/testdata/list/sshd_configured.txt
+++ b/erun-integration/testdata/list/sshd_configured.txt
@@ -26,4 +26,27 @@ Tenants:
   tenant-a [default, effective]
     default environment: dev
     environments:
-      - dev [default, effective] context=cluster-dev snapshot=off repo=<TMP> ports=17000-17099 mcp-port=17000 api-port=17033 api-url=http://<VERSION>.1:17033 ssh-port=17022 ssh=on host=erun-tenant-a-dev user=erun local-port=17022 workspace=<HOME>/git/tenant-a
+      - dev [default, effective] context=cluster-dev
+          remote: on
+          snapshot: off
+          repo: <TMP>
+          ports: 17000-17099
+          mcp-port: 17000
+          api-port: 17033
+          api-url: http://<VERSION>.1:17033
+          ssh-port: 17022
+          container-registry: none
+          runtime-version: none
+          runtime-pod: none
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: on
+          ssh-host: erun-tenant-a-dev
+          ssh-user: erun
+          ssh-local-port: 17022
+          ssh-workspace: <HOME>/git/tenant-a
+          ssh-public-key-path: <TMP>
+          ssh-workspace-sync: off
+          ssh-workspace-sync-local-path: none

--- a/erun-integration/testdata/list/with_seeded_tenant_env.txt
+++ b/erun-integration/testdata/list/with_seeded_tenant_env.txt
@@ -22,4 +22,20 @@ Tenants:
   team [default, effective]
     default environment: dev
     environments:
-      - dev [default, effective] context=test-context snapshot=off repo=<TMP> ports=17000-17099 mcp-port=17000 api-port=17033 api-url=http://<VERSION>.1:17033 ssh-port=17022
+      - dev [default, effective] context=test-context
+          remote: off
+          snapshot: off
+          repo: <TMP>
+          ports: 17000-17099
+          mcp-port: 17000
+          api-port: 17033
+          api-url: http://<VERSION>.1:17033
+          ssh-port: 17022
+          container-registry: registry.example/test
+          runtime-version: <VERSION>
+          runtime-pod: none
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: off

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -637,7 +637,18 @@ export class ERunUIController {
     this.applyPendingDebugHeader(result.sessionId);
     rebuildTerminalDisplayBuffer(this.sessions, result.sessionId);
     this.state.sessionId = result.sessionId;
-    this.state.selectedSessionByEnv = { ...this.state.selectedSessionByEnv, [key]: result.sessionId };
+    // Preserve the user's prior tab choice for this env across re-opens
+    // (Nielsen heuristic #4: consistency / user control). Only seed
+    // selectedSessionByEnv when nothing is remembered, or when the
+    // remembered session no longer exists in the live tabs for this env.
+    // restoreSelectedTabForEnv below switches the terminal back to the
+    // remembered tab when one exists.
+    const remembered = this.state.selectedSessionByEnv[key];
+    const liveTabs = this.state.tabsByEnv[key] || [];
+    const rememberedIsLive = remembered && liveTabs.some((tab) => tab.sessionId === remembered);
+    if (!rememberedIsLive) {
+      this.state.selectedSessionByEnv = { ...this.state.selectedSessionByEnv, [key]: result.sessionId };
+    }
     this.syncDebugDisplay();
     const slot = result.slot ?? 0;
     const kind: TerminalTabKind = slot === 0 ? 'erun' : 'extra';

--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -47,14 +47,14 @@ export function ManageDialogView({ controller, state }: { controller: ERunUICont
   return (
     <Dialog open={dialog.open} onOpenChange={(open) => !open && controller.closeManageDialog()}>
       <DialogContent
-        className="max-h-[min(85vh,800px)] sm:max-w-2xl"
+        className="h-[min(85vh,800px)] sm:max-w-2xl"
         onCloseAutoFocus={(event) => {
           event.preventDefault();
           controller.focusTerminalSoon();
         }}
       >
         <form
-          className="flex max-h-[calc(min(85vh,800px)-3rem)] min-h-0 flex-col gap-4"
+          className="flex h-[calc(min(85vh,800px)-3rem)] min-h-0 flex-col gap-4"
           onSubmit={(event) => {
             event.preventDefault();
             if (confirmingDelete && deleteEnabled) {


### PR DESCRIPTION
## Summary

- Deploy succeeds for `remote: true` envs from any cwd (no local tenant checkout needed). `ResolveCurrentDeploySpecs` now uses the embedded `default-devops` chart for `RemoteRepo()` envs, matching the open flow.
- Action commands (`deploy`, `build`, `push`, `release`, `init`, `delete`) default to verbosity 1 so the audit line, kubectl prep, and helm command print before helm starts waiting. No more silent "what is going on?" minutes.
- `erun list` exposes every `EnvConfig` field per env (`remote`, `runtime-version`, `runtime-pod`, `managed-cloud`, `ai-tool`, `claude`, `idle`, sshd workspace-sync) so misconfigurations are visible.
- Desktop UI keeps the active terminal tab when switching tenants/envs by not overwriting `selectedSessionByEnv` on re-open.
- Manage Environment dialog uses a fixed height so the top edge stays put when switching tabs (General/Runtime/AI/Ports/SSH).

Closes #258

## Test plan

- [x] `erun-common` `go test ./...`
- [x] `erun-cli` `go test ./...`
- [x] `erun-integration` `go test -run "TestDeploy|TestList|TestOpen|TestInit|TestBuild|TestPush|TestRelease|TestDelete" ./...`
- [x] New regression scenario `TestDeploy/dry_run_remote_env_uses_embedded_chart` covers remote-env-from-anywhere
- [x] 4 list goldens + 2 `real_run_via_stubs` goldens regenerated to capture the new visible-by-default trace and multi-line list format
- [x] `erun-ui` `go test ./...` and `tsc -b`
- [ ] `yarn build` on Mac (current Linux dev env hits a rolldown native-binding issue)
- [ ] Manual verify: deploy a remote env from `$HOME` and watch trace stream
- [ ] Manual verify: switch envs in desktop UI and confirm active tab persists per env
- [ ] Manual verify: open Manage Environment dialog and confirm top edge stays fixed when changing tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)