### PR TITLE
Scale review panel max width with viewport

### DIFF
--- a/erun-ui/frontend/src/app/ERunUIController.ts
+++ b/erun-ui/frontend/src/app/ERunUIController.ts
@@ -68,10 +68,10 @@ import { isNewSessionSelection } from './sessionSelection';
 import {
   MAX_DEBUG_HEIGHT,
   MAX_FILES_WIDTH,
-  MAX_REVIEW_WIDTH,
   MIN_DEBUG_HEIGHT,
   MIN_FILES_WIDTH,
   MIN_REVIEW_WIDTH,
+  computeMaxReviewWidth,
   defaultEnvironmentDialog,
   defaultGlobalConfigDialog,
   defaultManageDialog,
@@ -2192,9 +2192,9 @@ export class ERunUIController {
   }
 
   private clampedReviewWidth(): number {
-    const paneWidth = this.terminalPane?.getBoundingClientRect().width || 0;
-    const maxReviewForPane = paneWidth > 0 ? paneWidth - 370 : MAX_REVIEW_WIDTH;
-    return clamp(this.state.reviewWidth, MIN_REVIEW_WIDTH, Math.max(MIN_REVIEW_WIDTH, Math.min(MAX_REVIEW_WIDTH, maxReviewForPane)));
+    const effectiveSidebar = this.state.sidebarHidden ? 0 : this.state.sidebarWidth;
+    const maxWidth = computeMaxReviewWidth(window.innerWidth, effectiveSidebar);
+    return clamp(this.state.reviewWidth, MIN_REVIEW_WIDTH, maxWidth);
   }
 
   private clampedFilesWidth(): number {

--- a/erun-ui/frontend/src/app/layoutActions.ts
+++ b/erun-ui/frontend/src/app/layoutActions.ts
@@ -6,7 +6,6 @@ import {
   FILES_WIDTH_STORAGE_KEY,
   MAX_DEBUG_HEIGHT,
   MAX_FILES_WIDTH,
-  MAX_REVIEW_WIDTH,
   MAX_SIDEBAR_WIDTH,
   MIN_DEBUG_HEIGHT,
   MIN_FILES_WIDTH,
@@ -14,6 +13,7 @@ import {
   MIN_SIDEBAR_WIDTH,
   REVIEW_WIDTH_STORAGE_KEY,
   SIDEBAR_WIDTH_STORAGE_KEY,
+  computeMaxReviewWidth,
   type AppState,
 } from './state';
 import { clamp, saveBoolean, saveNumber } from './storage';
@@ -68,7 +68,9 @@ export function startReviewResize(state: AppState, event: React.MouseEvent<HTMLE
     if (!paneRect) {
       return;
     }
-    state.reviewWidth = clamp(paneRect.right - moveEvent.clientX, MIN_REVIEW_WIDTH, MAX_REVIEW_WIDTH);
+    const effectiveSidebar = state.sidebarHidden ? 0 : state.sidebarWidth;
+    const maxWidth = computeMaxReviewWidth(window.innerWidth, effectiveSidebar);
+    state.reviewWidth = clamp(paneRect.right - moveEvent.clientX, MIN_REVIEW_WIDTH, maxWidth);
     callbacks.applyLayoutVars();
     callbacks.emit();
     callbacks.queueTerminalResize();

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -19,8 +19,15 @@ export const MIN_SIDEBAR_WIDTH = 248;
 export const MAX_SIDEBAR_WIDTH = 520;
 export const DEFAULT_SIDEBAR_WIDTH = 338;
 export const MIN_REVIEW_WIDTH = 420;
-export const MAX_REVIEW_WIDTH = 920;
+export const MAX_REVIEW_WIDTH = 1400;
 export const DEFAULT_REVIEW_WIDTH = 620;
+const REVIEW_GRID_TERMINAL_MIN_WIDTH = 360;
+const REVIEW_GRID_DIVIDER_WIDTH = 10;
+
+export function computeMaxReviewWidth(viewportWidth: number, effectiveSidebarWidth: number): number {
+  const fittable = viewportWidth - effectiveSidebarWidth - REVIEW_GRID_TERMINAL_MIN_WIDTH - REVIEW_GRID_DIVIDER_WIDTH;
+  return Math.max(MIN_REVIEW_WIDTH, Math.min(MAX_REVIEW_WIDTH, fittable));
+}
 export const MIN_FILES_WIDTH = 220;
 export const MAX_FILES_WIDTH = 460;
 export const DEFAULT_FILES_WIDTH = 300;


### PR DESCRIPTION
## Summary
- Replaces the hardcoded 920px max width on the desktop review panel with a viewport-aware maximum so the panel can use available space on wide displays.
- New `computeMaxReviewWidth(viewportWidth, effectiveSidebarWidth)` helper bounds the max by the absolute readability cap (1400px) and by what fits after the sidebar, terminal-pane minimum (360px), and divider (10px). The drag handler and `clampedReviewWidth()` both use it, so dragging and window resizes stay in sync.
- The previous `clampedReviewWidth()` clamped against `paneWidth - 370`, where `paneWidth` is the terminal pane (coupled to the review width) — not a stable bound. The new calculation reads viewport and sidebar directly, which are independent of the panel being sized.

Effective ceilings:
- 1920px display: ~1302px
- 2560px display: 1400px (absolute cap)
- 1280px display: ~662px

## Test plan
- [x] `yarn build` in `erun-ui/frontend`
- [x] `yarn shadcn:check` in `erun-ui/frontend`
- [x] `go test ./...` in `erun-ui`
- [ ] Visually verify in the running app: drag the review divider on a wide monitor, confirm it now extends past 920px up to the new ceiling
- [ ] Shrink the window after widening — panel should re-clamp without breaking layout

Closes #319