### PR TITLE
Fix erun deploy silently dropping cloudflare/mcpAuth/registry/platform values

### DIFF
--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -95,49 +95,16 @@ type KubernetesDeployContext struct {
 	ChartPath     string
 }
 
+// HelmDeployParams is the execution view of a resolved deploy: the full
+// HelmDeploySpec (the single source of truth for the helm command) plus the
+// output writers the rollout wires. It embeds the spec rather than copying a
+// hand-maintained field list — a copy list silently dropped
+// Cloudflare/MCP-auth/registry/platform values from real deploys while the
+// traced command (built from the full spec) still showed them.
 type HelmDeployParams struct {
-	ReleaseName          string
-	ChartPath            string
-	ValuesFilePath       string
-	PulledValuesFilePath string
-	SubchartKey          string
-	Tenant               string
-	Environment          string
-	Namespace            string
-	KubernetesContext    string
-	WorktreeStorage      string
-	WorktreeRepoName     string
-	WorktreeHostPath     string
-	// RepoURL / RepoRef drive the runtime pod's clone-at-boot of a mutable
-	// source worktree for a runtime env that opted into MountSource. RepoRef is
-	// the release tag (v<version>) the checkout starts from. Both empty for
-	// every other env.
-	RepoURL            string
-	RepoRef            string
-	SSHDEnabled        bool
-	MCPPort            int
-	APIPort            int
-	SSHPort            int
-	ManagedCloud       bool
-	CloudContextName   string
-	CloudProvider      string
-	CloudProviderAlias string
-	CloudRegion        string
-	CloudInstanceID    string
-	UseHostCredentials bool
-	OIDCAllowedIssuers string
-	ContainerRegistry  string
-	ImageOverrides     map[string]string
-	ImagePullSecrets   []string
-	ResetDatabase      bool
-	Idle               EnvironmentIdleConfig
-	Claude             EnvironmentClaudeConfig
-	RuntimePod         RuntimePodResources
-	Version            string
-	Timeout            string
-	Verbosity          int
-	Stdout             io.Writer
-	Stderr             io.Writer
+	HelmDeploySpec
+	Stdout io.Writer
+	Stderr io.Writer
 }
 
 type HelmDeploySpec struct {
@@ -1788,47 +1755,11 @@ func resolveWorktreeHostPath(repoPath string) string {
 	return resolved
 }
 
+// Params pairs the full deploy spec with the rollout's output writers. The whole
+// spec rides along, so the executed command (built from it in helmDeployCommandSpec)
+// stays identical to the traced one — no field can be dropped in transit.
 func (d HelmDeploySpec) Params(stdout, stderr io.Writer) HelmDeployParams {
-	return HelmDeployParams{
-		ReleaseName:          d.ReleaseName,
-		ChartPath:            d.ChartPath,
-		ValuesFilePath:       d.ValuesFilePath,
-		PulledValuesFilePath: d.PulledValuesFilePath,
-		SubchartKey:          d.SubchartKey,
-		Tenant:               d.Tenant,
-		Environment:          d.Environment,
-		Namespace:            d.Namespace,
-		KubernetesContext:    d.KubernetesContext,
-		WorktreeStorage:      d.WorktreeStorage,
-		WorktreeRepoName:     d.WorktreeRepoName,
-		WorktreeHostPath:     d.WorktreeHostPath,
-		RepoURL:              d.RepoURL,
-		RepoRef:              d.RepoRef,
-		SSHDEnabled:          d.SSHDEnabled,
-		MCPPort:              d.MCPPort,
-		APIPort:              d.APIPort,
-		SSHPort:              d.SSHPort,
-		ManagedCloud:         d.ManagedCloud,
-		CloudContextName:     d.CloudContextName,
-		CloudProvider:        d.CloudProvider,
-		CloudProviderAlias:   d.CloudProviderAlias,
-		CloudRegion:          d.CloudRegion,
-		CloudInstanceID:      d.CloudInstanceID,
-		UseHostCredentials:   d.UseHostCredentials,
-		OIDCAllowedIssuers:   d.OIDCAllowedIssuers,
-		ContainerRegistry:    d.ContainerRegistry,
-		ImageOverrides:       cloneStringMap(d.ImageOverrides),
-		ImagePullSecrets:     append([]string(nil), d.ImagePullSecrets...),
-		ResetDatabase:        d.ResetDatabase,
-		Idle:                 d.Idle,
-		Claude:               d.Claude,
-		RuntimePod:           NormalizeRuntimePodResources(d.RuntimePod),
-		Version:              d.Version,
-		Timeout:              d.Timeout,
-		Verbosity:            d.Verbosity,
-		Stdout:               stdout,
-		Stderr:               stderr,
-	}
+	return HelmDeployParams{HelmDeploySpec: d, Stdout: stdout, Stderr: stderr}
 }
 
 func (d HelmDeploySpec) command() commandSpec {
@@ -2101,17 +2032,6 @@ func formatHelmPort(value, fallback int) string {
 
 func formatHelmInt64(value int64) string {
 	return fmt.Sprintf("%d", value)
-}
-
-func cloneStringMap(values map[string]string) map[string]string {
-	if len(values) == 0 {
-		return nil
-	}
-	clone := make(map[string]string, len(values))
-	for key, value := range values {
-		clone[key] = value
-	}
-	return clone
 }
 
 func sortedStringMapKeys(values map[string]string) []string {
@@ -2606,44 +2526,12 @@ func resolveHelmDeployChartPath(params HelmDeployParams) (string, func(), error)
 }
 
 func helmDeployCommandSpec(params HelmDeployParams, chartPath string) commandSpec {
-	return HelmDeploySpec{
-		ReleaseName:          params.ReleaseName,
-		ChartPath:            chartPath,
-		ValuesFilePath:       params.ValuesFilePath,
-		PulledValuesFilePath: params.PulledValuesFilePath,
-		SubchartKey:          params.SubchartKey,
-		Tenant:               params.Tenant,
-		Environment:          params.Environment,
-		Namespace:            params.Namespace,
-		KubernetesContext:    params.KubernetesContext,
-		WorktreeStorage:      params.WorktreeStorage,
-		WorktreeRepoName:     params.WorktreeRepoName,
-		WorktreeHostPath:     params.WorktreeHostPath,
-		RepoURL:              params.RepoURL,
-		RepoRef:              params.RepoRef,
-		SSHDEnabled:          params.SSHDEnabled,
-		MCPPort:              params.MCPPort,
-		APIPort:              params.APIPort,
-		SSHPort:              params.SSHPort,
-		ManagedCloud:         params.ManagedCloud,
-		CloudContextName:     params.CloudContextName,
-		CloudProvider:        params.CloudProvider,
-		CloudProviderAlias:   params.CloudProviderAlias,
-		CloudRegion:          params.CloudRegion,
-		CloudInstanceID:      params.CloudInstanceID,
-		UseHostCredentials:   params.UseHostCredentials,
-		OIDCAllowedIssuers:   params.OIDCAllowedIssuers,
-		ContainerRegistry:    params.ContainerRegistry,
-		ImageOverrides:       cloneStringMap(params.ImageOverrides),
-		ImagePullSecrets:     append([]string(nil), params.ImagePullSecrets...),
-		ResetDatabase:        params.ResetDatabase,
-		Idle:                 params.Idle,
-		Claude:               params.Claude,
-		RuntimePod:           params.RuntimePod,
-		Version:              params.Version,
-		Timeout:              params.Timeout,
-		Verbosity:            params.Verbosity,
-	}.command()
+	// The embedded spec is the traced spec verbatim; only the resolved chart path
+	// differs (a local umbrella unpacks to a temp dir). Building the command from
+	// it guarantees the executed helm command matches what RunHelmDeploy traced.
+	spec := params.HelmDeploySpec
+	spec.ChartPath = chartPath
+	return spec.command()
 }
 
 // configureHelmDeployCmdOutput wires the command's stdout/stderr and returns

--- a/erun-common/deploy_command_roundtrip_test.go
+++ b/erun-common/deploy_command_roundtrip_test.go
@@ -1,0 +1,67 @@
+package eruncommon
+
+import (
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestHelmDeployParamsPreservesCommand locks the invariant that the helm command
+// erun executes (built from HelmDeployParams via helmDeployCommandSpec) is
+// identical to the command it traces (HelmDeploySpec.command()). The two used to
+// be built from separate hand-maintained field lists, so a field present in the
+// spec but missing from the copy list was silently dropped from real deploys
+// while the trace still showed it — that dropped Cloudflare, MCP-auth, the
+// runtime registry, extra container registries, and platform config. A spec
+// populated with exactly those fields must round-trip losslessly.
+func TestHelmDeployParamsPreservesCommand(t *testing.T) {
+	spec := HelmDeploySpec{
+		ReleaseName:       "frs-devops",
+		ChartPath:         "oci://ghcr.io/sophium/charts/frs-devops",
+		SubchartKey:       "erun-devops",
+		Tenant:            "frs",
+		Environment:       "prod",
+		Namespace:         "frs-prod",
+		KubernetesContext: "erun",
+		Version:           "1.0.29",
+		Timeout:           "5m0s",
+		ContainerRegistry: "ghcr.io/sophium",
+		ImageOverrides:    map[string]string{"erun-devops": "ghcr.io/sophium/frs-devops:1.0.29"},
+		// The fields the old copy-list dropped in transit — the crux of the bug.
+		CloudflareEnabled:    true,
+		CloudflareAccountID:  "5688accc2b055ae8babb811a5da8b8e4",
+		CloudflareSecretName: "frs-devops-cloudflare",
+		CloudflareTokenRef:   "cloudflare/frs-alias",
+		MCPAuthEnabled:       true,
+		MCPAuthSecretName:    "frs-devops-mcp-auth",
+		MCPAuthIssuer:        "file:///etc/erun/mcp-auth/desktopid.pub",
+		MCPAuthAudience:      "erun-mcp:frs/prod",
+		RuntimeRegistry:      "ghcr.io/sophium",
+		ContainerRegistries:  ContainerRegistries{{Registry: "ghcr.io/sophium", Roles: []RegistryRole{"deploy"}}},
+		DisableBuildScript:   true,
+		Platform:             PlatformConfig{BaseDomain: "erunpaas.com", Env: "frs-prod", ServicesZone: "frs.erunpaas.com"},
+	}
+
+	traced := spec.command()
+	executed := helmDeployCommandSpec(spec.Params(io.Discard, io.Discard), spec.ChartPath)
+
+	if !reflect.DeepEqual(traced.Args, executed.Args) {
+		t.Fatalf("executed helm command diverges from the traced command (a field was dropped in the Params round-trip):\n  traced:   %v\n  executed: %v", traced.Args, executed.Args)
+	}
+
+	// DeepEqual alone would pass if both paths dropped the same field, so assert
+	// the previously-dropped values are actually present in the executed command.
+	joined := strings.Join(executed.Args, " ")
+	for _, want := range []string{
+		"cloudContext.cloudflare.enabled=true",
+		"cloudContext.cloudflare.secretName=frs-devops-cloudflare",
+		"mcpAuth.enabled=true",
+		"runtimeRegistry=ghcr.io/sophium",
+		"containerRegistries=",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("executed command missing %q; got %v", want, executed.Args)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

A real `erun deploy` of an env with a Cloudflare alias (frs/prod) created the `<release>-cloudflare` Secret but wired **no** `CLOUDFLARE_API_TOKEN` into the runtime Deployment, so in-pod `erun terraform apply` failed with `No value for required variable "cloudflare_api_token"`. The `-vvvv` trace showed the correct `--set …cloudflare.enabled=true`, and `helm upgrade --dry-run=server` with that exact command rendered the block — but the applied release had none. The same silently disabled `--mcp-auth-public-key` (secret created, edge auth never wired).

## Root cause

erun **traces** the helm command from the full `HelmDeploySpec` (`RunHelmDeploy` → `HelmDeploySpec.command()`) but **executes** it through a round-trip: `HelmDeploySpec.Params()` → `HelmDeployParams` → `helmDeployCommandSpec()` rebuilds a `HelmDeploySpec` → `.command()`. Both `Params()` and the rebuild were hand-maintained field lists, and `HelmDeployParams` didn't carry these fields at all, so both dropped:

- `CloudflareEnabled / AccountID / TokenRef / SecretName`
- `MCPAuthEnabled / SecretName / Issuer / Audience`
- `RuntimeRegistry`, `ContainerRegistries`, `DisableBuildScript`, `Platform`

So the traced/`--dry-run` command included these `--set`s but the **executed** command omitted them — a dry-run-contract violation that silently broke Cloudflare, MCP auth, the runtime registry, extra container registries, and PowerDNS platform config on every real deploy that used them.

## Fix

Embed `HelmDeploySpec` in `HelmDeployParams` so there is a single source of truth. `Params()` pairs the whole spec with the rollout's output writers; `helmDeployCommandSpec()` builds the command from the embedded spec (only `ChartPath` differs). No second field list can fall out of sync. Removed the now-unused `cloneStringMap`.

## Testing

- **New `TestHelmDeployParamsPreservesCommand`** asserts the executed command equals the traced command for a fully-populated spec. Verified it **fails against the pre-fix code** ("a field was dropped in the Params round-trip") and **passes after** — it guards the whole class, not just cloudflare. (The existing real-run deploy scenarios couldn't catch this: their stub `helm` doesn't capture argv.)
- `go test ./...` green in `erun-common`, `erun-cli`, `erun-mcp`; `make lint` clean (all modules); `make integration-test` green (coverage 75.7% ≥ 75.0%); pre-commit hook clean across every module including `erun-ui`.
- No golden changes: the fix alters only the *executed* helm argv (which goldens don't capture); dry-run traces (built from the full spec) were always correct.

## End-to-end

Live verification = deploying the fixed binary to frs/prod and confirming the pod carries `CLOUDFLARE_API_TOKEN` (which also unblocks `erun terraform apply` there). That rolls the prod pod, so it's pending operator go-ahead; the fix is otherwise proven by the fail-before/pass-after unit test.

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)