### PR TITLE
Self-heal desktop sidebar refresh after env init

### DIFF
--- a/erun-ui/frontend/src/app/bootThunks.ts
+++ b/erun-ui/frontend/src/app/bootThunks.ts
@@ -50,10 +50,15 @@ export const boot = (): AppThunk<Promise<void>> => async (dispatch, getState) =>
 // contexts to seed from.
 export const reloadStateAfterEnvironmentChange =
   (): AppThunk<Promise<void>> => async (dispatch, getState) => {
+    // initiate() registers a cache subscription that must be released, or
+    // repeated reloads (e.g. handleEnvironmentInitialized's retry loop) leak
+    // subscriptions and eventually stall RTK Query so a later refetch never
+    // resolves. Hold the request handle and unsubscribe in finally.
+    const request = dispatch(
+      stateApi.endpoints.getInitialState.initiate(undefined, { forceRefetch: true }),
+    );
     try {
-      const loaded = await dispatch(
-        stateApi.endpoints.getInitialState.initiate(undefined, { forceRefetch: true }),
-      ).unwrap();
+      const loaded = await request.unwrap();
       const current = getState().tenants;
       dispatch(setTenants(loaded.tenants));
       dispatch(setCloudProviders(loaded.cloudProviders ?? current.cloudProviders));
@@ -62,7 +67,15 @@ export const reloadStateAfterEnvironmentChange =
           normalizeVersionSuggestions(loaded.versionSuggestions ?? current.versionSuggestions),
         ),
       );
-    } catch {
-      // Silent failure: env-change reloads are best-effort.
+    } catch (error) {
+      // Env-change reloads are best-effort, but swallowing the failure
+      // silently used to leave the sidebar stale after a successful
+      // `erun init` with no diagnostic at all. Log it so a failed refresh is
+      // visible in the dev console / ErrorBoundary diagnostics; callers that
+      // depend on the new env surfacing (handleEnvironmentInitialized) retry
+      // rather than trusting a single best-effort pass.
+      console.error('reloadStateAfterEnvironmentChange failed:', error);
+    } finally {
+      request.unsubscribe();
     }
   };

--- a/erun-ui/frontend/src/app/wailsEventThunks.ts
+++ b/erun-ui/frontend/src/app/wailsEventThunks.ts
@@ -110,6 +110,44 @@ export const handleAppNotification =
     dispatch(showNotification(kind, message));
   };
 
+// Bounded retry budget for surfacing a just-initialized env. The
+// `==> Initialized` trace fires only after `erun init` has written the
+// tenant/env config to disk, so the env is on disk by the time we reload.
+// A single reload can still miss it though: a transient getInitialState
+// failure (swallowed as best-effort by reloadStateAfterEnvironmentChange)
+// or a reload that coalesced with the fsnotify watcher's near-simultaneous
+// refresh leaves the sidebar stale with no other recovery for the targeted
+// init signal — the regression class in erun-ui/AGENTS.md § "Command
+// Completion And State-Refresh Wiring". Retrying until the known env
+// appears makes a missed first refresh self-heal instead of silently
+// dropping the new environment. The first attempt has no delay, so the
+// happy path (env already visible) adds no latency.
+const ENVIRONMENT_INIT_RELOAD_ATTEMPTS = 3;
+const ENVIRONMENT_INIT_RELOAD_DELAY_MS = 400;
+
+const delayMs = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+
+// reloadUntilEnvironmentVisible refreshes the read model until the named env
+// surfaces in state.tenants, or the attempt budget is exhausted. Returns
+// whether the env became visible.
+const reloadUntilEnvironmentVisible =
+  (tenant: string, environment: string): AppThunk<Promise<boolean>> =>
+  async (dispatch, getState) => {
+    for (let attempt = 0; attempt < ENVIRONMENT_INIT_RELOAD_ATTEMPTS; attempt += 1) {
+      if (attempt > 0) {
+        await delayMs(ENVIRONMENT_INIT_RELOAD_DELAY_MS);
+      }
+      await dispatch(reloadStateAfterEnvironmentChange());
+      if (selectEnvironmentExists(getState(), tenant, environment)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
 // Fires when the backend's PTY trace handler observes
 // `==> Initialized <tenant>/<env>` from a piped `erun init` command, or
 // when the config-file watcher detects a new env. Reload state so the new
@@ -119,14 +157,24 @@ export const handleAppNotification =
 // "Command Completion And State-Refresh Wiring".
 export const handleEnvironmentInitialized =
   (payload: EnvironmentInitializedPayload): AppThunk<Promise<void>> =>
-  async (dispatch, getState) => {
+  async (dispatch) => {
     const tenant = payload.tenant.trim();
     const environment = payload.environment.trim();
     if (!tenant || !environment) {
       return;
     }
-    await dispatch(reloadStateAfterEnvironmentChange());
-    if (!selectEnvironmentExists(getState(), tenant, environment)) {
+    const visible = await dispatch(reloadUntilEnvironmentVisible(tenant, environment));
+    if (!visible) {
+      // The success trace fired (init wrote the config), but the env never
+      // surfaced in the read model after repeated refreshes. Surface a
+      // recoverable error instead of leaving the user staring at a sidebar
+      // that silently dropped their new environment (Nielsen #1 + #9).
+      dispatch(
+        showNotification(
+          'error',
+          `Created ${tenant} / ${environment}, but it did not appear in the sidebar. Reopen ERun to refresh.`,
+        ),
+      );
       return;
     }
     dispatch(showNotification('success', `Created ${tenant} / ${environment}.`));

--- a/erun-ui/playwright/fixtures/seedRoot.ts
+++ b/erun-ui/playwright/fixtures/seedRoot.ts
@@ -212,6 +212,28 @@ export function removeEnvironment(tenant: string, environment: string): void {
   fs.rmSync(path.join(erunConfigDir(), tenant, environment), { recursive: true, force: true });
 }
 
+// seedTenant writes a brand-new tenant's config.yaml (name + default
+// environment) — the minimum ListTenantConfigs needs to surface the tenant
+// at all (a tenant dir with no config.yaml is skipped as uninitialized).
+// Mirrors what `erun init` writes for a new tenant (see createTenantConfig in
+// erun-common/init.go). Pair with seedEnvironment to add the tenant's
+// environments, and removeTenant to clean up afterwards.
+export function seedTenant(tenant: string, defaultEnvironment: string): void {
+  const tenantDir = path.join(erunConfigDir(), tenant);
+  fs.mkdirSync(tenantDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(tenantDir, 'config.yaml'),
+    `name: ${tenant}\n` + `defaultenvironment: ${defaultEnvironment}\n`,
+  );
+}
+
+// removeTenant deletes a previously seeded tenant config dir (the tenant and
+// all of its environments). The backend's fsnotify config watcher picks the
+// deletion up and drops the sidebar rows.
+export function removeTenant(tenant: string): void {
+  fs.rmSync(path.join(erunConfigDir(), tenant), { recursive: true, force: true });
+}
+
 // removeIsolatedRoot deletes the whole suite-owned root. Only roots the
 // suite recognizably created are removed, so a caller-provided custom path
 // is never destroyed by accident.

--- a/erun-ui/playwright/tests/env-init-refresh.spec.ts
+++ b/erun-ui/playwright/tests/env-init-refresh.spec.ts
@@ -1,0 +1,87 @@
+import type { Page } from '@playwright/test';
+
+import { test, expect } from '../fixtures/erunApp.js';
+import {
+  removeTenant,
+  seedEnvironment,
+  seedTenant,
+  uniqueEnvironmentName,
+} from '../fixtures/seedRoot.js';
+
+// emitWailsEvent fires a backend event into the headless bridge, the same way
+// env-init.spec drives 'environments-changed'. The desktop's PTY trace
+// handler emits 'environment-initialized' (with a {tenant, environment}
+// payload) after observing `==> Initialized <tenant>/<env>` in the Local
+// shell; firing it here exercises handleEnvironmentInitialized directly,
+// which the real `erun init` flow cannot reach in this harness (the kubectl
+// stub fails namespace-ensure, so a live local-agent init never completes).
+async function emitWailsEvent(page: Page, name: string, payload?: unknown): Promise<void> {
+  await page.evaluate(
+    ({ name, payload }) => {
+      const runtime = (
+        window as unknown as { runtime: { EventsEmit: (n: string, ...a: unknown[]) => void } }
+      ).runtime;
+      if (payload === undefined) {
+        runtime.EventsEmit(name);
+      } else {
+        runtime.EventsEmit(name, payload);
+      }
+    },
+    { name, payload },
+  );
+}
+
+test.describe('environment init refresh', () => {
+  test('environment-initialized surfaces a brand-new tenant row and confirms with a toast', async ({
+    app,
+  }) => {
+    // Reproduces the reported scenario: `erun init` creates a brand-new
+    // tenant + env, then the desktop's init-complete signal must make it
+    // appear in the sidebar. The config is written first (so the handler's
+    // reload sees it), then the targeted event fires. The success toast is
+    // the handler-only signal — the fsnotify watcher's reload surfaces the
+    // row but shows no toast — so asserting the toast proves
+    // handleEnvironmentInitialized ran to completion, not just that the row
+    // appeared by some other path.
+    const tenant = uniqueEnvironmentName('init-tenant');
+    const environment = 'local';
+    seedTenant(tenant, environment);
+    seedEnvironment(tenant, environment);
+    try {
+      await emitWailsEvent(app.page, 'environment-initialized', { tenant, environment });
+
+      // Assert the transient success toast first — it auto-dismisses after a
+      // few seconds, whereas the row is persistent.
+      await expect(app.titlebar.statusMessage()).toContainText(
+        `Created ${tenant} / ${environment}`,
+        { timeout: 10_000 },
+      );
+      await expect(app.sidebar.envRowButton(tenant, environment)).toBeVisible({ timeout: 10_000 });
+    } finally {
+      removeTenant(tenant);
+    }
+  });
+
+  test('environment-initialized surfaces a recoverable error when the env never appears', async ({
+    app,
+  }) => {
+    // Regression guard for the silent-stale-sidebar bug: a transient reload
+    // miss (best-effort and swallowed by reloadStateAfterEnvironmentChange)
+    // used to leave the sidebar stale with no feedback at all. The handler
+    // now retries and, when the env still never surfaces, raises a
+    // recoverable error instead of nothing (Nielsen #1 + #9). Firing the
+    // event for an env that was never written drives the
+    // bounded-retry-then-observe path deterministically: nothing is on disk,
+    // so the watcher never surfaces it either, and the old code path would
+    // have shown no toast.
+    const tenant = uniqueEnvironmentName('ghost-tenant');
+    const environment = 'local';
+    await emitWailsEvent(app.page, 'environment-initialized', { tenant, environment });
+
+    await expect(app.titlebar.statusMessage()).toContainText('did not appear in the sidebar', {
+      timeout: 15_000,
+    });
+    await expect(app.sidebar.envRowButton(tenant, environment)).toHaveCount(0);
+    await app.titlebar.dismissStatus();
+  });
+});


### PR DESCRIPTION
## Summary

After `erun init` runs through the desktop's Local shell, the new tenant/env sometimes never appeared in the sidebar even though the env was fully written to disk and the backend read model returned it. The on-disk config, the shared list logic (`ListTenantConfigs`), and the sidebar render path are all correct — the gap was the refresh, which had no resilience or observability:

- `handleEnvironmentInitialized` did a single reload and returned **silently** if the env wasn't visible yet, so any transient miss (an early read, or a reload coalescing with the fsnotify watcher's near-simultaneous refresh) left the sidebar stale forever, with the watcher as the only backstop.
- `reloadStateAfterEnvironmentChange` swallowed reload failures in a bare `catch {}` with no diagnostic.

## Fix

- `handleEnvironmentInitialized` now reloads until the just-initialized env surfaces (`reloadUntilEnvironmentVisible`: 3 bounded attempts, first with no delay so the happy path adds no latency). If it still never appears, it raises a **recoverable error toast** instead of returning silently.
- `reloadStateAfterEnvironmentChange` releases the RTK Query subscription it opens (`unsubscribe` in `finally`) — repeated reloads otherwise leak subscriptions and stall RTK Query so a later refetch never resolves — and logs failures via `console.error` instead of swallowing them.

## Tests

- `erun-ui/playwright/tests/env-init-refresh.spec.ts` (new): a brand-new tenant surfaces in the sidebar with a success toast on the targeted init signal; and a never-appearing env yields a recoverable error toast (the old silent path showed nothing). A real `erun init` can't be driven through the headless harness (its kubectl stub fails namespace-ensure), so the spec fires the same `environment-initialized` Wails event the PTY trace handler emits.
- `seedRoot.ts` gains `seedTenant`/`removeTenant` to stage and tear down a brand-new tenant.

## UX Impact Review

1. **Affected paths:** `environment-initialized` event → `handleEnvironmentInitialized` → sidebar reload; `environments-changed` / env-delete → `reloadStateAfterEnvironmentChange`.
2. **Sequence:** init completes → new tenant/env row appears → success toast → env opens. On persistent failure → error toast naming a recovery.
3. **State→affordance:** `setTenants` → sidebar rows; toast → titlebar pill. No mutation without a visible consequence.
4/5. **Visibility + failure feedback (Nielsen #1/#9):** success toast kept; the previously-silent miss now has an actionable error toast.
6. **Consistency:** mirrors `handleEnvironmentInitFailed`'s error-toast pattern.
8. **Playwright:** `env-init-refresh.spec.ts` (2 tests) added in this PR.

## Validation

`yarn typecheck`/`lint`/`format:check`/`build` clean; Playwright suite green (the only failures are pre-existing host-flaky specs, #525, confirmed identical on `main`). Frontend-only — no Go / `erun-common` / `erun-cli` change, so docs and the integration gate are unaffected.

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)
