### PR TITLE
Fix the lint main was left red on

### DIFF
--- a/erun-common/build_platform_push_order_test.go
+++ b/erun-common/build_platform_push_order_test.go
@@ -58,14 +58,14 @@ func TestEachPlatformIsPushedBeforeTheNextIsBuilt(t *testing.T) {
 		}
 	}
 
-	if !(amd64Build < amd64Push) {
+	if amd64Build >= amd64Push {
 		t.Fatalf("a platform must be pushed after it is built, got build=%d push=%d", amd64Build, amd64Push)
 	}
 	// The whole point: nothing that was built may wait behind another build.
-	if !(amd64Push < arm64Build) {
+	if amd64Push >= arm64Build {
 		t.Fatalf("amd64 must be published before arm64 starts building, or its content need not survive; got amd64 push=%d arm64 build=%d", amd64Push, arm64Build)
 	}
-	if !(arm64Build < arm64Push) {
+	if arm64Build >= arm64Push {
 		t.Fatalf("arm64 must be pushed after it is built, got build=%d push=%d", arm64Build, arm64Push)
 	}
 }
@@ -82,7 +82,7 @@ func TestMultiArchManifestIsAssembledAfterEveryPlatformIsPushed(t *testing.T) {
 	if create < 0 || push < 0 {
 		t.Fatalf("multi-arch assembly missing: %+v", commands)
 	}
-	if !(lastPush < create && create < push) {
+	if lastPush >= create || create >= push {
 		t.Fatalf("expected every platform pushed, then manifest create, then manifest push; got lastPush=%d create=%d push=%d", lastPush, create, push)
 	}
 }
@@ -98,7 +98,7 @@ func TestPromotePublishesEachPlatformBeforeTaggingTheNext(t *testing.T) {
 	if amd64Push < 0 || arm64Tag < 0 {
 		t.Fatalf("promote trace missing a push or tag: %+v", commands)
 	}
-	if !(amd64Push < arm64Tag) {
+	if amd64Push >= arm64Tag {
 		t.Fatalf("promote must publish amd64 before it moves on to arm64; got push=%d next tag=%d", amd64Push, arm64Tag)
 	}
 }

--- a/erun-common/ghcr_push_preflight.go
+++ b/erun-common/ghcr_push_preflight.go
@@ -112,11 +112,17 @@ func githubTokenScopes(ctx context.Context, client *http.Client, token, apiBaseU
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, false
 	}
-	raw, ok := resp.Header[http.CanonicalHeaderKey(githubOAuthScopesHeader)]
+	return parseGitHubScopesHeader(resp.Header)
+}
+
+// parseGitHubScopesHeader reads the scopes GitHub reports on a response.
+//
+// A missing header is not an empty scope list: a fine-grained PAT or a GitHub
+// App token reports no OAuth scopes at all, which is a different permission
+// model rather than an absence of permission, so it declines to answer.
+func parseGitHubScopesHeader(header http.Header) ([]string, bool) {
+	raw, ok := header[http.CanonicalHeaderKey(githubOAuthScopesHeader)]
 	if !ok {
-		// A fine-grained PAT or a GitHub App token reports no OAuth scopes at
-		// all. That is not "no permissions", it is a different permission model
-		// this check cannot read — so it declines to answer.
 		return nil, false
 	}
 	scopes := make([]string, 0, 8)


### PR DESCRIPTION
Two changes (#951, #953) landed with lint failures, so every erun-driven build broke at the image's test stage — which is where `make check` runs, and the only place this repo gates. The 1.0.176 release died there after 1m56s:

```
ghcr_push_preflight.go:94:1: calculated cyclomatic complexity for function githubTokenScopes is 11, max is 10 (cyclop)
build_platform_push_order_test.go:61,65,68: QF1001: could apply De Morgan's law (staticcheck)
make: *** [Makefile:20: lint] Error 1
```

**The mistake was checking the wrong things.** `go build`, `go vet`, `go test` and `make integration-test` all passed — and none of them run golangci-lint. `make check` is `lint integration-test`, and only the second half had been run before merging.

## The fixes

- **staticcheck QF1001**, five negated comparisons in the push-order tests. `if a >= b` says the same thing as `if !(a < b)` and reads better; the compound one becomes `if lastPush >= create || create >= push`.
- **cyclop** on `githubTokenScopes`, which had grown to do request-building, transport, status handling and header parsing in one function. The header parse moves out into `parseGitHubScopesHeader` rather than the limit being waived — it is a separate concern, and it is the part worth testing directly. Its comment keeps the reason a missing header is not an empty scope list.

## Verification

`make check` — the whole gate this time, not half of it:

```
make check exit=0
ok  coverage 75.9% (>= 75.5%)
```

Zero lint issues, integration suite green.
