### PR TITLE
Add erun-blueprint-docs skill for product docs sites

### DIFF
--- a/erun-docs/docs/agent-reference/skills-spec.md
+++ b/erun-docs/docs/agent-reference/skills-spec.md
@@ -267,6 +267,18 @@ Key contract: the skill **explicitly reads** the cloned repo's `AGENTS.md` and e
 | Outputs | `<module>/go.mod`, `<module>/cmd/<module>/main.go`, `<module>/server.go`, `<module>/auth.go`, `<module>/oidc.go`, `<module>/identity_cache.go`, `<module>/api_path.go`, `<module>/audit.go`, `<module>/internal/{model,repository,routes}/...`, `<module>/AGENTS.md`. Includes a working `GET /v1/whoami` endpoint; entity routes are produced per user-supplied entity. |
 | Error behaviour | Target dir already has `go.mod` → stop. Empty OIDC issuer list → stop. Database side (matching `erun-backend-db`-shaped schema) missing → surface and offer to run `erun-blueprint-rls-db` first. `go build` fails after generation → surface compiler output; most common cause is module path mismatch. |
 
+### `erun-blueprint-docs`
+
+| Field | Value |
+|---|---|
+| Kind | Blueprint — packages ERun's docs-site pattern: a Docusaurus 3.x site published to Cloudflare Pages by a Kubernetes hook Job, the shape `erun-docs` captures. |
+| Source | `erun-skills/skills/erun-blueprint-docs/SKILL.md` + `templates/` |
+| Description | "Scaffold a product documentation site following ERun's blueprint — a Docusaurus 3.x site published to Cloudflare Pages through a Kubernetes Job, the exact shape erun-docs captures." |
+| Triggers | "set up product docs site", "scaffold a docusaurus docs site", "build erun-docs-shaped documentation", "create a docs site deployed to cloudflare pages", "add a documentation site for this project" |
+| Inputs | Module name (default `<concern>-docs`); target repo root; site title + tagline + production URL; Cloudflare Pages project name + branch alias; GitHub org/repo for `editUrl` |
+| Outputs | `<module>/` Docusaurus site (`docusaurus.config.ts` with `onBrokenLinks: throw`, `sidebars.ts`, `docs/`, `src/css`, `static/img`, `package.json`, `tsconfig.json`); `erun-devops/docker/<module>/{Dockerfile,entrypoint.sh}` (two-stage build → pinned wrangler); `erun-devops/k8s/<module>/{Chart.yaml,values.prod.yaml,templates/docs.yaml}` (ServiceAccount + `post-install,post-upgrade` hook Job that runs `wrangler pages deploy`). |
+| Error behaviour | Target dir already has `<module>/docusaurus.config.ts` → stop. `yarn build` fails on a broken link → fix the link, do not disable `onBrokenLinks`. `npx create-docusaurus` offline → fall back to bundled `templates/`. Cloudflare Pages project / `cf-creds` Secret missing → scaffold still succeeds; surface that the first `erun deploy` Job fails until the Direct-Upload project, custom domain, token, and Secret exist. User asks for a Git-connected Pages project → stop (Direct Upload only; a Git connection double-deploys). |
+
 The catalogue is open — new skills land in `erun-skills/skills/` and ship through both distribution paths automatically. Each skill's `description` is what the Agent matches on, so additions don't require coordinated client changes.
 
 ## Adding a custom skill

--- a/erun-docs/docs/concepts/skills.md
+++ b/erun-docs/docs/concepts/skills.md
@@ -48,6 +48,7 @@ Skills come in two kinds: *Blueprint* (ERun's accumulated best practices for ind
 |---|---|---|
 | `erun-blueprint-rls-db` | Blueprint | Build a multi-tenant PostgreSQL schema with row-level security, modelled on `erun-backend-db`. |
 | `erun-blueprint-api` | Blueprint | Build a multi-tenant Go HTTP API service modelled on `erun-backend-api`. |
+| `erun-blueprint-docs` | Blueprint | Scaffold a Docusaurus docs site that publishes to Cloudflare Pages, modelled on `erun-docs`. |
 | `erun-file-issue` | Workflow | File a bug or feature against ERun on GitHub (`sophium/erun`). |
 | `erun-contribute` | Workflow | Create a new issue against `sophium/erun`, then drive the full clone → branch → implement → PR motion to share your improvement back. |
 

--- a/erun-skills/skills/erun-blueprint-docs/SKILL.md
+++ b/erun-skills/skills/erun-blueprint-docs/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: erun-blueprint-docs
+description: Scaffold a product documentation site following ERun's blueprint — a Docusaurus 3.x site published to Cloudflare Pages through a Kubernetes Job, the exact shape erun-docs captures. Use when the user says "set up product docs site", "scaffold a docusaurus docs site", "build erun-docs-shaped documentation", "create a docs site deployed to cloudflare pages", "add a documentation site for this project", or any similar request for a new project documentation site.
+---
+
+# Build an erun-docs-shaped documentation site
+
+Produce a product documentation site following ERun's blueprint — the
+same shape `erun-docs` captures: a Docusaurus 3.x static site published
+to **Cloudflare Pages** by a two-stage container image run as a
+Kubernetes **Job** (a Helm `post-install,post-upgrade` hook), with the
+deploy chart living under `erun-devops/k8s/<name>-docs/`.
+
+This skill packages ERun's proven docs-site pattern. Do not freelance
+the plumbing; the deploy contract encoded here (build → wrangler image →
+hook Job → Cloudflare Pages Direct Upload) is what makes the site ship.
+
+## When to use
+
+Trigger on user phrasings such as:
+
+- "set up product docs site"
+- "scaffold a docusaurus docs site"
+- "build erun-docs-shaped documentation"
+- "create a docs site deployed to cloudflare pages"
+- "add a documentation site for this project"
+
+## Context awareness
+
+This skill runs both on a developer laptop and inside a deployed env.
+Gate the deploy-plumbing steps (k8s chart, in-cluster Job) on intent,
+not on tools — **do not assume `kubectl`/`helm`/`wrangler` are on PATH
+on a laptop**. The laptop flow scaffolds the site, runs `yarn build`
+locally to prove it, and writes the chart + image files; the actual
+in-cluster deploy happens later via `erun deploy` (which the runtime
+pod, not the laptop, executes). Only run cluster commands when
+`[ -n "${ERUN_TENANT:-}" ]` and the tool exists.
+
+## Inputs to collect
+
+Ask once, then proceed. Do not invent these.
+
+1. **Module name** (e.g. `acme-docs`, `billing-docs`). Directory name;
+   default to `<concern>-docs`. Per ERun convention the module is named
+   for the concern it documents, suffixed `-docs`.
+2. **Target repo root** (default: current working directory). The module
+   is a sibling top-level directory, like `erun-docs/`.
+3. **Site title + tagline** and the **production URL** (custom domain,
+   e.g. `docs.example.com`).
+4. **Cloudflare Pages project name** (default: `<module-name>`) and the
+   **branch alias** that maps to production (default: `main`).
+5. **GitHub org/repo** for the `editUrl` (default: derive from the repo's
+   `origin` remote).
+
+## What gets produced
+
+```
+<repo-root>/
+├── <module-name>/                         # the Docusaurus site
+│   ├── docusaurus.config.ts               # 3.x config: url/baseUrl, onBrokenLinks: throw
+│   ├── sidebars.ts                        # the doc tree
+│   ├── tsconfig.json
+│   ├── package.json                       # pinned @docusaurus/* 3.x, yarn
+│   ├── docs/                              # MDX/markdown pages
+│   ├── src/css/custom.css
+│   └── static/img/
+└── erun-devops/
+    ├── docker/<module-name>/
+    │   ├── Dockerfile                      # build site → wrangler image
+    │   └── entrypoint.sh                   # wrangler pages deploy $SITE_DIR
+    └── k8s/<module-name>/
+        ├── Chart.yaml
+        ├── values.prod.yaml                # docs.enabled, project, branch, secret
+        └── templates/docs.yaml             # ServiceAccount + hook Job
+
+```
+
+Verbatim-copyable plumbing ships alongside this `SKILL.md` under
+`templates/`. Substitute the placeholders (`__MODULE__`, `__PROJECT__`,
+`__BRANCH__`, `__TITLE__`, `__TAGLINE__`, `__URL__`, `__ORG__`,
+`__REPO__`) and use them as the source of truth — do not freelance the
+boilerplate.
+
+## The deploy contract (binding)
+
+This is the load-bearing part of the blueprint. It mirrors
+`erun-docs/AGENTS.md` and `erun-devops/k8s/erun-docs/`.
+
+- **Static site, no long-running pod.** The site is built once into a
+  container image, then a Job pushes it to Cloudflare Pages. There is no
+  in-cluster Service, Ingress, or Deployment. Cloudflare Pages owns CDN,
+  TLS, the custom domain, and per-deploy preview URLs.
+- **Two-stage image.** Stage 1 (`node:20-alpine`) runs
+  `yarn install --frozen-lockfile` then `yarn build` to produce
+  `/build`. Stage 2 installs a pinned `wrangler` and bakes the built
+  site at `$SITE_DIR=/site`. The entrypoint runs
+  `wrangler pages deploy "$SITE_DIR" --project-name="$CF_PAGES_PROJECT" --branch="$CF_PAGES_BRANCH" --commit-dirty=true`.
+- **Deploy as a Helm hook Job.** The chart renders a `Job` annotated
+  `helm.sh/hook: post-install,post-upgrade` with
+  `hook-delete-policy: before-hook-creation,hook-succeeded`. Each
+  `erun deploy` runs a fresh Job; success deletes it. `restartPolicy:
+  Never`, small `backoffLimit`, `ttlSecondsAfterFinished` so failed Jobs
+  self-clean.
+- **Credentials via Secret + values.** The Job reads
+  `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` from a Secret
+  (`credentialsSecretName`, e.g. `cf-creds`) and `CF_PAGES_PROJECT` /
+  `CF_PAGES_BRANCH` from chart values. The entrypoint refuses to run if
+  any of the four is missing — surface that as the contract, not a
+  surprise.
+- **Image pinning.** Pin both `node` and `wrangler` versions in the
+  Dockerfile so deploys stay reproducible (per repo release rules on
+  release-critical infra images).
+
+## External prerequisites (must exist before the first deploy)
+
+These are external to the repository and a deploy will fail without
+them. State them to the user up front; do not pretend the scaffold alone
+publishes a site.
+
+1. A **Cloudflare Pages project** of type **Direct Upload** named after
+   `CF_PAGES_PROJECT`. Do **not** connect a Git source — the Job uploads
+   directly via wrangler.
+2. The **custom domain** attached to that Pages project.
+3. A **Cloudflare API token** scoped `Pages:Edit`, plus the **account
+   id**.
+4. A Kubernetes **Secret** (e.g. `cf-creds`) in the deploy namespace
+   holding `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`.
+5. **DNS** for the domain proxied through Cloudflare so TLS is automatic.
+
+## Step-by-step
+
+### Step 1 — confirm inputs
+
+Read back module name, target repo root, title/tagline/URL, Pages
+project + branch, and org/repo. Confirm the external prerequisites exist
+(or note they must be created before deploy succeeds).
+
+### Step 2 — scaffold the Docusaurus site
+
+Prefer the official generator, then trim to the 3.x classic preset:
+
+```sh
+cd "<repo-root>"
+npx create-docusaurus@3 "<module-name>" classic --typescript
+```
+
+If `npx` / network is unavailable, copy `templates/docusaurus.config.ts`,
+`templates/sidebars.ts`, `templates/package.json`, and `templates/tsconfig.json`
+and create `docs/intro.md`. Either way, end on the canonical config:
+
+- `url` = production origin, `baseUrl` = `/`.
+- `onBrokenLinks: 'throw'` — broken links fail the build (this is the
+  link checker; keep it on).
+- `organizationName` / `projectName` and `editUrl` pointing at
+  `https://github.com/<org>/<repo>/tree/main/<module-name>/`.
+- `docs.routeBasePath: '/'`, `blog: false` (docs-only site).
+
+### Step 3 — write the deploy plumbing
+
+Copy and substitute placeholders:
+
+- `templates/Dockerfile` → `erun-devops/docker/<module-name>/Dockerfile`
+- `templates/entrypoint.sh` → `erun-devops/docker/<module-name>/entrypoint.sh` (mode 0755)
+- `templates/chart/Chart.yaml` → `erun-devops/k8s/<module-name>/Chart.yaml`
+- `templates/chart/values.prod.yaml` → `erun-devops/k8s/<module-name>/values.prod.yaml`
+- `templates/chart/templates/docs.yaml` → `erun-devops/k8s/<module-name>/templates/docs.yaml`
+
+### Step 4 — prove the build locally
+
+```sh
+cd "<repo-root>/<module-name>"
+yarn install --frozen-lockfile
+yarn build      # fails on any broken link (onBrokenLinks: throw)
+yarn typecheck  # tsc against docusaurus.config.ts and sidebars.ts
+```
+
+A clean `yarn build` is the gate. Fix broken links before moving on.
+
+### Step 5 — wire into the deploy flow
+
+Document (in the module's `AGENTS.md`) that the site deploys via
+`erun deploy` once the Secret + Pages project exist. Do not run
+`kubectl`/`helm` from a laptop; the runtime executes the deploy.
+
+## Audience: keep Operator and Agent docs separate
+
+When authoring pages, split by audience (mirrors `erun-docs/AGENTS.md`):
+
+- **Operator-facing** pages: task-oriented, what a human runs and sees.
+- **Agent-reference** pages: exact contracts — flags, inputs, outputs,
+  error behaviour, exit codes. Be specific ("aborts with `not in a git
+  repository`; exit code 1"), not vague ("errors if not in a repo").
+
+Add every new page id to `sidebars.ts` under the section that matches
+its **audience**, not its topic.
+
+## Error behaviour
+
+| Failure mode | Recovery |
+|---|---|
+| Target dir already contains `<module-name>/docusaurus.config.ts` | Stop. Offer a new module name or explicit overwrite; do not clobber an existing site. |
+| `yarn build` fails on a broken link | Fix the link or page id; do not disable `onBrokenLinks`. The throw is the link checker working. |
+| `npx create-docusaurus` unavailable (offline) | Fall back to the `templates/` scaffold; the produced files are valid without the generator. |
+| Cloudflare Pages project / Secret missing | Scaffold still succeeds; surface that the first `erun deploy` Job will fail until the Direct-Upload project, custom domain, token, and Secret exist. |
+| User asks for a Git-connected Pages project | Stop. The Job uploads directly (`wrangler pages deploy`); a Git-connected project double-deploys. Use Direct Upload. |
+| PostgreSQL/other backend coupling requested | Out of scope — this skill is the static docs site only. Point at `erun-blueprint-api` / `erun-blueprint-rls-db` for backend modules. |
+
+## Important
+
+- Do not connect the Cloudflare Pages project to a Git source. Direct
+  Upload + the wrangler Job is the contract; a Git connection causes
+  duplicate deploys.
+- Do not add a Service/Ingress/Deployment. The site is static and served
+  by Cloudflare; the only in-cluster object is the hook Job.
+- Do not turn off `onBrokenLinks: 'throw'`. It is the link checker.
+- Do not pin docs identity to release metadata indirectly — name the
+  module and Pages project explicitly (per repo rule on generated
+  runtime asset identity).
+- Pin `node` and `wrangler` versions in the Dockerfile; unpinned infra
+  images make deploys non-reproducible.

--- a/erun-skills/skills/erun-blueprint-docs/templates/Dockerfile
+++ b/erun-skills/skills/erun-blueprint-docs/templates/Dockerfile
@@ -1,0 +1,44 @@
+# Blueprint: two-stage image that builds the Docusaurus site, then pushes it
+# to Cloudflare Pages via a pinned wrangler. Substitute __MODULE__ with the
+# docs module directory name (e.g. acme-docs). Pin node + wrangler so deploys
+# stay reproducible.
+ARG ERUN_VERSION=1.0.0
+
+# Stage 1: build the Docusaurus static site.
+FROM node:20.18.1-alpine AS builder
+
+WORKDIR /src
+
+# Install deps first so source edits don't bust the cache.
+COPY __MODULE__/package.json __MODULE__/yarn.lock /src/__MODULE__/
+
+WORKDIR /src/__MODULE__
+
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn \
+    yarn install --frozen-lockfile --non-interactive
+
+# Copy the rest and build.
+COPY __MODULE__ /src/__MODULE__
+
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn \
+    yarn build
+
+# Stage 2: tiny image with pinned wrangler that pushes /site/ to Cloudflare Pages.
+FROM node:20.18.1-alpine
+
+ARG WRANGLER_VERSION=3.87.0
+
+RUN apk add --no-cache ca-certificates tini && \
+    npm install -g wrangler@${WRANGLER_VERSION} && \
+    addgroup -S erun && \
+    adduser -S -G erun -h /home/erun erun
+
+COPY --from=builder --chown=erun:erun /src/__MODULE__/build /site
+COPY --chmod=0755 erun-devops/docker/__MODULE__/entrypoint.sh /usr/local/bin/__MODULE__-entrypoint
+
+USER erun
+WORKDIR /home/erun
+
+ENV SITE_DIR=/site
+
+ENTRYPOINT ["/sbin/tini", "--", "__MODULE__-entrypoint"]

--- a/erun-skills/skills/erun-blueprint-docs/templates/chart/Chart.yaml
+++ b/erun-skills/skills/erun-blueprint-docs/templates/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 1.0.0
+description: Publish the __MODULE__ documentation site to Cloudflare Pages
+name: __MODULE__
+type: application
+version: 1.0.0

--- a/erun-skills/skills/erun-blueprint-docs/templates/chart/templates/docs.yaml
+++ b/erun-skills/skills/erun-blueprint-docs/templates/chart/templates/docs.yaml
@@ -1,0 +1,67 @@
+{{- $docs := default dict .Values.docs -}}
+{{- $enabled := default false $docs.enabled -}}
+{{- $project := default "__PROJECT__" $docs.project -}}
+{{- $branch := default "preview" $docs.branch -}}
+{{- $credentialsSecret := default "cf-creds" $docs.credentialsSecretName -}}
+{{- $imageOverrides := default dict .Values.imageOverrides -}}
+{{- $containerRegistry := default "ghcr.io/sophium" .Values.containerRegistry -}}
+{{- $docsImage := default (printf "%s/__MODULE__:%s" $containerRegistry .Chart.AppVersion) (index $imageOverrides "__MODULE__") -}}
+{{- if $enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: __MODULE__-deployer
+  labels:
+    app: __MODULE__
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: __MODULE__-deploy
+  labels:
+    app: __MODULE__
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "10"
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: __MODULE__
+    spec:
+      restartPolicy: Never
+      serviceAccountName: __MODULE__-deployer
+      containers:
+        - name: deploy
+          image: {{ $docsImage }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CF_PAGES_PROJECT
+              value: {{ $project | quote }}
+            - name: CF_PAGES_BRANCH
+              value: {{ $branch | quote }}
+            - name: CLOUDFLARE_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $credentialsSecret }}
+                  key: CLOUDFLARE_API_TOKEN
+            - name: CLOUDFLARE_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $credentialsSecret }}
+                  key: CLOUDFLARE_ACCOUNT_ID
+            - name: ERUN_TENANT
+              value: {{ required "tenant is required" .Values.tenant | quote }}
+            - name: ERUN_ENVIRONMENT
+              value: {{ required "environment is required" .Values.environment | quote }}
+          resources:
+            limits:
+              cpu: "1"
+              memory: 512Mi
+            requests:
+              cpu: "100m"
+              memory: 128Mi
+{{- end }}

--- a/erun-skills/skills/erun-blueprint-docs/templates/chart/values.prod.yaml
+++ b/erun-skills/skills/erun-blueprint-docs/templates/chart/values.prod.yaml
@@ -1,0 +1,8 @@
+# Production overlay: publish to the live Cloudflare Pages project on the
+# `__BRANCH__` branch alias. The branch alias controls which Cloudflare Pages
+# deployment maps to the production custom domain.
+docs:
+  enabled: true
+  project: __PROJECT__
+  branch: __BRANCH__
+  credentialsSecretName: cf-creds

--- a/erun-skills/skills/erun-blueprint-docs/templates/docusaurus.config.ts
+++ b/erun-skills/skills/erun-blueprint-docs/templates/docusaurus.config.ts
@@ -1,0 +1,75 @@
+import { themes as prismThemes } from 'prism-react-renderer';
+import type { Config } from '@docusaurus/types';
+import type * as Preset from '@docusaurus/preset-classic';
+
+// Blueprint Docusaurus 3.x config. Substitute __TITLE__, __TAGLINE__, __URL__
+// (production origin), __ORG__, and __REPO__. Keep onBrokenLinks: 'throw' —
+// it is the link checker that gates `yarn build`.
+const config: Config = {
+  title: '__TITLE__',
+  tagline: '__TAGLINE__',
+  favicon: 'img/favicon.svg',
+
+  url: '__URL__',
+  baseUrl: '/',
+
+  organizationName: '__ORG__',
+  projectName: '__REPO__',
+
+  onBrokenLinks: 'throw',
+
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en'],
+  },
+
+  markdown: {
+    mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
+
+  themes: ['@docusaurus/theme-mermaid'],
+
+  plugins: [
+    [
+      require.resolve('@easyops-cn/docusaurus-search-local'),
+      {
+        hashed: true,
+        indexBlog: false,
+        docsRouteBasePath: '/',
+      },
+    ],
+  ],
+
+  presets: [
+    [
+      'classic',
+      {
+        docs: {
+          routeBasePath: '/',
+          sidebarPath: './sidebars.ts',
+          editUrl: 'https://github.com/__ORG__/__REPO__/tree/main/__MODULE__/',
+        },
+        blog: false,
+        theme: {
+          customCss: './src/css/custom.css',
+        },
+      } satisfies Preset.Options,
+    ],
+  ],
+
+  themeConfig: {
+    navbar: {
+      title: '__TITLE__',
+      items: [],
+    },
+    prism: {
+      theme: prismThemes.github,
+      darkTheme: prismThemes.dracula,
+    },
+  } satisfies Preset.ThemeConfig,
+};
+
+export default config;

--- a/erun-skills/skills/erun-blueprint-docs/templates/entrypoint.sh
+++ b/erun-skills/skills/erun-blueprint-docs/templates/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Publish the pre-built Docusaurus static site (baked into the image at $SITE_DIR)
+# to a Cloudflare Pages project via wrangler.
+#
+# Required environment variables (provided by the helm chart from a Secret + values):
+#   CLOUDFLARE_API_TOKEN   — Cloudflare API token with `Pages:Edit` scope
+#   CLOUDFLARE_ACCOUNT_ID  — Cloudflare account id that owns the Pages project
+#   CF_PAGES_PROJECT       — Cloudflare Pages project name (Direct Upload type)
+#   CF_PAGES_BRANCH        — Branch alias the deploy is published under (e.g. main, preview)
+#
+# wrangler reads CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID directly.
+set -eu
+
+: "${SITE_DIR:?SITE_DIR is required}"
+: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required}"
+: "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID is required}"
+: "${CF_PAGES_PROJECT:?CF_PAGES_PROJECT is required}"
+: "${CF_PAGES_BRANCH:?CF_PAGES_BRANCH is required}"
+
+if [ ! -d "$SITE_DIR" ]; then
+  echo "error: site directory $SITE_DIR does not exist" >&2
+  exit 1
+fi
+
+echo "publishing $SITE_DIR to Cloudflare Pages project=$CF_PAGES_PROJECT branch=$CF_PAGES_BRANCH"
+exec wrangler pages deploy "$SITE_DIR" \
+  --project-name="$CF_PAGES_PROJECT" \
+  --branch="$CF_PAGES_BRANCH" \
+  --commit-dirty=true

--- a/erun-skills/skills/erun-blueprint-docs/templates/package.json
+++ b/erun-skills/skills/erun-blueprint-docs/templates/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "__MODULE__",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "docusaurus": "docusaurus",
+    "start": "docusaurus start",
+    "build": "docusaurus build",
+    "swizzle": "docusaurus swizzle",
+    "deploy": "docusaurus deploy",
+    "clear": "docusaurus clear",
+    "serve": "docusaurus serve",
+    "typecheck": "tsc"
+  },
+  "dependencies": {
+    "@docusaurus/core": "3.10.1",
+    "@docusaurus/preset-classic": "3.10.1",
+    "@docusaurus/theme-mermaid": "3.10.1",
+    "@easyops-cn/docusaurus-search-local": "0.49.2",
+    "@mdx-js/react": "3.0.1",
+    "clsx": "2.1.1",
+    "prism-react-renderer": "2.4.1",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@docusaurus/module-type-aliases": "3.10.1",
+    "@docusaurus/tsconfig": "3.10.1",
+    "@docusaurus/types": "3.10.1",
+    "typescript": "5.6.3"
+  },
+  "browserslist": {
+    "production": [">0.5%", "not dead", "not op_mini all"],
+    "development": [
+      "last 3 chrome version",
+      "last 3 firefox version",
+      "last 5 safari version"
+    ]
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "packageManager": "yarn@1.22.22"
+}

--- a/erun-skills/skills/erun-blueprint-docs/templates/sidebars.ts
+++ b/erun-skills/skills/erun-blueprint-docs/templates/sidebars.ts
@@ -1,0 +1,24 @@
+import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
+
+// Blueprint sidebar. Add each new page id under the category that matches its
+// audience (Operator-facing vs Agent-reference), not its topic. The id is the
+// path relative to docs/ without the .md extension.
+const sidebars: SidebarsConfig = {
+  docsSidebar: [
+    'intro',
+    {
+      type: 'category',
+      label: 'Getting started',
+      link: { type: 'generated-index' },
+      items: [],
+    },
+    {
+      type: 'category',
+      label: 'Reference',
+      link: { type: 'generated-index' },
+      items: [],
+    },
+  ],
+};
+
+export default sidebars;

--- a/erun-skills/skills/erun-blueprint-docs/templates/tsconfig.json
+++ b/erun-skills/skills/erun-blueprint-docs/templates/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@docusaurus/tsconfig",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "exclude": [".docusaurus", "build", "node_modules"]
+}


### PR DESCRIPTION
Closes #7

## Summary
New blueprint skill `erun-blueprint-docs` under `erun-skills/skills/` that captures ERun's proven docs-site pattern — the shape `erun-docs` uses: a **Docusaurus 3.x** static site published to **Cloudflare Pages** by a two-stage container image run as a Helm `post-install,post-upgrade` hook **Job**, with the deploy chart under `erun-devops/k8s/<name>-docs/`.

## What the skill captures
- **Docusaurus 3.x layout** — config with `onBrokenLinks: throw`, `sidebars.ts`, `docs/`, `src/css`, `static/img`, pinned `@docusaurus/*` 3.x, yarn.
- **Cloudflare Pages deploy contract** — Direct Upload via `wrangler pages deploy`; no in-cluster Service/Ingress/Deployment; credentials from a `cf-creds` Secret + chart values; the four required env vars (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `CF_PAGES_PROJECT`, `CF_PAGES_BRANCH`).
- **k8s Job integration shape** — ServiceAccount + hook Job under `erun-devops/k8s/<name>-docs/`.
- **Module placement & naming** — `<concern>-docs/`.
- **External prerequisites** — Direct-Upload Pages project, custom domain, API token + account id, Secret, DNS.
- **Audience split** — Operator-facing vs Agent-reference page authoring (mirrors `erun-docs/AGENTS.md`).
- **Context-aware** — laptop vs in-pod; does not assume `kubectl`/`helm`/`wrangler` on a laptop.

Ships verbatim-copyable `templates/` for the load-bearing plumbing (`Dockerfile`, `entrypoint.sh`, chart `Chart.yaml`/`values.prod.yaml`/`templates/docs.yaml`) plus an offline Docusaurus scaffold fallback (`docusaurus.config.ts`, `sidebars.ts`, `package.json`, `tsconfig.json`) with `__MODULE__`/`__PROJECT__`/`__BRANCH__`/`__TITLE__`/`__TAGLINE__`/`__URL__`/`__ORG__`/`__REPO__` placeholders.

Skills are auto-discovered from `skills/`, so **no `plugin.json` change** is needed; both consumers (runtime image `/etc/erun/skills/`, marketplace `erun-tools` plugin) pick it up automatically. The marketplace `source.sha` is bumped by the **stable release flow (#393)**, not per PR.

## Docs (same PR, per the skills docs contract in `erun-skills/AGENTS.md`)
- `erun-docs/docs/agent-reference/skills-spec.md` § "Built-in skill catalogue": full entry (name, `description` verbatim, triggers, inputs, outputs, error behaviour) — Agent-reference single source of truth.
- `erun-docs/docs/concepts/skills.md`: one-line Operator-facing summary row.

## Validation
- `python3 json.load` on `erun-skills/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` — both valid.
- `erun-docs`: `yarn typecheck` clean; `yarn build` clean — `onBrokenLinks: throw` passes (no broken links from the catalogue/summary edits).
- Skill directory is auto-baked into `/etc/erun/skills` via the Dockerfile `COPY erun-skills/skills /etc/erun/skills` (adding a directory under `skills/` is mechanically copied; no multi-arch image rebuild was run in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)