### PR TITLE
Make the hosted backend broker + MCP-token signer enableable via deploy

### DIFF
--- a/erun-devops/k8s/erun-backend-api/templates/api.yaml
+++ b/erun-devops/k8s/erun-backend-api/templates/api.yaml
@@ -14,6 +14,26 @@
 {{- $imageOverrides := default dict .Values.imageOverrides -}}
 {{- $containerRegistry := default "ghcr.io/sophium" .Values.containerRegistry -}}
 {{- $backendAPIImage := default (printf "%s/erun-backend-api:%s" $containerRegistry .Chart.AppVersion) (index $imageOverrides "erun-backend-api") -}}
+{{- /* Opt-in backend MCP-signing identity (#686/#818): a mounted Ed25519 key the
+       API signs per-env MCP and DNS-01 broker tokens with. Off by default — the
+       mint endpoints report 501 and the DNS-01 broker is unregistered — so
+       existing deploys are byte-for-byte unchanged. */ -}}
+{{- $mcpSigning := default dict $api.mcpSigning -}}
+{{- $mcpSigningSecretName := default "" $mcpSigning.secretName -}}
+{{- $mcpSigningSecretKey := default "signing.key" $mcpSigning.secretKey -}}
+{{- $mcpSigningMountDir := "/etc/erun/mcp-signing" -}}
+{{- /* Opt-in DNS-01 broker write path (#818): the services zone + the PowerDNS
+       :53 endpoint and its TSIG key. TSIG defaults match the erun-powerdns
+       chart, so enabling the broker only needs enabled + servicesZone. */ -}}
+{{- $dns01 := default dict $api.dns01 -}}
+{{- $dns01Enabled := default false $dns01.enabled -}}
+{{- $dns01ServicesZone := default "" $dns01.servicesZone -}}
+{{- $dns01Nameserver := default (printf "%s-powerdns:53" $tenant) $dns01.nameserver -}}
+{{- $dns01Tsig := default dict $dns01.tsig -}}
+{{- $dns01TsigSecretName := default (printf "%s-powerdns-tsig" $tenant) $dns01Tsig.secretName -}}
+{{- $dns01TsigSecretKey := default "tsig-secret" $dns01Tsig.secretKey -}}
+{{- $dns01TsigKeyName := default (printf "%s-dnsupdate" $tenant) $dns01Tsig.keyName -}}
+{{- $dns01TsigAlgorithm := default "hmac-sha256" $dns01Tsig.algorithm -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -75,6 +95,37 @@ spec:
               value: {{ required "tenant is required" .Values.tenant | quote }}
             - name: ERUN_ENVIRONMENT
               value: {{ required "environment is required" .Values.environment | quote }}
+            {{- if $mcpSigningSecretName }}
+            - name: ERUN_API_MCP_SIGNING_KEY_PATH
+              value: {{ printf "%s/%s" $mcpSigningMountDir $mcpSigningSecretKey | quote }}
+            {{- end }}
+            {{- if $dns01Enabled }}
+            - name: ERUN_DNS01_SERVICES_ZONE
+              value: {{ required "api.dns01.servicesZone is required when dns01.enabled" $dns01ServicesZone | quote }}
+            - name: ERUN_DNS01_POWERDNS_NAMESERVER
+              value: {{ $dns01Nameserver | quote }}
+            - name: ERUN_DNS01_TSIG_KEY_NAME
+              value: {{ $dns01TsigKeyName | quote }}
+            - name: ERUN_DNS01_TSIG_ALGORITHM
+              value: {{ $dns01TsigAlgorithm | quote }}
+            - name: ERUN_DNS01_TSIG_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $dns01TsigSecretName }}
+                  key: {{ $dns01TsigSecretKey }}
+            {{- end }}
+          {{- if $mcpSigningSecretName }}
+          volumeMounts:
+            - name: mcp-signing-key
+              mountPath: {{ $mcpSigningMountDir | quote }}
+              readOnly: true
+          {{- end }}
           ports:
             - containerPort: {{ $apiPort }}
               name: api
+      {{- if $mcpSigningSecretName }}
+      volumes:
+        - name: mcp-signing-key
+          secret:
+            secretName: {{ $mcpSigningSecretName }}
+      {{- end }}

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -221,7 +221,7 @@ The endpoint takes **no body**. On success it returns HTTP `200`:
 }
 ```
 
-**Backend signing key.** The signer is enabled by pointing `ERUN_API_MCP_SIGNING_KEY_PATH` at the backend's Ed25519 private key (PKCS#8 PEM). Unset, the endpoint reports `501` and mints nothing. The matching public key is what a deploy injects into the env (`erun deploy --mcp-auth-public-key`), so the edge trusts backend-signed tokens.
+**Backend signing key.** The signer is enabled by pointing `ERUN_API_MCP_SIGNING_KEY_PATH` at the backend's Ed25519 private key (PKCS#8 PEM) — on a hosted deploy, the `erun-backend-api` chart's `api.mcpSigning.secretName` value mounts that key Secret and sets the path (opt-in; unset leaves the endpoint at `501`). The matching public key is what a deploy injects into the env (`erun deploy --mcp-auth-public-key`), so the edge trusts backend-signed tokens.
 
 **Usable once the env is deployed.** A minted token only authenticates against a **deployed** env whose edge already carries the backend's public key. A dedicated `409`-until-deployed guard is `(Planned.)` — the backend does not yet track per-env deploy state (server-side deploy is itself `(Planned.)`; see [`POST /v1/environments`](#post-v1environments)); until then the endpoint mints whenever the signer is configured and the environment exists.
 
@@ -269,7 +269,7 @@ A request succeeds (`204`) only when:
 2. The challenge FQDN is an `_acme-challenge` name **within** that env's subzone `<tenant>-<environment>.<services-zone>` — anything else (another tenant's or env's name, a foreign zone, a non-challenge record) → `403`, no write. This is the impersonation guard: `(tenant, environment)` come only from the verified token, never the FQDN.
 3. The `_acme-challenge` TXT write to PowerDNS (RFC2136 DNS UPDATE + central TSIG) succeeds — a DNS failure → `502`. Every authorized write is audited.
 
-`present` adds the challenge TXT; `cleanup` removes it. The broker is only registered when the platform env configures the PowerDNS write path (`ERUN_DNS01_*`); otherwise the endpoints are absent. Driving this against a **live** two-tenant cluster (staging then production ACME, with the negative cross-tenant test) is the issue's end-to-end acceptance — `(Planned.)` until a second tenant is stood up on the platform cluster.
+`present` adds the challenge TXT; `cleanup` removes it. The broker is only registered when the platform env configures the PowerDNS write path (`ERUN_DNS01_*`); otherwise the endpoints are absent. On a hosted deploy those are set (opt-in) by the `erun-backend-api` chart's `api.dns01.{enabled,servicesZone}` values — the TSIG key, algorithm, and PowerDNS `:53` endpoint default to the co-located `erun-powerdns` chart's conventions, so enabling the broker needs only `enabled` + the services zone. Driving this against a **live** two-tenant cluster (staging then production ACME, with the negative cross-tenant test) is the issue's end-to-end acceptance — `(Planned.)` until a second tenant is stood up on the platform cluster.
 
 ### `POST /v1/contexts`
 


### PR DESCRIPTION
Closes #830.

The backend code for per-env MCP-token signing (#686) and the DNS-01 broker (#818) reads `ERUN_API_MCP_SIGNING_KEY_PATH` and `ERUN_DNS01_*`, but **no deploy path set them** — the `erun-backend-api` chart never plumbed the env or mounted a signing key. Both features were code-complete yet **not enableable**: the mint endpoints returned `501` and the broker endpoints weren't registered on any real deploy.

## What

Opt-in values on the `erun-backend-api` chart, **default off → existing deploys byte-for-byte unchanged**:
- `api.mcpSigning.secretName` — mounts the Ed25519 signing-key Secret at `/etc/erun/mcp-signing` and sets `ERUN_API_MCP_SIGNING_KEY_PATH`.
- `api.dns01.{enabled,servicesZone,...}` — sets `ERUN_DNS01_*`; the TSIG key/secret/algorithm and the PowerDNS `:53` endpoint default to the co-located `erun-powerdns` chart's conventions, so enabling the broker needs only `enabled` + `servicesZone`.

## Validation
`helm template`, four states:
- **off** → zero broker/signing lines (unchanged).
- **mcpSigning on** → `ERUN_API_MCP_SIGNING_KEY_PATH=/etc/erun/mcp-signing/signing.key` + key volume mount + volume.
- **dns01 on** → full `ERUN_DNS01_*` env, nameserver `frs-powerdns:53`, TSIG `frs-dnsupdate`/`frs-powerdns-tsig`, `hmac-sha256`.
- **dns01 on without servicesZone** → clean `required` error.

`erun-docs` `yarn build` clean. No `erun-cli`/`erun-common` change → integration gate unaffected.

## Scope / follow-up
This makes the features **operator-enableable** (set the values + provide the signing-key Secret). Auto-provisioning the signing key and threading these from platform/env config in `erun deploy` is the **#605** hosted-deploy-executor follow-up, and the remaining prerequisite for the live two-tenant DNS-01 acceptance test (#818).

🤖 Generated with [Claude Code](https://claude.com/claude-code)