### PR TITLE
Restore cursor when an unmatched DECTCEM hide leaks into the ERun tab

### DIFF
--- a/erun-ui/frontend/src/app/TerminalController.ts
+++ b/erun-ui/frontend/src/app/TerminalController.ts
@@ -38,7 +38,13 @@ import {
 } from './state';
 import { clamp } from './storage';
 import { store } from './store';
-import { filterTerminalDisplayData } from './terminalBuffers';
+import {
+  bufferCursorVisibility,
+  type CursorVisibilityState,
+  filterTerminalDisplayData,
+  scanCursorVisibility,
+  SHOW_CURSOR_SEQUENCE,
+} from './terminalBuffers';
 import { registerTerminalQueryResponseHandlers } from './terminalQueryResponses';
 import { TerminalSessionRegistry } from './TerminalSessionRegistry';
 import { decodeDebugOutput } from './terminalStatus';
@@ -82,6 +88,15 @@ export class TerminalController {
   private environmentsChangedOff: (() => void) | null = null;
   private aiActivityOff: (() => void) | null = null;
   private pasteHandler: ((event: ClipboardEvent) => void) | null = null;
+  // Track DECTCEM (`?25`) and alt-screen state across the bytes
+  // written to xterm for the active session. When the active session
+  // ends in "main screen + cursor hidden" with no further output, we
+  // restore `?25h` so an unmatched hide leaked by `erun open`, helm,
+  // kubectl, or a remote-side spinner doesn't strand the prompt with
+  // no visible cursor. Alt-screen TUIs are exempt by design.
+  private liveCursorState: CursorVisibilityState = { altScreen: false, cursorHidden: false };
+  private cursorRestoreTimer = 0;
+  private static readonly CURSOR_RESTORE_DELAY_MS = 250;
 
   constructor() {
     thunkExtra.controller = this;
@@ -266,6 +281,30 @@ export class TerminalController {
   resetTerminal(): void {
     this.terminal?.reset();
     this.terminal?.clear();
+    this.cancelCursorRestoreTimer();
+    this.liveCursorState = { altScreen: false, cursorHidden: false };
+  }
+
+  private cancelCursorRestoreTimer(): void {
+    if (this.cursorRestoreTimer !== 0) {
+      window.clearTimeout(this.cursorRestoreTimer);
+      this.cursorRestoreTimer = 0;
+    }
+  }
+
+  private scheduleCursorRestoreIfStuck(): void {
+    this.cancelCursorRestoreTimer();
+    if (this.liveCursorState.altScreen || !this.liveCursorState.cursorHidden) {
+      return;
+    }
+    this.cursorRestoreTimer = window.setTimeout(() => {
+      this.cursorRestoreTimer = 0;
+      if (this.liveCursorState.altScreen || !this.liveCursorState.cursorHidden) {
+        return;
+      }
+      this.terminal?.write(SHOW_CURSOR_SEQUENCE);
+      this.liveCursorState = { ...this.liveCursorState, cursorHidden: false };
+    }, TerminalController.CURSOR_RESTORE_DELAY_MS);
   }
 
   // handleTerminalOutput stays on the controller because it does the
@@ -287,6 +326,8 @@ export class TerminalController {
     }
     store.dispatch(hideTerminalMessageIfActive(payload.sessionId));
     this.terminal?.write(displayData);
+    this.liveCursorState = scanCursorVisibility(this.liveCursorState, displayData);
+    this.scheduleCursorRestoreIfStuck();
   }
 
   layoutCallbacks(): {
@@ -437,5 +478,13 @@ export class TerminalController {
     for (const chunk of chunks) {
       this.terminal?.write(chunk);
     }
+    // Rehydrate live cursor state from the replayed buffer.
+    // rebuildTerminalDisplayBuffer already appended `?25h` if the live
+    // state would have been "main + hidden", so under normal flow this
+    // ends at { altScreen: false, cursorHidden: false }. Scanning keeps
+    // the live tracking accurate when a TUI in alt-screen left the
+    // buffer in its own intentional state.
+    this.liveCursorState = bufferCursorVisibility(chunks);
+    this.cancelCursorRestoreTimer();
   }
 }

--- a/erun-ui/frontend/src/app/terminalBuffers.ts
+++ b/erun-ui/frontend/src/app/terminalBuffers.ts
@@ -27,6 +27,10 @@ export function rebuildTerminalDisplayBuffer(
       displayBuffer.push(displayData);
     }
   }
+  const finalState = bufferCursorVisibility(displayBuffer);
+  if (!finalState.altScreen && finalState.cursorHidden) {
+    displayBuffer.push(SHOW_CURSOR_SEQUENCE);
+  }
   sessions.replaceDisplayBuffer(sessionId, displayBuffer);
 }
 
@@ -60,6 +64,64 @@ function stripTerminalResponses(input: Uint8Array): Uint8Array {
     return input;
   }
   return new TextEncoder().encode(cleaned);
+}
+
+// Track DECTCEM (cursor visibility, `?25`) and alternate-screen
+// (`?47` / `?1047` / `?1049`) state across written bytes. The desktop
+// terminal is meant for shell interaction; a stuck `?25l` outside the
+// alt-screen (e.g. an unmatched hide leaked by a spinner inside
+// `erun open`, helm, kubectl, git over SSH, or the deploy pipeline)
+// surfaces as a missing cursor at the bash prompt. The replay path
+// uses scanCursorVisibility to detect that state and append a
+// well-formed `?25h` so the user sees a cursor again; live TUIs are
+// untouched because they sit inside the alternate screen.
+export interface CursorVisibilityState {
+  altScreen: boolean;
+  cursorHidden: boolean;
+}
+
+export const SHOW_CURSOR_SEQUENCE = '\x1B[?25h';
+
+const initialCursorVisibility: CursorVisibilityState = {
+  altScreen: false,
+  cursorHidden: false,
+};
+
+const DEC_PRIVATE_MODE = /\x1B\[\?([\d;]+)([lh])/g;
+const ALT_SCREEN_MODES = new Set(['47', '1047', '1049']);
+
+export function scanCursorVisibility(
+  prev: CursorVisibilityState,
+  data: TerminalWriteData,
+): CursorVisibilityState {
+  const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+  if (!text.includes('\x1B[?')) {
+    return prev;
+  }
+  let { altScreen, cursorHidden } = prev;
+  for (const match of text.matchAll(DEC_PRIVATE_MODE)) {
+    const set = match[2] === 'h';
+    const params = match[1] ?? '';
+    for (const param of params.split(';')) {
+      if (param === '25') {
+        cursorHidden = !set;
+      } else if (ALT_SCREEN_MODES.has(param)) {
+        altScreen = set;
+      }
+    }
+  }
+  if (altScreen === prev.altScreen && cursorHidden === prev.cursorHidden) {
+    return prev;
+  }
+  return { altScreen, cursorHidden };
+}
+
+export function bufferCursorVisibility(buffer: TerminalWriteData[]): CursorVisibilityState {
+  let state = initialCursorVisibility;
+  for (const chunk of buffer) {
+    state = scanCursorVisibility(state, chunk);
+  }
+  return state;
 }
 
 export function filterTerminalDisplayData(


### PR DESCRIPTION
## Summary
- Track DECTCEM (`?25`) and alternate-screen (`?47` / `?1047` / `?1049`) state across bytes written to xterm and emit `?25h` when the active session ends in "main screen + cursor hidden" with no further activity.
- Replay path (`rebuildTerminalDisplayBuffer`) appends `?25h` to the rebuilt buffer when the buffer's final state is main + hidden, so tab switches never reproduce a stuck hide.
- Live path (`TerminalController`) runs a 250 ms idle guard during live writes; alt-screen TUIs (vim/less/top) keep their hide, spinners that redraw faster than the guard keep resetting it.
- Closes #355.

## Background

The ERun tab could land at a bash prompt with no visible cursor — not even an unfocused outline — after `erun open` finished and dropped the user into the remote shell. The cause is an unmatched DECTCEM hide somewhere in the upstream byte stream (helm / kubectl / git-over-SSH / a spinner inside the deploy pipeline). Local and AI tabs were unaffected because they emit different sequences. The desktop terminal is meant for shell interaction; an unmatched `?25l` outside the alternate screen is treated here as a stuck state to correct.

## UX Impact Review

1. **Affected paths.** Per-session live-output handler (`handleTerminalOutput`) and the tab-switch replay (`terminalDisplayMiddleware` → `rebuildTerminalDisplayBuffer` / `writeTerminalBuffer`).
2. **User-visible sequence.** When the buffer / live stream would otherwise have left the cursor hidden at a shell prompt, the user now sees a blinking cursor either at tab switch (replay path) or 250 ms after the last byte (live path).
3. **State-without-affordance.** No new app-state mutations; the change is at the xterm byte-stream layer.
4. **Visibility of system status (Nielsen #1).** The cursor is the bash prompt's "ready to type" indicator. Restoring it directly fixes the missing status.
5. **Success and failure feedback (Nielsen #1, #9).** Restoring `?25h` does not interfere with any error/success messages; legitimate alt-screen TUIs (vim/less/top) keep their hide because alt-screen is tracked.
6. **Consistency with comparable flows (Nielsen #4).** Local and AI tabs already render a cursor at idle; ERun now matches.
7. **One-line heuristic pass.** Visibility-of-status: ✔ fixed. Match with user language: n/a. Consistency: ✔. Error prevention: ✔ (no destructive change). Recognition over recall: n/a. User control: ✔ (no new UI). Aesthetic/minimalist: ✔. Help users recover: ✔. Help and docs: n/a. Flexibility: n/a.
8. **Playwright coverage.** xterm renders the cursor on a `<canvas>` layer; cursor visibility is not observable from the headless DOM. The closest negative invariant the harness can reach is "switching tabs after `?25l` bytes does not crash", which is too weak to meaningfully lock the change in. The change is a pure byte-stream correction in two small functions (`scanCursorVisibility`, `bufferCursorVisibility`) plus a 250 ms idle guard in `TerminalController`; reviewers can verify by inspection. If we add a frontend unit-test framework (vitest), `scanCursorVisibility` is the natural first target.

## Test plan
- [x] `yarn typecheck` (frontend)
- [x] `yarn lint` (frontend)
- [x] `yarn format:check` (frontend, changed files)
- [ ] `yarn build` (blocked locally by a rolldown native-binding install issue; CI build will catch any regression)
- [ ] Manual: open a remote env, confirm cursor visible at the ERun tab's bash prompt; vim / less / top still hide the cursor while active and restore on exit.