### PR TITLE
Document per-tenant first-user bootstrap

### DIFF
--- a/erun-backend/erun-backend-api/AGENTS.md
+++ b/erun-backend/erun-backend-api/AGENTS.md
@@ -107,7 +107,7 @@ Module-specific guidance for `erun-backend-api`. Follow the repository root and 
 - Avoid package-level mutable auth configuration. Pass verifiers and tenant resolvers through explicit API construction.
 - Prefer a single identity resolver when database-backed auth is used, because empty-database bootstrap must resolve or create tenant, issuer, user, roles, and permissions atomically.
 - If there are no tenants, the first valid authenticated identity may create the initial `OPERATIONS` tenant and first ERun user. That user must receive both predefined roles: `ReadAll` and `WriteAll`.
-- Once any tenant exists, unknown issuers or unknown external subjects are unauthorized and must not create users implicitly.
+- Once any tenant exists, unknown or unregistered issuers are unauthorized, and an unknown external subject is unauthorized for a tenant that already has a user. The one implicit-creation case beyond empty-database bootstrap is per-tenant first-user bootstrap: when a token resolves to a tenant that has zero users, enrol that subject as the tenant's first user with both `ReadAll` and `WriteAll`. This is how a newly-provisioned tenant gets its first admin; for an org-scoped issuer it means the first valid caller in a new org becomes that tenant's admin. Do not create users implicitly in any other case.
 - Operations tenants are system tenants. PostgreSQL RLS allows them to access tenant-owned rows across tenants by setting the transaction role to `erun_operations`, but API authorization must still require assigned roles and permissions.
 - Normal tenant transactions must use PostgreSQL role `erun_tenant`; operations tenant transactions must use PostgreSQL role `erun_operations`.
 

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -52,10 +52,12 @@ For every authenticated request:
    - If `iss` is **not registered**: unauthorized (`401`) — **unless** the `tenants` table is empty, which triggers first-identity bootstrap (below).
    - If `org_field_key` is **NULL**: resolve `tenant_issuers` where `issuer = iss` and `org_field_value IS NULL` → tenant.
    - If `org_field_key` is **set**: read that claim's value (`org`) from the token. Empty/absent → `401`. Otherwise resolve `tenant_issuers` where `issuer = iss` and `org_field_value = org` → tenant.
-5. Resolve the ERun user from `(tenant, iss, sub)` via `user_external_ids`. Unknown subject → `401`; ERun does **not** implicitly create users once any tenant exists.
+5. Resolve the ERun user from `(tenant, iss, sub)` via `user_external_ids`. Unknown subject → `401` — **except** when the resolved tenant has **no users yet**, in which case the first valid token for it is enrolled as that tenant's first user with both `ReadAll` and `WriteAll` (per-tenant first-user bootstrap, below). Once a tenant has any user, unknown subjects for it stay unauthorized.
 6. Authorize the request against the user's roles/permissions; on success, allow and write the audit event.
 
-**First-identity bootstrap.** When the `tenants` table is empty, the first valid token bootstraps the system: it creates an `OPERATIONS` tenant, registers its `iss` in `issuers` as single-tenant (`org_field_key` NULL), creates the first user, and grants it both `ReadAll` and `WriteAll`. After any tenant exists, unknown issuers and subjects stay unauthorized.
+**First-identity bootstrap.** When the `tenants` table is empty, the first valid token bootstraps the system: it creates an `OPERATIONS` tenant, registers its `iss` in `issuers` as single-tenant (`org_field_key` NULL), creates the first user, and grants it both `ReadAll` and `WriteAll`.
+
+**Per-tenant first-user bootstrap.** Bootstrap is not limited to the empty-`tenants` case. Whenever a token resolves to a tenant (a registered issuer, the right org claim for org-scoped issuers) that has **zero** users, the first such valid token is enrolled as that tenant's first user with `ReadAll` + `WriteAll` — this is how a newly-provisioned tenant gets its first admin without a separate user-management call. **For an org-scoped issuer this means the first valid caller in a freshly-provisioned org becomes that tenant's admin**, so provisioning a tenant + registering its issuer/org is the act that authorizes its first caller. After a tenant has at least one user, unknown subjects for it — and unknown/unregistered issuers anywhere — stay unauthorized.
 
 **Audit.** Each authorized API request records `external_issuer_id` (the `iss`), `external_org_id` (the org claim value for org-scoped issuers; null for single-tenant), `external_user_id` (the `sub`), and the resolved `erun_user_id` — see [the audit log spec](/agent-reference/audit-log).
 


### PR DESCRIPTION
Resolves the 10th finding from the erunpaas review (#626) — a code-vs-contract conflict, now settled by operator decision (**the code is intended**).

Shipped `bootstrapFirstTenantUser` enrols the first user of **any** zero-user tenant with `ReadAll`+`WriteAll`, even when other tenants exist. The spec (`api-protocol.md` step 5) and the engineering contract (`erun-backend-api/AGENTS.md:110`) both said the opposite. This aligns them with the shipped behaviour and documents the per-tenant first-user bootstrap as a first-class concept.

It also makes the security implication explicit rather than silent: **for an org-scoped issuer, the first valid caller in a freshly-provisioned org becomes that tenant's admin** — so provisioning a tenant + registering its issuer/org is the act that authorizes its first caller.

## Changes
- `erun-docs/docs/agent-reference/api-protocol.md`: reworded step 5; added a **Per-tenant first-user bootstrap** paragraph alongside the existing first-identity bootstrap.
- `erun-backend/erun-backend-api/AGENTS.md`: rewrote the `:110` contract line to permit exactly the per-tenant zero-users case and forbid implicit creation otherwise.

No code change — shipped behaviour already matched.

## Validation
`erun-docs` `yarn build` clean (no broken links/anchors).

Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)