### PR TITLE
Release flow bumps .claude-plugin/marketplace.json source.sha

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/sophium/erun.git",
         "path": "erun-skills",
         "ref": "main",
-        "sha": "171cba26a584eac446ce370452d7de3b6a62a1f1"
+        "sha": "38e943bdc85d09a372d20152cf08fe17989d11a2"
       },
       "homepage": "https://github.com/sophium/erun/tree/main/erun-skills"
     }

--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -80,9 +80,11 @@ type ReleaseStage struct {
 }
 
 type ReleasePackagingSyncSpec struct {
-	Version     string `json:"version"`
-	FormulaPath string `json:"formulaPath,omitempty"`
-	ScoopPath   string `json:"scoopPath,omitempty"`
+	ProjectRoot     string `json:"projectRoot,omitempty"`
+	Version         string `json:"version"`
+	FormulaPath     string `json:"formulaPath,omitempty"`
+	ScoopPath       string `json:"scoopPath,omitempty"`
+	MarketplacePath string `json:"marketplacePath,omitempty"`
 }
 
 type ReleaseSpec struct {
@@ -885,7 +887,7 @@ func discoverReleaseLinuxScripts(releaseRoot, version string) ([]scriptSpec, err
 
 func discoverStableReleasePackaging(projectRoot, version string) ([]ReleaseFileUpdate, *ReleasePackagingSyncSpec, error) {
 	updates := make([]ReleaseFileUpdate, 0, 2)
-	syncSpec := &ReleasePackagingSyncSpec{Version: version}
+	syncSpec := &ReleasePackagingSyncSpec{ProjectRoot: projectRoot, Version: version}
 
 	formulaPath := filepath.Join(projectRoot, "Formula", "erun.rb")
 	formulaContent, formulaChanged, err := updateHomebrewFormulaReleaseVersion(formulaPath, version)
@@ -916,7 +918,13 @@ func discoverStableReleasePackaging(projectRoot, version string) ([]ReleaseFileU
 	if fileExists(scoopPath) {
 		syncSpec.ScoopPath = scoopPath
 	}
-	if syncSpec.FormulaPath == "" && syncSpec.ScoopPath == "" {
+
+	marketplacePath := filepath.Join(projectRoot, ".claude-plugin", "marketplace.json")
+	if fileExists(marketplacePath) {
+		syncSpec.MarketplacePath = marketplacePath
+	}
+
+	if syncSpec.FormulaPath == "" && syncSpec.ScoopPath == "" && syncSpec.MarketplacePath == "" {
 		return updates, nil, nil
 	}
 
@@ -1082,11 +1090,11 @@ func updateScoopManifestReleaseChecksum(manifestPath, checksum string) (string, 
 }
 
 func syncReleasePackagingChecksums(ctx Context, spec ReleasePackagingSyncSpec) ([]ReleaseFileUpdate, error) {
-	if spec.FormulaPath == "" && spec.ScoopPath == "" {
+	if spec.FormulaPath == "" && spec.ScoopPath == "" && spec.MarketplacePath == "" {
 		return nil, nil
 	}
 
-	updates := make([]ReleaseFileUpdate, 0, 2)
+	updates := make([]ReleaseFileUpdate, 0, 3)
 	formulaUpdate, ok, err := syncHomebrewReleaseChecksum(ctx, spec)
 	if err != nil {
 		return nil, err
@@ -1100,6 +1108,13 @@ func syncReleasePackagingChecksums(ctx Context, spec ReleasePackagingSyncSpec) (
 	}
 	if ok {
 		updates = append(updates, scoopUpdate)
+	}
+	marketplaceUpdate, ok, err := syncMarketplaceReleaseSHA(ctx, spec)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		updates = append(updates, marketplaceUpdate)
 	}
 	return updates, nil
 }
@@ -1144,6 +1159,58 @@ func syncScoopReleaseChecksum(ctx Context, spec ReleasePackagingSyncSpec) (Relea
 		return ReleaseFileUpdate{}, false, err
 	}
 	return ReleaseFileUpdate{Path: spec.ScoopPath, Content: content}, true, nil
+}
+
+// syncMarketplaceReleaseSHA bumps .claude-plugin/marketplace.json plugins[*].source.sha
+// to the commit the release tag points at, so the marketplace catalogue pins
+// the plugin to the release commit. Runs in the same stage as Homebrew/Scoop
+// because both require the release tag to exist first.
+func syncMarketplaceReleaseSHA(ctx Context, spec ReleasePackagingSyncSpec) (ReleaseFileUpdate, bool, error) {
+	if spec.MarketplacePath == "" {
+		return ReleaseFileUpdate{}, false, nil
+	}
+	if spec.ProjectRoot == "" {
+		return ReleaseFileUpdate{}, false, fmt.Errorf("release: marketplace sync requires ProjectRoot in sync spec")
+	}
+	ref := "v" + spec.Version + "^{}"
+	ctx.TraceCommand("", "git", "-C", spec.ProjectRoot, "rev-parse", ref)
+	if ctx.DryRun {
+		return ReleaseFileUpdate{}, false, nil
+	}
+	output, err := Command("git", "-C", spec.ProjectRoot, "rev-parse", ref).CombinedOutput()
+	if err != nil {
+		return ReleaseFileUpdate{}, false, fmt.Errorf("resolve release tag %q: %w", ref, err)
+	}
+	sha := strings.TrimSpace(string(output))
+	if sha == "" {
+		return ReleaseFileUpdate{}, false, fmt.Errorf("resolve release tag %q: empty result", ref)
+	}
+	content, changed, err := updateMarketplaceReleaseSHA(spec.MarketplacePath, sha)
+	if err != nil || !changed {
+		return ReleaseFileUpdate{}, false, err
+	}
+	return ReleaseFileUpdate{Path: spec.MarketplacePath, Content: content}, true, nil
+}
+
+// updateMarketplaceReleaseSHA swaps every "sha": "<hex>" field inside
+// .claude-plugin/marketplace.json with the given sha. Uses targeted text
+// replacement (not JSON marshal) to preserve the file's formatting and
+// key ordering.
+func updateMarketplaceReleaseSHA(marketplacePath, sha string) (string, bool, error) {
+	data, err := os.ReadFile(marketplacePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	content := string(data)
+	pattern := regexp.MustCompile(`("sha":\s*")[0-9a-f]{7,40}(")`)
+	updated := pattern.ReplaceAllString(content, `${1}`+sha+`${2}`)
+	if updated == content {
+		return "", false, nil
+	}
+	return updated, true, nil
 }
 
 func releaseArchiveSHA256(url string) (string, error) {
@@ -1227,16 +1294,19 @@ func newPushReleaseTagStage(projectRoot, version string) ReleaseStage {
 }
 
 func newSyncPackagingStage(projectRoot string, spec ReleasePackagingSyncSpec) ReleaseStage {
-	if spec.FormulaPath == "" && spec.ScoopPath == "" {
+	if spec.FormulaPath == "" && spec.ScoopPath == "" && spec.MarketplacePath == "" {
 		return ReleaseStage{}
 	}
 
-	updates := make([]ReleaseFileUpdate, 0, 2)
+	updates := make([]ReleaseFileUpdate, 0, 3)
 	if spec.FormulaPath != "" {
 		updates = append(updates, ReleaseFileUpdate{Path: spec.FormulaPath})
 	}
 	if spec.ScoopPath != "" {
 		updates = append(updates, ReleaseFileUpdate{Path: spec.ScoopPath})
+	}
+	if spec.MarketplacePath != "" {
+		updates = append(updates, ReleaseFileUpdate{Path: spec.MarketplacePath})
 	}
 
 	addArgs := append([]string{"add"}, releaseUpdatedPaths(projectRoot, updates)...)

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -324,6 +324,35 @@ func SeedReleaseRepo(t testing.TB, dir, branch string) string {
 	return dir
 }
 
+// SeedMarketplaceJSON writes a placeholder .claude-plugin/marketplace.json
+// inside dir so release scenarios can exercise the marketplace.json
+// source.sha bump path. The placeholder pins one plugin at a known SHA;
+// the release flow's syncMarketplaceReleaseSHA rewrites that SHA to the
+// resolved release tag commit during the sync-packaging-checksums stage.
+func SeedMarketplaceJSON(t testing.TB, dir string) {
+	t.Helper()
+	dst := filepath.Join(dir, ".claude-plugin")
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dst, err)
+	}
+	mustWrite(t, filepath.Join(dst, "marketplace.json"), `{
+  "name": "sophium/erun",
+  "plugins": [
+    {
+      "name": "erun-tools",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/sophium/erun.git",
+        "path": "erun-skills",
+        "ref": "main",
+        "sha": "0000000000000000000000000000000000000000"
+      }
+    }
+  ]
+}
+`)
+}
+
 // RunGit runs `git <args...>` inside dir. Useful for scenarios that need
 // to set up branches, tags, or remotes after SeedReleaseRepo.
 func RunGit(t testing.TB, dir string, args ...string) {

--- a/erun-integration/release_test.go
+++ b/erun-integration/release_test.go
@@ -104,6 +104,25 @@ func TestRelease(t *testing.T) {
 		golden.Equal(t, "release/dry_run_includes_linux_release_scripts", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_main_with_marketplace_emits_sha_sync", func(t *testing.T) {
+		// Exercises release.go marketplace.json bump path: when the project
+		// contains a .claude-plugin/marketplace.json, the sync-packaging-checksums
+		// stage must trace `git rev-parse v<VERSION>^{}` (to resolve the release
+		// commit) and include the marketplace.json path in the git-add list.
+		// The bump itself is gated on !DryRun so the trace alone proves the path
+		// is wired correctly.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "main")
+		fixture.SeedMarketplaceJSON(t, setup.Cwd)
+		fixture.RunGit(t, setup.Cwd, "add", ".claude-plugin")
+		fixture.RunGit(t, setup.Cwd, "commit", "-m", "add marketplace.json")
+		result := erun.Run(t, []string{"release", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "release/dry_run_main_with_marketplace_emits_sha_sync", normalize.Apply(result.Combined))
+	})
+
 	t.Run("dry_run_force_includes_tag_deletion_for_stale_release_tag", func(t *testing.T) {
 		// Exercises release.go --force path: when the release tag already
 		// exists remotely on a commit other than HEAD, --dry-run must

--- a/erun-integration/testdata/release/dry_run_main_with_marketplace_emits_sha_sync.txt
+++ b/erun-integration/testdata/release/dry_run_main_with_marketplace_emits_sha_sync.txt
@@ -1,0 +1,46 @@
+<VERSION>
+audit: erun release --dry-run
+release: resolving project root
+release: project root = <TMP>
+release: resolving release module root
+release: release root = <TMP>
+release: loading release config from project
+release: main branch = main, develop branch = develop
+release: resolving git branch and commit
+git -C <TMP> rev-parse --abbrev-ref HEAD
+git -C <TMP> rev-parse --short HEAD
+release: branch = main, commit = <SHORTSHA>
+release: resolving base version from VERSION file
+release: base version = <VERSION> (from <TMP>
+release: classified mode = stable
+git -C <TMP> show-ref --verify --quiet refs/heads/develop
+release: develop branch "develop" exists = false
+release: branch=main mode=stable version=<VERSION>
+next version: <VERSION>
+docker image: ghcr.io/sophium/api:<VERSION>
+stage: sync-remote
+cd <TMP> && git fetch origin
+cd <TMP> && git rebase origin/main
+stage: release
+write <TMP>
+  apiVersion: v2
+  appVersion: <VERSION>
+  name: api
+  version: <VERSION>
+cd <TMP> && git add erun-devops/k8s/api/Chart.yaml
+cd <TMP> && git commit -m '[skip ci] release <VERSION>'
+git -C <TMP> rev-parse '<VERSION>^{}'
+cd <TMP> && git tag -a <VERSION> -m 'Release <VERSION>'
+stage: push-release-tag
+cd <TMP> && git push origin <VERSION>
+stage: sync-packaging-checksums
+git -C <TMP> rev-parse '<VERSION>^{}'
+cd <TMP> && git add .claude-plugin/marketplace.json
+cd <TMP> && git commit -m '[skip ci] sync package metadata <VERSION>'
+stage: post-release-version-bump
+write <TMP>
+  <VERSION>
+cd <TMP> && git add erun-devops/VERSION
+cd <TMP> && git commit -m '[skip ci] prepare <VERSION>'
+stage: push
+cd <TMP> && git push --follow-tags origin main


### PR DESCRIPTION
## Summary

- Fold the marketplace.json `source.sha` bump into the existing `sync-packaging-checksums` stage, the same stage that already updates Homebrew formula and Scoop manifest SHA256 checksums after the release tag is pushed.
- One additional trace line in dry-run (`git rev-parse v<version>^{}` to resolve the release commit) and one additional file in the existing `git add` of the sync-packaging commit. No new commits beyond what the release flow already produces today.
- Immediate manual bump of `.claude-plugin/marketplace.json` `source.sha` to `38e943b` (the squash-merge of #391, which is the first commit on `main` containing `erun-skills/`). Unblocks the marketplace install path independent of when the next `erun build --release` runs.

## Why two-commit pattern fits naturally

The release flow already runs a multi-commit pattern: the `release` stage creates the release commit + tag, then after `push-release-tag`, the `sync-packaging-checksums` stage produces a second commit (`[skip ci] sync package metadata vX.Y.Z`) for metadata that can only be computed once the tag exists (e.g. SHA256 of `github.com/sophium/erun/archive/refs/tags/vX.Y.Z.tar.gz`).

`marketplace.json` `source.sha` is the same shape: it pins external consumers to the release commit, which is only knowable after the tag is created. So the bump fits in the same stage. The release tag remains at the release commit (which carries the plugin contents); the marketplace.json update rides on the same second commit Homebrew/Scoop already produce.

## Changes

- `erun-common/release.go`:
  - `ReleasePackagingSyncSpec` gains `ProjectRoot` (needed by `git rev-parse`) and `MarketplacePath` fields.
  - `discoverStableReleasePackaging` detects `<root>/.claude-plugin/marketplace.json` when present.
  - New `syncMarketplaceReleaseSHA(ctx, spec)` mirrors the Homebrew/Scoop sync functions: traces `git rev-parse v<version>^{}`, short-circuits in dry-run, otherwise resolves the SHA and rewrites every `"sha": "<hex>"` field in the marketplace manifest via targeted regex replacement (preserves file formatting vs. JSON marshal roundtrip).
  - `syncReleasePackagingChecksums` and `newSyncPackagingStage` updated to include the marketplace path in the file-update list and `git-add` command when present.
- `erun-integration/internal/fixture/fixture.go`: new `SeedMarketplaceJSON` helper.
- `erun-integration/release_test.go`: new scenario `dry_run_main_with_marketplace_emits_sha_sync` exercises the path end-to-end via the compiled binary; golden locks the trace.
- `.claude-plugin/marketplace.json` `source.sha` bumped `171cba26` → `38e943b`.

## Test plan

- [x] `go build ./...` clean in `erun-common`.
- [x] `make integration-test` green; coverage 56.9% (was 56.6% before, threshold 55%).
- [x] New scenario `dry_run_main_with_marketplace_emits_sha_sync` regenerated with `UPDATE_GOLDEN=1` then re-verified read-only.
- [x] Dry-run trace shows the `sync-packaging-checksums` stage with the new `git rev-parse` line and the marketplace.json in the `git add` list, even though the file write is gated behind `!ctx.DryRun`.
- [ ] First real release after this merges should produce a real bump on `marketplace.json` to the release tag's commit. Worth eyeballing the first release PR commit to confirm.

Closes #392