### PR TITLE
Gate each MCP tool on what the caller is allowed to do

### DIFF
--- a/erun-common/mcp_auth.go
+++ b/erun-common/mcp_auth.go
@@ -37,6 +37,17 @@ type MCPTokenClaims struct {
 	Audience  string `json:"aud,omitempty"`
 	IssuedAt  int64  `json:"iat,omitempty"`
 	ExpiresAt int64  `json:"exp,omitempty"`
+	// Scope and Roles carry what the caller may do, in the two shapes issuers
+	// actually produce: a space-delimited OAuth scope string, and a roles array
+	// of the kind project roles arrive in. Both are optional — a token carrying
+	// neither is the desktop's single-admin case.
+	Scope string   `json:"scope,omitempty"`
+	Roles []string `json:"roles,omitempty"`
+}
+
+// Capabilities resolves what this token permits at the edge.
+func (c MCPTokenClaims) Capabilities() MCPCapabilitySet {
+	return MCPCapabilitiesFromClaims(c.Scope, c.Roles)
 }
 
 // Only EdDSA is ever produced or accepted.
@@ -234,6 +245,16 @@ func mcpClaimsFromOIDC(verified OIDCClaims) MCPTokenClaims {
 	}
 	if len(verified.Audience) > 0 {
 		claims.Audience = verified.Audience[0]
+	}
+	if scope, ok := verified.Raw["scope"].(string); ok {
+		claims.Scope = scope
+	}
+	if roles, ok := verified.Raw["roles"].([]any); ok {
+		for _, role := range roles {
+			if name, ok := role.(string); ok {
+				claims.Roles = append(claims.Roles, name)
+			}
+		}
 	}
 	return claims
 }

--- a/erun-common/mcp_capabilities.go
+++ b/erun-common/mcp_capabilities.go
@@ -1,0 +1,153 @@
+package eruncommon
+
+import (
+	"sort"
+	"strings"
+)
+
+// Authentication answers which tenant a caller is; this answers what that caller
+// may do once it is in. The two are separate questions and the edge needs both:
+// a token that proves a tenant still reaches `raw`, which can kubectl-exec, and
+// `deploy`/`delete`/`context_*`, which mutate. A caller that only needs to watch
+// an environment should not be one typo away from rebuilding it.
+//
+// The table lives here rather than in erun-mcp so the edge and any other
+// transport that grows an authorization story read the same mapping. A tool
+// appears in exactly one capability, and anything absent is admin — a new tool
+// is dangerous until someone has decided otherwise, so the default fails closed.
+
+type MCPCapability string
+
+const (
+	// MCPCapabilityRead permits observation that cannot change the environment.
+	MCPCapabilityRead MCPCapability = "erun:read"
+	// MCPCapabilityAdmin permits everything, including remote execution.
+	MCPCapabilityAdmin MCPCapability = "erun:admin"
+)
+
+// mcpReadOnlyTools are the tools that only observe. Membership is the strict
+// test — a tool that writes anything at all, including keeping an environment
+// awake, is not here. Leases look harmless and are not: holding one defers
+// auto-stop, which spends money.
+var mcpReadOnlyTools = map[string]struct{}{
+	"version":           {},
+	"list":              {},
+	"idle":              {},
+	"idle_stop_history": {},
+	"context_list":      {},
+	"cloud_list":        {},
+	"diff":              {},
+	"outputs_list":      {},
+	"outputs_download":  {},
+	"job_status":        {},
+	"job_output":        {},
+	"job_await":         {},
+}
+
+// MCPToolCapability returns the capability a tool requires. An unknown tool
+// requires admin: the table is the allowlist, so a tool added without a decision
+// about its blast radius is unreachable to a read-only caller rather than
+// silently reachable.
+func MCPToolCapability(tool string) MCPCapability {
+	if _, ok := mcpReadOnlyTools[strings.TrimSpace(tool)]; ok {
+		return MCPCapabilityRead
+	}
+	return MCPCapabilityAdmin
+}
+
+// MCPCapabilitySet is a caller's resolved capabilities.
+type MCPCapabilitySet struct {
+	read  bool
+	admin bool
+}
+
+// NewMCPCapabilitySet builds a set from resolved capability names. Unrecognised
+// names are ignored rather than rejected, so an IdP that grants unrelated roles
+// alongside erun's does not lock the caller out.
+func NewMCPCapabilitySet(capabilities []string) MCPCapabilitySet {
+	var set MCPCapabilitySet
+	for _, capability := range capabilities {
+		switch MCPCapability(strings.TrimSpace(capability)) {
+		case MCPCapabilityAdmin:
+			set.admin = true
+		case MCPCapabilityRead:
+			set.read = true
+		}
+	}
+	return set
+}
+
+// AdminMCPCapabilitySet is the desktop's coarse case: a single operator who is
+// the tenant admin. It is also the compatibility default for a token minted
+// before capabilities existed, so adding this gate cannot lock out a caller that
+// worked yesterday — narrowing is opt-in, per the same direction as the rest of
+// the edge's auth.
+func AdminMCPCapabilitySet() MCPCapabilitySet {
+	return MCPCapabilitySet{read: true, admin: true}
+}
+
+// Allows reports whether the set satisfies a required capability. Admin implies
+// read, so an admin token never has to carry both.
+func (s MCPCapabilitySet) Allows(required MCPCapability) bool {
+	switch required {
+	case MCPCapabilityAdmin:
+		return s.admin
+	case MCPCapabilityRead:
+		return s.read || s.admin
+	}
+	return false
+}
+
+// AllowsTool is the question the edge actually asks.
+func (s MCPCapabilitySet) AllowsTool(tool string) bool {
+	return s.Allows(MCPToolCapability(tool))
+}
+
+// Empty reports a set that permits nothing, which is what an authenticated token
+// carrying only unrecognised roles resolves to.
+func (s MCPCapabilitySet) Empty() bool { return !s.read && !s.admin }
+
+// Names returns the granted capabilities, sorted, for audit lines and for the
+// cache key that identifies one distinct tool set.
+func (s MCPCapabilitySet) Names() []string {
+	names := make([]string, 0, 2)
+	if s.admin {
+		names = append(names, string(MCPCapabilityAdmin))
+	}
+	if s.read {
+		names = append(names, string(MCPCapabilityRead))
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Key identifies a capability set, so a server built for one set can be reused
+// for every caller carrying the same one.
+func (s MCPCapabilitySet) Key() string { return strings.Join(s.Names(), ",") }
+
+// MCPCapabilitiesFromClaims resolves what a token grants. Two shapes are
+// accepted because two issuers produce them: a space-delimited OAuth `scope`
+// string, and a roles array of the kind Zitadel project roles arrive in.
+//
+// A token that carries neither is treated as admin. That is the desktop's
+// existing single-operator model, and it is what keeps this change from
+// breaking every token minted before capabilities existed; an issuer that wants
+// a narrower caller says so explicitly.
+func MCPCapabilitiesFromClaims(scope string, roles []string) MCPCapabilitySet {
+	names := make([]string, 0, len(roles)+2)
+	names = append(names, strings.Fields(scope)...)
+	for _, role := range roles {
+		names = append(names, strings.TrimSpace(role))
+	}
+	if len(names) == 0 {
+		return AdminMCPCapabilitySet()
+	}
+	set := NewMCPCapabilitySet(names)
+	if set.Empty() {
+		// The token said something about roles, none of it erun's. Treating that
+		// as admin would make an unrelated role a privilege escalation, so it
+		// resolves to nothing and the caller sees an empty tool set.
+		return MCPCapabilitySet{}
+	}
+	return set
+}

--- a/erun-common/mcp_capabilities_test.go
+++ b/erun-common/mcp_capabilities_test.go
@@ -1,0 +1,106 @@
+package eruncommon
+
+import (
+	"slices"
+	"testing"
+)
+
+// The table is the allowlist. A tool that writes anything is admin, and a tool
+// nobody has classified is admin too — a new tool must be unreachable to a
+// read-only caller until someone decides otherwise, not silently reachable.
+func TestOnlyObservationIsReadCapability(t *testing.T) {
+	for _, tool := range []string{
+		"version", "list", "idle", "idle_stop_history", "context_list",
+		"cloud_list", "diff", "outputs_list", "outputs_download",
+		"job_status", "job_output", "job_await",
+	} {
+		if got := MCPToolCapability(tool); got != MCPCapabilityRead {
+			t.Fatalf("%s should be readable, got %s", tool, got)
+		}
+	}
+
+	// Remote execution, everything that mutates, and the leases that hold an
+	// environment awake (and therefore spend money).
+	for _, tool := range []string{
+		"raw", "build", "push", "deploy", "delete", "init", "release", "upgrade",
+		"expose", "terraform", "publish", "pin", "doctor", "contribute_clone",
+		"context_init", "context_start", "context_stop",
+		"cloud_login", "cloud_set", "cloud_init_aws", "cloud_inject_aws_credentials",
+		"job_start", "job_cancel", "job_attach",
+		"activity_lease_take", "activity_lease_release",
+		"idle_stop_cancel", "idle_stop_record",
+	} {
+		if got := MCPToolCapability(tool); got != MCPCapabilityAdmin {
+			t.Fatalf("%s must require admin, got %s", tool, got)
+		}
+	}
+
+	if got := MCPToolCapability("a_tool_added_next_week"); got != MCPCapabilityAdmin {
+		t.Fatalf("an unclassified tool must fail closed, got %s", got)
+	}
+}
+
+func TestAdminImpliesReadButReadDoesNotImplyAdmin(t *testing.T) {
+	read := NewMCPCapabilitySet([]string{string(MCPCapabilityRead)})
+	admin := NewMCPCapabilitySet([]string{string(MCPCapabilityAdmin)})
+
+	if !read.AllowsTool("version") || read.AllowsTool("raw") {
+		t.Fatalf("a read token may observe and may not execute: %+v", read)
+	}
+	if !admin.AllowsTool("version") || !admin.AllowsTool("raw") {
+		t.Fatalf("an admin token may do everything: %+v", admin)
+	}
+}
+
+// Adding this gate must not lock out a caller that worked yesterday: the
+// desktop mints a token for a single operator who is the tenant admin, and
+// those tokens say nothing about capabilities.
+func TestATokenSayingNothingAboutCapabilitiesIsTheAdminDesktopCase(t *testing.T) {
+	set := MCPCapabilitiesFromClaims("", nil)
+	if !set.AllowsTool("raw") {
+		t.Fatalf("a capability-less token is the coarse desktop admin, got %+v", set)
+	}
+}
+
+// Both shapes issuers actually produce.
+func TestCapabilitiesComeFromEitherScopeOrRoles(t *testing.T) {
+	fromScope := MCPCapabilitiesFromClaims("openid erun:read", nil)
+	if !fromScope.AllowsTool("list") || fromScope.AllowsTool("deploy") {
+		t.Fatalf("a read scope grants read only, got %+v", fromScope)
+	}
+
+	fromRoles := MCPCapabilitiesFromClaims("", []string{"erun:admin"})
+	if !fromRoles.AllowsTool("deploy") {
+		t.Fatalf("an admin role grants admin, got %+v", fromRoles)
+	}
+}
+
+// A token carrying roles, none of them erun's, must not be promoted to admin by
+// the "said nothing" default — that would make an unrelated role a privilege
+// escalation.
+func TestUnrelatedRolesGrantNothingRatherThanEverything(t *testing.T) {
+	set := MCPCapabilitiesFromClaims("openid profile", []string{"billing:reader"})
+	if !set.Empty() {
+		t.Fatalf("unrelated roles must grant nothing, got %+v", set)
+	}
+	if set.AllowsTool("version") || set.AllowsTool("raw") {
+		t.Fatalf("an empty set permits nothing, got %+v", set)
+	}
+}
+
+// The key identifies one distinct tool surface, so servers can be cached by it.
+func TestCapabilityKeyIdentifiesTheToolSurface(t *testing.T) {
+	a := NewMCPCapabilitySet([]string{"erun:read"})
+	b := NewMCPCapabilitySet([]string{"erun:read"})
+	admin := NewMCPCapabilitySet([]string{"erun:admin"})
+
+	if a.Key() != b.Key() {
+		t.Fatalf("equal capabilities must share a key: %q vs %q", a.Key(), b.Key())
+	}
+	if a.Key() == admin.Key() {
+		t.Fatalf("different capabilities must not share a key: %q", a.Key())
+	}
+	if !slices.Equal(admin.Names(), []string{"erun:admin"}) {
+		t.Fatalf("unexpected names: %v", admin.Names())
+	}
+}

--- a/erun-docs/docs/cli/mcp.md
+++ b/erun-docs/docs/cli/mcp.md
@@ -54,6 +54,32 @@ Each one resolves the target the same way `erun deploy` and `erun open` do — t
 
 Being able to reach the edge depends on the port-forward `erun open` establishes, and on the environment trusting this machine's identity — the same identity the desktop app injects when it deploys an env.
 
+## What a token is allowed to do {#capability-authorization}
+
+Authentication answers *which tenant* is calling. It does not answer *what that caller may do* — and the edge needs both, because `raw` can run arbitrary commands in the pod and `deploy`, `delete` and `context_*` all mutate.
+
+Every tool requires one of two capabilities:
+
+| Capability | Tools |
+| --- | --- |
+| `erun:read` | Observation that cannot change anything: `version`, `list`, `idle`, `idle_stop_history`, `context_list`, `cloud_list`, `diff`, `outputs_list`, `outputs_download`, `job_status`, `job_output`, `job_await` |
+| `erun:admin` | Everything else, including remote execution and every mutating tool |
+
+`erun:admin` implies `erun:read`, so an admin token never carries both.
+
+A caller sees only the tools it may call. `tools/list` is filtered to the caller's capabilities, so a disallowed tool is *unknown* rather than forbidden — the answer to "what can I do here" is the same as the answer to "what am I allowed to do". Each surviving handler re-checks at call time as well, so a tool reached by any other route still refuses. Both decisions are audited with the resolved tenant, user and tool.
+
+Two deliberate defaults:
+
+- **A token that says nothing about capabilities is an admin.** That is the desktop's model — one operator who is the tenant admin — and it is what keeps this gate from locking out tokens minted before capabilities existed. Narrowing a caller is opt-in.
+- **A tool nobody has classified requires admin.** The read set is an allowlist, so a newly added tool is unreachable to a read-only caller until someone decides it is safe, rather than silently reachable.
+
+A token that carries roles, none of them erun's, grants *nothing* — treating an unrelated role as admin would make it a privilege escalation. Such a caller is authenticated but not authorized, and the edge answers `403` rather than `401`: retrying with the same credentials will not help, and the fix is a role rather than a fresh login.
+
+Capabilities are read from either shape an issuer produces — a space-delimited OAuth `scope` claim, or a `roles` array of the kind project roles arrive in. For a hosted deployment, model them as IdP project roles and grant the subset a tenant may use at the org level, so a role never granted to an org cannot appear in its users' tokens.
+
+An edge deployed without a trust anchor is the loopback-only case that predates authentication, and keeps its existing surface: turning authentication off does not turn authorization on.
+
 ## Wiring a laptop-side MCP client {#wiring-a-laptop-side-mcp-client}
 
 `erun mcp proxy` is the same edge again, for a client that speaks MCP itself. It reads JSON-RPC on stdin, relays each message to the environment's edge with a bearer minted for that one request, and writes the reply back on stdout. Configure the client to launch it as a stdio server:

--- a/erun-mcp/auth.go
+++ b/erun-mcp/auth.go
@@ -91,11 +91,21 @@ func authHTTPMiddleware(cfg mcpAuthConfig, next http.Handler) http.Handler {
 			writeUnauthorized(w, "token tenant does not match this environment")
 			return
 		}
-		if _, err := eruncommon.VerifyMCPToken(req.Context(), cfg.oidc, token, issuer, cfg.audience, time.Now()); err != nil {
+		claims, err := eruncommon.VerifyMCPToken(req.Context(), cfg.oidc, token, issuer, cfg.audience, time.Now())
+		if err != nil {
 			writeUnauthorized(w, err.Error())
 			return
 		}
-		next.ServeHTTP(w, requestWithAuthTenant(req, tenant))
+		// Authentication is done; what the caller may do travels with the request
+		// from here, so the tool surface can be built for this caller rather than
+		// filtered after the fact.
+		identity := authIdentity{Tenant: tenant, User: claims.Subject, Capabilities: claims.Capabilities()}
+		if identity.Capabilities.Empty() {
+			writeForbidden(w, "token grants no erun capabilities")
+			return
+		}
+		req = requestWithAuthTenant(req, tenant)
+		next.ServeHTTP(w, req.WithContext(withAuthIdentity(req.Context(), identity)))
 	})
 }
 
@@ -117,6 +127,14 @@ func bearerToken(req *http.Request) string {
 		return ""
 	}
 	return strings.TrimSpace(header[len(prefix):])
+}
+
+// A caller whose token is valid but grants nothing is authenticated and not
+// authorized, which is 403 rather than 401: retrying with the same credentials
+// is pointless, and saying so is the difference between "log in again" and "ask
+// for a role".
+func writeForbidden(w http.ResponseWriter, reason string) {
+	http.Error(w, "forbidden: "+reason, http.StatusForbidden)
 }
 
 func writeUnauthorized(w http.ResponseWriter, reason string) {

--- a/erun-mcp/capabilities.go
+++ b/erun-mcp/capabilities.go
@@ -1,0 +1,135 @@
+package erunmcp
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// Authentication says which tenant is calling; this says what that caller may
+// do. The edge needs both, because a token that proves a tenant still reaches
+// `raw` — which can kubectl-exec — and every mutating tool besides.
+//
+// The gate is applied twice on purpose. The registered tool set is filtered per
+// request, so `tools/list` shows a caller only what it may call and anything
+// else is simply unknown to it; and each surviving handler re-checks at call
+// time, so a tool reached by any other route still cannot run. Neither layer
+// depends on the SDK propagating anything through context.
+
+// authIdentity is the resolved caller, carried from the auth middleware to the
+// per-request server factory and into audit lines.
+type authIdentity struct {
+	Tenant       string
+	User         string
+	Capabilities eruncommon.MCPCapabilitySet
+}
+
+type authContextKey struct{}
+
+func withAuthIdentity(ctx context.Context, identity authIdentity) context.Context {
+	return context.WithValue(ctx, authContextKey{}, identity)
+}
+
+// authIdentityFrom returns the resolved caller. An unauthenticated edge — the
+// loopback-only deployment that predates a trust anchor — has no identity, and
+// resolves to the coarse admin the desktop already assumes, so turning
+// authentication off does not quietly turn authorization on.
+func authIdentityFrom(ctx context.Context) authIdentity {
+	if identity, ok := ctx.Value(authContextKey{}).(authIdentity); ok {
+		return identity
+	}
+	return authIdentity{Capabilities: eruncommon.AdminMCPCapabilitySet()}
+}
+
+// toolRegistrar carries what a registration needs to decide. It exists because
+// generic functions cannot be methods, so the alternative was threading three
+// arguments through every register* call.
+type toolRegistrar struct {
+	server   *mcp.Server
+	identity authIdentity
+}
+
+// addTool registers a tool only when the caller may use it. A tool the caller
+// cannot call is never registered, so it does not appear in `tools/list` and is
+// reported as unknown rather than forbidden — the caller learns nothing about
+// what it is not allowed to see.
+func addTool[In, Out any](reg toolRegistrar, tool *mcp.Tool, handler mcp.ToolHandlerFor[In, Out]) {
+	if !reg.identity.Capabilities.AllowsTool(tool.Name) {
+		return
+	}
+	mcp.AddTool(reg.server, tool, guardTool(reg.identity, tool.Name, handler))
+}
+
+// guardTool re-checks at call time. Registration already filtered, so this only
+// fires if a tool is reached another way — which is exactly when a check that
+// depends on registration would have been useless.
+func guardTool[In, Out any](identity authIdentity, name string, handler mcp.ToolHandlerFor[In, Out]) mcp.ToolHandlerFor[In, Out] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input In) (*mcp.CallToolResult, Out, error) {
+		// A server is cached per capability set, so the identity captured at
+		// registration is whichever caller first produced that set. Its
+		// capabilities are right by construction; its user is not. Prefer the
+		// live caller so the audit line names who actually called.
+		if live, ok := ctx.Value(authContextKey{}).(authIdentity); ok {
+			identity = live
+		}
+		if !identity.Capabilities.AllowsTool(name) {
+			var zero Out
+			auditToolDecision(identity, name, false)
+			return nil, zero, fmt.Errorf("tool %q requires the %s capability", name, eruncommon.MCPToolCapability(name))
+		}
+		auditToolDecision(identity, name, true)
+		return handler(ctx, req, input)
+	}
+}
+
+// auditToolDecision records every allow and every deny with the resolved
+// identity. A deny nobody can see is indistinguishable from a tool that was
+// never called, which is the wrong thing to learn after an incident.
+func auditToolDecision(identity authIdentity, tool string, allowed bool) {
+	decision := "deny"
+	if allowed {
+		decision = "allow"
+	}
+	log.Printf("erun-mcp authz: %s tool=%s tenant=%s user=%s capabilities=%v",
+		decision, tool, orUnset(identity.Tenant), orUnset(identity.User), identity.Capabilities.Names())
+}
+
+func orUnset(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+// capabilityServerCache keeps one server per distinct capability set. Building a
+// server per request would rebuild 40-odd tool registrations on every call, and
+// the number of distinct sets is tiny — read, admin, and nothing.
+type capabilityServerCache struct {
+	mu      sync.Mutex
+	servers map[string]*mcp.Server
+	build   func(authIdentity) *mcp.Server
+}
+
+func newCapabilityServerCache(build func(authIdentity) *mcp.Server) *capabilityServerCache {
+	return &capabilityServerCache{servers: map[string]*mcp.Server{}, build: build}
+}
+
+func (c *capabilityServerCache) serverFor(req *http.Request) *mcp.Server {
+	identity := authIdentityFrom(req.Context())
+	// The tenant is already fixed per edge, so the capability set alone
+	// identifies a distinct tool surface.
+	key := identity.Capabilities.Key()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if server, ok := c.servers[key]; ok {
+		return server
+	}
+	server := c.build(identity)
+	c.servers[key] = server
+	return server
+}

--- a/erun-mcp/capabilities_test.go
+++ b/erun-mcp/capabilities_test.go
@@ -1,0 +1,164 @@
+package erunmcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// connectWithCapabilities serves the tool surface a caller with these
+// capabilities would get, and returns a connected session. It bypasses the auth
+// middleware deliberately: what is under test is the surface built for an
+// already-resolved caller, not the token parsing that resolves one.
+func connectWithCapabilities(t *testing.T, capabilities ...string) *mcp.ClientSession {
+	t.Helper()
+	for _, key := range []string{envMCPTrustedIssuers, envMCPTrustedIssuer, envMCPAudience, envTenant} {
+		t.Setenv(key, "")
+	}
+	identity := authIdentity{
+		Tenant:       "acme",
+		User:         "operator@acme",
+		Capabilities: eruncommon.NewMCPCapabilitySet(capabilities),
+	}
+	info := eruncommon.BuildInfo{Version: "1.2.3"}
+	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+		return newServer(info, RuntimeConfig{}, identity)
+	}, &mcp.StreamableHTTPOptions{JSONResponse: true})
+
+	httpServer := httptest.NewServer(handler)
+	t.Cleanup(httpServer.Close)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "capability-test", Version: "v0.0.1"}, nil)
+	session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{
+		Endpoint:             httpServer.URL,
+		DisableStandaloneSSE: true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+func listToolNames(t *testing.T, session *mcp.ClientSession) []string {
+	t.Helper()
+	tools, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+	names := make([]string, 0, len(tools.Tools))
+	for _, tool := range tools.Tools {
+		names = append(names, tool.Name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// tools/list must be the same answer as what the caller may do. A menu that
+// lists tools the caller cannot call teaches it about a surface it has no
+// business knowing, and invites an error where there should be none.
+func TestReadCapabilitySeesOnlyTheReadTools(t *testing.T) {
+	got := listToolNames(t, connectWithCapabilities(t, string(eruncommon.MCPCapabilityRead)))
+
+	want := []string{
+		"cloud_list", "context_list", "diff", "idle", "idle_stop_history",
+		"job_await", "job_output", "job_status", "list",
+		"outputs_download", "outputs_list", "version",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("read capability exposed %v, want %v", got, want)
+	}
+}
+
+// The tools that matter most: remote execution and everything that mutates.
+func TestReadCapabilityCannotSeeExecutionOrMutation(t *testing.T) {
+	got := listToolNames(t, connectWithCapabilities(t, string(eruncommon.MCPCapabilityRead)))
+
+	for _, forbidden := range []string{"raw", "deploy", "delete", "build", "push", "release", "context_init", "job_start"} {
+		if slices.Contains(got, forbidden) {
+			t.Fatalf("a read-only caller must not be offered %q: %v", forbidden, got)
+		}
+	}
+}
+
+func TestAdminCapabilitySeesEveryTool(t *testing.T) {
+	admin := listToolNames(t, connectWithCapabilities(t, string(eruncommon.MCPCapabilityAdmin)))
+	read := listToolNames(t, connectWithCapabilities(t, string(eruncommon.MCPCapabilityRead)))
+
+	if len(admin) <= len(read) {
+		t.Fatalf("admin must expose more than read: admin=%d read=%d", len(admin), len(read))
+	}
+	for _, required := range []string{"raw", "deploy", "delete", "version", "list"} {
+		if !slices.Contains(admin, required) {
+			t.Fatalf("admin is missing %q: %v", required, admin)
+		}
+	}
+	// Read is a subset, not a different set.
+	for _, tool := range read {
+		if !slices.Contains(admin, tool) {
+			t.Fatalf("admin should include every read tool, missing %q", tool)
+		}
+	}
+}
+
+// Calling a tool outside the caller's capabilities fails. It is unknown rather
+// than forbidden, because it was never registered for this caller.
+func TestCallingAToolOutsideTheCapabilityFails(t *testing.T) {
+	session := connectWithCapabilities(t, string(eruncommon.MCPCapabilityRead))
+
+	_, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: "raw"})
+	if err == nil {
+		t.Fatal("a read-only caller must not be able to call raw")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "raw") {
+		t.Fatalf("the error should name the tool that was refused, got %v", err)
+	}
+}
+
+// A read-only caller must still be able to do what it is for.
+func TestReadCapabilityCanStillCallAReadTool(t *testing.T) {
+	session := connectWithCapabilities(t, string(eruncommon.MCPCapabilityRead))
+
+	if _, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: "version"}); err != nil {
+		t.Fatalf("a read capability must permit version: %v", err)
+	}
+}
+
+// An edge with no trust anchor is the loopback-only deployment that predates
+// authentication. Turning authentication off must not quietly turn
+// authorization on and strand that deployment with an empty tool set.
+func TestAnUnauthenticatedEdgeKeepsTheCoarseAdminSurface(t *testing.T) {
+	identity := authIdentityFrom(context.Background())
+	if !identity.Capabilities.AllowsTool("raw") {
+		t.Fatalf("an unauthenticated edge keeps its existing surface, got %+v", identity.Capabilities)
+	}
+}
+
+// The guard is defence in depth: registration already filtered, so this only
+// matters if a handler is reached another way — exactly when a check that
+// relied on registration would have been useless.
+func TestGuardRefusesEvenWhenAHandlerIsReachedDirectly(t *testing.T) {
+	identity := authIdentity{
+		Tenant:       "acme",
+		Capabilities: eruncommon.NewMCPCapabilitySet([]string{string(eruncommon.MCPCapabilityRead)}),
+	}
+	called := false
+	handler := func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, struct{}, error) {
+		called = true
+		return nil, struct{}{}, nil
+	}
+
+	guarded := guardTool(identity, "raw", handler)
+	if _, _, err := guarded(context.Background(), nil, struct{}{}); err == nil {
+		t.Fatal("the guard must refuse a tool outside the caller's capabilities")
+	}
+	if called {
+		t.Fatal("a refused tool must not run its handler")
+	}
+}

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -56,10 +56,13 @@ func RunHTTP(ctx context.Context, info eruncommon.BuildInfo, cfg HTTPConfig, run
 func newHTTPHandler(info eruncommon.BuildInfo, cfg HTTPConfig, runtime RuntimeConfig) http.Handler {
 	cfg, _ = normalizeHTTPConfig(cfg)
 
-	server := newServer(info, runtime)
-	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
-		return server
-	}, &mcp.StreamableHTTPOptions{
+	// One server per distinct capability set, resolved per request: a caller
+	// sees exactly the tools it may call, and `tools/list` is the same answer as
+	// what it is allowed to do rather than a menu with locked entries.
+	servers := newCapabilityServerCache(func(identity authIdentity) *mcp.Server {
+		return newServer(info, runtime, identity)
+	})
+	handler := mcp.NewStreamableHTTPHandler(servers.serverFor, &mcp.StreamableHTTPOptions{
 		JSONResponse:   true,
 		SessionTimeout: 5 * time.Minute,
 	})
@@ -135,7 +138,7 @@ func endpointURL(cfg HTTPConfig) string {
 	return "http://" + listenAddress(cfg) + cfg.Path
 }
 
-func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig) *mcp.Server {
+func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig, identity authIdentity) *mcp.Server {
 	info = eruncommon.NormalizeBuildInfo(info)
 	runtime = normalizeRuntimeConfig(runtime)
 
@@ -144,59 +147,60 @@ func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig) *mcp.Server {
 		Version: info.Version,
 	}, nil)
 
-	registerReadModelTools(server, info, runtime)
-	registerIdleStopTools(server, runtime)
-	registerJobTools(server, runtime)
-	registerCloudTools(server, runtime)
-	registerContextTools(server, runtime)
-	registerDeliveryTools(server, runtime)
-	registerInspectionTools(server, runtime)
+	reg := toolRegistrar{server: server, identity: identity}
+	registerReadModelTools(reg, info, runtime)
+	registerIdleStopTools(reg, runtime)
+	registerJobTools(reg, runtime)
+	registerCloudTools(reg, runtime)
+	registerContextTools(reg, runtime)
+	registerDeliveryTools(reg, runtime)
+	registerInspectionTools(reg, runtime)
 
 	return server
 }
 
-func registerReadModelTools(server *mcp.Server, info eruncommon.BuildInfo, runtime RuntimeConfig) {
-	mcp.AddTool(server, &mcp.Tool{
+func registerReadModelTools(reg toolRegistrar, info eruncommon.BuildInfo, runtime RuntimeConfig) {
+	addTool(reg, &mcp.Tool{
 		Name:        "version",
 		Description: "Return build metadata for the current erun binary",
 	}, versionTool(info))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "list",
 		Description: "List configured tenants and environments, defaults, and the effective target for the current runtime directory",
 	}, listTool(runtime))
 }
 
-func registerIdleStopTools(server *mcp.Server, runtime RuntimeConfig) {
-	mcp.AddTool(server, &mcp.Tool{
+func registerIdleStopTools(reg toolRegistrar, runtime RuntimeConfig) {
+	addTool(reg, &mcp.Tool{
 		Name:        "idle",
 		Description: "Return environment idle stop timeout and marker status without recording activity. Includes the leases currently holding the env busy, so a caller can see what is deferring auto-stop.",
 	}, idleTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name: "activity_lease_take",
 		Description: "Hold a named lease for the lifetime of long work in this env, so it reports as busy and idle-stop leaves it alone. " +
 			"Take one before detaching a build, test suite, or agent run: a detached job makes no MCP calls while it runs, so without a lease the env reads as untouched and auto-stop would kill exactly the work worth protecting. " +
 			"Re-taking the same id renews it. Pass the detached job's pid so the lease is reclaimed if it dies; a lease also expires on its own, so it can never pin the env awake forever.",
 	}, activityLeaseTakeTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "activity_lease_release",
 		Description: "Release a lease taken by activity_lease_take once the work is done, so the env can go idle again. Releasing an unknown or already-expired lease succeeds.",
 	}, activityLeaseReleaseTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "idle_stop_cancel",
 		Description: "Dismiss the pending auto-stop grace warning for the env without touching AWS state. No-op when no warning is armed.",
 	}, idleStopCancelTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "idle_stop_history",
 		Description: "Return the last N (cap 10) auto-stop audit entries for the env, newest first. Each row carries the per-marker idle/active breakdown captured when the auto-stop grace was armed.",
 	}, idleStopHistoryTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "idle_stop_record",
 		Description: "Record a host-driven stop entry in stop-history.json (source=host-manual). Called by the desktop's Stop button after the AWS stop succeeds, so the History tab can also explain 'you clicked Stop' alongside the in-pod monitor's auto-stops.",
 	}, idleStopRecordTool(runtime))
 }
 
-func registerJobTools(server *mcp.Server, runtime RuntimeConfig) {
-	mcp.AddTool(server, &mcp.Tool{
+func registerJobTools(reg toolRegistrar, runtime RuntimeConfig) {
+	addTool(reg, &mcp.Tool{
 		Name: "job_start",
 		Description: "Run a long command in this env as a detached job and return its handle. " +
 			"Reach for this instead of `raw` for anything you will need to come back to — a build, a test suite, an agent run. " +
@@ -206,32 +210,32 @@ func registerJobTools(server *mcp.Server, runtime RuntimeConfig) {
 			"The id defaults to the name; re-using the id of a job that is still running is refused, while re-using a finished one replaces it. " +
 			"For an agent run pass agent (claude or codex) plus prompt instead of command: erun invokes the tool in its streaming mode, so job_output returns events while the agent works and job_status reports what it is doing. Running the tool yourself through command would report nothing at all until it exits.",
 	}, jobStartTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name: "job_attach",
 		Description: "Give work you started another way a job handle and an activity lease, so it is visible and protected from idle-stop. " +
 			"erun tracks the pid you name and nothing else: the job reads as running while that process lives and as unknown once it is gone. " +
 			"It can never report an exit status, because nothing erun ran was waiting on that process to observe one — start work through job_start when you need the outcome.",
 	}, jobAttachTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name: "job_status",
 		Description: "Return one job's state and outcome, or every retained job newest-first. " +
 			"The answer is always definite: running, exited with a captured exit code, or explicitly unknown with the reason (its supervisor is gone without an outcome, most often because the runtime pod was replaced). " +
 			"It is never a truncated or partial answer, so it is safe to act on. Finished jobs stay readable for 24 hours, so an orchestrator reconnecting after the work ended can still learn what happened. " +
 			"An agent job also carries progress — current activity (the last tool and its target), turns, tools run, and the last thing the agent said — normalized by erun from the tool's own event stream, so the shape is the same across AI tools. Poll this to report an in-pod agent's progress; do not scrape the agent's private transcript.",
 	}, jobStatusTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name: "job_await",
 		Description: "Wait a bounded time (default 30s, max 600s) for a job to finish. " +
 			"The call always returns inside the timeout — either the outcome or timedOut=true with the job still running — so no connection is held open for the work's lifetime and a dropped stream is never confused with a dead job. " +
 			"timedOut is reported separately from every outcome, so 'not finished yet' can never be read as a failure. Call it again to keep waiting.",
 	}, jobAwaitTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name: "job_output",
 		Description: "Read a page of a job's captured output, including while it is still running, so progress is visible before the work exits. " +
 			"Pass the previous read's nextOffset back as offset to continue where you left off. " +
 			"complete is true only when the job has finished and you have read to the end; the job's own outputTruncated says whether output was dropped at the cap.",
 	}, jobOutputTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name: "job_cancel",
 		Description: "Signal a running job's work (TERM by default, or INT/HUP/KILL). " +
 			"The target comes from the job record, never from a command-line pattern, so a cancel can only reach the work it names and never a process that merely looks like it. " +
@@ -239,32 +243,32 @@ func registerJobTools(server *mcp.Server, runtime RuntimeConfig) {
 	}, jobCancelTool(runtime))
 }
 
-func registerCloudTools(server *mcp.Server, runtime RuntimeConfig) {
-	mcp.AddTool(server, &mcp.Tool{
+func registerCloudTools(reg toolRegistrar, runtime RuntimeConfig) {
+	addTool(reg, &mcp.Tool{
 		Name:        "cloud_list",
 		Description: "List configured root-level cloud provider aliases and token status",
 	}, cloudListTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "cloud_init_aws",
 		Description: "Initialize an AWS SSO cloud provider alias in root ERun config, with preview support",
 	}, cloudInitAWSTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "cloud_init_cloudflare",
 		Description: "Initialize a Cloudflare cloud provider alias from a delegated API token (Zone + DNS edit, plus any other scopes the operator will use such as Cloudflare Pages for static sites). The token is verified against the Cloudflare API and held in a local secret store referenced from erun config, never written into erun-config.yaml; environments that attach the alias receive it as CLOUDFLARE_API_TOKEN. Supports preview.",
 	}, cloudInitCloudflareTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "cloud_login",
 		Description: "Login to a configured cloud provider alias, with preview support",
 	}, cloudLoginTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "cloud_oidc",
 		Description: "Refresh the OIDC issuer for a configured cloud provider alias, with preview support",
 	}, cloudOIDCTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "cloud_set",
 		Description: "Set the cloud provider alias for a tenant environment, with preview support",
 	}, cloudSetTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name: "cloud_inject_aws_credentials",
 		Description: "Write temporary AWS credentials into the runtime pod's ~/.aws/credentials under the erun-host profile, " +
 			"replacing that profile in place. The credential values are tool arguments, so DO NOT call this from anything " +
@@ -273,102 +277,102 @@ func registerCloudTools(server *mcp.Server, runtime RuntimeConfig) {
 			"script, an agent, or a terminal, run `erun cloud refresh <tenant> <environment>` instead: it reads the " +
 			"operator's own profile and streams the secret to the pod on stdin, so nothing sensitive passes through the caller.",
 	}, cloudInjectAWSCredentialsTool())
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "cloud_clear_aws_credentials",
 		Description: "Remove the erun-host profile from the runtime pod's ~/.aws/credentials",
 	}, cloudClearAWSCredentialsTool())
 }
 
-func registerContextTools(server *mcp.Server, runtime RuntimeConfig) {
-	mcp.AddTool(server, &mcp.Tool{
+func registerContextTools(reg toolRegistrar, runtime RuntimeConfig) {
+	addTool(reg, &mcp.Tool{
 		Name:        "context_list",
 		Description: "List managed ERun cloud Kubernetes contexts",
 	}, contextListTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "context_init",
 		Description: "Initialize a managed cloud k3s Kubernetes context, with preview support",
 	}, contextInitTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "context_stop",
 		Description: "Stop a managed ERun cloud Kubernetes context, with preview support",
 	}, contextStopTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "context_start",
 		Description: "Start a managed ERun cloud Kubernetes context, with preview support",
 	}, contextStartTool(runtime))
 }
 
-func registerDeliveryTools(server *mcp.Server, runtime RuntimeConfig) {
-	mcp.AddTool(server, &mcp.Tool{
+func registerDeliveryTools(reg toolRegistrar, runtime RuntimeConfig) {
+	addTool(reg, &mcp.Tool{
 		Name:        "init",
 		Description: "Run `erun init` using the shared init flow; when more input is needed, return a structured interaction request for the caller to answer in a follow-up tool call",
 	}, initTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "build",
 		Description: "Build the project's container images for the resolved tenant/environment. The build step of the build → release → push → deploy flow: set deploy to push and roll them out, or release to stamp and publish the release version first.",
 	}, buildTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "push",
 		Description: "Build and push the project's container images to the BUILD-marked registry for the resolved tenant/environment. The push step of the build → release → push → deploy flow.",
 	}, pushTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "deploy",
 		Description: "Roll the project's charts out to the resolved tenant/environment: build and push the images they need, mirror them from the FROM to the TO registry when both roles are marked, then run the rollout with the cluster pulling from the DEPLOY registry. The deploy step of the build → release → push → deploy flow. Waits for the rollout to become ready (default 5m, the env's deploy.timeout, or the timeout input) and watches the new pods, keeping the wait while an image is still pulling and aborting early on a real container failure.",
 	}, deployTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "publish",
 		Description: "Mirror an already-built version's images from the FROM registry to each TO registry for the resolved tenant/environment, without building or deploying. Use it to hand a version you have tested (e.g. built against a local cluster registry) to other users by copying that exact multi-arch image to the shared TO registry. Requires a version (produced by build then push) and a FROM source plus at least one TO destination marked in the registry list.",
 	}, publishTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "upgrade",
 		Description: "Redeploy the resolved environment to the latest version for its release channel when it is opted into Upgrade all (autoupgrade) and lags. Snapshot-channel environments adopt a stable release once one is published on top of the latest snapshot. High blast radius: rolls out a new runtime image and restarts pods. Set preview to resolve and return the plan (channel, current → target) without deploying.",
 	}, upgradeTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "doctor",
 		Description: "Diagnose and repair the resolved environment: report why a deploy may have failed (helm release status and runtime pods, read-only); recover a failing runtime release by clearing a stuck pending helm lock or rolling back to the last successful revision; prune unused Docker images, build cache, or stopped containers; and optionally restore or repair the root erun config from a backup or by re-initializing orphaned cloud provider aliases",
 	}, doctorTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "delete",
 		Description: "Delete an environment from ERun configuration and remove its remote runtime namespace after explicit tenant-environment confirmation",
 	}, deleteTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "expose",
 		Description: "Expose an in-namespace Service at a stable public hostname under the platform's services zone (requires a platform block in .erun/config.yaml): ensure the per-environment wildcard DNS record points at the env's ingress IP and apply a Host-routing Ingress. Supports preview.",
 	}, exposeTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name: "pin",
 		Description: "Re-pin every erun version reference for this environment in one motion: the Terraform module ?ref, each umbrella chart's erun chart dependencies, the build-env image tag, and the environment's own runtime version. " +
 			"They only work when they agree, and nothing else keeps them in step. Idempotent and a no-op once aligned. Refuses a version that is not published. Set revert to go back to the version recorded before the last re-pin. " +
 			"Set preview to return the full plan — every site, old and new — without writing. Edits the source of truth only: realizing the version (terraform apply, deploy) stays a separate explicit step.",
 	}, pinTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "terraform",
 		Description: "Run a hosted platform's per-environment Terraform from terraform-<tenant>/<environment>/ (or <tenant>-devops/terraform-<tenant>/<environment>/, or the paths.terraform base from .erun/config.yaml) for the resolved tenant/environment: resolve the env folder, pick up the symlinked common.tf, and run its main.tf with <environment>.tfvars. State and the provider cache live on the durable home directory (not the playbook tree), so they survive a runtime pod restart. operation is apply (init → fmt → plan → apply), plan (read-only), or destroy. apply/destroy mutate real cloud and cluster state and require confirm to equal the environment name. Injects TF_VAR_cloudflare_api_token from CLOUDFLARE_API_TOKEN when present. Set preview to resolve and return the terraform commands without executing them.",
 	}, terraformTool(runtime))
 }
 
-func registerInspectionTools(server *mcp.Server, runtime RuntimeConfig) {
-	mcp.AddTool(server, &mcp.Tool{
+func registerInspectionTools(reg toolRegistrar, runtime RuntimeConfig) {
+	addTool(reg, &mcp.Tool{
 		Name:        "diff",
 		Description: "Return the current git diff from the runtime repo root as raw text plus structured file, hunk, line, and tree data",
 	}, diffTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "raw",
 		Description: "Run an arbitrary command from the runtime repo root and return captured stdout, stderr, and trace output",
 	}, rawTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "outputs_list",
 		Description: "List the files and folders an agent produced in the runtime pod's outputs directory ($ERUN_OUTPUTS_DIR, default /home/erun/.erun/outputs), newest-first. Read-only.",
 	}, outputsListTool())
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "outputs_download",
 		Description: "Read one entry from the runtime pod's outputs directory and return its bytes inline as base64 (a folder as a tar.gz archive). The server runs in the pod, so it returns the content directly for the caller to save. Set preview to return name/type/size without the bytes.",
 	}, outputsDownloadTool())
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "release",
 		Description: "Cut a project release from the runtime repo root using .erun/config.yaml branch policy. Stamps the release version into the charts and packaging metadata and commits and tags it locally, then builds and publishes that version's images and helm charts and reads each one back from the registry, and only then pushes the tag, prepares the next patch version, and pushes the branches. A release that completes means deploy can resolve the image and the chart at that version; a release that cannot publish fails while nothing is public. Set preview to resolve and return the plan without executing it.",
 	}, releaseTool(runtime))
-	mcp.AddTool(server, &mcp.Tool{
+	addTool(reg, &mcp.Tool{
 		Name:        "contribute_clone",
 		Description: "Clone the ERun source repository into $HOME/git/erun inside the environment so contribute-mode tabs can build and run a local ERun checkout",
 	}, contributeCloneTool(runtime))


### PR DESCRIPTION
Authentication (#655 + the multi-issuer verifier) answers *which tenant* is calling. Nothing answered *what that caller may do* once it is in — and the edge needs both, because `raw` runs arbitrary commands in the pod and `deploy`, `delete` and `context_*` all mutate. A token that proved a tenant reached every one of them.

## The gate

Every tool requires a capability:

| Capability | Tools |
| --- | --- |
| `erun:read` | Observation that cannot change anything — `version`, `list`, `idle`, `idle_stop_history`, `context_list`, `cloud_list`, `diff`, `outputs_list`, `outputs_download`, `job_status`, `job_output`, `job_await` |
| `erun:admin` | Everything else, including remote execution and every mutating tool |

Admin implies read. The table lives in `erun-common` so the edge and any other transport that grows an authorization story read one mapping.

**Applied twice, for two different failures.** The registered tool set is filtered per request, so `tools/list` is the same answer as what the caller may do and a disallowed tool is *unknown* rather than forbidden — the caller learns nothing about a surface it has no business seeing. Each surviving handler also re-checks at call time, so a tool reached by any other route still refuses; a check that depended on registration would have been useless exactly when it mattered.

Servers are cached per capability set rather than rebuilt per request — the number of distinct sets is tiny, and rebuilding would re-register forty-odd tools on every call. The guard resolves the **live** caller from the request context rather than the identity captured at registration, so a cached server still audits whoever actually called rather than whoever first produced that capability set.

## Two deliberate defaults

- **A token that says nothing about capabilities is an admin.** That is the desktop's single-operator model, and every token minted before this existed says nothing — so adding the gate cannot lock out a caller that worked yesterday. Narrowing is opt-in.
- **A tool nobody has classified requires admin.** The read set is an allowlist, so a tool added without a decision about its blast radius is unreachable to a read-only caller rather than silently reachable.

A token carrying roles, none of them erun's, grants **nothing** rather than everything — the alternative turns an unrelated role into a privilege escalation. That caller is authenticated and not authorized, so the edge answers `403`, not `401`: retrying the same credentials will not help, and the fix is a role rather than a fresh login.

Capabilities are read from either shape an issuer produces: a space-delimited OAuth `scope` claim, or a `roles` array of the kind project roles arrive in.

## Verification

- `go build`, `go vet`, `gofmt` clean across `erun-common`, `erun-mcp`, `erun-cli`; all three suites green.
- `make integration-test` green (`-count=1`, cache defeated).
- New tests drive a **real MCP session over HTTP**, not just the table:
  - a read caller's `tools/list` is exactly the 12 observation tools, asserted by name
  - a read caller is never offered `raw`, `deploy`, `delete`, `build`, `push`, `release`, `context_init`, `job_start`
  - admin exposes every tool and read is a strict subset
  - calling `raw` as a read caller fails, and the error names the tool
  - a read caller can still call `version` — the gate must not break what it is for
  - the guard refuses even when a handler is invoked directly, and the handler does not run
  - an unauthenticated edge keeps its existing coarse-admin surface
- Capability-resolution tests cover both claim shapes, the capability-less admin default, the fail-closed default for unclassified tools, and that unrelated roles grant nothing.
- Docs: a new "What a token is allowed to do" section in `cli/mcp.md`.

## Not in this PR

The issue also lists closing the gap where `erun-mcp/init.go` honours an arbitrary `tenant` argument. The tenant floor itself is already enforced before dispatch (trusted-issuer→tenant mapping, the `resolved-tenant == env-tenant` check, and the per-env audience), and `scopedTenantEnv` exists for the argument case; auditing every tool's use of it is a separate change rather than something to fold into the capability gate.

Closes #657
