### PR TITLE
Honor .gitignore in release-root discovery walks

### DIFF
--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -1441,13 +1441,17 @@ func fileExists(path string) bool {
 }
 
 func findReleaseChartPaths(projectRoot string) ([]string, error) {
+	ignored, err := loadReleaseDiscoveryIgnoreSet(projectRoot)
+	if err != nil {
+		return nil, err
+	}
 	matches := make([]string, 0, 4)
-	err := filepath.WalkDir(projectRoot, func(path string, d os.DirEntry, err error) error {
+	err = filepath.WalkDir(projectRoot, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
-			if d.Name() == ".git" {
+			if skip := releaseDiscoverySkipDir(projectRoot, path, d, ignored); skip {
 				return filepath.SkipDir
 			}
 			return nil
@@ -1489,9 +1493,13 @@ func resolveReleaseModuleRoot(projectRoot string) (string, error) {
 }
 
 func findNestedReleaseRoots(projectRoot string) ([]string, error) {
+	ignored, err := loadReleaseDiscoveryIgnoreSet(projectRoot)
+	if err != nil {
+		return nil, err
+	}
 	matches := make([]string, 0, 2)
-	err := filepath.WalkDir(projectRoot, func(path string, d os.DirEntry, err error) error {
-		dir, ok, walkErr := nestedReleaseRootCandidate(projectRoot, path, d, err)
+	err = filepath.WalkDir(projectRoot, func(path string, d os.DirEntry, err error) error {
+		dir, ok, walkErr := nestedReleaseRootCandidate(projectRoot, path, d, err, ignored)
 		if ok {
 			matches = append(matches, dir)
 		}
@@ -1504,12 +1512,12 @@ func findNestedReleaseRoots(projectRoot string) ([]string, error) {
 	return matches, nil
 }
 
-func nestedReleaseRootCandidate(projectRoot, path string, d os.DirEntry, err error) (string, bool, error) {
+func nestedReleaseRootCandidate(projectRoot, path string, d os.DirEntry, err error, ignored *ignoreSet) (string, bool, error) {
 	if err != nil {
 		return "", false, err
 	}
 	if d.IsDir() {
-		if d.Name() == ".git" {
+		if skip := releaseDiscoverySkipDir(projectRoot, path, d, ignored); skip {
 			return "", false, filepath.SkipDir
 		}
 		return "", false, nil
@@ -1526,6 +1534,44 @@ func nestedReleaseRootCandidate(projectRoot, path string, d os.DirEntry, err err
 		return "", false, err
 	}
 	return dir, true, nil
+}
+
+// releaseDiscoverySkipDir reports whether the release walker should skip
+// descending into d. .git is excluded unconditionally (it is the VCS
+// store, not source). Anything ignored by the repo's .gitignore (root or
+// nested) is excluded too — third-party trees like node_modules/ or
+// vendor/ ship their own VERSION/Chart.yaml files that must not be
+// counted as release-root candidates.
+func releaseDiscoverySkipDir(projectRoot, path string, d os.DirEntry, ignored *ignoreSet) bool {
+	if d.Name() == ".git" {
+		return true
+	}
+	if path == projectRoot {
+		return false
+	}
+	rel, err := filepath.Rel(projectRoot, path)
+	if err != nil {
+		return false
+	}
+	return ignored.matches(filepath.ToSlash(rel), true)
+}
+
+// loadReleaseDiscoveryIgnoreSet builds the gitignore-only matcher used to
+// keep third-party trees out of release-root discovery. It deliberately
+// omits .dockerignore — that is the build-context contract, not the
+// source-tree contract — and relies on .gitignore alone to mark "not
+// part of this repo's source".
+func loadReleaseDiscoveryIgnoreSet(projectRoot string) (*ignoreSet, error) {
+	combined := &ignoreSet{}
+	root, err := loadIgnoreFile(filepath.Join(projectRoot, ".gitignore"), "")
+	if err != nil {
+		return nil, err
+	}
+	combined.patterns = append(combined.patterns, root.patterns...)
+	if err := loadNestedGitignores(projectRoot, []string{"."}, combined); err != nil {
+		return nil, err
+	}
+	return combined, nil
 }
 
 func releaseRootRelativeParts(projectRoot, dir string) ([]string, error) {

--- a/erun-integration/release_test.go
+++ b/erun-integration/release_test.go
@@ -145,4 +145,31 @@ func TestRelease(t *testing.T) {
 		}
 		golden.Equal(t, "release/dry_run_force_includes_tag_deletion_for_stale_release_tag", normalize.Apply(result.Combined))
 	})
+
+	t.Run("dry_run_skips_release_roots_in_gitignored_trees", func(t *testing.T) {
+		// Regression for #398. The release-root walker used to descend
+		// into third-party trees and treat every VERSION file as a
+		// candidate. In a contribute clone where `yarn install` ran in
+		// `erun-docs/`, `erun-docs/node_modules/lunr/VERSION` was
+		// picked up alongside `erun-devops/VERSION`, and resolution
+		// failed with "multiple release roots found under project
+		// root". The walker now honors .gitignore (root + nested), so
+		// any VERSION file in an ignored tree drops out of discovery.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "develop")
+		docsDir := filepath.Join(setup.Cwd, "erun-docs")
+		if err := os.MkdirAll(filepath.Join(docsDir, "node_modules", "lunr"), 0o755); err != nil {
+			t.Fatalf("mkdir node_modules/lunr: %v", err)
+		}
+		mustWriteFile(t, filepath.Join(docsDir, ".gitignore"), "node_modules\n")
+		mustWriteFile(t, filepath.Join(docsDir, "node_modules", "lunr", "VERSION"), "2.3.9\n")
+		fixture.RunGit(t, setup.Cwd, "add", "erun-docs/.gitignore")
+		fixture.RunGit(t, setup.Cwd, "commit", "-q", "-m", "ignore node_modules in docs")
+
+		result := erun.Run(t, []string{"release", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "release/dry_run_skips_release_roots_in_gitignored_trees", normalize.Apply(result.Combined))
+	})
 }

--- a/erun-integration/testdata/release/dry_run_skips_release_roots_in_gitignored_trees.txt
+++ b/erun-integration/testdata/release/dry_run_skips_release_roots_in_gitignored_trees.txt
@@ -1,0 +1,34 @@
+<VERSION>
+audit: erun release --dry-run
+release: resolving project root
+release: project root = <TMP>
+release: resolving release module root
+release: release root = <TMP>
+release: loading release config from project
+release: main branch = main, develop branch = develop
+release: resolving git branch and commit
+git -C <TMP> rev-parse --abbrev-ref HEAD
+git -C <TMP> rev-parse --short HEAD
+release: branch = develop, commit = <SHORTSHA>
+release: resolving base version from VERSION file
+release: base version = <VERSION> (from <TMP>
+release: classified mode = candidate
+git -C <TMP> show-ref --verify --quiet refs/heads/develop
+release: develop branch "develop" exists = true
+release: branch=develop mode=candidate version=<VERSION>
+docker image: ghcr.io/sophium/api:<VERSION>
+stage: sync-remote
+cd <TMP> && git fetch origin
+cd <TMP> && git rebase origin/develop
+stage: release
+write <TMP>
+  apiVersion: v2
+  appVersion: <VERSION>
+  name: api
+  version: <VERSION>
+cd <TMP> && git add erun-devops/k8s/api/Chart.yaml
+cd <TMP> && git commit -m '[skip ci] release <VERSION>'
+git -C <TMP> rev-parse '<VERSION>^{}'
+cd <TMP> && git tag -a <VERSION> -m 'Release candidate <VERSION>'
+stage: push
+cd <TMP> && git push --follow-tags origin develop


### PR DESCRIPTION
## Summary

- The release-root walker descended into every directory except `.git`. A third-party `VERSION` file in a gitignored tree (e.g. a contribute clone with `erun-docs/node_modules/lunr/VERSION` after `yarn install`) was counted alongside `erun-devops/VERSION`, and `erun build --release` bailed with `multiple release roots found under project root`.
- Both `findNestedReleaseRoots` and `findReleaseChartPaths` now load the repo's root + nested `.gitignore` and skip ignored directories during the walk. The existing semantic filter (`ignoredNestedReleaseRoot`, which excludes `assets/...` and `<top>/docker/...`) is unchanged — it handles checked-in non-release-root VERSION files inside our own trees and is complementary to the gitignore skip.
- Integration scenario `release/dry_run_skips_release_roots_in_gitignored_trees` seeds a nested `.gitignore` + `node_modules/lunr/VERSION` and asserts the dry-run plan resolves cleanly to `erun-devops`. Closes #398.

## Test plan

- [x] `make integration-test` (suite 32s, coverage 57.0% ≥ 55.0%).
- [x] `go build ./...` in `erun-common`, `erun-cli`, `erun-mcp`, `erun-ui`.
- [x] `go test ./...` in `erun-cli` and `erun-mcp`.
- [x] New regression scenario passes; golden is identical to the baseline `dry_run_develop_emits_candidate_plan` (correct — the ignored VERSION must not perturb the resolved plan).