### PR TITLE
Refresh orchestrator skills on host and auto-load erun-orchestrate on session start/resume

### DIFF
--- a/erun-docs/docs/agent-reference/skills-spec.md
+++ b/erun-docs/docs/agent-reference/skills-spec.md
@@ -85,9 +85,13 @@ The runtime Dockerfile vendors the whole tree with one line:
 COPY --chmod=0644 erun-skills/skills /etc/erun/skills
 ```
 
-On every entrypoint run, `initialize_claude_config` and `initialize_codex_config` iterate every subdirectory under `/etc/erun/skills/` and install each skill into `~/.claude/skills/<name>/` and `~/.codex/skills/<name>/` — but only when the destination `SKILL.md` is absent. Supporting files (templates, helper scripts) inside the skill directory ship with the skill automatically.
+On every entrypoint run, `initialize_claude_config` and `initialize_codex_config` run `skills-install.sh` over every subdirectory under `/etc/erun/skills/`, installing each skill into `~/.claude/skills/<name>/` and `~/.codex/skills/<name>/`. Supporting files (templates, helper scripts) inside the skill directory ship with the skill automatically.
 
-The `[ ! -e ]` guard means a user can edit `~/.claude/skills/<name>/SKILL.md` inside a running env and the edit survives pod restarts. Only a fresh home (or a new skill name) re-pulls the baked copy.
+The install both **installs a skill when absent and refreshes it when the baked copy changed**, so a rebuilt image's updated skill reaches existing envs — while **preserving in-pod edits**. Provenance is tracked per skill by recording the baked `SKILL.md` hash in a `.erun-skill-baked-sha256` marker: a copy whose `SKILL.md` still matches its marker is unmodified since erun installed it and is refreshed to the baked version, while one that differs was edited in-pod and is left untouched (a legacy copy with no marker is treated as unmodified and adopted on the first refresh). So an un-edited skill tracks the image across upgrades, and a skill you edit inside a running env survives both pod restarts and image rebuilds.
+
+### Host orchestrator (desktop)
+
+The desktop app installs the same canonical skills into the host's `~/.claude/skills/<name>/` for host-side orchestrator sessions, using the identical marker-based install-or-refresh — so a host orchestrator tracks the latest skill on each launch while preserving any host-side edits. It also writes a `SessionStart` hook into the shared orchestrators workspace's `.claude/settings.json` that loads the [`erun-orchestrate`](#erun-orchestrate) skill on every session start and reopen (Claude Code's `SessionStart` fires on both a new session and a `--continue`/`--resume`), so an orchestrator always operates under its current contract without having to invoke the skill by hand.
 
 ### Laptop (plugin marketplace)
 
@@ -361,8 +365,8 @@ Key contract: the skill **explicitly reads** the cloned repo's `AGENTS.md` and e
 | Source | `erun-skills/skills/erun-orchestrate/SKILL.md` |
 | Description | "Operate as a host-side erun orchestrator that drives and reviews work across remote-agent environments without editing their code locally." |
 | Triggers | "orchestrate erun environments", "drive the remote agents", "coordinate work across environments", "review what the agents changed", "review changes across envs", "run the built app to verify", "delegate this to the environment's agent" |
-| Inputs | The remote-agent environments in scope (via `erun list`) and each one's host mirror directory (the workspace-sync local path the operator mapped it to). |
-| Outputs | No files. The orchestrator delegates edits to the in-pod agents, reviews each env's synced mirror read-only (reading the synced files — the mirror is a plain one-way copy that needs no local git, so the authoritative diff is viewed from the pod), and runs host-native build artifacts (e.g. a cross-built `.exe` under the mirror's `.erun-outputs/`) to verify. Platform bugs are filed via `erun-file-issue`. |
+| Inputs | The orchestrator's own configuration — its `ERUN_ORCHESTRATOR_ID` and the `orchestrators:` entry in erun's config store listing its linked `tenant/environment/directory` mirrors (authoritative for scope; `erun list` only enumerates what exists) — plus, per linked env, the pod-side `localrepopath` where its agent edits and the host mirror directory (the workspace-sync local path). |
+| Outputs | No files. The orchestrator develops changes in the environment's pod (never on the host), delegating edits to the in-pod agents; reviews each env's synced mirror read-only (reading the synced files — the mirror is a plain one-way copy that needs no local git, so the authoritative diff is viewed from the pod); and to run an executable on the host has the in-pod agent cross-build it for the host arch into the mirror's `.erun-outputs/`, then runs it to verify. Platform bugs are filed via `erun-file-issue`. |
 | Error behaviour | Editing the host mirror is a no-op (the next sync overwrites it) — the skill directs all changes through the pod agent instead. A missing host mirror (workspace sync not enabled for an env) → review is unavailable for that env until sync is enabled. Destructive cross-env actions (deploy, delete) require explicit confirmation. |
 
 ### Catalogue evolution

--- a/erun-docs/docs/concepts/skills.md
+++ b/erun-docs/docs/concepts/skills.md
@@ -27,7 +27,7 @@ ERun ships skills through two paths, both vendored from the same canonical sourc
 
 ### Inside a deployed env
 
-The runtime image bakes the skill set, and the env's entrypoint installs each one into the Agent's discovery directory (`~/.claude/skills/<name>/` for Claude Code, `~/.codex/skills/<name>/` for Codex). The Operator doesn't install or wire anything — opening an env makes the skills available to whatever's running inside. Edits made to a skill file inside a running env survive pod restarts; only a fresh home (or a new skill name) re-pulls the baked copy.
+The runtime image bakes the skill set, and the env's entrypoint installs each one into the Agent's discovery directory (`~/.claude/skills/<name>/` for Claude Code, `~/.codex/skills/<name>/` for Codex). The Operator doesn't install or wire anything — opening an env makes the skills available to whatever's running inside. An un-edited skill is refreshed from the image when it changes, so envs track skill improvements across upgrades; edits made to a skill file inside a running env are preserved across pod restarts and rebuilds.
 
 ### On your laptop
 

--- a/erun-skills/skills/erun-orchestrate/SKILL.md
+++ b/erun-skills/skills/erun-orchestrate/SKILL.md
@@ -13,15 +13,37 @@ You are a **host-side orchestrator**: an AI running on the operator's machine th
 - To change code, **ask the in-pod agent** in the relevant environment to do it — never patch the host mirror.
 - You verify results two ways the pod cannot: **review the synced diff** on the host, and **run host-native build artifacts** (e.g. a Windows `.exe` cross-built in the Linux pod) on this machine.
 
+## Know your configuration
+
+Before doing anything, know **which orchestrator you are and what you actually control** — read it from erun's config, never infer it from what happens to be on disk.
+
+- **Your identity** is the `ERUN_ORCHESTRATOR_ID` environment variable (e.g. `petios1`).
+- **Your linked environments and their host mirrors** are defined authoritatively in erun's config store: `ERunConfigDir()/config.yaml` — on Windows `%LOCALAPPDATA%\ERun\config.yaml` (Linux `~/.config/ERun/config.yaml`, macOS `~/Library/Application Support/ERun/config.yaml`). Under `orchestrators:`, find the entry whose `id` matches `ERUN_ORCHESTRATOR_ID`; each `environments:` item gives the `tenant`, the `environment`, and the `directory` — the host mirror you review it in. The desktop's **Edit orchestrator** dialog shows and edits this same list.
+
+  ```yaml
+  orchestrators:
+    - id: petios1
+      environments:
+        - tenant: erun
+          environment: main
+          directory: C:\Users\...\orchestrators\erun-main
+        - tenant: petios
+          environment: rihards-win-develop
+          directory: C:\Users\...\orchestrators\petios-rihards-win-develop
+  ```
+
+- This list is the **source of truth for scope** — reconcile against it. Do **not** decide what you control from which mirror directories have files: a populated directory may belong to a *different* orchestrator's link (out of your scope), and an environment you *do* own may have an **empty** mirror simply because its first sync hasn't landed. Linked-but-empty means "sync hasn't arrived yet", not "not mine".
+- **Per-environment detail** lives at `ERunConfigDir()/<tenant>/<environment>/config.yaml`: `type` (`remote-agent`), **`localrepopath`** — the path *inside the pod* where that env's agent edits code (e.g. `/home/erun/git/petios`), `runtimeversion` (the erun release the env runs), and `sshd.workspacesync.localpath` (the host mirror, identical to `directory` above). `localrepopath` is where you point the in-pod agent; the mirror is only your read-only window onto it.
+
 ## Workflow
 
-1. **Enumerate.** `erun list` — find the remote-agent environments in scope. For each, note its tenant and its host sync directory (the operator maps each env to a directory; the synced mirror is where you review it).
+1. **Know your scope.** Read your configuration (see *Know your configuration*): your `ERUN_ORCHESTRATOR_ID` and the `orchestrators:` entry listing your linked `tenant/environment/directory` mirrors. `erun list` enumerates the environments that *exist*; your orchestrator config says which of them are *yours*. For each of yours, note the tenant, the host mirror directory (your read-only review window), and the pod-side `localrepopath` (where its agent works).
 
-2. **Delegate work to the in-pod agent.** Give the environment's agent a concrete task through erun — drive its in-pod agent session / MCP, or ask the operator to relay it. Keep the instruction specific ("implement X in package Y, run the tests") and let the pod agent do the editing and building. Do not edit the host mirror to "help".
+2. **Develop in the environment, never on the host.** All code changes are authored *in the environment's pod*, at its `localrepopath`, by that environment's in-pod agent — drive its agent session / MCP through erun. The host machine is for orchestration, review, and running host artifacts only; it is **never** where you edit code. That means not in a mirror (the next sync overwrites it) **and not in any host checkout of the same repo** (e.g. `~/git/sophium/erun`) — a host-side edit never reaches the pod that builds and runs the code, so it silently does nothing. Give the in-pod agent a specific task ("implement X in package Y under `localrepopath`, run the tests") and let it do the editing and building. This holds even for changes to **erun the platform itself**: author them in the `erun/main` environment's pod, not the local erun checkout. (The sole build-on-host exception is compiling the `erun-app` desktop binary — see *Rebuilding and restarting erun itself* — and even then the *code* is authored in the pod.)
 
 3. **Review on the host, read-only.** The sync directory is a one-way, read-only copy of the pod's working tree — a plain directory that needs no local git. Read the synced files to assess the change. For the authoritative diff of the agent's *uncommitted* work, view it from the pod (the environment's Review in the desktop app, or ask the in-pod agent to run `git diff`) — the git history lives in the pod, not the mirror. If you keep the mirror as your own git checkout, `git -C <env-host-dir> --no-pager diff` still works, but sync neither requires nor maintains it. If the change is wrong, go back to step 2 with feedback — don't fix it locally.
 
-4. **Verify by running artifacts on the host.** A binary the pod cross-built for this host (e.g. `erun-app.exe`) lands under the sync dir's read-only `.erun-outputs/`. Run or debug it on this machine to confirm it actually works — the pod can't execute a foreign-OS binary. (In the desktop app, use **Run on host** on the environment's Outputs, or launch the artifact directly.)
+4. **To run an executable on the host, have the environment cross-build it for the host's architecture.** The pod is Linux, so a binary it builds natively is `linux/amd64` and **will not run on this host**. When you need to *run* an executable to verify it, instruct the in-pod agent to **cross-compile it for the host target** — this host's OS/arch as `erun` reports it (`DetectHost()`, e.g. `windows/amd64`; for Go that is `GOOS=windows GOARCH=amd64`) — and write it into the pod's agent outputs dir (`/home/erun/.erun/outputs`). Be explicit about the target: the pod can't see the host, so it defaults to its own `linux/amd64` unless you tell it the host's OS/arch. Workspace-sync mirrors that outputs dir to the host under the sync dir's read-only `.erun-outputs/`. Then run or debug the artifact on this machine — desktop **Run on host** on the environment's Outputs, or launch it directly — and confirm the real flow succeeds. The pod can't execute a foreign-OS binary, so this host-run is the only true end-to-end check.
 
 5. **Iterate across environments.** You are cross-env: repeat per environment you own, keeping each one's review scoped to its own host directory. Multi-tenant / multi-directory orchestrators review each mapped directory independently.
 
@@ -35,6 +57,8 @@ You are a **host-side orchestrator**: an AI running on the operator's machine th
 ## Rebuilding and restarting erun itself (developing the platform)
 
 When the change under test is to **erun itself** — the `erun`/`emcp` CLI or the `erun-app` desktop — roll it into the live tooling and verify it end-to-end; don't stop at "it builds". You run *inside* `erun-app`, so restarting it ends your own session — but the desktop persists which orchestrator to reopen and resumes its Claude conversation with `claude --continue`, so you land back here mid-task and carry on.
+
+> **Why this is a host build (the one exception to step 4).** `erun-app` is a Wails **Windows GUI** — it needs the host's CGO/MinGW + WebView2 + Node/Yarn frontend toolchain, which the Linux `erun-devops` pod image deliberately does not carry, so the pod *cannot* cross-build it. It is therefore the single host-runnable artifact compiled **on the host** (per the `erun-windows-dev` skill) rather than cross-built in the environment. This is the exception, not the rule: every *other* host executable follows step 4 (cross-built in the environment into `.erun-outputs/`). The erun *code* is still authored in the `erun/main` pod; only the final Windows compile of the desktop happens here.
 
 **No rebuild — just restart.** The ERUN header's **Restart app & return here** relaunches the desktop and reopens this orchestrator; the per-row **Restart** (↻) control recycles a single orchestrator's session (its conversation resumes). Use these when the running binary is already the one you want.
 
@@ -64,6 +88,8 @@ Hand-patching to make erun behave — `kubectl apply`/`patch` of RBAC or Deploym
 
 ## Guardrails
 
-- **Never edit files in the host mirror directories.** They are read-only review copies; edits are lost and mislead you into thinking work is done. All code changes go through the pod agent.
+- **Know your scope from config, not disk.** What you control is the `orchestrators:` entry for your `ERUN_ORCHESTRATOR_ID` in `ERunConfigDir()/config.yaml` — not whichever mirror directories happen to have files. A populated mirror can belong to another orchestrator; an empty one can be yours awaiting first sync.
+- **Never edit code on the host — develop in the pod.** All code changes go through the in-pod agent at the environment's `localrepopath`. Do not edit the host mirror directories (read-only review copies; edits are lost and mislead you into thinking work is done) and do not edit any host checkout of the same repo (the edit never reaches the pod that builds and runs the code). The lone build-on-host artifact is the `erun-app` desktop (Wails Windows GUI the pod can't build); its code is still authored in the pod.
+- **Run on the host only what the environment cross-built for the host arch.** To run and verify an executable here, have the in-pod agent cross-compile it for this host's OS/arch into the pod outputs dir so it lands in `.erun-outputs/`; a pod-native `linux/amd64` binary won't run on this host.
 - If a problem is with **erun itself** (the platform) rather than the project, file it: use the `erun-file-issue` skill to open a bug in `sophium/erun`.
 - Destructive or cross-env actions (deploy, delete) are high blast-radius — confirm intent before driving them, especially when you own several environments.

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -164,6 +167,14 @@ func (a *App) ensureOrchestratorWorkspace() (string, error) {
 	if err := ensureOrchestratorSkills(); err != nil {
 		fmt.Fprintf(os.Stderr, "erun: could not install orchestrator skills: %v\n", err)
 	}
+	// Load the erun-orchestrate skill on every session start and reopen via a
+	// SessionStart hook, so an orchestrator always operates under its current
+	// contract instead of relying on the model to invoke the skill. Best-effort
+	// for the same reason as the skills install; a SessionStart hook is
+	// non-blocking, so a stale or missing one never prevents a launch.
+	if err := ensureOrchestratorSessionStartHook(dir); err != nil {
+		fmt.Fprintf(os.Stderr, "erun: could not write orchestrator SessionStart hook: %v\n", err)
+	}
 	return dir, nil
 }
 
@@ -196,11 +207,20 @@ func hostSkillsSource() string {
 	return ""
 }
 
+// orchestratorSkillMarker records, per installed skill, the sha256 of the
+// SKILL.md erun last installed, so a later launch can tell an untouched copy
+// (safe to refresh from the shipped source) from one the operator edited in
+// place (must be preserved). Mirrors the runtime pod's skills-install.sh marker.
+const orchestratorSkillMarker = ".erun-skill-baked-sha256"
+
 // ensureOrchestratorSkills installs every erun skill into ~/.claude/skills so the
 // orchestrator's Claude session sees them by default, with no operator install
-// step. A skill whose destination SKILL.md already exists is left untouched so
-// in-place edits survive (mirrors finishRemoteInitSkills). Returns nil when no
-// skills source is resolvable so a distributed binary still launches cleanly.
+// step. It installs a skill when absent and REFRESHES an untouched one when the
+// shipped source changed — so an orchestrator tracks the latest skill instead of
+// freezing at first install — while preserving any in-place operator edits via a
+// per-skill marker. Mirrors the pod entrypoint's install-or-refresh so host and
+// pod treat skill provenance identically. Returns nil when no skills source is
+// resolvable so a distributed binary still launches cleanly.
 func ensureOrchestratorSkills() error {
 	root := hostSkillsSource()
 	if root == "" {
@@ -219,15 +239,126 @@ func ensureOrchestratorSkills() error {
 		if !entry.IsDir() {
 			continue
 		}
-		dst := filepath.Join(destRoot, entry.Name())
-		if _, statErr := os.Stat(filepath.Join(dst, "SKILL.md")); statErr == nil {
-			continue // already installed — preserve any in-place edits
-		}
-		if err := copyDirTree(filepath.Join(root, entry.Name()), dst); err != nil {
+		if err := installOrRefreshOrchestratorSkill(filepath.Join(root, entry.Name()), filepath.Join(destRoot, entry.Name())); err != nil {
 			return fmt.Errorf("install skill %s: %w", entry.Name(), err)
 		}
 	}
 	return nil
+}
+
+// installOrRefreshOrchestratorSkill reconciles one installed skill against its
+// shipped source: install when absent; refresh when the installed copy is still
+// the one erun wrote (marker matches, or a legacy copy with no marker); leave a
+// copy the operator edited in place untouched.
+func installOrRefreshOrchestratorSkill(src, dst string) error {
+	bakedMD := filepath.Join(src, "SKILL.md")
+	if _, err := os.Stat(bakedMD); err != nil {
+		return nil // a source dir with no SKILL.md is not a skill
+	}
+	instMD := filepath.Join(dst, "SKILL.md")
+	if _, err := os.Stat(instMD); err != nil {
+		return copyOrchestratorSkill(src, dst) // absent — install
+	}
+	bakedSHA, err := fileSHA256(bakedMD)
+	if err != nil {
+		return err
+	}
+	instSHA, err := fileSHA256(instMD)
+	if err != nil {
+		return err
+	}
+	marker := filepath.Join(dst, orchestratorSkillMarker)
+	if instSHA == bakedSHA {
+		// Already the shipped version; record the marker so a future upgrade can
+		// still tell this untouched copy from an edited one (also adopts a
+		// pre-marker copy that happens to match).
+		return os.WriteFile(marker, []byte(bakedSHA+"\n"), 0o644)
+	}
+	markerSHA := ""
+	if b, readErr := os.ReadFile(marker); readErr == nil {
+		markerSHA = strings.TrimSpace(string(b))
+	}
+	if markerSHA == "" || instSHA == markerSHA {
+		// Unmodified since erun installed it, or a legacy copy with no marker —
+		// refresh to the shipped version.
+		return copyOrchestratorSkill(src, dst)
+	}
+	return nil // edited in place — preserve the operator's copy
+}
+
+// copyOrchestratorSkill replaces dst with a fresh copy of src and records the
+// shipped SKILL.md hash, so a later launch can distinguish an untouched copy
+// from an edited one.
+func copyOrchestratorSkill(src, dst string) error {
+	if err := os.RemoveAll(dst); err != nil {
+		return err
+	}
+	if err := copyDirTree(src, dst); err != nil {
+		return err
+	}
+	sha, err := fileSHA256(filepath.Join(src, "SKILL.md"))
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dst, orchestratorSkillMarker), []byte(sha+"\n"), 0o644)
+}
+
+// fileSHA256 returns the hex sha256 of a file's contents.
+func fileSHA256(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// orchestratorSkillHookCommand is the SessionStart hook command written into the
+// orchestrators root's .claude/settings.json. It echoes a directive to plain
+// stdout (added to the session context) telling the session to load and follow
+// the erun-orchestrate skill. Plain stdout — not JSON — sidesteps the
+// 10,000-char additionalContext cap (the skill body is larger) and Windows Git
+// Bash quoting hazards; the directive is deliberately ASCII-only and
+// apostrophe-free so the single-quoted echo is safe in both Git Bash (Windows)
+// and sh (macOS/Linux).
+const orchestratorSkillHookCommand = `echo 'You are a host-side erun orchestrator. Before doing anything else, invoke the erun-orchestrate skill and follow it: it is your authoritative, always-current operating contract, refreshed on every launch. Also follow the CLAUDE.md in this directory.'`
+
+// ensureOrchestratorSessionStartHook writes a SessionStart hook into the shared
+// orchestrators root's .claude/settings.json, merging so it never clobbers other
+// keys or hook events already there. SessionStart fires on a new session
+// (startup) and a reopened one (resume), so every orchestrator loads the skill's
+// contract both on start and on reopen.
+func ensureOrchestratorSessionStartHook(dir string) error {
+	claudeDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(claudeDir, "settings.json")
+	settings := map[string]any{}
+	if b, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(b, &settings) // best-effort; the hook is rebuilt below regardless
+	}
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+	}
+	hooks["SessionStart"] = orchestratorSessionStartHook()
+	settings["hooks"] = hooks
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(out, '\n'), 0o644)
+}
+
+// orchestratorSessionStartHook is the SessionStart hook block: the skill-loading
+// command runs on both new starts (startup) and reopens (resume).
+func orchestratorSessionStartHook() []any {
+	command := map[string]any{"type": "command", "command": orchestratorSkillHookCommand}
+	matcher := func(source string) map[string]any {
+		return map[string]any{"matcher": source, "hooks": []any{command}}
+	}
+	return []any{matcher("startup"), matcher("resume")}
 }
 
 // copyDirTree recursively copies src into dst (files + subdirectories), portable

--- a/erun-ui/orchestrator_test.go
+++ b/erun-ui/orchestrator_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -375,6 +376,160 @@ func TestOrchestratorSkillsInstalledByDefault(t *testing.T) {
 	}
 }
 
+// installedOrchestrateSkill is the path an installed erun-orchestrate SKILL.md
+// lands at under the test's confined $HOME.
+func installedOrchestrateSkill(t *testing.T) string {
+	t.Helper()
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".claude", "skills", "erun-orchestrate", "SKILL.md")
+}
+
+// singleSkillSource writes a one-skill fixture source (erun-orchestrate) and
+// points ERUN_SKILLS_DIR at it, returning the source SKILL.md path.
+func singleSkillSource(t *testing.T, body string) string {
+	t.Helper()
+	srcRoot := t.TempDir()
+	skillDir := filepath.Join(srcRoot, "erun-orchestrate")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	srcMD := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(srcMD, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ERUN_SKILLS_DIR", srcRoot)
+	return srcMD
+}
+
+func TestOrchestratorSkillsRefreshWhenSourceChanges(t *testing.T) {
+	srcMD := singleSkillSource(t, "# v1\n")
+	app := orchestratorTestApp(t)
+	defer app.shutdown(context.Background())
+
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("first ensureOrchestratorWorkspace: %v", err)
+	}
+	installed := installedOrchestrateSkill(t)
+	if data, _ := os.ReadFile(installed); string(data) != "# v1\n" {
+		t.Fatalf("expected installed v1, got %q", data)
+	}
+
+	// A newer skill ships; an untouched install must track it on next launch.
+	if err := os.WriteFile(srcMD, []byte("# v2 newer\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("second ensureOrchestratorWorkspace: %v", err)
+	}
+	if data, _ := os.ReadFile(installed); string(data) != "# v2 newer\n" {
+		t.Fatalf("expected untouched install refreshed to v2, got %q", data)
+	}
+}
+
+func TestOrchestratorSkillsPreserveEditAcrossSourceChange(t *testing.T) {
+	srcMD := singleSkillSource(t, "# v1\n")
+	app := orchestratorTestApp(t)
+	defer app.shutdown(context.Background())
+
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("first ensureOrchestratorWorkspace: %v", err)
+	}
+	installed := installedOrchestrateSkill(t)
+
+	// Operator edits the installed skill; then a newer source ships. The edit
+	// must win over the refresh.
+	if err := os.WriteFile(installed, []byte("# operator edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(srcMD, []byte("# v2 newer\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("second ensureOrchestratorWorkspace: %v", err)
+	}
+	if data, _ := os.ReadFile(installed); string(data) != "# operator edit\n" {
+		t.Fatalf("expected operator edit preserved across a source change, got %q", data)
+	}
+}
+
+func TestOrchestratorSessionStartHookLoadsSkill(t *testing.T) {
+	app := orchestratorTestApp(t)
+	defer app.shutdown(context.Background())
+
+	dir, err := app.ensureOrchestratorWorkspace()
+	if err != nil {
+		t.Fatalf("ensureOrchestratorWorkspace: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("read orchestrator settings.json: %v", err)
+	}
+	var settings struct {
+		Hooks struct {
+			SessionStart []struct {
+				Matcher string `json:"matcher"`
+				Hooks   []struct {
+					Type    string `json:"type"`
+					Command string `json:"command"`
+				} `json:"hooks"`
+			} `json:"SessionStart"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal settings.json: %v\n%s", err, data)
+	}
+	matchers := map[string]bool{}
+	for _, group := range settings.Hooks.SessionStart {
+		matchers[group.Matcher] = true
+		if len(group.Hooks) == 0 || group.Hooks[0].Type != "command" {
+			t.Fatalf("SessionStart matcher %q missing a command hook:\n%s", group.Matcher, data)
+		}
+		if !strings.Contains(group.Hooks[0].Command, "erun-orchestrate") {
+			t.Fatalf("SessionStart command does not load erun-orchestrate:\n%s", group.Hooks[0].Command)
+		}
+	}
+	for _, want := range []string{"startup", "resume"} {
+		if !matchers[want] {
+			t.Fatalf("SessionStart hook missing matcher %q:\n%s", want, data)
+		}
+	}
+}
+
+func TestOrchestratorSessionStartHookPreservesExistingSettings(t *testing.T) {
+	app := orchestratorTestApp(t)
+	defer app.shutdown(context.Background())
+
+	claudeDir := filepath.Join(orchestratorsRoot(), ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A pre-existing project settings file with an unrelated key and hook event.
+	pre := `{"model":"opus","hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo keep"}]}]}}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("ensureOrchestratorWorkspace: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal settings.json: %v\n%s", err, data)
+	}
+	if settings["model"] != "opus" {
+		t.Fatalf("expected unrelated key preserved, got %v\n%s", settings["model"], data)
+	}
+	hooks, _ := settings["hooks"].(map[string]any)
+	if _, ok := hooks["PreToolUse"]; !ok {
+		t.Fatalf("expected unrelated hook event preserved:\n%s", data)
+	}
+	if _, ok := hooks["SessionStart"]; !ok {
+		t.Fatalf("expected SessionStart hook added:\n%s", data)
+	}
+}
+
 func TestBuildOrchestratorLaunchResumesWithUltracodeOpus(t *testing.T) {
 	// No pinned session id (legacy/transient) keeps the continue-else-fresh path.
 	_, posix := buildOrchestratorLaunch("linux", "", false, "", "")
@@ -429,11 +584,16 @@ func TestBuildOrchestratorLaunchPinsPerOrchestratorSession(t *testing.T) {
 	if wcmd := win[len(win)-1]; !strings.Contains(wcmd, "--resume "+sid) || !strings.Contains(wcmd, "finish the task") {
 		t.Fatalf("windows pinned resume+prompt missing pieces: %q", wcmd)
 	}
+}
 
+// Per-orchestrator session ids are deterministic and unique so each orchestrator
+// resumes its own conversation, while a transient (empty-id) orchestrator has no
+// pinned session.
+func TestOrchestratorSessionIDIsStableAndDistinct(t *testing.T) {
 	if orchestratorSessionID("va1") == orchestratorSessionID("petios1") {
 		t.Fatal("distinct orchestrators must derive distinct session ids")
 	}
-	if orchestratorSessionID("va1") != orchestratorSessionID("va1") {
+	if id := orchestratorSessionID("va1"); id != orchestratorSessionID("va1") {
 		t.Fatal("session id must be stable for the same orchestrator")
 	}
 	if orchestratorSessionID("") != "" {


### PR DESCRIPTION
Closes #873.

## What and why

A host-side orchestrator could run a **stale** `erun-orchestrate` skill, and the skill's contract was **not guaranteed to be loaded** into the session at all. Two root causes, fixed here:

1. **The host skill installer never refreshed.** `ensureOrchestratorSkills` installed a skill only when absent and skipped it forever after, so a shipped improvement never reached existing orchestrators. It now mirrors the runtime pod's `skills-install.sh`: **install when absent, refresh an untouched copy when the source changed, preserve in-place edits** — tracked per skill by a `.erun-skill-baked-sha256` marker.
2. **The skill body only loaded on demand.** The shared `CLAUDE.md` said "Follow the `erun-orchestrate` skill", but at session start only the skill's `description` is in context. `ensureOrchestratorWorkspace` now also writes a project `.claude/settings.json` into the orchestrators root with a **`SessionStart` hook** (matchers `startup` + `resume`) that loads the skill on every new start and reopen.

Design notes:
- **Directive, not full-body injection.** The skill is ~16 KB, over Claude Code's 10,000-char `SessionStart` `additionalContext` cap, so the hook injects a compact directive to invoke+follow the skill via plain stdout (Git-Bash-safe on Windows, no JSON quoting). Combined with the refresh above, invoking the skill always loads the latest body.
- **Cannot break a launch.** `SessionStart` hooks are non-blocking by spec; the hook write and skill install are both best-effort (logged, never fatal). The settings writer **merges**, preserving any unrelated keys or hook events.
- The canonical `SKILL.md` is refreshed too (know-your-configuration, develop-in-the-environment-not-host, cross-build-for-host-arch).

## Docs plan (in this PR)

- `erun-docs/docs/agent-reference/skills-spec.md` (Agent reference): corrected **In-pod (runtime image)** — it still described install-only (`[ ! -e ]`) rather than the marker-based install-or-refresh `skills-install.sh` actually does; added a **Host orchestrator (desktop)** subsection; refreshed the `erun-orchestrate` catalogue Inputs/Outputs.
- `erun-docs/docs/concepts/skills.md` (Operator/conceptual): corrected the same install-only staleness.
- Validation: `cd erun-docs && yarn build` clean (exit 0), internal anchors resolve.

## Marketplace

Per repo convention (`git log` shows `.claude-plugin/marketplace.json` `source.sha` is bumped only by the release "sync package metadata" automation, not feature PRs), this PR leaves `marketplace.json` untouched; the release sync repoints the SHA so laptop marketplace users pick up the updated skill.

## UX Impact Review

1. **Affected paths.** Open/reopen an orchestrator → `spawnOrchestratorSession` → `ensureOrchestratorWorkspace` (writes CLAUDE.md, installs/refreshes skills, writes `.claude/settings.json` SessionStart hook) → `claude` launches with the hook loading `erun-orchestrate`.
2. **User-visible sequence.** On opening/reopening an orchestrator, the Claude session starts already operating under the current skill contract (a SessionStart directive to invoke+follow `erun-orchestrate`) from its first turn. No new dialog, button, field, or status.
3. **State-without-affordance.** No `AppState` mutations; the change writes files consumed by the launched session. The affordance is the session behaving per the skill.
4. **Visibility of system status (Nielsen #1).** The hook is silent launch infrastructure. There is no in-flight operation for the user to track; failures are non-blocking and logged to stderr.
5. **Success/failure feedback.** If skill install or the hook write fails, the orchestrator still launches (best-effort) and degrades to the prior behavior (skill loads on invocation) — never a broken state, no user recovery needed.
6. **Consistency (Nielsen #4).** Reuses the pod's existing marker-refresh model, so host and pod handle skill provenance identically.
7. **Heuristic pass.** No new visible control, so most heuristics are N/A; the relevant ones (error prevention, consistency) are satisfied by the non-blocking, best-effort, merge-preserving design.
8. **Playwright coverage.** The orchestrator launch spawns a live `claude` session — live infrastructure the headless harness deliberately lacks — so it is not reachable by a spec. The file-writing behaviour (SessionStart hook shape and matchers, marker-based refresh, edit preservation, settings merge) is covered by new Go unit tests in `erun-ui/orchestrator_test.go`. No new React surface to assert.

## Verification

- `go test .` (erun-ui `main`): pass, including new tests `TestOrchestratorSkillsRefreshWhenSourceChanges`, `TestOrchestratorSkillsPreserveEditAcrossSourceChange`, `TestOrchestratorSessionStartHookLoadsSkill`, `TestOrchestratorSessionStartHookPreservesExistingSettings`, `TestOrchestratorSessionIDIsStableAndDistinct`.
- `golangci-lint run ./...` (erun-ui): 0 issues (also fixed two pre-existing findings in `orchestrator_test.go` the touch surfaced).
- `erun-docs`: `yarn build` SUCCESS.
- Desktop build: `erun-ui/build.ps1` produced `erun-app.exe` cleanly (Wails + CGO).
- **Hook end-to-end**: `claude -p` in a temp dir with the exact generated `settings.json` returned the injected directive verbatim — the `SessionStart` (startup) hook fires and its stdout reaches the model context. The `resume` matcher is the same mechanism and is exercised by the live rebuild+restart of the desktop (below).



## Live verification (post rebuild+restart, on this branch's `erun-app`)

Verified end-to-end from a freshly built `erun-app` running this branch: the desktop was rebuilt+restarted and reopened this orchestrator (`petios1`), and **this very session** is the artifact under test. All three behaviours are live:

**1. `SessionStart` hook is written and references the skill.**
`~/orchestrators/.claude/settings.json` exists with a `SessionStart` hook under **both** matchers (`startup` and `resume`), each running:
```
echo 'You are a host-side erun orchestrator. Before doing anything else, invoke the erun-orchestrate skill and follow it: it is your authoritative, always-current operating contract, refreshed on every launch. Also follow the CLAUDE.md in this directory.'
```

**2. This resumed session actually received the directive (the `resume` matcher, live).**
On reopen, the `SessionStart:resume` hook fired and injected that directive into this session's context, and the session responded by invoking `erun-orchestrate` as its first action — before any other work. This is the `resume` path the "Verification › Hook end-to-end" note forward-referenced, now exercised against the real desktop rather than a `claude -p` harness.

**3. Host skill refresh ran, and the installed skill is the LATEST — not stale.**
The per-skill marker `~/.claude/skills/erun-orchestrate/.erun-skill-baked-sha256` now exists. Adversarial check of the actual staleness bug #873 targets — all three hashes are byte-identical:

| artifact | sha256 |
|---|---|
| marker `.erun-skill-baked-sha256` | `58481af2073532d0014979cd45544c4ef268c6f699445c17a3b55e34866e77cb` |
| installed `~/.claude/skills/erun-orchestrate/SKILL.md` | `58481af2073532d0014979cd45544c4ef268c6f699445c17a3b55e34866e77cb` |
| repo source `erun-skills/skills/erun-orchestrate/SKILL.md` @ `2fc096cc` | `58481af2073532d0014979cd45544c4ef268c6f699445c17a3b55e34866e77cb` |

So the host is running the shipped source verbatim, and the skill body loaded into this session at start is that latest content — the exact regression #873 fixes.

**Bonus — no regression to #872 isolation.** Across this rebuild+restart the session stayed pinned to petios1's own conversation: `CLAUDE_CODE_SESSION_ID == 0acefa72-e532-54ec-a32e-910dd6c2f98b` (the UUIDv5-derived id for `petios1`), not the old shared session.
