### PR TITLE
Lift cmd/open.go integration coverage with five new --dry-run scenarios

### DIFF
--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -33,6 +33,21 @@ func stubKubectlNotFound(t *testing.T, setup env.Setup) []string {
 	return append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
 }
 
+// stubKubectlGenericError writes a kubectl stub that exits non-zero with a
+// message that does not match the "NotFound" / "no resources found" tokens
+// CheckKubernetesDeployment treats as an absent deployment. Used to lock the
+// dry-run "kubernetes deployment check failed, assuming not deployed"
+// fallback in shouldDeployRuntime (open.go:407-410).
+func stubKubectlGenericError(t *testing.T, setup env.Setup) []string {
+	t.Helper()
+	stubs := setup.Cwd + "/stubs"
+	fixture.StubBinaryAdvanced(t, stubs, "kubectl", fixture.StubBinarySpec{
+		Stderr:   `Unable to connect to the server: dial tcp 10.0.0.1:443: i/o timeout`,
+		ExitCode: 2,
+	})
+	return append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+}
+
 func TestOpen(t *testing.T) {
 	t.Run("help", func(t *testing.T) {
 		setup := env.New(t)
@@ -207,4 +222,82 @@ func TestOpen(t *testing.T) {
 		}
 		golden.Equal(t, "open/default_tenant_environment_resolves_from_root_config", normalize.Apply(result.Combined))
 	})
+
+	t.Run("kubectl_error_assumes_not_deployed", func(t *testing.T) {
+		// kubectl stub exits non-zero with a non-NotFound error. In
+		// dry-run, shouldDeployRuntime traces "assuming not deployed" and
+		// proceeds with the helm upgrade. Locks the dry-run fallback in
+		// shouldDeployRuntime (open.go:407-410).
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		envVars := stubKubectlGenericError(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if !strings.Contains(result.Combined, "assuming not deployed") {
+			t.Fatalf("expected dry-run fallback trace when kubectl errors generically, got:\n%s", result.Combined)
+		}
+		golden.Equal(t, "open/kubectl_error_assumes_not_deployed", normalize.Apply(result.Combined))
+	})
+
+	t.Run("not_initialized_triggers_init_retry", func(t *testing.T) {
+		// `erun open team dev` with no config triggers
+		// resolveOpenWithInitStopForParams' init-fired branch:
+		// resolveOpen errors with ErrNotInitialized, shouldRunInitForOpenCommand
+		// matches, runInitBeforeOpenForParams runs init in dry-run, and the
+		// command exits via initRan=true (open.go:226-230). The init dry-run
+		// trace is captured in the golden alongside open's audit line.
+		setup := env.New(t)
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/not_initialized_triggers_init_retry", normalize.Apply(result.Combined))
+	})
+
+	t.Run("tenant_flag_only_resolves_default_env", func(t *testing.T) {
+		// `erun open --tenant team` (flag, no positional args) lands in
+		// resolveOpenParams' "tenant set, environment empty" switch case
+		// (open.go:172-174), with UseDefaultEnvironment=true so the env
+		// resolves from the tenant config. OpenParamsForArgs treats a
+		// single positional arg as the *environment*, not the tenant, so
+		// the tenant-only branch is only reachable via the --tenant flag.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "--tenant", "team", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if !strings.Contains(result.Combined, "tenant=team environment=dev") {
+			t.Fatalf("expected default env to resolve from tenant config, got:\n%s", result.Combined)
+		}
+		golden.Equal(t, "open/tenant_flag_only_resolves_default_env", normalize.Apply(result.Combined))
+	})
+
+	t.Run("environment_positional_resolves_default_tenant", func(t *testing.T) {
+		// `erun open dev` (single positional arg) lands in
+		// resolveOpenParams' "tenant empty, environment set" switch case
+		// (open.go:169-171), with UseDefaultTenant=true so the tenant
+		// resolves from the root config's defaulttenant. Locks the second
+		// switch case which existing 0-arg and 2-arg scenarios skip.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if !strings.Contains(result.Combined, "tenant=team environment=dev") {
+			t.Fatalf("expected default tenant to resolve from root config, got:\n%s", result.Combined)
+		}
+		golden.Equal(t, "open/environment_positional_resolves_default_tenant", normalize.Apply(result.Combined))
+	})
+
+	t.Run("remote_runtime_image_override", func(t *testing.T) {
+		// Remote env + --runtime-image rewrites the runtime release to
+		// use the embedded default-devops chart with the chosen image.
+		// Locks the RemoteRepo() branch in applyRuntimeDeployImageOverride
+		// (open.go:602-603), which the local-env runtime_image scenario
+		// does not reach.
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--runtime-image", "ghcr.io/example/custom-runtime", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if !strings.Contains(result.Combined, "ghcr.io/example/custom-runtime") {
+			t.Fatalf("expected --runtime-image to surface in helm trace, got:\n%s", result.Combined)
+		}
+		golden.Equal(t, "open/remote_runtime_image_override", normalize.Apply(result.Combined))
+	})
+
 }

--- a/erun-integration/testdata/open/environment_positional_resolves_default_tenant.txt
+++ b/erun-integration/testdata/open/environment_positional_resolves_default_tenant.txt
@@ -1,0 +1,17 @@
+kubectl config use-context 'test-context' >/dev/null &&
+kubectl config set-context --current --namespace='team-dev' >/dev/null &&
+cd '<TMP>'
+audit: erun open --dry-run --no-alias-prompt --no-shell dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+deploying the devops runtime before opening the shell
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <LOOPBACK>
+open: --no-shell selected, emitting setup commands instead of launching shell
+kubectl config use-context test-context
+kubectl config set-context --current --namespace=team-dev
+cd <TMP>

--- a/erun-integration/testdata/open/kubectl_error_assumes_not_deployed.txt
+++ b/erun-integration/testdata/open/kubectl_error_assumes_not_deployed.txt
@@ -1,0 +1,18 @@
+kubectl config use-context 'test-context' >/dev/null &&
+kubectl config set-context --current --namespace='team-dev' >/dev/null &&
+cd '<TMP>'
+audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+open: dry-run: kubernetes deployment check failed (failed to check deployment "team-devops": exit status 2), assuming not deployed
+deploying the devops runtime before opening the shell
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <LOOPBACK>
+open: --no-shell selected, emitting setup commands instead of launching shell
+kubectl config use-context test-context
+kubectl config set-context --current --namespace=team-dev
+cd <TMP>

--- a/erun-integration/testdata/open/not_initialized_triggers_init_retry.txt
+++ b/erun-integration/testdata/open/not_initialized_triggers_init_retry.txt
@@ -1,0 +1,5 @@
+audit: erun open --dry-run team dev
+running init before resolving open target
+Loading erun tool configuration, configPath=<TMP>
+Trying to detect current project directory
+erun config is not initialized. Run erun in project directory.

--- a/erun-integration/testdata/open/remote_runtime_image_override.txt
+++ b/erun-integration/testdata/open/remote_runtime_image_override.txt
@@ -1,0 +1,16 @@
+kubectl config use-context 'test-context' >/dev/null &&
+kubectl config set-context --current --namespace='team-dev' >/dev/null &&
+cd '<TMP>'
+audit: erun open --dry-run --no-alias-prompt --no-shell --runtime-image ghcr.io/example/custom-runtime team dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=true ide=shell
+deploying the devops runtime before opening the shell
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=pvc --set-string worktreeRepoName=team --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <LOOPBACK>
+open: --no-shell selected, emitting setup commands instead of launching shell
+kubectl config use-context test-context
+kubectl config set-context --current --namespace=team-dev
+cd <TMP>

--- a/erun-integration/testdata/open/tenant_flag_only_resolves_default_env.txt
+++ b/erun-integration/testdata/open/tenant_flag_only_resolves_default_env.txt
@@ -1,0 +1,17 @@
+kubectl config use-context 'test-context' >/dev/null &&
+kubectl config set-context --current --namespace='team-dev' >/dev/null &&
+cd '<TMP>'
+audit: erun open --dry-run --no-alias-prompt --no-shell --tenant team
+open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+deploying the devops runtime before opening the shell
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <LOOPBACK>
+open: --no-shell selected, emitting setup commands instead of launching shell
+kubectl config use-context test-context
+kubectl config set-context --current --namespace=team-dev
+cd <TMP>


### PR DESCRIPTION
## Summary

- Adds five `--dry-run` integration scenarios in `erun-integration/open_test.go` that lock previously-unreached branches in `cmd/open.go`.
- Coverage on `cmd/open.go`: **188/404 (46.5%) → 202/404 (50.0%)** — +14 statements, +3.5pp.
- No production-code changes; this is additive test coverage only.

## Scenarios added

| Scenario | Branch locked |
|---|---|
| `kubectl_error_assumes_not_deployed` | dry-run "assuming not deployed" fallback in `shouldDeployRuntime` (`open.go:407-410`) |
| `not_initialized_triggers_init_retry` | `runInitBeforeOpenForParams` (was 0%) and the init-fired branch in `resolveOpenWithInitStopForParams` (`open.go:188-191, 226-227`) |
| `tenant_flag_only_resolves_default_env` | `resolveOpenParams` tenant-only switch case (`open.go:172-174`) |
| `environment_positional_resolves_default_tenant` | `resolveOpenParams` env-only switch case (`open.go:169-171`) — `OpenParamsForArgs` treats a single positional as the *environment*, so this branch is reachable from a 1-arg invocation |
| `remote_runtime_image_override` | `applyRuntimeDeployImageOverride` `RemoteRepo()` branch (`open.go:602-603`); the existing local `runtime_image_override_uses_default_chart` scenario only reaches the non-remote branch |

Two helper-style stubs added next to `stubKubectlNotFound`:
- `stubKubectlGenericError` — kubectl exits 2 with a message that does not match the NotFound tokens, so `CheckKubernetesDeployment` returns an error and the dry-run fallback fires.

## Out of scope (follow-ups)

**Phase 2 real-run scenario dropped.** Mirroring `deploy_test.go::real_run_via_stubs` for `open` is non-deterministic: `activateForwarders` binds local ports (17000/17033/17022) before the `--no-shell` short-circuit, so consecutive runs flap between "timed out waiting for MCP port-forward" and "local MCP port already in use". This is the running-ports anti-pattern called out in `erun-integration/AGENTS.md:104-105`. Unblocking it needs a production-side flag/env to skip forwarders deterministically.

**`already_deployed_skips_helm` dropped.** `CheckKubernetesDeployment` calls `kubectl ... -o name` then `kubectl ... -o json`; the existing `StubBinarySpec` returns the same response to both, so the JSON parser fails on the second call and the dry-run fallback hides the "deployed=true" branch. Locking that branch needs an argv-branching stub helper.

Both will be tracked separately.

## Test plan

- [x] `UPDATE_GOLDEN=1 go test -run TestOpen ./erun-integration/...` seeds the five new goldens
- [x] Each new golden inspected by hand for trace completeness
- [x] `go test -run TestOpen ./erun-integration/...` (compare mode) — all 16 TestOpen scenarios pass
- [x] Coverage measured with `go tool covdata textfmt` on the merged profile: cmd/open.go 188 → 202 covered statements

## Pre-existing CI noise

`TestActivity/status_with_seeded_env`, `TestIdle/status_for_seeded_env`, and `TestRelease/dry_run_includes_linux_release_scripts` fail on `main` (verified by stashing this PR's changes). They are date- and git-state-dependent and unrelated to this PR.

Closes #286