### PR TITLE
Authorized tenant + environment registration API (#660 verifiable surface)

### DIFF
--- a/erun-backend/erun-backend-api/internal/repository/environments.go
+++ b/erun-backend/erun-backend-api/internal/repository/environments.go
@@ -17,6 +17,26 @@ func NewEnvironmentRepository(txs *TxManager) *EnvironmentRepository {
 	return &EnvironmentRepository{txs: txs}
 }
 
+// Create inserts a new environment for the caller's tenant and returns the
+// persisted row. Only the operator-authored columns are written; environment_id,
+// tenant_id, and the timestamps are owned by the database (the tenant_id DEFAULT +
+// RLS bind the row to the caller's tenant automatically), so they are excluded
+// from the Column list and populated by Returning("*"). The env references its
+// context by context_id; the composite (tenant_id, context_id) foreign key
+// enforces that the context belongs to the same tenant, so a context_id from
+// another tenant surfaces as a foreign-key-violation error here.
+func (r *EnvironmentRepository) Create(ctx context.Context, environment model.Environment) (model.Environment, error) {
+	created := environment
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		return tx.NewInsert().
+			Model(&created).
+			Column("name", "type", "kubernetes_context", "context_id", "runtime_version").
+			Returning("*").
+			Scan(ctx)
+	})
+	return created, err
+}
+
 func (r *EnvironmentRepository) List(ctx context.Context) ([]model.Environment, error) {
 	var environments []model.Environment
 	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {

--- a/erun-backend/erun-backend-api/internal/repository/tenants.go
+++ b/erun-backend/erun-backend-api/internal/repository/tenants.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"strings"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
@@ -14,6 +15,87 @@ type TenantRepository struct {
 
 func NewTenantRepository(txs *TxManager) *TenantRepository {
 	return &TenantRepository{txs: txs}
+}
+
+// CreateTenantParams is the operations-only tenant-registration input. It carries
+// the tenant identity plus the OIDC issuer mapping that resolves tokens to the
+// new tenant. orgFieldKey/orgFieldValue are set only for an org-scoped (shared)
+// issuer; a single-tenant issuer leaves both empty (NULL org_field_key on the
+// issuers registry, NULL org_field_value on the tenant_issuers mapping).
+type CreateTenantParams struct {
+	Name          string
+	Type          model.TenantType
+	Issuer        string
+	OrgFieldKey   string
+	OrgFieldValue string
+	DisplayName   string
+}
+
+// Create registers a new tenant and its OIDC issuer mapping in one transaction:
+// the tenants row, the issuers registry row (the globally unique issuer key with
+// its org-scoping mode), and the tenant_issuers mapping row binding the issuer
+// (and org value, when org-scoped) to the new tenant. These are root resolution
+// tables writable only by erun_operations, which WithinTx selects because the
+// caller is an OPERATIONS tenant. No first user is bootstrapped here — the
+// per-tenant first-user bootstrap enrols the tenant's first admin when its first
+// valid token arrives. Unlike tenant-owned tables, tenant_issuers.tenant_id is
+// set explicitly to the new tenant's id rather than defaulted from the security
+// context, because the operations caller's own tenant_id is not the new tenant's.
+func (r *TenantRepository) Create(ctx context.Context, params CreateTenantParams) (model.Tenant, error) {
+	tenant := model.Tenant{Name: strings.TrimSpace(params.Name), Type: params.Type}
+	issuer := strings.TrimSpace(params.Issuer)
+	orgFieldKey := strings.TrimSpace(params.OrgFieldKey)
+	orgFieldValue := strings.TrimSpace(params.OrgFieldValue)
+	displayName := strings.TrimSpace(params.DisplayName)
+	if displayName == "" {
+		displayName = issuer
+	}
+
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		if err := tx.NewInsert().
+			Model(&tenant).
+			Column("name", "type").
+			Returning("*").
+			Scan(ctx); err != nil {
+			return normalizeNoRows(err)
+		}
+
+		// Register the issuer once in the root issuers registry. org_field_key is
+		// NULL for a single-tenant issuer and names the org claim for an org-scoped
+		// (shared) issuer. ON CONFLICT DO NOTHING lets a shared issuer already in
+		// the registry map an additional tenant via a new tenant_issuers row below.
+		if _, err := tx.NewRaw(
+			`INSERT INTO issuers (issuer, org_field_key) VALUES (?, ?) ON CONFLICT (issuer) DO NOTHING`,
+			issuer, nullIfEmpty(orgFieldKey),
+		).Exec(ctx); err != nil {
+			return err
+		}
+
+		// Map the issuer (and org value, when org-scoped) to the new tenant.
+		// tenant_id is set explicitly to the freshly minted tenant.
+		if _, err := tx.NewRaw(
+			`INSERT INTO tenant_issuers (tenant_id, issuer, org_field_value, name) VALUES (?, ?, ?, ?)`,
+			tenant.TenantID, issuer, nullIfEmpty(orgFieldValue), displayName,
+		).Exec(ctx); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return model.Tenant{}, err
+	}
+	return tenant, nil
+}
+
+// nullIfEmpty maps an empty string to a SQL NULL so optional issuer columns
+// (org_field_key, org_field_value) store NULL — the single-tenant marker — rather
+// than an empty string, which the resolution uniqueness constraints treat as a
+// distinct value.
+func nullIfEmpty(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
 }
 
 // Current returns the row for the caller's resolved tenant. tenants is a root

--- a/erun-backend/erun-backend-api/internal/routes/config_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/config_test.go
@@ -23,15 +23,32 @@ func (r stubConfigTenantRepository) Current(context.Context) (model.Tenant, erro
 type stubEnvironmentRepository struct {
 	environments []model.Environment
 	environment  model.Environment
+	created      model.Environment
+	createCalls  int
+	createInput  model.Environment
 	err          error
 }
 
-func (r stubEnvironmentRepository) List(context.Context) ([]model.Environment, error) {
+func (r *stubEnvironmentRepository) List(context.Context) ([]model.Environment, error) {
 	return r.environments, r.err
 }
 
-func (r stubEnvironmentRepository) Get(context.Context, string) (model.Environment, error) {
+func (r *stubEnvironmentRepository) Get(context.Context, string) (model.Environment, error) {
 	return r.environment, r.err
+}
+
+func (r *stubEnvironmentRepository) Create(_ context.Context, environment model.Environment) (model.Environment, error) {
+	r.createCalls++
+	r.createInput = environment
+	if r.err != nil {
+		return model.Environment{}, r.err
+	}
+	created := r.created
+	if created.EnvironmentID == "" {
+		created = environment
+		created.EnvironmentID = "env-created"
+	}
+	return created, nil
 }
 
 type stubContextRepository struct {
@@ -65,7 +82,7 @@ func (r *stubContextRepository) Create(_ context.Context, cloudContext model.Con
 
 func TestConfigReturnsDenormalizedReadModel(t *testing.T) {
 	tenants := stubConfigTenantRepository{tenant: model.Tenant{TenantID: "tenant-1", Name: "acme", Type: model.TenantTypeCompany}}
-	environments := stubEnvironmentRepository{environments: []model.Environment{
+	environments := &stubEnvironmentRepository{environments: []model.Environment{
 		{EnvironmentID: "env-1", Name: "runtime", Type: model.EnvironmentTypeRuntime, ContextID: "ctx-1"},
 	}}
 	contexts := &stubContextRepository{contexts: []model.Context{
@@ -101,7 +118,7 @@ func TestConfigPropagatesRepositoryError(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/v1/config", nil)
 	rec := httptest.NewRecorder()
 
-	ConfigRoutes{tenants: tenants, environments: stubEnvironmentRepository{}, contexts: &stubContextRepository{}}.getConfig(rec, req)
+	ConfigRoutes{tenants: tenants, environments: &stubEnvironmentRepository{}, contexts: &stubContextRepository{}}.getConfig(rec, req)
 
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("unexpected status: %d", rec.Code)
@@ -109,7 +126,7 @@ func TestConfigPropagatesRepositoryError(t *testing.T) {
 }
 
 func TestGetEnvironmentNotFound(t *testing.T) {
-	environments := stubEnvironmentRepository{err: repository.ErrNotFound}
+	environments := &stubEnvironmentRepository{err: repository.ErrNotFound}
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/environments/missing", nil)
 	req.SetPathValue("environment_id", "missing")

--- a/erun-backend/erun-backend-api/internal/routes/environments.go
+++ b/erun-backend/erun-backend-api/internal/routes/environments.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 )
@@ -10,15 +11,29 @@ import (
 type EnvironmentRepository interface {
 	List(ctx context.Context) ([]model.Environment, error)
 	Get(ctx context.Context, environmentID string) (model.Environment, error)
+	Create(ctx context.Context, environment model.Environment) (model.Environment, error)
 }
 
 type EnvironmentRoutes struct {
 	environments EnvironmentRepository
 }
 
+// createEnvironmentRequest is the env-registration body. The tenant is resolved
+// from the caller's token (RLS scopes the write), never from the body, so it is
+// absent here. The env references its context by contextId; the composite
+// foreign key enforces that the context belongs to the caller's tenant.
+type createEnvironmentRequest struct {
+	Name              string `json:"name"`
+	Type              string `json:"type"`
+	ContextID         string `json:"contextId"`
+	KubernetesContext string `json:"kubernetesContext"`
+	RuntimeVersion    string `json:"runtimeVersion"`
+}
+
 func RegisterEnvironmentRoutes(register ProtectedRouteRegistrar, environments EnvironmentRepository) {
 	routes := EnvironmentRoutes{environments: environments}
 	register(http.MethodGet, "/v1/environments", http.HandlerFunc(routes.listEnvironments))
+	register(http.MethodPost, "/v1/environments", http.HandlerFunc(routes.createEnvironment))
 	register(http.MethodGet, "/v1/environments/{environment_id}", http.HandlerFunc(routes.getEnvironment))
 }
 
@@ -38,4 +53,58 @@ func (r EnvironmentRoutes) getEnvironment(w http.ResponseWriter, req *http.Reque
 		return
 	}
 	writeJSON(w, http.StatusOK, environment)
+}
+
+// validEnvironmentTypes is the closed set of env types the registration API
+// accepts, matching model.EnvironmentType.
+var validEnvironmentTypes = map[model.EnvironmentType]struct{}{
+	model.EnvironmentTypeRuntime:     {},
+	model.EnvironmentTypeRemoteAgent: {},
+	model.EnvironmentTypeLocalAgent:  {},
+}
+
+// createEnvironment registers an environment in the caller's tenant (resolved
+// from the token; RLS scopes the write) and returns the persisted row. It
+// validates the operator-authored input, then persists; the env references its
+// context by contextId, and the composite foreign key enforces that the context
+// belongs to the caller's tenant.
+func (r EnvironmentRoutes) createEnvironment(w http.ResponseWriter, req *http.Request) {
+	var body createEnvironmentRequest
+	if err := decodeJSON(req, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	name := strings.TrimSpace(body.Name)
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	envType := model.EnvironmentType(strings.TrimSpace(body.Type))
+	if _, ok := validEnvironmentTypes[envType]; !ok {
+		writeError(w, http.StatusBadRequest, "type must be one of runtime, remote-agent, local-agent")
+		return
+	}
+
+	created, err := r.environments.Create(req.Context(), model.Environment{
+		Name:              name,
+		Type:              envType,
+		ContextID:         strings.TrimSpace(body.ContextID),
+		KubernetesContext: strings.TrimSpace(body.KubernetesContext),
+		RuntimeVersion:    strings.TrimSpace(body.RuntimeVersion),
+	})
+	if err != nil {
+		// A context_id that does not belong to the caller's tenant violates the
+		// composite (tenant_id, context_id) foreign key; surface it as the
+		// repository error (a clean 4xx/5xx) rather than leaking the SQL detail.
+		writeRepositoryError(w, err)
+		return
+	}
+
+	// TODO(#660 live): run RunBootstrapInitWithDependencies server-side to ensure
+	// the <tenant>-<env> namespace + deploy the runtime chart; requires a live
+	// cluster, not executed in this build — the row stands as registered config
+	// until then.
+
+	writeJSON(w, http.StatusCreated, created)
 }

--- a/erun-backend/erun-backend-api/internal/routes/environments_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/environments_test.go
@@ -1,0 +1,95 @@
+package routes
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+)
+
+func postCreateEnvironment(t *testing.T, environments *stubEnvironmentRepository, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/environments", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	EnvironmentRoutes{environments: environments}.createEnvironment(rec, req)
+	return rec
+}
+
+func TestCreateEnvironmentRejectsInvalidInput(t *testing.T) {
+	cases := map[string]string{
+		"missing name":   `{"type":"runtime"}`,
+		"missing type":   `{"name":"prod"}`,
+		"unknown type":   `{"name":"prod","type":"staging"}`,
+		"empty body":     `{}`,
+		"malformed json": `{`,
+	}
+	for label, body := range cases {
+		t.Run(label, func(t *testing.T) {
+			environments := &stubEnvironmentRepository{}
+			rec := postCreateEnvironment(t, environments, body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("unexpected status: %d", rec.Code)
+			}
+			if environments.createCalls != 0 {
+				t.Fatalf("Create should not run on invalid input, got %d calls", environments.createCalls)
+			}
+		})
+	}
+}
+
+func TestCreateEnvironmentPersistsAndReturnsRow(t *testing.T) {
+	for _, envType := range []string{"runtime", "remote-agent", "local-agent"} {
+		t.Run(envType, func(t *testing.T) {
+			environments := &stubEnvironmentRepository{created: model.Environment{EnvironmentID: "env-1", Name: "prod", Type: model.EnvironmentType(envType)}}
+			rec := postCreateEnvironment(t, environments, `{
+				"name": "prod",
+				"type": "`+envType+`",
+				"contextId": "ctx-1",
+				"kubernetesContext": "primary",
+				"runtimeVersion": "1.2.3"
+			}`)
+
+			if rec.Code != http.StatusCreated {
+				t.Fatalf("unexpected status: %d", rec.Code)
+			}
+			if environments.createCalls != 1 {
+				t.Fatalf("expected exactly one Create call, got %d", environments.createCalls)
+			}
+			// The handler must thread the operator-authored fields into the
+			// persisted model; tenant binding is left to RLS, not the body.
+			if environments.createInput.ContextID != "ctx-1" || environments.createInput.RuntimeVersion != "1.2.3" {
+				t.Fatalf("unexpected create input: %+v", environments.createInput)
+			}
+
+			var response model.Environment
+			if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.EnvironmentID != "env-1" {
+				t.Fatalf("unexpected persisted environment: %+v", response)
+			}
+		})
+	}
+}
+
+func TestCreateEnvironmentSurfacesRepositoryError(t *testing.T) {
+	// A context_id from another tenant violates the composite foreign key; the
+	// repository error is surfaced as a clean HTTP error, not a SQL leak.
+	environments := &stubEnvironmentRepository{err: errForeignKey{}}
+	rec := postCreateEnvironment(t, environments, `{"name":"prod","type":"runtime","contextId":"ctx-other"}`)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+	if environments.createCalls != 1 {
+		t.Fatalf("expected exactly one Create call, got %d", environments.createCalls)
+	}
+}
+
+// errForeignKey stands in for a database foreign-key-violation error returned by
+// the repository when the referenced context is not the caller's.
+type errForeignKey struct{}
+
+func (errForeignKey) Error() string { return "foreign key violation" }

--- a/erun-backend/erun-backend-api/internal/routes/tenants.go
+++ b/erun-backend/erun-backend-api/internal/routes/tenants.go
@@ -1,0 +1,94 @@
+package routes
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+)
+
+type TenantRepository interface {
+	Create(ctx context.Context, params repository.CreateTenantParams) (model.Tenant, error)
+}
+
+type TenantRoutes struct {
+	tenants TenantRepository
+}
+
+// createTenantRequest is the operations-only tenant-registration body. It carries
+// the tenant identity plus the OIDC issuer mapping that resolves tokens to the
+// new tenant. orgFieldKey/orgFieldValue are set only for an org-scoped (shared)
+// issuer; a single-tenant issuer leaves both empty.
+type createTenantRequest struct {
+	Name          string `json:"name"`
+	Type          string `json:"type"`
+	Issuer        string `json:"issuer"`
+	OrgFieldKey   string `json:"orgFieldKey"`
+	OrgFieldValue string `json:"orgFieldValue"`
+	DisplayName   string `json:"displayName"`
+}
+
+func RegisterTenantRoutes(register ProtectedRouteRegistrar, tenants TenantRepository) {
+	routes := TenantRoutes{tenants: tenants}
+	register(http.MethodPost, "/v1/tenants", http.HandlerFunc(routes.createTenant))
+}
+
+// createTenant registers a new tenant plus its OIDC issuer mapping. Beyond the
+// broad WriteAll permission that authorization middleware enforces for POST, this
+// handler adds an explicit operations gate: the caller's resolved tenant must be
+// an OPERATIONS tenant, because tenants/issuers/tenant_issuers are root
+// resolution tables writable only by erun_operations. A non-OPERATIONS caller is
+// rejected with 403 here, before any write is attempted.
+func (r TenantRoutes) createTenant(w http.ResponseWriter, req *http.Request) {
+	securityContext, ok := security.FromContext(req.Context())
+	if !ok {
+		// Protected routes always run behind authentication middleware that stamps
+		// the security context, so a missing context is an internal wiring error,
+		// not a client fault.
+		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		return
+	}
+	if securityContext.TenantType != string(model.TenantTypeOperations) {
+		writeError(w, http.StatusForbidden, "tenant registration requires an operations tenant")
+		return
+	}
+
+	var body createTenantRequest
+	if err := decodeJSON(req, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	name := strings.TrimSpace(body.Name)
+	issuer := strings.TrimSpace(body.Issuer)
+	if name == "" || issuer == "" {
+		writeError(w, http.StatusBadRequest, "name and issuer are required")
+		return
+	}
+	tenantType := model.TenantType(strings.TrimSpace(body.Type))
+	if tenantType == "" {
+		tenantType = model.TenantTypeCompany
+	}
+	if tenantType != model.TenantTypeCompany && tenantType != model.TenantTypeOperations {
+		writeError(w, http.StatusBadRequest, "type must be one of COMPANY, OPERATIONS")
+		return
+	}
+
+	created, err := r.tenants.Create(req.Context(), repository.CreateTenantParams{
+		Name:          name,
+		Type:          tenantType,
+		Issuer:        issuer,
+		OrgFieldKey:   strings.TrimSpace(body.OrgFieldKey),
+		OrgFieldValue: strings.TrimSpace(body.OrgFieldValue),
+		DisplayName:   strings.TrimSpace(body.DisplayName),
+	})
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, created)
+}

--- a/erun-backend/erun-backend-api/internal/routes/tenants_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/tenants_test.go
@@ -1,0 +1,116 @@
+package routes
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+)
+
+type stubTenantRepository struct {
+	created      model.Tenant
+	createCalls  int
+	createParams repository.CreateTenantParams
+	err          error
+}
+
+func (r *stubTenantRepository) Create(_ context.Context, params repository.CreateTenantParams) (model.Tenant, error) {
+	r.createCalls++
+	r.createParams = params
+	if r.err != nil {
+		return model.Tenant{}, r.err
+	}
+	created := r.created
+	if created.TenantID == "" {
+		created = model.Tenant{TenantID: "tenant-created", Name: params.Name, Type: params.Type}
+	}
+	return created, nil
+}
+
+func postCreateTenant(t *testing.T, tenants *stubTenantRepository, tenantType string, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/tenants", bytes.NewBufferString(body))
+	// Authentication middleware stamps the resolved security context before route
+	// code runs; the OPERATIONS gate reads TenantType from it.
+	req = req.WithContext(security.WithContext(req.Context(), security.Context{
+		TenantID:   "tenant-caller",
+		TenantType: tenantType,
+		ErunUserID: "user-1",
+	}))
+	rec := httptest.NewRecorder()
+	TenantRoutes{tenants: tenants}.createTenant(rec, req)
+	return rec
+}
+
+func TestCreateTenantForbidsNonOperationsCaller(t *testing.T) {
+	for _, tenantType := range []string{string(model.TenantTypeCompany), ""} {
+		t.Run("type="+tenantType, func(t *testing.T) {
+			tenants := &stubTenantRepository{}
+			rec := postCreateTenant(t, tenants, tenantType, `{"name":"acme","type":"COMPANY","issuer":"https://idp.example"}`)
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("unexpected status: %d", rec.Code)
+			}
+			if tenants.createCalls != 0 {
+				t.Fatalf("non-operations caller must not reach Create, got %d calls", tenants.createCalls)
+			}
+		})
+	}
+}
+
+func TestCreateTenantRejectsInvalidInput(t *testing.T) {
+	cases := map[string]string{
+		"missing name":   `{"issuer":"https://idp.example"}`,
+		"missing issuer": `{"name":"acme"}`,
+		"unknown type":   `{"name":"acme","issuer":"https://idp.example","type":"PARTNER"}`,
+		"malformed json": `{`,
+	}
+	for label, body := range cases {
+		t.Run(label, func(t *testing.T) {
+			tenants := &stubTenantRepository{}
+			rec := postCreateTenant(t, tenants, string(model.TenantTypeOperations), body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("unexpected status: %d", rec.Code)
+			}
+			if tenants.createCalls != 0 {
+				t.Fatalf("Create should not run on invalid input, got %d calls", tenants.createCalls)
+			}
+		})
+	}
+}
+
+func TestCreateTenantOperationsCallerPersists(t *testing.T) {
+	tenants := &stubTenantRepository{created: model.Tenant{TenantID: "tenant-1", Name: "acme", Type: model.TenantTypeCompany}}
+	rec := postCreateTenant(t, tenants, string(model.TenantTypeOperations), `{
+		"name": "acme",
+		"type": "COMPANY",
+		"issuer": "https://idp.example",
+		"orgFieldKey": "org_id",
+		"orgFieldValue": "42",
+		"displayName": "Acme IdP"
+	}`)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+	if tenants.createCalls != 1 {
+		t.Fatalf("expected exactly one Create call, got %d", tenants.createCalls)
+	}
+	// The handler must thread the issuer mapping through to the repository.
+	if tenants.createParams.Issuer != "https://idp.example" || tenants.createParams.OrgFieldValue != "42" {
+		t.Fatalf("unexpected create params: %+v", tenants.createParams)
+	}
+
+	var response model.Tenant
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.TenantID != "tenant-1" {
+		t.Fatalf("unexpected persisted tenant: %+v", response)
+	}
+}

--- a/erun-backend/erun-backend-api/server.go
+++ b/erun-backend/erun-backend-api/server.go
@@ -89,6 +89,7 @@ func NewHandler(options HandlerOptions) (http.Handler, error) {
 		routes.RegisterCommentRoutes(register, comments, commentService)
 		routes.RegisterEnvironmentRoutes(register, environments)
 		routes.RegisterContextRoutes(register, contexts)
+		routes.RegisterTenantRoutes(register, tenants)
 		routes.RegisterConfigRoute(register, tenants, environments, contexts)
 	}
 	routes.RegisterWhoamiRoute(register, users)

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -82,7 +82,7 @@ When no trust anchor is configured the edge stays loopback-only (legacy, unauthe
 ### Endpoints
 
 :::note Shipped vs planned
-The `(iss, org) → tenant` resolution model and first-identity bootstrap above are **shipped**, as are `GET /v1/whoami`, `GET /v1/tenant-issuers` (list), and `PATCH /v1/tenant-issuers` (rename a trusted issuer's display name). Today, issuers and their org-scoping mode are provisioned directly in the `issuers` / `tenant_issuers` tables (migrations or the bootstrap path), not via a self-service endpoint. A self-service **trust-management** API (adding/removing issuers with `audience`/`tenantClaim`/`allowedSubjects`, and the `409`/`422` codes below) is `(Planned.)`, as is the structured machine-readable error `code` field — today the API returns bare HTTP status codes with a plain-text body (see [Errors](#errors) below).
+The `(iss, org) → tenant` resolution model and first-identity bootstrap above are **shipped**, as are `GET /v1/whoami`, `GET /v1/tenant-issuers` (list), and `PATCH /v1/tenant-issuers` (rename a trusted issuer's display name). New tenants and their issuer mapping can be registered through the operations-only `POST /v1/tenants` below; for an existing tenant, additional issuers and their org-scoping mode are still provisioned directly in the `issuers` / `tenant_issuers` tables (migrations or the bootstrap path), not via a tenant-self-service endpoint. A tenant-self-service **trust-management** API (a tenant adding/removing its own issuers with `audience`/`tenantClaim`/`allowedSubjects`, and the `409`/`422` codes below) is `(Planned.)`, as is the structured machine-readable error `code` field — today the API returns bare HTTP status codes with a plain-text body (see [Errors](#errors) below).
 :::
 
 | Method | Path | Description | Required scope |
@@ -92,10 +92,12 @@ The `(iss, org) → tenant` resolution model and first-identity bootstrap above 
 | `GET` | `/v1/whoami` | Resolved identity for the calling token. Response below. | Tenant member |
 | `GET` | `/v1/config` | The console's read model over the per-tenant erun config: `{tenant, environments[], contexts[]}`. | Tenant member |
 | `GET` | `/v1/environments` | List the tenant's environments. | Tenant member |
+| `POST` | `/v1/environments` | Register an environment in the caller's tenant, bound to a referenced context. Body below. | Tenant member (write) |
 | `GET` | `/v1/environments/{environment_id}` | Fetch one environment by id. | Tenant member |
 | `GET` | `/v1/contexts` | List the tenant's cloud contexts (managed clusters). | Tenant member |
 | `POST` | `/v1/contexts` | Register a cloud context (managed cluster) for the caller's tenant and return its cluster-bootstrap plan. Body below. | Tenant member (write) |
 | `GET` | `/v1/contexts/{context_id}` | Fetch one cloud context by id. | Tenant member |
+| `POST` | `/v1/tenants` | Register a new tenant plus its OIDC issuer mapping. Operations-only. Body below. | Operations only |
 
 `GET /v1/config` is the console's read model over the per-tenant erun config — the backend DB is the system of record for the tenant's environments and cloud contexts, and this endpoint returns them denormalized as the on-disk erun config shape. All of these reads are tenant-scoped by row-level security, so a token only ever sees its own tenant's rows.
 
@@ -151,6 +153,48 @@ Returns the updated tenant-issuer record (`200`). `400` if `issuer` or `name` is
 ```
 
 `remove` matches by `issuerUrl`. Both arrays are optional; either may be empty.
+
+### `POST /v1/environments`
+
+Registers an **environment** in the caller's tenant. The tenant is resolved from the token — never from the body — so a token can only register an environment under its own tenant (row-level security scopes the write). The environment **runs in a referenced context**: `contextId` points at one of the tenant's cloud contexts, and the composite `(tenant_id, context_id)` foreign key enforces that the context belongs to the same tenant.
+
+```jsonc
+// POST /v1/environments body
+{
+  "name": "prod",              // required — the environment name (tenant-scoped)
+  "type": "runtime",           // required — one of "runtime", "remote-agent", "local-agent"
+  "contextId": "019a7fa5-…",   // optional — the cloud context (cluster) the env runs in
+  "kubernetesContext": "primary", // optional — the kube context bound to the env
+  "runtimeVersion": "1.2.3"    // optional — pinned runtime chart version
+}
+```
+
+On success the endpoint persists the row and returns it with HTTP `201`:
+
+```jsonc
+// 201 response
+{
+  "environmentId": "019a7fa5-c2c0-7c55-bc70-714873a71f30",
+  "tenantId": "019a7fa5-c2c0-7c55-bc70-714873a71f10",
+  "name": "prod",
+  "type": "runtime",
+  "kubernetesContext": "primary",
+  "contextId": "019a7fa5-c2c0-7c55-bc70-714873a71f20",
+  "runtimeVersion": "1.2.3",
+  "createdAt": "2026-06-24T10:00:00Z",
+  "updatedAt": "2026-06-24T10:00:00Z"
+}
+```
+
+**Live namespace + runtime-chart deploy is `(Planned.)`.** This endpoint registers the environment row only; it does **not** yet ensure the `<tenant>-<env>` namespace or deploy the runtime chart server-side (that runs `RunBootstrapInitWithDependencies` against a live cluster). Until that lands, a registered environment stands as registered config — the namespace creation and chart deploy from the registered row are the planned follow-up.
+
+**Error behaviour.** Today the API returns a bare HTTP status with a plain-text body (no JSON envelope):
+
+| Status | Condition | Recovery |
+|---|---|---|
+| `400` | `name` is empty/missing, `type` is not one of `runtime`/`remote-agent`/`local-agent`, or the body is not valid JSON. | Send a non-empty `name` and a valid `type`. |
+| `401` / `403` | Standard auth failures (see [Errors](#errors)). The `WriteAll` permission covers `POST /v1/environments`. | Send a valid token whose roles permit the write. |
+| `500` | Persistence failed — e.g. `contextId` references a context that is not the caller's (the composite `(tenant_id, context_id)` foreign key is violated), or the request-scoped security context is missing (an internal wiring error). | Reference a context owned by the caller's tenant; if it persists with a valid context, it is a server bug. |
 
 ### `POST /v1/contexts`
 
@@ -212,6 +256,43 @@ The k3s admin token is a **server secret** and is never part of the response or 
 | `400` | The bootstrap plan could not be resolved (e.g. an unsupported `region`, `instanceType`, or `diskSizeGb` for the BYO-cloud bootstrap). | Use a supported region/instance type/disk size. |
 | `401` / `403` | Standard auth failures (see [Errors](#errors)). The `WriteAll` permission covers `POST /v1/contexts`. | Send a valid token whose roles permit the write. |
 | `500` | Persistence failed (e.g. missing request-scoped security context — an internal wiring error, never a client fault). | Retry; if it persists, it is a server bug. |
+
+### `POST /v1/tenants`
+
+Registers a **new tenant** plus the OIDC issuer mapping that resolves its tokens. This is an **operations-only** endpoint: beyond the broad `WriteAll` permission that authorization enforces for any write, the handler adds an explicit gate — the caller's resolved tenant must be an `OPERATIONS` tenant, because `tenants`, `issuers`, and `tenant_issuers` are root resolution tables writable only by the operations role. A non-operations caller is rejected with `403` before any write is attempted.
+
+```jsonc
+// POST /v1/tenants body (operations-only)
+{
+  "name": "acme",                  // required — the tenant name (globally unique)
+  "type": "COMPANY",               // optional — "COMPANY" (default) or "OPERATIONS"
+  "issuer": "https://idp.example", // required — the OIDC issuer whose tokens map to this tenant
+  "orgFieldKey": "org_id",         // optional — org-scoped (shared) issuer: the token claim carrying the org
+  "orgFieldValue": "42",           // optional — org-scoped issuer: the org value that selects this tenant
+  "displayName": "Acme IdP"        // optional — display name for the issuer mapping (defaults to the issuer URL)
+}
+```
+
+The three identity rows — the `tenants` row, the `issuers` registry row (the globally unique issuer key with its org-scoping mode), and the `tenant_issuers` mapping row binding the issuer (and org value, when org-scoped) to the new tenant — are inserted in **one transaction**. `orgFieldKey`/`orgFieldValue` are set only for an org-scoped (shared) issuer; a single-tenant issuer leaves both empty (NULL on the registry / mapping). No first user is created here: the tenant's first admin is enrolled by the per-tenant first-user bootstrap when the tenant's first valid token arrives (see [first-identity bootstrap](#tenant-issuers)).
+
+```jsonc
+// 201 response
+{
+  "tenantId": "019a7fa5-c2c0-7c55-bc70-714873a71f50",
+  "name": "acme",
+  "type": "COMPANY",
+  "createdAt": "2026-06-24T10:00:00Z",
+  "updatedAt": "2026-06-24T10:00:00Z"
+}
+```
+
+**Error behaviour.** Today the API returns a bare HTTP status with a plain-text body (no JSON envelope):
+
+| Status | Condition | Recovery |
+|---|---|---|
+| `400` | `name` or `issuer` is empty/missing, `type` is not one of `COMPANY`/`OPERATIONS`, or the body is not valid JSON. | Send a non-empty `name` and `issuer` and a valid `type`. |
+| `403` | The caller's resolved tenant is not an `OPERATIONS` tenant (the explicit operations gate, beyond the standard auth failures in [Errors](#errors)). | Call from an operations-tenant token whose roles permit the write. |
+| `500` | Persistence failed — e.g. the tenant `name` or the `(issuer, org_field_value)` mapping already exists (a uniqueness violation), or the request-scoped security context is missing (an internal wiring error). | Use a unique tenant name and issuer mapping; if it persists with unique inputs, it is a server bug. |
 
 ### Service-account flow for Agents
 


### PR DESCRIPTION
## Summary

Authorized erun‑API write routes to **register an environment** in the caller's tenant and **register a new tenant** (operations‑scoped) — the write counterpart of the #658 read API and a sibling of #659's `POST /v1/contexts`.

This delivers #660's **verifiable surface**. The live namespace/deploy orchestration is out of scope here (flagged); #660 stays open for it.

## What changed
- `repository/environments.go` — `Create` (writable cols only, `Returning("*")`, `WithinTx`; RLS binds the row to the caller's tenant; `context_id` honoured via the tenant‑scoped composite FK).
- `routes/environments.go` — `POST /v1/environments`: validates `name` + `type` ∈ {runtime, remote‑agent, local‑agent} (→ `400`), persists, returns `201 {environment}`; a cross‑tenant `contextId` trips the composite FK and is surfaced as a clean error. `WriteAll` covers POST; tenant scoping automatic.
- `repository/tenants.go` — `TenantRepository.Create`: one `erun_operations` tx writing `tenants` + `issuers` (`ON CONFLICT (issuer) DO NOTHING`) + `tenant_issuers` (mapping's `tenant_id` set **explicitly** to the new tenant, not the caller's). No first‑user bootstrap — that stays with the per‑tenant first‑user enrolment on the tenant's first valid token.
- `routes/tenants.go` — `POST /v1/tenants`: returns `403` unless the caller's security‑context `TenantType == OPERATIONS`, **before** any write (the explicit operations gate the issue asks for, on top of `WriteAll`); validates input; persists; `201 {tenant}`.
- `server.go` wiring; `erun-docs/api-protocol.md` endpoints + Error behaviour + `(Planned.)` on live orchestration.

## Verification (self‑run)
- `erun-backend-api` `go build` + `go test ./...` + `golangci-lint` — green. DB‑free route tests: env‑register validates type + calls `Create` once + surfaces the FK error; tenant‑register returns `403` for a non‑OPERATIONS caller (without reaching the repo) and persists once for an OPERATIONS caller.
- `cd erun-docs && yarn build` — clean.
- No erun‑ui surface → Playwright N/A; erun‑cli/common untouched → `make integration-test` unaffected.

## Honest scope boundary (not done here)
`POST /v1/environments` registers the env config row; the **live** `RunBootstrapInitWithDependencies` (ensure the `<tenant>-<env>` namespace + deploy the runtime chart) is an explicit `TODO(#660 live)` not executed in this build — it needs a real cluster to verify. Tracked as the live‑platform follow‑up on #660.

Completes the verifiable surface of the #656–#660 sequence. Builds on #658/#659. Relates #605, #606.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
