### PR TITLE
Enforce the injective <tenant>-<env> namespace guardrail on provisioning (#605)

### DIFF
--- a/erun-backend/erun-backend-api/internal/routes/environments.go
+++ b/erun-backend/erun-backend-api/internal/routes/environments.go
@@ -55,6 +55,22 @@ func (r EnvironmentRoutes) getEnvironment(w http.ResponseWriter, req *http.Reque
 	writeJSON(w, http.StatusOK, environment)
 }
 
+// validNamespaceLabel reports whether s is a DNS-1123 label safe to use as the
+// env component of the <tenant>-<env> runtime namespace: lowercase letters,
+// digits, and internal hyphens, not hyphen-bounded, at most 63 characters.
+func validNamespaceLabel(s string) bool {
+	if s == "" || len(s) > 63 || s[0] == '-' || s[len(s)-1] == '-' {
+		return false
+	}
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 // validEnvironmentTypes is the closed set of env types the registration API
 // accepts, matching model.EnvironmentType.
 var validEnvironmentTypes = map[model.EnvironmentType]struct{}{
@@ -76,8 +92,12 @@ func (r EnvironmentRoutes) createEnvironment(w http.ResponseWriter, req *http.Re
 	}
 
 	name := strings.TrimSpace(body.Name)
-	if name == "" {
-		writeError(w, http.StatusBadRequest, "name is required")
+	// The env name forms the <tenant>-<env> namespace, so it must be a DNS-1123
+	// label. The tenant is already hyphen-free (ValidateTenantName on tenant
+	// registration), so the env may itself contain internal hyphens and the
+	// first-hyphen split stays unambiguous (#605 injective-namespace guardrail).
+	if !validNamespaceLabel(name) {
+		writeError(w, http.StatusBadRequest, "name must be a DNS-1123 label: lowercase letters, digits, and internal hyphens, not starting or ending with a hyphen, at most 63 characters")
 		return
 	}
 	envType := model.EnvironmentType(strings.TrimSpace(body.Type))

--- a/erun-backend/erun-backend-api/internal/routes/environments_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/environments_test.go
@@ -20,11 +20,14 @@ func postCreateEnvironment(t *testing.T, environments *stubEnvironmentRepository
 
 func TestCreateEnvironmentRejectsInvalidInput(t *testing.T) {
 	cases := map[string]string{
-		"missing name":   `{"type":"runtime"}`,
-		"missing type":   `{"name":"prod"}`,
-		"unknown type":   `{"name":"prod","type":"staging"}`,
-		"empty body":     `{}`,
-		"malformed json": `{`,
+		"missing name":        `{"type":"runtime"}`,
+		"missing type":        `{"name":"prod"}`,
+		"unknown type":        `{"name":"prod","type":"staging"}`,
+		"empty body":          `{}`,
+		"malformed json":      `{`,
+		"uppercase name":      `{"name":"Prod","type":"runtime"}`,
+		"hyphen-bounded name": `{"name":"-prod","type":"runtime"}`,
+		"space in name":       `{"name":"my env","type":"runtime"}`,
 	}
 	for label, body := range cases {
 		t.Run(label, func(t *testing.T) {

--- a/erun-backend/erun-backend-api/internal/routes/tenants.go
+++ b/erun-backend/erun-backend-api/internal/routes/tenants.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	eruncommon "github.com/sophium/erun/erun-common"
+
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
@@ -64,8 +66,17 @@ func (r TenantRoutes) createTenant(w http.ResponseWriter, req *http.Request) {
 
 	name := strings.TrimSpace(body.Name)
 	issuer := strings.TrimSpace(body.Issuer)
-	if name == "" || issuer == "" {
-		writeError(w, http.StatusBadRequest, "name and issuer are required")
+	// Enforce the no-hyphen tenant-name rule (#605 mandatory guardrail): the
+	// runtime namespace is <tenant>-<env>, so a hyphen in the tenant would make
+	// the mapping non-injective (a-b + c and a + b-c both collapse to a-b-c), a
+	// cross-tenant namespace-collision/takeover vector on a public provisioning
+	// surface. ValidateTenantName allows only lowercase letters and digits.
+	if err := eruncommon.ValidateTenantName(name); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if issuer == "" {
+		writeError(w, http.StatusBadRequest, "issuer is required")
 		return
 	}
 	tenantType := model.TenantType(strings.TrimSpace(body.Type))

--- a/erun-backend/erun-backend-api/internal/routes/tenants_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/tenants_test.go
@@ -65,10 +65,12 @@ func TestCreateTenantForbidsNonOperationsCaller(t *testing.T) {
 
 func TestCreateTenantRejectsInvalidInput(t *testing.T) {
 	cases := map[string]string{
-		"missing name":   `{"issuer":"https://idp.example"}`,
-		"missing issuer": `{"name":"acme"}`,
-		"unknown type":   `{"name":"acme","issuer":"https://idp.example","type":"PARTNER"}`,
-		"malformed json": `{`,
+		"missing name":    `{"issuer":"https://idp.example"}`,
+		"missing issuer":  `{"name":"acme"}`,
+		"unknown type":    `{"name":"acme","issuer":"https://idp.example","type":"PARTNER"}`,
+		"malformed json":  `{`,
+		"hyphenated name": `{"name":"ac-me","issuer":"https://idp.example"}`,
+		"uppercase name":  `{"name":"Acme","issuer":"https://idp.example"}`,
 	}
 	for label, body := range cases {
 		t.Run(label, func(t *testing.T) {

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -161,7 +161,7 @@ Registers an **environment** in the caller's tenant. The tenant is resolved from
 ```jsonc
 // POST /v1/environments body
 {
-  "name": "prod",              // required — the environment name (tenant-scoped)
+  "name": "prod",              // required — a DNS-1123 label (lowercase letters, digits, internal hyphens)
   "type": "runtime",           // required — one of "runtime", "remote-agent", "local-agent"
   "contextId": "019a7fa5-…",   // optional — the cloud context (cluster) the env runs in
   "kubernetesContext": "primary", // optional — the kube context bound to the env
@@ -192,7 +192,7 @@ On success the endpoint persists the row and returns it with HTTP `201`:
 
 | Status | Condition | Recovery |
 |---|---|---|
-| `400` | `name` is empty/missing, `type` is not one of `runtime`/`remote-agent`/`local-agent`, or the body is not valid JSON. | Send a non-empty `name` and a valid `type`. |
+| `400` | `name` is not a DNS-1123 label (the env forms the `<tenant>-<env>` namespace), `type` is not one of `runtime`/`remote-agent`/`local-agent`, or the body is not valid JSON. | Send a DNS-1123 `name` and a valid `type`. |
 | `401` / `403` | Standard auth failures (see [Errors](#errors)). The `WriteAll` permission covers `POST /v1/environments`. | Send a valid token whose roles permit the write. |
 | `500` | Persistence failed — e.g. `contextId` references a context that is not the caller's (the composite `(tenant_id, context_id)` foreign key is violated), or the request-scoped security context is missing (an internal wiring error). | Reference a context owned by the caller's tenant; if it persists with a valid context, it is a server bug. |
 
@@ -264,7 +264,7 @@ Registers a **new tenant** plus the OIDC issuer mapping that resolves its tokens
 ```jsonc
 // POST /v1/tenants body (operations-only)
 {
-  "name": "acme",                  // required — the tenant name (globally unique)
+  "name": "acme",                  // required — lowercase letters and digits only, NO hyphens (globally unique)
   "type": "COMPANY",               // optional — "COMPANY" (default) or "OPERATIONS"
   "issuer": "https://idp.example", // required — the OIDC issuer whose tokens map to this tenant
   "orgFieldKey": "org_id",         // optional — org-scoped (shared) issuer: the token claim carrying the org
@@ -290,7 +290,7 @@ The three identity rows — the `tenants` row, the `issuers` registry row (the g
 
 | Status | Condition | Recovery |
 |---|---|---|
-| `400` | `name` or `issuer` is empty/missing, `type` is not one of `COMPANY`/`OPERATIONS`, or the body is not valid JSON. | Send a non-empty `name` and `issuer` and a valid `type`. |
+| `400` | `name` is empty or contains anything other than lowercase letters and digits (no hyphens — so the `<tenant>-<env>` namespace stays injective), `issuer` is empty/missing, `type` is not one of `COMPANY`/`OPERATIONS`, or the body is not valid JSON. | Send a hyphen-free lowercase-alphanumeric `name`, a non-empty `issuer`, and a valid `type`. |
 | `403` | The caller's resolved tenant is not an `OPERATIONS` tenant (the explicit operations gate, beyond the standard auth failures in [Errors](#errors)). | Call from an operations-tenant token whose roles permit the write. |
 | `500` | Persistence failed — e.g. the tenant `name` or the `(issuer, org_field_value)` mapping already exists (a uniqueness violation), or the request-scoped security context is missing (an internal wiring error). | Use a unique tenant name and issuer mapping; if it persists with unique inputs, it is a server bug. |
 


### PR DESCRIPTION
## Summary

Enforces the **#605 mandatory injective‑namespace guardrail** on the new hosted‑provisioning write surface: a per‑env runtime namespace is `<tenant>-<env>`, so a hyphen in the tenant name would make the mapping non‑injective (`a-b`+`c` and `a`+`b-c` both collapse to `a-b-c`) — a cross‑tenant namespace‑collision/takeover vector on a public surface.

- **`POST /v1/tenants`** now validates the tenant name with `eruncommon.ValidateTenantName` (lowercase letters + digits, **no hyphens**) → `400` otherwise.
- **`POST /v1/environments`** validates the env name as a **DNS‑1123 label** (lowercase letters, digits, internal hyphens, not hyphen‑bounded, ≤63) so the namespace is always valid. The env may carry internal hyphens; the hyphen‑free tenant keeps the first‑hyphen split unambiguous.

This is the verifiable, security‑critical guardrail piece of #605 (the live cluster‑bootstrap orchestration remains the live‑platform follow‑up on #605/#659/#660).

## Verification (self‑run)
- `erun-backend-api` `go test ./...` + `golangci-lint` — green. Route tests now reject hyphenated + uppercase **tenant** names and uppercase / hyphen‑bounded / space‑bearing **env** names with `400` (and assert the repo is not called); valid names still persist.
- `cd erun-docs && yarn build` — clean; `api-protocol.md` documents both validation rules in the endpoints' Error behaviour.
- No erun‑ui surface → Playwright N/A; erun‑cli/common untouched → `make integration-test` unaffected.

Relates #605, #659, #660.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
