### PR TITLE
Add erun push --build operator shortcut

### DIFF
--- a/erun-cli/cmd/build.go
+++ b/erun-cli/cmd/build.go
@@ -24,6 +24,11 @@ var errVersionFileNotFound = common.ErrVersionFileNotFound
 // "Command primitives vs orchestration").
 var errPushVersionRequired = fmt.Errorf("push requires a version: pass --version <version> produced by `erun build`. push publishes a built version's images and chart; it does not mint a version")
 
+// errPushBuildVersionConflict is returned when `erun push --build` is combined
+// with an explicit --version. With --build the version is whatever the build
+// step mints, so an explicit version is contradictory.
+var errPushBuildVersionConflict = fmt.Errorf("push --build builds and pushes the version it mints; do not also pass --version")
+
 func newBuildCmd(store common.DockerStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, resolveDeployContext common.DeployContextResolverFunc, now common.NowFunc, runBuildScript common.BuildScriptRunnerFunc, buildDockerImage common.DockerImageBuilderFunc, loginToDockerRegistry common.DockerRegistryLoginFunc, selectRunner SelectRunner, push common.DockerPushFunc, deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {
 	target := common.DockerCommandTarget{}
 	cmd := &cobra.Command{
@@ -156,7 +161,12 @@ func pushBuildWithRetry(ctx common.Context, buildDockerImage common.DockerImageB
 // multi-image push (when run from the project root with multiple docker
 // contexts). The nested "devops container push" command uses newPushCmd which
 // is single-image only.
-func newRootPushCmd(store common.DockerStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, now common.NowFunc, buildDockerImage common.DockerImageBuilderFunc, loginToDockerRegistry common.DockerRegistryLoginFunc, selectRunner SelectRunner, push common.DockerPushFunc) *cobra.Command {
+//
+// --build is an operator-convenience shortcut: it builds the current source
+// first (minting a snapshot version), then pushes that minted version. The
+// orchestration lives here in the CLI caller, exactly like `build --deploy` —
+// push itself stays a pure primitive that publishes an explicit version.
+func newRootPushCmd(store common.DockerStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, now common.NowFunc, runBuildScript common.BuildScriptRunnerFunc, buildDockerImage common.DockerImageBuilderFunc, loginToDockerRegistry common.DockerRegistryLoginFunc, selectRunner SelectRunner, push common.DockerPushFunc) *cobra.Command {
 	target := common.DockerCommandTarget{}
 	var force bool
 	cmd := &cobra.Command{
@@ -168,8 +178,11 @@ func newRootPushCmd(store common.DockerStore, findProjectRoot common.ProjectFind
 			"`erun build` minted; push publishes it, it does not mint one. push resolves that " +
 			"version's images from the local source (promoting unchanged images from the " +
 			"fingerprint cache, rebuilding only what changed), then pushes the multi-arch " +
-			"manifest and, for the runtime image, the runtime chart alongside it.",
-		Example:       "  erun push --version 1.2.3-snapshot-20260101010101",
+			"manifest and, for the runtime image, the runtime chart alongside it.\n\n" +
+			"--build is an operator shortcut that builds the current source first and then " +
+			"pushes the version that build mints, so you don't have to copy the snapshot " +
+			"version out of `erun build` by hand. It is mutually exclusive with --version.",
+		Example:       "  erun push --version 1.2.3-snapshot-20260101010101\n  erun push --build",
 		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -177,12 +190,23 @@ func newRootPushCmd(store common.DockerStore, findProjectRoot common.ProjectFind
 			if force {
 				target.NoIncremental = true
 			}
-			// Version is required: push publishes a content identity that
-			// `erun build` minted, it does not mint one.
-			if strings.TrimSpace(target.VersionOverride) == "" {
+			ctx := commandContext(cmd)
+			if target.Build {
+				// Operator shortcut: build the current source (which mints a
+				// snapshot version), then push that exact version. --version is
+				// redundant here — the version is whatever build mints — so
+				// reject the combination for a single clear contract.
+				if strings.TrimSpace(target.VersionOverride) != "" {
+					return errPushBuildVersionConflict
+				}
+				if err := runPushBuildStep(ctx, store, findProjectRoot, resolveBuildContext, now, &target, runBuildScript, buildDockerImage, loginToDockerRegistry, selectRunner, push); err != nil {
+					return err
+				}
+			} else if strings.TrimSpace(target.VersionOverride) == "" {
+				// Version is required: push publishes a content identity that
+				// `erun build` minted, it does not mint one.
 				return errPushVersionRequired
 			}
-			ctx := commandContext(cmd)
 			buildWithRetry := pushBuildWithRetry(ctx, buildDockerImage, loginToDockerRegistry, selectRunner)
 			buildContext, _ := resolveBuildContext()
 			if strings.TrimSpace(buildContext.DockerfilePath) != "" {
@@ -206,8 +230,31 @@ func newRootPushCmd(store common.DockerStore, findProjectRoot common.ProjectFind
 	addDryRunFlag(cmd)
 	addPushCommandTargetFlags(cmd, &target)
 	cmd.Flags().StringVar(&target.VersionOverride, "version", "", "Version to publish, produced by erun build")
-	cmd.Flags().BoolVar(&force, "force", false, "Rebuild and re-push every image, bypassing the fingerprint cache")
+	cmd.Flags().BoolVar(&force, "force", false, "Rebuild and re-push every image, bypassing the fingerprint cache (also forces the --build step)")
+	cmd.Flags().BoolVar(&target.Build, "build", false, "Build the current source first, then push the version it mints (operator shortcut for build → push)")
 	return cmd
+}
+
+// runPushBuildStep runs the pure build (the same resolve+run `erun build`
+// performs) so it mints a snapshot version, then sets that minted version on
+// target so the push path that follows publishes exactly what was just built.
+// The orchestration — and the version threading — lives here in the CLI caller,
+// not in the push primitive.
+func runPushBuildStep(ctx common.Context, store common.DockerStore, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, now common.NowFunc, target *common.DockerCommandTarget, runBuildScript common.BuildScriptRunnerFunc, buildDockerImage common.DockerImageBuilderFunc, loginToDockerRegistry common.DockerRegistryLoginFunc, selectRunner SelectRunner, push common.DockerPushFunc) error {
+	execution, err := common.ResolveBuildExecution(ctx, store, findProjectRoot, resolveBuildContext, now, *target)
+	if err != nil {
+		return err
+	}
+	buildWithRetry := pushBuildWithRetry(ctx, buildDockerImage, loginToDockerRegistry, selectRunner)
+	if err := common.RunBuildExecution(ctx, execution, runBuildScript, buildWithRetry, push); err != nil {
+		return err
+	}
+	version := strings.TrimSpace(common.NewBuildResult(execution).Version)
+	if version == "" {
+		return errors.New("erun push --build: the build did not mint a version to push")
+	}
+	target.VersionOverride = version
+	return nil
 }
 
 func runDockerPushWithRetry(ctx common.Context, pushInput common.DockerPushSpec, push common.DockerPushFunc, loginToDockerRegistry common.DockerRegistryLoginFunc, selectRunner SelectRunner) error {

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -208,7 +208,7 @@ func (d rootDependencies) optionalPushCommand() *cobra.Command {
 	if !hasOptionalPushCmd(common.FindProjectRoot, common.ResolveDockerBuildContext) {
 		return nil
 	}
-	pushCmd := newRootPushCmd(d.store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.DockerImageBuilder, common.DockerRegistryLogin, runSelect, d.push)
+	pushCmd := newRootPushCmd(d.store, common.FindProjectRoot, common.ResolveDockerBuildContext, time.Now, common.BuildScriptRunner, common.DockerImageBuilder, common.DockerRegistryLogin, runSelect, d.push)
 	pushCmd.Short = optionalPushCmdShort(common.FindProjectRoot, common.ResolveDockerBuildContext)
 	return pushCmd
 }

--- a/erun-common/build_types.go
+++ b/erun-common/build_types.go
@@ -126,6 +126,12 @@ type DockerCommandTarget struct {
 	Release         bool
 	Force           bool
 	Deploy          bool
+	// Build is the `erun push --build` operator shortcut: build the current
+	// source first (minting a snapshot version), then push that version. It is
+	// orchestration policy that lives in the CLI caller, not in any primitive —
+	// the shared resolvers never read it. See root AGENTS.md § "Command
+	// primitives vs orchestration".
+	Build bool
 	// NoIncremental disables the default fingerprint-based incremental build
 	// caching. When false (the default), each docker build context is fingerprinted
 	// from its Dockerfile and COPY sources; if a local image with the matching

--- a/erun-docs/docs/agent-reference/cli-flags.md
+++ b/erun-docs/docs/agent-reference/cli-flags.md
@@ -187,11 +187,12 @@ binfmt for <arch> not installed. Run:
 
 ## `erun push`
 
-### Version (required)
+### Version (required, unless `--build`)
 
 | Flag | Type | Required | Notes |
 |---|---|---|---|
-| `--version <version>` | string (semver, snapshot or bare) | **Yes** | The version to publish (the same flag `deploy` uses, for consistency across commands). `push` does not mint a version — it builds each image from source at this version (promoting unchanged images from the fingerprint cache), pushes the per-arch tags, assembles the multi-arch manifest list, then publishes the runtime helm chart. Missing → `NO_VERSION` (exit 1). |
+| `--version <version>` | string (semver, snapshot or bare) | **Yes**, unless `--build` is set | The version to publish (the same flag `deploy` uses, for consistency across commands). `push` does not mint a version — it builds each image from source at this version (promoting unchanged images from the fingerprint cache), pushes the per-arch tags, assembles the multi-arch manifest list, then publishes the runtime helm chart. Missing (and no `--build`) → `NO_VERSION` (exit 1). |
+| `--build` | bool (default `false`) | — | **Operator-only convenience switch** (CLI top-level `erun push` only). Builds the current source first — the same pure build `erun build` runs, minting a snapshot version — then pushes that exact minted version. Equivalent to `erun build && erun push --version <minted>`. Mutually exclusive with `--version` (the version is whatever build mints); passing both → exit 1, `push --build builds and pushes the version it mints; do not also pass --version`. `--force` propagates to the build step. **Not exposed over MCP**: the `push` tool keeps `version` required, because programmatic callers compose `build` → `push` themselves and thread the minted version (see [Command primitives](/concepts/command-primitives)). |
 
 ### What push publishes
 

--- a/erun-docs/docs/cli/push.md
+++ b/erun-docs/docs/cli/push.md
@@ -28,7 +28,8 @@ Because push publishes the chart for every version — snapshot or release — a
 
 | Flag | Description |
 |---|---|
-| `--force` | Rebuild and re-push every image, bypassing the fingerprint cache. |
+| `--build` | **Operator shortcut** (build → push). Build the current source first, then push the version that build mints — so you don't have to copy the snapshot version out of `erun build` by hand. Mutually exclusive with `--version`. Programmatic callers (the desktop app, scripts, Agents over MCP) compose `build` and `push` themselves and thread the version; see [Command primitives](/concepts/command-primitives). |
+| `--force` | Rebuild and re-push every image, bypassing the fingerprint cache. Also forces the `--build` step. |
 | `--dry-run` | Resolve and print every `docker build` / `docker push` / `docker manifest` and `helm package` / `helm push` command without executing. |
 
 ## Registry resolution

--- a/erun-docs/docs/concepts/command-primitives.md
+++ b/erun-docs/docs/concepts/command-primitives.md
@@ -33,7 +33,7 @@ That's why `push` and `deploy` ask for the version explicitly — so what you de
 
 You usually don't type those three commands by hand. There are two ways they get composed — and the difference matters:
 
-- **Operator convenience switches.** At the terminal, `erun build --deploy` runs build → push → deploy in one go, and `erun build --release` folds in the release flow. These are shortcuts *for a human* — they compose the primitives for you and thread the version automatically.
+- **Operator convenience switches.** At the terminal, `erun build --deploy` runs build → push → deploy in one go, `erun build --release` folds in the release flow, and `erun push --build` builds the current source then publishes the version it mints. These are shortcuts *for a human* — they compose the primitives for you and thread the version automatically.
 - **Programmatic orchestration.** The desktop app, scripts, and Agents driving [MCP](/mcp/overview) do **not** use those switches. They run the primitives themselves — `build`, then `push`, then `deploy` — capturing the version from `erun build --output json` and threading it through. This keeps the policy ("for this environment, the operator's click means build → push → deploy") in the caller, where it belongs, instead of buried inside a command.
 
 So the desktop app's **Deploy** button isn't calling one clever command that decides everything — it's running the same plain primitives you could run yourself, in the order that fits the environment, with the version carried between them.

--- a/erun-docs/docs/pipeline.md
+++ b/erun-docs/docs/pipeline.md
@@ -21,7 +21,7 @@ The four steps are **pure primitives** — each does exactly one thing, with no 
 - **[`push`](/cli/push)** — publish a version's outputs to the project's container registry: the multi-arch image **and** the runtime helm chart, together at the same version.
 - **[`deploy`](/cli/deploy)** — install a published version into an environment with a Helm upgrade, by reference. It never builds or pushes; a version is required.
 
-You rarely run the four by hand. For an Operator at the terminal, **convenience shortcuts** compose them: `erun build --release` folds the release flow into the build, and `erun build --deploy` carries one build straight through push and rollout — so one command runs the flow and the version threads through for you. Programmatic callers (the desktop app, scripts, an Agent over MCP) don't use the shortcuts; they run the primitives themselves and thread the version (captured from `erun build --output json`), keeping the "for this env type, do build→push→deploy" policy in the caller, not the command.
+You rarely run the four by hand. For an Operator at the terminal, **convenience shortcuts** compose them: `erun build --release` folds the release flow into the build, `erun build --deploy` carries one build straight through push and rollout, and `erun push --build` builds the current source then publishes the version it mints — so one command runs the flow and the version threads through for you. Programmatic callers (the desktop app, scripts, an Agent over MCP) don't use the shortcuts; they run the primitives themselves and thread the version (captured from `erun build --output json`), keeping the "for this env type, do build→push→deploy" policy in the caller, not the command.
 
 ## What `build` does
 

--- a/erun-integration/push_test.go
+++ b/erun-integration/push_test.go
@@ -155,6 +155,79 @@ func TestPush(t *testing.T) {
 		golden.Equal(t, "push/dry_run_single_image_from_dockerfile_cwd", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_build_shortcut_builds_then_pushes_minted_version", func(t *testing.T) {
+		// #585: `erun push --build` is the operator shortcut that builds the
+		// current source first (minting a snapshot version) and then pushes
+		// that exact version — no --version needed. The dry-run trace must
+		// show the build actions (==> would not appear in dry-run, but the
+		// docker build commands do) followed by the push actions, with the
+		// minted version threaded into the push lines.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		fixture.SeedProjectDockerfile(t, setup)
+		if err := os.WriteFile(filepath.Join(setup.Cwd, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+			t.Fatalf("write VERSION: %v", err)
+		}
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinaryWithScript(t, stubs, "docker", strings.Join([]string{
+			`case "$1" in`,
+			`  image)`,
+			`    case "$2" in inspect) exit 1 ;; *) exit 0 ;; esac ;;`,
+			`  *) exit 0 ;;`,
+			`esac`,
+		}, "\n"))
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker")...)
+		result := erun.Run(t, []string{"push", "--build", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "push/dry_run_build_shortcut_builds_then_pushes_minted_version", normalize.Apply(result.Combined))
+	})
+
+	t.Run("dry_run_build_shortcut_force_rebuilds", func(t *testing.T) {
+		// #585: --force must propagate to the --build step, so the build
+		// rebuilds every image instead of promoting from the fingerprint
+		// cache. The dry-run trace differs from the plain --build run (no
+		// fingerprint-promote decision lines) which is what this golden locks.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		fixture.SeedProjectDockerfile(t, setup)
+		if err := os.WriteFile(filepath.Join(setup.Cwd, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+			t.Fatalf("write VERSION: %v", err)
+		}
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinaryWithScript(t, stubs, "docker", strings.Join([]string{
+			`case "$1" in`,
+			`  image)`,
+			`    case "$2" in inspect) exit 1 ;; *) exit 0 ;; esac ;;`,
+			`  *) exit 0 ;;`,
+			`esac`,
+		}, "\n"))
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker")...)
+		result := erun.Run(t, []string{"push", "--build", "--force", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "push/dry_run_build_shortcut_force_rebuilds", normalize.Apply(result.Combined))
+	})
+
+	t.Run("build_shortcut_with_explicit_version_errors", func(t *testing.T) {
+		// #585: --build mints the version itself, so combining it with an
+		// explicit --version is contradictory and must fail clearly before any
+		// build or push work.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		fixture.SeedProjectDockerfile(t, setup)
+		result := erun.Run(t, []string{"push", "--build", "--version", "1.0.0", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit for --build with --version, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "push/build_shortcut_with_explicit_version_errors", normalize.Apply(result.Combined))
+	})
+
 	t.Run("real_run_single_image_from_dockerfile_cwd", func(t *testing.T) {
 		// Exercises the root `erun push` single-image branch for real:
 		// ResolveDockerPushSpec resolves the cwd Dockerfile into one build+push

--- a/erun-integration/testdata/push/build_shortcut_with_explicit_version_errors.txt
+++ b/erun-integration/testdata/push/build_shortcut_with_explicit_version_errors.txt
@@ -1,0 +1,2 @@
+audit: erun push --build --dry-run --version <VERSION>
+push --build builds and pushes the version it mints; do not also pass --version

--- a/erun-integration/testdata/push/dry_run_build_shortcut_builds_then_pushes_minted_version.txt
+++ b/erun-integration/testdata/push/dry_run_build_shortcut_builds_then_pushes_minted_version.txt
@@ -1,0 +1,23 @@
+audit: erun push --build --dry-run
+docker image inspect ghcr.io/sophium/cwd:fp-<HEX16>-amd64
+fingerprint image not found locally: ghcr.io/sophium/cwd:fp-<HEX16>-amd64
+docker image inspect ghcr.io/sophium/cwd:fp-<HEX16>-arm64
+fingerprint image not found locally: ghcr.io/sophium/cwd:fp-<HEX16>-arm64
+rebuilding ghcr.io/sophium/cwd:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker tag ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:fp-<HEX16>-amd64
+cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker tag ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:fp-<HEX16>-arm64
+docker image inspect ghcr.io/sophium/cwd:fp-<HEX16>-amd64
+fingerprint image not found locally: ghcr.io/sophium/cwd:fp-<HEX16>-amd64
+docker image inspect ghcr.io/sophium/cwd:fp-<HEX16>-arm64
+fingerprint image not found locally: ghcr.io/sophium/cwd:fp-<HEX16>-arm64
+rebuilding ghcr.io/sophium/cwd:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker tag ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:fp-<HEX16>-amd64
+cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker tag ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/cwd:<VERSION>
+cd <TMP> && docker push ghcr.io/sophium/cwd:<VERSION>
+cd <TMP> && docker manifest create --amend ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/cwd:<VERSION>

--- a/erun-integration/testdata/push/dry_run_build_shortcut_force_rebuilds.txt
+++ b/erun-integration/testdata/push/dry_run_build_shortcut_force_rebuilds.txt
@@ -1,0 +1,9 @@
+audit: erun push --build --dry-run --force
+cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker push ghcr.io/sophium/cwd:<VERSION>
+cd <TMP> && docker push ghcr.io/sophium/cwd:<VERSION>
+cd <TMP> && docker manifest create --amend ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/cwd:<VERSION>

--- a/erun-integration/testdata/push/help.txt
+++ b/erun-integration/testdata/push/help.txt
@@ -2,15 +2,19 @@ Publish a version's container images and runtime chart to the registry — the p
 
 A version is required (--version <v>, the same flag deploy uses) and is the one `erun build` minted; push publishes it, it does not mint one. push resolves that version's images from the local source (promoting unchanged images from the fingerprint cache, rebuilding only what changed), then pushes the multi-arch manifest and, for the runtime image, the runtime chart alongside it.
 
+--build is an operator shortcut that builds the current source first and then pushes the version that build mints, so you don't have to copy the snapshot version out of `erun build` by hand. It is mutually exclusive with --version.
+
 Usage:
   erun push [flags]
 
 Examples:
   erun push --version <VERSION>
+  erun push --build
 
 Flags:
+      --build            Build the current source first, then push the version it mints (operator shortcut for build → push)
       --dry-run          Resolve and trace mutating actions without executing them.
-      --force            Rebuild and re-push every image, bypassing the fingerprint cache
+      --force            Rebuild and re-push every image, bypassing the fingerprint cache (also forces the --build step)
   -h, --help             help for push
       --version string   Version to publish, produced by erun build
 


### PR DESCRIPTION
## Summary

`erun push` requires an explicit `--version` (it publishes the content identity `build` minted; it never mints one). So the common "build the current source, then publish it" loop was two commands plus a manual copy of the snapshot version string. `--build` removes that friction, exactly like `build --deploy` / `open --deploy` do for their flows.

`erun push --build` runs the pure build first (minting a snapshot version), captures that version off the resolved build execution, sets it on the target, then runs the existing push path at that version — identical to `erun build && erun push --version <minted>`.

## Behaviour

- `erun push --build` → build → push the minted version. No `--version` needed.
- Without `--build`, `push` is unchanged: `--version` required, `errPushVersionRequired` still fires.
- `--build` + `--version` are **mutually exclusive** (the version is whatever build mints) → clear error before any work.
- `--force` propagates to the build step (forces a rebuild before re-pushing).
- `--dry-run` traces both the build actions and the push actions, with the minted version threaded through.

## Where it lives (and where it doesn't)

- **CLI top-level `erun push` only** (`newRootPushCmd`). The orchestration and version threading live in the CLI caller, exactly like `build --deploy` lives in `runBuildCommand`. No env-type or policy decision moves into the `push` primitive.
- **Not in MCP.** The MCP push tool keeps `version` `required` — programmatic callers (the desktop app, scripts, Agents over MCP) compose `build` → `push` themselves and thread the minted version. Convenience switches are operator-only.

## Open design questions (resolved)

- `push --build --version X` → **rejected** (simplest contract), locked by a golden.
- `--release` interaction → out of scope; `push --build` mints a snapshot and does not tag. Release-tagging stays with `erun release`.

## Tests

- Integration goldens (`erun-integration/push_test.go`):
  - `dry_run_build_shortcut_builds_then_pushes_minted_version` — build actions then push actions, minted version threaded into the push lines.
  - `dry_run_build_shortcut_force_rebuilds` — `--force` reaches the build step (fingerprint-promote decision lines drop out).
  - `build_shortcut_with_explicit_version_errors` — `--build` + `--version` mutual-exclusion error, fails before any work.
  - `push/help` golden updated for the new flag + example.
  - Bare `push --dry-run` (no version) still errors (existing `missing_version_errors`).
- `make integration-test` green (coverage 77.5% ≥ 75.0%); `go test ./...` green in erun-common, erun-cli, erun-mcp.

## Docs

`--build` is a new public CLI switch, so docs land in this PR:

- `cli/push.md` — `--build` row in the flags table (marked Operator shortcut) + example.
- `concepts/command-primitives.md` and `pipeline.md` — added `push --build` to the convenience-switch lists.
- `agent-reference/cli-flags.md` — full `--build` spec (mutual exclusion, error, `--force` propagation, MCP-exclusion).

`cd erun-docs && yarn build` clean.

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)