### PR TITLE
Name the outputs list after whichever producer it is showing

### DIFF
--- a/erun-ui/frontend/src/components/app/OutputsDialog.tsx
+++ b/erun-ui/frontend/src/components/app/OutputsDialog.tsx
@@ -132,7 +132,10 @@ function OutputsDialogBody({
   }
   return (
     <div className="max-h-80 overflow-y-auto">
-      <ul className="divide-y divide-border/60" aria-label="Agent outputs">
+      <ul
+        className="divide-y divide-border/60"
+        aria-label={hostNative ? 'Orchestrator outputs' : 'Agent outputs'}
+      >
         {entries.map((entry) => (
           <OutputRow
             key={entry.name}

--- a/erun-ui/playwright/pages/OutputsDialog.ts
+++ b/erun-ui/playwright/pages/OutputsDialog.ts
@@ -11,6 +11,12 @@ export class OutputsDialog {
     return this.page.getByTestId('outputs-dialog');
   }
 
+  // The list's accessible name is what a screen reader announces over the
+  // entries, so it has to name the same producer the heading does.
+  list(name: string): Locator {
+    return this.locator().getByRole('list', { name });
+  }
+
   entry(name: string): Locator {
     return this.locator().getByText(name, { exact: true });
   }

--- a/erun-ui/playwright/tests/orchestrator-outputs.spec.ts
+++ b/erun-ui/playwright/tests/orchestrator-outputs.spec.ts
@@ -71,6 +71,10 @@ test.describe('orchestrator outputs (#865)', () => {
     await expect(app.outputsDialog.entry('summary.md')).toBeVisible();
     await expect(app.outputsDialog.entry('bundle')).toBeVisible();
 
+    // The heading names the orchestrator, so the list a screen reader announces
+    // must too — these files were produced on this host, not by a pod agent.
+    await expect(app.outputsDialog.list('Orchestrator outputs')).toBeVisible();
+
     // Scoped to this orchestrator: they share one workspace, so a call that did
     // not carry the id would show every orchestrator the same files.
     await expect.poll(() => listCalls.some((args) => args[0] === SEED_ORCHESTRATOR)).toBe(true);

--- a/erun-ui/playwright/tests/outputs-dialog.spec.ts
+++ b/erun-ui/playwright/tests/outputs-dialog.spec.ts
@@ -65,6 +65,7 @@ test.describe('agent outputs dialog (#588)', () => {
     await expect(app.outputsDialog.locator()).toBeVisible();
     await expect(app.outputsDialog.entry('results')).toBeVisible();
     await expect(app.outputsDialog.entry('report.pdf')).toBeVisible();
+    await expect(app.outputsDialog.list('Agent outputs')).toBeVisible();
 
     await app.outputsDialog.downloadButton('report.pdf').click();
     await expect


### PR DESCRIPTION
Closes #942

## What was wrong

The Outputs dialog serves two producers since #941: an environment's agent (files in the runtime pod) and an orchestrator (files on this host). The heading and description switch between them — the list did not. Its accessible name stayed hard-coded to `Agent outputs`, so a screen reader announced that over files the operator's own machine had produced, contradicting the "Outputs — <name>" heading directly above it.

## Why no test caught it

Both specs asserted the entries and the download button, and the page object reaches the dialog by `data-testid`. Nothing asserted the list's accessible name, so the env-only wording came straight through the change that made the dialog serve both producers.

Both specs now assert their own producer's label. That is the part that stops them drifting apart again — the fix itself is one line.

## How it was found

By opening the dialog in the running desktop after #941 merged and reading what was actually there, not by a test. The suites were green through the whole of #941.

## Validation

- Playwright: both outputs specs pass, run with `--build` so the binary carries the change.
- The new assertion was confirmed non-vacuous — it fails against the shipped label and passes with the fix.
- `erun-ui` Go suite green, `golangci-lint` clean, frontend typecheck/lint/format clean.
- `make integration-test` green (coverage 75.3%).