### PR TITLE
Run the env open/build/deploy preflight once per environment, not once per tab

### DIFF
--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -32,6 +32,7 @@ func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen 
 	var versionOverride string
 	var runtimeImage string
 	var appSession string
+	var skipEnsure bool
 	var aiTab bool
 	var contributeTab bool
 	target := common.OpenParams{}
@@ -89,6 +90,7 @@ func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen 
 				AppSession:       strings.TrimSpace(appSession),
 				AI:               aiTab,
 				Contribute:       contributeTab,
+				SkipEnsure:       skipEnsure,
 			}, promptRunner, openShell, runManagedDeploy, checkKubernetesDeployment, resolveRuntimeDeploySpec, deployHelmChart, activateMCP, activateAPI, activateSSHD, launchVSCode, launchIntelliJ)
 		},
 	}
@@ -110,9 +112,11 @@ func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen 
 	cmd.Flags().StringVar(&appSession, "app-session", "", "Reattach to a persistent terminal session with this id")
 	cmd.Flags().BoolVar(&aiTab, "ai", false, "Launch the configured AI tool as the persistent session's program")
 	cmd.Flags().BoolVar(&contributeTab, "contribute", false, "Start the persistent session in the contribute clone")
+	cmd.Flags().BoolVar(&skipEnsure, "skip-ensure", false, "Skip the runtime deploy preflight; the desktop ensures the environment once before spawning its tabs")
 	_ = cmd.Flags().MarkHidden("app-session")
 	_ = cmd.Flags().MarkHidden("ai")
 	_ = cmd.Flags().MarkHidden("contribute")
+	_ = cmd.Flags().MarkHidden("skip-ensure")
 	return cmd
 }
 
@@ -127,6 +131,7 @@ type openOptions struct {
 	SaveEnvConfig    func(string, common.EnvConfig) error
 	AppSession       string
 	AI               bool
+	SkipEnsure       bool
 	Contribute       bool
 }
 
@@ -334,7 +339,14 @@ func (r *resolvedOpenRunner) run() error {
 	shellReq.AppSession = r.options.AppSession
 	shellReq.AI = r.options.AI
 	shellReq.Contribute = r.options.Contribute
-	if err := r.maybeDeployRuntime(shellReq); err != nil {
+	if r.options.SkipEnsure {
+		// One ensure per environment (re)start (issue #463): the desktop
+		// runs the open/build/deploy preflight once via `open --no-shell`
+		// and spawns every tab with --skip-ensure; the shell runner's
+		// WaitForShellDeployment below still holds each tab until that
+		// ensure's deploy is available.
+		r.ctx.Trace("open: --skip-ensure set, skipping the runtime deploy preflight (ensured once per environment by the desktop)")
+	} else if err := r.maybeDeployRuntime(shellReq); err != nil {
 		return err
 	}
 	if err := r.activateForwarders(); err != nil {

--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -262,6 +262,19 @@ func TestOpen(t *testing.T) {
 		golden.Equal(t, "open/remote_dry_run_propagates_host_credentials_opt_in", normalize.Apply(result.Combined))
 	})
 
+	t.Run("app_session_skip_ensure_dry_run_skips_the_deploy_preflight", func(t *testing.T) {
+		// #463: the desktop runs the open/build/deploy preflight once per env
+		// (the shared ensure) and spawns every tab with --skip-ensure. The
+		// flag must skip the preflight with an explicit trace — and nothing
+		// else: the shell preview (the deployment wait + dtach exec) still
+		// runs, which is what holds the tab until the ensure's deploy lands.
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--app-session", "open-0", "--skip-ensure", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/app_session_skip_ensure_dry_run_skips_the_deploy_preflight", normalize.Apply(result.Combined))
+	})
+
 	t.Run("app_session_ai_dry_run_wraps_dtach_and_launches_claude", func(t *testing.T) {
 		// #478: the desktop AI tab runs `erun open --app-session ai --ai`. Without
 		// --no-shell the dry-run reaches traceShellPreview, so the bootstrap-script

--- a/erun-integration/testdata/open/app_session_skip_ensure_dry_run_skips_the_deploy_preflight.txt
+++ b/erun-integration/testdata/open/app_session_skip_ensure_dry_run_skips_the_deploy_preflight.txt
@@ -1,0 +1,68 @@
+audit: erun open --app-session open-0 --dry-run --skip-ensure team dev
+config: would assign localportrangestart=17000 to team/dev
+open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=false ide=shell
+open: --skip-ensure set, skipping the runtime deploy preflight (ensured once per environment by the desktop)
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment erun-api -o name
+kubectl --context test-context --namespace team-dev port-forward service/erun-api 17033:17033 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev wait --for=condition=Available --timeout 2m0s deployment/team-devops
+kubectl --context test-context --namespace team-dev exec -it deployment/team-devops -- /bin/sh -lc '<bootstrap-script>'
+bootstrap-script:
+  set -eu
+  export COLORTERM=truecolor
+  export COLORFGBG='15;0'
+  mkdir -p '<HOME>/git/team'
+  cd '<HOME>/git/team'
+  config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+  mkdir -p "$config_home/erun"
+  cat > "$config_home/erun/config.yaml" <<'EOF'
+  defaulttenant: team
+
+  EOF
+  mkdir -p "$config_home/erun/team"
+  cat > "$config_home/erun/team/config.yaml" <<'EOF'
+  projectroot: <HOME>/git/team
+  name: team
+  defaultenvironment: dev
+
+  EOF
+  mkdir -p "$config_home/erun/team/dev"
+  cat > "$config_home/erun/team/dev/config.yaml" <<'EOF'
+  name: dev
+  repopath: <HOME>/git/team
+  kubernetescontext: test-context
+  containerregistry: ""
+  remote: true
+
+  EOF
+  mkdir -p "$HOME/.erun/team/dev"
+  cat > "$HOME/.erun/team/dev/bashrc" <<'EOF'
+  export ERUN_SHELL_HOST='team-dev'
+  erun() {
+    if [ "${1:-}" = "deploy" ] && [ "$#" -eq 1 ] && [ -n "${ERUN_SHELL_REQUEST_FILE:-}" ]; then
+      : > "$ERUN_SHELL_REQUEST_FILE"
+      exit 0
+    fi
+    command erun "$@"
+  }
+  EOF
+  printf '\033]0;'team-dev'\007'
+  request_file="$HOME/.erun/team/dev/shell-request"
+  rm -f "$request_file"
+  export ERUN_SHELL_REQUEST_FILE="$request_file"
+  shell_status=0
+  mkdir -p "<TMP>"
+  cat > "$HOME/.erun/team/dev/launch-open-0.sh" <<'EOF'
+  exec /bin/bash --rcfile "$HOME/.erun/team/dev/bashrc" -i
+  EOF
+  attach_id="$$-$(date +%s)"
+  printf '%s' "$attach_id" > "<TMP>"
+  master_pid=""
+  for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if grep -qF "<TMP>" "/proc/$dtach_pid/cmdline" 2>/dev/null; then for child_pid in $(pgrep -P "$dtach_pid" 2>/dev/null || true); do child_comm="$(cat "/proc/$child_pid/comm" 2>/dev/null)"; if [ -n "$child_comm" ] && [ "$child_comm" != "dtach" ]; then master_pid="$dtach_pid"; fi; done; fi; done
+  if [ -S "<TMP>" ] && [ -n "$master_pid" ]; then for dtach_pid in $(pgrep -x dtach 2>/dev/null || true); do if [ "$dtach_pid" != "$master_pid" ] && grep -qF "<TMP>" "/proc/$dtach_pid/cmdline" 2>/dev/null; then kill "$dtach_pid" 2>/dev/null || true; fi; done; fi
+  dtach -A "<TMP>" -r ctrl_l /bin/bash "$HOME/.erun/team/dev/launch-open-0.sh" || shell_status=$?
+  if [ "$(cat "<TMP>" 2>/dev/null)" != "$attach_id" ]; then exit 76; fi
+  if [ -e "$request_file" ]; then rm -f "$request_file"; exit 75; fi
+  rm -f "$request_file"
+  exit "$shell_status"
+open: dry-run complete; would have launched shell

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -89,6 +89,9 @@ type App struct {
 	actionQueueMu             sync.Mutex
 	actionQueues              map[string]*envActionQueue
 	actionCancels             map[string]context.CancelFunc
+	envEnsureMu               sync.Mutex
+	envEnsureInflight         map[string]struct{}
+	envEnsureDone             map[string]time.Time
 	configWatcher             *configWatcher
 	contribute                *contributeStore
 	contributeApps            *contributeAppForwards

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -2318,9 +2318,10 @@ func TestStartSessionLeavesCloudContextStartupToErunCommand(t *testing.T) {
 	}
 
 	got := strings.Join(actions, "\n")
-	// The ERun tab runs `erun open … --app-session open-0`: a persistent,
-	// reattachable dtach session so reopening reconnects to the running shell (#478).
-	if got != "terminal open frs prod --app-session open-0" {
+	// The ERun tab runs `erun open … --app-session open-0 --skip-ensure`: a
+	// persistent, reattachable dtach session (#478) whose preflight runs once
+	// per env via the shared ensure, not per tab (#463).
+	if got != "terminal open frs prod --app-session open-0 --skip-ensure" {
 		t.Fatalf("expected only terminal start action, got:\n%s", got)
 	}
 	// Cloud-context Status is no longer persisted, so we rely on the
@@ -3396,7 +3397,9 @@ func TestStartAISessionRunsErunOpenAsPersistentAITab(t *testing.T) {
 	// reconnects to the running claude. The desktop no longer types the launch
 	// in, so there is no initial input. The AI tool + effort are resolved pod-side
 	// by `erun open --ai`; AISessionLaunchCommand is covered in erun-common. #478.
-	wantArgs := []string{"open", "erun", "remote", "--app-session", "ai", "--ai"}
+	// --skip-ensure: the preflight runs once per env via the shared ensure,
+	// not per tab (#463).
+	wantArgs := []string{"open", "erun", "remote", "--app-session", "ai", "--ai", "--skip-ensure"}
 	if strings.Join(started.Args, "\n") != strings.Join(wantArgs, "\n") {
 		t.Fatalf("unexpected args: got %+v want %+v", started.Args, wantArgs)
 	}

--- a/erun-ui/env_ensure.go
+++ b/erun-ui/env_ensure.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// envEnsureTTL bounds how long one completed ensure stands in for the next
+// tab spawn or respawn of the same env. Long enough to cover the burst an
+// env (re)start produces (the ERun + AI spawns and any pod-replace respawns
+// land within seconds of each other), short enough that a genuinely later
+// reopen re-checks the deployment.
+const envEnsureTTL = 30 * time.Second
+
+// ensureEnvRuntimeOnce runs the env's open/build/deploy preflight at most
+// once per (re)start window, across every tab and respawn (issue #463).
+// Before this, each tab's own `erun open` ran the full preflight — spec
+// resolution, per-arch docker cache walks, and, when stale, the whole
+// multi-arch rebuild + helm deploy — once per tab, with the rebuild
+// streaming into whichever tab won the per-env queue (the reported "docker
+// build inside the AI tab"). Now the desktop runs one `erun open --no-shell`
+// per window, streams its deploy traces into the activity queue (the same
+// `==> Deploying` parser the PTY channel feeds), and every tab launches with
+// --skip-ensure, relying on the shell runner's deployment wait to hold the
+// tab until this ensure's deploy is available.
+//
+// Fire-and-forget by design: callers never block on the ensure, and a
+// concurrent or recent ensure is simply not repeated. A failed ensure still
+// stamps the window (the TTL stops a failing env from being hammered once
+// per tab); its failure surfaces through the activity queue's deploy-failed
+// entry and the tabs' own deployment-wait errors, which feed the existing
+// reconnect-refusal machinery.
+func (a *App) ensureEnvRuntimeOnce(selection uiSelection) {
+	// a.ctx is set by startup() in both desktop and headless modes and stays
+	// nil in unit tests: the ensure must never fall back from a test app to
+	// the machine's real CLI and config (the #492 hazard class).
+	if a.ctx == nil {
+		return
+	}
+	selection = normalizeSelection(selection)
+	key := selectionKey(selection)
+
+	a.envEnsureMu.Lock()
+	if a.envEnsureInflight == nil {
+		a.envEnsureInflight = make(map[string]struct{})
+		a.envEnsureDone = make(map[string]time.Time)
+	}
+	if _, inflight := a.envEnsureInflight[key]; inflight {
+		a.envEnsureMu.Unlock()
+		return
+	}
+	if done, ok := a.envEnsureDone[key]; ok && time.Since(done) < envEnsureTTL {
+		a.envEnsureMu.Unlock()
+		return
+	}
+	a.envEnsureInflight[key] = struct{}{}
+	a.envEnsureMu.Unlock()
+
+	go func() {
+		defer func() {
+			a.envEnsureMu.Lock()
+			delete(a.envEnsureInflight, key)
+			a.envEnsureDone[key] = time.Now()
+			a.envEnsureMu.Unlock()
+		}()
+		result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
+			Tenant:      selection.Tenant,
+			Environment: selection.Environment,
+		})
+		if err != nil {
+			return
+		}
+		onLine := newActivityTraceLineHandler(a, selection, sessionKindOpen)
+		_ = a.deps.reconnectMCP(context.Background(), result, onLine)
+	}()
+}

--- a/erun-ui/env_ensure_test.go
+++ b/erun-ui/env_ensure_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// These tests lock the per-env ensure dedupe (issue #463): opening an env
+// with its default tabs — and respawning them — must run the open/build/
+// deploy preflight once per (re)start window, not once per tab. The tabs'
+// own `erun open` processes launch with --skip-ensure (locked by the
+// StartSession/StartAISession arg assertions in app_test.go) and the shared
+// ensure is the only preflight runner.
+
+func envEnsureTestApp(t *testing.T, ensures *int32, ensuresMu *sync.Mutex) *App {
+	t.Helper()
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", ProjectRoot: projectRoot, DefaultEnvironment: "remote"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {Name: "remote", RepoPath: projectRoot, KubernetesContext: "ctx"},
+		},
+	}
+	app := NewApp(erunUIDeps{
+		store:           store,
+		findProjectRoot: func() (string, string, error) { return "erun", projectRoot, nil },
+		resolveCLIPath:  func() string { return "/tmp/erun" },
+		startTerminal: func(startTerminalSessionParams) (terminalSession, error) {
+			return newStubTerminalSession(), nil
+		},
+		reconnectMCP: func(context.Context, eruncommon.OpenResult, func(string)) error {
+			ensuresMu.Lock()
+			*ensures++
+			ensuresMu.Unlock()
+			return nil
+		},
+	})
+	// The ensure no-ops while a.ctx is nil (the unit-test hermeticity gate);
+	// these tests inject every dep it reaches, so flipping the gate is safe.
+	// The emitter must be stubbed alongside it: with a non-nil ctx, emits
+	// would otherwise reach the real Wails runtime, which fatals outside a
+	// lifecycle context.
+	app.ctx = context.Background()
+	app.SetEmitter(func(string, ...any) {})
+	t.Cleanup(func() { app.shutdown(context.Background()) })
+	return app
+}
+
+func waitForEnsureCount(t *testing.T, ensures *int32, ensuresMu *sync.Mutex, want int32, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		ensuresMu.Lock()
+		got := *ensures
+		ensuresMu.Unlock()
+		if got == want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	ensuresMu.Lock()
+	got := *ensures
+	ensuresMu.Unlock()
+	t.Fatalf("ensure count = %d, want %d", got, want)
+}
+
+func TestEnsureEnvRuntimeOnceDedupesAcrossTabs(t *testing.T) {
+	var ensures int32
+	var ensuresMu sync.Mutex
+	app := envEnsureTestApp(t, &ensures, &ensuresMu)
+	selection := uiSelection{Tenant: "erun", Environment: "remote"}
+
+	if _, err := app.StartSession(selection, 0, 80, 24); err != nil {
+		t.Fatalf("StartSession failed: %v", err)
+	}
+	if _, err := app.StartAISession(selection, 0, 80, 24); err != nil {
+		t.Fatalf("StartAISession failed: %v", err)
+	}
+	// Both tab spawns share one preflight.
+	waitForEnsureCount(t, &ensures, &ensuresMu, 1, 2*time.Second)
+
+	// Still one after a settling beat — the AI spawn must not have queued a
+	// second ensure behind the first.
+	time.Sleep(100 * time.Millisecond)
+	ensuresMu.Lock()
+	got := ensures
+	ensuresMu.Unlock()
+	if got != 1 {
+		t.Fatalf("expected the burst to share one ensure, got %d", got)
+	}
+}
+
+func TestEnsureEnvRuntimeOnceRunsAgainAfterTheWindow(t *testing.T) {
+	var ensures int32
+	var ensuresMu sync.Mutex
+	app := envEnsureTestApp(t, &ensures, &ensuresMu)
+	selection := uiSelection{Tenant: "erun", Environment: "remote"}
+
+	app.ensureEnvRuntimeOnce(selection)
+	waitForEnsureCount(t, &ensures, &ensuresMu, 1, 2*time.Second)
+
+	// Age the completed window out (white-box: the TTL constant is the
+	// contract; sleeping it out would slow the suite for nothing).
+	key := selectionKey(normalizeSelection(selection))
+	app.envEnsureMu.Lock()
+	app.envEnsureDone[key] = time.Now().Add(-envEnsureTTL)
+	app.envEnsureMu.Unlock()
+
+	app.ensureEnvRuntimeOnce(selection)
+	waitForEnsureCount(t, &ensures, &ensuresMu, 2, 2*time.Second)
+}

--- a/erun-ui/playwright/tests/sidebar-env-hover.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-env-hover.spec.ts
@@ -98,9 +98,14 @@ test.describe('sidebar env hover card', () => {
     // Let the open settle first: the in-flight open's busy label outranks
     // the stopped state by design, and the spawn path itself emits a
     // clearing env-status — an injection raced against it would be
-    // overwritten (which is the production contract, not a flake).
+    // overwritten (which is the production contract, not a flake). The
+    // settled state is machine-dependent (a dev harness env whose real
+    // deploy fails settles on "Deploy failed", not "Idle" — the #483
+    // class), so accept any terminal non-busy state before injecting.
     const activity = card.locator('dd').nth(2);
-    await expect(activity).toContainText('Idle', { timeout: 15_000 });
+    await expect(activity).toContainText(/Idle|Stopped|Deploy failed|Not open/, {
+      timeout: 15_000,
+    });
 
     await emitEnvStatusEvent(page, tenant, env, 'stopped');
     await expect(dot).toHaveAttribute('data-env-state', 'stopped', { timeout: 4_000 });

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -67,10 +67,14 @@ func (a *App) runOpenSession(ctx context.Context, selection uiSelection, slot, c
 	}
 	a.mu.Unlock()
 
+	// One preflight per env (re)start (issue #463): the shared ensure runs
+	// the open/build/deploy once and streams its traces into the activity
+	// queue; the tab itself skips the preflight and waits on the deployment.
+	a.ensureEnvRuntimeOnce(selection)
 	openParams := startTerminalSessionParams{
 		Dir:        resolveTerminalStartDir(result.RepoPath),
 		Executable: a.deps.resolveCLIPath(),
-		Args:       withAppSession(buildOpenArgs(result.Tenant, result.Environment, selection.Debug), fmt.Sprintf("open-%d", slot), false, false),
+		Args:       append(withAppSession(buildOpenArgs(result.Tenant, result.Environment, selection.Debug), fmt.Sprintf("open-%d", slot), false, false), "--skip-ensure"),
 		Env:        []string{appSessionEnvVar + "=1"},
 		Cols:       cols,
 		Rows:       rows,
@@ -243,6 +247,8 @@ func (a *App) runAISession(ctx context.Context, selection uiSelection, slot, col
 	}
 	a.mu.Unlock()
 
+	// Shared per-env ensure (issue #463) — see StartSession.
+	a.ensureEnvRuntimeOnce(selection)
 	params := startTerminalSessionParams{
 		Dir:        resolveTerminalStartDir(result.RepoPath),
 		Executable: a.deps.resolveCLIPath(),
@@ -251,7 +257,7 @@ func (a *App) runAISession(ctx context.Context, selection uiSelection, slot, col
 		// resume at the env effort, issues #451/#469), once on create. Reopening
 		// reconnects to the running claude rather than typing it in again or
 		// spawning a parallel one (#478).
-		Args: withAppSession(buildOpenArgs(result.Tenant, result.Environment, selection.Debug), "ai", true, false),
+		Args: append(withAppSession(buildOpenArgs(result.Tenant, result.Environment, selection.Debug), "ai", true, false), "--skip-ensure"),
 		Env:  []string{appSessionEnvVar + "=1"},
 		Cols: cols,
 		Rows: rows,
@@ -1163,6 +1169,12 @@ func (a *App) tryReconnect(managed *managedTerminal, exitReason string) bool {
 	}
 
 	a.emitReconnectMarker(managed.serial, exitReason)
+	// The respawned `erun open` runs with --skip-ensure; refresh the shared
+	// ensure (TTL-deduped) so a replaced pod gets its deploy back without
+	// every tab repeating the preflight (issue #463).
+	if managed.kind != sessionKindLocal {
+		a.ensureEnvRuntimeOnce(managed.selection)
+	}
 	next, err := respawn()
 	if err != nil {
 		a.emitReconnectFailureMarker(managed.serial, err)


### PR DESCRIPTION
Closes #463.

## What changed

- **One ensure per env (re)start window** (`erun-ui/env_ensure.go`): `ensureEnvRuntimeOnce` runs a single `erun open --no-shell` per env — single-flighted and TTL-deduped (30s window) across the ERun/AI tab spawns **and** the pod-replace respawns — reusing the existing `runOpenForReconnect` runner via the `reconnectMCP` dep. Its `==> Deploying/Deployed` traces stream into the **activity queue** through the same parser the PTY channel feeds, so build/deploy progress appears once, in Activities, instead of inside whichever tab's terminal won the queue (the reported multi-arch docker build in the AI tab).
- **Tabs skip the preflight**: ERun and AI sessions (and their respawns, which reuse the same params) launch with the new hidden `erun open --skip-ensure` flag — preflight skipped with an explicit trace; the shell runner's `WaitForShellDeployment` still holds each tab until the ensure's deploy is available, so ordering needs no cross-process coordination and a first-open (deployment absent) just waits.
- **Premise re-verified before building** (recorded on the issue): the cross-process helm single-flight (`dedup: claim`) and the fingerprint cache landed since filing and bound the worst case — what remained was the per-tab resolve + per-arch cache walks, the full rebuild racing into a tab when stale, and the noise placement. This change removes the duplication itself.
- Contribute tabs keep their own open un-skipped for now (rarer, and the shared ensure warms the fingerprints they hit) — noted as intentional scope.

## Hermeticity guard (found during validation)

The ensure is gated on the app's runtime context — set by `startup()` in both desktop and headless modes, nil in unit tests — because a test-built `App` would otherwise fall back to the machine's **real** CLI and config (the #492 hazard class; caught when the unit suite slowed 2.5× running real `erun open` subprocesses for stub envs that exist on this machine).

## Tests

- **Go (`env_ensure_test.go`)**: an ERun+AI spawn burst shares exactly one ensure; the window re-arms after the TTL (white-box aging, no sleeps). Arg assertions in `app_test.go` updated to lock `--skip-ensure` on both tab launches.
- **Integration golden** (new `open/app_session_skip_ensure_dry_run_skips_the_deploy_preflight`): the skip trace, **no** preflight traces, and the `kubectl wait --for=condition=Available` + dtach exec still present — the exact mechanism that holds a tab for the shared ensure. `make integration-test` green (57.7% ≥ 55; one earlier red was a contention one-off, clean rerun green).
- **Playwright**: full suite 64 passed; failures were the documented machine-flaky family **plus one real interaction with this change** — the env-hover spec's settle precondition assumed "Idle", but the ensure now truthfully surfaces this machine's failing `local-ideas` deploy as "Deploy failed"; the spec accepts any terminal non-busy state (comment cites the #483 class). The dot/hover/upgrade spec files re-run 9/9 green after the fix.

## UX impact review (per erun-ui/AGENTS.md)

1. **Affected paths:** env open (ERun/AI tab spawn), tab respawn after pod replace.
2. **User-visible sequence:** click env → tabs appear and sit on the deployment wait ("waiting for <release>…") while one ensure builds/deploys; its progress lives in Activities (deploy entry, same as a manual deploy); tabs land in their programs when ready. The AI tab shows Claude, never a docker build.
3. **State-without-affordance:** none — ensure progress renders as activity entries; tab waits render their existing spinner lines.
4. **Visibility of status (Nielsen #1):** build/deploy progress appears once in the predictable place (Activities) instead of scattered per tab.
5. **Failure feedback (#9):** a failed ensure produces the deploy-failed activity entry with the existing recovery actions, and the tabs' wait failures feed the existing reconnect-refusal machinery — reported once, not N times.
6. **Consistency (#4):** reuses the activity-queue deploy entry comparable flows already have.
7. **Heuristic pass:** #2 match with reality (AI tab is Claude); #5 error prevention (no duplicate rebuilds); #8 minimalism (duplicate output noise removed); others unchanged.
8. **Playwright coverage:** the dedupe itself isn't headless-stageable (real builds); the Go tests own it and the golden owns the CLI contract (#331 pattern). The hover-spec hardening keeps the affected surface green.

## Docs

None needed: no operator-facing page documents per-tab preflight behaviour; the change makes the existing docs' mental model ("opening brings the env up") hold with less noise.

## Validation

`erun-cli`/`erun-ui`/`erun-common` suites green (unit suite back to ~5.5s after the hermeticity gate), integration gate green, full Playwright as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)