### PR TITLE
Lint-green erun-mcp: extract helpers, drop deprecated filepath.HasPrefix

### DIFF
--- a/erun-mcp/credentials_file.go
+++ b/erun-mcp/credentials_file.go
@@ -38,14 +38,10 @@ func parseAWSCredentialsFile(data []byte) []awsCredentialProfile {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
+		if isCommentOrBlankLine(line) {
 			continue
 		}
-		if strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
-			continue
-		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			name := strings.TrimSpace(line[1 : len(line)-1])
+		if name, ok := parseAWSProfileHeader(line); ok {
 			if name == "" {
 				current = nil
 				continue
@@ -57,18 +53,41 @@ func parseAWSCredentialsFile(data []byte) []awsCredentialProfile {
 		if current == nil {
 			continue
 		}
-		eq := strings.IndexByte(line, '=')
-		if eq <= 0 {
-			continue
+		if entry, ok := parseAWSCredentialEntry(line); ok {
+			current.Entries = append(current.Entries, entry)
 		}
-		key := strings.TrimSpace(line[:eq])
-		value := strings.TrimSpace(line[eq+1:])
-		if key == "" {
-			continue
-		}
-		current.Entries = append(current.Entries, awsCredentialEntry{Key: key, Value: value})
 	}
 	return profiles
+}
+
+// isCommentOrBlankLine reports whether a trimmed credentials-file line carries
+// no profile data (empty, or a `#` / `;` comment).
+func isCommentOrBlankLine(line string) bool {
+	return line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";")
+}
+
+// parseAWSProfileHeader returns the profile name and true when line is a
+// `[name]` section header. The name may be empty (a malformed `[]`), which the
+// caller treats as ending the current profile.
+func parseAWSProfileHeader(line string) (string, bool) {
+	if !strings.HasPrefix(line, "[") || !strings.HasSuffix(line, "]") {
+		return "", false
+	}
+	return strings.TrimSpace(line[1 : len(line)-1]), true
+}
+
+// parseAWSCredentialEntry parses a `key = value` line into an entry. ok is
+// false for lines with no `=` or an empty key.
+func parseAWSCredentialEntry(line string) (awsCredentialEntry, bool) {
+	eq := strings.IndexByte(line, '=')
+	if eq <= 0 {
+		return awsCredentialEntry{}, false
+	}
+	key := strings.TrimSpace(line[:eq])
+	if key == "" {
+		return awsCredentialEntry{}, false
+	}
+	return awsCredentialEntry{Key: key, Value: strings.TrimSpace(line[eq+1:])}, true
 }
 
 func setAWSCredentialProfile(profiles []awsCredentialProfile, name string, entries []awsCredentialEntry) []awsCredentialProfile {

--- a/erun-mcp/credentials_test.go
+++ b/erun-mcp/credentials_test.go
@@ -86,23 +86,14 @@ func TestCloudInjectAWSCredentialsMergesIntoExistingFile(t *testing.T) {
 	if result.Profile != "erun-host" || result.Path != credsPath {
 		t.Fatalf("unexpected result: %+v", result)
 	}
-	data, err := os.ReadFile(credsPath)
-	if err != nil {
-		t.Fatalf("read back failed: %v", err)
-	}
-	content := string(data)
-	for _, want := range []string{
+	assertFileContainsAll(t, credsPath,
 		"[default]",
 		"aws_access_key_id = AKIA-USER",
 		"[erun-host]",
 		"aws_access_key_id = ASIA-HOST",
 		"aws_session_token = host-token",
 		"x_erun_expiration = 2026-05-19T18:30:00Z",
-	} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("expected credentials file to contain %q, got:\n%s", want, content)
-		}
-	}
+	)
 	stat, err := os.Stat(credsPath)
 	if err != nil {
 		t.Fatalf("stat failed: %v", err)
@@ -170,5 +161,21 @@ func TestCloudInjectAWSCredentialsRequiresKeyAndSecret(t *testing.T) {
 	tool := cloudInjectAWSCredentialsTool()
 	if _, _, err := tool(context.Background(), nil, InjectAWSCredentialsInput{AccessKeyID: "ASIA"}); err == nil {
 		t.Fatal("expected missing secret access key error")
+	}
+}
+
+// assertFileContainsAll reads path and fails unless every wanted substring is
+// present, reporting the missing substring and full content on failure.
+func assertFileContainsAll(t *testing.T, path string, wants ...string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back failed: %v", err)
+	}
+	content := string(data)
+	for _, want := range wants {
+		if !strings.Contains(content, want) {
+			t.Fatalf("expected file %s to contain %q, got:\n%s", path, want, content)
+		}
 	}
 }

--- a/erun-mcp/doctor.go
+++ b/erun-mcp/doctor.go
@@ -73,30 +73,35 @@ func runDoctorToolCommand(runtime RuntimeConfig, input DoctorInput, runCtx erunc
 	if err != nil {
 		return report, err
 	}
-	if fatal {
+	if fatal || onlyRootConfigDoctorInput(input) {
 		return report, nil
 	}
-	if onlyRootConfigDoctorInput(input) {
-		return report, nil
-	}
-	target, err := resolveDoctorOpenResult(runtime, input)
-	if err != nil {
-		return report, err
-	}
-	req := eruncommon.ShellLaunchParamsFromResult(target)
-	if err := writeDoctorDeployDiagnosis(runCtx, req); err != nil {
-		return report, err
-	}
-	if err := runDoctorRecoveryToolActions(runCtx, input, req); err != nil {
-		return report, err
-	}
-	if err := writeDoctorInspection(runCtx, target, req); err != nil {
-		return report, err
-	}
-	if err := runDoctorToolActions(runCtx, input, req); err != nil {
+	if err := runDoctorTenantEnvActions(runtime, input, runCtx); err != nil {
 		return report, err
 	}
 	return report, nil
+}
+
+// runDoctorTenantEnvActions resolves the open target for the env and runs the
+// tenant/env-scoped diagnosis, recovery, inspection, and prune actions in
+// order. Called only after the root-config flow reports non-fatal and the
+// caller asked for more than root-config work.
+func runDoctorTenantEnvActions(runtime RuntimeConfig, input DoctorInput, runCtx eruncommon.Context) error {
+	target, err := resolveDoctorOpenResult(runtime, input)
+	if err != nil {
+		return err
+	}
+	req := eruncommon.ShellLaunchParamsFromResult(target)
+	if err := writeDoctorDeployDiagnosis(runCtx, req); err != nil {
+		return err
+	}
+	if err := runDoctorRecoveryToolActions(runCtx, input, req); err != nil {
+		return err
+	}
+	if err := writeDoctorInspection(runCtx, target, req); err != nil {
+		return err
+	}
+	return runDoctorToolActions(runCtx, input, req)
 }
 
 // onlyRootConfigDoctorInput mirrors the CLI's doctorOnlyRepairConfig:
@@ -127,25 +132,10 @@ func runDoctorRootConfigToolFlow(runtime RuntimeConfig, input DoctorInput, runCt
 	report := &DoctorRootConfigReport{Inspection: inspection}
 
 	if selector := strings.TrimSpace(input.RestoreConfigFromBackup); selector != "" {
-		backup, ok, err := resolveDoctorBackupSelector(inspection, selector)
+		refreshed, err := restoreDoctorRootConfigFromBackup(runtime, runCtx, inspection, selector, report)
 		if err != nil {
 			return report, true, err
 		}
-		if !ok {
-			return report, true, fmt.Errorf("no root config backup matches %q", selector)
-		}
-		if !runCtx.DryRun {
-			if err := eruncommon.RestoreRootConfigFromBackup(backup.Path, inspection.ConfigPath); err != nil {
-				return report, true, err
-			}
-		}
-		runCtx.TraceCommand("", "cp", backup.Path, inspection.ConfigPath)
-		report.RestoredFromBackup = backup.Path
-		refreshed, refreshErr := eruncommon.InspectRootConfig(runtime.Store)
-		if refreshErr != nil {
-			return report, true, refreshErr
-		}
-		report.Inspection = refreshed
 		inspection = refreshed
 	}
 
@@ -153,24 +143,61 @@ func runDoctorRootConfigToolFlow(runtime RuntimeConfig, input DoctorInput, runCt
 		if err := runDoctorAliasRepairs(runtime, input, runCtx, inspection, report); err != nil {
 			return report, true, err
 		}
-		refreshed, refreshErr := eruncommon.InspectRootConfig(runtime.Store)
-		if refreshErr != nil {
-			return report, true, refreshErr
+		refreshed, err := refreshDoctorInspection(runtime, report)
+		if err != nil {
+			return report, true, err
 		}
-		report.Inspection = refreshed
 		inspection = refreshed
 	}
 
-	if inspection.ConfigStatus != eruncommon.RootConfigStatusOK {
-		return report, true, nil
-	}
-	if len(inspection.OrphanedAliases) > 0 && onlyRootConfigDoctorInput(input) {
-		// The caller scoped the work to root-config repair but did not
-		// supply enough input to finish it; surface the remaining
-		// orphans so the agent can re-call with the missing aliases.
+	if doctorRootConfigBlocks(inspection, input) {
 		return report, true, nil
 	}
 	return report, false, nil
+}
+
+// restoreDoctorRootConfigFromBackup applies a restore-from-backup selector,
+// traces the copy, records it on the report, and returns the inspection
+// refreshed from the restored file. Every failure here is fatal to the flow,
+// so the caller stops on a non-nil error.
+func restoreDoctorRootConfigFromBackup(runtime RuntimeConfig, runCtx eruncommon.Context, inspection eruncommon.RootConfigInspection, selector string, report *DoctorRootConfigReport) (eruncommon.RootConfigInspection, error) {
+	backup, ok, err := resolveDoctorBackupSelector(inspection, selector)
+	if err != nil {
+		return inspection, err
+	}
+	if !ok {
+		return inspection, fmt.Errorf("no root config backup matches %q", selector)
+	}
+	if !runCtx.DryRun {
+		if err := eruncommon.RestoreRootConfigFromBackup(backup.Path, inspection.ConfigPath); err != nil {
+			return inspection, err
+		}
+	}
+	runCtx.TraceCommand("", "cp", backup.Path, inspection.ConfigPath)
+	report.RestoredFromBackup = backup.Path
+	return refreshDoctorInspection(runtime, report)
+}
+
+// refreshDoctorInspection re-reads the root config after a mutation and stores
+// the fresh inspection on the report.
+func refreshDoctorInspection(runtime RuntimeConfig, report *DoctorRootConfigReport) (eruncommon.RootConfigInspection, error) {
+	refreshed, err := eruncommon.InspectRootConfig(runtime.Store)
+	if err != nil {
+		return eruncommon.RootConfigInspection{}, err
+	}
+	report.Inspection = refreshed
+	return refreshed, nil
+}
+
+// doctorRootConfigBlocks reports whether the root config is in a state that must
+// stop the flow before tenant/env work: the config is not OK, or orphaned
+// aliases remain and the caller scoped the run to root-config repair without
+// supplying enough input to finish it.
+func doctorRootConfigBlocks(inspection eruncommon.RootConfigInspection, input DoctorInput) bool {
+	if inspection.ConfigStatus != eruncommon.RootConfigStatusOK {
+		return true
+	}
+	return len(inspection.OrphanedAliases) > 0 && onlyRootConfigDoctorInput(input)
 }
 
 func runDoctorAliasRepairs(runtime RuntimeConfig, input DoctorInput, runCtx eruncommon.Context, inspection eruncommon.RootConfigInspection, report *DoctorRootConfigReport) error {

--- a/erun-mcp/idle_stop_test.go
+++ b/erun-mcp/idle_stop_test.go
@@ -29,21 +29,9 @@ func TestIdleStopRecordToolWritesHostManualEntry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("idleStopRecordTool returned err: %v", err)
 	}
-	if result.Tenant != "tenant-a" || result.Environment != "dev" {
-		t.Fatalf("unexpected resolved target: %+v", result)
-	}
-	if time.Since(result.StoppedAt) > 5*time.Second {
-		t.Fatalf("StoppedAt should be near time.Now(), got %v", result.StoppedAt)
-	}
+	assertRecentStopTarget(t, result, "tenant-a", "dev")
 
-	entries, err := eruncommon.LoadEnvironmentStopHistory("tenant-a", "dev")
-	if err != nil {
-		t.Fatalf("LoadEnvironmentStopHistory: %v", err)
-	}
-	if len(entries) != 1 {
-		t.Fatalf("expected 1 history entry, got %d", len(entries))
-	}
-	entry := entries[0]
+	entry := loadSingleStopHistoryEntry(t, "tenant-a", "dev")
 	if entry.Source != eruncommon.StopHistorySourceHostManual {
 		t.Fatalf("expected source=%q, got %q", eruncommon.StopHistorySourceHostManual, entry.Source)
 	}
@@ -100,14 +88,7 @@ func TestIdleStopRecordToolFoldsPendingArmedGrace(t *testing.T) {
 		t.Fatalf("idleStopRecordTool returned err: %v", err)
 	}
 
-	entries, err := eruncommon.LoadEnvironmentStopHistory("tenant-a", "dev")
-	if err != nil {
-		t.Fatalf("LoadEnvironmentStopHistory: %v", err)
-	}
-	if len(entries) != 1 {
-		t.Fatalf("expected 1 history entry, got %d", len(entries))
-	}
-	entry := entries[0]
+	entry := loadSingleStopHistoryEntry(t, "tenant-a", "dev")
 	if entry.Source != eruncommon.StopHistorySourceHostManual {
 		t.Fatalf("expected source=host-manual even with armed grace, got %q", entry.Source)
 	}
@@ -127,19 +108,9 @@ func TestIdleStopRecordToolFoldsPendingArmedGrace(t *testing.T) {
 		t.Fatalf("expected 2 markers, got %d", len(entry.Markers))
 	}
 	// The pending file should be cleared after the record so a
-	// follow-up stop-ready tick arms a fresh grace from scratch.
-	pendingPath, err := eruncommon.EnvironmentStopPendingPath("tenant-a", "dev")
-	if err != nil {
-		t.Fatalf("EnvironmentStopPendingPath: %v", err)
-	}
-	if _, err := os.Stat(pendingPath); !os.IsNotExist(err) {
-		t.Fatalf("expected pending file cleared, stat err=%v", err)
-	}
-	// Sanity: the file is genuinely in the temp HOME, not the
-	// developer's real HOME.
-	if !filepath.HasPrefix(pendingPath, home) {
-		t.Fatalf("pending path escapes temp HOME: %s", pendingPath)
-	}
+	// follow-up stop-ready tick arms a fresh grace from scratch, and it
+	// must genuinely live under the temp HOME, not the developer's.
+	assertStopPendingCleared(t, "tenant-a", "dev", home)
 }
 
 // TestIdleStopRecordToolRequiresTenantAndEnvironment guards against
@@ -149,5 +120,50 @@ func TestIdleStopRecordToolRequiresTenantAndEnvironment(t *testing.T) {
 	handler := idleStopRecordTool(RuntimeConfig{})
 	if _, _, err := handler(context.Background(), nil, IdleStopRecordInput{}); err == nil {
 		t.Fatal("expected error when tenant and environment are both empty")
+	}
+}
+
+// assertRecentStopTarget checks the recorded result echoes the resolved
+// tenant/environment and stamps StoppedAt at roughly time.Now().
+func assertRecentStopTarget(t *testing.T, result IdleStopRecordResult, tenant, env string) {
+	t.Helper()
+	if result.Tenant != tenant || result.Environment != env {
+		t.Fatalf("unexpected resolved target: %+v", result)
+	}
+	if time.Since(result.StoppedAt) > 5*time.Second {
+		t.Fatalf("StoppedAt should be near time.Now(), got %v", result.StoppedAt)
+	}
+}
+
+// loadSingleStopHistoryEntry loads the env's stop history and fails unless
+// exactly one entry is present, returning it.
+func loadSingleStopHistoryEntry(t *testing.T, tenant, env string) eruncommon.EnvironmentStopHistoryEntry {
+	t.Helper()
+	entries, err := eruncommon.LoadEnvironmentStopHistory(tenant, env)
+	if err != nil {
+		t.Fatalf("LoadEnvironmentStopHistory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 history entry, got %d", len(entries))
+	}
+	return entries[0]
+}
+
+// assertStopPendingCleared fails unless the env's pending-stop file is gone and
+// its resolved path sits under home (catching a path that escapes the temp
+// HOME). Uses filepath.IsLocal for the boundary check rather than the
+// deprecated filepath.HasPrefix.
+func assertStopPendingCleared(t *testing.T, tenant, env, home string) {
+	t.Helper()
+	pendingPath, err := eruncommon.EnvironmentStopPendingPath(tenant, env)
+	if err != nil {
+		t.Fatalf("EnvironmentStopPendingPath: %v", err)
+	}
+	if _, err := os.Stat(pendingPath); !os.IsNotExist(err) {
+		t.Fatalf("expected pending file cleared, stat err=%v", err)
+	}
+	rel, err := filepath.Rel(home, pendingPath)
+	if err != nil || !filepath.IsLocal(rel) {
+		t.Fatalf("pending path escapes temp HOME: %s", pendingPath)
 	}
 }

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -142,6 +142,19 @@ func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig) *mcp.Server {
 		Version: info.Version,
 	}, nil)
 
+	registerReadModelTools(server, info, runtime)
+	registerIdleStopTools(server, runtime)
+	registerCloudTools(server, runtime)
+	registerContextTools(server, runtime)
+	registerDeliveryTools(server, runtime)
+	registerInspectionTools(server, runtime)
+
+	return server
+}
+
+// registerReadModelTools registers the read-only build/config introspection
+// tools.
+func registerReadModelTools(server *mcp.Server, info eruncommon.BuildInfo, runtime RuntimeConfig) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "version",
 		Description: "Return build metadata for the current erun binary",
@@ -150,6 +163,10 @@ func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig) *mcp.Server {
 		Name:        "list",
 		Description: "List configured tenants and environments, defaults, and the effective target for the current runtime directory",
 	}, listTool(runtime))
+}
+
+// registerIdleStopTools registers the idle status and auto-stop audit tools.
+func registerIdleStopTools(server *mcp.Server, runtime RuntimeConfig) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "idle",
 		Description: "Return environment idle stop timeout and marker status without recording activity",
@@ -166,6 +183,11 @@ func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig) *mcp.Server {
 		Name:        "idle_stop_record",
 		Description: "Record a host-driven stop entry in stop-history.json (source=host-manual). Called by the desktop's Stop button after the AWS stop succeeds, so the History tab can also explain 'you clicked Stop' alongside the in-pod monitor's auto-stops.",
 	}, idleStopRecordTool(runtime))
+}
+
+// registerCloudTools registers the cloud-provider-alias and AWS-credential
+// tools.
+func registerCloudTools(server *mcp.Server, runtime RuntimeConfig) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "cloud_list",
 		Description: "List configured root-level cloud provider aliases and token status",
@@ -194,6 +216,10 @@ func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig) *mcp.Server {
 		Name:        "cloud_clear_aws_credentials",
 		Description: "Remove the erun-host profile from the runtime pod's ~/.aws/credentials",
 	}, cloudClearAWSCredentialsTool())
+}
+
+// registerContextTools registers the managed-cloud Kubernetes context tools.
+func registerContextTools(server *mcp.Server, runtime RuntimeConfig) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "context_list",
 		Description: "List managed ERun cloud Kubernetes contexts",
@@ -210,6 +236,11 @@ func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig) *mcp.Server {
 		Name:        "context_start",
 		Description: "Start a managed ERun cloud Kubernetes context, with preview support",
 	}, contextStartTool(runtime))
+}
+
+// registerDeliveryTools registers the init → build → push → deploy lifecycle
+// tools plus upgrade, doctor, and delete.
+func registerDeliveryTools(server *mcp.Server, runtime RuntimeConfig) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "init",
 		Description: "Run `erun init` using the shared init flow; when more input is needed, return a structured interaction request for the caller to answer in a follow-up tool call",
@@ -238,6 +269,11 @@ func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig) *mcp.Server {
 		Name:        "delete",
 		Description: "Delete an environment from ERun configuration and remove its remote runtime namespace after explicit tenant-environment confirmation",
 	}, deleteTool(runtime))
+}
+
+// registerInspectionTools registers the repo-state and source-contribution
+// tools that operate from the runtime repo root.
+func registerInspectionTools(server *mcp.Server, runtime RuntimeConfig) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "diff",
 		Description: "Return the current git diff from the runtime repo root as raw text plus structured file, hunk, line, and tree data",
@@ -254,6 +290,4 @@ func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig) *mcp.Server {
 		Name:        "contribute_clone",
 		Description: "Clone the ERun source repository into $HOME/git/erun inside the environment so contribute-mode tabs can build and run a local ERun checkout",
 	}, contributeCloneTool(runtime))
-
-	return server
 }


### PR DESCRIPTION
Second module in the #571 repo-wide lint cleanup. Clears all 8 pre-existing `golangci-lint` findings in `erun-mcp` by correcting the code — no rule suppression, no threshold change. Behavior-preserving.

| Finding | Fix |
|---|---|
| `parseAWSCredentialsFile` cyclop 11 | extract `isCommentOrBlankLine` / `parseAWSProfileHeader` / `parseAWSCredentialEntry` |
| `runDoctorToolCommand` cyclop 11 | extract `runDoctorTenantEnvActions` |
| `runDoctorRootConfigToolFlow` cyclop 14 | extract `restoreDoctorRootConfigFromBackup` / `refreshDoctorInspection` / `doctorRootConfigBlocks` (fatal/refresh semantics preserved) |
| `newServer` funlen 122 | split into per-category `register*Tools` helpers — same tools, same order |
| `TestIdleStopRecordTool*` cyclop 12/14 | extract `assertRecentStopTarget` / `loadSingleStopHistoryEntry` / `assertStopPendingCleared` |
| `TestCloudInjectAWSCredentialsMergesIntoExistingFile` cyclop 11 | extract `assertFileContainsAll` |
| `filepath.HasPrefix` deprecated (SA1019) | replace with `filepath.Rel` + `filepath.IsLocal` boundary check |

## Validation
- `erun-mcp`: `golangci-lint run ./...` → **exit 0**; `go test ./...` → **green**.
- No `erun-cli`/`erun-common` change, so the integration gate (which exercises the `erun` CLI binary, not `emcp`) is unaffected.

Part of #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)