### PR TITLE
Wire the server-side env-deploy executor into env creation

### DIFF
--- a/erun-backend/erun-backend-api/cmd/eapi/main.go
+++ b/erun-backend/erun-backend-api/cmd/eapi/main.go
@@ -13,10 +13,13 @@ import (
 	"time"
 
 	"github.com/dbos-inc/dbos-transact-golang/dbos"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	backendapi "github.com/sophium/erun/erun-backend/erun-backend-api"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/dns01broker"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/mcptoken"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/provision"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/secrets"
 
@@ -64,6 +67,10 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
+	kubeClient, err := optionalKubeClient(cfg)
+	if err != nil {
+		return err
+	}
 
 	handler, err := backendapi.NewHandler(backendapi.HandlerOptions{
 		TokenVerifier: backendapi.NewBearerTokenVerifier(backendapi.BearerTokenVerifierOptions{
@@ -78,6 +85,12 @@ func run(args []string) error {
 		AWSEndpoint:   cfg.AWSEndpoint,
 		MCPSigner:     mcpSigner,
 		DNS01Broker:   dns01Broker,
+		KubeClient:    kubeClient,
+		EnvDeploy: provision.EnvDeployConfig{
+			Registry:               cfg.EnvDeployRegistry,
+			PlatformNamespace:      cfg.PlatformNamespace,
+			DeployerServiceAccount: cfg.EnvDeployerServiceAccount,
+		},
 	})
 	if err != nil {
 		return err
@@ -155,6 +168,15 @@ type apiConfig struct {
 	SecretsKey      string
 	DBOSDatabaseURL string
 	AWSEndpoint     string
+	// Server-side env-deploy executor (#605). EnvDeployerServiceAccount is the
+	// cluster-admin SA the deploy Job runs as; setting it enables live env
+	// provisioning (which then also needs an in-cluster kube client and
+	// DBOSContext). PlatformNamespace is the namespace the Jobs run in (the
+	// backend's own, via the downward API). EnvDeployRegistry is the image
+	// registry the tenant's <tenant>-devops runtime image is pulled from.
+	EnvDeployerServiceAccount string
+	PlatformNamespace         string
+	EnvDeployRegistry         string
 }
 
 func configFromEnv() apiConfig {
@@ -173,7 +195,27 @@ func configFromEnv() apiConfig {
 		DNS01TSIGKeyName:     strings.TrimSpace(os.Getenv("ERUN_DNS01_TSIG_KEY_NAME")),
 		DNS01TSIGAlgorithm:   strings.TrimSpace(os.Getenv("ERUN_DNS01_TSIG_ALGORITHM")),
 		DNS01TSIGSecret:      strings.TrimSpace(os.Getenv("ERUN_DNS01_TSIG_SECRET")),
+
+		EnvDeployerServiceAccount: strings.TrimSpace(os.Getenv("ERUN_ENV_DEPLOYER_SERVICE_ACCOUNT")),
+		PlatformNamespace:         strings.TrimSpace(os.Getenv("POD_NAMESPACE")),
+		EnvDeployRegistry:         envOrDefault("ERUN_ENV_DEPLOY_REGISTRY", "ghcr.io/sophium"),
 	}
+}
+
+// optionalKubeClient builds the in-cluster Kubernetes client the env-deploy
+// executor uses. A blank deployer ServiceAccount disables the executor (env
+// creation only registers the row); a set SA outside a cluster is a hard
+// misconfiguration (the SA is only ever set by the in-cluster deploy), so we
+// fail fast rather than silently disabling.
+func optionalKubeClient(cfg apiConfig) (kubernetes.Interface, error) {
+	if cfg.EnvDeployerServiceAccount == "" {
+		return nil, nil
+	}
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("in-cluster config for env-deploy executor: %w", err)
+	}
+	return kubernetes.NewForConfig(restConfig)
 }
 
 func optionalCipher(key string) (*secrets.Cipher, error) {

--- a/erun-backend/erun-backend-api/internal/deployexec/job.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/job.go
@@ -3,8 +3,9 @@
 // creates a Kubernetes Job that runs `erun deploy` inside the erun-devops
 // runtime image — which already carries erun + helm + kubectl — under a
 // cluster-admin ServiceAccount, and watches that Job to completion. This is the
-// executor half of the #605 provisioning control plane; the DBOS workflow that
-// moves the environment's status around it lands in a following increment.
+// executor half of the #605 provisioning control plane; the durable DBOS
+// workflow that moves the environment's status around it lives in the provision
+// package and drives this launcher through the service coordinator.
 package deployexec
 
 import (

--- a/erun-backend/erun-backend-api/internal/provision/environments.go
+++ b/erun-backend/erun-backend-api/internal/provision/environments.go
@@ -1,0 +1,100 @@
+package provision
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dbos-inc/dbos-transact-golang/dbos"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/deployexec"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+)
+
+// EnvProvisionInput is the durable workflow input DBOS checkpoints: tenant
+// identity plus the env's non-secret deploy coordinates. No secret is carried —
+// the deploy Job runs under its own cluster-admin ServiceAccount.
+type EnvProvisionInput struct {
+	TenantID      string `json:"tenantId"`
+	TenantType    string `json:"tenantType"`
+	ErunUserID    string `json:"erunUserId,omitempty"`
+	EnvironmentID string `json:"environmentId"`
+	Tenant        string `json:"tenant"`
+	Environment   string `json:"environment"`
+	Version       string `json:"version"`
+}
+
+// EnvCoordinator runs an env deploy to a terminal status — the service
+// EnvironmentProvisioner (mark provisioning → run the Job → mark running/failed).
+type EnvCoordinator interface {
+	Provision(ctx context.Context, environmentID string, params deployexec.DeployJobParams) error
+}
+
+// EnvDeployConfig is the per-instance placement the deploy Job needs: the image
+// registry, the namespace the Job runs in (the platform namespace), and the
+// cluster-admin ServiceAccount it runs as.
+type EnvDeployConfig struct {
+	Registry               string
+	PlatformNamespace      string
+	DeployerServiceAccount string
+}
+
+// EnvProvisioner runs the durable env-deploy workflow, so a control-plane restart
+// resumes it rather than re-running a completed deploy. It wraps the coordinator
+// in a DBOS workflow keyed by environment id, so a retried create never
+// double-deploys.
+type EnvProvisioner struct {
+	dbosCtx     dbos.DBOSContext
+	coordinator EnvCoordinator
+	config      EnvDeployConfig
+	workflowFn  func(dbos.DBOSContext, EnvProvisionInput) (string, error)
+}
+
+func NewEnvProvisioner(dbosCtx dbos.DBOSContext, coordinator EnvCoordinator, config EnvDeployConfig) *EnvProvisioner {
+	p := &EnvProvisioner{dbosCtx: dbosCtx, coordinator: coordinator, config: config}
+	// One stable function value shared by RegisterWorkflow and RunWorkflow, which
+	// is how DBOS names the workflow and recovers it across restarts.
+	p.workflowFn = p.provisionWorkflow
+	dbos.RegisterWorkflow(dbosCtx, p.workflowFn)
+	return p
+}
+
+// Start kicks off provisioning asynchronously so the HTTP handler returns
+// immediately while the durable workflow runs the deploy. The environment id is
+// the idempotency key, so a retried create does not start a second deploy.
+func (p *EnvProvisioner) Start(input EnvProvisionInput) error {
+	_, err := dbos.RunWorkflow(p.dbosCtx, p.workflowFn, input, dbos.WithWorkflowID("provision-env-"+input.EnvironmentID))
+	return err
+}
+
+// deployJobParams renders the placement for one env-deploy Job. The env deploys
+// with the tenant's own <tenant>-devops runtime image, which carries its baked
+// deploy config (the image-baked config model), pulled from the configured
+// registry at the requested version.
+func deployJobParams(config EnvDeployConfig, input EnvProvisionInput) deployexec.DeployJobParams {
+	return deployexec.DeployJobParams{
+		Tenant:         input.Tenant,
+		Environment:    input.Environment,
+		Version:        input.Version,
+		Namespace:      config.PlatformNamespace,
+		Image:          fmt.Sprintf("%s/%s-devops:%s", config.Registry, input.Tenant, input.Version),
+		ServiceAccount: config.DeployerServiceAccount,
+	}
+}
+
+func (p *EnvProvisioner) provisionWorkflow(dctx dbos.DBOSContext, input EnvProvisionInput) (string, error) {
+	params := deployJobParams(p.config, input)
+	// One step: the coordinator is idempotent on re-run (it re-marks provisioning
+	// and the Job create tolerates an already-exists, then re-watches), so a
+	// mid-deploy restart resumes cleanly without a second Job.
+	return dbos.RunAsStep(dctx, func(c context.Context) (string, error) {
+		scoped := security.WithContext(c, security.Context{
+			TenantID:   input.TenantID,
+			TenantType: input.TenantType,
+			ErunUserID: input.ErunUserID,
+		})
+		if err := p.coordinator.Provision(scoped, input.EnvironmentID, params); err != nil {
+			return "failed", err
+		}
+		return "running", nil
+	})
+}

--- a/erun-backend/erun-backend-api/internal/provision/environments_test.go
+++ b/erun-backend/erun-backend-api/internal/provision/environments_test.go
@@ -1,0 +1,30 @@
+package provision
+
+import "testing"
+
+// TestDeployJobParams pins the placement the deploy Job runs with: the tenant's
+// own <registry>/<tenant>-devops:<version> runtime image (image-baked config),
+// in the platform namespace, under the cluster-admin deployer ServiceAccount.
+func TestDeployJobParams(t *testing.T) {
+	params := deployJobParams(
+		EnvDeployConfig{
+			Registry:               "ghcr.io/sophium",
+			PlatformNamespace:      "erun-prod",
+			DeployerServiceAccount: "erun-env-deployer",
+		},
+		EnvProvisionInput{Tenant: "acme", Environment: "prod", Version: "1.2.3"},
+	)
+
+	if params.Image != "ghcr.io/sophium/acme-devops:1.2.3" {
+		t.Fatalf("image = %q, want ghcr.io/sophium/acme-devops:1.2.3", params.Image)
+	}
+	if params.Namespace != "erun-prod" {
+		t.Fatalf("namespace = %q, want erun-prod", params.Namespace)
+	}
+	if params.ServiceAccount != "erun-env-deployer" {
+		t.Fatalf("serviceAccount = %q, want erun-env-deployer", params.ServiceAccount)
+	}
+	if params.Tenant != "acme" || params.Environment != "prod" || params.Version != "1.2.3" {
+		t.Fatalf("deploy coordinates = %+v", params)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/routes/environments.go
+++ b/erun-backend/erun-backend-api/internal/routes/environments.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/provision"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
 )
 
 type EnvironmentRepository interface {
@@ -14,6 +16,13 @@ type EnvironmentRepository interface {
 	Get(ctx context.Context, environmentID string) (model.Environment, error)
 	Create(ctx context.Context, environment model.Environment) (model.Environment, error)
 	Count(ctx context.Context) (int, error)
+}
+
+// EnvironmentProvisioner starts the durable server-side deploy of a
+// freshly-created environment. Optional: when nil, POST /v1/environments only
+// registers the row (no live deploy), matching the pre-executor behavior.
+type EnvironmentProvisioner interface {
+	Start(provision.EnvProvisionInput) error
 }
 
 // TenantQuotaRepository reports the caller's environment-count cap. When the
@@ -26,6 +35,12 @@ type TenantQuotaRepository interface {
 type EnvironmentRoutes struct {
 	environments EnvironmentRepository
 	quotas       TenantQuotaRepository
+	// tenants resolves the caller's tenant name (not UUID) for the deploy, which
+	// forms the <tenant>-<env> namespace and runtime release name.
+	tenants ConfigTenantRepository
+	// provisioner is nil when live env provisioning is not wired; then create
+	// only registers the row.
+	provisioner EnvironmentProvisioner
 }
 
 // createEnvironmentRequest carries only operator-authored fields; the tenant is
@@ -38,8 +53,8 @@ type createEnvironmentRequest struct {
 	RuntimeVersion    string `json:"runtimeVersion"`
 }
 
-func RegisterEnvironmentRoutes(register ProtectedRouteRegistrar, environments EnvironmentRepository, quotas TenantQuotaRepository) {
-	routes := EnvironmentRoutes{environments: environments, quotas: quotas}
+func RegisterEnvironmentRoutes(register ProtectedRouteRegistrar, environments EnvironmentRepository, quotas TenantQuotaRepository, tenants ConfigTenantRepository, provisioner EnvironmentProvisioner) {
+	routes := EnvironmentRoutes{environments: environments, quotas: quotas, tenants: tenants, provisioner: provisioner}
 	register(http.MethodGet, "/v1/environments", http.HandlerFunc(routes.listEnvironments))
 	register(http.MethodPost, "/v1/environments", http.HandlerFunc(routes.createEnvironment))
 	register(http.MethodGet, "/v1/environments/{environment_id}", http.HandlerFunc(routes.getEnvironment))
@@ -134,9 +149,42 @@ func (r EnvironmentRoutes) createEnvironment(w http.ResponseWriter, req *http.Re
 		return
 	}
 
-	// TODO(live): provision the <tenant>-<env> namespace and deploy the runtime
-	// chart server-side; needs a live cluster, so for now the row is only
-	// registered config, not a running environment.
+	// A runtime env with a pinned version deploys server-side: when a provisioner
+	// is wired, start the durable deploy and return 202 so the caller polls
+	// GET /v1/environments/{id} to running/failed. Otherwise (no provisioner, a
+	// non-runtime env, or no version to deploy) the row is only registered
+	// config (201).
+	if r.provisioner == nil || envType != model.EnvironmentTypeRuntime || created.RuntimeVersion == "" {
+		writeJSON(w, http.StatusCreated, created)
+		return
+	}
+	if err := r.startProvisioning(req.Context(), created); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to start provisioning")
+		return
+	}
+	writeJSON(w, http.StatusAccepted, created)
+}
 
-	writeJSON(w, http.StatusCreated, created)
+// startProvisioning kicks off the durable deploy workflow for a runtime env. The
+// deploy needs the tenant name (RLS-scoped to the caller, so always the caller's
+// own) plus the request-scoped identity so the workflow's status writes rebind
+// to the right tenant.
+func (r EnvironmentRoutes) startProvisioning(ctx context.Context, created model.Environment) error {
+	tenant, err := r.tenants.Current(ctx)
+	if err != nil {
+		return err
+	}
+	securityContext, ok := security.FromContext(ctx)
+	if !ok {
+		return fmt.Errorf("missing security context")
+	}
+	return r.provisioner.Start(provision.EnvProvisionInput{
+		TenantID:      securityContext.TenantID,
+		TenantType:    securityContext.TenantType,
+		ErunUserID:    securityContext.ErunUserID,
+		EnvironmentID: created.EnvironmentID,
+		Tenant:        strings.TrimSpace(tenant.Name),
+		Environment:   created.Name,
+		Version:       created.RuntimeVersion,
+	})
 }

--- a/erun-backend/erun-backend-api/internal/routes/environments_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/environments_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/provision"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
 )
 
 func postCreateEnvironment(t *testing.T, environments *stubEnvironmentRepository, quotas stubTenantQuotaRepository, body string) *httptest.ResponseRecorder {
@@ -15,6 +17,37 @@ func postCreateEnvironment(t *testing.T, environments *stubEnvironmentRepository
 	req := httptest.NewRequest(http.MethodPost, "/v1/environments", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 	EnvironmentRoutes{environments: environments, quotas: quotas}.createEnvironment(rec, req)
+	return rec
+}
+
+type stubEnvironmentProvisioner struct {
+	started []provision.EnvProvisionInput
+	err     error
+}
+
+func (s *stubEnvironmentProvisioner) Start(in provision.EnvProvisionInput) error {
+	s.started = append(s.started, in)
+	return s.err
+}
+
+// postCreateEnvironmentWired posts through a fully-wired route (tenant resolver +
+// provisioner) with a request-scoped security context, the shape the live server
+// builds.
+func postCreateEnvironmentWired(t *testing.T, environments *stubEnvironmentRepository, prov *stubEnvironmentProvisioner, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/environments", bytes.NewBufferString(body))
+	req = req.WithContext(security.WithContext(req.Context(), security.Context{
+		TenantID:   "t1",
+		TenantType: string(model.TenantTypeCompany),
+		ErunUserID: "u1",
+	}))
+	rec := httptest.NewRecorder()
+	EnvironmentRoutes{
+		environments: environments,
+		quotas:       underCapQuota,
+		tenants:      stubConfigTenantRepository{tenant: model.Tenant{Name: "acme"}},
+		provisioner:  prov,
+	}.createEnvironment(rec, req)
 	return rec
 }
 
@@ -113,6 +146,62 @@ func TestCreateEnvironmentAllowsUnderQuota(t *testing.T) {
 	}
 	if environments.createCalls != 1 {
 		t.Fatalf("expected exactly one Create call, got %d", environments.createCalls)
+	}
+}
+
+// TestCreateEnvironmentStartsDeployWhenWired: a wired provisioner flips a
+// runtime env with a pinned version from an inline 201 to an async deploy
+// workflow (202 Accepted), threading the tenant name and version to the deploy.
+func TestCreateEnvironmentStartsDeployWhenWired(t *testing.T) {
+	environments := &stubEnvironmentRepository{created: model.Environment{
+		EnvironmentID: "env-1", Name: "prod", Type: model.EnvironmentTypeRuntime, RuntimeVersion: "1.2.3",
+	}}
+	prov := &stubEnvironmentProvisioner{}
+	rec := postCreateEnvironmentWired(t, environments, prov, `{"name":"prod","type":"runtime","runtimeVersion":"1.2.3"}`)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d (body %s), want 202 Accepted", rec.Code, rec.Body.String())
+	}
+	if len(prov.started) != 1 {
+		t.Fatalf("Start called %d times, want 1", len(prov.started))
+	}
+	if got := prov.started[0]; got.EnvironmentID != "env-1" || got.Tenant != "acme" ||
+		got.Environment != "prod" || got.Version != "1.2.3" || got.TenantID != "t1" {
+		t.Fatalf("provision input = %+v", got)
+	}
+}
+
+// TestCreateEnvironmentRegistersOnlyWithoutVersion: nothing to deploy without a
+// pinned runtime version, so create stays a plain 201 registration.
+func TestCreateEnvironmentRegistersOnlyWithoutVersion(t *testing.T) {
+	environments := &stubEnvironmentRepository{created: model.Environment{
+		EnvironmentID: "env-1", Name: "prod", Type: model.EnvironmentTypeRuntime,
+	}}
+	prov := &stubEnvironmentProvisioner{}
+	rec := postCreateEnvironmentWired(t, environments, prov, `{"name":"prod","type":"runtime"}`)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", rec.Code)
+	}
+	if len(prov.started) != 0 {
+		t.Fatalf("Start called %d times, want 0 (no version to deploy)", len(prov.started))
+	}
+}
+
+// TestCreateEnvironmentRegistersOnlyForNonRuntime: the deploy executor targets
+// runtime envs; an agent env is registered (201) without a deploy.
+func TestCreateEnvironmentRegistersOnlyForNonRuntime(t *testing.T) {
+	environments := &stubEnvironmentRepository{created: model.Environment{
+		EnvironmentID: "env-1", Name: "prod", Type: model.EnvironmentTypeRemoteAgent, RuntimeVersion: "1.2.3",
+	}}
+	prov := &stubEnvironmentProvisioner{}
+	rec := postCreateEnvironmentWired(t, environments, prov, `{"name":"prod","type":"remote-agent","runtimeVersion":"1.2.3"}`)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", rec.Code)
+	}
+	if len(prov.started) != 0 {
+		t.Fatalf("Start called %d times, want 0 (non-runtime env)", len(prov.started))
 	}
 }
 

--- a/erun-backend/erun-backend-api/server.go
+++ b/erun-backend/erun-backend-api/server.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 
 	"github.com/dbos-inc/dbos-transact-golang/dbos"
+	"k8s.io/client-go/kubernetes"
 
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/deployexec"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/dns01broker"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/mcptoken"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/provision"
@@ -42,6 +44,14 @@ type HandlerOptions struct {
 	// when the PowerDNS write path is not configured; the endpoints are then not
 	// registered (a cluster with no brokered DNS-01 solver never calls them).
 	DNS01Broker *dns01broker.Broker
+	// KubeClient runs the server-side env-deploy Jobs. Nil (the default outside a
+	// cluster) leaves env provisioning off: POST /v1/environments only registers
+	// the row. Set together with EnvDeploy and DBOSContext to enable live deploys.
+	KubeClient kubernetes.Interface
+	// EnvDeploy is the per-instance placement for env-deploy Jobs (image registry,
+	// platform namespace, cluster-admin deployer ServiceAccount). Env provisioning
+	// stays off until all three are set.
+	EnvDeploy provision.EnvDeployConfig
 }
 
 func NewHandler(options HandlerOptions) (http.Handler, error) {
@@ -116,7 +126,13 @@ func NewHandler(options HandlerOptions) (http.Handler, error) {
 		routes.RegisterReviewRoutes(register, reviews, reviewService)
 		routes.RegisterBuildRoutes(register, builds, buildService)
 		routes.RegisterCommentRoutes(register, comments, commentService)
-		routes.RegisterEnvironmentRoutes(register, environments, tenantQuotas)
+		var environmentProvisioner routes.EnvironmentProvisioner
+		if options.DBOSContext != nil && options.KubeClient != nil &&
+			options.EnvDeploy.DeployerServiceAccount != "" && options.EnvDeploy.PlatformNamespace != "" && options.EnvDeploy.Registry != "" {
+			coordinator := service.NewEnvironmentProvisioner(deployexec.NewLauncher(options.KubeClient), environments)
+			environmentProvisioner = provision.NewEnvProvisioner(options.DBOSContext, coordinator, options.EnvDeploy)
+		}
+		routes.RegisterEnvironmentRoutes(register, environments, tenantQuotas, tenants, environmentProvisioner)
 		routes.RegisterMCPTokenRoutes(register, environments, tenants, options.MCPSigner)
 		routes.RegisterDNS01TokenRoutes(register, environments, tenants, options.MCPSigner)
 		var contextProvisioner routes.ContextProvisioner

--- a/erun-devops/k8s/erun-backend-api/templates/api.yaml
+++ b/erun-devops/k8s/erun-backend-api/templates/api.yaml
@@ -34,6 +34,78 @@
 {{- $dns01TsigSecretKey := default "tsig-secret" $dns01Tsig.secretKey -}}
 {{- $dns01TsigKeyName := default (printf "%s-dnsupdate" $tenant) $dns01Tsig.keyName -}}
 {{- $dns01TsigAlgorithm := default "hmac-sha256" $dns01Tsig.algorithm -}}
+{{- /* Opt-in server-side env-deploy executor (#605): the API launches an
+       `erun deploy` Job per hosted env. Off by default — the API pod keeps the
+       namespace `default` SA and env creation only registers the row, so
+       existing deploys are byte-for-byte unchanged. Enabling it grants the API
+       pod's own SA namespaced Job management, and a separate cluster-admin
+       deployer SA the Jobs run as (the Job runs `erun deploy`: creates
+       namespaces, installs charts cluster-wide). The first deploy that adds the
+       cluster-admin binding must come from an admin context (apiserver
+       escalation check), same constraint as the runtime chart's platformAccount. */ -}}
+{{- $envDeployer := default dict $api.envDeployer -}}
+{{- $envDeployerEnabled := default false $envDeployer.enabled -}}
+{{- $apiServiceAccount := printf "%s-api" $tenant -}}
+{{- $envDeployerSA := default (printf "%s-env-deployer" $tenant) $envDeployer.serviceAccountName -}}
+{{- if $envDeployerEnabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $apiServiceAccount }}
+  labels:
+    app: {{ $tenant }}-api
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $envDeployerSA }}
+  labels:
+    app: {{ $tenant }}-api
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $tenant }}-api-env-deployer
+  labels:
+    app: {{ $tenant }}-api
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $tenant }}-api-env-deployer
+  labels:
+    app: {{ $tenant }}-api
+subjects:
+  - kind: ServiceAccount
+    name: {{ $apiServiceAccount }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $tenant }}-api-env-deployer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $envDeployerSA }}
+  labels:
+    app: {{ $tenant }}-api
+subjects:
+  - kind: ServiceAccount
+    name: {{ $envDeployerSA }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+---
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -67,6 +139,9 @@ spec:
       labels:
         app: {{ $tenant }}-api
     spec:
+      {{- if $envDeployerEnabled }}
+      serviceAccountName: {{ $apiServiceAccount }}
+      {{- end }}
       containers:
         - image: {{ $backendAPIImage }}
           name: erun-backend-api
@@ -95,6 +170,16 @@ spec:
               value: {{ required "tenant is required" .Values.tenant | quote }}
             - name: ERUN_ENVIRONMENT
               value: {{ required "environment is required" .Values.environment | quote }}
+            {{- if $envDeployerEnabled }}
+            - name: ERUN_ENV_DEPLOYER_SERVICE_ACCOUNT
+              value: {{ $envDeployerSA | quote }}
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ERUN_ENV_DEPLOY_REGISTRY
+              value: {{ $containerRegistry | quote }}
+            {{- end }}
             {{- if $mcpSigningSecretName }}
             - name: ERUN_API_MCP_SIGNING_KEY_PATH
               value: {{ printf "%s/%s" $mcpSigningMountDir $mcpSigningSecretKey | quote }}

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -96,7 +96,7 @@ The `(iss, org) → tenant` resolution model and first-identity bootstrap above 
 | `GET` | `/v1/whoami` | Resolved identity for the calling token. Response below. | Tenant member |
 | `GET` | `/v1/config` | The console's read model over the per-tenant erun config: `{tenant, environments[], contexts[]}`. | Tenant member |
 | `GET` | `/v1/environments` | List the tenant's environments. | Tenant member |
-| `POST` | `/v1/environments` | Register an environment in the caller's tenant, bound to a referenced context. Body below. | Tenant member (write) |
+| `POST` | `/v1/environments` | Register an environment in the caller's tenant, bound to a referenced context; when the deploy executor is configured, a runtime env with a pinned version also starts its durable server-side deploy (`202`). Body below. | Tenant member (write) |
 | `GET` | `/v1/environments/{environment_id}` | Fetch one environment by id. | Tenant member |
 | `POST` | `/v1/environments/{environment_id}/mcp-token` | Mint a per-env MCP bearer token (`{token, audience}`) for the caller to present to the env's `erun-mcp` edge. Body-less. Response below. | Tenant member (write) |
 | `POST` | `/v1/environments/{environment_id}/dns01-token` | Mint a per-env DNS-01 broker token (`{token, audience}`), the credential the cluster's cert-manager DNS-01 webhook presents to the [DNS-01 broker](#dns01-broker). Body-less. Response below. | Tenant member (write) |
@@ -177,10 +177,13 @@ Registers an **environment** in the caller's tenant. The tenant is resolved from
 }
 ```
 
-On success the endpoint persists the row and returns it with HTTP `201`:
+On success the endpoint persists the row and returns it. The status code tells the caller whether a deploy started:
+
+- **`201 Created`** — the row is registered config only, no deploy. This is the response when the deploy executor is not configured, or the env is not a `runtime` env, or no `runtimeVersion` is pinned (nothing to deploy). `status` is `registered`.
+- **`202 Accepted`** — the deploy executor is configured **and** this is a `runtime` env with a pinned `runtimeVersion`, so the backend has started the durable server-side deploy. The row comes back at `status: registered` and moves to `provisioning` → `running`/`failed` as the deploy runs; poll `GET /v1/environments/{id}` (or watch the `GET /v1/config` read model) to follow it.
 
 ```jsonc
-// 201 response
+// 201 / 202 response (same body shape; 202 means a deploy is now running)
 {
   "environmentId": "019a7fa5-c2c0-7c55-bc70-714873a71f30",
   "tenantId": "019a7fa5-c2c0-7c55-bc70-714873a71f10",
@@ -195,11 +198,13 @@ On success the endpoint persists the row and returns it with HTTP `201`:
 }
 ```
 
-A newly-registered environment is `registered` — the row exists but nothing is deployed. The server-side deploy executor (#605) moves it `provisioning` → `running`/`failed` and sets `provisionError` on failure; the same `status`/`provisionError` appear on `GET /v1/environments/{id}` and in the `GET /v1/config` read model. Until the executor lands, an environment stays `registered`.
+A newly-registered environment is `registered` — the row exists but nothing is deployed. The server-side deploy executor (#605) then moves it `provisioning` → `running`/`failed` and sets `provisionError` on failure; the same `status`/`provisionError` appear on `GET /v1/environments/{id}` and in the `GET /v1/config` read model.
 
 **Per-tenant environment-count quota.** After validating the body and before persisting, the endpoint enforces the tenant's environment-count cap: it compares how many environments the tenant already has against the cap and rejects the registration with HTTP `409` once the tenant is at or over it. The cap defaults to **10** and is overridden per tenant by a `tenant_quotas.max_environments` row. That override row is set by the operations-only [`PUT /v1/tenants/{tenant_id}/quota`](#put-v1tenantstenant_idquota) endpoint (below). Both the count and the cap are read under row-level security, so each is scoped to the caller's own tenant.
 
-**Live namespace + runtime-chart deploy is `(Planned.)`.** This endpoint registers the environment row only; it does **not** yet ensure the `<tenant>-<env>` namespace or deploy the runtime chart server-side (that runs `RunBootstrapInitWithDependencies` against a live cluster). Until that lands, a registered environment stands as registered config — the namespace creation and chart deploy from the registered row are the planned follow-up.
+**Server-side deploy executor.** When configured, the backend deploys the runtime chart itself: it runs the deploy as a Kubernetes `Job` in the tenant's `<tenant>-devops` runtime image (which carries `erun` + `helm` + `kubectl`) under a cluster-admin ServiceAccount, invoking `erun deploy <tenant> <env> --version <runtimeVersion>`, and watches the Job to completion — succeeded → `running`, failed → `failed` with the reason on `provisionError`. A durable workflow (DBOS) wraps this, keyed by environment id, so a control-plane restart resumes an in-flight deploy rather than double-deploying. The deploy image is `<registry>/<tenant>-devops:<runtimeVersion>` (image-baked config model).
+
+The executor is **opt-in and off by default** — it requires the backend to run in-cluster with a durable-workflow database, a kube client, and the deployer ServiceAccount configured (chart value `api.envDeployer.enabled`, which also provisions the SA and its cluster-admin binding). When it is off, or the env is not a `runtime` env, or no `runtimeVersion` is pinned, the endpoint is register-only (`201`) exactly as before.
 
 **Error behaviour.** Today the API returns a bare HTTP status with a plain-text body (no JSON envelope):
 
@@ -208,7 +213,7 @@ A newly-registered environment is `registered` — the row exists but nothing is
 | `400` | `name` is not a DNS-1123 label (the env forms the `<tenant>-<env>` namespace), `type` is not one of `runtime`/`remote-agent`/`local-agent`, or the body is not valid JSON. | Send a DNS-1123 `name` and a valid `type`. |
 | `401` / `403` | Standard auth failures (see [Errors](#errors)). The `WriteAll` permission covers `POST /v1/environments`. | Send a valid token whose roles permit the write. |
 | `409` | The tenant is at its environment-count cap (default `10` unless a `tenant_quotas` row overrides it); the body is `environment quota reached: this tenant already has N of N environments`. | Delete an unused environment, or raise the tenant's cap via [`PUT /v1/tenants/{tenant_id}/quota`](#put-v1tenantstenant_idquota) (operations-only). |
-| `500` | Persistence failed — e.g. `contextId` references a context that is not the caller's (the composite `(tenant_id, context_id)` foreign key is violated), or the request-scoped security context is missing (an internal wiring error). | Reference a context owned by the caller's tenant; if it persists with a valid context, it is a server bug. |
+| `500` | Persistence failed — e.g. `contextId` references a context that is not the caller's (the composite `(tenant_id, context_id)` foreign key is violated), or the request-scoped security context is missing (an internal wiring error). The row is persisted **before** the deploy is started, so a `failed to start provisioning` `500` (the deploy executor could not enqueue the durable workflow) leaves the environment registered — re-create is a no-op conflict; poll `GET /v1/environments/{id}` to confirm the row exists. | Reference a context owned by the caller's tenant; if it persists with a valid context, it is a server bug. |
 
 ### `POST /v1/environments/{environment_id}/mcp-token` {#mcp-token-endpoint}
 
@@ -226,7 +231,7 @@ The endpoint takes **no body**. On success it returns HTTP `200`:
 
 **Backend signing key.** The signer is enabled by pointing `ERUN_API_MCP_SIGNING_KEY_PATH` at the backend's Ed25519 private key (PKCS#8 PEM) — on a hosted deploy, the `erun-backend-api` chart's `api.mcpSigning.secretName` value mounts that key Secret and sets the path (opt-in; unset leaves the endpoint at `501`). The matching public key is what a deploy injects into the env (`erun deploy --mcp-auth-public-key`), so the edge trusts backend-signed tokens.
 
-**Usable once the env is deployed.** A minted token only authenticates against a **deployed** env whose edge already carries the backend's public key. A dedicated `409`-until-deployed guard is `(Planned.)` — the backend does not yet track per-env deploy state (server-side deploy is itself `(Planned.)`; see [`POST /v1/environments`](#post-v1environments)); until then the endpoint mints whenever the signer is configured and the environment exists.
+**Usable once the env is deployed.** A minted token only authenticates against a **deployed** env whose edge already carries the backend's public key. A dedicated `409`-until-deployed guard is `(Planned.)` — the backend tracks a per-env provisioning `status` (see [`POST /v1/environments`](#post-v1environments)) but the mint endpoint does not yet gate on it reaching `running`; until it does, the endpoint mints whenever the signer is configured and the environment exists.
 
 **Error behaviour.** Bare HTTP status with a plain-text body (no JSON envelope):
 


### PR DESCRIPTION
Completes the **#605 Slice A** executor path. The deploy-Job executor core (#833), the service coordinator + status persistence (#834), and the console status view (#835) already landed; this wires them together and triggers them from env creation.

## What changes
`POST /v1/environments` now starts a **durable server-side deploy** for a `runtime` env with a pinned `runtimeVersion` when the executor is configured (**202 Accepted**), and stays register-only (**201**) otherwise (no executor, non-runtime env, or no version). Mirrors the committed cloud-context provisioner exactly.

- **`routes/environments.go`** — optional `EnvironmentProvisioner` trigger: resolves the tenant name + request identity and starts the durable deploy workflow; returns 202. Register-only 201 path unchanged.
- **`server.go` / `cmd/eapi`** — builds `kube client → deploy-Job Launcher → service coordinator → DBOS EnvProvisioner`, gated on `DBOSContext + KubeClient + a complete EnvDeployConfig`. Off by default (an in-cluster kube client is only built when the deployer SA is configured).
- **`provision/environments.go`** — the durable env-deploy DBOS workflow (previously uncommitted), with a pure `deployJobParams` helper unit-tested for the `<registry>/<tenant>-devops:<version>` image ref.
- **`erun-backend-api` chart** — opt-in `api.envDeployer.enabled` (**default OFF**): provisions a namespaced `<tenant>-api` SA (Job create/watch) for the API pod and a cluster-admin `<tenant>-env-deployer` SA the Jobs run as, plus the executor env vars. Default-off render is byte-for-byte identical to before.
- **docs** (`api-protocol.md`) — spec the 201/202 split, executor mechanics + opt-in gating, and the `500 failed to start provisioning` behaviour.

## RBAC note
The deploy Job runs `erun deploy` (creates namespaces, installs charts cluster-wide), so its SA is bound to the built-in `cluster-admin` ClusterRole — opt-in and default-off, same posture as the runtime chart's `platformAccount`. Tightening to a scoped ClusterRole is a follow-up.

## Validation
- `erun-backend-api`: `go build` + `go vet` + `go test ./...` + `golangci-lint run ./...` — all green (0 issues).
- Chart: default-off render byte-for-byte identical to HEAD; enabled render valid YAML (7 docs); `helm lint` clean both states.
- `erun-docs`: `yarn build` clean (no broken links/anchors).
- `make integration-test`: green, coverage 75.8% ≥ 75.0%.

## Not verified
The full in-cluster path (enable the executor on a wired platform env → onboard a runtime env → watch the deploy Job) needs `api.envDeployer.enabled=true` and a tenant with issuers; the opt-in `ERUN_E2E_PROVISION` harness is the pattern that covers it once a platform env enables the executor.

Part of #605 (Slice A); the epic stays open for the remaining slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)