### PR TITLE
Let the env Cloud alias dropdown be cleared via "— None —"

### DIFF
--- a/erun-ui/frontend/src/components/app/ManageDialogGeneralTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogGeneralTab.tsx
@@ -19,6 +19,11 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import type { UICloudContextStatus } from '@/types';
 
+// Sentinel for the clear ("— None —") option in the cloud-alias dropdown.
+// Radix Select rejects an empty-string item value, so the option carries this
+// value and CloudAliasSelect maps it back to "" before persisting.
+const CLOUD_ALIAS_NONE_VALUE = '__none__';
+
 export function GeneralTab(): React.ReactElement {
   const dispatch = useAppDispatch();
   const dialog = useAppSelector((state) => state.manageDialog);
@@ -149,16 +154,27 @@ function CloudAliasSelect({
       </div>
     );
   }
+  // Radix Select forbids an empty-string item value, so the clear option uses
+  // a sentinel that maps back to "" on change. This gives the user a way out
+  // of a selected alias — without it the dropdown only ever offered aliases
+  // and a set value could never be cleared (issue #211). "" resolves to the
+  // placeholder, which renders the env as "Not linked" downstream.
+  const optionItems = [
+    { value: CLOUD_ALIAS_NONE_VALUE, label: '— None —' },
+    ...selectOptions.map((option) => ({ value: option, label: option })),
+  ];
   return (
     <SelectField
       id={id}
       label="Cloud alias"
       value={normalizedValue}
-      options={selectOptions.map((option) => ({ value: option, label: option }))}
+      options={optionItems}
       placeholder="Select cloud alias"
       emptyLabel="No cloud aliases configured"
       disabled={disabled}
-      onChange={onChange}
+      onChange={(next) => {
+        onChange(next === CLOUD_ALIAS_NONE_VALUE ? '' : next);
+      }}
     />
   );
 }

--- a/erun-ui/playwright/pages/ManageDialog.ts
+++ b/erun-ui/playwright/pages/ManageDialog.ts
@@ -126,4 +126,37 @@ export class ManageDialog {
     // so it is queried at the document root rather than inside the dialog.
     await this.page.getByRole('option', { name: mode }).click();
   }
+
+  // cloudAliasSelect targets the "Cloud alias" SelectField on the General tab.
+  // It only renders when the tenant has at least one cloud alias configured;
+  // otherwise an EmptyState renders instead, so specs check visibility first.
+  cloudAliasSelect(): Locator {
+    return this.locator().locator('#environment-config-cloudprovideralias');
+  }
+
+  async cloudAliasSelectVisible(): Promise<boolean> {
+    return this.cloudAliasSelect()
+      .isVisible()
+      .catch(() => false);
+  }
+
+  async cloudAliasSelectedValue(): Promise<string> {
+    return (await this.cloudAliasSelect().textContent())?.trim() ?? '';
+  }
+
+  async openCloudAliasOptions(): Promise<void> {
+    await this.cloudAliasSelect().click();
+  }
+
+  // cloudAliasNoneOption targets the "— None —" clear entry (issue #211). The
+  // Radix listbox is portal'd to the document body, so it is queried at the
+  // page root rather than inside the dialog.
+  cloudAliasNoneOption(): Locator {
+    return this.page.getByRole('option', { name: '— None —' });
+  }
+
+  async chooseCloudAliasNone(): Promise<void> {
+    await this.openCloudAliasOptions();
+    await this.cloudAliasNoneOption().click();
+  }
 }

--- a/erun-ui/playwright/pages/Sidebar.ts
+++ b/erun-ui/playwright/pages/Sidebar.ts
@@ -62,6 +62,16 @@ export class Sidebar {
     await this.environmentRow(tenant, env).click();
   }
 
+  // openManageDialogViaKeyboard activates the row's edit button with the
+  // keyboard instead of the mouse. The button is pointer-events-none until the
+  // row is hovered/selected/focused; focusing flips group-focus-within so it
+  // becomes interactive, and Enter fires the handler without a hover (a hover
+  // opens the row's IconTooltip, whose popper intercepts a mouse click). Works
+  // regardless of whether the env is the effective selection.
+  async openManageDialogViaKeyboard(tenant: string, env: string): Promise<void> {
+    await this.environmentRow(tenant, env).press('Enter');
+  }
+
   // envRowButton targets the clickable env-row button (the one whose
   // aria-label is "<tenant> / <env>" plus an optional "(local)" suffix).
   // Distinct from environmentRow(), which targets the row's edit button.

--- a/erun-ui/playwright/tests/manage-cloud-alias-clear.spec.ts
+++ b/erun-ui/playwright/tests/manage-cloud-alias-clear.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '../fixtures/erunApp.js';
+
+// Regression: issue #211 — the env Manage dialog's Cloud alias dropdown had no
+// way to clear a selection once set; it only offered configured aliases. The
+// fix always adds a selectable "— None —" entry whenever at least one alias is
+// configured, mapping to an empty cloudProviderAlias (env renders "Not
+// linked"). Verified here without saving, so the dev's config is untouched.
+//
+// Harness note: the Cloud alias select only renders when the tenant has at
+// least one cloud alias configured; otherwise an EmptyState renders. The
+// headless backend reflects the dev's real ~/.erun, so the spec skips with
+// justification when no tenant/env exposes the select. (Issue #442 will make
+// this deterministic against a fixture HOME.)
+test.describe('manage dialog cloud alias clear', () => {
+  test('a configured cloud alias can be cleared via "— None —"', async ({ app }) => {
+    const tenants = await app.sidebar.tenants();
+    test.skip(tenants.length === 0, 'no tenants in this developer harness');
+
+    const located = await openFirstEnvWithCloudAliasSelect(app);
+    test.skip(located === null, 'no env with a cloud alias select in this harness');
+
+    // The clear option is always offered when aliases exist.
+    await app.manageDialog.openCloudAliasOptions();
+    await expect(app.manageDialog.cloudAliasNoneOption()).toBeVisible();
+
+    // Selecting it clears the draft value back to the placeholder, the
+    // observable signal that cloudProviderAlias became empty. Cancel without
+    // saving so the dev's persisted config is not mutated.
+    await app.manageDialog.cloudAliasNoneOption().click();
+    await expect.poll(() => app.manageDialog.cloudAliasSelectedValue()).toBe('Select cloud alias');
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+});
+
+// openFirstEnvWithCloudAliasSelect walks the first tenant's envs, opening each
+// Manage dialog until it finds one whose General tab renders the cloud-alias
+// select. Returns the env name, or null when none qualifies (caller skips).
+async function openFirstEnvWithCloudAliasSelect(
+  app: import('../pages/index.js').AppShell,
+): Promise<string | null> {
+  const tenants = await app.sidebar.tenants();
+  const tenant = tenants[0]!;
+  const envs = await app.sidebar.environmentsFor(tenant);
+  for (const env of envs) {
+    // The row's edit button is pointer-events-none/opacity-0 until the row is
+    // hovered, selected, or focused. Activate it via the keyboard: focusing
+    // flips group-focus-within → interactive, and Enter fires the handler
+    // without depending on the env being the effective selection and without
+    // a hover (which would open the row tooltip and intercept a mouse click).
+    await app.sidebar.openManageDialogViaKeyboard(tenant, env);
+    await app.manageDialog.waitForOpen();
+    if (await app.manageDialog.cloudAliasSelectVisible()) {
+      return env;
+    }
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #211

## Problem
The env Manage dialog's **Cloud alias** dropdown (`CloudAliasSelect`) only offered the configured aliases. Once an alias was selected there was no path back to empty — the user was stuck with whatever was chosen.

## Fix
Always include a selectable **"— None —"** entry whenever at least one alias is configured. Radix `Select` forbids an empty-string item value, so the option carries a sentinel (`__none__`) that `CloudAliasSelect` maps back to `""` before persisting. An empty `cloudProviderAlias` renders the env as **"Not linked"** downstream. The Go-side `SaveEnvironmentConfig` already trims and accepts empty, so no backend change was needed.

## Validation
- `erun-ui/frontend`: `yarn typecheck && yarn lint && yarn format:check && yarn build` clean.
- `erun-ui`: `go test ./...` green (no Go change).
- **Playwright**: new `tests/manage-cloud-alias-clear.spec.ts` asserts the "— None —" option is offered and that selecting it clears the value to the placeholder.
- **End-to-end verified**: ran the spec against a hermetic fixture HOME (a `local-agent` env with `cloudprovideralias` set) on a manually-started `erun-app --headless` — the select renders, "— None —" appears, and selecting it clears the alias. Watched the originally-broken flow succeed.
- Against the dev's real `~/.erun` the spec **skips with justification** (no cloud aliases configured; first tenant is `erun`) — the exact #442 unstageable condition. It becomes a real run once #442 lands a fixture HOME.
- Added `Sidebar.openManageDialogViaKeyboard` (keyboard activation) so the dialog opens without a hover that would let the row's IconTooltip popper intercept the click — reusable for #442.

## UX Impact Review Checklist (erun-ui)
1. **Affected path:** Manage dialog → General tab → Cloud alias select → `SaveEnvironmentConfig`.
2. **Sequence:** open dropdown → pick "— None —" → trigger shows "Select cloud alias" placeholder → Save persists empty alias → Cloud context shows "Not linked".
3. **State/affordance:** the `cloudProviderAlias` mutation maps to a visible placeholder + "Not linked" context; no hidden mutations.
4. **Visibility of system status (#1):** the cleared state is visible (placeholder + Not linked).
5. **Success/failure feedback:** existing Save flow unchanged.
6. **Consistency (#4):** matches other clearable selects; "— None —" is a familiar clear affordance.
7. **Heuristic pass:** #3 user control & freedom — users can now undo a selection (the gap this fixes); others unaffected.
8. **Playwright coverage:** `tests/manage-cloud-alias-clear.spec.ts`.

## Docs
No `erun-docs` change — bug fix restoring expected control behaviour; no new feature, flag, or contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)