### PR TITLE
Refit terminal immediately on layout panel toggles

### DIFF
--- a/erun-ui/frontend/src/app/TerminalController.ts
+++ b/erun-ui/frontend/src/app/TerminalController.ts
@@ -75,6 +75,7 @@ export class TerminalController {
   private _diffList: HTMLDivElement | null = null;
   private resizeObserver: ResizeObserver | null = null;
   private resizeTimer = 0;
+  private resizeFrame = 0;
   private reviewScrollFrame = 0;
   private idleStatusTimer = 0;
   private reviewDiffRefreshTimer = 0;
@@ -126,6 +127,15 @@ export class TerminalController {
 
   fitTerminal(): void {
     this.fitAddon?.fit();
+    this.publishTerminalDims();
+  }
+
+  private publishTerminalDims(): void {
+    if (!this.terminalRoot || !this.terminal) {
+      return;
+    }
+    this.terminalRoot.dataset.terminalCols = String(this.terminal.cols);
+    this.terminalRoot.dataset.terminalRows = String(this.terminal.rows);
   }
 
   mount(elements: MountElements): () => void {
@@ -156,6 +166,7 @@ export class TerminalController {
     this.terminal.loadAddon(this.fitAddon);
     this.terminal.open(elements.terminalRoot);
     this.fitAddon.fit();
+    this.publishTerminalDims();
 
     this.terminalQueryResponseDisposables = registerTerminalQueryResponseHandlers(
       this.terminal,
@@ -231,6 +242,12 @@ export class TerminalController {
   private unmountTerminal(): void {
     window.removeEventListener('resize', this.queueTerminalResize);
     this.resizeObserver?.disconnect();
+    window.clearTimeout(this.resizeTimer);
+    this.resizeTimer = 0;
+    if (this.resizeFrame !== 0) {
+      window.cancelAnimationFrame(this.resizeFrame);
+      this.resizeFrame = 0;
+    }
     this.terminalDataDisposable?.dispose();
     for (const disposable of this.terminalQueryResponseDisposables) {
       disposable.dispose();
@@ -342,6 +359,7 @@ export class TerminalController {
     applyLayoutVars: () => void;
     focusTerminalSoon: () => void;
     queueTerminalResize: () => void;
+    flushTerminalResize: () => void;
   } {
     return {
       applyLayoutVars: () => {
@@ -351,6 +369,7 @@ export class TerminalController {
         this.focusTerminalSoon();
       },
       queueTerminalResize: this.queueTerminalResize,
+      flushTerminalResize: this.flushTerminalResize,
     };
   }
 
@@ -395,14 +414,39 @@ export class TerminalController {
   queueTerminalResize = (): void => {
     window.clearTimeout(this.resizeTimer);
     this.resizeTimer = window.setTimeout(() => {
-      this.applyLayoutVars();
-      this.fitAddon?.fit();
-      const sessionId = store.getState().terminal.sessionId;
-      if (sessionId > 0 && this.terminal) {
-        ResizeSession(sessionId, this.terminal.cols, this.terminal.rows).catch(noop);
-      }
+      this.runTerminalResize();
     }, 40);
   };
+
+  // flushTerminalResize fits the terminal on the next animation frame
+  // and resizes the PTY immediately, bypassing the 40 ms debounce that
+  // queueTerminalResize uses to coalesce drag/ResizeObserver bursts.
+  // One-shot layout toggles (review/sidebar/debug) call this so the
+  // shell sees the new cols before its next prompt redraw — the gap
+  // that caused issue #433 (review-open squashes the terminal and only
+  // partially un-squashes when closed because the PTY was still on the
+  // narrow cols when the next prompt was emitted).
+  flushTerminalResize = (): void => {
+    window.clearTimeout(this.resizeTimer);
+    this.resizeTimer = 0;
+    if (this.resizeFrame !== 0) {
+      return;
+    }
+    this.resizeFrame = window.requestAnimationFrame(() => {
+      this.resizeFrame = 0;
+      this.runTerminalResize();
+    });
+  };
+
+  private runTerminalResize(): void {
+    this.applyLayoutVars();
+    this.fitAddon?.fit();
+    this.publishTerminalDims();
+    const sessionId = store.getState().terminal.sessionId;
+    if (sessionId > 0 && this.terminal) {
+      ResizeSession(sessionId, this.terminal.cols, this.terminal.rows).catch(noop);
+    }
+  }
 
   queueVisibleDiffSelectionUpdate(): void {
     if (this.reviewScrollFrame > 0) {

--- a/erun-ui/frontend/src/app/layoutActions.ts
+++ b/erun-ui/frontend/src/app/layoutActions.ts
@@ -35,6 +35,7 @@ interface LayoutCallbacks {
   applyLayoutVars: () => void;
   focusTerminalSoon: () => void;
   queueTerminalResize: () => void;
+  flushTerminalResize: () => void;
 }
 
 export function toggleSidebar(
@@ -44,7 +45,7 @@ export function toggleSidebar(
 ): void {
   dispatch(setSidebarHidden(!getState().layout.sidebarHidden));
   callbacks.applyLayoutVars();
-  callbacks.queueTerminalResize();
+  callbacks.flushTerminalResize();
   callbacks.focusTerminalSoon();
 }
 
@@ -193,7 +194,10 @@ export function toggleReview(
   dispatch(setReviewOpenAction(next));
   callbacks.applyLayoutVars();
   setFilesOpen(dispatch, getState, getState().layout.filesOpen, false, callbacks.applyLayoutVars);
-  callbacks.queueTerminalResize();
+  // Immediate (rAF) refit so the PTY learns the new cols before the shell
+  // emits its next prompt; the 40 ms debounce was wide enough for output
+  // to land at the old cols and stick in scrollback (issue #433).
+  callbacks.flushTerminalResize();
   if (next) {
     callbacks.loadReviewDiff();
   }
@@ -218,7 +222,7 @@ export function setDebugOpen(
   dispatch: AppDispatch,
   getState: () => RootState,
   open: boolean,
-  queueTerminalResize: () => void,
+  flushTerminalResize: () => void,
 ): void {
   dispatch(setDebugOpenAction(open));
   saveBoolean(DEBUG_OPEN_STORAGE_KEY, open);
@@ -229,7 +233,7 @@ export function setDebugOpen(
       ),
     );
   }
-  queueTerminalResize();
+  flushTerminalResize();
 }
 
 // Re-export setChangedFilesOpen action so callers reading from this module

--- a/erun-ui/frontend/src/app/layoutThunks.ts
+++ b/erun-ui/frontend/src/app/layoutThunks.ts
@@ -54,7 +54,7 @@ export const setDebugOpen =
   (open: boolean): AppThunk =>
   (dispatch, getState, extra) => {
     const controller = requireController(extra);
-    applyDebugOpen(dispatch, getState, open, controller.queueTerminalResize);
+    applyDebugOpen(dispatch, getState, open, controller.flushTerminalResize);
   };
 
 export const clearDebugOutput = (): AppThunk => (dispatch, getState) => {

--- a/erun-ui/playwright/tests/layout.spec.ts
+++ b/erun-ui/playwright/tests/layout.spec.ts
@@ -6,6 +6,14 @@ async function readSidebarWidth(page: import('@playwright/test').Page): Promise<
   );
 }
 
+async function readTerminalCols(page: import('@playwright/test').Page): Promise<number> {
+  return await page.evaluate(() => {
+    const el = document.querySelector<HTMLElement>('.terminal');
+    const raw = el?.dataset.terminalCols ?? '';
+    return raw ? Number.parseInt(raw, 10) : 0;
+  });
+}
+
 test.describe('layout panels', () => {
   test('sidebar toggle flips --sidebar-width', async ({ app, page }) => {
     const initial = await readSidebarWidth(page);
@@ -28,6 +36,24 @@ test.describe('layout panels', () => {
 
     // Restore so subsequent tests don't observe an unexpected layout.
     await app.titlebar.toggleReviewPanel();
+  });
+
+  // Regression: issue #433 — opening the Review panel squashed the terminal,
+  // and closing it left the terminal at the narrow cols because the 40 ms
+  // debounce in queueTerminalResize was wide enough for the shell to emit a
+  // prompt at the old cols. flushTerminalResize refits on the next animation
+  // frame and resizes the PTY before that gap closes.
+  test('review panel toggle resizes terminal cols on both edges', async ({ app, page }) => {
+    await expect.poll(() => readTerminalCols(page)).toBeGreaterThan(0);
+    const wideCols = await readTerminalCols(page);
+
+    await app.titlebar.toggleReviewPanel();
+    await expect.poll(() => readTerminalCols(page)).toBeLessThan(wideCols);
+    const narrowCols = await readTerminalCols(page);
+    expect(narrowCols).toBeGreaterThan(0);
+
+    await app.titlebar.toggleReviewPanel();
+    await expect.poll(() => readTerminalCols(page)).toBe(wideCols);
   });
 
   test('debug panel toggle reveals the resize handle', async ({ app, page }) => {


### PR DESCRIPTION
## Summary

- Review/Sidebar/Debug panel toggles ran the terminal refit through `queueTerminalResize`, which debounces 40 ms to coalesce drag/ResizeObserver bursts. For a one-shot toggle that gap was wide enough for the shell to emit a prompt at the old cols, leaving the terminal visibly squashed after closing the Review panel.
- Adds `flushTerminalResize` on `TerminalController`: cancels the pending debounce and refits on the next animation frame, then resizes the PTY. Drag-resize paths keep the debounced `queueTerminalResize`.
- Publishes `terminal.cols`/`rows` as `data-terminal-cols`/`data-terminal-rows` on the terminal root so the Playwright suite can observe the fit.
- Adds a regression test in `layout.spec.ts` asserting terminal cols shrink on review open and restore to the wide value on close.

## UX impact

1. **Affected paths.** Titlebar Review/Sidebar/Debug toggles → terminal refit → PTY `ResizeSession`.
2. **User-visible sequence.** Click toggle → grid reflows → terminal refits on the next frame (was 40 ms later) → shell sees new cols before next prompt redraw.
3. **State-without-affordance.** No new state fields; existing `layout.reviewOpen` rendering unchanged.
4. **Visibility of system status.** Status banner unaffected.
5. **Success/failure feedback.** Terminal width is itself the feedback; closing the panel now restores the wide layout.
6. **Consistency with comparable flows.** Sidebar and Debug toggles get the same immediate-refit path so they behave identically to Review.
7. **Heuristic pass.** Match between system and real world ✓ (terminal width tracks visible container); user control ✓ (toggle is reversible); consistency ✓ (all three panels behave the same). Other heuristics N/A.
8. **Playwright coverage.** `layout.spec.ts` › "review panel toggle resizes terminal cols on both edges" — extended layout spec; reads `data-terminal-cols` on `.terminal` root before/after toggle.

## Docs

No docs update needed: behaviour-preserving bug fix to terminal refit timing; no new commands, flags, or surfaces.

## Test plan

- [x] `yarn typecheck` (erun-ui/frontend)
- [x] `yarn lint` (erun-ui/frontend)
- [x] `yarn format:check` (erun-ui/frontend)
- [x] `yarn build` (erun-ui/frontend)
- [x] `go test ./...` (erun-ui)
- [ ] `./playwright/run.sh -- --grep "review panel toggle resizes"` — could not run in the sandbox (Chromium missing `libnspr4.so` system library); the new spec compiles, follows the same shape as adjacent specs, and reads `data-terminal-cols` via the same DOM-attribute pattern.
- [ ] Manual verification in the desktop app: open the Review panel, observe the terminal refits cleanly; close it, observe the wide layout returns immediately for new prompt lines.

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)