### PR TITLE
Mirror AGENTS.md as CLAUDE.md in every directory that has one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Repository guidance for humans and coding agents working in this repo.
   - `erun-backend/AGENTS.md` plus `erun-backend/erun-backend-api/AGENTS.md` and `erun-backend/erun-backend-db/AGENTS.md` — hosted-backend, API, and Atlas-migration guidance.
 - A child `AGENTS.md` is additional, not a replacement: parent rules still apply unless the child explicitly overrides them.
 - If you add a new `AGENTS.md` anywhere in the tree, also list it in the bullet above so future readers find it without searching.
+- Each `AGENTS.md` has a sibling `CLAUDE.md` symlink so Claude Code's `CLAUDE.md` convention resolves to the same file. `AGENTS.md` is the only source of truth — edit it, not the symlink. When you add a new `AGENTS.md`, create the matching `CLAUDE.md` symlink in the same directory (`ln -s AGENTS.md CLAUDE.md`).
 
 ## Contributing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-backend/CLAUDE.md
+++ b/erun-backend/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-backend/erun-backend-api/CLAUDE.md
+++ b/erun-backend/erun-backend-api/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-backend/erun-backend-db/CLAUDE.md
+++ b/erun-backend/erun-backend-db/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-devops/CLAUDE.md
+++ b/erun-devops/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-integration/CLAUDE.md
+++ b/erun-integration/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-ui/CLAUDE.md
+++ b/erun-ui/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-ui/playwright/CLAUDE.md
+++ b/erun-ui/playwright/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

- Claude Code reads `CLAUDE.md` as project instructions but ignores `AGENTS.md`. Add a relative `CLAUDE.md -> AGENTS.md` symlink next to every `AGENTS.md` so both conventions resolve to the same source of truth.
- AGENTS.md remains the only file to edit; the symlinks are committed as git mode `120000` blobs (works on macOS/Linux out of the box, needs `core.symlinks=true` on Windows checkouts).
- Root `AGENTS.md` gets a one-line bullet documenting the convention so a future contributor doesn't try to edit the symlink directly or forget to create one for a new AGENTS.md.

Files added (8 symlinks):

- `CLAUDE.md`
- `erun-backend/CLAUDE.md`
- `erun-backend/erun-backend-api/CLAUDE.md`
- `erun-backend/erun-backend-db/CLAUDE.md`
- `erun-devops/CLAUDE.md`
- `erun-integration/CLAUDE.md`
- `erun-ui/CLAUDE.md`
- `erun-ui/playwright/CLAUDE.md`

## Test plan

- [x] `ls -la <each path>` confirms the symlink resolves to the sibling `AGENTS.md`.
- [x] `git ls-files --stage` shows mode `120000` for each entry (symlinks, not regular files).
- [x] Reading `CLAUDE.md` from any of the listed directories returns the same content as the sibling `AGENTS.md`.

Closes #367