### PR TITLE
Keep the environment row under its complexity gate

### DIFF
--- a/erun-ui/frontend/src/components/app/Sidebar.helpers.ts
+++ b/erun-ui/frontend/src/components/app/Sidebar.helpers.ts
@@ -62,7 +62,7 @@ export function deriveEnvironmentRow(
   // desktop-local: they report what this desktop launched, so an environment
   // driven by `erun` from a terminal, by an orchestrator over MCP, or by a
   // detached job was doing real work behind a row that looked idle.
-  const busy = isOpening || runningCommand !== '' || aiBusy || reconnecting || envBusy;
+  const busy = environmentRowIsBusy(isOpening, runningCommand, aiBusy, reconnecting, envBusy);
   const busyLabel = environmentRowBusyLabel(
     tenantName,
     environmentName,
@@ -87,6 +87,19 @@ export function deriveEnvironmentRow(
   };
 }
 
+// The five reasons a row spins, kept out of deriveEnvironmentRow so that
+// function stays under the complexity gate — and so the set is one named thing
+// rather than a disjunction growing inside a larger function.
+function environmentRowIsBusy(
+  isOpening: boolean,
+  runningCommand: string,
+  aiBusy: boolean,
+  reconnecting: boolean,
+  envBusy: boolean,
+): boolean {
+  return isOpening || runningCommand !== '' || aiBusy || reconnecting || envBusy;
+}
+
 function environmentRowBusyLabel(
   tenantName: string,
   environmentName: string,
@@ -109,9 +122,7 @@ function environmentRowBusyLabel(
     return `Reconnecting ${target}`;
   }
   if (envBusy) {
-    return envBusyDetail !== ''
-      ? `${target} is busy — ${envBusyDetail}`
-      : `${target} is busy`;
+    return envBusyDetail !== '' ? `${target} is busy — ${envBusyDetail}` : `${target} is busy`;
   }
   if (aiBusy) {
     return `AI tab working on ${target}`;


### PR DESCRIPTION
#956 added `envBusy` to the row's busy composition and pushed `deriveEnvironmentRow` to a complexity of 11, one over the gate:

```
Sidebar.helpers.ts 42:8  Function 'deriveEnvironmentRow' has a complexity of 11. Maximum allowed is 10
```

The desktop build is the only place that gate runs — `erun-ui`'s frontend and Go checks live in `erun-ui/build.sh` rather than the shared `make check`, because they need the CGO/webkit and frontend toolchain the image does not have.

**Why I missed it:** I ran the frontend gates in a tree where `wails generate module` had never run, saw 333 errors from the missing bindings module, and stopped treating lint as a signal. `build.sh` generates the bindings *before* the gates, so in a real build those errors do not exist and the gate is meaningful.

The five reasons a row spins move into `environmentRowIsBusy` — a named set rather than a disjunction growing inside a larger function, which is what the gate was asking for.

## Verification

Run in a tree with the bindings generated, so all four are real:

| gate | |
|---|---|
| `yarn typecheck` | PASS |
| `yarn lint` | PASS |
| `yarn format:check` | PASS |
| `yarn test` | PASS (21) |

Refs #956