### PR TITLE
Resolve project root from ERUN_REPO_PATH inside runtime pods

### DIFF
--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -813,7 +813,20 @@ func LoadProjectConfig(projectRoot string) (ProjectConfig, string, error) {
 	return config, configFilePath, nil
 }
 
+// FindProjectRoot resolves the project root, preferring ERUN_REPO_PATH when it
+// is set and names an existing directory. A sourceless runtime pod surfaces the
+// image-baked release tree at that path (a symlink into /opt/erun/release, with
+// no .git), so the cwd .git walk would fail there; honoring the env var lets
+// in-pod commands like `erun terraform` resolve the tree the same way the MCP
+// server does. The var is set only inside the pod, so laptop behavior (walk up
+// from cwd to the nearest .git) is unchanged.
 func FindProjectRoot() (string, string, error) {
+	if root := strings.TrimSpace(os.Getenv("ERUN_REPO_PATH")); root != "" {
+		root = filepath.Clean(root)
+		if info, err := os.Stat(root); err == nil && info.IsDir() {
+			return filepath.Base(root), root, nil
+		}
+	}
 	dir, err := os.Getwd()
 	if err != nil {
 		return "", "", err

--- a/erun-docs/docs/cli/terraform.md
+++ b/erun-docs/docs/cli/terraform.md
@@ -42,6 +42,7 @@ When the env has a Cloudflare alias, its `CLOUDFLARE_API_TOKEN` is forwarded to 
 
 | Condition | What happens | Recover |
 |---|---|---|
+| Not in a project (no git repo found on the host) | Aborts: `cannot find git project`; exit 1. | Run from inside your project checkout. This doesn't occur inside a runtime pod, where erun resolves the project tree automatically even though it has no `.git`. |
 | No `terraform-<tenant>/<env>/` folder | Aborts: `no Terraform root at … — scaffold it with the erun-blueprint-platform skill …`; exit 1. | Scaffold the per-env root with [`erun-blueprint-platform`](/agent-reference/skills-spec#erun-blueprint-platform), or create `terraform-<tenant>/<env>/` with its `main.tf` and `<env>.tfvars`. |
 | Environment not configured | Surfaces the config load error; exit 1. | Create the env (`erun init`) or fix the tenant/env name. |
 | No default tenant/environment and none passed | Aborts: default tenant/environment not configured; exit 1. | Pass `TENANT ENVIRONMENT` (or set a default scope). |

--- a/erun-docs/docs/reference/env-vars.md
+++ b/erun-docs/docs/reference/env-vars.md
@@ -10,7 +10,7 @@ ERun reads a small number of `ERUN_*` variables, mostly when running inside a ru
 
 | Variable | Type | Default | Purpose | Source |
 |---|---|---|---|---|
-| `ERUN_REPO_PATH` | absolute path | `/home/erun/git/<repo>` | Project checkout inside the pod. | Helm chart (`worktreeHostPath` template). |
+| `ERUN_REPO_PATH` | absolute path | `/home/erun/git/<repo>` | Project checkout inside the pod. In-pod `erun` resolves the project root from it (so `erun terraform` and the MCP repo-path find the tree); a sourceless runtime env's release tree is symlinked here with no `.git`, so the host's git-repo walk can't apply. | Helm chart (`worktreeHostPath` template). |
 | `ERUN_OUTPUTS_DIR` | absolute path | `/home/erun/.erun/outputs` | Canonical agent outputs directory: where agents/skills write deliverables that [`erun outputs`](/cli/outputs) lists and downloads. On the home PVC, so it persists across pod restarts. | Helm chart (literal on the runtime + MCP containers); created by the image and the entrypoint. |
 | `ERUN_REPO_REMOTE` | bool literal `true`/`false` | unset on host; `true` in pod | Marks the pod as a runtime pod. Used by `IsInRuntimeEnvironment`. | Helm chart, only when env type is `remote-agent` or `runtime`. |
 | `ERUN_REPO_URL` | git remote URL | unset unless mounting source | Git remote the runtime pod clones into `ERUN_REPO_PATH` on first boot, for a runtime env that opted into a mutable source worktree. The entrypoint clones only into an empty worktree, so live edits survive restarts. | Helm chart, only when [`EnvConfig.mountsource`](/reference/configuration#envconfig) is set with a `repourl`. |

--- a/erun-integration/terraform_test.go
+++ b/erun-integration/terraform_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sophium/erun/erun-integration/internal/env"
@@ -140,6 +141,44 @@ func TestTerraform(t *testing.T) {
 			t.Fatalf("expected non-zero exit without a terraform root, got 0:\n%s", result.Combined)
 		}
 		golden.Equal(t, "terraform/missing_root", normalize.Apply(result.Combined))
+	})
+
+	t.Run("apply_dry_run_repo_path_env", func(t *testing.T) {
+		// A sourceless runtime pod has no .git: the image-baked release tree is
+		// surfaced at ERUN_REPO_PATH. Root resolution must come from that env var
+		// (not the cwd .git walk), so terraform runs against
+		// <ERUN_REPO_PATH>/terraform-team/dev even though neither the cwd nor the
+		// repo dir is a git repository.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		repoDir := filepath.Join(setup.Home, "git", "team")
+		fixture.SeedTerraformEnvRootAt(t, filepath.Join(repoDir, "terraform-team"), "dev")
+		envVars := append(setup.Env(), "ERUN_REPO_PATH="+repoDir)
+		result := erun.Run(t, []string{"terraform", "apply", "team", "dev", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		// The resolved dir normalizes to <TMP>, so the snapshot alone can't prove
+		// resolution came from ERUN_REPO_PATH rather than the cwd. Assert on the
+		// un-normalized path (the masked-value case) to lock that the repo-dir
+		// tree — distinct from the cwd — drove the plan.
+		if terraformDir := filepath.Join(repoDir, "terraform-team", "dev"); !strings.Contains(result.Combined, terraformDir) {
+			t.Fatalf("expected terraform to resolve %s from ERUN_REPO_PATH, got:\n%s", terraformDir, result.Combined)
+		}
+		golden.Equal(t, "terraform/apply_dry_run_repo_path_env", normalize.Apply(result.Combined))
+	})
+
+	t.Run("not_in_git_without_repo_path", func(t *testing.T) {
+		// The laptop fallback is unchanged: with no .git up the tree and
+		// ERUN_REPO_PATH unset, root resolution still fails with "cannot find git
+		// project" before any terraform work.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"terraform", "apply", "team", "dev", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit without a git repo or ERUN_REPO_PATH, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "terraform/not_in_git_without_repo_path", normalize.Apply(result.Combined))
 	})
 
 	t.Run("apply_real_run_via_stub", func(t *testing.T) {

--- a/erun-integration/testdata/terraform/apply_dry_run_repo_path_env.txt
+++ b/erun-integration/testdata/terraform/apply_dry_run_repo_path_env.txt
@@ -1,0 +1,8 @@
+audit: erun terraform apply --dry-run team dev
+terraform: apply in <TMP> (env team/dev, namespace team-dev)
+terraform: var file dev.tfvars
+cd <TMP> && terraform init -input=false
+cd <TMP> && terraform fmt -recursive ..
+cd <TMP> && terraform plan -input=false -var-file=dev.tfvars -out apply.tfplan
+terraform: apply requires typing the environment name (dev) to confirm before apply
+cd <TMP> && terraform apply -input=false apply.tfplan

--- a/erun-integration/testdata/terraform/not_in_git_without_repo_path.txt
+++ b/erun-integration/testdata/terraform/not_in_git_without_repo_path.txt
@@ -1,0 +1,2 @@
+audit: erun terraform apply --dry-run team dev
+cannot find git project


### PR DESCRIPTION
## Problem

Inside a sourceless runtime pod (e.g. `frs-prod`), `erun terraform apply <tenant> <env>` fails immediately with `cannot find git project`, before any Terraform resolution.

**Root cause:** every CLI command resolves the project root via `common.FindProjectRoot` (`erun-cli/cmd/root.go`), which does `os.Getwd()` and walks *upward* looking for a `.git` directory. A sourceless runtime env has **no `.git`** by design — `ensure_runtime_source` only `git clone`s when `ERUN_REPO_URL` is set (mutable-source envs); otherwise `link_runtime_release` symlinks `~/git/<repo>` → the image-baked `/opt/erun/release` tree, which carries no git metadata. So the walk runs to `/` and errors.

This contradicts `erun-devops/AGENTS.md`, which states the chart sets `ERUN_REPO_PATH=/home/erun/git/<worktreeRepoName>` even on a sourceless env *"so `erun terraform` and the MCP repo-path resolve the symlinked tree."* The MCP path already honors it (`erun-mcp/terraform.go` → `firstNonEmpty(input.ProjectRoot, runtime.Context.RepoPath)`); the CLI's `FindProjectRoot` ignored `ERUN_REPO_PATH` entirely.

## Fix

`FindProjectRoot` now prefers `ERUN_REPO_PATH` when it is set and names an existing directory, falling back to the cwd `.git` walk otherwise. `ERUN_REPO_PATH` is set only inside the runtime pod (chart `service.yaml`), so laptop/desktop behavior is unchanged. This matches the MCP behavior and the existing `doctor_remote_init.go` precedent of treating `ERUN_REPO_PATH` as the in-pod project root.

## Tests

- `TestTerraform/apply_dry_run_repo_path_env` — models the sourceless pod (no `.git`, `ERUN_REPO_PATH` set to a dir distinct from cwd); asserts the plan resolves under the repo dir. The resolved path normalizes to `<TMP>`, so a substring assertion on the un-normalized output locks that resolution came from `ERUN_REPO_PATH` (the masked-value case in `erun-integration/AGENTS.md`).
- `TestTerraform/not_in_git_without_repo_path` — locks the unchanged laptop fallback: no `.git` + no `ERUN_REPO_PATH` still errors `cannot find git project`.

## Docs

- `cli/terraform.md` — added the `cannot find git project` row to the error table (Operator-facing; no env-var internals).
- `reference/env-vars.md` — documented that in-pod `erun` resolves the project root from `ERUN_REPO_PATH`.

## Validation

- `go test ./...` green in `erun-common`, `erun-cli`, `erun-mcp`.
- `make check` green: golangci-lint 0 issues across all gated modules; integration suite passes; coverage 75.6% ≥ 75.0%.
- `cd erun-docs && yarn build` clean (no broken links).
- **End-to-end:** ran the real compiled `erun` binary in a Linux container replicating the pod's sourceless layout (symlinked repo dir, no `.git`, `ERUN_REPO_PATH` set). Pre-fix binary reproduces `cannot find git project` verbatim; fixed binary resolves `…/terraform-frs/prod` and prints the full plan. The live `frs-prod` pod itself was not reachable from the dev environment (no cloud context wired; full release/redeploy blocked on build/host infra), so this container repro is the closest available target.

Closes #790