### PR TITLE
erun build: fail clearly when the Docker daemon cannot produce a required platform

### DIFF
--- a/erun-common/build_docker_commands.go
+++ b/erun-common/build_docker_commands.go
@@ -20,6 +20,9 @@ func DockerImageBuilder(buildInput DockerBuildSpec, stdout, stderr io.Writer) er
 }
 
 func runMultiPlatformBuild(buildInput DockerBuildSpec, stdout, stderr io.Writer) error {
+	if err := verifyDockerBuildPlatforms(buildInput.Platforms); err != nil {
+		return err
+	}
 	perPlatformTags := make([]string, 0, len(buildInput.Platforms))
 	for _, platform := range buildInput.Platforms {
 		platformTag := platformSuffixedTag(buildInput.Image.Tag, platform)

--- a/erun-common/build_platform_preflight.go
+++ b/erun-common/build_platform_preflight.go
@@ -1,0 +1,110 @@
+package eruncommon
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// verifyDockerBuildPlatforms checks the local Docker daemon can emit every
+// required build platform before the multi-arch build shells `docker build
+// --platform` once per architecture. erun always builds linux/amd64 +
+// linux/arm64, so on a host that has not registered binfmt/QEMU for the foreign
+// architecture the per-platform `docker build` otherwise fails with an opaque,
+// low-level error. This preflight fails fast instead, with a direct, actionable
+// message naming the unbuildable platform(s) and the binfmt remediation — the
+// same `tonistiigi/binfmt --install all` step the runtime pod's init container
+// uses. (Root AGENTS.md § "Release Rules": multi-architecture builds must
+// verify daemon capability explicitly; issue #645.)
+func verifyDockerBuildPlatforms(required []string) error {
+	available, err := dockerBuildxPlatforms()
+	if err != nil {
+		return err
+	}
+	// If the probe reported no parseable platform list, we cannot prove any
+	// platform is unsupported, so don't block the build. The missing-binfmt
+	// case this preflight targets surfaces as a populated list that omits the
+	// foreign arch (caught below); an empty or unrecognized inspect output
+	// (an unusual builder, a future format change) degrades gracefully to the
+	// prior behavior rather than failing a build that would have succeeded.
+	if len(available) == 0 {
+		return nil
+	}
+	missing := missingBuildPlatforms(required, available)
+	if len(missing) == 0 {
+		return nil
+	}
+	return newUnsupportedBuildPlatformError(missing)
+}
+
+// dockerBuildxPlatforms probes the current Docker builder for the platforms it
+// can build for. The platform list reflects the kernel's registered binfmt
+// handlers, so it is a faithful answer to "can `docker build --platform X`
+// emulate X here". A failure to run the probe (no buildx, daemon down) is
+// surfaced directly rather than letting the build fail later with a confusing
+// per-platform error.
+func dockerBuildxPlatforms() (map[string]bool, error) {
+	cmd := Command("docker", "buildx", "inspect")
+	out := new(bytes.Buffer)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Run(); err != nil {
+		message := strings.TrimSpace(out.String())
+		if message == "" {
+			return nil, fmt.Errorf("verify multi-arch build capability (docker buildx inspect): %w", err)
+		}
+		return nil, fmt.Errorf("verify multi-arch build capability (docker buildx inspect): %w\n%s", err, message)
+	}
+	return parseBuildxPlatforms(out.String()), nil
+}
+
+// parseBuildxPlatforms extracts the platform set from `docker buildx inspect`
+// output. The relevant line looks like:
+//
+//	Platforms: linux/arm64*, linux/amd64, linux/amd64/v2, linux/arm/v7
+//
+// buildx marks the node's default platform with a trailing `*`, which is
+// stripped. Multiple `Platforms:` lines (one per builder node) are unioned so a
+// multi-node builder reports the full reachable set.
+func parseBuildxPlatforms(inspectOutput string) map[string]bool {
+	platforms := make(map[string]bool)
+	for _, line := range strings.Split(inspectOutput, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "Platforms:") {
+			continue
+		}
+		list := strings.TrimSpace(strings.TrimPrefix(trimmed, "Platforms:"))
+		for _, token := range strings.Split(list, ",") {
+			token = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(token), "*"))
+			if token != "" {
+				platforms[token] = true
+			}
+		}
+	}
+	return platforms
+}
+
+// missingBuildPlatforms returns the required platforms the daemon cannot build,
+// preserving the required-list order so the error message is deterministic.
+func missingBuildPlatforms(required []string, available map[string]bool) []string {
+	var missing []string
+	for _, platform := range required {
+		if !available[platform] {
+			missing = append(missing, platform)
+		}
+	}
+	return missing
+}
+
+// newUnsupportedBuildPlatformError builds the actionable error returned when the
+// daemon cannot produce a required platform. It names the missing platform(s),
+// states the full set erun builds, and gives the exact binfmt-install command.
+func newUnsupportedBuildPlatformError(missing []string) error {
+	return fmt.Errorf(
+		"the local Docker daemon cannot build %s: no emulator is registered for the foreign architecture. "+
+			"erun always builds %s, so the build cannot proceed. Register binfmt/QEMU for the missing platform(s) and retry:\n"+
+			"  docker run --privileged --rm tonistiigi/binfmt --install all",
+		strings.Join(missing, ", "),
+		strings.Join(multiPlatformDockerBuilds, " + "),
+	)
+}

--- a/erun-integration/build_test.go
+++ b/erun-integration/build_test.go
@@ -176,6 +176,16 @@ func TestBuild(t *testing.T) {
 			`      *) exit 0 ;;`,
 			`    esac`,
 			`    ;;`,
+			// The multi-arch daemon-capability preflight (issue #645) runs
+			// `docker buildx inspect` before building; report both required
+			// platforms so it passes. The trailing `*` on the node default is
+			// realistic buildx output and exercises the marker-stripping parse.
+			`  buildx)`,
+			`    case "$2" in`,
+			`      inspect) echo "Platforms: linux/arm64*, linux/amd64" ;;`,
+			`      *) exit 0 ;;`,
+			`    esac`,
+			`    ;;`,
 			`  *) exit 0 ;;`,
 			`esac`,
 		}, "\n"))
@@ -185,6 +195,37 @@ func TestBuild(t *testing.T) {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
 		golden.Equal(t, "build/real_run_via_docker_stub_drives_multi_platform_build", normalize.Apply(result.Combined))
+	})
+
+	t.Run("real_run_fails_when_daemon_cannot_build_required_platform", func(t *testing.T) {
+		// Exercises the multi-arch daemon-capability preflight
+		// (verifyDockerBuildPlatforms in build_platform_preflight.go, issue
+		// #645). erun always builds linux/amd64 + linux/arm64, so before
+		// shelling `docker build` per platform it runs `docker buildx inspect`
+		// and fails fast with a direct, actionable error when the daemon has
+		// no emulator for a required platform — instead of the opaque
+		// per-platform `docker build` failure. The stub reports only
+		// linux/amd64, so linux/arm64 is unbuildable regardless of host arch
+		// (the stub controls the platform list). This is a real-run scenario
+		// because the preflight guards the real executor, not the dry-run plan.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "develop")
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinaryWithScript(t, stubs, "docker", strings.Join([]string{
+			`case "$1" in`,
+			`  image)`,
+			`    case "$2" in inspect) exit 1 ;; *) exit 0 ;; esac ;;`,
+			`  buildx)`,
+			`    case "$2" in inspect) echo "Platforms: linux/amd64" ;; *) exit 0 ;; esac ;;`,
+			`  *) exit 0 ;;`,
+			`esac`,
+		}, "\n"))
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker")...)
+		result := erun.Run(t, []string{"build", "-v"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected build to fail when the daemon cannot build a required platform; got exit 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "build/real_run_fails_when_daemon_cannot_build_required_platform", normalize.Apply(result.Combined))
 	})
 
 	t.Run("dry_run_no_incremental_skips_fingerprint_short_circuit", func(t *testing.T) {
@@ -436,6 +477,10 @@ func TestBuild(t *testing.T) {
 			`case "$1" in`,
 			`  image)`,
 			`    case "$2" in inspect) exit 1 ;; *) exit 0 ;; esac ;;`,
+			// Multi-arch capability preflight (issue #645): report both required
+			// platforms so `docker buildx inspect` passes.
+			`  buildx)`,
+			`    case "$2" in inspect) echo "Platforms: linux/amd64, linux/arm64" ;; *) exit 0 ;; esac ;;`,
 			`  *) exit 0 ;;`,
 			`esac`,
 		}, "\n"))

--- a/erun-integration/testdata/build/real_run_fails_when_daemon_cannot_build_required_platform.txt
+++ b/erun-integration/testdata/build/real_run_fails_when_daemon_cannot_build_required_platform.txt
@@ -1,0 +1,8 @@
+audit: erun build
+==> Building
+fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
+fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
+rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+==> Build failed after <ELAPSED>
+the local Docker daemon cannot build linux/arm64: no emulator is registered for the foreign architecture. erun always builds linux/amd64 + linux/arm64, so the build cannot proceed. Register binfmt/QEMU for the missing platform(s) and retry:
+  docker run --privileged --rm tonistiigi/binfmt --install all


### PR DESCRIPTION
## Summary

`erun build` always produces a multi-arch artifact (`linux/amd64` + `linux/arm64`) but never verified the local Docker daemon could actually emit the foreign arch. On a host without binfmt/QEMU registered, the per-platform `docker build` failed with an opaque low-level error instead of a clear, actionable message — a **currently-unmet** rule from root `AGENTS.md` § "Release Rules":

> Multi-architecture builds must verify daemon capability explicitly. Fail with a direct error … rather than letting the per-platform `docker build` fail with a confusing message.

## Change

- New `erun-common/build_platform_preflight.go`: a daemon-capability preflight at the top of `runMultiPlatformBuild`. It probes `docker buildx inspect` (the reported platform list reflects the kernel's registered binfmt handlers), and when a required platform is **absent from a populated list**, fails fast with a direct error naming the unbuildable platform(s) and the exact remediation — the same `docker run --privileged --rm tonistiigi/binfmt --install all` step the runtime pod's init container uses.
- **Graceful degradation:** an empty or unrecognized inspect output can't prove a platform is unsupported, so it does **not** block the build (prior behavior preserved for unusual builders / future format changes).
- Guards the **real executor only** — dry-run plans are unchanged (no golden churn on the dry-run build scenarios).

## Validation

- New `erun-integration` real-run scenario `real_run_fails_when_daemon_cannot_build_required_platform` stubs `docker buildx inspect` to report only `linux/amd64` and asserts the clear `linux/arm64` error + non-zero exit — deterministic regardless of host arch (the stub controls the platform list).
- The happy-path multi-arch stub now reports both platforms with the realistic `*` node-default marker (exercising the parser's marker-strip); other real-build stubs exercise the empty-output graceful-pass branch.
- `go build` / `go vet` / `go test` + `golangci-lint` clean in `erun-common`; `make integration-test` green (**76.1% ≥ 75.0%**).

## Docs

No docs change: a clearer build-time error only, no operator-facing feature; the binfmt remediation is in the error text itself.

## Relationship

Companion for the k3d e2e suite (#647): single-arch e2e hosts need binfmt for the mandatory multi-arch build, and this is the production preflight that makes the missing-binfmt failure clear.

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)