### PR TITLE
Force a resize nudge on AI-tab attach so reattached Claude repaints (#624)

### DIFF
--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -3601,6 +3601,7 @@ type stubTerminalSession struct {
 	mu            sync.Mutex
 	written       []byte
 	initialOutput []byte
+	resizes       [][2]int
 }
 
 // stubSessionReadyOutput is the line every newStubTerminalSession emits
@@ -3644,8 +3645,17 @@ func (s *stubTerminalSession) WrittenString() string {
 	return string(s.written)
 }
 
-func (s *stubTerminalSession) Resize(int, int) error {
+func (s *stubTerminalSession) Resize(cols, rows int) error {
+	s.mu.Lock()
+	s.resizes = append(s.resizes, [2]int{cols, rows})
+	s.mu.Unlock()
 	return nil
+}
+
+func (s *stubTerminalSession) Resizes() [][2]int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([][2]int(nil), s.resizes...)
 }
 
 func (s *stubTerminalSession) Wait() error {
@@ -3753,6 +3763,85 @@ func TestStartAISessionRunsErunOpenAsPersistentAITab(t *testing.T) {
 	}
 	if len(started.InitialInput) != 0 {
 		t.Fatalf("AI tab must not pipe an initial input (claude launches pod-side), got %q", string(started.InitialInput))
+	}
+}
+
+func swapAIRepaintNudgeTimings(delay, settle time.Duration) func() {
+	prevDelay, prevSettle := aiRepaintNudgeDelay, aiRepaintNudgeSettle
+	aiRepaintNudgeDelay, aiRepaintNudgeSettle = delay, settle
+	return func() { aiRepaintNudgeDelay, aiRepaintNudgeSettle = prevDelay, prevSettle }
+}
+
+// TestAISessionRepaintNudgeFiresOnAttachMarker pins the #618 fix: an AI tab
+// reattaching to a running Claude renders blank because Claude (a main-screen
+// TUI) only repaints on a real geometry change, and a same-size reattach
+// raises none. The desktop forces the repaint by briefly resizing the pty one
+// row shorter then back. The attach is detected by the bootstrap's window-title
+// escape (OSC 0), emitted right before `dtach -A` — nudging on the first output
+// overall would fire too early (it is the `erun open` audit trace). Verified
+// end-to-end against a live pod via the headless app + DOM read; this locks the
+// backend contract.
+func TestAISessionRepaintNudgeFiresOnAttachMarker(t *testing.T) {
+	defer swapAIRepaintNudgeTimings(time.Millisecond, time.Millisecond)()
+
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{"erun": {Name: "erun", DefaultEnvironment: "remote"}},
+		envs:    map[string]eruncommon.EnvConfig{"erun/remote": {Name: "remote", LocalRepoPath: projectRoot, KubernetesContext: "ctx"}},
+	}
+	session := newStubTerminalSession()
+	app := NewApp(erunUIDeps{
+		store:           store,
+		findProjectRoot: func() (string, string, error) { return "erun", projectRoot, nil },
+		resolveCLIPath:  func() string { return "/tmp/erun" },
+		startTerminal:   func(startTerminalSessionParams) (terminalSession, error) { return session, nil },
+	})
+	defer app.shutdown(context.Background())
+
+	managed := &managedTerminal{
+		session:   session,
+		selection: uiSelection{Tenant: "erun", Environment: "remote"},
+		key:       aiSessionKey(uiSelection{Tenant: "erun", Environment: "remote"}, 0),
+		serial:    1,
+		kind:      sessionKindAI,
+		lastCols:  80,
+		lastRows:  24,
+	}
+	app.mu.Lock()
+	app.sessions[managed.key] = managed
+	app.mu.Unlock()
+
+	var lastActivity time.Time
+	// Output without the attach marker (the open audit trace) must not nudge.
+	app.handleSessionOutput(managed, []byte("audit: erun open --ai --app-session ai erun remote\n"), &lastActivity)
+	time.Sleep(20 * time.Millisecond)
+	if got := session.Resizes(); len(got) != 0 {
+		t.Fatalf("non-marker output must not nudge; got resizes %v", got)
+	}
+
+	// The attach marker (OSC 0 window-title set) triggers shrink-then-restore.
+	app.handleSessionOutput(managed, []byte("\x1b]0;erun-remote\x07"), &lastActivity)
+	want := [][2]int{{80, 23}, {80, 24}}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got := session.Resizes()
+		if len(got) >= 2 {
+			if got[0] != want[0] || got[1] != want[1] {
+				t.Fatalf("unexpected nudge resizes: got %v want %v", got, want)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("repaint nudge did not fire; resizes=%v", got)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// The nudge is once per attach: a second marker chunk must not re-fire it.
+	app.handleSessionOutput(managed, []byte("\x1b]0;erun-remote\x07"), &lastActivity)
+	time.Sleep(30 * time.Millisecond)
+	if got := session.Resizes(); len(got) != 2 {
+		t.Fatalf("nudge must fire once per attach; got %v", got)
 	}
 }
 

--- a/erun-ui/contribute_sessions.go
+++ b/erun-ui/contribute_sessions.go
@@ -112,6 +112,8 @@ func (a *App) runContributeSession(ctx context.Context, selection uiSelection, s
 			return a.deps.startTerminal(params)
 		},
 		startedAt: time.Now(),
+		lastCols:  cols,
+		lastRows:  rows,
 	}
 	a.sessions[key] = managed
 	a.busyEnvs[selectionKey(selection)]++

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -279,6 +280,8 @@ func (a *App) runAISession(ctx context.Context, selection uiSelection, slot, col
 			return a.deps.startTerminal(params)
 		},
 		startedAt: time.Now(),
+		lastCols:  cols,
+		lastRows:  rows,
 	}
 	a.sessions[key] = managed
 	a.mu.Unlock()
@@ -778,6 +781,10 @@ func (a *App) ResizeSession(sessionID, cols, rows int) error {
 
 	a.mu.Lock()
 	managed := a.sessionBySerialLocked(sessionID)
+	if managed != nil {
+		managed.lastCols = cols
+		managed.lastRows = rows
+	}
 	a.mu.Unlock()
 	if managed == nil || managed.session == nil {
 		return nil
@@ -1034,6 +1041,7 @@ func (a *App) handleSessionOutput(managed *managedTerminal, chunk []byte, lastOu
 	})
 	a.feedActivityTraceFromTerminal(managed, chunk)
 	a.recordAIActivity(managed)
+	a.maybeNudgeAIRepaint(managed, chunk)
 	if managed.clearIdleBlockOnOutput {
 		a.mu.Lock()
 		a.releaseIdleBlockLocked(managed)
@@ -1052,6 +1060,85 @@ func (a *App) handleSessionOutput(managed *managedTerminal, chunk []byte, lastOu
 			*lastOutputActivity = time.Now()
 		}
 	}
+}
+
+// aiRepaintNudgeDelay is how long maybeNudgeAIRepaint waits after the
+// attach marker before resizing, so the bootstrap's `dtach -A` (which runs
+// immediately after the marker) has reattached the client to Claude and
+// Claude is listening for the WINCH. aiRepaintNudgeSettle is the gap between
+// the shrink and the restore so the two SIGWINCHes are not coalesced.
+// Vars, not consts, so tests can shrink them; production keeps the defaults.
+var (
+	aiRepaintNudgeDelay  = 400 * time.Millisecond
+	aiRepaintNudgeSettle = 150 * time.Millisecond
+)
+
+// aiAttachMarker is the window-title escape (OSC 0) the open bootstrap prints
+// immediately before `dtach -A` reattaches the client to the running program.
+// It is the precise "Claude is about to be (re)attached" signal — unlike the
+// first output overall, which is the `erun open` audit trace emitted well
+// before the pod-side attach, so nudging on it would fire too early.
+var aiAttachMarker = []byte("\x1b]0;")
+
+// isAITabKind reports whether the session is one of the AI-tab kinds (env AI
+// tab or contribute AI tab) whose program is the managed Claude.
+func isAITabKind(managed *managedTerminal) bool {
+	return managed != nil &&
+		(managed.kind == sessionKindAI || managed.kind == sessionKindContributeAI)
+}
+
+// maybeNudgeAIRepaint fires the once-per-attach AI repaint nudge when the
+// attach marker first appears in the output. dtach hands a reattached client a
+// cleared screen and signals the program to redraw, but Claude is a main-screen
+// TUI (Ink) that only does a full repaint on an actual geometry change — a
+// same-size reattach raises no effective WINCH, so the tab renders blank
+// (#618). The nudge below forces that geometry change once Claude is attached.
+func (a *App) maybeNudgeAIRepaint(managed *managedTerminal, chunk []byte) {
+	if !isAITabKind(managed) || !bytes.Contains(chunk, aiAttachMarker) {
+		return
+	}
+	a.mu.Lock()
+	if managed.repaintNudged || managed.closed {
+		a.mu.Unlock()
+		return
+	}
+	managed.repaintNudged = true
+	cols, rows := managed.lastCols, managed.lastRows
+	a.mu.Unlock()
+	go a.nudgeAIRepaint(managed, cols, rows)
+}
+
+// nudgeAIRepaint briefly tells the backend pty it is one row shorter, then
+// restores it. The size change crosses kubectl exec -> dtach master -> Claude
+// as a real WINCH and forces a full repaint after a same-size reattach. The
+// local xterm is never resized, so the user sees no reflow — only the AI
+// tab's content appearing. No-op when the session has no usable size or has
+// already closed.
+func (a *App) nudgeAIRepaint(managed *managedTerminal, cols, rows int) {
+	if cols <= 0 || rows <= 1 {
+		return
+	}
+	time.Sleep(aiRepaintNudgeDelay)
+	if !a.resizeSessionIfLive(managed, cols, rows-1) {
+		return
+	}
+	time.Sleep(aiRepaintNudgeSettle)
+	a.resizeSessionIfLive(managed, cols, rows)
+}
+
+// resizeSessionIfLive resizes the managed pty unless it has closed, reporting
+// whether the resize was attempted. Used by the AI repaint nudge so a session
+// that exits mid-nudge does not panic on a nil/closed pty.
+func (a *App) resizeSessionIfLive(managed *managedTerminal, cols, rows int) bool {
+	a.mu.Lock()
+	session := managed.session
+	closed := managed.closed
+	a.mu.Unlock()
+	if session == nil || closed {
+		return false
+	}
+	_ = session.Resize(cols, rows)
+	return true
 }
 
 // finalizeSessionExit tears down a managed PTY that streamSession could
@@ -1210,6 +1297,10 @@ func (a *App) tryReconnect(managed *managedTerminal, exitReason string) bool {
 	}
 	managed.session = next
 	managed.awaitingPostRespawnInput = true
+	// A reconnect is a fresh attach to the (possibly same) pod session, so
+	// re-arm the AI repaint nudge: the new client gets a cleared screen and
+	// Claude needs the geometry-change WINCH again to repaint (#618).
+	managed.repaintNudged = false
 	a.mu.Unlock()
 	// The respawn went through — whatever stopped/failed condition the row
 	// was flagged with is being retried, so clear it (the refusal paths
@@ -1653,6 +1744,18 @@ type managedTerminal struct {
 	lockedByActivity       string
 	activityTraceBuffer    string
 	startedAt              time.Time
+
+	// lastCols/lastRows track the most recent pty size (seeded from the
+	// spawn params, refreshed on every ResizeSession). The AI-tab repaint
+	// nudge needs a known size to resize to; the session itself does not
+	// expose its current geometry.
+	lastCols int
+	lastRows int
+
+	// repaintNudged guards the once-per-attach AI repaint nudge so it fires
+	// on the first output after a (re)attach and not on every chunk.
+	// tryReconnect clears it so the next attach nudges again.
+	repaintNudged bool
 
 	// awaitingPostRespawnInput, when true, tells streamSession to skip
 	// the 2s output-activity ticker. Set on each successful respawn so


### PR DESCRIPTION
Follow-up to #613, which fixed the AI-tab blank for *newly-created* sessions but left it blank when **reopening** an env at the same window size. Closes #624.

## Root cause (proven, not guessed)

I reproduced it in a headless `erun-app` against the real config and read the AI tab's xterm **DOM** directly:

| State | AI tab |
|---|---|
| Fresh session | ✅ renders Claude |
| First reattach at a *different* size | ✅ renders |
| Close + reopen at the **same** size | ❌ **0 rows (blank)** |
| Then resize the window | ✅ repaints |

So Claude (an Ink / main-screen TUI) only does a **full repaint on an actual geometry change**. dtach hands a reattached client a cleared screen, and a same-size reattach raises no effective WINCH — so the tab stays blank. #613's `-r winch` only *signals* a redraw without changing geometry, so Ink ignores it on a same-size reattach (it helps a freshly-created session, not a reopen).

## Fix

On an AI-tab attach the desktop briefly resizes the pty **one row shorter, then restores it** — a real WINCH that crosses `kubectl exec` → dtach master → Claude and forces a full repaint, independent of the dtach `-r` method or the session's age. The local xterm is never resized, so there is no visible reflow.

The attach is detected by the bootstrap's window-title escape (`OSC 0`), emitted immediately before `dtach -A`, so the nudge fires once Claude is attached — not on the earlier `erun open` audit trace (nudging on the first output overall fires too early; I caught that by watching the live stream). Re-armed on reconnect. Keeps #613's `-r winch` as belt-and-suspenders for fresh sessions.

Backend-only (`erun-ui`): `terminal_sessions.go` (`maybeNudgeAIRepaint`/`nudgeAIRepaint`, attach-marker detection, size tracked on `managedTerminal`, re-arm in `tryReconnect`), `contribute_sessions.go` (seed size for the contribute AI tab).

## Validation

- `go test ./...` green in `erun-ui`, including the new **`TestAISessionRepaintNudgeFiresOnAttachMarker`** (a non-marker chunk does not nudge; the `OSC 0` marker triggers a shrink-then-restore resize; fires once per attach).
- The pre-commit `golangci-lint` is clean across all modules.
- The fix sends *exactly* the geometry-change resize I proved (via DOM) makes Claude repaint.

**Not re-confirmed here, by design:** the full in-desktop render *with the nudge* on a live pod. The Playwright harness deliberately runs inert `sh` AI tabs with no real cluster, so it can't drive a real Claude reattach (the documented harness limitation — covered by the Go unit test instead). A clean live re-run was also blocked because a headless probe and the running desktop app collide on the same pod's port-forward. The reporter is validating by rebuilding their desktop app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
