### PR TITLE
Suppress stray console windows spawned by the Windows desktop app

### DIFF
--- a/erun-common/exec.go
+++ b/erun-common/exec.go
@@ -10,7 +10,15 @@ import (
 
 // Command wraps exec.Command, honoring an ERUN_<NAME>_BIN override so tests
 // can redirect a named binary to a stub without a live toolchain or account.
+// On Windows it also suppresses the stray console window that a console child
+// of the windowless desktop app would otherwise flash (see HideConsoleWindow).
 func Command(name string, args ...string) *exec.Cmd {
+	cmd := newExecCommand(name, args...)
+	HideConsoleWindow(cmd)
+	return cmd
+}
+
+func newExecCommand(name string, args ...string) *exec.Cmd {
 	if strings.ContainsAny(name, "/\\") {
 		return exec.Command(name, args...)
 	}

--- a/erun-common/exec_other.go
+++ b/erun-common/exec_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package eruncommon
+
+import "os/exec"
+
+// HideConsoleWindow is a no-op off Windows, where there is no stray console
+// window to suppress. See exec_windows.go for the real implementation.
+func HideConsoleWindow(cmd *exec.Cmd) {}

--- a/erun-common/exec_windows.go
+++ b/erun-common/exec_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package eruncommon
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// createNoWindow is the Win32 CREATE_NO_WINDOW process-creation flag. A console
+// subsystem child (git, kubectl, the erun CLI, ...) spawned from the desktop app
+// -- which is linked -H windowsgui and therefore owns no console -- otherwise
+// gets a brand new console window allocated for it, which flashes up and
+// vanishes. This flag runs the child without that console window.
+const createNoWindow = 0x08000000
+
+// HideConsoleWindow suppresses the transient console window Windows would
+// otherwise allocate for a console child of the windowless GUI app. It is a
+// no-op on other platforms (see exec_other.go). Inherited stdio handles still
+// work, so redirected stdout/stderr are unaffected.
+func HideConsoleWindow(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= createNoWindow
+}

--- a/erun-ui/buildinfo.go
+++ b/erun-ui/buildinfo.go
@@ -32,7 +32,9 @@ func resolveCurrentBuildInfo(resolveCLIPath func() string) eruncommon.BuildInfo 
 		return fallback
 	}
 
-	output, err := exec.Command(cliPath, "version", "--no-registry").Output()
+	versionCmd := exec.Command(cliPath, "version", "--no-registry")
+	eruncommon.HideConsoleWindow(versionCmd)
+	output, err := versionCmd.Output()
 	if err != nil {
 		return fallback
 	}

--- a/erun-ui/paste.go
+++ b/erun-ui/paste.go
@@ -39,6 +39,7 @@ func savePastedFileToRuntime(params pastedFileSaveParams) (string, error) {
 	name, args, _ := buildPastedFileCopyCommand(params.Result, remoteDir, remotePath)
 
 	cmd := exec.Command(name, args...)
+	eruncommon.HideConsoleWindow(cmd)
 	cmd.Stdin = strings.NewReader(base64.StdEncoding.EncodeToString(params.Data))
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/erun-ui/session_windows.go
+++ b/erun-ui/session_windows.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	"github.com/ActiveState/termtest/conpty"
+	eruncommon "github.com/sophium/erun/erun-common"
 )
 
 type windowsTerminalSession struct {
@@ -108,7 +109,9 @@ func (s *windowsTerminalSession) Close() error {
 		// open, leaving a stale dtach client attached in the pod after every
 		// close.
 		if s.process.Pid > 0 {
-			_ = exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(s.process.Pid)).Run()
+			killCmd := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(s.process.Pid))
+			eruncommon.HideConsoleWindow(killCmd)
+			_ = killCmd.Run()
 		}
 		_ = s.process.Kill()
 		_ = s.Wait()

--- a/erun-ui/state_handlers.go
+++ b/erun-ui/state_handlers.go
@@ -282,13 +282,17 @@ func buildDetailsFrom(info eruncommon.BuildInfo) uiBuildDetails {
 }
 
 func listKubernetesContexts() ([]string, error) {
-	output, err := exec.Command("kubectl", "config", "get-contexts", "-o=name").Output()
+	contextsCmd := exec.Command("kubectl", "config", "get-contexts", "-o=name")
+	eruncommon.HideConsoleWindow(contextsCmd)
+	output, err := contextsCmd.Output()
 	if err != nil {
 		return nil, wrapKubectlError(err)
 	}
 	contexts := strings.Split(string(output), "\n")
 
-	currentOutput, err := exec.Command("kubectl", "config", "current-context").Output()
+	currentCmd := exec.Command("kubectl", "config", "current-context")
+	eruncommon.HideConsoleWindow(currentCmd)
+	currentOutput, err := currentCmd.Output()
 	if err == nil {
 		contexts = preferCurrentKubernetesContext(contexts, string(currentOutput))
 	}


### PR DESCRIPTION
## Problem

On Windows the desktop app (`erun-app.exe`, linked `-H windowsgui`) owns no console. Every console-subsystem child it spawns — `git`, `kubectl`, `docker`, the `erun` CLI, `taskkill` on terminal-tab close — has a fresh console window allocated by Windows that flashes up and immediately disappears. PTY terminal tabs are unaffected because they run through ConPTY.

## Fix

Add a Windows-only `eruncommon.HideConsoleWindow` that sets the Win32 `CREATE_NO_WINDOW` process-creation flag, apply it centrally in `eruncommon.Command` (covers the bulk of spawns), and call it at the direct `exec.Command` sites that run inside the GUI process:

- `erun-common/exec_windows.go` / `exec_other.go` (new) + `exec.go` — central helper + wiring.
- `erun-ui/buildinfo.go` — `erun version --no-registry`.
- `erun-ui/state_handlers.go` — `kubectl` context lookups.
- `erun-ui/paste.go` — pasted-file copy into the runtime.
- `erun-ui/session_windows.go` — `taskkill` on terminal-tab close.

Inherited stdio handles are untouched, so redirected stdout/stderr still works; the helper is a no-op off Windows.

## Validation

- `erun-ui` compiles clean with `-tags desktop,production` (CGO); full `erun-app.exe` rebuild via `build.ps1` succeeds.
- Integration suite: all `--dry-run` goldens pass once the working tree is normalized to LF. Two pre-existing Windows-only test-harness failures remain and reproduce on `main` without this change (autocrlf CRLF goldens; docker credential-helper stub) — tracked in #839. This is a pure bug fix that preserves behavior and does not touch `erun-cli` or the version command.

Closes #838