### PR TITLE
Normalize ~/.ssh key permissions on every container start

### DIFF
--- a/erun-common/doctor_remote_init.go
+++ b/erun-common/doctor_remote_init.go
@@ -544,10 +544,16 @@ func finishRemoteInitCodeCommitSSHConfig(ctx Context, homeDir string, repository
 // 0644 on the public key. ssh silently refuses to use a private key
 // that is group- or world-accessible ("WARNING: UNPROTECTED PRIVATE
 // KEY FILE!" → bad permissions → key ignored), and runtime pods on
-// shared PVCs often persist files with permissive group bits because
-// of fsGroup or a non-077 umask. Init's chmod is best-effort and can
-// be reset by the storage layer between runs, so doctor re-applies the
-// expected mode every time it touches the key.
+// shared PVCs persist files with permissive group bits because the
+// chart's fsGroup makes kubelet re-OR g+rw into every PVC file on
+// each pod start. Init's chmod is therefore best-effort and gets
+// reset between runs, so doctor re-applies the expected mode every
+// time it touches the key. The runtime image's entrypoint also walks
+// ~/.ssh on container start (normalize_ssh_key_permissions in
+// erun-devops/docker/erun-devops/entrypoint.sh), so a freshly
+// restarted pod heals its own permissions before any tool tries to
+// read the key — this function stays as a belt-and-braces guarantee
+// for the doctor recovery path.
 func ensureRemoteInitSSHKeyPermissions(path string) error {
 	if err := os.Chmod(path, 0o600); err != nil {
 		if os.IsNotExist(err) {

--- a/erun-devops/docker/erun-devops/entrypoint.sh
+++ b/erun-devops/docker/erun-devops/entrypoint.sh
@@ -616,6 +616,21 @@ EOF
     mv "${tmp_bashrc}" "${bashrc_file}"
 }
 
+normalize_ssh_key_permissions() {
+    ssh_dir="${HOME}/.ssh"
+    [ -d "${ssh_dir}" ] || return 0
+    # Kubernetes' fsGroup recursively ORs g+rw into every PVC file on each
+    # pod start, so a private key that init left at 0600 comes back as 0660
+    # (and any file that ever picked up the user-x bit becomes 0760). ssh
+    # refuses to use a private key file whose perms are looser than 0600,
+    # so re-apply the canonical modes before anything tries to read them.
+    # *.pub files stay world-readable; everything else in ~/.ssh is treated
+    # as private — private keys, config, known_hosts, authorized_keys.
+    chmod 700 "${ssh_dir}" 2>/dev/null || true
+    find "${ssh_dir}" -mindepth 1 -maxdepth 1 -type f -name '*.pub' -exec chmod 644 {} + 2>/dev/null || true
+    find "${ssh_dir}" -mindepth 1 -maxdepth 1 -type f ! -name '*.pub' -exec chmod 600 {} + 2>/dev/null || true
+}
+
 start_sshd() {
     if ! runtime_sshd_enabled; then
         return
@@ -730,6 +745,7 @@ run_shell() {
 }
 
 write_kubeconfig
+normalize_ssh_key_permissions
 start_sshd
 start_environment_idle_monitor
 


### PR DESCRIPTION
## Summary

- New `normalize_ssh_key_permissions` in the runtime entrypoint runs on every container start, after kubelet's `fsGroup` pass, before `start_sshd`. Walks `~/.ssh` once: dir to `0700`, `*.pub` to `0644`, everything else (private keys, `config`, `known_hosts`, `authorized_keys`) to `0600`.
- Updated the `ensureRemoteInitSSHKeyPermissions` comment in `doctor_remote_init.go` to point at the new entrypoint backstop so the next reader sees both layers.

## Why

The chart pins `fsGroup: 1000` on the pod. Kubelet's default `fsGroupChangePolicy: Always` ORs `g+rw` into every PVC file on each pod start, so a key that init left at `0600` comes back as `0660` (or `0760` once anything sets the user-x bit). `ssh` refuses to use it. Doctor already chmod 600s on demand, but ordinary `erun open` does not touch private keys, so a fresh pod start with no doctor run leaves CodeCommit fetches broken.

## Test plan

- [x] `sh -n` clean on entrypoint.sh
- [x] Hand-run of the new logic against a tempdir with `id_rsa_codecommit` at `0760`, `config` at `0760`, and a `.pub` file → `0600 / 0600 / 0644` and dir stays `0700`
- [x] `go test ./...` in `erun-common` and `erun-integration` still green
- [ ] After the next devops image bump, redeploy a remote env that previously hit `Permissions 0760` and confirm `ssh -G git-codecommit.eu-west-1.amazonaws.com` works and `git fetch` succeeds without manual chmod

Closes #343