### PR TITLE
Fix 8 confirmed defects from the erunpaas platform review

### DIFF
--- a/erun-backend/erun-backend-api/auth.go
+++ b/erun-backend/erun-backend-api/auth.go
@@ -246,12 +246,24 @@ func (m *AuthMiddleware) resolveIdentity(ctx context.Context, claims Claims) (Id
 	// Derive the org claim value first so it is part of the cache key: a shared
 	// org-scoped issuer maps the same (issuer, subject) to different tenants per
 	// org, so (issuer, subject) alone would leak one tenant's RLS context to
-	// another. A failed org lookup degrades to org="" and falls through to full
-	// resolution, which surfaces the real error.
-	org := m.resolveOrg(ctx, claims)
+	// another.
+	//
+	// If derivation FAILS (e.g. a transient read of the issuer's org-scoping
+	// mode), the org dimension is unknown: caching under org="" would conflate a
+	// failed derivation with a single-tenant success or a different org and
+	// reintroduce that cross-tenant collision. So a derivation failure bypasses
+	// the identity cache entirely for this request — no Get, no SetSuccess, no
+	// SetFailure — and falls through to full resolution, which re-derives the org
+	// from the token itself. org="" is then reserved strictly for issuers that
+	// resolveOrg positively determined are single-tenant or unregistered.
+	org, orgErr := m.resolveOrg(ctx, claims)
+	cache := m.cache
+	if orgErr != nil {
+		cache = nil
+	}
 
-	if m.cache != nil {
-		if identity, err, ok := m.cache.Get(claims.Issuer, claims.Subject, org); ok {
+	if cache != nil {
+		if identity, err, ok := cache.Get(claims.Issuer, claims.Subject, org); ok {
 			if !cachedIdentityNeedsUsernameRefresh(identity, err, claims) {
 				return identity, err
 			}
@@ -264,14 +276,14 @@ func (m *AuthMiddleware) resolveIdentity(ctx context.Context, claims Claims) (Id
 			if err == nil {
 				err = ErrUserNotResolved
 			}
-			if m.cache != nil {
-				m.cache.SetFailure(claims.Issuer, claims.Subject, org, err)
+			if cache != nil {
+				cache.SetFailure(claims.Issuer, claims.Subject, org, err)
 			}
 			return Identity{}, err
 		}
-		identity := Identity{Tenant: tenant, User: user, Org: org}
-		if m.cache != nil {
-			m.cache.SetSuccess(claims.Issuer, claims.Subject, org, identity)
+		identity := Identity{Tenant: tenant, User: user, Org: m.resolvedOrg(ctx, claims, org, orgErr)}
+		if cache != nil {
+			cache.SetSuccess(claims.Issuer, claims.Subject, org, identity)
 		}
 		return identity, nil
 	}
@@ -279,40 +291,55 @@ func (m *AuthMiddleware) resolveIdentity(ctx context.Context, claims Claims) (Id
 	tenant, err := m.tenants.ResolveTenantByIssuer(ctx, claims)
 	if err != nil || strings.TrimSpace(tenant.TenantID) == "" {
 		err = ErrTenantNotResolved
-		if m.cache != nil {
-			m.cache.SetFailure(claims.Issuer, claims.Subject, org, err)
+		if cache != nil {
+			cache.SetFailure(claims.Issuer, claims.Subject, org, err)
 		}
 		return Identity{}, err
 	}
 	user, err := m.users.ResolveUserByExternalID(ctx, tenant.TenantID, claims.Issuer, claims.Subject)
 	if err != nil || strings.TrimSpace(user.UserID) == "" {
 		err = ErrUserNotResolved
-		if m.cache != nil {
-			m.cache.SetFailure(claims.Issuer, claims.Subject, org, err)
+		if cache != nil {
+			cache.SetFailure(claims.Issuer, claims.Subject, org, err)
 		}
 		return Identity{}, err
 	}
 
-	identity := Identity{Tenant: tenant, User: user, Org: org}
-	if m.cache != nil {
-		m.cache.SetSuccess(claims.Issuer, claims.Subject, org, identity)
+	identity := Identity{Tenant: tenant, User: user, Org: m.resolvedOrg(ctx, claims, org, orgErr)}
+	if cache != nil {
+		cache.SetSuccess(claims.Issuer, claims.Subject, org, identity)
 	}
 	return identity, nil
 }
 
 // resolveOrg derives the org claim value used in the identity cache key. A nil
 // resolver (e.g. non-DB test wiring) or a single-tenant/unregistered issuer
-// yields "", preserving (issuer, subject) keying. Lookup errors also yield ""
-// and are left for full resolution to surface.
-func (m *AuthMiddleware) resolveOrg(ctx context.Context, claims Claims) string {
+// yields ("", nil), preserving (issuer, subject) keying. A lookup error is
+// propagated so the caller can bypass the cache for that request rather than
+// poisoning the org="" keyspace with a failed derivation.
+func (m *AuthMiddleware) resolveOrg(ctx context.Context, claims Claims) (string, error) {
 	if m.orgResolver == nil {
-		return ""
+		return "", nil
 	}
-	org, err := m.orgResolver.ResolveOrg(ctx, claims)
-	if err != nil {
-		return ""
+	return m.orgResolver.ResolveOrg(ctx, claims)
+}
+
+// resolvedOrg returns the org to record on a successfully resolved identity
+// (AuthContext.Org and the audit external_org_id). On the normal path the org
+// derived for the cache key is authoritative. When the initial derivation failed
+// (orgErr != nil) the request bypassed the cache and full resolution re-read the
+// issuer's org-scoping mode — warming its cache — so re-derive the org now for an
+// accurate audit record. A still-failing derivation leaves it empty rather than
+// failing an already-resolved request; the value resolution actually used is
+// derived from the same memoized issuer mode, so the re-derivation is consistent.
+func (m *AuthMiddleware) resolvedOrg(ctx context.Context, claims Claims, org string, orgErr error) string {
+	if orgErr == nil {
+		return org
 	}
-	return org
+	if reOrg, reErr := m.resolveOrg(ctx, claims); reErr == nil {
+		return reOrg
+	}
+	return ""
 }
 
 func claimsWithUsernameHint(claims Claims, hint string) Claims {

--- a/erun-backend/erun-backend-api/auth_test.go
+++ b/erun-backend/erun-backend-api/auth_test.go
@@ -451,6 +451,87 @@ func TestAuthMiddlewareKeepsOrgScopedTenantsDistinctInCache(t *testing.T) {
 	}
 }
 
+// TestAuthMiddlewareBypassesIdentityCacheWhenOrgDerivationFails guards the
+// error-path variant of the cross-tenant hole: when org derivation fails for a
+// shared org-scoped issuer, the resolved tenant must NOT be cached under org=""
+// (which would collide with single-tenant successes or another org). A failed
+// derivation bypasses the cache entirely, so every request re-resolves from the
+// token rather than reading a stale tenant.
+func TestAuthMiddlewareBypassesIdentityCacheWhenOrgDerivationFails(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	cache := NewIdentityResolutionCache(IdentityCacheOptions{
+		PositiveTTL: time.Minute,
+		Now:         func() time.Time { return now },
+	})
+	tenantForOrg := map[string]string{
+		"org-a": "019a7fa5-c2c0-7c55-bc70-714873a71f1a",
+		"org-b": "019a7fa5-c2c0-7c55-bc70-714873a71f1b",
+	}
+	tenantResolverCalls := 0
+	middleware, err := NewAuthMiddleware(AuthMiddlewareOptions{
+		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
+			return Claims{Issuer: "https://shared.example", Subject: "user-1", Raw: map[string]any{"org": token}}, nil
+		}),
+		// Org derivation keeps failing (e.g. a transient read of the issuer's
+		// org-scoping mode); the request must bypass the cache instead of keying a
+		// resolved tenant under org="".
+		OrgResolver: OrgResolverFunc(func(ctx context.Context, claims Claims) (string, error) {
+			return "", errors.New("transient org lookup failure")
+		}),
+		// Full resolution re-derives the org from the token itself, so it still
+		// resolves the correct tenant despite the failed cache-key derivation.
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
+			tenantResolverCalls++
+			org, _ := claims.Raw["org"].(string)
+			tenantID, ok := tenantForOrg[org]
+			if !ok {
+				return Tenant{}, errors.New("unknown org")
+			}
+			return Tenant{TenantID: tenantID}, nil
+		}),
+		UserResolver: UserResolverFunc(func(ctx context.Context, tenantID string, issuer string, externalID string) (User, error) {
+			return User{UserID: "019a7fa5-c2c0-7c55-bc70-714873a71f11"}, nil
+		}),
+		IdentityCache: cache,
+	})
+	if err != nil {
+		t.Fatalf("NewAuthMiddleware failed: %v", err)
+	}
+
+	resolve := func(org string) string {
+		var resolvedTenant string
+		req := httptest.NewRequest(http.MethodGet, "/v1/whoami", nil)
+		req.Header.Set("Authorization", "Bearer "+org)
+		rec := httptest.NewRecorder()
+		middleware.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth, _ := AuthFromContext(r.Context())
+			resolvedTenant = auth.Tenant.TenantID
+			w.WriteHeader(http.StatusNoContent)
+		})).ServeHTTP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("org %q: unexpected status: %d", org, rec.Code)
+		}
+		return resolvedTenant
+	}
+
+	if got := resolve("org-a"); got != tenantForOrg["org-a"] {
+		t.Fatalf("org-a: tenant=%q", got)
+	}
+	// Same issuer+subject, different org, derivation still failing: must NOT
+	// return a cached org-a tenant.
+	if got := resolve("org-b"); got != tenantForOrg["org-b"] {
+		t.Fatalf("org-b leaked cached tenant: tenant=%q", got)
+	}
+	if got := resolve("org-a"); got != tenantForOrg["org-a"] {
+		t.Fatalf("org-a re-resolve: tenant=%q", got)
+	}
+	// The cache was bypassed on every request (nothing cached under org=""), so
+	// the tenant resolver ran for all three.
+	if tenantResolverCalls != 3 {
+		t.Fatalf("expected cache bypass to re-resolve every request, got %d tenant resolver calls", tenantResolverCalls)
+	}
+}
+
 func TestAuthMiddlewareLogsAuditEventForAuthorizedRequest(t *testing.T) {
 	var event AuditEvent
 	middleware, err := NewAuthMiddleware(AuthMiddlewareOptions{

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -1333,9 +1333,15 @@ func resolveProjectContainerRegistry(projectRoot, environment string) string {
 // resolveProjectPlatform loads the per-instance platform config from the
 // project's .erun/config.yaml and returns it with defaults resolved. Returns a
 // zero PlatformConfig when the project is uninitialized or declares no platform
-// block, so deploy threads no platform.* values for non-platform projects. The
-// block is validated earlier (loadProjectK8sPlanForRepo), so a malformed block
-// fails the plan before reaching here.
+// block, so deploy threads no platform.* values for non-platform projects.
+//
+// On the `erun deploy` / `build --deploy` path the block is validated up front
+// (loadProjectK8sPlanForRepo), so a malformed block fails the plan before
+// reaching here. The open-runtime deploy path does not pass through that plan
+// step, so it reaches here unvalidated — harmless today because the runtime
+// chart it deploys ignores the threaded platform.* values (only the PowerDNS
+// singleton reads them, and open never deploys it). Do not rely on this function
+// having validated the block.
 func resolveProjectPlatform(projectRoot string) PlatformConfig {
 	projectRoot = strings.TrimSpace(projectRoot)
 	if projectRoot == "" {

--- a/erun-common/expose.go
+++ b/erun-common/expose.go
@@ -117,6 +117,9 @@ func RunExposeService(ctx Context, params ExposeServiceParams, store ExposeStore
 	ctx.Trace(fmt.Sprintf("expose: platform powerdns namespace %s", result.PlatformNamespace))
 	ctx.TraceCommand("", "kubectl", powerDNSUpsertArgs(dnsParams)...)
 	ctx.TraceCommand("", "kubectl", ingressApplyArgs(ingressParams)...)
+	// The Ingress manifest is piped to `kubectl apply -f -` on stdin, so trace
+	// its body too — the argv alone hides the exact resource the real run applies.
+	ctx.TraceBlock("expose: ingress manifest", renderHostRoutingIngress(ingressParams))
 	if ctx.DryRun {
 		return result, nil
 	}
@@ -202,6 +205,13 @@ func resolveExposeServicePlan(params ExposeServiceParams, store ExposeStore) (Ex
 	// deriving any hostnames or zone names from it.
 	if err := platform.Validate(); err != nil {
 		return ExposeServiceResult{}, err
+	}
+	// platform.env is optional for the deploy/PowerDNS chart (it deploys into the
+	// release namespace), but expose derives the PowerDNS pod's namespace from it
+	// to exec the DNS write. Without it the write would run `kubectl -n "" exec`
+	// and silently target the current/default namespace, so require it here.
+	if strings.TrimSpace(platform.Env) == "" {
+		return ExposeServiceResult{}, fmt.Errorf("expose requires platform.env in .erun/config.yaml (the platform environment that runs the PowerDNS singleton)")
 	}
 	envConfig, _, err := store.LoadEnvConfig(tenant, environment)
 	if err != nil {

--- a/erun-devops/k8s/erun-powerdns/templates/powerdns.yaml
+++ b/erun-devops/k8s/erun-powerdns/templates/powerdns.yaml
@@ -190,7 +190,14 @@ spec:
             - |
               set -e
               if ! pdnsutil --config-dir={{ $configDir }} list-zone {{ $servicesZone | quote }} >/dev/null 2>&1; then
-                pdnsutil --config-dir={{ $configDir }} create-zone {{ $servicesZone | quote }}{{ range $ns := $nameservers }} {{ $ns | quote }}{{ end }}
+                # `pdnsutil create-zone ZONE [nsname]` takes at most ONE
+                # nameserver; passing more prints a usage error, exits 0, and
+                # creates nothing — silently leaving the zone unbootstrapped. So
+                # create with the first NS (if any) and add the rest as NS records.
+                pdnsutil --config-dir={{ $configDir }} create-zone {{ $servicesZone | quote }}{{ with (first $nameservers) }} {{ . | quote }}{{ end }}
+                {{- range $ns := (rest $nameservers) }}
+                pdnsutil --config-dir={{ $configDir }} add-record {{ $servicesZone | quote }} @ NS {{ $ns | quote }}
+                {{- end }}
               fi
           volumeMounts:
             - name: config

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -62,13 +62,13 @@ For every authenticated request:
 ### Endpoints
 
 :::note Shipped vs planned
-The `(iss, org) → tenant` resolution model and first-identity bootstrap above are **shipped**. The issuer-**management** API below (`PATCH /v1/tenant-issuers` and its `audience`/`tenantClaim`/`allowedSubjects`/`409`/`422` codes) is `(Planned.)`: today, issuers and their org-scoping mode are provisioned directly in the `issuers` / `tenant_issuers` tables (migrations or the bootstrap path), not via a self-service endpoint. `GET /v1/whoami` is shipped and returns the resolved `tenantId` and `userId`.
+The `(iss, org) → tenant` resolution model and first-identity bootstrap above are **shipped**, as are `GET /v1/whoami`, `GET /v1/tenant-issuers` (list), and `PATCH /v1/tenant-issuers` (rename a trusted issuer's display name). Today, issuers and their org-scoping mode are provisioned directly in the `issuers` / `tenant_issuers` tables (migrations or the bootstrap path), not via a self-service endpoint. A self-service **trust-management** API (adding/removing issuers with `audience`/`tenantClaim`/`allowedSubjects`, and the `409`/`422` codes below) is `(Planned.)`, as is the structured machine-readable error `code` field — today the API returns bare HTTP status codes with a plain-text body (see [Errors](#errors) below).
 :::
 
 | Method | Path | Description | Required scope |
 |---|---|---|---|
 | `GET` | `/v1/tenant-issuers` | List all issuers trusted by the caller's tenant. | Tenant member |
-| `PATCH` | `/v1/tenant-issuers` | Add or remove trusted issuers. Body shape below. `(Planned.)` | Tenant admin |
+| `PATCH` | `/v1/tenant-issuers` | Rename a trusted issuer's display name. Body below. | Tenant admin |
 | `GET` | `/v1/whoami` | Resolved identity for the calling token. Response below. | Tenant member |
 
 ### `GET /v1/whoami`
@@ -77,20 +77,35 @@ Returns the resolved identity for the bearer token — useful for Agents verifyi
 
 ```jsonc
 {
-  "creatorUserId": "agent-bot-a",
-  "tenant": "myapp",
-  "actorKind": "agent",                  // "operator" | "agent"
+  "tenantId": "019a7fa5-c2c0-7c55-bc70-714873a71f10",
+  "userId": "019a7fa5-c2c0-7c55-bc70-714873a71f11",
+  "username": "agent-bot-a",            // omitted when no user repository is wired
+  "roles": ["ReadAll", "WriteAll"],     // omitted when no user repository is wired
   "issuer": "https://issuer.example.com/oauth2/default",
-  "subject": "agent-bot-a",
-  "audience": "erun-api",
-  "expiresAt": "2026-05-25T15:31:02Z"
+  "subject": "agent-bot-a"
 }
 ```
 
 Errors: standard 401/403 only — no body-validation errors (the endpoint takes no input).
 
+### `PATCH /v1/tenant-issuers`
+
+Renames a trusted issuer's display `name` for the caller's tenant. The `(iss, org) → tenant` mapping itself is not editable here — only the human-readable label.
+
 ```jsonc
 // PATCH /v1/tenant-issuers body
+{
+  "issuer": "https://issuer.example.com/oauth2/default",
+  "name": "Acme corporate SSO"
+}
+```
+
+Returns the updated tenant-issuer record (`200`). `400` if `issuer` or `name` is empty; `404` if the `(tenant, issuer)` pair is not trusted by the caller's tenant.
+
+```jsonc
+// (Planned.) self-service trust-management API — add/remove trusted issuers.
+// Not yet implemented; issuers are provisioned in the issuers / tenant_issuers
+// tables today. Path/method are illustrative and not yet fixed.
 {
   "add": [
     {
@@ -122,6 +137,22 @@ When the token expires (typical lifetime 1 hour), the Agent's client refreshes i
 
 ### Errors
 
+Today the API rejects with a bare HTTP status code and a **plain-text** body — there is no JSON error envelope and no machine-readable `code` field. The underlying reason (which issuer, which claim) is logged server-side, not returned. The shipped contract:
+
+| Status | Body | Condition | Recovery |
+|---|---|---|---|
+| `401` | `missing bearer token` | No `Authorization` header, or it is not a single `Bearer <jwt>` pair. | Send `Authorization: Bearer <jwt>`. |
+| `401` | `invalid bearer token` | Signature/claims (`exp`/`nbf`/`iat`) failed, token expired, the issuer is not on the allow-list, or `iss`/`sub` is empty. | Re-mint a valid token from a registered issuer. |
+| `401` | `tenant not resolved` | Token verified, but no `(iss, org)` mapping resolves a tenant (and the `tenants` table is non-empty, so first-identity bootstrap does not apply). | Register the issuer/org in `tenant_issuers`. |
+| `401` | `user not resolved` | Tenant resolved, but no `user_external_ids` row matches `(tenant, iss, sub)` (and the tenant already has users). | Enrol the subject for the tenant. |
+| `403` | `Forbidden` | Authenticated, but the user's roles/permissions do not allow the request's method + path. | Grant the needed role/permission (admin action). |
+
+The audit trail records every authorized request with `issuer`, `sub`, org, and timestamp.
+
+#### Structured error codes `(Planned.)`
+
+A future structured error envelope will return a machine-readable `code` (and, where useful, a `details` object) per failure. It is **not implemented yet** — clients must branch on the HTTP status and plain-text body above, not on these codes:
+
 | Status | `code` | Condition | Recovery |
 |---|---|---|---|
 | `401` | `MISSING_AUTH_HEADER` | No `Authorization` header. | Add `Authorization: Bearer <jwt>`. |
@@ -131,11 +162,9 @@ When the token expires (typical lifetime 1 hour), the Agent's client refreshes i
 | `401` | `INVALID_CLAIM` | `iss` / `aud` / `exp` / `nbf` / `iat` validation failed. The `details.claim` field identifies which one. | Re-mint with correct claims; check token issuer config. |
 | `403` | `TENANT_MISMATCH` | Token's `tenantClaim` doesn't match the request's target tenant. | Use a token issued for the correct tenant. |
 | `403` | `SUBJECT_NOT_ALLOWED` | Token validates but `subjectClaim` value is not in `allowedSubjects`. | Add the subject to the tenant issuer's allowlist (admin action). |
-| `409` | `ISSUER_ALREADY_TRUSTED` | `PATCH /v1/tenant-issuers add` on an `issuerUrl` already present. | Use `remove` first, then `add`. |
-| `422` | `DISCOVERY_FETCH_FAILED` | `PATCH` with an issuer whose `<issuerUrl>/.well-known/openid-configuration` can't be fetched. | Verify the issuer is online and the URL is correct. |
+| `409` | `ISSUER_ALREADY_TRUSTED` | Self-service `add` on an `issuerUrl` already present. | Use `remove` first, then `add`. |
+| `422` | `DISCOVERY_FETCH_FAILED` | Self-service add with an issuer whose `<issuerUrl>/.well-known/openid-configuration` can't be fetched. | Verify the issuer is online and the URL is correct. |
 | `422` | `JWKS_INVALID` | Discovery document loads but `jwks_uri` returns no usable keys. | Verify the issuer's JWKS is published correctly. |
-
-The audit trail records every successful and failed sign-in attempt with `issuer`, `sub`, IP, and timestamp.
 
 ## Rate limits
 

--- a/erun-docs/docs/cli/expose.md
+++ b/erun-docs/docs/cli/expose.md
@@ -37,6 +37,7 @@ The exposed URL is **HTTP** today: the applied Ingress carries no TLS. A wildcar
 |---|---|---|
 | No `platform:` block (or no base domain) in `.erun/config.yaml` | Aborts: `expose requires a platform block with a base domain in .erun/config.yaml`; exit 1. | Add a [`platform:` block](/reference/configuration#platform-block). |
 | Malformed `platform:` block | Aborts with the specific validation error (bad base domain, services zone not under it, unparseable authoritative IP, …); exit 1. | Fix the offending field. |
+| `platform:` block has no `env` | Aborts: `expose requires platform.env in .erun/config.yaml …`; exit 1. `expose` derives the PowerDNS pod's namespace from `platform.env`, so it cannot run without it. | Set `platform.env` to the platform environment that runs PowerDNS. |
 | `--ip` omitted | Aborts: `a target IP is required …`; exit 1. | Pass `--ip <env ingress IP>`. |
 | Service name is not a DNS-1035 label | Aborts before any DNS write: `service name "…" must be a DNS-1035 label …`; exit 1. | Use a lowercase letters/digits/hyphen name. |
 | `pdnsutil` exec or Ingress apply fails (live run) | Surfaces the underlying `kubectl` error; the wildcard record and the Ingress are applied in that order, so a later failure can leave the DNS record written. | Re-run once the cluster issue is resolved — both operations are idempotent (record replace, Ingress apply). |

--- a/erun-integration/expose_test.go
+++ b/erun-integration/expose_test.go
@@ -62,6 +62,22 @@ func TestExpose(t *testing.T) {
 		golden.Equal(t, "expose/requires_platform_config", normalize.Apply(result.Combined))
 	})
 
+	t.Run("requires_platform_env", func(t *testing.T) {
+		// platform.env locates the PowerDNS pod's namespace for the per-env
+		// wildcard DNS write. A platform block with a base domain but no env would
+		// otherwise produce a `kubectl -n "" exec` that silently misroutes, so
+		// expose fails fast with an actionable error.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedGitRepo(t, setup.Cwd)
+		fixture.SeedProjectK8sConfig(t, setup, "platform:\n  basedomain: erunpaas.com\n")
+		result := erun.Run(t, []string{"expose", "team", "dev", "api", "--ip", "127.0.0.1", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit without platform.env, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "expose/requires_platform_env", normalize.Apply(result.Combined))
+	})
+
 	t.Run("requires_ip", func(t *testing.T) {
 		// The per-env wildcard record needs a target IP (the env's ingress IP);
 		// omitting --ip fails clearly instead of writing an empty record.

--- a/erun-integration/testdata/expose/dry_run.txt
+++ b/erun-integration/testdata/expose/dry_run.txt
@@ -4,3 +4,23 @@ expose: per-env wildcard *.team-dev.services.erunpaas.com A <VERSION>.10 ttl 60 
 expose: platform powerdns namespace frs-prod
 kubectl -n frs-prod exec deploy/erun-powerdns -- pdnsutil --config-dir=/etc/pdns-shared replace-rrset services.erunpaas.com '*.team-dev' A 60 <VERSION>.10
 kubectl --context test-context -n team-dev apply -f -
+expose: ingress manifest:
+  apiVersion: networking.k8s.io/v1
+  kind: Ingress
+  metadata:
+    name: expose-api
+    namespace: team-dev
+    labels:
+      app.kubernetes.io/managed-by: erun-expose
+  spec:
+    rules:
+      - host: api.team-dev.services.erunpaas.com
+        http:
+          paths:
+            - path: /
+              pathType: Prefix
+              backend:
+                service:
+                  name: api
+                  port:
+                    number: 80

--- a/erun-integration/testdata/expose/dry_run_cross_cluster.txt
+++ b/erun-integration/testdata/expose/dry_run_cross_cluster.txt
@@ -4,3 +4,23 @@ expose: per-env wildcard *.team-dev.services.erunpaas.com A <VERSION>.10 ttl 60 
 expose: platform powerdns namespace frs-prod
 kubectl --context platform-context -n frs-prod exec deploy/erun-powerdns -- pdnsutil --config-dir=/etc/pdns-shared replace-rrset services.erunpaas.com '*.team-dev' A 60 <VERSION>.10
 kubectl --context test-context -n team-dev apply -f -
+expose: ingress manifest:
+  apiVersion: networking.k8s.io/v1
+  kind: Ingress
+  metadata:
+    name: expose-api
+    namespace: team-dev
+    labels:
+      app.kubernetes.io/managed-by: erun-expose
+  spec:
+    rules:
+      - host: api.team-dev.services.erunpaas.com
+        http:
+          paths:
+            - path: /
+              pathType: Prefix
+              backend:
+                service:
+                  name: api
+                  port:
+                    number: 80

--- a/erun-integration/testdata/expose/requires_platform_env.txt
+++ b/erun-integration/testdata/expose/requires_platform_env.txt
@@ -1,0 +1,2 @@
+audit: erun expose --dry-run --ip <LOOPBACK> team dev api
+expose requires platform.env in .erun/config.yaml (the platform environment that runs the PowerDNS singleton)


### PR DESCRIPTION
A second adversarial defect sweep of the merged erunpaas platform work (#603/#604, after #623's 17 fixes) confirmed 10 defects. This PR lands the 8 that are clean behaviour-level corrections; the 10th is a code-vs-contract conflict surfaced for a decision (below).

## Fixes

| # | Sev | Area | Fix |
|---|-----|------|-----|
| 1 | HIGH | api-auth | `resolveOrg` swallowed lookup errors to `org=""`, so a transient failure could cache an org-scoped tenant under the `org=""` key and a later request for a **different** org would hit it — reintroducing the cross-tenant collision #623's org-keyed cache prevents. `resolveOrg` now propagates the error; a failed derivation **bypasses the identity cache entirely** (no Get/Set) and re-resolves from the token. Regression test added. |
| 2 | HIGH | powerdns | `pdnsutil create-zone ZONE [nsname]` takes **one** nameserver; passing more printed a usage error, **exited 0, and created nothing** — and the default config supplies two, so the services zone was silently never bootstrapped. Now create with the first NS and add the rest via `add-record @ NS`. Verified by `helm template` for 0/1/3 nameservers. |
| 3 | MED | expose | `expose` didn't require `platform.env`, so the DNS write ran `kubectl -n "" exec deploy/erun-powerdns` and silently misrouted to the default namespace. Now fails fast with an actionable error. Integration scenario + docs error-table row added. |
| 4 | LOW | expose | `expose --dry-run` didn't show the Ingress manifest piped to `kubectl apply -f -`. Added `TraceBlock`; goldens updated. |
| 5 | LOW | deploy | `resolveProjectPlatform`'s comment falsely claimed the platform block is always validated earlier; the open-runtime path skips it. Comment corrected (no functional fallout — the runtime chart ignores the threaded `platform.*` values). |
| 6 | MED | docs | `GET /v1/whoami` example showed a non-existent shape; replaced with the shipped `{tenantId, userId, username?, roles?, issuer, subject}`. |
| 7 | MED | docs | `PATCH /v1/tenant-issuers` was mislabelled `(Planned.)` with an add/remove body no code implements; documented the **shipped rename** endpoint and kept add/remove as a clearly-Planned future API. |
| 8 | MED | docs | Errors section specified machine-readable `code` values the API never emits; reworked to spec the shipped bare-text 401/403 and marked the typed-code catalogue `(Planned.)`. |

## Deliberately not auto-fixed (needs a decision)

The 10th finding: `api-protocol.md` step 5 says ERun "does not implicitly create users once any tenant exists", matching `erun-backend-api/AGENTS.md:110`. But shipped code (`bootstrapFirstTenantUser`) **does** enrol the first user of any zero-user tenant with `ReadAll`+`WriteAll`, even when other tenants exist — a privilege-relevant divergence. Editing the docs to match the code would deepen the conflict with the engineering contract, so this is surfaced rather than papered over.

## Validation

- `make integration-test` → **77.3% ≥ 75.0%** (added `expose/requires_platform_env` scenario)
- `golangci-lint run` → **0 issues** (`erun-common`, `erun-backend-api`)
- `go test ./...` green in `erun-backend-api` (incl. new cache-bypass test) and `erun-common`
- `erun-docs` `yarn build` clean (no broken links/anchors)
- PowerDNS chart `helm template` verified for 0, 1, and 3 nameservers

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)