### PR TITLE
Surface kubectl stderr in 'No contexts' dialog; add Rescan button

### DIFF
--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -1,6 +1,7 @@
 import { FolderPlus, LoaderCircle, Rocket } from 'lucide-react';
 import * as React from 'react';
 
+import { refreshKubernetesContexts } from '@/app/dialogContextsThunks';
 import {
   closeEnvironmentDialog,
   selectEnvironmentVersionSuggestion,
@@ -276,12 +277,27 @@ function KubernetesContextSelect({ dialog }: { dialog: EnvironmentDialog }): Rea
     ? 'Loading contexts...'
     : 'Select Kubernetes context';
   if (!dialog.kubernetesContextsLoading && dialog.kubernetesContexts.length === 0) {
+    const body =
+      "ERun runs `kubectl config get-contexts` using the PATH and KUBECONFIG it inherits from your login shell at startup. If your terminal sees contexts that don't appear here, set KUBECONFIG in ~/.zshenv (or ~/.bash_profile) so it applies to GUI launches too, then restart ERun. If kubectl is not yet installed, install it with `brew install kubectl`.";
+    const errorDetail = dialog.error?.trim() ?? '';
     return (
       <div className="grid gap-2">
         <Label htmlFor="environment-kubernetes-context">Kubernetes context</Label>
         <EmptyState
           heading="No Kubernetes contexts found"
-          body="ERun runs `kubectl config get-contexts` using the PATH and KUBECONFIG it inherits from your login shell at startup. If your terminal sees contexts that don't appear here, set KUBECONFIG in ~/.zshenv (or ~/.bash_profile) so it applies to GUI launches too, then restart ERun. If kubectl is not yet installed, install it with `brew install kubectl`."
+          body={errorDetail !== '' ? `${body}\n\nLast error from kubectl:\n${errorDetail}` : body}
+          action={
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                void dispatch(refreshKubernetesContexts());
+              }}
+            >
+              Rescan
+            </Button>
+          }
         />
       </div>
     );

--- a/erun-ui/state_handlers.go
+++ b/erun-ui/state_handlers.go
@@ -167,7 +167,7 @@ func buildDetailsFrom(info eruncommon.BuildInfo) uiBuildDetails {
 func listKubernetesContexts() ([]string, error) {
 	output, err := exec.Command("kubectl", "config", "get-contexts", "-o=name").Output()
 	if err != nil {
-		return nil, err
+		return nil, wrapKubectlError(err)
 	}
 	contexts := strings.Split(string(output), "\n")
 
@@ -177,6 +177,21 @@ func listKubernetesContexts() ([]string, error) {
 	}
 
 	return contexts, nil
+}
+
+// wrapKubectlError returns an error whose message includes kubectl's stderr
+// (when available) so the dialog can show the actual reason for the
+// failure — e.g. "stat /Users/x/.kube/config: no such file or directory"
+// or "executable file not found in $PATH" — instead of the bare exit-code
+// message that exec.Cmd.Output() yields by default.
+func wrapKubectlError(err error) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if stderr := strings.TrimSpace(string(exitErr.Stderr)); stderr != "" {
+			return fmt.Errorf("%w: %s", err, stderr)
+		}
+	}
+	return err
 }
 
 func normalizeKubernetesContexts(contexts []string) []string {


### PR DESCRIPTION
## Summary

The New Environment dialog shows generic guidance when \`kubectl config get-contexts\` returns nothing, with no signal as to whether the failure is missing PATH, bad \`KUBECONFIG\`, an empty kubeconfig, an auth problem, or something else.

- \`listKubernetesContexts()\` now wraps \`*exec.ExitError\` to include the trimmed stderr — so \"executable file not found in \$PATH\", \"error: stat /Users/x/.kube/config: no such file\", etc. flow up to the dialog.
- The empty state appends the captured error under the existing guidance copy.
- Added a \`Rescan\` action button so the user can retry without closing and reopening the dialog (useful after editing \`~/.zshenv\` or installing kubectl).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`yarn typecheck\` clean
- [ ] Manual: unset PATH so kubectl isn't found → empty state shows \"exec: ... executable file not found...\"
- [ ] Manual: set KUBECONFIG=/nonexistent → empty state shows kubectl's stat error
- [ ] Manual: Rescan picks up newly-installed kubectl without dialog reload

Closes #385