### PR TITLE
Widen UIEnvironmentConfig.type to string to match Wails binding

### DIFF
--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -1,8 +1,19 @@
 export type EnvironmentType = 'local-agent' | 'remote-agent' | 'runtime' | '';
 
+// EnvironmentTypeValues lists the dropdown options. The model type for the
+// `type` field below is widened to `string` because the Wails-generated
+// binding (frontend/wailsjs/go/models.ts) widens the Go EnvironmentType
+// alias to a bare `string` at the boundary — narrowing the field here would
+// fail the LoadEnvironmentConfig/SaveEnvironmentConfig assignability check.
+export const EnvironmentTypeValues: readonly EnvironmentType[] = [
+  'local-agent',
+  'remote-agent',
+  'runtime',
+] as const;
+
 export interface UIEnvironment {
   name: string;
-  type?: EnvironmentType;
+  type?: string;
   mcpUrl?: string;
   apiUrl?: string;
   runtimeVersion?: string;
@@ -278,7 +289,7 @@ export interface UIEnvironmentConfig {
   claude: UIEnvironmentClaudeConfig;
   claudeDefaults: UIEnvironmentClaudeDefaults;
   localPorts: UIEnvironmentLocalPorts;
-  type?: EnvironmentType;
+  type?: string;
   localRepoPath?: string;
   remote: boolean;
   snapshot: boolean;


### PR DESCRIPTION
## Summary

- \`yarn typecheck\` was failing after #376 because the hand-written \`UIEnvironmentConfig.type\` was narrowed to the \`EnvironmentType\` union, but the Wails-generated \`uiEnvironmentConfig\` widens the Go \`EnvironmentType\` alias to bare \`string\` at the binding boundary.
- Widen \`UIEnvironmentConfig.type\` (and \`UIEnvironment.type\`) to \`string\` so \`LoadEnvironmentConfig\` / \`SaveEnvironmentConfig\` return values pass the assignability check.
- Add \`EnvironmentTypeValues\` array for dropdown options / validation that needs the narrow union.

## Test plan

- [x] \`yarn typecheck\` green
- [ ] Manual: open env-edit modal in desktop and confirm Type field still renders

Closes #379