### PR TITLE
Fix erun build/push aborting when the tenant's -devops/k8s is absent

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -40,10 +40,29 @@ MSG
   fi
   GO_MODULE_DIRS=$(find "$REPO_ROOT" -name go.mod -not -path '*/node_modules/*' -not -path '*/.git/*' -exec dirname {} \; | sort)
   for module_dir in $GO_MODULE_DIRS; do
+    # A module nested inside another module's tree (an ancestor dir carries its
+    # own go.mod) is isolated by design and kept out of the parent's go.work —
+    # e.g. the playwright winstub fixture, which seedRoot.ts builds with
+    # GOWORK=off. Under the ambient workspace golangci-lint would reject it
+    # ("directory prefix . does not contain modules listed in go.work") and abort
+    # the whole hook, so lint it standalone the same way it is built.
+    gowork_off=
+    ancestor=$(dirname "$module_dir")
+    while [ "$ancestor" != "$REPO_ROOT" ] && [ "$ancestor" != "/" ]; do
+      if [ -f "$ancestor/go.mod" ]; then
+        gowork_off=1
+        break
+      fi
+      ancestor=$(dirname "$ancestor")
+    done
     printf 'golangci-lint --fix %s\n' "${module_dir#"$REPO_ROOT"/}"
     (
       cd "$module_dir"
-      golangci-lint run --fix ./...
+      if [ -n "$gowork_off" ]; then
+        GOWORK=off golangci-lint run --fix ./...
+      else
+        golangci-lint run --fix ./...
+      fi
     )
   done
   printf 'Restaging Go files touched by golangci-lint...\n'

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -2600,6 +2600,12 @@ func isKubernetesDeployModuleDir(dir string) (bool, error) {
 		if err.Error() == "helm chart not found in current directory" {
 			return false, nil
 		}
+		// An absent directory is simply not a deploy-module dir. Every caller
+		// probes a conventional <…>-devops/k8s location that need not exist,
+		// so a missing path answers the predicate rather than failing it.
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
 		return false, err
 	}
 	return len(deployContexts) > 0, nil
@@ -3347,12 +3353,13 @@ func discoverComponentChartDirs(projectRoot string) ([]KubernetesDeployContext, 
 // componentChartsK8sDir resolves the directory whose subdirectories are the
 // project's component charts, scoped so a brownfield tenant's own unrelated
 // k8s/*/Chart.yaml trees are never treated as publishable component charts.
-// Resolution order: the paths.k8s override; else, when a tenant is detected for
-// this project root, ONLY that tenant's <tenant>-devops/k8s — returning "no
-// charts" when it is absent rather than falling through to an unrelated -devops
-// module (deploy's runtime-chart lookup is name-scoped the same way); else, for a
-// tenant-less project (e.g. erun releasing itself), the single -devops/k8s
-// convention scan.
+// The paths.k8s override wins; otherwise resolution matches deploy's runtime
+// chart lookup exactly (resolveProjectRootDevopsK8sDir): the tenant's own
+// <tenant>-devops/k8s when present, else the single -devops/k8s convention
+// module. Only -devops modules are ever considered, so unrelated k8s trees stay
+// excluded whichever branch resolves — and build/push/deploy discover the same
+// charts, which the release-repo shape (repo basename != devops module prefix)
+// relies on.
 func componentChartsK8sDir(projectRoot string) (string, bool, error) {
 	projectRoot = filepath.Clean(strings.TrimSpace(projectRoot))
 	if projectRoot == "" {
@@ -3361,35 +3368,7 @@ func componentChartsK8sDir(projectRoot string) (string, bool, error) {
 	if dir, ok, err := configuredK8sDir(projectRoot); err != nil || ok {
 		return dir, ok, err
 	}
-	if tenant, detectedRoot, err := FindProjectRoot(); err == nil &&
-		filepath.Clean(strings.TrimSpace(detectedRoot)) == projectRoot &&
-		strings.TrimSpace(tenant) != "" {
-		k8sDir := filepath.Join(projectRoot, RuntimeReleaseName(tenant), "k8s")
-		ok, err := isKubernetesDeployModuleDir(k8sDir)
-		if err != nil {
-			return "", false, err
-		}
-		return k8sDir, ok, nil
-	}
-	return singleDevopsK8sDir(projectRoot)
-}
-
-// singleDevopsK8sDir returns the sole <name>-devops/k8s chart module under
-// projectRoot, for a tenant-less project where the tenant name cannot scope the
-// lookup; it errors when more than one exists rather than guessing.
-func singleDevopsK8sDir(projectRoot string) (string, bool, error) {
-	candidates, err := findDevopsK8sDirs(projectRoot)
-	if err != nil {
-		return "", false, err
-	}
-	switch len(candidates) {
-	case 0:
-		return "", false, nil
-	case 1:
-		return candidates[0], true, nil
-	default:
-		return "", false, fmt.Errorf("multiple devops k8s directories found under project root")
-	}
+	return resolveProjectRootDevopsK8sDir(FindProjectRoot, projectRoot)
 }
 
 func componentHelmChartCandidate(path string, d fs.DirEntry, componentName string, err error) (string, bool, error) {

--- a/erun-ui/orchestrator_mcp.go
+++ b/erun-ui/orchestrator_mcp.go
@@ -26,8 +26,10 @@ type orchestratorMCPConfig struct {
 
 // mcpPortResolver and bearerSigner are seams so the config assembly is unit
 // testable without a live config store or signing identity.
-type mcpPortResolver func(tenant, environment string) int
-type bearerSigner func(tenant, environment string) string
+type (
+	mcpPortResolver func(tenant, environment string) int
+	bearerSigner    func(tenant, environment string) string
+)
 
 // buildOrchestratorMCPConfig assembles the per-env MCP server map, keyed
 // "<tenant>-<environment>". An env is skipped (not an error) when its MCP port

--- a/erun-ui/orchestrator_mcp_test.go
+++ b/erun-ui/orchestrator_mcp_test.go
@@ -7,6 +7,30 @@ import (
 	eruncommon "github.com/sophium/erun/erun-common"
 )
 
+// orchestratorTestPort/Bearer are the port and bearer stubs the config builder
+// is driven with; extracted from the test body so its own branching stays under
+// the cyclop threshold. nobearer resolves a port but an empty bearer, so the
+// builder must still skip it.
+func orchestratorTestPort(tenant, _ string) int {
+	switch tenant {
+	case "petios":
+		return 17400
+	case "erun":
+		return 17300
+	case "nobearer":
+		return 18000
+	default:
+		return 0
+	}
+}
+
+func orchestratorTestBearer(tenant, _ string) string {
+	if tenant == "nobearer" {
+		return ""
+	}
+	return "tok-" + tenant
+}
+
 func TestBuildOrchestratorMCPConfig(t *testing.T) {
 	envs := []eruncommon.OrchestratorEnvConfig{
 		{Tenant: "petios", Environment: "rihards-win-develop"},
@@ -15,26 +39,8 @@ func TestBuildOrchestratorMCPConfig(t *testing.T) {
 		{Tenant: "nobearer", Environment: "y"}, // skipped: empty bearer
 		{Tenant: "", Environment: "z"},         // skipped: blank tenant
 	}
-	port := func(tenant, _ string) int {
-		switch tenant {
-		case "petios":
-			return 17400
-		case "erun":
-			return 17300
-		case "nobearer":
-			return 18000
-		default:
-			return 0
-		}
-	}
-	bearer := func(tenant, _ string) string {
-		if tenant == "nobearer" {
-			return ""
-		}
-		return "tok-" + tenant
-	}
 
-	config := buildOrchestratorMCPConfig(envs, port, bearer)
+	config := buildOrchestratorMCPConfig(envs, orchestratorTestPort, orchestratorTestBearer)
 
 	if len(config.MCPServers) != 2 {
 		t.Fatalf("expected 2 servers, got %d: %v", len(config.MCPServers), config.MCPServers)

--- a/erun-ui/playwright/fixtures/winstub/main.go
+++ b/erun-ui/playwright/fixtures/winstub/main.go
@@ -51,7 +51,7 @@ func main() {
 			// activity_queue_app.go), then block so the tab behaves like a healthy,
 			// quiet, killable session.
 			fmt.Print("erun@playwright:~$ \n")
-			os.Stdout.Sync()
+			_ = os.Stdout.Sync()
 			blockForever() // stay alive like `exec sleep`; killed on env close via taskkill
 		}
 		os.Exit(0)


### PR DESCRIPTION
## Symptom
Since #886 (`cb29cb8d`), a runtime-image rebuild re-ran the in-image `make check` gate and it went **red** across ~two dozen `TestBuild`/`TestPush` scenarios — every `erun build`/`push`/`release` aborting with:

```
open <projectRoot>/<tenant>-devops/k8s: no such file or directory
```

This blocks the image build (and therefore release), since the gate runs inside the `erun-devops` Dockerfile `test` stage.

## Root cause
`FindProjectRoot()` returns the **repo basename** as the tenant. #886's `componentChartsK8sDir` scoped component-chart discovery strictly to `<tenant>-devops/k8s` and, by design, returned "no charts" when that directory was absent — never falling back. Two defects followed:

1. `isKubernetesDeployModuleDir` only swallowed the literal `"helm chart not found"` error, so a **missing** directory (`os.ReadDir` → `ErrNotExist`) propagated as a hard failure.
2. When the repo basename differs from the devops module prefix — the release-repo shape (module `erun-devops`, basename `cwd` under test; and any real tenant repo) — `<tenant>-devops/k8s` never exists, so discovery found nothing and dropped the component charts. This diverged from the **deploy** side (`resolveProjectRootDevopsK8sDir`), which resolves the tenant's own `<tenant>-devops/k8s` first and then **falls back** to the single `-devops/k8s` convention.

## Fix
- `isKubernetesDeployModuleDir`: treat `os.ErrNotExist` as `(false, nil)` — a missing dir is simply not a deploy-module dir. Fixes all seven call sites.
- Unify `componentChartsK8sDir` with the deploy-side resolver (`paths.k8s` override, then `resolveProjectRootDevopsK8sDir`), so build/push/deploy discover the same charts. Removes the now-redundant `singleDevopsK8sDir`. Only `-devops` modules are ever considered, so #886's brownfield protection is preserved.

## Pre-existing findings cleared in the same PR
The local pre-commit hook (which lints every module, including `erun-ui`) surfaced issues invisible to the in-image gate (`LINT_MODULES` excludes `erun-ui`) and to GitHub squash-merges (which don't run the local hook):

- **pre-commit hook**: lint nested isolated modules (an ancestor dir carries a `go.mod`) with `GOWORK=off`, matching how `seedRoot.ts` builds the playwright `winstub` fixture. Without this the ambient `erun-ui/go.work` shadowed the nested module and golangci-lint aborted the entire hook (exit 7) — silently blocking **every** local Go commit since the fixture landed (#855).
- **winstub errcheck**: check `os.Stdout.Sync()`.
- **erun-ui cyclop**: `TestBuildOrchestratorMCPConfig` (complexity 14 > 10) — extract the port/bearer stubs into named helpers; gofumpt groups the adjacent `type` decls in `orchestrator_mcp.go`.

## Validation
- `make check` (lint + integration suite + coverage) green; the previously-red `TestBuild`/`TestPush` scenarios pass again **with no golden changes** (the fix restores the expected discovery, it doesn't rewrite expectations).
- Local pre-commit hook now completes across all Go modules including the winstub fixture.

## Docs
No `erun-docs` change: this is a behaviour-restoring bug fix (returns discovery to its pre-#886 contract) plus repo-tooling/lint cleanup — no public surface change.

Closes #889