### PR TITLE
Make failed cloud-context stops report the actionable reason

### DIFF
--- a/erun-common/cloud_context.go
+++ b/erun-common/cloud_context.go
@@ -572,7 +572,7 @@ func StopCloudContext(ctx Context, store CloudContextStore, params CloudContextP
 	// delete-env teardown) only see "stopped" once the instance has
 	// actually got there.
 	if _, err := deps.RunAWS(ctx, provider, status.Region, []string{"ec2", "wait", "instance-stopped", "--instance-ids", status.InstanceID}); err != nil {
-		return CloudContextStatus{}, err
+		return CloudContextStatus{}, fmt.Errorf("cloud context %q: stop was accepted but the instance was not observed stopped — it may still be transitioning; check its state in the AWS console and retry: %w", status.Name, classifyCloudContextPowerError("stop-instances", status.CloudContextConfig, err))
 	}
 	return status, nil
 }
@@ -608,6 +608,60 @@ func isAWSIncorrectInstanceStateError(err error) bool {
 		return false
 	}
 	return strings.Contains(err.Error(), "IncorrectInstanceState")
+}
+
+// awsExpiredCredentialsMarkers are the stderr signatures the AWS CLI emits
+// when the call failed for authentication rather than the requested
+// operation: an expired/invalid SSO session, expired STS credentials, or no
+// credentials at all. Substring matching on the wrapped error mirrors
+// isAWSIncorrectInstanceStateError.
+var awsExpiredCredentialsMarkers = []string{
+	"Token has expired",
+	"SSO session associated with this profile has expired",
+	"ExpiredToken",
+	"RequestExpired",
+	"Unable to locate credentials",
+	"InvalidClientTokenId",
+	"AuthFailure",
+}
+
+func isAWSExpiredCredentialsError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	for _, marker := range awsExpiredCredentialsMarkers {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// classifyCloudContextPowerError translates a raw start-instances /
+// stop-instances failure into the actionable reason the operator needs
+// (issue #456: a failed Stop surfaced as a bare exit 1 while the instance
+// kept running). The two failure families with a known next step:
+//
+//   - OperationNotPermitted on stop — stop protection (DisableApiStop) is
+//     on, the deliberate repair-time lock; the fix is unlocking it, not
+//     retrying.
+//   - Expired/missing AWS credentials — the call never reached the
+//     instance; the fix is signing in again.
+//
+// Anything else passes through unchanged so callers (including the
+// IncorrectInstanceState absorption in StopCloudContext/StartCloudContext)
+// keep seeing the raw AWS text.
+func classifyCloudContextPowerError(awsAction string, config CloudContextConfig, err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case awsAction == "stop-instances" && strings.Contains(err.Error(), "OperationNotPermitted"):
+		return fmt.Errorf("cloud context %q cannot be stopped: stop protection (DisableApiStop) is enabled on instance %s — turn it off first (`erun context enable-api-stop %s`, or the stop-protection toggle in the desktop titlebar), then retry: %w", config.Name, config.InstanceID, config.Name, err)
+	case isAWSExpiredCredentialsError(err):
+		return fmt.Errorf("cloud context %q: the AWS session for alias %q is expired or unavailable — sign in again (`erun cloud login --alias %s`, or the cloud login in the desktop settings), then retry: %w", config.Name, config.CloudProviderAlias, config.CloudProviderAlias, err)
+	}
+	return err
 }
 
 func StartCloudContext(ctx Context, store CloudContextStore, params CloudContextParams, deps CloudContextDependencies) (CloudContextStatus, error) {
@@ -1140,7 +1194,7 @@ func changeCloudContextPowerState(ctx Context, store CloudContextStore, params C
 		return CloudContextStatus{}, err
 	}
 	if _, err := deps.RunAWS(ctx, provider, config.Region, []string{"ec2", awsAction, "--instance-ids", config.InstanceID}); err != nil {
-		return CloudContextStatus{}, err
+		return CloudContextStatus{}, classifyCloudContextPowerError(awsAction, config, err)
 	}
 	return CloudContextStatus{CloudContextConfig: NormalizeCloudContextConfig(config), Status: status}, nil
 }

--- a/erun-common/cloud_context_power_error_test.go
+++ b/erun-common/cloud_context_power_error_test.go
@@ -1,0 +1,158 @@
+package eruncommon
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestCloudContextPowerErrorClassification pins the actionable-error contract
+// for stop/start failures (issue #456: a failed Stop surfaced as a bare
+// "exit status 1" while the instance kept running). These branches only fire
+// on real AWS error responses, which the dry-run integration harness cannot
+// produce — the same structural gap erun-integration/AGENTS.md records for
+// the AWS error helpers — so a white-box test with an injected RunAWS owns
+// the contract, mirroring deploy_persist_runtime_version_test.go.
+func TestCloudContextPowerErrorClassification(t *testing.T) {
+	ctx := Context{Logger: NewLoggerWithWriters(VerbosityInfo, io.Discard, io.Discard)}
+	params := CloudContextParams{Name: "petios-ctx"}
+
+	t.Run("stop blocked by stop protection names the lock and the unlock lever", func(t *testing.T) {
+		raw := "aws ec2 stop-instances --instance-ids i-0abc123: An error occurred (OperationNotPermitted) when calling the StopInstances operation: The instance 'i-0abc123' may not be stopped. Modify its 'disableApiStop' instance attribute and try again."
+		deps := CloudContextDependencies{RunAWS: failingRunAWS("stop-instances", raw)}
+		_, err := StopCloudContext(ctx, powerErrorTestStore(), params, deps)
+		if err == nil {
+			t.Fatal("expected the stop to fail")
+		}
+		for _, want := range []string{"stop protection", "enable-api-stop petios-ctx", "OperationNotPermitted"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error %q does not mention %q", err, want)
+			}
+		}
+	})
+
+	t.Run("stop with an expired AWS session names the login lever", func(t *testing.T) {
+		raw := "aws ec2 stop-instances --instance-ids i-0abc123: Error when retrieving token from sso: Token has expired and refresh failed"
+		deps := CloudContextDependencies{RunAWS: failingRunAWS("stop-instances", raw)}
+		_, err := StopCloudContext(ctx, powerErrorTestStore(), params, deps)
+		if err == nil {
+			t.Fatal("expected the stop to fail")
+		}
+		for _, want := range []string{"expired or unavailable", "erun cloud login --alias dev-aws", "Token has expired"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error %q does not mention %q", err, want)
+			}
+		}
+	})
+
+	t.Run("stop with an unrelated AWS error passes through unchanged", func(t *testing.T) {
+		raw := "aws ec2 stop-instances --instance-ids i-0abc123: An error occurred (InternalError) when calling the StopInstances operation"
+		deps := CloudContextDependencies{RunAWS: failingRunAWS("stop-instances", raw)}
+		_, err := StopCloudContext(ctx, powerErrorTestStore(), params, deps)
+		if err == nil {
+			t.Fatal("expected the stop to fail")
+		}
+		if got := err.Error(); got != raw {
+			t.Fatalf("unrelated error was rewritten: %q", got)
+		}
+	})
+
+	t.Run("stop on an already-stopping instance is still absorbed into the wait", func(t *testing.T) {
+		var waited bool
+		deps := CloudContextDependencies{RunAWS: func(_ Context, _ CloudProviderConfig, _ string, args []string) (string, error) {
+			joined := strings.Join(args, " ")
+			if strings.Contains(joined, "stop-instances") {
+				return "", fmt.Errorf("aws ec2 stop-instances: An error occurred (IncorrectInstanceState) when calling the StopInstances operation")
+			}
+			if strings.Contains(joined, "wait instance-stopped") {
+				waited = true
+				return "", nil
+			}
+			return "", nil
+		}}
+		status, err := StopCloudContext(ctx, powerErrorTestStore(), params, deps)
+		if err != nil {
+			t.Fatalf("expected the already-stopping stop to succeed, got %v", err)
+		}
+		if !waited {
+			t.Fatal("expected the stop to wait for instance-stopped")
+		}
+		if status.Status != CloudContextStatusStopped {
+			t.Fatalf("status = %q, want %q", status.Status, CloudContextStatusStopped)
+		}
+	})
+
+	t.Run("a failed stopped-wait reports the unobserved end state", func(t *testing.T) {
+		deps := CloudContextDependencies{RunAWS: func(_ Context, _ CloudProviderConfig, _ string, args []string) (string, error) {
+			if strings.Contains(strings.Join(args, " "), "wait instance-stopped") {
+				return "", fmt.Errorf("aws ec2 wait instance-stopped: Waiter InstanceStopped failed: Max attempts exceeded")
+			}
+			return "", nil
+		}}
+		_, err := StopCloudContext(ctx, powerErrorTestStore(), params, deps)
+		if err == nil {
+			t.Fatal("expected the wait failure to propagate")
+		}
+		for _, want := range []string{"not observed stopped", "Max attempts exceeded"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error %q does not mention %q", err, want)
+			}
+		}
+	})
+
+	t.Run("start with an expired AWS session names the login lever", func(t *testing.T) {
+		raw := "aws ec2 start-instances --instance-ids i-0abc123: An error occurred (ExpiredToken) when calling the StartInstances operation: The security token included in the request is expired"
+		deps := CloudContextDependencies{RunAWS: failingRunAWS("start-instances", raw)}
+		_, err := StartCloudContext(ctx, powerErrorTestStore(), params, deps)
+		if err == nil {
+			t.Fatal("expected the start to fail")
+		}
+		if !strings.Contains(err.Error(), "erun cloud login --alias dev-aws") {
+			t.Fatalf("error %q does not mention the login lever", err)
+		}
+	})
+
+	t.Run("start never claims stop protection", func(t *testing.T) {
+		raw := "aws ec2 start-instances --instance-ids i-0abc123: An error occurred (OperationNotPermitted) when calling the StartInstances operation"
+		deps := CloudContextDependencies{RunAWS: failingRunAWS("start-instances", raw)}
+		_, err := StartCloudContext(ctx, powerErrorTestStore(), params, deps)
+		if err == nil {
+			t.Fatal("expected the start to fail")
+		}
+		if strings.Contains(err.Error(), "stop protection") {
+			t.Fatalf("start failure misclassified as stop protection: %q", err)
+		}
+	})
+}
+
+// powerErrorTestStore returns the minimal store for the power-state paths:
+// one provider alias and one managed context bound to it.
+func powerErrorTestStore() CloudContextStore {
+	return stubCloudContextStore{config: ERunConfig{
+		CloudProviders: []CloudProviderConfig{{Alias: "dev-aws", Provider: CloudProviderAWS, Profile: "dev-profile"}},
+		CloudContexts: []CloudContextConfig{{
+			Name:               "petios-ctx",
+			Provider:           CloudProviderAWS,
+			CloudProviderAlias: "dev-aws",
+			Region:             "eu-west-1",
+			InstanceID:         "i-0abc123",
+		}},
+	}}
+}
+
+type stubCloudContextStore struct{ config ERunConfig }
+
+func (s stubCloudContextStore) LoadERunConfig() (ERunConfig, string, error) { return s.config, "", nil }
+func (s stubCloudContextStore) SaveERunConfig(ERunConfig) error             { return nil }
+
+// failingRunAWS fails the named ec2 action with the given message and lets
+// every other AWS call (waiters, association lookups) succeed.
+func failingRunAWS(action, message string) func(Context, CloudProviderConfig, string, []string) (string, error) {
+	return func(_ Context, _ CloudProviderConfig, _ string, args []string) (string, error) {
+		if strings.Contains(strings.Join(args, " "), action) {
+			return "", fmt.Errorf("%s", message)
+		}
+		return "", nil
+	}
+}

--- a/erun-ui/playwright/tests/idle-widget-stop-protection.spec.ts
+++ b/erun-ui/playwright/tests/idle-widget-stop-protection.spec.ts
@@ -599,4 +599,68 @@ test.describe('idle widget stop protection', () => {
     await app.manageDialog.cancel();
     await app.manageDialog.waitForClosed();
   });
+
+  // Issue #456 — a failed stop used to surface as a bare "exit status 1"
+  // while the instance kept running. erun-common's
+  // classifyCloudContextPowerError now names the reason and the unlock
+  // lever; this locks the desktop surface: the error toast carries the
+  // actionable message and the widget keeps reporting the running state
+  // (the stop affordance), never a false "stopped". A real AWS
+  // OperationNotPermitted cannot be staged headless (no EC2 with stop
+  // protection in the harness), so the rejected RPC carries the exact
+  // message shape the classifier emits; the classification itself is owned
+  // by erun-common/cloud_context_power_error_test.go.
+  test('a failed stop surfaces the actionable reason and keeps the running state', async ({
+    app,
+    page,
+  }) => {
+    const ctxName = 'mock-ctx-stop-fail';
+    const idle: IdleStatusFixture = {
+      cloudContextName: ctxName,
+      cloudContextStatus: 'running',
+      cloudContextLabel: ctxName,
+    };
+    const stopError =
+      `cloud context "${ctxName}" cannot be stopped: stop protection (DisableApiStop) is enabled on instance i-0abc123 — ` +
+      `turn it off first (\`erun context enable-api-stop ${ctxName}\`, or the stop-protection toggle in the desktop titlebar), ` +
+      'then retry: aws ec2 stop-instances: An error occurred (OperationNotPermitted) when calling the StopInstances operation';
+
+    await page.route('**/__erun_invoke', async (route, request) => {
+      const body = JSON.parse(request.postData() ?? '{}') as InvokeBody;
+      if (body.method === 'LoadIdleStatus') {
+        return route.fulfill(envelope(managedRunningIdleStatus(idle)));
+      }
+      if (body.method === 'DescribeCloudContextApiStop') {
+        // Locked — the same condition that makes the real stop fail.
+        return route.fulfill(envelope(apiStopStatus(ctxName, true)));
+      }
+      if (body.method === 'StopCloudContext') {
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ error: stopError }),
+        });
+      }
+      await route.continue();
+    });
+
+    const tenants = await app.sidebar.tenants();
+    test.skip(tenants.length === 0, 'no tenants in this developer harness');
+    const tenant = tenants[0]!;
+    const envs = await app.sidebar.environmentsFor(tenant);
+    test.skip(envs.length === 0, `no envs under tenant ${tenant}`);
+    await app.sidebar.openEnvironment(tenant, envs[0]!);
+
+    const stopButton = page.getByRole('button', { name: new RegExp(`^Stop ${ctxName}`) });
+    await stopButton.waitFor({ state: 'visible', timeout: 6_000 });
+    await stopButton.click();
+
+    // The failure reason renders where the user acted (Nielsen #1/#9):
+    // the titlebar error pill names stop protection as the cause.
+    const errorPill = page.getByRole('alert').filter({ hasText: 'stop protection' });
+    await expect(errorPill).toBeVisible({ timeout: 6_000 });
+
+    // The widget must keep reporting reality: still running, stop still
+    // offered — never a silent flip to "stopped".
+    await expect(stopButton).toBeVisible();
+  });
 });


### PR DESCRIPTION
Closes #456.

## What changed

A failed environment stop surfaced as a bare exit 1 while the instance kept running. The stop path (`StopCloudContext` → `changeCloudContextPowerState` → `aws ec2 stop-instances`) propagated the raw AWS CLI error with no reason and no next step — the UX gap the issue calls out independent of the specific root cause.

`classifyCloudContextPowerError` (erun-common) now translates the two failure families with a known recovery, inherited by all three transports (`erun context stop`, MCP `context_stop`, desktop Stop button) since they share the same function:

- **`OperationNotPermitted` on stop** → stop protection (`DisableApiStop`) is on — the issue's strongest candidate cause. The message names the lock and both unlock levers (`erun context enable-api-stop <name>`, documented in `cli/context.md`, or the titlebar stop-protection toggle).
- **Expired/missing AWS credentials** (`Token has expired`, `SSO session … has expired`, `ExpiredToken`, `RequestExpired`, `Unable to locate credentials`, `InvalidClientTokenId`, `AuthFailure`) → names the alias and the login lever (`erun cloud login --alias <alias>`). Applied to **start** too — the expired-SSO start failure is the exact scenario reported in #470's narrative.

Everything else passes through verbatim, so the `IncorrectInstanceState` absorption (already-stopping → wait for stopped) is untouched, and a failed `instance-stopped` wait now says the stop was accepted but the end state was not observed (with the raw waiter error preserved).

Status stays truthful on failure (still "running") — that part was already correct; the issue notes the defect was the unexplained failure, not the status.

## Tests

- **Go (`erun-common/cloud_context_power_error_test.go`)**: stop-protection classification (message names the lock + `enable-api-stop`), expired-session classification on stop and start, unrelated errors pass through byte-identical, `IncorrectInstanceState` still absorbed into the wait, failed wait wrapped, and start never claims stop protection. These branches only fire on real AWS error responses — unreachable from `--dry-run` (the documented AWS-error-helper gap in `erun-integration/AGENTS.md`), hence white-box tests with an injected `RunAWS`, mirroring `deploy_persist_runtime_version_test.go`.
- **Playwright** (`idle-widget-stop-protection.spec.ts`, +1 test): a rejected `StopCloudContext` RPC carrying the classifier's message renders the actionable reason in the titlebar error pill (`role="alert"`) and the widget keeps offering Stop — never a false "stopped". The real AWS failure can't be staged headless; the RPC stub carries the exact classifier message shape and the comment links the Go test that owns classification (the #331 pattern).

## UX impact review (per erun-ui/AGENTS.md)

1. **Affected paths:** titlebar Stop button → `toggleIdleCloudContext` → Wails `StopCloudContext`; `erun context stop`; MCP `context_stop`. No desktop code changed — the surface (error toast + terminal message) already existed; this changes the message content it receives.
2. **User-visible sequence:** click Stop → spinner/transition pill → on failure, the titlebar error pill states the cause and the fix; the widget still shows the running state and the Stop affordance.
3. **State-without-affordance:** none — no new state.
4. **Visibility of system status (Nielsen #1):** the failure reason is now visible where the user acted, instead of an opaque exit code.
5. **Success/failure feedback (Nielsen #9):** failure now carries the recovery action (unlock stop protection / sign in again).
6. **Consistency (Nielsen #4):** reuses the existing notification + terminal-message surfaces; no new affordance invented.
7. **Heuristic pass:** #1 visible cause (fixed), #2 status matches reality (kept), #5 error prevention n/a, #9 actionable recovery (fixed); others unaffected (no control changes).
8. **Playwright coverage:** named above, in the same PR.

## Verification gate honesty

What I could not verify end-to-end: a real `aws ec2 stop-instances` failure against a live EC2 instance with stop protection or an expired SSO session — this session has no authorized AWS context to stage one. The classification contract is locked by the unit tests against the real AWS CLI stderr shapes, the dry-run integration goldens prove the trace surface is unchanged, and the Playwright spec locks the desktop rendering. The issue's "pin the exact error" step remains open on the reporter's side; if the captured error turns out to be outside these two families, the classifier passes it through verbatim today and a follow-up can add the new family.

## Validation

- `erun-common`, `erun-cli`, `erun-mcp`, `erun-ui` `go test ./...` green.
- `make integration-test` green — coverage 57.7% (≥ 55), goldens unchanged.
- Full `./playwright/run.sh`: 57 passed; 7 failures all in this machine's documented env-flaky set (`sidebar-ai-activity` ×2, `sidebar-busy-spinner` ×2, `tab-respawn-on-context-running`, `manage-cloud-alias-clear`, `sidebar-local-badge` — the set varies run-to-run and reproduces on unmodified `main`; the class #483 tracks). The changed spec file passed all 8 tests including the new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)