### PR TITLE
Add (iss, org) -> tenant identity schema (normalized issuers table)

### DIFF
--- a/erun-backend/erun-backend-api/internal/repository/identity.go
+++ b/erun-backend/erun-backend-api/internal/repository/identity.go
@@ -127,6 +127,12 @@ func (r *IdentityRepository) bootstrapFirstIdentity(ctx context.Context, claims 
 			username = claims.Subject
 		}
 
+		// Register the issuer in the root issuers table first: tenant_issuers.issuer
+		// now foreign-keys issuers(issuer). The bootstrap issuer is single-tenant
+		// (org_field_key left NULL), so the token's iss alone resolves the tenant.
+		if _, err := tx.NewRaw(`INSERT INTO issuers (issuer) VALUES (?) ON CONFLICT (issuer) DO NOTHING`, claims.Issuer).Exec(ctx); err != nil {
+			return err
+		}
 		if _, err := tx.NewRaw(`INSERT INTO tenant_issuers (issuer, name) VALUES (?, ?)`, claims.Issuer, defaultTenantIssuerName(claims.Issuer)).Exec(ctx); err != nil {
 			return err
 		}

--- a/erun-backend/erun-backend-db/AGENTS.md
+++ b/erun-backend/erun-backend-db/AGENTS.md
@@ -107,19 +107,20 @@ Module-specific guidance for `erun-backend-db`. Follow the repository root and `
 
 - Prefer natural keys when the source value is globally stable, already externally defined, and is the exact lookup key used by the workflow.
 - Do not add surrogate IDs to mapping tables when a natural key already exists and is stable.
-- `tenant_issuers` uses `issuer` as its primary key because the OIDC issuer is the authenticated lookup key and must be globally unique.
+- `tenant_issuers` does not use `issuer` as a global primary key: a shared (org-scoped) issuer maps to many tenants. Its identity is `UNIQUE (tenant_id, issuer)` (a tenant maps an issuer once), and resolution uses `UNIQUE NULLS NOT DISTINCT (issuer, org_field_value)`. The per-issuer org-scoping mode lives once on `issuers.org_field_key`, and `issuers.issuer` is the globally unique issuer registry key.
 - Mapping tables may still include `tenant_id` or other foreign keys for traversal and integrity, but those foreign keys should not replace the natural lookup key.
 - Add composite uniqueness when another table needs to prove that two columns belong together. `tenant_issuers` keeps `UNIQUE (tenant_id, issuer)` so `user_external_ids` can foreign-key `(tenant_id, issuer)`.
 - Use UUIDv7 surrogate primary keys only for domain records that need their own externally visible identity, such as `tenants.tenant_id` or `users.user_id`.
 - Do not use UUID primary keys for purely internal association rows unless there is a current API, audit, or lifecycle requirement to address that row directly.
-- Keep identity-provider issuers globally unique in `tenant_issuers.issuer`, while allowing multiple issuer rows to reference the same `tenant_id`.
+- Register each OIDC issuer once in `issuers` (the globally unique issuer key). It may resolve to one tenant (single-tenant, NULL `org_field_value`) or many (org-scoped, one `tenant_issuers` row per org value). Multiple distinct issuers may still map to the same tenant.
 
 ## Multi-Tenant Database Plan
 
 - Use a shared database with tenant-scoped rows by default, not one database per tenant.
 - The `tenants` table is the root tenant registry. It stores tenant identity and tenant type without assuming a single identity provider issuer.
 - `tenants.type` must be one of `OPERATIONS` or `COMPANY` and defaults to `COMPANY`.
-- The `tenant_issuers` table maps OIDC issuers (`iss`) to tenants. Multiple issuers may map to the same tenant, but each issuer must be globally unique.
+- The `issuers` table holds each OIDC issuer once with its org-scoping mode: `org_field_key` NULL means a single-tenant issuer (the common case — BYO/external IdPs like cloud workload identity or a tenant's own OIDC); a set `org_field_key` names the token claim carrying the org for a shared multi-tenant issuer (e.g. a hosted Zitadel).
+- The `tenant_issuers` table maps `(issuer, org_field_value) → tenant`. An issuer is **not** globally unique to one tenant: a single-tenant issuer maps to exactly one tenant (NULL `org_field_value`), and an org-scoped issuer maps to many tenants (one row per org value). `UNIQUE NULLS NOT DISTINCT (issuer, org_field_value)` keeps the resolution key unambiguous; `tenant_issuers.issuer` foreign-keys `issuers(issuer)`. Multiple distinct issuers may still map to the same tenant.
 - The `users` table stores tenant-owned users with `user_id` as the UUIDv7 externally visible user identity.
 - The `user_external_ids` table maps multiple external identity-provider subjects to one user.
 - User external IDs must be unique per tenant with `PRIMARY KEY (tenant_id, issuer, external_id)`.
@@ -158,7 +159,7 @@ Module-specific guidance for `erun-backend-db`. Follow the repository root and `
 ## Initial Schema Direction
 
 - `tenants` stores tenant ID, name, type, and timestamps.
-- `tenant_issuers` stores globally unique OIDC issuers mapped to tenants.
+- `issuers` stores each OIDC issuer once with its org-scoping mode (`org_field_key`). `tenant_issuers` maps `(issuer, org_field_value)` to tenants — single-tenant (NULL org) or org-scoped (one row per org value).
 - `users` stores tenant-owned user records with a tenant-scoped `username`.
 - `user_external_ids` stores one or more external identity-provider subject IDs for each user, unique per tenant, issuer, and external ID.
 - `roles` stores tenant-owned role records with tenant-scoped names.
@@ -178,6 +179,7 @@ Module-specific guidance for `erun-backend-db`. Follow the repository root and `
 - Required common audit fields are `tenant_id`, `erun_user_id`, `external_user_id`, `external_issuer_id`, `type`, and `created_at`.
 - `type` must be one of `API`, `MCP`, or `CLI`.
 - `external_issuer_id` stores the OIDC `iss` value that mapped to the tenant.
+- `external_org_id` stores the org/resource-owner claim value (for org-scoped issuers) that, together with `iss`, resolved the tenant; NULL for single-tenant issuers.
 - `external_user_id` stores the external subject/user ID presented by the identity provider.
 - `erun_user_id` stores the internal ERun user ID resolved from the external identity.
 - API audit events must set `api_method` and `api_path`. `api_method` must be one of `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`, or `HEAD`.

--- a/erun-backend/erun-backend-db/atlas.hcl
+++ b/erun-backend/erun-backend-db/atlas.hcl
@@ -7,6 +7,7 @@ env "default" {
   src = [
     "file://schema/rls/context.sql",
     "file://schema/tables/tenants.sql",
+    "file://schema/tables/issuers.sql",
     "file://schema/tables/tenant_issuers.sql",
     "file://schema/tables/users.sql",
     "file://schema/tables/user_external_ids.sql",

--- a/erun-backend/erun-backend-db/migrations/default/20260621080214_tenant_issuer_org_scoping.sql
+++ b/erun-backend/erun-backend-db/migrations/default/20260621080214_tenant_issuer_org_scoping.sql
@@ -1,0 +1,19 @@
+-- Modify "audit_events" table
+ALTER TABLE "audit_events" ADD COLUMN "external_org_id" text NULL;
+-- Create "issuers" table
+CREATE TABLE "issuers" (
+  "issuer" text NOT NULL,
+  "org_field_key" text NULL,
+  "created_at" timestamptz NULL,
+  "updated_at" timestamptz NULL,
+  PRIMARY KEY ("issuer")
+);
+-- Modify "tenant_issuers" table
+ALTER TABLE "tenant_issuers" DROP CONSTRAINT "tenant_issuers_pkey", ADD COLUMN "org_field_value" text NULL, ADD CONSTRAINT "tenant_issuers_issuer_org_key" UNIQUE NULLS NOT DISTINCT ("issuer", "org_field_value"), ADD CONSTRAINT "tenant_issuers_issuer_fkey" FOREIGN KEY ("issuer") REFERENCES "issuers" ("issuer") ON UPDATE NO ACTION ON DELETE NO ACTION;
+-- Timestamp trigger for the new issuers table (atlas migrate diff omits
+-- trigger objects without an atlas login session; appended from the
+-- declarative schema; references the existing erun_set_timestamps()).
+CREATE TRIGGER issuers_set_timestamps
+  BEFORE INSERT OR UPDATE ON "issuers"
+  FOR EACH ROW
+  EXECUTE FUNCTION erun_set_timestamps();

--- a/erun-backend/erun-backend-db/migrations/default/atlas.sum
+++ b/erun-backend/erun-backend-db/migrations/default/atlas.sum
@@ -1,4 +1,5 @@
-h1:e3EWIAiDpr+mYOc1y9zf1h8Uyjl2B2NlO1DVQtJdzJA=
+h1:+MKJeCd6x4K23L1I/CgxUNs4wBFNoRJX9ucIeFAMoVE=
 20260501120000_initial_tenant_identity.sql h1:RpS03/4sFjbCggwYgcGNn6k3jNZCNTNl0BD/afOKFzo=
 20260503143000_tenant_issuer_names.sql h1:VEZjICG3/jU2YtEx0XX05l9Q8lJyWKeiRY8f4dXOkvE=
 20260503170000_audit_events.sql h1:OLjiGP/FhLTWvkx1bxS2xCcJK6tExdufnEC8R6LsKWA=
+20260621080214_tenant_issuer_org_scoping.sql h1:J2SYD5vm806J85oZLwMSSy+LplQBC4C+rC9Djnvztec=

--- a/erun-backend/erun-backend-db/schema/tables/audit_events.sql
+++ b/erun-backend/erun-backend-db/schema/tables/audit_events.sql
@@ -4,6 +4,7 @@ CREATE TABLE audit_events (
   erun_user_id UUID NOT NULL,
   external_user_id TEXT NOT NULL,
   external_issuer_id TEXT NOT NULL,
+  external_org_id TEXT,
   type TEXT NOT NULL,
   api_method TEXT,
   api_path TEXT,

--- a/erun-backend/erun-backend-db/schema/tables/issuers.sql
+++ b/erun-backend/erun-backend-db/schema/tables/issuers.sql
@@ -1,0 +1,6 @@
+CREATE TABLE issuers (
+  issuer TEXT PRIMARY KEY,
+  org_field_key TEXT,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ
+);

--- a/erun-backend/erun-backend-db/schema/tables/tenant_issuers.sql
+++ b/erun-backend/erun-backend-db/schema/tables/tenant_issuers.sql
@@ -1,10 +1,19 @@
 CREATE TABLE tenant_issuers (
   tenant_id UUID NOT NULL DEFAULT erun_current_tenant_id(),
-  issuer TEXT PRIMARY KEY,
+  issuer TEXT NOT NULL,
+  org_field_value TEXT,
   name TEXT NOT NULL,
   created_at TIMESTAMPTZ,
   updated_at TIMESTAMPTZ,
   FOREIGN KEY (tenant_id) REFERENCES tenants (tenant_id),
+  FOREIGN KEY (issuer) REFERENCES issuers (issuer),
   CONSTRAINT tenant_issuers_name_check CHECK (length(trim(name)) > 0),
-  CONSTRAINT tenant_issuers_tenant_issuer_key UNIQUE (tenant_id, issuer)
+  -- Identity is (tenant_id, issuer): a tenant maps a given issuer once. Kept as
+  -- a UNIQUE (not promoted to PK) so user_external_ids' (tenant_id, issuer) FK
+  -- keeps depending on this exact constraint and the migration needn't rebuild
+  -- it. Replaces the old global `issuer` PK so one issuer can serve many tenants.
+  CONSTRAINT tenant_issuers_tenant_issuer_key UNIQUE (tenant_id, issuer),
+  -- Resolution key: a token's (iss, org-claim value) maps to exactly one tenant.
+  -- NULLS NOT DISTINCT so a single-tenant issuer (NULL org) maps to one tenant.
+  CONSTRAINT tenant_issuers_issuer_org_key UNIQUE NULLS NOT DISTINCT (issuer, org_field_value)
 );

--- a/erun-backend/erun-backend-db/schema/triggers/timestamps.sql
+++ b/erun-backend/erun-backend-db/schema/triggers/timestamps.sql
@@ -20,6 +20,11 @@ CREATE TRIGGER tenants_set_timestamps
   FOR EACH ROW
   EXECUTE FUNCTION erun_set_timestamps();
 
+CREATE TRIGGER issuers_set_timestamps
+  BEFORE INSERT OR UPDATE ON issuers
+  FOR EACH ROW
+  EXECUTE FUNCTION erun_set_timestamps();
+
 CREATE TRIGGER tenant_issuers_set_timestamps
   BEFORE INSERT OR UPDATE ON tenant_issuers
   FOR EACH ROW


### PR DESCRIPTION
## What & why

Schema foundation for **#604**: resolve a tenant from **`(iss, org)`** so one shared hosted IdP (e.g. Zitadel, one org per tenant) can serve many tenants — while single-tenant BYO/external issuers keep resolving `iss → tenant` unchanged. **Additive and back-compat.**

This is the design we converged on in discussion (normalized `issuers` table, **no surrogate, no cross-table trigger**, `user_external_ids` unchanged).

## Schema

- **New `issuers` table** — each OIDC issuer once, with its org-scoping mode: `org_field_key` **NULL = single-tenant** (the common case: cloud workload identity, a tenant's own OIDC); **set** = the token claim that carries the org for a shared multi-tenant issuer.
- **`tenant_issuers`** — drops the global `issuer` PK (the only thing forbidding one issuer → many tenants); adds `org_field_value`; FKs `issuer → issuers`; adds `UNIQUE NULLS NOT DISTINCT (issuer, org_field_value)` as the resolution key. **Keeps `UNIQUE (tenant_id, issuer)`** so `user_external_ids`'s FK is untouched — that's what lets us avoid a surrogate and a constraint-rebuild.
- **`audit_events`** — `+ external_org_id` (the org value that, with `iss`, resolved the tenant; NULL for single-tenant).
- **Bootstrap** (`identity.go`) — registers the issuer in `issuers` before inserting `tenant_issuers`, satisfying the new FK.
- **`erun-backend-db/AGENTS.md`** — updated: issuer is no longer globally unique *to one tenant*; the `issuers`/`tenant_issuers` model is documented.

## How the migration was generated (login-free)

`atlas migrate diff` is gated behind `atlas login` for schemas containing functions — but only when diffing schema **source**. Diffing against a **live Postgres** holding the desired schema is *not* gated, so the table/constraint DDL is genuinely Atlas-generated. The one object Atlas omits without a login session (the `issuers` timestamp trigger) is appended verbatim from the declarative schema.

## Validation (login-free, in-sandbox)

- `erun-backend-api` builds + `go test ./...` green.
- `atlas migrate validate` clean; all 4 migrations **apply** cleanly to `postgres:18`.
- **Invariant insert-tests** against the applied schema all hold: **one issuer → two tenants**; duplicate `(issuer, org)` rejected; a single-tenant issuer maps to exactly one tenant; **cross-tenant issuer reference rejected** (the boundary).

## Scope

This is the **schema foundation only**. The `(iss, org)` **verifier + claims** change (`oidc.go`: read the org claim, resolve `(iss, org)`, thread org through claims/context/audit) is the **next** increment.

**Not auto-merging** — this is the identity/auth boundary you've been reviewing; it wants your eyes before merge. **Does not close #604.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)