### PR TITLE
Authorized POST /v1/contexts: register a context + bootstrap plan (#659 verifiable surface)

### DIFF
--- a/erun-backend/erun-backend-api/internal/repository/contexts.go
+++ b/erun-backend/erun-backend-api/internal/repository/contexts.go
@@ -17,6 +17,23 @@ func NewContextRepository(txs *TxManager) *ContextRepository {
 	return &ContextRepository{txs: txs}
 }
 
+// Create inserts a new cloud context for the caller's tenant and returns the
+// persisted row. Only the operator-authored columns are written; context_id,
+// tenant_id, and the timestamps are owned by the database (the tenant_id
+// DEFAULT + RLS bind the row to the caller's tenant automatically), so they are
+// excluded from the Column list and populated by Returning("*").
+func (r *ContextRepository) Create(ctx context.Context, cloudContext model.Context) (model.Context, error) {
+	created := cloudContext
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		return tx.NewInsert().
+			Model(&created).
+			Column("name", "provider", "cloud_provider_alias", "region", "instance_type", "disk_type", "disk_size_gb", "kubernetes_context").
+			Returning("*").
+			Scan(ctx)
+	})
+	return created, err
+}
+
 func (r *ContextRepository) List(ctx context.Context) ([]model.Context, error) {
 	var contexts []model.Context
 	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {

--- a/erun-backend/erun-backend-api/internal/routes/config_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/config_test.go
@@ -37,15 +37,30 @@ func (r stubEnvironmentRepository) Get(context.Context, string) (model.Environme
 type stubContextRepository struct {
 	contexts     []model.Context
 	cloudContext model.Context
+	created      model.Context
+	createCalls  int
 	err          error
 }
 
-func (r stubContextRepository) List(context.Context) ([]model.Context, error) {
+func (r *stubContextRepository) List(context.Context) ([]model.Context, error) {
 	return r.contexts, r.err
 }
 
-func (r stubContextRepository) Get(context.Context, string) (model.Context, error) {
+func (r *stubContextRepository) Get(context.Context, string) (model.Context, error) {
 	return r.cloudContext, r.err
+}
+
+func (r *stubContextRepository) Create(_ context.Context, cloudContext model.Context) (model.Context, error) {
+	r.createCalls++
+	if r.err != nil {
+		return model.Context{}, r.err
+	}
+	created := r.created
+	if created.ContextID == "" {
+		created = cloudContext
+		created.ContextID = "ctx-created"
+	}
+	return created, nil
 }
 
 func TestConfigReturnsDenormalizedReadModel(t *testing.T) {
@@ -53,7 +68,7 @@ func TestConfigReturnsDenormalizedReadModel(t *testing.T) {
 	environments := stubEnvironmentRepository{environments: []model.Environment{
 		{EnvironmentID: "env-1", Name: "runtime", Type: model.EnvironmentTypeRuntime, ContextID: "ctx-1"},
 	}}
-	contexts := stubContextRepository{contexts: []model.Context{
+	contexts := &stubContextRepository{contexts: []model.Context{
 		{ContextID: "ctx-1", Name: "primary", Provider: "aws"},
 	}}
 
@@ -86,7 +101,7 @@ func TestConfigPropagatesRepositoryError(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/v1/config", nil)
 	rec := httptest.NewRecorder()
 
-	ConfigRoutes{tenants: tenants, environments: stubEnvironmentRepository{}, contexts: stubContextRepository{}}.getConfig(rec, req)
+	ConfigRoutes{tenants: tenants, environments: stubEnvironmentRepository{}, contexts: &stubContextRepository{}}.getConfig(rec, req)
 
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("unexpected status: %d", rec.Code)
@@ -108,7 +123,7 @@ func TestGetEnvironmentNotFound(t *testing.T) {
 }
 
 func TestGetContextNotFound(t *testing.T) {
-	contexts := stubContextRepository{err: repository.ErrNotFound}
+	contexts := &stubContextRepository{err: repository.ErrNotFound}
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/contexts/missing", nil)
 	req.SetPathValue("context_id", "missing")

--- a/erun-backend/erun-backend-api/internal/routes/contexts.go
+++ b/erun-backend/erun-backend-api/internal/routes/contexts.go
@@ -1,24 +1,52 @@
 package routes
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"net/http"
+	"strings"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	eruncommon "github.com/sophium/erun/erun-common"
 )
 
 type ContextRepository interface {
 	List(ctx context.Context) ([]model.Context, error)
 	Get(ctx context.Context, contextID string) (model.Context, error)
+	Create(ctx context.Context, cloudContext model.Context) (model.Context, error)
 }
 
 type ContextRoutes struct {
 	contexts ContextRepository
 }
 
+// createContextRequest is the BYO-cloud registration body: the operator-authored
+// fields needed to bootstrap a managed cluster (cloud context) via the tenant's
+// AWS alias. preview=true returns the bootstrap plan only, with no DB write and
+// no execution.
+type createContextRequest struct {
+	Name               string `json:"name"`
+	CloudProviderAlias string `json:"cloudProviderAlias"`
+	Region             string `json:"region"`
+	InstanceType       string `json:"instanceType"`
+	DiskType           string `json:"diskType"`
+	DiskSizeGB         int    `json:"diskSizeGb"`
+	Preview            bool   `json:"preview"`
+}
+
+// createContextResponse pairs the persisted context row with the cluster-
+// bootstrap plan (the EC2/k3s commands the real bootstrap would run). On a
+// preview-only request Context is omitted and only Plan is returned.
+type createContextResponse struct {
+	Context *model.Context `json:"context,omitempty"`
+	Plan    []string       `json:"plan"`
+}
+
 func RegisterContextRoutes(register ProtectedRouteRegistrar, contexts ContextRepository) {
 	routes := ContextRoutes{contexts: contexts}
 	register(http.MethodGet, "/v1/contexts", http.HandlerFunc(routes.listContexts))
+	register(http.MethodPost, "/v1/contexts", http.HandlerFunc(routes.createContext))
 	register(http.MethodGet, "/v1/contexts/{context_id}", http.HandlerFunc(routes.getContext))
 }
 
@@ -38,4 +66,135 @@ func (r ContextRoutes) getContext(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, cloudContext)
+}
+
+// createContext registers a cloud context (cluster) for the caller's tenant and
+// returns the cluster-bootstrap plan. It always builds the plan via the
+// eruncommon.InitCloudContext dry-run; when preview=true it returns the plan
+// only, otherwise it persists a pending-status context row and returns
+// {context, plan}.
+func (r ContextRoutes) createContext(w http.ResponseWriter, req *http.Request) {
+	var body createContextRequest
+	if err := decodeJSON(req, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	name := strings.TrimSpace(body.Name)
+	alias := strings.TrimSpace(body.CloudProviderAlias)
+	region := strings.TrimSpace(body.Region)
+	if name == "" || alias == "" || region == "" {
+		writeError(w, http.StatusBadRequest, "name, cloudProviderAlias, and region are required")
+		return
+	}
+
+	plan, err := buildContextBootstrapPlan(body, name, alias, region)
+	if err != nil {
+		// A dry-run InitCloudContext failure here is an input-resolution error
+		// (e.g. an unsupported region/instance type), not a server fault.
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if body.Preview {
+		writeJSON(w, http.StatusOK, createContextResponse{Plan: plan})
+		return
+	}
+
+	created, err := r.contexts.Create(req.Context(), model.Context{
+		Name:               name,
+		Provider:           eruncommon.CloudProviderAWS,
+		CloudProviderAlias: alias,
+		Region:             region,
+		InstanceType:       strings.TrimSpace(body.InstanceType),
+		DiskType:           strings.TrimSpace(body.DiskType),
+		DiskSizeGB:         body.DiskSizeGB,
+		KubernetesContext:  name,
+	})
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+
+	// TODO(#659 live): execute the real bootstrap (InitCloudContext with
+	// DryRun=false + RunAWS against the tenant's alias) + custody the k3s admin
+	// token/kubeconfig server-side. Requires a live AWS account + cluster; not
+	// executed in this build. The persisted row above stands at its
+	// pending-style status (no instance_id / public_ip yet) until that real
+	// bootstrap runs and writes the resolved instance identity + token custody.
+
+	writeJSON(w, http.StatusCreated, createContextResponse{Context: &created, Plan: plan})
+}
+
+// buildContextBootstrapPlan runs eruncommon.InitCloudContext in dry-run mode and
+// returns the captured trace lines — the EC2/k3s commands the real bootstrap
+// would execute. The dry-run never reaches AWS: it is driven by an in-memory
+// CloudStore seeded with a matching AWS alias (InitCloudContext resolves the
+// provider from the store before emitting any plan) and zero-value
+// dependencies, so the helpers fall back to their deterministic dry-run output.
+func buildContextBootstrapPlan(body createContextRequest, name, alias, region string) ([]string, error) {
+	var trace bytes.Buffer
+	logger := eruncommon.NewLoggerWithWriters(eruncommon.VerbosityInfo, io.Discard, io.Discard).WithTraceSink(&trace)
+	ctx := eruncommon.Context{
+		Logger: logger,
+		DryRun: true,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	}
+
+	store := newInMemoryCloudStore(alias)
+	params := eruncommon.InitCloudContextParams{
+		Name:               name,
+		CloudProviderAlias: alias,
+		Region:             region,
+		InstanceType:       strings.TrimSpace(body.InstanceType),
+		DiskType:           strings.TrimSpace(body.DiskType),
+		DiskSizeGB:         body.DiskSizeGB,
+	}
+	// Zero-value dependencies: InitCloudContext normalizes them to its own
+	// defaults, and in DryRun the default RunAWS/RunKubectl only trace the argv
+	// (they never invoke the real CLIs).
+	if _, err := eruncommon.InitCloudContext(ctx, store, params, eruncommon.CloudContextDependencies{}); err != nil {
+		return nil, err
+	}
+	return splitTraceLines(trace.String()), nil
+}
+
+func splitTraceLines(trace string) []string {
+	lines := make([]string, 0)
+	for _, line := range strings.Split(trace, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// inMemoryCloudStore is a minimal eruncommon.CloudStore backed by an in-memory
+// ERunConfig. It exists only so the dry-run InitCloudContext can resolve the
+// caller's AWS alias and accumulate the plan without touching disk or AWS; the
+// dry-run never persists, so SaveERunConfig is retained in memory and not used.
+type inMemoryCloudStore struct {
+	config eruncommon.ERunConfig
+}
+
+func newInMemoryCloudStore(alias string) *inMemoryCloudStore {
+	return &inMemoryCloudStore{
+		config: eruncommon.ERunConfig{
+			CloudProviders: []eruncommon.CloudProviderConfig{{
+				Alias:    alias,
+				Provider: eruncommon.CloudProviderAWS,
+			}},
+		},
+	}
+}
+
+func (s *inMemoryCloudStore) LoadERunConfig() (eruncommon.ERunConfig, string, error) {
+	return s.config, "", nil
+}
+
+func (s *inMemoryCloudStore) SaveERunConfig(config eruncommon.ERunConfig) error {
+	s.config = config
+	return nil
 }

--- a/erun-backend/erun-backend-api/internal/routes/contexts_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/contexts_test.go
@@ -1,0 +1,113 @@
+package routes
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+)
+
+func postCreateContext(t *testing.T, contexts ContextRepository, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/contexts", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	ContextRoutes{contexts: contexts}.createContext(rec, req)
+	return rec
+}
+
+func TestCreateContextRejectsMissingRequiredFields(t *testing.T) {
+	cases := map[string]string{
+		"missing name":   `{"cloudProviderAlias":"aws-acme","region":"eu-west-2"}`,
+		"missing alias":  `{"name":"primary","region":"eu-west-2"}`,
+		"missing region": `{"name":"primary","cloudProviderAlias":"aws-acme"}`,
+		"empty body":     `{}`,
+	}
+	for label, body := range cases {
+		t.Run(label, func(t *testing.T) {
+			contexts := &stubContextRepository{}
+			rec := postCreateContext(t, contexts, body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("unexpected status: %d", rec.Code)
+			}
+			if contexts.createCalls != 0 {
+				t.Fatalf("Create should not run on invalid input, got %d calls", contexts.createCalls)
+			}
+		})
+	}
+}
+
+func TestCreateContextPreviewReturnsPlanWithoutPersisting(t *testing.T) {
+	contexts := &stubContextRepository{}
+	rec := postCreateContext(t, contexts, `{
+		"name": "primary",
+		"cloudProviderAlias": "aws-acme",
+		"region": "eu-west-2",
+		"preview": true
+	}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+	if contexts.createCalls != 0 {
+		t.Fatalf("preview must not call Create, got %d calls", contexts.createCalls)
+	}
+
+	var response createContextResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Context != nil {
+		t.Fatalf("preview response must omit the context, got %+v", response.Context)
+	}
+	if len(response.Plan) == 0 {
+		t.Fatalf("preview must return a non-empty bootstrap plan")
+	}
+	// The plan is the InitCloudContext dry-run trace; it must include the EC2
+	// run-instances command the real bootstrap would issue.
+	if !planContains(response.Plan, "ec2 run-instances") {
+		t.Fatalf("plan missing the EC2 run-instances step: %v", response.Plan)
+	}
+}
+
+func TestCreateContextPersistsAndReturnsPlan(t *testing.T) {
+	contexts := &stubContextRepository{created: model.Context{ContextID: "ctx-1", Name: "primary", Provider: "aws"}}
+	rec := postCreateContext(t, contexts, `{
+		"name": "primary",
+		"cloudProviderAlias": "aws-acme",
+		"region": "eu-west-2",
+		"instanceType": "c8gd.2xlarge",
+		"diskType": "gp3",
+		"diskSizeGb": 100
+	}`)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+	if contexts.createCalls != 1 {
+		t.Fatalf("expected exactly one Create call, got %d", contexts.createCalls)
+	}
+
+	var response createContextResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Context == nil || response.Context.ContextID != "ctx-1" {
+		t.Fatalf("unexpected persisted context: %+v", response.Context)
+	}
+	if len(response.Plan) == 0 {
+		t.Fatalf("non-preview create must still return the bootstrap plan")
+	}
+}
+
+func planContains(plan []string, substr string) bool {
+	for _, line := range plan {
+		if strings.Contains(line, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -94,6 +94,7 @@ The `(iss, org) → tenant` resolution model and first-identity bootstrap above 
 | `GET` | `/v1/environments` | List the tenant's environments. | Tenant member |
 | `GET` | `/v1/environments/{environment_id}` | Fetch one environment by id. | Tenant member |
 | `GET` | `/v1/contexts` | List the tenant's cloud contexts (managed clusters). | Tenant member |
+| `POST` | `/v1/contexts` | Register a cloud context (managed cluster) for the caller's tenant and return its cluster-bootstrap plan. Body below. | Tenant member (write) |
 | `GET` | `/v1/contexts/{context_id}` | Fetch one cloud context by id. | Tenant member |
 
 `GET /v1/config` is the console's read model over the per-tenant erun config — the backend DB is the system of record for the tenant's environments and cloud contexts, and this endpoint returns them denormalized as the on-disk erun config shape. All of these reads are tenant-scoped by row-level security, so a token only ever sees its own tenant's rows.
@@ -150,6 +151,67 @@ Returns the updated tenant-issuer record (`200`). `400` if `issuer` or `name` is
 ```
 
 `remove` matches by `issuerUrl`. Both arrays are optional; either may be empty.
+
+### `POST /v1/contexts`
+
+Registers a **cloud context** (a managed cluster) for the caller's tenant and returns the cluster-**bootstrap plan**. The model is **BYO-cloud**: the context bootstraps onto the tenant's own AWS account via a registered cloud-provider alias (`cloudProviderAlias`), provisioning an EC2 instance running k3s. The endpoint is tenant-scoped by row-level security — the registered row is bound to the caller's tenant automatically.
+
+```jsonc
+// POST /v1/contexts body (BYO-cloud)
+{
+  "name": "primary",            // required — the context (cluster) name; also its kubernetes context
+  "cloudProviderAlias": "aws-acme", // required — a registered AWS cloud-provider alias for the tenant
+  "region": "eu-west-2",        // required — AWS region (must be a supported region)
+  "instanceType": "c8gd.2xlarge", // optional — defaults applied server-side when empty
+  "diskType": "gp3",            // optional
+  "diskSizeGb": 100,            // optional
+  "preview": false              // optional — when true, returns the plan only (no registration)
+}
+```
+
+**The `plan`.** Every call resolves the **bootstrap plan** — the ordered EC2/k3s commands the bootstrap would run (security-group + IAM instance-profile setup, `ec2 run-instances`, the k3s install user-data, the kube-context wiring) — by running the bootstrap in **dry-run** against the tenant's alias. It is returned as an array of trace lines so the caller can preview exactly what the live bootstrap will do.
+
+- **`preview: true`** → returns `{ "plan": [ … ] }` only. Nothing is registered.
+- **`preview: false`** (default) → registers a context row at a **pending** status (no instance id / public IP yet) and returns `{ "context": { … }, "plan": [ … ] }` with HTTP `201`.
+
+```jsonc
+// 201 response (preview=false)
+{
+  "context": {
+    "contextId": "019a7fa5-c2c0-7c55-bc70-714873a71f20",
+    "tenantId": "019a7fa5-c2c0-7c55-bc70-714873a71f10",
+    "name": "primary",
+    "provider": "aws",
+    "cloudProviderAlias": "aws-acme",
+    "region": "eu-west-2",
+    "instanceType": "c8gd.2xlarge",
+    "diskType": "gp3",
+    "diskSizeGb": 100,
+    "kubernetesContext": "primary",
+    "createdAt": "2026-06-24T10:00:00Z",
+    "updatedAt": "2026-06-24T10:00:00Z"
+  },
+  "plan": [
+    "cloud-context init: alias=aws-acme region=eu-west-2 instance-type=c8gd.2xlarge disk=100GB/gp3",
+    "aws ec2 create-security-group …",
+    "aws ec2 run-instances …",
+    "kubectl config set-cluster primary …"
+  ]
+}
+```
+
+The k3s admin token is a **server secret** and is never part of the response or the context read model.
+
+**Live bootstrap execution and token custody are `(Planned.)`.** This endpoint registers the row and returns the plan; it does **not** yet execute the real (non-dry-run) EC2 + k3s bootstrap or take server-side custody of the k3s admin token / kubeconfig. Until that lands, a registered context stays at its pending status with no instance id or public IP — provisioning the live cluster from the plan is the planned follow-up, gated on the hosted platform having a live AWS path.
+
+**Error behaviour.** Today the API returns a bare HTTP status with a plain-text body (no JSON envelope):
+
+| Status | Condition | Recovery |
+|---|---|---|
+| `400` | `name`, `cloudProviderAlias`, or `region` is empty/missing, or the body is not valid JSON. | Send all three required fields. |
+| `400` | The bootstrap plan could not be resolved (e.g. an unsupported `region`, `instanceType`, or `diskSizeGb` for the BYO-cloud bootstrap). | Use a supported region/instance type/disk size. |
+| `401` / `403` | Standard auth failures (see [Errors](#errors)). The `WriteAll` permission covers `POST /v1/contexts`. | Send a valid token whose roles permit the write. |
+| `500` | Persistence failed (e.g. missing request-scoped security context — an internal wiring error, never a client fault). | Retry; if it persists, it is a server bug. |
 
 ### Service-account flow for Agents
 


### PR DESCRIPTION
## Summary

An authorized `POST /v1/contexts` that registers a cloud context for the caller's tenant and returns the cluster‑bootstrap **plan**. Decision: **BYO‑cloud** — bootstrap reuses the tenant's AWS alias via `eruncommon.InitCloudContext` (matching `erun context init` / "consistent with aws").

This delivers #659's **verifiable surface**. The live cluster bootstrap is honestly out of scope here (see below); #659 stays open for it.

## What changed
- `internal/repository/contexts.go` — `Create` (writable columns only, `Returning("*")`, inside `WithinTx`; `tenant_id`/RLS bind the row to the caller).
- `internal/routes/contexts.go` — `POST /v1/contexts`: validates `name`/`cloudProviderAlias`/`region` (→ `400`), builds the bootstrap plan from `InitCloudContext` with `DryRun=true` (captures the real EC2/IAM/k3s/kubectl argv via a trace sink + an in‑memory `CloudStore`), `preview=true` → plan only (no write), else persists a `pending` row and returns `201 {context, plan}`. Wired in `server.go`. `WriteAll` covers POST; tenant scoping automatic.
- `erun-docs/agent-reference/api-protocol.md` — `POST /v1/contexts` endpoint + request/response + Error behaviour; live bootstrap marked `(Planned.)`.

## Verification (self‑run)
- `erun-backend-api` `go build` + `go test ./...` + `golangci-lint` — green. DB‑free route test asserts: missing fields → error; `preview=true` returns a non‑empty plan (asserts it contains `ec2 run-instances`) **and does not call `Create`**; non‑preview calls `Create` once.
- `cd erun-docs && yarn build` — clean.
- No erun‑ui surface → Playwright N/A; erun‑cli/common untouched → `make integration-test` unaffected.

## Honest scope boundary (not done here)
The **live** (non‑dry‑run) EC2+k3s bootstrap and the server‑side **k3s admin‑token / kubeconfig custody** are an explicit `TODO(#659 live)` that this build does **not** execute — they require a live AWS account + a real cluster to verify, which this environment lacks, and shipping unverified security‑sensitive provisioning code would violate the project's verification bar. The persisted row stands at `pending` until that real bootstrap runs. Tracked as the live‑platform follow‑up on #659.

Builds on #655/#656/#657/#658. Relates #605, #660.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
