### PR TITLE
Windows desktop env-init: suppress console flashing and mark required fields

### DIFF
--- a/erun-cli/cmd/open_ide.go
+++ b/erun-cli/cmd/open_ide.go
@@ -104,6 +104,7 @@ func ideLaunchCommand(hostOS common.HostOS, uri string) (string, []string, error
 
 func openIDEURICommand(ctx common.Context, command string, args []string) (string, error) {
 	cmd := ideExecCommand(command, args...)
+	common.HideConsoleWindow(cmd)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdin = ctx.Stdin
@@ -122,6 +123,7 @@ func openIDEURICommand(ctx common.Context, command string, args []string) (strin
 
 func startIDEURICommand(ctx common.Context, command string, args []string) (string, error) {
 	cmd := ideExecCommand(command, args...)
+	common.HideConsoleWindow(cmd)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdin = nil
@@ -185,6 +187,7 @@ func runJetBrainsBootstrapAttempt(ctx common.Context, attempt jetbrainsBootstrap
 		return nil
 	}
 	cmd := ideExecCommand(attempt.command, attempt.args...)
+	common.HideConsoleWindow(cmd)
 	cmd.Stdin = nil
 	cmd.Stdout = &bytes.Buffer{}
 	cmd.Stderr = &bytes.Buffer{}

--- a/erun-ui/AGENTS.md
+++ b/erun-ui/AGENTS.md
@@ -12,6 +12,7 @@ Module-specific guidance for `erun-ui`. Follow the repository root `AGENTS.md` f
 ## Frontend And Backend Split
 
 - Keep Wails startup, native window integration, PTY management, process execution, and session lifecycle in Go.
+- The desktop is linked `-H windowsgui` and owns no console, so every console child it spawns on Windows (`erun`, `kubectl`, `helm`, `git`, `ssh`, `tar`, ...) otherwise gets a brand-new console window that flashes and vanishes. Any non-PTY `exec.Command`/`exec.CommandContext` in this module must call `eruncommon.HideConsoleWindow(cmd)` before running — it is a no-op off Windows. PTY-backed sessions (ConPTY/`creack/pty`) attach to their own pseudo-console and are exempt. This applies transitively: a child the desktop launches windowless whose own children are console apps must suppress them too (see the IDE launcher in `erun-cli/cmd/open_ide.go`).
 - Desktop terminal sessions are one per pod per tab id: opening an env in any window takes over the existing pod session (`screen -d -r`), never mirrors. Preserve this invariant.
 - Diagnostics and error capture must be always-on and bounded — never gated behind an opt-in the user discovers only after an error has happened.
 - Keep layout, interaction behavior, DOM state, and terminal presentation in the frontend source tree.

--- a/erun-ui/activity_helm_poller.go
+++ b/erun-ui/activity_helm_poller.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
 )
 
 type helmReleaseSnapshot struct {
@@ -80,6 +82,7 @@ func helmListTenantDevopsArgs(kubeContext string) []string {
 
 func listTenantDevopsHelmReleases(ctx context.Context, kubeContext string) ([]helmReleaseSnapshot, error) {
 	cmd := exec.CommandContext(ctx, "helm", helmListTenantDevopsArgs(kubeContext)...)
+	eruncommon.HideConsoleWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err

--- a/erun-ui/activity_queue_app.go
+++ b/erun-ui/activity_queue_app.go
@@ -798,6 +798,7 @@ func (a *App) fetchActivityContainerStatuses(ctx context.Context, entry activity
 		args = append(args, "--namespace", entry.Namespace)
 	}
 	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	eruncommon.HideConsoleWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err

--- a/erun-ui/api_log.go
+++ b/erun-ui/api_log.go
@@ -38,7 +38,9 @@ func kubectlText(ctx context.Context, kubernetesContext string, args ...string) 
 	if kubernetesContext != "" {
 		args = append([]string{"--context", kubernetesContext}, args...)
 	}
-	output, err := exec.CommandContext(ctx, "kubectl", args...).CombinedOutput()
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	eruncommon.HideConsoleWindow(cmd)
+	output, err := cmd.CombinedOutput()
 	text := strings.TrimRight(string(output), "\n")
 	if err != nil {
 		if strings.TrimSpace(text) != "" {

--- a/erun-ui/contribute_app.go
+++ b/erun-ui/contribute_app.go
@@ -106,6 +106,7 @@ var (
 // timeout. Reaping is owned by the forward, so this must not call Wait().
 var spawnContributeAppForwardCmd = func(ctx context.Context, args []string) (*exec.Cmd, *bytes.Buffer, error) {
 	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	eruncommon.HideConsoleWindow(cmd)
 	stderr := new(bytes.Buffer)
 	cmd.Stdout = io.Discard
 	cmd.Stderr = stderr

--- a/erun-ui/deploy_orchestration.go
+++ b/erun-ui/deploy_orchestration.go
@@ -138,6 +138,7 @@ func runErunCaptured(ctx context.Context, cliPath, dir string, onLine func(strin
 		cliPath = "erun"
 	}
 	cmd := exec.CommandContext(ctx, cliPath, args...)
+	eruncommon.HideConsoleWindow(cmd)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), appSessionEnvVar+"=1")
 	stdoutPipe, err := cmd.StdoutPipe()

--- a/erun-ui/environment_working_issue.go
+++ b/erun-ui/environment_working_issue.go
@@ -40,6 +40,7 @@ func parseIssueNumberFromBranch(branch string) int {
 
 func execWorkingIssueCommand(ctx context.Context, dir, name string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
+	eruncommon.HideConsoleWindow(cmd)
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	return strings.TrimSpace(string(out)), err

--- a/erun-ui/frontend/src/components/app/EditableComboField.tsx
+++ b/erun-ui/frontend/src/components/app/EditableComboField.tsx
@@ -3,9 +3,10 @@ import * as React from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
+
+import { FieldLabel } from './FieldLabel';
 
 function EditableComboChoices({
   id,
@@ -86,7 +87,9 @@ export function EditableComboField({
 
   return (
     <div className="grid gap-2">
-      <Label htmlFor={id}>{label}</Label>
+      <FieldLabel htmlFor={id} required={required}>
+        {label}
+      </FieldLabel>
       <div className="relative">
         <Input
           id={id}

--- a/erun-ui/frontend/src/components/app/EnvironmentTypeFields.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentTypeFields.tsx
@@ -63,6 +63,7 @@ export function LocalRepoPathField({ dialog }: { dialog: EnvironmentDialog }): R
       helper="Absolute path on this machine. Mounted into the agent pod as the worktree."
       value={dialog.localRepoPath}
       disabled={dialog.busy}
+      required
       onChange={(value) => {
         dispatch(updateEnvironmentDialog({ localRepoPath: value }));
       }}

--- a/erun-ui/frontend/src/components/app/FieldLabel.tsx
+++ b/erun-ui/frontend/src/components/app/FieldLabel.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+
+import { Label } from '@/components/ui/label';
+
+// FieldLabel is the shared label for form fields in the app's dialogs. It renders
+// an explicit required marker so users can see at a glance which fields are
+// mandatory (recognition over recall) instead of discovering it only when a
+// disabled submit button names one missing value at a time. The asterisk is a
+// glyph, not a colour-only cue, and the visually-hidden "(required)" folds into
+// the control's accessible name via htmlFor, so the requirement is conveyed
+// non-visually too (WCAG 1.4.1).
+export function FieldLabel({
+  htmlFor,
+  required,
+  children,
+}: {
+  htmlFor: string;
+  required?: boolean;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <Label htmlFor={htmlFor}>
+      {children}
+      {required && (
+        <>
+          <span aria-hidden="true" className="ml-0.5 text-destructive">
+            *
+          </span>
+          <span className="sr-only"> (required)</span>
+        </>
+      )}
+    </Label>
+  );
+}

--- a/erun-ui/frontend/src/components/app/LocalRepoPathInput.tsx
+++ b/erun-ui/frontend/src/components/app/LocalRepoPathInput.tsx
@@ -6,7 +6,8 @@ import { useAppDispatch } from '@/app/hooks';
 import { showTerminalMessage } from '@/app/notificationThunks';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
+
+import { FieldLabel } from './FieldLabel';
 
 // LocalRepoPathInput is the shared host-worktree-path field for the init dialog
 // and the env-settings General tab, so both edit the path identically. Free-text
@@ -18,6 +19,7 @@ export function LocalRepoPathInput({
   helper,
   value,
   disabled,
+  required,
   onChange,
 }: {
   id: string;
@@ -25,6 +27,7 @@ export function LocalRepoPathInput({
   helper: string;
   value: string;
   disabled?: boolean;
+  required?: boolean;
   onChange: (value: string) => void;
 }): React.ReactElement {
   const dispatch = useAppDispatch();
@@ -43,7 +46,9 @@ export function LocalRepoPathInput({
   };
   return (
     <div className="grid gap-2">
-      <Label htmlFor={id}>{label}</Label>
+      <FieldLabel htmlFor={id} required={required}>
+        {label}
+      </FieldLabel>
       <div className="flex items-stretch gap-2">
         <Input
           id={id}
@@ -53,6 +58,7 @@ export function LocalRepoPathInput({
           spellCheck={false}
           placeholder="/Users/you/code/your-project"
           aria-describedby={helperId}
+          required={required}
           disabled={disabled}
           onChange={(event) => {
             onChange(event.target.value);

--- a/erun-ui/frontend/src/components/app/SelectField.tsx
+++ b/erun-ui/frontend/src/components/app/SelectField.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -8,6 +7,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+
+import { FieldLabel } from './FieldLabel';
 
 export interface SelectFieldOption {
   value: string;
@@ -43,7 +44,9 @@ export function SelectField({
   const helperId = helper ? `${id}-helper` : undefined;
   return (
     <div className="grid min-w-0 gap-2">
-      <Label htmlFor={id}>{label}</Label>
+      <FieldLabel htmlFor={id} required={required}>
+        {label}
+      </FieldLabel>
       <Select
         value={value || undefined}
         required={required}
@@ -54,6 +57,7 @@ export function SelectField({
           id={id}
           className="w-full min-w-0 *:data-[slot=select-value]:min-w-0 *:data-[slot=select-value]:overflow-hidden *:data-[slot=select-value]:text-ellipsis"
           aria-describedby={helperId}
+          aria-required={required}
         >
           <SelectValue
             placeholder={noOptions ? (emptyLabel ?? 'No options') : (placeholder ?? '')}

--- a/erun-ui/playwright/tests/env-init.spec.ts
+++ b/erun-ui/playwright/tests/env-init.spec.ts
@@ -50,6 +50,38 @@ test.describe('environment init dialog', () => {
     await app.envInitDialog.waitForClosed();
   });
 
+  test('marks mandatory fields with a required indicator (not colour-only)', async ({
+    app,
+    page,
+  }) => {
+    // The reported gap: Create sat disabled with no on-field cue for which values
+    // were mandatory — only a one-at-a-time footer reason. Every required field now
+    // carries a marker, and the requirement folds into the accessible name via the
+    // label's visually-hidden "(required)", so it is conveyed non-visually too.
+    await stubDialogCluster(page);
+    await app.sidebar.openInitDialog();
+    await app.envInitDialog.waitForOpen();
+
+    for (const name of [
+      'Tenant (required)',
+      'Environment (required)',
+      'Environment type (required)',
+      'Kubernetes context (required)',
+      'Container registry (required)',
+    ]) {
+      await expect(page.getByLabel(name, { exact: true })).toBeVisible();
+    }
+
+    // The visible marker is a glyph, present in the label DOM.
+    await expect(page.locator('label[for="environment-container-registry"]')).toContainText('*');
+
+    // Optional fields (e.g. Runtime version) carry no requirement marker.
+    await expect(page.getByLabel('Runtime version (required)', { exact: true })).toHaveCount(0);
+
+    await app.envInitDialog.cancel();
+    await app.envInitDialog.waitForClosed();
+  });
+
   test('init mode shows the "create" description and a submit-reason status line', async ({
     app,
   }) => {

--- a/erun-ui/runtime_resources.go
+++ b/erun-ui/runtime_resources.go
@@ -254,7 +254,9 @@ func kubectlJSON(ctx context.Context, kubernetesContext string, args ...string) 
 	if kubernetesContext != "" {
 		args = append([]string{"--context", kubernetesContext}, args...)
 	}
-	output, err := exec.CommandContext(ctx, "kubectl", args...).CombinedOutput()
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	eruncommon.HideConsoleWindow(cmd)
+	output, err := cmd.CombinedOutput()
 	if err != nil {
 		detail := strings.TrimSpace(string(output))
 		if detail != "" {

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -82,6 +82,7 @@ func resolveCLIExecutableFromPath(goos, appExecutable, executableName string) st
 
 func runIDECommand(ctx context.Context, params startTerminalSessionParams) (string, error) {
 	cmd := exec.CommandContext(ctx, params.Executable, params.Args...)
+	eruncommon.HideConsoleWindow(cmd)
 	cmd.Dir = resolveTerminalStartDir(params.Dir)
 	if len(params.Env) > 0 {
 		cmd.Env = append(os.Environ(), params.Env...)
@@ -217,6 +218,7 @@ func buildOpenNoShellArgs(tenant, environment string) []string {
 func ensureMCPViaOpenCommand(ctx context.Context, cliPath string, result eruncommon.OpenResult) error {
 	args := buildOpenNoShellArgs(result.Tenant, result.Environment)
 	cmd := exec.CommandContext(ctx, cliPath, args...)
+	eruncommon.HideConsoleWindow(cmd)
 	cmd.Env = append(os.Environ(), "ERUN_IDLE_PROBE=1")
 	output, err := cmd.CombinedOutput()
 	if err == nil {
@@ -236,6 +238,7 @@ func ensureMCPViaOpenCommand(ctx context.Context, cliPath string, result eruncom
 func runOpenForReconnect(ctx context.Context, cliPath string, result eruncommon.OpenResult, onLine func(string)) error {
 	args := buildOpenNoShellArgs(result.Tenant, result.Environment)
 	cmd := exec.CommandContext(ctx, cliPath, args...)
+	eruncommon.HideConsoleWindow(cmd)
 	cmd.Env = append(os.Environ(), "ERUN_IDLE_PROBE=1")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -287,6 +290,7 @@ func scanReconnectOutput(reader io.Reader, captureErr bool, onLine func(string),
 func ensureSSHDViaOpenCommand(ctx context.Context, cliPath string, result eruncommon.OpenResult) error {
 	args := buildOpenNoShellArgs(result.Tenant, result.Environment)
 	cmd := exec.CommandContext(ctx, cliPath, args...)
+	eruncommon.HideConsoleWindow(cmd)
 	cmd.Env = append(os.Environ(), "ERUN_IDLE_PROBE=1")
 	output, err := cmd.CombinedOutput()
 	if err == nil {

--- a/erun-ui/workspace_sync.go
+++ b/erun-ui/workspace_sync.go
@@ -292,6 +292,7 @@ func workspaceSyncSSHReady(ctx context.Context, hostAlias string) error {
 		return fmt.Errorf("ssh host alias is required")
 	}
 	cmd := exec.CommandContext(ctx, "ssh", workspaceSyncSSHArgs(hostAlias, "true")...)
+	eruncommon.HideConsoleWindow(cmd)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("ssh workspace is not ready: %w: %s", err, strings.TrimSpace(string(output)))
@@ -308,6 +309,7 @@ func ensureLocalWorkspaceSyncTarget(ctx context.Context, localPath string) error
 		return fmt.Errorf("local workspace path is not a directory: %s", localPath)
 	}
 	cmd := exec.CommandContext(ctx, "git", "-C", localPath, "rev-parse", "--is-inside-work-tree")
+	eruncommon.HideConsoleWindow(cmd)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("local workspace is not a Git worktree: %w: %s", err, strings.TrimSpace(string(output)))
@@ -319,7 +321,9 @@ var errRemoteNotGitRepo = errors.New("remote workspace is not a git repository")
 
 func remoteWorkspaceGitVisibleFiles(ctx context.Context, hostAlias, remotePath string) ([]string, error) {
 	script := fmt.Sprintf("cd %s && git ls-files -coz --exclude-standard", shellQuote(remotePath))
-	output, err := exec.CommandContext(ctx, "ssh", workspaceSyncSSHArgs(hostAlias, script)...).CombinedOutput()
+	cmd := exec.CommandContext(ctx, "ssh", workspaceSyncSSHArgs(hostAlias, script)...)
+	eruncommon.HideConsoleWindow(cmd)
+	output, err := cmd.CombinedOutput()
 	if err != nil {
 		detail := strings.TrimSpace(string(output))
 		if strings.Contains(detail, "not a git repository") {
@@ -334,7 +338,9 @@ func remoteWorkspaceGitVisibleFiles(ctx context.Context, hostAlias, remotePath s
 }
 
 func localWorkspaceGitVisibleFiles(ctx context.Context, localPath string) ([]string, error) {
-	output, err := exec.CommandContext(ctx, "git", "-C", localPath, "ls-files", "-coz", "--exclude-standard").Output()
+	cmd := exec.CommandContext(ctx, "git", "-C", localPath, "ls-files", "-coz", "--exclude-standard")
+	eruncommon.HideConsoleWindow(cmd)
+	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("list local Git-visible files: %w", err)
 	}
@@ -346,6 +352,7 @@ func filterLocalIgnoredWorkspaceSyncPaths(ctx context.Context, localPath string,
 		return nil, nil
 	}
 	cmd := exec.CommandContext(ctx, "git", "-C", localPath, "check-ignore", "-z", "--stdin")
+	eruncommon.HideConsoleWindow(cmd)
 	cmd.Stdin = bytes.NewReader(encodeWorkspaceSyncPathList(paths))
 	output, err := cmd.Output()
 	if err != nil {
@@ -368,6 +375,7 @@ func filterLocalIgnoredWorkspaceSyncPaths(ctx context.Context, localPath string,
 func extractRemoteWorkspaceFiles(ctx context.Context, hostAlias, remotePath, localPath string, paths []string) error {
 	script := fmt.Sprintf("cd %s && tar --null --ignore-failed-read -T - -cf -", shellQuote(remotePath))
 	sshCmd := exec.CommandContext(ctx, "ssh", workspaceSyncSSHArgs(hostAlias, script)...)
+	eruncommon.HideConsoleWindow(sshCmd)
 	sshCmd.Stdin = bytes.NewReader(encodeWorkspaceSyncPathList(paths))
 	sshStdout, err := sshCmd.StdoutPipe()
 	if err != nil {
@@ -377,6 +385,7 @@ func extractRemoteWorkspaceFiles(ctx context.Context, hostAlias, remotePath, loc
 	sshCmd.Stderr = &sshStderr
 
 	tarCmd := exec.CommandContext(ctx, "tar", "-xf", "-", "-C", localPath)
+	eruncommon.HideConsoleWindow(tarCmd)
 	tarCmd.Stdin = sshStdout
 	var tarStderr bytes.Buffer
 	tarCmd.Stderr = &tarStderr


### PR DESCRIPTION
Two fixes to the Windows desktop env-init experience, bundled per request.

## 1. Suppress stray console windows (#845)
The desktop is linked `-H windowsgui` and owns no console, so every console child it spawns without `CREATE_NO_WINDOW` gets a fresh console window allocated — it flashes and vanishes. #840 added `eruncommon.HideConsoleWindow` but only covered a few call sites; the Initialize-env path and others still spawned unsuppressed.

Routed every remaining non-PTY console child through `HideConsoleWindow`:
- deploy orchestration (`erun build`/`push`/`deploy`), the kubectl/helm activity pollers, `erun open` reconnect/ensure calls, environment-working-issue git lookups, workspace-sync (ssh/git/tar);
- the IDE launcher in `erun-cli` (`cmd`/`start` grandchild flashes when the desktop runs `erun open` windowless).

PTY-backed sessions (ConPTY / `creack/pty`) attach to their own pseudo-console and are exempt. The `erun` CLI's own subprocess spawns already route through `eruncommon.Command`, so grandchildren during build/push/deploy were covered by #840. Captured the rule in `erun-ui/AGENTS.md`.

## 2. Mark required fields in the New Environment dialog (#846)
Create stays disabled until all required values are provided, but nothing on the fields showed which were mandatory — only a one-at-a-time footer reason. Added a shared `FieldLabel` that renders a required marker, used in every field wrapper so Tenant, Environment, Environment type, Kubernetes context, Container registry, and (for local-agent) Local repo path are marked. The requirement is conveyed non-visually too — a screen-reader `(required)` folded into each control's accessible name plus `required`/`aria-required` — so it is not colour-only (WCAG 1.4.1). The footer's dynamic "why disabled" line stays as the complementary status signal.

## Validation
- erun-ui + erun-cli `go build` clean; erun-cli `go test` green.
- Frontend: `yarn typecheck && yarn lint && yarn format:check && yarn build` clean.
- Playwright: new `env-init.spec.ts` test asserts the markers and accessible name; playwright subproject typecheck/lint/format clean. The headless browser suite runs on the Linux/macOS host (the harness spawns `./bin/erun-app` without `.exe`); not executed on this Windows machine.
- `erun-integration` (gate for the `erun-cli` change): green except the documented Windows-only `#839` case (`TestVersion/registry_ghcr_authenticates_via_docker_credential_helper`, fake docker credential-helper stub not invocable on Windows; fails on `main` too), unrelated to this diff.
- erun-ui Go unit tests: the 7 failing on Windows are pre-existing (identical on `main`; PowerShell quoting, `~` expansion, `file://C:\` issuers, non-executable fake `kubectl`), unrelated to this diff.
- Rebuilt `erun-app.exe` with both changes and launched it to confirm they compile into the shipped desktop binary.

## Docs
No `erun-docs` update needed: (1) is a pure bug fix with no public-surface change; (2) surfaces which fields are already required without changing the required set or any command contract.

Closes #845
Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)