### PR TITLE
Keep an orchestrator's row spinning for a whole turn

### DIFF
--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -415,9 +415,18 @@ func ensureOrchestratorSessionStartHook(dir string) error {
 	// The agent reports its own turn boundaries. Whether it is working cannot be
 	// read off its terminal: an agent TUI repaints continuously, so an
 	// output-driven latch never clears.
+	//
+	// The busy report goes on the tool-call events as well as the turn's start, so
+	// a turn longer than the staleness bound renews it instead of letting it
+	// expire underneath work that is still running. Each event is merged rather
+	// than assigned: this settings file is shared with the operator, and the
+	// tool-call events in particular are somewhere they are likely to have hooks
+	// of their own, which an assignment would silently delete.
 	busyHook, idleHook := orchestratorActivityHooks()
-	hooks["UserPromptSubmit"] = busyHook
-	hooks["Stop"] = idleHook
+	for _, event := range []string{"UserPromptSubmit", "PreToolUse", "PostToolUse"} {
+		hooks[event] = mergeOrchestratorActivityHook(hooks[event], busyHook)
+	}
+	hooks["Stop"] = mergeOrchestratorActivityHook(hooks["Stop"], idleHook)
 	settings["hooks"] = hooks
 	out, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {
@@ -430,8 +439,12 @@ func ensureOrchestratorSessionStartHook(dir string) error {
 // injecting command runs on both new starts (startup) and reopens (resume).
 func orchestratorSessionStartHook(dir string) []any {
 	command := map[string]any{"type": "command", "command": orchestratorSkillHookCommand(dir)}
+	// A session killed mid-turn never writes its end, so a new or reopened one
+	// would inherit the previous run's "working" and spin on arrival with nothing
+	// running. Clearing it here is what makes that guarantee real.
+	idle := map[string]any{"type": "command", "command": orchestratorActivityHookCommand(false)}
 	matcher := func(source string) map[string]any {
-		return map[string]any{"matcher": source, "hooks": []any{command}}
+		return map[string]any{"matcher": source, "hooks": []any{command, idle}}
 	}
 	return []any{matcher("startup"), matcher("resume")}
 }

--- a/erun-ui/orchestrator_activity.go
+++ b/erun-ui/orchestrator_activity.go
@@ -21,11 +21,24 @@ import (
 // workspace, so the report costs a file write per turn and replaces a guess
 // about pixels with a statement about work.
 
-// orchestratorActivityTTL bounds how long a "working" report stays believable.
-// A session killed mid-turn never writes its end, and without a bound its row
-// would spin for as long as the desktop ran — the same failure by a different
-// route.
+// orchestratorActivityTTL bounds how long a "working" report stays believable
+// once the desktop can no longer see the session that wrote it. A session
+// killed mid-turn never writes its end, and without a bound its row would spin
+// for as long as the desktop ran — the same failure by a different route.
 const orchestratorActivityTTL = 2 * time.Minute
+
+// orchestratorActivityLiveTTL is that bound for a session the desktop can still
+// see. A turn is not a short thing: it runs as long as the work does, and a
+// single tool call inside it — a build, a bounded wait on a detached job — can
+// outlast any interval worth calling "recent". Timing a live session out on the
+// short bound answered "not working" for the most ordinary case there is, an
+// orchestrator that is simply still working.
+//
+// A live session is bounded too, only far enough out that reaching it means the
+// reporting itself has stopped rather than the turn being long. Liveness is what
+// separates the two cases the short bound had to resolve identically; this keeps
+// the short bound for the case it was actually written for.
+const orchestratorActivityLiveTTL = 30 * time.Minute
 
 type orchestratorActivity struct {
 	Busy   bool  `json:"busy"`
@@ -48,10 +61,15 @@ func orchestratorActivityPath(id string) string {
 }
 
 // readOrchestratorActivity reports whether this orchestrator says it is working.
+// sessionAlive is whether the desktop can still see the session that writes the
+// report, and it selects which staleness bound applies: a report from a session
+// still in front of us ages out on the live bound, one from a session we can no
+// longer see on the short one.
+//
 // An unreadable, unparseable or stale file answers "not working": the report can
 // only keep a row spinning, never invent a spin, which is the same direction the
 // pod heartbeat is allowed to push an env's row.
-func readOrchestratorActivity(id string, now time.Time) (orchestratorActivity, bool) {
+func readOrchestratorActivity(id string, now time.Time, sessionAlive bool) (orchestratorActivity, bool) {
 	path := orchestratorActivityPath(id)
 	if path == "" {
 		return orchestratorActivity{}, false
@@ -64,7 +82,11 @@ func readOrchestratorActivity(id string, now time.Time) (orchestratorActivity, b
 	if err := json.Unmarshal(data, &activity); err != nil {
 		return orchestratorActivity{}, false
 	}
-	if activity.AtUnix <= 0 || now.Sub(time.Unix(activity.AtUnix, 0)) > orchestratorActivityTTL {
+	ttl := orchestratorActivityTTL
+	if sessionAlive {
+		ttl = orchestratorActivityLiveTTL
+	}
+	if activity.AtUnix <= 0 || now.Sub(time.Unix(activity.AtUnix, 0)) > ttl {
 		return orchestratorActivity{}, false
 	}
 	return activity, true
@@ -100,14 +122,75 @@ func orchestratorActivityHookCommand(busy bool) string {
 		` || true`
 }
 
-// orchestratorActivityHooks are the turn boundaries. UserPromptSubmit opens a
-// turn; Stop closes it. SessionStart closes one too, so a session resumed after
-// being killed mid-turn does not inherit the previous run's "working".
-func orchestratorActivityHooks() (busyHook, idleHook []any) {
-	wrap := func(command string) []any {
-		return []any{map[string]any{
-			"hooks": []any{map[string]any{"type": "command", "command": command}},
-		}}
+// orchestratorActivityHookMarker identifies a hook this file wrote, so a rewrite
+// replaces its own previous block instead of stacking another copy beside it,
+// and so merging into an event leaves everyone else's hooks alone.
+func orchestratorActivityHookMarker() string {
+	return filepath.ToSlash(orchestratorActivityDir())
+}
+
+// isOrchestratorActivityHookBlock reports whether a settings hook block is one
+// of ours. Anything it cannot read is somebody else's and is kept.
+func isOrchestratorActivityHookBlock(block any) bool {
+	group, ok := block.(map[string]any)
+	if !ok {
+		return false
 	}
-	return wrap(orchestratorActivityHookCommand(true)), wrap(orchestratorActivityHookCommand(false))
+	hooks, ok := group["hooks"].([]any)
+	if !ok {
+		return false
+	}
+	marker := orchestratorActivityHookMarker()
+	for _, hook := range hooks {
+		entry, ok := hook.(map[string]any)
+		if !ok {
+			continue
+		}
+		command, ok := entry["command"].(string)
+		if !ok {
+			continue
+		}
+		if strings.Contains(command, marker) && strings.Contains(command, `"busy":`) {
+			return true
+		}
+	}
+	return false
+}
+
+// orchestratorActivityHookBlock is one report bound to whichever event it is
+// installed on.
+func orchestratorActivityHookBlock(busy bool) []any {
+	return []any{map[string]any{
+		"hooks": []any{map[string]any{"type": "command", "command": orchestratorActivityHookCommand(busy)}},
+	}}
+}
+
+// orchestratorActivityHooks are the reports the settings file installs.
+//
+// The busy report is not bound to the turn's start alone. A turn boundary is the
+// only place work is *known* to begin and end, but it is not the only place the
+// report has to exist: a report written once at the start of a turn is stale for
+// every minute of that turn after the bound, and the row it should have kept
+// spinning goes quiet while the work is still running. Installing the same busy
+// report on the tool-call events renews it from the thing a working orchestrator
+// does constantly, at the cost of the same bare redirect.
+func orchestratorActivityHooks() (busyHook, idleHook []any) {
+	return orchestratorActivityHookBlock(true), orchestratorActivityHookBlock(false)
+}
+
+// mergeOrchestratorActivityHook installs ours on an event without disturbing
+// what is already bound to it. The workspace settings file is shared with the
+// operator, so an event we write to may already carry their hooks; replacing the
+// event outright would delete them. Our own previous block is dropped first so
+// this stays idempotent across restarts.
+func mergeOrchestratorActivityHook(existing any, ours []any) []any {
+	current, _ := existing.([]any)
+	merged := make([]any, 0, len(current)+len(ours))
+	for _, block := range current {
+		if isOrchestratorActivityHookBlock(block) {
+			continue
+		}
+		merged = append(merged, block)
+	}
+	return append(merged, ours...)
 }

--- a/erun-ui/orchestrator_activity_test.go
+++ b/erun-ui/orchestrator_activity_test.go
@@ -32,25 +32,27 @@ func TestOrchestratorActivityIsReadFromTheReportNotTheTerminal(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	now := time.Now()
 
-	if _, ok := readOrchestratorActivity("erun", now); ok {
+	if _, ok := readOrchestratorActivity("erun", now, true); ok {
 		t.Fatal("an orchestrator that has reported nothing is not working")
 	}
 
 	writeOrchestratorActivity(t, "erun", orchestratorActivity{Busy: true, AtUnix: now.Unix()})
-	activity, ok := readOrchestratorActivity("erun", now)
+	activity, ok := readOrchestratorActivity("erun", now, true)
 	if !ok || !activity.Busy {
 		t.Fatalf("a fresh working report must be believed, got %+v %v", activity, ok)
 	}
 
 	writeOrchestratorActivity(t, "erun", orchestratorActivity{Busy: false, AtUnix: now.Unix()})
-	activity, ok = readOrchestratorActivity("erun", now)
+	activity, ok = readOrchestratorActivity("erun", now, true)
 	if !ok || activity.Busy {
 		t.Fatalf("the turn-end report must clear it, got %+v %v", activity, ok)
 	}
 }
 
 // A session killed mid-turn never writes its end. Without a bound its row would
-// spin for as long as the desktop ran — the same failure by another route.
+// spin for as long as the desktop ran — the same failure by another route. The
+// desktop can no longer see that session, which is what puts it on the short
+// bound.
 func TestOrchestratorActivityExpiresAStaleWorkingReport(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
@@ -60,8 +62,8 @@ func TestOrchestratorActivityExpiresAStaleWorkingReport(t *testing.T) {
 		Busy:   true,
 		AtUnix: now.Add(-orchestratorActivityTTL - time.Minute).Unix(),
 	})
-	if _, ok := readOrchestratorActivity("erun", now); ok {
-		t.Fatal("a report older than its TTL must not keep a row spinning")
+	if _, ok := readOrchestratorActivity("erun", now, false); ok {
+		t.Fatal("a report from a session we can no longer see must not keep a row spinning")
 	}
 }
 
@@ -79,10 +81,10 @@ func TestOrchestratorActivityTreatsUnreadableInputAsIdle(t *testing.T) {
 	if err := os.WriteFile(path, []byte("not json"), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	if _, ok := readOrchestratorActivity("erun", now); ok {
+	if _, ok := readOrchestratorActivity("erun", now, true); ok {
 		t.Fatal("unparseable input must not read as working")
 	}
-	if _, ok := readOrchestratorActivity("  ", now); ok {
+	if _, ok := readOrchestratorActivity("  ", now, true); ok {
 		t.Fatal("an orchestrator with no id has no report")
 	}
 }
@@ -143,4 +145,124 @@ func hookCommandText(t *testing.T, hook []any) string {
 	}
 	text, _ := command["command"].(string)
 	return text
+}
+
+// The bug this pair exists for: a turn is as long as the work is, and the report
+// is written once at its start. Ageing a live session's report out on the short
+// bound answered "not working" for an orchestrator that was still working — the
+// most ordinary case there is.
+func TestOrchestratorActivitySurvivesATurnLongerThanTheShortBound(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	now := time.Now()
+
+	writeOrchestratorActivity(t, "erun", orchestratorActivity{
+		Busy:   true,
+		AtUnix: now.Add(-orchestratorActivityTTL - 5*time.Minute).Unix(),
+	})
+
+	activity, ok := readOrchestratorActivity("erun", now, true)
+	if !ok || !activity.Busy {
+		t.Fatalf("a live session's turn may outlast the short bound, got %+v %v", activity, ok)
+	}
+
+	// The same report, from a session the desktop can no longer see, is the
+	// killed-mid-turn case and must not keep the row spinning.
+	if _, ok := readOrchestratorActivity("erun", now, false); ok {
+		t.Fatal("a session we can no longer see must not keep its working report")
+	}
+}
+
+// The live bound is long, not absent. A report that stops being written at all
+// still ages out, so reporting that has died cannot pin a row spinning forever.
+func TestOrchestratorActivityStillBoundsALiveSession(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	now := time.Now()
+
+	writeOrchestratorActivity(t, "erun", orchestratorActivity{
+		Busy:   true,
+		AtUnix: now.Add(-orchestratorActivityLiveTTL - time.Minute).Unix(),
+	})
+	if _, ok := readOrchestratorActivity("erun", now, true); ok {
+		t.Fatal("a live session's report must still age out once nothing renews it")
+	}
+}
+
+// A turn renews its report from the thing a working orchestrator does
+// constantly. Without this the busy report exists only at the turn's first
+// instant, which is the whole defect.
+func TestOrchestratorActivityRenewsFromToolCalls(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", root)
+
+	if err := ensureOrchestratorSessionStartHook(root); err != nil {
+		t.Fatalf("ensureOrchestratorSessionStartHook: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	var settings struct {
+		Hooks map[string][]any `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal settings.json: %v\n%s", err, data)
+	}
+
+	for _, event := range []string{"UserPromptSubmit", "PreToolUse", "PostToolUse"} {
+		if len(settings.Hooks[event]) == 0 {
+			t.Fatalf("%s carries no hook, so a long turn stops reporting:\n%s", event, data)
+		}
+		found := false
+		for _, block := range settings.Hooks[event] {
+			if isOrchestratorActivityHookBlock(block) {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("%s is missing the busy report:\n%s", event, data)
+		}
+	}
+
+	// SessionStart clears an inherited "working": a session killed mid-turn never
+	// wrote its end, and the next one must not arrive already spinning.
+	idle := orchestratorActivityHookCommand(false)
+	clearsOnStart := false
+	for _, group := range settings.Hooks["SessionStart"] {
+		block, _ := group.(map[string]any)
+		entries, _ := block["hooks"].([]any)
+		for _, entry := range entries {
+			hook, _ := entry.(map[string]any)
+			if command, _ := hook["command"].(string); command == idle {
+				clearsOnStart = true
+			}
+		}
+	}
+	if !clearsOnStart {
+		t.Fatalf("SessionStart must clear an inherited working report:\n%s", data)
+	}
+}
+
+// Installing our report on an event must not delete what the operator already
+// bound to it, and must stay idempotent across restarts.
+func TestOrchestratorActivityHookMergePreservesOtherHooks(t *testing.T) {
+	theirs := map[string]any{
+		"matcher": "Bash",
+		"hooks":   []any{map[string]any{"type": "command", "command": "echo keep"}},
+	}
+	busy, _ := orchestratorActivityHooks()
+
+	merged := mergeOrchestratorActivityHook([]any{theirs}, busy)
+	if len(merged) != 2 {
+		t.Fatalf("expected theirs kept and ours appended, got %d: %+v", len(merged), merged)
+	}
+	again := mergeOrchestratorActivityHook(merged, busy)
+	if len(again) != 2 {
+		t.Fatalf("re-installing must replace our own block, not stack it: %+v", again)
+	}
+	if !isOrchestratorActivityHookBlock(again[1]) || isOrchestratorActivityHookBlock(again[0]) {
+		t.Fatalf("the operator's hook must survive and stay theirs: %+v", again)
+	}
 }

--- a/erun-ui/orchestrator_test.go
+++ b/erun-ui/orchestrator_test.go
@@ -623,8 +623,14 @@ func TestOrchestratorSessionStartHookPreservesExistingSettings(t *testing.T) {
 		t.Fatalf("expected unrelated key preserved, got %v\n%s", settings["model"], data)
 	}
 	hooks, _ := settings["hooks"].(map[string]any)
-	if _, ok := hooks["PreToolUse"]; !ok {
-		t.Fatalf("expected unrelated hook event preserved:\n%s", data)
+	// PreToolUse is an event erun writes to as well now, so "preserved" has to
+	// mean the operator's own hook is still there — not merely that the key is.
+	preToolUse, _ := hooks["PreToolUse"].([]any)
+	if !strings.Contains(string(data), "echo keep") {
+		t.Fatalf("expected the operator's own PreToolUse hook preserved:\n%s", data)
+	}
+	if len(preToolUse) < 2 {
+		t.Fatalf("expected erun's report merged alongside it, got %d blocks:\n%s", len(preToolUse), data)
 	}
 	if _, ok := hooks["SessionStart"]; !ok {
 		t.Fatalf("expected SessionStart hook added:\n%s", data)

--- a/erun-ui/session_heartbeat.go
+++ b/erun-ui/session_heartbeat.go
@@ -76,18 +76,29 @@ func (a *App) reconcileOrchestratorActivity() {
 		id     string
 		serial int
 		busy   bool
+		alive  bool
 	}
 	rows := make([]row, 0, len(a.orchestrators))
 	for id, session := range a.orchestrators {
 		if session == nil || session.transient {
 			continue
 		}
-		rows = append(rows, row{id: id, serial: session.serial, busy: session.aiBusy})
+		// Whether the desktop can still see the session that writes the report
+		// decides which staleness bound it ages out on. A live session's turn is
+		// allowed to be long; a session we can no longer see must not keep its
+		// "working" past the short bound, because nothing will ever clear it.
+		managed := a.sessions[orchestratorSessionKey(id)]
+		rows = append(rows, row{
+			id:     id,
+			serial: session.serial,
+			busy:   session.aiBusy,
+			alive:  managed != nil && !managed.closed,
+		})
 	}
 	a.mu.Unlock()
 
 	for _, r := range rows {
-		activity, ok := readOrchestratorActivity(r.id, now)
+		activity, ok := readOrchestratorActivity(r.id, now, r.alive)
 		busy := ok && activity.Busy
 		if busy == r.busy {
 			continue


### PR DESCRIPTION
An orchestrator's sidebar row stopped spinning about two minutes into a turn that was still running.

## Cause

The working report introduced by #946 is written at turn boundaries only — `UserPromptSubmit` sets `busy:true`, `Stop` sets `busy:false` — and read back under `orchestratorActivityTTL = 2m`. A turn lasts as long as the work does, so any turn longer than the bound had its report expire underneath it, and the row went quiet while the orchestrator was demonstrably still working.

Observed live on the `erun` orchestrator mid-turn:

```
~/Library/Application Support/ERun/orchestrator-activity/erun.json
{"busy":true,"atUnix":1786209697}     # 357s old, turn still running
```

The bound exists for a real case: a session killed mid-turn never writes its end, and without a bound its row would spin for as long as the desktop ran. But a flat wall clock cannot tell that case from a long turn, and resolved both to "not working" — so the common path was the broken one.

## Fix

Separate the two cases instead of timing them out identically.

- **Liveness selects the bound.** `readOrchestratorActivity` now takes whether the desktop can still see the session that writes the report. A live session's report ages out on `orchestratorActivityLiveTTL` (30m); a session the desktop can no longer see keeps the original 2m bound. `reconcileOrchestratorActivity` resolves liveness the same way the rest of `erun-ui` does — `a.sessions[orchestratorSessionKey(id)]` non-nil and not closed.
- **The turn renews its own report.** The busy report is installed on `PreToolUse` and `PostToolUse` as well as `UserPromptSubmit`, so a running turn keeps it fresh from the thing a working orchestrator does constantly. Renewal alone would not be enough — a single tool call can outlast any short bound — which is why the liveness bound carries the rest.
- The live bound is long, not absent: reporting that stops entirely still ages out, so a wedged session cannot pin a row spinning forever.

## Two gaps found in the same wiring

- **`SessionStart` never cleared an inherited "working".** The report's own comment said it did, but `ensureOrchestratorSessionStartHook` assigned that event the contract hook alone. A session killed mid-turn therefore left the next one spinning on arrival. The idle report now rides both the `startup` and `resume` matchers.
- **Installing a hook clobbered the event.** Each event was assigned outright, so writing to `PreToolUse`/`PostToolUse` would have deleted whatever the operator had bound there — in a settings file that is explicitly shared with them. Every event is merged now, dropping only our own previous block, which also makes the write idempotent across restarts.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean.
- `go test ./...` green for `erun-ui` and `erun-ui/headlessserver`.
- New tests cover all three acceptance criteria plus the two gaps: a turn outlasting the short bound keeps spinning; the same report from a session the desktop cannot see does not; a live session's report still ages out on the long bound; the busy report is present on every renewal event; `SessionStart` clears an inherited working report; and merging preserves the operator's own hook while staying idempotent.
- The emitted `settings.json` was inspected directly to confirm the hooks land on the wire, not just in the helper's return value.

Closes #947
