### PR TITLE
Desktop: dedup the runtime-unreachable notification so it can be dismissed

### DIFF
--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -105,6 +105,7 @@ type App struct {
 	envEnsureMu               sync.Mutex
 	envEnsureInflight         map[string]struct{}
 	envEnsureDone             map[string]time.Time
+	envEnsureFailNotified     map[string]struct{}
 	configWatcher             *configWatcher
 	contribute                *contributeStore
 	contributeApps            *contributeAppForwards

--- a/erun-ui/env_ensure.go
+++ b/erun-ui/env_ensure.go
@@ -44,6 +44,7 @@ func (a *App) ensureEnvRuntimeOnce(selection uiSelection) {
 	if a.envEnsureInflight == nil {
 		a.envEnsureInflight = make(map[string]struct{})
 		a.envEnsureDone = make(map[string]time.Time)
+		a.envEnsureFailNotified = make(map[string]struct{})
 	}
 	if _, inflight := a.envEnsureInflight[key]; inflight {
 		a.envEnsureMu.Unlock()
@@ -65,6 +66,9 @@ func (a *App) ensureEnvRuntimeOnce(selection uiSelection) {
 			// not suppress the next tab's retry for the whole TTL (#644).
 			if ensureErr == nil {
 				a.envEnsureDone[key] = time.Now()
+				// Reached again — end this failure episode so a later failure
+				// re-surfaces its notification (#711).
+				delete(a.envEnsureFailNotified, key)
 			}
 			a.envEnsureMu.Unlock()
 		}()
@@ -90,7 +94,24 @@ func (a *App) ensureEnvRuntimeOnce(selection uiSelection) {
 // reconnect usually fails because the runtime is not deployed — which `open`
 // no longer fixes on its own — so the recovery is an explicit deploy.
 func (a *App) surfaceEnvRuntimeEnsureFailure(selection uiSelection, err error) {
+	// The sidebar row's failed status is the persistent signal and is updated on
+	// every attempt. The notification is transient and posts only once per
+	// failure episode: the ensure retries on every tab open/respawn (it does not
+	// stamp the success TTL on failure, #644), so re-posting on each retry made
+	// the banner re-appear the instant the user dismissed it (#711). The dedup is
+	// cleared when the env is reached again, so a later failure surfaces afresh.
 	a.emitEnvStatus(selection, envStatusFailed)
+	key := selectionKey(normalizeSelection(selection))
+	a.envEnsureMu.Lock()
+	if a.envEnsureFailNotified == nil {
+		a.envEnsureFailNotified = make(map[string]struct{})
+	}
+	_, alreadyNotified := a.envEnsureFailNotified[key]
+	a.envEnsureFailNotified[key] = struct{}{}
+	a.envEnsureMu.Unlock()
+	if alreadyNotified {
+		return
+	}
 	a.emitAppNotification("warn", fmt.Sprintf(
 		"Could not reach the runtime for %s/%s: %s. Deploy the environment to bring it up.",
 		selection.Tenant, selection.Environment, strings.TrimSpace(err.Error()),

--- a/erun-ui/env_ensure_test.go
+++ b/erun-ui/env_ensure_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -114,4 +115,90 @@ func TestEnsureEnvRuntimeOnceRunsAgainAfterTheWindow(t *testing.T) {
 
 	app.ensureEnvRuntimeOnce(selection)
 	waitForEnsureCount(t, &ensures, &ensuresMu, 2, 2*time.Second)
+}
+
+// TestEnsureFailureNotificationDedupesPerEpisode locks the #711 fix: a runtime
+// that stays unreachable must surface its "Could not reach the runtime"
+// notification once per failure episode, not on every ensure retry — otherwise
+// the banner re-appears the instant the user dismisses it. The sidebar row is
+// still flagged failed on every attempt, and reaching the env again ends the
+// episode so a later failure surfaces afresh.
+func TestEnsureFailureNotificationDedupesPerEpisode(t *testing.T) {
+	emits := newCapturedEmits()
+	var ensures int32
+	var ensuresMu sync.Mutex
+	var reconnectMu sync.Mutex
+	reconnectErr := error(errors.New("timed out waiting for API port-forward"))
+
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", DefaultEnvironment: "remote"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {Name: "remote", LocalRepoPath: projectRoot, KubernetesContext: "ctx"},
+		},
+	}
+	app := NewApp(erunUIDeps{
+		store:           store,
+		findProjectRoot: func() (string, string, error) { return "erun", projectRoot, nil },
+		resolveCLIPath:  func() string { return "/tmp/erun" },
+		startTerminal: func(startTerminalSessionParams) (terminalSession, error) {
+			return newStubTerminalSession(), nil
+		},
+		reconnectMCP: func(context.Context, eruncommon.OpenResult, func(string)) error {
+			ensuresMu.Lock()
+			ensures++
+			ensuresMu.Unlock()
+			reconnectMu.Lock()
+			defer reconnectMu.Unlock()
+			return reconnectErr
+		},
+	})
+	app.ctx = context.Background()
+	app.SetEmitter(emits.fn())
+	t.Cleanup(func() { app.shutdown(context.Background()) })
+
+	selection := uiSelection{Tenant: "erun", Environment: "remote"}
+	key := selectionKey(normalizeSelection(selection))
+
+	// Two failures in one episode surface the banner once (so a dismiss sticks),
+	// but flag the sidebar row failed each time.
+	app.surfaceEnvRuntimeEnsureFailure(selection, errors.New("boom"))
+	app.surfaceEnvRuntimeEnsureFailure(selection, errors.New("boom"))
+	if got := len(emits.events(appNotificationEvent)); got != 1 {
+		t.Fatalf("notification emitted %d times in one failure episode, want 1", got)
+	}
+	if got := len(emits.events(envStatusEvent)); got != 2 {
+		t.Fatalf("env-status emitted %d times, want 2 (flagged on each attempt)", got)
+	}
+
+	// Reaching the env again ends the episode: a successful reconnect clears the
+	// dedup, so a later failure surfaces afresh.
+	reconnectMu.Lock()
+	reconnectErr = nil
+	reconnectMu.Unlock()
+	app.ensureEnvRuntimeOnce(selection)
+	waitForEnsureCount(t, &ensures, &ensuresMu, 1, 2*time.Second)
+	waitForFailEpisodeCleared(t, app, key, 2*time.Second)
+
+	app.surfaceEnvRuntimeEnsureFailure(selection, errors.New("boom again"))
+	if got := len(emits.events(appNotificationEvent)); got != 2 {
+		t.Fatalf("notification emitted %d times after recovery, want 2", got)
+	}
+}
+
+func waitForFailEpisodeCleared(t *testing.T, app *App, key string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		app.envEnsureMu.Lock()
+		_, still := app.envEnsureFailNotified[key]
+		app.envEnsureMu.Unlock()
+		if !still {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("successful ensure did not clear the failure episode")
 }


### PR DESCRIPTION
## Problem

When an env's runtime is unreachable (e.g. `frs/prod` with the API/MCP port-forward timing out), the titlebar banner — *"Could not reach the runtime for `<env>`: … Deploy the environment to bring it up."* — **re-appeared the instant it was dismissed**, so it couldn't be cleared.

**Cause:** `ensureEnvRuntimeOnce` runs on every tab open/respawn (`terminal_sessions.go`), and a **failed** ensure deliberately does not stamp the success TTL so the next open retries (#644). `surfaceEnvRuntimeEnsureFailure` re-posted the notification on **every** retry, so for a persistently-down env the tabs' respawns kept re-firing it — the dismiss (which works) never stuck.

## Fix

Post the ensure-failure notification **once per failure episode** (dedup per env via `envEnsureFailNotified`), cleared when the env is reached again (a successful ensure), so a later failure surfaces afresh. The sidebar row is still flagged **failed on every attempt** — the persistent status belongs there; only the transient banner dedups. The ensure retry itself is unchanged.

## UX Impact Review

1. **Affected paths.** Env runtime ensure (tab open/respawn) → `surfaceEnvRuntimeEnsureFailure` → `emitAppNotification` (titlebar banner) + `emitEnvStatus` (sidebar row).
2. **User-visible sequence.** Runtime unreachable → sidebar row flagged failed (every attempt) + banner posts **once** → dismiss now **sticks** (retries don't re-post) → when the env is reached again, the episode ends so a future failure surfaces again.
3. **State-without-affordance.** Persistent status stays on the sidebar row (visible where the user acts); the banner is the one-time transient alert. Dedup doesn't hide any state.
4. **Visibility of system status (#1).** Persistent failure = sidebar row; transient alert = banner (once).
5. **Success/failure (#1,#9).** Banner names the failure + recovery ("Deploy the environment…"); dismissable and stays dismissed.
6. **Consistency (#4).** Matches the app-notification model (post + dismiss); persistent blockers live on the sidebar row per the module UX rules.
7. **Heuristic pass.** User control (#3) — dismiss sticks; visibility of status (#1) — sidebar persists; error recovery (#9) — message names the fix. Others unaffected.
8. **Coverage.** `env_ensure_test.go::TestEnsureFailureNotificationDedupesPerEpisode` — two failures → **one** notification + **two** env-status emits; a successful ensure clears the episode so a later failure re-surfaces. Run with `-race`. Backend-only: the headless Playwright harness stubs `reconnectMCP` to succeed and can't produce a failing ensure, and the frontend dismiss (`TitlebarStatus`) is unchanged — so the Go test is the coverage.

## Validation

- `go test ./...` (erun-ui) green; `go test -race -run TestEnsure .` green; `golangci-lint` 0 issues.

## Docs

No update — a bug fix restoring intended behavior; the notification's re-post cadence isn't part of the documented contract.

Closes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)