### PR TITLE
Publish each platform as it is built, not after every build

### DIFF
--- a/erun-common/build_docker_commands.go
+++ b/erun-common/build_docker_commands.go
@@ -38,11 +38,14 @@ func runMultiPlatformBuild(buildInput DockerBuildSpec, stdout, stderr io.Writer)
 		if err := tagStableBaseVersionAfterBuild(buildInput, platform, stdout, stderr); err != nil {
 			return err
 		}
+		if err := pushPlatformImage(buildInput, platformTag, stdout, stderr); err != nil {
+			return err
+		}
 	}
 	if !buildInput.Push {
 		return nil
 	}
-	return pushMultiPlatformImage(buildInput.Image.Tag, perPlatformTags, buildInput.Verbosity, stdout, stderr)
+	return assembleMultiPlatformManifest(buildInput.Image.Tag, perPlatformTags, buildInput.Verbosity, stdout, stderr)
 }
 
 func promoteDockerImage(buildInput DockerBuildSpec, stdout, stderr io.Writer) error {
@@ -57,19 +60,36 @@ func promoteDockerImage(buildInput DockerBuildSpec, stdout, stderr io.Writer) er
 		if err := tagStableBaseVersionAfterBuild(buildInput, platform, stdout, stderr); err != nil {
 			return err
 		}
+		if err := pushPlatformImage(buildInput, platformTag, stdout, stderr); err != nil {
+			return err
+		}
 	}
 	if !buildInput.Push {
 		return nil
 	}
-	return pushMultiPlatformImage(buildInput.Image.Tag, perPlatformTags, buildInput.Verbosity, stdout, stderr)
+	return assembleMultiPlatformManifest(buildInput.Image.Tag, perPlatformTags, buildInput.Verbosity, stdout, stderr)
 }
 
-func pushMultiPlatformImage(tag string, perPlatformTags []string, verbosity int, stdout, stderr io.Writer) error {
-	for _, platformTag := range perPlatformTags {
-		if err := DockerImagePusher(platformTag, verbosity, stdout, stderr); err != nil {
-			return err
-		}
+// pushPlatformImage publishes one platform the moment it is built, instead of
+// leaving every platform for a push pass that runs after the last build.
+//
+// A daemon backed by the containerd image store is free to collect content that
+// only a tag points at, and does. With build-all-then-push the first platform's
+// manifest was routinely gone by the time its push ran, and the release failed
+// with "content digest ... not found" — after paying for every build. Publishing
+// each platform immediately means no artifact ever has to survive another build,
+// which is the property that was missing rather than anything about the content.
+//
+// The manifest list is unaffected: `docker manifest create` reads its inputs
+// back from the registry, so it does not care whether they are still local.
+func pushPlatformImage(buildInput DockerBuildSpec, platformTag string, stdout, stderr io.Writer) error {
+	if !buildInput.Push {
+		return nil
 	}
+	return DockerImagePusher(platformTag, buildInput.Verbosity, stdout, stderr)
+}
+
+func assembleMultiPlatformManifest(tag string, perPlatformTags []string, verbosity int, stdout, stderr io.Writer) error {
 	createArgs := append([]string{"manifest", "create", "--amend", tag}, perPlatformTags...)
 	if err := runDockerSimpleCommandWithVerbosity(createArgs, verbosity, stdout, stderr); err != nil {
 		return err

--- a/erun-common/build_platform_push_order_test.go
+++ b/erun-common/build_platform_push_order_test.go
@@ -1,0 +1,118 @@
+package eruncommon
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// A release used to build every platform and only then push them all. On a
+// daemon backed by the containerd image store that lost the first platform's
+// manifest before its push ran — the content is collectable once nothing but a
+// tag refers to it — so the release died with "content digest ... not found"
+// after paying for every build.
+//
+// The contract that fixes it is an ordering one: a platform is published before
+// the next platform is built, so no artifact has to survive another build. These
+// tests pin that ordering, per the repository rule that every release failure
+// mode gets a regression test.
+
+func buildSpecForPushOrder(promote bool) DockerBuildSpec {
+	return DockerBuildSpec{
+		ContextDir:  "/src",
+		Image:       DockerImageReference{Tag: "ghcr.io/acme/widget:1.2.3", Version: "1.2.3"},
+		Platforms:   []string{"linux/amd64", "linux/arm64"},
+		Push:        true,
+		Promote:     promote,
+		Fingerprint: "cafe",
+	}
+}
+
+// indexOfCommand returns the position of the first traced command whose joined
+// arguments contain every needle, or -1.
+func indexOfCommand(commands []commandSpec, needles ...string) int {
+	for i, command := range commands {
+		joined := strings.Join(command.Args, " ")
+		if slices.ContainsFunc(needles, func(n string) bool { return !strings.Contains(joined, n) }) {
+			continue
+		}
+		return i
+	}
+	return -1
+}
+
+func TestEachPlatformIsPushedBeforeTheNextIsBuilt(t *testing.T) {
+	commands := buildSpecForPushOrder(false).traceCommands()
+
+	amd64Build := indexOfCommand(commands, "build", "linux/amd64")
+	amd64Push := indexOfCommand(commands, "push", "1.2.3-amd64")
+	arm64Build := indexOfCommand(commands, "build", "linux/arm64")
+	arm64Push := indexOfCommand(commands, "push", "1.2.3-arm64")
+
+	for name, idx := range map[string]int{
+		"amd64 build": amd64Build, "amd64 push": amd64Push,
+		"arm64 build": arm64Build, "arm64 push": arm64Push,
+	} {
+		if idx < 0 {
+			t.Fatalf("%s missing from the traced commands: %+v", name, commands)
+		}
+	}
+
+	if !(amd64Build < amd64Push) {
+		t.Fatalf("a platform must be pushed after it is built, got build=%d push=%d", amd64Build, amd64Push)
+	}
+	// The whole point: nothing that was built may wait behind another build.
+	if !(amd64Push < arm64Build) {
+		t.Fatalf("amd64 must be published before arm64 starts building, or its content need not survive; got amd64 push=%d arm64 build=%d", amd64Push, arm64Build)
+	}
+	if !(arm64Build < arm64Push) {
+		t.Fatalf("arm64 must be pushed after it is built, got build=%d push=%d", arm64Build, arm64Push)
+	}
+}
+
+// The manifest list is assembled last and reads its inputs back from the
+// registry, so it neither needs nor keeps the per-arch images locally.
+func TestMultiArchManifestIsAssembledAfterEveryPlatformIsPushed(t *testing.T) {
+	commands := buildSpecForPushOrder(false).traceCommands()
+
+	lastPush := indexOfCommand(commands, "push", "1.2.3-arm64")
+	create := indexOfCommand(commands, "manifest", "create")
+	push := indexOfCommand(commands, "manifest", "push")
+
+	if create < 0 || push < 0 {
+		t.Fatalf("multi-arch assembly missing: %+v", commands)
+	}
+	if !(lastPush < create && create < push) {
+		t.Fatalf("expected every platform pushed, then manifest create, then manifest push; got lastPush=%d create=%d push=%d", lastPush, create, push)
+	}
+}
+
+// The promote path re-tags already-built fingerprint images rather than building
+// them, but it publishes the same per-arch tags and so carries the same hazard.
+func TestPromotePublishesEachPlatformBeforeTaggingTheNext(t *testing.T) {
+	commands := buildSpecForPushOrder(true).traceCommands()
+
+	amd64Push := indexOfCommand(commands, "push", "1.2.3-amd64")
+	arm64Tag := indexOfCommand(commands, "tag", "1.2.3-arm64")
+
+	if amd64Push < 0 || arm64Tag < 0 {
+		t.Fatalf("promote trace missing a push or tag: %+v", commands)
+	}
+	if !(amd64Push < arm64Tag) {
+		t.Fatalf("promote must publish amd64 before it moves on to arm64; got push=%d next tag=%d", amd64Push, arm64Tag)
+	}
+}
+
+// A build that is not pushing must emit no push at all — the ordering fix must
+// not turn a local build into a publish.
+func TestALocalBuildStillPushesNothing(t *testing.T) {
+	spec := buildSpecForPushOrder(false)
+	spec.Push = false
+
+	for _, command := range spec.traceCommands() {
+		joined := strings.Join(command.Args, " ")
+		if strings.HasPrefix(joined, "push ") || strings.Contains(joined, "manifest ") {
+			t.Fatalf("a non-pushing build must not publish anything, got %q", joined)
+		}
+	}
+}

--- a/erun-common/build_spec.go
+++ b/erun-common/build_spec.go
@@ -217,16 +217,16 @@ func multiPlatformTraceCommands(b DockerBuildSpec) []commandSpec {
 			commands = append(commands, dockerTagTraceCommand(b.ContextDir, platformTag, fingerprintTag(b.Image, b.Fingerprint, platform)))
 		}
 		commands = append(commands, stableBaseVersionTraceCommands(b.ContextDir, platformTag, baseTag, platform)...)
+		if b.Push {
+			commands = append(commands, commandSpec{
+				Dir:  b.ContextDir,
+				Name: "docker",
+				Args: dockerPushArgs(platformTag, b.Verbosity),
+			})
+		}
 	}
 	if !b.Push {
 		return commands
-	}
-	for _, platformTag := range perPlatformTags {
-		commands = append(commands, commandSpec{
-			Dir:  b.ContextDir,
-			Name: "docker",
-			Args: dockerPushArgs(platformTag, b.Verbosity),
-		})
 	}
 	commands = append(commands, commandSpec{
 		Dir:  b.ContextDir,
@@ -266,16 +266,16 @@ func promoteTraceCommands(b DockerBuildSpec) []commandSpec {
 		perPlatformTags = append(perPlatformTags, platformTag)
 		commands = append(commands, dockerTagTraceCommand(b.ContextDir, fingerprintTag(b.Image, b.Fingerprint, platform), platformTag))
 		commands = append(commands, stableBaseVersionTraceCommands(b.ContextDir, platformTag, baseTag, platform)...)
+		if b.Push {
+			commands = append(commands, commandSpec{
+				Dir:  b.ContextDir,
+				Name: "docker",
+				Args: dockerPushArgs(platformTag, b.Verbosity),
+			})
+		}
 	}
 	if !b.Push {
 		return commands
-	}
-	for _, platformTag := range perPlatformTags {
-		commands = append(commands, commandSpec{
-			Dir:  b.ContextDir,
-			Name: "docker",
-			Args: dockerPushArgs(platformTag, b.Verbosity),
-		})
 	}
 	commands = append(commands, commandSpec{
 		Dir:  b.ContextDir,

--- a/erun-integration/testdata/build/dry_run_release_includes_release_and_build_traces.txt
+++ b/erun-integration/testdata/build/dry_run_release_includes_release_and_build_traces.txt
@@ -41,9 +41,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>

--- a/erun-integration/testdata/build/dry_run_release_publishes_runtime_chart.txt
+++ b/erun-integration/testdata/build/dry_run_release_publishes_runtime_chart.txt
@@ -48,9 +48,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>
@@ -70,9 +70,9 @@ fingerprint image not found locally: ghcr.io/sophium/erun-devops:fp-<HEX16>-arm6
 rebuilding ghcr.io/sophium/erun-devops:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/erun-devops:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/erun-devops:<VERSION> ghcr.io/sophium/erun-devops:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/erun-devops:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/erun-devops:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/erun-devops:<VERSION> ghcr.io/sophium/erun-devops:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/erun-devops:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/erun-devops:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/erun-devops:<VERSION> ghcr.io/sophium/erun-devops:<VERSION> ghcr.io/sophium/erun-devops:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/erun-devops:<VERSION>

--- a/erun-integration/testdata/build/dry_run_release_pushes_release_tagged_docker_builds.txt
+++ b/erun-integration/testdata/build/dry_run_release_pushes_release_tagged_docker_builds.txt
@@ -42,9 +42,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>

--- a/erun-integration/testdata/build/real_run_release_push_auth_failure_retries_after_gh_login.txt
+++ b/erun-integration/testdata/build/real_run_release_push_auth_failure_retries_after_gh_login.txt
@@ -40,9 +40,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>

--- a/erun-integration/testdata/push/dry_run_build_shortcut_builds_then_pushes_minted_version.txt
+++ b/erun-integration/testdata/push/dry_run_build_shortcut_builds_then_pushes_minted_version.txt
@@ -15,9 +15,9 @@ fingerprint image not found locally: ghcr.io/sophium/cwd:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/cwd:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/cwd:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/cwd:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/cwd:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/cwd:<VERSION>

--- a/erun-integration/testdata/push/dry_run_build_shortcut_force_rebuilds.txt
+++ b/erun-integration/testdata/push/dry_run_build_shortcut_force_rebuilds.txt
@@ -2,8 +2,8 @@ audit: erun push --build --dry-run --force
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
-cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker push ghcr.io/sophium/cwd:<VERSION>
+cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker push ghcr.io/sophium/cwd:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/cwd:<VERSION>

--- a/erun-integration/testdata/push/dry_run_local_push_assembles_per_arch_manifest.txt
+++ b/erun-integration/testdata/push/dry_run_local_push_assembles_per_arch_manifest.txt
@@ -5,8 +5,8 @@ docker image inspect ghcr.io/sophium/api:fp-<HEX16>-arm64
 fingerprint image present locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 promoting from cached fingerprint image: ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker tag ghcr.io/sophium/api:fp-<HEX16>-amd64 ghcr.io/sophium/api:<VERSION>
-cd <TMP> && docker tag ghcr.io/sophium/api:fp-<HEX16>-arm64 ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker tag ghcr.io/sophium/api:fp-<HEX16>-arm64 ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>
@@ -16,8 +16,8 @@ docker image inspect ghcr.io/sophium/base:fp-<HEX16>-arm64
 fingerprint image present locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 promoting from cached fingerprint image: ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker tag ghcr.io/sophium/base:fp-<HEX16>-amd64 ghcr.io/sophium/base:<VERSION>
-cd <TMP> && docker tag ghcr.io/sophium/base:fp-<HEX16>-arm64 ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker tag ghcr.io/sophium/base:fp-<HEX16>-arm64 ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>

--- a/erun-integration/testdata/push/dry_run_single_image_from_dockerfile_cwd.txt
+++ b/erun-integration/testdata/push/dry_run_single_image_from_dockerfile_cwd.txt
@@ -6,9 +6,9 @@ fingerprint image not found locally: ghcr.io/sophium/cwd:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/cwd:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/cwd:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/cwd:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/cwd:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:<VERSION> ghcr.io/sophium/cwd:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/cwd:<VERSION>

--- a/erun-integration/testdata/release/dry_run_darwin_host_skips_linux_release_scripts.txt
+++ b/erun-integration/testdata/release/dry_run_darwin_host_skips_linux_release_scripts.txt
@@ -42,9 +42,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>

--- a/erun-integration/testdata/release/dry_run_develop_emits_candidate_plan.txt
+++ b/erun-integration/testdata/release/dry_run_develop_emits_candidate_plan.txt
@@ -42,9 +42,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>

--- a/erun-integration/testdata/release/dry_run_force_includes_tag_deletion_for_stale_release_tag.txt
+++ b/erun-integration/testdata/release/dry_run_force_includes_tag_deletion_for_stale_release_tag.txt
@@ -46,9 +46,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>

--- a/erun-integration/testdata/release/dry_run_includes_linux_release_scripts.txt
+++ b/erun-integration/testdata/release/dry_run_includes_linux_release_scripts.txt
@@ -42,9 +42,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>

--- a/erun-integration/testdata/release/dry_run_main_with_all_packaging_artifacts_syncs_them.txt
+++ b/erun-integration/testdata/release/dry_run_main_with_all_packaging_artifacts_syncs_them.txt
@@ -84,9 +84,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>

--- a/erun-integration/testdata/release/dry_run_main_with_develop_emits_stable_plan.txt
+++ b/erun-integration/testdata/release/dry_run_main_with_develop_emits_stable_plan.txt
@@ -43,9 +43,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>

--- a/erun-integration/testdata/release/dry_run_main_with_marketplace_emits_sha_sync.txt
+++ b/erun-integration/testdata/release/dry_run_main_with_marketplace_emits_sha_sync.txt
@@ -43,9 +43,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>

--- a/erun-integration/testdata/release/dry_run_main_with_scoop_manifest_validates_and_syncs.txt
+++ b/erun-integration/testdata/release/dry_run_main_with_scoop_manifest_validates_and_syncs.txt
@@ -72,9 +72,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>

--- a/erun-integration/testdata/release/dry_run_main_without_develop_pushes_only_main.txt
+++ b/erun-integration/testdata/release/dry_run_main_without_develop_pushes_only_main.txt
@@ -43,9 +43,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>

--- a/erun-integration/testdata/release/dry_run_release_tag_at_head_skips_tag_creation.txt
+++ b/erun-integration/testdata/release/dry_run_release_tag_at_head_skips_tag_creation.txt
@@ -44,9 +44,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>

--- a/erun-integration/testdata/release/dry_run_skips_release_roots_in_gitignored_trees.txt
+++ b/erun-integration/testdata/release/dry_run_skips_release_roots_in_gitignored_trees.txt
@@ -42,9 +42,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>

--- a/erun-integration/testdata/release/dry_run_with_untracked_file_reports_worktree_clean.txt
+++ b/erun-integration/testdata/release/dry_run_with_untracked_file_reports_worktree_clean.txt
@@ -42,9 +42,9 @@ fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
-cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest create --amend ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
 cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>


### PR DESCRIPTION
A release built every platform and only then pushed them all. Nothing kept the first platform's content alive in between, and a daemon backed by the **containerd image store** — the default in Docker Desktop 4.34+ and in OrbStack — is free to collect content that only a tag refers to. So the first platform's manifest was routinely gone by the time its push ran:

```
#8 naming to ghcr.io/sophium/frs-devops:1.0.41-amd64 done      <- built first
#8 naming to ghcr.io/sophium/frs-devops:1.0.41-arm64 done      <- built second
The push refers to repository [ghcr.io/sophium/frs-devops]
 Info -> ... not all of them are available locally
NotFound: content digest sha256:643ccd98e506...: not found      <- the amd64 manifest
==> Release failed after 13m29s
```

The content was never the problem. Rebuilding that exact platform and pushing it **in one step** reproduced the identical digest `sha256:643ccd98e506…` and published cleanly. What was missing was an ordering property.

## The change

A platform is published before the next one is built, so no artifact ever has to survive another build.

- `runMultiPlatformBuild` pushes each platform right after it is built and tagged, instead of leaving every platform to a push pass that runs after the last build.
- `promoteDockerImage` moves too: it re-tags cached fingerprint images rather than building them, but it publishes the same per-arch tags and carried the same hazard.
- `pushMultiPlatformImage` becomes `assembleMultiPlatformManifest` — manifest create + push only. That is unaffected by the change, because `docker manifest create` reads its inputs back from the registry and does not care whether they are still held locally.
- The dry-run trace mirrors the new order in both paths. It is documented to be an honest preview of the real build, and the integration suite golden-matches it.

## Why it mattered

Releasing from a workstation was the case this broke. A `local-agent` env runs its jobs on the host, so the tenant most likely to release from a laptop was the one that could not — while the same release succeeded from a runtime pod, whose dind daemon still uses the classic image store. The failure also arrived at the most expensive possible moment: after every image had been built for every architecture.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean; `erun-common` unit tests green.
- **New regression tests pin the ordering contract**, per the repo rule that each release failure mode gets one. Confirmed they genuinely fail against the old order rather than passing vacuously:
  ```
  --- FAIL: TestEachPlatformIsPushedBeforeTheNextIsBuilt
      amd64 must be published before arm64 starts building ... got amd64 push=4 arm64 build=2
  --- FAIL: TestPromotePublishesEachPlatformBeforeTaggingTheNext
      promote must publish amd64 before it moves on to arm64; got push=2 next tag=1
  ```
  They also cover that the manifest is assembled only after every platform is pushed, and that a non-pushing build still publishes nothing.
- `make integration-test` green (`go test -count=1`, cache defeated — a cached run had reported a false pass).
- Goldens updated for the new trace order. The diff there is a **pure reorder**: 20 files, 22 insertions / 22 deletions, and classifying every changed line gives equal counts added and removed (19 `docker push`, 2 `docker tag`, 1 `docker build`). No command is added, removed or altered.

Closes #950
