### PR TITLE
Capture repo guidance in AGENTS.md, not assistant memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Repository guidance for humans and coding agents working in this repo. This file
 - Each module-guidance `AGENTS.md` directory ships a `CLAUDE.md` symlink pointing to its `AGENTS.md` so Claude Code auto-loads the local guidance when launched from any subtree. Treat both names as the same file; only edit `AGENTS.md` directly.
 - **"Documentation" in agent-facing instructions means `AGENTS.md`** (this file plus every applicable subtree `AGENTS.md`). When the user says "read documentation", re-read the relevant `AGENTS.md` files end-to-end; do not substitute `erun-docs/` for that step. When the user says "update documentation", edit the nearest applicable `AGENTS.md`. `erun-docs/` is the public product documentation site — a separate concern with its own update workflow, owned by the `erun-docs/AGENTS.md` rules. Read it only when its content is the load-bearing reference for an investigation; do not treat it as the source of repo workflow or engineering guidance.
 - Do not add new documentation files unless the user explicitly asks for them; add repository instructions to `AGENTS.md` instead.
+- Capture repository guidance, conventions, and best practices in the appropriate `AGENTS.md` — the shared, tool-agnostic source of truth every human and agent reads. Do not use a coding assistant's own private memory or notes feature (for example Claude Code's memory) to persist repo guidance or best practices; that hides them from everyone not using that tool. When you learn something worth keeping as repo guidance, propose adding it to the relevant `AGENTS.md` instead.
 - Keep `AGENTS.md` focused on repository workflow and engineering guidance; do not document app behavior, command semantics, or end-user functionality in it.
 - Do not modify `README.md` unless the user explicitly asks for a README change.
 
@@ -85,6 +86,10 @@ Internal ownership and per-module conventions live in each module's `AGENTS.md`.
 - Prefer deterministic command behavior so tool calls are safe to run repeatedly and concurrently.
 - Prefer safety and clarity over micro-optimizations.
 - For documentation-only guidance changes, do not change app behavior. Update the nearest applicable `AGENTS.md` and validate by reviewing the edited guidance for consistency.
+- Fix lint findings by correcting the code; never disable, suppress, downgrade, or threshold-bump a lint rule.
+- Clarify design and trade-offs in prose conversation; don't batch shaping decisions into rigid question-forms.
+- When delegating analysis to sub-agents, use a capable model — not a lightweight locator model — for substantive reasoning.
+- Once the user authorizes a body of work (e.g. "do it all" / "carry on"), carry it through to completion across commits and PRs without re-asking permission between increments; surface only genuine blockers. This does not license unrequested expansion — still get plan sign-off before multi-module or public-surface diffs the user did not ask for.
 
 ## End-to-End Verification Gate (Mandatory)
 

--- a/erun-devops/AGENTS.md
+++ b/erun-devops/AGENTS.md
@@ -66,6 +66,7 @@ Additional guidance for `erun-devops` and its subtree.
   - after a successful stable release, the next patch version is prepared for subsequent work
 - Candidate releases use candidate version tags and still rely on the same shared release/build orchestration.
 - When changing release behavior, validate the repository-wide flow, not only this subtree. At minimum run the release-sensitive suites in `erun-common`, `erun-cli`, and `erun-mcp`.
+- Non-erun tenant deploys consume the **published** `erun-devops` image and chart from the registry; to land a runtime change in a tenant, publish it from the `erun` tenant first (build/release + push), then deploy the tenant.
 
 ## Version and Metadata Rules
 

--- a/erun-skills/AGENTS.md
+++ b/erun-skills/AGENTS.md
@@ -46,6 +46,8 @@ erun-skills/
 - Reference tools that are reliably present in both contexts (`gh`, `git`, `curl`) or check before use. Do not assume `kubectl`, `helm`, or `erun` are on PATH on a laptop.
 - Trigger the skill on **user intent**, not on individual mechanical steps. One workflow → one skill, not three sub-skills the user has to chain.
 - Keep skill bodies short. The body is loaded only when the skill fires; long bodies are fine when needed, but every line should be doing work — no "best practices" filler.
+- Two skill kinds: **Blueprint** (packages best practices plus a blueprint for building something) and **Workflow** (drives an ERun process, e.g. `erun-file-issue`, `erun-contribute`). Frame Blueprint skills as best-practices-plus-blueprints — never as "scaffolding" or "templates".
+- The `erun-contribute` workflow creates a **new** issue and PR (create-issue → implement → PR); it is not for working an already-open ticket.
 
 ## Editing skills
 

--- a/erun-ui/AGENTS.md
+++ b/erun-ui/AGENTS.md
@@ -11,6 +11,8 @@ Module-specific guidance for `erun-ui`. Follow the repository root `AGENTS.md` f
 ## Frontend And Backend Split
 
 - Keep Wails startup, native window integration, PTY management, process execution, and session lifecycle in Go.
+- Desktop terminal sessions are one per pod per tab id: opening an env in any window takes over the existing pod session (`screen -d -r`), never mirrors. Preserve this invariant.
+- Diagnostics and error capture must be always-on and bounded — never gated behind an opt-in the user discovers only after an error has happened.
 - Keep layout, interaction behavior, DOM state, and terminal presentation in the frontend source tree.
 - Keep terminal session ownership in Go. The frontend should attach to sessions by ID, render buffered output, and send input, but it should not start shells on its own.
 - Prefer small transport-facing Go methods with JSON-safe structs over leaking backend internals into the frontend contract.

--- a/erun-ui/playwright/AGENTS.md
+++ b/erun-ui/playwright/AGENTS.md
@@ -73,6 +73,7 @@ There is only one supported way to run the suite. The shell script `run.sh` in t
 - The Cancel buttons on `Init` and `Manage` dialogs sit below the default 900 px viewport. The config uses `1440x1200`; keep tall-dialog tests on that viewport rather than shrinking it.
 - The headless backend is a singleton; `playwright.config.ts` sets `fullyParallel: false` and `workers: 1`. Keep it that way unless you split the backend into per-test processes. Each test gets a fresh browser context (fresh Redux state), but backend-side sessions persist across specs — prefer the `seededEnv` fixture for specs whose tab/session churn would otherwise leak into the shared baseline rows.
 - Treat assertion failures as bugs to investigate, not noise to skip. If a test reveals a real frontend regression, fix the frontend; if a flow is genuinely flaky and the cause is environmental (clock skew, port reuse), fix the harness. Use `test.fixme(...)` only with a justification in a comment and a follow-up issue.
+- Some env-open specs can be host-environment-flaky. Before treating such a red as a regression you introduced, rebuild from `main` and re-run the focused spec to confirm it is pre-existing rather than caused by your change (tracked in #525).
 
 ## Validation
 


### PR DESCRIPTION
Part of #541.

## New rule
Root `AGENTS.md` now states: capture repository guidance/conventions/best practices in the appropriate `AGENTS.md` (the shared, tool-agnostic source of truth), **not** in a coding assistant's own private memory feature (e.g. Claude Code's memory) — that hides them from anyone not using that tool. Propose new guidance for the relevant `AGENTS.md` instead.

## Migrated accumulated guidance into the right AGENTS.md (compressed)
- **root** (Working Rules): fix-the-code-not-the-lint-rule; clarify design in prose not rigid question-forms; use a capable model for sub-agent analysis; once a body of work is authorized ("do it all"/"carry on"), carry it through across commits/PRs without re-asking — while still getting sign-off before *unrequested* multi-module/public-surface expansion.
- **erun-skills**: the two skill kinds (Blueprint vs Workflow) and never calling Blueprint skills "scaffolding"/"templates"; `erun-contribute` creates a new issue+PR, not work on an existing ticket.
- **erun-devops**: non-erun tenant deploys consume the published image+chart; publish from the `erun` tenant first.
- **erun-ui**: the one-session-per-pod-per-tab takeover invariant; diagnostics/error capture must be always-on and bounded.
- **erun-ui/playwright**: confirm a flaky env-open red is pre-existing (rebuild from main, focused re-run) before treating it as your regression (#525).

The corresponding entries were removed from the assistant's local memory store so `AGENTS.md` is the single source of truth.

## Validation
AGENTS.md-only documentation changes; no app behaviour, no build/test gate. Reviewed for cross-reference consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)