### PR TITLE
Reconnect to the running remote shell on reopen via persistent dtach sessions

### DIFF
--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -31,6 +31,9 @@ func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen 
 	var noAliasPrompt bool
 	var versionOverride string
 	var runtimeImage string
+	var appSession string
+	var aiTab bool
+	var contributeTab bool
 	target := common.OpenParams{}
 
 	cmd := &cobra.Command{
@@ -83,6 +86,9 @@ func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen 
 				RuntimeImage:     runtimeImage,
 				AllowLocalBuilds: allowLocalBuilds,
 				SaveEnvConfig:    saveEnvConfig,
+				AppSession:       strings.TrimSpace(appSession),
+				AI:               aiTab,
+				Contribute:       contributeTab,
 			}, promptRunner, openShell, runManagedDeploy, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart, activateMCP, activateAPI, activateSSHD, launchVSCode, launchIntelliJ)
 		},
 	}
@@ -97,6 +103,16 @@ func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen 
 	cmd.Flags().StringVar(&versionOverride, "version", "", "Override the runtime chart and image version before opening")
 	cmd.Flags().StringVar(&runtimeImage, "runtime-image", "", "Override the runtime image repository before opening")
 	addSnapshotFlags(cmd, &snapshot, &noSnapshot, "Build and deploy a local snapshot when opening the local environment")
+	// Desktop-integration flags: the app runs the remote shell as a persistent,
+	// reattachable dtach session so closing/reopening a tab reconnects to the
+	// running shell (and the AI tab's claude keeps working). Hidden because they
+	// only make sense when the desktop manages the session lifecycle. See #478.
+	cmd.Flags().StringVar(&appSession, "app-session", "", "Reattach to a persistent terminal session with this id")
+	cmd.Flags().BoolVar(&aiTab, "ai", false, "Launch the configured AI tool as the persistent session's program")
+	cmd.Flags().BoolVar(&contributeTab, "contribute", false, "Start the persistent session in the contribute clone")
+	_ = cmd.Flags().MarkHidden("app-session")
+	_ = cmd.Flags().MarkHidden("ai")
+	_ = cmd.Flags().MarkHidden("contribute")
 	return cmd
 }
 
@@ -109,6 +125,9 @@ type openOptions struct {
 	RuntimeImage     string
 	AllowLocalBuilds bool
 	SaveEnvConfig    func(string, common.EnvConfig) error
+	AppSession       string
+	AI               bool
+	Contribute       bool
 }
 
 func prepareOpenResultForRun(ctx common.Context, result common.OpenResult, snapshotOverride *bool, saveEnvConfig func(string, common.EnvConfig) error) (common.OpenResult, error) {
@@ -312,6 +331,9 @@ func (r *resolvedOpenRunner) run() error {
 	}
 
 	shellReq := common.ShellLaunchParamsFromResult(r.result)
+	shellReq.AppSession = r.options.AppSession
+	shellReq.AI = r.options.AI
+	shellReq.Contribute = r.options.Contribute
 	if err := r.maybeDeployRuntime(shellReq); err != nil {
 		return err
 	}

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -595,6 +595,10 @@ func (r *resolvedOpenRunner) emitNoShellSetup() error {
 
 func (r *resolvedOpenRunner) traceShellPreview(shellReq common.ShellLaunchParams) {
 	if preview, err := common.PreviewShellLaunch(shellReq); err == nil {
+		if len(preview.SeedArgs) > 0 {
+			r.ctx.TraceCommand("", "kubectl", preview.SeedArgs...)
+			r.ctx.Trace("open: SSH private key streamed to the runtime pod on stdin (kept off the command line)")
+		}
 		r.ctx.TraceCommand("", "kubectl", preview.WaitArgs...)
 		execArgs := append([]string{}, preview.ExecArgs...)
 		if len(execArgs) > 0 {

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -613,6 +613,15 @@ func (r *resolvedOpenRunner) runShellLoop(shellReq common.ShellLaunchParams) err
 		if errors.Is(err, common.ErrShellPodReplaced) {
 			continue
 		}
+		if errors.Is(err, common.ErrShellSessionTakenOver) {
+			// Another ERun window re-attached this persistent session
+			// (screen-style detach-and-reattach). The session keeps running
+			// there; end this viewer cleanly. The notice line is the
+			// desktop's signal to stop its reconnect loop instead of
+			// stealing the session straight back.
+			r.ctx.Info(common.ShellSessionTakenOverNotice)
+			return nil
+		}
 		if !errors.Is(err, common.ErrShellReattachDeploy) {
 			return err
 		}

--- a/erun-cli/cmd/open_shell_loop_test.go
+++ b/erun-cli/cmd/open_shell_loop_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	common "github.com/sophium/erun/erun-common"
+)
+
+// TestRunShellLoopEndsCleanlyWhenSessionTakenOver pins the takeover handover
+// from #478: when another ERun window re-attaches the persistent session,
+// ExecShell surfaces ErrShellSessionTakenOver and the loop must end cleanly —
+// no error, no relaunch — after printing the stable notice line the desktop
+// matches to suppress its reconnect. runShellLoop is TTY-gated, so this stays
+// a same-package unit test per the documented integration coverage gap.
+func TestRunShellLoopEndsCleanlyWhenSessionTakenOver(t *testing.T) {
+	var output bytes.Buffer
+	runner := &resolvedOpenRunner{
+		ctx: common.Context{Logger: common.NewLoggerWithWriters(0, &output, &output)},
+		openShell: func(common.Context, common.ShellLaunchParams) error {
+			return common.ErrShellSessionTakenOver
+		},
+	}
+
+	if err := runner.runShellLoop(common.ShellLaunchParams{}); err != nil {
+		t.Fatalf("takeover must end the shell loop cleanly, got %v", err)
+	}
+	if !strings.Contains(output.String(), common.ShellSessionTakenOverNotice) {
+		t.Fatalf("expected the taken-over notice %q in output, got %q",
+			common.ShellSessionTakenOverNotice, output.String())
+	}
+}

--- a/erun-common/ai_launch.go
+++ b/erun-common/ai_launch.go
@@ -1,0 +1,53 @@
+package eruncommon
+
+import "strings"
+
+const (
+	defaultAITool       = "claude"
+	defaultClaudeEffort = "max"
+)
+
+// claudeEffortLevels enumerates the valid `claude --effort` startup levels in
+// ascending order; max is the default.
+var claudeEffortLevels = []string{"low", "medium", "high", "xhigh", "max"}
+
+func validClaudeEffort(level string) bool {
+	level = strings.TrimSpace(level)
+	for _, candidate := range claudeEffortLevels {
+		if candidate == level {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveClaudeEffort(config EnvironmentClaudeConfig) string {
+	if config.Effort != nil {
+		if level := strings.TrimSpace(*config.Effort); validClaudeEffort(level) {
+			return level
+		}
+	}
+	return defaultClaudeEffort
+}
+
+// AISessionLaunchCommand returns the shell command the AI tab's persistent
+// remote session runs as its program: the configured AI tool, or — for claude —
+// a guard that resumes the cwd's existing Claude Code session when one exists
+// (else starts fresh), at the env's effort level. It runs once when the dtach
+// session is created; reattaches never re-run it. Mirrors the command the
+// desktop used to type into the shell (issues #451/#469); centralised here so
+// `erun open --ai` can launch it pod-side and survive a disconnect. See #478.
+func AISessionLaunchCommand(aiTool string, claude EnvironmentClaudeConfig) string {
+	if tool := strings.TrimSpace(aiTool); tool != "" && tool != defaultAITool {
+		return tool
+	}
+	return claudeLaunchGuard(resolveClaudeEffort(claude))
+}
+
+func claudeLaunchGuard(effort string) string {
+	flag := ""
+	if validClaudeEffort(effort) {
+		flag = " --effort " + effort
+	}
+	return `if [ -d "$HOME/.claude/projects/$(pwd | tr / -)" ]; then claude --continue` + flag + `; else claude` + flag + `; fi`
+}

--- a/erun-common/ai_launch_test.go
+++ b/erun-common/ai_launch_test.go
@@ -1,0 +1,82 @@
+package eruncommon
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAISessionLaunchCommand pins the AI tab's pod-side launcher (relocated from
+// erun-ui for issue #478): a bare/claude tool is wrapped in the cwd-guarded
+// resume with the env effort injected into both branches; any other tool, or
+// claude with explicit flags, launches verbatim.
+func TestAISessionLaunchCommand(t *testing.T) {
+	effort := func(level string) EnvironmentClaudeConfig {
+		l := level
+		return EnvironmentClaudeConfig{Effort: &l}
+	}
+
+	t.Run("default claude wraps in the cwd guard at the env effort", func(t *testing.T) {
+		got := AISessionLaunchCommand("", effort("high"))
+		if strings.Count(got, "--effort high") != 2 {
+			t.Fatalf("expected --effort high in both guard branches, got %q", got)
+		}
+		if !strings.Contains(got, "claude --continue --effort high") || !strings.Contains(got, "else claude --effort high") {
+			t.Fatalf("guard missing the resume/fresh branches: %q", got)
+		}
+	})
+
+	t.Run("explicit claude tool also uses the guard", func(t *testing.T) {
+		if got := AISessionLaunchCommand("claude", effort("low")); !strings.Contains(got, "claude --continue --effort low") {
+			t.Fatalf("explicit claude must use the guard, got %q", got)
+		}
+	})
+
+	t.Run("a non-claude tool launches verbatim", func(t *testing.T) {
+		if got := AISessionLaunchCommand("codex", effort("max")); got != "codex" {
+			t.Fatalf("codex must launch verbatim, got %q", got)
+		}
+	})
+
+	t.Run("claude with explicit flags launches verbatim", func(t *testing.T) {
+		if got := AISessionLaunchCommand("claude --resume", effort("max")); got != "claude --resume" {
+			t.Fatalf("explicit-flag claude must launch verbatim, got %q", got)
+		}
+	})
+
+	t.Run("unset and invalid effort both resolve to max", func(t *testing.T) {
+		if got := AISessionLaunchCommand("", EnvironmentClaudeConfig{}); !strings.Contains(got, "--effort max") {
+			t.Fatalf("unset effort must default to max, got %q", got)
+		}
+		// A bad persisted value must never reach the shell verbatim; it resolves
+		// to the default instead of injecting `--effort turbo`.
+		got := AISessionLaunchCommand("", effort("turbo"))
+		if strings.Contains(got, "turbo") || !strings.Contains(got, "--effort max") {
+			t.Fatalf("invalid effort must resolve to max, got %q", got)
+		}
+	})
+}
+
+// TestResolveClaudeEffort covers the per-env effort resolution: a valid level is
+// used; unset, blank, and invalid fall back to max so the launch never carries a
+// bad --effort flag.
+func TestResolveClaudeEffort(t *testing.T) {
+	level := func(v string) *string { return &v }
+	cases := []struct {
+		name   string
+		config EnvironmentClaudeConfig
+		want   string
+	}{
+		{"unset", EnvironmentClaudeConfig{}, "max"},
+		{"valid", EnvironmentClaudeConfig{Effort: level("low")}, "low"},
+		{"trimmed", EnvironmentClaudeConfig{Effort: level("  high  ")}, "high"},
+		{"blank", EnvironmentClaudeConfig{Effort: level("  ")}, "max"},
+		{"invalid", EnvironmentClaudeConfig{Effort: level("turbo")}, "max"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveClaudeEffort(tc.config); got != tc.want {
+				t.Fatalf("resolveClaudeEffort(%+v) = %q, want %q", tc.config, got, tc.want)
+			}
+		})
+	}
+}

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -76,6 +76,21 @@ type ShellLaunchParams struct {
 	ManagedCloud       bool
 	CloudProviderAlias string
 	Idle               EnvironmentIdleConfig
+	// AppSession, when non-empty, makes the remote shell a persistent,
+	// reattachable dtach session keyed by this id (distinct per desktop tab:
+	// kind + slot). Closing/reopening a tab — or a transient kubectl-exec drop —
+	// then reconnects to the still-running shell (and the AI tab's claude keeps
+	// working in the pod) instead of spawning a parallel one. Empty (the bare
+	// `erun open` CLI path) keeps the previous ephemeral behaviour. See #478.
+	AppSession string
+	// AI / Contribute select the persistent session's create-time program:
+	// Contribute cds into the contribute clone with its env; AI launches the AI
+	// tool (claude, at the env's effort) once on create. The desktop sets these
+	// instead of typing the prelude in, so a reattach never re-runs them.
+	AI         bool
+	Contribute bool
+	AITool     string
+	Claude     EnvironmentClaudeConfig
 }
 
 type ShellLaunchPreview struct {
@@ -482,6 +497,8 @@ func ShellLaunchParamsFromResult(result OpenResult) ShellLaunchParams {
 		ManagedCloud:       result.EnvConfig.ManagedCloud,
 		CloudProviderAlias: strings.TrimSpace(result.EnvConfig.CloudProviderAlias),
 		Idle:               result.EnvConfig.Idle,
+		AITool:             strings.TrimSpace(result.EnvConfig.AITool),
+		Claude:             result.EnvConfig.Claude,
 	}
 }
 
@@ -653,7 +670,7 @@ func remoteShellBaseScriptLines(req ShellLaunchParams, config remoteShellConfig,
 	markerDir := fmt.Sprintf("$HOME/.erun/%s/%s", req.Tenant, req.Environment)
 	bashrcPath := markerDir + "/bashrc"
 	requestPath := markerDir + "/shell-request"
-	return []string{
+	lines := []string{
 		"set -eu",
 		"export COLORTERM=truecolor",
 		"export COLORFGBG='15;0'",
@@ -673,11 +690,59 @@ func remoteShellBaseScriptLines(req ShellLaunchParams, config remoteShellConfig,
 		"rm -f \"$request_file\"",
 		"export ERUN_SHELL_REQUEST_FILE=\"$request_file\"",
 		"shell_status=0",
-		fmt.Sprintf("/bin/bash --rcfile \"%s\" -i || shell_status=$?", bashrcPath),
+	}
+	lines = append(lines, remoteShellLaunchLines(req, bashrcPath, markerDir)...)
+	return append(lines,
 		fmt.Sprintf("if [ -e \"$request_file\" ]; then rm -f \"$request_file\"; exit %d; fi", remoteShellReattachDeployExitCode),
 		"rm -f \"$request_file\"",
 		"exit \"$shell_status\"",
+	)
+}
+
+// remoteShellLaunchLines runs the interactive shell. Without AppSession (the
+// bare `erun open` CLI) it is the original single bash invocation, byte for
+// byte. With AppSession (a desktop tab) it runs the shell inside a persistent,
+// reattachable dtach session keyed by the id, so a disconnect detaches (the
+// session — and the AI tab's claude — keeps running in the pod) and the next
+// kubectl exec re-attaches rather than spawning a parallel chain. See #478.
+func remoteShellLaunchLines(req ShellLaunchParams, bashrcPath, markerDir string) []string {
+	if strings.TrimSpace(req.AppSession) == "" {
+		return []string{fmt.Sprintf("/bin/bash --rcfile \"%s\" -i || shell_status=$?", bashrcPath)}
 	}
+	id := sanitizeForFilename(req.AppSession)
+	// dtach sockets live on the pod-ephemeral filesystem so a pod replacement
+	// (redeploy) clears them — no stale socket to reattach to, and
+	// claude --continue resumes the conversation in the fresh session.
+	socket := fmt.Sprintf("/tmp/erun-app/%s-%s-%s.dtach", sanitizeForFilename(req.Tenant), sanitizeForFilename(req.Environment), id)
+	launchScript := fmt.Sprintf("%s/launch-%s.sh", markerDir, id)
+	body := strings.Join(remoteSessionLauncherBody(req, bashrcPath), "\n")
+	return []string{
+		"mkdir -p \"/tmp/erun-app\"",
+		fmt.Sprintf("cat > \"%s\" <<'EOF'\n%s\nEOF", launchScript, body),
+		fmt.Sprintf("dtach -A \"%s\" -r winch /bin/bash \"%s\" || shell_status=$?", socket, launchScript),
+	}
+}
+
+// remoteSessionLauncherBody is the dtach session's create-time program: the
+// per-tab prelude (run once on create) followed by the interactive shell. A
+// reattach connects to whatever this program is running, so the prelude — and
+// in particular the AI tool launch — never repeats.
+func remoteSessionLauncherBody(req ShellLaunchParams, bashrcPath string) []string {
+	var body []string
+	if req.Contribute {
+		// Match the desktop's former contribute prelude (issue #469): the
+		// contribute clone's built binary on PATH, fast incremental rebuilds,
+		// and the clone as the working directory.
+		body = append(body,
+			"export PATH=\"$HOME/.erun/contribute/bin:$PATH\"",
+			"export ERUN_SKIP_LINT=1",
+			"cd \"$HOME/git/erun\"",
+		)
+	}
+	if req.AI {
+		body = append(body, AISessionLaunchCommand(req.AITool, req.Claude))
+	}
+	return append(body, fmt.Sprintf("exec /bin/bash --rcfile \"%s\" -i", bashrcPath))
 }
 
 func remoteShellGitSeedLines(req ShellLaunchParams, redactHostSecrets bool, workdir string) ([]string, error) {

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -767,7 +767,13 @@ func remoteShellLaunchLines(req ShellLaunchParams, bashrcPath, markerDir string)
 		// reports the handover instead of reconnecting into a tug-of-war.
 		"attach_id=\"$$-$(date +%s)\"",
 		fmt.Sprintf("printf '%%s' \"$attach_id\" > \"%s\"", owner),
-		fmt.Sprintf("master_pid=\"$(ss -xlpH 2>/dev/null | grep -F \"%s\" | sed -n 's/.*pid=\\([0-9]*\\).*/\\1/p' | head -n1)\"", socket),
+		// The master is the dtach process with a non-dtach child (the session
+		// program). Clients have no children, and the -A creator's only child
+		// is the master itself. /proc-based on purpose: the runtime image
+		// ships no ss/lsof, and a missing tool must fail open (no kick), not
+		// kill the session.
+		"master_pid=\"\"",
+		fmt.Sprintf("for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if grep -qF \"%s\" \"/proc/$dtach_pid/cmdline\" 2>/dev/null; then for child_pid in $(pgrep -P \"$dtach_pid\" 2>/dev/null || true); do child_comm=\"$(cat \"/proc/$child_pid/comm\" 2>/dev/null)\"; if [ -n \"$child_comm\" ] && [ \"$child_comm\" != \"dtach\" ]; then master_pid=\"$dtach_pid\"; fi; done; fi; done", socket),
 		fmt.Sprintf("if [ -S \"%s\" ] && [ -n \"$master_pid\" ]; then for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if [ \"$dtach_pid\" != \"$master_pid\" ] && grep -qF \"%s\" \"/proc/$dtach_pid/cmdline\" 2>/dev/null; then kill \"$dtach_pid\" 2>/dev/null || true; fi; done; fi", socket, socket),
 		// ctrl_l, not winch: dtach keeps no screen buffer, so a reattach shows
 		// nothing until the program repaints. A same-size attach yields no

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -2,6 +2,7 @@ package eruncommon
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -129,6 +130,11 @@ type ShellLaunchParams struct {
 }
 
 type ShellLaunchPreview struct {
+	// SeedArgs is the `kubectl exec -i` that streams the SSH private key to the
+	// pod on stdin (the key is never in these args). Empty when the env has no
+	// private key to seed (remote-repo env, no resolvable git remote, or no key
+	// file). Traced before the shell exec so the dry-run plan shows the action.
+	SeedArgs []string
 	WaitArgs []string
 	ExecArgs []string
 	Script   string
@@ -561,7 +567,15 @@ func WaitForShellDeployment(req ShellLaunchParams) error {
 }
 
 func ExecShell(req ShellLaunchParams) error {
-	script, err := buildRemoteShellScript(req, false)
+	// Stream the SSH private key to the pod on stdin before the interactive
+	// shell, so it never appears in any kubectl exec argv (laptop `ps`, the
+	// pod's /proc/<pid>/cmdline, or cluster exec audit logs). The interactive
+	// script below seeds only the public known_hosts + ssh config inline.
+	if err := seedRemoteSSHKey(req); err != nil {
+		return err
+	}
+
+	script, err := buildRemoteShellScript(req)
 	if err != nil {
 		return err
 	}
@@ -586,12 +600,22 @@ func ExecShell(req ShellLaunchParams) error {
 }
 
 func PreviewShellLaunch(req ShellLaunchParams) (ShellLaunchPreview, error) {
-	script, err := buildRemoteShellScript(req, true)
+	script, err := buildRemoteShellScript(req)
 	if err != nil {
 		return ShellLaunchPreview{}, err
 	}
 
+	keyMaterial, err := remoteShellPrivateKeyMaterial(req)
+	if err != nil {
+		return ShellLaunchPreview{}, err
+	}
+	var seedArgs []string
+	if strings.TrimSpace(keyMaterial) != "" {
+		seedArgs = remoteSSHKeySeedArgs(req)
+	}
+
 	return ShellLaunchPreview{
+		SeedArgs: seedArgs,
 		WaitArgs: kubectlDeploymentWaitArgs(req),
 		ExecArgs: kubectlExecArgs(req, script),
 		Script:   script,
@@ -642,14 +666,14 @@ func kubectlTargetArgs(req ShellLaunchParams) []string {
 	return args
 }
 
-func buildRemoteShellScript(req ShellLaunchParams, redactHostSecrets bool) (string, error) {
+func buildRemoteShellScript(req ShellLaunchParams) (string, error) {
 	config, err := remoteShellConfigForRequest(req)
 	if err != nil {
 		return "", err
 	}
 	workdir := shellQuote(config.Workdir)
 	scriptLines := remoteShellBaseScriptLines(req, config, workdir, shellQuote(req.Title))
-	gitLines, err := remoteShellGitSeedLines(req, redactHostSecrets, workdir)
+	gitLines, err := remoteShellGitSeedLines(req, workdir)
 	if err != nil {
 		return "", err
 	}
@@ -836,7 +860,7 @@ func remoteSessionLauncherBody(req ShellLaunchParams, bashrcPath string) []strin
 	return append(body, fmt.Sprintf("exec /bin/bash --rcfile \"%s\" -i", bashrcPath))
 }
 
-func remoteShellGitSeedLines(req ShellLaunchParams, redactHostSecrets bool, workdir string) ([]string, error) {
+func remoteShellGitSeedLines(req ShellLaunchParams, workdir string) ([]string, error) {
 	if req.RemoteRepo {
 		return nil, nil
 	}
@@ -844,22 +868,17 @@ func remoteShellGitSeedLines(req ShellLaunchParams, redactHostSecrets bool, work
 	if err != nil {
 		return nil, nil
 	}
-	hostConfigEntries, err := resolveSSHConfigEntries(gitHost)
-	if err != nil {
-		return nil, err
-	}
 	knownHostsLines, err := loadKnownHostsLines(gitHost)
 	if err != nil {
 		return nil, err
 	}
-	keyLines, err := loadPrivateKeyMaterial(hostConfigEntries, redactHostSecrets)
-	if err != nil {
-		return nil, err
-	}
-	return remoteShellGitSeedScriptLines(workdir, gitHost, shellQuote(gitUser), shellQuote(gitRepo), strings.Join(knownHostsLines, "\n"), strings.Join(keyLines, "\n")), nil
+	// The private key is never written by this script — it streams to the pod
+	// on stdin via seedRemoteSSHKey (see ExecShell) so it stays out of the
+	// kubectl exec argv. known_hosts and the ssh config are public and inline.
+	return remoteShellGitSeedScriptLines(workdir, gitHost, shellQuote(gitUser), shellQuote(gitRepo), strings.Join(knownHostsLines, "\n")), nil
 }
 
-func remoteShellGitSeedScriptLines(workdir, gitHost, gitUser, gitRepo, knownHosts, keys string) []string {
+func remoteShellGitSeedScriptLines(workdir, gitHost, gitUser, gitRepo, knownHosts string) []string {
 	sshConfig := strings.Join([]string{
 		fmt.Sprintf("Host %s", gitHost),
 		fmt.Sprintf("  HostName %s", gitHost),
@@ -871,14 +890,14 @@ func remoteShellGitSeedScriptLines(workdir, gitHost, gitUser, gitRepo, knownHost
 		"set -eu",
 		"mkdir -p \"$HOME/.ssh\"",
 		"chmod 700 \"$HOME/.ssh\"",
-		"rm -f \"$HOME/.ssh/known_hosts\" \"$HOME/.ssh/keys\" \"$HOME/.ssh/config\"",
+		// Do not touch ~/.ssh/keys here — seedRemoteSSHKey owns it (stdin).
+		"rm -f \"$HOME/.ssh/known_hosts\" \"$HOME/.ssh/config\"",
 		"old_umask=\"$(umask)\"",
 		"umask 077",
 		fmt.Sprintf("cat > \"$HOME/.ssh/known_hosts\" <<'EOF'\n%s\nEOF", knownHosts),
-		fmt.Sprintf("cat > \"$HOME/.ssh/keys\" <<'EOF'\n%s\nEOF", keys),
 		fmt.Sprintf("cat > \"$HOME/.ssh/config\" <<'EOF'\n%s\nEOF", sshConfig),
 		"umask \"$old_umask\"",
-		"chmod 600 \"$HOME/.ssh/known_hosts\" \"$HOME/.ssh/keys\" \"$HOME/.ssh/config\"",
+		"chmod 600 \"$HOME/.ssh/known_hosts\" \"$HOME/.ssh/config\"",
 		fmt.Sprintf("mkdir -p %s", workdir),
 		fmt.Sprintf("cd %s", workdir),
 		// `git config --global` writes through a `~/.gitconfig.lock`
@@ -1015,7 +1034,11 @@ func loadKnownHostsLines(host string) ([]string, error) {
 	return lines, nil
 }
 
-func loadPrivateKeyMaterial(entries []sshConfigEntry, redact bool) ([]string, error) {
+// loadPrivateKeyMaterial reads the resolved private key files. The material is
+// only ever delivered to the pod on stdin (seedRemoteSSHKey) — never embedded
+// in a script or a command line — so there is no redaction mode: it is not
+// placed anywhere a dry-run trace or log would capture it.
+func loadPrivateKeyMaterial(entries []sshConfigEntry) ([]string, error) {
 	keyPaths := privateKeyPaths(entries)
 
 	lines := make([]string, 0, len(keyPaths))
@@ -1027,14 +1050,69 @@ func loadPrivateKeyMaterial(entries []sshConfigEntry, redact bool) ([]string, er
 			}
 			return nil, err
 		}
-		if redact {
-			lines = append(lines, fmt.Sprintf("# %s", filepath.Base(keyPath)))
-			lines = append(lines, "<redacted>")
-			continue
-		}
 		lines = append(lines, string(data))
 	}
 	return lines, nil
+}
+
+// remoteSSHKeySeedScript writes stdin to ~/.ssh/keys at mode 600. The key bytes
+// arrive on the exec's stdin, never in its argv.
+const remoteSSHKeySeedScript = `umask 077; mkdir -p "$HOME/.ssh"; cat > "$HOME/.ssh/keys"; chmod 600 "$HOME/.ssh/keys"`
+
+// remoteShellPrivateKeyMaterial resolves the SSH private key material the env's
+// git remote needs, or "" when there is nothing to seed (remote-repo env, no
+// resolvable git remote, or no key file present).
+func remoteShellPrivateKeyMaterial(req ShellLaunchParams) (string, error) {
+	if req.RemoteRepo {
+		return "", nil
+	}
+	gitHost, _, _, err := resolveGitRemote(req.Dir)
+	if err != nil {
+		return "", nil
+	}
+	entries, err := resolveSSHConfigEntries(gitHost)
+	if err != nil {
+		return "", err
+	}
+	keyLines, err := loadPrivateKeyMaterial(entries)
+	if err != nil {
+		return "", err
+	}
+	return strings.Join(keyLines, "\n"), nil
+}
+
+// remoteSSHKeySeedArgs is the non-interactive `kubectl exec -i` that streams the
+// private key to the pod. -i (not -it) keeps stdin a pipe for the key bytes;
+// the key is never in these args.
+func remoteSSHKeySeedArgs(req ShellLaunchParams) []string {
+	args := kubectlTargetArgs(req)
+	return append(args, "exec", "-i", "deployment/"+RuntimeReleaseName(req.Tenant), "--", "/bin/sh", "-c", remoteSSHKeySeedScript)
+}
+
+// seedRemoteSSHKey writes the env's SSH private key into the pod's ~/.ssh/keys
+// by piping it on stdin, so it never touches a command line. No-op when there
+// is no key to seed. Runs after the deployment is Available (the open flow
+// waits first) and before the interactive shell exec.
+func seedRemoteSSHKey(req ShellLaunchParams) error {
+	keyMaterial, err := remoteShellPrivateKeyMaterial(req)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(keyMaterial) == "" {
+		return nil
+	}
+	cmd := Command("kubectl", remoteSSHKeySeedArgs(req)...)
+	cmd.Stdin = strings.NewReader(keyMaterial)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err != nil {
+		if message := strings.TrimSpace(output.String()); message != "" {
+			return fmt.Errorf("seed remote ssh key: %w: %s", err, message)
+		}
+		return fmt.Errorf("seed remote ssh key: %w", err)
+	}
+	return nil
 }
 
 func privateKeyPaths(entries []sshConfigEntry) []string {

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -25,6 +25,7 @@ var (
 	ErrRepoPathNotConfigured           = errors.New("repo path is not configured")
 	ErrShellReattachDeploy             = errors.New("remote shell requested deploy handoff and reattach")
 	ErrShellPodReplaced                = errors.New("remote shell pod was replaced; reattach")
+	ErrShellSessionTakenOver           = errors.New("remote session was re-attached in another ERun window")
 
 	openUserHomeDir = os.UserHomeDir
 )
@@ -32,7 +33,41 @@ var (
 const (
 	defaultShellLaunchWaitTimeout     = "2m0s"
 	remoteShellReattachDeployExitCode = 75
+	remoteShellTakenOverExitCode      = 76
 )
+
+// ShellSessionTakenOverNotice is the stable line `erun open` prints when its
+// persistent session is re-attached from another ERun window (screen -d -r
+// semantics: the session keeps running, this viewer is detached). The desktop
+// matches this exact line to stop its reconnect loop instead of stealing the
+// session back, so treat the wording as a public contract.
+const ShellSessionTakenOverNotice = "open: session re-attached in another ERun window"
+
+// RemoteAppSessionSocketDir is where the bootstrap keeps the dtach sockets
+// (and owner files) of persistent desktop sessions inside the runtime pod.
+// Pod-ephemeral on purpose: a pod replacement clears them.
+const RemoteAppSessionSocketDir = "/tmp/erun-app"
+
+// ParseRemoteAppSessionIDs extracts this tenant+env's persistent desktop
+// session ids from an `ls` of RemoteAppSessionSocketDir in the runtime pod.
+// Socket files are named <tenant>-<env>-<id>.dtach with the same name
+// sanitization the bootstrap applies; owner files, other envs' sockets, and
+// ls noise are ignored. The desktop uses the ids to rebuild tabs for sessions
+// another ERun window created.
+func ParseRemoteAppSessionIDs(tenant, environment, lsOutput string) []string {
+	prefix := sanitizeForFilename(tenant) + "-" + sanitizeForFilename(environment) + "-"
+	var ids []string
+	for _, raw := range strings.Split(lsOutput, "\n") {
+		name := strings.TrimSpace(raw)
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ".dtach") {
+			continue
+		}
+		if id := strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".dtach"); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
 
 type OpenStore interface {
 	LoadERunConfig() (ERunConfig, string, error)
@@ -539,6 +574,9 @@ func ExecShell(req ShellLaunchParams) error {
 		if isShellReattachDeployExit(err) {
 			return ErrShellReattachDeploy
 		}
+		if isShellTakenOverExit(err) {
+			return ErrShellSessionTakenOver
+		}
 		if isShellReplacementExit(err) && shellReplacementPodReady(req, runOpenKubectl) {
 			return ErrShellPodReplaced
 		}
@@ -713,17 +751,30 @@ func remoteShellLaunchLines(req ShellLaunchParams, bashrcPath, markerDir string)
 	// dtach sockets live on the pod-ephemeral filesystem so a pod replacement
 	// (redeploy) clears them — no stale socket to reattach to, and
 	// claude --continue resumes the conversation in the fresh session.
-	socket := fmt.Sprintf("/tmp/erun-app/%s-%s-%s.dtach", sanitizeForFilename(req.Tenant), sanitizeForFilename(req.Environment), id)
+	socket := fmt.Sprintf("%s/%s-%s-%s.dtach", RemoteAppSessionSocketDir, sanitizeForFilename(req.Tenant), sanitizeForFilename(req.Environment), id)
+	owner := strings.TrimSuffix(socket, ".dtach") + ".owner"
 	launchScript := fmt.Sprintf("%s/launch-%s.sh", markerDir, id)
 	body := strings.Join(remoteSessionLauncherBody(req, bashrcPath), "\n")
 	return []string{
-		"mkdir -p \"/tmp/erun-app\"",
+		fmt.Sprintf("mkdir -p \"%s\"", RemoteAppSessionSocketDir),
 		fmt.Sprintf("cat > \"%s\" <<'EOF'\n%s\nEOF", launchScript, body),
+		// Take over the session from any other ERun window (screen-style
+		// detach-elsewhere-and-reattach-here): claim ownership, then detach
+		// other viewers by killing their dtach clients. The master — ss's
+		// listener pid, which owns the running shell/claude — is never
+		// touched, and when it cannot be identified no one is kicked. Kicked
+		// wrappers find a foreign owner id below and exit 76 so their window
+		// reports the handover instead of reconnecting into a tug-of-war.
+		"attach_id=\"$$-$(date +%s)\"",
+		fmt.Sprintf("printf '%%s' \"$attach_id\" > \"%s\"", owner),
+		fmt.Sprintf("master_pid=\"$(ss -xlpH 2>/dev/null | grep -F \"%s\" | sed -n 's/.*pid=\\([0-9]*\\).*/\\1/p' | head -n1)\"", socket),
+		fmt.Sprintf("if [ -S \"%s\" ] && [ -n \"$master_pid\" ]; then for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if [ \"$dtach_pid\" != \"$master_pid\" ] && grep -qF \"%s\" \"/proc/$dtach_pid/cmdline\" 2>/dev/null; then kill \"$dtach_pid\" 2>/dev/null || true; fi; done; fi", socket, socket),
 		// ctrl_l, not winch: dtach keeps no screen buffer, so a reattach shows
 		// nothing until the program repaints. A same-size attach yields no
 		// effective WINCH (bash's readline and claude's TUI both stay silent);
 		// the ^L dtach sends on attach makes both repaint immediately.
 		fmt.Sprintf("dtach -A \"%s\" -r ctrl_l /bin/bash \"%s\" || shell_status=$?", socket, launchScript),
+		fmt.Sprintf("if [ \"$(cat \"%s\" 2>/dev/null)\" != \"$attach_id\" ]; then exit %d; fi", owner, remoteShellTakenOverExitCode),
 	}
 }
 
@@ -831,6 +882,14 @@ func isShellReattachDeployExit(err error) bool {
 		return false
 	}
 	return exitErr.ExitCode() == remoteShellReattachDeployExitCode
+}
+
+func isShellTakenOverExit(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	return exitErr.ExitCode() == remoteShellTakenOverExitCode
 }
 
 func isShellReplacementExit(err error) bool {

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -719,7 +719,11 @@ func remoteShellLaunchLines(req ShellLaunchParams, bashrcPath, markerDir string)
 	return []string{
 		"mkdir -p \"/tmp/erun-app\"",
 		fmt.Sprintf("cat > \"%s\" <<'EOF'\n%s\nEOF", launchScript, body),
-		fmt.Sprintf("dtach -A \"%s\" -r winch /bin/bash \"%s\" || shell_status=$?", socket, launchScript),
+		// ctrl_l, not winch: dtach keeps no screen buffer, so a reattach shows
+		// nothing until the program repaints. A same-size attach yields no
+		// effective WINCH (bash's readline and claude's TUI both stay silent);
+		// the ^L dtach sends on attach makes both repaint immediately.
+		fmt.Sprintf("dtach -A \"%s\" -r ctrl_l /bin/bash \"%s\" || shell_status=$?", socket, launchScript),
 	}
 }
 

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -748,32 +748,25 @@ func remoteShellLaunchLines(req ShellLaunchParams, bashrcPath, markerDir string)
 		return []string{fmt.Sprintf("/bin/bash --rcfile \"%s\" -i || shell_status=$?", bashrcPath)}
 	}
 	id := sanitizeForFilename(req.AppSession)
-	// dtach sockets live on the pod-ephemeral filesystem so a pod replacement
-	// (redeploy) clears them — no stale socket to reattach to, and
-	// claude --continue resumes the conversation in the fresh session.
-	socket := fmt.Sprintf("%s/%s-%s-%s.dtach", RemoteAppSessionSocketDir, sanitizeForFilename(req.Tenant), sanitizeForFilename(req.Environment), id)
+	socket := remoteAppSessionSocketPath(req.Tenant, req.Environment, id)
 	owner := strings.TrimSuffix(socket, ".dtach") + ".owner"
 	launchScript := fmt.Sprintf("%s/launch-%s.sh", markerDir, id)
 	body := strings.Join(remoteSessionLauncherBody(req, bashrcPath), "\n")
-	return []string{
+	lines := []string{
 		fmt.Sprintf("mkdir -p \"%s\"", RemoteAppSessionSocketDir),
 		fmt.Sprintf("cat > \"%s\" <<'EOF'\n%s\nEOF", launchScript, body),
 		// Take over the session from any other ERun window (screen-style
 		// detach-elsewhere-and-reattach-here): claim ownership, then detach
-		// other viewers by killing their dtach clients. The master — ss's
-		// listener pid, which owns the running shell/claude — is never
-		// touched, and when it cannot be identified no one is kicked. Kicked
-		// wrappers find a foreign owner id below and exit 76 so their window
-		// reports the handover instead of reconnecting into a tug-of-war.
+		// other viewers by killing their dtach clients. The master — which
+		// owns the running shell/claude — is never touched, and when it
+		// cannot be identified no one is kicked. Kicked wrappers find a
+		// foreign owner id below and exit 76 so their window reports the
+		// handover instead of reconnecting into a tug-of-war.
 		"attach_id=\"$$-$(date +%s)\"",
 		fmt.Sprintf("printf '%%s' \"$attach_id\" > \"%s\"", owner),
-		// The master is the dtach process with a non-dtach child (the session
-		// program). Clients have no children, and the -A creator's only child
-		// is the master itself. /proc-based on purpose: the runtime image
-		// ships no ss/lsof, and a missing tool must fail open (no kick), not
-		// kill the session.
-		"master_pid=\"\"",
-		fmt.Sprintf("for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if grep -qF \"%s\" \"/proc/$dtach_pid/cmdline\" 2>/dev/null; then for child_pid in $(pgrep -P \"$dtach_pid\" 2>/dev/null || true); do child_comm=\"$(cat \"/proc/$child_pid/comm\" 2>/dev/null)\"; if [ -n \"$child_comm\" ] && [ \"$child_comm\" != \"dtach\" ]; then master_pid=\"$dtach_pid\"; fi; done; fi; done", socket),
+	}
+	lines = append(lines, remoteAppSessionMasterScanLines(socket)...)
+	return append(lines,
 		fmt.Sprintf("if [ -S \"%s\" ] && [ -n \"$master_pid\" ]; then for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if [ \"$dtach_pid\" != \"$master_pid\" ] && grep -qF \"%s\" \"/proc/$dtach_pid/cmdline\" 2>/dev/null; then kill \"$dtach_pid\" 2>/dev/null || true; fi; done; fi", socket, socket),
 		// ctrl_l, not winch: dtach keeps no screen buffer, so a reattach shows
 		// nothing until the program repaints. A same-size attach yields no
@@ -781,7 +774,44 @@ func remoteShellLaunchLines(req ShellLaunchParams, bashrcPath, markerDir string)
 		// the ^L dtach sends on attach makes both repaint immediately.
 		fmt.Sprintf("dtach -A \"%s\" -r ctrl_l /bin/bash \"%s\" || shell_status=$?", socket, launchScript),
 		fmt.Sprintf("if [ \"$(cat \"%s\" 2>/dev/null)\" != \"$attach_id\" ]; then exit %d; fi", owner, remoteShellTakenOverExitCode),
+	)
+}
+
+// remoteAppSessionSocketPath is the dtach socket for one persistent desktop
+// session. Pod-ephemeral on purpose: a pod replacement clears the sockets —
+// no stale socket to reattach to, and claude --continue resumes the
+// conversation in the fresh session.
+func remoteAppSessionSocketPath(tenant, environment, id string) string {
+	return fmt.Sprintf("%s/%s-%s-%s.dtach", RemoteAppSessionSocketDir, sanitizeForFilename(tenant), sanitizeForFilename(environment), sanitizeForFilename(id))
+}
+
+// remoteAppSessionMasterScanLines emits the sh lines that resolve $master_pid
+// for the session socket: the dtach process with a non-dtach child (the
+// session program). Clients have no children, and the -A creator's only child
+// is the master itself. /proc-based on purpose: the runtime image ships no
+// ss/lsof, and an unidentifiable master must leave $master_pid empty so
+// callers fail open instead of killing the session.
+func remoteAppSessionMasterScanLines(socket string) []string {
+	return []string{
+		"master_pid=\"\"",
+		fmt.Sprintf("for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if grep -qF \"%s\" \"/proc/$dtach_pid/cmdline\" 2>/dev/null; then for child_pid in $(pgrep -P \"$dtach_pid\" 2>/dev/null || true); do child_comm=\"$(cat \"/proc/$child_pid/comm\" 2>/dev/null)\"; if [ -n \"$child_comm\" ] && [ \"$child_comm\" != \"dtach\" ]; then master_pid=\"$dtach_pid\"; fi; done; fi; done", socket),
 	}
+}
+
+// RemoteAppSessionEndScript returns the sh script that permanently ends a
+// persistent desktop session: kill the dtach master (its program follows via
+// SIGHUP when the pty disappears) and remove the socket and owner file. The
+// desktop runs it when the user explicitly closes a custom terminal tab —
+// unlike closing the env or quitting the app, which only detach and leave the
+// session running for the next attach.
+func RemoteAppSessionEndScript(tenant, environment, id string) string {
+	socket := remoteAppSessionSocketPath(tenant, environment, id)
+	lines := remoteAppSessionMasterScanLines(socket)
+	lines = append(lines,
+		"if [ -n \"$master_pid\" ]; then kill \"$master_pid\" 2>/dev/null || true; fi",
+		fmt.Sprintf("rm -f \"%s\" \"%s\"", socket, strings.TrimSuffix(socket, ".dtach")+".owner"),
+	)
+	return strings.Join(lines, "\n")
 }
 
 // remoteSessionLauncherBody is the dtach session's create-time program: the

--- a/erun-common/open_reconnect_test.go
+++ b/erun-common/open_reconnect_test.go
@@ -54,12 +54,37 @@ func TestRemoteShellLaunchPersistentSession(t *testing.T) {
 		}
 	})
 
+	t.Run("attach takes the session over from other windows", func(t *testing.T) {
+		// screen-style detach-elsewhere-and-reattach-here: the attach claims
+		// an owner id, detaches other viewers by killing their dtach clients
+		// (never the master, which owns the running shell/claude — and no one
+		// when the master cannot be identified), and a kicked wrapper sees the
+		// foreign owner id and exits 76 so its window reports the handover.
+		req := base
+		req.AppSession = "open-0"
+		script := preview(t, req)
+		owner := `/tmp/erun-app/erun-local-open-0.owner`
+		if !strings.Contains(script, `printf '%s' "$attach_id" > "`+owner+`"`) {
+			t.Fatalf("attach must claim the owner file:\n%s", script)
+		}
+		if !strings.Contains(script, `if [ "$dtach_pid" != "$master_pid" ]`) {
+			t.Fatalf("kick loop must spare the session master:\n%s", script)
+		}
+		if !strings.Contains(script, `[ -S "/tmp/erun-app/erun-local-open-0.dtach" ] && [ -n "$master_pid" ]`) {
+			t.Fatalf("kick must be skipped when the master cannot be identified:\n%s", script)
+		}
+		if !strings.Contains(script, `!= "$attach_id" ]; then exit 76; fi`) {
+			t.Fatalf("kicked wrapper must exit 76 on foreign owner:\n%s", script)
+		}
+	})
+
 	t.Run("each terminal slot owns its own session", func(t *testing.T) {
-		// One env can carry several live sessions at once: custom "Terminal N"
-		// tabs in one app instance get distinct slot ids, while a second app
-		// instance (or machine) passing the same id shares the same socket and
-		// so reattaches to the same running shell. The socket key is
-		// tenant+env+id only — never anything app-instance-specific.
+		// One env carries exactly one session per id: custom "Terminal N" tabs
+		// get distinct slot ids, and a second ERun window passing the same id
+		// attaches to the same socket — taking the session over rather than
+		// spawning a parallel one. The socket key is tenant+env+id only, never
+		// anything app-instance-specific, and a takeover for one id must not
+		// touch any other slot's session.
 		req := base
 		req.AppSession = "open-1"
 		script := preview(t, req)
@@ -102,4 +127,31 @@ func TestRemoteShellLaunchPersistentSession(t *testing.T) {
 			t.Fatalf("contribute env missing:\n%s", script)
 		}
 	})
+}
+
+// TestParseRemoteAppSessionIDs pins the detection contract: a pod's
+// /tmp/erun-app listing yields exactly this env's session ids — dtach sockets
+// only, owner files and other envs' sockets ignored — so a fresh ERun window
+// can rebuild tabs for sessions another window created.
+func TestParseRemoteAppSessionIDs(t *testing.T) {
+	lsOutput := strings.Join([]string{
+		"erun-local-open-0.dtach",
+		"erun-local-open-1.dtach",
+		"erun-local-ai.dtach",
+		"erun-local-ai.owner",
+		"erun-local-contribute-ai.dtach",
+		"other-env-open-2.dtach",
+		"",
+		"not-a-socket",
+	}, "\n")
+	got := ParseRemoteAppSessionIDs("erun", "local", lsOutput)
+	want := []string{"open-0", "open-1", "ai", "contribute-ai"}
+	if len(got) != len(want) {
+		t.Fatalf("ParseRemoteAppSessionIDs = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ParseRemoteAppSessionIDs = %v, want %v", got, want)
+		}
+	}
 }

--- a/erun-common/open_reconnect_test.go
+++ b/erun-common/open_reconnect_test.go
@@ -1,0 +1,88 @@
+package eruncommon
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRemoteShellLaunchPersistentSession pins the #478 reconnect mechanism: a
+// desktop tab (AppSession set) runs the remote shell inside a persistent dtach
+// session keyed by the id, with the per-tab prelude (contribute cd, AI launch)
+// as the session's create-time program; the bare `erun open` CLI path is left
+// byte-for-byte unchanged.
+func TestRemoteShellLaunchPersistentSession(t *testing.T) {
+	base := ShellLaunchParams{
+		Tenant:      "erun",
+		Environment: "local",
+		Title:       "erun/local",
+		Namespace:   "erun-local",
+		RemoteRepo:  true, // skip the git-seed lines; focus on the launch path
+	}
+	const bashrc = `/bin/bash --rcfile "$HOME/.erun/erun/local/bashrc" -i`
+
+	preview := func(t *testing.T, req ShellLaunchParams) string {
+		t.Helper()
+		p, err := PreviewShellLaunch(req)
+		if err != nil {
+			t.Fatalf("PreviewShellLaunch: %v", err)
+		}
+		return p.Script
+	}
+
+	t.Run("bare CLI is unchanged (no dtach)", func(t *testing.T) {
+		script := preview(t, base)
+		if strings.Contains(script, "dtach") {
+			t.Fatalf("bare `erun open` must not use dtach:\n%s", script)
+		}
+		if !strings.Contains(script, bashrc+" || shell_status=$?") {
+			t.Fatalf("bare path lost its original bash invocation:\n%s", script)
+		}
+	})
+
+	t.Run("ERun tab persists via dtach, plain shell", func(t *testing.T) {
+		req := base
+		req.AppSession = "open-0"
+		script := preview(t, req)
+		if !strings.Contains(script, `dtach -A "/tmp/erun-app/erun-local-open-0.dtach" -r winch /bin/bash`) {
+			t.Fatalf("ERun tab missing dtach wrap:\n%s", script)
+		}
+		if strings.Contains(script, "claude") || strings.Contains(script, "ERUN_SKIP_LINT") {
+			t.Fatalf("plain ERun shell must not launch claude or set contribute env:\n%s", script)
+		}
+		if !strings.Contains(script, "exec "+bashrc) {
+			t.Fatalf("launcher must exec the interactive shell:\n%s", script)
+		}
+	})
+
+	t.Run("AI tab launches claude once as the session program", func(t *testing.T) {
+		req := base
+		req.AppSession = "ai"
+		req.AI = true
+		script := preview(t, req)
+		if !strings.Contains(script, `dtach -A "/tmp/erun-app/erun-local-ai.dtach"`) {
+			t.Fatalf("AI tab missing dtach wrap:\n%s", script)
+		}
+		if !strings.Contains(script, "claude --continue --effort max") {
+			t.Fatalf("AI tab must launch the claude guard at the env effort:\n%s", script)
+		}
+		if !strings.Contains(script, "exec "+bashrc) {
+			t.Fatalf("AI launcher must drop to an interactive shell after claude:\n%s", script)
+		}
+	})
+
+	t.Run("contribute-AI tab cds to the clone, then claude", func(t *testing.T) {
+		req := base
+		req.AppSession = "contribute-ai"
+		req.AI = true
+		req.Contribute = true
+		script := preview(t, req)
+		clone := strings.Index(script, `cd "$HOME/git/erun"`)
+		claude := strings.Index(script, "claude --continue")
+		if clone < 0 || claude < 0 || clone > claude {
+			t.Fatalf("contribute-AI must cd to the clone before launching claude:\n%s", script)
+		}
+		if !strings.Contains(script, "ERUN_SKIP_LINT") {
+			t.Fatalf("contribute env missing:\n%s", script)
+		}
+	})
+}

--- a/erun-common/open_reconnect_test.go
+++ b/erun-common/open_reconnect_test.go
@@ -158,3 +158,25 @@ func TestParseRemoteAppSessionIDs(t *testing.T) {
 		}
 	}
 }
+
+// TestRemoteAppSessionEndScript pins the explicit-close contract: ending a
+// custom terminal kills the session master (the program follows via SIGHUP)
+// and removes the socket and owner file, so detection cannot rebuild the tab.
+// The master scan is the same /proc child scan the attach uses; an
+// unidentifiable master means nothing is killed (fail open) but the socket
+// still goes away.
+func TestRemoteAppSessionEndScript(t *testing.T) {
+	script := RemoteAppSessionEndScript("erun", "local", "open-2")
+	for _, want := range []string{
+		`[ "$child_comm" != "dtach" ]`,
+		`if [ -n "$master_pid" ]; then kill "$master_pid" 2>/dev/null || true; fi`,
+		`rm -f "/tmp/erun-app/erun-local-open-2.dtach" "/tmp/erun-app/erun-local-open-2.owner"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("end script missing %q:\n%s", want, script)
+		}
+	}
+	if strings.Contains(script, "dtach -A") {
+		t.Fatalf("end script must not attach:\n%s", script)
+	}
+}

--- a/erun-common/open_reconnect_test.go
+++ b/erun-common/open_reconnect_test.go
@@ -180,3 +180,67 @@ func TestRemoteAppSessionEndScript(t *testing.T) {
 		t.Fatalf("end script must not attach:\n%s", script)
 	}
 }
+
+// TestRemoteShellGitSeedKeepsPrivateKeyOffArgv pins the security fix: the
+// inline bootstrap script seeds only the public known_hosts + ssh config and
+// clones the repo; it never writes the private key. The key reaches the pod
+// only via the separate seed exec's stdin, so it can never land in a kubectl
+// exec argv (laptop `ps`, the pod's /proc/<pid>/cmdline, or exec audit logs).
+func TestRemoteShellGitSeedKeepsPrivateKeyOffArgv(t *testing.T) {
+	lines := remoteShellGitSeedScriptLines(
+		`"$HOME/git/erun"`, "github.com", shellQuote("sophium"), shellQuote("erun"),
+		"github.com ssh-ed25519 AAAAEXAMPLE",
+	)
+	script := strings.Join(lines, "\n")
+
+	// The script must not WRITE / rm / chmod ~/.ssh/keys ($HOME form). The ssh
+	// config still *references* the key file via `~/.ssh/keys` (tilde) — that is
+	// a pointer, not the key material — so assert on the $HOME form the
+	// write/rm/chmod used.
+	if strings.Contains(script, `"$HOME/.ssh/keys"`) {
+		t.Fatalf("inline script must not write/rm/chmod the private key file:\n%s", script)
+	}
+	if strings.Contains(script, "PRIVATE KEY") {
+		t.Fatalf("inline script must not contain private key material:\n%s", script)
+	}
+	if !strings.Contains(script, `cat > "$HOME/.ssh/known_hosts"`) ||
+		!strings.Contains(script, `cat > "$HOME/.ssh/config"`) {
+		t.Fatalf("inline script must still seed the public known_hosts + config:\n%s", script)
+	}
+	if !strings.Contains(script, "IdentityFile ~/.ssh/keys") {
+		t.Fatalf("ssh config must still point at the seeded key file:\n%s", script)
+	}
+	if !strings.Contains(script, "git clone git@github.com:'sophium'/'erun'.git") {
+		t.Fatalf("inline script must still clone the repo:\n%s", script)
+	}
+}
+
+// TestRemoteSSHKeySeedArgsStreamOnStdin pins that the key-seed exec is a
+// non-interactive `kubectl exec -i` whose program reads the key from stdin
+// (`cat > ~/.ssh/keys`) — so the key bytes never appear in the argv.
+func TestRemoteSSHKeySeedArgsStreamOnStdin(t *testing.T) {
+	args := remoteSSHKeySeedArgs(ShellLaunchParams{Tenant: "erun", KubernetesContext: "ctx", Namespace: "erun-local"})
+
+	sawI, sawIT := false, false
+	for _, a := range args {
+		if a == "-i" {
+			sawI = true
+		}
+		if a == "-it" {
+			sawIT = true
+		}
+	}
+	if !sawI || sawIT {
+		t.Fatalf("seed must use a non-interactive exec (-i, not -it): %v", args)
+	}
+	joined := strings.Join(args, "\x00")
+	if !strings.Contains(joined, `cat > "$HOME/.ssh/keys"`) {
+		t.Fatalf("seed program must write the key from stdin to ~/.ssh/keys: %v", args)
+	}
+	if !strings.Contains(joined, "umask 077") || !strings.Contains(joined, "chmod 600") {
+		t.Fatalf("seed must create the key 0600 under a tight umask: %v", args)
+	}
+	if !strings.Contains(joined, "deployment/erun-devops") {
+		t.Fatalf("seed must target the runtime deployment: %v", args)
+	}
+}

--- a/erun-common/open_reconnect_test.go
+++ b/erun-common/open_reconnect_test.go
@@ -70,6 +70,9 @@ func TestRemoteShellLaunchPersistentSession(t *testing.T) {
 		if !strings.Contains(script, `if [ "$dtach_pid" != "$master_pid" ]`) {
 			t.Fatalf("kick loop must spare the session master:\n%s", script)
 		}
+		if !strings.Contains(script, `[ "$child_comm" != "dtach" ]`) {
+			t.Fatalf("master detection must be the /proc child scan (runtime image has no ss):\n%s", script)
+		}
 		if !strings.Contains(script, `[ -S "/tmp/erun-app/erun-local-open-0.dtach" ] && [ -n "$master_pid" ]`) {
 			t.Fatalf("kick must be skipped when the master cannot be identified:\n%s", script)
 		}

--- a/erun-common/open_reconnect_test.go
+++ b/erun-common/open_reconnect_test.go
@@ -43,7 +43,7 @@ func TestRemoteShellLaunchPersistentSession(t *testing.T) {
 		req := base
 		req.AppSession = "open-0"
 		script := preview(t, req)
-		if !strings.Contains(script, `dtach -A "/tmp/erun-app/erun-local-open-0.dtach" -r winch /bin/bash`) {
+		if !strings.Contains(script, `dtach -A "/tmp/erun-app/erun-local-open-0.dtach" -r ctrl_l /bin/bash`) {
 			t.Fatalf("ERun tab missing dtach wrap:\n%s", script)
 		}
 		if strings.Contains(script, "claude") || strings.Contains(script, "ERUN_SKIP_LINT") {
@@ -54,12 +54,29 @@ func TestRemoteShellLaunchPersistentSession(t *testing.T) {
 		}
 	})
 
+	t.Run("each terminal slot owns its own session", func(t *testing.T) {
+		// One env can carry several live sessions at once: custom "Terminal N"
+		// tabs in one app instance get distinct slot ids, while a second app
+		// instance (or machine) passing the same id shares the same socket and
+		// so reattaches to the same running shell. The socket key is
+		// tenant+env+id only — never anything app-instance-specific.
+		req := base
+		req.AppSession = "open-1"
+		script := preview(t, req)
+		if !strings.Contains(script, `dtach -A "/tmp/erun-app/erun-local-open-1.dtach" -r ctrl_l`) {
+			t.Fatalf("slot 1 missing its own dtach socket:\n%s", script)
+		}
+		if strings.Contains(script, "open-0") {
+			t.Fatalf("slot 1 must not touch slot 0's session:\n%s", script)
+		}
+	})
+
 	t.Run("AI tab launches claude once as the session program", func(t *testing.T) {
 		req := base
 		req.AppSession = "ai"
 		req.AI = true
 		script := preview(t, req)
-		if !strings.Contains(script, `dtach -A "/tmp/erun-app/erun-local-ai.dtach"`) {
+		if !strings.Contains(script, `dtach -A "/tmp/erun-app/erun-local-ai.dtach" -r ctrl_l`) {
 			t.Fatalf("AI tab missing dtach wrap:\n%s", script)
 		}
 		if !strings.Contains(script, "claude --continue --effort max") {

--- a/erun-devops/docker/erun-devops/Dockerfile
+++ b/erun-devops/docker/erun-devops/Dockerfile
@@ -80,7 +80,7 @@ USER root
 # contribute-app browser bridge is the only way to test desktop-side
 # changes without leaving the env.
 RUN apt-get update && \
-    apt-get install -y git bash-completion bubblewrap dpkg-dev procps \
+    apt-get install -y git bash-completion bubblewrap dpkg-dev dtach procps \
         build-essential pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev && \
     rm -rf /var/lib/apt/lists/* && \
     case "${TARGETARCH}" in \

--- a/erun-docs/docs/desktop/overview.md
+++ b/erun-docs/docs/desktop/overview.md
@@ -20,7 +20,7 @@ For CI/CD pipelines and headless workflows, use the [CLI](/cli/overview) instead
 
 ## Open it in your editor
 
-- **Persistent terminal sessions.** Each environment owns its own terminals. Switching tabs doesn't kill them. Your scrollback survives.
+- **Persistent terminal sessions.** Each environment owns its own terminals, and switching tabs doesn't kill them. For an environment backed by a runtime pod, the sessions live in the pod and keep running even while the environment is closed — a long-running Agent keeps working while you're away — so reopening reconnects you to the same sessions and scrollback instead of starting fresh ones.
 - **VS Code or IntelliJ in one click.** The IDE attaches to the environment's filesystem — editor, extensions, language servers, debugger, everything sees the same files the Agent sees.
 - **Any other editor that supports SSH.** Cursor, Zed, JetBrains Gateway, Neovim with remote plugins, anything else — the desktop publishes the local SSH details, point your editor at them.
 

--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -262,6 +262,43 @@ func TestOpen(t *testing.T) {
 		golden.Equal(t, "open/remote_dry_run_propagates_host_credentials_opt_in", normalize.Apply(result.Combined))
 	})
 
+	t.Run("app_session_ai_dry_run_wraps_dtach_and_launches_claude", func(t *testing.T) {
+		// #478: the desktop AI tab runs `erun open --app-session ai --ai`. Without
+		// --no-shell the dry-run reaches traceShellPreview, so the bootstrap-script
+		// block locks that the remote program is wrapped in a persistent dtach
+		// session (so reopening reconnects instead of stranding a parallel claude)
+		// and that the cwd-guarded claude is that session's create-time program.
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--app-session", "ai", "--ai", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/app_session_ai_dry_run_wraps_dtach_and_launches_claude", normalize.Apply(result.Combined))
+	})
+
+	t.Run("app_session_shell_dry_run_wraps_dtach", func(t *testing.T) {
+		// The ERun and custom "Terminal N" tabs run `erun open --app-session open-N`:
+		// the same persistent dtach session but running a plain interactive shell —
+		// no claude launch and no contribute prelude in the launcher body.
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--app-session", "open-0", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/app_session_shell_dry_run_wraps_dtach", normalize.Apply(result.Combined))
+	})
+
+	t.Run("app_session_contribute_ai_dry_run_preludes_clone", func(t *testing.T) {
+		// #478: the contribute-AI tab runs `erun open --app-session contribute-ai
+		// --contribute --ai`. The persistent dtach launcher must prepend the
+		// contribute prelude (contribute toolchain on PATH, ERUN_SKIP_LINT, cd into
+		// the cloned repo) before launching the cwd-guarded claude, all inside the
+		// reattachable session.
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--app-session", "contribute-ai", "--contribute", "--ai", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/app_session_contribute_ai_dry_run_preludes_clone", normalize.Apply(result.Combined))
+	})
+
 	t.Run("vscode_dry_run", func(t *testing.T) {
 		// VSCode against an sshd-enabled remote env: dry-run must reach
 		// past validateIDEOptions and emit the redeploy / port-forward /

--- a/erun-integration/testdata/open/app_session_ai_dry_run_wraps_dtach_and_launches_claude.txt
+++ b/erun-integration/testdata/open/app_session_ai_dry_run_wraps_dtach_and_launches_claude.txt
@@ -63,7 +63,12 @@ bootstrap-script:
   if [ -d "$HOME/.claude/projects/$(pwd | tr / -)" ]; then claude --continue --effort max; else claude --effort max; fi
   exec /bin/bash --rcfile "$HOME/.erun/team/dev/bashrc" -i
   EOF
+  attach_id="$$-$(date +%s)"
+  printf '%s' "$attach_id" > "<TMP>"
+  master_pid="$(ss -xlpH 2>/dev/null | grep -F "<TMP>" | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | head -n1)"
+  if [ -S "<TMP>" ] && [ -n "$master_pid" ]; then for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if [ "$dtach_pid" != "$master_pid" ] && grep -qF "<TMP>" "/proc/$dtach_pid/cmdline" 2>/dev/null; then kill "$dtach_pid" 2>/dev/null || true; fi; done; fi
   dtach -A "<TMP>" -r ctrl_l /bin/bash "$HOME/.erun/team/dev/launch-ai.sh" || shell_status=$?
+  if [ "$(cat "<TMP>" 2>/dev/null)" != "$attach_id" ]; then exit 76; fi
   if [ -e "$request_file" ]; then rm -f "$request_file"; exit 75; fi
   rm -f "$request_file"
   exit "$shell_status"

--- a/erun-integration/testdata/open/app_session_ai_dry_run_wraps_dtach_and_launches_claude.txt
+++ b/erun-integration/testdata/open/app_session_ai_dry_run_wraps_dtach_and_launches_claude.txt
@@ -1,0 +1,70 @@
+audit: erun open --ai --app-session ai --dry-run team dev
+config: would assign localportrangestart=17000 to team/dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=false ide=shell
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+deploying the devops runtime before opening the shell
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=pvc --set-string worktreeRepoName=team --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev wait --for=condition=Available --timeout 2m0s deployment/team-devops
+kubectl --context test-context --namespace team-dev exec -it deployment/team-devops -- /bin/sh -lc '<bootstrap-script>'
+bootstrap-script:
+  set -eu
+  export COLORTERM=truecolor
+  export COLORFGBG='15;0'
+  mkdir -p '<HOME>/git/team'
+  cd '<HOME>/git/team'
+  config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+  mkdir -p "$config_home/erun"
+  cat > "$config_home/erun/config.yaml" <<'EOF'
+  defaulttenant: team
+
+  EOF
+  mkdir -p "$config_home/erun/team"
+  cat > "$config_home/erun/team/config.yaml" <<'EOF'
+  projectroot: <HOME>/git/team
+  name: team
+  defaultenvironment: dev
+
+  EOF
+  mkdir -p "$config_home/erun/team/dev"
+  cat > "$config_home/erun/team/dev/config.yaml" <<'EOF'
+  name: dev
+  repopath: <HOME>/git/team
+  kubernetescontext: test-context
+  containerregistry: ""
+  remote: true
+
+  EOF
+  mkdir -p "$HOME/.erun/team/dev"
+  cat > "$HOME/.erun/team/dev/bashrc" <<'EOF'
+  export ERUN_SHELL_HOST='team-dev'
+  erun() {
+    if [ "${1:-}" = "deploy" ] && [ "$#" -eq 1 ] && [ -n "${ERUN_SHELL_REQUEST_FILE:-}" ]; then
+      : > "$ERUN_SHELL_REQUEST_FILE"
+      exit 0
+    fi
+    command erun "$@"
+  }
+  EOF
+  printf '\033]0;'team-dev'\007'
+  request_file="$HOME/.erun/team/dev/shell-request"
+  rm -f "$request_file"
+  export ERUN_SHELL_REQUEST_FILE="$request_file"
+  shell_status=0
+  mkdir -p "<TMP>"
+  cat > "$HOME/.erun/team/dev/launch-ai.sh" <<'EOF'
+  if [ -d "$HOME/.claude/projects/$(pwd | tr / -)" ]; then claude --continue --effort max; else claude --effort max; fi
+  exec /bin/bash --rcfile "$HOME/.erun/team/dev/bashrc" -i
+  EOF
+  dtach -A "<TMP>" -r winch /bin/bash "$HOME/.erun/team/dev/launch-ai.sh" || shell_status=$?
+  if [ -e "$request_file" ]; then rm -f "$request_file"; exit 75; fi
+  rm -f "$request_file"
+  exit "$shell_status"
+open: dry-run complete; would have launched shell

--- a/erun-integration/testdata/open/app_session_ai_dry_run_wraps_dtach_and_launches_claude.txt
+++ b/erun-integration/testdata/open/app_session_ai_dry_run_wraps_dtach_and_launches_claude.txt
@@ -63,7 +63,7 @@ bootstrap-script:
   if [ -d "$HOME/.claude/projects/$(pwd | tr / -)" ]; then claude --continue --effort max; else claude --effort max; fi
   exec /bin/bash --rcfile "$HOME/.erun/team/dev/bashrc" -i
   EOF
-  dtach -A "<TMP>" -r winch /bin/bash "$HOME/.erun/team/dev/launch-ai.sh" || shell_status=$?
+  dtach -A "<TMP>" -r ctrl_l /bin/bash "$HOME/.erun/team/dev/launch-ai.sh" || shell_status=$?
   if [ -e "$request_file" ]; then rm -f "$request_file"; exit 75; fi
   rm -f "$request_file"
   exit "$shell_status"

--- a/erun-integration/testdata/open/app_session_ai_dry_run_wraps_dtach_and_launches_claude.txt
+++ b/erun-integration/testdata/open/app_session_ai_dry_run_wraps_dtach_and_launches_claude.txt
@@ -65,7 +65,8 @@ bootstrap-script:
   EOF
   attach_id="$$-$(date +%s)"
   printf '%s' "$attach_id" > "<TMP>"
-  master_pid="$(ss -xlpH 2>/dev/null | grep -F "<TMP>" | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | head -n1)"
+  master_pid=""
+  for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if grep -qF "<TMP>" "/proc/$dtach_pid/cmdline" 2>/dev/null; then for child_pid in $(pgrep -P "$dtach_pid" 2>/dev/null || true); do child_comm="$(cat "/proc/$child_pid/comm" 2>/dev/null)"; if [ -n "$child_comm" ] && [ "$child_comm" != "dtach" ]; then master_pid="$dtach_pid"; fi; done; fi; done
   if [ -S "<TMP>" ] && [ -n "$master_pid" ]; then for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if [ "$dtach_pid" != "$master_pid" ] && grep -qF "<TMP>" "/proc/$dtach_pid/cmdline" 2>/dev/null; then kill "$dtach_pid" 2>/dev/null || true; fi; done; fi
   dtach -A "<TMP>" -r ctrl_l /bin/bash "$HOME/.erun/team/dev/launch-ai.sh" || shell_status=$?
   if [ "$(cat "<TMP>" 2>/dev/null)" != "$attach_id" ]; then exit 76; fi

--- a/erun-integration/testdata/open/app_session_contribute_ai_dry_run_preludes_clone.txt
+++ b/erun-integration/testdata/open/app_session_contribute_ai_dry_run_preludes_clone.txt
@@ -68,7 +68,8 @@ bootstrap-script:
   EOF
   attach_id="$$-$(date +%s)"
   printf '%s' "$attach_id" > "<TMP>"
-  master_pid="$(ss -xlpH 2>/dev/null | grep -F "<TMP>" | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | head -n1)"
+  master_pid=""
+  for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if grep -qF "<TMP>" "/proc/$dtach_pid/cmdline" 2>/dev/null; then for child_pid in $(pgrep -P "$dtach_pid" 2>/dev/null || true); do child_comm="$(cat "/proc/$child_pid/comm" 2>/dev/null)"; if [ -n "$child_comm" ] && [ "$child_comm" != "dtach" ]; then master_pid="$dtach_pid"; fi; done; fi; done
   if [ -S "<TMP>" ] && [ -n "$master_pid" ]; then for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if [ "$dtach_pid" != "$master_pid" ] && grep -qF "<TMP>" "/proc/$dtach_pid/cmdline" 2>/dev/null; then kill "$dtach_pid" 2>/dev/null || true; fi; done; fi
   dtach -A "<TMP>" -r ctrl_l /bin/bash "$HOME/.erun/team/dev/launch-contribute-ai.sh" || shell_status=$?
   if [ "$(cat "<TMP>" 2>/dev/null)" != "$attach_id" ]; then exit 76; fi

--- a/erun-integration/testdata/open/app_session_contribute_ai_dry_run_preludes_clone.txt
+++ b/erun-integration/testdata/open/app_session_contribute_ai_dry_run_preludes_clone.txt
@@ -66,7 +66,12 @@ bootstrap-script:
   if [ -d "$HOME/.claude/projects/$(pwd | tr / -)" ]; then claude --continue --effort max; else claude --effort max; fi
   exec /bin/bash --rcfile "$HOME/.erun/team/dev/bashrc" -i
   EOF
+  attach_id="$$-$(date +%s)"
+  printf '%s' "$attach_id" > "<TMP>"
+  master_pid="$(ss -xlpH 2>/dev/null | grep -F "<TMP>" | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | head -n1)"
+  if [ -S "<TMP>" ] && [ -n "$master_pid" ]; then for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if [ "$dtach_pid" != "$master_pid" ] && grep -qF "<TMP>" "/proc/$dtach_pid/cmdline" 2>/dev/null; then kill "$dtach_pid" 2>/dev/null || true; fi; done; fi
   dtach -A "<TMP>" -r ctrl_l /bin/bash "$HOME/.erun/team/dev/launch-contribute-ai.sh" || shell_status=$?
+  if [ "$(cat "<TMP>" 2>/dev/null)" != "$attach_id" ]; then exit 76; fi
   if [ -e "$request_file" ]; then rm -f "$request_file"; exit 75; fi
   rm -f "$request_file"
   exit "$shell_status"

--- a/erun-integration/testdata/open/app_session_contribute_ai_dry_run_preludes_clone.txt
+++ b/erun-integration/testdata/open/app_session_contribute_ai_dry_run_preludes_clone.txt
@@ -1,0 +1,73 @@
+audit: erun open --ai --app-session contribute-ai --contribute --dry-run team dev
+config: would assign localportrangestart=17000 to team/dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=false ide=shell
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+deploying the devops runtime before opening the shell
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=pvc --set-string worktreeRepoName=team --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev wait --for=condition=Available --timeout 2m0s deployment/team-devops
+kubectl --context test-context --namespace team-dev exec -it deployment/team-devops -- /bin/sh -lc '<bootstrap-script>'
+bootstrap-script:
+  set -eu
+  export COLORTERM=truecolor
+  export COLORFGBG='15;0'
+  mkdir -p '<HOME>/git/team'
+  cd '<HOME>/git/team'
+  config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+  mkdir -p "$config_home/erun"
+  cat > "$config_home/erun/config.yaml" <<'EOF'
+  defaulttenant: team
+
+  EOF
+  mkdir -p "$config_home/erun/team"
+  cat > "$config_home/erun/team/config.yaml" <<'EOF'
+  projectroot: <HOME>/git/team
+  name: team
+  defaultenvironment: dev
+
+  EOF
+  mkdir -p "$config_home/erun/team/dev"
+  cat > "$config_home/erun/team/dev/config.yaml" <<'EOF'
+  name: dev
+  repopath: <HOME>/git/team
+  kubernetescontext: test-context
+  containerregistry: ""
+  remote: true
+
+  EOF
+  mkdir -p "$HOME/.erun/team/dev"
+  cat > "$HOME/.erun/team/dev/bashrc" <<'EOF'
+  export ERUN_SHELL_HOST='team-dev'
+  erun() {
+    if [ "${1:-}" = "deploy" ] && [ "$#" -eq 1 ] && [ -n "${ERUN_SHELL_REQUEST_FILE:-}" ]; then
+      : > "$ERUN_SHELL_REQUEST_FILE"
+      exit 0
+    fi
+    command erun "$@"
+  }
+  EOF
+  printf '\033]0;'team-dev'\007'
+  request_file="$HOME/.erun/team/dev/shell-request"
+  rm -f "$request_file"
+  export ERUN_SHELL_REQUEST_FILE="$request_file"
+  shell_status=0
+  mkdir -p "<TMP>"
+  cat > "$HOME/.erun/team/dev/launch-contribute-ai.sh" <<'EOF'
+  export PATH="$HOME/.erun/contribute/bin:$PATH"
+  export ERUN_SKIP_LINT=1
+  cd "$HOME/git/erun"
+  if [ -d "$HOME/.claude/projects/$(pwd | tr / -)" ]; then claude --continue --effort max; else claude --effort max; fi
+  exec /bin/bash --rcfile "$HOME/.erun/team/dev/bashrc" -i
+  EOF
+  dtach -A "<TMP>" -r winch /bin/bash "$HOME/.erun/team/dev/launch-contribute-ai.sh" || shell_status=$?
+  if [ -e "$request_file" ]; then rm -f "$request_file"; exit 75; fi
+  rm -f "$request_file"
+  exit "$shell_status"
+open: dry-run complete; would have launched shell

--- a/erun-integration/testdata/open/app_session_contribute_ai_dry_run_preludes_clone.txt
+++ b/erun-integration/testdata/open/app_session_contribute_ai_dry_run_preludes_clone.txt
@@ -66,7 +66,7 @@ bootstrap-script:
   if [ -d "$HOME/.claude/projects/$(pwd | tr / -)" ]; then claude --continue --effort max; else claude --effort max; fi
   exec /bin/bash --rcfile "$HOME/.erun/team/dev/bashrc" -i
   EOF
-  dtach -A "<TMP>" -r winch /bin/bash "$HOME/.erun/team/dev/launch-contribute-ai.sh" || shell_status=$?
+  dtach -A "<TMP>" -r ctrl_l /bin/bash "$HOME/.erun/team/dev/launch-contribute-ai.sh" || shell_status=$?
   if [ -e "$request_file" ]; then rm -f "$request_file"; exit 75; fi
   rm -f "$request_file"
   exit "$shell_status"

--- a/erun-integration/testdata/open/app_session_shell_dry_run_wraps_dtach.txt
+++ b/erun-integration/testdata/open/app_session_shell_dry_run_wraps_dtach.txt
@@ -62,7 +62,7 @@ bootstrap-script:
   cat > "$HOME/.erun/team/dev/launch-open-0.sh" <<'EOF'
   exec /bin/bash --rcfile "$HOME/.erun/team/dev/bashrc" -i
   EOF
-  dtach -A "<TMP>" -r winch /bin/bash "$HOME/.erun/team/dev/launch-open-0.sh" || shell_status=$?
+  dtach -A "<TMP>" -r ctrl_l /bin/bash "$HOME/.erun/team/dev/launch-open-0.sh" || shell_status=$?
   if [ -e "$request_file" ]; then rm -f "$request_file"; exit 75; fi
   rm -f "$request_file"
   exit "$shell_status"

--- a/erun-integration/testdata/open/app_session_shell_dry_run_wraps_dtach.txt
+++ b/erun-integration/testdata/open/app_session_shell_dry_run_wraps_dtach.txt
@@ -1,0 +1,69 @@
+audit: erun open --app-session open-0 --dry-run team dev
+config: would assign localportrangestart=17000 to team/dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=false ide=shell
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+deploying the devops runtime before opening the shell
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 2m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=pvc --set-string worktreeRepoName=team --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev wait --for=condition=Available --timeout 2m0s deployment/team-devops
+kubectl --context test-context --namespace team-dev exec -it deployment/team-devops -- /bin/sh -lc '<bootstrap-script>'
+bootstrap-script:
+  set -eu
+  export COLORTERM=truecolor
+  export COLORFGBG='15;0'
+  mkdir -p '<HOME>/git/team'
+  cd '<HOME>/git/team'
+  config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+  mkdir -p "$config_home/erun"
+  cat > "$config_home/erun/config.yaml" <<'EOF'
+  defaulttenant: team
+
+  EOF
+  mkdir -p "$config_home/erun/team"
+  cat > "$config_home/erun/team/config.yaml" <<'EOF'
+  projectroot: <HOME>/git/team
+  name: team
+  defaultenvironment: dev
+
+  EOF
+  mkdir -p "$config_home/erun/team/dev"
+  cat > "$config_home/erun/team/dev/config.yaml" <<'EOF'
+  name: dev
+  repopath: <HOME>/git/team
+  kubernetescontext: test-context
+  containerregistry: ""
+  remote: true
+
+  EOF
+  mkdir -p "$HOME/.erun/team/dev"
+  cat > "$HOME/.erun/team/dev/bashrc" <<'EOF'
+  export ERUN_SHELL_HOST='team-dev'
+  erun() {
+    if [ "${1:-}" = "deploy" ] && [ "$#" -eq 1 ] && [ -n "${ERUN_SHELL_REQUEST_FILE:-}" ]; then
+      : > "$ERUN_SHELL_REQUEST_FILE"
+      exit 0
+    fi
+    command erun "$@"
+  }
+  EOF
+  printf '\033]0;'team-dev'\007'
+  request_file="$HOME/.erun/team/dev/shell-request"
+  rm -f "$request_file"
+  export ERUN_SHELL_REQUEST_FILE="$request_file"
+  shell_status=0
+  mkdir -p "<TMP>"
+  cat > "$HOME/.erun/team/dev/launch-open-0.sh" <<'EOF'
+  exec /bin/bash --rcfile "$HOME/.erun/team/dev/bashrc" -i
+  EOF
+  dtach -A "<TMP>" -r winch /bin/bash "$HOME/.erun/team/dev/launch-open-0.sh" || shell_status=$?
+  if [ -e "$request_file" ]; then rm -f "$request_file"; exit 75; fi
+  rm -f "$request_file"
+  exit "$shell_status"
+open: dry-run complete; would have launched shell

--- a/erun-integration/testdata/open/app_session_shell_dry_run_wraps_dtach.txt
+++ b/erun-integration/testdata/open/app_session_shell_dry_run_wraps_dtach.txt
@@ -62,7 +62,12 @@ bootstrap-script:
   cat > "$HOME/.erun/team/dev/launch-open-0.sh" <<'EOF'
   exec /bin/bash --rcfile "$HOME/.erun/team/dev/bashrc" -i
   EOF
+  attach_id="$$-$(date +%s)"
+  printf '%s' "$attach_id" > "<TMP>"
+  master_pid="$(ss -xlpH 2>/dev/null | grep -F "<TMP>" | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | head -n1)"
+  if [ -S "<TMP>" ] && [ -n "$master_pid" ]; then for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if [ "$dtach_pid" != "$master_pid" ] && grep -qF "<TMP>" "/proc/$dtach_pid/cmdline" 2>/dev/null; then kill "$dtach_pid" 2>/dev/null || true; fi; done; fi
   dtach -A "<TMP>" -r ctrl_l /bin/bash "$HOME/.erun/team/dev/launch-open-0.sh" || shell_status=$?
+  if [ "$(cat "<TMP>" 2>/dev/null)" != "$attach_id" ]; then exit 76; fi
   if [ -e "$request_file" ]; then rm -f "$request_file"; exit 75; fi
   rm -f "$request_file"
   exit "$shell_status"

--- a/erun-integration/testdata/open/app_session_shell_dry_run_wraps_dtach.txt
+++ b/erun-integration/testdata/open/app_session_shell_dry_run_wraps_dtach.txt
@@ -64,7 +64,8 @@ bootstrap-script:
   EOF
   attach_id="$$-$(date +%s)"
   printf '%s' "$attach_id" > "<TMP>"
-  master_pid="$(ss -xlpH 2>/dev/null | grep -F "<TMP>" | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | head -n1)"
+  master_pid=""
+  for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if grep -qF "<TMP>" "/proc/$dtach_pid/cmdline" 2>/dev/null; then for child_pid in $(pgrep -P "$dtach_pid" 2>/dev/null || true); do child_comm="$(cat "/proc/$child_pid/comm" 2>/dev/null)"; if [ -n "$child_comm" ] && [ "$child_comm" != "dtach" ]; then master_pid="$dtach_pid"; fi; done; fi; done
   if [ -S "<TMP>" ] && [ -n "$master_pid" ]; then for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if [ "$dtach_pid" != "$master_pid" ] && grep -qF "<TMP>" "/proc/$dtach_pid/cmdline" 2>/dev/null; then kill "$dtach_pid" 2>/dev/null || true; fi; done; fi
   dtach -A "<TMP>" -r ctrl_l /bin/bash "$HOME/.erun/team/dev/launch-open-0.sh" || shell_status=$?
   if [ "$(cat "<TMP>" 2>/dev/null)" != "$attach_id" ]; then exit 76; fi

--- a/erun-ui/activity_queue_app.go
+++ b/erun-ui/activity_queue_app.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
 )
 
 const (
@@ -916,6 +918,13 @@ func (a *App) feedActivityTraceFromTerminal(managed *managedTerminal, chunk []by
 		a.activityQueue.recordOutputLine(managed.selection.Tenant, managed.selection.Environment, line)
 		handler(line)
 		signalSessionReadyOnLine(managed, line)
+		// The CLI's taken-over notice is a public contract line (see
+		// eruncommon.ShellSessionTakenOverNotice): another ERun window
+		// re-attached this persistent session, so the upcoming PTY exit
+		// must not trigger a reconnect that would steal it back.
+		if strings.TrimSpace(line) == eruncommon.ShellSessionTakenOverNotice {
+			a.markSessionTakenOver(managed)
+		}
 	}
 }
 

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -2264,7 +2264,9 @@ func TestStartSessionLeavesCloudContextStartupToErunCommand(t *testing.T) {
 	}
 
 	got := strings.Join(actions, "\n")
-	if got != "terminal open frs prod" {
+	// The ERun tab runs `erun open … --app-session open-0`: a persistent,
+	// reattachable dtach session so reopening reconnects to the running shell (#478).
+	if got != "terminal open frs prod --app-session open-0" {
 		t.Fatalf("expected only terminal start action, got:\n%s", got)
 	}
 	// Cloud-context Status is no longer persisted, so we rely on the
@@ -3302,7 +3304,7 @@ func TestStartLocalSessionStartsShellAtRepoPath(t *testing.T) {
 	}
 }
 
-func TestStartAISessionRunsErunOpenWithClaudeInitialInput(t *testing.T) {
+func TestStartAISessionRunsErunOpenAsPersistentAITab(t *testing.T) {
 	projectRoot := t.TempDir()
 	store := stubUIStore{
 		tenants: map[string]eruncommon.TenantConfig{
@@ -3335,49 +3337,17 @@ func TestStartAISessionRunsErunOpenWithClaudeInitialInput(t *testing.T) {
 	if started.Executable != "/tmp/erun" {
 		t.Fatalf("expected erun executable, got %q", started.Executable)
 	}
-	wantArgs := []string{"open", "erun", "remote"}
+	// The AI tab runs `erun open --app-session ai --ai`: the persistent remote
+	// session launches the AI tool itself (pod-side, once on create), so a reopen
+	// reconnects to the running claude. The desktop no longer types the launch
+	// in, so there is no initial input. The AI tool + effort are resolved pod-side
+	// by `erun open --ai`; AISessionLaunchCommand is covered in erun-common. #478.
+	wantArgs := []string{"open", "erun", "remote", "--app-session", "ai", "--ai"}
 	if strings.Join(started.Args, "\n") != strings.Join(wantArgs, "\n") {
 		t.Fatalf("unexpected args: got %+v want %+v", started.Args, wantArgs)
 	}
-	// The env AI tab pipes the cwd-guarded Claude resume so it continues the
-	// env project's Claude Code session rather than starting fresh (issue
-	// #451). The guard runs in the env repo cwd inside `erun open`. With no
-	// per-env Effort configured it launches at the default level (max) via
-	// --effort (issue #469).
-	wantInput := claudeLaunchGuard(defaultClaudeEffort) + "\n"
-	if string(started.InitialInput) != wantInput {
-		t.Fatalf("expected initial input %q, got %q", wantInput, string(started.InitialInput))
-	}
-}
-
-func TestStartAISessionUsesConfiguredAITool(t *testing.T) {
-	projectRoot := t.TempDir()
-	store := stubUIStore{
-		tenants: map[string]eruncommon.TenantConfig{
-			"erun": {Name: "erun", ProjectRoot: projectRoot, DefaultEnvironment: "remote"},
-		},
-		envs: map[string]eruncommon.EnvConfig{
-			"erun/remote": {Name: "remote", RepoPath: projectRoot, KubernetesContext: "ctx", AITool: "codex"},
-		},
-	}
-
-	var started startTerminalSessionParams
-	app := NewApp(erunUIDeps{
-		store:           store,
-		findProjectRoot: func() (string, string, error) { return "erun", projectRoot, nil },
-		resolveCLIPath:  func() string { return "/tmp/erun" },
-		startTerminal: func(params startTerminalSessionParams) (terminalSession, error) {
-			started = params
-			return newStubTerminalSession(), nil
-		},
-	})
-	defer app.shutdown(context.Background())
-
-	if _, err := app.StartAISession(uiSelection{Tenant: "erun", Environment: "remote"}, 0, 80, 24); err != nil {
-		t.Fatalf("StartAISession failed: %v", err)
-	}
-	if string(started.InitialInput) != "codex\n" {
-		t.Fatalf("expected configured AI initial input %q, got %q", "codex\n", string(started.InitialInput))
+	if len(started.InitialInput) != 0 {
+		t.Fatalf("AI tab must not pipe an initial input (claude launches pod-side), got %q", string(started.InitialInput))
 	}
 }
 

--- a/erun-ui/contribute_app_test.go
+++ b/erun-ui/contribute_app_test.go
@@ -13,8 +13,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	eruncommon "github.com/sophium/erun/erun-common"
 )
 
 // Tests in this file pin the respawn-on-early-exit contract that
@@ -273,101 +271,5 @@ func TestAdoptRefusesAfterStop(t *testing.T) {
 	forward.stop()
 	if forward.adopt(&exec.Cmd{}, &bytes.Buffer{}) {
 		t.Fatalf("adopt should return false after stop()")
-	}
-}
-
-// TestBuildContributePreludeCommandResumesCloneSession asserts the contribute
-// AI tab pipes the cwd-guarded Claude resume after cd'ing to the clone, so it
-// continues the $HOME/git/erun session rather than starting fresh — the
-// local-agent gap in issue #451. The non-AI variant pipes no AI launch.
-func TestBuildContributePreludeCommandResumesCloneSession(t *testing.T) {
-	withAI := buildContributePreludeCommand(true, "")
-	if !strings.Contains(withAI, `cd "$HOME/git/erun"`) {
-		t.Fatalf("prelude must cd to the clone before launching the AI tool, got %q", withAI)
-	}
-	// The contribute tab has no per-env config, so it launches at the default
-	// effort (max) (issue #469).
-	if !strings.HasSuffix(withAI, claudeLaunchGuard(defaultClaudeEffort)+"\n") {
-		t.Fatalf("contribute AI prelude must end with the cwd-guarded claude resume at default effort, got %q", withAI)
-	}
-	if !strings.Contains(withAI, "--effort max") {
-		t.Fatalf("contribute AI prelude must inject --effort max, got %q", withAI)
-	}
-
-	// A non-claude tool launches verbatim (no resume injection), mirroring the
-	// wrapper's bypass rules.
-	codex := buildContributePreludeCommand(true, "codex")
-	if !strings.HasSuffix(codex, "codex\n") {
-		t.Fatalf("configured non-claude tool must launch verbatim, got %q", codex)
-	}
-	if strings.Contains(codex, "--continue") {
-		t.Fatalf("non-claude tool must not carry a claude resume, got %q", codex)
-	}
-
-	noAI := buildContributePreludeCommand(false, "")
-	if strings.Contains(noAI, "claude") {
-		t.Fatalf("non-AI contribute prelude must not launch an AI tool, got %q", noAI)
-	}
-}
-
-// TestAILaunchCommandGuardsClaudeOnly documents the bypass rules the desktop
-// shares with claude-wrapper.sh: a bare claude launch is wrapped in the
-// cwd-guarded resume; an explicit-flag claude invocation or a different tool
-// launches verbatim. The default-claude path injects --effort into both guard
-// branches; non-claude and explicit-flag launches are never altered (#469).
-func TestAILaunchCommandGuardsClaudeOnly(t *testing.T) {
-	wantGuard := claudeLaunchGuard("high")
-	if got := aiLaunchCommand("", "high"); got != wantGuard {
-		t.Fatalf("default (claude) must use the resume guard, got %q", got)
-	}
-	if got := aiLaunchCommand("claude", "high"); got != wantGuard {
-		t.Fatalf("explicit claude must use the resume guard, got %q", got)
-	}
-	// --effort is injected into both branches of the cwd guard.
-	if strings.Count(wantGuard, "--effort high") != 2 {
-		t.Fatalf("guard must inject --effort high into both branches, got %q", wantGuard)
-	}
-	if !strings.Contains(wantGuard, "claude --continue --effort high") ||
-		!strings.Contains(wantGuard, "else claude --effort high") {
-		t.Fatalf("guard must inject --effort after --continue and in the bare branch, got %q", wantGuard)
-	}
-	// A configured non-claude tool and explicit-flag claude launch verbatim,
-	// with no --effort injected.
-	if got := aiLaunchCommand("codex", "max"); got != "codex" {
-		t.Fatalf("codex must launch verbatim, got %q", got)
-	}
-	if got := aiLaunchCommand("claude --resume", "max"); got != "claude --resume" {
-		t.Fatalf("claude with explicit flags must launch verbatim, got %q", got)
-	}
-}
-
-// TestResolveClaudeEffort covers the per-env effort resolution the env AI tab
-// applies: a valid configured level is used; unset, blank, and invalid values
-// fall back to the default (max) so the launch never carries a bad flag (#469).
-func TestResolveClaudeEffort(t *testing.T) {
-	level := func(v string) *string { return &v }
-	cases := []struct {
-		name   string
-		config eruncommon.EnvironmentClaudeConfig
-		want   string
-	}{
-		{"unset falls back to max", eruncommon.EnvironmentClaudeConfig{}, "max"},
-		{"valid level is used", eruncommon.EnvironmentClaudeConfig{Effort: level("low")}, "low"},
-		{"surrounding space is trimmed", eruncommon.EnvironmentClaudeConfig{Effort: level("  high  ")}, "high"},
-		{"blank falls back to max", eruncommon.EnvironmentClaudeConfig{Effort: level("  ")}, "max"},
-		{"invalid falls back to max", eruncommon.EnvironmentClaudeConfig{Effort: level("turbo")}, "max"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := resolveClaudeEffort(tc.config); got != tc.want {
-				t.Fatalf("resolveClaudeEffort(%+v) = %q, want %q", tc.config, got, tc.want)
-			}
-		})
-	}
-
-	// An invalid effort passed straight to the guard injects no flag, so a bad
-	// persisted value can never reach the shell as `--effort turbo`.
-	if guard := claudeLaunchGuard("turbo"); strings.Contains(guard, "--effort") {
-		t.Fatalf("invalid effort must not be injected, got %q", guard)
 	}
 }

--- a/erun-ui/contribute_sessions.go
+++ b/erun-ui/contribute_sessions.go
@@ -82,15 +82,23 @@ func (a *App) runContributeSession(ctx context.Context, selection uiSelection, s
 	}
 	a.mu.Unlock()
 
-	prelude := buildContributePreludeCommand(withAI, result.EnvConfig.AITool)
+	// The contribute tab runs `erun open --app-session contribute-… --contribute
+	// [--ai]`: the persistent remote session cds into the contribute clone with
+	// its env (and launches the AI tool for the AI variant) as its create-time
+	// program, once, so reopening reconnects instead of re-running the prelude or
+	// spawning a parallel session (#478). What used to be typed in (issue #469)
+	// now happens pod-side in `erun open`.
+	appSessionID := "contribute-erun"
+	if withAI {
+		appSessionID = "contribute-ai"
+	}
 	params := startTerminalSessionParams{
-		Dir:          resolveTerminalStartDir(result.RepoPath),
-		Executable:   a.deps.resolveCLIPath(),
-		Args:         buildOpenArgs(result.Tenant, result.Environment, selection.Debug),
-		Env:          []string{appSessionEnvVar + "=1"},
-		Cols:         cols,
-		Rows:         rows,
-		InitialInput: []byte(prelude),
+		Dir:        resolveTerminalStartDir(result.RepoPath),
+		Executable: a.deps.resolveCLIPath(),
+		Args:       withAppSession(buildOpenArgs(result.Tenant, result.Environment, selection.Debug), appSessionID, withAI, true),
+		Env:        []string{appSessionEnvVar + "=1"},
+		Cols:       cols,
+		Rows:       rows,
 	}
 	session, err := a.deps.startTerminal(params)
 	if err != nil {
@@ -136,35 +144,6 @@ func (a *App) runContributeSession(ctx context.Context, selection uiSelection, s
 		Slot:      slot,
 		Kind:      string(kind),
 	}, managed, nil
-}
-
-// buildContributePreludeCommand returns the keystrokes piped into the
-// contribute tab's shell so the contribute clone becomes the working
-// directory and the shim becomes the resolved `erun`. The AI variant
-// additionally invokes the env's configured AI tool.
-//
-// ERUN_SKIP_LINT=1 is set in the contribute shell because the user
-// is iterating — they want fast incremental rebuilds, not a full
-// typecheck+lint+format gate on every `erun app`. The host-side
-// `erun app` workflow leaves the gates on (no contribute prelude
-// runs there), and CI still enforces them.
-func buildContributePreludeCommand(withAI bool, aiTool string) string {
-	parts := []string{
-		`export PATH="$HOME/.erun/contribute/bin:$PATH"`,
-		`export ERUN_SKIP_LINT=1`,
-		`cd "$HOME/git/erun"`,
-		`clear`,
-	}
-	prelude := strings.Join(parts, " && ") + "\n"
-	if withAI {
-		// The prelude already cd'd to $HOME/git/erun, so the cwd-guarded
-		// resume continues the contribute clone's Claude Code session rather
-		// than the env project's (issue #451). The contribute tab has no
-		// per-env config, so it launches at the default effort (max), keeping
-		// it aligned with env AI tabs (issue #469).
-		prelude += aiLaunchCommand(aiTool, defaultClaudeEffort) + "\n"
-	}
-	return prelude
 }
 
 func contributeSessionKey(selection uiSelection, slot int, withAI bool) string {

--- a/erun-ui/frontend/src/app/remoteSessionTabsThunks.ts
+++ b/erun-ui/frontend/src/app/remoteSessionTabsThunks.ts
@@ -1,0 +1,55 @@
+import type { StartSessionResult, UISelection } from '@/types';
+
+import { ListRemoteAppSessions, StartSession } from '../../wailsjs/go/main/App';
+import { registerDebugSession, trackOpenSession } from './slices/sessionsSlice';
+import type { AppThunk } from './store';
+import { recordTab } from './tabsThunks';
+
+// reattachRemoteTerminalTabs rebuilds tabs for persistent pod sessions this
+// window does not know about — custom terminals (`open-N`) created in another
+// ERun window or a previous run that are still running in the pod. The default
+// tabs attach-or-create on their own in ensureDefaultEnvTabs; this fills in
+// the extras, so every running remote session ends up attached here (the
+// attach itself takes the session over from any other window). Detection is
+// best-effort and must never stall the open flow.
+export const reattachRemoteTerminalTabs =
+  (runSelection: UISelection, key: string, cols: number, rows: number): AppThunk<Promise<void>> =>
+  async (dispatch, getState) => {
+    let ids: string[];
+    try {
+      // The generated binding is typed string[], but a Go nil slice arrives
+      // as null at runtime — widen before defaulting.
+      const listed = (await ListRemoteAppSessions(runSelection)) as string[] | null;
+      ids = listed ?? [];
+    } catch {
+      return; // env may be local-only, unreachable, or not deployed
+    }
+    for (const id of ids) {
+      const match = /^open-([1-9]\d*)$/.exec(id);
+      if (!match) {
+        continue;
+      }
+      const slot = Number(match[1]);
+      const tabs = getState().terminal.tabsByEnv[key] ?? [];
+      if (tabs.some((tab) => tab.slot === slot && tab.kind === 'extra')) {
+        continue;
+      }
+      try {
+        const result = (await StartSession(runSelection, slot, cols, rows)) as StartSessionResult;
+        // Same bookkeeping trackOpenSessionMetadata does for the + button:
+        // session registry, debug registry, and the tab entry — safe even if
+        // the user has navigated to another env meanwhile.
+        dispatch(trackOpenSession({ key, sessionId: result.sessionId, selection: runSelection }));
+        dispatch(
+          registerDebugSession({
+            sessionId: result.sessionId,
+            selection: runSelection,
+            mode: 'open',
+          }),
+        );
+        dispatch(recordTab(key, result.sessionId, slot, 'extra', `Terminal ${String(slot)}`));
+      } catch {
+        // skip sessions that fail to attach; the next env open retries
+      }
+    }
+  };

--- a/erun-ui/frontend/src/app/sessionThunks.ts
+++ b/erun-ui/frontend/src/app/sessionThunks.ts
@@ -2,6 +2,7 @@ import type { StartSessionResult, UISelection } from '@/types';
 
 import {
   CloseSession,
+  ListRemoteAppSessions,
   StartAISession,
   StartDeploySession,
   StartInitSession,
@@ -165,6 +166,41 @@ export const ensureDefaultEnvTabs =
     await dispatch(ensureLiveDefaultTab(key, runSelection, 'erun', 'ERun', cols, rows));
     await dispatch(ensureLiveDefaultTab(key, runSelection, 'local', 'Local', cols, rows));
     await dispatch(ensureLiveDefaultTab(key, runSelection, 'ai', 'AI', cols, rows));
+  };
+
+// reattachRemoteTerminalTabs rebuilds tabs for persistent pod sessions this
+// window does not know about — custom terminals (`open-N`) created in another
+// ERun window or a previous run that are still running in the pod. The default
+// tabs attach-or-create on their own in ensureDefaultEnvTabs; this fills in
+// the extras, so every running remote session ends up attached here (the
+// attach itself takes the session over from any other window). Detection is
+// best-effort and must never stall the open flow.
+const reattachRemoteTerminalTabs =
+  (runSelection: UISelection, key: string, cols: number, rows: number): AppThunk<Promise<void>> =>
+  async (dispatch, getState) => {
+    let ids: string[];
+    try {
+      ids = ((await ListRemoteAppSessions(runSelection)) ?? []) as string[];
+    } catch {
+      return; // env may be local-only, unreachable, or not deployed
+    }
+    for (const id of ids) {
+      const match = /^open-([1-9]\d*)$/.exec(id);
+      if (!match) {
+        continue;
+      }
+      const slot = Number(match[1]);
+      const tabs = getState().terminal.tabsByEnv[key] ?? [];
+      if (tabs.some((tab) => tab.slot === slot && tab.kind === 'extra')) {
+        continue;
+      }
+      try {
+        const result = (await StartSession(runSelection, slot, cols, rows)) as StartSessionResult;
+        dispatch(trackOpenSessionMetadata(key, result, runSelection));
+      } catch {
+        // skip sessions that fail to attach; the next env open retries
+      }
+    }
   };
 
 // surfaceEnvSession repoints the visible terminal at the new env's
@@ -438,6 +474,10 @@ const finishOpenSession =
     dispatch(showOpenSelectionStatus(result.sessionId, selection));
 
     await dispatch(ensureDefaultEnvTabs(runSelection, key, cols, rows));
+    // Fire-and-forget: rebuilding tabs for pod sessions another window
+    // created must not block the open flow, and trackOpenSessionMetadata
+    // records them safely even if the user has navigated away meanwhile.
+    void dispatch(reattachRemoteTerminalTabs(runSelection, key, cols, rows));
     if (!isCurrentSelection()) {
       return;
     }

--- a/erun-ui/frontend/src/app/sessionThunks.ts
+++ b/erun-ui/frontend/src/app/sessionThunks.ts
@@ -2,7 +2,6 @@ import type { StartSessionResult, UISelection } from '@/types';
 
 import {
   CloseSession,
-  ListRemoteAppSessions,
   StartAISession,
   StartDeploySession,
   StartInitSession,
@@ -13,6 +12,7 @@ import { resolveAutoStartGate } from './autoStartGate';
 import { applyPendingDebugHeader, setPendingDebugHeader, syncDebugDisplay } from './debugThunks';
 import { readError } from './errors';
 import { hideTerminalMessage, showTerminalMessage } from './notificationThunks';
+import { reattachRemoteTerminalTabs } from './remoteSessionTabsThunks';
 import { loadReviewDiff } from './reviewThunks';
 import { selectActiveSlotForSelection, selectEnvironmentExists } from './selectors';
 import { isNewSessionSelection } from './sessionSelection';
@@ -166,41 +166,6 @@ export const ensureDefaultEnvTabs =
     await dispatch(ensureLiveDefaultTab(key, runSelection, 'erun', 'ERun', cols, rows));
     await dispatch(ensureLiveDefaultTab(key, runSelection, 'local', 'Local', cols, rows));
     await dispatch(ensureLiveDefaultTab(key, runSelection, 'ai', 'AI', cols, rows));
-  };
-
-// reattachRemoteTerminalTabs rebuilds tabs for persistent pod sessions this
-// window does not know about — custom terminals (`open-N`) created in another
-// ERun window or a previous run that are still running in the pod. The default
-// tabs attach-or-create on their own in ensureDefaultEnvTabs; this fills in
-// the extras, so every running remote session ends up attached here (the
-// attach itself takes the session over from any other window). Detection is
-// best-effort and must never stall the open flow.
-const reattachRemoteTerminalTabs =
-  (runSelection: UISelection, key: string, cols: number, rows: number): AppThunk<Promise<void>> =>
-  async (dispatch, getState) => {
-    let ids: string[];
-    try {
-      ids = ((await ListRemoteAppSessions(runSelection)) ?? []) as string[];
-    } catch {
-      return; // env may be local-only, unreachable, or not deployed
-    }
-    for (const id of ids) {
-      const match = /^open-([1-9]\d*)$/.exec(id);
-      if (!match) {
-        continue;
-      }
-      const slot = Number(match[1]);
-      const tabs = getState().terminal.tabsByEnv[key] ?? [];
-      if (tabs.some((tab) => tab.slot === slot && tab.kind === 'extra')) {
-        continue;
-      }
-      try {
-        const result = (await StartSession(runSelection, slot, cols, rows)) as StartSessionResult;
-        dispatch(trackOpenSessionMetadata(key, result, runSelection));
-      } catch {
-        // skip sessions that fail to attach; the next env open retries
-      }
-    }
   };
 
 // surfaceEnvSession repoints the visible terminal at the new env's

--- a/erun-ui/frontend/src/app/terminalBuffers.ts
+++ b/erun-ui/frontend/src/app/terminalBuffers.ts
@@ -66,6 +66,13 @@ const TERMINAL_RESPONSE_PATTERNS: RegExp[] = [
   // above; without this the user sees the literal text at the prompt
   // even when terminalQueryResponses no longer answers the query.
   /(?:^|[^A-Za-z0-9])\d+(?:;\d+)+c(?![A-Za-z0-9])/g,
+  // DECRQSS status-string response: DCS [01] $ r <payload> ST
+  // (e.g. `\x1bP1$r0"q\x1b\\`). terminalQueryResponses no longer answers
+  // DECRQSS, so this is a backstop for a response that reaches the buffer
+  // another way (a pre-fix replayed buffer, or a tool that answers its own
+  // probe). The `(?:\x1bP)?` makes it also catch the bare `1$r0"q␛\` tail
+  // bash leaves after readline eats the leading `\x1bP`.
+  /(?:\x1BP)?[01]\$r[^\x1B]*\x1B\\/g,
 ];
 
 function stripTerminalResponses(input: Uint8Array): Uint8Array {

--- a/erun-ui/frontend/src/app/terminalQueryResponses.ts
+++ b/erun-ui/frontend/src/app/terminalQueryResponses.ts
@@ -4,7 +4,6 @@ type TerminalInputSender = (data: string) => Promise<unknown>;
 type TerminalInputErrorHandler = (error: unknown) => void;
 
 const ESC = '\x1B';
-const ST = `${ESC}\\`;
 
 export function registerTerminalQueryResponseHandlers(
   terminal: Terminal,
@@ -24,21 +23,29 @@ export function registerTerminalQueryResponseHandlers(
   };
 
   // xterm.js ships built-in OSC 10/11/12 handlers that answer fg/bg/cursor
-  // color queries with the current theme, and built-in CSI DA1/DA2
-  // handlers that answer terminal device-attribute probes. All of these
+  // color queries with the current theme, built-in CSI DA1/DA2 handlers
+  // that answer terminal device-attribute probes, and we used to answer
+  // DECRQSS (`DCS $ q … ST`) status-string queries here too. All of these
   // replies travel through SendSessionInput -> PTY, which is async — so
-  // when the asking process (claude, codex, an interactive ssh, …)
-  // exits between query and reply, the reply lands on the shell's
-  // stdin and bash interprets it as user input. Most visible
-  // manifestation: a bare `1;2c1;2c…` sitting at the next bash prompt
-  // after claude exits, which bash then tries to run as a command.
+  // when the asking process (claude, codex, an interactive ssh, …) exits
+  // between query and reply, OR a query reaches xterm on reattach while
+  // the session is back at a bare bash prompt, the reply lands on the
+  // shell's stdin and bash interprets it as user input. Most visible
+  // manifestations: a bare `1;2c1;2c…` after claude exits (DA), and a
+  // `1$r0"q␛\` tail at the prompt on reattach (DECRQSS) — bash then tries
+  // to run them as commands.
   //
   // Suppress every reply by registering no-op handlers that consume the
-  // query and return true so the built-in handler does not run.
-  // Querying tools time out (typical timeout ~100ms) and fall back to
-  // xterm defaults — the same defaults a hardcoded reply hard-coded
-  // anyway. The display strip in terminalBuffers.ts catches any
-  // partially-consumed tails as a backstop.
+  // query and return true so the built-in handler does not run. Querying
+  // tools time out (typical timeout ~100ms) and fall back to xterm
+  // defaults — the same defaults a hardcoded reply gave anyway. The
+  // display strip in terminalBuffers.ts catches partially-consumed tails
+  // as a backstop.
+  //
+  // Cursor-position reports (CSI DSR `n` / DEC DSR `?n`) are the one query
+  // we still answer: tools genuinely need the cursor location and there is
+  // no sane default to time out to. Those replies still route to the
+  // asking session via the writeSources queue (issue #347).
   const suppressQuery = (): boolean => true;
 
   return [
@@ -47,6 +54,7 @@ export function registerTerminalQueryResponseHandlers(
     terminal.parser.registerOscHandler(12, suppressQuery),
     terminal.parser.registerCsiHandler({ final: 'c' }, suppressQuery),
     terminal.parser.registerCsiHandler({ prefix: '>', final: 'c' }, suppressQuery),
+    terminal.parser.registerDcsHandler({ intermediates: '$', final: 'q' }, suppressQuery),
     terminal.parser.registerCsiHandler({ final: 'n' }, (params) => {
       switch (firstParam(params)) {
         case 5:
@@ -63,9 +71,6 @@ export function registerTerminalQueryResponseHandlers(
       }
       return sendResponse(cursorPositionReport(terminal, '?'));
     }),
-    terminal.parser.registerDcsHandler({ intermediates: '$', final: 'q' }, (data) => {
-      return sendResponse(statusStringReport(terminal, data));
-    }),
   ];
 }
 
@@ -80,33 +85,4 @@ function firstParam(params: (number | number[])[]): number {
 function cursorPositionReport(terminal: Terminal, prefix: string): string {
   const buffer = terminal.buffer.active;
   return `${ESC}[${prefix}${String(buffer.cursorY + 1)};${String(buffer.cursorX + 1)}R`;
-}
-
-function statusStringReport(terminal: Terminal, data: string): string {
-  switch (data) {
-    case '"q':
-      return `${ESC}P1$r0"q${ST}`;
-    case '"p':
-      return `${ESC}P1$r61;1"p${ST}`;
-    case 'r':
-      return `${ESC}P1$r1;${String(terminal.rows)}r${ST}`;
-    case 'm':
-      return `${ESC}P1$r0m${ST}`;
-    case ' q':
-      return `${ESC}P1$r${String(cursorStyleReport(terminal))} q${ST}`;
-    default:
-      return `${ESC}P0$r${ST}`;
-  }
-}
-
-function cursorStyleReport(terminal: Terminal): number {
-  const style = terminal.options.cursorStyle;
-  const blink = terminal.options.cursorBlink === true;
-  if (style === 'underline') {
-    return blink ? 3 : 4;
-  }
-  if (style === 'bar') {
-    return blink ? 5 : 6;
-  }
-  return blink ? 1 : 2;
 }

--- a/erun-ui/playwright/tests/remote-session-tabs.spec.ts
+++ b/erun-ui/playwright/tests/remote-session-tabs.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '../fixtures/erunApp.js';
+
+// remote-session-tabs covers the detection flow from #478: when an env opens,
+// finishOpenSession fires reattachRemoteTerminalTabs, which asks the backend
+// (ListRemoteAppSessions → kubectl exec ls of the pod's dtach sockets) for
+// persistent sessions another ERun window created and rebuilds `Terminal N`
+// tabs for them. Default tabs (Local, ERun, AI) attach-or-create on their own.
+//
+// The positive path — a pod that actually carries an `open-N` socket from
+// another window — is not reachable from the headless harness:
+//   - The harness has no staged runtime pod; ListRemoteAppSessions is
+//     fail-soft and returns nothing for envs whose cluster is absent.
+//   - Pre-seeding a dtach socket would require a live kubectl exec into a
+//     real pod, which the suite deliberately does not depend on.
+//
+// Invariant we CAN lock down: the detection pass is structurally silent when
+// there is nothing to detect — opening an env still yields a tab strip whose
+// entries are only the known kinds (Local/ERun/AI, contribute variants, or
+// `Terminal N` extras), with no duplicate labels and no error banner. This
+// catches the regression class where the fire-and-forget detection thunk
+// throws into the open flow or double-registers tabs it did not create.
+//
+// The positive detection path is covered by Go tests:
+// TestListRemoteAppSessionsParsesPodSockets (PATH-stubbed kubectl) and
+// TestParseRemoteAppSessionIDs in erun-common.
+
+test.describe('remote session tab detection', () => {
+  test('opening an env yields only known tab kinds with no duplicates', async ({ app, page }) => {
+    const tenants = await app.sidebar.tenants();
+    expect(tenants.length).toBeGreaterThan(0);
+    const tenant = tenants[0]!;
+    const envs = await app.sidebar.environmentsFor(tenant);
+    expect(envs.length).toBeGreaterThan(0);
+
+    await app.sidebar.openEnvironment(tenant, envs[0]!);
+
+    const strip = page.getByRole('tablist', { name: 'Open terminals' });
+    await expect(strip).toBeVisible();
+    // Give the fire-and-forget detection pass a window to run; it must not
+    // surface an error overlay or mutate the strip into unknown entries.
+    await page.waitForTimeout(1_000);
+
+    const labels = await strip.getByRole('tab').allInnerTexts();
+    expect(labels.length).toBeGreaterThan(0);
+    const known = /^(Local|ERun|AI|ERun \(contribute\)|AI \(contribute\)|Terminal \d+)/;
+    for (const label of labels) {
+      expect(label.trim()).toMatch(known);
+    }
+    const trimmed = labels.map((label) => label.trim());
+    expect(new Set(trimmed).size).toBe(trimmed.length);
+  });
+});

--- a/erun-ui/playwright/tests/terminal-query-response.spec.ts
+++ b/erun-ui/playwright/tests/terminal-query-response.spec.ts
@@ -17,11 +17,17 @@ import { expect, test } from '../fixtures/erunApp.js';
 // /__erun_emit fan-out, exactly like the real backend stream) and observes the
 // resulting SendSessionInput call on /__erun_invoke.
 //
-// DECRQSS (`ESC P $ q " q ESC \`) is used as the trigger because it is the one
-// query that survives stripTerminalResponses() in terminalBuffers.ts — that
-// strip removes CSI `ESC[<n>n` (DSR/CPR) and `ESC[…c` (DA) response *and* query
-// tails from the displayed bytes, but not DCS sequences — so DECRQSS
-// deterministically reaches xterm's parser and produces a reply.
+// A DEC-private cursor-position request (DEC DSR, `ESC [ ? 6 n`) is the trigger:
+// post-fix it is the query that both reaches xterm's parser and produces a
+// reply. Its `?` prefix dodges stripTerminalResponses() in terminalBuffers.ts
+// (whose patterns require a digit immediately after `ESC [`), so it is not
+// stripped from the bytes written to xterm, and the `?n` handler answers it
+// with a cursor-position report. DA1/DA2, OSC 10/11/12, and DECRQSS (`ESC P $ q
+// … ST`) are now all suppressed — they consume the query and never reply —
+// because their async reply landed at the bash prompt as junk when the asking
+// tool had exited or the query arrived on reattach. Cursor position is the one
+// reply still sent (tools need it; no sane default), so it is what this spec
+// observes.
 //
 // Harness limitation: the exact cross-session race (xterm deferring a query's
 // parse across a session switch, so reply-time selection != write-time source)
@@ -32,7 +38,7 @@ import { expect, test } from '../fixtures/erunApp.js';
 // query from a non-selected session is never answered — while the write-time
 // capture that closes the race lives in TerminalWriteSourceQueue.ts.
 
-const DECRQSS = '\x1bP$q"q\x1b\\';
+const CPR_QUERY = '\x1b[?6n';
 
 interface InvokeCall {
   method: string;
@@ -66,10 +72,10 @@ function captureInvokes(page: Page): InvokeCall[] {
   return calls;
 }
 
-// isDcsReply matches the DCS-framed reply the DECRQSS handler sends back
-// (statusStringReport returns `ESC P 1 $ r 0 " q ESC \`).
-function isDcsReply(data: unknown): data is string {
-  return typeof data === 'string' && data.startsWith('\x1bP');
+// isCprReply matches the cursor-position report the DEC DSR handler sends back
+// (cursorPositionReport returns `ESC [ ? <row> ; <col> R`).
+function isCprReply(data: unknown): data is string {
+  return typeof data === 'string' && data.startsWith('\x1b[') && data.endsWith('R');
 }
 
 // emitTerminalOutput injects a `terminal-output` event for sessionId carrying
@@ -117,14 +123,14 @@ test.describe('terminal query responses (#347)', () => {
     const invokes = captureInvokes(page);
     const selectedId = await discoverSelectedSessionId(app, page);
 
-    await emitTerminalOutput(page, selectedId, DECRQSS);
+    await emitTerminalOutput(page, selectedId, CPR_QUERY);
 
     // The reply must be addressed to the session that produced the query.
     await expect
       .poll(
         () => {
           const reply = invokes.find(
-            (call) => call.method === 'SendSessionInput' && isDcsReply(call.args[1]),
+            (call) => call.method === 'SendSessionInput' && isCprReply(call.args[1]),
           );
           return reply?.args[0];
         },
@@ -143,8 +149,8 @@ test.describe('terminal query responses (#347)', () => {
     // Emit the background query first, then a foreground query. Waiting for the
     // foreground reply proves the event pipeline drained past the background
     // emit, so a missing background reply is a real negative, not just slowness.
-    await emitTerminalOutput(page, backgroundId, DECRQSS);
-    await emitTerminalOutput(page, selectedId, DECRQSS);
+    await emitTerminalOutput(page, backgroundId, CPR_QUERY);
+    await emitTerminalOutput(page, selectedId, CPR_QUERY);
 
     await expect
       .poll(
@@ -152,7 +158,7 @@ test.describe('terminal query responses (#347)', () => {
           invokes.some(
             (call) =>
               call.method === 'SendSessionInput' &&
-              isDcsReply(call.args[1]) &&
+              isCprReply(call.args[1]) &&
               call.args[0] === selectedId,
           ),
         { timeout: 5_000 },
@@ -162,7 +168,7 @@ test.describe('terminal query responses (#347)', () => {
     const answeredToBackground = invokes.filter(
       (call) =>
         call.method === 'SendSessionInput' &&
-        isDcsReply(call.args[1]) &&
+        isCprReply(call.args[1]) &&
         call.args[0] === backgroundId,
     );
     expect(answeredToBackground).toHaveLength(0);

--- a/erun-ui/playwright/tests/terminal-scroll-on-switch.spec.ts
+++ b/erun-ui/playwright/tests/terminal-scroll-on-switch.spec.ts
@@ -36,28 +36,37 @@ test.describe('terminal scroll on session switch', () => {
     await localTab.waitFor({ state: 'visible', timeout: 15_000 });
 
     // Spawn a deterministic second session so we can drive a real switch.
-    const allTabs = page.getByRole('tab');
-    const initialTabCount = await allTabs.count();
+    // Count only the "Terminal N" extras, not the whole strip: the env's
+    // default tabs (notably AI) land asynchronously seconds after the env
+    // opens — the per-env action runner serializes ERun → Local → AI against
+    // the real pod — so a global tab count taken now is stale by the time the
+    // cleanup below compares against it.
+    const tablist = page.getByRole('tablist', { name: 'Open terminals' });
+    const extraTabs = tablist.getByRole('tab', { name: /Terminal \d+/ });
+    const initialExtraCount = await extraTabs.count();
     await page.getByRole('button', { name: 'Open a new terminal' }).click();
-    await expect.poll(() => allTabs.count(), { timeout: 15_000 }).toBeGreaterThan(initialTabCount);
+    await expect
+      .poll(() => extraTabs.count(), { timeout: 15_000 })
+      .toBeGreaterThan(initialExtraCount);
 
     // The new "extra" tab is the last one and is now active. Switch to Local
     // and back so the display buffer is rebuilt and replayed for each session
     // — the path the fix scrolls to the bottom.
-    const extraTab = allTabs.last();
+    const extraTab = extraTabs.last();
     await localTab.click();
     await extraTab.click();
 
     await expect.poll(() => terminalAtBottom(page), { timeout: 5_000 }).toBe(true);
 
     // Close the spawned terminal so the extra session does not drift the
-    // session set the singleton headless backend hands to later specs.
-    const tablist = page.getByRole('tablist', { name: 'Open terminals' });
+    // session set the singleton headless backend hands to later specs. The
+    // explicit close also ends the pod-side session (#478), so remote-session
+    // detection cannot resurrect the tab on a later env open.
     await tablist
       .getByRole('button', { name: /^Close / })
       .last()
       .click();
-    await expect.poll(() => allTabs.count()).toBe(initialTabCount);
+    await expect.poll(() => extraTabs.count()).toBe(initialExtraCount);
   });
 });
 

--- a/erun-ui/reconnect_loop_test.go
+++ b/erun-ui/reconnect_loop_test.go
@@ -491,3 +491,106 @@ func sawDeployFailedMarker(emits *capturedEmits) bool {
 	}
 	return false
 }
+
+// TestSessionTakenOverByAnotherWindowDoesNotReconnect locks the takeover
+// handover from #478: when another ERun window re-attaches a persistent pod
+// session, this window's `erun open` prints the stable taken-over notice and
+// exits cleanly. The desktop must NOT respawn — a respawn would re-attach and
+// steal the session straight back, and the two windows would fight over it —
+// and must surface the take-back affordance marker instead. Clicking the env
+// in the sidebar is the deliberate take-back (it starts a fresh session).
+func TestSessionTakenOverByAnotherWindowDoesNotReconnect(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", ProjectRoot: projectRoot, DefaultEnvironment: "remote"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {Name: "remote", RepoPath: projectRoot, KubernetesContext: "ctx"},
+		},
+	}
+
+	var sessionsMu sync.Mutex
+	var sessions []*stubTerminalSession
+	emits := newCapturedEmits()
+	app := NewApp(erunUIDeps{
+		store:           store,
+		findProjectRoot: func() (string, string, error) { return "erun", projectRoot, nil },
+		resolveCLIPath:  func() string { return "/tmp/erun" },
+		startTerminal: func(startTerminalSessionParams) (terminalSession, error) {
+			session := newStubTerminalSession()
+			// The PTY replays `erun open`'s output: the kubectl attach line,
+			// then the taken-over notice another window's attach triggered.
+			session.initialOutput = append(session.initialOutput,
+				[]byte(eruncommon.ShellSessionTakenOverNotice+"\n")...)
+			sessionsMu.Lock()
+			sessions = append(sessions, session)
+			sessionsMu.Unlock()
+			return session, nil
+		},
+	})
+	defer app.shutdown(context.Background())
+	app.SetEmitter(emits.fn())
+
+	if _, err := app.StartSession(uiSelection{Tenant: "erun", Environment: "remote"}, 0, 80, 24); err != nil {
+		t.Fatalf("StartSession failed: %v", err)
+	}
+	waitForSessionCount(t, &sessionsMu, &sessions, 1, 2*time.Second)
+
+	// Let streamSession scan the notice line, then end the PTY the way the
+	// CLI does after printing it.
+	waitForTakenOverFlag(t, app, 2*time.Second)
+	sessionsMu.Lock()
+	current := sessions[0]
+	sessionsMu.Unlock()
+	_ = current.Close()
+
+	time.Sleep(200 * time.Millisecond)
+	sessionsMu.Lock()
+	got := len(sessions)
+	sessionsMu.Unlock()
+	if got != 1 {
+		t.Fatalf("takeover must not respawn: expected 1 session, got %d", got)
+	}
+	if !sawTakenOverMarker(emits) {
+		t.Fatal("expected taken-over marker on terminal-output channel")
+	}
+}
+
+func waitForTakenOverFlag(t *testing.T, app *App, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		app.mu.Lock()
+		flagged := false
+		for _, managed := range app.sessions {
+			if managed != nil && managed.takenOver {
+				flagged = true
+			}
+		}
+		app.mu.Unlock()
+		if flagged {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for the taken-over notice to be scanned from session output")
+}
+
+func sawTakenOverMarker(emits *capturedEmits) bool {
+	const needle = "re-attached in another ERun window"
+	for _, evt := range emits.events(terminalOutputEvent) {
+		payload, ok := evt.(terminalOutputPayload)
+		if !ok {
+			continue
+		}
+		data, err := base64.StdEncoding.DecodeString(payload.Data)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(data), needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/erun-ui/remote_sessions.go
+++ b/erun-ui/remote_sessions.go
@@ -43,3 +43,35 @@ func (a *App) ListRemoteAppSessions(selection uiSelection) []string {
 	}
 	return eruncommon.ParseRemoteAppSessionIDs(selection.Tenant, selection.Environment, output)
 }
+
+// endRemoteAppSession permanently ends one persistent desktop session in the
+// env's runtime pod: the dtach master is killed (its shell/claude follows via
+// SIGHUP) and the socket is removed, so detection will not rebuild the tab.
+// Called when the user explicitly closes a custom terminal tab — the X is
+// that tab's only removal affordance, and without this the session would
+// outlive the close and resurrect on the next env open. Closing the env or
+// quitting the app never calls this; those only detach. Fail-soft: a missing
+// pod means the session is already gone.
+func (a *App) endRemoteAppSession(selection uiSelection, sessionID string) {
+	selection = normalizeSelection(selection)
+	if selection.Tenant == "" || selection.Environment == "" || strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	envConfig, _, err := a.deps.store.LoadEnvConfig(selection.Tenant, selection.Environment)
+	if err != nil {
+		return
+	}
+	kubernetesContext := strings.TrimSpace(envConfig.KubernetesContext)
+	if kubernetesContext == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, _ = kubectlText(ctx, kubernetesContext,
+		"--namespace", eruncommon.KubernetesNamespaceName(selection.Tenant, selection.Environment),
+		"exec",
+		"deployment/"+eruncommon.RuntimeReleaseName(selection.Tenant),
+		"--",
+		"/bin/sh", "-c", eruncommon.RemoteAppSessionEndScript(selection.Tenant, selection.Environment, sessionID),
+	)
+}

--- a/erun-ui/remote_sessions.go
+++ b/erun-ui/remote_sessions.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// ListRemoteAppSessions reports the persistent desktop sessions currently
+// running in the env's runtime pod, by session id (`open-0`, `ai`,
+// `contribute-erun`, …). The frontend calls it when an env opens so it can
+// rebuild tabs for sessions another ERun window created (custom terminals);
+// the default tabs attach-or-create on their own. Fail-soft by design: an
+// env without a kubernetes context, an unreachable cluster, or a pod that is
+// not deployed yields nil rather than an error — the open flow must never
+// stall on detection.
+func (a *App) ListRemoteAppSessions(selection uiSelection) []string {
+	selection = normalizeSelection(selection)
+	if selection.Tenant == "" || selection.Environment == "" {
+		return nil
+	}
+	envConfig, _, err := a.deps.store.LoadEnvConfig(selection.Tenant, selection.Environment)
+	if err != nil {
+		return nil
+	}
+	kubernetesContext := strings.TrimSpace(envConfig.KubernetesContext)
+	if kubernetesContext == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	output, err := kubectlText(ctx, kubernetesContext,
+		"--namespace", eruncommon.KubernetesNamespaceName(selection.Tenant, selection.Environment),
+		"exec",
+		"deployment/"+eruncommon.RuntimeReleaseName(selection.Tenant),
+		"--",
+		"/bin/sh", "-c", "ls "+eruncommon.RemoteAppSessionSocketDir+" 2>/dev/null || true",
+	)
+	if err != nil {
+		return nil
+	}
+	return eruncommon.ParseRemoteAppSessionIDs(selection.Tenant, selection.Environment, output)
+}

--- a/erun-ui/remote_sessions_test.go
+++ b/erun-ui/remote_sessions_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"testing"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// TestListRemoteAppSessionsParsesPodSockets drives the read-model through a
+// PATH-stubbed kubectl that prints a pod's /tmp/erun-app listing: dtach
+// sockets for this env become session ids, while owner files and other envs'
+// sockets are ignored. This is what lets a fresh ERun window rebuild tabs for
+// sessions another window created.
+func TestListRemoteAppSessionsParsesPodSockets(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH-stub kubectl uses a shell script; skipping on Windows")
+	}
+	stubDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"printf 'erun-remote-open-1.dtach\\nerun-remote-ai.dtach\\nerun-remote-open-1.owner\\nother-env-open-2.dtach\\n'\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	app := NewApp(erunUIDeps{store: stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", ProjectRoot: t.TempDir(), DefaultEnvironment: "remote"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {Name: "remote", KubernetesContext: "ctx"},
+		},
+	}})
+
+	got := app.ListRemoteAppSessions(uiSelection{Tenant: "erun", Environment: "remote"})
+	want := []string{"open-1", "ai"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("ListRemoteAppSessions = %v, want %v", got, want)
+	}
+}
+
+// TestListRemoteAppSessionsFailsSoft pins the contract that detection never
+// surfaces an error into the open flow: an unknown env and an env without a
+// kubernetes context both yield nil.
+func TestListRemoteAppSessionsFailsSoft(t *testing.T) {
+	app := NewApp(erunUIDeps{store: stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", ProjectRoot: t.TempDir(), DefaultEnvironment: "local"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/local": {Name: "local"}, // no kubernetes context
+		},
+	}})
+
+	if got := app.ListRemoteAppSessions(uiSelection{Tenant: "erun", Environment: "local"}); got != nil {
+		t.Fatalf("env without kubernetes context must yield nil, got %v", got)
+	}
+	if got := app.ListRemoteAppSessions(uiSelection{Tenant: "erun", Environment: "missing"}); got != nil {
+		t.Fatalf("unknown env must yield nil, got %v", got)
+	}
+}

--- a/erun-ui/remote_sessions_test.go
+++ b/erun-ui/remote_sessions_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 	"testing"
+	"time"
 
 	eruncommon "github.com/sophium/erun/erun-common"
 )
@@ -61,5 +64,77 @@ func TestListRemoteAppSessionsFailsSoft(t *testing.T) {
 	}
 	if got := app.ListRemoteAppSessions(uiSelection{Tenant: "erun", Environment: "missing"}); got != nil {
 		t.Fatalf("unknown env must yield nil, got %v", got)
+	}
+}
+
+// TestCloseSessionEndsRemoteCustomTerminal pins the explicit-close contract
+// end to end through the desktop: X-ing a custom terminal tab (slot > 0) must
+// run the end-script in the pod — otherwise the session outlives the close
+// and detection resurrects the tab on the next env open. The PATH-stubbed
+// kubectl captures the exec; a default tab close (slot 0) must not end
+// anything (long-running default sessions are the feature).
+func TestCloseSessionEndsRemoteCustomTerminal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH-stub kubectl uses a shell script; skipping on Windows")
+	}
+	stubDir := t.TempDir()
+	captureFile := filepath.Join(stubDir, "kubectl-args")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"" + captureFile + "\"\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	projectRoot := t.TempDir()
+	app := NewApp(erunUIDeps{
+		store: stubUIStore{
+			tenants: map[string]eruncommon.TenantConfig{
+				"erun": {Name: "erun", ProjectRoot: projectRoot, DefaultEnvironment: "remote"},
+			},
+			envs: map[string]eruncommon.EnvConfig{
+				"erun/remote": {Name: "remote", RepoPath: projectRoot, KubernetesContext: "ctx"},
+			},
+		},
+		findProjectRoot: func() (string, string, error) { return "erun", projectRoot, nil },
+		resolveCLIPath:  func() string { return "/tmp/erun" },
+		startTerminal: func(startTerminalSessionParams) (terminalSession, error) {
+			return newStubTerminalSession(), nil
+		},
+	})
+	defer app.shutdown(context.Background())
+	app.SetEmitter(func(string, ...any) {})
+
+	selection := uiSelection{Tenant: "erun", Environment: "remote"}
+	extra, err := app.StartSession(selection, 2, 80, 24)
+	if err != nil {
+		t.Fatalf("StartSession(slot 2): %v", err)
+	}
+	if err := app.CloseSession(extra.SessionID); err != nil {
+		t.Fatalf("CloseSession(extra): %v", err)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		data, _ := os.ReadFile(captureFile)
+		if strings.Contains(string(data), "erun-remote-open-2.dtach") &&
+			strings.Contains(string(data), "rm -f") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected the end-script kubectl exec for open-2, captured: %q", data)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	_ = os.Remove(captureFile)
+	def, err := app.StartSession(selection, 0, 80, 24)
+	if err != nil {
+		t.Fatalf("StartSession(slot 0): %v", err)
+	}
+	if err := app.CloseSession(def.SessionID); err != nil {
+		t.Fatalf("CloseSession(default): %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if data, _ := os.ReadFile(captureFile); strings.Contains(string(data), "rm -f") {
+		t.Fatalf("default tab close must not end the pod session, captured: %q", data)
 	}
 }

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -96,6 +96,24 @@ func buildOpenArgs(tenant, environment string, debug ...bool) []string {
 	return erunArgs(debugEnabled(debug...), "open", strings.TrimSpace(tenant), strings.TrimSpace(environment))
 }
 
+// withAppSession appends the desktop persistent-session flags to an `erun open`
+// argv so the remote shell runs as a reattachable dtach session: closing or
+// reopening the tab (or a transient kubectl-exec drop) reconnects to the running
+// shell instead of spawning a parallel one, and the AI tab's claude keeps
+// working in the pod meanwhile. sessionID is stable per (tab kind, slot) so the
+// reattach lands on the same session; the AI/contribute launch now happens
+// pod-side (no typed prelude). See issue #478.
+func withAppSession(args []string, sessionID string, ai, contribute bool) []string {
+	args = append(args, "--app-session", sessionID)
+	if contribute {
+		args = append(args, "--contribute")
+	}
+	if ai {
+		args = append(args, "--ai")
+	}
+	return args
+}
+
 func buildOpenIDEArgs(selection uiSelection, ide string) []string {
 	args := erunArgs(selection.Debug, "open", strings.TrimSpace(selection.Tenant), strings.TrimSpace(selection.Environment))
 	switch strings.TrimSpace(ide) {
@@ -407,13 +425,6 @@ func resolveLocalShellCommand(goos string) (string, []string) {
 	}
 }
 
-func resolveAIToolCommand(configured string) string {
-	if tool := strings.TrimSpace(configured); tool != "" {
-		return tool
-	}
-	return defaultAITool
-}
-
 // claudeEffortLevels enumerates the valid `claude --effort` startup levels, in
 // ascending order. The set mirrors `claude --help`; max is the highest and the
 // desktop default.
@@ -430,61 +441,6 @@ func claudeEffortLevelOptions() []string {
 	out := make([]string, len(claudeEffortLevels))
 	copy(out, claudeEffortLevels)
 	return out
-}
-
-func validClaudeEffort(level string) bool {
-	for _, l := range claudeEffortLevels {
-		if l == level {
-			return true
-		}
-	}
-	return false
-}
-
-// resolveClaudeEffort returns the env's configured Claude effort level when it
-// is a valid level, falling back to defaultClaudeEffort for an unset or invalid
-// value so the AI tab never launches with a bad --effort flag (issue #469).
-func resolveClaudeEffort(config eruncommon.EnvironmentClaudeConfig) string {
-	if config.Effort != nil {
-		if level := strings.TrimSpace(*config.Effort); validClaudeEffort(level) {
-			return level
-		}
-	}
-	return defaultClaudeEffort
-}
-
-// claudeLaunchGuard is the cwd-guarded Claude Code resume the desktop pipes
-// into an AI tab. It continues the session that belongs to the tab's working
-// directory — the env repo for the env AI tab, the $HOME/git/erun clone for
-// the contribute AI tab — so per-tab restore is correct on local-agent (host)
-// and remote-agent (pod) envs alike, no longer depending on the pod-only
-// claude-wrapper.sh that is absent on local-agent hosts (issue #451).
-//
-// The guard mirrors claude-wrapper.sh: resume only when Claude Code's
-// per-project session store exists for the current directory. It composes with
-// the pod wrapper because the wrapper treats --continue as a bypass flag, so it
-// forwards rather than double-injecting; --effort is likewise forwarded, not
-// stripped. The resolved effort level is injected into both branches so the
-// session runs at the env's configured effort (issue #469).
-func claudeLaunchGuard(effort string) string {
-	flag := ""
-	if validClaudeEffort(effort) {
-		flag = " --effort " + effort
-	}
-	return `if [ -d "$HOME/.claude/projects/$(pwd | tr / -)" ]; then claude --continue` + flag + `; else claude` + flag + `; fi`
-}
-
-// aiLaunchCommand returns the keystrokes the desktop pipes into an AI tab's
-// shell to launch the AI tool. A bare `claude` launch is wrapped in the
-// cwd-guarded resume with the resolved --effort level; any other tool, or
-// `claude` with explicit flags/a subcommand, launches verbatim — mirroring the
-// wrapper's bypass rules so we never alter a launch the user authored.
-func aiLaunchCommand(configured string, effort string) string {
-	tool := resolveAIToolCommand(configured)
-	if tool != defaultAITool {
-		return tool
-	}
-	return claudeLaunchGuard(effort)
 }
 
 func formatLaunchCommand(params startTerminalSessionParams) string {

--- a/erun-ui/session_unix.go
+++ b/erun-ui/session_unix.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"syscall"
 
 	"github.com/creack/pty"
 )
@@ -83,6 +84,14 @@ func (s *unixTerminalSession) Close() error {
 		return nil
 	}
 	if s.cmd != nil && s.cmd.Process != nil {
+		// Kill the whole process group, not just `erun open`: its kubectl exec
+		// child otherwise survives as an orphan that holds the exec stream open,
+		// leaving a stale dtach client attached in the pod after every close.
+		// pty.Start ran the child with Setsid, so it leads its own group
+		// (pgid == pid) and the negative-pid signal reaps the full chain.
+		if pid := s.cmd.Process.Pid; pid > 0 {
+			_ = syscall.Kill(-pid, syscall.SIGKILL)
+		}
 		_ = s.cmd.Process.Kill()
 		_ = s.Wait()
 	}

--- a/erun-ui/session_unix_test.go
+++ b/erun-ui/session_unix_test.go
@@ -1,0 +1,74 @@
+//go:build !windows
+
+package main
+
+import (
+	"regexp"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestCloseReapsWholeProcessGroup pins the #478 orphan fix: Close() must kill
+// the session's entire process group, not only the direct child. The session
+// runs a shell that spawns a grandchild (standing in for the kubectl exec that
+// `erun open` spawns) — after Close() the grandchild must be dead, not left
+// holding a remote exec stream open. Only the session's own group is signalled,
+// so sessions of other tabs or other app instances are untouched.
+func TestCloseReapsWholeProcessGroup(t *testing.T) {
+	session, err := startTerminalSession(startTerminalSessionParams{
+		Executable: "/bin/sh",
+		Args:       []string{"-c", `sleep 300 & echo "CHILD_PID=$!"; wait`},
+		Cols:       80,
+		Rows:       24,
+	})
+	if err != nil {
+		t.Fatalf("startTerminalSession: %v", err)
+	}
+
+	childPid := readChildPid(t, session)
+	if syscall.Kill(childPid, 0) != nil {
+		t.Fatalf("grandchild %d not alive before Close()", childPid)
+	}
+
+	_ = session.Close()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if syscall.Kill(childPid, 0) != nil {
+			return // whole group reaped
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = syscall.Kill(childPid, syscall.SIGKILL)
+	t.Fatalf("grandchild %d survived Close(); the kubectl exec orphan leak is back", childPid)
+}
+
+var childPidPattern = regexp.MustCompile(`CHILD_PID=(\d+)`)
+
+func readChildPid(t *testing.T, session terminalSession) int {
+	t.Helper()
+	var output []byte
+	buffer := make([]byte, 4096)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		n, err := session.Read(buffer)
+		if n > 0 {
+			output = append(output, buffer[:n]...)
+			if match := childPidPattern.FindSubmatch(output); match != nil {
+				pid, convErr := strconv.Atoi(string(match[1]))
+				if convErr != nil {
+					t.Fatalf("parse grandchild pid from %q: %v", match[1], convErr)
+				}
+				return pid
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	_ = session.Close()
+	t.Fatalf("grandchild pid never appeared in session output: %q", output)
+	return 0
+}

--- a/erun-ui/session_windows.go
+++ b/erun-ui/session_windows.go
@@ -5,6 +5,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"strconv"
 	"sync"
 	"syscall"
 
@@ -101,6 +103,14 @@ func (s *windowsTerminalSession) Close() error {
 		return nil
 	}
 	if s.process != nil {
+		// Kill the whole child tree, not just `erun open`: its kubectl exec
+		// child otherwise survives as an orphan that holds the exec stream
+		// open, leaving a stale dtach client attached in the pod after every
+		// close. taskkill /T is the Windows counterpart of the Unix
+		// process-group kill; Process.Kill stays as the fallback.
+		if s.process.Pid > 0 {
+			_ = exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(s.process.Pid)).Run()
+		}
 		_ = s.process.Kill()
 		_ = s.Wait()
 	}

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -803,9 +803,25 @@ func (a *App) ResizeSession(sessionID, cols, rows int) error {
 func (a *App) CloseSession(sessionID int) error {
 	a.mu.Lock()
 	managed := a.sessionBySerialLocked(sessionID)
+	var endRemote bool
+	var endSelection uiSelection
+	var endID string
+	if managed != nil && managed.kind == sessionKindOpen && managed.slot > 0 && !managed.takenOver {
+		// An explicit close of a custom terminal tab is the user removing
+		// that terminal, not just detaching: end the pod session too, or
+		// detection rebuilds the tab on the next env open. Default tabs stay
+		// detach-only (their long-running sessions are the feature), and a
+		// taken-over tab must never kill the session another window now owns.
+		endRemote = true
+		endSelection = managed.selection
+		endID = fmt.Sprintf("open-%d", managed.slot)
+	}
 	a.mu.Unlock()
 	if managed == nil || managed.session == nil {
 		return nil
+	}
+	if endRemote {
+		go a.endRemoteAppSession(endSelection, endID)
 	}
 	return managed.session.Close()
 }

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -70,7 +70,7 @@ func (a *App) runOpenSession(ctx context.Context, selection uiSelection, slot, c
 	openParams := startTerminalSessionParams{
 		Dir:        resolveTerminalStartDir(result.RepoPath),
 		Executable: a.deps.resolveCLIPath(),
-		Args:       buildOpenArgs(result.Tenant, result.Environment, selection.Debug),
+		Args:       withAppSession(buildOpenArgs(result.Tenant, result.Environment, selection.Debug), fmt.Sprintf("open-%d", slot), false, false),
 		Env:        []string{appSessionEnvVar + "=1"},
 		Cols:       cols,
 		Rows:       rows,
@@ -240,19 +240,18 @@ func (a *App) runAISession(ctx context.Context, selection uiSelection, slot, col
 	}
 	a.mu.Unlock()
 
-	tool := resolveAIToolCommand(result.EnvConfig.AITool)
 	params := startTerminalSessionParams{
 		Dir:        resolveTerminalStartDir(result.RepoPath),
 		Executable: a.deps.resolveCLIPath(),
-		Args:       buildOpenArgs(result.Tenant, result.Environment, selection.Debug),
-		Env:        []string{appSessionEnvVar + "=1"},
-		Cols:       cols,
-		Rows:       rows,
-		// The env AI tab runs in the env repo, so the cwd-guarded resume
-		// continues the env project's Claude Code session (issue #451). The
-		// per-env Claude effort level (default max) is injected as --effort
-		// (issue #469).
-		InitialInput: []byte(aiLaunchCommand(result.EnvConfig.AITool, resolveClaudeEffort(result.EnvConfig.Claude)) + "\n"),
+		// The AI tab runs `erun open --app-session ai --ai`: the persistent
+		// remote session launches the AI tool itself (the cwd-guarded claude
+		// resume at the env effort, issues #451/#469), once on create. Reopening
+		// reconnects to the running claude rather than typing it in again or
+		// spawning a parallel one (#478).
+		Args: withAppSession(buildOpenArgs(result.Tenant, result.Environment, selection.Debug), "ai", true, false),
+		Env:  []string{appSessionEnvVar + "=1"},
+		Cols: cols,
+		Rows: rows,
 	}
 	session, err := a.deps.startTerminal(params)
 	if err != nil {
@@ -280,7 +279,7 @@ func (a *App) runAISession(ctx context.Context, selection uiSelection, slot, col
 	a.rememberKubeContextForActivity(selection.KubernetesContext)
 	go a.streamSession(managed)
 
-	a.logSpawnedCommandToLocal(selection, "ai", formatLocalCommandLog(formatLaunchCommand(params)+" && "+shellQuoteIfNeeded(tool), "AI tab"))
+	a.logSpawnedCommandToLocal(selection, "ai", formatLocalCommandLog(formatLaunchCommand(params), "AI tab"))
 	_ = ctx
 	return startSessionResult{
 		SessionID: serial,

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -995,6 +995,16 @@ func (a *App) tryReconnect(managed *managedTerminal, exitReason string) bool {
 	respawn := managed.respawn
 	a.mu.Unlock()
 
+	// Another ERun window re-attached this persistent session — a
+	// deliberate handover, not a transient drop. Respawning would run
+	// `erun open` again, whose attach takes the session straight back,
+	// and the two windows would steal it from each other in a loop.
+	// Clicking the env in the sidebar is the deliberate take-back.
+	if a.sessionTakenOver(managed) {
+		a.emitTakenOverMarker(managed.serial)
+		return false
+	}
+
 	// Refuse to respawn while the env's linked cloud context is not
 	// running. Each respawn re-runs `erun open`, whose preflight calls
 	// StartCloudContext and immediately undoes any auto-stop that has
@@ -1167,6 +1177,7 @@ const (
 	reconnectLoopMaxExits   = 2
 	reconnectLoopMarkerANSI = "\r\n\x1b[2;33m── stopped reconnecting after repeated failures — click the environment in the sidebar to retry ──\x1b[0m\r\n"
 	deployFailedMarkerANSI  = "\r\n\x1b[2;33m── deploy failed — not retrying automatically; use Run doctor or Rebuild & redeploy on the failed deploy, or click the environment in the sidebar to retry ──\x1b[0m\r\n"
+	takenOverMarkerANSI     = "\r\n\x1b[2;33m── session re-attached in another ERun window — click the environment in the sidebar to attach it here ──\x1b[0m\r\n"
 )
 
 // trackExitForLoopGuard records the moment the managed PTY exited
@@ -1214,6 +1225,38 @@ func (a *App) emitDeployFailedMarker(sessionID int) {
 		SessionID: sessionID,
 		Data:      base64.StdEncoding.EncodeToString([]byte(deployFailedMarkerANSI)),
 	})
+}
+
+// emitTakenOverMarker writes a single diagnostic line when tryReconnect
+// refuses to respawn because another ERun window re-attached the session.
+// The named recovery action mirrors the other markers: clicking the env in
+// the sidebar deliberately takes the session back.
+func (a *App) emitTakenOverMarker(sessionID int) {
+	a.emitEvent(terminalOutputEvent, terminalOutputPayload{
+		SessionID: sessionID,
+		Data:      base64.StdEncoding.EncodeToString([]byte(takenOverMarkerANSI)),
+	})
+}
+
+// markSessionTakenOver flags the managed PTY whose output carried the CLI's
+// taken-over notice (eruncommon.ShellSessionTakenOverNotice); see the
+// takenOver field for the semantics.
+func (a *App) markSessionTakenOver(managed *managedTerminal) {
+	if managed == nil {
+		return
+	}
+	a.mu.Lock()
+	managed.takenOver = true
+	a.mu.Unlock()
+}
+
+func (a *App) sessionTakenOver(managed *managedTerminal) bool {
+	if managed == nil {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return managed.takenOver
 }
 
 // reconnectBlockedByDeployFailure reports whether the managed PTY's open
@@ -1488,6 +1531,14 @@ type managedTerminal struct {
 	// call, so a long-running successful session followed by a single
 	// exit never trips the cap. See issue #361.
 	recentExits []time.Time
+
+	// takenOver is set when the session's output carries the CLI's
+	// taken-over notice: another ERun window re-attached this persistent
+	// pod session (screen-style detach-and-reattach). tryReconnect must
+	// then refuse to respawn — respawning would steal the session straight
+	// back and the two windows would fight. Clicking the env in the
+	// sidebar starts a fresh session, which is the deliberate take-back.
+	takenOver bool
 
 	// aiActiveSince / aiLastOutput / aiBusyEmitted / aiInactivityTimer
 	// drive the debounced AI activity signal that powers the sidebar


### PR DESCRIPTION
## Problem

Reopening an environment (or an auto-reconnect after a transient `kubectl exec` drop) spawned a fresh `erun open → kubectl exec → bash → claude` chain in the runtime pod **every time** and left the previous pod-side `claude` running. A live `ps` in the `erun/local` pod showed 8 stranded `claude-real` processes laddering from ~10h old down to seconds. The long-running remote Agent is a *feature* — a reopen should reconnect to it, not start a parallel one. (Closes #478. Closes #481.)

## Fix

Run the pod-side shell inside a persistent, named, attachable **dtach** session keyed by `tenant+env+session-id`. A disconnect detaches (the session and its `claude` keep running); the next `kubectl exec` re-attaches to the same one via `dtach -A "<socket>" -r winch`.

**Why dtach, not tmux** (the issue proposed tmux): dtach is transparent — no status bar, no extra keybindings, no window/pane model. It just keeps one program attached to a detachable PTY, which is exactly the single-session-per-tab semantics we want. `-r winch` drives redraw via `SIGWINCH` so xterm resizes still propagate.

### What changed
- **erun-common** — `ShellLaunchParams` gains `AppSession` / `AI` / `Contribute` / `AITool` / `Claude`. `remoteShellLaunchLines` wraps the launcher in `dtach -A <socket> -r winch /bin/bash <launcher>` when `AppSession` is set; a bare `erun open` keeps the plain `/bin/bash -i` (no dtach). `AISessionLaunchCommand` (relocated here from erun-ui) builds the cwd-guarded `claude --continue` resume at the per-env effort.
- **erun-cli** — hidden `--app-session <id>` / `--ai` / `--contribute` flags on `erun open` select the persistent session and its create-time program.
- **erun-ui** — the AI, ERun, custom *Terminal N*, and contribute tabs pass `--app-session` (+ `--ai`/`--contribute`) instead of *typing* a `claude` `InitialInput`, so reopening reattaches to the live session. The Local tab is laptop-side and intentionally unchanged.
- **erun-devops** — `dtach` added to the runtime image.
- **erun-integration** — three `open --dry-run` scenarios lock the dtach bootstrap script for the shell, AI, and contribute-AI launcher bodies.
- **erun-docs** — `desktop/overview.md` "Persistent terminal sessions" now states the reopen-reconnect contract (Operator voice; the dtach/`--app-session` mechanism stays out of public docs).

Pre-existing stranded sessions clear on the next pod replacement (redeploy) — no manual kill needed.

## Validation

- **Integration gate** — `make integration-test` green; coverage **57.8%** (≥ 55.0%). The 3 new scenarios raised it (they exercise `traceShellPreview → buildRemoteShellScript → remoteShellLaunchLines → AISessionLaunchCommand`, previously uncovered). Bare-`open` goldens unchanged.
- **erun-common** — `go test` green, incl. `TestRemoteShellLaunchPersistentSession` (dtach wrap, plain-shell, AI guard, contribute prelude) and `TestAISessionLaunchCommand` / `TestResolveClaudeEffort`.
- **erun-ui** — `go test ./...` green; the exact open args (`--app-session`/`--ai`/`--contribute`, no `InitialInput`) are locked in `app_test.go` + `contribute_app_test.go`.
- **golangci-lint** — 0 issues (pre-commit).
- **Playwright** — 58 passed; the 2 failures (`manage-cloud-alias-clear`, `sidebar-local-badge`) are unrelated sidebar/manage row-click interceptions from a hover-popover overlap on this machine's crowded `~/.erun` — not surfaces this change touches, and none of the terminal/tab/AI/contribute specs are among them.
- **dtach (image artifact)** — verified live in a throwaway `ubuntu:noble` container (the runtime base): installs cleanly (`/usr/bin/dtach`) and `dtach -n` creates exactly one session/program. The `-A`-reattaches-an-existing-master behavior is dtach's documented core and is exactly what the integration-locked bootstrap script invokes.
- **erun-docs** — `yarn build` clean (no broken links).

### E2E gate — what is *not* self-verified
The full live reconnect (reopen the desktop tab → reattach to the running pod `claude`) requires rolling the new runtime image + erun binary into `erun/local`, which means **restarting that pod**. The env is actively in use (live MCP port-forward, the desktop app running), so I did not unilaterally redeploy it — that's the redeploy the issue notes will "tidy" the strand, on the operator's timing. After that redeploy + a desktop rebuild, the reconnect is live. The deterministic bootstrap script the binary emits is the public dry-run contract and is locked by the integration goldens above.

## UX Impact Review Checklist
1. **Affected paths.** AI tab (`StartAISession` → `erun open --app-session ai --ai`), ERun + custom *Terminal N* tabs (`StartSession` → `--app-session open-N`), contribute tabs (`--app-session contribute-erun|contribute-ai --contribute [--ai]`). All funnel to the pod-side shell launch in erun-common.
2. **User-visible sequence.** Open env → tab appears → terminal renders the pod session (unchanged). On **reopen** after closing, the tab reattaches to the still-running pod session — same Agent, same scrollback — instead of a fresh shell. No new dialogs or controls.
3. **State-without-affordance.** No new `AppState` fields or mutations. The change is child-process args + removal of the typed `InitialInput`; the tab's visible affordance is identical, the improvement is *what* it renders (the reconnected session).
4. **Visibility of system status (N#1).** No new in-flight operation; reconnect is transparent (the terminal shows the live session). No status overlay added or removed.
5. **Success/failure feedback (N#1,#9).** Unchanged: exec/reconnect failures surface in the terminal as before; the existing `tryReconnect`/exit handling is untouched.
6. **Consistency with comparable flows (N#4).** All pod-backed tabs (AI, ERun, custom Terminal, contribute) now use one persistent-session mechanism — consistent. Compared against the prior AI-tab `InitialInput` path, which this replaces.
7. **One-line heuristic pass.** #1 status: terminal shows the live session — pass. #2 match: "your session keeps running / reconnects" matches the operator's mental model — pass. #3 control: close/reopen still free, no longer strands — pass. #4 consistency: see above — pass. #5 error prevention: removes the process pile-up — pass. #6 recognition: scrollback + Agent state preserved across reopen — pass. #7 flexibility: reattach is automatic — pass. #8 minimalist: no new UI — N/A. #9 recover: existing handling intact — pass. #10 help: `desktop/overview.md` updated — pass.
8. **Playwright coverage.** No new spec: the reconnect is a pod-side behavior the headless harness can't stage (no real cluster/dtach). The closest observable invariants — one tab per (env, kind), reuse-by-key — are already covered by existing terminal/tab specs (all green this run). The arg contract is locked by Go tests; the pod-side dtach script by 3 integration goldens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Addendum: live-verification findings (reattach repaint + orphan reap)

Driving the fix on the real desktop surfaced two gaps, both fixed in this PR:

1. **Reattaching rendered a black terminal.** dtach keeps no screen buffer, and a same-size attach yields no effective WINCH — bash's readline and claude's TUI both stay silent. Measured in-pod against live sessions: winch-reattach emitted **32 bytes** (nothing), ctrl_l-reattach **2511 bytes** (full repaint). The attach mode is now `-r ctrl_l` for every session kind; the ^L dtach sends on attach makes bash and claude repaint immediately.
2. **Closing a tab orphaned the kubectl exec child.** `Close()` killed only `erun open`; the orphan held the exec stream open and left a stale dtach client attached in the pod on every close (14 piled up overnight). `Close()` now signals the whole local process group (`pty.Start` runs the child with Setsid, so pgid == pid); the Windows twin uses `taskkill /T /F` (build-verified via `GOOS=windows go vet`; no Windows host in the loop). Only the local chain is touched.

**Multi-window semantics — take over, not share (screen `-d -r` style):** exactly one persistent session exists per tab id (ERun `open-0`, AI, contribute pair, custom `open-N`). Whichever ERun window opens the env — at launch or by clicking it in the sidebar — attaches those sessions to itself: the bootstrap claims an owner id and detaches other viewers by killing their dtach clients (never the master, which owns the running shell/claude; no one is kicked when the master can't be identified). A kicked wrapper exits 76 → `erun open` prints the stable `ShellSessionTakenOverNotice` and ends cleanly → the other window matches the line, refuses to respawn (no tug-of-war), and shows a marker naming the take-back affordance (click the env in the sidebar). On env open the desktop also lists the pod's session sockets (`ListRemoteAppSessions` → `kubectl exec ls /tmp/erun-app`) and rebuilds `Terminal N` tabs for custom sessions another window created; default tabs attach-or-create on their own, so missing defaults respawn and running ones reattach.

Validation rerun after the addendum commits: erun-common + erun-ui `go test` green, `GOOS=windows go vet` green, integration gate green (57.7% ≥ 55.0%) with the three dtach goldens regenerated to `-r ctrl_l`.



**Live takeover E2E (verified against the deployed erun/local pod):** two concurrent viewers on the same `--app-session`. Viewer B's attach: clear + fully repainted prompt (ctrl_l). Viewer A's capture, verbatim sequence: `[got signal 15 - dying]` (B's kick of A's dtach client) → `command terminated with exit code 76` → `open: session re-attached in another ERun window` → clean exit. The session master and its shell were untouched throughout. The first live run also caught a real defect: the erun-devops container ships no `ss`, so the listener-pid master lookup silently came back empty and the safety gate skipped the kick — master detection is now a /proc child scan (the dtach process whose child is the session program), verified against the live pod before landing.


**Explicit close ends the session (follow-on caught by the suite):** with sessions persisting across closes, the X on a custom `Terminal N` tab only detached the viewer — detection then resurrected the tab on the next env open, so a custom terminal could never be removed. `CloseSession` now also runs the end-script in the pod (kill the dtach master; the shell follows via SIGHUP; remove socket + owner) — scoped to custom tabs only, never taken-over tabs, never defaults; env close and app quit still only detach. Final validation: integration gate 57.8%, all Go suites green, Playwright **59 passed / 2 failed** — the 2 are the same `manage-cloud-alias-clear` + `sidebar-local-badge` failures reproduced on this machine **before** any change on this branch (sidebar popover click interception; environmental).


---

## Addendum: two issues found while exercising the live desktop

**SSH private key off the command line (security, #481).** `erun open` embedded the git SSH private key as a heredoc in the `kubectl exec … -- /bin/sh -lc '<script>'` argv, so it sat in the session process's `/proc/<pid>/cmdline` (readable by the in-pod Agent and any dependency), the laptop kubectl argv, and any exec audit log. The key now streams to the pod on **stdin** via a separate non-interactive `kubectl exec -i` before the interactive shell; the inline bootstrap seeds only the public known_hosts + ssh config. Pinned by erun-common unit tests + verified live (pod `ps` shows no key in argv). Pre-existing; fixed here as it lives in the same bootstrap builder.

**DECRQSS reattach junk.** On reattach the ERun prompt showed `1$r0"q␛\` typed at the prompt: xterm answered DECRQSS status-string queries via SendSessionInput, and with the session back at a bash prompt the async reply was echoed as input. Moved DECRQSS to the same no-op suppression already used for DA1/DA2 + OSC color queries (tools time out → xterm defaults), added a display-strip backstop, and re-pointed the #347 spec at the DEC cursor-position query (the reply path that stays). Cursor-position reports remain answered.

Both verified by the gates (erun-common + erun-ui Go tests, integration 57.7%, frontend typecheck/lint/format, Playwright) and rolled into the rebuilt binaries.


**Playwright (final, two full runs):** run A 55/6, run B 59/2 — the failing set shrinks and shifts run-to-run (the env-flakiness tell on this dev machine's crowded `~/.erun`). The only consistent failures are `manage-cloud-alias-clear` + `sidebar-local-badge` (sidebar hover-popover intercepts the row click — environmental). `sidebar-reclick-no-duplicate-tabs` failed in A and **passed in B** (pre-existing ERun-slow-cold-start race reading count 0→1; the remote-session detection never creates Local/ERun/AI tabs). The #347 `terminal-query-response` spec — the one in this change's area — passes in both.
