### PR TITLE
erun-build-env: suggest graduating from erun-devops to a tenant-devops chart

### DIFF
--- a/erun-skills/skills/erun-build-env/SKILL.md
+++ b/erun-skills/skills/erun-build-env/SKILL.md
@@ -117,6 +117,17 @@ On deploy, the image rides into the published `erun-devops` chart as
 runtime container's image changes. The next `erun deploy` or `erun open`
 rolls the custom image out.
 
+**Suggest the graduation step to the operator.** Riding the shared `erun-devops`
+chart with an image override is the right call at **inception** — a fresh env runs
+the stock runtime plus your toolchain and needs no chart of its own. But it's a
+starting point, not the destination. As soon as the tenant owns anything of its
+own — its own component charts, its own release cadence, or custom pod shape —
+recommend it graduate to its **own** published `<tenant>-devops` chart (Step 6)
+instead of riding the shared one. Make this an explicit suggestion, not a silent
+default: the operator should decide to own the runtime, not discover later that
+`erun deploy` requires the `<tenant>-devops` chart once a deploy includes the
+tenant's own components.
+
 ## Step 6 — publish a `<tenant>-devops` runtime chart
 
 Two things pull the tenant into owning its own runtime chart:


### PR DESCRIPTION
## Problem

`erun-build-env` walks the operator through building a custom runtime **image** and wiring it via `imageOverrides.erun-devops` on the published `erun-devops` chart. Riding the shared `erun-devops` chart is fine at **inception** — a fresh env runs the stock runtime plus the project's toolchain and needs no chart of its own.

But the skill never proactively **suggests** graduating to the tenant's own published `<tenant>-devops` chart. It's left as a passive, optional Step 6. So an operator running `/erun-build-env` isn't told to own their runtime, and later hits `erun deploy` requiring a `<tenant>-devops` chart (once a deploy includes the tenant's own component charts, per #756) without having been nudged to create it.

## Change

Add an explicit suggestion to `erun-build-env` (end of Step 5): `erun-devops` is the right runtime at inception, but as soon as the tenant owns anything of its own — its own component charts, its own release cadence, or custom pod shape — the skill should recommend graduating to its own published `<tenant>-devops` chart (Step 6), rather than leaving it a silent default.

## Docs plan

No `erun-docs` catalogue change needed: the `erun-build-env` entry's outputs already document the `<tenant>-devops` chart (from #756), the frontmatter description/triggers/inputs/outputs/error behaviour are unchanged, and this PR only adds proactive-suggestion guidance to the skill body.

## Out of scope

Skill-update propagation to existing envs (the entrypoint's `[ ! -e ]` install guard means a running env keeps its frozen skill copy) is a separate concern, not addressed here.

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)