### PR TITLE
Fix Windows local-shell spawn (env creation: 'cannot find the file specified')

### DIFF
--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -758,6 +758,28 @@ func TestBuildInitArgsIncludesRuntimeVersion(t *testing.T) {
 	}
 }
 
+func TestResolveLocalShellCommandIgnoresPosixShellOnWindows(t *testing.T) {
+	// A Git Bash / MSYS $SHELL is a POSIX path ConPTY cannot launch; on Windows
+	// it must be ignored in favour of a PowerShell command, or starting the local
+	// shell fails with "the system cannot find the file specified".
+	t.Setenv("SHELL", "/usr/bin/bash")
+	shell, args := resolveLocalShellCommand("windows")
+	if shell == "/usr/bin/bash" {
+		t.Fatalf("windows shell honored POSIX $SHELL: %q", shell)
+	}
+	lower := strings.ToLower(shell)
+	if !strings.Contains(lower, "powershell") && !strings.Contains(lower, "pwsh") {
+		t.Fatalf("windows shell = %q, want a powershell/pwsh command", shell)
+	}
+	if len(args) == 0 || args[0] != "-NoLogo" {
+		t.Fatalf("windows shell args = %v, want -NoLogo", args)
+	}
+	// A non-Windows host still honors an absolute $SHELL.
+	if got, _ := resolveLocalShellCommand("linux"); got != "/usr/bin/bash" {
+		t.Fatalf("unix shell = %q, want /usr/bin/bash from $SHELL", got)
+	}
+}
+
 func TestBuildInitArgsRespectsExplicitType(t *testing.T) {
 	got := buildInitArgs(uiSelection{
 		Tenant:        "erun",

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -460,15 +460,24 @@ func resolveDeployStartDir(findProjectRoot eruncommon.ProjectFinderFunc, result 
 const defaultAITool = "claude"
 
 func resolveLocalShellCommand(goos string) (string, []string) {
+	if strings.TrimSpace(goos) == "windows" {
+		// ConPTY resolves a non-absolute executable relative to the session's
+		// start dir (not PATH), so a bare "powershell.exe" becomes
+		// "<startDir>\powershell.exe" and fails with "the system cannot find the
+		// file specified". Return an absolute shell path. $SHELL is ignored on
+		// Windows — it is typically a POSIX path from Git Bash that ConPTY cannot
+		// launch. Prefer PowerShell 7 (pwsh), fall back to Windows PowerShell.
+		for _, name := range []string{"pwsh.exe", "powershell.exe"} {
+			if resolved, err := exec.LookPath(name); err == nil {
+				return resolved, []string{"-NoLogo"}
+			}
+		}
+		return "powershell.exe", []string{"-NoLogo"}
+	}
 	if shell := strings.TrimSpace(os.Getenv("SHELL")); shell != "" {
 		return shell, nil
 	}
-	switch strings.TrimSpace(goos) {
-	case "windows":
-		return "powershell.exe", []string{"-NoLogo"}
-	default:
-		return "/bin/bash", nil
-	}
+	return "/bin/bash", nil
 }
 
 // claudeEffortLevels enumerates the selectable Claude effort levels in ascending

--- a/erun-ui/session_windows.go
+++ b/erun-ui/session_windows.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"syscall"
@@ -29,9 +30,20 @@ func startTerminalSession(params startTerminalSessionParams) (terminalSession, e
 	}
 
 	env := append(os.Environ(), append(params.Env, "TERM=xterm-256color", "COLORTERM=truecolor")...)
-	args := append([]string{params.Executable}, params.Args...)
 
-	pid, _, err := ptyDevice.Spawn(params.Executable, args, &syscall.ProcAttr{
+	// ConPTY's Spawn resolves a non-absolute executable relative to attr.Dir
+	// rather than searching PATH, so a bare name like "powershell.exe" would be
+	// looked for in the session's start dir and fail with "the system cannot find
+	// the file specified". Resolve it on PATH to an absolute path first.
+	executable := params.Executable
+	if !filepath.IsAbs(executable) {
+		if resolved, lookErr := exec.LookPath(executable); lookErr == nil {
+			executable = resolved
+		}
+	}
+	args := append([]string{executable}, params.Args...)
+
+	pid, _, err := ptyDevice.Spawn(executable, args, &syscall.ProcAttr{
 		Dir: params.Dir,
 		Env: env,
 	})


### PR DESCRIPTION
## Symptom

Creating an environment from the desktop app fails with **"The system cannot find the file specified."** (shown in the New environment dialog on Create).

## Root cause

Creating an env pipes `erun init …` into a **local shell** PTY. That shell is spawned as a bare `"powershell.exe"`. The Windows PTY library (`ActiveState/termtest/conpty`), when a start directory is set, resolves a **non-absolute** executable **relative to that dir** (not PATH) before calling `CreateProcess` — so `"powershell.exe"` becomes `"<startDir>\powershell.exe"`, which doesn't exist → `CreateProcess` fails with ERROR_FILE_NOT_FOUND.

`erun open` terminal sessions were unaffected because they pass an **absolute** CLI path; only the local shell — first exercised when creating an env — used a bare name, which is why this surfaced now (first local-cluster env creation on Windows).

## Fix

- `resolveLocalShellCommand`: on Windows, resolve the shell to an **absolute path** via `LookPath` (prefer PowerShell 7 `pwsh`, fall back to Windows PowerShell), and **ignore `$SHELL`** there — it's typically a POSIX Git Bash path ConPTY can't launch.
- `startTerminalSession` (windows): defensively `LookPath` any non-absolute executable before `Spawn`, so no caller can hit the dir-relative trap.

## Verification

`go build` + new portable test `TestResolveLocalShellCommandIgnoresPosixShellOnWindows` (and the existing `buildInitArgs` tests) pass. Independent of the dialog PRs (#852/#853) — different code area — so this targets `main` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)