### PR TITLE
Resolve tenant from (iss, org) in the OIDC verifier

### DIFF
--- a/erun-backend/erun-backend-api/auth.go
+++ b/erun-backend/erun-backend-api/auth.go
@@ -51,13 +51,16 @@ func (f TokenVerifierFunc) VerifyBearerToken(ctx context.Context, token string) 
 }
 
 type TenantResolver interface {
-	ResolveTenantByIssuer(ctx context.Context, issuer string) (Tenant, error)
+	// ResolveTenantByIssuer maps a verified token to its tenant. It takes the
+	// full Claims (not just the issuer) so it can read a per-issuer org claim
+	// for (iss, org) -> tenant resolution; single-tenant issuers ignore the org.
+	ResolveTenantByIssuer(ctx context.Context, claims Claims) (Tenant, error)
 }
 
-type TenantResolverFunc func(ctx context.Context, issuer string) (Tenant, error)
+type TenantResolverFunc func(ctx context.Context, claims Claims) (Tenant, error)
 
-func (f TenantResolverFunc) ResolveTenantByIssuer(ctx context.Context, issuer string) (Tenant, error) {
-	return f(ctx, issuer)
+func (f TenantResolverFunc) ResolveTenantByIssuer(ctx context.Context, claims Claims) (Tenant, error) {
+	return f(ctx, claims)
 }
 
 type UserResolver interface {
@@ -239,7 +242,7 @@ func (m *AuthMiddleware) resolveIdentity(ctx context.Context, claims Claims) (Id
 		return identity, nil
 	}
 
-	tenant, err := m.tenants.ResolveTenantByIssuer(ctx, claims.Issuer)
+	tenant, err := m.tenants.ResolveTenantByIssuer(ctx, claims)
 	if err != nil || strings.TrimSpace(tenant.TenantID) == "" {
 		err = ErrTenantNotResolved
 		if m.cache != nil {

--- a/erun-backend/erun-backend-api/auth_test.go
+++ b/erun-backend/erun-backend-api/auth_test.go
@@ -17,9 +17,9 @@ func TestAuthMiddlewareResolvesTenantFromIssuer(t *testing.T) {
 			}
 			return Claims{Issuer: "https://issuer.example", Subject: "user-1"}, nil
 		}),
-		TenantResolver: TenantResolverFunc(func(ctx context.Context, issuer string) (Tenant, error) {
-			if issuer != "https://issuer.example" {
-				t.Fatalf("unexpected issuer: %q", issuer)
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
+			if claims.Issuer != "https://issuer.example" {
+				t.Fatalf("unexpected issuer: %q", claims.Issuer)
 			}
 			return Tenant{TenantID: "019a7fa5-c2c0-7c55-bc70-714873a71f10"}, nil
 		}),
@@ -174,7 +174,7 @@ func TestAuthMiddlewareRejectsMissingBearerToken(t *testing.T) {
 			t.Fatal("verifier should not be called")
 			return Claims{}, nil
 		}),
-		TenantResolver: TenantResolverFunc(func(ctx context.Context, issuer string) (Tenant, error) {
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
 			t.Fatal("tenant resolver should not be called")
 			return Tenant{}, nil
 		}),
@@ -203,7 +203,7 @@ func TestAuthMiddlewareRejectsMalformedBearerToken(t *testing.T) {
 			t.Fatal("verifier should not be called")
 			return Claims{}, nil
 		}),
-		TenantResolver: TenantResolverFunc(func(ctx context.Context, issuer string) (Tenant, error) {
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
 			t.Fatal("tenant resolver should not be called")
 			return Tenant{}, nil
 		}),
@@ -233,7 +233,7 @@ func TestAuthMiddlewareRejectsUnknownTenantIssuer(t *testing.T) {
 		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
 			return Claims{Issuer: "https://unknown.example", Subject: "user-1"}, nil
 		}),
-		TenantResolver: TenantResolverFunc(func(ctx context.Context, issuer string) (Tenant, error) {
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
 			return Tenant{}, errors.New("not found")
 		}),
 		UserResolver: UserResolverFunc(func(ctx context.Context, tenantID string, issuer string, externalID string) (User, error) {
@@ -262,7 +262,7 @@ func TestAuthMiddlewareRejectsUnknownExternalUser(t *testing.T) {
 		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
 			return Claims{Issuer: "https://issuer.example", Subject: "unknown-user"}, nil
 		}),
-		TenantResolver: TenantResolverFunc(func(ctx context.Context, issuer string) (Tenant, error) {
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
 			return Tenant{TenantID: "019a7fa5-c2c0-7c55-bc70-714873a71f10"}, nil
 		}),
 		UserResolver: UserResolverFunc(func(ctx context.Context, tenantID string, issuer string, externalID string) (User, error) {
@@ -299,7 +299,7 @@ func TestAuthMiddlewareCachesFailedExternalUserResolution(t *testing.T) {
 		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
 			return Claims{Issuer: "https://issuer.example", Subject: "unknown-user"}, nil
 		}),
-		TenantResolver: TenantResolverFunc(func(ctx context.Context, issuer string) (Tenant, error) {
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
 			return Tenant{TenantID: "019a7fa5-c2c0-7c55-bc70-714873a71f10"}, nil
 		}),
 		UserResolver: UserResolverFunc(func(ctx context.Context, tenantID string, issuer string, externalID string) (User, error) {
@@ -343,7 +343,7 @@ func TestAuthMiddlewareExpiresFailedExternalUserResolutionCache(t *testing.T) {
 		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
 			return Claims{Issuer: "https://issuer.example", Subject: "unknown-user"}, nil
 		}),
-		TenantResolver: TenantResolverFunc(func(ctx context.Context, issuer string) (Tenant, error) {
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
 			return Tenant{TenantID: "019a7fa5-c2c0-7c55-bc70-714873a71f10"}, nil
 		}),
 		UserResolver: UserResolverFunc(func(ctx context.Context, tenantID string, issuer string, externalID string) (User, error) {
@@ -380,7 +380,7 @@ func TestAuthMiddlewareLogsAuditEventForAuthorizedRequest(t *testing.T) {
 		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
 			return Claims{Issuer: "https://issuer.example", Subject: "user-1"}, nil
 		}),
-		TenantResolver: TenantResolverFunc(func(ctx context.Context, issuer string) (Tenant, error) {
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
 			return Tenant{TenantID: "019a7fa5-c2c0-7c55-bc70-714873a71f10"}, nil
 		}),
 		UserResolver: UserResolverFunc(func(ctx context.Context, tenantID string, issuer string, externalID string) (User, error) {
@@ -437,7 +437,7 @@ func TestAuthMiddlewareAuthorizesBeforeAuditAndHandler(t *testing.T) {
 		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
 			return Claims{Issuer: "https://issuer.example", Subject: "user-1"}, nil
 		}),
-		TenantResolver: TenantResolverFunc(func(ctx context.Context, issuer string) (Tenant, error) {
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
 			return Tenant{TenantID: "019a7fa5-c2c0-7c55-bc70-714873a71f10"}, nil
 		}),
 		UserResolver: UserResolverFunc(func(ctx context.Context, tenantID string, issuer string, externalID string) (User, error) {
@@ -486,7 +486,7 @@ func TestAuthMiddlewareRejectsDeniedPermissionBeforeAuditAndHandler(t *testing.T
 		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
 			return Claims{Issuer: "https://issuer.example", Subject: "user-1"}, nil
 		}),
-		TenantResolver: TenantResolverFunc(func(ctx context.Context, issuer string) (Tenant, error) {
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
 			return Tenant{TenantID: "019a7fa5-c2c0-7c55-bc70-714873a71f10"}, nil
 		}),
 		UserResolver: UserResolverFunc(func(ctx context.Context, tenantID string, issuer string, externalID string) (User, error) {
@@ -528,7 +528,7 @@ func TestAuthMiddlewareDoesNotLogAuditEventForRejectedRequest(t *testing.T) {
 		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
 			return Claims{}, errors.New("invalid")
 		}),
-		TenantResolver: TenantResolverFunc(func(ctx context.Context, issuer string) (Tenant, error) {
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
 			t.Fatal("tenant resolver should not be called")
 			return Tenant{}, nil
 		}),

--- a/erun-backend/erun-backend-api/internal/repository/identity.go
+++ b/erun-backend/erun-backend-api/internal/repository/identity.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
@@ -26,7 +27,7 @@ func NewIdentityRepository(db *sql.DB, dialect Dialect) *IdentityRepository {
 }
 
 func (r *IdentityRepository) ResolveIdentity(ctx context.Context, claims security.Claims) (model.Tenant, model.User, error) {
-	tenant, err := r.ResolveTenantByIssuer(ctx, claims.Issuer)
+	tenant, err := r.ResolveTenantByIssuer(ctx, claims)
 	if err == nil {
 		user, err := r.ResolveUserByExternalID(ctx, tenant.TenantID, claims.Issuer, claims.Subject)
 		if err == nil {
@@ -80,19 +81,68 @@ func (r *IdentityRepository) refreshUserUsername(ctx context.Context, tenant mod
 	return user, nil
 }
 
-func (r *IdentityRepository) ResolveTenantByIssuer(ctx context.Context, issuer string) (model.Tenant, error) {
+// resolveTenant maps a verified token to its tenant. The issuer's org-scoping
+// mode lives once on issuers.org_field_key: NULL means a single-tenant issuer
+// (resolve by issuer alone, the common BYO/external-IdP case); a set key names
+// the token claim whose value selects the tenant among that issuer's orgs
+// (shared multi-tenant issuer, e.g. a hosted Zitadel). An org-scoped issuer
+// whose token carries no matching org claim returns ErrNotFound — unauthorized,
+// and never bootstraps once tenants exist (bootstrapFirstIdentity guards on an
+// empty tenants table). An unregistered issuer also returns ErrNotFound, which
+// routes to first-identity bootstrap when the database is empty.
+func (r *IdentityRepository) ResolveTenantByIssuer(ctx context.Context, claims security.Claims) (model.Tenant, error) {
+	issuer := strings.TrimSpace(claims.Issuer)
+	var orgFieldKey sql.NullString
+	if err := r.db.NewRaw(`SELECT org_field_key FROM issuers WHERE issuer = ?`, issuer).Scan(ctx, &orgFieldKey); err != nil {
+		return model.Tenant{}, normalizeNoRows(err)
+	}
+
 	var tenant model.Tenant
-	err := r.db.NewRaw(`
-		SELECT t.tenant_id, t.name, t.type, t.created_at, t.updated_at
-		  FROM tenant_issuers ti
-		  JOIN tenants t
-		    ON t.tenant_id = ti.tenant_id
-		 WHERE ti.issuer = ?
-	`, issuer).Scan(ctx, &tenant)
+	var err error
+	if key := strings.TrimSpace(orgFieldKey.String); orgFieldKey.Valid && key != "" {
+		org := orgClaimValue(claims.Raw, key)
+		if org == "" {
+			// Org-scoped issuer but the token carries no usable org claim.
+			return model.Tenant{}, ErrNotFound
+		}
+		err = r.db.NewRaw(`
+			SELECT t.tenant_id, t.name, t.type, t.created_at, t.updated_at
+			  FROM tenant_issuers ti
+			  JOIN tenants t ON t.tenant_id = ti.tenant_id
+			 WHERE ti.issuer = ? AND ti.org_field_value = ?
+		`, issuer, org).Scan(ctx, &tenant)
+	} else {
+		err = r.db.NewRaw(`
+			SELECT t.tenant_id, t.name, t.type, t.created_at, t.updated_at
+			  FROM tenant_issuers ti
+			  JOIN tenants t ON t.tenant_id = ti.tenant_id
+			 WHERE ti.issuer = ? AND ti.org_field_value IS NULL
+		`, issuer).Scan(ctx, &tenant)
+	}
 	if err != nil {
 		return model.Tenant{}, normalizeNoRows(err)
 	}
 	return tenant, nil
+}
+
+// orgClaimValue extracts the org-identifying claim value as a string. JSON
+// numbers (some IdPs emit numeric org/resource-owner IDs) decode as float64;
+// integers render without a decimal so they match the stored org_field_value.
+func orgClaimValue(raw map[string]any, key string) string {
+	if raw == nil {
+		return ""
+	}
+	switch v := raw[key].(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case float64:
+		if v == float64(int64(v)) {
+			return strconv.FormatInt(int64(v), 10)
+		}
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	default:
+		return ""
+	}
 }
 
 func (r *IdentityRepository) bootstrapFirstIdentity(ctx context.Context, claims security.Claims) (model.Tenant, model.User, error) {

--- a/erun-backend/erun-backend-api/internal/repository/org_claim_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/org_claim_test.go
@@ -1,0 +1,28 @@
+package repository
+
+import "testing"
+
+func TestOrgClaimValue(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  map[string]any
+		key  string
+		want string
+	}{
+		{name: "string", raw: map[string]any{"org": "acme"}, key: "org", want: "acme"},
+		{name: "trims string", raw: map[string]any{"org": "  acme  "}, key: "org", want: "acme"},
+		{name: "integer float renders without decimal", raw: map[string]any{"org": float64(42)}, key: "org", want: "42"},
+		{name: "fractional float", raw: map[string]any{"org": 3.5}, key: "org", want: "3.5"},
+		{name: "missing key", raw: map[string]any{"other": "x"}, key: "org", want: ""},
+		{name: "nil map", raw: nil, key: "org", want: ""},
+		{name: "unsupported type", raw: map[string]any{"org": true}, key: "org", want: ""},
+		{name: "nested unsupported", raw: map[string]any{"org": map[string]any{"id": "x"}}, key: "org", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := orgClaimValue(tc.raw, tc.key); got != tc.want {
+				t.Fatalf("orgClaimValue(%v, %q) = %q, want %q", tc.raw, tc.key, got, tc.want)
+			}
+		})
+	}
+}

--- a/erun-backend/erun-backend-api/internal/security/context.go
+++ b/erun-backend/erun-backend-api/internal/security/context.go
@@ -11,6 +11,10 @@ type Claims struct {
 	Issuer   string
 	Subject  string
 	Username string
+	// Raw is the full set of token claims, kept so the identity resolver can
+	// read a per-issuer org claim (issuers.org_field_key) for (iss, org) -> tenant
+	// resolution. The claim's name is configured per issuer, not known at verify time.
+	Raw map[string]any
 }
 
 type Context struct {

--- a/erun-backend/erun-backend-api/oidc.go
+++ b/erun-backend/erun-backend-api/oidc.go
@@ -79,10 +79,17 @@ func (v *OIDCTokenVerifier) VerifyBearerToken(ctx context.Context, token string)
 	if err := idToken.Claims(&claims); err != nil {
 		return Claims{}, err
 	}
-	return claimsFromOIDCTokenClaims(claims), nil
+	// Also capture the full claim set as a map so the identity resolver can read
+	// a per-issuer org claim (issuers.org_field_key) whose name is not known here
+	// — it is configured per issuer in the DB, not baked into the verifier.
+	var raw map[string]any
+	if err := idToken.Claims(&raw); err != nil {
+		return Claims{}, err
+	}
+	return claimsFromOIDCTokenClaims(claims, raw), nil
 }
 
-func claimsFromOIDCTokenClaims(claims oidcTokenClaims) Claims {
+func claimsFromOIDCTokenClaims(claims oidcTokenClaims, raw map[string]any) Claims {
 	username := strings.TrimSpace(claims.PreferredUsername)
 	if username == "" {
 		username = strings.TrimSpace(claims.Username)
@@ -98,6 +105,7 @@ func claimsFromOIDCTokenClaims(claims oidcTokenClaims) Claims {
 		Issuer:   strings.TrimSpace(claims.Issuer),
 		Subject:  subject,
 		Username: username,
+		Raw:      raw,
 	}
 }
 

--- a/erun-backend/erun-backend-api/oidc_test.go
+++ b/erun-backend/erun-backend-api/oidc_test.go
@@ -9,7 +9,7 @@ func TestClaimsFromOIDCTokenClaimsUsesAWSIdentityStoreUserID(t *testing.T) {
 		AWS: awsSTSClaims{
 			IdentityStoreUserID: "265222f4-f041-7008-6e0c-2d3993b555bf",
 		},
-	})
+	}, nil)
 
 	if claims.Subject != "265222f4-f041-7008-6e0c-2d3993b555bf" {
 		t.Fatalf("expected AWS identity store user id as subject, got %q", claims.Subject)
@@ -20,7 +20,7 @@ func TestClaimsFromOIDCTokenClaimsFallsBackToSubjectWithoutAWSIdentityStoreUserI
 	claims := claimsFromOIDCTokenClaims(oidcTokenClaims{
 		Issuer:  "https://a11bec5a-678d-4a6a-aa25-f3770df2ac5e.tokens.sts.global.api.aws",
 		Subject: "arn:aws:iam::020362606330:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_AdministratorAccess_c95738f708c1c268",
-	})
+	}, nil)
 
 	if claims.Subject != "arn:aws:iam::020362606330:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_AdministratorAccess_c95738f708c1c268" {
 		t.Fatalf("expected subject fallback, got %q", claims.Subject)
@@ -32,7 +32,7 @@ func TestClaimsFromOIDCTokenClaimsKeepsNonAWSSubject(t *testing.T) {
 		Issuer:            "https://issuer.example",
 		Subject:           "user-1",
 		PreferredUsername: "user@example",
-	})
+	}, nil)
 
 	if claims.Subject != "user-1" {
 		t.Fatalf("expected standard OIDC subject, got %q", claims.Subject)

--- a/erun-backend/erun-backend-api/server_test.go
+++ b/erun-backend/erun-backend-api/server_test.go
@@ -14,7 +14,7 @@ func TestHandlerRequiresBearerTokenForAPIEndpoint(t *testing.T) {
 		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
 			return Claims{Issuer: "https://issuer.example", Subject: "user-1"}, nil
 		}),
-		TenantResolver: TenantResolverFunc(func(ctx context.Context, issuer string) (Tenant, error) {
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
 			return Tenant{TenantID: "019a7fa5-c2c0-7c55-bc70-714873a71f10"}, nil
 		}),
 		UserResolver: UserResolverFunc(func(ctx context.Context, tenantID string, issuer string, externalID string) (User, error) {
@@ -38,7 +38,7 @@ func TestHandlerHealthzDoesNotRequireBearerToken(t *testing.T) {
 		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
 			return Claims{}, errors.New("verifier should not be called")
 		}),
-		TenantResolver: TenantResolverFunc(func(ctx context.Context, issuer string) (Tenant, error) {
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
 			return Tenant{}, errors.New("tenant resolver should not be called")
 		}),
 		UserResolver: UserResolverFunc(func(ctx context.Context, tenantID string, issuer string, externalID string) (User, error) {
@@ -65,7 +65,7 @@ func TestHandlerWhoamiReturnsResolvedTenant(t *testing.T) {
 		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
 			return Claims{Issuer: "https://issuer.example", Subject: "user-1"}, nil
 		}),
-		TenantResolver: TenantResolverFunc(func(ctx context.Context, issuer string) (Tenant, error) {
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
 			return Tenant{TenantID: "019a7fa5-c2c0-7c55-bc70-714873a71f10"}, nil
 		}),
 		UserResolver: UserResolverFunc(func(ctx context.Context, tenantID string, issuer string, externalID string) (User, error) {


### PR DESCRIPTION
## What & why

Implements the **`(iss, org)` → tenant resolution** logic on top of the issuers schema (#618). Single-tenant issuers keep resolving `iss → tenant` unchanged; an **org-scoped** issuer (`issuers.org_field_key` set) selects the tenant by the token claim that key names.

## Change

- **`oidc.go`** — `VerifyBearerToken` now also captures the full claim set as a map on `Claims.Raw`. The org claim's *name* is per-issuer config (`org_field_key`), not known at verify time, so the resolver needs the raw claims to read an arbitrary one.
- **`identity.go`** — `ResolveTenantByIssuer` takes `Claims` and is org-aware:
  - reads `issuers.org_field_key`; **NULL** → resolve by `(issuer, org_field_value IS NULL)` (single-tenant, unchanged); **set** → resolve by `(issuer, claims[key])`.
  - an org-scoped token with **no usable org claim** returns `ErrNotFound` → unauthorized. Safe: `bootstrapFirstIdentity` guards on an empty `tenants` table, so this never mints a tenant once any exist.
  - `orgClaimValue` extracts the claim (string or numeric).
- **`auth.go`** — the `TenantResolver` interface now takes `Claims` (not just the issuer string), so **both** middleware resolution paths (full `ResolveIdentity` and the tenant-only `TenantResolver`) are org-aware.

## Validation

- `erun-backend-api` builds + `go test ./...` green; updated the auth/oidc/server test fakes to the widened signatures.
- New `orgClaimValue` unit tests (string / numeric / missing / nil / unsupported).
- The actual `(iss, org)` routing + cross-tenant isolation is enforced at the **DB layer** by #618's constraints, proven there against `postgres:18` (one issuer → two tenants; wrong-org rejected; single-tenant maps once).

## ⚠️ Live verification gate (operator)

End-to-end against a real token + the hosted IdP: an org-scoped issuer's token resolves to the right tenant by its org claim, a token missing the org claim is rejected, and single-tenant/BYO issuers are unaffected.

## Scope

Completes the `(iss, org)` resolution. **Not auto-merging** — auth boundary, for your review. Remaining #604 follow-ons: populating `audit_events.external_org_id` on the resolved org, and the Zitadel singleton + auth-edge/MCP gate. **Does not close #604.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)