### PR TITLE
Default the new-environment dialog to the in-cluster erun-registry

### DIFF
--- a/erun-cli/cmd/init.go
+++ b/erun-cli/cmd/init.go
@@ -19,6 +19,7 @@ func newInitCmd(runInit func(common.Context, common.BootstrapInitParams) error) 
 	params := common.BootstrapInitParams{}
 	setDefaultTenant := false
 	confirmEnvironment := false
+	clusterRegistry := false
 	var envType string
 
 	cmd := &cobra.Command{
@@ -27,7 +28,7 @@ func newInitCmd(runInit func(common.Context, common.BootstrapInitParams) error) 
 		Args:         cobra.MaximumNArgs(2),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runParams, err := initRunParams(cmd, args, params, setDefaultTenant, confirmEnvironment, envType)
+			runParams, err := initRunParams(cmd, args, params, setDefaultTenant, confirmEnvironment, clusterRegistry, envType)
 			if err != nil {
 				return err
 			}
@@ -44,6 +45,7 @@ func newInitCmd(runInit func(common.Context, common.BootstrapInitParams) error) 
 	cmd.Flags().StringVar(&params.RuntimePod.Memory, "runtime-memory", "", "Runtime pod memory limit")
 	cmd.Flags().StringVar(&params.KubernetesContext, "kubernetes-context", "", "Kubernetes context to associate with the environment")
 	cmd.Flags().StringVar(&params.ContainerRegistry, "container-registry", "", "Container registry to associate with the environment")
+	cmd.Flags().BoolVar(&clusterRegistry, "cluster-registry", false, "Use the in-cluster erun-registry (addresses resolved from the env's kube-context) instead of --container-registry; mutually exclusive with it")
 	cmd.Flags().StringVar(&params.CodeCommitSSHKeyID, "codecommit-ssh-key-id", "", "CodeCommit SSH public key ID to use for remote repository access")
 	cmd.Flags().BoolVar(&params.Bootstrap, "bootstrap", false, "Deprecated: ignored; remote runtimes deploy the published erun-devops chart")
 	_ = cmd.Flags().MarkDeprecated("bootstrap", "remote runtimes deploy the published erun-devops chart; the flag is ignored")
@@ -59,13 +61,21 @@ func newInitCmd(runInit func(common.Context, common.BootstrapInitParams) error) 
 	return cmd
 }
 
-func initRunParams(cmd *cobra.Command, args []string, params common.BootstrapInitParams, setDefaultTenant, confirmEnvironment bool, envType string) (common.BootstrapInitParams, error) {
+func initRunParams(cmd *cobra.Command, args []string, params common.BootstrapInitParams, setDefaultTenant, confirmEnvironment, clusterRegistry bool, envType string) (common.BootstrapInitParams, error) {
 	runParams := params
 	if runParams.Tenant == "" && len(args) > 0 {
 		runParams.Tenant = args[0]
 	}
 	if runParams.Environment == "" && len(args) > 1 {
 		runParams.Environment = args[1]
+	}
+	if clusterRegistry {
+		if strings.TrimSpace(runParams.ContainerRegistry) != "" {
+			return common.BootstrapInitParams{}, fmt.Errorf("--cluster-registry conflicts with --container-registry; pick one")
+		}
+		// The in-cluster erun-registry is plain HTTP, so mark it insecure; the
+		// rest (service/namespace/port) fill from the erun-registry convention.
+		runParams.ClusterRegistry = &common.ClusterRegistry{Insecure: true}
 	}
 	if err := applyInitTypeFlag(cmd, &runParams, envType); err != nil {
 		return common.BootstrapInitParams{}, err

--- a/erun-common/container_registry.go
+++ b/erun-common/container_registry.go
@@ -381,6 +381,19 @@ func SingleContainerRegistries(registry string) ContainerRegistries {
 	}}
 }
 
+// ClusterContainerRegistries builds the one-entry list that seeds a new env from
+// an in-cluster registry (e.g. the erun-registry the local k3s setup deploys),
+// marked build+deploy. Its addresses resolve from the env's kube-context, so the
+// same entry works for an in-pod build (ClusterIP) and a host build (managed
+// port-forward) without hardcoding a host that only one of them can reach.
+func ClusterContainerRegistries(cluster ClusterRegistry) ContainerRegistries {
+	c := cluster.WithDefaults()
+	return ContainerRegistries{{
+		Cluster: &c,
+		Roles:   []RegistryRole{RegistryRoleBuild, RegistryRoleDeploy},
+	}}
+}
+
 // migrateLegacyContainerRegistry folds a legacy `containerregistry` scalar into
 // the marked list. The key is dropped on the next save, so the migration is
 // one-way.

--- a/erun-common/container_registry_cluster_test.go
+++ b/erun-common/container_registry_cluster_test.go
@@ -20,6 +20,34 @@ func TestClusterRegistryWithDefaults(t *testing.T) {
 	}
 }
 
+func TestClusterContainerRegistries(t *testing.T) {
+	list := ClusterContainerRegistries(ClusterRegistry{Insecure: true})
+	if len(list) != 1 {
+		t.Fatalf("len = %d, want 1", len(list))
+	}
+	entry := list[0]
+	if entry.Registry != "" {
+		t.Errorf("registry = %q, want empty (cluster entry)", entry.Registry)
+	}
+	if entry.Cluster == nil {
+		t.Fatal("cluster is nil, want a cluster block")
+	}
+	if entry.Cluster.Service != DefaultClusterRegistryService ||
+		entry.Cluster.Namespace != DefaultClusterRegistryNamespace ||
+		entry.Cluster.Port != DefaultClusterRegistryPort {
+		t.Errorf("cluster defaults not filled: %+v", *entry.Cluster)
+	}
+	if !entry.Cluster.Insecure {
+		t.Error("insecure not preserved")
+	}
+	if !entry.hasRole(RegistryRoleBuild) || !entry.hasRole(RegistryRoleDeploy) {
+		t.Errorf("roles = %v, want build+deploy", entry.Roles)
+	}
+	if err := list.Validate(); err != nil {
+		t.Errorf("validate: %v", err)
+	}
+}
+
 func TestContainerRegistriesValidateRejectsBothRegistryAndCluster(t *testing.T) {
 	list := ContainerRegistries{{
 		Registry: "ghcr.io/sophium",

--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -74,6 +74,10 @@ type BootstrapInitParams struct {
 	NoGit                    bool
 	KubernetesContext        string
 	ContainerRegistry        string
+	// ClusterRegistry, when set, seeds the new env with a resolvable cluster:
+	// registry entry (addresses resolved from the env's kube-context) instead of
+	// the static ContainerRegistry string. Set by `erun init --cluster-registry`.
+	ClusterRegistry *ClusterRegistry
 	// Type is the canonical environment type and takes precedence over the
 	// legacy Remote bool; when unset the type is derived from Remote for
 	// backward compatibility with --remote flag callers.
@@ -763,7 +767,7 @@ func (s *bootstrapRunState) createEnvConfig() error {
 	if err != nil {
 		return err
 	}
-	if err := s.runner.saveProjectContainerRegistry(envProjectRoot, s.envName, containerRegistry, s.params.Remote); err != nil {
+	if err := s.runner.saveProjectContainerRegistry(envProjectRoot, s.envName, containerRegistry, s.params); err != nil {
 		return err
 	}
 	s.runner.Context.Trace("Adding new environment")
@@ -788,10 +792,21 @@ func (s *bootstrapRunState) createEnvConfig() error {
 	if err := saveEnvConfig(s.runner.Store, s.tenant, s.envConfig); err != nil {
 		return err
 	}
-	s.envConfig.ContainerRegistries = SingleContainerRegistries(containerRegistry)
-	s.envConfigChanged = s.params.Remote && containerRegistry != ""
+	s.envConfig.ContainerRegistries = seedInitContainerRegistries(s.params, containerRegistry)
+	s.envConfigChanged = s.params.ClusterRegistry != nil || (s.params.Remote && containerRegistry != "")
 	s.result.CreatedEnvConfig = true
 	return nil
+}
+
+// seedInitContainerRegistries returns the marked list a new env is created with:
+// a resolvable cluster: entry when the operator requested the in-cluster registry
+// (--cluster-registry), otherwise the single static registry resolved from
+// --container-registry / the prompt.
+func seedInitContainerRegistries(params BootstrapInitParams, registry string) ContainerRegistries {
+	if params.ClusterRegistry != nil {
+		return ClusterContainerRegistries(*params.ClusterRegistry)
+	}
+	return SingleContainerRegistries(registry)
 }
 
 func (s *bootstrapRunState) envProjectRoot() (string, error) {
@@ -907,6 +922,17 @@ func (s *bootstrapRunState) updateEnvCloudProvider(kubernetesContext string) err
 
 func (s *bootstrapRunState) updateEnvContainerRegistry() error {
 	projectRoot := s.projectRoot()
+	if s.params.ClusterRegistry != nil {
+		if err := s.runner.saveProjectContainerRegistry(projectRoot, s.envName, "", s.params); err != nil {
+			return err
+		}
+		desired := ClusterContainerRegistries(*s.params.ClusterRegistry)
+		if !s.envConfig.ContainerRegistries.Equal(desired) {
+			s.envConfig.ContainerRegistries = desired
+			s.envConfigChanged = true
+		}
+		return nil
+	}
 	current, _ := s.envConfig.ContainerRegistries.BuildRegistry()
 	containerRegistry, err := s.runner.resolveContainerRegistry(s.params, s.tenant, s.envName, projectRoot, current, false)
 	if err != nil {
@@ -915,7 +941,7 @@ func (s *bootstrapRunState) updateEnvContainerRegistry() error {
 	if containerRegistry == "" {
 		return nil
 	}
-	if err := s.runner.saveProjectContainerRegistry(projectRoot, s.envName, containerRegistry, s.params.Remote); err != nil {
+	if err := s.runner.saveProjectContainerRegistry(projectRoot, s.envName, containerRegistry, s.params); err != nil {
 		return err
 	}
 	if existing, _ := s.envConfig.ContainerRegistries.BuildRegistry(); containerRegistry != existing {
@@ -1201,6 +1227,11 @@ func (s bootstrapRunner) resolveKubernetesContext(params BootstrapInitParams, te
 }
 
 func (s bootstrapRunner) resolveContainerRegistry(params BootstrapInitParams, tenant, envName, projectRoot, current string, creating bool) (string, error) {
+	// A cluster registry is written as a resolvable cluster: entry, not a static
+	// string, so short-circuit the string resolution/prompt entirely.
+	if params.ClusterRegistry != nil {
+		return "", nil
+	}
 	if params.ContainerRegistry != "" {
 		return params.ContainerRegistry, nil
 	}
@@ -1271,11 +1302,30 @@ func (s bootstrapRunner) resolveCloudProviderAlias(kubernetesContext, current st
 	return strings.TrimSpace(status.CloudProviderAlias), nil
 }
 
-func (s bootstrapRunner) saveProjectContainerRegistry(projectRoot, envName, registry string, remote bool) error {
-	if remote {
+func (s bootstrapRunner) saveProjectContainerRegistry(projectRoot, envName, registry string, params BootstrapInitParams) error {
+	// Remote envs record the registry on the env config only; the shared project
+	// config is for local-agent envs whose worktree lives in this repo.
+	if params.Remote {
 		return nil
 	}
-	if projectRoot == "" || envName == "" || registry == "" || s.SaveProjectConfig == nil {
+	if projectRoot == "" || envName == "" || s.SaveProjectConfig == nil {
+		return nil
+	}
+
+	if params.ClusterRegistry != nil {
+		projectConfig, err := s.loadProjectConfigForContainerRegistry(projectRoot)
+		if err != nil {
+			return err
+		}
+		desired := ClusterContainerRegistries(*params.ClusterRegistry)
+		if projectConfig.ContainerRegistriesForEnvironment(envName).Equal(desired) {
+			return nil
+		}
+		projectConfig.SetContainerRegistriesForEnvironment(envName, desired)
+		return s.SaveProjectConfig(projectRoot, projectConfig)
+	}
+
+	if registry == "" {
 		return nil
 	}
 

--- a/erun-integration/testdata/init/help.txt
+++ b/erun-integration/testdata/init/help.txt
@@ -4,6 +4,7 @@ Usage:
   erun init [TENANT] [ENVIRONMENT] [flags]
 
 Flags:
+      --cluster-registry               Use the in-cluster erun-registry (addresses resolved from the env's kube-context) instead of --container-registry; mutually exclusive with it
       --codecommit-ssh-key-id string   CodeCommit SSH public key ID to use for remote repository access
       --confirm-environment            Confirm environment initialization without prompting
       --container-registry string      Container registry to associate with the environment

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -49,6 +49,7 @@ type erunUIDeps struct {
 	deleteNamespace        eruncommon.NamespaceDeleterFunc
 	listKubeContexts       func() ([]string, error)
 	loadResourceStatus     func(context.Context, uiRuntimeResourceInput) (uiRuntimeResourceStatus, error)
+	loadClusterRegistry    func(context.Context, uiRuntimeResourceInput) (uiClusterRegistryStatus, error)
 	ensureMCP              func(context.Context, eruncommon.OpenResult) error
 	reconnectMCP           func(context.Context, eruncommon.OpenResult, func(string)) error
 	ensureSSHD             func(context.Context, eruncommon.OpenResult) error
@@ -231,6 +232,9 @@ func withDefaultRuntimeDeps(deps erunUIDeps) erunUIDeps {
 	}
 	if deps.loadResourceStatus == nil {
 		deps.loadResourceStatus = loadRuntimeResourceStatus
+	}
+	if deps.loadClusterRegistry == nil {
+		deps.loadClusterRegistry = loadClusterRegistry
 	}
 	if deps.ensureMCP == nil {
 		deps.ensureMCP = func(ctx context.Context, result eruncommon.OpenResult) error {

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -758,6 +758,28 @@ func TestBuildInitArgsIncludesRuntimeVersion(t *testing.T) {
 	}
 }
 
+func TestBuildInitArgsClusterRegistryReplacesContainerRegistry(t *testing.T) {
+	got := buildInitArgs(uiSelection{
+		Tenant:            "erun",
+		Environment:       "remote",
+		KubernetesContext: "erun-k3s",
+		// ContainerRegistry is ignored when ClusterRegistry is selected; the two
+		// are mutually exclusive and cluster wins.
+		ContainerRegistry: "erunpaas",
+		ClusterRegistry:   true,
+		SetDefaultTenant:  true,
+	})
+	want := []string{"init", "erun", "remote", "--type=remote-agent", "--kubernetes-context", "erun-k3s", "--cluster-registry", "--set-default-tenant=true", "--confirm-environment=true"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected args length: got %+v want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected arg[%d]: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestBuildInitArgsRespectsExplicitType(t *testing.T) {
 	got := buildInitArgs(uiSelection{
 		Tenant:        "erun",

--- a/erun-ui/frontend/src/app/api/environmentApi.ts
+++ b/erun-ui/frontend/src/app/api/environmentApi.ts
@@ -1,4 +1,5 @@
 import type {
+  UIClusterRegistryStatus,
   UIEnvironmentConfig,
   UIRuntimeResourceStatus,
   UISelection,
@@ -9,6 +10,7 @@ import {
   ChooseLocalRepoPath,
   ChooseWorkspaceSyncLocalFolder,
   DeleteEnvironment,
+  LoadClusterRegistry,
   LoadEnvironmentConfig,
   LoadRuntimeResourceStatus,
   LoadVersionSuggestions,
@@ -80,6 +82,12 @@ export const environmentApi = wailsApi.injectEndpoints({
     getRuntimeResourceStatus: builder.query<UIRuntimeResourceStatus, RuntimeResourceArgs>({
       queryFn: wailsQueryFn<RuntimeResourceArgs, UIRuntimeResourceStatus>((args) =>
         LoadRuntimeResourceStatus(args),
+      ),
+      providesTags: ['RuntimeResourceStatus'],
+    }),
+    getClusterRegistry: builder.query<UIClusterRegistryStatus, RuntimeResourceArgs>({
+      queryFn: wailsQueryFn<RuntimeResourceArgs, UIClusterRegistryStatus>((args) =>
+        LoadClusterRegistry(args),
       ),
       providesTags: ['RuntimeResourceStatus'],
     }),

--- a/erun-ui/frontend/src/app/dialogContextsThunks.ts
+++ b/erun-ui/frontend/src/app/dialogContextsThunks.ts
@@ -66,6 +66,48 @@ const refreshDialogRuntimeResources =
     }
   };
 
+// refreshDialogClusterRegistry detects the in-cluster erun-registry for the
+// selected context and defaults the dialog to using it. Cleared when no context
+// is selected or none is deployed, so the container-registry choice always
+// matches the selected cluster.
+export const refreshDialogClusterRegistry =
+  (kubernetesContext: string): AppThunk<Promise<void>> =>
+  async (dispatch, getState) => {
+    const context = normalizeDialogValue(kubernetesContext);
+    if (!getState().environmentDialog.open) {
+      return;
+    }
+    if (!context) {
+      dispatch(patchEnvironmentDialog({ clusterRegistry: null, useClusterRegistry: false }));
+      return;
+    }
+    try {
+      const status = await dispatch(
+        environmentApi.endpoints.getClusterRegistry.initiate(
+          { kubernetesContext: context },
+          { forceRefetch: true },
+        ),
+      ).unwrap();
+      if (!getState().environmentDialog.open) {
+        return;
+      }
+      const deployed = status.deployed;
+      dispatch(
+        patchEnvironmentDialog({
+          clusterRegistry: deployed ? status : null,
+          // Default to the in-cluster registry whenever one is detected for the
+          // chosen context; the user can still opt out to a static registry.
+          useClusterRegistry: deployed,
+        }),
+      );
+    } catch {
+      if (!getState().environmentDialog.open) {
+        return;
+      }
+      dispatch(patchEnvironmentDialog({ clusterRegistry: null, useClusterRegistry: false }));
+    }
+  };
+
 // forceRefetch is required: without it RTK Query pins the previous
 // (possibly transient-empty) context list to the dialog, so Rescan can
 // never recover after a kubeconfig change.
@@ -91,6 +133,7 @@ export const refreshKubernetesContexts =
         }),
       );
       await dispatch(refreshDialogRuntimeResources(resolved));
+      await dispatch(refreshDialogClusterRegistry(resolved));
     } catch (error) {
       const dialog = getState().environmentDialog;
       if (!dialog.open) {
@@ -101,6 +144,8 @@ export const refreshKubernetesContexts =
           kubernetesContexts: [],
           kubernetesContext: '',
           kubernetesContextsLoading: false,
+          clusterRegistry: null,
+          useClusterRegistry: false,
           error: readError(error),
         }),
       );

--- a/erun-ui/frontend/src/app/environmentDialogState.ts
+++ b/erun-ui/frontend/src/app/environmentDialogState.ts
@@ -43,7 +43,9 @@ export function missingRequiredFieldReason(dialog: EnvironmentDialogState): stri
   if (!values.kubernetesContext) {
     return 'Select a Kubernetes context.';
   }
-  if (!values.containerRegistry) {
+  // The in-cluster registry needs no host string — its addresses resolve from the
+  // kube-context — so a container registry is only required when not using it.
+  if (!dialog.useClusterRegistry && !values.containerRegistry) {
     return 'Select a container registry.';
   }
   return null;

--- a/erun-ui/frontend/src/app/environmentDialogThunks.ts
+++ b/erun-ui/frontend/src/app/environmentDialogThunks.ts
@@ -1,7 +1,7 @@
 import type { UISelection, UIVersionSuggestion } from '@/types';
 
 import { environmentApi } from './api/environmentApi';
-import { refreshKubernetesContexts } from './dialogContextsThunks';
+import { refreshDialogClusterRegistry, refreshKubernetesContexts } from './dialogContextsThunks';
 import {
   missingRequiredFieldReason,
   normalizedEnvironmentDialogValues,
@@ -47,6 +47,8 @@ export const openInitializeDialog = (): AppThunk => (dispatch, getState) => {
       resourceStatusLoading: false,
       runtimePod: defaultEnvironmentDialog().runtimePod,
       containerRegistry: containerRegistryDefault,
+      clusterRegistry: null,
+      useClusterRegistry: false,
       envType: 'remote-agent',
       localRepoPath: '',
       noGit: false,
@@ -89,6 +91,7 @@ export const updateEnvironmentDialog =
     }
     if (values.kubernetesContext !== undefined) {
       void dispatch(refreshEnvironmentRuntimeResources(values.kubernetesContext));
+      void dispatch(refreshDialogClusterRegistry(values.kubernetesContext));
     }
   };
 
@@ -197,11 +200,15 @@ function environmentDialogInitFields(
 ): Partial<UISelection> {
   const runtimePod = runtimePodConfigToKubernetes(dialog.runtimePod);
   const isLocalAgent = dialog.envType === 'local-agent';
+  // When the in-cluster registry is chosen, seed a resolvable cluster: entry and
+  // omit the static container-registry string (the two are mutually exclusive).
+  const useClusterRegistry = dialog.useClusterRegistry && !!dialog.clusterRegistry?.deployed;
   return {
     runtimeCpu: runtimePod.cpu,
     runtimeMemory: runtimePod.memory,
     kubernetesContext: values.kubernetesContext,
-    containerRegistry: values.containerRegistry,
+    containerRegistry: useClusterRegistry ? '' : values.containerRegistry,
+    clusterRegistry: useClusterRegistry,
     type: dialog.envType,
     localRepoPath: isLocalAgent ? values.localRepoPath : undefined,
     setDefaultTenant: dialog.setDefaultTenant,

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -4,6 +4,7 @@ import type {
   ManageTab,
   UICloudContextInitInput,
   UICloudProviderStatus,
+  UIClusterRegistryStatus,
   UIDeployableComponent,
   UIEnvironmentConfig,
   UIERunConfig,
@@ -68,6 +69,12 @@ export interface EnvironmentDialogState {
     memory: string;
   };
   containerRegistry: string;
+  // clusterRegistry is the in-cluster erun-registry detected for the selected
+  // Kubernetes context (null when none / not yet resolved). When present and
+  // useClusterRegistry is set, the env is created with a resolvable cluster:
+  // registry entry instead of the containerRegistry string.
+  clusterRegistry: UIClusterRegistryStatus | null;
+  useClusterRegistry: boolean;
   envType: EnvironmentType;
   localRepoPath: string;
   noGit: boolean;
@@ -267,6 +274,8 @@ export const defaultEnvironmentDialog = (): EnvironmentDialogState => ({
   resourceStatusLoading: false,
   runtimePod: defaultRuntimePodConfig(),
   containerRegistry: '',
+  clusterRegistry: null,
+  useClusterRegistry: false,
   envType: 'remote-agent',
   localRepoPath: '',
   noGit: false,

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -227,23 +227,61 @@ function EnvironmentNameFields({
 }
 
 function EnvironmentCreateFields({ dialog }: { dialog: EnvironmentDialog }): React.ReactElement {
-  const dispatch = useAppDispatch();
-  const containerRegistrySuggestions = React.useMemo(
-    () =>
-      uniqueSuggestions([
-        dialog.containerRegistry,
-        ...loadSavedPastContainerRegistries(),
-        'erunpaas',
-      ]),
-    [dialog.containerRegistry],
-  );
-
   return (
     <>
       <EnvironmentTypeSelect dialog={dialog} />
       {dialog.envType === 'local-agent' && <LocalRepoPathField dialog={dialog} />}
       <KubernetesContextSelect dialog={dialog} />
       <RuntimePodFields dialog={dialog} />
+      <ContainerRegistryField dialog={dialog} />
+      <EnvironmentCreateChecks dialog={dialog} />
+    </>
+  );
+}
+
+// ContainerRegistryField offers the in-cluster erun-registry (resolved from the
+// selected Kubernetes context) as the default when one is detected, and falls
+// back to a free-text registry otherwise. There is no hardcoded default host —
+// the deployed cluster registry is the default, not a placeholder like erunpaas.
+function ContainerRegistryField({ dialog }: { dialog: EnvironmentDialog }): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const containerRegistrySuggestions = React.useMemo(
+    () => uniqueSuggestions([dialog.containerRegistry, ...loadSavedPastContainerRegistries()]),
+    [dialog.containerRegistry],
+  );
+  const cluster = dialog.clusterRegistry;
+  const clusterAvailable = cluster?.deployed === true;
+  const useCluster = clusterAvailable && dialog.useClusterRegistry;
+  const clusterToggle = clusterAvailable ? (
+    <label className="flex items-center gap-2 text-sm font-normal">
+      <Checkbox
+        id="environment-use-cluster-registry"
+        checked={dialog.useClusterRegistry}
+        disabled={dialog.busy}
+        onCheckedChange={(value) => {
+          dispatch(updateEnvironmentDialog({ useClusterRegistry: value === true }));
+        }}
+      />
+      Use in-cluster registry ({cluster.service ?? 'erun-registry'})
+    </label>
+  ) : null;
+
+  if (useCluster) {
+    return (
+      <div className="grid gap-2">
+        <Label htmlFor="environment-use-cluster-registry">Container registry</Label>
+        {clusterToggle}
+        <p className="text-[12px] leading-[1.4] text-muted-foreground">
+          Resolved from {cluster.service}.{cluster.namespace}:{cluster.port} via this
+          environment&apos;s Kubernetes context — pushed and pulled in-cluster, no host address
+          needed.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-2">
       <EditableComboField
         id="environment-container-registry"
         label="Container registry"
@@ -255,8 +293,8 @@ function EnvironmentCreateFields({ dialog }: { dialog: EnvironmentDialog }): Rea
           dispatch(updateEnvironmentDialog({ containerRegistry }));
         }}
       />
-      <EnvironmentCreateChecks dialog={dialog} />
-    </>
+      {clusterToggle}
+    </div>
   );
 }
 

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -85,6 +85,8 @@ export interface UISelection {
   runtimeMemory?: string;
   kubernetesContext?: string;
   containerRegistry?: string;
+  // Selects the in-cluster erun-registry instead of the containerRegistry string.
+  clusterRegistry?: boolean;
   // Bare string to match the Wails binding, which widens the Go EnvironmentType
   // alias; use the EnvironmentType union for narrowed dropdown values.
   type?: string;
@@ -515,6 +517,13 @@ export interface UIRuntimeResourceNode {
   name: string;
   cpu: UIRuntimeResourceMetric;
   memory: UIRuntimeResourceMetric;
+}
+
+export interface UIClusterRegistryStatus {
+  deployed: boolean;
+  service?: string;
+  namespace?: string;
+  port?: number;
 }
 
 export interface StartSessionResult {

--- a/erun-ui/runtime_resources.go
+++ b/erun-ui/runtime_resources.go
@@ -20,6 +20,47 @@ func (a *App) LoadRuntimeResourceStatus(input uiRuntimeResourceInput) (uiRuntime
 	return a.deps.loadResourceStatus(ctx, normalizeRuntimeResourceInput(input))
 }
 
+// LoadClusterRegistry reports whether the given Kubernetes context has an
+// in-cluster erun-registry Service, so the new-environment dialog can default to
+// a resolvable cluster: registry entry (addresses derived from the context) for
+// that env instead of a hardcoded host.
+func (a *App) LoadClusterRegistry(input uiRuntimeResourceInput) (uiClusterRegistryStatus, error) {
+	ctx := a.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return a.deps.loadClusterRegistry(ctx, normalizeRuntimeResourceInput(input))
+}
+
+func loadClusterRegistry(ctx context.Context, input uiRuntimeResourceInput) (uiClusterRegistryStatus, error) {
+	input = normalizeRuntimeResourceInput(input)
+	if input.KubernetesContext == "" {
+		return uiClusterRegistryStatus{}, nil
+	}
+	service := eruncommon.DefaultClusterRegistryService
+	namespace := eruncommon.DefaultClusterRegistryNamespace
+	// A ClusterIP means the registry Service exists in this context. A missing
+	// Service makes kubectl exit non-zero — treated as "not deployed", not an
+	// error, so the dialog simply falls back to its normal registry default.
+	output, err := kubectlJSON(ctx, input.KubernetesContext,
+		"get", "svc", service, "-n", namespace, "-o", "jsonpath={.spec.clusterIP}")
+	clusterIP := strings.TrimSpace(string(output))
+	if err != nil || clusterIP == "" || clusterIP == "None" {
+		return uiClusterRegistryStatus{KubernetesContext: input.KubernetesContext, Deployed: false}, nil
+	}
+	port := eruncommon.DefaultClusterRegistryPort
+	return uiClusterRegistryStatus{
+		KubernetesContext: input.KubernetesContext,
+		Deployed:          true,
+		Service:           service,
+		Namespace:         namespace,
+		Port:              port,
+		// The erun-registry is plain HTTP, so mark it insecure for the in-pod dind.
+		Insecure: true,
+		Message:  fmt.Sprintf("In-cluster registry %s.%s:%d", service, namespace, port),
+	}, nil
+}
+
 func loadRuntimeResourceStatus(ctx context.Context, input uiRuntimeResourceInput) (uiRuntimeResourceStatus, error) {
 	input = normalizeRuntimeResourceInput(input)
 	if input.KubernetesContext == "" {

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -331,17 +331,25 @@ func buildInitArgs(selection uiSelection) []string {
 }
 
 func appendInitOptionalFlags(args []string, selection uiSelection) []string {
-	for _, pair := range []struct{ flag, value string }{
+	pairs := []struct{ flag, value string }{
 		{"--version", strings.TrimSpace(selection.Version)},
 		{"--runtime-image", strings.TrimSpace(selection.RuntimeImage)},
 		{"--runtime-cpu", strings.TrimSpace(selection.RuntimeCPU)},
 		{"--runtime-memory", strings.TrimSpace(selection.RuntimeMemory)},
 		{"--kubernetes-context", strings.TrimSpace(selection.KubernetesContext)},
-		{"--container-registry", strings.TrimSpace(selection.ContainerRegistry)},
-	} {
+	}
+	// The cluster registry and a static container registry are mutually exclusive
+	// (`erun init` rejects both); cluster wins when selected.
+	if !selection.ClusterRegistry {
+		pairs = append(pairs, struct{ flag, value string }{"--container-registry", strings.TrimSpace(selection.ContainerRegistry)})
+	}
+	for _, pair := range pairs {
 		if pair.value != "" {
 			args = append(args, pair.flag, pair.value)
 		}
+	}
+	if selection.ClusterRegistry {
+		args = append(args, "--cluster-registry")
 	}
 	return args
 }

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -69,7 +69,11 @@ type uiSelection struct {
 	RuntimeMemory     string `json:"runtimeMemory,omitempty"`
 	KubernetesContext string `json:"kubernetesContext,omitempty"`
 	ContainerRegistry string `json:"containerRegistry,omitempty"`
-	Type              string `json:"type,omitempty"`
+	// ClusterRegistry selects the in-cluster erun-registry (resolved from the
+	// env's kube-context) instead of the static ContainerRegistry string; the two
+	// are mutually exclusive and ClusterRegistry wins when set.
+	ClusterRegistry bool   `json:"clusterRegistry,omitempty"`
+	Type            string `json:"type,omitempty"`
 	LocalRepoPath     string `json:"localRepoPath,omitempty"`
 	NoGit             bool   `json:"noGit,omitempty"`
 	SetDefaultTenant  bool   `json:"setDefaultTenant,omitempty"`
@@ -328,6 +332,19 @@ type uiRuntimeResourceMetric struct {
 	Free      float64 `json:"free"`
 	Unit      string  `json:"unit"`
 	Formatted string  `json:"formatted"`
+}
+
+// uiClusterRegistryStatus reports whether the selected Kubernetes context has an
+// in-cluster erun-registry deployed, so the new-environment dialog can default to
+// a resolvable cluster: registry entry instead of a hardcoded host.
+type uiClusterRegistryStatus struct {
+	KubernetesContext string `json:"kubernetesContext"`
+	Deployed          bool   `json:"deployed"`
+	Service           string `json:"service,omitempty"`
+	Namespace         string `json:"namespace,omitempty"`
+	Port              int    `json:"port,omitempty"`
+	Insecure          bool   `json:"insecure"`
+	Message           string `json:"message,omitempty"`
 }
 
 type uiRuntimeResourceNode struct {


### PR DESCRIPTION
Stacked on #852 (shares the new-environment dialog files). Rebase onto main once #852 merges.

## What & why

The Container registry field defaulted to a hardcoded `erunpaas` suggestion. When the selected Kubernetes context has an in-cluster **erun-registry** deployed (as the local k3s setup provisions), the dialog now defaults to it instead — as a **resolvable `cluster:` registry entry**, not a frozen host string.

This matters because the correct registry address is env-type-dependent: an in-pod **remote-agent** build must push to the ClusterIP, while a host **local-agent** build reaches it via a managed port-forward. A `cluster:` entry resolves both from the env's kube-context; a hardcoded `localhost:5000` would break the remote-agent case. (Full-stack `cluster:` support landed earlier; this wires it into the create dialog.)

## Changes

- **erun-common**: `BootstrapInitParams.ClusterRegistry` + `ClusterContainerRegistries()`; the init workflow writes a `cluster:` entry (roles build+deploy) and skips static container-registry resolution when set.
- **erun-cli**: `erun init --cluster-registry` (mutually exclusive with `--container-registry`); marks the registry insecure since the erun-registry is plain HTTP.
- **erun-ui backend**: `LoadClusterRegistry` detects `svc/erun-registry` in the given context (Wails-exported, follows the `kubectlJSON` + `HideConsoleWindow` pattern).
- **erun-ui frontend**: detects on context change/open, defaults to the cluster registry with an opt-out checkbox, drops the `erunpaas` hardcode, and threads `--cluster-registry` through `StartInitSession`.

## Verification

- `go test` for erun-common / erun-cli / erun-ui registry + init-args paths, plus the erun-integration `TestInit` suite — all pass. New lock-in tests: `TestClusterContainerRegistries`, `TestBuildInitArgsClusterRegistryReplacesContainerRegistry`.
- Frontend `typecheck`, `lint`, `build`, `prettier` all pass.
- `init/help` golden regenerated (adds `--cluster-registry`). Wails bindings are gitignored (regenerated at build).

Answers the question that prompted this: `localhost:5000` **is** deployed (the in-cluster erun-registry), and the dialog now defaults to it rather than `erunpaas`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)