### PR TITLE
Add deploy --publish to push charts to OCI registry

### DIFF
--- a/erun-cli/cmd/deploy.go
+++ b/erun-cli/cmd/deploy.go
@@ -33,9 +33,9 @@ func newDeployCmd(store common.DeployStore, saveEnvConfig common.EnvConfigSaver,
 			}
 			deployTarget.Snapshot = snapshotOverride
 			deployTarget.Components = components
-			ctx.Trace(fmt.Sprintf("deploy: tenant=%s environment=%s version-override=%s snapshot=%v components=%v force=%v",
+			ctx.Trace(fmt.Sprintf("deploy: tenant=%s environment=%s version-override=%s snapshot=%v components=%v force=%v publish=%v",
 				deployTarget.Tenant, deployTarget.Environment, deployTarget.VersionOverride,
-				snapshotOverride != nil && *snapshotOverride, components, deployTarget.Force))
+				snapshotOverride != nil && *snapshotOverride, components, deployTarget.Force, deployTarget.Publish))
 			deploySpecs, err := common.ResolveCurrentDeploySpecs(ctx, store, findProjectRoot, resolveBuildContext, resolveDeployContext, now, deployTarget)
 			if err != nil {
 				ctx.Trace("deploy: spec resolution failed: " + err.Error())
@@ -95,6 +95,7 @@ func addDeployCommandTargetFlags(cmd *cobra.Command, target *common.DeployTarget
 	cmd.Flags().StringVar(&target.Tenant, "tenant", "", "Deploy for a specific tenant")
 	cmd.Flags().StringVar(&target.Environment, "environment", "", "Deploy for a specific environment; requires --tenant")
 	cmd.Flags().BoolVar(&target.Force, "force", false, "Bypass the fingerprint cache and re-run helm upgrade even when no source change is detected")
+	cmd.Flags().BoolVar(&target.Publish, "publish", false, "Package and push each resolved chart to the environment's container registry (oci://<containerRegistry>/<chart>:<version>) before helm upgrade")
 	cmd.Flags().StringVar(&target.RepoPath, "repo-path", "", "Repo path override for internal tooling")
 	_ = cmd.Flags().MarkHidden("repo-path")
 }

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -161,6 +161,12 @@ type DeployTarget struct {
 	// rebuilds from scratch, which also clears SkipHelm and re-runs the
 	// helm upgrade even when no source change is detected.
 	Force bool
+	// Publish, when true, packages each resolved chart and pushes the
+	// resulting tgz to the environment's container registry as an OCI
+	// Helm artifact (oci://<containerRegistry>/<chart-name>:<version>)
+	// before the helm upgrade runs. A missing container registry fails
+	// resolution so the user never sees a half-finished publish.
+	Publish bool
 }
 
 type DeploySpec struct {
@@ -174,6 +180,10 @@ type DeploySpec struct {
 	// pods are not rolled. Charts with no locally-built images keep
 	// SkipHelm=false so chart-only changes still ship.
 	SkipHelm bool
+	// PublishChart toggles the chart-publish step performed before
+	// helm upgrade. Publish carries the package/push parameters.
+	PublishChart bool
+	Publish      HelmChartPublishSpec
 }
 
 // EnvConfigSaver writes an updated env config to disk. The contract
@@ -371,7 +381,7 @@ func RunHelmDeploy(ctx Context, deployInput HelmDeploySpec, deploy HelmChartDepl
 }
 
 func RunDeploySpec(ctx Context, execution DeploySpec, build DockerImageBuilderFunc, push DockerPushFunc, deploy HelmChartDeployerFunc) error {
-	if execution.SkipHelm {
+	if execution.SkipHelm && !execution.PublishChart {
 		ctx.Trace("deploy: skipping " + execution.DeployContext.ComponentName + " (all images cached, no rebuild)")
 		return nil
 	}
@@ -393,6 +403,15 @@ func RunDeploySpec(ctx Context, execution DeploySpec, build DockerImageBuilderFu
 			return err
 		}
 	}
+	if execution.PublishChart {
+		if err := RunHelmChartPublish(ctx, execution.Publish); err != nil {
+			return err
+		}
+	}
+	if execution.SkipHelm {
+		ctx.Trace("deploy: skipping helm upgrade for " + execution.DeployContext.ComponentName + " (all images cached, no rebuild)")
+		return nil
+	}
 	return RunHelmDeploy(ctx, execution.Deploy, deploy)
 }
 
@@ -404,7 +423,14 @@ func ResolveDeploySpec(ctx Context, store DeployStore, findProjectRoot ProjectFi
 	if err != nil {
 		return DeploySpec{}, err
 	}
-	return resolveDeploySpecForOpenResult(ctx, store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, resolvedTarget, componentName, versionOverride, deployTargetSnapshotEnabled(resolvedTarget, target.Snapshot), target.Force)
+	spec, err := resolveDeploySpecForOpenResult(ctx, store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, resolvedTarget, componentName, versionOverride, deployTargetSnapshotEnabled(resolvedTarget, target.Snapshot), target.Force)
+	if err != nil {
+		return DeploySpec{}, err
+	}
+	if err := applyDeploySpecPublish(&spec, target.Publish); err != nil {
+		return DeploySpec{}, err
+	}
+	return spec, nil
 }
 
 func ResolveCurrentDeploySpecs(ctx Context, store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target DeployTarget) ([]DeploySpec, error) {
@@ -424,6 +450,9 @@ func ResolveCurrentDeploySpecs(ctx Context, store DeployStore, findProjectRoot P
 			spec.Deploy.Version = versionOverride
 		}
 		if err := configureDeployInputMetadata(store, resolvedTarget, &spec.Deploy); err != nil {
+			return nil, err
+		}
+		if err := applyDeploySpecPublish(&spec, target.Publish); err != nil {
 			return nil, err
 		}
 		return []DeploySpec{spec}, nil
@@ -456,10 +485,30 @@ func ResolveCurrentDeploySpecs(ctx Context, store DeployStore, findProjectRoot P
 		if err != nil {
 			return nil, err
 		}
+		if err := applyDeploySpecPublish(&spec, target.Publish); err != nil {
+			return nil, err
+		}
 		specs = append(specs, spec)
 	}
 
 	return specs, nil
+}
+
+// applyDeploySpecPublish sets the publish parameters on the spec when the
+// caller requested --publish. The OCI repo is derived from the spec's
+// resolved container registry; resolveHelmChartPublishSpec fails when the
+// registry is empty so we never reach the package step without one.
+func applyDeploySpecPublish(spec *DeploySpec, publish bool) error {
+	if !publish || spec == nil {
+		return nil
+	}
+	publishSpec, err := resolveHelmChartPublishSpec(spec.DeployContext.ChartPath, spec.Deploy.Version, spec.Deploy.ContainerRegistry)
+	if err != nil {
+		return err
+	}
+	spec.PublishChart = true
+	spec.Publish = publishSpec
+	return nil
 }
 
 func ResolveDeploySpecForOpenResult(ctx Context, store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, componentName, versionOverride string) (DeploySpec, error) {

--- a/erun-common/helm_chart_publish.go
+++ b/erun-common/helm_chart_publish.go
@@ -1,0 +1,141 @@
+package eruncommon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// HelmChartPublishSpec describes a single chart-publish step: package the
+// chart at ChartPath, then push the resulting tgz to OCIRepo as an OCI Helm
+// artifact. The published reference is `<OCIRepo trimmed of oci://>/<ChartName>:<Version>`.
+//
+// The publish step packages into the chart's parent directory rather than a
+// temp dir so the dry-run trace shows the actual `helm package` and
+// `helm push` argv the real run would execute, including the working
+// directory. The tgz is cleaned up after push.
+type HelmChartPublishSpec struct {
+	ChartPath string
+	ChartName string
+	Version   string
+	OCIRepo   string
+	Verbosity int
+}
+
+func (p HelmChartPublishSpec) packageCommand() commandSpec {
+	return commandSpec{
+		Dir:  filepath.Dir(p.ChartPath),
+		Name: "helm",
+		Args: []string{
+			"package",
+			filepath.Base(p.ChartPath),
+			"--version", p.Version,
+			"--app-version", p.Version,
+		},
+	}
+}
+
+func (p HelmChartPublishSpec) pushCommand() commandSpec {
+	return commandSpec{
+		Dir:  filepath.Dir(p.ChartPath),
+		Name: "helm",
+		Args: []string{
+			"push",
+			p.ChartName + "-" + p.Version + ".tgz",
+			p.OCIRepo,
+		},
+	}
+}
+
+// RunHelmChartPublish traces and executes the package + push pair. In
+// dry-run the trace lines are emitted and execution short-circuits before
+// any filesystem or network side effects occur. Real-run packages into the
+// chart's parent directory and removes the tgz once push completes (or
+// fails), regardless of the push outcome.
+func RunHelmChartPublish(ctx Context, spec HelmChartPublishSpec) error {
+	if strings.TrimSpace(spec.ChartName) == "" {
+		return errors.New("publish: chart name is required")
+	}
+	if strings.TrimSpace(spec.Version) == "" {
+		return fmt.Errorf("publish %s: chart version is required", spec.ChartName)
+	}
+	if strings.TrimSpace(spec.OCIRepo) == "" {
+		return fmt.Errorf("publish %s: oci repo is required", spec.ChartName)
+	}
+
+	pkg := spec.packageCommand()
+	push := spec.pushCommand()
+	ctx.TraceCommand(pkg.Dir, pkg.Name, pkg.Args...)
+	ctx.TraceCommand(push.Dir, push.Name, push.Args...)
+	if ctx.DryRun {
+		return nil
+	}
+
+	ctx.Info("==> Publishing " + spec.ChartName + " " + spec.Version + " to " + spec.OCIRepo)
+	if err := runHelmCommand(ctx, pkg); err != nil {
+		return fmt.Errorf("helm package %s: %w", spec.ChartName, err)
+	}
+	tgzPath := filepath.Join(pkg.Dir, spec.ChartName+"-"+spec.Version+".tgz")
+	defer os.Remove(tgzPath)
+	if err := runHelmCommand(ctx, push); err != nil {
+		return fmt.Errorf("helm push %s: %w", spec.ChartName, err)
+	}
+	return nil
+}
+
+func runHelmCommand(ctx Context, spec commandSpec) error {
+	cmd := Command(spec.Name, spec.Args...)
+	cmd.Dir = spec.Dir
+	cmd.Stdout = ctx.Stdout
+	cmd.Stderr = ctx.Stderr
+	return cmd.Run()
+}
+
+// loadHelmChartName reads the `name` field from <chartPath>/Chart.yaml.
+// Callers use this to know the tgz filename `helm package` will produce so
+// `helm push` can reference it without globbing the destination dir.
+func loadHelmChartName(chartPath string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(chartPath, "Chart.yaml"))
+	if err != nil {
+		return "", err
+	}
+	var chart struct {
+		Name string `yaml:"name"`
+	}
+	if err := yaml.Unmarshal(data, &chart); err != nil {
+		return "", fmt.Errorf("parse Chart.yaml at %s: %w", chartPath, err)
+	}
+	name := strings.TrimSpace(chart.Name)
+	if name == "" {
+		return "", fmt.Errorf("Chart.yaml at %s is missing the name field", chartPath)
+	}
+	return name, nil
+}
+
+// resolveHelmChartPublishSpec builds a HelmChartPublishSpec from a resolved
+// HelmDeploySpec and the chart path. It fails fast on a missing container
+// registry rather than surfacing the error in the middle of a deploy.
+func resolveHelmChartPublishSpec(chartPath, version, containerRegistry string) (HelmChartPublishSpec, error) {
+	chartName, err := loadHelmChartName(chartPath)
+	if err != nil {
+		return HelmChartPublishSpec{}, err
+	}
+	registry := strings.TrimSpace(containerRegistry)
+	if registry == "" {
+		return HelmChartPublishSpec{}, fmt.Errorf("publish %s: container registry is required (configure containerregistry in .erun/config.yaml)", chartName)
+	}
+	resolvedVersion := strings.TrimSpace(version)
+	if resolvedVersion == "" {
+		return HelmChartPublishSpec{}, fmt.Errorf("publish %s: chart version is required (pass --version or persist runtimeversion in env config)", chartName)
+	}
+	return HelmChartPublishSpec{
+		ChartPath: chartPath,
+		ChartName: chartName,
+		Version:   resolvedVersion,
+		OCIRepo:   "oci://" + registry,
+	}, nil
+}

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -49,6 +49,64 @@ func TestDeploy(t *testing.T) {
 		golden.Equal(t, "deploy/dry_run_from_devops_cwd", normalize.Apply(result.Combined))
 	})
 
+	t.Run("publish_traces_helm_package_and_push_before_upgrade", func(t *testing.T) {
+		// --publish runs `helm package` then `helm push oci://<registry>` in
+		// the chart's parent directory before the helm upgrade. The trace
+		// must show the real commands so dry-run is auditable; both must
+		// appear in the resolved spec ahead of the helm upgrade line.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		fixture.SeedProjectK8sConfig(t, setup, "containerregistry: registry.example/test\n")
+		result := erun.Run(t, []string{"deploy", "team", "dev", "--version", "1.0.0", "--publish", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "deploy/publish_traces_helm_package_and_push_before_upgrade", normalize.Apply(result.Combined))
+	})
+
+	t.Run("publish_real_run_invokes_helm_package_and_push_via_stubs", func(t *testing.T) {
+		// Real-run path: --publish without --dry-run exercises the
+		// runHelmCommand exec branch in helm_chart_publish.go. The helm
+		// stub exits 0 for any argv so package + push both succeed, and
+		// the deploy still drives helm upgrade after the publish step.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		fixture.SeedProjectK8sConfig(t, setup, "containerregistry: registry.example/test\n")
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinary(t, stubs, "kubectl", "")
+		fixture.StubBinary(t, stubs, "helm", "")
+		fixture.StubBinary(t, stubs, "docker", "")
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl", "helm", "docker")...)
+		result := erun.Run(t, []string{"deploy", "team", "dev", "--version", "1.0.0", "--publish", "--no-snapshot"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		out := normalize.Apply(result.Combined)
+		if !strings.Contains(out, "==> Publishing team-devops <VERSION> to oci://registry.example/test") {
+			t.Fatalf("expected ==> Publishing info line in output:\n%s", out)
+		}
+		if !strings.Contains(out, "==> Deployed team/dev <VERSION>") {
+			t.Fatalf("expected clean deploy completion after publish, got:\n%s", out)
+		}
+	})
+
+	t.Run("publish_without_container_registry_errors", func(t *testing.T) {
+		// --publish requires a container registry to derive the OCI repo.
+		// When the project has none configured, resolution must fail with a
+		// clear, actionable error rather than tracing a half-built command
+		// or pushing to an empty target.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"deploy", "team", "dev", "--version", "1.0.0", "--publish", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit when --publish has no container registry, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "deploy/publish_without_container_registry_errors", normalize.Apply(result.Combined))
+	})
+
 	t.Run("force_flag_appears_in_trace", func(t *testing.T) {
 		// --force surfaces in the deploy trace so dry-run callers can see
 		// the cache-bypass decision, and it propagates to the resolved

--- a/erun-integration/testdata/deploy/components_includes_backend_in_deploy_order.txt
+++ b/erun-integration/testdata/deploy/components_includes_backend_in_deploy_order.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --components [erun-backend-api,erun-backend-db,erun-backend-postgres] --dry-run --version <VERSION> team dev
-deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[erun-backend-api erun-backend-db erun-backend-postgres] force=false
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[erun-backend-api erun-backend-db erun-backend-postgres] force=false publish=false
 deploy: resolved 4 spec(s)
 kubectl --context test-context get namespace team-dev -o name
 kubectl --context test-context create namespace team-dev

--- a/erun-integration/testdata/deploy/components_rejects_unknown_name.txt
+++ b/erun-integration/testdata/deploy/components_rejects_unknown_name.txt
@@ -1,4 +1,4 @@
 audit: erun deploy --components [bogus] --dry-run --version <VERSION> team dev
-deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[bogus] force=false
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[bogus] force=false publish=false
 deploy: spec resolution failed: unknown deploy component "bogus"; valid opt-in components are: erun-backend-postgres, erun-backend-db, erun-backend-api
 unknown deploy component "bogus"; valid opt-in components are: erun-backend-postgres, erun-backend-db, erun-backend-api

--- a/erun-integration/testdata/deploy/default_skips_optin_backend_charts.txt
+++ b/erun-integration/testdata/deploy/default_skips_optin_backend_charts.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --dry-run --version <VERSION> team dev
-deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=false
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=false publish=false
 deploy: resolved 1 spec(s)
 kubectl --context test-context get namespace team-dev -o name
 kubectl --context test-context create namespace team-dev

--- a/erun-integration/testdata/deploy/dry_run_explicit_version_uses_project_registry_not_provenance.txt
+++ b/erun-integration/testdata/deploy/dry_run_explicit_version_uses_project_registry_not_provenance.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --dry-run --no-snapshot --version <VERSION> team dev
-deploy: tenant=team environment=dev version-override=<VERSION> snapshot=false components=[] force=false
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=false components=[] force=false publish=false
 deploy: resolved 1 spec(s)
 kubectl --context test-context get namespace team-dev -o name
 kubectl --context test-context create namespace team-dev

--- a/erun-integration/testdata/deploy/dry_run_from_devops_cwd.txt
+++ b/erun-integration/testdata/deploy/dry_run_from_devops_cwd.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --dry-run --version <VERSION> team dev
-deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=false
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=false publish=false
 deploy: resolved 1 spec(s)
 kubectl --context test-context get namespace team-dev -o name
 kubectl --context test-context create namespace team-dev

--- a/erun-integration/testdata/deploy/dry_run_outside_devops_with_tenant_env.txt
+++ b/erun-integration/testdata/deploy/dry_run_outside_devops_with_tenant_env.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --dry-run --version <VERSION> team dev
-deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=false
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=false publish=false
 deploy: resolved 1 spec(s)
 kubectl --context test-context get namespace team-dev -o name
 kubectl --context test-context create namespace team-dev

--- a/erun-integration/testdata/deploy/dry_run_persisted_version_reopen_uses_runtime_registry_provenance.txt
+++ b/erun-integration/testdata/deploy/dry_run_persisted_version_reopen_uses_runtime_registry_provenance.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --dry-run --no-snapshot team dev
-deploy: tenant=team environment=dev version-override= snapshot=false components=[] force=false
+deploy: tenant=team environment=dev version-override= snapshot=false components=[] force=false publish=false
 deploy: resolved 1 spec(s)
 kubectl --context test-context get namespace team-dev -o name
 kubectl --context test-context create namespace team-dev

--- a/erun-integration/testdata/deploy/dry_run_persisted_version_without_provenance_uses_project_registry.txt
+++ b/erun-integration/testdata/deploy/dry_run_persisted_version_without_provenance_uses_project_registry.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --dry-run --no-snapshot team dev
-deploy: tenant=team environment=dev version-override= snapshot=false components=[] force=false
+deploy: tenant=team environment=dev version-override= snapshot=false components=[] force=false publish=false
 deploy: resolved 1 spec(s)
 kubectl --context test-context get namespace team-dev -o name
 kubectl --context test-context create namespace team-dev

--- a/erun-integration/testdata/deploy/dry_run_remote_env_uses_embedded_chart.txt
+++ b/erun-integration/testdata/deploy/dry_run_remote_env_uses_embedded_chart.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --dry-run --version <VERSION> team dev
-deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=false
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=false publish=false
 deploy: resolved 1 spec(s)
 kubectl --context test-context get namespace team-dev -o name
 kubectl --context test-context create namespace team-dev

--- a/erun-integration/testdata/deploy/dry_run_with_aws_claude_models_traces_set_strings.txt
+++ b/erun-integration/testdata/deploy/dry_run_with_aws_claude_models_traces_set_strings.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --dry-run --no-snapshot --version <VERSION> managed prod
-deploy: tenant=managed environment=prod version-override=<VERSION> snapshot=false components=[] force=false
+deploy: tenant=managed environment=prod version-override=<VERSION> snapshot=false components=[] force=false publish=false
 deploy: resolved 1 spec(s)
 aws ec2 describe-instances --filters 'Name=instance-id,Values=i-0123456789abcdef0' --query 'Reservations[*].Instances[*].[InstanceId,State.Name]' --output text --region us-east-1 --profile dev
 kubectl --context edge get namespace managed-prod -o name

--- a/erun-integration/testdata/deploy/dry_run_with_managed_cloud_traces_helm_set_strings.txt
+++ b/erun-integration/testdata/deploy/dry_run_with_managed_cloud_traces_helm_set_strings.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --dry-run --no-snapshot --version <VERSION> managed prod
-deploy: tenant=managed environment=prod version-override=<VERSION> snapshot=false components=[] force=false
+deploy: tenant=managed environment=prod version-override=<VERSION> snapshot=false components=[] force=false publish=false
 deploy: resolved 1 spec(s)
 aws ec2 describe-instances --filters 'Name=instance-id,Values=i-0123456789abcdef0' --query 'Reservations[*].Instances[*].[InstanceId,State.Name]' --output text --region us-east-1 --profile dev
 kubectl --context edge get namespace managed-prod -o name

--- a/erun-integration/testdata/deploy/force_flag_appears_in_trace.txt
+++ b/erun-integration/testdata/deploy/force_flag_appears_in_trace.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --dry-run --force --version <VERSION> team dev
-deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=true
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=true publish=false
 deploy: resolved 1 spec(s)
 kubectl --context test-context get namespace team-dev -o name
 kubectl --context test-context create namespace team-dev

--- a/erun-integration/testdata/deploy/help_outside_devops_cwd.txt
+++ b/erun-integration/testdata/deploy/help_outside_devops_cwd.txt
@@ -10,6 +10,7 @@ Flags:
       --force                Bypass the fingerprint cache and re-run helm upgrade even when no source change is detected
   -h, --help                 help for deploy
       --no-snapshot          Alias for --snapshot=false
+      --publish              Package and push each resolved chart to the environment's container registry (oci://<containerRegistry>/<chart>:<version>) before helm upgrade
       --snapshot             Build and deploy local snapshot images in the local environment (default true)
       --tenant string        Deploy for a specific tenant
       --version string       Override the deployed chart and image version

--- a/erun-integration/testdata/deploy/project_k8s_plan_groups_parallel_step.txt
+++ b/erun-integration/testdata/deploy/project_k8s_plan_groups_parallel_step.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --components [erun-backend-postgres,erun-backend-db,erun-backend-api] --dry-run --version <VERSION> team dev
-deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[erun-backend-postgres erun-backend-db erun-backend-api] force=false
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[erun-backend-postgres erun-backend-db erun-backend-api] force=false publish=false
 deploy: resolved 4 spec(s)
 deploy: step 1 (parallel): team-devops, erun-backend-postgres
 kubectl --context test-context get namespace team-dev -o name

--- a/erun-integration/testdata/deploy/project_k8s_plan_includes_listed_charts_without_components_flag.txt
+++ b/erun-integration/testdata/deploy/project_k8s_plan_includes_listed_charts_without_components_flag.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --dry-run --version <VERSION> team dev
-deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=false
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=false publish=false
 deploy: resolved 4 spec(s)
 deploy: step 1 (parallel): team-devops, erun-backend-postgres
 kubectl --context test-context get namespace team-dev -o name

--- a/erun-integration/testdata/deploy/project_k8s_plan_rejects_invalid_step_node.txt
+++ b/erun-integration/testdata/deploy/project_k8s_plan_rejects_invalid_step_node.txt
@@ -1,4 +1,4 @@
 audit: erun deploy --dry-run --version <VERSION> team dev
-deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=false
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=false publish=false
 deploy: spec resolution failed: config file cannot be unmarshaled: k8s.deployments item must be a component name or a list of component names
 config file cannot be unmarshaled: k8s.deployments item must be a component name or a list of component names

--- a/erun-integration/testdata/deploy/publish_traces_helm_package_and_push_before_upgrade.txt
+++ b/erun-integration/testdata/deploy/publish_traces_helm_package_and_push_before_upgrade.txt
@@ -1,0 +1,11 @@
+audit: erun deploy --dry-run --publish --version <VERSION> team dev
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=false publish=true
+deploy: resolved 1 spec(s)
+cd <TMP> && helm package team-devops --version <VERSION> --app-version <VERSION>
+cd <TMP> && helm push team-devops-<VERSION>.tgz oci://registry.example/test
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set-string api.oidcAllowedIssuers= --set api.postgres.reset=true --set-string containerRegistry=registry.example/test --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)

--- a/erun-integration/testdata/deploy/publish_without_container_registry_errors.txt
+++ b/erun-integration/testdata/deploy/publish_without_container_registry_errors.txt
@@ -1,0 +1,4 @@
+audit: erun deploy --dry-run --publish --version <VERSION> team dev
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=true components=[] force=false publish=true
+deploy: spec resolution failed: publish team-devops: container registry is required (configure containerregistry in .erun/config.yaml)
+publish team-devops: container registry is required (configure containerregistry in .erun/config.yaml)

--- a/erun-integration/testdata/deploy/real_run_helm_pending_recovery_via_auto_recover_env.txt
+++ b/erun-integration/testdata/deploy/real_run_helm_pending_recovery_via_auto_recover_env.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --no-snapshot --version <VERSION> team dev
-deploy: tenant=team environment=dev version-override=<VERSION> snapshot=false components=[] force=false
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=false components=[] force=false publish=false
 deploy: resolved 1 spec(s)
 deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
 dedup: claim (release=test-context-team-dev-team-devops, hash=<HASH>, pid=<PID>)

--- a/erun-integration/testdata/deploy/real_run_via_stubs.txt
+++ b/erun-integration/testdata/deploy/real_run_via_stubs.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --no-snapshot --version <VERSION> team dev
-deploy: tenant=team environment=dev version-override=<VERSION> snapshot=false components=[] force=false
+deploy: tenant=team environment=dev version-override=<VERSION> snapshot=false components=[] force=false publish=false
 deploy: resolved 1 spec(s)
 deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
 dedup: claim (release=test-context-team-dev-team-devops, hash=<HASH>, pid=<PID>)

--- a/erun-integration/testdata/deploy/version_flag_recognized_outside_devops_cwd.txt
+++ b/erun-integration/testdata/deploy/version_flag_recognized_outside_devops_cwd.txt
@@ -1,4 +1,4 @@
 audit: erun deploy --dry-run --version <VERSION> missing missing
-deploy: tenant=missing environment=missing version-override=<VERSION> snapshot=true components=[] force=false
+deploy: tenant=missing environment=missing version-override=<VERSION> snapshot=true components=[] force=false publish=false
 deploy: spec resolution failed: no such tenant exists: missing
 no such tenant exists: missing

--- a/erun-integration/testdata/devops/k8s_deploy_help.txt
+++ b/erun-integration/testdata/devops/k8s_deploy_help.txt
@@ -9,6 +9,7 @@ Flags:
       --force                Bypass the fingerprint cache and re-run helm upgrade even when no source change is detected
   -h, --help                 help for deploy
       --no-snapshot          Alias for --snapshot=false
+      --publish              Package and push each resolved chart to the environment's container registry (oci://<containerRegistry>/<chart>:<version>) before helm upgrade
       --snapshot             Build and deploy local snapshot images in the local environment (default true)
       --tenant string        Deploy for a specific tenant
       --version string       Override the deployed chart and image version

--- a/erun-mcp/deploy.go
+++ b/erun-mcp/deploy.go
@@ -14,6 +14,7 @@ type DeployInput struct {
 	Version    string   `json:"version,omitempty" jsonschema:"optional explicit version override for the deployed chart"`
 	Snapshot   *bool    `json:"snapshot,omitempty" jsonschema:"optional local snapshot override; when false, skips local snapshot builds in the local environment"`
 	Force      bool     `json:"force,omitempty" jsonschema:"when true, bypass the fingerprint cache and re-run helm upgrade even when no source change is detected"`
+	Publish    bool     `json:"publish,omitempty" jsonschema:"when true, package and push each resolved chart to the environment's container registry as an OCI Helm artifact before helm upgrade"`
 	Preview    bool     `json:"preview,omitempty" jsonschema:"when true, resolve and print the planned actions without executing them"`
 	Verbosity  int      `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
 }
@@ -39,6 +40,7 @@ func deployTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReques
 				Snapshot:        input.Snapshot,
 				Components:      input.Components,
 				Force:           input.Force,
+				Publish:         input.Publish,
 			}
 
 			component := strings.TrimSpace(input.Component)


### PR DESCRIPTION
## Summary

- New `--publish` flag on `erun deploy` and `erun devops k8s deploy` (and on the MCP `deploy` tool's `Publish` input) that packages each resolved chart and pushes the tgz to `oci://<containerRegistry>/<chart-name>:<version>` before `helm upgrade`.
- A missing `containerregistry` fails resolution with a clear, actionable error rather than tracing a half-built push.
- Dry-run trace emits the real `helm package` and `helm push` argv per the audit contract; the trace line gains a `publish=<bool>` token.

## Test plan

- [x] `go test ./...` under `erun-integration/` — every deploy and devops scenario green.
- [x] New scenarios cover dry-run trace, real-run execution via stubs, and the missing-registry error.
- [x] Coverage on `erun-common/helm_chart_publish.go`: 75–100% per function; integration total 57.1% (gate 55%).
- [ ] `make integration-test` on a machine that can bind 127.0.0.1:17000 (the two `TestOpen/*_real_run_writes_*` IDE tests are red in the sandbox here for that reason and are red on `main` too — preexisting environmental flake, not part of this change).

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)