### PR TITLE
Light the sidebar spinner while erun release and erun push run

### DIFF
--- a/erun-cli/cmd/build.go
+++ b/erun-cli/cmd/build.go
@@ -115,7 +115,9 @@ func newPushCmd(store common.DockerStore, findProjectRoot common.ProjectFinderFu
 				}
 				return buildErr
 			}
-			return common.RunDockerPushSpec(ctx, pushInput, buildInput, builderWithGuidance, push)
+			return common.RunPushCommand(ctx, func() error {
+				return common.RunDockerPushSpec(ctx, pushInput, buildInput, builderWithGuidance, push)
+			})
 		},
 	}
 	addDryRunFlag(cmd)
@@ -167,13 +169,17 @@ func newRootPushCmd(store common.DockerStore, findProjectRoot common.ProjectFind
 				if err != nil {
 					return err
 				}
-				return common.RunDockerPushSpec(ctx, pushInput, buildInput, builderWithGuidance, push)
+				return common.RunPushCommand(ctx, func() error {
+					return common.RunDockerPushSpec(ctx, pushInput, buildInput, builderWithGuidance, push)
+				})
 			}
 			execution, err := common.ResolveDockerPushExecution(ctx, store, findProjectRoot, resolveBuildContext, now, target)
 			if err != nil {
 				return err
 			}
-			return common.RunDockerPushExecution(ctx, execution, builderWithGuidance, push)
+			return common.RunPushCommand(ctx, func() error {
+				return common.RunDockerPushExecution(ctx, execution, builderWithGuidance, push)
+			})
 		},
 	}
 	addDryRunFlag(cmd)

--- a/erun-common/build_run.go
+++ b/erun-common/build_run.go
@@ -124,7 +124,12 @@ func runBuildExecution(ctx Context, execution BuildExecutionSpec, deploySpecs []
 		}()
 	}
 	if execution.release != nil {
-		if err = RunReleaseSpec(ctx, *execution.release, nil, runScript); err != nil {
+		// Call the unexported runReleaseSpec, not the exported
+		// RunReleaseSpec: the release phase here is already wrapped by
+		// the `==> Building` umbrella above, so emitting RunReleaseSpec's
+		// own `==> Releasing` markers would register a redundant second
+		// activity entry for the same `erun build --release` invocation.
+		if err = runReleaseSpec(ctx, *execution.release, nil, runScript, nil); err != nil {
 			return err
 		}
 	}
@@ -244,6 +249,36 @@ func deployedVersionForSpecs(specs []DeploySpec) string {
 		}
 	}
 	return version
+}
+
+// RunPushCommand wraps a standalone `erun push` operation with the
+// `==> Pushing` / `==> Pushed in N` / `==> Push failed after N` umbrella
+// traces the desktop's activity-queue parser keys off so the sidebar
+// spinner lights while the push runs (mirrors runBuildExecution's
+// `==> Building`). Real run only: dry-run does no work.
+//
+// Only the standalone push entrypoints (the CLI `push` command and the
+// MCP push tool) route through here. Pushes that happen inside
+// `erun build`/`erun build --deploy` are already covered by the
+// `==> Building` umbrella, and the shared push executors
+// (RunDockerPushExecution / RunDockerPushSpec) run per-image inside that
+// flow — bracketing them directly would emit a marker per image and
+// double-fire under `==> Building`.
+func RunPushCommand(ctx Context, op func() error) (err error) {
+	if ctx.DryRun {
+		return op()
+	}
+	started := time.Now()
+	ctx.Info("==> Pushing")
+	defer func() {
+		elapsed := time.Since(started).Round(time.Second)
+		if err != nil {
+			ctx.Info("==> Push failed after " + elapsed.String())
+			return
+		}
+		ctx.Info("==> Pushed in " + elapsed.String())
+	}()
+	return op()
 }
 
 func RunDockerPush(ctx Context, pushInput DockerPushSpec, push DockerImagePusherFunc) error {

--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -168,7 +168,34 @@ func resolveReleaseSpec(ctx Context, findProjectRoot ProjectFinderFunc, loadProj
 
 type ReleasePackagingSyncerFunc func(Context, ReleasePackagingSyncSpec) ([]ReleaseFileUpdate, error)
 
-func RunReleaseSpec(ctx Context, spec ReleaseSpec, runGit GitCommandRunnerFunc, runScript BuildScriptRunnerFunc) error {
+func RunReleaseSpec(ctx Context, spec ReleaseSpec, runGit GitCommandRunnerFunc, runScript BuildScriptRunnerFunc) (err error) {
+	// `==> Releasing` / `==> Released ... in N` / `==> Release failed
+	// after N` are the umbrella traces the desktop's activity-queue
+	// parser keys off so a standalone `erun release` lights the sidebar
+	// spinner (mirrors RunHelmDeploy's `==> Deploying` and
+	// runBuildExecution's `==> Building`). Real run only: dry-run does no
+	// work, and skipping these lines keeps the dry-run release goldens
+	// stable. `erun build --release` does not pass through here —
+	// runBuildExecution calls the unexported runReleaseSpec directly so
+	// the release phase stays under the single `==> Building` umbrella
+	// instead of double-bracketing with a second activity entry.
+	if !ctx.DryRun {
+		releasing, released := "==> Releasing", "==> Released"
+		if target := strings.TrimSpace(spec.Version); target != "" {
+			releasing += " " + target
+			released += " " + target
+		}
+		started := time.Now()
+		ctx.Info(releasing)
+		defer func() {
+			elapsed := time.Since(started).Round(time.Second)
+			if err != nil {
+				ctx.Info("==> Release failed after " + elapsed.String())
+				return
+			}
+			ctx.Info(released + " in " + elapsed.String())
+		}()
+	}
 	return runReleaseSpec(ctx, spec, runGit, runScript, syncReleasePackagingChecksums)
 }
 

--- a/erun-integration/release_test.go
+++ b/erun-integration/release_test.go
@@ -195,4 +195,35 @@ func TestRelease(t *testing.T) {
 		}
 		golden.Equal(t, "release/dry_run_with_untracked_file_reports_worktree_clean", normalize.Apply(result.Combined))
 	})
+
+	t.Run("real_run_emits_release_lifecycle_traces", func(t *testing.T) {
+		// Real-run (no --dry-run) candidate release. Exercises the
+		// `==> Releasing` / `==> Released ... in <ELAPSED>` umbrella
+		// traces RunReleaseSpec emits via Info — the desktop activity
+		// queue keys off them to light the sidebar spinner for a
+		// standalone `erun release`. These lines are emitted only on a
+		// real run, so dry-run goldens cannot cover them (mirrors
+		// deploy_test.go's real_run_via_stubs and the build real-run
+		// goldens). git is stubbed: resolution queries return canned
+		// branch/commit, the tag-existence probe reports "not found" so
+		// the tag is not skipped, and every mutation (fetch/rebase/
+		// commit/tag/push) is a silent no-op — keeping the captured
+		// output deterministic without a real remote or network.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "develop")
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinaryWithScript(t, stubs, "git", `case "$*" in
+  *'rev-parse --abbrev-ref HEAD'*) echo develop ;;
+  *'rev-parse --short HEAD'*) echo abc1234 ;;
+  *'^{}'*) exit 1 ;;
+  *) exit 0 ;;
+esac
+`)
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "git")...)
+		result := erun.Run(t, []string{"release"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "release/real_run_emits_release_lifecycle_traces", normalize.Apply(result.Combined))
+	})
 }

--- a/erun-integration/testdata/push/devops_container_push_real_run_resolves_single_image_spec.txt
+++ b/erun-integration/testdata/push/devops_container_push_real_run_resolves_single_image_spec.txt
@@ -1,1 +1,3 @@
 audit: erun devops container push --version <VERSION>
+==> Pushing
+==> Pushed in <ELAPSED>

--- a/erun-integration/testdata/push/real_run_auth_failure_retries_after_login_via_auto_login_env.txt
+++ b/erun-integration/testdata/push/real_run_auth_failure_retries_after_login_via_auto_login_env.txt
@@ -1,2 +1,4 @@
 audit: erun push
+==> Pushing
 unauthorized: authentication required: denied: requested access to the resource is denied
+==> Pushed in <ELAPSED>

--- a/erun-integration/testdata/push/real_run_create_package_denied_emits_guidance.txt
+++ b/erun-integration/testdata/push/real_run_create_package_denied_emits_guidance.txt
@@ -1,4 +1,5 @@
 audit: erun push
+==> Pushing
 denied: denied: create_package permission_denied
 
 ghcr.io rejected the push: only the namespace owner can create new packages under ghcr.io/sophium/.
@@ -13,4 +14,5 @@ To bootstrap the first version of this image, get a personal access token from t
 
 After the package exists the owner can grant Write access to others (per-package settings, or via "Inherit access from source repository" on a linked repo). Future versions can then be pushed by anyone with that access — no PAT needed.
 
+==> Push failed after <ELAPSED>
 denied: denied: create_package permission_denied

--- a/erun-integration/testdata/push/real_run_scope_denied_attempts_scope_refresh.txt
+++ b/erun-integration/testdata/push/real_run_scope_denied_attempts_scope_refresh.txt
@@ -1,3 +1,5 @@
 audit: erun push
+==> Pushing
 denied: token does not match expected scopes
 denied: token does not match expected scopes
+==> Pushed in <ELAPSED>

--- a/erun-integration/testdata/release/real_run_emits_release_lifecycle_traces.txt
+++ b/erun-integration/testdata/release/real_run_emits_release_lifecycle_traces.txt
@@ -1,0 +1,22 @@
+<VERSION>
+audit: erun release
+release: resolving project root
+release: project root = <TMP>
+release: resolving release module root
+release: release root = <TMP>
+release: loading release config from project
+release: main branch = main, develop branch = develop
+release: resolving git branch and commit
+release: branch = develop, commit = <SHORTSHA>
+release: resolving base version from VERSION file
+release: base version = <VERSION> (from <TMP>
+release: classified mode = candidate
+release: develop branch "develop" exists = true
+==> Releasing <VERSION>
+release: branch=develop mode=candidate version=<VERSION>
+docker image: ghcr.io/sophium/api:<VERSION>
+release: worktree clean = true
+stage: sync-remote
+stage: release
+stage: push
+==> Released <VERSION> in <ELAPSED>

--- a/erun-mcp/build.go
+++ b/erun-mcp/build.go
@@ -59,7 +59,9 @@ func pushTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest,
 			if err != nil {
 				return err
 			}
-			return eruncommon.RunDockerPushExecution(runCtx, execution, runtime.BuildDockerImage, runtimePushFunc(runtime))
+			return eruncommon.RunPushCommand(runCtx, func() error {
+				return eruncommon.RunDockerPushExecution(runCtx, execution, runtime.BuildDockerImage, runtimePushFunc(runtime))
+			})
 		})
 		return nil, output, err
 	}

--- a/erun-ui/activity_queue_app.go
+++ b/erun-ui/activity_queue_app.go
@@ -343,6 +343,29 @@ var activityBuiltLineRe = regexp.MustCompile(`^==> Built\b`)
 // returns an error.
 var activityBuildFailedLineRe = regexp.MustCompile(`^==> Build failed\b`)
 
+// activityReleasing/Released/ReleaseFailed match the umbrella traces
+// RunReleaseSpec emits for a standalone `erun release` (mirrors
+// `==> Building`). Like build they carry no tenant/env, so the handler
+// keys the activity off the session selection. `erun build --release`
+// does not emit these — runBuildExecution calls the unexported
+// runReleaseSpec, keeping that flow under the single `==> Building`
+// umbrella.
+var (
+	activityReleasingLineRe     = regexp.MustCompile(`^==> Releasing\b`)
+	activityReleasedLineRe      = regexp.MustCompile(`^==> Released\b`)
+	activityReleaseFailedLineRe = regexp.MustCompile(`^==> Release failed\b`)
+)
+
+// activityPushing/Pushed/PushFailed match the umbrella traces
+// RunPushCommand emits for a standalone `erun push`. Build-internal
+// pushes stay under the `==> Building` umbrella, so these only fire for
+// the push command itself.
+var (
+	activityPushingLineRe    = regexp.MustCompile(`^==> Pushing\b`)
+	activityPushedLineRe     = regexp.MustCompile(`^==> Pushed\b`)
+	activityPushFailedLineRe = regexp.MustCompile(`^==> Push failed\b`)
+)
+
 // newActivityTraceLineHandler scans PTY output for trace lines emitted by
 // erun deploy and updates the activity queue accordingly.
 //
@@ -395,15 +418,39 @@ func newActivityTraceLineHandler(app *App, selection uiSelection, kind sessionKi
 			return
 		}
 		if activityBuildingLineRe.MatchString(line) {
-			app.startBuildFromTrace(selection)
+			app.startCommandFromTrace(selection, "build")
 			return
 		}
 		if activityBuiltLineRe.MatchString(line) {
-			app.finishBuildBySelection(selection, activityQueueStatusSucceeded, "")
+			app.finishCommandBySelection(selection, "build", activityQueueStatusSucceeded, "")
 			return
 		}
 		if activityBuildFailedLineRe.MatchString(line) {
-			app.finishBuildBySelection(selection, activityQueueStatusFailed, line)
+			app.finishCommandBySelection(selection, "build", activityQueueStatusFailed, line)
+			return
+		}
+		if activityReleasingLineRe.MatchString(line) {
+			app.startCommandFromTrace(selection, "release")
+			return
+		}
+		if activityReleasedLineRe.MatchString(line) {
+			app.finishCommandBySelection(selection, "release", activityQueueStatusSucceeded, "")
+			return
+		}
+		if activityReleaseFailedLineRe.MatchString(line) {
+			app.finishCommandBySelection(selection, "release", activityQueueStatusFailed, line)
+			return
+		}
+		if activityPushingLineRe.MatchString(line) {
+			app.startCommandFromTrace(selection, "push")
+			return
+		}
+		if activityPushedLineRe.MatchString(line) {
+			app.finishCommandBySelection(selection, "push", activityQueueStatusSucceeded, "")
+			return
+		}
+		if activityPushFailedLineRe.MatchString(line) {
+			app.finishCommandBySelection(selection, "push", activityQueueStatusFailed, line)
 			return
 		}
 		switch {
@@ -539,23 +586,24 @@ func (a *App) startDeployFromTrace(selection uiSelection, tenant, environment, v
 	}
 }
 
-// startBuildFromTrace registers a build entry from a `==> Building`
-// trace observed in the session's PTY. Unlike deploy/init the trace
-// line carries no tenant/env (build has no deploy target the way
+// startCommandFromTrace registers a build/release/push entry from a
+// `==> Building` / `==> Releasing` / `==> Pushing` trace observed in
+// the session's PTY. Unlike deploy/init these umbrella lines carry no
+// tenant/env (build, release, and push have no deploy target the way
 // RunHelmDeploy does), so the activity is keyed off the session
-// selection — the user invoked the build from a specific terminal
+// selection — the user invoked the command from a specific terminal
 // tab, and that tab's env row is the natural place to render the
-// spinner. No-op when the selection has no tenant/env yet (a
-// generic Local shell at the repo level): there is no row to attach
-// the indicator to, and a stray activity entry with empty
-// tenant/env would land on every row.
+// spinner. No-op when the selection has no tenant/env yet (a generic
+// Local shell at the repo level): there is no row to attach the
+// indicator to, and a stray activity entry with empty tenant/env
+// would land on every row.
 //
 // Intentionally skips lockTerminalsForActivity: deploys lock the
 // session so a user cannot run conflicting commands while helm is
-// rolling out, but a build runs IN the user's terminal — locking it
-// would freeze the very tab the user is reading build output in.
-// The sidebar spinner is the only indicator the build needs.
-func (a *App) startBuildFromTrace(selection uiSelection) {
+// rolling out, but build/release/push run IN the user's terminal —
+// locking it would freeze the very tab the user is reading output in.
+// The sidebar spinner is the only indicator these commands need.
+func (a *App) startCommandFromTrace(selection uiSelection, command string) {
 	if a.activityQueue == nil {
 		return
 	}
@@ -564,30 +612,30 @@ func (a *App) startBuildFromTrace(selection uiSelection) {
 	if tenant == "" || environment == "" {
 		return
 	}
-	if _, ok := a.activityQueue.findActiveByCommand("build", tenant, environment); ok {
+	if _, ok := a.activityQueue.findActiveByCommand(command, tenant, environment); ok {
 		return
 	}
 	kubeContext := a.resolveActivityKubeContext(selection, tenant, environment)
 	if _, fresh := a.activityQueue.start(activityQueueEntry{
-		Command:           "build",
+		Command:           command,
 		Tenant:            tenant,
 		Environment:       environment,
 		KubernetesContext: kubeContext,
 		Source:            "trace",
-		Summary:           "build " + tenant + "/" + environment,
+		Summary:           command + " " + tenant + "/" + environment,
 	}); !fresh {
 		return
 	}
 	a.rememberKubeContextForActivity(kubeContext)
 }
 
-// finishBuildBySelection finalizes the build entry registered by
-// startBuildFromTrace. Keyed off the session selection because the
-// `==> Built` / `==> Build failed` lines carry no tenant/env — see
-// startBuildFromTrace for the identity rationale. Idempotent unlock
-// in case a previous code path latched a lock that this entry did
-// not.
-func (a *App) finishBuildBySelection(selection uiSelection, status activityQueueStatus, errMsg string) {
+// finishCommandBySelection finalizes the build/release/push entry
+// registered by startCommandFromTrace. Keyed off the session selection
+// because the `==> Built` / `==> Released` / `==> Pushed` (and failed)
+// lines carry no tenant/env — see startCommandFromTrace for the
+// identity rationale. Idempotent unlock in case a previous code path
+// latched a lock that this entry did not.
+func (a *App) finishCommandBySelection(selection uiSelection, command string, status activityQueueStatus, errMsg string) {
 	if a.activityQueue == nil {
 		return
 	}
@@ -596,7 +644,7 @@ func (a *App) finishBuildBySelection(selection uiSelection, status activityQueue
 	if tenant == "" || environment == "" {
 		return
 	}
-	entry, ok := a.activityQueue.findActiveByCommand("build", tenant, environment)
+	entry, ok := a.activityQueue.findActiveByCommand(command, tenant, environment)
 	if !ok {
 		return
 	}

--- a/erun-ui/activity_queue_app_test.go
+++ b/erun-ui/activity_queue_app_test.go
@@ -264,18 +264,105 @@ func TestActivityTraceLineHandlerSkipsBuildWithoutSelection(t *testing.T) {
 	}
 }
 
-func TestStartBuildFromTraceDoesNotLockTerminal(t *testing.T) {
-	// Build runs IN the user's terminal, so locking the session would
-	// freeze the very tab they are reading build output in. Verify the
-	// build path skips the lock that deploy uses to prevent concurrent
-	// helm runs.
+func TestStartCommandFromTraceDoesNotLockTerminal(t *testing.T) {
+	// Build/release/push run IN the user's terminal, so locking the
+	// session would freeze the very tab they are reading output in.
+	// Verify the path skips the lock that deploy uses to prevent
+	// concurrent helm runs, for every command keyed off the selection.
+	for _, command := range []string{"build", "release", "push"} {
+		app := newTestAppForActivityQueue(t)
+		selection := uiSelection{Tenant: "erun", Environment: "local"}
+		envSession := &managedTerminal{selection: selection, key: "env\x00erun\x00local", serial: 1, kind: sessionKindOpen}
+		app.sessions[envSession.key] = envSession
+		app.startCommandFromTrace(selection, command)
+		if envSession.lockedByActivity != "" {
+			t.Fatalf("expected %s to not lock terminal, got %q", command, envSession.lockedByActivity)
+		}
+	}
+}
+
+func TestActivityTraceLineHandlerStartsAndFinishesRelease(t *testing.T) {
+	// `erun release` (standalone) emits `==> Releasing`/`==> Released`
+	// with no tenant/env, so the handler keys the activity off the
+	// session selection — the same contract as build. Without this the
+	// sidebar shows no spinner while a release the user kicked off in a
+	// tenant/env-bound terminal runs.
 	app := newTestAppForActivityQueue(t)
 	selection := uiSelection{Tenant: "erun", Environment: "local"}
-	envSession := &managedTerminal{selection: selection, key: "env\x00erun\x00local", serial: 1, kind: sessionKindOpen}
-	app.sessions[envSession.key] = envSession
-	app.startBuildFromTrace(selection)
-	if envSession.lockedByActivity != "" {
-		t.Fatalf("expected build to not lock terminal, got %q", envSession.lockedByActivity)
+	handler := newActivityTraceLineHandler(app, selection, sessionKindOpen)
+
+	handler("==> Releasing 1.4.2")
+	entry, ok := app.activityQueue.findActiveByCommand("release", "erun", "local")
+	if !ok {
+		t.Fatal("expected release entry to be active after ==> Releasing")
+	}
+	if entry.Source != "trace" {
+		t.Fatalf("expected source=trace, got %q", entry.Source)
+	}
+
+	handler("==> Released 1.4.2 in 12s")
+	if _, ok := app.activityQueue.findActiveByCommand("release", "erun", "local"); ok {
+		t.Fatal("expected release entry to be finished after ==> Released")
+	}
+	all := app.activityQueue.list()
+	if len(all) != 1 || all[0].Status != activityQueueStatusSucceeded {
+		t.Fatalf("expected one succeeded entry, got %+v", all)
+	}
+}
+
+func TestActivityTraceLineHandlerFinalizesReleaseOnFailure(t *testing.T) {
+	app := newTestAppForActivityQueue(t)
+	selection := uiSelection{Tenant: "erun", Environment: "local"}
+	handler := newActivityTraceLineHandler(app, selection, sessionKindLocal)
+
+	handler("==> Releasing 1.4.2")
+	handler("==> Release failed after 5s")
+
+	all := app.activityQueue.list()
+	if len(all) != 1 || all[0].Status != activityQueueStatusFailed {
+		t.Fatalf("expected one failed entry, got %+v", all)
+	}
+	if !strings.Contains(all[0].Error, "Release failed") {
+		t.Fatalf("expected Release failed in error, got %q", all[0].Error)
+	}
+}
+
+func TestActivityTraceLineHandlerStartsAndFinishesPush(t *testing.T) {
+	// `erun push` (standalone) emits `==> Pushing`/`==> Pushed`, keyed
+	// off the session selection like build/release.
+	app := newTestAppForActivityQueue(t)
+	selection := uiSelection{Tenant: "erun", Environment: "local"}
+	handler := newActivityTraceLineHandler(app, selection, sessionKindOpen)
+
+	handler("==> Pushing")
+	if _, ok := app.activityQueue.findActiveByCommand("push", "erun", "local"); !ok {
+		t.Fatal("expected push entry to be active after ==> Pushing")
+	}
+
+	handler("==> Pushed in 8s")
+	if _, ok := app.activityQueue.findActiveByCommand("push", "erun", "local"); ok {
+		t.Fatal("expected push entry to be finished after ==> Pushed")
+	}
+	all := app.activityQueue.list()
+	if len(all) != 1 || all[0].Status != activityQueueStatusSucceeded {
+		t.Fatalf("expected one succeeded entry, got %+v", all)
+	}
+}
+
+func TestActivityTraceLineHandlerFinalizesPushOnFailure(t *testing.T) {
+	app := newTestAppForActivityQueue(t)
+	selection := uiSelection{Tenant: "erun", Environment: "local"}
+	handler := newActivityTraceLineHandler(app, selection, sessionKindLocal)
+
+	handler("==> Pushing")
+	handler("==> Push failed after 3s")
+
+	all := app.activityQueue.list()
+	if len(all) != 1 || all[0].Status != activityQueueStatusFailed {
+		t.Fatalf("expected one failed entry, got %+v", all)
+	}
+	if !strings.Contains(all[0].Error, "Push failed") {
+		t.Fatalf("expected Push failed in error, got %q", all[0].Error)
 	}
 }
 

--- a/erun-ui/playwright/tests/sidebar-busy-spinner.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-busy-spinner.spec.ts
@@ -1,18 +1,22 @@
 import { expect, test } from '../fixtures/erunApp.js';
 
-// sidebar-busy-spinner covers the new running-command spinner that appears
+// sidebar-busy-spinner covers the running-command spinner that appears
 // next to an env name when an activity-queue entry for that env is in
-// 'running' state (deploy / init / sshd-init / doctor / build / push /
-// release). Activity-queue entries are populated by real terminal sessions
-// firing activity events; the headless harness has no portable way to
-// stage a running deploy per playwright/AGENTS.md. The spec therefore
-// locks the closest reachable invariant: an env that has no live activity
-// queued against it must NOT carry a spinner in steady state. The
-// positive flow is covered by the existing sidebar spec
-// "opening an environment surfaces status feedback" (which exercises the
-// same BusyRowSpinner via the isOpening path) plus the
-// deriveEnvironmentRow logic in Sidebar.helpers.ts, which selects the
-// busy state and aria-label.
+// 'running' state (deploy / init / build / release / push). A *deploy*
+// entry cannot be staged from the headless harness (it needs the helm
+// poller + cluster state per playwright/AGENTS.md), so the first two
+// tests lock the negative invariant: a quiet env carries no spinner, and
+// navigating away does not strand one.
+//
+// build / release / push entries, by contrast, are pure trace-driven
+// entries keyed off the session selection (no cluster dependency), so the
+// activity:state Wails event can stage one directly — the same staging
+// ux-tooltip-rules.spec.ts uses. The third test drives the positive flow
+// end to end: a running entry lights a labelled spinner on the env row,
+// and finishing it clears the spinner. This is the observable contract
+// that #428 wired up (CLI emits ==> Building/Releasing/Pushing, the
+// desktop registers a running entry, deriveEnvironmentRow renders the
+// spinner + per-command aria-label).
 
 test.describe('sidebar busy spinner', () => {
   test('quiet env rows show no spinner', async ({ app, page }) => {
@@ -60,5 +64,71 @@ test.describe('sidebar busy spinner', () => {
     const sidebar = page.locator('aside').first();
     const spinners = sidebar.getByRole('status');
     await expect(spinners).toHaveCount(0, { timeout: 5_000 });
+  });
+
+  test('running build/release/push entries surface a labelled spinner that clears on finish', async ({
+    app,
+    page,
+  }) => {
+    const tenants = await app.sidebar.tenants();
+    expect(tenants.length).toBeGreaterThan(0);
+    const tenant = tenants[0]!;
+    const envs = await app.sidebar.environmentsFor(tenant);
+    expect(envs.length).toBeGreaterThan(0);
+    const environment = envs[0]!;
+
+    const sidebar = page.locator('aside').first();
+    // Intentionally no "sidebar has zero spinners" precondition: the
+    // harness may still be settling an auto-open of the restored env
+    // ("Opening <t>/<e>..." is the isOpening spinner), which is unrelated
+    // to this test. We instead assert on the *specific* per-command
+    // label, which deriveEnvironmentRow gives precedence over the opening
+    // label, so the assertions are robust to a concurrent open.
+
+    const emitActivity = (command: string, status: 'running' | 'succeeded') =>
+      page.evaluate(
+        ({ command, status, tenant, environment }) => {
+          const runtime = (
+            window as unknown as {
+              runtime: { EventsEmit: (name: string, ...args: unknown[]) => void };
+            }
+          ).runtime;
+          const now = new Date().toISOString();
+          runtime.EventsEmit('activity:state', {
+            id: `spinner-spec-${command}`,
+            command,
+            tenant,
+            environment,
+            status,
+            startedAt: now,
+            lastUpdated: now,
+            endedAt: status === 'running' ? undefined : now,
+            source: 'trace',
+            summary: `${command} ${tenant}/${environment}`,
+          });
+        },
+        { command, status, tenant, environment },
+      );
+
+    // Each command maps to its own verb in deriveEnvironmentRow's
+    // busyLabel; staging a running entry must light a spinner whose
+    // accessible name names the operation and the target env.
+    for (const { command, verb } of [
+      { command: 'build', verb: 'Building' },
+      { command: 'release', verb: 'Releasing' },
+      { command: 'push', verb: 'Pushing' },
+    ]) {
+      const labelledSpinner = sidebar.getByRole('status', {
+        name: `${verb} ${tenant} / ${environment}`,
+      });
+      await emitActivity(command, 'running');
+      await expect(labelledSpinner).toBeVisible();
+
+      // Finishing the entry removes this command's spinner. Scope the
+      // assertion to the command label so a concurrent isOpening spinner
+      // on the same row does not make the test flaky.
+      await emitActivity(command, 'succeeded');
+      await expect(labelledSpinner).toHaveCount(0);
+    }
   });
 });


### PR DESCRIPTION
## Problem

While a long `erun release` or `erun push` runs in an environment's terminal tab, the env's sidebar row shows **no spinner** — no visibility that work is in flight. (The screenshot on #428 is `erun build --release`; the **build** half was since fixed by #425, but the standalone release/push commands were still uncovered.)

## Root cause

The sidebar spinner and activity drawer were wired in #332 to render `build`/`release`/`push` activity-queue entries (labels in `Sidebar.helpers.ts`, badge colors + subtitles in `ActivityQueueDrawer.helpers.ts`), but only `deploy`/`init` (and, since #425, `build`) ever **produce** a running entry. Entries are created from `==>` lifecycle markers parsed by `newActivityTraceLineHandler` in `erun-ui/activity_queue_app.go`; standalone `erun release` and `erun push` emitted no such marker, so `deriveEnvironmentRow` never set `busy`.

## Change

Completes the build → release → push → deploy spinner contract for the two missing standalone commands. **No frontend change** — the spinner labels and drawer cards already handle these commands.

- **erun-common**: `RunReleaseSpec` emits `==> Releasing` / `==> Released … in N` / `==> Release failed after N`; a new `RunPushCommand` umbrella emits `==> Pushing` / `==> Pushed in N` / `==> Push failed after N`. Real-run only, mirroring #425's `==> Building` and `RunHelmDeploy`'s `==> Deploying`.
- `runBuildExecution` now calls the unexported `runReleaseSpec`, so `erun build --release` stays under the single `==> Building` umbrella instead of registering a redundant nested release entry.
- **erun-cli / erun-mcp**: `erun push`, `erun devops container push`, and the MCP push tool wrap their push execution in `RunPushCommand`. Build-internal per-image pushes are untouched (already under `==> Building`).
- **erun-ui**: the trace handler parses the new markers and registers `release`/`push` entries keyed off the session selection (these commands have no deploy target). `startBuildFromTrace`/`finishBuildBySelection` generalized to `startCommandFromTrace`/`finishCommandBySelection`. No terminal locking, no kube poller (both already gated to `deploy`).

## UX Impact Review (erun-ui/AGENTS.md)

1. **Affected paths**: `erun release` / `erun push` in an env-bound terminal tab → PTY trace → activity-queue parser → running entry → sidebar `BusyRowSpinner` + activity drawer card.
2. **User-visible sequence**: command starts → row shows a spinner labelled "Releasing &lt;t&gt; / &lt;e&gt;" / "Pushing &lt;t&gt; / &lt;e&gt;"; on completion the entry flips to succeeded/failed (drawer card) and the spinner clears.
3. **State-without-affordance**: the new running entries map 1:1 onto existing affordances (spinner + drawer card); no orphan state.
4. **Visibility of system status (#1)**: persistent spinner for the operation's duration — the gap this PR closes.
5. **Success/failure feedback (#1, #9)**: succeeded/failed activity card after completion; failed markers fire on the error path.
6. **Consistency (#4)**: identical to `deploy`/`init` and to `build` (#425).
7. **Heuristic pass**: no new controls, labels, or colors — reuses the established pattern; accessibility unchanged (`role="status"` + per-command aria-label already in `BusyRowSpinner`).
8. **Playwright**: `sidebar-busy-spinner.spec.ts` extended with a positive test that stages running build/release/push entries via the `activity:state` event and asserts the labelled spinner appears and clears.

## Docs

No `erun-docs` change. The per-command activity spinner/drawer is not documented at this granularity (neither are `deploy`/`init`), and `desktop/overview.md`'s "live status" refers to cloud-machine lifecycle, not the activity spinner.

## Validation

- `go test ./...` in erun-common, erun-cli, erun-mcp, erun-ui — all pass.
- `make integration-test` green: release markers locked in a new real-run scenario (git-stubbed, deterministic), push markers locked in the existing real-run push goldens on both success and failure paths; coverage 57.0% ≥ 55.0%. No build/dry-run goldens changed.
- `./playwright/run.sh` — spinner/activity specs pass, including the new positive test. 4 unrelated specs fail on this dev harness (env-dependent open-dot/notification/titlebar + known #413); **confirmed identical failures on clean `main`**, so no regression from this change.
- Not verified by automation: running `erun release`/`erun push` inside the actual desktop Wails window and watching the pixel spin (requires a human-driven GUI + a real release/push pipeline). Covered as closely as the headless harness allows — the CLI→parser→React chain is verified at each link (integration golden → erun-ui handler test → Playwright render).

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)