### PR TITLE
erun terraform: split out `init` so apply/plan/destroy never write the read-only tree

### DIFF
--- a/erun-cli/cmd/terraform.go
+++ b/erun-cli/cmd/terraform.go
@@ -18,19 +18,31 @@ func newTerraformCmd(store common.TerraformStore, findProjectRoot common.Project
 			"without hand-running terraform or cd-ing into the folder.\n\n" +
 			"erun resolves the env's folder from the current scope, picks up the symlinked common.tf, and runs that " +
 			"env's main.tf with its <environment>.tfvars. State and the provider cache live on the durable home " +
-			"directory (not in the playbook tree), so they survive a runtime pod restart. Use a subcommand: " +
-			"`apply`, `plan`, or `destroy`.",
+			"directory (not in the playbook tree), so they survive a runtime pod restart. Use a subcommand: run " +
+			"`init` once (and after changing providers) to download providers and record the lock, then `plan`, " +
+			"`apply`, or `destroy`.",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(
+		newTerraformOperationCmd(store, findProjectRoot, common.TerraformInit, "init [TENANT] [ENVIRONMENT]",
+			"Initialize the env's Terraform: download providers, wire state, and record the provider lock",
+			"Initialize the env's Terraform root before plan/apply/destroy.\n\n"+
+				"Downloads providers into the durable home directory and points the local backend at the env's state "+
+				"file. On a writable checkout it generates .terraform.lock.hcl and records provider hashes for "+
+				"linux/amd64 and linux/arm64 (erun's deploy targets) — commit that lock so read-only runtime envs can "+
+				"initialize without rewriting their baked tree. On a tree that already has a committed lock it runs "+
+				"-lockfile=readonly and only refreshes the provider cache. Run this once, and again after changing "+
+				"providers; plan/apply/destroy no longer init implicitly.",
+			"  erun terraform init frs local\n  erun terraform init frs prod --dry-run"),
 		newTerraformOperationCmd(store, findProjectRoot, common.TerraformApply, "apply [TENANT] [ENVIRONMENT]",
 			"Plan and apply the env's Terraform (prompts for the environment name)",
 			"Plan and apply the env's Terraform root.\n\n"+
 				"Resolves the env's Terraform root (terraform-<tenant>/<environment>/ or "+
-				"<tenant>-devops/terraform-<tenant>/<environment>/), runs init -> fmt -> plan, then prompts you to type "+
-				"the environment name before applying — a guard against applying to the wrong env. It mutates real cloud "+
-				"and cluster state (DNS, TLS, ingress, workloads); state is kept on the durable home directory. Pass "+
-				"--confirm-environment <env> for non-interactive use, or --dry-run to preview the resolved terraform commands.",
+				"<tenant>-devops/terraform-<tenant>/<environment>/), runs fmt -> plan, then prompts you to type "+
+				"the environment name before applying — a guard against applying to the wrong env. Run `erun terraform "+
+				"init` first (once) so providers are available. It mutates real cloud and cluster state (DNS, TLS, "+
+				"ingress, workloads); state is kept on the durable home directory. Pass --confirm-environment <env> for "+
+				"non-interactive use, or --dry-run to preview the resolved terraform commands.",
 			"  erun terraform apply frs prod\n  erun terraform apply frs prod --dry-run"),
 		newTerraformOperationCmd(store, findProjectRoot, common.TerraformPlan, "plan [TENANT] [ENVIRONMENT]",
 			"Show the env's Terraform plan without applying", "", "  erun terraform plan frs prod"),
@@ -61,7 +73,7 @@ func newTerraformOperationCmd(store common.TerraformStore, findProjectRoot commo
 	addDryRunFlag(cmd)
 	cmd.Flags().StringVar(&tenantFlag, "tenant", "", "Target a specific tenant (defaults to the current scope)")
 	cmd.Flags().StringVar(&environmentFlag, "environment", "", "Target a specific environment (defaults to the tenant's default)")
-	if op != common.TerraformPlan {
+	if op == common.TerraformApply || op == common.TerraformDestroy {
 		cmd.Flags().StringVar(&confirmEnvironment, "confirm-environment", "", "Confirm by restating the environment name, bypassing the interactive prompt (non-interactive use)")
 	}
 	return cmd
@@ -103,10 +115,10 @@ func terraformArgOrFlag(flag string, args []string, index int) string {
 	return ""
 }
 
-// terraformConfirmer guards apply/destroy against hitting the wrong env; plan
-// never mutates, so it needs no confirmation.
+// terraformConfirmer guards apply/destroy against hitting the wrong env; init
+// and plan never mutate cloud/cluster state, so they need no confirmation.
 func terraformConfirmer(op common.TerraformOperation, confirmEnvironment string) common.TerraformConfirmFunc {
-	if op == common.TerraformPlan {
+	if op != common.TerraformApply && op != common.TerraformDestroy {
 		return nil
 	}
 	return func(ctx common.Context, environment string) error {

--- a/erun-common/terraform.go
+++ b/erun-common/terraform.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -19,10 +20,19 @@ type TerraformStore interface {
 type TerraformOperation string
 
 const (
+	TerraformInit    TerraformOperation = "init"
 	TerraformApply   TerraformOperation = "apply"
 	TerraformPlan    TerraformOperation = "plan"
 	TerraformDestroy TerraformOperation = "destroy"
 )
+
+// terraformLockPlatforms are the provider platforms `erun terraform init`
+// records in a generated .terraform.lock.hcl. They match erun's deploy targets
+// (build/deploy always produce linux/amd64 + linux/arm64), so one committed lock
+// lets init run -lockfile=readonly on every env regardless of the pod's arch — a
+// lock generated for only the local platform would fail a read-only init on a
+// pod of the other architecture.
+var terraformLockPlatforms = []string{"linux_amd64", "linux_arm64"}
 
 // TerraformConfirmFunc gates a mutating operation (apply/destroy) after the plan
 // is produced and before it is applied. The operator confirms by restating the
@@ -124,31 +134,87 @@ func traceTerraformPlan(ctx Context, result TerraformResult, steps []terraformSt
 	if result.ConfiguredTerraformBase != "" {
 		ctx.Trace("terraform: base " + result.ConfiguredTerraformBase + " from .erun/config.yaml paths.terraform")
 	}
-	if result.VarFile != "" {
-		ctx.Trace("terraform: var file " + result.VarFile)
-	} else {
-		ctx.Trace("terraform: no " + result.Environment + ".tfvars found; planning without -var-file")
+	if result.Operation != string(TerraformInit) {
+		if result.VarFile != "" {
+			ctx.Trace("terraform: var file " + result.VarFile)
+		} else {
+			ctx.Trace("terraform: no " + result.Environment + ".tfvars found; planning without -var-file")
+		}
 	}
 	// State, the plan file, and TF_DATA_DIR live on the durable home PVC, off the
 	// read-only playbook tree, so they survive a runtime pod restart.
 	ctx.Trace("terraform: state " + result.StateFile + " (local backend on the home PVC — survives pod restarts)")
 	ctx.Trace("terraform: TF_DATA_DIR " + result.DataDir)
+	traceTerraformStateBackend(ctx, result)
 	if result.LegacyStateInTree {
 		ctx.Trace("terraform: warning: legacy in-tree state " + filepath.Join(result.Directory, "terraform.tfstate") + " is ignored; state now lives at " + result.StateFile)
 	}
-	if result.LockReadonly {
-		ctx.Trace("terraform: baked .terraform.lock.hcl found — pinning providers with -lockfile=readonly")
-	}
+	traceTerraformInitLock(ctx, result)
 	if cloudflareTokenPresent() {
 		ctx.Trace("terraform: injecting TF_VAR_cloudflare_api_token from CLOUDFLARE_API_TOKEN")
 	}
 	ctx.TraceCommand("", "mkdir", "-p", result.WorkDir)
 	for _, step := range steps {
 		if step.confirm {
-			ctx.Trace(fmt.Sprintf("terraform: %s requires typing the environment name (%s) to confirm before apply", result.Operation, result.Environment))
+			ctx.Trace(fmt.Sprintf("terraform: confirmation gate — the %s below runs only after you type the environment name %q; a mismatch or empty entry aborts before anything is applied", result.Operation, result.Environment))
 		}
 		ctx.TraceCommand(result.Directory, "terraform", step.args...)
 	}
+}
+
+// terraformBackendBlockRe matches a `backend "…" {` declaration in a Terraform
+// config file, used to warn when the tree has none.
+var terraformBackendBlockRe = regexp.MustCompile(`(?m)^\s*backend\s+"`)
+
+// traceTerraformStateBackend warns when the tree declares no backend block. Only
+// then does `terraform init -backend-config=path=` persist to plan/apply; without
+// one, Terraform silently keeps state in ./terraform.tfstate inside the (often
+// read-only) playbook tree instead of on the durable home PVC.
+func traceTerraformStateBackend(ctx Context, result TerraformResult) {
+	if terraformTreeHasBackend(result.Directory) {
+		return
+	}
+	ctx.Trace("terraform: warning: no `backend \"local\"` block in the tree — Terraform keeps state in ./terraform.tfstate inside the playbook tree, not on the PVC; add `backend \"local\" {}` so state persists to " + result.StateFile + " and apply works on a read-only tree")
+}
+
+// terraformTreeHasBackend reports whether any .tf file in the env dir or its base
+// declares a backend block. It follows the env dir's symlinked common.tf and
+// also scans the base directly, matching how the playbook tree is laid out.
+func terraformTreeHasBackend(dir string) bool {
+	for _, scan := range []string{dir, filepath.Dir(dir)} {
+		entries, err := os.ReadDir(scan)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".tf") {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(scan, entry.Name()))
+			if err != nil {
+				continue
+			}
+			if terraformBackendBlockRe.Match(data) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// traceTerraformInitLock records how init will treat the provider lock: a
+// committed lock keeps init read-only (never rewrites the tree), while its
+// absence means init generates one covering every deploy platform for the
+// operator to commit.
+func traceTerraformInitLock(ctx Context, result TerraformResult) {
+	if result.Operation != string(TerraformInit) {
+		return
+	}
+	if result.LockReadonly {
+		ctx.Trace("terraform: committed .terraform.lock.hcl found — init runs -lockfile=readonly and never rewrites the tree")
+		return
+	}
+	ctx.Trace("terraform: no .terraform.lock.hcl yet — init will generate it and record provider hashes for " + strings.Join(terraformLockPlatforms, ", ") + "; commit it so read-only envs can init with -lockfile=readonly")
 }
 
 func executeTerraformSteps(ctx Context, result TerraformResult, steps []terraformStep, confirm TerraformConfirmFunc) error {
@@ -156,6 +222,14 @@ func executeTerraformSteps(ctx Context, result TerraformResult, steps []terrafor
 	// terraform can write the local-backend state and TF_DATA_DIR there.
 	if err := os.MkdirAll(result.WorkDir, 0o755); err != nil {
 		return fmt.Errorf("creating terraform state dir %s: %w", result.WorkDir, err)
+	}
+	// A lock-generating init needs to write .terraform.lock.hcl into the tree.
+	// Fail early with a recovery path rather than a raw permission error when the
+	// tree is read-only (e.g. a baked runtime release with no committed lock).
+	if result.Operation == string(TerraformInit) && !result.LockReadonly {
+		if err := ensureTerraformTreeWritable(result.Directory); err != nil {
+			return err
+		}
 	}
 	extraEnv := terraformExtraEnv(result.DataDir)
 	for _, step := range steps {
@@ -240,10 +314,10 @@ func resolveTerraformPlan(params TerraformParams, store TerraformStore) (Terrafo
 
 func validateTerraformOperation(op TerraformOperation) error {
 	switch op {
-	case TerraformApply, TerraformPlan, TerraformDestroy:
+	case TerraformInit, TerraformApply, TerraformPlan, TerraformDestroy:
 		return nil
 	default:
-		return fmt.Errorf("unsupported terraform operation %q (want apply, plan, or destroy)", op)
+		return fmt.Errorf("unsupported terraform operation %q (want init, apply, plan, or destroy)", op)
 	}
 }
 
@@ -335,25 +409,25 @@ func resolveTerraformScope(store TerraformStore, params TerraformParams) (tenant
 	return tenant, environment, nil
 }
 
+// buildTerraformSteps resolves the terraform command sequence for op. init is
+// its own operation, so plan/apply/destroy no longer run it implicitly — the
+// operator runs `erun terraform init` once (and after changing providers), which
+// keeps apply/plan/destroy from ever trying to write the lock file into a
+// read-only playbook tree.
 func buildTerraformSteps(op TerraformOperation, varFile, stateFile, planFile string, lockReadonly bool, extraArgs []string) []terraformStep {
-	// init points the local backend at the durable state file; a baked lock file
-	// pins providers read-only so init never rewrites the read-only playbook tree.
-	initArgs := []string{"init", "-input=false", "-backend-config=path=" + stateFile}
-	if lockReadonly {
-		initArgs = append(initArgs, "-lockfile=readonly")
-	}
-	initStep := terraformStep{args: initArgs}
 	switch op {
+	case TerraformInit:
+		return buildTerraformInitSteps(stateFile, lockReadonly)
 	case TerraformPlan:
 		plan := append([]string{"plan", "-input=false"}, terraformVarFileArgs(varFile)...)
 		plan = append(plan, extraArgs...)
-		return []terraformStep{initStep, {args: plan}}
+		return []terraformStep{{args: plan}}
 	case TerraformDestroy:
 		plan := append([]string{"plan", "-destroy", "-input=false"}, terraformVarFileArgs(varFile)...)
 		plan = append(plan, extraArgs...)
 		plan = append(plan, "-out", planFile)
 		apply := terraformStep{args: []string{"apply", "-input=false", planFile}, confirm: true}
-		return []terraformStep{initStep, {args: plan}, apply}
+		return []terraformStep{{args: plan}, apply}
 	default: // apply
 		// -check, not a rewrite: the playbook tree is read-only in the release.
 		fmtStep := terraformStep{args: []string{"fmt", "-check", "-recursive", ".."}}
@@ -361,8 +435,27 @@ func buildTerraformSteps(op TerraformOperation, varFile, stateFile, planFile str
 		plan = append(plan, extraArgs...)
 		plan = append(plan, "-out", planFile)
 		apply := terraformStep{args: []string{"apply", "-input=false", planFile}, confirm: true}
-		return []terraformStep{initStep, fmtStep, {args: plan}, apply}
+		return []terraformStep{fmtStep, {args: plan}, apply}
 	}
+}
+
+// buildTerraformInitSteps sets up the local backend at the durable state file and
+// populates the provider cache (TF_DATA_DIR) on the PVC. When the tree already
+// carries a committed .terraform.lock.hcl (e.g. a baked read-only release), init
+// runs -lockfile=readonly so it never rewrites the tree. When no lock exists yet,
+// init generates one and a follow-up `providers lock` records hashes for every
+// deploy platform, so the single committed lock initializes on any env's arch.
+func buildTerraformInitSteps(stateFile string, lockReadonly bool) []terraformStep {
+	initArgs := []string{"init", "-input=false", "-backend-config=path=" + stateFile}
+	if lockReadonly {
+		initArgs = append(initArgs, "-lockfile=readonly")
+		return []terraformStep{{args: initArgs}}
+	}
+	lockArgs := []string{"providers", "lock"}
+	for _, platform := range terraformLockPlatforms {
+		lockArgs = append(lockArgs, "-platform="+platform)
+	}
+	return []terraformStep{{args: initArgs}, {args: lockArgs}}
 }
 
 func terraformVarFileArgs(varFile string) []string {
@@ -394,6 +487,22 @@ func terraformExtraEnv(dataDir string) []string {
 		env = append(env, "TF_VAR_cloudflare_api_token="+token)
 	}
 	return env
+}
+
+// ensureTerraformTreeWritable confirms init can write .terraform.lock.hcl into
+// the playbook tree, and otherwise returns a recovery path. A sourceless runtime
+// env surfaces the tree as a symlink into the read-only, root-owned image layer
+// (/opt/erun/release), so the erun user cannot create the lock there — the lock
+// must be generated on a writable env and committed so it bakes into the image.
+func ensureTerraformTreeWritable(dir string) error {
+	probe, err := os.CreateTemp(dir, ".erun-tf-writeprobe-*")
+	if err != nil {
+		return fmt.Errorf("terraform init must generate .terraform.lock.hcl but the playbook tree %s is not writable — run `erun terraform init` on a writable env (e.g. a <tenant>-local checkout), commit the generated .terraform.lock.hcl, and rebuild/redeploy so it bakes into the image; then this env can init with -lockfile=readonly: %w", dir, err)
+	}
+	name := probe.Name()
+	_ = probe.Close()
+	_ = os.Remove(name)
+	return nil
 }
 
 func execTerraformStep(ctx Context, dir string, extraEnv, args []string) error {

--- a/erun-docs/docs/cli/terraform.md
+++ b/erun-docs/docs/cli/terraform.md
@@ -6,28 +6,35 @@ title: erun terraform
 
 Run a hosted platform's per-environment Terraform without hand-running `terraform` or `cd`-ing into a folder. `erun terraform` is for [platform deployments](/deployment/deploy-platform) whose Terraform is laid out per environment — one folder per env under `terraform-<tenant>/`, scaffolded by the [`erun-blueprint-platform`](/agent-reference/skills-spec#erun-blueprint-platform) skill. erun resolves the env's root from the current scope — `terraform-<tenant>/<environment>/` at the project root, or `<tenant>-devops/terraform-<tenant>/<environment>/` when the tenant keeps its whole devops footprint (`docker/`, `k8s/`, `terraform-<tenant>/`) under `<tenant>-devops/` (the same `-devops` convention `build`/`deploy` use) — picks up the symlinked `common.tf`, and runs that env's own `main.tf` with its `<environment>.tfvars`. The `terraform-<tenant>` base is the default; relocate it with [`paths.terraform`](/reference/configuration#paths-block) in `.erun/config.yaml` (erun still appends `/<environment>`).
 
-Terraform's mutable artifacts live **off** the playbook tree: erun keeps the local-backend state file, the plan file, and `TF_DATA_DIR` (downloaded providers/modules) under `~/.erun/terraform/<tenant>/<environment>/` on the durable home directory (the `/home/erun` PVC in a runtime pod). State and the provider cache therefore survive a pod restart, while the image-baked playbooks stay read-only.
+Terraform's mutable artifacts live **off** the playbook tree: erun keeps the local-backend state file, the plan file, and `TF_DATA_DIR` (downloaded providers/modules) under `~/.erun/terraform/<tenant>/<environment>/` on the durable home directory (the `/home/erun` PVC in a runtime pod). State and the provider cache therefore survive a pod restart, while the image-baked playbooks stay read-only. The one file Terraform insists on keeping next to `main.tf` is `.terraform.lock.hcl` — `erun terraform init` generates it (you commit it) so a read-only runtime env never has to write it.
 
 ```bash
-erun terraform apply frs prod              # init → fmt → plan → confirm → apply
-erun terraform plan frs prod               # read-only: init → plan
+erun terraform init frs prod               # once: download providers + record the provider lock
+erun terraform apply frs prod              # fmt → plan → confirm → apply
+erun terraform plan frs prod               # read-only: plan
 erun terraform destroy frs prod            # plan a destroy → confirm → apply
 erun terraform apply frs prod --dry-run    # preview the resolved terraform commands
 ```
 
-With no `TENANT`/`ENVIRONMENT` arguments, the command resolves the configured default scope.
+With no `TENANT`/`ENVIRONMENT` arguments, the command resolves the configured default scope. Run `init` once per environment (and again after you change providers) before `plan`/`apply`/`destroy` — they no longer init implicitly, matching how you run Terraform by hand.
 
 ## What it does
 
-For `erun terraform apply <tenant> <env>`, it resolves the env's root (see above) and runs Terraform **in that folder**, so the env picks up its symlinked `common.tf` and adds its own services via `main.tf`. `TF_DATA_DIR` is set to `~/.erun/terraform/<tenant>/<env>/data` for every step, so downloaded providers and modules persist on the durable home directory across runs and restarts:
+`TF_DATA_DIR` is set to `~/.erun/terraform/<tenant>/<env>/data` for every step, so downloaded providers and modules persist on the durable home directory across runs and restarts.
 
-1. `terraform init -input=false -backend-config=path=~/.erun/terraform/<tenant>/<env>/terraform.tfstate` — points the local backend at the durable state file. When a baked `.terraform.lock.hcl` pins providers, erun adds `-lockfile=readonly` so init never rewrites the read-only tree.
-2. `terraform fmt -check -recursive ..` — **verifies** formatting across the tree without rewriting it (the playbooks are read-only in a runtime release); a formatting drift fails the step.
-3. `terraform plan -input=false -var-file=<env>.tfvars -out ~/.erun/terraform/<tenant>/<env>/apply.tfplan` — using the env's var file when present.
-4. **Confirm:** you are prompted to **type the environment name** before anything is applied — the guard against applying to the wrong environment.
-5. `terraform apply -input=false ~/.erun/terraform/<tenant>/<env>/apply.tfplan` — applies the exact plan you reviewed.
+Run `erun terraform init <tenant> <env>` **once** first (and again after you change providers). It points the local backend at the durable state file (`-backend-config=path=~/.erun/terraform/<tenant>/<env>/terraform.tfstate`) and downloads providers into `TF_DATA_DIR`:
 
-`plan` stops after step 3 (read-only — no `fmt`, no `-out`, no confirm). `destroy` plans a `-destroy` and applies it behind the same confirm gate.
+- On a **writable** checkout it generates `.terraform.lock.hcl` and records provider hashes for `linux/amd64` and `linux/arm64` (erun's deploy targets, via `terraform providers lock`). **Commit that lock** so it bakes into the runtime image — then a read-only runtime env can initialize from it. A single committed lock works on every env because it covers both deploy architectures.
+- On a tree that **already has a committed lock** it runs `terraform init -lockfile=readonly`, refreshing only the PVC provider cache and never rewriting the (read-only) tree.
+
+`erun terraform apply <tenant> <env>` then resolves the env's root (see above) and runs Terraform **in that folder**, so the env picks up its symlinked `common.tf` and adds its own services via `main.tf` — with no implicit init:
+
+1. `terraform fmt -check -recursive ..` — **verifies** formatting across the tree without rewriting it (the playbooks are read-only in a runtime release); a formatting drift fails the step.
+2. `terraform plan -input=false -var-file=<env>.tfvars -out ~/.erun/terraform/<tenant>/<env>/apply.tfplan` — using the env's var file when present.
+3. **Confirm:** you are prompted to **type the environment name** before anything is applied — the guard against applying to the wrong environment. A wrong or empty entry aborts before the apply, so nothing is applied unless the name matches.
+4. `terraform apply -input=false ~/.erun/terraform/<tenant>/<env>/apply.tfplan` — applies the exact plan you reviewed.
+
+`plan` stops after step 2 (read-only — no `fmt`, no `-out`, no confirm). `destroy` plans a `-destroy` and applies it behind the same confirm gate. All three assume `init` has already run; if it hasn't, Terraform stops with a "run terraform init" error.
 
 When the env has a Cloudflare alias, its `CLOUDFLARE_API_TOKEN` is forwarded to Terraform as `TF_VAR_cloudflare_api_token` (so the edge module's cert-manager DNS-01 solver can prove control of the zone). The token rides in the environment — it never appears in the command line or the trace.
 
@@ -48,7 +55,9 @@ When the env has a Cloudflare alias, its `CLOUDFLARE_API_TOKEN` is forwarded to 
 | No Terraform root at either candidate | Aborts: `no Terraform root for <tenant>/<env> — looked under terraform-<tenant>/<env>/ and <tenant>-devops/terraform-<tenant>/<env>/ …`; exit 1. | Scaffold the per-env root with [`erun-blueprint-platform`](/agent-reference/skills-spec#erun-blueprint-platform), or create it at either location with its `main.tf` and `<env>.tfvars`. |
 | Environment not configured | Surfaces the config load error; exit 1. | Create the env (`erun init`) or fix the tenant/env name. |
 | No default tenant/environment and none passed | Aborts: default tenant/environment not configured; exit 1. | Pass `TENANT ENVIRONMENT` (or set a default scope). |
-| Confirmation doesn't match the env name | Aborts before the apply step: `confirmation "…" does not match environment "…"; aborting <operation>`; exit 1. The earlier read-only steps (`init`, `plan`, plus `fmt` for `apply`) have already run; only the apply is gated. | Re-run and type the exact environment name (or pass `--confirm-environment <env>`). |
+| Confirmation doesn't match the env name | Aborts before the apply step: `confirmation "…" does not match environment "…"; aborting <operation>`; exit 1. The earlier read-only steps (`plan`, plus `fmt` for `apply`) have already run; only the apply is gated. | Re-run and type the exact environment name (or pass `--confirm-environment <env>`). |
+| Providers not initialized (`init` not run) | A `plan`/`apply`/`destroy` `terraform` step stops with Terraform's *"Module not installed / please run terraform init"* error; exit 1. | Run `erun terraform init <tenant> <env>` first — once per environment, and again after changing providers. |
+| `init` on a read-only tree with no committed lock | `erun terraform init` aborts before running Terraform: the playbook tree is not writable and has no `.terraform.lock.hcl` to init read-only from; exit 1. | Run `erun terraform init` on a writable env (e.g. `<tenant>-local`), commit the generated `.terraform.lock.hcl`, and rebuild/redeploy so it bakes into the image. |
 | A `terraform` step fails (live run) | Surfaces the underlying `terraform` error and stops at that step; exit 1. | Fix the reported Terraform/cloud issue and re-run — `init`/`plan`/`apply` are safe to repeat. |
 
 ## See also

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -771,7 +771,7 @@ func SeedTerraformEnvRootAt(t testing.TB, root, environment string) {
 	if err := os.MkdirAll(envDir, 0o755); err != nil {
 		t.Fatalf("mkdir %s: %v", envDir, err)
 	}
-	mustWrite(t, filepath.Join(root, "common.tf"), "terraform {\n  required_version = \">= 1.3\"\n}\n")
+	mustWrite(t, filepath.Join(root, "common.tf"), "terraform {\n  required_version = \">= 1.3\"\n  backend \"local\" {}\n}\n")
 	mustWrite(t, filepath.Join(root, "variables.tf"), "variable \"base_domain\" {\n  type = string\n}\n")
 	mustWrite(t, filepath.Join(envDir, "main.tf"), "# "+environment+" services\n")
 	mustWrite(t, filepath.Join(envDir, environment+".tfvars"), "base_domain = \"erunpaas.com\"\n")

--- a/erun-integration/terraform_test.go
+++ b/erun-integration/terraform_test.go
@@ -32,6 +32,81 @@ func TestTerraform(t *testing.T) {
 		golden.Equal(t, "terraform/help_apply", normalize.Apply(result.Combined))
 	})
 
+	t.Run("help_init", func(t *testing.T) {
+		setup := env.New(t)
+		result := erun.Run(t, []string{"terraform", "init", "--help"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "terraform/help_init", normalize.Apply(result.Combined))
+	})
+
+	t.Run("init_dry_run", func(t *testing.T) {
+		// init is its own operation now (apply/plan/destroy no longer init). With no
+		// committed lock yet, init generates one and records provider hashes for both
+		// deploy arches via `providers lock`, so a single committed lock initializes
+		// on any env's architecture.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedGitRepo(t, setup.Cwd)
+		fixture.SeedTerraformEnvRoot(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"terraform", "init", "team", "dev", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "terraform/init_dry_run", normalize.Apply(result.Combined))
+	})
+
+	t.Run("init_dry_run_lockfile_readonly", func(t *testing.T) {
+		// A committed .terraform.lock.hcl in the (read-only) playbook tree pins
+		// providers, so init runs -lockfile=readonly and only refreshes the PVC
+		// provider cache — it never rewrites the tree and skips `providers lock`.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedGitRepo(t, setup.Cwd)
+		fixture.SeedTerraformEnvRoot(t, setup, "team", "dev")
+		lock := filepath.Join(setup.Cwd, "terraform-team", "dev", ".terraform.lock.hcl")
+		if err := os.WriteFile(lock, []byte("# pinned providers\n"), 0o644); err != nil {
+			t.Fatalf("write lock: %v", err)
+		}
+		result := erun.Run(t, []string{"terraform", "init", "team", "dev", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		golden.Equal(t, "terraform/init_dry_run_lockfile_readonly", normalize.Apply(result.Combined))
+	})
+
+	t.Run("init_real_run_via_stub", func(t *testing.T) {
+		// The real (non-dry-run) init path locks the writability pre-check, the init
+		// step, the cross-arch `providers lock` step, and the success line.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedGitRepo(t, setup.Cwd)
+		fixture.SeedTerraformEnvRoot(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinary(t, stubs, "terraform", "")
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "terraform")...)
+		result := erun.Run(t, []string{"terraform", "init", "team", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "terraform/init_real_run_via_stub", normalize.Apply(result.Combined))
+	})
+
+	t.Run("apply_dry_run_no_backend_warns", func(t *testing.T) {
+		// Without a `backend "local"` block, terraform's -backend-config=path override
+		// doesn't persist, so state would land in ./terraform.tfstate inside the
+		// (read-only) tree. erun warns so the operator adds the block before apply
+		// fails on a read-only tree.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedGitRepo(t, setup.Cwd)
+		fixture.SeedTerraformEnvRoot(t, setup, "team", "dev")
+		common := filepath.Join(setup.Cwd, "terraform-team", "common.tf")
+		if err := os.WriteFile(common, []byte("terraform {\n  required_version = \">= 1.3\"\n}\n"), 0o644); err != nil {
+			t.Fatalf("rewrite common.tf: %v", err)
+		}
+		result := erun.Run(t, []string{"terraform", "apply", "team", "dev", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		golden.Equal(t, "terraform/apply_dry_run_no_backend_warns", normalize.Apply(result.Combined))
+	})
+
 	t.Run("apply_dry_run", func(t *testing.T) {
 		// apply's full plan runs behind a type-the-env-name confirm gate and
 		// performs no side effects in dry-run.
@@ -92,21 +167,6 @@ func TestTerraform(t *testing.T) {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
 		golden.Equal(t, "terraform/apply_dry_run_under_devops", normalize.Apply(result.Combined))
-	})
-
-	t.Run("apply_dry_run_lockfile_readonly", func(t *testing.T) {
-		// A baked .terraform.lock.hcl in the (read-only) playbook tree pins providers,
-		// so init runs -lockfile=readonly and never rewrites the tree.
-		setup := env.New(t)
-		fixture.SeedTenantEnv(t, setup, "team", "dev")
-		fixture.SeedGitRepo(t, setup.Cwd)
-		fixture.SeedTerraformEnvRoot(t, setup, "team", "dev")
-		lock := filepath.Join(setup.Cwd, "terraform-team", "dev", ".terraform.lock.hcl")
-		if err := os.WriteFile(lock, []byte("# pinned providers\n"), 0o644); err != nil {
-			t.Fatalf("write lock: %v", err)
-		}
-		result := erun.Run(t, []string{"terraform", "apply", "team", "dev", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
-		golden.Equal(t, "terraform/apply_dry_run_lockfile_readonly", normalize.Apply(result.Combined))
 	})
 
 	t.Run("apply_dry_run_legacy_state_warning", func(t *testing.T) {

--- a/erun-integration/testdata/terraform/apply_confirm_mismatch.txt
+++ b/erun-integration/testdata/terraform/apply_confirm_mismatch.txt
@@ -3,5 +3,5 @@ terraform: apply in <TMP> (env team/dev, namespace team-dev)
 terraform: var file dev.tfvars
 terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
 terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
-terraform: apply requires typing the environment name (dev) to confirm before apply
+terraform: confirmation gate — the apply below runs only after you type the environment name "dev"; a mismatch or empty entry aborts before anything is applied
 confirmation "wrong" does not match environment "dev"; aborting apply

--- a/erun-integration/testdata/terraform/apply_dry_run.txt
+++ b/erun-integration/testdata/terraform/apply_dry_run.txt
@@ -4,8 +4,7 @@ terraform: var file dev.tfvars
 terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
 terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
 mkdir -p <STATE_ROOT>/team/dev
-cd <TMP> && terraform init -input=false -backend-config=path=<STATE_ROOT>/team/dev/terraform.tfstate
 cd <TMP> && terraform fmt -check -recursive ..
 cd <TMP> && terraform plan -input=false -var-file=dev.tfvars -out <STATE_ROOT>/team/dev/apply.tfplan
-terraform: apply requires typing the environment name (dev) to confirm before apply
+terraform: confirmation gate — the apply below runs only after you type the environment name "dev"; a mismatch or empty entry aborts before anything is applied
 cd <TMP> && terraform apply -input=false <STATE_ROOT>/team/dev/apply.tfplan

--- a/erun-integration/testdata/terraform/apply_dry_run_default_scope.txt
+++ b/erun-integration/testdata/terraform/apply_dry_run_default_scope.txt
@@ -4,8 +4,7 @@ terraform: var file dev.tfvars
 terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
 terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
 mkdir -p <STATE_ROOT>/team/dev
-cd <TMP> && terraform init -input=false -backend-config=path=<STATE_ROOT>/team/dev/terraform.tfstate
 cd <TMP> && terraform fmt -check -recursive ..
 cd <TMP> && terraform plan -input=false -var-file=dev.tfvars -out <STATE_ROOT>/team/dev/apply.tfplan
-terraform: apply requires typing the environment name (dev) to confirm before apply
+terraform: confirmation gate — the apply below runs only after you type the environment name "dev"; a mismatch or empty entry aborts before anything is applied
 cd <TMP> && terraform apply -input=false <STATE_ROOT>/team/dev/apply.tfplan

--- a/erun-integration/testdata/terraform/apply_dry_run_legacy_state_warning.txt
+++ b/erun-integration/testdata/terraform/apply_dry_run_legacy_state_warning.txt
@@ -5,8 +5,7 @@ terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the h
 terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
 terraform: warning: legacy in-tree state <TMP> is ignored; state now lives at <STATE_ROOT>/team/dev/terraform.tfstate
 mkdir -p <STATE_ROOT>/team/dev
-cd <TMP> && terraform init -input=false -backend-config=path=<STATE_ROOT>/team/dev/terraform.tfstate
 cd <TMP> && terraform fmt -check -recursive ..
 cd <TMP> && terraform plan -input=false -var-file=dev.tfvars -out <STATE_ROOT>/team/dev/apply.tfplan
-terraform: apply requires typing the environment name (dev) to confirm before apply
+terraform: confirmation gate — the apply below runs only after you type the environment name "dev"; a mismatch or empty entry aborts before anything is applied
 cd <TMP> && terraform apply -input=false <STATE_ROOT>/team/dev/apply.tfplan

--- a/erun-integration/testdata/terraform/apply_dry_run_no_backend_warns.txt
+++ b/erun-integration/testdata/terraform/apply_dry_run_no_backend_warns.txt
@@ -3,10 +3,9 @@ terraform: apply in <TMP> (env team/dev, namespace team-dev)
 terraform: var file dev.tfvars
 terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
 terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
-terraform: baked .terraform.lock.hcl found — pinning providers with -lockfile=readonly
+terraform: warning: no `backend "local"` block in the tree — Terraform keeps state in ./terraform.tfstate inside the playbook tree, not on the PVC; add `backend "local" {}` so state persists to <STATE_ROOT>/team/dev/terraform.tfstate and apply works on a read-only tree
 mkdir -p <STATE_ROOT>/team/dev
-cd <TMP> && terraform init -input=false -backend-config=path=<STATE_ROOT>/team/dev/terraform.tfstate -lockfile=readonly
 cd <TMP> && terraform fmt -check -recursive ..
 cd <TMP> && terraform plan -input=false -var-file=dev.tfvars -out <STATE_ROOT>/team/dev/apply.tfplan
-terraform: apply requires typing the environment name (dev) to confirm before apply
+terraform: confirmation gate — the apply below runs only after you type the environment name "dev"; a mismatch or empty entry aborts before anything is applied
 cd <TMP> && terraform apply -input=false <STATE_ROOT>/team/dev/apply.tfplan

--- a/erun-integration/testdata/terraform/apply_dry_run_no_tfvars.txt
+++ b/erun-integration/testdata/terraform/apply_dry_run_no_tfvars.txt
@@ -4,8 +4,7 @@ terraform: no dev.tfvars found; planning without -var-file
 terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
 terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
 mkdir -p <STATE_ROOT>/team/dev
-cd <TMP> && terraform init -input=false -backend-config=path=<STATE_ROOT>/team/dev/terraform.tfstate
 cd <TMP> && terraform fmt -check -recursive ..
 cd <TMP> && terraform plan -input=false -out <STATE_ROOT>/team/dev/apply.tfplan
-terraform: apply requires typing the environment name (dev) to confirm before apply
+terraform: confirmation gate — the apply below runs only after you type the environment name "dev"; a mismatch or empty entry aborts before anything is applied
 cd <TMP> && terraform apply -input=false <STATE_ROOT>/team/dev/apply.tfplan

--- a/erun-integration/testdata/terraform/apply_dry_run_repo_path_env.txt
+++ b/erun-integration/testdata/terraform/apply_dry_run_repo_path_env.txt
@@ -4,8 +4,7 @@ terraform: var file dev.tfvars
 terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
 terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
 mkdir -p <STATE_ROOT>/team/dev
-cd <TMP> && terraform init -input=false -backend-config=path=<STATE_ROOT>/team/dev/terraform.tfstate
 cd <TMP> && terraform fmt -check -recursive ..
 cd <TMP> && terraform plan -input=false -var-file=dev.tfvars -out <STATE_ROOT>/team/dev/apply.tfplan
-terraform: apply requires typing the environment name (dev) to confirm before apply
+terraform: confirmation gate — the apply below runs only after you type the environment name "dev"; a mismatch or empty entry aborts before anything is applied
 cd <TMP> && terraform apply -input=false <STATE_ROOT>/team/dev/apply.tfplan

--- a/erun-integration/testdata/terraform/apply_dry_run_under_devops.txt
+++ b/erun-integration/testdata/terraform/apply_dry_run_under_devops.txt
@@ -5,8 +5,7 @@ terraform: var file dev.tfvars
 terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
 terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
 mkdir -p <STATE_ROOT>/team/dev
-cd <TMP> && terraform init -input=false -backend-config=path=<STATE_ROOT>/team/dev/terraform.tfstate
 cd <TMP> && terraform fmt -check -recursive ..
 cd <TMP> && terraform plan -input=false -var-file=dev.tfvars -out <STATE_ROOT>/team/dev/apply.tfplan
-terraform: apply requires typing the environment name (dev) to confirm before apply
+terraform: confirmation gate — the apply below runs only after you type the environment name "dev"; a mismatch or empty entry aborts before anything is applied
 cd <TMP> && terraform apply -input=false <STATE_ROOT>/team/dev/apply.tfplan

--- a/erun-integration/testdata/terraform/apply_dry_run_with_cloudflare_token.txt
+++ b/erun-integration/testdata/terraform/apply_dry_run_with_cloudflare_token.txt
@@ -5,8 +5,7 @@ terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the h
 terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
 terraform: injecting TF_VAR_cloudflare_api_token from CLOUDFLARE_API_TOKEN
 mkdir -p <STATE_ROOT>/team/dev
-cd <TMP> && terraform init -input=false -backend-config=path=<STATE_ROOT>/team/dev/terraform.tfstate
 cd <TMP> && terraform fmt -check -recursive ..
 cd <TMP> && terraform plan -input=false -var-file=dev.tfvars -out <STATE_ROOT>/team/dev/apply.tfplan
-terraform: apply requires typing the environment name (dev) to confirm before apply
+terraform: confirmation gate — the apply below runs only after you type the environment name "dev"; a mismatch or empty entry aborts before anything is applied
 cd <TMP> && terraform apply -input=false <STATE_ROOT>/team/dev/apply.tfplan

--- a/erun-integration/testdata/terraform/apply_real_run_via_stub.txt
+++ b/erun-integration/testdata/terraform/apply_real_run_via_stub.txt
@@ -4,4 +4,4 @@ terraform: apply in <TMP> (env team/dev, namespace team-dev)
 terraform: var file dev.tfvars
 terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
 terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
-terraform: apply requires typing the environment name (dev) to confirm before apply
+terraform: confirmation gate — the apply below runs only after you type the environment name "dev"; a mismatch or empty entry aborts before anything is applied

--- a/erun-integration/testdata/terraform/destroy_dry_run.txt
+++ b/erun-integration/testdata/terraform/destroy_dry_run.txt
@@ -4,7 +4,6 @@ terraform: var file dev.tfvars
 terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
 terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
 mkdir -p <STATE_ROOT>/team/dev
-cd <TMP> && terraform init -input=false -backend-config=path=<STATE_ROOT>/team/dev/terraform.tfstate
 cd <TMP> && terraform plan -destroy -input=false -var-file=dev.tfvars -out <STATE_ROOT>/team/dev/apply.tfplan
-terraform: destroy requires typing the environment name (dev) to confirm before apply
+terraform: confirmation gate — the destroy below runs only after you type the environment name "dev"; a mismatch or empty entry aborts before anything is applied
 cd <TMP> && terraform apply -input=false <STATE_ROOT>/team/dev/apply.tfplan

--- a/erun-integration/testdata/terraform/help.txt
+++ b/erun-integration/testdata/terraform/help.txt
@@ -1,6 +1,6 @@
 Run Terraform against a hosted platform's per-environment root (terraform-<tenant>/<environment>/, <tenant>-devops/terraform-<tenant>/<environment>/, or the paths.terraform base from .erun/config.yaml) without hand-running terraform or cd-ing into the folder.
 
-erun resolves the env's folder from the current scope, picks up the symlinked common.tf, and runs that env's main.tf with its <environment>.tfvars. State and the provider cache live on the durable home directory (not in the playbook tree), so they survive a runtime pod restart. Use a subcommand: `apply`, `plan`, or `destroy`.
+erun resolves the env's folder from the current scope, picks up the symlinked common.tf, and runs that env's main.tf with its <environment>.tfvars. State and the provider cache live on the durable home directory (not in the playbook tree), so they survive a runtime pod restart. Use a subcommand: run `init` once (and after changing providers) to download providers and record the lock, then `plan`, `apply`, or `destroy`.
 
 Usage:
   erun terraform [command]
@@ -8,6 +8,7 @@ Usage:
 Available Commands:
   apply       Plan and apply the env's Terraform (prompts for the environment name)
   destroy     Plan and apply a destroy of the env's Terraform (prompts for the environment name)
+  init        Initialize the env's Terraform: download providers, wire state, and record the provider lock
   plan        Show the env's Terraform plan without applying
 
 Flags:

--- a/erun-integration/testdata/terraform/help_apply.txt
+++ b/erun-integration/testdata/terraform/help_apply.txt
@@ -1,6 +1,6 @@
 Plan and apply the env's Terraform root.
 
-Resolves the env's Terraform root (terraform-<tenant>/<environment>/ or <tenant>-devops/terraform-<tenant>/<environment>/), runs init -> fmt -> plan, then prompts you to type the environment name before applying — a guard against applying to the wrong env. It mutates real cloud and cluster state (DNS, TLS, ingress, workloads); state is kept on the durable home directory. Pass --confirm-environment <env> for non-interactive use, or --dry-run to preview the resolved terraform commands.
+Resolves the env's Terraform root (terraform-<tenant>/<environment>/ or <tenant>-devops/terraform-<tenant>/<environment>/), runs fmt -> plan, then prompts you to type the environment name before applying — a guard against applying to the wrong env. Run `erun terraform init` first (once) so providers are available. It mutates real cloud and cluster state (DNS, TLS, ingress, workloads); state is kept on the durable home directory. Pass --confirm-environment <env> for non-interactive use, or --dry-run to preview the resolved terraform commands.
 
 Usage:
   erun terraform apply [TENANT] [ENVIRONMENT] [flags]

--- a/erun-integration/testdata/terraform/help_init.txt
+++ b/erun-integration/testdata/terraform/help_init.txt
@@ -1,0 +1,21 @@
+Initialize the env's Terraform root before plan/apply/destroy.
+
+Downloads providers into the durable home directory and points the local backend at the env's state file. On a writable checkout it generates .terraform.lock.hcl and records provider hashes for linux/amd64 and linux/arm64 (erun's deploy targets) — commit that lock so read-only runtime envs can initialize without rewriting their baked tree. On a tree that already has a committed lock it runs -lockfile=readonly and only refreshes the provider cache. Run this once, and again after changing providers; plan/apply/destroy no longer init implicitly.
+
+Usage:
+  erun terraform init [TENANT] [ENVIRONMENT] [flags]
+
+Examples:
+  erun terraform init frs local
+  erun terraform init frs prod --dry-run
+
+Flags:
+      --dry-run              Resolve and trace mutating actions without executing them.
+      --environment string   Target a specific environment (defaults to the tenant's default)
+  -h, --help                 help for init
+      --tenant string        Target a specific tenant (defaults to the current scope)
+
+Global Flags:
+      --output string   Result format: text (default, human stream) or json (structured result on stdout for orchestrators). (default "text")
+      --time            Print the elapsed runtime after the command finishes.
+  -v, --verbose count   Increase verbosity: -v streams external tool output, -vv adds erun command traces.

--- a/erun-integration/testdata/terraform/init_dry_run.txt
+++ b/erun-integration/testdata/terraform/init_dry_run.txt
@@ -1,0 +1,8 @@
+audit: erun terraform init --dry-run team dev
+terraform: init in <TMP> (env team/dev, namespace team-dev)
+terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
+terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
+terraform: no .terraform.lock.hcl yet — init will generate it and record provider hashes for linux_amd64, linux_arm64; commit it so read-only envs can init with -lockfile=readonly
+mkdir -p <STATE_ROOT>/team/dev
+cd <TMP> && terraform init -input=false -backend-config=path=<STATE_ROOT>/team/dev/terraform.tfstate
+cd <TMP> && terraform providers lock -platform=linux_amd64 -platform=linux_arm64

--- a/erun-integration/testdata/terraform/init_dry_run_lockfile_readonly.txt
+++ b/erun-integration/testdata/terraform/init_dry_run_lockfile_readonly.txt
@@ -1,0 +1,7 @@
+audit: erun terraform init --dry-run team dev
+terraform: init in <TMP> (env team/dev, namespace team-dev)
+terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
+terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
+terraform: committed .terraform.lock.hcl found — init runs -lockfile=readonly and never rewrites the tree
+mkdir -p <STATE_ROOT>/team/dev
+cd <TMP> && terraform init -input=false -backend-config=path=<STATE_ROOT>/team/dev/terraform.tfstate -lockfile=readonly

--- a/erun-integration/testdata/terraform/init_real_run_via_stub.txt
+++ b/erun-integration/testdata/terraform/init_real_run_via_stub.txt
@@ -1,0 +1,6 @@
+terraform init complete in <TMP>
+audit: erun terraform init team dev
+terraform: init in <TMP> (env team/dev, namespace team-dev)
+terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
+terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
+terraform: no .terraform.lock.hcl yet — init will generate it and record provider hashes for linux_amd64, linux_arm64; commit it so read-only envs can init with -lockfile=readonly

--- a/erun-integration/testdata/terraform/plan_dry_run.txt
+++ b/erun-integration/testdata/terraform/plan_dry_run.txt
@@ -4,5 +4,4 @@ terraform: var file dev.tfvars
 terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
 terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
 mkdir -p <STATE_ROOT>/team/dev
-cd <TMP> && terraform init -input=false -backend-config=path=<STATE_ROOT>/team/dev/terraform.tfstate
 cd <TMP> && terraform plan -input=false -var-file=dev.tfvars

--- a/erun-integration/testdata/terraform/plan_dry_run_configured_path.txt
+++ b/erun-integration/testdata/terraform/plan_dry_run_configured_path.txt
@@ -5,5 +5,4 @@ terraform: var file dev.tfvars
 terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
 terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
 mkdir -p <STATE_ROOT>/team/dev
-cd <TMP> && terraform init -input=false -backend-config=path=<STATE_ROOT>/team/dev/terraform.tfstate
 cd <TMP> && terraform plan -input=false -var-file=dev.tfvars

--- a/erun-mcp/terraform.go
+++ b/erun-mcp/terraform.go
@@ -10,7 +10,7 @@ import (
 )
 
 type TerraformInput struct {
-	Operation   string   `json:"operation" jsonschema:"required terraform operation: apply (init/fmt/plan/apply), plan (read-only), or destroy"`
+	Operation   string   `json:"operation" jsonschema:"required terraform operation: init (download providers, wire state, record the provider lock — run once before the others), apply (fmt/plan/apply), plan (read-only), or destroy"`
 	Tenant      string   `json:"tenant,omitempty" jsonschema:"tenant name; defaults to the MCP runtime context tenant"`
 	Environment string   `json:"environment,omitempty" jsonschema:"environment name; defaults to the MCP runtime context environment"`
 	ProjectRoot string   `json:"projectRoot,omitempty" jsonschema:"project root holding terraform-<tenant>/ or <tenant>-devops/terraform-<tenant>/ (or the paths.terraform base from .erun/config.yaml); defaults to the runtime repo path"`

--- a/erun-skills/skills/erun-blueprint-platform/SKILL.md
+++ b/erun-skills/skills/erun-blueprint-platform/SKILL.md
@@ -122,6 +122,11 @@ There is **no `run.tf`** and **no per-env `apply.sh`/`setup.sh`/`confirm.sh`** �
 ```hcl
 terraform {
   required_version = ">= 1.3"
+  # Required so `erun terraform init -backend-config=path=` persists the state
+  # location to plan/apply. erun points it at ~/.erun/terraform/<tenant>/<env>/
+  # on the durable home PVC; without this block Terraform silently keeps state in
+  # ./terraform.tfstate inside the (read-only) playbook tree and apply fails there.
+  backend "local" {}
   required_providers {
     kubernetes = { source = "hashicorp/kubernetes", version = "~> 2.30" }
     helm       = { source = "hashicorp/helm", version = "~> 2.17" }
@@ -134,6 +139,8 @@ provider "helm" {
   kubernetes {}
 }
 ```
+
+Run `erun terraform init <tenant> <env>` once on a **writable** checkout (e.g. `<tenant>-local`) after scaffolding: it downloads providers and generates `.terraform.lock.hcl` covering `linux/amd64` + `linux/arm64`. **Commit that lock** — a read-only runtime env can only `init` from a committed lock (it runs `-lockfile=readonly`), and one cross-arch lock initializes on any env. Re-run `init` and re-commit after changing providers.
 
 **`terraform-acme/variables.tf`** (canonical; symlinked into each env). The
 Cloudflare token is **not** a tfvar — it is a secret injected at apply time as
@@ -354,16 +361,18 @@ dependency `version` is pinned to the erun release from Step 1.
 The operator applies these in the runtime env, never by hand-running `terraform`
 or `kubectl`:
 
-- **Terraform:** `erun terraform apply` resolves `terraform-<tenant>/<env>/`
-  (or `<tenant>-devops/terraform-<tenant>/<env>/` — the same `-devops` convention
-  `build`/`deploy` use, so a tree baked under `<tenant>-devops/` needs no
-  `paths.terraform` override) from the active cloud context and runs
-  `init → fmt → plan → confirm → apply`, injecting `TF_VAR_cloudflare_api_token`
-  from `CLOUDFLARE_API_TOKEN`. State and the provider cache live on the durable
-  home directory (`~/.erun/terraform/<tenant>/<env>/` on the `/home/erun` PVC),
-  off the read-only playbook tree, so they survive a pod restart. The confirm
-  step prompts the operator to **type the environment name** before applying, so
-  changes can't land in the wrong env. Preview with
+- **Terraform:** `erun terraform init` once (downloads providers, records the
+  committed cross-arch lock), then `erun terraform apply` resolves
+  `terraform-<tenant>/<env>/` (or `<tenant>-devops/terraform-<tenant>/<env>/` — the
+  same `-devops` convention `build`/`deploy` use, so a tree baked under
+  `<tenant>-devops/` needs no `paths.terraform` override) from the active cloud
+  context and runs `fmt → plan → confirm → apply` (no implicit init), injecting
+  `TF_VAR_cloudflare_api_token` from `CLOUDFLARE_API_TOKEN`. State and the provider
+  cache live on the durable home directory (`~/.erun/terraform/<tenant>/<env>/` on
+  the `/home/erun` PVC), off the read-only playbook tree, so they survive a pod
+  restart — this relies on the `backend "local" {}` block in `common.tf`. The
+  confirm step prompts the operator to **type the environment name** before
+  applying, so changes can't land in the wrong env. Preview with
   `erun terraform apply --dry-run`.
 - **Helm:** `erun deploy --version <version> --components=…` (with the `values.<env>.yaml`
   overlay), then the `erun-enable-hosting-edge` skill / `erun terraform apply`


### PR DESCRIPTION
## Problem

`erun terraform apply` on a sourceless runtime env (frs-prod) died during `terraform init`:

```
Error while writing new dependency lock information to .terraform.lock.hcl:
cannot create temporary file to update .terraform.lock.hcl: ... permission denied.
```

`~/git/<tenant>` on such an env is a symlink into the **read-only, root-owned image layer** (`/opt/erun/release`, via `release-link.sh`), so the `erun` user (UID 1000) can't write there. Two things forced writes into that tree:

1. **The lock file.** `terraform init` always writes `.terraform.lock.hcl` next to `main.tf` — Terraform has no flag to relocate it (`-lockfile` takes a *mode*, not a path; `TF_DATA_DIR` only moves `.terraform/`). The only guard, `-lockfile=readonly`, needs a lock that already exists.
2. **The state file (latent #796 bug).** `-backend-config=path=<PVC>` does **nothing durable without a `backend "local" {}` block** — Terraform warns *"Missing backend configuration"* and `plan`/`apply` fall back to `./terraform.tfstate` inside the tree. This stayed hidden because `init` failed first; fixing `init` exposed it (apply then dies acquiring the state lock).

## Changes

- **New `erun terraform init` command** (CLI + MCP). On a writable checkout it generates `.terraform.lock.hcl` and records hashes for `linux/amd64` + `linux/arm64` (via `terraform providers lock`), so one committed lock initializes on any env's architecture. On a tree with a committed lock it runs `-lockfile=readonly` and only refreshes the PVC provider cache.
- **Removed implicit `init` from `apply`/`plan`/`destroy`** — they are now `fmt→plan→confirm→apply`, `plan`, and `plan -destroy→confirm→apply`. `init` is run once (and after changing providers), matching how you run Terraform by hand.
- **Actionable error** when a lock-generating `init` hits a read-only tree, instead of a raw permission-denied.
- **State relocation fix:** the `erun-blueprint-platform` skill now scaffolds a `backend "local" {}` block in `common.tf`, and erun **warns** when a tree has no backend block (so state silently landing in the read-only tree is caught before apply fails).
- **Confirm-gate trace** reworded so a `--dry-run` preview reads as a real gate.

### Design note (state relocation)

I picked the **committed `backend "local" {}` block** over threading central `-state`/`-state-out` flags through erun. Rationale: frs-prod needs a tenant-repo change regardless (a committed cross-arch lock is unavoidable for read-only `init`), so the backend block rides along in that same commit; it's idiomatic Terraform with no deprecation warning; and erun's existing `init -backend-config=path=` already works with it. The `-state`-flags alternative would be fully central (no tenant change) but uses Terraform's legacy state flags. Happy to switch to that if preferred.

### On the confirm "bug"

The interactive confirm was investigated with the real binary: it **does** prompt, verify, and abort on a wrong/empty value. What was observed on frs-prod was `init` failing first (the gate is the last step, never reached) plus the `-vvvv` preview listing the `apply` command up front. Runtime behavior is unchanged; only the trace wording is clearer.

## Validation

- `go test ./...` green in `erun-common`, `erun-cli`, `erun-mcp`.
- `make lint` clean; `make integration-test` green (coverage 75.7% ≥ 75.0%); `erun-docs` `yarn build` clean.
- **End-to-end with real terraform on a read-only tree:** `init` runs `-lockfile=readonly` and completes; `apply` prompts, verifies `prod`, and completes (`local_file` resource created); state lands on the PVC; the tree is never written.

## Follow-up for frs-prod

To pick this up, the frs repo needs (once) a committed cross-arch `.terraform.lock.hcl` (generate via `erun terraform init` on frs-local) and a `backend "local" {}` block in `common.tf`, then a rebuild/redeploy.

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)