### PR TITLE
Fix PowerDNS dnssec/CAA and expose backend Service scoping

### DIFF
--- a/erun-cli/cmd/expose.go
+++ b/erun-cli/cmd/expose.go
@@ -18,7 +18,10 @@ func newExposeCmd(store common.ExposeStore, findProjectRoot common.ProjectFinder
 		Use:   "expose TENANT ENVIRONMENT SERVICE",
 		Short: "Expose an environment's Service at a public HTTPS hostname",
 		Long: "Expose an in-namespace Service at a stable public hostname under the platform's services zone.\n\n" +
-			"Ensures the per-environment wildcard DNS record points at the env's ingress IP and applies a " +
+			"SERVICE is the logical service name: it becomes the hostname label and routes to the tenant-scoped " +
+			"in-namespace Service <tenant>-<service> (the name its component chart renders, e.g. `api` -> `frs-api`), " +
+			"so the public host stays a clean label (api.frs-prod.services.erunpaas.com) while the Ingress targets the " +
+			"real Service. Ensures the per-environment wildcard DNS record points at the env's ingress IP and applies a " +
 			"Host-routing Ingress for the Service. TLS is on by default: the Ingress references the env's per-env " +
 			"wildcard cert Secret (<tenant>-<env>-wildcard-tls, issued by the cluster edge), so the host serves https " +
 			"with no per-service cert step. Pass --no-tls for http. Requires a platform block in .erun/config.yaml; it " +

--- a/erun-common/expose.go
+++ b/erun-common/expose.go
@@ -72,9 +72,16 @@ type ExposeServiceParams struct {
 // ExposeServiceResult is the resolved exposure plan: the public hostname, the
 // per-env wildcard record, and the ingress that will front the Service.
 type ExposeServiceResult struct {
-	Tenant            string `json:"tenant"`
-	Environment       string `json:"environment"`
-	Service           string `json:"service"`
+	Tenant      string `json:"tenant"`
+	Environment string `json:"environment"`
+	// Service is the logical service name — the DNS label in the public hostname.
+	Service string `json:"service"`
+	// BackendService is the in-namespace Service the Ingress routes to. Platform
+	// Services are tenant-scoped by their component charts (<tenant>-<service>,
+	// e.g. frs-api), so the backend is derived that way rather than assuming the
+	// public label names the Service. This lets the public host stay the clean
+	// logical label (api.frs-prod.…) while routing to the real Service (frs-api).
+	BackendService    string `json:"backendService"`
 	Namespace         string `json:"namespace"`
 	KubernetesContext string `json:"kubernetesContext,omitempty"`
 	Hostname          string `json:"hostname"`
@@ -134,7 +141,7 @@ func RunExposeService(ctx Context, params ExposeServiceParams, store ExposeStore
 
 	// Trace the real commands, not synthetic verbs, so the dry-run plan is
 	// faithful to the live run.
-	ctx.Trace(fmt.Sprintf("expose: %s -> service %s.%s.svc:%d", result.Hostname, result.Service, result.Namespace, result.ServicePort))
+	ctx.Trace(fmt.Sprintf("expose: %s -> service %s.%s.svc:%d", result.Hostname, result.BackendService, result.Namespace, result.ServicePort))
 	ctx.Trace(fmt.Sprintf("expose: per-env wildcard %s A %s ttl %d (zone %s)", result.WildcardName, result.TargetIP, dnsParams.TTL, result.ServicesZone))
 	ctx.Trace(fmt.Sprintf("expose: ingress class %s", result.IngressClass))
 	if result.TLSEnabled {
@@ -186,7 +193,7 @@ func exposeIngressParams(result ExposeServiceResult) IngressApplyParams {
 		Namespace:         result.Namespace,
 		Name:              result.IngressName,
 		Host:              result.Hostname,
-		ServiceName:       result.Service,
+		ServiceName:       result.BackendService,
 		ServicePort:       result.ServicePort,
 		IngressClass:      result.IngressClass,
 	}
@@ -260,6 +267,7 @@ func resolveExposeServicePlan(params ExposeServiceParams, store ExposeStore) (Ex
 		Tenant:                     tenant,
 		Environment:                environment,
 		Service:                    service,
+		BackendService:             fmt.Sprintf("%s-%s", TenantResourcePrefix(tenant), service),
 		Namespace:                  envLabel,
 		KubernetesContext:          strings.TrimSpace(envConfig.KubernetesContext),
 		Hostname:                   fmt.Sprintf("%s.%s.%s", service, envLabel, platform.ServicesZone),

--- a/erun-devops/k8s/erun-powerdns/templates/powerdns.yaml
+++ b/erun-devops/k8s/erun-powerdns/templates/powerdns.yaml
@@ -58,6 +58,21 @@
        (hmac-sha256); cert-manager uses its own uppercase form (HMACSHA256), wired
        separately in terraform-erun-cluster-edge. */ -}}
 {{- $dnsUpdateEnabled := default true $powerdns.dnsUpdateEnabled -}}
+{{- /* The generated config deliberately omits gpgsql-dnssec. The services zone
+       is an INSECURE delegation (the parent writes NS + glue but no DS), so it
+       is unsigned. Enabling dnssec makes PowerDNS take the NSEC negative-answer
+       path on an unsigned, unrectified zone and SERVFAIL on CAA lookups (failing
+       Let's Encrypt's pre-issuance CAA check) and stop serving freshly-written
+       records until the zone is manually rectified. TSIG key retrieval for DNS
+       UPDATE is independent of the dnssec query set, so leaving it off keeps
+       dynamic updates working. Do not add gpgsql-dnssec back for this zone. */ -}}
+{{- /* PowerDNS gates DNS UPDATE on the source IP FIRST (allow-dnsupdate-from /
+       per-zone ALLOW-DNSUPDATE-FROM); an empty list REFUSES every update even
+       with a valid TSIG. The TSIG key stays the real authorization — this list
+       is the coarse IP gate. Default to RFC1918 so any in-cluster cert-manager
+       (its pod IP) can reach it while public sources are refused at the IP gate;
+       it is generic (no instance-specific value). */ -}}
+{{- $dnsUpdateAllowFrom := default "10.0.0.0/8 172.16.0.0/12 192.168.0.0/16" $powerdns.dnsUpdateAllowFrom -}}
 {{- $tsigSecretName := default (printf "%s-powerdns-tsig" $tenant) $powerdns.tsigSecretName -}}
 {{- $tsigSecretKey := default "tsig-secret" $powerdns.tsigSecretKey -}}
 {{- $tsigKeyName := default (printf "%s-dnsupdate" $tenant) $powerdns.tsigKeyName -}}
@@ -186,8 +201,7 @@ spec:
               webserver-allow-from=127.0.0.1
               {{- if $dnsUpdateEnabled }}
               dnsupdate=yes
-              gpgsql-dnssec=yes
-              allow-dnsupdate-from=
+              allow-dnsupdate-from={{ $dnsUpdateAllowFrom }}
               {{- end }}
               EOF
           volumeMounts:

--- a/erun-docs/docs/agent-reference/networking-spec.md
+++ b/erun-docs/docs/agent-reference/networking-spec.md
@@ -128,16 +128,17 @@ For the public form, each segment must match:
 
 `erun expose <tenant> <env> <service>` (CLI and the `expose` MCP tool) automates Pattern 3 for a platform deployment — an install that runs the `erun-powerdns` singleton and declares a [`platform:` block](/reference/configuration#platform-block). For the Operator view see [Networking · Platform service exposure](/concepts/networking#platform-service-exposure).
 
-**Inputs.** `tenant`, `env`, `service` (positional); `--ip` (the env's ingress IP the wildcard record points at; required); `--port` (Service port, default `80`); `--dry-run`.
+**Inputs.** `tenant`, `env`, `service` (positional — the **logical** service name: the hostname label, resolved to the tenant-scoped backend Service `<tenant>-<service>`); `--ip` (the env's ingress IP the wildcard record points at; required); `--port` (Service port, default `80`); `--dry-run`.
 
 **Resolved plan.**
 
 | Field | Value |
 |---|---|
 | Public hostname | `<service>.<tenant>-<env>.<servicesZone>` |
+| Backend Service | `<tenant>-<service>` (the name the service's component chart renders, e.g. `api` → `frs-api`) |
 | Per-env wildcard record | `*.<tenant>-<env>.<servicesZone>` `A` `<ip>`, TTL `60` |
 | Services zone | `platform.serviceszone` (defaults to `services.<platform.basedomain>`) |
-| Ingress | `expose-<service>` in namespace `<tenant>-<env>`, Host-routing the hostname to `<service>:<port>` |
+| Ingress | `expose-<service>` in namespace `<tenant>-<env>`, Host-routing the hostname to `<tenant>-<service>:<port>` |
 
 **Execution.** Two side effects, in order:
 

--- a/erun-docs/docs/cli/expose.md
+++ b/erun-docs/docs/cli/expose.md
@@ -14,10 +14,10 @@ erun expose team dev api --ip 127.0.0.1 --dry-run     # preview, no side effects
 
 ## What it does
 
-For `erun expose <tenant> <env> <service>`, the public hostname is `<service>.<tenant>-<env>.<servicesZone>` (the services zone comes from the platform config — e.g. `api.team-dev.services.erunpaas.com`). The flow:
+For `erun expose <tenant> <env> <service>`, `<service>` is the **logical service name**: it becomes the DNS label in the public hostname `<service>.<tenant>-<env>.<servicesZone>` (the services zone comes from the platform config — e.g. `api.team-dev.services.erunpaas.com`) and the Ingress routes it to the tenant-scoped in-namespace Service `<tenant>-<service>` — the name that service's component chart renders (e.g. `api` → `team-api`). The public host stays a clean label while the Ingress targets the real Service. The flow:
 
 1. **Per-env wildcard A record.** It upserts `*.<tenant>-<env>.<servicesZone>` → `--ip` (TTL 60) in the platform's authoritative zone by exec'ing `pdnsutil` inside the platform's PowerDNS pod. The wildcard covers *every* service in that env, so exposing additional services later only adds an Ingress — the DNS record is written once.
-2. **Host-routing Ingress.** It applies an Ingress named `expose-<service>` into the env's namespace, routing the hostname to the in-namespace Service on `--port` (default `80`).
+2. **Host-routing Ingress.** It applies an Ingress named `expose-<service>` into the env's namespace, routing the hostname to the tenant-scoped Service `<tenant>-<service>` on `--port` (default `80`).
 
 The DNS write targets the **platform** environment's cluster (where PowerDNS runs); the Ingress is applied to the **target** env's cluster. These can be different clusters — `expose` resolves each context independently.
 

--- a/erun-integration/testdata/expose/dry_run.txt
+++ b/erun-integration/testdata/expose/dry_run.txt
@@ -1,5 +1,5 @@
 audit: erun expose --dry-run --ip <VERSION>.10 team dev api
-expose: api.team-dev.services.erunpaas.com -> service api.team-dev.svc:80
+expose: api.team-dev.services.erunpaas.com -> service team-api.team-dev.svc:80
 expose: per-env wildcard *.team-dev.services.erunpaas.com A <VERSION>.10 ttl 60 (zone services.erunpaas.com)
 expose: ingress class traefik
 expose: tls secret team-dev-wildcard-tls (namespace team-dev) -> https
@@ -28,6 +28,6 @@ expose: ingress manifest:
               pathType: Prefix
               backend:
                 service:
-                  name: api
+                  name: team-api
                   port:
                     number: 80

--- a/erun-integration/testdata/expose/dry_run_cross_cluster.txt
+++ b/erun-integration/testdata/expose/dry_run_cross_cluster.txt
@@ -1,5 +1,5 @@
 audit: erun expose --dry-run --ip <VERSION>.10 team dev api
-expose: api.team-dev.services.erunpaas.com -> service api.team-dev.svc:80
+expose: api.team-dev.services.erunpaas.com -> service team-api.team-dev.svc:80
 expose: per-env wildcard *.team-dev.services.erunpaas.com A <VERSION>.10 ttl 60 (zone services.erunpaas.com)
 expose: ingress class traefik
 expose: tls secret team-dev-wildcard-tls (namespace team-dev) -> https
@@ -28,6 +28,6 @@ expose: ingress manifest:
               pathType: Prefix
               backend:
                 service:
-                  name: api
+                  name: team-api
                   port:
                     number: 80

--- a/erun-integration/testdata/expose/dry_run_no_tls.txt
+++ b/erun-integration/testdata/expose/dry_run_no_tls.txt
@@ -1,5 +1,5 @@
 audit: erun expose --dry-run --ip <VERSION>.10 --no-tls team dev api
-expose: api.team-dev.services.erunpaas.com -> service api.team-dev.svc:80
+expose: api.team-dev.services.erunpaas.com -> service team-api.team-dev.svc:80
 expose: per-env wildcard *.team-dev.services.erunpaas.com A <VERSION>.10 ttl 60 (zone services.erunpaas.com)
 expose: ingress class traefik
 expose: http-only (--no-tls)
@@ -24,6 +24,6 @@ expose: ingress manifest:
               pathType: Prefix
               backend:
                 service:
-                  name: api
+                  name: team-api
                   port:
                     number: 80

--- a/erun-integration/testdata/expose/help.txt
+++ b/erun-integration/testdata/expose/help.txt
@@ -1,6 +1,6 @@
 Expose an in-namespace Service at a stable public hostname under the platform's services zone.
 
-Ensures the per-environment wildcard DNS record points at the env's ingress IP and applies a Host-routing Ingress for the Service. TLS is on by default: the Ingress references the env's per-env wildcard cert Secret (<tenant>-<env>-wildcard-tls, issued by the cluster edge), so the host serves https with no per-service cert step. Pass --no-tls for http. Requires a platform block in .erun/config.yaml; it mutates the platform DNS zone and applies to the env's cluster. Use --dry-run to preview the actions.
+SERVICE is the logical service name: it becomes the hostname label and routes to the tenant-scoped in-namespace Service <tenant>-<service> (the name its component chart renders, e.g. `api` -> `frs-api`), so the public host stays a clean label (api.frs-prod.services.erunpaas.com) while the Ingress targets the real Service. Ensures the per-environment wildcard DNS record points at the env's ingress IP and applies a Host-routing Ingress for the Service. TLS is on by default: the Ingress references the env's per-env wildcard cert Secret (<tenant>-<env>-wildcard-tls, issued by the cluster edge), so the host serves https with no per-service cert step. Pass --no-tls for http. Requires a platform block in .erun/config.yaml; it mutates the platform DNS zone and applies to the env's cluster. Use --dry-run to preview the actions.
 
 Usage:
   erun expose TENANT ENVIRONMENT SERVICE [flags]

--- a/erun-integration/testdata/expose/real_run_via_stubs.txt
+++ b/erun-integration/testdata/expose/real_run_via_stubs.txt
@@ -1,6 +1,6 @@
 exposed team/dev service api at https://api.team-dev.services.erunpaas.com
 audit: erun expose --ip <VERSION>.10 team dev api
-expose: api.team-dev.services.erunpaas.com -> service api.team-dev.svc:80
+expose: api.team-dev.services.erunpaas.com -> service team-api.team-dev.svc:80
 expose: per-env wildcard *.team-dev.services.erunpaas.com A <VERSION>.10 ttl 60 (zone services.erunpaas.com)
 expose: ingress class traefik
 expose: tls secret team-dev-wildcard-tls (namespace team-dev) -> https

--- a/erun-mcp/expose.go
+++ b/erun-mcp/expose.go
@@ -11,7 +11,7 @@ import (
 type ExposeInput struct {
 	Tenant       string `json:"tenant,omitempty" jsonschema:"tenant name; defaults to the MCP runtime context tenant"`
 	Environment  string `json:"environment,omitempty" jsonschema:"environment name; defaults to the MCP runtime context environment"`
-	Service      string `json:"service" jsonschema:"required name of the in-namespace Service to expose at a public hostname"`
+	Service      string `json:"service" jsonschema:"required logical service name; becomes the hostname label and routes to the tenant-scoped in-namespace Service <tenant>-<service> (e.g. api -> frs-api)"`
 	ProjectRoot  string `json:"projectRoot,omitempty" jsonschema:"project root holding the platform config (.erun/config.yaml); defaults to the runtime repo path"`
 	IP           string `json:"ip" jsonschema:"required ingress IP the per-env wildcard record points at (e.g. 127.0.0.1 for a local cluster, the public LB IP for remote)"`
 	Port         int    `json:"port,omitempty" jsonschema:"Service port to route to (default 80)"`


### PR DESCRIPTION
Driving the Phase-1 DNS-01 rollout end-to-end (issue a real Let's Encrypt wildcard cert for `*.frs-prod.services.erunpaas.com` via RFC2136 and serve it through `erun expose`) surfaced three bugs.

## erun-powerdns chart

1. **Drop `gpgsql-dnssec` from the generated `pdns.conf`.** The services zone is an **insecure delegation** — the Cloudflare parent writes NS + glue but no DS record, so the zone is unsigned. With `gpgsql-dnssec=yes`, PowerDNS takes the DNSSEC negative-answer path (NSEC ordering) on an unsigned, unrectified zone and **SERVFAILs on CAA lookups**, so Let's Encrypt's pre-issuance CAA check fails even after the DNS-01 TXT validates (`During secondary validation: … SERVFAIL looking up CAA for frs-prod.services.erunpaas.com`). The same mode also refuses to serve freshly-written records (e.g. the `expose` wildcard A) until the zone is manually `rectify`'d. TSIG key retrieval for DNS UPDATE is independent of the dnssec query set, so dynamic updates keep working without it. The rationale lives in a template comment so a future editor doesn't re-add it.
2. **Emit a non-empty `allow-dnsupdate-from`** (new `powerdns.dnsUpdateAllowFrom`, default RFC1918 `10.0.0.0/8 172.16.0.0/12 192.168.0.0/16`). PowerDNS gates DNS UPDATE on the source IP **first**, so the previously-empty list refused every cert-manager update even with a valid TSIG. TSIG remains the real authorization.

## erun expose

3. **Route the Ingress to the tenant-scoped Service `<tenant>-<service>`** (the name a component chart renders, e.g. `api` → `frs-api`) instead of the raw `service` arg (which built a backend named `api` → nonexistent → 503). The `service` arg is the logical name: it stays the hostname label while the Ingress targets the real Service.

## Validation

- `go test ./...` green in erun-common / erun-cli / erun-mcp; `golangci-lint` clean.
- `make integration-test` green; expose goldens (dry-run, no-tls, cross-cluster, help, real-run) updated.
- `helm template` renders the fixed `pdns.conf`.
- **E2E in-cluster:** real LE wildcard cert issued (`CN=*.frs-prod.services.erunpaas.com`, issuer Let's Encrypt YR2); traefik serves it for the exposed host (chain verifies with no `-k`); routes to `frs-api`; `GET /healthz` → 204.
- Docs: `erun-docs` build clean; updated `cli/expose.md` (Operator) and `agent-reference/networking-spec.md` (Agent) for the tenant-scoped backend.

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)