### PR TITLE
Make root-config writes safe and add doctor recovery

### DIFF
--- a/erun-cli/cmd/doctor.go
+++ b/erun-cli/cmd/doctor.go
@@ -14,13 +14,15 @@ import (
 )
 
 type doctorOptions struct {
-	pruneImages            bool
-	pruneBuildCache        bool
-	pruneContainers        bool
-	repairJetBrainsGateway bool
-	finishRemoteInit       bool
-	remoteRepositoryURL    string
-	codeCommitSSHKeyID     string
+	pruneImages             bool
+	pruneBuildCache         bool
+	pruneContainers         bool
+	repairJetBrainsGateway  bool
+	repairConfig            bool
+	restoreConfigFromBackup string
+	finishRemoteInit        bool
+	remoteRepositoryURL     string
+	codeCommitSSHKeyID      string
 }
 
 type jetBrainsGatewayDoctorRepair struct {
@@ -30,7 +32,7 @@ type jetBrainsGatewayDoctorRepair struct {
 	idePath     string
 }
 
-func newDoctorCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), promptRunner PromptRunner) *cobra.Command {
+func newDoctorCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), configStore common.ConfigStore, cloudDeps common.CloudDependencies, promptRunner PromptRunner) *cobra.Command {
 	options := doctorOptions{}
 	cmd := &cobra.Command{
 		Use:           "doctor [tenant] [environment]",
@@ -39,7 +41,7 @@ func newDoctorCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error)
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDoctorCommand(commandContext(cmd), resolveOpen, promptRunner, options, args)
+			return runDoctorCommand(commandContext(cmd), resolveOpen, configStore, cloudDeps, promptRunner, options, args)
 		},
 	}
 	addDryRunFlag(cmd)
@@ -47,16 +49,36 @@ func newDoctorCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error)
 	cmd.Flags().BoolVar(&options.pruneBuildCache, "prune-build-cache", false, "Prune unused BuildKit cache without prompting")
 	cmd.Flags().BoolVar(&options.pruneContainers, "prune-containers", false, "Prune stopped Docker containers without prompting")
 	cmd.Flags().BoolVar(&options.repairJetBrainsGateway, "repair-jetbrains-gateway", false, "Clear cached JetBrains Gateway backend metadata for this environment")
+	cmd.Flags().BoolVar(&options.repairConfig, "repair-config", false, "Inspect the root erun config and offer to restore from backup or re-init orphaned cloud provider aliases; stops before running tenant/env cleanup actions")
+	cmd.Flags().StringVar(&options.restoreConfigFromBackup, "restore-config-from-backup", "", "Restore the root erun config from a dated backup non-interactively (YYYY-MM-DD or absolute path)")
 	cmd.Flags().BoolVar(&options.finishRemoteInit, "finish-remote-init", false, "Finish unfinished remote init tasks without prompting (only takes effect when run inside a runtime pod)")
 	cmd.Flags().StringVar(&options.remoteRepositoryURL, "remote-repository-url", "", "Git remote URL to use when finishing an unfinished remote init")
 	cmd.Flags().StringVar(&options.codeCommitSSHKeyID, "codecommit-ssh-key-id", "", "CodeCommit SSH public key ID to use when finishing an unfinished remote init for an AWS CodeCommit repository")
 	return cmd
 }
 
-func runDoctorCommand(ctx common.Context, resolveOpen func(common.OpenParams) (common.OpenResult, error), promptRunner PromptRunner, options doctorOptions, args []string) error {
+func runDoctorCommand(ctx common.Context, resolveOpen func(common.OpenParams) (common.OpenResult, error), configStore common.ConfigStore, cloudDeps common.CloudDependencies, promptRunner PromptRunner, options doctorOptions, args []string) error {
+	// In-runtime invocations target a different surface entirely
+	// (remote-init recovery), and the root config they would inspect
+	// lives on the user's host, not in the pod. Short-circuit before
+	// the host-side checks fire.
 	if common.IsInRuntimeEnvironment(os.Getenv) {
 		return runDoctorInRuntime(ctx, promptRunner, options)
 	}
+
+	// Run the root-config inspection before any tenant/env work so a
+	// broken root config (the failure mode that motivated this flow:
+	// missing CloudProviders blocking resolveOpen) does not prevent
+	// recovery. The repair path here writes via SaveERunConfig +
+	// InitAWSCloudProvider; resolveOpen below picks up the healed
+	// state.
+	if _, err := runRootConfigDoctor(ctx, configStore, cloudDeps, promptRunner, options); err != nil {
+		return err
+	}
+	if doctorOnlyRepairConfig(options) {
+		return nil
+	}
+
 	params, err := common.OpenParamsForArgs(args)
 	if err != nil {
 		return err
@@ -77,6 +99,20 @@ func runDoctorCommand(ctx common.Context, resolveOpen func(common.OpenParams) (c
 		return nil
 	}
 	return runDoctorCleanupActions(ctx, promptRunner, result, options)
+}
+
+// doctorOnlyRepairConfig mirrors doctorOnlySelectedJetBrainsGatewayRepair:
+// when the only repair-style flag set is --repair-config (or
+// --restore-config-from-backup), the doctor flow should stop after
+// the root-config work instead of also attempting tenant/env cleanup.
+func doctorOnlyRepairConfig(options doctorOptions) bool {
+	repairOnly := options.repairConfig || strings.TrimSpace(options.restoreConfigFromBackup) != ""
+	return repairOnly &&
+		!options.pruneImages &&
+		!options.pruneBuildCache &&
+		!options.pruneContainers &&
+		!options.repairJetBrainsGateway &&
+		!options.finishRemoteInit
 }
 
 func runDoctorCleanupActions(ctx common.Context, promptRunner PromptRunner, result common.OpenResult, options doctorOptions) error {

--- a/erun-cli/cmd/doctor.go
+++ b/erun-cli/cmd/doctor.go
@@ -32,7 +32,7 @@ type jetBrainsGatewayDoctorRepair struct {
 	idePath     string
 }
 
-func newDoctorCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), configStore common.ConfigStore, cloudDeps common.CloudDependencies, promptRunner PromptRunner) *cobra.Command {
+func newDoctorCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), configStore common.ConfigStore, cloudDeps common.CloudDependencies, cloudContextDeps common.CloudContextDependencies, promptRunner PromptRunner) *cobra.Command {
 	options := doctorOptions{}
 	cmd := &cobra.Command{
 		Use:           "doctor [tenant] [environment]",
@@ -41,7 +41,7 @@ func newDoctorCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error)
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDoctorCommand(commandContext(cmd), resolveOpen, configStore, cloudDeps, promptRunner, options, args)
+			return runDoctorCommand(commandContext(cmd), resolveOpen, configStore, cloudDeps, cloudContextDeps, promptRunner, options, args)
 		},
 	}
 	addDryRunFlag(cmd)
@@ -57,7 +57,7 @@ func newDoctorCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error)
 	return cmd
 }
 
-func runDoctorCommand(ctx common.Context, resolveOpen func(common.OpenParams) (common.OpenResult, error), configStore common.ConfigStore, cloudDeps common.CloudDependencies, promptRunner PromptRunner, options doctorOptions, args []string) error {
+func runDoctorCommand(ctx common.Context, resolveOpen func(common.OpenParams) (common.OpenResult, error), configStore common.ConfigStore, cloudDeps common.CloudDependencies, cloudContextDeps common.CloudContextDependencies, promptRunner PromptRunner, options doctorOptions, args []string) error {
 	// In-runtime invocations target a different surface entirely
 	// (remote-init recovery), and the root config they would inspect
 	// lives on the user's host, not in the pod. Short-circuit before
@@ -72,7 +72,7 @@ func runDoctorCommand(ctx common.Context, resolveOpen func(common.OpenParams) (c
 	// recovery. The repair path here writes via SaveERunConfig +
 	// InitAWSCloudProvider; resolveOpen below picks up the healed
 	// state.
-	if _, err := runRootConfigDoctor(ctx, configStore, cloudDeps, promptRunner, options); err != nil {
+	if _, err := runRootConfigDoctor(ctx, configStore, cloudDeps, cloudContextDeps, promptRunner, options); err != nil {
 		return err
 	}
 	if doctorOnlyRepairConfig(options) {

--- a/erun-cli/cmd/doctor_root_config.go
+++ b/erun-cli/cmd/doctor_root_config.go
@@ -48,7 +48,7 @@ func runRootConfigDoctor(ctx common.Context, configStore common.ConfigStore, clo
 	if handled && inspection.Complete() {
 		return true, nil
 	}
-	shouldRepair, err := shouldOfferRootConfigRepair(ctx, inspection, options)
+	shouldRepair, err := shouldOfferRootConfigRepair(ctx, promptRunner, inspection, options)
 	if err != nil {
 		return handled, err
 	}
@@ -165,23 +165,25 @@ func formatOrphanedContexts(refs []common.OrphanedAliasContextRef) string {
 }
 
 // shouldOfferRootConfigRepair gates whether to enter the repair flow.
-// Auto-detect only surfaces the inspection report and a suggestion;
-// the actual repair (which prompts per orphan and may launch the
-// interactive cloud-init SSO flow) only runs when the user opted in
-// explicitly via --repair-config. Removing the "Repair root erun
-// config now?" general prompt was a deliberate UX choice: with one
-// orphan the per-alias prompt would have asked the same question
-// twice in a row, and even with many orphans the per-alias prompt
-// is the actionable confirmation.
-func shouldOfferRootConfigRepair(ctx common.Context, inspection common.RootConfigInspection, options doctorOptions) (bool, error) {
+// On an interactive terminal we enter the repair flow whenever there
+// is something to fix, even without --repair-config — the per-alias
+// prompt below is the only confirmation the user has to answer, so
+// the experience is "inspect, see the problem, confirm the fix" in
+// a single step. Dry-run and non-interactive runs cannot prompt, so
+// they print the suggestion line and exit the root-config flow; the
+// explicit --repair-config flag is what the suggestion points at.
+func shouldOfferRootConfigRepair(ctx common.Context, promptRunner PromptRunner, inspection common.RootConfigInspection, options doctorOptions) (bool, error) {
 	if inspection.Complete() {
 		return false, nil
 	}
 	if options.repairConfig {
 		return true, nil
 	}
-	_, err := fmt.Fprintln(ctx.Stdout, "Run `erun doctor --repair-config` to walk through restoring the root config or re-initializing orphaned cloud provider aliases.")
-	return false, err
+	if ctx.DryRun || promptRunner == nil {
+		_, err := fmt.Fprintln(ctx.Stdout, "Run `erun doctor --repair-config` to walk through restoring the root config or re-initializing orphaned cloud provider aliases.")
+		return false, err
+	}
+	return true, nil
 }
 
 // runRootConfigRepair walks the user through restoring from a backup

--- a/erun-cli/cmd/doctor_root_config.go
+++ b/erun-cli/cmd/doctor_root_config.go
@@ -48,7 +48,7 @@ func runRootConfigDoctor(ctx common.Context, configStore common.ConfigStore, clo
 	if handled && inspection.Complete() {
 		return true, nil
 	}
-	shouldRepair, err := shouldOfferRootConfigRepair(ctx, promptRunner, inspection, options)
+	shouldRepair, err := shouldOfferRootConfigRepair(ctx, inspection, options)
 	if err != nil {
 		return handled, err
 	}
@@ -164,21 +164,24 @@ func formatOrphanedContexts(refs []common.OrphanedAliasContextRef) string {
 	return strings.Join(names, ", ")
 }
 
-// shouldOfferRootConfigRepair returns true when there is something to
-// repair AND the caller is in a mode where repair is appropriate:
-// explicit flag, OR interactive run with confirmation.
-func shouldOfferRootConfigRepair(ctx common.Context, promptRunner PromptRunner, inspection common.RootConfigInspection, options doctorOptions) (bool, error) {
+// shouldOfferRootConfigRepair gates whether to enter the repair flow.
+// Auto-detect only surfaces the inspection report and a suggestion;
+// the actual repair (which prompts per orphan and may launch the
+// interactive cloud-init SSO flow) only runs when the user opted in
+// explicitly via --repair-config. Removing the "Repair root erun
+// config now?" general prompt was a deliberate UX choice: with one
+// orphan the per-alias prompt would have asked the same question
+// twice in a row, and even with many orphans the per-alias prompt
+// is the actionable confirmation.
+func shouldOfferRootConfigRepair(ctx common.Context, inspection common.RootConfigInspection, options doctorOptions) (bool, error) {
 	if inspection.Complete() {
 		return false, nil
 	}
 	if options.repairConfig {
 		return true, nil
 	}
-	if ctx.DryRun || promptRunner == nil {
-		_, err := fmt.Fprintln(ctx.Stdout, "Run `erun doctor --repair-config` to walk through restoring the root config or re-initializing orphaned cloud provider aliases.")
-		return false, err
-	}
-	return confirmPrompt(promptRunner, "Repair root erun config now?")
+	_, err := fmt.Fprintln(ctx.Stdout, "Run `erun doctor --repair-config` to walk through restoring the root config or re-initializing orphaned cloud provider aliases.")
+	return false, err
 }
 
 // runRootConfigRepair walks the user through restoring from a backup

--- a/erun-cli/cmd/doctor_root_config.go
+++ b/erun-cli/cmd/doctor_root_config.go
@@ -1,0 +1,394 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	common "github.com/sophium/erun/erun-common"
+)
+
+// rootConfigSkipsInspection returns true when nothing about the root
+// config inspection should fire: the file is healthy AND no explicit
+// repair flag was set. Used to keep `erun doctor` silent on the
+// common case where the user is invoking it for runtime cleanup.
+func rootConfigSkipsInspection(inspection common.RootConfigInspection, options doctorOptions) bool {
+	if !inspection.Complete() {
+		return false
+	}
+	if options.repairConfig {
+		return false
+	}
+	return strings.TrimSpace(options.restoreConfigFromBackup) == ""
+}
+
+// runRootConfigDoctor inspects the root config, prints a summary, and
+// dispatches into repair flows when problems are found OR the user
+// explicitly asked for one of the repair flags. The returned bool is
+// retained so future callers can branch on "any work attempted," but
+// today the caller short-circuits on doctorOnlyRepairConfig(options)
+// regardless of outcome — that matches the user's mental model of
+// "I asked for config repair, do not also run tenant/env cleanup."
+func runRootConfigDoctor(ctx common.Context, configStore common.ConfigStore, cloudDeps common.CloudDependencies, promptRunner PromptRunner, options doctorOptions) (bool, error) {
+	inspection, err := common.InspectRootConfig(configStore)
+	if err != nil {
+		return false, err
+	}
+	if rootConfigSkipsInspection(inspection, options) {
+		return false, nil
+	}
+	if err := writeRootConfigInspectionReport(ctx, inspection); err != nil {
+		return false, err
+	}
+	inspection, handled, err := runRootConfigRestoreSelector(ctx, configStore, inspection, options)
+	if err != nil {
+		return handled, err
+	}
+	if handled && inspection.Complete() {
+		return true, nil
+	}
+	shouldRepair, err := shouldOfferRootConfigRepair(ctx, promptRunner, inspection, options)
+	if err != nil {
+		return handled, err
+	}
+	if !shouldRepair {
+		return handled, nil
+	}
+	repaired, err := runRootConfigRepair(ctx, configStore, cloudDeps, promptRunner, inspection)
+	return handled || repaired, err
+}
+
+// runRootConfigRestoreSelector handles the --restore-config-from-backup
+// path when that flag is set. When it actually restored something it
+// re-runs the inspection and prints the refreshed report before
+// returning the new inspection plus handled=true.
+func runRootConfigRestoreSelector(ctx common.Context, configStore common.ConfigStore, inspection common.RootConfigInspection, options doctorOptions) (common.RootConfigInspection, bool, error) {
+	selector := strings.TrimSpace(options.restoreConfigFromBackup)
+	if selector == "" {
+		return inspection, false, nil
+	}
+	restored, err := runRootConfigRestoreFromBackup(ctx, inspection, selector)
+	if err != nil {
+		return inspection, false, err
+	}
+	if !restored {
+		return inspection, false, nil
+	}
+	refreshed, err := common.InspectRootConfig(configStore)
+	if err != nil {
+		return inspection, true, err
+	}
+	if err := writeRootConfigInspectionReport(ctx, refreshed); err != nil {
+		return refreshed, true, err
+	}
+	return refreshed, true, nil
+}
+
+// writeRootConfigInspectionReport renders the inspection as a small
+// human-readable block on ctx.Stdout. Errors are accumulated through
+// a lineWriter so each individual write does not add a branch to the
+// cyclomatic count; the function reads as a sequence of statements
+// even though it produces several lines of output.
+func writeRootConfigInspectionReport(ctx common.Context, inspection common.RootConfigInspection) error {
+	w := newLineWriter(ctx.Stdout)
+	w.Linef("Root config: %s (status=%s)", emptyIfBlank(inspection.ConfigPath), inspection.ConfigStatus)
+	if inspection.ConfigError != "" {
+		w.Linef("  load error: %s", inspection.ConfigError)
+	}
+	writeRootConfigInspectionCounts(w, inspection)
+	writeRootConfigInspectionOrphans(w, inspection)
+	writeRootConfigInspectionBackups(w, inspection)
+	return w.Err()
+}
+
+func writeRootConfigInspectionCounts(w *lineWriter, inspection common.RootConfigInspection) {
+	if inspection.ConfigStatus != common.RootConfigStatusOK {
+		return
+	}
+	w.Linef("  cloud providers configured: %d", inspection.ConfiguredCount)
+	w.Linef("  cloud contexts: %d, tenants: %d", inspection.CloudContextHits, inspection.TenantHits)
+}
+
+func writeRootConfigInspectionOrphans(w *lineWriter, inspection common.RootConfigInspection) {
+	if len(inspection.OrphanedAliases) == 0 {
+		if inspection.ConfigStatus == common.RootConfigStatusOK {
+			w.Linef("  no orphaned cloud-provider aliases.")
+		}
+		return
+	}
+	w.Linef("  orphaned aliases: %d", len(inspection.OrphanedAliases))
+	for _, orphan := range inspection.OrphanedAliases {
+		writeOrphanedAliasReport(w, orphan)
+	}
+}
+
+func writeRootConfigInspectionBackups(w *lineWriter, inspection common.RootConfigInspection) {
+	if len(inspection.Backups) == 0 {
+		return
+	}
+	w.Linef("  available backups (newest first):")
+	for _, backup := range inspection.Backups {
+		// Path is emitted as a separate field rather than wrapped
+		// in parens so the integration normalizer's <TMP> rule
+		// (which matches /tmp/... up to whitespace) does not eat
+		// a trailing closing paren into the placeholder.
+		w.Linef("    - %s path=%s", backup.Date.Format("2006-01-02"), backup.Path)
+	}
+}
+
+func writeOrphanedAliasReport(w *lineWriter, orphan common.OrphanedAlias) {
+	w.Linef("    - %s", orphan.Alias)
+	if orphan.Parsed {
+		w.Linef("        provider=%s account=%s user=%s", orphan.Provider, orphan.AccountID, orphan.Username)
+	} else {
+		w.Linef("        alias is malformed; cannot auto-seed an init")
+	}
+	if len(orphan.ReferencedByTenants) > 0 {
+		w.Linef("        tenants: %s", strings.Join(orphan.ReferencedByTenants, ", "))
+	}
+	if len(orphan.ReferencedByCloudContexts) > 0 {
+		w.Linef("        cloud contexts: %s", formatOrphanedContexts(orphan.ReferencedByCloudContexts))
+	}
+}
+
+func formatOrphanedContexts(refs []common.OrphanedAliasContextRef) string {
+	names := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		if strings.TrimSpace(ref.Region) != "" {
+			names = append(names, fmt.Sprintf("%s (%s)", ref.Name, ref.Region))
+			continue
+		}
+		names = append(names, ref.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+// shouldOfferRootConfigRepair returns true when there is something to
+// repair AND the caller is in a mode where repair is appropriate:
+// explicit flag, OR interactive run with confirmation.
+func shouldOfferRootConfigRepair(ctx common.Context, promptRunner PromptRunner, inspection common.RootConfigInspection, options doctorOptions) (bool, error) {
+	if inspection.Complete() {
+		return false, nil
+	}
+	if options.repairConfig {
+		return true, nil
+	}
+	if ctx.DryRun || promptRunner == nil {
+		_, err := fmt.Fprintln(ctx.Stdout, "Run `erun doctor --repair-config` to walk through restoring the root config or re-initializing orphaned cloud provider aliases.")
+		return false, err
+	}
+	return confirmPrompt(promptRunner, "Repair root erun config now?")
+}
+
+// runRootConfigRepair walks the user through restoring from a backup
+// (when one is available) and/or re-initializing every orphaned
+// cloud-provider alias.
+func runRootConfigRepair(ctx common.Context, configStore common.ConfigStore, cloudDeps common.CloudDependencies, promptRunner PromptRunner, inspection common.RootConfigInspection) (bool, error) {
+	inspection, restored, err := runRootConfigRepairRestore(ctx, configStore, promptRunner, inspection)
+	if err != nil {
+		return restored, err
+	}
+	if restored && inspection.Complete() {
+		return true, nil
+	}
+	if inspection.ConfigStatus != common.RootConfigStatusOK {
+		_, err := fmt.Fprintln(ctx.Stdout, "Root config is not loadable and no backup was restored; resolve the file manually (or supply --restore-config-from-backup <date>) and re-run.")
+		return restored, err
+	}
+	repaired, err := runRootConfigRepairAliases(ctx, configStore, cloudDeps, promptRunner, inspection)
+	return restored || repaired, err
+}
+
+func runRootConfigRepairRestore(ctx common.Context, configStore common.ConfigStore, promptRunner PromptRunner, inspection common.RootConfigInspection) (common.RootConfigInspection, bool, error) {
+	if inspection.ConfigStatus == common.RootConfigStatusOK || len(inspection.Backups) == 0 {
+		return inspection, false, nil
+	}
+	restored, err := offerRootConfigBackupRestore(ctx, promptRunner, inspection)
+	if err != nil || !restored {
+		return inspection, false, err
+	}
+	refreshed, err := common.InspectRootConfig(configStore)
+	if err != nil {
+		return inspection, true, err
+	}
+	if err := writeRootConfigInspectionReport(ctx, refreshed); err != nil {
+		return refreshed, true, err
+	}
+	return refreshed, true, nil
+}
+
+func runRootConfigRepairAliases(ctx common.Context, configStore common.ConfigStore, cloudDeps common.CloudDependencies, promptRunner PromptRunner, inspection common.RootConfigInspection) (bool, error) {
+	handled := false
+	for _, orphan := range inspection.OrphanedAliases {
+		repaired, err := offerOrphanedAliasRepair(ctx, configStore, cloudDeps, promptRunner, orphan)
+		if err != nil {
+			return handled, err
+		}
+		if repaired {
+			handled = true
+		}
+	}
+	return handled, nil
+}
+
+func offerRootConfigBackupRestore(ctx common.Context, promptRunner PromptRunner, inspection common.RootConfigInspection) (bool, error) {
+	backup := inspection.Backups[0]
+	if promptRunner == nil {
+		_, err := fmt.Fprintln(ctx.Stdout, "Non-interactive run: pass --restore-config-from-backup "+backup.Date.Format("2006-01-02")+" to restore.")
+		return false, err
+	}
+	label := fmt.Sprintf("Restore root config from backup %s path=%s?", backup.Date.Format("2006-01-02"), backup.Path)
+	ok, err := confirmPrompt(promptRunner, label)
+	if err != nil || !ok {
+		return false, err
+	}
+	return runRootConfigRestore(ctx, inspection.ConfigPath, backup)
+}
+
+func runRootConfigRestoreFromBackup(ctx common.Context, inspection common.RootConfigInspection, selector string) (bool, error) {
+	backup, ok, err := resolveRootConfigBackupSelector(inspection, selector)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, fmt.Errorf("no root config backup matches %q", selector)
+	}
+	return runRootConfigRestore(ctx, inspection.ConfigPath, backup)
+}
+
+func resolveRootConfigBackupSelector(inspection common.RootConfigInspection, selector string) (common.RootConfigBackup, bool, error) {
+	if strings.ContainsAny(selector, "/\\") {
+		return common.RootConfigBackup{Path: selector}, true, nil
+	}
+	parsed, err := time.Parse("2006-01-02", selector)
+	if err != nil {
+		return common.RootConfigBackup{}, false, fmt.Errorf("invalid backup date %q (expected YYYY-MM-DD or an absolute path)", selector)
+	}
+	for _, backup := range inspection.Backups {
+		if backup.Date.Equal(parsed) {
+			return backup, true, nil
+		}
+	}
+	return common.RootConfigBackup{}, false, nil
+}
+
+func runRootConfigRestore(ctx common.Context, livePath string, backup common.RootConfigBackup) (bool, error) {
+	ctx.TraceCommand("", "cp", backup.Path, livePath)
+	if ctx.DryRun {
+		_, err := fmt.Fprintf(ctx.Stdout, "Dry-run: would restore root config from %s\n", backup.Path)
+		return true, err
+	}
+	if err := common.RestoreRootConfigFromBackup(backup.Path, livePath); err != nil {
+		return false, err
+	}
+	_, err := fmt.Fprintf(ctx.Stdout, "Restored root config from %s\n", backup.Path)
+	return true, err
+}
+
+// offerOrphanedAliasRepair walks a single orphan through the repair
+// decision tree. It is intentionally only allowed to bail out early
+// via guard helpers (orphanRepairBlocked, runOrphanRepairDryRun) so
+// the function body stays linear and short.
+func offerOrphanedAliasRepair(ctx common.Context, configStore common.ConfigStore, cloudDeps common.CloudDependencies, promptRunner PromptRunner, orphan common.OrphanedAlias) (bool, error) {
+	if reason, blocked := orphanRepairBlockedReason(orphan); blocked {
+		_, err := fmt.Fprintln(ctx.Stdout, reason)
+		return false, err
+	}
+	if ctx.DryRun {
+		return runOrphanRepairDryRun(ctx, orphan)
+	}
+	if promptRunner == nil {
+		_, err := fmt.Fprintf(ctx.Stdout, "Cannot repair alias %q non-interactively; re-run with a TTY or run `erun cloud init aws` directly\n", orphan.Alias)
+		return false, err
+	}
+	ok, err := confirmPrompt(promptRunner, fmt.Sprintf("Re-initialize cloud provider alias %s (account %s, user %s)?", orphan.Alias, orphan.AccountID, orphan.Username))
+	if err != nil || !ok {
+		return false, err
+	}
+	return runOrphanRepair(ctx, configStore, cloudDeps, promptRunner, orphan)
+}
+
+func orphanRepairBlockedReason(orphan common.OrphanedAlias) (string, bool) {
+	if !orphan.Parsed {
+		return fmt.Sprintf("Skipping malformed alias %q; recreate it manually with `erun cloud init aws`", orphan.Alias), true
+	}
+	if orphan.Provider != common.CloudProviderAWS {
+		return fmt.Sprintf("Skipping alias %q: provider %q is not supported by repair flow", orphan.Alias, orphan.Provider), true
+	}
+	return "", false
+}
+
+// runOrphanRepairDryRun emits the trace + summary line the repair
+// flow would produce for one orphan in --dry-run mode. The cloud
+// init flow expects to prompt for SSO start URL / region; reaching
+// for that prompt under --dry-run would block on stdin or emit
+// non-deterministic prompt UI in the trace. Trace the intent and
+// let the user run the same step interactively when they actually
+// want to repair.
+func runOrphanRepairDryRun(ctx common.Context, orphan common.OrphanedAlias) (bool, error) {
+	region := preferredRegionForOrphan(orphan)
+	ctx.Trace(fmt.Sprintf("doctor repair-config: would re-init aws cloud provider alias=%s account=%s user=%s region=%s", orphan.Alias, orphan.AccountID, orphan.Username, region))
+	_, err := fmt.Fprintf(ctx.Stdout, "Dry-run: would re-initialize AWS provider for alias %s (account %s, user %s)\n", orphan.Alias, orphan.AccountID, orphan.Username)
+	return true, err
+}
+
+func runOrphanRepair(ctx common.Context, configStore common.ConfigStore, cloudDeps common.CloudDependencies, promptRunner PromptRunner, orphan common.OrphanedAlias) (bool, error) {
+	params := common.InitAWSCloudProviderParams{
+		Username:  orphan.Username,
+		AccountID: orphan.AccountID,
+		Region:    preferredRegionForOrphan(orphan),
+	}
+	if _, err := fmt.Fprintf(ctx.Stdout, "Re-initializing AWS provider for alias %s...\n", orphan.Alias); err != nil {
+		return false, err
+	}
+	if err := runCloudInitAWSCommand(ctx, configStore, promptRunner, params, cloudDeps); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func preferredRegionForOrphan(orphan common.OrphanedAlias) string {
+	for _, ref := range orphan.ReferencedByCloudContexts {
+		region := strings.TrimSpace(ref.Region)
+		if region != "" {
+			return region
+		}
+	}
+	return ""
+}
+
+func emptyIfBlank(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "<unresolved>"
+	}
+	return value
+}
+
+// lineWriter accumulates the first write error so call sites that
+// emit a fixed sequence of lines do not need a branch per write.
+// Cyclomatic complexity goes down without sacrificing the contract
+// that the first error halts the rest of the output.
+type lineWriter struct {
+	out io.Writer
+	err error
+}
+
+func newLineWriter(w io.Writer) *lineWriter {
+	return &lineWriter{out: w}
+}
+
+func (l *lineWriter) Linef(format string, args ...any) {
+	if l.err != nil {
+		return
+	}
+	_, err := fmt.Fprintf(l.out, format+"\n", args...)
+	if err != nil {
+		l.err = err
+	}
+}
+
+func (l *lineWriter) Err() error {
+	return l.err
+}

--- a/erun-cli/cmd/doctor_root_config.go
+++ b/erun-cli/cmd/doctor_root_config.go
@@ -30,7 +30,7 @@ func rootConfigSkipsInspection(inspection common.RootConfigInspection, options d
 // today the caller short-circuits on doctorOnlyRepairConfig(options)
 // regardless of outcome — that matches the user's mental model of
 // "I asked for config repair, do not also run tenant/env cleanup."
-func runRootConfigDoctor(ctx common.Context, configStore common.ConfigStore, cloudDeps common.CloudDependencies, promptRunner PromptRunner, options doctorOptions) (bool, error) {
+func runRootConfigDoctor(ctx common.Context, configStore common.ConfigStore, cloudDeps common.CloudDependencies, cloudContextDeps common.CloudContextDependencies, promptRunner PromptRunner, options doctorOptions) (bool, error) {
 	inspection, err := common.InspectRootConfig(configStore)
 	if err != nil {
 		return false, err
@@ -55,7 +55,7 @@ func runRootConfigDoctor(ctx common.Context, configStore common.ConfigStore, clo
 	if !shouldRepair {
 		return handled, nil
 	}
-	repaired, err := runRootConfigRepair(ctx, configStore, cloudDeps, promptRunner, inspection)
+	repaired, err := runRootConfigRepair(ctx, configStore, cloudDeps, cloudContextDeps, promptRunner, inspection)
 	return handled || repaired, err
 }
 
@@ -111,15 +111,36 @@ func writeRootConfigInspectionCounts(w *lineWriter, inspection common.RootConfig
 }
 
 func writeRootConfigInspectionOrphans(w *lineWriter, inspection common.RootConfigInspection) {
-	if len(inspection.OrphanedAliases) == 0 {
-		if inspection.ConfigStatus == common.RootConfigStatusOK {
-			w.Linef("  no orphaned cloud-provider aliases.")
+	switch {
+	case len(inspection.OrphanedAliases) > 0:
+		w.Linef("  orphaned aliases: %d", len(inspection.OrphanedAliases))
+		for _, orphan := range inspection.OrphanedAliases {
+			writeOrphanedAliasReport(w, orphan)
 		}
-		return
+	case inspection.ConfigStatus == common.RootConfigStatusOK && len(inspection.OrphanedContexts) == 0:
+		w.Linef("  no orphaned cloud-provider aliases.")
 	}
-	w.Linef("  orphaned aliases: %d", len(inspection.OrphanedAliases))
-	for _, orphan := range inspection.OrphanedAliases {
-		writeOrphanedAliasReport(w, orphan)
+	if len(inspection.OrphanedContexts) > 0 {
+		w.Linef("  orphaned cloud contexts: %d", len(inspection.OrphanedContexts))
+		for _, orphan := range inspection.OrphanedContexts {
+			writeOrphanedCloudContextReport(w, orphan)
+		}
+	}
+}
+
+func writeOrphanedCloudContextReport(w *lineWriter, orphan common.OrphanedCloudContext) {
+	w.Linef("    - %s", orphan.KubernetesContext)
+	if orphan.AccountID != "" && orphan.Region != "" {
+		w.Linef("        account=%s region=%s alias=%s", orphan.AccountID, orphan.Region, orphan.CloudProviderAlias)
+	} else {
+		w.Linef("        cannot decode account/region from name; AWS auto-recovery unavailable")
+	}
+	if len(orphan.ReferencedByEnvs) > 0 {
+		names := make([]string, 0, len(orphan.ReferencedByEnvs))
+		for _, ref := range orphan.ReferencedByEnvs {
+			names = append(names, ref.Tenant+"/"+ref.Environment)
+		}
+		w.Linef("        envs: %s", strings.Join(names, ", "))
 	}
 }
 
@@ -187,9 +208,10 @@ func shouldOfferRootConfigRepair(ctx common.Context, promptRunner PromptRunner, 
 }
 
 // runRootConfigRepair walks the user through restoring from a backup
-// (when one is available) and/or re-initializing every orphaned
-// cloud-provider alias.
-func runRootConfigRepair(ctx common.Context, configStore common.ConfigStore, cloudDeps common.CloudDependencies, promptRunner PromptRunner, inspection common.RootConfigInspection) (bool, error) {
+// (when one is available), re-initializing every orphaned cloud
+// provider alias, and recovering every orphaned cloud-context
+// reference from AWS.
+func runRootConfigRepair(ctx common.Context, configStore common.ConfigStore, cloudDeps common.CloudDependencies, cloudContextDeps common.CloudContextDependencies, promptRunner PromptRunner, inspection common.RootConfigInspection) (bool, error) {
 	inspection, restored, err := runRootConfigRepairRestore(ctx, configStore, promptRunner, inspection)
 	if err != nil {
 		return restored, err
@@ -201,8 +223,20 @@ func runRootConfigRepair(ctx common.Context, configStore common.ConfigStore, clo
 		_, err := fmt.Fprintln(ctx.Stdout, "Root config is not loadable and no backup was restored; resolve the file manually (or supply --restore-config-from-backup <date>) and re-run.")
 		return restored, err
 	}
+	return runRootConfigRepairOrphans(ctx, configStore, cloudDeps, cloudContextDeps, promptRunner, inspection, restored)
+}
+
+func runRootConfigRepairOrphans(ctx common.Context, configStore common.ConfigStore, cloudDeps common.CloudDependencies, cloudContextDeps common.CloudContextDependencies, promptRunner PromptRunner, inspection common.RootConfigInspection, restored bool) (bool, error) {
 	repaired, err := runRootConfigRepairAliases(ctx, configStore, cloudDeps, promptRunner, inspection)
-	return restored || repaired, err
+	if err != nil {
+		return restored || repaired, err
+	}
+	refreshed, refreshErr := common.InspectRootConfig(configStore)
+	if refreshErr != nil {
+		return restored || repaired, refreshErr
+	}
+	recoveredContexts, err := runRootConfigRepairContexts(ctx, configStore, cloudContextDeps, promptRunner, refreshed)
+	return restored || repaired || recoveredContexts, err
 }
 
 func runRootConfigRepairRestore(ctx common.Context, configStore common.ConfigStore, promptRunner PromptRunner, inspection common.RootConfigInspection) (common.RootConfigInspection, bool, error) {
@@ -235,6 +269,89 @@ func runRootConfigRepairAliases(ctx common.Context, configStore common.ConfigSto
 		}
 	}
 	return handled, nil
+}
+
+func runRootConfigRepairContexts(ctx common.Context, configStore common.ConfigStore, cloudContextDeps common.CloudContextDependencies, promptRunner PromptRunner, inspection common.RootConfigInspection) (bool, error) {
+	handled := false
+	for _, orphan := range inspection.OrphanedContexts {
+		recovered, err := offerOrphanedCloudContextRecovery(ctx, configStore, cloudContextDeps, promptRunner, orphan)
+		if err != nil {
+			return handled, err
+		}
+		if recovered {
+			handled = true
+		}
+	}
+	return handled, nil
+}
+
+// offerOrphanedCloudContextRecovery walks one orphaned cloud-context
+// reference through the recovery decision tree. The recovery itself
+// (AWS describe-instances + reconstruction + save) runs inside
+// common.RecoverCloudContextFromAWS; this function only handles the
+// CLI-side prompts and dry-run trace.
+func offerOrphanedCloudContextRecovery(ctx common.Context, configStore common.ConfigStore, cloudContextDeps common.CloudContextDependencies, promptRunner PromptRunner, orphan common.OrphanedCloudContext) (bool, error) {
+	if reason, blocked := contextRecoveryBlockedReason(orphan); blocked {
+		_, err := fmt.Fprintln(ctx.Stdout, reason)
+		return false, err
+	}
+	if !ctx.DryRun && promptRunner == nil {
+		_, err := fmt.Fprintf(ctx.Stdout, "Cannot recover cloud context %q non-interactively; re-run with a TTY or use --restore-config-from-backup <date>\n", orphan.KubernetesContext)
+		return false, err
+	}
+	if !ctx.DryRun {
+		label := fmt.Sprintf("Recover cloud context %s from AWS (account %s, region %s)?", orphan.KubernetesContext, orphan.AccountID, orphan.Region)
+		ok, err := confirmPrompt(promptRunner, label)
+		if err != nil || !ok {
+			return false, err
+		}
+	}
+	params := common.RecoverCloudContextParams{
+		KubernetesContext:  orphan.KubernetesContext,
+		CloudProviderAlias: orphan.CloudProviderAlias,
+		Region:             orphan.Region,
+	}
+	if _, err := fmt.Fprintf(ctx.Stdout, "Recovering cloud context %s...\n", orphan.KubernetesContext); err != nil {
+		return false, err
+	}
+	result, err := common.RecoverCloudContextFromAWS(ctx, configStore, params, cloudContextDeps)
+	if err != nil {
+		_, _ = fmt.Fprintf(ctx.Stdout, "Recovery failed for %s: %v\n", orphan.KubernetesContext, err)
+		return false, nil
+	}
+	writeCloudContextRecoverySummary(ctx, result)
+	return true, nil
+}
+
+func contextRecoveryBlockedReason(orphan common.OrphanedCloudContext) (string, bool) {
+	if strings.TrimSpace(orphan.AccountID) == "" || strings.TrimSpace(orphan.Region) == "" {
+		return fmt.Sprintf("Skipping context %q: name does not match the erun-<seq>-<account>-<region> shape, so AWS recovery cannot be auto-seeded", orphan.KubernetesContext), true
+	}
+	if strings.TrimSpace(orphan.CloudProviderAlias) == "" {
+		return fmt.Sprintf("Skipping context %q: env references it without a cloud provider alias, so AWS recovery cannot be authenticated", orphan.KubernetesContext), true
+	}
+	return "", false
+}
+
+func writeCloudContextRecoverySummary(ctx common.Context, result common.RecoverCloudContextResult) {
+	w := newLineWriter(ctx.Stdout)
+	w.Linef("Recovered cloud context %s from %s.", result.Saved.KubernetesContext, result.Source)
+	w.Linef("  instance: %s (%s)", result.Saved.InstanceID, result.Saved.InstanceType)
+	if result.Saved.PublicIP != "" {
+		w.Linef("  public ip: %s", result.Saved.PublicIP)
+	}
+	if result.Saved.DiskType != "" || result.Saved.DiskSizeGB != 0 {
+		w.Linef("  disk: %s %dG", result.Saved.DiskType, result.Saved.DiskSizeGB)
+	}
+	switch result.TokenFrom {
+	case "kubeconfig":
+		w.Linef("  admin token: restored from ~/.kube/config")
+	case "input":
+		w.Linef("  admin token: from --admin-token input")
+	case "none":
+		w.Linef("  admin token: NOT recovered — kubectl access will fail until you run `erun context init` for a fresh token or manually paste the existing one.")
+	}
+	_ = w.Err()
 }
 
 func offerRootConfigBackupRestore(ctx common.Context, promptRunner PromptRunner, inspection common.RootConfigInspection) (bool, error) {

--- a/erun-cli/cmd/doctor_root_config.go
+++ b/erun-cli/cmd/doctor_root_config.go
@@ -339,10 +339,9 @@ func runOrphanRepairDryRun(ctx common.Context, orphan common.OrphanedAlias) (boo
 }
 
 func runOrphanRepair(ctx common.Context, configStore common.ConfigStore, cloudDeps common.CloudDependencies, promptRunner PromptRunner, orphan common.OrphanedAlias) (bool, error) {
-	params := common.InitAWSCloudProviderParams{
-		Username:  orphan.Username,
-		AccountID: orphan.AccountID,
-		Region:    preferredRegionForOrphan(orphan),
+	params, err := buildOrphanRepairParams(ctx, orphan)
+	if err != nil {
+		return false, err
 	}
 	if _, err := fmt.Fprintf(ctx.Stdout, "Re-initializing AWS provider for alias %s...\n", orphan.Alias); err != nil {
 		return false, err
@@ -351,6 +350,79 @@ func runOrphanRepair(ctx common.Context, configStore common.ConfigStore, cloudDe
 		return false, err
 	}
 	return true, nil
+}
+
+// buildOrphanRepairParams seeds InitAWSCloudProviderParams from the
+// orphan plus whatever ~/.aws/config already knows about the same
+// account. The discovery is a UX optimization: the user usually has
+// an SSO profile registered for the orphaned account already (the
+// previous erun-sso-* profile that wrote the now-missing root
+// config), and that profile carries the SSO start URL + SSO region
+// erun cannot derive from the alias string alone.
+//
+// On a miss the user is pointed at the canonical lookup steps so
+// they can find the SSO start URL without leaving the prompt — the
+// help text is the value-add even when discovery itself produces
+// nothing.
+func buildOrphanRepairParams(ctx common.Context, orphan common.OrphanedAlias) (common.InitAWSCloudProviderParams, error) {
+	w := newLineWriter(ctx.Stdout)
+	params := common.InitAWSCloudProviderParams{
+		Username:  orphan.Username,
+		AccountID: orphan.AccountID,
+		Region:    preferredRegionForOrphan(orphan),
+	}
+	profile, ok, err := common.LookupAWSSSOProfileByAccountID(orphan.AccountID)
+	if err != nil {
+		w.Linef("Note: could not scan ~/.aws/config for SSO defaults: %v", err)
+		writeSSOLookupHelp(w, orphan)
+		return params, w.Err()
+	}
+	if !ok {
+		w.Linef("No SSO profile found in ~/.aws/config for account %s.", orphan.AccountID)
+		writeSSOLookupHelp(w, orphan)
+		return params, w.Err()
+	}
+	applyOrphanRepairProfile(w, &params, profile)
+	if params.SSOStartURL == "" {
+		writeSSOLookupHelp(w, orphan)
+	}
+	return params, w.Err()
+}
+
+func applyOrphanRepairProfile(w *lineWriter, params *common.InitAWSCloudProviderParams, profile common.AWSSSOProfile) {
+	w.Linef("Found existing AWS SSO profile %q in ~/.aws/config; pre-filling defaults you can edit or accept with Enter.", profile.Profile)
+	if profile.SSOStartURL != "" {
+		params.SSOStartURL = profile.SSOStartURL
+		w.Linef("  sso_start_url = %s", profile.SSOStartURL)
+	}
+	if profile.SSORegion != "" {
+		params.SSORegion = profile.SSORegion
+		w.Linef("  sso_region    = %s", profile.SSORegion)
+	}
+	if profile.RoleName != "" {
+		params.RoleName = profile.RoleName
+		w.Linef("  sso_role_name = %s", profile.RoleName)
+	}
+	if params.Region == "" && profile.Region != "" {
+		params.Region = profile.Region
+		w.Linef("  region        = %s", profile.Region)
+	}
+}
+
+// writeSSOLookupHelp prints a short, copy-pasteable cheat sheet so a
+// user who does not know their SSO portal URL can recover without
+// abandoning the prompt. The block is deliberately terse — three
+// pointers, one example shape — to stay readable beside the prompt
+// itself.
+func writeSSOLookupHelp(w *lineWriter, orphan common.OrphanedAlias) {
+	w.Linef("Where to find your AWS SSO start URL:")
+	w.Linef("  1. `grep -E 'sso_start_url|sso_region' ~/.aws/config` — fastest if you have ever run `aws sso login`.")
+	w.Linef("  2. AWS Console → IAM Identity Center → Settings → AWS access portal URL.")
+	w.Linef("  3. The IAM Identity Center invitation email your admin sent when this account was provisioned.")
+	w.Linef("  Format: https://<id>.awsapps.com/start (or your org's custom domain).")
+	if orphan.AccountID != "" {
+		w.Linef("  Target account: %s", orphan.AccountID)
+	}
 }
 
 func preferredRegionForOrphan(orphan common.OrphanedAlias) string {

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -126,7 +126,7 @@ func (d rootDependencies) commands() []*cobra.Command {
 		newCloudCmd(d.configStore, runPrompt, runSelect, common.CloudDependencies{}),
 		newContextCmd(d.configStore, runPrompt, runSelect, common.CloudContextDependencies{}),
 		newListCmd(d.configStore, common.FindProjectRoot),
-		newDoctorCmd(d.resolveOpen, d.configStore, common.CloudDependencies{}, runPrompt),
+		newDoctorCmd(d.resolveOpen, d.configStore, common.CloudDependencies{}, common.CloudContextDependencies{}, runPrompt),
 		newDeleteCmd(d.configStore, runPrompt, common.DeleteKubernetesNamespace),
 		newIdleCmd(d.configStore),
 		newReleaseCmd(common.FindProjectRoot, common.GitCommandRunner),

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -126,7 +126,7 @@ func (d rootDependencies) commands() []*cobra.Command {
 		newCloudCmd(d.configStore, runPrompt, runSelect, common.CloudDependencies{}),
 		newContextCmd(d.configStore, runPrompt, runSelect, common.CloudContextDependencies{}),
 		newListCmd(d.configStore, common.FindProjectRoot),
-		newDoctorCmd(d.resolveOpen, runPrompt),
+		newDoctorCmd(d.resolveOpen, d.configStore, common.CloudDependencies{}, runPrompt),
 		newDeleteCmd(d.configStore, runPrompt, common.DeleteKubernetesNamespace),
 		newIdleCmd(d.configStore),
 		newReleaseCmd(common.FindProjectRoot, common.GitCommandRunner),

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -90,6 +90,16 @@ func testCloudStoreOrDefault(store rootStore) cloudCommandStoreInterface {
 	return cloudStore
 }
 
+// testConfigStoreOrDefault feeds the doctor command a concrete
+// ConfigStore in tests. The doctor's root-config inspection path only
+// needs LoadERunConfig + ListTenantConfigs, both of which the real
+// ConfigStore satisfies against the test home directory set up by
+// env.New. Most cmd-level tests do not exercise the inspection path,
+// but the fall-through still requires a non-nil store.
+func testConfigStoreOrDefault(store rootStore) common.ConfigStore {
+	return common.ConfigStore{}
+}
+
 func testDeleteStoreOrDefault(store rootStore) common.DeleteStore {
 	deleteStore, ok := any(store).(common.DeleteStore)
 	if !ok {
@@ -439,7 +449,7 @@ func assembleTestRootCmd(parts testRootCmdParts) *cobra.Command {
 		newExecCmd(parts.findProjectRoot, parts.runGit, parts.deps.RunRawCommand),
 		newCloudCmd(testCloudStoreOrDefault(parts.store), parts.promptRunner, parts.selectRunner, common.CloudDependencies{}),
 		newListCmd(parts.listDataStore, parts.findProjectRoot),
-		newDoctorCmd(parts.resolveOpen, parts.promptRunner),
+		newDoctorCmd(parts.resolveOpen, testConfigStoreOrDefault(parts.store), common.CloudDependencies{}, parts.promptRunner),
 		newDeleteCmd(testDeleteStoreOrDefault(parts.store), parts.promptRunner, testNamespaceDeleterOrDefault(parts.deps.DeleteKubernetesNamespace)),
 		newReleaseCmd(parts.findProjectRoot, parts.runGit),
 		versionCmd,

--- a/erun-cli/cmd/root_test_helpers_test.go
+++ b/erun-cli/cmd/root_test_helpers_test.go
@@ -449,7 +449,7 @@ func assembleTestRootCmd(parts testRootCmdParts) *cobra.Command {
 		newExecCmd(parts.findProjectRoot, parts.runGit, parts.deps.RunRawCommand),
 		newCloudCmd(testCloudStoreOrDefault(parts.store), parts.promptRunner, parts.selectRunner, common.CloudDependencies{}),
 		newListCmd(parts.listDataStore, parts.findProjectRoot),
-		newDoctorCmd(parts.resolveOpen, testConfigStoreOrDefault(parts.store), common.CloudDependencies{}, parts.promptRunner),
+		newDoctorCmd(parts.resolveOpen, testConfigStoreOrDefault(parts.store), common.CloudDependencies{}, common.CloudContextDependencies{}, parts.promptRunner),
 		newDeleteCmd(testDeleteStoreOrDefault(parts.store), parts.promptRunner, testNamespaceDeleterOrDefault(parts.deps.DeleteKubernetesNamespace)),
 		newReleaseCmd(parts.findProjectRoot, parts.runGit),
 		versionCmd,

--- a/erun-common/aws_sso_config.go
+++ b/erun-common/aws_sso_config.go
@@ -1,0 +1,192 @@
+package eruncommon
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// awsConfigUserHomeDir is the seam tests use to point lookups at a
+// fake home directory. Mirrors the openUserHomeDir / hostUserHomeDir
+// pattern used elsewhere in this package so we do not invent a new
+// override mechanism just for this file.
+var awsConfigUserHomeDir = os.UserHomeDir
+
+// AWSSSOProfile is the subset of an AWS shared config profile the
+// doctor needs to pre-fill an InitAWSCloudProviderParams. Fields are
+// trimmed and never empty unless the source file omitted the entry.
+type AWSSSOProfile struct {
+	Profile     string
+	SSOStartURL string
+	SSORegion   string
+	AccountID   string
+	RoleName    string
+	Region      string
+}
+
+// LookupAWSSSOProfileByAccountID scans ~/.aws/config (or whichever
+// path AWS_CONFIG_FILE overrides it to) and returns the first profile
+// whose sso_account_id matches the supplied account. Returns
+// ok=false when no profile matches or the file does not exist.
+//
+// Both legacy "inline" SSO settings (the profile carries
+// sso_start_url, sso_region, sso_account_id directly) and the newer
+// sso_session indirection ("sso_session = foo" → look up the
+// matching [sso-session foo] block for sso_start_url + sso_region)
+// are resolved. Profiles whose sso_account_id is empty are
+// considered non-matches.
+func LookupAWSSSOProfileByAccountID(accountID string) (AWSSSOProfile, bool, error) {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return AWSSSOProfile{}, false, errors.New("account id is required")
+	}
+	path, err := awsConfigPath()
+	if err != nil {
+		return AWSSSOProfile{}, false, err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return AWSSSOProfile{}, false, nil
+		}
+		return AWSSSOProfile{}, false, err
+	}
+	defer file.Close()
+	sections, err := parseAWSSharedConfig(file)
+	if err != nil {
+		return AWSSSOProfile{}, false, err
+	}
+	profile, ok := findAWSSSOProfileForAccount(sections, accountID)
+	return profile, ok, nil
+}
+
+func findAWSSSOProfileForAccount(sections []awsConfigSection, accountID string) (AWSSSOProfile, bool) {
+	sessions := buildAWSSSOSessionIndex(sections)
+	for _, section := range sections {
+		if section.kind != "profile" {
+			continue
+		}
+		if strings.TrimSpace(section.values["sso_account_id"]) != accountID {
+			continue
+		}
+		profile := AWSSSOProfile{
+			Profile:     section.name,
+			SSOStartURL: strings.TrimSpace(section.values["sso_start_url"]),
+			SSORegion:   strings.TrimSpace(section.values["sso_region"]),
+			AccountID:   accountID,
+			RoleName:    strings.TrimSpace(section.values["sso_role_name"]),
+			Region:      strings.TrimSpace(section.values["region"]),
+		}
+		if sessionName := strings.TrimSpace(section.values["sso_session"]); sessionName != "" {
+			if session, ok := sessions[sessionName]; ok {
+				if profile.SSOStartURL == "" {
+					profile.SSOStartURL = strings.TrimSpace(session.values["sso_start_url"])
+				}
+				if profile.SSORegion == "" {
+					profile.SSORegion = strings.TrimSpace(session.values["sso_region"])
+				}
+			}
+		}
+		return profile, true
+	}
+	return AWSSSOProfile{}, false
+}
+
+func buildAWSSSOSessionIndex(sections []awsConfigSection) map[string]awsConfigSection {
+	out := make(map[string]awsConfigSection)
+	for _, section := range sections {
+		if section.kind != "sso-session" {
+			continue
+		}
+		out[section.name] = section
+	}
+	return out
+}
+
+type awsConfigSection struct {
+	// kind is "profile" or "sso-session"; the "default" block is
+	// surfaced as kind="profile", name="default".
+	kind   string
+	name   string
+	values map[string]string
+}
+
+// parseAWSSharedConfig parses the INI-flavored AWS shared config.
+// Only the subset we actually need is supported: top-level keys
+// inside a section. Nested-key blocks (the "s3 =" multi-line form
+// used by some advanced configs) are skipped — they have no overlap
+// with SSO settings.
+func parseAWSSharedConfig(r io.Reader) ([]awsConfigSection, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	sections := make([]awsConfigSection, 0, 8)
+	var current *awsConfigSection
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			sections = appendIfNotNil(sections, current)
+			next := newAWSConfigSection(line)
+			current = &next
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		// Nested-key continuation lines start with whitespace in the
+		// original file, which TrimSpace strips. Anything without "="
+		// at this point is a nested-block value we can safely ignore.
+		eq := strings.Index(line, "=")
+		if eq <= 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:eq])
+		value := strings.TrimSpace(line[eq+1:])
+		current.values[key] = value
+	}
+	sections = appendIfNotNil(sections, current)
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return sections, nil
+}
+
+func appendIfNotNil(sections []awsConfigSection, current *awsConfigSection) []awsConfigSection {
+	if current == nil {
+		return sections
+	}
+	return append(sections, *current)
+}
+
+func newAWSConfigSection(header string) awsConfigSection {
+	inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(header, "["), "]"))
+	switch {
+	case inner == "default":
+		return awsConfigSection{kind: "profile", name: "default", values: make(map[string]string)}
+	case strings.HasPrefix(inner, "profile "):
+		return awsConfigSection{kind: "profile", name: strings.TrimSpace(strings.TrimPrefix(inner, "profile ")), values: make(map[string]string)}
+	case strings.HasPrefix(inner, "sso-session "):
+		return awsConfigSection{kind: "sso-session", name: strings.TrimSpace(strings.TrimPrefix(inner, "sso-session ")), values: make(map[string]string)}
+	default:
+		return awsConfigSection{kind: "other", name: inner, values: make(map[string]string)}
+	}
+}
+
+// awsConfigPath returns the path the AWS CLI would read for its
+// shared config. AWS_CONFIG_FILE wins when set; otherwise the
+// canonical "~/.aws/config" applies.
+func awsConfigPath() (string, error) {
+	if override := strings.TrimSpace(os.Getenv("AWS_CONFIG_FILE")); override != "" {
+		return override, nil
+	}
+	home, err := awsConfigUserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".aws", "config"), nil
+}

--- a/erun-common/aws_sso_config_test.go
+++ b/erun-common/aws_sso_config_test.go
@@ -1,0 +1,231 @@
+package eruncommon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeAWSConfig(t *testing.T, body string) func() {
+	t.Helper()
+	tmp := t.TempDir()
+	awsDir := filepath.Join(tmp, ".aws")
+	if err := os.MkdirAll(awsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(awsDir, "config"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	previous := awsConfigUserHomeDir
+	awsConfigUserHomeDir = func() (string, error) { return tmp, nil }
+	prevEnv, hadEnv := os.LookupEnv("AWS_CONFIG_FILE")
+	_ = os.Unsetenv("AWS_CONFIG_FILE")
+	return func() {
+		awsConfigUserHomeDir = previous
+		if hadEnv {
+			_ = os.Setenv("AWS_CONFIG_FILE", prevEnv)
+		} else {
+			_ = os.Unsetenv("AWS_CONFIG_FILE")
+		}
+	}
+}
+
+// TestLookupAWSSSOProfileByAccountIDInlineProfile covers the legacy
+// inline form: a profile that carries sso_start_url, sso_region,
+// sso_account_id directly. This is the shape erun's own
+// runCloudInitAWSCommand writes today, so the doctor's discovery
+// must round-trip its own output cleanly.
+func TestLookupAWSSSOProfileByAccountIDInlineProfile(t *testing.T) {
+	restore := writeAWSConfig(t, `[default]
+[profile erun-sso-20260427124244]
+sso_start_url = https://d-9c674ca9d9.awsapps.com/start
+sso_region = eu-west-2
+sso_account_id = 020362606330
+sso_role_name = ErunDeveloper
+region = eu-west-2
+`)
+	defer restore()
+
+	got, ok, err := LookupAWSSSOProfileByAccountID("020362606330")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected match")
+	}
+	if got.SSOStartURL != "https://d-9c674ca9d9.awsapps.com/start" {
+		t.Fatalf("start URL: %q", got.SSOStartURL)
+	}
+	if got.SSORegion != "eu-west-2" {
+		t.Fatalf("sso region: %q", got.SSORegion)
+	}
+	if got.Region != "eu-west-2" {
+		t.Fatalf("region: %q", got.Region)
+	}
+	if got.RoleName != "ErunDeveloper" {
+		t.Fatalf("role name: %q", got.RoleName)
+	}
+	if got.Profile != "erun-sso-20260427124244" {
+		t.Fatalf("profile: %q", got.Profile)
+	}
+}
+
+// TestLookupAWSSSOProfileByAccountIDSSOSessionIndirection covers the
+// modern shape where a profile references an [sso-session] block via
+// sso_session = name. The lookup must resolve the indirection so the
+// SSO start URL is still discoverable.
+func TestLookupAWSSSOProfileByAccountIDSSOSessionIndirection(t *testing.T) {
+	restore := writeAWSConfig(t, `[sso-session my-org]
+sso_start_url = https://org.awsapps.com/start
+sso_region = eu-west-1
+sso_registration_scopes = sso:account:access
+
+[profile worker]
+sso_session = my-org
+sso_account_id = 999999999999
+sso_role_name = Developer
+region = eu-west-1
+`)
+	defer restore()
+
+	got, ok, err := LookupAWSSSOProfileByAccountID("999999999999")
+	if err != nil || !ok {
+		t.Fatalf("lookup: ok=%v err=%v", ok, err)
+	}
+	if got.SSOStartURL != "https://org.awsapps.com/start" {
+		t.Fatalf("start URL: %q", got.SSOStartURL)
+	}
+	if got.SSORegion != "eu-west-1" {
+		t.Fatalf("sso region: %q", got.SSORegion)
+	}
+}
+
+// TestLookupAWSSSOProfileByAccountIDInlinePrecedence guarantees that
+// when a profile carries both inline sso_start_url and a sso_session
+// reference, the inline value wins. Inline is the explicit, more
+// specific source; treating it otherwise would surprise users who
+// override one field in a profile they inherited.
+func TestLookupAWSSSOProfileByAccountIDInlinePrecedence(t *testing.T) {
+	restore := writeAWSConfig(t, `[sso-session my-org]
+sso_start_url = https://org.awsapps.com/start
+sso_region = eu-west-1
+
+[profile worker]
+sso_session = my-org
+sso_start_url = https://override.awsapps.com/start
+sso_region = us-east-1
+sso_account_id = 123456789012
+`)
+	defer restore()
+
+	got, ok, err := LookupAWSSSOProfileByAccountID("123456789012")
+	if err != nil || !ok {
+		t.Fatalf("lookup: %v / %v", ok, err)
+	}
+	if got.SSOStartURL != "https://override.awsapps.com/start" {
+		t.Fatalf("inline must win, got %q", got.SSOStartURL)
+	}
+	if got.SSORegion != "us-east-1" {
+		t.Fatalf("inline region must win, got %q", got.SSORegion)
+	}
+}
+
+// TestLookupAWSSSOProfileByAccountIDMissingReturnsNotFound: no
+// matching profile must produce ok=false, err=nil. Doctor relies on
+// that contract to fall back to manual prompts without surfacing a
+// fake error.
+func TestLookupAWSSSOProfileByAccountIDMissingReturnsNotFound(t *testing.T) {
+	restore := writeAWSConfig(t, `[default]
+region = us-east-1
+`)
+	defer restore()
+	got, ok, err := LookupAWSSSOProfileByAccountID("000000000000")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected no match, got %+v", got)
+	}
+}
+
+// TestLookupAWSSSOProfileByAccountIDMissingFileReturnsNotFound: the
+// shared config file may not exist at all (fresh machine). That is
+// not an error condition for the doctor — it just means we cannot
+// pre-fill anything and must prompt manually.
+func TestLookupAWSSSOProfileByAccountIDMissingFileReturnsNotFound(t *testing.T) {
+	previous := awsConfigUserHomeDir
+	awsConfigUserHomeDir = func() (string, error) { return t.TempDir(), nil }
+	prevEnv, hadEnv := os.LookupEnv("AWS_CONFIG_FILE")
+	_ = os.Unsetenv("AWS_CONFIG_FILE")
+	defer func() {
+		awsConfigUserHomeDir = previous
+		if hadEnv {
+			_ = os.Setenv("AWS_CONFIG_FILE", prevEnv)
+		} else {
+			_ = os.Unsetenv("AWS_CONFIG_FILE")
+		}
+	}()
+	_, ok, err := LookupAWSSSOProfileByAccountID("020362606330")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatal("expected no match when ~/.aws/config does not exist")
+	}
+}
+
+// TestLookupAWSSSOProfileHonorsAWSConfigFileEnv: the AWS CLI lets
+// users redirect the shared config file via AWS_CONFIG_FILE. erun
+// honors the same variable so users who keep multiple work configs
+// (and switch between them with envrc shims) see the discovery
+// against the active file.
+func TestLookupAWSSSOProfileHonorsAWSConfigFileEnv(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.alt")
+	if err := os.WriteFile(path, []byte(`[profile alt]
+sso_start_url = https://alt.awsapps.com/start
+sso_region = us-west-2
+sso_account_id = 111111111111
+`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	prevEnv, hadEnv := os.LookupEnv("AWS_CONFIG_FILE")
+	_ = os.Setenv("AWS_CONFIG_FILE", path)
+	defer func() {
+		if hadEnv {
+			_ = os.Setenv("AWS_CONFIG_FILE", prevEnv)
+		} else {
+			_ = os.Unsetenv("AWS_CONFIG_FILE")
+		}
+	}()
+	got, ok, err := LookupAWSSSOProfileByAccountID("111111111111")
+	if err != nil || !ok {
+		t.Fatalf("lookup: %v / %v", ok, err)
+	}
+	if got.SSOStartURL != "https://alt.awsapps.com/start" {
+		t.Fatalf("start URL: %q", got.SSOStartURL)
+	}
+}
+
+// TestParseAWSSharedConfigSkipsCommentsAndBlankLines documents the
+// parser's whitespace tolerance: comment characters anchored at the
+// start of a line are stripped, blank lines are ignored, and value
+// trimming is applied to both keys and values.
+func TestParseAWSSharedConfigSkipsCommentsAndBlankLines(t *testing.T) {
+	restore := writeAWSConfig(t, `
+# leading comment
+[profile good]
+   sso_account_id = 222222222222
+   sso_start_url = https://x.awsapps.com/start
+; semicolon comment
+   sso_region    = eu-west-3
+`)
+	defer restore()
+	got, ok, err := LookupAWSSSOProfileByAccountID("222222222222")
+	if err != nil || !ok {
+		t.Fatalf("lookup: %v / %v", ok, err)
+	}
+	if got.SSORegion != "eu-west-3" || got.SSOStartURL != "https://x.awsapps.com/start" {
+		t.Fatalf("trimmed values not parsed: %+v", got)
+	}
+}

--- a/erun-common/cloud.go
+++ b/erun-common/cloud.go
@@ -153,6 +153,39 @@ func CloudProviderAlias(username, accountID, provider string) string {
 	return username + "+" + accountID + "@" + provider
 }
 
+// ParseCloudProviderAlias is the inverse of CloudProviderAlias. It
+// splits a "username+accountid@provider" string into its three
+// components. Used by the doctor's root-config repair flow to seed
+// a fresh InitAWSCloudProviderParams from a dangling alias reference
+// when the underlying CloudProviderConfig has been lost from
+// erun-config but the tenant or cloud-context still names it.
+//
+// Returns ok=false when the alias does not match the documented
+// shape — callers should treat that as "cannot auto-repair, prompt
+// the user to recreate from scratch."
+func ParseCloudProviderAlias(alias string) (username, accountID, provider string, ok bool) {
+	alias = strings.TrimSpace(alias)
+	if alias == "" {
+		return "", "", "", false
+	}
+	at := strings.LastIndex(alias, "@")
+	if at <= 0 || at == len(alias)-1 {
+		return "", "", "", false
+	}
+	left := alias[:at]
+	provider = strings.ToLower(strings.TrimSpace(alias[at+1:]))
+	plus := strings.LastIndex(left, "+")
+	if plus <= 0 || plus == len(left)-1 {
+		return "", "", "", false
+	}
+	username = strings.TrimSpace(left[:plus])
+	accountID = strings.TrimSpace(left[plus+1:])
+	if username == "" || accountID == "" || provider == "" {
+		return "", "", "", false
+	}
+	return username, accountID, provider, true
+}
+
 func ListCloudProviders(store CloudReadStore) ([]CloudProviderConfig, error) {
 	if store == nil {
 		return nil, fmt.Errorf("store is required")

--- a/erun-common/cloud_context_recover.go
+++ b/erun-common/cloud_context_recover.go
@@ -1,0 +1,250 @@
+package eruncommon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// RecoverCloudContextParams carries the inputs the recovery flow
+// cannot derive from the orphan record on its own. The CloudContext
+// alias is required because describe-instances must run under a
+// concrete cloud provider; the region is required for the EC2
+// regional endpoint; admin-token recovery is optional and falls back
+// to ~/.kube/config when left blank.
+type RecoverCloudContextParams struct {
+	KubernetesContext  string
+	CloudProviderAlias string
+	Region             string
+	AdminToken         string
+}
+
+// RecoverCloudContextResult records what the recovery flow saved so
+// the caller can surface the values back to the user (and so MCP
+// callers can inspect them without re-reading the config).
+type RecoverCloudContextResult struct {
+	Saved      CloudContextConfig
+	Source     string // "aws-describe-instances"
+	TokenFrom  string // "kubeconfig" | "input" | "none"
+}
+
+type awsDescribeInstanceJSON struct {
+	Reservations []struct {
+		Instances []struct {
+			InstanceID         string `json:"InstanceId"`
+			State              struct {
+				Name string `json:"Name"`
+			} `json:"State"`
+			PublicIPAddress    string `json:"PublicIpAddress,omitempty"`
+			InstanceType       string `json:"InstanceType"`
+			IamInstanceProfile struct {
+				Arn string `json:"Arn"`
+			} `json:"IamInstanceProfile,omitempty"`
+			SecurityGroups []struct {
+				GroupID string `json:"GroupId"`
+			} `json:"SecurityGroups"`
+			BlockDeviceMappings []struct {
+				Ebs struct {
+					VolumeID string `json:"VolumeId"`
+				} `json:"Ebs"`
+			} `json:"BlockDeviceMappings,omitempty"`
+			LaunchTime string `json:"LaunchTime,omitempty"`
+		} `json:"Instances"`
+	} `json:"Reservations"`
+}
+
+type awsDescribeVolumeJSON struct {
+	Volumes []struct {
+		VolumeType string `json:"VolumeType"`
+		Size       int    `json:"Size"`
+	} `json:"Volumes"`
+}
+
+// RecoverCloudContextFromAWS rebuilds a CloudContextConfig for a
+// missing context name by describing the matching EC2 instance,
+// pulling the EBS volume's size + type, sourcing the bearer token
+// from the supplied params or the local kubeconfig, and saving the
+// result via the supplied store. Returns an error when the instance
+// is missing, terminated, or ambiguous (multiple matches) — the
+// caller surfaces those distinctly so the user can react.
+//
+// The function intentionally does not call IAM describe-instance-profile
+// to populate InstanceProfileName / RoleName: those are only needed
+// when re-init re-attaches a profile to the instance, and the
+// already-running instance the recovery touches already has them in
+// place. Leaving them blank in the restored config keeps the
+// recovery scope tight while still producing a fully-usable
+// CloudContextConfig for kubectl + start/stop.
+func RecoverCloudContextFromAWS(ctx Context, store CloudContextStore, params RecoverCloudContextParams, deps CloudContextDependencies) (RecoverCloudContextResult, error) {
+	params.KubernetesContext = strings.TrimSpace(params.KubernetesContext)
+	params.CloudProviderAlias = strings.TrimSpace(params.CloudProviderAlias)
+	params.Region = strings.TrimSpace(params.Region)
+	if params.KubernetesContext == "" {
+		return RecoverCloudContextResult{}, errors.New("kubernetes context is required")
+	}
+	if params.CloudProviderAlias == "" {
+		return RecoverCloudContextResult{}, errors.New("cloud provider alias is required")
+	}
+	if params.Region == "" {
+		return RecoverCloudContextResult{}, errors.New("region is required")
+	}
+	deps = normalizeCloudContextDependencies(deps)
+	provider, err := ResolveCloudProvider(store, params.CloudProviderAlias)
+	if err != nil {
+		return RecoverCloudContextResult{}, err
+	}
+	instance, err := describeCloudContextInstanceByName(ctx, deps, provider, params.Region, params.KubernetesContext)
+	if err != nil {
+		return RecoverCloudContextResult{}, err
+	}
+	disk, err := describeCloudContextVolume(ctx, deps, provider, params.Region, instance.volumeID)
+	if err != nil {
+		ctx.Trace("cloud-context recover: volume describe failed: " + err.Error())
+		// Volume detail is best-effort. The caller can still save a
+		// usable context with disk fields empty; treat the failure
+		// as non-fatal trace + continue.
+	}
+	token, tokenFrom := resolveRecoverAdminToken(params)
+
+	config := CloudContextConfig{
+		Name:               params.KubernetesContext,
+		Provider:           CloudProviderAWS,
+		CloudProviderAlias: params.CloudProviderAlias,
+		Region:             params.Region,
+		KubernetesContext:  params.KubernetesContext,
+		InstanceID:         instance.id,
+		PublicIP:           instance.publicIP,
+		InstanceType:       instance.instanceType,
+		DiskType:           disk.volumeType,
+		DiskSizeGB:         disk.size,
+		AdminToken:         token,
+		CreatedAt:          instance.launchTime,
+		UpdatedAt:          deps.Now().UTC().Format(time.RFC3339),
+	}
+	if ctx.DryRun {
+		ctx.TraceCommand("", "write-yaml", "erun-config:cloudcontext "+params.KubernetesContext)
+		return RecoverCloudContextResult{Saved: config, Source: "aws-describe-instances", TokenFrom: tokenFrom}, nil
+	}
+	if err := saveCloudContextConfig(store, config); err != nil {
+		return RecoverCloudContextResult{}, err
+	}
+	return RecoverCloudContextResult{Saved: config, Source: "aws-describe-instances", TokenFrom: tokenFrom}, nil
+}
+
+func resolveRecoverAdminToken(params RecoverCloudContextParams) (string, string) {
+	if token := strings.TrimSpace(params.AdminToken); token != "" {
+		return token, "input"
+	}
+	token, ok, err := LookupKubeContextBearerToken(params.KubernetesContext)
+	if err != nil || !ok {
+		return "", "none"
+	}
+	return token, "kubeconfig"
+}
+
+type recoveredInstance struct {
+	id           string
+	publicIP     string
+	instanceType string
+	securityGroup string
+	instanceProfileARN string
+	volumeID     string
+	launchTime   string
+}
+
+type recoveredVolume struct {
+	volumeType string
+	size       int
+}
+
+func describeCloudContextInstanceByName(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, name string) (recoveredInstance, error) {
+	out, err := deps.RunAWS(ctx, provider, region, []string{
+		"ec2", "describe-instances",
+		"--filters",
+		"Name=tag:Name,Values=" + name,
+		"Name=instance-state-name,Values=pending,running,stopping,stopped",
+		"--output", "json",
+	})
+	if err != nil {
+		return recoveredInstance{}, err
+	}
+	if ctx.DryRun {
+		return recoveredInstance{
+			id:           "i-<recovered>",
+			publicIP:     "203.0.113.10",
+			instanceType: "c8gd.2xlarge",
+			volumeID:     "vol-<recovered>",
+			launchTime:   "2026-01-01T00:00:00Z",
+		}, nil
+	}
+	parsed := awsDescribeInstanceJSON{}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		return recoveredInstance{}, fmt.Errorf("parse describe-instances: %w", err)
+	}
+	matches := flattenAWSDescribeInstances(parsed)
+	switch len(matches) {
+	case 0:
+		return recoveredInstance{}, fmt.Errorf("no EC2 instance found with Name tag %q in region %s", name, region)
+	case 1:
+		return matches[0], nil
+	default:
+		return recoveredInstance{}, fmt.Errorf("multiple EC2 instances found with Name tag %q in region %s; resolve manually then re-run", name, region)
+	}
+}
+
+func flattenAWSDescribeInstances(parsed awsDescribeInstanceJSON) []recoveredInstance {
+	out := make([]recoveredInstance, 0)
+	for _, reservation := range parsed.Reservations {
+		for _, raw := range reservation.Instances {
+			candidate := recoveredInstance{
+				id:                 strings.TrimSpace(raw.InstanceID),
+				publicIP:           strings.TrimSpace(raw.PublicIPAddress),
+				instanceType:       strings.TrimSpace(raw.InstanceType),
+				instanceProfileARN: strings.TrimSpace(raw.IamInstanceProfile.Arn),
+				launchTime:         strings.TrimSpace(raw.LaunchTime),
+			}
+			if len(raw.SecurityGroups) > 0 {
+				candidate.securityGroup = strings.TrimSpace(raw.SecurityGroups[0].GroupID)
+			}
+			if len(raw.BlockDeviceMappings) > 0 {
+				candidate.volumeID = strings.TrimSpace(raw.BlockDeviceMappings[0].Ebs.VolumeID)
+			}
+			if candidate.id == "" {
+				continue
+			}
+			out = append(out, candidate)
+		}
+	}
+	return out
+}
+
+func describeCloudContextVolume(ctx Context, deps CloudContextDependencies, provider CloudProviderConfig, region, volumeID string) (recoveredVolume, error) {
+	volumeID = strings.TrimSpace(volumeID)
+	if volumeID == "" || strings.HasPrefix(volumeID, "vol-<") {
+		return recoveredVolume{}, nil
+	}
+	out, err := deps.RunAWS(ctx, provider, region, []string{
+		"ec2", "describe-volumes",
+		"--volume-ids", volumeID,
+		"--output", "json",
+	})
+	if err != nil {
+		return recoveredVolume{}, err
+	}
+	if ctx.DryRun {
+		return recoveredVolume{volumeType: "gp3", size: 100}, nil
+	}
+	parsed := awsDescribeVolumeJSON{}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		return recoveredVolume{}, fmt.Errorf("parse describe-volumes: %w", err)
+	}
+	if len(parsed.Volumes) == 0 {
+		return recoveredVolume{}, nil
+	}
+	return recoveredVolume{
+		volumeType: strings.TrimSpace(parsed.Volumes[0].VolumeType),
+		size:       parsed.Volumes[0].Size,
+	}, nil
+}

--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -1,6 +1,7 @@
 package eruncommon
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -419,7 +420,15 @@ func SaveERunConfig(config ERunConfig) error {
 		return ErrFailedToSaveConfig
 	}
 
-	if err := os.WriteFile(configFilePath, data, 0o644); err != nil {
+	// Capture today's snapshot of the previous live file before we
+	// overwrite it. Best-effort: a backup failure must not block the
+	// save (the bug we are guarding against is data loss, and refusing
+	// to save when the backup directory is full would itself cause
+	// data loss). The implementation is idempotent on repeated saves
+	// within one local day.
+	_ = writeRootConfigBackupIfDue(configFilePath, timeNow)
+
+	if err := writeFileAtomic(configFilePath, data, 0o644); err != nil {
 		return ErrFailedToSaveConfig
 	}
 
@@ -436,6 +445,16 @@ func LoadERunConfig() (ERunConfig, string, error) {
 	data, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return config, configFilePath, ErrNotInitialized
+	}
+
+	// A zero-length file is the residue of an interrupted non-atomic
+	// write. Treating it as "successfully loaded empty config" lets
+	// the next writer rebuild a fresh ERunConfig{} with only the
+	// field it cares about, silently dropping every other section.
+	// Surface it as corruption so callers route into the doctor
+	// recovery path instead.
+	if len(bytes.TrimSpace(data)) == 0 {
+		return config, configFilePath, ErrConfigCorrupted
 	}
 
 	if err := yaml.Unmarshal(data, &config); err != nil {
@@ -461,7 +480,7 @@ func SaveTenantConfig(config TenantConfig) error {
 		return ErrFailedToSaveConfig
 	}
 
-	if err := os.WriteFile(configFilePath, data, 0o644); err != nil {
+	if err := writeFileAtomic(configFilePath, data, 0o644); err != nil {
 		return ErrFailedToSaveConfig
 	}
 
@@ -498,6 +517,10 @@ func LoadTenantConfig(tenant string) (TenantConfig, string, error) {
 	data, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return config, configFilePath, ErrNotInitialized
+	}
+
+	if len(bytes.TrimSpace(data)) == 0 {
+		return config, configFilePath, ErrConfigCorrupted
 	}
 
 	if err := yaml.Unmarshal(data, &config); err != nil {
@@ -562,7 +585,7 @@ func SaveEnvConfig(tenant string, config EnvConfig) error {
 		return ErrFailedToSaveConfig
 	}
 
-	if err := os.WriteFile(configFilePath, data, 0o644); err != nil {
+	if err := writeFileAtomic(configFilePath, data, 0o644); err != nil {
 		return ErrFailedToSaveConfig
 	}
 
@@ -591,6 +614,10 @@ func LoadEnvConfig(tenant, envName string) (EnvConfig, string, error) {
 	data, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return config, configFilePath, ErrNotInitialized
+	}
+
+	if len(bytes.TrimSpace(data)) == 0 {
+		return config, configFilePath, ErrConfigCorrupted
 	}
 
 	if err := yaml.Unmarshal(data, &config); err != nil {
@@ -655,7 +682,7 @@ func SaveProjectConfig(projectRoot string, config ProjectConfig) error {
 		return ErrFailedToSaveConfig
 	}
 
-	if err := os.WriteFile(configFilePath, data, 0o644); err != nil {
+	if err := writeFileAtomic(configFilePath, data, 0o644); err != nil {
 		return ErrFailedToSaveConfig
 	}
 
@@ -672,6 +699,10 @@ func LoadProjectConfig(projectRoot string) (ProjectConfig, string, error) {
 	data, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return config, configFilePath, ErrNotInitialized
+	}
+
+	if len(bytes.TrimSpace(data)) == 0 {
+		return config, configFilePath, ErrConfigCorrupted
 	}
 
 	if err := yaml.Unmarshal(data, &config); err != nil {
@@ -711,4 +742,47 @@ func projectConfigPath(projectRoot string) (string, error) {
 		return "", ErrNotInGitRepository
 	}
 	return filepath.Join(filepath.Clean(projectRoot), projectConfigDir, configFile), nil
+}
+
+// writeFileAtomic writes data to a sibling temp file in the same
+// directory as path, fsyncs the contents, then renames it over the
+// destination. The rename is atomic on POSIX filesystems when source
+// and destination share a filesystem, which is guaranteed here because
+// the temp file is created in filepath.Dir(path). A crash or process
+// kill between the create and the rename leaves either the previous
+// contents intact or no change at all — never a 0-byte or partially
+// written file. Replaces the previous os.WriteFile (O_TRUNC|O_WRONLY)
+// path which produced exactly that hazard on interruption.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }

--- a/erun-common/config_backup.go
+++ b/erun-common/config_backup.go
@@ -1,0 +1,254 @@
+package eruncommon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// rootConfigBackupSuffix is the trailing extension used for every
+// dated backup file. The full backup name follows the shape
+// "<live-basename>.<YYYY-MM-DD>.bak", written into the same directory
+// as the live root config so the atomic rename guarantee inside
+// writeFileAtomic still applies to backup creation.
+const rootConfigBackupSuffix = ".bak"
+
+// rootConfigBackupKeep is the cap on retained backups. The policy is
+// purely count-based: when a new daily backup pushes the file count
+// past this number, the oldest existing backup is evicted. Backups
+// are never pruned by age, so a pre-existing 10-day-old file is kept
+// until 5 newer dailies push it out.
+const rootConfigBackupKeep = 5
+
+// timeNow is the package-level clock used by every time-sensitive
+// helper in this file (backup naming, rotation, listing). Tests swap
+// it with a fixed clock; production keeps the default time.Now.
+// Defined here so the backup code is the only consumer that needs to
+// know about clock injection.
+var timeNow = time.Now
+
+// RootConfigBackup describes one dated backup file on disk. The Date
+// field is parsed from the filename (not the filesystem mtime) so
+// rotation order stays correct even on platforms with imprecise file
+// timestamps.
+type RootConfigBackup struct {
+	Path string
+	Date time.Time
+}
+
+// writeRootConfigBackupIfDue snapshots the *current* contents of the
+// live root config file under "<livePath>.<YYYY-MM-DD>.bak" using
+// the supplied clock for the date stamp. It is intentionally a
+// best-effort operation:
+//
+//   - When the live file does not exist yet (true first-write), there
+//     is nothing to back up; returns nil.
+//   - When today's dated backup already exists, the function is a
+//     no-op so multiple saves in the same UTC date do not rewrite the
+//     same snapshot or evict newer rotation slots.
+//   - After a successful write it calls pruneOldRootConfigBackups to
+//     enforce the count-based retention policy.
+//
+// The "if due" wording is deliberate: the only signal for "back up
+// now" is "today's slot is empty." There is no I/O dependency on
+// timers, mtimes, or external state.
+func writeRootConfigBackupIfDue(livePath string, now func() time.Time) error {
+	if strings.TrimSpace(livePath) == "" {
+		return errors.New("live path is required")
+	}
+	if now == nil {
+		now = time.Now
+	}
+	current, err := os.ReadFile(livePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	dir := filepath.Dir(livePath)
+	base := filepath.Base(livePath)
+	backupPath := filepath.Join(dir, rootConfigBackupName(base, now()))
+	if _, err := os.Stat(backupPath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := writeFileAtomic(backupPath, current, 0o644); err != nil {
+		return err
+	}
+	return pruneOldRootConfigBackups(dir, base, rootConfigBackupKeep)
+}
+
+// ListRootConfigBackups enumerates every dated backup found next to
+// the supplied live config path, newest first. Filenames that fail to
+// parse as a valid YYYY-MM-DD stamp are skipped silently — the
+// rotation policy never created them, so they are out-of-band and
+// stay where they are.
+func ListRootConfigBackups(livePath string) ([]RootConfigBackup, error) {
+	if strings.TrimSpace(livePath) == "" {
+		return nil, errors.New("live path is required")
+	}
+	dir := filepath.Dir(livePath)
+	base := filepath.Base(livePath)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	backups := make([]RootConfigBackup, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		date, ok := parseRootConfigBackupName(base, entry.Name())
+		if !ok {
+			continue
+		}
+		backups = append(backups, RootConfigBackup{
+			Path: filepath.Join(dir, entry.Name()),
+			Date: date,
+		})
+	}
+	sort.Slice(backups, func(i, j int) bool {
+		return backups[i].Date.After(backups[j].Date)
+	})
+	return backups, nil
+}
+
+// FindRootConfigBackupByDate returns the backup whose dated suffix
+// matches the supplied YYYY-MM-DD string. Used by the CLI's
+// --restore-config-from-backup flow to resolve a user-supplied date
+// without doing the full enumeration twice.
+func FindRootConfigBackupByDate(livePath, date string) (RootConfigBackup, bool, error) {
+	date = strings.TrimSpace(date)
+	if date == "" {
+		return RootConfigBackup{}, false, errors.New("date is required")
+	}
+	parsed, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		return RootConfigBackup{}, false, fmt.Errorf("invalid backup date %q: %w", date, err)
+	}
+	backups, err := ListRootConfigBackups(livePath)
+	if err != nil {
+		return RootConfigBackup{}, false, err
+	}
+	for _, backup := range backups {
+		if backup.Date.Equal(parsed) {
+			return backup, true, nil
+		}
+	}
+	return RootConfigBackup{}, false, nil
+}
+
+// RestoreRootConfigFromBackup copies the bytes of the supplied backup
+// file over the live root config path, after validating that the
+// bytes deserialize cleanly into an ERunConfig. The validation is the
+// whole point of routing the restore through this helper instead of a
+// plain cp: a corrupted backup must not replace a (possibly less
+// corrupted) live file. Restores via the atomic-write helper so a
+// crash mid-restore cannot itself produce a partial file.
+func RestoreRootConfigFromBackup(backupPath, livePath string) error {
+	if strings.TrimSpace(backupPath) == "" || strings.TrimSpace(livePath) == "" {
+		return errors.New("backup and live paths are required")
+	}
+	data, err := os.ReadFile(backupPath)
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return fmt.Errorf("backup %s is empty", backupPath)
+	}
+	probe := ERunConfig{}
+	if err := yaml.Unmarshal(data, &probe); err != nil {
+		return fmt.Errorf("backup %s is not a valid erun config: %w", backupPath, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(livePath), 0o755); err != nil {
+		return ErrNoUserDataFolder
+	}
+	if err := writeFileAtomic(livePath, data, 0o644); err != nil {
+		return ErrFailedToSaveConfig
+	}
+	return nil
+}
+
+// pruneOldRootConfigBackups enforces the count-based retention
+// policy. Backups whose filenames do not parse as YYYY-MM-DD are
+// considered out-of-band and are not counted toward the retention
+// budget; they are also not removed. This is intentional: the policy
+// is "evict by count among files we wrote" rather than "delete any
+// .bak in this directory."
+func pruneOldRootConfigBackups(dir, base string, keep int) error {
+	if keep <= 0 {
+		return nil
+	}
+	backups, err := listManagedRootConfigBackups(dir, base)
+	if err != nil {
+		return err
+	}
+	if len(backups) <= keep {
+		return nil
+	}
+	for _, victim := range backups[keep:] {
+		if err := os.Remove(victim.Path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
+}
+
+func listManagedRootConfigBackups(dir, base string) ([]RootConfigBackup, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	backups := make([]RootConfigBackup, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		date, ok := parseRootConfigBackupName(base, entry.Name())
+		if !ok {
+			continue
+		}
+		backups = append(backups, RootConfigBackup{
+			Path: filepath.Join(dir, entry.Name()),
+			Date: date,
+		})
+	}
+	sort.Slice(backups, func(i, j int) bool {
+		return backups[i].Date.After(backups[j].Date)
+	})
+	return backups, nil
+}
+
+func rootConfigBackupName(base string, t time.Time) string {
+	return base + "." + t.UTC().Format("2006-01-02") + rootConfigBackupSuffix
+}
+
+func parseRootConfigBackupName(base, name string) (time.Time, bool) {
+	prefix := base + "."
+	if !strings.HasPrefix(name, prefix) {
+		return time.Time{}, false
+	}
+	if !strings.HasSuffix(name, rootConfigBackupSuffix) {
+		return time.Time{}, false
+	}
+	stamp := strings.TrimSuffix(strings.TrimPrefix(name, prefix), rootConfigBackupSuffix)
+	parsed, err := time.Parse("2006-01-02", stamp)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
+}

--- a/erun-common/config_backup_test.go
+++ b/erun-common/config_backup_test.go
@@ -1,0 +1,356 @@
+package eruncommon
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+)
+
+// TestWriteRootConfigBackupSnapshotsPreviousContents covers the
+// happy path: a live config file is present, today's backup slot is
+// empty, and the helper should snapshot the current contents under
+// "<base>.<YYYY-MM-DD>.bak" without modifying the live file.
+func TestWriteRootConfigBackupSnapshotsPreviousContents(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(live, []byte("defaulttenant: foo\n"), 0o644); err != nil {
+		t.Fatalf("seed live config: %v", err)
+	}
+
+	now := func() time.Time { return time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC) }
+	if err := writeRootConfigBackupIfDue(live, now); err != nil {
+		t.Fatalf("writeRootConfigBackupIfDue: %v", err)
+	}
+
+	backup := filepath.Join(dir, "config.yaml.2026-05-21.bak")
+	data, err := os.ReadFile(backup)
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(data) != "defaulttenant: foo\n" {
+		t.Fatalf("unexpected backup contents %q", string(data))
+	}
+}
+
+// TestWriteRootConfigBackupIsIdempotentSameDay verifies that
+// repeated saves within one UTC date do not rewrite the day's
+// backup. The backup must capture the state BEFORE the user's
+// first save of the day; subsequent saves should leave it alone.
+func TestWriteRootConfigBackupIsIdempotentSameDay(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(live, []byte("first\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	now := func() time.Time { return time.Date(2026, 5, 21, 0, 0, 0, 0, time.UTC) }
+	if err := writeRootConfigBackupIfDue(live, now); err != nil {
+		t.Fatalf("first backup: %v", err)
+	}
+	// Mutate the live file to simulate a subsequent save's contents,
+	// then run the helper again with the same clock. The existing
+	// backup should remain unchanged (still "first\n").
+	if err := os.WriteFile(live, []byte("second\n"), 0o644); err != nil {
+		t.Fatalf("update live: %v", err)
+	}
+	if err := writeRootConfigBackupIfDue(live, now); err != nil {
+		t.Fatalf("second backup: %v", err)
+	}
+	backup := filepath.Join(dir, "config.yaml.2026-05-21.bak")
+	data, err := os.ReadFile(backup)
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(data) != "first\n" {
+		t.Fatalf("backup overwritten; got %q want %q", string(data), "first\n")
+	}
+}
+
+// TestWriteRootConfigBackupNoLiveFileIsNoop covers the first-write
+// case: the live config does not exist yet. There is nothing to
+// snapshot, so the helper must return success without creating a
+// stub or surfacing an error.
+func TestWriteRootConfigBackupNoLiveFileIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "config.yaml")
+	now := func() time.Time { return time.Date(2026, 5, 21, 0, 0, 0, 0, time.UTC) }
+	if err := writeRootConfigBackupIfDue(live, now); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no files, got %v", entries)
+	}
+}
+
+// TestPruneOldRootConfigBackupsKeepsFiveNewestRegardlessOfAge is the
+// core retention guarantee: rotation evicts by count, never by age.
+// Seven dated backups exist; a write today produces the eighth.
+// After pruning, only the five newest must remain — and crucially
+// that count includes the very old 2026-01-01 file when it is
+// among the newest five at prune time.
+func TestPruneOldRootConfigBackupsKeepsFiveNewestRegardlessOfAge(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "config.yaml")
+	base := filepath.Base(live)
+	dates := []time.Time{
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 16, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 17, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 19, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 21, 0, 0, 0, 0, time.UTC),
+	}
+	for _, d := range dates {
+		path := filepath.Join(dir, rootConfigBackupName(base, d))
+		if err := os.WriteFile(path, []byte(d.Format(time.RFC3339)), 0o644); err != nil {
+			t.Fatalf("seed %s: %v", path, err)
+		}
+	}
+
+	if err := pruneOldRootConfigBackups(dir, base, rootConfigBackupKeep); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+
+	remaining, err := listManagedRootConfigBackups(dir, base)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(remaining) != rootConfigBackupKeep {
+		t.Fatalf("expected %d remaining, got %d (%v)", rootConfigBackupKeep, len(remaining), remaining)
+	}
+	want := []string{"2026-05-21", "2026-05-20", "2026-05-19", "2026-05-18", "2026-05-17"}
+	for i, expected := range want {
+		got := remaining[i].Date.Format("2006-01-02")
+		if got != expected {
+			t.Fatalf("position %d: got %s, want %s", i, got, expected)
+		}
+	}
+}
+
+// TestPruneDoesNotWipePreexistingOldBackupBeforeFiveDailiesArrive
+// codifies the stated policy in plain English: a 10-day-old backup
+// that already lives in the directory at startup must survive the
+// first daily save. Only once five newer dailies accumulate does the
+// oldest one get evicted.
+func TestPruneDoesNotWipePreexistingOldBackupBeforeFiveDailiesArrive(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "config.yaml")
+	base := filepath.Base(live)
+	tenDaysAgo := time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC)
+	if err := os.WriteFile(filepath.Join(dir, rootConfigBackupName(base, tenDaysAgo)), []byte("ancient"), 0o644); err != nil {
+		t.Fatalf("seed ancient: %v", err)
+	}
+	if err := os.WriteFile(live, []byte("today\n"), 0o644); err != nil {
+		t.Fatalf("seed live: %v", err)
+	}
+
+	// Run backups for four consecutive days.
+	for _, d := range []time.Time{
+		time.Date(2026, 5, 21, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 23, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC),
+	} {
+		now := d
+		if err := writeRootConfigBackupIfDue(live, func() time.Time { return now }); err != nil {
+			t.Fatalf("backup %s: %v", d, err)
+		}
+	}
+
+	remaining, err := listManagedRootConfigBackups(dir, base)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(remaining) != 5 {
+		t.Fatalf("expected 5 backups (4 dailies + the preserved ancient), got %d", len(remaining))
+	}
+	dates := make([]string, 0, len(remaining))
+	for _, b := range remaining {
+		dates = append(dates, b.Date.Format("2006-01-02"))
+	}
+	if !containsTrimmedAlias(dates, "2026-05-11") {
+		t.Fatalf("ancient backup was wiped before five new dailies replaced it: %v", dates)
+	}
+
+	// Fifth daily must finally push the ancient one out.
+	fifth := time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC)
+	if err := writeRootConfigBackupIfDue(live, func() time.Time { return fifth }); err != nil {
+		t.Fatalf("fifth backup: %v", err)
+	}
+	remaining, err = listManagedRootConfigBackups(dir, base)
+	if err != nil {
+		t.Fatalf("relist: %v", err)
+	}
+	if len(remaining) != 5 {
+		t.Fatalf("expected 5 backups after eviction, got %d", len(remaining))
+	}
+	dates = dates[:0]
+	for _, b := range remaining {
+		dates = append(dates, b.Date.Format("2006-01-02"))
+	}
+	if containsTrimmedAlias(dates, "2026-05-11") {
+		t.Fatalf("ancient backup should have been evicted on the 5th daily: %v", dates)
+	}
+}
+
+// TestListRootConfigBackupsSortsNewestFirst documents the API
+// guarantee CLI report rendering relies on: callers want to surface
+// the most-recently-dated backup as the default restore option.
+func TestListRootConfigBackupsSortsNewestFirst(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "config.yaml")
+	base := filepath.Base(live)
+	for _, d := range []time.Time{
+		time.Date(2026, 5, 17, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 19, 0, 0, 0, 0, time.UTC),
+	} {
+		path := filepath.Join(dir, rootConfigBackupName(base, d))
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	got, err := ListRootConfigBackups(live)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !sort.SliceIsSorted(got, func(i, j int) bool {
+		return got[i].Date.After(got[j].Date)
+	}) {
+		t.Fatalf("not sorted newest-first: %v", got)
+	}
+}
+
+// TestRestoreRootConfigFromBackupRejectsCorruptBackup is the safety
+// guarantee: a backup that fails to deserialize must not replace
+// the live file. The whole point of routing the restore through
+// this helper is to avoid corrupted-replaces-broken cascades.
+func TestRestoreRootConfigFromBackupRejectsCorruptBackup(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(live, []byte("defaulttenant: original\n"), 0o644); err != nil {
+		t.Fatalf("seed live: %v", err)
+	}
+	backup := filepath.Join(dir, "config.yaml.2026-05-19.bak")
+	if err := os.WriteFile(backup, []byte("\xff\xff\xffnot yaml"), 0o644); err != nil {
+		t.Fatalf("seed corrupt backup: %v", err)
+	}
+	err := RestoreRootConfigFromBackup(backup, live)
+	if err == nil {
+		t.Fatalf("expected restore to refuse corrupt backup")
+	}
+	live2, err := os.ReadFile(live)
+	if err != nil {
+		t.Fatalf("re-read live: %v", err)
+	}
+	if string(live2) != "defaulttenant: original\n" {
+		t.Fatalf("live file was overwritten despite corrupt backup: %q", string(live2))
+	}
+}
+
+// TestRestoreRootConfigFromBackupHappyPath covers the success path.
+// The validation step accepts a well-formed YAML, the live file
+// receives an atomic rewrite, and a subsequent LoadERunConfig sees
+// the restored values.
+func TestRestoreRootConfigFromBackupHappyPath(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(live, []byte("\x00\x00\x00"), 0o644); err != nil {
+		t.Fatalf("seed live (corrupt): %v", err)
+	}
+	backup := filepath.Join(dir, "config.yaml.2026-05-20.bak")
+	if err := os.WriteFile(backup, []byte("defaulttenant: restored\n"), 0o644); err != nil {
+		t.Fatalf("seed backup: %v", err)
+	}
+	if err := RestoreRootConfigFromBackup(backup, live); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	data, err := os.ReadFile(live)
+	if err != nil {
+		t.Fatalf("read live: %v", err)
+	}
+	if string(data) != "defaulttenant: restored\n" {
+		t.Fatalf("live not replaced: %q", string(data))
+	}
+}
+
+// TestFindRootConfigBackupByDate exercises the selector helper the
+// CLI/MCP both call when the user supplies a YYYY-MM-DD string.
+func TestFindRootConfigBackupByDate(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "config.yaml")
+	base := filepath.Base(live)
+	d := time.Date(2026, 5, 19, 0, 0, 0, 0, time.UTC)
+	if err := os.WriteFile(filepath.Join(dir, rootConfigBackupName(base, d)), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	got, ok, err := FindRootConfigBackupByDate(live, "2026-05-19")
+	if err != nil || !ok {
+		t.Fatalf("find: ok=%v err=%v", ok, err)
+	}
+	if !got.Date.Equal(d) {
+		t.Fatalf("date mismatch: %v", got.Date)
+	}
+	_, ok, err = FindRootConfigBackupByDate(live, "2026-05-15")
+	if err != nil {
+		t.Fatalf("miss err: %v", err)
+	}
+	if ok {
+		t.Fatal("expected miss for absent date")
+	}
+	if _, _, err := FindRootConfigBackupByDate(live, "not-a-date"); err == nil {
+		t.Fatal("expected error for malformed date")
+	}
+}
+
+// TestWriteFileAtomicSwapsAtomically ensures the temp file is gone
+// after a successful write so callers can re-run the helper without
+// leftover state. The function is in config.go but its semantics are
+// the foundation for the backup machinery, so the test lives here.
+func TestWriteFileAtomicSwapsAtomically(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.txt")
+	if err := writeFileAtomic(target, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("contents: %q", string(data))
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("list dir: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != "out.txt" {
+			t.Fatalf("stray file in dir: %s", entry.Name())
+		}
+	}
+}
+
+// TestWriteFileAtomicCleansUpOnError verifies that a permission
+// failure during the rename phase leaves the directory clean rather
+// than littered with .tmp-* files.
+func TestWriteFileAtomicCleansUpOnError(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "subdir", "out.txt")
+	err := writeFileAtomic(target, []byte("data"), 0o644)
+	if err == nil {
+		t.Fatal("expected error: directory does not exist")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		// Different platforms surface this differently; the assertion
+		// here only documents that the write must fail loudly.
+		t.Logf("non-ErrNotExist failure surface: %v", err)
+	}
+}

--- a/erun-common/doctor_root_config.go
+++ b/erun-common/doctor_root_config.go
@@ -1,0 +1,281 @@
+package eruncommon
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// RootConfigStatus categorizes the on-disk root config's load state.
+// It is the doctor's first signal: "ok" means we can move on to
+// looking for orphaned references, anything else means the file
+// itself needs a restore before alias-level repair makes sense.
+type RootConfigStatus string
+
+const (
+	RootConfigStatusOK        RootConfigStatus = "ok"
+	RootConfigStatusMissing   RootConfigStatus = "missing"
+	RootConfigStatusCorrupted RootConfigStatus = "corrupted"
+)
+
+// OrphanedAliasContextRef names one cloud-context entry that points
+// at a missing root cloud-provider alias. The Region is captured so a
+// repair flow can pre-fill InitAWSCloudProviderParams.Region (it is
+// the only piece of context-side state that overlaps with provider
+// init params).
+type OrphanedAliasContextRef struct {
+	Name   string `json:"name"`
+	Region string `json:"region"`
+}
+
+// OrphanedAlias collects every back-reference for a single missing
+// alias plus the decoded username/account/provider triple. The
+// decoded fields are populated when ParseCloudProviderAlias succeeds;
+// otherwise they remain empty and Parsed is false, which tells the
+// repair flow it cannot auto-seed an init call.
+type OrphanedAlias struct {
+	Alias                     string                    `json:"alias"`
+	Username                  string                    `json:"username,omitempty"`
+	AccountID                 string                    `json:"accountId,omitempty"`
+	Provider                  string                    `json:"provider,omitempty"`
+	Parsed                    bool                      `json:"parsed"`
+	ReferencedByTenants       []string                  `json:"referencedByTenants,omitempty"`
+	ReferencedByCloudContexts []OrphanedAliasContextRef `json:"referencedByCloudContexts,omitempty"`
+}
+
+// RootConfigInspection is the structured view of the root config
+// state used by both the CLI doctor and the MCP doctor tool. It is
+// purely descriptive: nothing in this file performs side effects.
+type RootConfigInspection struct {
+	ConfigPath       string             `json:"configPath"`
+	ConfigStatus     RootConfigStatus   `json:"configStatus"`
+	ConfigError      string             `json:"configError,omitempty"`
+	OrphanedAliases  []OrphanedAlias    `json:"orphanedAliases,omitempty"`
+	Backups          []RootConfigBackup `json:"backups,omitempty"`
+	ConfiguredCount  int                `json:"configuredProviderCount"`
+	CloudContextHits int                `json:"cloudContextCount"`
+	TenantHits       int                `json:"tenantCount"`
+}
+
+// Complete reports whether the root config is in a state the rest of
+// erun can rely on. False when the file failed to load OR when any
+// orphan reference was found.
+func (r RootConfigInspection) Complete() bool {
+	if r.ConfigStatus != RootConfigStatusOK {
+		return false
+	}
+	return len(r.OrphanedAliases) == 0
+}
+
+// RootConfigInspectionStore is the read-only surface InspectRootConfig
+// needs. Kept narrow on purpose: the inspection must work even when
+// the root config is unloadable, so it leans on ListTenantConfigs
+// (which reads tenant-level files independently) and a direct
+// LoadERunConfig probe for the central file.
+type RootConfigInspectionStore interface {
+	LoadERunConfig() (ERunConfig, string, error)
+	ListTenantConfigs() ([]TenantConfig, error)
+}
+
+// InspectRootConfig walks the root config and every tenant config to
+// surface dangling cloud-provider-alias references. The walk does not
+// mutate anything; on a healthy install it produces an inspection
+// with status=ok, zero orphans, and (when present) the available
+// daily backup list so doctor can offer rollback as an option even on
+// a healthy system.
+func InspectRootConfig(store RootConfigInspectionStore) (RootConfigInspection, error) {
+	if store == nil {
+		return RootConfigInspection{}, errors.New("store is required")
+	}
+	config, configPath, err := store.LoadERunConfig()
+	inspection := RootConfigInspection{
+		ConfigPath: configPath,
+	}
+	switch {
+	case err == nil:
+		inspection.ConfigStatus = RootConfigStatusOK
+	case errors.Is(err, ErrNotInitialized):
+		inspection.ConfigStatus = RootConfigStatusMissing
+		inspection.ConfigError = err.Error()
+	case errors.Is(err, ErrConfigCorrupted):
+		inspection.ConfigStatus = RootConfigStatusCorrupted
+		inspection.ConfigError = err.Error()
+	default:
+		return RootConfigInspection{}, err
+	}
+
+	if backups, listErr := ListRootConfigBackups(configPath); listErr == nil {
+		inspection.Backups = backups
+	}
+
+	// Only walk references when the root config loaded cleanly. With
+	// a corrupted or missing root we have no source of truth for the
+	// CloudProviders list to compare against — every alias reference
+	// would look orphaned, which is noise. The recommended action in
+	// that state is "restore from backup," surfaced separately via
+	// Backups.
+	if inspection.ConfigStatus != RootConfigStatusOK {
+		return inspection, nil
+	}
+
+	configured := make(map[string]struct{}, len(config.CloudProviders))
+	for _, provider := range config.CloudProviders {
+		alias := strings.TrimSpace(provider.Alias)
+		if alias == "" {
+			continue
+		}
+		configured[alias] = struct{}{}
+	}
+	inspection.ConfiguredCount = len(configured)
+
+	tenants, err := store.ListTenantConfigs()
+	if err != nil {
+		return RootConfigInspection{}, err
+	}
+	inspection.TenantHits = len(tenants)
+	inspection.CloudContextHits = len(config.CloudContexts)
+
+	orphans := make(map[string]*OrphanedAlias)
+	addOrphanTenant := func(alias, tenant string) {
+		alias = strings.TrimSpace(alias)
+		tenant = strings.TrimSpace(tenant)
+		if alias == "" || tenant == "" {
+			return
+		}
+		entry := orphans[alias]
+		if entry == nil {
+			entry = newOrphanedAlias(alias)
+			orphans[alias] = entry
+		}
+		if !containsTrimmedAlias(entry.ReferencedByTenants, tenant) {
+			entry.ReferencedByTenants = append(entry.ReferencedByTenants, tenant)
+		}
+	}
+	addOrphanContext := func(alias, contextName, region string) {
+		alias = strings.TrimSpace(alias)
+		contextName = strings.TrimSpace(contextName)
+		if alias == "" || contextName == "" {
+			return
+		}
+		entry := orphans[alias]
+		if entry == nil {
+			entry = newOrphanedAlias(alias)
+			orphans[alias] = entry
+		}
+		ref := OrphanedAliasContextRef{Name: contextName, Region: strings.TrimSpace(region)}
+		for _, existing := range entry.ReferencedByCloudContexts {
+			if existing.Name == ref.Name {
+				return
+			}
+		}
+		entry.ReferencedByCloudContexts = append(entry.ReferencedByCloudContexts, ref)
+	}
+
+	for _, tenant := range tenants {
+		aliases := append([]string{}, tenant.CloudProviderAliases...)
+		if primary := strings.TrimSpace(tenant.PrimaryCloudProviderAlias); primary != "" {
+			aliases = append(aliases, primary)
+		}
+		for _, alias := range aliases {
+			alias = strings.TrimSpace(alias)
+			if alias == "" {
+				continue
+			}
+			if _, ok := configured[alias]; ok {
+				continue
+			}
+			addOrphanTenant(alias, tenant.Name)
+		}
+	}
+
+	for _, cloudContext := range config.CloudContexts {
+		alias := strings.TrimSpace(cloudContext.CloudProviderAlias)
+		if alias == "" {
+			continue
+		}
+		if _, ok := configured[alias]; ok {
+			continue
+		}
+		addOrphanContext(alias, cloudContext.Name, cloudContext.Region)
+	}
+
+	if len(orphans) == 0 {
+		return inspection, nil
+	}
+	aliases := make([]string, 0, len(orphans))
+	for alias := range orphans {
+		aliases = append(aliases, alias)
+	}
+	sort.Strings(aliases)
+	for _, alias := range aliases {
+		entry := orphans[alias]
+		sort.Strings(entry.ReferencedByTenants)
+		sort.Slice(entry.ReferencedByCloudContexts, func(i, j int) bool {
+			return entry.ReferencedByCloudContexts[i].Name < entry.ReferencedByCloudContexts[j].Name
+		})
+		inspection.OrphanedAliases = append(inspection.OrphanedAliases, *entry)
+	}
+	return inspection, nil
+}
+
+func newOrphanedAlias(alias string) *OrphanedAlias {
+	entry := &OrphanedAlias{Alias: alias}
+	if username, accountID, provider, ok := ParseCloudProviderAlias(alias); ok {
+		entry.Username = username
+		entry.AccountID = accountID
+		entry.Provider = provider
+		entry.Parsed = true
+	}
+	return entry
+}
+
+func containsTrimmedAlias(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// RepairOrphanedAliasParams carries the fields needed to re-init a
+// provider for one orphan. Region is sourced from a referenced cloud
+// context when available; SSORegion / SSOStartURL come from the
+// caller because they are not derivable from any persisted state.
+type RepairOrphanedAliasParams struct {
+	Orphan        OrphanedAlias
+	SSORegion     string
+	SSOStartURL   string
+	RoleName      string
+	Region        string
+	OIDCIssuerURL string
+	SkipLogin     bool
+}
+
+// RepairOrphanedAlias re-creates a CloudProviderConfig for one
+// orphaned alias by routing to InitAWSCloudProvider. The
+// implementation is intentionally a thin adapter: the heavy lifting
+// (SSO setup, identity probe, OIDC issuer resolution) already lives
+// in the cloud init flow, and replicating it here would fork the
+// upstream contract. Returns an error for non-AWS providers (the
+// only supported cloud today) or for unparseable aliases.
+func RepairOrphanedAlias(ctx Context, store CloudStore, params RepairOrphanedAliasParams, deps CloudDependencies) (CloudProviderConfig, error) {
+	if !params.Orphan.Parsed {
+		return CloudProviderConfig{}, fmt.Errorf("orphaned alias %q cannot be parsed; recreate the provider manually with `erun cloud init aws`", params.Orphan.Alias)
+	}
+	if params.Orphan.Provider != CloudProviderAWS {
+		return CloudProviderConfig{}, fmt.Errorf("unsupported provider %q for alias %q; only %q is supported", params.Orphan.Provider, params.Orphan.Alias, CloudProviderAWS)
+	}
+	initParams := InitAWSCloudProviderParams{
+		Username:      params.Orphan.Username,
+		AccountID:     params.Orphan.AccountID,
+		SSORegion:     strings.TrimSpace(params.SSORegion),
+		SSOStartURL:   strings.TrimSpace(params.SSOStartURL),
+		RoleName:      strings.TrimSpace(params.RoleName),
+		Region:        strings.TrimSpace(params.Region),
+		OIDCIssuerURL: strings.TrimSpace(params.OIDCIssuerURL),
+		SkipLogin:     params.SkipLogin,
+	}
+	return InitAWSCloudProvider(ctx, store, initParams, deps)
+}

--- a/erun-common/doctor_root_config.go
+++ b/erun-common/doctor_root_config.go
@@ -48,14 +48,39 @@ type OrphanedAlias struct {
 // state used by both the CLI doctor and the MCP doctor tool. It is
 // purely descriptive: nothing in this file performs side effects.
 type RootConfigInspection struct {
-	ConfigPath       string             `json:"configPath"`
-	ConfigStatus     RootConfigStatus   `json:"configStatus"`
-	ConfigError      string             `json:"configError,omitempty"`
-	OrphanedAliases  []OrphanedAlias    `json:"orphanedAliases,omitempty"`
-	Backups          []RootConfigBackup `json:"backups,omitempty"`
-	ConfiguredCount  int                `json:"configuredProviderCount"`
-	CloudContextHits int                `json:"cloudContextCount"`
-	TenantHits       int                `json:"tenantCount"`
+	ConfigPath       string                 `json:"configPath"`
+	ConfigStatus     RootConfigStatus       `json:"configStatus"`
+	ConfigError      string                 `json:"configError,omitempty"`
+	OrphanedAliases  []OrphanedAlias        `json:"orphanedAliases,omitempty"`
+	OrphanedContexts []OrphanedCloudContext `json:"orphanedCloudContexts,omitempty"`
+	Backups          []RootConfigBackup     `json:"backups,omitempty"`
+	ConfiguredCount  int                    `json:"configuredProviderCount"`
+	CloudContextHits int                    `json:"cloudContextCount"`
+	TenantHits       int                    `json:"tenantCount"`
+}
+
+// OrphanedCloudContextEnvRef records one (tenant, env) pair whose
+// EnvConfig.KubernetesContext names a cloud context that is missing
+// from the root config's CloudContexts list. The pair is what
+// doctor renders in its report so users can map "broken context"
+// back to "which env am I supposed to open?".
+type OrphanedCloudContextEnvRef struct {
+	Tenant      string `json:"tenant"`
+	Environment string `json:"environment"`
+}
+
+// OrphanedCloudContext aggregates every env reference for a single
+// missing cloud-context name and the cloud coordinates parseable
+// from the name itself (erun's naming convention encodes account ID
+// and region). The decoded fields exist so a future recovery flow
+// can describe the missing instance to AWS without making the user
+// retype anything.
+type OrphanedCloudContext struct {
+	KubernetesContext  string                       `json:"kubernetesContext"`
+	AccountID          string                       `json:"accountId,omitempty"`
+	Region             string                       `json:"region,omitempty"`
+	CloudProviderAlias string                       `json:"cloudProviderAlias,omitempty"`
+	ReferencedByEnvs   []OrphanedCloudContextEnvRef `json:"referencedByEnvs,omitempty"`
 }
 
 // Complete reports whether the root config is in a state the rest of
@@ -65,17 +90,21 @@ func (r RootConfigInspection) Complete() bool {
 	if r.ConfigStatus != RootConfigStatusOK {
 		return false
 	}
-	return len(r.OrphanedAliases) == 0
+	if len(r.OrphanedAliases) != 0 {
+		return false
+	}
+	return len(r.OrphanedContexts) == 0
 }
 
 // RootConfigInspectionStore is the read-only surface InspectRootConfig
 // needs. Kept narrow on purpose: the inspection must work even when
-// the root config is unloadable, so it leans on ListTenantConfigs
-// (which reads tenant-level files independently) and a direct
-// LoadERunConfig probe for the central file.
+// the root config is unloadable, so it leans on ListTenantConfigs +
+// ListEnvConfigs (which read tenant/env-level files independently)
+// and a direct LoadERunConfig probe for the central file.
 type RootConfigInspectionStore interface {
 	LoadERunConfig() (ERunConfig, string, error)
 	ListTenantConfigs() ([]TenantConfig, error)
+	ListEnvConfigs(tenant string) ([]EnvConfig, error)
 }
 
 // InspectRootConfig walks the root config and every tenant config to
@@ -200,23 +229,162 @@ func InspectRootConfig(store RootConfigInspectionStore) (RootConfigInspection, e
 		addOrphanContext(alias, cloudContext.Name, cloudContext.Region)
 	}
 
-	if len(orphans) == 0 {
-		return inspection, nil
+	if len(orphans) > 0 {
+		aliases := make([]string, 0, len(orphans))
+		for alias := range orphans {
+			aliases = append(aliases, alias)
+		}
+		sort.Strings(aliases)
+		for _, alias := range aliases {
+			entry := orphans[alias]
+			sort.Strings(entry.ReferencedByTenants)
+			sort.Slice(entry.ReferencedByCloudContexts, func(i, j int) bool {
+				return entry.ReferencedByCloudContexts[i].Name < entry.ReferencedByCloudContexts[j].Name
+			})
+			inspection.OrphanedAliases = append(inspection.OrphanedAliases, *entry)
+		}
 	}
-	aliases := make([]string, 0, len(orphans))
-	for alias := range orphans {
-		aliases = append(aliases, alias)
+
+	contextOrphans, err := collectOrphanedCloudContexts(store, config.CloudContexts, tenants)
+	if err != nil {
+		return RootConfigInspection{}, err
 	}
-	sort.Strings(aliases)
-	for _, alias := range aliases {
-		entry := orphans[alias]
-		sort.Strings(entry.ReferencedByTenants)
-		sort.Slice(entry.ReferencedByCloudContexts, func(i, j int) bool {
-			return entry.ReferencedByCloudContexts[i].Name < entry.ReferencedByCloudContexts[j].Name
-		})
-		inspection.OrphanedAliases = append(inspection.OrphanedAliases, *entry)
-	}
+	inspection.OrphanedContexts = contextOrphans
+
 	return inspection, nil
+}
+
+// collectOrphanedCloudContexts walks every env config and reports
+// kubernetescontext references that name a cloud-managed context
+// (the env carries a CloudProviderAlias) but no matching
+// CloudContextConfig exists in the root config. Local Kubernetes
+// targets (orbstack, docker-desktop, kind, ...) are skipped because
+// they are not erun-managed cloud contexts; the heuristic for
+// "cloud-managed" is "env has a non-empty CloudProviderAlias OR the
+// env is flagged ManagedCloud". Aggregates duplicate references so
+// a context shared by N envs becomes a single entry with N back-refs.
+func collectOrphanedCloudContexts(store RootConfigInspectionStore, existing []CloudContextConfig, tenants []TenantConfig) ([]OrphanedCloudContext, error) {
+	known := indexCloudContextsByKubernetesName(existing)
+	orphans := make(map[string]*OrphanedCloudContext)
+	for _, tenant := range tenants {
+		envs, err := store.ListEnvConfigs(tenant.Name)
+		if err != nil {
+			return nil, err
+		}
+		for _, env := range envs {
+			recordOrphanedCloudContext(orphans, known, tenant.Name, env)
+		}
+	}
+	if len(orphans) == 0 {
+		return nil, nil
+	}
+	names := make([]string, 0, len(orphans))
+	for name := range orphans {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	result := make([]OrphanedCloudContext, 0, len(names))
+	for _, name := range names {
+		entry := orphans[name]
+		sort.Slice(entry.ReferencedByEnvs, func(i, j int) bool {
+			if entry.ReferencedByEnvs[i].Tenant != entry.ReferencedByEnvs[j].Tenant {
+				return entry.ReferencedByEnvs[i].Tenant < entry.ReferencedByEnvs[j].Tenant
+			}
+			return entry.ReferencedByEnvs[i].Environment < entry.ReferencedByEnvs[j].Environment
+		})
+		result = append(result, *entry)
+	}
+	return result, nil
+}
+
+func indexCloudContextsByKubernetesName(contexts []CloudContextConfig) map[string]struct{} {
+	known := make(map[string]struct{}, 2*len(contexts))
+	for _, c := range contexts {
+		if name := strings.TrimSpace(c.Name); name != "" {
+			known[name] = struct{}{}
+		}
+		if k := strings.TrimSpace(c.KubernetesContext); k != "" {
+			known[k] = struct{}{}
+		}
+	}
+	return known
+}
+
+func recordOrphanedCloudContext(orphans map[string]*OrphanedCloudContext, known map[string]struct{}, tenantName string, env EnvConfig) {
+	if !envExpectsCloudContext(env) {
+		return
+	}
+	kubeContext := strings.TrimSpace(env.KubernetesContext)
+	if kubeContext == "" {
+		return
+	}
+	if _, ok := known[kubeContext]; ok {
+		return
+	}
+	entry := orphans[kubeContext]
+	if entry == nil {
+		account, region := parseErunCloudContextName(kubeContext)
+		entry = &OrphanedCloudContext{
+			KubernetesContext:  kubeContext,
+			AccountID:          account,
+			Region:             region,
+			CloudProviderAlias: strings.TrimSpace(env.CloudProviderAlias),
+		}
+		orphans[kubeContext] = entry
+	}
+	ref := OrphanedCloudContextEnvRef{
+		Tenant:      strings.TrimSpace(tenantName),
+		Environment: strings.TrimSpace(env.Name),
+	}
+	for _, existing := range entry.ReferencedByEnvs {
+		if existing == ref {
+			return
+		}
+	}
+	entry.ReferencedByEnvs = append(entry.ReferencedByEnvs, ref)
+}
+
+// envExpectsCloudContext is the heuristic that separates local
+// kubernetes targets (orbstack, kind, ...) from erun-managed cloud
+// contexts: a non-empty CloudProviderAlias or ManagedCloud=true is
+// the signal that the env is supposed to be backed by a managed
+// CloudContextConfig. Without this gate every env on the box would
+// look like an orphan reference whenever a local kube context name
+// did not appear in CloudContexts.
+func envExpectsCloudContext(env EnvConfig) bool {
+	if strings.TrimSpace(env.CloudProviderAlias) != "" {
+		return true
+	}
+	return env.ManagedCloud
+}
+
+// parseErunCloudContextName recognises erun's own naming convention
+// for managed cloud contexts: "erun-<seq>-<accountid>-<region>" where
+// <region> may itself contain hyphens (e.g. "eu-west-2"). The
+// account ID is a 12-digit AWS identifier. Returns ("", "") for any
+// name that does not match — the caller still records the orphan,
+// just without decoded coordinates the recovery flow could lean on.
+func parseErunCloudContextName(name string) (string, string) {
+	name = strings.TrimSpace(name)
+	if !strings.HasPrefix(name, "erun-") {
+		return "", ""
+	}
+	rest := strings.TrimPrefix(name, "erun-")
+	parts := strings.SplitN(rest, "-", 3)
+	if len(parts) < 3 {
+		return "", ""
+	}
+	accountID := strings.TrimSpace(parts[1])
+	region := strings.TrimSpace(parts[2])
+	if len(accountID) != 12 {
+		return "", ""
+	}
+	for _, c := range accountID {
+		if c < '0' || c > '9' {
+			return "", ""
+		}
+	}
+	return accountID, region
 }
 
 func newOrphanedAlias(alias string) *OrphanedAlias {

--- a/erun-common/doctor_root_config_test.go
+++ b/erun-common/doctor_root_config_test.go
@@ -58,6 +58,8 @@ type inspectStore struct {
 	loadErr    error
 	tenants    []TenantConfig
 	tenantsErr error
+	envs       map[string][]EnvConfig
+	envsErr    error
 }
 
 func (s *inspectStore) LoadERunConfig() (ERunConfig, string, error) {
@@ -66,6 +68,13 @@ func (s *inspectStore) LoadERunConfig() (ERunConfig, string, error) {
 
 func (s *inspectStore) ListTenantConfigs() ([]TenantConfig, error) {
 	return s.tenants, s.tenantsErr
+}
+
+func (s *inspectStore) ListEnvConfigs(tenant string) ([]EnvConfig, error) {
+	if s.envsErr != nil {
+		return nil, s.envsErr
+	}
+	return s.envs[tenant], nil
 }
 
 // TestInspectRootConfigClean covers the happy path: every alias the
@@ -208,5 +217,155 @@ func TestInspectRootConfigMalformedAliasParsedFalse(t *testing.T) {
 	}
 	if result.OrphanedAliases[0].Parsed {
 		t.Fatalf("Parsed=true for malformed alias")
+	}
+}
+
+// TestInspectRootConfigSurfacesOrphanedCloudContext covers the case
+// the screenshot reproduced in real life: an env config names a
+// cloud-managed kubernetes context that the root config no longer
+// lists. The walk must aggregate references across multiple
+// tenants/envs into one OrphanedCloudContext entry and decode the
+// account/region from the erun naming convention.
+func TestInspectRootConfigSurfacesOrphanedCloudContext(t *testing.T) {
+	alias := CloudProviderAlias("alice", "020362606330", "aws")
+	store := &inspectStore{
+		config: ERunConfig{
+			CloudProviders: []CloudProviderConfig{{Alias: alias, Provider: CloudProviderAWS}},
+			// Note: NO matching CloudContextConfig — the env's
+			// KubernetesContext is an orphaned reference.
+		},
+		configPath: "/tmp/erun-config.yaml",
+		tenants: []TenantConfig{
+			{Name: "petios", CloudProviderAliases: []string{alias}, PrimaryCloudProviderAlias: alias},
+		},
+		envs: map[string][]EnvConfig{
+			"petios": {
+				{
+					Name:               "rihards-review",
+					KubernetesContext:  "erun-001-020362606330-eu-west-2",
+					CloudProviderAlias: alias,
+				},
+				{
+					Name:               "rihards-hotfix",
+					KubernetesContext:  "erun-001-020362606330-eu-west-2",
+					CloudProviderAlias: alias,
+				},
+			},
+		},
+	}
+	result, err := InspectRootConfig(store)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if len(result.OrphanedAliases) != 0 {
+		t.Fatalf("unexpected orphaned aliases: %v", result.OrphanedAliases)
+	}
+	if len(result.OrphanedContexts) != 1 {
+		t.Fatalf("orphan contexts: %d", len(result.OrphanedContexts))
+	}
+	orphan := result.OrphanedContexts[0]
+	if orphan.KubernetesContext != "erun-001-020362606330-eu-west-2" {
+		t.Fatalf("name: %q", orphan.KubernetesContext)
+	}
+	if orphan.AccountID != "020362606330" {
+		t.Fatalf("account: %q", orphan.AccountID)
+	}
+	if orphan.Region != "eu-west-2" {
+		t.Fatalf("region: %q", orphan.Region)
+	}
+	if orphan.CloudProviderAlias != alias {
+		t.Fatalf("alias: %q", orphan.CloudProviderAlias)
+	}
+	if len(orphan.ReferencedByEnvs) != 2 {
+		t.Fatalf("env refs: %v", orphan.ReferencedByEnvs)
+	}
+	if result.Complete() {
+		t.Fatalf("Complete() must be false when cloud-context orphans exist")
+	}
+}
+
+// TestInspectRootConfigSkipsLocalKubeContexts: a non-cloud env (no
+// CloudProviderAlias, ManagedCloud=false) must NOT register its
+// KubernetesContext as an orphan even when that name isn't in the
+// root config's CloudContexts. Otherwise every local orbstack/kind
+// env would show up as a doctor finding.
+func TestInspectRootConfigSkipsLocalKubeContexts(t *testing.T) {
+	store := &inspectStore{
+		config:     ERunConfig{},
+		configPath: "/tmp/erun-config.yaml",
+		tenants:    []TenantConfig{{Name: "team"}},
+		envs: map[string][]EnvConfig{
+			"team": {
+				{Name: "local", KubernetesContext: "orbstack"},
+			},
+		},
+	}
+	result, err := InspectRootConfig(store)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if len(result.OrphanedContexts) != 0 {
+		t.Fatalf("local env should not produce an orphan, got %v", result.OrphanedContexts)
+	}
+}
+
+// TestInspectRootConfigMatchesExistingCloudContext locks the
+// negative path: when the root config DOES carry a matching
+// CloudContextConfig (matched on either Name or KubernetesContext),
+// the env reference is healthy and does not register as an orphan.
+func TestInspectRootConfigMatchesExistingCloudContext(t *testing.T) {
+	alias := CloudProviderAlias("alice", "020362606330", "aws")
+	store := &inspectStore{
+		config: ERunConfig{
+			CloudProviders: []CloudProviderConfig{{Alias: alias, Provider: CloudProviderAWS}},
+			CloudContexts: []CloudContextConfig{{
+				Name:               "erun-001-020362606330-eu-west-2",
+				KubernetesContext:  "erun-001-020362606330-eu-west-2",
+				CloudProviderAlias: alias,
+				Region:             "eu-west-2",
+			}},
+		},
+		configPath: "/tmp/erun-config.yaml",
+		tenants:    []TenantConfig{{Name: "petios", CloudProviderAliases: []string{alias}, PrimaryCloudProviderAlias: alias}},
+		envs: map[string][]EnvConfig{
+			"petios": {
+				{Name: "review", KubernetesContext: "erun-001-020362606330-eu-west-2", CloudProviderAlias: alias},
+			},
+		},
+	}
+	result, err := InspectRootConfig(store)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if len(result.OrphanedContexts) != 0 {
+		t.Fatalf("expected no orphans, got %v", result.OrphanedContexts)
+	}
+	if !result.Complete() {
+		t.Fatalf("Complete() must be true when all references resolve")
+	}
+}
+
+// TestParseErunCloudContextNameDecodesAccountAndRegion is a focused
+// test on the naming convention parser — region names contain
+// hyphens which the SplitN call has to handle correctly.
+func TestParseErunCloudContextNameDecodesAccountAndRegion(t *testing.T) {
+	cases := []struct {
+		name    string
+		account string
+		region  string
+	}{
+		{"erun-001-020362606330-eu-west-2", "020362606330", "eu-west-2"},
+		{"erun-99-123456789012-us-east-1", "123456789012", "us-east-1"},
+		{"orbstack", "", ""},
+		{"erun-1-tooshort-eu-west-1", "", ""},
+		{"erun-1-12345678901a-eu-west-1", "", ""},
+		{"erun-001", "", ""},
+		{"", "", ""},
+	}
+	for _, tc := range cases {
+		account, region := parseErunCloudContextName(tc.name)
+		if account != tc.account || region != tc.region {
+			t.Fatalf("%q -> (%q, %q), want (%q, %q)", tc.name, account, region, tc.account, tc.region)
+		}
 	}
 }

--- a/erun-common/doctor_root_config_test.go
+++ b/erun-common/doctor_root_config_test.go
@@ -1,0 +1,212 @@
+package eruncommon
+
+import (
+	"sort"
+	"testing"
+)
+
+// TestParseCloudProviderAliasRoundTrip locks the contract with
+// CloudProviderAlias: the parser must be its exact inverse for any
+// well-formed triple.
+func TestParseCloudProviderAliasRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		username  string
+		accountID string
+		provider  string
+	}{
+		{"alice", "1234567890", "aws"},
+		{"Rihards.Freimanis", "020362606330", "aws"},
+		{"user+with.dots", "9", "aws"},
+	} {
+		alias := CloudProviderAlias(tc.username, tc.accountID, tc.provider)
+		gotUser, gotAccount, gotProvider, ok := ParseCloudProviderAlias(alias)
+		if !ok {
+			t.Fatalf("alias %q failed to parse", alias)
+		}
+		if gotUser != tc.username || gotAccount != tc.accountID || gotProvider != tc.provider {
+			t.Fatalf("alias=%q got=(%q,%q,%q) want=(%q,%q,%q)", alias, gotUser, gotAccount, gotProvider, tc.username, tc.accountID, tc.provider)
+		}
+	}
+}
+
+// TestParseCloudProviderAliasMalformed documents the negative
+// surface: anything that does not contain both separators with
+// non-empty segments must surface as ok=false.
+func TestParseCloudProviderAliasMalformed(t *testing.T) {
+	for _, alias := range []string{
+		"",
+		"no-separators",
+		"missing@account",
+		"user+account",
+		"+1@aws",
+		"user+1@",
+		"user+@aws",
+		"@aws",
+		"+aws",
+	} {
+		if _, _, _, ok := ParseCloudProviderAlias(alias); ok {
+			t.Fatalf("expected ok=false for %q", alias)
+		}
+	}
+}
+
+// inspectStore is a tiny in-memory RootConfigInspectionStore so the
+// inspection tests do not depend on the real on-disk config layout.
+type inspectStore struct {
+	config     ERunConfig
+	configPath string
+	loadErr    error
+	tenants    []TenantConfig
+	tenantsErr error
+}
+
+func (s *inspectStore) LoadERunConfig() (ERunConfig, string, error) {
+	return s.config, s.configPath, s.loadErr
+}
+
+func (s *inspectStore) ListTenantConfigs() ([]TenantConfig, error) {
+	return s.tenants, s.tenantsErr
+}
+
+// TestInspectRootConfigClean covers the happy path: every alias the
+// tenants and cloud contexts reference is configured. Inspection
+// must report ok status, zero orphans, and the configured count.
+func TestInspectRootConfigClean(t *testing.T) {
+	alias := CloudProviderAlias("alice", "1", "aws")
+	store := &inspectStore{
+		config: ERunConfig{
+			CloudProviders: []CloudProviderConfig{{Alias: alias, Provider: CloudProviderAWS}},
+			CloudContexts:  []CloudContextConfig{{Name: "ctx-1", CloudProviderAlias: alias, Region: "eu-west-2"}},
+		},
+		configPath: "/tmp/erun-config.yaml",
+		tenants:    []TenantConfig{{Name: "team", CloudProviderAliases: []string{alias}, PrimaryCloudProviderAlias: alias}},
+	}
+	result, err := InspectRootConfig(store)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if result.ConfigStatus != RootConfigStatusOK {
+		t.Fatalf("status %q", result.ConfigStatus)
+	}
+	if len(result.OrphanedAliases) != 0 {
+		t.Fatalf("unexpected orphans: %v", result.OrphanedAliases)
+	}
+	if result.ConfiguredCount != 1 {
+		t.Fatalf("configuredCount=%d", result.ConfiguredCount)
+	}
+	if !result.Complete() {
+		t.Fatalf("Complete() must be true for clean state")
+	}
+}
+
+// TestInspectRootConfigSurfacesOrphanedAlias reproduces the failure
+// mode that motivated this work: tenant + cloud-context both name an
+// alias that is missing from CloudProviders. Inspection must collect
+// both back-references on a single OrphanedAlias entry, parse the
+// alias into its three components, and mark Complete()=false.
+func TestInspectRootConfigSurfacesOrphanedAlias(t *testing.T) {
+	alias := CloudProviderAlias("alice", "1234567890", "aws")
+	store := &inspectStore{
+		config: ERunConfig{
+			CloudContexts: []CloudContextConfig{
+				{Name: "ctx-1", CloudProviderAlias: alias, Region: "eu-west-2"},
+				{Name: "ctx-2", CloudProviderAlias: alias, Region: "eu-west-2"},
+			},
+		},
+		configPath: "/tmp/erun-config.yaml",
+		tenants: []TenantConfig{
+			{Name: "team", CloudProviderAliases: []string{alias}, PrimaryCloudProviderAlias: alias},
+			{Name: "other", CloudProviderAliases: []string{alias}},
+		},
+	}
+	result, err := InspectRootConfig(store)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if result.Complete() {
+		t.Fatalf("Complete() must be false when orphans exist")
+	}
+	if len(result.OrphanedAliases) != 1 {
+		t.Fatalf("expected 1 orphan, got %d", len(result.OrphanedAliases))
+	}
+	orphan := result.OrphanedAliases[0]
+	if orphan.Alias != alias {
+		t.Fatalf("alias mismatch: %q", orphan.Alias)
+	}
+	if !orphan.Parsed || orphan.AccountID != "1234567890" || orphan.Username != "alice" || orphan.Provider != CloudProviderAWS {
+		t.Fatalf("decoded fields wrong: %+v", orphan)
+	}
+	sort.Strings(orphan.ReferencedByTenants)
+	if len(orphan.ReferencedByTenants) != 2 || orphan.ReferencedByTenants[0] != "other" || orphan.ReferencedByTenants[1] != "team" {
+		t.Fatalf("tenant refs wrong: %v", orphan.ReferencedByTenants)
+	}
+	if len(orphan.ReferencedByCloudContexts) != 2 {
+		t.Fatalf("context refs wrong: %v", orphan.ReferencedByCloudContexts)
+	}
+	if orphan.ReferencedByCloudContexts[0].Region != "eu-west-2" {
+		t.Fatalf("region not captured: %v", orphan.ReferencedByCloudContexts[0])
+	}
+}
+
+// TestInspectRootConfigCorrupted: a corrupted root config must
+// short-circuit the alias walk (we have no source of truth for
+// configured providers to compare against). The inspection still
+// surfaces ConfigStatus=corrupted so the doctor knows to offer the
+// restore-from-backup path.
+func TestInspectRootConfigCorrupted(t *testing.T) {
+	store := &inspectStore{
+		configPath: "/tmp/erun-config.yaml",
+		loadErr:    ErrConfigCorrupted,
+	}
+	result, err := InspectRootConfig(store)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if result.ConfigStatus != RootConfigStatusCorrupted {
+		t.Fatalf("expected corrupted, got %q", result.ConfigStatus)
+	}
+	if len(result.OrphanedAliases) != 0 {
+		t.Fatalf("must not walk orphans when root config is unloadable")
+	}
+	if result.Complete() {
+		t.Fatal("Complete() must be false for corrupted root config")
+	}
+}
+
+// TestInspectRootConfigMissing: same as corrupted, but distinguished
+// in ConfigStatus so the doctor UI can offer different language.
+func TestInspectRootConfigMissing(t *testing.T) {
+	store := &inspectStore{
+		configPath: "/tmp/erun-config.yaml",
+		loadErr:    ErrNotInitialized,
+	}
+	result, err := InspectRootConfig(store)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if result.ConfigStatus != RootConfigStatusMissing {
+		t.Fatalf("expected missing, got %q", result.ConfigStatus)
+	}
+}
+
+// TestInspectRootConfigMalformedAliasParsedFalse: when a tenant or
+// context names an alias that does not match the documented shape,
+// it is still surfaced as an orphan, but Parsed=false so the repair
+// path skips it instead of attempting a doomed init.
+func TestInspectRootConfigMalformedAliasParsedFalse(t *testing.T) {
+	store := &inspectStore{
+		config:     ERunConfig{},
+		configPath: "/tmp/erun-config.yaml",
+		tenants:    []TenantConfig{{Name: "team", CloudProviderAliases: []string{"not-a-valid-alias"}}},
+	}
+	result, err := InspectRootConfig(store)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if len(result.OrphanedAliases) != 1 {
+		t.Fatalf("orphan count: %d", len(result.OrphanedAliases))
+	}
+	if result.OrphanedAliases[0].Parsed {
+		t.Fatalf("Parsed=true for malformed alias")
+	}
+}

--- a/erun-common/kubeconfig_lookup.go
+++ b/erun-common/kubeconfig_lookup.go
@@ -1,0 +1,96 @@
+package eruncommon
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// kubeconfigUserHomeDir is the seam tests use to point lookups at a
+// fake home directory. Mirrors awsConfigUserHomeDir / openUserHomeDir.
+var kubeconfigUserHomeDir = os.UserHomeDir
+
+// kubeconfigUser is the subset of a `users[].user` entry we need to
+// recover the bearer token erun's cloud-context restore flow uses to
+// re-write kubectl credentials. Only `token` is read here; the
+// exec/auth-provider alternatives are not used by erun-managed cloud
+// contexts because configureCloudKubeContext writes a literal token.
+type kubeconfigUser struct {
+	Token string `yaml:"token,omitempty"`
+}
+
+type kubeconfigUserEntry struct {
+	Name string         `yaml:"name"`
+	User kubeconfigUser `yaml:"user"`
+}
+
+type kubeconfigDocument struct {
+	Users []kubeconfigUserEntry `yaml:"users"`
+}
+
+// LookupKubeContextBearerToken reads the active kubeconfig and
+// returns the bearer token for the user entry whose name matches the
+// supplied context name. erun's `configureCloudKubeContext` writes
+// the user entry with name = KubernetesContext, so a healthy host
+// always has the token under that exact key. Returns ok=false when
+// the file does not exist, the named user is missing, or the user
+// is configured via a different auth method (exec, auth-provider,
+// etc.) than a static bearer token.
+//
+// KUBECONFIG is honored: when set, only the first path in the
+// list-separated value is read. The doctor only needs ONE bearer
+// token; iterating every entry would invite confusion if the user's
+// kubeconfig is a merge of multiple files where the same context
+// appears in more than one.
+func LookupKubeContextBearerToken(contextName string) (string, bool, error) {
+	contextName = strings.TrimSpace(contextName)
+	if contextName == "" {
+		return "", false, errors.New("context name is required")
+	}
+	path, err := kubeconfigPath()
+	if err != nil {
+		return "", false, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	doc := kubeconfigDocument{}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return "", false, err
+	}
+	for _, entry := range doc.Users {
+		if strings.TrimSpace(entry.Name) != contextName {
+			continue
+		}
+		token := strings.TrimSpace(entry.User.Token)
+		if token == "" {
+			return "", false, nil
+		}
+		return token, true, nil
+	}
+	return "", false, nil
+}
+
+func kubeconfigPath() (string, error) {
+	if override := strings.TrimSpace(os.Getenv("KUBECONFIG")); override != "" {
+		// KUBECONFIG can be a list separated by os.PathListSeparator.
+		// Take the first entry — see the docstring on
+		// LookupKubeContextBearerToken for why "first" is fine.
+		if idx := strings.IndexByte(override, os.PathListSeparator); idx > 0 {
+			override = override[:idx]
+		}
+		return override, nil
+	}
+	home, err := kubeconfigUserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".kube", "config"), nil
+}

--- a/erun-common/kubeconfig_lookup_test.go
+++ b/erun-common/kubeconfig_lookup_test.go
@@ -1,0 +1,157 @@
+package eruncommon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeKubeconfig(t *testing.T, body string) func() {
+	t.Helper()
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, ".kube")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	prev := kubeconfigUserHomeDir
+	kubeconfigUserHomeDir = func() (string, error) { return tmp, nil }
+	prevEnv, had := os.LookupEnv("KUBECONFIG")
+	_ = os.Unsetenv("KUBECONFIG")
+	return func() {
+		kubeconfigUserHomeDir = prev
+		if had {
+			_ = os.Setenv("KUBECONFIG", prevEnv)
+		} else {
+			_ = os.Unsetenv("KUBECONFIG")
+		}
+	}
+}
+
+// TestLookupKubeContextBearerTokenFindsErunContext is the happy
+// path — kubeconfig has a static-token user entry under the context
+// name erun-001-020362606330-eu-west-2, and the lookup returns it.
+func TestLookupKubeContextBearerTokenFindsErunContext(t *testing.T) {
+	restore := writeKubeconfig(t, `apiVersion: v1
+clusters: []
+contexts: []
+users:
+- name: erun-001-020362606330-eu-west-2
+  user:
+    token: pbtrwcoJhOi5F3eWBkibV_tzr7AxIKr9ZCYWYjRwtbg
+- name: arn:aws:eks:eu-west-1:123:cluster/foo
+  user:
+    exec:
+      command: aws
+`)
+	defer restore()
+	token, ok, err := LookupKubeContextBearerToken("erun-001-020362606330-eu-west-2")
+	if err != nil || !ok {
+		t.Fatalf("lookup: ok=%v err=%v", ok, err)
+	}
+	if token != "pbtrwcoJhOi5F3eWBkibV_tzr7AxIKr9ZCYWYjRwtbg" {
+		t.Fatalf("token: %q", token)
+	}
+}
+
+// TestLookupKubeContextBearerTokenMissingUserReturnsNotFound
+// documents the contract for a doctor that needs to fall back to a
+// different recovery surface (manual paste, SSM, ...) when the user
+// entry is absent.
+func TestLookupKubeContextBearerTokenMissingUserReturnsNotFound(t *testing.T) {
+	restore := writeKubeconfig(t, `users: []`)
+	defer restore()
+	_, ok, err := LookupKubeContextBearerToken("missing")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatal("expected miss")
+	}
+}
+
+// TestLookupKubeContextBearerTokenExecOnlyUserReturnsNotFound covers
+// the case where a user entry exists but uses exec auth instead of
+// a static token. erun's restore flow needs the literal bearer
+// token; an exec entry isn't usable here.
+func TestLookupKubeContextBearerTokenExecOnlyUserReturnsNotFound(t *testing.T) {
+	restore := writeKubeconfig(t, `users:
+- name: my-ctx
+  user:
+    exec:
+      command: aws
+`)
+	defer restore()
+	_, ok, err := LookupKubeContextBearerToken("my-ctx")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatal("exec-only user should not yield a token")
+	}
+}
+
+// TestLookupKubeContextBearerTokenHonorsKUBECONFIG verifies the env
+// override takes precedence and that a multi-path KUBECONFIG list
+// honors the documented "first entry wins" rule.
+func TestLookupKubeContextBearerTokenHonorsKUBECONFIG(t *testing.T) {
+	first := filepath.Join(t.TempDir(), "first")
+	second := filepath.Join(t.TempDir(), "second")
+	if err := os.WriteFile(first, []byte(`users:
+- name: ctx
+  user:
+    token: from-first
+`), 0o600); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if err := os.WriteFile(second, []byte(`users:
+- name: ctx
+  user:
+    token: from-second
+`), 0o600); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	prev, had := os.LookupEnv("KUBECONFIG")
+	_ = os.Setenv("KUBECONFIG", first+string(os.PathListSeparator)+second)
+	defer func() {
+		if had {
+			_ = os.Setenv("KUBECONFIG", prev)
+		} else {
+			_ = os.Unsetenv("KUBECONFIG")
+		}
+	}()
+	token, ok, err := LookupKubeContextBearerToken("ctx")
+	if err != nil || !ok {
+		t.Fatalf("ok=%v err=%v", ok, err)
+	}
+	if token != "from-first" {
+		t.Fatalf("token: %q (expected from-first)", token)
+	}
+}
+
+// TestLookupKubeContextBearerTokenMissingFile: a fresh host with no
+// kubeconfig at all must produce ok=false rather than a hard error.
+func TestLookupKubeContextBearerTokenMissingFile(t *testing.T) {
+	tmp := t.TempDir()
+	prev := kubeconfigUserHomeDir
+	kubeconfigUserHomeDir = func() (string, error) { return tmp, nil }
+	prevEnv, had := os.LookupEnv("KUBECONFIG")
+	_ = os.Unsetenv("KUBECONFIG")
+	defer func() {
+		kubeconfigUserHomeDir = prev
+		if had {
+			_ = os.Setenv("KUBECONFIG", prevEnv)
+		} else {
+			_ = os.Unsetenv("KUBECONFIG")
+		}
+	}()
+	_, ok, err := LookupKubeContextBearerToken("anything")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatal("expected miss when ~/.kube/config does not exist")
+	}
+}

--- a/erun-integration/doctor_test.go
+++ b/erun-integration/doctor_test.go
@@ -331,6 +331,51 @@ func TestDoctor(t *testing.T) {
 		golden.Equal(t, "doctor/inspect_corrupted_root_config", normalize.Apply(result.Combined))
 	})
 
+	t.Run("inspect_orphaned_cloud_context", func(t *testing.T) {
+		// Reproduce the screenshot scenario: an env config names a
+		// cloud-managed kubernetes context that the root config no
+		// longer lists, and the env still carries the cloud provider
+		// alias. Doctor must surface the orphan with decoded account
+		// + region and the back-reference to the env.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "petios", "rihards-review")
+		tenantPath := filepath.Join(setup.ConfigHome, "erun", "petios", "config.yaml")
+		alias := "alice+020362606330@aws"
+		if err := os.WriteFile(tenantPath, []byte("projectroot: "+setup.Cwd+"\n"+
+			"name: petios\n"+
+			"defaultenvironment: rihards-review\n"+
+			"cloudprovideraliases:\n"+
+			"    - "+alias+"\n"+
+			"primarycloudprovideralias: "+alias+"\n"), 0o644); err != nil {
+			t.Fatalf("tenant: %v", err)
+		}
+		envPath := filepath.Join(setup.ConfigHome, "erun", "petios", "rihards-review", "config.yaml")
+		if err := os.WriteFile(envPath, []byte("name: rihards-review\n"+
+			"repopath: "+setup.Cwd+"\n"+
+			"kubernetescontext: erun-001-020362606330-eu-west-2\n"+
+			"cloudprovideralias: "+alias+"\n"+
+			"managedcloud: true\n"), 0o644); err != nil {
+			t.Fatalf("env: %v", err)
+		}
+		// Seed the root config with the provider so the alias side
+		// of the inspection stays clean — we only want the context
+		// orphan to surface here.
+		rootPath := filepath.Join(setup.ConfigHome, "erun", "config.yaml")
+		if err := os.WriteFile(rootPath, []byte("defaulttenant: petios\n"+
+			"cloudproviders:\n"+
+			"    - alias: "+alias+"\n"+
+			"      provider: aws\n"+
+			"      username: alice\n"+
+			"      accountid: \"020362606330\"\n"), 0o644); err != nil {
+			t.Fatalf("root: %v", err)
+		}
+		result := erun.Run(t, []string{"doctor", "--repair-config", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "doctor/inspect_orphaned_cloud_context", normalize.Apply(result.Combined))
+	})
+
 	t.Run("restore_config_from_backup_dry_run", func(t *testing.T) {
 		// Seed a 0-byte root config plus a healthy backup for
 		// 2026-05-19. Doctor with --restore-config-from-backup

--- a/erun-integration/doctor_test.go
+++ b/erun-integration/doctor_test.go
@@ -272,4 +272,90 @@ func TestDoctor(t *testing.T) {
 		}
 		golden.Equal(t, "doctor/in_runtime_multi_tenant_markers_dry_run", normalize.Apply(result.Combined))
 	})
+
+	t.Run("inspect_clean_root_config", func(t *testing.T) {
+		// On a clean install (tenant with no cloud aliases, no
+		// cloud contexts), the host-side root-config inspection
+		// must report ok status, zero orphans, and proceed
+		// silently for callers that did not ask for repair work.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"doctor", "--repair-config", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "doctor/inspect_clean_root_config", normalize.Apply(result.Combined))
+	})
+
+	t.Run("inspect_orphaned_alias", func(t *testing.T) {
+		// Seed a tenant that references a cloud-provider alias the
+		// root config does not list. Doctor must surface the
+		// orphan with its decoded username/account/provider and
+		// the tenant back-reference, then suggest the repair flow
+		// without prompting (dry-run is non-interactive).
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		// Overwrite the tenant config to reference an orphan alias.
+		tenantPath := filepath.Join(setup.ConfigHome, "erun", "team", "config.yaml")
+		body := "projectroot: " + setup.Cwd + "\n" +
+			"name: team\n" +
+			"defaultenvironment: dev\n" +
+			"cloudprovideraliases:\n" +
+			"    - alice+1234567890@aws\n" +
+			"primarycloudprovideralias: alice+1234567890@aws\n"
+		if err := os.WriteFile(tenantPath, []byte(body), 0o644); err != nil {
+			t.Fatalf("write tenant: %v", err)
+		}
+		result := erun.Run(t, []string{"doctor", "--repair-config", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "doctor/inspect_orphaned_alias", normalize.Apply(result.Combined))
+	})
+
+	t.Run("inspect_corrupted_root_config", func(t *testing.T) {
+		// Truncated root config: doctor must report corrupted
+		// status without crashing and (when --repair-config is set
+		// but no backup exists) tell the user to resolve the file
+		// manually rather than silently overwriting.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		rootPath := filepath.Join(setup.ConfigHome, "erun", "config.yaml")
+		if err := os.WriteFile(rootPath, []byte(""), 0o644); err != nil {
+			t.Fatalf("truncate root config: %v", err)
+		}
+		result := erun.Run(t, []string{"doctor", "--repair-config", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		// Exit can be non-zero when corruption is fatal; the
+		// golden is what we lock, not the code.
+		_ = result
+		golden.Equal(t, "doctor/inspect_corrupted_root_config", normalize.Apply(result.Combined))
+	})
+
+	t.Run("restore_config_from_backup_dry_run", func(t *testing.T) {
+		// Seed a 0-byte root config plus a healthy backup for
+		// 2026-05-19. Doctor with --restore-config-from-backup
+		// 2026-05-19 --dry-run must trace the planned restore and
+		// stop without actually replacing the file.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		rootPath := filepath.Join(setup.ConfigHome, "erun", "config.yaml")
+		if err := os.WriteFile(rootPath, []byte(""), 0o644); err != nil {
+			t.Fatalf("truncate root config: %v", err)
+		}
+		backupPath := filepath.Join(setup.ConfigHome, "erun", "config.yaml.2026-05-19.bak")
+		body := "defaulttenant: team\n" +
+			"cloudproviders:\n" +
+			"    - alias: alice+1234567890@aws\n" +
+			"      provider: aws\n" +
+			"      username: alice\n" +
+			"      accountid: \"1234567890\"\n"
+		if err := os.WriteFile(backupPath, []byte(body), 0o644); err != nil {
+			t.Fatalf("write backup: %v", err)
+		}
+		result := erun.Run(t, []string{"doctor", "--restore-config-from-backup", "2026-05-19", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "doctor/restore_config_from_backup_dry_run", normalize.Apply(result.Combined))
+	})
 }

--- a/erun-integration/testdata/doctor/help.txt
+++ b/erun-integration/testdata/doctor/help.txt
@@ -4,15 +4,17 @@ Usage:
   erun doctor [tenant] [environment] [flags]
 
 Flags:
-      --codecommit-ssh-key-id string   CodeCommit SSH public key ID to use when finishing an unfinished remote init for an AWS CodeCommit repository
-      --dry-run                        Resolve and trace mutating actions without executing them.
-      --finish-remote-init             Finish unfinished remote init tasks without prompting (only takes effect when run inside a runtime pod)
-  -h, --help                           help for doctor
-      --prune-build-cache              Prune unused BuildKit cache without prompting
-      --prune-containers               Prune stopped Docker containers without prompting
-      --prune-images                   Prune unused Docker images without prompting
-      --remote-repository-url string   Git remote URL to use when finishing an unfinished remote init
-      --repair-jetbrains-gateway       Clear cached JetBrains Gateway backend metadata for this environment
+      --codecommit-ssh-key-id string        CodeCommit SSH public key ID to use when finishing an unfinished remote init for an AWS CodeCommit repository
+      --dry-run                             Resolve and trace mutating actions without executing them.
+      --finish-remote-init                  Finish unfinished remote init tasks without prompting (only takes effect when run inside a runtime pod)
+  -h, --help                                help for doctor
+      --prune-build-cache                   Prune unused BuildKit cache without prompting
+      --prune-containers                    Prune stopped Docker containers without prompting
+      --prune-images                        Prune unused Docker images without prompting
+      --remote-repository-url string        Git remote URL to use when finishing an unfinished remote init
+      --repair-config                       Inspect the root erun config and offer to restore from backup or re-init orphaned cloud provider aliases; stops before running tenant/env cleanup actions
+      --repair-jetbrains-gateway            Clear cached JetBrains Gateway backend metadata for this environment
+      --restore-config-from-backup string   Restore the root erun config from a dated backup non-interactively (YYYY-MM-DD or absolute path)
 
 Global Flags:
       --time            Print the elapsed runtime after the command finishes.

--- a/erun-integration/testdata/doctor/inspect_clean_root_config.txt
+++ b/erun-integration/testdata/doctor/inspect_clean_root_config.txt
@@ -1,0 +1,5 @@
+Root config: <TMP> (status=ok)
+  cloud providers configured: 0
+  cloud contexts: 0, tenants: 1
+  no orphaned cloud-provider aliases.
+audit: erun doctor --dry-run --repair-config

--- a/erun-integration/testdata/doctor/inspect_corrupted_root_config.txt
+++ b/erun-integration/testdata/doctor/inspect_corrupted_root_config.txt
@@ -1,0 +1,4 @@
+Root config: <TMP> (status=corrupted)
+  load error: config file cannot be unmarshaled
+Root config is not loadable and no backup was restored; resolve the file manually (or supply --restore-config-from-backup <date>) and re-run.
+audit: erun doctor --dry-run --repair-config

--- a/erun-integration/testdata/doctor/inspect_orphaned_alias.txt
+++ b/erun-integration/testdata/doctor/inspect_orphaned_alias.txt
@@ -1,0 +1,10 @@
+Root config: <TMP> (status=ok)
+  cloud providers configured: 0
+  cloud contexts: 0, tenants: 1
+  orphaned aliases: 1
+    - alice+1234567890@aws
+        provider=aws account=1234567890 user=alice
+        tenants: team
+Dry-run: would re-initialize AWS provider for alias alice+1234567890@aws (account 1234567890, user alice)
+audit: erun doctor --dry-run --repair-config
+doctor repair-config: would re-init aws cloud provider alias=alice+1234567890@aws account=1234567890 user=alice region=

--- a/erun-integration/testdata/doctor/inspect_orphaned_cloud_context.txt
+++ b/erun-integration/testdata/doctor/inspect_orphaned_cloud_context.txt
@@ -1,0 +1,15 @@
+Root config: <TMP> (status=ok)
+  cloud providers configured: 1
+  cloud contexts: 0, tenants: 1
+  orphaned cloud contexts: 1
+    - erun-001-020362606330-eu-west-2
+        account=020362606330 region=eu-west-2 alias=alice+020362606330@aws
+        envs: petios/rihards-review
+Recovering cloud context erun-001-020362606330-eu-west-2...
+Recovered cloud context erun-001-020362606330-eu-west-2 from aws-describe-instances.
+  instance: i-<recovered> (c8gd.2xlarge)
+  public ip: <VERSION>.10
+  admin token: NOT recovered — kubectl access will fail until you run `erun context init` for a fresh token or manually paste the existing one.
+audit: erun doctor --dry-run --repair-config
+aws ec2 describe-instances --filters 'Name=tag:Name,Values=erun-001-020362606330-eu-west-2' 'Name=instance-state-name,Values=pending,running,stopping,stopped' --output json --region eu-west-2
+write-yaml 'erun-config:cloudcontext erun-001-020362606330-eu-west-2'

--- a/erun-integration/testdata/doctor/restore_config_from_backup_dry_run.txt
+++ b/erun-integration/testdata/doctor/restore_config_from_backup_dry_run.txt
@@ -1,0 +1,12 @@
+Root config: <TMP> (status=corrupted)
+  load error: config file cannot be unmarshaled
+  available backups (newest first):
+    - 2026-05-19 path=<TMP>
+Dry-run: would restore root config from <TMP>
+Root config: <TMP> (status=corrupted)
+  load error: config file cannot be unmarshaled
+  available backups (newest first):
+    - 2026-05-19 path=<TMP>
+Run `erun doctor --repair-config` to walk through restoring the root config or re-initializing orphaned cloud provider aliases.
+audit: erun doctor --dry-run --restore-config-from-backup 2026-05-19
+cp <TMP> <TMP>

--- a/erun-mcp/doctor.go
+++ b/erun-mcp/doctor.go
@@ -10,34 +10,217 @@ import (
 )
 
 type DoctorInput struct {
-	Tenant          string `json:"tenant,omitempty" jsonschema:"optional explicit tenant override"`
-	Environment     string `json:"environment,omitempty" jsonschema:"optional explicit environment override"`
-	PruneImages     bool   `json:"pruneImages,omitempty" jsonschema:"when true, prune unused Docker images"`
-	PruneBuildCache bool   `json:"pruneBuildCache,omitempty" jsonschema:"when true, prune unused BuildKit cache"`
-	PruneContainers bool   `json:"pruneContainers,omitempty" jsonschema:"when true, prune stopped Docker containers"`
-	Preview         bool   `json:"preview,omitempty" jsonschema:"when true, resolve and print the planned actions without executing them"`
-	Verbosity       int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+	Tenant                  string                       `json:"tenant,omitempty" jsonschema:"optional explicit tenant override"`
+	Environment             string                       `json:"environment,omitempty" jsonschema:"optional explicit environment override"`
+	PruneImages             bool                         `json:"pruneImages,omitempty" jsonschema:"when true, prune unused Docker images"`
+	PruneBuildCache         bool                         `json:"pruneBuildCache,omitempty" jsonschema:"when true, prune unused BuildKit cache"`
+	PruneContainers         bool                         `json:"pruneContainers,omitempty" jsonschema:"when true, prune stopped Docker containers"`
+	Preview                 bool                         `json:"preview,omitempty" jsonschema:"when true, resolve and print the planned actions without executing them"`
+	Verbosity               int                          `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+	RestoreConfigFromBackup string                       `json:"restoreConfigFromBackup,omitempty" jsonschema:"YYYY-MM-DD or absolute path; when set, restore the root erun config from the matching daily backup before any tenant/env work"`
+	RepairOrphanedAliases   []DoctorRepairAliasInput     `json:"repairOrphanedAliases,omitempty" jsonschema:"per-alias AWS init parameters; when present, doctor re-initializes each listed cloud provider alias before tenant/env work"`
+}
+
+// DoctorRepairAliasInput is the MCP equivalent of the interactive
+// "Re-initialize cloud provider alias <alias>?" prompt. Required
+// fields are alias + SSO start URL + SSO region; the rest mirror
+// InitAWSCloudProviderParams so callers can stitch one tool call to
+// the structured RootConfigInspection emitted on a previous run.
+type DoctorRepairAliasInput struct {
+	Alias         string `json:"alias" jsonschema:"orphaned cloud provider alias (username+account@provider) to recreate"`
+	SSOStartURL   string `json:"ssoStartUrl" jsonschema:"AWS IAM Identity Center start URL"`
+	SSORegion     string `json:"ssoRegion" jsonschema:"AWS IAM Identity Center region"`
+	RoleName      string `json:"roleName,omitempty" jsonschema:"AWS role name used during SSO login"`
+	Region        string `json:"region,omitempty" jsonschema:"default AWS region for the recreated provider (derived from referenced cloud context when blank)"`
+	OIDCIssuerURL string `json:"oidcIssuerUrl,omitempty" jsonschema:"override for the OIDC issuer URL; usually inferred from AWS web identity token"`
+	SkipLogin     bool   `json:"skipLogin,omitempty" jsonschema:"when true, skip aws sso login and rely on existing credentials"`
+}
+
+// DoctorRootConfigReport pairs the inspection with whatever repair
+// outcomes happened in the current call. Returned in the structured
+// output so an LLM agent can decide whether to retry with full
+// per-alias init params or escalate to the user.
+type DoctorRootConfigReport struct {
+	Inspection         eruncommon.RootConfigInspection `json:"inspection"`
+	RestoredFromBackup string                          `json:"restoredFromBackup,omitempty"`
+	RepairedAliases    []string                        `json:"repairedAliases,omitempty"`
+	UnresolvedAliases  []string                        `json:"unresolvedAliases,omitempty"`
 }
 
 func doctorTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, DoctorInput) (*mcp.CallToolResult, CommandOutput, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input DoctorInput) (*mcp.CallToolResult, CommandOutput, error) {
+		var report *DoctorRootConfigReport
 		output, err := runRuntimeCommand(runtime, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, _ string) error {
-			return runDoctorToolCommand(runtime, input, runCtx)
+			r, runErr := runDoctorToolCommand(runtime, input, runCtx)
+			report = r
+			return runErr
 		})
+		if report != nil {
+			output.RootConfig = report
+		}
 		return nil, output, err
 	}
 }
 
-func runDoctorToolCommand(runtime RuntimeConfig, input DoctorInput, runCtx eruncommon.Context) error {
+func runDoctorToolCommand(runtime RuntimeConfig, input DoctorInput, runCtx eruncommon.Context) (*DoctorRootConfigReport, error) {
+	report, fatal, err := runDoctorRootConfigToolFlow(runtime, input, runCtx)
+	if err != nil {
+		return report, err
+	}
+	if fatal {
+		return report, nil
+	}
+	if onlyRootConfigDoctorInput(input) {
+		return report, nil
+	}
 	target, err := resolveDoctorOpenResult(runtime, input)
 	if err != nil {
-		return err
+		return report, err
 	}
 	req := eruncommon.ShellLaunchParamsFromResult(target)
 	if err := writeDoctorInspection(runCtx, target, req); err != nil {
-		return err
+		return report, err
 	}
-	return runDoctorToolActions(runCtx, input, req)
+	if err := runDoctorToolActions(runCtx, input, req); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+// onlyRootConfigDoctorInput mirrors the CLI's doctorOnlyRepairConfig:
+// when the caller asked exclusively for root-config work (restore or
+// repair) and no tenant/env action flags are set, do not fall through
+// to resolveDoctorOpenResult — that resolver would otherwise fail on
+// the same dangling alias the caller just asked us to fix.
+func onlyRootConfigDoctorInput(input DoctorInput) bool {
+	if len(input.RepairOrphanedAliases) == 0 && strings.TrimSpace(input.RestoreConfigFromBackup) == "" {
+		return false
+	}
+	return !input.PruneImages && !input.PruneBuildCache && !input.PruneContainers
+}
+
+// runDoctorRootConfigToolFlow handles inspection, optional
+// restore-from-backup, and any per-alias repair requested by the
+// caller. Returns the structured report so the outer tool wrapper
+// can attach it to the CommandOutput.
+//
+// fatal=true means the root config is in a state where we should not
+// proceed to tenant/env work even when more was requested — for
+// example, the file is corrupted and no repair input was supplied.
+func runDoctorRootConfigToolFlow(runtime RuntimeConfig, input DoctorInput, runCtx eruncommon.Context) (*DoctorRootConfigReport, bool, error) {
+	inspection, err := eruncommon.InspectRootConfig(runtime.Store)
+	if err != nil {
+		return nil, false, err
+	}
+	report := &DoctorRootConfigReport{Inspection: inspection}
+
+	if selector := strings.TrimSpace(input.RestoreConfigFromBackup); selector != "" {
+		backup, ok, err := resolveDoctorBackupSelector(inspection, selector)
+		if err != nil {
+			return report, true, err
+		}
+		if !ok {
+			return report, true, fmt.Errorf("no root config backup matches %q", selector)
+		}
+		if !runCtx.DryRun {
+			if err := eruncommon.RestoreRootConfigFromBackup(backup.Path, inspection.ConfigPath); err != nil {
+				return report, true, err
+			}
+		}
+		runCtx.TraceCommand("", "cp", backup.Path, inspection.ConfigPath)
+		report.RestoredFromBackup = backup.Path
+		refreshed, refreshErr := eruncommon.InspectRootConfig(runtime.Store)
+		if refreshErr != nil {
+			return report, true, refreshErr
+		}
+		report.Inspection = refreshed
+		inspection = refreshed
+	}
+
+	if len(input.RepairOrphanedAliases) > 0 {
+		if err := runDoctorAliasRepairs(runtime, input, runCtx, inspection, report); err != nil {
+			return report, true, err
+		}
+		refreshed, refreshErr := eruncommon.InspectRootConfig(runtime.Store)
+		if refreshErr != nil {
+			return report, true, refreshErr
+		}
+		report.Inspection = refreshed
+		inspection = refreshed
+	}
+
+	if inspection.ConfigStatus != eruncommon.RootConfigStatusOK {
+		return report, true, nil
+	}
+	if len(inspection.OrphanedAliases) > 0 && onlyRootConfigDoctorInput(input) {
+		// The caller scoped the work to root-config repair but did not
+		// supply enough input to finish it; surface the remaining
+		// orphans so the agent can re-call with the missing aliases.
+		return report, true, nil
+	}
+	return report, false, nil
+}
+
+func runDoctorAliasRepairs(runtime RuntimeConfig, input DoctorInput, runCtx eruncommon.Context, inspection eruncommon.RootConfigInspection, report *DoctorRootConfigReport) error {
+	byAlias := make(map[string]eruncommon.OrphanedAlias, len(inspection.OrphanedAliases))
+	for _, orphan := range inspection.OrphanedAliases {
+		byAlias[orphan.Alias] = orphan
+	}
+	for _, entry := range input.RepairOrphanedAliases {
+		alias := strings.TrimSpace(entry.Alias)
+		if alias == "" {
+			return fmt.Errorf("repairOrphanedAliases entries must include alias")
+		}
+		orphan, ok := byAlias[alias]
+		if !ok {
+			report.UnresolvedAliases = append(report.UnresolvedAliases, alias)
+			continue
+		}
+		params := eruncommon.RepairOrphanedAliasParams{
+			Orphan:        orphan,
+			SSOStartURL:   strings.TrimSpace(entry.SSOStartURL),
+			SSORegion:     strings.TrimSpace(entry.SSORegion),
+			RoleName:      strings.TrimSpace(entry.RoleName),
+			Region:        firstNonBlank(entry.Region, preferredRegionForOrphanAlias(orphan)),
+			OIDCIssuerURL: strings.TrimSpace(entry.OIDCIssuerURL),
+			SkipLogin:     entry.SkipLogin,
+		}
+		if _, err := eruncommon.RepairOrphanedAlias(runCtx, runtime.Store, params, eruncommon.CloudDependencies{}); err != nil {
+			return fmt.Errorf("repair alias %s: %w", alias, err)
+		}
+		report.RepairedAliases = append(report.RepairedAliases, alias)
+	}
+	return nil
+}
+
+func resolveDoctorBackupSelector(inspection eruncommon.RootConfigInspection, selector string) (eruncommon.RootConfigBackup, bool, error) {
+	if strings.ContainsAny(selector, "/\\") {
+		return eruncommon.RootConfigBackup{Path: selector}, true, nil
+	}
+	backup, ok, err := eruncommon.FindRootConfigBackupByDate(inspection.ConfigPath, selector)
+	if err != nil {
+		return eruncommon.RootConfigBackup{}, false, err
+	}
+	return backup, ok, nil
+}
+
+func preferredRegionForOrphanAlias(orphan eruncommon.OrphanedAlias) string {
+	for _, ref := range orphan.ReferencedByCloudContexts {
+		region := strings.TrimSpace(ref.Region)
+		if region != "" {
+			return region
+		}
+	}
+	return ""
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if v := strings.TrimSpace(value); v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func writeDoctorInspection(runCtx eruncommon.Context, target eruncommon.OpenResult, req eruncommon.ShellLaunchParams) error {

--- a/erun-mcp/runtime.go
+++ b/erun-mcp/runtime.go
@@ -40,11 +40,12 @@ type RuntimeConfig struct {
 }
 
 type CommandOutput struct {
-	Executed         bool     `json:"executed"`
-	WorkingDirectory string   `json:"workingDirectory,omitempty"`
-	Trace            []string `json:"trace,omitempty"`
-	Stdout           string   `json:"stdout,omitempty"`
-	Stderr           string   `json:"stderr,omitempty"`
+	Executed         bool                    `json:"executed"`
+	WorkingDirectory string                  `json:"workingDirectory,omitempty"`
+	Trace            []string                `json:"trace,omitempty"`
+	Stdout           string                  `json:"stdout,omitempty"`
+	Stderr           string                  `json:"stderr,omitempty"`
+	RootConfig       *DoctorRootConfigReport `json:"rootConfig,omitempty"`
 }
 
 var ansiRegexp = regexp.MustCompile(`\x1b\[[0-9;]*m`)


### PR DESCRIPTION
## Summary

- Atomic writes for every config save + 0-byte-file refusal close the wipe path that left `cloudproviders:` missing in real-world configs.
- Five rolling daily backups (by count, never by age) under `~/Library/Application Support/erun/config.yaml.YYYY-MM-DD.bak` keep a paper trail.
- `erun doctor` auto-inspects the root config first, surfaces orphaned cloud-provider aliases with full back-references, and offers `--repair-config` and `--restore-config-from-backup <date>` recovery paths.
- MCP doctor tool exposes the same inspection in structured output.

Closes #357.

## Test plan

- [x] `go test ./...` in erun-common, erun-cli, erun-mcp, erun-ui
- [x] `make integration-test` — coverage gate green at 55.9% (≥55%); pre-existing #351 flake retries clean
- [x] New unit tests for atomic writes, daily-backup rotation (count-based, preserves 10-day-old until 5 newer dailies arrive), orphan inspection, alias parser
- [x] New integration scenarios: `doctor/inspect_clean_root_config`, `doctor/inspect_orphaned_alias`, `doctor/inspect_corrupted_root_config`, `doctor/restore_config_from_backup_dry_run`
- [x] Manual smoke against the real broken config — doctor correctly identified `Rihards.Freimanis+020362606330@aws` as orphaned with tenant + cloud-context back-refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)