### PR TITLE
Fix erun-backend-api cold build: copy erun-common for the local replace

### DIFF
--- a/erun-devops/docker/erun-backend-api/Dockerfile
+++ b/erun-devops/docker/erun-backend-api/Dockerfile
@@ -5,6 +5,10 @@ FROM golang:1.26.0 AS builder
 WORKDIR /src
 
 COPY erun-backend/erun-backend-api/go.mod erun-backend/erun-backend-api/go.sum /src/erun-backend/erun-backend-api/
+# erun-backend-api's go.mod has `replace … => ../../erun-common`, so the replace
+# target must be in the build context. go mod download needs erun-common's go.mod
+# to resolve its (transitive) requires; the full source is copied before go build.
+COPY erun-common/go.mod /src/erun-common/go.mod
 
 WORKDIR /src/erun-backend/erun-backend-api
 
@@ -15,6 +19,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go mod download
 
+COPY erun-common /src/erun-common
 COPY erun-backend/erun-backend-api /src/erun-backend/erun-backend-api
 
 RUN --mount=type=cache,target=/go/pkg/mod \

--- a/erun-integration/image_build_replace_test.go
+++ b/erun-integration/image_build_replace_test.go
@@ -1,0 +1,110 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestImageDockerfilesCopyLocalReplaceTarget guards the regression in #691: a
+// module whose go.mod locally replaces erun-common (`replace … => ../../erun-common`)
+// can only build when the replace target is present in the Docker build context.
+// erun-backend-api's image Dockerfile copied only the module's own go.mod/go.sum,
+// so a cold (fingerprint-cache-miss) build failed at `go mod download` reading the
+// missing ../../erun-common — surfacing only on a fresh release version. The
+// invariant: every erun-devops image Dockerfile that builds an erun-common-replacing
+// module must COPY erun-common before its first `go mod download`.
+func TestImageDockerfilesCopyLocalReplaceTarget(t *testing.T) {
+	root := repoRoot(t)
+
+	cases := []struct {
+		name       string
+		goMod      string // module whose go.mod is checked for the local replace
+		dockerfile string // image Dockerfile that builds it
+	}{
+		{"erun-backend-api", "erun-backend/erun-backend-api/go.mod", "erun-devops/docker/erun-backend-api/Dockerfile"},
+		{"erun-devops (erun + emcp)", "erun-cli/go.mod", "erun-devops/docker/erun-devops/Dockerfile"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			goMod := mustReadRepoFile(t, root, tc.goMod)
+			if !strings.Contains(goMod, "replace github.com/sophium/erun/erun-common => ") {
+				t.Skipf("%s no longer replaces erun-common locally; invariant moot", tc.goMod)
+			}
+
+			df := mustReadRepoFile(t, root, tc.dockerfile)
+			download := indexOfCommandLine(df, "go mod download")
+			if download < 0 {
+				t.Fatalf("%s builds %s but has no `go mod download` step", tc.dockerfile, tc.goMod)
+			}
+			copyCommon := indexOfCopyErunCommon(df)
+			if copyCommon < 0 {
+				t.Fatalf("%s builds erun-common-replacing module %s but never COPYs erun-common into the build context — a cold build fails at `go mod download` reading the ../../erun-common replace target (regression #691)", tc.dockerfile, tc.goMod)
+			}
+			if copyCommon > download {
+				t.Fatalf("%s COPYs erun-common only after `go mod download`; the replace target must be present before the download (regression #691)", tc.dockerfile)
+			}
+		})
+	}
+}
+
+// indexOfCommandLine returns the byte offset of the first non-comment line
+// containing substr (so a comment that merely mentions `go mod download` is not
+// mistaken for the build step itself), or -1 if absent.
+func indexOfCommandLine(dockerfile, substr string) int {
+	offset := 0
+	for _, line := range strings.SplitAfter(dockerfile, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "#") && strings.Contains(line, substr) {
+			return offset
+		}
+		offset += len(line)
+	}
+	return -1
+}
+
+// indexOfCopyErunCommon returns the byte offset of the first `COPY erun-common…`
+// line (matching both `COPY erun-common/go.mod …` and `COPY erun-common /dest`),
+// or -1 if absent.
+func indexOfCopyErunCommon(dockerfile string) int {
+	offset := 0
+	for _, line := range strings.SplitAfter(dockerfile, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "COPY erun-common") {
+			return offset
+		}
+		offset += len(line)
+	}
+	return -1
+}
+
+func mustReadRepoFile(t *testing.T, root, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, rel))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(b)
+}
+
+// repoRoot walks up from the test's working directory to the repository root
+// (the directory that holds erun-devops), so the test reads source files no
+// matter where `go test` is invoked.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if st, err := os.Stat(filepath.Join(dir, "erun-devops")); err == nil && st.IsDir() {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not locate repo root (no erun-devops dir found walking up)")
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Problem
`erun release` / `erun push` fails building `erun-backend-api` at `go mod download` on any cold (fingerprint-cache-miss) build — i.e. every fresh release version. v1.0.97 and v1.0.98 cut their tags + GitHub releases + version-bump commits but **never published images** because of this.

```
go: github.com/sophium/erun/erun-common@v0.0.0 (replaced by ../../erun-common):
    reading /src/erun-common/go.mod: open /src/erun-common/go.mod: no such file or directory
```

## Root cause
`erun-backend/erun-backend-api/go.mod` has `replace github.com/sophium/erun/erun-common => ../../erun-common`, but `erun-devops/docker/erun-backend-api/Dockerfile` copied only the module's own `go.mod`/`go.sum`, so the replace target is absent in the build context. It built on a dev laptop (full monorepo present) and when the image was promoted from a fingerprint cache, hiding the bug since backend-api began importing `erun-common` (the MCP-token work). The sibling `erun-devops` image already does this correctly.

## Fix
Mirror the `erun-devops` Dockerfile pattern: `COPY erun-common/go.mod` before `go mod download`, and `COPY erun-common` before `go build`. `erun-common` has no further local replaces, so it is self-contained.

## Verification
- Diagnosed and reproduced **inside the live `erun-local` pod's dind** via its MCP endpoint: a fresh single-module download succeeds (proving network/proxy/go.sum are healthy), while the build's full `go mod download` fails on the missing replace target.
- **Verified the fix in that same dind**: built the corrected builder stage against the pod's real checkout — `go mod download` (11.5s) + `go build -o /out/eapi` (arm64, 10.8s) both succeed, image exported, exit 0.
- Regression test (`erun-integration/image_build_replace_test.go`): asserts every erun-devops image Dockerfile that builds an `erun-common`-replacing module COPYs `erun-common` before its `go mod download` (covers `erun-backend-api` and the `erun-devops` erun+emcp image).
- `make integration-test` green (75.1%); `golangci-lint` clean.

## Follow-up for the operator
v1.0.97 / v1.0.98 are published releases without images. After this lands, completing a release is `erun push --version 1.0.98` (don't re-run `erun release` — it cuts a new version). Builds now succeed cold.

Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)