### PR TITLE
Slim erun-backend-api and erun-backend-db images

### DIFF
--- a/erun-common/sshd_test.go
+++ b/erun-common/sshd_test.go
@@ -266,9 +266,9 @@ func TestRuntimeEntrypointEnsuresClaudeBypassPermissions(t *testing.T) {
 }
 
 func TestRuntimeEntrypointPassesOIDCIssuersToAPI(t *testing.T) {
-	data, err := os.ReadFile(filepath.Join("..", "erun-devops", "docker", "erun-devops", "entrypoint.sh"))
+	data, err := os.ReadFile(filepath.Join("..", "erun-devops", "docker", "erun-backend-api", "entrypoint.sh"))
 	if err != nil {
-		t.Fatalf("read runtime entrypoint: %v", err)
+		t.Fatalf("read backend-api entrypoint: %v", err)
 	}
 	content := string(data)
 	for _, want := range []string{
@@ -276,7 +276,7 @@ func TestRuntimeEntrypointPassesOIDCIssuersToAPI(t *testing.T) {
 		`--oidc-allowed-issuers "${ERUN_OIDC_ALLOWED_ISSUERS}"`,
 	} {
 		if !strings.Contains(content, want) {
-			t.Fatalf("expected runtime entrypoint to contain %q, got:\n%s", want, content)
+			t.Fatalf("expected backend-api entrypoint to contain %q, got:\n%s", want, content)
 		}
 	}
 }

--- a/erun-devops/docker/erun-backend-api/Dockerfile
+++ b/erun-devops/docker/erun-backend-api/Dockerfile
@@ -1,6 +1,41 @@
 ARG ERUN_VERSION=1.0.0
 
-FROM ghcr.io/sophium/erun-devops:${ERUN_VERSION}
+FROM golang:1.26.0 AS builder
 
-ENTRYPOINT ["erun-devops-entrypoint"]
-CMD ["api"]
+WORKDIR /src
+
+COPY erun-backend/erun-backend-api/go.mod erun-backend/erun-backend-api/go.sum /src/erun-backend/erun-backend-api/
+
+WORKDIR /src/erun-backend/erun-backend-api
+
+ARG TARGETOS=linux
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
+
+COPY erun-backend/erun-backend-api /src/erun-backend/erun-backend-api
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags "-s -w" -o /out/eapi ./cmd/eapi
+
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates && \
+    addgroup -S erun && \
+    adduser -S -G erun -h /home/erun erun && \
+    mkdir -p /home/erun && \
+    chown -R erun:erun /home/erun
+
+COPY --from=builder --chmod=0755 /out/eapi /usr/local/bin/eapi
+COPY --chmod=0755 erun-devops/docker/erun-backend-api/entrypoint.sh /usr/local/bin/erun-backend-api-entrypoint
+
+USER erun
+WORKDIR /home/erun
+
+EXPOSE 17033
+
+ENTRYPOINT ["erun-backend-api-entrypoint"]

--- a/erun-devops/docker/erun-backend-api/entrypoint.sh
+++ b/erun-devops/docker/erun-backend-api/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+# Translate optional env-driven config into eapi flags. Mirrors the
+# dispatch the runtime erun-devops-entrypoint used to perform when
+# erun-backend-api shared the runtime image.
+if [ -n "${ERUN_AWS_IDENTITY_STORE_REGION:-}" ]; then
+    set -- --aws-identity-store-region "${ERUN_AWS_IDENTITY_STORE_REGION}" "$@"
+fi
+if [ -n "${ERUN_AWS_IDENTITY_STORE_ID:-}" ]; then
+    set -- --aws-identity-store-id "${ERUN_AWS_IDENTITY_STORE_ID}" "$@"
+fi
+if [ -n "${ERUN_OIDC_ALLOWED_ISSUERS:-}" ]; then
+    set -- --oidc-allowed-issuers "${ERUN_OIDC_ALLOWED_ISSUERS}" "$@"
+fi
+
+echo "starting erun API on ${ERUN_API_HOST:-0.0.0.0}:${ERUN_API_PORT:-17033}"
+
+exec eapi \
+    --host "${ERUN_API_HOST:-0.0.0.0}" \
+    --port "${ERUN_API_PORT:-17033}" \
+    "$@"

--- a/erun-devops/docker/erun-backend-db/Dockerfile
+++ b/erun-devops/docker/erun-backend-db/Dockerfile
@@ -1,9 +1,28 @@
 ARG ERUN_VERSION=1.0.0
 
-FROM ghcr.io/sophium/erun-devops:${ERUN_VERSION}
+FROM alpine:3.20 AS atlas-fetcher
 
-USER root
+ARG TARGETARCH
+ARG ATLAS_VERSION=v1.2.0
 
+RUN apk add --no-cache ca-certificates curl && \
+    case "${TARGETARCH}" in \
+        amd64) atlas_arch=amd64 ;; \
+        arm64) atlas_arch=arm64 ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL -o /atlas "https://release.ariga.io/atlas/atlas-linux-${atlas_arch}-${ATLAS_VERSION}" && \
+    chmod 0755 /atlas
+
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates && \
+    addgroup -S erun && \
+    adduser -S -G erun -h /home/erun erun && \
+    mkdir -p /opt/erun-backend-db /home/erun && \
+    chown -R erun:erun /opt/erun-backend-db /home/erun
+
+COPY --from=atlas-fetcher /atlas /usr/local/bin/atlas
 COPY erun-backend/erun-backend-db /opt/erun-backend-db
 COPY --chmod=0755 erun-devops/docker/erun-backend-db/migrate.sh /usr/local/bin/erun-backend-db-migrate
 

--- a/erun-devops/docker/erun-devops/Dockerfile
+++ b/erun-devops/docker/erun-devops/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /src
 COPY erun-cli/go.mod erun-cli/go.sum erun-cli/go.work erun-cli/go.work.sum /src/erun-cli/
 COPY erun-common/go.mod /src/erun-common/go.mod
 COPY erun-mcp/go.mod erun-mcp/go.sum /src/erun-mcp/
-COPY erun-backend/erun-backend-api/go.mod erun-backend/erun-backend-api/go.sum /src/erun-backend/erun-backend-api/
 COPY erun-devops/VERSION /src/erun-devops/VERSION
 
 WORKDIR /src/erun-cli
@@ -19,13 +18,11 @@ ARG ERUN_DATE=""
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go mod download && \
-    cd /src/erun-backend/erun-backend-api && go mod download
+    go mod download
 
 COPY erun-cli /src/erun-cli
 COPY erun-common /src/erun-common
 COPY erun-mcp /src/erun-mcp
-COPY erun-backend/erun-backend-api /src/erun-backend/erun-backend-api
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
@@ -33,9 +30,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X github.com/sophium/erun/cmd.buildVersion=${ERUN_VERSION} -X github.com/sophium/erun/cmd.buildCommit=${ERUN_COMMIT} -X github.com/sophium/erun/cmd.buildDate=${ERUN_DATE}" -o /out/erun . && \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go build -ldflags "-X github.com/sophium/erun/erun-mcp.buildVersion=${ERUN_VERSION} -X github.com/sophium/erun/erun-mcp.buildCommit=${ERUN_COMMIT} -X github.com/sophium/erun/erun-mcp.buildDate=${ERUN_DATE}" -o /out/emcp ../erun-mcp/cmd/emcp && \
-    cd /src/erun-backend/erun-backend-api && \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/eapi ./cmd/eapi
+    go build -ldflags "-X github.com/sophium/erun/erun-mcp.buildVersion=${ERUN_VERSION} -X github.com/sophium/erun/erun-mcp.buildCommit=${ERUN_COMMIT} -X github.com/sophium/erun/erun-mcp.buildDate=${ERUN_DATE}" -o /out/emcp ../erun-mcp/cmd/emcp
 
 FROM ghcr.io/sophium/erun-ubuntu:noble-20260217
 
@@ -113,7 +108,6 @@ RUN apt-get update && \
 COPY --from=builder /usr/local/go /usr/local/go
 COPY --from=builder --chmod=0755 /out/erun /usr/local/bin/erun
 COPY --from=builder --chmod=0755 /out/emcp /usr/local/bin/emcp
-COPY --from=builder --chmod=0755 /out/eapi /usr/local/bin/eapi
 COPY --chmod=0755 erun-devops/docker/erun-devops/entrypoint.sh /usr/local/bin/erun-devops-entrypoint
 COPY --chmod=0755 erun-devops/docker/erun-devops/codex-wrapper.sh /usr/local/bin/codex
 COPY --chmod=0755 erun-devops/docker/erun-devops/claude-wrapper.sh /usr/local/bin/claude

--- a/erun-devops/docker/erun-devops/entrypoint.sh
+++ b/erun-devops/docker/erun-devops/entrypoint.sh
@@ -728,26 +728,6 @@ if [ "${1:-}" = "shell" ]; then
     run_shell "$@"
 fi
 
-if [ "${1:-}" = "api" ]; then
-    shift
-    initialize_erun_config
-    record_activity api
-    echo "starting erun API on ${ERUN_API_HOST:-0.0.0.0}:${ERUN_API_PORT:-17033}"
-    if [ -n "${ERUN_AWS_IDENTITY_STORE_REGION:-}" ]; then
-        set -- --aws-identity-store-region "${ERUN_AWS_IDENTITY_STORE_REGION}" "$@"
-    fi
-    if [ -n "${ERUN_AWS_IDENTITY_STORE_ID:-}" ]; then
-        set -- --aws-identity-store-id "${ERUN_AWS_IDENTITY_STORE_ID}" "$@"
-    fi
-    if [ -n "${ERUN_OIDC_ALLOWED_ISSUERS:-}" ]; then
-        set -- --oidc-allowed-issuers "${ERUN_OIDC_ALLOWED_ISSUERS}" "$@"
-    fi
-    exec eapi \
-        --host "${ERUN_API_HOST:-0.0.0.0}" \
-        --port "${ERUN_API_PORT:-17033}" \
-        "$@"
-fi
-
 if [ "${1:-}" = "mcp" ]; then
     shift
     initialize_erun_config


### PR DESCRIPTION
## Summary

Phase 1 of #264. Replace `FROM erun-devops` for both backend images with focused multi-stage Dockerfiles.

- `erun-backend-api`: `golang:1.26.0` builder → `alpine:3.20` runtime + ca-certs + a small env-to-flag entrypoint. ~3 GB → ~21 MB.
- `erun-backend-db`: separate `atlas-fetcher` stage downloads the pinned atlas binary; runtime is `alpine:3.20`. ~3 GB → ~130 MB.

Also remove `eapi` from the runtime `erun-devops` image — the chart already runs the API as its own container, so the bundled `eapi` was dead weight. With it gone, changes under `erun-backend/erun-backend-api/` no longer cascade rebuilds of the runtime image. The matching `api` dispatch branch in `erun-devops`'s entrypoint script comes out for the same reason.

Closes #264.

## Test plan

- [x] `go test ./...` in `erun-common`, `erun-cli`, `erun-mcp` — green.
- [x] Integration: `TestBuild|TestDeploy|TestPush|TestRelease|TestOpen|TestSshd|TestInit|TestDevops` — green.
- [x] Built `erun-backend-api` locally → 21.2 MB image; `eapi --help` works through the new entrypoint.
- [x] Built `erun-backend-db` locally → 130 MB image.
- [x] `erun build --dry-run` discovers all three images and gives each its own fingerprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)