### PR TITLE
Failed-deploy recovery: doctor recovery actions, single-recommendation, and stop a failed env re-deploying on reopen/reconnect

### DIFF
--- a/erun-cli/cmd/doctor.go
+++ b/erun-cli/cmd/doctor.go
@@ -41,15 +41,19 @@ func newDoctorCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error)
 		Short: "Diagnose and repair an environment's runtime and config",
 		Long: "Diagnose and repair an environment's runtime and config.\n\n" +
 			"Reports why a deploy may have failed (helm release status and the runtime pods, " +
-			"read-only). When the release looks unhealthy it offers recovery: clear a stuck pending " +
-			"helm release, or roll back to the last successful revision. It also prunes Docker " +
-			"images, build cache, or stopped containers; restores or fixes the root erun config; and " +
-			"finishes an interrupted remote init. Recovery and rollback mutate the live release; each " +
-			"action prompts before running unless you pass its matching flag.",
+			"read-only). When the release looks unhealthy it recommends the one recovery that fits — " +
+			"clear a stuck pending helm release, or roll back to the last successful revision — and " +
+			"prompts before running it. It also prunes Docker images, build cache, or stopped " +
+			"containers; restores or fixes the root erun config; and finishes an interrupted remote " +
+			"init. The recovery actions mutate the live release; run one directly with --clear-pending-helm " +
+			"or --rollback (the two are alternatives — pass only one).",
 		Args:          cobra.MaximumNArgs(2),
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateDoctorRecoveryFlags(options); err != nil {
+				return err
+			}
 			return runDoctorCommand(commandContext(cmd), resolveOpen, configStore, cloudDeps, cloudContextDeps, promptRunner, options, args)
 		},
 	}
@@ -124,6 +128,16 @@ func doctorOnlyRepairConfig(options doctorOptions) bool {
 		!options.pruneContainers &&
 		!options.repairJetBrainsGateway &&
 		!options.finishRemoteInit
+}
+
+// validateDoctorRecoveryFlags rejects asking for both helm-level recoveries at
+// once: clearing a pending lock and rolling back are alternative fixes, and
+// running both in one invocation steps the release back a revision too far.
+func validateDoctorRecoveryFlags(options doctorOptions) error {
+	if options.clearPendingHelm && options.rollback {
+		return errors.New("--clear-pending-helm and --rollback are alternative recoveries; pass only one")
+	}
+	return nil
 }
 
 func runDoctorCleanupActions(ctx common.Context, promptRunner PromptRunner, result common.OpenResult, options doctorOptions) error {
@@ -215,41 +229,34 @@ func runDeployRecoveryActions(ctx common.Context, promptRunner PromptRunner, req
 	return nil
 }
 
+// selectedDeployRecoveryActions resolves which recovery to run. Explicit flags
+// win (and are mutually exclusive — see validateDoctorRecoveryFlags). With no
+// flag, the interactive path offers a single confirm for the one recovery that
+// fits the diagnosis rather than asking about every action in turn: clearing a
+// pending lock and rolling back are alternative fixes, and running both is
+// wrong.
 func selectedDeployRecoveryActions(promptRunner PromptRunner, req common.ShellLaunchParams, options doctorOptions, diagnosis common.DeployDiagnosisResult, dryRun bool) ([]common.DeployRecoveryAction, error) {
-	selected := make([]common.DeployRecoveryAction, 0, 2)
 	if options.clearPendingHelm {
-		selected = append(selected, common.DeployRecoveryClearPendingHelm)
+		return []common.DeployRecoveryAction{common.DeployRecoveryClearPendingHelm}, nil
 	}
 	if options.rollback {
-		selected = append(selected, common.DeployRecoveryRollback)
+		return []common.DeployRecoveryAction{common.DeployRecoveryRollback}, nil
 	}
-	// Explicit flags win; otherwise only prompt when the release looks
-	// unhealthy so a healthy env is never offered a destructive rollback.
-	if len(selected) > 0 || dryRun || promptRunner == nil || !deployLooksUnhealthy(diagnosis) {
-		return selected, nil
+	if dryRun || promptRunner == nil {
+		return nil, nil
 	}
-	for _, action := range common.DeployRecoveryActions() {
-		ok, err := confirmPrompt(promptRunner, common.DeployRecoveryActionPromptLabel(action, req))
-		if err != nil {
-			return nil, err
-		}
-		if ok {
-			selected = append(selected, action)
-		}
+	action, ok := common.RecommendedDeployRecovery(diagnosis)
+	if !ok {
+		return nil, nil
 	}
-	return selected, nil
-}
-
-// deployLooksUnhealthy reports whether the diagnosis indicates the runtime
-// release is not in a healthy "deployed" state — the gate for offering the
-// destructive recovery actions interactively. An empty status (release
-// missing or cluster unreachable) counts as unhealthy.
-func deployLooksUnhealthy(diagnosis common.DeployDiagnosisResult) bool {
-	status := strings.ToLower(strings.TrimSpace(diagnosis.HelmStatus))
-	if status == "" {
-		return true
+	confirmed, err := confirmPrompt(promptRunner, common.DeployRecoveryActionPromptLabel(action, req))
+	if err != nil {
+		return nil, err
 	}
-	return !strings.Contains(status, "status: deployed")
+	if !confirmed {
+		return nil, nil
+	}
+	return []common.DeployRecoveryAction{action}, nil
 }
 
 func writeDeployDiagnosis(ctx common.Context, diagnosis common.DeployDiagnosisResult) error {

--- a/erun-cli/cmd/doctor.go
+++ b/erun-cli/cmd/doctor.go
@@ -17,6 +17,8 @@ type doctorOptions struct {
 	pruneImages             bool
 	pruneBuildCache         bool
 	pruneContainers         bool
+	clearPendingHelm        bool
+	rollback                bool
 	repairJetBrainsGateway  bool
 	repairConfig            bool
 	restoreConfigFromBackup string
@@ -38,10 +40,12 @@ func newDoctorCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error)
 		Use:   "doctor [tenant] [environment]",
 		Short: "Diagnose and repair an environment's runtime and config",
 		Long: "Diagnose and repair an environment's runtime and config.\n\n" +
-			"Reports why a deploy may have failed (helm release status and the runtime pods), then " +
-			"offers repairs: prune its Docker images, build cache, or stopped containers; restore or " +
-			"fix the root erun config; and finish an interrupted remote init. The deploy diagnosis is " +
-			"read-only; each repair prompts before running unless you pass its matching flag.",
+			"Reports why a deploy may have failed (helm release status and the runtime pods, " +
+			"read-only). When the release looks unhealthy it offers recovery: clear a stuck pending " +
+			"helm release, or roll back to the last successful revision. It also prunes Docker " +
+			"images, build cache, or stopped containers; restores or fixes the root erun config; and " +
+			"finishes an interrupted remote init. Recovery and rollback mutate the live release; each " +
+			"action prompts before running unless you pass its matching flag.",
 		Args:          cobra.MaximumNArgs(2),
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -53,6 +57,8 @@ func newDoctorCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error)
 	cmd.Flags().BoolVar(&options.pruneImages, "prune-images", false, "Prune unused Docker images without prompting")
 	cmd.Flags().BoolVar(&options.pruneBuildCache, "prune-build-cache", false, "Prune unused BuildKit cache without prompting")
 	cmd.Flags().BoolVar(&options.pruneContainers, "prune-containers", false, "Prune stopped Docker containers without prompting")
+	cmd.Flags().BoolVar(&options.clearPendingHelm, "clear-pending-helm", false, "Clear a stuck helm pending-install/upgrade lock for the runtime release without prompting")
+	cmd.Flags().BoolVar(&options.rollback, "rollback", false, "Roll the runtime release back to its last successful revision without prompting")
 	cmd.Flags().BoolVar(&options.repairJetBrainsGateway, "repair-jetbrains-gateway", false, "Clear cached JetBrains Gateway backend metadata for this environment")
 	cmd.Flags().BoolVar(&options.repairConfig, "repair-config", false, "Inspect the root erun config and offer to restore from backup or re-init orphaned cloud provider aliases; stops before running tenant/env cleanup actions")
 	cmd.Flags().StringVar(&options.restoreConfigFromBackup, "restore-config-from-backup", "", "Restore the root erun config from a dated backup non-interactively (YYYY-MM-DD or absolute path)")
@@ -122,7 +128,11 @@ func doctorOnlyRepairConfig(options doctorOptions) bool {
 
 func runDoctorCleanupActions(ctx common.Context, promptRunner PromptRunner, result common.OpenResult, options doctorOptions) error {
 	req := common.ShellLaunchParamsFromResult(result)
-	if err := runDeployDiagnosis(ctx, req); err != nil {
+	diagnosis, err := runDeployDiagnosis(ctx, req)
+	if err != nil {
+		return err
+	}
+	if err := runDeployRecoveryActions(ctx, promptRunner, req, options, diagnosis); err != nil {
 		return err
 	}
 	inspection, err := common.RunDoctorInspection(ctx, nil, req)
@@ -162,18 +172,84 @@ func writeNoDoctorActionsSelected(ctx common.Context) error {
 const deployDiagnosisGuidance = "If the release is stuck pending or an image failed to pull, re-run `erun deploy --force` to rebuild and redeploy, or clear the pending release."
 
 // runDeployDiagnosis reports the helm release status and runtime pods so the
-// reader can see why a deploy failed before any cleanup. Read-only; the
-// commands are traced for --dry-run.
-func runDeployDiagnosis(ctx common.Context, req common.ShellLaunchParams) error {
+// reader can see why a deploy failed before any recovery. Read-only; the
+// commands are traced for --dry-run. Returns the diagnosis so the caller can
+// decide whether to offer the (destructive) recovery actions.
+func runDeployDiagnosis(ctx common.Context, req common.ShellLaunchParams) (common.DeployDiagnosisResult, error) {
 	diagnosis := common.RunDeployDiagnosis(ctx, req)
 	if ctx.DryRun {
-		return nil
+		return diagnosis, nil
 	}
 	if err := writeDeployDiagnosis(ctx, diagnosis); err != nil {
+		return diagnosis, err
+	}
+	if _, err := fmt.Fprintln(ctx.Stdout, deployDiagnosisGuidance); err != nil {
+		return diagnosis, err
+	}
+	return diagnosis, nil
+}
+
+// runDeployRecoveryActions runs the helm-level recovery actions the user
+// selected (via flag, or via prompt when the diagnosis shows the release is
+// unhealthy). The actions mutate the live release, so prompts are gated on an
+// unhealthy diagnosis — `erun doctor` never offers rollback on a healthy env.
+func runDeployRecoveryActions(ctx common.Context, promptRunner PromptRunner, req common.ShellLaunchParams, options doctorOptions, diagnosis common.DeployDiagnosisResult) error {
+	actions, err := selectedDeployRecoveryActions(promptRunner, req, options, diagnosis, ctx.DryRun)
+	if err != nil {
 		return err
 	}
-	_, err := fmt.Fprintln(ctx.Stdout, deployDiagnosisGuidance)
-	return err
+	for _, action := range actions {
+		if _, err := fmt.Fprintf(ctx.Stdout, "Running: %s\n", common.DeployRecoveryActionDescription(action)); err != nil {
+			return err
+		}
+		output, runErr := common.RunDeployRecovery(ctx, req, action)
+		if runErr != nil {
+			return runErr
+		}
+		if !ctx.DryRun {
+			if err := writeDoctorCommandOutput(ctx, output, ""); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func selectedDeployRecoveryActions(promptRunner PromptRunner, req common.ShellLaunchParams, options doctorOptions, diagnosis common.DeployDiagnosisResult, dryRun bool) ([]common.DeployRecoveryAction, error) {
+	selected := make([]common.DeployRecoveryAction, 0, 2)
+	if options.clearPendingHelm {
+		selected = append(selected, common.DeployRecoveryClearPendingHelm)
+	}
+	if options.rollback {
+		selected = append(selected, common.DeployRecoveryRollback)
+	}
+	// Explicit flags win; otherwise only prompt when the release looks
+	// unhealthy so a healthy env is never offered a destructive rollback.
+	if len(selected) > 0 || dryRun || promptRunner == nil || !deployLooksUnhealthy(diagnosis) {
+		return selected, nil
+	}
+	for _, action := range common.DeployRecoveryActions() {
+		ok, err := confirmPrompt(promptRunner, common.DeployRecoveryActionPromptLabel(action, req))
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			selected = append(selected, action)
+		}
+	}
+	return selected, nil
+}
+
+// deployLooksUnhealthy reports whether the diagnosis indicates the runtime
+// release is not in a healthy "deployed" state — the gate for offering the
+// destructive recovery actions interactively. An empty status (release
+// missing or cluster unreachable) counts as unhealthy.
+func deployLooksUnhealthy(diagnosis common.DeployDiagnosisResult) bool {
+	status := strings.ToLower(strings.TrimSpace(diagnosis.HelmStatus))
+	if status == "" {
+		return true
+	}
+	return !strings.Contains(status, "status: deployed")
 }
 
 func writeDeployDiagnosis(ctx common.Context, diagnosis common.DeployDiagnosisResult) error {

--- a/erun-common/doctor_deploy.go
+++ b/erun-common/doctor_deploy.go
@@ -81,11 +81,34 @@ const (
 	DeployRecoveryRollback DeployRecoveryAction = "rollback"
 )
 
-// DeployRecoveryActions lists the helm-level recovery actions doctor offers.
-// Force rebuild & redeploy is driven by the CLI doctor through the deploy flow
-// (it is not a single helm command) and so is not in this list.
-func DeployRecoveryActions() []DeployRecoveryAction {
-	return []DeployRecoveryAction{DeployRecoveryClearPendingHelm, DeployRecoveryRollback}
+// RecommendedDeployRecovery picks the single recovery action that fits the
+// diagnosis so `erun doctor` recommends one fix instead of offering every
+// action at once. Clearing a stuck pending lock and rolling back are
+// alternative fixes for different failure modes, not additive steps: clearing
+// pending leaves the release at its last deployed revision, so a rollback run
+// straight after would step back a further revision. The bool is false when no
+// helm-level recovery applies — a healthy release, or no release to act on (a
+// missing release is recovered by `erun deploy --force`, not by helm).
+func RecommendedDeployRecovery(diagnosis DeployDiagnosisResult) (DeployRecoveryAction, bool) {
+	status := strings.ToLower(strings.TrimSpace(diagnosis.HelmStatus))
+	switch {
+	case status == "":
+		// No helm output at all (cluster unreachable / nothing to read).
+		return "", false
+	case strings.Contains(status, "not found"):
+		// `helm status` on a release that was never installed: deploy, not roll back.
+		return "", false
+	case strings.Contains(status, "pending-install"),
+		strings.Contains(status, "pending-upgrade"),
+		strings.Contains(status, "pending-rollback"):
+		return DeployRecoveryClearPendingHelm, true
+	case strings.Contains(status, "status: deployed"):
+		// Helm considers the release healthy; offer no destructive recovery.
+		return "", false
+	default:
+		// Release exists but is failed/superseded/unknown: roll back to the last good revision.
+		return DeployRecoveryRollback, true
+	}
 }
 
 // DeployRecoveryActionPromptLabel is the interactive confirm shown before the

--- a/erun-common/doctor_deploy.go
+++ b/erun-common/doctor_deploy.go
@@ -2,6 +2,7 @@ package eruncommon
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 )
 
@@ -62,4 +63,105 @@ func runDoctorDiagnosisCommand(name string, args []string) string {
 	cmd.Stderr = &out
 	_ = cmd.Run()
 	return strings.TrimSpace(out.String())
+}
+
+// DeployRecoveryAction names a recovery `erun doctor` can run against a failing
+// runtime release once the diagnosis surfaces a problem. These mutate the live
+// release, so callers gate them behind a prompt/flag; the commands are traced
+// for --dry-run so the exact helm/kubectl call is auditable before it runs.
+type DeployRecoveryAction string
+
+const (
+	// DeployRecoveryClearPendingHelm clears a stuck helm pending-install /
+	// pending-upgrade / pending-rollback lock so the next deploy can proceed.
+	DeployRecoveryClearPendingHelm DeployRecoveryAction = "clear_pending_helm"
+	// DeployRecoveryRollback rolls the release back to its previous (last
+	// successfully deployed) revision — the general recovery from a bad or
+	// non-converging deploy.
+	DeployRecoveryRollback DeployRecoveryAction = "rollback"
+)
+
+// DeployRecoveryActions lists the helm-level recovery actions doctor offers.
+// Force rebuild & redeploy is driven by the CLI doctor through the deploy flow
+// (it is not a single helm command) and so is not in this list.
+func DeployRecoveryActions() []DeployRecoveryAction {
+	return []DeployRecoveryAction{DeployRecoveryClearPendingHelm, DeployRecoveryRollback}
+}
+
+// DeployRecoveryActionPromptLabel is the interactive confirm shown before the
+// action runs.
+func DeployRecoveryActionPromptLabel(action DeployRecoveryAction, req ShellLaunchParams) string {
+	target := strings.TrimSpace(req.Tenant) + "/" + strings.TrimSpace(req.Environment)
+	switch action {
+	case DeployRecoveryClearPendingHelm:
+		return fmt.Sprintf("Clear the stuck pending helm release for %s?", target)
+	case DeployRecoveryRollback:
+		return fmt.Sprintf("Roll back %s to its last successful revision?", target)
+	default:
+		return fmt.Sprintf("Run deploy recovery %q for %s?", action, target)
+	}
+}
+
+// DeployRecoveryActionDescription is the one-line "Running: …" label.
+func DeployRecoveryActionDescription(action DeployRecoveryAction) string {
+	switch action {
+	case DeployRecoveryClearPendingHelm:
+		return "Clear pending helm release"
+	case DeployRecoveryRollback:
+		return "Roll back to the last successful revision"
+	default:
+		return string(action)
+	}
+}
+
+func helmRollbackArgs(req ShellLaunchParams) []string {
+	// `helm rollback <release>` with no revision rolls back to the previous
+	// release revision (the last one helm recorded as deployed).
+	args := []string{"rollback", RuntimeReleaseName(req.Tenant)}
+	if strings.TrimSpace(req.Namespace) != "" {
+		args = append(args, "--namespace", req.Namespace)
+	}
+	if strings.TrimSpace(req.KubernetesContext) != "" {
+		args = append(args, "--kube-context", req.KubernetesContext)
+	}
+	return append(args, "--wait", "--timeout", defaultShellLaunchWaitTimeout)
+}
+
+// RunDeployRecovery runs the chosen helm-level recovery against the runtime
+// release. It traces the exact command for --dry-run and only mutates the
+// cluster on a real run. The combined command output (helm/kubectl stdout +
+// stderr) is returned so the caller can render what happened.
+func RunDeployRecovery(ctx Context, req ShellLaunchParams, action DeployRecoveryAction) (string, error) {
+	switch action {
+	case DeployRecoveryClearPendingHelm:
+		clear := HelmReleaseRecoveryParams{
+			ReleaseName:       RuntimeReleaseName(req.Tenant),
+			Namespace:         strings.TrimSpace(req.Namespace),
+			KubernetesContext: strings.TrimSpace(req.KubernetesContext),
+			Verbosity:         ctx.Verbosity,
+		}
+		ctx.TraceCommand("", clear.command().Name, clear.command().Args...)
+		if ctx.DryRun {
+			return "", nil
+		}
+		var out bytes.Buffer
+		clear.Stdout = &out
+		clear.Stderr = &out
+		err := ClearHelmReleasePendingOperation(clear)
+		return strings.TrimSpace(out.String()), err
+	case DeployRecoveryRollback:
+		args := helmRollbackArgs(req)
+		ctx.TraceCommand("", "helm", args...)
+		if ctx.DryRun {
+			return "", nil
+		}
+		cmd := Command("helm", args...)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err := cmd.Run()
+		return strings.TrimSpace(out.String()), err
+	default:
+		return "", fmt.Errorf("unsupported deploy recovery action %q", action)
+	}
 }

--- a/erun-common/doctor_deploy_test.go
+++ b/erun-common/doctor_deploy_test.go
@@ -1,0 +1,61 @@
+package eruncommon
+
+import "testing"
+
+// TestRecommendedDeployRecovery locks the diagnosis → single-recovery mapping.
+// The classifier only runs on a real `erun doctor` (dry-run produces an empty
+// diagnosis because the helm/kubectl probes are traced, not executed), so it is
+// unreachable from the dry-run integration subprocess and is covered here.
+func TestRecommendedDeployRecovery(t *testing.T) {
+	cases := []struct {
+		name       string
+		helmStatus string
+		wantAction DeployRecoveryAction
+		wantOK     bool
+	}{
+		{
+			name:       "empty status offers nothing",
+			helmStatus: "",
+			wantOK:     false,
+		},
+		{
+			name:       "release not found offers nothing",
+			helmStatus: "Error: release: not found",
+			wantOK:     false,
+		},
+		{
+			name:       "pending-upgrade recommends clearing the lock",
+			helmStatus: "NAME: team-devops\nSTATUS: pending-upgrade\nREVISION: 3",
+			wantAction: DeployRecoveryClearPendingHelm,
+			wantOK:     true,
+		},
+		{
+			name:       "pending-install recommends clearing the lock",
+			helmStatus: "STATUS: pending-install",
+			wantAction: DeployRecoveryClearPendingHelm,
+			wantOK:     true,
+		},
+		{
+			name:       "deployed offers nothing",
+			helmStatus: "NAME: team-devops\nSTATUS: deployed\nREVISION: 4",
+			wantOK:     false,
+		},
+		{
+			name:       "failed recommends rollback",
+			helmStatus: "NAME: team-devops\nSTATUS: failed\nREVISION: 5",
+			wantAction: DeployRecoveryRollback,
+			wantOK:     true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			action, ok := RecommendedDeployRecovery(DeployDiagnosisResult{HelmStatus: tc.helmStatus})
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && action != tc.wantAction {
+				t.Fatalf("action = %q, want %q", action, tc.wantAction)
+			}
+		})
+	}
+}

--- a/erun-docs/docs/agent-reference/cli-flags.md
+++ b/erun-docs/docs/agent-reference/cli-flags.md
@@ -233,6 +233,8 @@ The skip emits `result: skipped (no change)` in the trace.
 |---|---|---|---|
 | `--dry-run` | bool | `false` | Run the inspection; print the recovery plan; do not execute it. |
 | `-y` | bool | `false` | Auto-approve every offered recovery action. |
+| `--clear-pending-helm` | bool | `false` | Run the clear-pending-helm recovery without prompting (see [Deploy recovery actions](#deploy-recovery-actions)). |
+| `--rollback` | bool | `false` | Run the rollback recovery without prompting (see [Deploy recovery actions](#deploy-recovery-actions)). |
 
 ### Check catalogue
 
@@ -258,6 +260,19 @@ Each check returns one of `ok`, `missing`, `error` (parse failure, permission de
 | `workspace.git_checkout` | The checkout's HEAD is on the marker's recorded branch. | Offers to `git checkout` the branch. |
 | `ssh.keypair` | `~/.ssh/id_ed25519` and `.pub` exist. | Offers `ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ''`. |
 | `ssh.codecommit_key` | When the marker recorded a CodeCommit host: `~/.ssh/id_rsa` (RSA, not ed25519) is registered with the IAM user. | Offers to generate and upload via `aws iam upload-ssh-public-key`. |
+
+### Deploy recovery actions {#deploy-recovery-actions}
+
+After the read-only deploy diagnosis (helm release status + runtime pods), `doctor` offers two recovery actions that **mutate the live release**. Each is gated: it runs non-interactively with its flag, or — when no flag is set — it is offered as a confirm prompt **only when the diagnosis shows the release is unhealthy** (helm status is empty, or not `status: deployed`). A healthy env is never offered a destructive rollback. Under `--dry-run` the exact command is traced and nothing runs.
+
+| Action | Flag | Command run | Use when |
+|---|---|---|---|
+| Clear pending helm release | `--clear-pending-helm` | `kubectl [--context <ctx>] --namespace <ns> delete secrets,configmaps -l 'owner=helm,name=<release>,status in (pending-install,pending-upgrade,pending-rollback)' --ignore-not-found` | A deploy died mid-upgrade and left the release locked in a pending state, so the next `erun deploy` refuses to start. |
+| Roll back to last successful revision | `--rollback` | `helm rollback <release> --namespace <ns> [--kube-context <ctx>] --wait --timeout <deploy-wait>` | The current revision is bad or never converged and a previous revision was healthy. |
+
+`<release>` is the runtime release name for the tenant; `<ns>` and `<ctx>` are the resolved env namespace and kube-context. To rebuild and roll out fresh images instead of recovering the existing release, re-run [`erun deploy --force`](/cli/deploy) — the desktop's failed-deploy card surfaces that as its **Force rebuild & redeploy** button.
+
+Both actions are also exposed on the [MCP `doctor` tool](/mcp/overview#doctor) via the `clearPendingHelm` and `rollback` boolean inputs.
 
 ### Exit codes
 

--- a/erun-docs/docs/agent-reference/cli-flags.md
+++ b/erun-docs/docs/agent-reference/cli-flags.md
@@ -263,7 +263,9 @@ Each check returns one of `ok`, `missing`, `error` (parse failure, permission de
 
 ### Deploy recovery actions {#deploy-recovery-actions}
 
-After the read-only deploy diagnosis (helm release status + runtime pods), `doctor` offers two recovery actions that **mutate the live release**. Each is gated: it runs non-interactively with its flag, or — when no flag is set — it is offered as a confirm prompt **only when the diagnosis shows the release is unhealthy** (helm status is empty, or not `status: deployed`). A healthy env is never offered a destructive rollback. Under `--dry-run` the exact command is traced and nothing runs.
+After the read-only deploy diagnosis (helm release status + runtime pods), `doctor` can run two recovery actions that **mutate the live release**. They are **alternative** fixes for different failure modes, not additive steps — clearing a pending lock leaves the release at its last deployed revision, so a rollback run straight after would step back a further revision. `--clear-pending-helm` and `--rollback` are therefore mutually exclusive; passing both aborts with `--clear-pending-helm and --rollback are alternative recoveries; pass only one` (exit 1, nothing runs).
+
+Gating: each action runs non-interactively with its flag. With **no flag**, `doctor` inspects the helm status and prompts for the **single recommended** action — `pending-install`/`pending-upgrade`/`pending-rollback` → clear pending; a present-but-unhealthy release (`failed`, `superseded`, …) → rollback; a healthy (`status: deployed`), missing (`not found`), or unreadable release → no destructive prompt at all. It never offers both at once. Under `--dry-run` the exact command is traced and nothing runs.
 
 | Action | Flag | Command run | Use when |
 |---|---|---|---|

--- a/erun-docs/docs/cli/doctor.md
+++ b/erun-docs/docs/cli/doctor.md
@@ -26,7 +26,7 @@ When any item is `missing`, `doctor` offers to run the corresponding recovery st
 
 Beyond reporting, `doctor` offers these fixes (each prompts first, or runs non-interactively with its flag):
 
-- **Deploy recovery** — when the diagnosis shows the runtime release is unhealthy, recover it by clearing a stuck pending helm release (a deploy that died mid-upgrade leaves the release locked, blocking the next deploy) or rolling it back to its last successful revision. These mutate the live release, so each prompts first; they are offered only when the release looks unhealthy, never on a healthy env. To rebuild and roll out fresh images instead, re-run `erun deploy --force`.
+- **Deploy recovery** — when the diagnosis shows the runtime release is unhealthy, `doctor` recommends the **one** recovery that fits: clearing a stuck pending helm release when a deploy died mid-upgrade and left it locked, or rolling back to the last successful revision when the current one is bad. It prompts for that single action (never both — they are alternative fixes, and running both would roll the release back a revision too far). These mutate the live release and are offered only when the release looks unhealthy, never on a healthy env. To rebuild and roll out fresh images instead, re-run `erun deploy --force`.
 - **Docker cleanup** — prune the environment's unused images, build cache, or stopped containers. These run against the environment's Docker, not your laptop's.
 - **Root config repair** — restore the root erun config from a dated backup, or re-initialize orphaned cloud provider aliases.
 - **JetBrains Gateway** — clear cached backend metadata for the environment when a Gateway connection is stuck.
@@ -104,6 +104,7 @@ The check format is fixed (`<category>: <name> <status> <detail>`); machine-read
 | Helm release missing or cluster unreachable during deploy diagnosis. | The helm/pod probe output (including the error) is shown as part of the diagnosis and `doctor` continues; the diagnosis is read-only, so nothing is changed. |
 | Deploy recovery (`--clear-pending-helm` / `--rollback`) fails. | The failing helm/kubectl output is surfaced and `doctor` aborts with that error; the release is left as helm leaves it (a failed rollback does not partially apply). Re-run the diagnosis to see the new state, then retry or `erun deploy --force`. |
 | `--rollback` with no prior successful revision. | `helm rollback` reports it has no revision to roll back to; nothing changes. Use `--clear-pending-helm` then `erun deploy --force` instead. |
+| Both `--clear-pending-helm` and `--rollback` passed. | Aborts immediately with `--clear-pending-helm and --rollback are alternative recoveries; pass only one`; exit code 1; nothing runs. |
 | Prune not confirmed and no `--prune-*` flag. | No Docker state is touched — prunes run only on confirmation or with the matching flag. |
 | Run inside a runtime pod with a complete init. | Reports "nothing to finish" and exits 0. |
 | Cluster unreachable. | Reports the pod check as failed; config and workspace checks still run. |

--- a/erun-docs/docs/cli/doctor.md
+++ b/erun-docs/docs/cli/doctor.md
@@ -26,6 +26,7 @@ When any item is `missing`, `doctor` offers to run the corresponding recovery st
 
 Beyond reporting, `doctor` offers these fixes (each prompts first, or runs non-interactively with its flag):
 
+- **Deploy recovery** — when the diagnosis shows the runtime release is unhealthy, recover it by clearing a stuck pending helm release (a deploy that died mid-upgrade leaves the release locked, blocking the next deploy) or rolling it back to its last successful revision. These mutate the live release, so each prompts first; they are offered only when the release looks unhealthy, never on a healthy env. To rebuild and roll out fresh images instead, re-run `erun deploy --force`.
 - **Docker cleanup** — prune the environment's unused images, build cache, or stopped containers. These run against the environment's Docker, not your laptop's.
 - **Root config repair** — restore the root erun config from a dated backup, or re-initialize orphaned cloud provider aliases.
 - **JetBrains Gateway** — clear cached backend metadata for the environment when a Gateway connection is stuck.
@@ -101,6 +102,8 @@ The check format is fixed (`<category>: <name> <status> <detail>`); machine-read
 |---|---|
 | Root config missing or corrupted. | Reports it; with `--repair-config` offers to restore from a dated backup, otherwise leaves it untouched. |
 | Helm release missing or cluster unreachable during deploy diagnosis. | The helm/pod probe output (including the error) is shown as part of the diagnosis and `doctor` continues; the diagnosis is read-only, so nothing is changed. |
+| Deploy recovery (`--clear-pending-helm` / `--rollback`) fails. | The failing helm/kubectl output is surfaced and `doctor` aborts with that error; the release is left as helm leaves it (a failed rollback does not partially apply). Re-run the diagnosis to see the new state, then retry or `erun deploy --force`. |
+| `--rollback` with no prior successful revision. | `helm rollback` reports it has no revision to roll back to; nothing changes. Use `--clear-pending-helm` then `erun deploy --force` instead. |
 | Prune not confirmed and no `--prune-*` flag. | No Docker state is touched — prunes run only on confirmation or with the matching flag. |
 | Run inside a runtime pod with a complete init. | Reports "nothing to finish" and exits 0. |
 | Cluster unreachable. | Reports the pod check as failed; config and workspace checks still run. |

--- a/erun-docs/docs/mcp/overview.md
+++ b/erun-docs/docs/mcp/overview.md
@@ -188,6 +188,8 @@ Runs a fixed set of in-pod health checks. Each check returns `ok | warn | fail` 
 
 A failing check returns `status: "fail"` and a `detail` describing the symptom. Agents should prefer running `doctor` before `raw` when they see unexpected behaviour.
 
+`doctor` also reports why a deploy may have failed (helm release status + runtime pods, read-only) and can recover a failing runtime release. Two boolean inputs request the recovery actions, each mutating the live release: `clearPendingHelm` clears a stuck helm pending-install/upgrade lock, and `rollback` rolls the release back to its last successful revision. See [CLI flag spec · Deploy recovery actions](/agent-reference/cli-flags#deploy-recovery-actions) for the exact commands and when to use each.
+
 ### `list`
 
 Same data as the CLI `erun list`, structured. Returns the caller's tenants, envs, and effective target.

--- a/erun-docs/docs/mcp/overview.md
+++ b/erun-docs/docs/mcp/overview.md
@@ -188,7 +188,7 @@ Runs a fixed set of in-pod health checks. Each check returns `ok | warn | fail` 
 
 A failing check returns `status: "fail"` and a `detail` describing the symptom. Agents should prefer running `doctor` before `raw` when they see unexpected behaviour.
 
-`doctor` also reports why a deploy may have failed (helm release status + runtime pods, read-only) and can recover a failing runtime release. Two boolean inputs request the recovery actions, each mutating the live release: `clearPendingHelm` clears a stuck helm pending-install/upgrade lock, and `rollback` rolls the release back to its last successful revision. See [CLI flag spec · Deploy recovery actions](/agent-reference/cli-flags#deploy-recovery-actions) for the exact commands and when to use each.
+`doctor` also reports why a deploy may have failed (helm release status + runtime pods, read-only) and can recover a failing runtime release. Two boolean inputs request the recovery actions, each mutating the live release: `clearPendingHelm` clears a stuck helm pending-install/upgrade lock, and `rollback` rolls the release back to its last successful revision. They are alternative fixes — requesting both in one call is rejected. See [CLI flag spec · Deploy recovery actions](/agent-reference/cli-flags#deploy-recovery-actions) for the exact commands and when to use each.
 
 ### `list`
 

--- a/erun-integration/doctor_test.go
+++ b/erun-integration/doctor_test.go
@@ -64,6 +64,20 @@ func TestDoctor(t *testing.T) {
 		golden.Equal(t, "doctor/dry_run_clear_pending_helm_traces_kubectl_delete", normalize.Apply(result.Combined))
 	})
 
+	t.Run("conflicting_recovery_flags_error", func(t *testing.T) {
+		// Clearing a pending lock and rolling back are alternative
+		// recoveries; passing both must fail fast with a clear error
+		// rather than running both (which would step the release back a
+		// revision too far).
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"doctor", "team", "dev", "--dry-run", "--clear-pending-helm", "--rollback"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit, got 0: %s", result.Combined)
+		}
+		golden.Equal(t, "doctor/conflicting_recovery_flags_error", normalize.Apply(result.Combined))
+	})
+
 	t.Run("in_runtime_complete_marker_dry_run", func(t *testing.T) {
 		// When the runtime env reports ERUN_REPO_REMOTE=true and the
 		// bootstrap marker shows the previous init finished, doctor

--- a/erun-integration/doctor_test.go
+++ b/erun-integration/doctor_test.go
@@ -36,6 +36,34 @@ func TestDoctor(t *testing.T) {
 		golden.Equal(t, "doctor/dry_run_prune_images_traces_dind_exec", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_rollback_traces_helm_rollback", func(t *testing.T) {
+		// Exercises the deploy-recovery action: --rollback --dry-run must
+		// trace the `helm rollback <release> --namespace --kube-context
+		// --wait --timeout` command for the runtime release, without
+		// mutating the cluster.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"doctor", "team", "dev", "--dry-run", "--rollback"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "doctor/dry_run_rollback_traces_helm_rollback", normalize.Apply(result.Combined))
+	})
+
+	t.Run("dry_run_clear_pending_helm_traces_kubectl_delete", func(t *testing.T) {
+		// Exercises the deploy-recovery action: --clear-pending-helm
+		// --dry-run must trace the `kubectl delete secrets,configmaps -l
+		// owner=helm,...,status in (pending-install,...)` command that
+		// clears the stuck helm pending-operation lock.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"doctor", "team", "dev", "--dry-run", "--clear-pending-helm"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "doctor/dry_run_clear_pending_helm_traces_kubectl_delete", normalize.Apply(result.Combined))
+	})
+
 	t.Run("in_runtime_complete_marker_dry_run", func(t *testing.T) {
 		// When the runtime env reports ERUN_REPO_REMOTE=true and the
 		// bootstrap marker shows the previous init finished, doctor

--- a/erun-integration/testdata/doctor/conflicting_recovery_flags_error.txt
+++ b/erun-integration/testdata/doctor/conflicting_recovery_flags_error.txt
@@ -1,0 +1,2 @@
+audit: erun doctor --clear-pending-helm --dry-run --rollback team dev
+--clear-pending-helm and --rollback are alternative recoveries; pass only one

--- a/erun-integration/testdata/doctor/dry_run_clear_pending_helm_traces_kubectl_delete.txt
+++ b/erun-integration/testdata/doctor/dry_run_clear_pending_helm_traces_kubectl_delete.txt
@@ -1,0 +1,17 @@
+Target: team/dev
+Running: Clear pending helm release
+No cleanup actions selected.
+audit: erun doctor --clear-pending-helm --dry-run team dev
+helm status team-devops --namespace team-dev --kube-context test-context
+kubectl --context test-context --namespace team-dev get pods -o wide
+kubectl --v=4 --context test-context --namespace team-dev delete 'secrets,configmaps' -l 'owner=helm,name=team-devops,status in (pending-install,pending-upgrade,pending-rollback)' --ignore-not-found
+kubectl --context test-context --namespace team-dev wait --for=condition=Available --timeout 2m0s deployment/team-devops
+kubectl --context test-context --namespace team-dev exec -c erun-dind deployment/team-devops -- /bin/sh -lc '<remote-script>'
+doctor-inspect:
+  set -eu
+  printf '== Disk usage (/var/lib/docker) ==\n'
+  df -h /var/lib/docker
+  printf '\n== Inode usage (/var/lib/docker) ==\n'
+  df -i /var/lib/docker
+  printf '\n== Docker system df ==\n'
+  docker system df

--- a/erun-integration/testdata/doctor/dry_run_rollback_traces_helm_rollback.txt
+++ b/erun-integration/testdata/doctor/dry_run_rollback_traces_helm_rollback.txt
@@ -1,0 +1,17 @@
+Target: team/dev
+Running: Roll back to the last successful revision
+No cleanup actions selected.
+audit: erun doctor --dry-run --rollback team dev
+helm status team-devops --namespace team-dev --kube-context test-context
+kubectl --context test-context --namespace team-dev get pods -o wide
+helm rollback team-devops --namespace team-dev --kube-context test-context --wait --timeout 2m0s
+kubectl --context test-context --namespace team-dev wait --for=condition=Available --timeout 2m0s deployment/team-devops
+kubectl --context test-context --namespace team-dev exec -c erun-dind deployment/team-devops -- /bin/sh -lc '<remote-script>'
+doctor-inspect:
+  set -eu
+  printf '== Disk usage (/var/lib/docker) ==\n'
+  df -h /var/lib/docker
+  printf '\n== Inode usage (/var/lib/docker) ==\n'
+  df -i /var/lib/docker
+  printf '\n== Docker system df ==\n'
+  docker system df

--- a/erun-integration/testdata/doctor/help.txt
+++ b/erun-integration/testdata/doctor/help.txt
@@ -1,6 +1,6 @@
 Diagnose and repair an environment's runtime and config.
 
-Reports why a deploy may have failed (helm release status and the runtime pods, read-only). When the release looks unhealthy it offers recovery: clear a stuck pending helm release, or roll back to the last successful revision. It also prunes Docker images, build cache, or stopped containers; restores or fixes the root erun config; and finishes an interrupted remote init. Recovery and rollback mutate the live release; each action prompts before running unless you pass its matching flag.
+Reports why a deploy may have failed (helm release status and the runtime pods, read-only). When the release looks unhealthy it recommends the one recovery that fits — clear a stuck pending helm release, or roll back to the last successful revision — and prompts before running it. It also prunes Docker images, build cache, or stopped containers; restores or fixes the root erun config; and finishes an interrupted remote init. The recovery actions mutate the live release; run one directly with --clear-pending-helm or --rollback (the two are alternatives — pass only one).
 
 Usage:
   erun doctor [tenant] [environment] [flags]

--- a/erun-integration/testdata/doctor/help.txt
+++ b/erun-integration/testdata/doctor/help.txt
@@ -1,11 +1,12 @@
 Diagnose and repair an environment's runtime and config.
 
-Reports why a deploy may have failed (helm release status and the runtime pods), then offers repairs: prune its Docker images, build cache, or stopped containers; restore or fix the root erun config; and finish an interrupted remote init. The deploy diagnosis is read-only; each repair prompts before running unless you pass its matching flag.
+Reports why a deploy may have failed (helm release status and the runtime pods, read-only). When the release looks unhealthy it offers recovery: clear a stuck pending helm release, or roll back to the last successful revision. It also prunes Docker images, build cache, or stopped containers; restores or fixes the root erun config; and finishes an interrupted remote init. Recovery and rollback mutate the live release; each action prompts before running unless you pass its matching flag.
 
 Usage:
   erun doctor [tenant] [environment] [flags]
 
 Flags:
+      --clear-pending-helm                  Clear a stuck helm pending-install/upgrade lock for the runtime release without prompting
       --codecommit-ssh-key-id string        CodeCommit SSH public key ID to use when finishing an unfinished remote init for an AWS CodeCommit repository
       --dry-run                             Resolve and trace mutating actions without executing them.
       --finish-remote-init                  Finish unfinished remote init tasks without prompting (only takes effect when run inside a runtime pod)
@@ -17,6 +18,7 @@ Flags:
       --repair-config                       Inspect the root erun config and offer to restore from backup or re-init orphaned cloud provider aliases; stops before running tenant/env cleanup actions
       --repair-jetbrains-gateway            Clear cached JetBrains Gateway backend metadata for this environment
       --restore-config-from-backup string   Restore the root erun config from a dated backup non-interactively (YYYY-MM-DD or absolute path)
+      --rollback                            Roll the runtime release back to its last successful revision without prompting
 
 Global Flags:
       --time            Print the elapsed runtime after the command finishes.

--- a/erun-mcp/doctor.go
+++ b/erun-mcp/doctor.go
@@ -2,6 +2,7 @@ package erunmcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -65,6 +66,9 @@ func doctorTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReques
 }
 
 func runDoctorToolCommand(runtime RuntimeConfig, input DoctorInput, runCtx eruncommon.Context) (*DoctorRootConfigReport, error) {
+	if input.ClearPendingHelm && input.Rollback {
+		return nil, errors.New("clearPendingHelm and rollback are alternative recoveries; request only one")
+	}
 	report, fatal, err := runDoctorRootConfigToolFlow(runtime, input, runCtx)
 	if err != nil {
 		return report, err

--- a/erun-mcp/doctor.go
+++ b/erun-mcp/doctor.go
@@ -15,6 +15,8 @@ type DoctorInput struct {
 	PruneImages             bool                         `json:"pruneImages,omitempty" jsonschema:"when true, prune unused Docker images"`
 	PruneBuildCache         bool                         `json:"pruneBuildCache,omitempty" jsonschema:"when true, prune unused BuildKit cache"`
 	PruneContainers         bool                         `json:"pruneContainers,omitempty" jsonschema:"when true, prune stopped Docker containers"`
+	ClearPendingHelm        bool                         `json:"clearPendingHelm,omitempty" jsonschema:"when true, clear a stuck helm pending-install/upgrade lock for the runtime release so the next deploy can proceed"`
+	Rollback                bool                         `json:"rollback,omitempty" jsonschema:"when true, roll the runtime release back to its last successful revision (recovers a bad/non-converging deploy)"`
 	Preview                 bool                         `json:"preview,omitempty" jsonschema:"when true, resolve and print the planned actions without executing them"`
 	Verbosity               int                          `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
 	RestoreConfigFromBackup string                       `json:"restoreConfigFromBackup,omitempty" jsonschema:"YYYY-MM-DD or absolute path; when set, restore the root erun config from the matching daily backup before any tenant/env work"`
@@ -79,6 +81,9 @@ func runDoctorToolCommand(runtime RuntimeConfig, input DoctorInput, runCtx erunc
 	}
 	req := eruncommon.ShellLaunchParamsFromResult(target)
 	if err := writeDoctorDeployDiagnosis(runCtx, req); err != nil {
+		return report, err
+	}
+	if err := runDoctorRecoveryToolActions(runCtx, input, req); err != nil {
 		return report, err
 	}
 	if err := writeDoctorInspection(runCtx, target, req); err != nil {
@@ -256,6 +261,40 @@ func writeDoctorInspection(runCtx eruncommon.Context, target eruncommon.OpenResu
 		return err
 	}
 	return writeDoctorOutput(runCtx, inspection.Stdout, inspection.Stderr)
+}
+
+// runDoctorRecoveryToolActions runs the deploy-recovery actions the caller
+// requested (clear pending helm / rollback). Non-interactive: each runs only
+// when its input flag is set. Mutates the live release; traced for dry-run.
+func runDoctorRecoveryToolActions(runCtx eruncommon.Context, input DoctorInput, req eruncommon.ShellLaunchParams) error {
+	for _, action := range deployRecoveryActionsFromInput(input) {
+		if !runCtx.DryRun {
+			if _, err := fmt.Fprintf(runCtx.Stdout, "Running: %s\n", eruncommon.DeployRecoveryActionDescription(action)); err != nil {
+				return err
+			}
+		}
+		output, err := eruncommon.RunDeployRecovery(runCtx, req, action)
+		if err != nil {
+			return err
+		}
+		if !runCtx.DryRun {
+			if err := writeDoctorOutput(runCtx, output, ""); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func deployRecoveryActionsFromInput(input DoctorInput) []eruncommon.DeployRecoveryAction {
+	actions := make([]eruncommon.DeployRecoveryAction, 0, 2)
+	if input.ClearPendingHelm {
+		actions = append(actions, eruncommon.DeployRecoveryClearPendingHelm)
+	}
+	if input.Rollback {
+		actions = append(actions, eruncommon.DeployRecoveryRollback)
+	}
+	return actions
 }
 
 func runDoctorToolActions(runCtx eruncommon.Context, input DoctorInput, req eruncommon.ShellLaunchParams) error {

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -228,7 +228,7 @@ func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig) *mcp.Server {
 	}, deployTool(runtime))
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "doctor",
-		Description: "Diagnose and repair the resolved environment: report why a deploy may have failed (helm release status and runtime pods, read-only), prune unused Docker images, build cache, or stopped containers, and optionally restore or repair the root erun config from a backup or by re-initializing orphaned cloud provider aliases",
+		Description: "Diagnose and repair the resolved environment: report why a deploy may have failed (helm release status and runtime pods, read-only); recover a failing runtime release by clearing a stuck pending helm lock or rolling back to the last successful revision; prune unused Docker images, build cache, or stopped containers; and optionally restore or repair the root erun config from a backup or by re-initializing orphaned cloud provider aliases",
 	}, doctorTool(runtime))
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "delete",

--- a/erun-ui/activity_queue.go
+++ b/erun-ui/activity_queue.go
@@ -239,6 +239,27 @@ func (s *activityQueueStore) findRunning(tenant, environment string) (activityQu
 	return activityQueueEntry{}, false
 }
 
+// latestDeployFailed reports whether the most recent deploy for the env ended
+// in failure. It looks at the newest deploy entry across active + history (the
+// snapshot is sorted newest-first): if that entry is failed, the env's runtime
+// release is currently broken. A later succeeded/running deploy — e.g. after
+// the user recovers via doctor or Rebuild & redeploy — flips this back to
+// false. Reconnect uses it to stop hammering a broken env with `erun open`
+// retries whose pod will never come ready (MCP port-forward timeout, SSH sync
+// not-ready), independent of whether this particular open emitted the
+// `==> Deploy failed` ready-error that reconnectBlockedByDeployFailure keys on.
+func (s *activityQueueStore) latestDeployFailed(tenant, environment string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, entry := range s.snapshotLocked() {
+		if entry.Command != "deploy" || entry.Tenant != tenant || entry.Environment != environment {
+			continue
+		}
+		return entry.Status == activityQueueStatusFailed
+	}
+	return false
+}
+
 // promoteToRunning moves a waiting entry into the running state and
 // records StartedRunningAt. Returns the snapshot and true when the
 // entry existed and was waiting; false when missing or already running

--- a/erun-ui/activity_queue_test.go
+++ b/erun-ui/activity_queue_test.go
@@ -52,6 +52,44 @@ func TestDeployQueueDuplicateStartsReturnExisting(t *testing.T) {
 	}
 }
 
+func TestLatestDeployFailed(t *testing.T) {
+	store := newTestActivityQueueStore(t)
+	base := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+
+	if store.latestDeployFailed("petios", "rihards-develop") {
+		t.Fatal("no deploy recorded: want false")
+	}
+
+	failed, _ := store.start(activityQueueEntry{ID: "d1", Command: "deploy", Tenant: "petios", Environment: "rihards-develop", StartedAt: base})
+	if _, ok := store.finish(failed.ID, activityQueueStatusFailed, "helm release failed"); !ok {
+		t.Fatal("finish failed deploy returned ok=false")
+	}
+	if !store.latestDeployFailed("petios", "rihards-develop") {
+		t.Fatal("latest deploy failed: want true")
+	}
+
+	// A newer non-deploy activity (an open retry) must not flip the verdict —
+	// the env's latest *deploy* is still the failed one.
+	store.start(activityQueueEntry{ID: "o1", Command: "open", Tenant: "petios", Environment: "rihards-develop", StartedAt: base.Add(time.Minute)})
+	if !store.latestDeployFailed("petios", "rihards-develop") {
+		t.Fatal("newer non-deploy activity must be ignored: want true")
+	}
+
+	// A different env is unaffected.
+	if store.latestDeployFailed("petios", "other") {
+		t.Fatal("different env: want false")
+	}
+
+	// A newer deploy that succeeded (recovery) clears it.
+	recovered, _ := store.start(activityQueueEntry{ID: "d2", Command: "deploy", Tenant: "petios", Environment: "rihards-develop", StartedAt: base.Add(2 * time.Minute)})
+	if _, ok := store.finish(recovered.ID, activityQueueStatusSucceeded, ""); !ok {
+		t.Fatal("finish recovered deploy returned ok=false")
+	}
+	if store.latestDeployFailed("petios", "rihards-develop") {
+		t.Fatal("newer succeeded deploy: want false")
+	}
+}
+
 func TestDeployQueueFinishMovesToHistory(t *testing.T) {
 	store := newTestActivityQueueStore(t)
 	entry, _ := store.start(activityQueueEntry{Tenant: "t", Environment: "e", Version: "1", Release: "t-devops"})

--- a/erun-ui/frontend/src/app/selectors.ts
+++ b/erun-ui/frontend/src/app/selectors.ts
@@ -33,6 +33,26 @@ export const selectSelectedIsPendingFor = (
   return !selectEnvironmentExists(state, tenant, environment);
 };
 
+// selectEnvHasFailedDeploy reports whether the env currently has a failed
+// deploy in the activity queue. Reopening a dead default tab (ai/local/erun)
+// re-runs `erun open`, which re-deploys; doing that for an env whose deploy
+// just failed re-fails the same way (and, across tabs, storms parallel
+// re-deploys). The click-driven respawn uses this to refuse — the same
+// terminal-state #447 stops for auto-reconnect (reconnectBlockedByDeployFailure)
+// — leaving recovery to the explicit failed-deploy card actions.
+export const selectEnvHasFailedDeploy = (
+  state: RootState,
+  tenant: string,
+  environment: string,
+): boolean =>
+  state.activity.entries.some(
+    (entry) =>
+      entry.command === 'deploy' &&
+      entry.status === 'failed' &&
+      entry.tenant === tenant &&
+      entry.environment === environment,
+  );
+
 export const selectActiveSlotForSelection = (state: RootState, selection: UISelection): number => {
   const tabs = state.terminal.tabsByEnv[selectionKey(selection)] ?? [];
   const first = tabs[0];

--- a/erun-ui/frontend/src/app/tabRespawnThunks.ts
+++ b/erun-ui/frontend/src/app/tabRespawnThunks.ts
@@ -4,6 +4,7 @@ import { StartAISession, StartLocalSession, StartSession } from '../../wailsjs/g
 import { syncDebugDisplay } from './debugThunks';
 import { readError } from './errors';
 import { hideTerminalMessage, showTerminalMessage } from './notificationThunks';
+import { selectEnvHasFailedDeploy } from './selectors';
 import { registerDebugSession, trackOpenSession } from './slices/sessionsSlice';
 import { setSelectedSessionForEnv, setSessionId } from './slices/terminalSlice';
 import { setTerminalCopyOutput, setTerminalCopyStatus } from './slices/terminalStatusSlice';
@@ -46,6 +47,15 @@ export const maybeRespawnDeadDefaultTab =
     const key = selectionKey(runSelection);
     const tab = state.terminal.tabsByEnv[key]?.find((t) => t.sessionId === sessionId);
     if (!tab || !respawnableDefaultKinds.has(tab.kind)) {
+      return false;
+    }
+    // Refuse the respawn when the env's deploy failed: reopening would re-run
+    // `erun open` and re-deploy the broken env, the same re-deploy storm #447
+    // stops for auto-reconnect. Returning false lets selectTerminalTab show the
+    // dead session's captured failure output and the deploy-failed marker
+    // instead, with recovery left to the failed-deploy card (Run doctor /
+    // Rebuild & redeploy).
+    if (selectEnvHasFailedDeploy(state, selection.tenant, selection.environment)) {
       return false;
     }
     if (sessionId !== state.terminal.sessionId) {

--- a/erun-ui/playwright/tests/respawn-deploy-failed-no-redeploy.spec.ts
+++ b/erun-ui/playwright/tests/respawn-deploy-failed-no-redeploy.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '../fixtures/erunApp.js';
+
+// Coverage for the deploy-failed respawn guard (feature/449 follow-up).
+//
+// maybeRespawnDeadDefaultTab now refuses to respawn a dead default tab
+// (ai/local/erun) when the env has a failed deploy in the activity queue
+// (selectEnvHasFailedDeploy). Reopening such a tab would re-run `erun open`
+// and re-deploy the broken env — the same re-deploy storm #447 already stops
+// for auto-reconnect (reconnectBlockedByDeployFailure). With the guard, the
+// click instead falls through to selectTerminalTab's dead-tab display: the
+// captured failure output and the "── deploy failed — not retrying
+// automatically … ──" marker, with recovery left to the failed-deploy card
+// (Run doctor / Rebuild & redeploy).
+//
+// The positive path — a dead PTY *and* a `status: failed` deploy activity
+// entry for the same env — cannot be staged deterministically in the headless
+// harness: it reflects the developer's real ~/.erun/ and has no cluster to
+// drive a failing deploy, so neither the exited managed terminal (see the
+// bug/368 note in sidebar-reclick-no-duplicate-tabs.spec.ts) nor the failed
+// activity entry can be arranged here. The guard itself is a pure selector
+// over state.activity.entries (selectEnvHasFailedDeploy in app/selectors.ts).
+//
+// What this spec locks is the reachable negative invariant: a healthy env
+// (no failed deploy — the headless default) must NOT surface the deploy-failed
+// marker and must open its default tabs normally, proving the new guard does
+// not misfire on the common path and block healthy envs from opening.
+test.describe('deploy-failed respawn guard', () => {
+  test('healthy env opens normally and shows no deploy-failed marker', async ({ app, page }) => {
+    const tenants = await app.sidebar.tenants();
+    expect(tenants.length).toBeGreaterThan(0);
+    const tenant = tenants[0]!;
+    const envs = await app.sidebar.environmentsFor(tenant);
+    expect(envs.length).toBeGreaterThan(0);
+    const env = envs[0]!;
+
+    await app.sidebar.openEnvironment(tenant, env);
+
+    // Local is spawned eagerly by openSelection, so it is the most reliable
+    // signal that the open settled (same precondition as the sibling specs).
+    const localTab = page.getByRole('tab', { name: 'Local', exact: true });
+    await localTab.waitFor({ state: 'visible', timeout: 15_000 });
+
+    // The guard is inactive for a healthy env: the open settles (Local is
+    // present) and the deploy-failed marker never appears. If
+    // selectEnvHasFailedDeploy misfired on a healthy env, the open/respawn
+    // flow would surface the "── deploy failed — not retrying automatically …"
+    // marker. (AI/ERun tab presence is not asserted: those depend on a
+    // reachable runtime the headless harness has no cluster for — see the
+    // bug/368 note in sidebar-reclick-no-duplicate-tabs.spec.ts.)
+    await expect(page.getByText(/deploy failed — not retrying automatically/i)).toBeHidden();
+  });
+});

--- a/erun-ui/reconnect_loop_test.go
+++ b/erun-ui/reconnect_loop_test.go
@@ -409,6 +409,43 @@ func TestTryReconnectRefusesAfterDeployFailure(t *testing.T) {
 	}
 }
 
+// TestTryReconnectRefusesWhenActivityDeployFailed covers the case the readyErr
+// guard misses: the deploy failed in a *separate* activity and this open exits
+// with an MCP port-forward timeout / pod-not-ready (no `==> Deploy failed`
+// readyErr) while trying to reach the never-ready pod. tryReconnect must still
+// refuse, consulting the activity queue, so the env stops hammering itself.
+func TestTryReconnectRefusesWhenActivityDeployFailed(t *testing.T) {
+	emits := newCapturedEmits()
+	app := &App{}
+	app.SetEmitter(emits.fn())
+	app.activityQueue = newActivityQueueStore(nil, nil)
+	failed, _ := app.activityQueue.start(activityQueueEntry{Command: "deploy", Tenant: "petios", Environment: "rihards-develop"})
+	if _, ok := app.activityQueue.finish(failed.ID, activityQueueStatusFailed, "helm release failed"); !ok {
+		t.Fatal("seed: finish failed deploy returned ok=false")
+	}
+
+	respawned := false
+	managed := &managedTerminal{
+		serial:      9,
+		selection:   uiSelection{Tenant: "petios", Environment: "rihards-develop"},
+		readyClosed: false, // no deploy-failed readyErr — this open timed out reaching the pod
+		respawn: func() (terminalSession, error) {
+			respawned = true
+			return newStubTerminalSession(), nil
+		},
+	}
+
+	if app.tryReconnect(managed, "timed out waiting for MCP port-forward") {
+		t.Fatal("tryReconnect must refuse when the env's latest deploy failed")
+	}
+	if respawned {
+		t.Fatal("respawn must not run when the env's latest deploy failed")
+	}
+	if !sawDeployFailedMarker(emits) {
+		t.Fatal("expected the deploy-failed marker on the terminal-output channel")
+	}
+}
+
 // TestTryReconnectAfterHealthyDropRespawns is the counterpart: a session that
 // reached a healthy ready (readyErr == nil) and then dropped is a transient
 // drop and must still reconnect. Its `erun open` finds the deploy already

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -1011,6 +1011,19 @@ func (a *App) tryReconnect(managed *managedTerminal, exitReason string) bool {
 		return false
 	}
 
+	// The readyErr guard above only catches an open that emitted the
+	// `==> Deploy failed` trace. When the deploy failed in a *separate*
+	// activity and this open is just trying to reach the resulting (never
+	// ready) pod, it exits with an MCP port-forward timeout / "pod not ready
+	// while syncing SSH" instead — no deploy-failed readyErr — and would loop
+	// here forever (each respawn re-runs `erun open`, re-times-out, and stacks
+	// another queued open). Consult the activity queue: if the env's latest
+	// deploy failed, refuse for the same reason and leave recovery to the user.
+	if a.reconnectBlockedByActivityDeployFailure(managed) {
+		a.emitDeployFailedMarker(managed.serial)
+		return false
+	}
+
 	// Cap consecutive fast-exit respawns. Without this, an env whose
 	// underlying cluster keeps tearing down the freshly-spawned pod
 	// (helm rollout timeouts, MCP port-forward races against a
@@ -1203,6 +1216,20 @@ func (a *App) reconnectBlockedByDeployFailure(managed *managedTerminal) bool {
 	managed.readyMu.Lock()
 	defer managed.readyMu.Unlock()
 	return managed.readyClosed && managed.readyErr != nil
+}
+
+// reconnectBlockedByActivityDeployFailure reports whether the managed PTY's env
+// has a failed deploy recorded in the activity queue. Unlike
+// reconnectBlockedByDeployFailure (which keys on this open's own
+// `==> Deploy failed` readyErr), this catches the case where the deploy failed
+// in a separate activity and the current open merely can't reach the resulting
+// pod — so reconnect still stops hammering the broken env. Cleared once a later
+// deploy succeeds (recovery), letting reconnect resume.
+func (a *App) reconnectBlockedByActivityDeployFailure(managed *managedTerminal) bool {
+	if managed == nil || a.activityQueue == nil {
+		return false
+	}
+	return a.activityQueue.latestDeployFailed(managed.selection.Tenant, managed.selection.Environment)
 }
 
 // emitStoppedContextMarker writes a single diagnostic line when

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -1141,7 +1141,7 @@ const (
 	reconnectLoopWindow    = 30 * time.Second
 	reconnectLoopMaxExits  = 2
 	reconnectLoopMarkerANSI = "\r\n\x1b[2;33m── stopped reconnecting after repeated failures — click the environment in the sidebar to retry ──\x1b[0m\r\n"
-	deployFailedMarkerANSI  = "\r\n\x1b[2;33m── deploy failed — not retrying automatically; use Run doctor or Rebuild & redeploy on the failed deploy, or click the environment to retry ──\x1b[0m\r\n"
+	deployFailedMarkerANSI  = "\r\n\x1b[2;33m── deploy failed — not retrying automatically; use Run doctor or Rebuild & redeploy on the failed deploy, or click the environment in the sidebar to retry ──\x1b[0m\r\n"
 )
 
 // trackExitForLoopGuard records the moment the managed PTY exited


### PR DESCRIPTION
This PR covers the failed-deploy recovery surface end to end: the `erun doctor` recovery actions, the single-recommendation fix for them, and the desktop fixes that stop a deploy-failed env from re-deploying itself on reopen/reconnect.

## 1 · doctor deploy-recovery actions

When a deploy fails, the runtime release can be left in a state the next `erun deploy` can't recover from: a deploy that died mid-upgrade leaves the helm release **locked in `pending-*`**; a **bad/non-converging revision** needs a rollback. `erun doctor` diagnosed these (helm status + pods, read-only) but offered no fix.

`erun doctor` now **recommends the single recovery that fits the diagnosis** and runs it (each mutates the live release):

| helm status | Recommended | Flag / MCP input | Command |
|---|---|---|---|
| `pending-install` / `pending-upgrade` / `pending-rollback` | Clear pending helm | `--clear-pending-helm` / `clearPendingHelm` | `kubectl delete secrets,configmaps -l 'owner=helm,name=<release>,status in (pending-*)' --ignore-not-found` |
| present but unhealthy (`failed`, `superseded`, …) | Roll back | `--rollback` / `rollback` | `helm rollback <release> --wait` |
| healthy (`status: deployed`), missing (`not found`), unreadable | nothing destructive | — | — |

Gating: run non-interactively with the flag; with no flag, prompt for the **single recommended** action only (never both, never on a healthy env); `--dry-run` traces the exact command and runs nothing.

## 2 · The two recoveries are alternatives, not additive

Clearing a pending lock and rolling back fix **different** failure modes. Running both is wrong: clearing pending leaves the release at its last deployed revision, so a rollback straight after steps it back a *further* revision. So the interactive path recommends/prompts **one** action, and `--clear-pending-helm` / `--rollback` (and the MCP inputs) are **mutually exclusive** — passing both aborts with `… are alternative recoveries; pass only one`. (Fixes the reported "why is doctor asking me to clear pending **and** roll back, and running both?")

### Scope note: "force rebuild & redeploy"

The third action from the issue is the existing `erun deploy --force`, already the one-click button on the desktop failed-deploy card (#446). `doctor` points at it rather than duplicating the deploy command.

## 3 · Desktop: a deploy-failed env stops re-deploying itself

A failed deploy leaves the pod never-ready, so every `erun open` against the env fails — and the desktop kept re-running it two ways, neither caught by the #447 readyErr guard:

- **Click-driven respawn** (`maybeRespawnDeadDefaultTab`): reopening a dead ai/local/erun tab re-ran `erun open` and re-deployed. Now guarded by `selectEnvHasFailedDeploy` (frontend) — the click falls through to the dead session's captured-failure display + deploy-failed marker instead of respawning.
- **Automatic reconnect** (`tryReconnect`): when the open exits with an MCP port-forward timeout / "pod not ready while syncing SSH" (no `==> Deploy failed` readyErr), reconnect looped and the activity queue filled with stacked OPEN/AI entries. Now guarded by `activityQueueStore.latestDeployFailed` — reconnect refuses (emits the deploy-failed marker) when the env's most recent deploy failed.

Both clear automatically once a later deploy succeeds (recovery via doctor / Rebuild & redeploy). Recovery stays explicit: the failed-deploy card actions or a deliberate sidebar re-click; the marker text is clarified to "click the environment **in the sidebar** to retry".

## Validation

- `make integration-test` green — coverage **57.5% ≥ 55%**. Dry-run scenarios lock the `helm rollback`, `kubectl delete` pending-selector, and conflicting-flags traces; doctor help golden updated.
- `RecommendedDeployRecovery` covered by an `erun-common` unit test (pure classifier, unreachable from dry-run).
- `go build ./... && go test ./...` green in `erun-common`, `erun-cli`, `erun-mcp`, `erun-ui` — incl. new `TestLatestDeployFailed` and `TestTryReconnectRefusesWhenActivityDeployFailed`.
- Frontend: `yarn typecheck && yarn lint && yarn format:check && yarn build` clean.
- Playwright: new `respawn-deploy-failed-no-redeploy.spec.ts` passes (reachable negative invariant); sibling `sidebar-reclick-no-duplicate-tabs.spec.ts` still green.
- `cd erun-docs && yarn build` clean.

### Test-reachability notes (honest limits)

- The **destructive helm mutation** against a live failing release (`helm rollback` / `kubectl delete`) was not driven end-to-end: no failing remote env is reachable from this environment. Covered by the dry-run goldens (exact commands) + the classifier unit test.
- The **desktop loop fixes**: the click-respawn guard's positive path (dead PTY + `status: failed` entry) is unstageable in the headless Playwright harness (no cluster) — negative invariant locked + limitation documented, same as bug/368. The auto-reconnect guard is a pure-Go change covered directly by Go unit tests; its marker channel/trigger are likewise unstageable headless.

### Docs

`cli/doctor.md`, `agent-reference/cli-flags.md` (Deploy recovery actions catalogue + mutual exclusivity), `mcp/overview.md` updated.

Closes #449