### PR TITLE
Clear the env 'failed' status when a later deploy succeeds

### DIFF
--- a/erun-ui/activity_queue_app.go
+++ b/erun-ui/activity_queue_app.go
@@ -489,6 +489,13 @@ func (a *App) finishDeployByTenantEnv(selection uiSelection, tenant, environment
 	}
 	if final, finished := a.activityQueue.finish(entry.ID, status, errMsg); finished {
 		a.unlockTerminalsForActivity(final)
+		if status == activityQueueStatusSucceeded {
+			// A successful deploy supersedes any stale 'failed' flag on the
+			// row (issue #498): the env-status clear keeps the sidebar dot
+			// and hover card truthful, and the next session exit respawns
+			// normally because latestDeployFailed is now false.
+			a.emitEnvStatus(uiSelection{Tenant: tenant, Environment: environment}, "")
+		}
 	}
 }
 

--- a/erun-ui/env_status_test.go
+++ b/erun-ui/env_status_test.go
@@ -149,3 +149,41 @@ func TestEnvStatusFailedAfterReconnectLoopCapAndClearedByRespawns(t *testing.T) 
 		t.Fatalf("expected at least %d clearing emissions (initial open + respawns), got %d in %+v", reconnectLoopMaxExits, clears, statuses)
 	}
 }
+
+// TestEnvStatusClearedByLaterSuccessfulDeploy locks the recovery path from
+// issue #498: an env flagged 'failed' (amber dot, refused ERun-tab respawn)
+// must drop the flag the moment a later deploy for it succeeds through the
+// activity queue — e.g. an `erun upgrade` run — instead of keeping a stale
+// failure on the row until the next manual row click.
+func TestEnvStatusClearedByLaterSuccessfulDeploy(t *testing.T) {
+	var sessionsMu sync.Mutex
+	var sessions []*stubTerminalSession
+	emits := newCapturedEmits()
+	app := envStatusTestApp(t, emits, &sessionsMu, &sessions)
+
+	app.activityQueue.start(activityQueueEntry{Command: "deploy", Tenant: "erun", Environment: "remote", Version: "1.0.1"})
+	app.finishDeployByTenantEnv(uiSelection{}, "erun", "remote", activityQueueStatusSucceeded, "")
+
+	waitForEnvStatus(t, emits, "", 2*time.Second)
+	statuses := envStatuses(emits)
+	last := statuses[len(statuses)-1]
+	if last.Tenant != "erun" || last.Environment != "remote" || last.Status != "" {
+		t.Fatalf("expected a clearing env-status for the deployed env, got %+v", statuses)
+	}
+}
+
+// TestEnvStatusNotClearedByFailedDeploy is the negative guard: a deploy that
+// finishes failed must not emit the clear.
+func TestEnvStatusNotClearedByFailedDeploy(t *testing.T) {
+	var sessionsMu sync.Mutex
+	var sessions []*stubTerminalSession
+	emits := newCapturedEmits()
+	app := envStatusTestApp(t, emits, &sessionsMu, &sessions)
+
+	app.activityQueue.start(activityQueueEntry{Command: "deploy", Tenant: "erun", Environment: "remote", Version: "1.0.1"})
+	app.finishDeployByTenantEnv(uiSelection{}, "erun", "remote", activityQueueStatusFailed, "==> Deploy failed after 2m1s")
+
+	if got := envStatuses(emits); len(got) != 0 {
+		t.Fatalf("a failed deploy must not emit env-status, got %+v", got)
+	}
+}


### PR DESCRIPTION
Closes #498.

Backend-only follow-up to #490, from the Upgrade-all review: a successful deploy recorded through the activity queue (e.g. an `erun upgrade` run) now emits the clearing `env-status` for its env in `finishDeployByTenantEnv` — succeeded only, never on failure/skip. The stale amber dot and the "deploy failed" hover state drop the moment recovery actually happens, instead of persisting until the next manual row click; the refused ERun-tab respawn resumes on the next exit because `latestDeployFailed` is already false at that point.

**Tests:** Go — `TestEnvStatusClearedByLaterSuccessfulDeploy` (clear emitted, addressed to the deployed env) and `TestEnvStatusNotClearedByFailedDeploy` (negative guard). Playwright: no new spec — a real deploy trace is not stageable headless; the rendered dot/hover transitions for `env-status` (including the clear) are already locked by `sidebar-open-dot.spec.ts`'s injection-driven state walk, and this change only adds an emission point (the #331 pattern: Go owns the unreachable branch, the existing spec owns the surface).

**UX review:** affected path — deploy success trace → sidebar row/hover card. Nielsen #1/#2: status now matches reality after recovery; no new controls; no state without affordance (the emission renders through the existing dot/card). Docs: none needed — the desktop overview already documents the dot semantics ("green while it runs…"); this makes the documented behaviour hold after recovery.

**Validation:** `erun-ui` `go test ./...` green. No `erun-common`/`erun-cli` surface (integration gate unaffected); no frontend diff (gates unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)