### PR TITLE
Replace silent MCP auto-recovery with explicit Reconnect action

### DIFF
--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -10,10 +10,11 @@ import (
 )
 
 const (
-	terminalOutputEvent = "terminal-output"
-	terminalExitEvent   = "terminal-exit"
-	appStatusEvent      = "app-status"
-	appSessionEnvVar    = "ERUN_UI_SESSION"
+	terminalOutputEvent   = "terminal-output"
+	terminalExitEvent     = "terminal-exit"
+	appStatusEvent        = "app-status"
+	mcpReconnectLineEvent = "mcp-reconnect-line"
+	appSessionEnvVar      = "ERUN_UI_SESSION"
 )
 
 type erunUIStore interface {
@@ -39,6 +40,7 @@ type erunUIDeps struct {
 	listKubeContexts      func() ([]string, error)
 	loadResourceStatus    func(context.Context, uiRuntimeResourceInput) (uiRuntimeResourceStatus, error)
 	ensureMCP             func(context.Context, eruncommon.OpenResult) error
+	reconnectMCP          func(context.Context, eruncommon.OpenResult, func(string)) error
 	ensureSSHD            func(context.Context, eruncommon.OpenResult) error
 	canConnectLocalPort   func(int) bool
 	setRemoteCloudAlias   func(context.Context, string, string, string, string) (eruncommon.EnvConfig, error)
@@ -116,6 +118,11 @@ func withDefaultRuntimeDeps(deps erunUIDeps) erunUIDeps {
 	if deps.ensureMCP == nil {
 		deps.ensureMCP = func(ctx context.Context, result eruncommon.OpenResult) error {
 			return ensureMCPViaOpenCommand(ctx, deps.resolveCLIPath(), result)
+		}
+	}
+	if deps.reconnectMCP == nil {
+		deps.reconnectMCP = func(ctx context.Context, result eruncommon.OpenResult, onLine func(string)) error {
+			return runOpenForReconnect(ctx, deps.resolveCLIPath(), result, onLine)
 		}
 	}
 	if deps.ensureSSHD == nil {

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -349,14 +349,14 @@ func TestLoadDiffUsesSelectedMCPPort(t *testing.T) {
 		},
 	}
 	var gotEndpoint string
-	var ensured eruncommon.OpenResult
+	ensureCalls := 0
 	app := NewApp(erunUIDeps{
 		store: store,
 		canConnectLocalPort: func(int) bool {
-			return false
+			return true
 		},
-		ensureMCP: func(_ context.Context, result eruncommon.OpenResult) error {
-			ensured = result
+		ensureMCP: func(_ context.Context, _ eruncommon.OpenResult) error {
+			ensureCalls++
 			return nil
 		},
 		loadDiff: func(_ context.Context, endpoint string, options uiDiffOptions) (eruncommon.DiffResult, error) {
@@ -375,15 +375,15 @@ func TestLoadDiffUsesSelectedMCPPort(t *testing.T) {
 	if gotEndpoint != "http://127.0.0.1:17000/mcp" {
 		t.Fatalf("unexpected endpoint: %q", gotEndpoint)
 	}
-	if ensured.Tenant != "erun" || ensured.Environment != "local" {
-		t.Fatalf("expected MCP forward to be ensured before diff, got %+v", ensured)
+	if ensureCalls != 0 {
+		t.Fatalf("LoadDiff must not implicitly run erun open; got ensureCalls=%d", ensureCalls)
 	}
 	if result.RawDiff == "" {
 		t.Fatalf("unexpected diff result: %+v", result)
 	}
 }
 
-func TestLoadDiffReactivatesMCPAfterConnectionError(t *testing.T) {
+func TestLoadDiffReturnsUnreachableWhenPortClosed(t *testing.T) {
 	projectRoot := t.TempDir()
 	store := stubUIStore{
 		tenants: map[string]eruncommon.TenantConfig{
@@ -406,36 +406,118 @@ func TestLoadDiffReactivatesMCPAfterConnectionError(t *testing.T) {
 	app := NewApp(erunUIDeps{
 		store: store,
 		canConnectLocalPort: func(int) bool {
-			return true
+			return false
 		},
-		ensureMCP: func(_ context.Context, result eruncommon.OpenResult) error {
+		ensureMCP: func(_ context.Context, _ eruncommon.OpenResult) error {
 			ensureCalls++
-			if result.Tenant != "erun" || result.Environment != "test" {
-				t.Fatalf("unexpected MCP target: %+v", result)
-			}
 			return nil
 		},
-		loadDiff: func(_ context.Context, endpoint string, _ uiDiffOptions) (eruncommon.DiffResult, error) {
+		loadDiff: func(_ context.Context, _ string, _ uiDiffOptions) (eruncommon.DiffResult, error) {
 			loadCalls++
-			if endpoint != "http://127.0.0.1:17000/mcp" {
-				t.Fatalf("unexpected endpoint: %q", endpoint)
-			}
-			if loadCalls == 1 {
-				return eruncommon.DiffResult{}, errors.New("EOF")
-			}
-			return eruncommon.DiffResult{RawDiff: "diff --git a/a.txt b/a.txt\n"}, nil
+			return eruncommon.DiffResult{}, nil
 		},
 	})
 
-	result, err := app.LoadDiff(uiSelection{Tenant: "erun", Environment: "test"}, uiDiffOptions{})
-	if err != nil {
-		t.Fatalf("LoadDiff failed: %v", err)
+	_, err := app.LoadDiff(uiSelection{Tenant: "erun", Environment: "test"}, uiDiffOptions{})
+	if err == nil {
+		t.Fatalf("expected unreachable error when port is closed")
 	}
-	if ensureCalls != 1 || loadCalls != 2 {
-		t.Fatalf("expected one MCP reactivation and retry, got ensure=%d load=%d", ensureCalls, loadCalls)
+	if !errors.Is(err, errMCPUnreachable) {
+		t.Fatalf("expected errMCPUnreachable, got %v", err)
 	}
-	if result.RawDiff == "" {
-		t.Fatalf("unexpected diff result: %+v", result)
+	if ensureCalls != 0 || loadCalls != 0 {
+		t.Fatalf("LoadDiff must not run erun open or attempt the dial when the port is closed; got ensure=%d load=%d", ensureCalls, loadCalls)
+	}
+}
+
+func TestLoadDiffWrapsDialFailureAsUnreachable(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {
+				Name:               "erun",
+				ProjectRoot:        projectRoot,
+				DefaultEnvironment: "test",
+			},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/test": {
+				Name:              "test",
+				RepoPath:          projectRoot,
+				KubernetesContext: "orbstack",
+			},
+		},
+	}
+	ensureCalls := 0
+	app := NewApp(erunUIDeps{
+		store: store,
+		canConnectLocalPort: func(int) bool {
+			return true
+		},
+		ensureMCP: func(_ context.Context, _ eruncommon.OpenResult) error {
+			ensureCalls++
+			return nil
+		},
+		loadDiff: func(_ context.Context, _ string, _ uiDiffOptions) (eruncommon.DiffResult, error) {
+			return eruncommon.DiffResult{}, errors.New("EOF")
+		},
+	})
+
+	_, err := app.LoadDiff(uiSelection{Tenant: "erun", Environment: "test"}, uiDiffOptions{})
+	if err == nil {
+		t.Fatalf("expected dial failure to surface as unreachable")
+	}
+	if !errors.Is(err, errMCPUnreachable) {
+		t.Fatalf("expected errMCPUnreachable, got %v", err)
+	}
+	if ensureCalls != 0 {
+		t.Fatalf("LoadDiff must not implicitly run erun open after a dial failure; got ensureCalls=%d", ensureCalls)
+	}
+}
+
+func TestReconnectMCPRunsOpenAndStreamsLines(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {
+				Name:               "erun",
+				ProjectRoot:        projectRoot,
+				DefaultEnvironment: "test",
+			},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/test": {
+				Name:              "test",
+				RepoPath:          projectRoot,
+				KubernetesContext: "orbstack",
+			},
+		},
+	}
+	calls := 0
+	var lines []string
+	app := NewApp(erunUIDeps{
+		store: store,
+		reconnectMCP: func(_ context.Context, result eruncommon.OpenResult, onLine func(string)) error {
+			calls++
+			if result.Tenant != "erun" || result.Environment != "test" {
+				t.Fatalf("unexpected target: %+v", result)
+			}
+			onLine("step: deploying erun-devops")
+			lines = append(lines, "step: deploying erun-devops")
+			onLine("==> Deployed erun/test")
+			lines = append(lines, "==> Deployed erun/test")
+			return nil
+		},
+	})
+
+	if err := app.ReconnectMCP(uiSelection{Tenant: " erun ", Environment: " test "}); err != nil {
+		t.Fatalf("ReconnectMCP failed: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected reconnect to invoke open exactly once, got %d", calls)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected two streamed lines, got %d", len(lines))
 	}
 }
 

--- a/erun-ui/frontend/src/App.tsx
+++ b/erun-ui/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { TerminalTabStrip } from '@/components/app/TerminalTabStrip';
 import { EnvironmentDialogView } from '@/components/app/EnvironmentDialogView';
 import { GlobalConfigDialogView } from '@/components/app/GlobalConfigDialogView';
 import { ManageDialogView } from '@/components/app/ManageDialogView';
+import { ReconnectDialog } from '@/components/app/ReconnectDialog';
 import { ReviewPanel } from '@/components/app/ReviewPanel';
 import { Sidebar } from '@/components/app/Sidebar';
 import { TenantDashboardView } from '@/components/app/TenantDashboardView';
@@ -81,6 +82,7 @@ export function App(): React.ReactElement {
       <EnvironmentDialogView controller={controller} state={state} />
       <GlobalConfigDialogView controller={controller} state={state} />
       <ManageDialogView controller={controller} state={state} />
+      <ReconnectDialog controller={controller} state={state} />
       <TenantDialogView controller={controller} state={state} />
     </TooltipProvider>
   );

--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -17,6 +17,7 @@ import {
   LoginCloudProvider,
   LogoutCloudProvider,
   OpenIDE,
+  ReconnectMCP,
   ResizeSession,
   SavePastedImage,
   SaveTenantConfig,
@@ -32,6 +33,7 @@ import { ClipboardSetText, EventsOn, WindowToggleMaximise } from '../../wailsjs/
 import { fileToBase64, decodeBase64Bytes, isTerminalPasteTarget, pastedImageFiles } from './clipboard';
 import { replaceCloudProvider } from './cloudContextState';
 import { chooseSelectedDiffPath } from './diffUtils';
+import { isMcpUnreachableMessage, stripMcpUnreachableMarker } from './reconnectCopy';
 import {
   normalizedEnvironmentDialogValues,
   rememberEnvironmentDialogSelection,
@@ -173,6 +175,8 @@ export class ERunUIController {
     diff: null,
     diffLoading: false,
     diffError: '',
+    diffErrorReconnectable: false,
+    reconnect: { status: 'idle', lastLine: '', error: '' },
     selectedDiffPath: '',
     selectedReviewScope: 'current',
     selectedReviewCommit: '',
@@ -224,6 +228,7 @@ export class ERunUIController {
   private terminalOutputOff: (() => void) | null = null;
   private terminalExitOff: (() => void) | null = null;
   private appStatusOff: (() => void) | null = null;
+  private reconnectLineOff: (() => void) | null = null;
   private pasteHandler: ((event: ClipboardEvent) => void) | null = null;
   private terminalStatusRetrySelection: UISelection | null = null;
   private readonly globalConfig = new GlobalConfigWorkflow({
@@ -329,6 +334,9 @@ export class ERunUIController {
     this.appStatusOff = EventsOn('app-status', (payload: AppStatusPayload) => {
       this.handleAppStatus(payload);
     });
+    this.reconnectLineOff = EventsOn('mcp-reconnect-line', (line: string) => {
+      this.handleReconnectLine(line);
+    });
 
     if (!this.bootStarted) {
       this.bootStarted = true;
@@ -349,6 +357,7 @@ export class ERunUIController {
     this.terminalOutputOff?.();
     this.terminalExitOff?.();
     this.appStatusOff?.();
+    this.reconnectLineOff?.();
     window.clearTimeout(this.notificationTimer);
     window.clearTimeout(this.terminalCopyStatusTimer);
     window.clearTimeout(this.idleStatusTimer);
@@ -359,6 +368,7 @@ export class ERunUIController {
     this.terminalOutputOff = null;
     this.terminalExitOff = null;
     this.appStatusOff = null;
+    this.reconnectLineOff = null;
     this.terminalQueryResponseDisposables = [];
     this.terminal?.dispose();
     this.terminal = null;
@@ -1435,6 +1445,7 @@ export class ERunUIController {
       }
       this.state.diff = diff;
       this.state.diffError = '';
+      this.state.diffErrorReconnectable = false;
       this.state.selectedReviewScope = diff.scope || 'current';
       this.state.selectedReviewCommit = diff.selectedCommit || '';
       this.state.selectedDiffPath = chooseSelectedDiffPath(diff, this.state.selectedDiffPath);
@@ -1448,7 +1459,14 @@ export class ERunUIController {
       if (!options.silent || !this.state.diff) {
         this.state.diff = null;
       }
-      this.state.diffError = readError(error);
+      const message = readError(error);
+      if (isMcpUnreachableMessage(message)) {
+        this.state.diffError = stripMcpUnreachableMarker(message);
+        this.state.diffErrorReconnectable = true;
+      } else {
+        this.state.diffError = message;
+        this.state.diffErrorReconnectable = false;
+      }
     } finally {
       if (request === this.reviewDiffRequest) {
         if (!options.silent) {
@@ -1496,6 +1514,59 @@ export class ERunUIController {
   private stopReviewDiffRefresh(): void {
     window.clearTimeout(this.reviewDiffRefreshTimer);
     this.reviewDiffRefreshTimer = 0;
+  }
+
+  // requestReconnect opens the explicit-confirmation dialog for the
+  // unreachable-MCP recovery flow. The dialog runs `erun open`, which can
+  // redeploy the runtime, so the action is gated on a deliberate user click.
+  requestReconnect(): void {
+    if (!this.state.selected) {
+      return;
+    }
+    this.state.reconnect = { status: 'confirm', lastLine: '', error: '' };
+    this.emit();
+  }
+
+  cancelReconnect(): void {
+    if (this.state.reconnect.status === 'running') {
+      return;
+    }
+    this.state.reconnect = { status: 'idle', lastLine: '', error: '' };
+    this.emit();
+  }
+
+  async confirmReconnect(): Promise<void> {
+    const selection = this.state.selected;
+    if (!selection || this.state.reconnect.status === 'running') {
+      return;
+    }
+    this.state.reconnect = { status: 'running', lastLine: '', error: '' };
+    this.emit();
+    try {
+      await ReconnectMCP(selection);
+      this.state.reconnect = { status: 'idle', lastLine: '', error: '' };
+      this.emit();
+      await this.loadReviewDiff();
+    } catch (error: unknown) {
+      this.state.reconnect = {
+        status: 'error',
+        lastLine: this.state.reconnect.lastLine,
+        error: readError(error),
+      };
+      this.emit();
+    }
+  }
+
+  private handleReconnectLine(line: string): void {
+    const trimmed = (line || '').trim();
+    if (!trimmed) {
+      return;
+    }
+    if (this.state.reconnect.status !== 'running') {
+      return;
+    }
+    this.state.reconnect = { ...this.state.reconnect, lastLine: trimmed };
+    this.emit();
   }
 
   toggleDiffDirectory(path: string): void {

--- a/erun-ui/frontend/src/app/reconnectCopy.ts
+++ b/erun-ui/frontend/src/app/reconnectCopy.ts
@@ -1,0 +1,37 @@
+// Strings shown when the desktop loses its connection to an environment's
+// in-cluster runtime (the local MCP port-forward is unreachable). The same
+// copy is reused across surfaces — review panel, manage dialog — so users
+// see consistent labels for what is essentially one recovery flow.
+//
+// The marker comes from erun-ui/mcp_errors.go and is opaque; it never
+// appears in user-facing text.
+export const MCP_UNREACHABLE_MARKER = 'ERUN_MCP_UNREACHABLE: ';
+
+export const reconnectCopy = {
+  errorTitle: 'Cannot reach the environment runtime',
+  errorBody: 'The diff could not be loaded because the connection to your environment is down.',
+  retryAction: 'Retry',
+  reconnectAction: 'Reconnect…',
+  dialogTitle: 'Reconnect to environment?',
+  dialogBody:
+    'This runs `erun open` to restore the connection. If the environment runtime is not currently running, it will be redeployed.',
+  dialogCancel: 'Cancel',
+  dialogConfirm: 'Reconnect',
+  runningStatus: 'Reconnecting…',
+  runningHint: 'Latest output will appear below.',
+  errorStatusTitle: 'Reconnect failed',
+} as const;
+
+// Strip the opaque marker from a wrapped backend error before surfacing it
+// in user-facing text. The marker prefix indicates the typed error category
+// but is never shown verbatim.
+export function stripMcpUnreachableMarker(message: string): string {
+  if (message.startsWith(MCP_UNREACHABLE_MARKER)) {
+    return message.slice(MCP_UNREACHABLE_MARKER.length);
+  }
+  return message;
+}
+
+export function isMcpUnreachableMessage(message: string): boolean {
+  return message.startsWith(MCP_UNREACHABLE_MARKER);
+}

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -137,6 +137,14 @@ export interface DoctorOutcome {
   message: string;
 }
 
+export type ReconnectStatus = 'idle' | 'confirm' | 'running' | 'error';
+
+export interface ReconnectState {
+  status: ReconnectStatus;
+  lastLine: string;
+  error: string;
+}
+
 export interface AppState {
   tenants: UITenant[];
   cloudProviders: UICloudProviderStatus[];
@@ -161,6 +169,8 @@ export interface AppState {
   diff: DiffResult | null;
   diffLoading: boolean;
   diffError: string;
+  diffErrorReconnectable: boolean;
+  reconnect: ReconnectState;
   selectedDiffPath: string;
   selectedReviewScope: 'current' | 'commit' | 'all';
   selectedReviewCommit: string;

--- a/erun-ui/frontend/src/components/app/DiffList.tsx
+++ b/erun-ui/frontend/src/components/app/DiffList.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { AlertCircle, RefreshCw } from 'lucide-react';
+import { AlertCircle, PlugZap, RefreshCw } from 'lucide-react';
 
 import type { ERunUIController } from '@/app/ERunUIController';
 import { compactDiffError, diffLineMark } from '@/app/diffUtils';
+import { reconnectCopy } from '@/app/reconnectCopy';
 import type { AppState } from '@/app/state';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -13,7 +14,15 @@ export function DiffList({ controller, state }: { controller: ERunUIController; 
     return <ReviewStatus>Loading diff...</ReviewStatus>;
   }
   if (state.diffError) {
-    return <DiffErrorAlert message={compactDiffError(state.diffError)} loading={state.diffLoading} onRetry={() => { void controller.loadReviewDiff(); }} />;
+    return (
+      <DiffErrorAlert
+        message={compactDiffError(state.diffError)}
+        loading={state.diffLoading}
+        reconnectable={state.diffErrorReconnectable}
+        onRetry={() => { void controller.loadReviewDiff(); }}
+        onReconnect={() => controller.requestReconnect()}
+      />
+    );
   }
   const files = state.diff?.files || [];
   if (files.length === 0) {
@@ -29,7 +38,21 @@ export function DiffList({ controller, state }: { controller: ERunUIController; 
   );
 }
 
-export function DiffErrorAlert({ message, loading, onRetry }: { message: string; loading: boolean; onRetry: () => void }): React.ReactElement {
+export function DiffErrorAlert({
+  message,
+  loading,
+  reconnectable,
+  onRetry,
+  onReconnect,
+}: {
+  message: string;
+  loading: boolean;
+  reconnectable?: boolean;
+  onRetry: () => void;
+  onReconnect?: () => void;
+}): React.ReactElement {
+  const title = reconnectable ? reconnectCopy.errorTitle : 'Could not load diff';
+  const body = reconnectable ? reconnectCopy.errorBody : message;
   return (
     <div
       role="alert"
@@ -37,13 +60,24 @@ export function DiffErrorAlert({ message, loading, onRetry }: { message: string;
     >
       <AlertCircle className="mt-px size-[18px] flex-none text-destructive" aria-hidden="true" />
       <div className="min-w-0 [overflow-wrap:anywhere] text-foreground">
-        <div className="font-semibold text-destructive">Could not load diff</div>
-        <div className="text-muted-foreground">{message}</div>
+        <div className="font-semibold text-destructive">{title}</div>
+        <div className="text-muted-foreground">{body}</div>
+        {reconnectable && message && message !== body && (
+          <div className="mt-1 truncate font-mono text-[12px] text-muted-foreground">{message}</div>
+        )}
       </div>
-      <Button type="button" variant="outline" size="sm" disabled={loading} onClick={onRetry}>
-        <RefreshCw aria-hidden="true" />
-        Retry
-      </Button>
+      <div className="flex flex-col items-end gap-1.5">
+        <Button type="button" variant="outline" size="sm" disabled={loading} onClick={onRetry}>
+          <RefreshCw aria-hidden="true" />
+          {reconnectCopy.retryAction}
+        </Button>
+        {reconnectable && onReconnect && (
+          <Button type="button" variant="outline" size="sm" disabled={loading} onClick={onReconnect}>
+            <PlugZap aria-hidden="true" />
+            {reconnectCopy.reconnectAction}
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/erun-ui/frontend/src/components/app/ReconnectDialog.tsx
+++ b/erun-ui/frontend/src/components/app/ReconnectDialog.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { AlertCircle, LoaderCircle, RefreshCw } from 'lucide-react';
+
+import type { ERunUIController } from '@/app/ERunUIController';
+import { reconnectCopy } from '@/app/reconnectCopy';
+import type { AppState } from '@/app/state';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+
+export function ReconnectDialog({ controller, state }: { controller: ERunUIController; state: AppState }): React.ReactElement {
+  const reconnect = state.reconnect;
+  const open = reconnect.status !== 'idle';
+  const running = reconnect.status === 'running';
+  const failed = reconnect.status === 'error';
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          controller.cancelReconnect();
+        }
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{reconnectCopy.dialogTitle}</DialogTitle>
+          <DialogDescription>{reconnectCopy.dialogBody}</DialogDescription>
+        </DialogHeader>
+        {(running || failed) && (
+          <div className="rounded-[var(--radius)] border bg-muted/40 px-3 py-2.5 text-[13px] leading-[1.4]">
+            {running && (
+              <div className="flex items-start gap-2 text-muted-foreground">
+                <LoaderCircle className="mt-px size-[14px] flex-none animate-spin" aria-hidden="true" />
+                <div className="min-w-0 [overflow-wrap:anywhere]">
+                  <div className="font-medium text-foreground">{reconnectCopy.runningStatus}</div>
+                  <div className="mt-0.5 truncate font-mono text-[12px] text-muted-foreground">
+                    {reconnect.lastLine || reconnectCopy.runningHint}
+                  </div>
+                </div>
+              </div>
+            )}
+            {failed && (
+              <div className="flex items-start gap-2">
+                <AlertCircle className="mt-px size-[14px] flex-none text-destructive" aria-hidden="true" />
+                <div className="min-w-0 [overflow-wrap:anywhere]">
+                  <div className="font-medium text-destructive">{reconnectCopy.errorStatusTitle}</div>
+                  <div className="mt-0.5 text-muted-foreground">{reconnect.error}</div>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+        <DialogFooter>
+          <Button type="button" variant="outline" disabled={running} onClick={() => controller.cancelReconnect()}>
+            {reconnectCopy.dialogCancel}
+          </Button>
+          <Button
+            type="button"
+            disabled={running}
+            onClick={() => {
+              void controller.confirmReconnect();
+            }}
+          >
+            {running ? <LoaderCircle className="animate-spin" aria-hidden="true" /> : <RefreshCw aria-hidden="true" />}
+            {reconnectCopy.dialogConfirm}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/erun-ui/frontend/src/components/app/ReviewPanel.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewPanel.tsx
@@ -238,7 +238,9 @@ function ChangedFileTree({ controller, state }: { controller: ERunUIController; 
       <DiffErrorAlert
         message={compactDiffError(state.diffError)}
         loading={state.diffLoading}
+        reconnectable={state.diffErrorReconnectable}
         onRetry={() => { void controller.loadReviewDiff(); }}
+        onReconnect={() => controller.requestReconnect()}
       />
     );
   }

--- a/erun-ui/mcp_errors.go
+++ b/erun-ui/mcp_errors.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"syscall"
+)
+
+// errMCPUnreachable is the sentinel error category returned by Wails methods
+// that talk to the in-cluster MCP server when the local port-forward cannot
+// be reached. The frontend uses errors.Is — via the leading marker on the
+// surfaced error string — to decide whether to render the unreachable state
+// with an explicit Reconnect action.
+//
+// Side-effecting recovery (running `erun open`, which can redeploy the
+// runtime) is gated on that explicit user action; LoadDiff and other MCP
+// readers no longer recover implicitly.
+var errMCPUnreachable = errors.New("mcp unreachable")
+
+// mcpUnreachableMarker is prefixed onto every surfaced error message so the
+// frontend can detect the unreachable state without depending on locale or
+// underlying error text. The marker is opaque; it is never shown to users.
+const mcpUnreachableMarker = "ERUN_MCP_UNREACHABLE: "
+
+func wrapMCPUnreachableError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s%w: %w", mcpUnreachableMarker, errMCPUnreachable, err)
+}
+
+func isMCPDialFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	var netErr *net.OpError
+	if errors.As(err, &netErr) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ETIMEDOUT) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "EOF") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "no route to host") ||
+		strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "context deadline exceeded")
+}

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -200,6 +201,59 @@ func ensureMCPViaOpenCommand(ctx context.Context, cliPath string, result eruncom
 		return fmt.Errorf("activate MCP port-forward: %w", err)
 	}
 	return fmt.Errorf("activate MCP port-forward: %w: %s", err, detail)
+}
+
+// runOpenForReconnect runs the same `erun open --no-shell --no-alias-prompt`
+// child process as ensureMCPViaOpenCommand, but streams stdout/stderr lines
+// via onLine so the desktop UI can show progress while the open (and any
+// runtime deploy it triggers) is in flight. The trailing buffered output is
+// included verbatim in the returned error so the user still sees the
+// actionable detail when the command exits non-zero.
+func runOpenForReconnect(ctx context.Context, cliPath string, result eruncommon.OpenResult, onLine func(string)) error {
+	args := buildOpenNoShellArgs(result.Tenant, result.Environment)
+	cmd := exec.CommandContext(ctx, cliPath, args...)
+	cmd.Env = append(os.Environ(), "ERUN_IDLE_PROBE=1")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("activate MCP port-forward: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("activate MCP port-forward: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("activate MCP port-forward: %w", err)
+	}
+	var lastErr strings.Builder
+	scan := func(reader io.Reader, captureErr bool) {
+		scanner := bufio.NewScanner(reader)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if onLine != nil && strings.TrimSpace(line) != "" {
+				onLine(line)
+			}
+			if captureErr {
+				if lastErr.Len() > 0 {
+					lastErr.WriteByte('\n')
+				}
+				lastErr.WriteString(line)
+			}
+		}
+	}
+	done := make(chan struct{}, 2)
+	go func() { scan(stdout, false); done <- struct{}{} }()
+	go func() { scan(stderr, true); done <- struct{}{} }()
+	<-done
+	<-done
+	if err := cmd.Wait(); err != nil {
+		detail := strings.TrimSpace(lastErr.String())
+		if detail == "" {
+			return fmt.Errorf("activate MCP port-forward: %w", err)
+		}
+		return fmt.Errorf("activate MCP port-forward: %w: %s", err, detail)
+	}
+	return nil
 }
 
 func ensureSSHDViaOpenCommand(ctx context.Context, cliPath string, result eruncommon.OpenResult) error {

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -637,18 +637,16 @@ func (a *App) LoadDiff(selection uiSelection, options uiDiffOptions) (eruncommon
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if err := a.ensureMCPAvailable(ctx, result); err != nil {
-		return eruncommon.DiffResult{}, err
+	mcpPort := eruncommon.MCPPortForResult(result)
+	if a.deps.canConnectLocalPort != nil && !a.deps.canConnectLocalPort(mcpPort) {
+		return eruncommon.DiffResult{}, wrapMCPUnreachableError(fmt.Errorf("mcp port %d is not reachable", mcpPort))
 	}
 	endpoint := mcpEndpointForOpenResult(result)
 	diff, err := a.deps.loadDiff(ctx, endpoint, options)
-	if err == nil || a.deps.ensureMCP == nil {
-		return diff, err
+	if err != nil && isMCPDialFailure(err) {
+		return eruncommon.DiffResult{}, wrapMCPUnreachableError(err)
 	}
-	if ensureErr := a.deps.ensureMCP(ctx, result); ensureErr != nil {
-		return eruncommon.DiffResult{}, err
-	}
-	return a.deps.loadDiff(ctx, endpoint, options)
+	return diff, err
 }
 
 func (a *App) ensureMCPAvailable(ctx context.Context, result eruncommon.OpenResult) error {
@@ -661,6 +659,42 @@ func (a *App) ensureMCPAvailable(ctx context.Context, result eruncommon.OpenResu
 		}
 	}
 	return nil
+}
+
+// ReconnectMCP runs `erun open --no-shell` for the selected environment so
+// the local MCP port-forward (and, if the runtime pod is missing, the
+// runtime itself) gets re-established. This is the only desktop path that
+// may invoke the open command implicitly on the user's behalf, and it is
+// gated on an explicit user click in the review panel's unreachable state.
+//
+// Stdout/stderr lines are streamed to the frontend via the
+// mcpReconnectLineEvent so a long-running deploy does not look frozen.
+func (a *App) ReconnectMCP(selection uiSelection) error {
+	selection = normalizeSelection(selection)
+	if selection.Tenant == "" || selection.Environment == "" {
+		return fmt.Errorf("tenant and environment are required")
+	}
+	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
+		Tenant:      selection.Tenant,
+		Environment: selection.Environment,
+	})
+	if err != nil {
+		return err
+	}
+	ctx := a.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if a.deps.reconnectMCP == nil {
+		return fmt.Errorf("reconnect is not configured")
+	}
+	emit := func(line string) {
+		if a.ctx == nil {
+			return
+		}
+		runtime.EventsEmit(a.ctx, mcpReconnectLineEvent, line)
+	}
+	return a.deps.reconnectMCP(ctx, result, emit)
 }
 
 func (a *App) ResizeSession(sessionID, cols, rows int) error {


### PR DESCRIPTION
## Summary
- Stop spawning `erun open --no-shell` implicitly from the review panel — that command runs `maybeDeployRuntime` before honoring `--no-shell`, so silent recovery was cascading into surprise full `erun deploy` runs.
- `LoadDiff` now returns a typed unreachable error (no auto-recovery). The review panel renders an inline error with primary `Retry` / secondary `Reconnect…`. `Reconnect…` opens a confirmation dialog that names the side effect, then calls the new `ReconnectMCP` Wails method, which streams the open command's stdout/stderr to the dialog.

## Why
Violates `erun-ui/AGENTS.md` line 97: "Status refresh, login, deploy, delete, and other side-effecting actions must be explicit user actions." User reported the review panel triggering a redeploy when MCP connection failed — the cause was `terminal_sessions.go:LoadDiff` calling `ensureMCPAvailable` pre-flight + an `ensureMCP` post-call retry, both of which run `erun open` which runs `maybeDeployRuntime` (`erun-cli/cmd/open.go:295`) before the `--no-shell` short-circuit (`:304`).

## UX gate (per erun-ui/AGENTS.md line 81)
- Inline error block where the user is looking — NN #1 *Visibility of system status*, AGENTS.md line 92.
- Explicit primary/secondary action split (`Retry` vs `Reconnect…`) — AGENTS.md line 90.
- Material *Dialog* for the side-effecting confirmation; trailing `…` signals the follow-up confirmation.
- Worst-case warning copy ("if the runtime is not running, it will be redeployed") — NN #5, AGENTS.md line 98.
- Running state shows latest streamed output line so a long deploy is not invisible — NN #1.
- User-language copy throughout, no MCP/k8s jargon in headlines — NN #2, AGENTS.md line 96.
- Icons (`PlugZap`, `RefreshCw`, `LoaderCircle`, `AlertCircle`) paired with text labels — non-color-only state per WCAG 1.4.1 / AGENTS.md line 101.
- Reuses existing shadcn `Dialog` + `Button` primitives — `yarn shadcn:check` stays green.

## Out of scope
- `erun open`'s own ordering of `maybeDeployRuntime` vs `--no-shell` (left as the CLI's contract).
- The save-time `saveRemoteCloudAlias` path that still uses `ensureMCPViaOpenCommand` (the user has already explicitly clicked Save in that flow).

## Test plan
- [x] `go test ./erun-ui/...` (passes; new tests `TestLoadDiffReturnsUnreachableWhenPortClosed`, `TestLoadDiffWrapsDialFailureAsUnreachable`, `TestReconnectMCPRunsOpenAndStreamsLines`)
- [x] `cd erun-ui/frontend && yarn build && yarn shadcn:check` (both green)
- [x] `make integration-test` — three pre-existing host/time-of-day failures (`TestActivity/status_with_seeded_env`, `TestIdle/status_for_seeded_env`, `TestRelease/dry_run_includes_linux_release_scripts`) reproduce on `main` with these changes stashed; not caused by this PR
- [ ] Manual: kill MCP port-forward → open review panel → see unreachable state with Reconnect… → click → confirmation dialog with side-effect copy → click Reconnect → spinner with last line of output → diff reloads
- [ ] Manual: with runtime down → click Reconnect → see streamed `erun deploy` lines in dialog → on completion, diff loads (or error shows actionable open stderr)

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)