### PR TITLE
Make deploy-lifecycle status and errors visible in the desktop toolbar

### DIFF
--- a/erun-cli/cmd/deploy.go
+++ b/erun-cli/cmd/deploy.go
@@ -51,16 +51,16 @@ func newDeployCmd(store common.DeployStore, saveEnvConfig common.EnvConfigSaver,
 			ctx.Trace(fmt.Sprintf("deploy: tenant=%s environment=%s version-override=%s components=%v force=%v current=%v",
 				deployTarget.Tenant, deployTarget.Environment, deployTarget.VersionOverride,
 				components, deployTarget.Force, useCurrent))
-			deploySpecs, err := common.ResolveCurrentDeploySpecs(ctx, store, findProjectRoot, resolveBuildContext, resolveDeployContext, now, deployTarget)
-			if err != nil {
-				ctx.Trace("deploy: spec resolution failed: " + err.Error())
+			if err := runDeploy(ctx, store, saveEnvConfig, findProjectRoot, resolveBuildContext, resolveDeployContext, now, deployHelmChart, deployTarget); err != nil {
+				// Emit a structured, env-tagged terminal failure so any transport
+				// watching the trace stream (the desktop's activity queue / toolbar)
+				// registers a failed deploy even when it fails *before* rollout —
+				// e.g. spec resolution. Without this the desktop, which reacts only
+				// to `==> ...` lines, sees no signal and surfaces nothing (#713).
+				ctx.Trace(fmt.Sprintf("==> Deploy failed %s/%s: %s", deployTarget.Tenant, deployTarget.Environment, err.Error()))
 				return err
 			}
-			ctx.Trace(fmt.Sprintf("deploy: resolved %d spec(s)", len(deploySpecs)))
-			if err := common.RunDeploySpecs(ctx, deploySpecs, deployHelmChart); err != nil {
-				return err
-			}
-			return common.PersistRuntimeVersionFromDeploySpecs(ctx, deploySpecs, saveEnvConfig, common.ResolveDeployedHelmReleaseVersion)
+			return nil
 		},
 	}
 	addDryRunFlag(cmd)
@@ -69,6 +69,23 @@ func newDeployCmd(store common.DeployStore, saveEnvConfig common.EnvConfigSaver,
 	cmd.Flags().BoolVar(&useCurrent, "current", false, "Redeploy the version this environment already runs (its persisted runtime version) instead of passing --version")
 	cmd.Flags().StringSliceVar(&components, "components", nil, fmt.Sprintf("Opt-in components to include alongside the runtime chart (%s)", strings.Join(common.OptInDeployComponentNames(), ", ")))
 	return cmd
+}
+
+// runDeploy resolves the deploy specs for the target and installs them, then
+// persists the runtime version. Kept as a named function so the RunE closure
+// stays thin (erun-cli/AGENTS.md) and every failure path funnels through one
+// return the caller tags with the structured `==> Deploy failed` trace.
+func runDeploy(ctx common.Context, store common.DeployStore, saveEnvConfig common.EnvConfigSaver, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, resolveDeployContext common.DeployContextResolverFunc, now common.NowFunc, deployHelmChart common.HelmChartDeployerFunc, deployTarget common.DeployTarget) error {
+	deploySpecs, err := common.ResolveCurrentDeploySpecs(ctx, store, findProjectRoot, resolveBuildContext, resolveDeployContext, now, deployTarget)
+	if err != nil {
+		ctx.Trace("deploy: spec resolution failed: " + err.Error())
+		return err
+	}
+	ctx.Trace(fmt.Sprintf("deploy: resolved %d spec(s)", len(deploySpecs)))
+	if err := common.RunDeploySpecs(ctx, deploySpecs, deployHelmChart); err != nil {
+		return err
+	}
+	return common.PersistRuntimeVersionFromDeploySpecs(ctx, deploySpecs, saveEnvConfig, common.ResolveDeployedHelmReleaseVersion)
 }
 
 func newK8sDeployCmd(store common.DeployStore, saveEnvConfig common.EnvConfigSaver, findProjectRoot common.ProjectFinderFunc, resolveBuildContext common.BuildContextResolverFunc, resolveDeployContext common.DeployContextResolverFunc, now common.NowFunc, buildDockerImage common.DockerImageBuilderFunc, push common.DockerPushFunc, deployHelmChart common.HelmChartDeployerFunc) *cobra.Command {

--- a/erun-devops/k8s/erun-backend-api/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-api/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.106
+appVersion: 1.0.107-pr.cf3de44
 description: ERun backend API
 name: erun-backend-api
 type: application
-version: 1.0.106
+version: 1.0.107-pr.cf3de44

--- a/erun-devops/k8s/erun-backend-db/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-db/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.106
+appVersion: 1.0.107-pr.cf3de44
 description: ERun backend database migration job
 name: erun-backend-db
 type: application
-version: 1.0.106
+version: 1.0.107-pr.cf3de44

--- a/erun-devops/k8s/erun-backend-postgres/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-postgres/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.106
+appVersion: 1.0.107-pr.cf3de44
 description: ERun backend PostgreSQL
 name: erun-backend-postgres
 type: application
-version: 1.0.106
+version: 1.0.107-pr.cf3de44

--- a/erun-devops/k8s/erun-devops/Chart.yaml
+++ b/erun-devops/k8s/erun-devops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.106
+appVersion: 1.0.107-pr.cf3de44
 description: ERun DevOps
 name: erun-devops
 type: application
-version: 1.0.106
+version: 1.0.107-pr.cf3de44

--- a/erun-devops/k8s/erun-docs/Chart.yaml
+++ b/erun-devops/k8s/erun-docs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.106
+appVersion: 1.0.107-pr.cf3de44
 description: Publish the ERun documentation site to Cloudflare Pages
 name: erun-docs
 type: application
-version: 1.0.106
+version: 1.0.107-pr.cf3de44

--- a/erun-devops/k8s/erun-powerdns/Chart.yaml
+++ b/erun-devops/k8s/erun-powerdns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.106
+appVersion: 1.0.107-pr.cf3de44
 description: ERun platform PowerDNS authoritative nameserver
 name: erun-powerdns
 type: application
-version: 1.0.106
+version: 1.0.107-pr.cf3de44

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/chart-issuer/Chart.yaml
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/chart-issuer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.106
+appVersion: 1.0.107-pr.cf3de44
 description: cert-manager ClusterIssuer (Cloudflare DNS-01) + optional wildcard Certificate for the erun services edge. Applied by the terraform-erun-cluster-edge module after cert-manager's CRDs exist.
 name: erun-cluster-edge-issuer
 type: application
-version: 1.0.106
+version: 1.0.107-pr.cf3de44

--- a/erun-integration/testdata/deploy/components_rejects_unknown_name.txt
+++ b/erun-integration/testdata/deploy/components_rejects_unknown_name.txt
@@ -2,4 +2,5 @@ audit: erun deploy --components [bogus] --dry-run --version <VERSION> team dev
 trace-log: would append the full trace to <TMP>
 deploy: tenant=team environment=dev version-override=<VERSION> components=[bogus] force=false current=false
 deploy: spec resolution failed: unknown deploy component "bogus"; valid opt-in components are: erun-backend-postgres, erun-backend-db, erun-backend-api, erun-powerdns
+==> Deploy failed team/dev: unknown deploy component "bogus"; valid opt-in components are: erun-backend-postgres, erun-backend-db, erun-backend-api, erun-powerdns
 unknown deploy component "bogus"; valid opt-in components are: erun-backend-postgres, erun-backend-db, erun-backend-api, erun-powerdns

--- a/erun-integration/testdata/deploy/dry_run_multiple_devops_modules_errors.txt
+++ b/erun-integration/testdata/deploy/dry_run_multiple_devops_modules_errors.txt
@@ -2,4 +2,5 @@ audit: erun deploy --dry-run --version <VERSION> team dev
 trace-log: would append the full trace to <TMP>
 deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
 deploy: spec resolution failed: multiple devops k8s directories found under project root
+==> Deploy failed team/dev: multiple devops k8s directories found under project root
 multiple devops k8s directories found under project root

--- a/erun-integration/testdata/deploy/dry_run_no_devops_module_errors.txt
+++ b/erun-integration/testdata/deploy/dry_run_no_devops_module_errors.txt
@@ -2,4 +2,5 @@ audit: erun deploy --dry-run --version <VERSION> team dev
 trace-log: would append the full trace to <TMP>
 deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
 deploy: spec resolution failed: helm chart not found in current directory
+==> Deploy failed team/dev: helm chart not found in current directory
 helm chart not found in current directory

--- a/erun-integration/testdata/deploy/env_deploy_timeout_invalid_duration_errors.txt
+++ b/erun-integration/testdata/deploy/env_deploy_timeout_invalid_duration_errors.txt
@@ -2,4 +2,5 @@ audit: erun deploy --dry-run --version <VERSION> team dev
 trace-log: would append the full trace to <TMP>
 deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
 deploy: spec resolution failed: invalid environment deploy timeout "nonsense"
+==> Deploy failed team/dev: invalid environment deploy timeout "nonsense"
 invalid environment deploy timeout "nonsense"

--- a/erun-integration/testdata/deploy/project_k8s_plan_rejects_invalid_step_node.txt
+++ b/erun-integration/testdata/deploy/project_k8s_plan_rejects_invalid_step_node.txt
@@ -2,4 +2,5 @@ audit: erun deploy --dry-run --version <VERSION> team dev
 trace-log: would append the full trace to <TMP>
 deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
 deploy: spec resolution failed: config file cannot be unmarshaled: k8s.deployments item must be a component name or a list of component names
+==> Deploy failed team/dev: config file cannot be unmarshaled: k8s.deployments item must be a component name or a list of component names
 config file cannot be unmarshaled: k8s.deployments item must be a component name or a list of component names

--- a/erun-integration/testdata/deploy/real_run_dedup_conflict_on_different_params.txt
+++ b/erun-integration/testdata/deploy/real_run_dedup_conflict_on_different_params.txt
@@ -4,4 +4,5 @@ deploy: tenant=team environment=dev version-override=<VERSION> components=[] for
 deploy: version <VERSION> pinned; installing the published image by reference (deploy never builds)
 deploy: resolved 1 spec(s)
 deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+==> Deploy failed team/dev: another erun deploy is in progress for team/dev <VERSION> (release "team-devops", namespace "team-dev", context "test-context", pid=<PID>, started <TS>); refusing to run a conflicting helm upgrade
 another erun deploy is in progress for team/dev <VERSION> (release "team-devops", namespace "team-dev", context "test-context", pid=<PID>, started <TS>); refusing to run a conflicting helm upgrade

--- a/erun-integration/testdata/deploy/real_run_pinned_version_missing_image_errors.txt
+++ b/erun-integration/testdata/deploy/real_run_pinned_version_missing_image_errors.txt
@@ -3,4 +3,5 @@ trace-log: appending the full trace to <TMP>
 deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
 deploy: version <VERSION> pinned; installing the published image by reference (deploy never builds)
 deploy: spec resolution failed: deploy --version <VERSION>: image ghcr.io/sophium/team-devops:<VERSION> is not present locally or in the registry; deploy installs an existing version and does not build it — run erun build/push to create it first
+==> Deploy failed team/dev: deploy --version <VERSION>: image ghcr.io/sophium/team-devops:<VERSION> is not present locally or in the registry; deploy installs an existing version and does not build it — run erun build/push to create it first
 deploy --version <VERSION>: image ghcr.io/sophium/team-devops:<VERSION> is not present locally or in the registry; deploy installs an existing version and does not build it — run erun build/push to create it first

--- a/erun-integration/testdata/deploy/real_run_published_chart_not_found_reports_actionable_error.txt
+++ b/erun-integration/testdata/deploy/real_run_published_chart_not_found_reports_actionable_error.txt
@@ -9,5 +9,7 @@ dedup: claim (release=test-context-team-dev-team-devops, hash=<HASH>, pid=<PID>)
     namespace team-dev on context test-context
     waiting for helm rollout (timeout 5m0s)...
 ==> Deploy of team-devops failed after <ELAPSED>
+==> Deploy failed team/dev: runtime chart oci://registry.example/test/charts/erun-devops version <VERSION> could not be pulled from registry.example/test: that version has no published chart in the registry. `erun push` publishes a version's image and chart together, so a version is deployable only after it is pushed — run `erun push --version <VERSION>` (or `erun release` for a release version), then deploy.
+Error: failed to perform "FetchReference" on source: registry.example/test/charts/erun-devops: not found
 runtime chart oci://registry.example/test/charts/erun-devops version <VERSION> could not be pulled from registry.example/test: that version has no published chart in the registry. `erun push` publishes a version's image and chart together, so a version is deployable only after it is pushed — run `erun push --version <VERSION>` (or `erun release` for a release version), then deploy.
 Error: failed to perform "FetchReference" on source: registry.example/test/charts/erun-devops: not found

--- a/erun-integration/testdata/deploy/rejects_inconsistent_platform_config.txt
+++ b/erun-integration/testdata/deploy/rejects_inconsistent_platform_config.txt
@@ -2,4 +2,5 @@ audit: erun deploy --dry-run --version <VERSION> team dev
 trace-log: would append the full trace to <TMP>
 deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
 deploy: spec resolution failed: platform config: serviceszone "services.kppaas.com" must be "erunpaas.com" or a subdomain of it
+==> Deploy failed team/dev: platform config: serviceszone "services.kppaas.com" must be "erunpaas.com" or a subdomain of it
 platform config: serviceszone "services.kppaas.com" must be "erunpaas.com" or a subdomain of it

--- a/erun-integration/testdata/deploy/rollout_timeout_flag_invalid_duration_errors.txt
+++ b/erun-integration/testdata/deploy/rollout_timeout_flag_invalid_duration_errors.txt
@@ -3,4 +3,5 @@ trace-log: would append the full trace to <TMP>
 deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
 deploy: version <VERSION> pinned; installing the published image by reference (deploy never builds)
 deploy: spec resolution failed: invalid rollout timeout "bogus"
+==> Deploy failed team/dev: invalid rollout timeout "bogus"
 invalid rollout timeout "bogus"

--- a/erun-integration/testdata/deploy/version_flag_recognized_outside_devops_cwd.txt
+++ b/erun-integration/testdata/deploy/version_flag_recognized_outside_devops_cwd.txt
@@ -2,4 +2,5 @@ audit: erun deploy --dry-run --version <VERSION> missing missing
 trace-log: would append the full trace to <TMP>
 deploy: tenant=missing environment=missing version-override=<VERSION> components=[] force=false current=false
 deploy: spec resolution failed: no such tenant exists: missing
+==> Deploy failed missing/missing: no such tenant exists: missing
 no such tenant exists: missing

--- a/erun-ui/activity_queue_app.go
+++ b/erun-ui/activity_queue_app.go
@@ -165,6 +165,12 @@ func (a *App) lockTerminalsForActivity(entry activityQueueEntry) {
 	for _, ev := range events {
 		a.emitEvent(activityQueueLockEvent, ev)
 	}
+	if len(events) > 0 {
+		// A deploy just started for this env (only deploys lock terminals). The
+		// runtime-unreachable warning that told the operator to "Deploy the
+		// environment" is now being acted on — clear it (#713).
+		a.emitClearEnvNotification(entry.Tenant, entry.Environment, notificationSourceRuntimeUnreachable)
+	}
 }
 
 // lockTerminalForActivity locks a single session by its serial ID. Used when
@@ -198,6 +204,9 @@ func (a *App) lockTerminalForActivity(sessionID int, entry activityQueueEntry) {
 	a.mu.Unlock()
 	if event != nil {
 		a.emitEvent(activityQueueLockEvent, *event)
+		// A late-joining session locked onto an in-flight deploy — the runtime
+		// is being (re)deployed, so clear any runtime-unreachable warning (#713).
+		a.emitClearEnvNotification(entry.Tenant, entry.Environment, notificationSourceRuntimeUnreachable)
 	}
 }
 

--- a/erun-ui/activity_queue_app.go
+++ b/erun-ui/activity_queue_app.go
@@ -166,10 +166,11 @@ func (a *App) lockTerminalsForActivity(entry activityQueueEntry) {
 		a.emitEvent(activityQueueLockEvent, ev)
 	}
 	if len(events) > 0 {
-		// A deploy just started for this env (only deploys lock terminals). The
-		// runtime-unreachable warning that told the operator to "Deploy the
-		// environment" is now being acted on — clear it (#713).
-		a.emitClearEnvNotification(entry.Tenant, entry.Environment, notificationSourceRuntimeUnreachable)
+		// A deploy just started for this env (only deploys lock terminals). Retire
+		// any env-scoped warning that told the operator to act — the
+		// runtime-unreachable banner, or a prior deploy-failed error — since the
+		// deploy is now underway (#713).
+		a.emitClearEnvNotification(entry.Tenant, entry.Environment, "")
 	}
 }
 
@@ -204,9 +205,9 @@ func (a *App) lockTerminalForActivity(sessionID int, entry activityQueueEntry) {
 	a.mu.Unlock()
 	if event != nil {
 		a.emitEvent(activityQueueLockEvent, *event)
-		// A late-joining session locked onto an in-flight deploy — the runtime
-		// is being (re)deployed, so clear any runtime-unreachable warning (#713).
-		a.emitClearEnvNotification(entry.Tenant, entry.Environment, notificationSourceRuntimeUnreachable)
+		// A late-joining session locked onto an in-flight deploy — the runtime is
+		// being (re)deployed, so clear any env-scoped warning for it (#713).
+		a.emitClearEnvNotification(entry.Tenant, entry.Environment, "")
 	}
 }
 
@@ -311,6 +312,13 @@ var activityDeployedLineRe = regexp.MustCompile(`^==> Deployed ([^/\s]+)/([^/\s]
 // dedup decides this caller is a duplicate. Captures: tenant,
 // environment.
 var activitySkippingLineRe = regexp.MustCompile(`^==> Skipping ([^/\s]+)/([^/\s]+)\b`)
+
+// activityDeployFailedLineRe matches the `==> Deploy failed tenant/env: reason`
+// trace `erun deploy` emits on any failure — including a pre-rollout failure
+// like spec resolution, which fails before `==> Deploying` and so left the
+// desktop with no signal to surface (issue #713). Captures: tenant,
+// environment, optional reason.
+var activityDeployFailedLineRe = regexp.MustCompile(`^==> Deploy failed ([^/\s]+)/([^/\s]+)(?::\s*(.*))?$`)
 
 // activityInitializingLineRe matches the umbrella `==> Initializing
 // tenant/env` trace emitted by RunBootstrapInit once tenant + env are
@@ -431,7 +439,36 @@ func (a *App) handleDeployTraceLine(selection uiSelection, line string) bool {
 		a.finishDeployByTenantEnv(selection, match[1], match[2], activityQueueStatusSkipped, line)
 		return true
 	}
+	if match := activityDeployFailedLineRe.FindStringSubmatch(line); match != nil {
+		reason := strings.TrimSpace(match[3])
+		// Finalize the drawer entry if one was started, and — the #713 fix —
+		// surface the failure in the toolbar so a failed deploy is visible where
+		// the operator is looking, not only in the activity queue (and not at
+		// all when the failure came before any `==> Deploying` started an entry).
+		a.finishDeployByTenantEnv(selection, match[1], match[2], activityQueueStatusFailed, reason)
+		a.surfaceDeployFailure(match[1], match[2], reason)
+		return true
+	}
 	return false
+}
+
+// surfaceDeployFailure makes a failed deploy visible in the toolbar (Nielsen #1),
+// not just as a red terminal line or a drawer entry: it flags the env's sidebar
+// row failed and posts an env-tagged error notification. The notification is
+// tagged so the deploy lifecycle retires it once the state moves on — the next
+// deploy for the env starts, or the runtime becomes reachable (issue #713).
+func (a *App) surfaceDeployFailure(tenant, environment, reason string) {
+	tenant = strings.TrimSpace(tenant)
+	environment = strings.TrimSpace(environment)
+	if tenant == "" || environment == "" {
+		return
+	}
+	a.emitEnvStatus(uiSelection{Tenant: tenant, Environment: environment}, envStatusFailed)
+	message := fmt.Sprintf("Deploy of %s/%s failed.", tenant, environment)
+	if reason != "" {
+		message = fmt.Sprintf("Deploy of %s/%s failed: %s", tenant, environment, reason)
+	}
+	a.emitEnvNotification("error", tenant, environment, notificationSourceDeployFailed, message)
 }
 
 // handleInitTraceLine dispatches the init lifecycle trace lines

--- a/erun-ui/activity_queue_app_test.go
+++ b/erun-ui/activity_queue_app_test.go
@@ -55,6 +55,64 @@ func TestLockTerminalsForActivityLocksMatchingSessions(t *testing.T) {
 	}
 }
 
+// TestLockTerminalsForActivityClearsRuntimeUnreachableNotification locks the
+// #713 fix: when a deploy starts locking an env's terminals, the runtime-
+// unreachable banner that told the operator to "Deploy the environment" is now
+// being acted on, so a matching app-notification-clear fires for that env.
+func TestLockTerminalsForActivityClearsRuntimeUnreachableNotification(t *testing.T) {
+	app := newTestAppForActivityQueue(t)
+	emits := newCapturedEmits()
+	app.SetEmitter(emits.fn())
+	selection := uiSelection{Tenant: "team", Environment: "dev", Version: "1.0.0"}
+	envSession := &managedTerminal{selection: selection, key: "env\x00team\x00dev", serial: 1, kind: sessionKindOpen}
+	app.sessions[envSession.key] = envSession
+
+	entry, _ := app.activityQueue.start(activityQueueEntry{
+		Command:     "deploy",
+		Tenant:      "team",
+		Environment: "dev",
+		Version:     "1.0.0",
+		Release:     "team-devops",
+	})
+	app.lockTerminalsForActivity(entry)
+
+	events := emits.events(appNotificationClearEvent)
+	if len(events) != 1 {
+		t.Fatalf("clear emitted %d times, want exactly 1", len(events))
+	}
+	payload, ok := events[0].(appNotificationClearPayload)
+	if !ok {
+		t.Fatalf("clear payload has unexpected type %T", events[0])
+	}
+	if payload.Tenant != "team" || payload.Environment != "dev" ||
+		payload.Source != notificationSourceRuntimeUnreachable {
+		t.Fatalf("clear payload = %+v, want team/dev %q", payload, notificationSourceRuntimeUnreachable)
+	}
+}
+
+// TestLockTerminalsForActivityWithoutMatchClearsNothing guards the gate: a
+// deploy that locks no local sessions (nothing to act on for this desktop) must
+// not fire a stray notification-clear (issue #713).
+func TestLockTerminalsForActivityWithoutMatchClearsNothing(t *testing.T) {
+	app := newTestAppForActivityQueue(t)
+	emits := newCapturedEmits()
+	app.SetEmitter(emits.fn())
+	other := &managedTerminal{
+		selection: uiSelection{Tenant: "other", Environment: "dev"},
+		key:       "env\x00other\x00dev", serial: 1, kind: sessionKindOpen,
+	}
+	app.sessions[other.key] = other
+
+	entry, _ := app.activityQueue.start(activityQueueEntry{
+		Command: "deploy", Tenant: "team", Environment: "dev", Version: "1.0.0", Release: "team-devops",
+	})
+	app.lockTerminalsForActivity(entry)
+
+	if got := len(emits.events(appNotificationClearEvent)); got != 0 {
+		t.Fatalf("clear emitted %d times with no matching session, want 0", got)
+	}
+}
+
 // TestLockTerminalEventsAlwaysCarryReason pins the contract documented in
 // erun-ui/AGENTS.md "Professional UX": the ActivityLockOverlay relies on
 // the backend always populating Reason on Locked=true events. The

--- a/erun-ui/activity_queue_app_test.go
+++ b/erun-ui/activity_queue_app_test.go
@@ -55,11 +55,12 @@ func TestLockTerminalsForActivityLocksMatchingSessions(t *testing.T) {
 	}
 }
 
-// TestLockTerminalsForActivityClearsRuntimeUnreachableNotification locks the
-// #713 fix: when a deploy starts locking an env's terminals, the runtime-
-// unreachable banner that told the operator to "Deploy the environment" is now
-// being acted on, so a matching app-notification-clear fires for that env.
-func TestLockTerminalsForActivityClearsRuntimeUnreachableNotification(t *testing.T) {
+// TestLockTerminalsForActivityClearsEnvNotifications locks the #713 fix: when a
+// deploy starts locking an env's terminals, any env-scoped warning that told the
+// operator to act (the runtime-unreachable banner, or a prior deploy-failed
+// error) is now being acted on, so an env-wide app-notification-clear fires
+// (empty source = clear any env-scoped notification for the env).
+func TestLockTerminalsForActivityClearsEnvNotifications(t *testing.T) {
 	app := newTestAppForActivityQueue(t)
 	emits := newCapturedEmits()
 	app.SetEmitter(emits.fn())
@@ -84,9 +85,43 @@ func TestLockTerminalsForActivityClearsRuntimeUnreachableNotification(t *testing
 	if !ok {
 		t.Fatalf("clear payload has unexpected type %T", events[0])
 	}
-	if payload.Tenant != "team" || payload.Environment != "dev" ||
-		payload.Source != notificationSourceRuntimeUnreachable {
-		t.Fatalf("clear payload = %+v, want team/dev %q", payload, notificationSourceRuntimeUnreachable)
+	if payload.Tenant != "team" || payload.Environment != "dev" || payload.Source != "" {
+		t.Fatalf("clear payload = %+v, want team/dev with empty (any) source", payload)
+	}
+}
+
+// TestDeployFailedTraceSurfacesToToolbar locks the #713 fix: a `==> Deploy
+// failed tenant/env: reason` trace (emitted by `erun deploy` on any failure,
+// including a pre-rollout spec-resolution failure) surfaces the failure in the
+// toolbar — an env-tagged error notification plus a failed sidebar status — so a
+// failed deploy is not silent.
+func TestDeployFailedTraceSurfacesToToolbar(t *testing.T) {
+	app := newTestAppForActivityQueue(t)
+	emits := newCapturedEmits()
+	app.SetEmitter(emits.fn())
+	selection := uiSelection{Tenant: "frs", Environment: "local"}
+	onLine := newActivityTraceLineHandler(app, selection, sessionKindLocal)
+
+	onLine(`==> Deploy failed frs/local: values file not found for environment "local"`)
+
+	notes := emits.events(appNotificationEvent)
+	if len(notes) != 1 {
+		t.Fatalf("deploy failure emitted %d toolbar notifications, want 1", len(notes))
+	}
+	note, ok := notes[0].(appNotificationPayload)
+	if !ok {
+		t.Fatalf("notification payload has unexpected type %T", notes[0])
+	}
+	if note.Kind != "error" || note.Tenant != "frs" || note.Environment != "local" ||
+		note.Source != notificationSourceDeployFailed {
+		t.Fatalf("notification = %+v, want error frs/local %q", note, notificationSourceDeployFailed)
+	}
+	if !strings.Contains(note.Message, "Deploy of frs/local failed") ||
+		!strings.Contains(note.Message, "values file not found") {
+		t.Fatalf("notification message = %q, want the failed target + reason", note.Message)
+	}
+	if got := len(emits.events(envStatusEvent)); got != 1 {
+		t.Fatalf("failed sidebar status emitted %d times, want 1", got)
 	}
 }
 

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -15,6 +15,7 @@ const (
 	terminalExitEvent           = "terminal-exit"
 	appStatusEvent              = "app-status"
 	appNotificationEvent        = "app-notification"
+	appNotificationClearEvent   = "app-notification-clear"
 	mcpReconnectLineEvent       = "mcp-reconnect-line"
 	environmentInitializedEvent = "environment-initialized"
 	environmentInitFailedEvent  = "environment-init-failed"

--- a/erun-ui/config_handlers.go
+++ b/erun-ui/config_handlers.go
@@ -395,6 +395,11 @@ func (a *App) emitAppNotification(kind, message string) {
 // string the frontend compares in dismissNotificationForEnv.
 const notificationSourceRuntimeUnreachable = "runtime-unreachable"
 
+// notificationSourceDeployFailed tags the "Deploy of …/… failed" error (issue
+// #713) so the same lifecycle clear retires it once a new deploy for the env
+// starts or the runtime becomes reachable.
+const notificationSourceDeployFailed = "deploy-failed"
+
 // emitEnvNotification posts a notification tagged with the env it describes and
 // a stable source, so a later emitClearEnvNotification for the same
 // (source, tenant, environment) can dismiss it. Use it for env-scoped, state-

--- a/erun-ui/config_handlers.go
+++ b/erun-ui/config_handlers.go
@@ -390,6 +390,40 @@ func (a *App) emitAppNotification(kind, message string) {
 	a.emit(appNotificationEvent, appNotificationPayload{Kind: kind, Message: message})
 }
 
+// notificationSourceRuntimeUnreachable tags the "Could not reach the runtime …"
+// warning (issue #711/#713) so the deploy lifecycle can clear it. Must match the
+// string the frontend compares in dismissNotificationForEnv.
+const notificationSourceRuntimeUnreachable = "runtime-unreachable"
+
+// emitEnvNotification posts a notification tagged with the env it describes and
+// a stable source, so a later emitClearEnvNotification for the same
+// (source, tenant, environment) can dismiss it. Use it for env-scoped, state-
+// backed notifications (not one-shot toasts).
+func (a *App) emitEnvNotification(kind, tenant, environment, source, message string) {
+	if strings.TrimSpace(message) == "" {
+		return
+	}
+	a.emit(appNotificationEvent, appNotificationPayload{
+		Kind:        kind,
+		Message:     message,
+		Tenant:      tenant,
+		Environment: environment,
+		Source:      source,
+	})
+}
+
+// emitClearEnvNotification asks the frontend to dismiss a notification posted by
+// emitEnvNotification, but only when its source/tenant/environment all match.
+// Fired when the state a notification described has moved on (issue #713): a
+// deploy for the env starts, or the runtime becomes reachable again.
+func (a *App) emitClearEnvNotification(tenant, environment, source string) {
+	a.emit(appNotificationClearEvent, appNotificationClearPayload{
+		Tenant:      tenant,
+		Environment: environment,
+		Source:      source,
+	})
+}
+
 func cloudContextDisplayName(status eruncommon.CloudContextStatus) string {
 	if name := strings.TrimSpace(status.KubernetesContext); name != "" {
 		return name

--- a/erun-ui/env_ensure.go
+++ b/erun-ui/env_ensure.go
@@ -130,8 +130,10 @@ func (a *App) surfaceEnvRuntimeEnsureFailure(selection uiSelection, err error) {
 		return
 	}
 	// Tag the notification with the env + a stable source so the deploy
-	// lifecycle can clear it once the state it describes moves on (#713).
-	a.emitEnvNotification("warn", selection.Tenant, selection.Environment, notificationSourceRuntimeUnreachable, fmt.Sprintf(
+	// lifecycle can clear it once the state it describes moves on (#713). Kind
+	// "warning" (not "warn") is the contract the frontend maps to the
+	// attention icon; an unrecognized kind renders as a neutral info ⓘ (#713).
+	a.emitEnvNotification("warning", selection.Tenant, selection.Environment, notificationSourceRuntimeUnreachable, fmt.Sprintf(
 		"Could not reach the runtime for %s/%s: %s. Deploy the environment to bring it up.",
 		selection.Tenant, selection.Environment, strings.TrimSpace(err.Error()),
 	))

--- a/erun-ui/env_ensure.go
+++ b/erun-ui/env_ensure.go
@@ -62,15 +62,22 @@ func (a *App) ensureEnvRuntimeOnce(selection uiSelection) {
 		defer func() {
 			a.envEnsureMu.Lock()
 			delete(a.envEnsureInflight, key)
+			reached := ensureErr == nil
 			// Stamp the dedup window only on success: a failed reconnect must
 			// not suppress the next tab's retry for the whole TTL (#644).
-			if ensureErr == nil {
+			if reached {
 				a.envEnsureDone[key] = time.Now()
 				// Reached again — end this failure episode so a later failure
 				// re-surfaces its notification (#711).
 				delete(a.envEnsureFailNotified, key)
 			}
 			a.envEnsureMu.Unlock()
+			// Runtime reached — the "Could not reach the runtime …" warning, if
+			// one is still up, is now stale; clear it (#713). Emitted outside
+			// the mutex; the frontend only clears a matching notification.
+			if reached {
+				a.emitClearEnvNotification(selection.Tenant, selection.Environment, notificationSourceRuntimeUnreachable)
+			}
 		}()
 		result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
 			Tenant:      selection.Tenant,
@@ -94,6 +101,15 @@ func (a *App) ensureEnvRuntimeOnce(selection uiSelection) {
 // reconnect usually fails because the runtime is not deployed — which `open`
 // no longer fixes on its own — so the recovery is an explicit deploy.
 func (a *App) surfaceEnvRuntimeEnsureFailure(selection uiSelection, err error) {
+	selection = normalizeSelection(selection)
+	// A deploy for this env being in flight IS the recovery this failure would
+	// recommend ("Deploy the environment …"), and the deploy-progress overlay
+	// already communicates it. Surfacing a contradictory failed status + banner
+	// on top of the running deploy is the #713 confusion, so stay quiet while the
+	// deploy owns the env's state; a genuine post-deploy failure surfaces afresh.
+	if a.deployInFlightForEnv(selection) {
+		return
+	}
 	// The sidebar row's failed status is the persistent signal and is updated on
 	// every attempt. The notification is transient and posts only once per
 	// failure episode: the ensure retries on every tab open/respawn (it does not
@@ -101,7 +117,7 @@ func (a *App) surfaceEnvRuntimeEnsureFailure(selection uiSelection, err error) {
 	// the banner re-appear the instant the user dismissed it (#711). The dedup is
 	// cleared when the env is reached again, so a later failure surfaces afresh.
 	a.emitEnvStatus(selection, envStatusFailed)
-	key := selectionKey(normalizeSelection(selection))
+	key := selectionKey(selection)
 	a.envEnsureMu.Lock()
 	if a.envEnsureFailNotified == nil {
 		a.envEnsureFailNotified = make(map[string]struct{})
@@ -112,8 +128,29 @@ func (a *App) surfaceEnvRuntimeEnsureFailure(selection uiSelection, err error) {
 	if alreadyNotified {
 		return
 	}
-	a.emitAppNotification("warn", fmt.Sprintf(
+	// Tag the notification with the env + a stable source so the deploy
+	// lifecycle can clear it once the state it describes moves on (#713).
+	a.emitEnvNotification("warn", selection.Tenant, selection.Environment, notificationSourceRuntimeUnreachable, fmt.Sprintf(
 		"Could not reach the runtime for %s/%s: %s. Deploy the environment to bring it up.",
 		selection.Tenant, selection.Environment, strings.TrimSpace(err.Error()),
 	))
+}
+
+// deployInFlightForEnv reports whether a deploy that locks terminals is
+// currently in flight for the env: any of its open sessions is locked by an
+// activity (only deploys lock sibling terminals — see sessionMatchesActivity).
+func (a *App) deployInFlightForEnv(selection uiSelection) bool {
+	selection = normalizeSelection(selection)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, managed := range a.sessions {
+		if managed == nil || managed.closed || managed.lockedByActivity == "" {
+			continue
+		}
+		if strings.TrimSpace(managed.selection.Tenant) == selection.Tenant &&
+			strings.TrimSpace(managed.selection.Environment) == selection.Environment {
+			return true
+		}
+	}
+	return false
 }

--- a/erun-ui/env_ensure.go
+++ b/erun-ui/env_ensure.go
@@ -72,11 +72,12 @@ func (a *App) ensureEnvRuntimeOnce(selection uiSelection) {
 				delete(a.envEnsureFailNotified, key)
 			}
 			a.envEnsureMu.Unlock()
-			// Runtime reached — the "Could not reach the runtime …" warning, if
-			// one is still up, is now stale; clear it (#713). Emitted outside
-			// the mutex; the frontend only clears a matching notification.
+			// Runtime reached — any env-scoped warning (a "Could not reach the
+			// runtime …" banner, or a prior deploy-failed error) is now stale;
+			// clear it (#713). Emitted outside the mutex; the frontend only clears
+			// a notification that targets this env.
 			if reached {
-				a.emitClearEnvNotification(selection.Tenant, selection.Environment, notificationSourceRuntimeUnreachable)
+				a.emitClearEnvNotification(selection.Tenant, selection.Environment, "")
 			}
 		}()
 		result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{

--- a/erun-ui/env_ensure_test.go
+++ b/erun-ui/env_ensure_test.go
@@ -202,3 +202,111 @@ func waitForFailEpisodeCleared(t *testing.T, app *App, key string, timeout time.
 	}
 	t.Fatal("successful ensure did not clear the failure episode")
 }
+
+// capturedEnsureApp builds an ensure-capable App wired to a captured emitter so
+// tests can assert the exact events a reconnect produces. reconnect drives the
+// success/failure path.
+func capturedEnsureApp(
+	t *testing.T,
+	reconnect func(context.Context, eruncommon.OpenResult, func(string)) error,
+) (*App, *capturedEmits) {
+	t.Helper()
+	emits := newCapturedEmits()
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", DefaultEnvironment: "remote"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/remote": {Name: "remote", LocalRepoPath: projectRoot, KubernetesContext: "ctx"},
+		},
+	}
+	app := NewApp(erunUIDeps{
+		store:           store,
+		findProjectRoot: func() (string, string, error) { return "erun", projectRoot, nil },
+		resolveCLIPath:  func() string { return "/tmp/erun" },
+		startTerminal: func(startTerminalSessionParams) (terminalSession, error) {
+			return newStubTerminalSession(), nil
+		},
+		reconnectMCP: reconnect,
+	})
+	app.ctx = context.Background()
+	app.SetEmitter(emits.fn())
+	t.Cleanup(func() { app.shutdown(context.Background()) })
+	return app, emits
+}
+
+// TestSurfaceEnsureFailureSuppressedWhileDeployInFlight locks the #713 fix: a
+// deploy for the env being in flight IS the recovery the runtime-unreachable
+// banner would recommend ("Deploy the environment …"), and the deploy-progress
+// overlay already communicates it. Surfacing a contradictory failed status +
+// banner on top of the running deploy is the confusion this fixes, so the
+// failure must stay quiet while a deploy locks the env's terminals.
+func TestSurfaceEnsureFailureSuppressedWhileDeployInFlight(t *testing.T) {
+	app, emits := capturedEnsureApp(t, func(context.Context, eruncommon.OpenResult, func(string)) error {
+		return nil
+	})
+	selection := uiSelection{Tenant: "erun", Environment: "remote"}
+
+	// A deploy is locking this env's terminal — the recovery is already underway.
+	app.mu.Lock()
+	app.sessions["s1"] = &managedTerminal{
+		selection:        selection,
+		key:              "s1",
+		serial:           1,
+		kind:             sessionKindOpen,
+		lockedByActivity: "dep-1",
+	}
+	app.mu.Unlock()
+
+	app.surfaceEnvRuntimeEnsureFailure(selection, errors.New("timed out waiting for API port-forward"))
+
+	if got := len(emits.events(appNotificationEvent)); got != 0 {
+		t.Fatalf("banner emitted %d times during an in-flight deploy, want 0", got)
+	}
+	if got := len(emits.events(envStatusEvent)); got != 0 {
+		t.Fatalf("failed status emitted %d times during an in-flight deploy, want 0", got)
+	}
+
+	// With no deploy locking the env, the failure surfaces normally.
+	app.mu.Lock()
+	app.sessions["s1"].lockedByActivity = ""
+	app.mu.Unlock()
+	app.surfaceEnvRuntimeEnsureFailure(selection, errors.New("timed out waiting for API port-forward"))
+	if got := len(emits.events(appNotificationEvent)); got != 1 {
+		t.Fatalf("banner emitted %d times once the deploy cleared, want 1", got)
+	}
+}
+
+// TestEnsureSuccessClearsRuntimeUnreachableNotification locks the #713 fix: once
+// the runtime is reachable again, the "Could not reach the runtime …" banner is
+// stale, so a successful ensure clears it (tagged by env + source so an
+// unrelated toast is left alone).
+func TestEnsureSuccessClearsRuntimeUnreachableNotification(t *testing.T) {
+	app, emits := capturedEnsureApp(t, func(context.Context, eruncommon.OpenResult, func(string)) error {
+		return nil
+	})
+	selection := uiSelection{Tenant: "erun", Environment: "remote"}
+
+	app.ensureEnvRuntimeOnce(selection)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(emits.events(appNotificationClearEvent)) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	events := emits.events(appNotificationClearEvent)
+	if len(events) == 0 {
+		t.Fatal("a successful ensure did not clear the runtime-unreachable banner")
+	}
+	payload, ok := events[0].(appNotificationClearPayload)
+	if !ok {
+		t.Fatalf("clear payload has unexpected type %T", events[0])
+	}
+	if payload.Tenant != "erun" || payload.Environment != "remote" ||
+		payload.Source != notificationSourceRuntimeUnreachable {
+		t.Fatalf("clear payload = %+v, want erun/remote %q", payload, notificationSourceRuntimeUnreachable)
+	}
+}

--- a/erun-ui/env_ensure_test.go
+++ b/erun-ui/env_ensure_test.go
@@ -273,8 +273,18 @@ func TestSurfaceEnsureFailureSuppressedWhileDeployInFlight(t *testing.T) {
 	app.sessions["s1"].lockedByActivity = ""
 	app.mu.Unlock()
 	app.surfaceEnvRuntimeEnsureFailure(selection, errors.New("timed out waiting for API port-forward"))
-	if got := len(emits.events(appNotificationEvent)); got != 1 {
-		t.Fatalf("banner emitted %d times once the deploy cleared, want 1", got)
+	notes := emits.events(appNotificationEvent)
+	if len(notes) != 1 {
+		t.Fatalf("banner emitted %d times once the deploy cleared, want 1", len(notes))
+	}
+	note, ok := notes[0].(appNotificationPayload)
+	if !ok {
+		t.Fatalf("notification payload has unexpected type %T", notes[0])
+	}
+	// Kind "warning" (not "warn") is the contract the frontend maps to the
+	// attention icon; an unrecognized kind renders as a neutral info ⓘ (#713).
+	if note.Kind != "warning" || note.Source != notificationSourceRuntimeUnreachable {
+		t.Fatalf("notification = %+v, want kind=warning source=%q", note, notificationSourceRuntimeUnreachable)
 	}
 }
 

--- a/erun-ui/env_ensure_test.go
+++ b/erun-ui/env_ensure_test.go
@@ -305,8 +305,7 @@ func TestEnsureSuccessClearsRuntimeUnreachableNotification(t *testing.T) {
 	if !ok {
 		t.Fatalf("clear payload has unexpected type %T", events[0])
 	}
-	if payload.Tenant != "erun" || payload.Environment != "remote" ||
-		payload.Source != notificationSourceRuntimeUnreachable {
-		t.Fatalf("clear payload = %+v, want erun/remote %q", payload, notificationSourceRuntimeUnreachable)
+	if payload.Tenant != "erun" || payload.Environment != "remote" || payload.Source != "" {
+		t.Fatalf("clear payload = %+v, want erun/remote with empty (any) source", payload)
 	}
 }

--- a/erun-ui/frontend/src/app/model/appNotificationPayload.ts
+++ b/erun-ui/frontend/src/app/model/appNotificationPayload.ts
@@ -8,4 +8,18 @@ import type { AppNotification } from '../state';
 export interface AppNotificationPayload {
   kind?: AppNotification['kind'];
   message?: string;
+  // Env tag (issue #713): the runtime-unreachable warning carries the env it
+  // targets and a stable source so the deploy lifecycle can clear it later.
+  tenant?: string;
+  environment?: string;
+  source?: string;
+}
+
+// AppNotificationClearPayload dismisses an env-tagged notification (see the Go
+// appNotificationClearEvent). The frontend clears the current notification only
+// when its source/tenant/environment all match (issue #713).
+export interface AppNotificationClearPayload {
+  tenant?: string;
+  environment?: string;
+  source?: string;
 }

--- a/erun-ui/frontend/src/app/model/index.ts
+++ b/erun-ui/frontend/src/app/model/index.ts
@@ -1,5 +1,5 @@
 export type { AIActivityPayload } from './aiActivityPayload';
-export type { AppNotificationPayload } from './appNotificationPayload';
+export type { AppNotificationClearPayload, AppNotificationPayload } from './appNotificationPayload';
 export type { AppStatusPayload } from './appStatusPayload';
 export type { ClassifiedTerminalFailure } from './classifiedTerminalFailure';
 export type { CloudInitProvider } from './cloudInitProvider';

--- a/erun-ui/frontend/src/app/notificationThunks.ts
+++ b/erun-ui/frontend/src/app/notificationThunks.ts
@@ -105,14 +105,26 @@ export const dismissTerminalStatus = (): AppThunk => (dispatch, getState) => {
 };
 
 export const showNotification =
-  (kind: AppNotification['kind'], message: string): AppThunk =>
+  (
+    kind: AppNotification['kind'],
+    message: string,
+    meta?: { tenant?: string; environment?: string; source?: string },
+  ): AppThunk =>
   (dispatch) => {
     const trimmed = message.trim();
     if (!trimmed) {
       return;
     }
     window.clearTimeout(notificationTimer);
-    dispatch(showNotificationAction({ kind, message: trimmed }));
+    dispatch(
+      showNotificationAction({
+        kind,
+        message: trimmed,
+        tenant: meta?.tenant,
+        environment: meta?.environment,
+        source: meta?.source,
+      }),
+    );
     if (kind === 'success' || kind === 'info') {
       notificationTimer = window.setTimeout(() => {
         dispatch(dismissNotification());

--- a/erun-ui/frontend/src/app/slices/notificationSlice.ts
+++ b/erun-ui/frontend/src/app/slices/notificationSlice.ts
@@ -26,21 +26,21 @@ export const notificationSlice = createSlice({
     dismissNotification(state) {
       state.notification = null;
     },
-    // dismissNotificationForEnv clears the current notification only when its
-    // source/tenant/environment all match — so the deploy lifecycle can retire
-    // the runtime-unreachable warning it raised without touching an unrelated
-    // toast (issue #713).
+    // dismissNotificationForEnv clears the current notification when it targets
+    // this env, so the deploy lifecycle can retire the warning it raised without
+    // touching an unrelated toast (issue #713). An empty `source` matches any
+    // env-scoped notification (a deploy starting retires both the
+    // runtime-unreachable warning and a prior deploy-failed error); a non-empty
+    // `source` clears only that kind.
     dismissNotificationForEnv(state, action: PayloadAction<NotificationEnvMatch>) {
       const current = state.notification;
       if (!current) {
         return;
       }
       const { tenant, environment, source } = action.payload;
-      if (
-        current.source === source &&
-        current.tenant === tenant &&
-        current.environment === environment
-      ) {
+      const envMatches = current.tenant === tenant && current.environment === environment;
+      const sourceMatches = source === '' || current.source === source;
+      if (envMatches && sourceMatches) {
         state.notification = null;
       }
     },

--- a/erun-ui/frontend/src/app/slices/notificationSlice.ts
+++ b/erun-ui/frontend/src/app/slices/notificationSlice.ts
@@ -10,6 +10,12 @@ const initialState: NotificationState = {
   notification: null,
 };
 
+export interface NotificationEnvMatch {
+  tenant: string;
+  environment: string;
+  source: string;
+}
+
 export const notificationSlice = createSlice({
   name: 'notification',
   initialState,
@@ -20,8 +26,27 @@ export const notificationSlice = createSlice({
     dismissNotification(state) {
       state.notification = null;
     },
+    // dismissNotificationForEnv clears the current notification only when its
+    // source/tenant/environment all match — so the deploy lifecycle can retire
+    // the runtime-unreachable warning it raised without touching an unrelated
+    // toast (issue #713).
+    dismissNotificationForEnv(state, action: PayloadAction<NotificationEnvMatch>) {
+      const current = state.notification;
+      if (!current) {
+        return;
+      }
+      const { tenant, environment, source } = action.payload;
+      if (
+        current.source === source &&
+        current.tenant === tenant &&
+        current.environment === environment
+      ) {
+        state.notification = null;
+      }
+    },
   },
 });
 
-export const { showNotification, dismissNotification } = notificationSlice.actions;
+export const { showNotification, dismissNotification, dismissNotificationForEnv } =
+  notificationSlice.actions;
 export default notificationSlice.reducer;

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -142,6 +142,13 @@ export interface GlobalConfigDialogState {
 export interface AppNotification {
   kind: 'success' | 'warning' | 'error' | 'info';
   message: string;
+  // Optional env tag so a notification can be cleared later by the state it
+  // describes (issue #713). The runtime-unreachable warning carries the env it
+  // targets and a stable `source`; the deploy lifecycle dismisses it by matching
+  // all three (see dismissNotificationForEnv).
+  tenant?: string;
+  environment?: string;
+  source?: string;
 }
 
 export type TerminalStatusKind = 'info' | 'warning' | 'error';

--- a/erun-ui/frontend/src/app/wailsEventForwarders.ts
+++ b/erun-ui/frontend/src/app/wailsEventForwarders.ts
@@ -1,7 +1,9 @@
 import { EventsOn } from '../../wailsjs/runtime/runtime';
 import type { ActivityLockEvent, ActivityQueueEntry } from './activityQueueState';
 import { wailsApi } from './api/wailsApi';
+import type { AppNotificationClearPayload } from './model';
 import { setActivityLock, upsertActivityEntry } from './slices/activitySlice';
+import { dismissNotificationForEnv } from './slices/notificationSlice';
 import type { AppDispatch } from './store';
 
 // attachWailsEventForwarders bridges Go-side runtime events into Redux. The
@@ -15,6 +17,19 @@ export function attachWailsEventForwarders(dispatch: AppDispatch): void {
   });
   EventsOn('activity:lock', (event: ActivityLockEvent) => {
     dispatch(setActivityLock(event));
+  });
+  // Retire an env-tagged notification when the state it described has moved on
+  // (issue #713): the runtime-unreachable warning is cleared once a deploy for
+  // its env starts or the runtime becomes reachable. The reducer clears it only
+  // when source/tenant/environment all match, so an unrelated toast is untouched.
+  EventsOn('app-notification-clear', (event: AppNotificationClearPayload) => {
+    dispatch(
+      dismissNotificationForEnv({
+        tenant: event.tenant ?? '',
+        environment: event.environment ?? '',
+        source: event.source ?? '',
+      }),
+    );
   });
   EventsOn('environments-changed', () => {
     dispatch(wailsApi.util.invalidateTags(['AppState']));

--- a/erun-ui/frontend/src/app/wailsEventThunks.ts
+++ b/erun-ui/frontend/src/app/wailsEventThunks.ts
@@ -115,7 +115,13 @@ export const handleAppNotification =
       return;
     }
     const kind = payload.kind ?? 'info';
-    dispatch(showNotification(kind, message));
+    dispatch(
+      showNotification(kind, message, {
+        tenant: payload.tenant,
+        environment: payload.environment,
+        source: payload.source,
+      }),
+    );
   };
 
 // Bounded retry budget for surfacing a just-initialized env. The

--- a/erun-ui/frontend/src/components/app/ActivityLockOverlay.tsx
+++ b/erun-ui/frontend/src/components/app/ActivityLockOverlay.tsx
@@ -27,7 +27,10 @@ export function ActivityLockOverlay({
 }: ActivityLockOverlayProps): React.ReactElement {
   return (
     <div
-      className="pointer-events-none absolute top-3 right-3 z-10 flex max-w-[360px] flex-col items-end gap-1"
+      // Cap the card at the pane width (minus the 12px inset on each side) so a
+      // narrow/starved terminal pane shrinks it to fit instead of clipping its
+      // right edge behind the pane's own overflow-hidden (issue #713).
+      className="pointer-events-none absolute top-3 right-3 z-10 flex max-w-[min(360px,calc(100%_-_1.5rem))] flex-col items-end gap-1"
       role="status"
       aria-live="polite"
     >

--- a/erun-ui/frontend/src/components/app/TerminalPane.tsx
+++ b/erun-ui/frontend/src/components/app/TerminalPane.tsx
@@ -55,10 +55,18 @@ export function TerminalPane({
   return (
     <div
       className={cn(
-        'grid min-h-0 min-w-0 grid-cols-[minmax(360px,1fr)] overflow-hidden',
+        // The terminal column tracks the visible width (min 0). A hard min
+        // (e.g. minmax(360px,1fr)) forces the pane wider than the available
+        // area when the sidebar is wide or the window is narrow, so the
+        // `overflow-hidden` parent clips its right edge — and drags the
+        // right-anchored ActivityLockOverlay off-screen with it (issue #713).
+        // At any width where the terminal already fits, `minmax(0,1fr)` is
+        // pixel-identical to a hard min; it only differs when starved, where
+        // letting xterm reflow narrower beats clipping content off the right.
+        'grid min-h-0 min-w-0 grid-cols-[minmax(0,1fr)] overflow-hidden',
         hidden && 'hidden',
         reviewOpen &&
-          'grid-cols-[minmax(360px,1fr)_10px_minmax(420px,var(--review-width))] max-[980px]:grid-cols-[minmax(260px,1fr)_10px_minmax(360px,min(var(--review-width),58vw))]',
+          'grid-cols-[minmax(0,1fr)_10px_minmax(420px,var(--review-width))] max-[980px]:grid-cols-[minmax(0,1fr)_10px_minmax(360px,min(var(--review-width),58vw))]',
       )}
     >
       <div className="grid h-full min-h-0 min-w-0 grid-rows-[32px_minmax(0,1fr)] overflow-hidden">

--- a/erun-ui/frontend/src/components/app/Titlebar.Status.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.Status.tsx
@@ -16,6 +16,8 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
+import { ClipboardSetText } from '../../../wailsjs/runtime/runtime';
+
 // Long error text (AWS/IAM/Helm/etc. messages) routinely runs over the
 // titlebar pill width. Anything past this threshold escalates the trigger
 // from a hover tooltip to a click-to-open popover with selectable content
@@ -78,7 +80,12 @@ export function TitlebarStatus(): React.ReactElement | null {
         <StatusIcon status={status} />
         <StatusMessage status={status} />
         {status.action === 'wait-longer' && <StatusWaitAction />}
-        {status.copyOutput && <StatusCopyAction status={status} />}
+        {status.copyOutput &&
+          (status.source === 'notification' ? (
+            <NotificationCopyAction text={status.copyOutput} />
+          ) : (
+            <StatusCopyAction status={status} />
+          ))}
         <StatusDismissAction status={status} />
       </div>
     </div>
@@ -103,7 +110,14 @@ function computeTitlebarStatus(
       source: 'notification',
       detail: '',
       busy: false,
-      copyOutput: '',
+      // Error/warning notifications (deploy failed, runtime unreachable) carry
+      // an actionable message with long paths the operator needs to copy into a
+      // bug report — give them a copy button, like the terminal-status errors
+      // already have (issue #713). Transient success/info toasts don't need one.
+      copyOutput:
+        notification.kind === 'error' || notification.kind === 'warning'
+          ? notification.message
+          : '',
       copyStatus: '',
       action: '',
     };
@@ -249,6 +263,36 @@ function StatusCopyAction({ status }: { status: TitlebarStatusValue }): React.Re
           <Copy aria-hidden="true" />
         )}
         {status.copyStatus || 'Copy output'}
+      </Button>
+    </IconTooltip>
+  );
+}
+
+// NotificationCopyAction copies an error/warning notification's message to the
+// clipboard (issue #713). Notifications have no terminal copy-output slot, so it
+// copies the message directly and shows a transient "Copied" via local state —
+// the terminal path (StatusCopyAction) keeps its Redux-backed copy flow.
+function NotificationCopyAction({ text }: { text: string }): React.ReactElement {
+  const [copied, setCopied] = React.useState(false);
+  const onCopy = React.useCallback(() => {
+    void ClipboardSetText(text).then(() => {
+      setCopied(true);
+      window.setTimeout(() => {
+        setCopied(false);
+      }, 1400);
+    });
+  }, [text]);
+  return (
+    <IconTooltip label="Copy message">
+      <Button
+        className="h-6 flex-none gap-1 rounded-md px-2 text-[12px] text-foreground hover:bg-accent hover:text-accent-foreground [&_svg]:size-3.5"
+        type="button"
+        variant="ghost"
+        size="xs"
+        onClick={onCopy}
+      >
+        {copied ? <CheckCircle2 aria-hidden="true" /> : <Copy aria-hidden="true" />}
+        {copied ? 'Copied' : 'Copy'}
       </Button>
     </IconTooltip>
   );

--- a/erun-ui/frontend/src/components/app/Titlebar.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.tsx
@@ -21,9 +21,17 @@ import { TitlebarStatus } from '@/components/app/Titlebar.Status';
 // stack above it without needing explicit z-index on every button.
 export function Titlebar(): React.ReactElement {
   const dispatch = useAppDispatch();
+  // min-w-0 on the header: it is a grid item (row 1 of the app grid) whose
+  // default min-width:auto lets it grow to its content width. A long status
+  // message then stretched the header past the viewport, so the pill's
+  // `max-w-full` resolved to that oversized width — the message never truncated
+  // and the dismiss button was pushed off-screen, leaving the banner
+  // un-dismissable (#713). min-w-0 caps the header at the grid track (viewport),
+  // restoring the truncate chain so the message ellipsizes and the dismiss X
+  // stays reachable.
   return (
     <header
-      className="relative box-border flex h-full items-center gap-3 border-b bg-[color-mix(in_oklch,var(--background)_94%,transparent)] px-3 select-none [--wails-draggable:drag]"
+      className="relative box-border flex h-full min-w-0 items-center gap-3 border-b bg-[color-mix(in_oklch,var(--background)_94%,transparent)] px-3 select-none [--wails-draggable:drag]"
       data-wails-drag
       onDoubleClick={(event) => {
         dispatch(titlebarDoubleClick(event));

--- a/erun-ui/idle_status.go
+++ b/erun-ui/idle_status.go
@@ -288,7 +288,7 @@ func (a *App) recordManualStopForCloudContext(ctx context.Context, cloudContextN
 			Environment: selection.Environment,
 		})
 		if err != nil {
-			a.emitAppNotification("warn", fmt.Sprintf("Could not record manual stop for %s/%s: %s", selection.Tenant, selection.Environment, err.Error()))
+			a.emitAppNotification("warning", fmt.Sprintf("Could not record manual stop for %s/%s: %s", selection.Tenant, selection.Environment, err.Error()))
 			continue
 		}
 		mcpPort := eruncommon.MCPPortForResult(result)
@@ -302,7 +302,7 @@ func (a *App) recordManualStopForCloudContext(ctx context.Context, cloudContextN
 		endpoint := mcpEndpointForOpenResult(result)
 		bearer := a.mcpBearer(selection.Tenant, selection.Environment)
 		if err := recordManualStopViaMCP(ctx, endpoint, bearer, selection.Tenant, selection.Environment, "Manual stop via desktop", cloudContextName); err != nil {
-			a.emitAppNotification("warn", fmt.Sprintf("Could not record manual stop for %s/%s: %s", selection.Tenant, selection.Environment, err.Error()))
+			a.emitAppNotification("warning", fmt.Sprintf("Could not record manual stop for %s/%s: %s", selection.Tenant, selection.Environment, err.Error()))
 		}
 	}
 }

--- a/erun-ui/playwright/fixtures/erunApp.ts
+++ b/erun-ui/playwright/fixtures/erunApp.ts
@@ -35,12 +35,17 @@ export const test = base.extend<{ app: AppShell; seededEnv: SeededEnvironment }>
   seededEnv: async ({ app }, use, testInfo) => {
     const environment = uniqueEnvironmentName(testInfo.title);
     seedEnvironment(SEED_TENANT, environment);
-    // The config watcher debounces ~250 ms before emitting
-    // environments-changed; wait for the row so specs start from a
-    // mounted, clickable env.
+    // The backend's fsnotify config watcher normally surfaces the new row, but
+    // the very first env created right after boot can race the watcher's
+    // readiness — the create/write events are missed and the row never appears
+    // within the wait (a flake, ~40% when this fixture is the first env change
+    // after boot). The config file is already on disk (synchronous write), and
+    // the backend reads config fresh on each state refetch, so a forced reload
+    // surfaces the row deterministically, independent of fsnotify timing.
+    await app.reloadEnvironments();
     await app.sidebar
       .envRowButton(SEED_TENANT, environment)
-      .waitFor({ state: 'visible', timeout: 10_000 });
+      .waitFor({ state: 'visible', timeout: 15_000 });
     await use({ tenant: SEED_TENANT, environment });
     removeEnvironment(SEED_TENANT, environment);
   },

--- a/erun-ui/playwright/pages/AppShell.ts
+++ b/erun-ui/playwright/pages/AppShell.ts
@@ -43,6 +43,19 @@ export class AppShell {
       .waitFor({ state: 'visible' });
   }
 
+  // reloadEnvironments forces the frontend to re-fetch tenant/env state from
+  // disk by emitting the same `environments-changed` event the backend's config
+  // watcher fires. Used to surface a freshly-seeded env deterministically
+  // instead of waiting on fsnotify, which can race the watcher's readiness right
+  // after boot (see the seededEnv fixture).
+  async reloadEnvironments(): Promise<void> {
+    await this.page.evaluate(() => {
+      (window as unknown as { runtime: { EventsEmit: (name: string) => void } }).runtime.EventsEmit(
+        'environments-changed',
+      );
+    });
+  }
+
   get sidebar(): Sidebar {
     return new Sidebar(this.page);
   }

--- a/erun-ui/playwright/tests/activity-lock-overlay.spec.ts
+++ b/erun-ui/playwright/tests/activity-lock-overlay.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '../fixtures/erunApp.js';
+import type { Page, Request } from '@playwright/test';
+import type { AppShell } from '../pages/index.js';
+
+// Issue #713 — the deploy-progress overlay (ActivityLockOverlay) is anchored to
+// the top-right of the terminal pane. The pane used to carry a hard 360px
+// grid-column minimum, so when the pane's available width dropped below that
+// (wide sidebar and/or narrow window) the pane overflowed its overflow-hidden
+// parent and dragged the right-anchored overlay off-screen — its text was cut
+// off at the window edge. The fix lets the terminal column track the visible
+// width (minmax(0,1fr)) so the pane never overflows, and caps the overlay to the
+// pane so it shrinks instead of clipping. This spec starves the pane below the
+// old floor and asserts the overlay stays fully inside the viewport.
+//
+// The overlay renders over the active terminal session while a deploy locks it;
+// the lock is staged by injecting the `activity:lock` event the Go side emits
+// (same EventsEmit seam terminal-scroll-on-resize.spec.ts uses), so no cluster
+// or real deploy is needed.
+test.describe('deploy-progress overlay stays on-screen (#713)', () => {
+  test('the activity-lock overlay is not clipped when the terminal pane is starved', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    // The ERun tab is the env's default terminal; make sure it is the active
+    // session the overlay will render over.
+    const erunTab = page.getByRole('tab', { name: 'ERun', exact: true });
+    await erunTab.waitFor({ state: 'visible', timeout: 15_000 });
+    await erunTab.click();
+
+    const sessionId = await discoverSelectedSessionId(app, page);
+    expect(sessionId).toBeGreaterThan(0);
+
+    // Starve the terminal pane: the sidebar (~348px incl. handle) plus the old
+    // 360px column minimum needed ~708px of width, so 640px forced the overflow.
+    await page.setViewportSize({ width: 640, height: 900 });
+
+    // Stage an in-flight deploy lock for the active session — this renders the
+    // overlay (Reason + deployTarget mirror what lockTerminalsForActivity emits).
+    await emitActivityLock(page, sessionId);
+
+    const overlay = page.getByRole('status').filter({ hasText: 'frs/prod 1.0.106' });
+    await expect(overlay).toBeVisible();
+    await expect(overlay).toContainText('Waiting for deploy to complete');
+
+    // The overlay must sit fully within the viewport — no right-edge clip.
+    const viewportWidth = page.viewportSize()?.width ?? 0;
+    const box = await overlay.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box?.x ?? -1).toBeGreaterThanOrEqual(0);
+    // Allow a sub-pixel rounding slack; the old bug pushed the right edge tens
+    // of pixels past the viewport, so this cleanly separates fixed from broken.
+    expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(viewportWidth + 1);
+
+    // And the pane it lives in must not overflow the viewport either (the root
+    // cause: a pane wider than the visible area took the overlay off-screen).
+    const paneRight = await page.evaluate(() => {
+      const pane = document.querySelector('#erun-terminal-pane');
+      return pane ? pane.getBoundingClientRect().right : Number.POSITIVE_INFINITY;
+    });
+    expect(paneRight).toBeLessThanOrEqual(viewportWidth + 1);
+
+    // Restore the config default viewport for later specs in the singleton backend.
+    await page.setViewportSize({ width: 1440, height: 1200 });
+  });
+});
+
+interface InvokeCall {
+  method: string;
+  args: unknown[];
+}
+
+// parseInvoke decodes a /__erun_invoke POST body into {method, args}, or null
+// when the request is not an invoke (or carries no JSON body).
+function parseInvoke(req: Request): InvokeCall | null {
+  if (req.method() !== 'POST' || !req.url().endsWith('/__erun_invoke')) {
+    return null;
+  }
+  let body: { method?: string; args?: unknown[] } | null = null;
+  try {
+    body = req.postDataJSON() as { method?: string; args?: unknown[] } | null;
+  } catch {
+    return null;
+  }
+  return body?.method ? { method: body.method, args: body.args ?? [] } : null;
+}
+
+// discoverSelectedSessionId finds the session the terminal is rendering by
+// provoking a resize (sidebar toggle) and sniffing the ResizeSession invoke,
+// then restores the sidebar. 0 means no session is selected.
+async function discoverSelectedSessionId(app: AppShell, page: Page): Promise<number> {
+  const waitForResize = page
+    .waitForRequest((req) => parseInvoke(req)?.method === 'ResizeSession')
+    .catch(() => null);
+  await app.titlebar.toggleButton().click();
+  const resize = await waitForResize;
+  await app.titlebar.toggleButton().click();
+  const id = resize ? parseInvoke(resize)?.args[0] : undefined;
+  return typeof id === 'number' ? id : 0;
+}
+
+// emitActivityLock stages an in-flight deploy lock for sessionId, mirroring the
+// activity:lock event lockTerminalsForActivity emits on the Go side.
+async function emitActivityLock(page: Page, sessionId: number): Promise<void> {
+  await page.evaluate((sid) => {
+    const runtime = (
+      window as unknown as {
+        runtime: { EventsEmit: (name: string, ...args: unknown[]) => void };
+      }
+    ).runtime;
+    runtime.EventsEmit('activity:lock', {
+      sessionId: sid,
+      tenant: 'frs',
+      environment: 'prod',
+      locked: true,
+      deployId: 'dep-1',
+      reason: 'Waiting for deploy to complete',
+      deployTarget: 'frs/prod 1.0.106',
+    });
+  }, sessionId);
+}

--- a/erun-ui/playwright/tests/deploy-failure-toolbar.spec.ts
+++ b/erun-ui/playwright/tests/deploy-failure-toolbar.spec.ts
@@ -38,6 +38,32 @@ test.describe('failed deploys surface in the toolbar (#713)', () => {
     await emitClear(page, { tenant: 'frs', environment: 'prod', source: '' });
     await expect(banner(page)).toBeHidden();
   });
+
+  test('the deploy-failed error can be copied to the clipboard', async ({ app }) => {
+    const { page } = app;
+    await emitDeployFailed(page, message);
+    await expect(banner(page)).toBeVisible();
+
+    // Error notifications carry long paths the operator needs to copy into a bug
+    // report, so they get a copy button like terminal-status errors do (#713).
+    const copy = page.getByRole('button', { name: 'Copy', exact: true });
+    await expect(copy).toBeVisible();
+
+    // Clicking it writes the message to the clipboard — the headless shim routes
+    // ClipboardSetText to a POST /__erun_clipboard {action:"set", text}.
+    const clipboardWrite = page.waitForRequest(
+      (req) =>
+        req.method() === 'POST' &&
+        req.url().endsWith('/__erun_clipboard') &&
+        (req.postData() ?? '').includes('"action":"set"'),
+    );
+    await copy.click();
+    const req = await clipboardWrite;
+    expect(req.postData() ?? '').toContain('Deploy of frs/prod failed');
+
+    // And it confirms the copy in place.
+    await expect(page.getByRole('button', { name: 'Copied', exact: true })).toBeVisible();
+  });
 });
 
 interface RuntimeShim {

--- a/erun-ui/playwright/tests/deploy-failure-toolbar.spec.ts
+++ b/erun-ui/playwright/tests/deploy-failure-toolbar.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '../fixtures/erunApp.js';
+import type { Page } from '@playwright/test';
+
+// Issue #713 — a failed deploy must be visible in the top toolbar, not only as a
+// red terminal line or a drawer entry (it wasn't surfaced at all when the deploy
+// failed before rollout, e.g. spec resolution). `erun deploy` now emits a
+// `==> Deploy failed tenant/env: reason` trace on every failure path; the desktop
+// turns that into an env-tagged error notification (surfaceDeployFailure). This
+// spec locks the frontend contract: the deploy-failed error renders in the
+// toolbar, and the deploy lifecycle's env-wide clear (empty source — a new
+// deploy starting, or the runtime becoming reachable) retires it, while a clear
+// for a different env leaves it alone.
+//
+// The events mirror what the Go side emits (app-notification with
+// source=deploy-failed; app-notification-clear with an empty source), injected
+// over the EventsEmit seam. The Go trace→surface wiring is covered by
+// activity_queue_app_test.go::TestDeployFailedTraceSurfacesToToolbar.
+test.describe('failed deploys surface in the toolbar (#713)', () => {
+  const message = 'Deploy of frs/prod failed: values file not found for environment "prod".';
+  const banner = (page: Page) => page.getByText(/Deploy of frs\/prod failed/);
+
+  test('the deploy-failed error shows and is retired by the env-wide lifecycle clear', async ({
+    app,
+  }) => {
+    const { page } = app;
+
+    await emitDeployFailed(page, message);
+    await expect(banner(page)).toBeVisible();
+
+    // A lifecycle clear for a different env must NOT dismiss this error. Sample
+    // over a window so a buggy "clear everything" is caught once its SSE lands.
+    await emitClear(page, { tenant: 'other', environment: 'prod', source: '' });
+    expect(await bannerGoneWithin(page, 700)).toBe(false);
+
+    // The env-wide clear the deploy lifecycle fires for frs/prod (empty source =
+    // any env-scoped warning) retires it — this is what a new deploy starting or
+    // the runtime becoming reachable emits.
+    await emitClear(page, { tenant: 'frs', environment: 'prod', source: '' });
+    await expect(banner(page)).toBeHidden();
+  });
+});
+
+interface RuntimeShim {
+  runtime: { EventsEmit: (name: string, ...args: unknown[]) => void };
+}
+
+async function emitDeployFailed(page: Page, message: string): Promise<void> {
+  await page.evaluate((msg) => {
+    (window as unknown as RuntimeShim).runtime.EventsEmit('app-notification', {
+      kind: 'error',
+      message: msg,
+      tenant: 'frs',
+      environment: 'prod',
+      source: 'deploy-failed',
+    });
+  }, message);
+}
+
+async function emitClear(
+  page: Page,
+  target: { tenant: string; environment: string; source: string },
+): Promise<void> {
+  await page.evaluate((t) => {
+    (window as unknown as RuntimeShim).runtime.EventsEmit('app-notification-clear', t);
+  }, target);
+}
+
+// bannerGoneWithin samples the error's presence for `ms` in the browser and
+// reports whether it ever disappeared — the deterministic "assert it stayed"
+// primitive (mirrors terminal-scroll-on-resize's viewportEverAtBottom).
+async function bannerGoneWithin(page: Page, ms: number): Promise<boolean> {
+  return await page.evaluate(async (duration) => {
+    const present = (): boolean => document.body.innerText.includes('Deploy of frs/prod failed');
+    const deadline = Date.now() + duration;
+    while (Date.now() < deadline) {
+      if (!present()) {
+        return true;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    return false;
+  }, ms);
+}

--- a/erun-ui/playwright/tests/runtime-unreachable-banner-clear.spec.ts
+++ b/erun-ui/playwright/tests/runtime-unreachable-banner-clear.spec.ts
@@ -26,6 +26,11 @@ test.describe('runtime-unreachable banner clears with the deploy lifecycle (#713
     await emitRuntimeUnreachable(page, message);
     await expect(banner(page)).toBeVisible();
 
+    // The warning renders with the attention icon (lucide circle-alert), not the
+    // neutral info ⓘ — the Go side must emit kind "warning", not an unrecognized
+    // "warn" that falls through to the info icon (#713).
+    expect(await bannerIconKind(page)).toBe('alert');
+
     // A clear for a different env must NOT dismiss this warning. Sample over a
     // window (mirrors terminal-scroll-on-resize's negative check) so a buggy
     // "clear everything" would be caught once its SSE round-trip lands.
@@ -45,6 +50,41 @@ test.describe('runtime-unreachable banner clears with the deploy lifecycle (#713
     });
     await expect(banner(page)).toBeHidden();
   });
+
+  test('a long message stays within the bar and the dismiss button is reachable', async ({
+    app,
+  }) => {
+    const { page } = app;
+    // A real runtime-unreachable message includes the port-forward log path and
+    // is far longer than the pill — it used to stretch the header past the
+    // viewport, so nothing truncated and the dismiss X was pushed off-screen,
+    // leaving the banner un-dismissable (#713).
+    const longMessage =
+      'Could not reach the runtime for frs/prod: activate MCP port-forward: exit status 1: ' +
+      'timed out waiting for API port-forward on 127.0.0.1:17333; see ' +
+      '/Users/example/Library/Application Support/erun/portforward/api/frs/prod.log. ' +
+      'Deploy the environment to bring it up.';
+    await emitRuntimeUnreachable(page, longMessage);
+    await expect(banner(page)).toBeVisible();
+
+    // The header must not overflow the viewport, and the dismiss button must sit
+    // fully inside it (the bug pushed it hundreds of px off the right edge).
+    const viewportWidth = page.viewportSize()?.width ?? 0;
+    const headerRight = await page.evaluate(
+      () =>
+        document.querySelector('header')?.getBoundingClientRect().right ?? Number.POSITIVE_INFINITY,
+    );
+    expect(headerRight).toBeLessThanOrEqual(viewportWidth + 1);
+
+    const dismiss = page.getByRole('button', { name: 'Dismiss status' });
+    const box = await dismiss.boundingBox();
+    expect(box).not.toBeNull();
+    expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(viewportWidth);
+
+    // And it actually dismisses — the whole point.
+    await dismiss.click();
+    await expect(banner(page)).toBeHidden();
+  });
 });
 
 interface RuntimeShim {
@@ -54,7 +94,7 @@ interface RuntimeShim {
 async function emitRuntimeUnreachable(page: Page, message: string): Promise<void> {
   await page.evaluate((msg) => {
     (window as unknown as RuntimeShim).runtime.EventsEmit('app-notification', {
-      kind: 'warn',
+      kind: 'warning',
       message: msg,
       tenant: 'frs',
       environment: 'prod',
@@ -70,6 +110,26 @@ async function emitNotificationClear(
   await page.evaluate((t) => {
     (window as unknown as RuntimeShim).runtime.EventsEmit('app-notification-clear', t);
   }, target);
+}
+
+// bannerIconKind reads the icon lucide renders inside the runtime-unreachable
+// banner: 'alert' for the attention icon (circle-alert, warning/error), 'info'
+// for the neutral ⓘ, or 'other'. Locks that the warning gets the attention icon.
+async function bannerIconKind(page: Page): Promise<'alert' | 'info' | 'other'> {
+  return await page.evaluate(() => {
+    const banners = Array.from(document.querySelectorAll('[role="status"],[role="alert"]'));
+    const banner = banners.find((b) =>
+      (b.textContent ?? '').includes('Could not reach the runtime for frs/prod'),
+    );
+    const cls = banner?.querySelector('svg')?.getAttribute('class') ?? '';
+    if (cls.includes('lucide-circle-alert')) {
+      return 'alert';
+    }
+    if (cls.includes('lucide-info')) {
+      return 'info';
+    }
+    return 'other';
+  });
 }
 
 // bannerHiddenWithin samples the banner's presence for `ms` and reports whether

--- a/erun-ui/playwright/tests/runtime-unreachable-banner-clear.spec.ts
+++ b/erun-ui/playwright/tests/runtime-unreachable-banner-clear.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '../fixtures/erunApp.js';
+import type { Page } from '@playwright/test';
+
+// Issue #713 — the "Could not reach the runtime … Deploy the environment to
+// bring it up." warning (issue #711) used to linger while a deploy for that env
+// was already in flight, contradicting the deploy-progress overlay, and stayed
+// up after the runtime became reachable again. The Go side now tags the warning
+// with its env + a stable source and fires an `app-notification-clear` when the
+// state it describes moves on (a deploy for the env starts, or the runtime is
+// reached). This spec locks the frontend contract that backs that clear: a
+// matching clear dismisses the warning, a mismatched one leaves it alone.
+//
+// The events are the same ones the Go side emits (app-notification /
+// app-notification-clear), injected over the EventsEmit seam, so no cluster or
+// real reconnect is needed. The Go decisions that fire these events are covered
+// by env_ensure_test.go and activity_queue_app_test.go.
+test.describe('runtime-unreachable banner clears with the deploy lifecycle (#713)', () => {
+  const message =
+    'Could not reach the runtime for frs/prod: timed out waiting for API port-forward. Deploy the environment to bring it up.';
+  const banner = (page: Page) => page.getByText(/Could not reach the runtime for frs\/prod/);
+
+  test('a matching clear dismisses the warning; a mismatched one does not', async ({ app }) => {
+    // The `app` fixture boots the headless app (navigates to '/' and installs
+    // the window.runtime shim the injected events ride on).
+    const { page } = app;
+    await emitRuntimeUnreachable(page, message);
+    await expect(banner(page)).toBeVisible();
+
+    // A clear for a different env must NOT dismiss this warning. Sample over a
+    // window (mirrors terminal-scroll-on-resize's negative check) so a buggy
+    // "clear everything" would be caught once its SSE round-trip lands.
+    await emitNotificationClear(page, {
+      tenant: 'other',
+      environment: 'prod',
+      source: 'runtime-unreachable',
+    });
+    expect(await bannerHiddenWithin(page, 700)).toBe(false);
+
+    // The matching clear — what the deploy lifecycle fires when a deploy for
+    // frs/prod starts or the runtime is reached — dismisses it.
+    await emitNotificationClear(page, {
+      tenant: 'frs',
+      environment: 'prod',
+      source: 'runtime-unreachable',
+    });
+    await expect(banner(page)).toBeHidden();
+  });
+});
+
+interface RuntimeShim {
+  runtime: { EventsEmit: (name: string, ...args: unknown[]) => void };
+}
+
+async function emitRuntimeUnreachable(page: Page, message: string): Promise<void> {
+  await page.evaluate((msg) => {
+    (window as unknown as RuntimeShim).runtime.EventsEmit('app-notification', {
+      kind: 'warn',
+      message: msg,
+      tenant: 'frs',
+      environment: 'prod',
+      source: 'runtime-unreachable',
+    });
+  }, message);
+}
+
+async function emitNotificationClear(
+  page: Page,
+  target: { tenant: string; environment: string; source: string },
+): Promise<void> {
+  await page.evaluate((t) => {
+    (window as unknown as RuntimeShim).runtime.EventsEmit('app-notification-clear', t);
+  }, target);
+}
+
+// bannerHiddenWithin samples the banner's presence for `ms` and reports whether
+// it ever went hidden — the deterministic "assert it stayed" primitive for the
+// mismatched-clear case (an async SSE clear would land within the window). The
+// sampling loop runs in the browser (mirrors terminal-scroll-on-resize's
+// viewportEverAtBottom) so it is a bounded observation, not a spec-side sleep.
+async function bannerHiddenWithin(page: Page, ms: number): Promise<boolean> {
+  return await page.evaluate(async (duration) => {
+    const present = (): boolean =>
+      document.body.innerText.includes('Could not reach the runtime for frs/prod');
+    const deadline = Date.now() + duration;
+    while (Date.now() < deadline) {
+      if (!present()) {
+        return true;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    return false;
+  }, ms);
+}

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -428,6 +428,23 @@ type appStatusPayload struct {
 type appNotificationPayload struct {
 	Kind    string `json:"kind"`
 	Message string `json:"message"`
+	// Tenant/Environment/Source tag a notification so it can be cleared later
+	// by the state it describes. The runtime-unreachable warning (issue #713)
+	// carries the env it targets and a stable source, so the deploy lifecycle
+	// (a deploy starting for that env, or the runtime becoming reachable) can
+	// dismiss it without touching an unrelated toast.
+	Tenant      string `json:"tenant,omitempty"`
+	Environment string `json:"environment,omitempty"`
+	Source      string `json:"source,omitempty"`
+}
+
+// appNotificationClearPayload dismisses an env-tagged notification (see
+// appNotificationClearEvent). The frontend clears the current notification
+// only when its source/tenant/environment all match.
+type appNotificationClearPayload struct {
+	Tenant      string `json:"tenant"`
+	Environment string `json:"environment"`
+	Source      string `json:"source"`
 }
 
 type pastedFilePayload struct {


### PR DESCRIPTION
Closes #713.

Desktop (`erun-ui`) toolbar status/error correctness — the deploy lifecycle failing to communicate usably through the top toolbar. Grew across review because it's one body of work.

## 1. Deploy-progress overlay clipped at the window's right edge
`ActivityLockOverlay` (`absolute right-3` inside `#erun-terminal-pane`) got dragged off-screen when the pane hit its hard `minmax(360px,1fr)` floor and overflowed. **Fix:** terminal column → `minmax(0,1fr)` + overlay capped to the pane.

## 2. Runtime-unreachable banner contradicted an in-flight deploy
It stayed up during a deploy for that env and lingered after the runtime came back. **Fix:** env-tagged; the deploy lifecycle suppresses it while a deploy is in flight, and clears it when a deploy starts or the runtime is reached.

## 3. A failed deploy showed nothing in the toolbar
A pre-rollout failure (spec resolution) fails before any `==> Deploying`, and even detected failures only updated the drawer. **Fix:** `erun deploy` emits a structured env-tagged `==> Deploy failed <tenant>/<env>: <reason>` on **every** failure path; the desktop surfaces it as an env-tagged error notification + failed sidebar status.

## 4. The runtime-unreachable banner could not be dismissed (overflowed the bar)
The `<header>` (a grid item, default `min-width:auto`) grew to its content width; a ~270-char message stretched it past the viewport, so nothing truncated and the dismiss X was pushed hundreds of px off-screen. **Fix:** `min-w-0` on the header caps it at the viewport, restoring the truncate chain — message ellipsizes (full text via the popover) and the dismiss X stays reachable.

## 5. Warnings rendered as neutral info (ⓘ)
The Go side emitted invalid kind `"warn"` (not `"warning"`), so warnings fell through to the info icon. **Fix:** emit `"warning"` → amber attention icon.

## 6. Error/warning notifications had no copy button
They carry long paths the operator needs to copy into a bug report, but only terminal-status errors had a copy button, and a message just under the 160-char popover threshold rendered as a non-selectable hover tooltip. **Fix:** error/warning notifications get a copy button (`NotificationCopyAction`) that copies the message and confirms in place.

## Test-infra flake fixed
The new overlay spec exposed a pre-existing `seededEnv` flake (fsnotify racing the watcher's readiness on the first env after boot, ~40% miss in isolation). The fixture now forces a state reload (backend reads config fresh on refetch) — deterministic (overlay spec 5/5 in isolation).

## Validation
- **Integration gate green:** `make integration-test` — coverage **75.3% ≥ 75.0%**, all goldens pass (11 deploy goldens regenerated; only change is the appended `==> Deploy failed …` line on failure scenarios).
- **Full Playwright suite: 103/103 passed**, incl. six new specs/tests: overlay-not-clipped at a starved width; runtime-unreachable clear (match vs mismatch) + warning-icon + long-message overflow/dismiss; deploy-failed renders + env-wide clear + **copy-to-clipboard**.
- **Go unit tests:** overlay-suppress/clear lifecycle, `TestDeployFailedTraceSurfacesToToolbar`, kind=warning.
- `yarn typecheck && yarn lint && yarn format:check && yarn build` green; pre-commit lint clean.
- **Verified live in `erun-app --headless`:** overlay in-viewport at 640px; failed deploy shows in the toolbar with its reason; runtime-unreachable renders with the amber alert icon, a reachable/working dismiss X on a 270-char message, and a working copy button.

## Scope / docs
Touches `erun-cli` (one trace line) + integration goldens (hence the integration gate above). The frs-repo config that caused the observed failure (`frs-devops/k8s/erun-docs/values.<env>.yaml` missing) is an frs concern, not fixed here — the app now surfaces such failures instead of swallowing them. Behaviour/UX bug fixes plus one additive CLI trace line — no `erun-docs` update required per `erun-docs/AGENTS.md` § Spec discipline exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)