### PR TITLE
Apply incremental build to deploy and push paths

### DIFF
--- a/erun-common/build_incremental.go
+++ b/erun-common/build_incremental.go
@@ -412,15 +412,24 @@ type LocalDockerImageInspector func(tag string) (bool, error)
 // noIncremental is true it returns execution unchanged. Errors during fingerprint
 // computation propagate so callers can decide how to surface them.
 func ApplyIncrementalToBuildExecution(execution BuildExecutionSpec, noIncremental bool) (BuildExecutionSpec, error) {
-	if noIncremental || len(execution.dockerBuilds) == 0 {
-		return execution, nil
-	}
-	updated, err := applyIncrementalPromotion(execution.dockerBuilds, nil)
+	updated, err := ApplyIncrementalToDockerBuilds(execution.dockerBuilds, noIncremental)
 	if err != nil {
 		return BuildExecutionSpec{}, err
 	}
 	execution.dockerBuilds = updated
 	return execution, nil
+}
+
+// ApplyIncrementalToDockerBuilds applies fingerprint-based incremental
+// promotion to a slice of docker builds. When noIncremental is true the slice
+// is returned unchanged. This is the single entry point every command should
+// use so deploy, push, and runtime deploy paths share the same skip logic as
+// erun build.
+func ApplyIncrementalToDockerBuilds(builds []DockerBuildSpec, noIncremental bool) ([]DockerBuildSpec, error) {
+	if noIncremental || len(builds) == 0 {
+		return builds, nil
+	}
+	return applyIncrementalPromotion(builds, nil)
 }
 
 // applyIncrementalPromotion computes a fingerprint for each build and, when an

--- a/erun-common/build_push_plan.go
+++ b/erun-common/build_push_plan.go
@@ -42,6 +42,11 @@ func ResolveDockerPushExecution(store DockerStore, findProjectRoot ProjectFinder
 		pushes = append(pushes, NewDockerPushSpec(buildContext.Dir, imageRef))
 	}
 
+	builds, err = ApplyIncrementalToDockerBuilds(builds, target.NoIncremental)
+	if err != nil {
+		return DockerPushExecutionSpec{}, err
+	}
+
 	return DockerPushExecutionSpec{builds: builds, pushes: pushes}, nil
 }
 
@@ -67,6 +72,11 @@ func ResolveDockerPushSpec(store DockerStore, findProjectRoot ProjectFinderFunc,
 		if err != nil {
 			return DockerPushSpec{}, nil, err
 		}
+		incremental, err := ApplyIncrementalToDockerBuilds([]DockerBuildSpec{resolvedBuild}, target.NoIncremental)
+		if err != nil {
+			return DockerPushSpec{}, nil, err
+		}
+		resolvedBuild = incremental[0]
 		build = &resolvedBuild
 		imageRef = resolvedBuild.Image
 	}

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -338,6 +338,10 @@ func resolveDeploySpecForContext(store DeployStore, findProjectRoot ProjectFinde
 		builds = append(builds, dependencyBuilds...)
 	}
 	builds = configureDockerBuildsForDeploy(builds)
+	builds, err = ApplyIncrementalToDockerBuilds(builds, false)
+	if err != nil {
+		return DeploySpec{}, err
+	}
 
 	return DeploySpec{
 		Target:        target,
@@ -367,6 +371,10 @@ func configureDeployInputMetadata(store DeployStore, target OpenResult, deployIn
 
 func resolveDeploySpecForCurrentDockerBuild(store DeployStore, target OpenResult, deployContext KubernetesDeployContext, build DockerBuildSpec) (DeploySpec, error) {
 	builds := configureDockerBuildsForDeploy([]DockerBuildSpec{build})
+	builds, err := ApplyIncrementalToDockerBuilds(builds, false)
+	if err != nil {
+		return DeploySpec{}, err
+	}
 	deployInput, err := newHelmDeploySpec(target, deployContext, "")
 	if err != nil {
 		return DeploySpec{}, err

--- a/erun-ui/.gitignore
+++ b/erun-ui/.gitignore
@@ -2,3 +2,4 @@
 /frontend/node_modules/
 /frontend/dist/
 /frontend/wailsjs/
+/frontend/*.tsbuildinfo


### PR DESCRIPTION
## Summary

Build has to be always incremental. Today the fingerprint-skip layer (`ApplyIncrementalToBuildExecution`) is applied only by `erun build`. Other paths that produce `DockerBuildSpec` slices — `erun deploy`, `erun push`, `erun open` (managed runtime deploy), `erun sshd init`, and the corresponding MCP tools — bypass it and always issue a full `docker build`.

Closes #262.

## Changes

- New `ApplyIncrementalToDockerBuilds(builds, noIncremental)` slice-level helper in `erun-common/build_incremental.go`. `ApplyIncrementalToBuildExecution` is refactored to delegate to it.
- Apply the helper inside the deploy resolution path (`resolveDeploySpecForContext`, `resolveDeploySpecForCurrentDockerBuild`).
- Apply it inside the push resolution path (`ResolveDockerPushExecution`, `ResolveDockerPushSpec`); push honors `target.NoIncremental` already plumbed via `DockerCommandTarget`.
- Drive-by: ignore `erun-ui/frontend/*.tsbuildinfo` (local TypeScript incremental cache).

`erun build`, MCP `build`, MCP `push`, and MCP `deploy` all reach the deploy/push resolvers, so they inherit the change without further wiring.

## Test plan

- [x] `go test ./...` in `erun-common`, `erun-cli`, `erun-mcp` — all green.
- [x] Targeted integration: `TestBuild`, `TestDeploy`, `TestPush`, `TestOpen`, `TestSshd` — all green.
- [ ] Full `make integration-test` — pre-existing `TestActivity/status_with_seeded_env` and `TestIdle/status_for_seeded_env` fail on `main` too because their goldens are time-of-day sensitive (assume outside working hours 08:00–20:00). Not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)