### PR TITLE
Fix New environment dialog Create button silently doing nothing

### DIFF
--- a/erun-ui/frontend/src/app/environmentDialogState.ts
+++ b/erun-ui/frontend/src/app/environmentDialogState.ts
@@ -23,16 +23,30 @@ export function normalizedEnvironmentDialogValues(
   };
 }
 
-export function validEnvironmentDialogValues(values: NormalizedEnvironmentDialogValues): boolean {
+// missingRequiredFieldReason is the single source of truth for what the New
+// Environment dialog requires before it can be submitted: it returns a
+// user-facing reason for the first missing value, or null when the dialog is
+// submittable. Both the Create button's enabled state and submitEnvironmentDialog
+// derive from it, so the button can never look active while submit would fail —
+// the defect where an unselected Kubernetes context left an active-looking button
+// that silently did nothing on click, with no error shown.
+export function missingRequiredFieldReason(dialog: EnvironmentDialogState): string | null {
+  const values = normalizedEnvironmentDialogValues(dialog);
   if (!values.tenant || !values.environment) {
-    return false;
+    return 'Enter a tenant and environment name.';
   }
   // local-agent envs mount a host directory into the agent pod; the path
   // is required and free-text (the user picks where their project lives).
   if (values.envType === 'local-agent' && !values.localRepoPath) {
-    return false;
+    return 'Local repo path is required for local-agent envs.';
   }
-  return Boolean(values.kubernetesContext && values.containerRegistry);
+  if (!values.kubernetesContext) {
+    return 'Select a Kubernetes context.';
+  }
+  if (!values.containerRegistry) {
+    return 'Select a container registry.';
+  }
+  return null;
 }
 
 export function rememberEnvironmentDialogSelection(selection: UISelection): void {

--- a/erun-ui/frontend/src/app/environmentDialogThunks.ts
+++ b/erun-ui/frontend/src/app/environmentDialogThunks.ts
@@ -3,9 +3,9 @@ import type { UISelection, UIVersionSuggestion } from '@/types';
 import { environmentApi } from './api/environmentApi';
 import { refreshKubernetesContexts } from './dialogContextsThunks';
 import {
+  missingRequiredFieldReason,
   normalizedEnvironmentDialogValues,
   rememberEnvironmentDialogSelection,
-  validEnvironmentDialogValues,
 } from './environmentDialogState';
 import { readError } from './errors';
 import { showTerminalMessage } from './notificationThunks';
@@ -136,7 +136,11 @@ export const submitEnvironmentDialog =
     }
     const selection = environmentDialogSelection(dialog, state.tenants.versionSuggestions);
     if (!selection) {
-      dispatch(patchEnvironmentDialog({ error: '' }));
+      // The submit gate keeps the Create button disabled while a required field
+      // is missing, but Enter-key submits bypass the button — surface the reason
+      // as a visible error rather than only the native validity bubble, which the
+      // Wails WebView does not reliably render.
+      dispatch(patchEnvironmentDialog({ error: missingRequiredFieldReason(dialog) ?? '' }));
       form.reportValidity();
       return;
     }
@@ -170,10 +174,10 @@ function environmentDialogSelection(
   dialog: EnvironmentDialogState,
   versionSuggestions: UIVersionSuggestion[],
 ): UISelection | null {
-  const values = normalizedEnvironmentDialogValues(dialog);
-  if (!validEnvironmentDialogValues(values)) {
+  if (missingRequiredFieldReason(dialog)) {
     return null;
   }
+  const values = normalizedEnvironmentDialogValues(dialog);
   // noGit only affects the remote-worktree init path; local-agent has no
   // remote repo, so ignore any stale noGit left by a previous type selection.
   const noGit = dialog.envType === 'local-agent' ? false : dialog.noGit;

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -1,6 +1,7 @@
 import { FolderPlus, LoaderCircle } from 'lucide-react';
 import * as React from 'react';
 
+import { missingRequiredFieldReason } from '@/app/environmentDialogState';
 import {
   closeEnvironmentDialog,
   selectEnvironmentVersionSuggestion,
@@ -354,21 +355,17 @@ function environmentDialogSubmitGate(dialog: EnvironmentDialog): EnvironmentSubm
   if (dialog.busy) {
     return { disabled: true, reason: '' };
   }
+  // kubernetesContextBlocker (contexts loading / none discovered) is an
+  // environmental blocker and must win over missingRequiredFieldReason, which
+  // would otherwise say "Select a Kubernetes context" when there are none to
+  // select. missingRequiredFieldReason then covers the value requirements —
+  // including a context that is available but not yet selected — so the button's
+  // enabled state matches exactly what submitEnvironmentDialog will accept.
   const blocker =
-    localRepoPathBlocker(dialog) ??
     kubernetesContextBlocker(dialog) ??
+    missingRequiredFieldReason(dialog) ??
     runtimeCapacityBlocker(dialog);
   return blocker ? { disabled: true, reason: blocker } : { disabled: false, reason: '' };
-}
-
-function localRepoPathBlocker(dialog: EnvironmentDialog): string | null {
-  if (dialog.envType !== 'local-agent') {
-    return null;
-  }
-  if (dialog.localRepoPath.trim() === '') {
-    return 'Local repo path is required for local-agent envs.';
-  }
-  return null;
 }
 
 function kubernetesContextBlocker(dialog: EnvironmentDialog): string | null {

--- a/erun-ui/playwright/pages/EnvironmentInitDialog.ts
+++ b/erun-ui/playwright/pages/EnvironmentInitDialog.ts
@@ -28,6 +28,37 @@ export class EnvironmentInitDialog {
     return this.page.locator('#environment-version');
   }
 
+  containerRegistryInput(): Locator {
+    return this.page.locator('#environment-container-registry');
+  }
+
+  kubernetesContextTrigger(): Locator {
+    return this.page.locator('#environment-kubernetes-context');
+  }
+
+  // createButton matches the submit button in both its idle ("Create") and
+  // in-flight ("Creating...") copy so callers can assert its enabled state.
+  createButton(): Locator {
+    return this.locator().getByRole('button', { name: /^(Create|Creating)/ });
+  }
+
+  // submitReason is the live-region status line that explains why Create is
+  // blocked; it stays mounted (empty) when the dialog is submittable.
+  submitReason(): Locator {
+    return this.page.locator('#environment-dialog-submit-reason');
+  }
+
+  async fillContainerRegistry(value: string): Promise<void> {
+    await this.containerRegistryInput().fill(value);
+  }
+
+  // selectKubernetesContext opens the context dropdown and picks an option by
+  // its label (the context name).
+  async selectKubernetesContext(name: string): Promise<void> {
+    await this.kubernetesContextTrigger().click();
+    await this.page.getByRole('option', { name, exact: true }).click();
+  }
+
   async fillTenant(name: string): Promise<void> {
     await this.tenantInput().fill(name);
   }

--- a/erun-ui/playwright/tests/env-init.spec.ts
+++ b/erun-ui/playwright/tests/env-init.spec.ts
@@ -1,5 +1,40 @@
+import type { Page } from '@playwright/test';
+
 import { test, expect } from '../fixtures/erunApp.js';
 import { SEED_TENANT } from '../fixtures/seedRoot.js';
+
+// stubDialogCluster makes the env-init dialog behave as if a real cluster were
+// reachable: the kubectl stub in the isolated harness reports no contexts (the
+// deterministic empty state), so without this the context blocker masks every
+// other gate reason. One context lets the dialog auto-select it, and an
+// available resource status clears the capacity blocker, leaving the value
+// requirements (environment name, container registry) as the only blockers —
+// which is exactly what this spec exercises.
+async function stubDialogCluster(page: Page): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+    if (body.method === 'LoadKubernetesContexts') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: ['orbstack'] }),
+      });
+    }
+    if (body.method === 'LoadRuntimeResourceStatus') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            kubernetesContext: 'orbstack',
+            available: true,
+            cpu: { total: 8, used: 0, free: 8, unit: 'cores', formatted: '8' },
+            memory: { total: 16, used: 0, free: 16, unit: 'GiB', formatted: '16' },
+          },
+        }),
+      });
+    }
+    await route.continue();
+  });
+}
 
 test.describe('environment init dialog', () => {
   test('opens with tenant pre-populated and cancels', async ({ app }) => {
@@ -114,6 +149,60 @@ test.describe('environment init dialog', () => {
 
     await expect(emptyState).toBeVisible();
     await expect(select).toBeHidden();
+
+    await app.envInitDialog.cancel();
+    await app.envInitDialog.waitForClosed();
+  });
+
+  test('keeps Create disabled with a visible reason until every required value is provided', async ({
+    app,
+    page,
+  }) => {
+    // Regression (the reported bug): the submit gate only checked that the
+    // Kubernetes-context *list* was non-empty — never that a context was actually
+    // selected or a container registry chosen. A context can be available yet
+    // unselected (the reported state), so the button looked active, but clicking
+    // hit the invalid-selection branch whose only feedback was a native validity
+    // bubble the Wails WebView does not render — Create silently did nothing. The
+    // gate now derives from the same required-field rules submit enforces and
+    // surfaces the first missing value, walking the fields as the user fills them.
+    await stubDialogCluster(page);
+    await app.sidebar.openInitDialog();
+    await app.envInitDialog.waitForOpen();
+
+    const createButton = app.envInitDialog.createButton();
+    const reason = app.envInitDialog.submitReason();
+
+    // The stub populates one context but the dialog does not preselect it — the
+    // trigger sits on its placeholder, reproducing the reported state.
+    await expect(app.envInitDialog.locator().getByText('No Kubernetes contexts found')).toHaveCount(
+      0,
+    );
+    await expect(app.envInitDialog.kubernetesContextTrigger()).toContainText(
+      'Select Kubernetes context',
+    );
+
+    // Empty environment name is the first blocker; Create is disabled and says why.
+    await expect(createButton).toBeDisabled();
+    await expect(reason).toHaveText('Enter a tenant and environment name.');
+
+    // Name provided, context still unselected: the button stays disabled and now
+    // names the missing selection instead of silently doing nothing on click.
+    await app.envInitDialog.fillEnvironment('review');
+    await expect(createButton).toBeDisabled();
+    await expect(reason).toHaveText('Select a Kubernetes context.');
+
+    // Selecting the context advances to the container registry — the required
+    // field the old gate never checked, which is what left Create wrongly active.
+    await app.envInitDialog.selectKubernetesContext('orbstack');
+    await expect(createButton).toBeDisabled();
+    await expect(reason).toHaveText('Select a container registry.');
+
+    // Providing the registry clears the last value blocker, so Create activates
+    // and the reason line goes quiet.
+    await app.envInitDialog.fillContainerRegistry('ghcr.io/sophium');
+    await expect(createButton).toBeEnabled();
+    await expect(reason).toHaveText('');
 
     await app.envInitDialog.cancel();
     await app.envInitDialog.waitForClosed();


### PR DESCRIPTION
## Problem

In the desktop **New environment** dialog, the **Create** button appears active but clicking does nothing — no environment is created and no validation error is shown. Reproduced with a Kubernetes context available but not selected (the dialog does not preselect one).

## Root cause

The button's enabled state and its submit validation disagreed:

- `validEnvironmentDialogValues` (submit path) required a **selected** Kubernetes context *and* a container registry.
- `environmentDialogSubmitGate` (button state) only blocked on an empty context **list** — never on an unselected context, and never checked the container registry.

So with a context available-but-unselected, the button looked active. Clicking fell into the `if (!selection)` branch whose only feedback was `form.reportValidity()` — a native HTML5 bubble the Wails WebView does not render. Active-looking button, no action, no error.

## Fix

Introduce `missingRequiredFieldReason(dialog)` as the single source of truth for the dialog's required-field rules; both the button gate and `submitEnvironmentDialog` derive from it, so they can never disagree.

- The gate now disables Create with a specific, visible reason (rendered in the existing `aria-live` status line): *"Select a Kubernetes context."*, *"Select a container registry."*, etc.
- The Enter-key submit path surfaces that reason as a visible error instead of relying only on the native bubble.
- Folds the previously duplicated `localRepoPathBlocker` into the shared reason function.

## UX impact review

- **Affected path:** New environment dialog → Create gate + `submitEnvironmentDialog`.
- **User-visible sequence:** dialog opens → Create disabled with a reason naming the first missing field → user fills each field → reason advances → all present → Create enables.
- **State-without-affordance:** every blocking state maps to the always-mounted `#environment-dialog-submit-reason` live region (`aria-live=polite`); no silent mutation.
- **Nielsen #1/#5:** visibility of status + error prevention (disable + explain, not a dead button); recognition over recall names the missing field.
- **Consistency (#4):** matches the existing blocker/reason pattern, folded into one source of truth.

## Validation

- `yarn typecheck && lint && format:check && build` clean.
- Rebuilt `bin/erun-app` and ran the full Playwright suite: **118 passed**, including a new `env-init.spec.ts` regression that reproduces the reported flow — context available-but-unselected → Create disabled + *"Select a Kubernetes context."* → select context → *"Select a container registry."* → fill registry → **Create enables**.
- Not verifiable headlessly: the Wails WebView's native-bubble rendering can't be driven without the real desktop window; the fix makes that path unreachable via the (now correctly disabled) button, and the harness locks the gate/reason behavior.

## Notes

Pure bug fix restoring the intended gate contract (the reason-line affordance already existed for other blockers); docs-exempt.

Separately observed: the dialog does not preselect a Kubernetes context even when one is available. This fix makes that state actionable rather than a dead button; auto-preselecting the sole/last-used context is a possible follow-up.

Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)