### PR TITLE
Gate golangci-lint in the build (image test stage + erun-ui build)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,20 @@
-.PHONY: integration-test
+.PHONY: integration-test lint check
+
+# Go modules linted by the in-build gate. erun-ui is intentionally excluded:
+# it needs the CGO/webkit + frontend toolchain the erun-devops build image does
+# not carry, so its golangci-lint gate lives in erun-ui/build.sh instead.
+LINT_MODULES := erun-common erun-cli erun-mcp erun-integration
+
+# Run golangci-lint across the gated modules, each against its own
+# .golangci.yml (erun-integration has none, so it uses the default linters).
+# Stops at the first module with findings so the build fails with a clear,
+# scoped error. golangci-lint must be on PATH (the image test stage installs
+# it; locally, install the pinned version or run `make integration-test`).
+lint:
+	@for m in $(LINT_MODULES); do \
+		echo ">> golangci-lint $$m"; \
+		(cd $$m && golangci-lint run ./...) || exit 1; \
+	done
 
 # Build, run, and coverage-gate the erun integration suite.
 # The coverage threshold defaults to the value pinned in
@@ -7,3 +23,7 @@
 # place.
 integration-test:
 	./erun-integration/scripts/integration-test.sh
+
+# The full in-build gate: golangci-lint, then the integration suite + coverage.
+# The erun-devops image test stage runs this; a failure tags no image.
+check: lint integration-test

--- a/erun-devops/docker/erun-devops/Dockerfile
+++ b/erun-devops/docker/erun-devops/Dockerfile
@@ -9,15 +9,29 @@ FROM --platform=$BUILDPLATFORM golang:1.26.0 AS test
 
 WORKDIR /src
 
+# Build golangci-lint from source against this stage's Go toolchain — same
+# reason as the builder stage: a prebuilt binary's embedded analyzer libraries
+# (go/ast, go/types, go/parser) drift behind erun's go.mod Go version and abort
+# with "go language version used to build golangci-lint is lower than the
+# targeted Go version". Installed before the source COPYs (stable, expensive)
+# so source changes do not invalidate this layer. Pinned repo-wide.
+ARG GOLANGCI_LINT_VERSION=v2.2.2
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOBIN=/usr/local/bin go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
+
 COPY Makefile /src/Makefile
 COPY erun-cli /src/erun-cli
 COPY erun-common /src/erun-common
 COPY erun-mcp /src/erun-mcp
 COPY erun-integration /src/erun-integration
 
+# `make check` runs golangci-lint across the Go modules then the integration
+# suite + coverage gate. A failing lint or test fails the build, the builder
+# stage's COPY --from=test /test-ok fails, and no image is tagged.
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    make integration-test && touch /test-ok
+    make check && touch /test-ok
 
 FROM golang:1.26.0 AS builder
 

--- a/erun-ui/build.sh
+++ b/erun-ui/build.sh
@@ -55,6 +55,11 @@ if [ -d frontend ]; then
 		"$YARN_BIN" typecheck
 		"$YARN_BIN" lint
 		"$YARN_BIN" format:check
+		# Go-side lint gate. erun-ui's Go module is not built by the
+		# erun-devops image (it needs this CGO/webkit + frontend toolchain),
+		# so its golangci-lint gate lives here next to the frontend checks
+		# rather than in the shared `make check` the image runs.
+		(cd "$SCRIPT_DIR" && golangci-lint run ./...)
 	fi
 	"$YARN_BIN" build
 	cd "$SCRIPT_DIR"


### PR DESCRIPTION
#571 cleared every `golangci-lint` finding repo-wide — but nothing re-ran the linter, so it would silently drift back. The integration suite is already gated in the build (the `erun-devops` image `test` stage runs it, and the builder stage depends on its `/test-ok` marker — a failing gate fails the build and tags no image). This change gives lint the same enforcement, so a green build is a lint-clean build.

## Changes
- **`Makefile`**: `lint` (golangci-lint across `erun-common`, `erun-cli`, `erun-mcp`, `erun-integration`) and `check` (`lint` + `integration-test`).
- **`erun-devops` image test stage**: install golangci-lint **from source** against the stage's Go toolchain — the same thing the builder stage already does, because a prebuilt binary's embedded analyzer libs drift behind `go.mod`'s Go version. Installed before the source `COPY`s so the layer stays cached; runs `make check` in place of `make integration-test`. A lint/test failure fails the build → `COPY --from=test /test-ok` fails → no image.
- **`erun-ui/build.sh`**: erun-ui isn't built by that image (it needs the CGO/webkit + frontend toolchain the build image lacks), so its `golangci-lint run ./...` gate lives in `build.sh` alongside the frontend checks, under the same escapable `ERUN_SKIP_LINT`.

Pinned to **golangci-lint v2.2.2** (matches what the builder stage installs). No hosted CI required (#521) — every erun-driven build re-runs the gate.

## Validation (end-to-end)
`docker build --target test` against the real Dockerfile:
```
>> golangci-lint erun-common      0 issues.
>> golangci-lint erun-cli         0 issues.
>> golangci-lint erun-mcp         0 issues.
>> golangci-lint erun-integration 0 issues.
ok  coverage 77.4% (>= 75.0%)
naming to docker.io/library/erun-test-stage-verify done
```
Lint runs inside the build and gates it; the integration suite still runs after. `make lint` is green locally. (Probe image cleaned up.)

> Note: `erun-ui/build.sh` itself wasn't run end-to-end here — it builds the full Wails desktop app — but the added `golangci-lint run ./...` is verified exit 0 against `erun-ui` in isolation, and it sits inside the existing gate block.

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)