### PR TITLE
Mount the repo worktree into the erun-dind sidecar so tenant compose bind mounts resolve

### DIFF
--- a/erun-devops/k8s/erun-devops/templates/service.yaml
+++ b/erun-devops/k8s/erun-devops/templates/service.yaml
@@ -637,7 +637,19 @@ spec:
                   - sh
                   - -lc
                   - while [ ! -S /var/run/docker.sock ]; do sleep 1; done; chmod 0666 /var/run/docker.sock
+          # The dind sidecar is the docker daemon that resolves a tenant's
+          # docker-compose bind-mount sources on its own filesystem, so it must
+          # see the same home + repo tree as the erun-devops container: without
+          # the repo mount a "./relative" compose bind mount resolves to a path
+          # the daemon lacks and Docker silently creates an empty dir there
+          # (localstack init hooks, DB seed SQL, service configs all vanish).
           volumeMounts:
+            - name: erun-home
+              mountPath: /home/erun
+            {{- if ne $worktreeStorage "none" }}
+            - name: repo-worktree
+              mountPath: {{ $worktreePath | quote }}
+            {{- end }}
             - name: docker-socket
               mountPath: /var/run
             - name: docker-state


### PR DESCRIPTION
Closes #878.

### Problem
The erun-devops runtime pod's `erun-dind` sidecar mounted only the docker socket + `docker-state`, not the repo worktree. A docker-compose bind-mount source is resolved on the **DIND daemon's** filesystem, so the daemon couldn't see `/home/erun/git/<tenant>/...` and Docker silently created empty dirs at every bind-mount path — a tenant's local e2e stack lost its localstack init hooks, DB seed SQL, and service configs.

Observed on petios: `ls /home/erun/git/petios/vetenv-devops/local/init-sqs.py` inside the dind showed an empty dir; the localstack SQS init hook never ran, so the `practice-import` queue was never created and the Playwright e2e stalled.

### Fix
Mount `erun-home` and `repo-worktree` into the `erun-dind` container at the same paths, under the same `worktreeStorage` guard, as the `erun-devops` container — so the daemon sees the same home + repo tree and compose bind mounts resolve.

### Validation
- `helm template` for all storage modes: **pvc** and **host** → dind now mounts `/home/erun` + `/home/erun/git/<repo>` + socket + state; **none** (sourceless runtime) → `/home/erun` + socket + state, no worktree (correct). The `erun-devops`/`erun-mcp` containers are unchanged.
- `helm lint` clean.
- Chart-template-only change: no golden or test asserts the dind `volumeMounts`, and the deploy integration tests are command/pod-status level (no `--set` flag or command changes).
- Proven earlier by patching a live deployment's dind volumeMounts with `repo-worktree -> /home/erun/git/petios`: the dind then read the real repo and the compose init hooks ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)