### PR TITLE
Fail clearly instead of hanging when gh scope refresh can't run headlessly

### DIFF
--- a/erun-cli/cmd/build.go
+++ b/erun-cli/cmd/build.go
@@ -310,7 +310,10 @@ func addPushCommandTargetFlags(cmd *cobra.Command, target *common.DockerCommandT
 // still fails with a scope error (the stored gh token itself lacks the
 // scope), it runs `gh auth refresh -s write:packages,read:packages`
 // interactively and retries once more. The user only types a one-time
-// device code; the rest is automated.
+// device code; the rest is automated. In a headless runtime pod or any
+// non-interactive context that escalation cannot complete, so
+// RefreshGHCRPackageScopes returns an actionable error instead of launching
+// the flow (#587) and that error surfaces here as finalErr.
 func handleNamespaceAuthError(authErr common.DockerRegistryAuthError, retry func() error, stdin io.Reader, stdout, stderr io.Writer) (bool, error) {
 	if !common.IsDockerCreatePackageDenied(authErr.Message) && !common.IsDockerScopeDenied(authErr.Message) {
 		return false, nil

--- a/erun-common/build_docker_commands.go
+++ b/erun-common/build_docker_commands.go
@@ -534,6 +534,13 @@ func captureGHCommand(args ...string) (string, error) {
 // (gh not installed, non-ghcr tag, missing namespace), and (false, err)
 // for gh or docker errors.
 //
+// When the context cannot complete an interactive browser login — a
+// chart-injected runtime pod (headless, no browser) or any non-interactive
+// stdin (MCP, CI, pipes) — it does not launch gh and returns (false, err)
+// with the actionable recovery error from newNonInteractiveGHCRScopeRefreshError,
+// so the caller fails clearly with the manual recovery commands instead of
+// stranding the operator on a device-code prompt that can never advance (#587).
+//
 // Use this only after TryGHCRNamespaceLogin + retry fails with a
 // scope-denied error: that signals the gh-stored token itself lacks the
 // scope, and the only remedy is replacing the token.
@@ -547,6 +554,16 @@ func RefreshGHCRPackageScopes(tag string, stdin io.Reader, stdout, stderr io.Wri
 	}
 	if _, err := exec.LookPath("gh"); err != nil {
 		return false, nil
+	}
+
+	// gh auth switch/refresh/login below all drive (or depend on) gh's
+	// interactive browser device-code flow. In a headless runtime pod there is
+	// no browser, and in any non-interactive context (MCP, CI, pipes) there is
+	// no operator at the prompt — launching the flow there hangs forever. Bail
+	// out before mutating any gh state and tell the operator exactly how to
+	// widen the scope from a host shell with a browser.
+	if !interactiveGHAuthAllowed(stdin) {
+		return false, newNonInteractiveGHCRScopeRefreshError(tag, namespace)
 	}
 
 	switchCmd := Command("gh", "auth", "switch", "-h", "github.com", "-u", namespace)
@@ -572,6 +589,64 @@ func RefreshGHCRPackageScopes(tag string, stdin io.Reader, stdout, stderr io.Wri
 	}
 
 	return TryGHCRNamespaceLogin(tag, stdout, stderr)
+}
+
+// interactiveGHAuthAllowed reports whether RefreshGHCRPackageScopes may launch
+// gh's interactive browser device-code flow. It is false in a chart-injected
+// runtime pod (headless — even the desktop terminal is a pod shell with a PTY,
+// but there is no browser to complete the device flow) and in any context
+// where stdin is not a real terminal (MCP, CI, pipes). The in-pod check comes
+// first so the PTY-backed pod shell is still treated as headless.
+//
+// ERUN_FORCE_TTY=1 is the same deliberate test seam the CLI uses
+// (writerIsTerminal) so the integration harness, whose stdin is always a pipe,
+// can still exercise the interactive success path.
+func interactiveGHAuthAllowed(stdin io.Reader) bool {
+	if inInjectedRuntimePod() {
+		return false
+	}
+	if os.Getenv("ERUN_FORCE_TTY") == "1" {
+		return true
+	}
+	file, ok := stdin.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := file.Stat()
+	return err == nil && (info.Mode()&os.ModeCharDevice) != 0
+}
+
+// inInjectedRuntimePod reports whether the process is running inside the
+// chart-injected runtime pod, detected the same way ResolveInjectedRuntimeConfig
+// does: the entrypoint sets both ERUN_TENANT and ERUN_ENVIRONMENT for every
+// runtime pod, and nothing else does.
+func inInjectedRuntimePod() bool {
+	return strings.TrimSpace(os.Getenv("ERUN_TENANT")) != "" &&
+		strings.TrimSpace(os.Getenv("ERUN_ENVIRONMENT")) != ""
+}
+
+// newNonInteractiveGHCRScopeRefreshError builds the actionable error returned
+// when the scope-refresh escalation cannot run its interactive gh flow. It
+// names the missing write:packages scope and the exact commands to run from a
+// host shell with a browser, so the operator has a clear path forward instead
+// of a hung prompt (#587).
+func newNonInteractiveGHCRScopeRefreshError(tag, namespace string) error {
+	registry := dockerRegistryFromImageTag(tag)
+	if registry == "" {
+		registry = "ghcr.io"
+	}
+	reason := "stdin is not an interactive terminal"
+	if inInjectedRuntimePod() {
+		reason = "this runtime pod is headless and has no browser"
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s rejected the push: the gh-stored token lacks the write:packages scope.\n\n", registry)
+	fmt.Fprintf(&sb, "erun can widen the scope automatically, but that needs gh's interactive browser login, which cannot run here (%s).\n", reason)
+	sb.WriteString("From a host shell signed in to the namespace owner's GitHub account, with a browser available, run:\n")
+	fmt.Fprintf(&sb, "  gh auth refresh -h github.com -u %s -s write:packages,read:packages\n", namespace)
+	fmt.Fprintf(&sb, "  gh auth token -u %s -h github.com | docker login %s -u %s --password-stdin\n", namespace, registry, namespace)
+	sb.WriteString("then re-run erun push.")
+	return errors.New(sb.String())
 }
 
 // TryGHCRNamespaceLogin re-authenticates docker to ghcr.io as the GitHub user

--- a/erun-docs/docs/agent-reference/cli-flags.md
+++ b/erun-docs/docs/agent-reference/cli-flags.md
@@ -210,10 +210,22 @@ When `docker push` returns one of these registry-side error strings, `erun push`
 | `unauthorized` | Re-runs `docker login <registry>` interactively (TTY required). |
 | `denied` | Same. |
 | `insufficient_scope` | Same. |
-| `does not match expected scopes` (GHCR-specific) | Invokes `gh auth refresh -s write:packages,read:packages` and retries. |
+| `does not match expected scopes` (GHCR-specific) | Invokes `gh auth refresh -s write:packages,read:packages` and retries. Requires an interactive browser login (see gating below). |
 | `permission_denied` (GHCR-specific) | Same as above. |
 
-If no TTY is attached, the retry skips the login prompt and surfaces the original error.
+If no TTY is attached, the generic `docker login` retry skips the login prompt and surfaces the original error.
+
+The GHCR scope refresh has a stricter gate: it drives `gh`'s interactive browser device-code flow, so `erun push` never launches it when there is no browser or no operator at the prompt. It is skipped when **either**:
+
+- the process runs inside the chart-injected runtime pod (`ERUN_TENANT` and `ERUN_ENVIRONMENT` set) — headless, no browser, even though the desktop terminal is a PTY-backed pod shell; or
+- `stdin` is not an interactive terminal (MCP, CI, pipes).
+
+When the refresh is skipped, `erun push` does **not** hang on a device-code prompt. It fails with an actionable error naming the missing `write:packages` scope and the exact commands to run from a host shell with a browser:
+
+```
+gh auth refresh -h github.com -u <owner> -s write:packages,read:packages
+gh auth token -u <owner> -h github.com | docker login ghcr.io -u <owner> --password-stdin
+```
 
 ### Error codes
 

--- a/erun-docs/docs/cli/push.md
+++ b/erun-docs/docs/cli/push.md
@@ -52,7 +52,7 @@ erun push --version 1.0.81-snapshot-20260616120000 --dry-run
 
 ## Authentication
 
-If the registry rejects the push as unauthorised, `erun push` retries automatically with an interactive `docker login` prompt; for GHCR, a scope-mismatch additionally triggers `gh auth refresh -s write:packages,read:packages`. Both retries require a TTY. Full retry-trigger pattern table: [Agent reference · CLI flag spec · `erun push` authentication](/agent-reference/cli-flags#erun-push).
+If the registry rejects the push as unauthorised, `erun push` retries automatically with an interactive `docker login` prompt; for GHCR, a scope-mismatch additionally triggers `gh auth refresh -s write:packages,read:packages`. Both retries need an interactive terminal, and the GHCR scope refresh is skipped entirely inside a runtime pod — that shell has no browser to complete the login, even though it looks like a terminal. When the scope refresh can't run, the push fails with an error that names the missing `write:packages` scope and the exact `gh auth refresh` + `docker login` commands to run from a host shell with a browser. Full retry-trigger pattern table: [Agent reference · CLI flag spec · `erun push` authentication](/agent-reference/cli-flags#erun-push).
 
 ## Error behaviour
 
@@ -61,5 +61,5 @@ If the registry rejects the push as unauthorised, `erun push` retries automatica
 | No `--version`. | Errors before any work: `push requires a version` — push publishes a specific version, it does not mint one. Exit code 1. |
 | No build context to publish. | Errors; nothing is pushed. |
 | Foreign-arch binfmt missing. | Fails before the per-arch build with a direct error. |
-| Registry rejects the push as unauthorised. | Retries with `docker login` (and `gh auth refresh` for GHCR scope mismatches); both need a TTY. Without one, errors with the auth failure. |
+| Registry rejects the push as unauthorised. | Retries with `docker login` (and `gh auth refresh` for GHCR scope mismatches); both need an interactive terminal, and the GHCR scope refresh is also skipped inside a runtime pod (no browser). Without one, errors — for a GHCR scope mismatch with the exact `gh auth refresh` + `docker login` recovery commands. |
 | Chart `helm push` or the `helm pull` verification fails. | Errors after the images pushed; the version's images are published but its chart is not, so it is not yet deployable. Re-run `erun push --version <version>` once the registry/auth issue is fixed. |

--- a/erun-docs/docs/reference/troubleshooting.md
+++ b/erun-docs/docs/reference/troubleshooting.md
@@ -31,8 +31,8 @@ kubectl logs -n <tenant>-<env> <pod> -c erun-devops --tail=200
 
 **Fix path:**
 
-1. `erun push` will retry automatically with an interactive `docker login`. If you're not in a TTY, that retry fails silently — run `docker login <registry>` once by hand and retry.
-2. For GHCR, the token needs `write:packages`. `gh auth refresh -s write:packages` fixes most cases.
+1. `erun push` will retry automatically with an interactive `docker login`. If you're not in a TTY, that retry is skipped — run `docker login <registry>` once by hand and retry.
+2. For GHCR, the token needs `write:packages`. `erun push` tries to widen it automatically with `gh auth refresh -s write:packages,read:packages`, but that needs an interactive browser login — so it's skipped in CI, over MCP, and inside a runtime pod (the desktop terminal is a pod shell with no browser). When it's skipped, the push fails with the exact recovery commands. Run them from a host shell with a browser: `gh auth refresh -h github.com -u <owner> -s write:packages,read:packages` then `gh auth token -u <owner> -h github.com | docker login ghcr.io -u <owner> --password-stdin`.
 3. For ECR, the token expires after 12 hours. `aws ecr get-login-password --region <r> | docker login --username AWS --password-stdin <account>.dkr.ecr.<r>.amazonaws.com`.
 
 ## "kubernetes context not found"

--- a/erun-integration/internal/erun/erun.go
+++ b/erun-integration/internal/erun/erun.go
@@ -203,9 +203,13 @@ func Run(t testing.TB, args []string, opts RunOptions) Result {
 	env = append(env, opts.Env...)
 	env = append(env, CoverDirEnv+"="+coverDir)
 	cmd.Env = env
-	if opts.Stdin != "" {
-		cmd.Stdin = bytes.NewBufferString(opts.Stdin)
-	}
+	// Always feed stdin from a buffer (empty when the scenario passes no
+	// Stdin) so the subprocess never inherits the developer's terminal. This
+	// keeps stdin a non-terminal pipe locally, matching CI's /dev/null stdin,
+	// so stdin-TTY-gated branches (e.g. the #587 interactive-gh-auth gate)
+	// behave the same everywhere. Scenarios that need the interactive branch
+	// opt in explicitly via the ERUN_FORCE_TTY seam.
+	cmd.Stdin = bytes.NewBufferString(opts.Stdin)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/erun-integration/push_test.go
+++ b/erun-integration/push_test.go
@@ -311,6 +311,12 @@ func TestPush(t *testing.T) {
 		// retryAfterScopeRefresh which runs `gh auth refresh`. The
 		// stubbed gh exits 0 so RefreshGHCRPackageScopes returns true,
 		// and the retry push succeeds on the second invocation.
+		//
+		// ERUN_FORCE_TTY=1 is the deliberate seam that lets the gate added
+		// in #587 treat this piped-stdin harness run as interactive, so the
+		// interactive scope-refresh success path stays covered. The two
+		// scenarios below assert the non-interactive and in-pod paths fail
+		// clearly instead of launching gh.
 		setup := env.New(t)
 		fixture.SeedReleaseRepo(t, setup.Cwd, "develop")
 		stubs := setup.Cwd + "/stubs"
@@ -350,11 +356,97 @@ func TestPush(t *testing.T) {
 		}, "\n"))
 		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker", "gh")...)
 		envVars = append(envVars, "PATH="+stubs+":"+os.Getenv("PATH"))
-		envVars = append(envVars, "ERUN_AUTO_LOGIN_ON_PUSH=1")
+		envVars = append(envVars, "ERUN_AUTO_LOGIN_ON_PUSH=1", "ERUN_FORCE_TTY=1")
 		result := erun.Run(t, []string{"push", "--version", "1.0.0", "-v"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
 		golden.Equal(t, "push/real_run_scope_denied_attempts_scope_refresh", normalize.Apply(result.Combined))
+	})
+
+	t.Run("real_run_scope_denied_non_interactive_fails_clearly", func(t *testing.T) {
+		// #587: with no interactive terminal (the harness pipes stdin and
+		// ERUN_FORCE_TTY is unset), RefreshGHCRPackageScopes must NOT launch
+		// gh's interactive device-code flow — which would hang forever — and
+		// must instead return the actionable write:packages-scope error. The
+		// gh stub records any auth switch/refresh/login call to a marker file;
+		// the assertion below proves that flow was never launched.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "develop")
+		stubs := setup.Cwd + "/stubs"
+		marker := setup.Cwd + "/gh-interactive-marker"
+		// docker push always fails the scope check, so the only way the push
+		// could succeed is the (gated) interactive scope refresh.
+		fixture.StubBinaryWithScript(t, stubs, "docker", strings.Join([]string{
+			`case "$1" in`,
+			`  push)`,
+			`    printf 'denied: token does not match expected scopes\n' >&2`,
+			`    exit 1 ;;`,
+			`  image)`,
+			`    case "$2" in inspect) exit 1 ;; *) exit 0 ;; esac ;;`,
+			`  *) exit 0 ;;`,
+			`esac`,
+		}, "\n"))
+		// gh: token works (so the namespace-login retry runs), but any
+		// interactive auth call writes the marker — it must never fire.
+		fixture.StubBinaryWithScript(t, stubs, "gh", strings.Join([]string{
+			`case "$1 $2" in`,
+			`  "auth switch"|"auth refresh"|"auth login") printf 'launched\n' > '` + marker + `'; exit 0 ;;`,
+			`  "auth token") printf 'gh-token\n'; exit 0 ;;`,
+			`  *) exit 0 ;;`,
+			`esac`,
+		}, "\n"))
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker", "gh")...)
+		envVars = append(envVars, "PATH="+stubs+":"+os.Getenv("PATH"))
+		envVars = append(envVars, "ERUN_AUTO_LOGIN_ON_PUSH=1")
+		result := erun.Run(t, []string{"push", "--version", "1.0.0", "-v"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit when scope refresh is gated, got 0:\n%s", result.Combined)
+		}
+		if _, err := os.Stat(marker); err == nil {
+			t.Fatalf("interactive gh auth flow was launched in a non-interactive context:\n%s", result.Combined)
+		}
+		golden.Equal(t, "push/real_run_scope_denied_non_interactive_fails_clearly", normalize.Apply(result.Combined))
+	})
+
+	t.Run("real_run_scope_denied_in_pod_fails_clearly", func(t *testing.T) {
+		// #587: inside a chart-injected runtime pod (ERUN_TENANT/
+		// ERUN_ENVIRONMENT set) the desktop terminal is a PTY-backed pod
+		// shell, so ERUN_FORCE_TTY=1 is set to prove the in-pod check wins
+		// over the TTY seam: even with a "terminal", there is no browser, so
+		// the gate must still fire and the interactive gh flow must not run.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "develop")
+		stubs := setup.Cwd + "/stubs"
+		marker := setup.Cwd + "/gh-interactive-marker"
+		fixture.StubBinaryWithScript(t, stubs, "docker", strings.Join([]string{
+			`case "$1" in`,
+			`  push)`,
+			`    printf 'denied: token does not match expected scopes\n' >&2`,
+			`    exit 1 ;;`,
+			`  image)`,
+			`    case "$2" in inspect) exit 1 ;; *) exit 0 ;; esac ;;`,
+			`  *) exit 0 ;;`,
+			`esac`,
+		}, "\n"))
+		fixture.StubBinaryWithScript(t, stubs, "gh", strings.Join([]string{
+			`case "$1 $2" in`,
+			`  "auth switch"|"auth refresh"|"auth login") printf 'launched\n' > '` + marker + `'; exit 0 ;;`,
+			`  "auth token") printf 'gh-token\n'; exit 0 ;;`,
+			`  *) exit 0 ;;`,
+			`esac`,
+		}, "\n"))
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker", "gh")...)
+		envVars = append(envVars, "PATH="+stubs+":"+os.Getenv("PATH"))
+		envVars = append(envVars, "ERUN_AUTO_LOGIN_ON_PUSH=1", "ERUN_FORCE_TTY=1")
+		envVars = append(envVars, "ERUN_TENANT=team", "ERUN_ENVIRONMENT=dev")
+		result := erun.Run(t, []string{"push", "--version", "1.0.0", "-v"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit when scope refresh is gated in-pod, got 0:\n%s", result.Combined)
+		}
+		if _, err := os.Stat(marker); err == nil {
+			t.Fatalf("interactive gh auth flow was launched inside the runtime pod:\n%s", result.Combined)
+		}
+		golden.Equal(t, "push/real_run_scope_denied_in_pod_fails_clearly", normalize.Apply(result.Combined))
 	})
 }

--- a/erun-integration/testdata/push/real_run_scope_denied_in_pod_fails_clearly.txt
+++ b/erun-integration/testdata/push/real_run_scope_denied_in_pod_fails_clearly.txt
@@ -1,0 +1,15 @@
+audit: erun push --version <VERSION>
+==> Pushing
+fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
+fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
+rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+denied: token does not match expected scopes
+denied: token does not match expected scopes
+==> Push failed after <ELAPSED>
+ghcr.io rejected the push: the gh-stored token lacks the write:packages scope.
+
+erun can widen the scope automatically, but that needs gh's interactive browser login, which cannot run here (this runtime pod is headless and has no browser).
+From a host shell signed in to the namespace owner's GitHub account, with a browser available, run:
+  gh auth refresh -h github.com -u sophium -s write:packages,read:packages
+  gh auth token -u sophium -h github.com | docker login ghcr.io -u sophium --password-stdin
+then re-run erun push.

--- a/erun-integration/testdata/push/real_run_scope_denied_non_interactive_fails_clearly.txt
+++ b/erun-integration/testdata/push/real_run_scope_denied_non_interactive_fails_clearly.txt
@@ -1,0 +1,15 @@
+audit: erun push --version <VERSION>
+==> Pushing
+fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
+fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
+rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+denied: token does not match expected scopes
+denied: token does not match expected scopes
+==> Push failed after <ELAPSED>
+ghcr.io rejected the push: the gh-stored token lacks the write:packages scope.
+
+erun can widen the scope automatically, but that needs gh's interactive browser login, which cannot run here (stdin is not an interactive terminal).
+From a host shell signed in to the namespace owner's GitHub account, with a browser available, run:
+  gh auth refresh -h github.com -u sophium -s write:packages,read:packages
+  gh auth token -u sophium -h github.com | docker login ghcr.io -u sophium --password-stdin
+then re-run erun push.


### PR DESCRIPTION
## Problem

`erun push` against GHCR can be rejected with `permission_denied: The token provided does not match expected scopes`. On that denial the CLI escalates to `gh`'s interactive browser device-code flow (`gh auth refresh` / `gh auth login -w`). From the desktop app's "Erun" terminal — a shell **into the runtime pod** — that flow can never complete: the pod is headless (no browser), and the operator was stranded on a `Authenticate Git with your GitHub credentials? (Y/n)` prompt that never advanced, leaving the push hung. The same trap applies to any non-interactive caller (MCP, CI, pipes).

## Fix

`RefreshGHCRPackageScopes` (erun-common) now gates the interactive flow. It does **not** launch `gh` when either:

- the process runs inside the chart-injected runtime pod (`ERUN_TENANT` **and** `ERUN_ENVIRONMENT` set) — headless, no browser, even though the desktop terminal is a PTY-backed pod shell; or
- `stdin` is not a real terminal (MCP, CI, pipes).

The in-pod check is evaluated first, so a PTY-backed pod shell is still treated as headless. When gated, it returns an actionable error instead of hanging:

```
ghcr.io rejected the push: the gh-stored token lacks the write:packages scope.

erun can widen the scope automatically, but that needs gh's interactive browser login, which cannot run here (this runtime pod is headless and has no browser).
From a host shell signed in to the namespace owner's GitHub account, with a browser available, run:
  gh auth refresh -h github.com -u <owner> -s write:packages,read:packages
  gh auth token -u <owner> -h github.com | docker login ghcr.io -u <owner> --password-stdin
then re-run erun push.
```

`ERUN_FORCE_TTY=1` (the existing CLI test seam) bypasses the stdin check so the interactive success path stays reachable from the integration harness.

### On the Ctrl-C acceptance criterion

The reported hang is the headless-pod case, which this gate removes outright — no interactive prompt is launched, so there is nothing to interrupt. In a genuine interactive host terminal (the only place the flow still runs), `erun` installs no SIGINT handler, so Ctrl-C reaches the foreground `gh` child via the process group and `gh` restores the terminal itself. No extra signal handling was needed.

## Tests

- New integration scenarios (`erun-integration/push_test.go`): `real_run_scope_denied_non_interactive_fails_clearly` and `real_run_scope_denied_in_pod_fails_clearly`. Both assert a non-zero exit, the actionable error, and — via a marker file the `gh` stub writes on any `auth switch/refresh/login` — that the interactive flow was **never** launched. The in-pod scenario sets `ERUN_FORCE_TTY=1` to prove the in-pod check wins over the TTY seam.
- The existing `real_run_scope_denied_attempts_scope_refresh` scenario keeps the interactive success path covered via `ERUN_FORCE_TTY=1`.
- The integration harness now always feeds the subprocess a stdin pipe (instead of leaving `cmd.Stdin` nil, which inherited the developer's terminal), so the stdin-TTY gate behaves identically locally and in CI.
- `make integration-test` green (coverage 77.5% ≥ 75.0%); `go test ./...` green in erun-common, erun-cli, erun-mcp.

## Docs

This corrected behaviour that the docs described inaccurately:

- `cli/push.md` (Operator) — Authentication section + error table.
- `agent-reference/cli-flags.md` (source of truth) — scope-refresh gating spec.
- `reference/troubleshooting.md` — replaced "fails silently" with the actionable recovery.

`cd erun-docs && yarn build` clean.

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)