### PR TITLE
Clarify published runtime chart label in deploy checklist

### DIFF
--- a/erun-ui/frontend/src/app/deployComponentsSelection.ts
+++ b/erun-ui/frontend/src/app/deployComponentsSelection.ts
@@ -52,13 +52,34 @@ export function deployComponentSelectionChanged(
   return baseline.some((name) => !selected.has(name));
 }
 
+// PUBLISHED_RUNTIME_CHART_NAME is the canonical runtime chart every
+// published-chart environment installs, regardless of tenant: the deploy path
+// hardcodes oci://<registry>/charts/erun-devops (erun-common's
+// DevopsComponentName, consumed by resolvePublishedDevopsDeploySpec). It is NOT
+// the release name — that is <tenant>-devops. Mirrors the backend constant; if
+// published charts ever become tenant-aware, update both together.
+const PUBLISHED_RUNTIME_CHART_NAME = 'erun-devops';
+
 // deployComponentLabel renders a user-facing label: the runtime item names its
-// role and source (the operator does not manage the raw chart), while component
-// charts show their chart name directly.
+// role, chart, and release (the operator does not manage the raw chart), while
+// component charts show their chart name directly.
+//
+// The published-runtime case names the real chart (erun-devops) and the release
+// name separately, because component.name there is only the Helm release name
+// (<tenant>-devops): no per-tenant chart is published, so "<tenant>-devops
+// (published)" wrongly implied a published <tenant>-devops chart and contradicted
+// the erun-devops versions the picker offers (#721). The local-chart case is
+// left as-is — there component.name is a real repo-local chart directory the
+// operator does manage.
 export function deployComponentLabel(component: UIDeployableComponent): string {
   if (component.runtime) {
-    const published = component.source === 'published-chart' ? ' (published)' : '';
-    return `Runtime — ${component.name}${published}`;
+    if (component.source === 'published-chart') {
+      if (component.name === PUBLISHED_RUNTIME_CHART_NAME) {
+        return `Runtime — published ${PUBLISHED_RUNTIME_CHART_NAME} chart`;
+      }
+      return `Runtime — published ${PUBLISHED_RUNTIME_CHART_NAME} chart (released as ${component.name})`;
+    }
+    return `Runtime — ${component.name}`;
   }
   return component.name;
 }

--- a/erun-ui/playwright/tests/manage-deploy-components.spec.ts
+++ b/erun-ui/playwright/tests/manage-deploy-components.spec.ts
@@ -29,6 +29,15 @@ test.describe('manage dialog — components to deploy (#718)', () => {
     await expect(runtime).toBeChecked();
     await expect(saveDefault).toBeDisabled();
 
+    // The headless baseline vendors no local runtime chart, so the item is the
+    // published erun-devops chart. Its label must name that real chart and show
+    // <tenant>-devops only as the release name — not present the release name as
+    // a published chart (#721). This keeps the checklist consistent with the
+    // erun-devops versions the "Version to deploy" picker offers.
+    await expect(runtime).toHaveAccessibleName(
+      `Runtime — published erun-devops chart (released as ${runtimeName})`,
+    );
+
     // Unchecking is a real change → "Set as default" becomes actionable.
     await runtime.click();
     await expect(runtime).not.toBeChecked();


### PR DESCRIPTION
## Problem

In the desktop **Manage → Runtime → Components to deploy** checklist, an environment with no repo-local runtime chart rendered its runtime item as:

> Runtime — **frs-devops** (published)

That reads as *"a published `frs-devops` chart exists"* — it does not. `frs-devops` is only the Helm **release name** (`RuntimeReleaseName(tenant)`, `erun-common/open.go:634`). The chart actually pulled and installed is the canonical **`erun-devops`** chart: `oci://<registry>/charts/erun-devops`, hardcoded via `DevopsComponentName` in `resolvePublishedDevopsDeploySpec` (`erun-common/published_devops_chart.go:19,75`). That is also why the "Version to deploy" picker lists `ghcr.io/sophium/erun-devops` versions — the published-runtime item *is* the `erun-devops` chart. The label conflated the release name with the chart source, so the screen contradicted itself.

## Fix

Frontend copy fix in `deployComponentLabel` (`erun-ui/frontend/src/app/deployComponentsSelection.ts`): for the `published-chart` runtime case, name the real chart (`erun-devops`) and show the release name separately — `Runtime — published erun-devops chart (released as <tenant>-devops)` (or just `Runtime — published erun-devops chart` when the tenant is the canonical one). The `local-chart` case is unchanged: there `component.name` is a real repo-local chart directory the operator manages.

Keying off `source` (which the backend already sets) keeps the label correct whether or not a per-tenant chart is ever vendored or published: a repo-local `<tenant>-devops` chart flips the item to `local-chart` on its own, and the published-chart path always maps to `erun-devops` regardless of tenant.

## Scope / boundaries

- **Behaviour-preserving**: label text only; no deploy or resolution change.
- **No CLI/MCP equivalent**: label rendering is desktop-only (`grep` confirms no `(published)` label in `erun-cli`/`erun-mcp`).
- **Docs-exempt**: no `erun-docs` page references this string, and behaviour is unchanged (pure copy correctness).

## UX Impact Review (erun-ui/AGENTS.md)

1. **Affected paths.** Manage dialog → Runtime tab → "Components to deploy" checklist label render (`deployComponentLabel`).
2. **User-visible sequence.** Opening Manage → Runtime shows the runtime checklist item; its label now names the `erun-devops` chart and the release name instead of implying a published `<tenant>-devops` chart.
3. **State-without-affordance.** None — no state mutated; a rendered label is corrected.
4/5. **Visibility / feedback.** Improves *match with the real system* (Nielsen #2, #4): the checklist item now agrees with the `erun-devops` versions the picker offers, removing a self-contradiction.
6. **Consistency.** The label now matches the chart identity used across the version picker and `resolvePublishedDevopsDeploySpec`.
7. **Heuristic pass.** Recognition over recall + match with system state: names the artifact actually installed. **Accessibility:** the corrected text is the checkbox's accessible name (`<Label htmlFor>` association), asserted via `toHaveAccessibleName`.
8. **Playwright coverage.** `erun-ui/playwright/tests/manage-deploy-components.spec.ts` extended to assert the runtime item's accessible name equals `Runtime — published erun-devops chart (released as <tenant>-devops)`.

## Validation

- `yarn typecheck && yarn lint && yarn format:check && yarn build` (erun-ui/frontend) — clean.
- `./playwright/run.sh --build` — rebuilt the headless binary (production tag embeds the frontend) and ran the suite: **104 passed**, including the corrected-label assertion verified against the real headless app.

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)