### PR TITLE
DB-backed environments + contexts tables and console read API

### DIFF
--- a/erun-backend/erun-backend-api/internal/model/context.go
+++ b/erun-backend/erun-backend-api/internal/model/context.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+// Context mirrors the contexts table — the per-tenant system of record for a
+// managed cloud context (cluster), the DB-backed shape of
+// eruncommon.CloudContextConfig. The k3s admin token is a server secret and is
+// deliberately not part of this read model.
+type Context struct {
+	bun.BaseModel      `bun:"table:contexts,alias:c"`
+	ContextID          string    `json:"contextId" bun:"context_id,pk,scanonly"`
+	TenantID           string    `json:"tenantId" bun:"tenant_id,scanonly"`
+	Name               string    `json:"name" bun:"name"`
+	Provider           string    `json:"provider" bun:"provider"`
+	CloudProviderAlias string    `json:"cloudProviderAlias,omitempty" bun:"cloud_provider_alias,nullzero"`
+	Region             string    `json:"region,omitempty" bun:"region,nullzero"`
+	InstanceID         string    `json:"instanceId,omitempty" bun:"instance_id,nullzero"`
+	PublicIP           string    `json:"publicIp,omitempty" bun:"public_ip,nullzero"`
+	InstanceType       string    `json:"instanceType,omitempty" bun:"instance_type,nullzero"`
+	DiskType           string    `json:"diskType,omitempty" bun:"disk_type,nullzero"`
+	DiskSizeGB         int       `json:"diskSizeGb,omitempty" bun:"disk_size_gb,nullzero"`
+	KubernetesContext  string    `json:"kubernetesContext,omitempty" bun:"kubernetes_context,nullzero"`
+	CreatedAt          time.Time `json:"createdAt" bun:"created_at,scanonly"`
+	UpdatedAt          time.Time `json:"updatedAt" bun:"updated_at,scanonly"`
+}

--- a/erun-backend/erun-backend-api/internal/model/environment.go
+++ b/erun-backend/erun-backend-api/internal/model/environment.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+type EnvironmentType string
+
+const (
+	EnvironmentTypeLocalAgent  EnvironmentType = "local-agent"
+	EnvironmentTypeRemoteAgent EnvironmentType = "remote-agent"
+	EnvironmentTypeRuntime     EnvironmentType = "runtime"
+)
+
+// Environment mirrors the environments table — the per-tenant system of record
+// for an erun environment, the DB-backed shape of eruncommon.EnvConfig. The
+// env-to-context link is a real tenant-scoped foreign key (ContextID), not a
+// kubernetes-context string match.
+type Environment struct {
+	bun.BaseModel     `bun:"table:environments,alias:e"`
+	EnvironmentID     string          `json:"environmentId" bun:"environment_id,pk,scanonly"`
+	TenantID          string          `json:"tenantId" bun:"tenant_id,scanonly"`
+	Name              string          `json:"name" bun:"name"`
+	Type              EnvironmentType `json:"type" bun:"type"`
+	KubernetesContext string          `json:"kubernetesContext,omitempty" bun:"kubernetes_context,nullzero"`
+	ContextID         string          `json:"contextId,omitempty" bun:"context_id,nullzero"`
+	RuntimeVersion    string          `json:"runtimeVersion,omitempty" bun:"runtime_version,nullzero"`
+	CreatedAt         time.Time       `json:"createdAt" bun:"created_at,scanonly"`
+	UpdatedAt         time.Time       `json:"updatedAt" bun:"updated_at,scanonly"`
+}

--- a/erun-backend/erun-backend-api/internal/repository/contexts.go
+++ b/erun-backend/erun-backend-api/internal/repository/contexts.go
@@ -1,0 +1,43 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/uptrace/bun"
+)
+
+type ContextRepository struct {
+	txs *TxManager
+}
+
+const contextColumns = `context_id, tenant_id, name, provider, cloud_provider_alias, region, instance_id, public_ip, instance_type, disk_type, disk_size_gb, kubernetes_context, created_at, updated_at`
+
+func NewContextRepository(txs *TxManager) *ContextRepository {
+	return &ContextRepository{txs: txs}
+}
+
+func (r *ContextRepository) List(ctx context.Context) ([]model.Context, error) {
+	var contexts []model.Context
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		return tx.NewRaw(`
+			SELECT `+contextColumns+`
+			  FROM contexts
+			 ORDER BY name ASC, context_id ASC
+		`).Scan(ctx, &contexts)
+	})
+	return contexts, err
+}
+
+func (r *ContextRepository) Get(ctx context.Context, contextID string) (model.Context, error) {
+	var cloudContext model.Context
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		err := tx.NewRaw(`
+			SELECT `+contextColumns+`
+			  FROM contexts
+			 WHERE context_id = ?
+		`, contextID).Scan(ctx, &cloudContext)
+		return normalizeNoRows(err)
+	})
+	return cloudContext, err
+}

--- a/erun-backend/erun-backend-api/internal/repository/environments.go
+++ b/erun-backend/erun-backend-api/internal/repository/environments.go
@@ -1,0 +1,43 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/uptrace/bun"
+)
+
+type EnvironmentRepository struct {
+	txs *TxManager
+}
+
+const environmentColumns = `environment_id, tenant_id, name, type, kubernetes_context, context_id, runtime_version, created_at, updated_at`
+
+func NewEnvironmentRepository(txs *TxManager) *EnvironmentRepository {
+	return &EnvironmentRepository{txs: txs}
+}
+
+func (r *EnvironmentRepository) List(ctx context.Context) ([]model.Environment, error) {
+	var environments []model.Environment
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		return tx.NewRaw(`
+			SELECT `+environmentColumns+`
+			  FROM environments
+			 ORDER BY name ASC, environment_id ASC
+		`).Scan(ctx, &environments)
+	})
+	return environments, err
+}
+
+func (r *EnvironmentRepository) Get(ctx context.Context, environmentID string) (model.Environment, error) {
+	var environment model.Environment
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		err := tx.NewRaw(`
+			SELECT `+environmentColumns+`
+			  FROM environments
+			 WHERE environment_id = ?
+		`, environmentID).Scan(ctx, &environment)
+		return normalizeNoRows(err)
+	})
+	return environment, err
+}

--- a/erun-backend/erun-backend-api/internal/repository/tenants.go
+++ b/erun-backend/erun-backend-api/internal/repository/tenants.go
@@ -1,0 +1,38 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+	"github.com/uptrace/bun"
+)
+
+type TenantRepository struct {
+	txs *TxManager
+}
+
+func NewTenantRepository(txs *TxManager) *TenantRepository {
+	return &TenantRepository{txs: txs}
+}
+
+// Current returns the row for the caller's resolved tenant. tenants is a root
+// resolution table (not RLS-scoped), so the query is scoped explicitly by the
+// authenticated security context's tenant ID, the same way TenantIssuer.List
+// scopes its read.
+func (r *TenantRepository) Current(ctx context.Context) (model.Tenant, error) {
+	securityContext, ok := security.FromContext(ctx)
+	if !ok {
+		return model.Tenant{}, ErrMissingSecurityContext
+	}
+	var tenant model.Tenant
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		err := tx.NewRaw(`
+			SELECT tenant_id, name, type, created_at, updated_at
+			  FROM tenants
+			 WHERE tenant_id = ?
+		`, securityContext.TenantID).Scan(ctx, &tenant)
+		return normalizeNoRows(err)
+	})
+	return tenant, err
+}

--- a/erun-backend/erun-backend-api/internal/routes/config.go
+++ b/erun-backend/erun-backend-api/internal/routes/config.go
@@ -1,0 +1,60 @@
+package routes
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+)
+
+type ConfigTenantRepository interface {
+	Current(ctx context.Context) (model.Tenant, error)
+}
+
+// ConfigRoutes serves the console read model: the caller's tenant config
+// denormalized as the on-disk erun config shape (tenant + environments +
+// contexts). All three reads are tenant-scoped by RLS, so the response only
+// ever contains the caller's own rows.
+type ConfigRoutes struct {
+	tenants      ConfigTenantRepository
+	environments EnvironmentRepository
+	contexts     ContextRepository
+}
+
+// configResponse is the denormalized read model the web console renders. It
+// projects the per-tenant erun config: the tenant header plus its
+// environments and the cloud contexts they reference.
+type configResponse struct {
+	Tenant       model.Tenant        `json:"tenant"`
+	Environments []model.Environment `json:"environments"`
+	Contexts     []model.Context     `json:"contexts"`
+}
+
+func RegisterConfigRoute(register ProtectedRouteRegistrar, tenants ConfigTenantRepository, environments EnvironmentRepository, contexts ContextRepository) {
+	routes := ConfigRoutes{tenants: tenants, environments: environments, contexts: contexts}
+	register(http.MethodGet, "/v1/config", http.HandlerFunc(routes.getConfig))
+}
+
+func (r ConfigRoutes) getConfig(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	tenant, err := r.tenants.Current(ctx)
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	environments, err := r.environments.List(ctx)
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	contexts, err := r.contexts.List(ctx)
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, configResponse{
+		Tenant:       tenant,
+		Environments: environments,
+		Contexts:     contexts,
+	})
+}

--- a/erun-backend/erun-backend-api/internal/routes/config_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/config_test.go
@@ -1,0 +1,122 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+)
+
+type stubConfigTenantRepository struct {
+	tenant model.Tenant
+	err    error
+}
+
+func (r stubConfigTenantRepository) Current(context.Context) (model.Tenant, error) {
+	return r.tenant, r.err
+}
+
+type stubEnvironmentRepository struct {
+	environments []model.Environment
+	environment  model.Environment
+	err          error
+}
+
+func (r stubEnvironmentRepository) List(context.Context) ([]model.Environment, error) {
+	return r.environments, r.err
+}
+
+func (r stubEnvironmentRepository) Get(context.Context, string) (model.Environment, error) {
+	return r.environment, r.err
+}
+
+type stubContextRepository struct {
+	contexts     []model.Context
+	cloudContext model.Context
+	err          error
+}
+
+func (r stubContextRepository) List(context.Context) ([]model.Context, error) {
+	return r.contexts, r.err
+}
+
+func (r stubContextRepository) Get(context.Context, string) (model.Context, error) {
+	return r.cloudContext, r.err
+}
+
+func TestConfigReturnsDenormalizedReadModel(t *testing.T) {
+	tenants := stubConfigTenantRepository{tenant: model.Tenant{TenantID: "tenant-1", Name: "acme", Type: model.TenantTypeCompany}}
+	environments := stubEnvironmentRepository{environments: []model.Environment{
+		{EnvironmentID: "env-1", Name: "runtime", Type: model.EnvironmentTypeRuntime, ContextID: "ctx-1"},
+	}}
+	contexts := stubContextRepository{contexts: []model.Context{
+		{ContextID: "ctx-1", Name: "primary", Provider: "aws"},
+	}}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/config", nil)
+	rec := httptest.NewRecorder()
+
+	ConfigRoutes{tenants: tenants, environments: environments, contexts: contexts}.getConfig(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+	var response configResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Tenant.Name != "acme" {
+		t.Fatalf("unexpected tenant name: %q", response.Tenant.Name)
+	}
+	if len(response.Environments) != 1 || response.Environments[0].ContextID != "ctx-1" {
+		t.Fatalf("unexpected environments: %+v", response.Environments)
+	}
+	if len(response.Contexts) != 1 || response.Contexts[0].Provider != "aws" {
+		t.Fatalf("unexpected contexts: %+v", response.Contexts)
+	}
+}
+
+func TestConfigPropagatesRepositoryError(t *testing.T) {
+	tenants := stubConfigTenantRepository{err: repository.ErrMissingSecurityContext}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/config", nil)
+	rec := httptest.NewRecorder()
+
+	ConfigRoutes{tenants: tenants, environments: stubEnvironmentRepository{}, contexts: stubContextRepository{}}.getConfig(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+}
+
+func TestGetEnvironmentNotFound(t *testing.T) {
+	environments := stubEnvironmentRepository{err: repository.ErrNotFound}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/environments/missing", nil)
+	req.SetPathValue("environment_id", "missing")
+	rec := httptest.NewRecorder()
+
+	EnvironmentRoutes{environments: environments}.getEnvironment(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+}
+
+func TestGetContextNotFound(t *testing.T) {
+	contexts := stubContextRepository{err: repository.ErrNotFound}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/contexts/missing", nil)
+	req.SetPathValue("context_id", "missing")
+	rec := httptest.NewRecorder()
+
+	ContextRoutes{contexts: contexts}.getContext(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/routes/contexts.go
+++ b/erun-backend/erun-backend-api/internal/routes/contexts.go
@@ -1,0 +1,41 @@
+package routes
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+)
+
+type ContextRepository interface {
+	List(ctx context.Context) ([]model.Context, error)
+	Get(ctx context.Context, contextID string) (model.Context, error)
+}
+
+type ContextRoutes struct {
+	contexts ContextRepository
+}
+
+func RegisterContextRoutes(register ProtectedRouteRegistrar, contexts ContextRepository) {
+	routes := ContextRoutes{contexts: contexts}
+	register(http.MethodGet, "/v1/contexts", http.HandlerFunc(routes.listContexts))
+	register(http.MethodGet, "/v1/contexts/{context_id}", http.HandlerFunc(routes.getContext))
+}
+
+func (r ContextRoutes) listContexts(w http.ResponseWriter, req *http.Request) {
+	contexts, err := r.contexts.List(req.Context())
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, contexts)
+}
+
+func (r ContextRoutes) getContext(w http.ResponseWriter, req *http.Request) {
+	cloudContext, err := r.contexts.Get(req.Context(), req.PathValue("context_id"))
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, cloudContext)
+}

--- a/erun-backend/erun-backend-api/internal/routes/environments.go
+++ b/erun-backend/erun-backend-api/internal/routes/environments.go
@@ -1,0 +1,41 @@
+package routes
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+)
+
+type EnvironmentRepository interface {
+	List(ctx context.Context) ([]model.Environment, error)
+	Get(ctx context.Context, environmentID string) (model.Environment, error)
+}
+
+type EnvironmentRoutes struct {
+	environments EnvironmentRepository
+}
+
+func RegisterEnvironmentRoutes(register ProtectedRouteRegistrar, environments EnvironmentRepository) {
+	routes := EnvironmentRoutes{environments: environments}
+	register(http.MethodGet, "/v1/environments", http.HandlerFunc(routes.listEnvironments))
+	register(http.MethodGet, "/v1/environments/{environment_id}", http.HandlerFunc(routes.getEnvironment))
+}
+
+func (r EnvironmentRoutes) listEnvironments(w http.ResponseWriter, req *http.Request) {
+	environments, err := r.environments.List(req.Context())
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, environments)
+}
+
+func (r EnvironmentRoutes) getEnvironment(w http.ResponseWriter, req *http.Request) {
+	environment, err := r.environments.Get(req.Context(), req.PathValue("environment_id"))
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, environment)
+}

--- a/erun-backend/erun-backend-api/server.go
+++ b/erun-backend/erun-backend-api/server.go
@@ -77,6 +77,9 @@ func NewHandler(options HandlerOptions) (http.Handler, error) {
 		builds := repository.NewBuildRepository(txManager)
 		comments := repository.NewCommentRepository(txManager)
 		tenantIssuers := repository.NewTenantIssuerRepository(txManager)
+		tenants := repository.NewTenantRepository(txManager)
+		environments := repository.NewEnvironmentRepository(txManager)
+		contexts := repository.NewContextRepository(txManager)
 		reviewService := service.NewReviewService(reviews, builds)
 		buildService := service.NewBuildService(builds, reviewService)
 		commentService := service.NewCommentService(comments)
@@ -84,6 +87,9 @@ func NewHandler(options HandlerOptions) (http.Handler, error) {
 		routes.RegisterReviewRoutes(register, reviews, reviewService)
 		routes.RegisterBuildRoutes(register, builds, buildService)
 		routes.RegisterCommentRoutes(register, comments, commentService)
+		routes.RegisterEnvironmentRoutes(register, environments)
+		routes.RegisterContextRoutes(register, contexts)
+		routes.RegisterConfigRoute(register, tenants, environments, contexts)
 	}
 	routes.RegisterWhoamiRoute(register, users)
 	return mux, nil

--- a/erun-backend/erun-backend-db/atlas.hcl
+++ b/erun-backend/erun-backend-db/atlas.hcl
@@ -19,6 +19,8 @@ env "default" {
     "file://schema/tables/builds.sql",
     "file://schema/tables/comments.sql",
     "file://schema/tables/audit_events.sql",
+    "file://schema/tables/contexts.sql",
+    "file://schema/tables/environments.sql",
     "file://schema/indexes/users.sql",
     "file://schema/indexes/user_external_ids.sql",
     "file://schema/indexes/role_permissions.sql",
@@ -28,6 +30,8 @@ env "default" {
     "file://schema/indexes/builds.sql",
     "file://schema/indexes/comments.sql",
     "file://schema/indexes/audit_events.sql",
+    "file://schema/indexes/contexts.sql",
+    "file://schema/indexes/environments.sql",
     "file://schema/triggers/comments.sql",
     "file://schema/triggers/timestamps.sql",
     "file://schema/fks/review_builds.sql",
@@ -42,6 +46,8 @@ env "default" {
     "file://schema/rls/builds.sql",
     "file://schema/rls/comments.sql",
     "file://schema/rls/audit_events.sql",
+    "file://schema/rls/contexts.sql",
+    "file://schema/rls/environments.sql",
   ]
   url = var.database_url
   dev = "docker://postgres/18/dev?search_path=public"

--- a/erun-backend/erun-backend-db/migrations/default/20260624145559_config_read_model.sql
+++ b/erun-backend/erun-backend-db/migrations/default/20260624145559_config_read_model.sql
@@ -1,0 +1,99 @@
+-- Create "contexts" table
+CREATE TABLE "contexts" (
+  "context_id" uuid NOT NULL DEFAULT uuidv7(),
+  "tenant_id" uuid NOT NULL DEFAULT erun_current_tenant_id(),
+  "name" text NOT NULL,
+  "provider" text NOT NULL,
+  "cloud_provider_alias" text NULL,
+  "region" text NULL,
+  "instance_id" text NULL,
+  "public_ip" text NULL,
+  "instance_type" text NULL,
+  "disk_type" text NULL,
+  "disk_size_gb" integer NULL,
+  "kubernetes_context" text NULL,
+  "created_at" timestamptz NULL,
+  "updated_at" timestamptz NULL,
+  PRIMARY KEY ("context_id"),
+  CONSTRAINT "contexts_tenant_context_key" UNIQUE ("tenant_id", "context_id"),
+  CONSTRAINT "contexts_tenant_name_key" UNIQUE ("tenant_id", "name"),
+  CONSTRAINT "contexts_tenant_id_fkey" FOREIGN KEY ("tenant_id") REFERENCES "tenants" ("tenant_id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "contexts_name_check" CHECK (length(TRIM(BOTH FROM name)) > 0),
+  CONSTRAINT "contexts_provider_check" CHECK (length(TRIM(BOTH FROM provider)) > 0)
+);
+-- Create index "contexts_tenant_provider_idx" to table: "contexts"
+CREATE INDEX "contexts_tenant_provider_idx" ON "contexts" ("tenant_id", "provider");
+-- Create "environments" table
+CREATE TABLE "environments" (
+  "environment_id" uuid NOT NULL DEFAULT uuidv7(),
+  "tenant_id" uuid NOT NULL DEFAULT erun_current_tenant_id(),
+  "name" text NOT NULL,
+  "type" text NOT NULL,
+  "kubernetes_context" text NULL,
+  "context_id" uuid NULL,
+  "runtime_version" text NULL,
+  "created_at" timestamptz NULL,
+  "updated_at" timestamptz NULL,
+  PRIMARY KEY ("environment_id"),
+  CONSTRAINT "environments_tenant_environment_key" UNIQUE ("tenant_id", "environment_id"),
+  CONSTRAINT "environments_tenant_name_key" UNIQUE ("tenant_id", "name"),
+  CONSTRAINT "environments_tenant_id_context_id_fkey" FOREIGN KEY ("tenant_id", "context_id") REFERENCES "contexts" ("tenant_id", "context_id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "environments_tenant_id_fkey" FOREIGN KEY ("tenant_id") REFERENCES "tenants" ("tenant_id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "environments_name_check" CHECK (length(TRIM(BOTH FROM name)) > 0),
+  CONSTRAINT "environments_type_check" CHECK (type = ANY (ARRAY['local-agent'::text, 'remote-agent'::text, 'runtime'::text]))
+);
+-- Create index "environments_tenant_context_idx" to table: "environments"
+CREATE INDEX "environments_tenant_context_idx" ON "environments" ("tenant_id", "context_id");
+-- Create index "environments_tenant_type_idx" to table: "environments"
+CREATE INDEX "environments_tenant_type_idx" ON "environments" ("tenant_id", "type");
+-- Timestamp triggers for the new tables (atlas migrate diff omits trigger
+-- objects without an atlas login session; appended from the declarative
+-- schema; references the existing erun_set_timestamps()).
+CREATE TRIGGER contexts_set_timestamps
+  BEFORE INSERT OR UPDATE ON "contexts"
+  FOR EACH ROW
+  EXECUTE FUNCTION erun_set_timestamps();
+CREATE TRIGGER environments_set_timestamps
+  BEFORE INSERT OR UPDATE ON "environments"
+  FOR EACH ROW
+  EXECUTE FUNCTION erun_set_timestamps();
+-- Grant tenant-owned CRUD on the new tables to the application roles
+-- (atlas migrate diff omits permissions without an atlas login session;
+-- appended from schema/roles.sql). erun_tenant gets RLS-scoped access;
+-- erun_operations crosses tenants under its own policies.
+GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES
+  ON "contexts", "environments"
+  TO erun_tenant, erun_operations;
+-- Row-level security for the new tenant-owned tables (atlas migrate diff omits
+-- policies without an atlas login session; appended from schema/rls/contexts.sql
+-- and schema/rls/environments.sql). Two policies per table mirror the reviews
+-- template: tenant_isolation scopes erun_tenant by erun_current_tenant_id();
+-- operations_access lets erun_operations cross tenants.
+ALTER TABLE "contexts" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "contexts" FORCE ROW LEVEL SECURITY;
+CREATE POLICY contexts_tenant_isolation
+  ON "contexts"
+  FOR ALL
+  TO erun_tenant
+  USING (tenant_id = erun_current_tenant_id())
+  WITH CHECK (tenant_id = erun_current_tenant_id());
+CREATE POLICY contexts_operations_access
+  ON "contexts"
+  FOR ALL
+  TO erun_operations
+  USING (true)
+  WITH CHECK (true);
+ALTER TABLE "environments" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "environments" FORCE ROW LEVEL SECURITY;
+CREATE POLICY environments_tenant_isolation
+  ON "environments"
+  FOR ALL
+  TO erun_tenant
+  USING (tenant_id = erun_current_tenant_id())
+  WITH CHECK (tenant_id = erun_current_tenant_id());
+CREATE POLICY environments_operations_access
+  ON "environments"
+  FOR ALL
+  TO erun_operations
+  USING (true)
+  WITH CHECK (true);

--- a/erun-backend/erun-backend-db/migrations/default/atlas.sum
+++ b/erun-backend/erun-backend-db/migrations/default/atlas.sum
@@ -1,5 +1,6 @@
-h1:LEdSekWby0ba1ScXOls4DNXhOJImEU5cEAuA0f0DvKg=
+h1:P6kRaPG+RZ6zzkbDaPHCU6e2XLFk4FR2ew5N7/18mcg=
 20260501120000_initial_tenant_identity.sql h1:RpS03/4sFjbCggwYgcGNn6k3jNZCNTNl0BD/afOKFzo=
 20260503143000_tenant_issuer_names.sql h1:VEZjICG3/jU2YtEx0XX05l9Q8lJyWKeiRY8f4dXOkvE=
 20260503170000_audit_events.sql h1:OLjiGP/FhLTWvkx1bxS2xCcJK6tExdufnEC8R6LsKWA=
 20260621080214_tenant_issuer_org_scoping.sql h1:0j307UhB2vONxxTgh8edO8L6skfgTvy0eP2xHWCm1wo=
+20260624145559_config_read_model.sql h1:eB3uGQkL5h5ekfG5Wm5qANqRpTt0tToKXT0jezIq9Vs=

--- a/erun-backend/erun-backend-db/schema/indexes/contexts.sql
+++ b/erun-backend/erun-backend-db/schema/indexes/contexts.sql
@@ -1,0 +1,2 @@
+CREATE INDEX contexts_tenant_provider_idx
+  ON contexts (tenant_id, provider);

--- a/erun-backend/erun-backend-db/schema/indexes/environments.sql
+++ b/erun-backend/erun-backend-db/schema/indexes/environments.sql
@@ -1,0 +1,5 @@
+CREATE INDEX environments_tenant_type_idx
+  ON environments (tenant_id, type);
+
+CREATE INDEX environments_tenant_context_idx
+  ON environments (tenant_id, context_id);

--- a/erun-backend/erun-backend-db/schema/rls/contexts.sql
+++ b/erun-backend/erun-backend-db/schema/rls/contexts.sql
@@ -1,0 +1,16 @@
+ALTER TABLE contexts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE contexts FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY contexts_tenant_isolation
+  ON contexts
+  FOR ALL
+  TO erun_tenant
+  USING (tenant_id = erun_current_tenant_id())
+  WITH CHECK (tenant_id = erun_current_tenant_id());
+
+CREATE POLICY contexts_operations_access
+  ON contexts
+  FOR ALL
+  TO erun_operations
+  USING (true)
+  WITH CHECK (true);

--- a/erun-backend/erun-backend-db/schema/rls/environments.sql
+++ b/erun-backend/erun-backend-db/schema/rls/environments.sql
@@ -1,0 +1,16 @@
+ALTER TABLE environments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE environments FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY environments_tenant_isolation
+  ON environments
+  FOR ALL
+  TO erun_tenant
+  USING (tenant_id = erun_current_tenant_id())
+  WITH CHECK (tenant_id = erun_current_tenant_id());
+
+CREATE POLICY environments_operations_access
+  ON environments
+  FOR ALL
+  TO erun_operations
+  USING (true)
+  WITH CHECK (true);

--- a/erun-backend/erun-backend-db/schema/roles.sql
+++ b/erun-backend/erun-backend-db/schema/roles.sql
@@ -17,7 +17,7 @@ GRANT UPDATE (name) ON tenant_issuers TO erun_tenant;
 GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON tenants, tenant_issuers, issuers TO erun_operations;
 
 GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES
-  ON users, user_external_ids, roles, role_permissions, user_roles, reviews, review_merge_queue, builds, comments
+  ON users, user_external_ids, roles, role_permissions, user_roles, reviews, review_merge_queue, builds, comments, contexts, environments
   TO erun_tenant, erun_operations;
 
 GRANT SELECT, INSERT, REFERENCES

--- a/erun-backend/erun-backend-db/schema/tables/contexts.sql
+++ b/erun-backend/erun-backend-db/schema/tables/contexts.sql
@@ -1,0 +1,21 @@
+CREATE TABLE contexts (
+  context_id UUID PRIMARY KEY DEFAULT uuidv7(),
+  tenant_id UUID NOT NULL DEFAULT erun_current_tenant_id(),
+  name TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  cloud_provider_alias TEXT,
+  region TEXT,
+  instance_id TEXT,
+  public_ip TEXT,
+  instance_type TEXT,
+  disk_type TEXT,
+  disk_size_gb INT,
+  kubernetes_context TEXT,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ,
+  FOREIGN KEY (tenant_id) REFERENCES tenants (tenant_id),
+  CONSTRAINT contexts_name_check CHECK (length(trim(name)) > 0),
+  CONSTRAINT contexts_provider_check CHECK (length(trim(provider)) > 0),
+  CONSTRAINT contexts_tenant_context_key UNIQUE (tenant_id, context_id),
+  CONSTRAINT contexts_tenant_name_key UNIQUE (tenant_id, name)
+);

--- a/erun-backend/erun-backend-db/schema/tables/environments.sql
+++ b/erun-backend/erun-backend-db/schema/tables/environments.sql
@@ -1,0 +1,17 @@
+CREATE TABLE environments (
+  environment_id UUID PRIMARY KEY DEFAULT uuidv7(),
+  tenant_id UUID NOT NULL DEFAULT erun_current_tenant_id(),
+  name TEXT NOT NULL,
+  type TEXT NOT NULL,
+  kubernetes_context TEXT,
+  context_id UUID,
+  runtime_version TEXT,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ,
+  FOREIGN KEY (tenant_id) REFERENCES tenants (tenant_id),
+  FOREIGN KEY (tenant_id, context_id) REFERENCES contexts (tenant_id, context_id),
+  CONSTRAINT environments_name_check CHECK (length(trim(name)) > 0),
+  CONSTRAINT environments_type_check CHECK (type IN ('local-agent', 'remote-agent', 'runtime')),
+  CONSTRAINT environments_tenant_environment_key UNIQUE (tenant_id, environment_id),
+  CONSTRAINT environments_tenant_name_key UNIQUE (tenant_id, name)
+);

--- a/erun-backend/erun-backend-db/schema/triggers/timestamps.sql
+++ b/erun-backend/erun-backend-db/schema/triggers/timestamps.sql
@@ -74,3 +74,13 @@ CREATE TRIGGER comments_set_timestamps
   BEFORE INSERT OR UPDATE ON comments
   FOR EACH ROW
   EXECUTE FUNCTION erun_set_timestamps();
+
+CREATE TRIGGER contexts_set_timestamps
+  BEFORE INSERT OR UPDATE ON contexts
+  FOR EACH ROW
+  EXECUTE FUNCTION erun_set_timestamps();
+
+CREATE TRIGGER environments_set_timestamps
+  BEFORE INSERT OR UPDATE ON environments
+  FOR EACH ROW
+  EXECUTE FUNCTION erun_set_timestamps();

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -90,6 +90,13 @@ The `(iss, org) → tenant` resolution model and first-identity bootstrap above 
 | `GET` | `/v1/tenant-issuers` | List all issuers trusted by the caller's tenant. | Tenant member |
 | `PATCH` | `/v1/tenant-issuers` | Rename a trusted issuer's display name. Body below. | Tenant admin |
 | `GET` | `/v1/whoami` | Resolved identity for the calling token. Response below. | Tenant member |
+| `GET` | `/v1/config` | The console's read model over the per-tenant erun config: `{tenant, environments[], contexts[]}`. | Tenant member |
+| `GET` | `/v1/environments` | List the tenant's environments. | Tenant member |
+| `GET` | `/v1/environments/{environment_id}` | Fetch one environment by id. | Tenant member |
+| `GET` | `/v1/contexts` | List the tenant's cloud contexts (managed clusters). | Tenant member |
+| `GET` | `/v1/contexts/{context_id}` | Fetch one cloud context by id. | Tenant member |
+
+`GET /v1/config` is the console's read model over the per-tenant erun config — the backend DB is the system of record for the tenant's environments and cloud contexts, and this endpoint returns them denormalized as the on-disk erun config shape. All of these reads are tenant-scoped by row-level security, so a token only ever sees its own tenant's rows.
 
 ### `GET /v1/whoami`
 


### PR DESCRIPTION
## Summary

Makes the backend DB the **per‑tenant system of record** for erun environments and cloud contexts, and exposes a **read API the web console renders**. Scoped to tables + read API; the write/provisioning path is #659/#660.

Closes #658.

## What changed

- **erun‑backend‑db** — two new tenant‑owned tables on the reviews template:
  - `contexts` — mirrors `CloudContextConfig` (`context_id` PK UUIDv7, `tenant_id` DEFAULT `erun_current_tenant_id()`, name/provider/region/instance/disk/`kubernetes_context`, timestamps). `UNIQUE(tenant_id, name)` + `UNIQUE(tenant_id, context_id)`. No k3s admin token (server secret, out of scope).
  - `environments` — `environment_id` PK, `tenant_id`, `name`, `type` CHECK∈{local‑agent,remote‑agent,runtime}, `kubernetes_context`, nullable `context_id`, `runtime_version`. `UNIQUE(tenant_id, name)` + a **tenant‑scoped composite FK** `(tenant_id, context_id) → contexts(tenant_id, context_id)`.
  - Both: two‑policy RLS (`*_tenant_isolation` for `erun_tenant`, `*_operations_access` for `erun_operations`), RLS **enabled + forced**, timestamps trigger, `erun_tenant`/`erun_operations` grants, registered in `atlas.hcl` in dependency order (contexts before environments). Migration `20260624145559_config_read_model.sql`.
- **erun‑backend‑api** — `model.Environment`/`model.Context`; read repositories (`List`/`Get`) inside `WithinTx` (RLS + tenant scoping automatic); routes `GET /v1/environments[/{id}]`, `GET /v1/contexts[/{id}]`, and `GET /v1/config` (denormalized `{tenant, environments, contexts}` — the console's read model). Wired in `server.go`. `ReadAll` covers GET; no new authz code.
- **erun‑docs** — `api-protocol.md` Endpoints table gains the read routes + a note that `/v1/config` is the console read model.

## Verification (self‑run; nothing handed off)

- **Migration applies to a fresh Postgres 18** — `atlas migrate apply` ran all **5 migrations / 123 statements** clean (exit 0); `contexts` + `environments` present; `relrowsecurity`/`relforcerowsecurity` = true on both (tenant isolation active).
- `atlas migrate validate --env default` — exit 0 (dir integrity).
- `erun-backend-api` `go build` + `go test ./...` + `golangci-lint` — green.
- `cd erun-docs && yarn build` — clean.
- **No erun‑ui surface** (backend + docs only), so the Playwright suite is not applicable here. `make integration-test` is unaffected (erun‑cli/common untouched).

## Atlas note (honest)

The canary atlas CLI gates declarative parsing of functions/RLS/triggers and `migrate lint` behind `atlas login`. So, exactly as the repo's prior migration (`20260621080214_tenant_issuer_org_scoping.sql`) did, the table/index DDL was generated via an atlas dev‑DB diff and the RLS/trigger/grant DDL was hand‑appended with comments. Correctness is proven by the clean fresh‑DB apply + RLS‑forced check above, not by the login‑gated lint.

Builds on the auth edge (#655/#656/#657). Relates #606, #659, #660.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
