### PR TITLE
Operations-only PUT /v1/tenants/{id}/quota to set per-tenant env caps (#605)

### DIFF
--- a/erun-backend/erun-backend-api/internal/repository/tenant_quotas.go
+++ b/erun-backend/erun-backend-api/internal/repository/tenant_quotas.go
@@ -41,3 +41,24 @@ func (r *TenantQuotaRepository) MaxEnvironments(ctx context.Context) (int, error
 	}
 	return quota.MaxEnvironments, nil
 }
+
+// Set upserts a tenant's environment-count cap and returns the stored row. It is
+// operations-only at the route layer; the operations role's RLS policy lets it
+// write any tenant's row, and tenant_id is set explicitly to the target — not
+// the erun_current_tenant_id() column default, which would be the operations
+// caller's own tenant.
+func (r *TenantQuotaRepository) Set(ctx context.Context, tenantID string, maxEnvironments int) (model.TenantQuota, error) {
+	var quota model.TenantQuota
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		return tx.NewRaw(`
+			INSERT INTO tenant_quotas (tenant_id, max_environments)
+			VALUES (?, ?)
+			ON CONFLICT (tenant_id) DO UPDATE SET max_environments = EXCLUDED.max_environments
+			RETURNING tenant_id, max_environments, created_at, updated_at
+		`, tenantID, maxEnvironments).Scan(ctx, &quota)
+	})
+	if err != nil {
+		return model.TenantQuota{}, err
+	}
+	return quota, nil
+}

--- a/erun-backend/erun-backend-api/internal/routes/tenant_quotas.go
+++ b/erun-backend/erun-backend-api/internal/routes/tenant_quotas.go
@@ -1,0 +1,64 @@
+package routes
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+)
+
+// TenantQuotaWriter sets a tenant's environment-count cap (the per-tenant
+// override the #605 quota guardrail enforces on env registration).
+type TenantQuotaWriter interface {
+	Set(ctx context.Context, tenantID string, maxEnvironments int) (model.TenantQuota, error)
+}
+
+type TenantQuotaRoutes struct {
+	quotas TenantQuotaWriter
+}
+
+type setTenantQuotaRequest struct {
+	MaxEnvironments int `json:"maxEnvironments"`
+}
+
+func RegisterTenantQuotaRoute(register ProtectedRouteRegistrar, quotas TenantQuotaWriter) {
+	routes := TenantQuotaRoutes{quotas: quotas}
+	register(http.MethodPut, "/v1/tenants/{tenant_id}/quota", http.HandlerFunc(routes.setQuota))
+}
+
+// setQuota sets a tenant's environment-count cap. Operations-only: like tenant
+// registration, the caller must be an OPERATIONS tenant, because it writes
+// another tenant's quota row (the operations role's RLS policy permits it).
+func (r TenantQuotaRoutes) setQuota(w http.ResponseWriter, req *http.Request) {
+	securityContext, ok := security.FromContext(req.Context())
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "missing security context")
+		return
+	}
+	if securityContext.TenantType != string(model.TenantTypeOperations) {
+		writeError(w, http.StatusForbidden, "setting a tenant quota requires an operations tenant")
+		return
+	}
+	tenantID := strings.TrimSpace(req.PathValue("tenant_id"))
+	if tenantID == "" {
+		writeError(w, http.StatusBadRequest, "tenant_id is required")
+		return
+	}
+	var body setTenantQuotaRequest
+	if err := decodeJSON(req, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if body.MaxEnvironments < 0 {
+		writeError(w, http.StatusBadRequest, "maxEnvironments must be >= 0")
+		return
+	}
+	quota, err := r.quotas.Set(req.Context(), tenantID, body.MaxEnvironments)
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, quota)
+}

--- a/erun-backend/erun-backend-api/internal/routes/tenant_quotas_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/tenant_quotas_test.go
@@ -1,0 +1,76 @@
+package routes
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+)
+
+type stubTenantQuotaWriter struct {
+	setCalls  int
+	gotTenant string
+	gotMax    int
+}
+
+func (r *stubTenantQuotaWriter) Set(_ context.Context, tenantID string, maxEnvironments int) (model.TenantQuota, error) {
+	r.setCalls++
+	r.gotTenant = tenantID
+	r.gotMax = maxEnvironments
+	return model.TenantQuota{TenantID: tenantID, MaxEnvironments: maxEnvironments}, nil
+}
+
+func putQuota(t *testing.T, quotas *stubTenantQuotaWriter, tenantType, tenantID, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/v1/tenants/"+tenantID+"/quota", bytes.NewBufferString(body))
+	req.SetPathValue("tenant_id", tenantID)
+	req = req.WithContext(security.WithContext(req.Context(), security.Context{
+		TenantID:   "ops-caller",
+		TenantType: tenantType,
+		ErunUserID: "user-1",
+	}))
+	rec := httptest.NewRecorder()
+	TenantQuotaRoutes{quotas: quotas}.setQuota(rec, req)
+	return rec
+}
+
+func TestSetTenantQuotaForbidsNonOperations(t *testing.T) {
+	for _, tt := range []string{string(model.TenantTypeCompany), ""} {
+		quotas := &stubTenantQuotaWriter{}
+		rec := putQuota(t, quotas, tt, "tenant-x", `{"maxEnvironments":50}`)
+		if rec.Code != http.StatusForbidden || quotas.setCalls != 0 {
+			t.Fatalf("type=%q: status=%d setCalls=%d, want 403 / 0 calls", tt, rec.Code, quotas.setCalls)
+		}
+	}
+}
+
+func TestSetTenantQuotaOperationsPersists(t *testing.T) {
+	quotas := &stubTenantQuotaWriter{}
+	rec := putQuota(t, quotas, string(model.TenantTypeOperations), "tenant-x", `{"maxEnvironments":50}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if quotas.setCalls != 1 || quotas.gotTenant != "tenant-x" || quotas.gotMax != 50 {
+		t.Fatalf("Set called %d times tenant=%q max=%d, want 1 / tenant-x / 50", quotas.setCalls, quotas.gotTenant, quotas.gotMax)
+	}
+}
+
+func TestSetTenantQuotaRejectsInvalid(t *testing.T) {
+	cases := map[string]string{
+		"negative cap":   `{"maxEnvironments":-1}`,
+		"malformed json": `{`,
+	}
+	for label, body := range cases {
+		t.Run(label, func(t *testing.T) {
+			quotas := &stubTenantQuotaWriter{}
+			rec := putQuota(t, quotas, string(model.TenantTypeOperations), "tenant-x", body)
+			if rec.Code != http.StatusBadRequest || quotas.setCalls != 0 {
+				t.Fatalf("status=%d setCalls=%d, want 400 / 0 calls", rec.Code, quotas.setCalls)
+			}
+		})
+	}
+}

--- a/erun-backend/erun-backend-api/server.go
+++ b/erun-backend/erun-backend-api/server.go
@@ -91,6 +91,7 @@ func NewHandler(options HandlerOptions) (http.Handler, error) {
 		routes.RegisterEnvironmentRoutes(register, environments, tenantQuotas)
 		routes.RegisterContextRoutes(register, contexts)
 		routes.RegisterTenantRoutes(register, tenants)
+		routes.RegisterTenantQuotaRoute(register, tenantQuotas)
 		routes.RegisterConfigRoute(register, tenants, environments, contexts)
 		routes.RegisterProvisionRoute(register, tenants, environments, tenantQuotas)
 	}

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -187,7 +187,7 @@ On success the endpoint persists the row and returns it with HTTP `201`:
 }
 ```
 
-**Per-tenant environment-count quota.** After validating the body and before persisting, the endpoint enforces the tenant's environment-count cap: it compares how many environments the tenant already has against the cap and rejects the registration with HTTP `409` once the tenant is at or over it. The cap defaults to **10** and is overridden per tenant by a `tenant_quotas.max_environments` row. That override row is set **out-of-band** today — directly in the `tenant_quotas` table (a migration or operator-run statement); an operations quota-set endpoint is `(Planned.)`. Both the count and the cap are read under row-level security, so each is scoped to the caller's own tenant.
+**Per-tenant environment-count quota.** After validating the body and before persisting, the endpoint enforces the tenant's environment-count cap: it compares how many environments the tenant already has against the cap and rejects the registration with HTTP `409` once the tenant is at or over it. The cap defaults to **10** and is overridden per tenant by a `tenant_quotas.max_environments` row. That override row is set by the operations-only [`PUT /v1/tenants/{tenant_id}/quota`](#put-v1tenantstenant_idquota) endpoint (below). Both the count and the cap are read under row-level security, so each is scoped to the caller's own tenant.
 
 **Live namespace + runtime-chart deploy is `(Planned.)`.** This endpoint registers the environment row only; it does **not** yet ensure the `<tenant>-<env>` namespace or deploy the runtime chart server-side (that runs `RunBootstrapInitWithDependencies` against a live cluster). Until that lands, a registered environment stands as registered config — the namespace creation and chart deploy from the registered row are the planned follow-up.
 
@@ -197,7 +197,7 @@ On success the endpoint persists the row and returns it with HTTP `201`:
 |---|---|---|
 | `400` | `name` is not a DNS-1123 label (the env forms the `<tenant>-<env>` namespace), `type` is not one of `runtime`/`remote-agent`/`local-agent`, or the body is not valid JSON. | Send a DNS-1123 `name` and a valid `type`. |
 | `401` / `403` | Standard auth failures (see [Errors](#errors)). The `WriteAll` permission covers `POST /v1/environments`. | Send a valid token whose roles permit the write. |
-| `409` | The tenant is at its environment-count cap (default `10` unless a `tenant_quotas` row overrides it); the body is `environment quota reached: this tenant already has N of N environments`. | Delete an unused environment, or raise the tenant's `tenant_quotas.max_environments` cap (out-of-band today; an operations quota-set endpoint is `(Planned.)`). |
+| `409` | The tenant is at its environment-count cap (default `10` unless a `tenant_quotas` row overrides it); the body is `environment quota reached: this tenant already has N of N environments`. | Delete an unused environment, or raise the tenant's cap via [`PUT /v1/tenants/{tenant_id}/quota`](#put-v1tenantstenant_idquota) (operations-only). |
 | `500` | Persistence failed — e.g. `contextId` references a context that is not the caller's (the composite `(tenant_id, context_id)` foreign key is violated), or the request-scoped security context is missing (an internal wiring error). | Reference a context owned by the caller's tenant; if it persists with a valid context, it is a server bug. |
 
 ### `POST /v1/contexts`
@@ -366,6 +366,30 @@ The three identity rows — the `tenants` row, the `issuers` registry row (the g
 | `400` | `name` is empty or contains anything other than lowercase letters and digits (no hyphens — so the `<tenant>-<env>` namespace stays injective), `issuer` is empty/missing, `type` is not one of `COMPANY`/`OPERATIONS`, or the body is not valid JSON. | Send a hyphen-free lowercase-alphanumeric `name`, a non-empty `issuer`, and a valid `type`. |
 | `403` | The caller's resolved tenant is not an `OPERATIONS` tenant (the explicit operations gate, beyond the standard auth failures in [Errors](#errors)). | Call from an operations-tenant token whose roles permit the write. |
 | `500` | Persistence failed — e.g. the tenant `name` or the `(issuer, org_field_value)` mapping already exists (a uniqueness violation), or the request-scoped security context is missing (an internal wiring error). | Use a unique tenant name and issuer mapping; if it persists with unique inputs, it is a server bug. |
+
+### `PUT /v1/tenants/{tenant_id}/quota` {#put-v1tenantstenant_idquota}
+
+Sets a tenant's **environment-count cap** — the per-tenant override the [`POST /v1/environments`](#post-v1environments) quota guardrail enforces. **Operations-only**, like tenant registration: the caller's resolved tenant must be `OPERATIONS`, because it writes another tenant's `tenant_quotas` row (the operations role's RLS policy permits cross-tenant writes; the row's `tenant_id` is set explicitly to the path's `{tenant_id}`, not the operations caller's own tenant). The write upserts, so it both creates and updates the cap.
+
+```jsonc
+// PUT /v1/tenants/019a7fa5-…/quota body
+{ "maxEnvironments": 50 }   // required — the cap (>= 0); 0 blocks all new environments
+
+// 200 response
+{
+  "tenantId": "019a7fa5-c2c0-7c55-bc70-714873a71f50",
+  "maxEnvironments": 50,
+  "createdAt": "2026-06-24T10:00:00Z",
+  "updatedAt": "2026-06-24T10:05:00Z"
+}
+```
+
+**Error behaviour.** Today the API returns a bare HTTP status with a plain-text body (no JSON envelope):
+
+| Status | Condition | Recovery |
+|---|---|---|
+| `400` | `tenant_id` is empty, `maxEnvironments` is negative, or the body is not valid JSON. | Send a non-negative `maxEnvironments`. |
+| `403` | The caller's resolved tenant is not an `OPERATIONS` tenant (the explicit operations gate). | Call from an operations-tenant token. |
 
 ### Service-account flow for Agents
 


### PR DESCRIPTION
## Summary

Completes the #605 quota guardrail: an **operations-only** `PUT /v1/tenants/{tenant_id}/quota` to set a tenant's environment-count cap. #670 added the `tenant_quotas` table + the `409` enforcement (default `10`); this adds the management endpoint that #670 explicitly left `(Planned.)`, so caps can actually be raised/lowered per tenant.

- `TenantQuotaRepository.Set` — upsert (`ON CONFLICT (tenant_id) DO UPDATE`), `tenant_id` set **explicitly** to the target (not the operations caller's `erun_current_tenant_id()` default).
- `PUT /v1/tenants/{tenant_id}/quota` — `403` unless the caller's security‑context `TenantType == OPERATIONS` (before any write), `400` on negative/malformed body, else upsert + `200`.

## Verification (self‑run)
- `erun-backend-api` `go build` + `go test ./...` + `golangci-lint` — green. Route tests: non‑operations → `403` (no write); operations → `200` + `Set(tenant-x, 50)` once; negative cap / malformed JSON → `400` (no write).
- `cd erun-docs && yarn build` — clean; `api-protocol.md` documents the endpoint and repoints the two prior `(Planned.)` quota‑set notes to it (explicit anchor, no broken links).
- Pure Go + DB (no schema change — the table is from #670); no Docker/cluster/Zitadel; no erun‑ui surface → Playwright N/A; erun‑cli/common untouched → `make integration-test` unaffected.

Relates #605, #670.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
