### PR TITLE
erun-ui: scrollable new-environment dialog + fix stale runtime capacity

### DIFF
--- a/erun-ui/frontend/src/app/dialogContextsThunks.ts
+++ b/erun-ui/frontend/src/app/dialogContextsThunks.ts
@@ -11,7 +11,13 @@ const refreshDialogRuntimeResources =
   async (dispatch, getState) => {
     const context = normalizeDialogValue(kubernetesContext);
     let dialog = getState().environmentDialog;
-    if (!dialog.open || !context) {
+    if (!dialog.open) {
+      return;
+    }
+    // No selected context → clear stale capacity rather than leaving a figure from
+    // a previously resolved context showing under an empty selection.
+    if (!context) {
+      dispatch(patchEnvironmentDialog({ resourceStatus: null, resourceStatusLoading: false }));
       return;
     }
     dispatch(

--- a/erun-ui/frontend/src/app/environmentDialogThunks.ts
+++ b/erun-ui/frontend/src/app/environmentDialogThunks.ts
@@ -288,7 +288,14 @@ const refreshEnvironmentRuntimeResources =
     const request = getState().requestCounters.environmentDialogResourceStatus;
     const context = normalizeDialogValue(kubernetesContext);
     const dialog = getState().environmentDialog;
-    if (!dialog.open || !context) {
+    if (!dialog.open) {
+      return;
+    }
+    // No selected context → there is no cluster to measure. Clear any capacity
+    // fetched for a previously selected/auto-resolved context so the dialog never
+    // shows a stale "Available on best node" figure under an empty selection.
+    if (!context) {
+      dispatch(patchEnvironmentDialog({ resourceStatus: null, resourceStatusLoading: false }));
       return;
     }
     dispatch(

--- a/erun-ui/frontend/src/components/app/EditableComboField.tsx
+++ b/erun-ui/frontend/src/components/app/EditableComboField.tsx
@@ -26,6 +26,7 @@ function EditableComboChoices({
       id={`${id}-choices`}
       className="w-96 max-w-[calc(100vw-4rem)] p-1"
       align="start"
+      collisionPadding={12}
     >
       {visibleSuggestions.length === 0 ? (
         <div className="px-2 py-6 text-center text-sm text-muted-foreground">

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -81,14 +81,19 @@ export function EnvironmentDialogView(): React.ReactElement {
       }}
     >
       <DialogContent
-        className="sm:max-w-md"
+        // Bound the panel to the viewport and let the field region scroll, so the
+        // top fields (Tenant/Environment) stay reachable and the footer stays
+        // visible on short windows — a plain centered grid overflowed off both
+        // edges with nothing scrollable. Overrides the shadcn base grid/gap/p via
+        // tailwind-merge; no generated ui/dialog.tsx edit needed.
+        className="flex max-h-[85vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-md"
         onCloseAutoFocus={(event) => {
           event.preventDefault();
           controller.focusTerminalSoon();
         }}
       >
         <form
-          className="grid gap-4"
+          className="flex min-h-0 flex-1 flex-col"
           onSubmit={(event) => {
             event.preventDefault();
             void dispatch(submitEnvironmentDialog(event.currentTarget)).catch((error: unknown) => {
@@ -96,10 +101,16 @@ export function EnvironmentDialogView(): React.ReactElement {
             });
           }}
         >
-          <EnvironmentDialogHeader dialog={dialog} />
-          <EnvironmentDialogFields tenantRef={tenantRef} environmentRef={environmentRef} />
-          <DialogError error={dialog.error} />
-          <EnvironmentDialogFooter dialog={dialog} />
+          <div className="shrink-0 px-6 pt-6 pb-4">
+            <EnvironmentDialogHeader dialog={dialog} />
+          </div>
+          <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto px-6 pb-1">
+            <EnvironmentDialogFields tenantRef={tenantRef} environmentRef={environmentRef} />
+            <DialogError error={dialog.error} />
+          </div>
+          <div className="shrink-0 border-t px-6 pt-4 pb-6">
+            <EnvironmentDialogFooter dialog={dialog} />
+          </div>
         </form>
       </DialogContent>
     </Dialog>

--- a/erun-ui/frontend/src/components/app/SelectField.tsx
+++ b/erun-ui/frontend/src/components/app/SelectField.tsx
@@ -64,7 +64,10 @@ export function SelectField({
           />
         </SelectTrigger>
         {!noOptions && (
-          <SelectContent>
+          // popper (not the default item-aligned) anchors the list to the trigger
+          // and flips/clamps with collision detection, so it never renders off the
+          // top of the dialog; collisionPadding keeps it clear of the window edges.
+          <SelectContent position="popper" collisionPadding={12}>
             {options.map((item) => (
               <SelectItem key={item.value} value={item.value} disabled={item.disabled}>
                 {item.label}

--- a/erun-ui/frontend/src/components/app/VersionField.tsx
+++ b/erun-ui/frontend/src/components/app/VersionField.tsx
@@ -81,7 +81,7 @@ export function VersionField({
               <ChevronsUpDown />
             </Button>
           </PopoverTrigger>
-          <PopoverContent className="w-80 p-0" align="start">
+          <PopoverContent className="w-80 p-0" align="start" collisionPadding={12}>
             <Command>
               <CommandInput placeholder="Search versions..." />
               <CommandList>


### PR DESCRIPTION
## Context

Reviewing the desktop **New environment** dialog surfaced two real defects (plus a dropdown-positioning issue), all fixed here at the usage sites — no generated shadcn `ui/*` files touched.

## 1. Top fields unreachable / no scroll
`DialogContent` was a vertically-centered grid with **no `max-height` and no `overflow`**, and the `<form>` was a plain grid. A tall form (Tenant, Environment, Runtime version, Env type, K8s context, the Runtime Resources panel, Container registry, checkboxes) overflowed off **both** the top and bottom of the viewport with nothing scrollable, so the Tenant/Environment fields at the top could not be reached ("cannot access values on top").

**Fix:** bound the panel to `max-h-[85vh]`, put the fields in a `flex-1 overflow-y-auto` region, and pin the header and footer (with a divider) so the top fields stay reachable and **Create** stays visible. Done via `className` overrides merged by tailwind-merge.

## 2. Availability shown before a cluster is selected
The dialog auto-selects the first Kubernetes context on open (`selectDialogKubernetesContext` → `contexts[0]`) and fetches *its* node capacity. But when the context is cleared, the refresh thunks returned early **without clearing `resourceStatus`**, so the "Available on best node: N CPU / M GiB" figure lingered under an empty "Select Kubernetes context" dropdown — capacity for a cluster that was no longer selected.

**Fix:** in both `refreshEnvironmentRuntimeResources` and `refreshDialogRuntimeResources`, clear `resourceStatus` when there is no selected context, so capacity always corresponds to the selected cluster.

## 3. Dropdowns could open off the top
Radix `Select` used the default `item-aligned` positioning (can render above the viewport top); the comboboxes had no `collisionPadding`.

**Fix:** `position=\"popper\"` + `collisionPadding` on the Select, and `collisionPadding` on the combobox/version popovers, so lists anchor to the trigger and flip/clamp within the window.

## Verification
`yarn typecheck`, `yarn lint`, `yarn build`, and `prettier --check` on the changed files all pass. Generated shadcn files are untouched (no `shadcn:check` impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)