### PR TITLE
Port-forward reliability bundle: persist range, adopt orphans, drop API-port check

### DIFF
--- a/erun-cli/cmd/api_port_forward.go
+++ b/erun-cli/cmd/api_port_forward.go
@@ -39,9 +39,7 @@ func ensureAPIPortForward(ctx common.Context, result common.OpenResult) (int, er
 	ctx.TraceCommand("", "kubectl", checkArgs...)
 
 	if ctx.DryRun {
-		args := kubectlAPIPortForwardArgs(result, localPort)
-		ctx.TraceCommand("", "kubectl", args...)
-		return localPort, nil
+		return ensureAPIPortForwardDryRun(ctx, result, localPort)
 	}
 
 	exists, err := checkAPIDeploymentPresent(checkArgs)
@@ -58,14 +56,51 @@ func ensureAPIPortForward(ctx common.Context, result common.OpenResult) (int, er
 		return localPort, nil
 	}
 	stopStaleMCPPortForward(state, expectedState, localPort)
+	args := kubectlAPIPortForwardArgs(result, localPort)
 	if canConnectLocalPort(localPort) {
-		return 0, fmt.Errorf("local API port %d is already in use", localPort)
+		adopted, err := adoptForeignAPIPortForward(ctx, statePath, expectedState, args, localPort)
+		if err != nil {
+			return 0, err
+		}
+		if adopted {
+			return localPort, nil
+		}
 	}
 
-	args := kubectlAPIPortForwardArgs(result, localPort)
 	ctx.TraceCommand("", "kubectl", args...)
 
 	return startAPIPortForward(statePath, expectedState, args, localPort)
+}
+
+func ensureAPIPortForwardDryRun(ctx common.Context, result common.OpenResult, localPort int) (int, error) {
+	args := kubectlAPIPortForwardArgs(result, localPort)
+	if previewed, port := previewAdoptOrConflict(ctx, "api", localPort, args); previewed {
+		return port, nil
+	}
+	ctx.TraceCommand("", "kubectl", args...)
+	return localPort, nil
+}
+
+// adoptForeignAPIPortForward mirrors adoptForeignMCPPortForward for the
+// erun-api service forward (target shape is service/erun-api rather than
+// deployment/<release>-devops). See adoptForeignMCPPortForward for the
+// contract.
+func adoptForeignAPIPortForward(ctx common.Context, statePath string, expected mcpPortForwardState, expectedArgs []string, localPort int) (bool, error) {
+	pid, argv, ok := findLocalPortHolder(localPort)
+	if !ok {
+		return false, fmt.Errorf("local API port %d is already in use", localPort)
+	}
+	if !argvMatchesExpectedKubectlPortForward(argv, expectedArgs) {
+		return false, fmt.Errorf("local API port %d is already in use by %s", localPort, formatHolderForError(pid, argv))
+	}
+	adopted := expected
+	adopted.ProcessID = pid
+	adopted.LogPath = mcpPortForwardLogPath(statePath)
+	if err := saveMCPPortForwardState(statePath, adopted); err != nil {
+		return false, fmt.Errorf("adopt API port-forward (PID %d): %w", pid, err)
+	}
+	ctx.Trace(fmt.Sprintf("api: adopted existing kubectl port-forward on 127.0.0.1:%d (PID %d)", localPort, pid))
+	return true, nil
 }
 
 func kubectlAPIDeploymentCheckArgs(kubernetesContext, namespace string) []string {
@@ -157,11 +192,7 @@ func kubectlAPIPortForwardArgs(result common.OpenResult, localPort int) []string
 }
 
 func apiPortForwardStatePath(tenant, environment string) (string, error) {
-	path, err := mcpPortForwardStatePath(tenant, environment)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(filepath.Dir(filepath.Dir(path)), "api", tenant, filepath.Base(path)), nil
+	return portForwardStatePath("api", tenant, environment)
 }
 
 func canReachLocalAPIEndpoint(port int) bool {

--- a/erun-cli/cmd/mcp_port_forward.go
+++ b/erun-cli/cmd/mcp_port_forward.go
@@ -51,6 +51,9 @@ func ensureMCPPortForward(ctx common.Context, result common.OpenResult) (int, er
 
 	if ctx.DryRun {
 		args := kubectlMCPPortForwardArgs(result, localPort)
+		if previewed, port := previewAdoptOrConflict(ctx, "mcp", localPort, args); previewed {
+			return port, nil
+		}
 		ctx.TraceCommand("", "kubectl", args...)
 		return localPort, nil
 	}
@@ -59,14 +62,46 @@ func ensureMCPPortForward(ctx common.Context, result common.OpenResult) (int, er
 		return localPort, nil
 	}
 	stopStaleMCPPortForward(state, expectedState, localPort)
+	args := kubectlMCPPortForwardArgs(result, localPort)
 	if canConnectLocalPort(localPort) {
-		return 0, fmt.Errorf("local MCP port %d is already in use", localPort)
+		adopted, err := adoptForeignMCPPortForward(ctx, statePath, expectedState, args, localPort)
+		if err != nil {
+			return 0, err
+		}
+		if adopted {
+			return localPort, nil
+		}
 	}
 
-	args := kubectlMCPPortForwardArgs(result, localPort)
 	ctx.TraceCommand("", "kubectl", args...)
 
 	return startMCPPortForward(statePath, expectedState, args, localPort)
+}
+
+// adoptForeignMCPPortForward inspects the process currently holding
+// localPort and, if its argv matches the kubectl port-forward erun would
+// start itself, writes a fresh state file claiming that PID so subsequent
+// opens reuse it instead of fighting over the port. Returns adopted=true
+// when the PID was claimed, adopted=false when we could not identify the
+// holder (e.g. lsof missing). A non-nil error is returned only when the
+// holder is identified but is *not* a matching kubectl port-forward, so
+// the caller can surface a precise "port held by X" error.
+func adoptForeignMCPPortForward(ctx common.Context, statePath string, expected mcpPortForwardState, expectedArgs []string, localPort int) (bool, error) {
+	pid, argv, ok := findLocalPortHolder(localPort)
+	if !ok {
+		return false, fmt.Errorf("local MCP port %d is already in use", localPort)
+	}
+	if !argvMatchesExpectedKubectlPortForward(argv, expectedArgs) {
+		return false, fmt.Errorf("local MCP port %d is already in use by %s", localPort, formatHolderForError(pid, argv))
+	}
+	adopted := expected
+	adopted.ProcessID = pid
+	adopted.LogPath = mcpPortForwardLogPath(statePath)
+	if err := saveMCPPortForwardState(statePath, adopted); err != nil {
+		return false, fmt.Errorf("adopt MCP port-forward (PID %d): %w", pid, err)
+	}
+	ctx.Trace(fmt.Sprintf("mcp: adopted existing kubectl port-forward on 127.0.0.1:%d (PID %d)", localPort, pid))
+	return true, nil
 }
 
 func stopStaleMCPPortForward(state, expectedState mcpPortForwardState, localPort int) {
@@ -144,15 +179,11 @@ func kubectlMCPPortForwardArgs(result common.OpenResult, localPort int) []string
 }
 
 func mcpPortForwardStatePath(tenant, environment string) (string, error) {
-	cacheDir, err := os.UserCacheDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(cacheDir, "erun", "mcp", tenant, environment+".json"), nil
+	return portForwardStatePath("mcp", tenant, environment)
 }
 
 func mcpPortForwardLogPath(statePath string) string {
-	return strings.TrimSuffix(statePath, filepath.Ext(statePath)) + ".log"
+	return portForwardLogPath(statePath)
 }
 
 func loadMCPPortForwardState(path string) (mcpPortForwardState, error) {

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -408,7 +408,6 @@ func (r *resolvedOpenRunner) shouldDeployRuntime(shellReq common.ShellLaunchPara
 		ExpectedRepoPath:   common.RemoteShellWorktreePath(shellReq),
 		ExpectedSSHD:       sshdExpectationForDeployment(r.result),
 		ExpectedMCPPort:    common.MCPPortForResult(r.result),
-		ExpectedAPIPort:    common.APIPortForResult(r.result),
 		ExpectedSSHPort:    common.SSHLocalPortForResult(r.result),
 		ExpectedRuntimePod: r.result.EnvConfig.RuntimePod,
 	})

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -61,7 +61,7 @@ func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen 
 			if err != nil {
 				return err
 			}
-			result, err = applyOpenSnapshotPreference(result, snapshotOverride, saveEnvConfig)
+			result, err = prepareOpenResultForRun(ctx, result, snapshotOverride, saveEnvConfig)
 			if err != nil {
 				return err
 			}
@@ -104,6 +104,14 @@ type openOptions struct {
 	RuntimeImage     string
 	AllowLocalBuilds bool
 	SaveEnvConfig    func(string, common.EnvConfig) error
+}
+
+func prepareOpenResultForRun(ctx common.Context, result common.OpenResult, snapshotOverride *bool, saveEnvConfig func(string, common.EnvConfig) error) (common.OpenResult, error) {
+	result, err := applyOpenSnapshotPreference(result, snapshotOverride, saveEnvConfig)
+	if err != nil {
+		return common.OpenResult{}, err
+	}
+	return common.EnsureLocalPortRangePersisted(ctx, saveEnvConfig, result)
 }
 
 func applyOpenSnapshotPreference(result common.OpenResult, enabled *bool, saveEnvConfig func(string, common.EnvConfig) error) (common.OpenResult, error) {

--- a/erun-cli/cmd/port_forward_adopt.go
+++ b/erun-cli/cmd/port_forward_adopt.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	common "github.com/sophium/erun/erun-common"
+)
+
+// previewAdoptOrConflict surfaces in dry-run what the live path would do
+// when the local port is already held: adopt the existing kubectl
+// port-forward (when argv matches expected) or refuse with a holder
+// description. Returns previewed=true when a holder was identified and a
+// trace was emitted, in which case the caller should short-circuit and
+// return that port. previewed=false means no holder was identified and
+// the caller should fall back to the normal "trace kubectl args" path.
+//
+// The probe is gated on lsof being available (findLocalPortHolder
+// returns false otherwise), so platforms without lsof keep today's
+// behaviour: a kubectl trace line and an assumed-fresh-start plan.
+func previewAdoptOrConflict(ctx common.Context, kind string, localPort int, expectedArgs []string) (bool, int) {
+	// We deliberately do not gate on canConnectLocalPort here: lsof is
+	// the source of truth for "is there a TCP listener", and gating on a
+	// separate Dial would make the probe sensitive to transient connect
+	// races. When nothing is listening lsof exits non-zero, so the probe
+	// stays silent without any extra check.
+	pid, argv, ok := findLocalPortHolder(localPort)
+	if !ok {
+		return false, 0
+	}
+	if argvMatchesExpectedKubectlPortForward(argv, expectedArgs) {
+		ctx.Trace(fmt.Sprintf("%s: would adopt existing kubectl port-forward on 127.0.0.1:%d (PID %d)", kind, localPort, pid))
+		return true, localPort
+	}
+	ctx.TraceCommand("", "kubectl", expectedArgs...)
+	ctx.Trace(fmt.Sprintf("%s: would refuse to bind 127.0.0.1:%d — held by %s", kind, localPort, formatHolderForError(pid, argv)))
+	return true, 0
+}
+
+// kubectlPortForwardArgv is a parsed view of a `kubectl ... port-forward ...`
+// invocation. We only carry the fields that participate in adopt-or-conflict
+// identity decisions: namespace, the target spec (e.g.
+// `deployment/erun-devops` or `service/erun-api`), the local:remote port
+// mapping, and the optional bind address. context is kept for richer error
+// messages but is not part of the strict identity comparison — the
+// kubernetes context lives on the calling host and we want adoption to
+// succeed even if a user invoked kubectl with a different `--context`
+// alias that happens to resolve to the same cluster.
+type kubectlPortForwardArgv struct {
+	Binary    string
+	Context   string
+	Namespace string
+	Target    string
+	PortPair  string
+	Address   string
+}
+
+// parseKubectlPortForwardArgv tries to interpret an argv slice as a
+// `kubectl port-forward` invocation. Returns the parsed form and true when
+// the argv matches that shape. The binary token is allowed to be any path
+// whose basename starts with "kubectl" so that version-managed launchers
+// (`kuberlr`'s `kubectl1.32.0`, `kubectx`'s wrappers, etc.) still adopt.
+func parseKubectlPortForwardArgv(argv []string) (kubectlPortForwardArgv, bool) {
+	if len(argv) == 0 || !strings.HasPrefix(filepath.Base(argv[0]), "kubectl") {
+		return kubectlPortForwardArgv{}, false
+	}
+	out := kubectlPortForwardArgv{Binary: argv[0]}
+	sawPortForward := false
+	positionals := make([]string, 0, 4)
+	for i := 1; i < len(argv); i++ {
+		token := argv[i]
+		if token == "port-forward" {
+			sawPortForward = true
+			continue
+		}
+		if consumed := consumeKubectlPortForwardFlag(argv, &i, &out); consumed {
+			continue
+		}
+		if strings.HasPrefix(token, "-") {
+			continue
+		}
+		positionals = append(positionals, token)
+	}
+	if !sawPortForward || len(positionals) < 2 {
+		return kubectlPortForwardArgv{}, false
+	}
+	out.Target = positionals[0]
+	out.PortPair = positionals[1]
+	return out, true
+}
+
+// consumeKubectlPortForwardFlag matches one of the kubectl flags whose
+// value participates in identity comparison (--context, --namespace/-n,
+// --address) at argv[*i]. On a match the parsed value is written into
+// out, *i is advanced past the consumed token(s), and consumed=true is
+// returned. Tokens we don't recognise leave *i untouched.
+func consumeKubectlPortForwardFlag(argv []string, i *int, out *kubectlPortForwardArgv) bool {
+	for _, flag := range kubectlPortForwardIdentityFlags {
+		value, advance, matched := matchKubectlFlag(argv, *i, flag.names)
+		if !matched {
+			continue
+		}
+		if advance > 0 {
+			flag.assign(out, value)
+			*i += advance - 1
+		}
+		return true
+	}
+	return false
+}
+
+type kubectlPortForwardIdentityFlag struct {
+	names  []string
+	assign func(*kubectlPortForwardArgv, string)
+}
+
+var kubectlPortForwardIdentityFlags = []kubectlPortForwardIdentityFlag{
+	{names: []string{"--context"}, assign: func(o *kubectlPortForwardArgv, v string) { o.Context = v }},
+	{names: []string{"--namespace", "-n"}, assign: func(o *kubectlPortForwardArgv, v string) { o.Namespace = v }},
+	{names: []string{"--address"}, assign: func(o *kubectlPortForwardArgv, v string) { o.Address = v }},
+}
+
+// matchKubectlFlag reports whether argv[i] is one of the given flag names,
+// returning the parsed value. advance is the number of argv tokens
+// consumed: 1 for `--flag=value`, 2 for `--flag value`, 0 when the flag
+// matched but is missing its value (caller treats this as a malformed
+// flag we skip).
+func matchKubectlFlag(argv []string, i int, names []string) (value string, advance int, matched bool) {
+	token := argv[i]
+	for _, name := range names {
+		if token == name {
+			if i+1 >= len(argv) {
+				return "", 0, true
+			}
+			return argv[i+1], 2, true
+		}
+		if strings.HasPrefix(token, name+"=") {
+			return strings.TrimPrefix(token, name+"="), 1, true
+		}
+	}
+	return "", 0, false
+}
+
+// argvMatchesExpectedKubectlPortForward decides whether a foreign
+// `kubectl port-forward` invocation describes the same target erun would
+// start itself. Mismatch on namespace, target, or port pair is a hard "do
+// not adopt" — those are the fields whose drift indicates a different
+// tenant, environment, or service. Context and address are intentionally
+// not part of the equality check; see kubectlPortForwardArgv.Context for
+// the rationale.
+func argvMatchesExpectedKubectlPortForward(actual []string, expected []string) bool {
+	a, ok := parseKubectlPortForwardArgv(actual)
+	if !ok {
+		return false
+	}
+	e, ok := parseKubectlPortForwardArgv(append([]string{"kubectl"}, expected...))
+	if !ok {
+		return false
+	}
+	return a.Namespace == e.Namespace && a.Target == e.Target && a.PortPair == e.PortPair
+}
+
+// formatHolderForError produces a short, human-readable description of the
+// process currently holding a port erun wanted to bind. Used to enrich the
+// "already in use" error so the user sees what they need to kill instead
+// of a bare port number.
+func formatHolderForError(pid int, argv []string) string {
+	command := strings.Join(argv, " ")
+	if command == "" {
+		return ""
+	}
+	return "PID " + strconv.Itoa(pid) + ": " + command
+}

--- a/erun-cli/cmd/port_forward_adopt_unix.go
+++ b/erun-cli/cmd/port_forward_adopt_unix.go
@@ -1,0 +1,67 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"strconv"
+	"strings"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// findLocalPortHolder reports the PID and full argv of the process holding a
+// listener on 127.0.0.1:port, if it can be determined via the host's lsof + ps.
+// Both macOS and Linux ship a compatible lsof, so the only cross-host risk is
+// that lsof is not installed; in that case we behave as if no holder was
+// found, and the caller falls back to the legacy "already in use" error path.
+//
+// Returning (0, nil, false) is reserved for "I could not determine a holder",
+// not "the port is free". The caller has already established via
+// canConnectLocalPort that the port is held; this function is strictly about
+// identifying *who* holds it.
+func findLocalPortHolder(port int) (int, []string, bool) {
+	if port <= 0 {
+		return 0, nil, false
+	}
+	out, err := eruncommon.Command("lsof", "-nP", "-iTCP:"+strconv.Itoa(port), "-sTCP:LISTEN", "-t").Output()
+	if err != nil {
+		return 0, nil, false
+	}
+	pidStr := strings.TrimSpace(string(out))
+	if pidStr == "" {
+		return 0, nil, false
+	}
+	// If multiple processes share the listener (rare for TCP listeners but
+	// possible after a fork before bind teardown), keep the first.
+	if newline := strings.IndexAny(pidStr, "\n\r"); newline > 0 {
+		pidStr = pidStr[:newline]
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(pidStr))
+	if err != nil || pid <= 0 {
+		return 0, nil, false
+	}
+	argv, ok := readProcessArgv(pid)
+	if !ok {
+		return 0, nil, false
+	}
+	return pid, argv, true
+}
+
+func readProcessArgv(pid int) ([]string, bool) {
+	if pid <= 0 {
+		return nil, false
+	}
+	out, err := eruncommon.Command("ps", "-ww", "-o", "command=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return nil, false
+	}
+	command := strings.TrimSpace(string(out))
+	if command == "" {
+		return nil, false
+	}
+	// `ps -o command=` returns a single line per pid with space-separated
+	// argv tokens. kubectl port-forward never embeds quoted spaces in any
+	// of its args (paths can but namespaces/contexts/deployments cannot),
+	// so a plain Fields split is safe here.
+	return strings.Fields(command), true
+}

--- a/erun-cli/cmd/port_forward_adopt_windows.go
+++ b/erun-cli/cmd/port_forward_adopt_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package cmd
+
+// findLocalPortHolder is a unix-only feature; on Windows we return "no
+// holder identified" and let the caller fall through to the legacy
+// "already in use" error path. Adoption of foreign port-forwards is not
+// implemented for Windows.
+func findLocalPortHolder(int) (int, []string, bool) {
+	return 0, nil, false
+}

--- a/erun-cli/cmd/port_forward_state.go
+++ b/erun-cli/cmd/port_forward_state.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// portForwardStatePath returns the on-disk path for a port-forward state
+// file, scoped by kind (mcp / sshd / api), tenant, and environment.
+//
+// State now lives under os.UserConfigDir() rather than os.UserCacheDir().
+// Cache directories are explicitly evictable by the OS and by user-level
+// cleanup tools, and we saw the eviction-then-orphan failure mode in
+// practice: macOS purges ~/Library/Caches/erun/..., the detached `kubectl
+// port-forward` outlives the record, and the next `erun open` has no way
+// to recognise its own forward.
+//
+// For installs that already have state under the legacy cache path,
+// portForwardStatePath performs a one-time, silent rename on first access
+// so the relink does not require user action.
+func portForwardStatePath(kind, tenant, environment string) (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	newPath := filepath.Join(configDir, "erun", "portforward", kind, tenant, environment+".json")
+
+	if _, err := os.Stat(newPath); err == nil {
+		return newPath, nil
+	}
+	migrateLegacyPortForwardState(kind, tenant, environment, newPath)
+	return newPath, nil
+}
+
+func migrateLegacyPortForwardState(kind, tenant, environment, newPath string) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return
+	}
+	legacyPath := filepath.Join(cacheDir, "erun", kind, tenant, environment+".json")
+	if _, err := os.Stat(legacyPath); err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(newPath), 0o755); err != nil {
+		return
+	}
+	if err := os.Rename(legacyPath, newPath); err != nil {
+		return
+	}
+	legacyLog := portForwardLogPath(legacyPath)
+	newLog := portForwardLogPath(newPath)
+	_ = os.Rename(legacyLog, newLog)
+}
+
+func portForwardLogPath(statePath string) string {
+	return strings.TrimSuffix(statePath, filepath.Ext(statePath)) + ".log"
+}

--- a/erun-cli/cmd/sshd_port_forward.go
+++ b/erun-cli/cmd/sshd_port_forward.go
@@ -45,17 +45,47 @@ func ensureSSHDPortForward(ctx common.Context, result common.OpenResult) (common
 		return info, nil
 	}
 	stopStaleSSHDPortForward(state, expectedState, info.Port)
-	if canConnectLocalPort(info.Port) {
-		return common.SSHConnectionInfo{}, fmt.Errorf("local SSH port %d is already in use", info.Port)
-	}
-
 	args := kubectlPortForwardArgs(result, info.Port)
-	ctx.TraceCommand("", "kubectl", args...)
 	if ctx.DryRun {
+		if previewed, _ := previewAdoptOrConflict(ctx, "sshd", info.Port, args); previewed {
+			return info, nil
+		}
+		ctx.TraceCommand("", "kubectl", args...)
 		return info, nil
 	}
+	if canConnectLocalPort(info.Port) {
+		adopted, err := adoptForeignSSHDPortForward(ctx, statePath, expectedState, args, info)
+		if err != nil {
+			return common.SSHConnectionInfo{}, err
+		}
+		if adopted {
+			return info, nil
+		}
+	}
+
+	ctx.TraceCommand("", "kubectl", args...)
 
 	return startSSHDPortForward(statePath, expectedState, args, info)
+}
+
+// adoptForeignSSHDPortForward mirrors adoptForeignMCPPortForward for the
+// SSHD forward. See that function for the contract.
+func adoptForeignSSHDPortForward(ctx common.Context, statePath string, expected sshdPortForwardState, expectedArgs []string, info common.SSHConnectionInfo) (bool, error) {
+	pid, argv, ok := findLocalPortHolder(info.Port)
+	if !ok {
+		return false, fmt.Errorf("local SSH port %d is already in use", info.Port)
+	}
+	if !argvMatchesExpectedKubectlPortForward(argv, expectedArgs) {
+		return false, fmt.Errorf("local SSH port %d is already in use by %s", info.Port, formatHolderForError(pid, argv))
+	}
+	adopted := expected
+	adopted.ProcessID = pid
+	adopted.LogPath = sshdPortForwardLogPath(statePath)
+	if err := saveSSHDPortForwardState(statePath, adopted); err != nil {
+		return false, fmt.Errorf("adopt SSHD port-forward (PID %d): %w", pid, err)
+	}
+	ctx.Trace(fmt.Sprintf("sshd: adopted existing kubectl port-forward on 127.0.0.1:%d (PID %d)", info.Port, pid))
+	return true, nil
 }
 
 func stopStaleSSHDPortForward(state, expectedState sshdPortForwardState, localPort int) {
@@ -133,15 +163,11 @@ func kubectlPortForwardArgs(result common.OpenResult, localPort int) []string {
 }
 
 func sshdPortForwardStatePath(tenant, environment string) (string, error) {
-	cacheDir, err := os.UserCacheDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(cacheDir, "erun", "sshd", tenant, environment+".json"), nil
+	return portForwardStatePath("sshd", tenant, environment)
 }
 
 func sshdPortForwardLogPath(statePath string) string {
-	return strings.TrimSuffix(statePath, filepath.Ext(statePath)) + ".log"
+	return portForwardLogPath(statePath)
 }
 
 func loadSSHDPortForwardState(path string) (sshdPortForwardState, error) {

--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -81,20 +81,21 @@ type TenantConfig struct {
 }
 
 type EnvConfig struct {
-	Name               string
-	RepoPath           string
-	KubernetesContext  string
-	ContainerRegistry  string
-	CloudProviderAlias string                  `yaml:"cloudprovideralias,omitempty"`
-	ManagedCloud       bool                    `yaml:"managedcloud,omitempty" json:"managedCloud,omitempty"`
-	RuntimeVersion     string                  `yaml:"runtimeversion,omitempty"`
-	RuntimePod         RuntimePodResources     `yaml:"runtimepod,omitempty"`
-	SSHD               SSHDConfig              `yaml:"sshd,omitempty"`
-	Idle               EnvironmentIdleConfig   `yaml:"idle,omitempty"`
-	Claude             EnvironmentClaudeConfig `yaml:"claude,omitempty" json:"claude,omitempty"`
-	AITool             string                  `yaml:"aitool,omitempty" json:"aiTool,omitempty"`
-	Remote             bool                    `yaml:"remote,omitempty"`
-	Snapshot           *bool                   `yaml:"snapshot,omitempty"`
+	Name                string
+	RepoPath            string
+	KubernetesContext   string
+	ContainerRegistry   string
+	CloudProviderAlias  string                  `yaml:"cloudprovideralias,omitempty"`
+	ManagedCloud        bool                    `yaml:"managedcloud,omitempty" json:"managedCloud,omitempty"`
+	RuntimeVersion      string                  `yaml:"runtimeversion,omitempty"`
+	RuntimePod          RuntimePodResources     `yaml:"runtimepod,omitempty"`
+	SSHD                SSHDConfig              `yaml:"sshd,omitempty"`
+	Idle                EnvironmentIdleConfig   `yaml:"idle,omitempty"`
+	Claude              EnvironmentClaudeConfig `yaml:"claude,omitempty" json:"claude,omitempty"`
+	AITool              string                  `yaml:"aitool,omitempty" json:"aiTool,omitempty"`
+	Remote              bool                    `yaml:"remote,omitempty"`
+	Snapshot            *bool                   `yaml:"snapshot,omitempty"`
+	LocalPortRangeStart int                     `yaml:"localportrangestart,omitempty" json:"localPortRangeStart,omitempty"`
 }
 
 func (c TenantConfig) SnapshotEnabled() bool {

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -141,7 +141,6 @@ type KubernetesDeploymentCheckParams struct {
 	ExpectedRepoPath   string
 	ExpectedSSHD       *bool
 	ExpectedMCPPort    int
-	ExpectedAPIPort    int
 	ExpectedSSHPort    int
 	ExpectedRuntimePod RuntimePodResources
 }
@@ -1958,7 +1957,6 @@ func hasExpectedDeploymentSettings(params KubernetesDeploymentCheckParams) bool 
 	return strings.TrimSpace(params.ExpectedRepoPath) != "" ||
 		params.ExpectedSSHD != nil ||
 		params.ExpectedMCPPort > 0 ||
-		params.ExpectedAPIPort > 0 ||
 		params.ExpectedSSHPort > 0 ||
 		params.ExpectedRuntimePod != (RuntimePodResources{})
 }
@@ -2026,17 +2024,26 @@ type deploymentExpectedMatches struct {
 	repoPath   bool
 	sshd       bool
 	mcpPort    bool
-	apiPort    bool
 	sshPort    bool
 	runtimePod bool
 }
 
+// expectedDeploymentMatches seeds the per-field match state. Each field
+// starts true when the corresponding expectation is unset (so a caller
+// that didn't ask about it doesn't gate the result), and false otherwise
+// — apply() flips it back to true on the first container env var that
+// confirms the expected value.
+//
+// ERUN_API_PORT is deliberately not part of this matcher: the erun-api
+// service is a separate Kubernetes deployment with its own port-forward
+// path and presence check. Tenant-owned <tenant>-devops charts can
+// legitimately omit ERUN_API_PORT from the runtime pod, and demanding it
+// here would force a redeploy on every open for those tenants.
 func expectedDeploymentMatches(params KubernetesDeploymentCheckParams) deploymentExpectedMatches {
 	return deploymentExpectedMatches{
 		repoPath:   strings.TrimSpace(params.ExpectedRepoPath) == "",
 		sshd:       params.ExpectedSSHD == nil,
 		mcpPort:    params.ExpectedMCPPort <= 0,
-		apiPort:    params.ExpectedAPIPort <= 0,
 		sshPort:    params.ExpectedSSHPort <= 0,
 		runtimePod: params.ExpectedRuntimePod == (RuntimePodResources{}),
 	}
@@ -2050,15 +2057,13 @@ func (m *deploymentExpectedMatches) apply(params KubernetesDeploymentCheckParams
 		m.sshd = matchesExpectedBool(value, params.ExpectedSSHD)
 	case "ERUN_MCP_PORT":
 		m.mcpPort = matchesExpectedPort(value, params.ExpectedMCPPort)
-	case "ERUN_API_PORT":
-		m.apiPort = matchesExpectedPort(value, params.ExpectedAPIPort)
 	case "ERUN_SSHD_PORT":
 		m.sshPort = matchesExpectedPort(value, params.ExpectedSSHPort)
 	}
 }
 
 func (m deploymentExpectedMatches) ok() bool {
-	return m.repoPath && m.sshd && m.mcpPort && m.apiPort && m.sshPort && m.runtimePod
+	return m.repoPath && m.sshd && m.mcpPort && m.sshPort && m.runtimePod
 }
 
 func matchesExpectedRepoPath(value, expected string) bool {

--- a/erun-common/init_remote.go
+++ b/erun-common/init_remote.go
@@ -126,14 +126,13 @@ func remoteRepositoryEnvConfig(envName, kubernetesContext, projectRoot string) E
 }
 
 func (s bootstrapRunner) remoteRepositoryLocalPorts(tenant, envName string) EnvironmentLocalPorts {
-	ports := DefaultEnvironmentLocalPorts()
 	portStore, ok := s.Store.(environmentPortStore)
 	if !ok {
-		return ports
+		return EnvironmentLocalPorts{}
 	}
 	resolved, err := ResolveEnvironmentLocalPorts(portStore, tenant, envName)
 	if err != nil {
-		return ports
+		return EnvironmentLocalPorts{}
 	}
 	return resolved
 }

--- a/erun-common/list.go
+++ b/erun-common/list.go
@@ -228,10 +228,6 @@ func APIURLForListEnvironment(tenant TenantConfig, localPorts EnvironmentLocalPo
 
 func listEnvironmentLocalPorts(tenant string, env EnvConfig, portAllocations map[string]EnvironmentLocalPorts) EnvironmentLocalPorts {
 	localPorts := portAllocations[environmentPortKey(tenant, env.Name)]
-	if localPorts.RangeStart != 0 {
-		return localPorts
-	}
-	localPorts = DefaultEnvironmentLocalPorts()
 	if env.SSHD.LocalPort > 0 {
 		localPorts.SSH = env.SSHD.LocalPort
 	}

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -192,6 +192,38 @@ func ResolveOpen(store OpenStore, params OpenParams) (OpenResult, error) {
 	return resolveOpenWithFinder(store, FindProjectRoot, params)
 }
 
+// EnsureLocalPortRangePersisted freezes the resolver's choice for this env
+// into its config so future opens are stable against alphabetical reshuffles
+// of unrelated tenants/envs. It is a no-op when the env already declares a
+// LocalPortRangeStart. In dry-run mode the assignment is traced but not
+// written to disk. The persisted EnvConfig is returned via the OpenResult so
+// callers can continue using it for the rest of the open flow.
+func EnsureLocalPortRangePersisted(ctx Context, saveEnvConfig func(string, EnvConfig) error, result OpenResult) (OpenResult, error) {
+	if result.EnvConfig.LocalPortRangeStart > 0 {
+		return result, nil
+	}
+	rangeStart := result.LocalPorts.RangeStart
+	if rangeStart == 0 {
+		return result, fmt.Errorf("local port range is not resolved for %s/%s", result.Tenant, result.Environment)
+	}
+	updated := result.EnvConfig
+	updated.LocalPortRangeStart = rangeStart
+	if ctx.DryRun {
+		ctx.Trace(fmt.Sprintf("config: would assign localportrangestart=%d to %s/%s", rangeStart, result.Tenant, result.Environment))
+		result.EnvConfig = updated
+		return result, nil
+	}
+	if saveEnvConfig == nil {
+		return result, fmt.Errorf("persist local port range: env config storage is not wired")
+	}
+	if err := saveEnvConfig(result.Tenant, updated); err != nil {
+		return result, fmt.Errorf("persist local port range: %w", err)
+	}
+	ctx.Trace(fmt.Sprintf("config: assigned localportrangestart=%d to %s/%s", rangeStart, result.Tenant, result.Environment))
+	result.EnvConfig = updated
+	return result, nil
+}
+
 func resolveOpenWithFinder(store OpenStore, findProjectRoot ProjectFinderFunc, params OpenParams) (OpenResult, error) {
 	if store == nil {
 		return OpenResult{}, fmt.Errorf("store is required")

--- a/erun-common/ports.go
+++ b/erun-common/ports.go
@@ -32,28 +32,64 @@ type environmentPortStore interface {
 	ListEnvConfigs(string) ([]EnvConfig, error)
 }
 
+// ErrLocalPortRangeOverlap is returned when two envs persist the same
+// LocalPortRangeStart. Surfacing the conflict is preferred over silent
+// reassignment because the persisted value is the durable user-visible
+// contract and either of the two configs must be edited to resolve it.
+type ErrLocalPortRangeOverlap struct {
+	A          string
+	B          string
+	RangeStart int
+}
+
+func (e ErrLocalPortRangeOverlap) Error() string {
+	return fmt.Sprintf("local port range start %d is claimed by both %s and %s; edit localportrangestart in one of the env configs to resolve", e.RangeStart, e.A, e.B)
+}
+
 func ServicePort(offset int) int {
 	return LowerServicePort + offset
 }
 
-func DefaultEnvironmentLocalPorts() EnvironmentLocalPorts {
-	ports, _ := environmentLocalPortsForIndex(0, EnvConfig{})
-	return ports
+// EnvironmentLocalPortsFromRangeStart derives the per-service ports from a
+// persisted range start. Callers should prefer this over assembling the
+// struct piecemeal so the offsets stay in one place.
+func EnvironmentLocalPortsFromRangeStart(rangeStart int) EnvironmentLocalPorts {
+	if rangeStart <= 0 {
+		return EnvironmentLocalPorts{}
+	}
+	return EnvironmentLocalPorts{
+		RangeStart: rangeStart,
+		RangeEnd:   rangeStart + EnvironmentPortRangeSize - 1,
+		MCP:        rangeStart + MCPServicePortOffset,
+		API:        rangeStart + APIServicePortOffset,
+		SSH:        rangeStart + SSHServicePortOffset,
+	}
 }
 
+// LocalPortsForResult derives the effective local ports for an OpenResult.
+// It prefers the persisted EnvConfig.LocalPortRangeStart over the resolver's
+// in-memory allocation so the result is stable regardless of how many other
+// envs exist. If neither is set it returns a zero value — callers that
+// actually need to bind a port will fail loudly on port 0, which is the
+// intended signal: a missing range is a bug upstream, not a default.
 func LocalPortsForResult(result OpenResult) EnvironmentLocalPorts {
-	ports := result.LocalPorts
-	if ports.RangeStart == 0 || ports.RangeEnd == 0 {
-		ports = DefaultEnvironmentLocalPorts()
+	var ports EnvironmentLocalPorts
+	switch {
+	case result.EnvConfig.LocalPortRangeStart > 0:
+		ports = EnvironmentLocalPortsFromRangeStart(result.EnvConfig.LocalPortRangeStart)
+	case result.LocalPorts.RangeStart > 0:
+		ports = result.LocalPorts
 	}
-	if ports.MCP == 0 {
-		ports.MCP = ports.RangeStart + MCPServicePortOffset
-	}
-	if ports.API == 0 {
-		ports.API = ports.RangeStart + APIServicePortOffset
-	}
-	if ports.SSH == 0 {
-		ports.SSH = ports.RangeStart + SSHServicePortOffset
+	if ports.RangeStart > 0 {
+		if ports.MCP == 0 {
+			ports.MCP = ports.RangeStart + MCPServicePortOffset
+		}
+		if ports.API == 0 {
+			ports.API = ports.RangeStart + APIServicePortOffset
+		}
+		if ports.SSH == 0 {
+			ports.SSH = ports.RangeStart + SSHServicePortOffset
+		}
 	}
 	if result.EnvConfig.SSHD.LocalPort > 0 {
 		ports.SSH = result.EnvConfig.SSHD.LocalPort
@@ -73,6 +109,13 @@ func SSHLocalPortForResult(result OpenResult) int {
 	return LocalPortsForResult(result).SSH
 }
 
+// ResolveAllEnvironmentLocalPorts returns a per-env port allocation in two
+// passes. Pass A locks in any env whose config has a non-zero
+// LocalPortRangeStart at its declared range. Pass B walks the remaining envs
+// in alphabetical (tenant, env) order, picking the lowest index not already
+// claimed by Pass A. Two persisted envs that share a range start cause an
+// ErrLocalPortRangeOverlap so the misconfiguration is surfaced instead of
+// silently reassigned.
 func ResolveAllEnvironmentLocalPorts(store environmentPortStore) (map[string]EnvironmentLocalPorts, error) {
 	if store == nil {
 		return nil, fmt.Errorf("store is required")
@@ -86,14 +129,16 @@ func ResolveAllEnvironmentLocalPorts(store environmentPortStore) (map[string]Env
 		return strings.TrimSpace(tenants[i].Name) < strings.TrimSpace(tenants[j].Name)
 	})
 
-	allocations := make(map[string]EnvironmentLocalPorts)
-	index := 0
+	type envRef struct {
+		key string
+		env EnvConfig
+	}
+	var persisted, unpersisted []envRef
 	for _, tenant := range tenants {
 		tenantName := strings.TrimSpace(tenant.Name)
 		if tenantName == "" {
 			continue
 		}
-
 		envs, err := store.ListEnvConfigs(tenantName)
 		if err != nil {
 			return nil, err
@@ -101,20 +146,54 @@ func ResolveAllEnvironmentLocalPorts(store environmentPortStore) (map[string]Env
 		sort.Slice(envs, func(i, j int) bool {
 			return strings.TrimSpace(envs[i].Name) < strings.TrimSpace(envs[j].Name)
 		})
-
 		for _, env := range envs {
 			environmentName := strings.TrimSpace(env.Name)
 			if environmentName == "" {
 				continue
 			}
-
-			ports, err := environmentLocalPortsForIndex(index, env)
-			if err != nil {
-				return nil, err
+			ref := envRef{key: environmentPortKey(tenantName, environmentName), env: env}
+			if env.LocalPortRangeStart > 0 {
+				persisted = append(persisted, ref)
+			} else {
+				unpersisted = append(unpersisted, ref)
 			}
-			allocations[environmentPortKey(tenantName, environmentName)] = ports
-			index++
 		}
+	}
+
+	allocations := make(map[string]EnvironmentLocalPorts, len(persisted)+len(unpersisted))
+	claimedByIndex := make(map[int]string, len(persisted)+len(unpersisted))
+
+	for _, ref := range persisted {
+		index, err := environmentPortIndexForRangeStart(ref.env.LocalPortRangeStart, ref.key)
+		if err != nil {
+			return nil, err
+		}
+		if other, dup := claimedByIndex[index]; dup {
+			return nil, ErrLocalPortRangeOverlap{A: other, B: ref.key, RangeStart: ref.env.LocalPortRangeStart}
+		}
+		ports, err := environmentLocalPortsForIndex(index, ref.env)
+		if err != nil {
+			return nil, err
+		}
+		claimedByIndex[index] = ref.key
+		allocations[ref.key] = ports
+	}
+
+	walkerIndex := 0
+	for _, ref := range unpersisted {
+		for {
+			if _, claimed := claimedByIndex[walkerIndex]; !claimed {
+				break
+			}
+			walkerIndex++
+		}
+		ports, err := environmentLocalPortsForIndex(walkerIndex, ref.env)
+		if err != nil {
+			return nil, err
+		}
+		claimedByIndex[walkerIndex] = ref.key
+		allocations[ref.key] = ports
+		walkerIndex++
 	}
 
 	return allocations, nil
@@ -134,18 +213,18 @@ func ResolveEnvironmentLocalPorts(store environmentPortStore, tenant, environmen
 }
 
 func environmentLocalPortsForTarget(store OpenStore, tenant string, env EnvConfig) (EnvironmentLocalPorts, error) {
-	if portStore, ok := store.(environmentPortStore); ok {
-		ports, err := ResolveEnvironmentLocalPorts(portStore, tenant, env.Name)
-		if err != nil {
-			return EnvironmentLocalPorts{}, err
-		}
-		if env.SSHD.LocalPort > 0 {
-			ports.SSH = env.SSHD.LocalPort
-		}
-		return ports, nil
+	portStore, ok := store.(environmentPortStore)
+	if !ok {
+		return EnvironmentLocalPorts{}, fmt.Errorf("local port range cannot be resolved without tenant/environment listing for %s/%s", strings.TrimSpace(tenant), strings.TrimSpace(env.Name))
 	}
-
-	ports := DefaultEnvironmentLocalPorts()
+	// Always go through the two-pass resolver, even when env already has a
+	// persisted range start: the resolver is what catches cross-tenant
+	// overlap between two persisted envs, and skipping it for the
+	// already-persisted env would let the conflict slip through silently.
+	ports, err := ResolveEnvironmentLocalPorts(portStore, tenant, env.Name)
+	if err != nil {
+		return EnvironmentLocalPorts{}, err
+	}
 	if env.SSHD.LocalPort > 0 {
 		ports.SSH = env.SSHD.LocalPort
 	}
@@ -177,6 +256,17 @@ func environmentLocalPortsForIndex(index int, env EnvConfig) (EnvironmentLocalPo
 		ports.SSH = env.SSHD.LocalPort
 	}
 	return ports, nil
+}
+
+func environmentPortIndexForRangeStart(rangeStart int, ownerKey string) (int, error) {
+	if rangeStart < LowerServicePort {
+		return 0, fmt.Errorf("local port range start %d for %s is below %d", rangeStart, ownerKey, LowerServicePort)
+	}
+	offset := rangeStart - LowerServicePort
+	if offset%EnvironmentPortRangeSize != 0 {
+		return 0, fmt.Errorf("local port range start %d for %s is not aligned to %d-port boundaries from %d", rangeStart, ownerKey, EnvironmentPortRangeSize, LowerServicePort)
+	}
+	return offset / EnvironmentPortRangeSize, nil
 }
 
 func environmentPortKey(tenant, environment string) string {

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -569,7 +569,6 @@ type KubectlDeployedStubSpec struct {
 	RepoPath       string
 	SSHDEnabled    bool
 	MCPPort        int
-	APIPort        int
 	SSHPort        int
 }
 
@@ -592,8 +591,8 @@ func StubKubectlDeployed(t testing.TB, stubsDir string, spec KubectlDeployedStub
 	}
 	portsim := PortSimBinary(t)
 	pidFile := filepath.Join(stubsDir, "portsim-pids")
-	deploymentJSON := fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"name":%q,"env":[{"name":"ERUN_REPO_PATH","value":%q},{"name":"ERUN_SSHD_ENABLED","value":%q},{"name":"ERUN_MCP_PORT","value":"%d"},{"name":"ERUN_API_PORT","value":"%d"},{"name":"ERUN_SSHD_PORT","value":"%d"}],"resources":{"limits":{}}}]}}}}`,
-		spec.ContainerName, spec.RepoPath, formatStubBool(spec.SSHDEnabled), spec.MCPPort, spec.APIPort, spec.SSHPort)
+	deploymentJSON := fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"name":%q,"env":[{"name":"ERUN_REPO_PATH","value":%q},{"name":"ERUN_SSHD_ENABLED","value":%q},{"name":"ERUN_MCP_PORT","value":"%d"},{"name":"ERUN_SSHD_PORT","value":"%d"}],"resources":{"limits":{}}}]}}}}`,
+		spec.ContainerName, spec.RepoPath, formatStubBool(spec.SSHDEnabled), spec.MCPPort, spec.SSHPort)
 	script := strings.Join([]string{
 		// Find the local port in `port-forward ... LOCAL:REMOTE [...]` argv.
 		// Production passes the mapping as a single positional after the

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -56,6 +56,70 @@ func SeedTenantEnv(t testing.TB, setup env.Setup, tenant, environment string) {
 	)
 }
 
+// SeedTenantEnvWithLocalPortRangeStart writes the same minimal config tree
+// as SeedTenantEnv but persists a fixed localportrangestart on the env
+// config so commands that key off EnvConfig.LocalPortRangeStart (notably
+// `erun open`) exercise the persisted-range branch instead of the resolver's
+// alphabetical walker.
+func SeedTenantEnvWithLocalPortRangeStart(t testing.TB, setup env.Setup, tenant, environment string, rangeStart int) {
+	t.Helper()
+	root := filepath.Join(setup.ConfigHome, "erun")
+	tenantDir := filepath.Join(root, tenant)
+	envDir := filepath.Join(tenantDir, environment)
+	for _, dir := range []string{root, tenantDir, envDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	mustWrite(t, filepath.Join(root, "config.yaml"), "defaulttenant: "+tenant+"\n")
+	mustWrite(t, filepath.Join(tenantDir, "config.yaml"),
+		"projectroot: "+setup.Cwd+"\n"+
+			"name: "+tenant+"\n"+
+			"defaultenvironment: "+environment+"\n",
+	)
+	mustWrite(t, filepath.Join(envDir, "config.yaml"),
+		"name: "+environment+"\n"+
+			"repopath: "+setup.Cwd+"\n"+
+			"kubernetescontext: test-context\n"+
+			"containerregistry: registry.example/test\n"+
+			"runtimeversion: 1.0.0\n"+
+			"localportrangestart: "+strconv.Itoa(rangeStart)+"\n",
+	)
+}
+
+// SeedSecondaryTenantEnv writes a second tenant/env into an already-seeded
+// XDG tree so resolver scenarios can exercise cross-tenant interactions
+// (walker skip, overlap detection) without overwriting the primary tenant.
+// Callers may set rangeStart > 0 to persist localportrangestart on the
+// secondary env; pass 0 to leave it unpersisted.
+func SeedSecondaryTenantEnv(t testing.TB, setup env.Setup, tenant, environment string, rangeStart int) {
+	t.Helper()
+	root := filepath.Join(setup.ConfigHome, "erun")
+	tenantDir := filepath.Join(root, tenant)
+	envDir := filepath.Join(tenantDir, environment)
+	for _, dir := range []string{root, tenantDir, envDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	mustWrite(t, filepath.Join(tenantDir, "config.yaml"),
+		"projectroot: "+setup.Cwd+"\n"+
+			"name: "+tenant+"\n"+
+			"defaultenvironment: "+environment+"\n",
+	)
+	envContents := "name: " + environment + "\n" +
+		"repopath: " + setup.Cwd + "\n" +
+		"kubernetescontext: test-context\n" +
+		"containerregistry: registry.example/test\n" +
+		"runtimeversion: 1.0.0\n"
+	if rangeStart > 0 {
+		envContents += "localportrangestart: " + strconv.Itoa(rangeStart) + "\n"
+	}
+	mustWrite(t, filepath.Join(envDir, "config.yaml"), envContents)
+}
+
 // SeedTenantEnvWithSnapshot writes the same minimal config tree as
 // SeedTenantEnv but persists snapshot=<enabled> on the env config so
 // commands that key off EnvConfig.SnapshotEnabled() (notably `erun open`)

--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -308,7 +308,6 @@ func TestOpen(t *testing.T) {
 			RepoPath:       "/home/erun/git/team",
 			SSHDEnabled:    true,
 			MCPPort:        17000,
-			APIPort:        17033,
 			SSHPort:        17022,
 		})...)
 		fixture.StubBinary(t, stubsDir, "ssh-keyscan", "[127.0.0.1]:17022 ssh-ed25519 AAAATESTKEY=")
@@ -360,7 +359,6 @@ func TestOpen(t *testing.T) {
 			RepoPath:       "/home/erun/git/team",
 			SSHDEnabled:    true,
 			MCPPort:        17000,
-			APIPort:        17033,
 			SSHPort:        17022,
 		})...)
 		fixture.StubBinary(t, stubsDir, "ssh-keyscan", "[127.0.0.1]:17022 ssh-ed25519 AAAAINTELLIJKEY=")
@@ -562,5 +560,29 @@ func TestOpen(t *testing.T) {
 		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		golden.Equal(t, "open/refuses_to_bind_when_foreign_process_holds_port", normalize.Apply(result.Combined))
 	})
+
+	t.Run("deployment_match_ignores_missing_api_port", func(t *testing.T) {
+		// Regression for the --intellij short-circuit on tenant-owned
+		// devops charts. The runtime-pod identity matcher must accept a
+		// deployment whose containers expose ERUN_REPO_PATH,
+		// ERUN_SSHD_ENABLED, ERUN_MCP_PORT, and ERUN_SSHD_PORT but not
+		// ERUN_API_PORT — the erun-api service is a separate deployment
+		// with its own port-forward path, so the runtime pod legitimately
+		// omits that env var. Without the fix, every open against a
+		// tenant chart predating ERUN_API_PORT would be flagged as "not
+		// deployed" and either redeploy unnecessarily (shell flow) or
+		// hard-error (--intellij / --vscode flow).
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		stubsDir := filepath.Join(setup.Cwd, "stubs")
+		envVars := append(setup.Env(), fixture.StubKubectlDeployed(t, stubsDir, fixture.KubectlDeployedStubSpec{
+			DeploymentName: "team-devops",
+			ContainerName:  "team-devops",
+			RepoPath:       "/home/erun/git/team",
+			MCPPort:        17000,
+			SSHPort:        17022,
+		})...)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/deployment_match_ignores_missing_api_port", normalize.Apply(result.Combined))
 
 }

--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -582,7 +582,14 @@ func TestOpen(t *testing.T) {
 			MCPPort:        17000,
 			SSHPort:        17022,
 		})...)
+		// Keep the adopt-or-conflict probe silent: this scenario is about
+		// the deployment-match path, not orphan adoption, and we don't
+		// want the developer's host state to leak a "would refuse" line
+		// into the golden when port 17000 is in use locally.
+		stubLsofNoHolder(t, stubsDir)
+		envVars = append(envVars, fixture.StubEnv(stubsDir, "lsof", "ps")...)
 		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		golden.Equal(t, "open/deployment_match_ignores_missing_api_port", normalize.Apply(result.Combined))
+	})
 
 }

--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -57,7 +57,49 @@ func stubKubectlNotFound(t *testing.T, setup env.Setup) []string {
 		Stderr:   `Error from server (NotFound): deployments.apps "team-devops" not found`,
 		ExitCode: 1,
 	})
-	return append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+	stubLsofNoHolder(t, stubs)
+	return append(setup.Env(), fixture.StubEnv(stubs, "kubectl", "lsof", "ps")...)
+}
+
+// stubAdoptHolderProbes overwrites the lsof + ps stubs that
+// stubKubectlNotFound installed with versions that present a fake port
+// holder for one specific TCP port. The lsof stub returns holderPID only
+// when the queried -iTCP:<port> matches holderPort; for every other port
+// it exits 1 (no holder), so the API/SSHD probes for sibling ports stay
+// silent. The ps stub returns the configured argv only for holderPID.
+//
+// Returns nothing — the env vars are already wired by the kubectl helper
+// because the two stubs live in the same directory.
+func stubAdoptHolderProbes(t *testing.T, setup env.Setup, holderPID, holderPort int, holderArgv string) {
+	t.Helper()
+	stubs := setup.Cwd + "/stubs"
+	lsofScript := fmt.Sprintf(`for arg in "$@"; do
+    case "$arg" in
+        -iTCP:%d) printf '%%s\n' '%d'; exit 0 ;;
+    esac
+done
+exit 1
+`, holderPort, holderPID)
+	fixture.StubBinaryWithScript(t, stubs, "lsof", lsofScript)
+	psScript := fmt.Sprintf(`pid=
+prev=
+for arg in "$@"; do
+    if [ "$prev" = "-p" ]; then
+        pid="$arg"
+    fi
+    prev="$arg"
+done
+if [ "$pid" = "%d" ]; then
+    printf '%%s\n' %s
+    exit 0
+fi
+exit 1
+`, holderPID, shellQuote(holderArgv))
+	fixture.StubBinaryWithScript(t, stubs, "ps", psScript)
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
 }
 
 // stubKubectlGenericError writes a kubectl stub that exits non-zero with a
@@ -72,7 +114,24 @@ func stubKubectlGenericError(t *testing.T, setup env.Setup) []string {
 		Stderr:   `Unable to connect to the server: dial tcp 10.0.0.1:443: i/o timeout`,
 		ExitCode: 2,
 	})
-	return append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+	stubLsofNoHolder(t, stubs)
+	return append(setup.Env(), fixture.StubEnv(stubs, "kubectl", "lsof", "ps")...)
+}
+
+// stubLsofNoHolder writes lsof + ps stubs that report no holder for any
+// queried port. Integration scenarios that don't intentionally drive the
+// adopt-or-conflict probe install these stubs to keep the probe silent and
+// the resulting golden host-independent: without them, a developer with a
+// leftover `kubectl port-forward` on one of erun's default ports causes
+// the probe to fire mid-scenario and corrupt the captured trace.
+func stubLsofNoHolder(t *testing.T, stubsDir string) {
+	t.Helper()
+	fixture.StubBinaryAdvanced(t, stubsDir, "lsof", fixture.StubBinarySpec{
+		ExitCode: 1,
+	})
+	fixture.StubBinaryAdvanced(t, stubsDir, "ps", fixture.StubBinarySpec{
+		ExitCode: 1,
+	})
 }
 
 func TestOpen(t *testing.T) {
@@ -471,6 +530,37 @@ func TestOpen(t *testing.T) {
 		envVars := stubKubectlNotFound(t, setup)
 		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		golden.Equal(t, "open/misaligned_persisted_range_fails_with_pointer", normalize.Apply(result.Combined))
+	})
+
+	t.Run("adopts_existing_kubectl_port_forward", func(t *testing.T) {
+		// Regression for the orphan-kubectl-can't-adopt failure: when the
+		// per-env state file is missing but a long-lived `kubectl
+		// port-forward` is already serving the env's MCP port, erun must
+		// recognise the holder as its own and reuse it instead of erroring
+		// with "already in use". The probe runs in dry-run too, so we lock
+		// the decision in the golden via the "would adopt" trace.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		envVars := stubKubectlNotFound(t, setup)
+		stubAdoptHolderProbes(t, setup, 99999, 17000,
+			"kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address 127.0.0.1")
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/adopts_existing_kubectl_port_forward", normalize.Apply(result.Combined))
+	})
+
+	t.Run("refuses_to_bind_when_foreign_process_holds_port", func(t *testing.T) {
+		// When the port is held by a process whose argv does not look like
+		// the kubectl port-forward erun would start, adoption is unsafe.
+		// erun must trace what is holding the port (PID + argv) so the
+		// user sees what to kill, instead of the bare "already in use"
+		// message that gave nothing actionable in the prior UI loop.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		envVars := stubKubectlNotFound(t, setup)
+		stubAdoptHolderProbes(t, setup, 88888, 17000,
+			"/usr/local/bin/some-foreign-process --bind 127.0.0.1:17000")
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/refuses_to_bind_when_foreign_process_holds_port", normalize.Apply(result.Combined))
 	})
 
 }

--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -416,4 +416,61 @@ func TestOpen(t *testing.T) {
 		golden.Equal(t, "open/remote_runtime_image_override", normalize.Apply(result.Combined))
 	})
 
+	t.Run("persisted_local_port_range_is_honoured", func(t *testing.T) {
+		// EnvConfig.LocalPortRangeStart is the durable per-env port
+		// contract. When it is already set on disk, open must derive every
+		// service port from it (MCP 17500, API 17533, SSH 17522) and must
+		// not emit the "config: would assign" trace. Locks the early-return
+		// in EnsureLocalPortRangePersisted (open.go::common helper).
+		setup := env.New(t)
+		fixture.SeedTenantEnvWithLocalPortRangeStart(t, setup, "team", "dev", 17500)
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/persisted_local_port_range_is_honoured", normalize.Apply(result.Combined))
+	})
+
+	t.Run("walker_skips_index_claimed_by_other_tenant", func(t *testing.T) {
+		// When a second env on the host has already persisted
+		// localportrangestart=17000, the alphabetical walker must skip
+		// that index when allocating an unpersisted env. team/dev sorts
+		// before other/staging but the persisted claim wins, so team/dev
+		// resolves to 17100 and the dry-run trace records the would-be
+		// assignment. Locks the cross-tenant claim-respect branch in
+		// ResolveAllEnvironmentLocalPorts.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedSecondaryTenantEnv(t, setup, "other", "staging", 17000)
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/walker_skips_index_claimed_by_other_tenant", normalize.Apply(result.Combined))
+	})
+
+	t.Run("overlapping_persisted_ranges_fail_with_pointer", func(t *testing.T) {
+		// Two envs that persist the same localportrangestart must surface
+		// an ErrLocalPortRangeOverlap pointing at both. The CLI should
+		// fail with a non-zero exit and a message naming both envs and the
+		// range, instead of silently re-allocating one of them. Locks the
+		// overlap path in ResolveAllEnvironmentLocalPorts.
+		setup := env.New(t)
+		fixture.SeedTenantEnvWithLocalPortRangeStart(t, setup, "team", "dev", 17000)
+		fixture.SeedSecondaryTenantEnv(t, setup, "other", "staging", 17000)
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/overlapping_persisted_ranges_fail_with_pointer", normalize.Apply(result.Combined))
+	})
+
+	t.Run("misaligned_persisted_range_fails_with_pointer", func(t *testing.T) {
+		// localportrangestart must align to EnvironmentPortRangeSize=100
+		// boundaries from LowerServicePort=17000. A value like 17050
+		// would make MCP/API/SSH offsets bleed into another env's range,
+		// so the resolver refuses with a clear alignment error instead of
+		// accepting it. Locks environmentPortIndexForRangeStart's
+		// validation branch.
+		setup := env.New(t)
+		fixture.SeedTenantEnvWithLocalPortRangeStart(t, setup, "team", "dev", 17050)
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/misaligned_persisted_range_fails_with_pointer", normalize.Apply(result.Combined))
+	})
+
 }

--- a/erun-integration/testdata/open/adopts_existing_kubectl_port_forward.txt
+++ b/erun-integration/testdata/open/adopts_existing_kubectl_port_forward.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 deploying the devops runtime before opening the shell

--- a/erun-integration/testdata/open/adopts_existing_kubectl_port_forward.txt
+++ b/erun-integration/testdata/open/adopts_existing_kubectl_port_forward.txt
@@ -1,0 +1,20 @@
+kubectl config use-context 'test-context' >/dev/null &&
+kubectl config set-context --current --namespace='team-dev' >/dev/null &&
+cd '<TMP>'
+audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+deploying the devops runtime before opening the shell
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)
+mcp: would adopt existing kubectl port-forward on <LOOPBACK>:17000 (PID 99999)
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <LOOPBACK>
+open: --no-shell selected, emitting setup commands instead of launching shell
+kubectl config use-context test-context
+kubectl config set-context --current --namespace=team-dev
+cd <TMP>

--- a/erun-integration/testdata/open/default_tenant_environment_resolves_from_root_config.txt
+++ b/erun-integration/testdata/open/default_tenant_environment_resolves_from_root_config.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 deploying the devops runtime before opening the shell

--- a/erun-integration/testdata/open/deployment_match_ignores_missing_api_port.txt
+++ b/erun-integration/testdata/open/deployment_match_ignores_missing_api_port.txt
@@ -1,0 +1,14 @@
+kubectl config use-context 'test-context' >/dev/null &&
+kubectl config set-context --current --namespace='team-dev' >/dev/null &&
+cd '<TMP>'
+audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=true ide=shell
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+kubectl --context test-context --namespace team-dev get deployment team-devops -o json
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <LOOPBACK>
+open: --no-shell selected, emitting setup commands instead of launching shell
+kubectl config use-context test-context
+kubectl config set-context --current --namespace=team-dev
+cd <TMP>

--- a/erun-integration/testdata/open/deployment_match_ignores_missing_api_port.txt
+++ b/erun-integration/testdata/open/deployment_match_ignores_missing_api_port.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 kubectl --context test-context --namespace team-dev get deployment team-devops -o json

--- a/erun-integration/testdata/open/environment_positional_resolves_default_tenant.txt
+++ b/erun-integration/testdata/open/environment_positional_resolves_default_tenant.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 deploying the devops runtime before opening the shell

--- a/erun-integration/testdata/open/intellij_dry_run.txt
+++ b/erun-integration/testdata/open/intellij_dry_run.txt
@@ -6,6 +6,7 @@ SSH:
   key: none
   workspace: <HOME>/git/team
 audit: erun open --dry-run --intellij team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=false ide=intellij
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 open: dry-run: would deploy runtime for team/dev before launching IntelliJ IDEA; in real mode the user must run `erun sshd init team dev` or `erun open team dev` first

--- a/erun-integration/testdata/open/intellij_without_sshd_errors_with_guidance.txt
+++ b/erun-integration/testdata/open/intellij_without_sshd_errors_with_guidance.txt
@@ -1,3 +1,4 @@
 audit: erun open --dry-run --intellij team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=false ide=intellij
 --intellij requires sshd-enabled remote environment; run `erun sshd init team dev` first

--- a/erun-integration/testdata/open/kubectl_error_assumes_not_deployed.txt
+++ b/erun-integration/testdata/open/kubectl_error_assumes_not_deployed.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 open: dry-run: kubernetes deployment check failed (failed to check deployment "team-devops": exit status 2), assuming not deployed

--- a/erun-integration/testdata/open/misaligned_persisted_range_fails_with_pointer.txt
+++ b/erun-integration/testdata/open/misaligned_persisted_range_fails_with_pointer.txt
@@ -1,0 +1,2 @@
+audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+local port range start 17050 for team/dev is not aligned to 100-port boundaries from 17000

--- a/erun-integration/testdata/open/no_shell_dry_run.txt
+++ b/erun-integration/testdata/open/no_shell_dry_run.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 deploying the devops runtime before opening the shell

--- a/erun-integration/testdata/open/no_snapshot_skips_local_build.txt
+++ b/erun-integration/testdata/open/no_snapshot_skips_local_build.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-local' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell --no-snapshot team local
+config: would assign localportrangestart=17000 to team/local
 open: tenant=team environment=local kubernetes-context=test-context remote=false no-shell=true ide=shell
 kubectl --context test-context --namespace team-local get deployment team-devops -o name
 deploying the devops runtime before opening the shell

--- a/erun-integration/testdata/open/overlapping_persisted_ranges_fail_with_pointer.txt
+++ b/erun-integration/testdata/open/overlapping_persisted_ranges_fail_with_pointer.txt
@@ -1,0 +1,2 @@
+audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+local port range start 17000 is claimed by both other/staging and team/dev; edit localportrangestart in one of the env configs to resolve

--- a/erun-integration/testdata/open/persisted_local_port_range_is_honoured.txt
+++ b/erun-integration/testdata/open/persisted_local_port_range_is_honoured.txt
@@ -1,0 +1,20 @@
+kubectl config use-context 'test-context' >/dev/null &&
+kubectl config set-context --current --namespace='team-dev' >/dev/null &&
+cd '<TMP>'
+audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+deploying the devops runtime before opening the shell
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17500 --set apiPort=17533 --set sshPort=17522 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17500:17500 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17533:17533 --address <LOOPBACK>
+open: --no-shell selected, emitting setup commands instead of launching shell
+kubectl config use-context test-context
+kubectl config set-context --current --namespace=team-dev
+cd <TMP>

--- a/erun-integration/testdata/open/refuses_to_bind_when_foreign_process_holds_port.txt
+++ b/erun-integration/testdata/open/refuses_to_bind_when_foreign_process_holds_port.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 deploying the devops runtime before opening the shell

--- a/erun-integration/testdata/open/refuses_to_bind_when_foreign_process_holds_port.txt
+++ b/erun-integration/testdata/open/refuses_to_bind_when_foreign_process_holds_port.txt
@@ -1,0 +1,21 @@
+kubectl config use-context 'test-context' >/dev/null &&
+kubectl config set-context --current --namespace='team-dev' >/dev/null &&
+cd '<TMP>'
+audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+deploying the devops runtime before opening the shell
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <LOOPBACK>
+mcp: would refuse to bind <LOOPBACK>:17000 — held by PID 88888: /usr/local/bin/some-foreign-process --bind <LOOPBACK>:17000
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <LOOPBACK>
+open: --no-shell selected, emitting setup commands instead of launching shell
+kubectl config use-context test-context
+kubectl config set-context --current --namespace=team-dev
+cd <TMP>

--- a/erun-integration/testdata/open/remote_dry_run_traces_port_forwards.txt
+++ b/erun-integration/testdata/open/remote_dry_run_traces_port_forwards.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 deploying the devops runtime before opening the shell

--- a/erun-integration/testdata/open/remote_runtime_image_override.txt
+++ b/erun-integration/testdata/open/remote_runtime_image_override.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell --runtime-image ghcr.io/example/custom-runtime team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=true ide=shell
 deploying the devops runtime before opening the shell
 kubectl --context test-context get namespace team-dev -o name

--- a/erun-integration/testdata/open/runtime_image_override_uses_default_chart.txt
+++ b/erun-integration/testdata/open/runtime_image_override_uses_default_chart.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell --runtime-image ghcr.io/example/custom-runtime team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 deploying the devops runtime before opening the shell
 kubectl --context test-context get namespace team-dev -o name

--- a/erun-integration/testdata/open/snapshot_env_config_drives_local_build.txt
+++ b/erun-integration/testdata/open/snapshot_env_config_drives_local_build.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-local' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell team local
+config: would assign localportrangestart=17000 to team/local
 open: tenant=team environment=local kubernetes-context=test-context remote=false no-shell=true ide=shell
 deploying the devops runtime before opening the shell
 docker image inspect ghcr.io/sophium/team-devops:fp-<HEX16>-amd64

--- a/erun-integration/testdata/open/tenant_flag_only_resolves_default_env.txt
+++ b/erun-integration/testdata/open/tenant_flag_only_resolves_default_env.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell --tenant team
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 deploying the devops runtime before opening the shell

--- a/erun-integration/testdata/open/version_override_skips_local_build.txt
+++ b/erun-integration/testdata/open/version_override_skips_local_build.txt
@@ -2,6 +2,7 @@ kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
 audit: erun open --dry-run --no-alias-prompt --no-shell --version <VERSION> team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
 deploying the devops runtime before opening the shell
 kubectl --context test-context get namespace team-dev -o name

--- a/erun-integration/testdata/open/vscode_dry_run.txt
+++ b/erun-integration/testdata/open/vscode_dry_run.txt
@@ -6,6 +6,7 @@ SSH:
   key: none
   workspace: <HOME>/git/team
 audit: erun open --dry-run --vscode team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=false ide=vscode
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 open: dry-run: would deploy runtime for team/dev before launching VS Code; in real mode the user must run `erun sshd init team dev` or `erun open team dev` first

--- a/erun-integration/testdata/open/vscode_without_sshd_errors_with_guidance.txt
+++ b/erun-integration/testdata/open/vscode_without_sshd_errors_with_guidance.txt
@@ -1,3 +1,4 @@
 audit: erun open --dry-run --vscode team dev
+config: would assign localportrangestart=17000 to team/dev
 open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=false ide=vscode
 --vscode requires sshd-enabled remote environment; run `erun sshd init team dev` first

--- a/erun-integration/testdata/open/walker_skips_index_claimed_by_other_tenant.txt
+++ b/erun-integration/testdata/open/walker_skips_index_claimed_by_other_tenant.txt
@@ -1,0 +1,21 @@
+kubectl config use-context 'test-context' >/dev/null &&
+kubectl config set-context --current --namespace='team-dev' >/dev/null &&
+cd '<TMP>'
+audit: erun open --dry-run --no-alias-prompt --no-shell team dev
+config: would assign localportrangestart=17100 to team/dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=true ide=shell
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+deploying the devops runtime before opening the shell
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17100 --set apiPort=17133 --set sshPort=17122 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17100:17100 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17133:17133 --address <LOOPBACK>
+open: --no-shell selected, emitting setup commands instead of launching shell
+kubectl config use-context test-context
+kubectl config set-context --current --namespace=team-dev
+cd <TMP>


### PR DESCRIPTION
## Summary

Consolidates three open PRs into one so the port-forward fixes ship together:

- **#312 — Persist per-env local port range.** \`EnvConfig.LocalPortRangeStart\` is written to the env config on first open; the resolver becomes a two-pass build (claim persisted ranges first, walker fills the rest, overlap errors instead of silent re-allocation). Drops the four silent \`DefaultEnvironmentLocalPorts()\` fallbacks that landed every alphabetically-non-first env on port 17000.
- **#314 — Adopt foreign kubectl port-forward when argv matches.** Move per-PF state from \`os.UserCacheDir()\` to \`os.UserConfigDir()\` (migrates legacy state). When the local port is held and the recorded state doesn't match, probe the holder via \`lsof\` + \`ps\`; if its argv is a \`kubectl port-forward\` for the same target, claim the PID and reuse the forward. Otherwise the "already in use" error is enriched with the holder's PID and argv. Same probe runs in dry-run as a \`would adopt\` / \`would refuse to bind\` trace.
- **#316 — Drop \`ERUN_API_PORT\` from the runtime-pod identity check.** Tenant-owned devops charts legitimately omit it (the \`erun-api\` deployment is separate, with its own port-forward and presence check). The matcher no longer demands it, so \`erun open --intellij\` against tenant charts stops short-circuiting with "requires updating the runtime deployment" when the runtime is already healthy.

## Why consolidate

The three branches build on each other in practice — together they unblock the screenshot the user kept hitting:

1. After persisting per-env ranges, future envs no longer reshuffle into port 17000 on alphabetical changes.
2. Adoption handles the immediate "PID 50796 / PID 41266 / PID 44082 is still on the port" without requiring a manual kill.
3. The API-port matcher fix removes the last unrelated reason \`--intellij\` would refuse to open an already-deployed env.

Landing them as one PR avoids the rebase-and-stack dance and means the user only has to rebuild local \`erun\` once.

## Commit structure

\`\`\`
d3e49b1 Persist per-env local port range so it does not depend on alphabetical order
c0e2b14 Adopt foreign kubectl port-forward when argv matches expected target
34a9415 Drop ERUN_API_PORT from runtime-pod identity check
5d199c1 Consolidate fixes: resolve test conflicts and re-record affected goldens
\`\`\`

The fourth commit is purely cherry-pick conflict resolution (both prior commits appended a t.Run to the same anchor in \`open_test.go\`) plus host-isolation: the deployment-match scenario gains explicit \`lsof\` / \`ps\` no-holder stubs so a developer running erun locally cannot leak a "would refuse to bind" line into the golden, and three goldens re-record to include the new \`config: would assign localportrangestart=...\` trace.

## Test plan

- [x] \`go test ./...\` in \`erun-common\`, \`erun-cli\`, \`erun-mcp\`, \`erun-ui\` — all green.
- [x] \`go test ./...\` in \`erun-integration/\` — all scenarios green.
- [x] Seven new integration scenarios cover the new branches:
  - \`open/persisted_local_port_range_is_honoured\`
  - \`open/walker_skips_index_claimed_by_other_tenant\`
  - \`open/overlapping_persisted_ranges_fail_with_pointer\`
  - \`open/misaligned_persisted_range_fails_with_pointer\`
  - \`open/adopts_existing_kubectl_port_forward\`
  - \`open/refuses_to_bind_when_foreign_process_holds_port\`
  - \`open/deployment_match_ignores_missing_api_port\`

## Known unrelated red

\`scripts/integration-test.sh\` enforces a 90% coverage threshold; \`main\` is already at ~55%. This bundle nudges coverage up by ~1pp from the new scenarios but does not bring the gate back to green. Tracked separately from this PR.

Closes #312
Closes #314
Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)