### PR TITLE
Agent-instructions block: update in place (replace-on-change) + add read-directly / answer-first guidance

### DIFF
--- a/erun-cli/internal/claude_md.go
+++ b/erun-cli/internal/claude_md.go
@@ -6,9 +6,26 @@ import (
 	"strings"
 )
 
-const claudeMDMarker = "erun-agents-md-hook"
+const (
+	claudeMDOpenMarker  = "<!-- erun-agents-md-hook -->"
+	claudeMDCloseMarker = "<!-- /erun-agents-md-hook -->"
+)
 
-const claudeMDBlock = "\n<!-- erun-agents-md-hook -->\n# Agent Instructions\n\nIMPORTANT: Before doing anything else, read `AGENTS.md` in the project root. This is mandatory — do not skip it.\nAlso read `AGENTS.md` in any subdirectory relevant to the task at hand,\nas subdirectories may contain more specific guidance.\n<!-- /erun-agents-md-hook -->\n"
+// claudeMDBlock is erun's managed agent-instructions region for the global
+// CLAUDE.md / Codex instructions file. It is delimited by the open/close markers
+// so it can be rewritten in place on every run: editing this constant updates
+// existing files the next time the CLI runs, not only freshly created ones. Keep
+// it byte-aligned with the in-pod copy in
+// erun-devops/docker/erun-devops/entrypoint.sh.
+const claudeMDBlock = claudeMDOpenMarker + "\n" +
+	"# Agent Instructions\n" +
+	"\n" +
+	"IMPORTANT: Before doing anything else, read `AGENTS.md` in the project root. This is mandatory — do not skip it.\n" +
+	"Also read `AGENTS.md` in any subdirectory relevant to the task at hand,\n" +
+	"as subdirectories may contain more specific guidance.\n" +
+	"\n" +
+	"When the project's structure is explicit — AGENTS.md, documented module boundaries, a named file or function — read the source directly instead of spawning sub-agent searches to rediscover it. Answer the operator's questions before acting; a question is not authorization to begin the work it hints at.\n" +
+	claudeMDCloseMarker + "\n"
 
 func EnsureGlobalAgentInstructions() error {
 	homeDir, err := os.UserHomeDir()
@@ -38,13 +55,40 @@ func ensureAgentInstructionsFile(dir, filename string) error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	if strings.Contains(string(data), claudeMDMarker) {
+	updated := upsertAgentInstructionsBlock(string(data))
+	if updated == string(data) {
 		return nil
 	}
-	content := string(data)
-	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
-		content += "\n"
+	return os.WriteFile(path, []byte(updated), 0o600)
+}
+
+// upsertAgentInstructionsBlock returns content with erun's managed
+// agent-instructions block present and current. An existing block — delimited by
+// the open/close markers — is replaced in place; otherwise the block is appended,
+// separated from any preceding content by one blank line. The result is stable:
+// applying the function to its own output returns it unchanged.
+func upsertAgentInstructionsBlock(content string) string {
+	body := strings.TrimRight(stripAgentInstructionsBlock(content), "\n")
+	if body == "" {
+		return claudeMDBlock
 	}
-	content += claudeMDBlock
-	return os.WriteFile(path, []byte(content), 0o600)
+	return body + "\n\n" + claudeMDBlock
+}
+
+// stripAgentInstructionsBlock removes erun's managed block (markers inclusive)
+// from content, leaving everything outside it untouched. A dangling open marker
+// with no matching close drops everything from the open marker onward so the
+// caller can re-append a clean block.
+func stripAgentInstructionsBlock(content string) string {
+	open := strings.Index(content, claudeMDOpenMarker)
+	if open == -1 {
+		return content
+	}
+	afterOpen := open + len(claudeMDOpenMarker)
+	closeRel := strings.Index(content[afterOpen:], claudeMDCloseMarker)
+	if closeRel == -1 {
+		return content[:open]
+	}
+	end := afterOpen + closeRel + len(claudeMDCloseMarker)
+	return content[:open] + content[end:]
 }

--- a/erun-cli/internal/claude_md_test.go
+++ b/erun-cli/internal/claude_md_test.go
@@ -1,0 +1,62 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUpsertAgentInstructionsBlockAppendsToEmpty(t *testing.T) {
+	got := upsertAgentInstructionsBlock("")
+	if got != claudeMDBlock {
+		t.Fatalf("empty content should produce exactly the block, got:\n%q", got)
+	}
+}
+
+func TestUpsertAgentInstructionsBlockAppendsAfterExistingContent(t *testing.T) {
+	got := upsertAgentInstructionsBlock("# My notes\n")
+	want := "# My notes\n\n" + claudeMDBlock
+	if got != want {
+		t.Fatalf("expected block appended after user content with one blank line, got:\n%q", got)
+	}
+}
+
+func TestUpsertAgentInstructionsBlockIsIdempotent(t *testing.T) {
+	for _, start := range []string{"", "# My notes\n", claudeMDBlock} {
+		once := upsertAgentInstructionsBlock(start)
+		twice := upsertAgentInstructionsBlock(once)
+		if once != twice {
+			t.Fatalf("upsert must be stable on its own output:\nstart:\n%q\nonce:\n%q\ntwice:\n%q", start, once, twice)
+		}
+	}
+}
+
+func TestUpsertAgentInstructionsBlockReplacesStaleBlock(t *testing.T) {
+	stale := "# My notes\n\n" + claudeMDOpenMarker + "\n# Agent Instructions\n\nold guidance\n" + claudeMDCloseMarker + "\n"
+	got := upsertAgentInstructionsBlock(stale)
+	if strings.Contains(got, "old guidance") {
+		t.Fatalf("stale block content must be replaced, got:\n%q", got)
+	}
+	if !strings.Contains(got, "read the source directly") {
+		t.Fatalf("current block content must be present, got:\n%q", got)
+	}
+	if n := strings.Count(got, claudeMDOpenMarker); n != 1 {
+		t.Fatalf("exactly one managed block expected, got %d:\n%q", n, got)
+	}
+	if !strings.HasPrefix(got, "# My notes\n") {
+		t.Fatalf("user content must be preserved, got:\n%q", got)
+	}
+}
+
+func TestUpsertAgentInstructionsBlockRecoversFromDanglingOpenMarker(t *testing.T) {
+	dangling := "# My notes\n\n" + claudeMDOpenMarker + "\n# Agent Instructions\n(no close marker)\n"
+	got := upsertAgentInstructionsBlock(dangling)
+	if n := strings.Count(got, claudeMDOpenMarker); n != 1 {
+		t.Fatalf("expected exactly one open marker, got %d:\n%q", n, got)
+	}
+	if n := strings.Count(got, claudeMDCloseMarker); n != 1 {
+		t.Fatalf("expected exactly one close marker, got %d:\n%q", n, got)
+	}
+	if !strings.HasPrefix(got, "# My notes\n") {
+		t.Fatalf("user content before the dangling marker must be preserved, got:\n%q", got)
+	}
+}

--- a/erun-devops/docker/erun-devops/entrypoint.sh
+++ b/erun-devops/docker/erun-devops/entrypoint.sh
@@ -345,11 +345,17 @@ mcp_url="http://127.0.0.1:${ERUN_MCP_PORT:-17000}${ERUN_MCP_PATH:-/mcp}"
 mkdir -p "${codex_dir}"
 
 codex_instructions="${codex_dir}/instructions.md"
-agents_marker="erun-agents-md-hook"
-if [ ! -f "${codex_instructions}" ] || ! grep -qF "${agents_marker}" "${codex_instructions}" 2>/dev/null; then
-    printf '\n<!-- %s -->\n# Agent Instructions\n\nIMPORTANT: Before doing anything else, read `AGENTS.md` in the project root. This is mandatory — do not skip it.\nAlso read `AGENTS.md` in any subdirectory relevant to the task at hand,\nas subdirectories may contain more specific guidance.\n<!-- /%s -->\n' \
-        "${agents_marker}" "${agents_marker}" >> "${codex_instructions}"
+codex_existing=""
+if [ -f "${codex_instructions}" ]; then
+    codex_existing="$(awk '/<!-- erun-agents-md-hook -->/{skip=1} skip&&/<!-- \/erun-agents-md-hook -->/{skip=0;next} !skip{print}' "${codex_instructions}")"
 fi
+codex_tmp="${codex_instructions}.tmp.$$"
+{
+    if [ -n "${codex_existing}" ]; then
+        printf '%s\n\n' "${codex_existing}"
+    fi
+    printf '<!-- erun-agents-md-hook -->\n# Agent Instructions\n\nIMPORTANT: Before doing anything else, read `AGENTS.md` in the project root. This is mandatory — do not skip it.\nAlso read `AGENTS.md` in any subdirectory relevant to the task at hand,\nas subdirectories may contain more specific guidance.\n\nWhen the project'\''s structure is explicit — AGENTS.md, documented module boundaries, a named file or function — read the source directly instead of spawning sub-agent searches to rediscover it. Answer the operator'\''s questions before acting; a question is not authorization to begin the work it hints at.\n<!-- /erun-agents-md-hook -->\n'
+} > "${codex_tmp}" && mv "${codex_tmp}" "${codex_instructions}"
 
 if [ -d /etc/erun/skills ]; then
     for src_dir in /etc/erun/skills/*/; do
@@ -460,11 +466,17 @@ claude_mcp_url="http://127.0.0.1:${ERUN_MCP_PORT:-17000}${ERUN_MCP_PATH:-/mcp}"
 mkdir -p "${claude_dir}"
 
 claude_md="${claude_dir}/CLAUDE.md"
-agents_marker="erun-agents-md-hook"
-if [ ! -f "${claude_md}" ] || ! grep -qF "${agents_marker}" "${claude_md}" 2>/dev/null; then
-    printf '\n<!-- %s -->\n# Agent Instructions\n\nIMPORTANT: Before doing anything else, read `AGENTS.md` in the project root. This is mandatory — do not skip it.\nAlso read `AGENTS.md` in any subdirectory relevant to the task at hand,\nas subdirectories may contain more specific guidance.\n<!-- /%s -->\n' \
-        "${agents_marker}" "${agents_marker}" >> "${claude_md}"
+claude_existing=""
+if [ -f "${claude_md}" ]; then
+    claude_existing="$(awk '/<!-- erun-agents-md-hook -->/{skip=1} skip&&/<!-- \/erun-agents-md-hook -->/{skip=0;next} !skip{print}' "${claude_md}")"
 fi
+claude_md_tmp="${claude_md}.tmp.$$"
+{
+    if [ -n "${claude_existing}" ]; then
+        printf '%s\n\n' "${claude_existing}"
+    fi
+    printf '<!-- erun-agents-md-hook -->\n# Agent Instructions\n\nIMPORTANT: Before doing anything else, read `AGENTS.md` in the project root. This is mandatory — do not skip it.\nAlso read `AGENTS.md` in any subdirectory relevant to the task at hand,\nas subdirectories may contain more specific guidance.\n\nWhen the project'\''s structure is explicit — AGENTS.md, documented module boundaries, a named file or function — read the source directly instead of spawning sub-agent searches to rediscover it. Answer the operator'\''s questions before acting; a question is not authorization to begin the work it hints at.\n<!-- /erun-agents-md-hook -->\n'
+} > "${claude_md_tmp}" && mv "${claude_md_tmp}" "${claude_md}"
 
 if [ -d /etc/erun/skills ]; then
     for src_dir in /etc/erun/skills/*/; do


### PR DESCRIPTION
## What

erun writes a marked `# Agent Instructions` block (`erun-agents-md-hook`) into `~/.claude/CLAUDE.md` and `~/.codex/instructions.md` so agents read `AGENTS.md` first. Two problems, both fixed here:

1. **Append-if-absent, never updated.** Once the block existed it was never rewritten, so existing environments (the home dir is a persisted PVC) kept stale guidance forever — editing the canonical block only reached fresh installs.
2. **Too thin.** The block only said "read AGENTS.md". It now also carries two tenant-agnostic discipline lines.

## Change

- **Replace-on-change.** Rewrite the marked region in place on every run so edits to the canonical block propagate to existing envs. The upsert is idempotent (applying it to its own output is a no-op) and only ever touches erun's delimited region — anything outside the markers is preserved.
- **Extended content.** Added: *"When the project's structure is explicit — AGENTS.md, documented module boundaries, a named file or function — read the source directly instead of spawning sub-agent searches to rediscover it. Answer the operator's questions before acting; a question is not authorization to begin the work it hints at."*

## Files (one contract)

- `erun-cli/internal/claude_md.go` — new open/close marker constants, `upsertAgentInstructionsBlock` / `stripAgentInstructionsBlock`, extended `claudeMDBlock`; removed the now-dead `claudeMDMarker`. Runs on every CLI invocation via `root_runtime.go`, covering both files.
- `erun-devops/docker/erun-devops/entrypoint.sh` — the claude and codex configure scripts, converted to the same replace-on-change behavior with byte-aligned content.
- `erun-cli/internal/claude_md_test.go` — idempotency unit test (append / replace / dangling-marker / stable-on-own-output).

## Validation

- `make integration-test` green — coverage **77.3% (≥ 75.0%)**. (One transient 30s timeout on the heaviest deploy scenario on the first run under coverage instrumentation; passes in 4.7s in isolation and the full re-run was green — unrelated to this diff, which is not on the deploy path.)
- Go: `gofmt`/`go vet`/`go build` clean; unit tests pass.
- Shell replica of the in-pod logic verified under both `/bin/sh` and `/bin/bash`: idempotent in empty and replace cases, stale block replaced, user content preserved, exactly one open/close marker.

## Rollout note

The `entrypoint.sh` half only takes effect after a runtime-image rebuild + redeploy; the `claude_md.go` half applies on the next CLI run.

## Docs

No `erun-docs` change needed — the managed block is an internal config-maintenance mechanism, not referenced anywhere in `erun-docs`.

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)