### PR TITLE
Restart kubectl port-forward on early exit during contribute open

### DIFF
--- a/erun-ui/contribute_app.go
+++ b/erun-ui/contribute_app.go
@@ -26,24 +26,87 @@ import (
 //   - stopped by App.stopContributeAppForward on contribute-mode-off,
 //     env switch, or app shutdown.
 type contributeAppForward struct {
+	mu        sync.Mutex
+	gen       int
 	cmd       *exec.Cmd
-	localPort int
 	stderr    *bytes.Buffer
+	localPort int
+	exited    bool
+	stopped   bool
 }
 
-// exitedWithError reports whether the kubectl process has already
-// terminated and, if so, returns the captured stderr. Used by
-// waitForContributeAppReachable to fail fast instead of polling the
-// HTTP port for 5 minutes when kubectl is already dead.
+// newContributeAppForward wires the initial kubectl cmd into a fresh
+// forward and starts the reap goroutine that records its exit so
+// exitedWithError can read it race-free under f.mu.
+func newContributeAppForward(cmd *exec.Cmd, stderr *bytes.Buffer, localPort int) *contributeAppForward {
+	f := &contributeAppForward{cmd: cmd, stderr: stderr, localPort: localPort, gen: 1}
+	f.startReap(1, cmd)
+	return f
+}
+
+// exitedWithError reports whether the kubectl process currently held
+// by the forward has already terminated and, if so, returns the
+// captured stderr. The exit signal is published under f.mu by
+// startReap, so reads here are race-free against the cmd's I/O
+// teardown.
 func (f *contributeAppForward) exitedWithError() (bool, string) {
-	if f == nil || f.cmd == nil || f.cmd.Process == nil {
+	if f == nil {
 		return false, ""
 	}
-	if f.cmd.ProcessState == nil {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.exited {
 		return false, ""
 	}
-	msg := strings.TrimSpace(f.stderr.String())
+	msg := ""
+	if f.stderr != nil {
+		msg = strings.TrimSpace(f.stderr.String())
+	}
 	return true, msg
+}
+
+// adopt swaps in a freshly-spawned kubectl cmd and stderr buffer as
+// the forward's current process. It returns false when stop() has
+// already been called concurrently — in that case the caller must
+// kill the supplied cmd so we don't leak a kubectl process the user
+// has asked to tear down. The generation counter ensures the previous
+// cmd's late reap (it may exit after adopt swaps it out) does not
+// mark the new cmd as exited.
+func (f *contributeAppForward) adopt(cmd *exec.Cmd, stderr *bytes.Buffer) bool {
+	if f == nil {
+		return false
+	}
+	f.mu.Lock()
+	if f.stopped {
+		f.mu.Unlock()
+		return false
+	}
+	f.gen++
+	gen := f.gen
+	f.cmd = cmd
+	f.stderr = stderr
+	f.exited = false
+	f.mu.Unlock()
+	f.startReap(gen, cmd)
+	return true
+}
+
+// startReap blocks until cmd exits, then publishes the exit under
+// f.mu — but only if the forward is still on the same generation. A
+// later adopt() bumps gen, so a slow Wait() return for an old cmd
+// does not falsely mark the current cmd as exited.
+func (f *contributeAppForward) startReap(gen int, cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	go func() {
+		_ = cmd.Wait()
+		f.mu.Lock()
+		if f.gen == gen {
+			f.exited = true
+		}
+		f.mu.Unlock()
+	}()
 }
 
 // contributeAppPortReachableTimeout is generous on purpose. The first
@@ -53,82 +116,127 @@ func (f *contributeAppForward) exitedWithError() (bool, string) {
 // a cold pod that's 2-3 minutes; subsequent incremental builds are
 // ~30s. 5 minutes leaves headroom for both without being so long that
 // a genuine failure (no listener, port-forward dead) hides behind it.
-const contributeAppPortReachableTimeout = 5 * time.Minute
+//
+// Declared as vars (rather than consts) so tests can shrink them.
+var (
+	contributeAppPortReachableTimeout      = 5 * time.Minute
+	contributeAppPortReachablePollInterval = 500 * time.Millisecond
+)
 
-func (a *App) startContributeAppForward(ctx context.Context, selection uiSelection) (*contributeAppForward, int, error) {
+// spawnContributeAppForwardCmd builds and starts the kubectl
+// port-forward process. kubectl's stderr is captured so a real
+// error (no such deployment, context not in kubeconfig, host port
+// busy, refused-by-pod-with-no-listener) surfaces instead of just
+// the 5-minute reachability timeout. Reaping is owned by the
+// forward (newContributeAppForward / adopt call startReap); the
+// spawn function deliberately does not call Wait() so test fakes
+// stay symmetric with the production shape. Exposed as a var so
+// tests can substitute a fake.
+var spawnContributeAppForwardCmd = func(ctx context.Context, args []string) (*exec.Cmd, *bytes.Buffer, error) {
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	stderr := new(bytes.Buffer)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		return nil, nil, fmt.Errorf("start kubectl port-forward: %w", err)
+	}
+	return cmd, stderr, nil
+}
+
+func (a *App) startContributeAppForward(ctx context.Context, selection uiSelection) (*contributeAppForward, []string, int, error) {
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
 		Tenant:      selection.Tenant,
 		Environment: selection.Environment,
 	})
 	if err != nil {
-		return nil, 0, fmt.Errorf("resolve environment: %w", err)
+		return nil, nil, 0, fmt.Errorf("resolve environment: %w", err)
 	}
 	port := eruncommon.ContributeAppPortForResult(result)
 	if port <= 0 {
-		return nil, 0, fmt.Errorf("contribute-app port is not allocated for %s/%s", selection.Tenant, selection.Environment)
+		return nil, nil, 0, fmt.Errorf("contribute-app port is not allocated for %s/%s", selection.Tenant, selection.Environment)
 	}
 	// If something is already listening locally, reuse it. The most
 	// common case is a still-running forward from a previous click.
 	if canConnectLocalContributeAppPort(port) {
-		return nil, port, nil
+		return nil, nil, port, nil
 	}
 	args := kubectlContributeAppPortForwardArgs(result, port)
-	cmd := exec.CommandContext(ctx, "kubectl", args...)
-	stderr := new(bytes.Buffer)
-	cmd.Stdout = io.Discard
-	// Capture kubectl's stderr so we can surface a real error message
-	// when it exits early (no such deployment, context not in kubeconfig,
-	// port already in use on host, etc.) instead of staring at the
-	// 5-minute reachability timeout.
-	cmd.Stderr = stderr
-	if err := cmd.Start(); err != nil {
-		return nil, 0, fmt.Errorf("start kubectl port-forward: %w", err)
+	cmd, stderr, err := spawnContributeAppForwardCmd(ctx, args)
+	if err != nil {
+		return nil, nil, 0, err
 	}
-	forward := &contributeAppForward{cmd: cmd, localPort: port, stderr: stderr}
-	// Reap the process in a background goroutine so cmd.ProcessState is
-	// populated when (if) kubectl exits. exitedWithError() can then
-	// detect a dead forward without blocking the caller.
-	go func() {
-		_ = cmd.Wait()
-	}()
-	return forward, port, nil
+	return newContributeAppForward(cmd, stderr, port), args, port, nil
 }
 
 func (f *contributeAppForward) stop() {
-	if f == nil || f.cmd == nil || f.cmd.Process == nil {
+	if f == nil {
 		return
 	}
-	_ = f.cmd.Process.Kill()
-	// Wait is already reaped by the goroutine spawned in
-	// startContributeAppForward; calling it again here is a no-op.
+	f.mu.Lock()
+	f.stopped = true
+	cmd := f.cmd
+	f.mu.Unlock()
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+	// startReap has the Wait() goroutine; no need to Wait() here.
 }
 
 // waitForContributeAppReachable polls the local port until the headless
 // ERun app is actually serving HTTP, or the timeout expires. Using HTTP
 // (instead of plain TCP dial) is essential because kubectl port-forward
 // happily accepts TCP connections on the host even when nothing inside
-// the pod is listening — the proxied connection then drops. The
-// headless boot includes a Wails frontend build on first run, which
-// can take a while, so the timeout is generous.
+// the pod is listening — the proxied connection then drops the whole
+// forward with `error: lost connection to pod`. When that happens the
+// in-pod side is almost always still mid-rebuild and will bind a few
+// seconds later, so a fresh kubectl spawned right after will succeed.
 //
-// If forward.exitedWithError() reports kubectl is already dead the
-// wait fails immediately with kubectl's stderr so the user sees the
-// real cause instead of a generic 5-minute timeout.
-func waitForContributeAppReachable(port int, forward *contributeAppForward) error {
+// The loop therefore respawns kubectl whenever the forward exits and
+// the deadline has not yet expired, preserving the last captured
+// stderr so a genuine failure (no such deployment, host port busy,
+// context missing) still surfaces if the in-pod app never binds.
+//
+// `forward` is nil and `args` is empty in the reuse path (something is
+// already listening on the local port) — the loop then simply polls
+// HTTP without owning any kubectl lifecycle.
+func waitForContributeAppReachable(ctx context.Context, port int, forward *contributeAppForward, args []string) error {
 	deadline := time.Now().Add(contributeAppPortReachableTimeout)
+	var lastExitMsg string
 	for time.Now().Before(deadline) {
 		if canReachLocalContributeAppEndpoint(port) {
 			return nil
 		}
-		if exited, msg := forward.exitedWithError(); exited {
-			if msg == "" {
-				msg = "(no stderr captured)"
+		if forward != nil && len(args) > 0 {
+			if exited, msg := forward.exitedWithError(); exited {
+				if msg != "" {
+					lastExitMsg = msg
+				}
+				cmd, stderr, spawnErr := spawnContributeAppForwardCmd(ctx, args)
+				if spawnErr != nil {
+					return fmt.Errorf("respawn kubectl port-forward for 127.0.0.1:%d after early exit (%s): %w", port, lastExitMsgOrPlaceholder(lastExitMsg), spawnErr)
+				}
+				if !forward.adopt(cmd, stderr) {
+					if cmd.Process != nil {
+						_ = cmd.Process.Kill()
+					}
+					return fmt.Errorf("contribute-app port-forward for 127.0.0.1:%d was stopped before becoming reachable", port)
+				}
 			}
-			return fmt.Errorf("kubectl port-forward for 127.0.0.1:%d exited before the headless app was reachable: %s", port, msg)
 		}
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(contributeAppPortReachablePollInterval)
+	}
+	if lastExitMsg != "" {
+		return fmt.Errorf("contribute-app on 127.0.0.1:%d did not become reachable within %s (last kubectl exit: %s)", port, contributeAppPortReachableTimeout, lastExitMsg)
 	}
 	return fmt.Errorf("contribute-app on 127.0.0.1:%d did not become reachable within %s", port, contributeAppPortReachableTimeout)
+}
+
+func lastExitMsgOrPlaceholder(msg string) string {
+	if msg == "" {
+		return "(no stderr captured)"
+	}
+	return msg
 }
 
 // canReachLocalContributeAppEndpoint reports whether the host-side

--- a/erun-ui/contribute_app_test.go
+++ b/erun-ui/contribute_app_test.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Tests in this file pin the respawn-on-early-exit contract that
+// fixes #407 (kubectl port-forward died before the in-pod listener
+// bound, so the contribute-app open flow gave up before the headless
+// erun-app finished its CLI rebuild). They exercise
+// waitForContributeAppReachable with a fake spawn that emits
+// short-lived `sh -c` subprocesses, which keeps the exec.Cmd /
+// ProcessState integration honest without needing a real kubectl.
+
+func skipIfNoSh(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("respawn tests use /bin/sh; skipping on Windows")
+	}
+}
+
+// freeTCPPort returns a port that was bindable a moment ago. Tests
+// re-bind it on demand for the fake HTTP server; the race window
+// between this call and the re-bind is acceptable for local/CI use.
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
+// startTinyHTTPServerOn binds an HTTP server on the requested port
+// that answers `200 OK` to every request. It models the in-pod
+// `erun app --headless` server becoming reachable through the fake
+// kubectl port-forward so the HTTP probe in
+// canReachLocalContributeAppEndpoint succeeds.
+func startTinyHTTPServerOn(t *testing.T, port int) func() {
+	t.Helper()
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("bind %d: %v", port, err)
+	}
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	}
+	go func() { _ = srv.Serve(ln) }()
+	return func() { _ = srv.Close() }
+}
+
+// shrinkContributeAppTimings replaces the package's reach deadline +
+// poll interval with test-fast values, restoring originals on cleanup.
+func shrinkContributeAppTimings(t *testing.T, deadline, poll time.Duration) {
+	t.Helper()
+	origDeadline := contributeAppPortReachableTimeout
+	origPoll := contributeAppPortReachablePollInterval
+	contributeAppPortReachableTimeout = deadline
+	contributeAppPortReachablePollInterval = poll
+	t.Cleanup(func() {
+		contributeAppPortReachableTimeout = origDeadline
+		contributeAppPortReachablePollInterval = origPoll
+	})
+}
+
+// spawnPlan is the per-call recipe a test supplies to the fake
+// spawnContributeAppForwardCmd.
+type spawnPlan struct {
+	// script runs under `sh -c`. Use `exit 1` to simulate kubectl
+	// dying after a connection-refused inside the pod, or `sleep N`
+	// to simulate a live forward.
+	script string
+	// stderr is the buffer contents exitedWithError will surface for
+	// this spawn. The real kubectl writes to its captured buffer
+	// while running; the test pre-populates it because the fake
+	// subprocess doesn't.
+	stderr string
+	// onSpawn, if non-nil, runs synchronously before the cmd starts.
+	// Used to bring up the fake HTTP server on the respawn that
+	// should make the wait succeed.
+	onSpawn func()
+}
+
+// installFakeContributeSpawn replaces spawnContributeAppForwardCmd
+// with a counter-aware stub driven by `plan`. The counter is bumped
+// before each call so tests can assert how many times kubectl was
+// spawned overall.
+func installFakeContributeSpawn(t *testing.T, plan func(n int) spawnPlan, counter *int32) {
+	t.Helper()
+	orig := spawnContributeAppForwardCmd
+	spawnContributeAppForwardCmd = func(ctx context.Context, _ []string) (*exec.Cmd, *bytes.Buffer, error) {
+		n := atomic.AddInt32(counter, 1)
+		p := plan(int(n))
+		if p.onSpawn != nil {
+			p.onSpawn()
+		}
+		cmd := exec.CommandContext(ctx, "sh", "-c", p.script)
+		cmd.Stdout = io.Discard
+		if err := cmd.Start(); err != nil {
+			return nil, nil, err
+		}
+		// Reaping is owned by the forward (startReap), not the spawn
+		// fake — match the production shape so the race detector sees
+		// the same synchronisation discipline.
+		return cmd, bytes.NewBufferString(p.stderr), nil
+	}
+	t.Cleanup(func() { spawnContributeAppForwardCmd = orig })
+}
+
+// initialContributeSpawn does the first spawn the same way
+// startContributeAppForward would, returning a forward + canned args
+// the wait loop can use to respawn.
+func initialContributeSpawn(t *testing.T, port int) (*contributeAppForward, []string) {
+	t.Helper()
+	args := []string{"port-forward", "deployment/test", fmt.Sprintf("%d:%d", port, port)}
+	cmd, stderr, err := spawnContributeAppForwardCmd(context.Background(), args)
+	if err != nil {
+		t.Fatalf("initial spawn: %v", err)
+	}
+	return newContributeAppForward(cmd, stderr, port), args
+}
+
+// TestWaitForContributeAppReachableSucceedsWhenAlreadyServing covers
+// the reuse path: something is already listening on the local port
+// so the wait just polls HTTP without owning any kubectl process.
+func TestWaitForContributeAppReachableSucceedsWhenAlreadyServing(t *testing.T) {
+	shrinkContributeAppTimings(t, 2*time.Second, 25*time.Millisecond)
+	port := freeTCPPort(t)
+	closeFn := startTinyHTTPServerOn(t, port)
+	t.Cleanup(closeFn)
+
+	if err := waitForContributeAppReachable(context.Background(), port, nil, nil); err != nil {
+		t.Fatalf("expected reachable, got %v", err)
+	}
+}
+
+// TestWaitForContributeAppReachableRespawnsKubectlOnEarlyExit locks
+// the bug from #407. The first kubectl spawn dies immediately
+// (simulating kubectl's "lost connection to pod" when the in-pod
+// listener has not yet bound during the CLI rebuild window). The
+// loop must respawn and succeed once the in-pod side is up.
+func TestWaitForContributeAppReachableRespawnsKubectlOnEarlyExit(t *testing.T) {
+	skipIfNoSh(t)
+	shrinkContributeAppTimings(t, 5*time.Second, 25*time.Millisecond)
+	port := freeTCPPort(t)
+
+	var spawnCount int32
+	var srvCloseFn func()
+	installFakeContributeSpawn(t, func(n int) spawnPlan {
+		if n == 1 {
+			return spawnPlan{script: "exit 1", stderr: "error: lost connection to pod"}
+		}
+		return spawnPlan{
+			script: "sleep 60",
+			onSpawn: func() {
+				if srvCloseFn == nil {
+					srvCloseFn = startTinyHTTPServerOn(t, port)
+				}
+			},
+		}
+	}, &spawnCount)
+	t.Cleanup(func() {
+		if srvCloseFn != nil {
+			srvCloseFn()
+		}
+	})
+
+	forward, args := initialContributeSpawn(t, port)
+	t.Cleanup(forward.stop)
+
+	if err := waitForContributeAppReachable(context.Background(), port, forward, args); err != nil {
+		t.Fatalf("expected reachable after one respawn, got %v", err)
+	}
+	if n := atomic.LoadInt32(&spawnCount); n != 2 {
+		t.Errorf("expected exactly 2 spawn calls (initial + 1 respawn), got %d", n)
+	}
+}
+
+// TestWaitForContributeAppReachableTimesOutPreservesLastExit covers
+// the deadline path. kubectl keeps dying (a real failure mode: wrong
+// context, deployment missing, host port busy on the pod side). The
+// deadline error must include the last captured kubectl stderr so
+// the user sees the cause, not just a 5-minute timeout banner.
+func TestWaitForContributeAppReachableTimesOutPreservesLastExit(t *testing.T) {
+	skipIfNoSh(t)
+	shrinkContributeAppTimings(t, 250*time.Millisecond, 25*time.Millisecond)
+	port := freeTCPPort(t)
+
+	const exitStderr = "Error from server (NotFound): deployments.apps \"erun\" not found"
+	var spawnCount int32
+	installFakeContributeSpawn(t, func(_ int) spawnPlan {
+		return spawnPlan{script: "exit 1", stderr: exitStderr}
+	}, &spawnCount)
+
+	forward, args := initialContributeSpawn(t, port)
+	t.Cleanup(forward.stop)
+
+	err := waitForContributeAppReachable(context.Background(), port, forward, args)
+	if err == nil {
+		t.Fatalf("expected deadline error, got nil")
+	}
+	if !strings.Contains(err.Error(), "did not become reachable") {
+		t.Errorf("expected deadline message, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), exitStderr) {
+		t.Errorf("expected last kubectl exit (%q) in error, got %q", exitStderr, err.Error())
+	}
+	if n := atomic.LoadInt32(&spawnCount); n < 2 {
+		t.Errorf("expected at least 2 spawn calls (initial + ≥1 respawn) before timeout, got %d", n)
+	}
+}
+
+// TestStopAbortsRespawn covers the race where the user toggles
+// contribute mode off (or the env closes) while the wait is mid-
+// respawn. forward.adopt must refuse to install the new cmd, the
+// freshly-spawned kubectl must be killed, and the wait must return a
+// "stopped" error rather than burning the full deadline.
+func TestStopAbortsRespawn(t *testing.T) {
+	skipIfNoSh(t)
+	shrinkContributeAppTimings(t, 5*time.Second, 25*time.Millisecond)
+	port := freeTCPPort(t)
+
+	var spawnCount int32
+	installFakeContributeSpawn(t, func(_ int) spawnPlan {
+		return spawnPlan{script: "exit 1", stderr: "error: lost connection to pod"}
+	}, &spawnCount)
+
+	forward, args := initialContributeSpawn(t, port)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- waitForContributeAppReachable(context.Background(), port, forward, args)
+	}()
+	time.Sleep(100 * time.Millisecond)
+	forward.stop()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("expected stopped error, got nil")
+		}
+		if !strings.Contains(err.Error(), "stopped before becoming reachable") {
+			t.Errorf("expected stopped-before-reachable error, got %q", err.Error())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("wait did not return after stop()")
+	}
+}
+
+// TestAdoptRefusesAfterStop is the unit-level invariant behind
+// TestStopAbortsRespawn: once stop() has set the stopped flag,
+// subsequent adopt calls must return false so the caller can kill
+// the orphaned kubectl.
+func TestAdoptRefusesAfterStop(t *testing.T) {
+	forward := &contributeAppForward{}
+	forward.stop()
+	if forward.adopt(&exec.Cmd{}, &bytes.Buffer{}) {
+		t.Fatalf("adopt should return false after stop()")
+	}
+}

--- a/erun-ui/contribute_mode.go
+++ b/erun-ui/contribute_mode.go
@@ -183,7 +183,7 @@ func (a *App) StartContributeApp(selection uiSelection) (uiContributeAppLaunch, 
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	forward, localPort, err := a.startContributeAppForward(ctx, selection)
+	forward, args, localPort, err := a.startContributeAppForward(ctx, selection)
 	if err != nil {
 		return uiContributeAppLaunch{}, err
 	}
@@ -191,7 +191,7 @@ func (a *App) StartContributeApp(selection uiSelection) (uiContributeAppLaunch, 
 		a.contributeApps.put(selection, forward)
 	}
 	_ = result
-	if err := waitForContributeAppReachable(localPort, forward); err != nil {
+	if err := waitForContributeAppReachable(ctx, localPort, forward, args); err != nil {
 		a.stopContributeAppForward(selection)
 		return uiContributeAppLaunch{}, err
 	}


### PR DESCRIPTION
## Summary

- "Open contribute app" failed on first click during the in-pod CLI rebuild window: kubectl port-forward exited with `lost connection to pod` before the headless `erun app` bound port 17550, the desktop treated that as fatal, and Ctrl-C'd the (by-now-built) in-pod app.
- The reach-wait now respawns kubectl on each early exit until either the HTTP probe succeeds or the 5-minute deadline fires; the last kubectl stderr is preserved so genuine failures (no such deployment, host port busy, context missing) still surface.
- `contributeAppForward` now owns reaping under a mutex with a generation counter, so `adopt()` can swap the cmd without racing with the previous `Wait()`'s `ProcessState` write.

Closes #407

## UX impact review

1. **Affected paths.** `App.StartContributeApp` (Wails) → `startContributeAppForward` → `waitForContributeAppReachable`. No frontend or Wails-signature change.
2. **User-visible sequence.** Click "Open contribute app" → the in-pod `erun app --headless` rebuilds the CLI (~2s on warm pod) → desktop spawns kubectl, kubectl may die once or twice during the bind window → wait respawns silently → HTTP probe succeeds → default browser opens the contribute app URL. Failure path: deadline elapses with kubectl stderr included in the banner.
3. **State-without-affordance.** No new `AppState` mutations. The forward map remains scoped to `App.contributeApps`.
4. **Visibility of system status.** In-flight status is unchanged: the contribute ERun PTY shows the in-pod build progress; the banner shows reach failure if any. The banner text now includes the last kubectl exit message on deadline, improving the diagnostic vs. the previous generic "did not become reachable in 5m".
5. **Success / failure feedback.** Success: browser opens. Failure: banner with last kubectl exit. No silent drops.
6. **Consistency with comparable flows.** Matches the existing reach-wait shape; only the loop body changed.
7. **Heuristic pass.** Visibility/status, error prevention, recognition over recall — all improved (better error text). Other heuristics unaffected (no new control surface).
8. **Playwright coverage.** No new Playwright spec. This change is **internal helper refactor / lifecycle wiring** behind an unchanged Wails method; the affected branch requires a real kubectl + real pod that the headless harness cannot stage, so per `erun-ui/AGENTS.md` end-to-end-tests guidance the closest observable invariant is the existing `contribute.spec.ts` toggle behaviour (still passing). The respawn contract is locked down by Go unit tests:
   - `TestWaitForContributeAppReachableSucceedsWhenAlreadyServing` — reuse path
   - `TestWaitForContributeAppReachableRespawnsKubectlOnEarlyExit` — single respawn → reachable (the bug)
   - `TestWaitForContributeAppReachableTimesOutPreservesLastExit` — deadline error includes last kubectl stderr
   - `TestStopAbortsRespawn` — user toggling contribute off mid-wait aborts cleanly
   - `TestAdoptRefusesAfterStop` — unit invariant behind the above

## Test plan

- [x] `go test -race -count=10 -run 'TestWait|TestStopAborts|TestAdopt' ./erun-ui` — 10/10 stable
- [x] `go test -race -count=1 ./erun-ui/...` — full module pass with race detector
- [ ] On rihards-review (the env where the bug was reproduced): rebuild + redeploy erun-app and click "Open contribute app" with a freshly-rebuilt in-pod CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)