### PR TITLE
Add ERUN_CLOUDFLARE_API_BASE_URL seam for testing the cloud-alias wizard

### DIFF
--- a/erun-common/cloud_cloudflare.go
+++ b/erun-common/cloud_cloudflare.go
@@ -14,23 +14,50 @@ import (
 	"time"
 )
 
-// cloudflareTokenVerifyURL is Cloudflare's token self-verification endpoint. A
-// successful response confirms the scoped API token is valid and active.
-const cloudflareTokenVerifyURL = "https://api.cloudflare.com/client/v4/user/tokens/verify"
+// cloudflareAPIBaseURLEnv is a subprocess-reachable test seam: when set, every
+// Cloudflare API call (token verify, accounts, zones) targets this base URL
+// instead of the live api.cloudflare.com. The desktop runs the cloud-alias
+// wizard as a `erun cloud init cloudflare` PTY subprocess, so an in-process Go
+// override (the CloudDependencies func fields) is unreachable from a desktop or
+// real-run e2e test; an env var crosses the process boundary and lets a mock
+// HTTP server stand in for Cloudflare. Mirrors the ERUN_UPGRADE_VERSIONS_OVERRIDE
+// env seam (issue #646).
+const cloudflareAPIBaseURLEnv = "ERUN_CLOUDFLARE_API_BASE_URL"
 
-// cloudflareAccountsURL lists the accounts a token can act on (works for tokens
-// with an account-scope permission). Used to auto-resolve the account id.
-const cloudflareAccountsURL = "https://api.cloudflare.com/client/v4/accounts"
+// defaultCloudflareAPIBaseURL is the live Cloudflare API root used when the
+// cloudflareAPIBaseURLEnv seam is unset.
+const defaultCloudflareAPIBaseURL = "https://api.cloudflare.com"
 
-// cloudflareZonesURL lists the zones a token can act on. It is the fallback
-// account source for a Zone-scope-only token (which cannot list /accounts):
-// each zone object carries its account id+name.
-const cloudflareZonesURL = "https://api.cloudflare.com/client/v4/zones"
+// Cloudflare API paths joined onto the resolved base URL. Kept as paths (not
+// full URLs) so the cloudflareAPIBaseURLEnv seam can redirect every call.
+const (
+	// cloudflareTokenVerifyPath is the token self-verification endpoint; a
+	// successful response confirms the scoped API token is valid and active.
+	cloudflareTokenVerifyPath = "/client/v4/user/tokens/verify"
+	// cloudflareAccountsPath lists the accounts a token can act on (works for
+	// tokens with an account-scope permission). Used to auto-resolve the account id.
+	cloudflareAccountsPath = "/client/v4/accounts"
+	// cloudflareZonesPath lists the zones a token can act on. It is the fallback
+	// account source for a Zone-scope-only token (which cannot list /accounts):
+	// each zone object carries its account id+name.
+	cloudflareZonesPath = "/client/v4/zones"
+)
 
 // CloudflareCreateTokenURL is the Cloudflare dashboard page where an operator
 // mints an API token. The guided CLI flow prints it so the operator creates the
-// scoped token in their already-authenticated browser session.
+// scoped token in their already-authenticated browser session. This is a
+// browser destination, not an API call, so the API-base seam never applies.
 const CloudflareCreateTokenURL = "https://dash.cloudflare.com/profile/api-tokens"
+
+// cloudflareAPIBaseURL resolves the Cloudflare API base URL: the
+// cloudflareAPIBaseURLEnv seam when set (trailing slash trimmed so path joins
+// stay predictable), else the live default.
+func cloudflareAPIBaseURL() string {
+	if override := strings.TrimSpace(os.Getenv(cloudflareAPIBaseURLEnv)); override != "" {
+		return strings.TrimRight(override, "/")
+	}
+	return defaultCloudflareAPIBaseURL
+}
 
 // CloudSecretStore persists provider secrets (today: Cloudflare scoped API
 // tokens) outside erun-config.yaml. Implementations key on an opaque ref so
@@ -225,11 +252,12 @@ func redactSecretPresence(value string) string {
 // the supplied scoped token. In dry-run it traces the call and returns a
 // synthetic active result without touching the network.
 func defaultVerifyCloudflareToken(ctx Context, token string) (CloudflareTokenInfo, error) {
-	ctx.Trace("GET " + cloudflareTokenVerifyURL)
+	verifyURL := cloudflareAPIBaseURL() + cloudflareTokenVerifyPath
+	ctx.Trace("GET " + verifyURL)
 	if ctx.DryRun {
 		return CloudflareTokenInfo{Status: "active"}, nil
 	}
-	return verifyCloudflareTokenAt(cloudflareTokenVerifyURL, token)
+	return verifyCloudflareTokenAt(verifyURL, token)
 }
 
 // verifyCloudflareTokenAt performs the live token verification against url. It
@@ -287,18 +315,21 @@ func verifyCloudflareTokenAt(url, token string) (CloudflareTokenInfo, error) {
 // has no account-read permission — it falls back to deriving the account from
 // the token's zones. Dry-run returns a synthetic account without any network.
 func defaultListCloudflareAccounts(ctx Context, token string) ([]CloudflareAccount, error) {
-	ctx.Trace("GET " + cloudflareAccountsURL)
+	base := cloudflareAPIBaseURL()
+	accountsURL := base + cloudflareAccountsPath
+	ctx.Trace("GET " + accountsURL)
 	if ctx.DryRun {
 		return []CloudflareAccount{{ID: "cf-account-id", Name: "Cloudflare account"}}, nil
 	}
-	accounts, err := listCloudflareAccountsAt(cloudflareAccountsURL, token)
+	accounts, err := listCloudflareAccountsAt(accountsURL, token)
 	if err == nil && len(accounts) > 0 {
 		return accounts, nil
 	}
 	// Zone-scope-only tokens cannot list /accounts; derive from the zones the
 	// token can see — each zone object carries its account id+name.
-	ctx.Trace("GET " + cloudflareZonesURL)
-	zoneAccounts, zonesErr := resolveCloudflareAccountsViaZones(cloudflareZonesURL, token)
+	zonesURL := base + cloudflareZonesPath
+	ctx.Trace("GET " + zonesURL)
+	zoneAccounts, zonesErr := resolveCloudflareAccountsViaZones(zonesURL, token)
 	if zonesErr != nil {
 		if err != nil {
 			return nil, err

--- a/erun-common/cloud_cloudflare_test.go
+++ b/erun-common/cloud_cloudflare_test.go
@@ -225,6 +225,44 @@ func TestResolveCloudflareAccountsViaZones(t *testing.T) {
 	})
 }
 
+// TestDefaultCloudflareCallsHonorBaseURLSeam proves the subprocess-reachable
+// seam: with only the env var set (no in-process CloudDependencies injection),
+// the default verifier and accounts resolver hit a mock standing in for the
+// Cloudflare API. This is the path a desktop/e2e test exercises through the
+// `erun cloud init cloudflare` subprocess (issue #646).
+func TestDefaultCloudflareCallsHonorBaseURLSeam(t *testing.T) {
+	gotPaths := make(map[string]bool)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+			t.Errorf("authorization header = %q", got)
+		}
+		gotPaths[r.URL.Path] = true
+		switch r.URL.Path {
+		case cloudflareTokenVerifyPath:
+			_, _ = w.Write([]byte(`{"success":true,"result":{"id":"abc","status":"active"}}`))
+		case cloudflareAccountsPath:
+			_, _ = w.Write([]byte(`{"success":true,"result":[{"id":"a1","name":"Acme"}]}`))
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv(cloudflareAPIBaseURLEnv, srv.URL)
+
+	info, err := defaultVerifyCloudflareToken(Context{}, "tok")
+	mustNoErr(t, err, "verify")
+	if info.ID != "abc" || info.Status != "active" {
+		t.Fatalf("verify info = %+v", info)
+	}
+	accounts, err := defaultListCloudflareAccounts(Context{}, "tok")
+	mustNoErr(t, err, "accounts")
+	assertCloudflareAccounts(t, accounts, []CloudflareAccount{{ID: "a1", Name: "Acme"}})
+
+	if !gotPaths[cloudflareTokenVerifyPath] || !gotPaths[cloudflareAccountsPath] {
+		t.Fatalf("mock did not receive both Cloudflare paths; got %v", gotPaths)
+	}
+}
+
 func TestResolveTenantCloudProviderIssuersSkipsCloudflare(t *testing.T) {
 	store := stubCloudContextStore{config: ERunConfig{CloudProviders: []CloudProviderConfig{
 		{Alias: "alice+123456789012@aws", Provider: CloudProviderAWS, OIDCIssuerURL: "https://issuer.example.com"},

--- a/erun-integration/cloud_test.go
+++ b/erun-integration/cloud_test.go
@@ -171,6 +171,31 @@ func TestCloud(t *testing.T) {
 		golden.Equal(t, "cloud/init_cloudflare_dry_run_auto_account", normalize.Apply(result.Combined))
 	})
 
+	t.Run("init_cloudflare_dry_run_honors_api_base_url_seam", func(t *testing.T) {
+		// Exercises the ERUN_CLOUDFLARE_API_BASE_URL subprocess-reachable seam
+		// (issue #646): when set, every Cloudflare API call targets the override
+		// base instead of api.cloudflare.com. The seam is what lets a desktop /
+		// real-run e2e point the `erun cloud init cloudflare` subprocess at a
+		// mock. In --dry-run the GET trace fires before the network short-circuit,
+		// so the override base is observable here without any network call. The
+		// trailing slash on the override is intentional: the golden's single
+		// `/client/v4/...` (no double slash) locks the base-URL trim too.
+		setup := env.New(t)
+		args := []string{
+			"cloud", "init", "cloudflare",
+			"--account-id", "cf-acct-123",
+			"--token-name", "ci-token",
+			"--api-token", "dummy-token",
+			"--dry-run",
+		}
+		envVars := append(setup.Env(), "ERUN_CLOUDFLARE_API_BASE_URL=https://cf-mock.example/")
+		result := erun.Run(t, args, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "cloud/init_cloudflare_dry_run_api_base_url_seam", normalize.Apply(result.Combined))
+	})
+
 	t.Run("init_aws_dry_run_traces_sso_setup_and_oidc_persistence", func(t *testing.T) {
 		// Exercises cloud.go runCloudInitAWSCommand: --dry-run must trace
 		// the aws configure sso plan, the sso login command, the sts

--- a/erun-integration/testdata/cloud/init_cloudflare_dry_run_api_base_url_seam.txt
+++ b/erun-integration/testdata/cloud/init_cloudflare_dry_run_api_base_url_seam.txt
@@ -1,0 +1,8 @@
+Dry run: Cloudflare cloud provider initialization planned.
+audit: erun cloud init cloudflare --account-id cf-acct-123 --api-token <redacted> --dry-run --token-name <redacted>
+cloud init cloudflare: account-id=cf-acct-123 token-name=ci-token api-token=<redacted>
+cloud init cloudflare: verifying scoped api token
+GET https://cf-mock.example/client/v4/user/tokens/verify
+cloud init cloudflare: secret store is configured
+store cloudflare api token at ref cloudflare/ci-token+cf-acct-123@cloudflare
+write cloud provider ci-token+cf-acct-123@cloudflare


### PR DESCRIPTION
## Summary

The Cloudflare cloud-alias wizard made direct `net/http` GETs to three hardcoded `api.cloudflare.com` URLs (`cloud_cloudflare.go`), with **no subprocess-reachable seam** to point them at a mock. The desktop runs `erun cloud init cloudflare` as a PTY subprocess, so the in-process `CloudDependencies` func fields are unreachable from a desktop / real-run e2e test — only Go `httptest` unit tests could intercept the calls. This blocked any real-run / e2e coverage of the wizard.

## Change

- Add an **`ERUN_CLOUDFLARE_API_BASE_URL`** env seam, resolved by a small helper (`cloudflareAPIBaseURL()`, trailing slash trimmed). The default verifier / accounts / zones calls now build their URLs from the resolved base + path consts, defaulting to `https://api.cloudflare.com` so **default behaviour is byte-identical** (existing goldens unchanged).
- Mirrors the existing `ERUN_UPGRADE_VERSIONS_OVERRIDE` env seam used for deterministic testing.

### Why env var, not `cloudflare.baseurl` config

The issue allows "and/or". The env var is the **subprocess-reachable** seam the e2e actually needs, matches erun-common's dominant `ERUN_*` direct-getenv seam pattern (`ERUN_HOST_OS_OVERRIDE`, `ERUN_UPGRADE_VERSIONS_OVERRIDE`, `ERUN_DEPLOY_POD_WATCH_INTERVAL`), and avoids a config disk-read in the cloud-deps path — KISS.

## Validation

- **erun-common unit test** drives the default (non-injected) verifier and accounts resolver against an `httptest` mock **via the env seam** — the subprocess-reachability proof, exactly the validation the issue asks for, and a path integration `--dry-run` cannot reach (the real HTTP call is short-circuited in dry-run).
- **New erun-integration `--dry-run` scenario** locks the override base in the `GET` trace and the trailing-slash trim; the redundant pure-resolver unit test is dropped in its favour per the integration-coverage rule.
- `go build` / `go vet` / `go test` + `golangci-lint` clean in `erun-common`; `make integration-test` green (**76.1% ≥ 75.0%**).

## Docs

No docs change: internal test seam, no operator-facing behaviour change.

## Relationship

Prerequisite for the Cloudflare-wizard coverage in the k3d e2e suite (#647).

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)