### PR TITLE
Ignore Playwright run output under erun-console

### DIFF
--- a/erun-console/.gitignore
+++ b/erun-console/.gitignore
@@ -3,3 +3,7 @@ dist/
 .vite/
 *.local
 .DS_Store
+
+# Playwright run output (regenerated; never committed)
+test-results/
+playwright-report/


### PR DESCRIPTION
`erun-console/.gitignore` ignored `node_modules/` but not Playwright's generated output dirs, so a local console e2e run left `erun-console/playwright/test-results/` (e.g. `.last-run.json`) showing as untracked noise in `git status`.

Adds `test-results/` and `playwright-report/` — Playwright's standard run-output dirs, which regenerate and must never be committed.

The console Playwright e2e suite itself is a documented follow-up (`erun-console/AGENTS.md` § Validation: the component test is the right weight for the current increment; a Playwright harness comes once the OIDC flow + a runnable backend stub exist), so it is intentionally not committed yet — this change only stops the run artifacts from leaking into `git status`.

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)