### PR TITLE
Authenticate the per-env MCP edge with a desktop-key JWT

### DIFF
--- a/erun-cli/cmd/deploy.go
+++ b/erun-cli/cmd/deploy.go
@@ -99,6 +99,7 @@ func addDeployCommandTargetFlags(cmd *cobra.Command, target *common.DeployTarget
 	cmd.Flags().StringVar(&target.Environment, "environment", "", "Deploy for a specific environment; requires --tenant")
 	cmd.Flags().BoolVar(&target.Force, "force", false, "Re-run the helm upgrade even when the deployed release already matches the requested version")
 	cmd.Flags().StringVar(&target.RolloutTimeout, "rollout-timeout", "", "Override the helm rollout wait for this deploy (Go duration, e.g. 8m); empty uses the env's deploy.timeout or the 5m default")
+	cmd.Flags().StringVar(&target.MCPAuthPublicKeyPath, "mcp-auth-public-key", "", "Require the env's MCP edge to authenticate bearer tokens signed by this PEM public key (issue #655); empty leaves the edge loopback-only")
 	cmd.Flags().StringVar(&target.RepoPath, "repo-path", "", "Repo path override for internal tooling")
 	_ = cmd.Flags().MarkHidden("repo-path")
 }

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -189,6 +189,18 @@ type HelmDeploySpec struct {
 	// projects; when set, deploy threads it to every chart as platform.*
 	// values so the PowerDNS singleton can bootstrap its authoritative zone.
 	Platform PlatformConfig
+	// MCPAuth* require the per-env erun-mcp edge to authenticate bearer tokens
+	// against a trusted public key (issue #655). MCPAuthEnabled gates the whole
+	// path; MCPAuthPublicKeyPEM is the (non-secret) key delivered out-of-band as
+	// a Secret like the Cloudflare token; MCPAuthIssuer is the file:// issuer the
+	// token's iss claim names and the server loads the key from; MCPAuthAudience
+	// is the per-env audience. Empty leaves the edge in legacy loopback-only
+	// pass-through, so non-desktop deploys are byte-for-byte unchanged.
+	MCPAuthEnabled      bool
+	MCPAuthPublicKeyPEM string
+	MCPAuthIssuer       string
+	MCPAuthAudience     string
+	MCPAuthSecretName   string
 }
 
 type HelmReleaseRecoveryParams struct {
@@ -237,6 +249,13 @@ type DeployTarget struct {
 	// leaves the resolved per-env/default value untouched. Set by the CLI
 	// `--rollout-timeout` flag and the MCP `timeout` input.
 	RolloutTimeout string
+	// MCPAuthPublicKeyPath, when set, points at a PEM public key the runtime
+	// chart trusts so the per-env erun-mcp edge requires a bearer token signed
+	// by it (issue #655). Empty leaves the edge in legacy loopback-only mode, so
+	// non-desktop deploys are unchanged. The desktop sets it to its persisted
+	// public key on both its deploy paths; the CLI exposes it as
+	// `--mcp-auth-public-key`.
+	MCPAuthPublicKeyPath string
 }
 
 // DeploySpec is a pure helm-install plan: it installs the image and chart
@@ -488,6 +507,9 @@ func RunHelmDeploy(ctx Context, deployInput HelmDeploySpec, deploy HelmChartDepl
 	if err := applyCloudflareCredentialsSecret(ctx, deployInput); err != nil {
 		return fmt.Errorf("deploy %s: %w", deployInput.ReleaseName, err)
 	}
+	if err := applyMCPAuthSecret(ctx, deployInput); err != nil {
+		return fmt.Errorf("deploy %s: %w", deployInput.ReleaseName, err)
+	}
 	command := deployInput.command()
 	ctx.TraceCommand(command.Dir, command.Name, command.Args...)
 	tracePodWatchAction(ctx, deployInput.ReleaseName, deployInput.Namespace, deployInput.KubernetesContext)
@@ -597,6 +619,9 @@ func ResolveDeploySpec(ctx Context, store DeployStore, findProjectRoot ProjectFi
 	if ok {
 		spec.Deploy.Timeout = override
 	}
+	if err := applyMCPAuthToRuntimeSpec(target, &spec); err != nil {
+		return DeploySpec{}, err
+	}
 	return spec, nil
 }
 
@@ -614,6 +639,11 @@ func ResolveCurrentDeploySpecs(ctx Context, store DeployStore, findProjectRoot P
 	if ok {
 		for i := range specs {
 			specs[i].Deploy.Timeout = override
+		}
+	}
+	for i := range specs {
+		if err := applyMCPAuthToRuntimeSpec(target, &specs[i]); err != nil {
+			return nil, err
 		}
 	}
 	return specs, nil
@@ -1567,6 +1597,18 @@ func (d HelmDeploySpec) command() commandSpec {
 			"--set", "cloudContext.cloudflare.enabled=true",
 			"--set-string", "cloudContext.cloudflare.accountId="+d.CloudflareAccountID,
 			"--set-string", "cloudContext.cloudflare.secretName="+d.CloudflareSecretName,
+		)
+	}
+	// MCP auth is appended only when a trusted key is injected (desktop deploy),
+	// so existing deploy plans are byte-for-byte unchanged. The public key rides
+	// out-of-band as a Secret (applyMCPAuthSecret); only its name + the issuer
+	// and per-env audience are helm values.
+	if d.MCPAuthEnabled {
+		args = append(args,
+			"--set", "mcpAuth.enabled=true",
+			"--set-string", "mcpAuth.secretName="+d.MCPAuthSecretName,
+			"--set-string", "mcpAuth.issuer="+escapeHelmSetValue(d.MCPAuthIssuer),
+			"--set-string", "mcpAuth.audience="+escapeHelmSetValue(d.MCPAuthAudience),
 		)
 	}
 	args = append(args, helmRegistrySetArgs(d)...)

--- a/erun-common/mcp_auth.go
+++ b/erun-common/mcp_auth.go
@@ -1,0 +1,240 @@
+package eruncommon
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// MCP auth edge (issue #655). The per-env erun-mcp server is exposed publicly
+// and its `raw` tool can kubectl-exec, so it must always be authenticated. For
+// a desktop deployment the trust anchor is a self-contained Ed25519 keypair:
+// the desktop signs an EdDSA JWT bearer token with its private key
+// (desktopid.key), injects the matching public key into the runtime pod, and
+// names that public key in the token's `iss` claim as a `file://<path>` URL.
+// The MCP server is configured to trust exactly that issuer, loads the public
+// key from the path, and verifies the token's signature against it.
+//
+// The format is deliberately minimal and fully controlled (this package both
+// signs and verifies): EdDSA only — `alg` is hard-checked, so the JWT
+// alg-confusion class (accepting `none`/HMAC/RS256 against a public key) cannot
+// occur — and the verifier only ever loads the public key from the issuer the
+// caller already trusts, never an arbitrary `file://` from the token.
+
+// MCPTokenClaims is the registered-claim subset the MCP auth edge uses.
+type MCPTokenClaims struct {
+	Issuer    string `json:"iss"`
+	Subject   string `json:"sub,omitempty"`
+	Audience  string `json:"aud,omitempty"`
+	IssuedAt  int64  `json:"iat,omitempty"`
+	ExpiresAt int64  `json:"exp,omitempty"`
+}
+
+// mcpTokenHeader is the JWS header. Only EdDSA is ever produced or accepted.
+type mcpTokenHeader struct {
+	Algorithm string `json:"alg"`
+	Type      string `json:"typ"`
+}
+
+const mcpTokenAlgorithm = "EdDSA"
+
+// GenerateDesktopIdentity creates a new Ed25519 desktop identity keypair and
+// returns it PEM-encoded (PKCS#8 private, PKIX public). The desktop persists the
+// private key as desktopid.key and injects the public key into the runtime pod;
+// the MCP server verifies bearer tokens against the public key (issue #655).
+func GenerateDesktopIdentity() (privatePEM, publicPEM []byte, err error) {
+	public, private, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate desktop identity: %w", err)
+	}
+	privateDER, err := x509.MarshalPKCS8PrivateKey(private)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal desktop private key: %w", err)
+	}
+	publicDER, err := x509.MarshalPKIXPublicKey(public)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal desktop public key: %w", err)
+	}
+	privatePEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateDER})
+	publicPEM = pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicDER})
+	return privatePEM, publicPEM, nil
+}
+
+// FileIssuer formats a public-key file path as the `file://<path>` issuer URL
+// the desktop puts in the token's `iss` claim and the MCP server is configured
+// to trust. The path is the location of the public key inside the runtime pod.
+func FileIssuer(publicKeyPath string) string {
+	return "file://" + publicKeyPath
+}
+
+// SignMCPToken signs an EdDSA (Ed25519) JWT for the given claims with the
+// PEM-encoded private key. The claims' Issuer must be a `file://<path>` URL
+// naming the public-key file the verifier will load.
+func SignMCPToken(privatePEM []byte, claims MCPTokenClaims) (string, error) {
+	key, err := parseEd25519PrivateKey(privatePEM)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(claims.Issuer) == "" {
+		return "", fmt.Errorf("mcp token issuer is required")
+	}
+	headerSegment, err := encodeJWTSegment(mcpTokenHeader{Algorithm: mcpTokenAlgorithm, Type: "JWT"})
+	if err != nil {
+		return "", err
+	}
+	claimsSegment, err := encodeJWTSegment(claims)
+	if err != nil {
+		return "", err
+	}
+	signingInput := headerSegment + "." + claimsSegment
+	signature := ed25519.Sign(key, []byte(signingInput))
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+// VerifyMCPToken verifies an MCP bearer token. It hard-requires alg EdDSA,
+// requires the token's issuer to equal trustedIssuer (a `file://<path>` URL the
+// MCP server is configured to trust — never an arbitrary issuer from the
+// token), loads the Ed25519 public key from that path, verifies the signature,
+// checks expiry against now, and checks the audience when expectedAudience is
+// non-empty. It returns the validated claims or a descriptive error.
+func VerifyMCPToken(token, trustedIssuer, expectedAudience string, now time.Time) (MCPTokenClaims, error) {
+	trustedIssuer = strings.TrimSpace(trustedIssuer)
+	if trustedIssuer == "" {
+		return MCPTokenClaims{}, fmt.Errorf("no trusted issuer configured for MCP auth")
+	}
+	signingInput, claims, signature, err := parseMCPToken(token)
+	if err != nil {
+		return MCPTokenClaims{}, err
+	}
+	// Only ever load the key from the issuer we already trust — never a
+	// file:// path supplied by the (unverified) token.
+	if claims.Issuer != trustedIssuer {
+		return MCPTokenClaims{}, fmt.Errorf("MCP token issuer %q is not the trusted issuer", claims.Issuer)
+	}
+	publicKey, err := loadEd25519PublicKeyFromFileIssuer(trustedIssuer)
+	if err != nil {
+		return MCPTokenClaims{}, err
+	}
+	if !ed25519.Verify(publicKey, []byte(signingInput), signature) {
+		return MCPTokenClaims{}, fmt.Errorf("MCP token signature is not valid for the trusted public key")
+	}
+	if err := validateMCPClaims(claims, expectedAudience, now); err != nil {
+		return MCPTokenClaims{}, err
+	}
+	return claims, nil
+}
+
+// parseMCPToken splits a JWT into its signing input, decoded claims, and raw
+// signature, hard-requiring the EdDSA algorithm in the header (closing the
+// alg-confusion class — none / HMAC verified against the public key bytes).
+func parseMCPToken(token string) (signingInput string, claims MCPTokenClaims, signature []byte, err error) {
+	segments := strings.Split(strings.TrimSpace(token), ".")
+	if len(segments) != 3 {
+		return "", MCPTokenClaims{}, nil, fmt.Errorf("malformed MCP token: expected 3 JWT segments")
+	}
+	var header mcpTokenHeader
+	if err := decodeJWTSegment(segments[0], &header); err != nil {
+		return "", MCPTokenClaims{}, nil, fmt.Errorf("decode MCP token header: %w", err)
+	}
+	if header.Algorithm != mcpTokenAlgorithm {
+		return "", MCPTokenClaims{}, nil, fmt.Errorf("unsupported MCP token algorithm %q (only %s)", header.Algorithm, mcpTokenAlgorithm)
+	}
+	if err := decodeJWTSegment(segments[1], &claims); err != nil {
+		return "", MCPTokenClaims{}, nil, fmt.Errorf("decode MCP token claims: %w", err)
+	}
+	signature, err = base64.RawURLEncoding.DecodeString(segments[2])
+	if err != nil {
+		return "", MCPTokenClaims{}, nil, fmt.Errorf("decode MCP token signature: %w", err)
+	}
+	return segments[0] + "." + segments[1], claims, signature, nil
+}
+
+// validateMCPClaims checks the time and audience constraints on already
+// signature-verified claims.
+func validateMCPClaims(claims MCPTokenClaims, expectedAudience string, now time.Time) error {
+	if claims.ExpiresAt != 0 && now.After(time.Unix(claims.ExpiresAt, 0)) {
+		return fmt.Errorf("MCP token expired")
+	}
+	if expectedAudience != "" && claims.Audience != expectedAudience {
+		return fmt.Errorf("MCP token audience %q does not match %q", claims.Audience, expectedAudience)
+	}
+	return nil
+}
+
+// loadEd25519PublicKeyFromFileIssuer parses a `file://<path>` issuer and reads
+// the PEM-encoded Ed25519 public key at that path.
+func loadEd25519PublicKeyFromFileIssuer(issuer string) (ed25519.PublicKey, error) {
+	parsed, err := url.Parse(issuer)
+	if err != nil || parsed.Scheme != "file" {
+		return nil, fmt.Errorf("trusted issuer %q is not a file:// URL", issuer)
+	}
+	// file://<path> — the path is parsed.Path (host is empty for file:///abs or
+	// file://abs forms we mint via FileIssuer).
+	path := parsed.Path
+	if path == "" {
+		path = parsed.Opaque
+	}
+	if parsed.Host != "" {
+		path = parsed.Host + path
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read MCP trusted public key %s: %w", path, err)
+	}
+	return parseEd25519PublicKey(data)
+}
+
+func parseEd25519PrivateKey(privatePEM []byte) (ed25519.PrivateKey, error) {
+	block, _ := pem.Decode(privatePEM)
+	if block == nil {
+		return nil, fmt.Errorf("desktop private key is not valid PEM")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse desktop private key: %w", err)
+	}
+	key, ok := parsed.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("desktop private key is not an Ed25519 key")
+	}
+	return key, nil
+}
+
+func parseEd25519PublicKey(publicPEM []byte) (ed25519.PublicKey, error) {
+	block, _ := pem.Decode(publicPEM)
+	if block == nil {
+		return nil, fmt.Errorf("trusted public key is not valid PEM")
+	}
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse trusted public key: %w", err)
+	}
+	key, ok := parsed.(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("trusted public key is not an Ed25519 key")
+	}
+	return key, nil
+}
+
+func encodeJWTSegment(value any) (string, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(encoded), nil
+}
+
+func decodeJWTSegment(segment string, into any) error {
+	decoded, err := base64.RawURLEncoding.DecodeString(segment)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(decoded, into)
+}

--- a/erun-common/mcp_auth.go
+++ b/erun-common/mcp_auth.go
@@ -239,6 +239,21 @@ func loadEd25519PublicKeyFromFileIssuer(issuer string) (ed25519.PublicKey, error
 	return parseEd25519PublicKey(data)
 }
 
+// DesktopPublicKeyPEM derives the PKIX public-key PEM from a persisted desktop
+// private key, so the private key (desktopid.key) is the single source of truth
+// the desktop persists; the public half is recomputed for injection on deploy.
+func DesktopPublicKeyPEM(privatePEM []byte) ([]byte, error) {
+	key, err := parseEd25519PrivateKey(privatePEM)
+	if err != nil {
+		return nil, err
+	}
+	publicDER, err := x509.MarshalPKIXPublicKey(key.Public())
+	if err != nil {
+		return nil, fmt.Errorf("marshal desktop public key: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicDER}), nil
+}
+
 func parseEd25519PrivateKey(privatePEM []byte) (ed25519.PrivateKey, error) {
 	block, _ := pem.Decode(privatePEM)
 	if block == nil {

--- a/erun-common/mcp_auth.go
+++ b/erun-common/mcp_auth.go
@@ -168,6 +168,23 @@ func validateMCPClaims(claims MCPTokenClaims, expectedAudience string, now time.
 	return nil
 }
 
+// UnverifiedMCPTokenIssuer extracts the `iss` claim from a token WITHOUT
+// verifying its signature. The MCP server uses it — exactly as the erun api's
+// issuerFromJWT does — only to select which trusted issuer (and therefore which
+// tenant) the token claims to come from; VerifyMCPToken then re-checks the
+// issuer and verifies the signature against that issuer's key. The EdDSA-only
+// header check still runs, so a non-EdDSA token is rejected here too.
+func UnverifiedMCPTokenIssuer(token string) (string, error) {
+	_, claims, _, err := parseMCPToken(token)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(claims.Issuer) == "" {
+		return "", fmt.Errorf("MCP token has no issuer")
+	}
+	return claims.Issuer, nil
+}
+
 // loadEd25519PublicKeyFromFileIssuer parses a `file://<path>` issuer and reads
 // the PEM-encoded Ed25519 public key at that path.
 func loadEd25519PublicKeyFromFileIssuer(issuer string) (ed25519.PublicKey, error) {

--- a/erun-common/mcp_auth.go
+++ b/erun-common/mcp_auth.go
@@ -74,6 +74,37 @@ func FileIssuer(publicKeyPath string) string {
 	return "file://" + publicKeyPath
 }
 
+const (
+	// DesktopMCPPublicKeyDir is the in-pod directory the desktop's public key is
+	// mounted into by the runtime chart.
+	DesktopMCPPublicKeyDir  = "/etc/erun/mcp-auth"
+	desktopMCPPublicKeyFile = "desktopid.pub"
+)
+
+// DesktopMCPPublicKeyPath is the in-pod path the desktop public key is mounted
+// at. It is the single location the `file://` issuer references and the MCP
+// server loads the trusted key from, so the chart mount, the desktop signer's
+// `iss` claim, and the server's trusted-issuer env all derive from it.
+func DesktopMCPPublicKeyPath() string {
+	return DesktopMCPPublicKeyDir + "/" + desktopMCPPublicKeyFile
+}
+
+// DesktopMCPIssuer is the `file://` issuer the desktop stamps in its tokens and
+// the MCP server is configured to trust for a desktop deployment.
+func DesktopMCPIssuer() string {
+	return FileIssuer(DesktopMCPPublicKeyPath())
+}
+
+// MCPTokenAudience is the stable per-environment audience a desktop or console
+// token must carry and the env's MCP edge enforces, so a token minted for one
+// environment cannot be replayed against another (issue #655). It is transport-
+// independent — the same value whether the edge is reached over the desktop's
+// local port-forward or the public Traefik route — so the signer and the
+// chart's ERUN_MCP_AUDIENCE always agree.
+func MCPTokenAudience(tenant, environment string) string {
+	return "erun-mcp:" + strings.TrimSpace(tenant) + "/" + strings.TrimSpace(environment)
+}
+
 // SignMCPToken signs an EdDSA (Ed25519) JWT for the given claims with the
 // PEM-encoded private key. The claims' Issuer must be a `file://<path>` URL
 // naming the public-key file the verifier will load.

--- a/erun-common/mcp_auth_deploy.go
+++ b/erun-common/mcp_auth_deploy.go
@@ -1,0 +1,126 @@
+package eruncommon
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// resolveMCPAuthPublicKey reads the PEM public key the deploy will trust the
+// per-env MCP edge against (issue #655). A blank path means no MCP auth — the
+// default; the edge stays loopback-only — so ok is false. A non-empty path that
+// cannot be read is a hard error.
+func resolveMCPAuthPublicKey(path string) (string, bool, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", false, nil
+	}
+	pem, err := os.ReadFile(path)
+	if err != nil {
+		return "", false, fmt.Errorf("read mcp auth public key %s: %w", path, err)
+	}
+	return string(pem), true, nil
+}
+
+// applyMCPAuthToRuntimeSpec injects MCP-auth metadata onto the runtime chart's
+// spec only — the erun-mcp container lives in the erun-devops runtime release,
+// so backend component charts never receive mcpAuth values. It reads the public
+// key from target.MCPAuthPublicKeyPath; a blank path is a no-op, leaving a
+// non-desktop deploy unauthenticated (back-compat).
+func applyMCPAuthToRuntimeSpec(target DeployTarget, spec *DeploySpec) error {
+	if spec == nil || spec.Deploy.ReleaseName != RuntimeReleaseName(target.Tenant) {
+		return nil
+	}
+	pem, ok, err := resolveMCPAuthPublicKey(target.MCPAuthPublicKeyPath)
+	if err != nil {
+		return err
+	}
+	if ok {
+		applyMCPAuthDeployMetadata(&spec.Deploy, pem)
+	}
+	return nil
+}
+
+// mcpAuthSecretName derives the per-release Secret that carries the desktop
+// public key the env's erun-mcp edge verifies bearer tokens against (#655).
+func mcpAuthSecretName(releaseName string) string {
+	return strings.TrimSpace(releaseName) + "-mcp-auth"
+}
+
+// mcpAuthSecretApplyArgs builds the kubectl argv that applies the MCP-auth
+// public-key Secret, reading the manifest from stdin (`-f -`). Shared by the
+// dry-run trace and the live apply.
+func mcpAuthSecretApplyArgs(namespace, kubernetesContext string) []string {
+	args := []string{}
+	if ctxName := strings.TrimSpace(kubernetesContext); ctxName != "" {
+		args = append(args, "--context", ctxName)
+	}
+	args = append(args, "-n", strings.TrimSpace(namespace), "apply", "-f", "-")
+	return args
+}
+
+// renderMCPAuthSecret renders the Secret manifest carrying the desktop public
+// key under the desktopid.pub key — the same filename the chart mounts and the
+// file:// issuer references. The key is public, but it rides in a Secret so the
+// out-of-band apply reuses the same mechanics as the Cloudflare token.
+func renderMCPAuthSecret(name, namespace, publicKeyPEM string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    app.kubernetes.io/managed-by: erun-deploy
+type: Opaque
+stringData:
+  %s: %q
+`, name, namespace, desktopMCPPublicKeyFile, publicKeyPEM)
+}
+
+// applyMCPAuthSecret creates or updates the Secret that delivers the desktop
+// public key into the env's runtime pod, piped to `kubectl apply -f -` via
+// stdin so the manifest is never an argv element. It is a no-op unless the
+// deploy injected a trusted key (a desktop deploy); dry-run traces the apply
+// without touching the cluster.
+func applyMCPAuthSecret(ctx Context, deployInput HelmDeploySpec) error {
+	if !deployInput.MCPAuthEnabled || strings.TrimSpace(deployInput.MCPAuthSecretName) == "" {
+		return nil
+	}
+	args := mcpAuthSecretApplyArgs(deployInput.Namespace, deployInput.KubernetesContext)
+	ctx.Trace("apply mcp auth public key secret " + deployInput.MCPAuthSecretName)
+	ctx.TraceCommand("", "kubectl", args...)
+	if ctx.DryRun {
+		return nil
+	}
+	if strings.TrimSpace(deployInput.MCPAuthPublicKeyPEM) == "" {
+		return fmt.Errorf("deploy %s: mcp auth enabled but no public key provided", deployInput.ReleaseName)
+	}
+	manifest := renderMCPAuthSecret(
+		deployInput.MCPAuthSecretName,
+		deployInput.Namespace,
+		deployInput.MCPAuthPublicKeyPEM,
+	)
+	cmd := Command("kubectl", args...)
+	cmd.Stdin = strings.NewReader(manifest)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("kubectl apply mcp auth secret: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// applyMCPAuthDeployMetadata fills the MCP-auth deploy fields from a desktop
+// public key (PEM). It performs no side effects — the Secret is applied later
+// at execution time by applyMCPAuthSecret. An empty key is a no-op, so a
+// non-desktop deploy leaves the edge unauthenticated (back-compat). The issuer
+// and audience derive from the shared conventions so the signer, the chart, and
+// the verifier all agree.
+func applyMCPAuthDeployMetadata(deployInput *HelmDeploySpec, publicKeyPEM string) {
+	if deployInput == nil || strings.TrimSpace(publicKeyPEM) == "" {
+		return
+	}
+	deployInput.MCPAuthEnabled = true
+	deployInput.MCPAuthPublicKeyPEM = publicKeyPEM
+	deployInput.MCPAuthIssuer = DesktopMCPIssuer()
+	deployInput.MCPAuthAudience = MCPTokenAudience(deployInput.Tenant, deployInput.Environment)
+	deployInput.MCPAuthSecretName = mcpAuthSecretName(deployInput.ReleaseName)
+}

--- a/erun-common/mcp_auth_test.go
+++ b/erun-common/mcp_auth_test.go
@@ -34,6 +34,23 @@ func signTestToken(t *testing.T, privatePEM []byte, claims MCPTokenClaims) strin
 	return token
 }
 
+func TestDesktopMCPConventions(t *testing.T) {
+	if got := DesktopMCPPublicKeyPath(); got != "/etc/erun/mcp-auth/desktopid.pub" {
+		t.Fatalf("DesktopMCPPublicKeyPath() = %q", got)
+	}
+	if got := DesktopMCPIssuer(); got != "file:///etc/erun/mcp-auth/desktopid.pub" {
+		t.Fatalf("DesktopMCPIssuer() = %q", got)
+	}
+	if got := MCPTokenAudience(" acme ", " prod "); got != "erun-mcp:acme/prod" {
+		t.Fatalf("MCPTokenAudience() = %q", got)
+	}
+	// The per-env audience distinguishes environments of the same tenant, so a
+	// token minted for one env cannot satisfy another's expected audience.
+	if MCPTokenAudience("acme", "prod") == MCPTokenAudience("acme", "dev") {
+		t.Fatal("expected distinct per-env audiences")
+	}
+}
+
 func TestMCPTokenSignVerifyRoundTrip(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
 	priv, issuer := writeTrustedPublicKey(t)

--- a/erun-common/mcp_auth_test.go
+++ b/erun-common/mcp_auth_test.go
@@ -1,0 +1,128 @@
+package eruncommon
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeTrustedPublicKey writes a generated public key to a temp file and returns
+// the key pair PEMs plus the file:// issuer the MCP server would trust.
+func writeTrustedPublicKey(t *testing.T) (privatePEM []byte, issuer string) {
+	t.Helper()
+	priv, pub, err := GenerateDesktopIdentity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "desktopid.pub")
+	if err := os.WriteFile(path, pub, 0o600); err != nil {
+		t.Fatalf("write public key: %v", err)
+	}
+	return priv, FileIssuer(path)
+}
+
+func signTestToken(t *testing.T, privatePEM []byte, claims MCPTokenClaims) string {
+	t.Helper()
+	token, err := SignMCPToken(privatePEM, claims)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return token
+}
+
+func TestMCPTokenSignVerifyRoundTrip(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	priv, issuer := writeTrustedPublicKey(t)
+	token := signTestToken(t, priv, MCPTokenClaims{
+		Issuer:    issuer,
+		Subject:   "desktop",
+		Audience:  "erun-mcp",
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(time.Hour).Unix(),
+	})
+
+	claims, err := VerifyMCPToken(token, issuer, "erun-mcp", now)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if claims.Subject != "desktop" || claims.Issuer != issuer {
+		t.Fatalf("claims = %+v", claims)
+	}
+}
+
+func TestMCPTokenVerifyRejections(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	priv, issuer := writeTrustedPublicKey(t)
+	good := MCPTokenClaims{Issuer: issuer, Audience: "erun-mcp", ExpiresAt: now.Add(time.Hour).Unix()}
+
+	t.Run("tampered signature", func(t *testing.T) {
+		token := signTestToken(t, priv, good)
+		segments := strings.Split(token, ".")
+		// Decode → flip a byte → re-encode so the signature is deterministically
+		// different (flipping a base64url char alone can change only padding bits).
+		sig, err := base64.RawURLEncoding.DecodeString(segments[2])
+		if err != nil {
+			t.Fatalf("decode signature: %v", err)
+		}
+		sig[0] ^= 0xFF
+		segments[2] = base64.RawURLEncoding.EncodeToString(sig)
+		if _, err := VerifyMCPToken(strings.Join(segments, "."), issuer, "erun-mcp", now); err == nil {
+			t.Fatal("expected a tampered signature to be rejected")
+		}
+	})
+
+	t.Run("wrong signing key", func(t *testing.T) {
+		// Trusted issuer holds identity A's public key; sign with identity B.
+		otherPriv, _, err := GenerateDesktopIdentity()
+		if err != nil {
+			t.Fatalf("generate other identity: %v", err)
+		}
+		token := signTestToken(t, otherPriv, good)
+		if _, err := VerifyMCPToken(token, issuer, "erun-mcp", now); err == nil {
+			t.Fatal("expected a token signed by a different key to be rejected")
+		}
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		token := signTestToken(t, priv, MCPTokenClaims{Issuer: issuer, ExpiresAt: now.Add(-time.Minute).Unix()})
+		if _, err := VerifyMCPToken(token, issuer, "", now); err == nil {
+			t.Fatal("expected an expired token to be rejected")
+		}
+	})
+
+	t.Run("issuer not the trusted issuer", func(t *testing.T) {
+		token := signTestToken(t, priv, MCPTokenClaims{Issuer: "file:///some/other/key.pub", ExpiresAt: now.Add(time.Hour).Unix()})
+		if _, err := VerifyMCPToken(token, issuer, "", now); err == nil {
+			t.Fatal("expected a token whose issuer differs from the trusted issuer to be rejected")
+		}
+	})
+
+	t.Run("wrong audience", func(t *testing.T) {
+		token := signTestToken(t, priv, good)
+		if _, err := VerifyMCPToken(token, issuer, "some-other-audience", now); err == nil {
+			t.Fatal("expected an audience mismatch to be rejected")
+		}
+	})
+
+	t.Run("alg confusion rejected", func(t *testing.T) {
+		// Forge a token with alg=none and an empty signature: a verifier that
+		// honoured the header's alg would accept it. Ours must not.
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+		payload, _ := json.Marshal(good)
+		forged := header + "." + base64.RawURLEncoding.EncodeToString(payload) + "."
+		if _, err := VerifyMCPToken(forged, issuer, "", now); err == nil {
+			t.Fatal("expected an alg=none token to be rejected")
+		}
+	})
+
+	t.Run("no trusted issuer configured", func(t *testing.T) {
+		token := signTestToken(t, priv, good)
+		if _, err := VerifyMCPToken(token, "", "", now); err == nil {
+			t.Fatal("expected verification with no trusted issuer to fail closed")
+		}
+	})
+}

--- a/erun-common/mcp_auth_test.go
+++ b/erun-common/mcp_auth_test.go
@@ -34,6 +34,23 @@ func signTestToken(t *testing.T, privatePEM []byte, claims MCPTokenClaims) strin
 	return token
 }
 
+func TestDesktopPublicKeyPEMMatchesGenerated(t *testing.T) {
+	priv, pub, err := GenerateDesktopIdentity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+	derived, err := DesktopPublicKeyPEM(priv)
+	if err != nil {
+		t.Fatalf("derive public key: %v", err)
+	}
+	if string(derived) != string(pub) {
+		t.Fatalf("derived public key does not match generated:\n got %q\nwant %q", derived, pub)
+	}
+	if _, err := DesktopPublicKeyPEM([]byte("not a pem")); err == nil {
+		t.Fatal("expected error deriving public key from invalid private PEM")
+	}
+}
+
 func TestDesktopMCPConventions(t *testing.T) {
 	if got := DesktopMCPPublicKeyPath(); got != "/etc/erun/mcp-auth/desktopid.pub" {
 		t.Fatalf("DesktopMCPPublicKeyPath() = %q", got)

--- a/erun-devops/k8s/erun-devops/templates/service.yaml
+++ b/erun-devops/k8s/erun-devops/templates/service.yaml
@@ -68,6 +68,19 @@ emitted; type is the single source of truth.
 {{- $cloudflareEnabled := default false $cloudflare.enabled -}}
 {{- $cloudflareAccountId := default "" $cloudflare.accountId -}}
 {{- $cloudflareSecretName := default "" $cloudflare.secretName -}}
+{{- /* MCP auth edge (#655): when enabled, mount the desktop public key and
+       configure the per-env MCP server to require a bearer token signed by it.
+       Absent/disabled renders byte-for-byte unchanged (legacy loopback-only). */ -}}
+{{- $mcpAuth := default dict .Values.mcpAuth -}}
+{{- $mcpAuthEnabled := default false $mcpAuth.enabled -}}
+{{- $mcpAuthSecretName := default "" $mcpAuth.secretName -}}
+{{- $mcpAuthIssuer := default "" $mcpAuth.issuer -}}
+{{- $mcpAuthAudience := default "" $mcpAuth.audience -}}
+{{- /* Fixed in-pod convention: must equal eruncommon.DesktopMCPPublicKeyPath
+       (/etc/erun/mcp-auth/desktopid.pub), which the desktop's file:// issuer
+       references and the MCP server loads the trusted key from. */ -}}
+{{- $mcpAuthMountDir := "/etc/erun/mcp-auth" -}}
+{{- $mcpAuthKeyFile := "desktopid.pub" -}}
 {{- $claude := default dict .Values.claude -}}
 {{- $claudeUseBedrock := default "0" $claude.useBedrock -}}
 {{- $claudeUseMantle := default "0" $claude.useMantle -}}
@@ -482,6 +495,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if $mcpAuthEnabled }}
+            - name: ERUN_MCP_TRUSTED_ISSUER
+              value: {{ $mcpAuthIssuer | quote }}
+            - name: ERUN_MCP_AUDIENCE
+              value: {{ $mcpAuthAudience | quote }}
+            {{- end }}
           ports:
             - containerPort: {{ $mcpPort }}
               name: mcp
@@ -494,6 +513,11 @@ spec:
             {{- end }}
             - name: docker-socket
               mountPath: /var/run
+            {{- if $mcpAuthEnabled }}
+            - name: mcp-auth
+              mountPath: {{ $mcpAuthMountDir | quote }}
+              readOnly: true
+            {{- end }}
         - image: {{ $dindImage }}
           name: erun-dind
           imagePullPolicy: IfNotPresent
@@ -539,6 +563,14 @@ spec:
         {{- end }}
         - name: docker-socket
           emptyDir: {}
+        {{- if $mcpAuthEnabled }}
+        - name: mcp-auth
+          secret:
+            secretName: {{ $mcpAuthSecretName | quote }}
+            items:
+              - key: {{ $mcpAuthKeyFile | quote }}
+                path: {{ $mcpAuthKeyFile | quote }}
+        {{- end }}
         - name: docker-state
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-docker

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -61,6 +61,20 @@ For every authenticated request:
 
 **Audit.** Each authorized API request records `external_issuer_id` (the `iss`), `external_org_id` (the org claim value for org-scoped issuers; null for single-tenant), `external_user_id` (the `sub`), and the resolved `erun_user_id` — see [the audit log spec](/agent-reference/audit-log).
 
+### Per-env MCP edge authentication {#mcp-edge}
+
+The per-environment `erun-mcp` server is exposed publicly (Traefik routes it at `mcp.<tenant>-<env>.services.<base-domain>`) and its `raw` tool can `kubectl exec`, so it is RCE-sensitive and **must always be authenticated** once a trust anchor is configured. The edge resolves the tenant from the verified token's issuer — the same `(iss) → tenant` model as the REST API, applied per URL.
+
+The runtime chart configures each edge with a set of trusted issuers mapping each issuer to the tenant it authenticates (`ERUN_MCP_TRUSTED_ISSUERS`, a JSON `{"<issuer>":"<tenant>"}` object; `ERUN_MCP_TRUSTED_ISSUER` + `ERUN_TENANT` is single-issuer sugar). A request is authorized when:
+
+1. `Authorization: Bearer <jwt>` is present — missing → `401`.
+2. The token's `iss` is a trusted issuer for this edge — untrusted → `401`; the mapped value is the resolved tenant.
+3. The signature verifies against that issuer's key, and `exp` and the audience (`aud`) match. **Unlike the REST API, the MCP edge enforces `aud`** — the per-env audience (`erun-mcp:<tenant>/<environment>`) means a token minted for one environment cannot be replayed against another, or against the REST API.
+
+**Desktop deployments** (issue #655) use a self-contained local trust anchor instead of an OIDC IdP: the desktop generates an Ed25519 key (`desktopid.key`) once, signs an EdDSA JWT whose `iss` is a `file://<path>` URL naming the public key, and injects that public key into the runtime pod on deploy (`erun deploy --mcp-auth-public-key`). The edge loads the key from that `file://` path and verifies the signature against it; `alg` is hard-locked to `EdDSA` for `file://` issuers, closing the alg-confusion class. When no trust anchor is configured the edge stays loopback-only (legacy, unauthenticated) — a desktop deploy always configures one.
+
+Trusting hosted **OIDC issuers** (the platform's Zitadel, AWS) at the same edge — JWKS verification, multiple issuers per edge — is `(Planned.)` (issue #656); per-tool authorization of the edge's RCE-capable tools is `(Planned.)` (issue #657).
+
 ### Endpoints
 
 :::note Shipped vs planned

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -50,6 +50,26 @@ func TestDeploy(t *testing.T) {
 		golden.Equal(t, "deploy/dry_run_from_devops_cwd", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_with_mcp_auth_public_key", func(t *testing.T) {
+		// --mcp-auth-public-key makes the runtime deploy require the per-env MCP
+		// edge to authenticate bearer tokens signed by the desktop public key:
+		// the key is applied out-of-band as a <release>-mcp-auth Secret and the
+		// file:// issuer + per-env audience ride as mcpAuth.* helm values on the
+		// runtime (team-devops) chart only (#655).
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		keyPath := filepath.Join(t.TempDir(), "desktopid.pub")
+		if err := os.WriteFile(keyPath, []byte("-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAtestkeytestkeytestkeytestkeytestkeytestke=\n-----END PUBLIC KEY-----\n"), 0o600); err != nil {
+			t.Fatalf("write public key fixture: %v", err)
+		}
+		result := erun.Run(t, []string{"deploy", "team", "dev", "--version", "1.0.0", "--mcp-auth-public-key", keyPath, "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "deploy/dry_run_with_mcp_auth_public_key", normalize.Apply(result.Combined))
+	})
+
 	t.Run("dry_run_copies_images_from_to_before_deploy", func(t *testing.T) {
 		// When the project registry list marks a FROM source and a TO
 		// destination, deploy mirrors every image the cluster pulls (the

--- a/erun-integration/testdata/deploy/dry_run_with_mcp_auth_public_key.txt
+++ b/erun-integration/testdata/deploy/dry_run_with_mcp_auth_public_key.txt
@@ -1,0 +1,13 @@
+audit: erun deploy --dry-run --mcp-auth-public-key <TMP> --version <VERSION> team dev
+trace-log: would append the full trace to <TMP>
+deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
+deploy: version <VERSION> pinned; installing the published image by reference (deploy never builds)
+deploy: resolved 1 spec(s)
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+apply mcp auth public key secret team-devops-mcp-auth
+kubectl --context test-context -n team-dev apply -f -
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --timeout 5m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set-string api.oidcAllowedIssuers= --set api.postgres.reset=true --set mcpAuth.enabled=true --set-string mcpAuth.secretName=team-devops-mcp-auth --set-string mcpAuth.issuer=file:///etc/erun/mcp-auth/desktopid.pub --set-string mcpAuth.audience=erun-mcp:team/dev --set-json 'containerRegistries=[{"registry":"registry.example/test","roles":["build","deploy"]}]' --set disableBuildScript=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)

--- a/erun-integration/testdata/deploy/help_outside_devops_cwd.txt
+++ b/erun-integration/testdata/deploy/help_outside_devops_cwd.txt
@@ -13,15 +13,16 @@ Examples:
   erun deploy team prod --version <VERSION> --rollout-timeout 10m
 
 Flags:
-      --components strings       Opt-in components to include alongside the runtime chart (erun-backend-postgres, erun-backend-db, erun-backend-api, erun-powerdns)
-      --current                  Redeploy the version this environment already runs (its persisted runtime version) instead of passing --version
-      --dry-run                  Resolve and trace mutating actions without executing them.
-      --environment string       Deploy for a specific environment; requires --tenant
-      --force                    Re-run the helm upgrade even when the deployed release already matches the requested version
-  -h, --help                     help for deploy
-      --rollout-timeout string   Override the helm rollout wait for this deploy (Go duration, e.g. 8m); empty uses the env's deploy.timeout or the 5m default
-      --tenant string            Deploy for a specific tenant
-      --version erun build       Version to install by reference (produced by erun build/`erun push`); fails if that version's image is absent
+      --components strings           Opt-in components to include alongside the runtime chart (erun-backend-postgres, erun-backend-db, erun-backend-api, erun-powerdns)
+      --current                      Redeploy the version this environment already runs (its persisted runtime version) instead of passing --version
+      --dry-run                      Resolve and trace mutating actions without executing them.
+      --environment string           Deploy for a specific environment; requires --tenant
+      --force                        Re-run the helm upgrade even when the deployed release already matches the requested version
+  -h, --help                         help for deploy
+      --mcp-auth-public-key string   Require the env's MCP edge to authenticate bearer tokens signed by this PEM public key (issue #655); empty leaves the edge loopback-only
+      --rollout-timeout string       Override the helm rollout wait for this deploy (Go duration, e.g. 8m); empty uses the env's deploy.timeout or the 5m default
+      --tenant string                Deploy for a specific tenant
+      --version erun build           Version to install by reference (produced by erun build/`erun push`); fails if that version's image is absent
 
 Global Flags:
       --output string   Result format: text (default, human stream) or json (structured result on stdout for orchestrators). (default "text")

--- a/erun-integration/testdata/devops/k8s_deploy_help.txt
+++ b/erun-integration/testdata/devops/k8s_deploy_help.txt
@@ -4,13 +4,14 @@ Usage:
   erun devops k8s deploy COMPONENT [flags]
 
 Flags:
-      --dry-run                  Resolve and trace mutating actions without executing them.
-      --environment string       Deploy for a specific environment; requires --tenant
-      --force                    Re-run the helm upgrade even when the deployed release already matches the requested version
-  -h, --help                     help for deploy
-      --rollout-timeout string   Override the helm rollout wait for this deploy (Go duration, e.g. 8m); empty uses the env's deploy.timeout or the 5m default
-      --tenant string            Deploy for a specific tenant
-      --version erun build       Version to install by reference (produced by erun build/`erun push`); fails if that version's image is absent
+      --dry-run                      Resolve and trace mutating actions without executing them.
+      --environment string           Deploy for a specific environment; requires --tenant
+      --force                        Re-run the helm upgrade even when the deployed release already matches the requested version
+  -h, --help                         help for deploy
+      --mcp-auth-public-key string   Require the env's MCP edge to authenticate bearer tokens signed by this PEM public key (issue #655); empty leaves the edge loopback-only
+      --rollout-timeout string       Override the helm rollout wait for this deploy (Go duration, e.g. 8m); empty uses the env's deploy.timeout or the 5m default
+      --tenant string                Deploy for a specific tenant
+      --version erun build           Version to install by reference (produced by erun build/`erun push`); fails if that version's image is absent
 
 Global Flags:
       --output string   Result format: text (default, human stream) or json (structured result on stdout for orchestrators). (default "text")

--- a/erun-mcp/auth.go
+++ b/erun-mcp/auth.go
@@ -1,6 +1,8 @@
 package erunmcp
 
 import (
+	"encoding/json"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -12,42 +14,79 @@ import (
 // MCP auth edge (issue #655). The per-env erun-mcp server is exposed publicly
 // (Traefik routes it at mcp.<tenant>-<env>.services.<base-domain>) and its `raw`
 // tool can kubectl-exec, so it must always be authenticated once a trust anchor
-// is configured. authHTTPMiddleware verifies a bearer JWT against a trusted
-// file:// issuer (the desktop's injected public key); the verification itself
-// lives in erun-common so the desktop signer and this verifier share one
-// contract.
+// is configured.
+//
+// Auth mirrors the erun api's model (erun-backend-api): a key/value map of
+// trusted issuer → tenant. A bearer token is accepted only when its verified
+// `iss` is a configured trusted issuer; the mapped value is the tenant the
+// token authenticates, so the tenant is identified per URL exactly as the api
+// resolves it from the issuer. An issuer is either a `file://<path>` desktop
+// public key (verified by erun-common's Ed25519 verifier) — the desktop case —
+// or, later, an OIDC issuer URL. The crypto verification lives in erun-common
+// so the desktop signer and this verifier share one contract.
 const (
-	// envMCPTrustedIssuer names the file://<path> issuer whose public key the
-	// server loads to verify bearer tokens. When set, auth is REQUIRED.
+	// envMCPTrustedIssuers is a JSON object mapping each trusted issuer to the
+	// tenant it authenticates: {"file:///etc/erun/mcp-auth/desktopid.pub":"acme"}.
+	envMCPTrustedIssuers = "ERUN_MCP_TRUSTED_ISSUERS"
+	// envMCPTrustedIssuer is single-issuer sugar: the one trusted issuer, mapped
+	// to the env's own tenant (ERUN_TENANT). Convenient for the common
+	// one-tenant-per-server case; ERUN_MCP_TRUSTED_ISSUERS wins when both are set.
 	envMCPTrustedIssuer = "ERUN_MCP_TRUSTED_ISSUER"
 	// envMCPAudience optionally pins the expected token audience.
 	envMCPAudience = "ERUN_MCP_AUDIENCE"
+	// envTenant is the env's own tenant, used as the value for the single-issuer
+	// sugar form.
+	envTenant = "ERUN_TENANT"
 )
 
 type mcpAuthConfig struct {
-	trustedIssuer string
-	audience      string
+	// trustedIssuers maps each trusted token issuer (the key — a file:// public
+	// key path or an OIDC issuer URL) to the tenant it authenticates (the value),
+	// mirroring the erun api's issuer→tenant model. A token is accepted only when
+	// its verified iss is a key here; the value is the resolved tenant.
+	trustedIssuers map[string]string
+	audience       string
 }
 
 // mcpAuthConfigFromEnv reads the auth configuration the chart wires onto the
-// erun-mcp container. An empty trusted issuer means no auth is configured —
-// the legacy loopback-only behavior — so existing deployments that have not yet
-// injected a desktop key keep working; a desktop deployment always sets it, so
-// its MCP edge is always authenticated.
+// erun-mcp container. An empty map means no auth is configured — the legacy
+// loopback-only behavior — so existing deployments that have not yet injected a
+// desktop key keep working; a desktop deployment always sets it, so its MCP
+// edge is always authenticated.
 func mcpAuthConfigFromEnv() mcpAuthConfig {
-	return mcpAuthConfig{
-		trustedIssuer: strings.TrimSpace(os.Getenv(envMCPTrustedIssuer)),
-		audience:      strings.TrimSpace(os.Getenv(envMCPAudience)),
+	cfg := mcpAuthConfig{
+		trustedIssuers: map[string]string{},
+		audience:       strings.TrimSpace(os.Getenv(envMCPAudience)),
 	}
+	if raw := strings.TrimSpace(os.Getenv(envMCPTrustedIssuers)); raw != "" {
+		parsed := map[string]string{}
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			log.Printf("erun-mcp auth: ignoring malformed %s: %v", envMCPTrustedIssuers, err)
+		} else {
+			for issuer, tenant := range parsed {
+				if issuer = strings.TrimSpace(issuer); issuer != "" {
+					cfg.trustedIssuers[issuer] = strings.TrimSpace(tenant)
+				}
+			}
+		}
+	}
+	// Single-issuer sugar: maps the one trusted issuer to the env's own tenant.
+	if single := strings.TrimSpace(os.Getenv(envMCPTrustedIssuer)); single != "" {
+		if _, ok := cfg.trustedIssuers[single]; !ok {
+			cfg.trustedIssuers[single] = strings.TrimSpace(os.Getenv(envTenant))
+		}
+	}
+	return cfg
 }
 
 func (c mcpAuthConfig) enabled() bool {
-	return c.trustedIssuer != ""
+	return len(c.trustedIssuers) > 0
 }
 
 // authHTTPMiddleware rejects unauthenticated requests with 401 when auth is
-// configured, verifying the bearer JWT against the trusted file:// issuer's
-// public key. When auth is not configured it passes through unchanged.
+// configured. It reads the (unverified) issuer to select the trusted entry,
+// verifies the bearer JWT against that issuer's key, and resolves the tenant
+// from the map. When auth is not configured it passes through unchanged.
 func authHTTPMiddleware(cfg mcpAuthConfig, next http.Handler) http.Handler {
 	if !cfg.enabled() {
 		return next
@@ -58,12 +97,36 @@ func authHTTPMiddleware(cfg mcpAuthConfig, next http.Handler) http.Handler {
 			writeUnauthorized(w, "a bearer token is required")
 			return
 		}
-		if _, err := eruncommon.VerifyMCPToken(token, cfg.trustedIssuer, cfg.audience, time.Now()); err != nil {
+		issuer, err := eruncommon.UnverifiedMCPTokenIssuer(token)
+		if err != nil {
 			writeUnauthorized(w, err.Error())
 			return
 		}
-		next.ServeHTTP(w, req)
+		tenant, trusted := cfg.trustedIssuers[issuer]
+		if !trusted {
+			writeUnauthorized(w, "token issuer is not a trusted MCP issuer")
+			return
+		}
+		if _, err := eruncommon.VerifyMCPToken(token, issuer, cfg.audience, time.Now()); err != nil {
+			writeUnauthorized(w, err.Error())
+			return
+		}
+		// Tenant identified per URL from the issuer→tenant map (mirrors the erun
+		// api). Carry it on the request so tools/audit can read the authenticated
+		// tenant.
+		next.ServeHTTP(w, requestWithAuthTenant(req, tenant))
 	})
+}
+
+// authTenantHeader carries the tenant the auth edge resolved for the request.
+const authTenantHeader = "X-Erun-Auth-Tenant"
+
+func requestWithAuthTenant(req *http.Request, tenant string) *http.Request {
+	if tenant == "" {
+		return req
+	}
+	req.Header.Set(authTenantHeader, tenant)
+	return req
 }
 
 // bearerToken extracts the token from an `Authorization: Bearer <token>` header

--- a/erun-mcp/auth.go
+++ b/erun-mcp/auth.go
@@ -1,0 +1,83 @@
+package erunmcp
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// MCP auth edge (issue #655). The per-env erun-mcp server is exposed publicly
+// (Traefik routes it at mcp.<tenant>-<env>.services.<base-domain>) and its `raw`
+// tool can kubectl-exec, so it must always be authenticated once a trust anchor
+// is configured. authHTTPMiddleware verifies a bearer JWT against a trusted
+// file:// issuer (the desktop's injected public key); the verification itself
+// lives in erun-common so the desktop signer and this verifier share one
+// contract.
+const (
+	// envMCPTrustedIssuer names the file://<path> issuer whose public key the
+	// server loads to verify bearer tokens. When set, auth is REQUIRED.
+	envMCPTrustedIssuer = "ERUN_MCP_TRUSTED_ISSUER"
+	// envMCPAudience optionally pins the expected token audience.
+	envMCPAudience = "ERUN_MCP_AUDIENCE"
+)
+
+type mcpAuthConfig struct {
+	trustedIssuer string
+	audience      string
+}
+
+// mcpAuthConfigFromEnv reads the auth configuration the chart wires onto the
+// erun-mcp container. An empty trusted issuer means no auth is configured —
+// the legacy loopback-only behavior — so existing deployments that have not yet
+// injected a desktop key keep working; a desktop deployment always sets it, so
+// its MCP edge is always authenticated.
+func mcpAuthConfigFromEnv() mcpAuthConfig {
+	return mcpAuthConfig{
+		trustedIssuer: strings.TrimSpace(os.Getenv(envMCPTrustedIssuer)),
+		audience:      strings.TrimSpace(os.Getenv(envMCPAudience)),
+	}
+}
+
+func (c mcpAuthConfig) enabled() bool {
+	return c.trustedIssuer != ""
+}
+
+// authHTTPMiddleware rejects unauthenticated requests with 401 when auth is
+// configured, verifying the bearer JWT against the trusted file:// issuer's
+// public key. When auth is not configured it passes through unchanged.
+func authHTTPMiddleware(cfg mcpAuthConfig, next http.Handler) http.Handler {
+	if !cfg.enabled() {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		token := bearerToken(req)
+		if token == "" {
+			writeUnauthorized(w, "a bearer token is required")
+			return
+		}
+		if _, err := eruncommon.VerifyMCPToken(token, cfg.trustedIssuer, cfg.audience, time.Now()); err != nil {
+			writeUnauthorized(w, err.Error())
+			return
+		}
+		next.ServeHTTP(w, req)
+	})
+}
+
+// bearerToken extracts the token from an `Authorization: Bearer <token>` header
+// (the scheme match is case-insensitive per RFC 7235).
+func bearerToken(req *http.Request) string {
+	header := strings.TrimSpace(req.Header.Get("Authorization"))
+	const prefix = "bearer "
+	if len(header) < len(prefix) || !strings.EqualFold(header[:len(prefix)], prefix) {
+		return ""
+	}
+	return strings.TrimSpace(header[len(prefix):])
+}
+
+func writeUnauthorized(w http.ResponseWriter, reason string) {
+	w.Header().Set("WWW-Authenticate", "Bearer")
+	http.Error(w, "unauthorized: "+reason, http.StatusUnauthorized)
+}

--- a/erun-mcp/auth_test.go
+++ b/erun-mcp/auth_test.go
@@ -1,0 +1,85 @@
+package erunmcp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// okHandler is a stub the auth middleware wraps; reaching it means the request
+// was authorized.
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func trustedIssuerWithToken(t *testing.T) (issuer, token string) {
+	t.Helper()
+	priv, pub, err := eruncommon.GenerateDesktopIdentity()
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "desktopid.pub")
+	if err := os.WriteFile(path, pub, 0o600); err != nil {
+		t.Fatalf("write public key: %v", err)
+	}
+	issuer = eruncommon.FileIssuer(path)
+	token, err = eruncommon.SignMCPToken(priv, eruncommon.MCPTokenClaims{
+		Issuer:    issuer,
+		Audience:  "erun-mcp",
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return issuer, token
+}
+
+func TestAuthMiddleware(t *testing.T) {
+	issuer, token := trustedIssuerWithToken(t)
+	authed := mcpAuthConfig{trustedIssuer: issuer, audience: "erun-mcp"}
+
+	cases := []struct {
+		name       string
+		cfg        mcpAuthConfig
+		authHeader string
+		wantStatus int
+	}{
+		{name: "no auth configured passes through", cfg: mcpAuthConfig{}, authHeader: "", wantStatus: http.StatusOK},
+		{name: "configured but no token is rejected", cfg: authed, authHeader: "", wantStatus: http.StatusUnauthorized},
+		{name: "valid bearer is authorized", cfg: authed, authHeader: "Bearer " + token, wantStatus: http.StatusOK},
+		{name: "garbage bearer is rejected", cfg: authed, authHeader: "Bearer not-a-jwt", wantStatus: http.StatusUnauthorized},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			rec := httptest.NewRecorder()
+			authHTTPMiddleware(tc.cfg, okHandler()).ServeHTTP(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body %q)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestMCPAuthConfigFromEnv(t *testing.T) {
+	t.Setenv(envMCPTrustedIssuer, "file:///etc/erun/mcp-auth/desktopid.pub")
+	t.Setenv(envMCPAudience, "erun-mcp")
+	cfg := mcpAuthConfigFromEnv()
+	if !cfg.enabled() || cfg.trustedIssuer != "file:///etc/erun/mcp-auth/desktopid.pub" || cfg.audience != "erun-mcp" {
+		t.Fatalf("cfg = %+v", cfg)
+	}
+	t.Setenv(envMCPTrustedIssuer, "")
+	if mcpAuthConfigFromEnv().enabled() {
+		t.Fatal("expected auth disabled when no trusted issuer is set")
+	}
+}

--- a/erun-mcp/auth_test.go
+++ b/erun-mcp/auth_test.go
@@ -11,15 +11,19 @@ import (
 	eruncommon "github.com/sophium/erun/erun-common"
 )
 
-// okHandler is a stub the auth middleware wraps; reaching it means the request
-// was authorized.
-func okHandler() http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+// tenantEchoHandler is a stub the auth middleware wraps; reaching it means the
+// request was authorized, and it echoes the resolved auth tenant so a test can
+// assert per-URL tenant identification.
+func tenantEchoHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(r.Header.Get(authTenantHeader)))
 	})
 }
 
-func trustedIssuerWithToken(t *testing.T) (issuer, token string) {
+// identityWithToken generates an Ed25519 identity, writes its public key to a
+// temp file, and returns the file:// issuer plus a signed bearer token.
+func identityWithToken(t *testing.T) (issuer, token string) {
 	t.Helper()
 	priv, pub, err := eruncommon.GenerateDesktopIdentity()
 	if err != nil {
@@ -42,19 +46,24 @@ func trustedIssuerWithToken(t *testing.T) (issuer, token string) {
 }
 
 func TestAuthMiddleware(t *testing.T) {
-	issuer, token := trustedIssuerWithToken(t)
-	authed := mcpAuthConfig{trustedIssuer: issuer, audience: "erun-mcp"}
+	issuer, token := identityWithToken(t)
+	// A second, untrusted identity: validly signed by its own key, but its issuer
+	// is not in the trusted map, so it must still be rejected.
+	_, otherToken := identityWithToken(t)
+	authed := mcpAuthConfig{trustedIssuers: map[string]string{issuer: "acme"}, audience: "erun-mcp"}
 
 	cases := []struct {
 		name       string
 		cfg        mcpAuthConfig
 		authHeader string
 		wantStatus int
+		wantTenant string
 	}{
-		{name: "no auth configured passes through", cfg: mcpAuthConfig{}, authHeader: "", wantStatus: http.StatusOK},
-		{name: "configured but no token is rejected", cfg: authed, authHeader: "", wantStatus: http.StatusUnauthorized},
-		{name: "valid bearer is authorized", cfg: authed, authHeader: "Bearer " + token, wantStatus: http.StatusOK},
+		{name: "no auth configured passes through", cfg: mcpAuthConfig{}, wantStatus: http.StatusOK},
+		{name: "configured but no token is rejected", cfg: authed, wantStatus: http.StatusUnauthorized},
+		{name: "valid bearer is authorized and resolves the tenant", cfg: authed, authHeader: "Bearer " + token, wantStatus: http.StatusOK, wantTenant: "acme"},
 		{name: "garbage bearer is rejected", cfg: authed, authHeader: "Bearer not-a-jwt", wantStatus: http.StatusUnauthorized},
+		{name: "untrusted issuer is rejected", cfg: authed, authHeader: "Bearer " + otherToken, wantStatus: http.StatusUnauthorized},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -63,23 +72,68 @@ func TestAuthMiddleware(t *testing.T) {
 				req.Header.Set("Authorization", tc.authHeader)
 			}
 			rec := httptest.NewRecorder()
-			authHTTPMiddleware(tc.cfg, okHandler()).ServeHTTP(rec, req)
+			authHTTPMiddleware(tc.cfg, tenantEchoHandler()).ServeHTTP(rec, req)
 			if rec.Code != tc.wantStatus {
 				t.Fatalf("status = %d, want %d (body %q)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if tc.wantStatus == http.StatusOK && tc.wantTenant != "" && rec.Body.String() != tc.wantTenant {
+				t.Fatalf("resolved tenant = %q, want %q", rec.Body.String(), tc.wantTenant)
 			}
 		})
 	}
 }
 
+// TestAuthMiddlewareMultiTenant locks the key/value model: two issuers map to
+// two tenants, and a token from one issuer resolves that issuer's tenant.
+func TestAuthMiddlewareMultiTenant(t *testing.T) {
+	issuerA, tokenA := identityWithToken(t)
+	issuerB, tokenB := identityWithToken(t)
+	cfg := mcpAuthConfig{
+		trustedIssuers: map[string]string{issuerA: "acme", issuerB: "beta"},
+		audience:       "erun-mcp",
+	}
+	for _, tc := range []struct{ token, wantTenant string }{
+		{tokenA, "acme"},
+		{tokenB, "beta"},
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer "+tc.token)
+		rec := httptest.NewRecorder()
+		authHTTPMiddleware(cfg, tenantEchoHandler()).ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK || rec.Body.String() != tc.wantTenant {
+			t.Fatalf("status=%d tenant=%q, want 200 / %q", rec.Code, rec.Body.String(), tc.wantTenant)
+		}
+	}
+}
+
 func TestMCPAuthConfigFromEnv(t *testing.T) {
-	t.Setenv(envMCPTrustedIssuer, "file:///etc/erun/mcp-auth/desktopid.pub")
-	t.Setenv(envMCPAudience, "erun-mcp")
-	cfg := mcpAuthConfigFromEnv()
-	if !cfg.enabled() || cfg.trustedIssuer != "file:///etc/erun/mcp-auth/desktopid.pub" || cfg.audience != "erun-mcp" {
-		t.Fatalf("cfg = %+v", cfg)
-	}
-	t.Setenv(envMCPTrustedIssuer, "")
-	if mcpAuthConfigFromEnv().enabled() {
-		t.Fatal("expected auth disabled when no trusted issuer is set")
-	}
+	t.Run("key/value map", func(t *testing.T) {
+		t.Setenv(envMCPTrustedIssuers, `{"file:///etc/erun/mcp-auth/a.pub":"acme","https://idp.example":"beta"}`)
+		t.Setenv(envMCPAudience, "erun-mcp")
+		cfg := mcpAuthConfigFromEnv()
+		if !cfg.enabled() || cfg.trustedIssuers["file:///etc/erun/mcp-auth/a.pub"] != "acme" || cfg.trustedIssuers["https://idp.example"] != "beta" {
+			t.Fatalf("cfg = %+v", cfg)
+		}
+		if cfg.audience != "erun-mcp" {
+			t.Fatalf("audience = %q", cfg.audience)
+		}
+	})
+
+	t.Run("single-issuer sugar maps to the env tenant", func(t *testing.T) {
+		t.Setenv(envMCPTrustedIssuers, "")
+		t.Setenv(envMCPTrustedIssuer, "file:///etc/erun/mcp-auth/desktopid.pub")
+		t.Setenv(envTenant, "acme")
+		cfg := mcpAuthConfigFromEnv()
+		if cfg.trustedIssuers["file:///etc/erun/mcp-auth/desktopid.pub"] != "acme" {
+			t.Fatalf("cfg = %+v", cfg)
+		}
+	})
+
+	t.Run("disabled when nothing configured", func(t *testing.T) {
+		t.Setenv(envMCPTrustedIssuers, "")
+		t.Setenv(envMCPTrustedIssuer, "")
+		if mcpAuthConfigFromEnv().enabled() {
+			t.Fatal("expected auth disabled when no trusted issuer is set")
+		}
+	})
 }

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -65,7 +65,10 @@ func newHTTPHandler(info eruncommon.BuildInfo, cfg HTTPConfig, runtime RuntimeCo
 	})
 
 	mux := http.NewServeMux()
-	mux.Handle(cfg.Path, activityHTTPMiddleware(runtime, handler))
+	// Auth is the outermost edge: when a trusted issuer is configured (#655),
+	// every request on the MCP path — including idle probes — must carry a valid
+	// bearer token signed by the desktop's injected key before any tool runs.
+	mux.Handle(cfg.Path, authHTTPMiddleware(mcpAuthConfigFromEnv(), activityHTTPMiddleware(runtime, handler)))
 	return mux
 }
 

--- a/erun-ui/api_log.go
+++ b/erun-ui/api_log.go
@@ -17,7 +17,7 @@ func loadAPILog(ctx context.Context, input uiTenantDashboardInput) (string, erro
 		return loadAPILogFromKubernetes(ctx, kubernetesContext, tenant, environment)
 	}
 	if mcpURL := strings.TrimSpace(input.MCPURL); mcpURL != "" {
-		return loadAPILogFromMCP(ctx, mcpURL)
+		return loadAPILogFromMCP(ctx, mcpURL, input.mcpBearer)
 	}
 	return "", fmt.Errorf("tenant dashboard needs a Kubernetes context or MCP URL to load API logs")
 }

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log"
 	"sync"
 	"time"
 
@@ -51,32 +52,39 @@ type erunUIDeps struct {
 	reconnectMCP           func(context.Context, eruncommon.OpenResult, func(string)) error
 	ensureSSHD             func(context.Context, eruncommon.OpenResult) error
 	canConnectLocalPort    func(int) bool
-	setRemoteCloudAlias    func(context.Context, string, string, string, string) (eruncommon.EnvConfig, error)
+	setRemoteCloudAlias    func(context.Context, string, string, string, string, string) (eruncommon.EnvConfig, error)
 	startTerminal          func(startTerminalSessionParams) (terminalSession, error)
 	runIDECommand          func(context.Context, startTerminalSessionParams) (string, error)
 	savePastedFile         func(pastedFileSaveParams) (string, error)
 	listAgentOutputs       func(eruncommon.OpenResult, eruncommon.RuntimeOutputsParams) (eruncommon.RuntimeOutputsListResult, error)
 	downloadAgentOutput    func(eruncommon.OpenResult, eruncommon.RuntimeOutputDownloadParams) (eruncommon.RuntimeOutputResult, error)
-	loadDiff               func(context.Context, string, uiDiffOptions) (eruncommon.DiffResult, error)
-	loadIdleStatus         func(context.Context, string) (eruncommon.EnvironmentIdleStatus, error)
+	loadDiff               func(context.Context, string, string, uiDiffOptions) (eruncommon.DiffResult, error)
+	loadIdleStatus         func(context.Context, string, string) (eruncommon.EnvironmentIdleStatus, error)
 	loadAPILog             func(context.Context, uiTenantDashboardInput) (string, error)
 	workspaceSyncReady     func(context.Context, string) error
 	syncWorkspace          func(context.Context, workspaceSyncParams) (workspaceSyncResult, error)
 	workspaceSyncInterval  time.Duration
 	recordActivity         func(eruncommon.EnvironmentActivityParams) error
 	runWorkingIssueCommand workingIssueCommandRunner
-	loadPodBranch          func(context.Context, string) (string, error)
-	runPodRaw              func(context.Context, string, []string) (string, error)
+	loadPodBranch          func(context.Context, string, string) (string, error)
+	runPodRaw              func(context.Context, string, string, []string) (string, error)
 	stopCloudContext       func(context.Context, string) (eruncommon.CloudContextStatus, error)
 	windowStatePath        string
 	windowMaximised        func(context.Context) bool
-	cloneERun              func(context.Context, string) error
+	cloneERun              func(context.Context, string, string) error
 	contributeStatePath    string
 }
 
 type App struct {
 	ctx  context.Context
 	deps erunUIDeps
+
+	// identity is the desktop's persistent signing identity (issue #655). It
+	// mints the short-lived per-env bearer the desktop sends to each env's MCP
+	// edge and supplies the public key deploy injects so the edge verifies
+	// those tokens. nil in unit tests, where mcpBearer returns "" so non-auth
+	// envs and stubbed MCP deps keep working.
+	identity *desktopIdentity
 
 	mu                        sync.Mutex
 	nextSerial                int
@@ -174,7 +182,26 @@ func NewApp(deps erunUIDeps) *App {
 		go app.pollActivityContainerStatuses(context.Background(), entry)
 	}
 	app.contribute = newContributeStore(deps.contributeStatePath)
+	if app.identity == nil {
+		app.identity = newDesktopIdentity(defaultDesktopIdentityDir())
+	}
 	return app
+}
+
+// mcpBearer mints the short-lived per-env bearer the desktop sends to the env's
+// MCP edge (issue #655). A nil identity (unit tests) or a signing failure yields
+// "", so non-auth envs and stubbed MCP deps keep working; an auth-enabled env
+// rejects an empty bearer with 401, which is the correct outcome.
+func (a *App) mcpBearer(tenant, environment string) string {
+	if a.identity == nil {
+		return ""
+	}
+	token, err := a.identity.signToken(tenant, environment, time.Now())
+	if err != nil {
+		log.Printf("erun-app: sign MCP bearer for %s/%s: %v", tenant, environment, err)
+		return ""
+	}
+	return token
 }
 
 func withDefaultCoreDeps(deps erunUIDeps) erunUIDeps {

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -451,7 +451,7 @@ func TestLoadDiffUsesSelectedMCPPort(t *testing.T) {
 			ensureCalls++
 			return nil
 		},
-		loadDiff: func(_ context.Context, endpoint string, options uiDiffOptions) (eruncommon.DiffResult, error) {
+		loadDiff: func(_ context.Context, endpoint, _ string, options uiDiffOptions) (eruncommon.DiffResult, error) {
 			gotEndpoint = endpoint
 			if options.Scope != "commit" || options.SelectedCommit != "abc123" {
 				t.Fatalf("unexpected diff options: %+v", options)
@@ -503,7 +503,7 @@ func TestLoadDiffReturnsUnreachableWhenPortClosed(t *testing.T) {
 			ensureCalls++
 			return nil
 		},
-		loadDiff: func(_ context.Context, _ string, _ uiDiffOptions) (eruncommon.DiffResult, error) {
+		loadDiff: func(_ context.Context, _, _ string, _ uiDiffOptions) (eruncommon.DiffResult, error) {
 			loadCalls++
 			return eruncommon.DiffResult{}, nil
 		},
@@ -548,7 +548,7 @@ func TestLoadDiffWrapsDialFailureAsUnreachable(t *testing.T) {
 			ensureCalls++
 			return nil
 		},
-		loadDiff: func(_ context.Context, _ string, _ uiDiffOptions) (eruncommon.DiffResult, error) {
+		loadDiff: func(_ context.Context, _, _ string, _ uiDiffOptions) (eruncommon.DiffResult, error) {
 			return eruncommon.DiffResult{}, errors.New("EOF")
 		},
 	})
@@ -1058,6 +1058,11 @@ func TestStartDeploySessionPipesCommandToLocal(t *testing.T) {
 			return s, nil
 		},
 	})
+	// No desktop identity: the in-shell deploy stays unauthenticated, so this
+	// test asserts the bare `erun deploy ...` command without the
+	// --mcp-auth-public-key flag (issue #655). The auth-injecting path is
+	// covered by its own test below.
+	app.identity = nil
 	defer app.shutdown(context.Background())
 
 	result, err := app.StartDeploySession(uiSelection{Tenant: " erun ", Environment: " remote ", Version: " 1.0.19 "}, 80, 24)
@@ -1070,6 +1075,55 @@ func TestStartDeploySessionPipesCommandToLocal(t *testing.T) {
 	written := sessions[0].WrittenString()
 	if !strings.Contains(written, "/tmp/erun deploy erun remote --version 1.0.19\n") {
 		t.Fatalf("expected deploy command in Local pty, got %q", written)
+	}
+}
+
+// TestStartDeploySessionInjectsMCPAuthPublicKey covers the auth-injecting half
+// of the deploy path (issue #655): when the desktop has a signing identity, the
+// in-shell `erun deploy` carries `--mcp-auth-public-key <path>` so the deployed
+// env requires the same desktop-signed bearer the desktop sends to its MCP
+// edge. The identity is pinned to a temp dir so the test never touches the
+// developer's real config and the public key lands at a deterministic path.
+func TestStartDeploySessionInjectsMCPAuthPublicKey(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", DefaultEnvironment: "remote"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {Name: "remote", LocalRepoPath: projectRoot, KubernetesContext: "rancher-desktop"},
+		},
+	}
+
+	var sessions []*stubTerminalSession
+	app := NewApp(erunUIDeps{
+		store:           store,
+		findProjectRoot: func() (string, string, error) { return "erun", projectRoot, nil },
+		resolveCLIPath:  func() string { return "/tmp/erun" },
+		startTerminal: func(startTerminalSessionParams) (terminalSession, error) {
+			s := newStubTerminalSession()
+			sessions = append(sessions, s)
+			return s, nil
+		},
+	})
+	identityDir := t.TempDir()
+	app.identity = newDesktopIdentity(identityDir)
+	defer app.shutdown(context.Background())
+
+	if _, err := app.StartDeploySession(uiSelection{Tenant: "erun", Environment: "remote", Version: "1.0.19"}, 80, 24); err != nil {
+		t.Fatalf("StartDeploySession failed: %v", err)
+	}
+	wantPath := filepath.Join(identityDir, desktopIdentityPubFile)
+	written := sessions[0].WrittenString()
+	// The path is shell-quoted by buildLocalErunCommand only when it needs it
+	// (e.g. spaces in the temp dir), so assert against the same quoting helper
+	// rather than a fixed literal.
+	wantFlag := "--mcp-auth-public-key " + shellQuoteIfNeeded(wantPath)
+	if !strings.Contains(written, "deploy erun remote --version 1.0.19 "+wantFlag+"\n") {
+		t.Fatalf("expected deploy command to carry %q, got %q", wantFlag, written)
+	}
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("expected desktop public key written to %q: %v", wantPath, err)
 	}
 }
 
@@ -2440,7 +2494,7 @@ func TestSaveRemoteEnvironmentConfigSetsCloudAliasViaMCP(t *testing.T) {
 	app := NewApp(erunUIDeps{
 		store:               store,
 		canConnectLocalPort: func(int) bool { return true },
-		setRemoteCloudAlias: func(_ context.Context, endpoint, tenant, environment, alias string) (eruncommon.EnvConfig, error) {
+		setRemoteCloudAlias: func(_ context.Context, endpoint, _, tenant, environment, alias string) (eruncommon.EnvConfig, error) {
 			remoteEndpoint = endpoint
 			remoteTenant = tenant
 			remoteEnvironment = environment
@@ -3064,7 +3118,7 @@ func TestLoadIdleStatusDoesNotStopWhileEnvironmentCommandRunning(t *testing.T) {
 			return newStubTerminalSession(), nil
 		},
 		canConnectLocalPort: func(int) bool { return true },
-		loadIdleStatus: func(context.Context, string) (eruncommon.EnvironmentIdleStatus, error) {
+		loadIdleStatus: func(context.Context, string, string) (eruncommon.EnvironmentIdleStatus, error) {
 			return eruncommon.EnvironmentIdleStatus{
 				ManagedCloud: true,
 				StopEligible: true,
@@ -4099,7 +4153,7 @@ func TestMaybeStopIdleClearsStaleIdleStopWhenContextIsRunningAgain(t *testing.T)
 	app := NewApp(erunUIDeps{
 		store:               store,
 		canConnectLocalPort: func(int) bool { return false },
-		loadIdleStatus: func(context.Context, string) (eruncommon.EnvironmentIdleStatus, error) {
+		loadIdleStatus: func(context.Context, string, string) (eruncommon.EnvironmentIdleStatus, error) {
 			return eruncommon.EnvironmentIdleStatus{}, fmt.Errorf("mcp unreachable")
 		},
 		stopCloudContext: func(context.Context, string) (eruncommon.CloudContextStatus, error) {

--- a/erun-ui/cloud_credentials_mcp.go
+++ b/erun-ui/cloud_credentials_mcp.go
@@ -3,21 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func injectCloudHostCredentialsViaMCP(ctx context.Context, endpoint string, accessKeyID, secretAccessKey, sessionToken string, expiration time.Time) error {
+func injectCloudHostCredentialsViaMCP(ctx context.Context, endpoint, bearer string, accessKeyID, secretAccessKey, sessionToken string, expiration time.Time) error {
 	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
-	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint: endpoint,
-		HTTPClient: &http.Client{
-			Transport: idleProbeRoundTripper{},
-		},
-		DisableStandaloneSSE: true,
-	}, nil)
+	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, false), nil)
 	if err != nil {
 		return err
 	}
@@ -43,15 +36,9 @@ func injectCloudHostCredentialsViaMCP(ctx context.Context, endpoint string, acce
 	return nil
 }
 
-func clearCloudHostCredentialsViaMCP(ctx context.Context, endpoint string) error {
+func clearCloudHostCredentialsViaMCP(ctx context.Context, endpoint, bearer string) error {
 	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
-	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint: endpoint,
-		HTTPClient: &http.Client{
-			Transport: idleProbeRoundTripper{},
-		},
-		DisableStandaloneSSE: true,
-	}, nil)
+	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, false), nil)
 	if err != nil {
 		return err
 	}

--- a/erun-ui/cloud_credentials_refresher.go
+++ b/erun-ui/cloud_credentials_refresher.go
@@ -145,7 +145,7 @@ func (a *App) stopCloudCredentialsRefresherForSelection(selection uiSelection) {
 	endpoint := mcpEndpointForOpenResult(result)
 	clearCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	_ = clearCloudHostCredentialsViaMCP(clearCtx, endpoint)
+	_ = clearCloudHostCredentialsViaMCP(clearCtx, endpoint, a.mcpBearer(selection.Tenant, selection.Environment))
 }
 
 func (a *App) stopAllCloudCredentialsRefreshersLocked() {
@@ -182,7 +182,8 @@ func (a *App) runCloudCredentialsRefresher(ctx context.Context, selection uiSele
 			}
 			continue
 		}
-		if err := injectCloudHostCredentialsViaMCP(ctx, endpoint, creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken, creds.Expiration); err != nil {
+		bearer := a.mcpBearer(result.Tenant, result.EnvConfig.Name)
+		if err := injectCloudHostCredentialsViaMCP(ctx, endpoint, bearer, creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken, creds.Expiration); err != nil {
 			a.surfaceCredentialRefreshFailure(selection, fmt.Errorf("inject host credentials into runtime: %w", err), &notifiedFailure)
 			if !sleepWithCancel(ctx, credentialRefreshBackoff) {
 				return

--- a/erun-ui/contribute_mcp.go
+++ b/erun-ui/contribute_mcp.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -14,15 +13,9 @@ import (
 // Mirrors the call pattern used by loadDiffFromMCP / loadIdleStatusFromMCP
 // so the same idle-probe round-tripper keeps the call from refreshing
 // the env's idle activity marker.
-func cloneERunViaMCP(ctx context.Context, endpoint string) error {
+func cloneERunViaMCP(ctx context.Context, endpoint, bearer string) error {
 	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
-	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint: endpoint,
-		HTTPClient: &http.Client{
-			Transport: idleProbeRoundTripper{},
-		},
-		DisableStandaloneSSE: true,
-	}, nil)
+	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, true), nil)
 	if err != nil {
 		return err
 	}

--- a/erun-ui/contribute_mode.go
+++ b/erun-ui/contribute_mode.go
@@ -124,7 +124,7 @@ func (a *App) runEnsureErunClone(selection uiSelection) error {
 	if a.deps.cloneERun == nil {
 		return fmt.Errorf("contribute clone is not configured")
 	}
-	if err := a.deps.cloneERun(ctx, endpoint); err != nil {
+	if err := a.deps.cloneERun(ctx, endpoint, a.mcpBearer(result.Tenant, result.EnvConfig.Name)); err != nil {
 		if isMCPDialFailure(err) {
 			return wrapMCPUnreachableError(err)
 		}

--- a/erun-ui/deploy_orchestration.go
+++ b/erun-ui/deploy_orchestration.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -51,6 +52,7 @@ func (a *App) runDeployOrchestration(ctx context.Context, selection uiSelection,
 		if force {
 			deployArgs = append(deployArgs, "--force")
 		}
+		deployArgs = a.appendMCPAuthPublicKeyFlag(deployArgs)
 		_, err = runErunCaptured(ctx, cli, dir, onLine, deployArgs...)
 		return err
 	}
@@ -64,8 +66,32 @@ func (a *App) runDeployOrchestration(ctx context.Context, selection uiSelection,
 	if force {
 		args = append(args, "--force")
 	}
+	args = a.appendMCPAuthPublicKeyFlag(args)
 	_, err := runErunCaptured(ctx, cli, dir, onLine, args...)
 	return err
+}
+
+// appendMCPAuthPublicKeyFlag appends `--mcp-auth-public-key <path>` so the
+// deployed env requires the same desktop-signed bearer the desktop sends to its
+// MCP edge (issue #655). The public key is written beside the desktop's private
+// identity; ensurePublicKeyPath generates it on first use. A nil identity (unit
+// tests) or an unset identity dir yields no flag, leaving the env
+// unauthenticated. A generation error logs and proceeds without the flag rather
+// than failing the deploy — an unauthenticated env is recoverable; a blocked
+// deploy is not.
+func (a *App) appendMCPAuthPublicKeyFlag(args []string) []string {
+	if a.identity == nil {
+		return args
+	}
+	path, err := a.identity.ensurePublicKeyPath()
+	if err != nil {
+		log.Printf("erun-app: resolve MCP auth public key for deploy: %v", err)
+		return args
+	}
+	if path == "" {
+		return args
+	}
+	return append(args, "--mcp-auth-public-key", path)
 }
 
 // deployNeedsBuildOrchestration is the desktop's per-env-type deploy policy

--- a/erun-ui/diff_mcp.go
+++ b/erun-ui/diff_mcp.go
@@ -24,15 +24,48 @@ func (t idleProbeRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 	return base.RoundTrip(req)
 }
 
-func loadDiffFromMCP(ctx context.Context, endpoint string, options uiDiffOptions) (eruncommon.DiffResult, error) {
-	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
-	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
+// mcpAuthRoundTripper stamps the per-env bearer onto every MCP request so an
+// auth-enabled env edge (issue #655) accepts the call. An empty token is a
+// no-op, so non-auth envs and unit tests (which sign no token) keep working;
+// an auth-enabled env rejects the empty bearer with 401, which is correct.
+type mcpAuthRoundTripper struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (t mcpAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	if t.token != "" {
+		req.Header.Set("Authorization", "Bearer "+t.token)
+	}
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(req)
+}
+
+// mcpClientTransport builds the shared StreamableClientTransport every desktop
+// MCP call uses: it always carries the per-env bearer (mcpAuthRoundTripper) and,
+// for diagnostic reads, wraps the idle-probe header round-tripper underneath so
+// the call does not register as activity and hold an idle env awake.
+func mcpClientTransport(endpoint, bearer string, idleProbe bool) *mcp.StreamableClientTransport {
+	var base http.RoundTripper
+	if idleProbe {
+		base = idleProbeRoundTripper{}
+	}
+	return &mcp.StreamableClientTransport{
 		Endpoint: endpoint,
 		HTTPClient: &http.Client{
-			Transport: idleProbeRoundTripper{},
+			Transport: mcpAuthRoundTripper{token: bearer, base: base},
 		},
 		DisableStandaloneSSE: true,
-	}, nil)
+	}
+}
+
+func loadDiffFromMCP(ctx context.Context, endpoint, bearer string, options uiDiffOptions) (eruncommon.DiffResult, error) {
+	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
+	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, true), nil)
 	if err != nil {
 		return eruncommon.DiffResult{}, err
 	}
@@ -63,12 +96,9 @@ func loadDiffFromMCP(ctx context.Context, endpoint string, options uiDiffOptions
 	return diff, nil
 }
 
-func setEnvironmentCloudAliasViaMCP(ctx context.Context, endpoint, tenant, environment, alias string) (eruncommon.EnvConfig, error) {
+func setEnvironmentCloudAliasViaMCP(ctx context.Context, endpoint, bearer, tenant, environment, alias string) (eruncommon.EnvConfig, error) {
 	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
-	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint:             endpoint,
-		DisableStandaloneSSE: true,
-	}, nil)
+	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, false), nil)
 	if err != nil {
 		return eruncommon.EnvConfig{}, err
 	}
@@ -105,15 +135,9 @@ func setEnvironmentCloudAliasViaMCP(ctx context.Context, endpoint, tenant, envir
 // endpoint's raw tool and returns its stdout. The idle-probe header keeps
 // these diagnostic reads from registering as activity, so a hover or an
 // open Diagnostics console never holds an idle env awake.
-func runPodRawFromMCP(ctx context.Context, endpoint string, argv []string) (string, error) {
+func runPodRawFromMCP(ctx context.Context, endpoint, bearer string, argv []string) (string, error) {
 	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
-	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint: endpoint,
-		HTTPClient: &http.Client{
-			Transport: idleProbeRoundTripper{},
-		},
-		DisableStandaloneSSE: true,
-	}, nil)
+	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, true), nil)
 	if err != nil {
 		return "", err
 	}
@@ -147,23 +171,17 @@ func runPodRawFromMCP(ctx context.Context, endpoint string, argv []string) (stri
 // loadPodBranchFromMCP reads the env worktree's current git branch from
 // inside the runtime pod via the per-env MCP endpoint's raw tool — the
 // sidebar hover card's "Working on" source for remote envs (issue #462).
-func loadPodBranchFromMCP(ctx context.Context, endpoint string) (string, error) {
-	out, err := runPodRawFromMCP(ctx, endpoint, []string{"git", "rev-parse", "--abbrev-ref", "HEAD"})
+func loadPodBranchFromMCP(ctx context.Context, endpoint, bearer string) (string, error) {
+	out, err := runPodRawFromMCP(ctx, endpoint, bearer, []string{"git", "rev-parse", "--abbrev-ref", "HEAD"})
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(out), nil
 }
 
-func loadIdleStatusFromMCP(ctx context.Context, endpoint string) (eruncommon.EnvironmentIdleStatus, error) {
+func loadIdleStatusFromMCP(ctx context.Context, endpoint, bearer string) (eruncommon.EnvironmentIdleStatus, error) {
 	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
-	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint: endpoint,
-		HTTPClient: &http.Client{
-			Transport: idleProbeRoundTripper{},
-		},
-		DisableStandaloneSSE: true,
-	}, nil)
+	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, true), nil)
 	if err != nil {
 		return eruncommon.EnvironmentIdleStatus{}, err
 	}
@@ -187,12 +205,9 @@ func loadIdleStatusFromMCP(ctx context.Context, endpoint string) (eruncommon.Env
 	return status, nil
 }
 
-func loadAPILogFromMCP(ctx context.Context, endpoint string) (string, error) {
+func loadAPILogFromMCP(ctx context.Context, endpoint, bearer string) (string, error) {
 	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
-	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint:             endpoint,
-		DisableStandaloneSSE: true,
-	}, nil)
+	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, false), nil)
 	if err != nil {
 		return "", err
 	}

--- a/erun-ui/env_trace_handlers.go
+++ b/erun-ui/env_trace_handlers.go
@@ -99,7 +99,7 @@ func (a *App) podEnvTraceTail(result eruncommon.OpenResult) (string, string) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	out, err := a.deps.runPodRaw(ctx, mcpEndpointForOpenResult(result), []string{
+	out, err := a.deps.runPodRaw(ctx, mcpEndpointForOpenResult(result), a.mcpBearer(result.Tenant, result.EnvConfig.Name), []string{
 		"sh", "-c",
 		fmt.Sprintf("tail -c %d \"$HOME/.erun/%s/%s/trace.log\" 2>/dev/null || true", envTraceTailBytes, result.Tenant, result.Environment),
 	})

--- a/erun-ui/env_trace_handlers_test.go
+++ b/erun-ui/env_trace_handlers_test.go
@@ -27,7 +27,7 @@ func envTraceApp(t *testing.T, env eruncommon.EnvConfig, reachable bool, podOut 
 		store:               store,
 		findProjectRoot:     func() (string, string, error) { return "acme", "/tmp/acme", nil },
 		canConnectLocalPort: func(int) bool { return reachable },
-		runPodRaw: func(context.Context, string, []string) (string, error) {
+		runPodRaw: func(context.Context, string, string, []string) (string, error) {
 			return podOut, podErr
 		},
 	})

--- a/erun-ui/environment_config.go
+++ b/erun-ui/environment_config.go
@@ -270,7 +270,8 @@ func (a *App) saveRemoteCloudAlias(selection uiSelection, existing, updated erun
 	if err := a.ensureMCPAvailable(ctx, result); err != nil {
 		return err
 	}
-	_, err = a.deps.setRemoteCloudAlias(ctx, mcpEndpointForOpenResult(result), selection.Tenant, selection.Environment, updated.CloudProviderAlias)
+	bearer := a.mcpBearer(selection.Tenant, selection.Environment)
+	_, err = a.deps.setRemoteCloudAlias(ctx, mcpEndpointForOpenResult(result), bearer, selection.Tenant, selection.Environment, updated.CloudProviderAlias)
 	return err
 }
 

--- a/erun-ui/environment_working_issue.go
+++ b/erun-ui/environment_working_issue.go
@@ -130,7 +130,7 @@ func (a *App) resolvePodWorkingIssue(result eruncommon.OpenResult) uiWorkingIssu
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	branch, err := a.deps.loadPodBranch(ctx, mcpEndpointForOpenResult(result))
+	branch, err := a.deps.loadPodBranch(ctx, mcpEndpointForOpenResult(result), a.mcpBearer(result.Tenant, result.EnvConfig.Name))
 	if err != nil {
 		return uiWorkingIssue{Available: false, Reason: "in-pod work is not reachable right now"}
 	}

--- a/erun-ui/environment_working_issue_test.go
+++ b/erun-ui/environment_working_issue_test.go
@@ -51,7 +51,7 @@ func workingIssueApp(t *testing.T, env eruncommon.EnvConfig, run workingIssueCom
 		findProjectRoot:        func() (string, string, error) { return "acme", "/tmp/acme", nil },
 		runWorkingIssueCommand: run,
 		canConnectLocalPort:    func(int) bool { return false },
-		loadPodBranch: func(context.Context, string) (string, error) {
+		loadPodBranch: func(context.Context, string, string) (string, error) {
 			t.Fatal("loadPodBranch must not run through the legacy working-issue helper")
 			return "", nil
 		},
@@ -135,7 +135,7 @@ func TestEnvironmentWorkingIssueUnavailableForRemoteWorktree(t *testing.T) {
 // remoteWorkingIssueApp builds an App for the pod-backed resolution paths
 // (issue #462): a remote-agent env with a port range, an injectable
 // reachability answer, and an injectable in-pod branch loader.
-func remoteWorkingIssueApp(t *testing.T, reachable bool, loadPodBranch func(context.Context, string) (string, error), run workingIssueCommandRunner) *App {
+func remoteWorkingIssueApp(t *testing.T, reachable bool, loadPodBranch func(context.Context, string, string) (string, error), run workingIssueCommandRunner) *App {
 	t.Helper()
 	store := stubUIStore{
 		tenants: map[string]eruncommon.TenantConfig{
@@ -164,7 +164,7 @@ func remoteWorkingIssueApp(t *testing.T, reachable bool, loadPodBranch func(cont
 
 func TestEnvironmentWorkingIssueRemoteNotReachable(t *testing.T) {
 	app := remoteWorkingIssueApp(t, false,
-		func(context.Context, string) (string, error) {
+		func(context.Context, string, string) (string, error) {
 			t.Fatal("loadPodBranch must not run while the env is not reachable")
 			return "", nil
 		},
@@ -189,7 +189,7 @@ func TestEnvironmentWorkingIssueRemoteNotReachable(t *testing.T) {
 func TestEnvironmentWorkingIssueRemoteReadsPodBranch(t *testing.T) {
 	var ghDirs []string
 	app := remoteWorkingIssueApp(t, true,
-		func(context.Context, string) (string, error) {
+		func(context.Context, string, string) (string, error) {
 			return "bug/470-sidebar-status", nil
 		},
 		func(_ context.Context, dir, name string, _ ...string) (string, error) {
@@ -216,7 +216,7 @@ func TestEnvironmentWorkingIssueRemoteReadsPodBranch(t *testing.T) {
 func TestEnvironmentWorkingIssueRemotePodErrorNotCached(t *testing.T) {
 	var loads int
 	app := remoteWorkingIssueApp(t, true,
-		func(context.Context, string) (string, error) {
+		func(context.Context, string, string) (string, error) {
 			loads++
 			return "", context.DeadlineExceeded
 		},

--- a/erun-ui/idle_status.go
+++ b/erun-ui/idle_status.go
@@ -33,7 +33,7 @@ func (a *App) LoadIdleStatus(selection uiSelection) (uiIdleStatus, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	status, err := a.deps.loadIdleStatus(ctx, mcpEndpointForOpenResult(result))
+	status, err := a.deps.loadIdleStatus(ctx, mcpEndpointForOpenResult(result), a.mcpBearer(result.Tenant, result.EnvConfig.Name))
 	if err != nil {
 		status, err := a.loadLocalIdleStatus(result)
 		if err == nil {
@@ -259,7 +259,8 @@ func (a *App) CancelPendingIdleStop(selection uiSelection) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if err := cancelStopPendingViaMCP(ctx, endpoint, selection.Tenant, selection.Environment); err != nil {
+	bearer := a.mcpBearer(selection.Tenant, selection.Environment)
+	if err := cancelStopPendingViaMCP(ctx, endpoint, bearer, selection.Tenant, selection.Environment); err != nil {
 		return err
 	}
 	a.emitAppNotification("info", fmt.Sprintf("Cancelled pending auto-stop for %s/%s.", selection.Tenant, selection.Environment))
@@ -299,7 +300,8 @@ func (a *App) recordManualStopForCloudContext(ctx context.Context, cloudContextN
 			continue
 		}
 		endpoint := mcpEndpointForOpenResult(result)
-		if err := recordManualStopViaMCP(ctx, endpoint, selection.Tenant, selection.Environment, "Manual stop via desktop", cloudContextName); err != nil {
+		bearer := a.mcpBearer(selection.Tenant, selection.Environment)
+		if err := recordManualStopViaMCP(ctx, endpoint, bearer, selection.Tenant, selection.Environment, "Manual stop via desktop", cloudContextName); err != nil {
 			a.emitAppNotification("warn", fmt.Sprintf("Could not record manual stop for %s/%s: %s", selection.Tenant, selection.Environment, err.Error()))
 		}
 	}
@@ -326,7 +328,8 @@ func (a *App) LoadStopHistory(selection uiSelection) ([]uiLastStopEvent, error) 
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	entries, err := loadStopHistoryViaMCP(ctx, endpoint, selection.Tenant, selection.Environment)
+	bearer := a.mcpBearer(selection.Tenant, selection.Environment)
+	entries, err := loadStopHistoryViaMCP(ctx, endpoint, bearer, selection.Tenant, selection.Environment)
 	if err != nil {
 		return nil, err
 	}

--- a/erun-ui/idle_stop_mcp.go
+++ b/erun-ui/idle_stop_mcp.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -30,17 +29,11 @@ const idleStopMCPTimeout = 10 * time.Second
 // the next idle poll from any client (including the in-pod monitor's
 // next 30 s tick) re-evaluates eligibility and re-arms the warning
 // if the env is still idle.
-func cancelStopPendingViaMCP(ctx context.Context, endpoint, tenant, environment string) error {
+func cancelStopPendingViaMCP(ctx context.Context, endpoint, bearer, tenant, environment string) error {
 	ctx, cancel := context.WithTimeout(ctx, idleStopMCPTimeout)
 	defer cancel()
 	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
-	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint: endpoint,
-		HTTPClient: &http.Client{
-			Transport: idleProbeRoundTripper{},
-		},
-		DisableStandaloneSSE: true,
-	}, nil)
+	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, false), nil)
 	if err != nil {
 		return err
 	}
@@ -68,17 +61,11 @@ func cancelStopPendingViaMCP(ctx context.Context, endpoint, tenant, environment 
 // stop-history.json from the env's shared PVC, so a desktop running
 // after a long break sees the same audit trail the in-pod monitor
 // has been appending to.
-func loadStopHistoryViaMCP(ctx context.Context, endpoint, tenant, environment string) ([]eruncommon.EnvironmentStopHistoryEntry, error) {
+func loadStopHistoryViaMCP(ctx context.Context, endpoint, bearer, tenant, environment string) ([]eruncommon.EnvironmentStopHistoryEntry, error) {
 	ctx, cancel := context.WithTimeout(ctx, idleStopMCPTimeout)
 	defer cancel()
 	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
-	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint: endpoint,
-		HTTPClient: &http.Client{
-			Transport: idleProbeRoundTripper{},
-		},
-		DisableStandaloneSSE: true,
-	}, nil)
+	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, false), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -124,17 +111,11 @@ func loadStopHistoryViaMCP(ctx context.Context, endpoint, tenant, environment st
 // older runtime images that do not register the tool yet, the
 // caller swallows the formatted error so manual stops still
 // succeed — formatIdleStopMCPError points at the rebuild fix.
-func recordManualStopViaMCP(ctx context.Context, endpoint, tenant, environment, reason, cloudContextName string) error {
+func recordManualStopViaMCP(ctx context.Context, endpoint, bearer, tenant, environment, reason, cloudContextName string) error {
 	ctx, cancel := context.WithTimeout(ctx, idleStopMCPTimeout)
 	defer cancel()
 	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
-	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint: endpoint,
-		HTTPClient: &http.Client{
-			Transport: idleProbeRoundTripper{},
-		},
-		DisableStandaloneSSE: true,
-	}, nil)
+	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, false), nil)
 	if err != nil {
 		return err
 	}

--- a/erun-ui/mcp_identity.go
+++ b/erun-ui/mcp_identity.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+const (
+	desktopIdentityKeyFile = "desktopid.key"
+	desktopIdentityPubFile = "desktopid.pub"
+	// desktopMCPTokenTTL keeps the per-env bearer short-lived so a leaked token
+	// has a small window; the desktop signs a fresh one per MCP call.
+	desktopMCPTokenTTL = 5 * time.Minute
+)
+
+// desktopIdentity is the desktop's persistent Ed25519 identity (issue #655). It
+// signs the per-env bearer tokens the desktop sends to each env's MCP edge and
+// supplies the public key the deploy injects into the pod so the edge can
+// verify them. The private key is the single source of truth, persisted once
+// under the user config dir; the public key is written beside it so deploy can
+// pass its path to `erun deploy --mcp-auth-public-key`.
+type desktopIdentity struct {
+	dir        string
+	mu         sync.Mutex
+	privatePEM []byte
+}
+
+// defaultDesktopIdentityDir is the per-user directory the desktop keeps its
+// identity in, matching the contribute-state convention (UserConfigDir/ERun).
+func defaultDesktopIdentityDir() string {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(configDir, "ERun")
+}
+
+func newDesktopIdentity(dir string) *desktopIdentity {
+	return &desktopIdentity{dir: dir}
+}
+
+func (d *desktopIdentity) keyPath() string       { return filepath.Join(d.dir, desktopIdentityKeyFile) }
+func (d *desktopIdentity) publicKeyPath() string { return filepath.Join(d.dir, desktopIdentityPubFile) }
+
+// ensure loads the persisted private key, generating and persisting a fresh
+// keypair (and writing the public key beside it) on first use. Safe for
+// concurrent callers.
+func (d *desktopIdentity) ensure() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.privatePEM) > 0 {
+		return nil
+	}
+	if strings.TrimSpace(d.dir) == "" {
+		return fmt.Errorf("desktop identity directory is unset")
+	}
+	switch data, err := os.ReadFile(d.keyPath()); {
+	case err == nil:
+		if _, derr := eruncommon.DesktopPublicKeyPEM(data); derr != nil {
+			return fmt.Errorf("persisted desktop identity is invalid: %w", derr)
+		}
+		d.privatePEM = data
+	case os.IsNotExist(err):
+		priv, _, gerr := eruncommon.GenerateDesktopIdentity()
+		if gerr != nil {
+			return gerr
+		}
+		if mkErr := os.MkdirAll(d.dir, 0o700); mkErr != nil {
+			return fmt.Errorf("create desktop identity dir: %w", mkErr)
+		}
+		if wErr := os.WriteFile(d.keyPath(), priv, 0o600); wErr != nil {
+			return fmt.Errorf("write desktop identity: %w", wErr)
+		}
+		d.privatePEM = priv
+	default:
+		return fmt.Errorf("read desktop identity: %w", err)
+	}
+	return d.writePublicKeyLocked()
+}
+
+// writePublicKeyLocked writes the derived public key beside the private key so
+// deploy can reference it by path. The caller holds d.mu.
+func (d *desktopIdentity) writePublicKeyLocked() error {
+	pub, err := eruncommon.DesktopPublicKeyPEM(d.privatePEM)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(d.publicKeyPath(), pub, 0o600); err != nil {
+		return fmt.Errorf("write desktop public key: %w", err)
+	}
+	return nil
+}
+
+// ensurePublicKeyPath ensures the identity exists and returns the public-key
+// file path for the deploy `--mcp-auth-public-key` input. It returns "" with no
+// error when no identity dir is configured, so a deploy from such a desktop
+// stays unauthenticated rather than failing.
+func (d *desktopIdentity) ensurePublicKeyPath() (string, error) {
+	if d == nil || strings.TrimSpace(d.dir) == "" {
+		return "", nil
+	}
+	if err := d.ensure(); err != nil {
+		return "", err
+	}
+	return d.publicKeyPath(), nil
+}
+
+// signToken signs a short-lived bearer for the given env's MCP edge, stamped
+// with the file:// issuer the edge trusts and the per-env audience it enforces,
+// so a token for one env cannot be replayed against another.
+func (d *desktopIdentity) signToken(tenant, environment string, now time.Time) (string, error) {
+	if d == nil {
+		return "", fmt.Errorf("desktop identity is not configured")
+	}
+	if err := d.ensure(); err != nil {
+		return "", err
+	}
+	d.mu.Lock()
+	priv := d.privatePEM
+	d.mu.Unlock()
+	return eruncommon.SignMCPToken(priv, eruncommon.MCPTokenClaims{
+		Issuer:    eruncommon.DesktopMCPIssuer(),
+		Subject:   "erun-desktop",
+		Audience:  eruncommon.MCPTokenAudience(tenant, environment),
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(desktopMCPTokenTTL).Unix(),
+	})
+}

--- a/erun-ui/mcp_identity_test.go
+++ b/erun-ui/mcp_identity_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+func mustNoErr(t *testing.T, err error, what string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", what, err)
+	}
+}
+
+// TestDesktopIdentityRoundTrip locks the desktop↔server contract: the keypair
+// the desktop persists (and whose public half it injects on deploy) signs a
+// token the real erun-common verifier accepts, and signToken stamps the shared
+// file:// issuer + the per-env audience the MCP edge enforces (#655).
+func TestDesktopIdentityRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	id := newDesktopIdentity(dir)
+
+	pubPath, err := id.ensurePublicKeyPath()
+	mustNoErr(t, err, "ensurePublicKeyPath")
+	if pubPath != filepath.Join(dir, desktopIdentityPubFile) {
+		t.Fatalf("public key path = %q", pubPath)
+	}
+	_, err = os.Stat(pubPath)
+	mustNoErr(t, err, "stat public key")
+
+	// signToken stamps the canonical desktop issuer (the audience is checked via
+	// the verify round-trip below).
+	now := time.Unix(1_800_000_000, 0)
+	token, err := id.signToken("acme", "prod", now)
+	mustNoErr(t, err, "signToken")
+	issuer, err := eruncommon.UnverifiedMCPTokenIssuer(token)
+	mustNoErr(t, err, "UnverifiedMCPTokenIssuer")
+	if issuer != eruncommon.DesktopMCPIssuer() {
+		t.Fatalf("token issuer = %q, want %q", issuer, eruncommon.DesktopMCPIssuer())
+	}
+
+	// The persisted keypair verifies end-to-end through the real verifier when
+	// the issuer points at the on-disk public key (the chart mounts it at the
+	// canonical path in the pod; here we verify against the temp path).
+	priv, err := os.ReadFile(filepath.Join(dir, desktopIdentityKeyFile))
+	mustNoErr(t, err, "read persisted private key")
+	localIssuer := eruncommon.FileIssuer(pubPath)
+	audience := eruncommon.MCPTokenAudience("acme", "prod")
+	verifyToken, err := eruncommon.SignMCPToken(priv, eruncommon.MCPTokenClaims{
+		Issuer:    localIssuer,
+		Audience:  audience,
+		ExpiresAt: now.Add(time.Hour).Unix(),
+	})
+	mustNoErr(t, err, "sign verify token")
+	claims, err := eruncommon.VerifyMCPToken(verifyToken, localIssuer, audience, now)
+	mustNoErr(t, err, "VerifyMCPToken against persisted key")
+	if claims.Audience != audience {
+		t.Fatalf("verified audience = %q, want %q", claims.Audience, audience)
+	}
+
+	// A second ensure() reuses the persisted key rather than regenerating it.
+	priv2, err := os.ReadFile(filepath.Join(dir, desktopIdentityKeyFile))
+	mustNoErr(t, err, "re-read persisted private key")
+	if string(priv) != string(priv2) {
+		t.Fatal("private key was regenerated on second ensure")
+	}
+}

--- a/erun-ui/tenant_dashboard.go
+++ b/erun-ui/tenant_dashboard.go
@@ -32,6 +32,7 @@ func (a *App) LoadTenantDashboard(input uiTenantDashboardInput) (uiTenantDashboa
 		ctx = context.Background()
 	}
 	if strings.TrimSpace(input.MCPURL) != "" || strings.TrimSpace(input.KubernetesContext) != "" {
+		input.mcpBearer = a.mcpBearer(tenant, strings.TrimSpace(input.Environment))
 		log, err := a.deps.loadAPILog(ctx, input)
 		if err != nil {
 			dashboard.APILogError = err.Error()

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -317,7 +317,7 @@ func (a *App) StartDeploySession(selection uiSelection, cols, rows int) (startSe
 	// from the Local tab and registers a deploy entry within milliseconds.
 	// The helm release poller converges onto the same record by ID once
 	// the cluster sees the pending release.
-	return a.runErunCommandInLocal(selection, cols, rows, buildDeployArgs(selection))
+	return a.runErunCommandInLocal(selection, cols, rows, a.appendMCPAuthPublicKeyFlag(buildDeployArgs(selection)))
 }
 
 // StartForceDeploySession runs `erun deploy --force` in the Local tab.
@@ -329,7 +329,7 @@ func (a *App) StartForceDeploySession(selection uiSelection, cols, rows int) (st
 	if result, ok := a.maybeStartDeployOrchestration(selection, true); ok {
 		return result, nil
 	}
-	args := append(buildDeployArgs(selection), "--force")
+	args := a.appendMCPAuthPublicKeyFlag(append(buildDeployArgs(selection), "--force"))
 	return a.runErunCommandInLocal(selection, cols, rows, args)
 }
 
@@ -772,7 +772,8 @@ func (a *App) LoadDiff(selection uiSelection, options uiDiffOptions) (eruncommon
 		return eruncommon.DiffResult{}, wrapMCPUnreachableError(fmt.Errorf("mcp port %d is not reachable", mcpPort))
 	}
 	endpoint := mcpEndpointForOpenResult(result)
-	diff, err := a.deps.loadDiff(ctx, endpoint, options)
+	bearer := a.mcpBearer(result.Tenant, result.EnvConfig.Name)
+	diff, err := a.deps.loadDiff(ctx, endpoint, bearer, options)
 	if err != nil && isMCPDialFailure(err) {
 		return eruncommon.DiffResult{}, wrapMCPUnreachableError(err)
 	}

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -116,6 +116,12 @@ type uiTenantDashboardInput struct {
 	MCPURL             string `json:"mcpUrl,omitempty"`
 	KubernetesContext  string `json:"kubernetesContext,omitempty"`
 	CloudProviderAlias string `json:"cloudProviderAlias"`
+
+	// mcpBearer is the per-env MCP edge token (issue #655) the dashboard's
+	// MCP API-log read sends. It is set server-side by LoadTenantDashboard
+	// from the desktop identity, never by the frontend; being unexported it
+	// is excluded from generated Wails bindings and never serialized.
+	mcpBearer string
 }
 
 type uiTenantDashboard struct {


### PR DESCRIPTION
## Summary

Authenticates the per-env `erun-mcp` edge so its RCE-capable `raw` tool is never reachable unauthenticated. For the **desktop deployment case** the trust anchor is a self-contained Ed25519 keypair: the desktop signs a short-lived EdDSA JWT, injects the matching public key into the runtime pod on deploy, names that key in the token's `iss` as a `file://<path>` URL, and the MCP server verifies the signature against it. Tenant is resolved per URL from an `issuer → tenant` map (mirroring the erun API), and the audience is pinned per environment so a token for one env can't be replayed against another or against the REST API.

Closes #655. The hosted **OIDC-issuer** generalization of the same edge (#656) and per-tool authorization (#657) are tracked separately and marked `(Planned.)` in the docs.

## What changed

- **erun-common** — `mcp_auth.go`: Ed25519 keygen, EdDSA JWT sign/verify against a configured trusted `file://` issuer (`alg=EdDSA` hard-locked → no alg-confusion), the per-URL `issuer → tenant` selection helper, the shared conventions (`DesktopMCPPublicKeyPath`/`DesktopMCPIssuer`/`MCPTokenAudience`), and `DesktopPublicKeyPEM` (derive the public half from the persisted private key). `mcp_auth_deploy.go`: deploy-time injection — applies the public key out-of-band as a `<release>-mcp-auth` Secret (mirroring the Cloudflare-token path) and threads `mcpAuth.*` helm values onto the runtime chart only.
- **erun-mcp** — `auth.go`: bearer-auth HTTP middleware (the outermost edge); resolves the tenant from `ERUN_MCP_TRUSTED_ISSUERS` (JSON map) / `ERUN_MCP_TRUSTED_ISSUER`+`ERUN_TENANT` (single-issuer sugar), verifies the token, enforces per-env `aud`, and carries the resolved tenant on `X-Erun-Auth-Tenant`. Empty config = legacy loopback-only pass-through (back-compat).
- **erun-cli** — `erun deploy --mcp-auth-public-key <pem>` (on both `deploy` and `devops k8s deploy`).
- **erun-devops chart** — gated MCP-auth on the `erun-mcp` container: mount the public-key Secret at `/etc/erun/mcp-auth/desktopid.pub`, wire `ERUN_MCP_TRUSTED_ISSUER` + per-env `ERUN_MCP_AUDIENCE`. `helm template` verified **byte-for-byte unchanged when disabled**.
- **erun-ui (desktop)** — persists `desktopid.key` (single source of truth; public key derived + written for deploy), signs a per-env `Bearer` (file:// issuer + `erun-mcp:<tenant>/<env>` audience, 5-min TTL) via an auth `RoundTripper` alongside the idle-probe one, routes all MCP call sites through it, and passes `--mcp-auth-public-key` on both desktop deploy paths. Nil-safe: no identity / sign failure → empty bearer (logged), so non-auth envs and tests are unchanged.
- **erun-docs** — `api-protocol.md`: the authenticated-edge spec (issuer→tenant map, the `file://` desktop case, per-env `aud` enforcement — noting the MCP edge enforces `aud` unlike the REST API).

## UX impact review (erun-ui)

1. **Affected paths.** Deploy (`StartDeploySession`/orchestration → `erun deploy`) and the MCP read paths the React tree calls (idle status, diagnostics `raw`, diff, stop-history, cloud-credential inject/clear, contribute clone).
2. **User-visible sequence.** Unchanged. Deploy still produces the same activity-queue entries; MCP-backed panels load the same. The only differences are non-DOM: an extra CLI flag on the spawned `erun deploy`, and an `Authorization` header on MCP HTTP calls.
3. **State-without-affordance.** None added.
4–7. **Heuristics.** No new controls, statuses, or recovery surfaces. The auth is transparent transport plumbing; a signing/auth failure surfaces through the existing MCP-unreachable error path (`wrapMCPUnreachableError`).
8. **Playwright.** This change adds **zero observable frontend surface** (no `frontend/src/` diff; backend transport + a deploy-arg flag). The new branches are covered by Go unit tests — `TestStartDeploySessionInjectsMCPAuthPublicKey` (deploy-flag injection) and `TestDesktopIdentityRoundTrip` (persisted keypair signs+verifies through the real verifier with the per-env audience). The headless harness has no auth-enabled MCP edge to exercise the token round-trip. The full suite is running to confirm no regression; result noted below.

## Validation

- `go test ./...` + `golangci-lint run ./...` green in erun-common, erun-mcp, erun-cli, erun-ui.
- `make integration-test` green — **coverage 75.3% ≥ 75.0%**. New scenario `deploy/dry_run_with_mcp_auth_public_key` locks the dry-run trace (out-of-band secret apply + `mcpAuth.*` helm values with `issuer=file:///etc/erun/mcp-auth/desktopid.pub`, `audience=erun-mcp:team/dev`, runtime chart only); two `--help` goldens refreshed for the new flag.
- `cd erun-docs && yarn build` clean.
- Playwright (`erun-ui/playwright/run.sh`) — running; will confirm green.

## Not verified end-to-end (honest gate note)

Verified at the unit/integration level (crypto sign↔verify round-trip, `helm template` render, deploy `--dry-run` trace, middleware 401/tenant tests). **Not** yet exercised against a live k3d cluster with a real auth-enabled MCP edge (a desktop-signed token accepted + an unauthenticated request 401'd in-cluster) — that is the opt-in `run.sh --e2e-k3d` path and is the recommended pre-merge live check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
