### PR TITLE
Cover the cluster-registry paths in the integration gate

### DIFF
--- a/erun-integration/build_test.go
+++ b/erun-integration/build_test.go
@@ -47,6 +47,26 @@ func TestBuild(t *testing.T) {
 		golden.Equal(t, "build/dry_run_from_devops_cwd", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_cluster_registry_resolves_host_port_forward", func(t *testing.T) {
+		// A cluster: container registry resolves its concrete push host from the
+		// kube-context at build time. On the host (not in-pod) the push host is a
+		// managed port-forward to the registry Service; dry-run traces the ClusterIP
+		// lookup and the port-forward and uses placeholders so no cluster is touched.
+		// Locks the cluster-registry build resolution (Concrete → expandClusterEntry
+		// → resolver → port-forward) that plain registries skip.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedGitRepo(t, setup.Cwd)
+		fixture.SeedProjectK8sConfig(t, setup, "paths:\n    docker: build/docker\n    version: build/VERSION\ncontainerregistries:\n    - cluster: {}\n      roles:\n        - build\n        - deploy\n")
+		fixture.SeedDockerComponentAt(t, filepath.Join(setup.Cwd, "build", "docker"), "api")
+		mustWriteFile(t, filepath.Join(setup.Cwd, "build", "VERSION"), "2.3.4\n")
+		result := erun.Run(t, []string{"build", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: append(setup.Env(), stubDockerNoLocalImages(t, setup)...)})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "build/dry_run_cluster_registry_resolves_host_port_forward", normalize.Apply(result.Combined))
+	})
+
 	t.Run("dry_run_configured_docker_and_version_paths", func(t *testing.T) {
 		// paths.docker and paths.version in .erun/config.yaml relocate the docker
 		// build root and VERSION file out of the <tenant>-devops convention: the

--- a/erun-integration/init_test.go
+++ b/erun-integration/init_test.go
@@ -286,6 +286,50 @@ func TestInit(t *testing.T) {
 		golden.Equal(t, "init/type_remote_agent_dry_run", normalize.Apply(result.Combined))
 	})
 
+	t.Run("cluster_registry_dry_run", func(t *testing.T) {
+		// --cluster-registry seeds the in-cluster erun-registry as the env's
+		// container registry (a cluster: entry whose push/pull hosts resolve from
+		// the kube-context at build/deploy time) instead of a static
+		// --container-registry, so the resolved plan carries the cluster marker.
+		setup := env.New(t)
+		args := []string{
+			"init", "team", "dev",
+			"--type", "remote-agent",
+			"--version", "1.0.0",
+			"--kubernetes-context", "test-context",
+			"--cluster-registry",
+			"--no-git",
+			"--set-default-tenant=true",
+			"--confirm-environment=true",
+			"--dry-run",
+		}
+		result := erun.Run(t, args, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "init/cluster_registry_dry_run", normalize.Apply(result.Combined))
+	})
+
+	t.Run("cluster_registry_conflicts_with_container_registry", func(t *testing.T) {
+		// --cluster-registry and --container-registry are mutually exclusive; supplying
+		// both fails fast before any resolution.
+		setup := env.New(t)
+		args := []string{
+			"init", "team", "dev",
+			"--type", "remote-agent",
+			"--version", "1.0.0",
+			"--kubernetes-context", "test-context",
+			"--cluster-registry",
+			"--container-registry", "registry.example/test",
+			"--dry-run",
+		}
+		result := erun.Run(t, args, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit for conflicting flags, got 0: %s", result.Combined)
+		}
+		golden.Equal(t, "init/cluster_registry_conflicts_with_container_registry", normalize.Apply(result.Combined))
+	})
+
 	t.Run("dry_run_with_mcp_auth_public_key", func(t *testing.T) {
 		// --mcp-auth-public-key folds the desktop's MCP-auth key into init's single
 		// runtime deploy: the runtime (team-devops) chart carries mcpAuth.* helm

--- a/erun-integration/testdata/build/dry_run_cluster_registry_resolves_host_port_forward.txt
+++ b/erun-integration/testdata/build/dry_run_cluster_registry_resolves_host_port_forward.txt
@@ -1,0 +1,18 @@
+audit: erun build --dry-run
+build: docker build root configured as build/docker (.erun/config.yaml paths.docker)
+build: version file configured as build/VERSION (.erun/config.yaml paths.version)
+kubectl -n kube-system get svc erun-registry -o 'jsonpath={.spec.clusterIP}'
+kubectl -n kube-system port-forward svc/erun-registry :5000
+docker image inspect localhost:5000/api:fp-<HEX16>-amd64
+fingerprint image not found locally: localhost:5000/api:fp-<HEX16>-amd64
+docker image inspect localhost:5000/api:fp-<HEX16>-arm64
+fingerprint image not found locally: localhost:5000/api:fp-<HEX16>-arm64
+rebuilding localhost:5000/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t localhost:5000/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker tag localhost:5000/api:<VERSION> localhost:5000/api:fp-<HEX16>-amd64
+cd <TMP> && docker tag localhost:5000/api:<VERSION> localhost:5000/api:<VERSION>
+cd <TMP> && docker tag localhost:5000/api:<VERSION> localhost:5000/api:<VERSION>
+cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t localhost:5000/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker tag localhost:5000/api:<VERSION> localhost:5000/api:fp-<HEX16>-arm64
+cd <TMP> && docker tag localhost:5000/api:<VERSION> localhost:5000/api:<VERSION>
+cd <TMP> && docker tag localhost:5000/api:<VERSION> localhost:5000/api:<VERSION>

--- a/erun-integration/testdata/init/cluster_registry_conflicts_with_container_registry.txt
+++ b/erun-integration/testdata/init/cluster_registry_conflicts_with_container_registry.txt
@@ -1,0 +1,2 @@
+audit: erun init --cluster-registry --container-registry registry.example/test --dry-run --kubernetes-context test-context --type remote-agent --version <VERSION> team dev
+--cluster-registry conflicts with --container-registry; pick one

--- a/erun-integration/testdata/init/cluster_registry_dry_run.txt
+++ b/erun-integration/testdata/init/cluster_registry_dry_run.txt
@@ -1,0 +1,47 @@
+audit: erun init --cluster-registry --confirm-environment --dry-run --kubernetes-context test-context --no-git --set-default-tenant --type remote-agent --version <VERSION> team dev
+Loading erun tool configuration, configPath=<TMP>
+Saving default config
+mkdir -p <TMP>
+write-yaml <TMP>
+Loaded erun tool configuration
+Loading tenant configuration
+Adding new tenant
+mkdir -p <TMP>
+write-yaml <TMP>
+Loaded tenant configuration
+Loading environment configuration
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+Adding new environment
+mkdir -p <TMP>
+write-yaml <TMP>
+==> Initializing team/dev
+deploy: no local runtime chart; using published chart oci://ghcr.io/sophium/charts/erun-devops version <VERSION>
+deploy: defaulting runtime image to the tenant's team-devops image ghcr.io/sophium/team-devops:<VERSION> (imageOverrides.erun-devops)
+kubectl --context test-context get namespace team-dev -o name
+kubectl --context test-context create namespace team-dev
+helm upgrade --install --wait --wait-for-jobs --server-side true --force-conflicts --timeout 5m0s --namespace team-dev --debug --kube-context test-context --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=pvc --set-string worktreeRepoName=team --set-string worktreeHostPath=<HOME>/git/team --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.region= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string containerRegistry=ghcr.io/sophium --set-json 'containerRegistries=[{"cluster":{"service":"erun-registry","namespace":"kube-system","port":5000,"insecure":true},"roles":["build","deploy"]}]' --set disableBuildScript=false --set-string imageOverrides.erun-devops=ghcr.io/sophium/team-devops:<VERSION> --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops oci://ghcr.io/sophium/charts/erun-devops --version <VERSION>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)
+kubectl --context test-context --namespace team-dev wait --for=condition=Available --timeout 2m0s deployment/team-devops
+kubectl --context test-context --namespace team-dev exec deployment/team-devops -- /bin/sh -lc '<remote-script>'
+remote-worktree:
+  set -eu
+  mkdir -p '<HOME>/git/team'
+kubectl --context test-context --namespace team-dev exec deployment/team-devops -- /bin/sh -lc '<remote-script>'
+remote-init-marker:
+  set -eu
+  mkdir -p '$HOME/.erun/team/dev'
+  cat > '$HOME/.erun/team/dev/bootstrap.yaml' <<'__ERUN_BOOTSTRAP_MARKER__'
+  tenant: team
+  environment: dev
+  project_root: <HOME>/git/team
+  no_git: true
+  bootstrap_complete: true
+  __ERUN_BOOTSTRAP_MARKER__
+  chmod 600 '$HOME/.erun/team/dev/bootstrap.yaml'
+==> Initialized team/dev
+Configuration initialized OK
+ensure-agent-instructions
+ensure-claude-settings


### PR DESCRIPTION
## Problem

With the lint gate restored (#857 / #856), `make check` reaches the integration coverage gate and fails it: gated `erun-cli`+`erun-common` statement coverage was **74.9%** in the `erun-devops` image test stage — below the 75.0% threshold — so no runtime image is tagged. This is the second (deeper) reason releases 1.0.150–1.0.153 produced git tags with no published images.

## Root cause

The context-resolved cluster-registry feature (#849) landed a large `erun-common` block — `Concrete`/`expandClusterEntry`/`isClusterPullRole`/`ClusterEntry`/`ClusterContainerRegistries`, the `NewClusterRegistryResolver`/`clusterRegistryHost`/`ClusterRegistryDepsFor`/`lookupClusterIP` resolver chain, `saveClusterContainerRegistry` — plus the `--cluster-registry` init flag, with **near-zero integration coverage**, dragging the gated total to the threshold boundary.

## Changes

Add integration scenarios (the gate's only coverage signal); **no threshold change**:
- `TestInit/cluster_registry_dry_run` — the `--cluster-registry` happy path (`applyClusterRegistryFlag` set-path, `ClusterContainerRegistries`, cluster marker in the resolved init plan).
- `TestInit/cluster_registry_conflicts_with_container_registry` — the mutually-exclusive-flags error branch.
- `TestBuild/dry_run_cluster_registry_resolves_host_port_forward` — build resolving a `cluster:` registry to its concrete push host (`Concrete` → `expandClusterEntry` → `isClusterPullRole` → resolver chain → `lookupClusterIP`/port-forward), all via dry-run placeholders — no cluster touched.

## Validation

Gated coverage 75.4% locally and **75.3% in the `erun-devops` image test stage** (verified by building the `test` target end-to-end), comfortably above the 75.0% floor. Full `make check` green.

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)