### PR TITLE
Console: operator surface for cloud-context provisioning (status + create flow) (#606/#605)

### DIFF
--- a/erun-console/AGENTS.md
+++ b/erun-console/AGENTS.md
@@ -22,9 +22,10 @@ When you implement either, replace the placeholder with the real flow and add th
 
 ## Layout
 
-- `src/config/` — the read model. `types.ts` mirrors the `GET /v1/config` JSON (`tenant`, `environments[]`, `contexts[]`); `client.ts` is the typed `fetchConfig(token)` + `ConfigFetchError`; `ConfigView.tsx` renders the tenant header, environments table, and contexts list with empty states.
+- `src/config/` — the read model. `types.ts` mirrors the `GET /v1/config` JSON (`tenant`, `environments[]`, `contexts[]`), including each context's provisioning `status`/`provisionError`; `client.ts` is the typed `fetchConfig(token)` + `ConfigFetchError`, plus the provisioning writes (`setCloudProviderAlias`, `createContext`, `getContext`); `ConfigView.tsx` renders the tenant header, environments table, and the contexts list with empty states and a per-context status badge.
+- `src/provision/` — the cloud-context provisioning surface (issue #605/#676): `controller.ts` is the thin request/poll controller (a `useProvisionController` hook that sequences the client calls — register a BYO-cloud alias, `POST /v1/contexts`, then poll `GET /v1/contexts/{id}` to `running`/`failed`), and `ProvisionPanel.tsx` is the render layer (alias form + create-context form + live status). This is **verifiable**, not a placeholder: `ProvisionPanel.test.tsx` exercises the alias PUT and the create→poll flow against a mocked `fetch`, the same weight as the read view's test. The live OIDC token still comes from the dev stub — only the auth flow is flagged.
 - `src/auth/` — the flagged OIDC/env-MCP placeholders (see above).
-- `src/App.tsx` — wires the token source → `fetchConfig` → `ConfigView`, with loading / signed-out (401) / error states.
+- `src/App.tsx` — wires the token source → `fetchConfig` → `ConfigView`, with loading / signed-out (401) / error states, and renders `ProvisionPanel` below the read view when a token is present.
 - `src/test/setup.ts` — Testing Library jest-dom matchers for vitest.
 
 ## Toolchain

--- a/erun-console/src/App.tsx
+++ b/erun-console/src/App.tsx
@@ -4,6 +4,7 @@ import { devBearerToken } from './auth/auth';
 import { ConfigFetchError, fetchConfig } from './config/client';
 import { ConfigView } from './config/ConfigView';
 import type { TenantConfigView } from './config/types';
+import { ProvisionPanel } from './provision/ProvisionPanel';
 
 type LoadState =
   | { status: 'loading' }
@@ -41,9 +42,12 @@ function loadStateFromError(error: unknown): LoadState {
 
 export function App(): React.ReactElement {
   const [state, setState] = React.useState<LoadState>({ status: 'loading' });
+  // The dev token is read once; it gates both the config fetch and the
+  // provisioning panel (which is only shown when a token is present). Replaced
+  // by the OIDC-derived token once login() lands (TODO(#606) in src/auth/auth.ts).
+  const token = React.useMemo(() => devBearerToken(), []);
 
   React.useEffect(() => {
-    const token = devBearerToken();
     if (token === undefined) {
       setState({ status: 'signed-out' });
       return;
@@ -65,7 +69,7 @@ export function App(): React.ReactElement {
     return () => {
       active = false;
     };
-  }, []);
+  }, [token]);
 
   return (
     <main className="app">
@@ -77,6 +81,7 @@ export function App(): React.ReactElement {
       {state.status === 'signed-out' && <SignInPrompt />}
       {state.status === 'error' && <ErrorMessage message={state.message} />}
       {state.status === 'ready' && <ConfigView config={state.config} />}
+      {token !== undefined && state.status === 'ready' && <ProvisionPanel token={token} />}
     </main>
   );
 }

--- a/erun-console/src/config/ConfigView.test.tsx
+++ b/erun-console/src/config/ConfigView.test.tsx
@@ -33,6 +33,15 @@ const SAMPLE_CONFIG = {
       provider: 'aws',
       region: 'eu-west-2',
       kubernetesContext: 'primary',
+      status: 'running',
+    },
+    {
+      contextId: 'ctx-2',
+      name: 'secondary',
+      provider: 'aws',
+      region: 'us-east-1',
+      status: 'failed',
+      provisionError: 'run-instances: InsufficientInstanceCapacity',
     },
   ],
 };
@@ -93,6 +102,22 @@ describe('ConfigView via App', () => {
     const contexts = within(screen.getByRole('region', { name: 'Cloud contexts' }));
     expect(contexts.getByText('primary')).toBeInTheDocument();
     expect(contexts.getByText('aws · eu-west-2')).toBeInTheDocument();
+  });
+
+  it('renders a running badge and a failed badge with its provision error', async () => {
+    mockFetch(jsonResponse(SAMPLE_CONFIG));
+    render(<App />);
+
+    const contexts = within(await screen.findByRole('region', { name: 'Cloud contexts' }));
+
+    // The running context shows a "Running" badge (semantic text label, not
+    // color-only) and no error reason.
+    expect(contexts.getByText('Running')).toBeInTheDocument();
+
+    // The failed context shows a "Failed" badge plus the provision error inline
+    // (essential info is visible text, not hidden behind a bare title tooltip).
+    expect(contexts.getByText('Failed')).toBeInTheDocument();
+    expect(contexts.getByText('run-instances: InsufficientInstanceCapacity')).toBeInTheDocument();
   });
 
   it('renders empty states for an empty payload', async () => {

--- a/erun-console/src/config/ConfigView.tsx
+++ b/erun-console/src/config/ConfigView.tsx
@@ -1,6 +1,6 @@
 import type * as React from 'react';
 
-import type { CloudContext, Environment, Tenant, TenantConfigView } from './types';
+import type { CloudContext, ContextStatus, Environment, Tenant, TenantConfigView } from './types';
 
 // What an Operator sees in the console: the tenant header, the list of
 // environments (name, type, kubernetes context, runtime version), and the list
@@ -67,12 +67,39 @@ function EnvironmentsSection({
   );
 }
 
+const STATUS_LABELS: Record<ContextStatus, string> = {
+  provisioning: 'Provisioning',
+  running: 'Running',
+  failed: 'Failed',
+};
+
+// A semantic, non-color-only status badge: it always carries a text label
+// (Provisioning / Running / Failed) alongside the color, so it reads correctly
+// for color-blind users and screen readers (jsx-a11y; erun-ui/AGENTS.md
+// § Professional UX). Returns null for an absent/unknown status so a context
+// registered before provisioning existed renders no badge.
+function StatusBadge({ status }: { status: ContextStatus | undefined }): React.ReactElement | null {
+  if (status === undefined) {
+    return null;
+  }
+  return <span className={`status-badge status-badge--${status}`}>{STATUS_LABELS[status]}</span>;
+}
+
 function ContextItem({ context }: { context: CloudContext }): React.ReactElement {
   return (
     <li>
       <span className="context-name">{context.name}</span>
       <span className="context-meta">
         {context.provider} · {context.region}
+      </span>
+      <span className="context-status">
+        <StatusBadge status={context.status} />
+        {context.status === 'failed' && context.provisionError !== undefined && (
+          // The failure reason is essential information, so it is shown inline
+          // as visible text rather than hidden behind a bare `title` tooltip
+          // (jsx-a11y / module a11y rules).
+          <span className="context-error">{context.provisionError}</span>
+        )}
       </span>
     </li>
   );

--- a/erun-console/src/config/client.ts
+++ b/erun-console/src/config/client.ts
@@ -1,4 +1,4 @@
-import type { CloudContext, Environment, Tenant, TenantConfigView } from './types';
+import type { CloudContext, ContextStatus, Environment, Tenant, TenantConfigView } from './types';
 
 // Base URL of the erun-backend-api. The console calls the API directly — there
 // is no separate BFF service in this increment (the API already carries the
@@ -29,6 +29,13 @@ function asOptionalString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
+// Parse the context provisioning status. Only the three known states are
+// surfaced as a ContextStatus; anything else (including an absent field) is
+// undefined so the UI renders no badge rather than a misleading one.
+function asContextStatus(value: unknown): ContextStatus | undefined {
+  return value === 'provisioning' || value === 'running' || value === 'failed' ? value : undefined;
+}
+
 function parseTenant(raw: Record<string, unknown>): Tenant {
   return {
     tenantId: asString(raw.tenantId),
@@ -57,6 +64,8 @@ function parseContext(raw: Record<string, unknown>): CloudContext {
     kubernetesContext: asOptionalString(raw.kubernetesContext),
     cloudProviderAlias: asOptionalString(raw.cloudProviderAlias),
     instanceType: asOptionalString(raw.instanceType),
+    status: asContextStatus(raw.status),
+    provisionError: asOptionalString(raw.provisionError),
   };
 }
 
@@ -108,4 +117,117 @@ export async function fetchConfig(token: string): Promise<TenantConfigView> {
 
   const body: unknown = await response.json();
   return parseConfig(body);
+}
+
+// The bearer-auth header every authenticated call sends, exactly as fetchConfig
+// builds it. `Accept` carries application/json; callers that send a body add
+// Content-Type themselves.
+function authHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/json',
+  };
+}
+
+// Issue `fetch` with the standard auth header, translating a transport failure
+// into a ConfigFetchError (status undefined) so callers see one error type.
+async function authedFetch(
+  path: string,
+  token: string,
+  init?: Omit<RequestInit, 'headers'> & { headers?: Record<string, string> },
+): Promise<Response> {
+  try {
+    return await fetch(`${API_BASE}${path}`, {
+      ...init,
+      headers: { ...authHeaders(token), ...init?.headers },
+    });
+  } catch {
+    throw new ConfigFetchError('could not reach the erun API', undefined);
+  }
+}
+
+// The BYO-cloud credentials an operator registers under an alias. `provider`
+// defaults to aws server-side; `credentials` is an opaque provider-specific JSON
+// string the API encrypts at rest (never returned).
+export interface CloudProviderAliasInput {
+  provider?: string;
+  credentials: string;
+}
+
+// Register/update the tenant's BYO-cloud credentials under `alias`
+// (`PUT /v1/cloud-provider-aliases/{alias}`). The API encrypts the credentials
+// at rest and returns 204 No Content; any non-2xx is a ConfigFetchError carrying
+// the status (e.g. 400 empty credentials, 401 bad token).
+export async function setCloudProviderAlias(
+  token: string,
+  alias: string,
+  input: CloudProviderAliasInput,
+): Promise<void> {
+  const response = await authedFetch(
+    `/v1/cloud-provider-aliases/${encodeURIComponent(alias)}`,
+    token,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    },
+  );
+  if (!response.ok) {
+    throw new ConfigFetchError(
+      `alias request failed (${String(response.status)})`,
+      response.status,
+    );
+  }
+}
+
+// The fields needed to register (provision) a cloud context.
+export interface CreateContextInput {
+  name: string;
+  cloudProviderAlias: string;
+  region: string;
+}
+
+// Register a cloud context and kick off its live bootstrap
+// (`POST /v1/contexts`, preview omitted so it defaults to false). Resolves to
+// the created context (parsed from the 202 body's `context` field, at status
+// `provisioning`); poll getContext to follow it to `running`/`failed`. A non-2xx
+// is a ConfigFetchError carrying the status (e.g. 400 missing field, 401).
+export async function createContext(
+  token: string,
+  input: CreateContextInput,
+): Promise<CloudContext> {
+  const response = await authedFetch('/v1/contexts', token, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!response.ok) {
+    throw new ConfigFetchError(
+      `create context request failed (${String(response.status)})`,
+      response.status,
+    );
+  }
+  const body: unknown = await response.json();
+  if (!isRecord(body) || !isRecord(body.context)) {
+    throw new ConfigFetchError('create context response was not in the expected shape');
+  }
+  return parseContext(body.context);
+}
+
+// Fetch one cloud context by id, including its provisioning `status`
+// (`GET /v1/contexts/{context_id}`). The console polls this after createContext
+// until status reaches `running`/`failed`.
+export async function getContext(token: string, contextId: string): Promise<CloudContext> {
+  const response = await authedFetch(`/v1/contexts/${encodeURIComponent(contextId)}`, token);
+  if (!response.ok) {
+    throw new ConfigFetchError(
+      `context request failed (${String(response.status)})`,
+      response.status,
+    );
+  }
+  const body: unknown = await response.json();
+  if (!isRecord(body)) {
+    throw new ConfigFetchError('context response was not in the expected shape');
+  }
+  return parseContext(body);
 }

--- a/erun-console/src/config/types.ts
+++ b/erun-console/src/config/types.ts
@@ -24,6 +24,13 @@ export interface Environment {
   runtimeVersion?: string;
 }
 
+// The provisioning lifecycle a context moves through once `POST /v1/contexts`
+// kicks off the live bootstrap (issue #605/#676): `provisioning` → `running`
+// (success) | `failed`. Kept as a string union for the known states but parsed
+// leniently from the wire (see parseContext) so an unknown future state still
+// renders rather than failing the parse.
+export type ContextStatus = 'provisioning' | 'running' | 'failed';
+
 export interface CloudContext {
   contextId: string;
   name: string;
@@ -33,6 +40,11 @@ export interface CloudContext {
   kubernetesContext?: string;
   cloudProviderAlias?: string;
   instanceType?: string;
+  // Provisioning status from `GET /v1/contexts/{id}` (omitted by the read model
+  // for contexts registered before live provisioning existed).
+  status?: ContextStatus;
+  // The failure reason when `status === 'failed'`.
+  provisionError?: string;
 }
 
 // The console's read model over the per-tenant erun config.

--- a/erun-console/src/provision/ProvisionPanel.test.tsx
+++ b/erun-console/src/provision/ProvisionPanel.test.tsx
@@ -1,0 +1,192 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ProvisionPanel } from './ProvisionPanel';
+
+// Component tests for the provisioning panel. `fetch` is mocked per request
+// (matched on method + URL) so each flow exercises the real client + controller
+// against the documented API shapes (api-protocol.md): PUT alias → 204,
+// POST /v1/contexts → 202 with the registered context at `provisioning`, then
+// GET /v1/contexts/{id} polled until `running`/`failed`.
+
+interface MockReq {
+  method: string;
+  url: string;
+  body: unknown;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+// A 204 has no JSON body; calling .json() would throw, matching the real fetch.
+function noContentResponse(): Response {
+  return {
+    ok: true,
+    status: 204,
+    json: () => Promise.reject(new Error('204 has no body')),
+  } as unknown as Response;
+}
+
+// The client always calls fetch with a string URL, so resolving the recorded
+// URL only needs the string and URL cases (no Request objects in these flows).
+function requestUrl(input: string | URL): string {
+  return input instanceof URL ? input.href : input;
+}
+
+// Install a fetch mock that records every request and answers via `handler`.
+function mockFetch(handler: (req: MockReq) => Response): MockReq[] {
+  const calls: MockReq[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: string | URL, init?: RequestInit) => {
+      const req: MockReq = {
+        method: init?.method ?? 'GET',
+        url: requestUrl(input),
+        body: init?.body !== undefined ? JSON.parse(init.body as string) : undefined,
+      };
+      calls.push(req);
+      return Promise.resolve(handler(req));
+    }),
+  );
+  return calls;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+const RUNNING_CONTEXT = {
+  contextId: 'ctx-9',
+  name: 'primary',
+  provider: 'aws',
+  cloudProviderAlias: 'aws-acme',
+  region: 'eu-west-2',
+  kubernetesContext: 'primary',
+  status: 'running',
+};
+
+const PROVISIONING_CONTEXT = { ...RUNNING_CONTEXT, status: 'provisioning' };
+
+describe('ProvisionPanel alias form', () => {
+  it('PUTs the BYO-cloud credentials to /v1/cloud-provider-aliases/{alias}', async () => {
+    const calls = mockFetch(() => noContentResponse());
+    render(<ProvisionPanel token="dev-token" />);
+
+    fireEvent.change(screen.getByLabelText('Alias name'), { target: { value: 'aws-acme' } });
+    fireEvent.change(
+      screen.getByLabelText('BYO-cloud credentials JSON (stored encrypted server-side)'),
+      { target: { value: '{"accessKeyId":"AK","secretAccessKey":"SK"}' } },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save credentials' }));
+
+    expect(
+      await screen.findByText('Credentials saved (encrypted server-side).'),
+    ).toBeInTheDocument();
+
+    const put = calls.find((c) => c.method === 'PUT');
+    expect(put).toBeDefined();
+    expect(put?.url).toBe('/v1/cloud-provider-aliases/aws-acme');
+    expect(put?.body).toEqual({
+      provider: 'aws',
+      credentials: '{"accessKeyId":"AK","secretAccessKey":"SK"}',
+    });
+  });
+
+  it('surfaces a 400 alias error', async () => {
+    mockFetch(() => jsonResponse('credentials empty', 400));
+    render(<ProvisionPanel token="dev-token" />);
+
+    fireEvent.change(screen.getByLabelText('Alias name'), { target: { value: 'aws-acme' } });
+    fireEvent.change(
+      screen.getByLabelText('BYO-cloud credentials JSON (stored encrypted server-side)'),
+      { target: { value: 'x' } },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save credentials' }));
+
+    expect(
+      await screen.findByText('Could not save credentials: alias request failed (400)'),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('ProvisionPanel create-context flow', () => {
+  it('POSTs the context then polls getContext and shows the final running status', async () => {
+    vi.useFakeTimers();
+    // POST → 202 provisioning; first GET still provisioning (so the poll loop is
+    // exercised), second GET running (terminal).
+    let getCount = 0;
+    const calls = mockFetch((req) => {
+      if (req.method === 'POST') {
+        return jsonResponse({ context: PROVISIONING_CONTEXT, plan: [] }, 202);
+      }
+      getCount += 1;
+      return getCount === 1 ? jsonResponse(PROVISIONING_CONTEXT) : jsonResponse(RUNNING_CONTEXT);
+    });
+    render(<ProvisionPanel token="dev-token" />);
+
+    fireEvent.change(screen.getByLabelText('Context name'), { target: { value: 'primary' } });
+    fireEvent.change(screen.getByLabelText('Cloud provider alias'), {
+      target: { value: 'aws-acme' },
+    });
+    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'eu-west-2' } });
+
+    // The click triggers the POST + first poll, whose promise resolutions update
+    // state; flush them inside act so React applies them before we assert.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Provision context' }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    // After the POST + first poll, the panel is in the polling state.
+    expect(screen.getByText('Provisioning primary…')).toBeInTheDocument();
+
+    // Advancing the poll interval fires the next GET, which returns `running`.
+    // Wrapped in act so the poll-driven state update is flushed inside React.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(screen.getByText('primary is running.')).toBeInTheDocument();
+
+    const post = calls.find((c) => c.method === 'POST');
+    expect(post?.url).toBe('/v1/contexts');
+    expect(post?.body).toEqual({
+      name: 'primary',
+      cloudProviderAlias: 'aws-acme',
+      region: 'eu-west-2',
+    });
+    expect(calls.some((c) => c.method === 'GET' && c.url === '/v1/contexts/ctx-9')).toBe(true);
+  });
+
+  it('shows the failed status plus the provision error from the poll', async () => {
+    const failed = {
+      ...RUNNING_CONTEXT,
+      status: 'failed',
+      provisionError: 'run-instances: InsufficientInstanceCapacity',
+    };
+    mockFetch((req) =>
+      req.method === 'POST'
+        ? jsonResponse({ context: failed, plan: [] }, 202)
+        : jsonResponse(failed),
+    );
+    render(<ProvisionPanel token="dev-token" />);
+
+    fireEvent.change(screen.getByLabelText('Context name'), { target: { value: 'primary' } });
+    fireEvent.change(screen.getByLabelText('Cloud provider alias'), {
+      target: { value: 'aws-acme' },
+    });
+    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'eu-west-2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Provision context' }));
+
+    // The 202 already carries `failed`, so the terminal state is shown without
+    // polling — both the status line and the reason render.
+    expect(await screen.findByText('primary failed to provision.')).toBeInTheDocument();
+    expect(screen.getByText('run-instances: InsufficientInstanceCapacity')).toBeInTheDocument();
+  });
+});

--- a/erun-console/src/provision/ProvisionPanel.tsx
+++ b/erun-console/src/provision/ProvisionPanel.tsx
@@ -1,0 +1,193 @@
+import * as React from 'react';
+
+import type { AliasState, ProvisionState } from './controller';
+import { useProvisionController } from './controller';
+
+// "Provision a cloud context" panel: a thin render layer over the provisioning
+// controller. It collects the BYO-cloud alias credentials and the create-context
+// fields, then surfaces the live provisioning status (the controller polls
+// GET /v1/contexts until running/failed). No business logic lives here — every
+// request goes through the controller, which calls the typed client.
+
+const DEFAULT_PROVIDER = 'aws';
+
+function AliasFeedback({ alias }: { alias: AliasState }): React.ReactElement | null {
+  if (alias.status === 'saved') {
+    return (
+      <p className="provision-feedback provision-feedback--ok" role="status">
+        Credentials saved (encrypted server-side).
+      </p>
+    );
+  }
+  if (alias.status === 'error') {
+    return (
+      <p className="provision-feedback provision-feedback--error" role="alert">
+        Could not save credentials: {alias.message}
+      </p>
+    );
+  }
+  return null;
+}
+
+function AliasForm({
+  alias,
+  onSave,
+}: {
+  alias: AliasState;
+  onSave: (alias: string, provider: string, credentials: string) => void;
+}): React.ReactElement {
+  const [name, setName] = React.useState('');
+  const [provider, setProvider] = React.useState(DEFAULT_PROVIDER);
+  const [credentials, setCredentials] = React.useState('');
+  const saving = alias.status === 'saving';
+
+  const submit = (event: React.SyntheticEvent): void => {
+    event.preventDefault();
+    onSave(name.trim(), provider.trim(), credentials);
+  };
+
+  return (
+    <form className="provision-form" onSubmit={submit} aria-labelledby="alias-form-heading">
+      <h3 id="alias-form-heading">Register cloud credentials</h3>
+      <label htmlFor="alias-name">Alias name</label>
+      <input
+        id="alias-name"
+        value={name}
+        onChange={(e) => {
+          setName(e.target.value);
+        }}
+        required
+      />
+      <label htmlFor="alias-provider">Provider</label>
+      <input
+        id="alias-provider"
+        value={provider}
+        onChange={(e) => {
+          setProvider(e.target.value);
+        }}
+      />
+      <label htmlFor="alias-credentials">
+        BYO-cloud credentials JSON (stored encrypted server-side)
+      </label>
+      <textarea
+        id="alias-credentials"
+        value={credentials}
+        onChange={(e) => {
+          setCredentials(e.target.value);
+        }}
+        rows={4}
+        placeholder={'{"accessKeyId":"…","secretAccessKey":"…"}'}
+        required
+      />
+      <button type="submit" disabled={saving}>
+        {saving ? 'Saving…' : 'Save credentials'}
+      </button>
+      <AliasFeedback alias={alias} />
+    </form>
+  );
+}
+
+function statusLine(provision: ProvisionState): string {
+  switch (provision.status) {
+    case 'creating':
+      return 'Registering context…';
+    case 'polling':
+      return `Provisioning ${provision.context.name}…`;
+    case 'running':
+      return `${provision.context.name} is running.`;
+    case 'failed':
+      return `${provision.context.name} failed to provision.`;
+    case 'error':
+      return `Request failed: ${provision.message}`;
+    case 'idle':
+      return '';
+  }
+}
+
+function feedbackRole(provision: ProvisionState): 'status' | 'alert' {
+  return provision.status === 'failed' || provision.status === 'error' ? 'alert' : 'status';
+}
+
+function ProvisionStatus({ provision }: { provision: ProvisionState }): React.ReactElement | null {
+  if (provision.status === 'idle') {
+    return null;
+  }
+  const failureReason =
+    provision.status === 'failed' ? provision.context.provisionError : undefined;
+  return (
+    <div className="provision-status" role={feedbackRole(provision)} aria-live="polite">
+      <p>{statusLine(provision)}</p>
+      {failureReason !== undefined && <p className="context-error">{failureReason}</p>}
+    </div>
+  );
+}
+
+function CreateContextForm({
+  provision,
+  onProvision,
+}: {
+  provision: ProvisionState;
+  onProvision: (input: { name: string; cloudProviderAlias: string; region: string }) => void;
+}): React.ReactElement {
+  const [name, setName] = React.useState('');
+  const [cloudProviderAlias, setAlias] = React.useState('');
+  const [region, setRegion] = React.useState('');
+  const busy = provision.status === 'creating' || provision.status === 'polling';
+
+  const submit = (event: React.SyntheticEvent): void => {
+    event.preventDefault();
+    onProvision({
+      name: name.trim(),
+      cloudProviderAlias: cloudProviderAlias.trim(),
+      region: region.trim(),
+    });
+  };
+
+  return (
+    <form className="provision-form" onSubmit={submit} aria-labelledby="context-form-heading">
+      <h3 id="context-form-heading">Provision a cloud context</h3>
+      <label htmlFor="context-name">Context name</label>
+      <input
+        id="context-name"
+        value={name}
+        onChange={(e) => {
+          setName(e.target.value);
+        }}
+        required
+      />
+      <label htmlFor="context-alias">Cloud provider alias</label>
+      <input
+        id="context-alias"
+        value={cloudProviderAlias}
+        onChange={(e) => {
+          setAlias(e.target.value);
+        }}
+        required
+      />
+      <label htmlFor="context-region">Region</label>
+      <input
+        id="context-region"
+        value={region}
+        onChange={(e) => {
+          setRegion(e.target.value);
+        }}
+        required
+      />
+      <button type="submit" disabled={busy}>
+        {busy ? 'Provisioning…' : 'Provision context'}
+      </button>
+      <ProvisionStatus provision={provision} />
+    </form>
+  );
+}
+
+export function ProvisionPanel({ token }: { token: string }): React.ReactElement {
+  const { alias, provision, saveAlias, provisionContext } = useProvisionController(token);
+  return (
+    <section className="provision-panel" aria-labelledby="provision-heading">
+      <h2 id="provision-heading">Provision a cloud context</h2>
+      <AliasForm alias={alias} onSave={saveAlias} />
+      <CreateContextForm provision={provision} onProvision={provisionContext} />
+    </section>
+  );
+}

--- a/erun-console/src/provision/controller.ts
+++ b/erun-console/src/provision/controller.ts
@@ -1,0 +1,138 @@
+import * as React from 'react';
+
+import {
+  createContext,
+  type CreateContextInput,
+  getContext,
+  setCloudProviderAlias,
+} from '../config/client';
+import type { CloudContext } from '../config/types';
+
+// Thin controller for the provisioning panel: it owns the request/poll state and
+// calls the typed client (setCloudProviderAlias / createContext / getContext).
+// It holds no business logic beyond sequencing those calls — the render layer
+// (ProvisionPanel) shows whatever state this hook exposes.
+
+// How often the create-context flow polls GET /v1/contexts/{id} while the
+// context is still `provisioning`.
+const POLL_INTERVAL_MS = 2000;
+
+// State of the alias-registration request.
+export type AliasState =
+  | { status: 'idle' }
+  | { status: 'saving' }
+  | { status: 'saved' }
+  | { status: 'error'; message: string };
+
+// State of the create-context + poll flow.
+export type ProvisionState =
+  | { status: 'idle' }
+  | { status: 'creating' }
+  // Registered (202) and polling getContext; `context` carries the latest poll.
+  | { status: 'polling'; context: CloudContext }
+  | { status: 'running'; context: CloudContext }
+  | { status: 'failed'; context: CloudContext }
+  | { status: 'error'; message: string };
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'unexpected error';
+}
+
+function isTerminal(context: CloudContext): boolean {
+  return context.status === 'running' || context.status === 'failed';
+}
+
+function terminalState(context: CloudContext): ProvisionState {
+  return context.status === 'failed'
+    ? { status: 'failed', context }
+    : { status: 'running', context };
+}
+
+export interface ProvisionController {
+  alias: AliasState;
+  provision: ProvisionState;
+  saveAlias: (alias: string, provider: string, credentials: string) => void;
+  provisionContext: (input: CreateContextInput) => void;
+}
+
+export function useProvisionController(token: string): ProvisionController {
+  const [alias, setAlias] = React.useState<AliasState>({ status: 'idle' });
+  const [provision, setProvision] = React.useState<ProvisionState>({ status: 'idle' });
+
+  // Guards the poll loop against running after the component unmounts.
+  const activeRef = React.useRef(true);
+  React.useEffect(() => {
+    activeRef.current = true;
+    return () => {
+      activeRef.current = false;
+    };
+  }, []);
+
+  const saveAlias = React.useCallback(
+    (aliasName: string, provider: string, credentials: string) => {
+      setAlias({ status: 'saving' });
+      setCloudProviderAlias(token, aliasName, { provider, credentials })
+        .then(() => {
+          setAlias({ status: 'saved' });
+        })
+        .catch((error: unknown) => {
+          setAlias({ status: 'error', message: errorMessage(error) });
+        });
+    },
+    [token],
+  );
+
+  const poll = React.useCallback(
+    (contextId: string) => {
+      if (!activeRef.current) {
+        return;
+      }
+      getContext(token, contextId)
+        .then((context) => {
+          if (!activeRef.current) {
+            return;
+          }
+          if (isTerminal(context)) {
+            setProvision(terminalState(context));
+            return;
+          }
+          setProvision({ status: 'polling', context });
+          setTimeout(() => {
+            poll(contextId);
+          }, POLL_INTERVAL_MS);
+        })
+        .catch((error: unknown) => {
+          if (activeRef.current) {
+            setProvision({ status: 'error', message: errorMessage(error) });
+          }
+        });
+    },
+    [token],
+  );
+
+  const provisionContext = React.useCallback(
+    (input: CreateContextInput) => {
+      setProvision({ status: 'creating' });
+      createContext(token, input)
+        .then((context) => {
+          if (!activeRef.current) {
+            return;
+          }
+          if (isTerminal(context)) {
+            setProvision(terminalState(context));
+            return;
+          }
+          setProvision({ status: 'polling', context });
+          poll(context.contextId);
+        })
+        .catch((error: unknown) => {
+          if (activeRef.current) {
+            setProvision({ status: 'error', message: errorMessage(error) });
+          }
+        });
+    },
+    [token, poll],
+  );
+
+  return { alias, provision, saveAlias, provisionContext };
+}

--- a/erun-console/src/styles.css
+++ b/erun-console/src/styles.css
@@ -92,3 +92,100 @@ th {
 .error-detail {
   font-size: 0.85rem;
 }
+
+.context-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid currentColor;
+}
+
+.status-badge--provisioning {
+  color: #92740a;
+}
+
+.status-badge--running {
+  color: #15803d;
+}
+
+.status-badge--failed {
+  color: #b91c1c;
+}
+
+.context-error {
+  color: #b91c1c;
+  font-size: 0.8rem;
+}
+
+.provision-panel {
+  border-top: 1px solid var(--border);
+  padding-top: 1.5rem;
+}
+
+.provision-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1.5rem;
+  max-width: 480px;
+}
+
+.provision-form h3 {
+  font-size: 0.95rem;
+  margin: 0 0 0.25rem;
+}
+
+.provision-form label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.provision-form input,
+.provision-form textarea {
+  font: inherit;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.provision-form button {
+  align-self: flex-start;
+  margin-top: 0.5rem;
+  padding: 0.4rem 0.9rem;
+  font: inherit;
+  font-weight: 600;
+  color: var(--bg);
+  background: var(--accent);
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.provision-form button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.provision-feedback,
+.provision-status {
+  font-size: 0.85rem;
+  margin: 0.25rem 0 0;
+}
+
+.provision-feedback--ok,
+.provision-status {
+  color: var(--muted);
+}
+
+.provision-feedback--error {
+  color: #b91c1c;
+}


### PR DESCRIPTION
## What

Surfaces the live provisioning executor (#605/#676) in the erunpaas console — closing the **#605 → #606 loop**: an operator registers a BYO‑cloud alias, creates a cloud context, and watches it go `provisioning → running` (or `failed`), backed by the durable DBOS executor.

## Changes (erun-console only)

- **Status badge** — `ConfigView` renders a per‑context status badge (`provisioning`/`running`/`failed`); on failure the `provisionError` reason is shown inline (accessible text, non‑color‑only, not a bare `title`).
- **Client** — `setCloudProviderAlias` (PUT, 204), `createContext` (POST, 202), `getContext` (GET), plus shared `authedFetch`/`authHeaders` matching `fetchConfig`.
- **ProvisionPanel + `useProvisionController`** — register a BYO‑cloud alias (credentials field labeled "stored encrypted server‑side"), create a context, and watch live status via 2s polling of `getContext` until terminal. Visible system status, success/failure feedback (`role=status`/`alert`, `aria-live`), form error states. The hook holds no logic beyond sequencing the typed client.

## Tests

vitest + @testing-library, mocked `fetch` (9 total): running/failed badges + the failure reason; alias `PUT` body; the create‑context flow `POST`s then polls `getContext` to a final `running`; a `202`‑carrying‑`failed` renders the failure. `yarn typecheck`/`lint`/`format:check`/`build`/`test` all green.

## Scope

Only `erun-console/` touched. OIDC stays the flagged dev‑token placeholder (real PKCE‑against‑Zitadel remains a follow‑up needing a live IdP); the provisioning surface itself is genuinely verifiable via the mocked‑fetch component tests. Part of #606.

🤖 Generated with [Claude Code](https://claude.com/claude-code)