### PR TITLE
Skip the Dockerfile-copy guard in the partial in-build context (#691 follow-up)

### DIFF
--- a/erun-integration/image_build_replace_test.go
+++ b/erun-integration/image_build_replace_test.go
@@ -16,7 +16,15 @@ import (
 // invariant: every erun-devops image Dockerfile that builds an erun-common-replacing
 // module must COPY erun-common before its first `go mod download`.
 func TestImageDockerfilesCopyLocalReplaceTarget(t *testing.T) {
-	root := repoRoot(t)
+	// The integration suite also runs inside the erun-devops image build, whose
+	// context copies only the Go modules (erun-cli/common/mcp/integration) — not
+	// erun-backend/ or erun-devops/docker/. This static Dockerfile guard needs the
+	// full source tree, so it no-ops in that partial context and runs on a full
+	// checkout (where a developer/CI runs the gate before a release).
+	root, ok := findFullCheckoutRoot()
+	if !ok {
+		t.Skip("full source tree not present (partial in-build build context); this Dockerfile-content guard runs on a full checkout")
+	}
 
 	cases := []struct {
 		name       string
@@ -88,22 +96,23 @@ func mustReadRepoFile(t *testing.T, root, rel string) string {
 	return string(b)
 }
 
-// repoRoot walks up from the test's working directory to the repository root
-// (the directory that holds erun-devops), so the test reads source files no
-// matter where `go test` is invoked.
-func repoRoot(t *testing.T) string {
-	t.Helper()
+// findFullCheckoutRoot walks up from the working directory looking for the
+// erun-backend-api image Dockerfile — a file present only in a full checkout,
+// not in the partial erun-devops in-build context. Returns (root, true) when
+// found, ("", false) otherwise so callers can skip.
+func findFullCheckoutRoot() (string, bool) {
 	dir, err := os.Getwd()
 	if err != nil {
-		t.Fatalf("getwd: %v", err)
+		return "", false
 	}
+	const sentinel = "erun-devops/docker/erun-backend-api/Dockerfile"
 	for {
-		if st, err := os.Stat(filepath.Join(dir, "erun-devops")); err == nil && st.IsDir() {
-			return dir
+		if _, err := os.Stat(filepath.Join(dir, sentinel)); err == nil {
+			return dir, true
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			t.Fatal("could not locate repo root (no erun-devops dir found walking up)")
+			return "", false
 		}
 		dir = parent
 	}


### PR DESCRIPTION
Follow-up to #692. The #691 regression test reads `erun-backend/` and `erun-devops/docker/` files, but the integration suite also runs **inside the erun-devops image build** (the `make check` test stage), whose context copies only `erun-cli`/`erun-common`/`erun-mcp`/`erun-integration`. The test fataled on the missing files, failing `make check` → failing the `erun-devops` image build (the release build's next step after the #691 `erun-backend-api` fix landed).

Fix: locate the full source tree by a sentinel (`erun-devops/docker/erun-backend-api/Dockerfile`) and `t.Skip` when it's absent (partial in-build context). The guard still runs on a full checkout — where the gate runs before a release.

## Verification
- Local full checkout: the guard runs and **passes** (both `erun-backend-api` and `erun-devops` cases).
- **Live `erun-local` pod, reproduced partial context** (only the modules the erun-devops build copies, no `erun-backend`/`erun-devops/docker`): the test **skips** and the full integration suite passes (exit 0) — i.e. the in-build `make check` will now pass.
- `make integration-test` green; `golangci-lint` clean.

Closes #693
🤖 Generated with [Claude Code](https://claude.com/claude-code)