### PR TITLE
Push multi-arch manifest from standalone erun push

### DIFF
--- a/erun-common/build_push_plan.go
+++ b/erun-common/build_push_plan.go
@@ -30,6 +30,13 @@ func ResolveDockerPushExecution(ctx Context, store DockerStore, findProjectRoot 
 			if err != nil {
 				return DockerPushExecutionSpec{}, err
 			}
+			// Push through the build's own multi-platform push so the per-arch
+			// images go up and a manifest list is assembled (pushMultiPlatformImage),
+			// the same path release/deploy use. A locally-built multi-arch image
+			// only exists under per-arch tags; pushing the bare version tag (the
+			// pushes entry below) would fail "tag does not exist", so RunDockerPushExecution
+			// skips it once the build is marked pushed.
+			build.Push = true
 			builds = append(builds, build)
 			imageRef = build.Image
 		}
@@ -67,6 +74,11 @@ func ResolveDockerPushSpec(ctx Context, store DockerStore, findProjectRoot Proje
 		if err != nil {
 			return DockerPushSpec{}, nil, err
 		}
+		// Push via the build's multi-platform push (per-arch + manifest list),
+		// not the bare version tag — a local multi-arch image has no arch-less
+		// tag to `docker push`. RunDockerPushSpec returns after the build once
+		// Push is set, skipping the redundant single-tag push.
+		resolvedBuild.Push = true
 		incremental, err := ApplyIncrementalToDockerBuilds(ctx, []DockerBuildSpec{resolvedBuild}, target.NoIncremental)
 		if err != nil {
 			return DockerPushSpec{}, nil, err

--- a/erun-integration/push_test.go
+++ b/erun-integration/push_test.go
@@ -146,6 +146,45 @@ func TestPush(t *testing.T) {
 		golden.Equal(t, "push/real_run_single_image_from_dockerfile_cwd", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_local_push_assembles_per_arch_manifest", func(t *testing.T) {
+		// Locks the fix for standalone `erun push` of local-env (snapshot) images.
+		// From the project root with no cwd Dockerfile, push resolves multiple
+		// docker contexts (ResolveDockerPushExecution). A locally-built multi-arch
+		// image only exists under per-arch tags, so push must push those and
+		// assemble a manifest list — the same multi-platform push release uses —
+		// not `docker push` the arch-less version tag (which would fail
+		// "tag does not exist"). The stub answers every fp inspect present, so
+		// images promote (mirroring the real failure); the plan must show, per
+		// image, the per-arch `docker push` + `docker manifest create`/`push`.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "develop")
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinaryAdvanced(t, stubs, "docker", fixture.StubBinarySpec{ExitCode: 0})
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker")...)
+		result := erun.Run(t, []string{"push", "--dry-run", "--environment", "local"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "push/dry_run_local_push_assembles_per_arch_manifest", normalize.Apply(result.Combined))
+	})
+
+	t.Run("real_run_local_push_assembles_per_arch_manifest", func(t *testing.T) {
+		// Companion to the dry-run scenario: drives RunDockerPushExecution +
+		// pushMultiPlatformImage for real against the stub (promote, per-arch
+		// docker push, docker manifest create/push). Previously this path failed
+		// "tag does not exist" on the arch-less push; it must now complete.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "develop")
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinaryAdvanced(t, stubs, "docker", fixture.StubBinarySpec{ExitCode: 0})
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker")...)
+		result := erun.Run(t, []string{"push", "-v", "--environment", "local"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "push/real_run_local_push_assembles_per_arch_manifest", normalize.Apply(result.Combined))
+	})
+
 	t.Run("real_run_auth_failure_prompts_login_and_retries", func(t *testing.T) {
 		// Exercises promptDockerLoginRetry's interactive Select (the
 		// non-ERUN_AUTO_LOGIN_ON_PUSH path) plus runDockerPushWithRetry's

--- a/erun-integration/testdata/push/dry_run_local_push_assembles_per_arch_manifest.txt
+++ b/erun-integration/testdata/push/dry_run_local_push_assembles_per_arch_manifest.txt
@@ -1,0 +1,27 @@
+audit: erun push --dry-run --environment local
+docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
+fingerprint image present locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
+docker image inspect ghcr.io/sophium/api:fp-<HEX16>-arm64
+fingerprint image present locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
+promoting from cached fingerprint image: ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker tag ghcr.io/sophium/api:fp-<HEX16>-amd64 ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker tag ghcr.io/sophium/api:fp-<HEX16>-arm64 ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>
+docker image inspect ghcr.io/sophium/base:fp-<HEX16>-amd64
+fingerprint image present locally: ghcr.io/sophium/base:fp-<HEX16>-amd64
+docker image inspect ghcr.io/sophium/base:fp-<HEX16>-arm64
+fingerprint image present locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
+promoting from cached fingerprint image: ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker tag ghcr.io/sophium/base:fp-<HEX16>-amd64 ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker tag ghcr.io/sophium/base:fp-<HEX16>-arm64 ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create --amend ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>

--- a/erun-integration/testdata/push/real_run_local_push_assembles_per_arch_manifest.txt
+++ b/erun-integration/testdata/push/real_run_local_push_assembles_per_arch_manifest.txt
@@ -1,0 +1,9 @@
+audit: erun push --environment local
+==> Pushing
+fingerprint image present locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
+fingerprint image present locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
+promoting from cached fingerprint image: ghcr.io/sophium/api:<VERSION>
+fingerprint image present locally: ghcr.io/sophium/base:fp-<HEX16>-amd64
+fingerprint image present locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
+promoting from cached fingerprint image: ghcr.io/sophium/base:<VERSION>
+==> Pushed in <ELAPSED>


### PR DESCRIPTION
## Problem

`erun push` (from the project root, local/snapshot images) fails:

```
promoting from cached fingerprint image: ghcr.io/sophium/erun-backend-api:1.0.90-snapshot-<TS>
tag does not exist: ghcr.io/sophium/erun-backend-api:1.0.90-snapshot-<TS>
==> Push failed after 1s
```

## Root cause

The standalone push path (`ResolveDockerPushExecution`/`RunDockerPushExecution`, and the single-image `ResolveDockerPushSpec`/`RunDockerPushSpec`) promotes each image to its **per-arch** tags (`…-amd64`/`-arm64`) and then runs `docker push <arch-less version tag>`. A locally-built multi-arch image has no arch-less tag — that name only ever becomes a **manifest list**, assembled via `docker manifest create` + `docker manifest push`. So `docker push` reports the tag doesn't exist.

Release/deploy avoid this because they set `Push=true` on the builds, so `pushMultiPlatformImage` pushes the per-arch tags **and assembles the manifest**. Standalone push skipped that step.

Verified on the pod: the per-arch tags (`…-<TS>-amd64`/`-arm64`) exist with **identical image IDs** from both the build and the push (same content, just different timestamp labels — `build` and `push` each call `now()`), while the arch-less version tag does not exist at all.

The multi-image push path had **no integration scenario**, and the single-image scenarios only stub `docker`, so the bare-tag push never actually hit a daemon — which is why it went unnoticed.

## Fix

Mark the resolved builds `Push=true` in `ResolveDockerPushExecution` and `ResolveDockerPushSpec`, so they push through `pushMultiPlatformImage` (per-arch push + `docker manifest create`/`push`) — the same multi-platform push release/deploy use. `RunDockerPushExecution`/`RunDockerPushSpec` then skip the redundant bare-tag push. Scoped to locally-built (`IsLocalBuild`) images; non-local push is unchanged.

## Verification

- New integration scenarios for the previously-uncovered multi-image local-push path: `dry_run_local_push_assembles_per_arch_manifest` (plan shows, per image, the per-arch `docker push` + `docker manifest create`/`push`) and `real_run_local_push_assembles_per_arch_manifest` (drives `pushMultiPlatformImage` to completion via stub — previously failed "tag does not exist").
- `make integration-test` green (78.1% ≥ 75.0%); `go vet`/`go test` clean. No existing goldens changed (the prior scenarios are non-local, untouched by this branch).

Note: I did not run a real `erun push` to ghcr as verification (that publishes images — your call to run). The fix is the same multi-platform push path release/deploy already use successfully, exercised end-to-end against the stub.

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)