### PR TITLE
Review panel: auto-scroll the tree to follow the diff, mirror filter/collapse

### DIFF
--- a/erun-ui/frontend/src/app/TerminalController.ts
+++ b/erun-ui/frontend/src/app/TerminalController.ts
@@ -27,7 +27,7 @@ import type {
   TerminalWriteData,
 } from './model';
 import { showTerminalMessage } from './notificationThunks';
-import { visibleDiffPath } from './reviewDiffNavigation';
+import { scrollSelectedTreeNodeIntoView, visibleDiffPath } from './reviewDiffNavigation';
 import { setSelectedDiffPath } from './slices/reviewSlice';
 import {
   computeMaxReviewWidth,
@@ -79,6 +79,7 @@ export class TerminalController {
   private _reviewView: HTMLElement | null = null;
   private reviewMain: HTMLDivElement | null = null;
   private _diffList: HTMLDivElement | null = null;
+  private treeContainer: HTMLDivElement | null = null;
   private resizeObserver: ResizeObserver | null = null;
   private resizeTimer = 0;
   private resizeFrame = 0;
@@ -126,6 +127,16 @@ export class TerminalController {
 
   get diffList(): HTMLDivElement | null {
     return this._diffList;
+  }
+
+  // setTreeContainer registers the changed-files tree's scroll container so the
+  // diff→tree scrollspy can keep the active node visible (#547). It is a
+  // callback ref, not part of mount(): the tree container is conditionally
+  // rendered (only while the Changed files section is open), so it mounts and
+  // unmounts independently of the one-time controller mount — passing null on
+  // unmount keeps the reference from going stale.
+  setTreeContainer(element: HTMLDivElement | null): void {
+    this.treeContainer = element;
   }
 
   terminalSize(): { cols: number; rows: number } {
@@ -494,6 +505,11 @@ export class TerminalController {
       return;
     }
     store.dispatch(setSelectedDiffPath(path));
+    // Keep the now-active node visible in the changed-files tree (#547). Only
+    // the diff→tree direction drives this, and it scrolls the tree container,
+    // never the diff — so it can't feed back into visibleDiffPath above (which
+    // reads the diff/reviewMain scroll position) and re-trigger selection.
+    scrollSelectedTreeNodeIntoView(this.treeContainer, path);
   }
 
   // Review-diff refresh timer accessors. reviewThunks owns the polling logic

--- a/erun-ui/frontend/src/app/diffUtils.ts
+++ b/erun-ui/frontend/src/app/diffUtils.ts
@@ -37,6 +37,22 @@ export function visibleDiffTreeNodes(
   });
 }
 
+// visibleDiffFilePaths returns the set of file paths the changed-files tree is
+// currently showing — after the active filter and the collapsed directories.
+// The diff panel uses it to render the same subset the tree shows (in the
+// tree's pre-order, since ParseGitDiff already ordered diff.files to match the
+// tree, #435), so an active filter or a collapsed directory can't make the two
+// panels disagree (#547). An empty tree (no filter, nothing collapsed) yields
+// every file, so the unfiltered diff is unchanged.
+export function visibleDiffFilePaths(
+  tree: DiffTreeNode[],
+  filter: string,
+  collapsedDirs: Set<string>,
+): Set<string> {
+  const visible = visibleDiffTreeNodes(filterDiffTree(tree, filter), collapsedDirs);
+  return new Set(visible.filter((node) => node.type === 'file').map((node) => node.path));
+}
+
 export function chooseSelectedDiffPath(diff: DiffResult | null, currentPath: string): string {
   const files = diff?.files ?? [];
   if (files.some((file) => file.path === currentPath)) {

--- a/erun-ui/frontend/src/app/reviewDiffNavigation.ts
+++ b/erun-ui/frontend/src/app/reviewDiffNavigation.ts
@@ -13,6 +13,33 @@ export function scrollSelectedDiffIntoView(
     ?.scrollIntoView({ block: 'start', behavior: 'smooth' });
 }
 
+// scrollSelectedTreeNodeIntoView keeps the changed-files tree's active node
+// visible as the diff is scrolled (#547). It scrolls the tree's own scroll
+// container only when the node is currently out of view (scroll-into-view-if-
+// needed, nearest edge), so it never fights the diff→tree scrollspy or yanks
+// the tree on every scroll tick. Driven solely by the diff→tree direction; it
+// acts on the tree container, never on the diff container.
+export function scrollSelectedTreeNodeIntoView(
+  treeContainer: HTMLDivElement | null,
+  selectedDiffPath: string,
+): void {
+  if (!selectedDiffPath || !treeContainer) {
+    return;
+  }
+  const selector = `[data-path="${cssEscape(selectedDiffPath)}"]`;
+  const node = treeContainer.querySelector<HTMLElement>(selector);
+  if (!node) {
+    return;
+  }
+  const containerRect = treeContainer.getBoundingClientRect();
+  const nodeRect = node.getBoundingClientRect();
+  if (nodeRect.top < containerRect.top) {
+    node.scrollIntoView({ block: 'start', behavior: 'smooth' });
+  } else if (nodeRect.bottom > containerRect.bottom) {
+    node.scrollIntoView({ block: 'end', behavior: 'smooth' });
+  }
+}
+
 export function visibleDiffPath(
   diffList: HTMLDivElement | null,
   reviewMain: HTMLDivElement | null,

--- a/erun-ui/frontend/src/components/app/DiffList.tsx
+++ b/erun-ui/frontend/src/components/app/DiffList.tsx
@@ -1,7 +1,7 @@
 import { AlertCircle, CheckCircle2, Copy, PlugZap, RefreshCw } from 'lucide-react';
 import * as React from 'react';
 
-import { compactDiffError, diffLineMark } from '@/app/diffUtils';
+import { compactDiffError, diffLineMark, visibleDiffFilePaths } from '@/app/diffUtils';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { reconnectCopy } from '@/app/reconnectCopy';
 import { loadReviewDiff, requestReconnect } from '@/app/reviewThunks';
@@ -31,9 +31,23 @@ export function DiffList(): React.ReactElement {
       />
     );
   }
-  const files = review.diff?.files ?? [];
-  if (files.length === 0) {
+  const allFiles = review.diff?.files ?? [];
+  if (allFiles.length === 0) {
     return <ReviewStatus>No changes</ReviewStatus>;
+  }
+  // Render the same subset the changed-files tree shows — honouring the active
+  // filter and collapsed directories — in the tree's order (diff.files is
+  // already ordered to match the tree, #435). Without this the diff panel
+  // showed every file while the tree showed a filtered/collapsed subset, which
+  // read as an order mismatch (#547).
+  const visiblePaths = visibleDiffFilePaths(
+    review.diff?.tree ?? [],
+    review.diffFilter,
+    new Set(review.collapsedDiffDirs),
+  );
+  const files = allFiles.filter((file) => visiblePaths.has(file.path));
+  if (files.length === 0) {
+    return <ReviewStatus>No matching files</ReviewStatus>;
   }
   return (
     <>

--- a/erun-ui/frontend/src/components/app/ReviewPanel.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewPanel.tsx
@@ -108,8 +108,20 @@ function ChangedFilesSplitter({
 
 function ChangedFilesAside({ visible }: { visible: boolean }): React.ReactElement {
   const dispatch = useAppDispatch();
+  const controller = useController();
   const changedFilesOpen = useAppSelector((state) => state.layout.changedFilesOpen);
   const diffFilter = useAppSelector((state) => state.review.diffFilter);
+  // Register the tree's own scroll container with the controller so the
+  // diff→tree scrollspy can keep the active node visible (#547). A callback
+  // ref (stable across renders) tracks the conditionally-rendered container:
+  // it passes the node on mount and null when the Changed files section
+  // collapses, so the controller never holds a detached node.
+  const setTreeContainer = React.useCallback(
+    (element: HTMLDivElement | null) => {
+      controller.setTreeContainer(element);
+    },
+    [controller],
+  );
   return (
     <aside
       className={cn(
@@ -136,7 +148,11 @@ function ChangedFilesAside({ visible }: { visible: boolean }): React.ReactElemen
               }}
             />
           </Label>
-          <div className="min-h-0 flex-1 overflow-auto overscroll-contain pt-3.5">
+          <div
+            ref={setTreeContainer}
+            aria-label="Changed files tree"
+            className="min-h-0 flex-1 overflow-auto overscroll-contain pt-3.5"
+          >
             <ChangedFileTree />
           </div>
         </>

--- a/erun-ui/playwright/pages/ReviewPanel.ts
+++ b/erun-ui/playwright/pages/ReviewPanel.ts
@@ -34,4 +34,35 @@ export class ReviewPanel {
   async toggleChangedFiles(): Promise<void> {
     await this.page.getByRole('button', { name: 'Toggle changed files list' }).click();
   }
+
+  // changedFilesTree is the tree's own scroll container (#547).
+  changedFilesTree(): Locator {
+    return this.page.getByLabel('Changed files tree');
+  }
+
+  // treeFilePaths returns the data-path of each file node in the changed-files
+  // tree, in render order (directory rows carry no data-path).
+  async treeFilePaths(): Promise<string[]> {
+    return this.changedFilesTree()
+      .locator('[data-path]')
+      .evaluateAll((els) => els.map((el) => el.getAttribute('data-path') ?? ''));
+  }
+
+  // diffSectionPaths returns the data-path of each rendered diff section, in
+  // DOM order.
+  async diffSectionPaths(): Promise<string[]> {
+    return this.page
+      .locator('.diff-file[data-path]')
+      .evaluateAll((els) => els.map((el) => el.getAttribute('data-path') ?? ''));
+  }
+
+  async collapseDirectory(name: string): Promise<void> {
+    await this.page.getByRole('button', { name: `${name} directory` }).click();
+  }
+
+  // currentTreeNode is the highlighted (active) file node the diff scrollspy
+  // selected.
+  currentTreeNode(): Locator {
+    return this.changedFilesTree().locator('[aria-current="true"]');
+  }
 }

--- a/erun-ui/playwright/tests/review-diff-tree.spec.ts
+++ b/erun-ui/playwright/tests/review-diff-tree.spec.ts
@@ -1,0 +1,196 @@
+import type { Page } from '@playwright/test';
+
+import { test, expect } from '../fixtures/erunApp.js';
+
+// #547: two related review-panel guarantees.
+//   Part 2 — the diff panel renders the same files as the changed-files tree,
+//   in the same order, honouring the active filter and collapsed directories.
+//   Part 1 — the tree scrolls to keep the file currently in the diff viewport
+//   visible as the diff is scrolled.
+//
+// The diff payload is stubbed via the LoadDiff RPC over /__erun_invoke (the
+// same technique sidebar-upgrade-all.spec.ts uses), so no live cluster is
+// needed. ParseGitDiff already orders diff.files to match the tree (#435);
+// these specs lock that the rendered panels agree.
+
+interface DiffLineStub {
+  kind: string;
+  oldLine: number | null;
+  newLine: number | null;
+  content: string;
+}
+interface DiffFileStub {
+  path: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  binary: boolean;
+  hunks: { header: string; lines: DiffLineStub[] }[];
+}
+interface DiffNodeStub {
+  name: string;
+  path: string;
+  parentPath?: string;
+  type: 'file' | 'directory';
+  depth: number;
+}
+
+function dirNode(path: string, name: string, depth: number): DiffNodeStub {
+  return { name, path, type: 'directory', depth };
+}
+function fileNode(path: string, name: string, parentPath: string, depth: number): DiffNodeStub {
+  return { name, path, parentPath, type: 'file', depth };
+}
+function diffFile(path: string, lines: number): DiffFileStub {
+  return {
+    path,
+    status: 'modified',
+    additions: lines,
+    deletions: 0,
+    binary: false,
+    hunks: [
+      {
+        header: `@@ -1,${String(lines)} +1,${String(lines)} @@`,
+        lines: Array.from({ length: lines }, (_, i) => ({
+          kind: 'add',
+          oldLine: null,
+          newLine: i + 1,
+          content: `${path}:${String(i)}`,
+        })),
+      },
+    ],
+  };
+}
+function diffResult(files: DiffFileStub[], tree: DiffNodeStub[]): unknown {
+  return {
+    rawDiff: '',
+    workingDirectory: '/seed',
+    summary: {
+      fileCount: files.length,
+      additions: files.reduce((sum, f) => sum + f.additions, 0),
+      deletions: 0,
+    },
+    files,
+    tree,
+    scope: 'current',
+    includesWorktree: true,
+  };
+}
+
+async function stubDiff(page: Page, diff: unknown): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+    if (body.method === 'LoadDiff') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: diff }),
+      });
+    }
+    await route.continue();
+  });
+}
+
+// Small two-directory tree for the order / filter / collapse cases. diff.files
+// is in tree pre-order (the #435 contract the desktop relies on).
+const SMALL_FILES = [diffFile('src/a.ts', 2), diffFile('src/b.ts', 2), diffFile('docs/c.md', 2)];
+const SMALL_TREE = [
+  dirNode('src', 'src', 0),
+  fileNode('src/a.ts', 'a.ts', 'src', 1),
+  fileNode('src/b.ts', 'b.ts', 'src', 1),
+  dirNode('docs', 'docs', 0),
+  fileNode('docs/c.md', 'c.md', 'docs', 1),
+];
+const SMALL_ORDER = ['src/a.ts', 'src/b.ts', 'docs/c.md'];
+
+test.describe('review diff/tree consistency', () => {
+  test('the diff panel renders files in the changed-files tree order', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    await stubDiff(page, diffResult(SMALL_FILES, SMALL_TREE));
+    await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+    await expect(review.changedFilesTree()).toBeVisible({ timeout: 10_000 });
+    await expect.poll(() => review.diffSectionPaths(), { timeout: 10_000 }).toEqual(SMALL_ORDER);
+    expect(await review.treeFilePaths()).toEqual(SMALL_ORDER);
+  });
+
+  test('an active filter narrows the diff panel and tree to the same files', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    await stubDiff(page, diffResult(SMALL_FILES, SMALL_TREE));
+    await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+    await expect.poll(() => review.diffSectionPaths(), { timeout: 10_000 }).toEqual(SMALL_ORDER);
+
+    await review.setDiffFilter('b.ts');
+    await expect.poll(() => review.treeFilePaths()).toEqual(['src/b.ts']);
+    await expect.poll(() => review.diffSectionPaths()).toEqual(['src/b.ts']);
+  });
+
+  test('collapsing a directory hides its files in both the tree and the diff', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    await stubDiff(page, diffResult(SMALL_FILES, SMALL_TREE));
+    await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+    await expect.poll(() => review.diffSectionPaths(), { timeout: 10_000 }).toEqual(SMALL_ORDER);
+
+    await review.collapseDirectory('src');
+    await expect.poll(() => review.treeFilePaths()).toEqual(['docs/c.md']);
+    await expect.poll(() => review.diffSectionPaths()).toEqual(['docs/c.md']);
+  });
+
+  test('the tree scrolls to keep the active file visible as the diff scrolls', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    // Enough tall files that the tree overflows its container and the active
+    // node would otherwise scroll out of view.
+    const big = Array.from({ length: 30 }, (_, i) => `pkg/f${String(i).padStart(2, '0')}.ts`);
+    const files = big.map((path) => diffFile(path, 18));
+    const tree = [
+      dirNode('pkg', 'pkg', 0),
+      ...big.map((path) => fileNode(path, path.slice('pkg/'.length), 'pkg', 1)),
+    ];
+    await stubDiff(page, diffResult(files, tree));
+    await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+    await expect
+      .poll(() => review.diffSectionPaths().then((paths) => paths.length), { timeout: 10_000 })
+      .toBe(30);
+
+    // Scroll the diff to its last section; the scrollspy selects a late file
+    // and the tree must scroll to keep that node visible.
+    await page.locator('.diff-file[data-path]').last().scrollIntoViewIfNeeded();
+
+    const node = review.currentTreeNode();
+    await expect(node).toBeVisible();
+    // The active node must lie within the tree container's visible rect — the
+    // auto-scroll guarantee. Without it the node would sit below the container
+    // after scrolling the diff to the bottom.
+    await expect
+      .poll(
+        async () => {
+          const nb = await node.boundingBox();
+          const cb = await review.changedFilesTree().boundingBox();
+          if (!nb || !cb) {
+            return false;
+          }
+          return nb.y >= cb.y - 2 && nb.y + nb.height <= cb.y + cb.height + 2;
+        },
+        { timeout: 10_000 },
+      )
+      .toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Two related review/diff-panel fixes (follow-up to #435).

### Part 1 — tree auto-scroll (new)

Scrolling the diff already highlighted the file currently in view in the **Changed files** tree, but the tree itself was never scrolled — so on a long file list the highlighted node ended up off-screen. Now the tree scrolls to keep the active node visible:

- `scrollSelectedTreeNodeIntoView` (`reviewDiffNavigation.ts`) scrolls the tree's own container **only when the node is out of view** (scroll-into-view-if-needed, nearest edge), called from `TerminalController.updateSelectedDiffPathFromScroll` after the scrollspy selects a path.
- **Echo-loop guard:** it is driven solely by the diff→tree direction and acts only on the tree container, never on `reviewMain`, so it can't feed back into `visibleDiffPath` (which reads the diff scroll position) and re-trigger selection. The existing `path === selectedDiffPath` early-return is preserved.
- The tree container is registered via a **callback ref** (`controller.setTreeContainer`), not the one-time `mount()`: it's conditionally rendered (only while Changed files is open), so it mounts/unmounts independently and a `MountElements` entry would be null at boot and go stale on collapse.

### Part 2 — diff order must match the tree (root cause confirmed)

`ParseGitDiff` already orders `diff.files` to match the tree (#435), and that code is intact — so the operator's persisting mismatch is the **filter/collapse-mirroring gap the issue flagged as most likely**, confirmed by code inspection: `DiffList` rendered `review.diff.files` directly while the tree applied `filterDiffTree` + `visibleDiffTreeNodes`. With an active filter or a collapsed directory the two panels showed different subsets, which reads as an order mismatch. `DiffList` now renders the same visible subset via a shared `visibleDiffFilePaths` helper, in the tree's order. (Confirming the cause by inspection meant no operator repro was needed; the ordering source-of-truth in `erun-common/diff.go` is unchanged.)

## Plan delta vs the issue

- The issue's mountElements path was `src/model/mountElements.ts`; it actually lives at `src/app/model/mountElements.ts` — and the callback-ref approach means it isn't touched at all.
- The POM-label concern was overstated: `"Resize diff panel"` (the terminal↔review splitter) and `"Resize changed files list"` (the files splitter) are two distinct live splitters; neither POM was broken, so no rename was needed. The new spec adds an accessible label (`"Changed files tree"`) to the tree scroll container for the geometry assertion rather than touching the splitters.

## UX Impact Review

- **Affected path:** diff scroll → scrollspy → tree highlight (now + tree auto-scroll); filter/collapse → both panels.
- **Visibility / recognition (Nielsen #1, #6):** the highlighted file stays visible in the tree as you scroll; the diff and tree always show the same files, so neither misrepresents the other.
- No new control; behaviour-preserving where the panels already agreed (no filter, nothing collapsed → identical rendering).

## Validation

- Frontend gates green: `yarn typecheck && yarn lint && yarn format:check && yarn build`.
- **Playwright** (`review-diff-tree.spec.ts`, new — stubs `LoadDiff` over `/__erun_invoke`): diff-section order == tree file-node order; an active filter narrows both panels to the same files; collapsing a directory hides its files in both; and the tree auto-scrolls so the active node stays within the tree container's rect after scrolling the diff. 4 pass. Existing `diff-error-copy` + `layout` specs still pass (no regression).
- No `erun-common`/CLI/integration change — the diff ordering (`reorderFilesByTree`) was already correct; this is a frontend rendering + scroll fix.

## Docs

Exempt — the desktop diff/changed-files panel is not a documented operator feature (referenced only within the Contribute flow in `docs/desktop/overview.md`), so these UX refinements have no operator-facing page to amend, and documenting the panel from scratch is out of scope for this fix.

Closes #547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)