### PR TITLE
Isolate ERUN_SKILLS_DIR in the integration harness

### DIFF
--- a/erun-integration/internal/env/env.go
+++ b/erun-integration/internal/env/env.go
@@ -36,6 +36,17 @@ func (s Setup) Env() []string {
 		// goldens.
 		"TERM=dumb",
 		"NO_COLOR=1",
+		// Isolate the agent-skills source. The runtime image bakes skills
+		// into /etc/erun/skills, which doctor's remote-init skills check
+		// (bakedSkillsRoot) reads when ERUN_SKILLS_DIR is unset. On a host
+		// that has that directory (a runtime image, or a box that installed
+		// one) the unset seam leaks the host's baked skills into doctor
+		// output and the in_runtime_* goldens drift. Default the seam to an
+		// isolated, non-existent path so the "no baked skills → row omitted"
+		// branch is deterministic everywhere; scenarios that test the skills
+		// row append their own ERUN_SKILLS_DIR after Env() (the last value
+		// for a duplicated key wins).
+		"ERUN_SKILLS_DIR=" + filepath.Join(s.Home, ".no-baked-skills"),
 	}
 }
 


### PR DESCRIPTION
## Summary

`make integration-test` was **red on any host that has `/etc/erun/skills`** (a runtime image, or a dev box / sandbox that installed the baked skills) and green on a clean dev machine — so `main` carried the red silently. Eleven `TestDoctor` `in_runtime_*` / `finish_remote_init_*` scenarios failed.

## Root cause

The doctor remote-init **agent-skills** check resolves its baked-skills source via `bakedSkillsRoot` (`erun-common/doctor_remote_init.go`), which returns `/etc/erun/skills` when `ERUN_SKILLS_DIR` is unset. The affected scenarios don't set the seam, so on a host that *has* `/etc/erun/skills` they read the host's real baked skills and emit an `agent skills MISSING` row (the isolated test HOME has no `~/.claude/skills`) that the goldens — generated on a host *without* that directory — don't contain.

This is a test-isolation leak: the harness isolates HOME/XDG but not this seam, so a host path leaks into the subprocess. Per `erun-integration/AGENTS.md` ("platform-dependent red is a defect to fix, not a reason to ship") it should be pinned like `ERUN_HOST_OS_OVERRIDE`.

## Change

`env.Setup.Env()` now defaults `ERUN_SKILLS_DIR` to an isolated, non-existent path (`<Home>/.no-baked-skills`), so every scenario takes the deterministic "no baked skills → row omitted" branch regardless of the host. The two scenarios that *do* test the skills row (`in_runtime_skills_installed_dry_run`, `in_runtime_finish_skills_dry_run`) already append their own `ERUN_SKILLS_DIR` after `setup.Env()`, and Go's `exec` keeps the last value for a duplicated key, so they still drive the skills-present branch.

**No golden changes** — output matches the existing goldens everywhere.

## Validation

- Before: 11 `TestDoctor` scenarios red on this host (`/etc/erun/skills` present).
- After: `make integration-test` green, coverage 77.4% ≥ 75.0% threshold.
- The two skills-specific scenarios still pass (their explicit seam overrides the default).

Closes #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)