### PR TITLE
Add environment provisioning status (#605 Slice A foundation)

### DIFF
--- a/erun-backend/erun-backend-api/internal/model/environment.go
+++ b/erun-backend/erun-backend-api/internal/model/environment.go
@@ -14,6 +14,18 @@ const (
 	EnvironmentTypeRuntime     EnvironmentType = "runtime"
 )
 
+// EnvironmentStatus is the provisioning lifecycle of a hosted environment
+// (#605): a row is `registered` when created, then the server-side deploy
+// executor moves it `provisioning` → `running`/`failed`.
+type EnvironmentStatus string
+
+const (
+	EnvironmentStatusRegistered   EnvironmentStatus = "registered"
+	EnvironmentStatusProvisioning EnvironmentStatus = "provisioning"
+	EnvironmentStatusRunning      EnvironmentStatus = "running"
+	EnvironmentStatusFailed       EnvironmentStatus = "failed"
+)
+
 // Environment is the per-tenant system of record for an erun environment, the
 // DB-backed shape of eruncommon.EnvConfig. Its link to a context is a real
 // tenant-scoped foreign key (ContextID), not a kubernetes-context string match.
@@ -26,6 +38,12 @@ type Environment struct {
 	KubernetesContext string          `json:"kubernetesContext,omitempty" bun:"kubernetes_context,nullzero"`
 	ContextID         string          `json:"contextId,omitempty" bun:"context_id,nullzero"`
 	RuntimeVersion    string          `json:"runtimeVersion,omitempty" bun:"runtime_version,nullzero"`
-	CreatedAt         time.Time       `json:"createdAt" bun:"created_at,scanonly"`
-	UpdatedAt         time.Time       `json:"updatedAt" bun:"updated_at,scanonly"`
+	// Status is DB-owned: it defaults to `registered` on insert and is moved by
+	// the server-side deploy executor, so it is scan-only here (never inserted or
+	// updated through the create path). ProvisionError carries the failure detail
+	// when Status is `failed`.
+	Status         EnvironmentStatus `json:"status" bun:"status,scanonly"`
+	ProvisionError string            `json:"provisionError,omitempty" bun:"provision_error,scanonly,nullzero"`
+	CreatedAt      time.Time         `json:"createdAt" bun:"created_at,scanonly"`
+	UpdatedAt      time.Time         `json:"updatedAt" bun:"updated_at,scanonly"`
 }

--- a/erun-backend/erun-backend-api/internal/repository/environments.go
+++ b/erun-backend/erun-backend-api/internal/repository/environments.go
@@ -11,7 +11,7 @@ type EnvironmentRepository struct {
 	txs *TxManager
 }
 
-const environmentColumns = `environment_id, tenant_id, name, type, kubernetes_context, context_id, runtime_version, created_at, updated_at`
+const environmentColumns = `environment_id, tenant_id, name, type, kubernetes_context, context_id, runtime_version, status, provision_error, created_at, updated_at`
 
 func NewEnvironmentRepository(txs *TxManager) *EnvironmentRepository {
 	return &EnvironmentRepository{txs: txs}

--- a/erun-backend/erun-backend-db/migrations/default/20260714120000_env_provision_status.sql
+++ b/erun-backend/erun-backend-db/migrations/default/20260714120000_env_provision_status.sql
@@ -1,0 +1,9 @@
+-- Add the provisioning-status columns to "environments" (#605 Slice A): an env
+-- row is `registered` when created, then the server-side deploy executor moves
+-- it `provisioning` -> `running`/`failed`. Mirrors the contexts status pattern.
+-- Hand-written column add (atlas migrate diff is login-gated on the RLS
+-- functions in the source schema); no new table/RLS, so the existing
+-- environments row-level security already covers these columns.
+ALTER TABLE "environments" ADD COLUMN "status" text NOT NULL DEFAULT 'registered';
+ALTER TABLE "environments" ADD COLUMN "provision_error" text NULL;
+ALTER TABLE "environments" ADD CONSTRAINT "environments_status_check" CHECK (status IN ('registered', 'provisioning', 'running', 'failed'));

--- a/erun-backend/erun-backend-db/migrations/default/atlas.sum
+++ b/erun-backend/erun-backend-db/migrations/default/atlas.sum
@@ -1,4 +1,4 @@
-h1:jiXB1frNMh8UbWGmChcteSb4E6CnRNP9wF8yAHIzLgc=
+h1:jYX5902nDn04ImMdLfJL1P9t0DAgJRrIKl+sx5TEL50=
 20260501120000_initial_tenant_identity.sql h1:RpS03/4sFjbCggwYgcGNn6k3jNZCNTNl0BD/afOKFzo=
 20260503143000_tenant_issuer_names.sql h1:VEZjICG3/jU2YtEx0XX05l9Q8lJyWKeiRY8f4dXOkvE=
 20260503170000_audit_events.sql h1:OLjiGP/FhLTWvkx1bxS2xCcJK6tExdufnEC8R6LsKWA=
@@ -6,3 +6,4 @@ h1:jiXB1frNMh8UbWGmChcteSb4E6CnRNP9wF8yAHIzLgc=
 20260624145559_config_read_model.sql h1:eB3uGQkL5h5ekfG5Wm5qANqRpTt0tToKXT0jezIq9Vs=
 20260624160330_tenant_env_quota.sql h1:kezgTEMk6MOalPbJen2uoucMm8jxJQ4nowGCnreYNGk=
 20260625120000_context_provisioning.sql h1:VzIUJx9vdNEzADuxKONvZiDODahI3S9Urf9liLvtCVY=
+20260714120000_env_provision_status.sql h1:OwYEmbnFhj3ycSmNmQU2DG+TD2WwIaLIS3Pz8BdeQQM=

--- a/erun-backend/erun-backend-db/schema/tables/environments.sql
+++ b/erun-backend/erun-backend-db/schema/tables/environments.sql
@@ -6,12 +6,15 @@ CREATE TABLE environments (
   kubernetes_context TEXT,
   context_id UUID,
   runtime_version TEXT,
+  status TEXT NOT NULL DEFAULT 'registered',
+  provision_error TEXT,
   created_at TIMESTAMPTZ,
   updated_at TIMESTAMPTZ,
   FOREIGN KEY (tenant_id) REFERENCES tenants (tenant_id),
   FOREIGN KEY (tenant_id, context_id) REFERENCES contexts (tenant_id, context_id),
   CONSTRAINT environments_name_check CHECK (length(trim(name)) > 0),
   CONSTRAINT environments_type_check CHECK (type IN ('local-agent', 'remote-agent', 'runtime')),
+  CONSTRAINT environments_status_check CHECK (status IN ('registered', 'provisioning', 'running', 'failed')),
   CONSTRAINT environments_tenant_environment_key UNIQUE (tenant_id, environment_id),
   CONSTRAINT environments_tenant_name_key UNIQUE (tenant_id, name)
 );

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -189,10 +189,13 @@ On success the endpoint persists the row and returns it with HTTP `201`:
   "kubernetesContext": "primary",
   "contextId": "019a7fa5-c2c0-7c55-bc70-714873a71f20",
   "runtimeVersion": "1.2.3",
+  "status": "registered",       // provisioning lifecycle: registered → provisioning → running/failed
   "createdAt": "2026-06-24T10:00:00Z",
   "updatedAt": "2026-06-24T10:00:00Z"
 }
 ```
+
+A newly-registered environment is `registered` — the row exists but nothing is deployed. The server-side deploy executor (#605) moves it `provisioning` → `running`/`failed` and sets `provisionError` on failure; the same `status`/`provisionError` appear on `GET /v1/environments/{id}` and in the `GET /v1/config` read model. Until the executor lands, an environment stays `registered`.
 
 **Per-tenant environment-count quota.** After validating the body and before persisting, the endpoint enforces the tenant's environment-count cap: it compares how many environments the tenant already has against the cap and rejects the registration with HTTP `409` once the tenant is at or over it. The cap defaults to **10** and is overridden per tenant by a `tenant_quotas.max_environments` row. That override row is set by the operations-only [`PUT /v1/tenants/{tenant_id}/quota`](#put-v1tenantstenant_idquota) endpoint (below). Both the count and the cap are read under row-level security, so each is scoped to the caller's own tenant.
 


### PR DESCRIPTION
Part of **#605** (hosted provisioning control plane). First increment: give a hosted environment a provisioning lifecycle the server-side deploy executor will drive.

## What
- **`erun-backend-db`** — migration adds `environments.status` (`NOT NULL DEFAULT 'registered'`) + `provision_error`, with a status CHECK (`registered` | `provisioning` | `running` | `failed`), mirroring the `contexts` pattern. Existing `environments` RLS already covers the new columns. `atlas migrate hash` + `validate` clean. (`atlas migrate diff` is login-gated on the RLS functions in the source schema, so the pure column-add is hand-written — the same pattern the existing migrations use for non-table objects.)
- **`erun-backend-api`** — `model.Environment` gains `Status` + `ProvisionError` (**scan-only**: DB-owned on insert, moved later by the executor); the repository read column list returns them, so they flow through `Create`'s `RETURNING`, `GET /v1/environments/{id}`, and the `GET /v1/config` read model.

## Behaviour
A newly-registered env is `registered` — the row exists, nothing is deployed — and stays there until the executor lands. Adding a column with a default is a safe, non-breaking migration (existing rows become `registered`).

## Verification
`atlas migrate hash` + `validate` (applies clean on a throwaway dev DB); `go build`/`go test`/`golangci-lint` (0) in `erun-backend-api`; `erun-docs` `yarn build` clean. No `erun-cli`/`erun-common` change → integration gate unaffected. (No real-DB repository harness exists, so the column-flow is verified by the migration validation + the model/repo wiring, not a new DB test.)

## Next increment (same #605 arc)
The Job-runner executor — the backend creates + watches an `erun-devops` deploy Job (`erun deploy … --version X`) with the platform SA — that moves `registered → provisioning → running/failed`, plus the console status display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)