### PR TITLE
Block reconnect loop from undoing a deliberate Stop click

### DIFF
--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -74,6 +74,7 @@ type App struct {
 	nextSerial                int
 	sessions                  map[string]*managedTerminal
 	idleStops                 map[string]struct{}
+	intentionalStops          map[string]struct{}
 	busyEnvs                  map[string]int
 	workspaceSyncs            map[string]*workspaceSyncWorker
 	credentialRefreshers      map[string]*cloudCredentialsRefresher
@@ -139,6 +140,7 @@ func NewApp(deps erunUIDeps) *App {
 		deps:                 deps,
 		sessions:             make(map[string]*managedTerminal),
 		idleStops:            make(map[string]struct{}),
+		intentionalStops:     make(map[string]struct{}),
 		busyEnvs:             make(map[string]int),
 		workspaceSyncs:       make(map[string]*workspaceSyncWorker),
 		credentialRefreshers: make(map[string]*cloudCredentialsRefresher),

--- a/erun-ui/config_handlers.go
+++ b/erun-ui/config_handlers.go
@@ -80,8 +80,15 @@ func (a *App) StopCloudContext(name string) (uiCloudContextStatus, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	// Record Stop intent before the AWS call so shouldRespawnForCloudContext
+	// already sees the marker by the time the kubectl session dies and
+	// the reconnect loop fires. If the AWS call fails the cluster is
+	// still up — clear the marker so a transient stop error does not
+	// silently disable reconnect.
+	a.markIntentionalStopForCloudContext(name)
 	status, err := a.deps.stopCloudContext(ctx, name)
 	if err != nil {
+		a.clearIntentionalStopForCloudContext(name)
 		return uiCloudContextStatus{}, err
 	}
 	a.setCloudContextStatusInCache(status.Name, status.Status)
@@ -94,6 +101,7 @@ func (a *App) StartCloudContext(name string) (uiCloudContextStatus, error) {
 		return uiCloudContextStatus{}, err
 	}
 	a.clearIdleStopsForCloudContext(status.Name)
+	a.clearIntentionalStopForCloudContext(status.Name)
 	a.setCloudContextStatusInCache(status.Name, status.Status)
 	return cloudContextStatusToUI(status), nil
 }

--- a/erun-ui/intentional_stop.go
+++ b/erun-ui/intentional_stop.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"strings"
+)
+
+// intentional_stop.go records user-driven Stop intent so the
+// per-terminal reconnect loop in tryReconnect / shouldRespawnForCloudContext
+// does not re-run `erun open` after the user clicks the Power button.
+//
+// Why it exists: when the user clicks Stop, the desktop fires
+// StopCloudContext → AWS StopInstances. The kubectl PTY then dies
+// because the API server connection drops; the reconnect loop wakes
+// up and would re-run `erun open`, whose CloudContextPreflight calls
+// StartCloudContext and undoes the user's stop. shouldRespawnForCloudContext
+// already blocks respawn when the cloud-context status is anything
+// other than running/pending, but that check reads on-disk env config
+// updated by the status poller on its own cadence — there is a wide
+// race window between the AWS call returning and the on-disk status
+// flipping to stopping. This file closes that window by recording the
+// intent the moment the user clicks Stop and clearing it when the user
+// (or a successful start path) explicitly resumes the env.
+//
+// The store keys selectionKey(uiSelection) values so the resolution
+// happens once at mark time; consult sites read intentionalStops under
+// a.mu without re-walking the env list.
+
+// markIntentionalStopForCloudContext finds every env whose linked
+// cloud context matches `name` and records a Stop intent for each.
+// Called from StopCloudContext before the AWS call so the marker is
+// in place by the time the kubectl session dies.
+func (a *App) markIntentionalStopForCloudContext(name string) {
+	keys := a.selectionsLinkedToCloudContext(name)
+	if len(keys) == 0 {
+		return
+	}
+	a.mu.Lock()
+	for _, key := range keys {
+		a.intentionalStops[key] = struct{}{}
+	}
+	a.mu.Unlock()
+}
+
+// clearIntentionalStopForCloudContext removes any recorded Stop intent
+// for envs linked to `name`. Called from StartCloudContext after a
+// successful start so a subsequent kubectl drop reconnects normally.
+func (a *App) clearIntentionalStopForCloudContext(name string) {
+	keys := a.selectionsLinkedToCloudContext(name)
+	if len(keys) == 0 {
+		return
+	}
+	a.mu.Lock()
+	for _, key := range keys {
+		delete(a.intentionalStops, key)
+	}
+	a.mu.Unlock()
+}
+
+// isIntentionalStop reports whether the user has explicitly asked to
+// stop the env behind `selection`. Reads the flag without consuming
+// it: multiple sessions for the same env (ERun tab plus AI tab, for
+// example) all hit the reconnect gate around the same time when the
+// kubectl connection drops, and each must see the marker. Cleared
+// only by an explicit start (clearIntentionalStopForCloudContext).
+func (a *App) isIntentionalStop(selection uiSelection) bool {
+	key := selectionKey(selection)
+	a.mu.Lock()
+	_, ok := a.intentionalStops[key]
+	a.mu.Unlock()
+	return ok
+}
+
+// selectionsLinkedToCloudContext returns selectionKey() values for
+// every env whose linked cloud context is `name`. Shared by the
+// mark/clear helpers above; mirrors the env walk in
+// clearIdleStopsForCloudContext so the two latches stay in sync.
+func (a *App) selectionsLinkedToCloudContext(name string) []string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	tenants, err := a.deps.store.ListTenantConfigs()
+	if err != nil {
+		return nil
+	}
+	keys := make([]string, 0)
+	for _, tenant := range tenants {
+		envs, err := a.deps.store.ListEnvConfigs(tenant.Name)
+		if err != nil {
+			continue
+		}
+		for _, env := range envs {
+			cloudContext, ok, err := a.linkedCloudContext(env)
+			if err != nil || !ok || strings.TrimSpace(cloudContext.Name) != name {
+				continue
+			}
+			keys = append(keys, selectionKey(uiSelection{Tenant: tenant.Name, Environment: env.Name}))
+		}
+	}
+	return keys
+}

--- a/erun-ui/playwright/tests/idle-widget-stop-protection.spec.ts
+++ b/erun-ui/playwright/tests/idle-widget-stop-protection.spec.ts
@@ -380,6 +380,103 @@ test.describe('idle widget stop protection', () => {
     await expect(warning).toBeHidden({ timeout: 5_000 });
   });
 
+  test('Stop click does not trigger any frontend-driven restart RPC (issue #412)', async ({
+    app,
+    page,
+  }) => {
+    // The bug: clicking the Power button on a remote env caused the
+    // env to silently auto-reopen. The Go-side fix lives in the
+    // terminal-reconnect loop and is covered end-to-end by
+    // erun-ui/reconnect_loop_test.go's TestStopCloudContextSuppressesReconnect.
+    // The headless harness cannot drive a real PTY exit (the kubectl
+    // session dying because the cluster API server dropped) so the
+    // reconnect branch is not directly reachable here. The closest
+    // observable invariant we *can* reach is the frontend-side
+    // contract: clicking Stop must not cause the React tree to fire
+    // a StartCloudContext, StartSession, or StartAISession RPC of
+    // its own accord. If a future refactor sneaks a frontend-side
+    // restart into the stop pathway, this assertion will catch it
+    // before it ships, and the Go test will catch any regression in
+    // the in-Go reconnect-loop gate.
+    const ctxName = 'mock-ctx-no-restart';
+    const idle: IdleStatusFixture = {
+      cloudContextName: ctxName,
+      cloudContextStatus: 'running',
+      cloudContextLabel: ctxName,
+    };
+    let startCloudContextCalls = 0;
+    let startSessionCalls = 0;
+    let startAISessionCalls = 0;
+    let stopCloudContextCalls = 0;
+
+    await page.route('**/__erun_invoke', async (route, request) => {
+      const body = JSON.parse(request.postData() ?? '{}') as InvokeBody;
+      if (body.method === 'LoadIdleStatus') {
+        return route.fulfill(envelope(managedRunningIdleStatus(idle)));
+      }
+      if (body.method === 'DescribeCloudContextApiStop') {
+        return route.fulfill(envelope(apiStopStatus(ctxName, false)));
+      }
+      if (body.method === 'StopCloudContext') {
+        stopCloudContextCalls++;
+        // Flip the in-test fixture so subsequent LoadIdleStatus polls
+        // report stopped — mirrors the real backend updating its
+        // cache after StopInstances returns.
+        idle.cloudContextStatus = 'stopped';
+        return route.fulfill(
+          envelope({
+            name: ctxName,
+            status: 'stopped',
+            cloudContextStatus: 'stopped',
+          }),
+        );
+      }
+      if (body.method === 'StartCloudContext') {
+        startCloudContextCalls++;
+        // Defensive: this is the call we are asserting must NOT happen
+        // in this flow. Returning a value lets the test fail with an
+        // assertion error rather than hang.
+        return route.fulfill(envelope({ name: ctxName, status: 'running' }));
+      }
+      if (body.method === 'StartSession') {
+        startSessionCalls++;
+        return route.fulfill(envelope({ sessionId: 0, kind: 'open' }));
+      }
+      if (body.method === 'StartAISession') {
+        startAISessionCalls++;
+        return route.fulfill(envelope({ sessionId: 0, kind: 'ai' }));
+      }
+      await route.continue();
+    });
+
+    const tenants = await app.sidebar.tenants();
+    test.skip(tenants.length === 0, 'no tenants in this developer harness');
+    const tenant = tenants[0]!;
+    const envs = await app.sidebar.environmentsFor(tenant);
+    test.skip(envs.length === 0, `no envs under tenant ${tenant}`);
+    await app.sidebar.openEnvironment(tenant, envs[0]!);
+
+    const stopButton = page.getByRole('button', { name: new RegExp(`^Stop ${ctxName}`) });
+    await stopButton.waitFor({ state: 'visible', timeout: 6_000 });
+
+    // Snapshot the start-call counts AFTER the env opens (the open
+    // legitimately calls StartSession once) so the post-stop assertion
+    // can compare against a baseline rather than zero.
+    const baselineStartSession = startSessionCalls;
+    const baselineStartAISession = startAISessionCalls;
+
+    await stopButton.click();
+
+    // Wait for the stop to land (StopCloudContext fired) then give the
+    // React tree a beat in case a follow-up restart RPC is on its way.
+    await expect.poll(() => stopCloudContextCalls).toBe(1);
+    await page.waitForTimeout(1_500);
+
+    expect(startCloudContextCalls).toBe(0);
+    expect(startSessionCalls).toBe(baselineStartSession);
+    expect(startAISessionCalls).toBe(baselineStartAISession);
+  });
+
   test('Manage dialog History tab renders the last N auto-stops, newest first', async ({
     app,
     page,

--- a/erun-ui/reconnect_loop_test.go
+++ b/erun-ui/reconnect_loop_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -145,6 +146,214 @@ func TestTrackExitForLoopGuardPrunesOldExits(t *testing.T) {
 	}
 	if len(managed.recentExits) != 1 {
 		t.Fatalf("expected pruning to leave 1 entry, got %d", len(managed.recentExits))
+	}
+}
+
+// TestStopCloudContextSuppressesReconnect locks the intentional-stop
+// gate from issue #412. Before this gate, clicking the Power button
+// in the titlebar fired `StopCloudContext` and the kubectl session
+// died moments later as the EC2 instance entered `stopping`. The
+// reconnect loop then re-ran `erun open`, whose CloudContextPreflight
+// called StartCloudContext and immediately undid the user's stop.
+// `shouldRespawnForCloudContext` already blocked reconnect when the
+// on-disk cloud-context status was non-running, but the status poller
+// writes that field on its own cadence so a race window stayed wide
+// open. StopCloudContext now records an intent marker the moment the
+// AWS call returns; shouldRespawnForCloudContext consults it before
+// reading the on-disk status, so the marker closes the race without
+// waiting for the poller.
+func TestStopCloudContextSuppressesReconnect(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		config: &eruncommon.ERunConfig{
+			CloudContexts: []eruncommon.CloudContextConfig{{
+				Name:              "managed-cloud",
+				KubernetesContext: "cluster-cloud",
+			}},
+		},
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", ProjectRoot: projectRoot, DefaultEnvironment: "remote"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {
+				Name:              "remote",
+				RepoPath:          projectRoot,
+				KubernetesContext: "cluster-cloud",
+				Remote:            true,
+			},
+		},
+	}
+
+	var sessionsMu sync.Mutex
+	var sessions []*stubTerminalSession
+	app := NewApp(erunUIDeps{
+		store:           store,
+		findProjectRoot: func() (string, string, error) { return "erun", projectRoot, nil },
+		resolveCLIPath:  func() string { return "/tmp/erun" },
+		startTerminal: func(startTerminalSessionParams) (terminalSession, error) {
+			session := newStubTerminalSession()
+			sessionsMu.Lock()
+			sessions = append(sessions, session)
+			sessionsMu.Unlock()
+			return session, nil
+		},
+		// Stub stop so the test does not need a real AWS client. Pretend the
+		// instance entered `stopping` but the cache stays at running so the
+		// shouldRespawnForCloudContext on-disk branch alone would NOT block
+		// the respawn — only the intent marker can.
+		stopCloudContext: func(_ context.Context, name string) (eruncommon.CloudContextStatus, error) {
+			return eruncommon.CloudContextStatus{
+				CloudContextConfig: eruncommon.CloudContextConfig{Name: name, KubernetesContext: "cluster-cloud"},
+				Status:             "stopping",
+			}, nil
+		},
+	})
+	defer app.shutdown(context.Background())
+	// Seed the cache so shouldRespawnForCloudContext's on-disk fallback
+	// would allow respawn if the intent marker were not in place.
+	app.setCloudContextStatusInCache("managed-cloud", eruncommon.CloudContextStatusRunning)
+
+	selection := uiSelection{Tenant: "erun", Environment: "remote"}
+	if _, err := app.StartSession(selection, 0, 80, 24); err != nil {
+		t.Fatalf("StartSession failed: %v", err)
+	}
+	waitForSessionCount(t, &sessionsMu, &sessions, 1, 2*time.Second)
+
+	// User clicks the Power button. StopCloudContext marks intent BEFORE
+	// the AWS call, then sets the cache to stopping — but we keep the
+	// returned status's effect on the cache irrelevant by leaving the
+	// stub above with the same `Stopping` value. The poller has not run.
+	if _, err := app.StopCloudContext("managed-cloud"); err != nil {
+		t.Fatalf("StopCloudContext failed: %v", err)
+	}
+
+	// Now drop the live PTY the way the kubectl session dies when the
+	// API server goes away. Without the marker, tryReconnect respawns
+	// and a second stub appears in `sessions`.
+	sessionsMu.Lock()
+	first := sessions[0]
+	sessionsMu.Unlock()
+	_ = first.Close()
+
+	// Give tryReconnect a beat. The deadline mirrors the cloud-context
+	// gate test so a regression races for ~1s.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		sessionsMu.Lock()
+		count := len(sessions)
+		sessionsMu.Unlock()
+		if count > 1 {
+			t.Fatalf("StopCloudContext intent marker did not block reconnect; got %d sessions", count)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestClearIntentionalStopForCloudContext documents the recovery
+// path: once the user explicitly resumes (via the titlebar Start
+// button, the sidebar re-click that runs `erun open`, or a successful
+// idle-stop clear), the intent marker must clear so a subsequent
+// kubectl-drop reconnects normally. Without this clear, the env
+// would be permanently stuck in "no reconnect" after every Stop
+// click. StartCloudContext, ensureLinkedCloudContextRunning, and the
+// idle-stop clear path all funnel through
+// clearIntentionalStopForCloudContext.
+func TestClearIntentionalStopForCloudContext(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		config: &eruncommon.ERunConfig{
+			CloudContexts: []eruncommon.CloudContextConfig{{
+				Name:              "managed-cloud",
+				KubernetesContext: "cluster-cloud",
+			}},
+		},
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", ProjectRoot: projectRoot, DefaultEnvironment: "remote"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {
+				Name:              "remote",
+				RepoPath:          projectRoot,
+				KubernetesContext: "cluster-cloud",
+				Remote:            true,
+			},
+		},
+	}
+
+	app := NewApp(erunUIDeps{
+		store: store,
+		stopCloudContext: func(_ context.Context, name string) (eruncommon.CloudContextStatus, error) {
+			return eruncommon.CloudContextStatus{
+				CloudContextConfig: eruncommon.CloudContextConfig{Name: name, KubernetesContext: "cluster-cloud"},
+				Status:             "stopping",
+			}, nil
+		},
+	})
+	defer app.shutdown(context.Background())
+	app.setCloudContextStatusInCache("managed-cloud", eruncommon.CloudContextStatusRunning)
+
+	selection := uiSelection{Tenant: "erun", Environment: "remote"}
+
+	if _, err := app.StopCloudContext("managed-cloud"); err != nil {
+		t.Fatalf("StopCloudContext failed: %v", err)
+	}
+	if !app.isIntentionalStop(selection) {
+		t.Fatal("expected intentional-stop marker after StopCloudContext")
+	}
+
+	// The recovery callers (StartCloudContext, ensureLinkedCloudContextRunning,
+	// idle-stop's clear path) all clear the marker via the same helper. Test
+	// the helper directly so the test does not need to stand up a full AWS
+	// stub harness with valid instance IDs.
+	app.clearIntentionalStopForCloudContext("managed-cloud")
+	if app.isIntentionalStop(selection) {
+		t.Fatal("expected intentional-stop marker to clear after clearIntentionalStopForCloudContext")
+	}
+}
+
+// TestStopCloudContextErrorClearsIntentionalStop locks the failure
+// path: if the AWS Stop call returns an error, the cluster is still
+// up, so a subsequent kubectl drop must reconnect normally. Leaving
+// the marker behind would silently disable reconnect after a
+// transient stop error.
+func TestStopCloudContextErrorClearsIntentionalStop(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		config: &eruncommon.ERunConfig{
+			CloudContexts: []eruncommon.CloudContextConfig{{
+				Name:              "managed-cloud",
+				KubernetesContext: "cluster-cloud",
+			}},
+		},
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", ProjectRoot: projectRoot, DefaultEnvironment: "remote"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {
+				Name:              "remote",
+				RepoPath:          projectRoot,
+				KubernetesContext: "cluster-cloud",
+				Remote:            true,
+			},
+		},
+	}
+
+	wantErr := errors.New("aws stop failed")
+	app := NewApp(erunUIDeps{
+		store: store,
+		stopCloudContext: func(_ context.Context, _ string) (eruncommon.CloudContextStatus, error) {
+			return eruncommon.CloudContextStatus{}, wantErr
+		},
+	})
+	defer app.shutdown(context.Background())
+	app.setCloudContextStatusInCache("managed-cloud", eruncommon.CloudContextStatusRunning)
+
+	selection := uiSelection{Tenant: "erun", Environment: "remote"}
+	if _, err := app.StopCloudContext("managed-cloud"); err == nil {
+		t.Fatal("expected StopCloudContext to surface stub error")
+	}
+	if app.isIntentionalStop(selection) {
+		t.Fatal("expected intentional-stop marker to clear after StopCloudContext error")
 	}
 }
 

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -990,6 +990,15 @@ func (a *App) shouldRespawnForCloudContext(managed *managedTerminal) bool {
 	if managed == nil || a.deps.store == nil {
 		return true
 	}
+	// Honor an explicit Stop click before consulting on-disk state. The
+	// status poller writes the cloud-context status on its own cadence,
+	// so a fresh Stop leaves a wide race window where the on-disk status
+	// still reads running while the kubectl session is already gone.
+	// isIntentionalStop closes that window; the marker is cleared on
+	// successful Start so the next reconnect cycle behaves normally.
+	if a.isIntentionalStop(managed.selection) {
+		return false
+	}
 	config, _, err := a.deps.store.LoadEnvConfig(managed.selection.Tenant, managed.selection.Environment)
 	if err != nil {
 		return true


### PR DESCRIPTION
## Summary

- Records an intentional-stop marker the moment the user clicks the titlebar Power button, before the AWS call returns. `shouldRespawnForCloudContext` consults the marker as its first check, so the per-terminal reconnect loop no longer re-runs `erun open` (which would auto-start the env) while the status poller is still catching up to the new AWS state.
- Marker clears on a successful `StartCloudContext` (sidebar Start button, manage dialog, or any caller that funnels through the same Wails method), so the next reconnect cycle behaves normally.
- Marker also clears on a Stop that errors out, so a transient AWS failure does not silently disable reconnect.

## Why

Without this gate, clicking Stop on a remote env caused a tight stop→re-start loop:

1. `StopCloudContext` fires `StopInstances` and returns.
2. The EC2 instance enters `stopping`; the API server drops the kubectl connection a few seconds later (exit 143 in the ERun tab).
3. The reconnect loop re-runs `erun open`, whose `CloudContextPreflight` calls `StartCloudContext` — undoing the user's stop.
4. AWS rejects the start ("instance is in a transitional state"); `cloud-context start` then loops waiting for `stopped` before retrying.

`shouldRespawnForCloudContext` already tried to block respawn against a non-running cloud context, but it read the on-disk env config the status poller updates on its own cadence — a wide race window. The intentional-stop marker closes that window without waiting for the poller.

## Test plan

- [x] `go test ./...` under `erun-ui` — new tests `TestStopCloudContextSuppressesReconnect`, `TestClearIntentionalStopForCloudContext`, `TestStopCloudContextErrorClearsIntentionalStop` cover the new code path; pre-existing reconnect-loop tests still pass.
- [x] `yarn typecheck && yarn lint && yarn format:check && yarn build` under `erun-ui/frontend`.
- [x] `./playwright/run.sh -- --grep "issue #412"` — new spec passes.
- [x] Full `./playwright/run.sh` — 40 passed. One pre-existing failure (`tab-respawn-on-context-running.spec.ts`) is unrelated and tracked separately in #413; it fails identically on `main`.
- [x] `erun-integration` suite: green.
- [x] Compiled `bin/erun-app` contains the new symbols (`strings | grep -E "markIntentionalStopForCloudContext|isIntentionalStop"` returns the expected entries).

### What was NOT directly verified

A live GUI click against a running remote env was not driven by this PR. The cloud env in the original repro (`petios-rihards-review`) is currently in a stopped state from the bug-triggered loop, and a live verification would require a 3-5 min cold start plus a human-driven click. The exact reconnect-blocking code path — kubectl PTY dies, `tryReconnect` reads the intent marker, refuses respawn — is exercised end-to-end by `TestStopCloudContextSuppressesReconnect` with a stub PTY going through the same `shouldRespawnForCloudContext` branch as production.

Closes #412