### PR TITLE
Strip xterm DSR/OSC response echoes and refresh idle status on selection change

### DIFF
--- a/erun-ui/frontend/src/app/middleware/selectionSyncMiddleware.ts
+++ b/erun-ui/frontend/src/app/middleware/selectionSyncMiddleware.ts
@@ -1,8 +1,10 @@
 import { createListenerMiddleware } from '@reduxjs/toolkit';
 
+import { refreshIdleStatus } from '../idleThunks';
 import { setSelected } from '../slices/selectionSlice';
 import { setSessionId } from '../slices/terminalSlice';
 import type { AppDispatch, RootState } from '../store';
+import { thunkExtra } from '../thunkExtra';
 import { selectionKey } from '../versionSuggestions';
 
 // selectionSyncMiddleware reconciles state.terminal.sessionId with the
@@ -31,10 +33,17 @@ startListening({
   effect: (_action, listenerApi) => {
     const state = listenerApi.getState();
     const next = reconcileSessionForSelection(state);
-    if (next === state.terminal.sessionId) {
-      return;
+    if (next !== state.terminal.sessionId) {
+      listenerApi.dispatch(setSessionId(next));
     }
-    listenerApi.dispatch(setSessionId(next));
+    // Fire an immediate idle-status refresh so the titlebar Play button
+    // (and any other UI gated on idleStatus) reflects the new env within
+    // ~50 ms instead of waiting up to the next 1 s polling tick. Without
+    // this, clicking a stopped remote env left the user with no visible
+    // Start affordance for almost a full second.
+    if (thunkExtra.controller) {
+      void listenerApi.dispatch(refreshIdleStatus());
+    }
   },
 });
 

--- a/erun-ui/frontend/src/app/terminalBuffers.ts
+++ b/erun-ui/frontend/src/app/terminalBuffers.ts
@@ -30,11 +30,46 @@ export function rebuildTerminalDisplayBuffer(
   sessions.replaceDisplayBuffer(sessionId, displayBuffer);
 }
 
+// Strip xterm DSR / OSC query *responses* that leak into the displayed
+// output. A tool inside the PTY sends a query (e.g. CPR `\x1b[6n`, or
+// OSC 11 background-color query); xterm answers via onData; the answer
+// lands in the PTY's stdin, the shell echoes it as if the user typed it,
+// and the echo comes back through the output stream as visible gibberish
+// like `^[[51;1R` or `^[]11;rgb:0000/0000/0000^[\`. Stripping the
+// response patterns at the display boundary keeps the visible buffer
+// clean without changing what the tools see.
+const TERMINAL_RESPONSE_PATTERNS: RegExp[] = [
+  // CSI Cursor Position Report response: ESC [ row ; col R
+  /\x1B\[\d+;\d+R/g,
+  // CSI Device Status Report response: ESC [ <n> n  (e.g. 0n)
+  /\x1B\[\d+n/g,
+  // OSC 10/11 (foreground / background color) responses terminated by
+  // ST (ESC \) or BEL (0x07).
+  /\x1B\](?:10|11);rgb:[0-9a-fA-F/]+(?:\x1B\\|\x07)/g,
+  // Primary Device Attributes / Secondary Device Attributes responses
+  // (CSI ? <params> c)
+  /\x1B\[\?[\d;]+c/g,
+];
+
+function stripTerminalResponses(input: Uint8Array): Uint8Array {
+  const decoder = new TextDecoder();
+  const text = decoder.decode(input);
+  let cleaned = text;
+  for (const pattern of TERMINAL_RESPONSE_PATTERNS) {
+    cleaned = cleaned.replace(pattern, '');
+  }
+  if (cleaned === text) {
+    return input;
+  }
+  return new TextEncoder().encode(cleaned);
+}
+
 export function filterTerminalDisplayData(
   sessions: TerminalSessionRegistry,
   sessionId: number,
   data: Uint8Array,
 ): TerminalWriteData | null {
+  data = stripTerminalResponses(data);
   const debugMode = sessions.debugMode(sessionId);
   if (!debugMode) {
     return data;


### PR DESCRIPTION
## Summary

- Filter CPR, generic DSR, OSC 10/11 color reports, and Primary Device Attributes response patterns out of the displayed buffer in \`filterTerminalDisplayData\`. Tools still see their own DSR responses on the PTY side; only the visible echo is suppressed.
- \`selectionSyncMiddleware\` now also dispatches \`refreshIdleStatus()\` on every \`setSelected\`, so the titlebar Start button appears within ~50 ms of clicking a stopped remote env instead of waiting up to the next 1 s polling tick.

Closes #335.

## Test plan

- [x] \`yarn typecheck && yarn lint && yarn format:check && yarn build\` in erun-ui/frontend
- [x] \`./playwright/run.sh\` — 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)