### PR TITLE
Add deploy --runtime-image to bootstrap envs on the ERun base image

### DIFF
--- a/erun-cli/cmd/deploy.go
+++ b/erun-cli/cmd/deploy.go
@@ -20,12 +20,14 @@ func newDeployCmd(store common.DeployStore, saveEnvConfig common.EnvConfigSaver,
 			"at a version, by reference. It never builds or pushes — produce a version with `erun build` " +
 			"and `erun push` (or `erun build --deploy` to chain them) first. Pass the version with " +
 			"--version; use --current to redeploy the version this environment already runs. " +
+			"Pass --runtime-image to install the canonical ERun base image (or any image) via the " +
+			"published runtime chart — useful to bootstrap an environment before its own image is built. " +
 			"Defaults to the current scope; pass TENANT and ENVIRONMENT (or --tenant/--environment) to target another.\n\n" +
 			"deploy waits for the rollout to become ready — default 5m, or the env's `deploy.timeout`, " +
 			"or --rollout-timeout — and watches the new pods: it keeps waiting while an image is still " +
 			"pulling and aborts early on a real container failure (crash, config error, or a permanent " +
 			"image-pull rejection) instead of waiting out the timeout.",
-		Example:       "  erun deploy team prod --version 1.2.3\n  erun deploy team dev --current\n  erun deploy team prod --version 1.2.3 --rollout-timeout 10m",
+		Example:       "  erun deploy team prod --version 1.2.3\n  erun deploy team dev --current\n  erun deploy team dev --version 1.2.3 --runtime-image ghcr.io/sophium/erun-devops\n  erun deploy team prod --version 1.2.3 --rollout-timeout 10m",
 		Args:          cobra.MaximumNArgs(2),
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -63,6 +65,7 @@ func newDeployCmd(store common.DeployStore, saveEnvConfig common.EnvConfigSaver,
 	}
 	addDryRunFlag(cmd)
 	addDeployCommandTargetFlags(cmd, &target)
+	cmd.Flags().StringVar(&target.RuntimeImageOverride, "runtime-image", "", "Install the runtime running this image via the published erun-devops chart (imageOverrides.erun-devops), pinned to --version, even when the env has a repo-local runtime chart; mirrors `erun open --runtime-image`")
 	cmd.Flags().BoolVar(&useCurrent, "current", false, "Redeploy the version this environment already runs (its persisted runtime version) instead of passing --version")
 	cmd.Flags().StringSliceVar(&components, "components", nil, fmt.Sprintf("Opt-in components to include alongside the runtime chart (%s)", strings.Join(common.OptInDeployComponentNames(), ", ")))
 	return cmd

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -256,6 +256,16 @@ type DeployTarget struct {
 	// public key on both its deploy paths; the CLI exposes it as
 	// `--mcp-auth-public-key`.
 	MCPAuthPublicKeyPath string
+	// RuntimeImageOverride, when set, installs the runtime via the canonical
+	// published erun-devops chart with this image as imageOverrides.erun-devops,
+	// pinned to the deploy version — even when the env has a repo-local runtime
+	// chart. It lets an operator bootstrap an env on the canonical ERun image (or
+	// any external image) before the env's own <tenant>-devops image exists, then
+	// switch to the tenant image once it is built. The CLI exposes it as
+	// `--runtime-image`, mirroring `erun open --runtime-image`; the raw value is
+	// recorded as EnvConfig.RuntimeImage so a later open/redeploy addresses the
+	// same image. Empty leaves runtime-chart resolution untouched (#697).
+	RuntimeImageOverride string
 }
 
 // DeploySpec is a pure helm-install plan: it installs the image and chart
@@ -685,6 +695,17 @@ func resolveCurrentDeploySpecs(ctx Context, store DeployStore, findProjectRoot P
 		return nil, err
 	}
 
+	runtimeImageOverride := strings.TrimSpace(target.RuntimeImageOverride)
+	if runtimeImageOverride != "" {
+		// The operator chose the runtime image explicitly (the desktop picker's
+		// ERun-base entry, or `--runtime-image`). Record it on the env so the
+		// remote/published-chart paths honour it as imageOverrides.erun-devops and
+		// a later open/redeploy addresses the same image; the local-chart branch
+		// reroutes through the published chart so the override wins even when a
+		// repo-local runtime chart exists (#697).
+		resolvedTarget.EnvConfig.RuntimeImage = runtimeImageOverride
+	}
+
 	if resolvedTarget.RemoteRepo() {
 		return resolveRemoteRepoDeploySpecs(ctx, store, resolvedTarget, target.VersionOverride)
 	}
@@ -708,7 +729,7 @@ func resolveCurrentDeploySpecs(ctx Context, store DeployStore, findProjectRoot P
 
 	specs := make([]DeploySpec, 0, len(deployContexts))
 	for _, deployContext := range deployContexts {
-		spec, err := resolveDeploySpecForContext(ctx, store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, resolvedTarget, deployContext, target.VersionOverride, currentBuild)
+		spec, err := resolveDeploySpecForContext(ctx, store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, resolvedTarget, deployContext, target.VersionOverride, currentBuild, runtimeImageOverride)
 		if err != nil {
 			return nil, err
 		}
@@ -761,10 +782,10 @@ func resolveDeploySpecForOpenResult(ctx Context, store DeployStore, findProjectR
 		return DeploySpec{}, err
 	}
 
-	return resolveDeploySpecForContext(ctx, store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target, deployContext, versionOverride, currentBuild)
+	return resolveDeploySpecForContext(ctx, store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target, deployContext, versionOverride, currentBuild, "")
 }
 
-func resolveDeploySpecForContext(ctx Context, store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, deployContext KubernetesDeployContext, versionOverride string, currentBuild *DockerBuildSpec) (DeploySpec, error) {
+func resolveDeploySpecForContext(ctx Context, store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, deployContext KubernetesDeployContext, versionOverride string, currentBuild *DockerBuildSpec, runtimeImageOverride string) (DeploySpec, error) {
 	// A pure deploy installs by reference; only the store is consulted (for
 	// cloud/tenant metadata and image verification). findProjectRoot,
 	// resolveDockerBuildContext, resolveKubernetesDeployContext, and now are
@@ -798,6 +819,14 @@ func resolveDeploySpecForContext(ctx Context, store DeployStore, findProjectRoot
 	}
 	if version == "" {
 		return DeploySpec{}, fmt.Errorf("deploy: a version is required — pass a version produced by `erun build`/`erun push`, or `--current` to redeploy the version this environment already runs")
+	}
+	// An explicit runtime-image override installs the canonical published
+	// erun-devops chart with the chosen image (imageOverrides.erun-devops),
+	// bypassing the repo-local runtime chart so the operator can bootstrap the
+	// env on the ERun base image before its own <tenant>-devops image exists
+	// (#697). target.EnvConfig.RuntimeImage already carries the override.
+	if runtimeImageOverride != "" && deployContextOwnsRuntimeChart(deployContext, target.Tenant) {
+		return resolvePublishedDevopsDeploySpecWithReason(ctx, target, version, "bypassing the repo-local runtime chart for the runtime image override "+runtimeImageOverride)
 	}
 	return resolveInstallExistingVersionDeploySpec(ctx, store, target, deployContext, version, versionFromPersist)
 }

--- a/erun-common/published_devops_chart.go
+++ b/erun-common/published_devops_chart.go
@@ -46,6 +46,14 @@ func ResolvePublishedDevopsDeploySpec(ctx Context, target OpenResult, versionOve
 // scaffold per tenant — the copy had already drifted from the canonical
 // chart (#510); the published chart is the single contract (#505).
 func resolvePublishedDevopsDeploySpec(ctx Context, target OpenResult, versionOverride string) (DeploySpec, error) {
+	// "no local runtime chart" is the reason the published chart is used on the
+	// usual callers (remote envs, envs with no <tenant>-devops chart). The
+	// runtime-image override caller passes its own reason, since the env there
+	// does have a local chart it is deliberately bypassing (#697).
+	return resolvePublishedDevopsDeploySpecWithReason(ctx, target, versionOverride, "no local runtime chart")
+}
+
+func resolvePublishedDevopsDeploySpecWithReason(ctx Context, target OpenResult, versionOverride, reason string) (DeploySpec, error) {
 	registry := publishedDevopsChartRegistry(target)
 	version := strings.TrimSpace(versionOverride)
 	if version == "" {
@@ -56,12 +64,12 @@ func resolvePublishedDevopsDeploySpec(ctx Context, target OpenResult, versionOve
 		// plan before returning. This is the fresh-env path — no local chart
 		// and no persisted/overridden runtime version — that a desktop create
 		// must avoid by composing deploy at a built version (issue #644).
-		ctx.Trace("deploy: no local runtime chart and no runtime version resolved; cannot deploy the published " + DevopsComponentName + " chart")
+		ctx.Trace("deploy: " + reason + " and no runtime version resolved; cannot deploy the published " + DevopsComponentName + " chart")
 		return DeploySpec{}, fmt.Errorf("runtime version is required to deploy the published %s chart: pass --version or persist runtimeversion in the env config", DevopsComponentName)
 	}
 
 	chartReference := publishedDevopsChartReference(registry)
-	ctx.Trace("deploy: no local runtime chart; using published chart " + chartReference + " version " + version)
+	ctx.Trace("deploy: " + reason + "; using published chart " + chartReference + " version " + version)
 
 	deployContext := KubernetesDeployContext{
 		ComponentName: DevopsComponentName,

--- a/erun-docs/docs/agent-reference/cli-flags.md
+++ b/erun-docs/docs/agent-reference/cli-flags.md
@@ -248,7 +248,7 @@ gh auth token -u <owner> -h github.com | docker login ghcr.io -u <owner> --passw
 
 ### Common flags
 
-`--version`, `--current`, `--components`, `--force`, `--rollout-timeout`, `--dry-run`, `--output`. Subcommand: `erun deploy <component>`.
+`--version`, `--runtime-image`, `--current`, `--components`, `--force`, `--rollout-timeout`, `--dry-run`, `--output`. Subcommand: `erun deploy <component>`.
 
 ### Version selection — `--version` / `--current` (required)
 
@@ -268,6 +268,16 @@ Once the version is resolved, `deploy`:
 3. Errors during resolution, before `helm upgrade`, when an image at the version is absent both locally and in the registry: `deploy --version <v>: image <ref> is not present locally or in the registry; deploy installs an existing version and does not build it — run erun build/push to create it first`.
 
 The dry-run trace names the decision per spec: `deploy: version <v> pinned; installing the published image, no local build`. Every env installs by reference from the published `oci://…/charts/erun-devops` chart (or the repo-local chart when the project carries one).
+
+### Runtime image override — `--runtime-image` {#deploy-runtime-image}
+
+`--runtime-image <ref>` installs the runtime running the given image via the canonical published `erun-devops` chart (the image rides in as `imageOverrides.erun-devops`), pinned to `--version` — **even when the env carries a repo-local `<tenant>-devops` chart**, which the override deliberately bypasses. This lets an operator bootstrap an environment on the canonical ERun base image (or any external image) before the env's own `<tenant>-devops` image has been built and pushed, then switch to the tenant image once it exists. It mirrors [`erun open --runtime-image`](#erun-open) but on the pure `deploy` primitive (it does not imply anything beyond the deploy).
+
+| Flag | Type | Default | Validation | Persists to |
+|---|---|---|---|---|
+| `--runtime-image <ref>` | string (OCI image ref) | unset → the env's resolved runtime image (repo-local chart, or `EnvConfig.runtimeimage`). | Same reference rules as [`erun init --runtime-image`](#erun-init): a full reference (registry path and/or tag present) is used verbatim; a bare/tagless reference is qualified against the env's registry and pinned to `<version>` (never `:latest`). | `EnvConfig.runtimeimage`, so a later `open`/redeploy addresses the same image. |
+
+The dry-run trace names the decision: `deploy: bypassing the repo-local runtime chart for the runtime image override <ref>; using published chart <chart> version <v>`, followed by `deploy: runtime image override <ref>:<v> (imageOverrides.erun-devops)`. The desktop runtime dialog threads this flag automatically when the operator picks the ERun-base entry in the version picker (#697); picking the env's own `<tenant>-devops` image deploys the env's own chart with no override.
 
 ### `--components` value set {#components-value-set}
 

--- a/erun-docs/docs/cli/deploy.md
+++ b/erun-docs/docs/cli/deploy.md
@@ -30,12 +30,23 @@ helm upgrade --install <tenant>-devops oci://<registry>/charts/erun-devops --ver
 
 The chart and runtime image are one contract — published together to the same registry at the same version. [`erun push`](/cli/push) publishes both at once, so whatever version `deploy` is handed already has a matching chart waiting; `deploy` only pulls and installs it, never publishes. Because push publishes the chart for *every* version it pushes — snapshot or release — any pushed version is deployable, with no chart-versus-image gap (see [Release flow](/deployment/release-flow)). The cluster pulls from the `deploy`-marked registry in the env's [registry list](/deployment/registries) (the env's recorded runtime registry wins as provenance); when the list marks a `from` and a `to`, ERun copies the image there first. The dry-run trace names the decision: `deploy: no local runtime chart; using published chart <ref> version <v>`. To customise a published-chart deploy, use the env's values overlay and the `runtimeimage` field — see [Configuration · Advanced chart values](/reference/configuration#advanced-chart-values).
 
+### Bootstrapping from the ERun base image {#runtime-image-bootstrap}
+
+A brand-new tenant environment has no `<tenant>-devops` image of its own yet — nothing to install by reference. `--runtime-image` lets you get it running on the canonical ERun base image first:
+
+```bash
+erun deploy team dev --version 1.2.3 --runtime-image ghcr.io/sophium/erun-devops
+```
+
+This installs the published `erun-devops` chart with `ghcr.io/sophium/erun-devops:1.2.3` as the runtime image, **bypassing any repo-local `<tenant>-devops` chart**. The chosen image is recorded as the env's runtime image, so a later `open` or `deploy --current` reuses it. Once you have built and pushed the env's own image, deploy that version without the flag (or pick the tenant image in the desktop runtime dialog) to switch over. The desktop's version picker offers both the ERun base image and the env's own image and threads this flag for you when you pick the base.
+
 ## Flags
 
 | Flag | Description |
 |---|---|
 | `--version <version>` | The published version to install, by reference. Required unless `--current` is given. The version's image and chart must already exist (locally or in the registry) or the deploy errors — `deploy` never builds them. |
 | `--current` | Redeploy the version the environment is already recorded as running (its persisted runtime version). Use it to re-roll the same version, or after a `--force`-style retry, without retyping the number. Required unless `--version` is given. |
+| `--runtime-image <ref>` | Install the runtime running this image via the published `erun-devops` chart (`imageOverrides.erun-devops`), pinned to `--version`, **even when the env has a repo-local runtime chart** (which it bypasses). Use it to [bootstrap an env on the canonical ERun base image](#runtime-image-bootstrap) before its own image is built; mirrors [`erun open --runtime-image`](/cli/open). |
 | `--components <name,name,...>` | Opt-in components to include alongside the runtime chart. The accepted values are a fixed set — `erun-backend-postgres`, `erun-backend-db`, `erun-backend-api`, `erun-powerdns` — and an unknown name is rejected with `unknown deploy component`. See [Agent reference · `--components`](/agent-reference/cli-flags#components-value-set). |
 | `--force` | Re-run helm upgrade even when the resolved version is unchanged and nothing needs rolling. |
 | `--rollout-timeout <dur>` | How long to wait for the rollout before giving up (e.g. `10m`). Defaults to the env's setting, or 5 minutes. Raise it for the first deploy of a large image on a slow connection; see [rollout wait and monitoring](/agent-reference/cli-flags#rollout-wait-and-pod-monitoring). |
@@ -82,6 +93,12 @@ Redeploy the version the environment already runs:
 
 ```bash
 erun deploy --current
+```
+
+Bootstrap a new environment on the canonical ERun base image (before its own image is built):
+
+```bash
+erun deploy team dev --version 1.2.3 --runtime-image ghcr.io/sophium/erun-devops
 ```
 
 Install a version plus the backend stack:

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -623,6 +623,26 @@ func TestDeploy(t *testing.T) {
 		golden.Equal(t, "deploy/dry_run_remote_env_runtime_image_without_tag", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_runtime_image_override_uses_published_chart", func(t *testing.T) {
+		// #697: `--runtime-image` installs the canonical published erun-devops
+		// chart with the chosen image as imageOverrides.erun-devops, pinned to
+		// --version, EVEN when the env carries a repo-local runtime chart
+		// (SeedDevopsRepo materializes team-devops/k8s/team-devops). The trace
+		// names the override decision and reroutes to the published chart
+		// instead of installing the local team-devops chart by reference, so an
+		// operator can bootstrap an env on the ERun base image before its own
+		// <tenant>-devops image is built. The tagless override is pinned to the
+		// deploy version (not :latest).
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"deploy", "team", "dev", "--version", "1.0.0", "--runtime-image", "ghcr.io/sophium/erun-devops", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "deploy/dry_run_runtime_image_override_uses_published_chart", normalize.Apply(result.Combined))
+	})
+
 	t.Run("dry_run_remote_env_values_overlay", func(t *testing.T) {
 		// A published-chart deploy has no chart directory to host the
 		// operator's values.<env>.yaml overlay; the env config dir's

--- a/erun-integration/testdata/deploy/dry_run_runtime_image_override_uses_published_chart.txt
+++ b/erun-integration/testdata/deploy/dry_run_runtime_image_override_uses_published_chart.txt
@@ -1,0 +1,12 @@
+audit: erun deploy --dry-run --runtime-image ghcr.io/sophium/erun-devops --version <VERSION> team dev
+trace-log: would append the full trace to <TMP>
+deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
+deploy: bypassing the repo-local runtime chart for the runtime image override ghcr.io/sophium/erun-devops; using published chart oci://registry.example/test/charts/erun-devops version <VERSION>
+deploy: runtime image override ghcr.io/sophium/erun-devops:<VERSION> (imageOverrides.erun-devops)
+deploy: resolved 1 spec(s)
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+helm upgrade --install --wait --wait-for-jobs --timeout 5m0s --namespace team-dev --debug --kube-context test-context --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string containerRegistry=registry.example/test --set-json 'containerRegistries=[{"registry":"registry.example/test","roles":["build","deploy"]}]' --set disableBuildScript=false --set-string imageOverrides.erun-devops=ghcr.io/sophium/erun-devops:<VERSION> --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops oci://registry.example/test/charts/erun-devops --version <VERSION>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)

--- a/erun-integration/testdata/deploy/help_outside_devops_cwd.txt
+++ b/erun-integration/testdata/deploy/help_outside_devops_cwd.txt
@@ -1,6 +1,6 @@
 Install a published version into an environment with helm.
 
-deploy is a pure consume operation: it installs the image and chart already published at a version, by reference. It never builds or pushes — produce a version with `erun build` and `erun push` (or `erun build --deploy` to chain them) first. Pass the version with --version; use --current to redeploy the version this environment already runs. Defaults to the current scope; pass TENANT and ENVIRONMENT (or --tenant/--environment) to target another.
+deploy is a pure consume operation: it installs the image and chart already published at a version, by reference. It never builds or pushes — produce a version with `erun build` and `erun push` (or `erun build --deploy` to chain them) first. Pass the version with --version; use --current to redeploy the version this environment already runs. Pass --runtime-image to install the canonical ERun base image (or any image) via the published runtime chart — useful to bootstrap an environment before its own image is built. Defaults to the current scope; pass TENANT and ENVIRONMENT (or --tenant/--environment) to target another.
 
 deploy waits for the rollout to become ready — default 5m, or the env's `deploy.timeout`, or --rollout-timeout — and watches the new pods: it keeps waiting while an image is still pulling and aborts early on a real container failure (crash, config error, or a permanent image-pull rejection) instead of waiting out the timeout.
 
@@ -10,19 +10,21 @@ Usage:
 Examples:
   erun deploy team prod --version <VERSION>
   erun deploy team dev --current
+  erun deploy team dev --version <VERSION> --runtime-image ghcr.io/sophium/erun-devops
   erun deploy team prod --version <VERSION> --rollout-timeout 10m
 
 Flags:
-      --components strings           Opt-in components to include alongside the runtime chart (erun-backend-postgres, erun-backend-db, erun-backend-api, erun-powerdns)
-      --current                      Redeploy the version this environment already runs (its persisted runtime version) instead of passing --version
-      --dry-run                      Resolve and trace mutating actions without executing them.
-      --environment string           Deploy for a specific environment; requires --tenant
-      --force                        Re-run the helm upgrade even when the deployed release already matches the requested version
-  -h, --help                         help for deploy
-      --mcp-auth-public-key string   Require the env's MCP edge to authenticate bearer tokens signed by this PEM public key (issue #655); empty leaves the edge loopback-only
-      --rollout-timeout string       Override the helm rollout wait for this deploy (Go duration, e.g. 8m); empty uses the env's deploy.timeout or the 5m default
-      --tenant string                Deploy for a specific tenant
-      --version erun build           Version to install by reference (produced by erun build/`erun push`); fails if that version's image is absent
+      --components strings                        Opt-in components to include alongside the runtime chart (erun-backend-postgres, erun-backend-db, erun-backend-api, erun-powerdns)
+      --current                                   Redeploy the version this environment already runs (its persisted runtime version) instead of passing --version
+      --dry-run                                   Resolve and trace mutating actions without executing them.
+      --environment string                        Deploy for a specific environment; requires --tenant
+      --force                                     Re-run the helm upgrade even when the deployed release already matches the requested version
+  -h, --help                                      help for deploy
+      --mcp-auth-public-key string                Require the env's MCP edge to authenticate bearer tokens signed by this PEM public key (issue #655); empty leaves the edge loopback-only
+      --rollout-timeout string                    Override the helm rollout wait for this deploy (Go duration, e.g. 8m); empty uses the env's deploy.timeout or the 5m default
+      --runtime-image erun open --runtime-image   Install the runtime running this image via the published erun-devops chart (imageOverrides.erun-devops), pinned to --version, even when the env has a repo-local runtime chart; mirrors erun open --runtime-image
+      --tenant string                             Deploy for a specific tenant
+      --version erun build                        Version to install by reference (produced by erun build/`erun push`); fails if that version's image is absent
 
 Global Flags:
       --output string   Result format: text (default, human stream) or json (structured result on stdout for orchestrators). (default "text")

--- a/erun-mcp/deploy.go
+++ b/erun-mcp/deploy.go
@@ -15,13 +15,14 @@ import (
 var errMissingDeployVersion = errors.New("deploy requires a version: it installs a published version by reference (produced by `build` then `push`) and never builds — set the version input")
 
 type DeployInput struct {
-	Component  string   `json:"component,omitempty" jsonschema:"component name for the devops k8s deploy COMPONENT command"`
-	Components []string `json:"components,omitempty" jsonschema:"opt-in components to include alongside the runtime chart (erun-backend-postgres, erun-backend-db, erun-backend-api, erun-powerdns); ignored when component is set"`
-	Version    string   `json:"version" jsonschema:"required published version to install by reference (produced by build then push); deploy installs by reference and never builds"`
-	Force      bool     `json:"force,omitempty" jsonschema:"when true, re-run the helm upgrade even when the deployed release already matches the requested version"`
-	Timeout    string   `json:"timeout,omitempty" jsonschema:"override the helm rollout wait for this deploy as a Go duration (e.g. 8m); empty uses the env's deploy.timeout or the 5m default. The deploy keeps waiting while an image is still pulling and aborts early on a real container failure"`
-	Preview    bool     `json:"preview,omitempty" jsonschema:"when true, resolve and print the planned actions without executing them"`
-	Verbosity  int      `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+	Component    string   `json:"component,omitempty" jsonschema:"component name for the devops k8s deploy COMPONENT command"`
+	Components   []string `json:"components,omitempty" jsonschema:"opt-in components to include alongside the runtime chart (erun-backend-postgres, erun-backend-db, erun-backend-api, erun-powerdns); ignored when component is set"`
+	Version      string   `json:"version" jsonschema:"required published version to install by reference (produced by build then push); deploy installs by reference and never builds"`
+	RuntimeImage string   `json:"runtime_image,omitempty" jsonschema:"install the runtime running this image via the published erun-devops chart (imageOverrides.erun-devops), pinned to version, even when the env has a repo-local runtime chart; use it to bootstrap an env on the canonical ERun base image before its own image is built"`
+	Force        bool     `json:"force,omitempty" jsonschema:"when true, re-run the helm upgrade even when the deployed release already matches the requested version"`
+	Timeout      string   `json:"timeout,omitempty" jsonschema:"override the helm rollout wait for this deploy as a Go duration (e.g. 8m); empty uses the env's deploy.timeout or the 5m default. The deploy keeps waiting while an image is still pulling and aborts early on a real container failure"`
+	Preview      bool     `json:"preview,omitempty" jsonschema:"when true, resolve and print the planned actions without executing them"`
+	Verbosity    int      `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
 }
 
 func deployTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, DeployInput) (*mcp.CallToolResult, CommandOutput, error) {
@@ -44,13 +45,14 @@ func deployTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReques
 			}
 
 			target := eruncommon.DeployTarget{
-				Tenant:          strings.TrimSpace(runtime.Context.Tenant),
-				Environment:     strings.TrimSpace(runtime.Context.Environment),
-				RepoPath:        workDir,
-				VersionOverride: strings.TrimSpace(input.Version),
-				Components:      input.Components,
-				Force:           input.Force,
-				RolloutTimeout:  strings.TrimSpace(input.Timeout),
+				Tenant:               strings.TrimSpace(runtime.Context.Tenant),
+				Environment:          strings.TrimSpace(runtime.Context.Environment),
+				RepoPath:             workDir,
+				VersionOverride:      strings.TrimSpace(input.Version),
+				RuntimeImageOverride: strings.TrimSpace(input.RuntimeImage),
+				Components:           input.Components,
+				Force:                input.Force,
+				RolloutTimeout:       strings.TrimSpace(input.Timeout),
 			}
 
 			component := strings.TrimSpace(input.Component)

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -742,6 +742,40 @@ func TestBuildInitArgsRuntimeTypeOmitsProjectRoot(t *testing.T) {
 func TestBuildDeployArgsRunsDeploy(t *testing.T) {
 	got := buildDeployArgs(uiSelection{Tenant: " erun ", Environment: " remote ", Version: " 1.0.19 "})
 	want := []string{"deploy", "erun", "remote", "--version", "1.0.19"}
+	assertArgsEqual(t, got, want)
+}
+
+// TestBuildDeployArgsThreadsRuntimeImageOverride covers #697: picking the
+// canonical ERun base image in the runtime dialog must thread --runtime-image so
+// deploy installs the published erun-devops chart with that image, letting the
+// operator bootstrap an env before its own image is built.
+func TestBuildDeployArgsThreadsRuntimeImageOverride(t *testing.T) {
+	got := buildDeployArgs(uiSelection{
+		Tenant:       "frs",
+		Environment:  "local",
+		Version:      "1.0.102",
+		RuntimeImage: "ghcr.io/sophium/erun-devops",
+	})
+	want := []string{"deploy", "frs", "local", "--version", "1.0.102", "--runtime-image", "ghcr.io/sophium/erun-devops"}
+	assertArgsEqual(t, got, want)
+}
+
+// TestBuildDeployArgsOmitsOwnTenantImage covers the other family: picking the
+// env's own <tenant>-devops image is not an override — deploy installs the env's
+// own chart as before, with no --runtime-image flag.
+func TestBuildDeployArgsOmitsOwnTenantImage(t *testing.T) {
+	got := buildDeployArgs(uiSelection{
+		Tenant:       "frs",
+		Environment:  "local",
+		Version:      "1.0.102",
+		RuntimeImage: "ghcr.io/sophium/frs-devops",
+	})
+	want := []string{"deploy", "frs", "local", "--version", "1.0.102"}
+	assertArgsEqual(t, got, want)
+}
+
+func assertArgsEqual(t *testing.T, got, want []string) {
+	t.Helper()
 	if len(got) != len(want) {
 		t.Fatalf("unexpected args length: got %+v want %+v", got, want)
 	}

--- a/erun-ui/deploy_orchestration.go
+++ b/erun-ui/deploy_orchestration.go
@@ -33,35 +33,51 @@ func (a *App) runDeployOrchestration(ctx context.Context, selection uiSelection,
 	onLine := newActivityTraceLineHandler(a, selection, sessionKindLocal)
 
 	if result.EnvConfig.BuildsHere() && !result.RemoteRepo() {
-		buildArgs := []string{"build", "--output", "json"}
-		if force {
-			buildArgs = append(buildArgs, "--no-incremental")
-		}
-		out, err := runErunCaptured(ctx, cli, dir, onLine, buildArgs...)
-		if err != nil {
-			return err
-		}
-		version := parseBuildResultVersion(out)
-		if version == "" {
-			return fmt.Errorf("build did not report a version to deploy")
-		}
-		if _, err := runErunCaptured(ctx, cli, dir, onLine, "push", "--version", version); err != nil {
-			return err
-		}
-		deployArgs := []string{"deploy", selection.Tenant, selection.Environment, "--version", version}
-		if force {
-			deployArgs = append(deployArgs, "--force")
-		}
-		deployArgs = a.appendMCPAuthPublicKeyFlag(deployArgs)
-		_, err = runErunCaptured(ctx, cli, dir, onLine, deployArgs...)
+		return a.runBuildPushDeployOrchestration(ctx, cli, dir, onLine, selection, force)
+	}
+	return a.runInstallByReferenceDeploy(ctx, cli, dir, onLine, selection, force)
+}
+
+// runBuildPushDeployOrchestration is the builds-here path: build the working
+// tree, push the minted version, then deploy it by reference, threading the
+// version `build` reported so what deploys is exactly what was built.
+func (a *App) runBuildPushDeployOrchestration(ctx context.Context, cli, dir string, onLine func(string), selection uiSelection, force bool) error {
+	buildArgs := []string{"build", "--output", "json"}
+	if force {
+		buildArgs = append(buildArgs, "--no-incremental")
+	}
+	out, err := runErunCaptured(ctx, cli, dir, onLine, buildArgs...)
+	if err != nil {
 		return err
 	}
+	version := parseBuildResultVersion(out)
+	if version == "" {
+		return fmt.Errorf("build did not report a version to deploy")
+	}
+	if _, err := runErunCaptured(ctx, cli, dir, onLine, "push", "--version", version); err != nil {
+		return err
+	}
+	deployArgs := []string{"deploy", selection.Tenant, selection.Environment, "--version", version}
+	if force {
+		deployArgs = append(deployArgs, "--force")
+	}
+	deployArgs = a.appendMCPAuthPublicKeyFlag(deployArgs)
+	_, err = runErunCaptured(ctx, cli, dir, onLine, deployArgs...)
+	return err
+}
 
+// runInstallByReferenceDeploy is the runtime/remote path: install the selected
+// version (or --current) by reference, threading the picked runtime-image
+// override so a bootstrap on the ERun base image rolls out (#697).
+func (a *App) runInstallByReferenceDeploy(ctx context.Context, cli, dir string, onLine func(string), selection uiSelection, force bool) error {
 	args := []string{"deploy", selection.Tenant, selection.Environment}
 	if version := strings.TrimSpace(selection.Version); version != "" {
 		args = append(args, "--version", version)
 	} else {
 		args = append(args, "--current")
+	}
+	if image := deployRuntimeImageOverride(selection); image != "" {
+		args = append(args, "--runtime-image", image)
 	}
 	if force {
 		args = append(args, "--force")

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -372,7 +372,36 @@ func buildDeployArgs(selection uiSelection) []string {
 		// install the persisted version via --current rather than erroring.
 		args = append(args, "--current")
 	}
+	if image := deployRuntimeImageOverride(selection); image != "" {
+		args = append(args, "--runtime-image", image)
+	}
 	return args
+}
+
+// deployRuntimeImageOverride returns the picked runtime image to pass as
+// `deploy --runtime-image` (#697), or "" to leave the deploy on the env's own
+// runtime chart. The version picker offers two families: the env's own tenant
+// image (<tenant>-devops) and the canonical ERun base image (erun-devops). A
+// pick of the env's own image deploys the env's own chart as before; only a
+// different image (the ERun base, or any external image) is an override that
+// deploy must install via the published runtime chart, so the operator can
+// bootstrap the env on the canonical image before its own image exists.
+func deployRuntimeImageOverride(selection uiSelection) string {
+	image := strings.TrimSpace(selection.RuntimeImage)
+	if image == "" {
+		return ""
+	}
+	repo := image
+	if idx := strings.LastIndex(repo, "/"); idx >= 0 {
+		repo = repo[idx+1:]
+	}
+	if idx := strings.IndexAny(repo, ":@"); idx >= 0 {
+		repo = repo[:idx]
+	}
+	if repo == eruncommon.RuntimeReleaseName(strings.TrimSpace(selection.Tenant)) {
+		return ""
+	}
+	return image
 }
 
 // buildUpgradeArgs builds the per-environment `erun upgrade` invocation:


### PR DESCRIPTION
## Problem

The desktop runtime dialog's version picker offers two image families per tenant env — the env's own `<tenant>-devops` image and the canonical ERun base image (`ghcr.io/sophium/erun-devops`, #501) — and each dropdown entry carries its own image. The frontend already threads the picked image into the deploy selection (`manageDeployThunks.ts`). But the Go deploy path dropped it:

- `buildDeployArgs` (erun-ui) passed only `--version`, never the picked image.
- `erun deploy` had no `--runtime-image` flag to receive it (`erun open` does).
- The install-by-reference deploy path ignored `EnvConfig.RuntimeImage` for an env with a repo-local runtime chart, resolving the local chart's own hardcoded image instead.

So picking the ERun base entry (e.g. `ghcr.io/sophium/erun-devops:1.0.102`, which exists) deployed `<env-registry>/<tenant>-devops:1.0.102` — a tenant image that was never built — and failed:

```
deploy: spec resolution failed: deploy --version 1.0.102: image erunpaas/frs-devops:1.0.102 is not present locally or in the registry; deploy installs an existing version and does not build it
```

## Fix

Add `--runtime-image` to `erun deploy` (mirroring `erun open --runtime-image`). When set, deploy installs the canonical published `erun-devops` chart with that image as `imageOverrides.erun-devops`, pinned to `--version`, **even when the env carries a repo-local runtime chart** (which it bypasses). This lets an operator bootstrap an env on the ERun base image before its own `<tenant>-devops` image is built, then switch to the tenant image once it exists. The desktop threads the picked image for the ERun-base family; the picker keeps offering both families. Additive — deploys without the flag are unchanged.

- **erun-common**: `DeployTarget.RuntimeImageOverride`; route the runtime chart through the published chart with the override; reason-parameterized the shared published-chart trace so existing goldens are untouched and the override path reads honestly.
- **erun-cli**: `deploy --runtime-image` (top-level `deploy` only, not the `devops k8s deploy COMPONENT` subcommand).
- **erun-mcp**: `deploy` tool `runtime_image` input (transport parity).
- **erun-ui**: thread the picked image in the deploy orchestration when it overrides the env's own `<tenant>-devops` image; split `runDeployOrchestration` into two helpers to stay under the complexity gate.
- **erun-integration**: dry-run golden `dry_run_runtime_image_override_uses_published_chart`; regenerated the `deploy --help` golden.
- **erun-docs**: documented `deploy --runtime-image` on `cli/deploy.md` and `agent-reference/cli-flags.md`.

## Docs plan

- `erun-docs/docs/cli/deploy.md` (Operator/CLI): flags-table row, a "Bootstrapping from the ERun base image" subsection with anchor, an Examples entry, and a note in the chart-source section. 
- `erun-docs/docs/agent-reference/cli-flags.md` (Agent): added `--runtime-image` to the common-flags line and a full spec subsection (reference rules, persistence, dry-run trace). 
- Validation: `cd erun-docs && yarn build` clean (no broken links/anchors).

## UX impact review (erun-ui/AGENTS.md)

1. **Affected paths**: Runtime dialog "Deploy" → `StartDeploySession` → `buildDeployArgs` → `erun deploy`; and the background `runDeployOrchestration` install-by-reference branch.
2. **User-visible sequence**: operator picks a version (ERun base or tenant) and clicks Deploy → deploy runs in the Local tab with the usual `==> Deploying / ==> Deployed` activity-queue trace. For an ERun-base pick the deploy now succeeds instead of failing at image resolution.
3. **State-without-affordance**: none — no new `AppState` mutations; the frontend already threaded `runtimeImage`. The change is Go arg-construction + deploy resolution.
4. **Visibility of system status / 5. success-failure feedback / 6. consistency**: unchanged — deploy progress and outcome surface through the existing activity-queue trace lines and env-status, identical to every other deploy.
7. **Heuristic pass**: error prevention — the picker's ERun-base entry now actually deploys instead of producing an opaque "image not present"; match-to-real-world — "bootstrap from the base image, then switch to my own" is the operator's mental model.
8. **Playwright**: no frontend source changed (the `runtimeImage` wiring already existed), so the observable surface is the Go arg-construction, covered by `TestBuildDeployArgsThreadsRuntimeImageOverride` / `TestBuildDeployArgsOmitsOwnTenantImage`. A real deploy needs a live cluster the headless harness lacks; verified live (see below).

## Verification

- `go test ./...` green in erun-common, erun-cli, erun-mcp, erun-ui.
- `make integration-test` green; coverage 75.1% ≥ 75.0%.
- `cd erun-docs && yarn build` clean.
- **End-to-end against the live target** (orbstack, `frs/local`, the originally-failing env): reproduced the original `image erunpaas/frs-devops:1.0.102 is not present` failure verbatim with the rebuilt binary, then ran the exact command the desktop now generates — `erun deploy frs local --version 1.0.102 --runtime-image ghcr.io/sophium/erun-devops` — and watched it succeed (`==> Deployed frs/local 1.0.102 in 48s`). The pod is `3/3 Running` on `ghcr.io/sophium/erun-devops:1.0.102`, helm release `frs-devops` chart `erun-devops-1.0.102`, and the env config persisted the chosen version/registry/image.
- Not driven: a literal click in the rebuilt desktop GUI (requires an `erun-app` rebuild + a human watching the dialog). The arg-construction half is unit-tested and the executed command was verified live, so both halves of the GUI path are covered.

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)