### PR TITLE
Fix erun deploy --runtime-image for a chartless local env

### DIFF
--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -707,11 +707,21 @@ func resolveCurrentDeploySpecs(ctx Context, store DeployStore, findProjectRoot P
 	}
 
 	if resolvedTarget.RemoteRepo() {
-		return resolveRemoteRepoDeploySpecs(ctx, store, resolvedTarget, target.VersionOverride)
+		return resolvePublishedDevopsDeploySpecs(ctx, store, resolvedTarget, target.VersionOverride)
 	}
 
 	deployContexts, err := resolveCurrentLocalDeployContexts(findProjectRoot, resolveKubernetesDeployContext, resolvedTarget, target.Components)
 	if err != nil {
+		// A local env with an explicit --runtime-image override but no repo-local
+		// runtime chart (the <tenant>-devops/k8s tree is absent) bootstraps on the
+		// published erun-devops chart by reference — the same install-by-reference
+		// path a remote-repo target uses — so the env can come up on the ERun base
+		// image before its own chart exists (#707). Without the override there is
+		// no chart to install, so the missing-tree error stands.
+		if runtimeImageOverride != "" && errors.Is(err, fs.ErrNotExist) {
+			ctx.Trace("deploy: no repo-local runtime chart; installing the published erun-devops chart for runtime image override " + runtimeImageOverride)
+			return resolvePublishedDevopsDeploySpecs(ctx, store, resolvedTarget, target.VersionOverride)
+		}
 		return nil, err
 	}
 
@@ -727,22 +737,28 @@ func resolveCurrentDeploySpecs(ctx Context, store DeployStore, findProjectRoot P
 		}
 	}
 
+	return resolveDeploySpecsForContexts(ctx, store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, resolvedTarget, deployContexts, target.VersionOverride, currentBuild, runtimeImageOverride)
+}
+
+// resolveDeploySpecsForContexts resolves a deploy spec for each local k8s deploy
+// context, preserving order.
+func resolveDeploySpecsForContexts(ctx Context, store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, deployContexts []KubernetesDeployContext, versionOverride string, currentBuild *DockerBuildSpec, runtimeImageOverride string) ([]DeploySpec, error) {
 	specs := make([]DeploySpec, 0, len(deployContexts))
 	for _, deployContext := range deployContexts {
-		spec, err := resolveDeploySpecForContext(ctx, store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, resolvedTarget, deployContext, target.VersionOverride, currentBuild, runtimeImageOverride)
+		spec, err := resolveDeploySpecForContext(ctx, store, findProjectRoot, resolveDockerBuildContext, resolveKubernetesDeployContext, now, target, deployContext, versionOverride, currentBuild, runtimeImageOverride)
 		if err != nil {
 			return nil, err
 		}
 		specs = append(specs, spec)
 	}
-
 	return specs, nil
 }
 
-// resolveRemoteRepoDeploySpecs resolves the single published-devops deploy spec
-// for a remote-repo target (no local k8s tree), attaching cloud/tenant metadata
-// to the helm input.
-func resolveRemoteRepoDeploySpecs(ctx Context, store DeployStore, resolvedTarget OpenResult, versionOverride string) ([]DeploySpec, error) {
+// resolvePublishedDevopsDeploySpecs resolves the single published-devops deploy
+// spec for a target with no local k8s tree to install — a remote-repo target, or
+// a local env bootstrapping on `--runtime-image` before its own <tenant>-devops
+// chart exists — attaching cloud/tenant metadata to the helm input.
+func resolvePublishedDevopsDeploySpecs(ctx Context, store DeployStore, resolvedTarget OpenResult, versionOverride string) ([]DeploySpec, error) {
 	spec, err := resolvePublishedDevopsDeploySpec(ctx, resolvedTarget, versionOverride)
 	if err != nil {
 		return nil, err

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -643,6 +643,30 @@ func TestDeploy(t *testing.T) {
 		golden.Equal(t, "deploy/dry_run_runtime_image_override_uses_published_chart", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_runtime_image_override_no_k8s_tree_uses_published_chart", func(t *testing.T) {
+		// #707: `--runtime-image` on a local env whose <tenant>-devops module has
+		// no k8s chart tree (os.ReadDir(.../k8s) → fs.ErrNotExist) must bootstrap
+		// on the published erun-devops chart by reference instead of failing spec
+		// resolution ("open .../k8s: no such file or directory"). The desktop's
+		// ERun-base picker deploys a bare tenant this way before its own
+		// <tenant>-devops chart exists. Contrast dry_run_no_devops_module_errors
+		// (no override → errors) and dry_run_runtime_image_override_uses_published_chart
+		// (chart present → reroutes). The module exists (docker + VERSION) but has
+		// no k8s tree, mirroring validation-agent-devops.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		fixture.SeedDevopsRuntimeDockerfile(t, setup, "team")
+		if err := os.RemoveAll(filepath.Join(setup.Cwd, "team-devops", "k8s")); err != nil {
+			t.Fatalf("remove k8s tree: %v", err)
+		}
+		result := erun.Run(t, []string{"deploy", "team", "dev", "--version", "1.0.0", "--runtime-image", "ghcr.io/sophium/erun-devops", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "deploy/dry_run_runtime_image_override_no_k8s_tree_uses_published_chart", normalize.Apply(result.Combined))
+	})
+
 	t.Run("dry_run_remote_env_values_overlay", func(t *testing.T) {
 		// A published-chart deploy has no chart directory to host the
 		// operator's values.<env>.yaml overlay; the env config dir's

--- a/erun-integration/testdata/deploy/dry_run_runtime_image_override_no_k8s_tree_uses_published_chart.txt
+++ b/erun-integration/testdata/deploy/dry_run_runtime_image_override_no_k8s_tree_uses_published_chart.txt
@@ -1,0 +1,13 @@
+audit: erun deploy --dry-run --runtime-image ghcr.io/sophium/erun-devops --version <VERSION> team dev
+trace-log: would append the full trace to <TMP>
+deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
+deploy: no repo-local runtime chart; installing the published erun-devops chart for runtime image override ghcr.io/sophium/erun-devops
+deploy: no local runtime chart; using published chart oci://registry.example/test/charts/erun-devops version <VERSION>
+deploy: runtime image override ghcr.io/sophium/erun-devops:<VERSION> (imageOverrides.erun-devops)
+deploy: resolved 1 spec(s)
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+helm upgrade --install --wait --wait-for-jobs --timeout 5m0s --namespace team-dev --debug --kube-context test-context --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string containerRegistry=registry.example/test --set-json 'containerRegistries=[{"registry":"registry.example/test","roles":["build","deploy"]}]' --set disableBuildScript=false --set-string imageOverrides.erun-devops=ghcr.io/sophium/erun-devops:<VERSION> --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops oci://registry.example/test/charts/erun-devops --version <VERSION>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)


### PR DESCRIPTION
## Problem

The desktop bootstraps a bare tenant env on the published ERun base image:

```
erun deploy validation-agent local --version 1.0.105 --runtime-image ghcr.io/sophium/erun-devops …
deploy: spec resolution failed: open /…/validation-agent/validation-agent-devops/k8s: no such file or directory
```

`--runtime-image` is meant to install the **published** `erun-devops` chart by reference, bypassing any repo-local runtime chart — exactly so an env can come up before its own `<tenant>-devops` chart/image exists (#697/#698). But `resolveCurrentDeploySpecs` resolved the local k8s deploy contexts (opening the missing `<tenant>-devops/k8s` tree) **before** the runtime-image published path (`resolveDeploySpecForContext`) could run, so a chartless local env errored instead of bootstrapping. The remote-repo path already did the right thing; local envs didn't.

## Fix

When the local k8s tree is absent (`fs.ErrNotExist`) **and** `--runtime-image` is set, resolve the published `erun-devops` deploy spec directly — the same install-by-reference path a remote-repo target uses. Without the override there's no chart to install, so the missing-tree error still stands.

- Renamed `resolveRemoteRepoDeploySpecs` → `resolvePublishedDevopsDeploySpecs` (it now serves remote repos **and** chartless local bootstraps).
- Extracted `resolveDeploySpecsForContexts` to keep `resolveCurrentDeploySpecs` within the cyclop limit.

## Verification

- New integration scenario `deploy/dry_run_runtime_image_override_no_k8s_tree_uses_published_chart` (module with docker+VERSION, no k8s → `fs.ErrNotExist`) locks the published-chart resolution; contrasts `dry_run_no_devops_module_errors` (no override → errors) and `dry_run_runtime_image_override_uses_published_chart` (chart present → reroutes).
- `go test ./...` green in erun-common / erun-cli / erun-mcp; `make integration-test` green, coverage **75.3%**; lint clean.
- **Live:** `erun deploy validation-agent local --version 1.0.105 --runtime-image ghcr.io/sophium/erun-devops` now resolves the published chart and proceeds to helm rollout (the reported spec-resolution error is gone).

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)