### PR TITLE
Restore the make check gate: fix lint findings and stale open goldens

### DIFF
--- a/erun-cli/cmd/init.go
+++ b/erun-cli/cmd/init.go
@@ -65,19 +65,9 @@ func newInitCmd(runInit func(common.Context, common.BootstrapInitParams) error) 
 
 func initRunParams(cmd *cobra.Command, args []string, params common.BootstrapInitParams, setDefaultTenant, confirmEnvironment, clusterRegistry bool, envType string) (common.BootstrapInitParams, error) {
 	runParams := params
-	if runParams.Tenant == "" && len(args) > 0 {
-		runParams.Tenant = args[0]
-	}
-	if runParams.Environment == "" && len(args) > 1 {
-		runParams.Environment = args[1]
-	}
-	if clusterRegistry {
-		if strings.TrimSpace(runParams.ContainerRegistry) != "" {
-			return common.BootstrapInitParams{}, fmt.Errorf("--cluster-registry conflicts with --container-registry; pick one")
-		}
-		// The in-cluster erun-registry is plain HTTP, so mark it insecure; the
-		// rest (service/namespace/port) fill from the erun-registry convention.
-		runParams.ClusterRegistry = &common.ClusterRegistry{Insecure: true}
+	applyPositionalInitArgs(&runParams, args)
+	if err := applyClusterRegistryFlag(&runParams, clusterRegistry); err != nil {
+		return common.BootstrapInitParams{}, err
 	}
 	if err := applyInitTypeFlag(cmd, &runParams, envType); err != nil {
 		return common.BootstrapInitParams{}, err
@@ -92,6 +82,28 @@ func initRunParams(cmd *cobra.Command, args []string, params common.BootstrapIni
 		runParams.ConfirmEnvironment = &confirmEnvironment
 	}
 	return runParams, nil
+}
+
+func applyPositionalInitArgs(runParams *common.BootstrapInitParams, args []string) {
+	if runParams.Tenant == "" && len(args) > 0 {
+		runParams.Tenant = args[0]
+	}
+	if runParams.Environment == "" && len(args) > 1 {
+		runParams.Environment = args[1]
+	}
+}
+
+func applyClusterRegistryFlag(runParams *common.BootstrapInitParams, clusterRegistry bool) error {
+	if !clusterRegistry {
+		return nil
+	}
+	if strings.TrimSpace(runParams.ContainerRegistry) != "" {
+		return fmt.Errorf("--cluster-registry conflicts with --container-registry; pick one")
+	}
+	// The in-cluster erun-registry is plain HTTP, so mark it insecure; the
+	// rest (service/namespace/port) fill from the erun-registry convention.
+	runParams.ClusterRegistry = &common.ClusterRegistry{Insecure: true}
+	return nil
 }
 
 func applyInitTypeFlag(cmd *cobra.Command, runParams *common.BootstrapInitParams, envType string) error {

--- a/erun-common/container_registry.go
+++ b/erun-common/container_registry.go
@@ -82,11 +82,6 @@ func (e ContainerRegistryEntry) identity() string {
 	return strings.TrimSpace(e.Registry)
 }
 
-// isConfigured reports whether the entry names a target at all.
-func (e ContainerRegistryEntry) isConfigured() bool {
-	return e.Cluster != nil || strings.TrimSpace(e.Registry) != ""
-}
-
 // ContainerRegistries is the marked registry list. Build pushes to the BUILD
 // registry; deploy copies images FROM → every TO when both are set, then the
 // cluster pulls from the DEPLOY registry.
@@ -218,30 +213,42 @@ func (r ContainerRegistries) Concrete(resolve ClusterRegistryResolver) (Containe
 			out = append(out, entry)
 			continue
 		}
-		addrs, err := resolve(entry.Cluster.WithDefaults())
+		expanded, err := expandClusterEntry(entry, resolve)
 		if err != nil {
 			return nil, err
 		}
-		var pull, push []RegistryRole
-		for _, role := range entry.Roles {
-			if isClusterPullRole(role) {
-				pull = append(pull, role)
-			} else {
-				push = append(push, role)
-			}
+		out = append(out, expanded...)
+	}
+	return out, nil
+}
+
+// expandClusterEntry resolves one cluster entry's push/pull hosts and splits its
+// roles into plain per-host entries: DEPLOY pulls; BUILD/FROM/TO push.
+func expandClusterEntry(entry ContainerRegistryEntry, resolve ClusterRegistryResolver) (ContainerRegistries, error) {
+	addrs, err := resolve(entry.Cluster.WithDefaults())
+	if err != nil {
+		return nil, err
+	}
+	var pull, push []RegistryRole
+	for _, role := range entry.Roles {
+		if isClusterPullRole(role) {
+			pull = append(pull, role)
+		} else {
+			push = append(push, role)
 		}
-		if len(push) > 0 {
-			if strings.TrimSpace(addrs.Push) == "" {
-				return nil, errors.New("cluster registry resolved an empty push address")
-			}
-			out = append(out, ContainerRegistryEntry{Registry: addrs.Push, Roles: push})
+	}
+	out := make(ContainerRegistries, 0, 2)
+	if len(push) > 0 {
+		if strings.TrimSpace(addrs.Push) == "" {
+			return nil, errors.New("cluster registry resolved an empty push address")
 		}
-		if len(pull) > 0 {
-			if strings.TrimSpace(addrs.Pull) == "" {
-				return nil, errors.New("cluster registry resolved an empty pull address")
-			}
-			out = append(out, ContainerRegistryEntry{Registry: addrs.Pull, Roles: pull})
+		out = append(out, ContainerRegistryEntry{Registry: addrs.Push, Roles: push})
+	}
+	if len(pull) > 0 {
+		if strings.TrimSpace(addrs.Pull) == "" {
+			return nil, errors.New("cluster registry resolved an empty pull address")
 		}
+		out = append(out, ContainerRegistryEntry{Registry: addrs.Pull, Roles: pull})
 	}
 	return out, nil
 }

--- a/erun-common/container_registry_cluster_test.go
+++ b/erun-common/container_registry_cluster_test.go
@@ -40,6 +40,11 @@ func TestClusterContainerRegistries(t *testing.T) {
 	if !entry.Cluster.Insecure {
 		t.Error("insecure not preserved")
 	}
+}
+
+func TestClusterContainerRegistriesRolesAndValidate(t *testing.T) {
+	list := ClusterContainerRegistries(ClusterRegistry{Insecure: true})
+	entry := list[0]
 	if !entry.hasRole(RegistryRoleBuild) || !entry.hasRole(RegistryRoleDeploy) {
 		t.Errorf("roles = %v, want build+deploy", entry.Roles)
 	}

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -1812,7 +1812,7 @@ func windowsDrivePathToWSLMount(p string) string {
 		return p
 	}
 	drive := p[0]
-	if !((drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z')) {
+	if (drive < 'A' || drive > 'Z') && (drive < 'a' || drive > 'z') {
 		return p
 	}
 	rest := strings.TrimPrefix(p[2:], "/")

--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -1324,31 +1324,35 @@ func (s bootstrapRunner) saveProjectContainerRegistry(projectRoot, envName, regi
 	}
 
 	if params.ClusterRegistry != nil {
-		projectConfig, err := s.loadProjectConfigForContainerRegistry(projectRoot)
-		if err != nil {
-			return err
-		}
-		desired := ClusterContainerRegistries(*params.ClusterRegistry)
-		if projectConfig.ContainerRegistriesForEnvironment(envName).Equal(desired) {
-			return nil
-		}
-		projectConfig.SetContainerRegistriesForEnvironment(envName, desired)
-		return s.SaveProjectConfig(projectRoot, projectConfig)
+		return s.saveClusterContainerRegistry(projectRoot, envName, *params.ClusterRegistry)
 	}
+	return s.savePlainContainerRegistry(projectRoot, envName, registry)
+}
 
-	if registry == "" {
-		return nil
-	}
-
+func (s bootstrapRunner) saveClusterContainerRegistry(projectRoot, envName string, cluster ClusterRegistry) error {
 	projectConfig, err := s.loadProjectConfigForContainerRegistry(projectRoot)
 	if err != nil {
 		return err
 	}
+	desired := ClusterContainerRegistries(cluster)
+	if projectConfig.ContainerRegistriesForEnvironment(envName).Equal(desired) {
+		return nil
+	}
+	projectConfig.SetContainerRegistriesForEnvironment(envName, desired)
+	return s.SaveProjectConfig(projectRoot, projectConfig)
+}
 
+func (s bootstrapRunner) savePlainContainerRegistry(projectRoot, envName, registry string) error {
+	if registry == "" {
+		return nil
+	}
+	projectConfig, err := s.loadProjectConfigForContainerRegistry(projectRoot)
+	if err != nil {
+		return err
+	}
 	if existing, _ := projectConfig.ContainerRegistriesForEnvironment(envName).BuildRegistry(); existing == registry {
 		return nil
 	}
-
 	projectConfig.SetContainerRegistriesForEnvironment(envName, SingleContainerRegistries(registry))
 	return s.SaveProjectConfig(projectRoot, projectConfig)
 }

--- a/erun-integration/internal/fixture/stubrunner/main.go
+++ b/erun-integration/internal/fixture/stubrunner/main.go
@@ -26,7 +26,7 @@ func main() {
 	if err != nil {
 		os.Exit(97)
 	}
-	defer os.Remove(argvFile.Name())
+	defer func() { _ = os.Remove(argvFile.Name()) }()
 	for _, arg := range os.Args[1:] {
 		if _, err := argvFile.WriteString(arg); err != nil {
 			os.Exit(97)

--- a/erun-integration/testdata/open/alias_prompt_accept_appends_alias_real_run.txt
+++ b/erun-integration/testdata/open/alias_prompt_accept_appends_alias_real_run.txt
@@ -1,6 +1,6 @@
-add team-dev to <TMP> y
 kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
+add team-dev to <TMP> y
 added team-dev to <TMP>
 open a new shell to use team-dev

--- a/erun-integration/testdata/open/alias_prompt_bash_accept_creates_bashrc.txt
+++ b/erun-integration/testdata/open/alias_prompt_bash_accept_creates_bashrc.txt
@@ -1,6 +1,6 @@
-add team-dev to <TMP> y
 kubectl config use-context 'test-context' >/dev/null &&
 kubectl config set-context --current --namespace='team-dev' >/dev/null &&
 cd '<TMP>'
+add team-dev to <TMP> y
 added team-dev to <TMP>
 open a new shell to use team-dev


### PR DESCRIPTION
## Problem

Every erun-driven build re-runs `make check` (lint → integration) in the `erun-devops` image test stage, so a red `make check` on `main` fails all builds (surfaced as a runtime image rebuild aborting mid `erun push`). The gate was red for several pre-existing, stacked reasons — `make check` stops at the first failure, hiding the rest.

## Changes

**Lint (`make lint`)**
- `erun-common`: reduce cyclomatic complexity of `Concrete` (extract `expandClusterEntry`), `saveProjectContainerRegistry` (extract `saveClusterContainerRegistry` / `savePlainContainerRegistry`), and split the over-complex `TestClusterContainerRegistries`.
- `erun-common/deploy.go`: apply De Morgan's law to the Windows drive-letter guard (staticcheck QF1001).
- `erun-common`: drop the unused `ContainerRegistryEntry.isConfigured`.
- `erun-cli/cmd/init.go`: reduce `initRunParams` complexity via `applyPositionalInitArgs` / `applyClusterRegistryFlag`.
- `erun-integration`: check the `os.Remove` return in the stub runner (errcheck).

**Integration (`make integration-test`)**
- Regenerate the two `open` alias-prompt real-run goldens on Linux. Since #855 the stderr alias messages emit before the stdout eval-script, changing the deterministic `Combined` order; the goldens were last regenerated on macOS and never re-run on Linux. Real-run append behavior stays asserted by the scenarios' side-effect checks.

All behavior-preserving except the golden updates, which only re-record current deterministic output order.

## Validation

`make check` green: lint clean across all four modules, integration passing, coverage 75.0% (≥ 75.0%).

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)