### PR TITLE
Reconcile terminal session with selected env via listener middleware

### DIFF
--- a/erun-ui/frontend/src/app/middleware/selectionSyncMiddleware.ts
+++ b/erun-ui/frontend/src/app/middleware/selectionSyncMiddleware.ts
@@ -1,0 +1,57 @@
+import { createListenerMiddleware } from '@reduxjs/toolkit';
+
+import { setSelected } from '../slices/selectionSlice';
+import { setSessionId } from '../slices/terminalSlice';
+import type { AppDispatch, RootState } from '../store';
+import { selectionKey } from '../versionSuggestions';
+
+// selectionSyncMiddleware reconciles state.terminal.sessionId with the
+// currently selected env every time state.selection.selected changes.
+//
+// Without this, paths that dispatch setSelected without going through
+// openSelection (boot persistence rehydrate, startInitSelection,
+// startDeploySelection, manageHiddenSessionThunks, error rollbacks, the
+// "click-the-already-selected-env" no-op in prepareOpenSelection) leave
+// the terminal pointing at whatever session was previously visible —
+// which can be a completely different env's PTY. The sidebar then shows
+// env A as selected while the terminal renders env B's prompt and
+// content, and input typed by the user is sent to the wrong PTY.
+//
+// The reconcile follows the same rule the explicit surfaceEnvSession
+// helper in sessionThunks uses on the spawn path: if the current session
+// already belongs to the new env's tab list, leave it alone; otherwise
+// pick the remembered tab if it still exists, else any Local tab, else 0
+// (the display middleware translates that into resetTerminal()).
+export const selectionSyncMiddleware = createListenerMiddleware();
+
+const startListening = selectionSyncMiddleware.startListening.withTypes<RootState, AppDispatch>();
+
+startListening({
+  actionCreator: setSelected,
+  effect: (_action, listenerApi) => {
+    const state = listenerApi.getState();
+    const next = reconcileSessionForSelection(state);
+    if (next === state.terminal.sessionId) {
+      return;
+    }
+    listenerApi.dispatch(setSessionId(next));
+  },
+});
+
+function reconcileSessionForSelection(state: RootState): number {
+  const selected = state.selection.selected;
+  if (!selected) {
+    return 0;
+  }
+  const key = selectionKey(selected);
+  const tabs = state.terminal.tabsByEnv[key] ?? [];
+  const currentSessionId = state.terminal.sessionId;
+  if (currentSessionId > 0 && tabs.some((tab) => tab.sessionId === currentSessionId)) {
+    return currentSessionId;
+  }
+  const remembered = state.terminal.selectedSessionByEnv[key] ?? 0;
+  if (tabs.some((tab) => tab.sessionId === remembered)) {
+    return remembered;
+  }
+  return tabs.find((tab) => tab.kind === 'local')?.sessionId ?? 0;
+}

--- a/erun-ui/frontend/src/app/sessionThunks.ts
+++ b/erun-ui/frontend/src/app/sessionThunks.ts
@@ -205,16 +205,13 @@ const prepareOpenSelection =
       dispatch(setSelectedReviewScope('current'));
       dispatch(setSelectedReviewCommit(''));
       dispatch(setSelectedDiffPath(''));
-      // Detach the terminal from the previous env's PTY immediately.
-      // Without this the visible terminal keeps painting the old env's
-      // output (and accepting input on the wrong session) until the new
-      // env's slower StartSession returns and registerOpenSessionResult
-      // calls setSessionId. surfaceEnvSession below tries to repoint at
-      // whatever the new env already has (remembered tab or a live
-      // Local), and falls back to 0 so the terminal goes quiet for the
-      // gap rather than lying.
-      dispatch(surfaceEnvSession(newKey));
     }
+    // setSelected is observed by selectionSyncMiddleware, which reconciles
+    // state.terminal.sessionId with the new env's tabs in the same tick.
+    // Every setSelected dispatch — including re-clicks where newKey ===
+    // previousKey but the terminal happens to point at a stale session
+    // from another env — flows through the listener, so no caller has to
+    // remember to pair setSelected with a manual surface.
     dispatch(setSelected(selection));
     dispatch(setIdleStatus(null));
     if (!isNewSessionSelection(previousSessionId, previousKnownSessionId)) {

--- a/erun-ui/frontend/src/app/store.ts
+++ b/erun-ui/frontend/src/app/store.ts
@@ -15,6 +15,7 @@ import { setupListeners } from '@reduxjs/toolkit/query';
 
 import { wailsApi } from './api/wailsApi';
 import { persistenceMiddleware } from './middleware/persistenceMiddleware';
+import { selectionSyncMiddleware } from './middleware/selectionSyncMiddleware';
 import { terminalDisplayMiddleware } from './middleware/terminalDisplayMiddleware';
 import activityReducer from './slices/activitySlice';
 import autoStartPromptReducer from './slices/autoStartPromptSlice';
@@ -69,6 +70,7 @@ export const store = configureStore({
     })
       .concat(wailsApi.middleware)
       .concat(persistenceMiddleware.middleware)
+      .concat(selectionSyncMiddleware.middleware)
       .concat(terminalDisplayMiddleware.middleware),
 });
 


### PR DESCRIPTION
## Summary

After #331's H-fix added \`surfaceEnvSession\` inside \`prepareOpenSelection\`, the terminal still desynced from the sidebar through any setSelected path that did not go through that thunk (boot rehydrate, startInitSelection, startDeploySelection, manageHiddenSessionThunks, error rollbacks). Re-clicking the already-selected env also skipped the repoint because the \`newKey !== previousKey\` guard short-circuited.

This PR makes the repoint a derived effect: a new \`selectionSyncMiddleware\` listens on \`setSelected\` and reconciles \`state.terminal.sessionId\` with the selected env's tab list in one place. Every code path that mutates the selection now flows through the same repoint, so the sidebar and terminal cannot drift again.

Closes #333.

## Test plan

- [x] \`yarn typecheck && yarn lint && yarn format:check && yarn build\` in erun-ui/frontend
- [x] \`./playwright/run.sh\` — 15/15 (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)