### PR TITLE
Add no-hyphen tenant-name validator enforced at tenant creation

### DIFF
--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -676,6 +676,9 @@ func (s *bootstrapRunState) loadTenantConfig() error {
 }
 
 func (s *bootstrapRunState) createTenantConfig() error {
+	if err := ValidateTenantName(s.tenant); err != nil {
+		return err
+	}
 	projectRoot, err := s.tenantProjectRoot()
 	if err != nil {
 		return err
@@ -1030,6 +1033,37 @@ func remoteKeyImportLabel(tenant, envName string) string {
 
 func remoteHostConfigLabel(tenant, envName string) string {
 	return fmt.Sprintf("Use existing SSH host config for environment %q in tenant %q", envName, tenant)
+}
+
+// maxTenantNameLength caps a tenant name at the RFC 1123 DNS label limit. The
+// combined `<tenant>-<env>` namespace is normalized and truncated separately by
+// normalizeNamespaceName; this bound just keeps a tenant name a single label.
+const maxTenantNameLength = 63
+
+// ValidateTenantName enforces that a tenant name is a single DNS-safe label of
+// lowercase letters and digits with no hyphens. Tenant names feed the
+// `<tenant>-<env>` namespace mapping (KubernetesNamespaceName); forbidding
+// hyphens keeps that mapping unambiguous (split on the first hyphen) and
+// injective, so `a-b`+`c` and `a`+`b-c` can no longer collide on one namespace.
+//
+// The rule is checked before normalization so a caller cannot rely on
+// normalizeNamespaceName to silently repair an invalid name. It is enforced at
+// tenant creation only; tenants created before this rule keep working unchanged
+// (no re-validation on load), preserving back-compat.
+func ValidateTenantName(name string) error {
+	if name == "" {
+		return fmt.Errorf("tenant name is required")
+	}
+	if len(name) > maxTenantNameLength {
+		return fmt.Errorf("invalid tenant name %q: must be at most %d characters", name, maxTenantNameLength)
+	}
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		return fmt.Errorf("invalid tenant name %q: tenant names must use only lowercase letters and digits with no hyphens, so the <tenant>-<env> namespace is unambiguous", name)
+	}
+	return nil
 }
 
 func KubernetesNamespaceName(tenant, envName string) string {

--- a/erun-integration/init_test.go
+++ b/erun-integration/init_test.go
@@ -363,6 +363,31 @@ func TestInit(t *testing.T) {
 		golden.Equal(t, "init/type_rejects_invalid_value", normalize.Apply(result.Combined))
 	})
 
+	t.Run("rejects_hyphenated_tenant", func(t *testing.T) {
+		// A new tenant name containing a hyphen is rejected at creation, before
+		// any tenant/env config is written, so the `<tenant>-<env>` namespace
+		// mapping stays unambiguous (split on the first hyphen) and injective.
+		// The gate fires only when the tenant is new; existing hyphenated
+		// tenants load without re-validation, preserving back-compat.
+		setup := env.New(t)
+		args := []string{
+			"init", "team-one", "prod",
+			"--type", "runtime",
+			"--version", "1.0.0",
+			"--kubernetes-context", "test-context",
+			"--container-registry", "registry.example/test",
+			"--no-git",
+			"--set-default-tenant=true",
+			"--confirm-environment=true",
+			"--dry-run",
+		}
+		result := erun.Run(t, args, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "init/rejects_hyphenated_tenant", normalize.Apply(result.Combined))
+	})
+
 	t.Run("prompts_for_container_registry_via_stdin", func(t *testing.T) {
 		// Executes containerRegistryPrompt (init.go): --container-registry is
 		// omitted so the bootstrap falls through to the interactive promptui

--- a/erun-integration/testdata/init/rejects_hyphenated_tenant.txt
+++ b/erun-integration/testdata/init/rejects_hyphenated_tenant.txt
@@ -1,0 +1,8 @@
+audit: erun init --confirm-environment --container-registry registry.example/test --dry-run --kubernetes-context test-context --no-git --set-default-tenant --type runtime --version <VERSION> team-one prod
+Loading erun tool configuration, configPath=<TMP>
+Saving default config
+mkdir -p <TMP>
+write-yaml <TMP>
+Loaded erun tool configuration
+Loading tenant configuration
+invalid tenant name "team-one": tenant names must use only lowercase letters and digits with no hyphens, so the <tenant>-<env> namespace is unambiguous

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -680,7 +680,7 @@ func TestInitToolUsesExplicitRuntimeVersionOverride(t *testing.T) {
 	}))
 
 	_, output, err := handler(context.Background(), nil, InitInput{
-		Tenant:             "tenant-a",
+		Tenant:             "tenanta",
 		Environment:        "dev",
 		Version:            "1.0.19-snapshot-20260418141901",
 		Remote:             true,


### PR DESCRIPTION
## What & why

First increment of the erunpaas platform epic (**#603**): the shared **no-hyphen tenant-name validator**.

Tenant names feed the `<tenant>-<env>` Kubernetes namespace mapping (`KubernetesNamespaceName`). With no separator guard, `a-b`+`c` and `a`+`b-c` both normalize to the same `a-b-c` namespace — a cross-tenant collision/takeover vector for any public name-choosing surface (the hosted provisioning and console work will expose exactly such a surface).

## Change

- **`ValidateTenantName`** (`erun-common/init.go`): requires a single DNS-safe label of lowercase letters and digits, **no hyphens**, checked *before* normalization so a caller can't rely on `normalizeNamespaceName` to silently repair an invalid name. This makes `<tenant>-<env>` split unambiguously on the first hyphen and the `tenant+env → namespace` mapping injective.
- Enforced in **`createTenantConfig`**, which runs only on the `ErrNotInitialized` (new-tenant) arm of `loadTenantConfig`. Existing tenants load via the `err == nil` arm and are **never re-validated**, so any tenant already created with a hyphen keeps working unchanged (**back-compat**).
- Enforced in the **shared bootstrap**, so it covers **both CLI and MCP** at the lowest shared layer (no transport-specific duplication).

## Validation

- `erun-common`, `erun-cli`, `erun-mcp` — `go build ./...` + `go test ./...` green.
- `make integration-test` green; coverage **77.1% ≥ 75.0%**.
- New integration scenario `init/rejects_hyphenated_tenant` — a new tenant `team-one` is rejected at the creation gate (before any config/namespace write), with an informative error. Existing init goldens (including new-tenant inits like `type_runtime_dry_run` with valid tenant `team`) unchanged.
- Fixed one `erun-mcp` unit test that created a new tenant named `tenant-a`; other `tenant-a` usages (existing-tenant contexts) intentionally left to demonstrate back-compat.

## Scope

Part of the erunpaas platform epic; **does not close #603**. Shared prerequisite reused by hosted provisioning (**#605**) and the web console (**#606**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)