### PR TITLE
Add Windows PowerShell run-scripts for the dev workflow

### DIFF
--- a/erun-cli/erun.cmd
+++ b/erun-cli/erun.cmd
@@ -1,0 +1,6 @@
+@echo off
+REM erun shim: Windows equivalent of the `erun` alias on macOS/Linux.
+REM Put this dir (erun-cli) on PATH; typing `erun ...` forwards to run.ps1,
+REM which rebuilds from source and runs the latest build. ASCII-only on purpose.
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0run.ps1" %*
+exit /b %ERRORLEVEL%

--- a/erun-cli/run.ps1
+++ b/erun-cli/run.ps1
@@ -1,0 +1,80 @@
+<#
+run.ps1 - Windows counterpart of erun-cli/run.sh.
+
+Rebuilds the erun CLI from source on every invocation and execs it, so `erun`
+always runs the latest source. For `erun app` it also rebuilds the desktop app
+(via erun-ui/build.ps1) into erun-cli\bin\erun-app.exe before launching, so
+`erun app` resolves the fresh desktop next to erun.exe (erun-cli/cmd/app.go).
+
+Invoked via the `erun` shim (erun.cmd) on PATH; not usually called directly.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$CliArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+# Make the toolchain resolvable even from a shell with a stale in-memory PATH.
+$persisted = ([Environment]::GetEnvironmentVariable('Path','Machine'), [Environment]::GetEnvironmentVariable('Path','User')) -join ';'
+$env:Path = $persisted + ';' + $env:Path
+
+$ScriptDir = $PSScriptRoot                       # erun-cli
+$RepoRoot = Split-Path $ScriptDir -Parent
+$Bin = Join-Path $ScriptDir "bin"
+$CliExe = Join-Path $Bin "erun.exe"
+$AppExe = Join-Path $Bin "erun-app.exe"
+$UiBuild = Join-Path $RepoRoot "erun-ui\build.ps1"
+New-Item -ItemType Directory -Force -Path $Bin | Out-Null
+
+# --- version stamp (mirror run.sh) ----------------------------------------
+$versionFile = Join-Path $RepoRoot "erun-devops\VERSION"
+$buildVersion = if (Test-Path $versionFile) { (Get-Content $versionFile -Raw).Trim() } else { "dev" }
+$buildCommit = ""
+$buildDate = ""
+if (git -C $ScriptDir rev-parse --is-inside-work-tree 2>$null) {
+    $buildCommit = (git -C $ScriptDir rev-parse --short=12 HEAD).Trim()
+    $buildDate = (git -C $ScriptDir show -s --format=%cI HEAD).Trim()
+}
+
+# --- detect subcommand (first non-flag arg) and --no-shell quiet mode ------
+$commandName = ""
+foreach ($a in $CliArgs) {
+    if ($a -eq "--") { break }
+    if ($a -notlike "-*") { $commandName = $a; break }
+}
+$quiet = ($CliArgs -contains "--no-shell")
+
+# --- always rebuild the CLI (CGO disabled; fast) ---------------------------
+$ldflags = "-X github.com/sophium/erun/cmd.buildVersion=$buildVersion " +
+           "-X github.com/sophium/erun/cmd.buildCommit=$buildCommit " +
+           "-X github.com/sophium/erun/cmd.buildDate=$buildDate"
+if (-not $quiet) { [Console]::Error.Write(">> rebuilding erun CLI ($buildVersion)... ") }
+$env:CGO_ENABLED = "0"
+try {
+    Push-Location $ScriptDir
+    go build -ldflags $ldflags -o $CliExe .
+    if ($LASTEXITCODE -ne 0) { throw "failed to build erun.exe" }
+    Pop-Location
+} finally { Remove-Item Env:CGO_ENABLED -ErrorAction SilentlyContinue }
+if (-not $quiet) { [Console]::Error.WriteLine("ok -> $CliExe") }
+
+# --- for `erun app`, rebuild the desktop bundle into the same bin ----------
+# Non-fatal like run.sh: a missing wails/yarn/node/gcc toolchain warns but still
+# lets the CLI run (its `app` subcommand emits a clear not-found message).
+if ($commandName -eq "app") {
+    try {
+        & $UiBuild -Target $AppExe
+        if ($LASTEXITCODE -ne 0 -and $null -ne $LASTEXITCODE) { throw "build.ps1 returned $LASTEXITCODE" }
+    } catch {
+        [Console]::Error.WriteLine(">> skipping desktop rebuild: $($_.Exception.Message) (missing wails/yarn/node/gcc toolchain?)")
+    }
+}
+
+# Prepend bin so the launched desktop app (and any PTY tab it spawns) resolves
+# the freshly-built plain erun.exe here, not the rebuilding shim on PATH.
+$env:Path = "$Bin;$env:Path"
+
+& $CliExe @CliArgs
+exit $LASTEXITCODE

--- a/erun-mcp/emcp.cmd
+++ b/erun-mcp/emcp.cmd
@@ -1,0 +1,6 @@
+@echo off
+REM emcp shim: Windows equivalent of the `emcp` alias on macOS/Linux.
+REM Put this dir (erun-mcp) on PATH; typing `emcp ...` forwards to run.ps1,
+REM which rebuilds emcp from source and runs the latest build. ASCII-only.
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0run.ps1" %*
+exit /b %ERRORLEVEL%

--- a/erun-mcp/run.ps1
+++ b/erun-mcp/run.ps1
@@ -1,0 +1,48 @@
+<#
+run.ps1 - Windows counterpart of erun-mcp/run.sh.
+
+Rebuilds the emcp (ERun MCP server) binary from source on every invocation and
+execs it, so `emcp` always runs the latest source. Invoked via the `emcp` shim
+(emcp.cmd) on PATH; not usually called directly.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$CliArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+# Make the toolchain resolvable even from a shell with a stale in-memory PATH.
+$persisted = ([Environment]::GetEnvironmentVariable('Path','Machine'), [Environment]::GetEnvironmentVariable('Path','User')) -join ';'
+$env:Path = $persisted + ';' + $env:Path
+
+$ScriptDir = $PSScriptRoot                       # erun-mcp
+$RepoRoot = Split-Path $ScriptDir -Parent
+$Bin = Join-Path $ScriptDir "bin"
+$McpExe = Join-Path $Bin "emcp.exe"
+New-Item -ItemType Directory -Force -Path $Bin | Out-Null
+
+# --- version stamp (mirror run.sh) ----------------------------------------
+$versionFile = Join-Path $RepoRoot "erun-devops\VERSION"
+$buildVersion = if (Test-Path $versionFile) { (Get-Content $versionFile -Raw).Trim() } else { "dev" }
+$buildCommit = ""
+$buildDate = ""
+if (git -C $ScriptDir rev-parse --is-inside-work-tree 2>$null) {
+    $buildCommit = (git -C $ScriptDir rev-parse --short=12 HEAD).Trim()
+    $buildDate = (git -C $ScriptDir show -s --format=%cI HEAD).Trim()
+}
+
+$ldflags = "-X github.com/sophium/erun/erun-mcp.buildVersion=$buildVersion " +
+           "-X github.com/sophium/erun/erun-mcp.buildCommit=$buildCommit " +
+           "-X github.com/sophium/erun/erun-mcp.buildDate=$buildDate"
+$env:CGO_ENABLED = "0"
+try {
+    Push-Location $ScriptDir
+    go build -ldflags $ldflags -o $McpExe ./cmd/emcp
+    if ($LASTEXITCODE -ne 0) { throw "failed to build emcp.exe" }
+    Pop-Location
+} finally { Remove-Item Env:CGO_ENABLED -ErrorAction SilentlyContinue }
+
+& $McpExe @CliArgs
+exit $LASTEXITCODE

--- a/erun-ui/build.ps1
+++ b/erun-ui/build.ps1
@@ -1,0 +1,92 @@
+<#
+build.ps1 - Windows counterpart of erun-ui/build.sh.
+
+Builds the ERun desktop binary (erun-app.exe): installs the go.mod-pinned Wails
+CLI, generates frontend bindings, builds the React/Vite frontend with Yarn, then
+compiles the Go desktop app with the desktop,production tags and -H windowsgui.
+
+Unlike build.sh this skips the lint/typecheck/format gates for a fast "produce
+the binary" build (run those via the pre-commit hook or `yarn` directly). The
+Wails Windows build uses CGO, so a C compiler (MinGW gcc) must be on PATH.
+
+  .\build.ps1                         # -> erun-ui\bin\erun-app.exe
+  .\build.ps1 -Target C:\path\app.exe # explicit output (run.ps1 uses erun-cli\bin)
+#>
+[CmdletBinding()]
+param(
+    [string]$Target
+)
+
+$ErrorActionPreference = "Stop"
+
+# Make the toolchain (go/node/yarn/gcc, Scoop-installed and persisted to PATH)
+# resolvable even if the launching shell has a stale in-memory PATH.
+$persisted = ([Environment]::GetEnvironmentVariable('Path','Machine'), [Environment]::GetEnvironmentVariable('Path','User')) -join ';'
+$env:Path = $persisted + ';' + $env:Path
+
+$ScriptDir = $PSScriptRoot
+$RepoRoot = Split-Path $ScriptDir -Parent
+if (-not $Target) { $Target = Join-Path $ScriptDir "bin\erun-app.exe" }
+New-Item -ItemType Directory -Force -Path (Split-Path $Target -Parent) | Out-Null
+
+function Require-Cmd($name, $hint) {
+    if (-not (Get-Command $name -ErrorAction SilentlyContinue)) { throw "'$name' not found on PATH. $hint" }
+}
+Require-Cmd go   "Install with: scoop install go"
+Require-Cmd node "Install with: scoop install nodejs"
+Require-Cmd yarn "Install with: scoop install yarn"
+Require-Cmd gcc  "erun-app.exe needs a C compiler. Install with: scoop install mingw"
+
+# --- version stamp (mirror build.sh) --------------------------------------
+$versionFile = Join-Path $RepoRoot "erun-devops\VERSION"
+$buildVersion = if (Test-Path $versionFile) { (Get-Content $versionFile -Raw).Trim() } else { "dev" }
+$buildCommit = ""
+$buildDate = ""
+if (git -C $ScriptDir rev-parse --is-inside-work-tree 2>$null) {
+    $buildCommit = (git -C $ScriptDir rev-parse --short=12 HEAD).Trim()
+    $buildDate = (git -C $ScriptDir show -s --format=%cI HEAD).Trim()
+}
+
+Push-Location $ScriptDir
+try {
+    # --- Wails CLI (pinned to go.mod), cached in bin\.wails-bin -------------
+    $wailsVersion = (go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2)
+    if ($LASTEXITCODE -ne 0) { throw "failed to resolve Wails version" }
+    $wailsBin = Join-Path $ScriptDir "bin\.wails-bin"
+    $wailsExe = Join-Path $wailsBin "wails.exe"
+    if (-not (Test-Path $wailsExe)) {
+        Write-Host ">> installing pinned Wails CLI ($wailsVersion) ..."
+        New-Item -ItemType Directory -Force -Path $wailsBin | Out-Null
+        $env:GOBIN = $wailsBin
+        try {
+            go install "github.com/wailsapp/wails/v2/cmd/wails@$wailsVersion"
+            if ($LASTEXITCODE -ne 0) { throw "failed to install Wails CLI" }
+        } finally { Remove-Item Env:GOBIN -ErrorAction SilentlyContinue }
+    }
+
+    Write-Host ">> generating frontend bindings ..."
+    & $wailsExe generate module
+    if ($LASTEXITCODE -ne 0) { throw "failed to generate frontend bindings" }
+
+    # --- frontend ----------------------------------------------------------
+    Push-Location (Join-Path $ScriptDir "frontend")
+    try {
+        Write-Host ">> yarn install ..."
+        if (Test-Path "yarn.lock") { yarn install --frozen-lockfile } else { yarn install }
+        if ($LASTEXITCODE -ne 0) { throw "failed to install frontend dependencies" }
+        Write-Host ">> yarn build ..."
+        yarn build
+        if ($LASTEXITCODE -ne 0) { throw "failed to build frontend assets" }
+    } finally { Pop-Location }
+
+    # --- desktop binary ----------------------------------------------------
+    Write-Host ">> building $([System.IO.Path]::GetFileName($Target)) ($buildVersion) ..."
+    $ldflags = "-s -w -H windowsgui " +
+               "-X github.com/sophium/erun/erun-ui.buildVersion=$buildVersion " +
+               "-X github.com/sophium/erun/erun-ui.buildCommit=$buildCommit " +
+               "-X github.com/sophium/erun/erun-ui.buildDate=$buildDate"
+    go build -trimpath -tags "desktop,production" -ldflags $ldflags -o $Target .
+    if ($LASTEXITCODE -ne 0) { throw "failed to build erun-app.exe" }
+} finally { Pop-Location }
+
+Write-Host ">> ok -> $Target" -ForegroundColor Green


### PR DESCRIPTION
Closes #836

Adds PowerShell counterparts to the POSIX dev scripts so `erun`, `erun app`, and `emcp` rebuild from source and run the latest build on Windows, matching the alias-driven workflow on macOS/Linux.

## What
- `erun-cli/run.ps1` + `erun-cli/erun.cmd` — rebuild the CLI each call; for `erun app`, also build the desktop into `erun-cli\bin\erun-app.exe` (next to `erun.exe`, where `erun-cli/cmd/app.go` resolves it), then exec.
- `erun-ui/build.ps1` — desktop builder mirroring `build.sh` (pinned Wails CLI, `yarn` frontend build, `-tags desktop,production -H windowsgui`); names outputs `.exe`; skips lint gates for a fast dev build.
- `erun-mcp/run.ps1` + `erun-mcp/emcp.cmd` — same pattern for `emcp`.

## Why the `.sh` scripts couldn't be reused
- `go build -o bin/erun` yields a file named `erun` (no `.exe`) on Windows, but `app.go` resolves `erun-app.exe` with the extension — so `erun app` couldn't find the desktop binary.
- `build.sh` runs the lint/typecheck/format gates (needs `golangci-lint`), heavier than a run-latest dev loop.

## Notes
- Scripts derive the repo root from their own location (no hardcoded paths) and self-load the persisted PATH so the toolchain resolves from any shell.
- No Go changes; lint/integration gates don't apply.

## Verified (Windows 11)
- `erun version` → rebuilds `erun-cli\bin\erun.exe`, prints version.
- `erun app` → rebuilds desktop, launches the "ERun" window from `erun-cli\bin\erun-app.exe`.
- `emcp --help` → rebuilds `erun-mcp\bin\emcp.exe`, prints usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)