### PR TITLE
Desktop: send the deployed version's runtime image so the deploy targets it

### DIFF
--- a/erun-ui/frontend/src/app/manageDeployThunks.ts
+++ b/erun-ui/frontend/src/app/manageDeployThunks.ts
@@ -18,12 +18,18 @@ export const submitManageDeploy = (): AppThunk<Promise<void>> => async (dispatch
   // Deploys exactly what the operator checked (opt-in only); an empty set leaves
   // deploy to fall back to the env's saved default.
   const components = [...dialog.deployComponentSelection];
+  // Resolve the runtime image while the dialog is still open: closeManageDialog
+  // resets the dialog slice (including its version suggestions), and the image is
+  // resolved from those dialog-owned suggestions. Resolving after close would read
+  // an empty list, drop the --runtime-image flag, and silently deploy the local
+  // umbrella's pinned erun-devops version instead of the one the operator targeted.
+  const runtimeImage = version ? selectManageRuntimeImage(getState(), version) : '';
   dispatch(closeManageDialog());
   await dispatch(
     startDeploySelection({
       ...selection,
       version,
-      runtimeImage: version ? selectManageRuntimeImage(getState(), version) : '',
+      runtimeImage,
       components,
     }),
   );

--- a/erun-ui/frontend/src/app/selectors.ts
+++ b/erun-ui/frontend/src/app/selectors.ts
@@ -1,7 +1,7 @@
 import type { UISelection } from '@/types';
 
 import type { RootState } from './store';
-import { normalizeDialogValue, selectionKey } from './versionSuggestions';
+import { findVersionSuggestion, normalizeDialogValue, selectionKey } from './versionSuggestions';
 
 export const selectEnvironmentExists = (
   state: RootState,
@@ -58,11 +58,22 @@ export const selectActiveSlotForSelection = (state: RootState, selection: UISele
   return (active ?? first).slot;
 };
 
+// selectManageRuntimeImage resolves the runtime image for the version being
+// deployed. It resolves against the dialog-owned suggestion list — the same one
+// the picker renders (dialog.versionSuggestions), NOT the shared tenants slice,
+// which is written for the sidebar-selected env and clobbered by env-change
+// deltas, so the picked version is often absent from it. It must come from a
+// real suggestion for that version, not the stored versionImage on its own: a
+// stale/mismatched versionImage (or an absent one) would otherwise drop the
+// --runtime-image flag, silently deploying the local umbrella's pinned
+// erun-devops version instead of the version the operator targeted. Prefer the
+// exact (version, image) suggestion so lines that share a version stay distinct,
+// then fall back to the first suggestion for the version.
 export const selectManageRuntimeImage = (state: RootState, version: string): string => {
-  if (state.manageDialog.versionImage) {
-    return state.manageDialog.versionImage;
-  }
-  const suggestion = state.tenants.versionSuggestions.find((value) => value.version === version);
+  const suggestions = state.manageDialog.versionSuggestions;
+  const suggestion =
+    findVersionSuggestion(suggestions, version, state.manageDialog.versionImage) ??
+    findVersionSuggestion(suggestions, version, '');
   return suggestion?.image ?? '';
 };
 

--- a/erun-ui/playwright/tests/manage-version-picker.spec.ts
+++ b/erun-ui/playwright/tests/manage-version-picker.spec.ts
@@ -208,4 +208,61 @@ test.describe('manage dialog — version picker (#756)', () => {
     await expect(page.getByRole('option', { name: /1\.0\.16/ })).toBeVisible();
     await expect(page.getByRole('option', { name: /9\.9\.9/ })).toHaveCount(0);
   });
+
+  test('deploying a version sends its runtime image so the deploy targets that erun-devops version (#792)', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    // Regression: the runtime image for the deployed version must resolve from the
+    // dialog-owned suggestion list the picker renders, not the shared tenants
+    // slice (written for the sidebar-selected env, clobbered by env-change deltas).
+    // Editing the version field clears the picked image, so if resolution fell
+    // back to the shared slice the deploy would omit --runtime-image and silently
+    // install the local umbrella's pinned erun-devops version instead of the one
+    // the operator targeted. The image reaching StartDeploySession is the proof it
+    // resolved from the dialog list.
+    await page.route('**/__erun_invoke', async (route, request) => {
+      const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+      if (body.method === 'LoadVersionSuggestions') {
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: {
+              suggestions: [
+                {
+                  label: 'Upstream ERun',
+                  version: '1.0.134',
+                  source: 'ERun',
+                  image: 'ghcr.io/sophium/erun-devops',
+                },
+              ],
+              notices: [],
+            },
+          }),
+        });
+      }
+      await route.continue();
+    });
+
+    await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('Runtime');
+    await app.manageDialog.openVersionPicker();
+    // Edit the version field directly — the operator's path — which clears the
+    // picked image; resolution must still find it in the dialog's own list.
+    await app.manageDialog.runtimeVersionInput().fill('1.0.134');
+    await expect(app.manageDialog.deployButton()).toBeEnabled();
+
+    const deployRequest = page.waitForRequest(
+      (req) =>
+        req.url().includes('/__erun_invoke') &&
+        (req.postData() ?? '').includes('StartDeploySession'),
+    );
+    await app.manageDialog.deploy();
+    const payload = (await deployRequest).postData() ?? '';
+    // Carries the erun-devops image → buildDeployArgs adds --runtime-image → the
+    // deploy routes to the published erun-devops chart at the targeted version.
+    expect(payload).toContain('ghcr.io/sophium/erun-devops');
+  });
 });


### PR DESCRIPTION
## Problem

Deploying a `<tenant>-devops` runtime env from the desktop and picking a specific `erun-devops` version (e.g. **Upstream ERun 1.0.134**) ran the version the repo's `<tenant>-devops` wrapper chart is pinned to (1.0.133), not the one selected. `erun-devops` is the runtime image; `frs-devops` is only a wrapper chart in the tenant repo whose `Chart.lock` pins the `erun-devops` sub-chart to 1.0.133.

The desktop passed `--version 1.0.134` but **dropped `--runtime-image`**. Without it, the deploy installs the repo's wrapper (→ erun-devops 1.0.133) instead of pulling the `erun-devops` chart at 1.0.134 (whose image defaults to its own appVersion, `erun-devops:1.0.134`).

## Cause (two bugs in the Runtime-tab deploy path)

1. `submitManageDeploy` resolved the runtime image **after** dispatching `closeManageDialog()`, which resets the dialog slice — emptying its dialog-owned version suggestions.
2. `selectManageRuntimeImage` read `state.tenants.versionSuggestions` (the **shared** slice, written for the sidebar-selected env and clobbered by env-change deltas), not the dialog-owned list the picker renders.

So the picked version's image couldn't be resolved, `runtimeImage` came back `""`, `--runtime-image` was omitted, and the deploy fell back to the pinned wrapper.

## Fix

- `selectManageRuntimeImage` resolves from `state.manageDialog.versionSuggestions` (the picker's own list), authoritatively by version via `findVersionSuggestion`.
- `submitManageDeploy` resolves the image **before** closing the dialog.

Now an Upstream-ERun pick sends `--runtime-image ghcr.io/sophium/erun-devops`, so the deploy installs the published `erun-devops` chart at the picked version → image at that version.

## Tests

`erun-ui/playwright/tests/manage-version-picker.spec.ts` — new regression: editing the version field (which clears the picked image) and deploying now sends the erun-devops image on `StartDeploySession`. Fails pre-fix (`runtimeImage:""`), passes post-fix.

## Validation

- `yarn typecheck` / `yarn lint` / `yarn build` clean.
- **Full Playwright suite green: 119 passed, 0 failed** (`./run.sh`).
- **End-to-end against a live env:** ran the exact command the fixed desktop now generates against `frs/local` on orbstack → deployment image `ghcr.io/sophium/erun-devops:1.0.134`, running pod on `erun-devops:1.0.134`, and the in-pod `erun version` reports **1.0.134** (was 1.0.133 — the original failing symptom).

Closes #792