### PR TITLE
Lint every module in the pre-commit hook; expand the gate to erun-backend-api

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,16 +2,8 @@
 set -eu
 
 if [ "${SKIP_GOLANGCI_LINT:-0}" = "1" ]; then
-  echo "SKIP_GOLANGCI_LINT=1 detected; skipping golangci-lint pre-commit check." >&2
+  echo "SKIP_GOLANGCI_LINT=1 detected; skipping pre-commit lint." >&2
   exit 0
-fi
-
-if ! command -v golangci-lint >/dev/null 2>&1; then
-  cat <<'MSG' >&2
-error: golangci-lint is not installed.
-Install it from https://golangci-lint.run/welcome/install/ and ensure it is on your PATH.
-MSG
-  exit 1
 fi
 
 if ! command -v git >/dev/null 2>&1; then
@@ -19,40 +11,72 @@ if ! command -v git >/dev/null 2>&1; then
   exit 1
 fi
 
-CHANGED_GO_FILES=$(git diff --cached --name-only --diff-filter=ACMR -- '*.go' || true)
-if [ -z "$CHANGED_GO_FILES" ]; then
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+CHANGED=$(git diff --cached --name-only --diff-filter=ACMR || true)
+CHANGED_GO=$(printf '%s\n' "$CHANGED" | grep -E '\.go$' || true)
+CHANGED_FRONTEND=$(printf '%s\n' "$CHANGED" | grep -E '^erun-ui/(frontend|playwright)/' || true)
+
+if [ -z "$CHANGED_GO" ] && [ -z "$CHANGED_FRONTEND" ]; then
   exit 0
 fi
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
-cd "$REPO_ROOT"
-CLI_ROOT="$REPO_ROOT/erun-cli"
-MODULE_DIR="$CLI_ROOT"
-
-if [ ! -d "$MODULE_DIR" ]; then
-  echo "error: unable to locate CLI module directory at $MODULE_DIR" >&2
-  exit 1
+# --- Go: lint EVERY Go module, each from its own directory so its .golangci.yml
+# applies. This is intentionally broader than the in-build gate (Makefile
+# LINT_MODULES), which can't lint erun-ui in the build image's toolchain — but
+# locally that CGO/webkit toolchain is present, so the hook covers erun-ui (and
+# the backend) too. Linting only a subset let a cyclop finding in erun-common
+# reach the build gate (#595/#597); config-enabled linters like cyclop only fire
+# from inside the module that enables them. Modules are discovered so a new
+# go.mod is covered automatically.
+if [ -n "$CHANGED_GO" ]; then
+  if ! command -v golangci-lint >/dev/null 2>&1; then
+    cat <<'MSG' >&2
+error: golangci-lint is not installed.
+Install it from https://golangci-lint.run/welcome/install/ and ensure it is on your PATH.
+MSG
+    exit 1
+  fi
+  GO_MODULE_DIRS=$(find "$REPO_ROOT" -name go.mod -not -path '*/node_modules/*' -not -path '*/.git/*' -exec dirname {} \; | sort)
+  for module_dir in $GO_MODULE_DIRS; do
+    printf 'golangci-lint --fix %s\n' "${module_dir#"$REPO_ROOT"/}"
+    (
+      cd "$module_dir"
+      golangci-lint run --fix ./...
+    )
+  done
+  printf 'Restaging Go files touched by golangci-lint...\n'
+  printf '%s\n' "$CHANGED_GO" | while IFS= read -r go_file; do
+    if [ -n "$go_file" ] && [ -f "$go_file" ]; then
+      git add "$go_file"
+    fi
+  done
 fi
 
-if [ -f "$CLI_ROOT/go.work" ]; then
-  export GOWORK="$CLI_ROOT/go.work"
+# --- Frontend: lint the desktop app's frontend + Playwright projects when their
+# sources change (eslint via `yarn lint`). Best-effort: skipped with a warning
+# when yarn or a project's node_modules are absent so a Go-only contributor is
+# never blocked. Unlike the Go path it does not auto-fix — TS fixes are left to
+# the author to review.
+if [ -n "$CHANGED_FRONTEND" ]; then
+  if command -v yarn >/dev/null 2>&1; then
+    for fe in erun-ui/frontend erun-ui/playwright; do
+      if printf '%s\n' "$CHANGED_FRONTEND" | grep -q "^$fe/"; then
+        if [ -d "$REPO_ROOT/$fe/node_modules" ]; then
+          printf 'yarn lint %s\n' "$fe"
+          (
+            cd "$REPO_ROOT/$fe"
+            yarn --silent lint
+          )
+        else
+          echo "note: $fe/node_modules missing; skipping its lint (run 'yarn install' there to enable)" >&2
+        fi
+      fi
+    done
+  else
+    echo "note: yarn not found; skipping frontend lint" >&2
+  fi
 fi
 
-printf 'Running golangci-lint with --fix...\n'
-(
-  cd "$MODULE_DIR"
-  golangci-lint run --fix ./...
-)
-printf 'golangci-lint completed successfully.\n'
-
-printf 'Restaging Go files touched by golangci-lint...\n'
-printf '%s\n' "$CHANGED_GO_FILES" | while IFS= read -r go_file; do
-  if [ -z "$go_file" ]; then
-    continue
-  fi
-  if [ ! -f "$go_file" ]; then
-    continue
-  fi
-  git add "$go_file"
-done
-printf 'Go files restaged.\n'
+printf 'pre-commit lint completed.\n'

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 .PHONY: integration-test lint check
 
-# Go modules linted by the in-build gate. erun-ui is intentionally excluded:
-# it needs the CGO/webkit + frontend toolchain the erun-devops build image does
-# not carry, so its golangci-lint gate lives in erun-ui/build.sh instead.
-LINT_MODULES := erun-common erun-cli erun-mcp erun-integration
+# Go modules linted by the in-build gate — every Go module the erun-devops
+# build image can compile. erun-ui is intentionally excluded: it needs the
+# CGO/webkit + frontend toolchain the build image does not carry, so its
+# golangci-lint gate lives in erun-ui/build.sh instead (and the .githooks
+# pre-commit hook lints it locally, where that toolchain is present).
+LINT_MODULES := erun-common erun-cli erun-mcp erun-integration erun-backend/erun-backend-api
 
 # Run golangci-lint across the gated modules, each against its own
 # .golangci.yml (erun-integration has none, so it uses the default linters).

--- a/erun-backend/erun-backend-api/cmd/eapi/main.go
+++ b/erun-backend/erun-backend-api/cmd/eapi/main.go
@@ -39,7 +39,7 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	handler, err := backendapi.NewHandler(backendapi.HandlerOptions{
 		TokenVerifier: backendapi.NewOIDCTokenVerifierWithOptions(backendapi.OIDCTokenVerifierOptions{

--- a/erun-backend/erun-backend-api/internal/routes/json.go
+++ b/erun-backend/erun-backend-api/internal/routes/json.go
@@ -6,7 +6,7 @@ import (
 )
 
 func decodeJSON(r *http.Request, target any) error {
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 	return json.NewDecoder(r.Body).Decode(target)
 }
 

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -1041,9 +1041,9 @@ func kubectlDeployedOptionalArms(t testing.TB, stubsDir string, spec KubectlDepl
 		arms.WriteString(`    printf 'call\n' >> '` + counterFile + `'` + "\n")
 		arms.WriteString(`    case "$count" in` + "\n")
 		for index, code := range spec.ExecExitCodes[:len(spec.ExecExitCodes)-1] {
-			arms.WriteString(fmt.Sprintf(`      %d) exit %d ;;`+"\n", index, code))
+			fmt.Fprintf(&arms, `      %d) exit %d ;;`+"\n", index, code)
 		}
-		arms.WriteString(fmt.Sprintf(`      *) exit %d ;;`+"\n", spec.ExecExitCodes[len(spec.ExecExitCodes)-1]))
+		fmt.Fprintf(&arms, `      *) exit %d ;;`+"\n", spec.ExecExitCodes[len(spec.ExecExitCodes)-1])
 		arms.WriteString(`    esac ;;` + "\n")
 	}
 	if spec.SeedKeyFile != "" {
@@ -1056,7 +1056,7 @@ func kubectlDeployedOptionalArms(t testing.TB, stubsDir string, spec KubectlDepl
 		if spec.WaitStderr != "" {
 			arms.WriteString(`    printf '%s\n' ` + shellSingleQuote(spec.WaitStderr) + ` >&2` + "\n")
 		}
-		arms.WriteString(fmt.Sprintf(`    exit %d ;;`+"\n", spec.WaitExitCode))
+		fmt.Fprintf(&arms, `    exit %d ;;`+"\n", spec.WaitExitCode)
 	}
 	if spec.PodsJSON != "" {
 		podsFile := filepath.Join(stubsDir, "pods.json")


### PR DESCRIPTION
## Problem

The `.githooks/pre-commit` hook only linted **erun-cli**. A finding in any other module — like the #595 `cyclop` in `erun-common` — passed the hook and only failed later in the `erun-devops` image test stage (`make check` → `make lint`). `cyclop` and similar linters are enabled per-module in `.golangci.yml` and only fire when golangci-lint runs from inside that module, so a partial scope is a real gap. The build gate (`make lint`) also missed a lintable Go module (`erun-backend-api`).

## Changes

**Hook — lint everything locally** (`.githooks/pre-commit`):
- Lint **every Go module**, each from its own directory so its `.golangci.yml` applies. Modules are discovered from `go.mod`, so a new module is covered automatically. This includes **erun-ui** and **erun-backend**, which the in-build gate can't lint (the build image lacks erun-ui's CGO/webkit toolchain) but a developer machine can.
- Also lint the desktop app's **frontend + Playwright** projects (`yarn lint`) when their sources change — best-effort, skipped with a warning when `yarn`/`node_modules` are absent so a Go-only contributor isn't blocked.
- Keeps the Go `--fix` + restage behaviour; `SKIP_GOLANGCI_LINT=1` still bypasses everything.

**Gate — every image-lintable Go module** (`Makefile` `LINT_MODULES`):
- Add `erun-backend/erun-backend-api`. erun-ui stays excluded (build-image toolchain) with the reason documented — it's covered by `erun-ui/build.sh` and the hook.

**Findings the broadened scope surfaced** (the gate uses pinned golangci-lint **v2.2.2**; fixed per the repo rule — correct the code, never suppress):
- `erun-backend-api`: `errcheck` on deferred `db.Close` / `r.Body.Close`.
- `erun-integration` fixture: `QF1012` (`fmt.Fprintf` over `WriteString(fmt.Sprintf(...))`).

## Verification

- `make check` green — `make lint` 0 issues across all 5 gate modules (erun-common, erun-cli, erun-mcp, erun-integration, erun-backend-api) under pinned v2.2.2; integration suite green, coverage 77.1% ≥ 75%.
- The new hook lints all **6** Go modules (incl. erun-ui) clean under **both** the pinned v2.2.2 and a newer local golangci-lint (v2.12.2) — verified by running it on this very commit.
- `go test ./...` green in erun-backend-api.

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)