### PR TITLE
Fix erun-powerdns :53 bind on first real k3s deploy

### DIFF
--- a/erun-devops/k8s/erun-powerdns/templates/powerdns.yaml
+++ b/erun-devops/k8s/erun-powerdns/templates/powerdns.yaml
@@ -57,6 +57,14 @@
 {{- $platform := default dict .Values.platform -}}
 {{- $servicesZone := default "" $platform.servicesZone -}}
 {{- $nameservers := default (list) $platform.nameservers -}}
+{{- /* pdns listen address. Under hostNetwork a 0.0.0.0:53 bind collides with
+       systemd-resolved's 127.0.0.53:53 stub on nodes that run it, and the public
+       authoritative IP is typically a NAT'd address that is not a local
+       interface (so it can't be bound directly). Set powerdns.localAddress to
+       the node's own interface IP (the one the public IP NATs to) to bind a
+       specific local address and coexist with the node resolver. Defaults to
+       0.0.0.0 for nodes where :53 is already free. */ -}}
+{{- $localAddress := default "0.0.0.0" $powerdns.localAddress -}}
 {{- $configDir := "/etc/pdns-shared" -}}
 apiVersion: v1
 kind: Secret
@@ -120,7 +128,7 @@ spec:
               gpgsql-dbname={{ $powerdnsDatabase }}
               gpgsql-user={{ $postgresUser }}
               gpgsql-password=$PDNS_GPGSQL_PASSWORD
-              local-address=0.0.0.0
+              local-address={{ $localAddress }}
               local-port=53
               api=yes
               api-key=$PDNS_API_KEY
@@ -208,7 +216,12 @@ spec:
           image: {{ $powerdnsImage }}
           imagePullPolicy: IfNotPresent
           securityContext:
-            # Non-root pdns user binding privileged :53 under hostNetwork.
+            # Bind privileged :53 under hostNetwork. k8s adds capabilities to the
+            # bounding set, not the ambient set, so a non-root process cannot use
+            # NET_BIND_SERVICE on k3s/containerd — run as root to bind :53. (A
+            # cleaner alternative is to setcap cap_net_bind_service on the wrapper
+            # image's pdns_server and keep non-root; that needs an image rebuild.)
+            runAsUser: 0
             capabilities:
               add: ["NET_BIND_SERVICE"]
           command:


### PR DESCRIPTION
## Problem

`erun-powerdns` had **never been deployed before** its chart started publishing (#702). Its first real deploy (to live `frs-prod` on k3s) failed two ways:

1. **Privileged :53 bind as non-root.** The container ran as the non-root `pdns` user with `capabilities.add: [NET_BIND_SERVICE]`. k8s adds capabilities to the *bounding* set, not the *ambient* set, so a non-root process can't use `NET_BIND_SERVICE` on k3s/containerd → `Permission denied` binding `:53`.
2. **`0.0.0.0:53` collides with the node's `systemd-resolved` stub** (`127.0.0.53:53`) → `Address already in use`. The platform's public `authoritativeIP` (`212.93.120.230`) is a NAT'd address, not a local interface, so it can't be bound directly either.

## Fix

- Run the powerdns container as **root** (`runAsUser: 0`) so it can bind privileged `:53`. (Cleaner follow-up noted in-code: `setcap cap_net_bind_service` on the wrapper image and keep non-root — needs an image rebuild.)
- Make the listen address **configurable** via `powerdns.localAddress` (default `0.0.0.0`, preserving prior behavior for nodes where `:53` is already free), so an operator can bind the node's own interface IP (the one the public IP NATs to) and coexist with `systemd-resolved`.

## Verification (live)

Deployed to `frs-prod` with `powerdns.localAddress: 10.10.10.202`:
- pod **1/1 Running**, log shows `UDP/TCP server bound to 10.10.10.202:53`, `ready to distribute questions`.
- `pdnsutil list-all-zones` → `services.erunpaas.com`.
- `nslookup -type=soa/-type=ns services.erunpaas.com @10.10.10.202` answers SOA and **`ns1.erunpaas.com` + `ns2.erunpaas.com`**.
- `helm lint` clean.

No integration-golden impact (the suite's release fixture uses a minimal chart, not erun-powerdns).

## Follow-ups (separate, surfaced by the same first deploy)

- `ghcr.io/sophium/erun-powerdns` is **private** while its siblings (`erun-backend-postgres`, `erun-devops`) are public — the cluster can't pull it anonymously. Either make it public to match, or have `erun deploy` wire an env pull secret. (Worked around live with a `ghcr-pull` secret.)
- The zone's SOA primary renders as the powerdns default placeholder; the zone-bootstrap could set it to `ns1.<base-domain>` (cosmetic; serving is unaffected).

Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)