### PR TITLE
Wire each linked env's erun MCP into the orchestrator session

### DIFF
--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -59,7 +59,7 @@ type erunUIDeps struct {
 	startTerminal             func(startTerminalSessionParams) (terminalSession, error)
 	runIDECommand             func(context.Context, startTerminalSessionParams) (string, error)
 	launchHostArtifact        func(exePath, dir string) error
-	resolveOrchestratorLaunch func(sessionID, initialPrompt, resumePrompt string) (string, []string, error)
+	resolveOrchestratorLaunch func(sessionID, initialPrompt, resumePrompt, mcpConfigPath string) (string, []string, error)
 	savePastedFile            func(pastedFileSaveParams) (string, error)
 	listAgentOutputs          func(eruncommon.OpenResult, eruncommon.RuntimeOutputsParams) (eruncommon.RuntimeOutputsListResult, error)
 	downloadAgentOutput       func(eruncommon.OpenResult, eruncommon.RuntimeOutputDownloadParams) (eruncommon.RuntimeOutputResult, error)

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -476,11 +477,11 @@ const orchestratorUltracodeFlag = ` --settings '{"ultracode":true}'`
 // conversation in the shared workspace. A non-empty resumePrompt is handed to
 // the resumed (or freshly created) session so a rebuild+restart continues its
 // task itself.
-func orchestratorLaunchCommand(sessionID, initialPrompt, resumePrompt string) (string, []string, error) {
+func orchestratorLaunchCommand(sessionID, initialPrompt, resumePrompt, mcpConfigPath string) (string, []string, error) {
 	if _, err := exec.LookPath(defaultAITool); err != nil {
 		return "", nil, fmt.Errorf("the %q CLI was not found on PATH; install it to run an orchestrator", defaultAITool)
 	}
-	shell, args := buildOrchestratorLaunch(runtime.GOOS, sessionID, orchestratorSessionExists(sessionID), initialPrompt, resumePrompt)
+	shell, args := buildOrchestratorLaunch(runtime.GOOS, sessionID, orchestratorSessionExists(sessionID), initialPrompt, resumePrompt, mcpConfigPath)
 	return shell, args, nil
 }
 
@@ -530,8 +531,11 @@ func orchestratorSessionExists(sessionID string) bool {
 // first run: PowerShell tests $LASTEXITCODE, POSIX chains with ||. A resumePrompt
 // is appended to both the resume and the fresh-fallback branch so an auto-resume
 // runs the task even on the first launch.
-func buildOrchestratorLaunch(goos, sessionID string, sessionExists bool, initialPrompt, resumePrompt string) (string, []string) {
+func buildOrchestratorLaunch(goos, sessionID string, sessionExists bool, initialPrompt, resumePrompt, mcpConfigPath string) (string, []string) {
 	flags := orchestratorUltracodeFlag + " --model " + orchestratorModel
+	if strings.TrimSpace(mcpConfigPath) != "" {
+		flags += ` --mcp-config "` + mcpConfigPath + `"`
+	}
 	fresh := defaultAITool + flags
 	shell, shellArgs := resolveLocalShellCommand(goos)
 
@@ -819,7 +823,14 @@ func (a *App) runningOrchestratorInfo(id string) (orchestratorInfo, bool) {
 // mirror directory and tracks the live session.
 func (a *App) spawnOrchestratorSession(id, name string, envs []eruncommon.OrchestratorEnvConfig, initialPrompt, resumePrompt string, transient bool, cols, rows int) (orchestratorInfo, error) {
 	cols, rows = clampTerminalSize(cols, rows)
-	executable, args, err := a.deps.resolveOrchestratorLaunch(orchestratorSessionID(id), initialPrompt, resumePrompt)
+	// Wire each linked env's erun MCP into the orchestrator session so it drives
+	// its envs through the MCP (raw/build/deploy/…) rather than raw kubectl.
+	// Non-fatal: the orchestrator still launches without the env MCP.
+	mcpConfigPath, mcpErr := a.writeOrchestratorMCPConfig(id, envs)
+	if mcpErr != nil {
+		log.Printf("erun-app: write orchestrator MCP config for %s: %v", id, mcpErr)
+	}
+	executable, args, err := a.deps.resolveOrchestratorLaunch(orchestratorSessionID(id), initialPrompt, resumePrompt, mcpConfigPath)
 	if err != nil {
 		return orchestratorInfo{}, err
 	}

--- a/erun-ui/orchestrator_mcp.go
+++ b/erun-ui/orchestrator_mcp.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// orchestratorMCPServer is one Claude Code HTTP MCP server entry: a linked env's
+// erun MCP edge (emcp in the pod, exposing raw/diff/build/push/deploy/outputs_*),
+// reached over the desktop's local port-forward and authenticated with a
+// desktop-signed bearer.
+type orchestratorMCPServer struct {
+	Type    string            `json:"type"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+type orchestratorMCPConfig struct {
+	MCPServers map[string]orchestratorMCPServer `json:"mcpServers"`
+}
+
+// mcpPortResolver and bearerSigner are seams so the config assembly is unit
+// testable without a live config store or signing identity.
+type mcpPortResolver func(tenant, environment string) int
+type bearerSigner func(tenant, environment string) string
+
+// buildOrchestratorMCPConfig assembles the per-env MCP server map, keyed
+// "<tenant>-<environment>". An env is skipped (not an error) when its MCP port
+// or bearer cannot be resolved, so a partially-signable orchestrator still wires
+// the envs it can.
+func buildOrchestratorMCPConfig(envs []eruncommon.OrchestratorEnvConfig, mcpPort mcpPortResolver, bearer bearerSigner) orchestratorMCPConfig {
+	servers := map[string]orchestratorMCPServer{}
+	for _, env := range envs {
+		tenant := strings.TrimSpace(env.Tenant)
+		environment := strings.TrimSpace(env.Environment)
+		if tenant == "" || environment == "" {
+			continue
+		}
+		port := mcpPort(tenant, environment)
+		if port <= 0 {
+			continue
+		}
+		token := strings.TrimSpace(bearer(tenant, environment))
+		if token == "" {
+			continue
+		}
+		servers[tenant+"-"+environment] = orchestratorMCPServer{
+			Type:    "http",
+			URL:     fmt.Sprintf("http://127.0.0.1:%d/mcp", port),
+			Headers: map[string]string{"Authorization": "Bearer " + token},
+		}
+	}
+	return orchestratorMCPConfig{MCPServers: servers}
+}
+
+// writeOrchestratorMCPConfig writes a per-orchestrator Claude Code --mcp-config
+// file wiring each linked env's erun MCP into the orchestrator session, so it
+// drives its envs through the MCP rather than raw kubectl. Returns "" (no file)
+// when no env resolves a port + bearer, so the caller skips --mcp-config.
+// Bearers are minted fresh at each launch/resume (they expire; a longer-lived
+// refresh is a follow-up).
+func (a *App) writeOrchestratorMCPConfig(id string, envs []eruncommon.OrchestratorEnvConfig) (string, error) {
+	config := buildOrchestratorMCPConfig(envs,
+		func(tenant, environment string) int {
+			ports, err := eruncommon.ResolveEnvironmentLocalPorts(a.deps.store, tenant, environment)
+			if err != nil {
+				return 0
+			}
+			return ports.MCP
+		},
+		a.mcpBearer,
+	)
+	if len(config.MCPServers) == 0 {
+		return "", nil
+	}
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	path := orchestratorMCPConfigPath(id)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// orchestratorMCPConfigPath is a per-orchestrator sibling of
+// orchestrator-restore.json under UserConfigDir()/ERun, so each orchestrator's
+// env-MCP wiring is isolated (the shared orchestrators workspace can't hold a
+// per-orchestrator .mcp.json).
+func orchestratorMCPConfigPath(id string) string {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		configDir = os.TempDir()
+	}
+	return filepath.Join(configDir, "ERun", "orchestrator-mcp-"+sanitizeOrchestratorFileID(id)+".json")
+}
+
+func sanitizeOrchestratorFileID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "default"
+	}
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		default:
+			return '-'
+		}
+	}, id)
+}

--- a/erun-ui/orchestrator_mcp_test.go
+++ b/erun-ui/orchestrator_mcp_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+func TestBuildOrchestratorMCPConfig(t *testing.T) {
+	envs := []eruncommon.OrchestratorEnvConfig{
+		{Tenant: "petios", Environment: "rihards-win-develop"},
+		{Tenant: "erun", Environment: "main"},
+		{Tenant: "noport", Environment: "x"},   // skipped: port 0
+		{Tenant: "nobearer", Environment: "y"}, // skipped: empty bearer
+		{Tenant: "", Environment: "z"},         // skipped: blank tenant
+	}
+	port := func(tenant, _ string) int {
+		switch tenant {
+		case "petios":
+			return 17400
+		case "erun":
+			return 17300
+		case "nobearer":
+			return 18000
+		default:
+			return 0
+		}
+	}
+	bearer := func(tenant, _ string) string {
+		if tenant == "nobearer" {
+			return ""
+		}
+		return "tok-" + tenant
+	}
+
+	config := buildOrchestratorMCPConfig(envs, port, bearer)
+
+	if len(config.MCPServers) != 2 {
+		t.Fatalf("expected 2 servers, got %d: %v", len(config.MCPServers), config.MCPServers)
+	}
+	petios, ok := config.MCPServers["petios-rihards-win-develop"]
+	if !ok {
+		t.Fatalf("missing petios server: %v", config.MCPServers)
+	}
+	if petios.Type != "http" || petios.URL != "http://127.0.0.1:17400/mcp" {
+		t.Fatalf("unexpected petios server: %+v", petios)
+	}
+	if got := petios.Headers["Authorization"]; got != "Bearer tok-petios" {
+		t.Fatalf("unexpected petios auth header: %q", got)
+	}
+	if _, ok := config.MCPServers["erun-main"]; !ok {
+		t.Fatalf("missing erun server")
+	}
+	for _, skipped := range []string{"noport-x", "nobearer-y", "-z"} {
+		if _, ok := config.MCPServers[skipped]; ok {
+			t.Fatalf("expected %s to be skipped", skipped)
+		}
+	}
+}
+
+func TestBuildOrchestratorLaunchInjectsMCPConfig(t *testing.T) {
+	_, withMCP := buildOrchestratorLaunch("linux", "", false, "", "", "/cfg/orchestrator-mcp-petios3.json")
+	if joined := strings.Join(withMCP, " "); !strings.Contains(joined, `--mcp-config "/cfg/orchestrator-mcp-petios3.json"`) {
+		t.Fatalf("expected --mcp-config in launch, got: %s", joined)
+	}
+
+	_, withoutMCP := buildOrchestratorLaunch("linux", "", false, "", "", "")
+	if joined := strings.Join(withoutMCP, " "); strings.Contains(joined, "--mcp-config") {
+		t.Fatalf("expected no --mcp-config when path empty, got: %s", joined)
+	}
+}
+
+func TestSanitizeOrchestratorFileID(t *testing.T) {
+	for in, want := range map[string]string{
+		"petios3":     "petios3",
+		"va1":         "va1",
+		"a/b c":       "a-b-c",
+		"":            "default",
+		"weird..name": "weird--name",
+	} {
+		if got := sanitizeOrchestratorFileID(in); got != want {
+			t.Fatalf("sanitizeOrchestratorFileID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/erun-ui/orchestrator_test.go
+++ b/erun-ui/orchestrator_test.go
@@ -39,7 +39,7 @@ func orchestratorTestApp(t *testing.T) *App {
 		startTerminal: func(startTerminalSessionParams) (terminalSession, error) {
 			return newStubTerminalSession(), nil
 		},
-		resolveOrchestratorLaunch: func(string, string, string) (string, []string, error) {
+		resolveOrchestratorLaunch: func(string, string, string, string) (string, []string, error) {
 			return "claude-stub", nil, nil
 		},
 	})
@@ -189,7 +189,7 @@ func TestSpawnOrchestratorSessionExposesOrchestratorID(t *testing.T) {
 			capturedEnv = p.Env
 			return newStubTerminalSession(), nil
 		},
-		resolveOrchestratorLaunch: func(string, string, string) (string, []string, error) { return "claude-stub", nil, nil },
+		resolveOrchestratorLaunch: func(string, string, string, string) (string, []string, error) { return "claude-stub", nil, nil },
 	})
 	defer app.shutdown(context.Background())
 
@@ -269,7 +269,7 @@ func TestInvestigateFailureSpawnsTransientTenantScopedOrchestrator(t *testing.T)
 		startTerminal: func(startTerminalSessionParams) (terminalSession, error) {
 			return newStubTerminalSession(), nil
 		},
-		resolveOrchestratorLaunch: func(_, prompt, _ string) (string, []string, error) {
+		resolveOrchestratorLaunch: func(_, prompt, _, _ string) (string, []string, error) {
 			seededPrompt = prompt
 			return "claude-stub", nil, nil
 		},
@@ -532,7 +532,7 @@ func TestOrchestratorSessionStartHookPreservesExistingSettings(t *testing.T) {
 
 func TestBuildOrchestratorLaunchResumesWithUltracodeOpus(t *testing.T) {
 	// No pinned session id (legacy/transient) keeps the continue-else-fresh path.
-	_, posix := buildOrchestratorLaunch("linux", "", false, "", "")
+	_, posix := buildOrchestratorLaunch("linux", "", false, "", "", "")
 	posixCmd := posix[len(posix)-1]
 	for _, want := range []string{"claude --continue", "ultracode", "--model opus", " || claude"} {
 		if !strings.Contains(posixCmd, want) {
@@ -540,7 +540,7 @@ func TestBuildOrchestratorLaunchResumesWithUltracodeOpus(t *testing.T) {
 		}
 	}
 
-	_, win := buildOrchestratorLaunch("windows", "", false, "", "")
+	_, win := buildOrchestratorLaunch("windows", "", false, "", "", "")
 	winCmd := win[len(win)-1]
 	for _, want := range []string{"claude --continue", "ultracode", "--model opus", "$LASTEXITCODE"} {
 		if !strings.Contains(winCmd, want) {
@@ -549,7 +549,7 @@ func TestBuildOrchestratorLaunchResumesWithUltracodeOpus(t *testing.T) {
 	}
 
 	// A seeded (Investigate) launch is a fresh session — no resume.
-	_, seeded := buildOrchestratorLaunch("linux", "", false, "fix the thing", "")
+	_, seeded := buildOrchestratorLaunch("linux", "", false, "fix the thing", "", "")
 	seededCmd := seeded[len(seeded)-1]
 	if strings.Contains(seededCmd, "--continue") {
 		t.Fatalf("seeded launch must not resume: %q", seededCmd)
@@ -565,13 +565,13 @@ func TestBuildOrchestratorLaunchResumesWithUltracodeOpus(t *testing.T) {
 func TestBuildOrchestratorLaunchPinsPerOrchestratorSession(t *testing.T) {
 	const sid = "6f7e9c2a-1b3d-4e5f-8a9b-000000000001"
 
-	_, existing := buildOrchestratorLaunch("linux", sid, true, "", "")
+	_, existing := buildOrchestratorLaunch("linux", sid, true, "", "", "")
 	cmd := existing[len(existing)-1]
 	if !strings.Contains(cmd, "--resume "+sid) || strings.Contains(cmd, "--continue") {
 		t.Fatalf("existing session must --resume its own id, not --continue: %q", cmd)
 	}
 
-	_, firstOpen := buildOrchestratorLaunch("linux", sid, false, "", "")
+	_, firstOpen := buildOrchestratorLaunch("linux", sid, false, "", "", "")
 	fresh := firstOpen[len(firstOpen)-1]
 	if !strings.Contains(fresh, "--session-id "+sid) {
 		t.Fatalf("first open must create the pinned session: %q", fresh)
@@ -580,7 +580,7 @@ func TestBuildOrchestratorLaunchPinsPerOrchestratorSession(t *testing.T) {
 		t.Fatalf("first open must not continue/resume: %q", fresh)
 	}
 
-	_, win := buildOrchestratorLaunch("windows", sid, true, "", "finish the task")
+	_, win := buildOrchestratorLaunch("windows", sid, true, "", "finish the task", "")
 	if wcmd := win[len(win)-1]; !strings.Contains(wcmd, "--resume "+sid) || !strings.Contains(wcmd, "finish the task") {
 		t.Fatalf("windows pinned resume+prompt missing pieces: %q", wcmd)
 	}
@@ -607,7 +607,7 @@ func TestOrchestratorSessionIDIsStableAndDistinct(t *testing.T) {
 func TestBuildOrchestratorLaunchResumeWithPromptRunsIt(t *testing.T) {
 	const prompt = "verify the rebuild is live, then finish the task"
 
-	_, posix := buildOrchestratorLaunch("linux", "", false, "", prompt)
+	_, posix := buildOrchestratorLaunch("linux", "", false, "", prompt, "")
 	posixCmd := posix[len(posix)-1]
 	for _, want := range []string{"claude --continue", prompt, " || claude", "ultracode", "--model opus"} {
 		if !strings.Contains(posixCmd, want) {
@@ -619,7 +619,7 @@ func TestBuildOrchestratorLaunchResumeWithPromptRunsIt(t *testing.T) {
 		t.Fatalf("expected the resume prompt on both branches: %q", posixCmd)
 	}
 
-	_, win := buildOrchestratorLaunch("windows", "", false, "", prompt)
+	_, win := buildOrchestratorLaunch("windows", "", false, "", prompt, "")
 	winCmd := win[len(win)-1]
 	for _, want := range []string{"claude --continue", prompt, "$LASTEXITCODE"} {
 		if !strings.Contains(winCmd, want) {
@@ -628,7 +628,7 @@ func TestBuildOrchestratorLaunchResumeWithPromptRunsIt(t *testing.T) {
 	}
 
 	// initialPrompt still wins over resumePrompt (a seeded fresh session ignores resume).
-	_, seeded := buildOrchestratorLaunch("linux", "", false, "fix the thing", prompt)
+	_, seeded := buildOrchestratorLaunch("linux", "", false, "fix the thing", prompt, "")
 	if seededCmd := seeded[len(seeded)-1]; strings.Contains(seededCmd, "--continue") {
 		t.Fatalf("initialPrompt must take precedence over resumePrompt (fresh, no resume): %q", seededCmd)
 	}


### PR DESCRIPTION
Closes #881.

### Problem
A host-side orchestrator is meant to drive its linked environments through each env's **erun MCP** (the `emcp` server in the pod's `erun-mcp` sidecar — `raw`/`diff`/`build`/`push`/`deploy`/`outputs_*`). But the desktop never wired that MCP into the orchestrator's Claude Code session, so the orchestrator had no erun MCP tools and was forced to bypass with `kubectl`. The env MCP edge is 401-gated behind a bearer only the desktop's identity key can sign (`app.go` `mcpBearer` → `identity.signToken`).

### Change
When `spawnOrchestratorSession` launches (or resumes) an orchestrator, it now writes a **per-orchestrator** Claude Code `--mcp-config` file — one HTTP MCP server per linked env, `http://127.0.0.1:<mcp-port>/mcp` with `Authorization: Bearer <mcpBearer(tenant,env)>` — and threads `--mcp-config <path>` into the launch (`buildOrchestratorLaunch`). Ports resolve from each env's local port range (`ResolveEnvironmentLocalPorts`); bearers reuse the existing desktop-signed `mcpBearer`.

A **per-orchestrator file** (sibling of `orchestrator-restore.json` under `UserConfigDir()/ERun`), not a shared-workspace `.mcp.json`, keeps each orchestrator's envs isolated and correct across MCP reconnects (all orchestrators share one workspace dir). Writing the config is **non-fatal** — an orchestrator still launches without the env MCP. Bearers are minted fresh per launch/resume; they expire, so a longer-lived refresh is a noted follow-up.

Files: `erun-ui/orchestrator_mcp.go` (new), `erun-ui/orchestrator_mcp_test.go` (new), `erun-ui/orchestrator.go` (launch threading + writer call), `erun-ui/app.go` (dep signature), `erun-ui/orchestrator_test.go` (call sites).

### Validation
- `go build ./...` + `go vet ./...` clean in `erun-ui`.
- `go test ./... -run 'Orchestrator|MCPConfig|Sanitize'` green — covers the config assembly (URL from port, bearer header, skips envs missing a port/bearer), the `--mcp-config` launch injection, and every call site whose signature changed. The full `erun-ui` suite was too slow to complete in-session under concurrent load; recommend a full `go test ./...` before merge.
- **End-to-end** (the env MCP tools actually appearing in a running orchestrator session) requires a **desktop rebuild + restart** — manual verification step, not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)