### PR TITLE
Add per-instance platform config block with validation

### DIFF
--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -269,6 +269,10 @@ type ProjectConfig struct {
 	ContainerRegistries ContainerRegistries                 `yaml:"containerregistries,omitempty"`
 	Environments        map[string]ProjectEnvironmentConfig `yaml:"environments,omitempty"`
 	Release             ReleaseConfig                       `yaml:"release,omitempty"`
+	// Platform is the per-instance erunpaas platform configuration (base
+	// domain, delegated services zone, authoritative nameserver, platform
+	// env). Empty for projects that do not run a platform deployment.
+	Platform PlatformConfig `yaml:"platform,omitempty"`
 }
 
 // K8sForEnvironment returns the k8s deploy plan declared for the given

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -418,6 +418,13 @@ func loadProjectK8sPlanForRepo(repoPath, environment string) (ProjectK8sConfig, 
 		}
 		return ProjectK8sConfig{}, err
 	}
+	// A malformed platform block would otherwise surface only later, when
+	// deploy templates platform artifacts (PowerDNS zone, exposure hostnames)
+	// from these values. Reject it here so an inconsistent base-domain /
+	// services-zone / authoritative-IP fails the deploy plan up front.
+	if err := config.Platform.Validate(); err != nil {
+		return ProjectK8sConfig{}, err
+	}
 	return config.K8sForEnvironment(environment), nil
 }
 

--- a/erun-common/platform_config.go
+++ b/erun-common/platform_config.go
@@ -1,0 +1,145 @@
+package eruncommon
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// PlatformConfig is the per-instance configuration for an erunpaas platform
+// deployment, declared under `platform:` in a project's `.erun/config.yaml`.
+//
+// The erun-core platform is a generic, installable product: any vendor can
+// deploy it under their own names, so the base domain, the delegated services
+// zone, the authoritative nameserver, and the platform environment are
+// configuration — never hardcoded literals. The values in any one project are
+// that deployment's; another vendor's deployment (e.g. on a different base
+// domain) supplies its own from the same artifacts.
+//
+// All fields are optional. An empty block (IsZero) means the project does not
+// run a platform deployment. Once any field is set the block is "in use" and
+// Validate enforces internal consistency so a malformed block fails fast
+// rather than producing inconsistent downstream artifacts.
+type PlatformConfig struct {
+	// BaseDomain is the registered domain this deployment serves, e.g.
+	// "erunpaas.com". Required whenever the block is in use; everything else
+	// derives from it.
+	BaseDomain string `yaml:"basedomain,omitempty"`
+	// Env is the dedicated platform environment that owns the per-deployment
+	// global singletons (PowerDNS, the DNS-01 broker), e.g. "frs-prod".
+	Env string `yaml:"env,omitempty"`
+	// ServicesZone is the child zone delegated to this deployment's PowerDNS,
+	// under which tenant services are exposed. Defaults to
+	// "services.<BaseDomain>".
+	ServicesZone string `yaml:"serviceszone,omitempty"`
+	// AuthoritativeIP is the public IP this deployment's authoritative
+	// nameserver answers on (the glue-record target for ServicesZone).
+	AuthoritativeIP string `yaml:"authoritativeip,omitempty"`
+	// Nameservers are the NS hostnames the parent zone delegates ServicesZone
+	// to. Defaults to ["ns1.<BaseDomain>", "ns2.<BaseDomain>"].
+	Nameservers []string `yaml:"nameservers,omitempty"`
+	// AuthHost is the hosted-IdP host, served from the Cloudflare-managed apex
+	// zone (not ServicesZone). Defaults to "auth.<BaseDomain>".
+	AuthHost string `yaml:"authhost,omitempty"`
+	// ACMEEmail is the account email for this deployment's Let's Encrypt
+	// registration. LE rate limits are per registered domain, so each
+	// deployment uses its own account.
+	ACMEEmail string `yaml:"acmeemail,omitempty"`
+}
+
+// IsZero reports whether no platform configuration is set, i.e. the project
+// does not run a platform deployment.
+func (c PlatformConfig) IsZero() bool {
+	return strings.TrimSpace(c.BaseDomain) == "" &&
+		strings.TrimSpace(c.Env) == "" &&
+		strings.TrimSpace(c.ServicesZone) == "" &&
+		strings.TrimSpace(c.AuthoritativeIP) == "" &&
+		len(c.Nameservers) == 0 &&
+		strings.TrimSpace(c.AuthHost) == "" &&
+		strings.TrimSpace(c.ACMEEmail) == ""
+}
+
+// Resolve returns a copy with the derived defaults filled in from BaseDomain
+// (services zone, auth host, nameservers). It does not mutate the receiver and
+// does not invent a BaseDomain: with BaseDomain unset the trimmed input is
+// returned unchanged and Validate rejects the in-use block.
+func (c PlatformConfig) Resolve() PlatformConfig {
+	resolved := c
+	resolved.BaseDomain = strings.TrimSpace(c.BaseDomain)
+	resolved.Env = strings.TrimSpace(c.Env)
+	resolved.ServicesZone = strings.TrimSpace(c.ServicesZone)
+	resolved.AuthoritativeIP = strings.TrimSpace(c.AuthoritativeIP)
+	resolved.AuthHost = strings.TrimSpace(c.AuthHost)
+	resolved.ACMEEmail = strings.TrimSpace(c.ACMEEmail)
+	if resolved.BaseDomain == "" {
+		return resolved
+	}
+	if resolved.ServicesZone == "" {
+		resolved.ServicesZone = "services." + resolved.BaseDomain
+	}
+	if resolved.AuthHost == "" {
+		resolved.AuthHost = "auth." + resolved.BaseDomain
+	}
+	if len(resolved.Nameservers) == 0 {
+		resolved.Nameservers = []string{"ns1." + resolved.BaseDomain, "ns2." + resolved.BaseDomain}
+	}
+	return resolved
+}
+
+// Validate enforces internal consistency of an in-use platform block; it is a
+// no-op for an empty block. The rules keep the nothing-hardcoded invariant
+// honest: a deployment must declare its own base domain, a services zone under
+// that domain, a parseable authoritative IP (when set), an auth host under the
+// base domain, and a platform env name that is a clean namespace label.
+func (c PlatformConfig) Validate() error {
+	if c.IsZero() {
+		return nil
+	}
+	resolved := c.Resolve()
+	if resolved.BaseDomain == "" {
+		return fmt.Errorf("platform config: basedomain is required when a platform block is set")
+	}
+	if !isDNSName(resolved.BaseDomain) {
+		return fmt.Errorf("platform config: basedomain %q is not a valid domain name", resolved.BaseDomain)
+	}
+	if !isUnderDomain(resolved.ServicesZone, resolved.BaseDomain) {
+		return fmt.Errorf("platform config: serviceszone %q must be %q or a subdomain of it", resolved.ServicesZone, resolved.BaseDomain)
+	}
+	if !isUnderDomain(resolved.AuthHost, resolved.BaseDomain) {
+		return fmt.Errorf("platform config: authhost %q must be %q or a subdomain of it", resolved.AuthHost, resolved.BaseDomain)
+	}
+	if resolved.AuthoritativeIP != "" && net.ParseIP(resolved.AuthoritativeIP) == nil {
+		return fmt.Errorf("platform config: authoritativeip %q is not a valid IP address", resolved.AuthoritativeIP)
+	}
+	if resolved.Env != "" && normalizeNamespaceName(resolved.Env) != resolved.Env {
+		return fmt.Errorf("platform config: env %q must be a DNS-safe namespace label (lowercase letters, digits, and hyphens)", resolved.Env)
+	}
+	return nil
+}
+
+// isUnderDomain reports whether host is base itself or a subdomain of base.
+func isUnderDomain(host, base string) bool {
+	return host == base || strings.HasSuffix(host, "."+base)
+}
+
+// isDNSName reports whether name is a plausible DNS domain name: dotted,
+// lowercase, with labels of [a-z0-9-] that do not start or end with a hyphen.
+// It is intentionally strict and lowercase-only so config values match the
+// charset the rest of erun normalizes hostnames to.
+func isDNSName(name string) bool {
+	if name == "" || len(name) > 253 || !strings.Contains(name, ".") {
+		return false
+	}
+	for _, label := range strings.Split(name, ".") {
+		if label == "" || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for _, r := range label {
+			if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+				continue
+			}
+			return false
+		}
+	}
+	return true
+}

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -701,6 +701,24 @@ func TestDeploy(t *testing.T) {
 		golden.Equal(t, "deploy/project_k8s_plan_rejects_invalid_step_node", normalize.Apply(result.Combined))
 	})
 
+	t.Run("rejects_inconsistent_platform_config", func(t *testing.T) {
+		// A `platform:` block whose serviceszone is not under the configured
+		// basedomain is rejected when deploy resolves the project plan, before
+		// any chart work — the per-instance platform config must be internally
+		// consistent (nothing-hardcoded: the services zone belongs under this
+		// deployment's own base domain). Reaches PlatformConfig.Validate via
+		// loadProjectK8sPlanForRepo.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		fixture.SeedProjectK8sConfig(t, setup, "platform:\n  basedomain: erunpaas.com\n  env: frs-prod\n  serviceszone: services.kppaas.com\n")
+		result := erun.Run(t, []string{"deploy", "team", "dev", "--version", "1.0.0", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit for inconsistent platform config, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "deploy/rejects_inconsistent_platform_config", normalize.Apply(result.Combined))
+	})
+
 	t.Run("components_rejects_unknown_name", func(t *testing.T) {
 		setup := env.New(t)
 		fixture.SeedTenantEnv(t, setup, "team", "dev")

--- a/erun-integration/testdata/deploy/rejects_inconsistent_platform_config.txt
+++ b/erun-integration/testdata/deploy/rejects_inconsistent_platform_config.txt
@@ -1,0 +1,5 @@
+audit: erun deploy --dry-run --version <VERSION> team dev
+trace-log: would append the full trace to <TMP>
+deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
+deploy: spec resolution failed: platform config: serviceszone "services.kppaas.com" must be "erunpaas.com" or a subdomain of it
+platform config: serviceszone "services.kppaas.com" must be "erunpaas.com" or a subdomain of it


### PR DESCRIPTION
## What & why

Step 0.2 of the erunpaas platform epic (**#603**): the **per-instance platform config block**.

The platform is a generic, installable product — any vendor deploys it under their own names — so the base domain, delegated services zone, authoritative nameserver, platform env, and ACME account are **configuration, never hardcoded literals**. This adds the `platform:` block that every later platform artifact (PowerDNS zone, exposure hostnames, the DNS-01 broker) templates from.

## Change

- **`PlatformConfig`** (`erun-common/platform_config.go`), added to `ProjectConfig` (`.erun/config.yaml`): `basedomain`, `env`, `serviceszone`, `authoritativeip`, `nameservers`, `authhost`, `acmeemail`.
- **`Resolve()`** derives defaults from `BaseDomain` — `services.<base>`, `auth.<base>`, `ns1/ns2.<base>` — so a deployment only has to declare its base domain.
- **`Validate()`** enforces internal consistency: base domain set and DNS-valid, services zone and auth host under the base domain, authoritative IP parseable, env a clean namespace label. No-op for an empty block (projects that don't run a platform deployment).
- **Deploy consumes it**: `loadProjectK8sPlanForRepo` validates the block when resolving the project plan, so an inconsistent block (e.g. a services zone pointing at a *different* domain) fails the deploy up front instead of producing mismatched downstream artifacts. This is the gate-covered first consumer.

## Validation (in-sandbox)

- `erun-common`, `erun-cli`, `erun-mcp` — `go build` + `go test` green.
- `make integration-test` green; coverage **77.1% ≥ 75%**.
- New scenario `deploy/rejects_inconsistent_platform_config` — a `platform:` block with `serviceszone: services.kppaas.com` under `basedomain: erunpaas.com` is rejected at plan resolution with a clear error, before any chart work. No existing deploy goldens drifted (the block is new; absent fixtures are unaffected).

> **Live gate:** none — this is config schema + validation, fully gated in-sandbox.

## Scope

First consumer of the block. The **PowerDNS singleton** and the **exposure wiring** that template PowerDNS zone / service hostnames from these resolved values land next (those carry live cluster/DNS gates). **Does not close #603.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)