### PR TITLE
Cloudflare wizard: robust account auto-resolution + broad-token guidance

### DIFF
--- a/erun-cli/cmd/cloud.go
+++ b/erun-cli/cmd/cloud.go
@@ -108,7 +108,8 @@ func newCloudInitCloudflareCmd(store common.CloudStore, promptRunner PromptRunne
 		Short: "Set up a Cloudflare cloud provider alias",
 		Long: "Set up a Cloudflare cloud provider alias.\n\n" +
 			"Run with no flags for a guided setup: ERun shows you where to mint a delegated " +
-			"API token (Zone:Edit + DNS:Edit across your account's zones), then prompts for it, " +
+			"API token (Zone + DNS edit, plus any other scopes you'll use such as Cloudflare " +
+			"Pages for static sites), then prompts for it, " +
 			"verifies it against the Cloudflare API, and auto-resolves the account ID from the " +
 			"token. The token is held in a local secret store referenced from erun config — it is " +
 			"never written into erun-config.yaml. Environments that attach this alias receive the " +
@@ -123,7 +124,7 @@ func newCloudInitCloudflareCmd(store common.CloudStore, promptRunner PromptRunne
 	}
 	cmd.Flags().StringVar(&params.AccountID, "account-id", "", "Cloudflare account ID the token belongs to (auto-resolved in guided setup)")
 	cmd.Flags().StringVar(&params.TokenName, "token-name", "", "Label for the scoped API token (defaults in guided setup)")
-	cmd.Flags().StringVar(&params.APIToken, "api-token", "", "Cloudflare scoped API token value (Zone:Edit + DNS:Edit across the account's zones)")
+	cmd.Flags().StringVar(&params.APIToken, "api-token", "", "Cloudflare API token value (Zone + DNS edit, plus any other scopes you'll use such as Cloudflare Pages)")
 	addDryRunFlag(cmd)
 	return cmd
 }
@@ -189,16 +190,19 @@ func resolveCloudflareAccountNonInteractive(ctx common.Context, token string, de
 func runCloudflareInitWizard(ctx common.Context, promptRunner PromptRunner, selectRunner SelectRunner, params common.InitCloudflareCloudProviderParams, deps common.CloudDependencies) (common.InitCloudflareCloudProviderParams, error) {
 	out := ctx.Stdout
 	fmt.Fprintln(out, "\nAdd a Cloudflare cloud alias")
-	fmt.Fprintln(out, "ERun needs a delegated, account-scoped API token (Zone:Edit + DNS:Edit). It never sees your Cloudflare password.")
+	fmt.Fprintln(out, "ERun needs a delegated Cloudflare API token. It never sees your Cloudflare password.")
 	fmt.Fprintln(out, "\nStep 1 of 3 · Create the token")
 	fmt.Fprintln(out, "  Open this page (you're already logged in to Cloudflare there):")
 	fmt.Fprintln(out, "    "+common.CloudflareCreateTokenURL)
 	fmt.Fprintln(out, "  Click Create Token → Create Custom Token, give it a name, then add")
-	fmt.Fprintln(out, "  two permission rows (each row is Scope → Permission → Access; use")
-	fmt.Fprintln(out, "  \"+ Add more\" for the second):")
-	fmt.Fprintln(out, "    Zone → Zone → Edit    (create the delegated subzone)")
-	fmt.Fprintln(out, "    Zone → DNS  → Edit    (manage DNS records)")
-	fmt.Fprintln(out, "  Set Zone Resources to:  Include → All zones")
+	fmt.Fprintln(out, "  these permission rows (each row is Scope → Permission → Access; use")
+	fmt.Fprintln(out, "  \"+ Add more\" for each):")
+	fmt.Fprintln(out, "    Zone    → Zone             → Edit   (create/manage zones)")
+	fmt.Fprintln(out, "    Zone    → DNS              → Edit   (manage DNS records)")
+	fmt.Fprintln(out, "    Account → Cloudflare Pages → Edit   (deploy static sites)")
+	fmt.Fprintln(out, "  Set Zone Resources to:    Include → All zones")
+	fmt.Fprintln(out, "  Set Account Resources to: Include → your account")
+	fmt.Fprintln(out, "  Add more rows (Workers, R2, etc.) if this token will manage those too.")
 	fmt.Fprintln(out, "  Continue to summary → Create Token, then copy the token.")
 	if _, err := promptRunner(promptui.Prompt{Label: "Press Enter once you've copied the token"}); err != nil {
 		return params, err

--- a/erun-common/cloud_cloudflare.go
+++ b/erun-common/cloud_cloudflare.go
@@ -18,9 +18,14 @@ import (
 // successful response confirms the scoped API token is valid and active.
 const cloudflareTokenVerifyURL = "https://api.cloudflare.com/client/v4/user/tokens/verify"
 
-// cloudflareAccountsURL lists the accounts a token can act on, used to
-// auto-resolve the account id during guided alias setup.
+// cloudflareAccountsURL lists the accounts a token can act on (works for tokens
+// with an account-scope permission). Used to auto-resolve the account id.
 const cloudflareAccountsURL = "https://api.cloudflare.com/client/v4/accounts"
+
+// cloudflareZonesURL lists the zones a token can act on. It is the fallback
+// account source for a Zone-scope-only token (which cannot list /accounts):
+// each zone object carries its account id+name.
+const cloudflareZonesURL = "https://api.cloudflare.com/client/v4/zones"
 
 // CloudflareCreateTokenURL is the Cloudflare dashboard page where an operator
 // mints an API token. The guided CLI flow prints it so the operator creates the
@@ -53,8 +58,9 @@ type CloudflareAccount struct {
 
 // InitCloudflareCloudProviderParams are the explicit inputs for adding a
 // Cloudflare cloud alias. The API token is a delegated, custom token the
-// operator minted in the Cloudflare dashboard with Zone:Edit + DNS:Edit across
-// the account's zones; erun stores it via the CloudSecretStore, never inline.
+// operator minted in the Cloudflare dashboard — Zone + DNS edit for delegation,
+// plus any other scopes they will use (e.g. Cloudflare Pages for static sites);
+// erun stores it via the CloudSecretStore, never inline.
 type InitCloudflareCloudProviderParams struct {
 	AccountID string
 	TokenName string
@@ -273,15 +279,92 @@ func verifyCloudflareTokenAt(url, token string) (CloudflareTokenInfo, error) {
 	return CloudflareTokenInfo{ID: payload.Result.ID, Status: payload.Result.Status}, nil
 }
 
-// defaultListCloudflareAccounts lists the accounts a token can act on, so the
-// guided setup can auto-resolve the account id. Dry-run returns a synthetic
-// account without touching the network.
+// defaultListCloudflareAccounts resolves the accounts a token can act on so the
+// guided setup can auto-resolve the account id. It tries /accounts first (works
+// for tokens carrying an account-scope permission, e.g. Cloudflare Pages); when
+// that yields nothing — the case for a least-privilege Zone-only token, which
+// has no account-read permission — it falls back to deriving the account from
+// the token's zones. Dry-run returns a synthetic account without any network.
 func defaultListCloudflareAccounts(ctx Context, token string) ([]CloudflareAccount, error) {
 	ctx.Trace("GET " + cloudflareAccountsURL)
 	if ctx.DryRun {
 		return []CloudflareAccount{{ID: "cf-account-id", Name: "Cloudflare account"}}, nil
 	}
-	return listCloudflareAccountsAt(cloudflareAccountsURL, token)
+	accounts, err := listCloudflareAccountsAt(cloudflareAccountsURL, token)
+	if err == nil && len(accounts) > 0 {
+		return accounts, nil
+	}
+	// Zone-scope-only tokens cannot list /accounts; derive from the zones the
+	// token can see — each zone object carries its account id+name.
+	ctx.Trace("GET " + cloudflareZonesURL)
+	zoneAccounts, zonesErr := resolveCloudflareAccountsViaZones(cloudflareZonesURL, token)
+	if zonesErr != nil {
+		if err != nil {
+			return nil, err
+		}
+		return nil, zonesErr
+	}
+	return zoneAccounts, nil
+}
+
+// resolveCloudflareAccountsViaZones derives the distinct account(s) a token can
+// act on from the zones it can list. A Zone-scope token can read /zones even
+// when it cannot read /accounts, so this is the robust fallback for the
+// least-privilege token. Split out for httptest-based unit testing.
+func resolveCloudflareAccountsViaZones(url, token string) ([]CloudflareAccount, error) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil, fmt.Errorf("cloudflare api token is required")
+	}
+	req, err := http.NewRequest(http.MethodGet, url+"?per_page=50", nil)
+	if err != nil {
+		return nil, fmt.Errorf("build cloudflare zones request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list cloudflare zones: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	var payload struct {
+		Success bool `json:"success"`
+		Errors  []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+		Result []struct {
+			Account struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"account"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("parse cloudflare zones response (status %d): %w", resp.StatusCode, err)
+	}
+	if !payload.Success {
+		message := "cloudflare rejected the zones request"
+		if len(payload.Errors) > 0 && strings.TrimSpace(payload.Errors[0].Message) != "" {
+			message = payload.Errors[0].Message
+		}
+		return nil, fmt.Errorf("list cloudflare zones: %s", message)
+	}
+	seen := make(map[string]struct{})
+	accounts := make([]CloudflareAccount, 0, 1)
+	for _, zone := range payload.Result {
+		id := strings.TrimSpace(zone.Account.ID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		accounts = append(accounts, CloudflareAccount{ID: id, Name: zone.Account.Name})
+	}
+	return accounts, nil
 }
 
 // listCloudflareAccountsAt performs the live accounts lookup against url. Split

--- a/erun-common/cloud_cloudflare_test.go
+++ b/erun-common/cloud_cloudflare_test.go
@@ -171,6 +171,57 @@ func TestListCloudflareAccountsAt(t *testing.T) {
 	}
 }
 
+func TestResolveCloudflareAccountsViaZones(t *testing.T) {
+	t.Run("dedupes account across zones", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+				t.Fatalf("authorization header = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"success":true,"result":[
+				{"id":"z1","account":{"id":"a1","name":"Acme"}},
+				{"id":"z2","account":{"id":"a1","name":"Acme"}},
+				{"id":"z3","account":{"id":"","name":"skip-blank"}}
+			]}`))
+		}))
+		defer srv.Close()
+		accounts, err := resolveCloudflareAccountsViaZones(srv.URL, "tok")
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		// One distinct account (a1), blank-account zone dropped.
+		if len(accounts) != 1 || accounts[0].ID != "a1" || accounts[0].Name != "Acme" {
+			t.Fatalf("accounts = %+v", accounts)
+		}
+	})
+
+	t.Run("returns each distinct account", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"success":true,"result":[
+				{"id":"z1","account":{"id":"a1","name":"Acme"}},
+				{"id":"z2","account":{"id":"a2","name":"Beta"}}
+			]}`))
+		}))
+		defer srv.Close()
+		accounts, err := resolveCloudflareAccountsViaZones(srv.URL, "tok")
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if len(accounts) != 2 || accounts[0].ID != "a1" || accounts[1].ID != "a2" {
+			t.Fatalf("accounts = %+v", accounts)
+		}
+	})
+
+	t.Run("rejected", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"success":false,"errors":[{"message":"bad token"}]}`))
+		}))
+		defer srv.Close()
+		if _, err := resolveCloudflareAccountsViaZones(srv.URL, "tok"); err == nil || !strings.Contains(err.Error(), "bad token") {
+			t.Fatalf("expected rejection error, got %v", err)
+		}
+	})
+}
+
 func TestResolveTenantCloudProviderIssuersSkipsCloudflare(t *testing.T) {
 	store := stubCloudContextStore{config: ERunConfig{CloudProviders: []CloudProviderConfig{
 		{Alias: "alice+123456789012@aws", Provider: CloudProviderAWS, OIDCIssuerURL: "https://issuer.example.com"},

--- a/erun-docs/docs/cli/cloud.md
+++ b/erun-docs/docs/cli/cloud.md
@@ -37,7 +37,7 @@ Omitted flags are prompted for interactively.
 
 Saves a delegated, account-scoped Cloudflare API token as a cloud provider alias. Run with **no flags** for a guided, step-by-step setup:
 
-1. **Create the token** — ERun prints the Cloudflare token page and the exact **Custom Token** permissions to set — `Zone → Zone → Edit` and `Zone → DNS → Edit`, with Zone Resources `Include → All zones` — then waits while you mint it in your already-logged-in browser session.
+1. **Create the token** — ERun prints the Cloudflare token page and the **Custom Token** permissions to set — `Zone → Zone → Edit` and `Zone → DNS → Edit` (Zone Resources `Include → All zones`), plus `Account → Cloudflare Pages → Edit` and any other scopes you'll use (Account Resources `Include → your account`) — then waits while you mint it in your already-logged-in browser session.
 2. **Paste the token** — entered masked and verified against the Cloudflare API; an invalid token re-prompts in place.
 3. **Confirm the account** — ERun resolves the account ID from the token automatically (a picker appears if the token sees more than one account), and proposes an editable token label.
 

--- a/erun-docs/docs/deployment/cloud-setup.md
+++ b/erun-docs/docs/deployment/cloud-setup.md
@@ -81,7 +81,7 @@ ERun deploys into it exactly the same way, but doesn't manage its lifecycle — 
 
 Cloudflare support is a **separate alias type**, not a managed cloud context. There is no VM to provision and no lifecycle to manage — a Cloudflare alias simply delivers a delegated, account-scoped API token into an environment's runtime pod so in-pod tooling (such as Terraform) can manage Cloudflare DNS and zones. It is independent of the AWS path above: an environment can hold an AWS alias and a Cloudflare alias at the same time.
 
-The token is **delegated and least-privilege** — you mint it once in the Cloudflare dashboard as a **Custom Token** with two permission rows, `Zone → Zone → Edit` (create the delegated subzone) and `Zone → DNS → Edit` (manage records), scoped to **Zone Resources: All zones**. ERun never asks for your dashboard password or your Global API Key. Register it with the guided setup:
+The token is **delegated** — you mint it once in the Cloudflare dashboard as a **Custom Token** scoped to what you'll do with it. For DNS and zone delegation that's two rows, `Zone → Zone → Edit` (create the delegated subzone) and `Zone → DNS → Edit` (manage records), with **Zone Resources: Include → All zones**. If you'll also deploy static sites with the same token, add `Account → Cloudflare Pages → Edit` (an Account-scope row, so also set **Account Resources: Include → your account**); add more rows (Workers, R2, …) for anything else the token will manage. ERun never asks for your dashboard password or your Global API Key. Register it with the guided setup:
 
 ```bash
 erun cloud init cloudflare

--- a/erun-integration/testdata/cloud/init_cloudflare_help.txt
+++ b/erun-integration/testdata/cloud/init_cloudflare_help.txt
@@ -1,6 +1,6 @@
 Set up a Cloudflare cloud provider alias.
 
-Run with no flags for a guided setup: ERun shows you where to mint a delegated API token (Zone:Edit + DNS:Edit across your account's zones), then prompts for it, verifies it against the Cloudflare API, and auto-resolves the account ID from the token. The token is held in a local secret store referenced from erun config — it is never written into erun-config.yaml. Environments that attach this alias receive the token as CLOUDFLARE_API_TOKEN so in-pod tooling (e.g. terraform) authenticates as it.
+Run with no flags for a guided setup: ERun shows you where to mint a delegated API token (Zone + DNS edit, plus any other scopes you'll use such as Cloudflare Pages for static sites), then prompts for it, verifies it against the Cloudflare API, and auto-resolves the account ID from the token. The token is held in a local secret store referenced from erun config — it is never written into erun-config.yaml. Environments that attach this alias receive the token as CLOUDFLARE_API_TOKEN so in-pod tooling (e.g. terraform) authenticates as it.
 
 Pass --api-token (with --account-id and --token-name) for non-interactive setup.
 
@@ -13,7 +13,7 @@ Examples:
 
 Flags:
       --account-id string   Cloudflare account ID the token belongs to (auto-resolved in guided setup)
-      --api-token string    Cloudflare scoped API token value (Zone:Edit + DNS:Edit across the account's zones)
+      --api-token string    Cloudflare API token value (Zone + DNS edit, plus any other scopes you'll use such as Cloudflare Pages)
       --dry-run             Resolve and trace mutating actions without executing them.
   -h, --help                help for cloudflare
       --token-name string   Label for the scoped API token (defaults in guided setup)

--- a/erun-mcp/cloud.go
+++ b/erun-mcp/cloud.go
@@ -27,7 +27,7 @@ type CloudInitAWSInput struct {
 type CloudInitCloudflareInput struct {
 	AccountID string `json:"accountId" jsonschema:"Cloudflare account ID the scoped API token belongs to"`
 	TokenName string `json:"tokenName" jsonschema:"label for the scoped API token"`
-	APIToken  string `json:"apiToken" jsonschema:"Cloudflare scoped API token value (Zone:Edit + DNS:Edit across the account's zones); held in the local secret store, never written to erun-config.yaml"`
+	APIToken  string `json:"apiToken" jsonschema:"Cloudflare API token value (Zone + DNS edit, plus any other scopes you'll use such as Cloudflare Pages); held in the local secret store, never written to erun-config.yaml"`
 	Preview   bool   `json:"preview,omitempty" jsonschema:"when true, return the planned operation without verifying the token or saving config"`
 	Verbosity int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
 }

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -198,7 +198,7 @@ func registerCloudTools(server *mcp.Server, runtime RuntimeConfig) {
 	}, cloudInitAWSTool(runtime))
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "cloud_init_cloudflare",
-		Description: "Initialize a Cloudflare cloud provider alias from a delegated API token (Zone:Edit + DNS:Edit across the account's zones). The token is verified against the Cloudflare API and held in a local secret store referenced from erun config, never written into erun-config.yaml; environments that attach the alias receive it as CLOUDFLARE_API_TOKEN. Supports preview.",
+		Description: "Initialize a Cloudflare cloud provider alias from a delegated API token (Zone + DNS edit, plus any other scopes the operator will use such as Cloudflare Pages for static sites). The token is verified against the Cloudflare API and held in a local secret store referenced from erun config, never written into erun-config.yaml; environments that attach the alias receive it as CLOUDFLARE_API_TOKEN. Supports preview.",
 	}, cloudInitCloudflareTool(runtime))
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "cloud_login",


### PR DESCRIPTION
Closes #636
Closes #637

Two fixes to the guided `erun cloud init cloudflare` flow, both surfaced by running it live against a real least-privilege token.

## Account auto-resolution (#636)

Step 3 auto-resolved the account via `GET /accounts` — but a **Zone-scope-only** token (exactly what we tell operators to mint) has no account-read permission, so `/accounts` returned nothing and the wizard fell back to "enter it manually." The resolver now:

1. tries `GET /accounts` (works for tokens with an account-scope permission), then
2. falls back to deriving the account from `GET /zones` — a Zone-scope token *can* list its zones, and each zone object carries `account: {id, name}`. Distinct accounts are deduped (one → use it, several → picker, none → manual).

httptest unit tests cover the single-account and multi-account zone cases. The `--dry-run` path still uses `/accounts` (synthetic), so the dry-run golden is unchanged.

## Broad-token guidance (#637)

Operators use the same injected `CLOUDFLARE_API_TOKEN` for more than DNS — notably deploying static sites to **Cloudflare Pages**. The wizard now recommends a token broad enough for real use:

```
Zone    → Zone             → Edit   (create/manage zones)
Zone    → DNS              → Edit   (manage DNS records)
Account → Cloudflare Pages → Edit   (deploy static sites)
Zone Resources:    Include → All zones
Account Resources: Include → your account
Add more rows (Workers, R2, …) if this token will manage those too.
```

CLI Long help, the `--api-token` flag, the MCP `cloud_init_cloudflare` description + schema, the erun-common comment, and the docs (`cli/cloud.md`, `deployment/cloud-setup.md`) are aligned to the same ground truth. (An Account-scope permission like Pages also makes `/accounts` succeed, complementing the fallback.) Rendered wizard verified against the built binary.

## Validation

- `go build`/`test` green in erun-cli/erun-mcp/erun-common; new httptest unit tests for the `/zones` derivation.
- `make integration-test` green @ **76.0%** (≥ 75% gate). Only the `cloud init cloudflare --help` golden regenerated; dry-run goldens unchanged.
- `cd erun-docs && yarn build` clean.

**Coverage note:** down 76.2% → 76.0% — the `/zones` fallback runs only at real runtime (when `/accounts` is empty), which the dry-run harness can't reach (no Cloudflare base-URL seam). Same known gap class as the interactive wizard code. The standing follow-up (add a base-URL test seam + scripted-stdin wizard scenario) would cover both and recover the dip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)