### PR TITLE
Fix the deploy version picker for tenant runtime envs

### DIFF
--- a/erun-common/deploy_components.go
+++ b/erun-common/deploy_components.go
@@ -229,9 +229,31 @@ type DeployableComponent struct {
 	// default selection (saved deploy.components, else the repo plan, else —
 	// when both are empty — the runtime alone).
 	Selected bool `json:"selected"`
+	// PublishedChart is the chart repo a by-reference deploy actually installs for
+	// this item at the chosen version. For the runtime it is the tenant's own
+	// <tenant>-devops chart when that is published at the version, else the
+	// canonical erun-devops fallback — so the picker can name the chart the deploy
+	// will install rather than assuming the fallback. Empty until a version-aware
+	// transport resolves it (see ResolvedRuntimeChartName); non-runtime items are
+	// their own chart (Name).
+	PublishedChart string `json:"publishedChart,omitempty"`
 }
 
 const deployComponentSourcePublished = "published-chart"
+
+// ResolvedRuntimeChartName returns the published chart a by-reference runtime
+// deploy installs: the tenant's own <tenant>-devops chart when it is published at
+// the deploy version (tenantChartPublished), else the canonical erun-devops. The
+// erun product tenant's runtime release name IS erun-devops, so it always resolves
+// there. This is the single source of truth shared by the deploy path
+// (resolvePublishedRuntimeChartReference) and the desktop picker label.
+func ResolvedRuntimeChartName(tenant string, tenantChartPublished bool) string {
+	chart := RuntimeReleaseName(tenant)
+	if chart != DevopsComponentName && tenantChartPublished {
+		return chart
+	}
+	return DevopsComponentName
+}
 
 // ResolveDeployableComponents lists the published component charts a deploy of a
 // chosen version can roll out — the canonical platform components plus the runtime,

--- a/erun-common/deploy_components_test.go
+++ b/erun-common/deploy_components_test.go
@@ -1,0 +1,24 @@
+package eruncommon
+
+import "testing"
+
+func TestResolvedRuntimeChartName(t *testing.T) {
+	cases := []struct {
+		name            string
+		tenant          string
+		tenantPublished bool
+		want            string
+	}{
+		{"tenant chart published", "frs", true, "frs-devops"},
+		{"tenant chart not published falls back", "frs", false, "erun-devops"},
+		{"erun product tenant always canonical", "", true, "erun-devops"},
+		{"erun product tenant, unpublished flag ignored", "", false, "erun-devops"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolvedRuntimeChartName(tc.tenant, tc.tenantPublished); got != tc.want {
+				t.Fatalf("ResolvedRuntimeChartName(%q, %v) = %q, want %q", tc.tenant, tc.tenantPublished, got, tc.want)
+			}
+		})
+	}
+}

--- a/erun-common/published_devops_chart.go
+++ b/erun-common/published_devops_chart.go
@@ -16,10 +16,6 @@ func PublishedDevopsChartOCIRepo(containerRegistry string) string {
 	return "oci://" + strings.TrimSpace(containerRegistry) + "/charts"
 }
 
-func publishedDevopsChartReference(containerRegistry string) string {
-	return PublishedDevopsChartOCIRepo(containerRegistry) + "/" + DevopsComponentName
-}
-
 // resolvePublishedRuntimeChartReference prefers the tenant's own published
 // <tenant>-devops chart (typically a thin umbrella wrapping erun-devops, per the
 // erun-build-env skill) and falls back to the canonical charts/erun-devops when
@@ -34,10 +30,10 @@ func publishedDevopsChartReference(containerRegistry string) string {
 // the chart is a wrapped umbrella that needs subchart re-scoping.
 func resolvePublishedRuntimeChartReference(ctx context.Context, containerRegistry, tenant, version string) (reference, chartName string) {
 	tenantChart := RuntimeReleaseName(tenant)
-	if tenantChart != DevopsComponentName && publishedChartHasVersion(ctx, containerRegistry, tenantChart, version) {
-		return PublishedDevopsChartOCIRepo(containerRegistry) + "/" + tenantChart, tenantChart
-	}
-	return publishedDevopsChartReference(containerRegistry), DevopsComponentName
+	tenantChartPublished := tenantChart != DevopsComponentName &&
+		publishedChartHasVersion(ctx, containerRegistry, tenantChart, version)
+	chartName = ResolvedRuntimeChartName(tenant, tenantChartPublished)
+	return PublishedDevopsChartOCIRepo(containerRegistry) + "/" + chartName, chartName
 }
 
 // publishedUmbrellaSubchartKey returns the value-scope key of the canonical

--- a/erun-common/registry_auth.go
+++ b/erun-common/registry_auth.go
@@ -38,21 +38,48 @@ type dockerAuthEntry struct {
 
 // resolveGHCRBasicAuth resolves a pull credential for ghcr.io, preferring the
 // credential docker itself pulls with (so "if docker can pull it, the picker
-// lists it") and falling back to a gh-issued token. owner scopes the gh token
-// to the account that owns the namespace.
+// lists it"), then a gh-issued token, then an explicit GH_TOKEN/GITHUB_TOKEN.
+// The env-var path is last but load-bearing: it needs no credential-helper or gh
+// subprocess, so it stays reachable when a desktop app's subprocess or keychain
+// access is intermittently blocked (endpoint security, a locked keychain) — the
+// failure that otherwise strands the picker on anonymous access. owner scopes the
+// credential to the account that owns the namespace.
 func resolveGHCRBasicAuth(owner string) (registryBasicAuth, bool) {
 	if auth, ok := resolveRegistryBasicAuth("ghcr.io"); ok {
 		return auth, true
 	}
-	token, ok := resolveGHCRTokenViaGH(owner)
-	if !ok {
-		return registryBasicAuth{}, false
+	if token, ok := resolveGHCRTokenViaGH(owner); ok {
+		return ghcrTokenBasicAuth(owner, token), true
 	}
+	if token, ok := ghcrTokenFromEnv(); ok {
+		return ghcrTokenBasicAuth(owner, token), true
+	}
+	return registryBasicAuth{}, false
+}
+
+// ghcrTokenEnvVars are the token env vars honored for ghcr.io, in gh's own
+// precedence order, so an operator's existing GitHub token authenticates the
+// picker with no keychain or subprocess dependency.
+var ghcrTokenEnvVars = []string{"GH_TOKEN", "GITHUB_TOKEN"}
+
+func ghcrTokenFromEnv() (string, bool) {
+	for _, name := range ghcrTokenEnvVars {
+		if token := strings.TrimSpace(os.Getenv(name)); token != "" {
+			return token, true
+		}
+	}
+	return "", false
+}
+
+// ghcrTokenBasicAuth pairs a bearer token with the namespace owner as the basic-
+// auth username; GHCR ignores the username on a token exchange but requires one,
+// so an empty owner uses the conventional token placeholder.
+func ghcrTokenBasicAuth(owner, token string) registryBasicAuth {
 	user := strings.TrimSpace(owner)
 	if user == "" {
 		user = "x-access-token"
 	}
-	return registryBasicAuth{username: user, secret: token}, true
+	return registryBasicAuth{username: user, secret: token}
 }
 
 // resolveRegistryBasicAuth looks up a host's credential the way docker does: a

--- a/erun-common/registry_auth_test.go
+++ b/erun-common/registry_auth_test.go
@@ -185,3 +185,53 @@ func TestResolveGHCRBasicAuthPrefersDockerOverGH(t *testing.T) {
 		t.Fatalf("got %+v ok=%v, want docker credential", auth, ok)
 	}
 }
+
+func TestResolveGHCRBasicAuthFallsBackToEnvTokenWhenSubprocessAuthUnavailable(t *testing.T) {
+	useDockerConfigDir(t, t.TempDir()) // no docker cred
+	useGHToken(t, func(string) (string, bool) { return "", false })
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "envtok")
+
+	auth, ok := resolveGHCRBasicAuth("sophium")
+	if !ok || auth.username != "sophium" || auth.secret != "envtok" {
+		t.Fatalf("got %+v ok=%v, want sophium/envtok", auth, ok)
+	}
+}
+
+func TestResolveGHCRBasicAuthUsesGithubTokenWhenGhTokenEmpty(t *testing.T) {
+	useDockerConfigDir(t, t.TempDir())
+	useGHToken(t, func(string) (string, bool) { return "", false })
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "ghenv")
+
+	auth, ok := resolveGHCRBasicAuth("")
+	if !ok || auth.username != "x-access-token" || auth.secret != "ghenv" {
+		t.Fatalf("got %+v ok=%v, want x-access-token/ghenv", auth, ok)
+	}
+}
+
+func TestResolveGHCRBasicAuthPrefersDockerOverEnvToken(t *testing.T) {
+	dir := writeDockerConfig(t, fmt.Sprintf(`{"auths":{"ghcr.io":{"auth":%q}}}`, b64Auth("dockeruser:dockerpw")))
+	useDockerConfigDir(t, dir)
+	useGHToken(t, func(string) (string, bool) {
+		t.Fatal("gh fallback must not run when docker has a credential")
+		return "", false
+	})
+	t.Setenv("GH_TOKEN", "envtok")
+
+	auth, ok := resolveGHCRBasicAuth("sophium")
+	if !ok || auth.username != "dockeruser" {
+		t.Fatalf("got %+v ok=%v, want docker credential", auth, ok)
+	}
+}
+
+func TestResolveGHCRBasicAuthNoneAvailable(t *testing.T) {
+	useDockerConfigDir(t, t.TempDir())
+	useGHToken(t, func(string) (string, bool) { return "", false })
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	if _, ok := resolveGHCRBasicAuth("sophium"); ok {
+		t.Fatal("expected no credential when docker, gh, and env are all empty")
+	}
+}

--- a/erun-common/registry_versions.go
+++ b/erun-common/registry_versions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"slices"
@@ -27,6 +28,26 @@ func registryStatusError(kind, status string, code int) error {
 		return fmt.Errorf("%s failed: %s: %w", kind, status, ErrRegistryAuthRequired)
 	}
 	return fmt.Errorf("%s failed: %s", kind, status)
+}
+
+// isTransientRegistryError reports whether err is a momentary transport failure
+// (connection reset, DNS blip) worth retrying. A timeout is terminal: it means a
+// slow or hung registry, and retrying only multiplies the wait a blocking caller
+// (erun version) already paid. Auth failures, a cancelled context, and definitive
+// HTTP status responses are terminal too — a listing that reached the registry and
+// got an answer surfaces as an actionable notice rather than being retried.
+func isTransientRegistryError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrRegistryAuthRequired) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return !netErr.Timeout()
+	}
+	return false
 }
 
 type RuntimeRegistryVersions struct {
@@ -82,13 +103,67 @@ func ResolveDefaultRuntimeRegistryVersions(ctx context.Context) (RuntimeRegistry
 	return ResolveConfiguredRuntimeRegistryVersions(ctx, config.RuntimeRegistry)
 }
 
+// registryListMaxAttempts bounds retries of a transient transport failure;
+// registryListRetryBase is the linear backoff step (a var so tests can zero it).
+// A few fast attempts clear a momentary network blip without making a real outage
+// crawl — a persistent failure still surfaces as the picker's authenticate/unreachable
+// notice rather than silently degrading to the anonymous/upstream fallback.
+const registryListMaxAttempts = 3
+
+var registryListRetryBase = 200 * time.Millisecond
+
 func ResolveConfiguredRuntimeRegistryVersions(ctx context.Context, cfg RuntimeRegistryConfig) (RuntimeRegistryVersions, error) {
 	resolved := cfg.Resolved()
+	return resolveRegistryVersionsWithRetry(ctx, func() (RuntimeRegistryVersions, error) {
+		return resolveConfiguredRuntimeRegistryVersionsOnce(ctx, resolved)
+	})
+}
+
+func resolveConfiguredRuntimeRegistryVersionsOnce(ctx context.Context, resolved RuntimeRegistryConfig) (RuntimeRegistryVersions, error) {
 	client := &http.Client{Timeout: 5 * time.Second}
 	if owner, ok := ghcrOwnerFromNamespace(resolved.Namespace); ok {
 		return resolveGHCRRuntimeRegistryVersionsAt(ctx, client, owner, resolved.Repository, resolved.BaseURL, resolved.TokenURL)
 	}
 	return resolveDockerHubRuntimeRegistryVersionsAt(ctx, client, resolved.Namespace, resolved.Repository, resolved.BaseURL)
+}
+
+// resolveRegistryVersionsWithRetry re-runs resolve on a transient transport
+// failure with a short linear backoff, so a momentary network blip does not
+// immediately degrade to anonymous/upstream access. Auth failures, timeouts, and
+// any definitive HTTP status response return on the first try.
+func resolveRegistryVersionsWithRetry(ctx context.Context, resolve func() (RuntimeRegistryVersions, error)) (RuntimeRegistryVersions, error) {
+	var lastErr error
+	for attempt := 0; attempt < registryListMaxAttempts; attempt++ {
+		if attempt > 0 {
+			if err := sleepWithContext(ctx, registryListRetryBase*time.Duration(attempt)); err != nil {
+				return RuntimeRegistryVersions{}, err
+			}
+		}
+		versions, err := resolve()
+		if err == nil || !isTransientRegistryError(err) {
+			return versions, err
+		}
+		lastErr = err
+	}
+	return RuntimeRegistryVersions{}, lastErr
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	if ctx == nil {
+		<-timer.C
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // ResolveRuntimeImageRegistryVersions is a compatibility overload for callers that pass an explicit namespace/repository pair.

--- a/erun-common/registry_versions_test.go
+++ b/erun-common/registry_versions_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -84,5 +85,118 @@ func TestRegistryStatusErrorClassification(t *testing.T) {
 	}
 	if err := registryStatusError("x", "s", http.StatusInternalServerError); errors.Is(err, ErrRegistryAuthRequired) {
 		t.Fatal("500 must not classify as auth-required")
+	}
+	// A definitive HTTP status (even 5xx/429) is terminal for retry purposes: the
+	// registry answered, so a retry re-asks an already-answered question.
+	if isTransientRegistryError(registryStatusError("x", "s", http.StatusTooManyRequests)) {
+		t.Fatal("a 429 status response must not be retried")
+	}
+}
+
+func withZeroRegistryRetryBackoff(t *testing.T) {
+	t.Helper()
+	prev := registryListRetryBase
+	registryListRetryBase = 0
+	t.Cleanup(func() { registryListRetryBase = prev })
+}
+
+// fakeNetError models a transport-level failure; timeout distinguishes a slow/hung
+// registry (terminal) from a momentary blip (retryable).
+type fakeNetError struct{ timeout bool }
+
+func (fakeNetError) Error() string   { return "fake network error" }
+func (e fakeNetError) Timeout() bool { return e.timeout }
+func (fakeNetError) Temporary() bool { return true }
+
+func TestResolveRegistryVersionsRetriesTransportBlipThenSucceeds(t *testing.T) {
+	withZeroRegistryRetryBackoff(t)
+	calls := 0
+	got, err := resolveRegistryVersionsWithRetry(context.Background(), func() (RuntimeRegistryVersions, error) {
+		calls++
+		if calls < 2 {
+			return RuntimeRegistryVersions{}, fakeNetError{} // momentary transport blip
+		}
+		return RuntimeRegistryVersions{LatestStable: "1.0.18"}, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.LatestStable != "1.0.18" {
+		t.Fatalf("LatestStable = %q, want 1.0.18", got.LatestStable)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2 (one retry)", calls)
+	}
+}
+
+func TestResolveRegistryVersionsDoesNotRetryAuth(t *testing.T) {
+	withZeroRegistryRetryBackoff(t)
+	calls := 0
+	_, err := resolveRegistryVersionsWithRetry(context.Background(), func() (RuntimeRegistryVersions, error) {
+		calls++
+		return RuntimeRegistryVersions{}, fmt.Errorf("no: %w", ErrRegistryAuthRequired)
+	})
+	if !errors.Is(err, ErrRegistryAuthRequired) {
+		t.Fatalf("err = %v, want auth", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1 (auth must not retry)", calls)
+	}
+}
+
+func TestResolveRegistryVersionsDoesNotRetryTimeout(t *testing.T) {
+	withZeroRegistryRetryBackoff(t)
+	calls := 0
+	_, err := resolveRegistryVersionsWithRetry(context.Background(), func() (RuntimeRegistryVersions, error) {
+		calls++
+		return RuntimeRegistryVersions{}, fakeNetError{timeout: true}
+	})
+	if err == nil {
+		t.Fatal("expected the timeout error to surface")
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1 (a timeout must not be retried)", calls)
+	}
+}
+
+func TestResolveRegistryVersionsExhaustsTransportRetries(t *testing.T) {
+	withZeroRegistryRetryBackoff(t)
+	calls := 0
+	_, err := resolveRegistryVersionsWithRetry(context.Background(), func() (RuntimeRegistryVersions, error) {
+		calls++
+		return RuntimeRegistryVersions{}, fakeNetError{}
+	})
+	if !isTransientRegistryError(err) {
+		t.Fatalf("err = %v, want a transient transport error", err)
+	}
+	if calls != registryListMaxAttempts {
+		t.Fatalf("calls = %d, want %d attempts", calls, registryListMaxAttempts)
+	}
+}
+
+func TestIsTransientRegistryError(t *testing.T) {
+	if isTransientRegistryError(nil) {
+		t.Error("nil is not transient")
+	}
+	if isTransientRegistryError(context.Canceled) {
+		t.Error("context.Canceled is not transient")
+	}
+	if isTransientRegistryError(context.DeadlineExceeded) {
+		t.Error("a timeout is terminal, not transient")
+	}
+	if isTransientRegistryError(fmt.Errorf("%w", ErrRegistryAuthRequired)) {
+		t.Error("auth is not transient")
+	}
+	if !isTransientRegistryError(fakeNetError{}) {
+		t.Error("a fast transport error is transient")
+	}
+	if isTransientRegistryError(fakeNetError{timeout: true}) {
+		t.Error("a transport timeout is terminal")
+	}
+	if !isTransientRegistryError(&url.Error{Op: "Get", URL: "https://ghcr.io", Err: fakeNetError{}}) {
+		t.Error("a transport url.Error is transient")
+	}
+	if isTransientRegistryError(errors.New("json decode failed")) {
+		t.Error("a non-network error is terminal")
 	}
 }

--- a/erun-docs/docs/deployment/registries.md
+++ b/erun-docs/docs/deployment/registries.md
@@ -60,7 +60,7 @@ The copy is manifest-aware, so the runtime image's `linux/amd64` + `linux/arm64`
 
 When the desktop offers versions to deploy or upgrade, it asks only the environment's listed registries — not a global default — and labels each offered version with the registry it came from. If two registries publish different newer versions, the deploy picker and the Upgrade-all dialog let you pick which one; `erun upgrade` on the command line skips such an environment as ambiguous until you pass `--version`. See [`erun upgrade`](/cli/upgrade).
 
-Version discovery uses the same local registry credentials as build and deploy (see [Authentication](#authentication)), so a **private** runtime image's versions appear only once you are logged in to its registry. When the desktop cannot list an image — a private one you have not authenticated to, or an unreachable registry — it shows a notice under the version picker naming the image and how to sign in, instead of silently offering nothing.
+Version discovery uses the same local registry credentials as build and deploy (see [Authentication](#authentication)), so a **private** runtime image's versions appear only once you are logged in to its registry. A momentary registry hiccup is retried a few times first, so a transient blip doesn't strand a tenant environment on the upstream fallback. Only when the desktop still cannot list an image — a private one you have not authenticated to, or an unreachable registry — does it show a notice under the version picker naming the image and how to sign in, instead of silently offering nothing.
 
 ## Multi-architecture builds
 
@@ -68,7 +68,7 @@ Every `erun build`, `erun build --release`, and `erun deploy` produces both `lin
 
 ## Authentication
 
-- **ghcr.io** — `gh auth login` (and a `write:packages` token scope) covers it.
+- **ghcr.io** — `gh auth login` (and a `write:packages` token scope) covers it. On a machine where keychain or subprocess access is restricted, set `GH_TOKEN` (or `GITHUB_TOKEN`) instead — the desktop reads it directly, with no keychain or `gh` dependency.
 - **AWS ECR** — the cluster's IRSA role grants the runtime pod permission to push; for local `docker push` you use a profile via `aws ecr get-login-password`.
 - **Other registries** — `docker login` once; credentials are persisted at `~/.docker/config.json`.
 

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -2194,6 +2194,58 @@ func TestLoadDeployComponentsVersionAwareFiltersUnavailableCharts(t *testing.T) 
 	}
 }
 
+// TestLoadDeployComponentsRuntimeChartReflectsTenantChart asserts the runtime row
+// reports the chart a by-reference deploy actually installs: the tenant's own
+// <tenant>-devops chart when it is published at the version, else the canonical
+// erun-devops fallback. The picker labels the row from PublishedChart, so it must
+// match what resolvePublishedRuntimeChartReference installs.
+func TestLoadDeployComponentsRuntimeChartReflectsTenantChart(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		config:  &eruncommon.ERunConfig{},
+		tenants: map[string]eruncommon.TenantConfig{"frs": {Name: "frs"}},
+		envs: map[string]eruncommon.EnvConfig{
+			"frs/prod": {
+				Name:              "prod",
+				LocalRepoPath:     projectRoot,
+				KubernetesContext: "test-context",
+				RuntimeVersion:    "1.0.20",
+				Type:              eruncommon.EnvironmentTypeRuntime,
+			},
+		},
+	}
+	runtimePublishedChart := func(t *testing.T, tags map[string][]string) string {
+		t.Helper()
+		app := NewApp(erunUIDeps{
+			store: store,
+			resolveImageRegistry: func(_ context.Context, _, repository string) (eruncommon.RuntimeRegistryVersions, error) {
+				return eruncommon.RuntimeRegistryVersions{Tags: tags[repository]}, nil
+			},
+		})
+		components, err := app.LoadDeployComponents(uiSelection{Tenant: "frs", Environment: "prod", Version: "1.0.20"})
+		if err != nil {
+			t.Fatalf("LoadDeployComponents failed: %v", err)
+		}
+		for _, component := range components {
+			if component.Runtime {
+				return component.PublishedChart
+			}
+		}
+		t.Fatal("no runtime component returned")
+		return ""
+	}
+
+	// The tenant publishes its own frs-devops chart at the version → the runtime
+	// installs (and the picker names) frs-devops, not the canonical fallback.
+	if got := runtimePublishedChart(t, map[string][]string{"charts/frs-devops": {"1.0.20"}}); got != "frs-devops" {
+		t.Fatalf("runtime PublishedChart with tenant chart published = %q, want frs-devops", got)
+	}
+	// No tenant runtime chart at the version → the deploy falls back to erun-devops.
+	if got := runtimePublishedChart(t, map[string][]string{}); got != "erun-devops" {
+		t.Fatalf("runtime PublishedChart with no tenant chart = %q, want erun-devops (fallback)", got)
+	}
+}
+
 func assertLoadedEnvironmentConfig(t *testing.T, loaded uiEnvironmentConfig, projectRoot string) {
 	t.Helper()
 

--- a/erun-ui/deploy_components.go
+++ b/erun-ui/deploy_components.go
@@ -60,17 +60,30 @@ func (a *App) filterDeployComponentsByChartAvailability(tenant, environment, ver
 		return components
 	}
 
-	probe := make([]string, 0, len(components))
+	runtimeChart := eruncommon.RuntimeReleaseName(tenant)
+	probe := make([]string, 0, len(components)+1)
 	for _, component := range components {
 		if !component.Runtime {
 			probe = append(probe, component.Name)
 		}
 	}
+	// Probe the tenant's own runtime chart too so the runtime row can name the
+	// chart the deploy will actually install — the tenant's <tenant>-devops when
+	// it is published at this version, else the canonical erun-devops fallback.
+	if runtimeChart != eruncommon.DevopsComponentName {
+		probe = append(probe, runtimeChart)
+	}
 	available := a.publishedComponentChartAvailability(tenant, environment, version, probe)
+	resolvedRuntimeChart := eruncommon.ResolvedRuntimeChartName(tenant, available[runtimeChart])
 
 	filtered := make([]eruncommon.DeployableComponent, 0, len(components))
 	for _, component := range components {
-		if component.Runtime || available[component.Name] {
+		if component.Runtime {
+			component.PublishedChart = resolvedRuntimeChart
+			filtered = append(filtered, component)
+			continue
+		}
+		if available[component.Name] {
 			filtered = append(filtered, component)
 		}
 	}

--- a/erun-ui/frontend/src/app/bootThunks.ts
+++ b/erun-ui/frontend/src/app/bootThunks.ts
@@ -49,9 +49,14 @@ export const boot = (): AppThunk<Promise<void>> => async (dispatch, getState) =>
   }
 };
 
-// This is a delta refresh, not the authoritative initial load (boot() is),
-// so it preserves existing cloudProviders / versionSuggestions when the new
-// payload omits them. It must not touch the env-init dialog's
+// This is a delta refresh of the sidebar/tenants, not the authoritative initial
+// load (boot() is), so it preserves existing cloudProviders when the new payload
+// omits them. It deliberately does NOT touch version suggestions: those are
+// resolved per-env by whichever dialog is open (each owns/refreshes its own), and
+// getInitialState always recomputes them for the sidebar-selected env — so writing
+// them here clobbered an open picker with the wrong env's versions on every
+// environment-change tick (e.g. leaving only the upstream fallback while a tenant
+// build fired deltas). It must also not touch the env-init dialog's
 // kubernetes-context list: a stale environments-changed tick used to wipe a
 // populated dropdown.
 export const reloadStateAfterEnvironmentChange =
@@ -68,18 +73,6 @@ export const reloadStateAfterEnvironmentChange =
       const current = getState().tenants;
       dispatch(setTenants(loaded.tenants));
       dispatch(setCloudProviders(loaded.cloudProviders ?? current.cloudProviders));
-      dispatch(
-        setVersionSuggestions(
-          normalizeVersionSuggestions(loaded.versionSuggestions ?? current.versionSuggestions),
-        ),
-      );
-      dispatch(
-        setVersionSuggestionNotices(
-          normalizeVersionSuggestionNotices(
-            loaded.versionSuggestionNotices ?? current.versionSuggestionNotices,
-          ),
-        ),
-      );
     } catch (error) {
       // Env-change reloads are best-effort, but swallowing the failure
       // silently used to leave the sidebar stale after a successful

--- a/erun-ui/frontend/src/app/deployComponentsSelection.ts
+++ b/erun-ui/frontend/src/app/deployComponentsSelection.ts
@@ -10,6 +10,7 @@ export function normalizeDeployComponents(
     runtime: component.runtime,
     source: component.source,
     selected: component.selected,
+    publishedChart: component.publishedChart,
   }));
 }
 
@@ -57,18 +58,25 @@ const PUBLISHED_RUNTIME_CHART_NAME = 'erun-devops';
 
 // deployComponentLabel builds the user-facing label for a deploy row.
 //
-// For a published runtime, component.name is only the Helm release name
-// (<tenant>-devops), not a published chart, so the label names the real
-// erun-devops chart — otherwise it would imply a published <tenant>-devops
-// chart that does not exist. A local chart's name is a real repo-local chart
+// For a published runtime, publishedChart is the chart the deploy actually
+// installs: the tenant's own <tenant>-devops chart when it is published at the
+// chosen version (name it directly), else the canonical erun-devops fallback
+// (name it, noting the <tenant>-devops release name it installs under). The erun
+// tenant's chart IS erun-devops. A local chart's name is a real repo-local chart
 // directory, shown as-is.
 export function deployComponentLabel(component: UIDeployableComponent): string {
   if (component.runtime) {
     if (component.source === 'published-chart') {
-      if (component.name === PUBLISHED_RUNTIME_CHART_NAME) {
-        return `Runtime — published ${PUBLISHED_RUNTIME_CHART_NAME} chart`;
+      const chart = component.publishedChart?.trim() ?? PUBLISHED_RUNTIME_CHART_NAME;
+      // Falling back to the canonical chart under a different release name: the
+      // env's own <tenant>-devops chart is not published at this version.
+      if (
+        chart === PUBLISHED_RUNTIME_CHART_NAME &&
+        component.name !== PUBLISHED_RUNTIME_CHART_NAME
+      ) {
+        return `Runtime — published ${PUBLISHED_RUNTIME_CHART_NAME} chart (released as ${component.name})`;
       }
-      return `Runtime — published ${PUBLISHED_RUNTIME_CHART_NAME} chart (released as ${component.name})`;
+      return `Runtime — published ${chart} chart`;
     }
     return `Runtime — ${component.name}`;
   }

--- a/erun-ui/frontend/src/app/manageDialogThunks.ts
+++ b/erun-ui/frontend/src/app/manageDialogThunks.ts
@@ -21,7 +21,6 @@ import {
 } from './runtimeResources';
 import { patchManageDialog, setManageDialog } from './slices/manageDialogSlice';
 import { bumpManageDialogVersion } from './slices/requestCountersSlice';
-import { setVersionSuggestionNotices, setVersionSuggestions } from './slices/tenantsSlice';
 import { defaultEnvironmentConfig, defaultManageDialog, type ManageDialogState } from './state';
 import { rememberPastContainerRegistry } from './storage';
 import type { AppThunk } from './store';
@@ -54,6 +53,8 @@ export const openManageDialog =
         choicesOpen: false,
         error: '',
         pendingRedeploy: false,
+        versionSuggestions: [],
+        versionSuggestionNotices: [],
         deployComponents: [],
         deployComponentSelection: [],
         deployComponentsLoading: true,
@@ -412,8 +413,9 @@ const refreshManageVersionSuggestions =
     ) {
       return;
     }
-    dispatch(setVersionSuggestions(suggestions));
-    dispatch(setVersionSuggestionNotices(notices));
+    dispatch(
+      patchManageDialog({ versionSuggestions: suggestions, versionSuggestionNotices: notices }),
+    );
     // Only auto-select a default when explicitly asked. Never override a version
     // the operator picked or typed: the dialog opens at '', so any non-empty
     // version when this async fetch resolves is a fresh operator action, and an

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -14,6 +14,7 @@ import type {
   UITenantConfig,
   UITenantDashboard,
   UIVersionSuggestion,
+  UIVersionSuggestionNotice,
 } from '@/types';
 
 export const MIN_SIDEBAR_WIDTH = 248;
@@ -95,6 +96,12 @@ export interface ManageDialogState {
   choicesOpen: boolean;
   error: string;
   pendingRedeploy: boolean;
+  // Version suggestions are dialog-owned, not read from the shared tenants slice:
+  // that slice is (re)written by boot and every environment-change delta for the
+  // sidebar-selected env, which would clobber this dialog's env-specific picker
+  // (e.g. showing only the upstream fallback while a tenant build fires deltas).
+  versionSuggestions: UIVersionSuggestion[];
+  versionSuggestionNotices: UIVersionSuggestionNotice[];
   deployComponents: UIDeployableComponent[];
   deployComponentSelection: string[];
   deployComponentsLoading: boolean;
@@ -288,6 +295,8 @@ export const defaultManageDialog = (): ManageDialogState => ({
   choicesOpen: false,
   error: '',
   pendingRedeploy: false,
+  versionSuggestions: [],
+  versionSuggestionNotices: [],
   deployComponents: [],
   deployComponentSelection: [],
   deployComponentsLoading: false,

--- a/erun-ui/frontend/src/components/app/ManageDialogRuntimeTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogRuntimeTab.tsx
@@ -49,8 +49,11 @@ type ManageDialog = AppState['manageDialog'];
 export function RuntimeTab(): React.ReactElement {
   const dispatch = useAppDispatch();
   const dialog = useAppSelector((state) => state.manageDialog);
-  const versionSuggestions = useAppSelector((state) => state.tenants.versionSuggestions);
-  const versionNotices = useAppSelector((state) => state.tenants.versionSuggestionNotices);
+  // Dialog-owned (not the shared tenants slice): this dialog resolves versions for
+  // its own env; boot/env-change deltas rewrite the tenants slice for the selected
+  // env and must not clobber this picker.
+  const versionSuggestions = dialog.versionSuggestions;
+  const versionNotices = dialog.versionSuggestionNotices;
   return (
     <>
       <RuntimeDeployField

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -108,6 +108,11 @@ export interface UIDeployableComponent {
   // The env's current resolved default selection: saved deploy.components, else
   // the repo plan, else the runtime alone.
   selected: boolean;
+  // The chart a by-reference deploy installs for this item at the chosen version.
+  // For the runtime it is the tenant's own <tenant>-devops chart when published,
+  // else the canonical erun-devops fallback; empty until the version-aware backend
+  // resolves it.
+  publishedChart?: string;
 }
 
 export interface UIBuildDetails {

--- a/erun-ui/playwright/tests/manage-deploy-components.spec.ts
+++ b/erun-ui/playwright/tests/manage-deploy-components.spec.ts
@@ -293,4 +293,78 @@ test.describe('manage dialog — components to deploy (#718)', () => {
     await lastComponent.scrollIntoViewIfNeeded();
     await expect(lastComponent).toBeInViewport();
   });
+
+  // Stub the picker plus a single runtime deploy row whose publishedChart is fixed,
+  // so the runtime row's label reflects the chart the deploy actually installs.
+  async function stubRuntimeDeployRow(page: Page, publishedChart: string): Promise<void> {
+    await page.route('**/__erun_invoke', async (route, request) => {
+      const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+      if (body.method === 'LoadVersionSuggestions') {
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: { suggestions: [{ label: 'Latest stable', version: '1.0.20' }], notices: [] },
+          }),
+        });
+      }
+      if (body.method === 'LoadDeployComponents') {
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: [
+              {
+                name: 'pw-devops',
+                runtime: true,
+                source: 'published-chart',
+                selected: true,
+                publishedChart,
+              },
+            ],
+          }),
+        });
+      }
+      await route.continue();
+    });
+  }
+
+  test('runtime row names the tenant chart the deploy installs (#767)', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    // The tenant's own pw-devops chart is published at the version, so the runtime
+    // row names it — the label must reflect the chart the deploy installs, not the
+    // canonical erun-devops fallback it used to always claim.
+    await stubRuntimeDeployRow(page, 'pw-devops');
+    await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('Runtime');
+    await app.manageDialog.pickVersion('1.0.20');
+    await expect(
+      app.manageDialog
+        .versionPickerPopover()
+        .getByText('Runtime — published pw-devops chart', { exact: true }),
+    ).toBeVisible();
+  });
+
+  test('runtime row shows the erun-devops fallback when the tenant chart is unpublished (#767)', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    // No tenant chart at the version → the deploy falls back to the canonical
+    // erun-devops chart, installed under the pw-devops release name; the label says so.
+    await stubRuntimeDeployRow(page, 'erun-devops');
+    await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('Runtime');
+    await app.manageDialog.pickVersion('1.0.20');
+    await expect(
+      app.manageDialog
+        .versionPickerPopover()
+        .getByText('Runtime — published erun-devops chart (released as pw-devops)', {
+          exact: true,
+        }),
+    ).toBeVisible();
+  });
 });

--- a/erun-ui/playwright/tests/manage-version-picker.spec.ts
+++ b/erun-ui/playwright/tests/manage-version-picker.spec.ts
@@ -61,19 +61,16 @@ test.describe('manage dialog — version picker (#756)', () => {
     await expect(page.getByRole('option', { name: /1\.0\.0/ })).toBeVisible();
   });
 
-  test('a version picked during an in-flight suggestions fetch is not clobbered', async ({
+  test("reopening the picker resets to the env's own suggestions, not a prior open's (#767)", async ({
     app,
     page,
     seededEnv,
   }) => {
-    // Regression: the dialog opens at version '' and fires the ~1s suggestions
-    // fetch; the global suggestions list still holds the previous open's versions,
-    // so the operator can pick one before this open's fetch lands. Before the fix,
-    // that fetch's post-processing auto-reselected suggestions[0] — undefined for an
-    // unlistable registry — which reset the version to '' and collapsed the
-    // "Components to deploy" panel to its gated hint with no error. The fix never
-    // overrides an operator's pick.
-    const runtimeName = `${seededEnv.tenant}-devops`;
+    // Regression: version suggestions are dialog-owned and reset on open, so a
+    // reopen never shows a previous open's versions while its own fetch is in
+    // flight. That stale carryover in the shared store was what a build's
+    // environments-changed delta rewrote, clobbering the picker to the upstream
+    // fallback.
     let calls = 0;
     let releaseSecond: () => void = () => undefined;
     const secondHeld = new Promise<void>((resolve) => {
@@ -84,17 +81,15 @@ test.describe('manage dialog — version picker (#756)', () => {
       if (body.method === 'LoadVersionSuggestions') {
         calls += 1;
         if (calls === 1) {
-          // First open populates the global suggestions store with 1.0.0.
           return route.fulfill({
             contentType: 'application/json',
             body: JSON.stringify({
-              data: { suggestions: [{ label: 'Current', version: '1.0.0' }], notices: [] },
+              data: { suggestions: [{ label: 'Latest stable', version: '2.0.0' }], notices: [] },
             }),
           });
         }
-        // Second open: hold the fetch so the stale 1.0.0 can be picked while it is
-        // in flight, then resolve it with an empty list (an unlistable registry) —
-        // the exact case that reset the version before the fix.
+        // Second open: hold the fetch so the picker's pre-fetch state is
+        // observable — it must show none of the first open's 2.0.0.
         await secondHeld;
         return route.fulfill({
           contentType: 'application/json',
@@ -104,34 +99,33 @@ test.describe('manage dialog — version picker (#756)', () => {
       await route.continue();
     });
 
-    // First open resolves suggestions into the global store, then closes.
+    // First open resolves 2.0.0 into this dialog's own suggestions.
     await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
     await app.manageDialog.waitForOpen();
     await app.manageDialog.selectTab('Runtime');
     await app.manageDialog.openVersionPicker();
-    await expect(page.getByRole('option', { name: /1\.0\.0/ })).toBeVisible();
+    await expect(page.getByRole('option', { name: /2\.0\.0/ })).toBeVisible();
     await app.manageDialog.cancel();
     await app.manageDialog.waitForClosed();
 
-    // Second open: its suggestions fetch is held, so the picker shows the stale
-    // 1.0.0. Pick it and confirm the components panel populates.
+    // Reopen with the suggestions fetch held: the picker is open (heading shown)
+    // but shows none of the prior open's 2.0.0 — the dialog reset its own state.
     await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
     await app.manageDialog.waitForOpen();
     await app.manageDialog.selectTab('Runtime');
     await app.manageDialog.openVersionPicker();
-    await app.manageDialog.pickVersion('1.0.0');
-    await expect(app.manageDialog.deployComponentCheckbox(runtimeName)).toBeVisible();
+    await expect(page.getByRole('option', { name: /2\.0\.0/ })).toHaveCount(0);
 
-    // Release the held fetch, which returns an empty list; wait for it to apply
-    // (the stale 1.0.0 option drops out of the picker) — a real completion signal,
-    // not a wall-clock guess.
+    // Releasing the held (empty) fetch keeps it empty — still no stale 2.0.0.
+    const suggestionsDone = page.waitForResponse(
+      (resp) =>
+        resp.url().includes('__erun_invoke') &&
+        (JSON.parse(resp.request().postData() ?? '{}') as { method?: string }).method ===
+          'LoadVersionSuggestions',
+    );
     releaseSecond();
-    await expect(page.getByRole('option', { name: /1\.0\.0/ })).toHaveCount(0);
-
-    // The operator's pick survives: the panel stays populated and never re-gates.
-    await expect(app.manageDialog.deployComponentCheckbox(runtimeName)).toBeVisible();
-    await expect(app.manageDialog.deployComponentsHint()).toHaveCount(0);
-    await expect(app.manageDialog.runtimeVersionInput()).toHaveValue('1.0.0');
+    await suggestionsDone;
+    await expect(page.getByRole('option', { name: /2\.0\.0/ })).toHaveCount(0);
   });
 
   test('an environments-changed reload does not clobber the open picker (#767)', async ({

--- a/erun-ui/playwright/tests/manage-version-picker.spec.ts
+++ b/erun-ui/playwright/tests/manage-version-picker.spec.ts
@@ -133,4 +133,85 @@ test.describe('manage dialog — version picker (#756)', () => {
     await expect(app.manageDialog.deployComponentsHint()).toHaveCount(0);
     await expect(app.manageDialog.runtimeVersionInput()).toHaveValue('1.0.0');
   });
+
+  test('an environments-changed reload does not clobber the open picker (#767)', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    // Regression: version suggestions used to live in the shared tenants slice, which
+    // every environments-changed delta (fired constantly while a tenant builds)
+    // rewrote from LoadState's suggestions for the sidebar-selected env — clobbering
+    // an open picker down to the upstream fallback so a tenant env showed no tenant
+    // versions or charts. The dialog now owns its suggestions and the delta no longer
+    // touches them. Here the dialog resolves the tenant's pw-devops 1.0.16; the
+    // reload returns a distinct 9.9.9 that must NOT reach the picker.
+    await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+      const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+      if (body.method === 'LoadVersionSuggestions') {
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: {
+              suggestions: [
+                {
+                  label: 'Latest stable',
+                  version: '1.0.16',
+                  source: 'pw',
+                  image: 'ghcr.io/sophium/pw-devops',
+                },
+              ],
+              notices: [],
+            },
+          }),
+        });
+      }
+      if (body.method === 'LoadState') {
+        // The delta reload recomputes suggestions for the selected env; return a
+        // distinct value the pre-fix code would have pushed into the shared slice.
+        const original = await route.fetch();
+        const payload = (await original.json()) as {
+          data?: { versionSuggestions?: unknown; versionSuggestionNotices?: unknown };
+        };
+        if (payload.data) {
+          payload.data.versionSuggestions = [
+            {
+              label: 'Latest stable',
+              version: '9.9.9',
+              source: 'ERun',
+              image: 'ghcr.io/sophium/erun-devops',
+            },
+          ];
+          payload.data.versionSuggestionNotices = [];
+        }
+        return route.fulfill({ contentType: 'application/json', body: JSON.stringify(payload) });
+      }
+      await route.continue();
+    });
+
+    await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('Runtime');
+    await app.manageDialog.openVersionPicker();
+    await expect(page.getByRole('option', { name: /1\.0\.16/ })).toBeVisible();
+
+    // Fire the exact event a build/deploy fires, and wait for the reload it triggers
+    // to actually complete (a real signal, not a wall-clock guess) before asserting.
+    const reloadDone = page.waitForResponse(
+      (resp) =>
+        resp.url().includes('__erun_invoke') &&
+        (JSON.parse(resp.request().postData() ?? '{}') as { method?: string }).method ===
+          'LoadState',
+    );
+    await page.evaluate(() => {
+      (
+        window as unknown as { runtime: { EventsEmit: (name: string, ...a: unknown[]) => void } }
+      ).runtime.EventsEmit('environments-changed');
+    });
+    await reloadDone;
+
+    // The tenant version survives; the reload's 9.9.9 never reaches this picker.
+    await expect(page.getByRole('option', { name: /1\.0\.16/ })).toBeVisible();
+    await expect(page.getByRole('option', { name: /9\.9\.9/ })).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
Fixes three defects in the desktop deploy version picker for a tenant runtime env (e.g. `frs/prod`), surfaced while chasing "no frs charts / wrong chart offered". The backend was correct throughout — every defect was in what the picker *showed*.

## 1. Picker clobbered to the upstream fallback (the reported bug)

The picker read version suggestions from the **shared `tenants` slice**, which `boot` and every `environments-changed` delta rewrite from `LoadState`'s suggestions for the *sidebar-selected* env. While a tenant env builds, those deltas fire constantly, so an open `frs/prod` picker was repeatedly reset to only the public `erun-devops` versions (which never match frs's charts) — "no frs charts", reason buried.

**Fix (erun-ui):** the manage dialog now **owns its version suggestions in dialog state**, written only by its own env fetch and reset on open — immune to boot/delta writers and to a prior open's (or another env's) values. `reloadStateAfterEnvironmentChange` no longer writes version suggestions at all (a sidebar/tenants delta must not own per-env picker data; this also protects the create dialog).

## 2. Runtime row named the wrong chart

The runtime row always claimed the canonical `erun-devops` chart, even though a by-reference deploy of a tenant env installs the tenant's own `<tenant>-devops` chart when it's published (`resolvePublishedRuntimeChartReference` resolves it; `ensureTenantChartsPublished` requires it). `frs/prod` at `1.0.20` installs `charts/frs-devops`, but the row said "published erun-devops chart (released as frs-devops)".

**Fix:** `DeployableComponent` gains `PublishedChart`; a shared `ResolvedRuntimeChartName` rule (tenant chart when published at the version, else `erun-devops`) is used by **both** the deploy path and the picker. The version-aware component filter probes the tenant runtime chart and sets the row, so it names the chart the deploy will install (`frs-devops`), with the `erun-devops` fallback only when the tenant chart isn't published.

## 3. Registry-listing resilience (secondary hardening)

- **erun-common:** retry a momentary transport blip when listing versions; timeouts and HTTP status responses stay terminal so the blocking `erun version` never hangs.
- **erun-common:** honor `GH_TOKEN`/`GITHUB_TOKEN` as a last-resort, keychain-/subprocess-independent GHCR credential.

## Tests

- **Playwright** (`manage-version-picker`, `manage-deploy-components`): an `environments-changed` reload does not clobber the open picker; reopening resets to the env's own suggestions (no stale carryover); the runtime row names the tenant chart when published and the `erun-devops` fallback when not. Reworked the in-flight-suggestions spec for the dialog-owned model. 10/10 green.
- **erun-ui Go:** `LoadDeployComponents` sets the runtime `PublishedChart` (tenant chart vs fallback).
- **erun-common:** `ResolvedRuntimeChartName` rule; transport-blip retry (auth/timeout not retried); `resolveGHCRBasicAuth` env-var fallback + precedence.
- `make integration-test` green; `erun-common`/`erun-cli`/`erun-mcp`/`erun-ui` `go build`+`go test` green; `golangci-lint` clean; frontend `yarn typecheck`/`lint`/`format`/`build` green; `erun-docs` `yarn build` clean.
- **End-to-end:** drove the real React frontend (browser harness) against the real config — first open shows all `frs` versions, holds them across an `environments-changed` reload, and the runtime row names `frs-devops`. Confirmed via trace that a deploy installs `oci://…/charts/frs-devops` at 1.0.20.

## UX impact (erun-ui)

Manage dialog → Runtime version picker: reliably shows the env's own versions, unaffected by background reloads, and names the chart each row installs. No new affordance; corrected behaviour. Covered by the specs above.

## Docs

`erun-docs/docs/deployment/registries.md` — listing retry + `GH_TOKEN`/`GITHUB_TOKEN` note. `yarn build` clean.

Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)