### PR TITLE
Migrate .erun/config.yaml to the containerregistries schema

### DIFF
--- a/.erun/config.yaml
+++ b/.erun/config.yaml
@@ -1,14 +1,19 @@
 environments:
     local:
-        containerregistry: ghcr.io/sophium
+        containerregistries:
+            - registry: ghcr.io/sophium
+              roles:
+                - build
+                - deploy
         docker:
             fingerprints:
-                erun-ubuntu: 6ffef71a59498123
-                erun-dind: 13446de55f7ffdc8
                 erun-backend-postgres: cb6d9b701f4ad75b
+                erun-dind: 13446de55f7ffdc8
                 erun-powerdns: 28aba123cf9f7c73
+                erun-ubuntu: 6ffef71a59498123
         k8s:
             deployments:
-                - [erun-devops, erun-backend-postgres]
+                - - erun-devops
+                  - erun-backend-postgres
                 - erun-backend-db
                 - erun-backend-api


### PR DESCRIPTION
Tool-driven normalization of the tracked local config:

- The single `containerregistry: ghcr.io/sophium` string becomes a `containerregistries` list carrying `build`/`deploy` roles — the current registry schema.
- The docker `fingerprints` and k8s `deployments` blocks are rewritten to the canonical serialization erun now emits (alphabetized fingerprints; block-sequence deployments).

No behaviour change — this only lands the schema migration erun already applies at runtime, so the tracked config stops re-diffing on every command that rewrites it.

Closes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)