### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ profile.cov
 
 .claude
 
+# macOS
+.DS_Store
+
 # Editor/IDE
 .idea/
 # .vscode/


### PR DESCRIPTION
Add a `.DS_Store` pattern to the root `.gitignore` so macOS Finder metadata files are never committed. The pattern matches at any depth, covering the untracked `.DS_Store`, `erun-ui/.DS_Store`, and `erun-ui/frontend/.DS_Store` currently showing in `git status`.

Closes #539