### PR TITLE
Align desktop deploy UX with terminal

### DIFF
--- a/erun-ui/AGENTS.md
+++ b/erun-ui/AGENTS.md
@@ -71,6 +71,7 @@ Module-specific guidance for `erun-ui`. Follow the repository root `AGENTS.md` f
 - Preserve CSS variables for runtime-sized panels and computed values such as sidebar width, review width, file-list width, tree depth, and diff content width.
 - Use semantic Tailwind tokens such as `bg-background`, `text-foreground`, `border-border`, `bg-sidebar`, and app-owned tokens from app theme files instead of repeating raw color values in component markup.
 - Avoid reintroducing broad semantic CSS class files for ordinary component styling. If a selector is only used by one React component and does not require a true global rule, keep the styling beside that component in `className`.
+- Do not add padding (or borders that affect layout) directly to the element passed to `Terminal.open` (`terminalRoot`). xterm's `FitAddon` reads that element's computed height to compute row count but does not subtract its own padding, so padding there over-counts rows and clips the bottom line behind whatever sits beneath the terminal (tab strip, debug panel, status bar). Keep visual padding on a wrapper around `terminalRoot` instead.
 - For frontend styling changes, run `yarn build`, `yarn shadcn:check`, and `go test ./...` from the relevant module paths unless the change is documentation-only.
 
 ## Professional UX

--- a/erun-ui/activity_helm_poller.go
+++ b/erun-ui/activity_helm_poller.go
@@ -109,10 +109,107 @@ func (a *App) applyHelmReleaseSnapshot(kubeContext string, release helmReleaseSn
 	case "pending-install", "pending-upgrade", "pending-rollback", "uninstalling":
 		a.upsertHelmActivity(tenant, environment, kubeContext, release)
 	case "deployed":
-		a.finishHelmActivityIfActive(tenant, environment, activityQueueStatusSucceeded, "")
+		a.finishHelmDeployedIfActive(tenant, environment, release)
 	case "failed":
 		a.finishHelmActivityIfActive(tenant, environment, activityQueueStatusFailed, "helm release failed")
 	}
+}
+
+// helmDeployedFreshnessSkew is the tolerance applied when comparing a
+// helm release's Updated timestamp against the entry's StartedAt. It
+// covers the realistic gap between helm marking a release Updated and
+// the desktop registering the corresponding entry — a few poller
+// intervals plus modest clock skew — without being so loose that a
+// stale prior deploy from minutes ago slips through.
+const helmDeployedFreshnessSkew = 60 * time.Second
+
+// finishHelmDeployedIfActive finalizes an active deploy entry when helm
+// reports the release as "deployed", but only when the snapshot
+// describes the deploy this entry is tracking.
+//
+// Two checks gate finalization:
+//
+//   - Version match: helm's release.AppVersion must equal entry.Version.
+//     A "deployed" status with the previous deploy's AppVersion is the
+//     stale state we're racing — finalizing on it would mark the
+//     activity done with the user's new version still rolling out.
+//   - Updated freshness: release.Updated must be within
+//     helmDeployedFreshnessSkew of (or after) entry.StartedAt. This
+//     catches same-version redeploys (common in snapshot workflows)
+//     where AppVersion alone can't distinguish the prior "deployed"
+//     from the new one.
+//
+// Either check missing data (unparseable Updated, empty AppVersion or
+// Version) is treated as inconclusive and we defer to the trace
+// handler's `==> Deployed` line and the pod-readiness watchdog. Helm
+// "failed" still finalizes unconditionally so a PTY that dies mid-deploy
+// cannot leave an entry stuck running.
+func (a *App) finishHelmDeployedIfActive(tenant, environment string, release helmReleaseSnapshot) {
+	if a.activityQueue == nil {
+		return
+	}
+	active, ok := a.activityQueue.findActiveByCommand("deploy", tenant, environment)
+	if !ok {
+		return
+	}
+	if !helmDeployedSnapshotMatchesEntry(release, active) {
+		return
+	}
+	if final, finished := a.activityQueue.finish(active.ID, activityQueueStatusSucceeded, ""); finished {
+		a.unlockTerminalsForActivity(final)
+	}
+}
+
+// helmDeployedSnapshotMatchesEntry reports whether a "deployed" helm
+// release snapshot describes the deploy that the supplied entry is
+// tracking, by checking version match and Updated freshness. Returns
+// false (defer finalization) whenever evidence is missing — a missing
+// AppVersion, an unparseable Updated, or an Updated older than the
+// entry's StartedAt by more than the skew tolerance.
+func helmDeployedSnapshotMatchesEntry(release helmReleaseSnapshot, entry activityQueueEntry) bool {
+	expected := strings.TrimSpace(entry.Version)
+	observed := strings.TrimSpace(release.AppVersion)
+	if expected == "" || observed == "" || expected != observed {
+		return false
+	}
+	updated, ok := parseHelmUpdated(release.Updated)
+	if !ok {
+		return false
+	}
+	if updated.Add(helmDeployedFreshnessSkew).Before(entry.StartedAt) {
+		return false
+	}
+	return true
+}
+
+// helmUpdatedLayouts lists the timestamp formats `helm list -o json`
+// has been observed to emit. Helm v3+ uses Go's default
+// time.Time.String() shape ("2006-01-02 15:04:05.999999999 -0700 MST");
+// some versions trim sub-second precision or omit the timezone
+// abbreviation. We try each in order and accept the first that parses.
+var helmUpdatedLayouts = []string{
+	"2006-01-02 15:04:05.999999999 -0700 MST",
+	"2006-01-02 15:04:05 -0700 MST",
+	"2006-01-02 15:04:05.999999999 -0700",
+	"2006-01-02 15:04:05 -0700",
+	time.RFC3339Nano,
+	time.RFC3339,
+}
+
+// parseHelmUpdated parses the `updated` field from `helm list -o json`.
+// The string is the Go default time.Time format; we accept a few
+// variants for robustness across helm versions.
+func parseHelmUpdated(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range helmUpdatedLayouts {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
 }
 
 // upsertHelmActivity registers a new running entry for a pending helm

--- a/erun-ui/activity_queue_app.go
+++ b/erun-ui/activity_queue_app.go
@@ -26,14 +26,6 @@ const (
 	// the user sees pods transition; long enough that polling load is
 	// negligible against modest cluster sizes.
 	activityQueuePollInterval = 2 * time.Second
-
-	// activitySteadyReadyTicks is the number of consecutive poll ticks
-	// (≈ 2s each) over which every container must report Ready and not
-	// failing before the desktop finalizes the deploy as succeeded. The
-	// short hysteresis avoids declaring success during a flap (e.g. a
-	// container briefly Ready then CrashLoopBackOff) while still
-	// finalizing within ~6 seconds of the rollout completing.
-	activitySteadyReadyTicks = 3
 )
 
 // activityStateEvent is the payload shape pushed to the frontend on each
@@ -384,59 +376,6 @@ func (a *App) startDeployFromTrace(selection uiSelection, tenant, environment, v
 	}
 }
 
-// allContainersReadyAndHealthy returns true when every container in the
-// snapshot is in a healthy Ready state. Empty snapshots are treated as
-// not-ready (we don't have evidence of a healthy rollout yet). Failing
-// reasons override Ready=true even if kubelet temporarily reports both.
-func allContainersReadyAndHealthy(statuses []activityQueueContainerStatus) bool {
-	if len(statuses) == 0 {
-		return false
-	}
-	for _, status := range statuses {
-		if !status.Ready {
-			return false
-		}
-		if !containerHealthy(status) {
-			return false
-		}
-	}
-	return true
-}
-
-func containerHealthy(status activityQueueContainerStatus) bool {
-	if status.Phase == "Terminated" {
-		return false
-	}
-	switch strings.TrimSpace(status.Reason) {
-	case "ImagePullBackOff",
-		"ErrImagePull",
-		"CrashLoopBackOff",
-		"CreateContainerConfigError",
-		"CreateContainerError",
-		"InvalidImageName",
-		"OOMKilled",
-		"Error",
-		"RunContainerError":
-		return false
-	}
-	return true
-}
-
-// finalizeDeployFromPodReadiness moves a still-running deploy entry into
-// history with success status. Used by the pod-status poller when every
-// container has been Ready and healthy across activitySteadyReadyTicks
-// consecutive ticks. Idempotent — finish() returns false on a second
-// call so a racing trace handler that also tries to finish the same
-// entry is harmless.
-func (a *App) finalizeDeployFromPodReadiness(id string) {
-	if a.activityQueue == nil {
-		return
-	}
-	if final, ok := a.activityQueue.finish(id, activityQueueStatusSucceeded, ""); ok {
-		a.unlockTerminalsForActivity(final)
-	}
-}
-
 func (a *App) captureActivityErrorIfRunning(selection uiSelection, line string) {
 	if a.activityQueue == nil {
 		return
@@ -458,15 +397,18 @@ func (a *App) captureActivityErrorIfRunning(selection uiSelection, line string) 
 
 // pollActivityContainerStatuses runs an ad-hoc kubectl poll loop while
 // the supplied deploy entry is active. Each tick parses pod JSON for the
-// helm release's pods and pushes a snapshot into the queue.
+// helm release's pods and pushes a snapshot into the queue so the
+// frontend can render per-container Ready pills.
 //
-// When all containers in the snapshot are Ready and none are failing for
-// activitySteadyReadyWindow consecutive ticks, finalize the entry as
-// succeeded — the marker file may be on a runtime-pod filesystem the
-// host cannot read, so the in-pod CLI's FinalizeRunningCommand call is
-// invisible from here. Pod readiness is the user-visible definition of
-// "deploy is done", and using it lifts the terminal lock that depends
-// on the entry's running state.
+// The loop is intentionally display-only: it does NOT finalize entries.
+// Pod readiness can flip to Ready a few seconds before helm's `--wait`
+// returns (Deployment.status.readyReplicas trails container readiness
+// while controllers reconcile), so finalizing here would mark the
+// activity done while the user's terminal still shows the deploy
+// running. Completion is owned by the trace handler's `==> Deployed`
+// line (authoritative for trace-source entries — it matches the
+// terminal exactly) and by the helm poller's version+freshness check
+// (for helm-source entries and as a backstop if the PTY dies).
 //
 // The loop exits when the entry is no longer active or ctx is cancelled.
 func (a *App) pollActivityContainerStatuses(ctx context.Context, entry activityQueueEntry) {
@@ -475,26 +417,15 @@ func (a *App) pollActivityContainerStatuses(ctx context.Context, entry activityQ
 	}
 	ticker := time.NewTicker(activityQueuePollInterval)
 	defer ticker.Stop()
-	steadyReadyTicks := 0
 	pollOnce := func() bool {
 		if _, ok := a.activityQueue.findActive(entry.Tenant, entry.Environment); !ok {
 			return false
 		}
 		statuses, err := a.fetchActivityContainerStatuses(ctx, entry)
 		if err != nil {
-			steadyReadyTicks = 0
 			return true
 		}
 		a.activityQueue.updateContainers(entry.ID, statuses)
-		if allContainersReadyAndHealthy(statuses) {
-			steadyReadyTicks++
-			if steadyReadyTicks >= activitySteadyReadyTicks {
-				a.finalizeDeployFromPodReadiness(entry.ID)
-				return false
-			}
-		} else {
-			steadyReadyTicks = 0
-		}
 		return true
 	}
 	if !pollOnce() {

--- a/erun-ui/activity_queue_app_test.go
+++ b/erun-ui/activity_queue_app_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // newTestAppForActivityQueue builds a minimal App with an in-memory queue
@@ -122,6 +123,174 @@ func TestActivityTraceLineHandlerRegistersForAllSessionKinds(t *testing.T) {
 	}
 }
 
+// TestApplyHelmReleaseSnapshotIgnoresStaleVersionOnDeployed guards the
+// race the user observed: at deploy start the previous release still
+// shows status="deployed" for a brief window before helm flips it to
+// pending-upgrade. The helm poller must not finalize on that stale
+// snapshot — its AppVersion is still the prior deploy's, not the
+// version this entry is rolling out.
+func TestApplyHelmReleaseSnapshotIgnoresStaleVersionOnDeployed(t *testing.T) {
+	app := newTestAppForActivityQueue(t)
+	app.activityQueue.start(activityQueueEntry{
+		Command:     "deploy",
+		Tenant:      "erun",
+		Environment: "local",
+		Version:     "1.0.51-snapshot-20260510135933",
+		Release:     "erun-devops",
+		Namespace:   "erun-local",
+		Source:      "trace",
+	})
+
+	app.applyHelmReleaseSnapshot("orbstack", helmReleaseSnapshot{
+		Name:       "erun-devops",
+		Namespace:  "erun-local",
+		Status:     "deployed",
+		AppVersion: "1.0.50-snapshot-prior",
+		Updated:    helmUpdatedNow(t),
+	})
+
+	entry, ok := app.activityQueue.findActive("erun", "local")
+	if !ok {
+		t.Fatal("entry must remain active when helm reports a different AppVersion as deployed")
+	}
+	if entry.Status != activityQueueStatusRunning {
+		t.Fatalf("entry status = %q, want running", entry.Status)
+	}
+}
+
+// TestApplyHelmReleaseSnapshotIgnoresStaleTimestampOnDeployed covers
+// the same-version redeploy case (common in snapshot workflows):
+// AppVersion alone cannot distinguish the prior "deployed" snapshot
+// from the new one when both carry the identical version string.
+// The Updated freshness check rejects snapshots whose Updated is
+// older than entry.StartedAt by more than the skew tolerance.
+func TestApplyHelmReleaseSnapshotIgnoresStaleTimestampOnDeployed(t *testing.T) {
+	app := newTestAppForActivityQueue(t)
+	now := time.Now()
+	app.activityQueue.now = func() time.Time { return now }
+	app.activityQueue.start(activityQueueEntry{
+		Command:     "deploy",
+		Tenant:      "erun",
+		Environment: "local",
+		Version:     "1.0.51-snapshot-20260510135933",
+		Release:     "erun-devops",
+		Namespace:   "erun-local",
+		Source:      "trace",
+	})
+
+	staleUpdated := now.Add(-(helmDeployedFreshnessSkew + 5*time.Minute))
+	app.applyHelmReleaseSnapshot("orbstack", helmReleaseSnapshot{
+		Name:       "erun-devops",
+		Namespace:  "erun-local",
+		Status:     "deployed",
+		AppVersion: "1.0.51-snapshot-20260510135933",
+		Updated:    staleUpdated.Format("2006-01-02 15:04:05.999999999 -0700 MST"),
+	})
+
+	entry, ok := app.activityQueue.findActive("erun", "local")
+	if !ok {
+		t.Fatal("entry must remain active when helm 'deployed' Updated predates entry.StartedAt")
+	}
+	if entry.Status != activityQueueStatusRunning {
+		t.Fatalf("entry status = %q, want running", entry.Status)
+	}
+}
+
+// TestApplyHelmReleaseSnapshotFinalizesOnFreshDeployedMatch verifies
+// the happy path: AppVersion matches the entry's Version and Updated
+// is fresh, so the snapshot describes the entry's own deploy.
+func TestApplyHelmReleaseSnapshotFinalizesOnFreshDeployedMatch(t *testing.T) {
+	app := newTestAppForActivityQueue(t)
+	app.activityQueue.start(activityQueueEntry{
+		Command:     "deploy",
+		Tenant:      "erun",
+		Environment: "local",
+		Version:     "1.0.51-snapshot-20260510135933",
+		Release:     "erun-devops",
+		Namespace:   "erun-local",
+		Source:      "trace",
+	})
+
+	app.applyHelmReleaseSnapshot("orbstack", helmReleaseSnapshot{
+		Name:       "erun-devops",
+		Namespace:  "erun-local",
+		Status:     "deployed",
+		AppVersion: "1.0.51-snapshot-20260510135933",
+		Updated:    helmUpdatedNow(t),
+	})
+
+	if _, stillActive := app.activityQueue.findActive("erun", "local"); stillActive {
+		t.Fatal("entry should be finalized when version matches and Updated is fresh")
+	}
+	history := app.activityQueue.list()
+	if len(history) != 1 || history[0].Status != activityQueueStatusSucceeded {
+		t.Fatalf("expected one succeeded entry in history, got %+v", history)
+	}
+}
+
+// TestApplyHelmReleaseSnapshotFinalizesOnFailedRegardlessOfVersion
+// pins the failure path: the gating only applies to "deployed". A
+// "failed" status must still finalize even when AppVersion doesn't
+// match — if the PTY dies mid-deploy the trace handler can't fire
+// `==> Deploy failed`, and we don't want entries stuck running.
+func TestApplyHelmReleaseSnapshotFinalizesOnFailedRegardlessOfVersion(t *testing.T) {
+	app := newTestAppForActivityQueue(t)
+	app.activityQueue.start(activityQueueEntry{
+		Command:     "deploy",
+		Tenant:      "erun",
+		Environment: "local",
+		Version:     "1.0.51-snapshot-20260510135933",
+		Release:     "erun-devops",
+		Namespace:   "erun-local",
+		Source:      "trace",
+	})
+
+	app.applyHelmReleaseSnapshot("orbstack", helmReleaseSnapshot{
+		Name:       "erun-devops",
+		Namespace:  "erun-local",
+		Status:     "failed",
+		AppVersion: "1.0.50-snapshot-prior",
+	})
+
+	if _, stillActive := app.activityQueue.findActive("erun", "local"); stillActive {
+		t.Fatal("entry should be finalized when helm reports failed")
+	}
+	history := app.activityQueue.list()
+	if len(history) != 1 || history[0].Status != activityQueueStatusFailed {
+		t.Fatalf("expected one failed entry in history, got %+v", history)
+	}
+}
+
+// TestParseHelmUpdatedAcceptsHelmFormats covers the `helm list -o json`
+// timestamp shapes parseHelmUpdated must handle.
+func TestParseHelmUpdatedAcceptsHelmFormats(t *testing.T) {
+	cases := []string{
+		"2026-05-10 17:00:26.926452 +0300 EEST",
+		"2026-05-10 17:00:26 +0300 EEST",
+		"2026-05-10 17:00:26.926452 +0300",
+		"2026-05-10T17:00:26.926452+03:00",
+		"2026-05-10T17:00:26+03:00",
+	}
+	for _, value := range cases {
+		if _, ok := parseHelmUpdated(value); !ok {
+			t.Errorf("parseHelmUpdated rejected %q", value)
+		}
+	}
+	if _, ok := parseHelmUpdated(""); ok {
+		t.Error("parseHelmUpdated must reject empty input")
+	}
+	if _, ok := parseHelmUpdated("not a timestamp"); ok {
+		t.Error("parseHelmUpdated must reject garbage input")
+	}
+}
+
+// helmUpdatedNow returns the current time formatted in helm's default
+// `helm list -o json` Updated layout, for use in test snapshots.
+func helmUpdatedNow(t *testing.T) string {
+	t.Helper()
+	return time.Now().Format("2006-01-02 15:04:05.999999999 -0700 MST")
+}
+
 func TestNamespaceForTenantEnv(t *testing.T) {
 	cases := []struct {
 		tenant, environment, want string
@@ -150,7 +319,16 @@ func TestReleaseNameForTenant(t *testing.T) {
 	}
 }
 
-func TestFinalizeDeployFromPodReadinessTransitionsToSucceeded(t *testing.T) {
+// TestPollActivityContainerStatusesDoesNotFinalizeOnReadyPods pins the
+// display-only contract for the pod-status poller. It must not mark an
+// entry succeeded just because every container is currently Ready —
+// pod readiness can flip a few seconds before helm's `--wait` returns,
+// so finalizing here would beat the trace handler's `==> Deployed` and
+// the activity panel would show "done" while the user's terminal still
+// shows the deploy spinning. Completion is owned by the trace handler
+// and the helm poller's version+freshness check, both of which match
+// the runtime CLI's actual return.
+func TestPollActivityContainerStatusesDoesNotFinalizeOnReadyPods(t *testing.T) {
 	app := newTestAppForActivityQueue(t)
 	entry, _ := app.activityQueue.start(activityQueueEntry{
 		Command:     "deploy",
@@ -158,41 +336,20 @@ func TestFinalizeDeployFromPodReadinessTransitionsToSucceeded(t *testing.T) {
 		Environment: "local",
 		Version:     "1.0.0",
 		Release:     "erun-devops",
+		Source:      "trace",
 	})
-	app.finalizeDeployFromPodReadiness(entry.ID)
-	if _, stillActive := app.activityQueue.findActive("erun", "local"); stillActive {
-		t.Fatal("entry should be moved out of active after pod-readiness finalize")
-	}
-	all := app.activityQueue.list()
-	if len(all) != 1 || all[0].Status != activityQueueStatusSucceeded {
-		t.Fatalf("expected one succeeded entry in history, got %+v", all)
-	}
-}
 
-func TestAllContainersReadyAndHealthyHandlesFailureReasons(t *testing.T) {
-	healthy := []activityQueueContainerStatus{
-		{Name: "a", Phase: "Running", Ready: true},
-		{Name: "b", Phase: "Running", Ready: true},
+	allReady := []activityQueueContainerStatus{
+		{Name: "erun-devops", Phase: "Running", Ready: true},
+		{Name: "erun-dind", Phase: "Running", Ready: true},
+		{Name: "erun-mcp", Phase: "Running", Ready: true},
 	}
-	if !allContainersReadyAndHealthy(healthy) {
-		t.Fatal("expected healthy snapshot to be Ready+healthy")
+	for i := 0; i < 5; i++ {
+		app.activityQueue.updateContainers(entry.ID, allReady)
 	}
-	withImagePullBackoff := []activityQueueContainerStatus{
-		{Name: "a", Phase: "Running", Ready: true},
-		{Name: "b", Phase: "Waiting", Ready: true, Reason: "ImagePullBackOff"},
-	}
-	if allContainersReadyAndHealthy(withImagePullBackoff) {
-		t.Fatal("a Ready=true container with ImagePullBackOff reason must not pass the gate")
-	}
-	withTerminated := []activityQueueContainerStatus{
-		{Name: "a", Phase: "Running", Ready: true},
-		{Name: "b", Phase: "Terminated", Ready: true},
-	}
-	if allContainersReadyAndHealthy(withTerminated) {
-		t.Fatal("a terminated container must not pass the gate")
-	}
-	if allContainersReadyAndHealthy(nil) {
-		t.Fatal("empty snapshot must not pass the gate")
+
+	if _, stillActive := app.activityQueue.findActive("erun", "local"); !stillActive {
+		t.Fatal("trace-source entry must remain active even when every container reports Ready")
 	}
 }
 

--- a/erun-ui/frontend/src/App.tsx
+++ b/erun-ui/frontend/src/App.tsx
@@ -220,8 +220,9 @@ function TerminalPane({
     >
       <div className="grid h-full min-h-0 min-w-0 grid-rows-[32px_minmax(0,1fr)] overflow-hidden">
         <TerminalTabStrip controller={controller} state={state} />
-        <div id="erun-terminal-pane" className="relative h-full min-h-0 min-w-0 overflow-hidden">
-          <div ref={terminalRootRef} className="terminal h-full min-h-0 min-w-0 w-full box-border px-4 py-3.5" />
+        {/* Padding lives on the wrapper, not on the FitAddon parent: xterm's FitAddon reads the parent's computed height but does not subtract its padding, so any padding on terminalRoot would over-count rows and clip the bottom line. */}
+        <div id="erun-terminal-pane" className="relative h-full min-h-0 min-w-0 overflow-hidden box-border px-4 pt-3.5">
+          <div ref={terminalRootRef} className="terminal h-full min-h-0 min-w-0 w-full" />
           <TerminalBusyOverlay message={state.terminalBusy ? state.terminalMessage : ''} />
           {activeLock && <ActivityLockOverlay lock={activeLock} onOpenQueue={onOpenActivityQueue} onProceedAnyway={hideActiveLock} />}
         </div>


### PR DESCRIPTION
## Summary
- Move padding off xterm's FitAddon parent (`terminalRoot`) so the bottom prompt no longer hides behind the Debug bar; AGENTS.md gains a matching styling rule.
- Helm poller's `deployed` finalization now requires `release.AppVersion == entry.Version` AND `release.Updated` within a 60s skew of `entry.StartedAt`, so stale prior-release "deployed" and same-version redeploy races no longer mark the new entry done. `failed` stays unconditional.
- `pollActivityContainerStatuses` is now display-only — pods can flip Ready a few seconds before helm's `--wait` returns, so finalizing on it always beat the runtime CLI's `==> Deployed`. Completion is now owned by the trace handler and the helm poller.

Closes #298

## Test plan
- [x] `go test ./...` under `erun-ui/`
- [x] `yarn build` and `yarn shadcn:check` under `erun-ui/frontend/`
- [ ] Run a deploy from the desktop app and confirm the activity card transitions to succeeded at the same moment the terminal prints `==> Deployed`
- [ ] Confirm the shell prompt at the bottom of the terminal is no longer clipped by the Debug bar