### PR TITLE
Remove all dead code across the repo (9 unreachable functions)

### DIFF
--- a/erun-backend/erun-backend-api/internal/repository/permissions.go
+++ b/erun-backend/erun-backend-api/internal/repository/permissions.go
@@ -13,10 +13,6 @@ type PermissionAuthorizer struct {
 	txs *TxManager
 }
 
-func NewPermissionAuthorizer(db *sql.DB) *PermissionAuthorizer {
-	return NewPermissionAuthorizerForDialect(db, DialectPostgres)
-}
-
 func NewPermissionAuthorizerForDialect(db *sql.DB, dialect Dialect) *PermissionAuthorizer {
 	return &PermissionAuthorizer{txs: NewTxManager(db, dialect)}
 }

--- a/erun-common/build_spec.go
+++ b/erun-common/build_spec.go
@@ -93,53 +93,6 @@ func parseDockerImageReference(image string) (registry, imageName, version strin
 	return registry, imageName, version, true
 }
 
-func ResolveDockerBuildForImageReference(ctx Context, store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, projectRoot, environment, image string) (DockerBuildSpec, bool, error) {
-	image = strings.TrimSpace(image)
-	registry, imageName, version, ok := parseDockerImageReference(image)
-	if !ok {
-		return DockerBuildSpec{}, false, nil
-	}
-
-	if registry == "" {
-		resolved, err := resolveDockerBuildRegistryForEnvironment(ctx, projectRoot, environment)
-		if err != nil {
-			return DockerBuildSpec{}, false, err
-		}
-		registry = resolved
-	}
-
-	buildContext, ok, err := FindComponentDockerBuildContext(projectRoot, imageName)
-	if err != nil || !ok {
-		return DockerBuildSpec{}, false, err
-	}
-
-	tag := image
-	if !strings.Contains(image, "/") {
-		tag = fmt.Sprintf("%s/%s:%s", strings.TrimRight(registry, "/"), imageName, version)
-	}
-
-	imageRef := DockerImageReference{
-		ProjectRoot: projectRoot,
-		Environment: strings.TrimSpace(environment),
-		Registry:    registry,
-		ImageName:   imageName,
-		Version:     version,
-		Tag:         tag,
-	}
-
-	contextDir, err := ResolveDockerBuildContextDirForProject(buildContext.Dir, projectRoot)
-	if err != nil {
-		return DockerBuildSpec{}, false, err
-	}
-
-	return DockerBuildSpec{
-		ContextDir:     contextDir,
-		DockerfilePath: buildContext.DockerfilePath,
-		Image:          imageRef,
-		Platforms:      slices.Clone(multiPlatformDockerBuilds),
-	}, true, nil
-}
-
 func resolveDockerBuildSpec(ctx Context, store DockerStore, findProjectRoot ProjectFinderFunc, resolveBuildContext BuildContextResolverFunc, now NowFunc, buildContext DockerBuildContext, target DockerCommandTarget) (DockerBuildSpec, error) {
 	projectRoot, err := resolveDockerBuildProjectRoot(findProjectRoot, target)
 	if err != nil {

--- a/erun-common/contribute.go
+++ b/erun-common/contribute.go
@@ -35,16 +35,6 @@ func ContributeShimPath(homeDir string) (string, error) {
 	return filepath.Join(resolved, ".erun", "contribute", "bin", "erun"), nil
 }
 
-// ContributeShimDir returns the directory holding the `erun` shim that
-// contribute tabs prepend to PATH.
-func ContributeShimDir(homeDir string) (string, error) {
-	shim, err := ContributeShimPath(homeDir)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Dir(shim), nil
-}
-
 // ContributeRunScriptPath returns the path to erun-cli/run.sh inside the
 // contribute clone, which the shim forwards to.
 func ContributeRunScriptPath(homeDir string) (string, error) {

--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -212,22 +212,6 @@ type bootstrapRunState struct {
 	envConfigChanged      bool
 }
 
-func RunBootstrapInit(ctx Context, params BootstrapInitParams, store BootstrapStore, findProjectRoot ProjectFinderFunc, getWorkingDir WorkDirFunc, selectTenant SelectTenantFunc, confirm ConfirmFunc, promptKubernetesContext PromptValueFunc, promptContainerRegistry PromptValueFunc, ensureKubernetesNamespace NamespaceEnsurerFunc, loadProjectConfig ProjectConfigLoaderFunc, saveProjectConfig ProjectConfigSaverFunc) (BootstrapInitResult, error) {
-	return RunBootstrapInitWithDependencies(BootstrapInitDependencies{
-		Store:                     store,
-		FindProjectRoot:           findProjectRoot,
-		GetWorkingDir:             getWorkingDir,
-		SelectTenant:              selectTenant,
-		Confirm:                   confirm,
-		PromptKubernetesContext:   promptKubernetesContext,
-		PromptContainerRegistry:   promptContainerRegistry,
-		EnsureKubernetesNamespace: ensureKubernetesNamespace,
-		LoadProjectConfig:         loadProjectConfig,
-		SaveProjectConfig:         saveProjectConfig,
-		Context:                   ctx,
-	}, params)
-}
-
 func RunBootstrapInitWithDependencies(deps BootstrapInitDependencies, params BootstrapInitParams) (BootstrapInitResult, error) {
 	return bootstrapRunner{
 		BootstrapInitDependencies: deps,

--- a/erun-common/ports.go
+++ b/erun-common/ports.go
@@ -48,10 +48,6 @@ func (e ErrLocalPortRangeOverlap) Error() string {
 	return fmt.Sprintf("local port range start %d is claimed by both %s and %s; edit localportrangestart in one of the env configs to resolve", e.RangeStart, e.A, e.B)
 }
 
-func ServicePort(offset int) int {
-	return LowerServicePort + offset
-}
-
 // EnvironmentLocalPortsFromRangeStart derives the per-service ports from a
 // persisted range start.
 func EnvironmentLocalPortsFromRangeStart(rangeStart int) EnvironmentLocalPorts {

--- a/erun-common/registry_versions.go
+++ b/erun-common/registry_versions.go
@@ -192,10 +192,6 @@ func ghcrOwnerFromNamespace(namespace string) (string, bool) {
 	return rest, true
 }
 
-func ResolveDockerHubRuntimeRegistryVersions(ctx context.Context, client *http.Client, namespace, repository string) (RuntimeRegistryVersions, error) {
-	return resolveDockerHubRuntimeRegistryVersionsAt(ctx, client, namespace, repository, defaultDockerHubRegistryBaseURL)
-}
-
 func resolveDockerHubRuntimeRegistryVersionsAt(ctx context.Context, client *http.Client, namespace, repository, baseURL string) (RuntimeRegistryVersions, error) {
 	namespace = strings.TrimSpace(namespace)
 	repository = strings.TrimSpace(repository)
@@ -228,10 +224,6 @@ func resolveDockerHubRuntimeRegistryVersionsAt(ctx context.Context, client *http
 	versions := latestRuntimeVersionsFromTags(tags)
 	versions.Image = namespace + "/" + repository
 	return versions, nil
-}
-
-func ResolveGHCRRuntimeRegistryVersions(ctx context.Context, client *http.Client, owner, repository string) (RuntimeRegistryVersions, error) {
-	return resolveGHCRRuntimeRegistryVersionsAt(ctx, client, owner, repository, defaultGHCRRegistryBaseURL, defaultGHCRRegistryBaseURL)
 }
 
 func resolveGHCRRuntimeRegistryVersionsAt(ctx context.Context, client *http.Client, owner, repository, baseURL, tokenURL string) (RuntimeRegistryVersions, error) {

--- a/erun-common/runtime_resources.go
+++ b/erun-common/runtime_resources.go
@@ -102,10 +102,3 @@ func FormatKubernetesCPUFromMilli(milli int64) string {
 	}
 	return strconv.FormatFloat(float64(milli)/1000.0, 'f', -1, 64)
 }
-
-func FormatKubernetesMemoryFromMi(mi int64) string {
-	if mi <= 0 {
-		return ""
-	}
-	return strconv.FormatInt(mi, 10) + "Mi"
-}

--- a/erun-common/upgrade.go
+++ b/erun-common/upgrade.go
@@ -12,13 +12,6 @@ import (
 // without a registry. Not a production knob.
 const UpgradeVersionsOverrideEnv = "ERUN_UPGRADE_VERSIONS_OVERRIDE"
 
-// RuntimeVersionsOverrideFromEnv reads the test-seam versions; ok is false when
-// the seam is unset.
-func RuntimeVersionsOverrideFromEnv() (RuntimeRegistryVersions, bool) {
-	versions, _, ok := runtimeVersionsOverrideFromEnvWithError()
-	return versions, ok
-}
-
 func runtimeVersionsOverrideFromEnvWithError() (RuntimeRegistryVersions, string, bool) {
 	raw := strings.TrimSpace(os.Getenv(UpgradeVersionsOverrideEnv))
 	if raw == "" {


### PR DESCRIPTION
## What

Removes **9 dead functions** — every function that whole-program reachability analysis flags as unreachable across the entire repo. Most are **exported** symbols the `unused` linter is blind to (it only checks unexported); three more hid behind names that still match live text (a struct field, doc comments).

No behavior changes: no CLI output, no goldens, no API surface anything actually calls.

## Scope: the whole repo, not just erun-common

I swept all seven Go modules with `go run golang.org/x/tools/cmd/deadcode -test` (whole-program reachability) plus `golangci-lint --default=none -E unused` (for unexported types/vars/consts the func analysis doesn't cover):

| Module | Real dead funcs | Removed |
|--------|----------------:|:-------:|
| erun-common | 8 | ✅ |
| erun-backend-api (`eapi`) | 1 | ✅ |
| erun-cli (internal pkgs) | 0 | — |
| erun-mcp (internal pkgs) | 0 | — |
| erun-ui (internal pkgs) | 0 * | — |
| erun-devops/dns01-webhook | 0 | — |
| erun-integration | 0 | — |

\* erun-ui's 14 deadcode hits are all in vendored `node_modules/flatted/golang` (a third-party lib), not our code.

`unused` is clean in every module too — no orphaned unexported symbols left behind.

## How the erun-common set was found

`erun-common` is a shared library consumed by three mains — `erun` (CLI), `erun-app` (UI/Wails), `emcp` (MCP). A function there is dead only if unreachable from **all three**. I ran `deadcode` (filtered to `erun-common`) from each main and took the **intersection**:

| main | erun-common funcs unreachable |
|------|------------------------------:|
| erun (CLI) | 63 |
| emcp (MCP) | 240 |
| erun-app (UI) | 987 |
| **∩ (dead everywhere)** | **8** |

### erun-common — dead exports (commit 1)
`FormatKubernetesMemoryFromMi`, `ResolveDockerBuildForImageReference`, `ResolveDockerHubRuntimeRegistryVersions`, `ResolveGHCRRuntimeRegistryVersions`, `RunBootstrapInit`

### erun-common — transitively/precisely dead (commit 2)
- `ContributeShimDir` — only its own doc comment mentions the name
- `ServicePort` — the live `ServicePort` references are the **struct field** in `expose.go`, a different symbol from this free function
- `RuntimeVersionsOverrideFromEnv` — no call anywhere, tests included

### erun-backend-api (commit 3)
- `NewPermissionAuthorizer` — a Postgres-default convenience wrapper around `NewPermissionAuthorizerForDialect`; every caller (prod + tests) uses the dialect-explicit form, and the package is `internal/` so nothing outside the module can reach it.

## Verification

- `deadcode` intersection across all three mains is now **empty**; per-module sweeps show no remaining dead funcs
- `go build ./...` clean in **every** module
- `go test ./...` clean in erun-common and erun-backend-api
- `golangci-lint --default=none -E unused ./...` clean in every module
- All removals are **uncovered** (dead) code, so the integration coverage gate can only hold or rise — re-running it clean as the final check

🤖 Generated with [Claude Code](https://claude.com/claude-code)