### PR TITLE
Resolve ${ERUN_VERSION} wrapper base per-arch in local builds

### DIFF
--- a/erun-common/build_docker_commands.go
+++ b/erun-common/build_docker_commands.go
@@ -85,22 +85,33 @@ func tagFingerprintAfterBuild(buildInput DockerBuildSpec, platform string, stdou
 	return runDockerTag(sourceTag, target, stdout, stderr)
 }
 
-// tagStableBaseVersionAfterBuild re-tags the platform-suffixed snapshot
-// image as the unsuffixed BaseVersion tag so wrapper builds whose
-// Dockerfiles reference `FROM image:${ERUN_VERSION}` can resolve a base
-// image locally without hitting the registry. Each platform's iteration
-// overwrites the previous one's tag; for a multi-platform build the last
-// platform iterated wins, which is acceptable because Docker BuildKit will
-// emulate cross-platform when the local FROM target's arch does not match
-// the requested --platform. Returns nil when BaseVersion is empty (release
-// builds whose Version already equals the stable tag) or when the source
-// and target tags are identical.
+// tagStableBaseVersionAfterBuild re-tags the platform-suffixed snapshot image
+// under the stable BaseVersion tags that `FROM image:${ERUN_VERSION}` wrappers
+// resolve from the local daemon (the snapshot tag is never pushed). It writes
+// two tags per platform:
+//
+//   - a per-arch tag, e.g. erun-devops:1.0.90-snapshot-amd64 — what a wrapper
+//     resolves for that platform (see dockerBuildArgs), so a multi-platform
+//     wrapper build always finds the matching architecture locally.
+//   - the arch-less tag, e.g. erun-devops:1.0.90-snapshot, kept for any
+//     consumer that references the bare BaseVersion. It is overwritten per
+//     platform (last arch wins) and is therefore single-arch, which is exactly
+//     why wrappers must use the per-arch tag instead.
+//
+// Returns nil when BaseVersion is empty (release builds, whose Version equals
+// the stable tag — those resolve the base from its pushed multi-arch manifest,
+// not from a local tag).
 func tagStableBaseVersionAfterBuild(buildInput DockerBuildSpec, platform string, stdout, stderr io.Writer) error {
 	target := stableBaseVersionTag(buildInput.Image)
 	if target == "" {
 		return nil
 	}
 	sourceTag := platformSuffixedTag(buildInput.Image.Tag, platform)
+	if archTarget := platformSuffixedTag(target, platform); archTarget != sourceTag {
+		if err := runDockerTag(sourceTag, archTarget, stdout, stderr); err != nil {
+			return err
+		}
+	}
 	if sourceTag == target {
 		return nil
 	}
@@ -343,6 +354,18 @@ func dockerBuildArgs(buildInput DockerBuildSpec, platform string) []string {
 	buildArgVersion := dockerImageTagVersion(strings.TrimSpace(buildInput.Image.Tag))
 	if buildInput.Image.BaseVersion != "" {
 		buildArgVersion = buildInput.Image.BaseVersion
+		// A wrapper that resolves its base via ${ERUN_VERSION} must point at the
+		// base's per-arch stable tag (e.g. erun-devops:1.0.90-snapshot-amd64).
+		// The arch-less stable tag names only the last arch built, so a
+		// multi-platform wrapper build would otherwise resolve the wrong arch
+		// (and, on a strict image store, fail "not found"). The base publishes
+		// the matching <BaseVersion>-<arch> tag in tagStableBaseVersionAfterBuild.
+		// Only the snapshot path needs this — a release wrapper resolves its base
+		// from the base's pushed multi-arch manifest, so BaseVersion is empty and
+		// this branch is skipped.
+		if dockerfileHasVersionedFrom(buildInput.DockerfilePath) {
+			buildArgVersion = buildArgVersion + "-" + platformShortSuffix(platform)
+		}
 	}
 	if buildArgVersion != "" {
 		args = append(args, "--build-arg", "ERUN_VERSION="+buildArgVersion)

--- a/erun-common/build_spec.go
+++ b/erun-common/build_spec.go
@@ -269,9 +269,7 @@ func multiPlatformTraceCommands(b DockerBuildSpec) []commandSpec {
 		if b.Fingerprint != "" {
 			commands = append(commands, dockerTagTraceCommand(b.ContextDir, platformTag, fingerprintTag(b.Image, b.Fingerprint, platform)))
 		}
-		if baseTag != "" && platformTag != baseTag {
-			commands = append(commands, dockerTagTraceCommand(b.ContextDir, platformTag, baseTag))
-		}
+		commands = append(commands, stableBaseVersionTraceCommands(b.ContextDir, platformTag, baseTag, platform)...)
 	}
 	if !b.Push {
 		return commands
@@ -296,6 +294,24 @@ func multiPlatformTraceCommands(b DockerBuildSpec) []commandSpec {
 	return commands
 }
 
+// stableBaseVersionTraceCommands mirrors tagStableBaseVersionAfterBuild in the
+// dry-run plan: a per-arch stable tag (what ${ERUN_VERSION} wrappers resolve)
+// followed by the arch-less stable tag, in the same order the executor writes
+// them so the trace stays an honest preview of the real build.
+func stableBaseVersionTraceCommands(dir, platformTag, baseTag, platform string) []commandSpec {
+	if baseTag == "" {
+		return nil
+	}
+	commands := make([]commandSpec, 0, 2)
+	if archTag := platformSuffixedTag(baseTag, platform); archTag != platformTag {
+		commands = append(commands, dockerTagTraceCommand(dir, platformTag, archTag))
+	}
+	if platformTag != baseTag {
+		commands = append(commands, dockerTagTraceCommand(dir, platformTag, baseTag))
+	}
+	return commands
+}
+
 func promoteTraceCommands(b DockerBuildSpec) []commandSpec {
 	commands := make([]commandSpec, 0, len(b.Platforms)*3+2)
 	perPlatformTags := make([]string, 0, len(b.Platforms))
@@ -304,9 +320,7 @@ func promoteTraceCommands(b DockerBuildSpec) []commandSpec {
 		platformTag := platformSuffixedTag(b.Image.Tag, platform)
 		perPlatformTags = append(perPlatformTags, platformTag)
 		commands = append(commands, dockerTagTraceCommand(b.ContextDir, fingerprintTag(b.Image, b.Fingerprint, platform), platformTag))
-		if baseTag != "" && platformTag != baseTag {
-			commands = append(commands, dockerTagTraceCommand(b.ContextDir, platformTag, baseTag))
-		}
+		commands = append(commands, stableBaseVersionTraceCommands(b.ContextDir, platformTag, baseTag, platform)...)
 	}
 	if !b.Push {
 		return commands

--- a/erun-integration/build_test.go
+++ b/erun-integration/build_test.go
@@ -676,6 +676,74 @@ func TestBuild(t *testing.T) {
 		golden.Equal(t, "build/dry_run_missing_base_platform_cascades_dependent_rebuild", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_versioned_wrapper_resolves_per_arch_base", func(t *testing.T) {
+		// Locks the fix for the ${ERUN_VERSION}-wrapper build failure. A wrapper
+		// that FROMs its base via ${ERUN_VERSION} resolves the base's unsuffixed
+		// local snapshot tag, which is never pushed and (tagged once per arch
+		// under one name) only ever holds the last arch built. A multi-platform
+		// wrapper build of the other arch therefore can't resolve it on a strict
+		// image store. The fix: the base also publishes a per-arch stable tag
+		// (…-snapshot-<arch>) and the wrapper's per-platform build asks for the
+		// matching arch via ERUN_VERSION=<baseversion>-<arch>. The plan must show
+		// both: the per-arch base tag and the per-arch ERUN_VERSION build-arg.
+		// --environment local makes versions snapshot-suffixed so BaseVersion is
+		// set; the stub answers every fp-tag inspect "missing" so all rebuild.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "develop")
+		mustWriteFile(t, filepath.Join(setup.Cwd, "erun-devops", "docker", "wrapper", "Dockerfile"),
+			"FROM ghcr.io/sophium/api:${ERUN_VERSION}\nCMD [\"true\"]\n")
+		fixture.RunGit(t, setup.Cwd, "add", "erun-devops/docker/wrapper/Dockerfile")
+		fixture.RunGit(t, setup.Cwd, "commit", "-q", "-m", "add ${ERUN_VERSION} wrapper over api")
+		result := erun.Run(t, []string{"build", "--dry-run", "--environment", "local"}, erun.RunOptions{Cwd: setup.Cwd, Env: append(setup.Env(), stubDockerNoLocalImages(t, setup)...)})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "build/dry_run_versioned_wrapper_resolves_per_arch_base", normalize.Apply(result.Combined))
+		// Version normalization collapses the arch suffix (…-snapshot-<ts>-amd64
+		// and …-snapshot-amd64 both become <VERSION>), so the per-arch behavior
+		// this scenario exists to lock is invisible in the golden. Assert it on
+		// the raw output: the wrapper resolves its base per platform, and the
+		// base publishes the matching per-arch stable tag. BaseVersion carries no
+		// timestamp, so these are stable.
+		for _, want := range []string{
+			"--build-arg ERUN_VERSION=1.4.2-snapshot-amd64", // wrapper's amd64 build resolves the amd64 base
+			"--build-arg ERUN_VERSION=1.4.2-snapshot-arm64", // wrapper's arm64 build resolves the arm64 base
+			"ghcr.io/sophium/api:1.4.2-snapshot-amd64",       // base publishes per-arch stable tag
+			"ghcr.io/sophium/api:1.4.2-snapshot-arm64",
+		} {
+			if !strings.Contains(result.Combined, want) {
+				t.Errorf("expected per-arch base resolution %q in output:\n%s", want, result.Combined)
+			}
+		}
+	})
+
+	t.Run("real_run_versioned_wrapper_tags_per_arch_base", func(t *testing.T) {
+		// Companion to the dry-run scenario: drives runMultiPlatformBuild and the
+		// per-arch tagStableBaseVersionAfterBuild for real. The docker stub
+		// returns exit 1 for `image inspect` (no fp images → everything rebuilds)
+		// and exit 0 otherwise, so the per-arch base re-tag (docker tag) and the
+		// wrapper build run against the stub rather than a real daemon.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "develop")
+		mustWriteFile(t, filepath.Join(setup.Cwd, "erun-devops", "docker", "wrapper", "Dockerfile"),
+			"FROM ghcr.io/sophium/api:${ERUN_VERSION}\nCMD [\"true\"]\n")
+		fixture.RunGit(t, setup.Cwd, "add", "erun-devops/docker/wrapper/Dockerfile")
+		fixture.RunGit(t, setup.Cwd, "commit", "-q", "-m", "add ${ERUN_VERSION} wrapper over api")
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinaryWithScript(t, stubs, "docker", strings.Join([]string{
+			`case "$1 $2" in`,
+			`  "image inspect") exit 1 ;;`,
+			`  *) exit 0 ;;`,
+			`esac`,
+		}, "\n"))
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker")...)
+		result := erun.Run(t, []string{"build", "-v", "--environment", "local"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "build/real_run_versioned_wrapper_tags_per_arch_base", normalize.Apply(result.Combined))
+	})
+
 	t.Run("real_run_release_push_auth_failure_retries_after_gh_login", func(t *testing.T) {
 		// Exercises the build-side GHCR auth-retry chain:
 		// runDockerBuildWithRetry catches the DockerRegistryAuthError that

--- a/erun-integration/exec_test.go
+++ b/erun-integration/exec_test.go
@@ -18,6 +18,9 @@ import (
 
 func mustWriteFile(t testing.TB, path, contents string) {
 	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
 	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}

--- a/erun-integration/testdata/build/dry_run_versioned_wrapper_resolves_per_arch_base.txt
+++ b/erun-integration/testdata/build/dry_run_versioned_wrapper_resolves_per_arch_base.txt
@@ -1,10 +1,4 @@
 audit: erun build --dry-run --environment local
-docker manifest inspect ghcr.io/sophium/base:<VERSION>
-docker pull --platform linux/amd64 ghcr.io/sophium/base:<VERSION>
-docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
-docker manifest inspect ghcr.io/sophium/base:<VERSION>
-docker pull --platform linux/arm64 ghcr.io/sophium/base:<VERSION>
-docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-arm64
@@ -27,3 +21,16 @@ cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=pl
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+docker image inspect ghcr.io/sophium/wrapper:fp-<HEX16>-amd64
+fingerprint image not found locally: ghcr.io/sophium/wrapper:fp-<HEX16>-amd64
+docker image inspect ghcr.io/sophium/wrapper:fp-<HEX16>-arm64
+fingerprint image not found locally: ghcr.io/sophium/wrapper:fp-<HEX16>-arm64
+rebuilding ghcr.io/sophium/wrapper:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/wrapper:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker tag ghcr.io/sophium/wrapper:<VERSION> ghcr.io/sophium/wrapper:fp-<HEX16>-amd64
+cd <TMP> && docker tag ghcr.io/sophium/wrapper:<VERSION> ghcr.io/sophium/wrapper:<VERSION>
+cd <TMP> && docker tag ghcr.io/sophium/wrapper:<VERSION> ghcr.io/sophium/wrapper:<VERSION>
+cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/wrapper:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker tag ghcr.io/sophium/wrapper:<VERSION> ghcr.io/sophium/wrapper:fp-<HEX16>-arm64
+cd <TMP> && docker tag ghcr.io/sophium/wrapper:<VERSION> ghcr.io/sophium/wrapper:<VERSION>
+cd <TMP> && docker tag ghcr.io/sophium/wrapper:<VERSION> ghcr.io/sophium/wrapper:<VERSION>

--- a/erun-integration/testdata/build/real_run_versioned_wrapper_tags_per_arch_base.txt
+++ b/erun-integration/testdata/build/real_run_versioned_wrapper_tags_per_arch_base.txt
@@ -1,0 +1,12 @@
+audit: erun build --environment local
+==> Building
+fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
+fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
+rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-amd64
+fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
+rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+fingerprint image not found locally: ghcr.io/sophium/wrapper:fp-<HEX16>-amd64
+fingerprint image not found locally: ghcr.io/sophium/wrapper:fp-<HEX16>-arm64
+rebuilding ghcr.io/sophium/wrapper:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+==> Built in <ELAPSED>

--- a/erun-integration/testdata/deploy/dry_run_local_docker_cwd_uses_current_build_for_owning_chart.txt
+++ b/erun-integration/testdata/deploy/dry_run_local_docker_cwd_uses_current_build_for_owning_chart.txt
@@ -9,8 +9,10 @@ rebuilding ghcr.io/sophium/team-devops:<VERSION> because fingerprint image is mi
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/team-devops:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/team-devops:<VERSION> ghcr.io/sophium/team-devops:fp-<HEX16>-amd64
 cd <TMP> && docker tag ghcr.io/sophium/team-devops:<VERSION> ghcr.io/sophium/team-devops:<VERSION>
+cd <TMP> && docker tag ghcr.io/sophium/team-devops:<VERSION> ghcr.io/sophium/team-devops:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/team-devops:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/team-devops:<VERSION> ghcr.io/sophium/team-devops:fp-<HEX16>-arm64
+cd <TMP> && docker tag ghcr.io/sophium/team-devops:<VERSION> ghcr.io/sophium/team-devops:<VERSION>
 cd <TMP> && docker tag ghcr.io/sophium/team-devops:<VERSION> ghcr.io/sophium/team-devops:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/team-devops:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/team-devops:<VERSION>

--- a/erun-integration/testdata/deploy/dry_run_lockstep_publishes_runtime_chart_when_image_pushed.txt
+++ b/erun-integration/testdata/deploy/dry_run_lockstep_publishes_runtime_chart_when_image_pushed.txt
@@ -9,8 +9,10 @@ rebuilding registry.example/test/erun-devops:<VERSION> because fingerprint image
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t registry.example/test/erun-devops:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag registry.example/test/erun-devops:<VERSION> registry.example/test/erun-devops:fp-<HEX16>-amd64
 cd <TMP> && docker tag registry.example/test/erun-devops:<VERSION> registry.example/test/erun-devops:<VERSION>
+cd <TMP> && docker tag registry.example/test/erun-devops:<VERSION> registry.example/test/erun-devops:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t registry.example/test/erun-devops:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag registry.example/test/erun-devops:<VERSION> registry.example/test/erun-devops:fp-<HEX16>-arm64
+cd <TMP> && docker tag registry.example/test/erun-devops:<VERSION> registry.example/test/erun-devops:<VERSION>
 cd <TMP> && docker tag registry.example/test/erun-devops:<VERSION> registry.example/test/erun-devops:<VERSION>
 cd <TMP> && docker push registry.example/test/erun-devops:<VERSION>
 cd <TMP> && docker push registry.example/test/erun-devops:<VERSION>

--- a/erun-integration/testdata/open/snapshot_env_config_drives_local_build.txt
+++ b/erun-integration/testdata/open/snapshot_env_config_drives_local_build.txt
@@ -14,8 +14,10 @@ rebuilding ghcr.io/sophium/team-devops:<VERSION> because fingerprint image is mi
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/team-devops:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/team-devops:<VERSION> ghcr.io/sophium/team-devops:fp-<HEX16>-amd64
 cd <TMP> && docker tag ghcr.io/sophium/team-devops:<VERSION> ghcr.io/sophium/team-devops:<VERSION>
+cd <TMP> && docker tag ghcr.io/sophium/team-devops:<VERSION> ghcr.io/sophium/team-devops:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/team-devops:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/team-devops:<VERSION> ghcr.io/sophium/team-devops:fp-<HEX16>-arm64
+cd <TMP> && docker tag ghcr.io/sophium/team-devops:<VERSION> ghcr.io/sophium/team-devops:<VERSION>
 cd <TMP> && docker tag ghcr.io/sophium/team-devops:<VERSION> ghcr.io/sophium/team-devops:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/team-devops:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/team-devops:<VERSION>


### PR DESCRIPTION
## Problem

A local (non-release) `erun build` fails when a `${ERUN_VERSION}` wrapper image (e.g. `erun-mcp`, which is `FROM ghcr.io/sophium/erun-devops:${ERUN_VERSION}`) actually rebuilds:

```
rebuilding erun-mcp ... because dependency erun-devops:...-snapshot is rebuilding
Dockerfile:3  >>> FROM ghcr.io/sophium/erun-devops:${ERUN_VERSION}
ERROR: failed to solve: ghcr.io/sophium/erun-devops:1.0.90-snapshot: not found
```

## Root cause

`erun-mcp` resolves its base via the unsuffixed local snapshot tag `erun-devops:1.0.90-snapshot`. That tag is:

- **single-arch** — `runMultiPlatformBuild` runs `docker tag …-snapshot-<TS>-<arch> erun-devops:1.0.90-snapshot` once per platform, so the last arch (arm64) overwrites the first (amd64). *Verified in the pod: the bare tag is arm64; the amd64 image exists only under `…-amd64`/`fp-…-amd64`.*
- **never pushed** — it's a local-build convenience.

Every `erun build` builds both arches with an explicit `--platform`, so `erun-mcp`'s `--platform linux/amd64` pass needs an amd64 base. On the runtime pod's **overlay2** image store (strict), the arm64-only local tag can't satisfy an amd64 target, so BuildKit falls back to the registry → the snapshot tag isn't there → `not found`.

Why it went unnoticed:
- **Release / deploy (any version) are unaffected** — they push the base as a multi-arch manifest list (verified: `erun-devops:1.0.87` in ghcr is a `manifest.list` with amd64+arm64), and the wrapper resolves it from the registry.
- A **containerd** image-store dev machine leniently serves the wrong-arch local image, so the bug is invisible there.
- The wrapper normally **promotes** from cache instead of building, so the `FROM` is never evaluated. It only bites the narrow intersection: plain local build + wrapper cascade-rebuild + strict overlay2 store.

## Fix (scoped to the snapshot/local path; release untouched)

- `tagStableBaseVersionAfterBuild` also publishes a **per-arch stable tag** (`erun-devops:1.0.90-snapshot-amd64` / `-arm64`) alongside the arch-less one.
- `dockerBuildArgs` gives `${ERUN_VERSION}` wrappers a **per-arch build arg** (`ERUN_VERSION=<baseversion>-<arch>`) so `FROM` resolves the matching arch locally. This finally wires up the existing-but-unused `dockerfileHasVersionedFrom`.
- `build_spec.go` trace mirrors the per-arch tag so dry-run stays in step with real-run.

No new spec field. Release builds (empty `BaseVersion`) are unchanged — they keep resolving the base from the pushed multi-arch manifest.

## Verification

- **On the runtime pod's overlay2 daemon (the live target):** reproduced the failure (`--platform amd64` `FROM` the arm64-only stable tag → `not found`), then confirmed the fix's per-arch tag resolves the amd64 build **locally, no registry**.
- New integration scenarios: `dry_run_versioned_wrapper_resolves_per_arch_base` (locks the per-arch tag + `ERUN_VERSION` in the plan; raw-output assertion since version normalization masks the arch) and `real_run_versioned_wrapper_tags_per_arch_base` (drives the execution path).
- `make integration-test` green (78.1% ≥ 75.0%); `go vet`/`go test` clean.

### Golden changes
Four existing local-env/snapshot scenarios gain one extra per-arch `docker tag` line per platform (collapsed to `<VERSION>` by normalization, hence the doubled-looking lines): `build/dry_run_configured_fingerprint_traces_pull_and_tag`, `deploy/dry_run_local_docker_cwd_uses_current_build_for_owning_chart`, `deploy/dry_run_lockstep_publishes_runtime_chart_when_image_pushed`, `open/snapshot_env_config_drives_local_build`.

Docs: behavior-preserving build-internals fix → no `erun-docs` change.

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)