### PR TITLE
Add the env provisioning coordinator + status persistence (#605 Slice A)

### DIFF
--- a/erun-backend/erun-backend-api/internal/repository/environments.go
+++ b/erun-backend/erun-backend-api/internal/repository/environments.go
@@ -56,6 +56,22 @@ func (r *EnvironmentRepository) Count(ctx context.Context) (int, error) {
 	return count, err
 }
 
+// UpdateProvisioningStatus persists an environment's provisioning-lifecycle
+// transition (registered → provisioning → running/failed), clearing the error
+// on any non-failed state. Mirrors the contexts provisioning-result update; RLS
+// keeps the write scoped to the caller's tenant.
+func (r *EnvironmentRepository) UpdateProvisioningStatus(ctx context.Context, environmentID, status, provisionError string) error {
+	return r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		_, err := tx.NewRaw(`
+			UPDATE environments
+			   SET status = ?,
+			       provision_error = NULLIF(?, '')
+			 WHERE environment_id = ?
+		`, status, provisionError, environmentID).Exec(ctx)
+		return err
+	})
+}
+
 func (r *EnvironmentRepository) Get(ctx context.Context, environmentID string) (model.Environment, error) {
 	var environment model.Environment
 	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {

--- a/erun-backend/erun-backend-api/internal/service/environments.go
+++ b/erun-backend/erun-backend-api/internal/service/environments.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/deployexec"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+)
+
+// EnvironmentStatusWriter persists an environment's provisioning-lifecycle
+// transitions (the repository).
+type EnvironmentStatusWriter interface {
+	UpdateProvisioningStatus(ctx context.Context, environmentID, status, provisionError string) error
+}
+
+// DeployRunner runs a hosted-env deploy to a terminal outcome — satisfied by the
+// deployexec Job launcher, which the durable workflow supplies.
+type DeployRunner interface {
+	Run(ctx context.Context, params deployexec.DeployJobParams) (deployexec.Outcome, error)
+}
+
+// EnvironmentProvisioner drives a hosted env's deploy: it marks the env
+// provisioning, runs the deploy (a Job in the runtime image), and records the
+// terminal running/failed status. The durable DBOS workflow wraps this; keeping
+// the state transitions here makes them unit-testable without a cluster.
+type EnvironmentProvisioner struct {
+	runner DeployRunner
+	status EnvironmentStatusWriter
+}
+
+func NewEnvironmentProvisioner(runner DeployRunner, status EnvironmentStatusWriter) *EnvironmentProvisioner {
+	return &EnvironmentProvisioner{runner: runner, status: status}
+}
+
+// Provision moves the env → provisioning → running/failed. A run error or a
+// non-succeeded deploy Job both land it in failed with the reason; only a
+// succeeded Job marks it running.
+func (p *EnvironmentProvisioner) Provision(ctx context.Context, environmentID string, params deployexec.DeployJobParams) error {
+	if err := p.status.UpdateProvisioningStatus(ctx, environmentID, string(model.EnvironmentStatusProvisioning), ""); err != nil {
+		return fmt.Errorf("mark provisioning: %w", err)
+	}
+	outcome, runErr := p.runner.Run(ctx, params)
+	if runErr != nil {
+		return p.fail(ctx, environmentID, runErr.Error(), runErr)
+	}
+	if outcome != deployexec.OutcomeSucceeded {
+		return p.fail(ctx, environmentID, fmt.Sprintf("deploy job %s", outcome), fmt.Errorf("deploy job outcome %q", outcome))
+	}
+	if err := p.status.UpdateProvisioningStatus(ctx, environmentID, string(model.EnvironmentStatusRunning), ""); err != nil {
+		return fmt.Errorf("mark running: %w", err)
+	}
+	return nil
+}
+
+// fail records the failed status best-effort and returns the underlying cause,
+// so a status-write hiccup never masks the real provisioning failure.
+func (p *EnvironmentProvisioner) fail(ctx context.Context, environmentID, reason string, cause error) error {
+	_ = p.status.UpdateProvisioningStatus(ctx, environmentID, string(model.EnvironmentStatusFailed), reason)
+	return cause
+}

--- a/erun-backend/erun-backend-api/internal/service/environments_test.go
+++ b/erun-backend/erun-backend-api/internal/service/environments_test.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/deployexec"
+)
+
+type recordingStatusWriter struct {
+	transitions []string // "status:error" per call
+	err         error
+}
+
+func (w *recordingStatusWriter) UpdateProvisioningStatus(_ context.Context, _, status, provisionError string) error {
+	w.transitions = append(w.transitions, status+":"+provisionError)
+	return w.err
+}
+
+type fakeRunner struct {
+	outcome deployexec.Outcome
+	err     error
+}
+
+func (r fakeRunner) Run(context.Context, deployexec.DeployJobParams) (deployexec.Outcome, error) {
+	return r.outcome, r.err
+}
+
+func provision(t *testing.T, runner DeployRunner, status *recordingStatusWriter) error {
+	t.Helper()
+	return NewEnvironmentProvisioner(runner, status).Provision(context.Background(), "env-1", deployexec.DeployJobParams{})
+}
+
+func TestProvisionMarksRunningOnSuccess(t *testing.T) {
+	status := &recordingStatusWriter{}
+	if err := provision(t, fakeRunner{outcome: deployexec.OutcomeSucceeded}, status); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	want := []string{"provisioning:", "running:"}
+	assertTransitions(t, status.transitions, want)
+}
+
+func TestProvisionMarksFailedOnJobFailure(t *testing.T) {
+	status := &recordingStatusWriter{}
+	err := provision(t, fakeRunner{outcome: deployexec.OutcomeFailed}, status)
+	if err == nil {
+		t.Fatal("expected an error when the deploy job fails")
+	}
+	if len(status.transitions) != 2 || status.transitions[0] != "provisioning:" || status.transitions[1] == "running:" {
+		t.Fatalf("transitions = %v, want provisioning then a failed state", status.transitions)
+	}
+	if status.transitions[1][:7] != "failed:" {
+		t.Fatalf("second transition = %q, want failed:*", status.transitions[1])
+	}
+}
+
+func TestProvisionMarksFailedOnRunError(t *testing.T) {
+	status := &recordingStatusWriter{}
+	err := provision(t, fakeRunner{err: errors.New("cluster unreachable")}, status)
+	if err == nil {
+		t.Fatal("expected the run error to propagate")
+	}
+	if status.transitions[len(status.transitions)-1] != "failed:cluster unreachable" {
+		t.Fatalf("last transition = %q, want failed:cluster unreachable", status.transitions[len(status.transitions)-1])
+	}
+}
+
+func assertTransitions(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("transitions = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("transition[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
Part of **#605**. The orchestration on top of the tested deploy-Job launcher — the state machine that moves a hosted env `registered → provisioning → running/failed` around a deploy run.

## What
- **repository** — `EnvironmentRepository.UpdateProvisioningStatus` persists the transition (`status` + `provision_error`, cleared on non-failed), RLS-scoped; mirrors the `contexts` provisioning-result update.
- **service** — `EnvironmentProvisioner.Provision` marks `provisioning`, runs the deploy (via a `DeployRunner` — the `deployexec` launcher), and records the terminal status. A run error **or** a non-succeeded Job both land it `failed` with the reason, best-effort so a status-write hiccup never masks the real failure. The transitions live in the service so they're unit-testable without a cluster.

## Verification
Fakes cover the three transition sequences: running-on-success, failed-on-job-failure, failed-on-run-error. `go build`/`go test`/`golangci-lint` (0) full-module. No `erun-cli`/`erun-common` change → integration gate unaffected.

## Final wiring increment (same #605 arc)
The durable **DBOS workflow** wrapping this coordinator, the **in-cluster kube client**, the **deployer-SA RBAC**, the **env-create trigger**, and the **console status display**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)