### PR TITLE
Let an environment say it is busy

### DIFF
--- a/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
@@ -326,6 +326,8 @@ export function EnvironmentRow({
     runningCommand,
     aiBusy,
     reconnecting,
+    envBusy,
+    envBusyDetail,
   );
   // While an orchestrator owns the terminal pane, no environment is the focused
   // thing — suppress the env's selected highlight so the sidebar matches what the

--- a/erun-ui/frontend/src/components/app/Sidebar.helpers.test.ts
+++ b/erun-ui/frontend/src/components/app/Sidebar.helpers.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { environmentIndicator } from './Sidebar.helpers';
+import { deriveEnvironmentRow, environmentIndicator } from './Sidebar.helpers';
 
 // One derived row state from three inputs: the sticky condition the desktop set,
 // what the environment reports about itself, and whether the desktop owns tabs.
@@ -105,4 +105,89 @@ test('a reachable environment is reported on its own terms, not a stale conditio
   assert.equal(indicator.visible, true);
   assert.equal(indicator.dot, 'running');
   assert.equal(indicator.activity, 'In use elsewhere — not opened here');
+});
+
+// The row's spinner is a separate question from the status dot: the dot carries
+// the environment's condition, the spinner carries whether it is working.
+//
+// Four of the five inputs are desktop-local — they report what this desktop
+// launched. The fifth is what the environment says about itself, and it is the
+// only one true regardless of who started the work. It was selected,
+// destructured, and then not passed in, so an environment driven from a
+// terminal, by an orchestrator over MCP, or by a detached job did real work
+// behind a row that looked idle.
+
+function rowArgs(overrides: {
+  isOpening?: boolean;
+  runningCommand?: string;
+  aiBusy?: boolean;
+  reconnecting?: boolean;
+  envBusy?: boolean;
+  envBusyDetail?: string;
+}) {
+  return {
+    isOpening: false,
+    runningCommand: '',
+    aiBusy: false,
+    reconnecting: false,
+    envBusy: false,
+    envBusyDetail: '',
+    ...overrides,
+  };
+}
+
+function row(overrides: Parameters<typeof rowArgs>[0]) {
+  const input = rowArgs(overrides);
+  return deriveEnvironmentRow(
+    'team',
+    'dev',
+    null,
+    [],
+    input.isOpening,
+    input.runningCommand,
+    input.aiBusy,
+    input.reconnecting,
+    input.envBusy,
+    input.envBusyDetail,
+  );
+}
+
+test('an environment working for reasons this desktop did not start still spins', () => {
+  const derived = row({ envBusy: true, envBusyDetail: 'erun release 1.0.176' });
+  assert.equal(derived.busy, true);
+  // The lease names the work, and that is the only signal saying what is
+  // actually running — so it belongs in the label rather than a generic "busy".
+  assert.equal(derived.busyLabel, 'team / dev is busy — erun release 1.0.176');
+});
+
+test('an environment reporting itself busy without a detail still spins', () => {
+  const derived = row({ envBusy: true });
+  assert.equal(derived.busy, true);
+  assert.equal(derived.busyLabel, 'team / dev is busy');
+});
+
+test('a quiet environment nobody is driving does not spin', () => {
+  const derived = row({});
+  assert.equal(derived.busy, false);
+  assert.equal(derived.busyLabel, '');
+});
+
+test('a command this desktop started keeps its own more specific label', () => {
+  // The desktop knows what it launched; the environment only knows that
+  // something holds it. The specific answer wins when both are true.
+  const derived = row({ runningCommand: 'deploy', envBusy: true, envBusyDetail: 'a lease' });
+  assert.equal(derived.busy, true);
+  assert.match(derived.busyLabel, /team \/ dev$/);
+  assert.doesNotMatch(derived.busyLabel, /a lease/);
+});
+
+test('each desktop-local reason still spins its own row on its own', () => {
+  for (const overrides of [
+    { isOpening: true },
+    { runningCommand: 'deploy' },
+    { aiBusy: true },
+    { reconnecting: true },
+  ]) {
+    assert.equal(row(overrides).busy, true, `expected busy for ${JSON.stringify(overrides)}`);
+  }
 });

--- a/erun-ui/frontend/src/components/app/Sidebar.helpers.ts
+++ b/erun-ui/frontend/src/components/app/Sidebar.helpers.ts
@@ -48,13 +48,21 @@ export function deriveEnvironmentRow(
   runningCommand: string,
   aiBusy: boolean,
   reconnecting: boolean,
+  envBusy: boolean,
+  envBusyDetail: string,
 ): EnvironmentRowDerived {
   const selected =
     selectedSelection?.tenant === tenantName && selectedSelection.environment === environmentName;
   // busy is scoped to this env and independent of which env is selected, so
   // concurrent work on multiple envs shows a spinner on every row that's actually
   // doing something — not just the one in the active terminal.
-  const busy = isOpening || runningCommand !== '' || aiBusy || reconnecting;
+  //
+  // envBusy is what the environment says about itself, and it is the only input
+  // here that is true regardless of who started the work. The other four are
+  // desktop-local: they report what this desktop launched, so an environment
+  // driven by `erun` from a terminal, by an orchestrator over MCP, or by a
+  // detached job was doing real work behind a row that looked idle.
+  const busy = isOpening || runningCommand !== '' || aiBusy || reconnecting || envBusy;
   const busyLabel = environmentRowBusyLabel(
     tenantName,
     environmentName,
@@ -62,6 +70,8 @@ export function deriveEnvironmentRow(
     runningCommand,
     aiBusy,
     reconnecting,
+    envBusy,
+    envBusyDetail,
   );
   const environment = tenants
     .find((tenant) => tenant.name === tenantName)
@@ -84,6 +94,8 @@ function environmentRowBusyLabel(
   runningCommand: string,
   aiBusy: boolean,
   reconnecting: boolean,
+  envBusy: boolean,
+  envBusyDetail: string,
 ): string {
   const target = `${tenantName} / ${environmentName}`;
   if (runningCommand !== '') {
@@ -95,6 +107,11 @@ function environmentRowBusyLabel(
   }
   if (reconnecting) {
     return `Reconnecting ${target}`;
+  }
+  if (envBusy) {
+    return envBusyDetail !== ''
+      ? `${target} is busy — ${envBusyDetail}`
+      : `${target} is busy`;
   }
   if (aiBusy) {
     return `AI tab working on ${target}`;


### PR DESCRIPTION
The environment row's spinner was composed from four **desktop-local** inputs:

```ts
const busy = isOpening || runningCommand !== '' || aiBusy || reconnecting;
```

Each reports what *this desktop* launched. So an environment driven from a terminal, by an orchestrator over MCP, or by a detached job was doing real work behind a row that looked idle.

## The answer was already there

The pipeline is built and correct end to end:

- `observeEnvironmentActivity` reads the environment's own idle status over its edge — and does it for a CLI-opened environment too, because `erun open` writes the forward state whoever ran it
- `environmentBusyFromIdleStatus` reduces the markers to one line, preferring a held lease *"because it is the only signal that names the work"*
- that travels through the `env-activity` event into `activityByEnv`
- `Sidebar.EnvironmentRow.tsx` selects it as `envBusy` / `envBusyDetail`, with a comment saying exactly why it exists: *"What the environment itself reports, which is true whoever opened it — the desktop, a CLI `erun open`, or an agent over MCP"*

…and then drops both on the floor: `deriveEnvironmentRow` was called without them. A complete pipeline disconnected at the last inch.

## Observed

`erun/ux` held a lease for eleven minutes while a release ran, reported busy **by name**, and its row showed nothing:

```json
"leases": [{"id":"job-release-176b","name":"erun release 1.0.176 (retry, lint fixed)"}]
"lease": {"idle": false, "reason": "held by erun release 1.0.176 (retry, lint fixed)"}
```

## The change

`envBusy` joins the composition, and `envBusyDetail` becomes the label whenever the work started somewhere this desktop cannot see — so the row reads `team / dev is busy — erun release 1.0.176` rather than a generic spinner. The four local inputs keep priority for the label: the desktop knows specifically what it launched, while the environment only knows that something holds it.

It can only ever make a genuinely-busy row spin. Nothing here suppresses a spinner.

## Scope: this is half of #955

The other half — a desktop-local latch that outlives whatever set it, so an **idle** environment spins forever (observed on `frs/prod`: every marker idle, no lease, nothing deployed for 6h21m, still spinning) — needs those latches bounded, and is deliberately not attempted here.

The tempting fix, suppressing the spinner whenever the environment reports idle, would hide a genuine desktop-driven deploy: the pod is being replaced and the environment legitimately looks quiet. That is a design call, not a one-liner, so #955 stays open for it.

## Verification

- `yarn test` — 21 pass, 0 fail, including five new cases: an environment busy for reasons the desktop did not start spins and is labelled by its lease; busy without a detail still spins; a quiet environment does not; a desktop-started command keeps its own more specific label; and each of the four local inputs still spins its row on its own.
- `yarn typecheck` reports **51 errors both with and without this change** — identical. They are all `Cannot find module '../../../wailsjs/...'` and its knock-on implicit-`any`s, from the wails bindings that are generated at build time and gitignored, so absent in a fresh clone. Measured by count against pristine `main` rather than eyeballing a truncated tail.

Refs #955
