### PR TITLE
Stop SelectField from overflowing its column and tighten devops fingerprint cache keys

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,7 +30,7 @@ __debug_bin*
 # Local packaging / release artifacts
 /packaging/apt/dist
 /erun-devops/linux/*/dist
-/erun-cli/bin/erun-app
+/erun-cli/bin
 
 # Desktop UI build outputs (not consumed by service Dockerfiles)
 /erun-ui/bin

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ __debug_bin*
 .gomodcache
 /packaging/apt/dist/
 /erun-devops/linux/**/dist/
-/erun-cli/bin/erun-app
+/erun-cli/bin/
 
 # Playwright MCP debugging artifacts (console logs, page snapshots) written
 # at the repo root by the local dev tooling, never by tests

--- a/erun-common/build_incremental.go
+++ b/erun-common/build_incremental.go
@@ -122,7 +122,7 @@ func computeBuildFingerprint(buildInput DockerBuildSpec) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ignored, err := loadContextIgnoreSet(contextDir)
+	ignored, err := loadContextIgnoreSet(contextDir, sources)
 	if err != nil {
 		return "", err
 	}
@@ -228,30 +228,98 @@ type ignorePattern struct {
 	anchored bool
 	dirOnly  bool
 	negate   bool
+	// base is the directory containing the .gitignore the pattern came
+	// from, relative to contextDir and slash-normalized (empty for the
+	// root .dockerignore / .gitignore). The matcher uses it to scope a
+	// pattern to its own subtree, matching git's own behaviour where a
+	// nested .gitignore only governs files beneath it.
+	base string
 }
 
 type ignoreSet struct {
 	patterns []ignorePattern
 }
 
-// loadContextIgnoreSet reads .dockerignore and .gitignore from contextDir and
-// returns a single matcher combining the two. A missing file is not an error;
-// callers receive whatever set could be parsed. .dockerignore patterns are
-// applied first, .gitignore second, so a later negation can override an
-// earlier exclusion.
-func loadContextIgnoreSet(contextDir string) (*ignoreSet, error) {
+// loadContextIgnoreSet builds the ignore matcher applied during fingerprint
+// computation. The root .dockerignore and .gitignore apply to every file in
+// the context. .gitignore files nested under the COPY sources are also
+// honoured, with each nested file's patterns scoped to its own directory
+// subtree — mirroring how git itself reads .gitignore files. Missing files
+// are not an error: callers receive whatever set could be parsed. Patterns
+// are appended in load order so a later negation can override an earlier
+// exclusion.
+func loadContextIgnoreSet(contextDir string, sources []string) (*ignoreSet, error) {
 	combined := &ignoreSet{}
 	for _, name := range []string{".dockerignore", ".gitignore"} {
-		set, err := loadIgnoreFile(filepath.Join(contextDir, name))
+		set, err := loadIgnoreFile(filepath.Join(contextDir, name), "")
 		if err != nil {
 			return nil, err
 		}
 		combined.patterns = append(combined.patterns, set.patterns...)
 	}
+	if err := loadNestedGitignores(contextDir, sources, combined); err != nil {
+		return nil, err
+	}
 	return combined, nil
 }
 
-func loadIgnoreFile(path string) (*ignoreSet, error) {
+// loadNestedGitignores walks under each directory source and appends the
+// patterns from every .gitignore it finds. Nested .dockerignore files are
+// intentionally not honoured because Docker itself only reads the root
+// one — keeping the fingerprint algorithm consistent with the actual build
+// context.
+func loadNestedGitignores(contextDir string, sources []string, combined *ignoreSet) error {
+	visited := make(map[string]struct{}, len(sources))
+	for _, src := range sources {
+		full := filepath.Join(contextDir, src)
+		info, err := os.Lstat(full)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return err
+		}
+		if !info.IsDir() {
+			continue
+		}
+		walkErr := filepath.WalkDir(full, func(path string, d os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			rel, err := filepath.Rel(contextDir, path)
+			if err != nil {
+				return err
+			}
+			rel = filepath.ToSlash(rel)
+			if d.IsDir() {
+				if _, seen := visited[rel]; seen {
+					return filepath.SkipDir
+				}
+				visited[rel] = struct{}{}
+				return nil
+			}
+			if d.Name() != ".gitignore" {
+				return nil
+			}
+			base := filepath.ToSlash(filepath.Dir(rel))
+			if base == "." || base == "" {
+				return nil // root, already loaded
+			}
+			set, err := loadIgnoreFile(path, base)
+			if err != nil {
+				return err
+			}
+			combined.patterns = append(combined.patterns, set.patterns...)
+			return nil
+		})
+		if walkErr != nil {
+			return walkErr
+		}
+	}
+	return nil
+}
+
+func loadIgnoreFile(path, base string) (*ignoreSet, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -259,10 +327,10 @@ func loadIgnoreFile(path string) (*ignoreSet, error) {
 		}
 		return nil, err
 	}
-	return parseIgnoreData(data), nil
+	return parseIgnoreData(data, base), nil
 }
 
-func parseIgnoreData(data []byte) *ignoreSet {
+func parseIgnoreData(data []byte, base string) *ignoreSet {
 	set := &ignoreSet{}
 	for _, raw := range strings.Split(string(data), "\n") {
 		line := strings.TrimRight(raw, "\r")
@@ -303,6 +371,7 @@ func parseIgnoreData(data []byte) *ignoreSet {
 			anchored: anchored,
 			dirOnly:  dirOnly,
 			negate:   negate,
+			base:     base,
 		})
 	}
 	return set
@@ -328,6 +397,16 @@ func (s *ignoreSet) matches(rel string, isDir bool) bool {
 func patternMatchesPath(p ignorePattern, rel string) bool {
 	if p.raw == "" || p.raw == "." {
 		return false
+	}
+	// Patterns loaded from a nested .gitignore only govern files under
+	// that .gitignore's own directory. Strip the base prefix so the rest
+	// of the matcher (anchoring, globbing, dir-only handling) works on a
+	// path relative to where the pattern was declared.
+	if p.base != "" {
+		if rel == p.base || !strings.HasPrefix(rel, p.base+"/") {
+			return false
+		}
+		rel = strings.TrimPrefix(rel, p.base+"/")
 	}
 	if p.anchored {
 		if globMatch(p.raw, rel) {

--- a/erun-integration/build_test.go
+++ b/erun-integration/build_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -12,6 +13,8 @@ import (
 	"github.com/sophium/erun/erun-integration/internal/golden"
 	"github.com/sophium/erun/erun-integration/internal/normalize"
 )
+
+var apiFingerprintRE = regexp.MustCompile(`ghcr\.io/sophium/api:fp-([0-9a-f]{16})-amd64`)
 
 func TestBuild(t *testing.T) {
 	t.Run("help", func(t *testing.T) {
@@ -245,6 +248,60 @@ func TestBuild(t *testing.T) {
 		// Build should still trace docker build for both images, even
 		// though the dockerignore parser fires during fingerprint walk.
 		golden.Equal(t, "build/dry_run_with_dockerignore_drives_ignore_pattern_parser", normalize.Apply(result.Combined))
+	})
+
+	t.Run("nested_gitignore_excludes_files_from_fingerprint", func(t *testing.T) {
+		// Exercises loadNestedGitignores in erun-common/build_incremental.go:
+		// a .gitignore at the root of a COPY'd directory must scope its
+		// patterns to that subtree so files matching the nested patterns
+		// drop out of the fingerprint hash. This guards the local-vs-CI
+		// drift seen on #359 where locally-built erun-cli/bin artifacts
+		// were rolling the devops fingerprint despite being .gitignore'd
+		// by a nested file. Verified by comparing fingerprints across
+		// three runs:
+		//   1. baseline with ignored "secret.txt" content X
+		//   2. ignored content rewritten to Y → fingerprint must stay equal
+		//   3. tracked "tracked.txt" content rewritten → fingerprint must move
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "develop")
+		// Replace the default no-COPY api Dockerfile with one that COPYs a
+		// subdirectory so the fingerprint walker actually descends.
+		dockerfile := filepath.Join(setup.Cwd, "erun-devops", "docker", "api", "Dockerfile")
+		mustWriteFile(t, dockerfile, "FROM alpine:3.22\nCOPY app/ /app/\n")
+		appDir := filepath.Join(setup.Cwd, "app")
+		if err := os.MkdirAll(appDir, 0o755); err != nil {
+			t.Fatalf("mkdir app: %v", err)
+		}
+		mustWriteFile(t, filepath.Join(appDir, ".gitignore"), "secret.txt\n")
+		mustWriteFile(t, filepath.Join(appDir, "tracked.txt"), "tracked v1\n")
+		mustWriteFile(t, filepath.Join(appDir, "secret.txt"), "secret v1\n")
+		fixture.RunGit(t, setup.Cwd, "add", "app/.gitignore", "app/tracked.txt", "erun-devops/docker/api/Dockerfile")
+		fixture.RunGit(t, setup.Cwd, "commit", "-q", "-m", "add app dir with nested gitignore")
+
+		fp := func(label string) string {
+			t.Helper()
+			result := erun.Run(t, []string{"build", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+			if result.ExitCode != 0 {
+				t.Fatalf("%s: exit %d: %s", label, result.ExitCode, result.Combined)
+			}
+			match := apiFingerprintRE.FindStringSubmatch(result.Combined)
+			if match == nil {
+				t.Fatalf("%s: api fingerprint not found in trace:\n%s", label, result.Combined)
+			}
+			return match[1]
+		}
+
+		baseline := fp("baseline")
+		mustWriteFile(t, filepath.Join(appDir, "secret.txt"), "secret v2\n")
+		afterIgnoredChange := fp("after ignored change")
+		if afterIgnoredChange != baseline {
+			t.Fatalf("nested .gitignore not honored: fp moved from %s to %s after editing an ignored file", baseline, afterIgnoredChange)
+		}
+		mustWriteFile(t, filepath.Join(appDir, "tracked.txt"), "tracked v2\n")
+		afterTrackedChange := fp("after tracked change")
+		if afterTrackedChange == baseline {
+			t.Fatalf("fingerprint did not move when a tracked file changed; got %s for both runs", baseline)
+		}
 	})
 
 	t.Run("real_run_with_existing_fingerprint_promotes_via_tag", func(t *testing.T) {

--- a/erun-ui/frontend/src/components/app/SelectField.tsx
+++ b/erun-ui/frontend/src/components/app/SelectField.tsx
@@ -42,7 +42,7 @@ export function SelectField({
   const triggerDisabled = disabled === true || noOptions;
   const helperId = helper ? `${id}-helper` : undefined;
   return (
-    <div className="grid gap-2">
+    <div className="grid min-w-0 gap-2">
       <Label htmlFor={id}>{label}</Label>
       <Select
         value={value || undefined}
@@ -50,7 +50,11 @@ export function SelectField({
         disabled={triggerDisabled}
         onValueChange={onChange}
       >
-        <SelectTrigger id={id} className="w-full" aria-describedby={helperId}>
+        <SelectTrigger
+          id={id}
+          className="w-full min-w-0 *:data-[slot=select-value]:min-w-0 *:data-[slot=select-value]:overflow-hidden *:data-[slot=select-value]:text-ellipsis"
+          aria-describedby={helperId}
+        >
           <SelectValue
             placeholder={noOptions ? (emptyLabel ?? 'No options') : (placeholder ?? '')}
           />

--- a/erun-ui/playwright/pages/GlobalConfigDialog.ts
+++ b/erun-ui/playwright/pages/GlobalConfigDialog.ts
@@ -34,6 +34,18 @@ export class GlobalConfigDialog {
     await this.page.getByRole('option', { name }).click();
   }
 
+  cloudContextProviderTrigger(): Locator {
+    return this.page.locator('#global-config-cloudcontext-provider');
+  }
+
+  cloudContextRegionTrigger(): Locator {
+    return this.page.locator('#global-config-cloudcontext-region');
+  }
+
+  cloudContextProviderValue(): Locator {
+    return this.cloudContextProviderTrigger().locator('[data-slot="select-value"]');
+  }
+
   cloudAliasRow(alias: string): Locator {
     return this.locator().locator(`text=${alias}`).first();
   }

--- a/erun-ui/playwright/tests/global-config.spec.ts
+++ b/erun-ui/playwright/tests/global-config.spec.ts
@@ -12,4 +12,49 @@ test.describe('global config dialog', () => {
     await app.globalConfigDialog.cancel();
     await app.globalConfigDialog.waitForClosed();
   });
+
+  test('long cloud-provider value stays inside its column and does not cover the Region trigger', async ({
+    app,
+  }) => {
+    await app.sidebar.openSettings();
+    await app.globalConfigDialog.waitForOpen();
+
+    const provider = app.globalConfigDialog.cloudContextProviderTrigger();
+    const region = app.globalConfigDialog.cloudContextRegionTrigger();
+    await provider.waitFor({ state: 'visible' });
+    await region.waitFor({ state: 'visible' });
+
+    // The Cloud provider and Region SelectFields sit in adjacent 1fr
+    // tracks of a sm:grid-cols-2 grid. A configured alias long enough
+    // to exceed the track (e.g. "Rihards.Freimanis+020362606330@aws")
+    // used to bleed past the trigger and visually cover the start of
+    // the Region trigger (#359). The headless backend reflects the
+    // developer's ~/.erun/ config, so we cannot stage a real long
+    // alias here — mutate the select-value span directly to force the
+    // same layout state and assert the rendered content stays within
+    // its column.
+    await provider.evaluate((btn) => {
+      const span = btn.querySelector('[data-slot="select-value"]');
+      if (!(span instanceof HTMLElement)) {
+        throw new Error('select-value span not found on Cloud provider trigger');
+      }
+      span.textContent = `long.user.name+0123456789@aws-${'x'.repeat(80)}`;
+    });
+
+    const providerBox = await provider.boundingBox();
+    const valueBox = await app.globalConfigDialog.cloudContextProviderValue().boundingBox();
+    const regionBox = await region.boundingBox();
+    expect(providerBox).not.toBeNull();
+    expect(valueBox).not.toBeNull();
+    expect(regionBox).not.toBeNull();
+    if (!providerBox || !valueBox || !regionBox) return;
+    // The visible content span must not extend past the Cloud provider
+    // trigger, and the trigger must not extend past the start of the
+    // Region trigger.
+    expect(valueBox.x + valueBox.width).toBeLessThanOrEqual(providerBox.x + providerBox.width);
+    expect(providerBox.x + providerBox.width).toBeLessThanOrEqual(regionBox.x);
+
+    await app.globalConfigDialog.cancel();
+    await app.globalConfigDialog.waitForClosed();
+  });
 });


### PR DESCRIPTION
## Summary
- `SelectField` now constrains its trigger and value to the grid track via `min-w-0` on the wrapper, `min-w-0` on the trigger, and `min-w-0`/`overflow-hidden`/`text-ellipsis` on the `data-slot=select-value` child. Long Cloud provider aliases (e.g. `Rihards.Freimanis+020362606330@aws`) no longer bleed past the trigger and cover the start of the adjacent **Region** trigger in the Cloud contexts section of ERun settings.
- Tightened `.dockerignore` and root `.gitignore` to exclude all of `/erun-cli/bin/` (previously only the bare `erun-app` was listed), so locally produced binaries and the macOS `ERun.app/` bundle stop feeding into the docker-build fingerprint.
- Taught `loadContextIgnoreSet` to honour **nested `.gitignore` files** the way git itself does: it walks each COPY source, parses every nested `.gitignore`, and tags its patterns with the base directory they came from. `patternMatchesPath` strips that base before matching, so a nested `.gitignore` only governs files under its own subtree. `.dockerignore` is intentionally not recursed because Docker itself only reads the root one.

Together the last two items remove an entire class of local-vs-CI fingerprint drift: with `/erun-cli/bin/` excluded and nested `.gitignore` files honoured, the devops build cache key no longer rotates every time a developer rebuilds the CLI binary locally.

Closes #359.

## Behaviour impact
- Fingerprint hashes rotate **once** for every image after this lands (the input set is strictly smaller), then stabilise. Previously cached `fp-…` images in local Docker daemons and on ghcr will not match the new keys; the next build everywhere produces new `fp-…` tags and the cache rebuilds normally from there.
- `git ls-files erun-cli/bin/` was already empty; the broader `.gitignore` pattern does not change which files git tracks.

## Test plan
- [x] `go test ./...` in `erun-common` — green.
- [x] `go test ./...` in `erun-integration` — green, including the new `TestBuild/nested_gitignore_excludes_files_from_fingerprint` scenario that proves a nested `.gitignore` keeps the fingerprint stable when an ignored file's contents change and moves it when a tracked file's contents change.
- [x] `make integration-test` — green, coverage gate passing.
- [x] `yarn typecheck` + `yarn lint` + `yarn format:check` + `yarn build` in `erun-ui/frontend` — green.
- [ ] `./erun-ui/playwright/run.sh -- --grep "global config"` — the new spec asserts the Cloud provider trigger's value span never extends past the Region trigger after a long string is injected. Could not execute end-to-end in the sandbox where this branch was prepared (no `pkg-config`/Wails toolchain), but the spec is committed and runs in any normal dev environment.