### PR TITLE
Scope the Manage-dialog redeploy banner and unsaved-changes dot to deploy-relevant fields

### DIFF
--- a/erun-ui/frontend/src/app/manageDialogHelpers.ts
+++ b/erun-ui/frontend/src/app/manageDialogHelpers.ts
@@ -41,6 +41,50 @@ export function aiSessionLaunchSignature(config: UIEnvironmentConfig): string {
   );
 }
 
+// nextPendingRedeploy reports whether the pending-redeploy banner should be
+// up after a save: it stays up once raised (a later metadata-only save must
+// not clear a redeploy the user still owes the pod), and a save raises it
+// only when it changed a pod-shaping field (issue #460). A missing prior
+// config means the diff cannot be computed, so claim the redeploy — the
+// conservative direction.
+export function nextPendingRedeploy(
+  alreadyPending: boolean,
+  prior: UIEnvironmentConfig | null,
+  saved: UIEnvironmentConfig,
+): boolean {
+  if (alreadyPending || !prior) {
+    return true;
+  }
+  return deployRelevantSignature(prior) !== deployRelevantSignature(saved);
+}
+
+// deployRelevantSignature distills the env config down to the fields that
+// shape the running pod — the values erun-common/deploy.go renders into the
+// Helm release (pod resources, idle.* pod env, the claude.* pod env subset)
+// plus the image registry/channel and the cloud binding the deploy resolves
+// against. Fields that never reach the pod stay out: autoUpgrade /
+// upgradeChannel select a future `erun upgrade` run, autoStart and
+// remoteHostCredentials are desktop-side behaviour, sshd.workspaceSync* is
+// desktop sync, and claude effort/defaultModel/verboseDebug only change the
+// AI launch command (the save path relaunches AI tabs for those). A save
+// whose signature is unchanged must not raise the pending-redeploy banner
+// (issue #460).
+function deployRelevantSignature(config: UIEnvironmentConfig): string {
+  return JSON.stringify({
+    containerRegistry: config.containerRegistry,
+    cloudProviderAlias: config.cloudProviderAlias,
+    snapshot: config.snapshot,
+    runtimePod: config.runtimePod,
+    idle: config.idle,
+    claudePod: {
+      useMantle: config.claude.useMantle,
+      useBedrock: config.claude.useBedrock,
+      models: config.claude.models,
+      maxOutputTokens: config.claude.maxOutputTokens,
+    },
+  });
+}
+
 export function manageDialogTabHasUnsavedChanges(
   tab: ManageTab,
   config: UIEnvironmentConfig,
@@ -53,9 +97,14 @@ export function manageDialogTabHasUnsavedChanges(
     keys.some((key) => JSON.stringify(config[key]) !== JSON.stringify(initial[key]));
   switch (tab) {
     case 'general':
-      return compare('containerRegistry', 'cloudProviderAlias', 'snapshot');
+      return compare(
+        'containerRegistry',
+        'cloudProviderAlias',
+        'snapshot',
+        'remoteHostCredentials',
+      );
     case 'runtime':
-      return compare('runtimePod', 'idle');
+      return compare('runtimePod', 'idle', 'autoStart', 'autoUpgrade', 'upgradeChannel');
     case 'ai':
       return compare('claude');
     case 'ports':

--- a/erun-ui/frontend/src/app/manageDialogThunks.ts
+++ b/erun-ui/frontend/src/app/manageDialogThunks.ts
@@ -6,6 +6,7 @@ import {
   aiSessionLaunchSignature,
   cloneEnvironmentConfig,
   compactClaudeDraft,
+  nextPendingRedeploy,
 } from './manageDialogHelpers';
 import { showTerminalMessage } from './notificationThunks';
 import {
@@ -310,7 +311,10 @@ export const submitManageConfig = (): AppThunk<Promise<void>> => async (dispatch
         busyAction: '',
         busyTarget: '',
         error: '',
-        pendingRedeploy: true,
+        // The banner means "the running pod is behind the saved config", so
+        // raise it only when this save changed a pod-shaping field (issue
+        // #460: saving autoUpgrade/autoStart must not prompt a pod roll).
+        pendingRedeploy: nextPendingRedeploy(dialog.pendingRedeploy, priorConfig, displayConfig),
       }),
     );
     // A changed Claude launch flag only applies when the AI session's

--- a/erun-ui/playwright/pages/ManageDialog.ts
+++ b/erun-ui/playwright/pages/ManageDialog.ts
@@ -41,6 +41,32 @@ export class ManageDialog {
     return this.locator().getByRole('tab', { name: new RegExp(`^${name}(,|$)`) });
   }
 
+  // tabHasUnsavedChanges reads the dirty marker off the tab trigger's
+  // accessible name ("<label>, has unsaved changes" — issue #460).
+  async tabHasUnsavedChanges(name: ManageTab): Promise<boolean> {
+    const label = await this.tab(name).getAttribute('aria-label');
+    return label?.includes('has unsaved changes') ?? false;
+  }
+
+  // redeployBanner targets the amber "Pending redeploy" alert raised after a
+  // save that changed a pod-shaping field (issue #460).
+  redeployBanner(): Locator {
+    return this.locator().getByRole('alert').filter({ hasText: 'Pending redeploy' });
+  }
+
+  // autoUpgradeCheckbox targets the Runtime tab's "Include in Upgrade all"
+  // opt-in — selection metadata for a future `erun upgrade`, never a pod
+  // input (issue #460).
+  autoUpgradeCheckbox(): Locator {
+    return this.locator().locator('#environment-config-autoupgrade');
+  }
+
+  // idleTimeoutInput targets the Runtime tab's Idle-stop "Timeout" field — a
+  // pod-shaping value (helm idle.* → pod env).
+  idleTimeoutInput(): Locator {
+    return this.locator().locator('#environment-config-idle-timeout');
+  }
+
   async selectTab(name: ManageTab): Promise<void> {
     await this.tab(name).click();
   }

--- a/erun-ui/playwright/tests/manage-redeploy-banner.spec.ts
+++ b/erun-ui/playwright/tests/manage-redeploy-banner.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '../fixtures/erunApp.js';
+import type { AppShell } from '../pages/index.js';
+
+// Issue #460 — two mirror-image defects on the Manage dialog's Runtime tab:
+// the "Pending redeploy" banner fired on every save, including saves that
+// only touched fields the running pod never sees (autoUpgrade/upgradeChannel
+// select a future `erun upgrade` run; autoStart is desktop open-time
+// behaviour), prompting a pointless pod roll — while editing those same
+// fields never lit the per-tab unsaved-changes dot. Both now derive from one
+// classification: the dot reflects every editable field on the tab, the
+// banner only pod-shaping ones (deployRelevantSignature).
+//
+// Saves are stubbed over the /__erun_invoke bridge (the
+// sidebar-upgrade-all.spec.ts technique), echoing the submitted config back
+// as the save result — the developer's real ~/.erun is never written, while
+// the dialog behaves exactly as after a real save (initialConfig refresh,
+// pendingRedeploy computation).
+test.describe('manage dialog redeploy banner scoping (#460)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/__erun_invoke', async (route, request) => {
+      const body = JSON.parse(request.postData() ?? '{}') as {
+        method: string;
+        args: unknown[];
+      };
+      if (body.method === 'SaveEnvironmentConfig') {
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ data: body.args[1] }),
+        });
+      }
+      await route.continue();
+    });
+  });
+
+  test('editing autoUpgrade lights the Runtime dot and clears when reverted', async ({ app }) => {
+    await openFirstEnvManageDialog(app);
+    await app.manageDialog.selectTab('Runtime');
+
+    expect(await app.manageDialog.tabHasUnsavedChanges('Runtime')).toBe(false);
+    await app.manageDialog.autoUpgradeCheckbox().click();
+    await expect.poll(() => app.manageDialog.tabHasUnsavedChanges('Runtime')).toBe(true);
+    await app.manageDialog.autoUpgradeCheckbox().click();
+    await expect.poll(() => app.manageDialog.tabHasUnsavedChanges('Runtime')).toBe(false);
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+
+  test('the banner skips metadata-only saves, fires for pod-shaping ones, and sticks', async ({
+    app,
+  }) => {
+    await openFirstEnvManageDialog(app);
+    await app.manageDialog.selectTab('Runtime');
+
+    // Save with only autoUpgrade toggled → nothing the pod needs changed →
+    // no banner.
+    await app.manageDialog.autoUpgradeCheckbox().click();
+    await app.manageDialog.save();
+    // The dot clearing proves the save round-tripped (initialConfig refresh).
+    await expect.poll(() => app.manageDialog.tabHasUnsavedChanges('Runtime')).toBe(false);
+    await expect(app.manageDialog.redeployBanner()).toHaveCount(0);
+
+    // Save with a pod-shaping change (idle timeout → helm idle.* pod env) →
+    // banner appears.
+    const idle = app.manageDialog.idleTimeoutInput();
+    const original = await idle.inputValue();
+    await idle.fill(original === '7m' ? '9m' : '7m');
+    await app.manageDialog.save();
+    await expect(app.manageDialog.redeployBanner()).toBeVisible({ timeout: 6_000 });
+
+    // A later metadata-only save must not clear a redeploy the user still
+    // owes the pod: toggle autoUpgrade back and save again — banner stays.
+    await app.manageDialog.autoUpgradeCheckbox().click();
+    await app.manageDialog.save();
+    await expect.poll(() => app.manageDialog.tabHasUnsavedChanges('Runtime')).toBe(false);
+    await expect(app.manageDialog.redeployBanner()).toBeVisible();
+
+    // Close without clicking "Redeploy now"; the stubbed saves never touched
+    // the real config, so there is nothing to restore.
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+});
+
+// openFirstEnvManageDialog opens the Manage dialog for the first environment
+// of the first tenant via the keyboard path (mouse row clicks can be
+// intercepted by the env hover-card popover on crowded sidebars).
+async function openFirstEnvManageDialog(app: AppShell): Promise<void> {
+  const tenants = await app.sidebar.tenants();
+  test.skip(tenants.length === 0, 'no tenants in this developer harness');
+  const tenant = tenants[0]!;
+  const envs = await app.sidebar.environmentsFor(tenant);
+  test.skip(envs.length === 0, 'no environments in this developer harness');
+  await app.sidebar.openManageDialogViaKeyboard(tenant, envs[0]!);
+  await app.manageDialog.waitForOpen();
+}


### PR DESCRIPTION
Closes #460.

## What changed

Two mirror-image defects on the Manage dialog (both verified against `deploy.go` + the runtime chart at HEAD):

1. **False-positive "Pending redeploy" banner** — `submitManageConfig` set `pendingRedeploy: true` unconditionally on every save. Saving only `autoUpgrade` / `upgradeChannel` / `autoStart` (fields the pod never sees) prompted a pointless pod roll. The banner now derives from `deployRelevantSignature`: the pod-shaping subset — `runtimePod`, `idle` (helm `idle.*` → pod env), the Claude pod-env values (`useMantle`/`useBedrock`/`models`/`maxOutputTokens` → helm `claude.*`, `deploy.go:1545-1551`), `containerRegistry`, `cloudProviderAlias`, `snapshot`. Launch-only Claude fields (`effort`, `defaultModel`, `verboseDebug`) stay out — the save path already relaunches AI tabs for those (#477/#482). Once raised, the banner **stays up** across later metadata-only saves: the user still owes the pod the redeploy.
2. **False-negative unsaved-changes dot** — the Runtime tab's dirty check now includes `autoStart`, `autoUpgrade`, `upgradeChannel`; the General tab's gains `remoteHostCredentials` (same omission class, found while classifying the fields). The dot and the banner stay distinct predicates: "has unsaved edits" (any editable field) vs "saved changes the pod needs" (deploy-relevant only), per the issue.

## UX impact review (per erun-ui/AGENTS.md)

1. **Affected paths:** Manage dialog → Runtime/General tab edit → tab dirty dot; Manage dialog → Save → `submitManageConfig` → Pending-redeploy banner.
2. **User-visible sequence:** editing any Runtime/General field now lights that tab's dot immediately; Save clears the dot; the amber banner appears only when the save changed something the running pod consumes, and persists across subsequent saves until the user redeploys or closes.
3. **State-without-affordance:** `pendingRedeploy` already renders as the banner; the new computation only changes *when* it is true. No new unrendered state.
4. **Visibility of system status (Nielsen #1):** the banner is a status signal; removing the false positive makes it truthful — present exactly when a pod-affecting change is pending.
5. **Success/failure feedback (Nielsen #1/#9):** unchanged save feedback (dot clears, errors render); the banner keeps its "Redeploy now / Later" recovery actions.
6. **Consistency (Nielsen #4):** the dot now covers every editable field on its tab, matching the other tabs' behaviour; checked against the AI tab (whole `claude` key compared).
7. **Heuristic pass:** #1 truthful status (fixed); #2 match with real state (banner ⇔ pod actually behind); #3 user control (no push toward unnecessary pod rolls); #4 consistency (above); #5 error prevention (no longer invites a needless disruptive redeploy); #6 recognition (dot makes unsaved `autoUpgrade` visible); #7/#8 n/a (no new controls); #9 recovery unchanged; #10 n/a.
8. **Playwright coverage:** new `tests/manage-redeploy-banner.spec.ts` — both tests **fail against the unfixed build** (verified by stash + rebuild): dirty dot lights/clears for `autoUpgrade`; a metadata-only save raises no banner; an idle-timeout save raises it; a later metadata-only save does not clear it (sticky). Saves are stubbed over `/__erun_invoke` (the `sidebar-upgrade-all.spec.ts` technique), echoing the submitted config — the developer's real `~/.erun` is never written.

## Docs plan

No `erun-docs` update needed: no page documents the banner's firing conditions, and the fix restores the behaviour the existing docs imply (`reference/configuration.md` describes `autoupgrade` as Upgrade-all selection metadata, not a pod input).

## Validation

- `yarn typecheck && yarn lint && yarn format:check && yarn build` green (a complexity-limit hit was fixed by extracting `nextPendingRedeploy` into the helpers module — no lint suppressions).
- New spec: 2/2 green with the fix, 2/2 red without it.
- Full `./playwright/run.sh`: **62 passed, 3 failed — all pre-existing/flaky on this machine, none touching this surface**: `manage-cloud-alias-clear` + `sidebar-local-badge` fail identically on an unmodified `main` build (machine-dependent `~/.erun`; the class #483 tracks), `terminal-scroll-on-switch` was a one-off that passes in isolation immediately after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)