### PR TITLE
Stop re-deploying a failed env on reconnect (no parallel deploy storm across tabs)

### DIFF
--- a/erun-ui/reconnect_loop_test.go
+++ b/erun-ui/reconnect_loop_test.go
@@ -375,3 +375,82 @@ func TestTrackExitForLoopGuardTripsAfterCap(t *testing.T) {
 			reconnectLoopMaxExits+1, reconnectLoopMaxExits)
 	}
 }
+
+// TestTryReconnectRefusesAfterDeployFailure pins #447: when an env's open
+// ended in a deploy failure (signalReady recorded an error from
+// `==> Deploy failed`), tryReconnect must NOT respawn. Respawning re-runs
+// `erun open`, re-deploying a broken env — and because every tab (ERun + AI)
+// reconnects independently, that becomes a parallel re-deploy storm. The user
+// recovers via the failed-deploy card actions or by reopening the env.
+func TestTryReconnectRefusesAfterDeployFailure(t *testing.T) {
+	emits := newCapturedEmits()
+	app := &App{}
+	app.SetEmitter(emits.fn())
+
+	respawned := false
+	managed := &managedTerminal{
+		serial:      7,
+		readyClosed: true,
+		readyErr:    errors.New("==> Deploy failed after 4s"),
+		respawn: func() (terminalSession, error) {
+			respawned = true
+			return newStubTerminalSession(), nil
+		},
+	}
+
+	if app.tryReconnect(managed, "exit code 1") {
+		t.Fatal("tryReconnect must refuse to respawn after a deploy failure")
+	}
+	if respawned {
+		t.Fatal("respawn must not run after a deploy failure")
+	}
+	if !sawDeployFailedMarker(emits) {
+		t.Fatal("expected the deploy-failed marker on the terminal-output channel")
+	}
+}
+
+// TestTryReconnectAfterHealthyDropRespawns is the counterpart: a session that
+// reached a healthy ready (readyErr == nil) and then dropped is a transient
+// drop and must still reconnect. Its `erun open` finds the deploy already
+// current and skips it, so no re-deploy storm.
+func TestTryReconnectAfterHealthyDropRespawns(t *testing.T) {
+	emits := newCapturedEmits()
+	app := &App{}
+	app.SetEmitter(emits.fn())
+
+	respawned := false
+	managed := &managedTerminal{
+		serial:      8,
+		readyClosed: true,
+		readyErr:    nil,
+		respawn: func() (terminalSession, error) {
+			respawned = true
+			return newStubTerminalSession(), nil
+		},
+	}
+
+	if !app.tryReconnect(managed, "transient drop") {
+		t.Fatal("a healthy session that dropped should reconnect")
+	}
+	if !respawned {
+		t.Fatal("respawn should run for a healthy dropped session")
+	}
+}
+
+func sawDeployFailedMarker(emits *capturedEmits) bool {
+	const needle = "deploy failed — not retrying"
+	for _, evt := range emits.events(terminalOutputEvent) {
+		payload, ok := evt.(terminalOutputPayload)
+		if !ok {
+			continue
+		}
+		data, err := base64.StdEncoding.DecodeString(payload.Data)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(data), needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -997,6 +997,20 @@ func (a *App) tryReconnect(managed *managedTerminal, exitReason string) bool {
 		return false
 	}
 
+	// A deploy failure is terminal, not a transient drop. Respawning
+	// re-runs `erun open`, which re-deploys and fails the same way — and
+	// because every env tab (ERun + AI) reconnects independently, that
+	// turns one failing deploy into a parallel re-deploy storm across
+	// tabs. Refuse here and leave recovery to the user (the failed-deploy
+	// card's Run doctor / Rebuild & redeploy, or the titlebar Play
+	// button). A session that reached a healthy shell and then dropped has
+	// readyErr == nil and still reconnects below; its `erun open` finds the
+	// deploy already current and skips it.
+	if a.reconnectBlockedByDeployFailure(managed) {
+		a.emitDeployFailedMarker(managed.serial)
+		return false
+	}
+
 	// Cap consecutive fast-exit respawns. Without this, an env whose
 	// underlying cluster keeps tearing down the freshly-spawned pod
 	// (helm rollout timeouts, MCP port-forward races against a
@@ -1127,6 +1141,7 @@ const (
 	reconnectLoopWindow    = 30 * time.Second
 	reconnectLoopMaxExits  = 2
 	reconnectLoopMarkerANSI = "\r\n\x1b[2;33m── stopped reconnecting after repeated failures — click the environment in the sidebar to retry ──\x1b[0m\r\n"
+	deployFailedMarkerANSI  = "\r\n\x1b[2;33m── deploy failed — not retrying automatically; use Run doctor or Rebuild & redeploy on the failed deploy, or click the environment to retry ──\x1b[0m\r\n"
 )
 
 // trackExitForLoopGuard records the moment the managed PTY exited
@@ -1164,6 +1179,30 @@ func (a *App) emitReconnectLoopMarker(sessionID int) {
 		SessionID: sessionID,
 		Data:      base64.StdEncoding.EncodeToString([]byte(reconnectLoopMarkerANSI)),
 	})
+}
+
+// emitDeployFailedMarker writes a single diagnostic line when tryReconnect
+// refuses to respawn because the env's deploy failed (rather than a transient
+// drop). See tryReconnect.
+func (a *App) emitDeployFailedMarker(sessionID int) {
+	a.emitEvent(terminalOutputEvent, terminalOutputPayload{
+		SessionID: sessionID,
+		Data:      base64.StdEncoding.EncodeToString([]byte(deployFailedMarkerANSI)),
+	})
+}
+
+// reconnectBlockedByDeployFailure reports whether the managed PTY's open
+// ended in a deploy failure — signalReady was called with an error from the
+// `==> Deploy failed` trace line — as opposed to a healthy ready that later
+// dropped. tryReconnect uses it to avoid re-deploying a broken env (and the
+// parallel re-deploy storm that results when every tab reconnects at once).
+func (a *App) reconnectBlockedByDeployFailure(managed *managedTerminal) bool {
+	if managed == nil {
+		return false
+	}
+	managed.readyMu.Lock()
+	defer managed.readyMu.Unlock()
+	return managed.readyClosed && managed.readyErr != nil
 }
 
 // emitStoppedContextMarker writes a single diagnostic line when


### PR DESCRIPTION
## Problem (#447)

When a remote env's deploy fails (`==> Deploy failed` / helm rollout timeout), the desktop floods the terminals re-running `erun open` (which deploys) over and over, **in parallel across the ERun and AI tabs**, and the env can't be opened.

## Root cause

Both tabs run `erun open` (deploy + shell). The initial opens are serialized by the per-env action-runner gate, so they aren't the parallel source. The spam comes from **`tryReconnect`**: it is ungated and per-tab, and its `respawn` re-runs the **full `erun open` (deploy)**. On a failing deploy, each tab's open exits in seconds and each respawns independently → parallel re-deploys in a loop. The fast-exit loop guard (#361) eventually trips but still re-deploys several times and doesn't distinguish a failed deploy from a transient drop.

## Fix

`tryReconnect` now refuses to respawn when the prior open ended in a **deploy failure**, using the signal that already exists: `signalSessionReadyOnLine` calls `signalReady(err)` on `==> Deploy failed` (vs `signalReady(nil)` on a healthy shell / `==> Deployed`).

- Deploy failed → no respawn; emit a single `── deploy failed — not retrying … ──` marker; recovery is the failed-deploy card's **Run doctor** / **Rebuild & redeploy** (or reopening the env). Both tabs hit the same refusal, so no parallel re-deploy.
- Healthy ready then dropped (transient) → still reconnects as before; its `erun open` finds the deploy already current and skips it.

(Follow-on, larger: have only one tab drive the `erun open` deploy and others attach without deploying — needs an attach/`--no-deploy` path. Not required here.)

## Validation
- `go test ./...` (erun-ui) ✅ — new `TestTryReconnectRefusesAfterDeployFailure` + `TestTryReconnectAfterHealthyDropRespawns`, alongside the existing #361 loop-guard test.
- Go-only change in `terminal_sessions.go`; no frontend/CLI/common, so the integration gate is unaffected. No React surface change (terminal-output marker on the same channel as the existing reconnect markers), so no Playwright change — consistent with how the loop-guard marker is covered.

Found while testing the deploy-failure-details feature (#439) against a failing remote env; companion to the failed-card feedback fix (#446).