### PR TITLE
Cloudflare wizard: drop the redundant press-Enter gate before the token prompt

### DIFF
--- a/erun-cli/cmd/cloud.go
+++ b/erun-cli/cmd/cloud.go
@@ -204,9 +204,6 @@ func runCloudflareInitWizard(ctx common.Context, promptRunner PromptRunner, sele
 	fmt.Fprintln(out, "  Set Account Resources to: Include → your account")
 	fmt.Fprintln(out, "  Add more rows (Workers, R2, etc.) if this token will manage those too.")
 	fmt.Fprintln(out, "  Continue to summary → Create Token, then copy the token.")
-	if _, err := promptRunner(promptui.Prompt{Label: "Press Enter once you've copied the token"}); err != nil {
-		return params, err
-	}
 
 	fmt.Fprintln(out, "\nStep 2 of 3 · Paste the token")
 	token, err := verifyCloudflareTokenInteractive(ctx, promptRunner, deps)


### PR DESCRIPTION
Closes #639

Follow-up to #638. The guided `erun cloud init cloudflare` flow printed Step 1 (create the token) then waited on `Press Enter once you've copied the token:` before Step 2's masked prompt. The Enter gate was a redundant keystroke — pasting the token *is* the signal the operator made it. Removed it, so Step 1's instructions (URL + permissions, still on screen) flow straight into the masked `Cloudflare API token:` prompt.

Verified against the built binary: Step 1 → `Step 2 of 3 · Paste the token` → `Cloudflare API token:` with no Enter gate between.

Interactive-only prose change — no `--dry-run` goldens or `--help` affected. `make integration-test` green @ 76.0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)