### PR TITLE
Keep orchestrator env MCP alive: proxy the edge instead of freezing a bearer

### DIFF
--- a/erun-cli/cmd/mcp.go
+++ b/erun-cli/cmd/mcp.go
@@ -64,14 +64,15 @@ func newMCPCmd(resolveOpen func(common.OpenParams) (common.OpenResult, error), r
 		},
 	}
 
-	addCommands(cmd, newMCPCallCmd(resolveOpen), newMCPToolsCmd(resolveOpen), newMCPTokenCmd(resolveOpen))
+	addCommands(cmd, newMCPCallCmd(resolveOpen), newMCPToolsCmd(resolveOpen), newMCPTokenCmd(resolveOpen), newMCPProxyCmd(resolveOpen))
 	addDryRunFlag(cmd)
 	cmd.Flags().StringVar(&host, "host", defaultMCPHost, "Host interface to bind the MCP HTTP server to")
 	cmd.Flags().IntVar(&port, "port", defaultMCPPort, "Port to bind the MCP HTTP server to")
 	cmd.Flags().StringVar(&path, "path", defaultMCPPath, "HTTP path to serve the MCP endpoint from")
 	cmd.Long = "Run ERun as an MCP server over HTTP, exposing this machine's erun commands as MCP tools.\n\n" +
 		"The subcommands go the other way: they talk to an already-running environment's MCP edge " +
-		"(`call`, `tools`) or mint a bearer for it (`token`)."
+		"(`call`, `tools`), mint a bearer for it (`token`), or bridge a stdio MCP client to it " +
+		"(`proxy`)."
 	cmd.Example = fmt.Sprintf("  erun mcp --host %s --port %d --path %s\n  erun mcp tenant-a dev\n  erun mcp call --tool version", defaultMCPHost, defaultMCPPort, defaultMCPPath)
 	return cmd
 }

--- a/erun-cli/cmd/mcp_proxy.go
+++ b/erun-cli/cmd/mcp_proxy.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"context"
+
+	common "github.com/sophium/erun/erun-common"
+	"github.com/spf13/cobra"
+)
+
+func newMCPProxyCmd(resolveOpen OpenResolver) *cobra.Command {
+	var tenant, environment string
+	cmd := &cobra.Command{
+		Use:   "proxy",
+		Short: "Bridge a stdio MCP client to an environment's MCP edge",
+		Long: "Speak MCP on stdin/stdout and relay every message to an environment's MCP edge, " +
+			"minting a fresh bearer for each request.\n\n" +
+			"Point an MCP client at this command instead of writing a bearer into the client's " +
+			"config. A client reads that config once at launch and cannot refresh a header, so a " +
+			"token in it ages out mid-session and every tool for the environment fails at once; " +
+			"nothing this command needs is a credential, so a session keeps working for as long as " +
+			"it runs. Reaching the edge still requires the port-forward `erun open` establishes — " +
+			"while it is down, each request is answered with a JSON-RPC error saying so rather than " +
+			"a dead pipe.\n\n" +
+			"stdout carries JSON-RPC and nothing else; every diagnostic goes to stderr.",
+		Example: "  erun mcp proxy --tenant acme --environment dev\n" +
+			"  claude --mcp-config '{\"mcpServers\":{\"acme-dev\":{\"type\":\"stdio\"," +
+			"\"command\":\"erun\",\"args\":[\"mcp\",\"proxy\",\"--tenant\",\"acme\",\"--environment\",\"dev\"]}}}'",
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMCPProxyCommand(cmd.Context(), commandContext(cmd), resolveOpen, scopedOpenParams(tenant, environment))
+		},
+	}
+	addDryRunFlag(cmd)
+	addMCPEdgeScopeFlags(cmd, &tenant, &environment)
+	return cmd
+}
+
+func runMCPProxyCommand(ctx context.Context, commandCtx common.Context, resolveOpen OpenResolver, params common.OpenParams) error {
+	target, err := resolveMCPEdgeTarget(commandCtx, resolveOpen, params)
+	if err != nil {
+		return err
+	}
+
+	commandCtx.TraceCommand("", "mcp", "proxy", target.endpoint)
+	if commandCtx.DryRun {
+		return nil
+	}
+
+	return common.RunMCPStdioProxy(ctx, common.MCPStdioProxyParams{
+		Endpoint:      target.endpoint,
+		MintToken:     mcpEdgeTokenMinter(target),
+		ClientVersion: currentBuildInfo().Version,
+		In:            commandCtx.Stdin,
+		Out:           commandCtx.Stdout,
+		Diagnostics:   commandCtx.Stderr,
+		DescribeError: func(err error) string { return mcpEdgeError(target, err).Error() },
+	})
+}

--- a/erun-common/erun_executable_test.go
+++ b/erun-common/erun_executable_test.go
@@ -1,0 +1,67 @@
+package eruncommon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The shipped desktop runs from inside a macOS .app bundle, so the erun it needs
+// sits three levels above its own directory rather than beside it. Missing that
+// layout is what left an orchestrator session with none of its environment
+// tools, so every layout the resolver must handle is pinned here.
+func TestErunExecutableNear(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		program string
+		binary  string
+	}{
+		{name: "macos_app_bundle", program: "bin/ERun.app/Contents/MacOS/erun-app", binary: "bin/erun"},
+		{name: "same_directory", program: "bin/emcp", binary: "bin/erun"},
+		{name: "source_build_sibling_module", program: "erun-mcp/bin/emcp", binary: "erun-cli/bin/erun"},
+		{name: "not_found", program: "bin/emcp"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := t.TempDir()
+			program := writeTestExecutable(t, root, testCase.program)
+			want := ""
+			if testCase.binary != "" {
+				want = writeTestExecutable(t, root, testCase.binary)
+			}
+			if got := erunExecutableNear(program, "erun"); got != want {
+				t.Fatalf("erunExecutableNear(%q) = %q, want %q", program, got, want)
+			}
+		})
+	}
+}
+
+// A bundle-shaped path is only recognized as one when every level matches, so an
+// ordinary directory named MacOS cannot pull the search outside its own tree.
+func TestMacOSBundleContainerIgnoresNonBundleLayouts(t *testing.T) {
+	for _, dir := range []string{
+		filepath.FromSlash("/opt/erun/bin"),
+		filepath.FromSlash("/opt/erun/MacOS"),
+		filepath.FromSlash("/opt/erun/Contents/MacOS"),
+		filepath.FromSlash("/opt/ERun.app/MacOS"),
+	} {
+		if got := macOSBundleContainer(dir); got != "" {
+			t.Fatalf("macOSBundleContainer(%q) = %q, want no container", dir, got)
+		}
+	}
+	bundled := filepath.FromSlash("/opt/erun/bin/ERun.app/Contents/MacOS")
+	if got, want := macOSBundleContainer(bundled), filepath.FromSlash("/opt/erun/bin"); got != want {
+		t.Fatalf("macOSBundleContainer(%q) = %q, want %q", bundled, got, want)
+	}
+}
+
+func writeTestExecutable(t *testing.T, root, relative string) string {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relative))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}

--- a/erun-common/job_supervisor.go
+++ b/erun-common/job_supervisor.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -612,17 +613,54 @@ func normalizeEnvironmentJobSignal(signal string) (string, error) {
 	}
 }
 
-// ResolveErunExecutable finds the erun binary a caller can hand to
-// StartEnvironmentJobParams.SupervisorPath. A transport that is not itself the
-// erun binary — the MCP server running in the environment — uses this, and gets
-// a clear failure rather than a job that never registers.
+// ResolveErunExecutable finds the erun binary for a transport that is not itself
+// that binary — the in-environment MCP server supervising a job, the desktop app
+// wiring a per-env MCP proxy — so those callers get a clear failure rather than a
+// launch that silently never happens. A sibling of the running program is
+// preferred over PATH so a source build resolves the binary it was built beside
+// instead of an unrelated installed one.
 func ResolveErunExecutable() (string, error) {
 	if override := strings.TrimSpace(os.Getenv("ERUN_ERUN_BIN")); override != "" {
 		return override, nil
 	}
-	path, err := exec.LookPath("erun")
+	name := ErunExecutableName()
+	if sibling := erunExecutableNearRunningProgram(name); sibling != "" {
+		return sibling, nil
+	}
+	path, err := exec.LookPath(name)
 	if err != nil {
-		return "", fmt.Errorf("the erun executable is required to supervise a job but was not found on PATH: %w", err)
+		return "", fmt.Errorf("the erun executable was not found beside this program or on PATH: %w", err)
 	}
 	return path, nil
+}
+
+// ErunExecutableName is the on-disk file name of the erun binary for this host.
+func ErunExecutableName() string {
+	if runtime.GOOS == "windows" {
+		return "erun.exe"
+	}
+	return "erun"
+}
+
+// erunExecutableNearRunningProgram mirrors how the CLI locates its sibling
+// erun-app: the install layout puts every erun executable in one directory, and
+// a source build puts them in each module's own bin/.
+func erunExecutableNearRunningProgram(name string) string {
+	executable, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	dir := filepath.Dir(executable)
+	for _, candidate := range []string{
+		filepath.Join(dir, name),
+		filepath.Clean(filepath.Join(dir, "..", "..", "erun-cli", "bin", name)),
+	} {
+		if candidate == executable {
+			continue
+		}
+		if info, statErr := os.Stat(candidate); statErr == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	return ""
 }

--- a/erun-common/job_supervisor.go
+++ b/erun-common/job_supervisor.go
@@ -642,25 +642,61 @@ func ErunExecutableName() string {
 	return "erun"
 }
 
-// erunExecutableNearRunningProgram mirrors how the CLI locates its sibling
-// erun-app: the install layout puts every erun executable in one directory, and
-// a source build puts them in each module's own bin/.
+// erunExecutableNearRunningProgram searches beside the running program: the
+// install layout puts every erun executable in one directory, and a source build
+// puts them in each module's own bin/. It is not the mirror of how the CLI finds
+// erun-app — that direction stops at the .app bundle, while a program running
+// from inside one sits three levels below the directory its siblings share.
 func erunExecutableNearRunningProgram(name string) string {
 	executable, err := os.Executable()
 	if err != nil {
 		return ""
 	}
-	dir := filepath.Dir(executable)
-	for _, candidate := range []string{
-		filepath.Join(dir, name),
-		filepath.Clean(filepath.Join(dir, "..", "..", "erun-cli", "bin", name)),
-	} {
-		if candidate == executable {
-			continue
-		}
-		if info, statErr := os.Stat(candidate); statErr == nil && !info.IsDir() {
-			return candidate
+	return erunExecutableNear(executable, name)
+}
+
+func erunExecutableNear(executable, name string) string {
+	for _, root := range executableSiblingRoots(filepath.Dir(executable)) {
+		for _, candidate := range []string{
+			filepath.Join(root, name),
+			filepath.Clean(filepath.Join(root, "..", "..", "erun-cli", "bin", name)),
+		} {
+			if candidate == executable {
+				continue
+			}
+			if info, statErr := os.Stat(candidate); statErr == nil && !info.IsDir() {
+				return candidate
+			}
 		}
 	}
 	return ""
+}
+
+// executableSiblingRoots lists the directories an erun executable may sit in
+// relative to the running program: its own directory, plus the directory holding
+// the macOS .app bundle it runs inside, if any.
+func executableSiblingRoots(dir string) []string {
+	roots := []string{dir}
+	if container := macOSBundleContainer(dir); container != "" {
+		roots = append(roots, container)
+	}
+	return roots
+}
+
+// macOSBundleContainer returns the directory holding the <Name>.app bundle whose
+// Contents/MacOS is dir, and "" for every other layout — so no other host's
+// directory names can accidentally match the bundle shape.
+func macOSBundleContainer(dir string) string {
+	if filepath.Base(dir) != "MacOS" {
+		return ""
+	}
+	contents := filepath.Dir(dir)
+	if filepath.Base(contents) != "Contents" {
+		return ""
+	}
+	bundle := filepath.Dir(contents)
+	if filepath.Ext(bundle) != ".app" {
+		return ""
+	}
+	return filepath.Dir(bundle)
 }

--- a/erun-common/mcp_client.go
+++ b/erun-common/mcp_client.go
@@ -150,7 +150,10 @@ type mcpSession struct {
 	nextID        int
 }
 
-func openMCPSession(ctx context.Context, endpoint string, mintToken MCPTokenMinter, clientVersion string) (*mcpSession, error) {
+// newMCPSession prepares the transport without performing the handshake, so a
+// relay that forwards a client's own initialize can share the header, session,
+// and framing rules with the typed callers.
+func newMCPSession(endpoint string, mintToken MCPTokenMinter, clientVersion string) (*mcpSession, error) {
 	endpoint = strings.TrimSpace(endpoint)
 	if endpoint == "" {
 		return nil, fmt.Errorf("MCP endpoint is required")
@@ -163,11 +166,18 @@ func openMCPSession(ctx context.Context, endpoint string, mintToken MCPTokenMint
 	}
 	// Deliberately no client timeout: a tool call may legitimately run for many
 	// minutes, so the deadline belongs to the caller's context.
-	session := &mcpSession{
+	return &mcpSession{
 		endpoint:      endpoint,
 		mintToken:     mintToken,
 		clientVersion: clientVersion,
 		client:        &http.Client{},
+	}, nil
+}
+
+func openMCPSession(ctx context.Context, endpoint string, mintToken MCPTokenMinter, clientVersion string) (*mcpSession, error) {
+	session, err := newMCPSession(endpoint, mintToken, clientVersion)
+	if err != nil {
+		return nil, err
 	}
 	if _, err := session.call(ctx, "initialize", map[string]any{
 		"protocolVersion": mcpClientProtocolVersion,
@@ -208,21 +218,29 @@ func (s *mcpSession) post(ctx context.Context, payload mcpJSONRPCRequest) (*mcpJ
 	if err != nil {
 		return nil, err
 	}
+	raw, err := s.postRaw(ctx, body)
+	if err != nil || len(raw) == 0 {
+		return nil, err
+	}
+	var decoded mcpJSONRPCResponse
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, fmt.Errorf("decode MCP reply: %w", err)
+	}
+	return &decoded, nil
+}
+
+// postRaw sends one already-encoded JSON-RPC message and returns the raw reply,
+// or nil when the edge answered without a body — the 202 a notification gets.
+// Bearer minting and session-id capture live here so a raw relay and a typed
+// call cannot drift apart on either.
+func (s *mcpSession) postRaw(ctx context.Context, body []byte) ([]byte, error) {
 	token, err := s.mintToken()
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint, bytes.NewReader(body))
+	req, err := s.newRequest(ctx, body, token)
 	if err != nil {
 		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json, text/event-stream")
-	req.Header.Set(mcpProtocolVersionHeader, mcpClientProtocolVersion)
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("User-Agent", mcpClientName+"/"+s.clientVersion)
-	if s.sessionID != "" {
-		req.Header.Set(mcpSessionHeader, s.sessionID)
 	}
 
 	resp, err := s.client.Do(req)
@@ -239,6 +257,22 @@ func (s *mcpSession) post(ctx context.Context, payload mcpJSONRPCRequest) (*mcpJ
 		return nil, err
 	}
 	return decodeMCPReply(resp)
+}
+
+func (s *mcpSession) newRequest(ctx context.Context, body []byte, token string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set(mcpProtocolVersionHeader, mcpClientProtocolVersion)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("User-Agent", mcpClientName+"/"+s.clientVersion)
+	if s.sessionID != "" {
+		req.Header.Set(mcpSessionHeader, s.sessionID)
+	}
+	return req, nil
 }
 
 // A failure to dial the loopback port is reported as unreachable rather than as a
@@ -268,8 +302,9 @@ func mcpStatusError(endpoint string, resp *http.Response) error {
 }
 
 // The edge answers either a plain JSON body or an SSE-framed stream depending on
-// how it was configured, so both framings are accepted.
-func decodeMCPReply(resp *http.Response) (*mcpJSONRPCResponse, error) {
+// how it was configured, so both framings are accepted. The reply is returned as
+// the raw JSON-RPC object so a relay can forward it verbatim.
+func decodeMCPReply(resp *http.Response) ([]byte, error) {
 	if resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent {
 		return nil, nil
 	}
@@ -283,17 +318,13 @@ func decodeMCPReply(resp *http.Response) (*mcpJSONRPCResponse, error) {
 	if len(bytes.TrimSpace(body)) == 0 {
 		return nil, nil
 	}
-	var decoded mcpJSONRPCResponse
-	if err := json.Unmarshal(body, &decoded); err != nil {
-		return nil, fmt.Errorf("decode MCP reply: %w", err)
-	}
-	return &decoded, nil
+	return body, nil
 }
 
 // Only the first event carrying a JSON-RPC result or error is consumed; progress
 // notifications on the same stream are skipped. Each event's payload is one line,
 // which is how the edge frames it.
-func decodeMCPEventStream(body io.Reader) (*mcpJSONRPCResponse, error) {
+func decodeMCPEventStream(body io.Reader) ([]byte, error) {
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
 	for scanner.Scan() {
@@ -301,12 +332,13 @@ func decodeMCPEventStream(body io.Reader) (*mcpJSONRPCResponse, error) {
 		if !ok {
 			continue
 		}
+		payload := strings.TrimSpace(data)
 		var decoded mcpJSONRPCResponse
-		if err := json.Unmarshal([]byte(strings.TrimSpace(data)), &decoded); err != nil {
+		if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
 			continue
 		}
 		if decoded.Result != nil || decoded.Error != nil {
-			return &decoded, nil
+			return []byte(payload), nil
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/erun-common/mcp_proxy.go
+++ b/erun-common/mcp_proxy.go
@@ -1,0 +1,179 @@
+package eruncommon
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Stdio side of the per-environment MCP edge. An MCP client reads its server
+// config once at launch and cannot refresh a header afterwards, so a bearer
+// written into that config expires mid-session and every tool for the
+// environment fails at once. This relay removes the credential from the config
+// entirely: the client launches a command, and the bearer is minted here, per
+// request, for as long as the session runs.
+
+// jsonRPCInternalError is the code a relay failure is reported under, so a
+// client that cannot reach the edge renders an actionable message instead of
+// seeing its pipe go quiet.
+const jsonRPCInternalError = -32603
+
+type MCPStdioProxyParams struct {
+	Endpoint      string
+	MintToken     MCPTokenMinter
+	ClientVersion string
+	In            io.Reader
+	Out           io.Writer
+	// Diagnostics carries every human-facing line. Out is JSON-RPC and nothing
+	// else: one stray byte there desynchronizes the client's parser.
+	Diagnostics io.Writer
+	// DescribeError turns a relay failure into the message the client shows. The
+	// caller owns the recovery wording because it knows which command brings the
+	// edge back up; nil falls back to the raw error.
+	DescribeError func(error) string
+}
+
+// RunMCPStdioProxy relays newline-delimited JSON-RPC between a client on stdin
+// and an environment's MCP edge until stdin closes. Messages are relayed one at
+// a time: a client waits for each reply before it acts on the next, and serial
+// relay keeps the edge's session bookkeeping in the order the client wrote it.
+func RunMCPStdioProxy(ctx context.Context, params MCPStdioProxyParams) error {
+	if params.In == nil || params.Out == nil {
+		return fmt.Errorf("MCP stdio proxy requires an input and an output stream")
+	}
+	session, err := newMCPSession(params.Endpoint, params.MintToken, params.ClientVersion)
+	if err != nil {
+		return err
+	}
+	proxy := &mcpStdioProxy{session: session, params: params}
+	reader := bufio.NewReader(params.In)
+	for {
+		message, err := readJSONRPCLine(reader)
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read MCP client message: %w", err)
+		}
+		if len(message) == 0 {
+			continue
+		}
+		if err := proxy.relay(ctx, message); err != nil {
+			return err
+		}
+	}
+}
+
+type mcpStdioProxy struct {
+	session *mcpSession
+	params  MCPStdioProxyParams
+}
+
+// relay forwards one client message and writes at most one line to stdout. A
+// failure is answered as a JSON-RPC error carrying the message's own id, so the
+// client surfaces it against the request it is waiting on; a notification has no
+// id to answer against, so it only reaches the diagnostics stream. Either way the
+// relay keeps serving — a transient edge outage must not kill the session.
+func (p *mcpStdioProxy) relay(ctx context.Context, message []byte) error {
+	id := jsonRPCMessageID(message)
+	reply, err := p.session.postRaw(ctx, message)
+	switch {
+	case err != nil:
+		p.diagnose(err.Error())
+		return p.writeError(id, p.describe(err))
+	case len(reply) > 0:
+		return p.writeReply(reply)
+	case len(id) > 0:
+		detail := fmt.Sprintf("the MCP edge at %s accepted the request but returned no reply", p.params.Endpoint)
+		p.diagnose(detail)
+		return p.writeError(id, detail)
+	}
+	return nil
+}
+
+// writeReply compacts before writing so a pretty-printed edge reply still
+// reaches the client as exactly one line.
+func (p *mcpStdioProxy) writeReply(reply []byte) error {
+	compact := new(bytes.Buffer)
+	if err := json.Compact(compact, reply); err != nil {
+		p.diagnose(fmt.Sprintf("the MCP edge at %s returned a reply that is not JSON: %v", p.params.Endpoint, err))
+		return nil
+	}
+	return p.writeLine(compact.Bytes())
+}
+
+func (p *mcpStdioProxy) writeError(id json.RawMessage, message string) error {
+	if len(id) == 0 {
+		return nil
+	}
+	encoded, err := json.Marshal(mcpJSONRPCErrorReply{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   mcpJSONRPCError{Code: jsonRPCInternalError, Message: message},
+	})
+	if err != nil {
+		return err
+	}
+	return p.writeLine(encoded)
+}
+
+func (p *mcpStdioProxy) writeLine(payload []byte) error {
+	if _, err := p.params.Out.Write(append(payload, '\n')); err != nil {
+		return fmt.Errorf("write MCP reply: %w", err)
+	}
+	return nil
+}
+
+func (p *mcpStdioProxy) diagnose(message string) {
+	if p.params.Diagnostics == nil {
+		return
+	}
+	_, _ = fmt.Fprintln(p.params.Diagnostics, "mcp proxy: "+message)
+}
+
+func (p *mcpStdioProxy) describe(err error) string {
+	if p.params.DescribeError == nil {
+		return err.Error()
+	}
+	return p.params.DescribeError(err)
+}
+
+type mcpJSONRPCErrorReply struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Error   mcpJSONRPCError `json:"error"`
+}
+
+// readJSONRPCLine returns the next message, tolerating a final line the client
+// wrote without a trailing newline before closing.
+func readJSONRPCLine(reader *bufio.Reader) ([]byte, error) {
+	line, err := reader.ReadBytes('\n')
+	trimmed := bytes.TrimSpace(line)
+	if err != nil {
+		if errors.Is(err, io.EOF) && len(trimmed) > 0 {
+			return trimmed, nil
+		}
+		return nil, err
+	}
+	return trimmed, nil
+}
+
+// jsonRPCMessageID reports the message's id, or nil when it carries none — the
+// notification case, which the protocol answers with nothing at all. A literal
+// null id is a notification too.
+func jsonRPCMessageID(message []byte) json.RawMessage {
+	var envelope struct {
+		ID json.RawMessage `json:"id"`
+	}
+	if err := json.Unmarshal(message, &envelope); err != nil {
+		return nil
+	}
+	if len(bytes.TrimSpace(envelope.ID)) == 0 || bytes.Equal(bytes.TrimSpace(envelope.ID), []byte("null")) {
+		return nil
+	}
+	return envelope.ID
+}

--- a/erun-docs/docs/agent-reference/cli-flags.md
+++ b/erun-docs/docs/agent-reference/cli-flags.md
@@ -826,9 +826,9 @@ See [MCP overview](/mcp/overview) for the protocol and the tool list. The launch
 | `--host <addr>` | string | `127.0.0.1` | The bind address. The in-pod default is loopback-only. |
 | `--path <p>` | string | `/mcp` | The HTTP path the endpoint is served from. |
 
-### `erun mcp call` / `tools` / `token` — client side
+### `erun mcp call` / `tools` / `token` / `proxy` — client side
 
-These call an environment's MCP edge rather than serving one; they are the supported way for a script or an orchestrating Agent to reach an env without configuring an MCP client, and the reason no MCP *tool* exists for this (a tool that calls another env's edge would invert the transport). All three share the target flags:
+These call an environment's MCP edge rather than serving one; they are the supported way for a script or an orchestrating Agent to reach an env without configuring an MCP client, and the reason no MCP *tool* exists for this (a tool that calls another env's edge would invert the transport). All four share the target flags:
 
 | Flag | Type | Default | Effect |
 |---|---|---|---|
@@ -850,6 +850,37 @@ Resolution and request contract:
 2. The endpoint is `http://127.0.0.1:<localPort>/mcp`, where `localPort` is the env's MCP port — the value `erun list` reports and `erun open` forwards.
 3. A bearer is minted **per HTTP request**, immediately before it is sent: EdDSA (Ed25519) over the desktop identity, `iss=file:///etc/erun/mcp-auth/desktopid.pub`, `aud=erun-mcp:<tenant>/<environment>`, 5-minute expiry. No client-side timeout is imposed on the call, so a tool that runs for minutes is not cut short and cannot fail on an aged-out token.
 4. The handshake is the standard one — `initialize`, `notifications/initialized`, then `tools/call` or `tools/list` — propagating `Mcp-Session-Id` and accepting both plain-JSON and SSE-framed replies.
+
+#### `proxy` — stdio bridge
+
+`proxy` takes only the shared target flags. It is a transport adapter, not an operation: an MCP client launches it as a stdio server and it relays that client's own JSON-RPC to the env's edge. It exists because a client reads its server config once at launch and cannot refresh a header, so a bearer written into that config turns the 5-minute token lifetime into a hard session limit — every tool for the env failing at the same moment. Configuring a *command* rather than a credential removes the class of failure: nothing in the client's config expires.
+
+| Property | Contract |
+|---|---|
+| Input framing | Newline-delimited JSON-RPC on **stdin**, one message per line. A final message without a trailing newline is still relayed. Blank lines are ignored. Relay is sequential — one message in flight at a time. |
+| Output framing | One JSON-RPC message per line on **stdout**, compacted to a single line even when the edge pretty-printed it. **stdout carries JSON-RPC and nothing else**; the audit line, trace output, and every diagnostic go to stderr. |
+| Notifications | A message with no `id` (or `"id": null`) gets no stdout line at all — including when the relay fails, since there is no id to answer against. The failure still reaches stderr. |
+| Session | The `Mcp-Session-Id` from the first reply is captured and sent on every subsequent request; the client never sees it. |
+| Bearer | Minted per relayed request, same claims as row 3 above. The proxy never writes a token to disk and never reuses one past its life. |
+| Handshake | Not performed by the proxy — the client's own `initialize` / `notifications/initialized` are relayed like any other message. |
+| Termination | Exits `0` when stdin closes. |
+
+Failure mapping. Every one of these is answered as a JSON-RPC error on the failing request's own `id`, with code `-32603`, and the relay keeps serving the next message — the edge can come back mid-session:
+
+| Condition | `error.message` |
+|---|---|
+| Nothing listening on the local MCP port | `MCP endpoint is not reachable: <endpoint> (…); run erun open <tenant> <env> so the local MCP port-forward is up` |
+| Edge answered `401`/`403` | `MCP endpoint rejected the bearer token: <endpoint> (HTTP 401); <tenant>/<env> was deployed without this machine's MCP public key, so redeploy it from the ERun desktop app` |
+| Edge accepted a request but returned no body | `the MCP edge at <endpoint> accepted the request but returned no reply` — the client fails visibly instead of waiting on a reply that is not coming. |
+| No desktop identity on this machine | The minting error, naming the path it looked at. |
+
+The same text is written to stderr on every failure, including the notification case that has no reply to carry it.
+
+```json
+// a Claude Code / Codex stdio server entry
+{ "mcpServers": { "acme-dev": { "type": "stdio", "command": "erun",
+  "args": ["mcp", "proxy", "--tenant", "acme", "--environment", "dev"] } } }
+```
 
 `--output json` shapes:
 

--- a/erun-docs/docs/cli/mcp.md
+++ b/erun-docs/docs/cli/mcp.md
@@ -13,6 +13,7 @@ erun mcp [TENANT] [ENVIRONMENT] [flags]
 erun mcp call  --tool <name> [--args '<json>'] [--tenant T --environment E]
 erun mcp tools [--tenant T --environment E]
 erun mcp token [--tenant T --environment E]
+erun mcp proxy [--tenant T --environment E]
 ```
 
 The `mcp` command is a launcher for the `emcp` executable that ships in the `erun-mcp` package. It establishes the runtime context (tenant + environment) and then hands off to `emcp`.
@@ -28,7 +29,7 @@ For the protocol, the full tool list with schemas, the handshake, and worked exa
 You rarely run `erun mcp` directly. Three normal entry points:
 
 1. **The default — in the runtime pod.** The runtime container (`erun-devops`) serves the env's MCP edge on `ERUN_MCP_PORT` (default `17000`), so every tool call runs with the environment's own toolchain. The in-pod Agent (`claude`, `codex`) reaches it at loopback; the desktop app port-forwards it for any laptop-side client.
-2. **Laptop-side client (troubleshooting).** Point an MCP-aware tool at the local port the desktop app maintains at `<UserConfigDir>/erun/portforward/mcp/<tenant>/<environment>.json`. See [Troubleshooting · Connecting a laptop-side Agent client](/reference/troubleshooting#connecting-a-laptop-side-agent-client) for when this is the right call.
+2. **Laptop-side client.** Point an MCP-aware tool at [`erun mcp proxy`](#wiring-a-laptop-side-mcp-client), which bridges the client's stdio to the env's edge. See [Troubleshooting · Connecting a laptop-side Agent client](/reference/troubleshooting#connecting-a-laptop-side-agent-client) for when this is the right call.
 3. **Direct launch (for local development of MCP itself).**
 
    ```bash
@@ -53,6 +54,26 @@ Each one resolves the target the same way `erun deploy` and `erun open` do — t
 
 Being able to reach the edge depends on the port-forward `erun open` establishes, and on the environment trusting this machine's identity — the same identity the desktop app injects when it deploys an env.
 
+## Wiring a laptop-side MCP client {#wiring-a-laptop-side-mcp-client}
+
+`erun mcp proxy` is the same edge again, for a client that speaks MCP itself. It reads JSON-RPC on stdin, relays each message to the environment's edge with a bearer minted for that one request, and writes the reply back on stdout. Configure the client to launch it as a stdio server:
+
+```json
+{
+  "mcpServers": {
+    "acme-dev": {
+      "type": "stdio",
+      "command": "erun",
+      "args": ["mcp", "proxy", "--tenant", "acme", "--environment", "dev"]
+    }
+  }
+}
+```
+
+**Configure the command, never a token.** An MCP client reads its server config once when it starts and has no way to refresh a header afterwards, so a bearer written into that config expires partway through the session and every tool for that environment fails at the same moment. Nothing in the config above is a credential, so a session keeps working for as long as it runs — however long that is.
+
+If the port-forward is down, the proxy answers each request with a JSON-RPC error telling you to run `erun open`, and keeps serving; the client shows the message and recovers on its own once the forward is back. stdout carries JSON-RPC and nothing else — every diagnostic goes to stderr, where the client's own log picks it up.
+
 ## Error behaviour
 
 | Failure | Behaviour |
@@ -67,3 +88,4 @@ Being able to reach the edge depends on the port-forward `erun open` establishes
 | The tool itself reports an error. | Prints the tool's own message (`MCP tool <name> reported an error: …`); exit code 1. |
 | The tool does not exist. | Prints the edge's JSON-RPC error, including its code; exit code 1. |
 | No desktop identity on this machine. | Errors with the path it looked at and tells you to open an environment from the desktop app once so the identity exists; exit code 1. A fresh key is never generated, because no deployed env would trust it. |
+| `proxy` cannot reach the edge, or the edge rejects the bearer. | The failing request is answered with a JSON-RPC error carrying the same recovery text as the table rows above, and the relay keeps serving the next message. The command itself stays running and exits 0 when the client closes stdin. |

--- a/erun-docs/docs/mcp/overview.md
+++ b/erun-docs/docs/mcp/overview.md
@@ -68,12 +68,15 @@ An env deployed with a trust anchor requires a **bearer on every request**, incl
 
 An env deployed before key injection (no anchor configured) stays unauthenticated — loopback-only, behind the namespace's default-deny `NetworkPolicy`.
 
-**Don't hand-roll the token.** `erun mcp call` and `erun mcp tools` mint one internally per request, and `erun mcp token` prints one for a client that speaks MCP itself:
+**Don't hand-roll the token.** `erun mcp call` and `erun mcp tools` mint one internally per request; `erun mcp proxy` does the same for a client that speaks MCP itself, relaying its stdio to this endpoint; and `erun mcp token` prints one for a caller driving the protocol directly:
 
 ```bash
 erun mcp call --tool list --output json          # one typed call, no token handling
+erun mcp proxy --tenant myapp --environment local  # stdio MCP server, bearer per request
 TOKEN=$(erun mcp token --tenant myapp --environment local)
 ```
+
+**A bearer must never be written into an MCP client's server config.** The client reads that config once at launch and cannot refresh a header, so the 5-minute lifetime above becomes a hard session limit: every tool for the env fails at once when the token ages out. Configure `erun mcp proxy` as a stdio server instead — the config then names a command, not a credential, and the token is minted per request behind it. See [`erun mcp` · Wiring a laptop-side MCP client](/cli/mcp#wiring-a-laptop-side-mcp-client).
 
 See [`erun mcp`](/cli/mcp#talking-to-an-environments-mcp-edge) for the Operator view and [CLI flags · `erun mcp`](/agent-reference/cli-flags#erun-mcp) for the full contract.
 

--- a/erun-docs/docs/reference/troubleshooting.md
+++ b/erun-docs/docs/reference/troubleshooting.md
@@ -70,24 +70,26 @@ The Agent runs inside the env by default — the runtime pod ships the `EnvConfi
    ```bash
    erun open my-tenant local
    ```
-2. `erun open` publishes the local MCP port at `<UserConfigDir>/erun/portforward/mcp/<tenant>/<env>.json` — read the `localPort` field.
-3. Point your laptop-side Agent at the published config. Example for Claude Code:
+2. Configure the client to launch `erun mcp proxy` as a stdio MCP server for that env. Example for Claude Code:
    ```bash
-   claude --mcp-config <UserConfigDir>/erun/portforward/mcp/my-tenant/local.json
+   claude --mcp-config '{"mcpServers":{"my-tenant-local":{"type":"stdio","command":"erun",
+     "args":["mcp","proxy","--tenant","my-tenant","--environment","local"]}}}'
    ```
-   For Codex / custom clients, use the equivalent config pointing at `http://127.0.0.1:<localPort>/mcp`.
-4. Verify by asking the Agent to call the `list` tool — it should return the same data as `erun list`.
+   For Codex / custom clients, use the equivalent stdio-server entry with the same command and arguments. See [`erun mcp` · Wiring a laptop-side MCP client](/cli/mcp#wiring-a-laptop-side-mcp-client).
+3. Verify by asking the Agent to call the `list` tool — it should return the same data as `erun list`.
 
 If you find yourself reaching for this regularly, treat it as a signal that the in-pod Agent's config or version needs work — `erun doctor` will surface most causes.
 
-**"requires re-authorization (token expired)".** A laptop-side client holds the bearer it was configured with, and those are short-lived by design — when it expires, every tool for that env stops at once. You do not need the client to keep working: `erun mcp call` mints a fresh token per request, so it keeps answering while the client is stale.
+**"requires re-authorization (token expired)".** This means the client was configured with a bearer of its own rather than with `erun mcp proxy`. Bearers are short-lived by design, a client reads its config once at launch and cannot refresh a header, so roughly five minutes in every tool for that env stops at the same moment. Re-point the client at the proxy as shown above: it mints a bearer per request, so nothing in the client's config expires and the session keeps working for as long as it runs.
+
+Meanwhile, and for checking the edge itself:
 
 ```bash
 erun mcp tools --tenant my-tenant --environment local        # is the edge healthy?
 erun mcp call --tool list --output json                      # keep working meanwhile
 ```
 
-Restart or re-authorize the client to pick up a new token. If `erun mcp call` reports `MCP endpoint rejected the bearer token`, the env does not trust this machine at all — redeploy it from the desktop app. If it reports `MCP endpoint is not reachable`, the port-forward is down: re-run `erun open`.
+If `erun mcp call` reports `MCP endpoint rejected the bearer token`, the env does not trust this machine at all — redeploy it from the desktop app. If it reports `MCP endpoint is not reachable`, the port-forward is down: re-run `erun open`. The proxy surfaces both of those as JSON-RPC errors carrying the same recovery text, so a client wired through it shows the fix instead of going silent.
 
 ## Cloud context won't start
 

--- a/erun-docs/docs/reference/troubleshooting.md
+++ b/erun-docs/docs/reference/troubleshooting.md
@@ -91,6 +91,17 @@ erun mcp call --tool list --output json                      # keep working mean
 
 If `erun mcp call` reports `MCP endpoint rejected the bearer token`, the env does not trust this machine at all — redeploy it from the desktop app. If it reports `MCP endpoint is not reachable`, the port-forward is down: re-run `erun open`. The proxy surfaces both of those as JSON-RPC errors carrying the same recovery text, so a client wired through it shows the fix instead of going silent.
 
+## Orchestrator started without its environment tools
+
+**Symptoms:** the desktop titlebar shows a warning reading `<name> started without its environment tools`, and the [orchestrator](/collaboration/workflow) has none of the tools for the environments it links — every call against one fails, even though the session itself looks healthy.
+
+The desktop wires each linked environment in by launching `erun mcp proxy` for it. When it cannot wire any of them the session still starts, and the warning names which of the two causes applies, because the fixes differ:
+
+- **"the erun executable could not be resolved"** — the `erun` command line tool was not found beside the desktop app or on `PATH`. Install it, then restart the orchestrator.
+- **"no linked environment resolved an MCP port"** — none of the linked environments resolves a port any more, usually because they were renamed or removed. Check the orchestrator's linked environments in the desktop app, then restart it.
+
+The warning stays until you dismiss it and carries a copy action, so the message is still readable after the session comes up. An orchestrator that links no environments has nothing to wire and stays quiet.
+
 ## Cloud context won't start
 
 **Symptoms:** `erun open` reports a long-running "starting" status that never resolves.

--- a/erun-integration/mcp_test.go
+++ b/erun-integration/mcp_test.go
@@ -36,6 +36,10 @@ type fakeMCPEdge struct {
 	SSE bool
 	// Status, when set, answers every POST with that status instead of a reply.
 	Status int
+	// AcceptEverything answers even a request carrying an id with a bodyless 202,
+	// the protocol anomaly that leaves a client waiting on a reply that is never
+	// coming.
+	AcceptEverything bool
 	// Results maps a JSON-RPC method to the raw JSON result it answers with.
 	Results map[string]string
 	// RPCErrors maps a JSON-RPC method to a raw JSON-RPC error object, the
@@ -86,7 +90,7 @@ func (e *fakeMCPEdge) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Mcp-Session-Id", "test-session")
-	if len(request.ID) == 0 {
+	if len(request.ID) == 0 || e.AcceptEverything {
 		w.WriteHeader(http.StatusAccepted)
 		return
 	}
@@ -165,6 +169,53 @@ func verifyMCPToken(t *testing.T, token string, publicKey ed25519.PublicKey) mcp
 		t.Fatal("token signature does not verify against the seeded desktop identity")
 	}
 	return claims
+}
+
+// proxyStdin frames JSON-RPC messages the way an MCP client writes them: one
+// per line, newline-delimited, then EOF.
+func proxyStdin(messages ...string) string {
+	return strings.Join(messages, "\n") + "\n"
+}
+
+// requireJSONRPCLines is the proxy's stdout contract, and the one thing the
+// Combined snapshot cannot assert: it concatenates both streams, so it cannot
+// tell a diagnostic that leaked onto stdout from one that went to stderr where it
+// belongs. A single stray byte on stdout desynchronizes the client's parser, so
+// every line is parsed here and the decoded messages are returned for the
+// scenario to assert against.
+func requireJSONRPCLines(t *testing.T, stdout string, want int) []map[string]any {
+	t.Helper()
+	if stdout == "" && want == 0 {
+		return nil
+	}
+	if !strings.HasSuffix(stdout, "\n") {
+		t.Fatalf("proxy stdout does not end in a newline: %q", stdout)
+	}
+	lines := strings.Split(strings.TrimSuffix(stdout, "\n"), "\n")
+	messages := make([]map[string]any, 0, len(lines))
+	for index, line := range lines {
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+			t.Fatalf("proxy stdout line %d is not JSON-RPC (%v): %q", index+1, err, line)
+		}
+		messages = append(messages, decoded)
+	}
+	if len(messages) != want {
+		t.Fatalf("proxy wrote %d stdout lines, want %d:\n%s", len(messages), want, stdout)
+	}
+	return messages
+}
+
+// jsonRPCErrorMessage returns a reply's error message, failing when the reply
+// carries no error at all.
+func jsonRPCErrorMessage(t *testing.T, message map[string]any) string {
+	t.Helper()
+	failure, ok := message["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("reply carries no JSON-RPC error: %v", message)
+	}
+	text, _ := failure["message"].(string)
+	return text
 }
 
 func decodeJWTSegment(t *testing.T, segment string, into any) {
@@ -281,6 +332,15 @@ exit 3`)
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
 		golden.Equal(t, "mcp/tools_help", normalize.Apply(result.Combined))
+	})
+
+	t.Run("proxy_help", func(t *testing.T) {
+		setup := env.New(t)
+		result := erun.Run(t, []string{"mcp", "proxy", "--help"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "mcp/proxy_help", normalize.Apply(result.Combined))
 	})
 
 	t.Run("token_help", func(t *testing.T) {
@@ -540,6 +600,189 @@ exit 3`)
 			t.Fatalf("expected non-zero exit for an unreachable edge, got 0:\n%s", result.Combined)
 		}
 		golden.Equal(t, "mcp/call_real_run_unreachable_edge_points_at_open", normalize.Apply(result.Combined))
+	})
+
+	t.Run("proxy_dry_run_traces_the_resolved_edge", func(t *testing.T) {
+		// The plan must name the edge the relay would reach, and must neither read
+		// stdin nor touch the network.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"mcp", "proxy", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "mcp/proxy_dry_run_traces_the_resolved_edge", normalize.Apply(result.Combined))
+	})
+
+	t.Run("proxy_real_run_relays_a_json_framed_session", func(t *testing.T) {
+		// The whole session an MCP client drives: initialize, the initialized
+		// notification, then tools/list. The notification must produce no stdout
+		// line at all, and the tools/list must carry the session the handshake
+		// handed out — the client never sees either fact, so the relay owns both.
+		skipIfPortsBusy(t, mcpEdgeLocalPort)
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnvWithSSHDPortRange(t, setup, "team", "dev", mcpEdgeLocalPort)
+		identity := fixture.SeedDesktopIdentity(t, setup)
+		edge := &fakeMCPEdge{Results: map[string]string{
+			"initialize": `{"protocolVersion":"2025-06-18","capabilities":{"tools":{}}}`,
+			"tools/list": `{"tools":[{"name":"version","description":"Report the runtime's erun version"}]}`,
+		}}
+		edge.start(t, mcpEdgeLocalPort)
+
+		stdin := proxyStdin(
+			`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}`,
+			`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+			`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`,
+		)
+		result := erun.Run(t, []string{"mcp", "proxy", "--tenant", "team", "--environment", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: stdin})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "mcp/proxy_real_run_relays_a_json_framed_session", normalize.Apply(result.Combined))
+
+		replies := requireJSONRPCLines(t, result.Stdout, 2)
+		if replies[0]["id"] != float64(1) || replies[1]["id"] != float64(2) {
+			t.Fatalf("replies came back on the wrong ids: %v", replies)
+		}
+		list := edge.requestFor(t, "tools/list")
+		if list.SessionID != "test-session" {
+			t.Fatalf("tools/list session id = %q, want test-session", list.SessionID)
+		}
+		// Every relayed request carries its own freshly minted bearer — the reason
+		// a session outlives the 5-minute token lifetime. The headers are in
+		// neither stream, so the snapshot cannot see them. (Two mints inside the
+		// same second sign identical claims, so the bearers are byte-equal here;
+		// what is assertable is that each request carried a verifiable one.)
+		for _, request := range []fakeMCPRequest{edge.requestFor(t, "initialize"), list} {
+			claims := verifyMCPToken(t, request.Authbearer, identity.PublicKey)
+			if claims.Audience != "erun-mcp:team/dev" {
+				t.Fatalf("%s bearer audience = %q", request.Method, claims.Audience)
+			}
+		}
+	})
+
+	t.Run("proxy_real_run_relays_an_sse_framed_reply", func(t *testing.T) {
+		// The edge may frame a reply as an event stream; the client only speaks
+		// newline-delimited JSON, so the relay must unwrap the data: framing and
+		// drop the progress event ahead of it.
+		skipIfPortsBusy(t, mcpEdgeLocalPort)
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnvWithSSHDPortRange(t, setup, "team", "dev", mcpEdgeLocalPort)
+		fixture.SeedDesktopIdentity(t, setup)
+		edge := &fakeMCPEdge{SSE: true, Results: map[string]string{
+			"tools/call": `{"content":[{"type":"text","text":"1.2.3"}]}`,
+		}}
+		edge.start(t, mcpEdgeLocalPort)
+
+		stdin := proxyStdin(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"version","arguments":{}}}`)
+		result := erun.Run(t, []string{"mcp", "proxy", "--tenant", "team", "--environment", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: stdin})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "mcp/proxy_real_run_relays_an_sse_framed_reply", normalize.Apply(result.Combined))
+		requireJSONRPCLines(t, result.Stdout, 1)
+	})
+
+	t.Run("proxy_real_run_writes_nothing_for_a_notification", func(t *testing.T) {
+		// A notification has no id, so the protocol has nothing to answer it with.
+		// Writing anything here would leave the client one reply ahead of itself.
+		skipIfPortsBusy(t, mcpEdgeLocalPort)
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnvWithSSHDPortRange(t, setup, "team", "dev", mcpEdgeLocalPort)
+		fixture.SeedDesktopIdentity(t, setup)
+		edge := &fakeMCPEdge{}
+		edge.start(t, mcpEdgeLocalPort)
+
+		stdin := proxyStdin(`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":3}}`)
+		result := erun.Run(t, []string{"mcp", "proxy", "--tenant", "team", "--environment", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: stdin})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "mcp/proxy_real_run_writes_nothing_for_a_notification", normalize.Apply(result.Combined))
+		requireJSONRPCLines(t, result.Stdout, 0)
+		edge.requestFor(t, "notifications/cancelled")
+	})
+
+	t.Run("proxy_real_run_unreachable_edge_answers_every_request_and_keeps_serving", func(t *testing.T) {
+		// Nothing listening means the port-forward is missing. A relay that went
+		// quiet here would look to the client like a hung server, so each request
+		// gets a JSON-RPC error naming `erun open`, and the next one is still
+		// served — the port-forward can come back mid-session.
+		skipIfPortsBusy(t, mcpEdgeLocalPort)
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnvWithSSHDPortRange(t, setup, "team", "dev", mcpEdgeLocalPort)
+		fixture.SeedDesktopIdentity(t, setup)
+
+		// The notification in the middle still has no id to answer against, so the
+		// outage reaches stderr only and stdout stays at one line per request.
+		stdin := proxyStdin(
+			`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`,
+			`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+			`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`,
+		)
+		result := erun.Run(t, []string{"mcp", "proxy", "--tenant", "team", "--environment", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: stdin})
+		if result.ExitCode != 0 {
+			t.Fatalf("expected the relay to keep serving and exit 0, got %d:\n%s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "mcp/proxy_real_run_unreachable_edge_answers_every_request_and_keeps_serving", normalize.Apply(result.Combined))
+
+		replies := requireJSONRPCLines(t, result.Stdout, 2)
+		for index, reply := range replies {
+			if message := jsonRPCErrorMessage(t, reply); !strings.Contains(message, "erun open team dev") {
+				t.Fatalf("reply %d does not name the port-forward recovery: %q", index+1, message)
+			}
+		}
+	})
+
+	t.Run("proxy_real_run_unauthorized_edge_answers_with_the_redeploy_recovery", func(t *testing.T) {
+		// An edge that rejects the bearer is a trust problem, not connectivity, and
+		// the client must see that distinction rather than a generic failure.
+		skipIfPortsBusy(t, mcpEdgeLocalPort)
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnvWithSSHDPortRange(t, setup, "team", "dev", mcpEdgeLocalPort)
+		fixture.SeedDesktopIdentity(t, setup)
+		edge := &fakeMCPEdge{Status: http.StatusUnauthorized}
+		edge.start(t, mcpEdgeLocalPort)
+
+		// Deliberately unterminated: a client that closes the pipe right after its
+		// last message leaves no trailing newline, and that message must still be
+		// relayed rather than dropped.
+		stdin := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+		result := erun.Run(t, []string{"mcp", "proxy", "--tenant", "team", "--environment", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: stdin})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "mcp/proxy_real_run_unauthorized_edge_answers_with_the_redeploy_recovery", normalize.Apply(result.Combined))
+
+		replies := requireJSONRPCLines(t, result.Stdout, 1)
+		if message := jsonRPCErrorMessage(t, replies[0]); !strings.Contains(message, "redeploy it from the ERun desktop app") {
+			t.Fatalf("reply does not name the trust recovery: %q", message)
+		}
+	})
+
+	t.Run("proxy_real_run_answers_a_request_the_edge_left_unanswered", func(t *testing.T) {
+		// An edge that accepts a request and returns no body would leave the client
+		// waiting forever on a reply. The relay closes that hole: the request is
+		// answered with an error naming what happened, so the client fails visibly
+		// instead of hanging.
+		skipIfPortsBusy(t, mcpEdgeLocalPort)
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnvWithSSHDPortRange(t, setup, "team", "dev", mcpEdgeLocalPort)
+		fixture.SeedDesktopIdentity(t, setup)
+		edge := &fakeMCPEdge{AcceptEverything: true}
+		edge.start(t, mcpEdgeLocalPort)
+
+		stdin := proxyStdin(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+		result := erun.Run(t, []string{"mcp", "proxy", "--tenant", "team", "--environment", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: stdin})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "mcp/proxy_real_run_answers_a_request_the_edge_left_unanswered", normalize.Apply(result.Combined))
+
+		replies := requireJSONRPCLines(t, result.Stdout, 1)
+		if message := jsonRPCErrorMessage(t, replies[0]); !strings.Contains(message, "returned no reply") {
+			t.Fatalf("reply does not say the edge answered without one: %q", message)
+		}
 	})
 
 	t.Run("tools_real_run_lists_tools_with_their_arguments", func(t *testing.T) {

--- a/erun-integration/testdata/mcp/help.txt
+++ b/erun-integration/testdata/mcp/help.txt
@@ -1,6 +1,6 @@
 Run ERun as an MCP server over HTTP, exposing this machine's erun commands as MCP tools.
 
-The subcommands go the other way: they talk to an already-running environment's MCP edge (`call`, `tools`) or mint a bearer for it (`token`).
+The subcommands go the other way: they talk to an already-running environment's MCP edge (`call`, `tools`), mint a bearer for it (`token`), or bridge a stdio MCP client to it (`proxy`).
 
 Usage:
   erun mcp [TENANT] [ENVIRONMENT] [flags]
@@ -13,6 +13,7 @@ Examples:
 
 Available Commands:
   call        Call one tool on an environment's MCP edge
+  proxy       Bridge a stdio MCP client to an environment's MCP edge
   token       Mint a bearer token for an environment's MCP edge
   tools       List the tools an environment's MCP edge exposes
 

--- a/erun-integration/testdata/mcp/proxy_dry_run_traces_the_resolved_edge.txt
+++ b/erun-integration/testdata/mcp/proxy_dry_run_traces_the_resolved_edge.txt
@@ -1,0 +1,3 @@
+audit: erun mcp proxy --dry-run
+mcp: team/dev edge resolved to http://<LOOPBACK>:17000/mcp
+mcp proxy http://<LOOPBACK>:17000/mcp

--- a/erun-integration/testdata/mcp/proxy_help.txt
+++ b/erun-integration/testdata/mcp/proxy_help.txt
@@ -1,0 +1,23 @@
+Speak MCP on stdin/stdout and relay every message to an environment's MCP edge, minting a fresh bearer for each request.
+
+Point an MCP client at this command instead of writing a bearer into the client's config. A client reads that config once at launch and cannot refresh a header, so a token in it ages out mid-session and every tool for the environment fails at once; nothing this command needs is a credential, so a session keeps working for as long as it runs. Reaching the edge still requires the port-forward `erun open` establishes — while it is down, each request is answered with a JSON-RPC error saying so rather than a dead pipe.
+
+stdout carries JSON-RPC and nothing else; every diagnostic goes to stderr.
+
+Usage:
+  erun mcp proxy [flags]
+
+Examples:
+  erun mcp proxy --tenant acme --environment dev
+  claude --mcp-config '{"mcpServers":{"acme-dev":{"type":"stdio","command":"erun","args":["mcp","proxy","--tenant","acme","--environment","dev"]}}}'
+
+Flags:
+      --dry-run              Resolve and trace mutating actions without executing them.
+      --environment string   Target a specific environment; requires --tenant
+  -h, --help                 help for proxy
+      --tenant string        Target a specific tenant (default: the current scope)
+
+Global Flags:
+      --output string   Result format: text (default, human stream) or json (structured result on stdout for orchestrators). (default "text")
+      --time            Print the elapsed runtime after the command finishes.
+  -v, --verbose count   Increase verbosity: -v streams external tool output, -vv adds erun command traces.

--- a/erun-integration/testdata/mcp/proxy_real_run_answers_a_request_the_edge_left_unanswered.txt
+++ b/erun-integration/testdata/mcp/proxy_real_run_answers_a_request_the_edge_left_unanswered.txt
@@ -1,0 +1,4 @@
+{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"the MCP edge at http://<LOOPBACK>:26100/mcp accepted the request but returned no reply"}}
+audit: erun mcp proxy --environment dev --tenant team
+mcp: team/dev edge resolved to http://<LOOPBACK>:26100/mcp
+mcp proxy: the MCP edge at http://<LOOPBACK>:26100/mcp accepted the request but returned no reply

--- a/erun-integration/testdata/mcp/proxy_real_run_relays_a_json_framed_session.txt
+++ b/erun-integration/testdata/mcp/proxy_real_run_relays_a_json_framed_session.txt
@@ -1,0 +1,4 @@
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{}}}}
+{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"version","description":"Report the runtime's erun version"}]}}
+audit: erun mcp proxy --environment dev --tenant team
+mcp: team/dev edge resolved to http://<LOOPBACK>:26100/mcp

--- a/erun-integration/testdata/mcp/proxy_real_run_relays_an_sse_framed_reply.txt
+++ b/erun-integration/testdata/mcp/proxy_real_run_relays_an_sse_framed_reply.txt
@@ -1,0 +1,3 @@
+{"jsonrpc":"2.0","id":7,"result":{"content":[{"type":"text","text":"<VERSION>"}]}}
+audit: erun mcp proxy --environment dev --tenant team
+mcp: team/dev edge resolved to http://<LOOPBACK>:26100/mcp

--- a/erun-integration/testdata/mcp/proxy_real_run_unauthorized_edge_answers_with_the_redeploy_recovery.txt
+++ b/erun-integration/testdata/mcp/proxy_real_run_unauthorized_edge_answers_with_the_redeploy_recovery.txt
@@ -1,0 +1,4 @@
+{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"MCP endpoint rejected the bearer token: http://<LOOPBACK>:26100/mcp (HTTP 401): edge refused the request; team/dev was deployed without this machine's MCP public key, so redeploy it from the ERun desktop app"}}
+audit: erun mcp proxy --environment dev --tenant team
+mcp: team/dev edge resolved to http://<LOOPBACK>:26100/mcp
+mcp proxy: MCP endpoint rejected the bearer token: http://<LOOPBACK>:26100/mcp (HTTP 401): edge refused the request

--- a/erun-integration/testdata/mcp/proxy_real_run_unreachable_edge_answers_every_request_and_keeps_serving.txt
+++ b/erun-integration/testdata/mcp/proxy_real_run_unreachable_edge_answers_every_request_and_keeps_serving.txt
@@ -1,0 +1,7 @@
+{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"MCP endpoint is not reachable: http://<LOOPBACK>:26100/mcp (Post \"http://<LOOPBACK>:26100/mcp\": dial tcp <LOOPBACK>:26100: connect: connection refused); run `erun open team dev` so the local MCP port-forward is up"}}
+{"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"MCP endpoint is not reachable: http://<LOOPBACK>:26100/mcp (Post \"http://<LOOPBACK>:26100/mcp\": dial tcp <LOOPBACK>:26100: connect: connection refused); run `erun open team dev` so the local MCP port-forward is up"}}
+audit: erun mcp proxy --environment dev --tenant team
+mcp: team/dev edge resolved to http://<LOOPBACK>:26100/mcp
+mcp proxy: MCP endpoint is not reachable: http://<LOOPBACK>:26100/mcp (Post "http://<LOOPBACK>:26100/mcp": dial tcp <LOOPBACK>:26100: connect: connection refused)
+mcp proxy: MCP endpoint is not reachable: http://<LOOPBACK>:26100/mcp (Post "http://<LOOPBACK>:26100/mcp": dial tcp <LOOPBACK>:26100: connect: connection refused)
+mcp proxy: MCP endpoint is not reachable: http://<LOOPBACK>:26100/mcp (Post "http://<LOOPBACK>:26100/mcp": dial tcp <LOOPBACK>:26100: connect: connection refused)

--- a/erun-integration/testdata/mcp/proxy_real_run_writes_nothing_for_a_notification.txt
+++ b/erun-integration/testdata/mcp/proxy_real_run_writes_nothing_for_a_notification.txt
@@ -1,0 +1,2 @@
+audit: erun mcp proxy --environment dev --tenant team
+mcp: team/dev edge resolved to http://<LOOPBACK>:26100/mcp

--- a/erun-skills/skills/erun-orchestrate/SKILL.md
+++ b/erun-skills/skills/erun-orchestrate/SKILL.md
@@ -71,6 +71,7 @@ When the change under test is to erun's own tooling, roll it into the live tooli
 
 - If only the CLI changed, replace the binary in place; a running executable can be moved aside on every platform erun supports.
 - If the desktop binary is locked while running, the rebuild has to happen *after* it exits — from a **detached** relauncher that outlives your session. Record the return target first, including what to verify on resume.
+- **Reason about a restart from where your session actually runs — process ancestry answers that.** A quit command returning, or the old process still being listed a moment later, is not evidence that the quit failed or that your session lives elsewhere; shutdown is asynchronous. Acting on that inference skips the return target you are about to need.
 - On resume, confirm the new code is actually live, then finish the task without waiting to be told. Answering a resume with "nothing to do" is a defect.
 - Building the desktop on the host is the one exception to "never build on the host": its GUI toolchain is not in the pod image. The code is still authored in the pod.
 

--- a/erun-skills/skills/erun-orchestrate/SKILL.md
+++ b/erun-skills/skills/erun-orchestrate/SKILL.md
@@ -71,7 +71,7 @@ When the change under test is to erun's own tooling, roll it into the live tooli
 
 - If only the CLI changed, replace the binary in place; a running executable can be moved aside on every platform erun supports.
 - If the desktop binary is locked while running, the rebuild has to happen *after* it exits — from a **detached** relauncher that outlives your session. Record the return target first, including what to verify on resume.
-- **Reason about a restart from where your session actually runs — process ancestry answers that.** A quit command returning, or the old process still being listed a moment later, is not evidence that the quit failed or that your session lives elsewhere; shutdown is asynchronous. Acting on that inference skips the return target you are about to need.
+- **Reason about a restart from where your session actually runs — process ancestry answers that.** A quit command returning is not evidence that it worked or that your session lives elsewhere; shutdown is asynchronous, and a signal the target ignores looks identical to one that landed. Confirm the restart instead: the process is gone, or its start time moved. A resume-shaped nudge, or the tool list appearing to change, proves neither.
 - On resume, confirm the new code is actually live, then finish the task without waiting to be told. Answering a resume with "nothing to do" is a defect.
 - Building the desktop on the host is the one exception to "never build on the host": its GUI toolchain is not in the pod image. The code is still authored in the pod.
 

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -910,10 +910,13 @@ func (a *App) spawnOrchestratorSession(id, name string, envs []eruncommon.Orches
 	cols, rows = clampTerminalSize(cols, rows)
 	// Wire each linked env's erun MCP into the orchestrator session so it drives
 	// its envs through the MCP (raw/build/deploy/…) rather than raw kubectl.
-	// Non-fatal: the orchestrator still launches without the env MCP.
+	// Non-fatal: the orchestrator still launches without the env MCP, but an
+	// agent with linked envs and none of their tools looks working and is not,
+	// so the operator is told why instead of discovering it tool by tool.
 	mcpConfigPath, mcpErr := a.writeOrchestratorMCPConfig(id, envs)
 	if mcpErr != nil {
 		log.Printf("erun-app: write orchestrator MCP config for %s: %v", id, mcpErr)
+		a.emitAppNotification("warning", orchestratorMCPUnwiredNotice(name, mcpErr))
 	}
 	executable, args, err := a.deps.resolveOrchestratorLaunch(orchestratorSessionID(id), initialPrompt, resumePrompt, mcpConfigPath)
 	if err != nil {

--- a/erun-ui/orchestrator_mcp.go
+++ b/erun-ui/orchestrator_mcp.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,51 +9,48 @@ import (
 	eruncommon "github.com/sophium/erun/erun-common"
 )
 
-// orchestratorMCPServer is one Claude Code HTTP MCP server entry: a linked env's
-// erun MCP edge (emcp in the pod, exposing raw/diff/build/push/deploy/outputs_*),
-// reached over the desktop's local port-forward and authenticated with a
-// desktop-signed bearer.
+// orchestratorMCPServer is one Claude Code MCP server entry: a linked env's erun
+// MCP edge (emcp in the pod, exposing raw/diff/build/push/deploy/outputs_*),
+// reached by launching `erun mcp proxy` over stdio. The proxy mints a bearer per
+// request, so no credential is written here and a session cannot lose its envs
+// partway through to an aged-out token.
 type orchestratorMCPServer struct {
-	Type    string            `json:"type"`
-	URL     string            `json:"url"`
-	Headers map[string]string `json:"headers,omitempty"`
+	Type    string   `json:"type"`
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
 }
 
 type orchestratorMCPConfig struct {
 	MCPServers map[string]orchestratorMCPServer `json:"mcpServers"`
 }
 
-// mcpPortResolver and bearerSigner are seams so the config assembly is unit
-// testable without a live config store or signing identity.
-type (
-	mcpPortResolver func(tenant, environment string) int
-	bearerSigner    func(tenant, environment string) string
-)
+// mcpPortResolver is a seam so the config assembly is unit testable without a
+// live config store.
+type mcpPortResolver func(tenant, environment string) int
 
 // buildOrchestratorMCPConfig assembles the per-env MCP server map, keyed
 // "<tenant>-<environment>". An env is skipped (not an error) when its MCP port
-// or bearer cannot be resolved, so a partially-signable orchestrator still wires
-// the envs it can.
-func buildOrchestratorMCPConfig(envs []eruncommon.OrchestratorEnvConfig, mcpPort mcpPortResolver, bearer bearerSigner) orchestratorMCPConfig {
+// does not resolve — that env is not wired for MCP at all — so an orchestrator
+// still gets the envs it can reach.
+func buildOrchestratorMCPConfig(envs []eruncommon.OrchestratorEnvConfig, executable string, mcpPort mcpPortResolver) orchestratorMCPConfig {
 	servers := map[string]orchestratorMCPServer{}
+	executable = strings.TrimSpace(executable)
+	if executable == "" {
+		return orchestratorMCPConfig{MCPServers: servers}
+	}
 	for _, env := range envs {
 		tenant := strings.TrimSpace(env.Tenant)
 		environment := strings.TrimSpace(env.Environment)
 		if tenant == "" || environment == "" {
 			continue
 		}
-		port := mcpPort(tenant, environment)
-		if port <= 0 {
-			continue
-		}
-		token := strings.TrimSpace(bearer(tenant, environment))
-		if token == "" {
+		if mcpPort(tenant, environment) <= 0 {
 			continue
 		}
 		servers[tenant+"-"+environment] = orchestratorMCPServer{
-			Type:    "http",
-			URL:     fmt.Sprintf("http://127.0.0.1:%d/mcp", port),
-			Headers: map[string]string{"Authorization": "Bearer " + token},
+			Type:    "stdio",
+			Command: executable,
+			Args:    []string{"mcp", "proxy", "--tenant", tenant, "--environment", environment},
 		}
 	}
 	return orchestratorMCPConfig{MCPServers: servers}
@@ -63,19 +59,22 @@ func buildOrchestratorMCPConfig(envs []eruncommon.OrchestratorEnvConfig, mcpPort
 // writeOrchestratorMCPConfig writes a per-orchestrator Claude Code --mcp-config
 // file wiring each linked env's erun MCP into the orchestrator session, so it
 // drives its envs through the MCP rather than raw kubectl. Returns "" (no file)
-// when no env resolves a port + bearer, so the caller skips --mcp-config.
-// Bearers are minted fresh at each launch/resume (they expire; a longer-lived
-// refresh is a follow-up).
+// when no env resolves a port, so the caller skips --mcp-config.
 func (a *App) writeOrchestratorMCPConfig(id string, envs []eruncommon.OrchestratorEnvConfig) (string, error) {
-	config := buildOrchestratorMCPConfig(envs,
+	// No erun binary means no proxy to launch, so the session launches without
+	// its envs rather than with entries that would fail on first use.
+	executable, err := eruncommon.ResolveErunExecutable()
+	if err != nil {
+		return "", err
+	}
+	config := buildOrchestratorMCPConfig(envs, executable,
 		func(tenant, environment string) int {
-			ports, err := eruncommon.ResolveEnvironmentLocalPorts(a.deps.store, tenant, environment)
-			if err != nil {
+			ports, portErr := eruncommon.ResolveEnvironmentLocalPorts(a.deps.store, tenant, environment)
+			if portErr != nil {
 				return 0
 			}
 			return ports.MCP
 		},
-		a.mcpBearer,
 	)
 	if len(config.MCPServers) == 0 {
 		return "", nil

--- a/erun-ui/orchestrator_mcp.go
+++ b/erun-ui/orchestrator_mcp.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,16 +58,50 @@ func buildOrchestratorMCPConfig(envs []eruncommon.OrchestratorEnvConfig, executa
 	return orchestratorMCPConfig{MCPServers: servers}
 }
 
+// The two ways an orchestrator ends up with linked environments but none of
+// their tools. They stay distinct because the operator's fix differs: one is a
+// missing erun install, the other a linked environment that no longer resolves.
+var (
+	errOrchestratorMCPExecutable = errors.New("the erun executable could not be resolved")
+	errOrchestratorMCPNoPort     = errors.New("no linked environment resolved an MCP port")
+)
+
+// orchestratorMCPUnwiredNotice is the operator-facing line for an orchestrator
+// that launched without the tools for the environments it is linked to. It names
+// the cause and the matching recovery, since the session otherwise looks healthy
+// right up to the first environment call.
+func orchestratorMCPUnwiredNotice(name string, err error) string {
+	label := strings.TrimSpace(name)
+	if label == "" {
+		label = "The orchestrator"
+	}
+	cause, recovery := err.Error(), "Restart the orchestrator once that is resolved."
+	switch {
+	case errors.Is(err, errOrchestratorMCPExecutable):
+		cause = errOrchestratorMCPExecutable.Error()
+		recovery = "Install the erun command line tool, then restart the orchestrator."
+	case errors.Is(err, errOrchestratorMCPNoPort):
+		cause = errOrchestratorMCPNoPort.Error()
+		recovery = "Check its linked environments still exist, then restart the orchestrator."
+	}
+	return fmt.Sprintf("%s started without its environment tools: %s. %s", label, cause, recovery)
+}
+
 // writeOrchestratorMCPConfig writes a per-orchestrator Claude Code --mcp-config
 // file wiring each linked env's erun MCP into the orchestrator session, so it
-// drives its envs through the MCP rather than raw kubectl. Returns "" (no file)
-// when no env resolves a port, so the caller skips --mcp-config.
+// drives its envs through the MCP rather than raw kubectl. Returns "" with an
+// error naming why when nothing could be wired, so the caller skips
+// --mcp-config and can tell the operator which fix applies.
 func (a *App) writeOrchestratorMCPConfig(id string, envs []eruncommon.OrchestratorEnvConfig) (string, error) {
+	// An orchestrator with no linked envs has nothing to wire, and that is normal.
+	if len(envs) == 0 {
+		return "", nil
+	}
 	// No erun binary means no proxy to launch, so the session launches without
 	// its envs rather than with entries that would fail on first use.
 	executable, err := eruncommon.ResolveErunExecutable()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("%w: %w", errOrchestratorMCPExecutable, err)
 	}
 	config := buildOrchestratorMCPConfig(envs, executable,
 		func(tenant, environment string) int {
@@ -77,7 +113,7 @@ func (a *App) writeOrchestratorMCPConfig(id string, envs []eruncommon.Orchestrat
 		},
 	)
 	if len(config.MCPServers) == 0 {
-		return "", nil
+		return "", errOrchestratorMCPNoPort
 	}
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {

--- a/erun-ui/orchestrator_mcp_test.go
+++ b/erun-ui/orchestrator_mcp_test.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -93,6 +99,198 @@ func TestBuildOrchestratorLaunchInjectsMCPConfig(t *testing.T) {
 	_, withoutMCP := buildOrchestratorLaunch("linux", "", false, "", "", "")
 	if joined := strings.Join(withoutMCP, " "); strings.Contains(joined, "--mcp-config") {
 		t.Fatalf("expected no --mcp-config when path empty, got: %s", joined)
+	}
+}
+
+// bundledDesktopOutputEnvVar marks the re-exec'd child of
+// TestWriteOrchestratorMCPConfigFromBundledDesktop and tells it where to leave
+// the config it wrote, so the parent can assert on real written bytes.
+const bundledDesktopOutputEnvVar = "ERUN_TEST_BUNDLED_DESKTOP_OUTPUT"
+
+// The shipped desktop runs from <root>/bin/ERun.app/Contents/MacOS/erun-app and
+// launches its proxies with the erun beside the bundle at <root>/bin/erun. Only
+// a process actually running from that path exercises the resolution, so this
+// re-execs itself from a copy there — with an empty PATH and no ERUN_ERUN_BIN,
+// so the sibling binary is the only thing that can resolve.
+func TestWriteOrchestratorMCPConfigFromBundledDesktop(t *testing.T) {
+	if output := strings.TrimSpace(os.Getenv(bundledDesktopOutputEnvVar)); output != "" {
+		writeBundledDesktopMCPConfig(t, output)
+		return
+	}
+	root := t.TempDir()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test executable: %v", err)
+	}
+	program := copyTestFile(t, self, filepath.Join(root, "bin", "ERun.app", "Contents", "MacOS", "erun-app"))
+	sibling := copyTestFile(t, self, filepath.Join(root, "bin", "erun"))
+	output := filepath.Join(root, "written.json")
+
+	home := t.TempDir()
+	child := exec.Command(program, "-test.run", "^"+t.Name()+"$")
+	child.Env = []string{
+		"PATH=",
+		"HOME=" + home,
+		"USERPROFILE=" + home,
+		"XDG_CONFIG_HOME=" + filepath.Join(home, "config"),
+		bundledDesktopOutputEnvVar + "=" + output,
+	}
+	combined, runErr := child.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("bundled desktop child failed: %v\n%s", runErr, combined)
+	}
+	data, readErr := os.ReadFile(output)
+	if readErr != nil {
+		t.Fatalf("the bundled desktop wrote no MCP config: %v\n%s", readErr, combined)
+	}
+	assertBundledDesktopMCPConfig(t, data, sibling)
+}
+
+// writeBundledDesktopMCPConfig is the child half: it runs the real wiring from
+// inside the bundle and hands the bytes back through output.
+func writeBundledDesktopMCPConfig(t *testing.T, output string) {
+	t.Helper()
+	app := orchestratorTestApp(t)
+	defer app.shutdown(context.Background())
+
+	path, err := app.writeOrchestratorMCPConfig("petios", []eruncommon.OrchestratorEnvConfig{
+		{Tenant: "frs", Environment: "dev"},
+	})
+	if err != nil {
+		t.Fatalf("writeOrchestratorMCPConfig: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written config %s: %v", path, err)
+	}
+	if err := os.WriteFile(output, data, 0o600); err != nil {
+		t.Fatalf("hand config back: %v", err)
+	}
+}
+
+func assertBundledDesktopMCPConfig(t *testing.T, data []byte, wantCommand string) {
+	t.Helper()
+	var config orchestratorMCPConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("parse written config: %v\n%s", err, data)
+	}
+	server, ok := config.MCPServers["frs-dev"]
+	if !ok {
+		t.Fatalf("written config has no server for the linked env:\n%s", data)
+	}
+	if server.Type != "stdio" || server.Command != wantCommand {
+		t.Fatalf("server = %+v, want a stdio entry commanding %q", server, wantCommand)
+	}
+	if got, want := strings.Join(server.Args, " "), "mcp proxy --tenant frs --environment dev"; got != want {
+		t.Fatalf("args = %q, want %q", got, want)
+	}
+	for _, forbidden := range []string{"Bearer", "Authorization", "authorization", "headers", "token"} {
+		if strings.Contains(string(data), forbidden) {
+			t.Fatalf("written config carries %q:\n%s", forbidden, data)
+		}
+	}
+}
+
+func copyTestFile(t *testing.T, source, destination string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		t.Fatalf("create %s: %v", filepath.Dir(destination), err)
+	}
+	in, err := os.Open(source)
+	if err != nil {
+		t.Fatalf("open %s: %v", source, err)
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("create %s: %v", destination, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		t.Fatalf("copy %s: %v", destination, err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("close %s: %v", destination, err)
+	}
+	return destination
+}
+
+// An orchestrator whose linked environments produced no MCP server has to say
+// so: the session launches and looks healthy, and the operator would otherwise
+// only find out one missing tool call at a time. No linked environments is the
+// ordinary case and stays quiet.
+func TestSpawnOrchestratorSignalsUnwiredEnvironments(t *testing.T) {
+	for _, testCase := range []struct {
+		name     string
+		envs     []eruncommon.OrchestratorEnvConfig
+		wantNote string
+	}{
+		{
+			name: "linked env resolves an MCP port",
+			envs: []eruncommon.OrchestratorEnvConfig{{Tenant: "frs", Environment: "dev"}},
+		},
+		{
+			name:     "linked env resolves no MCP port",
+			envs:     []eruncommon.OrchestratorEnvConfig{{Tenant: "ghost", Environment: "missing"}},
+			wantNote: errOrchestratorMCPNoPort.Error(),
+		},
+		{
+			name: "no linked envs",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			// The override keeps the erun binary resolvable regardless of what sits
+			// beside the test binary, so the port is the only variable under test.
+			t.Setenv("ERUN_ERUN_BIN", filepath.Join(t.TempDir(), "erun"))
+			app := orchestratorTestApp(t)
+			defer app.shutdown(context.Background())
+			emits := newCapturedEmits()
+			app.emitFn = emits.fn()
+
+			if _, err := app.spawnOrchestratorSession("petios", "Petios", testCase.envs, "", "", false, 80, 24); err != nil {
+				t.Fatalf("spawnOrchestratorSession: %v", err)
+			}
+			assertUnwiredNotice(t, emits.events(appNotificationEvent), testCase.wantNote)
+		})
+	}
+}
+
+func assertUnwiredNotice(t *testing.T, events []any, wantNote string) {
+	t.Helper()
+	if wantNote == "" {
+		if len(events) != 0 {
+			t.Fatalf("expected no notification, got %+v", events)
+		}
+		return
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected one notification, got %+v", events)
+	}
+	payload, ok := events[0].(appNotificationPayload)
+	if !ok {
+		t.Fatalf("unexpected payload type: %T", events[0])
+	}
+	if payload.Kind != "warning" {
+		t.Fatalf("kind = %q, want warning so the banner persists", payload.Kind)
+	}
+	if !strings.Contains(payload.Message, wantNote) || !strings.Contains(payload.Message, "Petios") {
+		t.Fatalf("message %q does not name the orchestrator and the cause %q", payload.Message, wantNote)
+	}
+}
+
+// The two causes need different fixes, so the notice must not collapse them into
+// one "could not be wired".
+func TestOrchestratorMCPUnwiredNoticeNamesTheCause(t *testing.T) {
+	executable := orchestratorMCPUnwiredNotice("Petios", errors.Join(errOrchestratorMCPExecutable, errors.New("not on PATH")))
+	if !strings.Contains(executable, errOrchestratorMCPExecutable.Error()) || !strings.Contains(executable, "Install the erun command line tool") {
+		t.Fatalf("executable notice does not name its recovery: %q", executable)
+	}
+	port := orchestratorMCPUnwiredNotice("", errOrchestratorMCPNoPort)
+	if !strings.Contains(port, errOrchestratorMCPNoPort.Error()) || !strings.Contains(port, "linked environments still exist") {
+		t.Fatalf("port notice does not name its recovery: %q", port)
+	}
+	if strings.Contains(port, errOrchestratorMCPExecutable.Error()) {
+		t.Fatalf("port notice blames the executable: %q", port)
 	}
 }
 

--- a/erun-ui/orchestrator_mcp_test.go
+++ b/erun-ui/orchestrator_mcp_test.go
@@ -1,46 +1,38 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	eruncommon "github.com/sophium/erun/erun-common"
 )
 
-// orchestratorTestPort/Bearer are the port and bearer stubs the config builder
-// is driven with; extracted from the test body so its own branching stays under
-// the cyclop threshold. nobearer resolves a port but an empty bearer, so the
-// builder must still skip it.
+// orchestratorTestPort is the port stub the config builder is driven with;
+// extracted from the test body so its own branching stays under the cyclop
+// threshold.
 func orchestratorTestPort(tenant, _ string) int {
 	switch tenant {
 	case "petios":
 		return 17400
 	case "erun":
 		return 17300
-	case "nobearer":
-		return 18000
 	default:
 		return 0
 	}
 }
 
-func orchestratorTestBearer(tenant, _ string) string {
-	if tenant == "nobearer" {
-		return ""
+func orchestratorTestEnvs() []eruncommon.OrchestratorEnvConfig {
+	return []eruncommon.OrchestratorEnvConfig{
+		{Tenant: "petios", Environment: "rihards-win-develop"},
+		{Tenant: "erun", Environment: "main"},
+		{Tenant: "noport", Environment: "x"}, // skipped: port 0
+		{Tenant: "", Environment: "z"},       // skipped: blank tenant
 	}
-	return "tok-" + tenant
 }
 
 func TestBuildOrchestratorMCPConfig(t *testing.T) {
-	envs := []eruncommon.OrchestratorEnvConfig{
-		{Tenant: "petios", Environment: "rihards-win-develop"},
-		{Tenant: "erun", Environment: "main"},
-		{Tenant: "noport", Environment: "x"},   // skipped: port 0
-		{Tenant: "nobearer", Environment: "y"}, // skipped: empty bearer
-		{Tenant: "", Environment: "z"},         // skipped: blank tenant
-	}
-
-	config := buildOrchestratorMCPConfig(envs, orchestratorTestPort, orchestratorTestBearer)
+	config := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort)
 
 	if len(config.MCPServers) != 2 {
 		t.Fatalf("expected 2 servers, got %d: %v", len(config.MCPServers), config.MCPServers)
@@ -49,19 +41,46 @@ func TestBuildOrchestratorMCPConfig(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing petios server: %v", config.MCPServers)
 	}
-	if petios.Type != "http" || petios.URL != "http://127.0.0.1:17400/mcp" {
+	if petios.Type != "stdio" || petios.Command != "/opt/erun/bin/erun" {
 		t.Fatalf("unexpected petios server: %+v", petios)
 	}
-	if got := petios.Headers["Authorization"]; got != "Bearer tok-petios" {
-		t.Fatalf("unexpected petios auth header: %q", got)
+	wantArgs := "mcp proxy --tenant petios --environment rihards-win-develop"
+	if got := strings.Join(petios.Args, " "); got != wantArgs {
+		t.Fatalf("petios args = %q, want %q", got, wantArgs)
 	}
 	if _, ok := config.MCPServers["erun-main"]; !ok {
 		t.Fatalf("missing erun server")
 	}
-	for _, skipped := range []string{"noport-x", "nobearer-y", "-z"} {
+	for _, skipped := range []string{"noport-x", "-z"} {
 		if _, ok := config.MCPServers[skipped]; ok {
 			t.Fatalf("expected %s to be skipped", skipped)
 		}
+	}
+}
+
+// The written file is what a launched orchestrator reads, and it must never be a
+// place a bearer can leak from: an MCP client cannot refresh a header it was
+// configured with, so the fix for the expiry was to stop writing one at all.
+func TestBuildOrchestratorMCPConfigCarriesNoCredential(t *testing.T) {
+	config := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort)
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	for _, forbidden := range []string{"Bearer", "Authorization", "authorization", "headers", "token"} {
+		if strings.Contains(string(data), forbidden) {
+			t.Fatalf("config carries %q:\n%s", forbidden, data)
+		}
+	}
+}
+
+// Without an erun binary there is no proxy to launch, so the whole map is empty
+// and the caller skips --mcp-config rather than writing entries that fail on
+// first use.
+func TestBuildOrchestratorMCPConfigSkipsEveryEnvWithoutAnExecutable(t *testing.T) {
+	config := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "  ", orchestratorTestPort)
+	if len(config.MCPServers) != 0 {
+		t.Fatalf("expected no servers without an executable, got %v", config.MCPServers)
 	}
 }
 

--- a/erun-ui/playwright/tests/app-notification.spec.ts
+++ b/erun-ui/playwright/tests/app-notification.spec.ts
@@ -56,6 +56,36 @@ test.describe('app-notification toast', () => {
     await expect(pill).toBeVisible();
   });
 
+  test('warning notification persists and stays copyable', async ({ app: _app, page }) => {
+    // An orchestrator that launched without the tools for its linked
+    // environments posts a warning here, and the operator must still be able to
+    // read the cause after the session is up — a warning that auto-dismissed
+    // would put the diagnosis back where it was, in the log. The emit itself is
+    // owned by TestSpawnOrchestratorSignalsUnwiredEnvironments (Go): spawning an
+    // orchestrator needs a real AI harness and PTY, which this harness lacks.
+    const message =
+      'Petios started without its environment tools: no linked environment resolved an MCP port. Check its linked environments still exist, then restart the orchestrator.';
+    await page.clock.install();
+    await page.evaluate(
+      (payload) => {
+        const runtime = (
+          window as unknown as {
+            runtime: { EventsEmit: (n: string, ...a: unknown[]) => void };
+          }
+        ).runtime;
+        runtime.EventsEmit('app-notification', payload);
+      },
+      { kind: 'warning', message },
+    );
+
+    const pill = page.getByRole('status').filter({ hasText: message });
+    await expect(pill).toBeVisible();
+
+    await page.clock.fastForward(5_000);
+    await expect(pill).toBeVisible();
+    await expect(pill.getByRole('button', { name: /copy/i })).toBeVisible();
+  });
+
   test('payload with empty message is ignored', async ({ app: _app, page }) => {
     // The titlebar idle-status widget also carries role=status when an env with
     // a managed cloud context is active, so an ignored payload can't be checked


### PR DESCRIPTION
Three orchestrator defects, all found by hitting them mid-task — including the third, which this PR's own first pass shipped and the end-to-end gate caught.

Closes #921
Closes #923

## An orchestrator session's env MCP tools died ~5 minutes in (#923)

The desktop wired each linked environment's MCP edge into the session by writing a Claude Code `--mcp-config` file containing a **frozen** bearer:

```go
Headers: map[string]string{"Authorization": "Bearer " + token},
```

That token has a deliberately short TTL (`desktopMCPTokenTTL = 5 * time.Minute`), and an MCP client reads its config once at launch — it cannot refresh a header. So about five minutes into every orchestrator session, **every tool for every linked env** started failing with `requires re-authorization (token expired)`: `raw`, `deploy`, `diff`, `outputs_*`, `job_*`, all at once, because the failure sits at the transport's auth edge rather than in any tool. The file's own comment conceded it — *"they expire; a longer-lived refresh is a follow-up"*. This is that follow-up.

It fired three times in a single working session. The real damage is the pressure it creates: with the sanctioned interface dead and no in-session recovery, the tempting next step is `kubectl exec`, which the guidance forbids. A guardrail that expires five minutes in teaches people to route around it.

**The fix removes the class of failure rather than widening the window.** Nothing in the client's config is a credential any more: each env is injected as a **stdio** server that launches `erun mcp proxy --tenant T --environment E`, which mints a fresh bearer *per request* and relays to the pod's HTTP edge. Tokens stay short-lived (the security rationale is preserved), no credential is ever written to disk (previously one sat in a `0600` file), and session length is decoupled from token lifetime. Lengthening the TTL was explicitly rejected: it trades the security property away and any finite TTL still fails a long session.

Design notes: newline-delimited JSON-RPC in, one compacted line out; SSE `data:` framing unwrapped; `Mcp-Session-Id` captured and replayed so the client never sees it; the client's own `initialize` is relayed rather than shadowed. Every failure — unreachable edge, 401/403, or an accepted request with no body (which would otherwise hang the client forever) — is answered as a JSON-RPC error on the failing request's own id, carrying the `erun open` / redeploy recovery text, and the relay keeps serving. **stdout carries JSON-RPC and nothing else**; all diagnostics go to stderr.

`erun-common/mcp_client.go` was split rather than duplicated (`newMCPSession` transport vs `openMCPSession` handshake, plus a `postRaw` owning bearer minting and session capture), so a raw relay and a typed `mcp call` cannot drift on headers, session or framing.

## The desktop could not find `erun` from inside its own .app bundle

The first pass of this PR shipped the proxy and **still left an orchestrator with zero env MCP servers** — the failure mode flagged during review as worse than the original bug. The end-to-end gate caught it; this is the fix.

`writeOrchestratorMCPConfig` starts at `ResolveErunExecutable`, whose sibling search only looked in the running program's own directory and two levels above it. That was written as "mirrors `resolveAppExecutable`", but the two directions are **not** symmetric: CLI→app climbs two levels to `bin/ERun.app`, while app→CLI must climb *three* out of `ERun.app/Contents/MacOS/`. Both candidates missed:

```
…/bin/ERun.app/Contents/MacOS/erun     MISSING   (dir/erun)
…/bin/ERun.app/erun-cli/bin/erun       MISSING   (dir/../../erun-cli/bin/erun)
actual binary:  …/bin/erun
```

The `PATH` fallback missed too — on the reporting host `erun` is a shell alias, not a binary. So resolution failed, `writeOrchestratorMCPConfig` returned `("", err)`, the caller omitted `--mcp-config` entirely, and the session launched with no env tools at all.

`erunExecutableNear` now detects the bundle shape and adds the directory *containing* the bundle as a second search root, applying the existing candidate patterns to both roots. `macOSBundleContainer` only matches when every level lines up (`…/<Name>.app/Contents/MacOS`), so no other host's directory named `MacOS` can pull the search outside its own tree; non-bundle layouts resolve exactly as before.

**The silence was the other half of the defect.** The failure was one `log.Printf` — an agent with linked environments and none of their tools looks healthy right up to the first environment call, so the operator discovers it one dead tool at a time. When an orchestrator has linked envs and nothing could be wired, the desktop now posts a **warning** notification naming the cause and the matching recovery. The two causes stay distinct because their fixes differ (`errOrchestratorMCPExecutable` → install the CLI; `errOrchestratorMCPNoPort` → check the linked envs still exist), and the session still launches. Warning-kind notifications persist in the titlebar and carry a copy action, so the diagnosis lands where the operator acts rather than in the log. An orchestrator with **no** linked envs has nothing to wire and stays quiet.

Dead code removed along the way: the `bearerSigner` seam and the skip-on-unsignable-bearer condition — an env is now skipped only if its MCP port or the erun binary cannot be resolved.

### UX impact review

1. **Affected paths.** Orchestrator start/restart and Investigate → `spawnOrchestratorSession`.
2. **User-visible sequence.** The session opens as before; if its envs could not be wired, a persistent warning pill appears in the titlebar naming the cause and the recovery.
3. **State-without-affordance.** The emit renders the titlebar notification pill; no `AppState` field is mutated without one.
4. **Visibility of system status (Nielsen #1).** Persistent — a warning does not auto-dismiss, so the diagnosis survives the session coming up.
5. **Success/failure feedback (Nielsen #1, #9).** The notice names the cause and the concrete next action.
6. **Consistency (Nielsen #4).** Matches the runtime-unreachable warning in `env_ensure.go`.
7. **Heuristic pass.** #1 visibility and #9 error recovery drive the change; user control, consistency, error prevention, recognition, flexibility, aesthetics, match with the real world and help docs are unaffected.
8. **Playwright.** `app-notification.spec.ts` gains warning-persistence coverage (the pill survives a 5s clock fast-forward and keeps its copy action). The emit itself needs a real AI harness and PTY, which the headless harness lacks, so `TestSpawnOrchestratorSignalsUnwiredEnvironments` owns that branch.

**Docs.** `reference/troubleshooting` (Operator-facing) gains an "Orchestrator started without its environment tools" section: the symptom, both causes as the operator sees them worded, and the fix each one needs. The existing proxy pages from the first pass (`cli/mcp`, `agent-reference/cli-flags`, `mcp/overview`, and the re-authorization entry on the same troubleshooting page) already cover `erun mcp proxy` itself.

## The restart guidance never said where the session runs (#921)

It required a relauncher that "outlives your session" without saying where the session lives, so an asynchronous desktop shutdown misreads badly: the quit command returns immediately and the old process stays listed for seconds. That reads as "my session isn't hosted by the desktop", which was wrong — ancestry showed the chain terminating at the desktop process, and the restart had worked exactly as documented. Reading it that way invites skipping the recorded return target, and the session then ends with nothing to resume to. One abstract bullet in the `erun-orchestrate` skill, per its closing rule: reason about a restart from where the session actually runs, and *confirm* it landed rather than inferring it — a signal the target ignores looks identical to one that worked, so the evidence is the process being gone or its start time having moved, not a resume-shaped nudge.

## Verification

**Gates.** `make lint` `0 issues.` across all five gated modules, plus `0 issues.` for `erun-ui`. `go test ./...` green in `erun-common`, `erun-cli`, `erun-mcp`, `erun-ui`. `make integration-test` green at **76.2%** (≥ 75.0). `gofmt -l` clean. `erun-ui/build.sh` green end to end (`yarn typecheck` + `lint` + `format:check` + frontend unit tests + `golangci-lint` + `vite build` + the Go link). `playwright/run.sh` **140 passed** (139 before, +1 for the new warning-persistence spec). `cd erun-docs && yarn build` clean, which is also what proves the new troubleshooting section's link resolves (`onBrokenLinks: 'throw'`).

7 integration scenarios with recorded goldens cover the proxy: help, dry-run trace, a full JSON-framed session (stdout purity via per-line JSON parse, notification producing no line, session-id propagation, per-request verifiable bearer), SSE-framed reply, notification-only, unreachable edge answering every request and continuing, unauthorized edge, and the no-reply case.

**The bundle defect is proven by before/after against real binaries, not by unit tests alone.** The previous pass's suite passed while production was broken, because nothing exercised a `.app/Contents/MacOS` layout — so the regression proof is a real `erun-app` running from that path. Two binaries were built from this branch: the pre-fix tip (`b2a434e1`) and the fix (`1f22fbd2`). Each was placed at `<root>/bin/ERun.app/Contents/MacOS/erun-app` with the real `erun` CLI beside the bundle at `<root>/bin/erun`, booted `--headless` against an isolated `HOME`/`XDG_CONFIG_HOME` with one seeded tenant/env, and driven through the shipped path — `CreateOrchestrator` then `StartOrchestrator` over `/__erun_invoke`. **`PATH` was scrubbed of `erun`** (the host has one at `/usr/local/bin/erun`; it was excluded), so only sibling resolution could succeed.

*Pre-fix — the reported failure, reproduced exactly:*

```
StartOrchestrator: {"status":"running", …}      ← looks healthy
--- written MCP config(s) ---
NO orchestrator-mcp-*.json WAS WRITTEN
--- server log ---
erun-app: write orchestrator MCP config for petios: the erun executable was not
  found beside this program or on PATH: exec: "erun": executable file not found in $PATH
```

*Post-fix — same layout, same inputs:*

```json
{
  "mcpServers": {
    "frs-dev": {
      "type": "stdio",
      "command": "…/run-fixed/bin/erun",
      "args": ["mcp", "proxy", "--tenant", "frs", "--environment", "dev"]
    }
  }
}
```

The resolved command is the binary beside the bundle — three levels above the running program, the level the old search never reached — and the file carries no `Bearer`, no `Authorization`, no token.

*The notification half, driven the same way* with **no** `erun` beside the bundle and none on `PATH`, capturing the headless SSE event stream the frontend consumes:

- Pre-fix: `(NONE — the operator was told nothing)`.
- Post-fix: `{"kind":"warning","message":"Petios started without its environment tools: the erun executable could not be resolved. Install the erun command line tool, then restart the orchestrator."}`

From the earlier pass, still standing: the proxy mechanism **does not age out**. At **6 minutes 31 seconds** of session elapsed — past the mark where the frozen bearer used to die — a full `initialize` + `tools/call version` through `erun mcp proxy` returned `{"version":"1.0.167"}`, and the host-CLI control `erun mcp call` returned the same. Session propagation was proven negatively too: `tools/list` alone through a fresh proxy gets `method "tools/list" is invalid during session initialization`, so the successful calls only worked because the proxy carried the id. Against a pod holding a *different* desktop key, every request came back as a mapped JSON-RPC error (`HTTP 401: MCP token signature is not valid…`) and the relay kept serving and exited 0.

### Not verified

This pass ran from inside the `erun/local` runtime pod (Linux/arm64), not the macOS host desktop, so it could not restart the shipped desktop app and watch an operator's session hold its env tools past the six-minute mark. What that leaves unproven is macOS-native and client-side, not the logic under test: the bundle-shape detection is pure path handling with no `runtime.GOOS` gate, which is exactly why a Linux run can exercise it faithfully. Not covered here: the darwin packaging arm of `erun-ui/build.sh` that produces the real `ERun.app`, the Wails window rendering the warning pill (the Playwright spec covers the pill's persistence and copy action in the same React tree), and Claude Code itself reading the written `--mcp-config` and launching the stdio proxy.
