### PR TITLE
Light the sidebar spinner while `erun build` runs

### DIFF
--- a/erun-common/build_run.go
+++ b/erun-common/build_run.go
@@ -3,6 +3,7 @@ package eruncommon
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 func RunDockerBuild(ctx Context, buildInput DockerBuildSpec, build DockerImageBuilderFunc) error {
@@ -102,9 +103,28 @@ func RunBuildExecutionAndDeploy(ctx Context, execution BuildExecutionSpec, deplo
 	return runBuildExecution(ctx, execution, deploySpecs, runScript, build, push, deploy)
 }
 
-func runBuildExecution(ctx Context, execution BuildExecutionSpec, deploySpecs []DeploySpec, runScript BuildScriptRunnerFunc, build DockerImageBuilderFunc, push DockerPushFunc, deploy HelmChartDeployerFunc) error {
+func runBuildExecution(ctx Context, execution BuildExecutionSpec, deploySpecs []DeploySpec, runScript BuildScriptRunnerFunc, build DockerImageBuilderFunc, push DockerPushFunc, deploy HelmChartDeployerFunc) (err error) {
+	// `==> Building` / `==> Built in N` / `==> Build failed after N` are
+	// the umbrella traces the desktop's activity-queue parser keys off
+	// (mirrors RunHelmDeploy's `==> Deploying` / `==> Deployed`). Real
+	// run only: dry-run performs no work so there is nothing to put a
+	// spinner on, and skipping these lines in dry-run also keeps the
+	// dry-run integration goldens stable.
+	var started time.Time
+	if !ctx.DryRun {
+		started = time.Now()
+		ctx.Info("==> Building")
+		defer func() {
+			elapsed := time.Since(started).Round(time.Second)
+			if err != nil {
+				ctx.Info("==> Build failed after " + elapsed.String())
+				return
+			}
+			ctx.Info("==> Built in " + elapsed.String())
+		}()
+	}
 	if execution.release != nil {
-		if err := RunReleaseSpec(ctx, *execution.release, nil, runScript); err != nil {
+		if err = RunReleaseSpec(ctx, *execution.release, nil, runScript); err != nil {
 			return err
 		}
 	}
@@ -117,7 +137,7 @@ func runBuildExecution(ctx Context, execution BuildExecutionSpec, deploySpecs []
 		return err
 	}
 	for _, deploySpec := range filterDeploySpecsForPushedTags(deploySpecs, pushedTags) {
-		if err := RunDeploySpec(ctx, deploySpec, build, push, deploy); err != nil {
+		if err = RunDeploySpec(ctx, deploySpec, build, push, deploy); err != nil {
 			return err
 		}
 	}

--- a/erun-integration/testdata/build/real_run_configured_fingerprint_inspects_remote_manifest.txt
+++ b/erun-integration/testdata/build/real_run_configured_fingerprint_inspects_remote_manifest.txt
@@ -1,7 +1,9 @@
 audit: erun build --environment local
+==> Building
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+==> Built in <ELAPSED>

--- a/erun-integration/testdata/build/real_run_release_pushes_multi_platform_manifest.txt
+++ b/erun-integration/testdata/build/real_run_release_pushes_multi_platform_manifest.txt
@@ -11,6 +11,7 @@ release: base version = <VERSION> (from <TMP>
 release: classified mode = prerelease
 release: develop branch "develop" exists = true
 audit: erun build --release
+==> Building
 release: branch= mode=prerelease version=<VERSION>
 docker image: ghcr.io/sophium/api:<VERSION>
 release: worktree clean = true
@@ -23,3 +24,4 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 release version: <VERSION>
+==> Built in <ELAPSED>

--- a/erun-integration/testdata/build/real_run_via_docker_stub_drives_multi_platform_build.txt
+++ b/erun-integration/testdata/build/real_run_via_docker_stub_drives_multi_platform_build.txt
@@ -1,7 +1,9 @@
 audit: erun build
+==> Building
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+==> Built in <ELAPSED>

--- a/erun-integration/testdata/build/real_run_with_existing_fingerprint_promotes_via_tag.txt
+++ b/erun-integration/testdata/build/real_run_with_existing_fingerprint_promotes_via_tag.txt
@@ -1,7 +1,9 @@
 audit: erun build
+==> Building
 fingerprint image present locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image present locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 promoting from cached fingerprint image: ghcr.io/sophium/api:<VERSION>
 fingerprint image present locally: ghcr.io/sophium/base:fp-<HEX16>-amd64
 fingerprint image present locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 promoting from cached fingerprint image: ghcr.io/sophium/base:<VERSION>
+==> Built in <ELAPSED>

--- a/erun-ui/activity_queue_app.go
+++ b/erun-ui/activity_queue_app.go
@@ -326,6 +326,23 @@ var activityInitializedLineRe = regexp.MustCompile(`^==> Initialized ([^/\s]+)/(
 // after Initializing returns an error. Captures: tenant, environment.
 var activityInitFailedLineRe = regexp.MustCompile(`^==> Initialization failed ([^/\s]+)/([^/\s]+)\b`)
 
+// activityBuildingLineRe matches the umbrella `==> Building` trace
+// emitted by RunBuildExecution at the top of the build pipeline.
+// Unlike deploy/init the line carries no tenant/env — build has no
+// deploy target the way RunHelmDeploy does, so the handler attaches
+// the activity to the session selection (the terminal tab the user
+// is looking at) instead of parsing identity out of the line.
+var activityBuildingLineRe = regexp.MustCompile(`^==> Building\b`)
+
+// activityBuiltLineRe matches the `==> Built in <elapsed>` trace
+// emitted on successful completion of the build pipeline.
+var activityBuiltLineRe = regexp.MustCompile(`^==> Built\b`)
+
+// activityBuildFailedLineRe matches the `==> Build failed after
+// <elapsed>` trace emitted when any step of runBuildExecution
+// returns an error.
+var activityBuildFailedLineRe = regexp.MustCompile(`^==> Build failed\b`)
+
 // newActivityTraceLineHandler scans PTY output for trace lines emitted by
 // erun deploy and updates the activity queue accordingly.
 //
@@ -375,6 +392,18 @@ func newActivityTraceLineHandler(app *App, selection uiSelection, kind sessionKi
 		if match := activityInitFailedLineRe.FindStringSubmatch(line); match != nil {
 			app.finishInitByTenantEnv(match[1], match[2], activityQueueStatusFailed, line)
 			app.emitEnvironmentInitFailed(match[1], match[2])
+			return
+		}
+		if activityBuildingLineRe.MatchString(line) {
+			app.startBuildFromTrace(selection)
+			return
+		}
+		if activityBuiltLineRe.MatchString(line) {
+			app.finishBuildBySelection(selection, activityQueueStatusSucceeded, "")
+			return
+		}
+		if activityBuildFailedLineRe.MatchString(line) {
+			app.finishBuildBySelection(selection, activityQueueStatusFailed, line)
 			return
 		}
 		switch {
@@ -507,6 +536,72 @@ func (a *App) startDeployFromTrace(selection uiSelection, tenant, environment, v
 	a.lockTerminalsForActivity(entry)
 	if a.activityStatusPoller != nil {
 		a.activityStatusPoller(entry)
+	}
+}
+
+// startBuildFromTrace registers a build entry from a `==> Building`
+// trace observed in the session's PTY. Unlike deploy/init the trace
+// line carries no tenant/env (build has no deploy target the way
+// RunHelmDeploy does), so the activity is keyed off the session
+// selection — the user invoked the build from a specific terminal
+// tab, and that tab's env row is the natural place to render the
+// spinner. No-op when the selection has no tenant/env yet (a
+// generic Local shell at the repo level): there is no row to attach
+// the indicator to, and a stray activity entry with empty
+// tenant/env would land on every row.
+//
+// Intentionally skips lockTerminalsForActivity: deploys lock the
+// session so a user cannot run conflicting commands while helm is
+// rolling out, but a build runs IN the user's terminal — locking it
+// would freeze the very tab the user is reading build output in.
+// The sidebar spinner is the only indicator the build needs.
+func (a *App) startBuildFromTrace(selection uiSelection) {
+	if a.activityQueue == nil {
+		return
+	}
+	tenant := strings.TrimSpace(selection.Tenant)
+	environment := strings.TrimSpace(selection.Environment)
+	if tenant == "" || environment == "" {
+		return
+	}
+	if _, ok := a.activityQueue.findActiveByCommand("build", tenant, environment); ok {
+		return
+	}
+	kubeContext := a.resolveActivityKubeContext(selection, tenant, environment)
+	if _, fresh := a.activityQueue.start(activityQueueEntry{
+		Command:           "build",
+		Tenant:            tenant,
+		Environment:       environment,
+		KubernetesContext: kubeContext,
+		Source:            "trace",
+		Summary:           "build " + tenant + "/" + environment,
+	}); !fresh {
+		return
+	}
+	a.rememberKubeContextForActivity(kubeContext)
+}
+
+// finishBuildBySelection finalizes the build entry registered by
+// startBuildFromTrace. Keyed off the session selection because the
+// `==> Built` / `==> Build failed` lines carry no tenant/env — see
+// startBuildFromTrace for the identity rationale. Idempotent unlock
+// in case a previous code path latched a lock that this entry did
+// not.
+func (a *App) finishBuildBySelection(selection uiSelection, status activityQueueStatus, errMsg string) {
+	if a.activityQueue == nil {
+		return
+	}
+	tenant := strings.TrimSpace(selection.Tenant)
+	environment := strings.TrimSpace(selection.Environment)
+	if tenant == "" || environment == "" {
+		return
+	}
+	entry, ok := a.activityQueue.findActiveByCommand("build", tenant, environment)
+	if !ok {
+		return
+	}
+	if final, finished := a.activityQueue.finish(entry.ID, status, errMsg); finished {
+		a.unlockTerminalsForActivity(final)
 	}
 }
 

--- a/erun-ui/activity_queue_app_test.go
+++ b/erun-ui/activity_queue_app_test.go
@@ -205,6 +205,80 @@ func TestActivityTraceLineHandlerFinalizesSkippingFromLine(t *testing.T) {
 	}
 }
 
+func TestActivityTraceLineHandlerStartsAndFinishesBuild(t *testing.T) {
+	// `erun build` umbrella traces don't carry tenant/env (build has no
+	// deploy target), so the handler must key off the session selection.
+	// Without this wiring the sidebar shows no busy spinner during a
+	// build that the user explicitly invoked in a tenant/env-bound
+	// terminal — that gap is the regression this scenario locks down.
+	app := newTestAppForActivityQueue(t)
+	selection := uiSelection{Tenant: "erun", Environment: "local"}
+	handler := newActivityTraceLineHandler(app, selection, sessionKindLocal)
+
+	handler("==> Building")
+	entry, ok := app.activityQueue.findActiveByCommand("build", "erun", "local")
+	if !ok {
+		t.Fatal("expected build entry to be active after ==> Building")
+	}
+	if entry.Source != "trace" {
+		t.Fatalf("expected source=trace, got %q", entry.Source)
+	}
+
+	handler("==> Built in 42s")
+	if _, ok := app.activityQueue.findActiveByCommand("build", "erun", "local"); ok {
+		t.Fatal("expected build entry to be finished after ==> Built")
+	}
+	all := app.activityQueue.list()
+	if len(all) != 1 || all[0].Status != activityQueueStatusSucceeded {
+		t.Fatalf("expected one succeeded entry, got %+v", all)
+	}
+}
+
+func TestActivityTraceLineHandlerFinalizesBuildOnFailure(t *testing.T) {
+	app := newTestAppForActivityQueue(t)
+	selection := uiSelection{Tenant: "erun", Environment: "local"}
+	handler := newActivityTraceLineHandler(app, selection, sessionKindLocal)
+
+	handler("==> Building")
+	handler("==> Build failed after 5s")
+
+	all := app.activityQueue.list()
+	if len(all) != 1 || all[0].Status != activityQueueStatusFailed {
+		t.Fatalf("expected one failed entry, got %+v", all)
+	}
+	if !strings.Contains(all[0].Error, "Build failed") {
+		t.Fatalf("expected Build failed in error, got %q", all[0].Error)
+	}
+}
+
+func TestActivityTraceLineHandlerSkipsBuildWithoutSelection(t *testing.T) {
+	// A generic Local shell at the repo root has no tenant/env bound to
+	// it. Build traces observed there must NOT register an entry — a
+	// stray (empty, empty) row would highlight every sidebar entry
+	// because the spinner selector walks all entries by tenant/env.
+	app := newTestAppForActivityQueue(t)
+	handler := newActivityTraceLineHandler(app, uiSelection{}, sessionKindLocal)
+	handler("==> Building")
+	if len(app.activityQueue.list()) != 0 {
+		t.Fatalf("expected no entries registered without a selection, got %+v", app.activityQueue.list())
+	}
+}
+
+func TestStartBuildFromTraceDoesNotLockTerminal(t *testing.T) {
+	// Build runs IN the user's terminal, so locking the session would
+	// freeze the very tab they are reading build output in. Verify the
+	// build path skips the lock that deploy uses to prevent concurrent
+	// helm runs.
+	app := newTestAppForActivityQueue(t)
+	selection := uiSelection{Tenant: "erun", Environment: "local"}
+	envSession := &managedTerminal{selection: selection, key: "env\x00erun\x00local", serial: 1, kind: sessionKindOpen}
+	app.sessions[envSession.key] = envSession
+	app.startBuildFromTrace(selection)
+	if envSession.lockedByActivity != "" {
+		t.Fatalf("expected build to not lock terminal, got %q", envSession.lockedByActivity)
+	}
+}
+
 func TestResolveActivityKubeContextFallsBackToEnvConfig(t *testing.T) {
 	// startDeployFromTrace registers entries with a kube context drawn
 	// first from the session selection, falling back to the env config


### PR DESCRIPTION
## Summary

Closes #424.

Deploy and init both light a busy spinner on the env row when their umbrella trace fires (\`==> Deploying tenant/env\` / \`==> Initializing tenant/env\`). Build was missing the equivalent trace, so the sidebar stayed quiet during builds — including \`erun build --release\` which can take minutes.

- Emit \`==> Building\` / \`==> Built in <elapsed>\` / \`==> Build failed after <elapsed>\` around \`runBuildExecution\` in \`erun-common\` (real-run only; dry-run performs no work).
- Match those lines in the desktop's activity-queue trace handler and register a build entry keyed on the session selection — build has no deploy target the way \`RunHelmDeploy\` does, so the natural identity for the spinner is the terminal tab the user invoked the build from.
- Skip \`lockTerminalsForActivity\` for build: the build runs IN the user's terminal, so locking it would freeze the very tab they are reading output in. The sidebar spinner alone is the right indicator.

## UX Impact Review

1. **Affected paths.** Local-terminal session → \`newActivityTraceLineHandler\` → new \`startBuildFromTrace\` / \`finishBuildBySelection\` → \`activityQueue.start\` / \`finish\` → \`activity:state\` Wails event → \`state.activity.entries\` → sidebar \`BusyRowSpinner\`.
2. **User-visible sequence.** Type \`erun build --release\` in a Local tab → first line of build output is \`==> Building\` → sidebar row for that tab's env shows the half-circle spinner labelled \"Building <tenant>/<env>\" → on completion the last line is \`==> Built in <elapsed>\` → spinner disappears.
3. **State-without-affordance.** The new activity-queue entry has \`command=\"build\"\`. \`activityCommandLabel('build') → 'Building'\` (\`Sidebar.helpers.ts:108\`), and \`BusyRowSpinner\` renders unchanged. No mutation without a corresponding affordance.
4. **Visibility of system status (Nielsen #1).** The spinner is the persistent indicator the user expects while a long-running build is in flight. Matches the existing deploy/init pattern exactly.
5. **Success and failure feedback.** \`==> Built\` clears the spinner cleanly; \`==> Build failed after <elapsed>\` finalizes the entry as failed and clears the spinner with the error text captured on the entry.
6. **Consistency with comparable flows.** Matches deploy and init exactly: same umbrella shape, same activity-queue model, same sidebar selector.
7. **Heuristic pass.** Visibility ✓, match-with-user-language (\"Building\" matches the verb the user is reading in the terminal) ✓, consistency-with-comparable-flows ✓, error-prevention (no-op for sessions without tenant/env so a stray \`==> Building\` in a generic Local tab does not splash spinners onto every row) ✓, accessibility (spinner already has role=status + aria-label) ✓.
8. **Playwright coverage.** The existing \`sidebar-busy-spinner.spec.ts\` documents the harness limitation: \"the headless harness has no portable way to stage a running deploy.\" The same applies to a real \`erun build\` subprocess. The change is covered by:
   - **Go unit tests** for the trace-handler wiring (start, finish-success, finish-failure, no-selection no-op, no-lock invariant — \`activity_queue_app_test.go\`).
   - **Existing Playwright tests** locking that an env with a \`runningCommand\` selector match renders the \`BusyRowSpinner\` (via the \`isOpening\` path, which exercises the same \`deriveEnvironmentRow\` branch).
   - **Integration golden** \`real_run_via_docker_stub_drives_multi_platform_build.txt\` (and three others) locking the new trace lines end-to-end through the compiled binary subprocess.

## Docs

No public CLI surface, MCP description, or \`erun-docs/\` page changes. The new traces are observable in terminal output and matched by the desktop; both are consistent with the existing deploy/init contract that is already documented there. No doc update required.

## Test plan

- [x] \`go test ./...\` in \`erun-common\`, \`erun-cli\`, \`erun-mcp\`, \`erun-ui\`
- [x] Four new \`activity_queue_app_test.go\` scenarios cover the matchers and start/finish behavior
- [x] \`make integration-test\` — four \`real_run_*\` build goldens regenerated with the new trace lines on real-run paths
- [ ] **Manual:** trigger \`erun build --release\` from a desktop Local terminal against a real env, confirm the sidebar row for that env carries a half-circle spinner with the \"Building\" label until \`==> Built in <elapsed>\` clears it