### PR TITLE
Fix paste-image container flag for non-erun tenants

### DIFF
--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -3243,10 +3243,14 @@ func TestDecodePastedImagePayloadAcceptsDataURL(t *testing.T) {
 }
 
 func TestBuildPastedImageCopyCommandTargetsRuntimeDeployment(t *testing.T) {
+	// Use a non-erun tenant so the Helm release name (petios-devops) is distinct
+	// from the runtime container literal (erun-devops). For tenant "erun" the two
+	// coincide, which previously masked the bug where the release name was passed
+	// as the kubectl -c container flag (#532).
 	result := eruncommon.OpenResult{
-		Tenant:      "erun",
+		Tenant:      "petios",
 		Environment: "local",
-		RepoPath:    "/Users/example/git/erun",
+		RepoPath:    "/Users/example/git/petios",
 		EnvConfig: eruncommon.EnvConfig{
 			KubernetesContext: "rancher-desktop",
 		},
@@ -3263,10 +3267,10 @@ func TestBuildPastedImageCopyCommandTargetsRuntimeDeployment(t *testing.T) {
 	}
 	wantArgs := []string{
 		"--context", "rancher-desktop",
-		"--namespace", "erun-local",
+		"--namespace", "petios-local",
 		"exec", "-i",
 		"-c", "erun-devops",
-		"deployment/erun-devops",
+		"deployment/petios-devops",
 		"--",
 		"/bin/sh", "-lc",
 		"mkdir -p '/home/erun/.codex/attachments' && base64 -d > '/home/erun/.codex/attachments/paste.png'",

--- a/erun-ui/paste.go
+++ b/erun-ui/paste.go
@@ -63,7 +63,7 @@ func buildPastedImageCopyCommand(result eruncommon.OpenResult, remoteDir, remote
 		"exec",
 		"-i",
 		"-c",
-		release,
+		eruncommon.DevopsComponentName,
 		"deployment/"+release,
 		"--",
 		"/bin/sh",


### PR DESCRIPTION
## Summary

Pasting an image into the desktop AI tab failed for any non-`erun` tenant with `container <tenant>-devops is not valid for pod ...`. `buildPastedImageCopyCommand` (`erun-ui/paste.go`) derived a single `release := RuntimeReleaseName(result.Tenant)` (`<tenant>-devops`) and reused it for **both** the kubectl `-c` container flag **and** the `deployment/` target. The deployment target is correct, but the runtime container is always the fixed literal `erun-devops` (the chart hardcodes it independent of the release name), so the API server rejected the exec and the clipboard image never reached the pod.

## Change

- `erun-ui/paste.go`: pass `eruncommon.DevopsComponentName` (the existing `"erun-devops"` constant, already the canonical container name used by `runtime_resources.go`) for the `-c` flag; keep `deployment/<release>` as the target.
- `erun-ui/app_test.go`: `TestBuildPastedImageCopyCommandTargetsRuntimeDeployment` used `Tenant: "erun"`, where the release name equals the container literal — the equality masked the bug. Switched to a non-`erun` tenant (`petios`) so the assertion locks in `-c erun-devops` alongside `deployment/petios-devops`.

No new constant introduced; `eruncommon.DevopsComponentName` already exists.

## Plan delta vs the issue

The issue flagged an "out-of-scope sibling defect" in `erun-ui/runtime_resources.go:144`. That is **already fixed** — `runtime_resources.go` now uses `eruncommon.DevopsComponentName` (landed in #517). Nothing left to file there. (Line citations in the issue also drifted: the test is at `app_test.go:3245`, not `:3095`.)

## UX Impact Review

1. **Affected path:** AI-tab image paste → `savePastedImageToRuntime` → `kubectl exec` into the runtime pod. Behaviour-preserving for `erun` tenant; **fixes** the crash for every other tenant.
2. **User-visible sequence:** unchanged on success (image lands in `/home/erun/.codex/attachments`); the previous `BadRequest` error path is eliminated for non-`erun` tenants.
3. No new control, status, or rendered state — pure correction of a kubectl arg builder. No `AppState` mutation added.

## Validation

- `go test ./...` in `erun-ui`: the updated `TestBuildPastedImageCopyCommandTargetsRuntimeDeployment` passes. (One unrelated test, `TestCloseReapsWholeProcessGroup`, fails identically on pristine `main` in this sandbox — it needs real process-group signal reaping the sandbox lacks; not touched by this change.)
- **Playwright:** the paste exec path is cluster-bound (needs a real runtime pod the headless harness deliberately lacks), and the fix changes only kubectl argument construction with no rendered-DOM surface. The owning coverage is the Go unit test `TestBuildPastedImageCopyCommandTargetsRuntimeDeployment`, per `erun-ui/AGENTS.md` § End-to-end UI tests (cluster-bound exception).
- **Manual repro (operator, live pod):** open a non-`erun` runtime in the AI tab and paste an image; confirm the file lands in `/home/erun/.codex/attachments/` and no `BadRequest` is raised.

## Docs

Exempt — the container-name contract is already documented correctly in `erun-docs/docs/concepts/conventions.md`; this change makes the code honor the existing contract.

Closes #532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)