### PR TITLE
Route terminal query replies to the source session

### DIFF
--- a/erun-ui/frontend/src/app/TerminalController.ts
+++ b/erun-ui/frontend/src/app/TerminalController.ts
@@ -49,6 +49,7 @@ import {
 import { registerTerminalQueryResponseHandlers } from './terminalQueryResponses';
 import { TerminalSessionRegistry } from './TerminalSessionRegistry';
 import { decodeDebugOutput } from './terminalStatus';
+import { TerminalWriteSourceQueue } from './TerminalWriteSourceQueue';
 import { thunkExtra } from './thunkExtra';
 import {
   handleAIActivity,
@@ -66,6 +67,10 @@ const REVIEW_DIFF_REFRESH_INTERVAL_MS = 5000;
 
 export class TerminalController {
   readonly sessions = new TerminalSessionRegistry();
+  // Tracks the source session of each in-flight xterm write so terminal query
+  // replies route back to the asking session, not the currently-selected one
+  // (issue #347). See TerminalWriteSourceQueue and writeToTerminal().
+  private readonly writeSources = new TerminalWriteSourceQueue();
   private terminal: Terminal | null = null;
   private fitAddon: FitAddon | null = null;
   private terminalRoot: HTMLDivElement | null = null;
@@ -170,7 +175,12 @@ export class TerminalController {
 
     this.terminalQueryResponseDisposables = registerTerminalQueryResponseHandlers(
       this.terminal,
-      (data) => SendSessionInput(store.getState().terminal.sessionId, data),
+      // Address the reply to the session whose output xterm is parsing right
+      // now (writeSources head), falling back to the current selection when no
+      // write is in flight. Reading the live selection here would misroute the
+      // reply if the user switched sessions during a deferred parse (#347).
+      (data) =>
+        SendSessionInput(this.writeSources.current(store.getState().terminal.sessionId), data),
       (error) => {
         store.dispatch(showTerminalMessage(readError(error)));
       },
@@ -262,6 +272,9 @@ export class TerminalController {
     this.terminal?.dispose();
     this.terminal = null;
     this.fitAddon = null;
+    // xterm drops pending write-completion callbacks on dispose, so reset the
+    // source queue to avoid carrying a stale head into the next mount.
+    this.writeSources.clear();
   }
 
   private detachWailsEventListeners(): void {
@@ -327,7 +340,7 @@ export class TerminalController {
       if (this.liveCursorState.altScreen || !this.liveCursorState.cursorHidden) {
         return;
       }
-      this.terminal?.write(SHOW_CURSOR_SEQUENCE);
+      this.writeToTerminal(store.getState().terminal.sessionId, SHOW_CURSOR_SEQUENCE);
       this.liveCursorState = { ...this.liveCursorState, cursorHidden: false };
     }, TerminalController.CURSOR_RESTORE_DELAY_MS);
   }
@@ -350,9 +363,21 @@ export class TerminalController {
       return;
     }
     store.dispatch(hideTerminalMessageIfActive(payload.sessionId));
-    this.terminal?.write(displayData);
+    this.writeToTerminal(payload.sessionId, displayData);
     this.liveCursorState = scanCursorVisibility(this.liveCursorState, displayData);
     this.scheduleCursorRestoreIfStuck();
+  }
+
+  // writeToTerminal is the single seam for every xterm write. It tags the write
+  // with its source session via the write-source queue and hands xterm the
+  // matching completion callback, so terminal query replies fired while xterm
+  // parses this chunk route back to sessionId (issue #347).
+  private writeToTerminal(sessionId: number, data: TerminalWriteData): void {
+    const terminal = this.terminal;
+    if (!terminal) {
+      return;
+    }
+    terminal.write(data, this.writeSources.begin(sessionId));
   }
 
   layoutCallbacks(): {
@@ -526,9 +551,9 @@ export class TerminalController {
     this.focusTerminalSoon();
   }
 
-  writeTerminalBuffer(chunks: TerminalWriteData[]): void {
+  writeTerminalBuffer(sessionId: number, chunks: TerminalWriteData[]): void {
     for (const chunk of chunks) {
-      this.terminal?.write(chunk);
+      this.writeToTerminal(sessionId, chunk);
     }
     // Rehydrate live cursor state from the replayed buffer.
     // rebuildTerminalDisplayBuffer already appended `?25h` if the live

--- a/erun-ui/frontend/src/app/TerminalWriteSourceQueue.ts
+++ b/erun-ui/frontend/src/app/TerminalWriteSourceQueue.ts
@@ -1,0 +1,49 @@
+// TerminalWriteSourceQueue records which PTY session each in-flight xterm write
+// belongs to, so terminal query replies (CPR/DSR/DECRQSS) route back to the
+// session whose output asked — not whichever session happens to be selected at
+// the moment xterm fires the reply handler.
+//
+// Why a queue and not a single field: xterm parses writes and fires their
+// completion callbacks strictly FIFO, and a large write can defer parsing
+// across several tasks (xterm yields after a ~12 ms budget and resumes on a
+// later setTimeout). If the user switches sessions inside that window, reading
+// the currently-selected session at reply time addresses the reply to the wrong
+// PTY (issue #347). Pairing every write with begin() and handing its returned
+// completion callback to terminal.write(data, callback) keeps the queue head
+// aligned with the chunk xterm is parsing right now, so current() yields the
+// originating session even across a mid-parse session switch.
+export class TerminalWriteSourceQueue {
+  private readonly sources: number[] = [];
+
+  // begin records sessionId as the source of the next xterm write and returns
+  // the completion callback to hand to terminal.write(data, callback). xterm
+  // invokes that callback once the chunk is parsed; FIFO ordering means the
+  // first callback to fire belongs to the head entry, so shifting the head
+  // keeps the queue aligned. The callback is idempotent so a double-fire can
+  // never desync the queue.
+  begin(sessionId: number): () => void {
+    this.sources.push(sessionId);
+    let settled = false;
+    return () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      this.sources.shift();
+    };
+  }
+
+  // current returns the session whose write xterm is parsing right now, or
+  // fallback when no write is in flight (e.g. a reply arriving outside any
+  // write — preserves the previous "current selection" behaviour as a floor).
+  current(fallback: number): number {
+    return this.sources[0] ?? fallback;
+  }
+
+  // clear drops all pending sources. Call when the terminal is disposed: xterm
+  // does not fire completion callbacks for writes abandoned at teardown, so the
+  // queue must be reset to avoid carrying a stale head into the next mount.
+  clear(): void {
+    this.sources.length = 0;
+  }
+}

--- a/erun-ui/frontend/src/app/middleware/terminalDisplayMiddleware.ts
+++ b/erun-ui/frontend/src/app/middleware/terminalDisplayMiddleware.ts
@@ -33,6 +33,6 @@ startListening({
     }
     rebuildTerminalDisplayBuffer(controller.sessions, sessionId);
     controller.resetTerminal();
-    controller.writeTerminalBuffer(controller.sessions.displayBuffer(sessionId));
+    controller.writeTerminalBuffer(sessionId, controller.sessions.displayBuffer(sessionId));
   },
 });

--- a/erun-ui/playwright/tests/terminal-query-response.spec.ts
+++ b/erun-ui/playwright/tests/terminal-query-response.spec.ts
@@ -1,0 +1,170 @@
+import type { Page, Request } from '@playwright/test';
+
+import type { AppShell } from '../pages/index.js';
+import { expect, test } from '../fixtures/erunApp.js';
+
+// terminal-query-response covers issue #347: a tool inside a PTY emits a
+// terminal query (CPR / DSR / DECRQSS); xterm parses it and the controller's
+// registerTerminalQueryResponseHandlers wiring answers via SendSessionInput.
+// The bug was that the reply was addressed to store.getState().terminal.sessionId
+// read at *reply* time, so switching sessions during a deferred xterm parse
+// injected the reply into the wrong PTY. The fix (TerminalWriteSourceQueue)
+// tags every xterm write with its source session and answers the session whose
+// output xterm is parsing right now.
+//
+// This spec drives the same React path the production query takes: it injects a
+// `terminal-output` Wails event (which round-trips through the headless bridge's
+// /__erun_emit fan-out, exactly like the real backend stream) and observes the
+// resulting SendSessionInput call on /__erun_invoke.
+//
+// DECRQSS (`ESC P $ q " q ESC \`) is used as the trigger because it is the one
+// query that survives stripTerminalResponses() in terminalBuffers.ts — that
+// strip removes CSI `ESC[<n>n` (DSR/CPR) and `ESC[…c` (DA) response *and* query
+// tails from the displayed bytes, but not DCS sequences — so DECRQSS
+// deterministically reaches xterm's parser and produces a reply.
+//
+// Harness limitation: the exact cross-session race (xterm deferring a query's
+// parse across a session switch, so reply-time selection != write-time source)
+// cannot be staged deterministically here. The Redux store / selected session
+// is not exposed to the page, and forcing xterm to defer a parse depends on its
+// internal write-buffer timing. These tests therefore lock the two observable
+// invariants that bound the bug — replies route to the asking session, and a
+// query from a non-selected session is never answered — while the write-time
+// capture that closes the race lives in TerminalWriteSourceQueue.ts.
+
+const DECRQSS = '\x1bP$q"q\x1b\\';
+
+interface InvokeCall {
+  method: string;
+  args: unknown[];
+}
+
+// parseInvoke decodes a /__erun_invoke POST body into {method, args}, or null
+// when the request is not an invoke (or carries no JSON body).
+function parseInvoke(req: Request): InvokeCall | null {
+  if (req.method() !== 'POST' || !req.url().endsWith('/__erun_invoke')) {
+    return null;
+  }
+  let body: { method?: string; args?: unknown[] } | null = null;
+  try {
+    body = req.postDataJSON() as { method?: string; args?: unknown[] } | null;
+  } catch {
+    return null;
+  }
+  return body?.method ? { method: body.method, args: body.args ?? [] } : null;
+}
+
+// captureInvokes records every window.go.main.App.<method> call the page makes.
+function captureInvokes(page: Page): InvokeCall[] {
+  const calls: InvokeCall[] = [];
+  page.on('request', (req: Request) => {
+    const call = parseInvoke(req);
+    if (call) {
+      calls.push(call);
+    }
+  });
+  return calls;
+}
+
+// isDcsReply matches the DCS-framed reply the DECRQSS handler sends back
+// (statusStringReport returns `ESC P 1 $ r 0 " q ESC \`).
+function isDcsReply(data: unknown): data is string {
+  return typeof data === 'string' && data.startsWith('\x1bP');
+}
+
+// emitTerminalOutput injects a `terminal-output` event for sessionId carrying
+// raw bytes, mirroring what the Go PTY stream emits. data is base64 like the
+// real payload; btoa is safe because every byte here is < 256.
+async function emitTerminalOutput(page: Page, sessionId: number, raw: string): Promise<void> {
+  await page.evaluate(
+    (payload) => {
+      const runtime = (
+        window as unknown as {
+          runtime: { EventsEmit: (name: string, ...args: unknown[]) => void };
+        }
+      ).runtime;
+      runtime.EventsEmit('terminal-output', {
+        sessionId: payload.sessionId,
+        data: btoa(payload.raw),
+      });
+    },
+    { sessionId, raw },
+  );
+}
+
+// discoverSelectedSessionId finds the session the terminal is currently
+// rendering. Toggling the sidebar provokes a resize; runTerminalResize calls
+// ResizeSession(selected, …) only when a session is selected (id > 0). When
+// nothing is open (e.g. a fresh checkout with no persisted selection), no
+// ResizeSession fires and the selected id is 0 — the post-boot sentinel that
+// the terminal-output gate compares against. Both outcomes are valid and
+// machine-independent.
+async function discoverSelectedSessionId(app: AppShell, page: Page): Promise<number> {
+  const waitForResize = page
+    .waitForRequest((req) => parseInvoke(req)?.method === 'ResizeSession', { timeout: 1500 })
+    .catch(() => null);
+  await app.titlebar.toggleButton().click();
+  const resize = await waitForResize;
+  const id = resize ? parseInvoke(resize)?.args[0] : undefined;
+  return typeof id === 'number' ? id : 0;
+}
+
+test.describe('terminal query responses (#347)', () => {
+  test('a query in the selected session is answered to that same session', async ({
+    app,
+    page,
+  }) => {
+    const invokes = captureInvokes(page);
+    const selectedId = await discoverSelectedSessionId(app, page);
+
+    await emitTerminalOutput(page, selectedId, DECRQSS);
+
+    // The reply must be addressed to the session that produced the query.
+    await expect
+      .poll(
+        () => {
+          const reply = invokes.find(
+            (call) => call.method === 'SendSessionInput' && isDcsReply(call.args[1]),
+          );
+          return reply?.args[0];
+        },
+        { timeout: 5_000 },
+      )
+      .toBe(selectedId);
+  });
+
+  test('a query for a non-selected session is never answered', async ({ app, page }) => {
+    const invokes = captureInvokes(page);
+    const selectedId = await discoverSelectedSessionId(app, page);
+    // A session id that is definitely neither selected nor a live backend
+    // session, so the only way it could receive a reply is the #347 misroute.
+    const backgroundId = selectedId + 987_654;
+
+    // Emit the background query first, then a foreground query. Waiting for the
+    // foreground reply proves the event pipeline drained past the background
+    // emit, so a missing background reply is a real negative, not just slowness.
+    await emitTerminalOutput(page, backgroundId, DECRQSS);
+    await emitTerminalOutput(page, selectedId, DECRQSS);
+
+    await expect
+      .poll(
+        () =>
+          invokes.some(
+            (call) =>
+              call.method === 'SendSessionInput' &&
+              isDcsReply(call.args[1]) &&
+              call.args[0] === selectedId,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBe(true);
+
+    const answeredToBackground = invokes.filter(
+      (call) =>
+        call.method === 'SendSessionInput' &&
+        isDcsReply(call.args[1]) &&
+        call.args[0] === backgroundId,
+    );
+    expect(answeredToBackground).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #347: xterm terminal-query reply handlers (CPR / DSR / DECRQSS) addressed the reply to `store.getState().terminal.sessionId` read at **reply** time. xterm can defer a query's parse past a session switch, so the reply could be injected into the **wrong** PTY — surfacing as stray escape bytes (or a mis-run command) on a session that never asked.

## Fix

- New `TerminalWriteSourceQueue` — a FIFO that tags each in-flight xterm write with its source session. xterm fires write-completion callbacks strictly FIFO, so the queue head always reflects the chunk being parsed *right now*, even across a mid-parse session switch (the issue's Option 1, made race-safe rather than a single mutable field).
- `TerminalController`: all three `terminal.write` sites now flow through one `writeToTerminal(sessionId, data)` seam that pairs the write with `writeSources.begin(sessionId)`; the reply handler reads `writeSources.current(selection)` instead of the live selection; the queue is cleared on teardown.
- `terminalDisplayMiddleware`: threads the session id into `writeTerminalBuffer` for the session-switch replay path.

## UX Impact Review

1. **Affected paths:** terminal query-reply path (`terminal-output` event → xterm parse → CSI/DCS reply handler → `SendSessionInput`).
2. **User-visible sequence:** no visible UI change; the fix removes a corruption (stray reply bytes landing on a session that didn't ask).
3. **State-without-affordance:** no `AppState` mutations added.
4–7. Visibility/feedback/consistency/heuristics: N/A — behaviour-preserving bug fix, no new status, control, or flow.
8. **Playwright:** `tests/terminal-query-response.spec.ts` (new) drives the real event → xterm → reply path and locks two invariants — replies route to the asking session, and a query for a non-selected session is never answered.

## Validation

- Frontend: `yarn typecheck` ✓, `yarn format:check` ✓, `eslint` on changed files ✓.
- New `#347` Playwright spec: **2/2 pass** against a freshly built, fix-embedded `erun-app`.
- Full Playwright suite: 44 passed, 1 skipped, 4 failed; the 4 failures reproduce **identically on the pre-fix baseline** (pre-existing, tied to opening the dev's real `~/.erun/` envs headless) — this change is regression-free.

## Limitations

The exact cross-session async-parse race is not deterministically stageable in the headless harness (the Redux store / selected session is not exposed to the page, and forcing xterm to defer a parse depends on its internal write-buffer timing). The spec documents this and the queue closes the race by construction.

Docs: behaviour-preserving bug fix with no public-surface change → no `erun-docs` update warranted.

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)