### PR TITLE
Thread platform config into PowerDNS deploy and bootstrap its zone

### DIFF
--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -177,6 +177,11 @@ type HelmDeploySpec struct {
 	// DisableBuildScript mirrors EnvConfig.DisableBuildScript so a remote-agent
 	// pod's in-pod build honours the operator's build.sh-discovery choice (#548).
 	DisableBuildScript bool
+	// Platform is the resolved per-instance platform config (base domain,
+	// services zone, authoritative IP, nameservers). Zero for non-platform
+	// projects; when set, deploy threads it to every chart as platform.*
+	// values so the PowerDNS singleton can bootstrap its authoritative zone.
+	Platform PlatformConfig
 }
 
 type HelmReleaseRecoveryParams struct {
@@ -1294,6 +1299,7 @@ func newHelmDeploySpecWithValues(target OpenResult, deployContext KubernetesDepl
 		ContainerRegistry:   resolveProjectContainerRegistry(target.RepoPath, target.Environment),
 		RuntimeRegistry:     strings.TrimSpace(target.EnvConfig.RuntimeRegistry),
 		ContainerRegistries: containerRegistries,
+		Platform:            resolveProjectPlatform(target.RepoPath),
 		DisableBuildScript:  target.EnvConfig.DisableBuildScript,
 		Idle:                target.EnvConfig.Idle,
 		Claude:              target.EnvConfig.Claude,
@@ -1322,6 +1328,24 @@ func resolveProjectContainerRegistry(projectRoot, environment string) string {
 	}
 	registry, _ := list.DeployRegistry()
 	return registry
+}
+
+// resolveProjectPlatform loads the per-instance platform config from the
+// project's .erun/config.yaml and returns it with defaults resolved. Returns a
+// zero PlatformConfig when the project is uninitialized or declares no platform
+// block, so deploy threads no platform.* values for non-platform projects. The
+// block is validated earlier (loadProjectK8sPlanForRepo), so a malformed block
+// fails the plan before reaching here.
+func resolveProjectPlatform(projectRoot string) PlatformConfig {
+	projectRoot = strings.TrimSpace(projectRoot)
+	if projectRoot == "" {
+		return PlatformConfig{}
+	}
+	projectConfig, _, err := LoadProjectConfig(projectRoot)
+	if err != nil {
+		return PlatformConfig{}
+	}
+	return projectConfig.Platform.Resolve()
 }
 
 func applyCloudContextStopMetadata(store CloudReadStore, env EnvConfig, deployInput *HelmDeploySpec) {
@@ -1536,6 +1560,23 @@ func (d HelmDeploySpec) command() commandSpec {
 	args = append(args, "--set", "disableBuildScript="+formatHelmBool(d.DisableBuildScript))
 	for _, key := range sortedStringMapKeys(d.ImageOverrides) {
 		args = append(args, "--set-string", "imageOverrides."+key+"="+d.ImageOverrides[key])
+	}
+	// Per-instance platform values, guarded on presence so non-platform deploys
+	// (every existing env) render no platform.* args. Threaded to every chart;
+	// only the PowerDNS singleton reads them (to bootstrap its services zone).
+	if p := d.Platform; !p.IsZero() {
+		args = append(args,
+			"--set-string", "platform.baseDomain="+p.BaseDomain,
+			"--set-string", "platform.env="+p.Env,
+			"--set-string", "platform.servicesZone="+p.ServicesZone,
+			"--set-string", "platform.authoritativeIP="+p.AuthoritativeIP,
+			"--set-string", "platform.authHost="+p.AuthHost,
+		)
+		if len(p.Nameservers) > 0 {
+			if encoded, marshalErr := json.Marshal(p.Nameservers); marshalErr == nil {
+				args = append(args, "--set-json", "platform.nameservers="+string(encoded))
+			}
+		}
 	}
 	args = append(args,
 		"--set-string", "idle.timeout="+helmIdleTimeout(d.Idle),

--- a/erun-devops/k8s/erun-powerdns/templates/powerdns.yaml
+++ b/erun-devops/k8s/erun-powerdns/templates/powerdns.yaml
@@ -41,6 +41,9 @@
 {{- $containerRegistry := default "ghcr.io/sophium" .Values.containerRegistry -}}
 {{- $powerdnsImage := default (printf "%s/erun-powerdns:4.9.3" $containerRegistry) (index $imageOverrides "erun-powerdns") -}}
 {{- $postgresImage := default (printf "%s/erun-backend-postgres:18.3" $containerRegistry) (index $imageOverrides "erun-backend-postgres") -}}
+{{- $platform := default dict .Values.platform -}}
+{{- $servicesZone := default "" $platform.servicesZone -}}
+{{- $nameservers := default (list) $platform.nameservers -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -132,6 +135,29 @@ spec:
           volumeMounts:
             - name: schema
               mountPath: /schema
+        {{- if $servicesZone }}
+        # Bootstrap the authoritative services zone once, with its nameservers,
+        # from the per-instance platform config that deploy threads in as
+        # platform.* values. Idempotent (skips when the zone already exists).
+        # Per-env wildcard/_acme-challenge records are added later via the API.
+        - name: zone-bootstrap
+          image: {{ $powerdnsImage }}
+          env:
+            - name: PDNS_GPGSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresPasswordSecretName }}
+                  key: {{ $postgresPasswordSecretKey }}
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              pdnsutil="pdnsutil --launch=gpgsql --gpgsql-host={{ $postgresHost }} --gpgsql-port={{ $postgresPort }} --gpgsql-dbname={{ $powerdnsDatabase }} --gpgsql-user={{ $postgresUser }} --gpgsql-password=$PDNS_GPGSQL_PASSWORD"
+              if ! $pdnsutil list-zone {{ $servicesZone | quote }} >/dev/null 2>&1; then
+                $pdnsutil create-zone {{ $servicesZone | quote }}{{ range $ns := $nameservers }} {{ $ns | quote }}{{ end }}
+              fi
+        {{- end }}
       containers:
         - name: erun-powerdns
           image: {{ $powerdnsImage }}

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -719,6 +719,20 @@ func TestDeploy(t *testing.T) {
 		golden.Equal(t, "deploy/rejects_inconsistent_platform_config", normalize.Apply(result.Combined))
 	})
 
+	t.Run("platform_config_threads_into_helm_set", func(t *testing.T) {
+		// A valid `platform:` block flows into every chart's helm command as
+		// guarded platform.* --set args, with Resolve's defaults filled in
+		// (serviceszone/authhost/nameservers derived from basedomain). Only the
+		// PowerDNS singleton reads them; the runtime chart ignores them. Proves
+		// the deploy -> platform-config -> helm wiring end to end.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		fixture.SeedProjectK8sConfig(t, setup, "platform:\n  basedomain: erunpaas.com\n  env: frs-prod\n  authoritativeip: 212.93.120.230\n")
+		result := erun.Run(t, []string{"deploy", "team", "dev", "--version", "1.0.0", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		golden.Equal(t, "deploy/platform_config_threads_into_helm_set", normalize.Apply(result.Combined))
+	})
+
 	t.Run("components_rejects_unknown_name", func(t *testing.T) {
 		setup := env.New(t)
 		fixture.SeedTenantEnv(t, setup, "team", "dev")

--- a/erun-integration/testdata/deploy/platform_config_threads_into_helm_set.txt
+++ b/erun-integration/testdata/deploy/platform_config_threads_into_helm_set.txt
@@ -1,0 +1,11 @@
+audit: erun deploy --dry-run --version <VERSION> team dev
+trace-log: would append the full trace to <TMP>
+deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
+deploy: version <VERSION> pinned; installing the published image by reference (deploy never builds)
+deploy: resolved 1 spec(s)
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 5m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set-string api.oidcAllowedIssuers= --set api.postgres.reset=true --set-json 'containerRegistries=[{"registry":"registry.example/test","roles":["build","deploy"]}]' --set disableBuildScript=false --set-string platform.baseDomain=erunpaas.com --set-string platform.env=frs-prod --set-string platform.servicesZone=services.erunpaas.com --set-string platform.authoritativeIP=<VERSION>.230 --set-string platform.authHost=auth.erunpaas.com --set-json 'platform.nameservers=["ns1.erunpaas.com","ns2.erunpaas.com"]' --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)


### PR DESCRIPTION
## What & why

Wires the per-instance platform config (#610) through `deploy` into the PowerDNS singleton (#611) — the consumer that makes the config block load-bearing.

## Change

- **`deploy` threads the platform config to charts.** `resolveProjectPlatform` loads the project's `platform:` block; when present, deploy passes it to every chart's helm install as **guarded** `platform.*` `--set` args (`baseDomain`/`env`/`servicesZone`/`authoritativeIP`/`authHost` + `nameservers` as `--set-json`), with `Resolve`'s defaults filled in. Guarded on `PlatformConfig.IsZero`, so every existing (non-platform) deploy renders **no** `platform.*` args and **no goldens churn**. Only the PowerDNS chart reads them; the runtime chart ignores them.
- **PowerDNS chart bootstraps its zone.** A guarded `zone-bootstrap` init container creates the authoritative `services.<base-domain>` zone with its nameservers via `pdnsutil` (idempotent — skips when the zone exists). Per-env wildcard / `_acme-challenge` records are added later through the API.

## Validation (in-sandbox)

- `helm template` renders the zone-bootstrap **only** when a services zone is set (guarded), and emits the correct `pdnsutil create-zone services.erunpaas.com ns1... ns2...`.
- `erun-common`, `erun-cli`, `erun-mcp` build + test green.
- `make integration-test` green; coverage **77.1% ≥ 75%**. New scenario `deploy/platform_config_threads_into_helm_set` proves the platform block flows into the helm command with `Resolve`'s derived defaults; existing deploy goldens unchanged (guarded).

## ⚠️ Live verification gate (operator, on real frs-prod)

- `pdnsutil --launch=gpgsql ...` arg handling and `create-zone` behavior against the shared postgres;
- the zone actually becomes resolvable / authoritative once delegated.

## Scope

Completes the deploy→config→PowerDNS→zone path. **Next:** the per-cluster Traefik ingress + the exposure command (wildcard A per env), then the DNS-01 broker (which depends on #604 identity). **Does not close #603.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)