### PR TITLE
Stop re-answering cursor-position queries replayed from saved terminal buffers

### DIFF
--- a/erun-ui/frontend/src/app/TerminalController.ts
+++ b/erun-ui/frontend/src/app/TerminalController.ts
@@ -184,6 +184,10 @@ export class TerminalController {
       (error) => {
         store.dispatch(showTerminalMessage(readError(error)));
       },
+      // Suppress replies to queries re-parsed from a replayed display buffer:
+      // the asking tool consumed the live reply long ago, so a second reply
+      // would land on the session's shell as typed input (#484).
+      () => this.writeSources.currentIsReplay(),
     );
     this.terminalDataDisposable = this.terminal.onData((data) => {
       SendSessionInput(store.getState().terminal.sessionId, data).catch((error: unknown) => {
@@ -371,13 +375,15 @@ export class TerminalController {
   // writeToTerminal is the single seam for every xterm write. It tags the write
   // with its source session via the write-source queue and hands xterm the
   // matching completion callback, so terminal query replies fired while xterm
-  // parses this chunk route back to sessionId (issue #347).
-  private writeToTerminal(sessionId: number, data: TerminalWriteData): void {
+  // parses this chunk route back to sessionId (issue #347). replay marks
+  // chunks re-rendered from the saved display buffer, whose stale queries must
+  // be consumed without replying (issue #484).
+  private writeToTerminal(sessionId: number, data: TerminalWriteData, replay = false): void {
     const terminal = this.terminal;
     if (!terminal) {
       return;
     }
-    terminal.write(data, this.writeSources.begin(sessionId));
+    terminal.write(data, this.writeSources.begin(sessionId, replay));
   }
 
   layoutCallbacks(): {
@@ -553,7 +559,7 @@ export class TerminalController {
 
   writeTerminalBuffer(sessionId: number, chunks: TerminalWriteData[]): void {
     for (const chunk of chunks) {
-      this.writeToTerminal(sessionId, chunk);
+      this.writeToTerminal(sessionId, chunk, true);
     }
     // Rehydrate live cursor state from the replayed buffer.
     // rebuildTerminalDisplayBuffer already appended `?25h` if the live

--- a/erun-ui/frontend/src/app/TerminalWriteSourceQueue.ts
+++ b/erun-ui/frontend/src/app/TerminalWriteSourceQueue.ts
@@ -1,7 +1,9 @@
 // TerminalWriteSourceQueue records which PTY session each in-flight xterm write
-// belongs to, so terminal query replies (CPR/DSR/DECRQSS) route back to the
-// session whose output asked — not whichever session happens to be selected at
-// the moment xterm fires the reply handler.
+// belongs to — and whether the write streams live output or replays a saved
+// buffer — so terminal query replies (CPR/DSR/DECRQSS) route back to the
+// session whose output asked, and stale queries re-parsed from a replayed
+// buffer are never answered at all (issue #484): the asking tool is long gone,
+// so the reply would land on the live shell's stdin as typed junk.
 //
 // Why a queue and not a single field: xterm parses writes and fires their
 // completion callbacks strictly FIFO, and a large write can defer parsing
@@ -12,17 +14,23 @@
 // completion callback to terminal.write(data, callback) keeps the queue head
 // aligned with the chunk xterm is parsing right now, so current() yields the
 // originating session even across a mid-parse session switch.
+interface TerminalWriteSource {
+  sessionId: number;
+  replay: boolean;
+}
+
 export class TerminalWriteSourceQueue {
-  private readonly sources: number[] = [];
+  private readonly sources: TerminalWriteSource[] = [];
 
   // begin records sessionId as the source of the next xterm write and returns
   // the completion callback to hand to terminal.write(data, callback). xterm
   // invokes that callback once the chunk is parsed; FIFO ordering means the
   // first callback to fire belongs to the head entry, so shifting the head
   // keeps the queue aligned. The callback is idempotent so a double-fire can
-  // never desync the queue.
-  begin(sessionId: number): () => void {
-    this.sources.push(sessionId);
+  // never desync the queue. replay marks chunks re-rendered from a saved
+  // display buffer rather than streamed live from the PTY.
+  begin(sessionId: number, replay = false): () => void {
+    this.sources.push({ sessionId, replay });
     let settled = false;
     return () => {
       if (settled) {
@@ -37,7 +45,14 @@ export class TerminalWriteSourceQueue {
   // fallback when no write is in flight (e.g. a reply arriving outside any
   // write — preserves the previous "current selection" behaviour as a floor).
   current(fallback: number): number {
-    return this.sources[0] ?? fallback;
+    return this.sources[0]?.sessionId ?? fallback;
+  }
+
+  // currentIsReplay reports whether the chunk xterm is parsing right now was
+  // replayed from a saved buffer. Outside any write it returns false, matching
+  // the live-input assumption the current() fallback makes.
+  currentIsReplay(): boolean {
+    return this.sources[0]?.replay ?? false;
   }
 
   // clear drops all pending sources. Call when the terminal is disposed: xterm

--- a/erun-ui/frontend/src/app/terminalBuffers.ts
+++ b/erun-ui/frontend/src/app/terminalBuffers.ts
@@ -66,6 +66,14 @@ const TERMINAL_RESPONSE_PATTERNS: RegExp[] = [
   // above; without this the user sees the literal text at the prompt
   // even when terminalQueryResponses no longer answers the query.
   /(?:^|[^A-Za-z0-9])\d+(?:;\d+)+c(?![A-Za-z0-9])/g,
+  // Bare CPR tail run (`1;64R`, `1;64R1;69R1;1R`, …) — same readline
+  // stripping, for cursor-position reports that landed on a shell prompt.
+  // terminalQueryResponses no longer answers queries re-parsed from a
+  // replayed buffer (#484), so this is a backstop that cleans buffers
+  // already polluted before that fix. Echoed reports concatenate (each
+  // report is typed input, so the next lands right after it), hence the
+  // run grouping; the anchoring mirrors the DA tail above.
+  /(?:^|[^A-Za-z0-9])(?:\d+(?:;\d+)+R)+(?![A-Za-z0-9])/g,
   // DECRQSS status-string response: DCS [01] $ r <payload> ST
   // (e.g. `\x1bP1$r0"q\x1b\\`). terminalQueryResponses no longer answers
   // DECRQSS, so this is a backstop for a response that reaches the buffer

--- a/erun-ui/frontend/src/app/terminalQueryResponses.ts
+++ b/erun-ui/frontend/src/app/terminalQueryResponses.ts
@@ -9,6 +9,7 @@ export function registerTerminalQueryResponseHandlers(
   terminal: Terminal,
   sendInput: TerminalInputSender,
   onError: TerminalInputErrorHandler,
+  isReplayParse: () => boolean,
 ): IDisposable[] {
   const sendResponse = async (data: string): Promise<boolean> => {
     if (!data) {
@@ -46,6 +47,16 @@ export function registerTerminalQueryResponseHandlers(
   // we still answer: tools genuinely need the cursor location and there is
   // no sane default to time out to. Those replies still route to the
   // asking session via the writeSources queue (issue #347).
+  //
+  // …but only for live parses. Query bytes are saved verbatim in the
+  // per-session buffer, so re-rendering a tab (setSessionId →
+  // terminalDisplayMiddleware → writeTerminalBuffer) re-parses every query a
+  // tool ever emitted in that session — BuildKit's tty progress and claude
+  // both probe with `ESC[6n`. The asking tool is long gone by then, so the
+  // re-answered report lands on the shell's stdin and readline echoes its
+  // printable tail as typed junk (`1;64R1;69R…` at the prompt, issue #484).
+  // isReplayParse (backed by the writeSources queue) identifies those
+  // replayed chunks; their queries are consumed without a reply.
   const suppressQuery = (): boolean => true;
 
   return [
@@ -56,6 +67,9 @@ export function registerTerminalQueryResponseHandlers(
     terminal.parser.registerCsiHandler({ prefix: '>', final: 'c' }, suppressQuery),
     terminal.parser.registerDcsHandler({ intermediates: '$', final: 'q' }, suppressQuery),
     terminal.parser.registerCsiHandler({ final: 'n' }, (params) => {
+      if (isReplayParse()) {
+        return true;
+      }
       switch (firstParam(params)) {
         case 5:
           return sendResponse(`${ESC}[0n`);
@@ -66,7 +80,7 @@ export function registerTerminalQueryResponseHandlers(
       }
     }),
     terminal.parser.registerCsiHandler({ prefix: '?', final: 'n' }, (params) => {
-      if (firstParam(params) !== 6) {
+      if (isReplayParse() || firstParam(params) !== 6) {
         return true;
       }
       return sendResponse(cursorPositionReport(terminal, '?'));

--- a/erun-ui/playwright/tests/terminal-query-response.spec.ts
+++ b/erun-ui/playwright/tests/terminal-query-response.spec.ts
@@ -27,7 +27,14 @@ import { expect, test } from '../fixtures/erunApp.js';
 // because their async reply landed at the bash prompt as junk when the asking
 // tool had exited or the query arrived on reattach. Cursor position is the one
 // reply still sent (tools need it; no sane default), so it is what this spec
-// observes.
+// observes — for live parses only: issue #484 covers the replay side. Query
+// bytes are saved verbatim in the per-session buffer, so re-rendering a tab
+// (setSessionId → terminalDisplayMiddleware → writeTerminalBuffer) re-parses
+// every query a tool ever emitted there; answering those again injects the
+// reply into the live PTY where nothing is waiting, and the shell echoes it
+// as typed junk (`1;64R1;69R…` at the prompt). The third test locks the
+// replay invariant: a query replayed from the saved buffer is never
+// re-answered, while a live query still is.
 //
 // Harness limitation: the exact cross-session race (xterm deferring a query's
 // parse across a session switch, so reply-time selection != write-time source)
@@ -76,6 +83,15 @@ function captureInvokes(page: Page): InvokeCall[] {
 // (cursorPositionReport returns `ESC [ ? <row> ; <col> R`).
 function isCprReply(data: unknown): data is string {
   return typeof data === 'string' && data.startsWith('\x1b[') && data.endsWith('R');
+}
+
+// cprRepliesTo collects the cursor-position report strings addressed to
+// sessionId, in arrival order.
+function cprRepliesTo(invokes: InvokeCall[], sessionId: number): string[] {
+  return invokes
+    .filter((call) => call.method === 'SendSessionInput' && call.args[0] === sessionId)
+    .map((call) => call.args[1])
+    .filter(isCprReply);
 }
 
 // emitTerminalOutput injects a `terminal-output` event for sessionId carrying
@@ -172,5 +188,72 @@ test.describe('terminal query responses (#347)', () => {
         call.args[0] === backgroundId,
     );
     expect(answeredToBackground).toHaveLength(0);
+  });
+
+  test('a query replayed from a saved buffer is never re-answered (#484)', async ({
+    app,
+    page,
+  }) => {
+    const target = await app.sidebar.firstEnvironmentExcludingLocal();
+    test.skip(target === null, 'no non-local environment in this developer harness');
+    const { tenant, env } = target!;
+
+    await app.sidebar.openEnvironment(tenant, env);
+    const localTab = page.getByRole('tab', { name: 'Local', exact: true });
+    await localTab.waitFor({ state: 'visible', timeout: 15_000 });
+
+    // Spawn a deterministic second session via the tab strip's "Open a new
+    // terminal" button (same pattern as terminal-scroll-on-switch.spec.ts);
+    // the new extra tab becomes the active one.
+    const tablist = page.getByRole('tablist', { name: 'Open terminals' });
+    const extraTabs = tablist.getByRole('tab', { name: /Terminal \d+/ });
+    const initialExtraCount = await extraTabs.count();
+    await page.getByRole('button', { name: 'Open a new terminal' }).click();
+    await expect
+      .poll(() => extraTabs.count(), { timeout: 15_000 })
+      .toBeGreaterThan(initialExtraCount);
+    const extraTab = extraTabs.last();
+    await extraTab.click();
+
+    const invokes = captureInvokes(page);
+    const extraId = await discoverSelectedSessionId(app, page);
+    expect(extraId).toBeGreaterThan(0);
+
+    // 1. A live DEC query is answered once — and its bytes are now part of
+    //    the session's saved buffer (the `?` prefix dodges the display strip,
+    //    exactly like production queries split across PTY chunks do).
+    await emitTerminalOutput(page, extraId, CPR_QUERY);
+    await expect.poll(() => cprRepliesTo(invokes, extraId).length, { timeout: 5_000 }).toBe(1);
+
+    // 2. Switch away and back. The middleware rebuilds and replays the extra
+    //    session's display buffer — stale query included — into xterm.
+    await localTab.click();
+    await extraTab.click();
+
+    // 3. Drain with a *plain* CSI query (`ESC [ 6 n`), split across two
+    //    output events so the per-chunk display strip cannot eat it. Its
+    //    reply carries no `?`, so it is distinguishable from any reply to the
+    //    replayed DEC query; xterm parses writes FIFO, so once the plain
+    //    reply lands every replayed chunk from step 2 has been parsed.
+    await emitTerminalOutput(page, extraId, '\x1b[');
+    await emitTerminalOutput(page, extraId, '6n');
+    await expect
+      .poll(() => cprRepliesTo(invokes, extraId).filter((r) => !r.startsWith('\x1b[?')).length, {
+        timeout: 5_000,
+      })
+      .toBe(1);
+
+    // The replay parse is provably complete and must have contributed
+    // nothing: the only DEC-shaped reply is the live one from step 1.
+    const decReplies = cprRepliesTo(invokes, extraId).filter((r) => r.startsWith('\x1b[?'));
+    expect(decReplies).toHaveLength(1);
+
+    // Close the spawned terminal so the extra session does not drift the
+    // session set the singleton headless backend hands to later specs.
+    await tablist
+      .getByRole('button', { name: /^Close / })
+      .last()
+      .click();
+    await expect.poll(() => extraTabs.count()).toBe(initialExtraCount);
   });
 });


### PR DESCRIPTION
Closes #484

## Problem

After reattaching to a persistent pod session (#478) and switching tabs, the ERun tab's shell shows junk typed at the prompt — `1;64R1;69R1;1R1;78R` — and it is real pending input in readline's edit line (Enter would try to execute it), not just a rendering artifact.

`1;<col>R` are cursor-position reports: xterm's answers to `ESC[6n`. BuildKit's tty progress (every in-pod `erun deploy`) and Claude Code both emit those queries, and the raw bytes are saved verbatim in the session's buffer. Re-rendering a tab (`setSessionId` → `terminalDisplayMiddleware` → `writeTerminalBuffer`) re-parses the stale queries, and the CSI `n` handler answered each one again, unconditionally. The #347 write-source queue then delivered the replies into the session's live PTY — where nothing was waiting, so the shell echoed them as typed input. The echoed bare tails (`1;64R`, no ESC prefix left after readline consumed it) matched no display-strip pattern, became permanent visible buffer content, and the cycle compounded on every later switch.

49d81d6 fixed the same disease for DA/OSC/DECRQSS by suppressing those replies entirely and deliberately kept answering CPR (live tools genuinely need it; there is no sane default). That is correct for live parses and wrong for replayed ones — and the wiring could not tell them apart. Regex-stripping queries out of buffers cannot close this either: queries split across PTY chunk boundaries dodge any per-chunk pattern (which is exactly how the BuildKit queries survived into the buffer).

## Fix

- `TerminalWriteSourceQueue` entries now carry live-vs-replay provenance (`{sessionId, replay}`), exposed via `currentIsReplay()`.
- `writeToTerminal` accepts a replay flag; `writeTerminalBuffer` — the only replay seam — tags its writes.
- The CSI `n` / `?n` handlers consume queries without replying when the chunk being parsed is a replay (covers DSR-5 as well as CPR-6/DECXCPR). Parse-time suppression is chunk-boundary-proof; live queries are still answered and still route to the asking session.
- Display backstop: a bare CPR tail-run pattern (`1;64R1;69R…`) joins the strip list, mirroring the existing DA tail, so buffers polluted before this fix render clean.

## Evidence

Diagnosed against the live pod via the per-env MCP endpoint: the affected tab's history is repeated `erun deploy` runs, and `/usr/local/lib/docker/cli-plugins/docker-buildx` embeds the literal `\x1b[6n` bytes (`claude-real` does too; helm/kubectl/erun/git are clean). The screenshot's reports all carry row 1 — replay-time geometry against a freshly reset terminal, proving they were generated by the replay, not by a live tool.

## UX Impact Review Checklist

1. **Affected paths.** Terminal tab switch and env reopen (`setSessionId` → middleware buffer replay) for every session kind (ERun, AI, Local, extra terminals); live PTY output parsing.
2. **User-visible sequence.** Switching back to a tab replays its scrollback. Previously, stale queries in that scrollback typed junk into the live shell at the prompt; now the replay renders identically and injects nothing. Live querying tools (BuildKit progress, claude) still receive their reports.
3. **State-without-affordance.** No `AppState` mutations added or removed; the change removes an invisible, harmful side effect.
4. **Visibility of system status (Nielsen #1).** Unchanged indicators; the prompt now shows only what the user actually typed.
5. **Success and failure feedback (Nielsen #1, #9).** No operation outcome changed; `SendSessionInput` error surfacing for live replies is preserved.
6. **Consistency with comparable flows (Nielsen #4).** Matches the DA/OSC/DECRQSS suppression model from 49d81d6 — CPR now joins it for replayed parses only.
7. **Heuristic pass.** #1 visibility: no phantom input at the prompt — pass. #5 error prevention: junk can no longer be executed by pressing Enter — pass. #4 consistency: replay now behaves like the other suppressed queries — pass. Remaining heuristics (language, control, recognition, flexibility, minimalism, recovery, help/docs) not applicable: no new control, label, or flow.
8. **Playwright coverage.** `terminal-query-response.spec.ts` gains "a query replayed from a saved buffer is never re-answered (#484)": it plants a DEC CPR query in a real extra-terminal session, switches away/back to force the middleware replay, then drains with a chunk-split plain CPR query whose reply shape is distinguishable and FIFO-ordered behind the replay — so the assertion cannot pass transiently on buggy code. The two existing #347 specs keep the live-routing invariants locked.

## Docs

No `erun-docs` update: bug fix preserving intended behaviour (scrollback replay is an internal rendering mechanism, not documented product surface) — exempt per the root AGENTS.md docs gate.

## Validation

- `erun-ui/frontend`: `yarn typecheck && yarn lint && yarn format:check && yarn build` — green.
- `./playwright/run.sh --build` full suite: 58 passed, 3 failed, 1 skipped (pre-existing `contribute.spec.ts` skip). All 3 failures classified as not from this change: `app-notification` passes in isolation (order-dependent flake); `manage-cloud-alias-clear` and `sidebar-local-badge` fail identically on an unmodified `main`-built binary (stash + rebuild baseline) — known env-dependent failures on this dev harness (crowded-sidebar popover-anchor click interception), unrelated surfaces.
- `./playwright/run.sh --build -- tests/terminal-query-response.spec.ts` on the final binary: 3 passed.
- No Go changes; the integration-test gate does not apply (no `erun-cli`/`erun-common`/entrypoint/chart/golden changes).

**Verified end-to-end:** the headless harness drives the exact failing React path (saved buffer containing a query → tab-switch replay → `SendSessionInput` observation). **Not verified:** the rendered Wails GUI of a relaunched desktop app — requires restarting the installed app; the new spec is the harness signal for that surface, and the junk currently sitting at the live pod prompt is pending input cleared with Ctrl+C/Ctrl+U.

🤖 Generated with [Claude Code](https://claude.com/claude-code)