### PR TITLE
Playwright: remove artificial sub-default timeouts causing roving full-suite flakiness

### DIFF
--- a/erun-ui/playwright/tests/activity-events.spec.ts
+++ b/erun-ui/playwright/tests/activity-events.spec.ts
@@ -24,5 +24,5 @@ test('activity:state events populate the queue drawer', async ({ app }) => {
 
   await expect(
     app.activityDrawer.locator().getByText('open petios/rihards-review', { exact: false }),
-  ).toBeVisible({ timeout: 5000 });
+  ).toBeVisible();
 });

--- a/erun-ui/playwright/tests/activity-failure-details.spec.ts
+++ b/erun-ui/playwright/tests/activity-failure-details.spec.ts
@@ -48,9 +48,7 @@ test('failed deploy card reveals captured output and offers a copyable report', 
   const card = drawer.locator('article').filter({ hasText: 'petios/rihards-develop' }).first();
 
   // The one-line summary stays first-class.
-  await expect(card.getByText('==> Deploy failed after 4s', { exact: false })).toBeVisible({
-    timeout: 5000,
-  });
+  await expect(card.getByText('==> Deploy failed after 4s', { exact: false })).toBeVisible();
 
   // Captured output is collapsed by default and revealed via the disclosure.
   // "UPGRADE FAILED" lives only in the captured output, never in the summary.

--- a/erun-ui/playwright/tests/app-notification.spec.ts
+++ b/erun-ui/playwright/tests/app-notification.spec.ts
@@ -34,16 +34,22 @@ test.describe('app-notification toast', () => {
     );
 
     const pill = page.getByRole('status').filter({ hasText: message });
-    await expect(pill).toBeVisible({ timeout: 5_000 });
+    await expect(pill).toBeVisible();
 
     // notificationThunks.ts auto-dismisses success/info after 3.2 s.
     // Give the timer 5 s headroom so we are not racing with it; if the
     // pill is still up at that point the auto-dismiss broke.
-    await expect(pill).toHaveCount(0, { timeout: 5_000 });
+    await expect(pill).toHaveCount(0);
   });
 
   test('error notification persists (no auto-dismiss)', async ({ app: _app, page }) => {
     const message = 'Backend pinned a problem you should read.';
+    // Take over the page clock so the 3.2 s success/info auto-dismiss timer can
+    // be advanced deterministically instead of slept through. The notification
+    // slot is single-occupancy (notificationThunks.showNotification replaces the
+    // one toast), so a sibling info toast would race the error rather than time
+    // alongside it — the clock is the reliable signal that the window elapsed.
+    await page.clock.install();
     await page.evaluate(
       (payload) => {
         const runtime = (
@@ -57,12 +63,11 @@ test.describe('app-notification toast', () => {
     );
 
     const pill = page.getByRole('alert').filter({ hasText: message });
-    await expect(pill).toBeVisible({ timeout: 5_000 });
+    await expect(pill).toBeVisible();
 
-    // Confirm the toast does NOT auto-dismiss on the success/info
-    // timer. 4 s easily clears the 3.2 s window without making this
-    // spec sluggish.
-    await page.waitForTimeout(4_000);
+    // Advance well past the 3.2 s window that auto-dismisses success/info
+    // toasts. An error toast sets no timer, so it must still be visible.
+    await page.clock.fastForward(5_000);
     await expect(pill).toBeVisible();
   });
 
@@ -75,17 +80,24 @@ test.describe('app-notification toast', () => {
     // no-op dispatch must leave the counts unchanged.
     const statusBefore = await page.locator('[role="status"]').count();
     const alertBefore = await page.locator('[role="alert"]').count();
-    await page.evaluate(() => {
+    const sentinel = 'Sentinel error toast proving the empty payload was processed.';
+    // Emit the empty payload, then a valid error sentinel. Events are ordered,
+    // so once the sentinel renders the empty dispatch has provably been
+    // processed — bounding the no-op window with a real event, not a sleep. The
+    // sentinel is an error toast so it persists (no auto-dismiss race).
+    await page.evaluate((msg) => {
       const runtime = (
         window as unknown as {
           runtime: { EventsEmit: (n: string, ...a: unknown[]) => void };
         }
       ).runtime;
       runtime.EventsEmit('app-notification', { kind: 'info', message: '   ' });
-    });
-    // Wait a short tick to give the dispatcher a chance to no-op.
-    await page.waitForTimeout(200);
+      runtime.EventsEmit('app-notification', { kind: 'error', message: msg });
+    }, sentinel);
+    await expect(page.getByRole('alert').filter({ hasText: sentinel })).toBeVisible();
+    // The empty payload added no toast: the status count is unchanged and only
+    // the sentinel raised the alert count.
     await expect(page.locator('[role="status"]')).toHaveCount(statusBefore);
-    await expect(page.locator('[role="alert"]')).toHaveCount(alertBefore);
+    await expect(page.locator('[role="alert"]')).toHaveCount(alertBefore + 1);
   });
 });

--- a/erun-ui/playwright/tests/auto-start.spec.ts
+++ b/erun-ui/playwright/tests/auto-start.spec.ts
@@ -57,6 +57,6 @@ test.describe('auto-start gate', () => {
     // then assert the prompt did not open. Using toBeHidden() (auto-retry)
     // rather than waitForTimeout keeps the test deterministic on slow
     // machines while still failing fast when the gate misfires.
-    await expect(app.autoStartPromptDialog.locator()).toBeHidden({ timeout: 2_000 });
+    await expect(app.autoStartPromptDialog.locator()).toBeHidden();
   });
 });

--- a/erun-ui/playwright/tests/idle-tooltip.spec.ts
+++ b/erun-ui/playwright/tests/idle-tooltip.spec.ts
@@ -18,13 +18,18 @@ test.describe('idle tooltip', () => {
     app,
     page,
   }) => {
-    await app.sidebar.openEnvironment(SEED_TENANT, SEED_ENV_ALPHA);
-
     // The widget only mounts after a LoadIdleStatus poll reports a managed
     // cloud context. The seeded env has none, so the badge must not appear.
-    // Give the first poll a window to land before asserting — toBeHidden
-    // alone would pass instantly and prove nothing about the poll result.
-    await page.waitForTimeout(2_000);
+    // Wait on the poll RPC (not the wall clock) so the assertion reflects a
+    // completed poll, not a poll that simply hasn't run yet — toBeHidden alone
+    // would pass instantly and prove nothing about the poll result.
+    const idlePolled = page.waitForResponse(
+      (response) =>
+        response.url().includes('/__erun_invoke') &&
+        (response.request().postData() ?? '').includes('LoadIdleStatus'),
+    );
+    await app.sidebar.openEnvironment(SEED_TENANT, SEED_ENV_ALPHA);
+    await idlePolled;
     const badge = app.titlebar.idleStatusBadge();
     await expect(badge).toBeHidden();
   });

--- a/erun-ui/playwright/tests/manage-disable-build-script.spec.ts
+++ b/erun-ui/playwright/tests/manage-disable-build-script.spec.ts
@@ -28,7 +28,7 @@ test.describe('manage dialog disable-build-script toggle (#533)', () => {
     // rebuilds the image, so the running env owes a redeploy to apply it.
     await app.manageDialog.save();
     await expect.poll(() => app.manageDialog.tabHasUnsavedChanges('Runtime')).toBe(false);
-    await expect(app.manageDialog.redeployBanner()).toBeVisible({ timeout: 6_000 });
+    await expect(app.manageDialog.redeployBanner()).toBeVisible();
 
     // The saved value round-trips through the Go load/save path: reopening the
     // dialog shows it checked.

--- a/erun-ui/playwright/tests/manage-redeploy-banner.spec.ts
+++ b/erun-ui/playwright/tests/manage-redeploy-banner.spec.ts
@@ -67,7 +67,7 @@ test.describe('manage dialog redeploy banner scoping (#460)', () => {
     const original = await idle.inputValue();
     await idle.fill(original === '7m' ? '9m' : '7m');
     await app.manageDialog.save();
-    await expect(app.manageDialog.redeployBanner()).toBeVisible({ timeout: 6_000 });
+    await expect(app.manageDialog.redeployBanner()).toBeVisible();
 
     // A later metadata-only save must not clear a redeploy the user still
     // owes the pod: toggle autoUpgrade back and save again — banner stays.

--- a/erun-ui/playwright/tests/remote-session-tabs.spec.ts
+++ b/erun-ui/playwright/tests/remote-session-tabs.spec.ts
@@ -28,13 +28,21 @@ import { SEED_ENV_ALPHA, SEED_TENANT } from '../fixtures/seedRoot.js';
 
 test.describe('remote session tab detection', () => {
   test('opening an env yields only known tab kinds with no duplicates', async ({ app, page }) => {
+    // The fire-and-forget remote-session detection pass round-trips a
+    // ListRemoteAppSessions RPC; wait on that event (not the wall clock) so the
+    // assertions reflect a completed detection pass.
+    const detected = page.waitForResponse(
+      (response) =>
+        response.url().includes('/__erun_invoke') &&
+        (response.request().postData() ?? '').includes('ListRemoteAppSessions'),
+    );
     await app.sidebar.openEnvironment(SEED_TENANT, SEED_ENV_ALPHA);
 
     const strip = page.getByRole('tablist', { name: 'Open terminals' });
     await expect(strip).toBeVisible();
-    // Give the fire-and-forget detection pass a window to run; it must not
-    // surface an error overlay or mutate the strip into unknown entries.
-    await page.waitForTimeout(1_000);
+    // The detection pass must not surface an error overlay or mutate the strip
+    // into unknown entries.
+    await detected;
 
     const labels = await strip.getByRole('tab').allInnerTexts();
     expect(labels.length).toBeGreaterThan(0);

--- a/erun-ui/playwright/tests/sidebar-ai-activity.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-ai-activity.spec.ts
@@ -57,7 +57,7 @@ test.describe('sidebar AI activity spinner', () => {
     );
 
     const spinner = sidebar.getByRole('status').first();
-    await expect(spinner).toBeVisible({ timeout: 5_000 });
+    await expect(spinner).toBeVisible();
     await expect(spinner).toHaveAttribute('aria-label', new RegExp(`${env}`));
 
     // Emit busy=false; the spinner must disappear.
@@ -77,7 +77,7 @@ test.describe('sidebar AI activity spinner', () => {
       },
       { tenant, env },
     );
-    await expect(sidebar.getByRole('status')).toHaveCount(0, { timeout: 5_000 });
+    await expect(sidebar.getByRole('status')).toHaveCount(0);
   });
 
   test('ai-activity payloads with empty tenant or environment are ignored', async ({

--- a/erun-ui/playwright/tests/sidebar-busy-spinner.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-busy-spinner.spec.ts
@@ -54,7 +54,7 @@ test.describe('sidebar busy spinner', () => {
     // with auto-retry so the test is not racing on a precise timing.
     const sidebar = page.locator('aside').first();
     const spinners = sidebar.getByRole('status');
-    await expect(spinners).toHaveCount(0, { timeout: 5_000 });
+    await expect(spinners).toHaveCount(0);
   });
 
   test('running build/release/push entries surface a labelled spinner that clears on finish', async ({

--- a/erun-ui/playwright/tests/sidebar-env-hover.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-env-hover.spec.ts
@@ -18,7 +18,7 @@ test.describe('sidebar env hover card', () => {
     await app.sidebar.hoverEnvironmentRow(SEED_TENANT, SEED_ENV_ALPHA);
 
     const card = app.sidebar.envHoverCard(SEED_TENANT, SEED_ENV_ALPHA);
-    await expect(card).toBeVisible({ timeout: 6_000 });
+    await expect(card).toBeVisible();
 
     // All three sections are present.
     await expect(card.getByText('Version', { exact: true })).toBeVisible();
@@ -51,10 +51,10 @@ test.describe('sidebar env hover card', () => {
 
     await app.sidebar.hoverEnvironmentRow(tenant, environment);
     const card = app.sidebar.envHoverCard(tenant, environment);
-    await expect(card).toBeVisible({ timeout: 6_000 });
+    await expect(card).toBeVisible();
 
     const activity = card.locator('dd').nth(2);
-    await expect(activity).toHaveText('Not open', { timeout: 6_000 });
+    await expect(activity).toHaveText('Not open');
 
     const workingOn = card.locator('dd').nth(1);
     await expect.poll(async () => (await workingOn.textContent())?.trim() ?? '').not.toBe('');
@@ -74,14 +74,14 @@ test.describe('sidebar env hover card', () => {
 
     await app.sidebar.openEnvironment(tenant, environment);
     const dot = app.sidebar.envOpenDot(tenant, environment);
-    await expect(dot).toBeVisible({ timeout: 6_000 });
+    await expect(dot).toBeVisible();
 
     // The open click left the pointer on the row, so hovering it again would
     // be a no-op (no fresh mouseenter) — park the pointer elsewhere first.
     await page.mouse.move(0, 0);
     await app.sidebar.hoverEnvironmentRow(tenant, environment);
     const card = app.sidebar.envHoverCard(tenant, environment);
-    await expect(card).toBeVisible({ timeout: 6_000 });
+    await expect(card).toBeVisible();
 
     // Let the open settle first: the in-flight open's busy label outranks
     // the stopped state by design, and the spawn path itself emits a
@@ -96,14 +96,14 @@ test.describe('sidebar env hover card', () => {
     });
 
     await emitEnvStatusEvent(page, tenant, environment, 'stopped');
-    await expect(dot).toHaveAttribute('data-env-state', 'stopped', { timeout: 4_000 });
-    await expect(activity).toContainText('Stopped', { timeout: 4_000 });
+    await expect(dot).toHaveAttribute('data-env-state', 'stopped');
+    await expect(activity).toContainText('Stopped');
 
     // Restore the row's healthy state and close the env for later specs.
     await emitEnvStatusEvent(page, tenant, environment, '');
-    await expect(dot).toHaveAttribute('data-env-state', 'running', { timeout: 4_000 });
+    await expect(dot).toHaveAttribute('data-env-state', 'running');
     await dot.click();
-    await expect(dot).toHaveCount(0, { timeout: 6_000 });
+    await expect(dot).toHaveCount(0);
   });
 });
 

--- a/erun-ui/playwright/tests/sidebar-open-dot.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-open-dot.spec.ts
@@ -41,14 +41,14 @@ test.describe('sidebar env open dot', () => {
     // the matching edit button is the row this test owns.
     const sidebar = page.locator('aside').first();
     const dot = sidebar.getByRole('button', { name: `Close ${tenant} / ${environment}` });
-    await expect(dot).toBeVisible({ timeout: 6_000 });
+    await expect(dot).toBeVisible();
 
     // Clicking the dot must not also trigger the row's openSelection.
     // The selected env after the close should NOT remain on the one
     // we just closed; we assert the dot disappears, which is the
     // observable signal that tabsByEnv was cleared.
     await dot.click();
-    await expect(dot).toHaveCount(0, { timeout: 6_000 });
+    await expect(dot).toHaveCount(0);
   });
 
   // Issue #470 — the dot must reflect the env's REAL condition, not just tab
@@ -69,24 +69,24 @@ test.describe('sidebar env open dot', () => {
 
     await app.sidebar.openEnvironment(tenant, environment);
     const dot = app.sidebar.envOpenDot(tenant, environment);
-    await expect(dot).toBeVisible({ timeout: 6_000 });
+    await expect(dot).toBeVisible();
     await expect(dot).toHaveAttribute('data-env-state', 'running');
 
     await emitEnvStatus(page, tenant, environment, 'stopped');
-    await expect(dot).toHaveAttribute('data-env-state', 'stopped', { timeout: 4_000 });
+    await expect(dot).toHaveAttribute('data-env-state', 'stopped');
     await expect(dot).toHaveAccessibleName(new RegExp(`^${tenant} / ${environment} is stopped`));
 
     await emitEnvStatus(page, tenant, environment, 'failed');
-    await expect(dot).toHaveAttribute('data-env-state', 'failed', { timeout: 4_000 });
+    await expect(dot).toHaveAttribute('data-env-state', 'failed');
     await expect(dot).toHaveAccessibleName(/deploy failed/);
 
     await emitEnvStatus(page, tenant, environment, '');
-    await expect(dot).toHaveAttribute('data-env-state', 'running', { timeout: 4_000 });
+    await expect(dot).toHaveAttribute('data-env-state', 'running');
     await expect(dot).toHaveAccessibleName(`Close ${tenant} / ${environment}`);
 
     // Close the env so the singleton backend returns to its pre-test shape.
     await dot.click();
-    await expect(dot).toHaveCount(0, { timeout: 6_000 });
+    await expect(dot).toHaveCount(0);
   });
 });
 

--- a/erun-ui/playwright/tests/sidebar-reclick-no-duplicate-tabs.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-reclick-no-duplicate-tabs.spec.ts
@@ -50,7 +50,7 @@ test.describe('sidebar env re-click with alive default tabs', () => {
     // Generous window so a delayed misfire of ensureLiveDefaultTab on
     // a healthy session still trips this assertion. The headless backend
     // is a singleton with workers: 1, so 2 s is cheap.
-    await expect(page.getByText(/Reopening Local shell/i)).toBeHidden({ timeout: 2_000 });
+    await expect(page.getByText(/Reopening Local shell/i)).toBeHidden();
     await expect(page.getByText(/Reopening AI session/i)).toBeHidden();
     await expect(page.getByText(/Reopening ERun session/i)).toBeHidden();
 

--- a/erun-ui/playwright/tests/sidebar-upgrade-all.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-upgrade-all.spec.ts
@@ -14,7 +14,7 @@ test.describe('sidebar Upgrade all', () => {
     await app.sidebar.openUpgradeAll();
 
     const dialog = app.sidebar.upgradeAllDialog();
-    await expect(dialog).toBeVisible({ timeout: 6_000 });
+    await expect(dialog).toBeVisible();
 
     // The body resolves to one of the two terminal states (never stuck on the
     // loading spinner): a plan table, or the opted-in empty state.
@@ -105,7 +105,7 @@ test.describe('sidebar Upgrade all', () => {
 
     await app.sidebar.openUpgradeAll();
     const dialog = app.sidebar.upgradeAllDialog();
-    await expect(dialog).toBeVisible({ timeout: 6_000 });
+    await expect(dialog).toBeVisible();
     await expect(dialog.getByRole('table', { name: 'Upgrade plan' })).toBeVisible();
 
     // Lagging env → "will upgrade", showing current → target.
@@ -247,12 +247,12 @@ test.describe('sidebar Upgrade all', () => {
 
     await app.sidebar.openUpgradeAll();
     const dialog = app.sidebar.upgradeAllDialog();
-    await expect(dialog).toBeVisible({ timeout: 6_000 });
+    await expect(dialog).toBeVisible();
     await dialog.getByRole('button', { name: 'Upgrade 2' }).click();
 
     // One scoped run per lagging member, each in its own env — never the
     // up-to-date member, never a single global run.
-    await expect.poll(() => upgradeRuns.length, { timeout: 6_000 }).toBe(2);
+    await expect.poll(() => upgradeRuns.length).toBe(2);
     const ran = upgradeRuns
       .map((selection) => `${selection.tenant ?? ''}/${selection.environment ?? ''}`)
       .sort();
@@ -334,7 +334,7 @@ test.describe('sidebar Upgrade all', () => {
 
     await app.sidebar.openUpgradeAll();
     const dialog = app.sidebar.upgradeAllDialog();
-    await expect(dialog).toBeVisible({ timeout: 6_000 });
+    await expect(dialog).toBeVisible();
 
     // Until a version is picked the env asks for one and is not in the count;
     // Upgrade stays disabled (nothing to redeploy yet).
@@ -356,7 +356,7 @@ test.describe('sidebar Upgrade all', () => {
 
     // The confirmed run carries the picked version so `erun upgrade` deploys
     // exactly what the operator chose (issue #527).
-    await expect.poll(() => upgradeRuns.length, { timeout: 6_000 }).toBe(1);
+    await expect.poll(() => upgradeRuns.length).toBe(1);
     expect(upgradeRuns[0]?.environment).toBe('pick-env');
     expect(upgradeRuns[0]?.version).toBe(newer);
     await expect(dialog).toBeHidden();

--- a/erun-ui/playwright/tests/tab-respawn-on-context-running.spec.ts
+++ b/erun-ui/playwright/tests/tab-respawn-on-context-running.spec.ts
@@ -38,14 +38,21 @@ import { SEED_ENV_ALPHA, SEED_TENANT } from '../fixtures/seedRoot.js';
 
 test.describe('tab respawn after cloud context returns to running', () => {
   test('non-managed env does not lose tabs across an idle poll cycle', async ({ app, page }) => {
+    // The idle poll round-trips a LoadIdleStatus RPC; wait on that event (not
+    // the wall clock) so the assertions reflect a completed poll cycle.
+    const idlePolled = page.waitForResponse(
+      (response) =>
+        response.url().includes('/__erun_invoke') &&
+        (response.request().postData() ?? '').includes('LoadIdleStatus'),
+    );
     // Open a seeded env so its tabs are initialized.
     await app.sidebar.openEnvironment(SEED_TENANT, SEED_ENV_ALPHA);
 
-    // Give the idle poll a window to run; the seeded local-agent env
-    // returns managedCloud=false and the transition detector should be a
-    // no-op. We assert the sidebar continues to render a single row
-    // for this env with no errant spinner from spurious tab spawn.
-    await page.waitForTimeout(1_500);
+    // Once the poll has reported (the seeded local-agent env returns
+    // managedCloud=false), the transition detector should have been a no-op.
+    // Assert the sidebar still renders a single row for this env with no
+    // errant spinner from a spurious tab spawn.
+    await idlePolled;
     const sidebar = page.locator('aside').first();
     await expect(sidebar.getByRole('status')).toHaveCount(0);
 

--- a/erun-ui/playwright/tests/tab-strip.spec.ts
+++ b/erun-ui/playwright/tests/tab-strip.spec.ts
@@ -44,7 +44,7 @@ test.describe('terminal tab strip', () => {
     // would see a yellow busy pill with this text. toBeHidden with a
     // generous window catches both immediate and delayed misfires while
     // staying fast on a healthy build.
-    await expect(page.getByText(/Reopening Local shell/i)).toBeHidden({ timeout: 2_000 });
+    await expect(page.getByText(/Reopening Local shell/i)).toBeHidden();
     await expect(page.getByText(/Reopening AI session/i)).toBeHidden();
     await expect(page.getByText(/Reopening ERun session/i)).toBeHidden();
   });

--- a/erun-ui/playwright/tests/terminal-paste-file.spec.ts
+++ b/erun-ui/playwright/tests/terminal-paste-file.spec.ts
@@ -107,8 +107,6 @@ test.describe('terminal paste of any file (#584)', () => {
     expect(savePayload?.data?.length ?? 0).toBeGreaterThan(0);
 
     // The remote path the copy returned is typed into the terminal.
-    await expect
-      .poll(() => sentInputs.some((input) => input.includes(REMOTE_PATH)), { timeout: 5_000 })
-      .toBe(true);
+    await expect.poll(() => sentInputs.some((input) => input.includes(REMOTE_PATH))).toBe(true);
   });
 });

--- a/erun-ui/playwright/tests/terminal-query-response.spec.ts
+++ b/erun-ui/playwright/tests/terminal-query-response.spec.ts
@@ -123,7 +123,7 @@ async function emitTerminalOutput(page: Page, sessionId: number, raw: string): P
 // machine-independent.
 async function discoverSelectedSessionId(app: AppShell, page: Page): Promise<number> {
   const waitForResize = page
-    .waitForRequest((req) => parseInvoke(req)?.method === 'ResizeSession', { timeout: 1500 })
+    .waitForRequest((req) => parseInvoke(req)?.method === 'ResizeSession')
     .catch(() => null);
   await app.titlebar.toggleButton().click();
   const resize = await waitForResize;
@@ -143,15 +143,12 @@ test.describe('terminal query responses (#347)', () => {
 
     // The reply must be addressed to the session that produced the query.
     await expect
-      .poll(
-        () => {
-          const reply = invokes.find(
-            (call) => call.method === 'SendSessionInput' && isCprReply(call.args[1]),
-          );
-          return reply?.args[0];
-        },
-        { timeout: 5_000 },
-      )
+      .poll(() => {
+        const reply = invokes.find(
+          (call) => call.method === 'SendSessionInput' && isCprReply(call.args[1]),
+        );
+        return reply?.args[0];
+      })
       .toBe(selectedId);
   });
 
@@ -169,15 +166,13 @@ test.describe('terminal query responses (#347)', () => {
     await emitTerminalOutput(page, selectedId, CPR_QUERY);
 
     await expect
-      .poll(
-        () =>
-          invokes.some(
-            (call) =>
-              call.method === 'SendSessionInput' &&
-              isCprReply(call.args[1]) &&
-              call.args[0] === selectedId,
-          ),
-        { timeout: 5_000 },
+      .poll(() =>
+        invokes.some(
+          (call) =>
+            call.method === 'SendSessionInput' &&
+            isCprReply(call.args[1]) &&
+            call.args[0] === selectedId,
+        ),
       )
       .toBe(true);
 
@@ -224,7 +219,7 @@ test.describe('terminal query responses (#347)', () => {
     //    the session's saved buffer (the `?` prefix dodges the display strip,
     //    exactly like production queries split across PTY chunks do).
     await emitTerminalOutput(page, extraId, CPR_QUERY);
-    await expect.poll(() => cprRepliesTo(invokes, extraId).length, { timeout: 5_000 }).toBe(1);
+    await expect.poll(() => cprRepliesTo(invokes, extraId).length).toBe(1);
 
     // 2. Switch away and back. The middleware rebuilds and replays the extra
     //    session's display buffer — stale query included — into xterm.
@@ -239,9 +234,7 @@ test.describe('terminal query responses (#347)', () => {
     await emitTerminalOutput(page, extraId, '\x1b[');
     await emitTerminalOutput(page, extraId, '6n');
     await expect
-      .poll(() => cprRepliesTo(invokes, extraId).filter((r) => !r.startsWith('\x1b[?')).length, {
-        timeout: 5_000,
-      })
+      .poll(() => cprRepliesTo(invokes, extraId).filter((r) => !r.startsWith('\x1b[?')).length)
       .toBe(1);
 
     // The replay parse is provably complete and must have contributed

--- a/erun-ui/playwright/tests/terminal-scroll-on-resize.spec.ts
+++ b/erun-ui/playwright/tests/terminal-scroll-on-resize.spec.ts
@@ -48,7 +48,7 @@ test.describe('terminal scroll on resize (#465)', () => {
     await expect.poll(() => viewportHasScrollback(page), { timeout: 10_000 }).toBe(true);
     // xterm keeps an at-bottom viewport pinned while output streams, so the
     // staging leaves the viewport at the live prompt.
-    await expect.poll(() => terminalAtBottom(page), { timeout: 5_000 }).toBe(true);
+    await expect.poll(() => terminalAtBottom(page)).toBe(true);
 
     // At-bottom resize: the review-panel toggle changes the terminal's
     // column count and rewraps the buffer; the viewport must come back to
@@ -56,16 +56,16 @@ test.describe('terminal scroll on resize (#465)', () => {
     const colsBefore = await readTerminalCols(page);
     expect(colsBefore).toBeGreaterThan(0);
     await app.titlebar.toggleReviewPanel();
-    await expect.poll(() => readTerminalCols(page), { timeout: 5_000 }).not.toBe(colsBefore);
-    await expect.poll(() => terminalAtBottom(page), { timeout: 5_000 }).toBe(true);
+    await expect.poll(() => readTerminalCols(page)).not.toBe(colsBefore);
+    await expect.poll(() => terminalAtBottom(page)).toBe(true);
 
     // Scrolled-up resize: a reader parked in history must not be yanked to
     // the bottom by the next resize.
     await setViewportScrollTop(page, 0);
-    await expect.poll(() => terminalAtBottom(page), { timeout: 5_000 }).toBe(false);
+    await expect.poll(() => terminalAtBottom(page)).toBe(false);
     const colsMid = await readTerminalCols(page);
     await app.titlebar.toggleReviewPanel(); // restores the panel to its original state
-    await expect.poll(() => readTerminalCols(page), { timeout: 5_000 }).not.toBe(colsMid);
+    await expect.poll(() => readTerminalCols(page)).not.toBe(colsMid);
     // The faulty force-scroll would fire from the post-fit write callback
     // within milliseconds of the refit; sample the viewport over a short
     // window and require that it never lands at the bottom.
@@ -75,23 +75,23 @@ test.describe('terminal scroll on resize (#465)', () => {
     // at the bottom — the viewport must come back to the prompt — then grow
     // it back while scrolled up — the reading position must survive.
     await setViewportScrollTop(page, Number.MAX_SAFE_INTEGER);
-    await expect.poll(() => terminalAtBottom(page), { timeout: 5_000 }).toBe(true);
+    await expect.poll(() => terminalAtBottom(page)).toBe(true);
     const colsWide = await readTerminalCols(page);
     await page.setViewportSize({ width: 1080, height: 860 });
-    await expect.poll(() => readTerminalCols(page), { timeout: 5_000 }).not.toBe(colsWide);
-    await expect.poll(() => terminalAtBottom(page), { timeout: 5_000 }).toBe(true);
+    await expect.poll(() => readTerminalCols(page)).not.toBe(colsWide);
+    await expect.poll(() => terminalAtBottom(page)).toBe(true);
 
     await setViewportScrollTop(page, 0);
-    await expect.poll(() => terminalAtBottom(page), { timeout: 5_000 }).toBe(false);
+    await expect.poll(() => terminalAtBottom(page)).toBe(false);
     const colsNarrow = await readTerminalCols(page);
     await page.setViewportSize({ width: 1440, height: 1200 }); // config default
-    await expect.poll(() => readTerminalCols(page), { timeout: 5_000 }).not.toBe(colsNarrow);
+    await expect.poll(() => readTerminalCols(page)).not.toBe(colsNarrow);
     expect(await viewportEverAtBottom(page, 600)).toBe(false);
 
     // Leave the viewport at the prompt so later specs in the singleton
     // backend see the usual at-bottom baseline.
     await setViewportScrollTop(page, Number.MAX_SAFE_INTEGER);
-    await expect.poll(() => terminalAtBottom(page), { timeout: 5_000 }).toBe(true);
+    await expect.poll(() => terminalAtBottom(page)).toBe(true);
   });
 });
 
@@ -120,7 +120,7 @@ function parseInvoke(req: Request): InvokeCall | null {
 // then restores the sidebar. 0 means no session is selected.
 async function discoverSelectedSessionId(app: AppShell, page: Page): Promise<number> {
   const waitForResize = page
-    .waitForRequest((req) => parseInvoke(req)?.method === 'ResizeSession', { timeout: 1500 })
+    .waitForRequest((req) => parseInvoke(req)?.method === 'ResizeSession')
     .catch(() => null);
   await app.titlebar.toggleButton().click();
   const resize = await waitForResize;

--- a/erun-ui/playwright/tests/terminal-scroll-on-switch.spec.ts
+++ b/erun-ui/playwright/tests/terminal-scroll-on-switch.spec.ts
@@ -58,7 +58,7 @@ test.describe('terminal scroll on session switch', () => {
     await localTab.click();
     await extraTab.click();
 
-    await expect.poll(() => terminalAtBottom(page), { timeout: 5_000 }).toBe(true);
+    await expect.poll(() => terminalAtBottom(page)).toBe(true);
 
     // Close the spawned terminal so the extra session does not drift the
     // session set the singleton headless backend hands to later specs. The

--- a/erun-ui/playwright/tests/titlebar-status-overflow.spec.ts
+++ b/erun-ui/playwright/tests/titlebar-status-overflow.spec.ts
@@ -67,7 +67,7 @@ test.describe('titlebar status overflow', () => {
     // does not race against the truncated-vs-full text shown in the
     // collapsed state.
     const trigger = page.getByTestId('titlebar-status-message');
-    await expect(trigger).toBeVisible({ timeout: 5_000 });
+    await expect(trigger).toBeVisible();
 
     await emitLong();
     await trigger.click();
@@ -101,7 +101,7 @@ test.describe('titlebar status overflow', () => {
       ).runtime;
       runtime.EventsEmit('app-status', { message, busy: false });
     }, SHORT);
-    await expect(page.getByText(SHORT, { exact: false })).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText(SHORT, { exact: false })).toBeVisible();
     // The popover trigger testid only renders for long messages.
     await expect(page.getByTestId('titlebar-status-message')).toHaveCount(0);
   });

--- a/erun-ui/playwright/tests/ux-tooltip-rules.spec.ts
+++ b/erun-ui/playwright/tests/ux-tooltip-rules.spec.ts
@@ -80,7 +80,7 @@ test.describe('UX tooltip rules', () => {
     const clearAll = app.activityDrawer
       .locator()
       .getByRole('button', { name: /Force dismiss all/ });
-    await expect(clearAll).toBeVisible({ timeout: 5_000 });
+    await expect(clearAll).toBeVisible();
     // The new ClearAllButton drops the native title attribute and routes
     // the hint through Tooltip + aria-label, so the title is absent and
     // aria-label carries the explanatory hint.
@@ -120,7 +120,7 @@ test.describe('UX tooltip rules', () => {
       .locator()
       .getByRole('button', { name: 'Dismiss', exact: true })
       .first();
-    await expect(dismissButton).toBeVisible({ timeout: 5_000 });
+    await expect(dismissButton).toBeVisible();
     await expect(dismissButton).not.toHaveAttribute('title', /.*/);
   });
 });


### PR DESCRIPTION
## Summary

The headless Playwright suite had roving, intermittent failures under full-suite load — a *different* env-open/async spec timed out on each run. The cause was an anti-pattern, not per-spec logic: ~25 specs pinned waits/assertions at **sub-default `timeout:` overrides** (5_000/6_000/4_000/2_000/1500) tighter than the suite's 10s `expect` default, plus a handful of fixed `page.waitForTimeout` sleeps. The shared headless backend is a singleton with sessions persisting across specs, so late-suite RPC latency rises and a wait pinned at 4–6s flakes where the 10s default would clear (forbidden by `playwright/AGENTS.md` § "No flaky tests").

## Change

- **Remove every sub-default `timeout:` override across 22 specs** — handling the sole-arg, trailing-arg, multi-line options-object, and `expect.poll`/`waitForRequest` forms individually (not a blind regex). The `10_000`/`15_000` overrides where a step is genuinely slow are kept.
- **Replace all 5 `page.waitForTimeout(...)` sleeps with real-event waits:** `waitForResponse` on the `LoadIdleStatus` poll (idle-tooltip, tab-respawn) and the `ListRemoteAppSessions` detection RPC (remote-session-tabs), and ordered `app-notification` emits bounded by the rendered sentinel toast.
- **`app-notification` "error persists (no auto-dismiss)":** the notification slot is single-occupancy (`notificationThunks.showNotification` replaces the one toast), so a sibling info toast *races* the error rather than timing alongside it. Use Playwright's `page.clock` to advance past the 3.2s auto-dismiss window deterministically — confirmed **5/5** under `--repeat-each`, and faster than the old sleep.

## Validation

- `yarn typecheck` + `yarn lint` (`playwright/no-wait-for-timeout` now **0**) + `format:check` clean.
- Across the pre-fix **3 consecutive full-suite runs**, every spec except the single `app-notification` flake passed all three; that flake is now fixed and **5/5-deterministic**. A final full-suite run gates this merge.

## Note on the deeper option

The issue's "deeper option" (a harness-level per-spec backend session reset to cut late-suite latency at the source) is left as a separate follow-up — the sub-default-timeout removal is the targeted fix for the roving flakiness and keeps this PR focused.

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)