### PR TITLE
Exclude erun-docs build artifacts from the docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -43,5 +43,16 @@ __debug_bin*
 /erun-ui/frontend/dist
 /erun-ui/frontend/wailsjs
 
+# Docs site dependencies and build outputs. The erun-docs image runs
+# `yarn install` + `yarn build` inside its Dockerfile, so these are
+# regenerated in-image and must never enter the build context: they bloat it
+# (~1GB of node_modules alone) and, because the build only honours this root
+# .dockerignore while the fingerprint also honours erun-docs/.gitignore, their
+# presence diverges the real context from the fingerprint.
+/erun-docs/node_modules
+/erun-docs/build
+/erun-docs/.docusaurus
+/erun-docs/.cache-loader
+
 # Env files
 .env

--- a/erun-common/dockerignore_build_context_test.go
+++ b/erun-common/dockerignore_build_context_test.go
@@ -1,0 +1,78 @@
+package eruncommon
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// repoRootForDockerignoreTest resolves the repository root from this test
+// file's own location. erun-common is a direct child of the repo root, so the
+// grandparent of this file is the root regardless of the working directory the
+// test runs from.
+func repoRootForDockerignoreTest(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Dir(filepath.Dir(file))
+}
+
+// TestRootDockerignoreExcludesDocsBuildArtifacts locks the fix for the
+// erun-docs build failure: the erun-docs image runs `yarn install` +
+// `yarn build` inside its Dockerfile, so node_modules/, build/, and
+// .docusaurus/ are regenerated in-image and must never enter the build
+// context.
+//
+// The real `docker build` only honours the context-root .dockerignore — it
+// does NOT read erun-docs/.gitignore — so these directories must be excluded
+// here. computeBuildFingerprint, by contrast, also honours nested .gitignore
+// files (loadNestedGitignores), so it already drops them from the hash. That
+// asymmetry is the bug: a fingerprint that excludes content the real context
+// still ships diverges the two, bloats the context (~1GB of node_modules), and
+// — depending on the daemon's state — can fail the build outright.
+//
+// This cannot be exercised from the integration subprocess harness: it has no
+// real docker daemon, and the fingerprint excludes these dirs whether or not
+// the root .dockerignore does, so only a direct check of the parsed root
+// .dockerignore can catch the divergence.
+func TestRootDockerignoreExcludesDocsBuildArtifacts(t *testing.T) {
+	root := repoRootForDockerignoreTest(t)
+	data, err := os.ReadFile(filepath.Join(root, ".dockerignore"))
+	if err != nil {
+		t.Fatalf("read root .dockerignore: %v", err)
+	}
+	// base "" mirrors how docker (and loadContextIgnoreSet for the root file)
+	// treats the context-root .dockerignore.
+	set := parseIgnoreData(data, "")
+
+	excludedDirs := []string{
+		"erun-docs/node_modules",
+		"erun-docs/build",
+		"erun-docs/.docusaurus",
+	}
+	for _, dir := range excludedDirs {
+		if !set.matches(dir, true) {
+			t.Errorf("root .dockerignore must exclude %q from the build context (regenerated in-image by the erun-docs Dockerfile)", dir)
+		}
+		// docker walks the tree, so files beneath the directory must drop too.
+		if !set.matches(dir+"/index.js", false) {
+			t.Errorf("root .dockerignore must exclude files under %q", dir)
+		}
+	}
+
+	// The sources the erun-docs Dockerfile actually copies must survive.
+	kept := []string{
+		"erun-docs/package.json",
+		"erun-docs/yarn.lock",
+		"erun-docs/docusaurus.config.ts",
+		"erun-docs/docs/intro.md",
+	}
+	for _, path := range kept {
+		if set.matches(path, false) {
+			t.Errorf("root .dockerignore must NOT exclude %q (the erun-docs Dockerfile copies it)", path)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`erun build` fails when the `erun-docs` image needs a rebuild (its fingerprint isn't cached locally):

```
rebuilding ghcr.io/sophium/erun-docs:... because fingerprint image is missing
Dockerfile:17
  17 | >>> COPY erun-docs /src/erun-docs
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref ...: "/erun-docs": not found
```

It fails in ~3s during BuildKit's context-resolution phase, before `yarn` runs. The image normally promotes from a cached `fp-` tag, so this only surfaces when an `erun-docs` content change forces a real rebuild.

## Root cause

The real `docker build` context diverged from the build fingerprint:

- `computeBuildFingerprint` (`erun-common/build_incremental.go`) honors **nested** `.gitignore` files (`loadNestedGitignores`), so `erun-docs/{node_modules,build,.docusaurus}` are excluded from the hash.
- The real `docker build -f … .` (context = repo root) only honors the **root `.dockerignore`**, which had entries for `erun-ui` but **none for `erun-docs`**.

So those regenerated dirs entered the real context (**measured at ~1.16 GB**) while the fingerprint assumed they were absent. On a constrained dind daemon (the runtime pod) that oversized/inconsistent context fails the whole-directory `COPY erun-docs`.

## Fix

- `.dockerignore`: add `/erun-docs/{node_modules,build,.docusaurus,.cache-loader}`, mirroring the existing `erun-ui` block and the dirs `erun-docs/.gitignore` already lists.
- `erun-common/dockerignore_build_context_test.go`: regression test asserting the root `.dockerignore` excludes those dirs but keeps the real `COPY` sources. This can't be caught by the integration suite (no real docker daemon, and the fingerprint excludes these dirs regardless), so it's a unit-test concern.

The fingerprint is **unchanged** (it already excluded these via the nested `.gitignore`), so cached promotion of `fp-…` keeps working.

## Verification

- Rebuilt the docs image with the fix: context dropped **1.16 GB → 7.53 kB**, the previously-failing `COPY erun-docs` succeeded, `yarn build` completed, image built.
- New test passes; confirmed it fails against a pre-fix `.dockerignore`.
- `go vet` + full `erun-common` suite green.
- `make integration-test` green (78.0% ≥ 75.0%, no golden drift).

Docs: behavior-preserving build-hygiene fix — no `erun-docs/` product-docs change needed.

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)