### PR TITLE
AGENTS.md: require syncing main before cutting a branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,6 +312,7 @@ Methodology when reviewing or editing help / descriptions:
 ## Branching Strategy
 
 - Create a GitHub issue before starting implementation work.
+- Sync `main` before cutting the branch. Run `git checkout main && git pull --ff-only origin main` first so the new branch starts from the current remote tip, never a stale local `main`.
 - Branch from `main`.
 - Use `feature/<issue-number>-<short-kebab-case-description>` for new functionality.
 - Use `bug/<issue-number>-<short-kebab-case-description>` for bug fixes.


### PR DESCRIPTION
Closes #495.

Documentation-only guidance change to the root `AGENTS.md` Branching Strategy section: adds the explicit step to sync `main` (`git checkout main && git pull --ff-only origin main`) before cutting a branch, so new branches never start from a stale local `main`.

No app behavior affected; validated by reviewing the edited section for consistency — the new bullet sits between issue creation and the branch-from-`main` rule, matching the real order of operations. No test surface (zero observable app surface; the Playwright/integration suites are not applicable to repo-guidance text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)