### PR TITLE
Persist per-env local port range so it does not depend on alphabetical order

### DIFF
--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -61,7 +61,7 @@ func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen 
 			if err != nil {
 				return err
 			}
-			result, err = applyOpenSnapshotPreference(result, snapshotOverride, saveEnvConfig)
+			result, err = prepareOpenResultForRun(ctx, result, snapshotOverride, saveEnvConfig)
 			if err != nil {
 				return err
 			}
@@ -104,6 +104,14 @@ type openOptions struct {
 	RuntimeImage     string
 	AllowLocalBuilds bool
 	SaveEnvConfig    func(string, common.EnvConfig) error
+}
+
+func prepareOpenResultForRun(ctx common.Context, result common.OpenResult, snapshotOverride *bool, saveEnvConfig func(string, common.EnvConfig) error) (common.OpenResult, error) {
+	result, err := applyOpenSnapshotPreference(result, snapshotOverride, saveEnvConfig)
+	if err != nil {
+		return common.OpenResult{}, err
+	}
+	return common.EnsureLocalPortRangePersisted(ctx, saveEnvConfig, result)
 }
 
 func applyOpenSnapshotPreference(result common.OpenResult, enabled *bool, saveEnvConfig func(string, common.EnvConfig) error) (common.OpenResult, error) {

--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -81,20 +81,21 @@ type TenantConfig struct {
 }
 
 type EnvConfig struct {
-	Name               string
-	RepoPath           string
-	KubernetesContext  string
-	ContainerRegistry  string
-	CloudProviderAlias string                  `yaml:"cloudprovideralias,omitempty"`
-	ManagedCloud       bool                    `yaml:"managedcloud,omitempty" json:"managedCloud,omitempty"`
-	RuntimeVersion     string                  `yaml:"runtimeversion,omitempty"`
-	RuntimePod         RuntimePodResources     `yaml:"runtimepod,omitempty"`
-	SSHD               SSHDConfig              `yaml:"sshd,omitempty"`
-	Idle               EnvironmentIdleConfig   `yaml:"idle,omitempty"`
-	Claude             EnvironmentClaudeConfig `yaml:"claude,omitempty" json:"claude,omitempty"`
-	AITool             string                  `yaml:"aitool,omitempty" json:"aiTool,omitempty"`
-	Remote             bool                    `yaml:"remote,omitempty"`
-	Snapshot           *bool                   `yaml:"snapshot,omitempty"`
+	Name                string
+	RepoPath            string
+	KubernetesContext   string
+	ContainerRegistry   string
+	CloudProviderAlias  string                  `yaml:"cloudprovideralias,omitempty"`
+	ManagedCloud        bool                    `yaml:"managedcloud,omitempty" json:"managedCloud,omitempty"`
+	RuntimeVersion      string                  `yaml:"runtimeversion,omitempty"`
+	RuntimePod          RuntimePodResources     `yaml:"runtimepod,omitempty"`
+	SSHD                SSHDConfig              `yaml:"sshd,omitempty"`
+	Idle                EnvironmentIdleConfig   `yaml:"idle,omitempty"`
+	Claude              EnvironmentClaudeConfig `yaml:"claude,omitempty" json:"claude,omitempty"`
+	AITool              string                  `yaml:"aitool,omitempty" json:"aiTool,omitempty"`
+	Remote              bool                    `yaml:"remote,omitempty"`
+	Snapshot            *bool                   `yaml:"snapshot,omitempty"`
+	LocalPortRangeStart int                     `yaml:"localportrangestart,omitempty" json:"localPortRangeStart,omitempty"`
 }
 
 func (c TenantConfig) SnapshotEnabled() bool {

--- a/erun-common/init_remote.go
+++ b/erun-common/init_remote.go
@@ -126,14 +126,13 @@ func remoteRepositoryEnvConfig(envName, kubernetesContext, projectRoot string) E
 }
 
 func (s bootstrapRunner) remoteRepositoryLocalPorts(tenant, envName string) EnvironmentLocalPorts {
-	ports := DefaultEnvironmentLocalPorts()
 	portStore, ok := s.Store.(environmentPortStore)
 	if !ok {
-		return ports
+		return EnvironmentLocalPorts{}
 	}
 	resolved, err := ResolveEnvironmentLocalPorts(portStore, tenant, envName)
 	if err != nil {
-		return ports
+		return EnvironmentLocalPorts{}
 	}
 	return resolved
 }

--- a/erun-common/list.go
+++ b/erun-common/list.go
@@ -228,10 +228,6 @@ func APIURLForListEnvironment(tenant TenantConfig, localPorts EnvironmentLocalPo
 
 func listEnvironmentLocalPorts(tenant string, env EnvConfig, portAllocations map[string]EnvironmentLocalPorts) EnvironmentLocalPorts {
 	localPorts := portAllocations[environmentPortKey(tenant, env.Name)]
-	if localPorts.RangeStart != 0 {
-		return localPorts
-	}
-	localPorts = DefaultEnvironmentLocalPorts()
 	if env.SSHD.LocalPort > 0 {
 		localPorts.SSH = env.SSHD.LocalPort
 	}

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -192,6 +192,38 @@ func ResolveOpen(store OpenStore, params OpenParams) (OpenResult, error) {
 	return resolveOpenWithFinder(store, FindProjectRoot, params)
 }
 
+// EnsureLocalPortRangePersisted freezes the resolver's choice for this env
+// into its config so future opens are stable against alphabetical reshuffles
+// of unrelated tenants/envs. It is a no-op when the env already declares a
+// LocalPortRangeStart. In dry-run mode the assignment is traced but not
+// written to disk. The persisted EnvConfig is returned via the OpenResult so
+// callers can continue using it for the rest of the open flow.
+func EnsureLocalPortRangePersisted(ctx Context, saveEnvConfig func(string, EnvConfig) error, result OpenResult) (OpenResult, error) {
+	if result.EnvConfig.LocalPortRangeStart > 0 {
+		return result, nil
+	}
+	rangeStart := result.LocalPorts.RangeStart
+	if rangeStart == 0 {
+		return result, fmt.Errorf("local port range is not resolved for %s/%s", result.Tenant, result.Environment)
+	}
+	updated := result.EnvConfig
+	updated.LocalPortRangeStart = rangeStart
+	if ctx.DryRun {
+		ctx.Trace(fmt.Sprintf("config: would assign localportrangestart=%d to %s/%s", rangeStart, result.Tenant, result.Environment))
+		result.EnvConfig = updated
+		return result, nil
+	}
+	if saveEnvConfig == nil {
+		return result, fmt.Errorf("persist local port range: env config storage is not wired")
+	}
+	if err := saveEnvConfig(result.Tenant, updated); err != nil {
+		return result, fmt.Errorf("persist local port range: %w", err)
+	}
+	ctx.Trace(fmt.Sprintf("config: assigned localportrangestart=%d to %s/%s", rangeStart, result.Tenant, result.Environment))
+	result.EnvConfig = updated
+	return result, nil
+}
+
 func resolveOpenWithFinder(store OpenStore, findProjectRoot ProjectFinderFunc, params OpenParams) (OpenResult, error) {
 	if store == nil {
 		return OpenResult{}, fmt.Errorf("store is required")

--- a/erun-common/ports.go
+++ b/erun-common/ports.go
@@ -32,28 +32,64 @@ type environmentPortStore interface {
 	ListEnvConfigs(string) ([]EnvConfig, error)
 }
 
+// ErrLocalPortRangeOverlap is returned when two envs persist the same
+// LocalPortRangeStart. Surfacing the conflict is preferred over silent
+// reassignment because the persisted value is the durable user-visible
+// contract and either of the two configs must be edited to resolve it.
+type ErrLocalPortRangeOverlap struct {
+	A          string
+	B          string
+	RangeStart int
+}
+
+func (e ErrLocalPortRangeOverlap) Error() string {
+	return fmt.Sprintf("local port range start %d is claimed by both %s and %s; edit localportrangestart in one of the env configs to resolve", e.RangeStart, e.A, e.B)
+}
+
 func ServicePort(offset int) int {
 	return LowerServicePort + offset
 }
 
-func DefaultEnvironmentLocalPorts() EnvironmentLocalPorts {
-	ports, _ := environmentLocalPortsForIndex(0, EnvConfig{})
-	return ports
+// EnvironmentLocalPortsFromRangeStart derives the per-service ports from a
+// persisted range start. Callers should prefer this over assembling the
+// struct piecemeal so the offsets stay in one place.
+func EnvironmentLocalPortsFromRangeStart(rangeStart int) EnvironmentLocalPorts {
+	if rangeStart <= 0 {
+		return EnvironmentLocalPorts{}
+	}
+	return EnvironmentLocalPorts{
+		RangeStart: rangeStart,
+		RangeEnd:   rangeStart + EnvironmentPortRangeSize - 1,
+		MCP:        rangeStart + MCPServicePortOffset,
+		API:        rangeStart + APIServicePortOffset,
+		SSH:        rangeStart + SSHServicePortOffset,
+	}
 }
 
+// LocalPortsForResult derives the effective local ports for an OpenResult.
+// It prefers the persisted EnvConfig.LocalPortRangeStart over the resolver's
+// in-memory allocation so the result is stable regardless of how many other
+// envs exist. If neither is set it returns a zero value — callers that
+// actually need to bind a port will fail loudly on port 0, which is the
+// intended signal: a missing range is a bug upstream, not a default.
 func LocalPortsForResult(result OpenResult) EnvironmentLocalPorts {
-	ports := result.LocalPorts
-	if ports.RangeStart == 0 || ports.RangeEnd == 0 {
-		ports = DefaultEnvironmentLocalPorts()
+	var ports EnvironmentLocalPorts
+	switch {
+	case result.EnvConfig.LocalPortRangeStart > 0:
+		ports = EnvironmentLocalPortsFromRangeStart(result.EnvConfig.LocalPortRangeStart)
+	case result.LocalPorts.RangeStart > 0:
+		ports = result.LocalPorts
 	}
-	if ports.MCP == 0 {
-		ports.MCP = ports.RangeStart + MCPServicePortOffset
-	}
-	if ports.API == 0 {
-		ports.API = ports.RangeStart + APIServicePortOffset
-	}
-	if ports.SSH == 0 {
-		ports.SSH = ports.RangeStart + SSHServicePortOffset
+	if ports.RangeStart > 0 {
+		if ports.MCP == 0 {
+			ports.MCP = ports.RangeStart + MCPServicePortOffset
+		}
+		if ports.API == 0 {
+			ports.API = ports.RangeStart + APIServicePortOffset
+		}
+		if ports.SSH == 0 {
+			ports.SSH = ports.RangeStart + SSHServicePortOffset
+		}
 	}
 	if result.EnvConfig.SSHD.LocalPort > 0 {
 		ports.SSH = result.EnvConfig.SSHD.LocalPort
@@ -73,6 +109,13 @@ func SSHLocalPortForResult(result OpenResult) int {
 	return LocalPortsForResult(result).SSH
 }
 
+// ResolveAllEnvironmentLocalPorts returns a per-env port allocation in two
+// passes. Pass A locks in any env whose config has a non-zero
+// LocalPortRangeStart at its declared range. Pass B walks the remaining envs
+// in alphabetical (tenant, env) order, picking the lowest index not already
+// claimed by Pass A. Two persisted envs that share a range start cause an
+// ErrLocalPortRangeOverlap so the misconfiguration is surfaced instead of
+// silently reassigned.
 func ResolveAllEnvironmentLocalPorts(store environmentPortStore) (map[string]EnvironmentLocalPorts, error) {
 	if store == nil {
 		return nil, fmt.Errorf("store is required")
@@ -86,14 +129,16 @@ func ResolveAllEnvironmentLocalPorts(store environmentPortStore) (map[string]Env
 		return strings.TrimSpace(tenants[i].Name) < strings.TrimSpace(tenants[j].Name)
 	})
 
-	allocations := make(map[string]EnvironmentLocalPorts)
-	index := 0
+	type envRef struct {
+		key string
+		env EnvConfig
+	}
+	var persisted, unpersisted []envRef
 	for _, tenant := range tenants {
 		tenantName := strings.TrimSpace(tenant.Name)
 		if tenantName == "" {
 			continue
 		}
-
 		envs, err := store.ListEnvConfigs(tenantName)
 		if err != nil {
 			return nil, err
@@ -101,20 +146,54 @@ func ResolveAllEnvironmentLocalPorts(store environmentPortStore) (map[string]Env
 		sort.Slice(envs, func(i, j int) bool {
 			return strings.TrimSpace(envs[i].Name) < strings.TrimSpace(envs[j].Name)
 		})
-
 		for _, env := range envs {
 			environmentName := strings.TrimSpace(env.Name)
 			if environmentName == "" {
 				continue
 			}
-
-			ports, err := environmentLocalPortsForIndex(index, env)
-			if err != nil {
-				return nil, err
+			ref := envRef{key: environmentPortKey(tenantName, environmentName), env: env}
+			if env.LocalPortRangeStart > 0 {
+				persisted = append(persisted, ref)
+			} else {
+				unpersisted = append(unpersisted, ref)
 			}
-			allocations[environmentPortKey(tenantName, environmentName)] = ports
-			index++
 		}
+	}
+
+	allocations := make(map[string]EnvironmentLocalPorts, len(persisted)+len(unpersisted))
+	claimedByIndex := make(map[int]string, len(persisted)+len(unpersisted))
+
+	for _, ref := range persisted {
+		index, err := environmentPortIndexForRangeStart(ref.env.LocalPortRangeStart, ref.key)
+		if err != nil {
+			return nil, err
+		}
+		if other, dup := claimedByIndex[index]; dup {
+			return nil, ErrLocalPortRangeOverlap{A: other, B: ref.key, RangeStart: ref.env.LocalPortRangeStart}
+		}
+		ports, err := environmentLocalPortsForIndex(index, ref.env)
+		if err != nil {
+			return nil, err
+		}
+		claimedByIndex[index] = ref.key
+		allocations[ref.key] = ports
+	}
+
+	walkerIndex := 0
+	for _, ref := range unpersisted {
+		for {
+			if _, claimed := claimedByIndex[walkerIndex]; !claimed {
+				break
+			}
+			walkerIndex++
+		}
+		ports, err := environmentLocalPortsForIndex(walkerIndex, ref.env)
+		if err != nil {
+			return nil, err
+		}
+		claimedByIndex[walkerIndex] = ref.key
+		allocations[ref.key] = ports
+		walkerIndex++
 	}
 
 	return allocations, nil
@@ -134,18 +213,18 @@ func ResolveEnvironmentLocalPorts(store environmentPortStore, tenant, environmen
 }
 
 func environmentLocalPortsForTarget(store OpenStore, tenant string, env EnvConfig) (EnvironmentLocalPorts, error) {
-	if portStore, ok := store.(environmentPortStore); ok {
-		ports, err := ResolveEnvironmentLocalPorts(portStore, tenant, env.Name)
-		if err != nil {
-			return EnvironmentLocalPorts{}, err
-		}
-		if env.SSHD.LocalPort > 0 {
-			ports.SSH = env.SSHD.LocalPort
-		}
-		return ports, nil
+	portStore, ok := store.(environmentPortStore)
+	if !ok {
+		return EnvironmentLocalPorts{}, fmt.Errorf("local port range cannot be resolved without tenant/environment listing for %s/%s", strings.TrimSpace(tenant), strings.TrimSpace(env.Name))
 	}
-
-	ports := DefaultEnvironmentLocalPorts()
+	// Always go through the two-pass resolver, even when env already has a
+	// persisted range start: the resolver is what catches cross-tenant
+	// overlap between two persisted envs, and skipping it for the
+	// already-persisted env would let the conflict slip through silently.
+	ports, err := ResolveEnvironmentLocalPorts(portStore, tenant, env.Name)
+	if err != nil {
+		return EnvironmentLocalPorts{}, err
+	}
 	if env.SSHD.LocalPort > 0 {
 		ports.SSH = env.SSHD.LocalPort
 	}
@@ -177,6 +256,17 @@ func environmentLocalPortsForIndex(index int, env EnvConfig) (EnvironmentLocalPo
 		ports.SSH = env.SSHD.LocalPort
 	}
 	return ports, nil
+}
+
+func environmentPortIndexForRangeStart(rangeStart int, ownerKey string) (int, error) {
+	if rangeStart < LowerServicePort {
+		return 0, fmt.Errorf("local port range start %d for %s is below %d", rangeStart, ownerKey, LowerServicePort)
+	}
+	offset := rangeStart - LowerServicePort
+	if offset%EnvironmentPortRangeSize != 0 {
+		return 0, fmt.Errorf("local port range start %d for %s is not aligned to %d-port boundaries from %d", rangeStart, ownerKey, EnvironmentPortRangeSize, LowerServicePort)
+	}
+	return offset / EnvironmentPortRangeSize, nil
 }
 
 func environmentPortKey(tenant, environment string) string {

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -56,6 +56,70 @@ func SeedTenantEnv(t testing.TB, setup env.Setup, tenant, environment string) {
 	)
 }
 
+// SeedTenantEnvWithLocalPortRangeStart writes the same minimal config tree
+// as SeedTenantEnv but persists a fixed localportrangestart on the env
+// config so commands that key off EnvConfig.LocalPortRangeStart (notably
+// `erun open`) exercise the persisted-range branch instead of the resolver's
+// alphabetical walker.
+func SeedTenantEnvWithLocalPortRangeStart(t testing.TB, setup env.Setup, tenant, environment string, rangeStart int) {
+	t.Helper()
+	root := filepath.Join(setup.ConfigHome, "erun")
+	tenantDir := filepath.Join(root, tenant)
+	envDir := filepath.Join(tenantDir, environment)
+	for _, dir := range []string{root, tenantDir, envDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	mustWrite(t, filepath.Join(root, "config.yaml"), "defaulttenant: "+tenant+"\n")
+	mustWrite(t, filepath.Join(tenantDir, "config.yaml"),
+		"projectroot: "+setup.Cwd+"\n"+
+			"name: "+tenant+"\n"+
+			"defaultenvironment: "+environment+"\n",
+	)
+	mustWrite(t, filepath.Join(envDir, "config.yaml"),
+		"name: "+environment+"\n"+
+			"repopath: "+setup.Cwd+"\n"+
+			"kubernetescontext: test-context\n"+
+			"containerregistry: registry.example/test\n"+
+			"runtimeversion: 1.0.0\n"+
+			"localportrangestart: "+strconv.Itoa(rangeStart)+"\n",
+	)
+}
+
+// SeedSecondaryTenantEnv writes a second tenant/env into an already-seeded
+// XDG tree so resolver scenarios can exercise cross-tenant interactions
+// (walker skip, overlap detection) without overwriting the primary tenant.
+// Callers may set rangeStart > 0 to persist localportrangestart on the
+// secondary env; pass 0 to leave it unpersisted.
+func SeedSecondaryTenantEnv(t testing.TB, setup env.Setup, tenant, environment string, rangeStart int) {
+	t.Helper()
+	root := filepath.Join(setup.ConfigHome, "erun")
+	tenantDir := filepath.Join(root, tenant)
+	envDir := filepath.Join(tenantDir, environment)
+	for _, dir := range []string{root, tenantDir, envDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	mustWrite(t, filepath.Join(tenantDir, "config.yaml"),
+		"projectroot: "+setup.Cwd+"\n"+
+			"name: "+tenant+"\n"+
+			"defaultenvironment: "+environment+"\n",
+	)
+	envContents := "name: " + environment + "\n" +
+		"repopath: " + setup.Cwd + "\n" +
+		"kubernetescontext: test-context\n" +
+		"containerregistry: registry.example/test\n" +
+		"runtimeversion: 1.0.0\n"
+	if rangeStart > 0 {
+		envContents += "localportrangestart: " + strconv.Itoa(rangeStart) + "\n"
+	}
+	mustWrite(t, filepath.Join(envDir, "config.yaml"), envContents)
+}
+
 // SeedTenantEnvWithSnapshot writes the same minimal config tree as
 // SeedTenantEnv but persists snapshot=<enabled> on the env config so
 // commands that key off EnvConfig.SnapshotEnabled() (notably `erun open`)

--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -416,4 +416,61 @@ func TestOpen(t *testing.T) {
 		golden.Equal(t, "open/remote_runtime_image_override", normalize.Apply(result.Combined))
 	})
 
+	t.Run("persisted_local_port_range_is_honoured", func(t *testing.T) {
+		// EnvConfig.LocalPortRangeStart is the durable per-env port
+		// contract. When it is already set on disk, open must derive every
+		// service port from it (MCP 17500, API 17533, SSH 17522) and must
+		// not emit the "config: would assign" trace. Locks the early-return
+		// in EnsureLocalPortRangePersisted (open.go::common helper).
+		setup := env.New(t)
+		fixture.SeedTenantEnvWithLocalPortRangeStart(t, setup, "team", "dev", 17500)
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/persisted_local_port_range_is_honoured", normalize.Apply(result.Combined))
+	})
+
+	t.Run("walker_skips_index_claimed_by_other_tenant", func(t *testing.T) {
+		// When a second env on the host has already persisted
+		// localportrangestart=17000, the alphabetical walker must skip
+		// that index when allocating an unpersisted env. team/dev sorts
+		// before other/staging but the persisted claim wins, so team/dev
+		// resolves to 17100 and the dry-run trace records the would-be
+		// assignment. Locks the cross-tenant claim-respect branch in
+		// ResolveAllEnvironmentLocalPorts.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedSecondaryTenantEnv(t, setup, "other", "staging", 17000)
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/walker_skips_index_claimed_by_other_tenant", normalize.Apply(result.Combined))
+	})
+
+	t.Run("overlapping_persisted_ranges_fail_with_pointer", func(t *testing.T) {
+		// Two envs that persist the same localportrangestart must surface
+		// an ErrLocalPortRangeOverlap pointing at both. The CLI should
+		// fail with a non-zero exit and a message naming both envs and the
+		// range, instead of silently re-allocating one of them. Locks the
+		// overlap path in ResolveAllEnvironmentLocalPorts.
+		setup := env.New(t)
+		fixture.SeedTenantEnvWithLocalPortRangeStart(t, setup, "team", "dev", 17000)
+		fixture.SeedSecondaryTenantEnv(t, setup, "other", "staging", 17000)
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/overlapping_persisted_ranges_fail_with_pointer", normalize.Apply(result.Combined))
+	})
+
+	t.Run("misaligned_persisted_range_fails_with_pointer", func(t *testing.T) {
+		// localportrangestart must align to EnvironmentPortRangeSize=100
+		// boundaries from LowerServicePort=17000. A value like 17050
+		// would make MCP/API/SSH offsets bleed into another env's range,
+		// so the resolver refuses with a clear alignment error instead of
+		// accepting it. Locks environmentPortIndexForRangeStart's
+		// validation branch.
+		setup := env.New(t)
+		fixture.SeedTenantEnvWithLocalPortRangeStart(t, setup, "team", "dev", 17050)
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/misaligned_persisted_range_fails_with_pointer", normalize.Apply(result.Combined))
+	})
+
 }

--- a/erun-integration/testdata/open/default_tenant_environment_resolves_from_root_config.txt
+++ b/erun-integration/testdata/open/default_tenant_environment_resolves_from_root_config.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 deploying the devops runtime before opening the shell

--- a/erun-integration/testdata/open/environment_positional_resolves_default_tenant.txt
+++ b/erun-integration/testdata/open/environment_positional_resolves_default_tenant.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 deploying the devops runtime before opening the shell

--- a/erun-integration/testdata/open/intellij_dry_run.txt
+++ b/erun-integration/testdata/open/intellij_dry_run.txt
@@ -6,6 +6,7 @@ SSH:
   key: none
   workspace: <HOME>/git/team
 audit: erun open --dry-run --intellij team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=false ide=intellij
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 open: dry-run: would deploy runtime for team/dev before launching IntelliJ IDEA; in real mode the user must run `erun sshd init team dev` or `erun open team dev` first

--- a/erun-integration/testdata/open/intellij_without_sshd_errors_with_guidance.txt
+++ b/erun-integration/testdata/open/intellij_without_sshd_errors_with_guidance.txt
@@ -1,3 +1,4 @@
 audit: erun open --dry-run --intellij team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=false ide=intellij
 --intellij requires sshd-enabled remote environment; run `erun sshd init team dev` first

--- a/erun-integration/testdata/open/kubectl_error_assumes_not_deployed.txt
+++ b/erun-integration/testdata/open/kubectl_error_assumes_not_deployed.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 open: dry-run: kubernetes deployment check failed (failed to check deployment "team-devops": exit status 2), assuming not deployed

--- a/erun-integration/testdata/open/misaligned_persisted_range_fails_with_pointer.txt
+++ b/erun-integration/testdata/open/misaligned_persisted_range_fails_with_pointer.txt
@@ -1,0 +1,2 @@
+audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+local port range start 17050 for team/dev is not aligned to 100-port boundaries from 17000

--- a/erun-integration/testdata/open/no_shell_dry_run.txt
+++ b/erun-integration/testdata/open/no_shell_dry_run.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 deploying the devops runtime before opening the shell

--- a/erun-integration/testdata/open/no_snapshot_skips_local_build.txt
+++ b/erun-integration/testdata/open/no_snapshot_skips_local_build.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-local' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell --no-snapshot team local
+config: would assign localportrangestart=17000 to team/local
 open: tenant=team environment=local kubernetes-context=test-context remote=false no-shell=true ide=shell
 kubectl --context test-context --namespace team-local get deployment team-devops -o name
 deploying the devops runtime before opening the shell

--- a/erun-integration/testdata/open/overlapping_persisted_ranges_fail_with_pointer.txt
+++ b/erun-integration/testdata/open/overlapping_persisted_ranges_fail_with_pointer.txt
@@ -1,0 +1,2 @@
+audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+local port range start 17000 is claimed by both other/staging and team/dev; edit localportrangestart in one of the env configs to resolve

--- a/erun-integration/testdata/open/persisted_local_port_range_is_honoured.txt
+++ b/erun-integration/testdata/open/persisted_local_port_range_is_honoured.txt
@@ -1,0 +1,20 @@
+kubectl config use-context 'test-context' >/dev/null &&
+kubectl config set-context --current --namespace='team-dev' >/dev/null &&
+cd '<TMP>'
+audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+deploying the devops runtime before opening the shell
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17500 --set apiPort=17533 --set sshPort=17522 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17500:17500 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17533:17533 --address <LOOPBACK>
+open: --no-shell selected, emitting setup commands instead of launching shell
+kubectl config use-context test-context
+kubectl config set-context --current --namespace=team-dev
+cd <TMP>

--- a/erun-integration/testdata/open/remote_dry_run_traces_port_forwards.txt
+++ b/erun-integration/testdata/open/remote_dry_run_traces_port_forwards.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 deploying the devops runtime before opening the shell

--- a/erun-integration/testdata/open/remote_runtime_image_override.txt
+++ b/erun-integration/testdata/open/remote_runtime_image_override.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell --runtime-image ghcr.io/example/custom-runtime team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=true ide=shell
 deploying the devops runtime before opening the shell
 kubectl --context test-context get namespace team-dev -o name

--- a/erun-integration/testdata/open/runtime_image_override_uses_default_chart.txt
+++ b/erun-integration/testdata/open/runtime_image_override_uses_default_chart.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell --runtime-image ghcr.io/example/custom-runtime team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 deploying the devops runtime before opening the shell
 kubectl --context test-context get namespace team-dev -o name

--- a/erun-integration/testdata/open/snapshot_env_config_drives_local_build.txt
+++ b/erun-integration/testdata/open/snapshot_env_config_drives_local_build.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-local' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell team local
+config: would assign localportrangestart=17000 to team/local
 open: tenant=team environment=local kubernetes-context=test-context remote=false no-shell=true ide=shell
 deploying the devops runtime before opening the shell
 docker image inspect ghcr.io/sophium/team-devops:fp-<HEX16>-amd64

--- a/erun-integration/testdata/open/tenant_flag_only_resolves_default_env.txt
+++ b/erun-integration/testdata/open/tenant_flag_only_resolves_default_env.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell --tenant team
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 deploying the devops runtime before opening the shell

--- a/erun-integration/testdata/open/version_override_skips_local_build.txt
+++ b/erun-integration/testdata/open/version_override_skips_local_build.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell --version <VERSION> team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 deploying the devops runtime before opening the shell
 kubectl --context test-context get namespace team-dev -o name

--- a/erun-integration/testdata/open/vscode_dry_run.txt
+++ b/erun-integration/testdata/open/vscode_dry_run.txt
@@ -6,6 +6,7 @@ SSH:
   key: none
   workspace: <HOME>/git/team
 audit: erun open --dry-run --vscode team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=false ide=vscode
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 open: dry-run: would deploy runtime for team/dev before launching VS Code; in real mode the user must run `erun sshd init team dev` or `erun open team dev` first

--- a/erun-integration/testdata/open/vscode_without_sshd_errors_with_guidance.txt
+++ b/erun-integration/testdata/open/vscode_without_sshd_errors_with_guidance.txt
@@ -1,3 +1,4 @@
 audit: erun open --dry-run --vscode team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=false ide=vscode
 --vscode requires sshd-enabled remote environment; run `erun sshd init team dev` first

--- a/erun-integration/testdata/open/walker_skips_index_claimed_by_other_tenant.txt
+++ b/erun-integration/testdata/open/walker_skips_index_claimed_by_other_tenant.txt
@@ -1,0 +1,21 @@
+kubectl config use-context 'test-context' >/dev/null &&
+kubectl config set-context --current --namespace='team-dev' >/dev/null &&
+cd '<TMP>'
+audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+config: would assign localportrangestart=17100 to team/dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+deploying the devops runtime before opening the shell
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17100 --set apiPort=17133 --set sshPort=17122 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17100:17100 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17133:17133 --address <LOOPBACK>
+open: --no-shell selected, emitting setup commands instead of launching shell
+kubectl config use-context test-context
+kubectl config set-context --current --namespace=team-dev
+cd <TMP>


### PR DESCRIPTION
## Summary

- Fix `erun-common/ports.go` so each env's local port range is durable instead of recomputed from the alphabetical order of all tenants/envs. Adding/renaming a tenant no longer shifts every later env's ports and leaves orphan `kubectl port-forward` collisions behind.
- Remove the four `DefaultEnvironmentLocalPorts()` fallbacks (`LocalPortsForResult`, `listEnvironmentLocalPorts`, `remoteRepositoryLocalPorts`, `environmentLocalPortsForTarget`). An unresolvable range now surfaces as a clear error or zero ports, not a silent collision with the alphabetically-first env on port 17000.
- Persist `localportrangestart` on the env config on first `Open`; emit a trace in dry-run and an `assigned` trace in live mode. Hybrid migration — existing envs keep their walker-derived range until they're opened for the first time, at which point the choice is frozen.

## Behaviour changes

- `EnvConfig.LocalPortRangeStart` is a new persisted field (`yaml:localportrangestart`). MCP/API/SSH offsets remain derived from it via the existing `*ServicePortOffset` constants.
- `ResolveAllEnvironmentLocalPorts` runs two passes: claim persisted ranges, then walk the remaining envs while skipping anything already claimed. Two persisted envs that share a range yield `ErrLocalPortRangeOverlap` with both envs and the colliding port named — no silent re-allocation.
- `EnsureLocalPortRangePersisted` is wired into `erun open`. Dry-run emits `config: would assign localportrangestart=N to T/E`; live mode calls `SaveEnvConfig` then emits `config: assigned localportrangestart=N to T/E`.

## Test plan

- [x] `go test ./...` in `erun-common`, `erun-cli`, `erun-mcp`, `erun-ui` — all green.
- [x] Integration suite (`go test ./...` in `erun-integration/`) — all scenarios green.
- [x] Four new integration scenarios cover the resolver branches:
  - `open/persisted_local_port_range_is_honoured`
  - `open/walker_skips_index_claimed_by_other_tenant`
  - `open/overlapping_persisted_ranges_fail_with_pointer`
  - `open/misaligned_persisted_range_fails_with_pointer`
- [x] Existing open goldens re-recorded to include the new `config: would assign localportrangestart=N to T/E` dry-run trace.

## Known unrelated red

`scripts/integration-test.sh` enforces a 90% coverage threshold but `main` already sits at ~55%. This PR nudges coverage up (+0.2pp from the four new scenarios) but does not bring the gate back to green. Worth tracking as a follow-up issue; this PR is gated on scenario greenness, not the threshold.

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)