### PR TITLE
Validate the Scoop manifest during stable release

### DIFF
--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -138,7 +139,7 @@ func resolveReleaseSpec(ctx Context, findProjectRoot ProjectFinderFunc, loadProj
 	if err != nil {
 		return ReleaseSpec{}, err
 	}
-	artifacts, err := discoverReleaseArtifacts(inputs)
+	artifacts, err := discoverReleaseArtifacts(ctx, inputs)
 	if err != nil {
 		return ReleaseSpec{}, err
 	}
@@ -669,13 +670,13 @@ func resolveReleaseGitState(ctx Context, projectRoot string, resolveBranch, reso
 	return branch, commit, nil
 }
 
-func discoverReleaseArtifacts(inputs releaseInputs) (releaseArtifacts, error) {
+func discoverReleaseArtifacts(ctx Context, inputs releaseInputs) (releaseArtifacts, error) {
 	charts, fileUpdates, err := discoverReleaseCharts(inputs.ReleaseRoot, inputs.Version)
 	if err != nil {
 		return releaseArtifacts{}, err
 	}
 	artifacts := releaseArtifacts{Charts: charts, FileUpdates: fileUpdates}
-	if err := discoverStableReleaseArtifacts(inputs, &artifacts); err != nil {
+	if err := discoverStableReleaseArtifacts(ctx, inputs, &artifacts); err != nil {
 		return releaseArtifacts{}, err
 	}
 	images, err := discoverReleaseDockerImages(inputs.ProjectRoot, inputs.ReleaseRoot, inputs.VersionFilePath, inputs.Version)
@@ -692,9 +693,12 @@ func discoverReleaseArtifacts(inputs releaseInputs) (releaseArtifacts, error) {
 	return artifacts, nil
 }
 
-func discoverStableReleaseArtifacts(inputs releaseInputs, artifacts *releaseArtifacts) error {
+func discoverStableReleaseArtifacts(ctx Context, inputs releaseInputs, artifacts *releaseArtifacts) error {
 	if inputs.Mode != ReleaseModeStable {
 		return nil
+	}
+	if err := validateStableScoopManifest(ctx, inputs.ProjectRoot); err != nil {
+		return err
 	}
 	packagingUpdates, syncSpec, err := discoverStableReleasePackaging(inputs.ProjectRoot, inputs.Version)
 	if err != nil {
@@ -702,6 +706,72 @@ func discoverStableReleaseArtifacts(inputs releaseInputs, artifacts *releaseArti
 	}
 	artifacts.FileUpdates = append(artifacts.FileUpdates, packagingUpdates...)
 	artifacts.PackagingSync = syncSpec
+	return nil
+}
+
+// requiredScoopBinaries are the executables the Windows Scoop install must put
+// on PATH. erun-app.exe is load-bearing: `erun app`, Homebrew, and Scoop
+// launcher wiring all depend on that artifact name.
+var requiredScoopBinaries = []string{"erun.exe", "emcp.exe", "eapi.exe", "erun-app.exe"}
+
+// validateStableScoopManifest fails the stable release when the checked-in
+// Scoop manifest has drifted from the invariants the Windows install depends
+// on, so a malformed bucket/erun.json is caught before the release publishes it
+// rather than at a user's `scoop install`. No-op when the project ships no
+// manifest. Runs during release resolution so the bailout precedes any git
+// mutation; the attempt is traced so --dry-run shows the check.
+func validateStableScoopManifest(ctx Context, projectRoot string) error {
+	scoopPath := filepath.Join(projectRoot, "bucket", "erun.json")
+	if !fileExists(scoopPath) {
+		return nil
+	}
+	ctx.Trace("release: validating scoop manifest " + scoopPath)
+	return checkScoopManifestInvariants(scoopPath)
+}
+
+// checkScoopManifestInvariants asserts the structural facts the Windows build
+// relies on: the MinGW C-compiler dependency plus its CGO/Wails prerequisite
+// wording (and the absence of the stale Fyne wording), a non-empty installer
+// script, and all four shipped executables in bin. It reports every violation
+// at once so a single failed release names everything that needs fixing.
+func checkScoopManifestInvariants(scoopPath string) error {
+	data, err := os.ReadFile(scoopPath)
+	if err != nil {
+		return err
+	}
+	var manifest struct {
+		Depends   []string `json:"depends"`
+		Installer struct {
+			Script []string `json:"script"`
+		} `json:"installer"`
+		Bin []string `json:"bin"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return fmt.Errorf("scoop manifest %s: %w", scoopPath, err)
+	}
+
+	var problems []string
+	if !slices.Contains(manifest.Depends, "mingw") {
+		problems = append(problems, `depends must include "mingw" for the Wails CGO build`)
+	}
+	if len(manifest.Installer.Script) == 0 {
+		problems = append(problems, "installer.script must not be empty")
+	}
+	script := strings.Join(manifest.Installer.Script, "\n")
+	if !strings.Contains(script, "MinGW for the Wails CGO build") {
+		problems = append(problems, "installer.script must state the MinGW/Wails CGO prerequisite")
+	}
+	if strings.Contains(script, "Fyne") {
+		problems = append(problems, "installer.script must not reference the stale Fyne prerequisite")
+	}
+	for _, bin := range requiredScoopBinaries {
+		if !slices.Contains(manifest.Bin, bin) {
+			problems = append(problems, "bin must include "+bin)
+		}
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("scoop manifest %s is invalid: %s", scoopPath, strings.Join(problems, "; "))
+	}
 	return nil
 }
 

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -353,6 +353,19 @@ func SeedMarketplaceJSON(t testing.TB, dir string) {
 `)
 }
 
+// SeedScoopManifest writes bucket/erun.json inside dir with the given content
+// so stable `release` scenarios exercise the Scoop manifest validation and the
+// version/checksum sync paths. Pass a valid manifest to reach the happy path,
+// or a deliberately malformed one to drive the validation-failure branch.
+func SeedScoopManifest(t testing.TB, dir, content string) {
+	t.Helper()
+	dst := filepath.Join(dir, "bucket")
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dst, err)
+	}
+	mustWrite(t, filepath.Join(dst, "erun.json"), content)
+}
+
 // RunGit runs `git <args...>` inside dir. Useful for scenarios that need
 // to set up branches, tags, or remotes after SeedReleaseRepo.
 func RunGit(t testing.TB, dir string, args ...string) {

--- a/erun-integration/release_test.go
+++ b/erun-integration/release_test.go
@@ -14,6 +14,69 @@ import (
 	"github.com/sophium/erun/erun-integration/internal/normalize"
 )
 
+// validScoopManifest satisfies every invariant the release-time Scoop
+// validation enforces: a mingw dependency, the MinGW/Wails CGO prerequisite
+// wording (and no stale Fyne wording), a non-empty installer script, and all
+// four shipped executables in bin.
+const validScoopManifest = `{
+  "version": "1.0.0",
+  "description": "erun developer toolkit",
+  "homepage": "https://github.com/sophium/erun",
+  "license": "MIT",
+  "depends": ["go", "mingw", "nodejs", "yarn"],
+  "url": "https://github.com/sophium/erun/archive/refs/tags/v1.0.0.zip",
+  "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "extract_dir": "erun-1.0.0",
+  "installer": {
+    "script": [
+      "if (-not (Get-Command gcc -ErrorAction SilentlyContinue)) { throw 'building erun-app.exe requires a C compiler such as MinGW for the Wails CGO build' }",
+      "go build -trimpath -o \"$dir\\erun.exe\" ."
+    ]
+  },
+  "bin": ["erun.exe", "emcp.exe", "eapi.exe", "erun-app.exe"]
+}
+`
+
+// scoopManifestMissingMingwAndBin violates four invariants at once: no mingw
+// dependency, stale Fyne wording instead of the MinGW/Wails prerequisite, and a
+// missing erun-app.exe in bin.
+const scoopManifestMissingMingwAndBin = `{
+  "version": "1.0.0",
+  "description": "erun developer toolkit",
+  "homepage": "https://github.com/sophium/erun",
+  "license": "MIT",
+  "depends": ["go", "nodejs", "yarn"],
+  "url": "https://github.com/sophium/erun/archive/refs/tags/v1.0.0.zip",
+  "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "extract_dir": "erun-1.0.0",
+  "installer": {
+    "script": [
+      "if (-not (Get-Command gcc -ErrorAction SilentlyContinue)) { throw 'building erun-app.exe requires the Fyne toolchain prerequisites' }"
+    ]
+  },
+  "bin": ["erun.exe", "emcp.exe", "eapi.exe"]
+}
+`
+
+// scoopManifestEmptyScript keeps depends and bin valid but empties the
+// installer script, tripping both the non-empty-script and MinGW-wording
+// invariants.
+const scoopManifestEmptyScript = `{
+  "version": "1.0.0",
+  "description": "erun developer toolkit",
+  "homepage": "https://github.com/sophium/erun",
+  "license": "MIT",
+  "depends": ["go", "mingw", "nodejs", "yarn"],
+  "url": "https://github.com/sophium/erun/archive/refs/tags/v1.0.0.zip",
+  "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "extract_dir": "erun-1.0.0",
+  "installer": {
+    "script": []
+  },
+  "bin": ["erun.exe", "emcp.exe", "eapi.exe", "erun-app.exe"]
+}
+`
+
 func TestRelease(t *testing.T) {
 	t.Run("help", func(t *testing.T) {
 		setup := env.New(t)
@@ -121,6 +184,57 @@ func TestRelease(t *testing.T) {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
 		golden.Equal(t, "release/dry_run_main_with_marketplace_emits_sha_sync", normalize.Apply(result.Combined))
+	})
+
+	t.Run("dry_run_main_with_scoop_manifest_validates_and_syncs", func(t *testing.T) {
+		// Exercises release.go's Scoop manifest validation + version/checksum
+		// sync on the stable path: a well-formed bucket/erun.json must trace
+		// `release: validating scoop manifest`, bump the version in the release
+		// stage, and reach the curl/shasum checksum-sync trace (gated on
+		// !DryRun). Locks the invariant guard's happy path.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "main")
+		fixture.SeedScoopManifest(t, setup.Cwd, validScoopManifest)
+		fixture.RunGit(t, setup.Cwd, "add", "bucket")
+		fixture.RunGit(t, setup.Cwd, "commit", "-m", "add scoop manifest")
+		result := erun.Run(t, []string{"release", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "release/dry_run_main_with_scoop_manifest_validates_and_syncs", normalize.Apply(result.Combined))
+	})
+
+	t.Run("dry_run_main_with_invalid_scoop_manifest_fails", func(t *testing.T) {
+		// A malformed bucket/erun.json (no mingw dependency, stale Fyne
+		// wording instead of the MinGW/Wails prerequisite, missing
+		// erun-app.exe) must fail the release during resolution — before any
+		// git mutation — naming every violated invariant. Locks the guard that
+		// keeps a broken Windows install recipe from being published.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "main")
+		fixture.SeedScoopManifest(t, setup.Cwd, scoopManifestMissingMingwAndBin)
+		fixture.RunGit(t, setup.Cwd, "add", "bucket")
+		fixture.RunGit(t, setup.Cwd, "commit", "-m", "add scoop manifest")
+		result := erun.Run(t, []string{"release", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit for invalid scoop manifest, got 0: %s", result.Combined)
+		}
+		golden.Equal(t, "release/dry_run_main_with_invalid_scoop_manifest_fails", normalize.Apply(result.Combined))
+	})
+
+	t.Run("dry_run_main_with_empty_scoop_script_fails", func(t *testing.T) {
+		// An empty installer.script trips both the non-empty-script and the
+		// MinGW-wording invariants, covering the remaining validation branches.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "main")
+		fixture.SeedScoopManifest(t, setup.Cwd, scoopManifestEmptyScript)
+		fixture.RunGit(t, setup.Cwd, "add", "bucket")
+		fixture.RunGit(t, setup.Cwd, "commit", "-m", "add scoop manifest")
+		result := erun.Run(t, []string{"release", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit for empty scoop script, got 0: %s", result.Combined)
+		}
+		golden.Equal(t, "release/dry_run_main_with_empty_scoop_script_fails", normalize.Apply(result.Combined))
 	})
 
 	t.Run("dry_run_force_includes_tag_deletion_for_stale_release_tag", func(t *testing.T) {

--- a/erun-integration/testdata/release/dry_run_main_with_empty_scoop_script_fails.txt
+++ b/erun-integration/testdata/release/dry_run_main_with_empty_scoop_script_fails.txt
@@ -1,0 +1,18 @@
+audit: erun release --dry-run
+release: resolving project root
+release: project root = <TMP>
+release: resolving release module root
+release: release root = <TMP>
+release: loading release config from project
+release: main branch = main, develop branch = develop
+release: resolving git branch and commit
+git -C <TMP> rev-parse --abbrev-ref HEAD
+git -C <TMP> rev-parse --short HEAD
+release: branch = main, commit = <SHORTSHA>
+release: resolving base version from VERSION file
+release: base version = <VERSION> (from <TMP>
+release: classified mode = stable
+git -C <TMP> show-ref --verify --quiet refs/heads/develop
+release: develop branch "develop" exists = false
+release: validating scoop manifest <TMP>
+scoop manifest <TMP> is invalid: installer.script must not be empty; installer.script must state the MinGW/Wails CGO prerequisite

--- a/erun-integration/testdata/release/dry_run_main_with_invalid_scoop_manifest_fails.txt
+++ b/erun-integration/testdata/release/dry_run_main_with_invalid_scoop_manifest_fails.txt
@@ -1,0 +1,18 @@
+audit: erun release --dry-run
+release: resolving project root
+release: project root = <TMP>
+release: resolving release module root
+release: release root = <TMP>
+release: loading release config from project
+release: main branch = main, develop branch = develop
+release: resolving git branch and commit
+git -C <TMP> rev-parse --abbrev-ref HEAD
+git -C <TMP> rev-parse --short HEAD
+release: branch = main, commit = <SHORTSHA>
+release: resolving base version from VERSION file
+release: base version = <VERSION> (from <TMP>
+release: classified mode = stable
+git -C <TMP> show-ref --verify --quiet refs/heads/develop
+release: develop branch "develop" exists = false
+release: validating scoop manifest <TMP>
+scoop manifest <TMP> is invalid: depends must include "mingw" for the Wails CGO build; installer.script must state the MinGW/Wails CGO prerequisite; installer.script must not reference the stale Fyne prerequisite; bin must include erun-app.exe

--- a/erun-integration/testdata/release/dry_run_main_with_scoop_manifest_validates_and_syncs.txt
+++ b/erun-integration/testdata/release/dry_run_main_with_scoop_manifest_validates_and_syncs.txt
@@ -1,0 +1,78 @@
+<VERSION>
+audit: erun release --dry-run
+release: resolving project root
+release: project root = <TMP>
+release: resolving release module root
+release: release root = <TMP>
+release: loading release config from project
+release: main branch = main, develop branch = develop
+release: resolving git branch and commit
+git -C <TMP> rev-parse --abbrev-ref HEAD
+git -C <TMP> rev-parse --short HEAD
+release: branch = main, commit = <SHORTSHA>
+release: resolving base version from VERSION file
+release: base version = <VERSION> (from <TMP>
+release: classified mode = stable
+git -C <TMP> show-ref --verify --quiet refs/heads/develop
+release: develop branch "develop" exists = false
+release: validating scoop manifest <TMP>
+release: branch=main mode=stable version=<VERSION>
+next version: <VERSION>
+docker image: ghcr.io/sophium/api:<VERSION>
+git -C <TMP> status --porcelain --untracked-files=no
+release: worktree clean = true
+stage: sync-remote
+cd <TMP> && git fetch origin
+cd <TMP> && git rebase origin/main
+stage: release
+write <TMP>
+  apiVersion: v2
+  appVersion: <VERSION>
+  name: api
+  version: <VERSION>
+write <TMP>
+  {
+    "version": "<VERSION>",
+    "description": "erun developer toolkit",
+    "homepage": "https://github.com/sophium/erun",
+    "license": "MIT",
+    "depends": [
+      "go",
+      "mingw",
+      "nodejs",
+      "yarn"
+    ],
+    "url": "https://github.com/sophium/erun/archive/refs/tags/<VERSION>.zip",
+    "hash": "<HEX>",
+    "extract_dir": "erun-<VERSION>",
+    "installer": {
+      "script": [
+        "if (-not (Get-Command gcc -ErrorAction SilentlyContinue)) { throw 'building erun-app.exe requires a C compiler such as MinGW for the Wails CGO build' }",
+        "go build -trimpath -o \"$dir\\erun.exe\" ."
+      ]
+    },
+    "bin": [
+      "erun.exe",
+      "emcp.exe",
+      "eapi.exe",
+      "erun-app.exe"
+    ]
+  }
+cd <TMP> && git add erun-devops/k8s/api/Chart.yaml bucket/erun.json
+cd <TMP> && git commit -m '[skip ci] release <VERSION>'
+git -C <TMP> rev-parse '<VERSION>^{}'
+cd <TMP> && git tag -a <VERSION> -m 'Release <VERSION>'
+stage: push-release-tag
+cd <TMP> && git push origin <VERSION>
+stage: sync-packaging-checksums
+curl -fsSL https://github.com/sophium/erun/archive/refs/tags/<VERSION>.zip
+shasum -a 256 <VERSION>.zip
+cd <TMP> && git add bucket/erun.json
+cd <TMP> && git commit -m '[skip ci] sync package metadata <VERSION>'
+stage: post-release-version-bump
+write <TMP>
+  <VERSION>
+cd <TMP> && git add erun-devops/VERSION
+cd <TMP> && git commit -m '[skip ci] prepare <VERSION>'
+stage: push
+cd <TMP> && git push --follow-tags origin main


### PR DESCRIPTION
## Summary

Closes #98. The Windows Scoop install recipe (`bucket/erun.json`) carries facts the build depends on — the `mingw` C-compiler dependency and its MinGW/Wails CGO prerequisite wording, no stale `Fyne` wording, a non-empty installer script, and all four shipped executables in `bin` — but nothing enforced them. A careless edit would only surface at a user's `scoop install`.

`erun release` already rewrites this manifest's version and checksum (`release.go`), so this makes the release the enforcement point: during stable-release resolution it validates the manifest and **aborts before any git mutation**, naming every violated invariant at once.

## Why this shape (not the unit test #98 originally proposed)

The integration suite is the only signal the coverage gate honors, and the repo's doctrine is to test `erun-cli`/`erun-common` behaviour there, not via unit tests. But the suite is hermetic (fixture repos), so it never reads the real `bucket/erun.json`. Resolution: the guard lives in `erun release` as gate-counted production behaviour, and integration scenarios lock the validation logic with seeded manifest fixtures. A malformed real manifest is then caught when a release is cut, by gate-covered code — rather than by a unit test that's invisible to the gate.

## Changes

- `erun-common/release.go`: `validateStableScoopManifest` / `checkScoopManifestInvariants` run during stable-release resolution; `--dry-run` traces `release: validating scoop manifest <path>`. `ctx` threaded through `discoverReleaseArtifacts` / `discoverStableReleaseArtifacts`.
- `erun-integration/`: three new `TestRelease` scenarios (valid → validates, version-bumps, reaches the dry-run-safe `curl`/`shasum` checksum sync; missing mingw/Fyne/exe → aborts; empty installer script → aborts), `fixture.SeedScoopManifest`, and three goldens.

## Validation

- All `TestRelease` scenarios pass in compare mode (10 existing + 3 new).
- Integration coverage **58.2% ≥ 55** threshold; the new code is exercised by the scenarios.
- No unit test added.
- Note: in my sandbox the unrelated real-run scenario `TestOpen/vscode_real_run_writes_known_hosts_and_launches_ide` times out on its MCP port-forward; it fails identically on the unmodified baseline (environment-specific, not introduced here). Expected green on CI infra.

## Docs

None needed — internal release-flow guardrail, no new flag/command or changed output on the valid path; `erun release` help is intentionally high-level and does not enumerate the existing packaging sync either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)