### PR TITLE
Improve erun cloud init aws: permission-set wording, guidance, and single-rendered Windows prompts

### DIFF
--- a/erun-cli/cmd/cloud.go
+++ b/erun-cli/cmd/cloud.go
@@ -65,7 +65,7 @@ func newCloudInitAWSCmd(store common.CloudStore, promptRunner PromptRunner, deps
 	cmd.Flags().StringVar(&params.SSOStartURL, "sso-start-url", "", "AWS IAM Identity Center start URL")
 	cmd.Flags().StringVar(&params.SSORegion, "sso-region", "", "AWS IAM Identity Center region")
 	cmd.Flags().StringVar(&params.AccountID, "account-id", "", "AWS account ID to use for SSO login")
-	cmd.Flags().StringVar(&params.RoleName, "role-name", "", "AWS role name to use for SSO login")
+	cmd.Flags().StringVar(&params.RoleName, "role-name", "", "AWS permission set (IAM Identity Center) to assume for SSO login")
 	cmd.Flags().StringVar(&params.Region, "region", "", "Default AWS region for the generated configuration")
 	cmd.Flags().StringVar(&params.OIDCIssuerURL, "oidc-issuer-url", "", "OIDC issuer URL trusted by deployed ERun APIs")
 	addDryRunFlag(cmd)
@@ -74,6 +74,9 @@ func newCloudInitAWSCmd(store common.CloudStore, promptRunner PromptRunner, deps
 
 func runCloudInitAWSCommand(ctx common.Context, store common.CloudStore, promptRunner PromptRunner, params common.InitAWSCloudProviderParams, deps common.CloudDependencies) error {
 	var err error
+	if strings.TrimSpace(params.Profile) == "" && awsInitParamsNeedPrompt(params) {
+		printAWSInitGuidance(ctx)
+	}
 	params, err = promptAWSInitParams(promptRunner, params)
 	if err != nil {
 		return err
@@ -308,7 +311,7 @@ func promptMissingAWSInitParams(promptRunner PromptRunner, params common.InitAWS
 	if err != nil {
 		return params, err
 	}
-	params.RoleName, err = promptCloudValueIfEmpty(promptRunner, params.RoleName, "AWS role name", "")
+	params.RoleName, err = promptCloudValueIfEmpty(promptRunner, params.RoleName, "AWS permission set", "")
 	if err != nil {
 		return params, err
 	}
@@ -317,6 +320,34 @@ func promptMissingAWSInitParams(promptRunner PromptRunner, params common.InitAWS
 		return params, err
 	}
 	return params, err
+}
+
+// awsInitParamsNeedPrompt reports whether the AWS SSO wizard will ask the
+// operator for at least one value — used to gate the one-time guidance block.
+func awsInitParamsNeedPrompt(params common.InitAWSCloudProviderParams) bool {
+	return strings.TrimSpace(params.SSOStartURL) == "" ||
+		strings.TrimSpace(params.SSORegion) == "" ||
+		strings.TrimSpace(params.AccountID) == "" ||
+		strings.TrimSpace(params.RoleName) == "" ||
+		strings.TrimSpace(params.Region) == ""
+}
+
+// awsInitGuidance orients the operator before the AWS SSO prompts: where to find
+// each value in the AWS access portal, and that IAM Identity Center grants the
+// account through a permission set.
+const awsInitGuidance = `Set up an AWS IAM Identity Center (SSO) profile for ERun.
+You'll sign in through your browser when prompted; ERun never sees your AWS password.
+Find each value in your AWS access portal (open the SSO start URL, sign in, then expand the account):
+  - SSO start URL   your Identity Center portal, e.g. https://my-sso.awsapps.com/start
+  - SSO region      the region Identity Center runs in, e.g. eu-west-2
+  - Account ID      the 12-digit AWS account to use
+  - Permission set  the permission set granted to you on that account (the name shown
+                    under the account tile, e.g. AdministratorAccess)
+
+`
+
+func printAWSInitGuidance(ctx common.Context) {
+	_, _ = fmt.Fprint(ctx.Stdout, awsInitGuidance)
 }
 
 func promptCloudValueIfEmpty(promptRunner PromptRunner, value, label, defaultValue string) (string, error) {

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"io"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/manifoldco/promptui"
@@ -22,13 +23,19 @@ type (
 // own goroutines, so its cursor-control frames' final flush would otherwise race
 // process exit.
 //
+// Windows takes the plain reader for interactive terminals too: the desktop app's
+// terminal is a ConPTY, whose repaints re-send promptui's in-place cursor redraws
+// as duplicate lines, so each answered prompt echoes twice. A single-write plain
+// prompt gives ConPTY nothing to re-paint. Masked prompts stay on promptui so the
+// secret input remains hidden — keeping it masked matters more than the repaint.
+//
 // The promptui branch binds its reader to os.Stdin explicitly: on Windows
 // readline otherwise opens the console directly and cannot read piped stdin at
 // all, so a forced-TTY scenario (or any scripted run) would read EOF. Passing
 // os.Stdin is a no-op for a real interactive terminal — that is already the
 // default source — and lets piped input drive the prompt on every host.
 func runPrompt(prompt promptui.Prompt) (string, error) {
-	if writerIsTerminal(os.Stdout) {
+	if writerIsTerminal(os.Stdout) && (runtime.GOOS != "windows" || prompt.Mask != 0) {
 		prompt.Stdin = os.Stdin
 		return prompt.Run()
 	}
@@ -36,7 +43,7 @@ func runPrompt(prompt promptui.Prompt) (string, error) {
 }
 
 func runSelect(prompt promptui.Select) (int, string, error) {
-	if writerIsTerminal(os.Stdout) {
+	if writerIsTerminal(os.Stdout) && runtime.GOOS != "windows" {
 		prompt.Stdin = os.Stdin
 		return prompt.Run()
 	}

--- a/erun-common/cloud.go
+++ b/erun-common/cloud.go
@@ -931,7 +931,7 @@ func validateAWSProfileConfig(config AWSProfileConfig) error {
 	case config.AccountID == "":
 		return fmt.Errorf("AWS account ID is required")
 	case config.RoleName == "":
-		return fmt.Errorf("AWS role name is required")
+		return fmt.Errorf("AWS permission set is required")
 	case config.Region == "":
 		return fmt.Errorf("AWS region is required")
 	default:

--- a/erun-docs/docs/cli/cloud.md
+++ b/erun-docs/docs/cli/cloud.md
@@ -27,7 +27,7 @@ Registers an AWS IAM Identity Center (SSO) profile and saves it as a cloud provi
 | `--sso-start-url` | AWS IAM Identity Center start URL. |
 | `--sso-region` | Identity Center region. |
 | `--account-id` | AWS account ID to log into. |
-| `--role-name` | AWS role to assume. |
+| `--role-name` | AWS permission set (IAM Identity Center) to assume — the name shown under the account in your AWS access portal. |
 | `--region` | Default region for the alias (defaults to `--sso-region`). |
 | `--oidc-issuer-url` | Override the OIDC issuer (normally derived from the live token). |
 

--- a/erun-docs/docs/deployment/cloud-setup.md
+++ b/erun-docs/docs/deployment/cloud-setup.md
@@ -15,7 +15,7 @@ If you already have a Kubernetes cluster — EKS, GKE, an on-prem k3s — you do
 ## Prerequisites
 
 1. An AWS account reachable through IAM Identity Center (SSO). Managed cloud contexts are AWS-only today.
-2. Permission for your SSO role to create and manage EC2 instances, security groups, and IAM instance profiles in the target region.
+2. Permission for your SSO permission set to create and manage EC2 instances, security groups, and IAM instance profiles in the target region.
 3. An OIDC issuer for ERun API callers — derived automatically from your AWS web-identity token in Step 1.
 
 ## Step 1 — Register a cloud provider alias

--- a/erun-integration/testdata/cloud/init_aws_help.txt
+++ b/erun-integration/testdata/cloud/init_aws_help.txt
@@ -11,7 +11,7 @@ Flags:
   -h, --help                     help for aws
       --oidc-issuer-url string   OIDC issuer URL trusted by deployed ERun APIs
       --region string            Default AWS region for the generated configuration
-      --role-name string         AWS role name to use for SSO login
+      --role-name string         AWS permission set (IAM Identity Center) to assume for SSO login
       --sso-region string        AWS IAM Identity Center region
       --sso-start-url string     AWS IAM Identity Center start URL
 

--- a/erun-integration/testdata/cloud/init_aws_prompts_missing_region_via_stdin.txt
+++ b/erun-integration/testdata/cloud/init_aws_prompts_missing_region_via_stdin.txt
@@ -1,3 +1,12 @@
+Set up an AWS IAM Identity Center (SSO) profile for ERun.
+You'll sign in through your browser when prompted; ERun never sees your AWS password.
+Find each value in your AWS access portal (open the SSO start URL, sign in, then expand the account):
+  - SSO start URL   your Identity Center portal, e.g. https://my-sso.awsapps.com/start
+  - SSO region      the region Identity Center runs in, e.g. eu-west-2
+  - Account ID      the 12-digit AWS account to use
+  - Permission set  the permission set granted to you on that account (the name shown
+                    under the account tile, e.g. AdministratorAccess)
+
 Default AWS region [eu-west-1]: Dry run: AWS cloud provider initialization planned.
 audit: erun cloud init aws --account-id 123456789012 --dry-run --role-name Admin --sso-region eu-west-1 --sso-start-url https://example.awsapps.com/start
 aws configure set sso_start_url https://example.awsapps.com/start --profile 'erun-sso-<timestamp>'

--- a/erun-mcp/cloud.go
+++ b/erun-mcp/cloud.go
@@ -17,7 +17,7 @@ type CloudInitAWSInput struct {
 	SSOStartURL   string `json:"ssoStartUrl" jsonschema:"AWS IAM Identity Center start URL"`
 	SSORegion     string `json:"ssoRegion" jsonschema:"AWS IAM Identity Center region"`
 	AccountID     string `json:"accountId" jsonschema:"AWS account ID to use for SSO login"`
-	RoleName      string `json:"roleName" jsonschema:"AWS role name to use for SSO login"`
+	RoleName      string `json:"roleName" jsonschema:"AWS permission set (IAM Identity Center) to assume for SSO login"`
 	Region        string `json:"region,omitempty" jsonschema:"default AWS region for the generated configuration; defaults to ssoRegion"`
 	OIDCIssuerURL string `json:"oidcIssuerUrl,omitempty" jsonschema:"OIDC issuer URL trusted by deployed ERun APIs"`
 	Preview       bool   `json:"preview,omitempty" jsonschema:"when true, return the planned operation without executing login or saving config"`

--- a/erun-mcp/doctor.go
+++ b/erun-mcp/doctor.go
@@ -32,7 +32,7 @@ type DoctorRepairAliasInput struct {
 	Alias         string `json:"alias" jsonschema:"orphaned cloud provider alias (username+account@provider) to recreate"`
 	SSOStartURL   string `json:"ssoStartUrl" jsonschema:"AWS IAM Identity Center start URL"`
 	SSORegion     string `json:"ssoRegion" jsonschema:"AWS IAM Identity Center region"`
-	RoleName      string `json:"roleName,omitempty" jsonschema:"AWS role name used during SSO login"`
+	RoleName      string `json:"roleName,omitempty" jsonschema:"AWS permission set (IAM Identity Center) used during SSO login"`
 	Region        string `json:"region,omitempty" jsonschema:"default AWS region for the recreated provider (derived from referenced cloud context when blank)"`
 	OIDCIssuerURL string `json:"oidcIssuerUrl,omitempty" jsonschema:"override for the OIDC issuer URL; usually inferred from AWS web identity token"`
 	SkipLogin     bool   `json:"skipLogin,omitempty" jsonschema:"when true, skip aws sso login and rely on existing credentials"`


### PR DESCRIPTION
Closes #877.

Two related improvements to the `erun cloud init aws` interactive experience.

### 1 — "permission set" wording + setup guidance (#877)
`erun cloud init aws` prompted for **`AWS role name`** with no guidance. The value is an **AWS IAM Identity Center (SSO) permission set** — the name shown under the account in the AWS access portal (e.g. `AdministratorAccess`).
- Interactive prompt `AWS role name` → **`AWS permission set`**.
- An **orientation block** now prints before the prompts (what each value is and where to find it in the portal).
- `--role-name` flag help and the MCP `roleName` descriptions reworded to match.
- Unchanged: the `sso_role_name` config key and the `--role-name` flag name (AWS-aligned). Scope limited to the SSO permission-set surfaces; the IAM instance-profile roles in `cloud context` are untouched.

### 2 — stop double-rendered prompts on Windows
The desktop app's terminal is a ConPTY, whose repaints re-send promptui's in-place cursor redraws as **duplicate lines** (each answered prompt echoed twice, e.g. `AWS SSO region: eu-west-2` printed twice). On **Windows**, non-masked prompts now use the existing plain single-write reader (already used for piped stdout), so ConPTY has nothing to re-paint. Masked secret prompts stay on promptui so input remains hidden. Non-Windows behaviour is unchanged.

### Validation
- `go build ./...` + `go test ./...` green in `erun-cli`, `erun-common`, `erun-mcp`.
- `erun-integration` **`TestCloud` green** (208s); goldens unaffected (integration already exercises the plain-prompt path via piped stdin, and the Windows branch is a `runtime.GOOS` guard).
- Verified the rebuilt binary: guidance + `AWS permission set:` prompt render, and prompts render once on the Windows desktop terminal.
- Docs updated: `deployment/cloud-setup.md`, `cli/cloud.md`.

Recommend a full `make integration-test` confirmation before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)