### PR TITLE
Env-init dialog: lint, dropdown wipe, derived bootstrap, env-type selector + repo conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ Repository guidance for humans and coding agents working in this repo.
 - If the user asks for `push, accept`, treat that as completing the full publish flow rather than stopping after the branch push.
 - If the user asks to `close`, always treat that as the repository publish flow in this repo: push the branch, open the PR, merge it with squash unless they asked otherwise, close the PR via merge, and close the linked issue.
 - Do not interpret `close` as a request to end or archive the conversation in this repository.
+- Stay within the current PR for the whole body of related work. When additional bugs, gaps, or improvements surface while working on a branch, add them to the same PR rather than filing a separate issue or opening a new branch. Do not propose splitting work into multiple PRs, and do not ask whether to split — assume the answer is "no" unless the user explicitly says otherwise. Update the PR title and body to reflect the broader scope when the diff grows.
+- One body of work, one PR. The PR may link to multiple issues (`Closes #A` / `Closes #B`), but the unit of review is the PR, not the issue.
 
 ## Project Structure
 
@@ -165,6 +167,8 @@ Repository guidance for humans and coding agents working in this repo.
 - Do not add new documentation files unless the user explicitly asks for them; add repository instructions to `AGENTS.md` instead.
 - Keep `AGENTS.md` focused on repository workflow and engineering guidance; do not document app behavior, command semantics, or end-user functionality in it.
 - Do not modify `README.md` unless the user explicitly asks for a README change.
+- **"Documentation" in agent-facing instructions means `AGENTS.md`** (this file plus every applicable subtree `AGENTS.md`). When the user says "read documentation", re-read the relevant `AGENTS.md` files end-to-end; do not substitute `erun-docs/` for that step. When the user says "update documentation", edit the nearest applicable `AGENTS.md`. `erun-docs/` is the public product documentation site — a separate concern with its own update workflow, owned by the `erun-docs/AGENTS.md` rules. Read it only when its content is the load-bearing reference for an investigation; do not treat it as the source of repo workflow or engineering guidance.
+- Each `AGENTS.md` directory ships a `CLAUDE.md` symlink pointing to its `AGENTS.md` so Claude Code auto-loads the local guidance when launched from any subtree. Treat both names as the same file; only edit `AGENTS.md` directly.
 
 ## Diagnosing A Deployed Runtime Via MCP
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-backend/CLAUDE.md
+++ b/erun-backend/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-backend/erun-backend-api/CLAUDE.md
+++ b/erun-backend/erun-backend-api/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-backend/erun-backend-db/CLAUDE.md
+++ b/erun-backend/erun-backend-db/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-devops/CLAUDE.md
+++ b/erun-devops/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-docs/CLAUDE.md
+++ b/erun-docs/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-docs/docs/concepts/environment-types.md
+++ b/erun-docs/docs/concepts/environment-types.md
@@ -101,3 +101,5 @@ erun init team prod --type runtime --no-git
 ```
 
 `--remote` is preserved as a deprecated alias for `--type=remote-agent`; passing both flags with conflicting values is an error.
+
+The desktop app's **New environment** dialog exposes the same choice as an **Environment type** field. Picking `Local agent` also reveals a **Local repo path** input (with a native folder picker) — that's the host directory mounted into the agent pod as the worktree, equivalent to the CLI's `--project-root`.

--- a/erun-integration/CLAUDE.md
+++ b/erun-integration/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-ui/CLAUDE.md
+++ b/erun-ui/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -587,7 +587,7 @@ func TestBuildOpenNoShellArgsTrimsTenantAndEnvironment(t *testing.T) {
 
 func TestBuildInitArgsTrimsTenantAndEnvironment(t *testing.T) {
 	got := buildInitArgs(uiSelection{Tenant: " erun ", Environment: " remote "})
-	want := []string{"init", "erun", "remote", "--remote", "--set-default-tenant=false", "--confirm-environment=true"}
+	want := []string{"init", "erun", "remote", "--type=remote-agent", "--set-default-tenant=false", "--confirm-environment=true"}
 	if len(got) != len(want) {
 		t.Fatalf("unexpected args length: got %+v want %+v", got, want)
 	}
@@ -612,7 +612,43 @@ func TestBuildInitArgsIncludesRuntimeVersion(t *testing.T) {
 		Bootstrap:         true,
 		SetDefaultTenant:  true,
 	})
-	want := []string{"init", "erun", "remote", "--remote", "--version", "1.0.19", "--runtime-image", "erun-devops", "--runtime-cpu", "6", "--runtime-memory", "12Gi", "--kubernetes-context", "orbstack", "--container-registry", "erunpaas", "--set-default-tenant=true", "--confirm-environment=true", "--no-git", "--bootstrap"}
+	want := []string{"init", "erun", "remote", "--type=remote-agent", "--version", "1.0.19", "--runtime-image", "erun-devops", "--runtime-cpu", "6", "--runtime-memory", "12Gi", "--kubernetes-context", "orbstack", "--container-registry", "erunpaas", "--set-default-tenant=true", "--confirm-environment=true", "--no-git", "--bootstrap"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected args length: got %+v want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected arg[%d]: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBuildInitArgsRespectsExplicitType(t *testing.T) {
+	got := buildInitArgs(uiSelection{
+		Tenant:        "erun",
+		Environment:   "local",
+		Type:          "local-agent",
+		LocalRepoPath: "/Users/me/code/project",
+	})
+	want := []string{"init", "erun", "local", "--type=local-agent", "--project-root", "/Users/me/code/project", "--set-default-tenant=false", "--confirm-environment=true"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected args length: got %+v want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected arg[%d]: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBuildInitArgsRuntimeTypeOmitsProjectRoot(t *testing.T) {
+	got := buildInitArgs(uiSelection{
+		Tenant:        "erun",
+		Environment:   "prod",
+		Type:          "runtime",
+		LocalRepoPath: "/should/be/ignored",
+	})
+	want := []string{"init", "erun", "prod", "--type=runtime", "--set-default-tenant=false", "--confirm-environment=true"}
 	if len(got) != len(want) {
 		t.Fatalf("unexpected args length: got %+v want %+v", got, want)
 	}
@@ -745,7 +781,7 @@ func TestStartInitSessionPipesCommandToLocal(t *testing.T) {
 		t.Fatalf("expected 1 spawned session (Local), got %d", len(sessions))
 	}
 	written := sessions[0].WrittenString()
-	wantSubstr := "/tmp/erun init erun remote --remote --version 1.0.19 --kubernetes-context orbstack --container-registry erunpaas --set-default-tenant=true --confirm-environment=true --no-git\n"
+	wantSubstr := "/tmp/erun init erun remote --type=remote-agent --version 1.0.19 --kubernetes-context orbstack --container-registry erunpaas --set-default-tenant=true --confirm-environment=true --no-git\n"
 	if !strings.Contains(written, wantSubstr) {
 		t.Fatalf("expected Local pty to receive %q, got %q", wantSubstr, written)
 	}
@@ -828,10 +864,10 @@ func TestStartInitSessionReusesLocalAcrossInvocations(t *testing.T) {
 		t.Fatalf("expected Local to be reused (1 spawn), got %d", startCalls)
 	}
 	written := lastSession.WrittenString()
-	if !strings.Contains(written, "init erun remote --remote --version 1.0.18") {
+	if !strings.Contains(written, "init erun remote --type=remote-agent --version 1.0.18") {
 		t.Fatalf("expected first init command in Local, got %q", written)
 	}
-	if !strings.Contains(written, "init erun remote --remote --version 1.0.19") {
+	if !strings.Contains(written, "init erun remote --type=remote-agent --version 1.0.19") {
 		t.Fatalf("expected second init command in Local, got %q", written)
 	}
 }

--- a/erun-ui/environment_config.go
+++ b/erun-ui/environment_config.go
@@ -139,6 +139,30 @@ func resolveWorkspaceSyncDialogDefaultDirectory(findProjectRoot eruncommon.Proje
 	return strings.TrimSpace(projectRoot)
 }
 
+// ChooseLocalRepoPath opens a native directory picker for the env-init
+// dialog's "Local repo path" field. local-agent envs mount this path into
+// the agent pod as the worktree, so the user has to pick a real directory
+// on this machine — typing absolute paths by hand is error-prone. Returns
+// the empty string if the user cancels the dialog.
+func (a *App) ChooseLocalRepoPath(current string) (string, error) {
+	if a.ctx == nil {
+		return "", fmt.Errorf("application context is not ready")
+	}
+	defaultDirectory := strings.TrimSpace(current)
+	if defaultDirectory != "" {
+		if info, err := os.Stat(defaultDirectory); err != nil || !info.IsDir() {
+			defaultDirectory = ""
+		}
+	}
+	if defaultDirectory == "" {
+		defaultDirectory = resolveWorkspaceSyncDialogDefaultDirectory(a.deps.findProjectRoot)
+	}
+	return runtime.OpenDirectoryDialog(a.ctx, runtime.OpenDialogOptions{
+		Title:            "Select local repo path",
+		DefaultDirectory: defaultDirectory,
+	})
+}
+
 func (a *App) updatedEnvironmentConfig(config uiEnvironmentConfig, existing eruncommon.EnvConfig) (eruncommon.EnvConfig, error) {
 	updated := environmentConfigFromUI(config, existing)
 	if _, err := updated.Idle.Resolve(); err != nil {

--- a/erun-ui/frontend/src/app/api/environmentApi.ts
+++ b/erun-ui/frontend/src/app/api/environmentApi.ts
@@ -6,6 +6,7 @@ import type {
 } from '@/types';
 
 import {
+  ChooseLocalRepoPath,
   ChooseWorkspaceSyncLocalFolder,
   DeleteEnvironment,
   LoadEnvironmentConfig,
@@ -67,6 +68,9 @@ export const environmentApi = wailsApi.injectEndpoints({
         ChooseWorkspaceSyncLocalFolder(selection, current),
       ),
     }),
+    chooseLocalRepoPath: builder.mutation<string, string>({
+      queryFn: wailsQueryFn<string, string>((current) => ChooseLocalRepoPath(current)),
+    }),
     getVersionSuggestions: builder.query<UIVersionSuggestion[], UISelection>({
       queryFn: wailsQueryFn<UISelection, UIVersionSuggestion[]>((selection) =>
         LoadVersionSuggestions(selection),
@@ -88,6 +92,7 @@ export const {
   useSaveEnvironmentConfigMutation,
   useDeleteEnvironmentMutation,
   useChooseWorkspaceSyncLocalFolderMutation,
+  useChooseLocalRepoPathMutation,
   useGetVersionSuggestionsQuery,
   useLazyGetVersionSuggestionsQuery,
   useGetRuntimeResourceStatusQuery,

--- a/erun-ui/frontend/src/app/bootThunks.ts
+++ b/erun-ui/frontend/src/app/bootThunks.ts
@@ -1,5 +1,4 @@
 import { stateApi } from './api/stateApi';
-import { selectLoadedKubernetesContexts } from './dialogContextsThunks';
 import { readError } from './errors';
 import { showTerminalMessage } from './notificationThunks';
 import { openSelection } from './sessionThunks';
@@ -9,9 +8,11 @@ import type { AppThunk } from './store';
 import { normalizeVersionSuggestions } from './versionSuggestions';
 
 // boot loads initial app state from the backend, hydrates the tenants /
-// cloud-providers / version-suggestions / k8s-contexts slices, and either
-// re-opens the previously-selected env or surfaces a "choose an env"
-// hint. Controller mount dispatches it once per app instance.
+// cloud-providers / version-suggestions slices, and either re-opens the
+// previously-selected env or surfaces a "choose an env" hint. Controller
+// mount dispatches it once per app instance. The env-init dialog manages
+// its own kubectl context list (openInitializeDialog →
+// refreshKubernetesContexts); boot does not seed it.
 export const boot = (): AppThunk<Promise<void>> => async (dispatch, getState) => {
   try {
     dispatch(showTerminalMessage('Loading environments...', true));
@@ -22,7 +23,6 @@ export const boot = (): AppThunk<Promise<void>> => async (dispatch, getState) =>
     dispatch(setCloudProviders(loaded.cloudProviders ?? []));
     dispatch(setSelected(loaded.selected ?? null));
     dispatch(setVersionSuggestions(normalizeVersionSuggestions(loaded.versionSuggestions ?? [])));
-    await dispatch(selectLoadedKubernetesContexts(loaded.kubernetesContexts ?? []));
     if (loaded.message !== undefined && loaded.message !== '') {
       dispatch(showTerminalMessage(loaded.message));
       return;
@@ -44,7 +44,10 @@ export const boot = (): AppThunk<Promise<void>> => async (dispatch, getState) =>
 // signals an env was created/removed (config watcher, environment-init
 // completion). Preserves the user's existing tenants / cloudProviders /
 // versionSuggestions if the new payload omits them, since this is a delta
-// refresh — boot() is the authoritative initial load.
+// refresh — boot() is the authoritative initial load. Does NOT touch the
+// env-init dialog's kubernetes-context list: a stale environments-changed
+// tick used to wipe a populated dropdown because uiState never carried
+// contexts to seed from.
 export const reloadStateAfterEnvironmentChange =
   (): AppThunk<Promise<void>> => async (dispatch, getState) => {
     try {
@@ -59,7 +62,6 @@ export const reloadStateAfterEnvironmentChange =
           normalizeVersionSuggestions(loaded.versionSuggestions ?? current.versionSuggestions),
         ),
       );
-      await dispatch(selectLoadedKubernetesContexts(loaded.kubernetesContexts ?? []));
     } catch {
       // Silent failure: env-change reloads are best-effort.
     }

--- a/erun-ui/frontend/src/app/dialogContextsThunks.ts
+++ b/erun-ui/frontend/src/app/dialogContextsThunks.ts
@@ -9,14 +9,13 @@ import { normalizeDialogValue } from './versionSuggestions';
 // dialogContextsThunks own the env-init dialog's "available kubernetes
 // contexts" + "selected context runtime resources" flows. The user-driven
 // refresh (kubernetesContext field changes) lives in
-// environmentDialogThunks; this module covers boot/env-change-triggered
-// refresh and the user-triggered "rescan k8s contexts" button.
+// environmentDialogThunks; this module covers dialog-open seeding and the
+// user-triggered "rescan k8s contexts" button.
 
 // refreshDialogRuntimeResources hits the runtime-resources endpoint for
 // the dialog's currently-selected k8s context and patches the dialog with
 // the resulting CPU/memory totals. Internal helper; not exported because
-// callers should drive it via refreshKubernetesContexts or
-// selectLoadedKubernetesContexts.
+// callers should drive it via refreshKubernetesContexts.
 const refreshDialogRuntimeResources =
   (kubernetesContext: string): AppThunk<Promise<void>> =>
   async (dispatch, getState) => {
@@ -71,36 +70,20 @@ const refreshDialogRuntimeResources =
     }
   };
 
-// selectLoadedKubernetesContexts seeds the dialog from a freshly-loaded
-// initial-state response. boot() and reloadStateAfterEnvironmentChange()
-// dispatch this after the contexts are returned from the backend.
-export const selectLoadedKubernetesContexts =
-  (contexts: string[]): AppThunk<Promise<void>> =>
-  async (dispatch, getState) => {
-    const dialog = getState().environmentDialog;
-    if (!dialog.open || dialog.actionMode !== 'init') {
-      return;
-    }
-    const normalized = contexts.map((context) => context.trim()).filter(Boolean);
-    const resolved = selectDialogKubernetesContext(getState(), normalized);
-    dispatch(
-      patchEnvironmentDialog({
-        kubernetesContexts: normalized,
-        kubernetesContext: resolved,
-        kubernetesContextsLoading: false,
-      }),
-    );
-    await dispatch(refreshDialogRuntimeResources(resolved));
-  };
-
 // refreshKubernetesContexts re-scans kubeconfig for available contexts and
 // patches the dialog. Triggered by the "rescan k8s contexts" button and
 // after cloud-context power changes that may have rewritten kubeconfig.
+// forceRefetch is required: without it RTK Query returns the cached
+// result of the previous LoadKubernetesContexts call, so a transient
+// empty result (or simply a need to re-scan after a kubeconfig edit) gets
+// pinned to the dialog and Rescan can never recover.
 export const refreshKubernetesContexts =
   (): AppThunk<Promise<void>> => async (dispatch, getState) => {
     try {
       const result = await dispatch(
-        kubernetesApi.endpoints.getKubernetesContexts.initiate(),
+        kubernetesApi.endpoints.getKubernetesContexts.initiate(undefined, {
+          forceRefetch: true,
+        }),
       ).unwrap();
       const contexts = result.map((context) => context.trim()).filter(Boolean);
       const dialog = getState().environmentDialog;

--- a/erun-ui/frontend/src/app/environmentDialogState.ts
+++ b/erun-ui/frontend/src/app/environmentDialogState.ts
@@ -18,6 +18,8 @@ export function normalizedEnvironmentDialogValues(
     version: normalizeDialogValue(dialog.version),
     kubernetesContext: normalizeDialogValue(dialog.kubernetesContext),
     containerRegistry: normalizeDialogValue(dialog.containerRegistry),
+    envType: dialog.envType,
+    localRepoPath: normalizeDialogValue(dialog.localRepoPath),
   };
 }
 
@@ -30,6 +32,11 @@ export function validEnvironmentDialogValues(
   }
   if (actionMode === 'deploy') {
     return Boolean(values.version);
+  }
+  // local-agent envs mount a host directory into the agent pod; the path
+  // is required and free-text (the user picks where their project lives).
+  if (values.envType === 'local-agent' && !values.localRepoPath) {
+    return false;
   }
   return Boolean(values.kubernetesContext && values.containerRegistry);
 }

--- a/erun-ui/frontend/src/app/environmentDialogThunks.ts
+++ b/erun-ui/frontend/src/app/environmentDialogThunks.ts
@@ -51,7 +51,6 @@ export const openInitializeDialog = (): AppThunk => (dispatch, getState) => {
       runtimePod: defaultEnvironmentDialog().runtimePod,
       containerRegistry: containerRegistryDefault,
       noGit: false,
-      bootstrap: false,
       setDefaultTenant: true,
       versionImage: state.tenants.versionSuggestions[0]?.image ?? '',
       choicesOpen: false,
@@ -136,7 +135,14 @@ export const submitEnvironmentDialog =
     if (dialog.busy) {
       return;
     }
-    const selection = environmentDialogSelection(dialog, state.tenants.versionSuggestions);
+    const tenantExists = state.tenants.tenants.some(
+      (tenant) => tenant.name === dialog.tenant.trim(),
+    );
+    const selection = environmentDialogSelection(
+      dialog,
+      state.tenants.versionSuggestions,
+      tenantExists,
+    );
     if (!selection) {
       dispatch(patchEnvironmentDialog({ error: '' }));
       form.reportValidity();
@@ -178,6 +184,7 @@ export const submitEnvironmentDialog =
 function environmentDialogSelection(
   dialog: EnvironmentDialogState,
   versionSuggestions: UIVersionSuggestion[],
+  tenantExists: boolean,
 ): UISelection | null {
   const values = normalizedEnvironmentDialogValues(dialog);
   if (!validEnvironmentDialogValues(values, dialog.actionMode)) {
@@ -195,7 +202,14 @@ function environmentDialogSelection(
     kubernetesContext: isInit ? values.kubernetesContext : undefined,
     containerRegistry: isInit ? values.containerRegistry : undefined,
     noGit: dialog.noGit,
-    bootstrap: isInit ? dialog.bootstrap : undefined,
+    // Bootstrap is derived, not asked. The desktop init flow always
+    // passes --remote (see erun-ui/session.go:buildInitArgs), so we're
+    // always on the remote-worktree path where --bootstrap matters. For
+    // a brand-new tenant (no envs in state.tenants) the remote devops
+    // module doesn't exist yet and the first deploy has nothing to
+    // render without it; for an existing tenant the module is already
+    // there and --bootstrap would be wasted SSH work.
+    bootstrap: isInit ? !tenantExists : undefined,
     setDefaultTenant: isInit ? dialog.setDefaultTenant : undefined,
   };
 }

--- a/erun-ui/frontend/src/app/environmentDialogThunks.ts
+++ b/erun-ui/frontend/src/app/environmentDialogThunks.ts
@@ -50,6 +50,8 @@ export const openInitializeDialog = (): AppThunk => (dispatch, getState) => {
       resourceStatusLoading: false,
       runtimePod: defaultEnvironmentDialog().runtimePod,
       containerRegistry: containerRegistryDefault,
+      envType: 'remote-agent',
+      localRepoPath: '',
       noGit: false,
       setDefaultTenant: true,
       versionImage: state.tenants.versionSuggestions[0]?.image ?? '',
@@ -191,26 +193,47 @@ function environmentDialogSelection(
     return null;
   }
   const isInit = dialog.actionMode === 'init';
-  const runtimePod = runtimePodConfigToKubernetes(dialog.runtimePod);
+  const initFields = isInit ? environmentDialogInitFields(dialog, values, tenantExists) : {};
+  // noGit only changes behavior on the remote-worktree init path
+  // (ensureRemoteRepository in erun-common/init.go). For local-agent
+  // init there is no remote repo, so suppress NoGit regardless of any
+  // stale dialog state from a previous type selection.
+  const noGit = isInit && dialog.envType === 'local-agent' ? false : dialog.noGit;
   return {
     tenant: values.tenant,
     environment: values.environment,
     version: values.version,
     runtimeImage: resolveEnvironmentRuntimeImage(values.version, dialog, versionSuggestions),
-    runtimeCpu: isInit ? runtimePod.cpu : undefined,
-    runtimeMemory: isInit ? runtimePod.memory : undefined,
-    kubernetesContext: isInit ? values.kubernetesContext : undefined,
-    containerRegistry: isInit ? values.containerRegistry : undefined,
-    noGit: dialog.noGit,
-    // Bootstrap is derived, not asked. The desktop init flow always
-    // passes --remote (see erun-ui/session.go:buildInitArgs), so we're
-    // always on the remote-worktree path where --bootstrap matters. For
-    // a brand-new tenant (no envs in state.tenants) the remote devops
-    // module doesn't exist yet and the first deploy has nothing to
-    // render without it; for an existing tenant the module is already
-    // there and --bootstrap would be wasted SSH work.
-    bootstrap: isInit ? !tenantExists : undefined,
-    setDefaultTenant: isInit ? dialog.setDefaultTenant : undefined,
+    noGit,
+    ...initFields,
+  };
+}
+
+function environmentDialogInitFields(
+  dialog: EnvironmentDialogState,
+  values: ReturnType<typeof normalizedEnvironmentDialogValues>,
+  tenantExists: boolean,
+): Partial<UISelection> {
+  const runtimePod = runtimePodConfigToKubernetes(dialog.runtimePod);
+  const isLocalAgent = dialog.envType === 'local-agent';
+  return {
+    runtimeCpu: runtimePod.cpu,
+    runtimeMemory: runtimePod.memory,
+    kubernetesContext: values.kubernetesContext,
+    containerRegistry: values.containerRegistry,
+    type: dialog.envType,
+    localRepoPath: isLocalAgent ? values.localRepoPath : undefined,
+    // Bootstrap is derived from env type and tenant state, not a user
+    // choice. local-agent never passes --bootstrap because the local
+    // code path (EnsureDefaultDevopsModuleWithVersion in
+    // erun-common/init.go) creates the devops module unconditionally
+    // and idempotently. For remote-agent / runtime we pass --bootstrap
+    // only when the tenant is new — no envs yet in state — so the
+    // first init scaffolds the remote devops module; for an existing
+    // tenant the module is already there and re-running the bootstrap
+    // step would be wasted SSH work.
+    bootstrap: !isLocalAgent && !tenantExists,
+    setDefaultTenant: dialog.setDefaultTenant,
   };
 }
 

--- a/erun-ui/frontend/src/app/model/normalizedEnvironmentDialogValues.ts
+++ b/erun-ui/frontend/src/app/model/normalizedEnvironmentDialogValues.ts
@@ -1,7 +1,11 @@
+import type { EnvironmentType } from '@/types';
+
 export interface NormalizedEnvironmentDialogValues {
   tenant: string;
   environment: string;
   version: string;
   kubernetesContext: string;
   containerRegistry: string;
+  envType: EnvironmentType;
+  localRepoPath: string;
 }

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -1,6 +1,7 @@
 import type {
   DiffResult,
   EnvironmentActionMode,
+  EnvironmentType,
   ManageTab,
   UICloudContextInitInput,
   UICloudProviderStatus,
@@ -67,6 +68,8 @@ export interface EnvironmentDialogState {
     memory: string;
   };
   containerRegistry: string;
+  envType: EnvironmentType;
+  localRepoPath: string;
   noGit: boolean;
   setDefaultTenant: boolean;
   versionImage: string;
@@ -240,6 +243,8 @@ export const defaultEnvironmentDialog = (): EnvironmentDialogState => ({
   resourceStatusLoading: false,
   runtimePod: defaultRuntimePodConfig(),
   containerRegistry: '',
+  envType: 'remote-agent',
+  localRepoPath: '',
   noGit: false,
   setDefaultTenant: true,
   versionImage: '',

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -68,7 +68,6 @@ export interface EnvironmentDialogState {
   };
   containerRegistry: string;
   noGit: boolean;
-  bootstrap: boolean;
   setDefaultTenant: boolean;
   versionImage: string;
   choicesOpen: boolean;
@@ -242,7 +241,6 @@ export const defaultEnvironmentDialog = (): EnvironmentDialogState => ({
   runtimePod: defaultRuntimePodConfig(),
   containerRegistry: '',
   noGit: false,
-  bootstrap: false,
   setDefaultTenant: true,
   versionImage: '',
   choicesOpen: false,

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -286,6 +286,12 @@ function RuntimePodFields({ dialog }: { dialog: EnvironmentDialog }): React.Reac
 
 function EnvironmentCreateChecks({ dialog }: { dialog: EnvironmentDialog }): React.ReactElement {
   const dispatch = useAppDispatch();
+  // The "Create tenant DevOps repository" toggle used to live here but
+  // its value is fully derived from state the dialog already has: the
+  // submit pipeline (environmentDialogSelection) passes --bootstrap iff
+  // the tenant is new, since that's the only case where the remote
+  // devops module isn't already in place. Removed to stop asking an
+  // unanswerable question.
   return (
     <div className="grid gap-3">
       <CheckboxField
@@ -304,16 +310,6 @@ function EnvironmentCreateChecks({ dialog }: { dialog: EnvironmentDialog }): Rea
         disabled={dialog.busy}
         onCheckedChange={(noGit) => {
           dispatch(updateEnvironmentDialog({ noGit }));
-        }}
-      />
-      <CheckboxField
-        id="environment-bootstrap"
-        label="Create tenant DevOps repository"
-        helper="Generates the tenant's shared DevOps module — Helm values and deployment templates reused by every environment in this tenant."
-        checked={dialog.bootstrap}
-        disabled={dialog.busy}
-        onCheckedChange={(bootstrap) => {
-          dispatch(updateEnvironmentDialog({ bootstrap }));
         }}
       />
     </div>

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -1,7 +1,6 @@
 import { FolderPlus, LoaderCircle, Rocket } from 'lucide-react';
 import * as React from 'react';
 
-import { refreshKubernetesContexts } from '@/app/dialogContextsThunks';
 import {
   closeEnvironmentDialog,
   selectEnvironmentVersionSuggestion,
@@ -35,10 +34,9 @@ import { Label } from '@/components/ui/label';
 
 import { EditableComboField } from './EditableComboField';
 import { uniqueSuggestions } from './EditableComboField.helpers';
-import { EmptyState } from './EmptyState';
+import { KubernetesContextSelect } from './KubernetesContextSelect';
 import { ReadonlyField } from './ManageDialog.fields';
 import { RuntimeResourceControls } from './RuntimeResourceControls';
-import { SelectField } from './SelectField';
 import { VersionField } from './VersionField';
 
 const dialogErrorClassName =
@@ -267,55 +265,6 @@ function EnvironmentCreateFields({ dialog }: { dialog: EnvironmentDialog }): Rea
       />
       <EnvironmentCreateChecks dialog={dialog} />
     </>
-  );
-}
-
-function KubernetesContextSelect({ dialog }: { dialog: EnvironmentDialog }): React.ReactElement {
-  const dispatch = useAppDispatch();
-  const items = dialog.kubernetesContexts.map((context) => ({ value: context, label: context }));
-  const placeholder = dialog.kubernetesContextsLoading
-    ? 'Loading contexts...'
-    : 'Select Kubernetes context';
-  if (!dialog.kubernetesContextsLoading && dialog.kubernetesContexts.length === 0) {
-    const body =
-      "ERun runs `kubectl config get-contexts` using the PATH and KUBECONFIG it inherits from your login shell at startup. If your terminal sees contexts that don't appear here, set KUBECONFIG in ~/.zshenv (or ~/.bash_profile) so it applies to GUI launches too, then restart ERun. If kubectl is not yet installed, install it with `brew install kubectl`.";
-    const errorDetail = dialog.error?.trim() ?? '';
-    return (
-      <div className="grid gap-2">
-        <Label htmlFor="environment-kubernetes-context">Kubernetes context</Label>
-        <EmptyState
-          heading="No Kubernetes contexts found"
-          body={errorDetail !== '' ? `${body}\n\nLast error from kubectl:\n${errorDetail}` : body}
-          action={
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                void dispatch(refreshKubernetesContexts());
-              }}
-            >
-              Rescan
-            </Button>
-          }
-        />
-      </div>
-    );
-  }
-  return (
-    <SelectField
-      id="environment-kubernetes-context"
-      label="Kubernetes context"
-      value={dialog.kubernetesContext}
-      options={items}
-      placeholder={placeholder}
-      emptyLabel="No Kubernetes contexts"
-      disabled={dialog.busy || dialog.kubernetesContextsLoading}
-      required
-      onChange={(kubernetesContext) => {
-        dispatch(updateEnvironmentDialog({ kubernetesContext }));
-      }}
-    />
   );
 }
 

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -34,6 +34,7 @@ import { Label } from '@/components/ui/label';
 
 import { EditableComboField } from './EditableComboField';
 import { uniqueSuggestions } from './EditableComboField.helpers';
+import { EnvironmentTypeSelect, LocalRepoPathField } from './EnvironmentTypeFields';
 import { KubernetesContextSelect } from './KubernetesContextSelect';
 import { ReadonlyField } from './ManageDialog.fields';
 import { RuntimeResourceControls } from './RuntimeResourceControls';
@@ -250,6 +251,8 @@ function EnvironmentCreateFields({ dialog }: { dialog: EnvironmentDialog }): Rea
 
   return (
     <>
+      <EnvironmentTypeSelect dialog={dialog} />
+      {dialog.envType === 'local-agent' && <LocalRepoPathField dialog={dialog} />}
       <KubernetesContextSelect dialog={dialog} />
       <RuntimePodFields dialog={dialog} />
       <EditableComboField
@@ -292,6 +295,11 @@ function EnvironmentCreateChecks({ dialog }: { dialog: EnvironmentDialog }): Rea
   // the tenant is new, since that's the only case where the remote
   // devops module isn't already in place. Removed to stop asking an
   // unanswerable question.
+  //
+  // "Initialize without Git checkout" only changes behavior on the
+  // remote-worktree init path (ensureRemoteRepository in
+  // erun-common/init.go); it's a no-op for local-agent. Hide it then.
+  const isLocalAgent = dialog.envType === 'local-agent';
   return (
     <div className="grid gap-3">
       <CheckboxField
@@ -303,15 +311,17 @@ function EnvironmentCreateChecks({ dialog }: { dialog: EnvironmentDialog }): Rea
           dispatch(updateEnvironmentDialog({ setDefaultTenant }));
         }}
       />
-      <CheckboxField
-        id="environment-no-git"
-        label="Initialize without Git checkout"
-        checked={dialog.noGit}
-        disabled={dialog.busy}
-        onCheckedChange={(noGit) => {
-          dispatch(updateEnvironmentDialog({ noGit }));
-        }}
-      />
+      {!isLocalAgent && (
+        <CheckboxField
+          id="environment-no-git"
+          label="Initialize without Git checkout"
+          checked={dialog.noGit}
+          disabled={dialog.busy}
+          onCheckedChange={(noGit) => {
+            dispatch(updateEnvironmentDialog({ noGit }));
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -390,8 +400,21 @@ function environmentDialogSubmitGate(
 // blocked instead of guessing. Preconditions are checked in order and
 // the first match wins.
 function environmentCreateSubmitGate(dialog: EnvironmentDialog): EnvironmentSubmitGate {
-  const blocker = kubernetesContextBlocker(dialog) ?? runtimeCapacityBlocker(dialog);
+  const blocker =
+    localRepoPathBlocker(dialog) ??
+    kubernetesContextBlocker(dialog) ??
+    runtimeCapacityBlocker(dialog);
   return blocker ? { disabled: true, reason: blocker } : { disabled: false, reason: '' };
+}
+
+function localRepoPathBlocker(dialog: EnvironmentDialog): string | null {
+  if (dialog.envType !== 'local-agent') {
+    return null;
+  }
+  if (dialog.localRepoPath.trim() === '') {
+    return 'Local repo path is required for local-agent envs.';
+  }
+  return null;
 }
 
 function kubernetesContextBlocker(dialog: EnvironmentDialog): string | null {

--- a/erun-ui/frontend/src/components/app/EnvironmentTypeFields.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentTypeFields.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react';
+
+import { useChooseLocalRepoPathMutation } from '@/app/api/environmentApi';
+import { updateEnvironmentDialog } from '@/app/environmentDialogThunks';
+import { readError } from '@/app/errors';
+import { useAppDispatch } from '@/app/hooks';
+import { showTerminalMessage } from '@/app/notificationThunks';
+import type { AppState } from '@/app/state';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { SelectField } from './SelectField';
+
+type EnvironmentDialog = AppState['environmentDialog'];
+
+// EnvironmentTypeSelect drives the env's `type` (local-agent, remote-agent,
+// runtime) — a fundamental shape choice that controls whether the worktree
+// lives on the host, on a PVC inside the cluster, or doesn't exist at all
+// (deploy-only runtime pod). See erun-common/config.go:EnvironmentType.
+// The trigger shows the short noun so it fits the dialog width; the
+// per-type description renders as helper text below, preserving
+// recognition-over-recall without truncating the trigger label.
+export function EnvironmentTypeSelect({
+  dialog,
+}: {
+  dialog: EnvironmentDialog;
+}): React.ReactElement {
+  const dispatch = useAppDispatch();
+  return (
+    <SelectField
+      id="environment-type"
+      label="Environment type"
+      value={dialog.envType}
+      options={[
+        { value: 'remote-agent', label: 'Remote agent' },
+        { value: 'local-agent', label: 'Local agent' },
+        { value: 'runtime', label: 'Runtime' },
+      ]}
+      placeholder="Select environment type"
+      emptyLabel=""
+      helper={environmentTypeHelper(dialog.envType)}
+      disabled={dialog.busy}
+      required
+      onChange={(value) => {
+        dispatch(updateEnvironmentDialog({ envType: value as EnvironmentDialog['envType'] }));
+      }}
+    />
+  );
+}
+
+function environmentTypeHelper(envType: EnvironmentDialog['envType']): string {
+  switch (envType) {
+    case 'local-agent':
+      return 'Worktree on this machine, mounted into the agent pod. Builds happen in the cluster.';
+    case 'remote-agent':
+      return 'Worktree on a PVC inside the cluster. Builds happen in the cluster.';
+    case 'runtime':
+      return 'No agent worktree. Deploy-only — the pod just receives built images.';
+    default:
+      return '';
+  }
+}
+
+// LocalRepoPathField captures the host path mounted into the agent pod for
+// `local-agent` envs. The CLI passes this through to `--project-root`,
+// which becomes EnvConfig.LocalRepoPath. Only meaningful for local-agent —
+// remote-agent uses a PVC and runtime has no worktree. The Browse button
+// opens a native directory picker (Wails OpenDirectoryDialog) so users do
+// not have to type absolute paths by hand.
+export function LocalRepoPathField({ dialog }: { dialog: EnvironmentDialog }): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const [chooseLocalRepoPath, { isLoading: choosing }] = useChooseLocalRepoPathMutation();
+  const helperId = 'environment-local-repo-path-helper';
+  const onBrowse = async (): Promise<void> => {
+    try {
+      const picked = await chooseLocalRepoPath(dialog.localRepoPath).unwrap();
+      if (picked.trim()) {
+        dispatch(updateEnvironmentDialog({ localRepoPath: picked }));
+      }
+    } catch (error) {
+      dispatch(showTerminalMessage(readError(error)));
+    }
+  };
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="environment-local-repo-path">Local repo path</Label>
+      <div className="flex items-stretch gap-2">
+        <Input
+          id="environment-local-repo-path"
+          value={dialog.localRepoPath}
+          type="text"
+          autoComplete="off"
+          spellCheck={false}
+          placeholder="/Users/you/code/your-project"
+          aria-describedby={helperId}
+          disabled={dialog.busy}
+          onChange={(event) => {
+            dispatch(updateEnvironmentDialog({ localRepoPath: event.target.value }));
+          }}
+          className="flex-1"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          disabled={dialog.busy || choosing}
+          onClick={() => {
+            void onBrowse();
+          }}
+        >
+          Browse…
+        </Button>
+      </div>
+      <p id={helperId} className="text-[12px] leading-[1.4] text-muted-foreground">
+        Absolute path on this machine. Mounted into the agent pod as the worktree.
+      </p>
+    </div>
+  );
+}

--- a/erun-ui/frontend/src/components/app/KubernetesContextSelect.tsx
+++ b/erun-ui/frontend/src/components/app/KubernetesContextSelect.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+
+import { refreshKubernetesContexts } from '@/app/dialogContextsThunks';
+import { updateEnvironmentDialog } from '@/app/environmentDialogThunks';
+import { useAppDispatch } from '@/app/hooks';
+import type { AppState } from '@/app/state';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+
+import { EmptyState } from './EmptyState';
+import { SelectField } from './SelectField';
+
+type EnvironmentDialog = AppState['environmentDialog'];
+
+// KubernetesContextSelect renders the Kubernetes-context picker for the
+// env-init dialog. Three surfaces:
+//  - loading: SelectField with the "Loading contexts..." placeholder.
+//  - populated: SelectField listing each detected context.
+//  - empty: EmptyState explaining where kubectl looks, with a Rescan
+//    action that re-invokes LoadKubernetesContexts and, if kubectl
+//    surfaced an error on the previous call, includes that as a "Last
+//    error from kubectl" suffix.
+export function KubernetesContextSelect({
+  dialog,
+}: {
+  dialog: EnvironmentDialog;
+}): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const items = dialog.kubernetesContexts.map((context) => ({ value: context, label: context }));
+  const placeholder = dialog.kubernetesContextsLoading
+    ? 'Loading contexts...'
+    : 'Select Kubernetes context';
+  if (!dialog.kubernetesContextsLoading && dialog.kubernetesContexts.length === 0) {
+    const body =
+      "ERun runs `kubectl config get-contexts` using the PATH and KUBECONFIG it inherits from your login shell at startup. If your terminal sees contexts that don't appear here, set KUBECONFIG in ~/.zshenv (or ~/.bash_profile) so it applies to GUI launches too, then restart ERun. If kubectl is not yet installed, install it with `brew install kubectl`.";
+    const errorDetail = dialog.error.trim();
+    return (
+      <div className="grid gap-2">
+        <Label htmlFor="environment-kubernetes-context">Kubernetes context</Label>
+        <EmptyState
+          heading="No Kubernetes contexts found"
+          body={errorDetail !== '' ? `${body}\n\nLast error from kubectl:\n${errorDetail}` : body}
+          action={
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                void dispatch(refreshKubernetesContexts());
+              }}
+            >
+              Rescan
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+  return (
+    <SelectField
+      id="environment-kubernetes-context"
+      label="Kubernetes context"
+      value={dialog.kubernetesContext}
+      options={items}
+      placeholder={placeholder}
+      emptyLabel="No Kubernetes contexts"
+      disabled={dialog.busy || dialog.kubernetesContextsLoading}
+      required
+      onChange={(kubernetesContext) => {
+        dispatch(updateEnvironmentDialog({ kubernetesContext }));
+      }}
+    />
+  );
+}

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -45,6 +45,11 @@ export interface UISelection {
   runtimeMemory?: string;
   kubernetesContext?: string;
   containerRegistry?: string;
+  // type stays as bare string to match the Wails binding, which widens
+  // the Go EnvironmentType alias at the boundary. Use the
+  // EnvironmentType union for narrowed dropdown values.
+  type?: string;
+  localRepoPath?: string;
   noGit?: boolean;
   bootstrap?: boolean;
   setDefaultTenant?: boolean;

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -64,7 +64,6 @@ export interface UIState {
   message?: string;
   build?: UIBuildDetails;
   versionSuggestions?: UIVersionSuggestion[];
-  kubernetesContexts?: string[];
   cloudProviders?: UICloudProviderStatus[];
 }
 

--- a/erun-ui/playwright/CLAUDE.md
+++ b/erun-ui/playwright/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/erun-ui/playwright/tests/env-init.spec.ts
+++ b/erun-ui/playwright/tests/env-init.spec.ts
@@ -64,6 +64,45 @@ test.describe('environment init dialog', () => {
     await app.envInitDialog.waitForClosed();
   });
 
+  test('local-agent type reveals the Local repo path field and hides the no-Git toggle', async ({
+    app,
+    page,
+  }) => {
+    await app.sidebar.openInitDialog();
+    await app.envInitDialog.waitForOpen();
+
+    const typeSelect = page.getByLabel('Environment type', { exact: true });
+    const localRepoPathInput = page.locator('#environment-local-repo-path');
+    const browseButton = page.getByRole('button', { name: /Browse/ });
+    const noGitCheckbox = page.locator('#environment-no-git');
+
+    // Default is remote-agent — the no-Git toggle is visible and
+    // LocalRepoPath / Browse are absent from the DOM.
+    await expect(typeSelect).toBeVisible();
+    await expect(localRepoPathInput).toHaveCount(0);
+    await expect(browseButton).toHaveCount(0);
+    await expect(noGitCheckbox).toBeVisible();
+
+    // Switch to local-agent: LocalRepoPath + Browse appear, the no-Git
+    // toggle drops out (it doesn't influence the local-agent init path
+    // — see EnvironmentCreateChecks for the rationale).
+    await typeSelect.click();
+    await page.getByRole('option', { name: 'Local agent' }).click();
+    await expect(localRepoPathInput).toBeVisible();
+    await expect(browseButton).toBeVisible();
+    await expect(noGitCheckbox).toHaveCount(0);
+
+    // Switch to runtime: LocalRepoPath disappears, no-Git returns.
+    await typeSelect.click();
+    await page.getByRole('option', { name: 'Runtime' }).click();
+    await expect(localRepoPathInput).toHaveCount(0);
+    await expect(browseButton).toHaveCount(0);
+    await expect(noGitCheckbox).toBeVisible();
+
+    await app.envInitDialog.cancel();
+    await app.envInitDialog.waitForClosed();
+  });
+
   test('kube-context dropdown survives an environments-changed Wails event', async ({
     app,
     page,

--- a/erun-ui/playwright/tests/env-init.spec.ts
+++ b/erun-ui/playwright/tests/env-init.spec.ts
@@ -42,4 +42,67 @@ test.describe('environment init dialog', () => {
     await app.envInitDialog.cancel();
     await app.envInitDialog.waitForClosed();
   });
+
+  test('"Create tenant DevOps repository" checkbox is gone — value is derived from tenant state', async ({
+    app,
+    page,
+  }) => {
+    await app.sidebar.openInitDialog();
+    await app.envInitDialog.waitForOpen();
+
+    // The Bootstrap toggle used to live at #environment-bootstrap. The
+    // value is now computed by environmentDialogSelection
+    // (!tenantExists), so the checkbox must not be in the DOM under any
+    // dialog state.
+    await expect(page.locator('#environment-bootstrap')).toHaveCount(0);
+    // The "Set as default tenant" and "Initialize without Git checkout"
+    // toggles still belong to the dialog — confirm they're untouched.
+    await expect(page.locator('#environment-default-tenant')).toBeVisible();
+    await expect(page.locator('#environment-no-git')).toBeVisible();
+
+    await app.envInitDialog.cancel();
+    await app.envInitDialog.waitForClosed();
+  });
+
+  test('kube-context dropdown survives an environments-changed Wails event', async ({
+    app,
+    page,
+  }) => {
+    // Regression: reloadStateAfterEnvironmentChange used to dispatch
+    // selectLoadedKubernetesContexts(loaded.kubernetesContexts ?? []),
+    // but the Go uiState never carried that field — every
+    // environments-changed tick overwrote the populated dropdown with
+    // []. Invariant: while the dialog is open, firing the event must
+    // leave the same surface visible (populated stays populated, empty
+    // stays empty). The test works whether or not the dev machine has
+    // kubectl contexts available.
+    await app.sidebar.openInitDialog();
+    await app.envInitDialog.waitForOpen();
+
+    const select = page.locator('#environment-kubernetes-context');
+    const emptyState = app.envInitDialog
+      .locator()
+      .getByRole('heading', { name: 'No Kubernetes contexts found' });
+
+    // Wait for "Loading contexts..." to clear: either surface is fine.
+    await expect(select.or(emptyState)).toBeVisible();
+    const wasPopulated = await select.isVisible().catch(() => false);
+
+    await page.evaluate(() => {
+      const runtime = (
+        window as unknown as { runtime: { EventsEmit: (n: string, ...a: unknown[]) => void } }
+      ).runtime;
+      runtime.EventsEmit('environments-changed');
+    });
+
+    // Allow the dispatch chain (event → reload → store update) to
+    // settle, then assert the surface we started with is still visible.
+    const expectedSurface = wasPopulated ? select : emptyState;
+    const otherSurface = wasPopulated ? emptyState : select;
+    await expect(expectedSurface).toBeVisible();
+    await expect(otherSurface).toBeHidden();
+
+    await app.envInitDialog.cancel();
+    await app.envInitDialog.waitForClosed();
+  });
 });

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -278,7 +278,15 @@ func ensureSSHDViaOpenCommand(ctx context.Context, cliPath string, result erunco
 }
 
 func buildInitArgs(selection uiSelection) []string {
-	args := erunArgs(selection.Debug, "init", strings.TrimSpace(selection.Tenant), strings.TrimSpace(selection.Environment), "--remote")
+	envType := strings.TrimSpace(selection.Type)
+	if envType == "" {
+		// Older frontends that don't yet send Type still expect the
+		// pre-Type behavior — pinned to remote-agent. The CLI itself
+		// defaults to local-agent when --type is unset, which would be
+		// a silent behavior change for the desktop flow.
+		envType = "remote-agent"
+	}
+	args := erunArgs(selection.Debug, "init", strings.TrimSpace(selection.Tenant), strings.TrimSpace(selection.Environment), "--type="+envType)
 	if version := strings.TrimSpace(selection.Version); version != "" {
 		args = append(args, "--version", version)
 	}
@@ -296,6 +304,11 @@ func buildInitArgs(selection uiSelection) []string {
 	}
 	if containerRegistry := strings.TrimSpace(selection.ContainerRegistry); containerRegistry != "" {
 		args = append(args, "--container-registry", containerRegistry)
+	}
+	if envType == "local-agent" {
+		if localRepoPath := strings.TrimSpace(selection.LocalRepoPath); localRepoPath != "" {
+			args = append(args, "--project-root", localRepoPath)
+		}
 	}
 	args = append(
 		args,

--- a/erun-ui/state_handlers.go
+++ b/erun-ui/state_handlers.go
@@ -238,6 +238,8 @@ func normalizeSelection(selection uiSelection) uiSelection {
 		RuntimeMemory:     strings.TrimSpace(selection.RuntimeMemory),
 		KubernetesContext: strings.TrimSpace(selection.KubernetesContext),
 		ContainerRegistry: strings.TrimSpace(selection.ContainerRegistry),
+		Type:              strings.TrimSpace(selection.Type),
+		LocalRepoPath:     strings.TrimSpace(selection.LocalRepoPath),
 		NoGit:             selection.NoGit,
 		Bootstrap:         selection.Bootstrap,
 		SetDefaultTenant:  selection.SetDefaultTenant,

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -40,6 +40,8 @@ type uiSelection struct {
 	RuntimeMemory     string `json:"runtimeMemory,omitempty"`
 	KubernetesContext string `json:"kubernetesContext,omitempty"`
 	ContainerRegistry string `json:"containerRegistry,omitempty"`
+	Type              string `json:"type,omitempty"`
+	LocalRepoPath     string `json:"localRepoPath,omitempty"`
 	NoGit             bool   `json:"noGit,omitempty"`
 	Bootstrap         bool   `json:"bootstrap,omitempty"`
 	SetDefaultTenant  bool   `json:"setDefaultTenant,omitempty"`


### PR DESCRIPTION
## Summary

Behavior-preserving and behavior-adding work on the New environment dialog (`erun-ui`), plus repo-wide conventions captured in `AGENTS.md` (`CLAUDE.md` symlinks per directory).

### Dialog fixes (#387, #389)

- **Lint cleanup (#387).** `KubernetesContextSelect` extracted to its own file so `EnvironmentDialogView.tsx` drops under the 500 line cap; \`dialog.error?.trim() ?? ''\` → \`dialog.error.trim()\` (the field is typed \`string\`, never nullish).
- **Kube-context dropdown survives env-list reloads (#389).** Dropped the dead \`selectLoadedKubernetesContexts(loaded.kubernetesContexts ?? [])\` dispatches in \`bootThunks.ts\` — Go's \`uiState\` never carried \`kubernetesContexts\`, so every \`environments-changed\` event was overwriting a populated dropdown with \`[]\`. Removed the helper and the unused \`UIState.kubernetesContexts\` field. Added \`{ forceRefetch: true }\` on \`getKubernetesContexts.initiate()\` so Rescan actually re-invokes the Go binding.
- **"Create tenant DevOps repository" checkbox removed (#389).** Value derives from env type and tenant state, not user choice. Submit pipeline computes \`bootstrap = !isLocalAgent && !tenantExists\`. \`bootstrap\` removed from \`EnvironmentDialogState\`.

### Env-type selector

- **New "Environment type" select.** Three options: \`Local agent\`, \`Remote agent\`, \`Runtime\`. Default \`remote-agent\` to preserve the pre-Type desktop behavior. Helper text under the select switches to a short per-type explanation.
- **Local repo path field with Browse button** for \`local-agent\`. Native folder picker via new \`App.ChooseLocalRepoPath\` Wails binding (mirrors the existing \`ChooseWorkspaceSyncLocalFolder\` pattern). The path lands in \`--project-root\` for the spawned \`erun init\`.
- **\`buildInitArgs\` swaps hardcoded \`--remote\` for \`--type=<value>\`**; emits \`--project-root\` only for local-agent.
- **No-Git toggle hidden for local-agent** (the flag is a no-op on the non-remote-worktree init path).
- Submit gate blocks until Local repo path is non-empty for local-agent envs.
- \`uiSelection\` gains \`Type\` + \`LocalRepoPath\` (json:"type" / "localRepoPath"), \`normalizeSelection\` trims both.

### Repo conventions

- **\`AGENTS.md\` (root)** gains two binding rules:
  - "Stay within the current PR for the whole body of related work" — adding scope to an open PR is preferred over filing separate issues / branches.
  - "Documentation" in agent-facing instructions means \`AGENTS.md\` files, not \`erun-docs/\`.
- **CLAUDE.md symlinks** added in every \`AGENTS.md\` directory (root + 8 subdirs) so Claude Code auto-loads the local guidance when launched from any subtree. \`AGENTS.md\` remains the source of truth.

### Docs (\`erun-docs\`)

- \`concepts/environment-types.md\` now points Operators at the desktop's "New environment" dialog as an equivalent surface to the CLI \`--type\` / \`--project-root\` pair.

## UX Impact Review Checklist (per erun-ui/AGENTS.md § "UX Impact Review Checklist")

1. **Affected paths.** New environment dialog → \`erun init\` pipeline; \`environments-changed\` Wails event → reload path.
2. **User-visible sequence.** Open dialog → pick Environment type → if \`Local agent\`: Local repo path field appears with Browse → fill other fields → Create. Kube-context dropdown stays populated across env-list reloads.
3. **State-without-affordance.** New state fields (\`envType\`, \`localRepoPath\`) each have a corresponding rendered control plus a submit-gate blocker for the required path.
4. **Visibility of system status.** Helper text under the type select; submit-gate blocker line surfaces "Local repo path is required for local-agent envs."
5. **Success/failure feedback.** Init pipeline unchanged.
6. **Consistency with comparable flows.** Browse button mirrors the workspace-sync folder picker; SelectField / TextField mirror existing dialog fields.
7. **One-line heuristic pass.** Visibility-of-status ✓, match-real-world (Operator-language labels) ✓, error-prevention ✓, recognition-over-recall (named types) ✓, accessibility (Label + aria-describedby) ✓, consistency ✓.
8. **Playwright coverage.** \`env-init.spec.ts\` covers (a) bootstrap checkbox is gone, (b) kube-context dropdown survives \`environments-changed\`, (c) local-agent reveals the Local repo path + Browse and hides the no-Git toggle; switching to Runtime reverses the visibility.

## Test plan

- [x] \`yarn typecheck && yarn lint && yarn format:check && yarn build\` in \`erun-ui/frontend\` — clean.
- [x] \`go test ./...\` in \`erun-ui\` — green (added two buildInitArgs tests for local-agent + runtime types; updated the two existing tests to expect \`--type=remote-agent\` instead of \`--remote\`).
- [x] \`./playwright/run.sh --build -- --grep "environment init"\` — 5 specs pass.
- [x] \`yarn build\` in \`erun-docs\` — clean.
- [x] \`make integration-test\` on this branch — \`ok\`, coverage 56.6% (>= 55%).

Closes #387
Closes #389