### PR TITLE
Pin the Playwright desktop to its inert erun stub so env-open specs settle

### DIFF
--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -779,6 +779,17 @@ func TestResolveCLIExecutableFromPathUsesExecutableSibling(t *testing.T) {
 	}
 }
 
+func TestResolveCLIExecutableHonorsAppCLISeam(t *testing.T) {
+	// The Playwright harness sets ERUN_APP_CLI to its inert `erun` stub so the
+	// desktop runs the stub regardless of any real erun-cli/bin/erun build
+	// artifact sitting next to the app binary (#525). The seam wins over the
+	// build-relative + PATH resolution.
+	t.Setenv("ERUN_APP_CLI", "/seam/stub/erun")
+	if got := resolveCLIExecutable(); got != "/seam/stub/erun" {
+		t.Fatalf("resolveCLIExecutable() = %q, want the ERUN_APP_CLI override", got)
+	}
+}
+
 func TestResolveTerminalStartDirUsesExistingPreferredDirectory(t *testing.T) {
 	preferred := t.TempDir()
 

--- a/erun-ui/playwright/fixtures/seedRoot.ts
+++ b/erun-ui/playwright/fixtures/seedRoot.ts
@@ -78,6 +78,12 @@ export function backendEnv(): Record<string, string> {
     XDG_CACHE_HOME: path.join(home, '.cache'),
     XDG_DATA_HOME: path.join(home, '.local', 'share'),
     PATH: `${stubsDir()}${path.delimiter}${process.env.PATH ?? ''}`,
+    // Force the desktop's ERun/AI tabs to run the inert `erun` stub. The PATH
+    // prepend alone is not enough: resolveCLIExecutable resolves a real
+    // erun-cli/bin/erun next to the app binary (a dev build artifact) before
+    // falling back to PATH, which makes the env-open specs loop red on a
+    // developer machine that has that artifact (#525). This seam pins the stub.
+    ERUN_APP_CLI: path.join(stubsDir(), 'erun'),
   };
 }
 

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -37,6 +37,16 @@ type startTerminalSessionParams struct {
 }
 
 func resolveCLIExecutable() string {
+	// ERUN_APP_CLI is a deliberate test seam (mirrors ERUN_HOST_OS_OVERRIDE /
+	// ERUN_FORCE_TTY): when set, the desktop runs exactly this `erun` and skips
+	// the build-relative + PATH resolution below. The Playwright harness points
+	// it at its inert `erun` stub so the ERun/AI tabs run the stub regardless of
+	// whether a real erun-cli/bin/erun build artifact happens to sit next to the
+	// app binary — otherwise that artifact is resolved here, the real `erun open`
+	// hits the stubbed cluster, and the env-open specs loop red (#525).
+	if override := strings.TrimSpace(os.Getenv("ERUN_APP_CLI")); override != "" {
+		return override
+	}
 	executableName := "erun"
 	if runtime.GOOS == "windows" {
 		executableName += ".exe"


### PR DESCRIPTION
## Problem

Five desktop Playwright specs (`sidebar`, `sidebar-busy-spinner`, `sidebar-env-hover`, `terminal-query-response` #484, `terminal-scroll-on-switch`) — plus, run-to-run, `diagnostics-console`, `review-diff-tree`, `sidebar-ai-activity`, `tab-respawn` — go red on macOS against pristine main. The failing set is non-deterministic, the hallmark of state bleed across the singleton backend.

## Root cause (verified)

The headless desktop runs a **real** `erun open` instead of the harness's inert `erun` stub.

`resolveCLIExecutable` (erun-ui/session.go) resolves `erun` **relative to the app binary first** — including `<app-dir>/../../erun-cli/bin/erun` — and only falls back to `PATH` (where the stub is prepended) when no build-relative candidate exists. On a developer machine that has built `erun-cli/bin/erun` (confirmed present here, a 16 MB real binary), the desktop resolves **that**. So `erun open pw alpha` runs for real → hits the harness's stubbed `kubectl` (which exits 1 — "no cluster in the Playwright harness") → the desktop's persistent-session **reconnect loop** retries it. That pins `pw/alpha` in a `role="status"` "Working on…" busy state, which:

- fails specs asserting the open **settles** (quiet rows show no spinner, spinner clears, terminal scroll/content, query replay), and
- bleeds across the singleton backend (`workers:1`, persistent sessions) into later specs.

On a clean CI box `erun-cli/bin/erun` is absent → PATH wins → the inert stub is used → green. That's why it's "macOS / this machine only." (The aria-snapshots from the failures show the real `erun open` trace + `── reconnecting exit status 1 ──`.)

The harness already *intends* the stub — `seedRoot.ts` documents that the ERun/AI tabs run `erun open` "from PATH" (the stub prints the ready marker then sleeps: alive + inert). Build-relative resolution silently bypassed it.

## Fix

A deliberate test seam **`ERUN_APP_CLI`** (mirroring `ERUN_HOST_OS_OVERRIDE` / `ERUN_FORCE_TTY`): when set, `resolveCLIExecutable` returns it and skips the build-relative + PATH resolution. The Playwright `webServer` env pins it to the stub, so the suite is deterministic regardless of stray build artifacts on the host.

- `erun-ui/session.go` — `ERUN_APP_CLI` seam in `resolveCLIExecutable`.
- `erun-ui/playwright/fixtures/seedRoot.ts` — set `ERUN_APP_CLI` to the inert stub in `backendEnv()`.
- `erun-ui/app_test.go` — `TestResolveCLIExecutableHonorsAppCLISeam`.

Production behaviour is unchanged when the seam is unset (the existing build-relative → PATH resolution stands).

## Verification

- `./playwright/run.sh --build` is **fully green — 87/87**, including all five originally-red specs and the previously-bleeding ones. (Before: 7–10 red, varying per run.)
- `go test ./...` green in `erun-ui`; the new seam unit test passes; playwright `typecheck`/`lint`/`format:check` clean.

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)