### PR TITLE
Fix 17 review findings in the merged erunpaas platform work

### DIFF
--- a/erun-backend/erun-backend-api/AGENTS.md
+++ b/erun-backend/erun-backend-api/AGENTS.md
@@ -126,6 +126,7 @@ Module-specific guidance for `erun-backend-api`. Follow the repository root and 
 - Keep negative-cache TTL short enough that newly created users become usable without a long delay.
 - Keep positive-cache TTL bounded so tenant issuer and user mapping changes converge without restarting the API.
 - Key identity caches by issuer and external subject. Do not cache only by subject because subjects are issuer-scoped.
+- Also key on the resolved org claim value for org-scoped (shared) issuers. Under a shared issuer the same `(issuer, subject)` resolves to different tenants per org, so an `(issuer, subject)`-only key would serve one tenant's resolved RLS context to another. Derive the org before the cache lookup (its claim name lives on `issuers.org_field_key`) and include it in the key; single-tenant issuers resolve org to empty and keep `(issuer, subject)` behavior.
 - Do not cache raw bearer tokens as identity keys.
 - Do not let identity cache decisions bypass token verification. Verify the bearer token first, then use claims to look up cached tenant/user resolution.
 - Cache entries must be safe for concurrent requests and must not use package-level mutable globals. Pass cache instances through API construction.

--- a/erun-backend/erun-backend-api/auth.go
+++ b/erun-backend/erun-backend-api/auth.go
@@ -28,6 +28,10 @@ type User = model.User
 type Identity struct {
 	Tenant Tenant
 	User   User
+	// Org is the resolved org claim value for an org-scoped issuer (empty for
+	// single-tenant issuers). It is part of the identity cache key and is recorded
+	// on audit events as external_org_id.
+	Org string
 }
 
 type IdentityResolver interface {
@@ -37,6 +41,21 @@ type IdentityResolver interface {
 type IdentityResolverFunc func(ctx context.Context, claims Claims) (Tenant, User, error)
 
 func (f IdentityResolverFunc) ResolveIdentity(ctx context.Context, claims Claims) (Tenant, User, error) {
+	return f(ctx, claims)
+}
+
+// OrgResolver derives the org claim value that, together with the issuer,
+// resolves the tenant for an org-scoped (shared) issuer. It returns "" for
+// single-tenant or unregistered issuers. The middleware uses it to compute the
+// identity cache key's org dimension before resolution, so a shared issuer
+// cannot collide different orgs onto one cached tenant.
+type OrgResolver interface {
+	ResolveOrg(ctx context.Context, claims Claims) (string, error)
+}
+
+type OrgResolverFunc func(ctx context.Context, claims Claims) (string, error)
+
+func (f OrgResolverFunc) ResolveOrg(ctx context.Context, claims Claims) (string, error) {
 	return f(ctx, claims)
 }
 
@@ -99,6 +118,9 @@ type AuthContext struct {
 	Claims Claims
 	Tenant Tenant
 	User   User
+	// Org is the resolved org claim value for an org-scoped issuer; empty for
+	// single-tenant issuers.
+	Org string
 }
 
 type authContextKey struct{}
@@ -109,13 +131,14 @@ func AuthFromContext(ctx context.Context) (AuthContext, bool) {
 }
 
 type AuthMiddleware struct {
-	verifier   TokenVerifier
-	identities IdentityResolver
-	tenants    TenantResolver
-	users      UserResolver
-	cache      *IdentityResolutionCache
-	audit      AuditLogger
-	authz      Authorizer
+	verifier    TokenVerifier
+	identities  IdentityResolver
+	tenants     TenantResolver
+	users       UserResolver
+	orgResolver OrgResolver
+	cache       *IdentityResolutionCache
+	audit       AuditLogger
+	authz       Authorizer
 }
 
 type AuthMiddlewareOptions struct {
@@ -123,6 +146,7 @@ type AuthMiddlewareOptions struct {
 	IdentityResolver IdentityResolver
 	TenantResolver   TenantResolver
 	UserResolver     UserResolver
+	OrgResolver      OrgResolver
 	IdentityCache    *IdentityResolutionCache
 	AuditLogger      AuditLogger
 	Authorizer       Authorizer
@@ -139,13 +163,14 @@ func NewAuthMiddleware(options AuthMiddlewareOptions) (*AuthMiddleware, error) {
 		return nil, errors.New("user resolver is required")
 	}
 	return &AuthMiddleware{
-		verifier:   options.TokenVerifier,
-		identities: options.IdentityResolver,
-		tenants:    options.TenantResolver,
-		users:      options.UserResolver,
-		cache:      options.IdentityCache,
-		audit:      options.AuditLogger,
-		authz:      options.Authorizer,
+		verifier:    options.TokenVerifier,
+		identities:  options.IdentityResolver,
+		tenants:     options.TenantResolver,
+		users:       options.UserResolver,
+		orgResolver: options.OrgResolver,
+		cache:       options.IdentityCache,
+		audit:       options.AuditLogger,
+		authz:       options.Authorizer,
 	}, nil
 }
 
@@ -181,6 +206,7 @@ func (m *AuthMiddleware) Wrap(next http.Handler) http.Handler {
 			Claims: claims,
 			Tenant: identity.Tenant,
 			User:   identity.User,
+			Org:    identity.Org,
 		})
 		ctx = security.WithContext(ctx, security.Context{
 			TenantID:       identity.Tenant.TenantID,
@@ -188,6 +214,7 @@ func (m *AuthMiddleware) Wrap(next http.Handler) http.Handler {
 			ErunUserID:     identity.User.UserID,
 			ExternalIssuer: claims.Issuer,
 			ExternalUserID: claims.Subject,
+			ExternalOrgID:  identity.Org,
 		})
 		req := r.WithContext(ctx)
 		if m.authz != nil {
@@ -216,8 +243,15 @@ func (m *AuthMiddleware) Wrap(next http.Handler) http.Handler {
 }
 
 func (m *AuthMiddleware) resolveIdentity(ctx context.Context, claims Claims) (Identity, error) {
+	// Derive the org claim value first so it is part of the cache key: a shared
+	// org-scoped issuer maps the same (issuer, subject) to different tenants per
+	// org, so (issuer, subject) alone would leak one tenant's RLS context to
+	// another. A failed org lookup degrades to org="" and falls through to full
+	// resolution, which surfaces the real error.
+	org := m.resolveOrg(ctx, claims)
+
 	if m.cache != nil {
-		if identity, err, ok := m.cache.Get(claims.Issuer, claims.Subject); ok {
+		if identity, err, ok := m.cache.Get(claims.Issuer, claims.Subject, org); ok {
 			if !cachedIdentityNeedsUsernameRefresh(identity, err, claims) {
 				return identity, err
 			}
@@ -231,13 +265,13 @@ func (m *AuthMiddleware) resolveIdentity(ctx context.Context, claims Claims) (Id
 				err = ErrUserNotResolved
 			}
 			if m.cache != nil {
-				m.cache.SetFailure(claims.Issuer, claims.Subject, err)
+				m.cache.SetFailure(claims.Issuer, claims.Subject, org, err)
 			}
 			return Identity{}, err
 		}
-		identity := Identity{Tenant: tenant, User: user}
+		identity := Identity{Tenant: tenant, User: user, Org: org}
 		if m.cache != nil {
-			m.cache.SetSuccess(claims.Issuer, claims.Subject, identity)
+			m.cache.SetSuccess(claims.Issuer, claims.Subject, org, identity)
 		}
 		return identity, nil
 	}
@@ -246,7 +280,7 @@ func (m *AuthMiddleware) resolveIdentity(ctx context.Context, claims Claims) (Id
 	if err != nil || strings.TrimSpace(tenant.TenantID) == "" {
 		err = ErrTenantNotResolved
 		if m.cache != nil {
-			m.cache.SetFailure(claims.Issuer, claims.Subject, err)
+			m.cache.SetFailure(claims.Issuer, claims.Subject, org, err)
 		}
 		return Identity{}, err
 	}
@@ -254,16 +288,31 @@ func (m *AuthMiddleware) resolveIdentity(ctx context.Context, claims Claims) (Id
 	if err != nil || strings.TrimSpace(user.UserID) == "" {
 		err = ErrUserNotResolved
 		if m.cache != nil {
-			m.cache.SetFailure(claims.Issuer, claims.Subject, err)
+			m.cache.SetFailure(claims.Issuer, claims.Subject, org, err)
 		}
 		return Identity{}, err
 	}
 
-	identity := Identity{Tenant: tenant, User: user}
+	identity := Identity{Tenant: tenant, User: user, Org: org}
 	if m.cache != nil {
-		m.cache.SetSuccess(claims.Issuer, claims.Subject, identity)
+		m.cache.SetSuccess(claims.Issuer, claims.Subject, org, identity)
 	}
 	return identity, nil
+}
+
+// resolveOrg derives the org claim value used in the identity cache key. A nil
+// resolver (e.g. non-DB test wiring) or a single-tenant/unregistered issuer
+// yields "", preserving (issuer, subject) keying. Lookup errors also yield ""
+// and are left for full resolution to surface.
+func (m *AuthMiddleware) resolveOrg(ctx context.Context, claims Claims) string {
+	if m.orgResolver == nil {
+		return ""
+	}
+	org, err := m.orgResolver.ResolveOrg(ctx, claims)
+	if err != nil {
+		return ""
+	}
+	return org
 }
 
 func claimsWithUsernameHint(claims Claims, hint string) Claims {
@@ -303,6 +352,7 @@ func (m *AuthMiddleware) logAuditEvent(r *http.Request) error {
 		ErunUserID:       auth.User.UserID,
 		ExternalUserID:   auth.Claims.Subject,
 		ExternalIssuerID: auth.Claims.Issuer,
+		ExternalOrgID:    auth.Org,
 		Type:             model.AuditEventTypeAPI,
 		APIMethod:        r.Method,
 		APIPath:          apiPath,

--- a/erun-backend/erun-backend-api/auth_test.go
+++ b/erun-backend/erun-backend-api/auth_test.go
@@ -374,6 +374,83 @@ func TestAuthMiddlewareExpiresFailedExternalUserResolutionCache(t *testing.T) {
 	}
 }
 
+// TestAuthMiddlewareKeepsOrgScopedTenantsDistinctInCache guards the cross-tenant
+// RLS hole: under a shared org-scoped issuer the same (issuer, subject) resolves
+// to different tenants per org claim, so the identity cache must key on the
+// resolved org too. It also asserts the resolved org reaches the audit event as
+// external_org_id.
+func TestAuthMiddlewareKeepsOrgScopedTenantsDistinctInCache(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	cache := NewIdentityResolutionCache(IdentityCacheOptions{
+		PositiveTTL: time.Minute,
+		Now:         func() time.Time { return now },
+	})
+	tenantForOrg := map[string]string{
+		"org-a": "019a7fa5-c2c0-7c55-bc70-714873a71f1a",
+		"org-b": "019a7fa5-c2c0-7c55-bc70-714873a71f1b",
+	}
+	var event AuditEvent
+	middleware, err := NewAuthMiddleware(AuthMiddlewareOptions{
+		// The bearer token carries the org claim; issuer and subject are identical
+		// across orgs (one Zitadel user acting in different orgs).
+		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
+			return Claims{Issuer: "https://shared.example", Subject: "user-1", Raw: map[string]any{"org": token}}, nil
+		}),
+		OrgResolver: OrgResolverFunc(func(ctx context.Context, claims Claims) (string, error) {
+			org, _ := claims.Raw["org"].(string)
+			return org, nil
+		}),
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
+			org, _ := claims.Raw["org"].(string)
+			tenantID, ok := tenantForOrg[org]
+			if !ok {
+				return Tenant{}, errors.New("unknown org")
+			}
+			return Tenant{TenantID: tenantID}, nil
+		}),
+		UserResolver: UserResolverFunc(func(ctx context.Context, tenantID string, issuer string, externalID string) (User, error) {
+			return User{UserID: "019a7fa5-c2c0-7c55-bc70-714873a71f11"}, nil
+		}),
+		AuditLogger: AuditLoggerFunc(func(ctx context.Context, auditEvent AuditEvent) error {
+			event = auditEvent
+			return nil
+		}),
+		IdentityCache: cache,
+	})
+	if err != nil {
+		t.Fatalf("NewAuthMiddleware failed: %v", err)
+	}
+
+	resolve := func(org string) (string, AuditEvent) {
+		event = AuditEvent{}
+		var resolvedTenant string
+		req := httptest.NewRequest(http.MethodGet, "/v1/whoami", nil)
+		req.Header.Set("Authorization", "Bearer "+org)
+		rec := httptest.NewRecorder()
+		withAPIPath("/v1/whoami", middleware.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth, _ := AuthFromContext(r.Context())
+			resolvedTenant = auth.Tenant.TenantID
+			w.WriteHeader(http.StatusNoContent)
+		}))).ServeHTTP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("org %q: unexpected status: %d", org, rec.Code)
+		}
+		return resolvedTenant, event
+	}
+
+	if got, ev := resolve("org-a"); got != tenantForOrg["org-a"] || ev.ExternalOrgID != "org-a" {
+		t.Fatalf("org-a: tenant=%q externalOrgID=%q", got, ev.ExternalOrgID)
+	}
+	// Same issuer+subject, different org: must NOT return the cached org-a tenant.
+	if got, ev := resolve("org-b"); got != tenantForOrg["org-b"] || ev.ExternalOrgID != "org-b" {
+		t.Fatalf("org-b leaked cached tenant: tenant=%q externalOrgID=%q", got, ev.ExternalOrgID)
+	}
+	// org-a again resolves from cache to the original tenant (no cross-org bleed).
+	if got, _ := resolve("org-a"); got != tenantForOrg["org-a"] {
+		t.Fatalf("org-a re-resolve: tenant=%q", got)
+	}
+}
+
 func TestAuthMiddlewareLogsAuditEventForAuthorizedRequest(t *testing.T) {
 	var event AuditEvent
 	middleware, err := NewAuthMiddleware(AuthMiddlewareOptions{

--- a/erun-backend/erun-backend-api/identity_cache.go
+++ b/erun-backend/erun-backend-api/identity_cache.go
@@ -22,6 +22,10 @@ type IdentityResolutionCache struct {
 type identityCacheKey struct {
 	issuer  string
 	subject string
+	// org is the resolved org claim value for org-scoped (shared) issuers, so the
+	// same (issuer, subject) presenting different org claims cannot collide on one
+	// cached tenant. Empty for single-tenant issuers.
+	org string
 }
 
 type identityCacheEntry struct {
@@ -52,12 +56,12 @@ func NewIdentityResolutionCache(options IdentityCacheOptions) *IdentityResolutio
 	}
 }
 
-func (c *IdentityResolutionCache) Get(issuer string, subject string) (Identity, error, bool) {
+func (c *IdentityResolutionCache) Get(issuer string, subject string, org string) (Identity, error, bool) {
 	if c == nil {
 		return Identity{}, nil, false
 	}
 
-	key := identityCacheKey{issuer: issuer, subject: subject}
+	key := identityCacheKey{issuer: issuer, subject: subject, org: org}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -72,25 +76,25 @@ func (c *IdentityResolutionCache) Get(issuer string, subject string) (Identity, 
 	return entry.identity, entry.err, true
 }
 
-func (c *IdentityResolutionCache) SetSuccess(issuer string, subject string, identity Identity) {
+func (c *IdentityResolutionCache) SetSuccess(issuer string, subject string, org string, identity Identity) {
 	if c == nil {
 		return
 	}
-	c.set(issuer, subject, identity, nil, c.positiveTTL)
+	c.set(issuer, subject, org, identity, nil, c.positiveTTL)
 }
 
-func (c *IdentityResolutionCache) SetFailure(issuer string, subject string, err error) {
+func (c *IdentityResolutionCache) SetFailure(issuer string, subject string, org string, err error) {
 	if c == nil {
 		return
 	}
-	c.set(issuer, subject, Identity{}, err, c.negativeTTL)
+	c.set(issuer, subject, org, Identity{}, err, c.negativeTTL)
 }
 
-func (c *IdentityResolutionCache) set(issuer string, subject string, identity Identity, err error, ttl time.Duration) {
+func (c *IdentityResolutionCache) set(issuer string, subject string, org string, identity Identity, err error, ttl time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.entries[identityCacheKey{issuer: issuer, subject: subject}] = identityCacheEntry{
+	c.entries[identityCacheKey{issuer: issuer, subject: subject, org: org}] = identityCacheEntry{
 		identity:  identity,
 		err:       err,
 		expiresAt: c.now().Add(ttl),

--- a/erun-backend/erun-backend-api/internal/model/audit_event.go
+++ b/erun-backend/erun-backend-api/internal/model/audit_event.go
@@ -13,10 +13,13 @@ const (
 )
 
 type AuditEvent struct {
-	TenantID          string         `json:"tenantId"`
-	ErunUserID        string         `json:"erunUserId"`
-	ExternalUserID    string         `json:"externalUserId"`
-	ExternalIssuerID  string         `json:"externalIssuerId"`
+	TenantID         string `json:"tenantId"`
+	ErunUserID       string `json:"erunUserId"`
+	ExternalUserID   string `json:"externalUserId"`
+	ExternalIssuerID string `json:"externalIssuerId"`
+	// ExternalOrgID is the org claim value that resolved the tenant for an
+	// org-scoped issuer; empty/omitted for single-tenant issuers.
+	ExternalOrgID     string         `json:"externalOrgId,omitempty"`
 	Type              AuditEventType `json:"type"`
 	APIMethod         string         `json:"apiMethod,omitempty"`
 	APIPath           string         `json:"apiPath,omitempty"`

--- a/erun-backend/erun-backend-api/internal/repository/audit_events.go
+++ b/erun-backend/erun-backend-api/internal/repository/audit_events.go
@@ -28,6 +28,7 @@ func (r *AuditEventRepository) LogAuditEvent(ctx context.Context, event model.Au
 				erun_user_id,
 				external_user_id,
 				external_issuer_id,
+				external_org_id,
 				type,
 				api_method,
 				api_path,
@@ -36,12 +37,13 @@ func (r *AuditEventRepository) LogAuditEvent(ctx context.Context, event model.Au
 				mcp_tool,
 				mcp_tool_parameters,
 				created_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`,
 			event.TenantID,
 			event.ErunUserID,
 			event.ExternalUserID,
 			event.ExternalIssuerID,
+			nullString(event.ExternalOrgID),
 			string(event.Type),
 			nullString(event.APIMethod),
 			nullString(event.APIPath),

--- a/erun-backend/erun-backend-api/internal/repository/identity.go
+++ b/erun-backend/erun-backend-api/internal/repository/identity.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
@@ -17,13 +19,106 @@ import (
 type IdentityRepository struct {
 	db      *bun.DB
 	dialect Dialect
+	orgKeys *issuerOrgKeyCache
 }
 
 func NewIdentityRepository(db *sql.DB, dialect Dialect) *IdentityRepository {
 	if dialect == "" {
 		dialect = DialectPostgres
 	}
-	return &IdentityRepository{db: bun.NewDB(db, pgdialect.New()), dialect: dialect}
+	return &IdentityRepository{db: bun.NewDB(db, pgdialect.New()), dialect: dialect, orgKeys: newIssuerOrgKeyCache()}
+}
+
+// issuerOrgKeyCacheTTL bounds how long a cached issuers.org_field_key (the
+// per-issuer org-scoping mode) is trusted before re-reading it, so an issuer
+// reconfigured between single-tenant and org-scoped converges without a restart.
+const issuerOrgKeyCacheTTL = 5 * time.Minute
+
+// issuerOrgKeyCache memoizes the small, stable issuers.org_field_key lookup so
+// the authenticated hot path (cache-key derivation and resolution) does not read
+// the issuers table on every request.
+type issuerOrgKeyCache struct {
+	mu      sync.Mutex
+	entries map[string]issuerOrgKeyEntry
+}
+
+type issuerOrgKeyEntry struct {
+	orgFieldKey string
+	registered  bool
+	expiresAt   time.Time
+}
+
+func newIssuerOrgKeyCache() *issuerOrgKeyCache {
+	return &issuerOrgKeyCache{entries: make(map[string]issuerOrgKeyEntry)}
+}
+
+func (c *issuerOrgKeyCache) get(issuer string) (issuerOrgKeyEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[issuer]
+	if !ok {
+		return issuerOrgKeyEntry{}, false
+	}
+	if !time.Now().Before(entry.expiresAt) {
+		delete(c.entries, issuer)
+		return issuerOrgKeyEntry{}, false
+	}
+	return entry, true
+}
+
+func (c *issuerOrgKeyCache) set(issuer string, entry issuerOrgKeyEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry.expiresAt = time.Now().Add(issuerOrgKeyCacheTTL)
+	c.entries[issuer] = entry
+}
+
+// orgFieldKeyForIssuer returns the issuer's org-scoping mode: registered=false
+// means the issuer is not in the issuers registry, registered=true with an empty
+// orgFieldKey means a single-tenant issuer, and a non-empty orgFieldKey names the
+// token claim whose value selects the tenant. Reads are memoized for a bounded TTL.
+func (r *IdentityRepository) orgFieldKeyForIssuer(ctx context.Context, issuer string) (orgFieldKey string, registered bool, err error) {
+	if r.orgKeys != nil {
+		if entry, ok := r.orgKeys.get(issuer); ok {
+			return entry.orgFieldKey, entry.registered, nil
+		}
+	}
+	var key sql.NullString
+	scanErr := r.db.NewRaw(`SELECT org_field_key FROM issuers WHERE issuer = ?`, issuer).Scan(ctx, &key)
+	if scanErr != nil {
+		if errors.Is(normalizeNoRows(scanErr), ErrNotFound) {
+			// Do not cache the unregistered case: an issuer registered by
+			// first-identity bootstrap would otherwise stay falsely unknown for
+			// the whole TTL. Unregistered lookups are rare and cheap.
+			return "", false, nil
+		}
+		return "", false, scanErr
+	}
+	value := ""
+	if key.Valid {
+		value = strings.TrimSpace(key.String)
+	}
+	if r.orgKeys != nil {
+		r.orgKeys.set(issuer, issuerOrgKeyEntry{orgFieldKey: value, registered: true})
+	}
+	return value, true, nil
+}
+
+// ResolveOrg returns the org claim value that, with the issuer, resolves the
+// tenant for an org-scoped issuer; it returns "" for single-tenant or
+// unregistered issuers. It is the authoritative source for the identity cache
+// key's org dimension, so the same (issuer, subject) presenting different org
+// claims cannot collide on one cached tenant. Resolution failures are surfaced
+// as errors so the caller can fall through to full resolution.
+func (r *IdentityRepository) ResolveOrg(ctx context.Context, claims security.Claims) (string, error) {
+	orgFieldKey, registered, err := r.orgFieldKeyForIssuer(ctx, strings.TrimSpace(claims.Issuer))
+	if err != nil {
+		return "", err
+	}
+	if !registered || orgFieldKey == "" {
+		return "", nil
+	}
+	return orgClaimValue(claims.Raw, orgFieldKey), nil
 }
 
 func (r *IdentityRepository) ResolveIdentity(ctx context.Context, claims security.Claims) (model.Tenant, model.User, error) {
@@ -92,15 +187,19 @@ func (r *IdentityRepository) refreshUserUsername(ctx context.Context, tenant mod
 // routes to first-identity bootstrap when the database is empty.
 func (r *IdentityRepository) ResolveTenantByIssuer(ctx context.Context, claims security.Claims) (model.Tenant, error) {
 	issuer := strings.TrimSpace(claims.Issuer)
-	var orgFieldKey sql.NullString
-	if err := r.db.NewRaw(`SELECT org_field_key FROM issuers WHERE issuer = ?`, issuer).Scan(ctx, &orgFieldKey); err != nil {
-		return model.Tenant{}, normalizeNoRows(err)
+	orgFieldKey, registered, err := r.orgFieldKeyForIssuer(ctx, issuer)
+	if err != nil {
+		return model.Tenant{}, err
+	}
+	if !registered {
+		// Unregistered issuer: unauthorized, or routes to first-identity
+		// bootstrap when the database is empty.
+		return model.Tenant{}, ErrNotFound
 	}
 
 	var tenant model.Tenant
-	var err error
-	if key := strings.TrimSpace(orgFieldKey.String); orgFieldKey.Valid && key != "" {
-		org := orgClaimValue(claims.Raw, key)
+	if orgFieldKey != "" {
+		org := orgClaimValue(claims.Raw, orgFieldKey)
 		if org == "" {
 			// Org-scoped issuer but the token carries no usable org claim.
 			return model.Tenant{}, ErrNotFound

--- a/erun-backend/erun-backend-api/internal/security/context.go
+++ b/erun-backend/erun-backend-api/internal/security/context.go
@@ -23,6 +23,10 @@ type Context struct {
 	ErunUserID     string
 	ExternalIssuer string
 	ExternalUserID string
+	// ExternalOrgID is the org/resource-owner claim value that, together with
+	// ExternalIssuer, resolved the tenant for an org-scoped (shared) issuer.
+	// Empty for single-tenant issuers, where the issuer alone resolves the tenant.
+	ExternalOrgID string
 }
 
 type contextKey struct{}

--- a/erun-backend/erun-backend-api/server.go
+++ b/erun-backend/erun-backend-api/server.go
@@ -14,6 +14,7 @@ type HandlerOptions struct {
 	IdentityResolver IdentityResolver
 	TenantResolver   TenantResolver
 	UserResolver     UserResolver
+	OrgResolver      OrgResolver
 	IdentityCache    *IdentityResolutionCache
 	AuditLogger      AuditLogger
 	Authorizer       Authorizer
@@ -29,7 +30,8 @@ func NewHandler(options HandlerOptions) (http.Handler, error) {
 	identityResolver := options.IdentityResolver
 	tenantResolver := options.TenantResolver
 	userResolver := options.UserResolver
-	if options.DB != nil && (tenantResolver == nil || userResolver == nil) {
+	orgResolver := options.OrgResolver
+	if options.DB != nil && (tenantResolver == nil || userResolver == nil || orgResolver == nil) {
 		identities := repository.NewIdentityRepository(options.DB, options.DBDialect)
 		if identityResolver == nil && tenantResolver == nil && userResolver == nil {
 			identityResolver = identities
@@ -38,6 +40,9 @@ func NewHandler(options HandlerOptions) (http.Handler, error) {
 		}
 		if userResolver == nil {
 			userResolver = identities
+		}
+		if orgResolver == nil {
+			orgResolver = identities
 		}
 	}
 	audit := options.AuditLogger
@@ -53,6 +58,7 @@ func NewHandler(options HandlerOptions) (http.Handler, error) {
 		IdentityResolver: identityResolver,
 		TenantResolver:   tenantResolver,
 		UserResolver:     userResolver,
+		OrgResolver:      orgResolver,
 		IdentityCache:    options.IdentityCache,
 		AuditLogger:      audit,
 		Authorizer:       authorizer,

--- a/erun-backend/erun-backend-db/migrations/default/20260621080214_tenant_issuer_org_scoping.sql
+++ b/erun-backend/erun-backend-db/migrations/default/20260621080214_tenant_issuer_org_scoping.sql
@@ -8,12 +8,27 @@ CREATE TABLE "issuers" (
   "updated_at" timestamptz NULL,
   PRIMARY KEY ("issuer")
 );
--- Modify "tenant_issuers" table
-ALTER TABLE "tenant_issuers" DROP CONSTRAINT "tenant_issuers_pkey", ADD COLUMN "org_field_value" text NULL, ADD CONSTRAINT "tenant_issuers_issuer_org_key" UNIQUE NULLS NOT DISTINCT ("issuer", "org_field_value"), ADD CONSTRAINT "tenant_issuers_issuer_fkey" FOREIGN KEY ("issuer") REFERENCES "issuers" ("issuer") ON UPDATE NO ACTION ON DELETE NO ACTION;
 -- Timestamp trigger for the new issuers table (atlas migrate diff omits
 -- trigger objects without an atlas login session; appended from the
 -- declarative schema; references the existing erun_set_timestamps()).
+-- Created before the backfill below so backfilled issuer rows receive
+-- created_at/updated_at.
 CREATE TRIGGER issuers_set_timestamps
   BEFORE INSERT OR UPDATE ON "issuers"
   FOR EACH ROW
   EXECUTE FUNCTION erun_set_timestamps();
+-- Backfill the issuers registry from existing tenant_issuers rows so the
+-- foreign key added below is satisfiable on an already-populated database:
+-- every distinct issuer already mapped to a tenant must first exist in
+-- issuers. New deploys have an empty tenant_issuers, so this is a no-op there.
+INSERT INTO "issuers" ("issuer")
+SELECT DISTINCT "issuer" FROM "tenant_issuers"
+ON CONFLICT ("issuer") DO NOTHING;
+-- Modify "tenant_issuers" table
+ALTER TABLE "tenant_issuers" DROP CONSTRAINT "tenant_issuers_pkey", ADD COLUMN "org_field_value" text NULL, ADD CONSTRAINT "tenant_issuers_issuer_org_key" UNIQUE NULLS NOT DISTINCT ("issuer", "org_field_value"), ADD CONSTRAINT "tenant_issuers_issuer_fkey" FOREIGN KEY ("issuer") REFERENCES "issuers" ("issuer") ON UPDATE NO ACTION ON DELETE NO ACTION;
+-- Grant access on the new issuers registry, mirroring tenants/tenant_issuers:
+-- erun_operations bootstraps and manages issuer rows; erun_tenant reads them
+-- during (iss, org) -> tenant resolution. Without these, first-identity
+-- bootstrap fails with permission denied on a brand-new hosted deploy.
+GRANT SELECT ON "issuers" TO erun_tenant;
+GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON "issuers" TO erun_operations;

--- a/erun-backend/erun-backend-db/migrations/default/atlas.sum
+++ b/erun-backend/erun-backend-db/migrations/default/atlas.sum
@@ -1,5 +1,5 @@
-h1:+MKJeCd6x4K23L1I/CgxUNs4wBFNoRJX9ucIeFAMoVE=
+h1:LEdSekWby0ba1ScXOls4DNXhOJImEU5cEAuA0f0DvKg=
 20260501120000_initial_tenant_identity.sql h1:RpS03/4sFjbCggwYgcGNn6k3jNZCNTNl0BD/afOKFzo=
 20260503143000_tenant_issuer_names.sql h1:VEZjICG3/jU2YtEx0XX05l9Q8lJyWKeiRY8f4dXOkvE=
 20260503170000_audit_events.sql h1:OLjiGP/FhLTWvkx1bxS2xCcJK6tExdufnEC8R6LsKWA=
-20260621080214_tenant_issuer_org_scoping.sql h1:J2SYD5vm806J85oZLwMSSy+LplQBC4C+rC9Djnvztec=
+20260621080214_tenant_issuer_org_scoping.sql h1:0j307UhB2vONxxTgh8edO8L6skfgTvy0eP2xHWCm1wo=

--- a/erun-backend/erun-backend-db/schema/roles.sql
+++ b/erun-backend/erun-backend-db/schema/roles.sql
@@ -12,9 +12,9 @@ $$;
 
 GRANT USAGE ON SCHEMA public TO erun_tenant, erun_operations;
 
-GRANT SELECT ON tenants, tenant_issuers TO erun_tenant;
+GRANT SELECT ON tenants, tenant_issuers, issuers TO erun_tenant;
 GRANT UPDATE (name) ON tenant_issuers TO erun_tenant;
-GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON tenants, tenant_issuers TO erun_operations;
+GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON tenants, tenant_issuers, issuers TO erun_operations;
 
 GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES
   ON users, user_external_ids, roles, role_permissions, user_roles, reviews, review_merge_queue, builds, comments

--- a/erun-cli/cmd/expose.go
+++ b/erun-cli/cmd/expose.go
@@ -51,7 +51,10 @@ func runExposeCommand(ctx common.Context, store common.ExposeStore, findProjectR
 		return err
 	}
 	if !ctx.DryRun {
-		_, _ = fmt.Fprintf(ctx.Stdout, "exposed %s/%s service %s at https://%s\n", result.Tenant, result.Environment, result.Service, result.Hostname)
+		// The applied Ingress is HTTP-only today (no TLS/cert-manager); the
+		// wildcard TLS certificate lands with the DNS-01 broker (Phase B), at
+		// which point this becomes https. Don't claim a scheme we don't serve.
+		_, _ = fmt.Fprintf(ctx.Stdout, "exposed %s/%s service %s at http://%s\n", result.Tenant, result.Environment, result.Service, result.Hostname)
 	}
 	return nil
 }

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -1783,11 +1783,11 @@ func helmPlatformSetArgs(p PlatformConfig) []string {
 		return nil
 	}
 	args := []string{
-		"--set-string", "platform.baseDomain=" + p.BaseDomain,
-		"--set-string", "platform.env=" + p.Env,
-		"--set-string", "platform.servicesZone=" + p.ServicesZone,
-		"--set-string", "platform.authoritativeIP=" + p.AuthoritativeIP,
-		"--set-string", "platform.authHost=" + p.AuthHost,
+		"--set-string", "platform.baseDomain=" + escapeHelmSetValue(p.BaseDomain),
+		"--set-string", "platform.env=" + escapeHelmSetValue(p.Env),
+		"--set-string", "platform.servicesZone=" + escapeHelmSetValue(p.ServicesZone),
+		"--set-string", "platform.authoritativeIP=" + escapeHelmSetValue(p.AuthoritativeIP),
+		"--set-string", "platform.authHost=" + escapeHelmSetValue(p.AuthHost),
 	}
 	if len(p.Nameservers) > 0 {
 		if encoded, marshalErr := json.Marshal(p.Nameservers); marshalErr == nil {

--- a/erun-common/expose.go
+++ b/erun-common/expose.go
@@ -73,6 +73,15 @@ type ExposeServiceResult struct {
 	TargetIP          string `json:"targetIP"`
 	IngressName       string `json:"ingressName"`
 	ServicePort       int    `json:"servicePort"`
+	// PlatformNamespace is the namespace the platform's PowerDNS singleton runs
+	// in (derived from platform.Env); the per-env wildcard record is written by
+	// exec'ing pdnsutil there.
+	PlatformNamespace string `json:"platformNamespace"`
+	// PlatformContext is the kube context of the platform env's own cluster,
+	// which the DNS write must target — it may differ from KubernetesContext (the
+	// target env's cluster). Empty when the platform env declares no explicit
+	// context (the current kube context is then used).
+	PlatformContext string `json:"platformContext,omitempty"`
 }
 
 const defaultExposeServicePort = 80
@@ -91,23 +100,68 @@ const defaultExposeWildcardTTL = 60
 func RunExposeService(ctx Context, params ExposeServiceParams, store ExposeStore, upsertDNSRecord DNSRecordUpserterFunc, applyIngress IngressApplierFunc) (ExposeServiceResult, error) {
 	store, upsertDNSRecord, applyIngress = normalizeExposeDependencies(store, upsertDNSRecord, applyIngress)
 
-	result, platform, err := resolveExposeServicePlan(params, store)
+	result, err := resolveExposeServicePlan(params, store)
 	if err != nil {
 		return ExposeServiceResult{}, err
 	}
 
+	dnsParams := exposeDNSParams(result)
+	ingressParams := exposeIngressParams(result)
+
+	// Trace the real commands (not synthetic verbs) so a dry-run is a faithful,
+	// side-effect-free plan: the per-env wildcard write execs pdnsutil in the
+	// platform's PowerDNS pod (its own namespace/context), and the Ingress is
+	// applied into the target env's namespace.
 	ctx.Trace(fmt.Sprintf("expose: %s -> service %s.%s.svc:%d", result.Hostname, result.Service, result.Namespace, result.ServicePort))
-	ctx.Trace(fmt.Sprintf("expose: per-env wildcard %s A %s (zone %s)", result.WildcardName, result.TargetIP, result.ServicesZone))
-	ctx.TraceCommand("", "powerdns-upsert-record", result.ServicesZone, result.WildcardName, "A", result.TargetIP)
-	ctx.TraceCommand("", "kubectl", "apply", "ingress/"+result.IngressName, "-n", result.Namespace)
+	ctx.Trace(fmt.Sprintf("expose: per-env wildcard %s A %s ttl %d (zone %s)", result.WildcardName, result.TargetIP, dnsParams.TTL, result.ServicesZone))
+	ctx.Trace(fmt.Sprintf("expose: platform powerdns namespace %s", result.PlatformNamespace))
+	ctx.TraceCommand("", "kubectl", powerDNSUpsertArgs(dnsParams)...)
+	ctx.TraceCommand("", "kubectl", ingressApplyArgs(ingressParams)...)
 	if ctx.DryRun {
 		return result, nil
 	}
 
-	if err := applyExposeService(ctx, result, platform, upsertDNSRecord, applyIngress); err != nil {
-		return result, err
+	// The Ingress lands in the target env's cluster; require that context here.
+	// The DNS write targets the platform cluster (dnsParams.KubernetesContext)
+	// and is left to kubectl's resolution (explicit platform context or current).
+	if err := ctx.RequireKubernetesContext(result.KubernetesContext); err != nil {
+		return result, fmt.Errorf("expose %s/%s: %w", result.Tenant, result.Environment, err)
+	}
+	if err := upsertDNSRecord(dnsParams); err != nil {
+		return result, fmt.Errorf("upsert wildcard DNS record %s: %w", result.WildcardName, err)
+	}
+	if err := applyIngress(ingressParams); err != nil {
+		return result, fmt.Errorf("apply ingress %s: %w", result.IngressName, err)
 	}
 	return result, nil
+}
+
+// exposeDNSParams builds the per-env wildcard A-record write from the resolved
+// plan. It targets the platform's PowerDNS (its namespace and own kube context),
+// not the target env's cluster.
+func exposeDNSParams(result ExposeServiceResult) DNSRecordUpsertParams {
+	return DNSRecordUpsertParams{
+		Zone:              result.ServicesZone,
+		Name:              result.WildcardName,
+		Type:              "A",
+		TTL:               defaultExposeWildcardTTL,
+		Value:             result.TargetIP,
+		PlatformNamespace: result.PlatformNamespace,
+		KubernetesContext: result.PlatformContext,
+	}
+}
+
+// exposeIngressParams builds the Host-routing Ingress apply from the resolved
+// plan, targeting the env's own namespace and cluster context.
+func exposeIngressParams(result ExposeServiceResult) IngressApplyParams {
+	return IngressApplyParams{
+		KubernetesContext: result.KubernetesContext,
+		Namespace:         result.Namespace,
+		Name:              result.IngressName,
+		Host:              result.Hostname,
+		ServiceName:       result.Service,
+		ServicePort:       result.ServicePort,
+	}
 }
 
 // validateExposeTarget trims and validates the required identity inputs,
@@ -122,6 +176,12 @@ func validateExposeTarget(params ExposeServiceParams) (tenant, environment, serv
 	if err := ValidateTenantName(tenant); err != nil {
 		return "", "", "", err
 	}
+	// The service name becomes a DNS label in the public hostname, an Ingress
+	// name (expose-<service>), and the routed Service name, so validate it up
+	// front — before any DNS record is written — rather than failing mid-flight.
+	if !isDNSLabel(service) || len(service) > 63 {
+		return "", "", "", fmt.Errorf("service name %q must be a DNS-1035 label: lowercase letters, digits, and hyphens, not starting or ending with a hyphen, at most 63 characters", service)
+	}
 	return tenant, environment, service, nil
 }
 
@@ -129,22 +189,27 @@ func validateExposeTarget(params ExposeServiceParams) (tenant, environment, serv
 // assembles the side-effect-free ExposeServiceResult plus the resolved platform
 // the execution phase needs. It does no tracing or mutation, so RunExposeService
 // keeps ownership of the dry-run trace order.
-func resolveExposeServicePlan(params ExposeServiceParams, store ExposeStore) (ExposeServiceResult, PlatformConfig, error) {
+func resolveExposeServicePlan(params ExposeServiceParams, store ExposeStore) (ExposeServiceResult, error) {
 	tenant, environment, service, err := validateExposeTarget(params)
 	if err != nil {
-		return ExposeServiceResult{}, PlatformConfig{}, err
+		return ExposeServiceResult{}, err
 	}
 	platform := resolveProjectPlatform(params.ProjectRoot)
 	if platform.IsZero() || strings.TrimSpace(platform.ServicesZone) == "" {
-		return ExposeServiceResult{}, PlatformConfig{}, fmt.Errorf("expose requires a platform block with a base domain in .erun/config.yaml (the services zone tenant hostnames live under)")
+		return ExposeServiceResult{}, fmt.Errorf("expose requires a platform block with a base domain in .erun/config.yaml (the services zone tenant hostnames live under)")
+	}
+	// Fail fast on a malformed platform block (matching deploy's contract) before
+	// deriving any hostnames or zone names from it.
+	if err := platform.Validate(); err != nil {
+		return ExposeServiceResult{}, err
 	}
 	envConfig, _, err := store.LoadEnvConfig(tenant, environment)
 	if err != nil {
-		return ExposeServiceResult{}, PlatformConfig{}, err
+		return ExposeServiceResult{}, err
 	}
 	targetIP := strings.TrimSpace(params.TargetIP)
 	if targetIP == "" {
-		return ExposeServiceResult{}, PlatformConfig{}, fmt.Errorf("a target IP is required (the env's ingress IP the wildcard record points at, e.g. 127.0.0.1 for a local cluster)")
+		return ExposeServiceResult{}, fmt.Errorf("a target IP is required (the env's ingress IP the wildcard record points at, e.g. 127.0.0.1 for a local cluster)")
 	}
 	servicePort := params.ServicePort
 	if servicePort <= 0 {
@@ -163,39 +228,40 @@ func resolveExposeServicePlan(params ExposeServiceParams, store ExposeStore) (Ex
 		TargetIP:          targetIP,
 		IngressName:       fmt.Sprintf("expose-%s", service),
 		ServicePort:       servicePort,
+		PlatformNamespace: normalizeNamespaceName(platform.Env),
+		PlatformContext:   resolvePlatformContext(store, platform.Env),
 	}
-	return result, platform, nil
+	return result, nil
 }
 
-// applyExposeService performs the post-dry-run side effects: require the env's
-// kubernetes context, ensure the per-env wildcard A record, and apply the
-// Host-routing ingress.
-func applyExposeService(ctx Context, result ExposeServiceResult, platform PlatformConfig, upsertDNSRecord DNSRecordUpserterFunc, applyIngress IngressApplierFunc) error {
-	if err := ctx.RequireKubernetesContext(result.KubernetesContext); err != nil {
-		return fmt.Errorf("expose %s/%s: %w", result.Tenant, result.Environment, err)
+// resolvePlatformContext finds the kube context of the platform env's own
+// cluster so the DNS write targets the platform's PowerDNS rather than the
+// target env's cluster (which may be a different cluster entirely). platformEnv
+// is a "<tenant>-<env>" namespace label; tenant names carry no hyphen, so the
+// first hyphen splits it unambiguously. Best-effort: if the platform env config
+// is not loadable, returns "" and kubectl falls back to the current context.
+func resolvePlatformContext(store ExposeStore, platformEnv string) string {
+	platTenant, platEnvName, ok := splitTenantEnv(platformEnv)
+	if !ok {
+		return ""
 	}
-	if err := upsertDNSRecord(DNSRecordUpsertParams{
-		Zone:              platform.ServicesZone,
-		Name:              result.WildcardName,
-		Type:              "A",
-		TTL:               defaultExposeWildcardTTL,
-		Value:             result.TargetIP,
-		PlatformNamespace: normalizeNamespaceName(platform.Env),
-		KubernetesContext: result.KubernetesContext,
-	}); err != nil {
-		return fmt.Errorf("upsert wildcard DNS record %s: %w", result.WildcardName, err)
+	envConfig, _, err := store.LoadEnvConfig(platTenant, platEnvName)
+	if err != nil {
+		return ""
 	}
-	if err := applyIngress(IngressApplyParams{
-		KubernetesContext: result.KubernetesContext,
-		Namespace:         result.Namespace,
-		Name:              result.IngressName,
-		Host:              result.Hostname,
-		ServiceName:       result.Service,
-		ServicePort:       result.ServicePort,
-	}); err != nil {
-		return fmt.Errorf("apply ingress %s: %w", result.IngressName, err)
+	return strings.TrimSpace(envConfig.KubernetesContext)
+}
+
+// splitTenantEnv splits a "<tenant>-<env>" namespace label on its first hyphen.
+// Tenant names contain no hyphens (ValidateTenantName), so the first hyphen is
+// the unambiguous tenant/env boundary; env may itself contain hyphens.
+func splitTenantEnv(label string) (tenant, env string, ok bool) {
+	label = strings.TrimSpace(label)
+	i := strings.IndexByte(label, '-')
+	if i <= 0 || i >= len(label)-1 {
+		return "", "", false
 	}
-	return nil
+	return label[:i], label[i+1:], true
 }
 
 func normalizeExposeDependencies(store ExposeStore, upsertDNSRecord DNSRecordUpserterFunc, applyIngress IngressApplierFunc) (ExposeStore, DNSRecordUpserterFunc, IngressApplierFunc) {

--- a/erun-common/expose_exec.go
+++ b/erun-common/expose_exec.go
@@ -2,34 +2,65 @@ package eruncommon
 
 import (
 	"fmt"
-	"os"
+	"strconv"
 	"strings"
 )
 
-// applyHostRoutingIngress renders and applies a networking.k8s.io/v1 Ingress
-// that Host-routes the exposed hostname to the in-namespace Service. Live-only:
-// it shells out to kubectl against the env's cluster, so it never runs under a
-// dry-run (RunExposeService short-circuits before calling it).
-func applyHostRoutingIngress(params IngressApplyParams) error {
-	manifest := renderHostRoutingIngress(params)
-	file, err := os.CreateTemp("", "erun-expose-ingress-*.yaml")
-	if err != nil {
-		return err
-	}
-	defer func() { _ = os.Remove(file.Name()) }()
-	if _, err := file.WriteString(manifest); err != nil {
-		_ = file.Close()
-		return err
-	}
-	if err := file.Close(); err != nil {
-		return err
-	}
+// powerDNSConfigDir is where the erun-powerdns chart writes the generated
+// gpgsql backend config (see erun-devops/k8s/erun-powerdns). pdnsutil in the
+// PowerDNS pod reads the backend (and the postgres password) from there via
+// --config-dir, so the exec carries no --gpgsql-* flags and no password.
+const powerDNSConfigDir = "/etc/pdns-shared"
+
+// powerDNSUpsertArgs builds the kubectl argv that replaces one record's rrset by
+// exec'ing pdnsutil in the platform's PowerDNS pod. The pdnsutil tokens are
+// passed as direct argv (no `sh -c`), so the wildcard name needs no shell
+// quoting and no secret is interpolated. Shared by the dry-run trace and the
+// live exec so they are identical.
+func powerDNSUpsertArgs(params DNSRecordUpsertParams) []string {
+	relName := strings.TrimSuffix(params.Name, "."+params.Zone)
 	args := []string{}
 	if ctxName := strings.TrimSpace(params.KubernetesContext); ctxName != "" {
 		args = append(args, "--context", ctxName)
 	}
-	args = append(args, "-n", params.Namespace, "apply", "-f", file.Name())
-	if out, err := Command("kubectl", args...).CombinedOutput(); err != nil {
+	args = append(args, "-n", params.PlatformNamespace, "exec", "deploy/erun-powerdns", "--",
+		"pdnsutil", "--config-dir="+powerDNSConfigDir, "replace-rrset",
+		params.Zone, relName, params.Type, strconv.Itoa(params.TTL), params.Value)
+	return args
+}
+
+// ingressApplyArgs builds the kubectl argv that applies the Host-routing Ingress
+// into the target env's namespace, reading the manifest from stdin (`-f -`) so
+// the command is deterministic (no temp-file path). Shared by trace and exec.
+func ingressApplyArgs(params IngressApplyParams) []string {
+	args := []string{}
+	if ctxName := strings.TrimSpace(params.KubernetesContext); ctxName != "" {
+		args = append(args, "--context", ctxName)
+	}
+	args = append(args, "-n", params.Namespace, "apply", "-f", "-")
+	return args
+}
+
+// upsertPowerDNSRecord replaces the rrset for one record in the platform's
+// services zone by exec'ing pdnsutil inside the PowerDNS pod, which reads the
+// gpgsql backend (and password) from its generated --config-dir config.
+// Live-only: never runs under a dry-run.
+func upsertPowerDNSRecord(params DNSRecordUpsertParams) error {
+	if out, err := Command("kubectl", powerDNSUpsertArgs(params)...).CombinedOutput(); err != nil {
+		return fmt.Errorf("kubectl exec pdnsutil replace-rrset: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// applyHostRoutingIngress renders and applies a networking.k8s.io/v1 Ingress
+// that Host-routes the exposed hostname to the in-namespace Service, piping the
+// manifest to `kubectl apply -f -`. Live-only: it shells out to kubectl against
+// the env's cluster, so it never runs under a dry-run (RunExposeService
+// short-circuits before calling it).
+func applyHostRoutingIngress(params IngressApplyParams) error {
+	cmd := Command("kubectl", ingressApplyArgs(params)...)
+	cmd.Stdin = strings.NewReader(renderHostRoutingIngress(params))
+	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("kubectl apply ingress: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil
@@ -56,32 +87,4 @@ spec:
                 port:
                   number: %d
 `, params.Name, params.Namespace, params.Host, params.ServiceName, params.ServicePort)
-}
-
-// upsertPowerDNSRecord replaces the rrset for one record in the platform's
-// services zone by exec'ing pdnsutil inside the PowerDNS pod, which holds the
-// gpgsql password in its PDNS_GPGSQL_PASSWORD env (expanded by the in-pod sh).
-// The gpgsql connection coordinates match the erun-powerdns chart defaults.
-// Live-only: never runs under a dry-run.
-func upsertPowerDNSRecord(params DNSRecordUpsertParams) error {
-	relName := strings.TrimSuffix(params.Name, "."+params.Zone)
-	script := fmt.Sprintf(
-		`pdnsutil --launch=gpgsql --gpgsql-host=erun-postgres --gpgsql-port=5432 --gpgsql-dbname=powerdns --gpgsql-user=erun --gpgsql-password="$PDNS_GPGSQL_PASSWORD" replace-rrset %s %s %s %d %s`,
-		shellSingleQuote(params.Zone), shellSingleQuote(relName), shellSingleQuote(params.Type), params.TTL, shellSingleQuote(params.Value),
-	)
-	args := []string{}
-	if ctxName := strings.TrimSpace(params.KubernetesContext); ctxName != "" {
-		args = append(args, "--context", ctxName)
-	}
-	args = append(args, "-n", params.PlatformNamespace, "exec", "deploy/erun-powerdns", "--", "sh", "-c", script)
-	if out, err := Command("kubectl", args...).CombinedOutput(); err != nil {
-		return fmt.Errorf("kubectl exec pdnsutil replace-rrset: %w: %s", err, strings.TrimSpace(string(out)))
-	}
-	return nil
-}
-
-// shellSingleQuote wraps a value in single quotes for safe interpolation into
-// the in-pod `sh -c` script, escaping any embedded single quotes.
-func shellSingleQuote(value string) string {
-	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
 }

--- a/erun-common/platform_config.go
+++ b/erun-common/platform_config.go
@@ -102,17 +102,31 @@ func (c PlatformConfig) Validate() error {
 	if !isDNSName(resolved.BaseDomain) {
 		return fmt.Errorf("platform config: basedomain %q is not a valid domain name", resolved.BaseDomain)
 	}
-	if !isUnderDomain(resolved.ServicesZone, resolved.BaseDomain) {
-		return fmt.Errorf("platform config: serviceszone %q must be %q or a subdomain of it", resolved.ServicesZone, resolved.BaseDomain)
+	if err := validatePlatformHost("serviceszone", resolved.ServicesZone, resolved.BaseDomain); err != nil {
+		return err
 	}
-	if !isUnderDomain(resolved.AuthHost, resolved.BaseDomain) {
-		return fmt.Errorf("platform config: authhost %q must be %q or a subdomain of it", resolved.AuthHost, resolved.BaseDomain)
+	if err := validatePlatformHost("authhost", resolved.AuthHost, resolved.BaseDomain); err != nil {
+		return err
 	}
 	if resolved.AuthoritativeIP != "" && net.ParseIP(resolved.AuthoritativeIP) == nil {
 		return fmt.Errorf("platform config: authoritativeip %q is not a valid IP address", resolved.AuthoritativeIP)
 	}
 	if resolved.Env != "" && normalizeNamespaceName(resolved.Env) != resolved.Env {
 		return fmt.Errorf("platform config: env %q must be a DNS-safe namespace label (lowercase letters, digits, and hyphens)", resolved.Env)
+	}
+	return nil
+}
+
+// validatePlatformHost checks that a derived platform host (the services zone or
+// the auth host) is a valid domain name and sits at or under the base domain,
+// keeping the nothing-hardcoded invariant honest and the value safe to thread
+// into helm --set-string.
+func validatePlatformHost(field, host, base string) error {
+	if !isDNSName(host) {
+		return fmt.Errorf("platform config: %s %q is not a valid domain name", field, host)
+	}
+	if !isUnderDomain(host, base) {
+		return fmt.Errorf("platform config: %s %q must be %q or a subdomain of it", field, host, base)
 	}
 	return nil
 }

--- a/erun-devops/k8s/erun-powerdns/templates/powerdns.yaml
+++ b/erun-devops/k8s/erun-powerdns/templates/powerdns.yaml
@@ -9,8 +9,21 @@
   - :53 is bound on the node via hostNetwork so the public glue record
     (ns1.<base-domain> -> <authoritativeIP>) resolves to this pod. dnsPolicy
     ClusterFirstWithHostNet keeps cluster DNS so `erun-postgres` still resolves.
-  - The HTTP API (used by the DNS-01 broker to write _acme-challenge / wildcard
-    records) is exposed on a ClusterIP Service, guarded by an api-key Secret.
+    The container runs as the image's non-root `pdns` user, so it carries
+    NET_BIND_SERVICE to bind the privileged :53 portably (k8s does not relax
+    ip_unprivileged_port_start the way the local Docker default does).
+  - The HTTP API/webserver is bound to loopback only (127.0.0.1) and is NOT
+    exposed cluster-wide: record writes happen via `pdnsutil` against the gpgsql
+    backend (see `erun-common/expose_exec.go`), not the HTTP API. The api-key
+    Secret and the local webserver remain so a future in-pod DNS-01 broker has a
+    foundation; reaching the API from another pod is a deliberate Phase B change.
+  - The gpgsql backend config (including the postgres password and api-key) is
+    written once to a generated pdns.conf on a per-pod volume and consumed via
+    --config-dir, so secrets never appear in process argv. pdnsutil in this
+    PowerDNS line does not accept --launch/--gpgsql-* on the command line, so a
+    config file is the only way to point it at the backend; pdns_server uses the
+    same file. The image ships a default sqlite pdns.conf that is fatal under
+    --launch=gpgsql, which --config-dir to the generated file also avoids.
   - The gpgsql schema is lifted out of the pinned PowerDNS image itself, so it
     always matches the server version, then loaded once into the powerdns DB.
 
@@ -44,6 +57,7 @@
 {{- $platform := default dict .Values.platform -}}
 {{- $servicesZone := default "" $platform.servicesZone -}}
 {{- $nameservers := default (list) $platform.nameservers -}}
+{{- $configDir := "/etc/pdns-shared" -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -53,21 +67,6 @@ metadata:
 type: Opaque
 stringData:
   {{ $apiKeySecretKey }}: {{ $apiKey | quote }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: erun-powerdns-api
-  labels:
-    app: erun-powerdns
-spec:
-  type: ClusterIP
-  selector:
-    app: erun-powerdns
-  ports:
-    - name: api
-      port: {{ $apiPort }}
-      targetPort: api
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -90,6 +89,49 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
+        # Generate the gpgsql backend config (with the postgres password and
+        # api-key from their Secrets) onto a per-pod volume, consumed by both
+        # pdns_server and pdnsutil via --config-dir. Keeps secrets out of argv,
+        # and avoids the image's default sqlite pdns.conf that is fatal under
+        # --launch=gpgsql.
+        - name: config-gen
+          image: {{ $powerdnsImage }}
+          env:
+            - name: PDNS_GPGSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $postgresPasswordSecretName }}
+                  key: {{ $postgresPasswordSecretKey }}
+            - name: PDNS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $apiKeySecretName }}
+                  key: {{ $apiKeySecretKey }}
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              umask 077
+              cat > {{ $configDir }}/pdns.conf <<EOF
+              launch=gpgsql
+              gpgsql-host={{ $postgresHost }}
+              gpgsql-port={{ $postgresPort }}
+              gpgsql-dbname={{ $powerdnsDatabase }}
+              gpgsql-user={{ $postgresUser }}
+              gpgsql-password=$PDNS_GPGSQL_PASSWORD
+              local-address=0.0.0.0
+              local-port=53
+              api=yes
+              api-key=$PDNS_API_KEY
+              webserver=yes
+              webserver-address=127.0.0.1
+              webserver-port={{ $apiPort }}
+              webserver-allow-from=127.0.0.1
+              EOF
+          volumeMounts:
+            - name: config
+              mountPath: {{ $configDir }}
         # Lift the gpgsql schema out of the pinned PowerDNS image so it always
         # matches the server version, onto a shared volume the loader can read.
         - name: schema-source
@@ -97,7 +139,7 @@ spec:
           command:
             - sh
             - -c
-            - cp /usr/share/pdns-backend-pgsql/schema/schema.pgsql.sql /schema/schema.sql
+            - cp /usr/local/share/doc/pdns/schema.pgsql.sql /schema/schema.sql
           volumeMounts:
             - name: schema
               mountPath: /schema
@@ -139,60 +181,32 @@ spec:
         # Bootstrap the authoritative services zone once, with its nameservers,
         # from the per-instance platform config that deploy threads in as
         # platform.* values. Idempotent (skips when the zone already exists).
-        # Per-env wildcard/_acme-challenge records are added later via the API.
+        # Per-env wildcard/_acme-challenge records are added later via pdnsutil.
         - name: zone-bootstrap
           image: {{ $powerdnsImage }}
-          env:
-            - name: PDNS_GPGSQL_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $postgresPasswordSecretName }}
-                  key: {{ $postgresPasswordSecretKey }}
           command:
             - sh
             - -c
             - |
               set -e
-              pdnsutil="pdnsutil --launch=gpgsql --gpgsql-host={{ $postgresHost }} --gpgsql-port={{ $postgresPort }} --gpgsql-dbname={{ $powerdnsDatabase }} --gpgsql-user={{ $postgresUser }} --gpgsql-password=$PDNS_GPGSQL_PASSWORD"
-              if ! $pdnsutil list-zone {{ $servicesZone | quote }} >/dev/null 2>&1; then
-                $pdnsutil create-zone {{ $servicesZone | quote }}{{ range $ns := $nameservers }} {{ $ns | quote }}{{ end }}
+              if ! pdnsutil --config-dir={{ $configDir }} list-zone {{ $servicesZone | quote }} >/dev/null 2>&1; then
+                pdnsutil --config-dir={{ $configDir }} create-zone {{ $servicesZone | quote }}{{ range $ns := $nameservers }} {{ $ns | quote }}{{ end }}
               fi
+          volumeMounts:
+            - name: config
+              mountPath: {{ $configDir }}
         {{- end }}
       containers:
         - name: erun-powerdns
           image: {{ $powerdnsImage }}
           imagePullPolicy: IfNotPresent
-          env:
-            - name: PDNS_GPGSQL_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $postgresPasswordSecretName }}
-                  key: {{ $postgresPasswordSecretKey }}
-            - name: PDNS_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $apiKeySecretName }}
-                  key: {{ $apiKeySecretKey }}
+          securityContext:
+            # Non-root pdns user binding privileged :53 under hostNetwork.
+            capabilities:
+              add: ["NET_BIND_SERVICE"]
           command:
             - pdns_server
-          # CLI args take precedence over the image's default pdns.conf, so the
-          # backend/API config is explicit here. Secrets are injected via the
-          # $(VAR) env substitution kubelet performs on args.
-          args:
-            - --launch=gpgsql
-            - --gpgsql-host={{ $postgresHost }}
-            - --gpgsql-port={{ $postgresPort }}
-            - --gpgsql-dbname={{ $powerdnsDatabase }}
-            - --gpgsql-user={{ $postgresUser }}
-            - --gpgsql-password=$(PDNS_GPGSQL_PASSWORD)
-            - --local-address=0.0.0.0
-            - --local-port=53
-            - --api=yes
-            - --api-key=$(PDNS_API_KEY)
-            - --webserver=yes
-            - --webserver-address=0.0.0.0
-            - --webserver-port={{ $apiPort }}
-            - --webserver-allow-from=0.0.0.0/0
+            - --config-dir={{ $configDir }}
           ports:
             - name: dns-udp
               containerPort: 53
@@ -202,20 +216,26 @@ spec:
               containerPort: 53
               hostPort: 53
               protocol: TCP
-            - name: api
-              containerPort: {{ $apiPort }}
+          # Probe the authoritative DNS port (the served surface). The HTTP API
+          # is loopback-only, so kubelet (which probes the pod/node IP under
+          # hostNetwork) cannot reach it.
           readinessProbe:
             tcpSocket:
-              port: api
+              port: dns-tcp
             periodSeconds: 5
             timeoutSeconds: 2
           startupProbe:
             tcpSocket:
-              port: api
+              port: dns-tcp
             periodSeconds: 2
             timeoutSeconds: 2
             failureThreshold: 60
+          volumeMounts:
+            - name: config
+              mountPath: {{ $configDir }}
       volumes:
         - name: schema
+          emptyDir: {}
+        - name: config
           emptyDir: {}
       restartPolicy: Always

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -17,47 +17,58 @@ Every request signs in the same way — Operators and Agents alike. ERun uses st
   <figcaption>One protocol for everyone. The caller fetches a JWT from a trusted issuer; the erun API verifies it against the issuer's JWKS, resolves the tenant from the token claims, and scopes the call.</figcaption>
 </figure>
 
-### Tenant issuers
+### Identity model: `(iss, org) → tenant` {#tenant-issuers}
 
-Each tenant declares one or more **trusted issuers**. A token is accepted only if it was minted by one of them.
+ERun resolves the tenant from the token itself, not from the request path. Two database tables hold the mapping:
+
+- **`issuers`** registers each OIDC issuer **once**, by its `iss` URL, with an org-scoping mode (`org_field_key`):
+  - `org_field_key` **NULL** → a **single-tenant issuer**: the `iss` alone resolves the tenant. This is the common case — a tenant's own IdP or a cloud workload-identity issuer (e.g. AWS IAM/OIDC).
+  - `org_field_key` **set** → an **org-scoped (shared) issuer** (e.g. one hosted Zitadel serving every tenant): the value names the **token claim** whose value selects which tenant the call belongs to.
+- **`tenant_issuers`** maps `(issuer, org_field_value) → tenant`:
+  - A single-tenant issuer has exactly one row with a NULL `org_field_value`.
+  - An org-scoped issuer has one row per org value, all sharing the same `iss`.
 
 ```jsonc
-// TenantIssuer
-{
-  "issuerUrl": "https://issuer.example.com/oauth2/default",  // unique within the tenant
-  "audience": "erun-api",                                     // expected `aud` claim
-  "subjectClaim": "sub",                                       // claim used as creator user id (default: "sub")
-  "tenantClaim": "custom:tenant",                              // optional; when set, ERun matches this claim against the tenant name
-  "allowedSubjects": ["agent-bot-a", "agent-bot-b"],           // optional allow-list of `sub` values
-  "createdAt": "2026-05-24T10:00:00Z"
-}
+// issuers — the global issuer registry (one row per iss)
+{ "issuer": "https://issuer.example.com",       "orgFieldKey": null }              // single-tenant
+{ "issuer": "https://auth.erunpaas.com",        "orgFieldKey": "urn:zitadel:iam:user:resourceowner:id" } // org-scoped
+
+// tenant_issuers — (issuer, org_field_value) -> tenant
+{ "issuer": "https://issuer.example.com", "orgFieldValue": null,        "tenant": "acme" }   // single-tenant
+{ "issuer": "https://auth.erunpaas.com",  "orgFieldValue": "123456789", "tenant": "acme" }   // org-scoped: acme's org
+{ "issuer": "https://auth.erunpaas.com",  "orgFieldValue": "987654321", "tenant": "globex" } // same issuer, different org -> different tenant
 ```
+
+A single issuer can therefore map to **many** tenants (org-scoped), and multiple distinct issuers can map to the **same** tenant. The resolution key `(iss, org)` is kept unambiguous by a `UNIQUE NULLS NOT DISTINCT (issuer, org_field_value)` constraint. See the [database schema guidance](https://github.com/sophium/erun/blob/main/erun-backend/erun-backend-db/AGENTS.md) for the full table contract.
 
 ### Token verification algorithm
 
 For every authenticated request:
 
-1. Read `Authorization: Bearer <jwt>`. Missing header → `401`.
-2. Decode the JWT header to extract `alg` and `kid`. Unsupported `alg` (anything outside `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`) → `401` with code `UNSUPPORTED_ALG`.
-3. Resolve the caller's tenant from the request path (`/v1/<resource>` is tenant-bound; the tenant is identified by the `tenantClaim` value validated below). Load the tenant's `TenantIssuer[]` set.
-4. For each issuer: fetch (or read from cache) `<issuerUrl>/.well-known/openid-configuration`. Cache TTL **60 minutes**; on cache miss or expiry, re-fetch synchronously.
-5. From the discovery document, fetch `jwks_uri` → JWKS. Cache TTL **15 minutes**.
-6. Find the key matching `kid` in the JWKS. If absent: re-fetch the JWKS once (bypassing cache). If still absent → `401` with code `UNKNOWN_KEY`.
-7. Verify the JWT signature against the key. Failure → `401` with code `INVALID_SIGNATURE`.
-8. Validate registered claims: `iss` matches the issuer; `aud` matches `TenantIssuer.audience`; `exp` > now; `nbf` ≤ now (or absent); `iat` is reasonable (< 24h in the past). Any miss → `401` with code `INVALID_CLAIM`.
-9. If `TenantIssuer.tenantClaim` is set: read that claim's value from the token; it must equal the request's target tenant name. Mismatch → `403` with code `TENANT_MISMATCH`.
-10. If `TenantIssuer.allowedSubjects` is set: the token's `subjectClaim` value (default `sub`) must be in the list. Miss → `403` with code `SUBJECT_NOT_ALLOWED`.
-11. Resolve the token's `subjectClaim` value to a stable `creator_user_id`; emit `signin.success` to the audit log.
-12. Allow the request.
+1. Read `Authorization: Bearer <jwt>`. Missing/malformed header → `401`.
+2. Extract `iss` from the JWT payload. If the server is configured with an allowed-issuers allow-list and `iss` is not on it → `401`.
+3. Fetch (or read from cache) the issuer's `<iss>/.well-known/openid-configuration` and its `jwks_uri` JWKS, and verify the JWT signature and registered claims (`exp`, `nbf`, `iat`). Failure → `401`. (Audience/`aud` is **not** currently enforced — the verifier skips the client-ID check; `aud` validation is `(Planned.)`)
+4. Look up `issuers.org_field_key` for `iss`.
+   - If `iss` is **not registered**: unauthorized (`401`) — **unless** the `tenants` table is empty, which triggers first-identity bootstrap (below).
+   - If `org_field_key` is **NULL**: resolve `tenant_issuers` where `issuer = iss` and `org_field_value IS NULL` → tenant.
+   - If `org_field_key` is **set**: read that claim's value (`org`) from the token. Empty/absent → `401`. Otherwise resolve `tenant_issuers` where `issuer = iss` and `org_field_value = org` → tenant.
+5. Resolve the ERun user from `(tenant, iss, sub)` via `user_external_ids`. Unknown subject → `401`; ERun does **not** implicitly create users once any tenant exists.
+6. Authorize the request against the user's roles/permissions; on success, allow and write the audit event.
 
-Any path that returns `401` / `403` also emits a `signin.failure` audit event with the reason code.
+**First-identity bootstrap.** When the `tenants` table is empty, the first valid token bootstraps the system: it creates an `OPERATIONS` tenant, registers its `iss` in `issuers` as single-tenant (`org_field_key` NULL), creates the first user, and grants it both `ReadAll` and `WriteAll`. After any tenant exists, unknown issuers and subjects stay unauthorized.
+
+**Audit.** Each authorized API request records `external_issuer_id` (the `iss`), `external_org_id` (the org claim value for org-scoped issuers; null for single-tenant), `external_user_id` (the `sub`), and the resolved `erun_user_id` — see [the audit log spec](/agent-reference/audit-log).
 
 ### Endpoints
+
+:::note Shipped vs planned
+The `(iss, org) → tenant` resolution model and first-identity bootstrap above are **shipped**. The issuer-**management** API below (`PATCH /v1/tenant-issuers` and its `audience`/`tenantClaim`/`allowedSubjects`/`409`/`422` codes) is `(Planned.)`: today, issuers and their org-scoping mode are provisioned directly in the `issuers` / `tenant_issuers` tables (migrations or the bootstrap path), not via a self-service endpoint. `GET /v1/whoami` is shipped and returns the resolved `tenantId` and `userId`.
+:::
 
 | Method | Path | Description | Required scope |
 |---|---|---|---|
 | `GET` | `/v1/tenant-issuers` | List all issuers trusted by the caller's tenant. | Tenant member |
-| `PATCH` | `/v1/tenant-issuers` | Add or remove trusted issuers. Body shape below. | Tenant admin |
+| `PATCH` | `/v1/tenant-issuers` | Add or remove trusted issuers. Body shape below. `(Planned.)` | Tenant admin |
 | `GET` | `/v1/whoami` | Resolved identity for the calling token. Response below. | Tenant member |
 
 ### `GET /v1/whoami`

--- a/erun-docs/docs/agent-reference/cli-flags.md
+++ b/erun-docs/docs/agent-reference/cli-flags.md
@@ -267,9 +267,9 @@ Once the version is resolved, `deploy`:
 
 The dry-run trace names the decision per spec: `deploy: version <v> pinned; installing the published image, no local build`. Every env installs by reference from the published `oci://…/charts/erun-devops` chart (or the repo-local chart when the project carries one).
 
-### `--components` value set
+### `--components` value set {#components-value-set}
 
-The `--components` flag's accepted values are derived from `<tenant>-devops/k8s/<component>/Chart.yaml` discovery at command-resolve time. For the erun repository itself, the registered set is `{erun-backend-postgres, erun-backend-db, erun-backend-api}`. Each tenant project ships its own set.
+The `--components` flag accepts a **fixed opt-in set** defined in code (`erun-common/deploy_components.go`, `OptInDeployComponentNames`), not values discovered from chart files. The set is `{erun-backend-postgres, erun-backend-db, erun-backend-api, erun-powerdns}`. These charts are never deployed by default — they ship only when explicitly named via `--components` or listed in the env's `k8s.deployments` plan (listing a chart in the plan is an implicit opt-in). An unrecognised name is rejected before any deploy runs with `unknown deploy component "<name>"; valid opt-in components are: erun-backend-postgres, erun-backend-db, erun-backend-api, erun-powerdns`, so typos surface immediately. `erun-powerdns` is the platform's authoritative DNS singleton; it runs the gpgsql backend against `erun-backend-postgres`, so it must be sequenced after it in the plan.
 
 ### Deploy-plan resolution
 

--- a/erun-docs/docs/agent-reference/networking-spec.md
+++ b/erun-docs/docs/agent-reference/networking-spec.md
@@ -122,6 +122,34 @@ For the public form, each segment must match:
 | `<environment>` | `[a-z][a-z0-9-]*` (the cluster's environment alias, e.g. `dev` / `staging` / `prod`) |
 | `<domain>` | RFC-1035 domain, set by the cluster admin. |
 
+## Platform service exposure
+
+`erun expose <tenant> <env> <service>` (CLI and the `expose` MCP tool) automates Pattern 3 for a platform deployment — an install that runs the `erun-powerdns` singleton and declares a [`platform:` block](/reference/configuration#platform-block). For the Operator view see [Networking · Platform service exposure](/concepts/networking#platform-service-exposure).
+
+**Inputs.** `tenant`, `env`, `service` (positional); `--ip` (the env's ingress IP the wildcard record points at; required); `--port` (Service port, default `80`); `--dry-run`.
+
+**Resolved plan.**
+
+| Field | Value |
+|---|---|
+| Public hostname | `<service>.<tenant>-<env>.<servicesZone>` |
+| Per-env wildcard record | `*.<tenant>-<env>.<servicesZone>` `A` `<ip>`, TTL `60` |
+| Services zone | `platform.serviceszone` (defaults to `services.<platform.basedomain>`) |
+| Ingress | `expose-<service>` in namespace `<tenant>-<env>`, Host-routing the hostname to `<service>:<port>` |
+
+**Execution.** Two side effects, in order:
+
+1. **DNS write.** `kubectl [--context <platform-ctx>] -n <platform-namespace> exec deploy/erun-powerdns -- pdnsutil --config-dir=/etc/pdns-shared replace-rrset <zone> <rel-name> A 60 <ip>`. The platform namespace is `platform.env` normalised to a namespace label; the **platform** env's own kube context is resolved from its env config (`platform.env` is a `<tenant>-<env>` label — tenant names carry no hyphen, so the first hyphen splits it). This is distinct from the target env's context — the DNS write lands on the cluster PowerDNS runs on, the Ingress on the target env's cluster, which may differ. If the platform env config is not loadable, the platform context is empty and `kubectl` falls back to the current context.
+2. **Ingress apply.** `kubectl [--context <env-ctx>] -n <tenant>-<env> apply -f -` with a `networking.k8s.io/v1` Ingress (`app.kubernetes.io/managed-by: erun-expose`), manifest piped on stdin.
+
+The dry-run trace prints both `kubectl` commands verbatim (including the TTL) plus the resolved hostname, wildcard, and platform namespace — no synthetic verbs, no side effects.
+
+**Records, not the HTTP API.** Writes go through `pdnsutil` against the gpgsql backend (the PowerDNS pod reads its connection — including the postgres password — from a generated `--config-dir` config, so no secret appears in the exec argv). The PowerDNS HTTP API is bound to loopback only and is not used by `expose`.
+
+**TLS.** The applied Ingress is HTTP-only (no `tls:`, no cert-manager annotation). The CLI prints `http://<hostname>`. A wildcard TLS certificate is `(Planned.)` — it arrives with the DNS-01 broker, at which point the hostname serves `https://`.
+
+**Idempotency / errors.** `replace-rrset` and `apply` are both idempotent; re-running converges. The wildcard record is written before the Ingress, so a failure applying the Ingress can leave the DNS record in place — re-run after resolving the cluster issue. Pre-flight validation (missing/malformed `platform:` block, missing `--ip`, non-DNS-1035 service name) fails before any write; see [`erun expose` · Error behaviour](/cli/expose#error-behaviour).
+
 ## Cross-namespace traffic semantics
 
 ERun's runtime chart deploys a default-deny `NetworkPolicy` per env that blocks ingress from outside the namespace. The shape:

--- a/erun-docs/docs/cli/deploy.md
+++ b/erun-docs/docs/cli/deploy.md
@@ -36,7 +36,7 @@ The chart and runtime image are one contract — published together to the same 
 |---|---|
 | `--version <version>` | The published version to install, by reference. Required unless `--current` is given. The version's image and chart must already exist (locally or in the registry) or the deploy errors — `deploy` never builds them. |
 | `--current` | Redeploy the version the environment is already recorded as running (its persisted runtime version). Use it to re-roll the same version, or after a `--force`-style retry, without retyping the number. Required unless `--version` is given. |
-| `--components <name,name,...>` | Opt-in components to include alongside the runtime chart. The accepted list is derived from each project's `<tenant>-devops/k8s/<component>/` charts. |
+| `--components <name,name,...>` | Opt-in components to include alongside the runtime chart. The accepted values are a fixed set — `erun-backend-postgres`, `erun-backend-db`, `erun-backend-api`, `erun-powerdns` — and an unknown name is rejected with `unknown deploy component`. See [Agent reference · `--components`](/agent-reference/cli-flags#components-value-set). |
 | `--force` | Re-run helm upgrade even when the resolved version is unchanged and nothing needs rolling. |
 | `--rollout-timeout <dur>` | How long to wait for the rollout before giving up (e.g. `10m`). Defaults to the env's setting, or 5 minutes. Raise it for the first deploy of a large image on a slow connection; see [rollout wait and monitoring](/agent-reference/cli-flags#rollout-wait-and-pod-monitoring). |
 | `--dry-run` | Resolve and print every `helm upgrade --install` command (and any image-copy step) without executing. |

--- a/erun-docs/docs/cli/expose.md
+++ b/erun-docs/docs/cli/expose.md
@@ -1,0 +1,48 @@
+---
+title: erun expose
+---
+
+# erun expose
+
+Expose an in-namespace Service at a stable public hostname under the platform's services zone. `erun expose` is for [platform deployments](/concepts/networking#platform-service-exposure) — installations that run the PowerDNS singleton and declare a [`platform:` block](/reference/configuration#platform-block). It does two things: it ensures a **per-environment wildcard DNS record** points at the env's ingress IP, and it applies a **Host-routing Ingress** for the Service.
+
+```bash
+erun expose team dev api --ip 203.0.113.10
+erun expose team dev api --ip 203.0.113.10 --port 8080
+erun expose team dev api --ip 127.0.0.1 --dry-run     # preview, no side effects
+```
+
+## What it does
+
+For `erun expose <tenant> <env> <service>`, the public hostname is `<service>.<tenant>-<env>.<servicesZone>` (the services zone comes from the platform config — e.g. `api.team-dev.services.erunpaas.com`). The flow:
+
+1. **Per-env wildcard A record.** It upserts `*.<tenant>-<env>.<servicesZone>` → `--ip` (TTL 60) in the platform's authoritative zone by exec'ing `pdnsutil` inside the platform's PowerDNS pod. The wildcard covers *every* service in that env, so exposing additional services later only adds an Ingress — the DNS record is written once.
+2. **Host-routing Ingress.** It applies an Ingress named `expose-<service>` into the env's namespace, routing the hostname to the in-namespace Service on `--port` (default `80`).
+
+The DNS write targets the **platform** environment's cluster (where PowerDNS runs); the Ingress is applied to the **target** env's cluster. These can be different clusters — `expose` resolves each context independently.
+
+The exposed URL is **HTTP** today: the applied Ingress carries no TLS. A wildcard TLS certificate (making the hostname `https://`) lands with the DNS-01 broker — see [Networking spec · Platform service exposure](/agent-reference/networking-spec#platform-service-exposure).
+
+## Flags
+
+| Flag | Description |
+|---|---|
+| `--ip <ip>` | **Required.** The env's ingress IP the per-env wildcard record points at — `127.0.0.1` for a VM-backed local cluster, a node/LAN IP, or the public LB IP for a remote cluster. |
+| `--port <int>` | Service port the Ingress routes to. Default `80`. |
+| `--dry-run` | Resolve and print the full plan — the hostname, the `pdnsutil` exec, and the Ingress apply — without touching DNS or the cluster. |
+
+## Error behaviour
+
+| Condition | What happens | Recover |
+|---|---|---|
+| No `platform:` block (or no base domain) in `.erun/config.yaml` | Aborts: `expose requires a platform block with a base domain in .erun/config.yaml`; exit 1. | Add a [`platform:` block](/reference/configuration#platform-block). |
+| Malformed `platform:` block | Aborts with the specific validation error (bad base domain, services zone not under it, unparseable authoritative IP, …); exit 1. | Fix the offending field. |
+| `--ip` omitted | Aborts: `a target IP is required …`; exit 1. | Pass `--ip <env ingress IP>`. |
+| Service name is not a DNS-1035 label | Aborts before any DNS write: `service name "…" must be a DNS-1035 label …`; exit 1. | Use a lowercase letters/digits/hyphen name. |
+| `pdnsutil` exec or Ingress apply fails (live run) | Surfaces the underlying `kubectl` error; the wildcard record and the Ingress are applied in that order, so a later failure can leave the DNS record written. | Re-run once the cluster issue is resolved — both operations are idempotent (record replace, Ingress apply). |
+
+## See also
+
+- [Networking · Platform service exposure](/concepts/networking#platform-service-exposure) — the model and when to use it.
+- [Networking spec · Platform service exposure](/agent-reference/networking-spec#platform-service-exposure) — the exact records, Ingress, and resolution rules.
+- [Configuration · `platform:` block](/reference/configuration#platform-block) — the per-instance platform config.

--- a/erun-docs/docs/cli/overview.md
+++ b/erun-docs/docs/cli/overview.md
@@ -29,6 +29,7 @@ The `build → release → push → deploy` commands form ERun's delivery pipeli
 | [`erun release`](/cli/release) | Cut a release: stamp the version, tag it, push the tag. |
 | [`erun push`](/cli/push) | Push built images to the configured container registry. |
 | [`erun deploy`](/cli/deploy) | Roll a version out to an environment (build · push · helm upgrade). |
+| [`erun expose`](/cli/expose) | Expose an env's Service at a public hostname under the platform's services zone. |
 | [`erun cloud`](/cli/cloud) | Set up and manage cloud provider aliases (AWS SSO). |
 | [`erun context`](/cli/context) | Create and power managed cloud contexts (an EC2 instance running k3s). |
 | [`erun sshd`](/cli/sshd) | Enable SSH (and IDE) access to a remote environment. |

--- a/erun-docs/docs/concepts/networking.md
+++ b/erun-docs/docs/concepts/networking.md
@@ -29,6 +29,18 @@ Four patterns, picked by what the env is for. The manifest skeletons for each (I
 | **Ingress per env** | Production-ish. Each env gets its own hostname (`<service>.<env>.<domain>`) without per-env chart edits. Requires a cluster-wide Ingress controller + wildcard DNS + wildcard TLS. |
 | **LoadBalancer per env** | Cloud envs without a shared Ingress controller. One cloud LB per env — easy to wire, more expensive at scale. |
 
+## Platform service exposure
+
+The four patterns above are manual building blocks. A **platform deployment** — an installation that runs ERun's PowerDNS singleton and declares a [`platform:` block](/reference/configuration#platform-block) — automates the Ingress-per-env pattern with one command:
+
+```bash
+erun expose team dev api --ip 203.0.113.10
+```
+
+This exposes the `api` Service in `team-dev` at `api.team-dev.services.<base-domain>`. ERun ensures a per-environment wildcard DNS record (`*.team-dev.services.<base-domain>` → the env's ingress IP) in the platform's authoritative zone and applies a Host-routing Ingress for the Service. The wildcard covers every service in the env, so exposing more services only adds an Ingress. The platform is generic: any vendor installs it under their own base domain and services zone — nothing is hardcoded.
+
+The exposed URL is HTTP today; a wildcard TLS certificate (making it `https://`) arrives with the DNS-01 broker. See [`erun expose`](/cli/expose) for the workflow and [Networking spec · Platform service exposure](/agent-reference/networking-spec#platform-service-exposure) for the exact records and Ingress.
+
 ## Inter-env communication
 
 By default, **envs cannot reach each other.** ERun's runtime chart deploys a default-deny NetworkPolicy on every env's namespace. Cross-env traffic requires an explicit opt-in NetworkPolicy on the target plus a matching label on the consumer namespace; this is rare and usually a sign you should be using one env rather than two. See [Networking spec · Cross-namespace traffic semantics](/agent-reference/networking-spec#cross-namespace-traffic-semantics) for the manifests.

--- a/erun-docs/docs/mcp/overview.md
+++ b/erun-docs/docs/mcp/overview.md
@@ -123,6 +123,7 @@ These wrap the [pure command primitives](/concepts/command-primitives): `build` 
 | `deploy` | `erun deploy` | Per-chart rollout status, helm release info. Requires `version`. |
 | `release` | `erun release` | Released version, tag, multi-arch confirmation. |
 | `open` | `erun open` | Local SSH + MCP ports, status (`opened` / `already_open`). |
+| `expose` | `erun expose` | Resolved public hostname, per-env wildcard record, Host-routing Ingress. Requires a `platform:` block. Supports preview (dry-run). |
 | `init` | `erun init` | Created files, deployed namespace. |
 | `delete` | `erun delete` | Namespace deleted, local config removed. |
 

--- a/erun-docs/docs/reference/configuration.md
+++ b/erun-docs/docs/reference/configuration.md
@@ -106,6 +106,37 @@ Committed to the repo, applies to anyone who checks it out.
 | `environments.<env>.k8s.deployments[]` | ordered list | `erun deploy` | The ordered deploy plan for this env. Each step is either a single component name or a list of names deployed in parallel. |
 | `release.mainbranch` | string | `erun release` | Main branch name (default `main`). |
 | `release.developbranch` | string | `erun release` | Develop branch name (default `develop`). |
+| `platform` | map | `erun deploy` (PowerDNS), `erun expose` | Per-instance platform deployment config. Absent for non-platform projects. See [`platform:` block](#platform-block). |
+
+#### `platform:` block {#platform-block}
+
+The `platform:` block configures an **erunpaas platform deployment** — an installation that runs the global DNS singleton (PowerDNS) and exposes tenant services under a delegated zone. ERun's platform is generic, installable software: any vendor deploys it under their **own** names, so every value is configuration — nothing (not even the base domain) is hardcoded. `erun deploy` threads these as `platform.*` helm values (only the `erun-powerdns` chart reads them today); [`erun expose`](/cli/expose) reads them to resolve service hostnames.
+
+The whole block is optional. An empty block means the project runs no platform deployment. Once any field is set the block is "in use" and is validated at deploy/expose time — a malformed block fails fast.
+
+| Field | Type | Required | Effect / default |
+|---|---|---|---|
+| `basedomain` | string | yes (when block in use) | The registered domain this deployment serves, e.g. `erunpaas.com`. Everything else derives from it. Must be a valid domain name. |
+| `env` | string | no | The dedicated platform environment that owns the singletons (PowerDNS, the DNS-01 broker), e.g. `frs-prod`. Must be a DNS-safe `<tenant>-<env>` namespace label. |
+| `serviceszone` | string | no | The child zone delegated to this deployment's PowerDNS, under which tenant services are exposed. Default `services.<basedomain>`. Must be a valid domain at or under `basedomain`. |
+| `authoritativeip` | string | no | The public IP this deployment's authoritative nameserver answers on (the glue-record target for `serviceszone`). Must parse as an IP when set. |
+| `nameservers` | list | no | The NS hostnames the parent zone delegates `serviceszone` to. Default `[ns1.<basedomain>, ns2.<basedomain>]`. |
+| `authhost` | string | no | The hosted-IdP host, served from the apex zone (not `serviceszone`). Default `auth.<basedomain>`. Must be a valid domain at or under `basedomain`. |
+| `acmeemail` | string | no | The account email for this deployment's Let's Encrypt registration (LE rate limits are per registered domain, so each deployment uses its own account). |
+
+```yaml
+# <repo>/.erun/config.yaml
+platform:
+  basedomain: erunpaas.com
+  env: frs-prod
+  authoritativeip: 203.0.113.10
+  # serviceszone, authhost, and nameservers default from basedomain:
+  #   serviceszone: services.erunpaas.com
+  #   authhost:     auth.erunpaas.com
+  #   nameservers:  [ns1.erunpaas.com, ns2.erunpaas.com]
+```
+
+A second vendor installs the same artifacts under their own names — e.g. `basedomain: kppaas.com`, `env: kp-prod` — with no code changes.
 
 ---
 

--- a/erun-docs/sidebars.ts
+++ b/erun-docs/sidebars.ts
@@ -38,6 +38,7 @@ const sidebars: SidebarsConfig = {
         'cli/release',
         'cli/push',
         'cli/deploy',
+        'cli/expose',
         'cli/upgrade',
         'cli/cloud',
         'cli/context',

--- a/erun-integration/expose_test.go
+++ b/erun-integration/expose_test.go
@@ -32,6 +32,22 @@ func TestExpose(t *testing.T) {
 		golden.Equal(t, "expose/dry_run", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_cross_cluster", func(t *testing.T) {
+		// The platform env (frs-prod) that owns PowerDNS is on a different
+		// cluster than the target env (team-dev). The per-env wildcard DNS write
+		// must exec against the platform env's own kube context, while the Ingress
+		// applies against the target env's context — the two must not collapse to
+		// one (a cross-cluster misroute). The platform env is seeded with a
+		// distinct context to lock that the DNS exec uses it.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedTenantEnvWithContext(t, setup, "frs", "prod", "platform-context")
+		fixture.SeedGitRepo(t, setup.Cwd)
+		fixture.SeedProjectK8sConfig(t, setup, "platform:\n  basedomain: erunpaas.com\n  env: frs-prod\n  authoritativeip: 203.0.113.10\n")
+		result := erun.Run(t, []string{"expose", "team", "dev", "api", "--ip", "203.0.113.10", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		golden.Equal(t, "expose/dry_run_cross_cluster", normalize.Apply(result.Combined))
+	})
+
 	t.Run("requires_platform_config", func(t *testing.T) {
 		// expose only makes sense for a platform deployment; without a platform
 		// block in .erun/config.yaml it fails with an actionable error rather

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -59,6 +59,36 @@ func SeedTenantEnv(t testing.TB, setup env.Setup, tenant, environment string) {
 	)
 }
 
+// SeedTenantEnvWithContext writes the same minimal config tree as SeedTenantEnv
+// but with a caller-chosen kubernetes context, so a scenario can place a second
+// environment on a distinct cluster (e.g. the platform env that owns PowerDNS
+// vs. a target env on another cluster, for expose's cross-cluster DNS routing).
+func SeedTenantEnvWithContext(t testing.TB, setup env.Setup, tenant, environment, kubernetesContext string) {
+	t.Helper()
+	root := filepath.Join(setup.ConfigHome, "erun")
+	tenantDir := filepath.Join(root, tenant)
+	envDir := filepath.Join(tenantDir, environment)
+	for _, dir := range []string{root, tenantDir, envDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	mustWrite(t, filepath.Join(tenantDir, "config.yaml"),
+		"projectroot: "+setup.Cwd+"\n"+
+			"name: "+tenant+"\n"+
+			"defaultenvironment: "+environment+"\n",
+	)
+	mustWrite(t, filepath.Join(envDir, "config.yaml"),
+		"name: "+environment+"\n"+
+			"repopath: "+setup.Cwd+"\n"+
+			"kubernetescontext: "+kubernetesContext+"\n"+
+			"containerregistry: registry.example/test\n"+
+			"runtimeversion: 1.0.0\n"+
+			"type: local-agent\n",
+	)
+}
+
 // SeedTenantEnvWithDeployTimeout writes the same minimal config tree as
 // SeedTenantEnv plus a per-env `deploy.timeout`, so deploy scenarios can
 // exercise the configurable helm rollout timeout (the value flows into the

--- a/erun-integration/testdata/expose/dry_run_cross_cluster.txt
+++ b/erun-integration/testdata/expose/dry_run_cross_cluster.txt
@@ -2,5 +2,5 @@ audit: erun expose --dry-run --ip <VERSION>.10 team dev api
 expose: api.team-dev.services.erunpaas.com -> service api.team-dev.svc:80
 expose: per-env wildcard *.team-dev.services.erunpaas.com A <VERSION>.10 ttl 60 (zone services.erunpaas.com)
 expose: platform powerdns namespace frs-prod
-kubectl -n frs-prod exec deploy/erun-powerdns -- pdnsutil --config-dir=/etc/pdns-shared replace-rrset services.erunpaas.com '*.team-dev' A 60 <VERSION>.10
+kubectl --context platform-context -n frs-prod exec deploy/erun-powerdns -- pdnsutil --config-dir=/etc/pdns-shared replace-rrset services.erunpaas.com '*.team-dev' A 60 <VERSION>.10
 kubectl --context test-context -n team-dev apply -f -


### PR DESCRIPTION
## Summary

An adversarial review of the merged erunpaas platform epic (#603 — PRs #610/#611/#612/#616/#618/#619) surfaced **17 confirmed defects**: four deploy-breakers that prevent a hosted bootstrap from succeeding, one HIGH cross-tenant security hole, plus a batch of correctness/UX/docs hardening. This is the fix-forward batch — one body of work, one PR.

> ⚠️ **Cross-tenant identity boundary — review before merge.** This PR includes a HIGH security fix to the identity-resolution cache (#1) plus the `(iss, org)` migration/auth wiring. Consistent with how #618/#619 were handled, I've opened it for review rather than auto-merging. Say the word and I'll squash-merge and close #622.

Closes #622. Relates to #603 (epic) and #607 (docs plan).

## What changed, by module

### DB (`erun-backend-db`) — deploy-breakers, verified live on Postgres 18
- **#2** `issuers` had no grants → bootstrap fails `permission denied`. `GRANT SELECT` to `erun_tenant`, full DML+`REFERENCES` to `erun_operations`, in both `schema/roles.sql` and the migration.
- **#3** migration added the `issuers` FK with no backfill → upgrade bricks on a populated DB. Timestamp trigger moved ahead of an `INSERT INTO issuers SELECT DISTINCT issuer FROM tenant_issuers ON CONFLICT` backfill, before the FK add.

### API (`erun-backend-api`)
- **#1 (HIGH/security)** identity cache keyed only `(issuer, subject)` → a shared org-scoped issuer could serve one tenant's resolved RLS context to another. Resolved org added to the cache key (memoized `issuers.org_field_key` lookup) + same-subject/different-org regression test.
- **#14** resolved org threaded through `security.Context`, `model.AuditEvent`, and the audit INSERT as `external_org_id`.

### devops (`erun-powerdns` chart) — verified end-to-end (create-zone, serve, dig)
- **#4** schema initContainer copied a path absent from the image → crash-loop; fixed to `/usr/local/share/doc/pdns/schema.pgsql.sql`.
- Also (found via the verification gate): the image's default sqlite `pdns.conf` is fatal under `--launch=gpgsql` and pdnsutil 4.9 rejects `--launch`/`--gpgsql-*` CLI flags → generate a gpgsql `pdns.conf` on a per-pod volume, run `pdns_server`/`pdnsutil` via `--config-dir`, add `NET_BIND_SERVICE`.
- **#5** HTTP API/webserver bound to loopback; probe the DNS port; drop the dead ClusterIP Service.
- **#15** postgres password + api-key kept out of argv (config file); verified with a metachars password.

### common / cli / integration (`erun expose` + platform config)
- **#6** DNS upsert exec'd into the platform namespace with the **target** env's kube context → cross-cluster misroute. Now resolves and uses the **platform** env's own context; new `dry_run_cross_cluster` golden proves the two contexts differ.
- **#9** validate `ServicesZone`/`AuthHost` as DNS names (not suffix-only) + `escapeHelmSetValue` on `platform.*`.
- **#10/#11** dry-run trace now shows the real `kubectl` exec/apply argv (incl. TTL) + platform namespace instead of a synthetic verb; Ingress applied via stdin (deterministic).
- **#13** `expose` prints `http://` (Ingress is HTTP-only; TLS is Phase B). **#16** `platform.Validate()` before deriving hostnames. **#17** service name validated as a DNS-1035 label.

### docs (`erun-docs`) — `yarn build` clean
- **#7** new `cli/expose.md`; platform service-exposure in `concepts/networking` + `agent-reference/networking-spec`; `platform:` block in `reference/configuration`.
- **#8** `api-protocol.md` tenant resolution rewritten to the shipped `(iss, org) → tenant` model; planned issuer-management API demarcated; fixed a pre-existing broken `#tenant-issuers` anchor.
- **#12** `--components` set corrected (incl. `erun-powerdns`) in `cli-flags.md` + `cli/deploy.md`.

## Verification
- **DB:** migration applies on a fresh Postgres 18 **and** on a seeded prior-version DB (backfill populates `issuers`, FK satisfiable); `issuers` grants confirmed.
- **API:** `go test ./...` (fresh) + `go vet` clean.
- **Integration gate:** full suite green; coverage **77.2% ≥ 75%**.
- **Docs:** `yarn build` clean (no broken links/anchors).
- **PowerDNS:** verified end-to-end against the pinned image per the commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)