### PR TITLE
POST /v1/provision: combined hosted-env provisioning dry-run plan (#605)

### DIFF
--- a/erun-backend/erun-backend-api/internal/routes/provision.go
+++ b/erun-backend/erun-backend-api/internal/routes/provision.go
@@ -1,0 +1,200 @@
+package routes
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+)
+
+// ProvisionRoutes serves the combined "provision a hosted env" preview: the
+// single auditable plan the operator/console sees before provisioning. It
+// composes the same dry-run primitives the discrete endpoints expose — the
+// per-tenant quota check (POST /v1/environments), the cluster-bootstrap plan
+// (POST /v1/contexts), the namespace + env registration, and the runtime
+// deploy — into one ordered, human-readable plan. This endpoint is plan-only:
+// it resolves and shows the concrete actions but never executes them and never
+// writes to the database.
+type ProvisionRoutes struct {
+	tenants      ConfigTenantRepository
+	environments EnvironmentRepository
+	quotas       TenantQuotaRepository
+}
+
+// provisionRequest is the operator-authored "provision a hosted env" body. The
+// tenant is resolved from the caller's token (the security context), never from
+// the body. Exactly one of context (provision a NEW cluster) or
+// kubernetesContext (reference an EXISTING context) describes where the env
+// lands; environment is always required.
+type provisionRequest struct {
+	Environment provisionEnvironment `json:"environment"`
+	// Context, when present, provisions a NEW cluster: its bootstrap plan is the
+	// real InitCloudContext dry-run argv, the same plan POST /v1/contexts returns.
+	Context *provisionContext `json:"context,omitempty"`
+	// KubernetesContext references an EXISTING context instead of bootstrapping a
+	// new cluster. Ignored when a context block is present.
+	KubernetesContext string `json:"kubernetesContext"`
+}
+
+type provisionEnvironment struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type provisionContext struct {
+	Name               string `json:"name"`
+	CloudProviderAlias string `json:"cloudProviderAlias"`
+	Region             string `json:"region"`
+	InstanceType       string `json:"instanceType"`
+	DiskType           string `json:"diskType"`
+	DiskSizeGB         int    `json:"diskSizeGb"`
+}
+
+// provisionResponse is the preview result: the ordered, audit-style plan and
+// whether the tenant is within its environment quota. quotaOk is false when the
+// provision would exceed the cap; the plan is still returned in full (a preview
+// surfaces the blocking decision rather than 4xx-ing it).
+type provisionResponse struct {
+	Plan    []string `json:"plan"`
+	QuotaOk bool     `json:"quotaOk"`
+}
+
+func RegisterProvisionRoute(register ProtectedRouteRegistrar, tenants ConfigTenantRepository, environments EnvironmentRepository, quotas TenantQuotaRepository) {
+	routes := ProvisionRoutes{tenants: tenants, environments: environments, quotas: quotas}
+	register(http.MethodPost, "/v1/provision", http.HandlerFunc(routes.provision))
+}
+
+// provision resolves and returns the complete, ordered plan to provision a
+// hosted env for the caller's tenant. It composes the quota check, context
+// (cluster) bootstrap, namespace creation, env registration, and runtime
+// deploy into one auditable preview. It NEVER executes the plan and NEVER
+// writes to the database — this endpoint is plan-only in this build (see the
+// TODO(#605 live) below for the real orchestration).
+func (r ProvisionRoutes) provision(w http.ResponseWriter, req *http.Request) {
+	var body provisionRequest
+	if err := decodeJSON(req, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	envName := strings.TrimSpace(body.Environment.Name)
+	// The env name forms the <tenant>-<env> namespace, so it must be a DNS-1123
+	// label (same guardrail as POST /v1/environments). The tenant is hyphen-free
+	// (ValidateTenantName at tenant registration), so the first-hyphen split of
+	// the namespace stays unambiguous (#605 injective-namespace guardrail).
+	if !validNamespaceLabel(envName) {
+		writeError(w, http.StatusBadRequest, "environment.name must be a DNS-1123 label: lowercase letters, digits, and internal hyphens, not starting or ending with a hyphen, at most 63 characters")
+		return
+	}
+	envType := model.EnvironmentType(strings.TrimSpace(body.Environment.Type))
+	if _, ok := validEnvironmentTypes[envType]; !ok {
+		writeError(w, http.StatusBadRequest, "environment.type must be one of runtime, remote-agent, local-agent")
+		return
+	}
+
+	var (
+		ctxName     string
+		ctxAlias    string
+		ctxRegion   string
+		contextPlan []string
+	)
+	if body.Context != nil {
+		ctxName = strings.TrimSpace(body.Context.Name)
+		ctxAlias = strings.TrimSpace(body.Context.CloudProviderAlias)
+		ctxRegion = strings.TrimSpace(body.Context.Region)
+		if ctxName == "" || ctxAlias == "" || ctxRegion == "" {
+			writeError(w, http.StatusBadRequest, "context.name, context.cloudProviderAlias, and context.region are required when a context block is present")
+			return
+		}
+		// Reuse the same dry-run cluster-bootstrap plan POST /v1/contexts builds:
+		// it runs eruncommon.InitCloudContext in DryRun mode against an in-memory
+		// CloudStore seeded with the alias, so it resolves the provider and emits
+		// the EC2/IAM/k3s argv the real bootstrap would run, without touching AWS.
+		plan, err := buildContextBootstrapPlan(createContextRequest{
+			InstanceType: strings.TrimSpace(body.Context.InstanceType),
+			DiskType:     strings.TrimSpace(body.Context.DiskType),
+			DiskSizeGB:   body.Context.DiskSizeGB,
+		}, ctxName, ctxAlias, ctxRegion)
+		if err != nil {
+			// A dry-run InitCloudContext failure is an input-resolution error
+			// (e.g. an unsupported region/instance type), not a server fault.
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		contextPlan = plan
+	}
+
+	// The tenant name (not the UUID) is the human identity that forms the
+	// <tenant>-<env> namespace and the runtime release name. It is read RLS-/
+	// security-scoped to the caller, so it always belongs to the caller's tenant.
+	tenant, err := r.tenants.Current(req.Context())
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	tenantName := strings.TrimSpace(tenant.Name)
+
+	plan := make([]string, 0, 8+len(contextPlan))
+
+	// 1. authz/tenant: the tenant the whole plan is scoped to, resolved from the
+	//    token's security context (never from the body).
+	plan = append(plan, fmt.Sprintf("provision: tenant %s (resolved from token)", tenantName))
+
+	// 2. quota: read the cap + current count and state whether this provision
+	//    fits. Over the cap, the plan is still returned (preview), but quotaOk is
+	//    false and the line names the block — consistent with a dry-run surfacing
+	//    decisions rather than 4xx-ing them.
+	maxEnvironments, err := r.quotas.MaxEnvironments(req.Context())
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	count, err := r.environments.Count(req.Context())
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	quotaOk := count < maxEnvironments
+	quotaLine := fmt.Sprintf("quota: tenant has %d of %d environments", count, maxEnvironments)
+	if quotaOk {
+		quotaLine += " — within quota"
+	} else {
+		quotaLine += " — WOULD EXCEED, provisioning blocked"
+	}
+	plan = append(plan, quotaLine)
+
+	// 3. context: either bootstrap a NEW cluster (append the InitCloudContext
+	//    dry-run argv under a header line) or reuse an EXISTING context.
+	if body.Context != nil {
+		plan = append(plan, fmt.Sprintf("context: bootstrap cluster %s via alias %s", ctxName, ctxAlias))
+		plan = append(plan, contextPlan...)
+	} else {
+		plan = append(plan, fmt.Sprintf("context: reuse existing kubernetes context %s", strings.TrimSpace(body.KubernetesContext)))
+	}
+
+	// 4. namespace: the <tenant>-<env> namespace the env runs in.
+	namespace := eruncommon.KubernetesNamespaceName(tenantName, envName)
+	plan = append(plan, fmt.Sprintf("namespace: would create %s", namespace))
+
+	// 5. register: persist the env row (config-only; the live deploy is step 6).
+	contextRef := strings.TrimSpace(body.KubernetesContext)
+	if body.Context != nil {
+		contextRef = ctxName
+	}
+	plan = append(plan, fmt.Sprintf("register: would persist environment %s (%s) in tenant %s referencing context %s", envName, envType, tenantName, contextRef))
+
+	// 6. deploy: helm-install the runtime chart for the tenant into the namespace.
+	plan = append(plan, fmt.Sprintf("deploy: would helm install the erun-devops runtime chart (release %s) into %s", eruncommon.RuntimeReleaseName(tenantName), namespace))
+
+	// TODO(#605 live): execute this plan — InitCloudContext (DryRun=false) →
+	// ensure namespace → RunBootstrapInitWithDependencies/deploy the runtime
+	// chart → wire exposure + the auth edge. Requires a live AWS account +
+	// cluster; this endpoint is plan-only in this build. Do not persist here —
+	// the discrete POST /v1/contexts and POST /v1/environments endpoints own the
+	// config writes; this preview composes their plans without side effects.
+
+	writeJSON(w, http.StatusOK, provisionResponse{Plan: plan, QuotaOk: quotaOk})
+}

--- a/erun-backend/erun-backend-api/internal/routes/provision_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/provision_test.go
@@ -1,0 +1,181 @@
+package routes
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+)
+
+func postProvision(t *testing.T, tenants ConfigTenantRepository, environments *stubEnvironmentRepository, quotas stubTenantQuotaRepository, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/provision", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	ProvisionRoutes{tenants: tenants, environments: environments, quotas: quotas}.provision(rec, req)
+	return rec
+}
+
+// acmeTenant is the caller's resolved tenant for provision tests; its Name is
+// what forms the <tenant>-<env> namespace and runtime release name.
+var acmeTenant = stubConfigTenantRepository{tenant: model.Tenant{TenantID: "tenant-1", Name: "acme", Type: model.TenantTypeCompany}}
+
+func TestProvisionRejectsInvalidEnvironment(t *testing.T) {
+	cases := map[string]string{
+		"missing environment":  `{}`,
+		"missing name":         `{"environment":{"type":"runtime"}}`,
+		"missing type":         `{"environment":{"name":"prod"}}`,
+		"unknown type":         `{"environment":{"name":"prod","type":"staging"}}`,
+		"uppercase name":       `{"environment":{"name":"Prod","type":"runtime"}}`,
+		"hyphen-bounded name":  `{"environment":{"name":"-prod","type":"runtime"}}`,
+		"space in name":        `{"environment":{"name":"my env","type":"runtime"}}`,
+		"malformed json":       `{`,
+		"context missing name": `{"environment":{"name":"prod","type":"runtime"},"context":{"cloudProviderAlias":"acme-aws","region":"eu-west-2"}}`,
+	}
+	for label, body := range cases {
+		t.Run(label, func(t *testing.T) {
+			environments := &stubEnvironmentRepository{}
+			rec := postProvision(t, acmeTenant, environments, underCapQuota, body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("unexpected status: %d", rec.Code)
+			}
+			// Provision is preview-only: no env row is ever created, even on the
+			// happy path, so it must never run on the invalid-input path either.
+			if environments.createCalls != 0 {
+				t.Fatalf("provision must never call Create, got %d calls", environments.createCalls)
+			}
+		})
+	}
+}
+
+// TestProvisionWithNewClusterComposesFullPlan proves the ordered plan for a NEW
+// cluster: it pulls the quota line, the real InitCloudContext dry-run argv (the
+// ec2 run-instances command), the <tenant>-<env> namespace line, the register
+// line, and the deploy line — all without persisting anything.
+func TestProvisionWithNewClusterComposesFullPlan(t *testing.T) {
+	environments := &stubEnvironmentRepository{count: 2}
+	rec := postProvision(t, acmeTenant, environments, stubTenantQuotaRepository{maxEnvironments: 10}, `{
+		"environment": {"name": "prod", "type": "runtime"},
+		"context": {
+			"name": "acme-prod",
+			"cloudProviderAlias": "acme-aws",
+			"region": "eu-west-2",
+			"instanceType": "c8gd.2xlarge",
+			"diskType": "gp3",
+			"diskSizeGb": 100
+		}
+	}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+	if environments.createCalls != 0 {
+		t.Fatalf("provision is preview-only and must not call Create, got %d calls", environments.createCalls)
+	}
+
+	var response provisionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !response.QuotaOk {
+		t.Fatalf("expected quotaOk=true under the cap, got false: %v", response.Plan)
+	}
+
+	// authz/tenant line, resolved from the token.
+	if !planContains(response.Plan, "provision: tenant acme (resolved from token)") {
+		t.Fatalf("plan missing the authz/tenant line: %v", response.Plan)
+	}
+	// quota line: 2 of 10, within quota.
+	if !planContains(response.Plan, "quota: tenant has 2 of 10 environments — within quota") {
+		t.Fatalf("plan missing the within-quota line: %v", response.Plan)
+	}
+	// context bootstrap header + the real InitCloudContext dry-run argv.
+	if !planContains(response.Plan, "context: bootstrap cluster acme-prod via alias acme-aws") {
+		t.Fatalf("plan missing the context bootstrap header: %v", response.Plan)
+	}
+	if !planContains(response.Plan, "ec2 run-instances") {
+		t.Fatalf("plan missing the EC2 run-instances step from the InitCloudContext dry-run: %v", response.Plan)
+	}
+	// namespace: <tenant>-<env>.
+	if !planContains(response.Plan, "namespace: would create acme-prod") {
+		t.Fatalf("plan missing the <tenant>-<env> namespace line: %v", response.Plan)
+	}
+	// register line, referencing the new cluster's context.
+	if !planContains(response.Plan, "register: would persist environment prod (runtime) in tenant acme referencing context acme-prod") {
+		t.Fatalf("plan missing the register line: %v", response.Plan)
+	}
+	// deploy line: the runtime chart at the tenant's release name into the namespace.
+	if !planContains(response.Plan, "deploy: would helm install the erun-devops runtime chart (release acme-devops) into acme-prod") {
+		t.Fatalf("plan missing the deploy line: %v", response.Plan)
+	}
+}
+
+// TestProvisionReusesExistingContext proves the existing-context path: no
+// bootstrap argv, just the reuse line plus the rest of the plan.
+func TestProvisionReusesExistingContext(t *testing.T) {
+	environments := &stubEnvironmentRepository{count: 0}
+	rec := postProvision(t, acmeTenant, environments, stubTenantQuotaRepository{maxEnvironments: 10}, `{
+		"environment": {"name": "staging", "type": "remote-agent"},
+		"kubernetesContext": "acme-prod"
+	}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+	if environments.createCalls != 0 {
+		t.Fatalf("provision is preview-only and must not call Create, got %d calls", environments.createCalls)
+	}
+
+	var response provisionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !planContains(response.Plan, "context: reuse existing kubernetes context acme-prod") {
+		t.Fatalf("plan missing the reuse-context line: %v", response.Plan)
+	}
+	if planContains(response.Plan, "ec2 run-instances") {
+		t.Fatalf("existing-context provision must not emit bootstrap argv: %v", response.Plan)
+	}
+	if !planContains(response.Plan, "namespace: would create acme-staging") {
+		t.Fatalf("plan missing the namespace line: %v", response.Plan)
+	}
+	if !planContains(response.Plan, "register: would persist environment staging (remote-agent) in tenant acme referencing context acme-prod") {
+		t.Fatalf("plan missing the register line: %v", response.Plan)
+	}
+}
+
+// TestProvisionOverCapReturnsPlanWithQuotaBlocked proves that at/over the cap
+// the full plan is still returned (it is a preview, not a 4xx), but quotaOk is
+// false and the quota line names the block. No Create runs.
+func TestProvisionOverCapReturnsPlanWithQuotaBlocked(t *testing.T) {
+	environments := &stubEnvironmentRepository{count: 10}
+	rec := postProvision(t, acmeTenant, environments, stubTenantQuotaRepository{maxEnvironments: 10}, `{
+		"environment": {"name": "prod", "type": "runtime"},
+		"kubernetesContext": "acme-prod"
+	}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("over-cap provision is still a 200 preview, got status %d", rec.Code)
+	}
+	if environments.createCalls != 0 {
+		t.Fatalf("provision must never call Create, got %d calls", environments.createCalls)
+	}
+
+	var response provisionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.QuotaOk {
+		t.Fatalf("expected quotaOk=false at the cap, got true: %v", response.Plan)
+	}
+	if !planContains(response.Plan, "quota: tenant has 10 of 10 environments — WOULD EXCEED, provisioning blocked") {
+		t.Fatalf("plan missing the blocked-quota line: %v", response.Plan)
+	}
+	// Even when blocked, the rest of the plan is shown so the operator sees the
+	// full intended work alongside the blocking reason.
+	if !planContains(response.Plan, "deploy: would helm install the erun-devops runtime chart (release acme-devops) into acme-prod") {
+		t.Fatalf("blocked plan should still show the full intended actions: %v", response.Plan)
+	}
+}

--- a/erun-backend/erun-backend-api/server.go
+++ b/erun-backend/erun-backend-api/server.go
@@ -92,6 +92,7 @@ func NewHandler(options HandlerOptions) (http.Handler, error) {
 		routes.RegisterContextRoutes(register, contexts)
 		routes.RegisterTenantRoutes(register, tenants)
 		routes.RegisterConfigRoute(register, tenants, environments, contexts)
+		routes.RegisterProvisionRoute(register, tenants, environments, tenantQuotas)
 	}
 	routes.RegisterWhoamiRoute(register, users)
 	return mux, nil

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -97,6 +97,7 @@ The `(iss, org) → tenant` resolution model and first-identity bootstrap above 
 | `GET` | `/v1/contexts` | List the tenant's cloud contexts (managed clusters). | Tenant member |
 | `POST` | `/v1/contexts` | Register a cloud context (managed cluster) for the caller's tenant and return its cluster-bootstrap plan. Body below. | Tenant member (write) |
 | `GET` | `/v1/contexts/{context_id}` | Fetch one cloud context by id. | Tenant member |
+| `POST` | `/v1/provision` | Return the complete, ordered **plan** to provision a hosted env (quota check → context bootstrap → namespace → env registration → runtime deploy) for the caller's tenant. Preview-only; no execution, no writes. Body below. | Tenant member (write) |
 | `POST` | `/v1/tenants` | Register a new tenant plus its OIDC issuer mapping. Operations-only. Body below. | Operations only |
 
 `GET /v1/config` is the console's read model over the per-tenant erun config — the backend DB is the system of record for the tenant's environments and cloud contexts, and this endpoint returns them denormalized as the on-disk erun config shape. All of these reads are tenant-scoped by row-level security, so a token only ever sees its own tenant's rows.
@@ -259,6 +260,75 @@ The k3s admin token is a **server secret** and is never part of the response or 
 | `400` | The bootstrap plan could not be resolved (e.g. an unsupported `region`, `instanceType`, or `diskSizeGb` for the BYO-cloud bootstrap). | Use a supported region/instance type/disk size. |
 | `401` / `403` | Standard auth failures (see [Errors](#errors)). The `WriteAll` permission covers `POST /v1/contexts`. | Send a valid token whose roles permit the write. |
 | `500` | Persistence failed (e.g. missing request-scoped security context — an internal wiring error, never a client fault). | Retry; if it persists, it is a server bug. |
+
+### `POST /v1/provision`
+
+Returns the complete, ordered **plan** to provision a hosted env for the caller's tenant — the single auditable preview a console or Operator sees before provisioning. It **composes the same dry-run primitives** the discrete endpoints expose into one ordered plan: the per-tenant environment-count quota check from [`POST /v1/environments`](#post-v1environments), the cluster-**bootstrap plan** from [`POST /v1/contexts`](#post-v1contexts), the `<tenant>-<env>` namespace creation, the environment registration, and the runtime-chart deploy. The endpoint is tenant-scoped by the token's security context — the tenant is **resolved from the token, never from the body**.
+
+This endpoint is **preview-only** in this build: it resolves and shows the concrete actions but **never executes** the plan and **never writes** to the database. The discrete `POST /v1/contexts` and `POST /v1/environments` endpoints own the config writes; this endpoint composes their plans with no side effects.
+
+```jsonc
+// POST /v1/provision body
+{
+  "environment": {                  // required
+    "name": "prod",                 // required — DNS-1123 label; forms the <tenant>-<env> namespace
+    "type": "runtime"               // required — one of runtime, remote-agent, local-agent
+  },
+  "context": {                      // optional — present when provisioning a NEW cluster
+    "name": "acme-prod",            // required when context is present — the cluster (and kube-context) name
+    "cloudProviderAlias": "acme-aws", // required when context is present — a registered AWS alias for the tenant
+    "region": "eu-west-2",          // required when context is present — AWS region
+    "instanceType": "c8gd.2xlarge", // optional
+    "diskType": "gp3",              // optional
+    "diskSizeGb": 100               // optional
+  },
+  "kubernetesContext": "acme-prod"  // optional — reference an EXISTING context instead of bootstrapping a new cluster
+}
+```
+
+Provide **either** a `context` block (provision a new cluster — its bootstrap plan is the real `InitCloudContext` dry-run argv) **or** a `kubernetesContext` (reuse an existing context). When a `context` block is present it wins and `kubernetesContext` is ignored.
+
+**The ordered `plan`.** The response is `{ "plan": [ … ], "quotaOk": <bool> }`. `plan` is the human-readable, audit-style ordered list of every action the live provision would take, in this exact order:
+
+1. **authz/tenant** — `provision: tenant <tenant> (resolved from token)`.
+2. **quota** — `quota: tenant has <count> of <cap> environments` followed by ` — within quota` or ` — WOULD EXCEED, provisioning blocked`. The cap is the tenant's `tenant_quotas.max_environments` (default `10`); both reads are row-level-security-scoped to the caller's tenant.
+3. **context** — when a `context` block was given: a `context: bootstrap cluster <name> via alias <alias>` header line followed by the full `InitCloudContext` dry-run argv (the security-group + IAM instance-profile setup, `ec2 run-instances`, the k3s install user-data, the kube-context wiring), exactly the plan [`POST /v1/contexts`](#post-v1contexts) returns. Otherwise: `context: reuse existing kubernetes context <kubernetesContext>`.
+4. **namespace** — `namespace: would create <tenant>-<env>`.
+5. **register** — `register: would persist environment <name> (<type>) in tenant <tenant> referencing context <ref>`.
+6. **deploy** — `deploy: would helm install the erun-devops runtime chart (release <tenant>-devops) into <tenant>-<env>`.
+
+**`quotaOk`.** `true` when the provision fits under the tenant's environment-count cap, `false` when it would exceed it. When `quotaOk` is `false` the endpoint **still returns the full plan** with HTTP `200` (it is a preview, not a write), and the quota line names the block — surfacing the blocking decision the way a dry-run does, rather than rejecting with a `409`. A caller gating on the quota should check `quotaOk`, not the status code.
+
+```jsonc
+// 200 response (new cluster, within quota)
+{
+  "plan": [
+    "provision: tenant acme (resolved from token)",
+    "quota: tenant has 2 of 10 environments — within quota",
+    "context: bootstrap cluster acme-prod via alias acme-aws",
+    "aws ec2 create-security-group …",
+    "aws ec2 run-instances …",
+    "kubectl config set-context acme-prod …",
+    "namespace: would create acme-prod",
+    "register: would persist environment prod (runtime) in tenant acme referencing context acme-prod",
+    "deploy: would helm install the erun-devops runtime chart (release acme-devops) into acme-prod"
+  ],
+  "quotaOk": true
+}
+```
+
+**Live orchestration is `(Planned.)`.** This endpoint only resolves and returns the plan. The live orchestration — `InitCloudContext` with `DryRun=false` → ensure the namespace → `RunBootstrapInitWithDependencies` / deploy the runtime chart → wire the env exposure and the per-env auth edge — requires a live AWS account and cluster and is **not executed** in this build. It composes the same dry-run primitives as `POST /v1/contexts` plus the registration endpoints, so the live path is the composition of their live paths.
+
+**Error behaviour.** Today the API returns a bare HTTP status with a plain-text body (no JSON envelope):
+
+| Status | Condition | Recovery |
+|---|---|---|
+| `400` | `environment.name` is not a DNS-1123 label, `environment.type` is not one of `runtime`/`remote-agent`/`local-agent`, a `context` block is present but missing `name`/`cloudProviderAlias`/`region`, or the body is not valid JSON. | Send a valid `environment` and, if provisioning a new cluster, a complete `context` block. |
+| `400` | The context bootstrap plan could not be resolved (e.g. an unsupported `region`, `instanceType`, or `diskSizeGb`). | Use a supported region/instance type/disk size. |
+| `401` / `403` | Standard auth failures (see [Errors](#errors)). The `WriteAll` permission covers `POST /v1/provision`. | Send a valid token whose roles permit the write. |
+| `500` | The tenant or quota read failed (e.g. missing request-scoped security context — an internal wiring error, never a client fault). | Retry; if it persists, it is a server bug. |
+
+Note that being **at or over quota is not an error** here — it returns `200` with `quotaOk: false` and the full plan (see `quotaOk` above), unlike `POST /v1/environments`, which rejects the actual write with `409`.
 
 ### `POST /v1/tenants`
 


### PR DESCRIPTION
## Summary

The #605 control‑plane **provisioning preview**: one authorized, tenant‑scoped `POST /v1/provision` that resolves and returns the **complete auditable plan** to provision a hosted env, composing the dry‑run primitives already shipped — tenant + **quota check** + **context bootstrap** (reusing #659's `InitCloudContext` dry‑run) + **namespace** + **env registration** + **runtime‑chart deploy** — as one ordered plan.

Preview/plan‑only: it **never executes and never writes** (no `Create`). Over‑cap returns `200` with `quotaOk:false` and the blocking quota line (a preview surfaces the decision rather than `409`‑ing). The live execution is an explicit `TODO(#605 live)`.

## Plan order
`provision: tenant …` → `quota: N of M … (within / WOULD EXCEED)` → `context: bootstrap … <real InitCloudContext argv>` or `reuse …` → `namespace: would create <tenant>-<env>` → `register: would persist environment …` → `deploy: would helm install the erun-devops runtime chart (release <tenant>-devops) …`.

## Verification (self‑run)
- `erun-backend-api` `go test` + lint — green. Route test asserts the plan carries the quota line, a real `ec2 run-instances` line (InitCloudContext dry‑run), the `<tenant>-<env>` namespace, the register + deploy lines; over‑cap → `quotaOk:false`; invalid env name/type or missing context fields → `400`; `createCalls == 0` on every path (preview‑only).
- `cd erun-docs && yarn build` — clean (`POST /v1/provision` documented; execution `(Planned.)`).
- No schema change; no erun‑ui surface → Playwright N/A; erun‑cli/common untouched → `make integration-test` unaffected.

This is the auditable preview for the #605 imperative provisioning op (per the repo's dry‑run philosophy). The live orchestration execution remains the live‑platform follow‑up. Relates #605, #659, #660, #670.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
