### PR TITLE
Remove dead erun-common functions and fix stale skill template paths

### DIFF
--- a/erun-common/activity.go
+++ b/erun-common/activity.go
@@ -168,14 +168,6 @@ func (c EnvironmentIdleConfig) Resolve() (EnvironmentIdlePolicy, error) {
 	}, nil
 }
 
-func DefaultEnvironmentIdleConfig() EnvironmentIdleConfig {
-	return EnvironmentIdleConfig{
-		Timeout:          DefaultEnvironmentIdleTimeout.String(),
-		WorkingHours:     DefaultEnvironmentWorkingHours,
-		IdleTrafficBytes: DefaultEnvironmentIdleTrafficBytes,
-	}
-}
-
 func ResolveEnvironmentIdleStatus(config EnvironmentIdleConfig, activity map[string]EnvironmentActivitySnapshot, now time.Time) (EnvironmentIdleStatus, error) {
 	policy, err := config.Resolve()
 	if err != nil {

--- a/erun-common/claude.go
+++ b/erun-common/claude.go
@@ -59,10 +59,6 @@ func (c EnvironmentClaudeConfig) NormalizedModels() []string {
 	return normalizeClaudeModels(c.Models)
 }
 
-func ValidateClaudeMaxOutputTokens(value int) bool {
-	return value >= claudeMaxOutputTokensFloor && value <= claudeMaxOutputTokensCeiling
-}
-
 func ClaudeMaxOutputTokensRange() (int, int) {
 	return claudeMaxOutputTokensFloor, claudeMaxOutputTokensCeiling
 }

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -641,10 +641,6 @@ func runtimeChartLockstepPublish(spec DeploySpec) (version string, ok bool) {
 	return "", false
 }
 
-func ResolveDeploySpecForOpenResult(ctx Context, store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, componentName, versionOverride string) (DeploySpec, error) {
-	return resolveDeploySpecForOpenResult(ctx, store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target, componentName, versionOverride, true, false)
-}
-
 func resolveDeploySpecForOpenResult(ctx Context, store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, componentName, versionOverride string, allowLocalBuilds, force bool) (DeploySpec, error) {
 	store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now = normalizeDeployDependencies(store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now)
 	now = freezeNow(now)

--- a/erun-common/linux_package.go
+++ b/erun-common/linux_package.go
@@ -70,25 +70,6 @@ func resolveExplicitLinuxPackageContexts(resolveBuildContext BuildContextResolve
 	return contexts, nil
 }
 
-func ResolveCurrentLinuxReleaseScripts(findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, target DockerCommandTarget, version string) ([]scriptSpec, error) {
-	contexts, err := ResolveCurrentLinuxPackageContexts(findProjectRoot, resolveBuildContext, target)
-	if err != nil {
-		return nil, err
-	}
-
-	scripts := make([]scriptSpec, 0, len(contexts))
-	for _, context := range contexts {
-		if strings.TrimSpace(context.ReleaseScriptPath) == "" {
-			continue
-		}
-		scripts = append(scripts, newScriptSpec(context.Dir, "./release.sh", version))
-	}
-	if len(scripts) == 0 {
-		return nil, ErrLinuxPackageBuildNotFound
-	}
-	return scripts, nil
-}
-
 func ResolveCurrentLinuxPackageContexts(findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, target DockerCommandTarget) ([]LinuxPackageContext, error) {
 	if resolveBuildContext == nil {
 		resolveBuildContext = ResolveDockerBuildContext
@@ -182,53 +163,6 @@ func ResolveLinuxPackageContextsAtDir(dir string) ([]LinuxPackageContext, error)
 		return nil, ErrLinuxPackageBuildNotFound
 	}
 	return contexts, nil
-}
-
-func FindComponentLinuxPackageContext(projectRoot, componentName string) (LinuxPackageContext, bool, error) {
-	projectRoot = filepath.Clean(strings.TrimSpace(projectRoot))
-	componentName = strings.TrimSpace(componentName)
-	if projectRoot == "" || componentName == "" {
-		return LinuxPackageContext{}, false, nil
-	}
-
-	matches := make([]LinuxPackageContext, 0, 1)
-	err := filepath.WalkDir(projectRoot, func(path string, d os.DirEntry, err error) error {
-		context, ok, walkErr := componentLinuxPackageContextCandidate(path, d, componentName, err)
-		if ok {
-			matches = append(matches, context)
-		}
-		return walkErr
-	})
-	if err != nil {
-		return LinuxPackageContext{}, false, err
-	}
-	if len(matches) == 0 {
-		return LinuxPackageContext{}, false, nil
-	}
-	if len(matches) > 1 {
-		return LinuxPackageContext{}, false, fmt.Errorf("multiple linux package contexts found for component %q", componentName)
-	}
-	return matches[0], true, nil
-}
-
-func componentLinuxPackageContextCandidate(path string, d os.DirEntry, componentName string, err error) (LinuxPackageContext, bool, error) {
-	if err != nil {
-		return LinuxPackageContext{}, false, err
-	}
-	if d.IsDir() {
-		if d.Name() == ".git" {
-			return LinuxPackageContext{}, false, filepath.SkipDir
-		}
-		return LinuxPackageContext{}, false, nil
-	}
-	if d.Name() != "build.sh" && d.Name() != "release.sh" {
-		return LinuxPackageContext{}, false, nil
-	}
-	dir := filepath.Dir(path)
-	if filepath.Base(dir) != componentName || filepath.Base(filepath.Dir(dir)) != "linux" {
-		return LinuxPackageContext{}, false, nil
-	}
-	return LinuxPackageContextAtDir(dir)
 }
 
 func resolveCurrentDevopsLinuxDir(findProjectRoot ProjectFinderFunc, dir string, target DockerCommandTarget) (string, bool, error) {

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -557,13 +557,6 @@ func LocalShellSetupScript(result OpenResult) string {
 	return strings.Join(commands, " &&\n") + "\n"
 }
 
-func LaunchShell(req ShellLaunchParams) error {
-	if err := WaitForShellDeployment(req); err != nil {
-		return err
-	}
-	return ExecShell(req)
-}
-
 func WaitForShellDeployment(req ShellLaunchParams) error {
 	if err := runOpenKubectl(kubectlDeploymentWaitArgs(req), io.Discard, os.Stderr); err != nil {
 		return enrichShellDeploymentError(req, err, runOpenKubectl)

--- a/erun-common/registry_versions.go
+++ b/erun-common/registry_versions.go
@@ -387,39 +387,6 @@ func (versions RuntimeRegistryVersions) HasVersion(version string) bool {
 	return slices.Contains(versions.Tags, version)
 }
 
-func RuntimeVersionSuggestions(info BuildInfo, registry RuntimeRegistryVersions) []RuntimeVersionSuggestion {
-	info = NormalizeBuildInfo(info)
-	suggestions := make([]RuntimeVersionSuggestion, 0, 4)
-	addSuggestion := func(label, value string) {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			return
-		}
-		for _, existing := range suggestions {
-			if existing.Version == value {
-				return
-			}
-		}
-		suggestions = append(suggestions, RuntimeVersionSuggestion{
-			Label:   strings.TrimSpace(label),
-			Version: value,
-		})
-	}
-
-	current := strings.TrimSpace(info.Version)
-	latestStable := strings.TrimSpace(registry.LatestStable)
-	stableBase := current
-	if latestStable != "" {
-		stableBase = latestStable
-	}
-
-	addSuggestion("Current", current)
-	addSuggestion("Latest stable", latestStable)
-	addSuggestion("Previous", previousPatchVersion(stableBase))
-	addSuggestion("Last snapshot", registry.LatestSnapshot)
-	return suggestions
-}
-
 func RuntimeDeployVersionSuggestions(info BuildInfo, registry RuntimeRegistryVersions) []RuntimeVersionSuggestion {
 	info = NormalizeBuildInfo(info)
 	suggestions := make([]RuntimeVersionSuggestion, 0, 4)

--- a/erun-skills/skills/erun-blueprint-api/SKILL.md
+++ b/erun-skills/skills/erun-blueprint-api/SKILL.md
@@ -145,7 +145,7 @@ Repositories never accept `tenant_id` as an argument. Instead,
 context from the authenticated context:
 
 ```go
-// Sketch — see templates/repository/tx.go.tmpl for the full version.
+// Sketch — see templates/repository_tx.go.tmpl for the full version.
 func (tm *TxManager) WithTx(ctx context.Context, fn func(*bun.Tx) error) error {
     sec, err := SecurityFromContext(ctx)
     if err != nil {

--- a/erun-skills/skills/erun-blueprint-rls-db/SKILL.md
+++ b/erun-skills/skills/erun-blueprint-rls-db/SKILL.md
@@ -177,11 +177,13 @@ Copy the reference files verbatim, substituting placeholders:
 - `templates/tables/tenant_issuers.sql` → `${module}/schema/tables/tenant_issuers.sql`
 - `templates/tables/users.sql` → `${module}/schema/tables/users.sql`
 - `templates/tables/user_external_ids.sql` → `${module}/schema/tables/user_external_ids.sql`
-- `templates/indexes/tenant_issuers.sql` → `${module}/schema/indexes/tenant_issuers.sql`
 - `templates/indexes/users.sql` → `${module}/schema/indexes/users.sql`
 - `templates/indexes/user_external_ids.sql` → `${module}/schema/indexes/user_external_ids.sql`
 - `templates/triggers/tenants_set_timestamps.sql` → `${module}/schema/triggers/tenants_set_timestamps.sql`
+- `templates/triggers/tenant_issuers_set_timestamps.sql` → `${module}/schema/triggers/tenant_issuers_set_timestamps.sql`
 - `templates/triggers/users_set_timestamps.sql` → `${module}/schema/triggers/users_set_timestamps.sql`
+- `templates/triggers/user_external_ids_set_timestamps.sql` → `${module}/schema/triggers/user_external_ids_set_timestamps.sql`
+- `templates/rls/context.sql` → `${module}/schema/rls/context.sql`
 - `templates/rls/users.sql` → `${module}/schema/rls/users.sql`
 - `templates/rls/user_external_ids.sql` → `${module}/schema/rls/user_external_ids.sql`
 - `templates/AGENTS.md` → `${module}/AGENTS.md`


### PR DESCRIPTION
Part of #541 (second slice; the umbrella issue stays open for the remaining `erun-ui` dead helpers and the #376 legacy-field removal).

## Dead code (erun-common)
Removed functions verified to have **no caller in any module** (cross-checked against `erun-cli`/`erun-mcp`/`erun-ui`/`erun-backend`/`erun-integration`, not just the integration binary):
- `ResolveDeploySpecForOpenResult` (public wrapper; the private impl stays — it's used by `resolveOpenRuntimeDeploySpec`)
- `LaunchShell`, `DefaultEnvironmentIdleConfig`, `ValidateClaudeMaxOutputTokens`, `RuntimeVersionSuggestions`, `ResolveCurrentLinuxReleaseScripts`, `FindComponentLinuxPackageContext` (+ its only-callee `componentLinuxPackageContextCandidate`)

Kept the siblings that **are** live in `erun-ui` (`ClaudeMaxOutputTokensRange`, `RuntimeDeployVersionSuggestions`, `previousPatchVersion`, `HasVersion`) — the broad audit list conflated "erun-cli-unreachable" with "dead", so each was re-verified per-symbol.

## Stale skill template paths
- `erun-blueprint-rls-db/SKILL.md`: the Step 3 copy list listed a nonexistent `indexes/tenant_issuers.sql` and omitted three real bootstrap files (`rls/context.sql`, `triggers/tenant_issuers_set_timestamps.sql`, `triggers/user_external_ids_set_timestamps.sql`) — a generated module would have been missing its RLS context function and two tables' timestamp triggers. Fixed to match the actual templates.
- `erun-blueprint-api/SKILL.md`: sketch comment pointed at `templates/repository/tx.go.tmpl`; corrected to the real `templates/repository_tx.go.tmpl`.

## Validation
- `go build ./...` green across erun-common/cli/mcp/ui; `go test ./...` (erun-common) green.
- `make integration-test` green — coverage **78.0%** (≥ 75% threshold), up from 77.6% (the removed funcs were uncovered dead code); dry-run goldens unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)