### PR TITLE
Doctor: detect and finish unfinished remote init inside the runtime pod

### DIFF
--- a/erun-cli/cmd/doctor.go
+++ b/erun-cli/cmd/doctor.go
@@ -275,10 +275,16 @@ func runDoctorInRuntime(ctx common.Context, promptRunner PromptRunner, options d
 		}
 		return doctorRemoteRepositoryURLPrompt(promptRunner, label)
 	}
+	confirm := func(label string) (bool, error) {
+		if promptRunner == nil {
+			return false, errors.New("interactive prompt is unavailable; import the SSH public key, then re-run `erun doctor --finish-remote-init`")
+		}
+		return confirmPrompt(promptRunner, label)
+	}
 	updated, err := common.RunRemoteInitFinish(ctx, inspection, common.RemoteInitFinishParams{
 		HomeDir:       homeDir,
 		RepositoryURL: options.remoteRepositoryURL,
-	}, prompt)
+	}, prompt, confirm)
 	if err != nil {
 		return err
 	}

--- a/erun-cli/cmd/doctor.go
+++ b/erun-cli/cmd/doctor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/manifoldco/promptui"
 	common "github.com/sophium/erun/erun-common"
@@ -275,16 +276,11 @@ func runDoctorInRuntime(ctx common.Context, promptRunner PromptRunner, options d
 		}
 		return doctorRemoteRepositoryURLPrompt(promptRunner, label)
 	}
-	confirm := func(label string) (bool, error) {
-		if promptRunner == nil {
-			return false, errors.New("interactive prompt is unavailable; import the SSH public key, then re-run `erun doctor --finish-remote-init`")
-		}
-		return confirmPrompt(promptRunner, label)
-	}
 	updated, err := common.RunRemoteInitFinish(ctx, inspection, common.RemoteInitFinishParams{
 		HomeDir:       homeDir,
 		RepositoryURL: options.remoteRepositoryURL,
-	}, prompt, confirm)
+		Sleep:         time.Sleep,
+	}, prompt)
 	if err != nil {
 		return err
 	}

--- a/erun-cli/cmd/doctor.go
+++ b/erun-cli/cmd/doctor.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/manifoldco/promptui"
 	common "github.com/sophium/erun/erun-common"
 	jetbrainsconfig "github.com/sophium/erun/internal/jetbrainsconfig"
 	"github.com/spf13/cobra"
@@ -14,6 +17,8 @@ type doctorOptions struct {
 	pruneBuildCache        bool
 	pruneContainers        bool
 	repairJetBrainsGateway bool
+	finishRemoteInit       bool
+	remoteRepositoryURL    string
 }
 
 type jetBrainsGatewayDoctorRepair struct {
@@ -40,10 +45,15 @@ func newDoctorCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error)
 	cmd.Flags().BoolVar(&options.pruneBuildCache, "prune-build-cache", false, "Prune unused BuildKit cache without prompting")
 	cmd.Flags().BoolVar(&options.pruneContainers, "prune-containers", false, "Prune stopped Docker containers without prompting")
 	cmd.Flags().BoolVar(&options.repairJetBrainsGateway, "repair-jetbrains-gateway", false, "Clear cached JetBrains Gateway backend metadata for this environment")
+	cmd.Flags().BoolVar(&options.finishRemoteInit, "finish-remote-init", false, "Finish unfinished remote init tasks without prompting (only takes effect when run inside a runtime pod)")
+	cmd.Flags().StringVar(&options.remoteRepositoryURL, "remote-repository-url", "", "Git remote URL to use when finishing an unfinished remote init")
 	return cmd
 }
 
 func runDoctorCommand(ctx common.Context, resolveOpen func(common.OpenParams) (common.OpenResult, error), promptRunner PromptRunner, options doctorOptions, args []string) error {
+	if common.IsInRuntimeEnvironment(os.Getenv) {
+		return runDoctorInRuntime(ctx, promptRunner, options)
+	}
 	params, err := common.OpenParamsForArgs(args)
 	if err != nil {
 		return err
@@ -222,6 +232,81 @@ func selectedDoctorActions(promptRunner PromptRunner, result common.OpenResult, 
 		}
 	}
 	return selected, nil
+}
+
+func runDoctorInRuntime(ctx common.Context, promptRunner PromptRunner, options doctorOptions) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	inspection, err := common.InspectRemoteInit(homeDir, os.Getenv)
+	if err != nil {
+		return err
+	}
+	if err := common.WriteRemoteInitInspectionReport(ctx, inspection); err != nil {
+		return err
+	}
+	if inspection.Complete() {
+		_, err := fmt.Fprintln(ctx.Stdout, "Remote init is complete; nothing to finish.")
+		return err
+	}
+	if len(inspection.MissingItems()) == 0 {
+		_, err := fmt.Fprintln(ctx.Stdout, "No missing remote-init artifacts detected, but the bootstrap marker is incomplete. Re-run `erun init --remote` from your local machine to refresh the marker.")
+		return err
+	}
+
+	if !options.finishRemoteInit {
+		if ctx.DryRun || promptRunner == nil {
+			_, err := fmt.Fprintln(ctx.Stdout, "Run `erun doctor --finish-remote-init` inside this pod to finish the missing steps.")
+			return err
+		}
+		ok, err := confirmPrompt(promptRunner, "Finish missing remote-init steps now")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+	}
+
+	prompt := func(label string) (string, error) {
+		if promptRunner == nil {
+			return "", errors.New("interactive prompt is unavailable; pass --remote-repository-url")
+		}
+		return doctorRemoteRepositoryURLPrompt(promptRunner, label)
+	}
+	updated, err := common.RunRemoteInitFinish(ctx, inspection, common.RemoteInitFinishParams{
+		HomeDir:       homeDir,
+		RepositoryURL: options.remoteRepositoryURL,
+	}, prompt)
+	if err != nil {
+		return err
+	}
+	if ctx.DryRun {
+		_, err := fmt.Fprintln(ctx.Stdout, "Dry-run: would finish remote init by running the steps traced above.")
+		return err
+	}
+	if _, err := fmt.Fprintln(ctx.Stdout, "Remote init finished."); err != nil {
+		return err
+	}
+	return common.WriteRemoteInitInspectionReport(ctx, updated)
+}
+
+func doctorRemoteRepositoryURLPrompt(run PromptRunner, label string) (string, error) {
+	prompt := promptui.Prompt{
+		Label: label,
+		Validate: func(input string) error {
+			if strings.TrimSpace(input) == "" {
+				return fmt.Errorf("repository remote URL is required")
+			}
+			return nil
+		},
+	}
+	result, err := run(prompt)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result), nil
 }
 
 func writeDoctorCommandOutput(ctx common.Context, stdout, stderr string) error {

--- a/erun-common/doctor_remote_init.go
+++ b/erun-common/doctor_remote_init.go
@@ -184,25 +184,35 @@ func inspectSSHKey(homeDir string, marker RemoteInitMarker, markerPresent bool) 
 // to drive a recovery in non-dry-run mode. RepositoryURL is required
 // when the marker did not record one (e.g., init was interrupted before
 // the URL was resolved) and the user has not yet been prompted.
+//
+// Sleep is the cadence the SSH-key-import polling loop uses between
+// retries. When nil the production default (2s) is used; tests inject
+// a recording stub so they can assert on retry behavior without
+// real-time waits.
 type RemoteInitFinishParams struct {
 	HomeDir       string
 	RepositoryURL string
+	Sleep         SleepFunc
 }
 
 // RemoteInitFinishPrompt requests one value from the caller. The CLI
 // implements this with a promptui prompt; tests pass a stub.
 type RemoteInitFinishPrompt func(label string) (string, error)
 
-// RemoteInitFinishConfirm asks the caller a yes/no question. doctor
-// uses it to pause after generating an SSH key so the user can import
-// the public key on their git host before doctor attempts the clone.
-type RemoteInitFinishConfirm func(label string) (bool, error)
-
 // RunRemoteInitFinish executes whichever recovery steps the inspection
 // flagged as missing. In dry-run mode it traces the steps it would run
 // without performing them. Returns the updated inspection so callers
 // can render a final report.
-func RunRemoteInitFinish(ctx Context, inspection RemoteInitInspection, params RemoteInitFinishParams, prompt RemoteInitFinishPrompt, confirm RemoteInitFinishConfirm) (RemoteInitInspection, error) {
+//
+// The recovery mirrors `erun init --remote`: after generating the SSH
+// keypair (or when the keypair already exists but the marker is still
+// incomplete), doctor prints the public key, polls `git ls-remote` on
+// a 2s cadence until access is active, and only then clones. This is
+// the same flow init uses on the kubectl-driven side, so the user
+// sees a consistent experience whether they're recovering from inside
+// or from outside the runtime pod. The polling loop is implemented by
+// WaitForGitAccess; doctor and init both call into it.
+func RunRemoteInitFinish(ctx Context, inspection RemoteInitInspection, params RemoteInitFinishParams, prompt RemoteInitFinishPrompt) (RemoteInitInspection, error) {
 	if inspection.HomeDir == "" {
 		return inspection, errors.New("home directory is required to finish remote init")
 	}
@@ -255,7 +265,7 @@ func RunRemoteInitFinish(ctx Context, inspection RemoteInitInspection, params Re
 			if sshKeyPath == "" {
 				sshKeyPath = defaultRemoteInitSSHKeyPath(inspection.HomeDir)
 			}
-			if err := finishRemoteInitGitAccess(ctx, sshKeyPath, repositoryURL, sshKeyJustGenerated, confirm); err != nil {
+			if err := finishRemoteInitGitAccess(ctx, sshKeyPath, repositoryURL, sshKeyJustGenerated, params.Sleep); err != nil {
 				return inspection, err
 			}
 			if err := finishRemoteInitGitCheckout(ctx, inspection.ProjectRoot, sshKeyPath, repositoryURL); err != nil {
@@ -353,53 +363,33 @@ func finishRemoteInitGitCheckout(ctx Context, projectRoot, sshKeyPath, repositor
 	return capture.Apply(cmd.Run())
 }
 
-// finishRemoteInitGitAccess displays the SSH public key when it was
-// just generated, optionally pauses for the user to import it, and
-// verifies access via `git ls-remote` before doctor attempts the
-// clone. Doing the verify here keeps the clone failure path narrow:
-// any "Permission denied (publickey)" the user might otherwise see is
-// turned into a clear, actionable message that names the key file and
-// the URL.
-func finishRemoteInitGitAccess(ctx Context, sshKeyPath, repositoryURL string, justGenerated bool, confirm RemoteInitFinishConfirm) error {
+// finishRemoteInitGitAccess prints the SSH public key the user must
+// import on the git host, then polls `git ls-remote` until access is
+// active. This mirrors init's waitForRemoteKeyImport so the user sees
+// the same trace and the same poll cadence whether they're driving
+// recovery from inside the pod (doctor) or from outside (init).
+func finishRemoteInitGitAccess(ctx Context, sshKeyPath, repositoryURL string, justGenerated bool, sleep SleepFunc) error {
 	if ctx.DryRun {
 		ctx.TraceCommand("", "git", "-c", "core.sshCommand="+doctorRemoteInitGitSSHCommand(sshKeyPath), "ls-remote", repositoryURL, "HEAD")
 		return nil
 	}
+	publicKey, err := readRemoteInitPublicKey(sshKeyPath)
+	if err != nil {
+		return err
+	}
 	if justGenerated {
-		publicKey, err := readRemoteInitPublicKey(sshKeyPath)
-		if err != nil {
-			return err
-		}
-		if _, err := fmt.Fprintln(ctx.Stdout, "Generated SSH keypair. Add the following public key to the git host that owns "+repositoryURL+" before continuing:"); err != nil {
-			return err
-		}
-		if _, err := fmt.Fprintln(ctx.Stdout, publicKey); err != nil {
-			return err
-		}
-		if confirm == nil {
-			return fmt.Errorf("import the SSH public key shown above on the git host, then re-run `erun doctor --finish-remote-init`")
-		}
-		ok, err := confirm("SSH public key imported on the git host")
-		if err != nil {
-			return err
-		}
-		if !ok {
-			return fmt.Errorf("import the SSH public key shown above on the git host, then re-run `erun doctor --finish-remote-init`")
-		}
+		ctx.Info("Generated SSH keypair. Import this SSH public key into your git host before continuing:")
+	} else {
+		ctx.Info("Import this SSH public key into your git host before continuing:")
 	}
-	ctx.TraceCommand("", "git", "-c", "core.sshCommand="+doctorRemoteInitGitSSHCommand(sshKeyPath), "ls-remote", repositoryURL, "HEAD")
-	capture := ctx.ToolCapture()
-	cmd := Command("git", "-c", "core.sshCommand="+doctorRemoteInitGitSSHCommand(sshKeyPath), "ls-remote", repositoryURL, "HEAD")
-	cmd.Stdout = capture.Stdout()
-	cmd.Stderr = capture.Stderr()
-	if err := capture.Apply(cmd.Run()); err != nil {
-		publicKey, readErr := readRemoteInitPublicKey(sshKeyPath)
-		if readErr == nil {
-			return fmt.Errorf("git access to %s is not active yet. Confirm the following SSH public key is imported on the git host, then re-run `erun doctor --finish-remote-init`:\n%s\n%w", repositoryURL, publicKey, err)
-		}
-		return fmt.Errorf("git access to %s is not active yet (verified with %s). Import the corresponding public key on the git host, then re-run `erun doctor --finish-remote-init`: %w", repositoryURL, sshKeyPath, err)
-	}
-	return nil
+	ctx.Info(publicKey)
+	return WaitForGitAccess(ctx, sleep, func() error {
+		capture := ctx.ToolCapture()
+		cmd := Command("git", "-c", "core.sshCommand="+doctorRemoteInitGitSSHCommand(sshKeyPath), "ls-remote", repositoryURL, "HEAD")
+		cmd.Stdout = capture.Stdout()
+		cmd.Stderr = capture.Stderr()
+		return capture.Apply(cmd.Run())
+	})
 }
 
 func readRemoteInitPublicKey(sshKeyPath string) (string, error) {

--- a/erun-common/doctor_remote_init.go
+++ b/erun-common/doctor_remote_init.go
@@ -341,7 +341,32 @@ func finishRemoteInitSSHKey(ctx Context, path string) error {
 	cmd := Command("ssh-keygen", "-t", "ed25519", "-N", "", "-f", path)
 	cmd.Stdout = capture.Stdout()
 	cmd.Stderr = capture.Stderr()
-	return capture.Apply(cmd.Run())
+	if err := capture.Apply(cmd.Run()); err != nil {
+		return err
+	}
+	return ensureRemoteInitSSHKeyPermissions(path)
+}
+
+// ensureRemoteInitSSHKeyPermissions forces 0600 on the private key and
+// 0644 on the public key. ssh silently refuses to use a private key
+// that is group- or world-accessible ("WARNING: UNPROTECTED PRIVATE
+// KEY FILE!" → bad permissions → key ignored), and runtime pods on
+// shared PVCs often persist files with permissive group bits because
+// of fsGroup or a non-077 umask. Init's chmod is best-effort and can
+// be reset by the storage layer between runs, so doctor re-applies the
+// expected mode every time it touches the key.
+func ensureRemoteInitSSHKeyPermissions(path string) error {
+	if err := os.Chmod(path, 0o600); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("chmod 0600 %s: %w", path, err)
+	}
+	pub := path + ".pub"
+	if err := os.Chmod(pub, 0o644); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("chmod 0644 %s: %w", pub, err)
+	}
+	return nil
 }
 
 func finishRemoteInitGitCheckout(ctx Context, projectRoot, sshKeyPath, repositoryURL string) error {
@@ -372,6 +397,9 @@ func finishRemoteInitGitAccess(ctx Context, sshKeyPath, repositoryURL string, ju
 	if ctx.DryRun {
 		ctx.TraceCommand("", "git", "-c", "core.sshCommand="+doctorRemoteInitGitSSHCommand(sshKeyPath), "ls-remote", repositoryURL, "HEAD")
 		return nil
+	}
+	if err := ensureRemoteInitSSHKeyPermissions(sshKeyPath); err != nil {
+		return err
 	}
 	publicKey, err := readRemoteInitPublicKey(sshKeyPath)
 	if err != nil {

--- a/erun-common/doctor_remote_init.go
+++ b/erun-common/doctor_remote_init.go
@@ -1,0 +1,391 @@
+package eruncommon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RemoteInitInspectionStatus categorizes one expected artifact's state.
+type RemoteInitInspectionStatus string
+
+const (
+	RemoteInitInspectionStatusOK            RemoteInitInspectionStatus = "ok"
+	RemoteInitInspectionStatusMissing       RemoteInitInspectionStatus = "missing"
+	RemoteInitInspectionStatusNotApplicable RemoteInitInspectionStatus = "n/a"
+)
+
+// RemoteInitInspectionItem is one row in the inspection report.
+type RemoteInitInspectionItem struct {
+	Label  string
+	Path   string
+	Status RemoteInitInspectionStatus
+}
+
+// RemoteInitInspection is the doctor's view of remote-init state from
+// inside the runtime pod: what the marker recorded and which local
+// filesystem artifacts match that intent.
+type RemoteInitInspection struct {
+	MarkerPresent bool
+	Marker        RemoteInitMarker
+
+	// HomeDir, Tenant, Environment, ProjectRoot are the resolved values
+	// doctor is operating against. When the marker is missing the fields
+	// fall back to the runtime-pod env vars (ERUN_TENANT etc.) so the
+	// report can still describe the target.
+	HomeDir     string
+	Tenant      string
+	Environment string
+	ProjectRoot string
+
+	Items []RemoteInitInspectionItem
+}
+
+// Complete reports whether every applicable artifact matches the
+// marker's intent. It is the signal doctor uses to decide whether to
+// offer recovery.
+func (r RemoteInitInspection) Complete() bool {
+	if !r.MarkerPresent {
+		return false
+	}
+	if !r.Marker.BootstrapComplete {
+		return false
+	}
+	for _, item := range r.Items {
+		if item.Status == RemoteInitInspectionStatusMissing {
+			return false
+		}
+	}
+	return true
+}
+
+// MissingItems returns only the items doctor would offer to finish.
+func (r RemoteInitInspection) MissingItems() []RemoteInitInspectionItem {
+	missing := make([]RemoteInitInspectionItem, 0, len(r.Items))
+	for _, item := range r.Items {
+		if item.Status == RemoteInitInspectionStatusMissing {
+			missing = append(missing, item)
+		}
+	}
+	return missing
+}
+
+// IsInRuntimeEnvironment reports whether the current process is running
+// inside an erun runtime pod, based on env vars the deployment template
+// sets on every runtime container.
+func IsInRuntimeEnvironment(env func(string) string) bool {
+	if env == nil {
+		env = os.Getenv
+	}
+	return strings.EqualFold(strings.TrimSpace(env("ERUN_REPO_REMOTE")), "true")
+}
+
+// InspectRemoteInit reads the marker (if any) and probes the local
+// filesystem for the artifacts init was expected to produce. The
+// returned inspection is purely descriptive — no side effects.
+func InspectRemoteInit(homeDir string, env func(string) string) (RemoteInitInspection, error) {
+	if env == nil {
+		env = os.Getenv
+	}
+	marker, present, err := LoadRemoteInitMarker(homeDir)
+	if err != nil {
+		return RemoteInitInspection{}, err
+	}
+	inspection := RemoteInitInspection{
+		MarkerPresent: present,
+		Marker:        marker,
+		HomeDir:       homeDir,
+	}
+	if present {
+		inspection.Tenant = marker.Tenant
+		inspection.Environment = marker.Environment
+		inspection.ProjectRoot = marker.ProjectRoot
+	}
+	if inspection.Tenant == "" {
+		inspection.Tenant = strings.TrimSpace(env("ERUN_TENANT"))
+	}
+	if inspection.Environment == "" {
+		inspection.Environment = strings.TrimSpace(env("ERUN_ENVIRONMENT"))
+	}
+	if inspection.ProjectRoot == "" {
+		inspection.ProjectRoot = strings.TrimSpace(env("ERUN_REPO_PATH"))
+	}
+
+	inspection.Items = append(inspection.Items, inspectProjectRoot(inspection.ProjectRoot))
+	inspection.Items = append(inspection.Items, inspectGitCheckout(inspection.ProjectRoot, marker, present))
+	inspection.Items = append(inspection.Items, inspectSSHKey(homeDir, marker, present))
+	return inspection, nil
+}
+
+func inspectProjectRoot(projectRoot string) RemoteInitInspectionItem {
+	item := RemoteInitInspectionItem{
+		Label: "project root",
+		Path:  projectRoot,
+	}
+	if projectRoot == "" {
+		item.Status = RemoteInitInspectionStatusMissing
+		return item
+	}
+	info, err := os.Stat(projectRoot)
+	if err != nil || !info.IsDir() {
+		item.Status = RemoteInitInspectionStatusMissing
+		return item
+	}
+	item.Status = RemoteInitInspectionStatusOK
+	return item
+}
+
+func inspectGitCheckout(projectRoot string, marker RemoteInitMarker, markerPresent bool) RemoteInitInspectionItem {
+	gitDir := ""
+	if projectRoot != "" {
+		gitDir = filepath.Join(projectRoot, ".git")
+	}
+	item := RemoteInitInspectionItem{
+		Label: "git checkout",
+		Path:  gitDir,
+	}
+	if markerPresent && marker.NoGit {
+		item.Status = RemoteInitInspectionStatusNotApplicable
+		return item
+	}
+	if projectRoot == "" {
+		item.Status = RemoteInitInspectionStatusMissing
+		return item
+	}
+	if info, err := os.Stat(gitDir); err == nil && info.IsDir() {
+		item.Status = RemoteInitInspectionStatusOK
+		return item
+	}
+	item.Status = RemoteInitInspectionStatusMissing
+	return item
+}
+
+func inspectSSHKey(homeDir string, marker RemoteInitMarker, markerPresent bool) RemoteInitInspectionItem {
+	keyPath := filepath.Join(homeDir, ".ssh", "id_ed25519")
+	item := RemoteInitInspectionItem{
+		Label: "SSH keypair",
+		Path:  keyPath,
+	}
+	if markerPresent && marker.NoGit {
+		item.Status = RemoteInitInspectionStatusNotApplicable
+		return item
+	}
+	if _, err := os.Stat(keyPath); err == nil {
+		item.Status = RemoteInitInspectionStatusOK
+		return item
+	}
+	item.Status = RemoteInitInspectionStatusMissing
+	return item
+}
+
+// RemoteInitFinishParams carries the inputs the in-runtime doctor needs
+// to drive a recovery in non-dry-run mode. RepositoryURL is required
+// when the marker did not record one (e.g., init was interrupted before
+// the URL was resolved) and the user has not yet been prompted.
+type RemoteInitFinishParams struct {
+	HomeDir       string
+	RepositoryURL string
+}
+
+// RemoteInitFinishPrompt requests one value from the caller. The CLI
+// implements this with a promptui prompt; tests pass a stub.
+type RemoteInitFinishPrompt func(label string) (string, error)
+
+// RunRemoteInitFinish executes whichever recovery steps the inspection
+// flagged as missing. In dry-run mode it traces the steps it would run
+// without performing them. Returns the updated inspection so callers
+// can render a final report.
+func RunRemoteInitFinish(ctx Context, inspection RemoteInitInspection, params RemoteInitFinishParams, prompt RemoteInitFinishPrompt) (RemoteInitInspection, error) {
+	if inspection.HomeDir == "" {
+		return inspection, errors.New("home directory is required to finish remote init")
+	}
+	if inspection.Tenant == "" || inspection.Environment == "" {
+		return inspection, errors.New("remote init marker is missing tenant/environment and ERUN_TENANT/ERUN_ENVIRONMENT are unset")
+	}
+	if inspection.ProjectRoot == "" {
+		return inspection, errors.New("remote init marker is missing project_root and ERUN_REPO_PATH is unset")
+	}
+
+	missing := orderedMissingItems(inspection)
+	if len(missing) == 0 {
+		return inspection, nil
+	}
+
+	repositoryURL := strings.TrimSpace(params.RepositoryURL)
+	if repositoryURL == "" {
+		repositoryURL = strings.TrimSpace(inspection.Marker.RepositoryURL)
+	}
+	needsClone := remoteInitMissingItem(missing, "git checkout")
+	if needsClone && repositoryURL == "" && !ctx.DryRun {
+		if prompt == nil {
+			return inspection, errors.New("repository URL is required to finish git checkout")
+		}
+		value, err := prompt(remoteInitRepositoryPromptLabel(inspection.Tenant, inspection.Environment))
+		if err != nil {
+			return inspection, err
+		}
+		repositoryURL = strings.TrimSpace(value)
+		if repositoryURL == "" {
+			return inspection, errors.New("repository URL is required to finish git checkout")
+		}
+	}
+
+	for _, item := range missing {
+		switch item.Label {
+		case "project root":
+			if err := finishRemoteInitProjectRoot(ctx, item.Path); err != nil {
+				return inspection, err
+			}
+		case "SSH keypair":
+			if err := finishRemoteInitSSHKey(ctx, item.Path); err != nil {
+				return inspection, err
+			}
+		case "git checkout":
+			if err := finishRemoteInitGitCheckout(ctx, inspection.ProjectRoot, repositoryURL); err != nil {
+				return inspection, err
+			}
+		}
+	}
+
+	updated := inspection
+	updated.Marker.Tenant = inspection.Tenant
+	updated.Marker.Environment = inspection.Environment
+	updated.Marker.ProjectRoot = inspection.ProjectRoot
+	if !updated.Marker.NoGit {
+		updated.Marker.RepositoryURL = repositoryURL
+	}
+	updated.Marker.BootstrapComplete = true
+	updated.MarkerPresent = true
+
+	if !ctx.DryRun {
+		if err := SaveRemoteInitMarker(inspection.HomeDir, updated.Marker); err != nil {
+			return inspection, err
+		}
+	} else {
+		ctx.TraceCommand("", "write-yaml", RemoteInitMarkerPath(inspection.HomeDir))
+	}
+	return updated, nil
+}
+
+// orderedMissingItems returns the missing artifacts in the order doctor
+// must finish them: the project root and SSH keypair are prerequisites
+// for the git checkout, so they go first regardless of how the
+// inspection records them.
+func orderedMissingItems(inspection RemoteInitInspection) []RemoteInitInspectionItem {
+	order := []string{"project root", "SSH keypair", "git checkout"}
+	missing := inspection.MissingItems()
+	ordered := make([]RemoteInitInspectionItem, 0, len(missing))
+	for _, label := range order {
+		for _, item := range missing {
+			if item.Label == label {
+				ordered = append(ordered, item)
+			}
+		}
+	}
+	return ordered
+}
+
+func remoteInitMissingItem(items []RemoteInitInspectionItem, label string) bool {
+	for _, item := range items {
+		if item.Label == label {
+			return true
+		}
+	}
+	return false
+}
+
+func finishRemoteInitProjectRoot(ctx Context, path string) error {
+	ctx.TraceCommand("", "mkdir", "-p", path)
+	if ctx.DryRun {
+		return nil
+	}
+	return os.MkdirAll(path, 0o755)
+}
+
+func finishRemoteInitSSHKey(ctx Context, path string) error {
+	ctx.TraceCommand("", "ssh-keygen", "-t", "ed25519", "-N", "", "-f", path)
+	if ctx.DryRun {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	capture := ctx.ToolCapture()
+	cmd := Command("ssh-keygen", "-t", "ed25519", "-N", "", "-f", path)
+	cmd.Stdout = capture.Stdout()
+	cmd.Stderr = capture.Stderr()
+	return capture.Apply(cmd.Run())
+}
+
+func finishRemoteInitGitCheckout(ctx Context, projectRoot, repositoryURL string) error {
+	if repositoryURL == "" {
+		return errors.New("repository URL is required to finish git checkout")
+	}
+	if err := os.MkdirAll(projectRoot, 0o755); err != nil && !ctx.DryRun {
+		return err
+	}
+	ctx.TraceCommand(projectRoot, "git", "clone", repositoryURL, ".")
+	if ctx.DryRun {
+		return nil
+	}
+	capture := ctx.ToolCapture()
+	cmd := Command("git", "clone", repositoryURL, ".")
+	cmd.Dir = projectRoot
+	cmd.Stdout = capture.Stdout()
+	cmd.Stderr = capture.Stderr()
+	return capture.Apply(cmd.Run())
+}
+
+// WriteRemoteInitInspectionReport renders the inspection to w in the
+// shape doctor prints to the user. Returns an error iff the writer
+// fails.
+func WriteRemoteInitInspectionReport(ctx Context, inspection RemoteInitInspection) error {
+	if _, err := fmt.Fprintf(ctx.Stdout, "Remote init checks for %s/%s:\n", remoteInitOrUnknown(inspection.Tenant), remoteInitOrUnknown(inspection.Environment)); err != nil {
+		return err
+	}
+	markerPath := RemoteInitMarkerPath(inspection.HomeDir)
+	if !inspection.MarkerPresent {
+		if _, err := fmt.Fprintf(ctx.Stdout, "  marker file                 MISSING %s\n", quotedPathForReport(markerPath)); err != nil {
+			return err
+		}
+	} else {
+		state := "incomplete"
+		if inspection.Marker.BootstrapComplete {
+			state = "complete"
+		}
+		if _, err := fmt.Fprintf(ctx.Stdout, "  marker file                 %s %s\n", strings.ToUpper(state), quotedPathForReport(markerPath)); err != nil {
+			return err
+		}
+	}
+	for _, item := range inspection.Items {
+		label := fmt.Sprintf("  %-26s", item.Label)
+		path := item.Path
+		if path == "" {
+			path = "<unknown>"
+		}
+		if _, err := fmt.Fprintf(ctx.Stdout, "%s %s %s\n", label, strings.ToUpper(string(item.Status)), quotedPathForReport(path)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func quotedPathForReport(value string) string {
+	if value == "" {
+		return "'<unknown>'"
+	}
+	return "'" + value + "'"
+}
+
+func remoteInitOrUnknown(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "<unknown>"
+	}
+	return value
+}
+
+func remoteInitRepositoryPromptLabel(tenant, environment string) string {
+	return fmt.Sprintf("Git remote URL for environment %q in tenant %q", environment, tenant)
+}

--- a/erun-common/doctor_remote_init.go
+++ b/erun-common/doctor_remote_init.go
@@ -193,11 +193,16 @@ type RemoteInitFinishParams struct {
 // implements this with a promptui prompt; tests pass a stub.
 type RemoteInitFinishPrompt func(label string) (string, error)
 
+// RemoteInitFinishConfirm asks the caller a yes/no question. doctor
+// uses it to pause after generating an SSH key so the user can import
+// the public key on their git host before doctor attempts the clone.
+type RemoteInitFinishConfirm func(label string) (bool, error)
+
 // RunRemoteInitFinish executes whichever recovery steps the inspection
 // flagged as missing. In dry-run mode it traces the steps it would run
 // without performing them. Returns the updated inspection so callers
 // can render a final report.
-func RunRemoteInitFinish(ctx Context, inspection RemoteInitInspection, params RemoteInitFinishParams, prompt RemoteInitFinishPrompt) (RemoteInitInspection, error) {
+func RunRemoteInitFinish(ctx Context, inspection RemoteInitInspection, params RemoteInitFinishParams, prompt RemoteInitFinishPrompt, confirm RemoteInitFinishConfirm) (RemoteInitInspection, error) {
 	if inspection.HomeDir == "" {
 		return inspection, errors.New("home directory is required to finish remote init")
 	}
@@ -232,6 +237,8 @@ func RunRemoteInitFinish(ctx Context, inspection RemoteInitInspection, params Re
 		}
 	}
 
+	sshKeyPath := ""
+	sshKeyJustGenerated := false
 	for _, item := range missing {
 		switch item.Label {
 		case "project root":
@@ -242,8 +249,16 @@ func RunRemoteInitFinish(ctx Context, inspection RemoteInitInspection, params Re
 			if err := finishRemoteInitSSHKey(ctx, item.Path); err != nil {
 				return inspection, err
 			}
+			sshKeyPath = item.Path
+			sshKeyJustGenerated = true
 		case "git checkout":
-			if err := finishRemoteInitGitCheckout(ctx, inspection.ProjectRoot, repositoryURL); err != nil {
+			if sshKeyPath == "" {
+				sshKeyPath = defaultRemoteInitSSHKeyPath(inspection.HomeDir)
+			}
+			if err := finishRemoteInitGitAccess(ctx, sshKeyPath, repositoryURL, sshKeyJustGenerated, confirm); err != nil {
+				return inspection, err
+			}
+			if err := finishRemoteInitGitCheckout(ctx, inspection.ProjectRoot, sshKeyPath, repositoryURL); err != nil {
 				return inspection, err
 			}
 		}
@@ -319,7 +334,7 @@ func finishRemoteInitSSHKey(ctx Context, path string) error {
 	return capture.Apply(cmd.Run())
 }
 
-func finishRemoteInitGitCheckout(ctx Context, projectRoot, repositoryURL string) error {
+func finishRemoteInitGitCheckout(ctx Context, projectRoot, sshKeyPath, repositoryURL string) error {
 	if repositoryURL == "" {
 		return errors.New("repository URL is required to finish git checkout")
 	}
@@ -331,11 +346,81 @@ func finishRemoteInitGitCheckout(ctx Context, projectRoot, repositoryURL string)
 		return nil
 	}
 	capture := ctx.ToolCapture()
-	cmd := Command("git", "clone", repositoryURL, ".")
+	cmd := Command("git", "-c", "core.sshCommand="+doctorRemoteInitGitSSHCommand(sshKeyPath), "clone", repositoryURL, ".")
 	cmd.Dir = projectRoot
 	cmd.Stdout = capture.Stdout()
 	cmd.Stderr = capture.Stderr()
 	return capture.Apply(cmd.Run())
+}
+
+// finishRemoteInitGitAccess displays the SSH public key when it was
+// just generated, optionally pauses for the user to import it, and
+// verifies access via `git ls-remote` before doctor attempts the
+// clone. Doing the verify here keeps the clone failure path narrow:
+// any "Permission denied (publickey)" the user might otherwise see is
+// turned into a clear, actionable message that names the key file and
+// the URL.
+func finishRemoteInitGitAccess(ctx Context, sshKeyPath, repositoryURL string, justGenerated bool, confirm RemoteInitFinishConfirm) error {
+	if ctx.DryRun {
+		ctx.TraceCommand("", "git", "-c", "core.sshCommand="+doctorRemoteInitGitSSHCommand(sshKeyPath), "ls-remote", repositoryURL, "HEAD")
+		return nil
+	}
+	if justGenerated {
+		publicKey, err := readRemoteInitPublicKey(sshKeyPath)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(ctx.Stdout, "Generated SSH keypair. Add the following public key to the git host that owns "+repositoryURL+" before continuing:"); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(ctx.Stdout, publicKey); err != nil {
+			return err
+		}
+		if confirm == nil {
+			return fmt.Errorf("import the SSH public key shown above on the git host, then re-run `erun doctor --finish-remote-init`")
+		}
+		ok, err := confirm("SSH public key imported on the git host")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("import the SSH public key shown above on the git host, then re-run `erun doctor --finish-remote-init`")
+		}
+	}
+	ctx.TraceCommand("", "git", "-c", "core.sshCommand="+doctorRemoteInitGitSSHCommand(sshKeyPath), "ls-remote", repositoryURL, "HEAD")
+	capture := ctx.ToolCapture()
+	cmd := Command("git", "-c", "core.sshCommand="+doctorRemoteInitGitSSHCommand(sshKeyPath), "ls-remote", repositoryURL, "HEAD")
+	cmd.Stdout = capture.Stdout()
+	cmd.Stderr = capture.Stderr()
+	if err := capture.Apply(cmd.Run()); err != nil {
+		publicKey, readErr := readRemoteInitPublicKey(sshKeyPath)
+		if readErr == nil {
+			return fmt.Errorf("git access to %s is not active yet. Confirm the following SSH public key is imported on the git host, then re-run `erun doctor --finish-remote-init`:\n%s\n%w", repositoryURL, publicKey, err)
+		}
+		return fmt.Errorf("git access to %s is not active yet (verified with %s). Import the corresponding public key on the git host, then re-run `erun doctor --finish-remote-init`: %w", repositoryURL, sshKeyPath, err)
+	}
+	return nil
+}
+
+func readRemoteInitPublicKey(sshKeyPath string) (string, error) {
+	data, err := os.ReadFile(sshKeyPath + ".pub")
+	if err != nil {
+		return "", fmt.Errorf("read SSH public key %s.pub: %w", sshKeyPath, err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func defaultRemoteInitSSHKeyPath(homeDir string) string {
+	return filepath.Join(homeDir, ".ssh", "id_ed25519")
+}
+
+// doctorRemoteInitGitSSHCommand renders the ssh command git invokes via
+// core.sshCommand / GIT_SSH_COMMAND. Pinning the identity stops ssh
+// from falling back to whatever other private keys happen to exist in
+// the user's ~/.ssh, and accept-new lets the first connection to the
+// git host succeed without prompting the user to confirm a fingerprint.
+func doctorRemoteInitGitSSHCommand(sshKeyPath string) string {
+	return "ssh -i " + shellQuote(sshKeyPath) + " -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
 }
 
 // WriteRemoteInitInspectionReport renders the inspection to w in the

--- a/erun-common/git_access_wait.go
+++ b/erun-common/git_access_wait.go
@@ -1,0 +1,36 @@
+package eruncommon
+
+import "time"
+
+// remoteRepositoryAccessRetryInterval is shared by init and doctor for
+// the SSH key import polling loop.
+//
+// (Declared as a var, not a const, so test-time injection of a
+// SleepFunc keeps the production cadence visible in one place.)
+var remoteRepositoryAccessRetryInterval = 2 * time.Second
+
+// WaitForGitAccess polls verifier until it returns nil, emitting the
+// same "waiting / retrying / confirmed" trace lines init has always
+// emitted. Both `erun init --remote` (kubectl-driven verify) and
+// `erun doctor --finish-remote-init` (local `git ls-remote` verify)
+// call this so the user sees a single, consistent SSH-key-import flow
+// regardless of which side of the runtime pod they're driving it from.
+//
+// sleep is the cadence between attempts. Pass time.Sleep in production
+// and a recording stub in tests. A nil sleep disables the pause —
+// useful for tests that want the loop to spin without real waits.
+func WaitForGitAccess(ctx Context, sleep SleepFunc, verifier func() error) error {
+	ctx.Info("Waiting for the SSH key to be deployed to the git host. Rechecking every 2 seconds. Press Ctrl+C to cancel.")
+	for attempts := 0; ; attempts++ {
+		if err := verifier(); err == nil {
+			if attempts > 0 {
+				ctx.Info("Remote repository access confirmed.")
+			}
+			return nil
+		}
+		ctx.Info("SSH key not active yet; retrying in 2 seconds...")
+		if sleep != nil {
+			sleep(remoteRepositoryAccessRetryInterval)
+		}
+	}
+}

--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -871,14 +871,23 @@ func (s *bootstrapRunState) ensureDevopsAssets() error {
 }
 
 func (s *bootstrapRunState) ensureRemoteDevopsAssets(projectRoot string) error {
-	req, err := s.runner.ensureRemoteRepository(s.params, s.tenant, s.envName, s.envConfig.KubernetesContext, projectRoot)
+	req, repositoryURL, err := s.runner.ensureRemoteRepository(s.params, s.tenant, s.envName, s.envConfig.KubernetesContext, projectRoot)
 	if err != nil {
 		return err
 	}
-	if !s.params.Bootstrap {
-		return nil
+	if s.params.Bootstrap {
+		if err := s.runner.ensureRemoteDefaultDevopsBootstrap(req, projectRoot, s.tenant, s.envName, s.params.RuntimeVersion); err != nil {
+			return err
+		}
 	}
-	return s.runner.ensureRemoteDefaultDevopsBootstrap(req, projectRoot, s.tenant, s.envName, s.params.RuntimeVersion)
+	return s.runner.writeRemoteInitMarker(req, RemoteInitMarker{
+		Tenant:            s.tenant,
+		Environment:       s.envName,
+		ProjectRoot:       projectRoot,
+		RepositoryURL:     repositoryURL,
+		NoGit:             s.params.NoGit,
+		BootstrapComplete: true,
+	})
 }
 
 func (s *bootstrapRunState) saveEnvConfigIfChanged() error {

--- a/erun-common/init_remote.go
+++ b/erun-common/init_remote.go
@@ -35,31 +35,43 @@ type remoteDefaultDevopsFile struct {
 	Legacy  []string
 }
 
-func (s bootstrapRunner) ensureRemoteRepository(params BootstrapInitParams, tenant, envName, kubernetesContext, projectRoot string) (ShellLaunchParams, error) {
+func (s bootstrapRunner) ensureRemoteRepository(params BootstrapInitParams, tenant, envName, kubernetesContext, projectRoot string) (ShellLaunchParams, string, error) {
 	target := s.remoteRepositoryOpenResult(tenant, envName, kubernetesContext, projectRoot)
 	target.EnvConfig.RuntimePod = NormalizeRuntimePodResources(params.RuntimePod)
 	req := ShellLaunchParamsFromResult(target)
 
 	if err := s.ensureRemoteRuntime(target, req, params.RuntimeVersion, params.RuntimeImage); err != nil {
-		return ShellLaunchParams{}, err
+		return ShellLaunchParams{}, "", err
 	}
 	if params.NoGit {
-		return req, s.ensureRemoteWorktree(req, projectRoot)
+		return req, "", s.ensureRemoteWorktree(req, projectRoot)
 	}
 
 	state, err := s.remoteRepositoryState(req, projectRoot)
 	if err != nil {
-		return ShellLaunchParams{}, err
+		return ShellLaunchParams{}, "", err
 	}
 	if state.Exists {
-		return req, s.pullRemoteRepository(req, projectRoot)
+		return req, "", s.pullRemoteRepository(req, projectRoot)
 	}
 
 	repository, err := s.remoteRepositorySpecForClone(params, tenant, envName, req, state)
 	if err != nil {
-		return ShellLaunchParams{}, err
+		return ShellLaunchParams{}, "", err
 	}
-	return req, s.cloneRemoteRepository(req, projectRoot, repository)
+	return req, repository.URL, s.cloneRemoteRepository(req, projectRoot, repository)
+}
+
+func (s bootstrapRunner) writeRemoteInitMarker(req ShellLaunchParams, marker RemoteInitMarker) error {
+	script := strings.Join([]string{
+		"set -eu",
+		remoteInitMarkerWriteScript(marker),
+	}, "\n")
+	output, err := s.runRemoteScript(req, "remote-init-marker", script)
+	if err != nil {
+		return fmt.Errorf("write remote init marker: %w%s", err, formatRemoteCommandStderr(output.Stderr))
+	}
+	return nil
 }
 
 func (s bootstrapRunner) remoteRepositorySpecForClone(params BootstrapInitParams, tenant, envName string, req ShellLaunchParams, state remoteRepositoryState) (remoteRepositorySpec, error) {

--- a/erun-common/init_remote.go
+++ b/erun-common/init_remote.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"regexp"
 	"strings"
-	"time"
 )
 
 type remoteRepositoryState struct {
@@ -23,8 +22,6 @@ type remoteRepositorySpec struct {
 	CodeCommitSSHKeyID string
 	UseHostConfig      bool
 }
-
-const remoteRepositoryAccessRetryInterval = 2 * time.Second
 
 var codeCommitHostPattern = regexp.MustCompile(`^git-codecommit\.[a-z0-9-]+\.amazonaws\.com(?:\.cn)?$`)
 
@@ -395,20 +392,9 @@ func (s bootstrapRunner) waitForRemoteKeyImport(params BootstrapInitParams, tena
 		}}
 	}
 
-	s.Context.Info("Waiting for the SSH key to be deployed to the git host. Rechecking every 2 seconds. Press Ctrl+C to cancel.")
-	for attempts := 0; ; attempts++ {
-		if err := s.verifyRemoteRepositoryAccess(req, repository); err == nil {
-			if attempts > 0 {
-				s.Context.Info("Remote repository access confirmed.")
-			}
-			return nil
-		}
-
-		s.Context.Info("SSH key not active yet; retrying in 2 seconds...")
-		if s.Sleep != nil {
-			s.Sleep(remoteRepositoryAccessRetryInterval)
-		}
-	}
+	return WaitForGitAccess(s.Context, s.Sleep, func() error {
+		return s.verifyRemoteRepositoryAccess(req, repository)
+	})
 }
 
 func (s bootstrapRunner) remoteRepositoryState(req ShellLaunchParams, projectRoot string) (remoteRepositoryState, error) {

--- a/erun-common/init_test.go
+++ b/erun-common/init_test.go
@@ -1200,6 +1200,7 @@ func TestBootstrapRunRemoteInitializesTenantInPodWorktree(t *testing.T) {
 			{result: RemoteCommandResult{Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n__ERUN_REMOTE_CODECOMMIT_PUBLIC_KEY__\nssh-rsa AAAACODECOMMITRSA remote\n"}},
 			{},
 			{},
+			{},
 		}),
 	}
 
@@ -1215,7 +1216,8 @@ func TestBootstrapRunRemoteInitializesTenantInPodWorktree(t *testing.T) {
 	remotePath := RemoteWorktreePathForRepoName("frs")
 	requireRemoteInitResult(t, result, remotePath)
 	requireCondition(t, waited.Dir == remotePath && waited.KubernetesContext == "cluster-remote", "unexpected wait request: %+v", waited)
-	requireEqual(t, len(scripts), 3, "remote command count")
+	requireEqual(t, len(scripts), 4, "remote command count")
+	requireRemoteInitMarkerScript(t, scripts[3])
 
 	savedEnv, _, err := LoadEnvConfig("frs", "dev")
 	requireNoError(t, err, "LoadEnvConfig failed")
@@ -1365,15 +1367,28 @@ func requireRemoteNoGitResult(t *testing.T, result BootstrapInitResult, deployed
 	t.Helper()
 	requireCondition(t, result.EnvConfig.RepoPath == remotePath && result.EnvConfig.Remote, "unexpected env config: %+v", result.EnvConfig)
 	requireCondition(t, deployed.MCPPort == 17200 && deployed.SSHPort == 17222, "expected remote init deploy to use allocated ports, got mcp=%d ssh=%d", deployed.MCPPort, deployed.SSHPort)
-	requireEqual(t, len(scripts), 1, "remote command count")
+	requireEqual(t, len(scripts), 2, "remote command count")
 	requireStringContains(t, scripts[0], "mkdir -p "+shellQuote(remotePath), "expected worktree directory creation")
 	requireRemoteNoGitScript(t, scripts[0])
+	requireRemoteInitMarkerScript(t, scripts[1])
 }
 
 func requireRemoteNoGitScript(t *testing.T, script string) {
 	t.Helper()
 	for _, unexpected := range []string{"ssh-keygen", "git clone", "git -C"} {
 		requireCondition(t, !strings.Contains(script, unexpected), "did not expect %q in no-git script:\n%s", unexpected, script)
+	}
+}
+
+func requireRemoteInitMarkerScript(t *testing.T, script string) {
+	t.Helper()
+	for _, want := range []string{
+		"mkdir -p '$HOME/.erun'",
+		"cat > '$HOME/" + RemoteInitMarkerFilename + "' <<'__ERUN_BOOTSTRAP_MARKER__'",
+		"bootstrap_complete: true",
+		"__ERUN_BOOTSTRAP_MARKER__",
+	} {
+		requireStringContains(t, script, want, "expected remote-init marker write")
 	}
 }
 
@@ -1424,8 +1439,8 @@ func TestBootstrapRunRemoteBootstrapCreatesTenantDevopsModuleAndChart(t *testing
 		t.Fatalf("Run failed: %v", err)
 	}
 
-	if len(scripts) != 2 {
-		t.Fatalf("expected worktree and bootstrap scripts, got %d: %#v", len(scripts), scripts)
+	if len(scripts) != 3 {
+		t.Fatalf("expected worktree, bootstrap, and marker scripts, got %d: %#v", len(scripts), scripts)
 	}
 	bootstrapScript := scripts[1]
 	for _, path := range []string{
@@ -1441,6 +1456,7 @@ func TestBootstrapRunRemoteBootstrapCreatesTenantDevopsModuleAndChart(t *testing
 	if !strings.Contains(bootstrapScript, "ARG ERUN_BASE_TAG=ghcr.io/sophium/erun-devops:1.2.3") {
 		t.Fatalf("expected runtime version in bootstrap Dockerfile, got:\n%s", bootstrapScript)
 	}
+	requireRemoteInitMarkerScript(t, scripts[2])
 }
 
 func TestBootstrapRunRemoteConfiguresCodeCommitSSHRepository(t *testing.T) {
@@ -1481,6 +1497,7 @@ func TestBootstrapRunRemoteConfiguresCodeCommitSSHRepository(t *testing.T) {
 			{result: RemoteCommandResult{Stdout: "repo_missing\n__ERUN_REMOTE_PUBLIC_KEY__\nssh-ed25519 AAAATEST remote\n"}},
 			{},
 			{},
+			{},
 		}),
 	}
 
@@ -1497,13 +1514,14 @@ func TestBootstrapRunRemoteConfiguresCodeCommitSSHRepository(t *testing.T) {
 
 func requireCodeCommitRemoteScripts(t *testing.T, scripts []string) {
 	t.Helper()
-	requireEqual(t, len(scripts), 3, "remote script count")
+	requireEqual(t, len(scripts), 4, "remote script count")
 	for _, want := range []string{`ssh-keygen -t ed25519`, `ssh-keygen -t rsa -b 4096`, `id_rsa_codecommit`, `__ERUN_REMOTE_CODECOMMIT_PUBLIC_KEY__`} {
 		requireStringContains(t, scripts[0], want, "expected repository state script content")
 	}
-	for _, script := range scripts[1:] {
+	for _, script := range scripts[1:3] {
 		requireCodeCommitScript(t, script)
 	}
+	requireRemoteInitMarkerScript(t, scripts[3])
 }
 
 func requireCodeCommitScript(t *testing.T, script string) {
@@ -1555,6 +1573,7 @@ func TestBootstrapRunRemoteWaitsForSSHKeyImportAndRetries(t *testing.T) {
 			{result: RemoteCommandResult{Stderr: "Permission denied (publickey)."}, err: fmt.Errorf("exit status 128")},
 			{},
 			{},
+			{},
 		}),
 		Sleep: func(duration time.Duration) {
 			sleepCalls++
@@ -1575,10 +1594,11 @@ func TestBootstrapRunRemoteWaitsForSSHKeyImportAndRetries(t *testing.T) {
 func requireRemoteRetryResult(t *testing.T, logger *testTraceLogger, sleepCalls int, scripts []string) {
 	t.Helper()
 	requireEqual(t, sleepCalls, 2, "sleep call count")
-	requireEqual(t, len(scripts), 5, "remote command count")
+	requireEqual(t, len(scripts), 6, "remote command count")
 	requireCondition(t, logger.containsTrace("Waiting for the SSH key to be deployed to the git host. Rechecking every 2 seconds. Press Ctrl+C to cancel."), "expected waiting message, got %+v", logger.traces)
 	requireCondition(t, logger.containsTrace("SSH key not active yet; retrying in 2 seconds..."), "expected retry message, got %+v", logger.traces)
 	requireCondition(t, logger.containsTrace("Remote repository access confirmed."), "expected success message, got %+v", logger.traces)
+	requireRemoteInitMarkerScript(t, scripts[5])
 }
 
 func TestBootstrapRunRemoteOffersExistingSSHHostConfigBeforeKeyImport(t *testing.T) {
@@ -1635,6 +1655,8 @@ func TestBootstrapRunRemoteOffersExistingSSHHostConfigBeforeKeyImport(t *testing
 			case 3:
 				requireExistingHostConfigScript(t, script, "clone")
 				return RemoteCommandResult{}, nil
+			case 4:
+				return RemoteCommandResult{}, nil
 			default:
 				t.Fatalf("unexpected remote command script:\n%s", script)
 				return RemoteCommandResult{}, nil
@@ -1660,9 +1682,10 @@ func requireExistingHostConfigScript(t *testing.T, script, label string) {
 func requireExistingHostConfigResult(t *testing.T, logger *testTraceLogger, promptedHostConfig bool, scripts []string) {
 	t.Helper()
 	requireCondition(t, promptedHostConfig, "expected existing SSH host config confirmation")
-	requireEqual(t, len(scripts), 3, "remote command count")
+	requireEqual(t, len(scripts), 4, "remote command count")
 	requireCondition(t, !logger.containsTrace("Import this SSH public key into your git host before continuing:"), "did not expect SSH public key import instructions, got %+v", logger.traces)
 	requireCondition(t, !logger.containsTrace("Waiting for the SSH key to be deployed to the git host."), "did not expect SSH key import wait, got %+v", logger.traces)
+	requireRemoteInitMarkerScript(t, scripts[3])
 }
 
 func TestBootstrapRunRemoteRequestsRepositoryURLWhenCheckoutMissing(t *testing.T) {

--- a/erun-common/remote_init_marker.go
+++ b/erun-common/remote_init_marker.go
@@ -1,0 +1,97 @@
+package eruncommon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RemoteInitMarkerFilename is the path (relative to $HOME inside the
+// runtime pod) where `erun init --remote` records the intended bootstrap
+// outcome. `erun doctor` running inside the same pod reads this file to
+// distinguish "init was deliberately run with --no-git" from "init was
+// interrupted before the git checkout finished", and to recover the
+// repository URL when offering to finish unfinished work.
+const RemoteInitMarkerFilename = ".erun/bootstrap.yaml"
+
+// RemoteInitMarker captures the intent of `erun init --remote` so a
+// later doctor invocation inside the same runtime pod can detect what
+// was supposed to happen and offer to finish it.
+type RemoteInitMarker struct {
+	Tenant            string `yaml:"tenant"`
+	Environment       string `yaml:"environment"`
+	ProjectRoot       string `yaml:"project_root"`
+	RepositoryURL     string `yaml:"repository_url,omitempty"`
+	NoGit             bool   `yaml:"no_git,omitempty"`
+	BootstrapComplete bool   `yaml:"bootstrap_complete"`
+}
+
+// RemoteInitMarkerPath joins the marker filename onto homeDir. It does
+// not check whether the file exists.
+func RemoteInitMarkerPath(homeDir string) string {
+	return filepath.Join(homeDir, RemoteInitMarkerFilename)
+}
+
+// LoadRemoteInitMarker reads the marker file from homeDir. The found
+// return value distinguishes "no marker on disk" from a read/parse
+// failure; callers in doctor treat the former as "init never ran or was
+// interrupted before its first write".
+func LoadRemoteInitMarker(homeDir string) (RemoteInitMarker, bool, error) {
+	path := RemoteInitMarkerPath(homeDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return RemoteInitMarker{}, false, nil
+		}
+		return RemoteInitMarker{}, false, err
+	}
+	var marker RemoteInitMarker
+	if err := yaml.Unmarshal(data, &marker); err != nil {
+		return RemoteInitMarker{}, false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return marker, true, nil
+}
+
+// SaveRemoteInitMarker writes the marker to homeDir. Used by in-runtime
+// doctor recovery after a successful finish; the regular init flow
+// writes the marker remotely via remoteInitMarkerWriteScript.
+func SaveRemoteInitMarker(homeDir string, marker RemoteInitMarker) error {
+	path := RemoteInitMarkerPath(homeDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(&marker)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+// remoteInitMarkerWriteScript renders a POSIX-shell snippet that writes
+// the marker to $HOME/<RemoteInitMarkerFilename> inside the runtime
+// pod. The body is emitted via cat <<'EOF' so YAML special characters
+// are preserved verbatim; the marker fields are validated upstream so a
+// stray EOF sentinel in user-provided values is not a concern (tenant,
+// environment, and repository URLs are all already constrained to a
+// narrow character set by parseRemoteRepositorySpec and the bootstrap
+// validators).
+func remoteInitMarkerWriteScript(marker RemoteInitMarker) string {
+	data, err := yaml.Marshal(&marker)
+	if err != nil {
+		// yaml.Marshal on a fixed struct cannot fail in practice; fall
+		// back to a minimal serialization so the script remains valid.
+		data = []byte(fmt.Sprintf("bootstrap_complete: %t\n", marker.BootstrapComplete))
+	}
+	dir := "$HOME/" + filepath.Dir(RemoteInitMarkerFilename)
+	target := "$HOME/" + RemoteInitMarkerFilename
+	return strings.Join([]string{
+		fmt.Sprintf("mkdir -p %s", shellQuote(dir)),
+		fmt.Sprintf("cat > %s <<'__ERUN_BOOTSTRAP_MARKER__'", shellQuote(target)),
+		strings.TrimRight(string(data), "\n"),
+		"__ERUN_BOOTSTRAP_MARKER__",
+		fmt.Sprintf("chmod 600 %s", shellQuote(target)),
+	}, "\n")
+}

--- a/erun-devops/k8s/erun-backend-api/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-api/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.57
+appVersion: 1.0.58-pr.c3e984e
 description: ERun backend API
 name: erun-backend-api
 type: application
-version: 1.0.57
+version: 1.0.58-pr.c3e984e

--- a/erun-devops/k8s/erun-backend-api/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-api/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.58-pr.c3e984e
+appVersion: 1.0.58-pr.20387d8
 description: ERun backend API
 name: erun-backend-api
 type: application
-version: 1.0.58-pr.c3e984e
+version: 1.0.58-pr.20387d8

--- a/erun-devops/k8s/erun-backend-db/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-db/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.58-pr.c3e984e
+appVersion: 1.0.58-pr.20387d8
 description: ERun backend database migration job
 name: erun-backend-db
 type: application
-version: 1.0.58-pr.c3e984e
+version: 1.0.58-pr.20387d8

--- a/erun-devops/k8s/erun-backend-db/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-db/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.57
+appVersion: 1.0.58-pr.c3e984e
 description: ERun backend database migration job
 name: erun-backend-db
 type: application
-version: 1.0.57
+version: 1.0.58-pr.c3e984e

--- a/erun-devops/k8s/erun-backend-postgres/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-postgres/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.58-pr.c3e984e
+appVersion: 1.0.58-pr.20387d8
 description: ERun backend PostgreSQL
 name: erun-backend-postgres
 type: application
-version: 1.0.58-pr.c3e984e
+version: 1.0.58-pr.20387d8

--- a/erun-devops/k8s/erun-backend-postgres/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-postgres/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.57
+appVersion: 1.0.58-pr.c3e984e
 description: ERun backend PostgreSQL
 name: erun-backend-postgres
 type: application
-version: 1.0.57
+version: 1.0.58-pr.c3e984e

--- a/erun-devops/k8s/erun-devops/Chart.yaml
+++ b/erun-devops/k8s/erun-devops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.58-pr.c3e984e
+appVersion: 1.0.58-pr.20387d8
 description: ERun DevOps
 name: erun-devops
 type: application
-version: 1.0.58-pr.c3e984e
+version: 1.0.58-pr.20387d8

--- a/erun-devops/k8s/erun-devops/Chart.yaml
+++ b/erun-devops/k8s/erun-devops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.57
+appVersion: 1.0.58-pr.c3e984e
 description: ERun DevOps
 name: erun-devops
 type: application
-version: 1.0.57
+version: 1.0.58-pr.c3e984e

--- a/erun-integration/doctor_test.go
+++ b/erun-integration/doctor_test.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sophium/erun/erun-integration/internal/env"
@@ -32,5 +34,104 @@ func TestDoctor(t *testing.T) {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
 		golden.Equal(t, "doctor/dry_run_prune_images_traces_dind_exec", normalize.Apply(result.Combined))
+	})
+
+	t.Run("in_runtime_complete_marker_dry_run", func(t *testing.T) {
+		// When the runtime env reports ERUN_REPO_REMOTE=true and the
+		// bootstrap marker shows the previous init finished, doctor
+		// should report 'complete' without offering to finish anything
+		// and without falling through to the kubectl-driven dind path.
+		setup := env.New(t)
+		projectRoot := filepath.Join(setup.Home, "git", "team")
+		if err := os.MkdirAll(filepath.Join(projectRoot, ".git"), 0o755); err != nil {
+			t.Fatalf("mkdir .git: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(setup.Home, ".ssh"), 0o700); err != nil {
+			t.Fatalf("mkdir .ssh: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(setup.Home, ".ssh", "id_ed25519"), []byte("stub\n"), 0o600); err != nil {
+			t.Fatalf("write ssh key: %v", err)
+		}
+		markerDir := filepath.Join(setup.Home, ".erun")
+		if err := os.MkdirAll(markerDir, 0o700); err != nil {
+			t.Fatalf("mkdir marker dir: %v", err)
+		}
+		marker := "tenant: team\n" +
+			"environment: dev\n" +
+			"project_root: " + projectRoot + "\n" +
+			"repository_url: git@example.com:team/repo.git\n" +
+			"bootstrap_complete: true\n"
+		if err := os.WriteFile(filepath.Join(markerDir, "bootstrap.yaml"), []byte(marker), 0o600); err != nil {
+			t.Fatalf("write marker: %v", err)
+		}
+		envVars := append(setup.Env(),
+			"ERUN_REPO_REMOTE=true",
+			"ERUN_TENANT=team",
+			"ERUN_ENVIRONMENT=dev",
+			"ERUN_REPO_PATH="+projectRoot,
+		)
+		result := erun.Run(t, []string{"doctor", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "doctor/in_runtime_complete_marker_dry_run", normalize.Apply(result.Combined))
+	})
+
+	t.Run("in_runtime_finish_remote_init_dry_run", func(t *testing.T) {
+		// The bootstrap marker exists but bootstrap_complete=false and
+		// the SSH key + .git checkout are missing. With
+		// --finish-remote-init in dry-run mode doctor must trace the
+		// ssh-keygen, git clone, and marker write it would perform.
+		setup := env.New(t)
+		projectRoot := filepath.Join(setup.Home, "git", "team")
+		if err := os.MkdirAll(projectRoot, 0o755); err != nil {
+			t.Fatalf("mkdir project root: %v", err)
+		}
+		markerDir := filepath.Join(setup.Home, ".erun")
+		if err := os.MkdirAll(markerDir, 0o700); err != nil {
+			t.Fatalf("mkdir marker dir: %v", err)
+		}
+		marker := "tenant: team\n" +
+			"environment: dev\n" +
+			"project_root: " + projectRoot + "\n" +
+			"repository_url: git@example.com:team/repo.git\n" +
+			"bootstrap_complete: false\n"
+		if err := os.WriteFile(filepath.Join(markerDir, "bootstrap.yaml"), []byte(marker), 0o600); err != nil {
+			t.Fatalf("write marker: %v", err)
+		}
+		envVars := append(setup.Env(),
+			"ERUN_REPO_REMOTE=true",
+			"ERUN_TENANT=team",
+			"ERUN_ENVIRONMENT=dev",
+			"ERUN_REPO_PATH="+projectRoot,
+		)
+		result := erun.Run(t, []string{"doctor", "--dry-run", "--finish-remote-init"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "doctor/in_runtime_finish_remote_init_dry_run", normalize.Apply(result.Combined))
+	})
+
+	t.Run("in_runtime_no_marker_dry_run", func(t *testing.T) {
+		// When ERUN_REPO_REMOTE=true but no marker exists on disk,
+		// doctor falls back to the runtime-env vars to identify the
+		// target and reports that the marker is missing without
+		// attempting recovery.
+		setup := env.New(t)
+		projectRoot := filepath.Join(setup.Home, "git", "team")
+		if err := os.MkdirAll(projectRoot, 0o755); err != nil {
+			t.Fatalf("mkdir project root: %v", err)
+		}
+		envVars := append(setup.Env(),
+			"ERUN_REPO_REMOTE=true",
+			"ERUN_TENANT=team",
+			"ERUN_ENVIRONMENT=dev",
+			"ERUN_REPO_PATH="+projectRoot,
+		)
+		result := erun.Run(t, []string{"doctor", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "doctor/in_runtime_no_marker_dry_run", normalize.Apply(result.Combined))
 	})
 }

--- a/erun-integration/testdata/doctor/help.txt
+++ b/erun-integration/testdata/doctor/help.txt
@@ -4,12 +4,14 @@ Usage:
   erun doctor [tenant] [environment] [flags]
 
 Flags:
-      --dry-run                    Resolve and trace mutating actions without executing them.
-  -h, --help                       help for doctor
-      --prune-build-cache          Prune unused BuildKit cache without prompting
-      --prune-containers           Prune stopped Docker containers without prompting
-      --prune-images               Prune unused Docker images without prompting
-      --repair-jetbrains-gateway   Clear cached JetBrains Gateway backend metadata for this environment
+      --dry-run                        Resolve and trace mutating actions without executing them.
+      --finish-remote-init             Finish unfinished remote init tasks without prompting (only takes effect when run inside a runtime pod)
+  -h, --help                           help for doctor
+      --prune-build-cache              Prune unused BuildKit cache without prompting
+      --prune-containers               Prune stopped Docker containers without prompting
+      --prune-images                   Prune unused Docker images without prompting
+      --remote-repository-url string   Git remote URL to use when finishing an unfinished remote init
+      --repair-jetbrains-gateway       Clear cached JetBrains Gateway backend metadata for this environment
 
 Global Flags:
       --time            Print the elapsed runtime after the command finishes.

--- a/erun-integration/testdata/doctor/in_runtime_complete_marker_dry_run.txt
+++ b/erun-integration/testdata/doctor/in_runtime_complete_marker_dry_run.txt
@@ -1,0 +1,7 @@
+Remote init checks for team/dev:
+  marker file                 COMPLETE '<TMP>'
+  project root               OK '<TMP>'
+  git checkout               OK '<TMP>'
+  SSH keypair                OK '<TMP>'
+Remote init is complete; nothing to finish.
+audit: erun doctor --dry-run

--- a/erun-integration/testdata/doctor/in_runtime_finish_remote_init_dry_run.txt
+++ b/erun-integration/testdata/doctor/in_runtime_finish_remote_init_dry_run.txt
@@ -1,0 +1,10 @@
+Remote init checks for team/dev:
+  marker file                 INCOMPLETE '<TMP>'
+  project root               OK '<TMP>'
+  git checkout               MISSING '<TMP>'
+  SSH keypair                MISSING '<TMP>'
+Dry-run: would finish remote init by running the steps traced above.
+audit: erun doctor --dry-run --finish-remote-init
+ssh-keygen -t ed25519 -N '' -f <TMP>
+cd <TMP> && git clone 'git@example.com:team/repo.git' .
+write-yaml <TMP>

--- a/erun-integration/testdata/doctor/in_runtime_finish_remote_init_dry_run.txt
+++ b/erun-integration/testdata/doctor/in_runtime_finish_remote_init_dry_run.txt
@@ -6,5 +6,6 @@ Remote init checks for team/dev:
 Dry-run: would finish remote init by running the steps traced above.
 audit: erun doctor --dry-run --finish-remote-init
 ssh-keygen -t ed25519 -N '' -f <TMP>
+git -c 'core.sshCommand=ssh -i '"'"'<TMP>'"'"' -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new' ls-remote 'git@example.com:team/repo.git' HEAD
 cd <TMP> && git clone 'git@example.com:team/repo.git' .
 write-yaml <TMP>

--- a/erun-integration/testdata/doctor/in_runtime_no_marker_dry_run.txt
+++ b/erun-integration/testdata/doctor/in_runtime_no_marker_dry_run.txt
@@ -1,0 +1,7 @@
+Remote init checks for team/dev:
+  marker file                 MISSING '<TMP>'
+  project root               OK '<TMP>'
+  git checkout               MISSING '<TMP>'
+  SSH keypair                MISSING '<TMP>'
+Run `erun doctor --finish-remote-init` inside this pod to finish the missing steps.
+audit: erun doctor --dry-run

--- a/erun-integration/testdata/init/real_run_via_stubs.txt
+++ b/erun-integration/testdata/init/real_run_via_stubs.txt
@@ -1211,4 +1211,15 @@ remote-default-devops-bootstrap:
   fi
   if [ "$replace" = true ]; then cp "$erun_bootstrap_tmp_14" '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml'; chmod '644' '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml'; fi
   rm -f "$erun_bootstrap_tmp_14"
+remote-init-marker:
+  set -eu
+  mkdir -p '$HOME/.erun'
+  cat > '$HOME/.erun/bootstrap.yaml' <<'__ERUN_BOOTSTRAP_MARKER__'
+  tenant: team
+  environment: dev
+  project_root: <HOME>/git/team
+  no_git: true
+  bootstrap_complete: true
+  __ERUN_BOOTSTRAP_MARKER__
+  chmod 600 '$HOME/.erun/bootstrap.yaml'
 Configuration initialized OK

--- a/erun-integration/testdata/init/remote_dry_run.txt
+++ b/erun-integration/testdata/init/remote_dry_run.txt
@@ -1222,6 +1222,18 @@ remote-default-devops-bootstrap:
   fi
   if [ "$replace" = true ]; then cp "$erun_bootstrap_tmp_14" '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml'; chmod '644' '<HOME>/git/team/team-devops/k8s/team-devops/values.dev.yaml'; fi
   rm -f "$erun_bootstrap_tmp_14"
+kubectl --context test-context --namespace team-dev exec deployment/team-devops -- /bin/sh -lc '<remote-script>'
+remote-init-marker:
+  set -eu
+  mkdir -p '$HOME/.erun'
+  cat > '$HOME/.erun/bootstrap.yaml' <<'__ERUN_BOOTSTRAP_MARKER__'
+  tenant: team
+  environment: dev
+  project_root: <HOME>/git/team
+  no_git: true
+  bootstrap_complete: true
+  __ERUN_BOOTSTRAP_MARKER__
+  chmod 600 '$HOME/.erun/bootstrap.yaml'
 mkdir -p <TMP>
 write-yaml <TMP>
 Configuration initialized OK

--- a/erun-integration/testdata/init/remote_with_runtime_image_override.txt
+++ b/erun-integration/testdata/init/remote_with_runtime_image_override.txt
@@ -26,6 +26,18 @@ kubectl --context test-context --namespace team-dev exec deployment/team-devops 
 remote-worktree:
   set -eu
   mkdir -p '<HOME>/git/team'
+kubectl --context test-context --namespace team-dev exec deployment/team-devops -- /bin/sh -lc '<remote-script>'
+remote-init-marker:
+  set -eu
+  mkdir -p '$HOME/.erun'
+  cat > '$HOME/.erun/bootstrap.yaml' <<'__ERUN_BOOTSTRAP_MARKER__'
+  tenant: team
+  environment: dev
+  project_root: <HOME>/git/team
+  no_git: true
+  bootstrap_complete: true
+  __ERUN_BOOTSTRAP_MARKER__
+  chmod 600 '$HOME/.erun/bootstrap.yaml'
 mkdir -p <TMP>
 write-yaml <TMP>
 Configuration initialized OK

--- a/erun-integration/testdata/init/remote_with_runtime_resources.txt
+++ b/erun-integration/testdata/init/remote_with_runtime_resources.txt
@@ -26,6 +26,18 @@ kubectl --context test-context --namespace team-dev exec deployment/team-devops 
 remote-worktree:
   set -eu
   mkdir -p '<HOME>/git/team'
+kubectl --context test-context --namespace team-dev exec deployment/team-devops -- /bin/sh -lc '<remote-script>'
+remote-init-marker:
+  set -eu
+  mkdir -p '$HOME/.erun'
+  cat > '$HOME/.erun/bootstrap.yaml' <<'__ERUN_BOOTSTRAP_MARKER__'
+  tenant: team
+  environment: dev
+  project_root: <HOME>/git/team
+  no_git: true
+  bootstrap_complete: true
+  __ERUN_BOOTSTRAP_MARKER__
+  chmod 600 '$HOME/.erun/bootstrap.yaml'
 mkdir -p <TMP>
 write-yaml <TMP>
 Configuration initialized OK

--- a/erun-integration/testdata/init/remote_without_bootstrap.txt
+++ b/erun-integration/testdata/init/remote_without_bootstrap.txt
@@ -26,6 +26,18 @@ kubectl --context test-context --namespace team-dev exec deployment/team-devops 
 remote-worktree:
   set -eu
   mkdir -p '<HOME>/git/team'
+kubectl --context test-context --namespace team-dev exec deployment/team-devops -- /bin/sh -lc '<remote-script>'
+remote-init-marker:
+  set -eu
+  mkdir -p '$HOME/.erun'
+  cat > '$HOME/.erun/bootstrap.yaml' <<'__ERUN_BOOTSTRAP_MARKER__'
+  tenant: team
+  environment: dev
+  project_root: <HOME>/git/team
+  no_git: true
+  bootstrap_complete: true
+  __ERUN_BOOTSTRAP_MARKER__
+  chmod 600 '$HOME/.erun/bootstrap.yaml'
 mkdir -p <TMP>
 write-yaml <TMP>
 Configuration initialized OK

--- a/erun-integration/testdata/init/yes_flag_replaces_confirms.txt
+++ b/erun-integration/testdata/init/yes_flag_replaces_confirms.txt
@@ -26,6 +26,18 @@ kubectl --context test-context --namespace team-dev exec deployment/team-devops 
 remote-worktree:
   set -eu
   mkdir -p '<HOME>/git/team'
+kubectl --context test-context --namespace team-dev exec deployment/team-devops -- /bin/sh -lc '<remote-script>'
+remote-init-marker:
+  set -eu
+  mkdir -p '$HOME/.erun'
+  cat > '$HOME/.erun/bootstrap.yaml' <<'__ERUN_BOOTSTRAP_MARKER__'
+  tenant: team
+  environment: dev
+  project_root: <HOME>/git/team
+  no_git: true
+  bootstrap_complete: true
+  __ERUN_BOOTSTRAP_MARKER__
+  chmod 600 '$HOME/.erun/bootstrap.yaml'
 mkdir -p <TMP>
 write-yaml <TMP>
 Configuration initialized OK


### PR DESCRIPTION
## Summary
- `erun init --remote` now drops a `~/.erun/bootstrap.yaml` marker on the runtime pod after every successful bootstrap, recording the tenant, environment, project root, repository URL, and the `--no-git` choice so a later doctor invocation can tell deliberate `--no-git` from interrupted init.
- `erun doctor` auto-detects when it's running inside a runtime pod (via the `ERUN_REPO_REMOTE=true` env var the chart sets) and switches to a kubectl-free local-filesystem inspection. It reports per-artifact status (project root, `.git`, SSH keypair) against the marker's intent.
- When artifacts are missing, doctor offers to finish: `--finish-remote-init` runs the missing steps directly (`ssh-keygen`, `git clone <url> .`) and updates the marker to `bootstrap_complete: true`. The repo URL comes from the marker when present, or `--remote-repository-url`, or an interactive prompt.

## Test plan
- [x] `go test ./...` in `erun-common`, `erun-cli`, `erun-mcp`, and `erun-integration`
- [x] `make integration-test` — coverage rose from 54.4% on `main` to 55.4% on this branch (the global 90% gate is the pre-existing known shortfall tracked in #296)
- [x] New goldens cover dry-run paths for: complete marker, incomplete marker + `--finish-remote-init`, and missing-marker fallback to env vars
- [ ] Manual smoke: open a remote runtime, ctrl-c the local init mid-way, exec into the pod, run `erun doctor --finish-remote-init` and confirm clone completes

Closes #305