### PR TITLE
Finalize env sessions on close so the sidebar stops spinning

### DIFF
--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -100,7 +100,6 @@ type App struct {
 	busyEnvs                  map[string]int
 	workspaceSyncs            map[string]*workspaceSyncWorker
 	orchestrators             map[string]*orchestratorSession
-	nextOrchestrator          int
 	credentialRefreshers      map[string]*cloudCredentialsRefresher
 	activityQueue             *activityQueueStore
 	activityStatusPoller      func(activityQueueEntry)
@@ -244,6 +243,12 @@ func withDefaultCloudDeps(deps erunUIDeps) erunUIDeps {
 }
 
 func withDefaultRuntimeDeps(deps erunUIDeps) erunUIDeps {
+	deps = withDefaultRuntimeResolutionDeps(deps)
+	deps = withDefaultRuntimeSessionDeps(deps)
+	return deps
+}
+
+func withDefaultRuntimeResolutionDeps(deps erunUIDeps) erunUIDeps {
 	if deps.listKubeContexts == nil {
 		deps.listKubeContexts = listKubernetesContexts
 	}
@@ -256,6 +261,19 @@ func withDefaultRuntimeDeps(deps erunUIDeps) erunUIDeps {
 	if deps.checkRuntimeDeployed == nil {
 		deps.checkRuntimeDeployed = checkRuntimeDeployed
 	}
+	if deps.canConnectLocalPort == nil {
+		deps.canConnectLocalPort = canConnectLocalTCP
+	}
+	if deps.setRemoteCloudAlias == nil {
+		deps.setRemoteCloudAlias = setEnvironmentCloudAliasViaMCP
+	}
+	if deps.resolveOrchestratorLaunch == nil {
+		deps.resolveOrchestratorLaunch = orchestratorLaunchCommand
+	}
+	return deps
+}
+
+func withDefaultRuntimeSessionDeps(deps erunUIDeps) erunUIDeps {
 	if deps.ensureMCP == nil {
 		deps.ensureMCP = func(ctx context.Context, result eruncommon.OpenResult) error {
 			return ensureMCPViaOpenCommand(ctx, deps.resolveCLIPath(), result)
@@ -271,12 +289,6 @@ func withDefaultRuntimeDeps(deps erunUIDeps) erunUIDeps {
 			return ensureSSHDViaOpenCommand(ctx, deps.resolveCLIPath(), result)
 		}
 	}
-	if deps.canConnectLocalPort == nil {
-		deps.canConnectLocalPort = canConnectLocalTCP
-	}
-	if deps.setRemoteCloudAlias == nil {
-		deps.setRemoteCloudAlias = setEnvironmentCloudAliasViaMCP
-	}
 	if deps.startTerminal == nil {
 		deps.startTerminal = startTerminalSession
 	}
@@ -285,9 +297,6 @@ func withDefaultRuntimeDeps(deps erunUIDeps) erunUIDeps {
 	}
 	if deps.launchHostArtifact == nil {
 		deps.launchHostArtifact = launchHostArtifactDetached
-	}
-	if deps.resolveOrchestratorLaunch == nil {
-		deps.resolveOrchestratorLaunch = orchestratorLaunchCommand
 	}
 	return deps
 }

--- a/erun-ui/close_environment_test.go
+++ b/erun-ui/close_environment_test.go
@@ -107,3 +107,48 @@ func TestCloseEnvironmentSessionsRejectsEmptyTarget(t *testing.T) {
 		t.Fatal("expected error when environment is empty")
 	}
 }
+
+// TestCloseEnvironmentSessionsMarksClosedSoReconnectRefuses guards the fix
+// behind the "sidebar keeps spinning after close" bug. Closing an env must
+// mark each live session closed (and release its idle-stop block) so
+// tryReconnect refuses to respawn it — which is what lets streamSession reach
+// finalizeSessionExit -> finalizeAIActivity and emit AI busy=false, clearing
+// the sidebar spinner. Before the fix CloseEnvironmentSessions closed the PTY
+// without marking closed, so the AI session reconnected the still-live pod
+// session, finalize never ran, and a continuously repainting Claude TUI (never
+// quiet for the 3s idle-clear) left the aiBusy latch — and the row — spinning
+// forever.
+func TestCloseEnvironmentSessionsMarksClosedSoReconnectRefuses(t *testing.T) {
+	app := &App{
+		sessions: make(map[string]*managedTerminal),
+		busyEnvs: make(map[string]int),
+	}
+	target := uiSelection{Tenant: "erun", Environment: "local"}
+	// respawn is non-nil so the ONLY reason tryReconnect can refuse is the
+	// closed flag the fix sets, not a nil respawn.
+	ai := &managedTerminal{
+		selection:      target,
+		session:        newStubTerminalSession(),
+		serial:         1,
+		key:            "ai",
+		kind:           sessionKindAI,
+		aiBusyEmitted:  true,
+		blocksIdleStop: true,
+		respawn:        func() (terminalSession, error) { return newStubTerminalSession(), nil },
+	}
+	app.sessions["ai"] = ai
+	app.busyEnvs[selectionKey(target)] = 1
+
+	if _, err := app.CloseEnvironmentSessions(target); err != nil {
+		t.Fatalf("CloseEnvironmentSessions returned err: %v", err)
+	}
+	if !ai.closed {
+		t.Fatal("close must mark the session closed so tryReconnect refuses it")
+	}
+	if _, ok := app.busyEnvs[selectionKey(target)]; ok {
+		t.Fatal("close must release the env's idle-stop block")
+	}
+	if app.tryReconnect(ai, "test") {
+		t.Fatal("tryReconnect must refuse a session closed by CloseEnvironmentSessions")
+	}
+}

--- a/erun-ui/frontend/src/app/closeEnvironmentThunks.ts
+++ b/erun-ui/frontend/src/app/closeEnvironmentThunks.ts
@@ -3,6 +3,7 @@ import type { UISelection } from '@/types';
 import { CloseEnvironmentSessions } from '../../wailsjs/go/main/App';
 import { readError } from './errors';
 import { showTerminalMessage } from './notificationThunks';
+import { setAIBusyForEnv } from './slices/aiActivitySlice';
 import { setSelected } from './slices/selectionSlice';
 import { clearEnvOpening } from './slices/sessionsSlice';
 import { clearSelectedSessionForEnv, clearTabsForEnv, setSessionId } from './slices/terminalSlice';
@@ -31,6 +32,11 @@ export const closeEnvironment =
     }
     const key = selectionKey({ tenant, environment });
     dispatch(clearTabsForEnv(key));
+    // Close is a definitive teardown of the desktop view; clear the AI-busy
+    // latch so the sidebar row stops spinning even if the backend's busy=false
+    // event is delayed or missed. The pod AI session keeps repainting after
+    // close, so recordAIActivity's idle clear may never fire on its own.
+    dispatch(setAIBusyForEnv({ key, busy: false }));
     dispatch(clearSelectedSessionForEnv(key));
     dispatch(clearEnvOpening({ tenant, environment }));
     const current = getState().selection.selected;

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -757,19 +757,7 @@ func (a *App) DeleteOrchestrator(id string) error {
 // uniqueOrchestratorID derives a stable, human-readable id from the name that
 // does not collide with an existing definition.
 func uniqueOrchestratorID(name string, existing []eruncommon.OrchestratorConfig) string {
-	var slug strings.Builder
-	for _, r := range strings.ToLower(strings.TrimSpace(name)) {
-		switch {
-		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
-			slug.WriteRune(r)
-		case r == ' ' || r == '-' || r == '_' || r == ',':
-			slug.WriteByte('-')
-		}
-	}
-	stem := strings.Trim(slug.String(), "-")
-	if stem == "" {
-		stem = "orchestrator"
-	}
+	stem := orchestratorIDStem(name)
 	taken := make(map[string]struct{}, len(existing))
 	for _, config := range existing {
 		taken[config.ID] = struct{}{}
@@ -781,4 +769,23 @@ func uniqueOrchestratorID(name string, existing []eruncommon.OrchestratorConfig)
 		}
 		candidate = fmt.Sprintf("%s-%d", stem, i)
 	}
+}
+
+// orchestratorIDStem slugifies name into a stable id stem, falling back to
+// "orchestrator" when the name carries no id-safe characters.
+func orchestratorIDStem(name string) string {
+	var slug strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(name)) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			slug.WriteRune(r)
+		case r == ' ' || r == '-' || r == '_' || r == ',':
+			slug.WriteByte('-')
+		}
+	}
+	stem := strings.Trim(slug.String(), "-")
+	if stem == "" {
+		return "orchestrator"
+	}
+	return stem
 }

--- a/erun-ui/orchestrator_test.go
+++ b/erun-ui/orchestrator_test.go
@@ -60,6 +60,54 @@ func TestListOrchestratorEnvCandidatesReturnsOnlyRemoteAgents(t *testing.T) {
 	}
 }
 
+// assertSingleOrchestratorStatus fails unless the app lists exactly one
+// orchestrator in wantStatus.
+func assertSingleOrchestratorStatus(t *testing.T, app *App, wantStatus string) {
+	t.Helper()
+	got := app.ListOrchestrators()
+	if len(got) != 1 || got[0].Status != wantStatus {
+		t.Fatalf("expected one %s orchestrator, got %+v", wantStatus, got)
+	}
+}
+
+// assertLoneTenant fails unless tenants is exactly [want].
+func assertLoneTenant(t *testing.T, tenants []string, want string) {
+	t.Helper()
+	if len(tenants) != 1 || tenants[0] != want {
+		t.Fatalf("expected the lone tenant %q, got %+v", want, tenants)
+	}
+}
+
+// assertSingleOrchestratorID fails unless the app lists exactly one
+// orchestrator with wantID.
+func assertSingleOrchestratorID(t *testing.T, app *App, wantID string) {
+	t.Helper()
+	listed := app.ListOrchestrators()
+	if len(listed) != 1 || listed[0].ID != wantID {
+		t.Fatalf("expected the orchestrator to persist, got %+v", listed)
+	}
+}
+
+// assertSingleTransientOrchestrator fails unless the app lists exactly one
+// transient orchestrator.
+func assertSingleTransientOrchestrator(t *testing.T, app *App) {
+	t.Helper()
+	listed := app.ListOrchestrators()
+	if len(listed) != 1 || !listed[0].Transient {
+		t.Fatalf("expected one transient investigator listed, got %+v", listed)
+	}
+}
+
+// assertCreatedFRSOrchestrator checks the shape of a freshly created
+// single-env "frs" orchestrator.
+func assertCreatedFRSOrchestrator(t *testing.T, info orchestratorInfo) {
+	t.Helper()
+	if info.Status != "stopped" || len(info.Environments) != 1 || info.Environments[0].Directory == "" {
+		t.Fatalf("unexpected created orchestrator: %+v", info)
+	}
+	assertLoneTenant(t, info.Tenants, "frs")
+}
+
 func TestCreateOrchestratorWiresSyncAndPersists(t *testing.T) {
 	app := orchestratorTestApp(t)
 	defer app.shutdown(context.Background())
@@ -75,12 +123,7 @@ func TestCreateOrchestratorWiresSyncAndPersists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateOrchestrator failed: %v", err)
 	}
-	if info.Status != "stopped" || len(info.Environments) != 1 || info.Environments[0].Directory == "" {
-		t.Fatalf("unexpected created orchestrator: %+v", info)
-	}
-	if len(info.Tenants) != 1 || info.Tenants[0] != "frs" {
-		t.Fatalf("expected tenants derived from the linked env, got %+v", info.Tenants)
-	}
+	assertCreatedFRSOrchestrator(t, info)
 
 	// The env's one-way workspace sync was wired to the mirror directory.
 	env, _, err := app.deps.store.LoadEnvConfig("frs", "dev")
@@ -96,10 +139,7 @@ func TestCreateOrchestratorWiresSyncAndPersists(t *testing.T) {
 		t.Fatalf("expected the mirror directory to be created: %v", statErr)
 	}
 	// Persisted.
-	listed := app.ListOrchestrators()
-	if len(listed) != 1 || listed[0].ID != info.ID {
-		t.Fatalf("expected the orchestrator to persist, got %+v", listed)
-	}
+	assertSingleOrchestratorID(t, app, info.ID)
 }
 
 func TestRestartOrchestratorRespawnsWithFreshSession(t *testing.T) {
@@ -205,15 +245,11 @@ func TestUpdateOrchestratorRelinksEnvironments(t *testing.T) {
 	if _, err := app.StartOrchestrator(created.ID, 80, 24); err != nil {
 		t.Fatalf("StartOrchestrator failed: %v", err)
 	}
-	if got := app.ListOrchestrators(); len(got) != 1 || got[0].Status != "running" {
-		t.Fatalf("expected one running orchestrator, got %+v", got)
-	}
+	assertSingleOrchestratorStatus(t, app, "running")
 	if err := app.StopOrchestrator(created.ID); err != nil {
 		t.Fatalf("StopOrchestrator failed: %v", err)
 	}
-	if got := app.ListOrchestrators(); len(got) != 1 || got[0].Status != "stopped" {
-		t.Fatalf("expected the definition to survive a stop, got %+v", got)
-	}
+	assertSingleOrchestratorStatus(t, app, "stopped")
 	if err := app.DeleteOrchestrator(created.ID); err != nil {
 		t.Fatalf("DeleteOrchestrator failed: %v", err)
 	}
@@ -246,9 +282,7 @@ func TestInvestigateFailureSpawnsTransientTenantScopedOrchestrator(t *testing.T)
 	if !info.Transient {
 		t.Fatalf("expected a transient investigator, got %+v", info)
 	}
-	if len(info.Tenants) != 1 || info.Tenants[0] != "frs" {
-		t.Fatalf("expected the investigator grouped under the failed env's tenant, got %+v", info.Tenants)
-	}
+	assertLoneTenant(t, info.Tenants, "frs")
 	if !strings.Contains(seededPrompt, "erun-investigate") || !strings.Contains(seededPrompt, "erun-file-issue") {
 		t.Fatalf("unexpected seed prompt: %q", seededPrompt)
 	}
@@ -264,9 +298,7 @@ func TestInvestigateFailureSpawnsTransientTenantScopedOrchestrator(t *testing.T)
 	if !strings.Contains(string(data), "helm timeout") {
 		t.Fatalf("staged report missing the failure detail: %q", data)
 	}
-	if listed := app.ListOrchestrators(); len(listed) != 1 || !listed[0].Transient {
-		t.Fatalf("expected one transient investigator listed, got %+v", listed)
-	}
+	assertSingleTransientOrchestrator(t, app)
 }
 
 func TestOrchestratorWorkspaceIsSharedRootWithOneClaudeMd(t *testing.T) {

--- a/erun-ui/playwright/tests/sidebar-ai-activity.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-ai-activity.spec.ts
@@ -84,4 +84,39 @@ test.describe('sidebar AI activity spinner', () => {
     });
     await expect(sidebar.getByRole('status')).toHaveCount(0);
   });
+
+  test('closing an env clears a latched AI-activity spinner', async ({ app, page, seededEnv }) => {
+    const { tenant, environment } = seededEnv;
+    const sidebar = page.locator('aside').first();
+    const envSpinner = sidebar.getByRole('status', {
+      name: new RegExp(`${tenant} / ${environment}`),
+    });
+
+    // Open the env so it has live tabs and the close dot mounts.
+    await app.sidebar.openEnvironment(tenant, environment);
+    const closeDot = sidebar.getByRole('button', { name: `Close ${tenant} / ${environment}` });
+    await expect(closeDot).toBeVisible();
+    await expect(envSpinner).toHaveCount(0);
+
+    // A real Claude TUI repaints continuously, so the Go idle-clear never fires
+    // and the ai-activity latch stays on; emulate that stuck busy=true.
+    await page.evaluate(
+      ({ tenant, environment }) => {
+        const runtime = (
+          window as unknown as {
+            runtime: { EventsEmit: (n: string, ...a: unknown[]) => void };
+          }
+        ).runtime;
+        runtime.EventsEmit('ai-activity', { sessionId: 99, tenant, environment, busy: true });
+      },
+      { tenant, environment },
+    );
+    await expect(envSpinner).toBeVisible();
+
+    // Closing the env must clear the busy latch. Before the fix the spinner
+    // stayed forever (green dot gone, row still spinning) because close never
+    // finalized the AI session, so busy=false was never emitted.
+    await closeDot.click();
+    await expect(envSpinner).toHaveCount(0);
+  });
 });

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -950,11 +950,24 @@ func (a *App) CloseEnvironmentSessions(selection uiSelection) ([]int, error) {
 	if selection.Tenant == "" || selection.Environment == "" {
 		return nil, fmt.Errorf("tenant and environment are required")
 	}
-	targets := a.collectLiveSessionsForSelection(selection)
+	targets := a.collectAndMarkClosedForSelection(selection)
+	// Close is a real teardown: stop the env's workspace-sync worker so a
+	// closed env stops mirroring its worktree. Startup starts one sync worker
+	// per configured env, so without this a closed env keeps an rsync-over-ssh
+	// poller running; reopening the env restarts it.
+	a.stopWorkspaceSyncForSelection(selection)
 	return closeManagedTerminals(targets)
 }
 
-func (a *App) collectLiveSessionsForSelection(selection uiSelection) []*managedTerminal {
+// collectAndMarkClosedForSelection gathers the env's live sessions and marks
+// each closed under a.mu BEFORE the caller shuts their PTYs down. Marking
+// closed here is what makes "close env" a genuine teardown rather than a
+// reconnect: tryReconnect and the spawn-reuse branch both refuse a closed
+// session, so streamSession reaches finalizeSessionExit — which emits the
+// terminal-exit and the AI-activity busy=false that clears the sidebar
+// spinner — instead of reconnecting the still-live pod session and leaving the
+// row spinning forever. Mirrors EndAISessions' mark-closed-under-lock.
+func (a *App) collectAndMarkClosedForSelection(selection uiSelection) []*managedTerminal {
 	var targets []*managedTerminal
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -968,6 +981,8 @@ func (a *App) collectLiveSessionsForSelection(selection uiSelection) []*managedT
 		if managed.selection.Environment != selection.Environment {
 			continue
 		}
+		managed.closed = true
+		a.releaseIdleBlockLocked(managed)
 		targets = append(targets, managed)
 	}
 	return targets

--- a/erun-ui/workspace_sync.go
+++ b/erun-ui/workspace_sync.go
@@ -274,12 +274,21 @@ func workspaceSyncLocalPath(result eruncommon.OpenResult, findProjectRoot erunco
 	return ""
 }
 
-func syncWorkspaceOnce(ctx context.Context, params workspaceSyncParams) (workspaceSyncResult, error) {
+// validateWorkspaceSyncParams trims the params in place and rejects a sync that
+// is missing the host alias, remote path, or local path.
+func validateWorkspaceSyncParams(params *workspaceSyncParams) error {
 	params.HostAlias = strings.TrimSpace(params.HostAlias)
 	params.RemotePath = strings.TrimSpace(params.RemotePath)
 	params.LocalPath = strings.TrimSpace(params.LocalPath)
 	if params.HostAlias == "" || params.RemotePath == "" || params.LocalPath == "" {
-		return workspaceSyncResult{}, fmt.Errorf("host alias, remote path, and local path are required")
+		return fmt.Errorf("host alias, remote path, and local path are required")
+	}
+	return nil
+}
+
+func syncWorkspaceOnce(ctx context.Context, params workspaceSyncParams) (workspaceSyncResult, error) {
+	if err := validateWorkspaceSyncParams(&params); err != nil {
+		return workspaceSyncResult{}, err
 	}
 	if err := ensureLocalWorkspaceSyncTarget(params.LocalPath); err != nil {
 		return workspaceSyncResult{}, err


### PR DESCRIPTION
Closing an environment left its sidebar row's busy spinner (↻) turning forever — green "open" dot gone, but the row still spinning.

## Root cause

The sidebar row spinner is `busy = isOpening || runningCommand || aiBusy || reconnecting`. The stuck flag is **`aiBusy`** (`aiActivity.aiBusyByEnv`), a Go-driven latch (`recordAIActivity`/`finalizeAIActivity`): busy=true after ~5s of sustained AI output, busy=false only after 3s of silence **or on session finalize**.

- **Close never finalized the session.** `CloseEnvironmentSessions` → `closeManagedTerminals` called `managed.session.Close()` **without** setting `managed.closed=true`, so when the PTY read returned, `streamSession` *reconnected* the still-live pod session (via `tryReconnect`, which only bails when `closed`) instead of reaching `finalizeSessionExit` → `finalizeAIActivity` — the only `busy=false` emit.
- **Claude repaints continuously.** The bundled Claude (`claude-real --remote-control`) idle-repaints (~2 KB/s, even detached), so output never has a 3s gap and the idle-clear never fires on its own.

Net: tabs cleared (green dot gone) but `aiBusy` stuck true → the row spins forever after close.

## Fix

- `erun-ui/terminal_sessions.go`: on close, mark each session `closed=true` (and release its idle-stop block) under `a.mu` **before** shutting its PTY — mirroring `EndAISessions` — so `tryReconnect` refuses the respawn and the session finalizes, emitting `busy=false`. Also stop the env's workspace-sync worker on close.
- `erun-ui/frontend/src/app/closeEnvironmentThunks.ts`: dispatch `setAIBusyForEnv({key, busy:false})` on close (immediate clear / defense-in-depth).
- Regression tests: `close_environment_test.go` (close marks sessions closed → `tryReconnect` refuses) and `sidebar-ai-activity.spec.ts` (busy=true → close → spinner clears).
- Also cleared **7 pre-existing erun-ui golangci-lint findings** surfaced by touching the module (dead `App.nextOrchestrator` field + cyclop/gocyclo refactors of `withDefaultRuntimeDeps`, `uniqueOrchestratorID`, `syncWorkspaceOnce`, and three orchestrator tests). erun-ui's Go lint is not part of the release gate, so these had drifted onto `main`.

## Known follow-up (not in this PR)

While a Claude AI tab is **open**, `aiBusy` stays latched because Claude's continuous idle repaint defeats the 3s idle-clear — so the "AI working" spinner is effectively always-on for open Claude tabs. Fixing that needs `recordAIActivity` to distinguish idle-repaint from real work (volume/content heuristic, or Claude's `--remote-control` busy state).

## Validation

`go test ./...` ✓, `golangci-lint run ./...` **0 issues** ✓, frontend `yarn typecheck && yarn lint && yarn format:check && yarn build` ✓. Full Playwright suite runs 128–129/131 green; the 2–3 non-passes are pre-existing load/timing flakes (a *different* set each run, zero overlap — every spec passes on some run). One of them, `terminal-scroll-on-resize` (#465), is unrelated to this change (touches no scroll/resize code) and is tracked separately in #867.

## UX Impact Review Checklist

1. **Affected paths:** Sidebar env "close" dot → `closeEnvironment` thunk → `CloseEnvironmentSessions` (Go) → session finalize / `ai-activity busy=false`.
2. **User-visible sequence:** user clicks the env's open/close dot → the env's tabs close and the green dot disappears → the row's busy spinner clears (previously it kept spinning).
3. **State-without-affordance:** `closeEnvironment` now dispatches `setAIBusyForEnv(busy:false)`; the visible consequence is the spinner disappearing. No state mutated without a rendered result.
4. **Visibility of system status (Nielsen #1):** the spinner now truthfully reflects "no AI work on a closed env" — a closed env must never imply in-flight work.
5. **Success/failure feedback (Nielsen #1, #9):** close is immediate and the row returns to idle; no new failure surface introduced.
6. **Consistency (Nielsen #4):** matches the existing `EndAISessions` close-and-finalize pattern (mark-closed-under-lock so `tryReconnect` refuses).
7. **Heuristic pass:** the change removes a false, non-dismissable status indicator; all other heuristics unaffected (no new controls, labels, or flows).
8. **Playwright coverage:** `sidebar-ai-activity.spec.ts` → new test "closing an env clears a latched AI-activity spinner" (emits `ai-activity` busy=true, closes via the open dot, asserts the spinner clears). Backend branch coverage: `close_environment_test.go`.

Closes #866
