### PR TITLE
Diagnostics console: pin pane toolbars outside the scroll regions, add Copy report

### DIFF
--- a/erun-docs/docs/desktop/overview.md
+++ b/erun-docs/docs/desktop/overview.md
@@ -25,7 +25,7 @@ When something misbehaves, the panel at the bottom of the terminal area gives yo
 - **erun trace.** The selected environment's persistent trace log: every erun command that ran for the env, at full trace detail, timestamped — including commands that finished before you opened the console. Capture is always on; the log is capped and rotated automatically (see [where it lives](/reference/config-locations#trace-log)). For a local environment the desktop reads the log from your machine; for a remote environment it reads the one inside the pod while the environment is open.
 - **UI trace.** The desktop's own action history — what the app just did, in order — for reporting a desktop bug rather than an environment one.
 
-Both panes have a **Copy** button so a bug report can carry the evidence instead of a description of it.
+Both panes have a **Copy** button for their own stream, and the console's **Copy report** button packages everything at once — app build, the selected environment's identity and state, the erun trace (or the reason there isn't one), and the UI trace — into a single paste-ready block, so a bug report carries the evidence instead of a description of it.
 
 ## Open it in your editor
 

--- a/erun-ui/frontend/src/app/diagnosticsReport.ts
+++ b/erun-ui/frontend/src/app/diagnosticsReport.ts
@@ -1,0 +1,59 @@
+import type { UIBuildDetails, UIEnvironment, UIEnvTrace, UISelection } from '@/types';
+
+import { formatUITrace, type UITraceEntry } from './uiTraceBuffer';
+
+// formatDiagnosticsReport renders the Diagnostics console's one-click bug
+// report (issue #514): everything a reader needs in a single paste-ready
+// block — app build, env identity and state, the erun trace tail (or its
+// empty-state reason: "unreachable" is itself evidence), and the UI action
+// history. Mirrors the Activities drawer's "Copy failure report" pattern.
+export interface DiagnosticsReportInput {
+  generatedAt: string;
+  build: UIBuildDetails | null;
+  selection: UISelection | null;
+  environment: UIEnvironment | null;
+  envStatus: string;
+  trace: UIEnvTrace | null;
+  uiTrace: UITraceEntry[];
+}
+
+export function formatDiagnosticsReport(input: DiagnosticsReportInput): string {
+  const lines: string[] = [`ERun diagnostics report — ${input.generatedAt}`];
+  if (input.build) {
+    lines.push(buildLine(input.build));
+  }
+  lines.push(environmentLine(input.selection, input.environment));
+  if (input.envStatus) {
+    lines.push(`status: ${input.envStatus}`);
+  }
+  lines.push(
+    '',
+    `── erun trace — ${input.trace?.path ?? 'unavailable'} ──`,
+    traceBlock(input.trace),
+  );
+  lines.push('', `── UI trace (${String(input.uiTrace.length)} entries) ──`);
+  lines.push(input.uiTrace.length > 0 ? formatUITrace(input.uiTrace) : 'no UI activity recorded');
+  return `${lines.join('\n')}\n`;
+}
+
+function buildLine(build: UIBuildDetails): string {
+  const extras = [build.commit, build.date].filter(Boolean).join(' ');
+  return `app: ${build.version}${extras ? ` (${extras})` : ''}`;
+}
+
+function traceBlock(trace: UIEnvTrace | null): string {
+  if (trace?.available && trace.content) {
+    return trace.content.trimEnd();
+  }
+  return trace?.reason ?? 'no trace loaded';
+}
+
+function environmentLine(selection: UISelection | null, env: UIEnvironment | null): string {
+  if (!selection) {
+    return 'environment: none selected';
+  }
+  const extras = [env?.type, env?.runtimeVersion ? `runtime ${env.runtimeVersion}` : '']
+    .filter(Boolean)
+    .join(', ');
+  return `environment: ${selection.tenant} / ${selection.environment}${extras ? ` (${extras})` : ''}`;
+}

--- a/erun-ui/frontend/src/components/app/DebugPanel.tsx
+++ b/erun-ui/frontend/src/components/app/DebugPanel.tsx
@@ -1,6 +1,16 @@
-import { CheckCircle2, ChevronDown, ChevronUp, Copy, RefreshCw, Trash2 } from 'lucide-react';
+import {
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  ClipboardList,
+  Copy,
+  RefreshCw,
+  Trash2,
+} from 'lucide-react';
 import * as React from 'react';
 
+import { stateApi } from '@/app/api/stateApi';
+import { formatDiagnosticsReport } from '@/app/diagnosticsReport';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { setDebugOpen, startDebugResize } from '@/app/layoutThunks';
 import {
@@ -10,6 +20,7 @@ import {
   type UITraceEntry,
   uiTraceGeneration,
 } from '@/app/uiTraceBuffer';
+import { selectionKey } from '@/app/versionSuggestions';
 import { ResizeHandle } from '@/components/app/ResizeHandle';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -82,9 +93,21 @@ export function DebugPanel({ open }: { open: boolean }): React.ReactElement {
           </span>
         </button>
         {open && (
-          <div className="flex items-center gap-1" role="tablist" aria-label="Diagnostics sections">
-            <DiagnosticsTabButton current={tab} value="erun" label="erun trace" onSelect={setTab} />
-            <DiagnosticsTabButton current={tab} value="ui" label="UI trace" onSelect={setTab} />
+          <div className="flex items-center gap-2">
+            <CopyReportButton selection={selection} />
+            <div
+              className="flex items-center gap-1"
+              role="tablist"
+              aria-label="Diagnostics sections"
+            >
+              <DiagnosticsTabButton
+                current={tab}
+                value="erun"
+                label="erun trace"
+                onSelect={setTab}
+              />
+              <DiagnosticsTabButton current={tab} value="ui" label="UI trace" onSelect={setTab} />
+            </div>
           </div>
         )}
       </div>
@@ -194,6 +217,78 @@ function CopyButton({
   );
 }
 
+// CopyReportButton assembles the one-click bug report (issue #514): app
+// build, the selected env's identity/state, a fresh erun-trace read (so the
+// report is current even between poll ticks), and the UI action history —
+// one paste-ready block, available from either tab.
+function CopyReportButton({ selection }: { selection: UISelection | null }): React.ReactElement {
+  const selectInitialState = React.useMemo(
+    () => stateApi.endpoints.getInitialState.select(undefined),
+    [],
+  );
+  const build = useAppSelector((state) => selectInitialState(state).data?.build ?? null);
+  const environment = useAppSelector((state) => {
+    if (!selection) {
+      return null;
+    }
+    const tenant = state.tenants.tenants.find((entry) => entry.name === selection.tenant);
+    return tenant?.environments.find((env) => env.name === selection.environment) ?? null;
+  });
+  const envStatus = useAppSelector((state) =>
+    selection ? (state.envStatus.statusByEnv[selectionKey(selection)] ?? '') : '',
+  );
+  const [status, setStatus] = React.useState('');
+
+  const copyReport = React.useCallback(() => {
+    const assemble = async (): Promise<void> => {
+      let trace: UIEnvTrace | null = null;
+      if (selection) {
+        trace = await LoadEnvTrace({
+          tenant: selection.tenant,
+          environment: selection.environment,
+        }).catch(() => null);
+      }
+      const report = formatDiagnosticsReport({
+        generatedAt: new Date().toISOString(),
+        build,
+        selection,
+        environment,
+        envStatus,
+        trace,
+        uiTrace: uiTraceEntries(),
+      });
+      await ClipboardSetText(report);
+    };
+    assemble()
+      .then(() => {
+        setStatus('Copied');
+        window.setTimeout(() => {
+          setStatus('');
+        }, 1400);
+      })
+      .catch(() => {
+        setStatus('Copy failed');
+      });
+  }, [selection, build, environment, envStatus]);
+
+  return (
+    <Button
+      className="h-6 px-2 text-[11px] [&_svg]:size-3.5"
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={copyReport}
+    >
+      {status === 'Copied' ? (
+        <CheckCircle2 aria-hidden="true" />
+      ) : (
+        <ClipboardList aria-hidden="true" />
+      )}
+      {status || 'Copy report'}
+    </Button>
+  );
+}
+
 // useEnvTracePoll loads the selected env's persistent trace log and keeps
 // it fresh while the pane is visible, so a running command's lines arrive
 // without manual refresh.
@@ -233,19 +328,23 @@ function ErunTracePane({ selection }: { selection: UISelection | null }): React.
   const content = trace?.content ?? '';
   const { outputRef, handleScroll } = useStickToBottom(content);
 
+  // The toolbar sits in its own grid row, outside the scroll region:
+  // stick-to-bottom would otherwise scroll the actions out the top the
+  // moment the log outgrows the pane — an affordance that exists but cannot
+  // be seen does not exist (issue #514).
   return (
-    <div className="grid min-h-0 grid-rows-[minmax(0,1fr)]">
+    <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)]">
+      <ErunTraceToolbar
+        label={erunTraceLabel(tenant, environment, trace)}
+        content={content}
+        onRefresh={refresh}
+      />
       <div
         ref={outputRef}
         onScroll={handleScroll}
-        className="min-h-0 overflow-auto px-3 py-2 font-mono text-[11px] leading-[1.35] text-[oklch(0.82_0_0)]"
+        className="min-h-0 overflow-auto px-3 pb-2 font-mono text-[11px] leading-[1.35] text-[oklch(0.82_0_0)]"
         aria-label="erun trace output"
       >
-        <ErunTraceToolbar
-          label={erunTraceLabel(tenant, environment, trace)}
-          content={content}
-          onRefresh={refresh}
-        />
         <ErunTraceBody tenant={tenant} environment={environment} trace={trace} />
       </div>
     </div>
@@ -270,7 +369,7 @@ function ErunTraceToolbar({
 }): React.ReactElement {
   const { copyStatus, copy } = useCopyAction(content);
   return (
-    <div className="mb-1 flex items-center justify-between gap-2">
+    <div className="flex items-center justify-between gap-2 px-3 pt-1.5 pb-1">
       <span className="min-w-0 truncate text-[10px] text-[oklch(0.5_0_0)]">{label}</span>
       <span className="flex flex-none items-center gap-1">
         <Button
@@ -340,14 +439,11 @@ function UITracePane(): React.ReactElement {
   const { outputRef, handleScroll } = useStickToBottom(text);
   const { copyStatus, copy } = useCopyAction(text);
 
+  // Actions are pinned outside the scroll region — same rationale as the
+  // erun trace toolbar (issue #514).
   return (
-    <div
-      ref={outputRef}
-      onScroll={handleScroll}
-      className="min-h-0 overflow-auto px-3 py-2 font-mono text-[11px] leading-[1.35] text-[oklch(0.82_0_0)]"
-      aria-label="UI trace output"
-    >
-      <div className="mb-1 flex items-center justify-end gap-1">
+    <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)]">
+      <div className="flex items-center justify-end gap-1 px-3 pt-1.5 pb-1">
         <CopyButton copyStatus={copyStatus} disabled={!text.trim()} onCopy={copy} />
         <Button
           className="h-6 px-2 text-[11px] [&_svg]:size-3.5"
@@ -363,13 +459,20 @@ function UITracePane(): React.ReactElement {
           Clear
         </Button>
       </div>
-      {entries.length === 0 ? (
-        <p className="m-0 text-[oklch(0.6_0_0)]">No UI activity recorded yet.</p>
-      ) : (
-        <pre className="m-0 font-mono text-[11px] leading-[1.35] break-words whitespace-pre-wrap">
-          {text}
-        </pre>
-      )}
+      <div
+        ref={outputRef}
+        onScroll={handleScroll}
+        className="min-h-0 overflow-auto px-3 pb-2 font-mono text-[11px] leading-[1.35] text-[oklch(0.82_0_0)]"
+        aria-label="UI trace output"
+      >
+        {entries.length === 0 ? (
+          <p className="m-0 text-[oklch(0.6_0_0)]">No UI activity recorded yet.</p>
+        ) : (
+          <pre className="m-0 font-mono text-[11px] leading-[1.35] break-words whitespace-pre-wrap">
+            {text}
+          </pre>
+        )}
+      </div>
     </div>
   );
 }

--- a/erun-ui/playwright/pages/DebugPanel.ts
+++ b/erun-ui/playwright/pages/DebugPanel.ts
@@ -53,4 +53,8 @@ export class DebugPanel {
   clearButton(): Locator {
     return this.page.getByRole('button', { name: 'Clear' });
   }
+
+  copyReportButton(): Locator {
+    return this.page.getByRole('button', { name: /^(Copy report|Copied|Copy failed)$/ });
+  }
 }

--- a/erun-ui/playwright/tests/diagnostics-console.spec.ts
+++ b/erun-ui/playwright/tests/diagnostics-console.spec.ts
@@ -33,9 +33,28 @@ test.describe('diagnostics console', () => {
     await expect(app.debugPanel.tab('erun trace')).toHaveAttribute('aria-selected', 'true');
     await expect(app.debugPanel.erunTracePane()).toBeVisible();
     // The pane always offers Refresh; Copy is present (enabled only when
-    // there is content to copy).
+    // there is content to copy); Copy report sits in the header, available
+    // from either tab.
     await expect(app.debugPanel.refreshButton()).toBeVisible();
     await expect(app.debugPanel.copyButton()).toBeVisible();
+    await expect(app.debugPanel.copyReportButton()).toBeVisible();
+  });
+
+  test('pane actions live outside the scroll regions and the report button spans tabs', async ({
+    app,
+  }) => {
+    // #514: the toolbars used to render inside the scrollable region, so
+    // stick-to-bottom pushed Copy/Refresh out the top as soon as always-on
+    // capture filled the pane. Lock the structure: the scroll regions
+    // contain no buttons at all — the actions are pinned rows above them.
+    await expect(app.debugPanel.erunTracePane().getByRole('button')).toHaveCount(0);
+    await expect(app.debugPanel.refreshButton()).toBeVisible();
+
+    await app.debugPanel.selectTab('UI trace');
+    await expect(app.debugPanel.uiTracePane().getByRole('button')).toHaveCount(0);
+    await expect(app.debugPanel.clearButton()).toBeVisible();
+    // The header's Copy report stays available regardless of active tab.
+    await expect(app.debugPanel.copyReportButton()).toBeVisible();
   });
 
   test('UI trace records dispatched actions and Clear empties it', async ({ app }) => {


### PR DESCRIPTION
Closes #514

From a live session screenshot: the Diagnostics console's Copy/Refresh buttons were effectively invisible — they rendered *inside* each pane's scrollable region, and stick-to-bottom scrolled them out the top the moment the (now always-on, #508) trace filled the pane. And filing a report still meant copying two streams by hand plus typing the env context.

## What changed

- **Pinned toolbars.** Both panes are now a `grid-rows-[auto,1fr]` split: the actions row (erun trace: path label + Refresh + Copy; UI trace: Copy + Clear) sits above the scroll region and stays visible at any scroll position.
- **Copy report.** A new header button (available from either tab) assembles one paste-ready block: app build details (from the initial-state cache), the selected env's identity, type, runtime version and real status, a *fresh* `LoadEnvTrace` read (or its empty-state reason — "unreachable" is itself evidence), and the UI action history. Formatting lives in a new dependency-light helper, `frontend/src/app/diagnosticsReport.ts`. Mirrors the Activities drawer's **Copy failure report** pattern.
- **Docs**: the desktop overview's Diagnostics section now describes Copy report (`erun-docs yarn build` clean). Operator-facing page only; no flag/field/spec surface changed, so no Agent-reference edits — the report is a clipboard convenience over already-specced data.

## UX impact review (erun-ui/AGENTS.md checklist)

1. **Affected paths.** Diagnostics console panes + header.
2. **User-visible sequence.** Open console → actions visible immediately at any scroll depth; click Copy report → button flips to "Copied" (or "Copy failed"), clipboard holds the full block.
3. **State-without-affordance.** This PR removes an instance of the inverse defect: an affordance without visibility.
4. **Visibility of system status (Nielsen #1) / user control (#3).** Actions no longer disappear under scroll; report includes the env's real status line.
5. **Success/failure feedback (#1/#9).** Copied/Copy failed transients on the new button, same as existing copy actions.
6. **Consistency (#4).** Matches the Activities drawer's Copy failure report; button styling matches the existing pane actions.
7. **Heuristic pass.** Recognition over recall: the reporter doesn't choose which pieces matter. Accessibility: semantic buttons, keyboard reachable, names unique (`Copy` vs `Copy report` are distinct accessible names).
8. **Playwright.** New structural spec locks the fix: the scroll regions (`erun trace output` / `UI trace output`) contain **no** buttons, the pinned actions and the header Copy report are visible from both tabs. Clipboard content itself isn't assertable headless; the report's assembly is pure formatting in `diagnosticsReport.ts` over already-tested inputs (`LoadEnvTrace` Go tests, uiTraceBuffer).

## Validation

- Frontend: `yarn typecheck`, `yarn lint`, `yarn format:check`, `yarn build` clean. Frontend-only — no Go change, no bindings regen.
- Playwright: 4 diagnostics specs + layout toggle green against a rebuilt `erun-app`.
- Docs: `yarn build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)