### PR TITLE
Titlebar: widen left padding so sidebar toggle clears the macOS traffic lights

### DIFF
--- a/erun-ui/frontend/src/components/app/Titlebar.Controls.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.Controls.tsx
@@ -37,7 +37,7 @@ export function TitlebarLeftControls(): React.ReactElement {
   const sidebarHidden = useAppSelector((state) => state.layout.sidebarHidden);
   const SidebarIcon = sidebarHidden ? PanelLeftOpen : PanelLeftClose;
   return (
-    <div className="relative z-[1] flex items-center gap-2 pl-[60px] [--wails-draggable:no-drag] max-[980px]:pl-[52px]">
+    <div className="relative z-[1] flex items-center gap-2 pl-[88px] [--wails-draggable:no-drag] max-[980px]:pl-[80px]">
       <IconTooltip label="Toggle sidebar">
         <Button
           className={titlebarButtonClassName}


### PR DESCRIPTION
## Summary

The titlebar sidebar-toggle button sits flush against the green traffic light on macOS. \`Titlebar.Controls.tsx\` reserves \`pl-[60px]\` (52px under 980px) but the traffic-light cluster spans ~78px from the left edge.

Bumped to \`pl-[88px]\` / \`pl-[80px]\` to give ~10px breathing room past the cluster.

## Test plan

- [x] \`yarn typecheck\` green
- [ ] Manual on macOS: sidebar toggle has visible gap to the right of the green traffic light, in both window widths

Closes #383