### PR TITLE
Remove dead erun-ui helpers

### DIFF
--- a/erun-ui/activity_queue.go
+++ b/erun-ui/activity_queue.go
@@ -129,8 +129,7 @@ type activityQueueStore struct {
 	// snapshots the tail into entry.Detail when the entry fails and drops the
 	// buffer. Not persisted and not part of the frontend snapshot — only the
 	// derived Detail crosses the wire.
-	outputByID      map[string][]string
-	closeNotifyOnce sync.Once
+	outputByID map[string][]string
 }
 
 // activityQueueHistoryCapacity caps in-memory history length so the
@@ -168,23 +167,16 @@ func newActivityQueueStore(notify func(activityQueueEntry), now func() time.Time
 	return s
 }
 
-// runNotifyLoop drains notifyCh in order, calling notify per snapshot.
-// Exits when notifyCh is closed (closeNotifyLoop, called from App
-// shutdown). A nil notify drains silently so unit tests that don't
-// wire a notifier don't accumulate snapshots in the buffer.
+// runNotifyLoop drains notifyCh in order, calling notify per snapshot,
+// for the lifetime of the store. A nil notify drains silently so unit
+// tests that don't wire a notifier don't accumulate snapshots in the
+// buffer.
 func (s *activityQueueStore) runNotifyLoop() {
 	for snapshot := range s.notifyCh {
 		if s.notify != nil {
 			s.notify(snapshot)
 		}
 	}
-}
-
-// closeNotifyLoop terminates the drain goroutine. Idempotent.
-func (s *activityQueueStore) closeNotifyLoop() {
-	s.closeNotifyOnce.Do(func() {
-		close(s.notifyCh)
-	})
 }
 
 // list returns a chronological snapshot (newest first) of every tracked
@@ -216,23 +208,6 @@ func (s *activityQueueStore) findActiveByCommand(command, tenant, environment st
 	defer s.mu.Unlock()
 	for _, entry := range s.active {
 		if entry.Command == command && entry.Tenant == tenant && entry.Environment == environment {
-			return *cloneActivityQueueEntry(entry), true
-		}
-	}
-	return activityQueueEntry{}, false
-}
-
-// findRunning returns the first running (status=running) entry matching
-// the predicate. Used for terminal-lock decisions, which only fire on
-// running deploys.
-func (s *activityQueueStore) findRunning(tenant, environment string) (activityQueueEntry, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for _, entry := range s.active {
-		if entry.Status != activityQueueStatusRunning {
-			continue
-		}
-		if entry.Tenant == tenant && entry.Environment == environment {
 			return *cloneActivityQueueEntry(entry), true
 		}
 	}

--- a/erun-ui/cloud_credentials_refresher.go
+++ b/erun-ui/cloud_credentials_refresher.go
@@ -231,13 +231,3 @@ func sleepWithCancel(ctx context.Context, d time.Duration) bool {
 		return true
 	}
 }
-
-// credentialRefresherRunning reports whether a refresher is currently tracked
-// for the selection. Exposed for tests.
-func (a *App) credentialRefresherRunning(selection uiSelection) bool {
-	key := a.cloudCredentialsRefresherKey(normalizeSelection(selection))
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	_, ok := a.credentialRefreshers[key]
-	return ok
-}

--- a/erun-ui/contribute_mode.go
+++ b/erun-ui/contribute_mode.go
@@ -133,15 +133,6 @@ func (a *App) runEnsureErunClone(selection uiSelection) error {
 	return nil
 }
 
-// uiContributeSnapshot returns the persisted contribute flags so the
-// initial state payload can rehydrate per-env toggle state on app boot.
-func (a *App) uiContributeSnapshot() map[string]bool {
-	if a.contribute == nil {
-		return map[string]bool{}
-	}
-	return a.contribute.snapshot()
-}
-
 // StartContributeApp is the Wails-exposed entrypoint for the "Open
 // contribute app" affordance. It boots `erun app --headless --port N`
 // inside the env's ERun (contribute) tab, brings up a kubectl

--- a/erun-ui/contribute_state.go
+++ b/erun-ui/contribute_state.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"sort"
-	"strings"
 	"sync"
 )
 
@@ -101,15 +99,6 @@ func (s *contributeStore) set(selection uiSelection, on bool) {
 	s.mu.Unlock()
 }
 
-// snapshot returns a copy of the persisted flag map keyed by
-// "<tenant>/<env>" so callers (e.g. initial state assembly) can pass it
-// to the frontend without exposing internal locking.
-func (s *contributeStore) snapshot() map[string]bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return cloneContributeFlags(s.data.Flags)
-}
-
 func cloneContributeFlags(in map[string]bool) map[string]bool {
 	out := make(map[string]bool, len(in))
 	for k, v := range in {
@@ -123,21 +112,4 @@ func cloneContributeFlags(in map[string]bool) map[string]bool {
 func contributeFlagKey(selection uiSelection) string {
 	selection = normalizeSelection(selection)
 	return selection.Tenant + "/" + selection.Environment
-}
-
-// sortedContributeKeys returns the persisted env keys in deterministic
-// order for tests / logging.
-func sortedContributeKeys(in map[string]bool) []string {
-	keys := make([]string, 0, len(in))
-	for k, v := range in {
-		if !v {
-			continue
-		}
-		if strings.TrimSpace(k) == "" {
-			continue
-		}
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }

--- a/erun-ui/notifications_test.go
+++ b/erun-ui/notifications_test.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"testing"
-	"time"
 )
 
 // TestEmitAppNotificationDropsEmptyMessage locks the contract that the
@@ -56,41 +54,3 @@ func TestEmitAppNotificationCarriesKindAndMessage(t *testing.T) {
 // `erun activity record-stop` writes the history entry) and by the
 // Playwright spec (which mocks the MCP response and renders the
 // History tab).
-
-func waitForAppNotification(emits *capturedEmits, timeout time.Duration) (appNotificationPayload, error) {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		events := emits.events(appNotificationEvent)
-		for _, evt := range events {
-			payload, ok := evt.(appNotificationPayload)
-			if !ok {
-				continue
-			}
-			return payload, nil
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return appNotificationPayload{}, fmt.Errorf("timed out waiting for app-notification emit")
-}
-
-// waitForAppNotificationByKind returns the first notification whose
-// Kind matches the requested string. Lets a test that arms the
-// grace-period warning (kind="warning") still find the later
-// success (kind="info") without false-matching the earlier one.
-func waitForAppNotificationByKind(emits *capturedEmits, kind string, timeout time.Duration) (appNotificationPayload, error) {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		events := emits.events(appNotificationEvent)
-		for _, evt := range events {
-			payload, ok := evt.(appNotificationPayload)
-			if !ok {
-				continue
-			}
-			if payload.Kind == kind {
-				return payload, nil
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return appNotificationPayload{}, fmt.Errorf("timed out waiting for app-notification emit with kind=%q", kind)
-}

--- a/erun-ui/runtime_resources.go
+++ b/erun-ui/runtime_resources.go
@@ -174,10 +174,6 @@ type runtimeResourceTotals struct {
 	MemoryMi int64
 }
 
-func cpuMetric(totalMilli, usedMilli int64) uiRuntimeResourceMetric {
-	return cpuMetricWithMinimumFree(totalMilli, usedMilli, 0)
-}
-
 func cpuMetricWithMinimumFree(totalMilli, usedMilli, minimumFreeMilli int64) uiRuntimeResourceMetric {
 	freeMilli := totalMilli - usedMilli
 	if freeMilli < 0 {
@@ -200,10 +196,6 @@ func formatRuntimeResourceCPU(milli int64) string {
 		return "0"
 	}
 	return eruncommon.FormatKubernetesCPUFromMilli(milli)
-}
-
-func memoryMetric(totalMi, usedMi int64) uiRuntimeResourceMetric {
-	return memoryMetricWithMinimumFree(totalMi, usedMi, 0)
 }
 
 func memoryMetricWithMinimumFree(totalMi, usedMi, minimumFreeMi int64) uiRuntimeResourceMetric {

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -569,70 +569,6 @@ func (a *App) DeleteEnvironment(selection uiSelection, confirmation string) (del
 	}, nil
 }
 
-func (a *App) startCommandSession(selection uiSelection, cols, rows int, key string, args []string, dir string, env []string) (startSessionResult, error) {
-	return a.startCommandSessionWithExecutable(selection, cols, rows, key, a.deps.resolveCLIPath(), args, dir, env)
-}
-
-func (a *App) startCommandSessionWithExecutable(selection uiSelection, cols, rows int, key string, executable string, args []string, dir string, env []string) (startSessionResult, error) {
-	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return startSessionResult{}, fmt.Errorf("tenant and environment are required")
-	}
-	if cols <= 0 {
-		cols = 120
-	}
-	if rows <= 0 {
-		rows = 34
-	}
-
-	a.mu.Lock()
-	if existing := a.sessions[key]; existing != nil && !existing.closed && existing.session != nil {
-		a.mu.Unlock()
-		return startSessionResult{
-			SessionID: existing.serial,
-			Selection: existing.selection,
-		}, nil
-	}
-	a.mu.Unlock()
-
-	session, err := a.deps.startTerminal(startTerminalSessionParams{
-		Dir:        dir,
-		Executable: executable,
-		Args:       args,
-		Env:        env,
-		Cols:       cols,
-		Rows:       rows,
-	})
-	if err != nil {
-		return startSessionResult{}, err
-	}
-
-	a.mu.Lock()
-	a.nextSerial++
-	serial := a.nextSerial
-	managed := &managedTerminal{
-		session:        session,
-		selection:      selection,
-		key:            key,
-		serial:         serial,
-		kind:           sessionKindCommand,
-		blocksIdleStop: true,
-		startedAt:      time.Now(),
-	}
-	a.sessions[key] = managed
-	a.busyEnvs[selectionKey(selection)]++
-	a.mu.Unlock()
-
-	a.recordTerminalActivity(selection)
-	a.rememberKubeContextForActivity(selection.KubernetesContext)
-	go a.streamSession(managed)
-
-	return startSessionResult{
-		SessionID: serial,
-		Selection: selection,
-	}, nil
-}
-
 func (a *App) SendSessionInput(sessionID int, data string) error {
 	if data == "" {
 		return nil
@@ -1617,15 +1553,6 @@ func (a *App) closeSessionsForSelection(selection uiSelection) {
 	}
 }
 
-func resolveInitStartDir(findProjectRoot eruncommon.ProjectFinderFunc) string {
-	if findProjectRoot != nil {
-		if _, projectRoot, err := findProjectRoot(); err == nil && strings.TrimSpace(projectRoot) != "" {
-			return resolveTerminalStartDir(projectRoot)
-		}
-	}
-	return resolveTerminalStartDir("")
-}
-
 type managedTerminal struct {
 	session                terminalSession
 	selection              uiSelection
@@ -1800,22 +1727,3 @@ func (a *App) releaseIdleBlockLocked(managed *managedTerminal) {
 	managed.clearIdleBlockOnOutput = false
 }
 
-func initSelectionKey(selection uiSelection) string {
-	selection = normalizeSelection(selection)
-	return "init\x00" + selection.Tenant + "\x00" + selection.Environment + "\x00" + selection.Version + "\x00" + selection.RuntimeImage + "\x00" + selection.RuntimeCPU + "\x00" + selection.RuntimeMemory + "\x00" + selection.KubernetesContext + "\x00" + selection.ContainerRegistry + "\x00" + fmt.Sprintf("%t", selection.SetDefaultTenant) + "\x00" + fmt.Sprintf("%t", selection.NoGit)
-}
-
-func deploySelectionKey(selection uiSelection) string {
-	selection = normalizeSelection(selection)
-	return "deploy\x00" + selection.Tenant + "\x00" + selection.Environment + "\x00" + selection.Version + "\x00" + selection.RuntimeImage
-}
-
-func sshdInitSelectionKey(selection uiSelection) string {
-	selection = normalizeSelection(selection)
-	return "sshd-init\x00" + selection.Tenant + "\x00" + selection.Environment
-}
-
-func doctorSelectionKey(selection uiSelection) string {
-	selection = normalizeSelection(selection)
-	return "doctor\x00" + selection.Tenant + "\x00" + selection.Environment
-}


### PR DESCRIPTION
Part of #541.

Removes `deadcode`-confirmed unreachable code from `erun-ui` (all unexported, none Wails-bound):

- `terminal_sessions.go`: `startCommandSession` + `startCommandSessionWithExecutable`, `resolveInitStartDir`, and the `init`/`deploy`/`sshd-init`/`doctor` `*SelectionKey` helpers.
- `activity_queue.go`: `closeNotifyLoop` + `findRunning`, and the now-orphaned `closeNotifyOnce` field (its only user was `closeNotifyLoop`); `runNotifyLoop`'s comment updated to drop the dangling reference.
- `cloud_credentials_refresher.go`: `credentialRefresherRunning`.
- `contribute_mode.go` / `contribute_state.go`: `uiContributeSnapshot`, `contributeStore.snapshot`, `sortedContributeKeys` (+ the now-unused `sort`/`strings` imports).
- `runtime_resources.go`: the zero-minimum `cpuMetric` / `memoryMetric` wrappers (the `*WithMinimumFree` variants they wrapped stay — they're live).
- `notifications_test.go`: the two orphaned `waitForAppNotification*` helpers left behind when their test moved to integration/Playwright (#411); kept the `// Note:` tombstone that records why.

Shared callees (`cpuMetricWithMinimumFree`, `cloneContributeFlags`, `normalizeSelection`, `cloneActivityQueueEntry`, `RuntimeDeployVersionSuggestions`, etc.) are live and untouched.

## Validation
- `go build ./...`, `go vet ./...`, `go test ./...` green (erun-ui + headlessserver); `deadcode -test ./...` clean afterward.
- Pure dead-code removal with zero observable UI surface, so Playwright is skipped per `erun-ui/AGENTS.md` (the "zero observable surface" exemption). Not in the integration coverage gate (erun-cli/erun-common only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)