### PR TITLE
Add erun expose command (CLI + MCP) for public service exposure

### DIFF
--- a/erun-cli/cmd/expose.go
+++ b/erun-cli/cmd/expose.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	common "github.com/sophium/erun/erun-common"
+	"github.com/spf13/cobra"
+)
+
+func newExposeCmd(store common.ExposeStore, findProjectRoot common.ProjectFinderFunc) *cobra.Command {
+	var targetIP string
+	var servicePort int
+	cmd := &cobra.Command{
+		Use:   "expose TENANT ENVIRONMENT SERVICE",
+		Short: "Expose an environment's Service at a public hostname",
+		Long: "Expose an in-namespace Service at a stable public hostname under the platform's services zone.\n\n" +
+			"Ensures the per-environment wildcard DNS record points at the env's ingress IP and applies a " +
+			"Host-routing Ingress for the Service. Requires a platform block in .erun/config.yaml; it mutates the " +
+			"platform DNS zone and applies to the env's cluster. Use --dry-run to preview the resolved hostname and actions.",
+		Example:      "  erun expose team dev api --ip 127.0.0.1\n  erun expose team dev api --ip 203.0.113.10 --port 8080",
+		Args:         cobra.ExactArgs(3),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExposeCommand(withCloudContextPreflight(commandContext(cmd), store), store, findProjectRoot, args[0], args[1], args[2], targetIP, servicePort)
+		},
+	}
+	addDryRunFlag(cmd)
+	cmd.Flags().StringVar(&targetIP, "ip", "", "Ingress IP the per-env wildcard record points at (e.g. 127.0.0.1 for a local cluster, the public LB IP for remote)")
+	cmd.Flags().IntVar(&servicePort, "port", 0, "Service port to route to (default 80)")
+	return cmd
+}
+
+func runExposeCommand(ctx common.Context, store common.ExposeStore, findProjectRoot common.ProjectFinderFunc, tenant, environment, service, targetIP string, servicePort int) error {
+	if findProjectRoot == nil {
+		findProjectRoot = common.FindProjectRoot
+	}
+	_, projectRoot, err := findProjectRoot()
+	if err != nil {
+		return err
+	}
+	result, err := common.RunExposeService(ctx, common.ExposeServiceParams{
+		Tenant:      strings.TrimSpace(tenant),
+		Environment: strings.TrimSpace(environment),
+		Service:     strings.TrimSpace(service),
+		ProjectRoot: projectRoot,
+		TargetIP:    strings.TrimSpace(targetIP),
+		ServicePort: servicePort,
+	}, store, nil, nil)
+	if err != nil {
+		return err
+	}
+	if !ctx.DryRun {
+		_, _ = fmt.Fprintf(ctx.Stdout, "exposed %s/%s service %s at https://%s\n", result.Tenant, result.Environment, result.Service, result.Hostname)
+	}
+	return nil
+}

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -141,6 +141,7 @@ func (d rootDependencies) commands() []*cobra.Command {
 		newOutputsCmd(d.resolveOpen),
 		newDoctorCmd(d.resolveOpen, d.configStore, common.CloudDependencies{}, common.CloudContextDependencies{}, runPrompt),
 		newDeleteCmd(d.configStore, runPrompt, common.DeleteKubernetesNamespace),
+		newExposeCmd(d.configStore, common.FindProjectRoot),
 		newContributeCmd(common.GitCommandRunner),
 		newIdleCmd(d.configStore),
 		newReleaseCmd(common.FindProjectRoot, common.GitCommandRunner),

--- a/erun-common/expose.go
+++ b/erun-common/expose.go
@@ -1,0 +1,185 @@
+package eruncommon
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ExposeStore is the read surface RunExposeService needs to resolve the target
+// environment (its namespace and kubernetes context).
+type ExposeStore interface {
+	LoadEnvConfig(string, string) (EnvConfig, string, error)
+}
+
+// DNSRecordUpserterFunc writes (creates or replaces) a single DNS record in the
+// platform's authoritative zone via the PowerDNS API. Injected so dry-run never
+// touches the network and tests stay deterministic; the default implementation
+// is live-only.
+type DNSRecordUpserterFunc func(params DNSRecordUpsertParams) error
+
+// IngressApplierFunc applies the Host-routing Ingress that fronts the exposed
+// Service. Injected for the same reason as DNSRecordUpserterFunc.
+type IngressApplierFunc func(params IngressApplyParams) error
+
+// DNSRecordUpsertParams is the per-record write the exposure flow performs
+// against PowerDNS (the per-env wildcard A record). PlatformNamespace and
+// KubernetesContext locate the platform's PowerDNS pod (the singleton that owns
+// the services zone), which the default implementation reaches by exec.
+type DNSRecordUpsertParams struct {
+	Zone              string
+	Name              string
+	Type              string
+	TTL               int
+	Value             string
+	PlatformNamespace string
+	KubernetesContext string
+}
+
+// IngressApplyParams is the Host-routing Ingress the exposure flow applies into
+// the env namespace.
+type IngressApplyParams struct {
+	KubernetesContext string
+	Namespace         string
+	Name              string
+	Host              string
+	ServiceName       string
+	ServicePort       int
+}
+
+// ExposeServiceParams are the inputs to exposing one in-namespace Service at a
+// stable public hostname. ProjectRoot locates the platform config; TargetIP is
+// the env's ingress IP the per-env wildcard A record points at (127.0.0.1 for a
+// VM-based local cluster, a node/LAN IP, or the public LB IP for remote).
+type ExposeServiceParams struct {
+	Tenant      string
+	Environment string
+	Service     string
+	ProjectRoot string
+	TargetIP    string
+	ServicePort int
+}
+
+// ExposeServiceResult is the resolved exposure plan: the public hostname, the
+// per-env wildcard record, and the ingress that will front the Service.
+type ExposeServiceResult struct {
+	Tenant            string `json:"tenant"`
+	Environment       string `json:"environment"`
+	Service           string `json:"service"`
+	Namespace         string `json:"namespace"`
+	KubernetesContext string `json:"kubernetesContext,omitempty"`
+	Hostname          string `json:"hostname"`
+	ServicesZone      string `json:"servicesZone"`
+	WildcardName      string `json:"wildcardName"`
+	TargetIP          string `json:"targetIP"`
+	IngressName       string `json:"ingressName"`
+	ServicePort       int    `json:"servicePort"`
+}
+
+const defaultExposeServicePort = 80
+
+// defaultExposeWildcardTTL is the TTL for the per-env wildcard A record. Short
+// enough that re-pointing an env (IP change) propagates quickly.
+const defaultExposeWildcardTTL = 60
+
+// RunExposeService resolves and (unless dry-run) performs the work to expose
+// Service <service> in <tenant>-<env> at <service>.<tenant>-<env>.<servicesZone>:
+// it ensures the per-env wildcard A record in the platform's services zone and
+// applies a Host-routing Ingress into the env namespace. The per-env wildcard
+// covers every service in the env, so exposing additional services only adds an
+// Ingress. Every action and decision is traced before execution so a dry-run is
+// a complete, side-effect-free plan.
+func RunExposeService(ctx Context, params ExposeServiceParams, store ExposeStore, upsertDNSRecord DNSRecordUpserterFunc, applyIngress IngressApplierFunc) (ExposeServiceResult, error) {
+	store, upsertDNSRecord, applyIngress = normalizeExposeDependencies(store, upsertDNSRecord, applyIngress)
+
+	tenant := strings.TrimSpace(params.Tenant)
+	environment := strings.TrimSpace(params.Environment)
+	service := strings.TrimSpace(params.Service)
+	if tenant == "" || environment == "" || service == "" {
+		return ExposeServiceResult{}, fmt.Errorf("tenant, environment, and service are required")
+	}
+	if err := ValidateTenantName(tenant); err != nil {
+		return ExposeServiceResult{}, err
+	}
+
+	platform := resolveProjectPlatform(params.ProjectRoot)
+	if platform.IsZero() || strings.TrimSpace(platform.ServicesZone) == "" {
+		return ExposeServiceResult{}, fmt.Errorf("expose requires a platform block with a base domain in .erun/config.yaml (the services zone tenant hostnames live under)")
+	}
+
+	envConfig, _, err := store.LoadEnvConfig(tenant, environment)
+	if err != nil {
+		return ExposeServiceResult{}, err
+	}
+
+	targetIP := strings.TrimSpace(params.TargetIP)
+	if targetIP == "" {
+		return ExposeServiceResult{}, fmt.Errorf("a target IP is required (the env's ingress IP the wildcard record points at, e.g. 127.0.0.1 for a local cluster)")
+	}
+
+	servicePort := params.ServicePort
+	if servicePort <= 0 {
+		servicePort = defaultExposeServicePort
+	}
+
+	envLabel := KubernetesNamespaceName(tenant, environment)
+	result := ExposeServiceResult{
+		Tenant:            tenant,
+		Environment:       environment,
+		Service:           service,
+		Namespace:         envLabel,
+		KubernetesContext: strings.TrimSpace(envConfig.KubernetesContext),
+		Hostname:          fmt.Sprintf("%s.%s.%s", service, envLabel, platform.ServicesZone),
+		ServicesZone:      platform.ServicesZone,
+		WildcardName:      fmt.Sprintf("*.%s.%s", envLabel, platform.ServicesZone),
+		TargetIP:          targetIP,
+		IngressName:       fmt.Sprintf("expose-%s", service),
+		ServicePort:       servicePort,
+	}
+
+	ctx.Trace(fmt.Sprintf("expose: %s -> service %s.%s.svc:%d", result.Hostname, service, result.Namespace, servicePort))
+	ctx.Trace(fmt.Sprintf("expose: per-env wildcard %s A %s (zone %s)", result.WildcardName, targetIP, platform.ServicesZone))
+	ctx.TraceCommand("", "powerdns-upsert-record", platform.ServicesZone, result.WildcardName, "A", targetIP)
+	ctx.TraceCommand("", "kubectl", "apply", "ingress/"+result.IngressName, "-n", result.Namespace)
+	if ctx.DryRun {
+		return result, nil
+	}
+
+	if err := ctx.RequireKubernetesContext(result.KubernetesContext); err != nil {
+		return result, fmt.Errorf("expose %s/%s: %w", tenant, environment, err)
+	}
+	if err := upsertDNSRecord(DNSRecordUpsertParams{
+		Zone:              platform.ServicesZone,
+		Name:              result.WildcardName,
+		Type:              "A",
+		TTL:               defaultExposeWildcardTTL,
+		Value:             targetIP,
+		PlatformNamespace: normalizeNamespaceName(platform.Env),
+		KubernetesContext: result.KubernetesContext,
+	}); err != nil {
+		return result, fmt.Errorf("upsert wildcard DNS record %s: %w", result.WildcardName, err)
+	}
+	if err := applyIngress(IngressApplyParams{
+		KubernetesContext: result.KubernetesContext,
+		Namespace:         result.Namespace,
+		Name:              result.IngressName,
+		Host:              result.Hostname,
+		ServiceName:       service,
+		ServicePort:       servicePort,
+	}); err != nil {
+		return result, fmt.Errorf("apply ingress %s: %w", result.IngressName, err)
+	}
+	return result, nil
+}
+
+func normalizeExposeDependencies(store ExposeStore, upsertDNSRecord DNSRecordUpserterFunc, applyIngress IngressApplierFunc) (ExposeStore, DNSRecordUpserterFunc, IngressApplierFunc) {
+	if store == nil {
+		store = ConfigStore{}
+	}
+	if upsertDNSRecord == nil {
+		upsertDNSRecord = upsertPowerDNSRecord
+	}
+	if applyIngress == nil {
+		applyIngress = applyHostRoutingIngress
+	}
+	return store, upsertDNSRecord, applyIngress
+}

--- a/erun-common/expose_exec.go
+++ b/erun-common/expose_exec.go
@@ -1,0 +1,87 @@
+package eruncommon
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// applyHostRoutingIngress renders and applies a networking.k8s.io/v1 Ingress
+// that Host-routes the exposed hostname to the in-namespace Service. Live-only:
+// it shells out to kubectl against the env's cluster, so it never runs under a
+// dry-run (RunExposeService short-circuits before calling it).
+func applyHostRoutingIngress(params IngressApplyParams) error {
+	manifest := renderHostRoutingIngress(params)
+	file, err := os.CreateTemp("", "erun-expose-ingress-*.yaml")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(file.Name()) }()
+	if _, err := file.WriteString(manifest); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	args := []string{}
+	if ctxName := strings.TrimSpace(params.KubernetesContext); ctxName != "" {
+		args = append(args, "--context", ctxName)
+	}
+	args = append(args, "-n", params.Namespace, "apply", "-f", file.Name())
+	if out, err := Command("kubectl", args...).CombinedOutput(); err != nil {
+		return fmt.Errorf("kubectl apply ingress: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func renderHostRoutingIngress(params IngressApplyParams) string {
+	return fmt.Sprintf(`apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    app.kubernetes.io/managed-by: erun-expose
+spec:
+  rules:
+    - host: %s
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: %s
+                port:
+                  number: %d
+`, params.Name, params.Namespace, params.Host, params.ServiceName, params.ServicePort)
+}
+
+// upsertPowerDNSRecord replaces the rrset for one record in the platform's
+// services zone by exec'ing pdnsutil inside the PowerDNS pod, which holds the
+// gpgsql password in its PDNS_GPGSQL_PASSWORD env (expanded by the in-pod sh).
+// The gpgsql connection coordinates match the erun-powerdns chart defaults.
+// Live-only: never runs under a dry-run.
+func upsertPowerDNSRecord(params DNSRecordUpsertParams) error {
+	relName := strings.TrimSuffix(params.Name, "."+params.Zone)
+	script := fmt.Sprintf(
+		`pdnsutil --launch=gpgsql --gpgsql-host=erun-postgres --gpgsql-port=5432 --gpgsql-dbname=powerdns --gpgsql-user=erun --gpgsql-password="$PDNS_GPGSQL_PASSWORD" replace-rrset %s %s %s %d %s`,
+		shellSingleQuote(params.Zone), shellSingleQuote(relName), shellSingleQuote(params.Type), params.TTL, shellSingleQuote(params.Value),
+	)
+	args := []string{}
+	if ctxName := strings.TrimSpace(params.KubernetesContext); ctxName != "" {
+		args = append(args, "--context", ctxName)
+	}
+	args = append(args, "-n", params.PlatformNamespace, "exec", "deploy/erun-powerdns", "--", "sh", "-c", script)
+	if out, err := Command("kubectl", args...).CombinedOutput(); err != nil {
+		return fmt.Errorf("kubectl exec pdnsutil replace-rrset: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// shellSingleQuote wraps a value in single quotes for safe interpolation into
+// the in-pod `sh -c` script, escaping any embedded single quotes.
+func shellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}

--- a/erun-integration/expose_test.go
+++ b/erun-integration/expose_test.go
@@ -1,0 +1,62 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/sophium/erun/erun-integration/internal/env"
+	"github.com/sophium/erun/erun-integration/internal/erun"
+	"github.com/sophium/erun/erun-integration/internal/fixture"
+	"github.com/sophium/erun/erun-integration/internal/golden"
+	"github.com/sophium/erun/erun-integration/internal/normalize"
+)
+
+func TestExpose(t *testing.T) {
+	t.Run("help", func(t *testing.T) {
+		setup := env.New(t)
+		result := erun.Run(t, []string{"expose", "--help"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "expose/help", normalize.Apply(result.Combined))
+	})
+
+	t.Run("dry_run", func(t *testing.T) {
+		// With a platform block and an env, expose resolves the public hostname
+		// and traces the full plan: the per-env wildcard A record upsert into
+		// the services zone and the Host-routing Ingress apply. No side effects.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedGitRepo(t, setup.Cwd)
+		fixture.SeedProjectK8sConfig(t, setup, "platform:\n  basedomain: erunpaas.com\n  env: frs-prod\n  authoritativeip: 203.0.113.10\n")
+		result := erun.Run(t, []string{"expose", "team", "dev", "api", "--ip", "203.0.113.10", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		golden.Equal(t, "expose/dry_run", normalize.Apply(result.Combined))
+	})
+
+	t.Run("requires_platform_config", func(t *testing.T) {
+		// expose only makes sense for a platform deployment; without a platform
+		// block in .erun/config.yaml it fails with an actionable error rather
+		// than resolving a hostname under an unknown zone.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedGitRepo(t, setup.Cwd)
+		result := erun.Run(t, []string{"expose", "team", "dev", "api", "--ip", "127.0.0.1", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit without a platform block, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "expose/requires_platform_config", normalize.Apply(result.Combined))
+	})
+
+	t.Run("requires_ip", func(t *testing.T) {
+		// The per-env wildcard record needs a target IP (the env's ingress IP);
+		// omitting --ip fails clearly instead of writing an empty record.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedGitRepo(t, setup.Cwd)
+		fixture.SeedProjectK8sConfig(t, setup, "platform:\n  basedomain: erunpaas.com\n  env: frs-prod\n")
+		result := erun.Run(t, []string{"expose", "team", "dev", "api", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit without --ip, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "expose/requires_ip", normalize.Apply(result.Combined))
+	})
+}

--- a/erun-integration/testdata/build/help.txt
+++ b/erun-integration/testdata/build/help.txt
@@ -33,6 +33,7 @@ Available Commands:
   devops      DevOps utilities
   doctor      Diagnose and repair an environment's runtime and config
   exec        Repository execution utilities
+  expose      Expose an environment's Service at a public hostname
   help        Help about any command
   idle        Show environment idle stop status
   init        Initialize configuration for the current project

--- a/erun-integration/testdata/expose/dry_run.txt
+++ b/erun-integration/testdata/expose/dry_run.txt
@@ -1,0 +1,5 @@
+audit: erun expose --dry-run --ip <VERSION>.10 team dev api
+expose: api.team-dev.services.erunpaas.com -> service api.team-dev.svc:80
+expose: per-env wildcard *.team-dev.services.erunpaas.com A <VERSION>.10 (zone services.erunpaas.com)
+powerdns-upsert-record services.erunpaas.com '*.team-dev.services.erunpaas.com' A <VERSION>.10
+kubectl apply ingress/expose-api -n team-dev

--- a/erun-integration/testdata/expose/help.txt
+++ b/erun-integration/testdata/expose/help.txt
@@ -1,0 +1,21 @@
+Expose an in-namespace Service at a stable public hostname under the platform's services zone.
+
+Ensures the per-environment wildcard DNS record points at the env's ingress IP and applies a Host-routing Ingress for the Service. Requires a platform block in .erun/config.yaml; it mutates the platform DNS zone and applies to the env's cluster. Use --dry-run to preview the resolved hostname and actions.
+
+Usage:
+  erun expose TENANT ENVIRONMENT SERVICE [flags]
+
+Examples:
+  erun expose team dev api --ip <LOOPBACK>
+  erun expose team dev api --ip <VERSION>.10 --port 8080
+
+Flags:
+      --dry-run     Resolve and trace mutating actions without executing them.
+  -h, --help        help for expose
+      --ip string   Ingress IP the per-env wildcard record points at (e.g. <LOOPBACK> for a local cluster, the public LB IP for remote)
+      --port int    Service port to route to (default 80)
+
+Global Flags:
+      --output string   Result format: text (default, human stream) or json (structured result on stdout for orchestrators). (default "text")
+      --time            Print the elapsed runtime after the command finishes.
+  -v, --verbose count   Increase verbosity: -v streams external tool output, -vv adds erun command traces.

--- a/erun-integration/testdata/expose/requires_ip.txt
+++ b/erun-integration/testdata/expose/requires_ip.txt
@@ -1,0 +1,2 @@
+audit: erun expose --dry-run team dev api
+a target IP is required (the env's ingress IP the wildcard record points at, e.g. <LOOPBACK> for a local cluster)

--- a/erun-integration/testdata/expose/requires_platform_config.txt
+++ b/erun-integration/testdata/expose/requires_platform_config.txt
@@ -1,0 +1,2 @@
+audit: erun expose --dry-run --ip <LOOPBACK> team dev api
+expose requires a platform block with a base domain in .erun/config.yaml (the services zone tenant hostnames live under)

--- a/erun-integration/testdata/root/help.txt
+++ b/erun-integration/testdata/root/help.txt
@@ -33,6 +33,7 @@ Available Commands:
   devops      DevOps utilities
   doctor      Diagnose and repair an environment's runtime and config
   exec        Repository execution utilities
+  expose      Expose an environment's Service at a public hostname
   help        Help about any command
   idle        Show environment idle stop status
   init        Initialize configuration for the current project

--- a/erun-mcp/expose.go
+++ b/erun-mcp/expose.go
@@ -1,0 +1,46 @@
+package erunmcp
+
+import (
+	"context"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+type ExposeInput struct {
+	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant name; defaults to the MCP runtime context tenant"`
+	Environment string `json:"environment,omitempty" jsonschema:"environment name; defaults to the MCP runtime context environment"`
+	Service     string `json:"service" jsonschema:"required name of the in-namespace Service to expose at a public hostname"`
+	ProjectRoot string `json:"projectRoot,omitempty" jsonschema:"project root holding the platform config (.erun/config.yaml); defaults to the runtime repo path"`
+	IP          string `json:"ip" jsonschema:"required ingress IP the per-env wildcard record points at (e.g. 127.0.0.1 for a local cluster, the public LB IP for remote)"`
+	Port        int    `json:"port,omitempty" jsonschema:"Service port to route to (default 80)"`
+	Preview     bool   `json:"preview,omitempty" jsonschema:"when true, resolve and print the planned actions without executing them"`
+	Verbosity   int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+}
+
+func exposeTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, ExposeInput) (*mcp.CallToolResult, CommandOutput, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input ExposeInput) (*mcp.CallToolResult, CommandOutput, error) {
+		tenant := firstNonEmpty(strings.TrimSpace(input.Tenant), strings.TrimSpace(runtime.Context.Tenant))
+		environment := firstNonEmpty(strings.TrimSpace(input.Environment), strings.TrimSpace(runtime.Context.Environment))
+		projectRoot := firstNonEmpty(strings.TrimSpace(input.ProjectRoot), strings.TrimSpace(runtime.Context.RepoPath))
+
+		exposeStore, ok := any(runtime.Store).(eruncommon.ExposeStore)
+		if !ok {
+			exposeStore = eruncommon.ConfigStore{}
+		}
+
+		output, err := runRuntimeCommand(runtime, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, _ string) error {
+			_, err := eruncommon.RunExposeService(runCtx, eruncommon.ExposeServiceParams{
+				Tenant:      tenant,
+				Environment: environment,
+				Service:     strings.TrimSpace(input.Service),
+				ProjectRoot: projectRoot,
+				TargetIP:    strings.TrimSpace(input.IP),
+				ServicePort: input.Port,
+			}, exposeStore, nil, nil)
+			return err
+		})
+		return nil, output, err
+	}
+}

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -269,6 +269,10 @@ func registerDeliveryTools(server *mcp.Server, runtime RuntimeConfig) {
 		Name:        "delete",
 		Description: "Delete an environment from ERun configuration and remove its remote runtime namespace after explicit tenant-environment confirmation",
 	}, deleteTool(runtime))
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "expose",
+		Description: "Expose an in-namespace Service at a stable public hostname under the platform's services zone (requires a platform block in .erun/config.yaml): ensure the per-environment wildcard DNS record points at the env's ingress IP and apply a Host-routing Ingress. Supports preview.",
+	}, exposeTool(runtime))
 }
 
 // registerInspectionTools registers the repo-state and source-contribution

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -166,7 +166,7 @@ func TestHTTPHandlerExposesVersionTool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTools failed: %v", err)
 	}
-	if len(tools.Tools) != 30 {
+	if len(tools.Tools) != 31 {
 		t.Fatalf("unexpected tools: %+v", tools.Tools)
 	}
 


### PR DESCRIPTION
## What & why

Phase A exposure surface of the erunpaas platform epic (**#603**): `erun expose`, which exposes an in-namespace Service at a stable public hostname `<service>.<tenant>-<env>.<services-zone>`.

## Change

- **Shared `RunExposeService`** (`erun-common/expose.go`): resolves the hostname from the per-instance platform config (#610), ensures the per-env wildcard A record (`*.<tenant>-<env>.<services-zone>` → the env's ingress IP) in the services zone, and applies a Host-routing Ingress for the Service. The per-env wildcard covers every service in the env, so exposing more services only adds an Ingress.
- **Both transports**: `erun expose TENANT ENV SERVICE --ip <ip> [--port N]` and the MCP `expose` tool, both with preview/`--dry-run`. Requires a platform block and an explicit target IP; fails clearly without either (MCP-safe explicit inputs).
- **Dry-run is a complete plan**: a trace line for every action/decision — resolved hostname, the wildcard record, the PowerDNS upsert, the ingress apply.
- **Real execution is injected and live-only** (never under dry-run): ingress via `kubectl apply`; the wildcard record via `pdnsutil replace-rrset` exec'd inside the platform PowerDNS pod (which holds the gpgsql password in its env).

## Validation (in-sandbox)

- `erun-common`, `erun-cli`, `erun-mcp` build + test green (MCP tool count updated to 31).
- `make integration-test` green; coverage **77.0% ≥ 75%**. New `expose_test.go` scenarios: `help`, `dry_run` (full plan), `requires_platform_config`, `requires_ip`. Regenerated `root/help.txt` + `build/help.txt` (now list `expose`).

## ⚠️ Live verification gate (operator, on real frs-prod)

- `pdnsutil replace-rrset` against the shared postgres writes the wildcard record;
- the Ingress routes via Traefik and `curl https://<service>.<tenant>-<env>.<services-zone>` succeeds end to end.
- v1 assumes the platform env and tenant env are co-located on one cluster (single kube context); cross-cluster is a follow-up.

## Scope

Completes the operator-facing exposure path for Phase A (HTTP(S)). **Next:** the per-cluster Traefik ingress controller wiring (reuse k3s built-in / install where absent), then #603 **Phase B** (DNS-01 broker + wildcard cert) — which depends on **#604** identity. **Does not close #603.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)