### PR TITLE
Scrub the integration suite inherited PATH so no scenario resolves an ambient binary

### DIFF
--- a/erun-common/activity.go
+++ b/erun-common/activity.go
@@ -213,13 +213,17 @@ func environmentIdleMarkers(activity map[string]EnvironmentActivitySnapshot, lea
 }
 
 func environmentStopEligibility(markers []EnvironmentIdleMarker, outsideWorkingHours bool) (bool, int64) {
-	if outsideWorkingHours {
-		return true, 0
-	}
 	stopEligible := true
 	secondsUntilStop := int64(0)
 	for _, marker := range markers {
 		if marker.Name == "working-hours" || marker.Idle {
+			continue
+		}
+		// Outside working hours the quiet signals no longer hold the environment
+		// up. A lease is not a quiet signal: it is a job saying it is running
+		// right now, so it blocks the stop whatever the clock says — otherwise an
+		// agent run started at 19:59 loses its environment a minute later.
+		if outsideWorkingHours && marker.Name != environmentActivityLeaseMarker {
 			continue
 		}
 		stopEligible = false

--- a/erun-integration/AGENTS.md
+++ b/erun-integration/AGENTS.md
@@ -68,6 +68,23 @@ Per the root `AGENTS.md`, `--dry-run` must produce a complete, side-effect-free 
 - `fixture.SeedGitRepo(t, dir)` runs `git init` + commit so release/diff/exec see a project root.
 - For commands that prompt interactively, prefer flags that bypass prompts (`--confirm-environment`, `--set-default-tenant=true`, `-y`) over scripted stdin. Goldens are easier to read without prompt redrawing.
 
+## The PATH is scrubbed: nothing ambient is reachable
+
+`setup.Env()` sets `PATH` to one generated directory (`setup.PathDir`) and does **not** inherit the host's. No host-installed binary is reachable from a scenario unless the scenario declared it. This is the contract that keeps the gate a contributor runs and the gate that blocks a release from disagreeing: the runtime image's test stage runs `make check` with no kubectl, helm, docker, aws or gh, while every developer machine and the agent pod have all of them. Before the scrub, a scenario that reached for an ambient binary recorded that host's answer into its golden and went red only inside the image build — eleven minutes into `erun build`, after the release tag was already cut.
+
+What the scrubbed PATH holds, both declared in `internal/env/env.go`:
+
+- `shellUtilities` — forwarders for the POSIX utilities the suite's **own stub scripts** use (`cat`, `dirname`, `mkdir`, `sleep`, `touch`, `tr`, `wc`). A stub runs as a child of the binary under test and inherits its PATH, so without these a stub that keeps a counter file cannot run. Add a name here only for a utility a stub body needs; never for a tool erun itself invokes.
+- `hostTools` — routed through their `ERUN_<NAME>_BIN` seam at an absolute path rather than through PATH. `git` only: the fixtures build real repositories with it and the release/diff/exec scenarios read real git state, so no stub can stand in for it. Treat any addition here as a new host prerequisite for the whole suite, and justify it.
+
+Consequences for writing a scenario:
+
+- A command that invokes an external binary needs a declared stub — `fixture.Stub*` plus `fixture.StubEnv` for anything reached through `eruncommon.Command`, or a stub directory prepended to PATH for anything reached through `exec.LookPath` (`gh`, `dpkg-deb`, the IDE launchers).
+- When a scenario prepends its own PATH entry, append `setup.PathDir` after it (`"PATH="+stubs+string(os.PathListSeparator)+setup.PathDir`) rather than `os.Getenv("PATH")`, or that scenario alone goes back to seeing the whole host.
+- `erun.Run` fails the test when the captured output shows `exec: "<name>": executable file not found`, naming the binary. That is the authoring-time signal: the scenario reached past its declared stubs.
+- A scenario that wants a binary to be *absent* needs no override — it already is. Say so in the test comment so a reader knows the absence is the point.
+- Nothing in the suite may gate on host capability. `runtime.GOOS` checks and `exec.LookPath` probes in test bodies were how host dependence used to hide: they turned into a `t.Skip` on some machines and a live tool on others, so a shared-fixture change could leave a golden stale and green everywhere except the image build. Pin the host through `ERUN_HOST_OS_OVERRIDE` and the tool through a stub instead — `TestRelease/dry_run_includes_linux_release_scripts` does both and runs everywhere as a result.
+
 ## Stubbing rules: dry-run-first, decision-input second
 
 Integration scenarios run `erun` in `--dry-run` mode by default. Dry-run is meant to be fully auditable: every action and every decision must surface as a trace line, so a complete dry-run output is sufficient evidence that the command would behave correctly. Pile on stubs only when the dry-run trace already shows the action; never use stubs to *replace* a missing trace.
@@ -142,16 +159,18 @@ Rules:
 - Document the override in the test comment so a future reader does not delete it. Without the override the scenario would silently re-shape the golden to whatever host ran `UPDATE_GOLDEN=1` last.
 - The override is a deliberate test seam, not a production knob. If you find yourself wanting to set it from a CLI command or MCP tool, that is a sign the production code should be detecting differently — fix the detection.
 
-### Linux-only scenarios skip on macOS — regenerate their goldens in Linux
+### Do not gate a scenario on a real host capability
 
-A few scenarios gate on a real Linux capability the override can't fake — notably `TestRelease/dry_run_includes_linux_release_scripts`, which needs both `runtime.GOOS == "linux"` **and** `dpkg-deb` on PATH (linux package builds), so it `t.Skip`s on macOS. `ERUN_HOST_OS_OVERRIDE` only fakes `DetectHost`; it does not conjure `dpkg-deb`, so these goldens can only be regenerated where the capability actually exists.
+No scenario skips on host OS or on a tool being installed, and none may start doing so. `TestRelease/dry_run_includes_linux_release_scripts` used to need both `runtime.GOOS == "linux"` **and** `dpkg-deb` on PATH, so it skipped on macOS; it now pins `ERUN_HOST_OS_OVERRIDE=linux` and declares a `dpkg-deb` stub on PATH, and runs everywhere.
 
-The trap: `UPDATE_GOLDEN=1` on macOS silently **skips** these scenarios, so a change to a **shared fixture** (e.g. `SeedReleaseRepo`) that alters their output leaves their goldens stale — green locally on macOS, red in the Linux image-build gate (`make check` inside the `erun-devops` Dockerfile), which is where it actually bites. When you touch a shared fixture, regenerate the linux-only goldens in Linux and run the full suite there before pushing:
+The trap that pattern created is why it is banned: `UPDATE_GOLDEN=1` on a host that skips the scenario leaves its golden un-regenerated, so a change to a **shared fixture** (e.g. `SeedReleaseRepo`) that alters its output goes green locally and red in the Linux image-build gate (`make check` inside the `erun-devops` Dockerfile) — the one place nobody is watching until `erun build` fails. A skipped scenario is not covered, and a scenario nobody notices is uncovered is worse than none.
+
+The Linux container run is still the closest local stand-in for the image-build gate, and worth one pass when you touch a shared fixture or the harness itself:
 
 ```sh
 docker run --rm -u "$(id -u):$(id -g)" -e HOME=/tmp -e GOCACHE=/tmp/gc -e GOMODCACHE=/tmp/gm \
   -v "$PWD":/src -w /src/erun-integration golang:1.26 sh -c \
-  'git config --global --add safe.directory "*"; UPDATE_GOLDEN=1 go test ./... && go test ./...'
+  'git config --global --add safe.directory "*"; go test ./...'
 ```
 
 ## TTY-dependent branches: force via `ERUN_FORCE_TTY`

--- a/erun-integration/activity_test.go
+++ b/erun-integration/activity_test.go
@@ -19,9 +19,32 @@ import (
 // activity is a hidden command group the runtime entrypoint uses to record
 // SSH/MCP/CLI/Codex traffic; its subcommands are exercised here.
 
+// The working-hours window decides which arm of the stop-eligibility branch a
+// scenario takes, and the resolved policy always has one (the default is
+// 08:00-20:00 in the host's zone), so a scenario that leaves it alone exercises
+// a different arm depending on the wall clock and the host's TZ. These two
+// blocks pin the arm: each is the widest window the parser accepts (start and
+// end must differ), inverted, so only the 23:59 UTC minute falls on the other
+// side. Landing on the other side there costs nothing — a held lease refuses the
+// stop identically on both arms, which is the point these scenarios make — so
+// what the pin buys is that each scenario reliably exercises the arm it names.
+const (
+	insideWorkingHoursIdleBlock  = "idle:\n  workinghours: 00:00-23:59\n  timezone: UTC\n"
+	outsideWorkingHoursIdleBlock = "idle:\n  workinghours: 23:59-00:00\n  timezone: UTC\n"
+)
+
 // seedManagedCloudTenantEnv marks the seeded env cloud-managed so the idle
 // resolver's Arm/Wait/Fire branches become reachable.
 func seedManagedCloudTenantEnv(t *testing.T, setup env.Setup, tenant, environment string) {
+	t.Helper()
+	seedManagedCloudTenantEnvWithIdle(t, setup, tenant, environment, "")
+}
+
+// seedManagedCloudTenantEnvWithIdle is seedManagedCloudTenantEnv with an
+// explicit idle block appended, so a scenario whose outcome depends on the
+// working-hours window can pin that window instead of inheriting the default
+// 08:00-20:00 and reading differently depending on the wall clock.
+func seedManagedCloudTenantEnvWithIdle(t *testing.T, setup env.Setup, tenant, environment, idleBlock string) {
 	t.Helper()
 	fixture.SeedTenantEnv(t, setup, tenant, environment)
 	cfgPath := filepath.Join(setup.ConfigHome, "erun", tenant, environment, "config.yaml")
@@ -29,7 +52,9 @@ func seedManagedCloudTenantEnv(t *testing.T, setup env.Setup, tenant, environmen
 	if err != nil {
 		t.Fatalf("read env config %s: %v", cfgPath, err)
 	}
-	if err := os.WriteFile(cfgPath, append(body, []byte("managedcloud: true\n")...), 0o644); err != nil {
+	body = append(body, []byte("managedcloud: true\n")...)
+	body = append(body, []byte(idleBlock)...)
+	if err := os.WriteFile(cfgPath, body, 0o644); err != nil {
 		t.Fatalf("write env config %s: %v", cfgPath, err)
 	}
 }
@@ -743,9 +768,12 @@ func TestActivity(t *testing.T) {
 	t.Run("stop_ready_blocked_by_a_held_lease", func(t *testing.T) {
 		// AC6 of the stop work: an otherwise-idle cloud-managed env that holds a
 		// lease must not be stopped, and the refusal must name the lease so an
-		// operator can see why auto-stop is being deferred.
+		// operator can see why auto-stop is being deferred. The window is pinned
+		// to a UTC day so the scenario stays on the inside-working-hours arm
+		// whatever time the suite runs; its outside-hours sibling below pins the
+		// other arm.
 		setup := env.New(t)
-		seedManagedCloudTenantEnv(t, setup, "team", "dev")
+		seedManagedCloudTenantEnvWithIdle(t, setup, "team", "dev", insideWorkingHoursIdleBlock)
 		take := erun.Run(t, []string{"activity", "lease", "take", "--tenant", "team", "--environment", "dev", "--name", "agent-run", "--ttl", "1h"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
 		if take.ExitCode != 0 {
 			t.Fatalf("take: exit %d: %s", take.ExitCode, take.Combined)
@@ -755,6 +783,28 @@ func TestActivity(t *testing.T) {
 			t.Fatalf("expected a leased env to refuse the stop, got exit 0:\n%s", result.Combined)
 		}
 		golden.Equal(t, "activity/stop_ready_blocked_by_a_held_lease", normalize.Apply(result.Combined))
+		if _, err := os.Stat(filepath.Join(setup.Home, ".erun", "team", "dev", "stop-pending.json")); !os.IsNotExist(err) {
+			t.Errorf("a leased env must not arm a grace window, stat err: %v", err)
+		}
+	})
+
+	t.Run("stop_ready_blocked_by_a_held_lease_outside_working_hours", func(t *testing.T) {
+		// The lease clause is absolute: outside working hours the quiet signals
+		// stop holding the environment up, but a held lease still does, or an
+		// agent run that starts near the end of the window loses its environment
+		// mid-job. Same refusal, same withheld grace window, other arm of the
+		// working-hours branch.
+		setup := env.New(t)
+		seedManagedCloudTenantEnvWithIdle(t, setup, "team", "dev", outsideWorkingHoursIdleBlock)
+		take := erun.Run(t, []string{"activity", "lease", "take", "--tenant", "team", "--environment", "dev", "--name", "agent-run", "--ttl", "1h"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if take.ExitCode != 0 {
+			t.Fatalf("take: exit %d: %s", take.ExitCode, take.Combined)
+		}
+		result := erun.Run(t, []string{"activity", "stop-ready", "--tenant", "team", "--environment", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected a leased env to refuse the stop outside working hours, got exit 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "activity/stop_ready_blocked_by_a_held_lease_outside_working_hours", normalize.Apply(result.Combined))
 		if _, err := os.Stat(filepath.Join(setup.Home, ".erun", "team", "dev", "stop-pending.json")); !os.IsNotExist(err) {
 			t.Errorf("a leased env must not arm a grace window, stat err: %v", err)
 		}

--- a/erun-integration/api_test.go
+++ b/erun-integration/api_test.go
@@ -1,8 +1,6 @@
 package integration
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/sophium/erun/erun-integration/internal/env"
@@ -11,18 +9,6 @@ import (
 	"github.com/sophium/erun/erun-integration/internal/golden"
 	"github.com/sophium/erun/erun-integration/internal/normalize"
 )
-
-// emptyPathDir yields a PATH override that makes "binary not on PATH"
-// deterministic: os/exec keeps the last duplicate Env value, so appending
-// it after setup.Env() reliably shadows whatever the host has installed.
-func emptyPathDir(t *testing.T, root string) string {
-	t.Helper()
-	dir := filepath.Join(root, "empty-path")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("mkdir %s: %v", dir, err)
-	}
-	return "PATH=" + dir
-}
 
 func TestAPI(t *testing.T) {
 	t.Run("help", func(t *testing.T) {
@@ -90,11 +76,11 @@ exit 0`)
 
 	t.Run("real_run_errors_when_eapi_missing", func(t *testing.T) {
 		// A missing eapi must surface the friendly "build or install it
-		// first" message, not a raw exec error.
+		// first" message, not a raw exec error. The scenario's scrubbed PATH is
+		// what makes eapi absent, on every host.
 		setup := env.New(t)
 		fixture.SeedTenantEnv(t, setup, "team", "dev")
-		envVars := append(setup.Env(), emptyPathDir(t, setup.Cwd))
-		result := erun.Run(t, []string{"api", "team", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		result := erun.Run(t, []string{"api", "team", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
 		if result.ExitCode == 0 {
 			t.Fatalf("expected non-zero exit when eapi is missing, got 0:\n%s", result.Combined)
 		}

--- a/erun-integration/app_test.go
+++ b/erun-integration/app_test.go
@@ -66,10 +66,10 @@ exit 0`)
 
 	t.Run("real_run_errors_when_app_binary_missing", func(t *testing.T) {
 		// A missing erun-app must surface the friendly build-or-install
-		// message rather than a raw exec error.
+		// message rather than a raw exec error. The scenario's scrubbed PATH is
+		// what makes erun-app absent, on every host.
 		setup := env.New(t)
-		envVars := append(setup.Env(), emptyPathDir(t, setup.Cwd))
-		result := erun.Run(t, []string{"app"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		result := erun.Run(t, []string{"app"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
 		if result.ExitCode == 0 {
 			t.Fatalf("expected non-zero exit when erun-app is missing, got 0:\n%s", result.Combined)
 		}

--- a/erun-integration/build_test.go
+++ b/erun-integration/build_test.go
@@ -676,7 +676,7 @@ func TestBuild(t *testing.T) {
 		stubs := setup.Cwd + "/stubs"
 		fixture.StubBinary(t, stubs, "dpkg-deb", "")
 		envVars := append(setup.Env(), "ERUN_HOST_OS_OVERRIDE=linux")
-		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+os.Getenv("PATH"))
+		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+setup.PathDir)
 		result := erun.Run(t, []string{"build", "--version", "1.0.0", "--dry-run"}, erun.RunOptions{Cwd: pkgDir, Env: envVars})
 		if result.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
@@ -703,7 +703,7 @@ func TestBuild(t *testing.T) {
 		stubs := setup.Cwd + "/stubs"
 		fixture.StubBinary(t, stubs, "dpkg-deb", "")
 		envVars := append(setup.Env(), "ERUN_HOST_OS_OVERRIDE=linux")
-		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+os.Getenv("PATH"))
+		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+setup.PathDir)
 		result := erun.Run(t, []string{"build", "--version", "1.0.0"}, erun.RunOptions{Cwd: linuxDir, Env: envVars})
 		if result.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
@@ -738,7 +738,7 @@ func TestBuild(t *testing.T) {
 		fixture.StubBinary(t, stubs, "dpkg-deb", "")
 		envVars := append(setup.Env(), stubDockerNoLocalImages(t, setup)...)
 		envVars = append(envVars, "ERUN_HOST_OS_OVERRIDE=linux")
-		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+os.Getenv("PATH"))
+		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+setup.PathDir)
 		result := erun.Run(t, []string{"build", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
@@ -1019,7 +1019,7 @@ func TestBuild(t *testing.T) {
 		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker", "gh", "git", "helm")...)
 		// tryGHCRLoginViaGH gates on exec.LookPath("gh"), which reads PATH
 		// rather than the ERUN_<NAME>_BIN override.
-		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+os.Getenv("PATH"))
+		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+setup.PathDir)
 		envVars = append(envVars, "ERUN_AUTO_LOGIN_ON_PUSH=1")
 		// -vv so the `docker login ghcr.io` TraceCommand that gates the
 		// retry is locked in the golden; at lower verbosity the retry is

--- a/erun-integration/internal/env/env.go
+++ b/erun-integration/internal/env/env.go
@@ -5,9 +5,27 @@ package env
 
 import (
 	"os"
+	osexec "os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// shellUtilities are the POSIX utilities the suite's own stub scripts invoke
+// (counters, marker files, heredocs). They are forwarded into every scenario's
+// PATH because a stub runs as a child of the binary under test and inherits its
+// PATH; everything else the host has installed stays unreachable. Adding a name
+// here is a deliberate act: it must be a utility a stub script needs, never a
+// tool erun itself invokes.
+var shellUtilities = []string{"cat", "dirname", "mkdir", "sleep", "touch", "tr", "wc"}
+
+// hostTools are the host executables erun itself may resolve, forwarded through
+// their declared ERUN_<NAME>_BIN seam rather than through PATH. git is the
+// suite's one irreducible host dependency: the fixtures build real repositories
+// with it and the release/diff/exec scenarios read real git state, so no stub
+// could stand in for it. A scenario that wants a scripted git appends its own
+// ERUN_GIT_BIN after Env() (the later duplicate wins).
+var hostTools = []string{"git"}
 
 // Setup is the resolved environment for a single subprocess invocation.
 type Setup struct {
@@ -16,13 +34,18 @@ type Setup struct {
 	CacheHome  string
 	DataHome   string
 	Cwd        string
+	// PathDir is the scenario's entire PATH: the host's PATH is deliberately
+	// not inherited, so a command can only reach an external binary the
+	// scenario declared. See scrubbedPathDir.
+	PathDir string
+	// toolBins routes hostTools to their absolute host paths.
+	toolBins []string
 }
 
 // Env returns the subprocess environment as a fresh slice each call, so
 // callers can append scenario-specific vars.
 func (s Setup) Env() []string {
-	path := os.Getenv("PATH")
-	return []string{
+	return append([]string{
 		"HOME=" + s.Home,
 		"XDG_CONFIG_HOME=" + s.ConfigHome,
 		"XDG_CACHE_HOME=" + s.CacheHome,
@@ -34,7 +57,12 @@ func (s Setup) Env() []string {
 		"USERPROFILE=" + s.Home,
 		"LOCALAPPDATA=" + s.ConfigHome,
 		"APPDATA=" + s.ConfigHome,
-		"PATH=" + path,
+		// The scenario's PATH holds nothing but the utility forwarders in
+		// scrubbedPathDir. A command under test therefore behaves the same on a
+		// laptop, in the agent pod, and in the runtime image's test stage — none
+		// of which agree about what is installed — and a scenario that needs
+		// kubectl/helm/docker/aws must declare a stub for it.
+		"PATH=" + s.PathDir,
 		// LANG is required by some path-handling code that calls into glibc.
 		"LANG=C.UTF-8",
 		// Prevent the subprocess from picking up the developer's terminal
@@ -61,7 +89,7 @@ func (s Setup) Env() []string {
 		// Scenarios that exercise the downgrade guard append their own
 		// ERUN_MCP_AUTH_LIVE_PROBE_OVERRIDE after Env() (the later duplicate wins).
 		"ERUN_MCP_AUTH_LIVE_PROBE_OVERRIDE=",
-	}
+	}, s.toolBins...)
 }
 
 // New creates a fresh Setup rooted at a per-test temp directory.
@@ -92,5 +120,50 @@ func New(t testing.TB) Setup {
 		CacheHome:  cache,
 		DataHome:   data,
 		Cwd:        cwd,
+		PathDir:    scrubbedPathDir(t, filepath.Join(root, "path")),
+		toolBins:   hostToolBins(t),
 	}
+}
+
+// scrubbedPathDir builds the one directory a scenario's PATH points at: a
+// forwarder per shellUtilities entry, and nothing else. Forwarders rather than
+// the host's own bin directories, because those also hold whatever tools the
+// developer installed — the ambient kubectl that made a golden depend on the
+// recording machine. Forwarders rather than symlinks, because Windows hosts
+// cannot create them without elevation.
+func scrubbedPathDir(t testing.TB, dir string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	for _, name := range shellUtilities {
+		target := hostBinary(t, name)
+		body := "#!/bin/sh\n# erun integration PATH forwarder\nexec '" + filepath.ToSlash(target) + "' \"$@\"\n"
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o755); err != nil {
+			t.Fatalf("write PATH forwarder %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+// hostToolBins routes each hostTools entry to its absolute host path through the
+// ERUN_<NAME>_BIN seam production already honors, so the tool stays reachable
+// with the PATH scrubbed.
+func hostToolBins(t testing.TB) []string {
+	t.Helper()
+	out := make([]string, 0, len(hostTools))
+	for _, name := range hostTools {
+		seam := "ERUN_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_")) + "_BIN"
+		out = append(out, seam+"="+hostBinary(t, name))
+	}
+	return out
+}
+
+func hostBinary(t testing.TB, name string) string {
+	t.Helper()
+	path, err := osexec.LookPath(name)
+	if err != nil {
+		t.Fatalf("the integration suite needs %q on the host PATH: %v", name, err)
+	}
+	return path
 }

--- a/erun-integration/internal/erun/erun.go
+++ b/erun-integration/internal/erun/erun.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -135,7 +136,8 @@ type RunOptions struct {
 	Cwd string
 	// Env is the full environment for the subprocess (it replaces the parent
 	// environment except for GOCOVERDIR which the harness always injects).
-	// PATH should be included by callers that need it.
+	// Build it from env.Setup.Env(), which carries the scrubbed PATH; a
+	// scenario that needs an external binary appends its own stub routing.
 	Env     []string
 	Stdin   string
 	Timeout time.Duration
@@ -235,10 +237,34 @@ func Run(t testing.TB, args []string, opts RunOptions) Result {
 		t.Fatalf("erun timed out after %s; args=%v\n--- subprocess goroutine dump (stderr) ---\n%s", timeout, args, stderr.String())
 	}
 
-	return Result{
+	result := Result{
 		Stdout:   stdout.String(),
 		Stderr:   stderr.String(),
 		Combined: stdout.String() + stderr.String(),
 		ExitCode: exitCode,
+	}
+	reportUndeclaredBinaries(t, result.Combined)
+	return result
+}
+
+// missingBinary matches the exec error Go reports when a command resolves no
+// executable, in either platform's spelling.
+var missingBinary = regexp.MustCompile(`exec: "([^"]+)": executable file not found in [$%]PATH%?`)
+
+// reportUndeclaredBinaries turns a scenario's reliance on an ambient binary into
+// an immediate failure. The suite's PATH is scrubbed, so this message means the
+// command reached for an external binary the scenario never declared: on a host
+// that happens to have it installed the scenario would instead capture that
+// host's answer, and the golden would only reproduce where it was recorded.
+func reportUndeclaredBinaries(t testing.TB, combined string) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, match := range missingBinary.FindAllStringSubmatch(combined, -1) {
+		name := match[1]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		t.Errorf("erun.Run: the command resolved no %q, so this scenario depends on whatever the host has installed; declare a stub (fixture.StubBinaryAdvanced + fixture.StubEnv) and re-record the golden", name)
 	}
 }

--- a/erun-integration/mcp_test.go
+++ b/erun-integration/mcp_test.go
@@ -237,11 +237,11 @@ exit 0`)
 
 	t.Run("real_run_errors_when_emcp_missing", func(t *testing.T) {
 		// A missing emcp must surface the friendly "build or install it
-		// first" message, not a raw exec error.
+		// first" message, not a raw exec error. The scenario's scrubbed PATH is
+		// what makes emcp absent, on every host.
 		setup := env.New(t)
 		fixture.SeedTenantEnv(t, setup, "team", "dev")
-		envVars := append(setup.Env(), emptyPathDir(t, setup.Cwd))
-		result := erun.Run(t, []string{"mcp", "team", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		result := erun.Run(t, []string{"mcp", "team", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
 		if result.ExitCode == 0 {
 			t.Fatalf("expected non-zero exit when emcp is missing, got 0:\n%s", result.Combined)
 		}

--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -560,10 +560,14 @@ func TestOpen(t *testing.T) {
 		// about to use the env. The plan must show the wait and the exec that
 		// rewrites the erun-host profile, and the resolved region — this env has
 		// a provider alias but no cloud context, the shape that produced both
-		// the expired-credentials and the empty-AWS_REGION failures.
+		// the expired-credentials and the empty-AWS_REGION failures. The
+		// run-state stub answers the pre-forward replica probe with a running
+		// runtime — an unremarkable answer, because this scenario is about the
+		// credential refresh, not about the wake branch its sibling locks.
 		setup := env.New(t)
 		fixture.SeedLocalTenantEnvWithAWSAlias(t, setup, "team", "dev", "ops+123456789012@aws", "eu-west-2", "")
-		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		envVars := stubKubectlRunState(t, setup, 1, 1)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
@@ -822,7 +826,7 @@ func TestOpen(t *testing.T) {
 		ideLog := filepath.Join(setup.Cwd, "ide-launcher.log")
 		fixture.StubBinaryWithScript(t, stubsDir, "open",
 			`printf '%s\n' "$*" > '`+ideLog+`'`+"\n"+`exit 0`+"\n")
-		envVars = append(envVars, "PATH="+stubsDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+		envVars = append(envVars, "PATH="+stubsDir+string(os.PathListSeparator)+setup.PathDir)
 		// Pin darwin so the IDE launcher resolves to the stubbed macOS
 		// `open` command. On a Linux host production calls xdg-open, which
 		// this scenario does not stub. (erun-integration/AGENTS.md —
@@ -888,7 +892,7 @@ func TestOpen(t *testing.T) {
 		ideLog := filepath.Join(setup.Cwd, "ide-launcher.log")
 		fixture.StubBinaryWithScript(t, stubsDir, "open",
 			`printf '%s\n' "$*" >> '`+ideLog+`'`+"\n"+`exit 0`+"\n")
-		envVars = append(envVars, "PATH="+stubsDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+		envVars = append(envVars, "PATH="+stubsDir+string(os.PathListSeparator)+setup.PathDir)
 		// Pin darwin: this scenario seeds the macOS JetBrains options dir
 		// above and asserts the `open -a 'IntelliJ IDEA'` bootstrap, both
 		// macOS-shaped. Without the pin a Linux host resolves a different
@@ -997,7 +1001,7 @@ func TestOpen(t *testing.T) {
 		ideLog := filepath.Join(setup.Cwd, "ide-launcher.log")
 		fixture.StubBinaryWithScript(t, stubsDir, "open",
 			`printf '%s\n' "$*" >> '`+ideLog+`'`+"\n"+`exit 0`+"\n")
-		envVars = append(envVars, "PATH="+stubsDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+		envVars = append(envVars, "PATH="+stubsDir+string(os.PathListSeparator)+setup.PathDir)
 		envVars = append(envVars, "ERUN_HOST_OS_OVERRIDE=darwin")
 
 		run1 := erun.Run(t, []string{"open", "team", "dev", "--intellij", "--no-alias-prompt"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
@@ -1117,7 +1121,7 @@ func TestOpen(t *testing.T) {
 		ideaLog := filepath.Join(setup.Cwd, "idea-launcher.log")
 		fixture.StubBinaryWithScript(t, stubsDir, "idea",
 			`printf 'idea %s\n' "$*" > '`+ideaLog+`'`+"\n"+`exit 0`+"\n")
-		envVars = append(envVars, "PATH="+stubsDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+		envVars = append(envVars, "PATH="+stubsDir+string(os.PathListSeparator)+setup.PathDir)
 		envVars = append(envVars, "ERUN_HOST_OS_OVERRIDE=linux")
 		result := erun.Run(t, []string{"open", "team", "dev", "--intellij", "--no-alias-prompt"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {

--- a/erun-integration/push_test.go
+++ b/erun-integration/push_test.go
@@ -405,7 +405,7 @@ func TestPush(t *testing.T) {
 		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker", "gh")...)
 		// Force PATH so `exec.LookPath("gh")` finds our stub (production
 		// uses LookPath directly, not the ERUN_<NAME>_BIN override).
-		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+os.Getenv("PATH"))
+		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+setup.PathDir)
 		envVars = append(envVars, "ERUN_AUTO_LOGIN_ON_PUSH=1")
 		result := erun.Run(t, []string{"push", "--version", "1.0.0", "-v"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode == 0 {
@@ -462,7 +462,7 @@ func TestPush(t *testing.T) {
 		}, "\n"))
 		fixture.StubBinary(t, stubs, "helm", "")
 		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker", "gh", "helm")...)
-		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+os.Getenv("PATH"))
+		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+setup.PathDir)
 		envVars = append(envVars, "ERUN_AUTO_LOGIN_ON_PUSH=1", "ERUN_FORCE_TTY=1")
 		result := erun.Run(t, []string{"push", "--version", "1.0.0", "-v"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
@@ -502,7 +502,7 @@ func TestPush(t *testing.T) {
 			`esac`,
 		}, "\n"))
 		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker", "gh")...)
-		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+os.Getenv("PATH"))
+		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+setup.PathDir)
 		envVars = append(envVars, "ERUN_AUTO_LOGIN_ON_PUSH=1")
 		result := erun.Run(t, []string{"push", "--version", "1.0.0", "-v"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode == 0 {
@@ -542,7 +542,7 @@ func TestPush(t *testing.T) {
 			`esac`,
 		}, "\n"))
 		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker", "gh")...)
-		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+os.Getenv("PATH"))
+		envVars = append(envVars, "PATH="+stubs+string(os.PathListSeparator)+setup.PathDir)
 		envVars = append(envVars, "ERUN_AUTO_LOGIN_ON_PUSH=1", "ERUN_FORCE_TTY=1")
 		envVars = append(envVars, "ERUN_TENANT=team", "ERUN_ENVIRONMENT=dev")
 		result := erun.Run(t, []string{"push", "--version", "1.0.0", "-v"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})

--- a/erun-integration/release_test.go
+++ b/erun-integration/release_test.go
@@ -2,9 +2,7 @@ package integration
 
 import (
 	"os"
-	osexec "os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -129,17 +127,13 @@ func TestRelease(t *testing.T) {
 	})
 
 	t.Run("dry_run_includes_linux_release_scripts", func(t *testing.T) {
-		// Linux release scripts run only where package builds are actually
-		// supported (GOOS=linux + dpkg-deb on PATH), so this skips on other
-		// hosts. The build-only second component (build.sh, no release.sh) is
-		// a valid linux context that contributes no release script, exercising
-		// the skip-component branch.
-		if runtime.GOOS != "linux" {
-			t.Skip("linux release scripts only run on Linux hosts")
-		}
-		if _, err := osexec.LookPath("dpkg-deb"); err != nil {
-			t.Skip("linux release scripts require dpkg-deb in PATH")
-		}
+		// Linux release scripts run only where package builds are supported,
+		// which erun reads as a linux host that has dpkg-deb. Both halves are
+		// declared here — ERUN_HOST_OS_OVERRIDE for the host, a dpkg-deb stub on
+		// PATH for the tool — so the golden is the same on every host instead of
+		// describing whichever machine recorded it. The build-only second
+		// component (build.sh, no release.sh) is a valid linux context that
+		// contributes no release script, exercising the skip-component branch.
 		setup := env.New(t)
 		fixture.SeedReleaseRepo(t, setup.Cwd, "develop")
 		linuxComponentDir := filepath.Join(setup.Cwd, "erun-devops", "linux", "erun-cli")
@@ -159,7 +153,15 @@ func TestRelease(t *testing.T) {
 		fixture.RunGit(t, setup.Cwd, "add", ".")
 		fixture.RunGit(t, setup.Cwd, "commit", "-m", "add linux release script")
 
-		result := erun.Run(t, []string{"release", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		stubs := filepath.Join(setup.Cwd, "stubs")
+		fixture.StubBinary(t, stubs, "dpkg-deb", "")
+		envVars := append(setup.Env(),
+			"ERUN_HOST_OS_OVERRIDE=linux",
+			// The support check resolves dpkg-deb through exec.LookPath, so the
+			// stub has to be reachable on PATH rather than via ERUN_..._BIN.
+			"PATH="+stubs+string(os.PathListSeparator)+setup.PathDir,
+		)
+		result := erun.Run(t, []string{"release", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}

--- a/erun-integration/testdata/activity/stop_ready_blocked_by_a_held_lease_outside_working_hours.txt
+++ b/erun-integration/testdata/activity/stop_ready_blocked_by_a_held_lease_outside_working_hours.txt
@@ -1,0 +1,2 @@
+audit: erun activity stop-ready --environment dev --tenant team
+environment is not stop eligible: lease: held by agent-run

--- a/erun-integration/testdata/open/dry_run_configured_aws_alias_refreshes_host_credentials.txt
+++ b/erun-integration/testdata/open/dry_run_configured_aws_alias_refreshes_host_credentials.txt
@@ -8,7 +8,7 @@ open: tenant=team environment=dev kubernetes-context=test-context remote=false n
 open: pure primitive — not deploying (run `erun deploy` first, or pass --deploy to deploy before opening)
 kubectl --context test-context --namespace team-dev get deployment team-devops -o name
 kubectl --context test-context --namespace team-dev get deployment team-devops -o 'jsonpath={.spec.replicas}/{.status.readyReplicas}'
-open: could not read the runtime's replica count (failed to read deployment "team-devops": exit status 1); assuming it is running and continuing
+runtime run state: deployment team-devops wants 1 replica(s), 1 ready
 cloud refresh: alias=ops+123456789012@aws profile=erun-host region=eu-west-2
 cloud refresh: credentials are exported from the host profile and streamed to the pod on stdin (never an argument or a trace line)
 kubectl --context test-context --namespace team-dev wait --for=condition=Available --timeout 2m0s deployment/team-devops


### PR DESCRIPTION
`erun build` has been failing on `main`, so no release could be published — the gate a contributor runs and the gate that blocks a release disagreed about ambient tooling, and the disagreement surfaced eleven minutes into an image build, after a release tag had already been cut and announced.

Closes #911

## The cause

`TestOpen/dry_run_configured_aws_alias_refreshes_host_credentials` was the one `open` scenario passing bare `setup.Env()`, so the pre-forward replica probe reached a **real kubectl from the ambient PATH**. Its golden's `exit status 1` was a live kubectl failing to find `deployment/team-devops`. Where no kubectl exists — the image test stage — the same line reads `exec: "kubectl": executable file not found in $PATH`, and the golden mismatches.

Every machine a human or agent works on has kubectl. The image test stage does not. So `make check` could not catch this, and only the release-blocking gate could.

The probe running in `--dry-run` is correct and is untouched: `kubectl port-forward` cannot attach to zero replicas, so `open` must read the replica count first, and the sibling `kubectl_error_assumes_not_deployed` pins that. The scenario simply never declared a stub; it now uses the run-state stub its siblings use, answering the probe with a running runtime — an unremarkable answer, since the scenario is about the credential-refresh plan, not the wake branch.

## Making the class impossible

`env.Setup.Env()` no longer inherits the host's `PATH`; it points `PATH` at one generated per-scenario directory.

This was chosen over a tripwire shim that shadows `kubectl`, because a shim is only *deterministic* while the scrub is **faithful**: shadowing the binary turns "tool absent" into "tool present and failing", which is a different production branch from the one the image test stage actually takes. A suite that is deterministic about the wrong branch still lets this bug through.

Two escapes, both declared in `internal/env/env.go`:

- forwarders for the POSIX utilities the suite's own stubs need — a stub script runs as a child of the binary under test and inherits its PATH, so without them a stub keeping a counter file dies with `touch: not found`;
- `ERUN_GIT_BIN` for git, the suite's one irreducible host dependency, since the fixtures build real repositories.

`erun.Run` additionally fails any test whose output contains `executable file not found`, naming the binary — so a missing stub lands while the scenario is being written rather than in review.

## What the sweep turned up

The scrub surfaced more than the reported scenario, and one of them is the same defect in a second place:

- **Twelve scenarios** in build/push/open appended `os.Getenv("PATH")` after their own stub directory, handing themselves the whole host. They now append `setup.PathDir`.
- **`TestRelease/dry_run_includes_linux_release_scripts` was skipping on macOS**, gated on `runtime.GOOS == "linux"` and an ambient `dpkg-deb`. A skipped scenario's golden goes stale unnoticed until the Linux image-build gate — the same "two gates disagree" failure, arrived at from the other direction. It now pins `ERUN_HOST_OS_OVERRIDE`, declares a `dpkg-deb` stub, and runs everywhere.
- `emptyPathDir` in api/app/mcp is redundant once absence is the default, and is deleted.

## A held lease did not block a stop outside working hours

`TestActivity/stop_ready_blocked_by_a_held_lease` was also red on `main`, for an unrelated reason the scrub exposed by making the suite runnable at 05:30: the scenario inherited the default 08:00–20:00 working-hours window, so which arm of the stop-eligibility branch it took depended on the wall clock.

On the outside-hours arm, `environmentStopEligibility` returned "stop eligible" immediately — **before the lease was ever consulted**:

```go
 func environmentStopEligibility(markers []EnvironmentIdleMarker, outsideWorkingHours bool) (bool, int64) {
-	if outsideWorkingHours {
-		return true, 0
-	}
```

So the activity lease's central promise held only between 08:00 and 20:00. Outside those hours a held lease was ignored, which is precisely the window where long unattended runs happen. The docs already specified the intended behaviour — *"The lease clause is absolute: a held lease makes the env ineligible regardless of how quiet every other source is"* — so this brings the code to the spec rather than changing the contract: quiet signals stop holding an environment up outside working hours, a lease still does, or an agent run started at 19:59 loses its environment a minute later.

Both arms are now pinned to explicit UTC windows, each with its own scenario, so neither can pass on the clock instead of on the logic again. The hole was latent rather than live, since automatic idle-stop is still off — but it would have bitten the moment it was enabled, which is the one thing the lease existed to make safe.

## Verification

```
gofmt -l                 clean
go build ./... / go test ./...   ok, every Go module
make lint                0 issues.  × 5 gated modules
make integration-test    ok  coverage 76.0% (>= 75.0%)
erun-docs yarn build     [SUCCESS] Generated static files in "build".  Done in 17.47s.

clean golang:1.26.0 container, kubectl/helm/docker/aws/gh/terraform all ABSENT:
  ok  github.com/sophium/erun/erun-integration  40.536s
  (the same container is FAIL on main, with the failure from the issue)

erun build   ==> Built in 6m33s        (and 1m20s on the committed tree)
```

Because the second `erun build` promoted images from cached fingerprints, the image test stage was re-run from scratch against the committed tree with `--no-cache-filter test`, so the in-image result is not a cache artifact:

```
#14 [test 10/10] RUN ... make check && touch /test-ok
#14  10.65  0 issues.
#14  16.60  0 issues.
#14  24.86  0 issues.
#14  28.50  0 issues.
#14  81.94  0 issues.
#14 122.3   ok  coverage 76.0% (>= 75.0%)
```

Coverage moves 76.1% → 76.0% as redundant helpers are deleted; the threshold is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
