### PR TITLE
Lint-green erun-common: extract helpers across 50 findings

### DIFF
--- a/erun-common/ai_launch_test.go
+++ b/erun-common/ai_launch_test.go
@@ -17,13 +17,7 @@ func TestAISessionLaunchCommand(t *testing.T) {
 	}
 
 	t.Run("default claude wraps in the cwd guard at the env effort", func(t *testing.T) {
-		got := AISessionLaunchCommand("", effort("high"))
-		if strings.Count(got, "--effort high") != 2 {
-			t.Fatalf("expected --effort high in both guard branches, got %q", got)
-		}
-		if !strings.Contains(got, "claude --continue --effort high") || !strings.Contains(got, "else claude --effort high") {
-			t.Fatalf("guard missing the resume/fresh branches: %q", got)
-		}
+		assertDefaultClaudeGuardAtEffort(t, effort("high"))
 	})
 
 	t.Run("explicit claude tool also uses the guard", func(t *testing.T) {
@@ -45,16 +39,7 @@ func TestAISessionLaunchCommand(t *testing.T) {
 	})
 
 	t.Run("unset and invalid effort both resolve to ultracode", func(t *testing.T) {
-		got := AISessionLaunchCommand("", EnvironmentClaudeConfig{})
-		if !strings.Contains(got, `--settings '{"ultracode":true}'`) || strings.Contains(got, "--effort") {
-			t.Fatalf("unset effort must default to ultracode via --settings, got %q", got)
-		}
-		// A bad persisted value must never reach the shell verbatim; it resolves
-		// to the default instead of injecting `--effort turbo`.
-		got = AISessionLaunchCommand("", effort("turbo"))
-		if strings.Contains(got, "turbo") || !strings.Contains(got, `--settings '{"ultracode":true}'`) {
-			t.Fatalf("invalid effort must resolve to ultracode, got %q", got)
-		}
+		assertEffortResolvesToUltracode(t, effort)
 	})
 
 	// Issue #491 — ultracode is not a `claude --effort` value: it launches
@@ -62,13 +47,7 @@ func TestAISessionLaunchCommand(t *testing.T) {
 	// and the settings JSON appears in both branches of the cwd-guarded
 	// resume, composing after --continue.
 	t.Run("ultracode launches via --settings in both guard branches", func(t *testing.T) {
-		got := AISessionLaunchCommand("", effort("ultracode"))
-		if strings.Count(got, `--settings '{"ultracode":true}'`) != 2 || strings.Contains(got, "--effort") {
-			t.Fatalf("ultracode must inject --settings (never --effort) in both branches, got %q", got)
-		}
-		if !strings.Contains(got, `claude --continue --settings '{"ultracode":true}'`) {
-			t.Fatalf("--settings must compose after --continue in the resume branch, got %q", got)
-		}
+		assertUltracodeInBothBranches(t, effort("ultracode"))
 	})
 
 	t.Run("an explicit max still launches via --effort", func(t *testing.T) {
@@ -77,6 +56,49 @@ func TestAISessionLaunchCommand(t *testing.T) {
 			t.Fatalf("explicit max must keep --effort max, got %q", got)
 		}
 	})
+}
+
+// assertDefaultClaudeGuardAtEffort pins that a default claude launch wraps in
+// the cwd guard with the env's effort level injected into both the resume and
+// the fresh branch.
+func assertDefaultClaudeGuardAtEffort(t *testing.T, config EnvironmentClaudeConfig) {
+	t.Helper()
+	got := AISessionLaunchCommand("", config)
+	if strings.Count(got, "--effort high") != 2 {
+		t.Fatalf("expected --effort high in both guard branches, got %q", got)
+	}
+	if !strings.Contains(got, "claude --continue --effort high") || !strings.Contains(got, "else claude --effort high") {
+		t.Fatalf("guard missing the resume/fresh branches: %q", got)
+	}
+}
+
+// assertEffortResolvesToUltracode pins that both an unset and an invalid effort
+// fall back to the ultracode --settings launch, never a bad --effort flag.
+func assertEffortResolvesToUltracode(t *testing.T, effort func(string) EnvironmentClaudeConfig) {
+	t.Helper()
+	got := AISessionLaunchCommand("", EnvironmentClaudeConfig{})
+	if !strings.Contains(got, `--settings '{"ultracode":true}'`) || strings.Contains(got, "--effort") {
+		t.Fatalf("unset effort must default to ultracode via --settings, got %q", got)
+	}
+	// A bad persisted value must never reach the shell verbatim; it resolves
+	// to the default instead of injecting `--effort turbo`.
+	got = AISessionLaunchCommand("", effort("turbo"))
+	if strings.Contains(got, "turbo") || !strings.Contains(got, `--settings '{"ultracode":true}'`) {
+		t.Fatalf("invalid effort must resolve to ultracode, got %q", got)
+	}
+}
+
+// assertUltracodeInBothBranches pins that ultracode injects the --settings JSON
+// (never --effort) into both guard branches and composes after --continue.
+func assertUltracodeInBothBranches(t *testing.T, config EnvironmentClaudeConfig) {
+	t.Helper()
+	got := AISessionLaunchCommand("", config)
+	if strings.Count(got, `--settings '{"ultracode":true}'`) != 2 || strings.Contains(got, "--effort") {
+		t.Fatalf("ultracode must inject --settings (never --effort) in both branches, got %q", got)
+	}
+	if !strings.Contains(got, `claude --continue --settings '{"ultracode":true}'`) {
+		t.Fatalf("--settings must compose after --continue in the resume branch, got %q", got)
+	}
 }
 
 // TestAISessionLaunchCommandModelAndDebugFlags pins the per-env default model

--- a/erun-common/aws_sso_config.go
+++ b/erun-common/aws_sso_config.go
@@ -54,7 +54,7 @@ func LookupAWSSSOProfileByAccountID(accountID string) (AWSSSOProfile, bool, erro
 		}
 		return AWSSSOProfile{}, false, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	sections, err := parseAWSSharedConfig(file)
 	if err != nil {
 		return AWSSSOProfile{}, false, err

--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -31,7 +31,7 @@ func ResolveBuildExecution(ctx Context, store DockerStore, findProjectRoot Proje
 
 	recommendBuildEnvIfMissing(ctx, findProjectRoot, target)
 
-	if env := ResolveDockerBuildEnvConfig(store, findProjectRoot, target); env != nil && env.DisableBuildScript {
+	if buildEnvDisablesBuildScript(store, findProjectRoot, target) {
 		target.DisableBuildScriptDiscovery = true
 	}
 
@@ -63,6 +63,14 @@ func ResolveBuildExecution(ctx Context, store DockerStore, findProjectRoot Proje
 		execution = BuildExecutionSpecWithRelease(execution, *releaseSpec)
 	}
 	return ApplyIncrementalToBuildExecution(ctx, execution, target.NoIncremental)
+}
+
+// buildEnvDisablesBuildScript reports whether the env a build resolves to has
+// its DisableBuildScript toggle set, so the caller can suppress build-script
+// discovery for that env.
+func buildEnvDisablesBuildScript(store DockerStore, findProjectRoot ProjectFinderFunc, target DockerCommandTarget) bool {
+	env := ResolveDockerBuildEnvConfig(store, findProjectRoot, target)
+	return env != nil && env.DisableBuildScript
 }
 
 // recommendBuildEnvIfMissing emits a one-line advisory pointing at the

--- a/erun-common/build_configured_fingerprint.go
+++ b/erun-common/build_configured_fingerprint.go
@@ -36,19 +36,9 @@ func materializeConfiguredFingerprints(ctx Context, builds []DockerBuildSpec) (m
 		if projectRoot == "" || imageName == "" {
 			continue
 		}
-		key := projectRoot + "\x00" + environment
-		configured, loaded := configuredByEnv[key]
-		if !loaded {
-			cfg, _, err := LoadProjectConfig(projectRoot)
-			if err != nil {
-				if errors.Is(err, ErrNotInitialized) {
-					configuredByEnv[key] = nil
-					continue
-				}
-				return nil, err
-			}
-			configured = cfg.DockerFingerprintsForEnvironment(environment)
-			configuredByEnv[key] = configured
+		configured, err := loadConfiguredFingerprints(projectRoot, environment, configuredByEnv)
+		if err != nil {
+			return nil, err
 		}
 		if configured == nil {
 			continue
@@ -61,21 +51,53 @@ func materializeConfiguredFingerprints(ctx Context, builds []DockerBuildSpec) (m
 			ctx.Trace(fmt.Sprintf("ignoring invalid configured fingerprint for %s: %q", imageName, hash))
 			continue
 		}
-		for _, platform := range build.Platforms {
-			fpTag := fingerprintTag(build.Image, hash, platform)
-			if exists, err := DockerImageExists(fpTag); err == nil && exists {
-				materialized[fpTag] = struct{}{}
-				continue
-			}
-			if err := pullAndTagConfiguredFingerprint(ctx, build.Image.Tag, fpTag, platform); err != nil {
-				ctx.Trace(fmt.Sprintf("could not materialize configured fingerprint %s: %v", fpTag, err))
-				continue
-			}
-			materialized[fpTag] = struct{}{}
-		}
+		materializeBuildFingerprints(ctx, build, hash, materialized)
 	}
 
 	return materialized, nil
+}
+
+// loadConfiguredFingerprints returns the docker.fingerprints map for the
+// build's environment, caching the per-(projectRoot, environment) result in
+// cache so repeated builds avoid re-reading the config. An uninitialized
+// project caches a nil entry rather than erroring; any other config error
+// propagates.
+func loadConfiguredFingerprints(projectRoot, environment string, cache map[string]map[string]string) (map[string]string, error) {
+	key := projectRoot + "\x00" + environment
+	if configured, loaded := cache[key]; loaded {
+		return configured, nil
+	}
+	cfg, _, err := LoadProjectConfig(projectRoot)
+	if err != nil {
+		if errors.Is(err, ErrNotInitialized) {
+			cache[key] = nil
+			return nil, nil
+		}
+		return nil, err
+	}
+	configured := cfg.DockerFingerprintsForEnvironment(environment)
+	cache[key] = configured
+	return configured, nil
+}
+
+// materializeBuildFingerprints ensures the local Docker store holds the
+// fp-tagged image for each of the build's platforms at the configured hash,
+// recording each materialized fp-tag. An fp-tag already present is recorded
+// directly; otherwise the pull+tag sequence runs (or is traced in dry-run).
+// Per-platform failures fall through silently so the build rebuilds as today.
+func materializeBuildFingerprints(ctx Context, build DockerBuildSpec, hash string, materialized map[string]struct{}) {
+	for _, platform := range build.Platforms {
+		fpTag := fingerprintTag(build.Image, hash, platform)
+		if exists, err := DockerImageExists(fpTag); err == nil && exists {
+			materialized[fpTag] = struct{}{}
+			continue
+		}
+		if err := pullAndTagConfiguredFingerprint(ctx, build.Image.Tag, fpTag, platform); err != nil {
+			ctx.Trace(fmt.Sprintf("could not materialize configured fingerprint %s: %v", fpTag, err))
+			continue
+		}
+		materialized[fpTag] = struct{}{}
+	}
 }
 
 // pullAndTagConfiguredFingerprint pulls sourceTag for platform and tags the

--- a/erun-common/build_incremental.go
+++ b/erun-common/build_incremental.go
@@ -78,18 +78,7 @@ func parseDockerfileCopyInstructions(dockerfile string) [][]string {
 		if len(args) < 2 {
 			continue
 		}
-		fromStage := false
-		filtered := make([]string, 0, len(args))
-		for _, arg := range args {
-			if strings.HasPrefix(arg, "--from=") {
-				fromStage = true
-				continue
-			}
-			if strings.HasPrefix(arg, "--chown=") || strings.HasPrefix(arg, "--chmod=") || strings.HasPrefix(arg, "--link") || strings.HasPrefix(arg, "--parents") {
-				continue
-			}
-			filtered = append(filtered, arg)
-		}
+		filtered, fromStage := filterDockerfileCopyArgs(args)
 		if fromStage {
 			continue
 		}
@@ -101,6 +90,26 @@ func parseDockerfileCopyInstructions(dockerfile string) [][]string {
 		results = append(results, sources)
 	}
 	return results
+}
+
+// filterDockerfileCopyArgs strips COPY flags from a single instruction's
+// argument list, returning the remaining positional arguments (sources plus
+// destination) and whether a --from=<stage> flag was present. A --from
+// instruction references a build stage rather than the host filesystem, so the
+// caller skips it entirely.
+func filterDockerfileCopyArgs(args []string) (filtered []string, fromStage bool) {
+	filtered = make([]string, 0, len(args))
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--from=") {
+			fromStage = true
+			continue
+		}
+		if strings.HasPrefix(arg, "--chown=") || strings.HasPrefix(arg, "--chmod=") || strings.HasPrefix(arg, "--link") || strings.HasPrefix(arg, "--parents") {
+			continue
+		}
+		filtered = append(filtered, arg)
+	}
+	return filtered, fromStage
 }
 
 // computeBuildFingerprint hashes the contents of the Dockerfile and every COPY
@@ -131,30 +140,41 @@ func computeBuildFingerprint(buildInput DockerBuildSpec) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	for _, path := range files {
-		rel, err := filepath.Rel(contextDir, path)
-		if err != nil {
-			return "", err
-		}
-		rel = filepath.ToSlash(rel)
-		if _, err := hasher.Write([]byte(rel)); err != nil {
-			return "", err
-		}
-		if _, err := hasher.Write([]byte{'\n'}); err != nil {
-			return "", err
-		}
-		if err := hashFileInto(hasher, path); err != nil {
-			return "", err
-		}
-		if _, err := hasher.Write([]byte{0}); err != nil {
-			return "", err
-		}
+	if err := hashFingerprintFiles(hasher, contextDir, files); err != nil {
+		return "", err
 	}
 	if err := hashComponentChartInto(hasher, buildInput); err != nil {
 		return "", err
 	}
 	digest := hex.EncodeToString(hasher.Sum(nil))
 	return digest[:16], nil
+}
+
+// hashFingerprintFiles folds each file's context-relative path and contents
+// into the hasher, separating entries with a NUL byte so distinct file lists
+// can never produce the same digest. Paths are slash-normalized so the result
+// is stable across host filesystems.
+func hashFingerprintFiles(hasher io.Writer, contextDir string, files []string) error {
+	for _, path := range files {
+		rel, err := filepath.Rel(contextDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if _, err := hasher.Write([]byte(rel)); err != nil {
+			return err
+		}
+		if _, err := hasher.Write([]byte{'\n'}); err != nil {
+			return err
+		}
+		if err := hashFileInto(hasher, path); err != nil {
+			return err
+		}
+		if _, err := hasher.Write([]byte{0}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // hashComponentChartInto folds the component's deployed Helm chart into the
@@ -241,43 +261,57 @@ func collectFingerprintFiles(contextDir string, sources []string, ignored *ignor
 			return nil, err
 		}
 		if !info.IsDir() {
-			rel, err := filepath.Rel(contextDir, full)
-			if err != nil {
+			if err := collectFingerprintFile(contextDir, full, ignored, add); err != nil {
 				return nil, err
-			}
-			rel = filepath.ToSlash(rel)
-			if !ignored.matches(rel, false) {
-				add(full)
 			}
 			continue
 		}
-		walkErr := filepath.WalkDir(full, func(path string, d os.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return walkErr
-			}
-			rel, err := filepath.Rel(contextDir, path)
-			if err != nil {
-				return err
-			}
-			rel = filepath.ToSlash(rel)
-			if d.IsDir() {
-				if rel != "." && ignored.matches(rel, true) {
-					return filepath.SkipDir
-				}
-				return nil
-			}
-			if ignored.matches(rel, false) {
-				return nil
-			}
-			add(path)
-			return nil
-		})
-		if walkErr != nil {
-			return nil, walkErr
+		if err := collectFingerprintDir(contextDir, full, ignored, add); err != nil {
+			return nil, err
 		}
 	}
 	sort.Strings(files)
 	return files, nil
+}
+
+// collectFingerprintFile records a single non-directory source unless it is
+// excluded by the ignore set.
+func collectFingerprintFile(contextDir, full string, ignored *ignoreSet, add func(string)) error {
+	rel, err := filepath.Rel(contextDir, full)
+	if err != nil {
+		return err
+	}
+	rel = filepath.ToSlash(rel)
+	if !ignored.matches(rel, false) {
+		add(full)
+	}
+	return nil
+}
+
+// collectFingerprintDir walks a directory source, recording every file that
+// survives the ignore set and pruning ignored subtrees so they are not visited.
+func collectFingerprintDir(contextDir, full string, ignored *ignoreSet, add func(string)) error {
+	return filepath.WalkDir(full, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(contextDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if d.IsDir() {
+			if rel != "." && ignored.matches(rel, true) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if ignored.matches(rel, false) {
+			return nil
+		}
+		add(path)
+		return nil
+	})
 }
 
 func hashFileInto(w io.Writer, path string) error {
@@ -349,41 +383,49 @@ func loadNestedGitignores(contextDir string, sources []string, combined *ignoreS
 		if !info.IsDir() {
 			continue
 		}
-		walkErr := filepath.WalkDir(full, func(path string, d os.DirEntry, walkErr error) error {
-			if walkErr != nil {
-				return walkErr
-			}
-			rel, err := filepath.Rel(contextDir, path)
-			if err != nil {
-				return err
-			}
-			rel = filepath.ToSlash(rel)
-			if d.IsDir() {
-				if _, seen := visited[rel]; seen {
-					return filepath.SkipDir
-				}
-				visited[rel] = struct{}{}
-				return nil
-			}
-			if d.Name() != ".gitignore" {
-				return nil
-			}
-			base := filepath.ToSlash(filepath.Dir(rel))
-			if base == "." || base == "" {
-				return nil // root, already loaded
-			}
-			set, err := loadIgnoreFile(path, base)
-			if err != nil {
-				return err
-			}
-			combined.patterns = append(combined.patterns, set.patterns...)
-			return nil
-		})
-		if walkErr != nil {
-			return walkErr
+		if err := walkNestedGitignores(contextDir, full, visited, combined); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// walkNestedGitignores walks one directory source, appending the patterns from
+// every nested .gitignore it encounters to combined. visited dedupes
+// directories so overlapping sources are not walked twice. Each nested file's
+// patterns are scoped to its own directory subtree; the root file is skipped
+// here because loadContextIgnoreSet already loaded it.
+func walkNestedGitignores(contextDir, full string, visited map[string]struct{}, combined *ignoreSet) error {
+	return filepath.WalkDir(full, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(contextDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if d.IsDir() {
+			if _, seen := visited[rel]; seen {
+				return filepath.SkipDir
+			}
+			visited[rel] = struct{}{}
+			return nil
+		}
+		if d.Name() != ".gitignore" {
+			return nil
+		}
+		base := filepath.ToSlash(filepath.Dir(rel))
+		if base == "." || base == "" {
+			return nil // root, already loaded
+		}
+		set, err := loadIgnoreFile(path, base)
+		if err != nil {
+			return err
+		}
+		combined.patterns = append(combined.patterns, set.patterns...)
+		return nil
+	})
 }
 
 func loadIgnoreFile(path, base string) (*ignoreSet, error) {
@@ -400,48 +442,60 @@ func loadIgnoreFile(path, base string) (*ignoreSet, error) {
 func parseIgnoreData(data []byte, base string) *ignoreSet {
 	set := &ignoreSet{}
 	for _, raw := range strings.Split(string(data), "\n") {
-		line := strings.TrimRight(raw, "\r")
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
+		pattern, ok := parseIgnoreLine(raw, base)
+		if !ok {
 			continue
 		}
-		negate := false
-		if strings.HasPrefix(line, "!") {
-			negate = true
-			line = strings.TrimSpace(line[1:])
-			if line == "" {
-				continue
-			}
-		}
-		anchored := false
-		if strings.HasPrefix(line, "/") {
-			anchored = true
-			line = strings.TrimPrefix(line, "/")
-		}
-		dirOnly := false
-		if strings.HasSuffix(line, "/") {
-			dirOnly = true
-			line = strings.TrimSuffix(line, "/")
-		}
-		// gitignore: a pattern that contains a slash anywhere except the
-		// trailing position is anchored to the file's directory. For our
-		// purposes the file's directory is contextDir, the same as
-		// leading-slash anchoring.
-		if !anchored && strings.Contains(line, "/") {
-			anchored = true
-		}
-		if line == "" {
-			continue
-		}
-		set.patterns = append(set.patterns, ignorePattern{
-			raw:      filepath.ToSlash(line),
-			anchored: anchored,
-			dirOnly:  dirOnly,
-			negate:   negate,
-			base:     base,
-		})
+		set.patterns = append(set.patterns, pattern)
 	}
 	return set
+}
+
+// parseIgnoreLine parses a single .gitignore/.dockerignore line into an
+// ignorePattern scoped to base. It returns ok=false for blank lines, comments,
+// and patterns that reduce to empty after stripping the negation, anchor, and
+// dir-only markers.
+func parseIgnoreLine(raw, base string) (ignorePattern, bool) {
+	line := strings.TrimRight(raw, "\r")
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return ignorePattern{}, false
+	}
+	negate := false
+	if strings.HasPrefix(line, "!") {
+		negate = true
+		line = strings.TrimSpace(line[1:])
+		if line == "" {
+			return ignorePattern{}, false
+		}
+	}
+	anchored := false
+	if strings.HasPrefix(line, "/") {
+		anchored = true
+		line = strings.TrimPrefix(line, "/")
+	}
+	dirOnly := false
+	if strings.HasSuffix(line, "/") {
+		dirOnly = true
+		line = strings.TrimSuffix(line, "/")
+	}
+	// gitignore: a pattern that contains a slash anywhere except the
+	// trailing position is anchored to the file's directory. For our
+	// purposes the file's directory is contextDir, the same as
+	// leading-slash anchoring.
+	if !anchored && strings.Contains(line, "/") {
+		anchored = true
+	}
+	if line == "" {
+		return ignorePattern{}, false
+	}
+	return ignorePattern{
+		raw:      filepath.ToSlash(line),
+		anchored: anchored,
+		dirOnly:  dirOnly,
+		negate:   negate,
+		base:     base,
+	}, true
 }
 
 func (s *ignoreSet) matches(rel string, isDir bool) bool {
@@ -476,23 +530,29 @@ func patternMatchesPath(p ignorePattern, rel string) bool {
 		rel = strings.TrimPrefix(rel, p.base+"/")
 	}
 	if p.anchored {
-		if globMatch(p.raw, rel) {
-			return true
-		}
-		// Anchored directory patterns also match descendants so the walker can
-		// short-circuit before visiting the directory entry itself.
-		parts := strings.Split(rel, "/")
-		for i := 1; i < len(parts); i++ {
-			prefix := strings.Join(parts[:i], "/")
-			if globMatch(p.raw, prefix) {
-				return true
-			}
-		}
-		return false
+		return anchoredPatternMatches(p.raw, rel)
 	}
 	// Non-anchored gitignore patterns match a basename anywhere in the tree.
 	for _, part := range strings.Split(rel, "/") {
 		if globMatch(p.raw, part) {
+			return true
+		}
+	}
+	return false
+}
+
+// anchoredPatternMatches reports whether an anchored gitignore glob matches rel
+// or any of rel's ancestor prefixes. Matching a prefix lets the walker
+// short-circuit an ignored directory before visiting the directory entry
+// itself.
+func anchoredPatternMatches(raw, rel string) bool {
+	if globMatch(raw, rel) {
+		return true
+	}
+	parts := strings.Split(rel, "/")
+	for i := 1; i < len(parts); i++ {
+		prefix := strings.Join(parts[:i], "/")
+		if globMatch(raw, prefix) {
 			return true
 		}
 	}
@@ -520,31 +580,41 @@ func globToRegex(pattern string) string {
 	b.WriteString("^")
 	i := 0
 	for i < len(pattern) {
-		switch {
-		case i+1 < len(pattern) && pattern[i] == '*' && pattern[i+1] == '*':
-			b.WriteString(".*")
-			i += 2
-			// Collapse `**/` so `a/**/b` matches `a/b` as well as `a/x/b`.
-			if i < len(pattern) && pattern[i] == '/' {
-				i++
-			}
-		case pattern[i] == '*':
-			b.WriteString("[^/]*")
-			i++
-		case pattern[i] == '?':
-			b.WriteString("[^/]")
-			i++
-		case strings.ContainsRune(`.+()|^$\{}`, rune(pattern[i])):
-			b.WriteByte('\\')
-			b.WriteByte(pattern[i])
-			i++
-		default:
-			b.WriteByte(pattern[i])
-			i++
-		}
+		i = writeGlobToken(&b, pattern, i)
 	}
 	b.WriteString("$")
 	return b.String()
+}
+
+// writeGlobToken translates the glob token starting at index i in pattern into
+// its regex equivalent, writes it to b, and returns the index of the next
+// unconsumed character. `**` becomes `.*` (consuming a following `/` so
+// `a/**/b` matches `a/b`), `*` and `?` stay segment-local, and regex
+// metacharacters are escaped.
+func writeGlobToken(b *strings.Builder, pattern string, i int) int {
+	switch {
+	case i+1 < len(pattern) && pattern[i] == '*' && pattern[i+1] == '*':
+		b.WriteString(".*")
+		i += 2
+		// Collapse `**/` so `a/**/b` matches `a/b` as well as `a/x/b`.
+		if i < len(pattern) && pattern[i] == '/' {
+			i++
+		}
+		return i
+	case pattern[i] == '*':
+		b.WriteString("[^/]*")
+		return i + 1
+	case pattern[i] == '?':
+		b.WriteString("[^/]")
+		return i + 1
+	case strings.ContainsRune(`.+()|^$\{}`, rune(pattern[i])):
+		b.WriteByte('\\')
+		b.WriteByte(pattern[i])
+		return i + 1
+	default:
+		b.WriteByte(pattern[i])
+		return i + 1
+	}
 }
 
 // LocalDockerImageInspector reports whether an image with the given tag exists

--- a/erun-common/build_run.go
+++ b/erun-common/build_run.go
@@ -95,6 +95,29 @@ func RunDockerBuilds(ctx Context, builds []DockerBuildSpec, build DockerImageBui
 	return nil
 }
 
+// traceBuildUmbrella emits the `==> Building` start marker and returns a finish
+// func to defer with the run's error pointer; the finish func emits
+// `==> Built in N` or `==> Build failed after N`. These are the umbrella traces
+// the desktop's activity-queue parser keys off (mirrors RunHelmDeploy's
+// `==> Deploying` / `==> Deployed`). Real run only: dry-run performs no work so
+// there is nothing to put a spinner on, and skipping these lines in dry-run
+// also keeps the dry-run integration goldens stable.
+func traceBuildUmbrella(ctx Context) func(*error) {
+	if ctx.DryRun {
+		return func(*error) {}
+	}
+	started := time.Now()
+	ctx.Info("==> Building")
+	return func(errp *error) {
+		elapsed := time.Since(started).Round(time.Second)
+		if errp != nil && *errp != nil {
+			ctx.Info("==> Build failed after " + elapsed.String())
+			return
+		}
+		ctx.Info("==> Built in " + elapsed.String())
+	}
+}
+
 func RunBuildExecution(ctx Context, execution BuildExecutionSpec, runScript BuildScriptRunnerFunc, build DockerImageBuilderFunc, push DockerPushFunc) error {
 	return runBuildExecution(ctx, execution, nil, runScript, build, push, nil)
 }
@@ -104,25 +127,7 @@ func RunBuildExecutionAndDeploy(ctx Context, execution BuildExecutionSpec, deplo
 }
 
 func runBuildExecution(ctx Context, execution BuildExecutionSpec, deploySpecs []DeploySpec, runScript BuildScriptRunnerFunc, build DockerImageBuilderFunc, push DockerPushFunc, deploy HelmChartDeployerFunc) (err error) {
-	// `==> Building` / `==> Built in N` / `==> Build failed after N` are
-	// the umbrella traces the desktop's activity-queue parser keys off
-	// (mirrors RunHelmDeploy's `==> Deploying` / `==> Deployed`). Real
-	// run only: dry-run performs no work so there is nothing to put a
-	// spinner on, and skipping these lines in dry-run also keeps the
-	// dry-run integration goldens stable.
-	var started time.Time
-	if !ctx.DryRun {
-		started = time.Now()
-		ctx.Info("==> Building")
-		defer func() {
-			elapsed := time.Since(started).Round(time.Second)
-			if err != nil {
-				ctx.Info("==> Build failed after " + elapsed.String())
-				return
-			}
-			ctx.Info("==> Built in " + elapsed.String())
-		}()
-	}
+	defer traceBuildUmbrella(ctx)(&err)
 	if execution.release != nil {
 		// Call the unexported runReleaseSpec, not the exported
 		// RunReleaseSpec: the release phase here is already wrapped by

--- a/erun-common/build_spec.go
+++ b/erun-common/build_spec.go
@@ -66,30 +66,41 @@ func currentComponentDockerBuildContext(resolveBuildContext BuildContextResolver
 	return buildContext, strings.TrimSpace(buildContext.DockerfilePath) != ""
 }
 
-func ResolveDockerBuildForImageReference(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, projectRoot, environment, image string) (DockerBuildSpec, bool, error) {
-	image = strings.TrimSpace(image)
+// parseDockerImageReference splits a trimmed image reference into its registry,
+// image name, and version. ok is false when the reference is empty, lacks a
+// usable name:tag, or carries a registry that looks like a version string.
+//
+// A version-looking registry (e.g. "1.0.51-snapshot-20260505151841/image-name:tag")
+// arises from helm chart printf templates that embed .Chart.AppVersion as a
+// namespace prefix; such references are not valid Docker registry hosts and
+// would cause a push-time DNS lookup failure, so they are rejected here.
+func parseDockerImageReference(image string) (registry, imageName, version string, ok bool) {
 	if image == "" {
-		return DockerBuildSpec{}, false, nil
+		return "", "", "", false
 	}
 
 	nameTag := image
-	registry := ""
 	if idx := strings.LastIndex(image, "/"); idx >= 0 {
 		registry = image[:idx]
 		nameTag = image[idx+1:]
 	}
 
-	imageName, version, ok := strings.Cut(nameTag, ":")
-	if !ok || strings.TrimSpace(imageName) == "" || strings.TrimSpace(version) == "" {
-		return DockerBuildSpec{}, false, nil
+	imageName, version, found := strings.Cut(nameTag, ":")
+	if !found || strings.TrimSpace(imageName) == "" || strings.TrimSpace(version) == "" {
+		return "", "", "", false
 	}
 
-	// Reject image references where the registry looks like a version string
-	// (e.g. "1.0.51-snapshot-20260505151841/image-name:tag").  Such references
-	// arise from helm chart printf templates that embed .Chart.AppVersion as a
-	// namespace prefix; they are not valid Docker registry hosts and would cause
-	// a push-time DNS lookup failure.
 	if dockerRegistryLooksLikeVersion(registry) {
+		return "", "", "", false
+	}
+
+	return registry, imageName, version, true
+}
+
+func ResolveDockerBuildForImageReference(store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, projectRoot, environment, image string) (DockerBuildSpec, bool, error) {
+	image = strings.TrimSpace(image)
+	registry, imageName, version, ok := parseDockerImageReference(image)
+	if !ok {
 		return DockerBuildSpec{}, false, nil
 	}
 

--- a/erun-common/cloud.go
+++ b/erun-common/cloud.go
@@ -97,14 +97,14 @@ type SetEnvironmentCloudAliasParams struct {
 }
 
 type CloudDependencies struct {
-	RunAWSConfigureSSO     func(Context, AWSProfileConfig) error
-	RunAWSLogin            func(Context, string) error
-	RunAWSLogout           func(Context, string) error
-	RunAWSBearerToken      func(Context, string, string) (string, error)
-	RunAWSEnableOIDC       func(Context, string) (string, error)
+	RunAWSConfigureSSO      func(Context, AWSProfileConfig) error
+	RunAWSLogin             func(Context, string) error
+	RunAWSLogout            func(Context, string) error
+	RunAWSBearerToken       func(Context, string, string) (string, error)
+	RunAWSEnableOIDC        func(Context, string) (string, error)
 	RunAWSExportCredentials func(Context, string) (CloudProviderCredentials, error)
-	ResolveAWSIdentity     func(Context, string) (AWSIdentity, error)
-	CheckAWSStatus         func(Context, CloudProviderConfig) CloudProviderStatus
+	ResolveAWSIdentity      func(Context, string) (AWSIdentity, error)
+	CheckAWSStatus          func(Context, CloudProviderConfig) CloudProviderStatus
 }
 
 // CloudProviderCredentials is a snapshot of temporary AWS credentials derived
@@ -384,46 +384,65 @@ func CloudProviderBearerToken(ctx Context, store CloudReadStore, params CloudBea
 	deps = normalizeCloudDependencies(deps)
 	switch provider.Provider {
 	case CloudProviderAWS:
-		status := CloudProviderTokenStatus(provider, deps)
-		if status.Status != CloudTokenStatusActive {
-			if err := deps.RunAWSLogin(ctx, provider.Profile); err != nil {
-				return CloudBearerToken{}, err
-			}
-		}
-		audience := normalizeCloudBearerAudience(params.Audience)
-		rawToken, err := deps.RunAWSBearerToken(ctx, provider.Profile, audience)
-		if err != nil {
-			if !isAWSOutboundWebIdentityFederationDisabled(err) {
-				return CloudBearerToken{}, err
-			}
-			if _, enableErr := deps.RunAWSEnableOIDC(ctx, provider.Profile); enableErr != nil {
-				return CloudBearerToken{}, enableErr
-			}
-			rawToken, err = deps.RunAWSBearerToken(ctx, provider.Profile, audience)
-			if err != nil {
-				return CloudBearerToken{}, err
-			}
-		}
-		if ctx.DryRun && strings.TrimSpace(rawToken) == "" {
-			return CloudBearerToken{
-				Alias:    provider.Alias,
-				Provider: provider.Provider,
-				Issuer:   "derived-from-aws-web-identity-token",
-			}, nil
-		}
-		issuer, err := issuerFromJWT(rawToken)
-		if err != nil {
-			return CloudBearerToken{}, err
-		}
-		return CloudBearerToken{
-			Alias:    provider.Alias,
-			Provider: provider.Provider,
-			Token:    rawToken,
-			Issuer:   issuer,
-		}, nil
+		return awsCloudProviderBearerToken(ctx, provider, params, deps)
 	default:
 		return CloudBearerToken{}, fmt.Errorf("unsupported cloud provider %q", provider.Provider)
 	}
+}
+
+// awsCloudProviderBearerToken mints an AWS web-identity bearer token for
+// the resolved provider: it re-logs in when the SSO session is stale,
+// fetches the token (enabling outbound web identity federation and
+// retrying once when AWS reports it disabled), and derives the issuer
+// from the JWT. In dry-run mode with no real token it returns the
+// synthetic issuer the trace path expects.
+func awsCloudProviderBearerToken(ctx Context, provider CloudProviderConfig, params CloudBearerParams, deps CloudDependencies) (CloudBearerToken, error) {
+	status := CloudProviderTokenStatus(provider, deps)
+	if status.Status != CloudTokenStatusActive {
+		if err := deps.RunAWSLogin(ctx, provider.Profile); err != nil {
+			return CloudBearerToken{}, err
+		}
+	}
+	audience := normalizeCloudBearerAudience(params.Audience)
+	rawToken, err := awsBearerTokenWithOIDCRetry(ctx, provider, audience, deps)
+	if err != nil {
+		return CloudBearerToken{}, err
+	}
+	if ctx.DryRun && strings.TrimSpace(rawToken) == "" {
+		return CloudBearerToken{
+			Alias:    provider.Alias,
+			Provider: provider.Provider,
+			Issuer:   "derived-from-aws-web-identity-token",
+		}, nil
+	}
+	issuer, err := issuerFromJWT(rawToken)
+	if err != nil {
+		return CloudBearerToken{}, err
+	}
+	return CloudBearerToken{
+		Alias:    provider.Alias,
+		Provider: provider.Provider,
+		Token:    rawToken,
+		Issuer:   issuer,
+	}, nil
+}
+
+// awsBearerTokenWithOIDCRetry fetches the AWS web-identity token and, when
+// the first attempt fails because outbound web identity federation is
+// disabled, enables it and retries exactly once. Any other failure is
+// returned unchanged.
+func awsBearerTokenWithOIDCRetry(ctx Context, provider CloudProviderConfig, audience string, deps CloudDependencies) (string, error) {
+	rawToken, err := deps.RunAWSBearerToken(ctx, provider.Profile, audience)
+	if err == nil {
+		return rawToken, nil
+	}
+	if !isAWSOutboundWebIdentityFederationDisabled(err) {
+		return "", err
+	}
+	if _, enableErr := deps.RunAWSEnableOIDC(ctx, provider.Profile); enableErr != nil {
+		return "", enableErr
+	}
+	return deps.RunAWSBearerToken(ctx, provider.Profile, audience)
 }
 
 // ExportCloudProviderCredentials returns short-lived AWS credentials derived

--- a/erun-common/cloud_context.go
+++ b/erun-common/cloud_context.go
@@ -72,11 +72,11 @@ type CloudContextConfig struct {
 // path deliberately does not fetch them so it stays one AWS call per
 // (alias,region) group.
 type CloudContextStatus struct {
-	CloudContextConfig `json:",inline" yaml:",inline"`
-	Status             string `json:"status,omitempty" yaml:"status,omitempty"`
-	Message            string `json:"message,omitempty" yaml:"message,omitempty"`
-	StopProtection     bool   `json:"stopProtection,omitempty" yaml:"stopprotection,omitempty"`
-	StopProtectionKnown bool  `json:"stopProtectionKnown,omitempty" yaml:"stopprotectionknown,omitempty"`
+	CloudContextConfig  `json:",inline" yaml:",inline"`
+	Status              string `json:"status,omitempty" yaml:"status,omitempty"`
+	Message             string `json:"message,omitempty" yaml:"message,omitempty"`
+	StopProtection      bool   `json:"stopProtection,omitempty" yaml:"stopprotection,omitempty"`
+	StopProtectionKnown bool   `json:"stopProtectionKnown,omitempty" yaml:"stopprotectionknown,omitempty"`
 }
 
 type InitCloudContextParams struct {
@@ -209,6 +209,17 @@ type cloudContextRefreshKey struct {
 }
 
 func refreshCloudContextStatusesFromAWS(ctx Context, store CloudReadStore, deps CloudContextDependencies, statuses []CloudContextStatus) {
+	groups := groupCloudContextRefreshIndices(statuses)
+	for key, indices := range groups {
+		refreshCloudContextRefreshGroup(ctx, store, deps, statuses, key, indices)
+	}
+}
+
+// groupCloudContextRefreshIndices buckets the status entries by
+// (alias,region) so each bucket can be refreshed with a single AWS
+// describe-instances call. Entries without an instance ID, alias, or
+// region keep their cached Status and are excluded from any group.
+func groupCloudContextRefreshIndices(statuses []CloudContextStatus) map[cloudContextRefreshKey][]int {
 	groups := make(map[cloudContextRefreshKey][]int)
 	for i, status := range statuses {
 		if strings.TrimSpace(status.InstanceID) == "" {
@@ -222,35 +233,52 @@ func refreshCloudContextStatusesFromAWS(ctx Context, store CloudReadStore, deps 
 		key := cloudContextRefreshKey{alias: alias, region: region}
 		groups[key] = append(groups[key], i)
 	}
-	for key, indices := range groups {
-		provider, err := ResolveCloudProvider(store, key.alias)
-		if err != nil {
-			applyCloudContextRefreshError(statuses, indices, err)
-			continue
-		}
-		instanceIDs := make([]string, 0, len(indices))
-		for _, i := range indices {
-			instanceIDs = append(instanceIDs, statuses[i].InstanceID)
-		}
-		states, err := describeCloudContextInstanceStates(ctx, deps, provider, key.region, instanceIDs)
-		if err != nil {
-			applyCloudContextRefreshError(statuses, indices, err)
-			continue
-		}
-		for _, i := range indices {
-			awsState, ok := states[statuses[i].InstanceID]
-			if !ok {
-				statuses[i].Status = CloudContextStatusUnknown
-				statuses[i].Message = "instance not found in AWS"
-				continue
-			}
-			statuses[i].Status = cloudContextStatusFromAWSInstanceState(awsState)
-			if statuses[i].Status == CloudContextStatusUnknown {
-				statuses[i].Message = "AWS instance state: " + awsState
-			} else {
-				statuses[i].Message = ""
-			}
-		}
+	return groups
+}
+
+// refreshCloudContextRefreshGroup resolves the provider for one
+// (alias,region) group, describes its instances in a single AWS call,
+// and overwrites each grouped status with the observed state. Any
+// provider-resolution or describe failure downgrades the whole group to
+// Unknown via applyCloudContextRefreshError so a stale "running" is not
+// surfaced as authoritative.
+func refreshCloudContextRefreshGroup(ctx Context, store CloudReadStore, deps CloudContextDependencies, statuses []CloudContextStatus, key cloudContextRefreshKey, indices []int) {
+	provider, err := ResolveCloudProvider(store, key.alias)
+	if err != nil {
+		applyCloudContextRefreshError(statuses, indices, err)
+		return
+	}
+	instanceIDs := make([]string, 0, len(indices))
+	for _, i := range indices {
+		instanceIDs = append(instanceIDs, statuses[i].InstanceID)
+	}
+	states, err := describeCloudContextInstanceStates(ctx, deps, provider, key.region, instanceIDs)
+	if err != nil {
+		applyCloudContextRefreshError(statuses, indices, err)
+		return
+	}
+	for _, i := range indices {
+		applyCloudContextRefreshState(&statuses[i], states)
+	}
+}
+
+// applyCloudContextRefreshState overwrites a single status's Status and
+// Message from the AWS-observed instance state map. A missing instance
+// reads as Unknown/"instance not found in AWS"; an unrecognized state
+// reads as Unknown with the raw state in the Message; a recognized state
+// clears the Message.
+func applyCloudContextRefreshState(status *CloudContextStatus, states map[string]string) {
+	awsState, ok := states[status.InstanceID]
+	if !ok {
+		status.Status = CloudContextStatusUnknown
+		status.Message = "instance not found in AWS"
+		return
+	}
+	status.Status = cloudContextStatusFromAWSInstanceState(awsState)
+	if status.Status == CloudContextStatusUnknown {
+		status.Message = "AWS instance state: " + awsState
+	} else {
+		status.Message = ""
 	}
 }
 
@@ -667,55 +695,29 @@ func classifyCloudContextPowerError(awsAction string, config CloudContextConfig,
 func StartCloudContext(ctx Context, store CloudContextStore, params CloudContextParams, deps CloudContextDependencies) (CloudContextStatus, error) {
 	deps = normalizeCloudContextDependencies(deps)
 	ctx.Trace(fmt.Sprintf("cloud-context start: name=%s force=%v", strings.TrimSpace(params.Name), params.Force))
-	if !params.Force {
-		if lookup, ok := store.(CloudContextEnvLookup); ok {
-			ctx.Trace("cloud-context start: checking working-hours gate")
-			reason, err := cloudContextStartBlockedByWorkingHours(store, lookup, params.Name, deps.Now())
-			if err != nil {
-				return CloudContextStatus{}, err
-			}
-			if reason != "" {
-				ctx.Trace("cloud-context start: gated: " + reason)
-				return CloudContextStatus{}, fmt.Errorf("cloud context %q cannot start: %s; pass force=true to override", strings.TrimSpace(params.Name), reason)
-			}
-			ctx.Trace("cloud-context start: working-hours gate clear")
-		}
-	} else {
-		ctx.Trace("cloud-context start: force=true bypasses working-hours gate")
+	if err := enforceCloudContextStartWorkingHoursGate(ctx, store, params, deps); err != nil {
+		return CloudContextStatus{}, err
 	}
 	if err := ensureCloudContextHostStopProfileAssociation(ctx, store, params, deps); err != nil {
 		ctx.Trace("skipping cloud context host-stop profile association: " + err.Error())
 	}
 	status, err := changeCloudContextPowerState(ctx, store, params, deps, "start-instances", CloudContextStatusRunning)
 	if err != nil {
-		if !isAWSIncorrectInstanceStateError(err) {
-			return CloudContextStatus{}, err
-		}
-		// IncorrectInstanceState means the instance is in a
-		// transitional state — almost always `stopping`, sometimes
-		// `pending` or `shutting-down`. start-instances only accepts
-		// fully-stopped instances. Wait for the transition to settle
-		// and retry once. Without this recovery the user's click on
-		// an env whose linked context just auto-stopped fails with a
-		// confusing AWS error and the desktop's reconnect loop spins
-		// pointlessly. See issue #361.
-		ctx.Trace("cloud-context start: instance is in a transitional state — waiting for stopped before retrying start-instances")
-		recovered, recoverErr := resolveCloudContextStatusForName(store, params.Name)
-		if recoverErr != nil {
-			return CloudContextStatus{}, recoverErr
-		}
-		provider, perr := ResolveCloudProvider(store, recovered.CloudProviderAlias)
-		if perr != nil {
-			return CloudContextStatus{}, perr
-		}
-		if _, werr := deps.RunAWS(ctx, provider, recovered.Region, []string{"ec2", "wait", "instance-stopped", "--instance-ids", recovered.InstanceID}); werr != nil {
-			return CloudContextStatus{}, werr
-		}
-		status, err = changeCloudContextPowerState(ctx, store, params, deps, "start-instances", CloudContextStatusRunning)
+		status, err = recoverCloudContextStartFromTransitionalState(ctx, store, params, deps, err)
 		if err != nil {
 			return CloudContextStatus{}, err
 		}
 	}
+	return finalizeStartedCloudContext(ctx, store, deps, status)
+}
+
+// finalizeStartedCloudContext brings a just-started instance fully up
+// and persists the result: it waits for instance-running, refreshes the
+// public IP, reconfigures the kube context, stamps UpdatedAt, and saves
+// the config (skipping the save in dry-run). This is Start's own
+// follow-up save that changeCloudContextPowerState deliberately leaves
+// to the caller.
+func finalizeStartedCloudContext(ctx Context, store CloudContextStore, deps CloudContextDependencies, status CloudContextStatus) (CloudContextStatus, error) {
 	deps = normalizeCloudContextDependencies(deps)
 	provider, err := ResolveCloudProvider(store, status.CloudProviderAlias)
 	if err != nil {
@@ -740,6 +742,61 @@ func StartCloudContext(ctx Context, store CloudContextStore, params CloudContext
 		return CloudContextStatus{}, err
 	}
 	return status, nil
+}
+
+// enforceCloudContextStartWorkingHoursGate applies the per-environment
+// working-hours gate before a start. force=true bypasses it; a store
+// that does not implement CloudContextEnvLookup skips it. When every
+// attached environment is outside its working hours the start is
+// rejected with the force-to-override hint.
+func enforceCloudContextStartWorkingHoursGate(ctx Context, store CloudContextStore, params CloudContextParams, deps CloudContextDependencies) error {
+	if params.Force {
+		ctx.Trace("cloud-context start: force=true bypasses working-hours gate")
+		return nil
+	}
+	lookup, ok := store.(CloudContextEnvLookup)
+	if !ok {
+		return nil
+	}
+	ctx.Trace("cloud-context start: checking working-hours gate")
+	reason, err := cloudContextStartBlockedByWorkingHours(store, lookup, params.Name, deps.Now())
+	if err != nil {
+		return err
+	}
+	if reason != "" {
+		ctx.Trace("cloud-context start: gated: " + reason)
+		return fmt.Errorf("cloud context %q cannot start: %s; pass force=true to override", strings.TrimSpace(params.Name), reason)
+	}
+	ctx.Trace("cloud-context start: working-hours gate clear")
+	return nil
+}
+
+// recoverCloudContextStartFromTransitionalState handles a failed
+// start-instances. A non-IncorrectInstanceState failure is returned
+// unchanged. IncorrectInstanceState means the instance is in a
+// transitional state — almost always `stopping`, sometimes `pending`
+// or `shutting-down`. start-instances only accepts fully-stopped
+// instances. Wait for the transition to settle and retry once. Without
+// this recovery the user's click on an env whose linked context just
+// auto-stopped fails with a confusing AWS error and the desktop's
+// reconnect loop spins pointlessly. See issue #361.
+func recoverCloudContextStartFromTransitionalState(ctx Context, store CloudContextStore, params CloudContextParams, deps CloudContextDependencies, startErr error) (CloudContextStatus, error) {
+	if !isAWSIncorrectInstanceStateError(startErr) {
+		return CloudContextStatus{}, startErr
+	}
+	ctx.Trace("cloud-context start: instance is in a transitional state — waiting for stopped before retrying start-instances")
+	recovered, recoverErr := resolveCloudContextStatusForName(store, params.Name)
+	if recoverErr != nil {
+		return CloudContextStatus{}, recoverErr
+	}
+	provider, perr := ResolveCloudProvider(store, recovered.CloudProviderAlias)
+	if perr != nil {
+		return CloudContextStatus{}, perr
+	}
+	if _, werr := deps.RunAWS(ctx, provider, recovered.Region, []string{"ec2", "wait", "instance-stopped", "--instance-ids", recovered.InstanceID}); werr != nil {
+		return CloudContextStatus{}, werr
+	}
+	return changeCloudContextPowerState(ctx, store, params, deps, "start-instances", CloudContextStatusRunning)
 }
 
 // CloudContextStopProtectionParams identifies the cloud context whose
@@ -1094,23 +1151,9 @@ func CloudContextPreflight(store CloudContextStore, deps CloudContextDependencie
 // working hours. If any attached environment permits start, or no environments
 // reference this context, the gate is not engaged.
 func cloudContextStartBlockedByWorkingHours(store CloudReadStore, lookup CloudContextEnvLookup, contextName string, now time.Time) (string, error) {
-	contextName = strings.TrimSpace(contextName)
-	if contextName == "" {
-		return "", nil
-	}
-	config, ok, err := findCloudContext(store, contextName)
-	if err != nil {
+	kubeContext, ok, err := resolveCloudContextWorkingHoursKubeContext(store, contextName)
+	if err != nil || !ok {
 		return "", err
-	}
-	if !ok {
-		return "", nil
-	}
-	kubeContext := strings.TrimSpace(config.KubernetesContext)
-	if kubeContext == "" {
-		kubeContext = strings.TrimSpace(config.Name)
-	}
-	if kubeContext == "" {
-		return "", nil
 	}
 
 	tenants, err := lookup.ListTenantConfigs()
@@ -1124,31 +1167,79 @@ func cloudContextStartBlockedByWorkingHours(store CloudReadStore, lookup CloudCo
 		if err != nil {
 			return "", err
 		}
-		for _, env := range envs {
-			if strings.TrimSpace(env.KubernetesContext) != kubeContext {
-				continue
-			}
-			hasAttachedEnv = true
-			policy, err := env.Idle.Resolve()
-			if err != nil {
-				continue
-			}
-			outside, _, err := workingHoursStatus(policy.WorkingHours, policy.Timezone, now)
-			if err != nil {
-				continue
-			}
-			if !outside {
-				return "", nil
-			}
-			if blockedReason == "" {
-				blockedReason = fmt.Sprintf("outside working hours %s for environment %s/%s", policy.WorkingHours, tenant.Name, env.Name)
-			}
+		permitsStart, tenantReason := evaluateTenantWorkingHoursGate(tenant, envs, kubeContext, now, &hasAttachedEnv)
+		if permitsStart {
+			return "", nil
+		}
+		if blockedReason == "" {
+			blockedReason = tenantReason
 		}
 	}
 	if !hasAttachedEnv {
 		return "", nil
 	}
 	return blockedReason, nil
+}
+
+// resolveCloudContextWorkingHoursKubeContext loads the named cloud
+// context and returns the kube-context name the working-hours gate
+// matches environments against (falling back to the context's own Name).
+// ok=false (with a nil error) means there is nothing to gate — a blank
+// name, an unknown context, or a context with no resolvable kube-context
+// — and the caller should treat the gate as not engaged.
+func resolveCloudContextWorkingHoursKubeContext(store CloudReadStore, contextName string) (string, bool, error) {
+	contextName = strings.TrimSpace(contextName)
+	if contextName == "" {
+		return "", false, nil
+	}
+	config, ok, err := findCloudContext(store, contextName)
+	if err != nil {
+		return "", false, err
+	}
+	if !ok {
+		return "", false, nil
+	}
+	kubeContext := strings.TrimSpace(config.KubernetesContext)
+	if kubeContext == "" {
+		kubeContext = strings.TrimSpace(config.Name)
+	}
+	if kubeContext == "" {
+		return "", false, nil
+	}
+	return kubeContext, true, nil
+}
+
+// evaluateTenantWorkingHoursGate inspects every environment in one
+// tenant that is attached to kubeContext. It sets *hasAttachedEnv when
+// it finds any attached env, returns permitsStart=true the moment an
+// attached env is inside its working hours (the caller treats that as
+// "gate clear" and stops), and otherwise returns the first
+// outside-working-hours reason it observed. Environments whose idle
+// policy or working-hours status cannot be resolved are skipped, matching
+// the original inline behavior.
+func evaluateTenantWorkingHoursGate(tenant TenantConfig, envs []EnvConfig, kubeContext string, now time.Time, hasAttachedEnv *bool) (bool, string) {
+	var blockedReason string
+	for _, env := range envs {
+		if strings.TrimSpace(env.KubernetesContext) != kubeContext {
+			continue
+		}
+		*hasAttachedEnv = true
+		policy, err := env.Idle.Resolve()
+		if err != nil {
+			continue
+		}
+		outside, _, err := workingHoursStatus(policy.WorkingHours, policy.Timezone, now)
+		if err != nil {
+			continue
+		}
+		if !outside {
+			return true, ""
+		}
+		if blockedReason == "" {
+			blockedReason = fmt.Sprintf("outside working hours %s for environment %s/%s", policy.WorkingHours, tenant.Name, env.Name)
+		}
+	}
+	return false, blockedReason
 }
 
 func findCloudContextForKubernetesContext(store CloudReadStore, kubernetesContext string) (CloudContextStatus, bool, error) {

--- a/erun-common/cloud_context_power_error_test.go
+++ b/erun-common/cloud_context_power_error_test.go
@@ -22,28 +22,14 @@ func TestCloudContextPowerErrorClassification(t *testing.T) {
 		raw := "aws ec2 stop-instances --instance-ids i-0abc123: An error occurred (OperationNotPermitted) when calling the StopInstances operation: The instance 'i-0abc123' may not be stopped. Modify its 'disableApiStop' instance attribute and try again."
 		deps := CloudContextDependencies{RunAWS: failingRunAWS("stop-instances", raw)}
 		_, err := StopCloudContext(ctx, powerErrorTestStore(), params, deps)
-		if err == nil {
-			t.Fatal("expected the stop to fail")
-		}
-		for _, want := range []string{"stop protection", "enable-api-stop petios-ctx", "OperationNotPermitted"} {
-			if !strings.Contains(err.Error(), want) {
-				t.Fatalf("error %q does not mention %q", err, want)
-			}
-		}
+		assertErrorMentions(t, err, "expected the stop to fail", "stop protection", "enable-api-stop petios-ctx", "OperationNotPermitted")
 	})
 
 	t.Run("stop with an expired AWS session names the login lever", func(t *testing.T) {
 		raw := "aws ec2 stop-instances --instance-ids i-0abc123: Error when retrieving token from sso: Token has expired and refresh failed"
 		deps := CloudContextDependencies{RunAWS: failingRunAWS("stop-instances", raw)}
 		_, err := StopCloudContext(ctx, powerErrorTestStore(), params, deps)
-		if err == nil {
-			t.Fatal("expected the stop to fail")
-		}
-		for _, want := range []string{"expired or unavailable", "erun cloud login --alias dev-aws", "Token has expired"} {
-			if !strings.Contains(err.Error(), want) {
-				t.Fatalf("error %q does not mention %q", err, want)
-			}
-		}
+		assertErrorMentions(t, err, "expected the stop to fail", "expired or unavailable", "erun cloud login --alias dev-aws", "Token has expired")
 	})
 
 	t.Run("stop with an unrelated AWS error passes through unchanged", func(t *testing.T) {
@@ -59,18 +45,8 @@ func TestCloudContextPowerErrorClassification(t *testing.T) {
 	})
 
 	t.Run("stop on an already-stopping instance is still absorbed into the wait", func(t *testing.T) {
-		var waited bool
-		deps := CloudContextDependencies{RunAWS: func(_ Context, _ CloudProviderConfig, _ string, args []string) (string, error) {
-			joined := strings.Join(args, " ")
-			if strings.Contains(joined, "stop-instances") {
-				return "", fmt.Errorf("aws ec2 stop-instances: An error occurred (IncorrectInstanceState) when calling the StopInstances operation")
-			}
-			if strings.Contains(joined, "wait instance-stopped") {
-				waited = true
-				return "", nil
-			}
-			return "", nil
-		}}
+		waited := false
+		deps := CloudContextDependencies{RunAWS: alreadyStoppingRunAWS(&waited)}
 		status, err := StopCloudContext(ctx, powerErrorTestStore(), params, deps)
 		if err != nil {
 			t.Fatalf("expected the already-stopping stop to succeed, got %v", err)
@@ -84,33 +60,16 @@ func TestCloudContextPowerErrorClassification(t *testing.T) {
 	})
 
 	t.Run("a failed stopped-wait reports the unobserved end state", func(t *testing.T) {
-		deps := CloudContextDependencies{RunAWS: func(_ Context, _ CloudProviderConfig, _ string, args []string) (string, error) {
-			if strings.Contains(strings.Join(args, " "), "wait instance-stopped") {
-				return "", fmt.Errorf("aws ec2 wait instance-stopped: Waiter InstanceStopped failed: Max attempts exceeded")
-			}
-			return "", nil
-		}}
+		deps := CloudContextDependencies{RunAWS: failingStopWaitRunAWS()}
 		_, err := StopCloudContext(ctx, powerErrorTestStore(), params, deps)
-		if err == nil {
-			t.Fatal("expected the wait failure to propagate")
-		}
-		for _, want := range []string{"not observed stopped", "Max attempts exceeded"} {
-			if !strings.Contains(err.Error(), want) {
-				t.Fatalf("error %q does not mention %q", err, want)
-			}
-		}
+		assertErrorMentions(t, err, "expected the wait failure to propagate", "not observed stopped", "Max attempts exceeded")
 	})
 
 	t.Run("start with an expired AWS session names the login lever", func(t *testing.T) {
 		raw := "aws ec2 start-instances --instance-ids i-0abc123: An error occurred (ExpiredToken) when calling the StartInstances operation: The security token included in the request is expired"
 		deps := CloudContextDependencies{RunAWS: failingRunAWS("start-instances", raw)}
 		_, err := StartCloudContext(ctx, powerErrorTestStore(), params, deps)
-		if err == nil {
-			t.Fatal("expected the start to fail")
-		}
-		if !strings.Contains(err.Error(), "erun cloud login --alias dev-aws") {
-			t.Fatalf("error %q does not mention the login lever", err)
-		}
+		assertErrorMentions(t, err, "expected the start to fail", "erun cloud login --alias dev-aws")
 	})
 
 	t.Run("start never claims stop protection", func(t *testing.T) {
@@ -124,6 +83,48 @@ func TestCloudContextPowerErrorClassification(t *testing.T) {
 			t.Fatalf("start failure misclassified as stop protection: %q", err)
 		}
 	})
+}
+
+// assertErrorMentions fails when err is nil (reporting expectMsg) or when its
+// message is missing any of the wanted substrings.
+func assertErrorMentions(t *testing.T, err error, expectMsg string, wants ...string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal(expectMsg)
+	}
+	for _, want := range wants {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// alreadyStoppingRunAWS fails stop-instances with IncorrectInstanceState (the
+// instance is already stopping) and succeeds the stopped-wait, flipping waited
+// so the caller can assert the wait absorbed the race.
+func alreadyStoppingRunAWS(waited *bool) func(Context, CloudProviderConfig, string, []string) (string, error) {
+	return func(_ Context, _ CloudProviderConfig, _ string, args []string) (string, error) {
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "stop-instances") {
+			return "", fmt.Errorf("aws ec2 stop-instances: An error occurred (IncorrectInstanceState) when calling the StopInstances operation")
+		}
+		if strings.Contains(joined, "wait instance-stopped") {
+			*waited = true
+			return "", nil
+		}
+		return "", nil
+	}
+}
+
+// failingStopWaitRunAWS fails the stopped-wait waiter and lets every other AWS
+// call succeed, modelling a stop that was issued but never observed stopped.
+func failingStopWaitRunAWS() func(Context, CloudProviderConfig, string, []string) (string, error) {
+	return func(_ Context, _ CloudProviderConfig, _ string, args []string) (string, error) {
+		if strings.Contains(strings.Join(args, " "), "wait instance-stopped") {
+			return "", fmt.Errorf("aws ec2 wait instance-stopped: Waiter InstanceStopped failed: Max attempts exceeded")
+		}
+		return "", nil
+	}
 }
 
 // powerErrorTestStore returns the minimal store for the power-state paths:

--- a/erun-common/cloud_context_recover.go
+++ b/erun-common/cloud_context_recover.go
@@ -25,16 +25,16 @@ type RecoverCloudContextParams struct {
 // the caller can surface the values back to the user (and so MCP
 // callers can inspect them without re-reading the config).
 type RecoverCloudContextResult struct {
-	Saved      CloudContextConfig
-	Source     string // "aws-describe-instances"
-	TokenFrom  string // "kubeconfig" | "input" | "none"
+	Saved     CloudContextConfig
+	Source    string // "aws-describe-instances"
+	TokenFrom string // "kubeconfig" | "input" | "none"
 }
 
 type awsDescribeInstanceJSON struct {
 	Reservations []struct {
 		Instances []struct {
-			InstanceID         string `json:"InstanceId"`
-			State              struct {
+			InstanceID string `json:"InstanceId"`
+			State      struct {
 				Name string `json:"Name"`
 			} `json:"State"`
 			PublicIPAddress    string `json:"PublicIpAddress,omitempty"`
@@ -145,13 +145,13 @@ func resolveRecoverAdminToken(params RecoverCloudContextParams) (string, string)
 }
 
 type recoveredInstance struct {
-	id           string
-	publicIP     string
-	instanceType string
-	securityGroup string
+	id                 string
+	publicIP           string
+	instanceType       string
+	securityGroup      string
 	instanceProfileARN string
-	volumeID     string
-	launchTime   string
+	volumeID           string
+	launchTime         string
 }
 
 type recoveredVolume struct {

--- a/erun-common/container_registry.go
+++ b/erun-common/container_registry.go
@@ -115,46 +115,65 @@ func (r ContainerRegistries) Validate() error {
 	if r.IsZero() {
 		return errors.New("registry list is empty")
 	}
-	var build, from, deploy int
-	var fromRegistry string
-	toRegistries := make(map[string]struct{}, len(r))
-	for _, entry := range r {
-		registry := strings.TrimSpace(entry.Registry)
-		if registry == "" {
-			return errors.New("registry list entry is missing a registry")
-		}
-		if entry.hasRole(RegistryRoleBuild) {
-			build++
-		}
-		if entry.hasRole(RegistryRoleFrom) {
-			from++
-			fromRegistry = registry
-		}
-		if entry.hasRole(RegistryRoleTo) {
-			toRegistries[registry] = struct{}{}
-		}
-		if entry.hasRole(RegistryRoleDeploy) {
-			deploy++
-		}
+	tally, err := r.tallyRoles()
+	if err != nil {
+		return err
 	}
-	if build > 1 {
+	if tally.build > 1 {
 		return errors.New("at most one registry may be marked build")
 	}
-	if from > 1 {
+	if tally.from > 1 {
 		return errors.New("at most one registry may be marked from")
 	}
-	if deploy < 1 {
+	if tally.deploy < 1 {
 		return errors.New("at least one registry must be marked deploy")
 	}
-	if (from > 0) != (len(toRegistries) > 0) {
+	if (tally.from > 0) != (len(tally.toRegistries) > 0) {
 		return errors.New("from and to must be set together (a copy needs both a source and a destination)")
 	}
-	if fromRegistry != "" {
-		if _, ok := toRegistries[fromRegistry]; ok {
-			return fmt.Errorf("registry %q cannot be both from and to", fromRegistry)
+	if tally.fromRegistry != "" {
+		if _, ok := tally.toRegistries[tally.fromRegistry]; ok {
+			return fmt.Errorf("registry %q cannot be both from and to", tally.fromRegistry)
 		}
 	}
 	return nil
+}
+
+// registryRoleTally accumulates the role counts and to/from registries needed
+// to enforce the marker invariants in Validate.
+type registryRoleTally struct {
+	build        int
+	from         int
+	deploy       int
+	fromRegistry string
+	toRegistries map[string]struct{}
+}
+
+// tallyRoles walks the list once, counting role markers and recording the from
+// and to registries. It errors on the first entry missing a registry, matching
+// Validate's original per-entry guard.
+func (r ContainerRegistries) tallyRoles() (registryRoleTally, error) {
+	tally := registryRoleTally{toRegistries: make(map[string]struct{}, len(r))}
+	for _, entry := range r {
+		registry := strings.TrimSpace(entry.Registry)
+		if registry == "" {
+			return registryRoleTally{}, errors.New("registry list entry is missing a registry")
+		}
+		if entry.hasRole(RegistryRoleBuild) {
+			tally.build++
+		}
+		if entry.hasRole(RegistryRoleFrom) {
+			tally.from++
+			tally.fromRegistry = registry
+		}
+		if entry.hasRole(RegistryRoleTo) {
+			tally.toRegistries[registry] = struct{}{}
+		}
+		if entry.hasRole(RegistryRoleDeploy) {
+			tally.deploy++
+		}
+	}
+	return tally, nil
 }
 
 // Equal reports whether two lists carry the same registries with the same

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -426,20 +427,7 @@ func RunHelmDeploy(ctx Context, deployInput HelmDeploySpec, deploy HelmChartDepl
 	if err != nil {
 		return err
 	}
-	// Name the release for a non-runtime component so a single-component
-	// deploy (e.g. erun-backend-postgres) is not mistaken for a full-env
-	// redeploy: "erun/local · erun-backend-postgres 18.3" instead of the
-	// bare "erun/local 18.3". The runtime chart's line stays "<tenant>/<env>
-	// <version>" — it *is* the env, carries the meaningful runtime version,
-	// and feeds the helm-release poller + version persistence (#476). The
-	// version on a component line is that component's own version.
-	target := deployInput.Tenant + "/" + deployInput.Environment
-	if release := strings.TrimSpace(deployInput.ReleaseName); release != "" && release != RuntimeReleaseName(deployInput.Tenant) {
-		target += " · " + release
-	}
-	if version := strings.TrimSpace(deployInput.Version); version != "" {
-		target += " " + version
-	}
+	target := helmDeployTargetLabel(deployInput)
 	if outcome == HelmDeploySingleFlightSkipDuplicate {
 		ctx.Info("==> Skipping " + target + " (identical deploy already in progress)")
 		return nil
@@ -449,7 +437,34 @@ func RunHelmDeploy(ctx Context, deployInput HelmDeploySpec, deploy HelmChartDepl
 	if ctx.DryRun {
 		return nil
 	}
+	return runHelmDeployRollout(ctx, deployInput, deploy, target)
+}
 
+// helmDeployTargetLabel builds the "<tenant>/<env>[ · <release>][ <version>]"
+// label used in deploy feedback. It names the release for a non-runtime
+// component so a single-component deploy (e.g. erun-backend-postgres) is not
+// mistaken for a full-env redeploy: "erun/local · erun-backend-postgres 18.3"
+// instead of the bare "erun/local 18.3". The runtime chart's line stays
+// "<tenant>/<env> <version>" — it *is* the env, carries the meaningful runtime
+// version, and feeds the helm-release poller + version persistence (#476). The
+// version on a component line is that component's own version.
+func helmDeployTargetLabel(deployInput HelmDeploySpec) string {
+	target := deployInput.Tenant + "/" + deployInput.Environment
+	if release := strings.TrimSpace(deployInput.ReleaseName); release != "" && release != RuntimeReleaseName(deployInput.Tenant) {
+		target += " · " + release
+	}
+	if version := strings.TrimSpace(deployInput.Version); version != "" {
+		target += " " + version
+	}
+	return target
+}
+
+// runHelmDeployRollout performs the real-run helm rollout for an acquired,
+// non-duplicate deploy: it emits the user-facing progress lines, runs the
+// deployer under a spinner, and reports timing plus success/failure. The
+// "==> Deploy of <release> failed" / "==> Deployed <target> in <elapsed>"
+// lines are part of the trace contract the desktop activity queue parses.
+func runHelmDeployRollout(ctx Context, deployInput HelmDeploySpec, deploy HelmChartDeployerFunc, target string) error {
 	ctx.Info("==> Deploying " + target)
 	ctx.Info("    namespace " + deployInput.Namespace + " on context " + deployInput.KubernetesContext)
 	if timeout := strings.TrimSpace(deployInput.Timeout); timeout != "" {
@@ -532,29 +547,13 @@ func resolveCurrentDeploySpecs(ctx Context, store DeployStore, findProjectRoot P
 	}
 
 	if resolvedTarget.RemoteRepo() {
-		spec, err := resolvePublishedDevopsDeploySpec(ctx, resolvedTarget, target.VersionOverride)
-		if err != nil {
-			return nil, err
-		}
-		if err := configureDeployInputMetadata(store, resolvedTarget, &spec.Deploy); err != nil {
-			return nil, err
-		}
-		return []DeploySpec{spec}, nil
+		return resolveRemoteRepoDeploySpecs(ctx, store, resolvedTarget, target.VersionOverride)
 	}
 
-	deployContexts, err := ResolveCurrentKubernetesDeployContexts(findProjectRoot, resolveKubernetesDeployContext, resolvedTarget.RepoPath)
+	deployContexts, err := resolveCurrentLocalDeployContexts(findProjectRoot, resolveKubernetesDeployContext, resolvedTarget, target.Components)
 	if err != nil {
 		return nil, err
 	}
-	projectK8s, err := loadProjectK8sPlanForRepo(resolvedTarget.RepoPath, resolvedTarget.Environment)
-	if err != nil {
-		return nil, err
-	}
-	deployContexts, err = filterDeployContextsByComponents(deployContexts, target.Components, projectK8s)
-	if err != nil {
-		return nil, err
-	}
-	sortDeployContextsByDeployOrder(deployContexts, projectK8s)
 
 	var currentBuild *DockerBuildSpec
 	if buildOrchestration && resolvedTarget.EnvConfig.BuildsHere() {
@@ -578,6 +577,40 @@ func resolveCurrentDeploySpecs(ctx Context, store DeployStore, findProjectRoot P
 	}
 
 	return specs, nil
+}
+
+// resolveRemoteRepoDeploySpecs resolves the single published-devops deploy spec
+// for a remote-repo target (no local k8s tree), attaching cloud/tenant metadata
+// to the helm input.
+func resolveRemoteRepoDeploySpecs(ctx Context, store DeployStore, resolvedTarget OpenResult, versionOverride string) ([]DeploySpec, error) {
+	spec, err := resolvePublishedDevopsDeploySpec(ctx, resolvedTarget, versionOverride)
+	if err != nil {
+		return nil, err
+	}
+	if err := configureDeployInputMetadata(store, resolvedTarget, &spec.Deploy); err != nil {
+		return nil, err
+	}
+	return []DeploySpec{spec}, nil
+}
+
+// resolveCurrentLocalDeployContexts discovers the local k8s deploy contexts for
+// the target's repo, filters them to the requested components, and sorts them
+// into the project's configured deploy order.
+func resolveCurrentLocalDeployContexts(findProjectRoot ProjectFinderFunc, resolveKubernetesDeployContext DeployContextResolverFunc, resolvedTarget OpenResult, components []string) ([]KubernetesDeployContext, error) {
+	deployContexts, err := ResolveCurrentKubernetesDeployContexts(findProjectRoot, resolveKubernetesDeployContext, resolvedTarget.RepoPath)
+	if err != nil {
+		return nil, err
+	}
+	projectK8s, err := loadProjectK8sPlanForRepo(resolvedTarget.RepoPath, resolvedTarget.Environment)
+	if err != nil {
+		return nil, err
+	}
+	deployContexts, err = filterDeployContextsByComponents(deployContexts, components, projectK8s)
+	if err != nil {
+		return nil, err
+	}
+	sortDeployContextsByDeployOrder(deployContexts, projectK8s)
+	return deployContexts, nil
 }
 
 func resolveDeploySpecForOpenResult(ctx Context, store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, componentName, versionOverride string, currentBuild *DockerBuildSpec) (DeploySpec, error) {
@@ -718,6 +751,14 @@ func verifyExistingDeployImage(ctx Context, ref, version, registry string) error
 	if ctx.DryRun {
 		return nil
 	}
+	return confirmDeployImagePresent(ctx, tag, version)
+}
+
+// confirmDeployImagePresent checks that the pinned tag exists locally or in the
+// registry, returning an error only when its absence is definitive. A registry
+// error that is not a "absent" verdict (network/auth) is traced and tolerated:
+// the rollout surfaces a real pull failure if the image is genuinely missing.
+func confirmDeployImagePresent(ctx Context, tag, version string) error {
 	remote, remoteErr := DockerManifestExists(tag)
 	if remote {
 		return nil
@@ -726,9 +767,6 @@ func verifyExistingDeployImage(ctx Context, ref, version, registry string) error
 		return nil
 	}
 	if remoteErr != nil {
-		// The registry could not confirm presence (network/auth, not a
-		// definitive "absent"); don't block the deploy on it — the rollout
-		// surfaces a real pull failure if the image is genuinely missing.
 		ctx.Trace("deploy: could not verify " + tag + " in the registry (" + remoteErr.Error() + "); proceeding")
 		return nil
 	}
@@ -1137,21 +1175,21 @@ func newHelmDeploySpecWithValues(target OpenResult, deployContext KubernetesDepl
 	}
 
 	return HelmDeploySpec{
-		ReleaseName:        deployContext.ComponentName,
-		ChartPath:          deployContext.ChartPath,
-		ValuesFilePath:     valuesFilePath,
-		Tenant:             target.Tenant,
-		Environment:        target.Environment,
-		Namespace:          KubernetesNamespaceName(target.Tenant, target.Environment),
-		KubernetesContext:  target.EnvConfig.KubernetesContext,
-		WorktreeStorage:    resolveWorktreeStorage(target),
-		WorktreeRepoName:   resolveWorktreeRepoName(target.RepoPath),
-		WorktreeHostPath:   resolveWorktreeHostPath(target.RepoPath),
-		SSHDEnabled:        target.EnvConfig.SSHD.Enabled,
-		MCPPort:            ports.MCP,
-		APIPort:            ports.API,
-		SSHPort:            ports.SSH,
-		CloudProviderAlias: target.EnvConfig.CloudProviderAlias,
+		ReleaseName:         deployContext.ComponentName,
+		ChartPath:           deployContext.ChartPath,
+		ValuesFilePath:      valuesFilePath,
+		Tenant:              target.Tenant,
+		Environment:         target.Environment,
+		Namespace:           KubernetesNamespaceName(target.Tenant, target.Environment),
+		KubernetesContext:   target.EnvConfig.KubernetesContext,
+		WorktreeStorage:     resolveWorktreeStorage(target),
+		WorktreeRepoName:    resolveWorktreeRepoName(target.RepoPath),
+		WorktreeHostPath:    resolveWorktreeHostPath(target.RepoPath),
+		SSHDEnabled:         target.EnvConfig.SSHD.Enabled,
+		MCPPort:             ports.MCP,
+		APIPort:             ports.API,
+		SSHPort:             ports.SSH,
+		CloudProviderAlias:  target.EnvConfig.CloudProviderAlias,
 		ContainerRegistry:   resolveProjectContainerRegistry(target.RepoPath, target.Environment),
 		RuntimeRegistry:     strings.TrimSpace(target.EnvConfig.RuntimeRegistry),
 		ContainerRegistries: containerRegistries,
@@ -1207,11 +1245,7 @@ func applyCloudProviderDeployMetadata(store CloudReadStore, env EnvConfig, deplo
 	alias := strings.TrimSpace(env.CloudProviderAlias)
 	deployInput.CloudProviderAlias = alias
 	if alias != "" {
-		if provider, err := ResolveCloudProvider(store, alias); err == nil {
-			deployInput.CloudProvider = provider.Provider
-		} else if provider := cloudProviderFromAlias(alias); provider != "" {
-			deployInput.CloudProvider = provider
-		}
+		deployInput.CloudProvider = resolveCloudProviderForAlias(store, alias, deployInput.CloudProvider)
 	}
 
 	status, ok, err := findCloudContextForKubernetesContext(store, env.KubernetesContext)
@@ -1227,6 +1261,20 @@ func applyCloudProviderDeployMetadata(store CloudReadStore, env EnvConfig, deplo
 	if deployInput.CloudRegion == "" && deployInput.CloudProvider == CloudProviderAWS {
 		deployInput.CloudRegion = cloudContextRegionFromName(env.KubernetesContext)
 	}
+}
+
+// resolveCloudProviderForAlias resolves the cloud provider for a non-empty
+// alias, preferring the store's configured provider and falling back to the
+// provider parsed from the alias suffix. When neither resolves, the existing
+// value is preserved.
+func resolveCloudProviderForAlias(store CloudReadStore, alias, current string) string {
+	if provider, err := ResolveCloudProvider(store, alias); err == nil {
+		return provider.Provider
+	}
+	if provider := cloudProviderFromAlias(alias); provider != "" {
+		return provider
+	}
+	return current
 }
 
 func cloudProviderFromAlias(alias string) string {
@@ -1732,13 +1780,8 @@ func resolveCurrentDevopsK8sDir(findProjectRoot ProjectFinderFunc, dir, projectR
 		return "", false, nil
 	}
 
-	k8sDir := filepath.Join(dir, "k8s")
-	if strings.HasSuffix(filepath.Base(dir), "-devops") {
-		if ok, err := isKubernetesDeployModuleDir(k8sDir); err != nil {
-			return "", false, err
-		} else if ok {
-			return k8sDir, true, nil
-		}
+	if k8sDir, ok, err := resolveDirDevopsK8sDir(dir); err != nil || ok {
+		return k8sDir, ok, err
 	}
 
 	if k8sDir, ok, err := resolveAncestorDevopsK8sDir(dir); err != nil || ok {
@@ -1758,6 +1801,24 @@ func resolveCurrentDevopsK8sDir(findProjectRoot ProjectFinderFunc, dir, projectR
 	}
 
 	return resolveProjectRootDevopsK8sDir(findProjectRoot, projectRoot)
+}
+
+// resolveDirDevopsK8sDir returns dir/k8s when dir is itself a "-devops" module
+// directory whose k8s subdir holds helm charts. It reports (k8sDir, true) on a
+// match and ("", false) when dir is not a devops module or has no charts.
+func resolveDirDevopsK8sDir(dir string) (string, bool, error) {
+	if !strings.HasSuffix(filepath.Base(dir), "-devops") {
+		return "", false, nil
+	}
+	k8sDir := filepath.Join(dir, "k8s")
+	ok, err := isKubernetesDeployModuleDir(k8sDir)
+	if err != nil {
+		return "", false, err
+	}
+	if ok {
+		return k8sDir, true, nil
+	}
+	return "", false, nil
 }
 
 func resolveAncestorDevopsK8sDir(dir string) (string, bool, error) {
@@ -1858,21 +1919,28 @@ func isKubernetesDeployModuleDir(dir string) (bool, error) {
 	return len(deployContexts) > 0, nil
 }
 
-func DeployHelmChart(params HelmDeployParams) error {
-	chartPath := params.ChartPath
-	var cleanup func()
-	// A published OCI chart cannot be copied and stamped locally; its
-	// version is pinned on the helm command line instead (see command()).
-	if strings.TrimSpace(params.Version) != "" && !isOCIChartReference(params.ChartPath) {
-		var err error
-		chartPath, cleanup, err = prepareHelmChartForDeploy(params.ChartPath, params.Version)
-		if err != nil {
-			return err
-		}
-		defer cleanup()
+// resolveHelmDeployChartPath returns the chart path to deploy and an optional
+// cleanup the caller must defer. A published OCI chart cannot be copied and
+// stamped locally; its version is pinned on the helm command line instead (see
+// command()), so it deploys from its original reference with no cleanup. A
+// local chart at a pinned version is copied and stamped into a temp dir, whose
+// removal is the returned cleanup.
+func resolveHelmDeployChartPath(params HelmDeployParams) (string, func(), error) {
+	if strings.TrimSpace(params.Version) == "" || isOCIChartReference(params.ChartPath) {
+		return params.ChartPath, nil, nil
 	}
+	chartPath, cleanup, err := prepareHelmChartForDeploy(params.ChartPath, params.Version)
+	if err != nil {
+		return "", nil, err
+	}
+	return chartPath, cleanup, nil
+}
 
-	command := HelmDeploySpec{
+// helmDeployCommandSpec builds the helm upgrade command for the deploy,
+// reusing the HelmDeploySpec command builder with the resolved (possibly
+// stamped) chart path.
+func helmDeployCommandSpec(params HelmDeployParams, chartPath string) commandSpec {
+	return HelmDeploySpec{
 		ReleaseName:        params.ReleaseName,
 		ChartPath:          chartPath,
 		ValuesFilePath:     params.ValuesFilePath,
@@ -1905,13 +1973,15 @@ func DeployHelmChart(params HelmDeployParams) error {
 		Timeout:            params.Timeout,
 		Verbosity:          params.Verbosity,
 	}.command()
+}
 
-	cmd := Command(command.Name, command.Args...)
-	cmd.Dir = command.Dir
-	// At VerbosityInfo helm output is captured silently so a successful run is
-	// quiet; the buffer feeds back into the returned error on failure. At
-	// VerbosityDebug or higher the output is also teed to params.Stdout/Stderr
-	// so the user sees the live --debug stream.
+// configureHelmDeployCmdOutput wires the command's stdout/stderr and returns
+// the capture buffers used for error classification. At VerbosityInfo helm
+// output is captured silently so a successful run is quiet; the buffer feeds
+// back into the returned error on failure. At VerbosityDebug or higher the
+// output is also teed to params.Stdout/Stderr so the user sees the live --debug
+// stream.
+func configureHelmDeployCmdOutput(cmd *exec.Cmd, params HelmDeployParams) (*bytes.Buffer, *strings.Builder) {
 	helmOutput := new(bytes.Buffer)
 	if params.Verbosity >= VerbosityDebug {
 		cmd.Stdout = teeWriter(params.Stdout, helmOutput)
@@ -1924,11 +1994,15 @@ func DeployHelmChart(params HelmDeployParams) error {
 		stderrWriters = append(stderrWriters, params.Stderr)
 	}
 	cmd.Stderr = io.MultiWriter(stderrWriters...)
+	return helmOutput, stderr
+}
 
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-
+// runHelmDeployWithPodWatch runs the already-started helm command alongside the
+// release pod watcher and returns once both finish. If the watcher reports an
+// early container failure before helm exits, helm is interrupted (then killed
+// after a grace period) so the deploy fails fast instead of waiting out the
+// helm timeout.
+func runHelmDeployWithPodWatch(cmd *exec.Cmd, params HelmDeployParams) (podWatchOutcome, error) {
 	watchCtx, cancelWatch := context.WithCancel(context.Background())
 	defer cancelWatch()
 	watchDone := make(chan podWatchOutcome, 1)
@@ -1969,7 +2043,38 @@ func DeployHelmChart(params HelmDeployParams) error {
 			}
 		}
 	}
+	return watchOutcome, helmErr
+}
 
+func DeployHelmChart(params HelmDeployParams) error {
+	chartPath, cleanup, err := resolveHelmDeployChartPath(params)
+	if err != nil {
+		return err
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	command := helmDeployCommandSpec(params, chartPath)
+	cmd := Command(command.Name, command.Args...)
+	cmd.Dir = command.Dir
+	helmOutput, stderr := configureHelmDeployCmdOutput(cmd, params)
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	watchOutcome, helmErr := runHelmDeployWithPodWatch(cmd, params)
+	return classifyHelmDeployResult(params, watchOutcome, helmErr, helmOutput, stderr)
+}
+
+// classifyHelmDeployResult turns the raw helm/pod-watch outcome into the final
+// error: an early container failure (watchOutcome) wins, then the
+// pending-operation and published-chart-not-found special cases are recognized
+// from helm's stderr, and otherwise a helm failure is returned with its
+// captured output appended (at non-debug verbosity, where the stream was
+// silenced). A nil helmErr with no watch failure means success.
+func classifyHelmDeployResult(params HelmDeployParams, watchOutcome podWatchOutcome, helmErr error, helmOutput *bytes.Buffer, stderr *strings.Builder) error {
 	if watchOutcome.Failure != nil {
 		failure := watchOutcome.Failure
 		failure.Err = helmErr
@@ -2591,14 +2696,23 @@ func chartTemplateImageValue(line string) (string, bool) {
 			if !strings.Contains(value, "/") || !strings.Contains(value, ":") {
 				continue
 			}
-			if strings.Contains(value, "%s") && strings.Contains(line, ".Chart.AppVersion") {
-				if strings.Count(value, "%s") == 2 && strings.HasPrefix(value, "%s/") {
-					value = value[len("%s/"):]
-				}
-				value = strings.ReplaceAll(value, "%s", "{{ .Chart.AppVersion }}")
-			}
-			return value, true
+			return rewriteChartTemplateImageValue(value, line), true
 		}
 	}
 	return "", false
+}
+
+// rewriteChartTemplateImageValue rewrites a quoted Sprintf-style image template
+// (%s placeholders fed .Chart.AppVersion) into the same {{ .Chart.AppVersion }}
+// form the helm-rendered values produce. A leading "%s/" registry placeholder
+// is dropped so the value matches the registry-less chart refs. Values without
+// the %s/.Chart.AppVersion pattern are returned unchanged.
+func rewriteChartTemplateImageValue(value, line string) string {
+	if !strings.Contains(value, "%s") || !strings.Contains(line, ".Chart.AppVersion") {
+		return value
+	}
+	if strings.Count(value, "%s") == 2 && strings.HasPrefix(value, "%s/") {
+		value = value[len("%s/"):]
+	}
+	return strings.ReplaceAll(value, "%s", "{{ .Chart.AppVersion }}")
 }

--- a/erun-common/deploy_components.go
+++ b/erun-common/deploy_components.go
@@ -148,28 +148,9 @@ func groupDeploySpecsByPlan(specs []DeploySpec, plan ProjectK8sConfig) [][]Deplo
 		return nil
 	}
 	if len(plan.Deployments) == 0 {
-		groups := make([][]DeploySpec, 0, len(specs))
-		for _, spec := range specs {
-			groups = append(groups, []DeploySpec{spec})
-		}
-		return groups
+		return serialDeploySpecGroups(specs)
 	}
-	specsByName := make(map[string]DeploySpec, len(specs))
-	stepIndex := make(map[string]int)
-	for i, step := range plan.Deployments {
-		for _, name := range step.Components {
-			stepIndex[strings.TrimSpace(name)] = i
-		}
-	}
-	var trailing []DeploySpec
-	for _, spec := range specs {
-		name := strings.TrimSpace(spec.DeployContext.ComponentName)
-		if _, planned := stepIndex[name]; planned {
-			specsByName[name] = spec
-			continue
-		}
-		trailing = append(trailing, spec)
-	}
+	specsByName, trailing := partitionDeploySpecsByPlan(specs, plan)
 	out := make([][]DeploySpec, 0, len(plan.Deployments)+len(trailing))
 	for _, step := range plan.Deployments {
 		group := make([]DeploySpec, 0, len(step.Components))
@@ -188,3 +169,36 @@ func groupDeploySpecsByPlan(specs []DeploySpec, plan ProjectK8sConfig) [][]Deplo
 	return out
 }
 
+// serialDeploySpecGroups puts each spec in its own step, preserving input
+// order — the empty-plan grouping (strictly serial deploys).
+func serialDeploySpecGroups(specs []DeploySpec) [][]DeploySpec {
+	groups := make([][]DeploySpec, 0, len(specs))
+	for _, spec := range specs {
+		groups = append(groups, []DeploySpec{spec})
+	}
+	return groups
+}
+
+// partitionDeploySpecsByPlan splits the specs into those whose component is
+// named in the plan (keyed by component name) and those that are not (the
+// trailing specs, in input order). It relies on the plan having at least one
+// deployment step.
+func partitionDeploySpecsByPlan(specs []DeploySpec, plan ProjectK8sConfig) (map[string]DeploySpec, []DeploySpec) {
+	stepIndex := make(map[string]int)
+	for i, step := range plan.Deployments {
+		for _, name := range step.Components {
+			stepIndex[strings.TrimSpace(name)] = i
+		}
+	}
+	specsByName := make(map[string]DeploySpec, len(specs))
+	var trailing []DeploySpec
+	for _, spec := range specs {
+		name := strings.TrimSpace(spec.DeployContext.ComponentName)
+		if _, planned := stepIndex[name]; planned {
+			specsByName[name] = spec
+			continue
+		}
+		trailing = append(trailing, spec)
+	}
+	return specsByName, trailing
+}

--- a/erun-common/deploy_persist_runtime_version_test.go
+++ b/erun-common/deploy_persist_runtime_version_test.go
@@ -41,16 +41,9 @@ func TestPersistRuntimeVersionFromDeploySpecs(t *testing.T) {
 	t.Run("rolled-out deploy persists the built and pushed version", func(t *testing.T) {
 		var savedTenant string
 		var saved *EnvConfig
-		save := func(tn string, cfg EnvConfig) error {
-			savedTenant = tn
-			c := cfg
-			saved = &c
-			return nil
-		}
+		save := capturingSave(&savedTenant, &saved)
 		// A real rollout records Deploy.Version and never consults the cluster.
-		if err := PersistRuntimeVersionFromDeploySpecs(Context{}, []DeploySpec{runtimeSpec(false)}, save, fixedRunningVersion(runningVersion)); err != nil {
-			t.Fatalf("persist: %v", err)
-		}
+		persistOrFatal(t, Context{}, []DeploySpec{runtimeSpec(false)}, save, fixedRunningVersion(runningVersion))
 		if saved == nil || savedTenant != tenant {
 			t.Fatalf("expected save for tenant %q after a real rollout (saved=%v tenant=%q)", tenant, saved != nil, savedTenant)
 		}
@@ -60,15 +53,10 @@ func TestPersistRuntimeVersionFromDeploySpecs(t *testing.T) {
 	})
 
 	t.Run("cached deploy (SkipHelm) heals to the running version, not the minted one", func(t *testing.T) {
+		var savedTenant string
 		var saved *EnvConfig
-		save := func(_ string, cfg EnvConfig) error {
-			c := cfg
-			saved = &c
-			return nil
-		}
-		if err := PersistRuntimeVersionFromDeploySpecs(Context{}, []DeploySpec{runtimeSpec(true)}, save, fixedRunningVersion(runningVersion)); err != nil {
-			t.Fatalf("persist: %v", err)
-		}
+		save := capturingSave(&savedTenant, &saved)
+		persistOrFatal(t, Context{}, []DeploySpec{runtimeSpec(true)}, save, fixedRunningVersion(runningVersion))
 		if saved == nil {
 			t.Fatalf("a cached deploy must heal RuntimeVersion to the running version")
 		}
@@ -81,9 +69,7 @@ func TestPersistRuntimeVersionFromDeploySpecs(t *testing.T) {
 		saved := false
 		save := func(string, EnvConfig) error { saved = true; return nil }
 		// Empty string models a missing release / unavailable helm.
-		if err := PersistRuntimeVersionFromDeploySpecs(Context{}, []DeploySpec{runtimeSpec(true)}, save, fixedRunningVersion("")); err != nil {
-			t.Fatalf("persist: %v", err)
-		}
+		persistOrFatal(t, Context{}, []DeploySpec{runtimeSpec(true)}, save, fixedRunningVersion(""))
 		if saved {
 			t.Fatalf("could not read the running version; must not persist (would be a phantom)")
 		}
@@ -93,14 +79,35 @@ func TestPersistRuntimeVersionFromDeploySpecs(t *testing.T) {
 		saved := false
 		resolverCalled := false
 		save := func(string, EnvConfig) error { saved = true; return nil }
-		resolver := func(Context, string, string, string) (string, error) { resolverCalled = true; return runningVersion, nil }
-		if err := PersistRuntimeVersionFromDeploySpecs(Context{DryRun: true}, []DeploySpec{runtimeSpec(true)}, save, resolver); err != nil {
-			t.Fatalf("persist: %v", err)
+		resolver := func(Context, string, string, string) (string, error) {
+			resolverCalled = true
+			return runningVersion, nil
 		}
+		persistOrFatal(t, Context{DryRun: true}, []DeploySpec{runtimeSpec(true)}, save, resolver)
 		if saved || resolverCalled {
 			t.Fatalf("dry-run must not persist (saved=%v) or query the cluster (resolverCalled=%v)", saved, resolverCalled)
 		}
 	})
+}
+
+// capturingSave returns a save func that records the tenant and a copy of the
+// saved EnvConfig through the given pointers.
+func capturingSave(savedTenant *string, saved **EnvConfig) func(string, EnvConfig) error {
+	return func(tn string, cfg EnvConfig) error {
+		*savedTenant = tn
+		c := cfg
+		*saved = &c
+		return nil
+	}
+}
+
+// persistOrFatal runs PersistRuntimeVersionFromDeploySpecs and fails the test
+// if it errors, so each subtest can focus on its persistence assertions.
+func persistOrFatal(t *testing.T, ctx Context, specs []DeploySpec, save func(string, EnvConfig) error, resolve HelmReleaseVersionResolverFunc) {
+	t.Helper()
+	if err := PersistRuntimeVersionFromDeploySpecs(ctx, specs, save, resolve); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
 }
 
 // TestCachedDeployRunThenPersistHealsToRunningVersion drives the real

--- a/erun-common/deploy_pod_watch.go
+++ b/erun-common/deploy_pod_watch.go
@@ -80,9 +80,9 @@ type podStatusItem struct {
 		Annotations map[string]string `json:"annotations"`
 	} `json:"metadata"`
 	Status struct {
-		Phase                 string                  `json:"phase"`
-		ContainerStatuses     []containerStatusEntry  `json:"containerStatuses"`
-		InitContainerStatuses []containerStatusEntry  `json:"initContainerStatuses"`
+		Phase                 string                 `json:"phase"`
+		ContainerStatuses     []containerStatusEntry `json:"containerStatuses"`
+		InitContainerStatuses []containerStatusEntry `json:"initContainerStatuses"`
 	} `json:"status"`
 }
 
@@ -139,9 +139,9 @@ const crashLoopRestartThreshold = 2
 // faster cadence than production. ERUN_DEPLOY_POD_WATCH_INTERVAL accepts any
 // time.ParseDuration value; values below 100ms are clamped to 100ms.
 const (
-	defaultPodWatchPollInterval  = 2 * time.Second
+	defaultPodWatchPollInterval   = 2 * time.Second
 	defaultPodWatchKubectlTimeout = 10 * time.Second
-	minPodWatchPollInterval      = 100 * time.Millisecond
+	minPodWatchPollInterval       = 100 * time.Millisecond
 )
 
 func resolvePodWatchPollInterval() time.Duration {
@@ -291,16 +291,8 @@ func classifyTerminalFailure(pods []podStatusItem, params podWatchParams) *HelmR
 
 func containerTerminalFailure(c containerStatusEntry) (reason, message string, ok bool) {
 	if c.State.Waiting != nil {
-		w := c.State.Waiting
-		if _, terminal := terminalWaitingReasons[w.Reason]; terminal {
-			return w.Reason, w.Message, true
-		}
-		if w.Reason == "CrashLoopBackOff" && c.RestartCount >= crashLoopRestartThreshold {
-			msg := w.Message
-			if t := c.LastState.Terminated; t != nil && strings.TrimSpace(t.Message) != "" {
-				msg = strings.TrimSpace(t.Message)
-			}
-			return w.Reason, msg, true
+		if r, m, waitingOK := containerWaitingTerminalFailure(c); waitingOK {
+			return r, m, true
 		}
 	}
 	if t := c.State.Terminated; t != nil && t.ExitCode != 0 && c.RestartCount >= crashLoopRestartThreshold {
@@ -309,6 +301,25 @@ func containerTerminalFailure(c containerStatusEntry) (reason, message string, o
 			reason = "Error"
 		}
 		return reason, t.Message, true
+	}
+	return "", "", false
+}
+
+// containerWaitingTerminalFailure classifies a waiting container as a terminal
+// failure: either a reason in terminalWaitingReasons, or a CrashLoopBackOff
+// that has restarted past the threshold (in which case the last terminated
+// message is preferred when present).
+func containerWaitingTerminalFailure(c containerStatusEntry) (reason, message string, ok bool) {
+	w := c.State.Waiting
+	if _, terminal := terminalWaitingReasons[w.Reason]; terminal {
+		return w.Reason, w.Message, true
+	}
+	if w.Reason == "CrashLoopBackOff" && c.RestartCount >= crashLoopRestartThreshold {
+		msg := w.Message
+		if t := c.LastState.Terminated; t != nil && strings.TrimSpace(t.Message) != "" {
+			msg = strings.TrimSpace(t.Message)
+		}
+		return w.Reason, msg, true
 	}
 	return "", "", false
 }
@@ -394,4 +405,3 @@ func renderPodSummaries(out io.Writer, summaries []podSummary, last map[string]s
 		_, _ = io.WriteString(out, "    "+s.Line+"\n")
 	}
 }
-

--- a/erun-common/deploy_singleflight.go
+++ b/erun-common/deploy_singleflight.go
@@ -178,66 +178,97 @@ func acquireHelmDeploySingleFlight(ctx Context, deploy HelmDeploySpec, deps helm
 	for attempt := 0; attempt < 2; attempt++ {
 		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o600)
 		if err == nil {
-			if writeErr := writeInflightRecord(f, record); writeErr != nil {
-				_ = f.Close()
-				_ = os.Remove(path)
-				return HelmDeploySingleFlightProceed, nil, fmt.Errorf("write deploy in-flight marker: %w", writeErr)
+			handle, writeErr := writeFreshInflightMarker(ctx, f, path, record, releaseKey, paramsHash)
+			if writeErr != nil {
+				return HelmDeploySingleFlightProceed, nil, writeErr
 			}
-			if closeErr := f.Close(); closeErr != nil {
-				_ = os.Remove(path)
-				return HelmDeploySingleFlightProceed, nil, fmt.Errorf("close deploy in-flight marker: %w", closeErr)
-			}
-			ctx.Trace(fmt.Sprintf("dedup: claim (release=%s, hash=%s, pid=%d)", releaseKey, paramsHash, record.PID))
-			return HelmDeploySingleFlightProceed, &HelmDeploySingleFlightHandle{path: path}, nil
+			return HelmDeploySingleFlightProceed, handle, nil
 		}
 		if !errors.Is(err, os.ErrExist) {
 			return HelmDeploySingleFlightProceed, nil, fmt.Errorf("acquire deploy in-flight marker: %w", err)
 		}
 
-		existing, readErr := readInflightRecord(path)
-		if readErr != nil {
-			ctx.Trace("dedup: replacing unreadable in-flight marker (" + readErr.Error() + ")")
-			if rmErr := os.Remove(path); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
-				return HelmDeploySingleFlightProceed, nil, fmt.Errorf("remove unreadable in-flight marker: %w", rmErr)
-			}
+		reclaim, outcome, recErr := reconcileExistingInflightMarker(ctx, deps, deploy, path, releaseKey, paramsHash)
+		if reclaim {
 			continue
 		}
-		if !deps.isAlive(existing.PID) {
-			ctx.Trace(fmt.Sprintf("dedup: reclaim (release=%s, prior pid=%d is dead)", releaseKey, existing.PID))
-			if rmErr := os.Remove(path); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
-				return HelmDeploySingleFlightProceed, nil, fmt.Errorf("remove stale in-flight marker: %w", rmErr)
-			}
-			continue
-		}
-		// PID liveness alone is not sufficient inside containers: a pod
-		// restart resets the PID namespace, and a coincidentally-alive
-		// new PID can shadow the dead deploy's recorded PID. Fall back
-		// to a max-age check so any marker older than a sensible deploy
-		// ceiling is reclaimed regardless of what PID the kernel hands
-		// out.
-		if !existing.StartedAt.IsZero() && deps.now().Sub(existing.StartedAt) > helmDeploySingleFlightMaxAge {
-			ctx.Trace(fmt.Sprintf("dedup: reclaim (release=%s, marker age %s exceeds max %s)", releaseKey, deps.now().Sub(existing.StartedAt).Round(time.Second), helmDeploySingleFlightMaxAge))
-			if rmErr := os.Remove(path); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
-				return HelmDeploySingleFlightProceed, nil, fmt.Errorf("remove aged-out in-flight marker: %w", rmErr)
-			}
-			continue
-		}
-		if existing.ParamsHash == paramsHash {
-			ctx.Trace(fmt.Sprintf("dedup: skip (release=%s, hash=%s, pid=%d already running identical deploy)", releaseKey, paramsHash, existing.PID))
-			return HelmDeploySingleFlightSkipDuplicate, nil, nil
-		}
-		return HelmDeploySingleFlightProceed, nil, &HelmReleaseConcurrentDeployError{
-			ReleaseName:       deploy.ReleaseName,
-			Namespace:         deploy.Namespace,
-			KubernetesContext: deploy.KubernetesContext,
-			OtherPID:          existing.PID,
-			OtherStartedAt:    existing.StartedAt,
-			OtherTenant:       existing.Tenant,
-			OtherEnvironment:  existing.Environment,
-			OtherVersion:      existing.Version,
-		}
+		return outcome, nil, recErr
 	}
 	return HelmDeploySingleFlightProceed, nil, fmt.Errorf("could not acquire deploy in-flight marker after retries")
+}
+
+// writeFreshInflightMarker writes our claim record into the freshly created
+// (O_EXCL) marker file and returns the owning handle. On any failure it closes
+// and removes the partial marker so a retry or a later acquire is not blocked
+// by a half-written file.
+func writeFreshInflightMarker(ctx Context, f *os.File, path string, record deployInflightRecord, releaseKey, paramsHash string) (*HelmDeploySingleFlightHandle, error) {
+	if writeErr := writeInflightRecord(f, record); writeErr != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("write deploy in-flight marker: %w", writeErr)
+	}
+	if closeErr := f.Close(); closeErr != nil {
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("close deploy in-flight marker: %w", closeErr)
+	}
+	ctx.Trace(fmt.Sprintf("dedup: claim (release=%s, hash=%s, pid=%d)", releaseKey, paramsHash, record.PID))
+	return &HelmDeploySingleFlightHandle{path: path}, nil
+}
+
+// removeInflightMarker deletes a marker file, treating an already-absent file
+// as success so a concurrent reclaim does not turn into an error.
+func removeInflightMarker(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// reconcileExistingInflightMarker inspects the marker that blocked our O_EXCL
+// claim and decides the outcome: reclaim it (reclaim=true, the caller retries
+// the claim), skip as an identical duplicate, or fail with a concurrent-deploy
+// error. Every reclaim path removes the marker first. PID liveness alone is not
+// sufficient inside containers — a pod restart resets the PID namespace and a
+// coincidentally-alive new PID can shadow the dead deploy's recorded PID — so a
+// max-age check reclaims any marker older than a sensible deploy ceiling
+// regardless of what PID the kernel hands out.
+func reconcileExistingInflightMarker(ctx Context, deps helmDeploySingleFlightDeps, deploy HelmDeploySpec, path, releaseKey, paramsHash string) (bool, HelmDeploySingleFlightOutcome, error) {
+	existing, readErr := readInflightRecord(path)
+	if readErr != nil {
+		ctx.Trace("dedup: replacing unreadable in-flight marker (" + readErr.Error() + ")")
+		if rmErr := removeInflightMarker(path); rmErr != nil {
+			return false, HelmDeploySingleFlightProceed, fmt.Errorf("remove unreadable in-flight marker: %w", rmErr)
+		}
+		return true, HelmDeploySingleFlightProceed, nil
+	}
+	if !deps.isAlive(existing.PID) {
+		ctx.Trace(fmt.Sprintf("dedup: reclaim (release=%s, prior pid=%d is dead)", releaseKey, existing.PID))
+		if rmErr := removeInflightMarker(path); rmErr != nil {
+			return false, HelmDeploySingleFlightProceed, fmt.Errorf("remove stale in-flight marker: %w", rmErr)
+		}
+		return true, HelmDeploySingleFlightProceed, nil
+	}
+	if !existing.StartedAt.IsZero() && deps.now().Sub(existing.StartedAt) > helmDeploySingleFlightMaxAge {
+		ctx.Trace(fmt.Sprintf("dedup: reclaim (release=%s, marker age %s exceeds max %s)", releaseKey, deps.now().Sub(existing.StartedAt).Round(time.Second), helmDeploySingleFlightMaxAge))
+		if rmErr := removeInflightMarker(path); rmErr != nil {
+			return false, HelmDeploySingleFlightProceed, fmt.Errorf("remove aged-out in-flight marker: %w", rmErr)
+		}
+		return true, HelmDeploySingleFlightProceed, nil
+	}
+	if existing.ParamsHash == paramsHash {
+		ctx.Trace(fmt.Sprintf("dedup: skip (release=%s, hash=%s, pid=%d already running identical deploy)", releaseKey, paramsHash, existing.PID))
+		return false, HelmDeploySingleFlightSkipDuplicate, nil
+	}
+	return false, HelmDeploySingleFlightProceed, &HelmReleaseConcurrentDeployError{
+		ReleaseName:       deploy.ReleaseName,
+		Namespace:         deploy.Namespace,
+		KubernetesContext: deploy.KubernetesContext,
+		OtherPID:          existing.PID,
+		OtherStartedAt:    existing.StartedAt,
+		OtherTenant:       existing.Tenant,
+		OtherEnvironment:  existing.Environment,
+		OtherVersion:      existing.Version,
+	}
 }
 
 // reportHelmDeploySingleFlightDryRun previews the dedup decision without

--- a/erun-common/docker_build_scope.go
+++ b/erun-common/docker_build_scope.go
@@ -289,14 +289,24 @@ func ResolveDockerBuildEnvConfig(store DockerStore, findProjectRoot ProjectFinde
 		if err != nil {
 			continue
 		}
-		for i := range envs {
-			if wantEnv != "" && envs[i].Name != wantEnv {
-				continue
-			}
-			path := strings.TrimSpace(envs[i].EffectiveLocalRepoPath())
-			if path != "" && filepath.Clean(path) == cleanRoot {
-				return &envs[i]
-			}
+		if match := matchDockerBuildEnvConfig(envs, wantEnv, cleanRoot); match != nil {
+			return match
+		}
+	}
+	return nil
+}
+
+// matchDockerBuildEnvConfig returns the first env in envs whose effective local
+// repo path matches cleanRoot, optionally filtered to wantEnv (when non-empty),
+// or nil when none matches.
+func matchDockerBuildEnvConfig(envs []EnvConfig, wantEnv, cleanRoot string) *EnvConfig {
+	for i := range envs {
+		if wantEnv != "" && envs[i].Name != wantEnv {
+			continue
+		}
+		path := strings.TrimSpace(envs[i].EffectiveLocalRepoPath())
+		if path != "" && filepath.Clean(path) == cleanRoot {
+			return &envs[i]
 		}
 	}
 	return nil

--- a/erun-common/doctor_remote_init.go
+++ b/erun-common/doctor_remote_init.go
@@ -308,6 +308,33 @@ func RunRemoteInitFinish(ctx Context, inspection RemoteInitInspection, params Re
 		return inspection, nil
 	}
 
+	repositoryURL, err := resolveRemoteInitRepositoryURL(ctx, inspection, params, prompt, missing)
+	if err != nil {
+		return inspection, err
+	}
+
+	repository := resolveRemoteInitRepositorySpec(repositoryURL, inspection.Marker)
+	missing = appendMissingCodeCommitKeypair(missing, repository, inspection.HomeDir)
+
+	state, err := applyRemoteInitMissingItems(ctx, inspection, missing)
+	if err != nil {
+		return inspection, err
+	}
+
+	if state.needsGitCheckout {
+		if err := runRemoteInitGitCheckout(ctx, inspection, &repository, state, params, prompt); err != nil {
+			return inspection, err
+		}
+	}
+
+	return saveRemoteInitCompletionMarker(ctx, inspection, repository, repositoryURL)
+}
+
+// resolveRemoteInitRepositoryURL resolves the git repository URL for a finish
+// run: the explicit param, then the marker, then (only when a clone is needed
+// and we are not in dry-run) an interactive prompt. Returns an error when a
+// clone is required but no URL can be obtained.
+func resolveRemoteInitRepositoryURL(ctx Context, inspection RemoteInitInspection, params RemoteInitFinishParams, prompt RemoteInitFinishPrompt, missing []RemoteInitInspectionItem) (string, error) {
 	repositoryURL := strings.TrimSpace(params.RepositoryURL)
 	if repositoryURL == "" {
 		repositoryURL = strings.TrimSpace(inspection.Marker.RepositoryURL)
@@ -315,83 +342,116 @@ func RunRemoteInitFinish(ctx Context, inspection RemoteInitInspection, params Re
 	needsClone := remoteInitMissingItem(missing, "git checkout")
 	if needsClone && repositoryURL == "" && !ctx.DryRun {
 		if prompt == nil {
-			return inspection, errors.New("repository URL is required to finish git checkout")
+			return "", errors.New("repository URL is required to finish git checkout")
 		}
 		value, err := prompt(remoteInitRepositoryPromptLabel(inspection.Tenant, inspection.Environment))
 		if err != nil {
-			return inspection, err
+			return "", err
 		}
 		repositoryURL = strings.TrimSpace(value)
 		if repositoryURL == "" {
-			return inspection, errors.New("repository URL is required to finish git checkout")
+			return "", errors.New("repository URL is required to finish git checkout")
 		}
 	}
+	return repositoryURL, nil
+}
 
-	repository := resolveRemoteInitRepositorySpec(repositoryURL, inspection.Marker)
-
-	if repository.CodeCommitHost != "" && !remoteInitMissingItem(missing, "CodeCommit SSH keypair") {
-		rsaPath := defaultRemoteInitCodeCommitSSHKeyPath(inspection.HomeDir)
-		if _, err := os.Stat(rsaPath); err != nil {
-			missing = append(missing, RemoteInitInspectionItem{
-				Label:  "CodeCommit SSH keypair",
-				Path:   rsaPath,
-				Status: RemoteInitInspectionStatusMissing,
-			})
-		}
+// appendMissingCodeCommitKeypair adds the CodeCommit SSH keypair to the missing
+// set when the repo is a CodeCommit host whose keypair is absent on disk but was
+// not already flagged (the inspection only checks it conditionally).
+func appendMissingCodeCommitKeypair(missing []RemoteInitInspectionItem, repository remoteRepositorySpec, homeDir string) []RemoteInitInspectionItem {
+	if repository.CodeCommitHost == "" || remoteInitMissingItem(missing, "CodeCommit SSH keypair") {
+		return missing
 	}
+	rsaPath := defaultRemoteInitCodeCommitSSHKeyPath(homeDir)
+	if _, err := os.Stat(rsaPath); err != nil {
+		missing = append(missing, RemoteInitInspectionItem{
+			Label:  "CodeCommit SSH keypair",
+			Path:   rsaPath,
+			Status: RemoteInitInspectionStatusMissing,
+		})
+	}
+	return missing
+}
 
-	sshKeyPath := defaultRemoteInitSSHKeyPath(inspection.HomeDir)
-	sshKeyJustGenerated := false
-	codeCommitKeyPath := ""
-	codeCommitKeyJustGenerated := false
-	needsGitCheckout := false
+// remoteInitKeyState carries the SSH/CodeCommit key paths and just-generated
+// flags produced while materializing missing items, plus whether a git checkout
+// is still pending — the checkout runs after the keys exist.
+type remoteInitKeyState struct {
+	sshKeyPath                 string
+	sshKeyJustGenerated        bool
+	codeCommitKeyPath          string
+	codeCommitKeyJustGenerated bool
+	needsGitCheckout           bool
+}
+
+// applyRemoteInitMissingItems materializes each missing item (project root, SSH
+// keys, agent skills) in canonical order, returning the key state the checkout
+// phase needs. The "git checkout" item only sets needsGitCheckout here because
+// the clone depends on the keys generated above.
+func applyRemoteInitMissingItems(ctx Context, inspection RemoteInitInspection, missing []RemoteInitInspectionItem) (remoteInitKeyState, error) {
+	state := remoteInitKeyState{sshKeyPath: defaultRemoteInitSSHKeyPath(inspection.HomeDir)}
 	for _, item := range orderRemoteInitMissingItems(missing) {
-		switch item.Label {
-		case "project root":
-			if err := finishRemoteInitProjectRoot(ctx, item.Path); err != nil {
-				return inspection, err
-			}
-		case "SSH keypair":
-			if err := finishRemoteInitSSHKey(ctx, item.Path); err != nil {
-				return inspection, err
-			}
-			sshKeyPath = item.Path
-			sshKeyJustGenerated = true
-		case "CodeCommit SSH keypair":
-			if err := finishRemoteInitCodeCommitSSHKey(ctx, item.Path); err != nil {
-				return inspection, err
-			}
-			codeCommitKeyPath = item.Path
-			codeCommitKeyJustGenerated = true
-		case "git checkout":
-			needsGitCheckout = true
-		case "agent skills":
-			if err := finishRemoteInitSkills(ctx, inspection.HomeDir); err != nil {
-				return inspection, err
-			}
+		if err := applyRemoteInitMissingItem(ctx, inspection, item, &state); err != nil {
+			return state, err
 		}
 	}
+	return state, nil
+}
 
-	if needsGitCheckout {
-		if repository.CodeCommitHost != "" {
-			if codeCommitKeyPath == "" {
-				codeCommitKeyPath = defaultRemoteInitCodeCommitSSHKeyPath(inspection.HomeDir)
-			}
-			if err := resolveCodeCommitSSHKeyID(ctx, &repository, codeCommitKeyPath, inspection.Tenant, inspection.Environment, params.CodeCommitSSHKeyID, prompt); err != nil {
-				return inspection, err
-			}
-			if err := finishRemoteInitCodeCommitSSHConfig(ctx, inspection.HomeDir, repository); err != nil {
-				return inspection, err
-			}
+// applyRemoteInitMissingItem materializes a single missing item, recording any
+// generated key path/flag on state. The "git checkout" item only flags
+// needsGitCheckout — the clone is run later, after every key exists.
+func applyRemoteInitMissingItem(ctx Context, inspection RemoteInitInspection, item RemoteInitInspectionItem, state *remoteInitKeyState) error {
+	switch item.Label {
+	case "project root":
+		return finishRemoteInitProjectRoot(ctx, item.Path)
+	case "SSH keypair":
+		if err := finishRemoteInitSSHKey(ctx, item.Path); err != nil {
+			return err
 		}
-		if err := finishRemoteInitGitAccess(ctx, sshKeyPath, codeCommitKeyPath, repository, sshKeyJustGenerated, codeCommitKeyJustGenerated, params.Sleep); err != nil {
-			return inspection, err
+		state.sshKeyPath = item.Path
+		state.sshKeyJustGenerated = true
+	case "CodeCommit SSH keypair":
+		if err := finishRemoteInitCodeCommitSSHKey(ctx, item.Path); err != nil {
+			return err
 		}
-		if err := finishRemoteInitGitCheckout(ctx, inspection.ProjectRoot, sshKeyPath, repository); err != nil {
-			return inspection, err
+		state.codeCommitKeyPath = item.Path
+		state.codeCommitKeyJustGenerated = true
+	case "git checkout":
+		state.needsGitCheckout = true
+	case "agent skills":
+		return finishRemoteInitSkills(ctx, inspection.HomeDir)
+	}
+	return nil
+}
+
+// runRemoteInitGitCheckout completes the CodeCommit SSH config (when the repo is
+// a CodeCommit host) and clones the project into ProjectRoot using the resolved
+// keys. repository may be updated in place with a resolved CodeCommit SSH key ID.
+func runRemoteInitGitCheckout(ctx Context, inspection RemoteInitInspection, repository *remoteRepositorySpec, state remoteInitKeyState, params RemoteInitFinishParams, prompt RemoteInitFinishPrompt) error {
+	codeCommitKeyPath := state.codeCommitKeyPath
+	if repository.CodeCommitHost != "" {
+		if codeCommitKeyPath == "" {
+			codeCommitKeyPath = defaultRemoteInitCodeCommitSSHKeyPath(inspection.HomeDir)
+		}
+		if err := resolveCodeCommitSSHKeyID(ctx, repository, codeCommitKeyPath, inspection.Tenant, inspection.Environment, params.CodeCommitSSHKeyID, prompt); err != nil {
+			return err
+		}
+		if err := finishRemoteInitCodeCommitSSHConfig(ctx, inspection.HomeDir, *repository); err != nil {
+			return err
 		}
 	}
+	if err := finishRemoteInitGitAccess(ctx, state.sshKeyPath, codeCommitKeyPath, *repository, state.sshKeyJustGenerated, state.codeCommitKeyJustGenerated, params.Sleep); err != nil {
+		return err
+	}
+	return finishRemoteInitGitCheckout(ctx, inspection.ProjectRoot, state.sshKeyPath, *repository)
+}
 
+// saveRemoteInitCompletionMarker stamps the marker complete (tenant, env,
+// project root, and — unless NoGit — the resolved repository details) and
+// persists it, or traces the would-be write in dry-run.
+func saveRemoteInitCompletionMarker(ctx Context, inspection RemoteInitInspection, repository remoteRepositorySpec, repositoryURL string) (RemoteInitInspection, error) {
 	updated := inspection
 	updated.Marker.Tenant = inspection.Tenant
 	updated.Marker.Environment = inspection.Environment

--- a/erun-common/doctor_root_config.go
+++ b/erun-common/doctor_root_config.go
@@ -148,14 +148,7 @@ func InspectRootConfig(store RootConfigInspectionStore) (RootConfigInspection, e
 		return inspection, nil
 	}
 
-	configured := make(map[string]struct{}, len(config.CloudProviders))
-	for _, provider := range config.CloudProviders {
-		alias := strings.TrimSpace(provider.Alias)
-		if alias == "" {
-			continue
-		}
-		configured[alias] = struct{}{}
-	}
+	configured := configuredAliasSet(config.CloudProviders)
 	inspection.ConfiguredCount = len(configured)
 
 	tenants, err := store.ListTenantConfigs()
@@ -165,42 +158,37 @@ func InspectRootConfig(store RootConfigInspectionStore) (RootConfigInspection, e
 	inspection.TenantHits = len(tenants)
 	inspection.CloudContextHits = len(config.CloudContexts)
 
-	orphans := make(map[string]*OrphanedAlias)
-	addOrphanTenant := func(alias, tenant string) {
-		alias = strings.TrimSpace(alias)
-		tenant = strings.TrimSpace(tenant)
-		if alias == "" || tenant == "" {
-			return
-		}
-		entry := orphans[alias]
-		if entry == nil {
-			entry = newOrphanedAlias(alias)
-			orphans[alias] = entry
-		}
-		if !containsTrimmedAlias(entry.ReferencedByTenants, tenant) {
-			entry.ReferencedByTenants = append(entry.ReferencedByTenants, tenant)
-		}
-	}
-	addOrphanContext := func(alias, contextName, region string) {
-		alias = strings.TrimSpace(alias)
-		contextName = strings.TrimSpace(contextName)
-		if alias == "" || contextName == "" {
-			return
-		}
-		entry := orphans[alias]
-		if entry == nil {
-			entry = newOrphanedAlias(alias)
-			orphans[alias] = entry
-		}
-		ref := OrphanedAliasContextRef{Name: contextName, Region: strings.TrimSpace(region)}
-		for _, existing := range entry.ReferencedByCloudContexts {
-			if existing.Name == ref.Name {
-				return
-			}
-		}
-		entry.ReferencedByCloudContexts = append(entry.ReferencedByCloudContexts, ref)
-	}
+	inspection.OrphanedAliases = detectOrphanedAliases(configured, tenants, config.CloudContexts)
 
+	contextOrphans, err := collectOrphanedCloudContexts(store, config.CloudContexts, tenants)
+	if err != nil {
+		return RootConfigInspection{}, err
+	}
+	inspection.OrphanedContexts = contextOrphans
+
+	return inspection, nil
+}
+
+// configuredAliasSet returns the set of non-empty, trimmed cloud-provider
+// aliases declared in the root config — the source of truth orphan detection
+// compares tenant and cloud-context references against.
+func configuredAliasSet(providers []CloudProviderConfig) map[string]struct{} {
+	configured := make(map[string]struct{}, len(providers))
+	for _, provider := range providers {
+		alias := strings.TrimSpace(provider.Alias)
+		if alias == "" {
+			continue
+		}
+		configured[alias] = struct{}{}
+	}
+	return configured
+}
+
+// detectOrphanedAliases finds cloud-provider aliases referenced by tenants or
+// cloud contexts that are not present in the configured set, aggregated by
+// alias and returned in a stable sorted order.
+func detectOrphanedAliases(configured map[string]struct{}, tenants []TenantConfig, cloudContexts []CloudContextConfig) []OrphanedAlias {
+	orphans := make(map[string]*OrphanedAlias)
 	for _, tenant := range tenants {
 		aliases := append([]string{}, tenant.CloudProviderAliases...)
 		if primary := strings.TrimSpace(tenant.PrimaryCloudProviderAlias); primary != "" {
@@ -214,11 +202,10 @@ func InspectRootConfig(store RootConfigInspectionStore) (RootConfigInspection, e
 			if _, ok := configured[alias]; ok {
 				continue
 			}
-			addOrphanTenant(alias, tenant.Name)
+			addOrphanTenantRef(orphans, alias, tenant.Name)
 		}
 	}
-
-	for _, cloudContext := range config.CloudContexts {
+	for _, cloudContext := range cloudContexts {
 		alias := strings.TrimSpace(cloudContext.CloudProviderAlias)
 		if alias == "" {
 			continue
@@ -226,32 +213,73 @@ func InspectRootConfig(store RootConfigInspectionStore) (RootConfigInspection, e
 		if _, ok := configured[alias]; ok {
 			continue
 		}
-		addOrphanContext(alias, cloudContext.Name, cloudContext.Region)
+		addOrphanContextRef(orphans, alias, cloudContext.Name, cloudContext.Region)
 	}
+	return sortedOrphanedAliases(orphans)
+}
 
-	if len(orphans) > 0 {
-		aliases := make([]string, 0, len(orphans))
-		for alias := range orphans {
-			aliases = append(aliases, alias)
+// addOrphanTenantRef records that tenant references the orphaned alias,
+// de-duplicating tenant names.
+func addOrphanTenantRef(orphans map[string]*OrphanedAlias, alias, tenant string) {
+	alias = strings.TrimSpace(alias)
+	tenant = strings.TrimSpace(tenant)
+	if alias == "" || tenant == "" {
+		return
+	}
+	entry := orphans[alias]
+	if entry == nil {
+		entry = newOrphanedAlias(alias)
+		orphans[alias] = entry
+	}
+	if !containsTrimmedAlias(entry.ReferencedByTenants, tenant) {
+		entry.ReferencedByTenants = append(entry.ReferencedByTenants, tenant)
+	}
+}
+
+// addOrphanContextRef records that the named cloud context references the
+// orphaned alias, de-duplicating by context name.
+func addOrphanContextRef(orphans map[string]*OrphanedAlias, alias, contextName, region string) {
+	alias = strings.TrimSpace(alias)
+	contextName = strings.TrimSpace(contextName)
+	if alias == "" || contextName == "" {
+		return
+	}
+	entry := orphans[alias]
+	if entry == nil {
+		entry = newOrphanedAlias(alias)
+		orphans[alias] = entry
+	}
+	ref := OrphanedAliasContextRef{Name: contextName, Region: strings.TrimSpace(region)}
+	for _, existing := range entry.ReferencedByCloudContexts {
+		if existing.Name == ref.Name {
+			return
 		}
-		sort.Strings(aliases)
-		for _, alias := range aliases {
-			entry := orphans[alias]
-			sort.Strings(entry.ReferencedByTenants)
-			sort.Slice(entry.ReferencedByCloudContexts, func(i, j int) bool {
-				return entry.ReferencedByCloudContexts[i].Name < entry.ReferencedByCloudContexts[j].Name
-			})
-			inspection.OrphanedAliases = append(inspection.OrphanedAliases, *entry)
-		}
 	}
+	entry.ReferencedByCloudContexts = append(entry.ReferencedByCloudContexts, ref)
+}
 
-	contextOrphans, err := collectOrphanedCloudContexts(store, config.CloudContexts, tenants)
-	if err != nil {
-		return RootConfigInspection{}, err
+// sortedOrphanedAliases flattens the orphan map into a slice ordered by alias,
+// with each entry's tenant and cloud-context references sorted too, so the
+// inspection output is deterministic.
+func sortedOrphanedAliases(orphans map[string]*OrphanedAlias) []OrphanedAlias {
+	if len(orphans) == 0 {
+		return nil
 	}
-	inspection.OrphanedContexts = contextOrphans
-
-	return inspection, nil
+	aliases := make([]string, 0, len(orphans))
+	for alias := range orphans {
+		aliases = append(aliases, alias)
+	}
+	sort.Strings(aliases)
+	result := make([]OrphanedAlias, 0, len(aliases))
+	for _, alias := range aliases {
+		entry := orphans[alias]
+		sort.Strings(entry.ReferencedByTenants)
+		sort.Slice(entry.ReferencedByCloudContexts, func(i, j int) bool {
+			return entry.ReferencedByCloudContexts[i].Name < entry.ReferencedByCloudContexts[j].Name
+		})
+		result = append(result, *entry)
+	}
+	return result
 }
 
 // collectOrphanedCloudContexts walks every env config and reports

--- a/erun-common/env_trace_test.go
+++ b/erun-common/env_trace_test.go
@@ -32,20 +32,8 @@ func TestActivateEnvTrace(t *testing.T) {
 			t.Fatalf("trace log not written: %v", err)
 		}
 		content := string(raw)
-		for _, want := range []string{"kubectl get pods", "==> Deploying team/dev 1.0.0", "appending the full trace"} {
-			if !strings.Contains(content, want) {
-				t.Fatalf("trace log missing %q:\n%s", want, content)
-			}
-		}
-		for _, line := range strings.Split(strings.TrimSpace(content), "\n") {
-			stamp, _, found := strings.Cut(line, " ")
-			if !found {
-				t.Fatalf("unstamped line %q", line)
-			}
-			if _, err := time.Parse(time.RFC3339, stamp); err != nil {
-				t.Fatalf("line %q does not start with an RFC3339 stamp: %v", line, err)
-			}
-		}
+		assertTraceLogContains(t, content, "kubectl get pods", "==> Deploying team/dev 1.0.0", "appending the full trace")
+		assertTraceLogLinesStamped(t, content)
 	})
 
 	t.Run("dry-run names the path and writes nothing", func(t *testing.T) {
@@ -97,4 +85,30 @@ func TestActivateEnvTrace(t *testing.T) {
 			t.Fatalf("expected a fresh capped log, got %d bytes", len(raw))
 		}
 	})
+}
+
+// assertTraceLogContains fails when content is missing any of the wanted
+// substrings, reporting the want and the full content.
+func assertTraceLogContains(t *testing.T, content string, wants ...string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(content, want) {
+			t.Fatalf("trace log missing %q:\n%s", want, content)
+		}
+	}
+}
+
+// assertTraceLogLinesStamped fails unless every non-blank line begins with an
+// RFC3339 timestamp followed by a space.
+func assertTraceLogLinesStamped(t *testing.T, content string) {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(content), "\n") {
+		stamp, _, found := strings.Cut(line, " ")
+		if !found {
+			t.Fatalf("unstamped line %q", line)
+		}
+		if _, err := time.Parse(time.RFC3339, stamp); err != nil {
+			t.Fatalf("line %q does not start with an RFC3339 stamp: %v", line, err)
+		}
+	}
 }

--- a/erun-common/helm_chart_publish.go
+++ b/erun-common/helm_chart_publish.go
@@ -80,7 +80,7 @@ func RunHelmChartPublish(ctx Context, spec HelmChartPublishSpec) error {
 		return fmt.Errorf("helm package %s: %w", spec.ChartName, err)
 	}
 	tgzPath := filepath.Join(pkg.Dir, spec.ChartName+"-"+spec.Version+".tgz")
-	defer os.Remove(tgzPath)
+	defer func() { _ = os.Remove(tgzPath) }()
 	if err := runHelmCommand(ctx, push); err != nil {
 		return fmt.Errorf("helm push %s: %w", spec.ChartName, err)
 	}
@@ -109,7 +109,7 @@ func VerifyPublishedHelmChart(ctx Context, ociRepo, chartName, version string) e
 	if err := runHelmCommand(ctx, commandSpec{Name: "helm", Args: args}); err != nil {
 		return fmt.Errorf("verify published chart %s:%s: %w", chartName, version, err)
 	}
-	defer os.Remove(filepath.Join(destination, chartName+"-"+version+".tgz"))
+	defer func() { _ = os.Remove(filepath.Join(destination, chartName+"-"+version+".tgz")) }()
 	ctx.Info("==> Verified published chart " + chartName + " " + version)
 	return nil
 }
@@ -137,7 +137,7 @@ func loadHelmChartName(chartPath string) (string, error) {
 	}
 	name := strings.TrimSpace(chart.Name)
 	if name == "" {
-		return "", fmt.Errorf("Chart.yaml at %s is missing the name field", chartPath)
+		return "", fmt.Errorf("missing name field in Chart.yaml at %s", chartPath)
 	}
 	return name, nil
 }
@@ -202,4 +202,3 @@ func publishRuntimeChartForPushedImage(ctx Context, image DockerImageReference) 
 	}
 	return VerifyPublishedHelmChart(ctx, publish.OCIRepo, publish.ChartName, publish.Version)
 }
-

--- a/erun-common/idle_stop_pending.go
+++ b/erun-common/idle_stop_pending.go
@@ -143,29 +143,48 @@ func MaybeArmOrFireIdleStop(params MaybeArmOrFireIdleStopParams) (MaybeArmOrFire
 		}
 		return MaybeArmOrFireIdleStopResult{Action: IdleStopActionSkip}, nil
 	}
-	grace := idleStopGraceSeconds(params.Status)
 	pending, ok, err := LoadEnvironmentStopPending(tenant, environment)
 	if err != nil {
 		return MaybeArmOrFireIdleStopResult{}, err
 	}
 	if !ok {
-		armed := EnvironmentStopPending{
-			Since:            now,
-			GraceSeconds:     grace,
-			CloudContextName: strings.TrimSpace(params.CloudContextName),
-			ReasonSummary:    strings.TrimSpace(params.ReasonSummary),
-			Markers:          cloneIdleMarkersForPending(params.Status.Markers),
-			Policy:           params.Status.Policy,
-		}
-		if err := SaveEnvironmentStopPending(tenant, environment, armed); err != nil {
-			return MaybeArmOrFireIdleStopResult{}, err
-		}
-		return MaybeArmOrFireIdleStopResult{
-			Action:           IdleStopActionArm,
-			State:            armed,
-			SecondsRemaining: grace,
-		}, nil
+		return armIdleStopGraceWindow(tenant, environment, params, now)
 	}
+	return resolveArmedIdleStopWindow(tenant, environment, pending, now)
+}
+
+// armIdleStopGraceWindow writes a fresh stop-pending entry and reports
+// the Arm action. Called by MaybeArmOrFireIdleStop on the first pass
+// for an eligible env that has no pending window on disk yet.
+func armIdleStopGraceWindow(tenant, environment string, params MaybeArmOrFireIdleStopParams, now time.Time) (MaybeArmOrFireIdleStopResult, error) {
+	grace := idleStopGraceSeconds(params.Status)
+	armed := EnvironmentStopPending{
+		Since:            now,
+		GraceSeconds:     grace,
+		CloudContextName: strings.TrimSpace(params.CloudContextName),
+		ReasonSummary:    strings.TrimSpace(params.ReasonSummary),
+		Markers:          cloneIdleMarkersForPending(params.Status.Markers),
+		Policy:           params.Status.Policy,
+	}
+	if err := SaveEnvironmentStopPending(tenant, environment, armed); err != nil {
+		return MaybeArmOrFireIdleStopResult{}, err
+	}
+	return MaybeArmOrFireIdleStopResult{
+		Action:           IdleStopActionArm,
+		State:            armed,
+		SecondsRemaining: grace,
+	}, nil
+}
+
+// resolveArmedIdleStopWindow decides between Wait and Fire for an env
+// whose grace window is already armed. While the window is still open
+// it reports Wait with the seconds remaining; once the grace has
+// elapsed it clears the pending file before reporting Fire so a
+// crashing caller does not leave the env stuck "armed forever" after a
+// successful stop attempt that didn't get a chance to clean up. The
+// history entry is written separately by the caller on successful AWS
+// stop.
+func resolveArmedIdleStopWindow(tenant, environment string, pending EnvironmentStopPending, now time.Time) (MaybeArmOrFireIdleStopResult, error) {
 	elapsed := now.Sub(pending.Since)
 	if elapsed < time.Duration(pending.GraceSeconds)*time.Second {
 		remaining := pending.GraceSeconds - int64(elapsed.Seconds())
@@ -178,11 +197,6 @@ func MaybeArmOrFireIdleStop(params MaybeArmOrFireIdleStopParams) (MaybeArmOrFire
 			SecondsRemaining: remaining,
 		}, nil
 	}
-	// Grace elapsed: clear the pending file before reporting Fire so
-	// a crashing caller does not leave the env stuck "armed forever"
-	// after a successful stop attempt that didn't get a chance to
-	// clean up. The history entry is written separately by the
-	// caller on successful AWS stop.
 	if err := ClearEnvironmentStopPending(tenant, environment); err != nil {
 		return MaybeArmOrFireIdleStopResult{}, err
 	}

--- a/erun-common/open_reconnect_test.go
+++ b/erun-common/open_reconnect_test.go
@@ -31,27 +31,19 @@ func TestRemoteShellLaunchPersistentSession(t *testing.T) {
 
 	t.Run("bare CLI is unchanged (no dtach)", func(t *testing.T) {
 		script := preview(t, base)
-		if strings.Contains(script, "dtach") {
-			t.Fatalf("bare `erun open` must not use dtach:\n%s", script)
-		}
-		if !strings.Contains(script, bashrc+" || shell_status=$?") {
-			t.Fatalf("bare path lost its original bash invocation:\n%s", script)
-		}
+		assertScriptLacks(t, script, "dtach", "bare `erun open` must not use dtach")
+		assertScriptHas(t, script, bashrc+" || shell_status=$?", "bare path lost its original bash invocation")
 	})
 
 	t.Run("ERun tab persists via dtach, plain shell", func(t *testing.T) {
 		req := base
 		req.AppSession = "open-0"
 		script := preview(t, req)
-		if !strings.Contains(script, `dtach -A "/tmp/erun-app/erun-local-open-0.dtach" -r ctrl_l /bin/bash`) {
-			t.Fatalf("ERun tab missing dtach wrap:\n%s", script)
-		}
+		assertScriptHas(t, script, `dtach -A "/tmp/erun-app/erun-local-open-0.dtach" -r ctrl_l /bin/bash`, "ERun tab missing dtach wrap")
 		if strings.Contains(script, "claude") || strings.Contains(script, "ERUN_SKIP_LINT") {
 			t.Fatalf("plain ERun shell must not launch claude or set contribute env:\n%s", script)
 		}
-		if !strings.Contains(script, "exec "+bashrc) {
-			t.Fatalf("launcher must exec the interactive shell:\n%s", script)
-		}
+		assertScriptHas(t, script, "exec "+bashrc, "launcher must exec the interactive shell")
 	})
 
 	t.Run("attach takes the session over from other windows", func(t *testing.T) {
@@ -64,21 +56,11 @@ func TestRemoteShellLaunchPersistentSession(t *testing.T) {
 		req.AppSession = "open-0"
 		script := preview(t, req)
 		owner := `/tmp/erun-app/erun-local-open-0.owner`
-		if !strings.Contains(script, `printf '%s' "$attach_id" > "`+owner+`"`) {
-			t.Fatalf("attach must claim the owner file:\n%s", script)
-		}
-		if !strings.Contains(script, `if [ "$dtach_pid" != "$master_pid" ]`) {
-			t.Fatalf("kick loop must spare the session master:\n%s", script)
-		}
-		if !strings.Contains(script, `[ "$child_comm" != "dtach" ]`) {
-			t.Fatalf("master detection must be the /proc child scan (runtime image has no ss):\n%s", script)
-		}
-		if !strings.Contains(script, `[ -S "/tmp/erun-app/erun-local-open-0.dtach" ] && [ -n "$master_pid" ]`) {
-			t.Fatalf("kick must be skipped when the master cannot be identified:\n%s", script)
-		}
-		if !strings.Contains(script, `!= "$attach_id" ]; then exit 76; fi`) {
-			t.Fatalf("kicked wrapper must exit 76 on foreign owner:\n%s", script)
-		}
+		assertScriptHas(t, script, `printf '%s' "$attach_id" > "`+owner+`"`, "attach must claim the owner file")
+		assertScriptHas(t, script, `if [ "$dtach_pid" != "$master_pid" ]`, "kick loop must spare the session master")
+		assertScriptHas(t, script, `[ "$child_comm" != "dtach" ]`, "master detection must be the /proc child scan (runtime image has no ss)")
+		assertScriptHas(t, script, `[ -S "/tmp/erun-app/erun-local-open-0.dtach" ] && [ -n "$master_pid" ]`, "kick must be skipped when the master cannot be identified")
+		assertScriptHas(t, script, `!= "$attach_id" ]; then exit 76; fi`, "kicked wrapper must exit 76 on foreign owner")
 	})
 
 	t.Run("each terminal slot owns its own session", func(t *testing.T) {
@@ -91,12 +73,8 @@ func TestRemoteShellLaunchPersistentSession(t *testing.T) {
 		req := base
 		req.AppSession = "open-1"
 		script := preview(t, req)
-		if !strings.Contains(script, `dtach -A "/tmp/erun-app/erun-local-open-1.dtach" -r ctrl_l`) {
-			t.Fatalf("slot 1 missing its own dtach socket:\n%s", script)
-		}
-		if strings.Contains(script, "open-0") {
-			t.Fatalf("slot 1 must not touch slot 0's session:\n%s", script)
-		}
+		assertScriptHas(t, script, `dtach -A "/tmp/erun-app/erun-local-open-1.dtach" -r ctrl_l`, "slot 1 missing its own dtach socket")
+		assertScriptLacks(t, script, "open-0", "slot 1 must not touch slot 0's session")
 	})
 
 	t.Run("AI tab launches claude once as the session program", func(t *testing.T) {
@@ -104,20 +82,14 @@ func TestRemoteShellLaunchPersistentSession(t *testing.T) {
 		req.AppSession = "ai"
 		req.AI = true
 		script := preview(t, req)
-		if !strings.Contains(script, `dtach -A "/tmp/erun-app/erun-local-ai.dtach" -r ctrl_l`) {
-			t.Fatalf("AI tab missing dtach wrap:\n%s", script)
-		}
-		if !strings.Contains(script, `claude --continue --settings '{"ultracode":true}'`) {
-			t.Fatalf("AI tab must launch the claude guard at the default effort (ultracode):\n%s", script)
-		}
+		assertScriptHas(t, script, `dtach -A "/tmp/erun-app/erun-local-ai.dtach" -r ctrl_l`, "AI tab missing dtach wrap")
+		assertScriptHas(t, script, `claude --continue --settings '{"ultracode":true}'`, "AI tab must launch the claude guard at the default effort (ultracode)")
 		// Claude's exit must not silently fall through to the shell: the
 		// wrapper names the exit and the resume command first (issue #464).
 		if !strings.Contains(script, "fi || ai_status=$?") || !strings.Contains(script, "resume with: %s") {
 			t.Fatalf("AI launcher missing the exit wrapper:\n%s", script)
 		}
-		if !strings.Contains(script, "exec "+bashrc) {
-			t.Fatalf("AI launcher must drop to an interactive shell after claude:\n%s", script)
-		}
+		assertScriptHas(t, script, "exec "+bashrc, "AI launcher must drop to an interactive shell after claude")
 	})
 
 	t.Run("contribute-AI tab cds to the clone, then claude", func(t *testing.T) {
@@ -131,10 +103,26 @@ func TestRemoteShellLaunchPersistentSession(t *testing.T) {
 		if clone < 0 || claude < 0 || clone > claude {
 			t.Fatalf("contribute-AI must cd to the clone before launching claude:\n%s", script)
 		}
-		if !strings.Contains(script, "ERUN_SKIP_LINT") {
-			t.Fatalf("contribute env missing:\n%s", script)
-		}
+		assertScriptHas(t, script, "ERUN_SKIP_LINT", "contribute env missing")
 	})
+}
+
+// assertScriptHas fails the test when script does not contain want, reporting
+// msg followed by the full script.
+func assertScriptHas(t *testing.T, script, want, msg string) {
+	t.Helper()
+	if !strings.Contains(script, want) {
+		t.Fatalf("%s:\n%s", msg, script)
+	}
+}
+
+// assertScriptLacks fails the test when script contains unwanted, reporting
+// msg followed by the full script.
+func assertScriptLacks(t *testing.T, script, unwanted, msg string) {
+	t.Helper()
+	if strings.Contains(script, unwanted) {
+		t.Fatalf("%s:\n%s", msg, script)
+	}
 }
 
 // TestParseRemoteAppSessionIDs pins the detection contract: a pod's

--- a/erun-common/ports.go
+++ b/erun-common/ports.go
@@ -124,6 +124,54 @@ func ContributeAppPortForResult(result OpenResult) int {
 	return LocalPortsForResult(result).ContributeApp
 }
 
+// environmentPortRef pairs an env's tenant/environment key with its config so
+// the two-pass allocator can split envs into persisted and unpersisted groups.
+type environmentPortRef struct {
+	key string
+	env EnvConfig
+}
+
+// collectEnvironmentPortRefs walks every tenant's envs in alphabetical
+// (tenant, env) order, splitting them into those with a persisted
+// LocalPortRangeStart and those without. Tenants and envs with blank names are
+// skipped, matching the original inline collection.
+func collectEnvironmentPortRefs(store environmentPortStore) (persisted, unpersisted []environmentPortRef, err error) {
+	tenants, err := store.ListTenantConfigs()
+	if err != nil {
+		return nil, nil, err
+	}
+	sort.Slice(tenants, func(i, j int) bool {
+		return strings.TrimSpace(tenants[i].Name) < strings.TrimSpace(tenants[j].Name)
+	})
+
+	for _, tenant := range tenants {
+		tenantName := strings.TrimSpace(tenant.Name)
+		if tenantName == "" {
+			continue
+		}
+		envs, err := store.ListEnvConfigs(tenantName)
+		if err != nil {
+			return nil, nil, err
+		}
+		sort.Slice(envs, func(i, j int) bool {
+			return strings.TrimSpace(envs[i].Name) < strings.TrimSpace(envs[j].Name)
+		})
+		for _, env := range envs {
+			environmentName := strings.TrimSpace(env.Name)
+			if environmentName == "" {
+				continue
+			}
+			ref := environmentPortRef{key: environmentPortKey(tenantName, environmentName), env: env}
+			if env.LocalPortRangeStart > 0 {
+				persisted = append(persisted, ref)
+			} else {
+				unpersisted = append(unpersisted, ref)
+			}
+		}
+	}
+	return persisted, unpersisted, nil
+}
+
 // ResolveAllEnvironmentLocalPorts returns a per-env port allocation in two
 // passes. Pass A locks in any env whose config has a non-zero
 // LocalPortRangeStart at its declared range. Pass B walks the remaining envs
@@ -136,64 +184,49 @@ func ResolveAllEnvironmentLocalPorts(store environmentPortStore) (map[string]Env
 		return nil, fmt.Errorf("store is required")
 	}
 
-	tenants, err := store.ListTenantConfigs()
+	persisted, unpersisted, err := collectEnvironmentPortRefs(store)
 	if err != nil {
 		return nil, err
-	}
-	sort.Slice(tenants, func(i, j int) bool {
-		return strings.TrimSpace(tenants[i].Name) < strings.TrimSpace(tenants[j].Name)
-	})
-
-	type envRef struct {
-		key string
-		env EnvConfig
-	}
-	var persisted, unpersisted []envRef
-	for _, tenant := range tenants {
-		tenantName := strings.TrimSpace(tenant.Name)
-		if tenantName == "" {
-			continue
-		}
-		envs, err := store.ListEnvConfigs(tenantName)
-		if err != nil {
-			return nil, err
-		}
-		sort.Slice(envs, func(i, j int) bool {
-			return strings.TrimSpace(envs[i].Name) < strings.TrimSpace(envs[j].Name)
-		})
-		for _, env := range envs {
-			environmentName := strings.TrimSpace(env.Name)
-			if environmentName == "" {
-				continue
-			}
-			ref := envRef{key: environmentPortKey(tenantName, environmentName), env: env}
-			if env.LocalPortRangeStart > 0 {
-				persisted = append(persisted, ref)
-			} else {
-				unpersisted = append(unpersisted, ref)
-			}
-		}
 	}
 
 	allocations := make(map[string]EnvironmentLocalPorts, len(persisted)+len(unpersisted))
 	claimedByIndex := make(map[int]string, len(persisted)+len(unpersisted))
 
+	if err := allocatePersistedEnvironmentPorts(persisted, allocations, claimedByIndex); err != nil {
+		return nil, err
+	}
+	if err := allocateUnpersistedEnvironmentPorts(unpersisted, allocations, claimedByIndex); err != nil {
+		return nil, err
+	}
+
+	return allocations, nil
+}
+
+// allocatePersistedEnvironmentPorts locks each persisted env in at the index
+// derived from its declared range start, recording the claim and its ports. A
+// second env claiming the same index yields an ErrLocalPortRangeOverlap.
+func allocatePersistedEnvironmentPorts(persisted []environmentPortRef, allocations map[string]EnvironmentLocalPorts, claimedByIndex map[int]string) error {
 	for _, ref := range persisted {
 		index, err := environmentPortIndexForRangeStart(ref.env.LocalPortRangeStart, ref.key)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if other, dup := claimedByIndex[index]; dup {
-			return nil, ErrLocalPortRangeOverlap{A: other, B: ref.key, RangeStart: ref.env.LocalPortRangeStart}
+			return ErrLocalPortRangeOverlap{A: other, B: ref.key, RangeStart: ref.env.LocalPortRangeStart}
 		}
 		ports, err := environmentLocalPortsForIndex(index, ref.env)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		claimedByIndex[index] = ref.key
 		allocations[ref.key] = ports
 	}
+	return nil
+}
 
+// allocateUnpersistedEnvironmentPorts walks the remaining envs in order,
+// assigning each the lowest index not already claimed by the persisted pass.
+func allocateUnpersistedEnvironmentPorts(unpersisted []environmentPortRef, allocations map[string]EnvironmentLocalPorts, claimedByIndex map[int]string) error {
 	walkerIndex := 0
 	for _, ref := range unpersisted {
 		for {
@@ -204,14 +237,13 @@ func ResolveAllEnvironmentLocalPorts(store environmentPortStore) (map[string]Env
 		}
 		ports, err := environmentLocalPortsForIndex(walkerIndex, ref.env)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		claimedByIndex[walkerIndex] = ref.key
 		allocations[ref.key] = ports
 		walkerIndex++
 	}
-
-	return allocations, nil
+	return nil
 }
 
 func ResolveEnvironmentLocalPorts(store environmentPortStore, tenant, environment string) (EnvironmentLocalPorts, error) {

--- a/erun-common/registry_versions.go
+++ b/erun-common/registry_versions.go
@@ -157,14 +157,8 @@ func resolveGHCRRuntimeRegistryVersionsAt(ctx context.Context, client *http.Clie
 	if client == nil {
 		client = http.DefaultClient
 	}
-	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
-	if baseURL == "" {
-		baseURL = defaultGHCRRegistryBaseURL
-	}
-	tokenURL = strings.TrimRight(strings.TrimSpace(tokenURL), "/")
-	if tokenURL == "" {
-		tokenURL = defaultGHCRRegistryBaseURL
-	}
+	baseURL = normalizeGHCRBaseURL(baseURL)
+	tokenURL = normalizeGHCRBaseURL(tokenURL)
 
 	repoPath := strings.ToLower(url.PathEscape(owner) + "/" + url.PathEscape(repository))
 	token, err := fetchGHCRPullToken(ctx, client, repoPath, tokenURL)
@@ -172,12 +166,34 @@ func resolveGHCRRuntimeRegistryVersionsAt(ctx context.Context, client *http.Clie
 		return RuntimeRegistryVersions{}, err
 	}
 
-	endpoint := baseURL + "/v2/" + repoPath + "/tags/list"
+	tags, err := collectGHCRTags(ctx, client, baseURL+"/v2/"+repoPath+"/tags/list", token)
+	if err != nil {
+		return RuntimeRegistryVersions{}, err
+	}
+
+	versions := latestRuntimeVersionsFromTags(tags)
+	versions.Image = "ghcr.io/" + strings.ToLower(owner+"/"+repository)
+	return versions, nil
+}
+
+// normalizeGHCRBaseURL trims a GHCR base/token URL and falls back to the
+// default registry endpoint when it is empty.
+func normalizeGHCRBaseURL(rawURL string) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(rawURL), "/")
+	if trimmed == "" {
+		return defaultGHCRRegistryBaseURL
+	}
+	return trimmed
+}
+
+// collectGHCRTags walks the GHCR tag listing across all pages, returning every
+// non-empty tag name in encounter order.
+func collectGHCRTags(ctx context.Context, client *http.Client, endpoint, token string) ([]string, error) {
 	tags := make([]string, 0, 128)
 	for endpoint != "" {
 		page, next, err := fetchGHCRTagPage(ctx, client, endpoint, token)
 		if err != nil {
-			return RuntimeRegistryVersions{}, err
+			return nil, err
 		}
 		for _, tag := range page.Tags {
 			if name := strings.TrimSpace(tag); name != "" {
@@ -186,10 +202,7 @@ func resolveGHCRRuntimeRegistryVersionsAt(ctx context.Context, client *http.Clie
 		}
 		endpoint = next
 	}
-
-	versions := latestRuntimeVersionsFromTags(tags)
-	versions.Image = "ghcr.io/" + strings.ToLower(owner+"/"+repository)
-	return versions, nil
+	return tags, nil
 }
 
 func fetchGHCRPullToken(ctx context.Context, client *http.Client, repoPath, tokenBaseURL string) (string, error) {
@@ -270,27 +283,41 @@ func nextLinkFromHeader(resp *http.Response, baseEndpoint string) string {
 		if !strings.Contains(segment, `rel="next"`) {
 			continue
 		}
-		start := strings.Index(segment, "<")
-		end := strings.Index(segment, ">")
-		if start < 0 || end < 0 || end <= start+1 {
-			continue
-		}
-		target := strings.TrimSpace(segment[start+1 : end])
+		target := nextLinkTargetFromSegment(segment)
 		if target == "" {
 			continue
 		}
-		if strings.HasPrefix(target, "/") {
-			base, err := url.Parse(baseEndpoint)
-			if err == nil {
-				ref, err := url.Parse(target)
-				if err == nil {
-					return base.ResolveReference(ref).String()
-				}
-			}
-		}
-		return target
+		return resolveNextLinkTarget(target, baseEndpoint)
 	}
 	return ""
+}
+
+// nextLinkTargetFromSegment extracts the `<...>` target from a single Link
+// header segment, returning "" when the angle-bracket reference is missing or
+// empty.
+func nextLinkTargetFromSegment(segment string) string {
+	start := strings.Index(segment, "<")
+	end := strings.Index(segment, ">")
+	if start < 0 || end < 0 || end <= start+1 {
+		return ""
+	}
+	return strings.TrimSpace(segment[start+1 : end])
+}
+
+// resolveNextLinkTarget resolves a root-relative pagination target against the
+// base endpoint; absolute targets (or anything that fails to parse) are
+// returned unchanged.
+func resolveNextLinkTarget(target, baseEndpoint string) string {
+	if strings.HasPrefix(target, "/") {
+		base, err := url.Parse(baseEndpoint)
+		if err == nil {
+			ref, err := url.Parse(target)
+			if err == nil {
+				return base.ResolveReference(ref).String()
+			}
+		}
+	}
+	return target
 }
 
 type dockerHubTagPage struct {

--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -989,30 +989,18 @@ func discoverStableReleasePackaging(projectRoot, version string) ([]ReleaseFileU
 	syncSpec := &ReleasePackagingSyncSpec{ProjectRoot: projectRoot, Version: version}
 
 	formulaPath := filepath.Join(projectRoot, "Formula", "erun.rb")
-	formulaContent, formulaChanged, err := updateHomebrewFormulaReleaseVersion(formulaPath, version)
+	updates, err := appendReleasePackagingUpdate(updates, formulaPath, version, updateHomebrewFormulaReleaseVersion)
 	if err != nil {
 		return nil, nil, err
-	}
-	if formulaChanged {
-		updates = append(updates, ReleaseFileUpdate{
-			Path:    formulaPath,
-			Content: formulaContent,
-		})
 	}
 	if fileExists(formulaPath) {
 		syncSpec.FormulaPath = formulaPath
 	}
 
 	scoopPath := filepath.Join(projectRoot, "bucket", "erun.json")
-	scoopContent, scoopChanged, err := updateScoopManifestReleaseVersion(scoopPath, version)
+	updates, err = appendReleasePackagingUpdate(updates, scoopPath, version, updateScoopManifestReleaseVersion)
 	if err != nil {
 		return nil, nil, err
-	}
-	if scoopChanged {
-		updates = append(updates, ReleaseFileUpdate{
-			Path:    scoopPath,
-			Content: scoopContent,
-		})
 	}
 	if fileExists(scoopPath) {
 		syncSpec.ScoopPath = scoopPath
@@ -1028,6 +1016,27 @@ func discoverStableReleasePackaging(projectRoot, version string) ([]ReleaseFileU
 	}
 
 	return updates, syncSpec, nil
+}
+
+// appendReleasePackagingUpdate runs a packaging-file version updater and, when
+// it reports a change, appends the rewritten content as a ReleaseFileUpdate.
+// An updater error propagates unchanged so the discovery aborts as before.
+func appendReleasePackagingUpdate(
+	updates []ReleaseFileUpdate,
+	path, version string,
+	update func(string, string) (string, bool, error),
+) ([]ReleaseFileUpdate, error) {
+	content, changed, err := update(path, version)
+	if err != nil {
+		return nil, err
+	}
+	if changed {
+		updates = append(updates, ReleaseFileUpdate{
+			Path:    path,
+			Content: content,
+		})
+	}
+	return updates, nil
 }
 
 func updateHelmChartReleaseVersion(chartFilePath, version string) (string, bool, ReleaseChartSpec, error) {

--- a/erun-common/upgrade.go
+++ b/erun-common/upgrade.go
@@ -202,20 +202,28 @@ func buildUpgradePlan(store DeployStore, target UpgradeTarget, resolveVersions E
 		if err != nil {
 			return UpgradePlan{}, err
 		}
-		for _, env := range envs {
-			if scopeEnv != "" && env.Name != scopeEnv {
-				continue
-			}
-			if !env.AutoUpgrade {
-				traceln(fmt.Sprintf("upgrade: %s/%s not opted in (autoupgrade=false), skipping", tenant.Name, env.Name))
-				continue
-			}
-			traceln(fmt.Sprintf("upgrade: %s/%s opted in, channel=%s current=%s", tenant.Name, env.Name, env.ResolvedUpgradeChannel(), strings.TrimSpace(env.RuntimeVersion)))
-			plan.Items = append(plan.Items, resolveEnvUpgradeItem(tenant.Name, env, override, resolveVersions, traceln))
-		}
+		plan.Items = appendTenantUpgradeItems(plan.Items, tenant.Name, envs, scopeEnv, override, resolveVersions, traceln)
 	}
 
 	return plan, nil
+}
+
+// appendTenantUpgradeItems resolves the upgrade decision for each opted-in env
+// of one tenant (scoped by scopeEnv when non-empty) and appends one plan item
+// per opted-in env, tracing the skip/opt-in decision for each.
+func appendTenantUpgradeItems(items []UpgradePlanItem, tenant string, envs []EnvConfig, scopeEnv, override string, resolveVersions EnvVersionsResolver, traceln func(string)) []UpgradePlanItem {
+	for _, env := range envs {
+		if scopeEnv != "" && env.Name != scopeEnv {
+			continue
+		}
+		if !env.AutoUpgrade {
+			traceln(fmt.Sprintf("upgrade: %s/%s not opted in (autoupgrade=false), skipping", tenant, env.Name))
+			continue
+		}
+		traceln(fmt.Sprintf("upgrade: %s/%s opted in, channel=%s current=%s", tenant, env.Name, env.ResolvedUpgradeChannel(), strings.TrimSpace(env.RuntimeVersion)))
+		items = append(items, resolveEnvUpgradeItem(tenant, env, override, resolveVersions, traceln))
+	}
+	return items
 }
 
 // resolveEnvUpgradeItem resolves one env's upgrade decision. With an explicit
@@ -250,24 +258,7 @@ func resolveEnvUpgradeItem(tenant string, env EnvConfig, override string, resolv
 		return item
 	}
 
-	candidates := make([]UpgradeVersionCandidate, 0, len(sourced))
-	seen := make(map[string]struct{}, len(sourced))
-	anyResolved := false
-	for _, sv := range sourced {
-		target := channelTarget(sv.Versions, channel)
-		if target == "" {
-			continue
-		}
-		anyResolved = true
-		if target == current {
-			continue
-		}
-		if _, ok := seen[target]; ok {
-			continue
-		}
-		seen[target] = struct{}{}
-		candidates = append(candidates, UpgradeVersionCandidate{Version: target, Registry: sv.Registry})
-	}
+	candidates, anyResolved := collectUpgradeCandidates(sourced, channel, current)
 	item.Candidates = candidates
 
 	switch len(candidates) {
@@ -291,6 +282,34 @@ func resolveEnvUpgradeItem(tenant string, env EnvConfig, override string, resolv
 		traceln(fmt.Sprintf("upgrade: %s/%s has %d newer candidates; needs a pick (%s)", tenant, env.Name, len(candidates), candidateSummary(candidates)))
 	}
 	return item
+}
+
+// collectUpgradeCandidates reduces the per-registry sourced versions to the
+// distinct newer candidates for the channel: it skips registries with no target
+// for the channel, skips the current version, and dedupes by version (first
+// registry wins). anyResolved reports whether at least one registry produced a
+// channel target (even when that target equals current), so the caller can tell
+// "up to date" from "nothing resolved".
+func collectUpgradeCandidates(sourced []SourcedRuntimeVersions, channel, current string) ([]UpgradeVersionCandidate, bool) {
+	candidates := make([]UpgradeVersionCandidate, 0, len(sourced))
+	seen := make(map[string]struct{}, len(sourced))
+	anyResolved := false
+	for _, sv := range sourced {
+		target := channelTarget(sv.Versions, channel)
+		if target == "" {
+			continue
+		}
+		anyResolved = true
+		if target == current {
+			continue
+		}
+		if _, ok := seen[target]; ok {
+			continue
+		}
+		seen[target] = struct{}{}
+		candidates = append(candidates, UpgradeVersionCandidate{Version: target, Registry: sv.Registry})
+	}
+	return candidates, anyResolved
 }
 
 // candidateRegistrySuffix renders " (from <registry>)" when the candidate

--- a/erun-common/upgrade_resolver_test.go
+++ b/erun-common/upgrade_resolver_test.go
@@ -23,17 +23,12 @@ func TestUpgradeVersionsResolverForStore(t *testing.T) {
 			queries = append(queries, namespace+"/"+repository)
 			return RuntimeRegistryVersions{LatestStable: "1.0.85", LatestSnapshot: "1.0.86-snapshot-1"}, nil
 		})
-		sourced, err := resolver(Context{}, "petios", petiosEnv)
-		if err != nil {
-			t.Fatalf("resolver: %v", err)
-		}
+		sourced := resolveOrFatal(t, resolver, "petios", petiosEnv, "resolver: %v")
 		want := []string{"ghcr.io/petios/petios-devops", DefaultContainerRegistry + "/" + DefaultRuntimeImageName}
 		if strings.Join(queries, ",") != strings.Join(want, ",") {
 			t.Fatalf("unexpected queries: got %v want %v", queries, want)
 		}
-		if len(sourced) != 2 || sourced[0].Registry != "ghcr.io/petios" {
-			t.Fatalf("expected the provenance and canonical sources, got %+v", sourced)
-		}
+		assertProvenanceAndCanonicalSources(t, sourced)
 	})
 
 	t.Run("a tenant lookup failure still resolves via the canonical image (#501)", func(t *testing.T) {
@@ -46,13 +41,8 @@ func TestUpgradeVersionsResolverForStore(t *testing.T) {
 			}
 			return RuntimeRegistryVersions{}, errors.New("ghcr token request failed: 403 Forbidden")
 		})
-		sourced, err := resolver(Context{}, "petios", petiosEnv)
-		if err != nil {
-			t.Fatalf("a failed tenant listing must not block, got %v", err)
-		}
-		if len(sourced) != 1 || sourced[0].Versions.LatestStable != "1.0.85" {
-			t.Fatalf("expected the canonical source to carry through, got %+v", sourced)
-		}
+		sourced := resolveOrFatal(t, resolver, "petios", petiosEnv, "a failed tenant listing must not block, got %v")
+		assertCanonicalSourceCarriedThrough(t, sourced)
 	})
 
 	t.Run("all lookups failing is an error with the first failure (#497)", func(t *testing.T) {
@@ -71,9 +61,7 @@ func TestUpgradeVersionsResolverForStore(t *testing.T) {
 			namespaces = append(namespaces, namespace)
 			return RuntimeRegistryVersions{LatestStable: "1.0.85"}, nil
 		})
-		if _, err := resolver(Context{}, "fresh", EnvConfig{Name: "dev"}); err != nil {
-			t.Fatalf("resolver: %v", err)
-		}
+		resolveOrFatal(t, resolver, "fresh", EnvConfig{Name: "dev"}, "resolver: %v")
 		if len(namespaces) != 2 || namespaces[0] != DefaultContainerRegistry {
 			t.Fatalf("expected the default registry namespace, got %v", namespaces)
 		}
@@ -92,6 +80,35 @@ func TestUpgradeVersionsResolverForStore(t *testing.T) {
 	})
 }
 
+// assertProvenanceAndCanonicalSources pins that both the provenance registry
+// and the canonical image resolved, with provenance first.
+func assertProvenanceAndCanonicalSources(t *testing.T, sourced []SourcedRuntimeVersions) {
+	t.Helper()
+	if len(sourced) != 2 || sourced[0].Registry != "ghcr.io/petios" {
+		t.Fatalf("expected the provenance and canonical sources, got %+v", sourced)
+	}
+}
+
+// assertCanonicalSourceCarriedThrough pins that the canonical source alone
+// carried its stable version through after a tenant-listing failure.
+func assertCanonicalSourceCarriedThrough(t *testing.T, sourced []SourcedRuntimeVersions) {
+	t.Helper()
+	if len(sourced) != 1 || sourced[0].Versions.LatestStable != "1.0.85" {
+		t.Fatalf("expected the canonical source to carry through, got %+v", sourced)
+	}
+}
+
+// resolveOrFatal runs the sourced-versions resolver and fails with failMsg (a
+// %v format) on error, returning the resolved sources for further assertions.
+func resolveOrFatal(t *testing.T, resolver func(Context, string, EnvConfig) ([]SourcedRuntimeVersions, error), tenant string, env EnvConfig, failMsg string) []SourcedRuntimeVersions {
+	t.Helper()
+	sourced, err := resolver(Context{}, tenant, env)
+	if err != nil {
+		t.Fatalf(failMsg, err)
+	}
+	return sourced
+}
+
 // TestResolveEnvUpgradeItemCandidates pins the per-env candidate logic (issue
 // #527): registries agreeing on the newest version yield a single target,
 // disagreeing registries yield an ambiguous item the caller must pick, and a
@@ -108,9 +125,7 @@ func TestResolveEnvUpgradeItemCandidates(t *testing.T) {
 			}, nil
 		}
 		item := resolveEnvUpgradeItem("team", env, "", resolver, noTrace)
-		if !item.Lagging || item.Target != "2.0.0" || len(item.Candidates) != 1 {
-			t.Fatalf("expected a single 2.0.0 target, got %+v", item)
-		}
+		assertLaggingSingleTarget(t, item, "2.0.0", "expected a single 2.0.0 target, got %+v")
 	})
 
 	t.Run("registries disagreeing yield multiple candidates and no auto-target", func(t *testing.T) {
@@ -138,10 +153,17 @@ func TestResolveEnvUpgradeItemCandidates(t *testing.T) {
 
 	t.Run("an explicit override is the single target", func(t *testing.T) {
 		item := resolveEnvUpgradeItem("team", env, "3.0.0", nil, noTrace)
-		if !item.Lagging || item.Target != "3.0.0" || len(item.Candidates) != 1 {
-			t.Fatalf("expected the override target, got %+v", item)
-		}
+		assertLaggingSingleTarget(t, item, "3.0.0", "expected the override target, got %+v")
 	})
+}
+
+// assertLaggingSingleTarget pins an item that lags with exactly one candidate
+// pointing at wantTarget, reporting failMsg (a %+v format) with the item.
+func assertLaggingSingleTarget(t *testing.T, item UpgradePlanItem, wantTarget, failMsg string) {
+	t.Helper()
+	if !item.Lagging || item.Target != wantTarget || len(item.Candidates) != 1 {
+		t.Fatalf(failMsg, item)
+	}
 }
 
 // TestBuildUpgradePlanPerEnv pins the per-env enumeration: only opted-in envs
@@ -199,11 +221,14 @@ type upgradeResolverStore struct {
 	envsByTenant map[string][]EnvConfig
 }
 
-func (s upgradeResolverStore) LoadERunConfig() (ERunConfig, string, error) { return ERunConfig{}, "", nil }
-func (s upgradeResolverStore) SaveERunConfig(ERunConfig) error             { return nil }
+func (s upgradeResolverStore) LoadERunConfig() (ERunConfig, string, error) {
+	return ERunConfig{}, "", nil
+}
+func (s upgradeResolverStore) SaveERunConfig(ERunConfig) error { return nil }
 func (s upgradeResolverStore) LoadTenantConfig(name string) (TenantConfig, string, error) {
 	return TenantConfig{Name: name}, "", nil
 }
+
 func (s upgradeResolverStore) LoadEnvConfig(tenant, environment string) (EnvConfig, string, error) {
 	return EnvConfig{Name: environment}, "", nil
 }


### PR DESCRIPTION
Third module in the #571 repo-wide lint cleanup — the largest. Clears all 50 pre-existing `golangci-lint` findings in `erun-common` by correcting the code: no rule suppression, no `//nolint`, no threshold change. **Behavior-preserving**, verified end-to-end.

### Mechanical (7)
- `helm_chart_publish.go`: check the two deferred `os.Remove` returns (errcheck); reword the capitalized `Chart.yaml` error string (ST1005).
- `aws_sso_config.go`: check the deferred `file.Close` return (errcheck).
- gofumpt-format `cloud.go`, `cloud_context.go`, `cloud_context_recover.go`.

### Complexity (43 cyclop/gocyclo)
Each over-limit function had cohesive package-private helpers extracted so it drops under the limit while behaving identically. Highlights:
- `deploy.go`: `DeployHelmChart` (gocyclo 23) → chart-path / command / output / pod-watch / result-classification phases; `RunHelmDeploy` + the deploy-spec resolvers factored. **Every `==> Deploying / Deployed / Skipping / Deploy of <rel> failed` trace line is preserved verbatim** (the desktop activity queue and #531 depend on them).
- `doctor_remote_init.go`: `RunRemoteInitFinish` (gocyclo 36) → URL-resolution / missing-item-application / git-checkout / marker-save phases.
- `doctor_root_config.go`: `InspectRootConfig` (gocyclo 31) → alias-set / orphan-detection / sort phases.
- `deploy_singleflight.go`: `acquireHelmDeploySingleFlight` (gocyclo 21) → fresh-claim + existing-marker-reconciliation helpers.
- `cloud_context.go` / `cloud.go`: `StartCloudContext`, working-hours gate, AWS status refresh, `CloudProviderBearerToken` (state/ordering preserved).
- `build_incremental.go`, `build*.go`, `upgrade.go`, `registry_versions.go`, `ports.go`, `container_registry.go`, `release.go`, `idle_stop_pending.go`, `docker_build_scope.go`: parse/resolve/validate helpers.
- Six test functions: repeated assertion/setup blocks lifted into `t.Helper()`s (coverage unchanged).

## Validation
- `erun-common`: `golangci-lint run ./...` → **exit 0**; `go test ./...` → **green**.
- `make integration-test`: **green**, coverage **77.5%** (≥ 75%). The instrumented `erun` binary runs every CLI dry-run golden — none changed, proving the deploy/build/upgrade/init resolution and trace output are byte-identical.

29 files changed. Large diff, but every hunk is a pure extraction.

Part of #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)