### PR TITLE
Surface auto-stop trigger source, policy, and grace window in History tab

### DIFF
--- a/erun-cli/cmd/activity.go
+++ b/erun-cli/cmd/activity.go
@@ -155,7 +155,12 @@ func runActivityStopReady(cmd *cobra.Command, store common.OpenStore, tenant, en
 
 // emitStopReadyJSON serializes the stop-ready decision to stdout in
 // the structured shape consumed by the in-pod monitor's heartbeat
-// log line.
+// log line. On Fire the payload carries the just-cleared pending
+// state under `pendingState` so the entrypoint script can pipe it
+// straight into `record-stop --state-stdin`; the on-disk pending
+// file is gone by this point (Fire clears it for crash safety) so
+// this is the only way the audit record can recover the markers,
+// reason, grace, and policy snapshot it was armed with.
 func emitStopReadyJSON(stdout io.Writer, status common.EnvironmentIdleStatus, result common.MaybeArmOrFireIdleStopResult) error {
 	payload := stopReadyJSON{
 		StopEligible:     status.StopEligible,
@@ -167,6 +172,10 @@ func emitStopReadyJSON(stdout io.Writer, status common.EnvironmentIdleStatus, re
 	}
 	if !result.State.Since.IsZero() {
 		payload.PendingSince = result.State.Since.UTC().Format(time.RFC3339)
+	}
+	if result.Action == common.IdleStopActionFire {
+		state := result.State
+		payload.PendingState = &state
 	}
 	encoder := json.NewEncoder(stdout)
 	return encoder.Encode(payload)
@@ -196,15 +205,18 @@ func stopReadyExitForAction(status common.EnvironmentIdleStatus, result common.M
 // stopReadyJSON is the structured stdout payload emitted when
 // --json is set. The desktop reads this through the MCP `idle` tool
 // (which surfaces the same fields on EnvironmentIdleStatus); the
-// CLI form is used by the in-pod entrypoint script for monitor.log.
+// CLI form is used by the in-pod entrypoint script for monitor.log
+// and (on Fire) is piped straight into `record-stop --state-stdin`
+// so the on-disk audit row preserves the per-marker breakdown.
 type stopReadyJSON struct {
-	StopEligible     bool   `json:"stopEligible"`
-	BlockedReason    string `json:"blockedReason,omitempty"`
-	Action           string `json:"action"`
-	PendingSince     string `json:"pendingSince,omitempty"`
-	SecondsRemaining int64  `json:"secondsRemaining"`
-	GraceSeconds     int64  `json:"graceSeconds"`
-	ReasonSummary    string `json:"reasonSummary,omitempty"`
+	StopEligible     bool                           `json:"stopEligible"`
+	BlockedReason    string                         `json:"blockedReason,omitempty"`
+	Action           string                         `json:"action"`
+	PendingSince     string                         `json:"pendingSince,omitempty"`
+	SecondsRemaining int64                          `json:"secondsRemaining"`
+	GraceSeconds     int64                          `json:"graceSeconds"`
+	ReasonSummary    string                         `json:"reasonSummary,omitempty"`
+	PendingState     *common.EnvironmentStopPending `json:"pendingState,omitempty"`
 }
 
 // newActivityCancelStopPendingCmd removes the stop-pending.json file
@@ -234,67 +246,143 @@ func newActivityCancelStopPendingCmd() *cobra.Command {
 
 // newActivityRecordStopCmd appends a stop entry to stop-history.json
 // for the named env. Called by the in-pod monitor's entrypoint.sh
-// after `stop_cloud_host` succeeds, and by the desktop's manual
-// Stop button after it observes the env transition to stopped.
-// Either caller passes the snapshot from stop-pending.json so the
-// per-marker breakdown survives the round-trip; if the file is
-// missing (e.g. a manual stop without prior grace), the record
-// carries an empty markers list and the reason flag value.
+// after `stop_cloud_host` succeeds (--source pod-monitor, piped
+// the stop-ready JSON via --state-stdin) and by the desktop's
+// manual Stop button via the idle_stop_record MCP tool (--source
+// host-manual). The source flag is what distinguishes the two on
+// the History tab.
+//
+// Pending-state recovery falls back in three layers so a History
+// row always has the richest data available:
+//
+//  1. --state-stdin parses a stop-ready --json blob piped on stdin.
+//     This is the in-pod monitor's path: stop-ready's Fire branch
+//     clears the on-disk pending file before record-stop runs, so
+//     stdin is the only way to recover markers/policy/grace.
+//  2. Otherwise, if stop-pending.json still exists on disk (the
+//     manual-stop-during-armed-grace case), use it.
+//  3. Otherwise (manual stop with no grace ever armed) the row
+//     carries just the reason and source.
 func newActivityRecordStopCmd() *cobra.Command {
 	var tenant string
 	var environment string
 	var reason string
 	var cloudContextName string
+	var source string
+	var stateStdin bool
 	cmd := &cobra.Command{
 		Use:  "record-stop",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			tenant = strings.TrimSpace(tenant)
-			environment = strings.TrimSpace(environment)
-			if tenant == "" || environment == "" {
-				return fmt.Errorf("tenant and environment are required")
-			}
-			now := time.Now().UTC()
-			entry := common.EnvironmentStopHistoryEntry{
-				StoppedAt:        now,
-				Reason:           strings.TrimSpace(reason),
-				CloudContextName: strings.TrimSpace(cloudContextName),
-			}
-			pending, ok, err := common.LoadEnvironmentStopPending(tenant, environment)
-			if err != nil {
-				return err
-			}
-			if ok {
-				entry.GraceSeconds = pending.GraceSeconds
-				if entry.Reason == "" {
-					entry.Reason = pending.ReasonSummary
-				}
-				if entry.CloudContextName == "" {
-					entry.CloudContextName = pending.CloudContextName
-				}
-				for _, marker := range pending.Markers {
-					entry.Markers = append(entry.Markers, common.EnvironmentStopHistoryMarker{
-						Name:           marker.Name,
-						Idle:           marker.Idle,
-						Reason:         marker.Reason,
-						SecondsIdleFor: secondsIdleForMarker(marker, pending.Since),
-					})
-				}
-			}
-			if err := common.AppendStopHistoryEntry(tenant, environment, entry); err != nil {
-				return err
-			}
-			// Clear the pending file once we've persisted the
-			// audit record so a follow-up `stop-ready` call after
-			// the env restarts arms a fresh grace window from
-			// scratch rather than reusing the stale entry.
-			return common.ClearEnvironmentStopPending(tenant, environment)
+			return runActivityRecordStop(cmd, tenant, environment, reason, cloudContextName, source, stateStdin)
 		},
 	}
 	addActivityTargetFlags(cmd, &tenant, &environment)
 	cmd.Flags().StringVar(&reason, "reason", "", "Reason summary to record (defaults to the pending entry's reason)")
 	cmd.Flags().StringVar(&cloudContextName, "cloud-context", "", "Cloud context name to record (defaults to the pending entry's value)")
+	cmd.Flags().StringVar(&source, "source", "", "Where the stop originated: 'pod-monitor' (in-pod idle loop) or 'host-manual' (desktop Stop button)")
+	cmd.Flags().BoolVar(&stateStdin, "state-stdin", false, "Read a stop-ready --json blob from stdin to recover the per-marker breakdown the in-pod monitor just consumed")
 	return cmd
+}
+
+func runActivityRecordStop(cmd *cobra.Command, tenant, environment, reason, cloudContextName, source string, stateStdin bool) error {
+	tenant = strings.TrimSpace(tenant)
+	environment = strings.TrimSpace(environment)
+	if tenant == "" || environment == "" {
+		return fmt.Errorf("tenant and environment are required")
+	}
+	source = normalizeStopHistorySource(source)
+	pending, havePending, err := loadPendingForRecord(commandContext(cmd).Stdin, stateStdin, tenant, environment)
+	if err != nil {
+		return err
+	}
+	entry := buildStopHistoryEntry(time.Now().UTC(), source, reason, cloudContextName, pending, havePending)
+	if err := common.AppendStopHistoryEntry(tenant, environment, entry); err != nil {
+		return err
+	}
+	// Clear the pending file once we've persisted the
+	// audit record so a follow-up `stop-ready` call after
+	// the env restarts arms a fresh grace window from
+	// scratch rather than reusing the stale entry.
+	return common.ClearEnvironmentStopPending(tenant, environment)
+}
+
+// loadPendingForRecord recovers the pending stop entry from stdin
+// (preferred — survives the Fire branch clearing the on-disk file)
+// or from the on-disk pending file as a fallback. Returns ok=false
+// with no error when neither source is available, which is the
+// expected case for a manual stop without prior grace.
+func loadPendingForRecord(stdin io.Reader, stateStdin bool, tenant, environment string) (common.EnvironmentStopPending, bool, error) {
+	if stateStdin {
+		body, err := io.ReadAll(stdin)
+		if err != nil {
+			return common.EnvironmentStopPending{}, false, fmt.Errorf("read --state-stdin: %w", err)
+		}
+		if len(strings.TrimSpace(string(body))) == 0 {
+			return common.EnvironmentStopPending{}, false, nil
+		}
+		var payload stopReadyJSON
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return common.EnvironmentStopPending{}, false, fmt.Errorf("parse --state-stdin: %w", err)
+		}
+		if payload.PendingState == nil {
+			return common.EnvironmentStopPending{}, false, nil
+		}
+		return *payload.PendingState, true, nil
+	}
+	pending, ok, err := common.LoadEnvironmentStopPending(tenant, environment)
+	if err != nil {
+		return common.EnvironmentStopPending{}, false, err
+	}
+	return pending, ok, nil
+}
+
+// buildStopHistoryEntry assembles the entry from the optional
+// pending state and the flag-supplied overrides. Kept pure so the
+// CLI command can stay a thin Cobra adapter and integration
+// goldens can lock the resulting on-disk shape.
+func buildStopHistoryEntry(now time.Time, source, reason, cloudContextName string, pending common.EnvironmentStopPending, havePending bool) common.EnvironmentStopHistoryEntry {
+	entry := common.EnvironmentStopHistoryEntry{
+		StoppedAt:        now,
+		Source:           source,
+		Reason:           strings.TrimSpace(reason),
+		CloudContextName: strings.TrimSpace(cloudContextName),
+	}
+	if !havePending {
+		return entry
+	}
+	entry.GraceSeconds = pending.GraceSeconds
+	entry.ArmedAt = pending.Since
+	entry.Policy = pending.Policy
+	if entry.Reason == "" {
+		entry.Reason = pending.ReasonSummary
+	}
+	if entry.CloudContextName == "" {
+		entry.CloudContextName = pending.CloudContextName
+	}
+	for _, marker := range pending.Markers {
+		entry.Markers = append(entry.Markers, common.EnvironmentStopHistoryMarker{
+			Name:           marker.Name,
+			Idle:           marker.Idle,
+			Reason:         marker.Reason,
+			SecondsIdleFor: secondsIdleForMarker(marker, pending.Since),
+		})
+	}
+	return entry
+}
+
+// normalizeStopHistorySource accepts the two stable string values
+// (pod-monitor / host-manual) plus the empty fallback. Any other
+// value is silently coerced to empty so old runtime images writing
+// without a source flag do not crash the audit append.
+func normalizeStopHistorySource(source string) string {
+	source = strings.TrimSpace(source)
+	switch source {
+	case common.StopHistorySourcePodMonitor, common.StopHistorySourceHostManual:
+		return source
+	default:
+		return ""
+	}
 }
 
 // secondsIdleForMarker reports how long marker has been idle as of

--- a/erun-common/idle_stop_pending.go
+++ b/erun-common/idle_stop_pending.go
@@ -42,7 +42,20 @@ type EnvironmentStopPending struct {
 	CloudContextName string                  `json:"cloudContextName,omitempty"`
 	ReasonSummary    string                  `json:"reasonSummary,omitempty"`
 	Markers          []EnvironmentIdleMarker `json:"markers,omitempty"`
+	// Policy is the resolved idle policy at the moment the grace
+	// window was armed. Threaded into the history record on fire so
+	// History rows can answer "what was the timeout when this fired?"
+	// even after the user later edits the policy.
+	Policy EnvironmentIdlePolicy `json:"policy"`
 }
+
+// Source values for EnvironmentStopHistoryEntry.Source. Stable
+// strings — the desktop renders them as a row badge and the
+// idle_stop_record MCP tool validates against them.
+const (
+	StopHistorySourcePodMonitor = "pod-monitor"
+	StopHistorySourceHostManual = "host-manual"
+)
 
 // EnvironmentStopHistoryEntry is one row in the
 // <home>/.erun/<tenant>/<env>/stop-history.json array. Each entry
@@ -50,12 +63,23 @@ type EnvironmentStopPending struct {
 // the moment the actual stop fired, so a user reading the History
 // tab can answer "why did my env stop?" — and "why has it stopped
 // repeatedly?" — without trawling logs.
+//
+// Source distinguishes auto-stops fired by the in-pod idle monitor
+// (entrypoint.sh's stop-ready loop) from manual stops fired by the
+// desktop's Stop button. ArmedAt is the moment the grace window
+// began — only set on pod-monitor stops; host-manual entries leave
+// it zero. Policy snapshots the resolved idle policy at arm/fire
+// time so a History row stays interpretable after the user later
+// edits the timeout or working hours.
 type EnvironmentStopHistoryEntry struct {
-	StoppedAt        time.Time                       `json:"stoppedAt"`
-	GraceSeconds     int64                           `json:"graceSeconds"`
-	Reason           string                          `json:"reason"`
-	CloudContextName string                          `json:"cloudContextName,omitempty"`
-	Markers          []EnvironmentStopHistoryMarker  `json:"markers,omitempty"`
+	StoppedAt        time.Time                      `json:"stoppedAt"`
+	ArmedAt          time.Time                      `json:"armedAt,omitzero"`
+	GraceSeconds     int64                          `json:"graceSeconds"`
+	Source           string                         `json:"source,omitempty"`
+	Reason           string                         `json:"reason"`
+	CloudContextName string                         `json:"cloudContextName,omitempty"`
+	Policy           EnvironmentIdlePolicy          `json:"policy,omitzero"`
+	Markers          []EnvironmentStopHistoryMarker `json:"markers,omitempty"`
 }
 
 // EnvironmentStopHistoryMarker mirrors EnvironmentIdleMarker's
@@ -131,6 +155,7 @@ func MaybeArmOrFireIdleStop(params MaybeArmOrFireIdleStopParams) (MaybeArmOrFire
 			CloudContextName: strings.TrimSpace(params.CloudContextName),
 			ReasonSummary:    strings.TrimSpace(params.ReasonSummary),
 			Markers:          cloneIdleMarkersForPending(params.Status.Markers),
+			Policy:           params.Status.Policy,
 		}
 		if err := SaveEnvironmentStopPending(tenant, environment, armed); err != nil {
 			return MaybeArmOrFireIdleStopResult{}, err

--- a/erun-devops/docker/erun-devops/entrypoint.sh
+++ b/erun-devops/docker/erun-devops/entrypoint.sh
@@ -794,16 +794,20 @@ start_environment_idle_monitor() {
                 # would re-kill them on every subsequent tick.
                 if stop_cloud_host >>"${stop_log}" 2>&1; then
                     # Persist the audit record before we hand off to
-                    # graceful_quit_clients. `erun activity record-stop`
-                    # reads stop-pending.json (which the same stop-ready
-                    # call just consumed) to recover the per-marker
-                    # breakdown, then writes stop-history.json + clears
-                    # the pending file. Best-effort — a failure here
-                    # does not block the EC2 stop because the AWS call
-                    # has already succeeded.
-                    erun activity record-stop \
+                    # graceful_quit_clients. We pipe the captured
+                    # stop-ready JSON into `record-stop --state-stdin`
+                    # because the Fire branch of `stop-ready` cleared
+                    # stop-pending.json for crash-safety, so the
+                    # in-memory state in `check_json` is the only
+                    # surviving source of markers/reason/grace/policy.
+                    # Best-effort — a failure here does not block the
+                    # EC2 stop because the AWS call has already
+                    # succeeded.
+                    printf '%s\n' "${check_json}" | erun activity record-stop \
                         --tenant "${ERUN_TENANT}" \
                         --environment "${ERUN_ENVIRONMENT}" \
+                        --source pod-monitor \
+                        --state-stdin \
                         >>"${stop_log}" 2>&1 || true
                     graceful_quit_clients >>"${stop_log}" 2>&1 || true
                     exit 0

--- a/erun-integration/activity_test.go
+++ b/erun-integration/activity_test.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -137,6 +139,123 @@ func TestActivity(t *testing.T) {
 		}
 		if result.ExitCode == 0 {
 			t.Errorf("expected non-zero exit for blocked env, got 0:\n%s", result.Combined)
+		}
+	})
+
+	t.Run("record_stop_folds_state_stdin_into_history", func(t *testing.T) {
+		// The in-pod monitor pipes the stop-ready --json blob into
+		// `record-stop --state-stdin --source pod-monitor` because the
+		// Fire branch of stop-ready has already cleared
+		// stop-pending.json by the time record-stop runs. This
+		// scenario locks that contract end-to-end: pipe a synthetic
+		// stop-ready JSON in, then read the resulting
+		// stop-history.json off the per-env runtime state dir and
+		// assert source/grace/policy/markers all made the round trip
+		// — which is what the History tab needs to answer "what
+		// triggered it?"
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		stdin := `{
+  "stopEligible": true,
+  "action": "fire",
+  "graceSeconds": 600,
+  "reasonSummary": "idle: terminal-stdin, ai",
+  "pendingState": {
+    "since": "2026-05-31T12:20:00Z",
+    "graceSeconds": 600,
+    "cloudContextName": "mock-cluster",
+    "reasonSummary": "idle: terminal-stdin, ai",
+    "policy": {
+      "timeout": 600000000000,
+      "workingHours": "09:00-18:00",
+      "timezone": "Europe/Riga",
+      "idleTrafficBytes": 0
+    },
+    "markers": [
+      {"name": "terminal-stdin", "idle": true, "reason": "no input"},
+      {"name": "ai", "idle": true, "reason": "no Claude session"}
+    ]
+  }
+}`
+		result := erun.Run(t, []string{
+			"activity", "record-stop",
+			"--tenant", "team",
+			"--environment", "dev",
+			"--source", "pod-monitor",
+			"--state-stdin",
+		}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: stdin})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		body, err := os.ReadFile(filepath.Join(setup.Home, ".erun", "team", "dev", "stop-history.json"))
+		if err != nil {
+			t.Fatalf("read stop-history.json: %v", err)
+		}
+		text := string(body)
+		// Source must be the value supplied via the flag — that is
+		// the field the History tab uses to render the row badge.
+		if !strings.Contains(text, `"source": "pod-monitor"`) {
+			t.Errorf("expected source=pod-monitor in history, got:\n%s", text)
+		}
+		// Grace + reason + cloud context must all fold from the
+		// piped pending payload — the on-disk pending file is
+		// already gone by the time the monitor calls record-stop.
+		if !strings.Contains(text, `"graceSeconds": 600`) {
+			t.Errorf("expected graceSeconds=600 carried through stdin, got:\n%s", text)
+		}
+		if !strings.Contains(text, `"reason": "idle: terminal-stdin, ai"`) {
+			t.Errorf("expected reason carried from pending, got:\n%s", text)
+		}
+		if !strings.Contains(text, `"cloudContextName": "mock-cluster"`) {
+			t.Errorf("expected cloud context name from pending, got:\n%s", text)
+		}
+		// Policy snapshot + markers must survive the round trip.
+		if !strings.Contains(text, `"workingHours": "09:00-18:00"`) {
+			t.Errorf("expected working-hours snapshot, got:\n%s", text)
+		}
+		if !strings.Contains(text, `"name": "terminal-stdin"`) || !strings.Contains(text, `"name": "ai"`) {
+			t.Errorf("expected per-marker breakdown carried through, got:\n%s", text)
+		}
+	})
+
+	t.Run("record_stop_host_manual_without_pending", func(t *testing.T) {
+		// Manual desktop stop without a prior armed grace. No stdin,
+		// no pending file on disk — the resulting row should still
+		// land with source=host-manual and the explicit reason
+		// flagged through. This is the bare path the desktop's Stop
+		// button takes when the user has not let the idle policy
+		// build any grace.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{
+			"activity", "record-stop",
+			"--tenant", "team",
+			"--environment", "dev",
+			"--source", "host-manual",
+			"--reason", "Manual stop via desktop",
+		}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		body, err := os.ReadFile(filepath.Join(setup.Home, ".erun", "team", "dev", "stop-history.json"))
+		if err != nil {
+			t.Fatalf("read stop-history.json: %v", err)
+		}
+		text := string(body)
+		if !strings.Contains(text, `"source": "host-manual"`) {
+			t.Errorf("expected source=host-manual, got:\n%s", text)
+		}
+		if !strings.Contains(text, `"reason": "Manual stop via desktop"`) {
+			t.Errorf("expected explicit reason carried through, got:\n%s", text)
+		}
+		// Without a pending file the row carries no grace, no
+		// armedAt, and no policy. Those fields are JSON-omitempty so
+		// they should not appear at all.
+		if strings.Contains(text, `"armedAt"`) {
+			t.Errorf("expected no armedAt without pending, got:\n%s", text)
+		}
+		if strings.Contains(text, `"policy"`) {
+			t.Errorf("expected no policy snapshot without pending, got:\n%s", text)
 		}
 	})
 }

--- a/erun-integration/testdata/release/dry_run_includes_linux_release_scripts.txt
+++ b/erun-integration/testdata/release/dry_run_includes_linux_release_scripts.txt
@@ -17,6 +17,8 @@ git -C <TMP> show-ref --verify --quiet refs/heads/develop
 release: develop branch "develop" exists = true
 release: branch=develop mode=candidate version=<VERSION>
 docker image: ghcr.io/sophium/api:<VERSION>
+git -C <TMP> status --porcelain --untracked-files=no
+release: worktree clean = true
 stage: sync-remote
 cd <TMP> && git fetch origin
 cd <TMP> && git rebase origin/develop

--- a/erun-mcp/idle_stop.go
+++ b/erun-mcp/idle_stop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	eruncommon "github.com/sophium/erun/erun-common"
@@ -80,4 +81,93 @@ func idleStopHistoryTool(runtime RuntimeConfig) func(context.Context, *mcp.CallT
 			Entries:     entries,
 		}, nil
 	}
+}
+
+// IdleStopRecordInput captures the inputs for a host-driven stop
+// audit record. The desktop calls this from StopCloudContext after
+// the AWS stop succeeds; the tool runs in the pod so the on-disk
+// write lands on the shared home PVC alongside the in-pod monitor's
+// auto-stop records. Reason is free-form (the desktop sends "Manual
+// stop via desktop"); CloudContextName helps disambiguate when one
+// env spans multiple cloud-context links over its lifetime.
+type IdleStopRecordInput struct {
+	Tenant           string `json:"tenant,omitempty" jsonschema:"tenant whose environment should have a stop entry recorded; defaults to the server tenant context"`
+	Environment      string `json:"environment,omitempty" jsonschema:"environment to record against; defaults to the server environment context"`
+	Reason           string `json:"reason,omitempty" jsonschema:"reason text rendered on the History row; empty falls back to a generic 'Manual stop'"`
+	CloudContextName string `json:"cloudContextName,omitempty" jsonschema:"cloud context name the stop targeted; informational"`
+}
+
+// IdleStopRecordResult echoes back the resolved tenant/environment
+// and the timestamp the new row carries, so the desktop can match
+// its eventual LoadStopHistory result against the row it just
+// recorded.
+type IdleStopRecordResult struct {
+	Tenant      string    `json:"tenant"`
+	Environment string    `json:"environment"`
+	StoppedAt   time.Time `json:"stoppedAt"`
+}
+
+func idleStopRecordTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, IdleStopRecordInput) (*mcp.CallToolResult, IdleStopRecordResult, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input IdleStopRecordInput) (*mcp.CallToolResult, IdleStopRecordResult, error) {
+		tenant := firstNonEmpty(input.Tenant, runtime.Context.Tenant)
+		environment := firstNonEmpty(input.Environment, runtime.Context.Environment)
+		if strings.TrimSpace(tenant) == "" || strings.TrimSpace(environment) == "" {
+			return nil, IdleStopRecordResult{}, fmt.Errorf("tenant and environment are required")
+		}
+		reason := strings.TrimSpace(input.Reason)
+		if reason == "" {
+			reason = "Manual stop"
+		}
+		now := time.Now().UTC()
+		entry := eruncommon.EnvironmentStopHistoryEntry{
+			StoppedAt:        now,
+			Source:           eruncommon.StopHistorySourceHostManual,
+			Reason:           reason,
+			CloudContextName: strings.TrimSpace(input.CloudContextName),
+		}
+		// Preserve the per-marker breakdown when the user clicks
+		// Stop while an idle grace window is already armed — the
+		// row then shows both "manual" and what would have fired
+		// it on its own. Missing pending file is fine; this is a
+		// manual stop without prior grace.
+		if pending, ok, err := eruncommon.LoadEnvironmentStopPending(tenant, environment); err != nil {
+			return nil, IdleStopRecordResult{}, err
+		} else if ok {
+			entry.GraceSeconds = pending.GraceSeconds
+			entry.ArmedAt = pending.Since
+			entry.Policy = pending.Policy
+			if entry.CloudContextName == "" {
+				entry.CloudContextName = pending.CloudContextName
+			}
+			for _, marker := range pending.Markers {
+				entry.Markers = append(entry.Markers, stopHistoryMarkerFromPending(marker, pending.Since))
+			}
+		}
+		if err := eruncommon.AppendStopHistoryEntry(tenant, environment, entry); err != nil {
+			return nil, IdleStopRecordResult{}, err
+		}
+		if err := eruncommon.ClearEnvironmentStopPending(tenant, environment); err != nil {
+			return nil, IdleStopRecordResult{}, err
+		}
+		return nil, IdleStopRecordResult{
+			Tenant:      tenant,
+			Environment: environment,
+			StoppedAt:   now,
+		}, nil
+	}
+}
+
+func stopHistoryMarkerFromPending(marker eruncommon.EnvironmentIdleMarker, since time.Time) eruncommon.EnvironmentStopHistoryMarker {
+	out := eruncommon.EnvironmentStopHistoryMarker{
+		Name:   marker.Name,
+		Idle:   marker.Idle,
+		Reason: marker.Reason,
+	}
+	if !marker.LastActivity.IsZero() {
+		delta := int64(since.Sub(marker.LastActivity).Seconds())
+		if delta > 0 {
+			out.SecondsIdleFor = delta
+		}
+	}
+	return out
 }

--- a/erun-mcp/idle_stop_test.go
+++ b/erun-mcp/idle_stop_test.go
@@ -1,0 +1,153 @@
+package erunmcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// TestIdleStopRecordToolWritesHostManualEntry covers the happy path
+// the desktop's Stop button takes: no prior idle grace armed, plain
+// reason text, single tenant/env. The recorded row must carry the
+// host-manual source so the History tab renders it under the
+// "Desktop manual stop" label.
+func TestIdleStopRecordToolWritesHostManualEntry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	runtime := RuntimeConfig{Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"}}
+	handler := idleStopRecordTool(runtime)
+
+	_, result, err := handler(context.Background(), nil, IdleStopRecordInput{
+		Reason:           "Manual stop via desktop",
+		CloudContextName: "mock-cluster",
+	})
+	if err != nil {
+		t.Fatalf("idleStopRecordTool returned err: %v", err)
+	}
+	if result.Tenant != "tenant-a" || result.Environment != "dev" {
+		t.Fatalf("unexpected resolved target: %+v", result)
+	}
+	if time.Since(result.StoppedAt) > 5*time.Second {
+		t.Fatalf("StoppedAt should be near time.Now(), got %v", result.StoppedAt)
+	}
+
+	entries, err := eruncommon.LoadEnvironmentStopHistory("tenant-a", "dev")
+	if err != nil {
+		t.Fatalf("LoadEnvironmentStopHistory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 history entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.Source != eruncommon.StopHistorySourceHostManual {
+		t.Fatalf("expected source=%q, got %q", eruncommon.StopHistorySourceHostManual, entry.Source)
+	}
+	if entry.Reason != "Manual stop via desktop" {
+		t.Fatalf("expected reason carried through, got %q", entry.Reason)
+	}
+	if entry.CloudContextName != "mock-cluster" {
+		t.Fatalf("expected cloud context name carried through, got %q", entry.CloudContextName)
+	}
+	if entry.GraceSeconds != 0 {
+		t.Fatalf("expected GraceSeconds=0 without prior arm, got %d", entry.GraceSeconds)
+	}
+	if !entry.ArmedAt.IsZero() {
+		t.Fatalf("expected ArmedAt zero without prior arm, got %v", entry.ArmedAt)
+	}
+}
+
+// TestIdleStopRecordToolFoldsPendingArmedGrace covers the
+// manual-stop-during-armed-grace case: when the user clicks Stop
+// while the in-pod monitor has already armed a grace window, the
+// recorded row should still be host-manual but include the marker
+// breakdown, the armed-at timestamp, and the policy snapshot. That
+// lets the History tab show what *would* have fired alongside the
+// fact that the user pre-empted it.
+func TestIdleStopRecordToolFoldsPendingArmedGrace(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	pending := eruncommon.EnvironmentStopPending{
+		Since:            time.Now().Add(-5 * time.Minute).UTC(),
+		GraceSeconds:     600,
+		CloudContextName: "mock-cluster",
+		ReasonSummary:    "idle: terminal-stdin, ai",
+		Markers: []eruncommon.EnvironmentIdleMarker{
+			{Name: "terminal-stdin", Idle: true, Reason: "no input", LastActivity: time.Now().Add(-15 * time.Minute).UTC()},
+			{Name: "ai", Idle: true, Reason: "no Claude session", LastActivity: time.Now().Add(-12 * time.Minute).UTC()},
+		},
+		Policy: eruncommon.EnvironmentIdlePolicy{
+			Timeout:      10 * time.Minute,
+			WorkingHours: "09:00-18:00",
+			Timezone:     "Europe/Riga",
+		},
+	}
+	if err := eruncommon.SaveEnvironmentStopPending("tenant-a", "dev", pending); err != nil {
+		t.Fatalf("SaveEnvironmentStopPending: %v", err)
+	}
+
+	runtime := RuntimeConfig{Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"}}
+	handler := idleStopRecordTool(runtime)
+
+	if _, _, err := handler(context.Background(), nil, IdleStopRecordInput{
+		Reason: "Manual stop via desktop",
+	}); err != nil {
+		t.Fatalf("idleStopRecordTool returned err: %v", err)
+	}
+
+	entries, err := eruncommon.LoadEnvironmentStopHistory("tenant-a", "dev")
+	if err != nil {
+		t.Fatalf("LoadEnvironmentStopHistory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 history entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.Source != eruncommon.StopHistorySourceHostManual {
+		t.Fatalf("expected source=host-manual even with armed grace, got %q", entry.Source)
+	}
+	if entry.GraceSeconds != 600 {
+		t.Fatalf("expected GraceSeconds folded from pending, got %d", entry.GraceSeconds)
+	}
+	if entry.ArmedAt.IsZero() {
+		t.Fatal("expected ArmedAt to carry pending.Since")
+	}
+	if entry.CloudContextName != "mock-cluster" {
+		t.Fatalf("expected cloud context name from pending, got %q", entry.CloudContextName)
+	}
+	if entry.Policy.Timeout != 10*time.Minute {
+		t.Fatalf("expected policy snapshot folded, got %+v", entry.Policy)
+	}
+	if len(entry.Markers) != 2 {
+		t.Fatalf("expected 2 markers, got %d", len(entry.Markers))
+	}
+	// The pending file should be cleared after the record so a
+	// follow-up stop-ready tick arms a fresh grace from scratch.
+	pendingPath, err := eruncommon.EnvironmentStopPendingPath("tenant-a", "dev")
+	if err != nil {
+		t.Fatalf("EnvironmentStopPendingPath: %v", err)
+	}
+	if _, err := os.Stat(pendingPath); !os.IsNotExist(err) {
+		t.Fatalf("expected pending file cleared, stat err=%v", err)
+	}
+	// Sanity: the file is genuinely in the temp HOME, not the
+	// developer's real HOME.
+	if !filepath.HasPrefix(pendingPath, home) {
+		t.Fatalf("pending path escapes temp HOME: %s", pendingPath)
+	}
+}
+
+// TestIdleStopRecordToolRequiresTenantAndEnvironment guards against
+// the desktop calling the tool before it has resolved an env target.
+func TestIdleStopRecordToolRequiresTenantAndEnvironment(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	handler := idleStopRecordTool(RuntimeConfig{})
+	if _, _, err := handler(context.Background(), nil, IdleStopRecordInput{}); err == nil {
+		t.Fatal("expected error when tenant and environment are both empty")
+	}
+}

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -163,6 +163,10 @@ func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig) *mcp.Server {
 		Description: "Return the last N (cap 10) auto-stop audit entries for the env, newest first. Each row carries the per-marker idle/active breakdown captured when the auto-stop grace was armed.",
 	}, idleStopHistoryTool(runtime))
 	mcp.AddTool(server, &mcp.Tool{
+		Name:        "idle_stop_record",
+		Description: "Record a host-driven stop entry in stop-history.json (source=host-manual). Called by the desktop's Stop button after the AWS stop succeeds, so the History tab can also explain 'you clicked Stop' alongside the in-pod monitor's auto-stops.",
+	}, idleStopRecordTool(runtime))
+	mcp.AddTool(server, &mcp.Tool{
 		Name:        "cloud_list",
 		Description: "List configured root-level cloud provider aliases and token status",
 	}, cloudListTool(runtime))

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -166,7 +166,7 @@ func TestHTTPHandlerExposesVersionTool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTools failed: %v", err)
 	}
-	if len(tools.Tools) != 26 {
+	if len(tools.Tools) != 27 {
 		t.Fatalf("unexpected tools: %+v", tools.Tools)
 	}
 

--- a/erun-ui/config_handlers.go
+++ b/erun-ui/config_handlers.go
@@ -92,6 +92,12 @@ func (a *App) StopCloudContext(name string) (uiCloudContextStatus, error) {
 		return uiCloudContextStatus{}, err
 	}
 	a.setCloudContextStatusInCache(status.Name, status.Status)
+	// Best-effort: record one host-manual entry in each linked env's
+	// stop-history.json so the History tab shows "you clicked Stop"
+	// alongside the in-pod monitor's auto-stops. Failures are logged
+	// to the activity queue and ignored — the AWS stop has already
+	// succeeded, so the user-visible action is complete.
+	a.recordManualStopForCloudContext(ctx, status.Name)
 	return cloudContextStatusToUI(status), nil
 }
 

--- a/erun-ui/frontend/src/components/app/ManageDialogHistoryTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogHistoryTab.tsx
@@ -2,23 +2,33 @@ import { History } from 'lucide-react';
 import * as React from 'react';
 
 import { readError } from '@/app/errors';
-import type { UILastStopEvent, UILastStopMarker, UISelection } from '@/types';
+import type { UIIdlePolicy, UILastStopEvent, UILastStopMarker, UISelection } from '@/types';
 
 import { LoadStopHistory } from '../../../wailsjs/go/main/App';
 
-// HistoryTab renders the last N auto-stop events for the selected
-// env (Go-side cap is stopHistoryCap = 10, newest first). The tab is
-// read-only — it pulls fresh data from disk every time the user opens
-// it so a stop that fired while the dialog was open shows up the next
-// time they switch back to this tab. Refresh is cheap (one small JSON
-// read from local config) so we don't bother caching.
+// Source values shipped from EnvironmentStopHistoryEntry.Source.
+// Kept here as constants (rather than an enum import) because the
+// Go side ships them as strings and the matching renders are local
+// to this component. Empty source ("") is the legacy fallback for
+// rows written before the field existed.
+const STOP_SOURCE_POD_MONITOR = 'pod-monitor';
+const STOP_SOURCE_HOST_MANUAL = 'host-manual';
+
+// HistoryTab renders the last N stop events for the selected env
+// (Go-side cap is stopHistoryCap = 10, newest first). The tab is
+// read-only — it pulls fresh data from disk every time the user
+// opens it so a stop that fired while the dialog was open shows up
+// the next time they switch back to this tab. Refresh is cheap
+// (one MCP call against the in-pod tool) so we don't cache.
 //
-// The "why did my env stop?" question motivated this surface — issue
-// #410 follow-up. Each row breaks out the per-marker idle/active
-// state captured at grace-arm time, so the user can tell at a glance
-// whether a recurring stop is caused by genuine inactivity or by a
-// specific marker (e.g., ssh-proxy quiet but cli still active means
-// the ssh-proxy activity reporter is misconfigured).
+// The "why did my env stop?" question motivated this surface
+// (issue #410 / #421). Each row carries: the source (in-pod idle
+// monitor vs. desktop manual stop), the resolved idle policy
+// snapshot at fire time, the grace-armed timestamp alongside the
+// AWS-stop timestamp, and the per-marker idle/active state captured
+// at grace-arm time. Together that lets the user distinguish "I
+// clicked Stop" from "the idle policy fired" from "a specific
+// marker (e.g., ssh-proxy) was incorrectly quiet."
 export function HistoryTab({
   selection,
   open,
@@ -74,13 +84,13 @@ export function HistoryTab({
   }
   if (history.length === 0) {
     return (
-      <HistoryEmptyState message="No auto-stops recorded yet. The desktop logs each idle-timeout stop here so you can see why an env was paused." />
+      <HistoryEmptyState message="No stops recorded yet. The desktop logs each idle-timeout stop and each manual Stop here so you can see why an env was paused." />
     );
   }
   return (
     <div className="flex flex-col gap-2" data-testid="manage-history-list">
       <p className="text-[13px] text-muted-foreground">
-        Showing the {history.length} most recent auto-stops, newest first.
+        Showing the {history.length} most recent stops, newest first.
       </p>
       {history.map((event) => (
         <StopHistoryRow key={`${event.stoppedAt}-${event.reason}`} event={event} />
@@ -102,9 +112,13 @@ function HistoryEmptyState({ message }: { message: string }): React.ReactElement
 }
 
 function StopHistoryRow({ event }: { event: UILastStopEvent }): React.ReactElement {
-  const when = formatStoppedAt(event.stoppedAt);
+  const stoppedAt = formatStoppedAt(event.stoppedAt);
+  const armedAt = event.armedAt ? formatStoppedAt(event.armedAt) : '';
   const idleMarkers = (event.markers ?? []).filter((m) => m.idle);
   const activeMarkers = (event.markers ?? []).filter((m) => !m.idle);
+  const sourceLabel = formatSourceLabel(event.source);
+  const policyLine = formatPolicyLine(event.policy);
+  const reason = formatReason(event);
   return (
     <article
       className="grid gap-1.5 rounded-[var(--radius)] border border-border bg-background px-3 py-2.5"
@@ -112,15 +126,26 @@ function StopHistoryRow({ event }: { event: UILastStopEvent }): React.ReactEleme
     >
       <header className="flex items-baseline justify-between gap-3 text-[13px]">
         <span className="font-medium text-foreground" data-testid="manage-history-row-when">
-          {when}
+          {stoppedAt}
         </span>
-        <span className="text-[12px] text-muted-foreground">
-          Grace {String(event.graceSeconds)}s
+        <span className="text-[12px] text-muted-foreground" data-testid="manage-history-row-source">
+          {sourceLabel}
+          {event.graceSeconds > 0 ? ` · Grace ${String(event.graceSeconds)}s` : ''}
         </span>
       </header>
       <div className="text-[13px] text-foreground" data-testid="manage-history-row-reason">
-        {event.reason || 'Auto-stop fired.'}
+        {reason}
       </div>
+      {armedAt && (
+        <div className="text-[12px] text-muted-foreground" data-testid="manage-history-row-armed">
+          Grace armed at {armedAt}, fired at {stoppedAt}.
+        </div>
+      )}
+      {policyLine && (
+        <div className="text-[12px] text-muted-foreground" data-testid="manage-history-row-policy">
+          {policyLine}
+        </div>
+      )}
       {idleMarkers.length > 0 && <MarkerList label="Idle markers" markers={idleMarkers} />}
       {activeMarkers.length > 0 && (
         <MarkerList label="Still-active markers" markers={activeMarkers} />
@@ -147,6 +172,60 @@ function MarkerList({
         .join(', ')}
     </div>
   );
+}
+
+function formatSourceLabel(source: string | undefined): string {
+  switch (source) {
+    case STOP_SOURCE_POD_MONITOR:
+      return 'In-pod idle monitor';
+    case STOP_SOURCE_HOST_MANUAL:
+      return 'Desktop manual stop';
+    default:
+      // Legacy entries written before the source field existed —
+      // we still want a sensible row header rather than nothing.
+      return 'Auto-stop';
+  }
+}
+
+function formatReason(event: UILastStopEvent): string {
+  const trimmed = event.reason.trim();
+  if (trimmed) return trimmed;
+  if (event.source === STOP_SOURCE_HOST_MANUAL) return 'Manual stop.';
+  return 'Auto-stop fired.';
+}
+
+function formatPolicyLine(policy: UIIdlePolicy | undefined): string {
+  if (!policy) return '';
+  const parts: string[] = [];
+  if (policy.timeoutSeconds > 0) {
+    parts.push(`timeout ${formatDurationSeconds(policy.timeoutSeconds)}`);
+  }
+  const workingHours = (policy.workingHours ?? '').trim();
+  if (workingHours) {
+    parts.push(`working hours ${workingHours}`);
+  }
+  const timezone = (policy.timezone ?? '').trim();
+  if (timezone) {
+    parts.push(timezone);
+  }
+  if (parts.length === 0) return '';
+  return `Policy: ${parts.join(', ')}`;
+}
+
+function formatDurationSeconds(seconds: number): string {
+  if (seconds < 60) return `${String(seconds)}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    const remainderSeconds = seconds - minutes * 60;
+    return remainderSeconds === 0
+      ? `${String(minutes)}m`
+      : `${String(minutes)}m ${String(remainderSeconds)}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remainderMinutes = minutes - hours * 60;
+  return remainderMinutes === 0
+    ? `${String(hours)}h`
+    : `${String(hours)}h ${String(remainderMinutes)}m`;
 }
 
 function formatStoppedAt(timestamp: string): string {

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -162,15 +162,29 @@ export interface UIIdleStatus {
   gracePeriodSeconds?: number;
 }
 
-// UILastStopEvent describes the most recent auto-stop for an env,
-// loaded from <userConfig>/erun/<tenant>/<env>/last-stop.json by the
-// Go-side LoadLastStopEvent. Surfaced in the idle-status tooltip so
-// the user can answer "why did my env stop?" without trawling logs.
+// UILastStopEvent describes one stop in the env's audit history.
+// Loaded from the in-pod `idle_stop_history` MCP tool, which reads
+// stop-history.json off the shared home PVC so the desktop sees
+// both the in-pod monitor's auto-stops and the desktop's own
+// manual stops. Surfaced in the env-config Manage dialog's History
+// tab so the user can answer "why did my env stop?" without
+// trawling logs.
+//
+// Source distinguishes auto-stops fired by the in-pod idle monitor
+// from manual stops fired by the desktop's Stop button; the row
+// renders a badge from this field. ArmedAt is the moment the grace
+// window began — set on pod-monitor entries, empty on host-manual
+// entries without prior armed grace. Policy is the resolved idle
+// policy snapshot at fire time; older entries on disk that pre-date
+// the snapshot leave it unset.
 export interface UILastStopEvent {
   stoppedAt: string;
+  armedAt?: string;
   graceSeconds: number;
+  source?: string;
   reason: string;
   cloudContextName?: string;
+  policy?: UIIdlePolicy;
   markers?: UILastStopMarker[];
 }
 
@@ -179,6 +193,16 @@ export interface UILastStopMarker {
   idle: boolean;
   reason?: string;
   secondsIdleFor?: number;
+}
+
+// UIIdlePolicy mirrors the History-tab snapshot of the resolved
+// idle policy from the Go side. TimeoutSeconds is rendered rather
+// than a Go duration string so the frontend never parses "10m0s".
+export interface UIIdlePolicy {
+  timeoutSeconds: number;
+  workingHours?: string;
+  timezone?: string;
+  idleTrafficBytes?: number;
 }
 
 export interface UIIdleMarker {

--- a/erun-ui/idle_status.go
+++ b/erun-ui/idle_status.go
@@ -266,6 +266,45 @@ func (a *App) CancelPendingIdleStop(selection uiSelection) error {
 	return nil
 }
 
+// recordManualStopForCloudContext writes a host-manual entry to
+// stop-history.json for every env linked to the supplied cloud
+// context. Called from StopCloudContext after the AWS stop
+// succeeds, so the History tab also explains "you clicked Stop"
+// alongside the in-pod monitor's auto-stops.
+//
+// Best-effort by design: AWS stop-instances has already succeeded
+// by the time we get here, so the user's intent ("stop this env")
+// is complete. A failure to record the audit row is reported to
+// the in-app activity queue and otherwise ignored — manual stops
+// must not appear to fail because a side audit channel did. Older
+// runtime images that do not yet register `idle_stop_record`
+// surface a single "rebuild runtime image" notification per env.
+func (a *App) recordManualStopForCloudContext(ctx context.Context, cloudContextName string) {
+	selections := a.selectionsForCloudContext(cloudContextName)
+	for _, selection := range selections {
+		result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
+			Tenant:      selection.Tenant,
+			Environment: selection.Environment,
+		})
+		if err != nil {
+			a.emitAppNotification("warn", fmt.Sprintf("Could not record manual stop for %s/%s: %s", selection.Tenant, selection.Environment, err.Error()))
+			continue
+		}
+		mcpPort := eruncommon.MCPPortForResult(result)
+		if !a.deps.canConnectLocalPort(mcpPort) {
+			// No live port-forward: nothing we can do from the
+			// host side. The audit row would have been welcome
+			// but is not load-bearing — the user clicked Stop
+			// and that already succeeded.
+			continue
+		}
+		endpoint := mcpEndpointForOpenResult(result)
+		if err := recordManualStopViaMCP(ctx, endpoint, selection.Tenant, selection.Environment, "Manual stop via desktop", cloudContextName); err != nil {
+			a.emitAppNotification("warn", fmt.Sprintf("Could not record manual stop for %s/%s: %s", selection.Tenant, selection.Environment, err.Error()))
+		}
+	}
+}
+
 // LoadStopHistory returns the env's last N auto-stop audit records,
 // newest first. Reads through the in-pod MCP `idle_stop_history`
 // tool so the canonical history (the one the in-pod monitor wrote
@@ -296,8 +335,20 @@ func (a *App) LoadStopHistory(selection uiSelection) ([]uiLastStopEvent, error) 
 		ui := uiLastStopEvent{
 			StoppedAt:        entry.StoppedAt.UTC().Format(time.RFC3339),
 			GraceSeconds:     entry.GraceSeconds,
+			Source:           strings.TrimSpace(entry.Source),
 			Reason:           strings.TrimSpace(entry.Reason),
 			CloudContextName: strings.TrimSpace(entry.CloudContextName),
+		}
+		if !entry.ArmedAt.IsZero() {
+			ui.ArmedAt = entry.ArmedAt.UTC().Format(time.RFC3339)
+		}
+		if !idlePolicyIsZero(entry.Policy) {
+			ui.Policy = &uiIdlePolicy{
+				TimeoutSeconds:   int64(entry.Policy.Timeout / time.Second),
+				WorkingHours:     strings.TrimSpace(entry.Policy.WorkingHours),
+				Timezone:         strings.TrimSpace(entry.Policy.Timezone),
+				IdleTrafficBytes: entry.Policy.IdleTrafficBytes,
+			}
 		}
 		for _, marker := range entry.Markers {
 			ui.Markers = append(ui.Markers, uiLastStopMarker{
@@ -310,6 +361,13 @@ func (a *App) LoadStopHistory(selection uiSelection) ([]uiLastStopEvent, error) 
 		out = append(out, ui)
 	}
 	return out, nil
+}
+
+// idlePolicyIsZero reports whether the entry's policy snapshot is
+// unset — older history rows pre-date the snapshot, so we render
+// nothing rather than a misleading "Timeout: 0s" line.
+func idlePolicyIsZero(p eruncommon.EnvironmentIdlePolicy) bool {
+	return p.Timeout == 0 && strings.TrimSpace(p.WorkingHours) == "" && strings.TrimSpace(p.Timezone) == "" && p.IdleTrafficBytes == 0
 }
 
 // clearIdleStopsForCloudContext removes any latched auto-stop flag

--- a/erun-ui/idle_stop_mcp.go
+++ b/erun-ui/idle_stop_mcp.go
@@ -115,6 +115,54 @@ func loadStopHistoryViaMCP(ctx context.Context, endpoint, tenant, environment st
 	return payload.Entries, nil
 }
 
+// recordManualStopViaMCP calls the in-pod `idle_stop_record` tool
+// to append a host-manual entry to stop-history.json. Used by the
+// desktop's Stop button so the History tab also explains "you
+// clicked Stop", not just auto-stops fired by the in-pod monitor.
+// Reason is the free-form text rendered on the row; passing the
+// empty string defers to the tool's default ("Manual stop"). On
+// older runtime images that do not register the tool yet, the
+// caller swallows the formatted error so manual stops still
+// succeed — formatIdleStopMCPError points at the rebuild fix.
+func recordManualStopViaMCP(ctx context.Context, endpoint, tenant, environment, reason, cloudContextName string) error {
+	ctx, cancel := context.WithTimeout(ctx, idleStopMCPTimeout)
+	defer cancel()
+	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
+	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint: endpoint,
+		HTTPClient: &http.Client{
+			Transport: idleProbeRoundTripper{},
+		},
+		DisableStandaloneSSE: true,
+	}, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = session.Close()
+	}()
+	args := map[string]any{}
+	if tenant != "" {
+		args["tenant"] = tenant
+	}
+	if environment != "" {
+		args["environment"] = environment
+	}
+	if strings.TrimSpace(reason) != "" {
+		args["reason"] = reason
+	}
+	if strings.TrimSpace(cloudContextName) != "" {
+		args["cloudContextName"] = cloudContextName
+	}
+	if _, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "idle_stop_record",
+		Arguments: args,
+	}); err != nil {
+		return formatIdleStopMCPError("idle_stop_record", err)
+	}
+	return nil
+}
+
 // formatIdleStopMCPError rewrites the SDK error to spell out the
 // most common failure mode plainly: the runtime image in the pod
 // predates this desktop version and does not have the new tool

--- a/erun-ui/intentional_stop.go
+++ b/erun-ui/intentional_stop.go
@@ -75,6 +75,20 @@ func (a *App) isIntentionalStop(selection uiSelection) bool {
 // mark/clear helpers above; mirrors the env walk in
 // clearIdleStopsForCloudContext so the two latches stay in sync.
 func (a *App) selectionsLinkedToCloudContext(name string) []string {
+	selections := a.selectionsForCloudContext(name)
+	keys := make([]string, 0, len(selections))
+	for _, sel := range selections {
+		keys = append(keys, selectionKey(sel))
+	}
+	return keys
+}
+
+// selectionsForCloudContext returns the (tenant, environment) pairs
+// every env linked to `name`. Used by recordManualStopForCloudContext
+// so it can resolve a per-env MCP endpoint and record an audit row
+// against each — selection keys encode an extra Debug bool that would
+// be ambiguous to reverse-parse.
+func (a *App) selectionsForCloudContext(name string) []uiSelection {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return nil
@@ -83,7 +97,7 @@ func (a *App) selectionsLinkedToCloudContext(name string) []string {
 	if err != nil {
 		return nil
 	}
-	keys := make([]string, 0)
+	selections := make([]uiSelection, 0)
 	for _, tenant := range tenants {
 		envs, err := a.deps.store.ListEnvConfigs(tenant.Name)
 		if err != nil {
@@ -94,8 +108,8 @@ func (a *App) selectionsLinkedToCloudContext(name string) []string {
 			if err != nil || !ok || strings.TrimSpace(cloudContext.Name) != name {
 				continue
 			}
-			keys = append(keys, selectionKey(uiSelection{Tenant: tenant.Name, Environment: env.Name}))
+			selections = append(selections, uiSelection{Tenant: tenant.Name, Environment: env.Name})
 		}
 	}
-	return keys
+	return selections
 }

--- a/erun-ui/playwright/tests/idle-widget-stop-protection.spec.ts
+++ b/erun-ui/playwright/tests/idle-widget-stop-protection.spec.ts
@@ -477,20 +477,31 @@ test.describe('idle widget stop protection', () => {
     expect(startAISessionCalls).toBe(baselineStartAISession);
   });
 
-  test('Manage dialog History tab renders the last N auto-stops, newest first', async ({
+  test('Manage dialog History tab renders the last N stops, newest first', async ({
     app,
     page,
   }) => {
-    // Three mocked auto-stop records simulate the rolling history a
-    // user would see in the Manage > History tab. The spec opens the
-    // first env's manage dialog, switches to History, and asserts the
-    // newest row is on top with the per-marker breakdown intact.
+    // Three mocked stop records simulate the rolling history a user
+    // would see in the Manage > History tab: one in-pod auto-stop
+    // with the per-marker breakdown, one manual desktop stop, and
+    // one legacy auto-stop without the new source/armedAt/policy
+    // fields. The spec asserts newest-first ordering, the source
+    // labels distinguishing pod-monitor vs. host-manual vs. legacy,
+    // the dual-timestamp line, the policy snapshot, and the marker
+    // breakdown.
     const history = [
       {
         stoppedAt: '2026-05-31T12:30:00Z',
+        armedAt: '2026-05-31T12:20:00Z',
         graceSeconds: 600,
+        source: 'pod-monitor',
         reason: 'idle: terminal-stdin, ai',
         cloudContextName: 'mock-cluster',
+        policy: {
+          timeoutSeconds: 600,
+          workingHours: '09:00-18:00',
+          timezone: 'Europe/Riga',
+        },
         markers: [
           { name: 'terminal-stdin', idle: true, reason: 'no input', secondsIdleFor: 750 },
           { name: 'ai', idle: true, reason: 'no Claude session activity', secondsIdleFor: 720 },
@@ -498,13 +509,10 @@ test.describe('idle widget stop protection', () => {
       },
       {
         stoppedAt: '2026-05-30T18:15:00Z',
-        graceSeconds: 600,
-        reason: 'idle: terminal-stdin',
+        graceSeconds: 0,
+        source: 'host-manual',
+        reason: 'Manual stop via desktop',
         cloudContextName: 'mock-cluster',
-        markers: [
-          { name: 'terminal-stdin', idle: true, reason: 'no input', secondsIdleFor: 660 },
-          { name: 'ai', idle: false, reason: 'Claude session active', secondsIdleFor: 0 },
-        ],
       },
       {
         stoppedAt: '2026-05-29T09:00:00Z',
@@ -538,21 +546,55 @@ test.describe('idle widget stop protection', () => {
     const rows = page.getByTestId('manage-history-row');
     await expect(rows).toHaveCount(history.length);
 
-    // Newest first: the row at index 0 corresponds to history[0].
-    const firstWhen = page.getByTestId('manage-history-row-when').first();
-    await expect(firstWhen).toContainText('2026-05-31');
-    const firstReason = page.getByTestId('manage-history-row-reason').first();
-    await expect(firstReason).toContainText('idle: terminal-stdin, ai');
+    // Newest first: the row at index 0 corresponds to history[0],
+    // the pod-monitor auto-stop. It must carry the source label,
+    // grace marker, dual-timestamp line, and policy snapshot — so a
+    // user reading the row can answer "what triggered it?" without
+    // recalling the underlying timeout.
+    const firstRow = rows.nth(0);
+    await expect(firstRow.getByTestId('manage-history-row-when')).toContainText('2026-05-31');
+    await expect(firstRow.getByTestId('manage-history-row-source')).toContainText(
+      'In-pod idle monitor',
+    );
+    await expect(firstRow.getByTestId('manage-history-row-source')).toContainText('Grace 600s');
+    await expect(firstRow.getByTestId('manage-history-row-reason')).toContainText(
+      'idle: terminal-stdin, ai',
+    );
+    await expect(firstRow.getByTestId('manage-history-row-armed')).toContainText('Grace armed at');
+    await expect(firstRow.getByTestId('manage-history-row-policy')).toContainText('timeout 10m');
+    await expect(firstRow.getByTestId('manage-history-row-policy')).toContainText(
+      'working hours 09:00-18:00',
+    );
+    // Per-marker breakdown — the audit's central diagnostic: it
+    // lets a user see which markers actually went idle vs. which
+    // stayed active.
+    await expect(firstRow).toContainText('Idle markers');
+    await expect(firstRow).toContainText('terminal-stdin');
+    await expect(firstRow).toContainText('ai');
 
-    // The per-marker breakdown is rendered on the active row so the
-    // user can see whether a specific marker stayed active across
-    // recurring stops. history[1] mixes an active "ai" marker with an
-    // idle "terminal-stdin" marker.
+    // The middle row is a manual desktop stop — must render with
+    // the host-manual source label, no grace tag, no armed-at line,
+    // no policy line, and no marker breakdown. This is the row that
+    // answers "did I click Stop?" — keep its shape narrow.
     const secondRow = rows.nth(1);
-    await expect(secondRow).toContainText('Idle markers');
-    await expect(secondRow).toContainText('terminal-stdin');
-    await expect(secondRow).toContainText('Still-active markers');
-    await expect(secondRow).toContainText('ai');
+    await expect(secondRow.getByTestId('manage-history-row-source')).toContainText(
+      'Desktop manual stop',
+    );
+    await expect(secondRow.getByTestId('manage-history-row-source')).not.toContainText('Grace');
+    await expect(secondRow.getByTestId('manage-history-row-reason')).toContainText(
+      'Manual stop via desktop',
+    );
+    await expect(secondRow.getByTestId('manage-history-row-armed')).toHaveCount(0);
+    await expect(secondRow.getByTestId('manage-history-row-policy')).toHaveCount(0);
+
+    // The last row is a legacy entry written before source/armedAt/
+    // policy existed. It must still render with a sensible header
+    // (no crash) — falling back to a generic "Auto-stop" label.
+    const thirdRow = rows.nth(2);
+    await expect(thirdRow.getByTestId('manage-history-row-source')).toContainText('Auto-stop');
+    await expect(thirdRow.getByTestId('manage-history-row-reason')).toContainText(
+      'outside working hours',
+    );
 
     await app.manageDialog.cancel();
     await app.manageDialog.waitForClosed();

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -403,12 +403,34 @@ type uiIdleStatus struct {
 // last-stop.json which is written by the desktop's idle-stop fire
 // path. Surfaced in the idle tooltip so the user can answer "why did
 // my env stop?" without trawling the activity drawer.
+//
+// Source is the stable string from
+// EnvironmentStopHistoryEntry.Source ("pod-monitor" or
+// "host-manual"); the frontend turns it into a row badge. ArmedAt
+// is the moment the grace window began; empty for host-manual rows
+// without a prior armed grace. Policy is the resolved idle policy
+// at fire time so the row stays interpretable after the user later
+// edits the timeout.
 type uiLastStopEvent struct {
-	StoppedAt        string                `json:"stoppedAt"`
-	GraceSeconds     int64                 `json:"graceSeconds"`
-	Reason           string                `json:"reason"`
-	CloudContextName string                `json:"cloudContextName,omitempty"`
-	Markers          []uiLastStopMarker    `json:"markers,omitempty"`
+	StoppedAt        string             `json:"stoppedAt"`
+	ArmedAt          string             `json:"armedAt,omitempty"`
+	GraceSeconds     int64              `json:"graceSeconds"`
+	Source           string             `json:"source,omitempty"`
+	Reason           string             `json:"reason"`
+	CloudContextName string             `json:"cloudContextName,omitempty"`
+	Policy           *uiIdlePolicy      `json:"policy,omitempty"`
+	Markers          []uiLastStopMarker `json:"markers,omitempty"`
+}
+
+// uiIdlePolicy is the History-tab-facing snapshot of the resolved
+// idle policy. Mirrors common.EnvironmentIdlePolicy in shape, but
+// renders TimeoutSeconds rather than a Go duration so the
+// frontend never has to parse "10m0s".
+type uiIdlePolicy struct {
+	TimeoutSeconds   int64  `json:"timeoutSeconds"`
+	WorkingHours     string `json:"workingHours,omitempty"`
+	Timezone         string `json:"timezone,omitempty"`
+	IdleTrafficBytes int64  `json:"idleTrafficBytes,omitempty"`
 }
 
 // uiLastStopMarker records the per-marker idle/active state captured


### PR DESCRIPTION
## Summary

Closes #421, closes #422.

The Manage > History tab in the env-config dialog was rendering identical "Auto-stop fired. Grace 0s" rows because the in-pod monitor's `record-stop` call was reading `stop-pending.json` *after* the same `stop-ready --json` invocation had cleared it for crash-safety. The audit row that should explain why an env stopped silently dropped its reason, markers, grace, and policy snapshot.

This PR closes both that data-loss bug and the original "what triggered it" gap. Plus a small follow-up to fix a stale release golden discovered during validation.

- **Fix data loss:** `stop-ready --json` now emits the pending payload in its output; `record-stop --state-stdin` parses it back. The on-disk crash-safety semantics are unchanged — Fire still clears the pending file before the AWS call.
- **Trigger source:** new `Source` field on `EnvironmentStopHistoryEntry` (`pod-monitor` | `host-manual`). The pod entrypoint passes `--source pod-monitor`; the desktop's Stop button calls a new `idle_stop_record` MCP tool that records `--source host-manual`. Manual stops now appear in History instead of being invisible.
- **Policy snapshot:** capture the resolved `EnvironmentIdlePolicy` (timeout, working hours, timezone) at grace-arm time and fold it onto the history row, so the tab keeps explaining old stops correctly after the user later edits the timeout.
- **Grace-armed timestamp:** record `pending.Since` as `ArmedAt` on the row so the tab can show "Grace armed at HH:MM, fired at HH:MM" instead of a single timestamp.
- **UI:** History tab now shows the source badge, the dual-timestamp line, the policy snapshot line, plus the existing marker breakdown. Legacy rows written before these fields render gracefully under "Auto-stop".
- **Bundled fix (closes #422):** Refresh the `dry_run_includes_linux_release_scripts.txt` golden. PR #401 added the worktree-clean preflight check and regenerated 9 release goldens, but missed this one — `make integration-test` on main has been red on it since. Two-line append; binary behavior is unchanged.

## UX Impact Review

1. **Affected paths.** Env-config dialog History tab → `LoadStopHistory` Wails call → `idle_stop_history` MCP tool. Desktop Stop button → `StopCloudContext` → `idle_stop_record` MCP tool (new).
2. **User-visible sequence.** Open Manage dialog → switch to History tab → each row shows source label + grace + dual timestamps + policy snapshot + marker breakdown. Click Stop → AWS stop fires → row appears in History under "Desktop manual stop" next time the tab is opened.
3. **State-without-affordance.** Every new field on `EnvironmentStopHistoryEntry` (`Source`, `ArmedAt`, `Policy`) renders as a discrete row element with its own `data-testid`. No silent mutations.
4. **Visibility of system status.** The History tab is a persistent affordance the user reaches for after a stop — fine that the answer surfaces only on view, not as a transient toast.
5. **Success/failure feedback.** `recordManualStopForCloudContext` is best-effort and surfaces failures (e.g. older runtime image missing `idle_stop_record`) via `emitAppNotification("warn", …)` with the rebuild-image hint from `formatIdleStopMCPError`.
6. **Consistency.** Matches the existing in-pod auto-stop path: same on-disk file, same surface, same shape.
7. **Heuristic pass.** Visibility (history is the answer surface), match-with-user-language ("In-pod idle monitor" / "Desktop manual stop" / "Manual stop"), consistency (same row layout), error prevention (omit-zero policy/armedAt for legacy rows so they still render), recognition over recall (source label spells out the trigger), user control (read-only tab, no implicit side effects), accessibility (semantic article + header + testids), help-and-documentation (n/a — diagnostic surface only).
8. **Playwright coverage.** `playwright/tests/idle-widget-stop-protection.spec.ts` History-tab test extended with three rows: pod-monitor auto-stop (source label, grace tag, armed line, policy line, marker breakdown), host-manual manual stop (no grace, no armed, no policy, no markers), legacy (no source field, falls back to "Auto-stop"). **Could not execute in the sandbox** — host is missing `libnspr4`/`libnss3` for chromium and lacks sudo. Run `./erun-ui/playwright/run.sh -- --grep 'History tab'` on a developer machine before merge.

## Docs

Pure bug fix on the data-loss side plus an internal-surface enrichment on the audit side. Both are observable only through the existing History tab, which already explains itself; no public-facing CLI command, MCP description, or `erun-docs/` page is affected. No doc updates required.

## Test plan

- [x] `go test ./...` in `erun-common`, `erun-cli`, `erun-mcp`, `erun-ui`
- [x] Two new `TestActivity` integration scenarios cover the pod-monitor stdin-piped path and the host-manual no-prior-grace path end-to-end against the on-disk JSON shape
- [x] Three new unit tests in `erun-mcp/idle_stop_test.go` cover the new tool
- [x] Frontend `yarn typecheck && yarn lint && yarn format:check && yarn build`
- [x] `TestRelease` now green (#422 golden refreshed)
- [ ] **Manual:** Run `./erun-ui/playwright/run.sh -- --grep 'History tab'` on a host with chromium deps installed
- [ ] **Manual:** Smoke-test against a real deployed env — auto-stop once and click Stop once, verify both rows appear in the History tab with their correct source label and detail