### PR TITLE
Multi-provider cloud aliases: add Cloudflare, send one-per-type to environments, multi-login sidebar

### DIFF
--- a/erun-cli/cmd/cloud.go
+++ b/erun-cli/cmd/cloud.go
@@ -30,6 +30,7 @@ func newCloudInitCmd(store common.CloudStore, promptRunner PromptRunner, deps co
 		"init",
 		"Initialize cloud provider configuration",
 		newCloudInitAWSCmd(store, promptRunner, deps),
+		newCloudInitCloudflareCmd(store, promptRunner, deps),
 	)
 }
 
@@ -96,6 +97,85 @@ func runCloudInitAWSCommand(ctx common.Context, store common.CloudStore, promptR
 		return err
 	}
 	return writeCloudProviderSaved(ctx, provider)
+}
+
+func newCloudInitCloudflareCmd(store common.CloudStore, promptRunner PromptRunner, deps common.CloudDependencies) *cobra.Command {
+	var params common.InitCloudflareCloudProviderParams
+	cmd := &cobra.Command{
+		Use:   "cloudflare",
+		Short: "Set up a Cloudflare cloud provider alias",
+		Long: "Set up a Cloudflare cloud provider alias.\n\n" +
+			"Verifies a delegated, account-scoped Cloudflare API token (account-level Zone:Edit + " +
+			"DNS:Edit) against the Cloudflare API and stores it on this machine as a cloud provider " +
+			"alias. The token is held in a local secret store referenced from erun config — it is " +
+			"never written into erun-config.yaml. Environments that attach this alias receive the " +
+			"token as CLOUDFLARE_API_TOKEN so in-pod tooling (e.g. terraform) authenticates as it.",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		Example:      "  erun cloud init cloudflare --account-id <account> --token-name <label> --api-token <token>",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCloudInitCloudflareCommand(commandContext(cmd), store, promptRunner, params, deps)
+		},
+	}
+	cmd.Flags().StringVar(&params.AccountID, "account-id", "", "Cloudflare account ID the token belongs to")
+	cmd.Flags().StringVar(&params.TokenName, "token-name", "", "Label for the scoped API token")
+	cmd.Flags().StringVar(&params.APIToken, "api-token", "", "Cloudflare scoped API token value (account-level Zone:Edit + DNS:Edit)")
+	addDryRunFlag(cmd)
+	return cmd
+}
+
+func runCloudInitCloudflareCommand(ctx common.Context, store common.CloudStore, promptRunner PromptRunner, params common.InitCloudflareCloudProviderParams, deps common.CloudDependencies) error {
+	var err error
+	params, err = promptCloudflareInitParams(promptRunner, params)
+	if err != nil {
+		return err
+	}
+	provider, err := common.InitCloudflareCloudProvider(ctx, store, params, deps)
+	if err != nil {
+		return err
+	}
+	if ctx.DryRun {
+		_, err := fmt.Fprintln(ctx.Stdout, "Dry run: Cloudflare cloud provider initialization planned.")
+		return err
+	}
+	return writeCloudProviderSaved(ctx, provider)
+}
+
+func promptCloudflareInitParams(promptRunner PromptRunner, params common.InitCloudflareCloudProviderParams) (common.InitCloudflareCloudProviderParams, error) {
+	var err error
+	params.AccountID, err = promptCloudValueIfEmpty(promptRunner, params.AccountID, "Cloudflare account ID", "")
+	if err != nil {
+		return params, err
+	}
+	params.TokenName, err = promptCloudValueIfEmpty(promptRunner, params.TokenName, "Cloudflare token name", "")
+	if err != nil {
+		return params, err
+	}
+	if strings.TrimSpace(params.APIToken) == "" {
+		params.APIToken, err = requiredCloudSecretPrompt(promptRunner, "Cloudflare API token")
+		if err != nil {
+			return params, err
+		}
+	}
+	return params, nil
+}
+
+func requiredCloudSecretPrompt(promptRunner PromptRunner, label string) (string, error) {
+	prompt := promptui.Prompt{
+		Label: label,
+		Mask:  '*',
+		Validate: func(input string) error {
+			if strings.TrimSpace(input) == "" {
+				return fmt.Errorf("%s is required", label)
+			}
+			return nil
+		},
+	}
+	value, err := promptRunner(prompt)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(value), nil
 }
 
 func promptAWSInitParams(promptRunner PromptRunner, params common.InitAWSCloudProviderParams) (common.InitAWSCloudProviderParams, error) {
@@ -250,7 +330,7 @@ func runCloudLoginCommand(ctx common.Context, store common.CloudStore, promptRun
 	}
 	if ctx.DryRun {
 		ctx.Trace("check cloud provider token status")
-		ctx.TraceCommand("", "aws", "sso", "login", "--profile", provider.Profile)
+		traceCloudLoginPlan(ctx, provider)
 		_, err := fmt.Fprintf(ctx.Stdout, "Dry run: cloud login planned for %s.\n", provider.Alias)
 		return err
 	}
@@ -270,6 +350,18 @@ func runCloudLoginCommand(ctx common.Context, store common.CloudStore, promptRun
 		return err
 	}
 	return writeCloudStatus(ctx, status)
+}
+
+// traceCloudLoginPlan emits the provider-appropriate login plan for dry-run.
+// AWS re-runs the SSO browser login; Cloudflare re-verifies its stored scoped
+// token against the Cloudflare API.
+func traceCloudLoginPlan(ctx common.Context, provider common.CloudProviderConfig) {
+	switch provider.Provider {
+	case common.CloudProviderCloudflare:
+		ctx.Trace("verify cloudflare api token via the Cloudflare API")
+	default:
+		ctx.TraceCommand("", "aws", "sso", "login", "--profile", provider.Profile)
+	}
 }
 
 func newCloudOIDCCmd(store common.CloudStore, promptRunner PromptRunner, selectRunner SelectRunner, deps common.CloudDependencies) *cobra.Command {
@@ -305,6 +397,9 @@ func runCloudOIDCCommand(ctx common.Context, store common.CloudStore, _ PromptRu
 	provider, err := common.ResolveCloudProvider(store, alias)
 	if err != nil {
 		return err
+	}
+	if provider.Provider == common.CloudProviderCloudflare {
+		return fmt.Errorf("cloud provider alias %q is a Cloudflare alias, which does not use OIDC web-identity federation", provider.Alias)
 	}
 	if ctx.DryRun {
 		audience := strings.TrimSpace(params.Audience)
@@ -354,15 +449,15 @@ func newCloudSetCmd(store common.EnvironmentCloudAliasStore) *cobra.Command {
 }
 
 func runCloudSetCommand(ctx common.Context, store common.EnvironmentCloudAliasStore, params common.SetEnvironmentCloudAliasParams) error {
-	config, err := common.SetEnvironmentCloudProviderAlias(ctx, store, params)
-	if err != nil {
+	if _, err := common.SetEnvironmentCloudProviderAlias(ctx, store, params); err != nil {
 		return err
 	}
+	var err error
 	if ctx.DryRun {
 		_, err = fmt.Fprintln(ctx.Stdout, "Dry run: cloud provider alias update planned.")
 		return err
 	}
-	_, err = fmt.Fprintf(ctx.Stdout, "Set cloud provider alias %s for %s/%s\n", config.CloudProviderAlias, strings.TrimSpace(params.Tenant), strings.TrimSpace(params.Environment))
+	_, err = fmt.Fprintf(ctx.Stdout, "Set cloud provider alias %s for %s/%s\n", strings.TrimSpace(params.Alias), strings.TrimSpace(params.Tenant), strings.TrimSpace(params.Environment))
 	return err
 }
 

--- a/erun-common/cloud.go
+++ b/erun-common/cloud.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	CloudProviderAWS = "aws"
+	CloudProviderAWS        = "aws"
+	CloudProviderCloudflare = "cloudflare"
 
 	CloudProviderBearerAudience = "erun-api"
 
@@ -23,6 +24,12 @@ const (
 	CloudTokenStatusNotConfigured = "not_configured"
 	CloudTokenStatusUnknown       = "unknown"
 )
+
+// ErrCloudProviderNoOIDC reports that a provider type does not participate in
+// OIDC web-identity federation (Cloudflare aliases authenticate the runtime
+// with a scoped API token, not a JWT issuer). Callers that aggregate issuers
+// — ResolveTenantCloudProviderIssuers — skip such providers rather than fail.
+var ErrCloudProviderNoOIDC = errors.New("cloud provider does not support OIDC issuance")
 
 type CloudStore interface {
 	CloudReadStore
@@ -47,6 +54,23 @@ type CloudProviderConfig struct {
 	SSORegion     string `json:"ssoRegion,omitempty" yaml:"ssoregion,omitempty"`
 	SSOStartURL   string `json:"ssoStartUrl,omitempty" yaml:"ssostarturl,omitempty"`
 	OIDCIssuerURL string `json:"oidcIssuerUrl,omitempty" yaml:"oidcissuerurl,omitempty"`
+
+	// Cloudflare carries the provider-specific identity for a Cloudflare
+	// alias. It is set only when Provider == CloudProviderCloudflare. The
+	// scoped API token itself is never stored inline; CloudflareProviderConfig
+	// holds a TokenRef pointing at the secret store instead.
+	Cloudflare *CloudflareProviderConfig `json:"cloudflare,omitempty" yaml:"cloudflare,omitempty"`
+}
+
+// CloudflareProviderConfig is the Cloudflare-specific identity for a cloud
+// alias. AccountID is the Cloudflare account the delegated, account-scoped
+// API token belongs to; TokenName is an operator-facing label for the token;
+// TokenRef is an opaque handle the CloudSecretStore resolves to the token
+// value, so the raw token never lands in erun-config.yaml.
+type CloudflareProviderConfig struct {
+	AccountID string `json:"accountId,omitempty" yaml:"accountid,omitempty"`
+	TokenName string `json:"tokenName,omitempty" yaml:"tokenname,omitempty"`
+	TokenRef  string `json:"tokenRef,omitempty" yaml:"tokenref,omitempty"`
 }
 
 type CloudProviderStatus struct {
@@ -105,6 +129,13 @@ type CloudDependencies struct {
 	RunAWSExportCredentials func(Context, string) (CloudProviderCredentials, error)
 	ResolveAWSIdentity      func(Context, string) (AWSIdentity, error)
 	CheckAWSStatus          func(Context, CloudProviderConfig) CloudProviderStatus
+
+	// VerifyCloudflareToken validates a Cloudflare scoped API token against the
+	// Cloudflare API. CloudSecretStore persists Cloudflare tokens off-config;
+	// it is nil unless a transport wires one, and Cloudflare operations that
+	// need it fail clearly when it is absent.
+	VerifyCloudflareToken func(Context, string) (CloudflareTokenInfo, error)
+	CloudSecretStore      CloudSecretStore
 }
 
 // CloudProviderCredentials is a snapshot of temporary AWS credentials derived
@@ -137,6 +168,11 @@ func NormalizeCloudProviderConfig(config CloudProviderConfig) CloudProviderConfi
 	config.SSORegion = strings.TrimSpace(config.SSORegion)
 	config.SSOStartURL = strings.TrimSpace(config.SSOStartURL)
 	config.OIDCIssuerURL = normalizeOIDCIssuerURL(config.OIDCIssuerURL)
+	if config.Cloudflare != nil {
+		config.Cloudflare.AccountID = strings.TrimSpace(config.Cloudflare.AccountID)
+		config.Cloudflare.TokenName = strings.TrimSpace(config.Cloudflare.TokenName)
+		config.Cloudflare.TokenRef = strings.TrimSpace(config.Cloudflare.TokenRef)
+	}
 	if config.Alias == "" && config.Provider != "" && config.Username != "" && config.AccountID != "" {
 		config.Alias = CloudProviderAlias(config.Username, config.AccountID, config.Provider)
 	}
@@ -325,6 +361,9 @@ func LoginCloudProviderAlias(ctx Context, store CloudStore, params CloudLoginPar
 		if err := deps.RunAWSLogin(ctx, provider.Profile); err != nil {
 			return status, err
 		}
+	case CloudProviderCloudflare:
+		// Cloudflare aliases carry a stored scoped token; there is no
+		// interactive login. Fall through to the token status re-check below.
 	default:
 		return status, fmt.Errorf("unsupported cloud provider %q", provider.Provider)
 	}
@@ -341,6 +380,12 @@ func LogoutCloudProviderAlias(ctx Context, store CloudStore, params CloudLoginPa
 	switch provider.Provider {
 	case CloudProviderAWS:
 		if err := deps.RunAWSLogout(ctx, provider.Profile); err != nil {
+			return status, err
+		}
+	case CloudProviderCloudflare:
+		// Cloudflare has no SSO session; "logout" removes the stored token so
+		// the alias keeps its identity but loses its credential.
+		if err := deleteCloudflareToken(ctx, provider, deps); err != nil {
 			return status, err
 		}
 	default:
@@ -385,6 +430,8 @@ func CloudProviderBearerToken(ctx Context, store CloudReadStore, params CloudBea
 	switch provider.Provider {
 	case CloudProviderAWS:
 		return awsCloudProviderBearerToken(ctx, provider, params, deps)
+	case CloudProviderCloudflare:
+		return CloudBearerToken{}, ErrCloudProviderNoOIDC
 	default:
 		return CloudBearerToken{}, fmt.Errorf("unsupported cloud provider %q", provider.Provider)
 	}
@@ -489,10 +536,11 @@ func SetEnvironmentCloudProviderAlias(ctx Context, store EnvironmentCloudAliasSt
 	if config.Name == "" {
 		config.Name = environment
 	}
-	if config.CloudProviderAlias == alias {
+	providerType := cloudProviderTypeFromAlias(alias)
+	if cloudEnvAliasForType(config, providerType) == alias {
 		return saveManagedCloudAliasIfNeeded(ctx, store, tenant, config)
 	}
-	config.CloudProviderAlias = alias
+	setCloudEnvAliasForType(&config, providerType, alias)
 	if config.RemoteWorktree() {
 		config.ManagedCloud = true
 	}
@@ -536,6 +584,38 @@ func saveManagedCloudAliasIfNeeded(ctx Context, store EnvironmentCloudAliasStore
 	return config, nil
 }
 
+// cloudProviderTypeFromAlias extracts the provider type from an alias's
+// "@provider" suffix, defaulting to AWS for any legacy or unparseable value so
+// pre-existing single-alias configs keep resolving to the AWS slot.
+func cloudProviderTypeFromAlias(alias string) string {
+	if _, _, provider, ok := ParseCloudProviderAlias(alias); ok {
+		return provider
+	}
+	return CloudProviderAWS
+}
+
+// cloudEnvAliasForType reads the env's attached alias for a provider type. AWS
+// lives in the legacy scalar; every other type lives in the per-type map.
+func cloudEnvAliasForType(config EnvConfig, providerType string) string {
+	if providerType == CloudProviderAWS {
+		return config.CloudProviderAlias
+	}
+	return config.CloudProviderAliases[providerType]
+}
+
+// setCloudEnvAliasForType writes the env's attached alias for a provider type,
+// keeping AWS in the legacy scalar so AWS behavior is byte-for-byte unchanged.
+func setCloudEnvAliasForType(config *EnvConfig, providerType, alias string) {
+	if providerType == CloudProviderAWS {
+		config.CloudProviderAlias = alias
+		return
+	}
+	if config.CloudProviderAliases == nil {
+		config.CloudProviderAliases = make(map[string]string)
+	}
+	config.CloudProviderAliases[providerType] = alias
+}
+
 func ResolveCloudProvider(store CloudReadStore, alias string) (CloudProviderConfig, error) {
 	alias = strings.TrimSpace(alias)
 	if alias == "" {
@@ -565,6 +645,12 @@ func ResolveTenantCloudProviderIssuers(store CloudReadStore, tenant TenantConfig
 		if err != nil {
 			return nil, err
 		}
+		if !cloudProviderSupportsOIDC(provider.Provider) {
+			// Cloudflare aliases authenticate the runtime with a scoped API
+			// token, not an OIDC JWT, so they contribute no issuer. Skip them
+			// rather than fail the tenant's issuer aggregation.
+			continue
+		}
 		issuer := CloudProviderOIDCIssuerURL(provider)
 		if issuer == "" {
 			return nil, fmt.Errorf("cloud provider alias %q does not have an OIDC issuer URL", alias)
@@ -576,6 +662,14 @@ func ResolveTenantCloudProviderIssuers(store CloudReadStore, tenant TenantConfig
 		seen[issuer] = struct{}{}
 	}
 	return issuers, nil
+}
+
+// cloudProviderSupportsOIDC reports whether a provider type participates in
+// OIDC web-identity federation. AWS mints web-identity JWTs; Cloudflare does
+// not. The check gates issuer aggregation strictly on provider type so an AWS
+// alias with a genuinely missing issuer still surfaces as an error.
+func cloudProviderSupportsOIDC(provider string) bool {
+	return strings.ToLower(strings.TrimSpace(provider)) != CloudProviderCloudflare
 }
 
 func CloudProviderOIDCIssuerURL(provider CloudProviderConfig) string {
@@ -631,6 +725,9 @@ func CloudProviderTokenStatus(provider CloudProviderConfig, deps CloudDependenci
 	}
 	if deps.CheckAWSStatus != nil && provider.Provider == CloudProviderAWS {
 		return deps.CheckAWSStatus(Context{}, provider)
+	}
+	if provider.Provider == CloudProviderCloudflare {
+		return cloudflareCloudProviderTokenStatus(provider, deps)
 	}
 	if provider.Provider != CloudProviderAWS {
 		return CloudProviderStatus{CloudProviderConfig: provider, Status: CloudTokenStatusUnknown, Message: "unsupported provider"}
@@ -780,6 +877,9 @@ func normalizeCloudDependencies(deps CloudDependencies) CloudDependencies {
 	}
 	if deps.CheckAWSStatus == nil {
 		deps.CheckAWSStatus = defaultCheckAWSStatus
+	}
+	if deps.VerifyCloudflareToken == nil {
+		deps.VerifyCloudflareToken = defaultVerifyCloudflareToken
 	}
 	return deps
 }

--- a/erun-common/cloud_cloudflare.go
+++ b/erun-common/cloud_cloudflare.go
@@ -194,11 +194,19 @@ func defaultVerifyCloudflareToken(ctx Context, token string) (CloudflareTokenInf
 	if ctx.DryRun {
 		return CloudflareTokenInfo{Status: "active"}, nil
 	}
+	return verifyCloudflareTokenAt(cloudflareTokenVerifyURL, token)
+}
+
+// verifyCloudflareTokenAt performs the live token verification against url. It
+// is split from defaultVerifyCloudflareToken (which owns the trace and dry-run
+// short-circuit) so the response parsing and status classification are unit
+// testable against an httptest server.
+func verifyCloudflareTokenAt(url, token string) (CloudflareTokenInfo, error) {
 	token = strings.TrimSpace(token)
 	if token == "" {
 		return CloudflareTokenInfo{}, fmt.Errorf("cloudflare api token is required")
 	}
-	req, err := http.NewRequest(http.MethodGet, cloudflareTokenVerifyURL, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return CloudflareTokenInfo{}, fmt.Errorf("build cloudflare token verify request: %w", err)
 	}

--- a/erun-common/cloud_cloudflare.go
+++ b/erun-common/cloud_cloudflare.go
@@ -1,0 +1,308 @@
+package eruncommon
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// cloudflareTokenVerifyURL is Cloudflare's token self-verification endpoint. A
+// successful response confirms the scoped API token is valid and active.
+const cloudflareTokenVerifyURL = "https://api.cloudflare.com/client/v4/user/tokens/verify"
+
+// CloudSecretStore persists provider secrets (today: Cloudflare scoped API
+// tokens) outside erun-config.yaml. Implementations key on an opaque ref so
+// the config file only ever carries the ref, never the secret value. The
+// transports wire a concrete store; erun-common ships a file-backed default
+// via NewFileCloudSecretStore.
+type CloudSecretStore interface {
+	SaveCloudSecret(ref, value string) error
+	LoadCloudSecret(ref string) (string, error)
+	DeleteCloudSecret(ref string) error
+}
+
+// CloudflareTokenInfo is the subset of Cloudflare's tokens/verify response the
+// alias lifecycle cares about.
+type CloudflareTokenInfo struct {
+	ID     string
+	Status string
+}
+
+// InitCloudflareCloudProviderParams are the explicit inputs for adding a
+// Cloudflare cloud alias. The API token is an account-scoped, delegated token
+// (account-level Zone:Edit + DNS:Edit) the operator minted in the Cloudflare
+// dashboard; erun stores it via the CloudSecretStore, never inline.
+type InitCloudflareCloudProviderParams struct {
+	AccountID string
+	TokenName string
+	APIToken  string
+}
+
+// InitCloudflareCloudProvider verifies a Cloudflare scoped API token, stores it
+// in the secret store, and saves a Cloudflare cloud alias
+// ("<token-name>+<account-id>@cloudflare"). The raw token is written only to
+// the secret store; erun-config.yaml carries the TokenRef handle.
+func InitCloudflareCloudProvider(ctx Context, store CloudStore, params InitCloudflareCloudProviderParams, deps CloudDependencies) (CloudProviderConfig, error) {
+	if store == nil {
+		return CloudProviderConfig{}, fmt.Errorf("store is required")
+	}
+	deps = normalizeCloudDependencies(deps)
+	accountID := strings.TrimSpace(params.AccountID)
+	tokenName := strings.TrimSpace(params.TokenName)
+	apiToken := strings.TrimSpace(params.APIToken)
+	ctx.Trace(fmt.Sprintf("cloud init cloudflare: account-id=%s token-name=%s api-token=%s",
+		accountID, tokenName, redactSecretPresence(apiToken)))
+	switch {
+	case accountID == "":
+		return CloudProviderConfig{}, fmt.Errorf("cloudflare account id is required")
+	case tokenName == "":
+		return CloudProviderConfig{}, fmt.Errorf("cloudflare token name is required")
+	case apiToken == "":
+		return CloudProviderConfig{}, fmt.Errorf("cloudflare api token is required")
+	}
+	alias := CloudProviderAlias(tokenName, accountID, CloudProviderCloudflare)
+	if alias == "" {
+		return CloudProviderConfig{}, fmt.Errorf("cloudflare cloud provider alias cannot be resolved")
+	}
+	ctx.Trace("cloud init cloudflare: verifying scoped api token")
+	if _, err := deps.VerifyCloudflareToken(ctx, apiToken); err != nil {
+		ctx.Trace("cloud init cloudflare: token verification failed: " + err.Error())
+		return CloudProviderConfig{}, err
+	}
+	tokenRef := cloudflareTokenRef(alias)
+	provider := cloudflareProviderConfig(alias, accountID, tokenName, tokenRef)
+	if ctx.DryRun {
+		ctx.Trace("store cloudflare api token at ref " + tokenRef)
+		ctx.Trace("write cloud provider " + alias)
+		return provider, nil
+	}
+	if deps.CloudSecretStore == nil {
+		return CloudProviderConfig{}, fmt.Errorf("cloud secret store is not configured")
+	}
+	if err := deps.CloudSecretStore.SaveCloudSecret(tokenRef, apiToken); err != nil {
+		return CloudProviderConfig{}, fmt.Errorf("store cloudflare api token: %w", err)
+	}
+	saved, err := SaveCloudProviderConfig(store, provider)
+	if err != nil {
+		return CloudProviderConfig{}, err
+	}
+	return saved, nil
+}
+
+// cloudflareProviderConfig assembles a normalized Cloudflare CloudProviderConfig.
+// Username/AccountID mirror the Cloudflare identity so generic listing and the
+// alias derivation work without special-casing; the Cloudflare sub-block holds
+// the TokenRef that distinguishes the credential.
+func cloudflareProviderConfig(alias, accountID, tokenName, tokenRef string) CloudProviderConfig {
+	return NormalizeCloudProviderConfig(CloudProviderConfig{
+		Alias:     alias,
+		Provider:  CloudProviderCloudflare,
+		Username:  tokenName,
+		AccountID: accountID,
+		Cloudflare: &CloudflareProviderConfig{
+			AccountID: accountID,
+			TokenName: tokenName,
+			TokenRef:  tokenRef,
+		},
+	})
+}
+
+// cloudflareCloudProviderTokenStatus reports whether the stored scoped token is
+// still valid by re-verifying it against Cloudflare. A missing store or token
+// reads as not_configured; a verification failure reads as expired.
+func cloudflareCloudProviderTokenStatus(provider CloudProviderConfig, deps CloudDependencies) CloudProviderStatus {
+	if provider.Cloudflare == nil || strings.TrimSpace(provider.Cloudflare.TokenRef) == "" {
+		return CloudProviderStatus{CloudProviderConfig: provider, Status: CloudTokenStatusNotConfigured, Message: "cloudflare api token is not configured"}
+	}
+	if deps.CloudSecretStore == nil {
+		return CloudProviderStatus{CloudProviderConfig: provider, Status: CloudTokenStatusUnknown, Message: "cloud secret store is not configured"}
+	}
+	token, err := deps.CloudSecretStore.LoadCloudSecret(provider.Cloudflare.TokenRef)
+	if err != nil || strings.TrimSpace(token) == "" {
+		return CloudProviderStatus{CloudProviderConfig: provider, Status: CloudTokenStatusNotConfigured, Message: "cloudflare api token is not available on this machine"}
+	}
+	if _, err := deps.VerifyCloudflareToken(Context{}, token); err != nil {
+		return CloudProviderStatus{CloudProviderConfig: provider, Status: CloudTokenStatusExpired, Message: err.Error()}
+	}
+	return CloudProviderStatus{CloudProviderConfig: provider, Status: CloudTokenStatusActive}
+}
+
+// exportCloudflareToken loads the scoped API token for a Cloudflare alias so a
+// caller (deploy, the desktop) can deliver it into a runtime environment. The
+// token value is sensitive: callers must never trace, log, or echo it.
+func exportCloudflareToken(provider CloudProviderConfig, deps CloudDependencies) (string, error) {
+	if provider.Cloudflare == nil || strings.TrimSpace(provider.Cloudflare.TokenRef) == "" {
+		return "", fmt.Errorf("cloudflare alias %q has no token reference", provider.Alias)
+	}
+	if deps.CloudSecretStore == nil {
+		return "", fmt.Errorf("cloud secret store is not configured")
+	}
+	token, err := deps.CloudSecretStore.LoadCloudSecret(provider.Cloudflare.TokenRef)
+	if err != nil {
+		return "", fmt.Errorf("load cloudflare api token for %q: %w", provider.Alias, err)
+	}
+	if strings.TrimSpace(token) == "" {
+		return "", fmt.Errorf("cloudflare api token for %q is empty", provider.Alias)
+	}
+	return token, nil
+}
+
+// deleteCloudflareToken removes the stored scoped token, the Cloudflare
+// equivalent of an SSO logout: the alias remains configured but loses its
+// credential until re-initialized.
+func deleteCloudflareToken(ctx Context, provider CloudProviderConfig, deps CloudDependencies) error {
+	if provider.Cloudflare == nil || strings.TrimSpace(provider.Cloudflare.TokenRef) == "" {
+		return nil
+	}
+	ctx.Trace("delete cloudflare api token at ref " + provider.Cloudflare.TokenRef)
+	if ctx.DryRun {
+		return nil
+	}
+	if deps.CloudSecretStore == nil {
+		return fmt.Errorf("cloud secret store is not configured")
+	}
+	return deps.CloudSecretStore.DeleteCloudSecret(provider.Cloudflare.TokenRef)
+}
+
+// cloudflareTokenRef derives a stable secret-store handle for an alias.
+func cloudflareTokenRef(alias string) string {
+	return "cloudflare/" + strings.TrimSpace(alias)
+}
+
+// redactSecretPresence reports whether a secret was supplied without echoing
+// it, keeping dry-run traces deterministic and free of credentials.
+func redactSecretPresence(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "<empty>"
+	}
+	return "<redacted>"
+}
+
+// defaultVerifyCloudflareToken calls Cloudflare's tokens/verify endpoint with
+// the supplied scoped token. In dry-run it traces the call and returns a
+// synthetic active result without touching the network.
+func defaultVerifyCloudflareToken(ctx Context, token string) (CloudflareTokenInfo, error) {
+	ctx.Trace("GET " + cloudflareTokenVerifyURL)
+	if ctx.DryRun {
+		return CloudflareTokenInfo{Status: "active"}, nil
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return CloudflareTokenInfo{}, fmt.Errorf("cloudflare api token is required")
+	}
+	req, err := http.NewRequest(http.MethodGet, cloudflareTokenVerifyURL, nil)
+	if err != nil {
+		return CloudflareTokenInfo{}, fmt.Errorf("build cloudflare token verify request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return CloudflareTokenInfo{}, fmt.Errorf("verify cloudflare token: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	var payload struct {
+		Success bool `json:"success"`
+		Errors  []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+		Result struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return CloudflareTokenInfo{}, fmt.Errorf("parse cloudflare token verify response (status %d): %w", resp.StatusCode, err)
+	}
+	if !payload.Success {
+		message := "cloudflare rejected the api token"
+		if len(payload.Errors) > 0 && strings.TrimSpace(payload.Errors[0].Message) != "" {
+			message = payload.Errors[0].Message
+		}
+		return CloudflareTokenInfo{}, fmt.Errorf("verify cloudflare token: %s", message)
+	}
+	if status := strings.ToLower(strings.TrimSpace(payload.Result.Status)); status != "" && status != "active" {
+		return CloudflareTokenInfo{}, fmt.Errorf("cloudflare api token is %s", payload.Result.Status)
+	}
+	return CloudflareTokenInfo{ID: payload.Result.ID, Status: payload.Result.Status}, nil
+}
+
+// fileCloudSecretStore is a 0600 file-backed CloudSecretStore. The ref is
+// hashed to a filename so alias punctuation never reaches the filesystem path.
+type fileCloudSecretStore struct {
+	dir string
+}
+
+// NewFileCloudSecretStore returns a CloudSecretStore that persists secrets as
+// 0600 files under dir (created 0700 on first write). Transports wire this with
+// a directory beside the erun config so secrets stay off the YAML config.
+func NewFileCloudSecretStore(dir string) CloudSecretStore {
+	return fileCloudSecretStore{dir: strings.TrimSpace(dir)}
+}
+
+// cloudSecretStoreDirName is the subdirectory under the erun config dir that
+// holds provider secrets.
+const cloudSecretStoreDirName = "cloud-secrets"
+
+// DefaultCloudSecretStore returns a file-backed CloudSecretStore rooted at
+// <erun-config-dir>/cloud-secrets. Transports wire this onto CloudDependencies
+// so Cloudflare tokens persist beside — never inside — erun-config.yaml.
+func DefaultCloudSecretStore() (CloudSecretStore, error) {
+	dir, err := ERunConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	return NewFileCloudSecretStore(filepath.Join(dir, cloudSecretStoreDirName)), nil
+}
+
+func (s fileCloudSecretStore) path(ref string) string {
+	sum := sha256.Sum256([]byte(ref))
+	return filepath.Join(s.dir, hex.EncodeToString(sum[:])+".token")
+}
+
+func (s fileCloudSecretStore) SaveCloudSecret(ref, value string) error {
+	if strings.TrimSpace(ref) == "" {
+		return fmt.Errorf("secret ref is required")
+	}
+	if s.dir == "" {
+		return fmt.Errorf("cloud secret store directory is not configured")
+	}
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("create cloud secret store directory: %w", err)
+	}
+	if err := os.WriteFile(s.path(ref), []byte(value), 0o600); err != nil {
+		return fmt.Errorf("write cloud secret: %w", err)
+	}
+	return nil
+}
+
+func (s fileCloudSecretStore) LoadCloudSecret(ref string) (string, error) {
+	if strings.TrimSpace(ref) == "" {
+		return "", fmt.Errorf("secret ref is required")
+	}
+	data, err := os.ReadFile(s.path(ref))
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (s fileCloudSecretStore) DeleteCloudSecret(ref string) error {
+	if strings.TrimSpace(ref) == "" {
+		return nil
+	}
+	if err := os.Remove(s.path(ref)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("delete cloud secret: %w", err)
+	}
+	return nil
+}

--- a/erun-common/cloud_cloudflare_test.go
+++ b/erun-common/cloud_cloudflare_test.go
@@ -1,0 +1,162 @@
+package eruncommon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFileCloudSecretStoreRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFileCloudSecretStore(filepath.Join(dir, "cloud-secrets"))
+
+	if err := store.SaveCloudSecret("cloudflare/ci+acct@cloudflare", "tok-value"); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := store.LoadCloudSecret("cloudflare/ci+acct@cloudflare")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got != "tok-value" {
+		t.Fatalf("load = %q, want tok-value", got)
+	}
+
+	// The secret file must be 0600 so other users on the host cannot read it.
+	entries, err := os.ReadDir(filepath.Join(dir, "cloud-secrets"))
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected one secret file, got %d", len(entries))
+	}
+	info, err := entries[0].Info()
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("secret file perm = %o, want 600", perm)
+	}
+
+	if err := store.DeleteCloudSecret("cloudflare/ci+acct@cloudflare"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	// Deleting a missing secret is a no-op, not an error.
+	if err := store.DeleteCloudSecret("cloudflare/ci+acct@cloudflare"); err != nil {
+		t.Fatalf("delete missing: %v", err)
+	}
+	if _, err := store.LoadCloudSecret("cloudflare/ci+acct@cloudflare"); err == nil {
+		t.Fatal("expected load after delete to fail")
+	}
+}
+
+func TestRedactSecretPresence(t *testing.T) {
+	if got := redactSecretPresence("super-secret"); got != "<redacted>" {
+		t.Fatalf("present = %q, want <redacted>", got)
+	}
+	if got := redactSecretPresence("   "); got != "<empty>" {
+		t.Fatalf("blank = %q, want <empty>", got)
+	}
+}
+
+func TestRenderCloudflareCredentialsSecretRedactsAndQuotes(t *testing.T) {
+	manifest := renderCloudflareCredentialsSecret("acme-dev-cloudflare", "acme-dev", `tok"with\quote`)
+	if !strings.Contains(manifest, "CLOUDFLARE_API_TOKEN: \"tok\\\"with\\\\quote\"") {
+		t.Fatalf("token not safely quoted in manifest:\n%s", manifest)
+	}
+	// Only the sensitive token belongs in the Secret; the account id rides as a
+	// non-secret helm value.
+	if strings.Contains(manifest, "CLOUDFLARE_ACCOUNT_ID") {
+		t.Fatalf("account id must not be in the secret manifest:\n%s", manifest)
+	}
+}
+
+func TestCloudProviderTypeFromAlias(t *testing.T) {
+	cases := map[string]string{
+		"alice+123456789012@aws":  CloudProviderAWS,
+		"ci+cf-acct-1@cloudflare": CloudProviderCloudflare,
+		"garbage-without-suffix":  CloudProviderAWS,
+		"":                        CloudProviderAWS,
+	}
+	for alias, want := range cases {
+		if got := cloudProviderTypeFromAlias(alias); got != want {
+			t.Fatalf("cloudProviderTypeFromAlias(%q) = %q, want %q", alias, got, want)
+		}
+	}
+}
+
+func TestResolvedCloudAliasesFoldsLegacyScalarAndMap(t *testing.T) {
+	env := EnvConfig{
+		CloudProviderAlias: "alice+123456789012@aws",
+		CloudProviderAliases: map[string]string{
+			CloudProviderCloudflare: "ci+cf-acct-1@cloudflare",
+		},
+	}
+	resolved := env.ResolvedCloudAliases()
+	if resolved[CloudProviderAWS] != "alice+123456789012@aws" {
+		t.Fatalf("aws slot = %q", resolved[CloudProviderAWS])
+	}
+	if resolved[CloudProviderCloudflare] != "ci+cf-acct-1@cloudflare" {
+		t.Fatalf("cloudflare slot = %q", resolved[CloudProviderCloudflare])
+	}
+	if len(resolved) != 2 {
+		t.Fatalf("expected 2 resolved aliases, got %d", len(resolved))
+	}
+}
+
+func TestVerifyCloudflareTokenAtClassifiesResponses(t *testing.T) {
+	t.Run("active", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+				t.Fatalf("authorization header = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"success":true,"result":{"id":"abc","status":"active"}}`))
+		}))
+		defer srv.Close()
+		info, err := verifyCloudflareTokenAt(srv.URL, "tok")
+		if err != nil {
+			t.Fatalf("verify: %v", err)
+		}
+		if info.ID != "abc" || info.Status != "active" {
+			t.Fatalf("info = %+v", info)
+		}
+	})
+
+	t.Run("rejected", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"success":false,"errors":[{"message":"Invalid API Token"}]}`))
+		}))
+		defer srv.Close()
+		if _, err := verifyCloudflareTokenAt(srv.URL, "tok"); err == nil || !strings.Contains(err.Error(), "Invalid API Token") {
+			t.Fatalf("expected rejection error, got %v", err)
+		}
+	})
+
+	t.Run("disabled-token", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"success":true,"result":{"id":"abc","status":"disabled"}}`))
+		}))
+		defer srv.Close()
+		if _, err := verifyCloudflareTokenAt(srv.URL, "tok"); err == nil || !strings.Contains(err.Error(), "disabled") {
+			t.Fatalf("expected disabled error, got %v", err)
+		}
+	})
+}
+
+func TestResolveTenantCloudProviderIssuersSkipsCloudflare(t *testing.T) {
+	store := stubCloudContextStore{config: ERunConfig{CloudProviders: []CloudProviderConfig{
+		{Alias: "alice+123456789012@aws", Provider: CloudProviderAWS, OIDCIssuerURL: "https://issuer.example.com"},
+		{Alias: "ci+cf-acct-1@cloudflare", Provider: CloudProviderCloudflare, Cloudflare: &CloudflareProviderConfig{AccountID: "cf-acct-1", TokenRef: "cloudflare/ci+cf-acct-1@cloudflare"}},
+	}}}
+	tenant := TenantConfig{CloudProviderAliases: []string{"alice+123456789012@aws", "ci+cf-acct-1@cloudflare"}}
+
+	issuers, err := ResolveTenantCloudProviderIssuers(store, tenant)
+	if err != nil {
+		t.Fatalf("resolve issuers: %v", err)
+	}
+	if len(issuers) != 1 || issuers[0] != "https://issuer.example.com" {
+		t.Fatalf("issuers = %v, want only the AWS issuer (Cloudflare has no OIDC)", issuers)
+	}
+}

--- a/erun-common/cloud_credentials_deploy.go
+++ b/erun-common/cloud_credentials_deploy.go
@@ -1,0 +1,104 @@
+package eruncommon
+
+import (
+	"fmt"
+	"strings"
+)
+
+// cloudflareSecretName derives the per-release Secret that carries the
+// Cloudflare credentials for an environment's runtime pod. It mirrors the
+// erun-docs cf-creds shape (CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID).
+func cloudflareSecretName(releaseName string) string {
+	return strings.TrimSpace(releaseName) + "-cloudflare"
+}
+
+// cloudflareSecretApplyArgs builds the kubectl argv that applies the Cloudflare
+// credentials Secret, reading the manifest from stdin (`-f -`) so the token is
+// never an argv element. Shared by the dry-run trace and the live apply.
+func cloudflareSecretApplyArgs(namespace, kubernetesContext string) []string {
+	args := []string{}
+	if ctxName := strings.TrimSpace(kubernetesContext); ctxName != "" {
+		args = append(args, "--context", ctxName)
+	}
+	args = append(args, "-n", strings.TrimSpace(namespace), "apply", "-f", "-")
+	return args
+}
+
+// renderCloudflareCredentialsSecret renders the Opaque Secret manifest carrying
+// only the sensitive token; the non-secret account id rides as a plain helm
+// value. The token is %q-quoted (valid YAML, since YAML is a JSON superset) so
+// any punctuation is safely escaped.
+func renderCloudflareCredentialsSecret(name, namespace, apiToken string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    app.kubernetes.io/managed-by: erun-deploy
+type: Opaque
+stringData:
+  CLOUDFLARE_API_TOKEN: %q
+`, name, namespace, apiToken)
+}
+
+// applyCloudflareCredentialsSecret creates or updates the Secret that delivers
+// the delegated Cloudflare token into the env's runtime pod. The token is
+// loaded from the default secret store and piped to `kubectl apply -f -` via
+// stdin, so it never appears in argv, the trace, or helm release values. It is
+// a no-op unless the env attached a Cloudflare alias; dry-run traces the apply
+// (token redacted) without touching the cluster.
+func applyCloudflareCredentialsSecret(ctx Context, deployInput HelmDeploySpec) error {
+	if !deployInput.CloudflareEnabled || strings.TrimSpace(deployInput.CloudflareSecretName) == "" {
+		return nil
+	}
+	args := cloudflareSecretApplyArgs(deployInput.Namespace, deployInput.KubernetesContext)
+	ctx.Trace("apply cloudflare credentials secret " + deployInput.CloudflareSecretName + " (token redacted)")
+	ctx.TraceCommand("", "kubectl", args...)
+	if ctx.DryRun {
+		return nil
+	}
+	if strings.TrimSpace(deployInput.CloudflareTokenRef) == "" {
+		return fmt.Errorf("deploy %s: cloudflare alias has no token reference", deployInput.ReleaseName)
+	}
+	store, err := DefaultCloudSecretStore()
+	if err != nil {
+		return fmt.Errorf("resolve cloud secret store: %w", err)
+	}
+	token, err := store.LoadCloudSecret(deployInput.CloudflareTokenRef)
+	if err != nil {
+		return fmt.Errorf("load cloudflare api token: %w", err)
+	}
+	manifest := renderCloudflareCredentialsSecret(
+		deployInput.CloudflareSecretName,
+		deployInput.Namespace,
+		token,
+	)
+	cmd := Command("kubectl", args...)
+	cmd.Stdin = strings.NewReader(manifest)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("kubectl apply cloudflare credentials secret: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// applyCloudflareDeployMetadata fills the Cloudflare deploy fields from the
+// env's attached Cloudflare alias (if any). It performs no side effects — the
+// Secret is applied later at execution time by applyCloudflareCredentialsSecret.
+func applyCloudflareDeployMetadata(store CloudReadStore, env EnvConfig, deployInput *HelmDeploySpec) {
+	if deployInput == nil {
+		return
+	}
+	alias := strings.TrimSpace(env.ResolvedCloudAliases()[CloudProviderCloudflare])
+	if alias == "" {
+		return
+	}
+	provider, err := ResolveCloudProvider(store, alias)
+	if err != nil || provider.Provider != CloudProviderCloudflare || provider.Cloudflare == nil {
+		return
+	}
+	deployInput.CloudflareEnabled = true
+	deployInput.CloudflareAccountID = provider.Cloudflare.AccountID
+	deployInput.CloudflareTokenRef = provider.Cloudflare.TokenRef
+	deployInput.CloudflareSecretName = cloudflareSecretName(deployInput.ReleaseName)
+}

--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -113,8 +113,8 @@ type EnvConfig struct {
 	// carries at most one alias per provider type.
 	CloudProviderAliases map[string]string `yaml:"cloudprovideraliases,omitempty" json:"cloudProviderAliases,omitempty"`
 	ManagedCloud         bool              `yaml:"managedcloud,omitempty" json:"managedCloud,omitempty"`
-	RuntimeVersion     string `yaml:"runtimeversion,omitempty"`
-	RuntimeRegistry    string `yaml:"runtimeregistry,omitempty" json:"runtimeRegistry,omitempty"`
+	RuntimeVersion       string            `yaml:"runtimeversion,omitempty"`
+	RuntimeRegistry      string            `yaml:"runtimeregistry,omitempty" json:"runtimeRegistry,omitempty"`
 	// ContainerRegistries carries the marked registry list for environments
 	// whose project config is not on the local machine (remote-agent and
 	// runtime envs). Local-agent envs resolve their list from the project's

--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -105,7 +105,14 @@ type EnvConfig struct {
 	LocalRepoPath      string          `yaml:"localrepopath,omitempty" json:"localRepoPath,omitempty"`
 	KubernetesContext  string
 	CloudProviderAlias string `yaml:"cloudprovideralias,omitempty"`
-	ManagedCloud       bool   `yaml:"managedcloud,omitempty" json:"managedCloud,omitempty"`
+	// CloudProviderAliases attaches additional cloud aliases to this env, one
+	// per provider type (keyed by provider type, e.g. "cloudflare"). The legacy
+	// CloudProviderAlias scalar above stays the AWS slot for backward
+	// compatibility — pre-existing configs keep working untouched —
+	// while ResolvedCloudAliases folds both into one per-type view. Each env
+	// carries at most one alias per provider type.
+	CloudProviderAliases map[string]string `yaml:"cloudprovideraliases,omitempty" json:"cloudProviderAliases,omitempty"`
+	ManagedCloud         bool              `yaml:"managedcloud,omitempty" json:"managedCloud,omitempty"`
 	RuntimeVersion     string `yaml:"runtimeversion,omitempty"`
 	RuntimeRegistry    string `yaml:"runtimeregistry,omitempty" json:"runtimeRegistry,omitempty"`
 	// ContainerRegistries carries the marked registry list for environments
@@ -144,6 +151,28 @@ type EnvConfig struct {
 	// with no buildable context if none exist. Default false preserves today's
 	// build.sh-shadows-docker behaviour.
 	DisableBuildScript bool `yaml:"disablebuildscript,omitempty" json:"disableBuildScript,omitempty"`
+}
+
+// ResolvedCloudAliases returns the env's attached cloud aliases keyed by
+// provider type. The legacy CloudProviderAlias scalar is folded in under its
+// own provider type (AWS for every pre-existing config), and explicit
+// CloudProviderAliases entries are layered on top. An env holds at most one
+// alias per provider type, so the runtime can be seeded with, e.g., both an
+// AWS identity and a Cloudflare token at once.
+func (c EnvConfig) ResolvedCloudAliases() map[string]string {
+	resolved := make(map[string]string)
+	if alias := strings.TrimSpace(c.CloudProviderAlias); alias != "" {
+		resolved[cloudProviderTypeFromAlias(alias)] = alias
+	}
+	for providerType, alias := range c.CloudProviderAliases {
+		providerType = strings.ToLower(strings.TrimSpace(providerType))
+		alias = strings.TrimSpace(alias)
+		if providerType == "" || alias == "" {
+			continue
+		}
+		resolved[providerType] = alias
+	}
+	return resolved
 }
 
 // ResolvedType returns the env's type, or "" when unresolved. Pre-#376 configs

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -165,6 +165,13 @@ type HelmDeploySpec struct {
 	Version            string
 	Timeout            string
 	Verbosity          int
+	// Cloudflare* deliver a delegated Cloudflare token to the runtime pod.
+	// CloudflareEnabled gates the whole path; CloudflareTokenRef is a handle
+	// into the secret store (never the token itself), resolved at execution time.
+	CloudflareEnabled    bool
+	CloudflareAccountID  string
+	CloudflareSecretName string
+	CloudflareTokenRef   string
 	// RuntimeRegistry is the env's runtime image-ref / runtime-version
 	// registry (EnvConfig.RuntimeRegistry), distinct from ContainerRegistry
 	// (the DEPLOY-marked registry the cluster pulls from). Injected so in-pod
@@ -478,6 +485,9 @@ func RunHelmDeploy(ctx Context, deployInput HelmDeploySpec, deploy HelmChartDepl
 		return fmt.Errorf("deploy %s: %w", deployInput.ReleaseName, err)
 	}
 	TraceEnsureKubernetesNamespace(ctx, deployInput.KubernetesContext, deployInput.Namespace)
+	if err := applyCloudflareCredentialsSecret(ctx, deployInput); err != nil {
+		return fmt.Errorf("deploy %s: %w", deployInput.ReleaseName, err)
+	}
 	command := deployInput.command()
 	ctx.TraceCommand(command.Dir, command.Name, command.Args...)
 	tracePodWatchAction(ctx, deployInput.ReleaseName, deployInput.Namespace, deployInput.KubernetesContext)
@@ -885,6 +895,7 @@ func configureDeployInputMetadata(store DeployStore, target OpenResult, deployIn
 	deployInput.ManagedCloud = managedCloud
 	deployInput.UseHostCredentials = target.EnvConfig.RemoteHostCredentials
 	applyCloudProviderDeployMetadata(store, target.EnvConfig, deployInput)
+	applyCloudflareDeployMetadata(store, target.EnvConfig, deployInput)
 	if managedCloud {
 		applyCloudContextStopMetadata(store, target.EnvConfig, deployInput)
 	}
@@ -1547,6 +1558,17 @@ func (d HelmDeploySpec) command() commandSpec {
 		"--set-string", "api.oidcAllowedIssuers="+escapeHelmSetValue(d.OIDCAllowedIssuers),
 		"--set", "api.postgres.reset="+formatHelmBool(d.ResetDatabase),
 	)
+	// Cloudflare credential wiring is appended only when an env attached a
+	// Cloudflare alias, so existing (AWS-only / no-cloud) deploy plans are
+	// byte-for-byte unchanged. The token is never a --set value — it is
+	// delivered out-of-band as a Secret (applyCloudflareCredentialsSecret).
+	if d.CloudflareEnabled {
+		args = append(args,
+			"--set", "cloudContext.cloudflare.enabled=true",
+			"--set-string", "cloudContext.cloudflare.accountId="+d.CloudflareAccountID,
+			"--set-string", "cloudContext.cloudflare.secretName="+d.CloudflareSecretName,
+		)
+	}
 	args = append(args, helmRegistrySetArgs(d)...)
 	// disableBuildScript is always set — a boolean projection must be able to
 	// reconcile a flip in either direction, so the chart always receives the

--- a/erun-devops/k8s/erun-devops/templates/service.yaml
+++ b/erun-devops/k8s/erun-devops/templates/service.yaml
@@ -64,6 +64,10 @@ emitted; type is the single source of truth.
 {{- $cloudRegion := default "" $cloudContext.region -}}
 {{- $cloudInstanceID := default "" $cloudContext.instanceId -}}
 {{- $useHostCredentials := default false $cloudContext.useHostCredentials -}}
+{{- $cloudflare := default dict $cloudContext.cloudflare -}}
+{{- $cloudflareEnabled := default false $cloudflare.enabled -}}
+{{- $cloudflareAccountId := default "" $cloudflare.accountId -}}
+{{- $cloudflareSecretName := default "" $cloudflare.secretName -}}
 {{- $claude := default dict .Values.claude -}}
 {{- $claudeUseBedrock := default "0" $claude.useBedrock -}}
 {{- $claudeUseMantle := default "0" $claude.useMantle -}}
@@ -388,6 +392,16 @@ spec:
               value: {{ $claudeEnablePromptCaching1H | quote }}
             {{ end }}
             {{ end }}
+            {{- if $cloudflareEnabled }}
+            - name: CLOUDFLARE_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $cloudflareSecretName | quote }}
+                  key: CLOUDFLARE_API_TOKEN
+                  optional: true
+            - name: CLOUDFLARE_ACCOUNT_ID
+              value: {{ $cloudflareAccountId | quote }}
+            {{- end }}
             - name: ERUN_KUBERNETES_CONTEXT
               value: in-cluster
             - name: ERUN_TENANT

--- a/erun-devops/terraform-erun/modules/terraform-erun-cloudflare-services/main.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cloudflare-services/main.tf
@@ -1,0 +1,51 @@
+locals {
+  # Fully-qualified name of the delegated child zone, e.g. "app.example.com".
+  delegated_zone_name = "${var.subdomain}.${var.base_domain_name}"
+
+  # FQDN of the service A record; an empty record_name targets the zone apex.
+  record_fqdn = var.record_name == "" ? local.delegated_zone_name : "${var.record_name}.${local.delegated_zone_name}"
+
+  # Resolve the parent zone id: an explicit input wins, otherwise the looked-up zone.
+  parent_zone_id = var.parent_zone_id != "" ? var.parent_zone_id : try(data.cloudflare_zone.parent[0].zone_id, "")
+}
+
+# Look up the parent zone only when delegation is managed here and no id was supplied.
+data "cloudflare_zone" "parent" {
+  count = var.manage_delegation && var.parent_zone_id == "" ? 1 : 0
+
+  filter = {
+    name    = var.base_domain_name
+    account = { id = var.cloudflare_account_id }
+  }
+}
+
+# The delegated child zone.
+resource "cloudflare_zone" "this" {
+  name = local.delegated_zone_name
+
+  account = {
+    id = var.cloudflare_account_id
+  }
+}
+
+# Delegation: publish each of the child zone's name servers as an NS record in the
+# parent zone so the subdomain is delegated to the child zone's Cloudflare name servers.
+resource "cloudflare_dns_record" "delegation" {
+  for_each = var.manage_delegation ? toset(cloudflare_zone.this.name_servers) : toset([])
+
+  zone_id = local.parent_zone_id
+  name    = local.delegated_zone_name
+  type    = "NS"
+  ttl     = var.delegation_ttl
+  content = each.value
+}
+
+# Service A record inside the delegated zone.
+resource "cloudflare_dns_record" "this" {
+  zone_id = cloudflare_zone.this.id
+  name    = local.record_fqdn
+  type    = "A"
+  ttl     = var.record_ttl
+  content = var.ip_address
+  proxied = var.proxied
+}

--- a/erun-devops/terraform-erun/modules/terraform-erun-cloudflare-services/outputs.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cloudflare-services/outputs.tf
@@ -1,0 +1,24 @@
+output "zone_id" {
+  description = "Cloudflare zone ID of the delegated child zone."
+  value       = cloudflare_zone.this.id
+}
+
+output "zone_name" {
+  description = "Fully-qualified name of the delegated child zone."
+  value       = cloudflare_zone.this.name
+}
+
+output "name_servers" {
+  description = "Cloudflare name servers assigned to the delegated child zone — the delegation target. Hand these to the parent operator when manage_delegation is false."
+  value       = cloudflare_zone.this.name_servers
+}
+
+output "record_fqdn" {
+  description = "Fully-qualified name of the service A record."
+  value       = cloudflare_dns_record.this.name
+}
+
+output "delegation_managed" {
+  description = "Whether this module wrote the NS delegation records into the parent zone."
+  value       = var.manage_delegation
+}

--- a/erun-devops/terraform-erun/modules/terraform-erun-cloudflare-services/variables.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cloudflare-services/variables.tf
@@ -1,0 +1,75 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID that owns the delegated child zone."
+  type        = string
+
+  validation {
+    condition     = length(var.cloudflare_account_id) > 0
+    error_message = "cloudflare_account_id must not be empty."
+  }
+}
+
+variable "base_domain_name" {
+  description = "Parent domain that owns the delegation, e.g. \"example.com\". The module creates a child zone for \"<subdomain>.<base_domain_name>\"."
+  type        = string
+
+  validation {
+    condition     = can(regex("^([a-z0-9]([a-z0-9-]*[a-z0-9])?\\.)+[a-z]{2,}$", var.base_domain_name))
+    error_message = "base_domain_name must be a valid DNS domain such as \"example.com\"."
+  }
+}
+
+variable "subdomain" {
+  description = "Single DNS label delegated under base_domain_name, e.g. \"app\" to manage \"app.example.com\"."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", var.subdomain))
+    error_message = "subdomain must be a single DNS label (letters, digits, hyphens; no dots)."
+  }
+}
+
+variable "ip_address" {
+  description = "IPv4 address the service A record resolves to."
+  type        = string
+
+  validation {
+    condition     = can(regex("^(\\d{1,3}\\.){3}\\d{1,3}$", var.ip_address))
+    error_message = "ip_address must be a valid IPv4 dotted-quad address."
+  }
+}
+
+variable "record_name" {
+  description = "Host label for the A record inside the delegated zone. Empty string targets the zone apex (\"<subdomain>.<base_domain_name>\")."
+  type        = string
+  default     = ""
+}
+
+variable "manage_delegation" {
+  description = "When true, resolve base_domain_name in Cloudflare and write the NS delegation records into the parent zone so the subdomain is delegated to the child zone's Cloudflare name servers. Set false when the parent zone lives outside this account/state; delegate manually using the name_servers output."
+  type        = bool
+  default     = true
+}
+
+variable "parent_zone_id" {
+  description = "Cloudflare zone ID of base_domain_name. Leave empty to look it up by name. Ignored when manage_delegation is false."
+  type        = string
+  default     = ""
+}
+
+variable "record_ttl" {
+  description = "TTL in seconds for the service A record."
+  type        = number
+  default     = 300
+}
+
+variable "delegation_ttl" {
+  description = "TTL in seconds for the NS delegation records in the parent zone."
+  type        = number
+  default     = 172800
+}
+
+variable "proxied" {
+  description = "Whether the service A record is proxied through Cloudflare (orange-cloud). Proxiable record types only; leave false for a plain DNS A record."
+  type        = bool
+  default     = false
+}

--- a/erun-devops/terraform-erun/modules/terraform-erun-cloudflare-services/versions.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cloudflare-services/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Authentication is delegated entirely to the Cloudflare provider's native
+# CLOUDFLARE_API_TOKEN environment variable, so this provider block is intentionally
+# empty. erun injects an account-scoped, delegated API token (account-level Zone:Edit
+# + DNS:Edit) into the runtime pod; do not hardcode the token here or accept it as a
+# Terraform variable.
+provider "cloudflare" {}

--- a/erun-docs/docs/cli/cloud.md
+++ b/erun-docs/docs/cli/cloud.md
@@ -4,12 +4,13 @@ title: erun cloud
 
 # `erun cloud`
 
-Set up and manage **cloud provider aliases** — the AWS credentials and OIDC issuer that managed [cloud contexts](/cli/context) and remote environments use. A cloud alias is named `<user>+<account>@aws` and is stored in your root ERun config.
+Set up and manage **cloud provider aliases** — the cloud credentials that managed [cloud contexts](/cli/context) and remote environments use. AWS aliases carry an IAM Identity Center profile and the OIDC issuer the deployed ERun APIs trust; Cloudflare aliases carry a delegated, account-scoped API token. An AWS alias is named `<user>+<account>@aws`; a Cloudflare alias is named `<token-name>+<account>@cloudflare`. Aliases are stored in your root ERun config — except the Cloudflare token itself, which is held in a local secret store referenced from config (never written into `erun-config.yaml`).
 
 ## Synopsis
 
 ```
 erun cloud init aws [flags]
+erun cloud init cloudflare [flags]
 erun cloud login [flags]
 erun cloud oidc [flags]
 erun cloud set TENANT ENVIRONMENT --alias <alias>
@@ -32,24 +33,38 @@ Registers an AWS IAM Identity Center (SSO) profile and saves it as a cloud provi
 
 Omitted flags are prompted for interactively.
 
+### `cloud init cloudflare`
+
+Verifies a delegated, account-scoped Cloudflare API token and saves it as a cloud provider alias. The token is one you minted in the Cloudflare dashboard with **account-level `Zone:Edit` + `DNS:Edit`** scope. ERun checks the token against the Cloudflare API, stores it in a **local secret store** referenced from your config (never written into `erun-config.yaml`), and saves the alias `<token-name>+<account>@cloudflare`. There is no browser login and no OIDC issuer — Cloudflare authenticates with the token directly.
+
+| Flag | Description |
+|---|---|
+| `--account-id` | Cloudflare account ID the token belongs to. |
+| `--token-name` | Label for the scoped API token (becomes part of the alias). |
+| `--api-token` | The scoped API token value. Omit it to be prompted with a masked input; it is never echoed or written to config. |
+
+Omitted flags are prompted for interactively (the token prompt is masked).
+
 ### `cloud login`
 
-Refreshes the AWS SSO session for an alias (`aws sso login`). Only touches the local SSO token cache. `--alias` selects the alias (prompted if omitted; **required** with `--dry-run`).
+Refreshes the credential for an alias. For an AWS alias this runs `aws sso login` and only touches the local SSO token cache; for a Cloudflare alias it re-verifies the stored token against the Cloudflare API. `--alias` selects the alias (prompted if omitted; **required** with `--dry-run`).
 
 ### `cloud oidc`
 
-Re-derives and saves the OIDC issuer for an alias by minting a short-lived AWS web-identity token and reading its issuer. `--alias` selects it; `--audience` sets the token audience (default `erun-api`).
+Re-derives and saves the OIDC issuer for an **AWS** alias by minting a short-lived AWS web-identity token and reading its issuer. `--alias` selects it; `--audience` sets the token audience (default `erun-api`). Cloudflare aliases have no OIDC issuer, so this command rejects them.
 
 ### `cloud set`
 
-Assigns an alias to a specific environment (local config only, no network). `TENANT` and `ENVIRONMENT` are required; `--alias` names the alias to assign. For a remote environment this also marks it cloud-managed.
+Assigns an alias to a specific environment (local config only, no network). `TENANT` and `ENVIRONMENT` are required; `--alias` names the alias to assign. The command routes the alias by its provider type, so an environment can carry **one AWS alias and one Cloudflare alias at the same time** — assigning a Cloudflare alias does not displace an AWS one. For a remote environment this also marks it cloud-managed.
 
 ## Examples
 
 ```bash
 erun cloud init aws --dry-run     # preview the AWS calls and writes
+erun cloud init cloudflare --account-id 0a1b2c3d --token-name dns-edit --api-token <token>
 erun cloud login --alias me+123456789012@aws
 erun cloud set my-tenant prod --alias me+123456789012@aws
+erun cloud set my-tenant prod --alias dns-edit+0a1b2c3d@cloudflare   # coexists with the AWS alias
 ```
 
 ## Error behaviour
@@ -58,7 +73,10 @@ erun cloud set my-tenant prod --alias me+123456789012@aws
 |---|---|
 | Required SSO field missing (non-interactive). | Aborts before any AWS call or file write. |
 | SSO login / token mint fails. | Surfaces the AWS error; no alias is saved. |
+| Cloudflare account ID, token name, or token missing (non-interactive). | Aborts before contacting Cloudflare; no alias is saved. |
+| Cloudflare rejects the token (`init`/`login`). | Surfaces the Cloudflare error; the alias is not saved (init) and the token reads as expired (login). |
+| `cloud oidc` against a Cloudflare alias. | Errors that the alias is Cloudflare and does not use OIDC web-identity federation. |
 | Alias not configured (`login`/`oidc`/`set`). | Errors with "cloud provider alias … is not configured". |
 | `--dry-run` without `--alias` on `login`. | Errors asking for an explicit `--alias`. |
 
-Only AWS is supported today; any other provider is rejected before side effects.
+AWS and Cloudflare are supported today; any other provider is rejected before side effects.

--- a/erun-docs/docs/concepts/cloud-contexts.md
+++ b/erun-docs/docs/concepts/cloud-contexts.md
@@ -39,3 +39,7 @@ For the exact eligibility predicate, default thresholds, and working-hours seman
 ## Configuring
 
 You create a cloud context with [`erun context init`](/cli/context), which provisions the VM and installs k3s; ERun manages its lifecycle from there. The one-time AWS prerequisites (registering a provider alias, permissions) are covered in [Cloud setup](/deployment/cloud-setup). Once it exists, environments reference it by its kubeconfig context, and `erun cloud set` ties an environment to the provider alias.
+
+## Cloud contexts are AWS-only; Cloudflare is context-less
+
+A cloud context is always an AWS EC2 instance running k3s — that's the only kind of VM ERun provisions and manages today. [Cloudflare aliases](/deployment/cloud-setup#cloudflare-aliases-dns-and-zone-management) are a different thing entirely: they have no VM, no `start` / `stop`, and no idle-stop, because there is nothing to bill around the clock. A Cloudflare alias just hands a scoped API token to an environment's runtime pod for DNS and zone work, so it is **context-less** — you attach it to an environment with `erun cloud set`, but it never appears in `erun context list`. An environment can carry both at once: an AWS alias backing its managed cloud context, and a Cloudflare alias for DNS.

--- a/erun-docs/docs/deployment/cloud-setup.md
+++ b/erun-docs/docs/deployment/cloud-setup.md
@@ -76,3 +76,23 @@ erun init my-tenant rihards-dev --type=remote-agent --kubernetes-context my-exis
 ```
 
 ERun deploys into it exactly the same way, but doesn't manage its lifecycle — there's no `erun context start` / `stop` / idle-stop for a cluster ERun didn't provision.
+
+## Cloudflare aliases (DNS and zone management)
+
+Cloudflare support is a **separate alias type**, not a managed cloud context. There is no VM to provision and no lifecycle to manage — a Cloudflare alias simply delivers a delegated, account-scoped API token into an environment's runtime pod so in-pod tooling (such as Terraform) can manage Cloudflare DNS and zones. It is independent of the AWS path above: an environment can hold an AWS alias and a Cloudflare alias at the same time.
+
+The token is **delegated and account-scoped** — you mint it once in the Cloudflare dashboard with account-level `Zone:Edit` + `DNS:Edit`, and ERun never asks for your dashboard password or a global key. Register it as an alias:
+
+```bash
+erun cloud init cloudflare --account-id 0a1b2c3d --token-name dns-edit --api-token <token>
+```
+
+ERun verifies the token against the Cloudflare API, then stores it in a local secret store referenced from your config — the raw token is **never written into `erun-config.yaml`**. The alias is named `<token-name>+<account>@cloudflare`. See [`erun cloud`](/cli/cloud).
+
+Attach it to an environment the same way you attach an AWS alias — and because aliases are routed by provider type, this **coexists with** any AWS alias the environment already carries:
+
+```bash
+erun cloud set my-tenant rihards-dev --alias dns-edit+0a1b2c3d@cloudflare
+```
+
+When that environment's runtime pod comes up, ERun injects the token as `CLOUDFLARE_API_TOKEN` and the account as `CLOUDFLARE_ACCOUNT_ID`. The in-pod Terraform Cloudflare provider reads both natively, so an Agent can manage DNS without ever handling the credential itself.

--- a/erun-docs/docs/reference/configuration.md
+++ b/erun-docs/docs/reference/configuration.md
@@ -24,7 +24,7 @@ Global defaults that apply across all tenants.
 | Field | Type | Used by | Effect |
 |---|---|---|---|
 | `default_tenant` | string | `erun` (no args), `erun open`, `erun list` | Tenant used when no tenant argument is supplied. |
-| `cloudproviders[]` | list | `erun init`, `erun open`, `erun cloud` | Known cloud provider identities (alias, provider, account, profile, SSO/OIDC settings). Each cloud-bound env references one by alias. |
+| `cloudproviders[]` | list | `erun init`, `erun open`, `erun cloud` | Known cloud provider identities (alias, provider, account, profile, SSO/OIDC settings). `provider` is `aws` or `cloudflare`. AWS entries carry the SSO profile and OIDC issuer; Cloudflare entries carry an account ID and a token reference into the local secret store (the scoped API token itself is never stored in this file). Each cloud-bound env references entries by alias. |
 | `cloudcontexts[]` | list | `erun open`, `erun deploy`, `erun cloud` | Known managed cloud clusters. Each binds a cluster to a provider, region, and instance type/size. |
 | `runtimeregistry.namespace` | string | `erun version`, runtime image pulls | Overrides where ERun looks for `erun-devops` and related runtime images. Useful for internal mirrors (Harbor, ECR, Artifactory). |
 | `runtimeregistry.repository` | string | same as above | Overrides the repository name in the namespace. |
@@ -55,7 +55,8 @@ One per environment. This is the most-edited file.
 | `repopath` | string | (legacy, read-only) | Removed struct field. A `repopath:` in an older config is migrated into `localRepoPath` on read and dropped on the next save; new configs only carry `localRepoPath`. ([Migration done.](#planned-changes)) |
 | `kubernetescontext` | string | `erun open`, `erun deploy`, `erun list` | Kubernetes context to deploy/open against. Special value `in-cluster` is set inside the runtime pod. |
 | `containerregistries` | list | `erun build`, `erun push`, `erun deploy`, build image tag resolution | Per-env marked registry list, set for `remote-agent`/`runtime` envs whose project config is not on the local machine (`local-agent` envs resolve the list from the project's `.erun/config.yaml` instead). Each entry is `{registry, roles}` where roles ⊆ `build`/`from`/`to`/`deploy`. See [Container registries](#container-registries). |
-| `cloudprovideralias` | string | `erun open`, `erun deploy`, idle-stop, audit labels | Which cloud provider identity backs this env. Resolves to the `cloudproviders[]` entry. |
+| `cloudprovideralias` | string | `erun open`, `erun deploy`, idle-stop, audit labels | Which AWS cloud provider identity backs this env. Resolves to a `cloudproviders[]` entry. |
+| `cloudprovideraliases` | map (provider → alias) | `erun open`, `erun deploy` | Additional cloud aliases attached to this env, keyed by provider type (e.g. `cloudflare`). AWS stays in the scalar `cloudprovideralias` above for backward compatibility; non-AWS providers live here. An env holds at most one alias per provider type, so a runtime pod can receive both an AWS identity and a Cloudflare token at once. A Cloudflare alias injects `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` for in-pod tooling. |
 | `managedcloud` | bool | helm chart (`ERUN_CLOUD_ENVIRONMENT`) | When true, marks the env as running on a managed cloud context (enables idle-stop, cloud-credential refresh, etc.). |
 | `runtimeversion` | string | `erun open`, `erun deploy`, chart appVersion | Pins the version of the runtime image used by this env. |
 | `runtimeregistry` | string | `erun open`, `erun deploy` | Overrides the registry the runtime image is pulled from (per-env). |

--- a/erun-integration/cloud_test.go
+++ b/erun-integration/cloud_test.go
@@ -102,6 +102,51 @@ func TestCloud(t *testing.T) {
 		golden.Equal(t, "cloud/init_aws_help", normalize.Apply(result.Combined))
 	})
 
+	t.Run("init_cloudflare_help", func(t *testing.T) {
+		setup := env.New(t)
+		result := erun.Run(t, []string{"cloud", "init", "cloudflare", "--help"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "cloud/init_cloudflare_help", normalize.Apply(result.Combined))
+	})
+
+	t.Run("init_cloudflare_dry_run_redacts_token_and_traces_alias_write", func(t *testing.T) {
+		// Exercises cloud.go runCloudInitCloudflareCommand and
+		// eruncommon.InitCloudflareCloudProvider in --dry-run: the command
+		// must trace the cloudflare init line with the api token REDACTED
+		// (never the literal value), trace the tokens/verify GET (which
+		// short-circuits in dry-run without touching the network), and trace
+		// the secret-store-ref + alias write — then print the dry-run summary
+		// without persisting anything. The redaction contract is the point of
+		// this scenario, so it is asserted directly against the un-normalized
+		// capture in addition to the snapshot.
+		setup := env.New(t)
+		args := []string{
+			"cloud", "init", "cloudflare",
+			"--account-id", "cf-acct-123",
+			"--token-name", "ci-token",
+			"--api-token", "dummy-token",
+			"--dry-run",
+		}
+		result := erun.Run(t, args, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		// The literal token must never reach the trace; the command prints
+		// "api-token=<redacted>" instead. Normalization does not mask this
+		// value, so a substring guard on the raw capture is the only way to
+		// lock the redaction contract (see erun-integration/AGENTS.md
+		// § "Whole-output snapshots vs targeted substring assertions" case 1).
+		if strings.Contains(result.Combined, "dummy-token") {
+			t.Fatalf("expected the api token to be redacted, but found the literal value in output:\n%s", result.Combined)
+		}
+		if !strings.Contains(result.Combined, "api-token=<redacted>") {
+			t.Fatalf("expected redacted api-token marker in output, got:\n%s", result.Combined)
+		}
+		golden.Equal(t, "cloud/init_cloudflare_dry_run", normalize.Apply(result.Combined))
+	})
+
 	t.Run("init_aws_dry_run_traces_sso_setup_and_oidc_persistence", func(t *testing.T) {
 		// Exercises cloud.go runCloudInitAWSCommand: --dry-run must trace
 		// the aws configure sso plan, the sso login command, the sts

--- a/erun-integration/testdata/cloud/init_cloudflare_dry_run.txt
+++ b/erun-integration/testdata/cloud/init_cloudflare_dry_run.txt
@@ -1,0 +1,7 @@
+Dry run: Cloudflare cloud provider initialization planned.
+audit: erun cloud init cloudflare --account-id cf-acct-123 --api-token <redacted> --dry-run --token-name <redacted>
+cloud init cloudflare: account-id=cf-acct-123 token-name=ci-token api-token=<redacted>
+cloud init cloudflare: verifying scoped api token
+GET https://api.cloudflare.com/client/v4/user/tokens/verify
+store cloudflare api token at ref cloudflare/ci-token+cf-acct-123@cloudflare
+write cloud provider ci-token+cf-acct-123@cloudflare

--- a/erun-integration/testdata/cloud/init_cloudflare_help.txt
+++ b/erun-integration/testdata/cloud/init_cloudflare_help.txt
@@ -1,0 +1,21 @@
+Set up a Cloudflare cloud provider alias.
+
+Verifies a delegated, account-scoped Cloudflare API token (account-level Zone:Edit + DNS:Edit) against the Cloudflare API and stores it on this machine as a cloud provider alias. The token is held in a local secret store referenced from erun config — it is never written into erun-config.yaml. Environments that attach this alias receive the token as CLOUDFLARE_API_TOKEN so in-pod tooling (e.g. terraform) authenticates as it.
+
+Usage:
+  erun cloud init cloudflare [flags]
+
+Examples:
+  erun cloud init cloudflare --account-id <account> --token-name <label> --api-token <token>
+
+Flags:
+      --account-id string   Cloudflare account ID the token belongs to
+      --api-token string    Cloudflare scoped API token value (account-level Zone:Edit + DNS:Edit)
+      --dry-run             Resolve and trace mutating actions without executing them.
+  -h, --help                help for cloudflare
+      --token-name string   Label for the scoped API token
+
+Global Flags:
+      --output string   Result format: text (default, human stream) or json (structured result on stdout for orchestrators). (default "text")
+      --time            Print the elapsed runtime after the command finishes.
+  -v, --verbose count   Increase verbosity: -v streams external tool output, -vv adds erun command traces.

--- a/erun-integration/testdata/cloud/init_help.txt
+++ b/erun-integration/testdata/cloud/init_help.txt
@@ -5,6 +5,7 @@ Usage:
 
 Available Commands:
   aws         Set up an AWS cloud provider alias
+  cloudflare  Set up a Cloudflare cloud provider alias
 
 Flags:
   -h, --help   help for init

--- a/erun-mcp/cloud.go
+++ b/erun-mcp/cloud.go
@@ -24,6 +24,14 @@ type CloudInitAWSInput struct {
 	Verbosity     int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
 }
 
+type CloudInitCloudflareInput struct {
+	AccountID string `json:"accountId" jsonschema:"Cloudflare account ID the scoped API token belongs to"`
+	TokenName string `json:"tokenName" jsonschema:"label for the scoped API token"`
+	APIToken  string `json:"apiToken" jsonschema:"Cloudflare scoped API token value (account-level Zone:Edit + DNS:Edit); held in the local secret store, never written to erun-config.yaml"`
+	Preview   bool   `json:"preview,omitempty" jsonschema:"when true, return the planned operation without verifying the token or saving config"`
+	Verbosity int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+}
+
 type CloudLoginInput struct {
 	Alias     string `json:"alias" jsonschema:"configured cloud provider alias to login"`
 	Preview   bool   `json:"preview,omitempty" jsonschema:"when true, return the planned operation without executing login"`
@@ -67,7 +75,7 @@ type CloudSetResult struct {
 
 func cloudListTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, CloudListInput) (*mcp.CallToolResult, CloudListResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input CloudListInput) (*mcp.CallToolResult, CloudListResult, error) {
-		statuses, err := eruncommon.ListCloudProviderStatuses(runtime.Store, eruncommon.CloudDependencies{})
+		statuses, err := eruncommon.ListCloudProviderStatuses(runtime.Store, cloudDependencies())
 		if err != nil {
 			return nil, CloudListResult{}, err
 		}
@@ -111,6 +119,32 @@ func cloudInitAWSTool(runtime RuntimeConfig) func(context.Context, *mcp.CallTool
 	}
 }
 
+func cloudInitCloudflareTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, CloudInitCloudflareInput) (*mcp.CallToolResult, CloudActionResult, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input CloudInitCloudflareInput) (*mcp.CallToolResult, CloudActionResult, error) {
+		traceOutput := strings.Builder{}
+		ctx := runtimeCallContext(input.Preview, input.Verbosity, nil, &traceOutput, &traceOutput)
+		params := eruncommon.InitCloudflareCloudProviderParams{
+			AccountID: input.AccountID,
+			TokenName: input.TokenName,
+			APIToken:  input.APIToken,
+		}
+		if input.Preview {
+			plan := []string{
+				"GET https://api.cloudflare.com/client/v4/user/tokens/verify (verify scoped API token)",
+				"store cloudflare api token in the local secret store",
+				"save cloud provider alias <token-name>+<account-id>@cloudflare",
+			}
+			return nil, CloudActionResult{Preview: true, Plan: plan}, nil
+		}
+		provider, err := eruncommon.InitCloudflareCloudProvider(ctx, runtime.Store, params, cloudDependencies())
+		if err != nil {
+			return nil, CloudActionResult{}, err
+		}
+		status := eruncommon.CloudProviderTokenStatus(provider, cloudDependencies())
+		return nil, CloudActionResult{Alias: provider.Alias, Provider: status, Trace: normalizeTraceLines(traceOutput.String())}, nil
+	}
+}
+
 func cloudLoginTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, CloudLoginInput) (*mcp.CallToolResult, CloudActionResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input CloudLoginInput) (*mcp.CallToolResult, CloudActionResult, error) {
 		alias := strings.TrimSpace(input.Alias)
@@ -122,7 +156,7 @@ func cloudLoginTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRe
 		if input.Preview {
 			return nil, CloudActionResult{Preview: true, Alias: alias, Plan: []string{"check cloud provider token status", "run provider login if token is expired"}}, nil
 		}
-		status, err := eruncommon.LoginCloudProviderAlias(ctx, runtime.Store, eruncommon.CloudLoginParams{Alias: alias}, eruncommon.CloudDependencies{})
+		status, err := eruncommon.LoginCloudProviderAlias(ctx, runtime.Store, eruncommon.CloudLoginParams{Alias: alias}, cloudDependencies())
 		if err != nil {
 			return nil, CloudActionResult{}, err
 		}
@@ -184,6 +218,18 @@ func cloudSetTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequ
 			Trace:       normalizeTraceLines(traceOutput.String()),
 		}, nil
 	}
+}
+
+// cloudDependencies builds the shared cloud dependency bag with the default
+// file-backed secret store wired in, so Cloudflare token operations can persist
+// and read the scoped token. AWS runners default inside erun-common. A missing
+// config dir leaves the store nil; Cloudflare operations then fail clearly.
+func cloudDependencies() eruncommon.CloudDependencies {
+	deps := eruncommon.CloudDependencies{}
+	if store, err := eruncommon.DefaultCloudSecretStore(); err == nil {
+		deps.CloudSecretStore = store
+	}
+	return deps
 }
 
 func cloudAudienceForPlan(audience string) string {

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -197,6 +197,10 @@ func registerCloudTools(server *mcp.Server, runtime RuntimeConfig) {
 		Description: "Initialize an AWS SSO cloud provider alias in root ERun config, with preview support",
 	}, cloudInitAWSTool(runtime))
 	mcp.AddTool(server, &mcp.Tool{
+		Name:        "cloud_init_cloudflare",
+		Description: "Initialize a Cloudflare cloud provider alias from a delegated, account-scoped API token (account-level Zone:Edit + DNS:Edit). The token is verified against the Cloudflare API and held in a local secret store referenced from erun config, never written into erun-config.yaml; environments that attach the alias receive it as CLOUDFLARE_API_TOKEN. Supports preview.",
+	}, cloudInitCloudflareTool(runtime))
+	mcp.AddTool(server, &mcp.Tool{
 		Name:        "cloud_login",
 		Description: "Login to a configured cloud provider alias, with preview support",
 	}, cloudLoginTool(runtime))

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -166,7 +166,7 @@ func TestHTTPHandlerExposesVersionTool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTools failed: %v", err)
 	}
-	if len(tools.Tools) != 31 {
+	if len(tools.Tools) != 32 {
 		t.Fatalf("unexpected tools: %+v", tools.Tools)
 	}
 

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -150,6 +150,7 @@ func (a *App) emit(name string, args ...any) {
 
 func NewApp(deps erunUIDeps) *App {
 	deps = withDefaultCoreDeps(deps)
+	deps = withDefaultCloudDeps(deps)
 	deps = withDefaultRuntimeDeps(deps)
 	deps = withDefaultUIDeps(deps)
 	app := &App{
@@ -195,6 +196,25 @@ func withDefaultCoreDeps(deps erunUIDeps) erunUIDeps {
 	}
 	if deps.deleteNamespace == nil {
 		deps.deleteNamespace = eruncommon.DeleteKubernetesNamespace
+	}
+	return deps
+}
+
+// withDefaultCloudDeps wires the cloud-provider dependency defaults the
+// desktop needs for cloud-alias operations. erun-common fills the AWS hooks
+// and VerifyCloudflareToken itself via normalizeCloudDependencies, but the
+// off-config CloudSecretStore that Cloudflare init/status/export require has
+// no usable zero value — it must be backed by a real directory. Wire the
+// file-backed default rooted beside erun-config.yaml so Cloudflare token
+// persistence works (today the desktop passes empty deps, so Cloudflare ops
+// would fail with "cloud secret store is not configured"). A resolution
+// failure leaves the store nil; erun-common then surfaces a clear error on
+// the Cloudflare path rather than touching AWS-only flows.
+func withDefaultCloudDeps(deps erunUIDeps) erunUIDeps {
+	if deps.cloudDeps.CloudSecretStore == nil {
+		if store, err := eruncommon.DefaultCloudSecretStore(); err == nil {
+			deps.cloudDeps.CloudSecretStore = store
+		}
 	}
 	return deps
 }

--- a/erun-ui/cloud_credentials_refresher.go
+++ b/erun-ui/cloud_credentials_refresher.go
@@ -91,9 +91,18 @@ func (a *App) resolveCloudCredentialsRefreshTarget(selection uiSelection) (strin
 	if !envConfig.RemoteHostCredentials || !envConfig.RemoteWorktree() {
 		return "", eruncommon.OpenResult{}, false
 	}
+	// CloudProviderAlias is the legacy scalar that always holds the env's AWS
+	// alias; non-AWS aliases (Cloudflare) live in EnvConfig.CloudProviderAliases
+	// and never reach this scalar. So a Cloudflare-attached env that carries no
+	// AWS alias reads as "" here and the refresher no-ops — exactly the desired
+	// behavior. Cloudflare credentials are delivered at deploy time via a chart
+	// Secret minted by the erun binary, not pushed by this host-credential timer.
 	if strings.TrimSpace(envConfig.CloudProviderAlias) == "" {
 		return "", eruncommon.OpenResult{}, false
 	}
+	// Defense in depth: even if a Cloudflare alias somehow landed in the scalar,
+	// the strict provider-type gate keeps the AWS-only credential push from
+	// trying to export temporary credentials from a token-based provider.
 	provider, err := eruncommon.ResolveCloudProvider(a.deps.store, envConfig.CloudProviderAlias)
 	if err != nil || provider.Provider != eruncommon.CloudProviderAWS {
 		return "", eruncommon.OpenResult{}, false

--- a/erun-ui/config_handlers.go
+++ b/erun-ui/config_handlers.go
@@ -14,7 +14,7 @@ func (a *App) LoadERunConfig() (uiERunConfig, error) {
 	if err != nil {
 		return uiERunConfig{}, err
 	}
-	ui := erunConfigToUI(config)
+	ui := a.erunConfigToUI(config)
 	statuses, err := eruncommon.RefreshCloudContextStatuses(eruncommon.Context{}, a.deps.store, a.deps.cloudContextDeps)
 	if err != nil {
 		return uiERunConfig{}, err
@@ -39,7 +39,7 @@ func (a *App) SaveERunConfig(config uiERunConfig) (uiERunConfig, error) {
 	if err := a.deps.store.SaveERunConfig(updated); err != nil {
 		return uiERunConfig{}, err
 	}
-	return erunConfigToUI(updated), nil
+	return a.erunConfigToUI(updated), nil
 }
 
 func (a *App) LoadCloudProviderStatuses() ([]uiCloudProviderStatus, error) {
@@ -187,6 +187,33 @@ func (a *App) InitAWSCloudProvider(input uiAWSCloudAliasInput) (uiCloudProviderS
 	return cloudProviderStatusToUI(eruncommon.CloudProviderTokenStatus(provider, a.deps.cloudDeps)), nil
 }
 
+// InitCloudflareCloudProvider adds a Cloudflare cloud alias from the desktop's
+// non-interactive "add token" form. Unlike `cloud init aws` (an SSO PTY
+// session), Cloudflare init takes the account ID, a token label, and the
+// scoped API token as explicit inputs, verifies the token against the
+// Cloudflare API, stores it off-config in the CloudSecretStore, and saves the
+// alias. The raw token is never echoed back to the UI.
+func (a *App) InitCloudflareCloudProvider(input uiCloudflareCloudAliasInput) (uiCloudProviderStatus, error) {
+	provider, err := eruncommon.InitCloudflareCloudProvider(eruncommon.Context{}, a.deps.store, eruncommon.InitCloudflareCloudProviderParams{
+		AccountID: strings.TrimSpace(input.AccountID),
+		TokenName: strings.TrimSpace(input.TokenName),
+		APIToken:  input.APIToken,
+	}, a.deps.cloudDeps)
+	if err != nil {
+		return uiCloudProviderStatus{}, err
+	}
+	return cloudProviderStatusToUI(eruncommon.CloudProviderTokenStatus(provider, a.deps.cloudDeps)), nil
+}
+
+// SaveCloudflareCloudProviderAlias re-verifies a supplied Cloudflare token and
+// re-saves the alias (the Cloudflare analogue of SaveAWSCloudProviderAlias: it
+// re-runs init so a re-entered token replaces the stored credential). The flow
+// is identical to add; the alias derived from account ID + token label is
+// stable, so re-saving updates the credential in place.
+func (a *App) SaveCloudflareCloudProviderAlias(input uiCloudflareCloudAliasInput) (uiCloudProviderStatus, error) {
+	return a.InitCloudflareCloudProvider(input)
+}
+
 func (a *App) LoginCloudProvider(alias string) (uiCloudProviderStatus, error) {
 	status, err := eruncommon.LoginCloudProviderAlias(eruncommon.Context{}, a.deps.store, eruncommon.CloudLoginParams{Alias: alias}, a.deps.cloudDeps)
 	if err != nil {
@@ -261,10 +288,10 @@ func (a *App) SaveTenantConfig(config uiTenantConfig) (uiTenantConfig, error) {
 	return a.tenantConfigToUI(updated, tenant), nil
 }
 
-func erunConfigToUI(config eruncommon.ERunConfig) uiERunConfig {
+func (a *App) erunConfigToUI(config eruncommon.ERunConfig) uiERunConfig {
 	return uiERunConfig{
 		DefaultTenant:  strings.TrimSpace(config.DefaultTenant),
-		CloudProviders: cloudProviderStatusesToUI(statusesForCloudProviders(config.CloudProviders)),
+		CloudProviders: cloudProviderStatusesToUI(a.statusesForCloudProviders(config.CloudProviders)),
 		CloudContexts:  cloudContextStatusesToUI(statusesForCloudContexts(config.CloudContexts)),
 	}
 }
@@ -293,10 +320,10 @@ func tenantConfigFromUI(config uiTenantConfig, existing eruncommon.TenantConfig)
 	return eruncommon.NormalizeTenantConfig(existing)
 }
 
-func statusesForCloudProviders(providers []eruncommon.CloudProviderConfig) []eruncommon.CloudProviderStatus {
+func (a *App) statusesForCloudProviders(providers []eruncommon.CloudProviderConfig) []eruncommon.CloudProviderStatus {
 	statuses := make([]eruncommon.CloudProviderStatus, 0, len(providers))
 	for _, provider := range providers {
-		statuses = append(statuses, eruncommon.CloudProviderTokenStatus(provider, eruncommon.CloudDependencies{}))
+		statuses = append(statuses, eruncommon.CloudProviderTokenStatus(provider, a.deps.cloudDeps))
 	}
 	return statuses
 }

--- a/erun-ui/environment_config.go
+++ b/erun-ui/environment_config.go
@@ -296,6 +296,7 @@ func (a *App) environmentConfigToUI(tenant string, config eruncommon.EnvConfig, 
 		ContainerRegistries:  registries,
 		CloudProviderAlias:   strings.TrimSpace(config.CloudProviderAlias),
 		CloudProviderAliases: environmentCloudProviderAliases(a.deps.store, config.CloudProviderAlias),
+		CloudAliasSlots:      environmentCloudAliasSlots(a.deps.store, config),
 		RuntimeVersion:       strings.TrimSpace(config.RuntimeVersion),
 		RuntimePod:           runtimePodConfigToUI(config.RuntimePod),
 		SSHD: uiSSHDConfig{
@@ -443,6 +444,75 @@ func environmentName(fallbackName string, config eruncommon.EnvConfig) string {
 	return strings.TrimSpace(fallbackName)
 }
 
+// environmentCloudProviderTypes is the order cloud-alias slots render in: AWS
+// first (the legacy primary), then Cloudflare. Adding a provider type to the
+// list gives it its own env selector and sidebar login row.
+var environmentCloudProviderTypes = []string{
+	eruncommon.CloudProviderAWS,
+	eruncommon.CloudProviderCloudflare,
+}
+
+// environmentCloudAliasSlots builds the per-provider-type cloud-alias view for
+// one env: for each known provider type, the alias currently attached to the
+// env for that type (from EnvConfig.ResolvedCloudAliases) plus the configured
+// aliases of that type the operator can pick from. A type with no configured
+// aliases and nothing attached is omitted so the env settings don't show an
+// empty Cloudflare selector before any Cloudflare token exists. A currently
+// attached alias whose provider config was deleted is still listed as an option
+// so the operator can see and clear it (recognition over recall).
+func environmentCloudAliasSlots(store eruncommon.CloudReadStore, config eruncommon.EnvConfig) []uiEnvironmentCloudAlias {
+	optionsByType := configuredCloudAliasesByType(store)
+	attached := config.ResolvedCloudAliases()
+	slots := make([]uiEnvironmentCloudAlias, 0, len(environmentCloudProviderTypes))
+	for _, providerType := range environmentCloudProviderTypes {
+		options := append([]string(nil), optionsByType[providerType]...)
+		current := strings.TrimSpace(attached[providerType])
+		if current != "" && !cloudAliasListContains(options, current) {
+			options = append([]string{current}, options...)
+		}
+		if current == "" && len(options) == 0 {
+			continue
+		}
+		slots = append(slots, uiEnvironmentCloudAlias{
+			Provider: providerType,
+			Alias:    current,
+			Options:  options,
+		})
+	}
+	return slots
+}
+
+// configuredCloudAliasesByType groups every configured cloud provider alias by
+// its provider type so each env slot can offer only the aliases that match.
+func configuredCloudAliasesByType(store eruncommon.CloudReadStore) map[string][]string {
+	grouped := make(map[string][]string)
+	providers, err := eruncommon.ListCloudProviders(store)
+	if err != nil {
+		return grouped
+	}
+	for _, provider := range providers {
+		alias := strings.TrimSpace(provider.Alias)
+		providerType := strings.ToLower(strings.TrimSpace(provider.Provider))
+		if alias == "" || providerType == "" {
+			continue
+		}
+		if cloudAliasListContains(grouped[providerType], alias) {
+			continue
+		}
+		grouped[providerType] = append(grouped[providerType], alias)
+	}
+	return grouped
+}
+
+func cloudAliasListContains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
 func environmentCloudProviderAliases(store eruncommon.CloudReadStore, current string) []string {
 	providers, err := eruncommon.ListCloudProviders(store)
 	if err != nil {
@@ -494,7 +564,7 @@ func canConnectLocalTCP(port int) bool {
 
 func environmentConfigFromUI(config uiEnvironmentConfig, existing eruncommon.EnvConfig) eruncommon.EnvConfig {
 	existing.Name = strings.TrimSpace(config.Name)
-	existing.CloudProviderAlias = strings.TrimSpace(config.CloudProviderAlias)
+	applyEnvironmentCloudAliasSlots(&existing, config)
 	// ContainerRegistries are written by SaveEnvironmentConfig, which routes the
 	// marked list to project config (.erun/config.yaml) for local-agent envs and
 	// to the env config for remote/runtime envs.
@@ -522,6 +592,39 @@ func environmentConfigFromUI(config uiEnvironmentConfig, existing eruncommon.Env
 		existing.UpgradeChannel = config.UpgradeChannel
 	}
 	return existing
+}
+
+// applyEnvironmentCloudAliasSlots writes the edited per-provider-type cloud
+// aliases back onto the env config. Each slot routes by its provider type with
+// the same semantics as erun-common's SetEnvironmentCloudProviderAlias: the AWS
+// alias stays in the legacy CloudProviderAlias scalar (so every existing AWS
+// reader — saveRemoteCloudAlias, linkedCloudContext, the credential refresher —
+// is byte-for-byte unchanged), and every other type lives in the per-type
+// CloudProviderAliases map. An empty slot value clears that type's attachment
+// (the "— None —" option). When the UI sends no slots (older callers, the
+// AWS-only single-selector path), the legacy scalar is applied directly so
+// behavior is preserved.
+func applyEnvironmentCloudAliasSlots(existing *eruncommon.EnvConfig, config uiEnvironmentConfig) {
+	if len(config.CloudAliasSlots) == 0 {
+		existing.CloudProviderAlias = strings.TrimSpace(config.CloudProviderAlias)
+		return
+	}
+	for _, slot := range config.CloudAliasSlots {
+		providerType := strings.ToLower(strings.TrimSpace(slot.Provider))
+		alias := strings.TrimSpace(slot.Alias)
+		if providerType == "" || providerType == eruncommon.CloudProviderAWS {
+			existing.CloudProviderAlias = alias
+			continue
+		}
+		if alias == "" {
+			delete(existing.CloudProviderAliases, providerType)
+			continue
+		}
+		if existing.CloudProviderAliases == nil {
+			existing.CloudProviderAliases = make(map[string]string)
+		}
+		existing.CloudProviderAliases[providerType] = alias
+	}
 }
 
 func claudeConfigToUI(config eruncommon.EnvironmentClaudeConfig) uiClaudeConfig {

--- a/erun-ui/frontend/src/app/api/cloudApi.ts
+++ b/erun-ui/frontend/src/app/api/cloudApi.ts
@@ -2,6 +2,7 @@ import type {
   UIAWSCloudAliasInput,
   UICloudContextInitInput,
   UICloudContextStatus,
+  UICloudflareCloudAliasInput,
   UICloudProviderBearerToken,
   UICloudProviderStatus,
 } from '@/types';
@@ -13,11 +14,13 @@ import {
   GetCloudProviderBearerToken,
   InitAWSCloudProvider,
   InitCloudContext,
+  InitCloudflareCloudProvider,
   LoadCloudContextStatuses,
   LoadCloudProviderStatuses,
   LoginCloudProvider,
   LogoutCloudProvider,
   SaveAWSCloudProviderAlias,
+  SaveCloudflareCloudProviderAlias,
   SetupCloudProviderOIDC,
   StartCloudContext,
   StopCloudContext,
@@ -122,6 +125,24 @@ export const cloudApi = wailsApi.injectEndpoints({
       ),
       invalidatesTags: ['CloudProviders'],
     }),
+    initCloudflareCloudProvider: builder.mutation<
+      UICloudProviderStatus,
+      UICloudflareCloudAliasInput
+    >({
+      queryFn: wailsQueryFn<UICloudflareCloudAliasInput, UICloudProviderStatus>((input) =>
+        InitCloudflareCloudProvider(input),
+      ),
+      invalidatesTags: ['CloudProviders'],
+    }),
+    saveCloudflareCloudProviderAlias: builder.mutation<
+      UICloudProviderStatus,
+      UICloudflareCloudAliasInput
+    >({
+      queryFn: wailsQueryFn<UICloudflareCloudAliasInput, UICloudProviderStatus>((input) =>
+        SaveCloudflareCloudProviderAlias(input),
+      ),
+      invalidatesTags: ['CloudProviders'],
+    }),
   }),
 });
 
@@ -140,4 +161,6 @@ export const {
   useSetupCloudProviderOIDCMutation,
   useInitAWSCloudProviderMutation,
   useSaveAWSCloudProviderAliasMutation,
+  useInitCloudflareCloudProviderMutation,
+  useSaveCloudflareCloudProviderAliasMutation,
 } = cloudApi;

--- a/erun-ui/frontend/src/app/cloudProviderThunks.ts
+++ b/erun-ui/frontend/src/app/cloudProviderThunks.ts
@@ -7,11 +7,12 @@ import { readError } from './errors';
 import { showNotification, showTerminalMessage } from './notificationThunks';
 import { setSidebarCloudAliasBusy } from './slices/sidebarSlice';
 import { setCloudProviders } from './slices/tenantsSlice';
-import type { AppThunk } from './store';
+import type { AppThunk, RootState } from './store';
 
-// cloudProviderThunks own the sidebar's primary-cloud-alias controls. The
-// busy/action flags it writes live on the sidebar slice; the thunks dispatch
-// the matching slice actions directly.
+// cloudProviderThunks own the sidebar's per-provider-type cloud-alias controls.
+// The busy/action flags it writes live on the sidebar slice keyed by alias, so
+// AWS and Cloudflare rows spin independently; the thunks dispatch the matching
+// slice actions directly.
 
 export const loginPrimaryCloudProvider =
   (alias: string): AppThunk<Promise<void>> =>
@@ -37,10 +38,10 @@ export const getPrimaryCloudProviderBearerToken =
   (alias: string): AppThunk<Promise<void>> =>
   async (dispatch, getState) => {
     alias = alias.trim();
-    if (!alias || getState().sidebar.sidebarCloudAliasBusy) {
+    if (!alias || aliasBusy(getState, alias)) {
       return;
     }
-    dispatch(setSidebarCloudAliasBusy({ busy: true, action: 'bearer' }));
+    dispatch(setSidebarCloudAliasBusy({ alias, busy: true, action: 'bearer' }));
     try {
       const result = await dispatch(
         cloudApi.endpoints.getCloudProviderBearerToken.initiate(alias),
@@ -49,7 +50,7 @@ export const getPrimaryCloudProviderBearerToken =
       dispatch(
         setCloudProviders(replaceCloudProvider(getState().tenants.cloudProviders, result.provider)),
       );
-      dispatch(setSidebarCloudAliasBusy({ busy: false, action: '' }));
+      dispatch(setSidebarCloudAliasBusy({ alias, busy: false, action: '' }));
       const issuer = result.issuer?.trim();
       dispatch(
         showTerminalMessage(
@@ -61,11 +62,15 @@ export const getPrimaryCloudProviderBearerToken =
       dispatch(showNotification('success', `Copied bearer token for ${result.alias}.`));
     } catch (error) {
       const message = readError(error);
-      dispatch(setSidebarCloudAliasBusy({ busy: false, action: '' }));
+      dispatch(setSidebarCloudAliasBusy({ alias, busy: false, action: '' }));
       dispatch(showTerminalMessage(message));
       dispatch(showNotification('error', message));
     }
   };
+
+function aliasBusy(getState: () => RootState, alias: string): boolean {
+  return Boolean(getState().sidebar.sidebarCloudAliasBusyByAlias[alias]);
+}
 
 const updatePrimaryCloudProvider =
   (
@@ -75,20 +80,20 @@ const updatePrimaryCloudProvider =
   ): AppThunk<Promise<void>> =>
   async (dispatch, getState) => {
     alias = alias.trim();
-    if (!alias || getState().sidebar.sidebarCloudAliasBusy) {
+    if (!alias || aliasBusy(getState, alias)) {
       return;
     }
-    dispatch(setSidebarCloudAliasBusy({ busy: true, action }));
+    dispatch(setSidebarCloudAliasBusy({ alias, busy: true, action }));
     try {
       const provider = (await run(alias)) as UICloudProviderStatus;
       dispatch(
         setCloudProviders(replaceCloudProvider(getState().tenants.cloudProviders, provider)),
       );
-      dispatch(setSidebarCloudAliasBusy({ busy: false, action: '' }));
+      dispatch(setSidebarCloudAliasBusy({ alias, busy: false, action: '' }));
       dispatch(showTerminalMessage(`${provider.alias}: ${provider.status}`));
     } catch (error) {
       const message = readError(error);
-      dispatch(setSidebarCloudAliasBusy({ busy: false, action: '' }));
+      dispatch(setSidebarCloudAliasBusy({ alias, busy: false, action: '' }));
       dispatch(showTerminalMessage(message));
       dispatch(showNotification('error', message));
     }

--- a/erun-ui/frontend/src/app/cloudflareProviderThunks.ts
+++ b/erun-ui/frontend/src/app/cloudflareProviderThunks.ts
@@ -1,0 +1,109 @@
+import type { UICloudflareCloudAliasInput } from '@/types';
+
+import { cloudApi } from './api/cloudApi';
+import { replaceCloudProvider } from './cloudContextState';
+import { readError } from './errors';
+import { showNotification, showTerminalMessage } from './notificationThunks';
+import { patchGlobalConfigDialog } from './slices/globalConfigDialogSlice';
+import { defaultCloudflareCloudAliasInput } from './state';
+import type { AppThunk } from './store';
+
+// cloudflareProviderThunks own the global-config dialog's non-interactive "add
+// Cloudflare token" flow. Unlike AWS (an SSO PTY session that takes over the
+// terminal), Cloudflare add is a masked form rendered inside the settings
+// dialog: collect account ID + token label + scoped token, verify the token,
+// store it off-config, and add the alias — no terminal.
+
+export const openCloudflareCloudInitForm = (): AppThunk => (dispatch, getState) => {
+  const dialog = getState().globalConfigDialog;
+  if (dialog.busy || dialog.configLoading) {
+    return;
+  }
+  dispatch(
+    patchGlobalConfigDialog({
+      cloudflareFormOpen: true,
+      cloudflareDraft: defaultCloudflareCloudAliasInput(),
+      error: '',
+    }),
+  );
+};
+
+export const closeCloudflareCloudInitForm = (): AppThunk => (dispatch, getState) => {
+  if (getState().globalConfigDialog.busy) {
+    return;
+  }
+  dispatch(
+    patchGlobalConfigDialog({
+      cloudflareFormOpen: false,
+      cloudflareDraft: defaultCloudflareCloudAliasInput(),
+      error: '',
+    }),
+  );
+};
+
+export const updateCloudflareDraft =
+  (values: Partial<UICloudflareCloudAliasInput>): AppThunk =>
+  (dispatch, getState) => {
+    const dialog = getState().globalConfigDialog;
+    if (dialog.busy || dialog.configLoading) {
+      return;
+    }
+    dispatch(
+      patchGlobalConfigDialog({
+        cloudflareDraft: { ...dialog.cloudflareDraft, ...values },
+        error: '',
+      }),
+    );
+  };
+
+// submitCloudflareCloudInit verifies the scoped token against Cloudflare,
+// stores it off-config, and adds the alias. On success the form closes, the
+// alias is merged into the dialog's provider list (so the new row appears with
+// its live status), and the masked token is dropped from client state.
+export const submitCloudflareCloudInit =
+  (): AppThunk<Promise<void>> => async (dispatch, getState) => {
+    const dialog = getState().globalConfigDialog;
+    if (dialog.busy || dialog.configLoading) {
+      return;
+    }
+    dispatch(
+      patchGlobalConfigDialog({
+        busy: true,
+        busyAction: 'cloud-provider-cloudflare-init',
+        busyTarget: '',
+        error: '',
+      }),
+    );
+    try {
+      const provider = await dispatch(
+        cloudApi.endpoints.initCloudflareCloudProvider.initiate(dialog.cloudflareDraft),
+      ).unwrap();
+      const currentConfig = getState().globalConfigDialog.config;
+      dispatch(
+        patchGlobalConfigDialog({
+          config: {
+            ...currentConfig,
+            cloudProviders: replaceCloudProvider(currentConfig.cloudProviders ?? [], provider),
+          },
+          cloudflareFormOpen: false,
+          cloudflareDraft: defaultCloudflareCloudAliasInput(),
+          busy: false,
+          busyAction: '',
+          busyTarget: '',
+          error: '',
+        }),
+      );
+      dispatch(showNotification('success', `Added Cloudflare token ${provider.alias}.`));
+    } catch (error) {
+      const message = readError(error);
+      dispatch(
+        patchGlobalConfigDialog({
+          busy: false,
+          busyAction: '',
+          busyTarget: '',
+          error: message,
+        }),
+      );
+      dispatch(showTerminalMessage(message));
+    }
+  };

--- a/erun-ui/frontend/src/app/globalConfigThunks.ts
+++ b/erun-ui/frontend/src/app/globalConfigThunks.ts
@@ -26,7 +26,11 @@ import { trackCloudInitSession } from './slices/sessionsSlice';
 import { setSessionId } from './slices/terminalSlice';
 import { setTerminalCopyOutput, setTerminalCopyStatus } from './slices/terminalStatusSlice';
 import type { GlobalConfigDialogState } from './state';
-import { defaultCloudContextInitInput, defaultGlobalConfigDialog } from './state';
+import {
+  defaultCloudContextInitInput,
+  defaultCloudflareCloudAliasInput,
+  defaultGlobalConfigDialog,
+} from './state';
 import type { AppDispatch, AppThunk, RootState } from './store';
 import { requireController } from './thunkExtra';
 
@@ -44,6 +48,8 @@ export const openGlobalConfigDialog = (): AppThunk => (dispatch) => {
         cloudContexts: [],
       },
       cloudContextDraft: defaultCloudContextInitInput(),
+      cloudflareDraft: defaultCloudflareCloudAliasInput(),
+      cloudflareFormOpen: false,
       configLoading: true,
       busy: false,
       busyAction: '',

--- a/erun-ui/frontend/src/app/manageDialogHelpers.ts
+++ b/erun-ui/frontend/src/app/manageDialogHelpers.ts
@@ -75,6 +75,9 @@ function deployRelevantSignature(config: UIEnvironmentConfig): string {
     containerRegistries: config.containerRegistries,
     disableBuildScript: config.disableBuildScript,
     cloudProviderAlias: config.cloudProviderAlias,
+    // Cloudflare (and any non-AWS) alias attachments are delivered into the pod
+    // at deploy time via a chart Secret, so changing a slot is deploy-relevant.
+    cloudAliasSlots: config.cloudAliasSlots,
     type: config.type,
     runtimePod: config.runtimePod,
     idle: config.idle,
@@ -99,7 +102,13 @@ export function manageDialogTabHasUnsavedChanges(
     keys.some((key) => JSON.stringify(config[key]) !== JSON.stringify(initial[key]));
   switch (tab) {
     case 'general':
-      return compare('containerRegistries', 'cloudProviderAlias', 'remoteHostCredentials', 'type');
+      return compare(
+        'containerRegistries',
+        'cloudProviderAlias',
+        'cloudAliasSlots',
+        'remoteHostCredentials',
+        'type',
+      );
     case 'runtime':
       return compare(
         'runtimePod',

--- a/erun-ui/frontend/src/app/manageDialogThunks.ts
+++ b/erun-ui/frontend/src/app/manageDialogThunks.ts
@@ -139,6 +139,31 @@ export const updateManageConfig =
     dispatch(patchManageDialog({ config, error: '' }));
   };
 
+// updateManageCloudAliasSlot updates one provider-type cloud-alias slot in the
+// draft (issue #630). It rewrites the matching entry in cloudAliasSlots and, for
+// the AWS slot, also mirrors the alias into the legacy cloudProviderAlias scalar
+// so the cloud-context linkage UI keeps working. Like updateManageConfig's
+// alias branch, changing the AWS alias clears the resolved cloud context so the
+// field re-resolves on the next load rather than showing a stale link.
+export const updateManageCloudAliasSlot =
+  (provider: string, alias: string): AppThunk =>
+  (dispatch, getState) => {
+    const dialog = getState().manageDialog;
+    if (dialog.busy || dialog.configLoading) {
+      return;
+    }
+    const providerType = provider.trim().toLowerCase();
+    const slots = (dialog.config.cloudAliasSlots ?? []).map((slot) =>
+      slot.provider.trim().toLowerCase() === providerType ? { ...slot, alias } : slot,
+    );
+    const config = { ...dialog.config, cloudAliasSlots: slots };
+    if (providerType === '' || providerType === 'aws') {
+      config.cloudProviderAlias = alias;
+      config.cloudContext = undefined;
+    }
+    dispatch(patchManageDialog({ config, error: '' }));
+  };
+
 export const updateManageClaudeConfig =
   (values: Partial<UIEnvironmentConfig['claude']>): AppThunk =>
   (dispatch, getState) => {

--- a/erun-ui/frontend/src/app/manageEnvironmentThunks.ts
+++ b/erun-ui/frontend/src/app/manageEnvironmentThunks.ts
@@ -18,6 +18,7 @@ export {
   submitManageConfig,
   toggleManageVersionChoices,
   updateManageClaudeConfig,
+  updateManageCloudAliasSlot,
   updateManageConfig,
   updateManageDialog,
   updateManageSSHDConfig,

--- a/erun-ui/frontend/src/app/slices/sidebarSlice.ts
+++ b/erun-ui/frontend/src/app/slices/sidebarSlice.ts
@@ -4,14 +4,17 @@ export type SidebarCloudAliasAction = '' | 'login' | 'logout' | 'bearer';
 
 export interface SidebarState {
   collapsedTenants: string[];
-  sidebarCloudAliasBusy: boolean;
-  sidebarCloudAliasAction: SidebarCloudAliasAction;
+  // sidebarCloudAliasBusyByAlias maps an alias to its current in-flight action.
+  // Absence means idle. Keyed by alias so per-provider-type rows (AWS,
+  // Cloudflare) show independent spinners: an AWS login and a Cloudflare token
+  // re-verify can run at once without one disabling the other's control
+  // (visibility of system status, Nielsen #1).
+  sidebarCloudAliasBusyByAlias: Record<string, SidebarCloudAliasAction>;
 }
 
 const initialState: SidebarState = {
   collapsedTenants: [],
-  sidebarCloudAliasBusy: false,
-  sidebarCloudAliasAction: '',
+  sidebarCloudAliasBusyByAlias: {},
 };
 
 export const sidebarSlice = createSlice({
@@ -29,10 +32,25 @@ export const sidebarSlice = createSlice({
     },
     setSidebarCloudAliasBusy(
       state,
-      action: PayloadAction<{ busy: boolean; action: SidebarCloudAliasAction }>,
+      action: PayloadAction<{ alias: string; busy: boolean; action: SidebarCloudAliasAction }>,
     ) {
-      state.sidebarCloudAliasBusy = action.payload.busy;
-      state.sidebarCloudAliasAction = action.payload.action;
+      const alias = action.payload.alias.trim();
+      if (!alias) {
+        return;
+      }
+      if (action.payload.busy) {
+        state.sidebarCloudAliasBusyByAlias[alias] = action.payload.action;
+        return;
+      }
+      // Drop the alias's entry without a dynamic delete: rebuild the map
+      // omitting it. Absence means idle.
+      const next: Record<string, SidebarCloudAliasAction> = {};
+      for (const [key, value] of Object.entries(state.sidebarCloudAliasBusyByAlias)) {
+        if (key !== alias) {
+          next[key] = value;
+        }
+      }
+      state.sidebarCloudAliasBusyByAlias = next;
     },
     setAll(_state, action: PayloadAction<SidebarState>) {
       return action.payload;

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -3,6 +3,7 @@ import type {
   EnvironmentType,
   ManageTab,
   UICloudContextInitInput,
+  UICloudflareCloudAliasInput,
   UICloudProviderStatus,
   UIEnvironmentConfig,
   UIERunConfig,
@@ -121,6 +122,14 @@ export interface GlobalConfigDialogState {
   open: boolean;
   config: UIERunConfig;
   cloudContextDraft: UICloudContextInitInput;
+  // cloudflareDraft holds the in-progress "add Cloudflare token" form. It is
+  // only meaningful while the Cloudflare add form is open; submitting or
+  // cancelling resets it. The apiToken lives only here on the client until the
+  // submit call hands it to the backend's off-config secret store.
+  cloudflareDraft: UICloudflareCloudAliasInput;
+  // cloudflareFormOpen toggles the inline Cloudflare add form open. AWS uses a
+  // PTY session instead of a form, so it has no equivalent flag.
+  cloudflareFormOpen: boolean;
   configLoading: boolean;
   busy: boolean;
   busyAction:
@@ -129,6 +138,7 @@ export interface GlobalConfigDialogState {
     | 'cloud-context-init'
     | 'cloud-context-power'
     | 'cloud-provider-init'
+    | 'cloud-provider-cloudflare-init'
     | 'cloud-provider-login';
   busyTarget: string;
   error: string;
@@ -237,8 +247,7 @@ export interface AppState {
   terminalCopyStatus: string;
   idleStatus: UIIdleStatus | null;
   idleCloudContextBusy: boolean;
-  sidebarCloudAliasBusy: boolean;
-  sidebarCloudAliasAction: '' | 'login' | 'logout' | 'bearer';
+  sidebarCloudAliasBusyByAlias: Record<string, '' | 'login' | 'logout' | 'bearer'>;
   debugOpen: boolean;
   debugHeight: number;
   lastDoctorBySelection: Record<string, DoctorOutcome>;
@@ -309,11 +318,19 @@ export const defaultGlobalConfigDialog = (): GlobalConfigDialogState => ({
   open: false,
   config: defaultERunConfig(),
   cloudContextDraft: defaultCloudContextInitInput(),
+  cloudflareDraft: defaultCloudflareCloudAliasInput(),
+  cloudflareFormOpen: false,
   configLoading: false,
   busy: false,
   busyAction: '',
   busyTarget: '',
   error: '',
+});
+
+export const defaultCloudflareCloudAliasInput = (): UICloudflareCloudAliasInput => ({
+  accountId: '',
+  tokenName: '',
+  apiToken: '',
 });
 
 export const defaultAutoStartPrompt = (): AutoStartPromptState => ({

--- a/erun-ui/frontend/src/components/app/GlobalConfigDialog.CloudAliases.tsx
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialog.CloudAliases.tsx
@@ -1,6 +1,7 @@
 import { Cloud, LoaderCircle, Plus, RefreshCw } from 'lucide-react';
 import * as React from 'react';
 
+import { openCloudflareCloudInitForm } from '@/app/cloudflareProviderThunks';
 import {
   loginGlobalCloudProvider,
   refreshCloudProviders,
@@ -9,12 +10,24 @@ import {
 import { useAppDispatch } from '@/app/hooks';
 import type { AppState } from '@/app/state';
 import { EmptyState } from '@/components/app/EmptyState';
-import { cloudProviderSummary } from '@/components/app/GlobalConfigDialog.helpers';
+import { CloudflareAliasForm } from '@/components/app/GlobalConfigDialog.CloudflareForm';
+import {
+  cloudProviderSummary,
+  cloudProviderTypeLabel,
+} from '@/components/app/GlobalConfigDialog.helpers';
 import { CloudAliasAction, CloudStatusBadge } from '@/components/app/GlobalConfigDialog.shared';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { CloudProviderAWS, CloudProviderCloudflare, type UICloudProviderStatus } from '@/types';
 
 type GlobalConfigDialog = AppState['globalConfigDialog'];
+
+// providerGroupOrder fixes the render order of the grouped alias list: AWS
+// first (the legacy primary), then Cloudflare, then any other configured
+// provider type alphabetically. Recognition over recall: aliases stay grouped
+// under a labelled heading so an operator with both an AWS account and a
+// Cloudflare token can tell which is which at a glance (Nielsen #6).
+const providerGroupOrder = [CloudProviderAWS, CloudProviderCloudflare];
 
 export function CloudAliasesSection({
   dialog,
@@ -28,20 +41,7 @@ export function CloudAliasesSection({
       <div className="flex items-center justify-between gap-2">
         <Label>Cloud aliases</Label>
         <div className="flex gap-1.5">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={dialog.busy}
-            onClick={() => void dispatch(startAWSCloudInit())}
-          >
-            {dialog.busyAction === 'cloud-provider-init' ? (
-              <LoaderCircle className="animate-spin" aria-hidden="true" />
-            ) : (
-              <Plus aria-hidden="true" />
-            )}
-            AWS
-          </Button>
+          <AddProviderButtons dialog={dialog} />
           <Button
             type="button"
             variant="ghost"
@@ -54,67 +54,200 @@ export function CloudAliasesSection({
           </Button>
         </div>
       </div>
+      {dialog.cloudflareFormOpen && <CloudflareAliasForm dialog={dialog} />}
       {providers.length === 0 ? (
-        <EmptyState
-          icon={<Cloud />}
-          heading="No cloud aliases yet"
-          body="Add a cloud account so ERun can deploy environments to it. AWS is the only provider supported today."
-          action={
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={dialog.busy}
-              onClick={() => void dispatch(startAWSCloudInit())}
-            >
-              {dialog.busyAction === 'cloud-provider-init' ? (
-                <LoaderCircle className="animate-spin" aria-hidden="true" />
-              ) : (
-                <Plus aria-hidden="true" />
-              )}
-              Add AWS account
-            </Button>
-          }
-        />
+        <CloudAliasesEmptyState dialog={dialog} />
       ) : (
-        <CloudAliasList dialog={dialog} />
+        <GroupedCloudAliasList dialog={dialog} providers={providers} />
       )}
     </div>
   );
 }
 
-function CloudAliasList({ dialog }: { dialog: GlobalConfigDialog }): React.ReactElement {
+// AddProviderButtons is the provider picker: one explicit button per provider
+// type. AWS opens an SSO PTY session (startAWSCloudInit); Cloudflare reveals
+// the inline masked-token form (no terminal). Two named buttons beat a generic
+// "Add" + a hidden type chooser — the operator sees both supported providers up
+// front (recognition over recall, Nielsen #6).
+function AddProviderButtons({ dialog }: { dialog: GlobalConfigDialog }): React.ReactElement {
   const dispatch = useAppDispatch();
   return (
-    <div className="overflow-hidden rounded-[var(--radius)] border border-border">
-      {(dialog.config.cloudProviders ?? []).map((provider, index) => (
-        <div
-          key={provider.alias}
-          className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-border px-3 py-2.5 data-[border=true]:border-t"
-          data-border={index > 0}
-          data-cloud-alias={provider.alias}
-          data-cloud-status={provider.status}
-        >
-          <CloudAliasSummary provider={provider} />
-          <CloudAliasAction
-            status={provider.status}
-            busy={dialog.busy}
-            loading={
-              dialog.busyAction === 'cloud-provider-login' && dialog.busyTarget === provider.alias
-            }
-            onLogin={() => void dispatch(loginGlobalCloudProvider(provider.alias))}
-          />
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={dialog.busy}
+        onClick={() => void dispatch(startAWSCloudInit())}
+      >
+        {dialog.busyAction === 'cloud-provider-init' ? (
+          <LoaderCircle className="animate-spin" aria-hidden="true" />
+        ) : (
+          <Plus aria-hidden="true" />
+        )}
+        AWS
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={dialog.busy || dialog.cloudflareFormOpen}
+        onClick={() => {
+          dispatch(openCloudflareCloudInitForm());
+        }}
+      >
+        <Plus aria-hidden="true" />
+        Cloudflare
+      </Button>
+    </>
+  );
+}
+
+function CloudAliasesEmptyState({ dialog }: { dialog: GlobalConfigDialog }): React.ReactElement {
+  const dispatch = useAppDispatch();
+  return (
+    <EmptyState
+      icon={<Cloud />}
+      heading="No cloud aliases yet"
+      body="Add a cloud account so ERun can deploy environments to it. Add an AWS account for compute, or a Cloudflare token for DNS and zone delegation."
+      action={
+        <div className="flex flex-wrap justify-center gap-1.5">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={dialog.busy}
+            onClick={() => void dispatch(startAWSCloudInit())}
+          >
+            {dialog.busyAction === 'cloud-provider-init' ? (
+              <LoaderCircle className="animate-spin" aria-hidden="true" />
+            ) : (
+              <Plus aria-hidden="true" />
+            )}
+            Add AWS account
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={dialog.busy || dialog.cloudflareFormOpen}
+            onClick={() => {
+              dispatch(openCloudflareCloudInitForm());
+            }}
+          >
+            <Plus aria-hidden="true" />
+            Add Cloudflare token
+          </Button>
+        </div>
+      }
+    />
+  );
+}
+
+// GroupedCloudAliasList renders the configured aliases under a labelled heading
+// per provider type so AWS accounts and Cloudflare tokens are visually
+// distinct. Each row independently logs in (or, for Cloudflare, re-verifies
+// the stored token) and shows its own status and spinner.
+function GroupedCloudAliasList({
+  dialog,
+  providers,
+}: {
+  dialog: GlobalConfigDialog;
+  providers: UICloudProviderStatus[];
+}): React.ReactElement {
+  const groups = groupProvidersByType(providers);
+  return (
+    <div className="grid gap-3">
+      {groups.map((group) => (
+        <div key={group.provider} className="grid gap-1.5">
+          <div
+            className="text-xs font-medium text-muted-foreground"
+            data-cloud-alias-group={group.provider}
+          >
+            {cloudProviderTypeLabel(group.provider)}
+          </div>
+          <div className="overflow-hidden rounded-[var(--radius)] border border-border">
+            {group.aliases.map((provider, index) => (
+              <CloudAliasRow
+                key={provider.alias}
+                dialog={dialog}
+                provider={provider}
+                bordered={index > 0}
+              />
+            ))}
+          </div>
         </div>
       ))}
     </div>
   );
 }
 
-function CloudAliasSummary({
+interface ProviderGroup {
+  provider: string;
+  aliases: UICloudProviderStatus[];
+}
+
+function groupProvidersByType(providers: UICloudProviderStatus[]): ProviderGroup[] {
+  const byType = new Map<string, UICloudProviderStatus[]>();
+  for (const provider of providers) {
+    const key = (provider.provider || '').trim().toLowerCase() || 'other';
+    const bucket = byType.get(key) ?? [];
+    bucket.push(provider);
+    byType.set(key, bucket);
+  }
+  const ordered: ProviderGroup[] = [];
+  for (const type of providerGroupOrder) {
+    const aliases = byType.get(type);
+    if (aliases) {
+      ordered.push({ provider: type, aliases });
+      byType.delete(type);
+    }
+  }
+  for (const key of [...byType.keys()].sort()) {
+    ordered.push({ provider: key, aliases: byType.get(key) ?? [] });
+  }
+  return ordered;
+}
+
+function CloudAliasRow({
+  dialog,
   provider,
+  bordered,
 }: {
-  provider: NonNullable<GlobalConfigDialog['config']['cloudProviders']>[number];
+  dialog: GlobalConfigDialog;
+  provider: UICloudProviderStatus;
+  bordered: boolean;
 }): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const isCloudflare = (provider.provider || '').trim().toLowerCase() === CloudProviderCloudflare;
+  return (
+    <div
+      className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-border px-3 py-2.5 data-[border=true]:border-t"
+      data-border={bordered}
+      data-cloud-alias={provider.alias}
+      data-cloud-status={provider.status}
+      data-cloud-provider={provider.provider}
+    >
+      <CloudAliasSummary provider={provider} />
+      <CloudAliasAction
+        status={provider.status}
+        busy={dialog.busy}
+        loading={
+          dialog.busyAction === 'cloud-provider-login' && dialog.busyTarget === provider.alias
+        }
+        // Cloudflare "login" re-verifies the stored scoped token against the
+        // Cloudflare API — there is no browser SSO — so the action reads
+        // "Verify token" rather than "Login" (match between system and the
+        // real world, Nielsen #2).
+        loginLabel={isCloudflare ? 'Verify token' : undefined}
+        loadingLabel={isCloudflare ? 'Verifying...' : undefined}
+        onLogin={() => void dispatch(loginGlobalCloudProvider(provider.alias))}
+      />
+    </div>
+  );
+}
+
+function CloudAliasSummary({ provider }: { provider: UICloudProviderStatus }): React.ReactElement {
   return (
     <div className="grid min-w-0 gap-1">
       <div className="flex min-w-0 items-center gap-2 text-sm font-medium">

--- a/erun-ui/frontend/src/components/app/GlobalConfigDialog.CloudflareForm.tsx
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialog.CloudflareForm.tsx
@@ -1,0 +1,142 @@
+import { LoaderCircle, Plus, X } from 'lucide-react';
+import * as React from 'react';
+
+import {
+  closeCloudflareCloudInitForm,
+  submitCloudflareCloudInit,
+  updateCloudflareDraft,
+} from '@/app/cloudflareProviderThunks';
+import { useAppDispatch } from '@/app/hooks';
+import type { AppState } from '@/app/state';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+type GlobalConfigDialog = AppState['globalConfigDialog'];
+
+// CloudflareAliasForm is the non-interactive "add Cloudflare token" form. It
+// collects the three explicit inputs erun-common's InitCloudflareCloudProvider
+// needs — account ID, a token label, and the scoped API token — and submits
+// them in one masked round-trip. The API token uses type="password" so it is
+// never shoulder-surfed or echoed; the backend stores it off-config and never
+// returns it. The submit button stays disabled until all three are present
+// (error prevention, Nielsen #5).
+export function CloudflareAliasForm({
+  dialog,
+}: {
+  dialog: GlobalConfigDialog;
+}): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const draft = dialog.cloudflareDraft;
+  const submitting = dialog.busyAction === 'cloud-provider-cloudflare-init';
+  const complete =
+    draft.accountId.trim() !== '' && draft.tokenName.trim() !== '' && draft.apiToken.trim() !== '';
+  return (
+    <form
+      className="grid gap-2 rounded-[var(--radius)] border border-border p-3"
+      aria-label="Add Cloudflare token"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (complete) {
+          void dispatch(submitCloudflareCloudInit());
+        }
+      }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-sm font-medium">Add Cloudflare token</div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          disabled={dialog.busy}
+          aria-label="Cancel adding Cloudflare token"
+          onClick={() => {
+            dispatch(closeCloudflareCloudInitForm());
+          }}
+        >
+          <X aria-hidden="true" />
+        </Button>
+      </div>
+      <CloudflareField
+        id="global-config-cloudflare-accountid"
+        label="Account ID"
+        value={draft.accountId}
+        placeholder="Cloudflare account ID"
+        disabled={dialog.busy}
+        onChange={(accountId) => {
+          dispatch(updateCloudflareDraft({ accountId }));
+        }}
+      />
+      <CloudflareField
+        id="global-config-cloudflare-tokenname"
+        label="Token label"
+        value={draft.tokenName}
+        placeholder="A name to recognize this token"
+        disabled={dialog.busy}
+        onChange={(tokenName) => {
+          dispatch(updateCloudflareDraft({ tokenName }));
+        }}
+      />
+      <CloudflareField
+        id="global-config-cloudflare-apitoken"
+        label="API token"
+        type="password"
+        value={draft.apiToken}
+        placeholder="Scoped API token (Zone:Edit + DNS:Edit)"
+        disabled={dialog.busy}
+        onChange={(apiToken) => {
+          dispatch(updateCloudflareDraft({ apiToken }));
+        }}
+      />
+      <p className="text-[12px] leading-[1.4] text-muted-foreground">
+        Mint an account-scoped token (account-level Zone:Edit + DNS:Edit) in the Cloudflare
+        dashboard. ERun verifies it, then stores it on this machine outside the config file.
+      </p>
+      <div className="flex justify-end gap-1.5">
+        <Button type="submit" size="sm" disabled={dialog.busy || !complete}>
+          {submitting ? (
+            <LoaderCircle className="animate-spin" aria-hidden="true" />
+          ) : (
+            <Plus aria-hidden="true" />
+          )}
+          {submitting ? 'Verifying...' : 'Add token'}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function CloudflareField({
+  id,
+  label,
+  value,
+  placeholder,
+  disabled,
+  type,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  placeholder?: string;
+  disabled?: boolean;
+  type?: 'text' | 'password';
+  onChange: (value: string) => void;
+}): React.ReactElement {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        type={type ?? 'text'}
+        value={value}
+        placeholder={placeholder}
+        disabled={disabled}
+        autoComplete={type === 'password' ? 'off' : undefined}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
+      />
+    </div>
+  );
+}

--- a/erun-ui/frontend/src/components/app/GlobalConfigDialog.helpers.ts
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialog.helpers.ts
@@ -26,6 +26,20 @@ export function cloudRegionLabel(region: string): string {
   return name ? `${region} (${name})` : region;
 }
 
+// cloudProviderTypeLabel turns a provider type token into a user-facing group
+// heading. Keep these in user language (not the CLI token) per the Professional
+// UX rules; unknown types fall back to an upper-cased token.
+export function cloudProviderTypeLabel(provider: string): string {
+  switch (provider.trim().toLowerCase()) {
+    case 'aws':
+      return 'AWS accounts';
+    case 'cloudflare':
+      return 'Cloudflare tokens';
+    default:
+      return provider.trim() ? `${provider.trim().toUpperCase()} aliases` : 'Other aliases';
+  }
+}
+
 export function cloudProviderSummary(provider: {
   provider: string;
   username?: string;

--- a/erun-ui/frontend/src/components/app/GlobalConfigDialog.shared.tsx
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialog.shared.tsx
@@ -24,11 +24,18 @@ export function CloudAliasAction({
   busy,
   loading,
   onLogin,
+  loginLabel,
+  loadingLabel,
 }: {
   status: string;
   busy: boolean;
   loading: boolean;
   onLogin: () => void;
+  // loginLabel / loadingLabel let a provider type relabel the action without a
+  // second component: Cloudflare re-verifies a stored token rather than running
+  // a browser SSO, so its button reads "Verify token" / "Verifying...".
+  loginLabel?: string;
+  loadingLabel?: string;
 }): React.ReactElement {
   if (status.trim() === 'active') {
     return (
@@ -41,6 +48,8 @@ export function CloudAliasAction({
       </div>
     );
   }
+  const idleLabel = loginLabel ?? 'Login';
+  const busyLabel = loadingLabel ?? 'Logging in...';
   return (
     <Button type="button" variant="outline" size="sm" disabled={busy} onClick={onLogin}>
       {loading ? (
@@ -48,7 +57,7 @@ export function CloudAliasAction({
       ) : (
         <LogIn aria-hidden="true" />
       )}
-      {loading ? 'Logging in...' : 'Login'}
+      {loading ? busyLabel : idleLabel}
     </Button>
   );
 }

--- a/erun-ui/frontend/src/components/app/ManageDialogGeneralTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogGeneralTab.tsx
@@ -8,17 +8,23 @@ import {
   closeManageDialog,
   startManageCloudContext,
   stopManageCloudContext,
+  updateManageCloudAliasSlot,
   updateManageConfig,
 } from '@/app/manageEnvironmentThunks';
 import { loadSavedPastContainerRegistries } from '@/app/storage';
 import { ContainerRegistriesField } from '@/components/app/ContainerRegistriesField';
 import { uniqueSuggestions } from '@/components/app/EditableComboField.helpers';
 import { EmptyState } from '@/components/app/EmptyState';
+import { cloudProviderTypeLabel } from '@/components/app/GlobalConfigDialog.helpers';
 import { CheckboxField, ReadonlyField, StatusBadge } from '@/components/app/ManageDialog.fields';
 import { SelectField } from '@/components/app/SelectField';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
-import { EnvironmentTypeValues, type UICloudContextStatus } from '@/types';
+import {
+  EnvironmentTypeValues,
+  type UICloudContextStatus,
+  type UIEnvironmentCloudAlias,
+} from '@/types';
 
 // Sentinel for the clear ("— None —") option in the cloud-alias dropdown.
 // Radix Select rejects an empty-string item value, so the option carries this
@@ -57,15 +63,7 @@ export function GeneralTab(): React.ReactElement {
           dispatch(updateManageConfig({ containerRegistries }));
         }}
       />
-      <CloudAliasSelect
-        id="environment-config-cloudprovideralias"
-        value={config.cloudProviderAlias}
-        options={config.cloudProviderAliases ?? []}
-        disabled={dialog.busy}
-        onChange={(cloudProviderAlias) => {
-          dispatch(updateManageConfig({ cloudProviderAlias }));
-        }}
-      />
+      <CloudAliasSlots config={config} disabled={dialog.busy} />
       <CloudContextField
         context={config.cloudContext}
         cloudProviderAlias={config.cloudProviderAlias}
@@ -146,14 +144,79 @@ function EnvironmentTypeField({
   );
 }
 
+// CloudAliasSlots renders one cloud-alias selector per provider type the env
+// can attach (issue #630): an AWS account AND a Cloudflare token can be linked
+// independently, each with its own "— None —" clear option. The per-type slots
+// come from the backend (EnvConfig.ResolvedCloudAliases grouped by type). When
+// the backend predates slots, a single AWS selector renders as a fallback so
+// the control never disappears.
+function CloudAliasSlots({
+  config,
+  disabled,
+}: {
+  config: {
+    cloudAliasSlots?: UIEnvironmentCloudAlias[];
+    cloudProviderAlias: string;
+    cloudProviderAliases?: string[];
+  };
+  disabled?: boolean;
+}): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const slots = config.cloudAliasSlots ?? [];
+  if (slots.length === 0) {
+    return (
+      <CloudAliasSelect
+        id="environment-config-cloudprovideralias"
+        label="Cloud alias"
+        value={config.cloudProviderAlias}
+        options={config.cloudProviderAliases ?? []}
+        disabled={disabled}
+        onChange={(alias) => {
+          dispatch(updateManageConfig({ cloudProviderAlias: alias }));
+        }}
+      />
+    );
+  }
+  return (
+    <>
+      {slots.map((slot) => (
+        <CloudAliasSelect
+          key={slot.provider}
+          id={cloudAliasSlotFieldId(slot.provider)}
+          label={cloudProviderTypeLabel(slot.provider)}
+          value={slot.alias}
+          options={slot.options}
+          disabled={disabled}
+          onChange={(alias) => {
+            dispatch(updateManageCloudAliasSlot(slot.provider, alias));
+          }}
+        />
+      ))}
+    </>
+  );
+}
+
+// cloudAliasSlotFieldId keeps the AWS slot on the historical id
+// (#environment-config-cloudprovideralias) so the long-standing AWS selector
+// contract — and the specs that target it — stay stable, while every other
+// provider type gets a suffixed id so the per-type selectors are addressable.
+function cloudAliasSlotFieldId(provider: string): string {
+  const type = provider.trim().toLowerCase();
+  return type === '' || type === 'aws'
+    ? 'environment-config-cloudprovideralias'
+    : `environment-config-cloudprovideralias-${type}`;
+}
+
 function CloudAliasSelect({
   id,
+  label,
   value,
   options,
   disabled,
   onChange,
 }: {
   id: string;
+  label: string;
   value: string;
   options: string[];
   disabled?: boolean;
@@ -169,11 +232,11 @@ function CloudAliasSelect({
   if (selectOptions.length === 0) {
     return (
       <div className="grid gap-2">
-        <Label htmlFor={id}>Cloud alias</Label>
+        <Label htmlFor={id}>{label}</Label>
         <EmptyState
           icon={<Server />}
           heading="No cloud aliases configured"
-          body="Cloud aliases are how ERun connects to your AWS account. Add one in ERun settings to link this environment to a cloud context."
+          body="Cloud aliases are how ERun connects to your cloud accounts. Add one in ERun settings to link this environment."
           action={
             <Button
               type="button"
@@ -205,7 +268,7 @@ function CloudAliasSelect({
   return (
     <SelectField
       id={id}
-      label="Cloud alias"
+      label={label}
       value={normalizedValue}
       options={optionItems}
       placeholder="Select cloud alias"

--- a/erun-ui/frontend/src/components/app/Sidebar.PrimaryCloudAliasControl.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.PrimaryCloudAliasControl.tsx
@@ -6,6 +6,7 @@ import {
   LoaderCircle,
   LogIn,
   LogOut,
+  RefreshCw,
   UserCircle2,
 } from 'lucide-react';
 import * as React from 'react';
@@ -16,15 +17,16 @@ import {
   logoutPrimaryCloudProvider,
 } from '@/app/cloudProviderThunks';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import { primaryCloudAliasFor } from '@/components/app/Sidebar.helpers';
+import { sidebarCloudAliases } from '@/components/app/Sidebar.helpers';
 import { cloudProviderStatusTone } from '@/components/app/StatusBadge.helpers';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
-import type { UICloudProviderStatus } from '@/types';
+import { CloudProviderCloudflare, type UICloudProviderStatus } from '@/types';
 
-interface PrimaryCloudAliasView {
+interface CloudAliasRowView {
   provider: UICloudProviderStatus;
+  isCloudflare: boolean;
   active: boolean;
   busy: boolean;
   loginBusy: boolean;
@@ -32,36 +34,75 @@ interface PrimaryCloudAliasView {
   bearerBusy: boolean;
 }
 
+// PrimaryCloudAliasControl renders one cloud-status row per provider type the
+// active tenant uses (issue #630): an AWS account and a Cloudflare token each
+// get an independent login/logout/status control with its own spinner. AWS
+// rows additionally offer "Get bearer token" (OIDC web-identity); Cloudflare
+// has no OIDC, so that action is hidden and "Log in" reads "Verify token".
 export function PrimaryCloudAliasControl(): React.ReactElement | null {
   const dispatch = useAppDispatch();
   const tenants = useAppSelector((s) => s.tenants.tenants);
   const cloudProviders = useAppSelector((s) => s.tenants.cloudProviders);
   const selected = useAppSelector((s) => s.selection.selected);
   const dashboardTenant = useAppSelector((s) => s.tenantDashboard.tenant);
-  const sidebarBusy = useAppSelector((s) => s.sidebar.sidebarCloudAliasBusy);
-  const sidebarAction = useAppSelector((s) => s.sidebar.sidebarCloudAliasAction);
-  const view = primaryCloudAliasView({
-    tenants,
-    cloudProviders,
-    selected,
-    dashboardTenant,
-    sidebarBusy,
-    sidebarAction,
-  });
-  if (!view) {
+  const busyByAlias = useAppSelector((s) => s.sidebar.sidebarCloudAliasBusyByAlias);
+  const aliases = sidebarCloudAliases({ tenants, cloudProviders, selected, dashboardTenant });
+  if (aliases.length === 0) {
     return null;
   }
+  return (
+    <div className="mt-3 mr-1 grid gap-1.5">
+      {aliases.map((alias) => (
+        <CloudAliasRow
+          key={alias}
+          view={cloudAliasRowView(alias, cloudProviders, busyByAlias)}
+          dispatch={dispatch}
+        />
+      ))}
+    </div>
+  );
+}
 
+function cloudAliasRowView(
+  alias: string,
+  cloudProviders: UICloudProviderStatus[],
+  busyByAlias: Record<string, string>,
+): CloudAliasRowView {
+  const provider = cloudProviders.find((candidate) => candidate.alias === alias) ?? {
+    alias,
+    provider: '',
+    status: 'unknown',
+  };
+  const action = busyByAlias[alias] ?? '';
+  const busy = action !== '';
+  return {
+    provider,
+    isCloudflare: provider.provider.trim().toLowerCase() === CloudProviderCloudflare,
+    active: provider.status.trim() === 'active',
+    busy,
+    loginBusy: action === 'login',
+    logoutBusy: action === 'logout',
+    bearerBusy: action === 'bearer',
+  };
+}
+
+function CloudAliasRow({
+  view,
+  dispatch,
+}: {
+  view: CloudAliasRowView;
+  dispatch: ReturnType<typeof useAppDispatch>;
+}): React.ReactElement {
   const triggerTone = cloudProviderStatusTone(view.provider.status);
   return (
     <Popover>
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="mt-3 mr-1 flex min-h-10 min-w-0 items-center gap-2 rounded-md border border-sidebar-border bg-background/88 px-3 py-2 text-left text-sm text-foreground shadow-sm hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+          className="flex min-h-10 min-w-0 items-center gap-2 rounded-md border border-sidebar-border bg-background/88 px-3 py-2 text-left text-sm text-foreground shadow-sm hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
           aria-label={`${view.provider.alias} cloud status`}
         >
-          <CloudAliasTriggerIcon tone={triggerTone} />
+          <CloudAliasTriggerIcon tone={triggerTone} busy={view.busy} />
           <span className="min-w-0 flex-1 truncate">{cloudProviderIdentity(view.provider)}</span>
         </button>
       </PopoverTrigger>
@@ -70,40 +111,17 @@ export function PrimaryCloudAliasControl(): React.ReactElement | null {
         side="top"
         align="start"
       >
-        <PrimaryCloudAliasPopoverBody view={view} dispatch={dispatch} />
+        <CloudAliasPopoverBody view={view} dispatch={dispatch} />
       </PopoverContent>
     </Popover>
   );
 }
 
-function primaryCloudAliasView(
-  input: Parameters<typeof primaryCloudAliasFor>[0],
-): PrimaryCloudAliasView | null {
-  const alias = primaryCloudAliasFor(input);
-  if (!alias) {
-    return null;
-  }
-  const provider = input.cloudProviders.find((candidate) => candidate.alias === alias) ?? {
-    alias,
-    provider: '',
-    status: 'unknown',
-  };
-  const busy = input.sidebarBusy;
-  return {
-    provider,
-    active: provider.status.trim() === 'active',
-    busy,
-    loginBusy: busy && input.sidebarAction === 'login',
-    logoutBusy: busy && input.sidebarAction === 'logout',
-    bearerBusy: busy && input.sidebarAction === 'bearer',
-  };
-}
-
-function PrimaryCloudAliasPopoverBody({
+function CloudAliasPopoverBody({
   view,
   dispatch,
 }: {
-  view: PrimaryCloudAliasView;
+  view: CloudAliasRowView;
   dispatch: ReturnType<typeof useAppDispatch>;
 }): React.ReactElement {
   return (
@@ -117,38 +135,42 @@ function PrimaryCloudAliasPopoverBody({
       <div className="my-1 border-t border-border" />
       <CloudAliasStatus provider={view.provider} />
       {view.active ? (
-        <PrimaryCloudAliasActiveActions view={view} dispatch={dispatch} />
+        <CloudAliasActiveActions view={view} dispatch={dispatch} />
       ) : (
-        <PrimaryCloudAliasLoginAction view={view} dispatch={dispatch} />
+        <CloudAliasLoginAction view={view} dispatch={dispatch} />
       )}
     </div>
   );
 }
 
-function PrimaryCloudAliasActiveActions({
+function CloudAliasActiveActions({
   view,
   dispatch,
 }: {
-  view: PrimaryCloudAliasView;
+  view: CloudAliasRowView;
   dispatch: ReturnType<typeof useAppDispatch>;
 }): React.ReactElement {
   return (
     <>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="justify-start"
-        disabled={view.busy}
-        onClick={() => void dispatch(getPrimaryCloudProviderBearerToken(view.provider.alias))}
-      >
-        {view.bearerBusy ? (
-          <LoaderCircle className="animate-spin" aria-hidden="true" />
-        ) : (
-          <Copy aria-hidden="true" />
-        )}
-        {view.bearerBusy ? 'Copying token...' : 'Get bearer token'}
-      </Button>
+      {/* Cloudflare aliases authenticate the runtime with a scoped API token,
+          not an OIDC JWT, so "Get bearer token" is N/A and hidden for them. */}
+      {!view.isCloudflare && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="justify-start"
+          disabled={view.busy}
+          onClick={() => void dispatch(getPrimaryCloudProviderBearerToken(view.provider.alias))}
+        >
+          {view.bearerBusy ? (
+            <LoaderCircle className="animate-spin" aria-hidden="true" />
+          ) : (
+            <Copy aria-hidden="true" />
+          )}
+          {view.bearerBusy ? 'Copying token...' : 'Get bearer token'}
+        </Button>
+      )}
       <Button
         type="button"
         variant="ghost"
@@ -162,19 +184,29 @@ function PrimaryCloudAliasActiveActions({
         ) : (
           <LogOut aria-hidden="true" />
         )}
-        {view.logoutBusy ? 'Logging out...' : 'Log out'}
+        {cloudAliasLogoutLabel(view)}
       </Button>
     </>
   );
 }
 
-function PrimaryCloudAliasLoginAction({
+function cloudAliasLogoutLabel(view: CloudAliasRowView): string {
+  if (view.isCloudflare) {
+    return view.logoutBusy ? 'Removing token...' : 'Remove token';
+  }
+  return view.logoutBusy ? 'Logging out...' : 'Log out';
+}
+
+function CloudAliasLoginAction({
   view,
   dispatch,
 }: {
-  view: PrimaryCloudAliasView;
+  view: CloudAliasRowView;
   dispatch: ReturnType<typeof useAppDispatch>;
 }): React.ReactElement {
+  // Cloudflare "login" re-verifies the stored scoped token against the
+  // Cloudflare API — there is no browser SSO — so the action reads "Verify
+  // token" (match between system and the real world, Nielsen #2).
   return (
     <Button
       type="button"
@@ -186,12 +218,21 @@ function PrimaryCloudAliasLoginAction({
     >
       {view.loginBusy ? (
         <LoaderCircle className="animate-spin" aria-hidden="true" />
+      ) : view.isCloudflare ? (
+        <RefreshCw aria-hidden="true" />
       ) : (
         <LogIn aria-hidden="true" />
       )}
-      {view.loginBusy ? 'Logging in...' : 'Log in'}
+      {cloudAliasLoginLabel(view)}
     </Button>
   );
+}
+
+function cloudAliasLoginLabel(view: CloudAliasRowView): string {
+  if (view.isCloudflare) {
+    return view.loginBusy ? 'Verifying...' : 'Verify token';
+  }
+  return view.loginBusy ? 'Logging in...' : 'Log in';
 }
 
 function CloudAliasPopoverRow({
@@ -228,9 +269,19 @@ function CloudAliasStatus({ provider }: { provider: UICloudProviderStatus }): Re
 
 function CloudAliasTriggerIcon({
   tone,
+  busy,
 }: {
   tone: ReturnType<typeof cloudProviderStatusTone>;
+  busy: boolean;
 }): React.ReactElement {
+  if (busy) {
+    return (
+      <LoaderCircle
+        className="size-4 shrink-0 animate-spin text-muted-foreground"
+        aria-hidden="true"
+      />
+    );
+  }
   if (tone === 'success') {
     return (
       <CheckCircle2

--- a/erun-ui/frontend/src/components/app/Sidebar.helpers.ts
+++ b/erun-ui/frontend/src/components/app/Sidebar.helpers.ts
@@ -135,18 +135,102 @@ function activityCommandLabel(command: string): string {
   }
 }
 
-export interface PrimaryCloudAliasInputs {
+export interface CloudAliasRowInputs {
   tenants: AppState['tenants'];
   cloudProviders: AppState['cloudProviders'];
   selected: AppState['selected'];
   dashboardTenant: string;
-  sidebarBusy: boolean;
-  sidebarAction: AppState['sidebarCloudAliasAction'];
 }
 
-export function primaryCloudAliasFor(input: PrimaryCloudAliasInputs): string | undefined {
+// sidebarCloudAliases returns the cloud aliases the active tenant uses, one per
+// provider type, in a stable order (AWS first, then Cloudflare, then any other
+// type alphabetically). The active tenant is the dashboard tenant when one is
+// open, otherwise the selected env's tenant. Each provider type that the tenant
+// references through its cloudProviderAliases (or its primary alias)
+// contributes exactly one row, so an env wired to both an AWS account and a
+// Cloudflare token shows two independent login rows. The provider type is
+// resolved from the configured cloudProviders; an alias with no matching
+// provider config still surfaces with an empty provider so the operator can see
+// and recover from it.
+export function sidebarCloudAliases(input: CloudAliasRowInputs): string[] {
   const tenantName = input.dashboardTenant || (input.selected?.tenant ?? '');
-  return input.tenants
-    .find((candidate) => candidate.name === tenantName)
-    ?.primaryCloudProviderAlias?.trim();
+  const tenant = input.tenants.find((candidate) => candidate.name === tenantName);
+  if (!tenant) {
+    return [];
+  }
+  const aliasByType = firstAliasPerProviderType(tenantCloudAliases(tenant), input.cloudProviders);
+  return orderCloudAliasRows(aliasByType);
+}
+
+// tenantCloudAliases collects the aliases a tenant references: its configured
+// list with the primary alias pulled to the front (so the primary's type wins
+// when two aliases share a type).
+function tenantCloudAliases(tenant: AppState['tenants'][number]): string[] {
+  const aliases = [...(tenant.cloudProviderAliases ?? [])];
+  const primary = tenant.primaryCloudProviderAlias?.trim();
+  if (primary && !aliases.includes(primary)) {
+    aliases.unshift(primary);
+  }
+  return aliases;
+}
+
+// firstAliasPerProviderType keeps the first alias seen for each provider type,
+// so each type contributes exactly one row. The type is resolved from the
+// configured cloudProviders, falling back to the alias's "@type" suffix.
+function firstAliasPerProviderType(
+  aliases: string[],
+  cloudProviders: AppState['cloudProviders'],
+): Map<string, string> {
+  const providerTypeByAlias = new Map(
+    cloudProviders.map((provider) => [provider.alias, provider.provider.trim().toLowerCase()]),
+  );
+  const aliasByType = new Map<string, string>();
+  for (const rawAlias of aliases) {
+    const alias = rawAlias.trim();
+    if (alias === '') {
+      continue;
+    }
+    const type = providerTypeByAlias.get(alias) ?? cloudProviderTypeFromAlias(alias);
+    if (!aliasByType.has(type)) {
+      aliasByType.set(type, alias);
+    }
+  }
+  return aliasByType;
+}
+
+// cloudProviderTypeFromAlias mirrors erun-common's fallback: the provider type
+// is the suffix after the last "@", defaulting to AWS for legacy / unparseable
+// aliases.
+function cloudProviderTypeFromAlias(alias: string): string {
+  const at = alias.lastIndexOf('@');
+  if (at <= 0 || at === alias.length - 1) {
+    return 'aws';
+  }
+  return (
+    alias
+      .slice(at + 1)
+      .trim()
+      .toLowerCase() || 'aws'
+  );
+}
+
+const cloudAliasRowOrder = ['aws', 'cloudflare'];
+
+function orderCloudAliasRows(aliasByType: Map<string, string>): string[] {
+  const ordered: string[] = [];
+  const remaining = new Map(aliasByType);
+  for (const type of cloudAliasRowOrder) {
+    const alias = remaining.get(type);
+    if (alias) {
+      ordered.push(alias);
+      remaining.delete(type);
+    }
+  }
+  for (const type of [...remaining.keys()].sort()) {
+    const alias = remaining.get(type);
+    if (alias) {
+      ordered.push(alias);
+    }
+  }
+  return ordered;
 }

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -309,6 +309,33 @@ export interface UIAWSCloudAliasInput {
   oidcIssuerUrl: string;
 }
 
+// UICloudflareCloudAliasInput mirrors the Go uiCloudflareCloudAliasInput: the
+// explicit inputs for the non-interactive "add Cloudflare token" form. The
+// apiToken rides through a masked field and is never echoed back from the
+// backend.
+export interface UICloudflareCloudAliasInput {
+  accountId: string;
+  tokenName: string;
+  apiToken: string;
+}
+
+// Canonical cloud provider type strings, matching erun-common's
+// CloudProviderAWS / CloudProviderCloudflare. Used to label and group cloud
+// aliases by their provider type across the settings dialog, sidebar, and env
+// manage tab.
+export const CloudProviderAWS = 'aws';
+export const CloudProviderCloudflare = 'cloudflare';
+
+// UIEnvironmentCloudAlias is one provider-type slot in the env's cloud-alias
+// view: the provider type, the alias currently attached for that type (empty
+// when none), and the configured aliases of that type the operator can choose
+// from.
+export interface UIEnvironmentCloudAlias {
+  provider: string;
+  alias: string;
+  options: string[];
+}
+
 export interface UICloudContextStatus {
   name: string;
   provider: string;
@@ -386,6 +413,11 @@ export interface UIEnvironmentConfig {
   containerRegistries: UIContainerRegistryEntry[];
   cloudProviderAlias: string;
   cloudProviderAliases?: string[];
+  // cloudAliasSlots is the per-provider-type cloud-alias view: one entry per
+  // provider type (aws, cloudflare) that has a configured alias or a current
+  // attachment, each carrying the env's chosen alias for that type plus the
+  // selectable options. The frontend renders one selector per slot.
+  cloudAliasSlots?: UIEnvironmentCloudAlias[];
   cloudContext?: UICloudContextStatus;
   runtimeVersion: string;
   runtimePod: UIRuntimePodConfig;

--- a/erun-ui/playwright/fixtures/seedRoot.ts
+++ b/erun-ui/playwright/fixtures/seedRoot.ts
@@ -29,10 +29,23 @@ import * as path from 'node:path';
 export const SEED_TENANT = 'pw';
 export const SEED_ENV_ALPHA = 'alpha';
 export const SEED_ENV_BETA = 'beta';
+// gamma attaches BOTH an AWS alias and a Cloudflare alias so the per-type env
+// cloud-alias selectors (issue #630) are stageable: the General tab must render
+// two independent selectors, one per provider type, each pre-selected to the
+// env's attachment.
+export const SEED_ENV_GAMMA = 'gamma';
 // One configured cloud provider alias so the Manage dialog's Cloud alias
 // select renders deterministically. The matching `aws` stub keeps its token
 // status check instant and offline.
 export const SEED_CLOUD_ALIAS = 'pw-aws';
+// One configured Cloudflare alias (issue #630). Cloudflare aliases follow the
+// "<token-label>+<account-id>@cloudflare" shape erun-common mints. No token is
+// written to the off-config secret store, so its status reads "not_configured"
+// deterministically and offline — the alias's scoped-token verify never hits
+// the network in the harness. That is the correct staged state for asserting
+// the per-type selector, the per-type sidebar row, and the "Verify token"
+// (re-verify) action without a live Cloudflare account.
+export const SEED_CLOUDFLARE_ALIAS = 'pw-token+0123456789abcdef@cloudflare';
 
 // isolatedRoot resolves the suite-owned root directory. run.sh exports
 // ERUN_PLAYWRIGHT_HOME; when the suite is launched without it (direct
@@ -173,7 +186,18 @@ export function seedBaseline(): void {
       'cloudproviders:\n' +
       `  - alias: ${SEED_CLOUD_ALIAS}\n` +
       '    provider: aws\n' +
-      `    profile: ${SEED_CLOUD_ALIAS}\n`,
+      `    profile: ${SEED_CLOUD_ALIAS}\n` +
+      // The Cloudflare alias carries its identity (account id + token label) and
+      // a token ref, but no token is written to the secret store, so its status
+      // resolves to not_configured without touching the Cloudflare API.
+      `  - alias: ${SEED_CLOUDFLARE_ALIAS}\n` +
+      '    provider: cloudflare\n' +
+      '    username: pw-token\n' +
+      '    accountid: 0123456789abcdef\n' +
+      '    cloudflare:\n' +
+      '      accountid: 0123456789abcdef\n' +
+      '      tokenname: pw-token\n' +
+      `      tokenref: cloudflare/${SEED_CLOUDFLARE_ALIAS}\n`,
   );
   fs.writeFileSync(
     path.join(root, SEED_TENANT, 'config.yaml'),
@@ -181,7 +205,8 @@ export function seedBaseline(): void {
       `name: ${SEED_TENANT}\n` +
       `defaultenvironment: ${SEED_ENV_ALPHA}\n` +
       'cloudprovideraliases:\n' +
-      `  - ${SEED_CLOUD_ALIAS}\n`,
+      `  - ${SEED_CLOUD_ALIAS}\n` +
+      `  - ${SEED_CLOUDFLARE_ALIAS}\n`,
   );
   seedEnvironment(SEED_TENANT, SEED_ENV_ALPHA);
   // beta additionally links the seeded cloud alias so the Manage dialog's
@@ -189,6 +214,15 @@ export function seedBaseline(): void {
   // clear.spec.ts). The alias has no cloud context behind it, so it stays
   // inert.
   seedEnvironment(SEED_TENANT, SEED_ENV_BETA, `cloudprovideralias: ${SEED_CLOUD_ALIAS}\n`);
+  // gamma links both an AWS alias (legacy scalar) and a Cloudflare alias
+  // (per-type map) so the per-provider-type env selectors are stageable.
+  seedEnvironment(
+    SEED_TENANT,
+    SEED_ENV_GAMMA,
+    `cloudprovideralias: ${SEED_CLOUD_ALIAS}\n` +
+      'cloudprovideraliases:\n' +
+      `  cloudflare: ${SEED_CLOUDFLARE_ALIAS}\n`,
+  );
 }
 
 // seedEnvironment writes one inert local-agent env config. Mirrors

--- a/erun-ui/playwright/pages/GlobalConfigDialog.ts
+++ b/erun-ui/playwright/pages/GlobalConfigDialog.ts
@@ -47,7 +47,61 @@ export class GlobalConfigDialog {
   }
 
   cloudAliasRow(alias: string): Locator {
-    return this.locator().locator(`text=${alias}`).first();
+    return this.locator().locator(`[data-cloud-alias="${alias}"]`).first();
+  }
+
+  // cloudAliasGroupHeading targets the labelled group heading for a provider
+  // type (issue #630). data-cloud-alias-group carries the provider type token.
+  cloudAliasGroupHeading(providerType: string): Locator {
+    return this.locator().locator(`[data-cloud-alias-group="${providerType}"]`);
+  }
+
+  // --- Add-provider picker + Cloudflare form (issue #630) ---
+
+  // addAWSButton targets the "AWS" add button in the provider picker (opens an
+  // SSO PTY session).
+  addAWSButton(): Locator {
+    return this.locator().getByRole('button', { name: 'AWS', exact: true });
+  }
+
+  // addCloudflareButton targets the "Cloudflare" add button in the provider
+  // picker (reveals the inline masked-token form).
+  addCloudflareButton(): Locator {
+    return this.locator().getByRole('button', { name: 'Cloudflare', exact: true });
+  }
+
+  async openCloudflareForm(): Promise<void> {
+    await this.addCloudflareButton().click();
+  }
+
+  cloudflareForm(): Locator {
+    return this.locator().locator('form[aria-label="Add Cloudflare token"]');
+  }
+
+  cloudflareAccountIdInput(): Locator {
+    return this.locator().locator('#global-config-cloudflare-accountid');
+  }
+
+  cloudflareTokenNameInput(): Locator {
+    return this.locator().locator('#global-config-cloudflare-tokenname');
+  }
+
+  cloudflareApiTokenInput(): Locator {
+    return this.locator().locator('#global-config-cloudflare-apitoken');
+  }
+
+  cloudflareSubmitButton(): Locator {
+    return this.cloudflareForm().getByRole('button', { name: /Add token|Verifying/ });
+  }
+
+  async fillCloudflareForm(input: {
+    accountId: string;
+    tokenName: string;
+    apiToken: string;
+  }): Promise<void> {
+    await this.cloudflareAccountIdInput().fill(input.accountId);
+    await this.cloudflareTokenNameInput().fill(input.tokenName);
+    await this.cloudflareApiTokenInput().fill(input.apiToken);
   }
 
   async refreshCloudProviders(): Promise<void> {
@@ -59,7 +113,10 @@ export class GlobalConfigDialog {
   }
 
   async cancel(): Promise<void> {
-    const button = this.locator().getByRole('button', { name: 'Cancel' });
+    // Match the footer Cancel exactly: the Cloudflare add form's close button
+    // is labelled "Cancel adding Cloudflare token", which a substring match
+    // would also resolve.
+    const button = this.locator().getByRole('button', { name: 'Cancel', exact: true });
     await button.scrollIntoViewIfNeeded();
     await button.click();
   }

--- a/erun-ui/playwright/pages/ManageDialog.ts
+++ b/erun-ui/playwright/pages/ManageDialog.ts
@@ -144,16 +144,22 @@ export class ManageDialog {
     return this.locator().getByRole('button', { name: `Remove registry ${String(index + 1)}` });
   }
 
-  // envTypeFieldValue reads the "Environment type" readonly field on the
-  // General tab so specs can pick a remote env without a backend round-trip.
-  // ReadonlyField puts the human label on the element with the field id and
-  // labels the value sibling with aria-labelledby, so the value lives on
-  // [aria-labelledby="<id>"], not on the id'd node itself.
+  // envTypeFieldValue reads the "Environment type" field on the General tab so
+  // specs can read the env's resolved type without a backend round-trip.
+  //
+  // The type field used to be a ReadonlyField (value carried on a sibling
+  // labelled [aria-labelledby="environment-config-type"]), but #617 turned it
+  // into the correctable EnvironmentTypeField SelectField whose value text
+  // lives on the trigger itself (id="environment-config-type"). The old
+  // aria-labelledby selector matches nothing now, which silently read every
+  // type as "" — caught here and fixed alongside the #630 cloud-alias work.
+  // Read the SelectField trigger's text content (its selected-value label).
   async envTypeFieldValue(): Promise<string> {
-    const field = this.locator().locator('[aria-labelledby="environment-config-type"]');
-    if (!(await field.isVisible().catch(() => false))) {
+    const field = this.environmentTypeSelect();
+    if ((await field.count()) === 0) {
       return '';
     }
+    await field.scrollIntoViewIfNeeded().catch(() => undefined);
     return (await field.textContent())?.trim() ?? '';
   }
 
@@ -225,6 +231,36 @@ export class ManageDialog {
   async chooseCloudAliasNone(): Promise<void> {
     await this.openCloudAliasOptions();
     await this.cloudAliasNoneOption().click();
+  }
+
+  // --- Per-provider-type cloud-alias selectors (issue #630) ---
+
+  // cloudAliasSlotSelect targets the per-provider-type cloud-alias selector on
+  // the General tab. The AWS slot keeps the historical id
+  // (#environment-config-cloudprovideralias); every other provider type
+  // ("cloudflare") uses a suffixed id, so an env attaching both aliases renders
+  // two addressable selectors.
+  cloudAliasSlotSelect(providerType: string): Locator {
+    const type = providerType.trim().toLowerCase();
+    const id =
+      type === '' || type === 'aws'
+        ? 'environment-config-cloudprovideralias'
+        : `environment-config-cloudprovideralias-${type}`;
+    return this.locator().locator(`#${id}`);
+  }
+
+  async cloudAliasSlotVisible(providerType: string): Promise<boolean> {
+    return this.cloudAliasSlotSelect(providerType)
+      .isVisible()
+      .catch(() => false);
+  }
+
+  async cloudAliasSlotValue(providerType: string): Promise<string> {
+    return (await this.cloudAliasSlotSelect(providerType).textContent())?.trim() ?? '';
+  }
+
+  async openCloudAliasSlotOptions(providerType: string): Promise<void> {
+    await this.cloudAliasSlotSelect(providerType).click();
   }
 
   // claudeEffortSelect targets the "Effort" SelectField in the Claude section

--- a/erun-ui/playwright/pages/Sidebar.ts
+++ b/erun-ui/playwright/pages/Sidebar.ts
@@ -160,6 +160,38 @@ export class Sidebar {
     return this.locator().getByRole('button').last();
   }
 
+  // --- Per-provider-type cloud-alias rows (issue #630) ---
+
+  // cloudAliasRowTrigger targets one bottom-of-sidebar cloud-status row by its
+  // alias. Each provider type the active tenant uses gets its own row, labelled
+  // "<alias> cloud status".
+  cloudAliasRowTrigger(alias: string): Locator {
+    return this.locator().getByRole('button', { name: `${alias} cloud status` });
+  }
+
+  // cloudAliasRowCount reports how many cloud-status rows render — one per
+  // provider type the active tenant references.
+  async cloudAliasRowCount(): Promise<number> {
+    return this.locator()
+      .getByRole('button', { name: /cloud status$/ })
+      .count();
+  }
+
+  async openCloudAliasPopover(alias: string): Promise<void> {
+    await this.cloudAliasRowTrigger(alias).click();
+  }
+
+  // cloudAliasPopover targets the open popover for a cloud-alias row. The
+  // popover is portal'd to the document body, so it is queried at the page
+  // root. Scoping by the alias text inside it keeps the right one selected.
+  cloudAliasPopover(): Locator {
+    return this.page.locator('[data-radix-popper-content-wrapper]').first();
+  }
+
+  cloudAliasPopoverButton(name: string | RegExp): Locator {
+    return this.cloudAliasPopover().getByRole('button', { name });
+  }
+
   async tenants(): Promise<string[]> {
     // The toggle button's aria-label is "Collapse <name>" or "Expand
     // <name>"; strip the prefix to recover the tenant name in DOM order.

--- a/erun-ui/playwright/tests/cloudflare-cloud-alias.spec.ts
+++ b/erun-ui/playwright/tests/cloudflare-cloud-alias.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '../fixtures/erunApp.js';
+import {
+  SEED_CLOUD_ALIAS,
+  SEED_CLOUDFLARE_ALIAS,
+  SEED_ENV_GAMMA,
+  SEED_TENANT,
+} from '../fixtures/seedRoot.js';
+
+// Multi-provider cloud aliases (issue #630): the desktop surfaces AWS and
+// Cloudflare aliases as distinct provider types. These specs lock the three
+// new user-facing surfaces against the seeded baseline (one AWS alias, one
+// Cloudflare alias, and the `gamma` env attaching both):
+//
+//  1. the settings dialog's provider picker + Cloudflare add form,
+//  2. the per-provider-type sidebar login rows,
+//  3. the per-provider-type env cloud-alias selectors.
+//
+// The seeded Cloudflare alias has no token in the off-config secret store, so
+// its status resolves to not_configured deterministically and offline — the
+// scoped-token verify never hits the network. Submitting the add form would
+// call the live Cloudflare API, so the add-form spec asserts the form's
+// presence, masking, and validation gating without submitting; the Go unit
+// coverage for the verify/store round-trip lives in erun-common
+// (cloud_cloudflare.go) and the erun-cli integration goldens.
+
+test.describe('multi-provider cloud aliases', () => {
+  test('settings provider picker reveals the masked Cloudflare add form', async ({ app }) => {
+    await app.sidebar.openSettings();
+    await app.globalConfigDialog.waitForOpen();
+
+    // Both seeded aliases render, grouped under their provider-type headings.
+    await expect(app.globalConfigDialog.cloudAliasGroupHeading('aws')).toBeVisible();
+    await expect(app.globalConfigDialog.cloudAliasGroupHeading('cloudflare')).toBeVisible();
+    await expect(app.globalConfigDialog.cloudAliasRow(SEED_CLOUD_ALIAS)).toBeVisible();
+    await expect(app.globalConfigDialog.cloudAliasRow(SEED_CLOUDFLARE_ALIAS)).toBeVisible();
+
+    // The provider picker offers both providers; Cloudflare reveals the inline
+    // masked-token form (no terminal/PTY).
+    await expect(app.globalConfigDialog.addAWSButton()).toBeVisible();
+    await app.globalConfigDialog.openCloudflareForm();
+    await expect(app.globalConfigDialog.cloudflareForm()).toBeVisible();
+
+    // The API token field is masked (error prevention / shoulder-surfing).
+    await expect(app.globalConfigDialog.cloudflareApiTokenInput()).toHaveAttribute(
+      'type',
+      'password',
+    );
+
+    // Submit stays disabled until every field is filled (error prevention,
+    // Nielsen #5). Filling the form enables it; we do not submit because the
+    // verify would call the live Cloudflare API.
+    await expect(app.globalConfigDialog.cloudflareSubmitButton()).toBeDisabled();
+    await app.globalConfigDialog.fillCloudflareForm({
+      accountId: '0123456789abcdef',
+      tokenName: 'pw-new-token',
+      apiToken: 'cf-test-token-value',
+    });
+    await expect(app.globalConfigDialog.cloudflareSubmitButton()).toBeEnabled();
+
+    await app.globalConfigDialog.cancel();
+    await app.globalConfigDialog.waitForClosed();
+  });
+
+  test('sidebar shows one independent login row per provider type', async ({ app }) => {
+    // Selecting any pw env makes the tenant's cloud rows the active set. gamma
+    // is a seeded baseline env under pw, which references both aliases.
+    await app.sidebar.openEnvironment(SEED_TENANT, SEED_ENV_GAMMA);
+
+    // Two rows render — one per provider type — each labelled by its alias.
+    await expect(app.sidebar.cloudAliasRowTrigger(SEED_CLOUD_ALIAS)).toBeVisible();
+    await expect(app.sidebar.cloudAliasRowTrigger(SEED_CLOUDFLARE_ALIAS)).toBeVisible();
+    await expect.poll(() => app.sidebar.cloudAliasRowCount()).toBe(2);
+
+    // The Cloudflare row's popover offers "Verify token" (a re-verify, not a
+    // browser SSO) and hides "Get bearer token" (Cloudflare has no OIDC).
+    await app.sidebar.openCloudAliasPopover(SEED_CLOUDFLARE_ALIAS);
+    await expect(app.sidebar.cloudAliasPopoverButton(/Verify token/)).toBeVisible();
+    await expect(app.sidebar.cloudAliasPopoverButton(/Get bearer token/)).toHaveCount(0);
+  });
+
+  test('env manage dialog renders a selector per provider type', async ({ app }) => {
+    await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, SEED_ENV_GAMMA);
+    await app.manageDialog.waitForOpen();
+
+    // gamma attaches both aliases, so both per-type selectors render, each
+    // pre-selected to the env's attachment for that type.
+    expect(await app.manageDialog.cloudAliasSlotVisible('aws')).toBe(true);
+    expect(await app.manageDialog.cloudAliasSlotVisible('cloudflare')).toBe(true);
+    await expect.poll(() => app.manageDialog.cloudAliasSlotValue('aws')).toBe(SEED_CLOUD_ALIAS);
+    await expect
+      .poll(() => app.manageDialog.cloudAliasSlotValue('cloudflare'))
+      .toBe(SEED_CLOUDFLARE_ALIAS);
+
+    // Each selector independently offers a "— None —" clear option. Clear the
+    // Cloudflare slot and confirm only it returns to the placeholder while the
+    // AWS slot stays attached (per-type independence). Cancel without saving so
+    // the seeded config is untouched.
+    await app.manageDialog.openCloudAliasSlotOptions('cloudflare');
+    await app.manageDialog.cloudAliasNoneOption().click();
+    await expect
+      .poll(() => app.manageDialog.cloudAliasSlotValue('cloudflare'))
+      .toBe('Select cloud alias');
+    await expect.poll(() => app.manageDialog.cloudAliasSlotValue('aws')).toBe(SEED_CLOUD_ALIAS);
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+});

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -223,6 +223,7 @@ type uiEnvironmentConfig struct {
 	ContainerRegistries   []uiContainerRegistryEntry `json:"containerRegistries"`
 	CloudProviderAlias    string                     `json:"cloudProviderAlias"`
 	CloudProviderAliases  []string                   `json:"cloudProviderAliases,omitempty"`
+	CloudAliasSlots       []uiEnvironmentCloudAlias  `json:"cloudAliasSlots,omitempty"`
 	CloudContext          *uiCloudContextStatus      `json:"cloudContext,omitempty"`
 	RuntimeVersion        string                     `json:"runtimeVersion"`
 	RuntimePod            uiRuntimePodConfig         `json:"runtimePod"`
@@ -344,6 +345,28 @@ type uiAWSCloudAliasInput struct {
 	SSORegion     string `json:"ssoRegion,omitempty"`
 	SSOStartURL   string `json:"ssoStartUrl,omitempty"`
 	OIDCIssuerURL string `json:"oidcIssuerUrl,omitempty"`
+}
+
+// uiCloudflareCloudAliasInput carries the explicit inputs for the
+// non-interactive Cloudflare "add token" form: the account the scoped token
+// belongs to, a human label for the token, and the secret token itself. The
+// token rides through a masked field; it is persisted to the off-config secret
+// store, never echoed back to the UI or written into erun-config.yaml.
+type uiCloudflareCloudAliasInput struct {
+	AccountID string `json:"accountId,omitempty"`
+	TokenName string `json:"tokenName,omitempty"`
+	APIToken  string `json:"apiToken,omitempty"`
+}
+
+// uiEnvironmentCloudAlias is one provider-type slot in the env's cloud-alias
+// view: the provider type ("aws", "cloudflare"), the alias currently attached
+// to the env for that type (empty when none), and the configured aliases of
+// that type the operator can choose from. The frontend renders one selector
+// per slot so an env can attach an AWS alias AND a Cloudflare alias at once.
+type uiEnvironmentCloudAlias struct {
+	Provider string   `json:"provider"`
+	Alias    string   `json:"alias"`
+	Options  []string `json:"options"`
 }
 
 type uiCloudContextInitInput struct {


### PR DESCRIPTION
Closes #630

## What this does

Generalizes ERun's cloud-alias system beyond AWS. An operator can now keep multiple cloud aliases on the desktop, attach **one per provider type** to an environment, and log into them independently from the sidebar. The first new provider type is **Cloudflare**, whose delegated, account-scoped API token is delivered into the runtime pod so the in-pod Terraform Cloudflare provider authenticates as it — driving the new `terraform-erun-cloudflare-services` zone-delegation module.

The approach extends the existing `switch provider.Provider` shape with a `case CloudProviderCloudflare` (KISS, per `erun-common/AGENTS.md`) rather than introducing a driver registry — so **every AWS branch is byte-for-byte unchanged** and existing behavior is preserved by construction.

## Cloudflare credential model

- The alias holds a **delegated, account-scoped** API token (account-level `Zone:Edit` + `DNS:Edit` — least-privilege but able to create the delegated zone). It is **verified against the Cloudflare API** at add time.
- The token is stored in a file-backed secret store (`<config>/cloud-secrets`, 0600), referenced from `erun-config.yaml` by a `TokenRef` — **never written inline**.
- At deploy, the token is delivered to the runtime pod as a Kubernetes Secret via `kubectl apply -f -` (manifest on **stdin**), so it never appears in argv, the trace, or helm release values. The chart wires `CLOUDFLARE_API_TOKEN` (secretKeyRef) + `CLOUDFLARE_ACCOUNT_ID` (non-secret value) — gated, so non-Cloudflare deploys are unchanged.
- Cloudflare aliases are **non-OIDC** (skipped in tenant issuer aggregation, strictly by type) and **context-less** (cloud contexts stay AWS/EC2-only).

## Change surface

- **erun-common** — `CloudProviderCloudflare`, `CloudflareProviderConfig`, `CloudSecretStore` (+ file-backed default), `InitCloudflareCloudProvider`, Cloudflare cases in login/logout/bearer/status, `ErrCloudProviderNoOIDC`. `EnvConfig.CloudProviderAliases` per-type map + `ResolvedCloudAliases()` (AWS scalar stays the AWS slot → zero churn to AWS readers). Deploy threads gated Cloudflare metadata + applies the Secret.
- **erun-cli / erun-mcp** — `erun cloud init cloudflare` + `cloud_init_cloudflare` (explicit inputs; masked CLI token prompt); `login`/`oidc`/`set` provider-neutral; `oidc` rejects Cloudflare aliases clearly.
- **erun-devops** — runtime chart Cloudflare block; new `terraform-erun-cloudflare-services` module (cloudflare/cloudflare v5 zone delegation).
- **erun-ui** — provider picker (Add AWS / Add Cloudflare) with a masked non-interactive token form; one sidebar login row per provider type with a per-alias busy map; per-type env attachment with per-type "— None —" clear; refresher stays AWS-only; Playwright fixtures + spec; Wails bindings regenerated.
- **erun-docs** — `cli/cloud.md`, `deployment/cloud-setup.md`, `concepts/cloud-contexts.md`, `reference/configuration.md`.

## Validation

- `erun-common` / `erun-cli` / `erun-mcp`: `go build` + `go vet` + `go test` green; focused unit tests added for the secret store (0600), token redaction, secret-manifest quoting, Cloudflare token-verify HTTP classification (httptest), per-type resolution, and OIDC-issuer skip.
- **`make integration-test` green @ 76.6% coverage** (≥ 75% gate). New `cloud init cloudflare` `--help` + `--dry-run` goldens (token redacted in trace and audit lines); **all AWS goldens byte-identical**.
- `erun-ui`: `go build`/`go vet`/`golangci-lint` clean (0 issues); frontend `typecheck`/`lint`/`format:check`/`build` all pass; new + impacted Playwright specs pass (41 passed, 0 failed); also fixes a pre-existing red POM helper (`sidebar-local-badge`, broken by #617).
- `terraform-erun-cloudflare-services`: `terraform validate` succeeds against the real cloudflare/cloudflare v5 schema.
- `erun-devops` chart: `helm template` confirms the Cloudflare env block is present when enabled and absent otherwise.
- `cd erun-docs && yarn build` clean.

## Honest notes (not fully verified here)

- **Live deploy against a real cluster was not run** — there is no cluster in this environment. The Secret-apply path is exercised by dry-run trace (token redacted) + unit-validated rendering; the actual `kubectl apply` + pod mount should be confirmed on a real deploy.
- The desktop add-form's **live Cloudflare token verify** (network call) is the one path not driven end-to-end by the Playwright harness (the seeded alias is offline → `not_configured`); its verify/store round-trip is covered by erun-common unit tests + the CLI integration goldens.
- `erun-ui` `TestCloseReapsWholeProcessGroup` fails **only in this sandbox** (a PTY process-group reaping artifact in `session_unix.go`); confirmed failing on clean `main` HEAD here, untouched by this work, and not part of the integration gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)