### PR TITLE
Ignore .idea/ at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ profile.cov
 .claude
 
 # Editor/IDE
-# .idea/
+.idea/
 # .vscode/
 /.codex
 


### PR DESCRIPTION
## Summary

- `.idea/` was commented out under the `# Editor/IDE` section in root `.gitignore`, so IntelliJ surfaced as untracked in every `git status` (and, until PR #401, blocked `erun release`).
- No tracked `.idea/` files exist in the repo, so the commented line is dead intent — uncomment it.
- `.vscode/` left commented for now; raise a follow-up if it bites anyone.

Closes #402.

## Test plan

- [x] `git status` on a checkout that contains `.idea/` shows the worktree clean (no untracked `.idea/`).