### PR TITLE
Regenerate stale linux-only release golden after the base-chart fixture change

### DIFF
--- a/erun-integration/AGENTS.md
+++ b/erun-integration/AGENTS.md
@@ -142,6 +142,18 @@ Rules:
 - Document the override in the test comment so a future reader does not delete it. Without the override the scenario would silently re-shape the golden to whatever host ran `UPDATE_GOLDEN=1` last.
 - The override is a deliberate test seam, not a production knob. If you find yourself wanting to set it from a CLI command or MCP tool, that is a sign the production code should be detecting differently — fix the detection.
 
+### Linux-only scenarios skip on macOS — regenerate their goldens in Linux
+
+A few scenarios gate on a real Linux capability the override can't fake — notably `TestRelease/dry_run_includes_linux_release_scripts`, which needs both `runtime.GOOS == "linux"` **and** `dpkg-deb` on PATH (linux package builds), so it `t.Skip`s on macOS. `ERUN_HOST_OS_OVERRIDE` only fakes `DetectHost`; it does not conjure `dpkg-deb`, so these goldens can only be regenerated where the capability actually exists.
+
+The trap: `UPDATE_GOLDEN=1` on macOS silently **skips** these scenarios, so a change to a **shared fixture** (e.g. `SeedReleaseRepo`) that alters their output leaves their goldens stale — green locally on macOS, red in the Linux image-build gate (`make check` inside the `erun-devops` Dockerfile), which is where it actually bites. When you touch a shared fixture, regenerate the linux-only goldens in Linux and run the full suite there before pushing:
+
+```sh
+docker run --rm -u "$(id -u):$(id -g)" -e HOME=/tmp -e GOCACHE=/tmp/gc -e GOMODCACHE=/tmp/gm \
+  -v "$PWD":/src -w /src/erun-integration golang:1.26 sh -c \
+  'git config --global --add safe.directory "*"; UPDATE_GOLDEN=1 go test ./... && go test ./...'
+```
+
 ## TTY-dependent branches: force via `ERUN_FORCE_TTY`
 
 The alias-setup flow in `erun open --no-shell` only prompts when stdout is a

--- a/erun-integration/testdata/release/dry_run_includes_linux_release_scripts.txt
+++ b/erun-integration/testdata/release/dry_run_includes_linux_release_scripts.txt
@@ -28,7 +28,12 @@ write <TMP>
   appVersion: <VERSION>
   name: api
   version: <VERSION>
-cd <TMP> && git add erun-devops/k8s/api/Chart.yaml
+write <TMP>
+  apiVersion: v2
+  appVersion: <VERSION>
+  name: base
+  version: <VERSION>
+cd <TMP> && git add erun-devops/k8s/api/Chart.yaml erun-devops/k8s/base/Chart.yaml
 cd <TMP> && git commit -m '[skip ci] release <VERSION>'
 git -C <TMP> rev-parse '<VERSION>^{}'
 cd <TMP> && git tag -a <VERSION> -m 'Release candidate <VERSION>'


### PR DESCRIPTION
## Problem

#702's `SeedReleaseRepo` change (added a `base` component chart, to exercise the version-pinned-base chart-publish fix) altered the output of **every** release scenario. But `TestRelease/dry_run_includes_linux_release_scripts` `t.Skip`s on non-Linux hosts (it needs `runtime.GOOS == "linux"` + `dpkg-deb`), so `UPDATE_GOLDEN=1` on macOS never regenerated it. The stale golden passed locally on darwin but failed `make check` **inside the `erun-devops` Linux image build** — breaking `erun build --release` for v1.0.104 (the release tag + package metadata pushed, but no images/charts published, because the in-image test gate fails before any image is tagged).

`ERUN_HOST_OS_OVERRIDE` can't pin this scenario — it fakes `DetectHost` but not the real `dpkg-deb` capability check — so its golden can only be regenerated where `dpkg-deb` exists (Linux).

## Fix

- Regenerate the golden **in Linux** (a `golang:1.26` container). The diff is exactly the `base` chart's version-bump write + its addition to the release `git add` line — the fixture change, reflected.
- Document the trap in `erun-integration/AGENTS.md`: linux-only scenarios skip on macOS, so a shared-fixture change must regenerate their goldens in a Linux env (one-liner `docker run` included).

## Verification

- Full integration suite **green in Linux** (`go test ./...` in `golang:1.26`) — the image-gate env.
- Darwin suite green (the linux-only scenario skips there, as designed).

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)