### PR TITLE
Make #324 IDE real-run integration scenarios pass on non-darwin hosts

### DIFF
--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -5,6 +5,7 @@ package fixture
 
 import (
 	"fmt"
+	"net"
 	"os"
 	osexec "os/exec"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/sophium/erun/erun-integration/internal/env"
 )
@@ -674,19 +676,19 @@ func StubKubectlDeployed(t testing.TB, stubsDir string, spec KubectlDeployedStub
 		`done`,
 		`if [ "$is_port_forward" = "1" ] && [ -n "$local_port" ]; then`,
 		// Production-side reachability checks differ by service:
-		//   SSH expects the first 4 bytes to be "SSH-"
-		//   MCP expects an HTTP response on POST /mcp
-		//   API expects an HTTP response on /healthz
-		// The simulator sends a per-port banner that satisfies the SSH
-		// check; MCP/API checks fall back to bare-TCP-reachable on a
-		// 200ms timeout, which a plain accept-and-close already passes.
+		//   SSH expects the server to greet with a "SSH-" prefix
+		//   MCP expects a successful HTTP response on GET /mcp
+		//   API expects a 2xx HTTP response on GET /healthz
+		// portsim writes the per-port banner to satisfy the SSH check; for
+		// the MCP/API ports it answers the probe's HTTP request with a 200.
+		// Only the SSH port needs a banner here.
 		`  banner=""`,
 		`  if [ "$local_port" = "` + strconv.Itoa(spec.SSHPort) + `" ]; then`,
 		`    banner="SSH-2.0-erun-portsim\r\n"`,
 		`  fi`,
 		`  ` + portsim + ` --port "$local_port" --banner "$banner" >/dev/null 2>&1 &`,
 		`  pid=$!`,
-		`  printf '%s\n' "$pid" >> '` + pidFile + `'`,
+		`  printf '%s %s\n' "$local_port" "$pid" >> '` + pidFile + `'`,
 		`  # Stay alive while the simulator runs so production code that`,
 		`  # treats the kubectl process as the port-forward owner sees it`,
 		`  # as live. Block until the simulator exits.`,
@@ -710,20 +712,44 @@ func StubKubectlDeployed(t testing.TB, stubsDir string, spec KubectlDeployedStub
 			return
 		}
 		for _, line := range strings.Split(string(raw), "\n") {
-			line = strings.TrimSpace(line)
-			if line == "" {
+			fields := strings.Fields(line)
+			if len(fields) != 2 {
 				continue
 			}
-			pid, err := strconv.Atoi(line)
-			if err != nil || pid <= 0 {
+			port, portErr := strconv.Atoi(fields[0])
+			pid, pidErr := strconv.Atoi(fields[1])
+			if pidErr != nil || pid <= 0 {
 				continue
 			}
 			if proc, err := os.FindProcess(pid); err == nil {
 				_ = proc.Kill()
 			}
+			// SIGKILL is async: block until the simulator's listener is
+			// actually released so a sibling real-run scenario reusing the
+			// same fixed ports does not trip its port-busy guard on this
+			// scenario's teardown.
+			if portErr == nil && port > 0 {
+				waitForPortClosed(port, 3*time.Second)
+			}
 		}
 	})
 	return StubEnv(stubsDir, "kubectl")
+}
+
+// waitForPortClosed blocks until nothing accepts a TCP connection on
+// 127.0.0.1:port, or the timeout elapses. Used by StubKubectlDeployed's
+// teardown so a killed port-forward simulator's listener is fully gone before
+// the next scenario probes the same fixed port.
+func waitForPortClosed(port int, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 100*time.Millisecond)
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 

--- a/erun-integration/internal/fixture/portsim/main.go
+++ b/erun-integration/internal/fixture/portsim/main.go
@@ -1,10 +1,17 @@
 // Command portsim is a stand-in for `kubectl port-forward` in integration
-// tests. It listens on the requested local TCP port and accepts (then
-// immediately closes) any inbound connections so production code's
-// "is the local port reachable?" polling succeeds. It runs until killed,
-// matching the long-lived behavior of a real port-forward.
+// tests. It listens on the requested local TCP port until killed, mirroring
+// the long-lived behavior of a real port-forward, and answers production's
+// reachability probes on each accepted connection:
 //
-// Usage: portsim --port PORT
+//   - With --banner set (the sshd port), it writes the banner first so the
+//     SSH probe — which reads the server greeting and checks for a "SSH-"
+//     prefix — succeeds.
+//   - Without a banner (the MCP and API ports), it reads the probe's HTTP
+//     request and replies with a minimal "200 OK". The MCP probe (GET /mcp)
+//     and the API probe (GET /healthz, which requires a 2xx) both need a real
+//     HTTP response, so a bare accept-and-close does not satisfy them.
+//
+// Usage: portsim --port PORT [--banner "SSH-2.0-test\r\n"]
 package main
 
 import (
@@ -15,6 +22,7 @@ import (
 	"os/signal"
 	"strconv"
 	"syscall"
+	"time"
 )
 
 func main() {
@@ -45,11 +53,29 @@ func main() {
 		if err != nil {
 			return
 		}
-		if len(bannerBytes) > 0 {
-			_, _ = conn.Write(bannerBytes)
-		}
-		_ = conn.Close()
+		go serve(conn, bannerBytes)
 	}
+}
+
+// serve answers a single probe connection. A real kubectl port-forward is
+// opaque TCP, but production's reachability checks are protocol-specific, and
+// the caller signals which protocol a port speaks by whether it sets a banner:
+//
+//   - banner set → SSH: the probe reads the server greeting and checks for a
+//     "SSH-" prefix, so we write the banner first (server-speaks-first).
+//   - no banner → HTTP (MCP /mcp, API /healthz): the probe issues an HTTP
+//     request and requires a successful response, so we read the request and
+//     reply with a minimal 200. We drain the request before closing so the
+//     client reads the full response without a connection-reset race.
+func serve(conn net.Conn, bannerBytes []byte) {
+	defer func() { _ = conn.Close() }()
+	if len(bannerBytes) > 0 {
+		_, _ = conn.Write(bannerBytes)
+		return
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	_, _ = conn.Read(make([]byte, 4096))
+	_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"))
 }
 
 // decodeBanner unescapes \r and \n so callers can pass "SSH-2.0-test\r\n"

--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -331,6 +331,11 @@ func TestOpen(t *testing.T) {
 		fixture.StubBinaryWithScript(t, stubsDir, "open",
 			`printf '%s\n' "$*" > '`+ideLog+`'`+"\n"+`exit 0`+"\n")
 		envVars = append(envVars, "PATH="+stubsDir+":"+os.Getenv("PATH"))
+		// Pin darwin so the IDE launcher resolves to the stubbed macOS
+		// `open` command. On a Linux host production calls xdg-open, which
+		// this scenario does not stub. (erun-integration/AGENTS.md —
+		// platform-dependent goldens.)
+		envVars = append(envVars, "ERUN_HOST_OS_OVERRIDE=darwin")
 		result := erun.Run(t, []string{"open", "team", "dev", "--vscode", "--no-alias-prompt"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
@@ -390,6 +395,11 @@ func TestOpen(t *testing.T) {
 		fixture.StubBinaryWithScript(t, stubsDir, "open",
 			`printf '%s\n' "$*" >> '`+ideLog+`'`+"\n"+`exit 0`+"\n")
 		envVars = append(envVars, "PATH="+stubsDir+":"+os.Getenv("PATH"))
+		// Pin darwin: this scenario seeds the macOS JetBrains options dir
+		// above and asserts the `open -a 'IntelliJ IDEA'` bootstrap, both
+		// macOS-shaped. Without the pin a Linux host resolves a different
+		// options dir and launcher and the writers never fire.
+		envVars = append(envVars, "ERUN_HOST_OS_OVERRIDE=darwin")
 		result := erun.Run(t, []string{"open", "team", "dev", "--intellij", "--no-alias-prompt"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)


### PR DESCRIPTION
## Problem

`make integration-test` was green on darwin but **red on Linux/CI**. Two committed real-run scenarios in `erun-integration/open_test.go` (added under #324 to cover the IDE-launcher / `jetbrainsconfig` / `sshknownhosts` real-run paths) failed:

- `TestOpen/vscode_real_run_writes_known_hosts_and_launches_ide`
- `TestOpen/intellij_real_run_writes_jetbrains_config_and_launches_ide`

Both with `timed out waiting for MCP port-forward on 127.0.0.1:17000` (exit 1). The suite has had no CI runner (see #324), so the Linux-red went unnoticed.

## Root causes & fixes

1. **portsim didn't answer reachability probes.** The `kubectl port-forward` stand-in (`internal/fixture/portsim`) only accepted and immediately closed connections. Production's reachability checks are protocol-specific — the MCP probe issues `GET /mcp`, the API probe `GET /healthz` (requires 2xx) — so accept-and-close never satisfied them. portsim now serves each accepted connection: it writes the SSH banner for the sshd port (server-speaks-first), or reads the HTTP request and replies `200 OK` for the MCP/API ports.
2. **IDE launcher is host-dependent.** Past the port-forward, the launcher resolves to `xdg-open` on Linux (unstubbed) instead of the stubbed macOS `open`. The two IDE real-run scenarios now pin `ERUN_HOST_OS_OVERRIDE=darwin` (per `erun-integration/AGENTS.md` — platform-dependent goldens).
3. **Port-busy flakiness on teardown.** `StubKubectlDeployed` recorded only pids; SIGKILL is async, so a sibling scenario reusing the same fixed ports (17000/17022) could trip its port-busy guard before the previous listener was released. Teardown now records `port pid` pairs and blocks until the port is released (`waitForPortClosed`) after SIGKILL.

## Scope

Test-harness only — no production code, no CLI/MCP surface, no goldens changed. Docs exempt (no public behaviour change). This fixes the Linux-red in #324's scenarios; it does **not** complete #324 (coverage is 59.2% vs the ≥80% target, and the CI workflow / production trace-lifting remain).

## Verification

- `make integration-test` green: **coverage 59.2% (>= 55.0%)**, full suite `ok`.
- Counterfactual proven: stashed the fix and ran both scenarios — both fail with the MCP port-forward timeout; with the fix both pass.

Closes #467
Refs #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)