### PR TITLE
Revert erun-backend-api from the in-build lint gate (unbreak the build)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 .PHONY: integration-test lint check
 
-# Go modules linted by the in-build gate — every Go module the erun-devops
-# build image can compile. erun-ui is intentionally excluded: it needs the
-# CGO/webkit + frontend toolchain the build image does not carry, so its
-# golangci-lint gate lives in erun-ui/build.sh instead (and the .githooks
-# pre-commit hook lints it locally, where that toolchain is present).
-LINT_MODULES := erun-common erun-cli erun-mcp erun-integration erun-backend/erun-backend-api
+# Go modules linted by the in-build gate. This list must stay limited to the
+# modules the erun-devops image test stage actually COPYs into its context
+# (erun-devops/docker/erun-devops/Dockerfile): erun-cli, erun-common, erun-mcp,
+# erun-integration. Adding a module the stage does not COPY makes `cd $m` fail
+# and breaks every build (this happened with erun-backend-api, #599). erun-ui
+# and erun-backend are not built by this image, so they are not gated here:
+# erun-ui's lint lives in erun-ui/build.sh, and the .githooks pre-commit hook
+# lints every module (erun-ui + erun-backend included) locally, where the full
+# toolchain is present.
+LINT_MODULES := erun-common erun-cli erun-mcp erun-integration
 
 # Run golangci-lint across the gated modules, each against its own
 # .golangci.yml (erun-integration has none, so it uses the default linters).


### PR DESCRIPTION
## Problem

`erun build` / `erun release` (v1.0.93) fail in the erun-devops image **test stage** at `make check` → `make lint`, exit code 2.

#598 added `erun-backend/erun-backend-api` to the Makefile `LINT_MODULES`, but the erun-devops image test stage (`erun-devops/docker/erun-devops/Dockerfile`) only COPYs `erun-cli`, `erun-common`, `erun-mcp`, `erun-integration` into its build context — it does **not** COPY `erun-backend`. So `make lint`'s `cd erun-backend/erun-backend-api` ran in a directory that does not exist in that stage and failed, breaking every build at `make check` (no image gets tagged).

The erun-devops **runtime** image does not build the backend (the backend ships as its own image under `erun-devops/docker/`), so the backend does not belong in this image's in-build lint gate.

## Fix

- Revert `LINT_MODULES` to the four modules the test stage actually COPYs: `erun-common erun-cli erun-mcp erun-integration`.
- Document the invariant in the Makefile: `LINT_MODULES` must track the stage's COPYs; adding a module the stage does not COPY breaks the build.
- `erun-backend-api` stays linted locally by the `.githooks` pre-commit hook, which discovers and lints **every** Go module (backend + erun-ui included) where the full toolchain is present.
- The `errcheck` fix in `erun-backend-api` and the `QF1012` fix in `erun-integration` from #598 are correct and remain.

## Validation

- `make check` green locally: lint across the four gate modules (0 issues each) + integration suite (coverage 77.1% ≥ 75.0%).
- This restores the exact module set the image test stage compiles, so the in-build `make check` passes again.

No app behavior changes; no docs impact (build-gate plumbing only).

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)