### PR TITLE
Enforce the per-env tenant/environment boundary at the MCP edge (#657 Layer 1)

### DIFF
--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -70,13 +70,14 @@ The runtime chart configures each edge with a set of trusted issuers mapping eac
 1. `Authorization: Bearer <jwt>` is present — missing → `401`.
 2. The token's `iss` is a trusted issuer for this edge — untrusted → `401`; the mapped value is the resolved tenant.
 3. The signature verifies against that issuer's key, and `exp` and the audience (`aud`) match. **Unlike the REST API, the MCP edge enforces `aud`** — the per-env audience (`erun-mcp:<tenant>/<environment>`) means a token minted for one environment cannot be replayed against another, or against the REST API.
+4. The resolved tenant matches **this** environment's tenant (a per-env edge serves exactly one tenant) — a token resolving to another tenant → `401`. Tenant-scoped tools are likewise pinned to the edge's own environment: a `tenant`/`environment` argument that differs from the pod's identity is refused, so a caller can never drive one env's MCP to act on another (issue #657).
 
 An edge can trust **multiple issuers at once**, of two kinds, dispatched by the *configured* issuer's scheme (not the token's claimed `iss`, so the verification path can't be attacker-chosen):
 
 - **`https://` OIDC issuer** (the platform's Zitadel, AWS) — verified via the issuer's JWKS through provider discovery, using the same shared verifier the REST API uses (so the API and every MCP edge verify identically). Hosted/console callers present their OIDC token directly.
 - **`file://` desktop key** (issue #655) — a self-contained local trust anchor for the **desktop** case, instead of an OIDC IdP: the desktop generates an Ed25519 key (`desktopid.key`) once, signs an EdDSA JWT whose `iss` is a `file://<path>` URL naming the public key, and injects that public key into the runtime pod on deploy (`erun deploy --mcp-auth-public-key`). The edge loads the key from that `file://` path and verifies the signature against it; `alg` is hard-locked to `EdDSA` for `file://` issuers, closing the alg-confusion class.
 
-When no trust anchor is configured the edge stays loopback-only (legacy, unauthenticated) — a desktop or hosted deploy always configures one. Per-tool authorization of the edge's RCE-capable tools is `(Planned.)` (issue #657).
+When no trust anchor is configured the edge stays loopback-only (legacy, unauthenticated) — a desktop or hosted deploy always configures one. Capability/scope-gated authorization of *individual* tools (e.g. restricting the RCE-capable `raw` to admin-scoped tokens, while a read-only token sees only the read tools) is `(Planned.)` — it rides on the hosted role source (issue #606).
 
 ### Endpoints
 

--- a/erun-mcp/auth.go
+++ b/erun-mcp/auth.go
@@ -46,6 +46,10 @@ type mcpAuthConfig struct {
 	// its verified iss is a key here; the value is the resolved tenant.
 	trustedIssuers map[string]string
 	audience       string
+	// tenant is this env's own tenant (ERUN_TENANT). A per-env edge serves exactly
+	// one tenant, so a token that resolves to a different tenant — a misconfigured
+	// trusted-issuer map pointing an issuer at another tenant — is rejected (#657).
+	tenant string
 	// oidc verifies tokens from `https://` OIDC issuers against their JWKS. It is
 	// the same shared verifier the hosted backend API uses (erun-common). One
 	// instance is created per middleware and reused so each issuer's key set is
@@ -62,6 +66,7 @@ func mcpAuthConfigFromEnv() mcpAuthConfig {
 	cfg := mcpAuthConfig{
 		trustedIssuers: map[string]string{},
 		audience:       strings.TrimSpace(os.Getenv(envMCPAudience)),
+		tenant:         strings.TrimSpace(os.Getenv(envTenant)),
 		oidc:           eruncommon.NewOIDCVerifier(),
 	}
 	if raw := strings.TrimSpace(os.Getenv(envMCPTrustedIssuers)); raw != "" {
@@ -111,6 +116,12 @@ func authHTTPMiddleware(cfg mcpAuthConfig, next http.Handler) http.Handler {
 		tenant, trusted := cfg.trustedIssuers[issuer]
 		if !trusted {
 			writeUnauthorized(w, "token issuer is not a trusted MCP issuer")
+			return
+		}
+		// A per-env edge serves exactly one tenant; a token resolving to another
+		// tenant means the trusted-issuer map is misconfigured for this env (#657).
+		if cfg.tenant != "" && tenant != cfg.tenant {
+			writeUnauthorized(w, "token tenant does not match this environment")
 			return
 		}
 		if _, err := eruncommon.VerifyMCPToken(req.Context(), cfg.oidc, token, issuer, cfg.audience, time.Now()); err != nil {

--- a/erun-mcp/auth_test.go
+++ b/erun-mcp/auth_test.go
@@ -69,6 +69,7 @@ func TestAuthMiddleware(t *testing.T) {
 		{name: "valid bearer is authorized and resolves the tenant", cfg: authed, authHeader: "Bearer " + token, wantStatus: http.StatusOK, wantTenant: "acme"},
 		{name: "garbage bearer is rejected", cfg: authed, authHeader: "Bearer not-a-jwt", wantStatus: http.StatusUnauthorized},
 		{name: "untrusted issuer is rejected", cfg: authed, authHeader: "Bearer " + otherToken, wantStatus: http.StatusUnauthorized},
+		{name: "tenant mismatch is rejected (#657)", cfg: mcpAuthConfig{trustedIssuers: map[string]string{issuer: "beta"}, audience: "erun-mcp", tenant: "acme"}, authHeader: "Bearer " + token, wantStatus: http.StatusUnauthorized},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/erun-mcp/cloud.go
+++ b/erun-mcp/cloud.go
@@ -198,8 +198,10 @@ func cloudOIDCTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReq
 
 func cloudSetTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, CloudSetInput) (*mcp.CallToolResult, CloudSetResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input CloudSetInput) (*mcp.CallToolResult, CloudSetResult, error) {
-		tenant := firstNonEmpty(strings.TrimSpace(input.Tenant), strings.TrimSpace(runtime.Context.Tenant))
-		environment := firstNonEmpty(strings.TrimSpace(input.Environment), strings.TrimSpace(runtime.Context.Environment))
+		tenant, environment, err := scopedTenantEnv(input.Tenant, input.Environment, runtime)
+		if err != nil {
+			return nil, CloudSetResult{}, err
+		}
 		traceOutput := strings.Builder{}
 		ctx := runtimeCallContext(input.Preview, input.Verbosity, nil, &traceOutput, &traceOutput)
 		config, err := eruncommon.SetEnvironmentCloudProviderAlias(ctx, runtime.Store, eruncommon.SetEnvironmentCloudAliasParams{

--- a/erun-mcp/delete.go
+++ b/erun-mcp/delete.go
@@ -19,8 +19,10 @@ type DeleteInput struct {
 
 func deleteTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, DeleteInput) (*mcp.CallToolResult, CommandOutput, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input DeleteInput) (*mcp.CallToolResult, CommandOutput, error) {
-		tenant := firstNonEmpty(input.Tenant, runtime.Context.Tenant)
-		environment := firstNonEmpty(input.Environment, runtime.Context.Environment)
+		tenant, environment, err := scopedTenantEnv(input.Tenant, input.Environment, runtime)
+		if err != nil {
+			return nil, CommandOutput{}, err
+		}
 		expected := eruncommon.DeleteEnvironmentConfirmation(tenant, environment)
 		if expected == "" {
 			return nil, CommandOutput{}, fmt.Errorf("tenant and environment are required")

--- a/erun-mcp/init.go
+++ b/erun-mcp/init.go
@@ -47,17 +47,21 @@ func initTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest,
 		if err != nil {
 			return nil, InitOutput{}, err
 		}
+		tenant, environment, err := scopedTenantEnv(input.Tenant, input.Environment, runtime)
+		if err != nil {
+			return nil, InitOutput{}, err
+		}
 
 		traceOutput := new(bytes.Buffer)
 		ctx := runtimeCallContext(input.Preview, input.Verbosity, nil, traceOutput, traceOutput)
 		ctx.KubernetesContextPreflight = eruncommon.CloudContextPreflight(runtime.Store, eruncommon.CloudContextDependencies{})
 
 		params := eruncommon.BootstrapInitParams{
-			Tenant:                   firstNonEmpty(strings.TrimSpace(input.Tenant), strings.TrimSpace(runtime.Context.Tenant)),
+			Tenant:                   tenant,
 			SelectedTenant:           strings.TrimSpace(input.SelectedTenant),
 			InitializeCurrentProject: input.InitializeCurrentProject,
 			ProjectRoot:              firstNonEmpty(strings.TrimSpace(input.ProjectRoot), strings.TrimSpace(runtime.Context.RepoPath)),
-			Environment:              firstNonEmpty(strings.TrimSpace(input.Environment), strings.TrimSpace(runtime.Context.Environment)),
+			Environment:              environment,
 			RuntimeVersion:           firstNonEmpty(strings.TrimSpace(input.Version), CurrentBuildInfo().Version),
 			RuntimePod: eruncommon.RuntimePodResources{
 				CPU:    strings.TrimSpace(input.RuntimeCPU),

--- a/erun-mcp/tenant_scope.go
+++ b/erun-mcp/tenant_scope.go
@@ -1,0 +1,31 @@
+package erunmcp
+
+import (
+	"fmt"
+	"strings"
+)
+
+// scopedTenantEnv pins a tenant-scoped tool to this per-env MCP server's own
+// environment (#657). A per-env erun-mcp server runs in one tenant's namespace
+// and operates only on its own tenant/environment, so a caller-supplied
+// tenant/environment that differs from the pod's identity is refused rather than
+// silently honored — closing the gap where a `tenant`/`environment` argument
+// overrode the pod's own identity. Empty inputs default to the pod's identity;
+// when the pod has no identity (unconfigured/local), the caller's value is used.
+func scopedTenantEnv(inputTenant, inputEnv string, runtime RuntimeConfig) (tenant, environment string, err error) {
+	tenant = strings.TrimSpace(runtime.Context.Tenant)
+	environment = strings.TrimSpace(runtime.Context.Environment)
+	if t := strings.TrimSpace(inputTenant); t != "" && tenant != "" && t != tenant {
+		return "", "", fmt.Errorf("this MCP server is scoped to tenant %q; refusing to operate on tenant %q", tenant, t)
+	}
+	if e := strings.TrimSpace(inputEnv); e != "" && environment != "" && e != environment {
+		return "", "", fmt.Errorf("this MCP server is scoped to environment %q; refusing to operate on environment %q", environment, e)
+	}
+	if tenant == "" {
+		tenant = strings.TrimSpace(inputTenant)
+	}
+	if environment == "" {
+		environment = strings.TrimSpace(inputEnv)
+	}
+	return tenant, environment, nil
+}

--- a/erun-mcp/tenant_scope_test.go
+++ b/erun-mcp/tenant_scope_test.go
@@ -1,0 +1,37 @@
+package erunmcp
+
+import "testing"
+
+func TestScopedTenantEnv(t *testing.T) {
+	pod := RuntimeConfig{Context: RuntimeContext{Tenant: "acme", Environment: "prod"}}
+	cases := []struct {
+		name             string
+		inTenant, inEnv  string
+		runtime          RuntimeConfig
+		wantTenant, wEnv string
+		wantErr          bool
+	}{
+		{name: "empty input defaults to the pod identity", runtime: pod, wantTenant: "acme", wEnv: "prod"},
+		{name: "matching input is accepted", inTenant: "acme", inEnv: "prod", runtime: pod, wantTenant: "acme", wEnv: "prod"},
+		{name: "mismatched tenant is refused", inTenant: "evil", inEnv: "prod", runtime: pod, wantErr: true},
+		{name: "mismatched environment is refused", inTenant: "acme", inEnv: "staging", runtime: pod, wantErr: true},
+		{name: "unconfigured pod falls back to the input", inTenant: "acme", inEnv: "prod", runtime: RuntimeConfig{}, wantTenant: "acme", wEnv: "prod"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tenant, env, err := scopedTenantEnv(tc.inTenant, tc.inEnv, tc.runtime)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got tenant=%q env=%q", tenant, env)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tenant != tc.wantTenant || env != tc.wEnv {
+				t.Fatalf("got tenant=%q env=%q, want %q/%q", tenant, env, tc.wantTenant, tc.wEnv)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements the **tenant‑boundary floor** of #657 (Layer 1): a per‑env `erun-mcp` server runs in one tenant's namespace and must operate only on its own environment. Two enforcement points close the gap where a caller could name a different tenant:

1. **Middleware** — the token's resolved tenant must equal this env's tenant (`ERUN_TENANT`). A token resolving to another tenant (a misconfigured trusted‑issuer map pointing an issuer at another tenant) → `401`.
2. **Tenant‑scoped tools** (`init`, `cloud_set`, `delete`) are pinned to the pod's env via a shared `scopedTenantEnv` helper: a `tenant`/`environment` argument that differs from the pod's identity is refused, closing the gap (found while auditing #655) where `init`'s `tenant` arg overrode the pod's own identity.

## What changed

- `erun-mcp/tenant_scope.go` (new) — `scopedTenantEnv(inputTenant, inputEnv, runtime)`: defaults to the pod's identity, refuses a conflicting caller value, falls back to the caller value only when the pod is unconfigured (local).
- `erun-mcp/auth.go` — `mcpAuthConfig` gains `tenant` (from `ERUN_TENANT`); the middleware rejects a resolved tenant ≠ the pod's tenant.
- `erun-mcp/{init,cloud,delete}.go` — replace `firstNonEmpty(input.X, runtime.Context.X)` with `scopedTenantEnv`.
- `erun-docs/agent-reference/api-protocol.md` — edge spec gains the tenant‑boundary step.

## Verification (self‑run; nothing handed off)

- `erun-mcp` `go test ./...` + `golangci-lint`: green. The middleware tenant‑mismatch (`tenant mismatch → 401`) is exercised against the **real** `authHTTPMiddleware` (production HTTP handler over `httptest`, not a mock); `scopedTenantEnv` has a table test (matching / mismatched tenant / mismatched env / unconfigured‑pod fallback); env‑config parsing is covered by `TestMCPAuthConfigFromEnv`.
- `make integration-test`: green — **coverage 75.0% (≥ 75.0%)**, unchanged (erun‑mcp is not in the gate's erun‑cli/common scope).
- `cd erun-docs && yarn build`: clean.
- **No erun‑ui surface** in this change (erun‑mcp + docs only), so the Playwright suite is not applicable here; the security behavior is fully covered by the real‑middleware + helper unit tests above.

## Scope note

This delivers #657's **Layer 1** (tenant boundary). The **Layer 2** capability/scope‑gated authorization of individual tools (e.g. restricting the RCE‑capable `raw` to admin‑scoped tokens while a read‑only token sees only the read tools) is deferred to #606, which provides the role/scope source (Zitadel project roles); #657 stays open for that layer.

Builds on #655, #656. Relates #606.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
