### PR TITLE
Add a Clear (view-baseline) button to the erun-trace pane

### DIFF
--- a/erun-docs/docs/desktop/overview.md
+++ b/erun-docs/docs/desktop/overview.md
@@ -27,6 +27,8 @@ When something misbehaves, the panel at the bottom of the terminal area gives yo
 
 Both panes have a **Copy** button for their own stream, and the console's **Copy report** button packages everything at once — app build, the selected environment's identity and state, the erun trace (or the reason there isn't one), and the UI trace — into a single paste-ready block, so a bug report carries the evidence instead of a description of it.
 
+On a busy environment the erun trace can be a wall of scrollback. **Clear** baselines the view — it hides the lines shown so far so whatever happens next stands out — without deleting anything: the persistent log stays intact, **Show all** brings the earlier lines back, and Copy and Copy report always include the full log. The baseline is per-environment, so switching environments starts fresh.
+
 ## Open it in your editor
 
 - **Persistent terminal sessions.** Each environment owns its own terminals, and switching tabs doesn't kill them. For an environment backed by a runtime pod, the sessions live in the pod and keep running even while the environment is closed — a long-running Agent keeps working while you're away — so reopening reconnects you to the same sessions and scrollback instead of starting fresh ones.

--- a/erun-ui/frontend/src/app/erunTraceBaseline.ts
+++ b/erun-ui/frontend/src/app/erunTraceBaseline.ts
@@ -1,0 +1,50 @@
+import * as React from 'react';
+
+// ErunTraceBaseline is the resolved state of the erun-trace "Clear" view
+// baseline (issue #529).
+export interface ErunTraceBaseline {
+  // cleared is true once the operator has clicked Clear and has not yet
+  // returned to the full view.
+  cleared: boolean;
+  // rotatedOut is true when the captured cut point has scrolled out of the
+  // bounded on-disk tail, so the suffix can no longer be computed and the
+  // pane has fallen back to showing everything.
+  rotatedOut: boolean;
+  // visibleContent is what the pane should render: the slice after the cut
+  // point while it is still present, otherwise the full content.
+  visibleContent: string;
+  clear: () => void;
+  showAll: () => void;
+}
+
+// useErunTraceBaseline implements the erun-trace Clear as a per-env view
+// baseline: Clear records the trace content as it stands and the pane then
+// renders only what arrives after it, so new lines stand out on a busy env.
+// It is a view aid only — the persistent log is never truncated and callers
+// keep reading the full content for Refresh / Copy / Copy report. It degrades
+// safely against log rotation (the on-disk trace is a bounded tail, #508):
+// the suffix is shown only while the current content still starts with the
+// captured baseline; once the cut point rotates out, it falls back to showing
+// all. The baseline resets whenever envKey changes so a stale cut point never
+// carries across environments.
+export function useErunTraceBaseline(envKey: string, content: string): ErunTraceBaseline {
+  const [baseline, setBaseline] = React.useState<string | null>(null);
+  React.useEffect(() => {
+    setBaseline(null);
+  }, [envKey]);
+  const clear = React.useCallback(() => {
+    setBaseline(content);
+  }, [content]);
+  const showAll = React.useCallback(() => {
+    setBaseline(null);
+  }, []);
+  const cleared = baseline !== null;
+  const stillPrefix = baseline !== null && content.startsWith(baseline);
+  return {
+    cleared,
+    rotatedOut: cleared && !stillPrefix,
+    visibleContent: stillPrefix ? content.slice(baseline.length) : content,
+    clear,
+    showAll,
+  };
+}

--- a/erun-ui/frontend/src/components/app/DebugPanel.tsx
+++ b/erun-ui/frontend/src/components/app/DebugPanel.tsx
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import { stateApi } from '@/app/api/stateApi';
 import { formatDiagnosticsReport } from '@/app/diagnosticsReport';
+import { useErunTraceBaseline } from '@/app/erunTraceBaseline';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { setDebugOpen, startDebugResize } from '@/app/layoutThunks';
 import {
@@ -326,27 +327,78 @@ function ErunTracePane({ selection }: { selection: UISelection | null }): React.
   const environment = selection?.environment ?? '';
   const { trace, refresh } = useEnvTracePoll(tenant, environment);
   const content = trace?.content ?? '';
-  const { outputRef, handleScroll } = useStickToBottom(content);
+  // The Clear view baseline (issue #529) is owned by useErunTraceBaseline; the
+  // pane only renders its result. Refresh / Copy / Copy report all keep
+  // reading the full `content`, so a cleared view never truncates a report.
+  const { cleared, rotatedOut, visibleContent, clear, showAll } = useErunTraceBaseline(
+    `${tenant}/${environment}`,
+    content,
+  );
+  const { outputRef, handleScroll } = useStickToBottom(visibleContent);
 
-  // The toolbar sits in its own grid row, outside the scroll region:
-  // stick-to-bottom would otherwise scroll the actions out the top the
-  // moment the log outgrows the pane — an affordance that exists but cannot
-  // be seen does not exist (issue #514).
+  // The toolbar (and the since-cleared notice) sit in their own grid rows,
+  // outside the scroll region: stick-to-bottom would otherwise scroll the
+  // actions out the top the moment the log outgrows the pane — an affordance
+  // that exists but cannot be seen does not exist (issue #514).
   return (
-    <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)]">
+    <div
+      className={cn(
+        'grid min-h-0',
+        cleared ? 'grid-rows-[auto_auto_minmax(0,1fr)]' : 'grid-rows-[auto_minmax(0,1fr)]',
+      )}
+    >
       <ErunTraceToolbar
         label={erunTraceLabel(tenant, environment, trace)}
         content={content}
+        canClear={content.trim().length > 0}
         onRefresh={refresh}
+        onClear={clear}
       />
+      {cleared && <ClearedNotice rotatedOut={rotatedOut} onShowAll={showAll} />}
       <div
         ref={outputRef}
         onScroll={handleScroll}
         className="min-h-0 overflow-auto px-3 pb-2 font-mono text-[11px] leading-[1.35] text-[oklch(0.82_0_0)]"
         aria-label="erun trace output"
       >
-        <ErunTraceBody tenant={tenant} environment={environment} trace={trace} />
+        <ErunTraceBody
+          tenant={tenant}
+          environment={environment}
+          trace={trace}
+          visibleContent={visibleContent}
+          cleared={cleared}
+        />
       </div>
+    </div>
+  );
+}
+
+// ClearedNotice surfaces why earlier lines vanished after Clear and offers a
+// one-click return to the full view (issue #529). Visibility of system status
+// (Nielsen #1) + user control / reversibility (Nielsen #3): the baseline hides
+// scrollback but the operator can always recover it, and the persistent log is
+// untouched. Lives in its own pinned grid row so it is never scrolled away.
+function ClearedNotice({
+  rotatedOut,
+  onShowAll,
+}: {
+  rotatedOut: boolean;
+  onShowAll: () => void;
+}): React.ReactElement {
+  return (
+    <div className="flex items-center justify-between gap-2 border-b border-[oklch(0.14_0_0)] px-3 py-1 text-[10px] text-[oklch(0.55_0_0)]">
+      <span className="min-w-0 truncate">
+        {rotatedOut
+          ? 'Cleared entries have rotated out of the log — showing all.'
+          : 'Showing entries since you cleared.'}
+      </span>
+      <button
+        type="button"
+        className="flex-none cursor-pointer rounded border-0 bg-transparent px-1 text-[10px] text-[oklch(0.7_0_0)] underline-offset-2 hover:underline"
+        onClick={onShowAll}
+      >
+        Show all
+      </button>
     </div>
   );
 }
@@ -361,12 +413,18 @@ function erunTraceLabel(tenant: string, environment: string, trace: UIEnvTrace |
 function ErunTraceToolbar({
   label,
   content,
+  canClear,
   onRefresh,
+  onClear,
 }: {
   label: string;
   content: string;
+  canClear: boolean;
   onRefresh: () => void;
+  onClear: () => void;
 }): React.ReactElement {
+  // Copy reads the full content, never the cleared view — a baselined view
+  // must never produce a truncated bug report (issue #529).
   const { copyStatus, copy } = useCopyAction(content);
   return (
     <div className="flex items-center justify-between gap-2 px-3 pt-1.5 pb-1">
@@ -383,6 +441,17 @@ function ErunTraceToolbar({
           Refresh
         </Button>
         <CopyButton copyStatus={copyStatus} disabled={!content.trim()} onCopy={copy} />
+        <Button
+          className="h-6 px-2 text-[11px] [&_svg]:size-3.5"
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={!canClear}
+          onClick={onClear}
+        >
+          <Trash2 aria-hidden="true" />
+          Clear
+        </Button>
       </span>
     </div>
   );
@@ -392,10 +461,14 @@ function ErunTraceBody({
   tenant,
   environment,
   trace,
+  visibleContent,
+  cleared,
 }: {
   tenant: string;
   environment: string;
   trace: UIEnvTrace | null;
+  visibleContent: string;
+  cleared: boolean;
 }): React.ReactElement | null {
   if (!tenant || !environment) {
     return (
@@ -406,12 +479,19 @@ function ErunTraceBody({
     return null;
   }
   if (trace.available) {
+    // visibleContent is the cleared-view slice (== trace.content when not
+    // cleared). When cleared and nothing new has arrived yet, say so rather
+    // than rendering a blank pane (visibility of system status, #529).
     return (
       <>
         <TraceNotice notice={trace.notice} />
-        <pre className="m-0 font-mono text-[11px] leading-[1.35] break-words whitespace-pre-wrap">
-          {trace.content}
-        </pre>
+        {cleared && visibleContent.length === 0 ? (
+          <p className="m-0 text-[oklch(0.6_0_0)]">No new entries since you cleared.</p>
+        ) : (
+          <pre className="m-0 font-mono text-[11px] leading-[1.35] break-words whitespace-pre-wrap">
+            {visibleContent}
+          </pre>
+        )}
       </>
     );
   }

--- a/erun-ui/playwright/pages/DebugPanel.ts
+++ b/erun-ui/playwright/pages/DebugPanel.ts
@@ -54,6 +54,19 @@ export class DebugPanel {
     return this.page.getByRole('button', { name: 'Clear' });
   }
 
+  // erunTraceClearButton scopes to the erun-trace pane's grid (toolbar +
+  // scroll body share a parent), disambiguating from other "Clear" buttons
+  // elsewhere in the app (e.g. the activity panel) when an environment is open.
+  erunTraceClearButton(): Locator {
+    return this.erunTracePane().locator('..').getByRole('button', { name: 'Clear', exact: true });
+  }
+
+  // erunTraceShowAllButton is the "Show all" affordance in the since-cleared
+  // notice row, scoped to the same erun-trace grid.
+  erunTraceShowAllButton(): Locator {
+    return this.erunTracePane().locator('..').getByRole('button', { name: 'Show all' });
+  }
+
   copyReportButton(): Locator {
     return this.page.getByRole('button', { name: /^(Copy report|Copied|Copy failed)$/ });
   }

--- a/erun-ui/playwright/tests/diagnostics-console.spec.ts
+++ b/erun-ui/playwright/tests/diagnostics-console.spec.ts
@@ -38,6 +38,10 @@ test.describe('diagnostics console', () => {
     await expect(app.debugPanel.refreshButton()).toBeVisible();
     await expect(app.debugPanel.copyButton()).toBeVisible();
     await expect(app.debugPanel.copyReportButton()).toBeVisible();
+    // #529: the erun-trace toolbar offers Clear (parity with UI trace),
+    // disabled until there is trace content to baseline.
+    await expect(app.debugPanel.clearButton()).toBeVisible();
+    await expect(app.debugPanel.clearButton()).toBeDisabled();
   });
 
   test('pane actions live outside the scroll regions and the report button spans tabs', async ({

--- a/erun-ui/playwright/tests/diagnostics-erun-trace-clear.spec.ts
+++ b/erun-ui/playwright/tests/diagnostics-erun-trace-clear.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from '../fixtures/erunApp.js';
+import {
+  SEED_TENANT,
+  removeEnvironment,
+  seedEnvironment,
+  uniqueEnvironmentName,
+} from '../fixtures/seedRoot.js';
+
+// #529: the erun-trace pane gains a non-destructive "Clear" that baselines the
+// view — it hides everything currently shown so new lines stand out, without
+// truncating the persistent log or the Copy / Copy-report reads.
+//
+// The headless harness can't populate a real trace.log for an inert seeded env
+// (capture depends on which commands ran, #508/#483), so these stub the
+// LoadEnvTrace RPC over /__erun_invoke to drive deterministic, evolving
+// content — the same technique sidebar-upgrade-all.spec.ts uses for
+// ResolveUpgradePlan. The baseline math itself (suffix vs rotation fallback)
+// is owned by the unit-level hook useErunTraceBaseline; here we lock the
+// rendered behaviour end to end.
+test.describe('diagnostics erun-trace clear', () => {
+  test.beforeEach(async ({ app }) => {
+    if (!(await app.debugPanel.isOpen())) {
+      await app.debugPanel.toggle();
+      await expect(app.debugPanel.resizeHandle()).toBeVisible();
+    }
+    await app.debugPanel.selectTab('erun trace');
+  });
+
+  test.afterEach(async ({ app }) => {
+    if (await app.debugPanel.isOpen()) {
+      await app.debugPanel.toggle();
+    }
+  });
+
+  test('Clear baselines the view; new lines stand out and Show all restores', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    // Mutable so a later poll tick can deliver a line that arrived "after" the
+    // baseline; every other RPC passes through untouched.
+    let extra = '';
+    await page.route('**/__erun_invoke', async (route, request) => {
+      const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+      if (body.method === 'LoadEnvTrace') {
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: {
+              available: true,
+              path: `/seed/${seededEnv.tenant}/${seededEnv.environment}/trace.log`,
+              content: `TRACE-OLD-1\nTRACE-OLD-2\n${extra}`,
+            },
+          }),
+        });
+      }
+      await route.continue();
+    });
+
+    // Selecting the env drives the erun-trace pane (the console is already open
+    // on the erun-trace tab from beforeEach).
+    await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    const pane = app.debugPanel.erunTracePane();
+    await expect(pane).toContainText('TRACE-OLD-1', { timeout: 10_000 });
+
+    // Clear baselines the view: the pre-clear lines vanish, the since-cleared
+    // notice explains why, and (nothing new yet) the pane says so.
+    await app.debugPanel.erunTraceClearButton().click();
+    await expect(page.getByText('Showing entries since you cleared.')).toBeVisible();
+    await expect(pane).not.toContainText('TRACE-OLD-1');
+    await expect(pane).toContainText('No new entries since you cleared.');
+
+    // A line that arrives after the baseline stands out; the pre-clear lines
+    // stay hidden.
+    extra = 'TRACE-NEW-1\n';
+    await expect(pane).toContainText('TRACE-NEW-1', { timeout: 10_000 });
+    await expect(pane).not.toContainText('TRACE-OLD-1');
+
+    // Show all is reversible and non-destructive: the full log returns, proving
+    // Clear never truncated the underlying content (Copy / Copy report read the
+    // same full content, never the cleared view).
+    await app.debugPanel.erunTraceShowAllButton().click();
+    await expect(pane).toContainText('TRACE-OLD-1');
+    await expect(page.getByText('Showing entries since you cleared.')).toBeHidden();
+  });
+
+  test('the baseline is per-env: switching envs resets it', async ({ app, page, seededEnv }) => {
+    // Two throwaway envs (seededEnv plus one seeded inline) so opening both
+    // never leaves the shared baseline rows open for other specs. Per-env
+    // content keyed off the LoadEnvTrace args makes a leaked cut point visible.
+    const envA = seededEnv.environment;
+    const envB = uniqueEnvironmentName('per-env-reset-b');
+    seedEnvironment(SEED_TENANT, envB);
+    try {
+      await app.sidebar
+        .envRowButton(SEED_TENANT, envB)
+        .waitFor({ state: 'visible', timeout: 10_000 });
+
+      await page.route('**/__erun_invoke', async (route, request) => {
+        const body = JSON.parse(request.postData() ?? '{}') as {
+          method: string;
+          args?: { environment?: string }[];
+        };
+        if (body.method === 'LoadEnvTrace') {
+          const envName = body.args?.[0]?.environment ?? '';
+          return route.fulfill({
+            contentType: 'application/json',
+            body: JSON.stringify({
+              data: {
+                available: true,
+                path: `/seed/trace.log`,
+                content: `LINE-FOR-${envName}-1\nLINE-FOR-${envName}-2\n`,
+              },
+            }),
+          });
+        }
+        await route.continue();
+      });
+
+      await app.sidebar.openEnvironment(SEED_TENANT, envA);
+      const pane = app.debugPanel.erunTracePane();
+      await expect(pane).toContainText(`LINE-FOR-${envA}-1`, { timeout: 10_000 });
+
+      await app.debugPanel.erunTraceClearButton().click();
+      await expect(page.getByText('Showing entries since you cleared.')).toBeVisible();
+
+      // Switching to a different env resets the baseline — the cleared state
+      // must not carry across, and the new env's content shows in full.
+      await app.sidebar.openEnvironment(SEED_TENANT, envB);
+      await expect(page.getByText('Showing entries since you cleared.')).toBeHidden();
+      await expect(pane).toContainText(`LINE-FOR-${envB}-1`, { timeout: 10_000 });
+    } finally {
+      removeEnvironment(SEED_TENANT, envB);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The Diagnostics console's **erun trace** pane had no way to baseline the view, so on a busy env it was a wall of scrollback with no way to tell which lines were new. This adds a **Clear** button to the erun-trace toolbar (next to Refresh/Copy, mirroring the UI-trace Clear) that **baselines the view** — it hides everything currently shown so new lines stand out, under a "Showing entries since you cleared · **Show all**" affordance.

Clear is a view aid, never destructive — the inverse of the UI-trace Clear, which wipes an ephemeral buffer:
- The persistent on-disk log (`~/.erun/<tenant>/<env>/trace.log`) is untouched.
- **Refresh, Copy, and Copy report all keep reading the full trace**, so a cleared view never produces a truncated bug report.
- **Show all** returns to the full view; the baseline is **per-env** (keyed on tenant/env) so switching envs starts fresh.
- It degrades safely against the bounded, rotating on-disk tail (#508): the suffix is shown only while the current content still starts with the captured baseline; once the cut point rotates out, it falls back to showing all under a notice.

## Implementation

- New focused hook `useErunTraceBaseline` (`erun-ui/frontend/src/app/erunTraceBaseline.ts`) owns the baseline math (suffix vs rotation fallback, per-env reset). `ErunTracePane` only renders its result.
- `ErunTraceToolbar` gains the Clear button (disabled when there is no content); a pinned `ClearedNotice` row carries the "since cleared / Show all" affordance — both outside the scroll region (the #514 invariant the existing spec locks).

## UX gate (per `erun-ui/AGENTS.md` § Professional UX)

- **Task:** distinguish "what just happened" from accumulated history on a high-volume persistent log. **Control:** a non-destructive Clear with a visible "since cleared / Show all" state.
- **Visibility of system status (#1):** the notice explains why earlier lines vanished and "No new entries since you cleared." covers the empty case, preventing "where did my log go?" confusion.
- **User control & error prevention (#3, #5):** non-destructive (log + full Copy/Copy-report intact) and reversible (Show all) — no confirmation needed precisely because nothing is destroyed.
- **Consistency (#4):** mirrors the UI-trace tab's Clear placement/icon; the behavioural difference (baseline vs buffer-wipe) is the persistent-vs-ephemeral distinction, noted here.
- **Accessibility:** semantic, keyboard-reachable buttons; the disabled state when empty.

## Validation

- Frontend gates green: `yarn typecheck && yarn lint && yarn format:check && yarn build`.
- **Playwright** (`diagnostics-erun-trace-clear.spec.ts`, new): stubs `LoadEnvTrace` over `/__erun_invoke` (the `sidebar-upgrade-all` technique) on throwaway envs to drive evolving content, and asserts the full flow — Clear baselines (old lines hidden, since-cleared notice, "No new entries"), a line arriving after the baseline stands out while pre-clear lines stay hidden, **Show all** restores the full log (proving Clear is non-destructive), and the baseline resets when switching envs. The existing tabs test also asserts Clear is present and disabled when empty. 3 focused specs pass. (The on-disk `trace.log` itself can't be staged headlessly per #508/#483, so content is stubbed; the baseline math is additionally owned by the `useErunTraceBaseline` hook.)
- No CLI/integration/Go surface — frontend-only; the UI-trace Clear is unchanged.

## Docs

`docs/desktop/overview.md` (Operator) — the diagnostics-console section, which enumerates the console controls, gains a paragraph on the erun-trace Clear: it baselines the view without deleting the log, Show all restores, Copy/Copy report stay full, and the baseline is per-environment. `yarn build` clean.

Closes #529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)