### PR TITLE
Recover from transient idle-stop failures and clear stale stop errors

### DIFF
--- a/erun-common/sshd_test.go
+++ b/erun-common/sshd_test.go
@@ -291,9 +291,10 @@ func TestRuntimeEntrypointStopsCloudHostAfterIdle(t *testing.T) {
 		"stop_cloud_host()",
 		`runtime_cloud_instance_id()`,
 		`runtime_cloud_region()`,
+		`AWS_MAX_ATTEMPTS=5 AWS_RETRY_MODE=standard`,
 		`aws --cli-connect-timeout 5 --cli-read-timeout 20 ec2 stop-instances --region "${region}" --instance-ids "${instance_id}"`,
 		`graceful_quit_clients >>"${stop_log}" 2>&1 || true`,
-		`stop_cloud_host >>"${stop_log}" 2>&1 || true`,
+		`if stop_cloud_host >>"${stop_log}" 2>&1; then`,
 		`stop_log_dir="${HOME}/.erun/${ERUN_TENANT}/${ERUN_ENVIRONMENT}"`,
 		`stop_log="${stop_log_dir}/idle-stop.log"`,
 		`monitor_log="${stop_log_dir}/idle-monitor.log"`,
@@ -314,9 +315,31 @@ func TestRuntimeEntrypointStopsCloudHostAfterIdle(t *testing.T) {
 		t.Fatalf("expected runtime entrypoint to no longer scale the deployment to 0 before EC2 stop, got:\n%s", content)
 	}
 	gracefulIdx := strings.Index(content, `graceful_quit_clients >>"${stop_log}"`)
-	stopIdx := strings.Index(content, `stop_cloud_host >>"${stop_log}"`)
+	stopIdx := strings.Index(content, `if stop_cloud_host >>"${stop_log}"`)
 	if gracefulIdx < 0 || stopIdx < 0 || gracefulIdx > stopIdx {
 		t.Fatalf("expected graceful_quit_clients to run before stop_cloud_host, got graceful=%d stop=%d", gracefulIdx, stopIdx)
+	}
+	// Pre-fix shape (one stop attempt then exit 0 regardless of outcome)
+	// must be gone, or a transient AWS failure would permanently kill the
+	// monitor and leave the env unable to auto-stop until pod restart.
+	if strings.Contains(content, `stop_cloud_host >>"${stop_log}" 2>&1 || true`) {
+		t.Fatalf("expected stop_cloud_host failure to keep the idle monitor loop alive instead of being swallowed with || true, got:\n%s", content)
+	}
+}
+
+func TestRuntimeEntrypointIdleStopLogIsTruncatedNotAppended(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "erun-devops", "docker", "erun-devops", "entrypoint.sh"))
+	if err != nil {
+		t.Fatalf("read runtime entrypoint: %v", err)
+	}
+	content := string(data)
+	// The log lives on the shared home PVC and would otherwise survive pod
+	// and host restarts, so the monitor must truncate it on start and
+	// before each stop attempt. Without this, the desktop surfaces stale
+	// errors from previous pod lifetimes as a current "stop failed" badge.
+	truncationCount := strings.Count(content, `: >"${stop_log}"`)
+	if truncationCount < 2 {
+		t.Fatalf("expected idle-stop.log to be truncated on monitor start and before each attempt (at least 2 `: >\"${stop_log}\"` lines), got %d:\n%s", truncationCount, content)
 	}
 }
 

--- a/erun-devops/docker/erun-devops/entrypoint.sh
+++ b/erun-devops/docker/erun-devops/entrypoint.sh
@@ -148,7 +148,8 @@ stop_cloud_host() {
         return 1
     fi
 
-    aws --cli-connect-timeout 5 --cli-read-timeout 20 ec2 stop-instances --region "${region}" --instance-ids "${instance_id}" >/dev/null
+    AWS_MAX_ATTEMPTS=5 AWS_RETRY_MODE=standard \
+        aws --cli-connect-timeout 5 --cli-read-timeout 20 ec2 stop-instances --region "${region}" --instance-ids "${instance_id}" >/dev/null
 }
 
 graceful_quit_clients() {
@@ -711,7 +712,12 @@ start_environment_idle_monitor() {
     (
         stop_log_dir="${HOME}/.erun/${ERUN_TENANT}/${ERUN_ENVIRONMENT}"
         monitor_log="${stop_log_dir}/idle-monitor.log"
+        stop_log="${stop_log_dir}/idle-stop.log"
         mkdir -p "${stop_log_dir}"
+        # idle-stop.log lives on the shared home PVC and survives pod and
+        # host restarts. Clear it on monitor start so the desktop never
+        # surfaces a stop error attributable to a previous pod lifetime.
+        : >"${stop_log}"
         while :; do
             sleep 30
             tick_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -726,10 +732,17 @@ start_environment_idle_monitor() {
             fi
             printf '{"ts":"%s","exit":%d,"check":%s}\n' "${tick_ts}" "${exit_code}" "${check_json:-null}" >>"${monitor_log}"
             if [ "${exit_code}" -eq 0 ]; then
-                stop_log="${stop_log_dir}/idle-stop.log"
+                # Reset the log each attempt so it reflects only the latest
+                # one — empty on success, the most recent error on failure.
+                : >"${stop_log}"
                 graceful_quit_clients >>"${stop_log}" 2>&1 || true
-                stop_cloud_host >>"${stop_log}" 2>&1 || true
-                exit 0
+                if stop_cloud_host >>"${stop_log}" 2>&1; then
+                    exit 0
+                fi
+                # A transient AWS failure (e.g. RequestExpired) leaves the
+                # loop running; the next tick re-checks stop-ready and
+                # retries. The error stays in idle-stop.log for the desktop
+                # to surface until the next attempt overwrites it.
             fi
         done
     ) &

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -3539,6 +3539,104 @@ func TestMaybeStopIdleClearsStaleIdleStopWhenContextIsRunningAgain(t *testing.T)
 	}
 }
 
+func TestIdleStatusToUIClearsStopErrorWhenContextIsRunning(t *testing.T) {
+	// idle-stop.log lives on the pod's home PVC and survives pod and host
+	// restarts. The runtime entrypoint truncates it on monitor start, but a
+	// freshly-restarted env can still surface a poll-window racing the
+	// truncate. The desktop guards against the stale error by suppressing
+	// StopError whenever the linked cloud context is observably running —
+	// a "stop failed" badge next to a healthy env is always wrong.
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		config: &eruncommon.ERunConfig{
+			CloudContexts: []eruncommon.CloudContextConfig{{
+				Name:              "managed-cloud",
+				KubernetesContext: "cluster-cloud",
+			}},
+		},
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", ProjectRoot: projectRoot, DefaultEnvironment: "remote"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {
+				Name:              "remote",
+				RepoPath:          projectRoot,
+				KubernetesContext: "cluster-cloud",
+				Remote:            true,
+				ManagedCloud:      true,
+			},
+		},
+	}
+	app := NewApp(erunUIDeps{store: store})
+	defer app.shutdown(context.Background())
+	app.setCloudContextStatusInCache("managed-cloud", eruncommon.CloudContextStatusRunning)
+
+	result, err := eruncommon.ResolveOpen(store, eruncommon.OpenParams{Tenant: "erun", Environment: "remote"})
+	if err != nil {
+		t.Fatalf("ResolveOpen failed: %v", err)
+	}
+	ui := app.idleStatusToUI(result, eruncommon.EnvironmentIdleStatus{
+		ManagedCloud: true,
+		Policy:       eruncommon.EnvironmentIdlePolicy{Timeout: 5 * time.Minute},
+		StopError:    "An error occurred (RequestExpired) when calling the StopInstances operation: Request has expired.",
+	})
+
+	if ui.CloudContextStatus != eruncommon.CloudContextStatusRunning {
+		t.Fatalf("expected CloudContextStatus=%q, got %q", eruncommon.CloudContextStatusRunning, ui.CloudContextStatus)
+	}
+	if ui.StopError != "" {
+		t.Fatalf("expected StopError to be cleared when context is running, got %q", ui.StopError)
+	}
+}
+
+func TestIdleStatusToUIKeepsStopErrorWhenContextIsStopped(t *testing.T) {
+	// Counterpart to the running-context test: when the linked cloud
+	// context is not running, the stop error is still the desktop's only
+	// surface for telling the user "the last auto-stop failed", so the
+	// projection must pass it through unchanged.
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		config: &eruncommon.ERunConfig{
+			CloudContexts: []eruncommon.CloudContextConfig{{
+				Name:              "managed-cloud",
+				KubernetesContext: "cluster-cloud",
+			}},
+		},
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", ProjectRoot: projectRoot, DefaultEnvironment: "remote"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {
+				Name:              "remote",
+				RepoPath:          projectRoot,
+				KubernetesContext: "cluster-cloud",
+				Remote:            true,
+				ManagedCloud:      true,
+			},
+		},
+	}
+	app := NewApp(erunUIDeps{store: store})
+	defer app.shutdown(context.Background())
+	app.setCloudContextStatusInCache("managed-cloud", eruncommon.CloudContextStatusStopped)
+
+	result, err := eruncommon.ResolveOpen(store, eruncommon.OpenParams{Tenant: "erun", Environment: "remote"})
+	if err != nil {
+		t.Fatalf("ResolveOpen failed: %v", err)
+	}
+	ui := app.idleStatusToUI(result, eruncommon.EnvironmentIdleStatus{
+		ManagedCloud: true,
+		Policy:       eruncommon.EnvironmentIdlePolicy{Timeout: 5 * time.Minute},
+		StopError:    "An error occurred (RequestExpired) when calling the StopInstances operation: Request has expired.",
+	})
+
+	if ui.CloudContextStatus != eruncommon.CloudContextStatusStopped {
+		t.Fatalf("expected CloudContextStatus=%q, got %q", eruncommon.CloudContextStatusStopped, ui.CloudContextStatus)
+	}
+	if ui.StopError == "" {
+		t.Fatal("expected StopError to be preserved when context is stopped")
+	}
+}
+
 func TestStartSessionLogsOpenCommandToLocal(t *testing.T) {
 	projectRoot := t.TempDir()
 	store := stubUIStore{

--- a/erun-ui/idle_status.go
+++ b/erun-ui/idle_status.go
@@ -68,6 +68,12 @@ func (a *App) idleStatusToUI(result eruncommon.OpenResult, status eruncommon.Env
 	ui.CloudContextName = strings.TrimSpace(cloudContext.Name)
 	ui.CloudContextStatus = strings.TrimSpace(cloudContext.Status)
 	ui.CloudContextLabel = cloudContextDisplayName(cloudContext)
+	// idle-stop.log on the pod persists across pod and host restarts. If the
+	// context is observably running again, the recorded error is from a
+	// previous lifetime and should not be advertised next to a healthy env.
+	if ui.CloudContextStatus == eruncommon.CloudContextStatusRunning {
+		ui.StopError = ""
+	}
 	return ui
 }
 


### PR DESCRIPTION
## Summary

- Keep the in-pod idle monitor alive on a failed `aws ec2 stop-instances` so the next 30s tick retries instead of permanently disabling auto-stop after a single transient AWS error.
- Treat `idle-stop.log` as a state file, not an append log: truncate on monitor start and before each attempt so it only ever reflects the most recent attempt (empty on success, latest error on failure), including across pod and host restarts (the log lives on the home PVC).
- Pass `AWS_MAX_ATTEMPTS=5 AWS_RETRY_MODE=standard` to the stop call so the SDK has more headroom on transient signing failures.
- Desktop drops `StopError` from the idle status when the linked cloud context is observably running — a "stop failed" badge next to a healthy env was always wrong.

## Test plan

- [x] `go test ./...` in `erun-common` (covers the entrypoint shape contract)
- [x] `go test ./...` in `erun-ui` (covers the StopError suppression projection)
- [x] `go test -run 'TestList/help|TestList/empty_config|TestList/with_seeded_tenant_env|TestList/cwd_overrides_default_tenant|TestList/sshd_configured|TestList/with_claude_config|TestActivity|TestContext|TestDoctor|TestInit|TestVersion|TestOpen|TestDeploy|TestBuild|TestPush|TestRelease|TestStop|TestStart' ./erun-integration/...`
- [ ] Manual: seed `~/.erun/<tenant>/<env>/idle-stop.log` with a `RequestExpired` blob, open the env in the desktop, confirm the badge appears, then start the cloud context and confirm the badge clears on the next idle-status poll.

## Notes

- `make integration-test` from a clean `main` checkout currently fails on `TestList/multi_tenant_with_multiple_envs` (30s timeout) — preexisting flake, reproduced on `main` at `f606907` and unrelated to this branch. Tracked separately at #351.
- Out of scope: configuring Amazon Time Sync in the k3s user-data so newly-launched hosts stay clock-synced. That would help prevent the AWS `RequestExpired` root cause but only on new instances, so it belongs in a separate change. The fixes here make recovery work regardless of why an individual stop call fails.

Closes #350