### PR TITLE
Name the release/component in deploy trace lines

### DIFF
--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -414,7 +414,17 @@ func RunHelmDeploy(ctx Context, deployInput HelmDeploySpec, deploy HelmChartDepl
 	if err != nil {
 		return err
 	}
+	// Name the release for a non-runtime component so a single-component
+	// deploy (e.g. erun-backend-postgres) is not mistaken for a full-env
+	// redeploy: "erun/local · erun-backend-postgres 18.3" instead of the
+	// bare "erun/local 18.3". The runtime chart's line stays "<tenant>/<env>
+	// <version>" — it *is* the env, carries the meaningful runtime version,
+	// and feeds the helm-release poller + version persistence (#476). The
+	// version on a component line is that component's own version.
 	target := deployInput.Tenant + "/" + deployInput.Environment
+	if release := strings.TrimSpace(deployInput.ReleaseName); release != "" && release != RuntimeReleaseName(deployInput.Tenant) {
+		target += " · " + release
+	}
 	if version := strings.TrimSpace(deployInput.Version); version != "" {
 		target += " " + version
 	}

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -1090,11 +1090,21 @@ func TestDeploy(t *testing.T) {
 		if !strings.Contains(out, "deploy: step 1 (parallel): team-devops, erun-backend-postgres") {
 			t.Fatalf("expected parallel-step trace line, got:\n%s", out)
 		}
-		if got := strings.Count(out, "==> Deploying team/dev <VERSION>"); got != 2 {
+		// #531: the runtime chart names only the env, while the non-runtime
+		// component names itself after a ` · ` separator so a component
+		// rollout is not mistaken for a full-env redeploy. Both rollouts
+		// still appear; exactly one of each pair names the component.
+		if got := strings.Count(out, "==> Deploying team/dev"); got != 2 {
 			t.Fatalf("expected 2 parallel ==> Deploying lines, got %d:\n%s", got, out)
 		}
-		if got := strings.Count(out, "==> Deployed team/dev <VERSION> in <ELAPSED>"); got != 2 {
+		if got := strings.Count(out, "==> Deploying team/dev · erun-backend-postgres"); got != 1 {
+			t.Fatalf("expected the component ==> Deploying line to name the release, got %d:\n%s", got, out)
+		}
+		if got := strings.Count(out, "==> Deployed team/dev"); got != 2 {
 			t.Fatalf("expected 2 ==> Deployed completions, got %d:\n%s", got, out)
+		}
+		if got := strings.Count(out, "==> Deployed team/dev · erun-backend-postgres"); got != 1 {
+			t.Fatalf("expected the component ==> Deployed line to name the release, got %d:\n%s", got, out)
 		}
 	})
 

--- a/erun-ui/activity_queue_app.go
+++ b/erun-ui/activity_queue_app.go
@@ -290,10 +290,12 @@ func namespaceForTenantEnv(tenant, environment string) string {
 	}
 }
 
-// activityDeployingLineRe matches the `==> Deploying tenant/env [version]`
-// trace emitted by RunHelmDeploy at deploy start. Captures: tenant,
-// environment, optional version.
-var activityDeployingLineRe = regexp.MustCompile(`^==> Deploying ([^/\s]+)/([^/\s]+)(?:\s+(\S+))?\s*$`)
+// activityDeployingLineRe matches the `==> Deploying tenant/env [· release]
+// [version]` trace emitted by RunHelmDeploy at deploy start. A non-runtime
+// component carries the release after a ` · ` separator (e.g. `erun/local ·
+// erun-backend-postgres 18.3`); the runtime chart omits it (`erun/local
+// 18.3`). Captures: tenant, environment, optional release, optional version.
+var activityDeployingLineRe = regexp.MustCompile(`^==> Deploying ([^/\s]+)/([^/\s]+)(?: · (\S+))?(?:\s+(\S+))?\s*$`)
 
 // activityDeployedLineRe matches the `==> Deployed tenant/env [version]
 // in <elapsed>` trace emitted at successful completion. Captures:
@@ -388,13 +390,16 @@ var (
 // Terminal-state lines (==> Deployed / ==> Deploy failed / ==> Skipping /
 // Error:) finalize the matching active entry from either channel.
 func newActivityTraceLineHandler(app *App, selection uiSelection, kind sessionKind) func(string) {
-	failedRe := regexp.MustCompile(`^==> Deploy failed`)
+	// RunHelmDeploy names the release on failure ("==> Deploy of <rel> failed
+	// after <elapsed>", #559) and falls back to "==> Deploy failed after
+	// <elapsed>" only when no release is set; match both shapes.
+	failedRe := regexp.MustCompile(`^==> Deploy (?:of \S+ )?failed`)
 	errorRe := regexp.MustCompile(`(?i)^Error: `)
 	_ = kind
 	return func(line string) {
 		line = strings.TrimSpace(line)
 		if match := activityDeployingLineRe.FindStringSubmatch(line); match != nil {
-			app.startDeployFromTrace(selection, match[1], match[2], match[3])
+			app.startDeployFromTrace(selection, match[1], match[2], match[3], match[4])
 			return
 		}
 		if match := activityDeployedLineRe.FindStringSubmatch(line); match != nil {
@@ -560,12 +565,13 @@ func (a *App) finishInitByTenantEnv(tenant, environment string, status activityQ
 // trace observed in any session's PTY. No-op when an active entry
 // already exists for the selection so the helm poller and trace
 // handler converge on the same record.
-func (a *App) startDeployFromTrace(selection uiSelection, tenant, environment, version string) {
+func (a *App) startDeployFromTrace(selection uiSelection, tenant, environment, release, version string) {
 	if a.activityQueue == nil {
 		return
 	}
 	tenant = strings.TrimSpace(tenant)
 	environment = strings.TrimSpace(environment)
+	release = strings.TrimSpace(release)
 	version = strings.TrimSpace(version)
 	if tenant == "" || environment == "" {
 		return
@@ -573,17 +579,28 @@ func (a *App) startDeployFromTrace(selection uiSelection, tenant, environment, v
 	if _, ok := a.activityQueue.findActiveByCommand("deploy", tenant, environment); ok {
 		return
 	}
+	// The runtime chart's `==> Deploying` line carries no release token, so an
+	// empty parsed release means the runtime deploy; fall back to its release
+	// name. A non-runtime component names itself, so the drawer labels it by
+	// component ("deploy erun/local · erun-backend-postgres") instead of
+	// reading like a full-env redeploy (#531).
+	summary := "deploy " + tenant + "/" + environment
+	if release == "" {
+		release = releaseNameForTenant(tenant)
+	} else {
+		summary += " · " + release
+	}
 	kubeContext := a.resolveActivityKubeContext(selection, tenant, environment)
 	entry, fresh := a.activityQueue.start(activityQueueEntry{
 		Command:           "deploy",
 		Tenant:            tenant,
 		Environment:       environment,
 		Version:           version,
-		Release:           releaseNameForTenant(tenant),
+		Release:           release,
 		Namespace:         namespaceForTenantEnv(tenant, environment),
 		KubernetesContext: kubeContext,
 		Source:            "trace",
-		Summary:           "deploy " + tenant + "/" + environment,
+		Summary:           summary,
 	})
 	if !fresh {
 		return
@@ -942,7 +959,7 @@ func (a *App) feedActivityTraceFromTerminal(managed *managedTerminal, chunk []by
 // is past the setup phase and a parallel queued action can safely run.
 var (
 	sessionReadyDeployedRe    = regexp.MustCompile(`^==> Deployed `)
-	sessionReadyFailedRe      = regexp.MustCompile(`^==> Deploy failed`)
+	sessionReadyFailedRe      = regexp.MustCompile(`^==> Deploy (?:of \S+ )?failed`)
 	sessionReadySkippedRe     = regexp.MustCompile(`^==> Skipping `)
 	sessionReadyAttachedRe    = regexp.MustCompile(`^Defaulted container "[^"]+" out of:`)
 	sessionReadyShellPromptRe = regexp.MustCompile(`[\w][\w.-]*@[\w][\w.-]*:[~/].*[\$#]\s*$`)

--- a/erun-ui/activity_queue_app_test.go
+++ b/erun-ui/activity_queue_app_test.go
@@ -157,6 +157,80 @@ func TestActivityTraceLineHandlerFinalizesOnDeployedAndFailed(t *testing.T) {
 	}
 }
 
+func TestActivityTraceLineHandlerFinalizesOnReleaseNamedFailure(t *testing.T) {
+	// #559 changed the failure line to "==> Deploy of <rel> failed after
+	// <elapsed>"; the desktop matcher must still finalize the entry as
+	// failed. The matcher was silently broken between #559 and #531.
+	app := newTestAppForActivityQueue(t)
+	selection := uiSelection{Tenant: "team", Environment: "dev"}
+	app.activityQueue.start(activityQueueEntry{Command: "deploy", Tenant: "team", Environment: "dev"})
+	handler := newActivityTraceLineHandler(app, selection, sessionKindLocal)
+	handler("Error: UPGRADE FAILED: timeout")
+	handler("==> Deploy of team-devops failed after 2m0s")
+	all := app.activityQueue.list()
+	if len(all) != 1 || all[0].Status != activityQueueStatusFailed {
+		t.Fatalf("expected one failed entry, got %+v", all)
+	}
+}
+
+func TestSessionReadyFailedMatchesReleaseNamedFailure(t *testing.T) {
+	// The session-ready gate matcher must track the same #559 wording so a
+	// failed deploy still releases the action runner.
+	if !sessionReadyFailedRe.MatchString("==> Deploy of team-devops failed after 2m0s") {
+		t.Fatal("sessionReadyFailedRe must match the release-named failure line")
+	}
+	if !sessionReadyFailedRe.MatchString("==> Deploy failed after 2m0s") {
+		t.Fatal("sessionReadyFailedRe must still match the no-release fallback")
+	}
+}
+
+func TestActivityTraceLineHandlerLabelsComponentDeployByRelease(t *testing.T) {
+	// A non-runtime component names the release after a ` · ` separator
+	// ("erun/local · erun-backend-postgres 18.3"). The entry must be labeled
+	// by component so the drawer does not read like a full-env redeploy, and
+	// the version is the component's own (#531).
+	app := newTestAppForActivityQueue(t)
+	selection := uiSelection{Tenant: "erun", Environment: "local"}
+	handler := newActivityTraceLineHandler(app, selection, sessionKindLocal)
+	handler("==> Deploying erun/local · erun-backend-postgres 18.3")
+	entry, ok := app.activityQueue.findActiveByCommand("deploy", "erun", "local")
+	if !ok {
+		t.Fatal("expected a deploy entry after the component ==> Deploying line")
+	}
+	if entry.Release != "erun-backend-postgres" {
+		t.Fatalf("expected release erun-backend-postgres, got %q", entry.Release)
+	}
+	if entry.Version != "18.3" {
+		t.Fatalf("expected the component version 18.3, got %q", entry.Version)
+	}
+	if !strings.Contains(entry.Summary, "· erun-backend-postgres") {
+		t.Fatalf("expected a component-labeled summary, got %q", entry.Summary)
+	}
+}
+
+func TestActivityTraceLineHandlerRuntimeDeployFallsBackToRuntimeRelease(t *testing.T) {
+	// The runtime chart's ==> Deploying line carries no release token; the
+	// entry falls back to the runtime release name and is not
+	// component-labeled (the runtime line shape is unchanged by #531).
+	app := newTestAppForActivityQueue(t)
+	selection := uiSelection{Tenant: "erun", Environment: "local"}
+	handler := newActivityTraceLineHandler(app, selection, sessionKindLocal)
+	handler("==> Deploying erun/local 1.0.0")
+	entry, ok := app.activityQueue.findActiveByCommand("deploy", "erun", "local")
+	if !ok {
+		t.Fatal("expected a deploy entry after the runtime ==> Deploying line")
+	}
+	if entry.Release != releaseNameForTenant("erun") {
+		t.Fatalf("expected runtime release %q, got %q", releaseNameForTenant("erun"), entry.Release)
+	}
+	if entry.Version != "1.0.0" {
+		t.Fatalf("expected version 1.0.0, got %q", entry.Version)
+	}
+	if strings.Contains(entry.Summary, "·") {
+		t.Fatalf("runtime deploy summary must not be component-labeled, got %q", entry.Summary)
+	}
+}
+
 func TestActivityTraceLineHandlerFinalizesUsingTenantEnvFromLine(t *testing.T) {
 	// Regression: the trace handler used to look up the active deploy
 	// entry by the *session selection's* tenant/env when ==> Deployed


### PR DESCRIPTION
## Summary

`RunHelmDeploy` runs once per component, but the `==> Deploying` / `==> Deployed` / `==> Skipping` lines named only `<tenant>/<env> <version>`. A single non-runtime component deploy (e.g. `erun-backend-postgres`) therefore read as if the whole env was redeployed — at a version that wasn't even the env's (the component's own, like postgres `18.3`). The desktop activity drawer mislabeled it the same way.

## Change

**CLI (`erun-common/deploy.go`)** — name the release for a **non-runtime** component:
`==> Deploying erun/local · erun-backend-postgres 18.3`. The **runtime** chart's line is unchanged (`erun/local 18.3`) — it is the env, carries the meaningful runtime version, and feeds the helm-release poller + version persistence (#476). The same `target` label drives `==> Skipping`.

**Desktop (`erun-ui/activity_queue_app.go`)** — the matcher contract these lines feed:
- `activityDeployingLineRe` captures the optional ` · release` token; `startDeployFromTrace` threads it into the entry so a component deploy is **labeled by component** (`deploy erun/local · erun-backend-postgres`) and the entry's `Release` is the actual release rather than the hardcoded runtime release.
- **Fix the two `^==> Deploy failed` matchers** that #559 silently broke: #559 changed the CLI failure line to `==> Deploy of <rel> failed after <elapsed>`, which `^==> Deploy failed` no longer matches — so a failed component deploy was no longer recognized by the activity drawer (`activity_queue_app.go:391`) or the session-ready gate (`:945`). Both now match `^==> Deploy (?:of \S+ )?failed`.

## Plan delta vs the issue

- Defect #3 (`==> Deploy failed` carrying no identity) was **already fixed by #559** (`==> Deploy of <rel> failed`). This PR instead fixes the desktop side #559 left stale — a latent regression where failed deploys stopped finalizing in the drawer.
- **18 goldens, 0 changed.** No golden-based real-run scenario deploys a *non-runtime* component (they deploy the runtime chart, whose format is unchanged), so regenerating produced no diff. The new format is locked by the real-run `real_run_parallel_step_deploys_charts_concurrently` scenario, updated to assert that exactly one of the two concurrent rollouts names the component.

## Scope boundary

The deploy activity entry keeps its `(command, tenant, env)` key. That key is load-bearing for `latestDeployFailed` / reconnect throttling and the helm poller, and parallel component deploys already shared it (identical lines) before this change. Re-keying deploy entries by release would ripple into reconnect/poller logic with regression risk disproportionate to the edge case (parallel component deploys observed in the drawer), so it is out of scope — the headline bug (misleading line + drawer label) is fully fixed.

## Validation

- `make integration-test` green, coverage 77.4% ≥ 75.0%. `real_run_parallel_step_deploys_charts_concurrently` now asserts the runtime line names only the env and exactly one line names the component (both `==> Deploying` and `==> Deployed`).
- `erun-ui` `go test`: new matcher tests cover the component label, the runtime fallback, the `==> Deploy of <rel> failed` finalization, and the session-ready matcher. (Unrelated pre-existing `TestCloseReapsWholeProcessGroup` fails identically on `main` in this sandbox — real-process orphan reaping the sandbox can't deliver; not touched here.)
- **Playwright:** a real component deploy can't be staged in the headless harness (needs a cluster + helm), and this is a backend matcher change with no new frontend control. The owning coverage is the `erun-ui` Go matcher tests, per `erun-ui/AGENTS.md` § End-to-end UI tests (cluster-bound exception).

## UX Impact Review

- **Affected path:** PTY trace observation → activity-drawer entry for a deploy. A component deploy is now labeled by component instead of reading as a full-env redeploy; a failed deploy is again finalized in the drawer (fixing the #559 regression).
- **Visibility of system status (Nielsen #1):** the drawer now tells the truth about which release rolled and whether it failed — the prior state showed a stuck/mislabeled entry.

## Docs

Exempt — the `==> Deploying` trace-line format is not documented in `erun-docs` (internal output wording); confirmed via grep. The desktop matcher contract lives in `erun-ui/AGENTS.md` § Command Completion, which already treats these as a public trace-line API.

Closes #531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)