### PR TITLE
Upgrade resolver: fall back to the canonical image when the tenant repo can't be listed

### DIFF
--- a/erun-common/upgrade.go
+++ b/erun-common/upgrade.go
@@ -67,12 +67,17 @@ type RegistryVersionsLookup func(ctx context.Context, namespace, repository stri
 //     first env of the tenant with a persisted RuntimeRegistry — falling
 //     back to the default registry, the same source the version picker uses
 //     (issue #475);
-//   - a tenant-specific image that resolves to no versions at all falls back
-//     per channel to the default ERun image: a tenant whose own image was
-//     never published runs the default image, so that is its real target;
-//   - a lookup error is returned, never substituted — the member reports
-//     "target unresolved" with the reason instead of being offered another
-//     image's version.
+//   - the tenant repo refines the targets when it is listable: a published
+//     tenant stream wins per channel;
+//   - a tenant lookup that fails or comes back empty falls back per channel
+//     to the canonical ERun image (issue #501): the tenant image is a thin
+//     wrapper the deploy rebuilds FROM the canonical image at the requested
+//     version (default_devops_module.go), so the canonical channel-latest is
+//     the tenant's real target universe — and registries like ghcr report
+//     403 for private and nonexistent repos alike, so a listing failure says
+//     nothing about what the env can deploy;
+//   - only a canonical-image lookup failure leaves the target unresolved,
+//     with that failure as the reason.
 func UpgradeVersionsResolverForStore(store DeployStore, lookup RegistryVersionsLookup) RuntimeVersionsResolver {
 	return func(_ Context, tenant string) (RuntimeRegistryVersions, error) {
 		if versions, forcedError, ok := runtimeVersionsOverrideFromEnvWithError(); ok {
@@ -86,22 +91,29 @@ func UpgradeVersionsResolverForStore(store DeployStore, lookup RegistryVersionsL
 			namespace = DefaultContainerRegistry
 		}
 		repository := RuntimeReleaseName(tenant)
-		versions, err := lookup(context.Background(), namespace, repository)
-		if err != nil {
-			return RuntimeRegistryVersions{}, err
-		}
 		if repository == DefaultRuntimeImageName {
+			return lookup(context.Background(), namespace, repository)
+		}
+		versions, tenantErr := lookup(context.Background(), namespace, repository)
+		if tenantErr == nil &&
+			strings.TrimSpace(versions.LatestStable) != "" && strings.TrimSpace(versions.LatestSnapshot) != "" {
 			return versions, nil
 		}
-		if strings.TrimSpace(versions.LatestStable) != "" && strings.TrimSpace(versions.LatestSnapshot) != "" {
-			return versions, nil
-		}
-		fallback, err := lookup(context.Background(), DefaultContainerRegistry, DefaultRuntimeImageName)
-		if err != nil {
-			// The tenant's own lookup succeeded (just empty); a failed
-			// default-image lookup must not fail the tenant — the empty
+		fallback, fallbackErr := lookup(context.Background(), DefaultContainerRegistry, DefaultRuntimeImageName)
+		if fallbackErr != nil {
+			if tenantErr != nil {
+				// Neither source is resolvable — genuinely unknown. The
+				// canonical failure is the actionable reason: it is the
+				// image the deploy would build from.
+				return RuntimeRegistryVersions{}, fallbackErr
+			}
+			// The tenant's own lookup succeeded (just partial); a failed
+			// canonical lookup must not fail the tenant — the empty
 			// channels simply stay unresolved.
 			return versions, nil
+		}
+		if tenantErr != nil {
+			return fallback, nil
 		}
 		if strings.TrimSpace(versions.LatestStable) == "" {
 			versions.LatestStable = fallback.LatestStable

--- a/erun-common/upgrade_resolver_test.go
+++ b/erun-common/upgrade_resolver_test.go
@@ -25,21 +25,37 @@ func TestUpgradeVersionsResolverForStore(t *testing.T) {
 		},
 	}
 
-	t.Run("a lookup error is returned, never substituted", func(t *testing.T) {
-		lookupErr := errors.New("ghcr token request failed: 403 Forbidden")
-		var fallbackQueried bool
-		resolver := UpgradeVersionsResolverForStore(store, func(_ context.Context, namespace, repository string) (RuntimeRegistryVersions, error) {
+	t.Run("a tenant lookup failure falls back to the canonical image", func(t *testing.T) {
+		// The tenant image is a wrapper the deploy rebuilds FROM the
+		// canonical image at the requested version, and ghcr 403s private
+		// and nonexistent repos alike — a listing failure must not block
+		// the upgrade (issue #501).
+		resolver := UpgradeVersionsResolverForStore(store, func(_ context.Context, _, repository string) (RuntimeRegistryVersions, error) {
 			if repository == DefaultRuntimeImageName {
-				fallbackQueried = true
+				return RuntimeRegistryVersions{LatestStable: "1.0.85", LatestSnapshot: "1.0.86-snapshot-1"}, nil
 			}
-			return RuntimeRegistryVersions{}, lookupErr
+			return RuntimeRegistryVersions{}, errors.New("ghcr token request failed: 403 Forbidden")
+		})
+		versions, err := resolver(Context{}, "petios")
+		if err != nil {
+			t.Fatalf("a failed tenant listing must fall back, got error %v", err)
+		}
+		if versions.LatestStable != "1.0.85" || versions.LatestSnapshot != "1.0.86-snapshot-1" {
+			t.Fatalf("expected the canonical image's versions, got %+v", versions)
+		}
+	})
+
+	t.Run("both lookups failing is unresolved with the canonical reason", func(t *testing.T) {
+		canonicalErr := errors.New("registry unreachable")
+		resolver := UpgradeVersionsResolverForStore(store, func(_ context.Context, _, repository string) (RuntimeRegistryVersions, error) {
+			if repository == DefaultRuntimeImageName {
+				return RuntimeRegistryVersions{}, canonicalErr
+			}
+			return RuntimeRegistryVersions{}, errors.New("ghcr token request failed: 403 Forbidden")
 		})
 		_, err := resolver(Context{}, "petios")
-		if !errors.Is(err, lookupErr) {
-			t.Fatalf("expected the lookup error to propagate, got %v", err)
-		}
-		if fallbackQueried {
-			t.Fatal("a failed tenant lookup must not be papered over with the default image")
+		if !errors.Is(err, canonicalErr) {
+			t.Fatalf("expected the canonical failure as the reason, got %v", err)
 		}
 	})
 

--- a/erun-docs/docs/cli/upgrade.md
+++ b/erun-docs/docs/cli/upgrade.md
@@ -65,7 +65,8 @@ erun upgrade team prod --version 1.2.3
 | Failure | Behaviour |
 |---|---|
 | No environments opted in (in scope). | Prints "No environments opted into Upgrade all" and exits 0 — nothing to do. |
-| Channel latest can't be resolved (registry lookup failed, no matching tags). | The environment is reported as **target unresolved** with the reason (e.g. the registry error), in the plan line, the skip trace, and the completion accounting (`==> Upgrade complete: N upgraded, N up to date, N unresolved, N failed`) — never as "up to date", and `erun upgrade` never deploys an unknown version. A failed lookup is never substituted with another image's versions. |
+| Tenant image repo can't be listed (private registry, never published). | The channel target falls back to the canonical `erun-devops` image — the base the tenant's wrapper image is rebuilt from at the requested version — so the environment still upgrades. A listable tenant repo refines the target (its published stream wins per channel). |
+| Channel latest can't be resolved anywhere (the canonical image lookup failed too, or no matching tags). | The environment is reported as **target unresolved** with the reason, in the plan line, the skip trace, and the completion accounting (`==> Upgrade complete: N upgraded, N up to date, N unresolved, N failed`) — never as "up to date", and `erun upgrade` never deploys an unknown version. |
 | `--environment` without `--tenant`. | Errors before any work; exit code 1. |
 | One member's deploy fails. | The run **continues** to the remaining members; the failed environment is reported in a summary and the command exits non-zero. Already-upgraded members stay deployed. |
 | Cluster unreachable / stopped cloud context for a member. | Surfaces per the underlying `erun deploy` behaviour for that member (see [`erun deploy` · Error behaviour](/cli/deploy#error-behaviour)). |

--- a/erun-ui/environment_upgrade_test.go
+++ b/erun-ui/environment_upgrade_test.go
@@ -127,13 +127,15 @@ func TestResolveUpgradePlanPrefersTenantImageOverDefault(t *testing.T) {
 	}
 }
 
-// TestResolveUpgradePlanReportsFailedLookupAsUnresolved locks the preview to
-// the run's semantics (issue #497): a tenant whose registry lookup FAILS
-// (the observed ghcr 403, as opposed to succeeding with no published tags)
-// is never substituted with the default ERun image's versions. The member
-// renders "latest unknown" with the reason instead of promising an upgrade
-// the scoped run would then refuse as "target unresolved".
-func TestResolveUpgradePlanReportsFailedLookupAsUnresolved(t *testing.T) {
+// TestResolveUpgradePlanFallsBackToCanonicalOnFailedTenantLookup locks the
+// corrected policy (issue #501): a tenant whose registry listing FAILS (the
+// observed ghcr 403 — indistinguishable from "never published" on ghcr) gets
+// its target from the canonical ERun image, because the tenant image is a
+// wrapper the deploy rebuilds FROM that canonical image at the requested
+// version. The env therefore upgrades instead of being parked on "latest
+// unknown".
+func TestResolveUpgradePlanFallsBackToCanonicalOnFailedTenantLookup(t *testing.T) {
+	const canonicalSnapshot = "1.0.86-snapshot-20260611061111"
 	app := NewApp(erunUIDeps{
 		store: stubUIStore{
 			tenants: map[string]eruncommon.TenantConfig{
@@ -150,7 +152,10 @@ func TestResolveUpgradePlanReportsFailedLookupAsUnresolved(t *testing.T) {
 		},
 		resolveImageRegistry: func(_ context.Context, _, repository string) (eruncommon.RuntimeRegistryVersions, error) {
 			if repository == eruncommon.DefaultRuntimeImageName {
-				t.Fatal("a failed tenant lookup must not be papered over with the default image")
+				return eruncommon.RuntimeRegistryVersions{
+					LatestStable:   "1.0.85",
+					LatestSnapshot: canonicalSnapshot,
+				}, nil
 			}
 			return eruncommon.RuntimeRegistryVersions{}, errors.New("ghcr token request failed: 403 Forbidden")
 		},
@@ -164,10 +169,47 @@ func TestResolveUpgradePlanReportsFailedLookupAsUnresolved(t *testing.T) {
 		t.Fatalf("expected 1 plan item, got %d: %+v", len(plan.Items), plan.Items)
 	}
 	item := plan.Items[0]
+	if item.Target != canonicalSnapshot || !item.Lagging || item.UnresolvedReason != "" {
+		t.Fatalf("expected a lagging member targeting the canonical snapshot, got %+v", item)
+	}
+}
+
+// TestResolveUpgradePlanUnresolvedWhenCanonicalLookupAlsoFails keeps the
+// honest terminal state: when neither the tenant repo nor the canonical
+// image is resolvable, the member is "latest unknown" with the canonical
+// failure as the reason — the dialog renders it and the run skips it.
+func TestResolveUpgradePlanUnresolvedWhenCanonicalLookupAlsoFails(t *testing.T) {
+	app := NewApp(erunUIDeps{
+		store: stubUIStore{
+			tenants: map[string]eruncommon.TenantConfig{
+				"petios": {Name: "petios"},
+			},
+			envs: map[string]eruncommon.EnvConfig{
+				"petios/rihards-develop": {
+					Name:           "rihards-develop",
+					AutoUpgrade:    true,
+					UpgradeChannel: eruncommon.UpgradeChannelSnapshot,
+					RuntimeVersion: "1.0.86-snapshot-20260610133238",
+				},
+			},
+		},
+		resolveImageRegistry: func(_ context.Context, _, repository string) (eruncommon.RuntimeRegistryVersions, error) {
+			if repository == eruncommon.DefaultRuntimeImageName {
+				return eruncommon.RuntimeRegistryVersions{}, errors.New("registry unreachable")
+			}
+			return eruncommon.RuntimeRegistryVersions{}, errors.New("ghcr token request failed: 403 Forbidden")
+		},
+	})
+
+	plan, err := app.ResolveUpgradePlan()
+	if err != nil {
+		t.Fatalf("ResolveUpgradePlan failed: %v", err)
+	}
+	item := plan.Items[0]
 	if item.Target != "" || item.Lagging {
 		t.Fatalf("expected an unresolved, non-lagging member, got %+v", item)
 	}
-	if !strings.Contains(item.UnresolvedReason, "403 Forbidden") {
-		t.Fatalf("expected the lookup failure as the reason, got %q", item.UnresolvedReason)
+	if !strings.Contains(item.UnresolvedReason, "registry unreachable") {
+		t.Fatalf("expected the canonical failure as the reason, got %q", item.UnresolvedReason)
 	}
 }


### PR DESCRIPTION
Closes #501. Policy correction on top of #499, from the post-merge screenshots: the dialog honestly parked `petios/rihards-develop` on "latest unknown (ghcr 403)" while the Runtime tab's version picker — and the env's own erun-lineage current version — showed it genuinely tracks the canonical `erun-devops` stream.

**Ground truth:** the tenant runtime image is a thin wrapper (`ARG ERUN_BASE_TAG=…erun-devops:<v>` / `FROM ${ERUN_BASE_TAG}`, `erun-common/default_devops_module.go:145`) that the deploy **rebuilds from the canonical base at the requested version and pushes itself** — the tenant repo's listing never gates target selection. And ghcr 403s anonymous tag listing for private and nonexistent repos alike, so "never published" and "forbidden" are indistinguishable at lookup time.

**New policy in the one shared resolver** (preview/CLI/MCP stay unified — the #497 invariant holds, only the policy moved):
- a listable tenant repo **refines** the target (its published stream wins per channel);
- a tenant listing that fails **or** is empty falls back per channel to the canonical `erun-devops` lookup — the env upgrades to the version its deploy actually ships;
- only a canonical-lookup failure yields **target unresolved**, with that failure as the reason — the "latest unknown" dialog state, the `(target unresolved: …)` plan line, and the four-way `==> Upgrade complete` accounting all remain for real outages.

**Net effect for the observed case:** petios/rihards-develop now resolves to the canonical snapshot, shows "will upgrade", and the per-env fan-out (#499) deploys it.

**Tests:** resolver — failed tenant listing → canonical versions (no error); both lookups failing → unresolved with the canonical reason; the existing refinement/empty-fallback/partial cases unchanged. Desktop preview — failed tenant lookup → lagging member targeting the canonical snapshot with no reason; both failing → "latest unknown" + canonical reason. The seam-staged unresolved goldens are unchanged (the seam short-circuits both lookups, now representing canonical failure).

**Docs:** `cli/upgrade.md` error-behaviour table split into the two real rows (tenant repo unlistable → canonical fallback; nothing resolvable → unresolved), replacing the over-strict "never substituted" wording from #499.

**Validation:** `erun-common`/`erun-cli`/`erun-mcp`/`erun-ui` `go test ./...` green; `make integration-test` green (57.7% ≥ 55, goldens unchanged); docs build clean. No frontend diff (the dialog reads the same plan fields); the Playwright upgrade specs stub the plan RPC and are unaffected. Live re-test: reopen Upgrade all — petios should now show "will upgrade → 1.0.86-snapshot-20260611061111".

🤖 Generated with [Claude Code](https://claude.com/claude-code)