### PR TITLE
erun-docs: Part A networking-doc corrections (NetworkPolicy, nginx skeleton, docs.erunpaas.com)

### DIFF
--- a/erun-docs/AGENTS.md
+++ b/erun-docs/AGENTS.md
@@ -22,7 +22,7 @@ Module-specific guidance for `erun-docs`. Follow the repository root `AGENTS.md`
 These must exist before the first deploy succeeds. They are external to this repository:
 
 1. **Cloudflare Pages project** named `erun-docs` (Direct Upload type — do **not** connect a Git source, the Job uploads directly).
-2. **Custom domain** `docs.erunpaas.com` attached to the Pages project.
+2. **Custom domain** `docs.erunpaas.com` attached to the Pages project. **(Planned.)** The DNS record is not cut over yet, so `https://docs.erunpaas.com` is not live; until it is, the site is reachable only at its Cloudflare Pages preview URL. Treat the custom-domain URL as aspirational wherever it appears above.
 3. **Cloudflare API token** with `Pages:Edit` scope, plus the Cloudflare account id.
 4. **Kubernetes Secret** named `cf-creds` (configurable via `docs.credentialsSecretName`) in the target tenant/env namespace, with keys:
    - `CLOUDFLARE_API_TOKEN`

--- a/erun-docs/docs/agent-reference/networking-spec.md
+++ b/erun-docs/docs/agent-reference/networking-spec.md
@@ -59,7 +59,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
-  ingressClassName: nginx
+  ingressClassName: <ingress-class>   # your controller's class: nginx, traefik, istio, alb, …
   rules:
     - host: <service>.{{ .Release.Namespace }}.<environment>.<domain>
       http:
@@ -152,7 +152,7 @@ The dry-run trace prints both `kubectl` commands verbatim (including the TTL) pl
 
 ## Cross-namespace traffic semantics
 
-ERun's runtime chart deploys a default-deny `NetworkPolicy` per env that blocks ingress from outside the namespace. The shape:
+Vanilla Kubernetes lets pods reach across namespaces, so ERun provides a default-deny `NetworkPolicy` as a **copy-paste pattern you apply per env** — the runtime chart does **not** auto-deploy one (no `NetworkPolicy` template ships in it). Apply this manifest to an env's namespace to block ingress from outside it. The shape:
 
 ```yaml
 apiVersion: networking.k8s.io/v1

--- a/erun-docs/docs/concepts/networking.md
+++ b/erun-docs/docs/concepts/networking.md
@@ -43,7 +43,7 @@ The exposed URL is HTTP today; a wildcard TLS certificate (making it `https://`)
 
 ## Inter-env communication
 
-By default, **envs cannot reach each other.** ERun's runtime chart deploys a default-deny NetworkPolicy on every env's namespace. Cross-env traffic requires an explicit opt-in NetworkPolicy on the target plus a matching label on the consumer namespace; this is rare and usually a sign you should be using one env rather than two. See [Networking spec · Cross-namespace traffic semantics](/agent-reference/networking-spec#cross-namespace-traffic-semantics) for the manifests.
+**Isolating envs from each other is opt-in.** Vanilla Kubernetes lets pods reach across namespaces, so ERun provides a default-deny NetworkPolicy as a copy-paste pattern — it does **not** auto-deploy one. Apply it to an env's namespace to block ingress from outside it; cross-env traffic then requires an explicit opt-in NetworkPolicy on the target plus a matching label on the consumer namespace. Needing this is rare and usually a sign you should be using one env rather than two. See [Networking spec · Cross-namespace traffic semantics](/agent-reference/networking-spec#cross-namespace-traffic-semantics) for the manifests.
 
 ## Per-env DNS
 


### PR DESCRIPTION
## Summary

The standalone-eligible **Part A** of the #607 docs plan — pre-existing doc-vs-reality inaccuracies, independent of the erunpaas platform features.

- **A1 — default-deny NetworkPolicy.** It was documented as auto-deployed by the runtime chart, but **no NetworkPolicy template ships** under `erun-devops/k8s/`. Reworded both the operator concept page (`concepts/networking.md`) and the agent-reference spec (`agent-reference/networking-spec.md`): ERun provides the default-deny policy as a **copy-paste pattern you apply per env**; vanilla Kubernetes lets pods cross namespaces, so isolating envs is opt-in (not auto-deployed).
- **A2 — nginx skeleton.** The Pattern 3 Ingress skeleton hard-coded `ingressClassName: nginx`, implying a default. Genericised to an `<ingress-class>` placeholder (nginx, traefik, istio, alb, …).
- **A4 — docs.erunpaas.com.** Documented as the live site URL, but DNS is not cut over. Marked the custom-domain prerequisite **(Planned.)** in `erun-docs/AGENTS.md` so the live URL reads as aspirational until DNS lands.

**A3** (hostname grammar gaining the hosted `services.<base-domain>` form) is **already satisfied**: #603's docs landed the platform service-exposure section + the `erun expose` grammar, so the BYO-ingress and hosted forms coexist without contradiction.

## Scope

This is **Part A only**. Part B (feature docs for #603–#606) lands inside those PRs per the docs-with-feature rule, so this PR **does not close #607** — it addresses the standalone subset.

## Validation

- `cd erun-docs && yarn build` clean (`onBrokenLinks: 'throw'`).
- No section moves → no anchor changes; canonical-terminology sweep clean.

Part A of #607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)