### PR TITLE
AI tab Claude effort level (#469) + stop persisting a phantom runtime version on cached deploys

### DIFF
--- a/erun-common/claude.go
+++ b/erun-common/claude.go
@@ -27,10 +27,19 @@ type EnvironmentClaudeConfig struct {
 	UseBedrock      *bool    `yaml:"usebedrock,omitempty" json:"useBedrock,omitempty"`
 	Models          []string `yaml:"models,omitempty" json:"models,omitempty"`
 	MaxOutputTokens *int     `yaml:"maxoutputtokens,omitempty" json:"maxOutputTokens,omitempty"`
+	// Effort is the per-env Claude Code session effort level (one of
+	// low|medium|high|xhigh|max) applied as `claude --effort` when the desktop
+	// launches the env's AI tab. Unset means the desktop falls back to the
+	// default (max). The level only influences the desktop AI-tab launch, so
+	// its validation, default, and resolution live in erun-ui; this shared
+	// field exists so the value round-trips through the same env config the UI
+	// reads and writes.
+	Effort *string `yaml:"effort,omitempty" json:"effort,omitempty"`
 }
 
 func (c EnvironmentClaudeConfig) IsZero() bool {
-	return c.UseMantle == nil && c.UseBedrock == nil && len(c.Models) == 0 && c.MaxOutputTokens == nil
+	return c.UseMantle == nil && c.UseBedrock == nil && len(c.Models) == 0 &&
+		c.MaxOutputTokens == nil && c.Effort == nil
 }
 
 func (c EnvironmentClaudeConfig) NormalizedModels() []string {

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -214,6 +214,15 @@ type EnvConfigSaver func(tenant string, config EnvConfig) error
 // the env config, the env config is rewritten with the deployed pair.
 // Component-only deploys (no runtime chart in the spec list) are
 // no-ops, as are dry-runs and calls with a nil saver.
+//
+// A runtime chart whose helm upgrade was skipped (SkipHelm: every image
+// promoted from the fingerprint cache, so nothing was rebuilt, pushed, or
+// rolled out) is also a no-op. Its Deploy.Version is a freshly minted
+// snapshot timestamp that was never pushed to the registry and is not what
+// the cluster is running, so persisting it would leave the env config — and
+// the desktop runtime dialog — pointing at a phantom version the deploy
+// picker can never offer (it gates on registry presence). Leave
+// RuntimeVersion at the last version that was actually rolled out.
 func PersistRuntimeVersionFromDeploySpecs(ctx Context, specs []DeploySpec, save EnvConfigSaver) error {
 	if save == nil || ctx.DryRun || len(specs) == 0 {
 		return nil
@@ -221,6 +230,9 @@ func PersistRuntimeVersionFromDeploySpecs(ctx Context, specs []DeploySpec, save 
 	for _, spec := range specs {
 		if !specDeploysRuntimeChart(spec) {
 			continue
+		}
+		if spec.SkipHelm {
+			return nil
 		}
 		version := strings.TrimSpace(spec.Deploy.Version)
 		if version == "" {

--- a/erun-common/deploy_persist_runtime_version_test.go
+++ b/erun-common/deploy_persist_runtime_version_test.go
@@ -1,0 +1,81 @@
+package eruncommon
+
+import "testing"
+
+// TestPersistRuntimeVersionFromDeploySpecs pins the contract that the env
+// config's runtime version is only advanced when the runtime chart was
+// actually rolled out. A no-change `erun deploy` mints a fresh snapshot
+// timestamp but promotes every image from the fingerprint cache (SkipHelm:
+// nothing rebuilt, pushed, or helm-upgraded); recording that version left the
+// env config — and the desktop runtime dialog — pointing at a tag that was
+// never pushed to the registry and is not running, which the deploy picker
+// can never offer because it gates on registry presence.
+//
+// Persist is a real, non-dry-run side effect (it early-returns on DryRun), so
+// it is unreachable from the dry-run integration binary; this white-box unit
+// test is the contract owner for the branch.
+func TestPersistRuntimeVersionFromDeploySpecs(t *testing.T) {
+	const tenant = "erun"
+	const version = "1.0.86-snapshot-20260608124610"
+	const registry = "ghcr.io/sophium"
+
+	runtimeSpec := func(skipHelm bool) DeploySpec {
+		return DeploySpec{
+			Target: OpenResult{Tenant: tenant, EnvConfig: EnvConfig{Name: "local"}},
+			Deploy: HelmDeploySpec{
+				ReleaseName:       RuntimeReleaseName(tenant),
+				Version:           version,
+				ContainerRegistry: registry,
+			},
+			SkipHelm: skipHelm,
+		}
+	}
+
+	t.Run("rolled-out deploy persists the version and registry", func(t *testing.T) {
+		var savedTenant string
+		var saved *EnvConfig
+		save := func(tn string, cfg EnvConfig) error {
+			savedTenant = tn
+			c := cfg
+			saved = &c
+			return nil
+		}
+		if err := PersistRuntimeVersionFromDeploySpecs(Context{}, []DeploySpec{runtimeSpec(false)}, save); err != nil {
+			t.Fatalf("persist: %v", err)
+		}
+		if saved == nil {
+			t.Fatalf("expected env config to be saved after a real rollout")
+		}
+		if savedTenant != tenant {
+			t.Fatalf("saved tenant = %q, want %q", savedTenant, tenant)
+		}
+		if saved.RuntimeVersion != version {
+			t.Fatalf("RuntimeVersion = %q, want %q", saved.RuntimeVersion, version)
+		}
+		if saved.RuntimeRegistry != registry {
+			t.Fatalf("RuntimeRegistry = %q, want %q", saved.RuntimeRegistry, registry)
+		}
+	})
+
+	t.Run("cached no-op deploy (SkipHelm) does not persist a phantom version", func(t *testing.T) {
+		saved := false
+		save := func(string, EnvConfig) error { saved = true; return nil }
+		if err := PersistRuntimeVersionFromDeploySpecs(Context{}, []DeploySpec{runtimeSpec(true)}, save); err != nil {
+			t.Fatalf("persist: %v", err)
+		}
+		if saved {
+			t.Fatalf("a SkipHelm deploy rolled nothing out; it must not persist a runtime version")
+		}
+	})
+
+	t.Run("dry-run never persists", func(t *testing.T) {
+		saved := false
+		save := func(string, EnvConfig) error { saved = true; return nil }
+		if err := PersistRuntimeVersionFromDeploySpecs(Context{DryRun: true}, []DeploySpec{runtimeSpec(false)}, save); err != nil {
+			t.Fatalf("persist: %v", err)
+		}
+		if saved {
+			t.Fatalf("dry-run must not persist")
+		}
+	})
+}

--- a/erun-common/deploy_persist_runtime_version_test.go
+++ b/erun-common/deploy_persist_runtime_version_test.go
@@ -1,6 +1,9 @@
 package eruncommon
 
-import "testing"
+import (
+	"io"
+	"testing"
+)
 
 // TestPersistRuntimeVersionFromDeploySpecs pins the contract that the env
 // config's runtime version is only advanced when the runtime chart was
@@ -78,4 +81,49 @@ func TestPersistRuntimeVersionFromDeploySpecs(t *testing.T) {
 			t.Fatalf("dry-run must not persist")
 		}
 	})
+}
+
+// TestCachedDeployRunThenPersistDoesNothing drives the real RunDeploySpecs
+// orchestration for a cached runtime chart (SkipHelm: every image promoted
+// from the fingerprint cache) and then PersistRuntimeVersionFromDeploySpecs.
+// It proves the end-to-end cached-deploy path: RunDeploySpec short-circuits
+// before building, pushing, or running helm — so nothing reaches the registry
+// or rolls the pod — and the freshly minted version is not persisted, so the
+// env config can't end up pointing at a tag that was never pushed. This is the
+// exact sequence the CLI deploy command runs (RunDeploySpecs then persist).
+func TestCachedDeployRunThenPersistDoesNothing(t *testing.T) {
+	const tenant = "erun"
+	ctx := Context{Logger: NewLoggerWithWriters(VerbosityInfo, io.Discard, io.Discard)}
+
+	spec := DeploySpec{
+		Target:        OpenResult{Tenant: tenant, EnvConfig: EnvConfig{Name: "local"}},
+		DeployContext: KubernetesDeployContext{ComponentName: RuntimeReleaseName(tenant)},
+		Deploy: HelmDeploySpec{
+			ReleaseName:       RuntimeReleaseName(tenant),
+			Version:           "1.0.86-snapshot-20260608124610",
+			ContainerRegistry: "ghcr.io/sophium",
+		},
+		SkipHelm: true,
+	}
+
+	built, pushed, helmed, saved := false, false, false, false
+	build := func(DockerBuildSpec, io.Writer, io.Writer) error { built = true; return nil }
+	push := func(Context, DockerPushSpec) error { pushed = true; return nil }
+	deploy := func(HelmDeployParams) error { helmed = true; return nil }
+	save := func(string, EnvConfig) error { saved = true; return nil }
+
+	specs := []DeploySpec{spec}
+	if err := RunDeploySpecs(ctx, specs, build, push, deploy); err != nil {
+		t.Fatalf("RunDeploySpecs: %v", err)
+	}
+	if err := PersistRuntimeVersionFromDeploySpecs(ctx, specs, save); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	if built || pushed || helmed {
+		t.Fatalf("cached (SkipHelm) deploy must not build/push/helm: built=%v pushed=%v helmed=%v", built, pushed, helmed)
+	}
+	if saved {
+		t.Fatalf("cached deploy rolled nothing out; it must not persist a runtime version")
+	}
 }

--- a/erun-docs/docs/desktop/overview.md
+++ b/erun-docs/docs/desktop/overview.md
@@ -32,6 +32,8 @@ The desktop is equally useful as a clean development surface for human-driven wo
 
 By default, **the Agent runs inside the env** — the runtime pod ships the configured Agent's CLI (`claude`, `codex`, …) pre-wired against the in-pod MCP loopback. The desktop's AI panel surfaces it; any terminal inside the pod can launch it directly.
 
+For a Claude env, the AI tab of the env settings dialog has an **Effort** control — how hard Claude thinks per turn, from low through max. New envs default to the highest level (max); the desktop applies your choice when it opens the env's Claude session. For the exact levels and how the value resolves, see [Agent reference · Configuration](/reference/configuration).
+
 When you do want a laptop-side Agent in addition, the env has two endpoints on the runtime pod — SSH and [MCP](/mcp/overview) — and both accept any client.
 
 - IDEs (VS Code, IntelliJ, Cursor, Zed, …) attach over SSH.

--- a/erun-docs/docs/reference/configuration.md
+++ b/erun-docs/docs/reference/configuration.md
@@ -79,6 +79,7 @@ One per environment. This is the most-edited file.
 | `claude.usebedrock` | `*bool` | chart (`CLAUDE_CODE_USE_BEDROCK`) | Route Claude through AWS Bedrock. |
 | `claude.models[]` | list | chart (`ERUN_CLAUDE_AVAILABLE_MODELS`) | Allow-list of Claude models for in-pod tools. |
 | `claude.maxoutputtokens` | `*int` | chart (`CLAUDE_CODE_MAX_OUTPUT_TOKENS`) | Max output tokens per Claude response. |
+| `claude.effort` | `*string` | desktop AI launcher (`claude --effort`) | Effort level for the env's Claude AI tab, one of `low`, `medium`, `high`, `xhigh`, `max`. Unset or invalid → `max`. Only the default Claude launch is affected; a non-`claude` `aitool` or a Claude launch the Operator wrote with explicit flags is left untouched. |
 | `aitool` | string | desktop AI launcher, runtime entrypoint | Which Agent is the default for this env (`claude`, `codex`, …). |
 | `remote` | bool | helm chart (worktree storage selection), build path resolution | When true, the runtime pod uses a PVC-backed checkout; when false, the host project root is mounted via `hostPath`. ([Planned removal — subsumed by `type`.](#planned-changes)) |
 | `snapshot` | `*bool` | `erun build`, `erun push`, `erun deploy`, `erun open` | Marks this env as agent-mode: when `true`, builds happen here and produce snapshot-tagged artefacts; when `false`, the env only receives deploys. ([Planned removal — subsumed by `type`.](#planned-changes)) |

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -3291,8 +3291,10 @@ func TestStartAISessionRunsErunOpenWithClaudeInitialInput(t *testing.T) {
 	}
 	// The env AI tab pipes the cwd-guarded Claude resume so it continues the
 	// env project's Claude Code session rather than starting fresh (issue
-	// #451). The guard runs in the env repo cwd inside `erun open`.
-	wantInput := claudeContinueGuard + "\n"
+	// #451). The guard runs in the env repo cwd inside `erun open`. With no
+	// per-env Effort configured it launches at the default level (max) via
+	// --effort (issue #469).
+	wantInput := claudeLaunchGuard(defaultClaudeEffort) + "\n"
 	if string(started.InitialInput) != wantInput {
 		t.Fatalf("expected initial input %q, got %q", wantInput, string(started.InitialInput))
 	}

--- a/erun-ui/contribute_app_test.go
+++ b/erun-ui/contribute_app_test.go
@@ -13,6 +13,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
 )
 
 // Tests in this file pin the respawn-on-early-exit contract that
@@ -283,8 +285,13 @@ func TestBuildContributePreludeCommandResumesCloneSession(t *testing.T) {
 	if !strings.Contains(withAI, `cd "$HOME/git/erun"`) {
 		t.Fatalf("prelude must cd to the clone before launching the AI tool, got %q", withAI)
 	}
-	if !strings.HasSuffix(withAI, claudeContinueGuard+"\n") {
-		t.Fatalf("contribute AI prelude must end with the cwd-guarded claude resume, got %q", withAI)
+	// The contribute tab has no per-env config, so it launches at the default
+	// effort (max) (issue #469).
+	if !strings.HasSuffix(withAI, claudeLaunchGuard(defaultClaudeEffort)+"\n") {
+		t.Fatalf("contribute AI prelude must end with the cwd-guarded claude resume at default effort, got %q", withAI)
+	}
+	if !strings.Contains(withAI, "--effort max") {
+		t.Fatalf("contribute AI prelude must inject --effort max, got %q", withAI)
 	}
 
 	// A non-claude tool launches verbatim (no resume injection), mirroring the
@@ -306,18 +313,61 @@ func TestBuildContributePreludeCommandResumesCloneSession(t *testing.T) {
 // TestAILaunchCommandGuardsClaudeOnly documents the bypass rules the desktop
 // shares with claude-wrapper.sh: a bare claude launch is wrapped in the
 // cwd-guarded resume; an explicit-flag claude invocation or a different tool
-// launches verbatim.
+// launches verbatim. The default-claude path injects --effort into both guard
+// branches; non-claude and explicit-flag launches are never altered (#469).
 func TestAILaunchCommandGuardsClaudeOnly(t *testing.T) {
-	if got := aiLaunchCommand(""); got != claudeContinueGuard {
+	wantGuard := claudeLaunchGuard("high")
+	if got := aiLaunchCommand("", "high"); got != wantGuard {
 		t.Fatalf("default (claude) must use the resume guard, got %q", got)
 	}
-	if got := aiLaunchCommand("claude"); got != claudeContinueGuard {
+	if got := aiLaunchCommand("claude", "high"); got != wantGuard {
 		t.Fatalf("explicit claude must use the resume guard, got %q", got)
 	}
-	if got := aiLaunchCommand("codex"); got != "codex" {
+	// --effort is injected into both branches of the cwd guard.
+	if strings.Count(wantGuard, "--effort high") != 2 {
+		t.Fatalf("guard must inject --effort high into both branches, got %q", wantGuard)
+	}
+	if !strings.Contains(wantGuard, "claude --continue --effort high") ||
+		!strings.Contains(wantGuard, "else claude --effort high") {
+		t.Fatalf("guard must inject --effort after --continue and in the bare branch, got %q", wantGuard)
+	}
+	// A configured non-claude tool and explicit-flag claude launch verbatim,
+	// with no --effort injected.
+	if got := aiLaunchCommand("codex", "max"); got != "codex" {
 		t.Fatalf("codex must launch verbatim, got %q", got)
 	}
-	if got := aiLaunchCommand("claude --resume"); got != "claude --resume" {
+	if got := aiLaunchCommand("claude --resume", "max"); got != "claude --resume" {
 		t.Fatalf("claude with explicit flags must launch verbatim, got %q", got)
+	}
+}
+
+// TestResolveClaudeEffort covers the per-env effort resolution the env AI tab
+// applies: a valid configured level is used; unset, blank, and invalid values
+// fall back to the default (max) so the launch never carries a bad flag (#469).
+func TestResolveClaudeEffort(t *testing.T) {
+	level := func(v string) *string { return &v }
+	cases := []struct {
+		name   string
+		config eruncommon.EnvironmentClaudeConfig
+		want   string
+	}{
+		{"unset falls back to max", eruncommon.EnvironmentClaudeConfig{}, "max"},
+		{"valid level is used", eruncommon.EnvironmentClaudeConfig{Effort: level("low")}, "low"},
+		{"surrounding space is trimmed", eruncommon.EnvironmentClaudeConfig{Effort: level("  high  ")}, "high"},
+		{"blank falls back to max", eruncommon.EnvironmentClaudeConfig{Effort: level("  ")}, "max"},
+		{"invalid falls back to max", eruncommon.EnvironmentClaudeConfig{Effort: level("turbo")}, "max"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveClaudeEffort(tc.config); got != tc.want {
+				t.Fatalf("resolveClaudeEffort(%+v) = %q, want %q", tc.config, got, tc.want)
+			}
+		})
+	}
+
+	// An invalid effort passed straight to the guard injects no flag, so a bad
+	// persisted value can never reach the shell as `--effort turbo`.
+	if guard := claudeLaunchGuard("turbo"); strings.Contains(guard, "--effort") {
+		t.Fatalf("invalid effort must not be injected, got %q", guard)
 	}
 }

--- a/erun-ui/contribute_sessions.go
+++ b/erun-ui/contribute_sessions.go
@@ -159,8 +159,10 @@ func buildContributePreludeCommand(withAI bool, aiTool string) string {
 	if withAI {
 		// The prelude already cd'd to $HOME/git/erun, so the cwd-guarded
 		// resume continues the contribute clone's Claude Code session rather
-		// than the env project's (issue #451).
-		prelude += aiLaunchCommand(aiTool) + "\n"
+		// than the env project's (issue #451). The contribute tab has no
+		// per-env config, so it launches at the default effort (max), keeping
+		// it aligned with env AI tabs (issue #469).
+		prelude += aiLaunchCommand(aiTool, defaultClaudeEffort) + "\n"
 	}
 	return prelude
 }

--- a/erun-ui/environment_config.go
+++ b/erun-ui/environment_config.go
@@ -416,6 +416,7 @@ func claudeConfigToUI(config eruncommon.EnvironmentClaudeConfig) uiClaudeConfig 
 		UseMantle:       copyBoolPtr(config.UseMantle),
 		UseBedrock:      copyBoolPtr(config.UseBedrock),
 		MaxOutputTokens: copyIntPtr(config.MaxOutputTokens),
+		Effort:          copyStringPtr(config.Effort),
 	}
 	if models := config.NormalizedModels(); len(models) > 0 {
 		out.Models = models
@@ -433,6 +434,7 @@ func claudeConfigFromUI(config uiClaudeConfig) eruncommon.EnvironmentClaudeConfi
 		UseBedrock:      copyBoolPtr(config.UseBedrock),
 		Models:          models,
 		MaxOutputTokens: copyIntPtr(config.MaxOutputTokens),
+		Effort:          copyStringPtr(config.Effort),
 	}
 }
 
@@ -446,6 +448,8 @@ func claudeDefaultsForUI() uiClaudeDefaults {
 		KnownModels:     eruncommon.KnownClaudeModels(),
 		MinTokens:       minTokens,
 		MaxTokens:       maxTokens,
+		Effort:          defaultClaudeEffort,
+		EffortLevels:    claudeEffortLevelOptions(),
 	}
 }
 
@@ -468,6 +472,14 @@ func copyBoolPtr(value *bool) *bool {
 }
 
 func copyIntPtr(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	v := *value
+	return &v
+}
+
+func copyStringPtr(value *string) *string {
 	if value == nil {
 		return nil
 	}

--- a/erun-ui/frontend/src/app/manageDialogThunks.ts
+++ b/erun-ui/frontend/src/app/manageDialogThunks.ts
@@ -146,6 +146,7 @@ export const updateManageClaudeConfig =
     if (merged.useBedrock !== undefined) next.useBedrock = merged.useBedrock;
     if (merged.models !== undefined && merged.models.length > 0) next.models = merged.models;
     if (merged.maxOutputTokens !== undefined) next.maxOutputTokens = merged.maxOutputTokens;
+    if (merged.effort !== undefined) next.effort = merged.effort;
     dispatch(
       patchManageDialog({
         config: { ...dialog.config, claude: next },

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -419,4 +419,6 @@ export const defaultClaudeDefaults = (): UIEnvironmentConfig['claudeDefaults'] =
   knownModels: ['opus', 'sonnet', 'haiku'],
   minTokens: 1,
   maxTokens: 200000,
+  effort: 'max',
+  effortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
 });

--- a/erun-ui/frontend/src/components/app/ManageDialog.helpers.ts
+++ b/erun-ui/frontend/src/components/app/ManageDialog.helpers.ts
@@ -8,7 +8,8 @@ export function isClaudeOverridden(claude: UIEnvironmentConfig['claude']): boole
     claude.useMantle !== undefined ||
     claude.useBedrock !== undefined ||
     (claude.models?.length ?? 0) > 0 ||
-    claude.maxOutputTokens !== undefined
+    claude.maxOutputTokens !== undefined ||
+    claude.effort !== undefined
   );
 }
 

--- a/erun-ui/frontend/src/components/app/ManageDialogAITab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogAITab.tsx
@@ -40,6 +40,7 @@ export function ClaudeSettingsSection({ dialog }: { dialog: ManageDialog }): Rea
                   useBedrock: undefined,
                   models: [],
                   maxOutputTokens: undefined,
+                  effort: undefined,
                 }),
               );
             }}
@@ -86,7 +87,47 @@ export function ClaudeSettingsSection({ dialog }: { dialog: ManageDialog }): Rea
           dispatch(updateManageClaudeConfig({ maxOutputTokens }));
         }}
       />
+      <ClaudeEffortField
+        defaults={defaults}
+        value={claude.effort}
+        disabled={disabled}
+        onChange={(effort) => {
+          dispatch(updateManageClaudeConfig({ effort }));
+        }}
+      />
     </div>
+  );
+}
+
+function ClaudeEffortField({
+  defaults,
+  value,
+  disabled,
+  onChange,
+}: {
+  defaults: UIEnvironmentConfig['claudeDefaults'];
+  value: string | undefined;
+  disabled?: boolean;
+  onChange: (value: string | undefined) => void;
+}): React.ReactElement {
+  // Effort is a fixed, known level set, so a constrained selector (recognition
+  // over recall) is the right control rather than free text. "Default (<level>)"
+  // mirrors the sibling Claude fields' override/reset pattern (Nielsen #4).
+  return (
+    <SelectField
+      id="environment-config-claude-effort"
+      label="Effort"
+      value={value ?? 'default'}
+      options={[
+        { value: 'default', label: `Default (${defaults.effort})` },
+        ...defaults.effortLevels.map((level) => ({ value: level, label: level })),
+      ]}
+      helper="Effort level Claude runs at in this environment's AI tab. Higher levels let Claude think longer before responding. Default applies the highest level (max)."
+      disabled={disabled}
+      onChange={(next) => {
+        onChange(next === 'default' ? undefined : next);
+      }}
+    />
   );
 }
 

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -398,6 +398,7 @@ export interface UIEnvironmentClaudeConfig {
   useBedrock?: boolean;
   models?: string[];
   maxOutputTokens?: number;
+  effort?: string;
 }
 
 export interface UIEnvironmentClaudeDefaults {
@@ -408,6 +409,8 @@ export interface UIEnvironmentClaudeDefaults {
   knownModels: string[];
   minTokens: number;
   maxTokens: number;
+  effort: string;
+  effortLevels: string[];
 }
 
 export interface UIRuntimePodConfig {

--- a/erun-ui/playwright/pages/ManageDialog.ts
+++ b/erun-ui/playwright/pages/ManageDialog.ts
@@ -159,4 +159,23 @@ export class ManageDialog {
     await this.openCloudAliasOptions();
     await this.cloudAliasNoneOption().click();
   }
+
+  // claudeEffortSelect targets the "Effort" SelectField in the Claude section
+  // of the AI tab (issue #469). It always renders; with no per-env override it
+  // shows "Default (max)".
+  claudeEffortSelect(): Locator {
+    return this.locator().locator('#environment-config-claude-effort');
+  }
+
+  async claudeEffortSelectedValue(): Promise<string> {
+    return (await this.claudeEffortSelect().textContent())?.trim() ?? '';
+  }
+
+  // chooseClaudeEffort opens the Effort listbox and picks an option by its
+  // visible label. The Radix listbox is portal'd to the document body, so the
+  // option is queried at the page root rather than inside the dialog.
+  async chooseClaudeEffort(label: string): Promise<void> {
+    await this.claudeEffortSelect().click();
+    await this.page.getByRole('option', { name: label, exact: true }).click();
+  }
 }

--- a/erun-ui/playwright/tests/manage-claude-effort.spec.ts
+++ b/erun-ui/playwright/tests/manage-claude-effort.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '../fixtures/erunApp.js';
+
+// Issue #469 — the env Manage dialog's AI tab gained a per-env Claude "Effort"
+// selector (low|medium|high|xhigh|max) that the desktop injects as
+// `claude --effort` when launching the AI tab. This spec exercises the control
+// end-to-end after a real boot: it renders, defaults to "Default (max)", an
+// override is reflected in the draft and marks the tab dirty, and resetting to
+// default returns the draft. All without saving, so the dev's persisted config
+// is untouched (mirrors the no-save approach in manage-cloud-alias-clear).
+//
+// Harness note: the real `claude --effort` launch cannot run headless, so the
+// observable invariant here is the persisted-draft value of the selector (the
+// #331 pattern). The launch-string composition and the max fallback for
+// unset/invalid values are covered by the Go test TestAILaunchCommandGuardsClaudeOnly
+// and TestResolveClaudeEffort in erun-ui.
+test.describe('manage dialog claude effort', () => {
+  test('Effort selector defaults to max, overrides, and resets', async ({ app }) => {
+    const tenants = await app.sidebar.tenants();
+    test.skip(tenants.length === 0, 'no tenants in this developer harness');
+    const tenant = tenants[0]!;
+    const envs = await app.sidebar.environmentsFor(tenant);
+    test.skip(envs.length === 0, 'no environments in this developer harness');
+    const env = envs[0]!;
+
+    await app.sidebar.openManageDialogFor(tenant, env);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('AI');
+    await expect.poll(() => app.manageDialog.getActiveTab()).toBe('AI');
+
+    // Unset → the selector shows the default level (max), proving the backend
+    // default reaches the field and the field is resettable to it.
+    await expect(app.manageDialog.claudeEffortSelect()).toBeVisible();
+    await expect.poll(() => app.manageDialog.claudeEffortSelectedValue()).toBe('Default (max)');
+
+    // Overriding to a concrete level is reflected in the draft and marks the
+    // AI tab dirty (visible affordance for the unsaved change).
+    await app.manageDialog.chooseClaudeEffort('low');
+    await expect.poll(() => app.manageDialog.claudeEffortSelectedValue()).toBe('low');
+    await expect(app.manageDialog.tab('AI')).toHaveAttribute('aria-label', /has unsaved changes/);
+
+    // Resetting to default returns the draft to "Default (max)".
+    await app.manageDialog.chooseClaudeEffort('Default (max)');
+    await expect.poll(() => app.manageDialog.claudeEffortSelectedValue()).toBe('Default (max)');
+
+    // Cancel without saving so the dev's persisted config is not mutated.
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+});

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -414,7 +414,46 @@ func resolveAIToolCommand(configured string) string {
 	return defaultAITool
 }
 
-// claudeContinueGuard is the cwd-guarded Claude Code resume the desktop pipes
+// claudeEffortLevels enumerates the valid `claude --effort` startup levels, in
+// ascending order. The set mirrors `claude --help`; max is the highest and the
+// desktop default.
+var claudeEffortLevels = []string{"low", "medium", "high", "xhigh", "max"}
+
+// defaultClaudeEffort is the effort level the desktop applies to a Claude AI
+// tab when the env has no explicit Effort configured, or has an invalid one
+// (issue #469). It is the highest level.
+const defaultClaudeEffort = "max"
+
+// claudeEffortLevelOptions returns the valid effort levels for transport to the
+// frontend selector.
+func claudeEffortLevelOptions() []string {
+	out := make([]string, len(claudeEffortLevels))
+	copy(out, claudeEffortLevels)
+	return out
+}
+
+func validClaudeEffort(level string) bool {
+	for _, l := range claudeEffortLevels {
+		if l == level {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveClaudeEffort returns the env's configured Claude effort level when it
+// is a valid level, falling back to defaultClaudeEffort for an unset or invalid
+// value so the AI tab never launches with a bad --effort flag (issue #469).
+func resolveClaudeEffort(config eruncommon.EnvironmentClaudeConfig) string {
+	if config.Effort != nil {
+		if level := strings.TrimSpace(*config.Effort); validClaudeEffort(level) {
+			return level
+		}
+	}
+	return defaultClaudeEffort
+}
+
+// claudeLaunchGuard is the cwd-guarded Claude Code resume the desktop pipes
 // into an AI tab. It continues the session that belongs to the tab's working
 // directory — the env repo for the env AI tab, the $HOME/git/erun clone for
 // the contribute AI tab — so per-tab restore is correct on local-agent (host)
@@ -424,20 +463,28 @@ func resolveAIToolCommand(configured string) string {
 // The guard mirrors claude-wrapper.sh: resume only when Claude Code's
 // per-project session store exists for the current directory. It composes with
 // the pod wrapper because the wrapper treats --continue as a bypass flag, so it
-// forwards rather than double-injecting.
-const claudeContinueGuard = `if [ -d "$HOME/.claude/projects/$(pwd | tr / -)" ]; then claude --continue; else claude; fi`
+// forwards rather than double-injecting; --effort is likewise forwarded, not
+// stripped. The resolved effort level is injected into both branches so the
+// session runs at the env's configured effort (issue #469).
+func claudeLaunchGuard(effort string) string {
+	flag := ""
+	if validClaudeEffort(effort) {
+		flag = " --effort " + effort
+	}
+	return `if [ -d "$HOME/.claude/projects/$(pwd | tr / -)" ]; then claude --continue` + flag + `; else claude` + flag + `; fi`
+}
 
 // aiLaunchCommand returns the keystrokes the desktop pipes into an AI tab's
 // shell to launch the AI tool. A bare `claude` launch is wrapped in the
-// cwd-guarded resume; any other tool, or `claude` with explicit flags/a
-// subcommand, launches verbatim — mirroring the wrapper's bypass rules so we
-// never inject a resume the user did not ask for.
-func aiLaunchCommand(configured string) string {
+// cwd-guarded resume with the resolved --effort level; any other tool, or
+// `claude` with explicit flags/a subcommand, launches verbatim — mirroring the
+// wrapper's bypass rules so we never alter a launch the user authored.
+func aiLaunchCommand(configured string, effort string) string {
 	tool := resolveAIToolCommand(configured)
 	if tool != defaultAITool {
 		return tool
 	}
-	return claudeContinueGuard
+	return claudeLaunchGuard(effort)
 }
 
 func formatLaunchCommand(params startTerminalSessionParams) string {

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -249,8 +249,10 @@ func (a *App) runAISession(ctx context.Context, selection uiSelection, slot, col
 		Cols:       cols,
 		Rows:       rows,
 		// The env AI tab runs in the env repo, so the cwd-guarded resume
-		// continues the env project's Claude Code session (issue #451).
-		InitialInput: []byte(aiLaunchCommand(result.EnvConfig.AITool) + "\n"),
+		// continues the env project's Claude Code session (issue #451). The
+		// per-env Claude effort level (default max) is injected as --effort
+		// (issue #469).
+		InitialInput: []byte(aiLaunchCommand(result.EnvConfig.AITool, resolveClaudeEffort(result.EnvConfig.Claude)) + "\n"),
 	}
 	session, err := a.deps.startTerminal(params)
 	if err != nil {

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -223,6 +223,7 @@ type uiClaudeConfig struct {
 	UseBedrock      *bool    `json:"useBedrock,omitempty"`
 	Models          []string `json:"models,omitempty"`
 	MaxOutputTokens *int     `json:"maxOutputTokens,omitempty"`
+	Effort          *string  `json:"effort,omitempty"`
 }
 
 type uiClaudeDefaults struct {
@@ -233,6 +234,8 @@ type uiClaudeDefaults struct {
 	KnownModels     []string `json:"knownModels"`
 	MinTokens       int      `json:"minTokens"`
 	MaxTokens       int      `json:"maxTokens"`
+	Effort          string   `json:"effort"`
+	EffortLevels    []string `json:"effortLevels"`
 }
 
 type uiRuntimePodConfig struct {


### PR DESCRIPTION
This PR carries two changes. They're independent; bundled into one PR at the maintainer's request.

---

## 1. Per-env Claude Effort (Closes #469)

Adds a per-env Claude **Effort** setting on the Manage dialog's **AI** tab and injects it as `claude --effort <level>` when the desktop launches the env's AI tab. Levels are `low|medium|high|xhigh|max`; an unset, blank, or invalid value resolves to **max**.

- **`erun-common`** — `Effort *string` on `EnvironmentClaudeConfig` (round-trips through env config); level set, default, validation, and resolution live in `erun-ui` since the injection is desktop-only.
- **`erun-ui` (Go)** — `aiLaunchCommand` injects `--effort` into both branches of the cwd-guarded resume for the default-claude path only; non-`claude` tools and explicit-flag launches stay verbatim. `runAISession` resolves the level from `EnvConfig.Claude` (max fallback); the contribute tab uses max. The pod `claude-wrapper.sh` forwards `--effort` unchanged.
- **`erun-ui` (frontend)** — an Effort `SelectField` in the Claude section of the AI tab (override + "Default (max)" + reset), wired through `updateManageClaudeConfig`.
- **Docs** — `claude.effort` row in the configuration reference + an Operator note on the desktop overview.

### UX checklist (effort)
- Affected path: Manage → AI tab → Claude section → `updateManageClaudeConfig`; env AI-tab open → `runAISession` → `aiLaunchCommand`.
- State→affordance: only the dialog draft `claude.effort`, rendered by the selector + tab dirty indicator.
- Component: constrained `SelectField` (recognition over recall / error prevention), mirrors sibling Use Mantle / Max output tokens (Nielsen #4).
- Playwright: `manage-claude-effort.spec.ts` (renders, defaults to max, override marks dirty, reset returns) — no save, so the dev's config is untouched; launch-string + max fallback covered by Go tests.

---

## 2. Stop persisting a phantom runtime version on cached deploys

Found while investigating "why doesn't the deploy picker offer the version the dialog shows as current."

A no-change `erun deploy` mints a fresh `-snapshot-<timestamp>` version, then promotes every image from the fingerprint cache (`SkipHelm`) — `RunDeploySpec` returns success **without building, pushing, or running a helm upgrade**. But `PersistRuntimeVersionFromDeploySpecs` recorded that freshly-minted version as the env's `RuntimeVersion` anyway.

The result is a phantom: the env config (and the Manage dialog's "Runtime version") points at a tag that was never pushed to the registry and isn't what the cluster runs. The deploy version picker gates suggestions on registry presence (correct — k3s can only pull pushed tags), so it can never offer that tag back. Symptom: the dialog shows a "current" runtime version that can't be redeployed, and the newest version it *does* offer is the last one actually pushed.

**Fix:** skip the persist when the runtime chart's helm upgrade was skipped (`SkipHelm`); leave `RuntimeVersion` at the last version actually rolled out.

- **`erun-common/deploy.go`** — `PersistRuntimeVersionFromDeploySpecs` returns early for a `SkipHelm` runtime spec.
- **Test** — white-box unit test in `erun-common` (rolled-out deploy persists; `SkipHelm` no-op does not; dry-run never persists). Persist is a non-dry-run side effect, so it's unreachable from the dry-run integration binary — the unit test is the contract owner.

### Scope / verification honesty
- This is forward-looking: it stops the phantom from being written. An env that **already** has a phantom `runtimeversion` persisted is corrected on its next real (non-cached) deploy, or by clearing the `runtimeversion` line in its env config.
- I verified the persist logic via the unit test and confirmed no integration-golden movement. I could **not** drive the original reporter's `orbstack` cluster from the dev pod, so the end-to-end "dialog now shows the rolled-out version after a cached deploy" was not exercised against that live target; it's covered by the persist unit test.

---

## Validation
- `go test ./...` in `erun-common`, `erun-ui`, `erun-mcp` — pass.
- `make integration-test` — pass; coverage gate green (57.9% ≥ 55%), no goldens changed.
- `erun-ui/frontend`: typecheck / lint / format / build — pass (Wails bindings regenerated).
- `erun-ui/playwright` effort spec — pass against a real headless boot.
- `erun-docs` `yarn build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)