### PR TITLE
Fix the phantom runtime version: mint once per deploy, guard the open-flow persist, and resolve the picker's registry from the env

### DIFF
--- a/erun-cli/cmd/deploy.go
+++ b/erun-cli/cmd/deploy.go
@@ -51,7 +51,7 @@ func newDeployCmd(store common.DeployStore, saveEnvConfig common.EnvConfigSaver,
 			if err := common.RunDeploySpecs(ctx, deploySpecs, buildDockerImage, push, deployHelmChart); err != nil {
 				return err
 			}
-			return common.PersistRuntimeVersionFromDeploySpecs(ctx, deploySpecs, saveEnvConfig)
+			return common.PersistRuntimeVersionFromDeploySpecs(ctx, deploySpecs, saveEnvConfig, common.ResolveDeployedHelmReleaseVersion)
 		},
 	}
 	addDryRunFlag(cmd)
@@ -87,7 +87,7 @@ func newK8sDeployCmd(store common.DeployStore, saveEnvConfig common.EnvConfigSav
 			if err := common.RunDeploySpec(ctx, deploySpec, buildDockerImage, push, deployHelmChart); err != nil {
 				return err
 			}
-			return common.PersistRuntimeVersionFromDeploySpecs(ctx, []common.DeploySpec{deploySpec}, saveEnvConfig)
+			return common.PersistRuntimeVersionFromDeploySpecs(ctx, []common.DeploySpec{deploySpec}, saveEnvConfig, common.ResolveDeployedHelmReleaseVersion)
 		},
 	}
 	addDryRunFlag(cmd)

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -270,6 +270,7 @@ func runResolvedOpenCommandWithAPI(ctx common.Context, result common.OpenResult,
 		checkKubernetesDeployment: checkKubernetesDeployment,
 		resolveRuntimeDeploySpec:  resolveRuntimeDeploySpec,
 		deployHelmChart:           deployHelmChart,
+		resolveDeployedVersion:    common.ResolveDeployedHelmReleaseVersion,
 		activateMCP:               activateMCP,
 		activateAPI:               activateAPI,
 		activateSSHD:              activateSSHD,
@@ -289,6 +290,7 @@ type resolvedOpenRunner struct {
 	checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc
 	resolveRuntimeDeploySpec  func(common.Context, common.OpenResult, bool) (common.DeploySpec, error)
 	deployHelmChart           common.HelmChartDeployerFunc
+	resolveDeployedVersion    common.HelmReleaseVersionResolverFunc
 	activateMCP               MCPForwarder
 	activateAPI               APIForwarder
 	activateSSHD              SSHDActivator
@@ -465,12 +467,17 @@ func (r *resolvedOpenRunner) deployRuntime(execution common.DeploySpec) error {
 		// execution.Deploy.Version is a freshly minted snapshot timestamp that
 		// was never pushed; persisting it would leave the env config — and the
 		// desktop runtime dialog — pointing at a phantom version the deploy
-		// picker can never offer (it gates on registry presence). This is the
-		// open-flow twin of the deploy-command guard in
-		// PersistRuntimeVersionFromDeploySpecs. Leave RuntimeVersion at the last
-		// version that was actually rolled out. See issue #475.
-		r.ctx.Trace("open: runtime images all cached (no rebuild); leaving persisted runtime version unchanged")
-		return nil
+		// picker can never offer (it gates on registry presence). Heal the
+		// persisted version to what the release is actually running (guaranteed
+		// pushed) instead; if it can't be read, leave it unchanged. Twin of the
+		// deploy-command guard in PersistRuntimeVersionFromDeploySpecs. See #475.
+		running := r.resolveRunningRuntimeVersion(execution)
+		if running == "" {
+			r.ctx.Trace("open: runtime images all cached (no rebuild); could not read the deployed version, leaving persisted runtime version unchanged")
+			return nil
+		}
+		r.ctx.Trace("open: runtime images all cached (no rebuild); persisting the running runtime version " + running)
+		return r.persistRuntimeVersion(running, execution.Deploy.ContainerRegistry)
 	}
 	return r.persistRuntimeVersion(execution.Deploy.Version, execution.Deploy.ContainerRegistry)
 }
@@ -497,6 +504,22 @@ func (r *resolvedOpenRunner) persistRuntimeVersion(version, registry string) err
 	}
 	r.result = result
 	return nil
+}
+
+// resolveRunningRuntimeVersion reads the version the runtime release is actually
+// running, used to heal the persisted version after a cached (SkipHelm) open.
+// Returns "" when it can't be read (dry-run, no resolver, helm error) so the
+// caller leaves the persisted version untouched rather than recording a phantom.
+func (r *resolvedOpenRunner) resolveRunningRuntimeVersion(execution common.DeploySpec) string {
+	if r.ctx.DryRun || r.resolveDeployedVersion == nil {
+		return ""
+	}
+	version, err := r.resolveDeployedVersion(r.ctx, execution.Deploy.ReleaseName, execution.Deploy.Namespace, execution.Deploy.KubernetesContext)
+	if err != nil {
+		r.ctx.Trace("open: reading the deployed runtime version failed: " + err.Error())
+		return ""
+	}
+	return strings.TrimSpace(version)
 }
 
 func (r *resolvedOpenRunner) activateForwarders() error {

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -459,6 +459,19 @@ func (r *resolvedOpenRunner) deployRuntime(execution common.DeploySpec) error {
 	if err := common.RunDeploySpec(r.ctx, execution, common.DockerImageBuilder, runOpenDockerPush, r.openHelmDeployer(execution)); err != nil {
 		return err
 	}
+	if execution.SkipHelm {
+		// Every runtime image promoted from the fingerprint cache, so
+		// RunDeploySpec rebuilt, pushed, and rolled out nothing.
+		// execution.Deploy.Version is a freshly minted snapshot timestamp that
+		// was never pushed; persisting it would leave the env config — and the
+		// desktop runtime dialog — pointing at a phantom version the deploy
+		// picker can never offer (it gates on registry presence). This is the
+		// open-flow twin of the deploy-command guard in
+		// PersistRuntimeVersionFromDeploySpecs. Leave RuntimeVersion at the last
+		// version that was actually rolled out. See issue #475.
+		r.ctx.Trace("open: runtime images all cached (no rebuild); leaving persisted runtime version unchanged")
+		return nil
+	}
 	return r.persistRuntimeVersion(execution.Deploy.Version, execution.Deploy.ContainerRegistry)
 }
 

--- a/erun-cli/cmd/open_persist_runtime_version_test.go
+++ b/erun-cli/cmd/open_persist_runtime_version_test.go
@@ -7,52 +7,72 @@ import (
 	common "github.com/sophium/erun/erun-common"
 )
 
-// TestDeployRuntimeSkipsPersistOnCachedNoOp pins the open-flow twin of the
-// deploy-command guard in PersistRuntimeVersionFromDeploySpecs (#474). When the
-// runtime deploy promoted every image from the fingerprint cache (SkipHelm —
+// TestDeployRuntimeHealsPersistedVersionOnCachedNoOp pins the open-flow twin of
+// the deploy-command guard in PersistRuntimeVersionFromDeploySpecs (#475). When
+// the runtime deploy promoted every image from the fingerprint cache (SkipHelm:
 // RunDeploySpec rebuilt, pushed, and rolled out nothing), execution.Deploy.Version
-// is a freshly minted snapshot timestamp that was never pushed. Persisting it
-// left the env config — and the desktop Manage dialog's "Runtime version" —
-// pointing at a phantom version the deploy picker can never offer because it
-// gates on registry presence.
+// is a freshly minted snapshot that was never pushed. Persisting it left the env
+// config — and the desktop Manage dialog's "Runtime version" — pointing at a
+// phantom the deploy picker can never offer. The open flow now heals the
+// persisted version to what the release is actually running (guaranteed pushed),
+// and leaves it untouched when that can't be read.
 //
-// persistRuntimeVersion is a non-dry-run side effect (it early-returns on
-// DryRun), so this branch is unreachable from the dry-run integration binary;
-// this white-box test owns the contract, mirroring
-// erun-common/deploy_persist_runtime_version_test.go.
-func TestDeployRuntimeSkipsPersistOnCachedNoOp(t *testing.T) {
+// persistRuntimeVersion is a non-dry-run side effect, unreachable from the
+// dry-run integration binary; this white-box test owns the contract.
+func TestDeployRuntimeHealsPersistedVersionOnCachedNoOp(t *testing.T) {
 	const tenant = "erun"
-	const deployedVersion = "1.0.86-snapshot-20260608163154"
-	const phantomVersion = "1.0.86-snapshot-20260608163431"
+	const mintedVersion = "1.0.86-snapshot-20260608164914"  // minted by the cached resolve; never pushed
+	const runningVersion = "1.0.86-snapshot-20260605090000" // what the release is actually running
+	const stalePersisted = "1.0.86-snapshot-00000000000000"
 	const registry = "ghcr.io/sophium"
 
-	runner := &resolvedOpenRunner{
-		ctx: common.Context{Logger: common.NewLoggerWithWriters(0, io.Discard, io.Discard)},
-		result: common.OpenResult{
-			Tenant:    tenant,
-			EnvConfig: common.EnvConfig{Name: "local", RuntimeVersion: deployedVersion, RuntimeRegistry: registry},
-		},
-		options: openOptions{SaveEnvConfig: func(string, common.EnvConfig) error {
-			t.Fatalf("a SkipHelm open rolled nothing out; it must not persist a runtime version")
-			return nil
-		}},
+	newRunner := func(resolver common.HelmReleaseVersionResolverFunc, save func(string, common.EnvConfig) error) *resolvedOpenRunner {
+		return &resolvedOpenRunner{
+			ctx: common.Context{Logger: common.NewLoggerWithWriters(0, io.Discard, io.Discard)},
+			result: common.OpenResult{
+				Tenant:    tenant,
+				EnvConfig: common.EnvConfig{Name: "local", RuntimeVersion: stalePersisted, RuntimeRegistry: registry},
+			},
+			options:                openOptions{SaveEnvConfig: save},
+			resolveDeployedVersion: resolver,
+		}
 	}
-
-	execution := common.DeploySpec{
+	skipHelmExecution := common.DeploySpec{
 		SkipHelm: true,
 		Deploy: common.HelmDeploySpec{
 			ReleaseName:       common.RuntimeReleaseName(tenant),
-			Version:           phantomVersion,
+			Namespace:         "erun-local",
+			Version:           mintedVersion,
 			ContainerRegistry: registry,
 		},
 	}
 
-	if err := runner.deployRuntime(execution); err != nil {
-		t.Fatalf("deployRuntime: %v", err)
-	}
-	if got := runner.result.EnvConfig.RuntimeVersion; got != deployedVersion {
-		t.Fatalf("RuntimeVersion = %q, want unchanged %q", got, deployedVersion)
-	}
+	t.Run("heals to the running version, never the minted one", func(t *testing.T) {
+		var savedVersion string
+		runner := newRunner(
+			func(common.Context, string, string, string) (string, error) { return runningVersion, nil },
+			func(_ string, cfg common.EnvConfig) error { savedVersion = cfg.RuntimeVersion; return nil },
+		)
+		if err := runner.deployRuntime(skipHelmExecution); err != nil {
+			t.Fatalf("deployRuntime: %v", err)
+		}
+		if savedVersion != runningVersion {
+			t.Fatalf("persisted %q, want the running version %q (never the minted %q)", savedVersion, runningVersion, mintedVersion)
+		}
+	})
+
+	t.Run("unreadable running version leaves the persisted value unchanged", func(t *testing.T) {
+		runner := newRunner(
+			func(common.Context, string, string, string) (string, error) { return "", nil },
+			func(string, common.EnvConfig) error {
+				t.Fatalf("must not persist when the running version can't be read (would be a phantom)")
+				return nil
+			},
+		)
+		if err := runner.deployRuntime(skipHelmExecution); err != nil {
+			t.Fatalf("deployRuntime: %v", err)
+		}
+	})
 }
 
 // TestPersistOpenRuntimeVersionWritesRolledOutVersion pins the positive half:

--- a/erun-cli/cmd/open_persist_runtime_version_test.go
+++ b/erun-cli/cmd/open_persist_runtime_version_test.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"io"
+	"testing"
+
+	common "github.com/sophium/erun/erun-common"
+)
+
+// TestDeployRuntimeSkipsPersistOnCachedNoOp pins the open-flow twin of the
+// deploy-command guard in PersistRuntimeVersionFromDeploySpecs (#474). When the
+// runtime deploy promoted every image from the fingerprint cache (SkipHelm —
+// RunDeploySpec rebuilt, pushed, and rolled out nothing), execution.Deploy.Version
+// is a freshly minted snapshot timestamp that was never pushed. Persisting it
+// left the env config — and the desktop Manage dialog's "Runtime version" —
+// pointing at a phantom version the deploy picker can never offer because it
+// gates on registry presence.
+//
+// persistRuntimeVersion is a non-dry-run side effect (it early-returns on
+// DryRun), so this branch is unreachable from the dry-run integration binary;
+// this white-box test owns the contract, mirroring
+// erun-common/deploy_persist_runtime_version_test.go.
+func TestDeployRuntimeSkipsPersistOnCachedNoOp(t *testing.T) {
+	const tenant = "erun"
+	const deployedVersion = "1.0.86-snapshot-20260608163154"
+	const phantomVersion = "1.0.86-snapshot-20260608163431"
+	const registry = "ghcr.io/sophium"
+
+	runner := &resolvedOpenRunner{
+		ctx: common.Context{Logger: common.NewLoggerWithWriters(0, io.Discard, io.Discard)},
+		result: common.OpenResult{
+			Tenant:    tenant,
+			EnvConfig: common.EnvConfig{Name: "local", RuntimeVersion: deployedVersion, RuntimeRegistry: registry},
+		},
+		options: openOptions{SaveEnvConfig: func(string, common.EnvConfig) error {
+			t.Fatalf("a SkipHelm open rolled nothing out; it must not persist a runtime version")
+			return nil
+		}},
+	}
+
+	execution := common.DeploySpec{
+		SkipHelm: true,
+		Deploy: common.HelmDeploySpec{
+			ReleaseName:       common.RuntimeReleaseName(tenant),
+			Version:           phantomVersion,
+			ContainerRegistry: registry,
+		},
+	}
+
+	if err := runner.deployRuntime(execution); err != nil {
+		t.Fatalf("deployRuntime: %v", err)
+	}
+	if got := runner.result.EnvConfig.RuntimeVersion; got != deployedVersion {
+		t.Fatalf("RuntimeVersion = %q, want unchanged %q", got, deployedVersion)
+	}
+}
+
+// TestPersistOpenRuntimeVersionWritesRolledOutVersion pins the positive half:
+// when a rollout actually happened, the open flow records the deployed version
+// and registry so the dialog and a later reopen address the same image.
+func TestPersistOpenRuntimeVersionWritesRolledOutVersion(t *testing.T) {
+	const tenant = "erun"
+	const version = "1.0.86-snapshot-20260608163154"
+	const registry = "ghcr.io/sophium"
+
+	var savedTenant string
+	var saved common.EnvConfig
+	result := common.OpenResult{Tenant: tenant, EnvConfig: common.EnvConfig{Name: "local"}}
+
+	updated, err := persistOpenRuntimeVersion(result, version, registry, func(tn string, cfg common.EnvConfig) error {
+		savedTenant = tn
+		saved = cfg
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("persistOpenRuntimeVersion: %v", err)
+	}
+	if savedTenant != tenant {
+		t.Fatalf("saved tenant = %q, want %q", savedTenant, tenant)
+	}
+	if saved.RuntimeVersion != version || saved.RuntimeRegistry != registry {
+		t.Fatalf("saved = {%q, %q}, want {%q, %q}", saved.RuntimeVersion, saved.RuntimeRegistry, version, registry)
+	}
+	if updated.EnvConfig.RuntimeVersion != version {
+		t.Fatalf("returned result RuntimeVersion = %q, want %q", updated.EnvConfig.RuntimeVersion, version)
+	}
+}

--- a/erun-cli/cmd/upgrade.go
+++ b/erun-cli/cmd/upgrade.go
@@ -118,7 +118,7 @@ func newUpgradeDeployer(store common.DeployStore, saveEnvConfig common.EnvConfig
 		if err := common.RunDeploySpecs(ctx, specs, buildDockerImage, push, deployHelmChart); err != nil {
 			return err
 		}
-		return common.PersistRuntimeVersionFromDeploySpecs(ctx, specs, saveEnvConfig)
+		return common.PersistRuntimeVersionFromDeploySpecs(ctx, specs, saveEnvConfig, common.ResolveDeployedHelmReleaseVersion)
 	}
 }
 

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -452,6 +452,7 @@ func ResolveDeploySpec(ctx Context, store DeployStore, findProjectRoot ProjectFi
 
 func ResolveCurrentDeploySpecs(ctx Context, store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target DeployTarget) ([]DeploySpec, error) {
 	store, findProjectRoot, resolveDockerBuildContext, _, now = normalizeDeployDependencies(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now)
+	now = freezeNow(now)
 
 	resolvedTarget, err := resolveDeployTarget(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target)
 	if err != nil {
@@ -534,6 +535,7 @@ func ResolveDeploySpecForOpenResult(ctx Context, store DeployStore, findProjectR
 
 func resolveDeploySpecForOpenResult(ctx Context, store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, componentName, versionOverride string, allowLocalBuilds, force bool) (DeploySpec, error) {
 	store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now = normalizeDeployDependencies(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now)
+	now = freezeNow(now)
 
 	deployContext, err := resolveDeployContextForTarget(findProjectRoot, resolveKubernetesDeployContext, target, componentName)
 	if err != nil {
@@ -711,6 +713,7 @@ func applyDeployKubernetesContext(store DeployStore, target OpenResult) OpenResu
 
 func ResolveOpenRuntimeDeploySpec(ctx Context, store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, allowLocalBuilds bool) (DeploySpec, error) {
 	store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now = normalizeDeployDependencies(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now)
+	now = freezeNow(now)
 	return resolveOpenRuntimeDeploySpec(ctx, store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target, allowLocalBuilds)
 }
 
@@ -814,6 +817,27 @@ func normalizeBuildDeployDependencies(store BuildDeployStore, findProjectRoot Pr
 		now = time.Now
 	}
 	return store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now
+}
+
+// freezeNow pins now to a single instant so every snapshot version minted while
+// resolving one deploy (or build) shares the same timestamp. The per-chart build
+// (ResolveDockerBuildForComponent), the cwd "current build"
+// (resolveCurrentDockerComponentBuildForDeploy), and each image's version
+// (resolveDockerImageVersion) otherwise call now() independently; across a
+// multi-image / multi-spec deploy those timestamps drift apart, so the runtime
+// chart's persisted RuntimeVersion can end up differing from the tag actually
+// built and pushed — a phantom version the deploy picker can never offer because
+// it gates on registry presence. Capturing now() once at the resolution
+// entrypoint and threading the frozen clock downstream keeps build, push, helm,
+// and persist on one identical tag. freezeNow is idempotent: freezing an
+// already-frozen clock reproduces the same instant, so applying it at more than
+// one entrypoint on the same call path is safe. See issue #475.
+func freezeNow(now NowFunc) NowFunc {
+	if now == nil {
+		now = time.Now
+	}
+	frozen := now()
+	return func() time.Time { return frozen }
 }
 
 func resolveDeployTargetForDockerTarget(store BuildDeployStore, findProjectRoot ProjectFinderFunc, target DockerCommandTarget) (DeployTarget, error) {

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -3,6 +3,7 @@ package eruncommon
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -217,13 +218,14 @@ type EnvConfigSaver func(tenant string, config EnvConfig) error
 //
 // A runtime chart whose helm upgrade was skipped (SkipHelm: every image
 // promoted from the fingerprint cache, so nothing was rebuilt, pushed, or
-// rolled out) is also a no-op. Its Deploy.Version is a freshly minted
-// snapshot timestamp that was never pushed to the registry and is not what
-// the cluster is running, so persisting it would leave the env config — and
-// the desktop runtime dialog — pointing at a phantom version the deploy
-// picker can never offer (it gates on registry presence). Leave
-// RuntimeVersion at the last version that was actually rolled out.
-func PersistRuntimeVersionFromDeploySpecs(ctx Context, specs []DeploySpec, save EnvConfigSaver) error {
+// rolled out) keeps a freshly minted Deploy.Version that was never pushed.
+// Persisting that would point the env config — and the desktop runtime dialog —
+// at a phantom version the deploy picker can never offer (it gates on registry
+// presence). Instead, heal RuntimeVersion to the version the release is actually
+// running (resolveDeployedVersion reads the live helm appVersion), which is
+// guaranteed pushed. When that cannot be read, leave RuntimeVersion untouched
+// rather than record a phantom. See issue #475.
+func PersistRuntimeVersionFromDeploySpecs(ctx Context, specs []DeploySpec, save EnvConfigSaver, resolveDeployedVersion HelmReleaseVersionResolverFunc) error {
 	if save == nil || ctx.DryRun || len(specs) == 0 {
 		return nil
 	}
@@ -232,25 +234,82 @@ func PersistRuntimeVersionFromDeploySpecs(ctx Context, specs []DeploySpec, save 
 			continue
 		}
 		if spec.SkipHelm {
-			return nil
+			version := resolveRunningRuntimeVersion(ctx, spec, resolveDeployedVersion)
+			if version == "" {
+				return nil
+			}
+			return persistRuntimeVersionIfChanged(spec, version, save)
 		}
 		version := strings.TrimSpace(spec.Deploy.Version)
 		if version == "" {
 			continue
 		}
-		registry := strings.TrimSpace(spec.Deploy.ContainerRegistry)
-		envConfig := spec.Target.EnvConfig
-		if strings.TrimSpace(envConfig.RuntimeVersion) == version && strings.TrimSpace(envConfig.RuntimeRegistry) == registry {
-			return nil
-		}
-		envConfig.RuntimeVersion = version
-		envConfig.RuntimeRegistry = registry
-		if err := save(spec.Target.Tenant, envConfig); err != nil {
-			return fmt.Errorf("persist runtime version after deploy: %w", err)
-		}
-		return nil
+		return persistRuntimeVersionIfChanged(spec, version, save)
 	}
 	return nil
+}
+
+// resolveRunningRuntimeVersion returns the version the runtime release is
+// actually running, used to heal RuntimeVersion after a cached (SkipHelm)
+// deploy. An empty string means "could not determine" — the caller then leaves
+// the persisted version untouched rather than recording the never-pushed mint.
+func resolveRunningRuntimeVersion(ctx Context, spec DeploySpec, resolveDeployedVersion HelmReleaseVersionResolverFunc) string {
+	if resolveDeployedVersion == nil {
+		return ""
+	}
+	version, err := resolveDeployedVersion(ctx, spec.Deploy.ReleaseName, spec.Deploy.Namespace, spec.Deploy.KubernetesContext)
+	if err != nil {
+		ctx.Trace("persist runtime version: reading deployed version for " + spec.Deploy.ReleaseName + " failed: " + err.Error())
+		return ""
+	}
+	return strings.TrimSpace(version)
+}
+
+func persistRuntimeVersionIfChanged(spec DeploySpec, version string, save EnvConfigSaver) error {
+	registry := strings.TrimSpace(spec.Deploy.ContainerRegistry)
+	envConfig := spec.Target.EnvConfig
+	if strings.TrimSpace(envConfig.RuntimeVersion) == version && strings.TrimSpace(envConfig.RuntimeRegistry) == registry {
+		return nil
+	}
+	envConfig.RuntimeVersion = version
+	envConfig.RuntimeRegistry = registry
+	if err := save(spec.Target.Tenant, envConfig); err != nil {
+		return fmt.Errorf("persist runtime version after deploy: %w", err)
+	}
+	return nil
+}
+
+// HelmReleaseVersionResolverFunc reads the appVersion of a deployed helm release
+// — the runtime version the cluster is actually running — so a cached (SkipHelm)
+// deploy can heal EnvConfig.RuntimeVersion to a real, pushed version instead of
+// leaving a stale or phantom value. See issue #475.
+type HelmReleaseVersionResolverFunc func(ctx Context, releaseName, namespace, kubernetesContext string) (string, error)
+
+// ResolveDeployedHelmReleaseVersion returns the appVersion of the named helm
+// release (the runtime version the cluster is actually running). It returns an
+// empty string with a nil error when the release is absent or helm cannot be
+// queried, so reading the version never blocks a deploy or open.
+func ResolveDeployedHelmReleaseVersion(ctx Context, releaseName, namespace, kubernetesContext string) (string, error) {
+	releaseName = strings.TrimSpace(releaseName)
+	namespace = strings.TrimSpace(namespace)
+	if releaseName == "" || namespace == "" {
+		return "", nil
+	}
+	args := []string{"get", "metadata", releaseName, "--namespace", namespace, "-o", "json"}
+	if kubernetesContext = strings.TrimSpace(kubernetesContext); kubernetesContext != "" {
+		args = append(args, "--kube-context", kubernetesContext)
+	}
+	output, err := Command("helm", args...).Output()
+	if err != nil {
+		return "", nil
+	}
+	var metadata struct {
+		AppVersion string `json:"appVersion"`
+	}
+	if err := json.Unmarshal(output, &metadata); err != nil {
+		return "", nil
+	}
+	return strings.TrimSpace(metadata.AppVersion), nil
 }
 
 func specDeploysRuntimeChart(spec DeploySpec) bool {

--- a/erun-common/deploy_freeze_now_test.go
+++ b/erun-common/deploy_freeze_now_test.go
@@ -1,0 +1,73 @@
+package eruncommon
+
+import (
+	"testing"
+	"time"
+)
+
+// TestFreezeNow pins the mechanism that keeps a whole deploy on a single
+// snapshot timestamp. The local snapshot version is minted from now() at several
+// independent sites — the per-chart build (ResolveDockerBuildForComponent), the
+// cwd "current build" (resolveCurrentDockerComponentBuildForDeploy), and each
+// image's version (resolveDockerImageVersion). The resolution entrypoints
+// (ResolveCurrentDeploySpecs, resolveDeploySpecForOpenResult,
+// ResolveOpenRuntimeDeploySpec) call freezeNow once, above the per-spec work, so
+// every one of those sites observes the same instant. Without it a multi-image /
+// multi-spec deploy stamps images with timestamps that drift apart and the
+// runtime chart's persisted RuntimeVersion can end up being a tag that was never
+// built or pushed — a phantom version the deploy picker can never offer because
+// it gates on registry presence. See issue #475.
+//
+// The end-to-end property (one timestamp across a real multi-image deploy) is
+// not observable from the dry-run integration binary: it uses the real clock so
+// independent now() calls land in the same wall-clock second, and the golden
+// normalizer collapses every snapshot version to <VERSION>, so a golden cannot
+// tell a single timestamp from drifting ones. This white-box test owns the
+// contract instead, mirroring deploy_persist_runtime_version_test.go.
+func TestFreezeNow(t *testing.T) {
+	t.Run("collapses a ticking clock to one instant", func(t *testing.T) {
+		base := time.Date(2026, 6, 8, 16, 16, 43, 0, time.UTC)
+		ticks := 0
+		ticking := func() time.Time {
+			ticks++
+			return base.Add(time.Duration(ticks) * time.Second)
+		}
+
+		frozen := freezeNow(ticking)
+		first := frozen()
+		for i := 0; i < 5; i++ {
+			if got := frozen(); !got.Equal(first) {
+				t.Fatalf("call %d returned %s, want frozen %s", i, got, first)
+			}
+		}
+		// The underlying clock is read exactly once, at freeze time, no matter
+		// how many mint sites consult the frozen clock afterward.
+		if ticks != 1 {
+			t.Fatalf("freezeNow read the underlying clock %d times, want 1", ticks)
+		}
+	})
+
+	t.Run("idempotent: freezing a frozen clock keeps the same instant", func(t *testing.T) {
+		base := time.Date(2026, 6, 8, 16, 16, 43, 0, time.UTC)
+		ticking := func() time.Time {
+			base = base.Add(time.Second)
+			return base
+		}
+
+		once := freezeNow(ticking)
+		want := once()
+		twice := freezeNow(once)
+		if got := twice(); !got.Equal(want) {
+			t.Fatalf("re-freezing changed the instant: got %s, want %s", got, want)
+		}
+	})
+
+	t.Run("nil clock falls back to time.Now", func(t *testing.T) {
+		before := time.Now()
+		got := freezeNow(nil)()
+		after := time.Now()
+		if got.Before(before) || got.After(after) {
+			t.Fatalf("freezeNow(nil) = %s, want within [%s, %s]", got, before, after)
+		}
+	})
+}

--- a/erun-common/deploy_persist_runtime_version_test.go
+++ b/erun-common/deploy_persist_runtime_version_test.go
@@ -5,21 +5,22 @@ import (
 	"testing"
 )
 
-// TestPersistRuntimeVersionFromDeploySpecs pins the contract that the env
-// config's runtime version is only advanced when the runtime chart was
-// actually rolled out. A no-change `erun deploy` mints a fresh snapshot
-// timestamp but promotes every image from the fingerprint cache (SkipHelm:
-// nothing rebuilt, pushed, or helm-upgraded); recording that version left the
-// env config — and the desktop runtime dialog — pointing at a tag that was
-// never pushed to the registry and is not running, which the deploy picker
-// can never offer because it gates on registry presence.
+// TestPersistRuntimeVersionFromDeploySpecs pins how the env config's runtime
+// version is advanced after a deploy:
+//   - a real rollout records the version that was built and pushed;
+//   - a cached no-op (SkipHelm: every image promoted from the fingerprint
+//     cache, nothing rebuilt/pushed/rolled) must NOT record the freshly minted
+//     Deploy.Version — it was never pushed — and instead heals to the version
+//     the release is actually running (resolveDeployedVersion), which is
+//     guaranteed pushed; when that can't be read it leaves the value untouched.
 //
-// Persist is a real, non-dry-run side effect (it early-returns on DryRun), so
-// it is unreachable from the dry-run integration binary; this white-box unit
-// test is the contract owner for the branch.
+// Persist is a real, non-dry-run side effect (it early-returns on DryRun), so it
+// is unreachable from the dry-run integration binary; this white-box unit test
+// is the contract owner. See issue #475.
 func TestPersistRuntimeVersionFromDeploySpecs(t *testing.T) {
 	const tenant = "erun"
-	const version = "1.0.86-snapshot-20260608124610"
+	const mintedVersion = "1.0.86-snapshot-20260608124610"
+	const runningVersion = "1.0.86-snapshot-20260605090000"
 	const registry = "ghcr.io/sophium"
 
 	runtimeSpec := func(skipHelm bool) DeploySpec {
@@ -27,14 +28,17 @@ func TestPersistRuntimeVersionFromDeploySpecs(t *testing.T) {
 			Target: OpenResult{Tenant: tenant, EnvConfig: EnvConfig{Name: "local"}},
 			Deploy: HelmDeploySpec{
 				ReleaseName:       RuntimeReleaseName(tenant),
-				Version:           version,
+				Version:           mintedVersion,
 				ContainerRegistry: registry,
 			},
 			SkipHelm: skipHelm,
 		}
 	}
+	fixedRunningVersion := func(version string) HelmReleaseVersionResolverFunc {
+		return func(Context, string, string, string) (string, error) { return version, nil }
+	}
 
-	t.Run("rolled-out deploy persists the version and registry", func(t *testing.T) {
+	t.Run("rolled-out deploy persists the built and pushed version", func(t *testing.T) {
 		var savedTenant string
 		var saved *EnvConfig
 		save := func(tn string, cfg EnvConfig) error {
@@ -43,56 +47,74 @@ func TestPersistRuntimeVersionFromDeploySpecs(t *testing.T) {
 			saved = &c
 			return nil
 		}
-		if err := PersistRuntimeVersionFromDeploySpecs(Context{}, []DeploySpec{runtimeSpec(false)}, save); err != nil {
+		// A real rollout records Deploy.Version and never consults the cluster.
+		if err := PersistRuntimeVersionFromDeploySpecs(Context{}, []DeploySpec{runtimeSpec(false)}, save, fixedRunningVersion(runningVersion)); err != nil {
+			t.Fatalf("persist: %v", err)
+		}
+		if saved == nil || savedTenant != tenant {
+			t.Fatalf("expected save for tenant %q after a real rollout (saved=%v tenant=%q)", tenant, saved != nil, savedTenant)
+		}
+		if saved.RuntimeVersion != mintedVersion || saved.RuntimeRegistry != registry {
+			t.Fatalf("saved {%q, %q}, want {%q, %q}", saved.RuntimeVersion, saved.RuntimeRegistry, mintedVersion, registry)
+		}
+	})
+
+	t.Run("cached deploy (SkipHelm) heals to the running version, not the minted one", func(t *testing.T) {
+		var saved *EnvConfig
+		save := func(_ string, cfg EnvConfig) error {
+			c := cfg
+			saved = &c
+			return nil
+		}
+		if err := PersistRuntimeVersionFromDeploySpecs(Context{}, []DeploySpec{runtimeSpec(true)}, save, fixedRunningVersion(runningVersion)); err != nil {
 			t.Fatalf("persist: %v", err)
 		}
 		if saved == nil {
-			t.Fatalf("expected env config to be saved after a real rollout")
+			t.Fatalf("a cached deploy must heal RuntimeVersion to the running version")
 		}
-		if savedTenant != tenant {
-			t.Fatalf("saved tenant = %q, want %q", savedTenant, tenant)
-		}
-		if saved.RuntimeVersion != version {
-			t.Fatalf("RuntimeVersion = %q, want %q", saved.RuntimeVersion, version)
-		}
-		if saved.RuntimeRegistry != registry {
-			t.Fatalf("RuntimeRegistry = %q, want %q", saved.RuntimeRegistry, registry)
+		if saved.RuntimeVersion != runningVersion {
+			t.Fatalf("RuntimeVersion = %q, want the running version %q (never the minted %q)", saved.RuntimeVersion, runningVersion, mintedVersion)
 		}
 	})
 
-	t.Run("cached no-op deploy (SkipHelm) does not persist a phantom version", func(t *testing.T) {
+	t.Run("cached deploy (SkipHelm) with an unreadable running version leaves it unchanged", func(t *testing.T) {
 		saved := false
 		save := func(string, EnvConfig) error { saved = true; return nil }
-		if err := PersistRuntimeVersionFromDeploySpecs(Context{}, []DeploySpec{runtimeSpec(true)}, save); err != nil {
+		// Empty string models a missing release / unavailable helm.
+		if err := PersistRuntimeVersionFromDeploySpecs(Context{}, []DeploySpec{runtimeSpec(true)}, save, fixedRunningVersion("")); err != nil {
 			t.Fatalf("persist: %v", err)
 		}
 		if saved {
-			t.Fatalf("a SkipHelm deploy rolled nothing out; it must not persist a runtime version")
+			t.Fatalf("could not read the running version; must not persist (would be a phantom)")
 		}
 	})
 
-	t.Run("dry-run never persists", func(t *testing.T) {
+	t.Run("dry-run never persists or queries the cluster", func(t *testing.T) {
 		saved := false
+		resolverCalled := false
 		save := func(string, EnvConfig) error { saved = true; return nil }
-		if err := PersistRuntimeVersionFromDeploySpecs(Context{DryRun: true}, []DeploySpec{runtimeSpec(false)}, save); err != nil {
+		resolver := func(Context, string, string, string) (string, error) { resolverCalled = true; return runningVersion, nil }
+		if err := PersistRuntimeVersionFromDeploySpecs(Context{DryRun: true}, []DeploySpec{runtimeSpec(true)}, save, resolver); err != nil {
 			t.Fatalf("persist: %v", err)
 		}
-		if saved {
-			t.Fatalf("dry-run must not persist")
+		if saved || resolverCalled {
+			t.Fatalf("dry-run must not persist (saved=%v) or query the cluster (resolverCalled=%v)", saved, resolverCalled)
 		}
 	})
 }
 
-// TestCachedDeployRunThenPersistDoesNothing drives the real RunDeploySpecs
-// orchestration for a cached runtime chart (SkipHelm: every image promoted
-// from the fingerprint cache) and then PersistRuntimeVersionFromDeploySpecs.
-// It proves the end-to-end cached-deploy path: RunDeploySpec short-circuits
-// before building, pushing, or running helm — so nothing reaches the registry
-// or rolls the pod — and the freshly minted version is not persisted, so the
-// env config can't end up pointing at a tag that was never pushed. This is the
-// exact sequence the CLI deploy command runs (RunDeploySpecs then persist).
-func TestCachedDeployRunThenPersistDoesNothing(t *testing.T) {
+// TestCachedDeployRunThenPersistHealsToRunningVersion drives the real
+// RunDeploySpecs orchestration for a cached runtime chart (SkipHelm) and then
+// PersistRuntimeVersionFromDeploySpecs — the exact sequence the CLI deploy
+// command runs. It proves the end-to-end cached-deploy path: RunDeploySpec
+// short-circuits before building, pushing, or running helm (nothing reaches the
+// registry or rolls the pod), and the persist step heals RuntimeVersion to the
+// version the release is actually running rather than the freshly minted,
+// never-pushed Deploy.Version. See issue #475.
+func TestCachedDeployRunThenPersistHealsToRunningVersion(t *testing.T) {
 	const tenant = "erun"
+	const mintedVersion = "1.0.86-snapshot-20260608124610"
+	const runningVersion = "1.0.86-snapshot-20260605090000"
 	ctx := Context{Logger: NewLoggerWithWriters(VerbosityInfo, io.Discard, io.Discard)}
 
 	spec := DeploySpec{
@@ -100,30 +122,32 @@ func TestCachedDeployRunThenPersistDoesNothing(t *testing.T) {
 		DeployContext: KubernetesDeployContext{ComponentName: RuntimeReleaseName(tenant)},
 		Deploy: HelmDeploySpec{
 			ReleaseName:       RuntimeReleaseName(tenant),
-			Version:           "1.0.86-snapshot-20260608124610",
+			Version:           mintedVersion,
 			ContainerRegistry: "ghcr.io/sophium",
 		},
 		SkipHelm: true,
 	}
 
-	built, pushed, helmed, saved := false, false, false, false
+	built, pushed, helmed := false, false, false
+	var savedVersion string
 	build := func(DockerBuildSpec, io.Writer, io.Writer) error { built = true; return nil }
 	push := func(Context, DockerPushSpec) error { pushed = true; return nil }
 	deploy := func(HelmDeployParams) error { helmed = true; return nil }
-	save := func(string, EnvConfig) error { saved = true; return nil }
+	save := func(_ string, cfg EnvConfig) error { savedVersion = cfg.RuntimeVersion; return nil }
+	resolveRunning := func(Context, string, string, string) (string, error) { return runningVersion, nil }
 
 	specs := []DeploySpec{spec}
 	if err := RunDeploySpecs(ctx, specs, build, push, deploy); err != nil {
 		t.Fatalf("RunDeploySpecs: %v", err)
 	}
-	if err := PersistRuntimeVersionFromDeploySpecs(ctx, specs, save); err != nil {
+	if err := PersistRuntimeVersionFromDeploySpecs(ctx, specs, save, resolveRunning); err != nil {
 		t.Fatalf("persist: %v", err)
 	}
 
 	if built || pushed || helmed {
 		t.Fatalf("cached (SkipHelm) deploy must not build/push/helm: built=%v pushed=%v helmed=%v", built, pushed, helmed)
 	}
-	if saved {
-		t.Fatalf("cached deploy rolled nothing out; it must not persist a runtime version")
+	if savedVersion != runningVersion {
+		t.Fatalf("RuntimeVersion = %q, want healed to the running version %q (never the minted %q)", savedVersion, runningVersion, mintedVersion)
 	}
 }

--- a/erun-mcp/deploy.go
+++ b/erun-mcp/deploy.go
@@ -52,7 +52,7 @@ func deployTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReques
 				if err := eruncommon.RunDeploySpec(runCtx, execution, runtime.BuildDockerImage, runtimePushFunc(runtime), runtime.DeployHelmChart); err != nil {
 					return err
 				}
-				return eruncommon.PersistRuntimeVersionFromDeploySpecs(runCtx, []eruncommon.DeploySpec{execution}, runtime.Store.SaveEnvConfig)
+				return eruncommon.PersistRuntimeVersionFromDeploySpecs(runCtx, []eruncommon.DeploySpec{execution}, runtime.Store.SaveEnvConfig, eruncommon.ResolveDeployedHelmReleaseVersion)
 			}
 
 			executions, err := eruncommon.ResolveCurrentDeploySpecs(runCtx, runtime.Store, findProjectRoot, resolveBuildContext, resolveDeployContext, nil, target)
@@ -62,7 +62,7 @@ func deployTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReques
 			if err := eruncommon.RunDeploySpecs(runCtx, executions, runtime.BuildDockerImage, runtimePushFunc(runtime), runtime.DeployHelmChart); err != nil {
 				return err
 			}
-			return eruncommon.PersistRuntimeVersionFromDeploySpecs(runCtx, executions, runtime.Store.SaveEnvConfig)
+			return eruncommon.PersistRuntimeVersionFromDeploySpecs(runCtx, executions, runtime.Store.SaveEnvConfig, eruncommon.ResolveDeployedHelmReleaseVersion)
 		})
 		return nil, output, err
 	}

--- a/erun-mcp/upgrade.go
+++ b/erun-mcp/upgrade.go
@@ -58,7 +58,7 @@ func upgradeTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReque
 				if err := eruncommon.RunDeploySpecs(ctx, specs, runtime.BuildDockerImage, runtimePushFunc(runtime), runtime.DeployHelmChart); err != nil {
 					return err
 				}
-				return eruncommon.PersistRuntimeVersionFromDeploySpecs(ctx, specs, runtime.Store.SaveEnvConfig)
+				return eruncommon.PersistRuntimeVersionFromDeploySpecs(ctx, specs, runtime.Store.SaveEnvConfig, eruncommon.ResolveDeployedHelmReleaseVersion)
 			}
 
 			result := eruncommon.RunUpgradePlan(runCtx, plan, deployer)

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -138,6 +138,7 @@ func TestLoadStateUsesTenantSpecificDeployableVersionSuggestions(t *testing.T) {
 
 func TestLoadVersionSuggestionsFiltersOutMissingTenantImageTags(t *testing.T) {
 	app := NewApp(erunUIDeps{
+		store:                stubUIStore{},
 		resolveBuildInfo:     func() eruncommon.BuildInfo { return eruncommon.BuildInfo{Version: "1.0.50"} },
 		resolveImageRegistry: missingTenantImageRegistry(t),
 	})
@@ -153,6 +154,52 @@ func TestLoadVersionSuggestionsFiltersOutMissingTenantImageTags(t *testing.T) {
 	}
 	if suggestions[0].Label != "frs latest stable" || suggestions[0].Image != "frs-devops" || suggestions[3].Label != "ERun current" || suggestions[3].Image != eruncommon.DefaultRuntimeImageName {
 		t.Fatalf("unexpected suggestion metadata: %+v", suggestions)
+	}
+}
+
+func TestLoadVersionSuggestionsUsesEnvPersistedRuntimeRegistry(t *testing.T) {
+	// #475: the "Version to deploy" picker must query the registry the env's
+	// runtime image was actually published to (EnvConfig.RuntimeRegistry, the
+	// provenance deploy records), not the hardcoded default. Otherwise an env on
+	// a non-default registry resolves its suggestions from the wrong place and
+	// can never offer its own deployed version back. The ERun fallback image
+	// stays on the canonical default registry.
+	const customRegistry = "harbor.example/team"
+	var tenantImageNamespace string
+	app := NewApp(erunUIDeps{
+		store: stubUIStore{
+			envs: map[string]eruncommon.EnvConfig{
+				"team/prod": {Name: "prod", RuntimeRegistry: customRegistry},
+			},
+		},
+		resolveBuildInfo: func() eruncommon.BuildInfo { return eruncommon.BuildInfo{Version: "1.0.50"} },
+		resolveImageRegistry: func(_ context.Context, namespace, repository string) (eruncommon.RuntimeRegistryVersions, error) {
+			switch repository {
+			case "team-devops":
+				tenantImageNamespace = namespace
+				return eruncommon.RuntimeRegistryVersions{
+					Image:          namespace + "/" + repository,
+					Tags:           []string{"1.0.11", "1.0.12-snapshot-20260608120000"},
+					LatestStable:   "1.0.11",
+					LatestSnapshot: "1.0.12-snapshot-20260608120000",
+				}, nil
+			case eruncommon.DefaultRuntimeImageName:
+				if namespace != eruncommon.DefaultContainerRegistry {
+					t.Fatalf("ERun fallback image must use the default registry, got %s", namespace)
+				}
+				return eruncommon.RuntimeRegistryVersions{Image: namespace + "/" + repository}, nil
+			default:
+				t.Fatalf("unexpected registry repository: %s", repository)
+			}
+			return eruncommon.RuntimeRegistryVersions{}, nil
+		},
+	})
+
+	if _, err := app.LoadVersionSuggestions(uiSelection{Tenant: "team", Environment: "prod"}); err != nil {
+		t.Fatalf("LoadVersionSuggestions failed: %v", err)
+	}
+	if tenantImageNamespace != customRegistry {
+		t.Fatalf("tenant runtime image queried namespace %q, want %q", tenantImageNamespace, customRegistry)
 	}
 }
 
@@ -186,6 +233,7 @@ func missingTenantImageRegistry(t *testing.T) func(context.Context, string, stri
 func TestLoadVersionSuggestionsDoesNotDuplicateDefaultRuntimeForErunTenant(t *testing.T) {
 	var repositories []string
 	app := NewApp(erunUIDeps{
+		store:            stubUIStore{},
 		resolveBuildInfo: func() eruncommon.BuildInfo { return eruncommon.BuildInfo{Version: "1.0.50"} },
 		resolveImageRegistry: func(_ context.Context, namespace, repository string) (eruncommon.RuntimeRegistryVersions, error) {
 			if namespace != eruncommon.DefaultContainerRegistry {
@@ -220,6 +268,7 @@ func TestLoadVersionSuggestionsDoesNotDuplicateDefaultRuntimeForErunTenant(t *te
 
 func TestLoadVersionSuggestionsFallsBackToDefaultRuntimeTagsWhenTenantImageMissing(t *testing.T) {
 	app := NewApp(erunUIDeps{
+		store:            stubUIStore{},
 		resolveBuildInfo: func() eruncommon.BuildInfo { return eruncommon.BuildInfo{Version: "1.0.50"} },
 		resolveImageRegistry: func(_ context.Context, namespace, repository string) (eruncommon.RuntimeRegistryVersions, error) {
 			if namespace != eruncommon.DefaultContainerRegistry {
@@ -255,6 +304,7 @@ func TestLoadVersionSuggestionsFallsBackToDefaultRuntimeTagsWhenTenantImageMissi
 
 func TestLoadVersionSuggestionsForInitUsesAvailableRuntimeImageTags(t *testing.T) {
 	app := NewApp(erunUIDeps{
+		store:            stubUIStore{},
 		resolveBuildInfo: func() eruncommon.BuildInfo { return eruncommon.BuildInfo{Version: "1.0.50"} },
 		resolveImageRegistry: func(_ context.Context, namespace, repository string) (eruncommon.RuntimeRegistryVersions, error) {
 			if namespace != eruncommon.DefaultContainerRegistry {

--- a/erun-ui/environment_upgrade.go
+++ b/erun-ui/environment_upgrade.go
@@ -33,7 +33,7 @@ func (a *App) ResolveUpgradePlan() (eruncommon.UpgradePlan, error) {
 // upgrade — even though the picker offers the ERun image's version for the same
 // env. Reuses resolveRuntimeRegistryVersionsForTenant for both lookups.
 func (a *App) resolveUpgradeRegistryVersionsForTenant(tenant string) eruncommon.RuntimeRegistryVersions {
-	versions := a.resolveRuntimeRegistryVersionsForTenant(tenant)
+	versions := a.resolveRuntimeRegistryVersionsForTenant(a.runtimeRegistryNamespace(tenant, ""), tenant)
 	// The ERun tenant already resolves the default image; nothing to fall back
 	// to, and an empty result is genuinely "no versions".
 	if strings.TrimSpace(tenant) == "" ||
@@ -43,7 +43,7 @@ func (a *App) resolveUpgradeRegistryVersionsForTenant(tenant string) eruncommon.
 	if strings.TrimSpace(versions.LatestStable) != "" && strings.TrimSpace(versions.LatestSnapshot) != "" {
 		return versions
 	}
-	fallback := a.resolveRuntimeRegistryVersionsForTenant("")
+	fallback := a.resolveRuntimeRegistryVersionsForTenant("", "")
 	if strings.TrimSpace(versions.LatestStable) == "" {
 		versions.LatestStable = fallback.LatestStable
 	}

--- a/erun-ui/state_handlers.go
+++ b/erun-ui/state_handlers.go
@@ -21,7 +21,7 @@ func (a *App) LoadState() (uiState, error) {
 			return uiState{
 				Message:            "ERun is not initialized yet. Run `erun init` first.",
 				Build:              buildDetailsFrom(info),
-				VersionSuggestions: a.runtimeVersionSuggestions(info, ""),
+				VersionSuggestions: a.runtimeVersionSuggestions(info, "", ""),
 			}, nil
 		}
 		return uiState{}, err
@@ -29,53 +29,91 @@ func (a *App) LoadState() (uiState, error) {
 	info := a.deps.resolveBuildInfo()
 	state := stateFromListResult(result, info)
 	suggestionTenant := ""
+	suggestionEnv := ""
 	if state.Selected != nil {
 		suggestionTenant = state.Selected.Tenant
+		suggestionEnv = state.Selected.Environment
 	} else if len(state.Tenants) > 0 {
 		suggestionTenant = state.Tenants[0].Name
 	}
-	state.VersionSuggestions = a.runtimeVersionSuggestions(info, suggestionTenant)
+	state.VersionSuggestions = a.runtimeVersionSuggestions(info, suggestionTenant, suggestionEnv)
 	return state, nil
 }
 
-func (a *App) resolveRuntimeRegistryVersionsForTenant(tenant string) eruncommon.RuntimeRegistryVersions {
+func (a *App) resolveRuntimeRegistryVersionsForTenant(namespace, tenant string) eruncommon.RuntimeRegistryVersions {
 	ctx := a.ctx
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if namespace = strings.TrimSpace(namespace); namespace == "" {
+		namespace = eruncommon.DefaultContainerRegistry
 	}
 	repository := eruncommon.DefaultRuntimeImageName
 	if tenant = strings.TrimSpace(tenant); tenant != "" {
 		repository = eruncommon.RuntimeReleaseName(tenant)
 	}
-	versions, err := a.deps.resolveImageRegistry(ctx, eruncommon.DefaultContainerRegistry, repository)
+	versions, err := a.deps.resolveImageRegistry(ctx, namespace, repository)
 	if err != nil {
 		return eruncommon.RuntimeRegistryVersions{}
 	}
 	return versions
 }
 
-func (a *App) runtimeVersionSuggestions(info eruncommon.BuildInfo, tenant string) []uiVersion {
+// runtimeRegistryNamespace returns the container-registry namespace where the
+// given environment's runtime image was last published, so the "Version to
+// deploy" picker queries the same place `erun deploy` pushed to instead of the
+// hardcoded default. It mirrors the deploy provenance recorded by
+// PersistRuntimeVersionFromDeploySpecs (issue #363): the env's persisted
+// RuntimeRegistry. When no specific environment is given (the tenant-wide
+// initial state and the Upgrade-all plan) the first env of the tenant that
+// recorded a registry stands in for the tenant. Returns "" when nothing is
+// recorded — a never-deployed env, or one predating the provenance — so the
+// caller falls back to DefaultContainerRegistry. See issue #475.
+func (a *App) runtimeRegistryNamespace(tenant, environment string) string {
 	tenant = strings.TrimSpace(tenant)
 	if tenant == "" {
-		return labelRuntimeVersionSuggestions("ERun", eruncommon.DefaultRuntimeImageName, eruncommon.RuntimeDeployVersionSuggestions(info, a.resolveRuntimeRegistryVersionsForTenant("")))
+		return ""
+	}
+	envs, err := a.deps.store.ListEnvConfigs(tenant)
+	if err != nil {
+		return ""
+	}
+	if environment = strings.TrimSpace(environment); environment != "" {
+		for _, env := range envs {
+			if strings.EqualFold(strings.TrimSpace(env.Name), environment) {
+				return strings.TrimSpace(env.RuntimeRegistry)
+			}
+		}
+		return ""
+	}
+	for _, env := range envs {
+		if registry := strings.TrimSpace(env.RuntimeRegistry); registry != "" {
+			return registry
+		}
+	}
+	return ""
+}
+
+func (a *App) runtimeVersionSuggestions(info eruncommon.BuildInfo, tenant, environment string) []uiVersion {
+	tenant = strings.TrimSpace(tenant)
+	if tenant == "" {
+		return labelRuntimeVersionSuggestions("ERun", eruncommon.DefaultRuntimeImageName, eruncommon.RuntimeDeployVersionSuggestions(info, a.resolveRuntimeRegistryVersionsForTenant("", "")))
 	}
 
+	namespace := a.runtimeRegistryNamespace(tenant, environment)
 	suggestions := make([]uiVersion, 0, 8)
 	tenantImage := eruncommon.RuntimeReleaseName(tenant)
-	suggestions = append(suggestions, labelRuntimeVersionSuggestions(tenant, tenantImage, eruncommon.RuntimeDeployVersionSuggestions(info, a.resolveRuntimeRegistryVersionsForTenant(tenant)))...)
+	suggestions = append(suggestions, labelRuntimeVersionSuggestions(tenant, tenantImage, eruncommon.RuntimeDeployVersionSuggestions(info, a.resolveRuntimeRegistryVersionsForTenant(namespace, tenant)))...)
 	if tenantImage == eruncommon.DefaultRuntimeImageName {
 		return suggestions
 	}
-	suggestions = append(suggestions, labelRuntimeVersionSuggestions("ERun", eruncommon.DefaultRuntimeImageName, eruncommon.RuntimeDeployVersionSuggestions(info, a.resolveRuntimeRegistryVersionsForTenant("")))...)
+	suggestions = append(suggestions, labelRuntimeVersionSuggestions("ERun", eruncommon.DefaultRuntimeImageName, eruncommon.RuntimeDeployVersionSuggestions(info, a.resolveRuntimeRegistryVersionsForTenant("", "")))...)
 	return suggestions
 }
 
 func (a *App) LoadVersionSuggestions(selection uiSelection) ([]uiVersion, error) {
 	selection = normalizeSelection(selection)
-	if selection.Action == "init" {
-		return a.runtimeVersionSuggestions(a.deps.resolveBuildInfo(), selection.Tenant), nil
-	}
-	return a.runtimeVersionSuggestions(a.deps.resolveBuildInfo(), selection.Tenant), nil
+	return a.runtimeVersionSuggestions(a.deps.resolveBuildInfo(), selection.Tenant, selection.Environment), nil
 }
 
 func (a *App) LoadKubernetesContexts() ([]string, error) {


### PR DESCRIPTION
## Summary

Fixes #475 — deploy/open persists and displays a runtime version that was never
pushed (a phantom the deploy picker can never offer, since it gates on registry
presence). Three root causes, all fixed and verified live against the binary the
desktop actually spawns.

### 1. Mint one snapshot timestamp per deploy (`erun-common`)

The local snapshot version was minted from `now()` at several independent sites,
so a multi-image deploy stamped images with timestamps that drifted apart.
`freezeNow()` pins `now()` once at each resolution entrypoint
(`ResolveCurrentDeploySpecs`, `resolveDeploySpecForOpenResult`,
`ResolveOpenRuntimeDeploySpec`) above the per-spec work, so build → push → helm →
persist all carry one identical tag.

**Verified:** `erun deploy erun local --dry-run -vv --force` minted **four**
timestamps before, **one** after; a live rebuild deploy minted a single
`…172916` across its images.

### 2. Heal the persisted runtime version from the cluster on a cached deploy/open (`erun-common`, `erun-cli`)

PR #474 stopped a cached (`SkipHelm`) deploy from persisting a freshly minted,
never-pushed version — but *skipping* the persist only prevents new phantoms; it
leaves whatever was last written. An env whose `RuntimeVersion` was already stale
or wrong (a pre-fix phantom) stayed wrong, and a normal cached deploy/open never
corrected it.

Now both the deploy path (`PersistRuntimeVersionFromDeploySpecs`, CLI + MCP) and
the open path (`deployRuntime`) **heal** on `SkipHelm`: they read the version the
release is actually running (`helm get metadata … appVersion`, guaranteed
pushed) via the new `HelmReleaseVersionResolverFunc` /
`ResolveDeployedHelmReleaseVersion`, and persist that. When it can't be read,
`RuntimeVersion` is left untouched rather than recording a phantom.

### 3. Version picker queries the env's registry (`erun-ui`)

`resolveRuntimeRegistryVersionsForTenant` hardcoded `DefaultContainerRegistry`,
ignoring the env's persisted `RuntimeRegistry` (#363 provenance). The
tenant-specific image lookup (picker + Upgrade-all plan) now uses the env's
`RuntimeRegistry`, falling back to the default; the ERun fallback image stays on
the canonical default registry.

## Live end-to-end verification (rebuilt `erun-cli/bin/erun`)

Against the live `erun/local` env (orbstack), with an unmistakable sentinel
planted in `config.yaml` so any change is provably the code's doing:

1. **Rebuild (non-SkipHelm):** `open erun local` rebuilt the runtime and persisted
   the real built+deployed version `…172916` over the sentinel — `==> Deployed
   erun/local …172916`. That tag is **present in ghcr** (HTTP 200).
2. **Cached (SkipHelm, zero rebuilds):** a second `open` re-planted the sentinel,
   hit `deploy: skipping erun-devops (all images cached, no rebuild)`, and the
   heal fired: `open: runtime images all cached (no rebuild); persisting the
   running runtime version 1.0.86-snapshot-20260608172916` — read from the
   cluster, no hand-editing. config + helm `appVersion` + registry all agree on
   `…172916`.

## Tests

- `erun-common` `TestFreezeNow` (single-mint mechanism);
  `TestPersistRuntimeVersionFromDeploySpecs` + `TestCachedDeployRunThenPersistHealsToRunningVersion`
  (rollout persists the pushed version; cached deploy heals to the running version;
  unreadable → unchanged; dry-run never persists or queries the cluster).
- `erun-cli` `TestDeployRuntimeHealsPersistedVersionOnCachedNoOp` +
  `TestPersistOpenRuntimeVersionWritesRolledOutVersion` (open-flow heal + positive
  persist). White-box, because persist is a non-dry-run side effect unreachable
  from the dry-run integration binary.
- `erun-ui` `TestLoadVersionSuggestionsUsesEnvPersistedRuntimeRegistry` (picker
  env-registry lookup); store-less version-suggestion tests inject a stub store.
- `make integration-test` green — no golden drift (the cluster read and heal are
  non-dry-run), coverage gate passes.

## UX Impact Review Checklist (erun-ui)

1. **Affected paths.** Manage dialog "Version to deploy" picker
   (`LoadVersionSuggestions`), initial state (`LoadState`), Upgrade-all
   (`ResolveUpgradePlan`); the persisted `RuntimeVersion` the dialog/hover render
   (set by deploy/open).
2. **User-visible sequence.** Opening the dialog populates the version dropdown and
   shows the runtime version; both now reflect an actually-pushed version. No new
   controls.
3. **State-without-affordance.** No new `AppState` fields; `RuntimeVersion` /
   `VersionSuggestions` already rendered.
4–6. **Status / feedback / consistency.** Unchanged surfaces; picker, Upgrade-all,
   and deploy/open now resolve registry and version the same way.
7. **Heuristic pass.** Improves "match with the real world" (the dialog reflects
   what's deployed) and "recognition over recall"; no heuristic regresses.
8. **Playwright.** No new rendered surface (Wails signatures + suggestion shape
   unchanged); the deltas — which registry is queried, and healing the version
   from the cluster — depend on a live cluster/registry the headless harness can't
   stage (`resolveImageRegistry` and the helm read are injected in Go tests).
   Rendered picker/upgrade behavior stays locked by `manage.spec.ts` /
   `sidebar-upgrade-all.spec.ts`; the new branches are owned by the Go tests and
   the live verification above. Documented escape hatch for state the harness
   cannot stage.

## Docs

No `erun-docs` change: bug fix restoring intended behavior (no new command, flag,
or contract) — exempt per the root `AGENTS.md` docs rule.

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)
