### PR TITLE
Bump cluster-edge cert-manager to v1.20.3 (Cloudflare DNS-01 cleanup fix)

### DIFF
--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/variables.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/variables.tf
@@ -72,9 +72,9 @@ variable "issuer_name" {
 }
 
 variable "cert_manager_chart_version" {
-  description = "Pinned cert-manager Helm chart version."
+  description = "Pinned cert-manager Helm chart version. Keep >= v1.17.2: earlier versions delete the DNS-01 _acme-challenge TXT with an empty Cloudflare zone id, orphaning records and wedging issuance/renewal."
   type        = string
-  default     = "v1.16.2"
+  default     = "v1.20.3"
 }
 
 variable "traefik_chart_version" {


### PR DESCRIPTION
## Problem

`terraform-erun-cluster-edge` pins `cert_manager_chart_version = "v1.16.2"`, which has a broken Cloudflare DNS-01 **cleanup** path. After Cloudflare stopped returning `zone_id` on individual DNS-record responses (~Feb 2025), cert-manager deletes the `_acme-challenge` TXT with an **empty zone id** — `DELETE /zones//dns_records/<id>` → Cloudflare `Error 7003: Could not route`. Cleanup then fails, orphaning TXT records and wedging issuance.

Observed live on the frs-prod edge: the wildcard `Certificate` sat `Ready=False` for ~54 min — a stuck challenge cleanup (`processing=true`) blocked the ACME order so the second challenge never presented. This affects **every** erun cluster edge on this module.

Upstream: cert-manager [PR #7549](https://github.com/cert-manager/cert-manager/pull/7549) ("ensure we set ZoneID"), issue [#7540](https://github.com/cert-manager/cert-manager/issues/7540).

## Change

Bump the pinned chart to **v1.20.3**.

## Why v1.20.3

- **Carries the fix** — verified in source (`pkg/issuer/acme/dns/cloudflare/cloudflare.go` sets `rec.ZoneID = zoneID` before delete).
- **Current & proven** — released 2025-06-25; supported line. Skipped v1.21.0 (3 days old) and v1.16.x (EOL; its last patch v1.16.5 has the fix but no future security patches).
- **No breaking changes for this module's usage** (ACME `ClusterIssuer` + Cloudflare DNS-01 + wildcard `Certificate`, `crds.enabled=true`). The v1.20 breaking items — `cert-manager-edit` RBAC for Challenge/Order *create*, cert-manager pod UID 1000→65532, feature-gate promotions — don't touch this usage. `crds.enabled` value key unchanged.
- **Verified**: `jetstack/cert-manager v1.20.3` pulls and templates cleanly with `crds.enabled=true`; edge cluster runs k8s v1.34 (well within support).

## Scope / validation

- One-line default bump; the version string is referenced in exactly one place (`main.tf` via the var). No goldens, docs, or integration tests reference the cert-manager version. `terraform fmt` clean.
- Not an `erun-cli`/`erun-common`/runtime-entrypoint/chart-deploy change, so the integration gate scope is untouched.
- Docs: none needed (no `erun-docs` page or skill pins the cert-manager version) — pure bug-fix version bump.

## Rollout

The module is consumed by `?ref=v<version>`, so this reaches an edge only after an erun release and the edge re-pinning + re-applying (which upgrades cert-manager in place). frs-prod's current cert was already unblocked manually, so this prevents recurrence on renewal.

Closes #806