### PR TITLE
Make AI-tab Claude restore explicit and per-cwd (works on local-agent)

### DIFF
--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -3289,8 +3289,12 @@ func TestStartAISessionRunsErunOpenWithClaudeInitialInput(t *testing.T) {
 	if strings.Join(started.Args, "\n") != strings.Join(wantArgs, "\n") {
 		t.Fatalf("unexpected args: got %+v want %+v", started.Args, wantArgs)
 	}
-	if string(started.InitialInput) != defaultAITool+"\n" {
-		t.Fatalf("expected initial input %q, got %q", defaultAITool+"\n", string(started.InitialInput))
+	// The env AI tab pipes the cwd-guarded Claude resume so it continues the
+	// env project's Claude Code session rather than starting fresh (issue
+	// #451). The guard runs in the env repo cwd inside `erun open`.
+	wantInput := claudeContinueGuard + "\n"
+	if string(started.InitialInput) != wantInput {
+		t.Fatalf("expected initial input %q, got %q", wantInput, string(started.InitialInput))
 	}
 }
 

--- a/erun-ui/contribute_app_test.go
+++ b/erun-ui/contribute_app_test.go
@@ -273,3 +273,51 @@ func TestAdoptRefusesAfterStop(t *testing.T) {
 		t.Fatalf("adopt should return false after stop()")
 	}
 }
+
+// TestBuildContributePreludeCommandResumesCloneSession asserts the contribute
+// AI tab pipes the cwd-guarded Claude resume after cd'ing to the clone, so it
+// continues the $HOME/git/erun session rather than starting fresh — the
+// local-agent gap in issue #451. The non-AI variant pipes no AI launch.
+func TestBuildContributePreludeCommandResumesCloneSession(t *testing.T) {
+	withAI := buildContributePreludeCommand(true, "")
+	if !strings.Contains(withAI, `cd "$HOME/git/erun"`) {
+		t.Fatalf("prelude must cd to the clone before launching the AI tool, got %q", withAI)
+	}
+	if !strings.HasSuffix(withAI, claudeContinueGuard+"\n") {
+		t.Fatalf("contribute AI prelude must end with the cwd-guarded claude resume, got %q", withAI)
+	}
+
+	// A non-claude tool launches verbatim (no resume injection), mirroring the
+	// wrapper's bypass rules.
+	codex := buildContributePreludeCommand(true, "codex")
+	if !strings.HasSuffix(codex, "codex\n") {
+		t.Fatalf("configured non-claude tool must launch verbatim, got %q", codex)
+	}
+	if strings.Contains(codex, "--continue") {
+		t.Fatalf("non-claude tool must not carry a claude resume, got %q", codex)
+	}
+
+	noAI := buildContributePreludeCommand(false, "")
+	if strings.Contains(noAI, "claude") {
+		t.Fatalf("non-AI contribute prelude must not launch an AI tool, got %q", noAI)
+	}
+}
+
+// TestAILaunchCommandGuardsClaudeOnly documents the bypass rules the desktop
+// shares with claude-wrapper.sh: a bare claude launch is wrapped in the
+// cwd-guarded resume; an explicit-flag claude invocation or a different tool
+// launches verbatim.
+func TestAILaunchCommandGuardsClaudeOnly(t *testing.T) {
+	if got := aiLaunchCommand(""); got != claudeContinueGuard {
+		t.Fatalf("default (claude) must use the resume guard, got %q", got)
+	}
+	if got := aiLaunchCommand("claude"); got != claudeContinueGuard {
+		t.Fatalf("explicit claude must use the resume guard, got %q", got)
+	}
+	if got := aiLaunchCommand("codex"); got != "codex" {
+		t.Fatalf("codex must launch verbatim, got %q", got)
+	}
+	if got := aiLaunchCommand("claude --resume"); got != "claude --resume" {
+		t.Fatalf("claude with explicit flags must launch verbatim, got %q", got)
+	}
+}

--- a/erun-ui/contribute_sessions.go
+++ b/erun-ui/contribute_sessions.go
@@ -157,8 +157,10 @@ func buildContributePreludeCommand(withAI bool, aiTool string) string {
 	}
 	prelude := strings.Join(parts, " && ") + "\n"
 	if withAI {
-		tool := resolveAIToolCommand(aiTool)
-		prelude += tool + "\n"
+		// The prelude already cd'd to $HOME/git/erun, so the cwd-guarded
+		// resume continues the contribute clone's Claude Code session rather
+		// than the env project's (issue #451).
+		prelude += aiLaunchCommand(aiTool) + "\n"
 	}
 	return prelude
 }

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -407,6 +407,32 @@ func resolveAIToolCommand(configured string) string {
 	return defaultAITool
 }
 
+// claudeContinueGuard is the cwd-guarded Claude Code resume the desktop pipes
+// into an AI tab. It continues the session that belongs to the tab's working
+// directory — the env repo for the env AI tab, the $HOME/git/erun clone for
+// the contribute AI tab — so per-tab restore is correct on local-agent (host)
+// and remote-agent (pod) envs alike, no longer depending on the pod-only
+// claude-wrapper.sh that is absent on local-agent hosts (issue #451).
+//
+// The guard mirrors claude-wrapper.sh: resume only when Claude Code's
+// per-project session store exists for the current directory. It composes with
+// the pod wrapper because the wrapper treats --continue as a bypass flag, so it
+// forwards rather than double-injecting.
+const claudeContinueGuard = `if [ -d "$HOME/.claude/projects/$(pwd | tr / -)" ]; then claude --continue; else claude; fi`
+
+// aiLaunchCommand returns the keystrokes the desktop pipes into an AI tab's
+// shell to launch the AI tool. A bare `claude` launch is wrapped in the
+// cwd-guarded resume; any other tool, or `claude` with explicit flags/a
+// subcommand, launches verbatim — mirroring the wrapper's bypass rules so we
+// never inject a resume the user did not ask for.
+func aiLaunchCommand(configured string) string {
+	tool := resolveAIToolCommand(configured)
+	if tool != defaultAITool {
+		return tool
+	}
+	return claudeContinueGuard
+}
+
 func formatLaunchCommand(params startTerminalSessionParams) string {
 	parts := make([]string, 0, len(params.Args)+1)
 	parts = append(parts, params.Executable)

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -248,7 +248,9 @@ func (a *App) runAISession(ctx context.Context, selection uiSelection, slot, col
 		Env:          []string{appSessionEnvVar + "=1"},
 		Cols:         cols,
 		Rows:         rows,
-		InitialInput: []byte(tool + "\n"),
+		// The env AI tab runs in the env repo, so the cwd-guarded resume
+		// continues the env project's Claude Code session (issue #451).
+		InitialInput: []byte(aiLaunchCommand(result.EnvConfig.AITool) + "\n"),
 	}
 	session, err := a.deps.startTerminal(params)
 	if err != nil {


### PR DESCRIPTION
Closes #451

## Problem
Contribute-mode AI restore was unreliable — most visibly on **local-agent** envs, where the ERun AI tab started a fresh Claude instead of resuming the `~/git/erun` clone conversation. "Restore" was implemented only by the pod-side `claude-wrapper.sh` (auto `--continue` keyed on cwd), which is **absent on local-agent hosts** — there the AI tab runs the host's real `claude`, so a bare `claude` never resumed. (Same gap affects the plain env AI tab on local-agent.)

## Fix
Make per-cwd resume an explicit part of the desktop's AI-tab launch command, shared by the env and contribute paths, so it works on host (local-agent) and pod (remote-agent) alike. New `aiLaunchCommand` wraps a bare `claude` launch in a cwd-guarded resume:

```sh
if [ -d "$HOME/.claude/projects/$(pwd | tr / -)" ]; then claude --continue; else claude; fi
```

Per-tab correctness falls out of cwd: the **env AI tab** runs in the env repo (resumes the env session); the **contribute AI tab** already `cd`s to `$HOME/git/erun` (resumes the clone session). The guard mirrors `claude-wrapper.sh` and **composes** with it — the wrapper treats `--continue` as a bypass flag, so it forwards rather than double-injecting in the pod. Other tools (`codex`) and explicit-flag `claude` invocations launch verbatim, matching the wrapper's bypass rules.

## Validation
- `erun-ui`: `go test ./...` green. Updated the env-tab test to expect the guard; added contribute-prelude + `aiLaunchCommand` tests covering claude (guarded), codex (verbatim), explicit-flag claude (verbatim), and the non-AI prelude.
- Verified the guard snippet's branch logic in **sh and bash**: project dir present → `claude --continue`; absent → `claude`.
- **Playwright** cannot drive real Claude session resume (no real Claude in the headless harness; the AI tab errors either way) — the documented exception per `erun-ui/playwright/AGENTS.md`. The launch-command invariant is owned by the Go tests; the actual resume needs manual verification (open a contribute AI tab on a local-agent env → resumes `~/git/erun`; env AI tab → resumes the env session).
- `claude-wrapper.sh` unchanged; its semantics stay aligned with the in-tab guard.

## UX Impact Review Checklist (erun-ui)
1. **Affected path:** AI tab launch — `StartAISession → runAISession` (env) and the contribute AI tab → `buildContributePreludeCommand`.
2. **Sequence:** AI tab opens → `erun open` shell → piped launch command resumes the cwd's Claude session instead of starting fresh.
3. **State/affordance:** no `AppState` change; observable effect is the resumed conversation in the AI tab.
4. **Visibility of system status (#1):** the user sees prior context restored rather than a blank session.
5. **Success/failure feedback:** unchanged; the AI tab renders the resumed (or fresh) Claude UI.
6. **Consistency (#4):** matches the long-standing pod-wrapper behaviour, now reliable on local-agent too.
7. **Heuristic pass:** #1 visibility (context restored); others unaffected. Restore stays implicit, matching the wrapper.
8. **Playwright coverage:** not stageable (no real Claude); Go tests own the launch-command invariant — `TestStartAISessionRunsErunOpenWithClaudeInitialInput`, `TestBuildContributePreludeCommandResumesCloneSession`, `TestAILaunchCommandGuardsClaudeOnly`.

## Docs
No `erun-docs` change — bug fix restoring intended per-tab restore behaviour; no new feature, flag, or contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)