### PR TITLE
Stop EC2 first, then quit clients in idle-stop flow

### DIFF
--- a/erun-devops/docker/erun-devops/entrypoint.sh
+++ b/erun-devops/docker/erun-devops/entrypoint.sh
@@ -761,14 +761,24 @@ start_environment_idle_monitor() {
                 # Reset the log each attempt so it reflects only the latest
                 # one — empty on success, the most recent error on failure.
                 : >"${stop_log}"
-                graceful_quit_clients >>"${stop_log}" 2>&1 || true
+                # Ask AWS to stop the host first. EC2 stop-instances returns
+                # immediately with `PendingState=stopping`; the OS-level
+                # shutdown follows asynchronously, so there is plenty of
+                # window to gracefully terminate clients before power-off.
+                # Quitting clients pre-emptively would destroy the user's
+                # claude/codex state for nothing when the stop is refused
+                # (e.g. `disableApiStop=true`, missing permission), and
+                # would re-kill them on every subsequent tick.
                 if stop_cloud_host >>"${stop_log}" 2>&1; then
+                    graceful_quit_clients >>"${stop_log}" 2>&1 || true
                     exit 0
                 fi
-                # A transient AWS failure (e.g. RequestExpired) leaves the
-                # loop running; the next tick re-checks stop-ready and
-                # retries. The error stays in idle-stop.log for the desktop
-                # to surface until the next attempt overwrites it.
+                # A transient AWS failure (e.g. RequestExpired) or a
+                # permanent one (e.g. stop-protection) leaves the loop
+                # running and the user's processes untouched; the next
+                # tick re-checks stop-ready and retries. The error stays
+                # in idle-stop.log for the desktop to surface until the
+                # next attempt overwrites it.
             fi
         done
     ) &


### PR DESCRIPTION
## Summary

- The runtime idle monitor (`erun-devops/docker/erun-devops/entrypoint.sh`) used to `pkill -TERM` claude/codex on every stop-eligible tick *before* asking AWS to stop the instance. When AWS refused the stop — `disableApiStop=true`, missing permission, transient error — the user's interactive work was killed for nothing, and the next 30-second tick re-killed it.
- Reproduced on `petios/rihards-review` today: the EC2 instance has stop-protection on, `aws ec2 stop-instances` returns `OperationNotPermitted`, but by then claude had already been SIGTERM'd (exit `143`).
- Swap the order: call `stop_cloud_host` first; only `graceful_quit_clients` on success. EC2 stop is async (returns immediately with `PendingState=stopping`), so clients still get the full graceful-quit window while the OS shuts down. Refused stops now leave the user's processes untouched, and the per-tick re-kill loop is gone.

Closes #405.

## Test plan

- [x] `bash -n` syntax check on the edited entrypoint.
- [x] `make integration-test` (suite green, coverage 57.0% ≥ 55.0%) — entrypoint shell logic isn't covered by the suite; review is by inspection.
- [ ] Manual validation in a managed-cloud env after the next runtime-image release — once the new image rolls into a contribute env with `disableApiStop` set, the idle ticker should leave claude untouched while AWS keeps refusing.