### PR TITLE
Lint-green erun-ui: extract helpers, exclude playwright/node_modules

### DIFF
--- a/erun-ui/.golangci.yml
+++ b/erun-ui/.golangci.yml
@@ -7,6 +7,7 @@ linters:
   exclusions:
     paths:
       - ^frontend/node_modules/
+      - ^playwright/node_modules/
   enable:
     - errcheck
     - govet

--- a/erun-ui/action_runner.go
+++ b/erun-ui/action_runner.go
@@ -184,11 +184,7 @@ func (a *App) executeDesktopAction(action *desktopAction) {
 	// payloads via activityEntriesShallowEqual).
 	a.emitActivityState(promoted)
 	a.lockTerminalsForActivity(promoted)
-	if action.kind == "deploy" || action.kind == "force-deploy" {
-		if a.activityStatusPoller != nil {
-			a.activityStatusPoller(current)
-		}
-	}
+	a.startActivityStatusPollerForAction(action, current)
 	ctx, cancel := context.WithCancel(a.activityWatcherCtx())
 	a.registerCancel(action.id, cancel)
 	defer a.clearCancel(action.id)
@@ -196,20 +192,39 @@ func (a *App) executeDesktopAction(action *desktopAction) {
 
 	err := action.run(ctx)
 
-	status := activityQueueStatusSucceeded
-	errMsg := ""
-	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			status = activityQueueStatusCancelled
-			errMsg = "cancelled"
-		} else {
-			status = activityQueueStatusFailed
-			errMsg = err.Error()
-		}
-	}
+	status, errMsg := desktopActionTerminalStatus(err)
 	if final, finished := a.activityQueue.finish(action.id, status, errMsg); finished {
 		a.unlockTerminalsForActivity(final)
 	}
+}
+
+// startActivityStatusPollerForAction kicks off the container-status poller
+// for deploy/force-deploy actions when a poller is configured. Other action
+// kinds (and a nil poller) are a no-op. Extracted from executeDesktopAction
+// so it stays under the cyclomatic-complexity limit; behavior is unchanged.
+func (a *App) startActivityStatusPollerForAction(action *desktopAction, entry activityQueueEntry) {
+	if action.kind != "deploy" && action.kind != "force-deploy" {
+		return
+	}
+	if a.activityStatusPoller == nil {
+		return
+	}
+	a.activityStatusPoller(entry)
+}
+
+// desktopActionTerminalStatus maps an action's run error to the terminal
+// queue status and message. A nil error succeeds; a context.Canceled error
+// is reported as cancelled; anything else fails with the error text.
+// Extracted from executeDesktopAction so it stays under the
+// cyclomatic-complexity limit; the mapping is unchanged.
+func desktopActionTerminalStatus(err error) (activityQueueStatus, string) {
+	if err == nil {
+		return activityQueueStatusSucceeded, ""
+	}
+	if errors.Is(err, context.Canceled) {
+		return activityQueueStatusCancelled, "cancelled"
+	}
+	return activityQueueStatusFailed, err.Error()
 }
 
 // registerCancel and clearCancel track the active context.CancelFunc

--- a/erun-ui/activity_queue_app.go
+++ b/erun-ui/activity_queue_app.go
@@ -30,11 +30,6 @@ const (
 	activityQueuePollInterval = 2 * time.Second
 )
 
-// activityStateEvent is the payload shape pushed to the frontend on each
-// transition. Wails serializes the embedded entry directly; the type alias
-// keeps the contract documented and stable.
-type activityStateEvent = activityQueueEntry
-
 // activityLockEvent describes a terminal lock transition driven by the deploy
 // queue. The frontend keys overlays by SessionID.
 type activityLockEvent struct {
@@ -398,75 +393,102 @@ func newActivityTraceLineHandler(app *App, selection uiSelection, kind sessionKi
 	_ = kind
 	return func(line string) {
 		line = strings.TrimSpace(line)
-		if match := activityDeployingLineRe.FindStringSubmatch(line); match != nil {
-			app.startDeployFromTrace(selection, match[1], match[2], match[3], match[4])
-			return
-		}
-		if match := activityDeployedLineRe.FindStringSubmatch(line); match != nil {
-			app.finishDeployByTenantEnv(selection, match[1], match[2], activityQueueStatusSucceeded, "")
-			return
-		}
-		if match := activitySkippingLineRe.FindStringSubmatch(line); match != nil {
-			app.finishDeployByTenantEnv(selection, match[1], match[2], activityQueueStatusSkipped, line)
-			return
-		}
-		if match := activityInitializingLineRe.FindStringSubmatch(line); match != nil {
-			app.startInitFromTrace(selection, match[1], match[2])
-			return
-		}
-		if match := activityInitializedLineRe.FindStringSubmatch(line); match != nil {
-			app.finishInitByTenantEnv(match[1], match[2], activityQueueStatusSucceeded, "")
-			app.emitEnvironmentInitialized(match[1], match[2])
-			return
-		}
-		if match := activityInitFailedLineRe.FindStringSubmatch(line); match != nil {
-			app.finishInitByTenantEnv(match[1], match[2], activityQueueStatusFailed, line)
-			app.emitEnvironmentInitFailed(match[1], match[2])
-			return
-		}
-		if activityBuildingLineRe.MatchString(line) {
-			app.startCommandFromTrace(selection, "build")
-			return
-		}
-		if activityBuiltLineRe.MatchString(line) {
-			app.finishCommandBySelection(selection, "build", activityQueueStatusSucceeded, "")
-			return
-		}
-		if activityBuildFailedLineRe.MatchString(line) {
-			app.finishCommandBySelection(selection, "build", activityQueueStatusFailed, line)
-			return
-		}
-		if activityReleasingLineRe.MatchString(line) {
-			app.startCommandFromTrace(selection, "release")
-			return
-		}
-		if activityReleasedLineRe.MatchString(line) {
-			app.finishCommandBySelection(selection, "release", activityQueueStatusSucceeded, "")
-			return
-		}
-		if activityReleaseFailedLineRe.MatchString(line) {
-			app.finishCommandBySelection(selection, "release", activityQueueStatusFailed, line)
-			return
-		}
-		if activityPushingLineRe.MatchString(line) {
-			app.startCommandFromTrace(selection, "push")
-			return
-		}
-		if activityPushedLineRe.MatchString(line) {
-			app.finishCommandBySelection(selection, "push", activityQueueStatusSucceeded, "")
-			return
-		}
-		if activityPushFailedLineRe.MatchString(line) {
-			app.finishCommandBySelection(selection, "push", activityQueueStatusFailed, line)
-			return
-		}
 		switch {
+		case app.handleDeployTraceLine(selection, line):
+		case app.handleInitTraceLine(selection, line):
+		case app.handleCommandTraceLine(selection, line):
 		case failedRe.MatchString(line):
 			app.finishActivityTracking(selection, activityQueueStatusFailed, line)
 		case errorRe.MatchString(line):
 			app.captureActivityErrorIfRunning(selection, line)
 		}
 	}
+}
+
+// handleDeployTraceLine dispatches the deploy lifecycle trace lines
+// (`==> Deploying` / `==> Deployed` / `==> Skipping`). Returns true when
+// the line matched one of them so the caller stops dispatching. The match
+// order is part of the trace-line contract and is preserved verbatim.
+func (a *App) handleDeployTraceLine(selection uiSelection, line string) bool {
+	if match := activityDeployingLineRe.FindStringSubmatch(line); match != nil {
+		a.startDeployFromTrace(selection, match[1], match[2], match[3], match[4])
+		return true
+	}
+	if match := activityDeployedLineRe.FindStringSubmatch(line); match != nil {
+		a.finishDeployByTenantEnv(selection, match[1], match[2], activityQueueStatusSucceeded, "")
+		return true
+	}
+	if match := activitySkippingLineRe.FindStringSubmatch(line); match != nil {
+		a.finishDeployByTenantEnv(selection, match[1], match[2], activityQueueStatusSkipped, line)
+		return true
+	}
+	return false
+}
+
+// handleInitTraceLine dispatches the init lifecycle trace lines
+// (`==> Initializing` / `==> Initialized` / `==> Initialization failed`).
+// Returns true when the line matched. The terminal lines also fire the
+// init Wails events the frontend listens for.
+func (a *App) handleInitTraceLine(selection uiSelection, line string) bool {
+	if match := activityInitializingLineRe.FindStringSubmatch(line); match != nil {
+		a.startInitFromTrace(selection, match[1], match[2])
+		return true
+	}
+	if match := activityInitializedLineRe.FindStringSubmatch(line); match != nil {
+		a.finishInitByTenantEnv(match[1], match[2], activityQueueStatusSucceeded, "")
+		a.emitEnvironmentInitialized(match[1], match[2])
+		return true
+	}
+	if match := activityInitFailedLineRe.FindStringSubmatch(line); match != nil {
+		a.finishInitByTenantEnv(match[1], match[2], activityQueueStatusFailed, line)
+		a.emitEnvironmentInitFailed(match[1], match[2])
+		return true
+	}
+	return false
+}
+
+// handleCommandTraceLine dispatches the build/release/push umbrella trace
+// lines. These carry no tenant/env, so the activity is keyed off the
+// session selection. Returns true when the line matched. The match order
+// is part of the trace-line contract and is preserved verbatim.
+func (a *App) handleCommandTraceLine(selection uiSelection, line string) bool {
+	if activityBuildingLineRe.MatchString(line) {
+		a.startCommandFromTrace(selection, "build")
+		return true
+	}
+	if activityBuiltLineRe.MatchString(line) {
+		a.finishCommandBySelection(selection, "build", activityQueueStatusSucceeded, "")
+		return true
+	}
+	if activityBuildFailedLineRe.MatchString(line) {
+		a.finishCommandBySelection(selection, "build", activityQueueStatusFailed, line)
+		return true
+	}
+	if activityReleasingLineRe.MatchString(line) {
+		a.startCommandFromTrace(selection, "release")
+		return true
+	}
+	if activityReleasedLineRe.MatchString(line) {
+		a.finishCommandBySelection(selection, "release", activityQueueStatusSucceeded, "")
+		return true
+	}
+	if activityReleaseFailedLineRe.MatchString(line) {
+		a.finishCommandBySelection(selection, "release", activityQueueStatusFailed, line)
+		return true
+	}
+	if activityPushingLineRe.MatchString(line) {
+		a.startCommandFromTrace(selection, "push")
+		return true
+	}
+	if activityPushedLineRe.MatchString(line) {
+		a.finishCommandBySelection(selection, "push", activityQueueStatusSucceeded, "")
+		return true
+	}
+	if activityPushFailedLineRe.MatchString(line) {
+		a.finishCommandBySelection(selection, "push", activityQueueStatusFailed, line)
+		return true
+	}
+	return false
 }
 
 // finishDeployByTenantEnv finalizes the active deploy entry for the
@@ -789,39 +811,49 @@ func (a *App) fetchActivityContainerStatuses(ctx context.Context, entry activity
 	return parseActivityContainerStatuses(out)
 }
 
+// kubectlPodList is the subset of `kubectl get pods -o json` the activity
+// container-status poller decodes. Named (rather than an anonymous struct
+// literal) so the per-container conversion can be split into a focused
+// helper without restating the anonymous type at each boundary.
+type kubectlPodList struct {
+	Items []kubectlPodItem `json:"items"`
+}
+
+type kubectlPodItem struct {
+	Spec struct {
+		Containers []struct {
+			Name  string `json:"name"`
+			Image string `json:"image"`
+		} `json:"containers"`
+	} `json:"spec"`
+	Status struct {
+		ContainerStatuses []kubectlContainerStatus `json:"containerStatuses"`
+	} `json:"status"`
+}
+
+type kubectlContainerStatus struct {
+	Name         string `json:"name"`
+	Image        string `json:"image"`
+	Ready        bool   `json:"ready"`
+	RestartCount int    `json:"restartCount"`
+	State        struct {
+		Waiting *struct {
+			Reason  string `json:"reason"`
+			Message string `json:"message"`
+		} `json:"waiting,omitempty"`
+		Running *struct {
+			StartedAt string `json:"startedAt"`
+		} `json:"running,omitempty"`
+		Terminated *struct {
+			Reason   string `json:"reason"`
+			Message  string `json:"message"`
+			ExitCode int    `json:"exitCode"`
+		} `json:"terminated,omitempty"`
+	} `json:"state"`
+}
+
 func parseActivityContainerStatuses(raw []byte) ([]activityQueueContainerStatus, error) {
-	var parsed struct {
-		Items []struct {
-			Spec struct {
-				Containers []struct {
-					Name  string `json:"name"`
-					Image string `json:"image"`
-				} `json:"containers"`
-			} `json:"spec"`
-			Status struct {
-				ContainerStatuses []struct {
-					Name         string `json:"name"`
-					Image        string `json:"image"`
-					Ready        bool   `json:"ready"`
-					RestartCount int    `json:"restartCount"`
-					State        struct {
-						Waiting *struct {
-							Reason  string `json:"reason"`
-							Message string `json:"message"`
-						} `json:"waiting,omitempty"`
-						Running *struct {
-							StartedAt string `json:"startedAt"`
-						} `json:"running,omitempty"`
-						Terminated *struct {
-							Reason   string `json:"reason"`
-							Message  string `json:"message"`
-							ExitCode int    `json:"exitCode"`
-						} `json:"terminated,omitempty"`
-					} `json:"state"`
-				} `json:"containerStatuses"`
-			} `json:"status"`
-		} `json:"items"`
-	}
+	var parsed kubectlPodList
 	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return nil, err
 	}
@@ -835,42 +867,50 @@ func parseActivityContainerStatuses(raw []byte) ([]activityQueueContainerStatus,
 			imageByName[c.Name] = c.Image
 		}
 		for _, cs := range item.Status.ContainerStatuses {
-			key := cs.Name
-			if seen[key] {
+			if seen[cs.Name] {
 				continue
 			}
-			seen[key] = true
-			image := strings.TrimSpace(cs.Image)
-			if image == "" {
-				image = imageByName[cs.Name]
-			}
-			status := activityQueueContainerStatus{
-				Name:     cs.Name,
-				Image:    image,
-				Ready:    cs.Ready,
-				Restarts: cs.RestartCount,
-			}
-			switch {
-			case cs.State.Running != nil:
-				status.Phase = "Running"
-			case cs.State.Waiting != nil:
-				status.Phase = "Waiting"
-				status.Reason = cs.State.Waiting.Reason
-				status.Message = cs.State.Waiting.Message
-			case cs.State.Terminated != nil:
-				status.Phase = "Terminated"
-				status.Reason = cs.State.Terminated.Reason
-				status.Message = fmt.Sprintf("exited with code %d", cs.State.Terminated.ExitCode)
-				if msg := strings.TrimSpace(cs.State.Terminated.Message); msg != "" {
-					status.Message += ": " + msg
-				}
-			default:
-				status.Phase = "Pending"
-			}
-			out = append(out, status)
+			seen[cs.Name] = true
+			out = append(out, convertActivityContainerStatus(cs, imageByName))
 		}
 	}
 	return out, nil
+}
+
+// convertActivityContainerStatus maps one decoded container status into the
+// queue's display shape, resolving the image from the spec fallback and
+// classifying the phase. Extracted from parseActivityContainerStatuses so
+// the parse loop stays under the cyclomatic-complexity limit; behavior is
+// identical to the inline body it replaced.
+func convertActivityContainerStatus(cs kubectlContainerStatus, imageByName map[string]string) activityQueueContainerStatus {
+	image := strings.TrimSpace(cs.Image)
+	if image == "" {
+		image = imageByName[cs.Name]
+	}
+	status := activityQueueContainerStatus{
+		Name:     cs.Name,
+		Image:    image,
+		Ready:    cs.Ready,
+		Restarts: cs.RestartCount,
+	}
+	switch {
+	case cs.State.Running != nil:
+		status.Phase = "Running"
+	case cs.State.Waiting != nil:
+		status.Phase = "Waiting"
+		status.Reason = cs.State.Waiting.Reason
+		status.Message = cs.State.Waiting.Message
+	case cs.State.Terminated != nil:
+		status.Phase = "Terminated"
+		status.Reason = cs.State.Terminated.Reason
+		status.Message = fmt.Sprintf("exited with code %d", cs.State.Terminated.ExitCode)
+		if msg := strings.TrimSpace(cs.State.Terminated.Message); msg != "" {
+			status.Message += ": " + msg
+		}
+	default:
+		status.Phase = "Pending"
+	}
+	return status
 }
 
 // activityTargetForRuntime returns the human-readable "tenant/env [version]"
@@ -905,6 +945,37 @@ func (a *App) feedActivityTraceFromTerminal(managed *managedTerminal, chunk []by
 	}
 	a.mu.Lock()
 	managed.activityTraceBuffer += stripActivityTraceANSI(string(chunk))
+	lines := drainActivityTraceLines(managed)
+	a.mu.Unlock()
+	if len(lines) == 0 {
+		return
+	}
+	handler := newActivityTraceLineHandler(a, managed.selection, managed.kind)
+	for _, line := range lines {
+		// Buffer the line for the active entry before dispatching it, so the
+		// "==> Deploy failed" line that finalizes the entry (and the error
+		// output preceding it) is already captured when finish() snapshots
+		// the buffer into entry.Detail.
+		a.activityQueue.recordOutputLine(managed.selection.Tenant, managed.selection.Environment, line)
+		handler(line)
+		signalSessionReadyOnLine(managed, line)
+		// The CLI's taken-over notice is a public contract line (see
+		// eruncommon.ShellSessionTakenOverNotice): another ERun window
+		// re-attached this persistent session, so the upcoming PTY exit
+		// must not trigger a reconnect that would steal it back.
+		if strings.TrimSpace(line) == eruncommon.ShellSessionTakenOverNotice {
+			a.markSessionTakenOver(managed)
+		}
+	}
+}
+
+// drainActivityTraceLines consumes every complete `\n`-terminated line from
+// the managed terminal's activity trace buffer, returning the cleaned lines
+// and leaving any trailing partial line buffered for the next chunk. The
+// caller must hold a.mu. Extracted from feedActivityTraceFromTerminal so the
+// feed stays under the cyclomatic-complexity limit; the line cleaning is
+// identical to the inline loop it replaced.
+func drainActivityTraceLines(managed *managedTerminal) []string {
 	lines := []string{}
 	for {
 		idx := strings.IndexByte(managed.activityTraceBuffer, '\n')
@@ -929,27 +1000,7 @@ func (a *App) feedActivityTraceFromTerminal(managed *managedTerminal, chunk []by
 		lines = append(lines, line)
 		managed.activityTraceBuffer = managed.activityTraceBuffer[idx+1:]
 	}
-	a.mu.Unlock()
-	if len(lines) == 0 {
-		return
-	}
-	handler := newActivityTraceLineHandler(a, managed.selection, managed.kind)
-	for _, line := range lines {
-		// Buffer the line for the active entry before dispatching it, so the
-		// "==> Deploy failed" line that finalizes the entry (and the error
-		// output preceding it) is already captured when finish() snapshots
-		// the buffer into entry.Detail.
-		a.activityQueue.recordOutputLine(managed.selection.Tenant, managed.selection.Environment, line)
-		handler(line)
-		signalSessionReadyOnLine(managed, line)
-		// The CLI's taken-over notice is a public contract line (see
-		// eruncommon.ShellSessionTakenOverNotice): another ERun window
-		// re-attached this persistent session, so the upcoming PTY exit
-		// must not trigger a reconnect that would steal it back.
-		if strings.TrimSpace(line) == eruncommon.ShellSessionTakenOverNotice {
-			a.markSessionTakenOver(managed)
-		}
-	}
+	return lines
 }
 
 // sessionReady*Re match lines that indicate the session's setup phase

--- a/erun-ui/activity_recovery.go
+++ b/erun-ui/activity_recovery.go
@@ -25,47 +25,20 @@ type activityRecoveryResult struct {
 // proceed. The entry is force-dismissed after the recovery so the
 // drawer reflects the cluster state again. Wails-exported.
 func (a *App) RecoverPendingHelmRelease(id string) activityRecoveryResult {
-	if a.activityQueue == nil {
-		return activityRecoveryResult{OK: false, Error: "activity queue is not initialized"}
-	}
-	id = strings.TrimSpace(id)
-	if id == "" {
-		return activityRecoveryResult{OK: false, Error: "activity id is required"}
-	}
-	var entry activityQueueEntry
-	for _, candidate := range a.activityQueue.list() {
-		if candidate.ID == id {
-			entry = candidate
-			break
-		}
-	}
-	if entry.ID == "" {
-		return activityRecoveryResult{OK: false, Error: "activity not found"}
-	}
-	if entry.Source != "helm" {
-		return activityRecoveryResult{OK: false, Error: "recovery only applies to helm-source entries"}
-	}
-	release := strings.TrimSpace(entry.Release)
-	namespace := strings.TrimSpace(entry.Namespace)
-	if release == "" || namespace == "" {
-		return activityRecoveryResult{OK: false, Error: "activity is missing release/namespace; nothing to recover"}
+	entry, errResult := a.resolveRecoverableHelmEntry(id)
+	if errResult != nil {
+		return *errResult
 	}
 	var stdout, stderr bytes.Buffer
 	err := eruncommon.ClearHelmReleasePendingOperation(eruncommon.HelmReleaseRecoveryParams{
-		ReleaseName:       release,
-		Namespace:         namespace,
+		ReleaseName:       strings.TrimSpace(entry.Release),
+		Namespace:         strings.TrimSpace(entry.Namespace),
 		KubernetesContext: strings.TrimSpace(entry.KubernetesContext),
 		Verbosity:         eruncommon.VerbosityDebug,
 		Stdout:            &stdout,
 		Stderr:            &stderr,
 	})
-	combined := strings.TrimSpace(stdout.String())
-	if errOut := strings.TrimSpace(stderr.String()); errOut != "" {
-		if combined != "" {
-			combined += "\n"
-		}
-		combined += errOut
-	}
+	combined := combineRecoveryOutput(stdout.String(), stderr.String())
 	if err != nil {
 		return activityRecoveryResult{
 			OK:     false,
@@ -78,4 +51,51 @@ func (a *App) RecoverPendingHelmRelease(id string) activityRecoveryResult {
 		a.emitActivityState(final)
 	}
 	return activityRecoveryResult{OK: true, Output: combined}
+}
+
+// resolveRecoverableHelmEntry validates the recovery preconditions and
+// returns the matching helm-source entry. On any precondition failure it
+// returns a non-nil error result the caller should hand back verbatim, so
+// RecoverPendingHelmRelease stays under the cyclomatic-complexity limit
+// without changing any of the error messages.
+func (a *App) resolveRecoverableHelmEntry(id string) (activityQueueEntry, *activityRecoveryResult) {
+	if a.activityQueue == nil {
+		return activityQueueEntry{}, &activityRecoveryResult{OK: false, Error: "activity queue is not initialized"}
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return activityQueueEntry{}, &activityRecoveryResult{OK: false, Error: "activity id is required"}
+	}
+	var entry activityQueueEntry
+	for _, candidate := range a.activityQueue.list() {
+		if candidate.ID == id {
+			entry = candidate
+			break
+		}
+	}
+	if entry.ID == "" {
+		return activityQueueEntry{}, &activityRecoveryResult{OK: false, Error: "activity not found"}
+	}
+	if entry.Source != "helm" {
+		return activityQueueEntry{}, &activityRecoveryResult{OK: false, Error: "recovery only applies to helm-source entries"}
+	}
+	if strings.TrimSpace(entry.Release) == "" || strings.TrimSpace(entry.Namespace) == "" {
+		return activityQueueEntry{}, &activityRecoveryResult{OK: false, Error: "activity is missing release/namespace; nothing to recover"}
+	}
+	return entry, nil
+}
+
+// combineRecoveryOutput concatenates the helm recovery command's stdout and
+// stderr into the single Output blob the frontend renders, joining them with
+// a newline only when both are non-empty. Behavior matches the inline
+// combination it replaced.
+func combineRecoveryOutput(stdout, stderr string) string {
+	combined := strings.TrimSpace(stdout)
+	if errOut := strings.TrimSpace(stderr); errOut != "" {
+		if combined != "" {
+			combined += "\n"
+		}
+		combined += errOut
+	}
+	return combined
 }

--- a/erun-ui/ai_activity_test.go
+++ b/erun-ui/ai_activity_test.go
@@ -57,46 +57,63 @@ func TestRecordAIActivityDebounce(t *testing.T) {
 			managed.aiActiveSince = time.Now().Add(-(aiActivitySustainedThreshold + time.Second))
 			app.mu.Unlock()
 			app.recordAIActivity(managed)
-			busyEvents := emits.events(aiActivityEvent)
-			if tc.wantEmits {
-				if len(busyEvents) != 1 {
-					t.Fatalf("expected one busy=true emit, got %+v", busyEvents)
-				}
-				payload, ok := busyEvents[0].(aiActivityPayload)
-				if !ok {
-					t.Fatalf("unexpected payload type: %T", busyEvents[0])
-				}
-				if !payload.Busy {
-					t.Fatalf("expected busy=true, got %+v", payload)
-				}
-				if payload.Tenant != "t" || payload.Environment != "e" {
-					t.Fatalf("expected selection echoed in payload, got %+v", payload)
-				}
-			} else {
-				if len(busyEvents) != 0 {
-					t.Fatalf("expected no emit for kind %s, got %+v", tc.kind, busyEvents)
-				}
-			}
+			assertBusyEmit(t, emits.events(aiActivityEvent), tc.kind, tc.wantEmits)
 
 			// finalizeAIActivity must release a latched busy=true. For
 			// non-AI kinds it must remain a no-op (no emits at all).
 			app.finalizeAIActivity(managed)
-			allEvents := emits.events(aiActivityEvent)
-			if tc.wantEmits {
-				if len(allEvents) != 2 {
-					t.Fatalf("expected busy=true then busy=false, got %+v", allEvents)
-				}
-				payload, ok := allEvents[1].(aiActivityPayload)
-				if !ok {
-					t.Fatalf("unexpected payload type: %T", allEvents[1])
-				}
-				if payload.Busy {
-					t.Fatalf("expected busy=false from finalize, got %+v", payload)
-				}
-			} else if len(allEvents) != 0 {
-				t.Fatalf("expected no emits for kind %s, got %+v", tc.kind, allEvents)
-			}
+			assertFinalizeEmit(t, emits.events(aiActivityEvent), tc.kind, tc.wantEmits)
 		})
+	}
+}
+
+// assertBusyEmit checks the emit set after sustained output: an AI session
+// must have produced exactly one busy=true payload echoing the selection,
+// while a silent kind must have produced nothing.
+func assertBusyEmit(t *testing.T, busyEvents []any, kind sessionKind, wantEmits bool) {
+	t.Helper()
+
+	if !wantEmits {
+		if len(busyEvents) != 0 {
+			t.Fatalf("expected no emit for kind %s, got %+v", kind, busyEvents)
+		}
+		return
+	}
+	if len(busyEvents) != 1 {
+		t.Fatalf("expected one busy=true emit, got %+v", busyEvents)
+	}
+	payload, ok := busyEvents[0].(aiActivityPayload)
+	if !ok {
+		t.Fatalf("unexpected payload type: %T", busyEvents[0])
+	}
+	if !payload.Busy {
+		t.Fatalf("expected busy=true, got %+v", payload)
+	}
+	if payload.Tenant != "t" || payload.Environment != "e" {
+		t.Fatalf("expected selection echoed in payload, got %+v", payload)
+	}
+}
+
+// assertFinalizeEmit checks the emit set after finalize: an AI session must
+// now show a trailing busy=false release, while a silent kind stays empty.
+func assertFinalizeEmit(t *testing.T, allEvents []any, kind sessionKind, wantEmits bool) {
+	t.Helper()
+
+	if !wantEmits {
+		if len(allEvents) != 0 {
+			t.Fatalf("expected no emits for kind %s, got %+v", kind, allEvents)
+		}
+		return
+	}
+	if len(allEvents) != 2 {
+		t.Fatalf("expected busy=true then busy=false, got %+v", allEvents)
+	}
+	payload, ok := allEvents[1].(aiActivityPayload)
+	if !ok {
+		t.Fatalf("unexpected payload type: %T", allEvents[1])
+	}
+	if payload.Busy {
+		t.Fatalf("expected busy=false from finalize, got %+v", payload)
 	}
 }
 
@@ -141,9 +158,7 @@ func (c *capturedEmits) fn() func(string, ...any) {
 	return func(name string, args ...any) {
 		c.mu.Lock()
 		defer c.mu.Unlock()
-		for _, arg := range args {
-			c.byName[name] = append(c.byName[name], arg)
-		}
+		c.byName[name] = append(c.byName[name], args...)
 		if len(args) == 0 {
 			c.byName[name] = append(c.byName[name], nil)
 		}

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -235,6 +235,16 @@ func withDefaultRuntimeDeps(deps erunUIDeps) erunUIDeps {
 }
 
 func withDefaultUIDeps(deps erunUIDeps) erunUIDeps {
+	deps = withDefaultWorkspaceDeps(deps)
+	deps = withDefaultPodDeps(deps)
+	deps = withDefaultWindowAndContributeDeps(deps)
+	return deps
+}
+
+// withDefaultWorkspaceDeps wires the read-model and workspace-sync defaults:
+// pasted-image save, diff/idle/API-log loaders, and the workspace sync
+// readiness check, runner, and interval.
+func withDefaultWorkspaceDeps(deps erunUIDeps) erunUIDeps {
 	if deps.savePastedImage == nil {
 		deps.savePastedImage = savePastedImageToRuntime
 	}
@@ -256,6 +266,13 @@ func withDefaultUIDeps(deps erunUIDeps) erunUIDeps {
 	if deps.workspaceSyncInterval <= 0 {
 		deps.workspaceSyncInterval = defaultWorkspaceSyncInterval
 	}
+	return deps
+}
+
+// withDefaultPodDeps wires the pod-facing defaults: working-issue command
+// runner, pod branch and raw-command loaders, activity recording, and the
+// cloud-context stop adapter.
+func withDefaultPodDeps(deps erunUIDeps) erunUIDeps {
 	if deps.runWorkingIssueCommand == nil {
 		deps.runWorkingIssueCommand = execWorkingIssueCommand
 	}
@@ -273,6 +290,13 @@ func withDefaultUIDeps(deps erunUIDeps) erunUIDeps {
 			return eruncommon.StopCloudContext(eruncommon.Context{}, deps.store, eruncommon.CloudContextParams{Name: name}, deps.cloudContextDeps)
 		}
 	}
+	return deps
+}
+
+// withDefaultWindowAndContributeDeps wires the window-state and contribute
+// defaults: window state path, maximised probe, ERun clone runner, and
+// contribute state path.
+func withDefaultWindowAndContributeDeps(deps erunUIDeps) erunUIDeps {
 	if deps.windowStatePath == "" {
 		deps.windowStatePath = defaultAppWindowStatePath()
 	}

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -48,20 +48,26 @@ func TestStateFromListResultUsesEffectiveSelection(t *testing.T) {
 	if len(state.Tenants) != 1 || len(state.Tenants[0].Environments) != 2 {
 		t.Fatalf("unexpected tenants: %+v", state.Tenants)
 	}
-	if state.Tenants[0].Environments[0].MCPURL != "http://127.0.0.1:17000/mcp" {
-		t.Fatalf("unexpected MCP URL: %+v", state.Tenants[0].Environments[0])
+	assertEffectiveSelectionEnvironments(t, state.Tenants[0].Environments)
+}
+
+func assertEffectiveSelectionEnvironments(t *testing.T, envs []uiEnvironment) {
+	t.Helper()
+
+	if envs[0].MCPURL != "http://127.0.0.1:17000/mcp" {
+		t.Fatalf("unexpected MCP URL: %+v", envs[0])
 	}
-	if state.Tenants[0].Environments[0].APIURL != "http://127.0.0.1:17033" {
-		t.Fatalf("unexpected API URL: %+v", state.Tenants[0].Environments[0])
+	if envs[0].APIURL != "http://127.0.0.1:17033" {
+		t.Fatalf("unexpected API URL: %+v", envs[0])
 	}
-	if state.Tenants[0].Environments[0].RuntimeVersion != "1.0.19-snapshot-20260418141901" {
-		t.Fatalf("unexpected runtime version: %+v", state.Tenants[0].Environments[0])
+	if envs[0].RuntimeVersion != "1.0.19-snapshot-20260418141901" {
+		t.Fatalf("unexpected runtime version: %+v", envs[0])
 	}
-	if !state.Tenants[0].Environments[0].SSHDEnabled || state.Tenants[0].Environments[1].SSHDEnabled {
-		t.Fatalf("unexpected SSHD flags: %+v", state.Tenants[0].Environments)
+	if !envs[0].SSHDEnabled || envs[1].SSHDEnabled {
+		t.Fatalf("unexpected SSHD flags: %+v", envs)
 	}
-	if state.Tenants[0].Environments[0].Type == string(eruncommon.EnvironmentTypeRemoteAgent) || state.Tenants[0].Environments[1].Type != string(eruncommon.EnvironmentTypeRemoteAgent) {
-		t.Fatalf("unexpected env types: %+v", state.Tenants[0].Environments)
+	if envs[0].Type == string(eruncommon.EnvironmentTypeRemoteAgent) || envs[1].Type != string(eruncommon.EnvironmentTypeRemoteAgent) {
+		t.Fatalf("unexpected env types: %+v", envs)
 	}
 }
 
@@ -1357,12 +1363,7 @@ func TestLoadAndSaveTenantConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadTenantConfig failed: %v", err)
 	}
-	if loaded.Name != "frs" || loaded.DefaultEnvironment != "dev" || loaded.APIURL != "https://api.old.example" || loaded.PrimaryCloudProviderAlias != "team-cloud" || len(loaded.CloudProviderAliases) != 1 || loaded.CloudProviderAliases[0] != "team-cloud" {
-		t.Fatalf("unexpected loaded config: %+v", loaded)
-	}
-	if len(loaded.CloudProviders) != 1 || loaded.CloudProviders[0].OIDCIssuerURL != "https://issuer.team.example" {
-		t.Fatalf("expected cloud provider statuses with issuer URL, got %+v", loaded.CloudProviders)
-	}
+	assertLoadedTenantConfig(t, loaded)
 
 	saved, err := app.SaveTenantConfig(uiTenantConfig{
 		Name:                      "frs",
@@ -1379,6 +1380,17 @@ func TestLoadAndSaveTenantConfig(t *testing.T) {
 	}
 	if store.tenants["frs"].APIURL != "https://api.new.example" || store.tenants["frs"].PrimaryCloudProviderAlias != "team-cloud" {
 		t.Fatalf("expected tenant project root to be preserved, got %+v", store.tenants["frs"])
+	}
+}
+
+func assertLoadedTenantConfig(t *testing.T, loaded uiTenantConfig) {
+	t.Helper()
+
+	if loaded.Name != "frs" || loaded.DefaultEnvironment != "dev" || loaded.APIURL != "https://api.old.example" || loaded.PrimaryCloudProviderAlias != "team-cloud" || len(loaded.CloudProviderAliases) != 1 || loaded.CloudProviderAliases[0] != "team-cloud" {
+		t.Fatalf("unexpected loaded config: %+v", loaded)
+	}
+	if len(loaded.CloudProviders) != 1 || loaded.CloudProviders[0].OIDCIssuerURL != "https://issuer.team.example" {
+		t.Fatalf("expected cloud provider statuses with issuer URL, got %+v", loaded.CloudProviders)
 	}
 }
 
@@ -1452,28 +1464,7 @@ func TestGetCloudProviderBearerTokenReturnsTokenAndStatus(t *testing.T) {
 func TestLoadTenantDashboardUsesPrimaryCloudBearer(t *testing.T) {
 	jwt := testUIJWT("https://sts.aws.example")
 	var requests []string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.Header.Get("Authorization") != "Bearer "+jwt {
-			t.Fatalf("unexpected authorization header: %q", req.Header.Get("Authorization"))
-		}
-		if req.Header.Get("X-ERun-Username") != "Rihards.Freimanis" {
-			t.Fatalf("unexpected username hint: %q", req.Header.Get("X-ERun-Username"))
-		}
-		requests = append(requests, req.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		switch req.URL.Path {
-		case "/v1/whoami":
-			_, _ = w.Write([]byte(`{"tenantId":"tenant-1","userId":"user-1","username":"Rihards.Freimanis","roles":["ReadAll","WriteAll"],"issuer":"https://sts.aws.example","subject":"subject-1"}`))
-		case "/v1/reviews":
-			_, _ = w.Write([]byte(`[{"reviewId":"review-1","tenantId":"tenant-1","name":"Review 1","targetBranch":"main","sourceBranch":"feature","status":"READY"}]`))
-		case "/v1/reviews/merge-queue":
-			_, _ = w.Write([]byte(`[{"reviewId":"review-1","tenantId":"tenant-1","name":"Review 1","targetBranch":"main","sourceBranch":"feature","status":"READY"}]`))
-		case "/v1/reviews/review-1/builds":
-			_, _ = w.Write([]byte(`[{"buildId":"build-1","tenantId":"tenant-1","reviewId":"review-1","successful":true,"commitId":"abc","version":"1.2.3"}]`))
-		default:
-			http.NotFound(w, req)
-		}
-	}))
+	server := httptest.NewServer(tenantDashboardHandler(t, jwt, &requests))
 	defer server.Close()
 
 	rootConfig := eruncommon.ERunConfig{CloudProviders: []eruncommon.CloudProviderConfig{{
@@ -1505,6 +1496,39 @@ func TestLoadTenantDashboardUsesPrimaryCloudBearer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadTenantDashboard failed: %v", err)
 	}
+	assertPrimaryCloudDashboard(t, dashboard, requests)
+}
+
+func tenantDashboardHandler(t *testing.T, jwt string, requests *[]string) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("Authorization") != "Bearer "+jwt {
+			t.Fatalf("unexpected authorization header: %q", req.Header.Get("Authorization"))
+		}
+		if req.Header.Get("X-ERun-Username") != "Rihards.Freimanis" {
+			t.Fatalf("unexpected username hint: %q", req.Header.Get("X-ERun-Username"))
+		}
+		*requests = append(*requests, req.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch req.URL.Path {
+		case "/v1/whoami":
+			_, _ = w.Write([]byte(`{"tenantId":"tenant-1","userId":"user-1","username":"Rihards.Freimanis","roles":["ReadAll","WriteAll"],"issuer":"https://sts.aws.example","subject":"subject-1"}`))
+		case "/v1/reviews":
+			_, _ = w.Write([]byte(`[{"reviewId":"review-1","tenantId":"tenant-1","name":"Review 1","targetBranch":"main","sourceBranch":"feature","status":"READY"}]`))
+		case "/v1/reviews/merge-queue":
+			_, _ = w.Write([]byte(`[{"reviewId":"review-1","tenantId":"tenant-1","name":"Review 1","targetBranch":"main","sourceBranch":"feature","status":"READY"}]`))
+		case "/v1/reviews/review-1/builds":
+			_, _ = w.Write([]byte(`[{"buildId":"build-1","tenantId":"tenant-1","reviewId":"review-1","successful":true,"commitId":"abc","version":"1.2.3"}]`))
+		default:
+			http.NotFound(w, req)
+		}
+	}
+}
+
+func assertPrimaryCloudDashboard(t *testing.T, dashboard uiTenantDashboard, requests []string) {
+	t.Helper()
+
 	if dashboard.User == nil || dashboard.User.Username != "Rihards.Freimanis" || len(dashboard.User.Roles) != 2 || len(dashboard.MergeQueue) != 1 || len(dashboard.Builds) != 1 || dashboard.Builds[0].ReviewName != "Review 1" {
 		t.Fatalf("unexpected dashboard: %+v", dashboard)
 	}
@@ -1887,11 +1911,20 @@ func assertStoredEnvironmentConfig(t *testing.T, stored eruncommon.EnvConfig, pr
 	t.Helper()
 
 	storedRegistry, _ := stored.ContainerRegistries.BuildRegistry()
-	if stored.EffectiveLocalRepoPath() != projectRoot || stored.Type != eruncommon.EnvironmentTypeRuntime || stored.RuntimeVersion != "1.0.0" || storedRegistry != "registry.example/team" || stored.CloudProviderAlias != "other-cloud" || stored.SSHD.Enabled || stored.SSHD.LocalPort != 60022 || stored.SSHD.PublicKeyPath != "/tmp/old.pub" {
+	if stored.EffectiveLocalRepoPath() != projectRoot || stored.Type != eruncommon.EnvironmentTypeRuntime || stored.RuntimeVersion != "1.0.0" || storedRegistry != "registry.example/team" || stored.CloudProviderAlias != "other-cloud" {
 		t.Fatalf("unexpected stored config: %+v", stored)
 	}
+	assertStoredEnvironmentSSHD(t, stored)
 	if stored.RuntimePod.CPU != "6" || stored.RuntimePod.Memory != "12Gi" {
 		t.Fatalf("unexpected stored runtime pod config: %+v", stored.RuntimePod)
+	}
+}
+
+func assertStoredEnvironmentSSHD(t *testing.T, stored eruncommon.EnvConfig) {
+	t.Helper()
+
+	if stored.SSHD.Enabled || stored.SSHD.LocalPort != 60022 || stored.SSHD.PublicKeyPath != "/tmp/old.pub" {
+		t.Fatalf("unexpected stored config: %+v", stored)
 	}
 }
 
@@ -2124,26 +2157,38 @@ func TestLoadEnvironmentConfigExposesClaudeDefaultsAndOverrides(t *testing.T) {
 		t.Fatalf("LoadEnvironmentConfig failed: %v", err)
 	}
 
-	if got.Claude.UseBedrock == nil || *got.Claude.UseBedrock {
-		t.Fatalf("expected Claude.UseBedrock=false, got %+v", got.Claude)
+	assertClaudeOverrides(t, got.Claude)
+	assertClaudeDefaults(t, got.ClaudeDefaults)
+}
+
+func assertClaudeOverrides(t *testing.T, claude uiClaudeConfig) {
+	t.Helper()
+
+	if claude.UseBedrock == nil || *claude.UseBedrock {
+		t.Fatalf("expected Claude.UseBedrock=false, got %+v", claude)
 	}
-	if got.Claude.UseMantle != nil {
-		t.Fatalf("expected Claude.UseMantle to remain unset, got %+v", got.Claude)
+	if claude.UseMantle != nil {
+		t.Fatalf("expected Claude.UseMantle to remain unset, got %+v", claude)
 	}
-	if got.Claude.MaxOutputTokens == nil || *got.Claude.MaxOutputTokens != 8192 {
-		t.Fatalf("expected Claude.MaxOutputTokens=8192, got %+v", got.Claude)
+	if claude.MaxOutputTokens == nil || *claude.MaxOutputTokens != 8192 {
+		t.Fatalf("expected Claude.MaxOutputTokens=8192, got %+v", claude)
 	}
-	if !equalStringSlices(got.Claude.Models, []string{"opus", "sonnet"}) {
-		t.Fatalf("expected Claude.Models=[opus sonnet], got %+v", got.Claude.Models)
+	if !equalStringSlices(claude.Models, []string{"opus", "sonnet"}) {
+		t.Fatalf("expected Claude.Models=[opus sonnet], got %+v", claude.Models)
 	}
-	if got.ClaudeDefaults.MaxOutputTokens != eruncommon.DefaultClaudeMaxOutputTokens {
-		t.Fatalf("expected default max output tokens, got %d", got.ClaudeDefaults.MaxOutputTokens)
+}
+
+func assertClaudeDefaults(t *testing.T, defaults uiClaudeDefaults) {
+	t.Helper()
+
+	if defaults.MaxOutputTokens != eruncommon.DefaultClaudeMaxOutputTokens {
+		t.Fatalf("expected default max output tokens, got %d", defaults.MaxOutputTokens)
 	}
-	if !equalStringSlices(got.ClaudeDefaults.Models, eruncommon.DefaultClaudeAvailableModels()) {
-		t.Fatalf("expected default models, got %+v", got.ClaudeDefaults.Models)
+	if !equalStringSlices(defaults.Models, eruncommon.DefaultClaudeAvailableModels()) {
+		t.Fatalf("expected default models, got %+v", defaults.Models)
 	}
-	if !equalStringSlices(got.ClaudeDefaults.KnownModels, eruncommon.KnownClaudeModels()) {
-		t.Fatalf("expected known models list, got %+v", got.ClaudeDefaults.KnownModels)
+	if !equalStringSlices(defaults.KnownModels, eruncommon.KnownClaudeModels()) {
+		t.Fatalf("expected known models list, got %+v", defaults.KnownModels)
 	}
 }
 
@@ -2284,42 +2329,58 @@ func TestSetEnvironmentAutoStartPersistsTriStateValue(t *testing.T) {
 	}
 	app := NewApp(erunUIDeps{store: store})
 
-	saved, err := app.SetEnvironmentAutoStart(uiSelection{Tenant: "frs", Environment: "prod"}, "never")
-	if err != nil {
-		t.Fatalf("SetEnvironmentAutoStart(never) failed: %v", err)
-	}
-	if saved.AutoStart == nil || *saved.AutoStart != false {
-		t.Fatalf("expected returned AutoStart=false, got %+v", saved.AutoStart)
-	}
-	if got := store.envs["frs/prod"].AutoStart; got == nil || *got != false {
-		t.Fatalf("expected stored AutoStart=false, got %+v", got)
-	}
+	never := false
+	saved := setAutoStartMode(t, app, "never")
+	assertReturnedAutoStart(t, saved.AutoStart, &never, "false")
+	assertStoredAutoStart(t, store.envs["frs/prod"].AutoStart, &never, "false")
 	if keptRegistry, _ := store.envs["frs/prod"].ContainerRegistries.BuildRegistry(); keptRegistry != "registry.example/keep" {
 		t.Fatalf("SetEnvironmentAutoStart must not rewrite unrelated fields, got %+v", store.envs["frs/prod"])
 	}
 
-	saved, err = app.SetEnvironmentAutoStart(uiSelection{Tenant: "frs", Environment: "prod"}, "always")
-	if err != nil {
-		t.Fatalf("SetEnvironmentAutoStart(always) failed: %v", err)
-	}
-	if saved.AutoStart == nil || *saved.AutoStart != true {
-		t.Fatalf("expected returned AutoStart=true, got %+v", saved.AutoStart)
-	}
+	always := true
+	saved = setAutoStartMode(t, app, "always")
+	assertReturnedAutoStart(t, saved.AutoStart, &always, "true")
 
-	saved, err = app.SetEnvironmentAutoStart(uiSelection{Tenant: "frs", Environment: "prod"}, "ask")
-	if err != nil {
-		t.Fatalf("SetEnvironmentAutoStart(ask) failed: %v", err)
-	}
-	if saved.AutoStart != nil {
-		t.Fatalf("expected returned AutoStart=nil after ask, got %+v", saved.AutoStart)
-	}
-	if got := store.envs["frs/prod"].AutoStart; got != nil {
-		t.Fatalf("expected stored AutoStart=nil after ask, got %+v", got)
-	}
+	saved = setAutoStartMode(t, app, "ask")
+	assertReturnedAutoStart(t, saved.AutoStart, nil, "nil after ask")
+	assertStoredAutoStart(t, store.envs["frs/prod"].AutoStart, nil, "nil after ask")
 
 	if _, err := app.SetEnvironmentAutoStart(uiSelection{Tenant: "frs", Environment: "prod"}, "bogus"); err == nil {
 		t.Fatal("expected unknown auto-start mode to be rejected")
 	}
+}
+
+func setAutoStartMode(t *testing.T, app *App, mode string) uiEnvironmentConfig {
+	t.Helper()
+
+	saved, err := app.SetEnvironmentAutoStart(uiSelection{Tenant: "frs", Environment: "prod"}, mode)
+	if err != nil {
+		t.Fatalf("SetEnvironmentAutoStart(%s) failed: %v", mode, err)
+	}
+	return saved
+}
+
+func assertReturnedAutoStart(t *testing.T, got, want *bool, label string) {
+	t.Helper()
+
+	if !equalBoolPtr(got, want) {
+		t.Fatalf("expected returned AutoStart=%s, got %+v", label, got)
+	}
+}
+
+func assertStoredAutoStart(t *testing.T, got, want *bool, label string) {
+	t.Helper()
+
+	if !equalBoolPtr(got, want) {
+		t.Fatalf("expected stored AutoStart=%s, got %+v", label, got)
+	}
+}
+
+func equalBoolPtr(a, b *bool) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
 }
 
 func equalStringSlices(a, b []string) bool {

--- a/erun-ui/cloud_credentials_refresher.go
+++ b/erun-ui/cloud_credentials_refresher.go
@@ -49,28 +49,8 @@ func (a *App) cloudCredentialsRefresherKey(selection uiSelection) string {
 // selection is a no-op.
 func (a *App) startCloudCredentialsRefresherForSelection(selection uiSelection) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return
-	}
-	envConfig, _, err := a.deps.store.LoadEnvConfig(selection.Tenant, selection.Environment)
-	if err != nil {
-		return
-	}
-	if !envConfig.RemoteHostCredentials || !envConfig.RemoteWorktree() {
-		return
-	}
-	if strings.TrimSpace(envConfig.CloudProviderAlias) == "" {
-		return
-	}
-	provider, err := eruncommon.ResolveCloudProvider(a.deps.store, envConfig.CloudProviderAlias)
-	if err != nil || provider.Provider != eruncommon.CloudProviderAWS {
-		return
-	}
-	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
-		Tenant:      selection.Tenant,
-		Environment: selection.Environment,
-	})
-	if err != nil {
+	alias, result, ok := a.resolveCloudCredentialsRefreshTarget(selection)
+	if !ok {
 		return
 	}
 
@@ -90,8 +70,42 @@ func (a *App) startCloudCredentialsRefresherForSelection(selection uiSelection) 
 
 	go func() {
 		defer close(refresher.done)
-		a.runCloudCredentialsRefresher(ctx, selection, envConfig.CloudProviderAlias, result)
+		a.runCloudCredentialsRefresher(ctx, selection, alias, result)
 	}()
+}
+
+// resolveCloudCredentialsRefreshTarget evaluates the per-env preconditions that
+// gate the host-credential refresher: a non-empty tenant/env, the
+// RemoteHostCredentials opt-in on a remote worktree, a configured AWS-backed
+// cloud provider alias, and a resolvable open target. It returns the provider
+// alias and resolved OpenResult plus ok=true only when every precondition holds;
+// any failing check returns ok=false so the caller becomes a no-op.
+func (a *App) resolveCloudCredentialsRefreshTarget(selection uiSelection) (string, eruncommon.OpenResult, bool) {
+	if selection.Tenant == "" || selection.Environment == "" {
+		return "", eruncommon.OpenResult{}, false
+	}
+	envConfig, _, err := a.deps.store.LoadEnvConfig(selection.Tenant, selection.Environment)
+	if err != nil {
+		return "", eruncommon.OpenResult{}, false
+	}
+	if !envConfig.RemoteHostCredentials || !envConfig.RemoteWorktree() {
+		return "", eruncommon.OpenResult{}, false
+	}
+	if strings.TrimSpace(envConfig.CloudProviderAlias) == "" {
+		return "", eruncommon.OpenResult{}, false
+	}
+	provider, err := eruncommon.ResolveCloudProvider(a.deps.store, envConfig.CloudProviderAlias)
+	if err != nil || provider.Provider != eruncommon.CloudProviderAWS {
+		return "", eruncommon.OpenResult{}, false
+	}
+	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
+		Tenant:      selection.Tenant,
+		Environment: selection.Environment,
+	})
+	if err != nil {
+		return "", eruncommon.OpenResult{}, false
+	}
+	return envConfig.CloudProviderAlias, result, true
 }
 
 // stopCloudCredentialsRefresherForSelection signals the refresher to exit and

--- a/erun-ui/config_watcher.go
+++ b/erun-ui/config_watcher.go
@@ -116,19 +116,27 @@ func (a *App) runConfigWatcher(ctx context.Context, cw *configWatcher, root stri
 			if !ok {
 				return
 			}
-			if event.Has(fsnotify.Create) {
-				if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
-					_ = cw.watcher.Add(event.Name)
-				}
-			}
-			if event.Has(fsnotify.Create | fsnotify.Write | fsnotify.Remove | fsnotify.Rename) {
-				queueEmit()
-			}
+			handleConfigWatchEvent(cw.watcher, event, queueEmit)
 		case _, ok := <-cw.watcher.Errors:
 			if !ok {
 				return
 			}
 		}
+	}
+}
+
+// handleConfigWatchEvent reacts to a single fsnotify event: newly-created
+// directories are added to the watch set so deeper config writes are observed,
+// and any create/write/remove/rename queues a debounced environments-changed
+// emission via queueEmit.
+func handleConfigWatchEvent(watcher *fsnotify.Watcher, event fsnotify.Event, queueEmit func()) {
+	if event.Has(fsnotify.Create) {
+		if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
+			_ = watcher.Add(event.Name)
+		}
+	}
+	if event.Has(fsnotify.Create | fsnotify.Write | fsnotify.Remove | fsnotify.Rename) {
+		queueEmit()
 	}
 }
 

--- a/erun-ui/contribute_app.go
+++ b/erun-ui/contribute_app.go
@@ -208,20 +208,8 @@ func waitForContributeAppReachable(ctx context.Context, port int, forward *contr
 			return nil
 		}
 		if forward != nil && len(args) > 0 {
-			if exited, msg := forward.exitedWithError(); exited {
-				if msg != "" {
-					lastExitMsg = msg
-				}
-				cmd, stderr, spawnErr := spawnContributeAppForwardCmd(ctx, args)
-				if spawnErr != nil {
-					return fmt.Errorf("respawn kubectl port-forward for 127.0.0.1:%d after early exit (%s): %w", port, lastExitMsgOrPlaceholder(lastExitMsg), spawnErr)
-				}
-				if !forward.adopt(cmd, stderr) {
-					if cmd.Process != nil {
-						_ = cmd.Process.Kill()
-					}
-					return fmt.Errorf("contribute-app port-forward for 127.0.0.1:%d was stopped before becoming reachable", port)
-				}
+			if err := respawnContributeAppForwardIfExited(ctx, port, forward, args, &lastExitMsg); err != nil {
+				return err
 			}
 		}
 		time.Sleep(contributeAppPortReachablePollInterval)
@@ -230,6 +218,33 @@ func waitForContributeAppReachable(ctx context.Context, port int, forward *contr
 		return fmt.Errorf("contribute-app on 127.0.0.1:%d did not become reachable within %s (last kubectl exit: %s)", port, contributeAppPortReachableTimeout, lastExitMsg)
 	}
 	return fmt.Errorf("contribute-app on 127.0.0.1:%d did not become reachable within %s", port, contributeAppPortReachableTimeout)
+}
+
+// respawnContributeAppForwardIfExited checks whether the forward's kubectl
+// process has already exited and, if so, spawns a fresh one and adopts it into
+// the forward. It records the most recent captured stderr in *lastExitMsg so a
+// genuine failure still surfaces if the in-pod app never binds. A nil return
+// means either the forward is still alive or a respawn succeeded; a non-nil
+// return is a terminal error that aborts the reachability wait.
+func respawnContributeAppForwardIfExited(ctx context.Context, port int, forward *contributeAppForward, args []string, lastExitMsg *string) error {
+	exited, msg := forward.exitedWithError()
+	if !exited {
+		return nil
+	}
+	if msg != "" {
+		*lastExitMsg = msg
+	}
+	cmd, stderr, spawnErr := spawnContributeAppForwardCmd(ctx, args)
+	if spawnErr != nil {
+		return fmt.Errorf("respawn kubectl port-forward for 127.0.0.1:%d after early exit (%s): %w", port, lastExitMsgOrPlaceholder(*lastExitMsg), spawnErr)
+	}
+	if !forward.adopt(cmd, stderr) {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		return fmt.Errorf("contribute-app port-forward for 127.0.0.1:%d was stopped before becoming reachable", port)
+	}
+	return nil
 }
 
 func lastExitMsgOrPlaceholder(msg string) string {

--- a/erun-ui/contribute_mode.go
+++ b/erun-ui/contribute_mode.go
@@ -139,24 +139,36 @@ func (a *App) runEnsureErunClone(selection uiSelection) error {
 // port-forward for the contribute-app port, waits for the headless
 // server to accept connections, and returns the http URL the frontend
 // should open in the user's browser.
-func (a *App) StartContributeApp(selection uiSelection) (uiContributeAppLaunch, error) {
-	selection = normalizeSelection(selection)
+// resolveContributeAppPort validates that the selection is in contribute mode
+// and resolves the env's allocated contribute-app port. It returns an error
+// describing the first failing precondition (missing tenant/env, contribute
+// mode off, environment resolution failure, or an unallocated port).
+func (a *App) resolveContributeAppPort(selection uiSelection) (int, error) {
 	if selection.Tenant == "" || selection.Environment == "" {
-		return uiContributeAppLaunch{}, fmt.Errorf("tenant and environment are required")
+		return 0, fmt.Errorf("tenant and environment are required")
 	}
 	if !a.GetContributeMode(selection) {
-		return uiContributeAppLaunch{}, fmt.Errorf("contribute mode is not enabled for %s/%s", selection.Tenant, selection.Environment)
+		return 0, fmt.Errorf("contribute mode is not enabled for %s/%s", selection.Tenant, selection.Environment)
 	}
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
 		Tenant:      selection.Tenant,
 		Environment: selection.Environment,
 	})
 	if err != nil {
-		return uiContributeAppLaunch{}, fmt.Errorf("resolve environment: %w", err)
+		return 0, fmt.Errorf("resolve environment: %w", err)
 	}
 	port := eruncommon.ContributeAppPortForResult(result)
 	if port <= 0 {
-		return uiContributeAppLaunch{}, fmt.Errorf("contribute-app port is not allocated for %s/%s", selection.Tenant, selection.Environment)
+		return 0, fmt.Errorf("contribute-app port is not allocated for %s/%s", selection.Tenant, selection.Environment)
+	}
+	return port, nil
+}
+
+func (a *App) StartContributeApp(selection uiSelection) (uiContributeAppLaunch, error) {
+	selection = normalizeSelection(selection)
+	port, err := a.resolveContributeAppPort(selection)
+	if err != nil {
+		return uiContributeAppLaunch{}, err
 	}
 
 	// Send the headless start command into the contribute ERun tab so
@@ -181,7 +193,6 @@ func (a *App) StartContributeApp(selection uiSelection) (uiContributeAppLaunch, 
 	if forward != nil {
 		a.contributeApps.put(selection, forward)
 	}
-	_ = result
 	if err := waitForContributeAppReachable(ctx, localPort, forward, args); err != nil {
 		a.stopContributeAppForward(selection)
 		return uiContributeAppLaunch{}, err

--- a/erun-ui/contribute_sessions.go
+++ b/erun-ui/contribute_sessions.go
@@ -69,18 +69,9 @@ func (a *App) runContributeSession(ctx context.Context, selection uiSelection, s
 		kind = sessionKindContributeAI
 	}
 
-	a.mu.Lock()
-	if existing := a.sessions[key]; existing != nil && !existing.closed && existing.session != nil {
-		a.mu.Unlock()
-		existing.signalReady(nil)
-		return startSessionResult{
-			SessionID: existing.serial,
-			Selection: existing.selection,
-			Slot:      slot,
-			Kind:      string(kind),
-		}, existing, nil
+	if reused, managed, ok := a.reuseExistingContributeSession(key, slot, kind); ok {
+		return reused, managed, nil
 	}
-	a.mu.Unlock()
 
 	// The contribute tab runs `erun open --app-session contribute-… --contribute
 	// [--ai]`: the persistent remote session cds into the contribute clone with
@@ -144,6 +135,28 @@ func (a *App) runContributeSession(ctx context.Context, selection uiSelection, s
 		Slot:      slot,
 		Kind:      string(kind),
 	}, managed, nil
+}
+
+// reuseExistingContributeSession reconnects to an already-live contribute
+// session for key when one exists, signalling it ready and returning its
+// start result. The third return value reports whether a reusable session was
+// found; when false the caller spawns a fresh session. The session map is
+// inspected under a.mu, matching the locking the spawn path uses.
+func (a *App) reuseExistingContributeSession(key string, slot int, kind sessionKind) (startSessionResult, *managedTerminal, bool) {
+	a.mu.Lock()
+	existing := a.sessions[key]
+	if existing == nil || existing.closed || existing.session == nil {
+		a.mu.Unlock()
+		return startSessionResult{}, nil, false
+	}
+	a.mu.Unlock()
+	existing.signalReady(nil)
+	return startSessionResult{
+		SessionID: existing.serial,
+		Selection: existing.selection,
+		Slot:      slot,
+		Kind:      string(kind),
+	}, existing, true
 }
 
 func contributeSessionKey(selection uiSelection, slot int, withAI bool) string {

--- a/erun-ui/deploy_orchestration.go
+++ b/erun-ui/deploy_orchestration.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -144,18 +145,7 @@ func runErunCaptured(ctx context.Context, cliPath, dir string, onLine func(strin
 		done <- struct{}{}
 	}()
 	go func() {
-		scanner := bufio.NewScanner(stderrPipe)
-		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-		for scanner.Scan() {
-			line := scanner.Text()
-			if onLine != nil && strings.TrimSpace(line) != "" {
-				onLine(line)
-			}
-			if lastErr.Len() > 0 {
-				lastErr.WriteByte('\n')
-			}
-			lastErr.WriteString(line)
-		}
+		scanErunStderr(stderrPipe, onLine, &lastErr)
 		done <- struct{}{}
 	}()
 	<-done
@@ -168,6 +158,25 @@ func runErunCaptured(ctx context.Context, cliPath, dir string, onLine func(strin
 		return stdoutBuf.String(), fmt.Errorf("erun %s: %w", args[0], err)
 	}
 	return stdoutBuf.String(), nil
+}
+
+// scanErunStderr streams erun's trace stream line by line: every non-blank
+// line is forwarded to onLine (the activity-queue trace handler) and every
+// line is accumulated into lastErr (newline-separated) so the captured tail
+// can be attached to a non-zero-exit error.
+func scanErunStderr(stderrPipe io.Reader, onLine func(string), lastErr *strings.Builder) {
+	scanner := bufio.NewScanner(stderrPipe)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if onLine != nil && strings.TrimSpace(line) != "" {
+			onLine(line)
+		}
+		if lastErr.Len() > 0 {
+			lastErr.WriteByte('\n')
+		}
+		lastErr.WriteString(line)
+	}
 }
 
 // parseBuildResultVersion extracts the minted version from `erun build

--- a/erun-ui/environment_config.go
+++ b/erun-ui/environment_config.go
@@ -40,30 +40,44 @@ func (a *App) SaveEnvironmentConfig(selection uiSelection, config uiEnvironmentC
 	if err != nil {
 		return uiEnvironmentConfig{}, err
 	}
-	updated, err := a.updatedEnvironmentConfig(config, existing)
+	updated, err := a.persistEnvironmentConfig(selection, config, existing)
 	if err != nil {
 		return uiEnvironmentConfig{}, err
 	}
-	registries, err := uiToContainerRegistries(config.ContainerRegistries)
-	if err != nil {
-		return uiEnvironmentConfig{}, err
-	}
-	if err := a.applyContainerRegistries(selection, &updated, registries); err != nil {
-		return uiEnvironmentConfig{}, err
-	}
-	if err := a.saveRemoteCloudAlias(selection, existing, updated); err != nil {
-		return uiEnvironmentConfig{}, err
-	}
-	if err := a.deps.store.SaveEnvConfig(selection.Tenant, updated); err != nil {
-		return uiEnvironmentConfig{}, err
-	}
-	a.reconcileWorkspaceSyncForSelection(selection, updated.SSHD.WorkspaceSync.Enabled)
-	a.reconcileCloudCredentialsRefresherForSelection(selection, updated.RemoteHostCredentials && updated.RemoteWorktree())
 	ports, err := eruncommon.ResolveEnvironmentLocalPorts(a.deps.store, selection.Tenant, selection.Environment)
 	if err != nil {
 		return uiEnvironmentConfig{}, err
 	}
 	return a.environmentConfigToUI(selection.Tenant, updated, selection.Environment, ports)
+}
+
+// persistEnvironmentConfig builds the updated env config from the edited UI
+// values and existing config, routes the container-registry list to its
+// owning store, applies a changed remote cloud alias, saves the env config,
+// and reconciles the workspace-sync and cloud-credentials refreshers. The
+// steps run in the same order and persist the same fields as before; it
+// returns the saved config so the caller can render it back to the UI.
+func (a *App) persistEnvironmentConfig(selection uiSelection, config uiEnvironmentConfig, existing eruncommon.EnvConfig) (eruncommon.EnvConfig, error) {
+	updated, err := a.updatedEnvironmentConfig(config, existing)
+	if err != nil {
+		return eruncommon.EnvConfig{}, err
+	}
+	registries, err := uiToContainerRegistries(config.ContainerRegistries)
+	if err != nil {
+		return eruncommon.EnvConfig{}, err
+	}
+	if err := a.applyContainerRegistries(selection, &updated, registries); err != nil {
+		return eruncommon.EnvConfig{}, err
+	}
+	if err := a.saveRemoteCloudAlias(selection, existing, updated); err != nil {
+		return eruncommon.EnvConfig{}, err
+	}
+	if err := a.deps.store.SaveEnvConfig(selection.Tenant, updated); err != nil {
+		return eruncommon.EnvConfig{}, err
+	}
+	a.reconcileWorkspaceSyncForSelection(selection, updated.SSHD.WorkspaceSync.Enabled)
+	a.reconcileCloudCredentialsRefresherForSelection(selection, updated.RemoteHostCredentials && updated.RemoteWorktree())
+	return updated, nil
 }
 
 // applyContainerRegistries persists the edited marked list to the place that

--- a/erun-ui/environment_upgrade_test.go
+++ b/erun-ui/environment_upgrade_test.go
@@ -98,24 +98,7 @@ func TestResolveUpgradePlanOffersCandidatesWhenRegistriesDisagree(t *testing.T) 
 				},
 			},
 		},
-		resolveImageRegistry: func(_ context.Context, namespace, repository string) (eruncommon.RuntimeRegistryVersions, error) {
-			switch repository {
-			case "petios-devops":
-				return eruncommon.RuntimeRegistryVersions{
-					Image:          namespace + "/" + repository,
-					Tags:           []string{tenantSnapshot},
-					LatestSnapshot: tenantSnapshot,
-				}, nil
-			case eruncommon.DefaultRuntimeImageName:
-				return eruncommon.RuntimeRegistryVersions{
-					Image:          namespace + "/" + repository,
-					LatestSnapshot: defaultSnapshot,
-				}, nil
-			default:
-				t.Fatalf("unexpected registry repository: %s", repository)
-			}
-			return eruncommon.RuntimeRegistryVersions{}, nil
-		},
+		resolveImageRegistry: disagreeingSnapshotRegistry(t, tenantSnapshot, defaultSnapshot),
 	})
 
 	plan, err := app.ResolveUpgradePlan()
@@ -135,12 +118,48 @@ func TestResolveUpgradePlanOffersCandidatesWhenRegistriesDisagree(t *testing.T) 
 	if !strings.Contains(item.UnresolvedReason, "multiple newer versions") {
 		t.Fatalf("expected the multiple-newer reason, got %q", item.UnresolvedReason)
 	}
+	assertCandidateVersions(t, item.Candidates, tenantSnapshot, defaultSnapshot)
+}
+
+// disagreeingSnapshotRegistry resolves the tenant image and the canonical ERun
+// image to different latest snapshots, so the upgrade planner sees two distinct
+// newer versions for the tracked channel.
+func disagreeingSnapshotRegistry(t *testing.T, tenantSnapshot, defaultSnapshot string) func(context.Context, string, string) (eruncommon.RuntimeRegistryVersions, error) {
+	t.Helper()
+
+	return func(_ context.Context, namespace, repository string) (eruncommon.RuntimeRegistryVersions, error) {
+		switch repository {
+		case "petios-devops":
+			return eruncommon.RuntimeRegistryVersions{
+				Image:          namespace + "/" + repository,
+				Tags:           []string{tenantSnapshot},
+				LatestSnapshot: tenantSnapshot,
+			}, nil
+		case eruncommon.DefaultRuntimeImageName:
+			return eruncommon.RuntimeRegistryVersions{
+				Image:          namespace + "/" + repository,
+				LatestSnapshot: defaultSnapshot,
+			}, nil
+		default:
+			t.Fatalf("unexpected registry repository: %s", repository)
+		}
+		return eruncommon.RuntimeRegistryVersions{}, nil
+	}
+}
+
+// assertCandidateVersions confirms each wanted version appears among the
+// offered upgrade candidates.
+func assertCandidateVersions(t *testing.T, candidates []eruncommon.UpgradeVersionCandidate, want ...string) {
+	t.Helper()
+
 	versions := map[string]bool{}
-	for _, candidate := range item.Candidates {
+	for _, candidate := range candidates {
 		versions[candidate.Version] = true
 	}
-	if !versions[tenantSnapshot] || !versions[defaultSnapshot] {
-		t.Fatalf("expected both registry versions as candidates, got %+v", item.Candidates)
+	for _, w := range want {
+		if !versions[w] {
+			t.Fatalf("expected %q among candidates, got %+v", w, candidates)
+		}
 	}
 }
 

--- a/erun-ui/environment_working_issue_test.go
+++ b/erun-ui/environment_working_issue_test.go
@@ -64,10 +64,10 @@ func TestEnvironmentWorkingIssueResolvesBranchAndTitle(t *testing.T) {
 	var calls [][]string
 	run := func(_ context.Context, dir, name string, args ...string) (string, error) {
 		calls = append(calls, append([]string{name}, args...))
-		switch {
-		case name == "git":
+		switch name {
+		case "git":
 			return "feature/437-sidebar-env-hover", nil
-		case name == "gh":
+		case "gh":
 			return "Sidebar environment hover", nil
 		}
 		return "", nil
@@ -83,12 +83,7 @@ func TestEnvironmentWorkingIssueResolvesBranchAndTitle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EnvironmentWorkingIssue: %v", err)
 	}
-	if !got.Available {
-		t.Fatalf("expected Available for a local-agent env, got %+v", got)
-	}
-	if got.Branch != "feature/437-sidebar-env-hover" || got.IssueNumber != 437 || got.IssueTitle != "Sidebar environment hover" {
-		t.Fatalf("unexpected working issue: %+v", got)
-	}
+	assertResolvedWorkingIssue(t, got)
 	if len(calls) != 2 {
 		t.Fatalf("expected git + gh (2 calls), got %d: %v", len(calls), calls)
 	}
@@ -99,6 +94,17 @@ func TestEnvironmentWorkingIssueResolvesBranchAndTitle(t *testing.T) {
 	}
 	if len(calls) != 2 {
 		t.Errorf("expected cache hit on second call (still 2 calls), got %d: %v", len(calls), calls)
+	}
+}
+
+func assertResolvedWorkingIssue(t *testing.T, got uiWorkingIssue) {
+	t.Helper()
+
+	if !got.Available {
+		t.Fatalf("expected Available for a local-agent env, got %+v", got)
+	}
+	if got.Branch != "feature/437-sidebar-env-hover" || got.IssueNumber != 437 || got.IssueTitle != "Sidebar environment hover" {
+		t.Fatalf("unexpected working issue: %+v", got)
 	}
 }
 

--- a/erun-ui/headlessserver/server.go
+++ b/erun-ui/headlessserver/server.go
@@ -150,29 +150,31 @@ func writeStatic(w http.ResponseWriter, path string, data []byte) {
 	_, _ = w.Write(data)
 }
 
+// contentTypeBySuffix maps a file-extension suffix to the Content-Type the
+// static handler advertises. Order matters: ".woff2" must precede ".woff" so
+// the longer suffix wins, mirroring the original switch.
+var contentTypeBySuffix = []struct {
+	suffix      string
+	contentType string
+}{
+	{".js", "application/javascript; charset=utf-8"},
+	{".css", "text/css; charset=utf-8"},
+	{".html", "text/html; charset=utf-8"},
+	{".json", "application/json; charset=utf-8"},
+	{".svg", "image/svg+xml"},
+	{".png", "image/png"},
+	{".woff2", "font/woff2"},
+	{".woff", "font/woff"},
+	{".map", "application/json; charset=utf-8"},
+}
+
 func contentTypeForPath(path string) string {
-	switch {
-	case strings.HasSuffix(path, ".js"):
-		return "application/javascript; charset=utf-8"
-	case strings.HasSuffix(path, ".css"):
-		return "text/css; charset=utf-8"
-	case strings.HasSuffix(path, ".html"):
-		return "text/html; charset=utf-8"
-	case strings.HasSuffix(path, ".json"):
-		return "application/json; charset=utf-8"
-	case strings.HasSuffix(path, ".svg"):
-		return "image/svg+xml"
-	case strings.HasSuffix(path, ".png"):
-		return "image/png"
-	case strings.HasSuffix(path, ".woff2"):
-		return "font/woff2"
-	case strings.HasSuffix(path, ".woff"):
-		return "font/woff"
-	case strings.HasSuffix(path, ".map"):
-		return "application/json; charset=utf-8"
-	default:
-		return ""
+	for _, entry := range contentTypeBySuffix {
+		if strings.HasSuffix(path, entry.suffix) {
+			return entry.contentType
+		}
 	}
+	return ""
 }
 
 // invokeRequest is the wire payload for /__erun_invoke. args is held as raw
@@ -217,10 +219,20 @@ func callMethod(method reflect.Value, rawArgs []json.RawMessage) (any, error) {
 	if len(rawArgs) != wantArgs {
 		return nil, fmt.Errorf("expected %d args, got %d", wantArgs, len(rawArgs))
 	}
-	in := make([]reflect.Value, wantArgs)
-	for i := 0; i < wantArgs; i++ {
-		paramType := mt.In(i)
-		slot := reflect.New(paramType)
+	in, err := decodeMethodArgs(mt, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	return mapMethodResults(method.Call(in))
+}
+
+// decodeMethodArgs reflectively unmarshals each raw JSON arg into the exact Go
+// type the method's matching parameter expects. A missing or null arg leaves
+// the parameter at its zero value, matching Wails' lenient call convention.
+func decodeMethodArgs(mt reflect.Type, rawArgs []json.RawMessage) ([]reflect.Value, error) {
+	in := make([]reflect.Value, mt.NumIn())
+	for i := 0; i < mt.NumIn(); i++ {
+		slot := reflect.New(mt.In(i))
 		if len(rawArgs[i]) > 0 && string(rawArgs[i]) != "null" {
 			if err := json.Unmarshal(rawArgs[i], slot.Interface()); err != nil {
 				return nil, fmt.Errorf("arg %d: %v", i, err)
@@ -228,9 +240,12 @@ func callMethod(method reflect.Value, rawArgs []json.RawMessage) (any, error) {
 		}
 		in[i] = slot.Elem()
 	}
-	results := method.Call(in)
-	// Wails methods return one of: (), (T), (error), or (T, error). Map
-	// the common shapes back to a {data, error?} envelope.
+	return in, nil
+}
+
+// mapMethodResults maps a Wails method's return values — one of (), (T),
+// (error), or (T, error) — back to a {data, error?} envelope.
+func mapMethodResults(results []reflect.Value) (any, error) {
 	var (
 		data any
 		err  error

--- a/erun-ui/headlessserver/server_test.go
+++ b/erun-ui/headlessserver/server_test.go
@@ -68,7 +68,7 @@ func TestIndexInjectsShim(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(resp.Body)
 	if !strings.Contains(string(body), "window.go.main.App[\"Echo\"]") {
 		t.Fatalf("shim missing Echo binding: %s", body)
@@ -87,7 +87,7 @@ func TestStaticAssetServed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(resp.Body)
 	if !strings.Contains(string(body), "console.log('main')") {
 		t.Fatalf("static asset body wrong: %s", body)
@@ -104,7 +104,7 @@ func TestInvokeReturnsData(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
 		out, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status %d: %s", resp.StatusCode, out)
@@ -131,7 +131,7 @@ func TestInvokeReturnsErrorEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 500 {
 		t.Fatalf("status = %d, want 500", resp.StatusCode)
 	}
@@ -151,7 +151,7 @@ func TestInvokeUnknownMethod(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 404 {
 		t.Fatalf("status = %d", resp.StatusCode)
 	}
@@ -164,7 +164,7 @@ func TestInvokePlainReturn(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	var env invokeEnvelope
 	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
 		t.Fatal(err)
@@ -189,7 +189,7 @@ func TestEmitFansOutToSubscriber(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Subscription happens during the handler; give it a beat to register
 	// before emitting so the test does not race the subscriber map.
@@ -198,38 +198,11 @@ func TestEmitFansOutToSubscriber(t *testing.T) {
 	got := make(chan event, 1)
 	go func() {
 		defer wg.Done()
-		reader := bufioReaderForSSE(resp.Body)
-		for {
-			line, err := reader.ReadString('\n')
-			if err != nil {
-				return
-			}
-			line = strings.TrimSpace(line)
-			if !strings.HasPrefix(line, "data:") {
-				continue
-			}
-			var ev event
-			if err := json.Unmarshal([]byte(strings.TrimSpace(strings.TrimPrefix(line, "data:"))), &ev); err == nil {
-				got <- ev
-				return
-			}
-		}
+		readFirstSSEEvent(resp.Body, got)
 	}()
 
 	// Wait until at least one subscriber is registered before emitting.
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		srv.subsMu.Lock()
-		n := len(srv.subs)
-		srv.subsMu.Unlock()
-		if n > 0 {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("no subscriber registered")
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitForSubscriber(t, srv)
 
 	srv.Emit("ping", "hello", 42)
 
@@ -243,6 +216,47 @@ func TestEmitFansOutToSubscriber(t *testing.T) {
 	}
 }
 
+// readFirstSSEEvent reads SSE "data:" frames from the response body until it
+// decodes one event, then sends it on got and returns.
+func readFirstSSEEvent(body io.Reader, got chan<- event) {
+	reader := bufioReaderForSSE(body)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		var ev event
+		if err := json.Unmarshal([]byte(strings.TrimSpace(strings.TrimPrefix(line, "data:"))), &ev); err == nil {
+			got <- ev
+			return
+		}
+	}
+}
+
+// waitForSubscriber blocks until the server has registered at least one SSE
+// subscriber, so an Emit cannot race ahead of the subscription.
+func waitForSubscriber(t *testing.T, srv *Server) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		srv.subsMu.Lock()
+		n := len(srv.subs)
+		srv.subsMu.Unlock()
+		if n > 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("no subscriber registered")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 func TestClipboardStoresInMemory(t *testing.T) {
 	_, _, ts := newTestServer(t)
 	body, _ := json.Marshal(clipboardRequest{Action: "set", Text: "hello"})
@@ -250,14 +264,14 @@ func TestClipboardStoresInMemory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	body, _ = json.Marshal(clipboardRequest{Action: "get"})
 	resp, err = http.Post(ts.URL+"/__erun_clipboard", "application/json", bytes.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	var got clipboardResponse
 	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
 		t.Fatal(err)

--- a/erun-ui/idle_status.go
+++ b/erun-ui/idle_status.go
@@ -380,9 +380,30 @@ func (a *App) clearIdleStopsForCloudContext(name string) bool {
 	if name == "" {
 		return false
 	}
+	cleared := a.selectionKeysForCloudContext(name)
+	if len(cleared) == 0 {
+		return false
+	}
+	removed := false
+	a.mu.Lock()
+	for _, key := range cleared {
+		if _, ok := a.idleStops[key]; ok {
+			delete(a.idleStops, key)
+			removed = true
+		}
+	}
+	a.mu.Unlock()
+	return removed
+}
+
+// selectionKeysForCloudContext returns the selection keys for every configured
+// environment linked to the supplied cloud context name. Extracted from
+// clearIdleStopsForCloudContext so the config scan and the latched-flag removal
+// stay independently simple; the matching rules are unchanged.
+func (a *App) selectionKeysForCloudContext(name string) []string {
 	tenants, err := a.deps.store.ListTenantConfigs()
 	if err != nil {
-		return false
+		return nil
 	}
 	cleared := make([]string, 0)
 	for _, tenant := range tenants {
@@ -398,19 +419,7 @@ func (a *App) clearIdleStopsForCloudContext(name string) bool {
 			cleared = append(cleared, selectionKey(uiSelection{Tenant: tenant.Name, Environment: env.Name}))
 		}
 	}
-	if len(cleared) == 0 {
-		return false
-	}
-	removed := false
-	a.mu.Lock()
-	for _, key := range cleared {
-		if _, ok := a.idleStops[key]; ok {
-			delete(a.idleStops, key)
-			removed = true
-		}
-	}
-	a.mu.Unlock()
-	return removed
+	return cleared
 }
 
 func activitySecondsUntilIdle(status eruncommon.EnvironmentIdleStatus) int64 {

--- a/erun-ui/idle_stop_mcp.go
+++ b/erun-ui/idle_stop_mcp.go
@@ -187,7 +187,7 @@ func formatIdleStopMCPError(tool string, err error) error {
 		return fmt.Errorf(
 			"%s: this runtime image does not yet support the auto-stop history feature. "+
 				"Rebuild and redeploy the env (erun deploy <tenant> <env>) so the pod runs "+
-				"a runtime image that includes the idle_stop_* MCP tools.",
+				"a runtime image that includes the idle_stop_* MCP tools",
 			tool,
 		)
 	}

--- a/erun-ui/main.go
+++ b/erun-ui/main.go
@@ -69,27 +69,69 @@ func parseHeadlessFlags(args []string) (headless bool, port int, leftover []stri
 	for i < len(args) {
 		a := args[i]
 		switch {
-		case a == "--headless" || a == "-headless":
-			headless = true
-		case strings.HasPrefix(a, "--headless=") || strings.HasPrefix(a, "-headless="):
-			headless = parseBoolFlag(stripFlagPrefix(a, "headless="))
-		case a == "--port" || a == "-port":
-			if i+1 < len(args) {
-				if p, err := strconv.Atoi(args[i+1]); err == nil && p > 0 {
-					port = p
-					i++
-				}
+		case matchHeadlessFlag(a, &headless):
+		case isPortFlag(a):
+			// --port value: consume the following arg only when it parses
+			// into port; otherwise the next arg flows through normally.
+			if consumePortFlagValue(args, i, &port) {
+				i++
 			}
-		case strings.HasPrefix(a, "--port=") || strings.HasPrefix(a, "-port="):
-			if p, err := strconv.Atoi(stripFlagPrefix(a, "port=")); err == nil && p > 0 {
-				port = p
-			}
+		case matchPortAssignFlag(a, &port):
 		default:
 			leftover = append(leftover, a)
 		}
 		i++
 	}
 	return headless, port, leftover
+}
+
+// matchHeadlessFlag reports whether arg is a --headless flag (bare or
+// =value form) and, when it is, updates headless accordingly.
+func matchHeadlessFlag(arg string, headless *bool) bool {
+	switch {
+	case arg == "--headless" || arg == "-headless":
+		*headless = true
+		return true
+	case strings.HasPrefix(arg, "--headless=") || strings.HasPrefix(arg, "-headless="):
+		*headless = parseBoolFlag(stripFlagPrefix(arg, "headless="))
+		return true
+	default:
+		return false
+	}
+}
+
+// isPortFlag reports whether arg is the bare `--port`/`-port` form, whose
+// value is the following argument.
+func isPortFlag(arg string) bool {
+	return arg == "--port" || arg == "-port"
+}
+
+// consumePortFlagValue parses the argument following a bare --port flag. When
+// it parses as a positive int, port is updated and true is returned so the
+// caller skips the consumed value; otherwise port is left untouched and the
+// following arg flows through to leftover, matching the prior behavior.
+func consumePortFlagValue(args []string, i int, port *int) bool {
+	if i+1 >= len(args) {
+		return false
+	}
+	p, err := strconv.Atoi(args[i+1])
+	if err != nil || p <= 0 {
+		return false
+	}
+	*port = p
+	return true
+}
+
+// matchPortAssignFlag reports whether arg is the `--port=value` form and, when
+// the value parses as a positive int, updates port.
+func matchPortAssignFlag(arg string, port *int) bool {
+	if !strings.HasPrefix(arg, "--port=") && !strings.HasPrefix(arg, "-port=") {
+		return false
+	}
+	if p, err := strconv.Atoi(stripFlagPrefix(arg, "port=")); err == nil && p > 0 {
+		*port = p
+	}
+	return true
 }
 
 func stripFlagPrefix(arg, name string) string {

--- a/erun-ui/mcp_errors.go
+++ b/erun-ui/mcp_errors.go
@@ -42,7 +42,14 @@ func isMCPDialFailure(err error) bool {
 	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ETIMEDOUT) {
 		return true
 	}
-	msg := err.Error()
+	return mcpDialFailureMessage(err.Error())
+}
+
+// mcpDialFailureMessage reports whether a surfaced error string matches one of
+// the substrings that indicate the MCP port-forward could not be dialed. Split
+// from isMCPDialFailure so the errno/net.OpError checks and the message scan
+// stay independently simple.
+func mcpDialFailureMessage(msg string) bool {
 	return strings.Contains(msg, "connection refused") ||
 		strings.Contains(msg, "EOF") ||
 		strings.Contains(msg, "connection reset") ||

--- a/erun-ui/remote_sessions_test.go
+++ b/erun-ui/remote_sessions_test.go
@@ -241,18 +241,7 @@ func TestCloseSessionEndsRemoteCustomTerminal(t *testing.T) {
 	if err := app.CloseSession(extra.SessionID); err != nil {
 		t.Fatalf("CloseSession(extra): %v", err)
 	}
-	deadline := time.Now().Add(3 * time.Second)
-	for {
-		data, _ := os.ReadFile(captureFile)
-		if strings.Contains(string(data), "erun-remote-open-2.dtach") &&
-			strings.Contains(string(data), "rm -f") {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("expected the end-script kubectl exec for open-2, captured: %q", data)
-		}
-		time.Sleep(25 * time.Millisecond)
-	}
+	waitForKubectlEndScript(t, captureFile, "erun-remote-open-2.dtach")
 
 	_ = os.Remove(captureFile)
 	def, err := app.StartSession(selection, 0, 80, 24)
@@ -265,5 +254,24 @@ func TestCloseSessionEndsRemoteCustomTerminal(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 	if data, _ := os.ReadFile(captureFile); strings.Contains(string(data), "rm -f") {
 		t.Fatalf("default tab close must not end the pod session, captured: %q", data)
+	}
+}
+
+// waitForKubectlEndScript polls the PATH-stub kubectl capture file until it
+// records the end-script exec (an "rm -f" of the named dtach socket), failing
+// the test if it does not appear within the deadline.
+func waitForKubectlEndScript(t *testing.T, captureFile, socket string) {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		data, _ := os.ReadFile(captureFile)
+		if strings.Contains(string(data), socket) && strings.Contains(string(data), "rm -f") {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected the end-script kubectl exec for %s, captured: %q", socket, data)
+		}
+		time.Sleep(25 * time.Millisecond)
 	}
 }

--- a/erun-ui/runtime_resources.go
+++ b/erun-ui/runtime_resources.go
@@ -47,40 +47,7 @@ func normalizeRuntimeResourceInput(input uiRuntimeResourceInput) uiRuntimeResour
 func runtimeResourceStatusFromKubernetes(input uiRuntimeResourceInput, nodes kubernetesNodeList, pods kubernetesPodList) uiRuntimeResourceStatus {
 	input = normalizeRuntimeResourceInput(input)
 	target := runtimeResourceTarget(input)
-	usage := make(map[string]runtimeResourceTotals)
-	targetUsage := make(map[string]runtimeResourceTotals)
-	targetNode := ""
-	for _, pod := range pods.Items {
-		if isTerminalKubernetesPodPhase(pod.Status.Phase) {
-			continue
-		}
-		nodeName := strings.TrimSpace(pod.Spec.NodeName)
-		if nodeName == "" {
-			continue
-		}
-		totals := usage[nodeName]
-		for _, container := range pod.Spec.Containers {
-			if target.matches(pod, container) {
-				targetNode = nodeName
-				targetTotals := targetUsage[nodeName]
-				if cpu, err := eruncommon.ParseKubernetesCPUToMilli(container.Resources.Limits.CPU); err == nil {
-					targetTotals.CPUMilli += cpu
-				}
-				if memory, err := eruncommon.ParseKubernetesMemoryToMi(container.Resources.Limits.Memory); err == nil {
-					targetTotals.MemoryMi += memory
-				}
-				targetUsage[nodeName] = targetTotals
-				continue
-			}
-			if cpu, err := eruncommon.ParseKubernetesCPUToMilli(container.Resources.Limits.CPU); err == nil {
-				totals.CPUMilli += cpu
-			}
-			if memory, err := eruncommon.ParseKubernetesMemoryToMi(container.Resources.Limits.Memory); err == nil {
-				totals.MemoryMi += memory
-			}
-		}
-		usage[nodeName] = totals
-	}
+	usage, targetUsage, targetNode := accumulateRuntimePodUsage(pods, target)
 
 	result := uiRuntimeResourceStatus{
 		KubernetesContext: input.KubernetesContext,
@@ -118,6 +85,50 @@ func runtimeResourceStatusFromKubernetes(input uiRuntimeResourceInput, nodes kub
 	}
 	result.Message = fmt.Sprintf("Available on best node: %s CPU and %s memory.", result.CPU.Formatted, result.Memory.Formatted)
 	return result
+}
+
+// accumulateRuntimePodUsage walks the non-terminal scheduled pods and sums each
+// node's container resource limits, splitting out the target runtime's own
+// containers into targetUsage and reporting the node the target landed on.
+// Extracted from runtimeResourceStatusFromKubernetes so that function stays
+// under the cyclomatic limit; the per-container target/non-target split is
+// unchanged.
+func accumulateRuntimePodUsage(pods kubernetesPodList, target runtimeResourceTargetSpec) (usage, targetUsage map[string]runtimeResourceTotals, targetNode string) {
+	usage = make(map[string]runtimeResourceTotals)
+	targetUsage = make(map[string]runtimeResourceTotals)
+	for _, pod := range pods.Items {
+		if isTerminalKubernetesPodPhase(pod.Status.Phase) {
+			continue
+		}
+		nodeName := strings.TrimSpace(pod.Spec.NodeName)
+		if nodeName == "" {
+			continue
+		}
+		totals := usage[nodeName]
+		for _, container := range pod.Spec.Containers {
+			if target.matches(pod, container) {
+				targetNode = nodeName
+				targetUsage[nodeName] = addContainerLimits(targetUsage[nodeName], container)
+				continue
+			}
+			totals = addContainerLimits(totals, container)
+		}
+		usage[nodeName] = totals
+	}
+	return usage, targetUsage, targetNode
+}
+
+// addContainerLimits adds a container's parseable CPU and memory limits to the
+// running totals, ignoring limits that fail to parse (the same tolerance the
+// inline accumulation used).
+func addContainerLimits(totals runtimeResourceTotals, container kubernetesContainer) runtimeResourceTotals {
+	if cpu, err := eruncommon.ParseKubernetesCPUToMilli(container.Resources.Limits.CPU); err == nil {
+		totals.CPUMilli += cpu
+	}
+	if memory, err := eruncommon.ParseKubernetesMemoryToMi(container.Resources.Limits.Memory); err == nil {
+		totals.MemoryMi += memory
+	}
+	return totals
 }
 
 func shouldUseRuntimeResourceNode(name, targetNode string, item uiRuntimeResourceNode, result uiRuntimeResourceStatus) bool {

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -250,20 +250,7 @@ func runOpenForReconnect(ctx context.Context, cliPath string, result eruncommon.
 	}
 	var lastErr strings.Builder
 	scan := func(reader io.Reader, captureErr bool) {
-		scanner := bufio.NewScanner(reader)
-		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-		for scanner.Scan() {
-			line := scanner.Text()
-			if onLine != nil && strings.TrimSpace(line) != "" {
-				onLine(line)
-			}
-			if captureErr {
-				if lastErr.Len() > 0 {
-					lastErr.WriteByte('\n')
-				}
-				lastErr.WriteString(line)
-			}
-		}
+		scanReconnectOutput(reader, captureErr, onLine, &lastErr)
 	}
 	done := make(chan struct{}, 2)
 	go func() { scan(stdout, false); done <- struct{}{} }()
@@ -278,6 +265,29 @@ func runOpenForReconnect(ctx context.Context, cliPath string, result eruncommon.
 		return fmt.Errorf("activate MCP port-forward: %w: %s", err, detail)
 	}
 	return nil
+}
+
+// scanReconnectOutput streams one of runOpenForReconnect's child-process pipes
+// line by line: it forwards non-blank lines to onLine and, when captureErr is
+// set, accumulates every line into lastErr (newline-joined) so the trailing
+// stderr can be folded into the returned error. Extracted from the inline
+// closure so runOpenForReconnect stays under the cyclomatic limit; the
+// per-line behavior is unchanged.
+func scanReconnectOutput(reader io.Reader, captureErr bool, onLine func(string), lastErr *strings.Builder) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if onLine != nil && strings.TrimSpace(line) != "" {
+			onLine(line)
+		}
+		if captureErr {
+			if lastErr.Len() > 0 {
+				lastErr.WriteByte('\n')
+			}
+			lastErr.WriteString(line)
+		}
+	}
 }
 
 func ensureSSHDViaOpenCommand(ctx context.Context, cliPath string, result eruncommon.OpenResult) error {
@@ -305,24 +315,7 @@ func buildInitArgs(selection uiSelection) []string {
 		envType = "remote-agent"
 	}
 	args := []string{"init", strings.TrimSpace(selection.Tenant), strings.TrimSpace(selection.Environment), "--type=" + envType}
-	if version := strings.TrimSpace(selection.Version); version != "" {
-		args = append(args, "--version", version)
-	}
-	if runtimeImage := strings.TrimSpace(selection.RuntimeImage); runtimeImage != "" {
-		args = append(args, "--runtime-image", runtimeImage)
-	}
-	if runtimeCPU := strings.TrimSpace(selection.RuntimeCPU); runtimeCPU != "" {
-		args = append(args, "--runtime-cpu", runtimeCPU)
-	}
-	if runtimeMemory := strings.TrimSpace(selection.RuntimeMemory); runtimeMemory != "" {
-		args = append(args, "--runtime-memory", runtimeMemory)
-	}
-	if kubernetesContext := strings.TrimSpace(selection.KubernetesContext); kubernetesContext != "" {
-		args = append(args, "--kubernetes-context", kubernetesContext)
-	}
-	if containerRegistry := strings.TrimSpace(selection.ContainerRegistry); containerRegistry != "" {
-		args = append(args, "--container-registry", containerRegistry)
-	}
+	args = appendInitOptionalFlags(args, selection)
 	if envType == "local-agent" {
 		if localRepoPath := strings.TrimSpace(selection.LocalRepoPath); localRepoPath != "" {
 			args = append(args, "--project-root", localRepoPath)
@@ -335,6 +328,26 @@ func buildInitArgs(selection uiSelection) []string {
 	)
 	if selection.NoGit {
 		args = append(args, "--no-git")
+	}
+	return args
+}
+
+// appendInitOptionalFlags appends the optional `--flag value` pairs that
+// buildInitArgs threads through, in their established order, skipping any whose
+// trimmed value is empty. Extracted so buildInitArgs stays under the cyclomatic
+// limit; the produced argument order and spellings are unchanged.
+func appendInitOptionalFlags(args []string, selection uiSelection) []string {
+	for _, pair := range []struct{ flag, value string }{
+		{"--version", strings.TrimSpace(selection.Version)},
+		{"--runtime-image", strings.TrimSpace(selection.RuntimeImage)},
+		{"--runtime-cpu", strings.TrimSpace(selection.RuntimeCPU)},
+		{"--runtime-memory", strings.TrimSpace(selection.RuntimeMemory)},
+		{"--kubernetes-context", strings.TrimSpace(selection.KubernetesContext)},
+		{"--container-registry", strings.TrimSpace(selection.ContainerRegistry)},
+	} {
+		if pair.value != "" {
+			args = append(args, pair.flag, pair.value)
+		}
 	}
 	return args
 }

--- a/erun-ui/tenant_dashboard.go
+++ b/erun-ui/tenant_dashboard.go
@@ -55,32 +55,40 @@ func (a *App) LoadTenantDashboard(input uiTenantDashboardInput) (uiTenantDashboa
 	}
 	usernameHint := a.tenantDashboardUsernameHint(token.Alias)
 	client := &http.Client{Timeout: 10 * time.Second}
+	loadTenantDashboardData(ctx, client, apiURL, bearer, usernameHint, &dashboard)
+	return dashboard, nil
+}
 
+// loadTenantDashboardData fetches the whoami, reviews, merge-queue, and build
+// sections in sequence and writes them onto dashboard. The first failing
+// section records its error in dashboard.APIError and stops further loads,
+// matching the prior fail-fast behavior where each section's error short-
+// circuited the rest while keeping already-loaded sections.
+func loadTenantDashboardData(ctx context.Context, client *http.Client, apiURL, bearer, usernameHint string, dashboard *uiTenantDashboard) {
 	user, err := loadTenantDashboardJSON[uiTenantDashboardUser](ctx, client, apiURL, "/v1/whoami", bearer, usernameHint)
 	if err != nil {
 		dashboard.APIError = err.Error()
-		return dashboard, nil
+		return
 	}
 	dashboard.User = &user
 	reviews, err := loadTenantDashboardJSON[[]uiTenantDashboardReview](ctx, client, apiURL, "/v1/reviews", bearer, usernameHint)
 	if err != nil {
 		dashboard.APIError = err.Error()
-		return dashboard, nil
+		return
 	}
 	dashboard.Reviews = reviews
 	mergeQueue, err := loadTenantDashboardJSON[[]uiTenantDashboardReview](ctx, client, apiURL, "/v1/reviews/merge-queue", bearer, usernameHint)
 	if err != nil {
 		dashboard.APIError = err.Error()
-		return dashboard, nil
+		return
 	}
 	dashboard.MergeQueue = mergeQueue
 	builds, err := loadTenantDashboardBuilds(ctx, client, apiURL, bearer, usernameHint, reviews)
 	if err != nil {
 		dashboard.APIError = err.Error()
-		return dashboard, nil
+		return
 	}
 	dashboard.Builds = builds
-	return dashboard, nil
 }
 
 func (a *App) tenantDashboardUsernameHint(alias string) string {
@@ -130,7 +138,7 @@ func loadTenantDashboardJSON[T any](ctx context.Context, client *http.Client, ap
 	if err != nil {
 		return result, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return result, fmt.Errorf("load tenant dashboard %s: %s", apiPath, resp.Status)
 	}

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -31,17 +31,25 @@ func (a *App) StartSession(selection uiSelection, slot, cols, rows int) (startSe
 	})
 }
 
-// runOpenSession is the original spawn logic for the ERun tab,
-// wrapped so the desktop action runner can call it on its turn.
-// Returns the result the Wails caller wants and the managedTerminal so
-// the runner can wait on its ready signal.
-func (a *App) runOpenSession(ctx context.Context, selection uiSelection, slot, cols, rows int) (startSessionResult, *managedTerminal, error) {
+// clampTerminalSize substitutes the default PTY geometry (120x34) for
+// any non-positive cols/rows the Wails caller passed, so every session
+// start path shares one fallback instead of repeating the guards.
+func clampTerminalSize(cols, rows int) (int, int) {
 	if cols <= 0 {
 		cols = 120
 	}
 	if rows <= 0 {
 		rows = 34
 	}
+	return cols, rows
+}
+
+// runOpenSession is the original spawn logic for the ERun tab,
+// wrapped so the desktop action runner can call it on its turn.
+// Returns the result the Wails caller wants and the managedTerminal so
+// the runner can wait on its ready signal.
+func (a *App) runOpenSession(ctx context.Context, selection uiSelection, slot, cols, rows int) (startSessionResult, *managedTerminal, error) {
+	cols, rows = clampTerminalSize(cols, rows)
 
 	key := openSessionKey(selection, slot)
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
@@ -129,12 +137,7 @@ func (a *App) StartLocalSession(selection uiSelection, slot, cols, rows int) (st
 	if selection.Tenant == "" || selection.Environment == "" {
 		return startSessionResult{}, fmt.Errorf("tenant and environment are required")
 	}
-	if cols <= 0 {
-		cols = 120
-	}
-	if rows <= 0 {
-		rows = 34
-	}
+	cols, rows = clampTerminalSize(cols, rows)
 
 	key := localSessionKey(selection, slot)
 
@@ -218,12 +221,7 @@ func (a *App) StartAISession(selection uiSelection, slot, cols, rows int) (start
 }
 
 func (a *App) runAISession(ctx context.Context, selection uiSelection, slot, cols, rows int) (startSessionResult, *managedTerminal, error) {
-	if cols <= 0 {
-		cols = 120
-	}
-	if rows <= 0 {
-		rows = 34
-	}
+	cols, rows = clampTerminalSize(cols, rows)
 
 	key := aiSessionKey(selection, slot)
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
@@ -424,16 +422,30 @@ func shellQuoteIfNeeded(value string) string {
 		return "''"
 	}
 	for _, r := range value {
-		switch {
-		case r >= 'A' && r <= 'Z':
-		case r >= 'a' && r <= 'z':
-		case r >= '0' && r <= '9':
-		case r == '-' || r == '_' || r == '.' || r == '/' || r == '=' || r == '+' || r == ':' || r == '@' || r == ',':
-		default:
+		if !shellQuoteSafeRune(r) {
 			return shellQuote(value)
 		}
 	}
 	return value
+}
+
+// shellQuoteSafePunct lists the punctuation runes that are safe to leave
+// unquoted in a shell command word alongside alphanumerics.
+const shellQuoteSafePunct = "-_./=+:@,"
+
+// shellQuoteSafeRune reports whether r can appear unquoted in a shell
+// command word. Anything outside this allow-list forces shellQuote.
+func shellQuoteSafeRune(r rune) bool {
+	switch {
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	default:
+		return strings.ContainsRune(shellQuoteSafePunct, r)
+	}
 }
 
 func (a *App) OpenIDE(selection uiSelection, ide string) error {
@@ -445,12 +457,32 @@ func (a *App) OpenIDE(selection uiSelection, ide string) error {
 	if ide != "vscode" && ide != "intellij" {
 		return fmt.Errorf("unsupported IDE %q", ide)
 	}
+	params, err := a.resolveOpenIDEParams(selection, ide)
+	if err != nil {
+		return err
+	}
+
+	ctx := a.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	output, err := a.deps.runIDECommand(ctx, params)
+	if err == nil {
+		return nil
+	}
+	return formatOpenIDEError(ide, output, err)
+}
+
+// resolveOpenIDEParams resolves the open target and builds the launch
+// params for `open <ide>`. Local repos launch the IDE directly; remote
+// repos go through `erun open` and require an sshd-enabled environment.
+func (a *App) resolveOpenIDEParams(selection uiSelection, ide string) (startTerminalSessionParams, error) {
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
 		Tenant:      selection.Tenant,
 		Environment: selection.Environment,
 	})
 	if err != nil {
-		return err
+		return startTerminalSessionParams{}, err
 	}
 
 	params := startTerminalSessionParams{
@@ -462,22 +494,19 @@ func (a *App) OpenIDE(selection uiSelection, ide string) error {
 	if !result.RemoteRepo() {
 		localParams, err := buildLocalOpenIDEParams(result, ide)
 		if err != nil {
-			return err
+			return startTerminalSessionParams{}, err
 		}
 		params = localParams
 		params.Env = []string{appSessionEnvVar + "=1"}
 	} else if !result.EnvConfig.SSHD.Enabled {
-		return fmt.Errorf("open %s requires sshd-enabled remote environment; run `erun sshd init %s %s` first", ide, selection.Tenant, selection.Environment)
+		return startTerminalSessionParams{}, fmt.Errorf("open %s requires sshd-enabled remote environment; run `erun sshd init %s %s` first", ide, selection.Tenant, selection.Environment)
 	}
+	return params, nil
+}
 
-	ctx := a.ctx
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	output, err := a.deps.runIDECommand(ctx, params)
-	if err == nil {
-		return nil
-	}
+// formatOpenIDEError wraps a non-nil runIDECommand error with the IDE
+// name, appending the trimmed command output as detail when present.
+func formatOpenIDEError(ide, output string, err error) error {
 	if detail := strings.TrimSpace(output); detail != "" {
 		return fmt.Errorf("open %s: %w: %s", ide, err, detail)
 	}
@@ -485,12 +514,7 @@ func (a *App) OpenIDE(selection uiSelection, ide string) error {
 }
 
 func (a *App) StartCloudInitAWSSession(cols, rows int) (startSessionResult, error) {
-	if cols <= 0 {
-		cols = 120
-	}
-	if rows <= 0 {
-		rows = 34
-	}
+	cols, rows = clampTerminalSize(cols, rows)
 	key := "cloud/init/aws"
 
 	a.mu.Lock()
@@ -805,8 +829,18 @@ func (a *App) CloseEnvironmentSessions(selection uiSelection) ([]int, error) {
 	if selection.Tenant == "" || selection.Environment == "" {
 		return nil, fmt.Errorf("tenant and environment are required")
 	}
+	targets := a.collectLiveSessionsForSelection(selection)
+	return closeManagedTerminals(targets)
+}
+
+// collectLiveSessionsForSelection gathers, under a.mu, every live
+// (non-nil, not-yet-closed) managed PTY bound to the supplied
+// (tenant, environment) pair. The lock is released before the caller
+// closes them — see CloseEnvironmentSessions for the deadlock rationale.
+func (a *App) collectLiveSessionsForSelection(selection uiSelection) []*managedTerminal {
 	var targets []*managedTerminal
 	a.mu.Lock()
+	defer a.mu.Unlock()
 	for _, managed := range a.sessions {
 		if managed == nil || managed.closed {
 			continue
@@ -819,7 +853,13 @@ func (a *App) CloseEnvironmentSessions(selection uiSelection) ([]int, error) {
 		}
 		targets = append(targets, managed)
 	}
-	a.mu.Unlock()
+	return targets
+}
+
+// closeManagedTerminals closes each target's underlying session and
+// returns the serial IDs that closed cleanly along with the first close
+// error encountered (if any). Targets with no session are skipped.
+func closeManagedTerminals(targets []*managedTerminal) ([]int, error) {
 	closed := make([]int, 0, len(targets))
 	var firstErr error
 	for _, managed := range targets {
@@ -967,31 +1007,7 @@ func (a *App) streamSession(managed *managedTerminal) {
 		}
 		count, err := current.Read(buffer)
 		if count > 0 {
-			payload := terminalOutputPayload{
-				SessionID: managed.serial,
-				Data:      base64.StdEncoding.EncodeToString(buffer[:count]),
-			}
-			a.emitEvent(terminalOutputEvent, payload)
-			a.feedActivityTraceFromTerminal(managed, buffer[:count])
-			a.recordAIActivity(managed)
-			if managed.clearIdleBlockOnOutput {
-				a.mu.Lock()
-				a.releaseIdleBlockLocked(managed)
-				a.mu.Unlock()
-			}
-			if time.Since(lastOutputActivity) >= 2*time.Second {
-				// While the session is waiting for the first user
-				// input after a respawn, ignore the output ticker.
-				// Reconnect noise (audit lines, "── reconnecting ──"
-				// banners, the output of a respawned `erun open`
-				// that fails again) must not refresh the idle
-				// marker — only real interaction does. A real
-				// keystroke clears the flag in SendSessionInput.
-				if !a.isAwaitingPostRespawnInput(managed) {
-					a.recordTerminalActivity(managed.selection)
-					lastOutputActivity = time.Now()
-				}
-			}
+			a.handleSessionOutput(managed, buffer[:count], &lastOutputActivity)
 		}
 		if err == nil {
 			continue
@@ -1000,31 +1016,72 @@ func (a *App) streamSession(managed *managedTerminal) {
 		if a.tryReconnect(managed, reason) {
 			continue
 		}
-		a.finalizeAIActivity(managed)
+		a.finalizeSessionExit(managed, reason)
+		return
+	}
+}
+
+// handleSessionOutput forwards one PTY read to the frontend, feeds the
+// activity-trace parser and the AI-activity debounce, releases the idle
+// block on first output, and refreshes the idle-activity marker no more
+// than once every 2s. lastOutputActivity is advanced in place when the
+// marker is refreshed.
+func (a *App) handleSessionOutput(managed *managedTerminal, chunk []byte, lastOutputActivity *time.Time) {
+	a.emitEvent(terminalOutputEvent, terminalOutputPayload{
+		SessionID: managed.serial,
+		Data:      base64.StdEncoding.EncodeToString(chunk),
+	})
+	a.feedActivityTraceFromTerminal(managed, chunk)
+	a.recordAIActivity(managed)
+	if managed.clearIdleBlockOnOutput {
 		a.mu.Lock()
-		managed.closed = true
-		if existing := a.sessions[managed.key]; existing == managed {
-			delete(a.sessions, managed.key)
-		}
 		a.releaseIdleBlockLocked(managed)
 		a.mu.Unlock()
-		a.emitEvent(terminalExitEvent, terminalExitPayload{
-			SessionID: managed.serial,
-			Reason:    reason,
-		})
-		// Release any action runner waiting on this session's ready
-		// signal. If the session never reached its setup-complete
-		// marker (e.g. process exited mid-build), the gate would
-		// otherwise hold until the action's hard timeout.
-		var readyErr error
-		if reason != "" {
-			readyErr = fmt.Errorf("%s", reason)
+	}
+	if time.Since(*lastOutputActivity) >= 2*time.Second {
+		// While the session is waiting for the first user
+		// input after a respawn, ignore the output ticker.
+		// Reconnect noise (audit lines, "── reconnecting ──"
+		// banners, the output of a respawned `erun open`
+		// that fails again) must not refresh the idle
+		// marker — only real interaction does. A real
+		// keystroke clears the flag in SendSessionInput.
+		if !a.isAwaitingPostRespawnInput(managed) {
+			a.recordTerminalActivity(managed.selection)
+			*lastOutputActivity = time.Now()
 		}
-		managed.signalReady(readyErr)
-		if reason == "" && strings.HasPrefix(managed.key, "sshd-init\x00") {
-			go a.startWorkspaceSyncForSelection(managed.selection)
-		}
-		return
+	}
+}
+
+// finalizeSessionExit tears down a managed PTY that streamSession could
+// not reconnect: it flips the AI busy latch off, removes the session
+// from the registry, releases its idle block, emits the exit event,
+// releases any action runner blocked on the ready signal, and kicks off
+// the post-sshd-init workspace sync on a clean exit.
+func (a *App) finalizeSessionExit(managed *managedTerminal, reason string) {
+	a.finalizeAIActivity(managed)
+	a.mu.Lock()
+	managed.closed = true
+	if existing := a.sessions[managed.key]; existing == managed {
+		delete(a.sessions, managed.key)
+	}
+	a.releaseIdleBlockLocked(managed)
+	a.mu.Unlock()
+	a.emitEvent(terminalExitEvent, terminalExitPayload{
+		SessionID: managed.serial,
+		Reason:    reason,
+	})
+	// Release any action runner waiting on this session's ready
+	// signal. If the session never reached its setup-complete
+	// marker (e.g. process exited mid-build), the gate would
+	// otherwise hold until the action's hard timeout.
+	var readyErr error
+	if reason != "" {
+		readyErr = fmt.Errorf("%s", reason)
+	}
+	managed.signalReady(readyErr)
+	if reason == "" && strings.HasPrefix(managed.key, "sshd-init\x00") {
+		go a.startWorkspaceSyncForSelection(managed.selection)
 	}
 }
 
@@ -1037,15 +1094,15 @@ func (a *App) currentSessionFor(managed *managedTerminal) terminalSession {
 	return managed.session
 }
 
-func (a *App) tryReconnect(managed *managedTerminal, exitReason string) bool {
-	a.mu.Lock()
-	if managed == nil || managed.closed || managed.respawn == nil {
-		a.mu.Unlock()
-		return false
-	}
-	respawn := managed.respawn
-	a.mu.Unlock()
-
+// reconnectRefused reports whether tryReconnect should decline to
+// respawn the managed PTY, emitting the matching terminal marker and env
+// status as a side effect. Each guard is a terminal condition (handover,
+// stopped cloud context, deploy failure, or a fast-exit loop) where an
+// automatic respawn would fight another actor or storm a broken env; the
+// user's recovery affordance is named in the emitted marker. A false
+// return means none of the terminal conditions apply and the caller may
+// respawn.
+func (a *App) reconnectRefused(managed *managedTerminal) bool {
 	// Another ERun window re-attached this persistent session — a
 	// deliberate handover, not a transient drop. Respawning would run
 	// `erun open` again, whose attach takes the session straight back,
@@ -1053,7 +1110,7 @@ func (a *App) tryReconnect(managed *managedTerminal, exitReason string) bool {
 	// Clicking the env in the sidebar is the deliberate take-back.
 	if a.sessionTakenOver(managed) {
 		a.emitTakenOverMarker(managed.serial)
-		return false
+		return true
 	}
 
 	// Refuse to respawn while the env's linked cloud context is not
@@ -1068,7 +1125,7 @@ func (a *App) tryReconnect(managed *managedTerminal, exitReason string) bool {
 	if !a.shouldRespawnForCloudContext(managed) {
 		a.emitStoppedContextMarker(managed.serial)
 		a.emitEnvStatus(managed.selection, envStatusStopped)
-		return false
+		return true
 	}
 
 	// A deploy failure is terminal, not a transient drop. Respawning
@@ -1083,7 +1140,7 @@ func (a *App) tryReconnect(managed *managedTerminal, exitReason string) bool {
 	if a.reconnectBlockedByDeployFailure(managed) {
 		a.emitDeployFailedMarker(managed.serial)
 		a.emitEnvStatus(managed.selection, envStatusFailed)
-		return false
+		return true
 	}
 
 	// The readyErr guard above only catches an open that emitted the
@@ -1097,7 +1154,7 @@ func (a *App) tryReconnect(managed *managedTerminal, exitReason string) bool {
 	if a.reconnectBlockedByActivityDeployFailure(managed) {
 		a.emitDeployFailedMarker(managed.serial)
 		a.emitEnvStatus(managed.selection, envStatusFailed)
-		return false
+		return true
 	}
 
 	// Cap consecutive fast-exit respawns. Without this, an env whose
@@ -1112,6 +1169,22 @@ func (a *App) tryReconnect(managed *managedTerminal, exitReason string) bool {
 	if a.trackExitForLoopGuard(managed) {
 		a.emitReconnectLoopMarker(managed.serial)
 		a.emitEnvStatus(managed.selection, envStatusFailed)
+		return true
+	}
+
+	return false
+}
+
+func (a *App) tryReconnect(managed *managedTerminal, exitReason string) bool {
+	a.mu.Lock()
+	if managed == nil || managed.closed || managed.respawn == nil {
+		a.mu.Unlock()
+		return false
+	}
+	respawn := managed.respawn
+	a.mu.Unlock()
+
+	if a.reconnectRefused(managed) {
 		return false
 	}
 

--- a/erun-ui/workspace_sync.go
+++ b/erun-ui/workspace_sync.go
@@ -108,23 +108,11 @@ func (a *App) runWorkspaceSyncLoop(ctx context.Context, key string, selection ui
 	}
 	for {
 		a.setWorkspaceSyncStatus(key, workspaceSyncStatus{Status: "syncing", Message: "Syncing workspace"})
-		if a.deps.canConnectLocalPort != nil && !a.deps.canConnectLocalPort(eruncommon.SSHLocalPortForResult(result)) && a.deps.ensureSSHD != nil {
-			if err := a.deps.ensureSSHD(ctx, result); err != nil {
-				a.setWorkspaceSyncError(key, err)
-				if !sleepWorkspaceSyncInterval(ctx, a.deps.workspaceSyncInterval) {
-					return
-				}
-				continue
-			}
-		}
-		if a.deps.workspaceSyncReady != nil {
-			if err := a.deps.workspaceSyncReady(ctx, params.HostAlias); err != nil {
-				a.setWorkspaceSyncStatus(key, workspaceSyncStatus{Status: "starting", Message: "Waiting for SSHD"})
-				if !sleepWorkspaceSyncInterval(ctx, a.deps.workspaceSyncInterval) {
-					return
-				}
-				continue
-			}
+		switch a.prepareWorkspaceSyncPass(ctx, key, result, params) {
+		case workspaceSyncPassStop:
+			return
+		case workspaceSyncPassRetry:
+			continue
 		}
 		synced, err := a.deps.syncWorkspace(ctx, params)
 		if err != nil {
@@ -141,6 +129,51 @@ func (a *App) runWorkspaceSyncLoop(ctx context.Context, key string, selection ui
 			return
 		}
 	}
+}
+
+// workspaceSyncPassOutcome tells runWorkspaceSyncLoop how to proceed after the
+// pre-sync readiness checks.
+type workspaceSyncPassOutcome int
+
+const (
+	// workspaceSyncPassProceed means the prerequisites are satisfied and the
+	// loop should run the sync.
+	workspaceSyncPassProceed workspaceSyncPassOutcome = iota
+	// workspaceSyncPassRetry means a prerequisite was not ready (the loop should
+	// continue to the next iteration after the interval has already elapsed).
+	workspaceSyncPassRetry
+	// workspaceSyncPassStop means the context was cancelled while waiting (the
+	// loop should return).
+	workspaceSyncPassStop
+)
+
+// prepareWorkspaceSyncPass runs the per-iteration readiness checks for the sync
+// loop: it ensures SSHD when the local port cannot be reached and waits for the
+// remote SSHD to answer. On any failure it records the worker status, sleeps one
+// interval, and reports whether the loop should retry or stop; otherwise it
+// reports proceed. Extracted so runWorkspaceSyncLoop stays under the cyclomatic
+// limit; the guard order, status writes, and sleep-driven continue/return
+// semantics are unchanged.
+func (a *App) prepareWorkspaceSyncPass(ctx context.Context, key string, result eruncommon.OpenResult, params workspaceSyncParams) workspaceSyncPassOutcome {
+	if a.deps.canConnectLocalPort != nil && !a.deps.canConnectLocalPort(eruncommon.SSHLocalPortForResult(result)) && a.deps.ensureSSHD != nil {
+		if err := a.deps.ensureSSHD(ctx, result); err != nil {
+			a.setWorkspaceSyncError(key, err)
+			if !sleepWorkspaceSyncInterval(ctx, a.deps.workspaceSyncInterval) {
+				return workspaceSyncPassStop
+			}
+			return workspaceSyncPassRetry
+		}
+	}
+	if a.deps.workspaceSyncReady != nil {
+		if err := a.deps.workspaceSyncReady(ctx, params.HostAlias); err != nil {
+			a.setWorkspaceSyncStatus(key, workspaceSyncStatus{Status: "starting", Message: "Waiting for SSHD"})
+			if !sleepWorkspaceSyncInterval(ctx, a.deps.workspaceSyncInterval) {
+				return workspaceSyncPassStop
+			}
+			return workspaceSyncPassRetry
+		}
+	}
+	return workspaceSyncPassProceed
 }
 
 func sleepWorkspaceSyncInterval(ctx context.Context, interval time.Duration) bool {
@@ -226,20 +259,12 @@ func syncWorkspaceOnce(ctx context.Context, params workspaceSyncParams) (workspa
 	if err := ensureLocalWorkspaceSyncTarget(ctx, params.LocalPath); err != nil {
 		return workspaceSyncResult{}, err
 	}
-	remotePaths, err := remoteWorkspaceGitVisibleFiles(ctx, params.HostAlias, params.RemotePath)
-	if errors.Is(err, errRemoteNotGitRepo) {
+	remotePaths, localPaths, notGitRepo, err := resolveWorkspaceSyncPaths(ctx, params)
+	if err != nil {
+		return workspaceSyncResult{}, err
+	}
+	if notGitRepo {
 		return workspaceSyncResult{}, nil
-	}
-	if err != nil {
-		return workspaceSyncResult{}, err
-	}
-	localPaths, err := localWorkspaceGitVisibleFiles(ctx, params.LocalPath)
-	if err != nil {
-		return workspaceSyncResult{}, err
-	}
-	remotePaths, err = filterLocalIgnoredWorkspaceSyncPaths(ctx, params.LocalPath, remotePaths)
-	if err != nil {
-		return workspaceSyncResult{}, err
 	}
 	if len(remotePaths) > 0 {
 		if err := extractRemoteWorkspaceFiles(ctx, params.HostAlias, params.RemotePath, params.LocalPath, remotePaths); err != nil {
@@ -251,6 +276,31 @@ func syncWorkspaceOnce(ctx context.Context, params workspaceSyncParams) (workspa
 		return workspaceSyncResult{}, err
 	}
 	return workspaceSyncResult{FilesCopied: len(remotePaths), FilesDeleted: deleted}, nil
+}
+
+// resolveWorkspaceSyncPaths lists the Git-visible files on the remote and local
+// sides for one sync pass, applying the local ignore filter to the remote set.
+// notGitRepo is true (with a nil error) when the remote workspace is not a Git
+// repository, which syncWorkspaceOnce treats as a no-op. Extracted so
+// syncWorkspaceOnce stays under the cyclomatic limit; the listing and filtering
+// order is unchanged.
+func resolveWorkspaceSyncPaths(ctx context.Context, params workspaceSyncParams) (remotePaths, localPaths []string, notGitRepo bool, err error) {
+	remotePaths, err = remoteWorkspaceGitVisibleFiles(ctx, params.HostAlias, params.RemotePath)
+	if errors.Is(err, errRemoteNotGitRepo) {
+		return nil, nil, true, nil
+	}
+	if err != nil {
+		return nil, nil, false, err
+	}
+	localPaths, err = localWorkspaceGitVisibleFiles(ctx, params.LocalPath)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	remotePaths, err = filterLocalIgnoredWorkspaceSyncPaths(ctx, params.LocalPath, remotePaths)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return remotePaths, localPaths, false, nil
 }
 
 func workspaceSyncSSHReady(ctx context.Context, hostAlias string) error {


### PR DESCRIPTION
Final module in the #571 repo-wide lint cleanup. Clears all 50 pre-existing `golangci-lint` findings in `erun-ui` by correcting the code — no rule suppression, no threshold change. **Behavior-preserving**: no exported/Wails method signature, event name, emitted payload, persisted field, CLI argv, output/error text, or control flow changed; **no frontend source touched**.

### Mechanical (8)
- errcheck: check the deferred/direct `resp.Body.Close` returns (`headlessserver/server_test.go` ×3, `tenant_dashboard.go` ×1).
- staticcheck: S1011 loop→`append(…)` (`ai_activity_test.go`), QF1002 tagged switch (`environment_working_issue_test.go`), ST1005 trailing-period error string (`idle_stop_mcp.go`).
- unused: delete the dead `activityStateEvent` type alias.
- `.golangci.yml`: exclude `^playwright/node_modules/` — gitignored third-party Go vendored inside the JS dependency tree. This mirrors the **existing** `^frontend/node_modules/` exclusion; it scopes the linter to first-party code, it is not a rule suppression.

### Complexity (42 cyclop/gocyclo)
Cohesive package-private (or `t.Helper()`) helpers extracted so each function drops under the limit while behaving identically — across `terminal_sessions.go`, `activity_queue_app.go` (**trace-line matchers preserved verbatim** — the desktop activity queue depends on them), `activity_recovery.go`, `action_runner.go`, the `contribute_*` files, `cloud_credentials_refresher.go`, `config_watcher.go`, `deploy_orchestration.go`, `workspace_sync.go`, `idle_status.go`, `session.go` (**`buildInitArgs` argv byte-identical**), `runtime_resources.go`, `mcp_errors.go`, `main.go`, `headlessserver/server.go`, `app.go` (every dependency default preserved), `tenant_dashboard.go`, `environment_config.go` (`SaveEnvironmentConfig` persistence scope/order preserved), and six test files.

## Validation
- `erun-ui`: `golangci-lint run ./...` → **exit 0**; `go build ./...` clean; `go test ./...` → both packages **green** (excluding the pre-existing, sandbox-specific `TestCloseReapsWholeProcessGroup`, which exercises real-subprocess `killpg` reaping — no coupling to this change).

## UX impact / Playwright
None. Internal-helper extraction with no observable frontend surface (no `.ts`/`.tsx` changed, no Wails-exported signature/event/payload changed — `StartContributeApp`, `SaveEnvironmentConfig`, `LoadTenantDashboard`, etc. are byte-identical). Per `erun-ui/AGENTS.md`, the Playwright suite is not required for a change with zero observable surface.

## This completes #571
With this merged, **`golangci-lint run ./...` is exit 0 across the whole repo** (erun-cli, erun-common, erun-mcp, erun-ui, erun-integration).

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)