### PR TITLE
Split postgres, db-migrate, and erun-backend-api out of the runtime pod

### DIFF
--- a/erun-cli/cmd/api_port_forward.go
+++ b/erun-cli/cmd/api_port_forward.go
@@ -111,7 +111,7 @@ func kubectlAPIPortForwardArgs(result common.OpenResult, localPort int) []string
 	}
 	args = append(args,
 		"port-forward",
-		"deployment/"+common.RuntimeReleaseName(result.Tenant),
+		"service/erun-api",
 		fmt.Sprintf("%d:%d", localPort, common.APIPortForResult(result)),
 		"--address", "127.0.0.1",
 	)

--- a/erun-common/assets/default-devops-chart/templates/api.yaml
+++ b/erun-common/assets/default-devops-chart/templates/api.yaml
@@ -1,0 +1,93 @@
+{{- $apiPort := default 17033 .Values.apiPort -}}
+{{- $api := default dict .Values.api -}}
+{{- $oidcAllowedIssuers := default "" $api.oidcAllowedIssuers -}}
+{{- $awsIdentityStoreID := default "" $api.awsIdentityStoreID -}}
+{{- $awsIdentityStoreRegion := default "" $api.awsIdentityStoreRegion -}}
+{{- $postgres := default dict $api.postgres -}}
+{{- $postgresDatabase := default "erun" $postgres.database -}}
+{{- $postgresUser := default "erun" $postgres.user -}}
+{{- $postgresPort := default 5432 $postgres.port -}}
+{{- $postgresPasswordSecretName := default "erun-backend-postgres" $postgres.passwordSecretName -}}
+{{- $postgresPasswordSecretKey := default "password" $postgres.passwordSecretKey -}}
+{{- $databaseURL := default (printf "postgres://%s:$(ERUN_POSTGRES_PASSWORD)@erun-postgres:%v/%s?sslmode=disable" $postgresUser $postgresPort $postgresDatabase) $api.databaseURL -}}
+{{- $imageOverrides := default dict .Values.imageOverrides -}}
+{{- $backendDBImage := default (printf "ghcr.io/sophium/erun-backend-db:%s" .Chart.AppVersion) (index $imageOverrides "erun-backend-db") -}}
+{{- $backendAPIImage := default (printf "ghcr.io/sophium/erun-backend-api:%s" .Chart.AppVersion) (index $imageOverrides "erun-backend-api") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: erun-api
+  labels:
+    app: erun-api
+spec:
+  type: ClusterIP
+  selector:
+    app: erun-api
+  ports:
+    - name: api
+      port: {{ $apiPort }}
+      targetPort: api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: erun-api
+  labels:
+    app: erun-api
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: erun-api
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: erun-api
+    spec:
+      initContainers:
+        - image: {{ $backendDBImage }}
+          name: erun-backend-db-migrate
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: HOME
+              value: /home/erun
+            - name: ERUN_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresPasswordSecretName }}
+                  key: {{ $postgresPasswordSecretKey }}
+            - name: ERUN_DATABASE_URL
+              value: {{ $databaseURL | quote }}
+      containers:
+        - image: {{ $backendAPIImage }}
+          name: erun-backend-api
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: HOME
+              value: /home/erun
+            - name: ERUN_API_HOST
+              value: 0.0.0.0
+            - name: ERUN_API_PORT
+              value: {{ $apiPort | quote }}
+            - name: ERUN_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresPasswordSecretName }}
+                  key: {{ $postgresPasswordSecretKey }}
+            - name: ERUN_DATABASE_URL
+              value: {{ $databaseURL | quote }}
+            - name: ERUN_OIDC_ALLOWED_ISSUERS
+              value: {{ $oidcAllowedIssuers | quote }}
+            - name: ERUN_AWS_IDENTITY_STORE_ID
+              value: {{ $awsIdentityStoreID | quote }}
+            - name: ERUN_AWS_IDENTITY_STORE_REGION
+              value: {{ $awsIdentityStoreRegion | quote }}
+            - name: ERUN_TENANT
+              value: {{ required "tenant is required" .Values.tenant | quote }}
+            - name: ERUN_ENVIRONMENT
+              value: {{ required "environment is required" .Values.environment | quote }}
+          ports:
+            - containerPort: {{ $apiPort }}
+              name: api

--- a/erun-common/assets/default-devops-chart/templates/postgres.yaml
+++ b/erun-common/assets/default-devops-chart/templates/postgres.yaml
@@ -1,0 +1,101 @@
+{{- $postgres := default dict (default dict .Values.api).postgres -}}
+{{- $postgresDatabase := default "erun" $postgres.database -}}
+{{- $postgresUser := default "erun" $postgres.user -}}
+{{- $postgresPort := default 5432 $postgres.port -}}
+{{- $postgresPasswordSecretName := default "erun-backend-postgres" $postgres.passwordSecretName -}}
+{{- $postgresPasswordSecretKey := default "password" $postgres.passwordSecretKey -}}
+{{- $postgresStorage := default "10Gi" $postgres.storage -}}
+{{- $imageOverrides := default dict .Values.imageOverrides -}}
+{{- $postgresImage := default "postgres:18" (index $imageOverrides "postgres") -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: erun-postgres-data
+  labels:
+    app: erun-postgres
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ $postgresStorage | quote }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: erun-postgres
+  labels:
+    app: erun-postgres
+spec:
+  type: ClusterIP
+  selector:
+    app: erun-postgres
+  ports:
+    - name: postgres
+      port: {{ $postgresPort }}
+      targetPort: postgres
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: erun-postgres
+  labels:
+    app: erun-postgres
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: erun-postgres
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: erun-postgres
+    spec:
+      securityContext:
+        fsGroup: 999
+      containers:
+        - image: {{ $postgresImage }}
+          name: erun-postgres
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_DB
+              value: {{ $postgresDatabase | quote }}
+            - name: POSTGRES_USER
+              value: {{ $postgresUser | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresPasswordSecretName }}
+                  key: {{ $postgresPasswordSecretKey }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: {{ $postgresPort }}
+              name: postgres
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -lc
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h 127.0.0.1 -p {{ $postgresPort }}
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -lc
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h 127.0.0.1 -p {{ $postgresPort }}
+            periodSeconds: 5
+            timeoutSeconds: 2
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: erun-postgres-data
+      restartPolicy: Always

--- a/erun-common/assets/default-devops-chart/templates/service.yaml
+++ b/erun-common/assets/default-devops-chart/templates/service.yaml
@@ -2,7 +2,6 @@
 {{- $worktreeRepoName := required "worktreeRepoName is required" .Values.worktreeRepoName -}}
 {{- $worktreePath := printf "/home/erun/git/%s" $worktreeRepoName -}}
 {{- $mcpPort := default 17000 .Values.mcpPort -}}
-{{- $apiPort := default 17033 .Values.apiPort -}}
 {{- $sshPort := default 17022 .Values.sshPort -}}
 {{- $idle := default dict .Values.idle -}}
 {{- $idleTimeout := default "5m0s" $idle.timeout -}}
@@ -18,18 +17,10 @@
 {{- $runtimeRequestCPU := default "0.25" $runtimeRequests.cpu -}}
 {{- $runtimeRequestMemory := default "1024Mi" $runtimeRequests.memory -}}
 {{- $managedCloud := default false .Values.managedCloud -}}
-{{- $api := default dict .Values.api -}}
-{{- $oidcAllowedIssuers := default "" $api.oidcAllowedIssuers -}}
-{{- $awsIdentityStoreID := default "" $api.awsIdentityStoreID -}}
-{{- $awsIdentityStoreRegion := default "" $api.awsIdentityStoreRegion -}}
-{{- $postgres := default dict $api.postgres -}}
-{{- $postgresDatabase := default "erun" $postgres.database -}}
-{{- $postgresUser := default "erun" $postgres.user -}}
-{{- $postgresPort := default 5432 $postgres.port -}}
+{{- $postgres := default dict (default dict .Values.api).postgres -}}
 {{- $postgresPasswordSecretName := default "erun-backend-postgres" $postgres.passwordSecretName -}}
 {{- $postgresPasswordSecretKey := default "password" $postgres.passwordSecretKey -}}
 {{- $postgresPassword := default "" $postgres.password -}}
-{{- $postgresReset := default false $postgres.reset -}}
 {{- $existingPostgresSecret := lookup "v1" "Secret" .Release.Namespace $postgresPasswordSecretName -}}
 {{- if and (eq $postgresPassword "") $existingPostgresSecret (hasKey $existingPostgresSecret.data $postgresPasswordSecretKey) -}}
 {{- $postgresPassword = (index $existingPostgresSecret.data $postgresPasswordSecretKey | b64dec) -}}
@@ -37,14 +28,9 @@
 {{- if eq $postgresPassword "" -}}
 {{- $postgresPassword = randAlphaNum 32 -}}
 {{- end -}}
-{{- $postgresDataSubPath := default ".erun/postgres" $postgres.dataSubPath -}}
-{{- $databaseURL := default (printf "postgres://%s:$(ERUN_POSTGRES_PASSWORD)@127.0.0.1:%v/%s?sslmode=disable" $postgresUser $postgresPort $postgresDatabase) $api.databaseURL -}}
 {{- $imageOverrides := default dict .Values.imageOverrides -}}
-{{- $backendDBImage := default (printf "ghcr.io/sophium/erun-backend-db:%s" .Chart.AppVersion) (index $imageOverrides "erun-backend-db") -}}
 {{- $devopsImage := default (printf "ghcr.io/sophium/erun-devops:%s" .Chart.AppVersion) (index $imageOverrides "erun-devops") -}}
 {{- $mcpImage := default (printf "ghcr.io/sophium/erun-mcp:%s" .Chart.AppVersion) (index $imageOverrides "erun-mcp") -}}
-{{- $backendAPIImage := default (printf "ghcr.io/sophium/erun-backend-api:%s" .Chart.AppVersion) (index $imageOverrides "erun-backend-api") -}}
-{{- $postgresImage := default "postgres:18" (index $imageOverrides "postgres") -}}
 {{- $dindImage := default "ghcr.io/sophium/erun-dind:28.1.1" (index $imageOverrides "erun-dind") -}}
 {{- $cloudContext := default dict .Values.cloudContext -}}
 {{- $cloudContextName := default "" $cloudContext.name -}}
@@ -205,66 +191,6 @@ spec:
             - amd64,arm64
           securityContext:
             privileged: true
-{{- if $postgresReset }}
-        - image: {{ $postgresImage }}
-          name: erun-backend-postgres-reset
-          imagePullPolicy: IfNotPresent
-          command:
-            - sh
-            - -lc
-            - rm -rf /home/erun/.erun/postgres && mkdir -p /home/erun/.erun/postgres
-          volumeMounts:
-            - name: erun-home
-              mountPath: /home/erun
-{{- end }}
-        - image: {{ $postgresImage }}
-          name: erun-backend-postgres
-          imagePullPolicy: IfNotPresent
-          restartPolicy: Always
-          env:
-            - name: POSTGRES_DB
-              value: {{ $postgresDatabase | quote }}
-            - name: POSTGRES_USER
-              value: {{ $postgresUser | quote }}
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $postgresPasswordSecretName }}
-                  key: {{ $postgresPasswordSecretKey }}
-            - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
-          ports:
-            - containerPort: {{ $postgresPort }}
-              name: postgres
-          startupProbe:
-            exec:
-              command:
-                - sh
-                - -lc
-                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h 127.0.0.1 -p {{ $postgresPort }}
-            periodSeconds: 2
-            timeoutSeconds: 2
-            failureThreshold: 60
-          volumeMounts:
-            - name: erun-home
-              mountPath: /var/lib/postgresql/data
-              subPath: {{ $postgresDataSubPath | quote }}
-        - image: {{ $backendDBImage }}
-          name: erun-backend-db
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: HOME
-              value: /home/erun
-            - name: ERUN_POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $postgresPasswordSecretName }}
-                  key: {{ $postgresPasswordSecretKey }}
-            - name: ERUN_DATABASE_URL
-              value: {{ $databaseURL | quote }}
-          volumeMounts:
-            - name: erun-home
-              mountPath: /home/erun
       containers:
         - image: {{ $devopsImage }}
           name: __MODULE_NAME__
@@ -436,39 +362,6 @@ spec:
 {{- end }}
             - name: docker-socket
               mountPath: /var/run
-        - image: {{ $backendAPIImage }}
-          name: erun-backend-api
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: HOME
-              value: /home/erun
-            - name: ERUN_API_HOST
-              value: 0.0.0.0
-            - name: ERUN_API_PORT
-              value: {{ $apiPort | quote }}
-            - name: ERUN_POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $postgresPasswordSecretName }}
-                  key: {{ $postgresPasswordSecretKey }}
-            - name: ERUN_DATABASE_URL
-              value: {{ $databaseURL | quote }}
-            - name: ERUN_OIDC_ALLOWED_ISSUERS
-              value: {{ $oidcAllowedIssuers | quote }}
-            - name: ERUN_AWS_IDENTITY_STORE_ID
-              value: {{ $awsIdentityStoreID | quote }}
-            - name: ERUN_AWS_IDENTITY_STORE_REGION
-              value: {{ $awsIdentityStoreRegion | quote }}
-            - name: ERUN_TENANT
-              value: {{ required "tenant is required" .Values.tenant | quote }}
-            - name: ERUN_ENVIRONMENT
-              value: {{ required "environment is required" .Values.environment | quote }}
-          ports:
-            - containerPort: {{ $apiPort }}
-              name: api
-          volumeMounts:
-            - name: erun-home
-              mountPath: /home/erun
         - image: {{ $dindImage }}
           name: erun-dind
           imagePullPolicy: IfNotPresent

--- a/erun-common/default_devops_chart.go
+++ b/erun-common/default_devops_chart.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-//go:embed assets/default-devops-chart/Chart.yaml assets/default-devops-chart/values.local.yaml assets/default-devops-chart/templates/service.yaml
+//go:embed assets/default-devops-chart/Chart.yaml assets/default-devops-chart/values.local.yaml assets/default-devops-chart/templates/service.yaml assets/default-devops-chart/templates/postgres.yaml assets/default-devops-chart/templates/api.yaml
 var defaultDevopsChartFiles embed.FS
 
 type defaultDevopsChartTemplate struct {
@@ -34,6 +34,16 @@ var defaultDevopsChartTemplates = []defaultDevopsChartTemplate{
 	{
 		AssetPath:  "assets/default-devops-chart/templates/service.yaml",
 		TargetPath: "__MODULE_NAME__/k8s/__MODULE_NAME__/templates/service.yaml",
+		Mode:       0o644,
+	},
+	{
+		AssetPath:  "assets/default-devops-chart/templates/postgres.yaml",
+		TargetPath: "__MODULE_NAME__/k8s/__MODULE_NAME__/templates/postgres.yaml",
+		Mode:       0o644,
+	},
+	{
+		AssetPath:  "assets/default-devops-chart/templates/api.yaml",
+		TargetPath: "__MODULE_NAME__/k8s/__MODULE_NAME__/templates/api.yaml",
 		Mode:       0o644,
 	},
 }

--- a/erun-common/deploy_test.go
+++ b/erun-common/deploy_test.go
@@ -387,25 +387,22 @@ func TestRuntimeChartsInstallBinfmtForMultiArchBuilds(t *testing.T) {
 }
 
 func TestRuntimeChartsExposeMCPAPIAndSSHPorts(t *testing.T) {
-	paths := []string{
-		filepath.Join("..", "erun-devops", "k8s", "erun-devops", "templates", "service.yaml"),
-		filepath.Join("assets", "default-devops-chart", "templates", "service.yaml"),
+	chartDirs := []string{
+		filepath.Join("..", "erun-devops", "k8s", "erun-devops", "templates"),
+		filepath.Join("assets", "default-devops-chart", "templates"),
 	}
 
-	for _, path := range paths {
-		data, err := os.ReadFile(path)
+	for _, dir := range chartDirs {
+		content, err := concatChartTemplates(dir)
 		if err != nil {
-			t.Fatalf("read %q: %v", path, err)
+			t.Fatalf("read templates in %q: %v", dir, err)
 		}
-		content := string(data)
 		for _, want := range []string{
 			`{{- $mcpPort := default 17000 .Values.mcpPort -}}`,
 			`{{- $apiPort := default 17033 .Values.apiPort -}}`,
 			`{{- $sshPort := default 17022 .Values.sshPort -}}`,
 			`{{- $api := default dict .Values.api -}}`,
 			`{{- $oidcAllowedIssuers := default "" $api.oidcAllowedIssuers -}}`,
-			`{{- $postgres := default dict $api.postgres -}}`,
-			`{{- $databaseURL := default (printf "postgres://%s:$(ERUN_POSTGRES_PASSWORD)@127.0.0.1:%v/%s?sslmode=disable" $postgresUser $postgresPort $postgresDatabase) $api.databaseURL -}}`,
 			`{{- $cloudContext := default dict .Values.cloudContext -}}`,
 			`{{- $cloudContextName := default "" $cloudContext.name -}}`,
 			`{{- $cloudProvider := default "" $cloudContext.provider -}}`,
@@ -433,7 +430,8 @@ func TestRuntimeChartsExposeMCPAPIAndSSHPorts(t *testing.T) {
 			"name: ERUN_DATABASE_URL",
 			"name: ERUN_OIDC_ALLOWED_ISSUERS",
 			"name: ERUN_SSHD_PORT",
-			"name: erun-backend-postgres",
+			"name: erun-postgres",
+			"name: erun-api",
 			"restartPolicy: Always",
 			"containerPort: {{ $mcpPort }}",
 			"name: mcp",
@@ -443,7 +441,7 @@ func TestRuntimeChartsExposeMCPAPIAndSSHPorts(t *testing.T) {
 			"name: ssh",
 		} {
 			if !strings.Contains(content, want) {
-				t.Fatalf("expected %q to contain %q, got:\n%s", path, want, content)
+				t.Fatalf("expected templates in %q to contain %q, got:\n%s", dir, want, content)
 			}
 		}
 		for _, forbidden := range []string{
@@ -452,10 +450,33 @@ func TestRuntimeChartsExposeMCPAPIAndSSHPorts(t *testing.T) {
 			"containerPort: 17023",
 		} {
 			if strings.Contains(content, forbidden) {
-				t.Fatalf("expected %q not to expose SSHD target port marker %q, got:\n%s", path, forbidden, content)
+				t.Fatalf("expected templates in %q not to expose SSHD target port marker %q, got:\n%s", dir, forbidden, content)
 			}
 		}
 	}
+}
+
+// concatChartTemplates returns the concatenated contents of every *.yaml file
+// in dir. Tests that assert a Helm chart contains a specific token use this
+// helper so they don't care which template file in the chart owns the token.
+func concatChartTemplates(dir string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+	var buf strings.Builder
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return "", err
+		}
+		buf.Write(data)
+		buf.WriteString("\n")
+	}
+	return buf.String(), nil
 }
 
 func TestRuntimeChartsUseNilSafeNestedValueDefaults(t *testing.T) {

--- a/erun-common/init_test.go
+++ b/erun-common/init_test.go
@@ -360,13 +360,14 @@ func requireTenantDevopsDockerfile(t *testing.T, dockerfile string) {
 func TestEnsureDefaultDevopsChartMigratesLegacyGeneratedServiceTemplate(t *testing.T) {
 	projectRoot := t.TempDir()
 	moduleName := "tenant-a-devops"
-	serviceTemplatePath := filepath.Join(projectRoot, moduleName, "k8s", moduleName, "templates", "service.yaml")
+	templatesDir := filepath.Join(projectRoot, moduleName, "k8s", moduleName, "templates")
+	serviceTemplatePath := filepath.Join(templatesDir, "service.yaml")
 	current, err := defaultDevopsChartFiles.ReadFile("assets/default-devops-chart/templates/service.yaml")
 	if err != nil {
 		t.Fatalf("read embedded service template: %v", err)
 	}
 	rendered := renderDefaultDevopsChartTemplate("assets/default-devops-chart/templates/service.yaml", moduleName, moduleName, current)
-	if err := os.MkdirAll(filepath.Dir(serviceTemplatePath), 0o755); err != nil {
+	if err := os.MkdirAll(templatesDir, 0o755); err != nil {
 		t.Fatalf("mkdir service template dir: %v", err)
 	}
 	if err := os.WriteFile(serviceTemplatePath, []byte(legacyDefaultDevopsServiceTemplate(rendered)), 0o644); err != nil {
@@ -377,17 +378,14 @@ func TestEnsureDefaultDevopsChartMigratesLegacyGeneratedServiceTemplate(t *testi
 		t.Fatalf("EnsureDefaultDevopsChart failed: %v", err)
 	}
 
-	migrated, err := os.ReadFile(serviceTemplatePath)
+	content, err := concatChartTemplates(templatesDir)
 	if err != nil {
-		t.Fatalf("read migrated service template: %v", err)
+		t.Fatalf("read migrated chart templates: %v", err)
 	}
-	content := string(migrated)
 	for _, want := range []string{
 		`{{- $mcpPort := default 17000 .Values.mcpPort -}}`,
 		`{{- $apiPort := default 17033 .Values.apiPort -}}`,
 		`{{- $sshPort := default 17022 .Values.sshPort -}}`,
-		`{{- $postgres := default dict $api.postgres -}}`,
-		`{{- $databaseURL := default (printf "postgres://%s:$(ERUN_POSTGRES_PASSWORD)@127.0.0.1:%v/%s?sslmode=disable" $postgresUser $postgresPort $postgresDatabase) $api.databaseURL -}}`,
 		`{{- $cloudContext := default dict .Values.cloudContext -}}`,
 		`{{- $cloudContextName := default "" $cloudContext.name -}}`,
 		`{{- $cloudProvider := default "" $cloudContext.provider -}}`,
@@ -414,14 +412,15 @@ func TestEnsureDefaultDevopsChartMigratesLegacyGeneratedServiceTemplate(t *testi
 		"name: ERUN_POSTGRES_PASSWORD",
 		"name: ERUN_DATABASE_URL",
 		"name: ERUN_SSHD_PORT",
-		"name: erun-backend-postgres",
+		"name: erun-postgres",
+		"name: erun-api",
 		"restartPolicy: Always",
 		"containerPort: {{ $mcpPort }}",
 		"containerPort: {{ $apiPort }}",
 		"containerPort: {{ $sshPort }}",
 	} {
 		if !strings.Contains(content, want) {
-			t.Fatalf("expected migrated service template to contain %q, got:\n%s", want, content)
+			t.Fatalf("expected migrated chart templates to contain %q, got:\n%s", want, content)
 		}
 	}
 }

--- a/erun-devops/k8s/erun-devops/templates/api.yaml
+++ b/erun-devops/k8s/erun-devops/templates/api.yaml
@@ -1,0 +1,94 @@
+{{- $apiPort := default 17033 .Values.apiPort -}}
+{{- $api := default dict .Values.api -}}
+{{- $oidcAllowedIssuers := default "" $api.oidcAllowedIssuers -}}
+{{- $awsIdentityStoreID := default "" $api.awsIdentityStoreID -}}
+{{- $awsIdentityStoreRegion := default "" $api.awsIdentityStoreRegion -}}
+{{- $postgres := default dict $api.postgres -}}
+{{- $postgresDatabase := default "erun" $postgres.database -}}
+{{- $postgresUser := default "erun" $postgres.user -}}
+{{- $postgresPort := default 5432 $postgres.port -}}
+{{- $postgresPasswordSecretName := default "erun-backend-postgres" $postgres.passwordSecretName -}}
+{{- $postgresPasswordSecretKey := default "password" $postgres.passwordSecretKey -}}
+{{- $databaseURL := default (printf "postgres://%s:$(ERUN_POSTGRES_PASSWORD)@erun-postgres:%v/%s?sslmode=disable" $postgresUser $postgresPort $postgresDatabase) $api.databaseURL -}}
+{{- $imageOverrides := default dict .Values.imageOverrides -}}
+{{- $containerRegistry := default "ghcr.io/sophium" .Values.containerRegistry -}}
+{{- $backendDBImage := default (printf "%s/erun-backend-db:%s" $containerRegistry .Chart.AppVersion) (index $imageOverrides "erun-backend-db") -}}
+{{- $backendAPIImage := default (printf "%s/erun-backend-api:%s" $containerRegistry .Chart.AppVersion) (index $imageOverrides "erun-backend-api") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: erun-api
+  labels:
+    app: erun-api
+spec:
+  type: ClusterIP
+  selector:
+    app: erun-api
+  ports:
+    - name: api
+      port: {{ $apiPort }}
+      targetPort: api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: erun-api
+  labels:
+    app: erun-api
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: erun-api
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: erun-api
+    spec:
+      initContainers:
+        - image: {{ $backendDBImage }}
+          name: erun-backend-db-migrate
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: HOME
+              value: /home/erun
+            - name: ERUN_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresPasswordSecretName }}
+                  key: {{ $postgresPasswordSecretKey }}
+            - name: ERUN_DATABASE_URL
+              value: {{ $databaseURL | quote }}
+      containers:
+        - image: {{ $backendAPIImage }}
+          name: erun-backend-api
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: HOME
+              value: /home/erun
+            - name: ERUN_API_HOST
+              value: 0.0.0.0
+            - name: ERUN_API_PORT
+              value: {{ $apiPort | quote }}
+            - name: ERUN_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresPasswordSecretName }}
+                  key: {{ $postgresPasswordSecretKey }}
+            - name: ERUN_DATABASE_URL
+              value: {{ $databaseURL | quote }}
+            - name: ERUN_OIDC_ALLOWED_ISSUERS
+              value: {{ $oidcAllowedIssuers | quote }}
+            - name: ERUN_AWS_IDENTITY_STORE_ID
+              value: {{ $awsIdentityStoreID | quote }}
+            - name: ERUN_AWS_IDENTITY_STORE_REGION
+              value: {{ $awsIdentityStoreRegion | quote }}
+            - name: ERUN_TENANT
+              value: {{ required "tenant is required" .Values.tenant | quote }}
+            - name: ERUN_ENVIRONMENT
+              value: {{ required "environment is required" .Values.environment | quote }}
+          ports:
+            - containerPort: {{ $apiPort }}
+              name: api

--- a/erun-devops/k8s/erun-devops/templates/postgres.yaml
+++ b/erun-devops/k8s/erun-devops/templates/postgres.yaml
@@ -1,0 +1,101 @@
+{{- $postgres := default dict (default dict .Values.api).postgres -}}
+{{- $postgresDatabase := default "erun" $postgres.database -}}
+{{- $postgresUser := default "erun" $postgres.user -}}
+{{- $postgresPort := default 5432 $postgres.port -}}
+{{- $postgresPasswordSecretName := default "erun-backend-postgres" $postgres.passwordSecretName -}}
+{{- $postgresPasswordSecretKey := default "password" $postgres.passwordSecretKey -}}
+{{- $postgresStorage := default "10Gi" $postgres.storage -}}
+{{- $imageOverrides := default dict .Values.imageOverrides -}}
+{{- $postgresImage := default "postgres:18" (index $imageOverrides "postgres") -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: erun-postgres-data
+  labels:
+    app: erun-postgres
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ $postgresStorage | quote }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: erun-postgres
+  labels:
+    app: erun-postgres
+spec:
+  type: ClusterIP
+  selector:
+    app: erun-postgres
+  ports:
+    - name: postgres
+      port: {{ $postgresPort }}
+      targetPort: postgres
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: erun-postgres
+  labels:
+    app: erun-postgres
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: erun-postgres
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: erun-postgres
+    spec:
+      securityContext:
+        fsGroup: 999
+      containers:
+        - image: {{ $postgresImage }}
+          name: erun-postgres
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_DB
+              value: {{ $postgresDatabase | quote }}
+            - name: POSTGRES_USER
+              value: {{ $postgresUser | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresPasswordSecretName }}
+                  key: {{ $postgresPasswordSecretKey }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: {{ $postgresPort }}
+              name: postgres
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -lc
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h 127.0.0.1 -p {{ $postgresPort }}
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -lc
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h 127.0.0.1 -p {{ $postgresPort }}
+            periodSeconds: 5
+            timeoutSeconds: 2
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: erun-postgres-data
+      restartPolicy: Always

--- a/erun-devops/k8s/erun-devops/templates/service.yaml
+++ b/erun-devops/k8s/erun-devops/templates/service.yaml
@@ -1,5 +1,4 @@
 {{- $mcpPort := default 17000 .Values.mcpPort -}}
-{{- $apiPort := default 17033 .Values.apiPort -}}
 {{- $sshPort := default 17022 .Values.sshPort -}}
 {{- $idle := default dict .Values.idle -}}
 {{- $idleTimeout := default "5m0s" $idle.timeout -}}
@@ -15,18 +14,10 @@
 {{- $runtimeRequestCPU := default "0.25" $runtimeRequests.cpu -}}
 {{- $runtimeRequestMemory := default "1024Mi" $runtimeRequests.memory -}}
 {{- $managedCloud := default false .Values.managedCloud -}}
-{{- $api := default dict .Values.api -}}
-{{- $oidcAllowedIssuers := default "" $api.oidcAllowedIssuers -}}
-{{- $awsIdentityStoreID := default "" $api.awsIdentityStoreID -}}
-{{- $awsIdentityStoreRegion := default "" $api.awsIdentityStoreRegion -}}
-{{- $postgres := default dict $api.postgres -}}
-{{- $postgresDatabase := default "erun" $postgres.database -}}
-{{- $postgresUser := default "erun" $postgres.user -}}
-{{- $postgresPort := default 5432 $postgres.port -}}
+{{- $postgres := default dict (default dict .Values.api).postgres -}}
 {{- $postgresPasswordSecretName := default "erun-backend-postgres" $postgres.passwordSecretName -}}
 {{- $postgresPasswordSecretKey := default "password" $postgres.passwordSecretKey -}}
 {{- $postgresPassword := default "" $postgres.password -}}
-{{- $postgresReset := default false $postgres.reset -}}
 {{- $existingPostgresSecret := lookup "v1" "Secret" .Release.Namespace $postgresPasswordSecretName -}}
 {{- if and (eq $postgresPassword "") $existingPostgresSecret (hasKey $existingPostgresSecret.data $postgresPasswordSecretKey) -}}
 {{- $postgresPassword = (index $existingPostgresSecret.data $postgresPasswordSecretKey | b64dec) -}}
@@ -34,15 +25,10 @@
 {{- if eq $postgresPassword "" -}}
 {{- $postgresPassword = randAlphaNum 32 -}}
 {{- end -}}
-{{- $postgresDataSubPath := default ".erun/postgres" $postgres.dataSubPath -}}
-{{- $databaseURL := default (printf "postgres://%s:$(ERUN_POSTGRES_PASSWORD)@127.0.0.1:%v/%s?sslmode=disable" $postgresUser $postgresPort $postgresDatabase) $api.databaseURL -}}
 {{- $imageOverrides := default dict .Values.imageOverrides -}}
 {{- $containerRegistry := default "ghcr.io/sophium" .Values.containerRegistry -}}
-{{- $backendDBImage := default (printf "%s/erun-backend-db:%s" $containerRegistry .Chart.AppVersion) (index $imageOverrides "erun-backend-db") -}}
 {{- $devopsImage := default (printf "%s/erun-devops:%s" $containerRegistry .Chart.AppVersion) (index $imageOverrides "erun-devops") -}}
 {{- $mcpImage := default (printf "%s/erun-mcp:%s" $containerRegistry .Chart.AppVersion) (index $imageOverrides "erun-mcp") -}}
-{{- $backendAPIImage := default (printf "%s/erun-backend-api:%s" $containerRegistry .Chart.AppVersion) (index $imageOverrides "erun-backend-api") -}}
-{{- $postgresImage := default "postgres:18" (index $imageOverrides "postgres") -}}
 {{- $dindImage := default (printf "%s/erun-dind:28.1.1" $containerRegistry) (index $imageOverrides "erun-dind") -}}
 {{- $cloudContext := default dict .Values.cloudContext -}}
 {{- $cloudContextName := default "" $cloudContext.name -}}
@@ -203,66 +189,6 @@ spec:
             - amd64,arm64
           securityContext:
             privileged: true
-{{- if $postgresReset }}
-        - image: {{ $postgresImage }}
-          name: erun-backend-postgres-reset
-          imagePullPolicy: IfNotPresent
-          command:
-            - sh
-            - -lc
-            - rm -rf /home/erun/.erun/postgres && mkdir -p /home/erun/.erun/postgres
-          volumeMounts:
-            - name: erun-home
-              mountPath: /home/erun
-{{- end }}
-        - image: {{ $postgresImage }}
-          name: erun-backend-postgres
-          imagePullPolicy: IfNotPresent
-          restartPolicy: Always
-          env:
-            - name: POSTGRES_DB
-              value: {{ $postgresDatabase | quote }}
-            - name: POSTGRES_USER
-              value: {{ $postgresUser | quote }}
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $postgresPasswordSecretName }}
-                  key: {{ $postgresPasswordSecretKey }}
-            - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
-          ports:
-            - containerPort: {{ $postgresPort }}
-              name: postgres
-          startupProbe:
-            exec:
-              command:
-                - sh
-                - -lc
-                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h 127.0.0.1 -p {{ $postgresPort }}
-            periodSeconds: 2
-            timeoutSeconds: 2
-            failureThreshold: 60
-          volumeMounts:
-            - name: erun-home
-              mountPath: /var/lib/postgresql/data
-              subPath: {{ $postgresDataSubPath | quote }}
-        - image: {{ $backendDBImage }}
-          name: erun-backend-db
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: HOME
-              value: /home/erun
-            - name: ERUN_POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $postgresPasswordSecretName }}
-                  key: {{ $postgresPasswordSecretKey }}
-            - name: ERUN_DATABASE_URL
-              value: {{ $databaseURL | quote }}
-          volumeMounts:
-            - name: erun-home
-              mountPath: /home/erun
       containers:
         - image: {{ $devopsImage }}
           name: erun-devops
@@ -430,39 +356,6 @@ spec:
               mountPath: {{ printf "/home/erun/git/%s" (base (required "worktreeHostPath is required" .Values.worktreeHostPath)) | quote }}
             - name: docker-socket
               mountPath: /var/run
-        - image: {{ $backendAPIImage }}
-          name: erun-backend-api
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: HOME
-              value: /home/erun
-            - name: ERUN_API_HOST
-              value: 0.0.0.0
-            - name: ERUN_API_PORT
-              value: {{ $apiPort | quote }}
-            - name: ERUN_POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $postgresPasswordSecretName }}
-                  key: {{ $postgresPasswordSecretKey }}
-            - name: ERUN_DATABASE_URL
-              value: {{ $databaseURL | quote }}
-            - name: ERUN_OIDC_ALLOWED_ISSUERS
-              value: {{ $oidcAllowedIssuers | quote }}
-            - name: ERUN_AWS_IDENTITY_STORE_ID
-              value: {{ $awsIdentityStoreID | quote }}
-            - name: ERUN_AWS_IDENTITY_STORE_REGION
-              value: {{ $awsIdentityStoreRegion | quote }}
-            - name: ERUN_TENANT
-              value: {{ required "tenant is required" .Values.tenant | quote }}
-            - name: ERUN_ENVIRONMENT
-              value: {{ required "environment is required" .Values.environment | quote }}
-          ports:
-            - containerPort: {{ $apiPort }}
-              name: api
-          volumeMounts:
-            - name: erun-home
-              mountPath: /home/erun
         - image: {{ $dindImage }}
           name: erun-dind
           imagePullPolicy: IfNotPresent

--- a/erun-integration/testdata/init/remote_dry_run.txt
+++ b/erun-integration/testdata/init/remote_dry_run.txt
@@ -125,7 +125,6 @@ remote-default-devops-bootstrap:
   {{- $worktreeRepoName := required "worktreeRepoName is required" .Values.worktreeRepoName -}}
   {{- $worktreePath := printf "<HOME>/git/%s" $worktreeRepoName -}}
   {{- $mcpPort := default 17000 .Values.mcpPort -}}
-  {{- $apiPort := default 17033 .Values.apiPort -}}
   {{- $sshPort := default 17022 .Values.sshPort -}}
   {{- $idle := default dict .Values.idle -}}
   {{- $idleTimeout := default "5m0s" $idle.timeout -}}
@@ -141,18 +140,10 @@ remote-default-devops-bootstrap:
   {{- $runtimeRequestCPU := default "0.25" $runtimeRequests.cpu -}}
   {{- $runtimeRequestMemory := default "1024Mi" $runtimeRequests.memory -}}
   {{- $managedCloud := default false .Values.managedCloud -}}
-  {{- $api := default dict .Values.api -}}
-  {{- $oidcAllowedIssuers := default "" $api.oidcAllowedIssuers -}}
-  {{- $awsIdentityStoreID := default "" $api.awsIdentityStoreID -}}
-  {{- $awsIdentityStoreRegion := default "" $api.awsIdentityStoreRegion -}}
-  {{- $postgres := default dict $api.postgres -}}
-  {{- $postgresDatabase := default "erun" $postgres.database -}}
-  {{- $postgresUser := default "erun" $postgres.user -}}
-  {{- $postgresPort := default 5432 $postgres.port -}}
+  {{- $postgres := default dict (default dict .Values.api).postgres -}}
   {{- $postgresPasswordSecretName := default "erun-backend-postgres" $postgres.passwordSecretName -}}
   {{- $postgresPasswordSecretKey := default "password" $postgres.passwordSecretKey -}}
   {{- $postgresPassword := default "" $postgres.password -}}
-  {{- $postgresReset := default false $postgres.reset -}}
   {{- $existingPostgresSecret := lookup "v1" "Secret" .Release.Namespace $postgresPasswordSecretName -}}
   {{- if and (eq $postgresPassword "") $existingPostgresSecret (hasKey $existingPostgresSecret.data $postgresPasswordSecretKey) -}}
   {{- $postgresPassword = (index $existingPostgresSecret.data $postgresPasswordSecretKey | b64dec) -}}
@@ -160,14 +151,9 @@ remote-default-devops-bootstrap:
   {{- if eq $postgresPassword "" -}}
   {{- $postgresPassword = randAlphaNum 32 -}}
   {{- end -}}
-  {{- $postgresDataSubPath := default ".erun/postgres" $postgres.dataSubPath -}}
-  {{- $databaseURL := default (printf "postgres://%s:$(ERUN_POSTGRES_PASSWORD)@<VERSION>.1:%v/%s?sslmode=disable" $postgresUser $postgresPort $postgresDatabase) $api.databaseURL -}}
   {{- $imageOverrides := default dict .Values.imageOverrides -}}
-  {{- $backendDBImage := default (printf "ghcr.io/sophium/erun-backend-db:%s" .Chart.AppVersion) (index $imageOverrides "erun-backend-db") -}}
   {{- $devopsImage := default (printf "ghcr.io/sophium/team-devops:%s" .Chart.AppVersion) (index $imageOverrides "team-devops") -}}
   {{- $mcpImage := default (printf "ghcr.io/sophium/erun-mcp:%s" .Chart.AppVersion) (index $imageOverrides "erun-mcp") -}}
-  {{- $backendAPIImage := default (printf "ghcr.io/sophium/erun-backend-api:%s" .Chart.AppVersion) (index $imageOverrides "erun-backend-api") -}}
-  {{- $postgresImage := default "postgres:18" (index $imageOverrides "postgres") -}}
   {{- $dindImage := default "ghcr.io/sophium/erun-dind:<VERSION>" (index $imageOverrides "erun-dind") -}}
   {{- $cloudContext := default dict .Values.cloudContext -}}
   {{- $cloudContextName := default "" $cloudContext.name -}}
@@ -328,66 +314,6 @@ remote-default-devops-bootstrap:
               - amd64,arm64
             securityContext:
               privileged: true
-  {{- if $postgresReset }}
-          - image: {{ $postgresImage }}
-            name: erun-backend-postgres-reset
-            imagePullPolicy: IfNotPresent
-            command:
-              - sh
-              - -lc
-              - rm -rf <HOME>/.erun/postgres && mkdir -p <HOME>/.erun/postgres
-            volumeMounts:
-              - name: erun-home
-                mountPath: <HOME>
-  {{- end }}
-          - image: {{ $postgresImage }}
-            name: erun-backend-postgres
-            imagePullPolicy: IfNotPresent
-            restartPolicy: Always
-            env:
-              - name: POSTGRES_DB
-                value: {{ $postgresDatabase | quote }}
-              - name: POSTGRES_USER
-                value: {{ $postgresUser | quote }}
-              - name: POSTGRES_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ $postgresPasswordSecretName }}
-                    key: {{ $postgresPasswordSecretKey }}
-              - name: PGDATA
-                value: /var/lib/postgresql/data/pgdata
-            ports:
-              - containerPort: {{ $postgresPort }}
-                name: postgres
-            startupProbe:
-              exec:
-                command:
-                  - sh
-                  - -lc
-                  - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h <VERSION>.1 -p {{ $postgresPort }}
-              periodSeconds: 2
-              timeoutSeconds: 2
-              failureThreshold: 60
-            volumeMounts:
-              - name: erun-home
-                mountPath: /var/lib/postgresql/data
-                subPath: {{ $postgresDataSubPath | quote }}
-          - image: {{ $backendDBImage }}
-            name: erun-backend-db
-            imagePullPolicy: IfNotPresent
-            env:
-              - name: HOME
-                value: <HOME>
-              - name: ERUN_POSTGRES_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ $postgresPasswordSecretName }}
-                    key: {{ $postgresPasswordSecretKey }}
-              - name: ERUN_DATABASE_URL
-                value: {{ $databaseURL | quote }}
-            volumeMounts:
-              - name: erun-home
-                mountPath: <HOME>
         containers:
           - image: {{ $devopsImage }}
             name: team-devops
@@ -559,39 +485,6 @@ remote-default-devops-bootstrap:
   {{- end }}
               - name: docker-socket
                 mountPath: /var/run
-          - image: {{ $backendAPIImage }}
-            name: erun-backend-api
-            imagePullPolicy: IfNotPresent
-            env:
-              - name: HOME
-                value: <HOME>
-              - name: ERUN_API_HOST
-                value: <VERSION>.0
-              - name: ERUN_API_PORT
-                value: {{ $apiPort | quote }}
-              - name: ERUN_POSTGRES_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ $postgresPasswordSecretName }}
-                    key: {{ $postgresPasswordSecretKey }}
-              - name: ERUN_DATABASE_URL
-                value: {{ $databaseURL | quote }}
-              - name: ERUN_OIDC_ALLOWED_ISSUERS
-                value: {{ $oidcAllowedIssuers | quote }}
-              - name: ERUN_AWS_IDENTITY_STORE_ID
-                value: {{ $awsIdentityStoreID | quote }}
-              - name: ERUN_AWS_IDENTITY_STORE_REGION
-                value: {{ $awsIdentityStoreRegion | quote }}
-              - name: ERUN_TENANT
-                value: {{ required "tenant is required" .Values.tenant | quote }}
-              - name: ERUN_ENVIRONMENT
-                value: {{ required "environment is required" .Values.environment | quote }}
-            ports:
-              - containerPort: {{ $apiPort }}
-                name: api
-            volumeMounts:
-              - name: erun-home
-                mountPath: <HOME>
           - image: {{ $dindImage }}
             name: erun-dind
             imagePullPolicy: IfNotPresent
@@ -648,6 +541,8 @@ remote-default-devops-bootstrap:
     printf %s '{{- $worktreeStorage := default "host" .Values.worktreeStorage -}}
   {{- $worktreeRepoName := required "worktreeRepoName is required" .Values.worktreeRepoName -}}
   {{- $worktreePath := printf "<HOME>/git/%s" $worktreeRepoName -}}
+  {{- $mcpPort := default 17000 .Values.mcpPort -}}
+  {{- $sshPort := default 17022 .Values.sshPort -}}
   {{- $idle := default dict .Values.idle -}}
   {{- $idleTimeout := default "5m0s" $idle.timeout -}}
   {{- $idleWorkingHours := default "08:00-20:00" $idle.workingHours -}}
@@ -662,16 +557,10 @@ remote-default-devops-bootstrap:
   {{- $runtimeRequestCPU := default "0.25" $runtimeRequests.cpu -}}
   {{- $runtimeRequestMemory := default "1024Mi" $runtimeRequests.memory -}}
   {{- $managedCloud := default false .Values.managedCloud -}}
-  {{- $awsIdentityStoreID := default "" $api.awsIdentityStoreID -}}
-  {{- $awsIdentityStoreRegion := default "" $api.awsIdentityStoreRegion -}}
-  {{- $postgres := default dict $api.postgres -}}
-  {{- $postgresDatabase := default "erun" $postgres.database -}}
-  {{- $postgresUser := default "erun" $postgres.user -}}
-  {{- $postgresPort := default 5432 $postgres.port -}}
+  {{- $postgres := default dict (default dict .Values.api).postgres -}}
   {{- $postgresPasswordSecretName := default "erun-backend-postgres" $postgres.passwordSecretName -}}
   {{- $postgresPasswordSecretKey := default "password" $postgres.passwordSecretKey -}}
   {{- $postgresPassword := default "" $postgres.password -}}
-  {{- $postgresReset := default false $postgres.reset -}}
   {{- $existingPostgresSecret := lookup "v1" "Secret" .Release.Namespace $postgresPasswordSecretName -}}
   {{- if and (eq $postgresPassword "") $existingPostgresSecret (hasKey $existingPostgresSecret.data $postgresPasswordSecretKey) -}}
   {{- $postgresPassword = (index $existingPostgresSecret.data $postgresPasswordSecretKey | b64dec) -}}
@@ -679,14 +568,9 @@ remote-default-devops-bootstrap:
   {{- if eq $postgresPassword "" -}}
   {{- $postgresPassword = randAlphaNum 32 -}}
   {{- end -}}
-  {{- $postgresDataSubPath := default ".erun/postgres" $postgres.dataSubPath -}}
-  {{- $databaseURL := default (printf "postgres://%s:$(ERUN_POSTGRES_PASSWORD)@<VERSION>.1:%v/%s?sslmode=disable" $postgresUser $postgresPort $postgresDatabase) $api.databaseURL -}}
   {{- $imageOverrides := default dict .Values.imageOverrides -}}
-  {{- $backendDBImage := default (printf "ghcr.io/sophium/erun-backend-db:%s" .Chart.AppVersion) (index $imageOverrides "erun-backend-db") -}}
   {{- $devopsImage := default (printf "ghcr.io/sophium/team-devops:%s" .Chart.AppVersion) (index $imageOverrides "team-devops") -}}
   {{- $mcpImage := default (printf "ghcr.io/sophium/erun-mcp:%s" .Chart.AppVersion) (index $imageOverrides "erun-mcp") -}}
-  {{- $backendAPIImage := default (printf "ghcr.io/sophium/erun-backend-api:%s" .Chart.AppVersion) (index $imageOverrides "erun-backend-api") -}}
-  {{- $postgresImage := default "postgres:18" (index $imageOverrides "postgres") -}}
   {{- $dindImage := default "ghcr.io/sophium/erun-dind:<VERSION>" (index $imageOverrides "erun-dind") -}}
   apiVersion: v1
   kind: Secret
@@ -824,66 +708,6 @@ remote-default-devops-bootstrap:
               - amd64,arm64
             securityContext:
               privileged: true
-  {{- if $postgresReset }}
-          - image: {{ $postgresImage }}
-            name: erun-backend-postgres-reset
-            imagePullPolicy: IfNotPresent
-            command:
-              - sh
-              - -lc
-              - rm -rf <HOME>/.erun/postgres && mkdir -p <HOME>/.erun/postgres
-            volumeMounts:
-              - name: erun-home
-                mountPath: <HOME>
-  {{- end }}
-          - image: {{ $postgresImage }}
-            name: erun-backend-postgres
-            imagePullPolicy: IfNotPresent
-            restartPolicy: Always
-            env:
-              - name: POSTGRES_DB
-                value: {{ $postgresDatabase | quote }}
-              - name: POSTGRES_USER
-                value: {{ $postgresUser | quote }}
-              - name: POSTGRES_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ $postgresPasswordSecretName }}
-                    key: {{ $postgresPasswordSecretKey }}
-              - name: PGDATA
-                value: /var/lib/postgresql/data/pgdata
-            ports:
-              - containerPort: {{ $postgresPort }}
-                name: postgres
-            startupProbe:
-              exec:
-                command:
-                  - sh
-                  - -lc
-                  - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h <VERSION>.1 -p {{ $postgresPort }}
-              periodSeconds: 2
-              timeoutSeconds: 2
-              failureThreshold: 60
-            volumeMounts:
-              - name: erun-home
-                mountPath: /var/lib/postgresql/data
-                subPath: {{ $postgresDataSubPath | quote }}
-          - image: {{ $backendDBImage }}
-            name: erun-backend-db
-            imagePullPolicy: IfNotPresent
-            env:
-              - name: HOME
-                value: <HOME>
-              - name: ERUN_POSTGRES_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ $postgresPasswordSecretName }}
-                    key: {{ $postgresPasswordSecretKey }}
-              - name: ERUN_DATABASE_URL
-                value: {{ $databaseURL | quote }}
-            volumeMounts:
-              - name: erun-home
-                mountPath: <HOME>
         containers:
           - image: {{ $devopsImage }}
             name: team-devops
@@ -989,39 +813,6 @@ remote-default-devops-bootstrap:
   {{- end }}
               - name: docker-socket
                 mountPath: /var/run
-          - image: {{ $backendAPIImage }}
-            name: erun-backend-api
-            imagePullPolicy: IfNotPresent
-            env:
-              - name: HOME
-                value: <HOME>
-              - name: ERUN_API_HOST
-                value: <VERSION>.0
-              - name: ERUN_API_PORT
-                value: {{ $apiPort | quote }}
-              - name: ERUN_POSTGRES_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ $postgresPasswordSecretName }}
-                    key: {{ $postgresPasswordSecretKey }}
-              - name: ERUN_DATABASE_URL
-                value: {{ $databaseURL | quote }}
-              - name: ERUN_OIDC_ALLOWED_ISSUERS
-                value: {{ $oidcAllowedIssuers | quote }}
-              - name: ERUN_AWS_IDENTITY_STORE_ID
-                value: {{ $awsIdentityStoreID | quote }}
-              - name: ERUN_AWS_IDENTITY_STORE_REGION
-                value: {{ $awsIdentityStoreRegion | quote }}
-              - name: ERUN_TENANT
-                value: {{ required "tenant is required" .Values.tenant | quote }}
-              - name: ERUN_ENVIRONMENT
-                value: {{ required "environment is required" .Values.environment | quote }}
-            ports:
-              - containerPort: {{ $apiPort }}
-                name: api
-            volumeMounts:
-              - name: erun-home
-                mountPath: <HOME>
           - image: {{ $dindImage }}
             name: erun-dind
             imagePullPolicy: IfNotPresent
@@ -1073,20 +864,242 @@ remote-default-devops-bootstrap:
   fi
   if [ "$replace" = true ]; then cp "$erun_bootstrap_tmp_4" '<HOME>/git/team/team-devops/k8s/team-devops/templates/service.yaml'; chmod '644' '<HOME>/git/team/team-devops/k8s/team-devops/templates/service.yaml'; fi
   rm -f "$erun_bootstrap_tmp_4"
-  mkdir -p '<HOME>/git/team/team-devops/k8s/team-devops'
-  if [ -d '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml' ]; then echo '"<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml" is a directory' >&2; exit 1; fi
+  mkdir -p '<HOME>/git/team/team-devops/k8s/team-devops/templates'
+  if [ -d '<HOME>/git/team/team-devops/k8s/team-devops/templates/postgres.yaml' ]; then echo '"<HOME>/git/team/team-devops/k8s/team-devops/templates/postgres.yaml" is a directory' >&2; exit 1; fi
   erun_bootstrap_tmp_5=$(mktemp)
-  printf %s '' > "$erun_bootstrap_tmp_5"
+  printf %s '{{- $postgres := default dict (default dict .Values.api).postgres -}}
+  {{- $postgresDatabase := default "erun" $postgres.database -}}
+  {{- $postgresUser := default "erun" $postgres.user -}}
+  {{- $postgresPort := default 5432 $postgres.port -}}
+  {{- $postgresPasswordSecretName := default "erun-backend-postgres" $postgres.passwordSecretName -}}
+  {{- $postgresPasswordSecretKey := default "password" $postgres.passwordSecretKey -}}
+  {{- $postgresStorage := default "10Gi" $postgres.storage -}}
+  {{- $imageOverrides := default dict .Values.imageOverrides -}}
+  {{- $postgresImage := default "postgres:18" (index $imageOverrides "postgres") -}}
+  apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: erun-postgres-data
+    labels:
+      app: erun-postgres
+  spec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: {{ $postgresStorage | quote }}
+  ---
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: erun-postgres
+    labels:
+      app: erun-postgres
+  spec:
+    type: ClusterIP
+    selector:
+      app: erun-postgres
+    ports:
+      - name: postgres
+        port: {{ $postgresPort }}
+        targetPort: postgres
+  ---
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: erun-postgres
+    labels:
+      app: erun-postgres
+  spec:
+    strategy:
+      type: Recreate
+    selector:
+      matchLabels:
+        app: erun-postgres
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: erun-postgres
+      spec:
+        securityContext:
+          fsGroup: 999
+        containers:
+          - image: {{ $postgresImage }}
+            name: erun-postgres
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: POSTGRES_DB
+                value: {{ $postgresDatabase | quote }}
+              - name: POSTGRES_USER
+                value: {{ $postgresUser | quote }}
+              - name: POSTGRES_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $postgresPasswordSecretName }}
+                    key: {{ $postgresPasswordSecretKey }}
+              - name: PGDATA
+                value: /var/lib/postgresql/data/pgdata
+            ports:
+              - containerPort: {{ $postgresPort }}
+                name: postgres
+            startupProbe:
+              exec:
+                command:
+                  - sh
+                  - -lc
+                  - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h <VERSION>.1 -p {{ $postgresPort }}
+              periodSeconds: 2
+              timeoutSeconds: 2
+              failureThreshold: 60
+            readinessProbe:
+              exec:
+                command:
+                  - sh
+                  - -lc
+                  - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h <VERSION>.1 -p {{ $postgresPort }}
+              periodSeconds: 5
+              timeoutSeconds: 2
+            volumeMounts:
+              - name: data
+                mountPath: /var/lib/postgresql/data
+        volumes:
+          - name: data
+            persistentVolumeClaim:
+              claimName: erun-postgres-data
+        restartPolicy: Always
+  ' > "$erun_bootstrap_tmp_5"
   replace=false
-  if [ ! -e '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml' ]; then
+  if [ ! -e '<HOME>/git/team/team-devops/k8s/team-devops/templates/postgres.yaml' ]; then
     replace=true
-  elif cmp -s "$erun_bootstrap_tmp_5" '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml'; then
+  elif cmp -s "$erun_bootstrap_tmp_5" '<HOME>/git/team/team-devops/k8s/team-devops/templates/postgres.yaml'; then
     replace=false
   else
     replace=false
   fi
-  if [ "$replace" = true ]; then cp "$erun_bootstrap_tmp_5" '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml'; chmod '644' '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml'; fi
+  if [ "$replace" = true ]; then cp "$erun_bootstrap_tmp_5" '<HOME>/git/team/team-devops/k8s/team-devops/templates/postgres.yaml'; chmod '644' '<HOME>/git/team/team-devops/k8s/team-devops/templates/postgres.yaml'; fi
   rm -f "$erun_bootstrap_tmp_5"
+  mkdir -p '<HOME>/git/team/team-devops/k8s/team-devops/templates'
+  if [ -d '<HOME>/git/team/team-devops/k8s/team-devops/templates/api.yaml' ]; then echo '"<HOME>/git/team/team-devops/k8s/team-devops/templates/api.yaml" is a directory' >&2; exit 1; fi
+  erun_bootstrap_tmp_6=$(mktemp)
+  printf %s '{{- $apiPort := default 17033 .Values.apiPort -}}
+  {{- $api := default dict .Values.api -}}
+  {{- $oidcAllowedIssuers := default "" $api.oidcAllowedIssuers -}}
+  {{- $awsIdentityStoreID := default "" $api.awsIdentityStoreID -}}
+  {{- $awsIdentityStoreRegion := default "" $api.awsIdentityStoreRegion -}}
+  {{- $postgres := default dict $api.postgres -}}
+  {{- $postgresDatabase := default "erun" $postgres.database -}}
+  {{- $postgresUser := default "erun" $postgres.user -}}
+  {{- $postgresPort := default 5432 $postgres.port -}}
+  {{- $postgresPasswordSecretName := default "erun-backend-postgres" $postgres.passwordSecretName -}}
+  {{- $postgresPasswordSecretKey := default "password" $postgres.passwordSecretKey -}}
+  {{- $databaseURL := default (printf "postgres://%s:$(ERUN_POSTGRES_PASSWORD)@erun-postgres:%v/%s?sslmode=disable" $postgresUser $postgresPort $postgresDatabase) $api.databaseURL -}}
+  {{- $imageOverrides := default dict .Values.imageOverrides -}}
+  {{- $backendDBImage := default (printf "ghcr.io/sophium/erun-backend-db:%s" .Chart.AppVersion) (index $imageOverrides "erun-backend-db") -}}
+  {{- $backendAPIImage := default (printf "ghcr.io/sophium/erun-backend-api:%s" .Chart.AppVersion) (index $imageOverrides "erun-backend-api") -}}
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: erun-api
+    labels:
+      app: erun-api
+  spec:
+    type: ClusterIP
+    selector:
+      app: erun-api
+    ports:
+      - name: api
+        port: {{ $apiPort }}
+        targetPort: api
+  ---
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: erun-api
+    labels:
+      app: erun-api
+  spec:
+    strategy:
+      type: Recreate
+    selector:
+      matchLabels:
+        app: erun-api
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: erun-api
+      spec:
+        initContainers:
+          - image: {{ $backendDBImage }}
+            name: erun-backend-db-migrate
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: HOME
+                value: <HOME>
+              - name: ERUN_POSTGRES_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $postgresPasswordSecretName }}
+                    key: {{ $postgresPasswordSecretKey }}
+              - name: ERUN_DATABASE_URL
+                value: {{ $databaseURL | quote }}
+        containers:
+          - image: {{ $backendAPIImage }}
+            name: erun-backend-api
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: HOME
+                value: <HOME>
+              - name: ERUN_API_HOST
+                value: <VERSION>.0
+              - name: ERUN_API_PORT
+                value: {{ $apiPort | quote }}
+              - name: ERUN_POSTGRES_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ $postgresPasswordSecretName }}
+                    key: {{ $postgresPasswordSecretKey }}
+              - name: ERUN_DATABASE_URL
+                value: {{ $databaseURL | quote }}
+              - name: ERUN_OIDC_ALLOWED_ISSUERS
+                value: {{ $oidcAllowedIssuers | quote }}
+              - name: ERUN_AWS_IDENTITY_STORE_ID
+                value: {{ $awsIdentityStoreID | quote }}
+              - name: ERUN_AWS_IDENTITY_STORE_REGION
+                value: {{ $awsIdentityStoreRegion | quote }}
+              - name: ERUN_TENANT
+                value: {{ required "tenant is required" .Values.tenant | quote }}
+              - name: ERUN_ENVIRONMENT
+                value: {{ required "environment is required" .Values.environment | quote }}
+            ports:
+              - containerPort: {{ $apiPort }}
+                name: api
+  ' > "$erun_bootstrap_tmp_6"
+  replace=false
+  if [ ! -e '<HOME>/git/team/team-devops/k8s/team-devops/templates/api.yaml' ]; then
+    replace=true
+  elif cmp -s "$erun_bootstrap_tmp_6" '<HOME>/git/team/team-devops/k8s/team-devops/templates/api.yaml'; then
+    replace=false
+  else
+    replace=false
+  fi
+  if [ "$replace" = true ]; then cp "$erun_bootstrap_tmp_6" '<HOME>/git/team/team-devops/k8s/team-devops/templates/api.yaml'; chmod '644' '<HOME>/git/team/team-devops/k8s/team-devops/templates/api.yaml'; fi
+  rm -f "$erun_bootstrap_tmp_6"
+  mkdir -p '<HOME>/git/team/team-devops/k8s/team-devops'
+  if [ -d '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml' ]; then echo '"<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml" is a directory' >&2; exit 1; fi
+  erun_bootstrap_tmp_7=$(mktemp)
+  printf %s '' > "$erun_bootstrap_tmp_7"
+  replace=false
+  if [ ! -e '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml' ]; then
+    replace=true
+  elif cmp -s "$erun_bootstrap_tmp_7" '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml'; then
+    replace=false
+  else
+    replace=false
+  fi
+  if [ "$replace" = true ]; then cp "$erun_bootstrap_tmp_7" '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml'; chmod '644' '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml'; fi
+  rm -f "$erun_bootstrap_tmp_7"
 mkdir -p <TMP>
 write-yaml <TMP>
 Configuration initialized OK

--- a/erun-integration/testdata/open/no_shell_dry_run.txt
+++ b/erun-integration/testdata/open/no_shell_dry_run.txt
@@ -9,7 +9,7 @@ kubectl --context test-context get namespace team-dev -o name
 kubectl --context test-context create namespace team-dev
 cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
 kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <VERSION>.1
-kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17033:17033 --address <VERSION>.1
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <VERSION>.1
 open: --no-shell selected, emitting setup commands instead of launching shell
 kubectl config use-context test-context
 kubectl config set-context --current --namespace=team-dev

--- a/erun-integration/testdata/open/remote_dry_run_traces_port_forwards.txt
+++ b/erun-integration/testdata/open/remote_dry_run_traces_port_forwards.txt
@@ -9,7 +9,7 @@ kubectl --context test-context get namespace team-dev -o name
 kubectl --context test-context create namespace team-dev
 cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=pvc --set-string worktreeRepoName=team --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
 kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <VERSION>.1
-kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17033:17033 --address <VERSION>.1
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <VERSION>.1
 open: --no-shell selected, emitting setup commands instead of launching shell
 kubectl config use-context test-context
 kubectl config set-context --current --namespace=team-dev

--- a/erun-integration/testdata/open/verbose_no_shell_dry_run.txt
+++ b/erun-integration/testdata/open/verbose_no_shell_dry_run.txt
@@ -9,7 +9,7 @@ kubectl --context test-context get namespace team-dev -o name
 kubectl --context test-context create namespace team-dev
 cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
 kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <VERSION>.1
-kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17033:17033 --address <VERSION>.1
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <VERSION>.1
 open: --no-shell selected, emitting setup commands instead of launching shell
 kubectl config use-context test-context
 kubectl config set-context --current --namespace=team-dev


### PR DESCRIPTION
## Summary

Phase 4. Moves the data layer and API into independent units so their lifecycle no longer tracks the runtime pod's idle stop/resume cycle, and pod restarts no longer pay the migration cost.

> Stacks on #268. Rebase to main once #268 lands.

Closes #267.

## Chart restructure

**New `postgres.yaml`**
- Dedicated `erun-postgres-data` PVC (ReadWriteOnce, 10 Gi).
- `erun-postgres` Deployment + ClusterIP Service.

**New `api.yaml`**
- `erun-api` Deployment + ClusterIP Service on port 17033.
- Migration folded in as an init container so atlas runs once per API pod start, not once per runtime pod start.

**Trimmed `service.yaml`**
- Removed: postgres sidecar (`restartPolicy: Always` initContainer), `erun-backend-postgres-reset` initContainer, `erun-backend-db` initContainer, `erun-backend-api` container.
- Runtime pod keeps `erun-devops` + `erun-mcp` + `erun-dind` only.

**Mirrored to `erun-common/assets/default-devops-chart`** and registered the two new templates in `default_devops_chart.go`'s embed list so tenants without their own devops module pick them up.

## CLI

`kubectlAPIPortForwardArgs` targets `service/erun-api` instead of `deployment/<runtime>` so desktop port-forwards survive runtime pod restarts.

## Tests

- `concatChartTemplates` helper in `deploy_test.go` lets existing chart-content assertions span the multi-file chart layout.
- `TestRuntimeEntrypointPassesOIDCIssuersToAPI` follows the OIDC pass-through into the backend-api entrypoint where Phase 1 moved it.
- Integration goldens updated for the new port-forward target.

## Data migration on upgrade

Postgres now uses its own PVC. Data previously stored inside `erun-devops-home/.erun/postgres` is orphaned on upgrade. Per #267 we explicitly accept fresh DB on upgrade — users who need to preserve data should `pg_dump` before upgrading.

## Test plan

- [x] `go test ./...` in `erun-common`, `erun-cli`, `erun-mcp` — green.
- [x] `helm template` against the runtime chart with `environment=dev` and `environment=local` — renders all expected resources (3 PVCs, 2 Services, 3 Deployments).
- [x] Integration suite (`TestBuild|TestDeploy|TestPush|TestRelease|TestOpen|TestSshd|TestInit|TestDevops`) — green.
- [ ] Real-cluster validation: chart hook ordering, idle-controller scoping, NetworkPolicy reachability between pods. Not possible in this environment.

## Followups (not in this PR)

- The deploy code still emits `--set api.postgres.reset=...`, which the chart now ignores. Replace with a wipe-PVC mechanism (one-shot Job, manual `kubectl delete pvc`, or a Helm uninstall flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)