### PR TITLE
Make the version stamp describe the binary, not the last commit

### DIFF
--- a/erun-cli/run.sh
+++ b/erun-cli/run.sh
@@ -27,11 +27,21 @@ if [ -f "$VERSION_FILE" ]; then
 	BUILD_VERSION=$(tr -d '\n' < "$VERSION_FILE")
 fi
 
+# The stamp has to describe the artifact, not the last commit. These scripts
+# exist to build from a working checkout, so an uncommitted change is the normal
+# case — and HEAD alone then names a commit the binary does not contain, which is
+# exactly the question `erun version` is asked to answer. A dirty build says so.
+#
+# BUILD_DATE is when the binary was built, not when HEAD was authored: a fresh
+# build off an older commit otherwise reports a stale-looking timestamp and reads
+# as the wrong binary.
 BUILD_COMMIT=
-BUILD_DATE=
+BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 if git -C "$SCRIPT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 	BUILD_COMMIT=$(git -C "$SCRIPT_DIR" rev-parse --short=12 HEAD)
-	BUILD_DATE=$(git -C "$SCRIPT_DIR" show -s --format=%cI HEAD)
+	if [ -n "$(git -C "$SCRIPT_DIR" status --porcelain 2>/dev/null)" ]; then
+		BUILD_COMMIT="${BUILD_COMMIT}-dirty"
+	fi
 fi
 
 # --no-shell is the eval-friendly mode (`eval "$(erun open ... --no-shell)"`);

--- a/erun-ui/build.sh
+++ b/erun-ui/build.sh
@@ -82,11 +82,21 @@ if [ -f "$VERSION_FILE" ]; then
 	BUILD_VERSION=$(tr -d '\n' < "$VERSION_FILE")
 fi
 
+# The stamp has to describe the artifact, not the last commit. These scripts
+# exist to build from a working checkout, so an uncommitted change is the normal
+# case — and HEAD alone then names a commit the binary does not contain, which is
+# exactly the question `erun version` is asked to answer. A dirty build says so.
+#
+# BUILD_DATE is when the binary was built, not when HEAD was authored: a fresh
+# build off an older commit otherwise reports a stale-looking timestamp and reads
+# as the wrong binary.
 BUILD_COMMIT=
-BUILD_DATE=
+BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 if git -C "$SCRIPT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 	BUILD_COMMIT=$(git -C "$SCRIPT_DIR" rev-parse --short=12 HEAD)
-	BUILD_DATE=$(git -C "$SCRIPT_DIR" show -s --format=%cI HEAD)
+	if [ -n "$(git -C "$SCRIPT_DIR" status --porcelain 2>/dev/null)" ]; then
+		BUILD_COMMIT="${BUILD_COMMIT}-dirty"
+	fi
 fi
 
 LDFLAGS="-s -w -X github.com/sophium/erun/erun-ui.buildVersion=${BUILD_VERSION} -X github.com/sophium/erun/erun-ui.buildCommit=${BUILD_COMMIT} -X github.com/sophium/erun/erun-ui.buildDate=${BUILD_DATE}"


### PR DESCRIPTION
Closes #960

## The lie

```
$ printf '// probe' >> erun-cli/cmd/version.go   # binary now contains uncommitted code
$ ./erun-cli/run.sh version
erun 1.0.177 (6c6b4faccd42 built 2026-08-09T12:38:49+03:00)
$ git rev-parse --short=12 HEAD
6c6b4faccd42
```

The binary says it is a commit it does not contain.

Found in the wild before I reproduced it: a desktop under `~/.cache/erun/dev-bin` reported `6fc644b7 built 2026-08-08T11:06Z` while `strings` showed it carrying `reconcileOrchestratorActivity` — code merged hours later in #946. The binary disagreed with its own version output, and the version output is what you would consult to settle that.

## Why

Both `erun-cli/run.sh` and `erun-ui/build.sh` stamped `git rev-parse HEAD` and `git show -s --format=%cI HEAD`. HEAD describes the last commit, not the tree that was compiled — and these scripts exist to build from a working checkout, so a dirty tree is their normal input.

`BUILD_DATE` compounded it by reporting the *commit's* date, so a binary built today off an older commit reads as a stale binary.

## The fix

- `-dirty` suffix when `git status --porcelain` is non-empty.
- `BUILD_DATE` is build time (UTC), not commit time.

## Verified, both arms, on the same build

```
clean tree  -> erun 1.0.177 (cb4e9dd8508f built 2026-08-09T09:52:23Z)
dirty tree  -> erun 1.0.177 (cb4e9dd8508f-dirty built 2026-08-09T09:52:24Z)
```

## What is not covered by a test, and why

The stamping lives in the two build scripts, not in Go, so neither the integration suite (which runs a prebuilt binary) nor any module suite can reach it — the suites never invoke `run.sh`/`build.sh`. I verified it by executing both scripts against a clean and a dirty tree and reading the output, shown above. Adding a shell-level gate would mean a test harness that does not exist today; worth doing if this class recurs, but I did not build one here rather than claim coverage I do not have.

## Validation

- All four module suites green, `golangci-lint` clean in each.
- `make integration-test` green (75.9%).
- Both scripts pass `sh -n`.