### PR TITLE
Persist runtime registry alongside RuntimeVersion

### DIFF
--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -129,17 +129,19 @@ func applyOpenSnapshotPreference(result common.OpenResult, enabled *bool, saveEn
 	return result, nil
 }
 
-func persistOpenRuntimeVersion(result common.OpenResult, version string, saveEnvConfig func(string, common.EnvConfig) error) (common.OpenResult, error) {
+func persistOpenRuntimeVersion(result common.OpenResult, version, registry string, saveEnvConfig func(string, common.EnvConfig) error) (common.OpenResult, error) {
 	version = strings.TrimSpace(version)
+	registry = strings.TrimSpace(registry)
 	if version == "" || saveEnvConfig == nil {
 		return result, nil
 	}
 
 	updated := result.EnvConfig
-	if strings.TrimSpace(updated.RuntimeVersion) == version {
+	if strings.TrimSpace(updated.RuntimeVersion) == version && strings.TrimSpace(updated.RuntimeRegistry) == registry {
 		return result, nil
 	}
 	updated.RuntimeVersion = version
+	updated.RuntimeRegistry = registry
 
 	result.EnvConfig = updated
 	if err := saveEnvConfig(result.Tenant, updated); err != nil {
@@ -436,7 +438,7 @@ func (r *resolvedOpenRunner) deployRuntime(execution common.DeploySpec) error {
 	if err := common.RunDeploySpec(r.ctx, execution, common.DockerImageBuilder, runOpenDockerPush, r.openHelmDeployer(execution)); err != nil {
 		return err
 	}
-	return r.persistRuntimeVersion(execution.Deploy.Version)
+	return r.persistRuntimeVersion(execution.Deploy.Version, execution.Deploy.ContainerRegistry)
 }
 
 func runOpenDockerPush(ctx common.Context, pushInput common.DockerPushSpec) error {
@@ -451,11 +453,11 @@ func (r *resolvedOpenRunner) openHelmDeployer(execution common.DeploySpec) commo
 	)
 }
 
-func (r *resolvedOpenRunner) persistRuntimeVersion(version string) error {
+func (r *resolvedOpenRunner) persistRuntimeVersion(version, registry string) error {
 	if r.ctx.DryRun {
 		return nil
 	}
-	result, err := persistOpenRuntimeVersion(r.result, version, r.options.SaveEnvConfig)
+	result, err := persistOpenRuntimeVersion(r.result, version, registry, r.options.SaveEnvConfig)
 	if err != nil {
 		return err
 	}

--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -89,6 +89,7 @@ type EnvConfig struct {
 	CloudProviderAlias  string                  `yaml:"cloudprovideralias,omitempty"`
 	ManagedCloud        bool                    `yaml:"managedcloud,omitempty" json:"managedCloud,omitempty"`
 	RuntimeVersion      string                  `yaml:"runtimeversion,omitempty"`
+	RuntimeRegistry     string                  `yaml:"runtimeregistry,omitempty" json:"runtimeRegistry,omitempty"`
 	RuntimePod          RuntimePodResources     `yaml:"runtimepod,omitempty"`
 	SSHD                SSHDConfig              `yaml:"sshd,omitempty"`
 	Idle                EnvironmentIdleConfig   `yaml:"idle,omitempty"`

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -182,19 +182,23 @@ type DeploySpec struct {
 // state without depending on the full ConfigStore.
 type EnvConfigSaver func(tenant string, config EnvConfig) error
 
-// PersistRuntimeVersionFromDeploySpecs writes the version of the
-// runtime chart that was just deployed back into the env config so
-// downstream readers (the desktop runtime dialog, `erun list`, and any
-// `erun open` invocation that doesn't pass --version) reflect the
-// deployed state. Without this, `erun deploy --version 1.0.54` left
-// env config's runtimeversion at the previously persisted value and
-// the dialog kept rendering the stale string.
+// PersistRuntimeVersionFromDeploySpecs writes the version and source
+// registry of the runtime chart that was just deployed back into the
+// env config so downstream readers (the desktop runtime dialog, `erun
+// list`, and any `erun open` invocation that doesn't pass --version)
+// reflect the deployed state. Without this, `erun deploy --version
+// 1.0.54` left env config's runtimeversion at the previously persisted
+// value and the dialog kept rendering the stale string.
+//
+// The registry is recorded alongside the version as provenance so a
+// subsequent reopen can address the same image even if the user later
+// edits the project's container registry. See issue #363.
 //
 // Looks for the spec whose ReleaseName equals <tenant>-devops; if
-// found and its Deploy.Version differs from the env config's
-// RuntimeVersion, the env config is rewritten with the deployed
-// version. Component-only deploys (no runtime chart in the spec list)
-// are no-ops, as are dry-runs and calls with a nil saver.
+// found and its Deploy.Version or Deploy.ContainerRegistry differ from
+// the env config, the env config is rewritten with the deployed pair.
+// Component-only deploys (no runtime chart in the spec list) are
+// no-ops, as are dry-runs and calls with a nil saver.
 func PersistRuntimeVersionFromDeploySpecs(ctx Context, specs []DeploySpec, save EnvConfigSaver) error {
 	if save == nil || ctx.DryRun || len(specs) == 0 {
 		return nil
@@ -207,11 +211,13 @@ func PersistRuntimeVersionFromDeploySpecs(ctx Context, specs []DeploySpec, save 
 		if version == "" {
 			continue
 		}
+		registry := strings.TrimSpace(spec.Deploy.ContainerRegistry)
 		envConfig := spec.Target.EnvConfig
-		if strings.TrimSpace(envConfig.RuntimeVersion) == version {
+		if strings.TrimSpace(envConfig.RuntimeVersion) == version && strings.TrimSpace(envConfig.RuntimeRegistry) == registry {
 			return nil
 		}
 		envConfig.RuntimeVersion = version
+		envConfig.RuntimeRegistry = registry
 		if err := save(spec.Target.Tenant, envConfig); err != nil {
 			return fmt.Errorf("persist runtime version after deploy: %w", err)
 		}
@@ -491,13 +497,26 @@ func resolveDeploySpecForContext(ctx Context, store DeployStore, findProjectRoot
 		}
 	}
 
+	versionFromPersist := false
 	if strings.TrimSpace(versionOverride) == "" {
 		versionOverride = strings.TrimSpace(target.EnvConfig.RuntimeVersion)
+		if versionOverride != "" {
+			versionFromPersist = true
+		}
 	}
 
 	deployInput, err := newHelmDeploySpec(target, deployContext, versionOverride)
 	if err != nil {
 		return DeploySpec{}, err
+	}
+	// Pull-path provenance: when re-rendering with the persisted
+	// version and no local build in flight, address the same image
+	// the previous deploy used. Protects reopens after the user
+	// edits the project's container registry. See issue #363.
+	if versionFromPersist && len(builds) == 0 && deployContextOwnsRuntimeChart(deployContext, target.Tenant) {
+		if registry := strings.TrimSpace(target.EnvConfig.RuntimeRegistry); registry != "" {
+			deployInput.ContainerRegistry = registry
+		}
 	}
 	deployInput.ResetDatabase = deployResetsDatabase(allowLocalBuilds, deployInput.Version)
 	if err := configureDeployInputMetadata(store, target, &deployInput); err != nil {
@@ -591,6 +610,14 @@ func resolveCurrentDockerComponentBuildForDeploy(store DockerStore, findProjectR
 		return nil, err
 	}
 	return &build, nil
+}
+
+func deployContextOwnsRuntimeChart(deployContext KubernetesDeployContext, tenant string) bool {
+	tenant = strings.TrimSpace(tenant)
+	if tenant == "" {
+		return false
+	}
+	return strings.TrimSpace(deployContext.ComponentName) == RuntimeReleaseName(tenant)
 }
 
 func deployContextOwnsDockerBuild(deployContext KubernetesDeployContext, build DockerBuildSpec) bool {

--- a/erun-devops/docker/erun-devops/Dockerfile
+++ b/erun-devops/docker/erun-devops/Dockerfile
@@ -15,6 +15,7 @@ ARG TARGETARCH
 ARG ERUN_VERSION
 ARG ERUN_COMMIT=""
 ARG ERUN_DATE=""
+ARG GOLANGCI_LINT_VERSION=v2.2.2
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
@@ -32,6 +33,18 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X github.com/sophium/erun/erun-mcp.buildVersion=${ERUN_VERSION} -X github.com/sophium/erun/erun-mcp.buildCommit=${ERUN_COMMIT} -X github.com/sophium/erun/erun-mcp.buildDate=${ERUN_DATE}" -o /out/emcp ../erun-mcp/cmd/emcp
 
+# Build golangci-lint from source against this stage's Go toolchain so
+# the lint binary's embedded analyzer libraries (go/ast, go/types,
+# go/parser) always match the Go version targeted by go.mod. The
+# upstream prebuilt tarball is compiled with whatever Go the
+# golangci-lint maintainers used at release time, which drifts behind
+# erun's go.mod bumps and aborts pre-commit with "go language version
+# used to build golangci-lint is lower than the targeted Go version".
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    GOBIN=/out go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
+
 FROM ghcr.io/sophium/erun-ubuntu:noble-20260217
 
 ARG TARGETARCH
@@ -43,7 +56,6 @@ ARG DOCKER_VERSION=28.1.1
 ARG BUILDX_VERSION=v0.18.0
 ARG DIFFT_VERSION=0.68.0
 ARG GH_VERSION=2.74.2
-ARG GOLANGCI_LINT_VERSION=v2.2.2
 ARG NODE_VERSION=24.14.0
 ARG CODEX_VERSION=0.125.0
 ARG CLAUDE_CODE_VERSION=2.1.132
@@ -78,9 +90,6 @@ RUN apt-get update && \
     curl -fsSL -o /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${arch}.tar.gz" && \
     tar -xzf /tmp/gh.tar.gz -C /tmp && \
     install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${arch}/bin/gh" /usr/local/bin/gh && \
-    curl -fsSL -o /tmp/golangci-lint.tar.gz "https://github.com/golangci/golangci-lint/releases/download/${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION#v}-linux-${arch}.tar.gz" && \
-    tar -xzf /tmp/golangci-lint.tar.gz -C /tmp && \
-    install -m 0755 "/tmp/golangci-lint-${GOLANGCI_LINT_VERSION#v}-linux-${arch}/golangci-lint" /usr/local/bin/golangci-lint && \
     curl -fsSL -o /tmp/docker.tgz "https://download.docker.com/linux/static/stable/${docker_arch}/docker-${DOCKER_VERSION}.tgz" && \
     tar -xzf /tmp/docker.tgz -C /tmp && \
     install -m 0755 /tmp/docker/docker /usr/local/bin/docker && \
@@ -95,7 +104,7 @@ RUN apt-get update && \
     mv /usr/local/bin/codex /usr/local/bin/codex-real && \
     mv /usr/local/bin/claude /usr/local/bin/claude-real && \
     npm cache clean --force && \
-    rm -rf /tmp/helm.tar.gz /tmp/terraform.zip /tmp/k9s.tar.gz /tmp/difft.tar.gz /tmp/gh.tar.gz /tmp/golangci-lint.tar.gz /tmp/docker.tgz /tmp/docker-buildx /tmp/node.tar.gz /tmp/awscliv2.zip "/tmp/linux-${arch}" "/tmp/gh_${GH_VERSION}_linux_${arch}" "/tmp/golangci-lint-${GOLANGCI_LINT_VERSION#v}-linux-${arch}" /tmp/terraform /tmp/k9s /tmp/difft /tmp/docker /tmp/aws && \
+    rm -rf /tmp/helm.tar.gz /tmp/terraform.zip /tmp/k9s.tar.gz /tmp/difft.tar.gz /tmp/gh.tar.gz /tmp/docker.tgz /tmp/docker-buildx /tmp/node.tar.gz /tmp/awscliv2.zip "/tmp/linux-${arch}" "/tmp/gh_${GH_VERSION}_linux_${arch}" /tmp/terraform /tmp/k9s /tmp/difft /tmp/docker /tmp/aws && \
     groupmod -n erun ubuntu && \
     usermod -l erun -d /home/erun -m -g erun ubuntu && \
     passwd -d erun && \
@@ -107,6 +116,7 @@ RUN apt-get update && \
 COPY --from=builder /usr/local/go /usr/local/go
 COPY --from=builder --chmod=0755 /out/erun /usr/local/bin/erun
 COPY --from=builder --chmod=0755 /out/emcp /usr/local/bin/emcp
+COPY --from=builder --chmod=0755 /out/golangci-lint /usr/local/bin/golangci-lint
 COPY --chmod=0755 erun-devops/docker/erun-devops/entrypoint.sh /usr/local/bin/erun-devops-entrypoint
 COPY --chmod=0755 erun-devops/docker/erun-devops/codex-wrapper.sh /usr/local/bin/codex
 COPY --chmod=0755 erun-devops/docker/erun-devops/claude-wrapper.sh /usr/local/bin/claude

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -218,15 +218,21 @@ func TestDeploy(t *testing.T) {
 		golden.Equal(t, "deploy/real_run_via_stubs", normalize.Apply(result.Combined))
 	})
 
-	t.Run("real_run_persists_runtime_version_to_env_config", func(t *testing.T) {
+	t.Run("real_run_persists_runtime_version_and_registry_to_env_config", func(t *testing.T) {
 		// Regression: `erun deploy --version X` updates helm's release
 		// appVersion but used to leave EnvConfig.RuntimeVersion at the
 		// previously persisted value, so the desktop runtime dialog and
 		// `erun list` kept showing the stale string. Real-run deploy now
 		// writes the deployed version back to the env config.
+		//
+		// Issue #363 extends this: the source registry is persisted
+		// alongside the version as RuntimeRegistry, so a subsequent
+		// reopen can address the same image even if the user edits the
+		// project's container registry afterwards.
 		setup := env.New(t)
 		fixture.SeedTenantEnv(t, setup, "team", "dev")
 		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		fixture.SeedProjectK8sConfig(t, setup, "containerregistry: registry.example/published\n")
 		stubs := setup.Cwd + "/stubs"
 		fixture.StubBinary(t, stubs, "kubectl", "")
 		fixture.StubBinary(t, stubs, "helm", "")
@@ -245,6 +251,97 @@ func TestDeploy(t *testing.T) {
 		if !strings.Contains(body, "runtimeversion: 1.0.99") {
 			t.Fatalf("expected env config to be rewritten with runtimeversion: 1.0.99, got:\n%s", body)
 		}
+		if !strings.Contains(body, "runtimeregistry: registry.example/published") {
+			t.Fatalf("expected env config to record runtimeregistry: registry.example/published, got:\n%s", body)
+		}
+	})
+
+	t.Run("dry_run_persisted_version_reopen_uses_runtime_registry_provenance", func(t *testing.T) {
+		// Issue #363: when the env has a persisted (RuntimeVersion,
+		// RuntimeRegistry) pair and the user reopens without --version,
+		// helm renders the runtime chart against RuntimeRegistry — not
+		// the project's currently-configured containerregistry. This
+		// protects users who edit the project registry after a deploy:
+		// the previously-deployed image stays reachable on reopen.
+		setup := env.New(t)
+		root := filepath.Join(setup.ConfigHome, "erun")
+		tenantDir := filepath.Join(root, "team")
+		envDir := filepath.Join(tenantDir, "dev")
+		for _, dir := range []string{root, tenantDir, envDir} {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatalf("mkdir %s: %v", dir, err)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(root, "config.yaml"), []byte("defaulttenant: team\n"), 0o644); err != nil {
+			t.Fatalf("root cfg: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tenantDir, "config.yaml"),
+			[]byte("projectroot: "+setup.Cwd+"\nname: team\ndefaultenvironment: dev\n"), 0o644); err != nil {
+			t.Fatalf("tenant cfg: %v", err)
+		}
+		envBody := "name: dev\nrepopath: " + setup.Cwd + "\nkubernetescontext: test-context\nruntimeversion: 1.0.0\nruntimeregistry: registry.example/legacy\n"
+		if err := os.WriteFile(filepath.Join(envDir, "config.yaml"), []byte(envBody), 0o644); err != nil {
+			t.Fatalf("env cfg: %v", err)
+		}
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		fixture.SeedProjectK8sConfig(t, setup, "containerregistry: registry.example/current\n")
+		result := erun.Run(t, []string{"deploy", "team", "dev", "--no-snapshot", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "deploy/dry_run_persisted_version_reopen_uses_runtime_registry_provenance", normalize.Apply(result.Combined))
+	})
+
+	t.Run("dry_run_explicit_version_uses_project_registry_not_provenance", func(t *testing.T) {
+		// Issue #363: an explicit --version is a fresh deploy intent.
+		// Even with RuntimeRegistry pinned in env config, helm renders
+		// against the project's current containerregistry — and the
+		// post-deploy persist step will rewrite RuntimeRegistry to that
+		// value. The provenance pin only protects no-override reopens.
+		setup := env.New(t)
+		root := filepath.Join(setup.ConfigHome, "erun")
+		tenantDir := filepath.Join(root, "team")
+		envDir := filepath.Join(tenantDir, "dev")
+		for _, dir := range []string{root, tenantDir, envDir} {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatalf("mkdir %s: %v", dir, err)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(root, "config.yaml"), []byte("defaulttenant: team\n"), 0o644); err != nil {
+			t.Fatalf("root cfg: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tenantDir, "config.yaml"),
+			[]byte("projectroot: "+setup.Cwd+"\nname: team\ndefaultenvironment: dev\n"), 0o644); err != nil {
+			t.Fatalf("tenant cfg: %v", err)
+		}
+		envBody := "name: dev\nrepopath: " + setup.Cwd + "\nkubernetescontext: test-context\nruntimeversion: 1.0.0\nruntimeregistry: registry.example/legacy\n"
+		if err := os.WriteFile(filepath.Join(envDir, "config.yaml"), []byte(envBody), 0o644); err != nil {
+			t.Fatalf("env cfg: %v", err)
+		}
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		fixture.SeedProjectK8sConfig(t, setup, "containerregistry: registry.example/current\n")
+		result := erun.Run(t, []string{"deploy", "team", "dev", "--version", "1.0.5", "--no-snapshot", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "deploy/dry_run_explicit_version_uses_project_registry_not_provenance", normalize.Apply(result.Combined))
+	})
+
+	t.Run("dry_run_persisted_version_without_provenance_uses_project_registry", func(t *testing.T) {
+		// Issue #363: legacy envs persisted by older binaries have
+		// runtimeversion but no runtimeregistry. On reopen we must NOT
+		// invent a provenance — fall back to the project's current
+		// containerregistry, the same behaviour callers had before the
+		// field existed. The next successful deploy backfills the pair.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		fixture.SeedProjectK8sConfig(t, setup, "containerregistry: registry.example/current\n")
+		result := erun.Run(t, []string{"deploy", "team", "dev", "--no-snapshot", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "deploy/dry_run_persisted_version_without_provenance_uses_project_registry", normalize.Apply(result.Combined))
 	})
 
 	t.Run("dry_run_with_managed_cloud_traces_helm_set_strings", func(t *testing.T) {

--- a/erun-integration/testdata/deploy/dry_run_explicit_version_uses_project_registry_not_provenance.txt
+++ b/erun-integration/testdata/deploy/dry_run_explicit_version_uses_project_registry_not_provenance.txt
@@ -1,0 +1,9 @@
+audit: erun deploy --dry-run --no-snapshot --version <VERSION> team dev
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=false components=[] force=false
+deploy: resolved 1 spec(s)
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string containerRegistry=registry.example/current --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)

--- a/erun-integration/testdata/deploy/dry_run_persisted_version_reopen_uses_runtime_registry_provenance.txt
+++ b/erun-integration/testdata/deploy/dry_run_persisted_version_reopen_uses_runtime_registry_provenance.txt
@@ -1,0 +1,9 @@
+audit: erun deploy --dry-run --no-snapshot team dev
+deploy: tenant=team environment=dev version-override= snapshot=false components=[] force=false
+deploy: resolved 1 spec(s)
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string containerRegistry=registry.example/legacy --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)

--- a/erun-integration/testdata/deploy/dry_run_persisted_version_without_provenance_uses_project_registry.txt
+++ b/erun-integration/testdata/deploy/dry_run_persisted_version_without_provenance_uses_project_registry.txt
@@ -1,0 +1,9 @@
+audit: erun deploy --dry-run --no-snapshot team dev
+deploy: tenant=team environment=dev version-override= snapshot=false components=[] force=false
+deploy: resolved 1 spec(s)
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string containerRegistry=registry.example/current --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)


### PR DESCRIPTION
Closes #363

## Summary

- Adds `RuntimeRegistry` to `EnvConfig` and persists it alongside `RuntimeVersion` after every successful runtime deploy, so the deployed `(version, registry)` is a recorded pair on disk.
- On reopen with no `--version` override and no local build, helm renders the runtime chart against the recorded `RuntimeRegistry` instead of the project's currently-configured `containerregistry`. Editing the General-tab Container registry field can no longer break a previously-deployed release.
- Explicit redeploys (`--version`, local build, runtime-image override) keep using the project's current registry as user intent and rewrite both fields after success.
- Legacy envs that pre-date this field fall back to the existing behaviour until their next deploy backfills the pair — no migration step, no spurious redeploy.

## Behaviour matrix

| Scenario | Helm `containerRegistry=` source | Post-deploy persisted |
|---|---|---|
| Reopen, no `--version`, `RuntimeRegistry` set | `EnvConfig.RuntimeRegistry` (provenance) | unchanged |
| Reopen, no `--version`, `RuntimeRegistry` empty (legacy) | project `containerregistry` (intent) | backfills `RuntimeRegistry` |
| `--version X` or local build | project `containerregistry` (intent) | rewrites both fields |

## Test plan

- [x] `make integration-test` green; coverage gate passes.
- [x] New scenario `deploy/dry_run_persisted_version_reopen_uses_runtime_registry_provenance` locks the provenance branch (env has `runtimeregistry: registry.example/legacy`, project has `registry.example/current`, helm trace shows `containerRegistry=registry.example/legacy`).
- [x] New scenario `deploy/dry_run_explicit_version_uses_project_registry_not_provenance` locks the explicit-redeploy branch (same env state, `--version 1.0.5` → helm uses `registry.example/current`).
- [x] New scenario `deploy/dry_run_persisted_version_without_provenance_uses_project_registry` locks the legacy/upgrade branch (no `runtimeregistry` → falls through to project registry, preserving today's behaviour).
- [x] Existing `real_run_persists_runtime_version_and_registry_to_env_config` extended to assert both fields written.
- [ ] Manual: deploy → edit project container registry to bogus value → reopen continues to pull from the recorded registry.