### PR TITLE
Bind PowerDNS to the node hostIP instead of 0.0.0.0

### DIFF
--- a/erun-devops/k8s/erun-powerdns/templates/powerdns.yaml
+++ b/erun-devops/k8s/erun-powerdns/templates/powerdns.yaml
@@ -61,11 +61,14 @@
 {{- /* pdns listen address. Under hostNetwork a 0.0.0.0:53 bind collides with
        systemd-resolved's 127.0.0.53:53 stub on nodes that run it, and the public
        authoritative IP is typically a NAT'd address that is not a local
-       interface (so it can't be bound directly). Set powerdns.localAddress to
-       the node's own interface IP (the one the public IP NATs to) to bind a
-       specific local address and coexist with the node resolver. Defaults to
-       0.0.0.0 for nodes where :53 is already free. */ -}}
-{{- $localAddress := default "0.0.0.0" $powerdns.localAddress -}}
+       interface (so it can't be bound directly). So bind the node's own
+       interface IP: it coexists with the node resolver's loopback stub and still
+       receives traffic DNAT'd from the public authoritative IP. Default to the
+       node's hostIP (injected into config-gen via the downward API as HOST_IP),
+       which is the interface the public IP NATs to; an explicit
+       powerdns.localAddress overrides it — e.g. 0.0.0.0 on a node where :53 is
+       free, or a specific address on a multi-homed node. */ -}}
+{{- $localAddress := default "" $powerdns.localAddress -}}
 {{- $configDir := "/etc/pdns-shared" -}}
 apiVersion: v1
 kind: Secret
@@ -116,6 +119,12 @@ spec:
                 secretKeyRef:
                   name: {{ $apiKeySecretName }}
                   key: {{ $apiKeySecretKey }}
+            # The node's own interface IP, so local-address can bind it instead
+            # of 0.0.0.0 and coexist with a systemd-resolved loopback stub.
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
           command:
             - sh
             - -c
@@ -129,7 +138,7 @@ spec:
               gpgsql-dbname={{ $powerdnsDatabase }}
               gpgsql-user={{ $postgresUser }}
               gpgsql-password=$PDNS_GPGSQL_PASSWORD
-              local-address={{ $localAddress }}
+              local-address={{ $localAddress | default "$HOST_IP" }}
               local-port=53
               api=yes
               api-key=$PDNS_API_KEY


### PR DESCRIPTION
## Problem

`erun-powerdns` crashloops on nodes running `systemd-resolved`:

```
Unable to bind UDP socket to '0.0.0.0:53': Address already in use
Fatal error: Unable to bind to UDP socket
```

Observed live on `frs-prod` (`frs-powerdns` CrashLoopBackOff, 12+ restarts). The init containers all succeed and the `services.erunpaas.com` zone is bootstrapped with its NS records; only `pdns_server` fails to start.

## Root cause

The pod runs `hostNetwork: true` and the chart hard-defaulted `local-address=0.0.0.0`. On a node running `systemd-resolved`, the stub resolver already holds `127.0.0.53:53` (and `127.0.0.54:53`). `0.0.0.0:53` is a superset that includes those loopback addresses, so the UDP bind fails with `EADDRINUSE`.

The chart already documented this and told operators to set `powerdns.localAddress` to the node's own interface IP by hand — but nothing made it automatic, so **every** systemd-resolved node crashloops out of the box. The configured `authoritativeIP` (`212.93.120.230`) is a NAT'd public address that is not a local interface, so it can't be bound directly either.

## Fix

Default `local-address` to the node's own interface IP via the downward API (`status.hostIP`) — precisely "the node's own interface IP (the one the public IP NATs to)" the comment already told operators to set. It coexists with the resolver's loopback stub and still receives traffic DNAT'd from the public authoritative IP. `powerdns.localAddress` still overrides it (e.g. `0.0.0.0` where `:53` is free, or a specific address on a multi-homed node).

- Inject `HOST_IP` from `status.hostIP` into the `config-gen` init container.
- `local-address={{ $localAddress | default "$HOST_IP" }}` renders `$HOST_IP` (shell-expanded in the config heredoc) by default, or the literal override when set.

## Verification

- `helm template` — default renders `local-address=$HOST_IP` + the `status.hostIP` downward env; explicit `powerdns.localAddress` renders the literal address. `helm lint` clean.
- **Live on `frs-prod`** (rolled in via the equivalent narrower path while the full chart republish path is unblocked): pod goes `1/1 Running`, logs show `UDP server bound to 10.10.10.202:53` / `TCP server bound to 10.10.10.202:53` / `ready to distribute questions`, and an over-the-wire query to `10.10.10.202:53` returns the authoritative `services.erunpaas.com` NS (`ns1`/`ns2.erunpaas.com`) and SOA.

Not verified (out of scope): external resolution through the public `212.93.120.230` (depends on NAT + parent-zone delegation, tracked separately).

## Docs

Exempt — internal platform-singleton bug fix; no operator-facing command, flag, or contract change (`powerdns.localAddress` override is unchanged in meaning).

## Tests

Integration suite not triggered — chart-template-only change; touches no `erun-cli`/`erun-common`/entrypoint/deploy-plumbing code and no integration golden (the only golden mentioning `erun-powerdns` references the component name, not rendered template content).

Closes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)
