### PR TITLE
Drop ERUN_API_PORT from runtime-pod identity check

### DIFF
--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -400,7 +400,6 @@ func (r *resolvedOpenRunner) shouldDeployRuntime(shellReq common.ShellLaunchPara
 		ExpectedRepoPath:   common.RemoteShellWorktreePath(shellReq),
 		ExpectedSSHD:       sshdExpectationForDeployment(r.result),
 		ExpectedMCPPort:    common.MCPPortForResult(r.result),
-		ExpectedAPIPort:    common.APIPortForResult(r.result),
 		ExpectedSSHPort:    common.SSHLocalPortForResult(r.result),
 		ExpectedRuntimePod: r.result.EnvConfig.RuntimePod,
 	})

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -141,7 +141,6 @@ type KubernetesDeploymentCheckParams struct {
 	ExpectedRepoPath   string
 	ExpectedSSHD       *bool
 	ExpectedMCPPort    int
-	ExpectedAPIPort    int
 	ExpectedSSHPort    int
 	ExpectedRuntimePod RuntimePodResources
 }
@@ -1958,7 +1957,6 @@ func hasExpectedDeploymentSettings(params KubernetesDeploymentCheckParams) bool 
 	return strings.TrimSpace(params.ExpectedRepoPath) != "" ||
 		params.ExpectedSSHD != nil ||
 		params.ExpectedMCPPort > 0 ||
-		params.ExpectedAPIPort > 0 ||
 		params.ExpectedSSHPort > 0 ||
 		params.ExpectedRuntimePod != (RuntimePodResources{})
 }
@@ -2026,17 +2024,26 @@ type deploymentExpectedMatches struct {
 	repoPath   bool
 	sshd       bool
 	mcpPort    bool
-	apiPort    bool
 	sshPort    bool
 	runtimePod bool
 }
 
+// expectedDeploymentMatches seeds the per-field match state. Each field
+// starts true when the corresponding expectation is unset (so a caller
+// that didn't ask about it doesn't gate the result), and false otherwise
+// — apply() flips it back to true on the first container env var that
+// confirms the expected value.
+//
+// ERUN_API_PORT is deliberately not part of this matcher: the erun-api
+// service is a separate Kubernetes deployment with its own port-forward
+// path and presence check. Tenant-owned <tenant>-devops charts can
+// legitimately omit ERUN_API_PORT from the runtime pod, and demanding it
+// here would force a redeploy on every open for those tenants.
 func expectedDeploymentMatches(params KubernetesDeploymentCheckParams) deploymentExpectedMatches {
 	return deploymentExpectedMatches{
 		repoPath:   strings.TrimSpace(params.ExpectedRepoPath) == "",
 		sshd:       params.ExpectedSSHD == nil,
 		mcpPort:    params.ExpectedMCPPort <= 0,
-		apiPort:    params.ExpectedAPIPort <= 0,
 		sshPort:    params.ExpectedSSHPort <= 0,
 		runtimePod: params.ExpectedRuntimePod == (RuntimePodResources{}),
 	}
@@ -2050,15 +2057,13 @@ func (m *deploymentExpectedMatches) apply(params KubernetesDeploymentCheckParams
 		m.sshd = matchesExpectedBool(value, params.ExpectedSSHD)
 	case "ERUN_MCP_PORT":
 		m.mcpPort = matchesExpectedPort(value, params.ExpectedMCPPort)
-	case "ERUN_API_PORT":
-		m.apiPort = matchesExpectedPort(value, params.ExpectedAPIPort)
 	case "ERUN_SSHD_PORT":
 		m.sshPort = matchesExpectedPort(value, params.ExpectedSSHPort)
 	}
 }
 
 func (m deploymentExpectedMatches) ok() bool {
-	return m.repoPath && m.sshd && m.mcpPort && m.apiPort && m.sshPort && m.runtimePod
+	return m.repoPath && m.sshd && m.mcpPort && m.sshPort && m.runtimePod
 }
 
 func matchesExpectedRepoPath(value, expected string) bool {

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -505,7 +505,6 @@ type KubectlDeployedStubSpec struct {
 	RepoPath       string
 	SSHDEnabled    bool
 	MCPPort        int
-	APIPort        int
 	SSHPort        int
 }
 
@@ -528,8 +527,8 @@ func StubKubectlDeployed(t testing.TB, stubsDir string, spec KubectlDeployedStub
 	}
 	portsim := PortSimBinary(t)
 	pidFile := filepath.Join(stubsDir, "portsim-pids")
-	deploymentJSON := fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"name":%q,"env":[{"name":"ERUN_REPO_PATH","value":%q},{"name":"ERUN_SSHD_ENABLED","value":%q},{"name":"ERUN_MCP_PORT","value":"%d"},{"name":"ERUN_API_PORT","value":"%d"},{"name":"ERUN_SSHD_PORT","value":"%d"}],"resources":{"limits":{}}}]}}}}`,
-		spec.ContainerName, spec.RepoPath, formatStubBool(spec.SSHDEnabled), spec.MCPPort, spec.APIPort, spec.SSHPort)
+	deploymentJSON := fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"name":%q,"env":[{"name":"ERUN_REPO_PATH","value":%q},{"name":"ERUN_SSHD_ENABLED","value":%q},{"name":"ERUN_MCP_PORT","value":"%d"},{"name":"ERUN_SSHD_PORT","value":"%d"}],"resources":{"limits":{}}}]}}}}`,
+		spec.ContainerName, spec.RepoPath, formatStubBool(spec.SSHDEnabled), spec.MCPPort, spec.SSHPort)
 	script := strings.Join([]string{
 		// Find the local port in `port-forward ... LOCAL:REMOTE [...]` argv.
 		// Production passes the mapping as a single positional after the

--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -249,7 +249,6 @@ func TestOpen(t *testing.T) {
 			RepoPath:       "/home/erun/git/team",
 			SSHDEnabled:    true,
 			MCPPort:        17000,
-			APIPort:        17033,
 			SSHPort:        17022,
 		})...)
 		fixture.StubBinary(t, stubsDir, "ssh-keyscan", "[127.0.0.1]:17022 ssh-ed25519 AAAATESTKEY=")
@@ -301,7 +300,6 @@ func TestOpen(t *testing.T) {
 			RepoPath:       "/home/erun/git/team",
 			SSHDEnabled:    true,
 			MCPPort:        17000,
-			APIPort:        17033,
 			SSHPort:        17022,
 		})...)
 		fixture.StubBinary(t, stubsDir, "ssh-keyscan", "[127.0.0.1]:17022 ssh-ed25519 AAAAINTELLIJKEY=")
@@ -414,6 +412,31 @@ func TestOpen(t *testing.T) {
 		envVars := stubKubectlNotFound(t, setup)
 		result := erun.Run(t, []string{"open", "team", "dev", "--runtime-image", "ghcr.io/example/custom-runtime", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		golden.Equal(t, "open/remote_runtime_image_override", normalize.Apply(result.Combined))
+	})
+
+	t.Run("deployment_match_ignores_missing_api_port", func(t *testing.T) {
+		// Regression for the --intellij short-circuit on tenant-owned
+		// devops charts. The runtime-pod identity matcher must accept a
+		// deployment whose containers expose ERUN_REPO_PATH,
+		// ERUN_SSHD_ENABLED, ERUN_MCP_PORT, and ERUN_SSHD_PORT but not
+		// ERUN_API_PORT — the erun-api service is a separate deployment
+		// with its own port-forward path, so the runtime pod legitimately
+		// omits that env var. Without the fix, every open against a
+		// tenant chart predating ERUN_API_PORT would be flagged as "not
+		// deployed" and either redeploy unnecessarily (shell flow) or
+		// hard-error (--intellij / --vscode flow).
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		stubsDir := filepath.Join(setup.Cwd, "stubs")
+		envVars := append(setup.Env(), fixture.StubKubectlDeployed(t, stubsDir, fixture.KubectlDeployedStubSpec{
+			DeploymentName: "team-devops",
+			ContainerName:  "team-devops",
+			RepoPath:       "/home/erun/git/team",
+			MCPPort:        17000,
+			SSHPort:        17022,
+		})...)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/deployment_match_ignores_missing_api_port", normalize.Apply(result.Combined))
 	})
 
 }

--- a/erun-integration/testdata/open/deployment_match_ignores_missing_api_port.txt
+++ b/erun-integration/testdata/open/deployment_match_ignores_missing_api_port.txt
@@ -1,0 +1,14 @@
+kubectl config use-context 'test-context' >/dev/null &&
+kubectl config set-context --current --namespace='team-dev' >/dev/null &&
+cd '<TMP>'
+audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=true ide=shell
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+kubectl --context test-context --namespace team-dev get deployment team-devops -o json
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <LOOPBACK>
+open: --no-shell selected, emitting setup commands instead of launching shell
+kubectl config use-context test-context
+kubectl config set-context --current --namespace=team-dev
+cd <TMP>


### PR DESCRIPTION
## Summary

- Remove \`apiPort\` from the runtime-pod deployment-match check in \`erun-common/deploy.go\`. The matcher used to require the runtime pod expose an \`ERUN_API_PORT\` env var even though \`erun-api\` is a separate Kubernetes deployment with its own port-forward and presence check.
- Drop \`ExpectedAPIPort\` from \`KubernetesDeploymentCheckParams\` and from the open-flow call site.
- Drop the same field from the integration fixture's deployment-JSON stub so the stub mirrors what a tenant-owned chart actually produces.

## Why

\`erun open --intellij petios rihards-review\` was failing with \"opening IntelliJ IDEA requires updating the runtime deployment\" even when the user had a working shell open against the same env. The live \`petios-devops\` Helm chart (tenant-owned, predates the env-var addition in our embedded default-devops chart) does not set \`ERUN_API_PORT\` on any of its containers. The matcher saw that as a mismatch, \`shouldDeployRuntime\` returned true, and \`--intellij\`'s "I won't redeploy" short-circuit kicked in.

Verified on the live deployment:

\`\`\`
ERUN_REPO_PATH=/home/erun/git/petios       ✓
ERUN_SSHD_ENABLED=true                     ✓
ERUN_MCP_PORT=17500                        ✓
ERUN_SSHD_PORT=17522                       ✓
(no ERUN_API_PORT)                         ✗ (this PR removes the check)
\`\`\`

## Test plan

- [x] \`go test ./...\` in \`erun-common\`, \`erun-cli\`, \`erun-mcp\`, \`erun-ui\` — all green.
- [x] \`go test ./...\` in \`erun-integration/\` — all scenarios green.
- [x] New integration scenario: \`open/deployment_match_ignores_missing_api_port\` — locks the regression by running a dry-run open against a stub deployment that exposes the other identity env vars but not \`ERUN_API_PORT\`; the resulting trace must show the deployment-match check ran and the helm upgrade was skipped.

## Known unrelated red

\`scripts/integration-test.sh\` coverage threshold (90%) was already failing on \`main\` (~55%) before this PR. Not in scope here.

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)