### PR TITLE
Fix Cloudflare token-setup guidance to match the real Create Custom Token UI

### DIFF
--- a/erun-cli/cmd/cloud.go
+++ b/erun-cli/cmd/cloud.go
@@ -107,8 +107,8 @@ func newCloudInitCloudflareCmd(store common.CloudStore, promptRunner PromptRunne
 		Use:   "cloudflare",
 		Short: "Set up a Cloudflare cloud provider alias",
 		Long: "Set up a Cloudflare cloud provider alias.\n\n" +
-			"Run with no flags for a guided setup: ERun shows you where to mint a delegated, " +
-			"account-scoped API token (account-level Zone:Edit + DNS:Edit), then prompts for it, " +
+			"Run with no flags for a guided setup: ERun shows you where to mint a delegated " +
+			"API token (Zone:Edit + DNS:Edit across your account's zones), then prompts for it, " +
 			"verifies it against the Cloudflare API, and auto-resolves the account ID from the " +
 			"token. The token is held in a local secret store referenced from erun config — it is " +
 			"never written into erun-config.yaml. Environments that attach this alias receive the " +
@@ -123,7 +123,7 @@ func newCloudInitCloudflareCmd(store common.CloudStore, promptRunner PromptRunne
 	}
 	cmd.Flags().StringVar(&params.AccountID, "account-id", "", "Cloudflare account ID the token belongs to (auto-resolved in guided setup)")
 	cmd.Flags().StringVar(&params.TokenName, "token-name", "", "Label for the scoped API token (defaults in guided setup)")
-	cmd.Flags().StringVar(&params.APIToken, "api-token", "", "Cloudflare scoped API token value (account-level Zone:Edit + DNS:Edit)")
+	cmd.Flags().StringVar(&params.APIToken, "api-token", "", "Cloudflare scoped API token value (Zone:Edit + DNS:Edit across the account's zones)")
 	addDryRunFlag(cmd)
 	return cmd
 }
@@ -193,10 +193,13 @@ func runCloudflareInitWizard(ctx common.Context, promptRunner PromptRunner, sele
 	fmt.Fprintln(out, "\nStep 1 of 3 · Create the token")
 	fmt.Fprintln(out, "  Open this page (you're already logged in to Cloudflare there):")
 	fmt.Fprintln(out, "    "+common.CloudflareCreateTokenURL)
-	fmt.Fprintln(out, "  Click Create Token → Create Custom Token, then set:")
-	fmt.Fprintln(out, "    Permissions:        Zone → Edit,  DNS → Edit")
-	fmt.Fprintln(out, "    Account Resources:  Include → <your account>")
-	fmt.Fprintln(out, "  Create the token and copy it.")
+	fmt.Fprintln(out, "  Click Create Token → Create Custom Token, give it a name, then add")
+	fmt.Fprintln(out, "  two permission rows (each row is Scope → Permission → Access; use")
+	fmt.Fprintln(out, "  \"+ Add more\" for the second):")
+	fmt.Fprintln(out, "    Zone → Zone → Edit    (create the delegated subzone)")
+	fmt.Fprintln(out, "    Zone → DNS  → Edit    (manage DNS records)")
+	fmt.Fprintln(out, "  Set Zone Resources to:  Include → All zones")
+	fmt.Fprintln(out, "  Continue to summary → Create Token, then copy the token.")
 	if _, err := promptRunner(promptui.Prompt{Label: "Press Enter once you've copied the token"}); err != nil {
 		return params, err
 	}

--- a/erun-common/cloud_cloudflare.go
+++ b/erun-common/cloud_cloudflare.go
@@ -52,9 +52,9 @@ type CloudflareAccount struct {
 }
 
 // InitCloudflareCloudProviderParams are the explicit inputs for adding a
-// Cloudflare cloud alias. The API token is an account-scoped, delegated token
-// (account-level Zone:Edit + DNS:Edit) the operator minted in the Cloudflare
-// dashboard; erun stores it via the CloudSecretStore, never inline.
+// Cloudflare cloud alias. The API token is a delegated, custom token the
+// operator minted in the Cloudflare dashboard with Zone:Edit + DNS:Edit across
+// the account's zones; erun stores it via the CloudSecretStore, never inline.
 type InitCloudflareCloudProviderParams struct {
 	AccountID string
 	TokenName string

--- a/erun-docs/docs/cli/cloud.md
+++ b/erun-docs/docs/cli/cloud.md
@@ -37,7 +37,7 @@ Omitted flags are prompted for interactively.
 
 Saves a delegated, account-scoped Cloudflare API token as a cloud provider alias. Run with **no flags** for a guided, step-by-step setup:
 
-1. **Create the token** — ERun prints the Cloudflare token page and the exact permissions to set (**account-level `Zone:Edit` + `DNS:Edit`**), then waits while you mint it in your already-logged-in browser session.
+1. **Create the token** — ERun prints the Cloudflare token page and the exact **Custom Token** permissions to set — `Zone → Zone → Edit` and `Zone → DNS → Edit`, with Zone Resources `Include → All zones` — then waits while you mint it in your already-logged-in browser session.
 2. **Paste the token** — entered masked and verified against the Cloudflare API; an invalid token re-prompts in place.
 3. **Confirm the account** — ERun resolves the account ID from the token automatically (a picker appears if the token sees more than one account), and proposes an editable token label.
 

--- a/erun-docs/docs/deployment/cloud-setup.md
+++ b/erun-docs/docs/deployment/cloud-setup.md
@@ -81,7 +81,7 @@ ERun deploys into it exactly the same way, but doesn't manage its lifecycle — 
 
 Cloudflare support is a **separate alias type**, not a managed cloud context. There is no VM to provision and no lifecycle to manage — a Cloudflare alias simply delivers a delegated, account-scoped API token into an environment's runtime pod so in-pod tooling (such as Terraform) can manage Cloudflare DNS and zones. It is independent of the AWS path above: an environment can hold an AWS alias and a Cloudflare alias at the same time.
 
-The token is **delegated and account-scoped** — you mint it once in the Cloudflare dashboard with account-level `Zone:Edit` + `DNS:Edit`, and ERun never asks for your dashboard password or a global key. Register it with the guided setup:
+The token is **delegated and least-privilege** — you mint it once in the Cloudflare dashboard as a **Custom Token** with two permission rows, `Zone → Zone → Edit` (create the delegated subzone) and `Zone → DNS → Edit` (manage records), scoped to **Zone Resources: All zones**. ERun never asks for your dashboard password or your Global API Key. Register it with the guided setup:
 
 ```bash
 erun cloud init cloudflare

--- a/erun-integration/testdata/cloud/init_cloudflare_help.txt
+++ b/erun-integration/testdata/cloud/init_cloudflare_help.txt
@@ -1,6 +1,6 @@
 Set up a Cloudflare cloud provider alias.
 
-Run with no flags for a guided setup: ERun shows you where to mint a delegated, account-scoped API token (account-level Zone:Edit + DNS:Edit), then prompts for it, verifies it against the Cloudflare API, and auto-resolves the account ID from the token. The token is held in a local secret store referenced from erun config — it is never written into erun-config.yaml. Environments that attach this alias receive the token as CLOUDFLARE_API_TOKEN so in-pod tooling (e.g. terraform) authenticates as it.
+Run with no flags for a guided setup: ERun shows you where to mint a delegated API token (Zone:Edit + DNS:Edit across your account's zones), then prompts for it, verifies it against the Cloudflare API, and auto-resolves the account ID from the token. The token is held in a local secret store referenced from erun config — it is never written into erun-config.yaml. Environments that attach this alias receive the token as CLOUDFLARE_API_TOKEN so in-pod tooling (e.g. terraform) authenticates as it.
 
 Pass --api-token (with --account-id and --token-name) for non-interactive setup.
 
@@ -13,7 +13,7 @@ Examples:
 
 Flags:
       --account-id string   Cloudflare account ID the token belongs to (auto-resolved in guided setup)
-      --api-token string    Cloudflare scoped API token value (account-level Zone:Edit + DNS:Edit)
+      --api-token string    Cloudflare scoped API token value (Zone:Edit + DNS:Edit across the account's zones)
       --dry-run             Resolve and trace mutating actions without executing them.
   -h, --help                help for cloudflare
       --token-name string   Label for the scoped API token (defaults in guided setup)

--- a/erun-mcp/cloud.go
+++ b/erun-mcp/cloud.go
@@ -27,7 +27,7 @@ type CloudInitAWSInput struct {
 type CloudInitCloudflareInput struct {
 	AccountID string `json:"accountId" jsonschema:"Cloudflare account ID the scoped API token belongs to"`
 	TokenName string `json:"tokenName" jsonschema:"label for the scoped API token"`
-	APIToken  string `json:"apiToken" jsonschema:"Cloudflare scoped API token value (account-level Zone:Edit + DNS:Edit); held in the local secret store, never written to erun-config.yaml"`
+	APIToken  string `json:"apiToken" jsonschema:"Cloudflare scoped API token value (Zone:Edit + DNS:Edit across the account's zones); held in the local secret store, never written to erun-config.yaml"`
 	Preview   bool   `json:"preview,omitempty" jsonschema:"when true, return the planned operation without verifying the token or saving config"`
 	Verbosity int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
 }

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -198,7 +198,7 @@ func registerCloudTools(server *mcp.Server, runtime RuntimeConfig) {
 	}, cloudInitAWSTool(runtime))
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "cloud_init_cloudflare",
-		Description: "Initialize a Cloudflare cloud provider alias from a delegated, account-scoped API token (account-level Zone:Edit + DNS:Edit). The token is verified against the Cloudflare API and held in a local secret store referenced from erun config, never written into erun-config.yaml; environments that attach the alias receive it as CLOUDFLARE_API_TOKEN. Supports preview.",
+		Description: "Initialize a Cloudflare cloud provider alias from a delegated API token (Zone:Edit + DNS:Edit across the account's zones). The token is verified against the Cloudflare API and held in a local secret store referenced from erun config, never written into erun-config.yaml; environments that attach the alias receive it as CLOUDFLARE_API_TOKEN. Supports preview.",
 	}, cloudInitCloudflareTool(runtime))
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "cloud_login",


### PR DESCRIPTION
Closes #634

Follow-up to #632. Walking the live Cloudflare "Create Custom Token" dashboard showed the guided wizard's instructions were imprecise — they said `Permissions: Zone → Edit, DNS → Edit` + `Account Resources`, but the real UI is a 3-dropdown row (Scope → Permission → Access) needing **two Zone-scope rows** plus **Zone Resources**.

## Change

The guided `erun cloud init cloudflare` Step 1 now prints the exact clicks:

```
Click Create Token → Create Custom Token, give it a name, then add
two permission rows (each row is Scope → Permission → Access; use
"+ Add more" for the second):
  Zone → Zone → Edit    (create the delegated subzone)
  Zone → DNS  → Edit    (manage DNS records)
Set Zone Resources to:  Include → All zones
```

(Verified against the built binary, not just the source.)

The inaccurate "account-level Zone:Edit + DNS:Edit" phrasing is corrected to "Zone:Edit + DNS:Edit across the account's zones" everywhere it described the permissions: the CLI Long help + `--api-token` flag, the `cloud_init_cloudflare` MCP description + `apiToken` schema, the `InitCloudflareCloudProviderParams` comment, and the docs (`cli/cloud.md`, `deployment/cloud-setup.md`).

## Validation

- `go build`/`test` green in erun-cli/erun-mcp/erun-common.
- `make integration-test` green @ 76.2%; only the `cloud init cloudflare --help` golden regenerated (text change). Dry-run goldens unchanged — the wizard prose is interactive, not part of the dry-run trace.
- `cd erun-docs && yarn build` clean.

Behaviour is unchanged — this is guidance/wording only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)