### PR TITLE
Sidebar environment hover card: version, working issue, and activity

### DIFF
--- a/erun-docs/docs/desktop/overview.md
+++ b/erun-docs/docs/desktop/overview.md
@@ -11,6 +11,7 @@ For CI/CD pipelines and headless workflows, use the [CLI](/cli/overview) instead
 ## Control panel
 
 - **Sidebar of projects and environments.** Every project and environment at a glance, with live status — running, stopping, idle, errored. Switch between them without typing commands.
+- **Environment details on hover.** Hover an environment row to see its runtime version, the issue it's working on (the current git branch and, when the branch names an issue, its title), and what it's doing right now. Branch and issue are shown for environments whose worktree is on your machine (local-agent envs).
 - **One-click lifecycle.** Start, stop, restart, and delete environments from the sidebar.
 - **Cloud status in real time.** Start, stop, and watch the cloud machines that back remote environments. The sidebar shows status as they wake up or shut down.
 - **Activities panel with failure details and fixes.** A queue of recent and in-flight operations — deploys, opens, builds. When a deploy fails, the entry keeps the captured command output (the real helm/kubectl error behind the one-line summary): expand **Show output** to read it, or use **Copy failure report** to package that output together with the environment, version, and container status so you can hand the whole picture to whoever can help. The failed entry also offers one-click recovery: **Run doctor** to troubleshoot (see [`erun doctor`](/cli/doctor)), **Rebuild & redeploy** to force a clean rebuild, and **Clear pending helm release** when a release is stuck.

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -34,36 +34,37 @@ type projectConfigLoader interface {
 }
 
 type erunUIDeps struct {
-	store                 erunUIStore
-	findProjectRoot       eruncommon.ProjectFinderFunc
-	resolveCLIPath        func() string
-	resolveBuildInfo      func() eruncommon.BuildInfo
-	resolveImageRegistry  func(context.Context, string, string) (eruncommon.RuntimeRegistryVersions, error)
-	cloudDeps             eruncommon.CloudDependencies
-	cloudContextDeps      eruncommon.CloudContextDependencies
-	deleteNamespace       eruncommon.NamespaceDeleterFunc
-	listKubeContexts      func() ([]string, error)
-	loadResourceStatus    func(context.Context, uiRuntimeResourceInput) (uiRuntimeResourceStatus, error)
-	ensureMCP             func(context.Context, eruncommon.OpenResult) error
-	reconnectMCP          func(context.Context, eruncommon.OpenResult, func(string)) error
-	ensureSSHD            func(context.Context, eruncommon.OpenResult) error
-	canConnectLocalPort   func(int) bool
-	setRemoteCloudAlias   func(context.Context, string, string, string, string) (eruncommon.EnvConfig, error)
-	startTerminal         func(startTerminalSessionParams) (terminalSession, error)
-	runIDECommand         func(context.Context, startTerminalSessionParams) (string, error)
-	savePastedImage       func(pastedImageSaveParams) (string, error)
-	loadDiff              func(context.Context, string, uiDiffOptions) (eruncommon.DiffResult, error)
-	loadIdleStatus        func(context.Context, string) (eruncommon.EnvironmentIdleStatus, error)
-	loadAPILog            func(context.Context, uiTenantDashboardInput) (string, error)
-	workspaceSyncReady    func(context.Context, string) error
-	syncWorkspace         func(context.Context, workspaceSyncParams) (workspaceSyncResult, error)
-	workspaceSyncInterval time.Duration
-	recordActivity        func(eruncommon.EnvironmentActivityParams) error
-	stopCloudContext      func(context.Context, string) (eruncommon.CloudContextStatus, error)
-	windowStatePath       string
-	windowMaximised       func(context.Context) bool
-	cloneERun             func(context.Context, string) error
-	contributeStatePath   string
+	store                  erunUIStore
+	findProjectRoot        eruncommon.ProjectFinderFunc
+	resolveCLIPath         func() string
+	resolveBuildInfo       func() eruncommon.BuildInfo
+	resolveImageRegistry   func(context.Context, string, string) (eruncommon.RuntimeRegistryVersions, error)
+	cloudDeps              eruncommon.CloudDependencies
+	cloudContextDeps       eruncommon.CloudContextDependencies
+	deleteNamespace        eruncommon.NamespaceDeleterFunc
+	listKubeContexts       func() ([]string, error)
+	loadResourceStatus     func(context.Context, uiRuntimeResourceInput) (uiRuntimeResourceStatus, error)
+	ensureMCP              func(context.Context, eruncommon.OpenResult) error
+	reconnectMCP           func(context.Context, eruncommon.OpenResult, func(string)) error
+	ensureSSHD             func(context.Context, eruncommon.OpenResult) error
+	canConnectLocalPort    func(int) bool
+	setRemoteCloudAlias    func(context.Context, string, string, string, string) (eruncommon.EnvConfig, error)
+	startTerminal          func(startTerminalSessionParams) (terminalSession, error)
+	runIDECommand          func(context.Context, startTerminalSessionParams) (string, error)
+	savePastedImage        func(pastedImageSaveParams) (string, error)
+	loadDiff               func(context.Context, string, uiDiffOptions) (eruncommon.DiffResult, error)
+	loadIdleStatus         func(context.Context, string) (eruncommon.EnvironmentIdleStatus, error)
+	loadAPILog             func(context.Context, uiTenantDashboardInput) (string, error)
+	workspaceSyncReady     func(context.Context, string) error
+	syncWorkspace          func(context.Context, workspaceSyncParams) (workspaceSyncResult, error)
+	workspaceSyncInterval  time.Duration
+	recordActivity         func(eruncommon.EnvironmentActivityParams) error
+	runWorkingIssueCommand workingIssueCommandRunner
+	stopCloudContext       func(context.Context, string) (eruncommon.CloudContextStatus, error)
+	windowStatePath        string
+	windowMaximised        func(context.Context) bool
+	cloneERun              func(context.Context, string) error
+	contributeStatePath    string
 }
 
 type App struct {
@@ -100,6 +101,12 @@ type App struct {
 	cloudContextStatusesMu sync.RWMutex
 	cloudContextStatuses   map[string]string
 	cloudContextPollerStop chan struct{}
+
+	// workingIssueCache memoizes the resolved working issue (branch +
+	// linked issue title) per env so the sidebar hover card doesn't re-run
+	// git + gh on every hover. Entries expire after workingIssueCacheTTL.
+	workingIssueMu    sync.Mutex
+	workingIssueCache map[string]workingIssueCacheEntry
 
 	// emitFn dispatches Wails-style events to the frontend. In normal Wails
 	// mode this calls runtime.EventsEmit; in headless mode it fans out to
@@ -144,6 +151,7 @@ func NewApp(deps erunUIDeps) *App {
 		busyEnvs:             make(map[string]int),
 		workspaceSyncs:       make(map[string]*workspaceSyncWorker),
 		credentialRefreshers: make(map[string]*cloudCredentialsRefresher),
+		workingIssueCache:    make(map[string]workingIssueCacheEntry),
 	}
 	app.activityQueue = newActivityQueueStore(
 		func(entry activityQueueEntry) {
@@ -240,6 +248,9 @@ func withDefaultUIDeps(deps erunUIDeps) erunUIDeps {
 	}
 	if deps.workspaceSyncInterval <= 0 {
 		deps.workspaceSyncInterval = defaultWorkspaceSyncInterval
+	}
+	if deps.runWorkingIssueCommand == nil {
+		deps.runWorkingIssueCommand = execWorkingIssueCommand
 	}
 	if deps.recordActivity == nil {
 		deps.recordActivity = eruncommon.RecordEnvironmentActivity

--- a/erun-ui/environment_working_issue.go
+++ b/erun-ui/environment_working_issue.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// workingIssueCommandRunner runs a command (git, gh) in dir and returns its
+// trimmed stdout. Injected so tests drive the resolver without a real repo or
+// network.
+type workingIssueCommandRunner func(ctx context.Context, dir, name string, args ...string) (string, error)
+
+// workingIssueCacheTTL bounds how long a resolved working issue is reused. The
+// hover card fetches lazily on open; a short TTL keeps the branch/title fresh
+// across a `git checkout` without re-running git + gh on every hover.
+const workingIssueCacheTTL = 30 * time.Second
+
+type workingIssueCacheEntry struct {
+	value     uiWorkingIssue
+	expiresAt time.Time
+}
+
+// branchIssuePattern matches the repository's branch naming convention
+// (feature/<n>-… / bug/<n>-…) so the issue number is parseable from the
+// branch. See the root AGENTS.md "Branching Strategy".
+var branchIssuePattern = regexp.MustCompile(`^(?:feature|bug)/(\d+)-`)
+
+// parseIssueNumberFromBranch extracts the issue number a branch is working on,
+// or 0 when the branch doesn't follow the feature/<n>- / bug/<n>- convention.
+func parseIssueNumberFromBranch(branch string) int {
+	match := branchIssuePattern.FindStringSubmatch(strings.TrimSpace(branch))
+	if match == nil {
+		return 0
+	}
+	n, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func execWorkingIssueCommand(ctx context.Context, dir, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	return strings.TrimSpace(string(out)), err
+}
+
+// EnvironmentWorkingIssue resolves what an environment is currently working on
+// for the sidebar hover card: the worktree's current git branch and, when the
+// branch names an issue, that issue's title. The worktree must be reachable
+// from the host, which holds for local-agent envs (worktree mounted from the
+// machine). Remote-agent / runtime envs keep their worktree in the pod, so the
+// result is marked unavailable with a reason rather than reaching into the pod
+// (which is only possible while the env is open). Results are cached per env
+// for workingIssueCacheTTL.
+func (a *App) EnvironmentWorkingIssue(selection uiSelection) (uiWorkingIssue, error) {
+	selection = normalizeSelection(selection)
+	if selection.Tenant == "" || selection.Environment == "" {
+		return uiWorkingIssue{}, nil
+	}
+
+	cacheKey := selectionKey(selection)
+	if cached, ok := a.lookupWorkingIssue(cacheKey); ok {
+		return cached, nil
+	}
+
+	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
+		Tenant:      selection.Tenant,
+		Environment: selection.Environment,
+	})
+	if err != nil {
+		return uiWorkingIssue{}, err
+	}
+
+	value := a.resolveWorkingIssue(result.EnvConfig)
+	a.storeWorkingIssue(cacheKey, value)
+	return value, nil
+}
+
+// resolveWorkingIssue is the transport-free core: it runs git in the env's
+// host worktree to read the branch, then gh to resolve the linked issue title.
+// It never errors out to the caller — an unreachable worktree or a failed
+// lookup degrades to an honest empty/partial state the hover card renders.
+func (a *App) resolveWorkingIssue(env eruncommon.EnvConfig) uiWorkingIssue {
+	if env.RemoteWorktree() {
+		return uiWorkingIssue{Available: false, Reason: "worktree lives in the pod"}
+	}
+	repo := env.EffectiveLocalRepoPath()
+	if repo == "" {
+		return uiWorkingIssue{Available: false, Reason: "no local worktree path"}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	branch, err := a.deps.runWorkingIssueCommand(ctx, repo, "git", "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil || branch == "" || branch == "HEAD" {
+		// No branch (not a repo, or detached HEAD). Available, but nothing
+		// to show beyond "no branch".
+		return uiWorkingIssue{Available: true}
+	}
+
+	value := uiWorkingIssue{Available: true, Branch: branch}
+	number := parseIssueNumberFromBranch(branch)
+	if number == 0 {
+		return value
+	}
+	value.IssueNumber = number
+
+	// `gh` resolves the repo from the worktree's origin remote when run with
+	// cmd.Dir set. A failed lookup (offline, gh unauthenticated, issue gone)
+	// leaves the number without a title — still useful.
+	title, err := a.deps.runWorkingIssueCommand(ctx, repo, "gh", "issue", "view", strconv.Itoa(number), "--json", "title", "-q", ".title")
+	if err == nil {
+		value.IssueTitle = strings.TrimSpace(title)
+	}
+	return value
+}
+
+func (a *App) lookupWorkingIssue(key string) (uiWorkingIssue, bool) {
+	a.workingIssueMu.Lock()
+	defer a.workingIssueMu.Unlock()
+	entry, ok := a.workingIssueCache[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return uiWorkingIssue{}, false
+	}
+	return entry.value, true
+}
+
+func (a *App) storeWorkingIssue(key string, value uiWorkingIssue) {
+	a.workingIssueMu.Lock()
+	defer a.workingIssueMu.Unlock()
+	a.workingIssueCache[key] = workingIssueCacheEntry{value: value, expiresAt: time.Now().Add(workingIssueCacheTTL)}
+}

--- a/erun-ui/environment_working_issue_test.go
+++ b/erun-ui/environment_working_issue_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+func TestParseIssueNumberFromBranch(t *testing.T) {
+	cases := map[string]int{
+		"feature/437-sidebar-env-hover": 437,
+		"bug/12-fix-thing":              12,
+		"feature/5-x":                   5,
+		"main":                          0,
+		"develop":                       0,
+		"feature/no-number":             0,
+		"hotfix/9-x":                    0, // only feature/ and bug/ per the convention
+		"":                              0,
+		"HEAD":                          0,
+	}
+	for branch, want := range cases {
+		if got := parseIssueNumberFromBranch(branch); got != want {
+			t.Errorf("parseIssueNumberFromBranch(%q) = %d, want %d", branch, got, want)
+		}
+	}
+}
+
+// workingIssueApp builds an App whose store resolves one env and whose
+// working-issue command runner is stubbed, so the resolver runs without a real
+// repo or gh.
+func workingIssueApp(t *testing.T, env eruncommon.EnvConfig, run workingIssueCommandRunner) *App {
+	t.Helper()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"acme": {Name: "acme", ProjectRoot: "/tmp/acme", DefaultEnvironment: "dev"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"acme/dev": env,
+		},
+	}
+	app := NewApp(erunUIDeps{
+		store:                  store,
+		findProjectRoot:        func() (string, string, error) { return "acme", "/tmp/acme", nil },
+		runWorkingIssueCommand: run,
+	})
+	t.Cleanup(func() { app.shutdown(context.Background()) })
+	return app
+}
+
+func TestEnvironmentWorkingIssueResolvesBranchAndTitle(t *testing.T) {
+	var calls [][]string
+	run := func(_ context.Context, dir, name string, args ...string) (string, error) {
+		calls = append(calls, append([]string{name}, args...))
+		switch {
+		case name == "git":
+			return "feature/437-sidebar-env-hover", nil
+		case name == "gh":
+			return "Sidebar environment hover", nil
+		}
+		return "", nil
+	}
+	app := workingIssueApp(t, eruncommon.EnvConfig{
+		Name:              "dev",
+		Type:              eruncommon.EnvironmentTypeLocalAgent,
+		KubernetesContext: "ctx",
+		LocalRepoPath:     t.TempDir(),
+	}, run)
+
+	got, err := app.EnvironmentWorkingIssue(uiSelection{Tenant: "acme", Environment: "dev"})
+	if err != nil {
+		t.Fatalf("EnvironmentWorkingIssue: %v", err)
+	}
+	if !got.Available {
+		t.Fatalf("expected Available for a local-agent env, got %+v", got)
+	}
+	if got.Branch != "feature/437-sidebar-env-hover" || got.IssueNumber != 437 || got.IssueTitle != "Sidebar environment hover" {
+		t.Fatalf("unexpected working issue: %+v", got)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected git + gh (2 calls), got %d: %v", len(calls), calls)
+	}
+
+	// Second call within the TTL is served from cache (no extra git/gh).
+	if _, err := app.EnvironmentWorkingIssue(uiSelection{Tenant: "acme", Environment: "dev"}); err != nil {
+		t.Fatalf("second EnvironmentWorkingIssue: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Errorf("expected cache hit on second call (still 2 calls), got %d: %v", len(calls), calls)
+	}
+}
+
+func TestEnvironmentWorkingIssueUnavailableForRemoteWorktree(t *testing.T) {
+	run := func(context.Context, string, string, ...string) (string, error) {
+		t.Fatalf("runner must not be invoked for a remote-worktree env")
+		return "", nil
+	}
+	app := workingIssueApp(t, eruncommon.EnvConfig{
+		Name:              "dev",
+		Type:              eruncommon.EnvironmentTypeRemoteAgent,
+		KubernetesContext: "ctx",
+	}, run)
+
+	got, err := app.EnvironmentWorkingIssue(uiSelection{Tenant: "acme", Environment: "dev"})
+	if err != nil {
+		t.Fatalf("EnvironmentWorkingIssue: %v", err)
+	}
+	if got.Available {
+		t.Fatalf("expected unavailable for remote-worktree env, got %+v", got)
+	}
+	if got.Reason == "" {
+		t.Errorf("expected a reason explaining why it's unavailable")
+	}
+}
+
+func TestEnvironmentWorkingIssueBranchWithoutIssue(t *testing.T) {
+	run := func(_ context.Context, _ string, name string, _ ...string) (string, error) {
+		if name == "gh" {
+			t.Fatalf("gh must not run when the branch names no issue")
+		}
+		return "main", nil
+	}
+	app := workingIssueApp(t, eruncommon.EnvConfig{
+		Name:              "dev",
+		Type:              eruncommon.EnvironmentTypeLocalAgent,
+		KubernetesContext: "ctx",
+		LocalRepoPath:     t.TempDir(),
+	}, run)
+
+	got, err := app.EnvironmentWorkingIssue(uiSelection{Tenant: "acme", Environment: "dev"})
+	if err != nil {
+		t.Fatalf("EnvironmentWorkingIssue: %v", err)
+	}
+	if !got.Available || got.Branch != "main" || got.IssueNumber != 0 || got.IssueTitle != "" {
+		t.Fatalf("expected available branch=main with no issue, got %+v", got)
+	}
+}

--- a/erun-ui/frontend/src/components/app/Sidebar.EnvHoverCard.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.EnvHoverCard.tsx
@@ -1,0 +1,218 @@
+import * as React from 'react';
+
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
+import type { UISelection, UIWorkingIssue } from '@/types';
+
+import { EnvironmentWorkingIssue } from '../../../wailsjs/go/main/App';
+
+// EnvHoverCard wraps a sidebar environment row and shows a richer hover card
+// (issue #437): the env's runtime version, the issue it's working on (current
+// branch + linked issue title), and its current activity. It replaces the
+// plain tenant/env tooltip — a multi-field card belongs in a Popover, not a
+// tooltip (erun-ui/AGENTS.md). The card opens on hover or keyboard focus of
+// the row and is positioned beside it via PopoverAnchor, so the row's own
+// click handler (open env) and edit button stay intact.
+//
+// The working-issue section is resolved lazily on first open via the
+// EnvironmentWorkingIssue binding (git + gh, cached backend-side) so the
+// branch/title lookup never runs until the user actually hovers.
+export function EnvHoverCard({
+  className,
+  tenantName,
+  environmentName,
+  selection,
+  isLocal,
+  runtimeVersion,
+  activityLabel,
+  children,
+}: {
+  className?: string;
+  tenantName: string;
+  environmentName: string;
+  selection: UISelection;
+  isLocal: boolean;
+  runtimeVersion: string;
+  activityLabel: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  const [open, setOpen] = React.useState(false);
+  const closeTimer = React.useRef(0);
+  const openNow = React.useCallback(() => {
+    window.clearTimeout(closeTimer.current);
+    setOpen(true);
+  }, []);
+  const closeSoon = React.useCallback(() => {
+    window.clearTimeout(closeTimer.current);
+    // Small grace so moving the pointer from the row onto the card doesn't
+    // close it (the card has the same enter/leave handlers).
+    closeTimer.current = window.setTimeout(() => {
+      setOpen(false);
+    }, 120);
+  }, []);
+  React.useEffect(
+    () => () => {
+      window.clearTimeout(closeTimer.current);
+    },
+    [],
+  );
+
+  const issue = useWorkingIssue(selection, open);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div
+          className={className}
+          onMouseEnter={openNow}
+          onMouseLeave={closeSoon}
+          onFocusCapture={openNow}
+          onBlurCapture={closeSoon}
+        >
+          {children}
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        side="right"
+        align="start"
+        sideOffset={8}
+        // Hover-card semantics: not a focus trap, and pointer-down outside
+        // (e.g. clicking the row to open the env) must not be swallowed.
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+        }}
+        onMouseEnter={openNow}
+        onMouseLeave={closeSoon}
+        className="w-72 p-0 text-sm"
+        role="dialog"
+        aria-label={`${tenantName} / ${environmentName} details`}
+      >
+        <div className="border-b border-border px-3 py-2">
+          <div className="flex items-center gap-1.5">
+            <span className="min-w-0 truncate font-medium">
+              {tenantName} / {environmentName}
+            </span>
+            {isLocal && (
+              <span className="flex-none rounded-[calc(var(--radius)-4px)] border border-border px-1 py-px text-[10px] font-medium uppercase leading-none tracking-wide text-muted-foreground">
+                Local
+              </span>
+            )}
+          </div>
+        </div>
+        <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1.5 px-3 py-2.5">
+          <HoverRow label="Version">
+            {runtimeVersion ? (
+              <span className="font-mono text-[12px]">{runtimeVersion}</span>
+            ) : (
+              <Muted>Not set</Muted>
+            )}
+          </HoverRow>
+          <HoverRow label="Working on">
+            <WorkingOn issue={issue} />
+          </HoverRow>
+          <HoverRow label="Activity">
+            {activityLabel ? <span>{activityLabel}</span> : <Muted>Idle</Muted>}
+          </HoverRow>
+        </dl>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function HoverRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <>
+      <dt className="text-[12px] text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 break-words text-foreground">{children}</dd>
+    </>
+  );
+}
+
+function Muted({ children }: { children: React.ReactNode }): React.ReactElement {
+  return <span className="text-muted-foreground">{children}</span>;
+}
+
+function WorkingOn({ issue }: { issue: WorkingIssueState }): React.ReactElement {
+  if (issue.status === 'idle' || issue.status === 'loading') {
+    return <Muted>Resolving…</Muted>;
+  }
+  if (issue.status === 'error') {
+    return <Muted>Unavailable</Muted>;
+  }
+  const value = issue.value;
+  if (!value.available) {
+    return <Muted>{value.reason ?? 'Not available for this environment'}</Muted>;
+  }
+  if (!value.branch) {
+    return <Muted>No branch checked out</Muted>;
+  }
+  return (
+    <div className="grid gap-0.5">
+      <span className="font-mono text-[12px]">{value.branch}</span>
+      {value.issueNumber ? (
+        <span className="text-[12px]">
+          #{value.issueNumber}
+          {value.issueTitle ? ` · ${value.issueTitle}` : ''}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+type WorkingIssueState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; value: UIWorkingIssue }
+  | { status: 'error' };
+
+// useWorkingIssue lazily resolves the env's working issue the first time the
+// card opens, then keeps the result for the row's lifetime (the backend caches
+// with a short TTL, so a re-fetch on every open would be wasteful).
+//
+// The fetch is guarded by a ref rather than the state status: putting the
+// status in the effect deps would re-run the effect when setState('loading')
+// lands, whose cleanup cancels the just-started fetch — leaving the card stuck
+// on "Resolving…". The selection is read through a ref so its per-render
+// identity churn doesn't retrigger the effect; only the env keys are deps.
+function useWorkingIssue(selection: UISelection, open: boolean): WorkingIssueState {
+  const [state, setState] = React.useState<WorkingIssueState>({ status: 'idle' });
+  const selectionRef = React.useRef(selection);
+  selectionRef.current = selection;
+  const fetched = React.useRef(false);
+  const mounted = React.useRef(true);
+  React.useEffect(
+    () => () => {
+      mounted.current = false;
+    },
+    [],
+  );
+  const { tenant, environment } = selection;
+  React.useEffect(() => {
+    if (!open || fetched.current) {
+      return;
+    }
+    // Fetch exactly once, on first open. Result is guarded by mount, not by
+    // the card's open state: closing the card mid-fetch must not drop the
+    // result (the fetched ref would then block a retry, leaving it stuck on
+    // "Resolving…"). The backend caches, so a single resolve per row is right.
+    fetched.current = true;
+    setState({ status: 'loading' });
+    void EnvironmentWorkingIssue(selectionRef.current)
+      .then((value) => {
+        if (mounted.current) {
+          setState({ status: 'loaded', value: value });
+        }
+      })
+      .catch(() => {
+        if (mounted.current) {
+          setState({ status: 'error' });
+        }
+      });
+  }, [open, tenant, environment]);
+  return state;
+}

--- a/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
@@ -9,9 +9,9 @@ import { closeEnvironment, openSelection } from '@/app/sessionThunks';
 import { envKey } from '@/app/slices/sessionsSlice';
 import { selectionKey } from '@/app/versionSuggestions';
 import { IconTooltip } from '@/components/app/IconTooltip';
+import { EnvHoverCard } from '@/components/app/Sidebar.EnvHoverCard';
 import { deriveEnvironmentRow } from '@/components/app/Sidebar.helpers';
 import { Button } from '@/components/ui/button';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import type { UISelection } from '@/types';
 
@@ -201,7 +201,7 @@ export function EnvironmentRow({
   const dispatch = useAppDispatch();
   const { selectedSelection, tenants, isOpening, runningCommand, aiBusy, isOpen, reconnecting } =
     useEnvironmentRowSelectors(tenantName, environmentName);
-  const { selected, busy, busyLabel, isLocal, selection } = deriveEnvironmentRow(
+  const { selected, busy, busyLabel, isLocal, runtimeVersion, selection } = deriveEnvironmentRow(
     tenantName,
     environmentName,
     selectedSelection,
@@ -214,36 +214,37 @@ export function EnvironmentRow({
 
   const rowLabel = `${tenantName} / ${environmentName}${isLocal ? ' (local)' : ''}`;
   return (
-    <div
+    <EnvHoverCard
       className={cn(
         'group relative mr-1 ml-1 flex h-8 items-center rounded-md pr-1.5 text-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
         selected &&
           'bg-primary text-primary-foreground shadow-sm hover:bg-primary hover:text-primary-foreground',
       )}
+      tenantName={tenantName}
+      environmentName={environmentName}
+      selection={selection}
+      isLocal={isLocal}
+      runtimeVersion={runtimeVersion}
+      activityLabel={busy ? busyLabel : ''}
     >
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            className={cn(
-              'flex h-8 min-w-0 flex-1 cursor-pointer items-center gap-1.5 border-0 bg-transparent py-0 pr-2 pl-10 text-left text-sm leading-[1.2] tracking-normal text-inherit',
-              selected ? 'font-medium' : 'font-normal',
-            )}
-            aria-label={rowLabel}
-            aria-current={selected ? 'page' : undefined}
-            onClick={() => {
-              void dispatch(openSelection(selection)).catch((error: unknown) => {
-                dispatch(showTerminalMessage(readError(error)));
-              });
-            }}
-          >
-            <span className="min-w-0 truncate">{environmentName}</span>
-            {isLocal && <LocalEnvBadge selected={selected} />}
-            {busy && <BusyRowSpinner label={busyLabel} />}
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="right">{rowLabel}</TooltipContent>
-      </Tooltip>
+      <button
+        type="button"
+        className={cn(
+          'flex h-8 min-w-0 flex-1 cursor-pointer items-center gap-1.5 border-0 bg-transparent py-0 pr-2 pl-10 text-left text-sm leading-[1.2] tracking-normal text-inherit',
+          selected ? 'font-medium' : 'font-normal',
+        )}
+        aria-label={rowLabel}
+        aria-current={selected ? 'page' : undefined}
+        onClick={() => {
+          void dispatch(openSelection(selection)).catch((error: unknown) => {
+            dispatch(showTerminalMessage(readError(error)));
+          });
+        }}
+      >
+        <span className="min-w-0 truncate">{environmentName}</span>
+        {isLocal && <LocalEnvBadge selected={selected} />}
+        {busy && <BusyRowSpinner label={busyLabel} />}
+      </button>
       {isOpen && (
         <OpenEnvDot
           tenantName={tenantName}
@@ -257,7 +258,7 @@ export function EnvironmentRow({
         selected={selected}
         selection={selection}
       />
-    </div>
+    </EnvHoverCard>
   );
 }
 

--- a/erun-ui/frontend/src/components/app/Sidebar.helpers.ts
+++ b/erun-ui/frontend/src/components/app/Sidebar.helpers.ts
@@ -51,6 +51,7 @@ export interface EnvironmentRowDerived {
   busy: boolean;
   busyLabel: string;
   isLocal: boolean;
+  runtimeVersion: string;
   selection: UISelection;
 }
 
@@ -92,6 +93,7 @@ export function deriveEnvironmentRow(
     busy,
     busyLabel,
     isLocal,
+    runtimeVersion: environment?.runtimeVersion?.trim() ?? '',
     selection: { tenant: tenantName, environment: environmentName },
   };
 }

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -24,6 +24,18 @@ export interface UIEnvironment {
   autoStart?: boolean;
 }
 
+// UIWorkingIssue mirrors the Go uiWorkingIssue read model returned by the
+// EnvironmentWorkingIssue binding: the env worktree's current branch and, when
+// the branch names an issue, its resolved title. `available` is false for
+// remote-worktree envs whose branch can't be read from the host.
+export interface UIWorkingIssue {
+  available: boolean;
+  branch?: string;
+  issueNumber?: number;
+  issueTitle?: string;
+  reason?: string;
+}
+
 export interface UITenant {
   name: string;
   defaultEnvironment?: string;

--- a/erun-ui/playwright/pages/Sidebar.ts
+++ b/erun-ui/playwright/pages/Sidebar.ts
@@ -79,6 +79,19 @@ export class Sidebar {
     return this.page.locator(`button[aria-label^="${tenant} / ${env}"]`).first();
   }
 
+  // hoverEnvironmentRow moves the pointer over the env row, which opens the
+  // env hover card (issue #437). Hovering the inner row button enters the row
+  // container that carries the open handler.
+  async hoverEnvironmentRow(tenant: string, env: string): Promise<void> {
+    await this.envRowButton(tenant, env).hover();
+  }
+
+  // envHoverCard targets the hover card popover for an env row. Its
+  // aria-label is "<tenant> / <env> details".
+  envHoverCard(tenant: string, env: string): Locator {
+    return this.page.getByRole('dialog', { name: `${tenant} / ${env} details` });
+  }
+
   // hasLocalBadge reports whether the env row renders the LOCAL pill
   // (the <span aria-label="Local environment"> inside the row button).
   async hasLocalBadge(tenant: string, env: string): Promise<boolean> {

--- a/erun-ui/playwright/tests/sidebar-env-hover.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-env-hover.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '../fixtures/erunApp.js';
+
+// Issue #437 — hovering a sidebar env row shows a hover card with the env's
+// version, the issue it's working on (branch + linked issue title), and its
+// current activity, replacing the plain tenant/env tooltip.
+//
+// The three section labels and the empty/populated states are reachable
+// against any config. The branch+title content depends on the env's worktree
+// being on the host (local-agent); the dev's real ~/.erun may only have
+// remote-worktree envs, so the spec asserts the card structure + that the
+// "Working on" section renders *some* resolved state (branch, an availability
+// reason, or "Resolving…"), not a specific branch. The populated branch+issue
+// path is verified end-to-end against a local-agent fixture in the PR.
+test.describe('sidebar env hover card', () => {
+  test('hovering an env row opens a card with version, working issue, and activity', async ({
+    app,
+  }) => {
+    const tenants = await app.sidebar.tenants();
+    expect(tenants.length).toBeGreaterThan(0);
+    const tenant = tenants[0]!;
+    const envs = await app.sidebar.environmentsFor(tenant);
+    expect(envs.length).toBeGreaterThan(0);
+    const env = envs[0]!;
+
+    await app.sidebar.hoverEnvironmentRow(tenant, env);
+
+    const card = app.sidebar.envHoverCard(tenant, env);
+    await expect(card).toBeVisible({ timeout: 6_000 });
+
+    // All three sections are present.
+    await expect(card.getByText('Version', { exact: true })).toBeVisible();
+    await expect(card.getByText('Working on', { exact: true })).toBeVisible();
+    await expect(card.getByText('Activity', { exact: true })).toBeVisible();
+
+    // The working-issue lookup resolves to a non-empty state (a branch, an
+    // availability reason for remote envs, or the transient loading text) —
+    // never a blank.
+    await expect
+      .poll(async () => (await card.locator('dd').nth(1).textContent())?.trim() ?? '')
+      .not.toBe('');
+  });
+});

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -32,6 +32,19 @@ type uiEnvironment struct {
 	AutoStart         *bool  `json:"autoStart,omitempty"`
 }
 
+// uiWorkingIssue is the sidebar hover card's "what is this env working on"
+// read model: the env worktree's current git branch and, when the branch
+// names an issue (feature/<n>-… or bug/<n>-…), the resolved issue title.
+// Empty fields render as honest empty states; Available is false when the
+// worktree isn't reachable from the host (remote-agent / runtime envs).
+type uiWorkingIssue struct {
+	Available   bool   `json:"available"`
+	Branch      string `json:"branch,omitempty"`
+	IssueNumber int    `json:"issueNumber,omitempty"`
+	IssueTitle  string `json:"issueTitle,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+}
+
 type uiSelection struct {
 	Tenant            string `json:"tenant"`
 	Environment       string `json:"environment"`
@@ -180,27 +193,27 @@ type uiPortStatus struct {
 }
 
 type uiEnvironmentConfig struct {
-	Name                 string                       `json:"name"`
-	Type                 eruncommon.EnvironmentType   `json:"type,omitempty"`
-	LocalRepoPath        string                       `json:"localRepoPath,omitempty"`
-	RepoPath             string                       `json:"repoPath"`
-	KubernetesContext    string                       `json:"kubernetesContext"`
-	ContainerRegistry    string                  `json:"containerRegistry"`
-	CloudProviderAlias   string                  `json:"cloudProviderAlias"`
-	CloudProviderAliases []string                `json:"cloudProviderAliases,omitempty"`
-	CloudContext         *uiCloudContextStatus   `json:"cloudContext,omitempty"`
-	RuntimeVersion       string                  `json:"runtimeVersion"`
-	RuntimePod           uiRuntimePodConfig      `json:"runtimePod"`
-	SSHD                 uiSSHDConfig            `json:"sshd"`
-	Idle                 uiIdleConfig            `json:"idle"`
-	Claude               uiClaudeConfig          `json:"claude"`
-	ClaudeDefaults       uiClaudeDefaults        `json:"claudeDefaults"`
-	AITool               string                  `json:"aiTool,omitempty"`
-	LocalPorts            uiEnvironmentLocalPorts `json:"localPorts"`
-	Remote                bool                    `json:"remote"`
-	Snapshot              bool                    `json:"snapshot"`
-	AutoStart             *bool                   `json:"autoStart,omitempty"`
-	RemoteHostCredentials bool                    `json:"remoteHostCredentials"`
+	Name                  string                     `json:"name"`
+	Type                  eruncommon.EnvironmentType `json:"type,omitempty"`
+	LocalRepoPath         string                     `json:"localRepoPath,omitempty"`
+	RepoPath              string                     `json:"repoPath"`
+	KubernetesContext     string                     `json:"kubernetesContext"`
+	ContainerRegistry     string                     `json:"containerRegistry"`
+	CloudProviderAlias    string                     `json:"cloudProviderAlias"`
+	CloudProviderAliases  []string                   `json:"cloudProviderAliases,omitempty"`
+	CloudContext          *uiCloudContextStatus      `json:"cloudContext,omitempty"`
+	RuntimeVersion        string                     `json:"runtimeVersion"`
+	RuntimePod            uiRuntimePodConfig         `json:"runtimePod"`
+	SSHD                  uiSSHDConfig               `json:"sshd"`
+	Idle                  uiIdleConfig               `json:"idle"`
+	Claude                uiClaudeConfig             `json:"claude"`
+	ClaudeDefaults        uiClaudeDefaults           `json:"claudeDefaults"`
+	AITool                string                     `json:"aiTool,omitempty"`
+	LocalPorts            uiEnvironmentLocalPorts    `json:"localPorts"`
+	Remote                bool                       `json:"remote"`
+	Snapshot              bool                       `json:"snapshot"`
+	AutoStart             *bool                      `json:"autoStart,omitempty"`
+	RemoteHostCredentials bool                       `json:"remoteHostCredentials"`
 }
 
 type uiClaudeConfig struct {
@@ -393,9 +406,9 @@ type uiIdleStatus struct {
 	// grace-period warning and the user has SecondsUntilForcedStop
 	// seconds to cancel or resume activity before the real
 	// ec2:StopInstances fires. Empty when no auto-stop is pending.
-	StopPendingSince        string `json:"stopPendingSince,omitempty"`
-	SecondsUntilForcedStop  int64  `json:"secondsUntilForcedStop,omitempty"`
-	GracePeriodSeconds      int64  `json:"gracePeriodSeconds,omitempty"`
+	StopPendingSince       string `json:"stopPendingSince,omitempty"`
+	SecondsUntilForcedStop int64  `json:"secondsUntilForcedStop,omitempty"`
+	GracePeriodSeconds     int64  `json:"gracePeriodSeconds,omitempty"`
 }
 
 // uiLastStopEvent describes the most recent automatic stop of a
@@ -456,7 +469,7 @@ type uiIdleMarker struct {
 // leave Clients nil. Bytes and SecondsAgo are pre-formatted at the
 // boundary so the React tooltip can render without computing them.
 type uiIdleMarkerClient struct {
-	Address      string `json:"address"`
-	Bytes        int64  `json:"bytes,omitempty"`
-	SecondsAgo   int64  `json:"secondsAgo,omitempty"`
+	Address    string `json:"address"`
+	Bytes      int64  `json:"bytes,omitempty"`
+	SecondsAgo int64  `json:"secondsAgo,omitempty"`
 }


### PR DESCRIPTION
Closes #437

## Summary
Hovering a sidebar environment row showed only a plain `tenant / environment` tooltip. This replaces it with a richer **hover card** (built on the existing Popover primitive — **no new dependency**) showing, at a glance:

- **Version** — the env's resolved runtime version (from sidebar state).
- **Working on** — the env worktree's current git branch and, when the branch names an issue (`feature/<n>-` / `bug/<n>-`), the linked issue title.
- **Activity** — what the env is doing right now (running command / AI activity), from existing state.

## Backend
New `EnvironmentWorkingIssue` Wails method (`erun-ui`) resolves the working issue for envs whose worktree is on the host (**local-agent**): reads the branch with `git`, parses the issue number, resolves the title with `gh` (run in the worktree so `gh` picks the repo from origin). Cached per env with a short TTL. **Remote-agent / runtime** envs keep their worktree in the pod → the card shows an honest "worktree lives in the pod" empty state rather than reaching into the pod. `git`/`gh` failures degrade gracefully (branch-only, or "No branch checked out").

The working issue is fetched **lazily on first hover**, fire-once and mount-guarded so closing the card mid-fetch can't strand it on "Resolving…".

## Validation
- `erun-ui` `go test ./...` green — new tests cover the branch→issue truth table, the local-agent resolve (branch + issue + title), the per-env cache, the remote-worktree unavailable path, and the branch-without-issue path.
- frontend `yarn typecheck && lint && format:check && build` clean.
- **Playwright**: `tests/sidebar-env-hover.spec.ts` asserts the card opens with Version / Working on / Activity sections and a non-empty working-issue state.
- **End-to-end verified** against a local-agent fixture pointed at this repo: the card rendered branch `feature/437-sidebar-env-hover`, `#437`, and the real `gh`-resolved title. That verification **caught and fixed a hook bug** that would have stuck the card on "Resolving…" in production (the lazy-fetch effect cancelled itself via an unstable `selection` dep + status-dep re-run).
- Wails binding regenerated via `wails generate module` (`frontend/wailsjs` is gitignored, regenerated at build time).

**Pre-existing, unrelated:** `tests/sidebar.spec.ts` "opening an environment surfaces status feedback" is flaky against the dev's real `~/.erun` (the env opens too fast for the transient "Opening…" status to be asserted) — **confirmed failing on main's binary too**; #442's hermetic fixture is the fix.

## UX Impact Review Checklist (erun-ui)
1. **Affected path:** sidebar env-row hover/focus → `EnvHoverCard` → `EnvironmentWorkingIssue` binding.
2. **Sequence:** hover row → card opens beside it → Version + Activity render from state immediately; Working on resolves lazily (Resolving… → branch/issue/title or empty state).
3. **State/affordance:** no `AppState` mutation; the row's click (open env) and edit button are unchanged (`PopoverAnchor`, not a click trigger).
4. **Visibility of system status (#1):** surfaces version/issue/activity at a glance.
5. **Success/failure feedback:** empty states are explicit (Not set / No branch checked out / worktree lives in the pod), never blank.
6. **Consistency (#4):** reuses the LOCAL badge + activity vocabulary already in the row.
7. **Heuristic pass:** recognition over recall (issue title shown, not just a branch); tooltips reserved for short text so a multi-field card uses a Popover (erun-ui/AGENTS.md); keyboard-reachable (opens on focus of the row button); others n/a.
8. **Playwright coverage:** `tests/sidebar-env-hover.spec.ts`.

## Docs
`erun-docs/docs/desktop/overview.md` Control-panel section gains an "Environment details on hover" bullet (Operator-facing). No Agent reference needed — `EnvironmentWorkingIssue` is a desktop-internal binding, not a CLI/MCP command. `yarn build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)