### PR TITLE
Resolve a stable-only snapshot channel, keep linked mirrors live, anchor a job dir, and show an orchestrator working

### DIFF
--- a/erun-common/job_supervisor.go
+++ b/erun-common/job_supervisor.go
@@ -78,7 +78,46 @@ func (p StartEnvironmentJobParams) normalize() (StartEnvironmentJobParams, error
 	if p.LeaseTTL, err = normalizeEnvironmentJobLeaseTTL(p.LeaseTTL); err != nil {
 		return p, err
 	}
+	if p.Dir, err = resolveEnvironmentJobDir(p.Dir); err != nil {
+		return p, err
+	}
 	return p, nil
+}
+
+// resolveEnvironmentJobDir resolves the directory the work runs in, and proves
+// it usable before anything is detached.
+//
+// The supervisor is started with no inherited working directory, so a relative
+// dir cannot mean "relative to the supervisor" — left alone it resolves against
+// whatever directory the transport happens to be sitting in, which is not the
+// repository. Anchor it to the project root instead, the same reading every
+// other repo-facing surface gives a path, so a caller can name a subdirectory
+// here exactly as they would to `raw`.
+//
+// The check happens now rather than at exec because Go reports an unusable
+// cmd.Dir as an ENOENT naming the *binary*: an unverified dir surfaces as a
+// missing shell, sending the reader after a broken image instead of a bad path.
+func resolveEnvironmentJobDir(dir string) (string, error) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return "", nil
+	}
+	resolved := dir
+	if !filepath.IsAbs(resolved) {
+		if _, root, err := FindProjectRoot(); err == nil {
+			resolved = filepath.Join(root, resolved)
+		} else if abs, absErr := filepath.Abs(resolved); absErr == nil {
+			resolved = abs
+		}
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("job dir %q does not exist (resolved to %s)", dir, resolved)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("job dir %q is not a directory (resolved to %s)", dir, resolved)
+	}
+	return resolved, nil
 }
 
 // normalizeEnvironmentJobIdentity resolves the target and the handle a job is

--- a/erun-common/upgrade.go
+++ b/erun-common/upgrade.go
@@ -397,7 +397,13 @@ func (p UpgradePlan) Lagging() []UpgradePlanItem {
 
 func channelTarget(versions RuntimeRegistryVersions, channel string) string {
 	if strings.TrimSpace(channel) == UpgradeChannelSnapshot {
-		if stable, _, superseded := stableSupersedesSnapshot(versions); superseded {
+		// An absent snapshot side is not "nothing newer exists" — it means the
+		// registry publishes no snapshots at all, and the stable release is then
+		// the only, and newest, candidate. Falling through to LatestSnapshot in
+		// that case resolves to "", which leaves a snapshot-channel env
+		// permanently unresolvable against a stable-only registry — the canonical
+		// one included, so every env pointed at it silently never upgraded.
+		if stable, snapshot, superseded := stableSupersedesSnapshot(versions); superseded || snapshot == "" {
 			return stable
 		}
 		return strings.TrimSpace(versions.LatestSnapshot)

--- a/erun-common/upgrade_resolver_test.go
+++ b/erun-common/upgrade_resolver_test.go
@@ -144,6 +144,47 @@ func TestResolveEnvUpgradeItemCandidates(t *testing.T) {
 		item := resolveEnvUpgradeItem("team", env, "3.0.0", nil, noTrace)
 		assertLaggingSingleTarget(t, item, "3.0.0", "expected the override target, got %+v")
 	})
+
+	t.Run("a snapshot-channel env adopts stable when the registry has no snapshots (#928)", func(t *testing.T) {
+		// The canonical registry publishes stable releases only. Before #928 the
+		// snapshot channel returned LatestSnapshot unconditionally once the
+		// supersede check declined, so an empty snapshot side resolved to "" and
+		// the env stayed unresolved forever against a perfectly good stable.
+		snapshotEnv := EnvConfig{Name: "ux", RuntimeVersion: "1.0.110", UpgradeChannel: UpgradeChannelSnapshot}
+		resolver := func(_ Context, _ string, _ EnvConfig) ([]SourcedRuntimeVersions, error) {
+			return []SourcedRuntimeVersions{{Registry: DefaultContainerRegistry, Versions: RuntimeRegistryVersions{LatestStable: "1.0.173"}}}, nil
+		}
+		item := resolveEnvUpgradeItem("erun", snapshotEnv, "", resolver, noTrace)
+		if item.UnresolvedReason != "" {
+			t.Fatalf("a stable-only registry must resolve for the snapshot channel, got %+v", item)
+		}
+		assertLaggingSingleTarget(t, item, "1.0.173", "expected the stable release as the snapshot-channel target, got %+v")
+	})
+
+	t.Run("a snapshot-channel env already at the stable release is up to date (#928)", func(t *testing.T) {
+		snapshotEnv := EnvConfig{Name: "ux", RuntimeVersion: "1.0.173", UpgradeChannel: UpgradeChannelSnapshot}
+		resolver := func(_ Context, _ string, _ EnvConfig) ([]SourcedRuntimeVersions, error) {
+			return []SourcedRuntimeVersions{{Registry: DefaultContainerRegistry, Versions: RuntimeRegistryVersions{LatestStable: "1.0.173"}}}, nil
+		}
+		item := resolveEnvUpgradeItem("erun", snapshotEnv, "", resolver, noTrace)
+		if item.Lagging || item.Target != "1.0.173" || item.UnresolvedReason != "" {
+			t.Fatalf("expected up to date, not unresolved, got %+v", item)
+		}
+	})
+
+	t.Run("a newer snapshot stream still wins for the snapshot channel", func(t *testing.T) {
+		// The #524 behaviour must survive #928: a snapshot whose base outranks the
+		// stable belongs to the next stream and stays the target.
+		snapshotEnv := EnvConfig{Name: "ux", RuntimeVersion: "1.0.100", UpgradeChannel: UpgradeChannelSnapshot}
+		resolver := func(_ Context, _ string, _ EnvConfig) ([]SourcedRuntimeVersions, error) {
+			return []SourcedRuntimeVersions{{Registry: DefaultContainerRegistry, Versions: RuntimeRegistryVersions{
+				LatestStable:   "1.0.173",
+				LatestSnapshot: "1.0.174-snapshot-20260808110000",
+			}}}, nil
+		}
+		item := resolveEnvUpgradeItem("erun", snapshotEnv, "", resolver, noTrace)
+		assertLaggingSingleTarget(t, item, "1.0.174-snapshot-20260808110000", "expected the newer snapshot stream to stay the target, got %+v")
+	})
 }
 
 func assertLaggingSingleTarget(t *testing.T, item UpgradePlanItem, wantTarget, failMsg string) {

--- a/erun-integration/job_test.go
+++ b/erun-integration/job_test.go
@@ -94,6 +94,45 @@ func TestJob(t *testing.T) {
 		golden.Equal(t, "job/help", normalize.Apply(result.Combined))
 	})
 
+	t.Run("start_refuses_a_dir_that_does_not_exist_by_name", func(t *testing.T) {
+		// An unusable working directory used to reach exec, where Go reports it
+		// as an ENOENT naming the *binary* — so a dir the supervisor could not
+		// resolve surfaced as a missing shell and sent the reader after a broken
+		// image instead of a bad path (#932).
+		setup := env.New(t)
+		envVars := jobStubEnv(t, setup, "printf '" + jobStubSignal + "'")
+		result := startJob(t, setup, envVars, "baddir", "--dir", "no-such-subdir", "--", "work")
+		if result.ExitCode == 0 {
+			t.Fatalf("expected a refusal for a missing dir, got exit 0:\n%s", result.Combined)
+		}
+		if !strings.Contains(result.Combined, "no-such-subdir") {
+			t.Fatalf("the refusal must name the dir, got:\n%s", result.Combined)
+		}
+		if strings.Contains(result.Combined, "fork/exec") {
+			t.Fatalf("a bad dir must not surface as an exec failure, got:\n%s", result.Combined)
+		}
+	})
+
+	t.Run("start_runs_the_work_in_a_relative_dir", func(t *testing.T) {
+		// The supervisor is detached with no inherited working directory, so a
+		// relative dir has to be anchored before it is handed over, the same way
+		// every other repo-facing surface reads a path (#932).
+		setup := env.New(t)
+		workdir := filepath.Join(setup.Cwd, "workdir-sub")
+		if err := os.MkdirAll(workdir, 0o755); err != nil {
+			t.Fatalf("create the work directory: %v", err)
+		}
+		envVars := jobStubEnv(t, setup, "pwd > pwd.txt")
+		result := startJob(t, setup, envVars, "reldir", "--dir", "workdir-sub", "--", "work")
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		got := strings.TrimSpace(waitForFile(t, filepath.Join(workdir, "pwd.txt"), 30*time.Second))
+		if filepath.Base(got) != "workdir-sub" {
+			t.Fatalf("work ran in %q, want it resolved to %s", got, workdir)
+		}
+	})
+
 	t.Run("await_help", func(t *testing.T) {
 		// The await exit codes are the contract an orchestrator branches on, so the
 		// help that states them is locked here.

--- a/erun-integration/testdata/upgrade/dry_run_snapshot_channel_without_published_snapshot.txt
+++ b/erun-integration/testdata/upgrade/dry_run_snapshot_channel_without_published_snapshot.txt
@@ -2,8 +2,17 @@ audit: erun upgrade --dry-run team
 upgrade: tenant=team environment= version-override= force=false
 upgrade: team/agent opted in, channel=snapshot current=<VERSION>
 upgrade: resolving versions for team/agent from the listed registries
-upgrade: team/agent target unresolved: no snapshot version found in the listed registries
-==> Upgrade plan: 1 member(s), 0 lagging
-    team/agent [snapshot] <VERSION> -> (unset)  (target unresolved: no snapshot version found in the listed registries)
-upgrade: team/agent target unresolved, skipping: no snapshot version found in the listed registries
-==> Upgrade complete: 0 upgraded, 0 up to date, 1 unresolved, 0 failed
+upgrade: team/agent <VERSION> -> <VERSION>
+==> Upgrade plan: 1 member(s), 1 lagging
+    team/agent [snapshot] <VERSION> -> <VERSION>  (will upgrade)
+==> Upgrading team/agent <VERSION> -> <VERSION> (snapshot)
+deploy: component selection source default (runtime only); deploying the runtime chart alone
+deploy: no local runtime chart; using published chart oci://ghcr.io/sophium/charts/erun-devops version <VERSION>
+deploy: defaulting runtime image to the tenant's team-devops image ghcr.io/sophium/team-devops:<VERSION> (imageOverrides.erun-devops)
+kubectl --context test-context get namespace team-agent -o name
+kubectl --context test-context create namespace team-agent
+helm upgrade --install --wait --wait-for-jobs --server-side true --force-conflicts --timeout 5m0s --namespace team-agent --debug --kube-context test-context --set-string tenant=team --set-string environment=agent --set-string worktreeStorage=pvc --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set-string api.oidcAllowedIssuers= --set api.postgres.reset=false --set-string containerRegistry=ghcr.io/sophium --set-json 'containerRegistries=[{"registry":"ghcr.io/sophium","roles":["build","deploy"]}]' --set disableBuildScript=false --set-string imageOverrides.erun-devops=ghcr.io/sophium/team-devops:<VERSION> --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops oci://ghcr.io/sophium/charts/erun-devops --version <VERSION>
+deploy: watching pods in team-agent on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-agent get pods -o json
+dedup: ready (release=test-context-team-agent-team-devops, hash=<HASH>)
+==> Upgrade complete: 1 upgraded, 0 up to date, 0 unresolved, 0 failed

--- a/erun-ui/ai_activity_test.go
+++ b/erun-ui/ai_activity_test.go
@@ -17,7 +17,10 @@ import (
 //     output, regardless of how long busy=true was latched.
 //   - Session close (finalizeAIActivity) must release a latched
 //     busy=true even mid-generation.
-//   - The signal is silent for non-AI session kinds.
+//   - An orchestrator session drives the signal exactly as an AI tab does:
+//     it runs the same agent, and its row is the one most likely to be
+//     working, so a silent orchestrator row read as idle while it worked.
+//   - The signal is silent for every other session kind.
 func TestRecordAIActivityDebounce(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -26,6 +29,7 @@ func TestRecordAIActivityDebounce(t *testing.T) {
 		wantSecond bool
 	}{
 		{name: "AI session emits ai-activity", kind: sessionKindAI, wantEmits: true},
+		{name: "Orchestrator session emits ai-activity", kind: sessionKindOrchestrator, wantEmits: true},
 		{name: "Local session is silent", kind: sessionKindLocal, wantEmits: false},
 		{name: "Open session is silent", kind: sessionKindOpen, wantEmits: false},
 		{name: "Command session is silent", kind: sessionKindCommand, wantEmits: false},

--- a/erun-ui/frontend/src/app/slices/aiActivitySlice.ts
+++ b/erun-ui/frontend/src/app/slices/aiActivitySlice.ts
@@ -8,10 +8,15 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 // Record<string, true> to keep the slice state serializable.
 export interface AIActivityState {
   aiBusyByEnv: Record<string, true>;
+  // Orchestrator sessions have no tenant/environment to key by, so their latch
+  // is keyed by session id. Same event, same debounce policy — only the address
+  // differs, because an orchestrator row is not an env row.
+  aiBusyBySession: Record<number, true>;
 }
 
 const initialState: AIActivityState = {
   aiBusyByEnv: {},
+  aiBusyBySession: {},
 };
 
 export const aiActivitySlice = createSlice({
@@ -25,11 +30,19 @@ export const aiActivitySlice = createSlice({
         Reflect.deleteProperty(state.aiBusyByEnv, action.payload.key);
       }
     },
+    setAIBusyForSession(state, action: PayloadAction<{ sessionId: number; busy: boolean }>) {
+      if (action.payload.busy) {
+        state.aiBusyBySession[action.payload.sessionId] = true;
+      } else {
+        Reflect.deleteProperty(state.aiBusyBySession, action.payload.sessionId);
+      }
+    },
     clearAIBusy(state) {
       state.aiBusyByEnv = {};
+      state.aiBusyBySession = {};
     },
   },
 });
 
-export const { setAIBusyForEnv, clearAIBusy } = aiActivitySlice.actions;
+export const { setAIBusyForEnv, setAIBusyForSession, clearAIBusy } = aiActivitySlice.actions;
 export default aiActivitySlice.reducer;

--- a/erun-ui/frontend/src/app/wailsEventThunks.ts
+++ b/erun-ui/frontend/src/app/wailsEventThunks.ts
@@ -25,7 +25,7 @@ import {
   selectSelectedIsPendingFor,
 } from './selectors';
 import { openSelection, selectTerminalTab, startInitialDeploySelection } from './sessionThunks';
-import { setAIBusyForEnv } from './slices/aiActivitySlice';
+import { setAIBusyForEnv, setAIBusyForSession } from './slices/aiActivitySlice';
 import { setDoctorAll } from './slices/doctorSlice';
 import { setEnvActivityForEnv, setEnvStatusForEnv } from './slices/envStatusSlice';
 import { appendReconnectLine } from './slices/reviewSlice';
@@ -61,6 +61,11 @@ export const handleAIActivity =
     const tenant = payload.tenant.trim();
     const environment = payload.environment.trim();
     if (!tenant || !environment) {
+      // An orchestrator session carries no env to key by. Dropping the event
+      // here is why the orchestrator row never spun while it was working.
+      if (payload.sessionId > 0) {
+        dispatch(setAIBusyForSession({ sessionId: payload.sessionId, busy: payload.busy }));
+      }
       return;
     }
     const key = selectionKey({ tenant, environment });

--- a/erun-ui/frontend/src/components/app/Sidebar.BusyRowSpinner.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.BusyRowSpinner.tsx
@@ -1,0 +1,19 @@
+import { LoaderCircle } from 'lucide-react';
+import * as React from 'react';
+
+// BusyRowSpinner is the shared "this row is working" indicator for sidebar
+// rows. Shared by AI-orchestrator and environment rows so both report activity
+// identically — an orchestrator driving its envs is working in exactly the
+// sense an env's AI tab is, and a row that looks idle while it works is the
+// worse failure. Independent of the status dot, which carries the row's
+// condition rather than its activity. The caller owns the accessible label.
+export function BusyRowSpinner({ label }: { label: string }): React.ReactElement {
+  return (
+    <LoaderCircle
+      className="size-3.5 flex-none animate-spin text-current opacity-75"
+      aria-label={label || undefined}
+      aria-hidden={label ? undefined : true}
+      role={label ? 'status' : undefined}
+    />
+  );
+}

--- a/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
@@ -10,6 +10,7 @@ import { closeEnvironment, openSelection } from '@/app/sessionThunks';
 import { envKey } from '@/app/slices/sessionsSlice';
 import { selectionKey } from '@/app/versionSuggestions';
 import { IconTooltip } from '@/components/app/IconTooltip';
+import { BusyRowSpinner } from '@/components/app/Sidebar.BusyRowSpinner';
 import { EnvHoverCard } from '@/components/app/Sidebar.EnvHoverCard';
 import {
   deriveEnvironmentRow,
@@ -102,17 +103,6 @@ function EnvironmentRowOutputsButton({
         <Download />
       </Button>
     </IconTooltip>
-  );
-}
-
-function BusyRowSpinner({ label }: { label: string }): React.ReactElement {
-  return (
-    <LoaderCircle
-      className="size-3.5 flex-none animate-spin text-current opacity-75"
-      aria-label={label || undefined}
-      aria-hidden={label ? undefined : true}
-      role={label ? 'status' : undefined}
-    />
   );
 }
 

--- a/erun-ui/frontend/src/components/app/Sidebar.ErunSection.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.ErunSection.tsx
@@ -14,6 +14,7 @@ import type { OrchestratorInfo } from '@/app/slices/orchestratorsSlice';
 import { openOrchestratorDialog } from '@/app/slices/orchestratorsSlice';
 import { EmptyState } from '@/components/app/EmptyState';
 import { IconTooltip } from '@/components/app/IconTooltip';
+import { BusyRowSpinner } from '@/components/app/Sidebar.BusyRowSpinner';
 import { StatusDotGlyph } from '@/components/app/Sidebar.StatusDot';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -166,6 +167,13 @@ function OrchestratorRow({
 }): React.ReactElement {
   const dispatch = useAppDispatch();
   const running = orchestrator.status === 'running' && orchestrator.sessionId > 0;
+  // Scoped to this orchestrator's own session, so concurrent orchestrators each
+  // spin on their own row rather than on whichever one happens to be selected.
+  const busy = useAppSelector(
+    (state) =>
+      orchestrator.sessionId > 0 &&
+      state.aiActivity.aiBusyBySession[orchestrator.sessionId] === true,
+  );
   return (
     <li
       className={cn(
@@ -191,6 +199,7 @@ function OrchestratorRow({
       >
         <span className="min-w-0 truncate">{orchestrator.name}</span>
       </button>
+      {busy && <BusyRowSpinner label={`${orchestrator.name} is working`} />}
       <OrchestratorRowActions orchestrator={orchestrator} running={running} active={active} />
     </li>
   );

--- a/erun-ui/session_heartbeat.go
+++ b/erun-ui/session_heartbeat.go
@@ -52,6 +52,14 @@ func (a *App) runSessionHeartbeatPoller(stop <-chan struct{}) {
 			return
 		case <-ticker.C:
 			a.reconcileSessionHeartbeatsOnce()
+			// Mirrors are re-enumerated here, not only at boot. An env linked
+			// while the app is already running — the usual case, since linking is
+			// done from the running app — never got a sync worker, so its mirror
+			// stayed silently empty until the next restart, indistinguishable
+			// from an env with no files. startWorkspaceSyncForSelection
+			// re-validates and dedups a running poller, so this settles to a
+			// no-op once every linked env is syncing.
+			a.startWorkspaceSyncForConfiguredEnvs()
 		}
 	}
 }
@@ -81,7 +89,7 @@ func (a *App) releaseUnobservedAIActivity() {
 	a.mu.Lock()
 	var candidates []*managedTerminal
 	for _, managed := range a.sessions {
-		if managed == nil || managed.closed || managed.kind != sessionKindAI || !managed.aiBusyEmitted {
+		if managed == nil || managed.closed || !aiActivityKind(managed.kind) || !managed.aiBusyEmitted {
 			continue
 		}
 		heartbeat, ok := a.sessionHeartbeats[selectionKey(managed.selection)]
@@ -156,7 +164,7 @@ func (a *App) applySessionHeartbeat(selection uiSelection, activity uiRuntimeAct
 // the pod may simply not have created its socket yet — so it is left alone.
 // Caller holds a.mu.
 func (h sessionHeartbeat) reportsFinished(managed *managedTerminal, key string) bool {
-	if managed == nil || managed.closed || managed.kind != sessionKindAI {
+	if managed == nil || managed.closed || !aiActivityKind(managed.kind) {
 		return false
 	}
 	if selectionKey(managed.selection) != key || !managed.aiBusyEmitted {

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -1675,8 +1675,23 @@ const aiActivityIdleThreshold = 3 * time.Second
 //     responses do not toggle the badge.
 //   - busy=false fires after aiActivityIdleThreshold (3 s) of silence.
 //   - Session close emits busy=false via finalizeAIActivity.
+//
+// aiActivityKind reports whether a session of this kind should drive the
+// sidebar's working spinner. An orchestrator runs the same agent an AI tab
+// does, and it is the row most likely to be working, so gating this on
+// sessionKindAI alone left the one row that is always driving work as the only
+// row that never showed it.
+//
+// It takes the kind rather than the session so each caller keeps its own
+// `managed == nil` guard visible: folding the nil check in here hid it from
+// static analysis, which then read every later field access as a possible nil
+// dereference.
+func aiActivityKind(kind sessionKind) bool {
+	return kind == sessionKindAI || kind == sessionKindOrchestrator
+}
+
 func (a *App) recordAIActivity(managed *managedTerminal) {
-	if managed == nil || managed.kind != sessionKindAI {
+	if managed == nil || !aiActivityKind(managed.kind) {
 		return
 	}
 	now := time.Now()
@@ -1767,7 +1782,7 @@ func (a *App) releaseAIActivity(managed *managedTerminal) {
 // tab mid-generation, or the underlying PTY drops). Caller must not
 // hold a.mu.
 func (a *App) finalizeAIActivity(managed *managedTerminal) {
-	if managed == nil || managed.kind != sessionKindAI {
+	if managed == nil || !aiActivityKind(managed.kind) {
 		return
 	}
 	a.mu.Lock()


### PR DESCRIPTION
Closes #928
Closes #929
Closes #932

Four defects on the host-side orchestrator path, all found while driving `erun/ux` from an orchestrator session. They share a shape: each one leaves a surface looking healthy while it quietly does nothing.

## `erun-common`

**#928 — a snapshot-channel env against a stable-only registry could never resolve.** `channelTarget` returned `LatestSnapshot` unconditionally once the supersede check declined, so an empty snapshot side resolved to `""`. The canonical registry publishes stable releases only, so *every* snapshot-channel env pointed at it reported `target unresolved` forever while a perfectly good stable sat there. `erun/ux` sat on `1.0.110` for a month this way, opted into autoupgrade the whole time.

An absent snapshot side is not "nothing newer exists" — it means the snapshot stream is absent, and the stable release is then the only, and newest, candidate.

**#932 — `job_start` rejected a repo-relative `dir` and blamed the shell.** The supervisor is detached with no inherited working directory, so a relative dir resolved against whatever directory the transport happened to sit in. Worse, Go reports an unusable `cmd.Dir` as an `ENOENT` naming the *binary*, so a bad path surfaced as `fork/exec /usr/bin/sh: no such file or directory` — sending the reader to hunt a missing shell in a container where `/usr/bin/sh` plainly exists.

`resolveEnvironmentJobDir` now anchors a relative dir to the project root (the reading `raw` already gives a path) and verifies it before anything is detached, so the failure names the directory.

## `erun-ui`

**#929 — an env linked while the app was running never started syncing.** Mirrors were enumerated only at boot. Linking is normally done *from the running app*, so the common case produced a permanently empty mirror — indistinguishable from an env with no files, with no error anywhere. `erun doctor --repair-workspace-sync` even reported success, because the SSH provisioning it checks was genuinely fine; there was simply no worker polling. The heartbeat tick now re-enumerates; `startWorkspaceSyncForSelection` already dedups, so it settles to a no-op.

**Orchestrator rows never showed a working spinner.** `recordAIActivity` gated on `sessionKindAI`, and the activity payload keys by tenant/environment, which an orchestrator has none of — the frontend dropped the event outright. The result: the one row that is *always* driving work was the only row that never showed it. The busy latch is now keyed by session id for orchestrators, and `BusyRowSpinner` moves beside `StatusDotGlyph` as a shared sidebar component, matching that file's existing "shared by AI-orchestrator and environment rows" contract.

## Validation

- Full integration suite: `ok erun-integration 40.241s`.
- `erun-common` and `erun-ui` `go test ./...`, plus `golangci-lint run ./...` clean.
- Frontend `typecheck` / `lint` / `format:check` clean.
- Playwright `--grep sidebar`: **30 passed**, identical to the `main` baseline.

One golden changed: `dry_run_snapshot_channel_without_published_snapshot.txt`. It had recorded the #928 bug as expected output (`0 lagging … 1 unresolved`); it now records the upgrade actually happening. That scenario existing under that name, asserting the wrong result, is the clearest evidence the bug was real.

New coverage: three `erun-common` subtests for the snapshot/stable resolution (including that #524's "newer snapshot stream still wins" survives), two integration scenarios for the job dir, and an orchestrator row in the `recordAIActivity` table.

**Playwright scope:** the suite was run and is green, but no new spec drives the orchestrator spinner's *render* — the harness seeds a stopped orchestrator (`sessionId 0`), so making one appear busy needs a running session the headless harness does not stand up. The emit gate is covered in `ai_activity_test.go` instead, matching the split `sidebar-ai-activity.spec.ts` already documents ("the debounce timing itself is covered by erun-ui app_test.go"). The spinner component itself is the one already exercised by that spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)