### PR TITLE
services-delegation module: bound TTLs to Cloudflare's range

### DIFF
--- a/erun-devops/terraform-erun/modules/terraform-erun-services-delegation/main.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-services-delegation/main.tf
@@ -28,6 +28,13 @@ resource "cloudflare_dns_record" "delegation" {
   ttl     = var.delegation_ttl
   content = each.value
   comment = var.comment
+
+  lifecycle {
+    precondition {
+      condition     = local.parent_zone_id != ""
+      error_message = "Could not resolve the parent zone id: pass parent_zone_id, or set cloudflare_account_id so base_domain_name can be looked up."
+    }
+  }
 }
 
 # Glue A records for in-bailiwick nameservers, so a resolver following the

--- a/erun-devops/terraform-erun/modules/terraform-erun-services-delegation/variables.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-services-delegation/variables.tf
@@ -58,13 +58,23 @@ variable "comment" {
 }
 
 variable "delegation_ttl" {
-  description = "TTL in seconds for the NS delegation records in the parent zone."
+  description = "TTL in seconds for the NS delegation records in the parent zone. Cloudflare accepts 60–86400 (a day, its maximum, suits a delegation that changes rarely)."
   type        = number
-  default     = 172800
+  default     = 86400
+
+  validation {
+    condition     = var.delegation_ttl >= 60 && var.delegation_ttl <= 86400
+    error_message = "delegation_ttl must be between 60 and 86400 (Cloudflare's DNS-record TTL range)."
+  }
 }
 
 variable "glue_ttl" {
-  description = "TTL in seconds for the glue A records in the parent zone."
+  description = "TTL in seconds for the glue A records in the parent zone. Cloudflare accepts 60–86400."
   type        = number
   default     = 300
+
+  validation {
+    condition     = var.glue_ttl >= 60 && var.glue_ttl <= 86400
+    error_message = "glue_ttl must be between 60 and 86400 (Cloudflare's DNS-record TTL range)."
+  }
 }


### PR DESCRIPTION
Adversarial review of the new module found the default `delegation_ttl` (172800) exceeds Cloudflare's max DNS-record TTL (86400) — `terraform validate` passes but apply hard-fails, so any reuse-by-reference consumer that doesn't override it breaks (frs is safe only because its wrapper hardcodes 300).

- Default `delegation_ttl` → 86400; validate `delegation_ttl`/`glue_ttl` to [60,86400].
- Add a precondition that the parent zone id resolves, instead of silently writing an empty `zone_id`.

Verified: `terraform validate` passes at ttl=300 and now fails cleanly at 172800.

Closes #812