### PR TITLE
Add green-dot indicator + click-to-close for open env rows

### DIFF
--- a/erun-ui/close_environment_test.go
+++ b/erun-ui/close_environment_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestCloseEnvironmentSessionsClosesEveryMatchingSession is the
+// regression for issue #426: the sidebar's "close env" dot must
+// tear down every PTY bound to (tenant, env) — Local + ERun + AI
+// + any extra terminals the user spawned — not just one. The
+// returned slice must list the serial IDs that were closed so the
+// frontend can drop them from tabsByEnv in one round-trip.
+func TestCloseEnvironmentSessionsClosesEveryMatchingSession(t *testing.T) {
+	app := &App{sessions: make(map[string]*managedTerminal)}
+	target := uiSelection{Tenant: "erun", Environment: "local"}
+	stub1 := newStubTerminalSession()
+	stub2 := newStubTerminalSession()
+	stub3 := newStubTerminalSession()
+	app.sessions["erun-local-1"] = &managedTerminal{selection: target, session: stub1, serial: 11, key: "erun-local-1"}
+	app.sessions["erun-local-2"] = &managedTerminal{selection: target, session: stub2, serial: 12, key: "erun-local-2"}
+	app.sessions["erun-local-3"] = &managedTerminal{selection: target, session: stub3, serial: 13, key: "erun-local-3"}
+
+	closed, err := app.CloseEnvironmentSessions(target)
+	if err != nil {
+		t.Fatalf("CloseEnvironmentSessions returned err: %v", err)
+	}
+	if len(closed) != 3 {
+		t.Fatalf("expected 3 sessions closed, got %d (%v)", len(closed), closed)
+	}
+	for _, stub := range []*stubTerminalSession{stub1, stub2, stub3} {
+		select {
+		case <-stub.closeCh:
+		default:
+			t.Fatalf("stub session was not Closed()")
+		}
+	}
+}
+
+// TestCloseEnvironmentSessionsLeavesOtherEnvsAlone guards against a
+// fat-fingered match predicate quietly tearing down a different env
+// (e.g. ignoring tenant, matching only by env name).
+func TestCloseEnvironmentSessionsLeavesOtherEnvsAlone(t *testing.T) {
+	app := &App{sessions: make(map[string]*managedTerminal)}
+	target := uiSelection{Tenant: "erun", Environment: "local"}
+	sameEnvDifferentTenant := uiSelection{Tenant: "petios", Environment: "local"}
+	sameTenantDifferentEnv := uiSelection{Tenant: "erun", Environment: "dev"}
+
+	targetStub := newStubTerminalSession()
+	otherStub := newStubTerminalSession()
+	siblingStub := newStubTerminalSession()
+	app.sessions["target"] = &managedTerminal{selection: target, session: targetStub, serial: 1, key: "target"}
+	app.sessions["other-tenant"] = &managedTerminal{selection: sameEnvDifferentTenant, session: otherStub, serial: 2, key: "other-tenant"}
+	app.sessions["sibling"] = &managedTerminal{selection: sameTenantDifferentEnv, session: siblingStub, serial: 3, key: "sibling"}
+
+	closed, err := app.CloseEnvironmentSessions(target)
+	if err != nil {
+		t.Fatalf("CloseEnvironmentSessions returned err: %v", err)
+	}
+	if len(closed) != 1 || closed[0] != 1 {
+		t.Fatalf("expected only serial 1 closed, got %v", closed)
+	}
+	for name, stub := range map[string]*stubTerminalSession{"other-tenant": otherStub, "sibling": siblingStub} {
+		select {
+		case <-stub.closeCh:
+			t.Fatalf("unrelated session %s was closed", name)
+		default:
+		}
+	}
+}
+
+// TestCloseEnvironmentSessionsSkipsAlreadyClosed guards the
+// idempotency the frontend relies on: clicking the dot a second
+// time after the underlying sessions have already exited (via PTY
+// crash, manual close-tab, etc.) must not return an error and must
+// not double-close a session.
+func TestCloseEnvironmentSessionsSkipsAlreadyClosed(t *testing.T) {
+	app := &App{sessions: make(map[string]*managedTerminal)}
+	target := uiSelection{Tenant: "erun", Environment: "local"}
+	stub := newStubTerminalSession()
+	app.sessions["one"] = &managedTerminal{selection: target, session: stub, serial: 1, key: "one", closed: true}
+
+	closed, err := app.CloseEnvironmentSessions(target)
+	if err != nil {
+		t.Fatalf("CloseEnvironmentSessions returned err: %v", err)
+	}
+	if len(closed) != 0 {
+		t.Fatalf("expected no sessions closed (already marked closed), got %v", closed)
+	}
+	select {
+	case <-stub.closeCh:
+		t.Fatalf("closed-flag session was Close()'d again")
+	default:
+	}
+}
+
+// TestCloseEnvironmentSessionsRejectsEmptyTarget keeps the API
+// contract narrow: the desktop must resolve a tenant/env pair
+// before asking the backend to tear down sessions. A bug that
+// passes an empty selection should fail loudly rather than
+// silently iterating over every session.
+func TestCloseEnvironmentSessionsRejectsEmptyTarget(t *testing.T) {
+	app := &App{sessions: make(map[string]*managedTerminal)}
+	if _, err := app.CloseEnvironmentSessions(uiSelection{}); err == nil {
+		t.Fatal("expected error when tenant and environment are both empty")
+	}
+	if _, err := app.CloseEnvironmentSessions(uiSelection{Tenant: "erun"}); err == nil {
+		t.Fatal("expected error when environment is empty")
+	}
+}

--- a/erun-ui/frontend/src/app/closeEnvironmentThunks.ts
+++ b/erun-ui/frontend/src/app/closeEnvironmentThunks.ts
@@ -1,0 +1,61 @@
+import type { UISelection } from '@/types';
+
+import { CloseEnvironmentSessions } from '../../wailsjs/go/main/App';
+import { readError } from './errors';
+import { showTerminalMessage } from './notificationThunks';
+import { setSelected } from './slices/selectionSlice';
+import { clearEnvOpening } from './slices/sessionsSlice';
+import {
+  clearSelectedSessionForEnv,
+  clearTabsForEnv,
+  setDebugOutput,
+  setSessionId,
+} from './slices/terminalSlice';
+import type { AppThunk } from './store';
+import { selectionKey } from './versionSuggestions';
+
+// closeEnvironment closes every PTY session bound to (tenant, env)
+// on the Go side, then drops the env's tab strip + remembered tab
+// + in-flight opening marker on the frontend, and clears
+// state.selection.selected when it points at this env. Used by the
+// sidebar's "open env" dot — clicking the dot tears down the env's
+// Local / ERun / AI tabs and stops the desktop from tracking the
+// env in its session state.
+//
+// Independent of the cloud-context Stop button: closing the env's
+// tabs is a desktop-only operation and does NOT touch AWS state.
+// Per-session bookkeeping (selectionToSessionId, openSelections,
+// debugBuffers) is cleared by handleTerminalExit as the Go-side
+// Close() fires terminalExitEvent for each session — the thunk
+// only handles env-scoped state that the per-session exit chain
+// would not unwind.
+export const closeEnvironment =
+  (selection: UISelection): AppThunk<Promise<void>> =>
+  async (dispatch, getState) => {
+    const tenant = selection.tenant.trim();
+    const environment = selection.environment.trim();
+    if (!tenant || !environment) {
+      return;
+    }
+    try {
+      await CloseEnvironmentSessions({ tenant, environment });
+    } catch (error: unknown) {
+      dispatch(showTerminalMessage(readError(error)));
+      return;
+    }
+    // Both debug-mode variants of the selection produce distinct keys
+    // in tabsByEnv / selectedSessionByEnv. Clear both so a follow-up
+    // open in either mode starts from a blank slate.
+    for (const debug of [false, true]) {
+      const key = selectionKey({ tenant, environment, debug: debug || undefined });
+      dispatch(clearTabsForEnv(key));
+      dispatch(clearSelectedSessionForEnv(key));
+    }
+    dispatch(clearEnvOpening({ tenant, environment }));
+    const current = getState().selection.selected;
+    if (current?.tenant === tenant && current.environment === environment) {
+      dispatch(setSelected(null));
+      dispatch(setSessionId(0));
+      dispatch(setDebugOutput(''));
+    }
+  };

--- a/erun-ui/frontend/src/app/sessionThunks.ts
+++ b/erun-ui/frontend/src/app/sessionThunks.ts
@@ -612,3 +612,8 @@ export const closeTerminalTab =
       }
     }
   };
+
+// closeEnvironment lives in ./closeEnvironmentThunks so this file
+// stays under the eslint max-lines cap; re-export it here for
+// callers that already reach for session-thunks imports.
+export { closeEnvironment } from './closeEnvironmentThunks';

--- a/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
@@ -5,7 +5,7 @@ import { readError } from '@/app/errors';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { openManageDialog } from '@/app/manageEnvironmentThunks';
 import { showTerminalMessage } from '@/app/notificationThunks';
-import { openSelection } from '@/app/sessionThunks';
+import { closeEnvironment, openSelection } from '@/app/sessionThunks';
 import { envKey } from '@/app/slices/sessionsSlice';
 import { selectionKey } from '@/app/versionSuggestions';
 import { IconTooltip } from '@/components/app/IconTooltip';
@@ -76,6 +76,52 @@ function BusyRowSpinner({ label }: { label: string }): React.ReactElement {
   );
 }
 
+// OpenEnvDot renders a small green circle next to an env name when
+// the env has live tabs registered (the user clicked the row at
+// least once and Local/ERun/AI tabs were spawned). The dot is a
+// real button so clicking it tears those tabs down via the
+// closeEnvironment thunk; stopPropagation keeps the click from
+// bubbling to the row's openSelection handler. Distinct from the
+// LOCAL pill (which marks the row as the dev-machine env) and
+// from BusyRowSpinner (which fires only while an activity-queue
+// entry is running) — open and busy are independent states and
+// can be visible together.
+function OpenEnvDot({
+  tenantName,
+  environmentName,
+  selection,
+}: {
+  tenantName: string;
+  environmentName: string;
+  selection: UISelection;
+}): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const label = `Close ${tenantName} / ${environmentName}`;
+  return (
+    <IconTooltip label={`${label} — terminals + tracking only, leaves AWS untouched`}>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-[18px] flex-none cursor-pointer rounded-full border-0 bg-transparent p-0 text-current hover:bg-[color-mix(in_oklch,currentColor_12%,transparent)]"
+        aria-label={label}
+        data-testid="env-open-dot"
+        onClick={(event) => {
+          event.stopPropagation();
+          void dispatch(closeEnvironment(selection)).catch((error: unknown) => {
+            dispatch(showTerminalMessage(readError(error)));
+          });
+        }}
+      >
+        <span
+          aria-hidden="true"
+          className="block size-2 rounded-full bg-emerald-500 shadow-[0_0_0_1px_color-mix(in_oklch,currentColor_20%,transparent)]"
+        />
+      </Button>
+    </IconTooltip>
+  );
+}
+
 export function EnvironmentRow({
   tenantName,
   environmentName,
@@ -114,6 +160,23 @@ export function EnvironmentRow({
         selectionKey({ tenant: tenantName, environment: environmentName })
       ] === true,
   );
+  // isOpen = the user has opened this env at least once and at least
+  // one of its tabs is still alive. Either debug-mode variant of the
+  // key counts — the dot is per-env, not per-debug-mode. Selector
+  // returns a primitive so React-Redux's default equality short-
+  // circuits row re-renders when unrelated tab maps churn.
+  const isOpen = useAppSelector((state) => {
+    const baseKey = selectionKey({ tenant: tenantName, environment: environmentName });
+    const debugKey = selectionKey({
+      tenant: tenantName,
+      environment: environmentName,
+      debug: true,
+    });
+    return (
+      (state.terminal.tabsByEnv[baseKey]?.length ?? 0) > 0 ||
+      (state.terminal.tabsByEnv[debugKey]?.length ?? 0) > 0
+    );
+  });
   const { selected, busy, busyLabel, isLocal, selection } = deriveEnvironmentRow(
     tenantName,
     environmentName,
@@ -156,6 +219,13 @@ export function EnvironmentRow({
         </TooltipTrigger>
         <TooltipContent side="right">{rowLabel}</TooltipContent>
       </Tooltip>
+      {isOpen && (
+        <OpenEnvDot
+          tenantName={tenantName}
+          environmentName={environmentName}
+          selection={selection}
+        />
+      )}
       <EnvironmentRowEditButton
         tenantName={tenantName}
         environmentName={environmentName}

--- a/erun-ui/playwright/tests/sidebar-open-dot.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-open-dot.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '../fixtures/erunApp.js';
+
+// sidebar-open-dot covers the per-env green dot that signals
+// "this env has tabs open in the desktop" and is clickable to
+// close the env (tear down its Local/ERun/AI tabs and stop
+// tracking it from the desktop session state). The dot is
+// independent of the LOCAL pill (which marks the dev-machine env)
+// and of the busy spinner (which fires only while an
+// activity-queue entry is running): open and busy are independent
+// states and can coexist.
+//
+// The dot is driven by state.terminal.tabsByEnv[selectionKey]
+// having at least one entry. The headless harness exercises the
+// same openSelection thunk a real click hits, so the dot mounts
+// after openEnvironment and disappears after the close click.
+
+test.describe('sidebar env open dot', () => {
+  test('quiet env rows show no open dot', async ({ app, page }) => {
+    // Steady state: no env has been clicked yet in this fresh harness,
+    // so no tabsByEnv entries exist, so no open dot should render. The
+    // negative invariant pins the "default off" branch of the new
+    // selector so a regression that flipped the predicate (e.g. NOT
+    // null-checking the map lookup) would fail loudly here.
+    const tenants = await app.sidebar.tenants();
+    test.skip(tenants.length === 0, 'no tenants in this developer harness');
+    const sidebar = page.locator('aside').first();
+    await expect(sidebar.getByTestId('env-open-dot')).toHaveCount(0);
+  });
+
+  test('opening an env mounts the dot; clicking the dot closes the env', async ({ app, page }) => {
+    const tenants = await app.sidebar.tenants();
+    test.skip(tenants.length === 0, 'no tenants in this developer harness');
+    const tenant = tenants[0]!;
+    const envs = await app.sidebar.environmentsFor(tenant);
+    test.skip(envs.length === 0, `no envs under tenant ${tenant}`);
+    const env = envs[0]!;
+
+    await app.sidebar.openEnvironment(tenant, env);
+
+    // Scope the dot lookup to the same env row to avoid collisions if
+    // multiple envs end up open across the suite — the row containing
+    // the matching edit button is the row this test owns.
+    const sidebar = page.locator('aside').first();
+    const dot = sidebar.getByRole('button', { name: `Close ${tenant} / ${env}` });
+    await expect(dot).toBeVisible({ timeout: 6_000 });
+
+    // Clicking the dot must not also trigger the row's openSelection.
+    // The selected env after the close should NOT remain on the one
+    // we just closed; we assert the dot disappears, which is the
+    // observable signal that tabsByEnv was cleared.
+    await dot.click();
+    await expect(dot).toHaveCount(0, { timeout: 6_000 });
+  });
+});

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -798,6 +798,59 @@ func (a *App) CloseSession(sessionID int) error {
 	return managed.session.Close()
 }
 
+// CloseEnvironmentSessions tears down every managed PTY session
+// bound to the supplied (tenant, environment) pair, regardless of
+// the per-session debug flag, and returns the serial IDs that were
+// closed so the frontend can drop them from tabsByEnv and related
+// session bookkeeping in one round-trip.
+//
+// Used by the sidebar's "close env" affordance (the green dot next
+// to an env name): the user clicked the dot to tear down the env's
+// Local/ERun/AI tabs and stop the desktop from tracking the env.
+// This is a desktop-only operation — it does NOT touch the cloud
+// context's AWS state. See StopCloudContext for that.
+//
+// Collect targets under a.mu, release the lock, then call Close on
+// each — session.Close may block on I/O and can call back into
+// session bookkeeping that re-acquires a.mu, so holding the lock
+// across the close would deadlock.
+func (a *App) CloseEnvironmentSessions(selection uiSelection) ([]int, error) {
+	selection = normalizeSelection(selection)
+	if selection.Tenant == "" || selection.Environment == "" {
+		return nil, fmt.Errorf("tenant and environment are required")
+	}
+	var targets []*managedTerminal
+	a.mu.Lock()
+	for _, managed := range a.sessions {
+		if managed == nil || managed.closed {
+			continue
+		}
+		if managed.selection.Tenant != selection.Tenant {
+			continue
+		}
+		if managed.selection.Environment != selection.Environment {
+			continue
+		}
+		targets = append(targets, managed)
+	}
+	a.mu.Unlock()
+	closed := make([]int, 0, len(targets))
+	var firstErr error
+	for _, managed := range targets {
+		if managed.session == nil {
+			continue
+		}
+		if err := managed.session.Close(); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		closed = append(closed, managed.serial)
+	}
+	return closed, firstErr
+}
+
 func (a *App) sessionBySerialLocked(sessionID int) *managedTerminal {
 	if sessionID <= 0 {
 		return nil


### PR DESCRIPTION
## Summary

Closes #426.

When the user clicks an env row, the desktop spawns its Local / ERun / AI tabs and tracks the env in \`state.terminal.tabsByEnv\`. There was no per-row indicator of that "open" state and no way to close the env short of quitting the app — the existing close path was per-tab only.

- **Go:** \`App.CloseEnvironmentSessions(selection)\` tears down every \`managedTerminal\` matching the (tenant, env) pair and returns the closed serial IDs. Collects targets under \`a.mu\` and releases the lock before \`Close()\` to avoid the session.Close → callback → \`a.mu\` deadlock risk. Idempotent on already-closed sessions.
- **Frontend:** \`closeEnvironment\` thunk calls the Go method, clears \`tabsByEnv[key]\` / \`selectedSessionByEnv[key]\` (both debug-mode variants) and \`openingByEnv\`, and drops \`state.selection.selected\` if it points at the just-closed env. Per-session bookkeeping (\`selectionToSessionId\`, \`openSelections\`, \`debugBuffers\`) is unwound by the existing \`handleTerminalExit\` chain as each \`Close()\` fires \`terminalExitEvent\`.
- **UI:** \`OpenEnvDot\` button on \`Sidebar.EnvironmentRow\` — small \`emerald-500\` circle, rendered when \`tabsByEnv\` has any entry for the env. Tooltip names the action explicitly (\`Close <tenant>/<env> — terminals + tracking only, leaves AWS untouched\`). \`stopPropagation\` keeps the dot click from also triggering the row's open behavior.
- **Independence:** The dot does NOT touch AWS state. Cloud-context Stop (autostop / manual stop) and env-open / env-close are decoupled features — they can be in any combination of states.

## UX Impact Review

1. **Affected paths.** Sidebar env row → \`OpenEnvDot\` click → \`closeEnvironment\` thunk → \`CloseEnvironmentSessions\` Wails call → \`managedTerminal.session.Close()\` per session → existing \`terminalExitEvent\` chain.
2. **User-visible sequence.** Click env row → tabs spawn → green dot appears on the row → click dot → tabs disappear → dot disappears → selection clears if it was this env.
3. **State-without-affordance.** The dot is the affordance for the \`tabsByEnv[key].length > 0\` state. Closing clears all the env-scoped slices in one thunk so no orphaned state lingers.
4. **Visibility of system status (Nielsen #1).** The dot persistently indicates "this env is open." Distinct from the busy spinner (which fires only while an activity-queue entry is running) and the LOCAL pill (dev-machine marker). All three can coexist.
5. **Success and failure feedback (Nielsen #1, #9).** Close completion is visible: the dot vanishes, the env's tabs are gone, the terminal panel detaches if the env was selected. Backend failures surface through \`showTerminalMessage(readError(error))\`.
6. **Consistency with comparable flows (Nielsen #4).** Click-to-act affordance matches the existing edit-kebab button on the same row. Tooltip + accessible label match the surrounding pattern.
7. **Heuristic pass.** Visibility ✓, match-with-user-language ("Close X" is the verb the user thinks) ✓, error-prevention (tooltip spells out exactly what closes and what stays untouched, so a user won't accidentally invoke this expecting AWS to stop) ✓, recognition over recall ✓, user control ✓, accessibility (semantic Button, aria-label, keyboard reachable) ✓.
8. **Playwright coverage.** New \`sidebar-open-dot.spec.ts\` locks the negative state (idle rows have no dot) and the positive flow (open env → dot appears → click dot → dot disappears).

## Tests

- [x] Four Go scenarios in \`close_environment_test.go\` cover the bulk close (every match, leave unrelated alone, skip already-closed, reject empty target).
- [x] \`go test ./...\` in \`erun-ui\` green.
- [x] Frontend \`yarn typecheck && yarn lint && yarn format:check && yarn build\` green.
- [ ] **Manual:** Run \`./erun-ui/playwright/run.sh -- --grep 'open dot'\` on a host with chromium deps installed. Could not execute in this sandbox (host missing \`libnspr4\` / \`libnss3\`, no sudo).
- [ ] **Manual:** In a real desktop session — click an env row, confirm dot appears; click the dot, confirm tabs tear down and the dot disappears; confirm the cloud context stays in whatever state it was in (start/running/stopped) regardless of the dot click.

## Docs

No public CLI surface, MCP description, or \`erun-docs/\` page changes. The dot affordance is purely desktop UI; no documentation update required.