### PR TITLE
Desktop: add a Platform account toggle to the env Runtime tab

### DIFF
--- a/erun-ui/environment_config.go
+++ b/erun-ui/environment_config.go
@@ -321,6 +321,7 @@ func (a *App) environmentConfigToUI(tenant string, config eruncommon.EnvConfig, 
 		AutoUpgrade:        config.AutoUpgrade,
 		UpgradeChannel:     config.ResolvedUpgradeChannel(),
 		DisableBuildScript: config.DisableBuildScript,
+		PlatformAccount:    config.PlatformAccount,
 		MountSource:        config.MountSource,
 		RepoURL:            strings.TrimSpace(config.RepoURL),
 		DeployComponents:   append([]string(nil), config.Deploy.Components...),
@@ -559,6 +560,7 @@ func environmentConfigFromUI(config uiEnvironmentConfig, existing eruncommon.Env
 	existing.AutoStart = copyBoolPtr(config.AutoStart)
 	existing.AutoUpgrade = config.AutoUpgrade
 	existing.DisableBuildScript = config.DisableBuildScript
+	existing.PlatformAccount = config.PlatformAccount
 	existing.MountSource = config.MountSource
 	existing.RepoURL = strings.TrimSpace(config.RepoURL)
 	// Preserve the sibling deploy.timeout; only the saved component selection is

--- a/erun-ui/frontend/src/app/manageDialogHelpers.ts
+++ b/erun-ui/frontend/src/app/manageDialogHelpers.ts
@@ -69,6 +69,9 @@ function deployRelevantSignature(config: UIEnvironmentConfig): string {
     localRepoPath: config.localRepoPath,
     containerRegistries: config.containerRegistries,
     disableBuildScript: config.disableBuildScript,
+    // Platform account flips the runtime SA's cluster RBAC (a <release>-platform
+    // ClusterRoleBinding to cluster-admin), which the next deploy renders/prunes.
+    platformAccount: config.platformAccount,
     // Mounting source flips a runtime env's worktree onto a PVC and makes the pod
     // clone repoURL at the release ref, so both change what a redeploy provisions.
     mountSource: config.mountSource,
@@ -117,6 +120,7 @@ export function manageDialogTabHasUnsavedChanges(
         'autoUpgrade',
         'upgradeChannel',
         'disableBuildScript',
+        'platformAccount',
         'mountSource',
         'repoURL',
       );

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -416,6 +416,7 @@ export const defaultEnvironmentConfig = (): UIEnvironmentConfig => ({
   autoUpgrade: false,
   upgradeChannel: 'stable',
   disableBuildScript: false,
+  platformAccount: false,
   mountSource: false,
   repoURL: '',
 });

--- a/erun-ui/frontend/src/components/app/ManageDialogRuntimeTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogRuntimeTab.tsx
@@ -200,8 +200,32 @@ function IdleStopFields({ dialog }: { dialog: ManageDialog }): React.ReactElemen
           dispatch(updateManageConfig({ disableBuildScript }));
         }}
       />
+      <PlatformAccountField dialog={dialog} />
       <MountSourceFields dialog={dialog} />
     </div>
+  );
+}
+
+// PlatformAccountField renders the opt-in that binds this env's runtime
+// ServiceAccount to cluster-admin, so in-pod platform Terraform (the cluster
+// edge) and component installs can create cluster-scoped resources. Env-type
+// agnostic — a hosted runtime platform env or a cluster-provisioning agent env
+// can both be a platform account — so it renders for every type. Extracted to
+// keep IdleStopFields within its size/complexity budget.
+function PlatformAccountField({ dialog }: { dialog: ManageDialog }): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const config = dialog.config;
+  return (
+    <CheckboxField
+      id="environment-config-platformaccount"
+      label="Platform account"
+      helper="Bind this environment's runtime ServiceAccount to cluster-admin so in-pod platform Terraform (the cluster edge) and component installs can create cluster-scoped resources — namespaces, CRDs, cluster RBAC. Off by default; the first deploy that grants it must run from a cluster-admin context."
+      checked={config.platformAccount}
+      disabled={dialog.busy || dialog.configLoading}
+      onChange={(platformAccount) => {
+        dispatch(updateManageConfig({ platformAccount }));
+      }}
+    />
   );
 }
 

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -452,6 +452,11 @@ export interface UIEnvironmentConfig {
   // images directly. Changes how a redeploy rebuilds the runtime image, so
   // saving it raises the pending-redeploy banner.
   disableBuildScript: boolean;
+  // platformAccount binds the env's runtime ServiceAccount to cluster-admin so
+  // in-pod platform Terraform (the cluster edge) and component installs can
+  // manage cluster-scoped resources. Changing it changes the RBAC a redeploy
+  // renders, so saving raises the pending-redeploy banner.
+  platformAccount: boolean;
   // mountSource opts a runtime env into a writable source worktree the pod clones
   // at the deployed release ref; repoURL is the git remote it clones. Runtime
   // envs only, and a no-op without repoURL. Changing either alters what a

--- a/erun-ui/playwright/pages/ManageDialog.ts
+++ b/erun-ui/playwright/pages/ManageDialog.ts
@@ -58,6 +58,12 @@ export class ManageDialog {
     return this.locator().locator('#environment-config-disablebuildscript');
   }
 
+  // The "Platform account" toggle binds the env's runtime SA to cluster-admin;
+  // env-type agnostic, so it renders for every environment type.
+  platformAccountCheckbox(): Locator {
+    return this.locator().locator('#environment-config-platformaccount');
+  }
+
   // The runtime-only "Mount source code" toggle and the git remote it reveals.
   // The URL field is rendered only while the toggle is on.
   mountSourceCheckbox(): Locator {

--- a/erun-ui/playwright/tests/manage-platform-account.spec.ts
+++ b/erun-ui/playwright/tests/manage-platform-account.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '../fixtures/erunApp.js';
+
+// The Manage dialog Runtime tab's "Platform account" toggle binds the env's
+// runtime ServiceAccount to cluster-admin so in-pod platform Terraform (the
+// cluster edge) and component installs can manage cluster-scoped resources.
+// It is deploy-relevant (saving raises the Pending-redeploy banner) and — unlike
+// the runtime-only Mount source toggle — renders for every environment type.
+test.describe('manage dialog platform-account toggle (#804)', () => {
+  test('toggles, raises the redeploy banner, and persists on a runtime env', async ({
+    app,
+    seededRuntimeEnv,
+  }) => {
+    await app.sidebar.openManageDialogViaKeyboard(
+      seededRuntimeEnv.tenant,
+      seededRuntimeEnv.environment,
+    );
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('Runtime');
+
+    const toggle = app.manageDialog.platformAccountCheckbox();
+    await expect(toggle).toBeVisible();
+    await expect(toggle).not.toBeChecked();
+    expect(await app.manageDialog.tabHasUnsavedChanges('Runtime')).toBe(false);
+
+    await toggle.click();
+    await expect(toggle).toBeChecked();
+    await expect.poll(() => app.manageDialog.tabHasUnsavedChanges('Runtime')).toBe(true);
+
+    await app.manageDialog.save();
+    await expect.poll(() => app.manageDialog.tabHasUnsavedChanges('Runtime')).toBe(false);
+    // Deploy-relevant change → the pending-redeploy banner tells the operator the
+    // grant takes effect on the next deploy (visibility of system status).
+    await expect(app.manageDialog.redeployBanner()).toBeVisible();
+
+    // Reopen: the grant persisted to the env config.
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+    await app.sidebar.openManageDialogViaKeyboard(
+      seededRuntimeEnv.tenant,
+      seededRuntimeEnv.environment,
+    );
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('Runtime');
+    await expect(app.manageDialog.platformAccountCheckbox()).toBeChecked();
+
+    // Turning it back off persists too (reconciles both ways).
+    await app.manageDialog.platformAccountCheckbox().click();
+    await expect(app.manageDialog.platformAccountCheckbox()).not.toBeChecked();
+    await app.manageDialog.save();
+    await expect.poll(() => app.manageDialog.tabHasUnsavedChanges('Runtime')).toBe(false);
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+    await app.sidebar.openManageDialogViaKeyboard(
+      seededRuntimeEnv.tenant,
+      seededRuntimeEnv.environment,
+    );
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('Runtime');
+    await expect(app.manageDialog.platformAccountCheckbox()).not.toBeChecked();
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+
+  test('renders for a non-runtime (agent) env too', async ({ app, seededEnv }) => {
+    // The grant is env-type agnostic, so — unlike Mount source, which is
+    // runtime-only — the toggle must render on an agent env's Runtime tab.
+    await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('Runtime');
+
+    await expect(app.manageDialog.platformAccountCheckbox()).toBeVisible();
+    // Sanity: the runtime-only Mount source toggle is absent here, confirming the
+    // platform-account toggle's presence is not just "all runtime controls show".
+    await expect(app.manageDialog.mountSourceCheckbox()).toHaveCount(0);
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+});

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -263,6 +263,10 @@ type uiEnvironmentConfig struct {
 	AutoUpgrade           bool                       `json:"autoUpgrade"`
 	UpgradeChannel        string                     `json:"upgradeChannel,omitempty"`
 	DisableBuildScript    bool                       `json:"disableBuildScript"`
+	// PlatformAccount binds the env's runtime ServiceAccount to cluster-admin so
+	// in-pod platform Terraform (the cluster edge) and component installs can
+	// manage cluster-scoped resources. See EnvConfig.PlatformAccount.
+	PlatformAccount bool `json:"platformAccount"`
 	// MountSource opts a runtime env into a mutable source worktree the pod clones
 	// at the deployed release ref; RepoURL is the git remote it clones. Runtime
 	// envs only, and a no-op without RepoURL. See EnvConfig.MountsRuntimeSource.


### PR DESCRIPTION
Follow-up to #801/#803. The `platformaccount` env option — binds the runtime ServiceAccount to `cluster-admin` so in-pod platform Terraform (the cluster edge) and component installs can manage cluster-scoped resources — was settable only via `erun init --platform-account`, the config field, and the MCP init param. There was **no desktop control**, so an operator on the Runtime tab couldn't flip it (this is exactly what a user hit).

## Change

A **"Platform account"** checkbox on the Manage dialog's Runtime tab, wired end-to-end:
- `ui_model.go` — `platformAccount` on the desktop EnvConfig input struct
- `environment_config.go` — the read (EnvConfig→UI) and write (UI→EnvConfig) mappings
- `types.ts` / `state.ts` — the frontend type + default
- `manageDialogHelpers.ts` — change tracking: `deployRelevantSignature` (so saving raises the pending-redeploy banner) and the Runtime-tab unsaved-changes list
- `ManageDialogRuntimeTab.tsx` — a `PlatformAccountField` (extracted like `MountSourceFields` to respect the function-size budget)
- Wails bindings regenerated for the new field (gitignored; regenerated at build)

Rendered for **every env type** (unlike the runtime-only Mount source toggle) because the grant is env-type agnostic — a hosted runtime platform env or a cluster-provisioning agent env can both be a platform account.

## UX Impact Review (`erun-ui/AGENTS.md`)

1. **Affected paths:** Runtime tab → "Platform account" checkbox → `updateManageConfig` → `SaveEnvironmentConfig` → `EnvConfig.platformaccount`; plus the `LoadEnvironmentConfig` read path.
2. **User-visible sequence:** open Manage → Runtime tab shows the checkbox (off by default) with helper text → toggle on → Runtime tab shows unsaved changes → Save → pending-redeploy banner appears → reopen shows it checked.
3. **State-without-affordance:** the toggle maps to `config.platformAccount` (checked state) + the unsaved-changes indicator + the pending-redeploy banner. No orphan mutations.
4. **Visibility of system status (Nielsen #1):** `platformAccount` is deploy-relevant, so saving raises the existing pending-redeploy banner — the grant takes effect on the next deploy.
5. **Success/failure feedback:** save clears the unsaved indicator + shows the banner; failures use the dialog's existing error path.
6. **Consistency (Nielsen #4):** matches sibling `disableBuildScript` (unconditional) / `mountSource` (runtime-only) toggles — same `CheckboxField`, helper pattern, deploy-relevant→banner behavior.
7. **Heuristic pass:** user language ("Platform account", not "cluster-admin RBAC"); error prevention + recognition-over-recall (helper names the consequence + admin-context caveat); user control (reversible, Cancel); WCAG (accessible `Checkbox`+label primitive, keyboard, non-color status).
8. **Playwright:** `erun-ui/playwright/tests/manage-platform-account.spec.ts` — toggle → banner → persist → untoggle on a runtime env, plus renders on an agent env.

## Validation

- `go test ./...` (erun-ui) ✓
- `yarn typecheck` / `yarn lint` / `yarn format:check` / `yarn build` ✓
- **Playwright: full suite 121/121 green**, including the 2 new specs.

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)