### PR TITLE
Pin the legacy working-issue test helper hermetic

### DIFF
--- a/erun-ui/environment_working_issue_test.go
+++ b/erun-ui/environment_working_issue_test.go
@@ -29,7 +29,13 @@ func TestParseIssueNumberFromBranch(t *testing.T) {
 
 // workingIssueApp builds an App whose store resolves one env and whose
 // working-issue command runner is stubbed, so the resolver runs without a real
-// repo or gh.
+// repo or gh. The pod-path deps are pinned hermetic (issue #492): a remote
+// env resolved through this helper must never probe the developer machine's
+// real local ports — ResolveOpen allocates a port range even when none is
+// persisted, and a live desktop/headless erun can be listening there, turning
+// the default reachability probe + MCP call into real network traffic. Tests
+// that exercise the pod-backed path inject their own deps via
+// remoteWorkingIssueApp.
 func workingIssueApp(t *testing.T, env eruncommon.EnvConfig, run workingIssueCommandRunner) *App {
 	t.Helper()
 	store := stubUIStore{
@@ -44,6 +50,11 @@ func workingIssueApp(t *testing.T, env eruncommon.EnvConfig, run workingIssueCom
 		store:                  store,
 		findProjectRoot:        func() (string, string, error) { return "acme", "/tmp/acme", nil },
 		runWorkingIssueCommand: run,
+		canConnectLocalPort:    func(int) bool { return false },
+		loadPodBranch: func(context.Context, string) (string, error) {
+			t.Fatal("loadPodBranch must not run through the legacy working-issue helper")
+			return "", nil
+		},
 	})
 	t.Cleanup(func() { app.shutdown(context.Background()) })
 	return app


### PR DESCRIPTION
Closes #492.

Post-#490, `TestEnvironmentWorkingIssueUnavailableForRemoteWorktree` probed the developer machine's real local ports (details in the issue): the legacy `workingIssueApp` helper predates the pod-backed remote path and left `canConnectLocalPort`/`loadPodBranch` on their real-network defaults, while `ResolveOpen` allocates a port range even when none is persisted. With a live erun MCP endpoint listening on the allocated port, the test fetched the real repo's branch and failed; it had passed on the PR branch only because the port was closed at that moment.

The helper now pins `canConnectLocalPort` to false and installs a `loadPodBranch` that fails the test if ever invoked through it. The dedicated pod-path tests (`remoteWorkingIssueApp`) keep their own explicit injection and are unchanged.

Test-only change with zero observable UI surface — no Playwright run required per erun-ui/AGENTS.md (skip case called out). `go test ./...` in `erun-ui` green, including the previously failing test with a live endpoint up on this machine — the exact condition that reproduced the defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)