### PR TITLE
Let an orchestrator say when it is working, instead of guessing from its terminal

### DIFF
--- a/erun-ui/ai_activity_test.go
+++ b/erun-ui/ai_activity_test.go
@@ -17,9 +17,12 @@ import (
 //     output, regardless of how long busy=true was latched.
 //   - Session close (finalizeAIActivity) must release a latched
 //     busy=true even mid-generation.
-//   - An orchestrator session drives the signal exactly as an AI tab does:
-//     it runs the same agent, and its row is the one most likely to be
-//     working, so a silent orchestrator row read as idle while it worked.
+//   - An orchestrator session does NOT drive this signal. It runs an
+//     interactive agent TUI, which repaints continuously, so the silence
+//     rule that releases the latch never fires and the row span forever.
+//     An env's AI tab survives that only because the pod heartbeat sees its
+//     program exit; an orchestrator has no pod, so it reports its own turn
+//     boundaries instead (orchestrator_activity.go).
 //   - The signal is silent for every other session kind.
 func TestRecordAIActivityDebounce(t *testing.T) {
 	tests := []struct {
@@ -29,7 +32,7 @@ func TestRecordAIActivityDebounce(t *testing.T) {
 		wantSecond bool
 	}{
 		{name: "AI session emits ai-activity", kind: sessionKindAI, wantEmits: true},
-		{name: "Orchestrator session emits ai-activity", kind: sessionKindOrchestrator, wantEmits: true},
+		{name: "Orchestrator session is silent: its spinner comes from its own report", kind: sessionKindOrchestrator, wantEmits: false},
 		{name: "Local session is silent", kind: sessionKindLocal, wantEmits: false},
 		{name: "Open session is silent", kind: sessionKindOpen, wantEmits: false},
 		{name: "Command session is silent", kind: sessionKindCommand, wantEmits: false},

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -43,6 +43,9 @@ type orchestratorSession struct {
 	name      string
 	envs      []eruncommon.OrchestratorEnvConfig
 	startedAt time.Time
+	// aiBusy is the last turn-boundary report published to the sidebar, kept so
+	// the poller emits only on change rather than every tick.
+	aiBusy bool
 }
 
 // orchestratorEnvInput is the frontend's env selection for create/update.
@@ -409,6 +412,12 @@ func ensureOrchestratorSessionStartHook(dir string) error {
 		hooks = map[string]any{}
 	}
 	hooks["SessionStart"] = orchestratorSessionStartHook(dir)
+	// The agent reports its own turn boundaries. Whether it is working cannot be
+	// read off its terminal: an agent TUI repaints continuously, so an
+	// output-driven latch never clears.
+	busyHook, idleHook := orchestratorActivityHooks()
+	hooks["UserPromptSubmit"] = busyHook
+	hooks["Stop"] = idleHook
 	settings["hooks"] = hooks
 	out, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {

--- a/erun-ui/orchestrator_activity.go
+++ b/erun-ui/orchestrator_activity.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Whether an orchestrator is working cannot be read off its terminal. The
+// sidebar's latch was driven by output reads, released after three seconds of
+// silence — and an agent TUI is never silent for three seconds, because it
+// repaints its prompt, spinner and counter continuously. So the latch set when
+// work began and then stayed set forever, with the desktop burning CPU reading
+// an idle session's redraws to keep it that way.
+//
+// The agent knows when its turn starts and ends, so it says so. erun already
+// composes the orchestrator's launch and already writes hooks into the shared
+// workspace, so the report costs a file write per turn and replaces a guess
+// about pixels with a statement about work.
+
+// orchestratorActivityTTL bounds how long a "working" report stays believable.
+// A session killed mid-turn never writes its end, and without a bound its row
+// would spin for as long as the desktop ran — the same failure by a different
+// route.
+const orchestratorActivityTTL = 2 * time.Minute
+
+type orchestratorActivity struct {
+	Busy   bool  `json:"busy"`
+	AtUnix int64 `json:"atUnix"`
+	Serial int   `json:"serial,omitempty"`
+}
+
+// orchestratorActivityPath is the file one orchestrator's hooks write and the
+// desktop reads. Per-orchestrator, beside the other per-orchestrator state.
+func orchestratorActivityPath(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ""
+	}
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		configDir = os.TempDir()
+	}
+	return filepath.Join(configDir, "ERun", "orchestrator-activity", id+".json")
+}
+
+// readOrchestratorActivity reports whether this orchestrator says it is working.
+// An unreadable, unparseable or stale file answers "not working": the report can
+// only keep a row spinning, never invent a spin, which is the same direction the
+// pod heartbeat is allowed to push an env's row.
+func readOrchestratorActivity(id string, now time.Time) (orchestratorActivity, bool) {
+	path := orchestratorActivityPath(id)
+	if path == "" {
+		return orchestratorActivity{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return orchestratorActivity{}, false
+	}
+	var activity orchestratorActivity
+	if err := json.Unmarshal(data, &activity); err != nil {
+		return orchestratorActivity{}, false
+	}
+	if activity.AtUnix <= 0 || now.Sub(time.Unix(activity.AtUnix, 0)) > orchestratorActivityTTL {
+		return orchestratorActivity{}, false
+	}
+	return activity, true
+}
+
+// orchestratorActivityDir is the directory the reports live in. The hooks
+// resolve their own file inside it at run time.
+func orchestratorActivityDir() string {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		configDir = os.TempDir()
+	}
+	return filepath.Join(configDir, "ERun", "orchestrator-activity")
+}
+
+// orchestratorActivityHookCommand writes one report.
+//
+// The orchestrators workspace is shared, so its settings file is too — one hook
+// serves every orchestrator. It therefore resolves which one it is at run time
+// from ERUN_ORCHESTRATOR_ID, the id the session already carries; baking an id in
+// would have every orchestrator reporting as whichever one wrote the file last.
+// A session without that variable (transient/Investigate) writes nothing rather
+// than a file named for nobody.
+//
+// It is a bare shell redirect rather than a helper binary on purpose: this runs
+// at every turn boundary of every orchestrator, and a hook that needed erun on
+// PATH would stop reporting exactly when the environment is misconfigured.
+func orchestratorActivityHookCommand(busy bool) string {
+	dir := filepath.ToSlash(orchestratorActivityDir())
+	state := strconv.FormatBool(busy)
+	return `[ -n "$ERUN_ORCHESTRATOR_ID" ] && mkdir -p "` + dir + `" && ` +
+		`printf '{"busy":` + state + `,"atUnix":%s}' "$(date +%s)" > "` + dir + `/$ERUN_ORCHESTRATOR_ID.json"` +
+		` || true`
+}
+
+// orchestratorActivityHooks are the turn boundaries. UserPromptSubmit opens a
+// turn; Stop closes it. SessionStart closes one too, so a session resumed after
+// being killed mid-turn does not inherit the previous run's "working".
+func orchestratorActivityHooks() (busyHook, idleHook []any) {
+	wrap := func(command string) []any {
+		return []any{map[string]any{
+			"hooks": []any{map[string]any{"type": "command", "command": command}},
+		}}
+	}
+	return wrap(orchestratorActivityHookCommand(true)), wrap(orchestratorActivityHookCommand(false))
+}

--- a/erun-ui/orchestrator_activity_test.go
+++ b/erun-ui/orchestrator_activity_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeOrchestratorActivity(t *testing.T, id string, activity orchestratorActivity) {
+	t.Helper()
+	path := orchestratorActivityPath(id)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data, err := json.Marshal(activity)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// The whole point of the report: an orchestrator's row must be able to stop
+// spinning while its terminal is still talking. The old output-driven latch
+// could not, because an agent TUI repaints forever.
+func TestOrchestratorActivityIsReadFromTheReportNotTheTerminal(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	now := time.Now()
+
+	if _, ok := readOrchestratorActivity("erun", now); ok {
+		t.Fatal("an orchestrator that has reported nothing is not working")
+	}
+
+	writeOrchestratorActivity(t, "erun", orchestratorActivity{Busy: true, AtUnix: now.Unix()})
+	activity, ok := readOrchestratorActivity("erun", now)
+	if !ok || !activity.Busy {
+		t.Fatalf("a fresh working report must be believed, got %+v %v", activity, ok)
+	}
+
+	writeOrchestratorActivity(t, "erun", orchestratorActivity{Busy: false, AtUnix: now.Unix()})
+	activity, ok = readOrchestratorActivity("erun", now)
+	if !ok || activity.Busy {
+		t.Fatalf("the turn-end report must clear it, got %+v %v", activity, ok)
+	}
+}
+
+// A session killed mid-turn never writes its end. Without a bound its row would
+// spin for as long as the desktop ran — the same failure by another route.
+func TestOrchestratorActivityExpiresAStaleWorkingReport(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	now := time.Now()
+
+	writeOrchestratorActivity(t, "erun", orchestratorActivity{
+		Busy:   true,
+		AtUnix: now.Add(-orchestratorActivityTTL - time.Minute).Unix(),
+	})
+	if _, ok := readOrchestratorActivity("erun", now); ok {
+		t.Fatal("a report older than its TTL must not keep a row spinning")
+	}
+}
+
+// Unreadable input answers "not working": the report may keep a row spinning,
+// never invent a spin.
+func TestOrchestratorActivityTreatsUnreadableInputAsIdle(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	now := time.Now()
+
+	path := orchestratorActivityPath("erun")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("not json"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, ok := readOrchestratorActivity("erun", now); ok {
+		t.Fatal("unparseable input must not read as working")
+	}
+	if _, ok := readOrchestratorActivity("  ", now); ok {
+		t.Fatal("an orchestrator with no id has no report")
+	}
+}
+
+// The orchestrators workspace is shared, so one settings file serves every
+// orchestrator. A hook with an id baked in would have them all reporting as
+// whichever wrote last, so it resolves its own id at run time.
+func TestOrchestratorActivityHooksResolveTheirOwnOrchestrator(t *testing.T) {
+	busyHook, idleHook := orchestratorActivityHooks()
+	busy := hookCommandText(t, busyHook)
+	idle := hookCommandText(t, idleHook)
+
+	for _, command := range []string{busy, idle} {
+		if !strings.Contains(command, "$ERUN_ORCHESTRATOR_ID") {
+			t.Fatalf("the hook must resolve its orchestrator at run time: %q", command)
+		}
+		// A transient session carries no id and must write nothing rather than a
+		// file named for nobody.
+		if !strings.Contains(command, `[ -n "$ERUN_ORCHESTRATOR_ID" ]`) {
+			t.Fatalf("the hook must skip a session with no id: %q", command)
+		}
+	}
+	if !strings.Contains(busy, `"busy":true`) {
+		t.Fatalf("the turn-start hook must report working: %q", busy)
+	}
+	if !strings.Contains(idle, `"busy":false`) {
+		t.Fatalf("the turn-end hook must report idle: %q", idle)
+	}
+}
+
+// An orchestrator must not drive the output-derived latch: that is the signal
+// that could never clear for a repainting TUI.
+func TestOrchestratorSessionsDoNotDriveTheOutputLatch(t *testing.T) {
+	if aiActivityKind(sessionKindOrchestrator) {
+		t.Fatal("an orchestrator's spinner must come from its own report, not from terminal output")
+	}
+	if !aiActivityKind(sessionKindAI) {
+		t.Fatal("an env's AI tab still drives the output latch, released by the pod heartbeat")
+	}
+}
+
+func hookCommandText(t *testing.T, hook []any) string {
+	t.Helper()
+	if len(hook) != 1 {
+		t.Fatalf("expected one matcher block, got %+v", hook)
+	}
+	block, ok := hook[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected hook shape: %+v", hook[0])
+	}
+	commands, ok := block["hooks"].([]any)
+	if !ok || len(commands) != 1 {
+		t.Fatalf("expected one command, got %+v", block["hooks"])
+	}
+	command, ok := commands[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected command shape: %+v", commands[0])
+	}
+	text, _ := command["command"].(string)
+	return text
+}

--- a/erun-ui/session_heartbeat.go
+++ b/erun-ui/session_heartbeat.go
@@ -60,7 +60,44 @@ func (a *App) runSessionHeartbeatPoller(stop <-chan struct{}) {
 			// re-validates and dedups a running poller, so this settles to a
 			// no-op once every linked env is syncing.
 			a.reconcileWorkspaceSyncForConfiguredEnvs()
+			a.reconcileOrchestratorActivity()
 		}
+	}
+}
+
+// reconcileOrchestratorActivity publishes what each orchestrator said about
+// itself. The agent writes a turn-boundary report; this turns it into the
+// sidebar's spinner. Emitted only on change, so a quiet orchestrator costs one
+// file read per tick and no events.
+func (a *App) reconcileOrchestratorActivity() {
+	now := time.Now()
+	a.mu.Lock()
+	type row struct {
+		id     string
+		serial int
+		busy   bool
+	}
+	rows := make([]row, 0, len(a.orchestrators))
+	for id, session := range a.orchestrators {
+		if session == nil || session.transient {
+			continue
+		}
+		rows = append(rows, row{id: id, serial: session.serial, busy: session.aiBusy})
+	}
+	a.mu.Unlock()
+
+	for _, r := range rows {
+		activity, ok := readOrchestratorActivity(r.id, now)
+		busy := ok && activity.Busy
+		if busy == r.busy {
+			continue
+		}
+		a.mu.Lock()
+		if session := a.orchestrators[r.id]; session != nil {
+			session.aiBusy = busy
+		}
+		a.mu.Unlock()
+		a.emitAIActivity(r.serial, uiSelection{}, busy)
 	}
 }
 

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -1690,8 +1690,16 @@ const aiActivityIdleThreshold = 3 * time.Second
 // `managed == nil` guard visible: folding the nil check in here hid it from
 // static analysis, which then read every later field access as a possible nil
 // dereference.
+//
+// An orchestrator is deliberately NOT here. It runs an interactive agent TUI,
+// which repaints its prompt and counters continuously, so "this terminal is
+// emitting bytes" is true forever and the silence rule that releases the latch
+// never fires — the row span forever and the desktop burned CPU reading redraws
+// to keep it that way. An env's AI tab survives the same weakness only because
+// the pod heartbeat independently observes its program exit. An orchestrator has
+// no pod, so it reports its own turn boundaries instead (orchestrator_activity.go).
 func aiActivityKind(kind sessionKind) bool {
-	return kind == sessionKindAI || kind == sessionKindOrchestrator
+	return kind == sessionKindAI
 }
 
 func (a *App) recordAIActivity(managed *managedTerminal) {


### PR DESCRIPTION
Closes #945

## The measurement

An orchestrator's row spun forever. With the session idle at a prompt and nothing running:

```
claude    5:05.93 -> 5:06.67 over 6 idle seconds   (8.5% CPU)
erun-app  1:57.28 -> 1:57.57 over the same 6s      (4.2% CPU)
```

The agent was repainting its prompt, spinner and counters continuously, and the desktop was burning CPU reading those redraws — to keep a row claiming work that had finished half an hour earlier.

## Why

`recordAIActivity` fires on every output read and re-arms the 3s idle timer; the latch releases only after 3s of silence. An interactive agent TUI is never silent for 3s, so the timer is re-armed forever.

The signal meant **"this terminal is emitting bytes"**. For a TUI that is not "the agent is working", and for an orchestrator it is never false while the session is attached.

An env's AI tab has the same weakness and survives it only because the pod heartbeat independently observes its program exit (`reportsFinished`). An orchestrator runs on the host with no `appSession`, so `heartbeatSaysRunning` returns false immediately and silence is the only release. Widening the spinner to orchestrator rows made the latch **settable without making it clearable**.

## The fix

The agent reports its own turn boundaries: `UserPromptSubmit` opens a turn, `Stop` closes it, `SessionStart` closes one too so a session resumed after being killed mid-turn does not inherit the previous run's "working". erun already writes hooks into the shared workspace, so this is a file write per turn replacing a guess about pixels.

The three things that make it safe:

- **The workspace is shared**, so one settings file serves every orchestrator. The hook resolves which one it is at run time from `ERUN_ORCHESTRATOR_ID` rather than baking an id in — which would have every orchestrator reporting as whichever wrote last. A transient session carries no id and writes nothing rather than a file named for nobody.
- **A stale report expires** after two minutes, so a session killed mid-turn cannot spin its row forever by another route.
- **Unreadable input reads as idle.** A report may keep a row spinning, never invent a spin — the same direction the pod heartbeat is allowed to push an env row.

## A test that encoded the bug

`TestRecordAIActivityDebounce` asserted that an orchestrator session emits from output — the defect written down as a contract, added alongside the spinner feature. It now pins the corrected one.

## Validation

- New tests cover the report round trip, TTL expiry, unreadable input, and that an orchestrator no longer drives the output latch.
- The hook command was **executed as a shell**, not just string-matched: it writes valid JSON with a real timestamp, and with no `ERUN_ORCHESTRATOR_ID` it writes nothing and exits 0 rather than failing the turn.
- All four module suites green, `golangci-lint` clean, `make integration-test` green (76.0%).