### PR TITLE
Silence `erun open --no-shell` stderr for eval-wrapped aliases

### DIFF
--- a/erun-cli/cmd/feedback_render.go
+++ b/erun-cli/cmd/feedback_render.go
@@ -41,6 +41,7 @@ func commandVerbosity(cmd *cobra.Command) int {
 	if err != nil {
 		verbosity = 0
 	}
+	userAskedForVerbose := err == nil && verbosity > 0
 	if isExecCommand(cmd) && verbosity < common.VerbosityDebug {
 		verbosity = common.VerbosityDebug
 	}
@@ -50,7 +51,25 @@ func commandVerbosity(cmd *cobra.Command) int {
 	if verbosity > common.VerbosityTrace {
 		verbosity = common.VerbosityTrace
 	}
+	if shouldSilenceNoShellOutput(cmd, userAskedForVerbose) {
+		return common.VerbosityInfo - 1
+	}
 	return verbosity
+}
+
+// shouldSilenceNoShellOutput keeps an `eval "$(erun open ... --no-shell)"`
+// alias quiet on stderr. The audit and trace lines are useful when the user
+// is actively auditing (-v / -vv) or previewing (--dry-run), but they surface
+// in the wrapping terminal on every alias invocation, which the docs already
+// promise is silent. Returns true only when the user has opted into none of
+// the verbose paths.
+func shouldSilenceNoShellOutput(cmd *cobra.Command, userAskedForVerbose bool) bool {
+	return !userAskedForVerbose && !isDryRunCommand(cmd) && isNoShellCommand(cmd)
+}
+
+func isNoShellCommand(cmd *cobra.Command) bool {
+	noShell, err := cmd.Flags().GetBool("no-shell")
+	return err == nil && noShell
 }
 
 func commandContext(cmd *cobra.Command) common.Context {

--- a/erun-cli/cmd/feedback_render_test.go
+++ b/erun-cli/cmd/feedback_render_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"testing"
+
+	common "github.com/sophium/erun/erun-common"
+	"github.com/spf13/cobra"
+)
+
+func TestCommandVerbosityNoShellSilencesByDefault(t *testing.T) {
+	// --no-shell is the eval-friendly output mode for `erun open`; when
+	// the user has not opted into -v / -vv or --dry-run, the command must
+	// keep stderr silent so the wrapping alias doesn't leak audit and
+	// trace lines into the user's terminal.
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{name: "no flags", args: nil, want: common.VerbosityInfo},
+		{name: "no-shell alone is silent", args: []string{"--no-shell"}, want: common.VerbosityInfo - 1},
+		{name: "no-shell + -v keeps debug verbosity", args: []string{"--no-shell", "-v"}, want: common.VerbosityDebug},
+		{name: "no-shell + -vv keeps trace verbosity", args: []string{"--no-shell", "-vv"}, want: common.VerbosityTrace},
+		{name: "no-shell + --dry-run keeps trace verbosity", args: []string{"--no-shell", "--dry-run"}, want: common.VerbosityTrace},
+		{name: "--dry-run alone keeps trace verbosity", args: []string{"--dry-run"}, want: common.VerbosityTrace},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			leaf := newOpenLikeCommandForTesting()
+			if err := leaf.ParseFlags(tc.args); err != nil {
+				t.Fatalf("parse flags %v: %v", tc.args, err)
+			}
+			got := commandVerbosity(leaf)
+			if got != tc.want {
+				t.Fatalf("commandVerbosity %v = %d, want %d", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsNoShellCommand(t *testing.T) {
+	leaf := newOpenLikeCommandForTesting()
+	if isNoShellCommand(leaf) {
+		t.Fatalf("fresh open command should not report --no-shell")
+	}
+	if err := leaf.Flags().Set("no-shell", "true"); err != nil {
+		t.Fatalf("set no-shell: %v", err)
+	}
+	if !isNoShellCommand(leaf) {
+		t.Fatalf("expected isNoShellCommand to be true after setting --no-shell")
+	}
+}
+
+func newOpenLikeCommandForTesting() *cobra.Command {
+	// Mirrors the shape of the real open command tree for the verbosity
+	// path: root owns the persistent --verbose, leaf owns --dry-run and
+	// --no-shell. commandVerbosity reads flags off the leaf via cobra's
+	// flag inheritance.
+	root := &cobra.Command{Use: "erun"}
+	root.PersistentFlags().CountP("verbose", "v", "")
+	addDryRunFlag(root)
+	leaf := &cobra.Command{Use: "open", RunE: func(cmd *cobra.Command, args []string) error { return nil }}
+	addDryRunFlag(leaf)
+	leaf.Flags().Bool("no-shell", false, "")
+	root.AddCommand(leaf)
+	return leaf
+}

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -682,7 +682,6 @@ func maybeConfigureOpenNoShellAlias(result common.OpenResult, promptRunner Promp
 	aliasName := openNoShellAliasName(result)
 	startupFile, aliasConfigured := detectOpenNoShellAliasStartupFile(result, shellPath)
 	if aliasConfigured {
-		writeOpenNoShellHintLines(stderr, result, shellPath)
 		return nil
 	}
 	if startupFile == "" || promptRunner == nil || dialect == openNoShellDialectPowerShell {
@@ -715,23 +714,9 @@ func writeOpenNoShellHintLines(stderr io.Writer, result common.OpenResult, shell
 
 func openNoShellHintLines(result common.OpenResult, shellPath string) []string {
 	dialect := openNoShellDialectForShell(shellPath)
-	aliasName := openNoShellAliasName(result)
-	aliasCommand := openNoShellAliasCommand(result, shellPath)
-	startupFile, aliasConfigured := detectOpenNoShellAliasStartupFile(result, shellPath)
-	if aliasConfigured {
-		return []string{
-			fmt.Sprintf("configured in your shell startup file: open a new shell to use %s", aliasName),
-		}
-	}
-	if startupFile == "" || dialect == openNoShellDialectPowerShell {
-		return []string{
-			openNoShellHintPrefix(dialect),
-			aliasCommand,
-		}
-	}
 	return []string{
 		openNoShellHintPrefix(dialect),
-		aliasCommand,
+		openNoShellAliasCommand(result, shellPath),
 	}
 }
 

--- a/erun-cli/run.sh
+++ b/erun-cli/run.sh
@@ -25,14 +25,30 @@ if git -C "$SCRIPT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 	BUILD_DATE=$(git -C "$SCRIPT_DIR" show -s --format=%cI HEAD)
 fi
 
-printf '>> rebuilding erun CLI (%s)... ' "$BUILD_VERSION" >&2
+# --no-shell is the eval-friendly mode (`eval "$(erun open ... --no-shell)"`);
+# the binary keeps stderr silent there, so the dev wrapper's rebuild progress
+# lines would be the only thing leaking into the wrapping terminal. Suppress
+# them here while keeping `go build`'s own output so compile errors still surface.
+QUIET_REBUILD=0
+for arg in "$@"; do
+	case "$arg" in
+	--no-shell ) QUIET_REBUILD=1; break ;;
+	-- ) break ;;
+	esac
+done
+
+if [ "$QUIET_REBUILD" -eq 0 ]; then
+	printf '>> rebuilding erun CLI (%s)... ' "$BUILD_VERSION" >&2
+fi
 build_started_at=$(date +%s)
 go build \
 	-ldflags "-X github.com/sophium/erun/cmd.buildVersion=${BUILD_VERSION} -X github.com/sophium/erun/cmd.buildCommit=${BUILD_COMMIT} -X github.com/sophium/erun/cmd.buildDate=${BUILD_DATE}" \
 	-o "$TARGET" \
 	./
 build_finished_at=$(date +%s)
-printf 'ok (%ss) -> %s\n' "$((build_finished_at - build_started_at))" "$TARGET" >&2
+if [ "$QUIET_REBUILD" -eq 0 ]; then
+	printf 'ok (%ss) -> %s\n' "$((build_finished_at - build_started_at))" "$TARGET" >&2
+fi
 
 COMMAND_NAME=
 for arg in "$@"; do


### PR DESCRIPTION
Closes #394

## Summary
- `--no-shell` is documented as the eval-friendly output mode (`alias my-tenant-local='eval "$(erun open ... --no-shell)"'` in `cli/open.md` and the root help example), but the audit and trace lines on stderr leaked into the user's terminal on every alias invocation.
- Lower the logger below Info verbosity when `--no-shell` is set and the user hasn't opted into `-v` / `-vv` or `--dry-run`. `Logger.Error` still flows.
- Drop the redundant "configured in your shell startup file: open a new shell to use <alias>" confirmation when the alias is already wired up — it isn't actionable, and after this PR it was the only stderr line that fired on direct (non-eval) interactive runs. Simplifies `openNoShellHintLines` accordingly.
- Suppress the dev wrapper's `>> rebuilding erun CLI ... ok (Ns) -> ...` progress lines when `--no-shell` is in argv. The wrapper is dev-only (release binaries never see it) but it leaks into the wrapping terminal of `eval "$(erun open ... --no-shell)"`. `go build`'s own output stays so compile errors still surface.
- `--dry-run` and `-v` / `-vv` keep the full trace, so every existing dry-run integration golden stays unchanged.

## Test plan
- [x] `go test ./...` in `erun-cli` (new `TestCommandVerbosityNoShellSilencesByDefault` + `TestIsNoShellCommand` lock the verbosity contract).
- [x] `go test ./...` in `erun-common` and `erun-mcp`.
- [x] `make integration-test` (coverage 56.9% ≥ 55%, all dry-run goldens green).
- [x] Manual: `eval "$(erun open erun local --no-shell)"` produces a silent terminal; `kubectl config current-context` / `pwd` confirm context, namespace, and worktree all switched.
- [x] Manual: `erun open --no-shell --dry-run` still emits the full audit + trace lines.
- [x] Manual: dev wrapper `./erun-cli/run.sh open --no-shell` silent; `./erun-cli/run.sh version` still shows the rebuild progress.

## Docs
Existing `cli/open.md` already documents the `eval "$(...)"` alias pattern, which implicitly promises silent operation. This PR brings actual behavior in line with that documented intent; no doc text needs updating.