### PR TITLE
Failed-deploy recovery: card actions activate the Local tab, and reconnect stops re-deploying a failed env

### DIFF
--- a/erun-ui/frontend/src/app/recoveryThunks.ts
+++ b/erun-ui/frontend/src/app/recoveryThunks.ts
@@ -1,0 +1,52 @@
+import type { StartSessionResult, UISelection } from '@/types';
+
+import { StartDoctorSession, StartForceDeploySession } from '../../wailsjs/go/main/App';
+import { showTerminalMessage } from './notificationThunks';
+import { activateLocalAfterCommand } from './sessionThunks';
+import { setSelected } from './slices/selectionSlice';
+import { setTerminalCopyOutput, setTerminalCopyStatus } from './slices/terminalStatusSlice';
+import type { AppThunk } from './store';
+import { requireController } from './thunkExtra';
+
+// runLocalRecoverySelection runs an `erun …` recovery command for the given env
+// in the shared Local shell and focuses the Local tab so the user sees it.
+// Without activateLocalAfterCommand the command runs in a background shell with
+// no visible feedback, which led users to click repeatedly and flood the shell
+// (#445). Mirrors startDeploySelection in sessionThunks.
+const runLocalRecoverySelection =
+  (
+    selection: UISelection,
+    busyMessage: string,
+    starter: (selection: UISelection, cols: number, rows: number) => Promise<unknown>,
+  ): AppThunk<Promise<void>> =>
+  async (dispatch, getState, extra) => {
+    const controller = requireController(extra);
+    const debugOpen = getState().layout.debugOpen;
+    const runSelection = { ...selection, debug: debugOpen || undefined };
+    dispatch(setSelected(selection));
+    dispatch(setTerminalCopyOutput(''));
+    dispatch(setTerminalCopyStatus(''));
+    dispatch(showTerminalMessage(busyMessage, true));
+    controller.fitTerminal();
+    const { cols, rows } = controller.terminalSize();
+    const result = (await starter(runSelection, cols, rows)) as StartSessionResult;
+    await dispatch(activateLocalAfterCommand(selection, result));
+  };
+
+// startDoctorSelection runs `erun doctor` for the env behind a failed deploy
+// card's "Run doctor" button.
+export const startDoctorSelection = (selection: UISelection): AppThunk<Promise<void>> =>
+  runLocalRecoverySelection(
+    selection,
+    `Running doctor for ${selection.tenant} / ${selection.environment}...`,
+    StartDoctorSession,
+  );
+
+// startForceDeploySelection runs `erun deploy --force` for the env behind a
+// failed deploy card's (or a failing container's) "Rebuild & redeploy" button.
+export const startForceDeploySelection = (selection: UISelection): AppThunk<Promise<void>> =>
+  runLocalRecoverySelection(
+    selection,
+    `Rebuilding & redeploying ${selection.tenant} / ${selection.environment}...`,
+    StartForceDeploySession,
+  );

--- a/erun-ui/frontend/src/components/app/ActivityCard.tsx
+++ b/erun-ui/frontend/src/components/app/ActivityCard.tsx
@@ -13,6 +13,8 @@ import {
 import * as React from 'react';
 
 import type { ActivityQueueEntry } from '@/app/activityQueueState';
+import { useAppDispatch } from '@/app/hooks';
+import { startDoctorSelection, startForceDeploySelection } from '@/app/recoveryThunks';
 import { ContainerStatusList } from '@/components/app/ActivityCard.ContainerStatus';
 import {
   activityElapsedLabel,
@@ -30,8 +32,6 @@ import {
 import { IconTooltip } from '@/components/app/IconTooltip';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-
-import { StartDoctorSession, StartForceDeploySession } from '../../../wailsjs/go/main/App';
 
 export interface ActivityCardProps {
   entry: ActivityQueueEntry;
@@ -239,6 +239,21 @@ function FailedDeployActions({
   entry: ActivityQueueEntry;
   onRecoverPendingHelm?: (id: string) => Promise<void>;
 }): React.ReactElement | null {
+  const dispatch = useAppDispatch();
+  const [running, setRunning] = React.useState<boolean>(false);
+  // Guard against re-fire: each action runs `erun …` in the shared Local
+  // shell, so without a guard (and with the Local tab now focused for
+  // feedback) repeated clicks could pile commands into that shell (#445).
+  const runAction = React.useCallback(
+    (action: () => Promise<unknown>) => {
+      if (running) return;
+      setRunning(true);
+      void Promise.resolve(action()).finally(() => {
+        setRunning(false);
+      });
+    },
+    [running],
+  );
   if (entry.command !== 'deploy' && entry.command !== 'open') return null;
   const selection = deployUiSelection(entry);
   const showClearPendingHelm = Boolean(onRecoverPendingHelm && entry.release && entry.namespace);
@@ -249,8 +264,9 @@ function FailedDeployActions({
         variant="default"
         size="xs"
         className="h-6 gap-1 text-[11px]"
+        disabled={running}
         onClick={() => {
-          void StartDoctorSession(selection, 120, 34);
+          runAction(() => dispatch(startDoctorSelection(selection)));
         }}
       >
         <Stethoscope aria-hidden="true" className="size-3" />
@@ -261,8 +277,9 @@ function FailedDeployActions({
         variant="secondary"
         size="xs"
         className="h-6 text-[11px]"
+        disabled={running}
         onClick={() => {
-          void StartForceDeploySession(selection, 120, 34);
+          runAction(() => dispatch(startForceDeploySelection(selection)));
         }}
       >
         Rebuild &amp; redeploy
@@ -273,8 +290,9 @@ function FailedDeployActions({
           variant="secondary"
           size="xs"
           className="h-6 text-[11px]"
+          disabled={running}
           onClick={() => {
-            void onRecoverPendingHelm(entry.id);
+            runAction(() => onRecoverPendingHelm(entry.id));
           }}
         >
           Clear pending helm release

--- a/erun-ui/frontend/src/components/app/ActivityQueueDrawer.helpers.ts
+++ b/erun-ui/frontend/src/components/app/ActivityQueueDrawer.helpers.ts
@@ -3,15 +3,14 @@ import {
   type ActivityQueueEntry,
   formatElapsed,
 } from '@/app/activityQueueState';
-
-import type { main as wailsMain } from '../../../wailsjs/go/models';
+import type { UISelection } from '@/types';
 
 // deployUiSelection builds the uiSelection a deploy-oriented recovery action
 // (force redeploy, doctor) needs from an activity entry. Only the fields those
 // flows read are populated from the entry; the rest are left empty so the
 // backend resolves them from the env config, matching how the container-status
 // recovery action constructs its selection.
-export function deployUiSelection(entry: ActivityQueueEntry): wailsMain.uiSelection {
+export function deployUiSelection(entry: ActivityQueueEntry): UISelection {
   return {
     tenant: entry.tenant,
     environment: entry.environment,

--- a/erun-ui/reconnect_loop_test.go
+++ b/erun-ui/reconnect_loop_test.go
@@ -375,3 +375,82 @@ func TestTrackExitForLoopGuardTripsAfterCap(t *testing.T) {
 			reconnectLoopMaxExits+1, reconnectLoopMaxExits)
 	}
 }
+
+// TestTryReconnectRefusesAfterDeployFailure pins #447: when an env's open
+// ended in a deploy failure (signalReady recorded an error from
+// `==> Deploy failed`), tryReconnect must NOT respawn. Respawning re-runs
+// `erun open`, re-deploying a broken env — and because every tab (ERun + AI)
+// reconnects independently, that becomes a parallel re-deploy storm. The user
+// recovers via the failed-deploy card actions or by reopening the env.
+func TestTryReconnectRefusesAfterDeployFailure(t *testing.T) {
+	emits := newCapturedEmits()
+	app := &App{}
+	app.SetEmitter(emits.fn())
+
+	respawned := false
+	managed := &managedTerminal{
+		serial:      7,
+		readyClosed: true,
+		readyErr:    errors.New("==> Deploy failed after 4s"),
+		respawn: func() (terminalSession, error) {
+			respawned = true
+			return newStubTerminalSession(), nil
+		},
+	}
+
+	if app.tryReconnect(managed, "exit code 1") {
+		t.Fatal("tryReconnect must refuse to respawn after a deploy failure")
+	}
+	if respawned {
+		t.Fatal("respawn must not run after a deploy failure")
+	}
+	if !sawDeployFailedMarker(emits) {
+		t.Fatal("expected the deploy-failed marker on the terminal-output channel")
+	}
+}
+
+// TestTryReconnectAfterHealthyDropRespawns is the counterpart: a session that
+// reached a healthy ready (readyErr == nil) and then dropped is a transient
+// drop and must still reconnect. Its `erun open` finds the deploy already
+// current and skips it, so no re-deploy storm.
+func TestTryReconnectAfterHealthyDropRespawns(t *testing.T) {
+	emits := newCapturedEmits()
+	app := &App{}
+	app.SetEmitter(emits.fn())
+
+	respawned := false
+	managed := &managedTerminal{
+		serial:      8,
+		readyClosed: true,
+		readyErr:    nil,
+		respawn: func() (terminalSession, error) {
+			respawned = true
+			return newStubTerminalSession(), nil
+		},
+	}
+
+	if !app.tryReconnect(managed, "transient drop") {
+		t.Fatal("a healthy session that dropped should reconnect")
+	}
+	if !respawned {
+		t.Fatal("respawn should run for a healthy dropped session")
+	}
+}
+
+func sawDeployFailedMarker(emits *capturedEmits) bool {
+	const needle = "deploy failed — not retrying"
+	for _, evt := range emits.events(terminalOutputEvent) {
+		payload, ok := evt.(terminalOutputPayload)
+		if !ok {
+			continue
+		}
+		data, err := base64.StdEncoding.DecodeString(payload.Data)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(data), needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -997,6 +997,20 @@ func (a *App) tryReconnect(managed *managedTerminal, exitReason string) bool {
 		return false
 	}
 
+	// A deploy failure is terminal, not a transient drop. Respawning
+	// re-runs `erun open`, which re-deploys and fails the same way — and
+	// because every env tab (ERun + AI) reconnects independently, that
+	// turns one failing deploy into a parallel re-deploy storm across
+	// tabs. Refuse here and leave recovery to the user (the failed-deploy
+	// card's Run doctor / Rebuild & redeploy, or the titlebar Play
+	// button). A session that reached a healthy shell and then dropped has
+	// readyErr == nil and still reconnects below; its `erun open` finds the
+	// deploy already current and skips it.
+	if a.reconnectBlockedByDeployFailure(managed) {
+		a.emitDeployFailedMarker(managed.serial)
+		return false
+	}
+
 	// Cap consecutive fast-exit respawns. Without this, an env whose
 	// underlying cluster keeps tearing down the freshly-spawned pod
 	// (helm rollout timeouts, MCP port-forward races against a
@@ -1127,6 +1141,7 @@ const (
 	reconnectLoopWindow    = 30 * time.Second
 	reconnectLoopMaxExits  = 2
 	reconnectLoopMarkerANSI = "\r\n\x1b[2;33m── stopped reconnecting after repeated failures — click the environment in the sidebar to retry ──\x1b[0m\r\n"
+	deployFailedMarkerANSI  = "\r\n\x1b[2;33m── deploy failed — not retrying automatically; use Run doctor or Rebuild & redeploy on the failed deploy, or click the environment to retry ──\x1b[0m\r\n"
 )
 
 // trackExitForLoopGuard records the moment the managed PTY exited
@@ -1164,6 +1179,30 @@ func (a *App) emitReconnectLoopMarker(sessionID int) {
 		SessionID: sessionID,
 		Data:      base64.StdEncoding.EncodeToString([]byte(reconnectLoopMarkerANSI)),
 	})
+}
+
+// emitDeployFailedMarker writes a single diagnostic line when tryReconnect
+// refuses to respawn because the env's deploy failed (rather than a transient
+// drop). See tryReconnect.
+func (a *App) emitDeployFailedMarker(sessionID int) {
+	a.emitEvent(terminalOutputEvent, terminalOutputPayload{
+		SessionID: sessionID,
+		Data:      base64.StdEncoding.EncodeToString([]byte(deployFailedMarkerANSI)),
+	})
+}
+
+// reconnectBlockedByDeployFailure reports whether the managed PTY's open
+// ended in a deploy failure — signalReady was called with an error from the
+// `==> Deploy failed` trace line — as opposed to a healthy ready that later
+// dropped. tryReconnect uses it to avoid re-deploying a broken env (and the
+// parallel re-deploy storm that results when every tab reconnects at once).
+func (a *App) reconnectBlockedByDeployFailure(managed *managedTerminal) bool {
+	if managed == nil {
+		return false
+	}
+	managed.readyMu.Lock()
+	defer managed.readyMu.Unlock()
+	return managed.readyClosed && managed.readyErr != nil
 }
 
 // emitStoppedContextMarker writes a single diagnostic line when


### PR DESCRIPTION
Two fixes for the failed-deploy recovery flow, found while testing the deploy-failure-details feature (#439) against a failing remote env.

Closes #445
Closes #447

## 1. Failed-card actions gave no feedback and piled commands into the Local shell (#445)

**Run doctor / Rebuild & redeploy / Clear pending helm** called the Wails methods directly, which pipe `erun …` into the shared Local shell and return — without focusing the Local tab or showing a busy indicator. So the buttons appeared to do nothing, and with no feedback users clicked repeatedly, flooding the shell.

**Fix:** route them through new `recoveryThunks` (`startDoctorSelection` / `startForceDeploySelection`) that mirror `startDeploySelection` — select the env, show a busy message, run the command, then `activateLocalAfterCommand` so the **Local tab is focused** and the user sees it run. A per-card in-flight guard disables the buttons while an action is starting so clicks can't pile up. `deployUiSelection` now returns the typed `UISelection` the thunks expect.

## 2. Reconnect re-deployed a failed env in a parallel storm across tabs (#447)

Both the ERun and AI tabs run `erun open` (deploy + shell). The initial opens are serialized by the per-env gate, but **`tryReconnect`** is ungated and per-tab, and its `respawn` re-runs the full `erun open` (deploy). On a failing deploy, each tab respawned independently → parallel re-deploys in a loop, and the env couldn't open.

**Fix:** `tryReconnect` refuses to respawn when the prior open ended in a **deploy failure**, using the existing ready signal (`signalReady(err)` on `==> Deploy failed` vs `nil` on a healthy shell). It emits one `── deploy failed — not retrying … ──` marker; recovery is the failed-card actions or reopening the env. A healthy-ready-then-dropped session still reconnects (and skips the already-current deploy).

(Follow-on, larger: have only one tab drive the `erun open` deploy and others attach without deploying — needs an attach/`--no-deploy` path.)

## Validation
- `go test ./...` (erun-ui) ✅ — incl. new `TestTryReconnectRefusesAfterDeployFailure` + `TestTryReconnectAfterHealthyDropRespawns`.
- Frontend `typecheck` / `lint` / `format` / `build` ✅; Playwright `activity-failure-details.spec.ts` ✅ (buttons render with the new wiring).
- Go-only reconnect change + frontend-only card change; no CLI/common, so the integration gate is unaffected.
- **Verification gap:** the live-desktop Local-tab activation and the "no more re-deploy storm" against a real failing remote env can't be driven from this contribute pod (needs an openable env — same constraint as #442). The fixes mirror the already-working `startDeploySelection` thunk and are Go-tested for the reconnect logic; final confirmation is on the desktop with the rebuilt app.