### PR TITLE
Let an environment's own report stop its row spinning

### DIFF
--- a/erun-ui/environment_activity.go
+++ b/erun-ui/environment_activity.go
@@ -45,7 +45,13 @@ type environmentActivity struct {
 
 type environmentActivityState struct {
 	reachable bool
-	busy      bool
+	// observed records that the environment answered the idle question, as
+	// opposed to busy's false meaning nobody got an answer. The two are not the
+	// same claim, and the sidebar clears a stale desktop latch on the strength
+	// of this one — a wedged edge whose port still answers must not be able to
+	// say "idle" on the environment's behalf.
+	observed bool
+	busy     bool
 	// detail names what is keeping the environment busy, in the operator's
 	// language, so the row can say "held by gradle-build" rather than "busy".
 	detail string
@@ -135,6 +141,7 @@ func (a *App) observeEnvironmentActivity(selection uiSelection) environmentActiv
 		// so report reachable-without-a-verdict rather than inventing one.
 		return observation
 	}
+	observation.state.observed = true
 	observation.state.busy, observation.state.detail = environmentBusyFromIdleStatus(status)
 	return observation
 }
@@ -212,6 +219,7 @@ func (a *App) emitEnvActivity(observation environmentActivity) {
 		Tenant:      observation.selection.Tenant,
 		Environment: observation.selection.Environment,
 		Reachable:   observation.state.reachable,
+		Observed:    observation.state.observed,
 		Busy:        observation.state.busy,
 		Detail:      observation.state.detail,
 	})

--- a/erun-ui/environment_activity_observed_test.go
+++ b/erun-ui/environment_activity_observed_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// The sidebar lets an environment's own answer stop a row spinning, which makes
+// the difference between "it answered, and reports no work" and "nobody got an
+// answer" load-bearing. Both leave busy false, so the observation has to carry
+// the distinction itself — otherwise an edge that has wedged behind a port that
+// still accepts connections would clear a latch on the environment's behalf and
+// hide work that is still running.
+
+func seedMCPForward(t *testing.T, tenant, environment string, port int) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	path, err := eruncommon.PortForwardStatePath("mcp", tenant, environment)
+	if err != nil {
+		t.Fatalf("PortForwardStatePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	data, err := json.Marshal(eruncommon.PortForwardState{
+		Tenant: tenant, Environment: environment, LocalPort: port,
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func observeWith(
+	t *testing.T,
+	canConnect bool,
+	load func(context.Context, string, string) (eruncommon.EnvironmentIdleStatus, error),
+) environmentActivityState {
+	t.Helper()
+	seedMCPForward(t, "acme", "dev", 17500)
+	app := NewApp(erunUIDeps{
+		store:               stubUIStore{},
+		canConnectLocalPort: func(int) bool { return canConnect },
+		loadIdleStatus:      load,
+	})
+	t.Cleanup(func() { app.shutdown(context.Background()) })
+	return app.observeEnvironmentActivity(uiSelection{Tenant: "acme", Environment: "dev"}).state
+}
+
+func TestObserveEnvironmentActivityWedgedEdgeGivesNoVerdict(t *testing.T) {
+	got := observeWith(t, true, func(context.Context, string, string) (eruncommon.EnvironmentIdleStatus, error) {
+		return eruncommon.EnvironmentIdleStatus{}, errors.New("edge did not answer")
+	})
+	if !got.reachable {
+		t.Fatal("a port that accepts connections is still reachable")
+	}
+	// The claim that matters: nobody asked the environment anything, so the
+	// observation must not read as the environment reporting no work.
+	if got.observed {
+		t.Fatal("a wedged edge must not be reported as an answered idle question")
+	}
+	if got.busy {
+		t.Fatal("no answer is not evidence of work either")
+	}
+}
+
+func TestObserveEnvironmentActivityIdleEnvironmentAnswers(t *testing.T) {
+	got := observeWith(t, true, func(context.Context, string, string) (eruncommon.EnvironmentIdleStatus, error) {
+		return eruncommon.EnvironmentIdleStatus{
+			Markers: []eruncommon.EnvironmentIdleMarker{{Name: eruncommon.ActivityKindProcess, Idle: true}},
+		}, nil
+	})
+	if !got.reachable || !got.observed {
+		t.Fatalf("an environment that answered is reachable and observed, got %+v", got)
+	}
+	if got.busy {
+		t.Fatal("every marker idle means no work")
+	}
+}
+
+func TestObserveEnvironmentActivityUnreachableGivesNoVerdict(t *testing.T) {
+	got := observeWith(t, false, func(context.Context, string, string) (eruncommon.EnvironmentIdleStatus, error) {
+		t.Fatal("the idle question must not be asked when the port does not answer")
+		return eruncommon.EnvironmentIdleStatus{}, nil
+	})
+	if got.reachable || got.observed || got.busy {
+		t.Fatalf("an unreachable environment reports nothing, got %+v", got)
+	}
+}
+
+// A transition in the verdict alone has to reach the sidebar: an environment
+// that stops answering while still holding its port changes nothing else about
+// the observation, and that is exactly the moment the row must stop trusting it.
+func TestEnvActivityStateComparesTheVerdict(t *testing.T) {
+	answered := environmentActivityState{reachable: true, observed: true}
+	silent := environmentActivityState{reachable: true}
+	if answered == silent {
+		t.Fatal("the verdict must take part in the transition check")
+	}
+}

--- a/erun-ui/frontend/src/app/model/envActivityPayload.ts
+++ b/erun-ui/frontend/src/app/model/envActivityPayload.ts
@@ -6,6 +6,7 @@ export interface EnvActivityPayload {
   tenant: string;
   environment: string;
   reachable: boolean;
+  observed: boolean;
   busy: boolean;
   detail?: string;
 }

--- a/erun-ui/frontend/src/app/slices/envStatusSlice.ts
+++ b/erun-ui/frontend/src/app/slices/envStatusSlice.ts
@@ -20,6 +20,10 @@ const envRealStatuses: readonly string[] = ['stopped', 'runtime-stopped', 'faile
 // tab-presence check cannot see.
 export interface EnvObservedActivity {
   reachable: boolean;
+  // observed is the environment having answered the idle question. It is what
+  // separates "asked, and it reports no work" from "never got an answer" —
+  // busy is false either way, and only the first may clear a row's latch.
+  observed: boolean;
   busy: boolean;
   detail: string;
 }

--- a/erun-ui/frontend/src/app/wailsEventThunks.ts
+++ b/erun-ui/frontend/src/app/wailsEventThunks.ts
@@ -105,6 +105,7 @@ export const handleEnvActivity =
         key,
         activity: {
           reachable: payload.reachable,
+          observed: payload.observed,
           busy: payload.busy,
           detail: (payload.detail ?? '').trim(),
         },

--- a/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
@@ -269,6 +269,12 @@ function useEnvironmentRowSelectors(tenantName: string, environmentName: string)
   const reachable = useAppSelector(
     (state) => state.envStatus.activityByEnv[activityKey]?.reachable === true,
   );
+  // Whether the environment answered at all, which is a different question from
+  // what it answered — see environmentRowIsBusy, where only an actual answer is
+  // allowed to stop a row spinning.
+  const envObserved = useAppSelector(
+    (state) => state.envStatus.activityByEnv[activityKey]?.observed === true,
+  );
   const envBusy = useAppSelector(
     (state) => state.envStatus.activityByEnv[activityKey]?.busy === true,
   );
@@ -285,6 +291,7 @@ function useEnvironmentRowSelectors(tenantName: string, environmentName: string)
     reconnecting,
     envState,
     reachable,
+    envObserved,
     envBusy,
     envBusyDetail,
   };
@@ -307,6 +314,7 @@ export function EnvironmentRow({
     reconnecting,
     envState,
     reachable,
+    envObserved,
     envBusy,
     envBusyDetail,
   } = useEnvironmentRowSelectors(tenantName, environmentName);
@@ -314,6 +322,7 @@ export function EnvironmentRow({
     selected: selectedBySelection,
     busy,
     busyLabel,
+    busyFromEnvironment,
     isLocal,
     runtimeVersion,
     selection,
@@ -328,6 +337,7 @@ export function EnvironmentRow({
     reconnecting,
     envBusy,
     envBusyDetail,
+    envObserved,
   );
   // While an orchestrator owns the terminal pane, no environment is the focused
   // thing — suppress the env's selected highlight so the sidebar matches what the
@@ -360,7 +370,7 @@ export function EnvironmentRow({
       selection={selection}
       isLocal={isLocal}
       runtimeVersion={runtimeVersion}
-      activityLabel={busy ? busyLabel : ''}
+      activityLabel={busy && !busyFromEnvironment ? busyLabel : ''}
       indicator={indicator}
     >
       <EnvironmentRowOpenButton

--- a/erun-ui/frontend/src/components/app/Sidebar.helpers.test.ts
+++ b/erun-ui/frontend/src/components/app/Sidebar.helpers.test.ts
@@ -124,6 +124,7 @@ function rowArgs(overrides: {
   reconnecting?: boolean;
   envBusy?: boolean;
   envBusyDetail?: string;
+  envObserved?: boolean;
 }) {
   return {
     isOpening: false,
@@ -132,6 +133,9 @@ function rowArgs(overrides: {
     reconnecting: false,
     envBusy: false,
     envBusyDetail: '',
+    // Unobserved by default: no answer from the environment must not clear
+    // anything, so a test that says nothing about it gets the old behaviour.
+    envObserved: false,
     ...overrides,
   };
 }
@@ -149,6 +153,7 @@ function row(overrides: Parameters<typeof rowArgs>[0]) {
     input.reconnecting,
     input.envBusy,
     input.envBusyDetail,
+    input.envObserved,
   );
 }
 
@@ -190,4 +195,58 @@ test('each desktop-local reason still spins its own row on its own', () => {
   ]) {
     assert.equal(row(overrides).busy, true, `expected busy for ${JSON.stringify(overrides)}`);
   }
+});
+
+// The defect: every other input is desktop-local, set when this desktop starts
+// something and cleared when it sees it end. A command driven from a terminal or
+// over MCP, or a session that goes away, leaves a latch nobody can clear — one
+// row span for six hours while the environment reported every marker idle.
+test('an environment that reports itself idle clears a stale desktop latch', () => {
+  const stuckCommand = row({ runningCommand: 'deploy', envObserved: true, envBusy: false });
+  assert.equal(stuckCommand.busy, false);
+
+  const stuckAI = row({ aiBusy: true, envObserved: true, envBusy: false });
+  assert.equal(stuckAI.busy, false);
+});
+
+// Silence is not an answer. This covers both an environment nobody reached and
+// one whose port answers while its edge has wedged — the poller reports no work
+// in both cases because nobody got a verdict, and neither may clear a latch.
+test('an environment that gave no verdict keeps its desktop latch', () => {
+  assert.equal(row({ runningCommand: 'deploy', envObserved: false }).busy, true);
+  assert.equal(row({ aiBusy: true, envObserved: false }).busy, true);
+});
+
+// The environment's own answer still wins upward, whoever started the work.
+test('an environment that reports work spins even when the desktop started nothing', () => {
+  assert.equal(row({ envBusy: true, envObserved: true }).busy, true);
+});
+
+// This desktop's own in-flight operations answer for themselves: the operator
+// clicked a moment ago and the environment cannot yet have observed it, so a
+// reachable-idle report must not swallow the feedback for the click.
+test("an idle report does not swallow this desktop's in-flight operation", () => {
+  assert.equal(row({ isOpening: true, envObserved: true, envBusy: false }).busy, true);
+  assert.equal(row({ reconnecting: true, envObserved: true, envBusy: false }).busy, true);
+});
+
+// The row's spinner label names its environment because a screen reader has no
+// other context for it. A hover card headed with that same environment does, so
+// it needs to know which kind of label it was handed rather than repeating
+// "<env> is busy — X" under a heading that already says "<env>".
+test('a label describing the environment is marked as the environment own', () => {
+  const derived = row({ envBusy: true, envBusyDetail: 'holding: gradle-build', envObserved: true });
+  assert.equal(derived.busyLabel, 'team / dev is busy — holding: gradle-build');
+  assert.equal(derived.busyFromEnvironment, true);
+});
+
+test('a label describing an operation this desktop is running is not', () => {
+  // A command this desktop is running names the row, so the label is about the
+  // desktop even when the environment reports busy at the same moment.
+  const withCommand = row({ runningCommand: 'build', envBusy: true, envObserved: true });
+  assert.equal(withCommand.busyLabel, 'Building team / dev');
+  assert.equal(withCommand.busyFromEnvironment, false);
+
+  assert.equal(row({ isOpening: true, envBusy: true }).busyFromEnvironment, false);
+  assert.equal(row({ reconnecting: true, envBusy: true }).busyFromEnvironment, false);
 });

--- a/erun-ui/frontend/src/components/app/Sidebar.helpers.ts
+++ b/erun-ui/frontend/src/components/app/Sidebar.helpers.ts
@@ -34,6 +34,13 @@ export interface EnvironmentRowDerived {
   selected: boolean;
   busy: boolean;
   busyLabel: string;
+  // busyFromEnvironment says the label describes the environment's own
+  // condition rather than an operation this desktop is running. A row's spinner
+  // needs the label either way, because a screen reader has no other context;
+  // a surface that already names the environment does not, and repeating
+  // "<env> is busy — X" inside a card headed "<env>" says the same thing twice
+  // while displacing the prose the indicator already owns.
+  busyFromEnvironment: boolean;
   isLocal: boolean;
   runtimeVersion: string;
   selection: UISelection;
@@ -50,6 +57,7 @@ export function deriveEnvironmentRow(
   reconnecting: boolean,
   envBusy: boolean,
   envBusyDetail: string,
+  envObserved: boolean,
 ): EnvironmentRowDerived {
   const selected =
     selectedSelection?.tenant === tenantName && selectedSelection.environment === environmentName;
@@ -62,7 +70,23 @@ export function deriveEnvironmentRow(
   // desktop-local: they report what this desktop launched, so an environment
   // driven by `erun` from a terminal, by an orchestrator over MCP, or by a
   // detached job was doing real work behind a row that looked idle.
-  const busy = environmentRowIsBusy(isOpening, runningCommand, aiBusy, reconnecting, envBusy);
+  const busy = environmentRowIsBusy(
+    isOpening,
+    runningCommand,
+    aiBusy,
+    reconnecting,
+    envBusy,
+    envObserved,
+  );
+  const busyFromEnvironment =
+    envBusy &&
+    environmentRowCommandLabel(
+      tenantName,
+      environmentName,
+      isOpening,
+      runningCommand,
+      reconnecting,
+    ) === '';
   const busyLabel = environmentRowBusyLabel(
     tenantName,
     environmentName,
@@ -81,6 +105,7 @@ export function deriveEnvironmentRow(
     selected,
     busy,
     busyLabel,
+    busyFromEnvironment,
     isLocal,
     runtimeVersion: environment?.runtimeVersion?.trim() ?? '',
     selection: { tenant: tenantName, environment: environmentName },
@@ -90,14 +115,38 @@ export function deriveEnvironmentRow(
 // The five reasons a row spins, kept out of deriveEnvironmentRow so that
 // function stays under the complexity gate — and so the set is one named thing
 // rather than a disjunction growing inside a larger function.
+// The environment's own answer both adds and subtracts. Adding was already
+// wired: work started from a terminal or over MCP spins a row the desktop never
+// launched anything on. Subtracting was not, and that is the half that matters
+// for a row nobody can clear — every other input here is desktop-local, set when
+// this desktop starts something and cleared when it sees it end, so any path
+// that loses the ending leaves a latch with nothing to release it. One row span
+// for six hours while `erun idle` reported every marker idle.
+//
+// An observation reporting no work is therefore allowed to clear those latches.
+// It has to be the environment's own answer, not merely a reachable port: an
+// edge that has wedged behind a port that still accepts connections reports no
+// work because nobody asked it, and letting that clear a latch would trade a row
+// that never stops for one that stops while the work is still running.
+//
+// isOpening and reconnecting stay authoritative regardless. They are this
+// desktop's own in-flight operations, begun a moment ago in response to a click,
+// and the environment cannot yet have observed what has not reached it.
 function environmentRowIsBusy(
   isOpening: boolean,
   runningCommand: string,
   aiBusy: boolean,
   reconnecting: boolean,
   envBusy: boolean,
+  envObserved: boolean,
 ): boolean {
-  return isOpening || runningCommand !== '' || aiBusy || reconnecting || envBusy;
+  if (envBusy || isOpening || reconnecting) {
+    return true;
+  }
+  if (envObserved) {
+    return false;
+  }
+  return runningCommand !== '' || aiBusy;
 }
 
 function environmentRowBusyLabel(
@@ -111,21 +160,44 @@ function environmentRowBusyLabel(
   envBusyDetail: string,
 ): string {
   const target = `${tenantName} / ${environmentName}`;
-  if (runningCommand !== '') {
-    const verb = activityCommandLabel(runningCommand);
-    return `${verb} ${target}`;
-  }
-  if (isOpening) {
-    return `Opening ${target}`;
-  }
-  if (reconnecting) {
-    return `Reconnecting ${target}`;
+  const command = environmentRowCommandLabel(
+    tenantName,
+    environmentName,
+    isOpening,
+    runningCommand,
+    reconnecting,
+  );
+  if (command !== '') {
+    return command;
   }
   if (envBusy) {
     return envBusyDetail !== '' ? `${target} is busy — ${envBusyDetail}` : `${target} is busy`;
   }
   if (aiBusy) {
     return `AI tab working on ${target}`;
+  }
+  return '';
+}
+
+// The operations this desktop is running itself, in the order that decides
+// which one names the row. Split out from the label so a caller can ask whether
+// there is one at all without re-deriving the precedence.
+function environmentRowCommandLabel(
+  tenantName: string,
+  environmentName: string,
+  isOpening: boolean,
+  runningCommand: string,
+  reconnecting: boolean,
+): string {
+  const target = `${tenantName} / ${environmentName}`;
+  if (runningCommand !== '') {
+    return `${activityCommandLabel(runningCommand)} ${target}`;
+  }
+  if (isOpening) {
+    return `Opening ${target}`;
+  }
+  if (reconnecting) {
+    return `Reconnecting ${target}`;
   }
   return '';
 }

--- a/erun-ui/playwright/tests/sidebar-env-activity.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-env-activity.spec.ts
@@ -36,7 +36,7 @@ test.describe('sidebar env activity', () => {
     const dot = app.sidebar.envOpenDot(tenant, environment);
     await driveEnvActivity(
       page,
-      { tenant, environment, reachable: true, busy: false },
+      { tenant, environment, reachable: true, observed: true, busy: false },
       async () => {
         await expect(dot).toHaveAttribute('data-env-state', 'running', { timeout: 1_000 });
         // Not opened here means there is nothing to close, so the indicator is a
@@ -50,7 +50,13 @@ test.describe('sidebar env activity', () => {
     );
 
     // And it goes back to blank when the environment stops answering.
-    await emitEnvActivity(page, { tenant, environment, reachable: false, busy: false });
+    await emitEnvActivity(page, {
+      tenant,
+      environment,
+      reachable: false,
+      observed: false,
+      busy: false,
+    });
     await expect(row.getByTestId('env-open-dot')).toHaveCount(0);
   });
 
@@ -60,6 +66,7 @@ test.describe('sidebar env activity', () => {
       tenant,
       environment,
       reachable: true,
+      observed: true,
       busy: true,
       detail: 'holding: gradle-build',
     };
@@ -82,7 +89,13 @@ test.describe('sidebar env activity', () => {
       );
     });
 
-    await emitEnvActivity(page, { tenant, environment, reachable: false, busy: false });
+    await emitEnvActivity(page, {
+      tenant,
+      environment,
+      reachable: false,
+      observed: false,
+      busy: false,
+    });
     const row: Locator = app.sidebar.envRowButton(tenant, environment).locator('..');
     await expect(row.getByTestId('env-open-dot')).toHaveCount(0);
   });
@@ -92,6 +105,7 @@ interface EnvActivityEvent {
   tenant: string;
   environment: string;
   reachable: boolean;
+  observed: boolean;
   busy: boolean;
   detail?: string;
 }

--- a/erun-ui/playwright/tests/sidebar-env-idle-clears-latch.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-env-idle-clears-latch.spec.ts
@@ -1,0 +1,141 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+
+// A row span for over six hours with nothing running (#955). Every input to its
+// busy state was desktop-local — set when the desktop starts something, cleared
+// when the desktop sees it end — so any path that loses the ending left a latch
+// with nothing able to release it. The environment's own report was already
+// fetched by the row and then discarded.
+//
+// This is that failure staged whole: a running command entry with no ending ever
+// delivered, which is precisely what a command driven from a terminal or over
+// MCP looks like from here, and then the environment answering that it is idle.
+// The unit derivation is owned by Sidebar.helpers.test.ts and the observation by
+// environment_activity_observed_test.go; what only the running app can show is
+// that the spinner an orphaned latch produces actually goes away.
+
+test.describe('an idle environment clears a stale desktop latch', () => {
+  test('an orphaned running entry stops spinning once the environment reports idle', async ({
+    app: _app,
+    page,
+    seededEnv,
+  }) => {
+    // A per-test environment, not the restored one: the harness auto-opens that
+    // one, and an open in flight is this desktop's own operation, which stays
+    // authoritative by design and would hold the row busy for an unrelated
+    // reason.
+    const { tenant, environment } = seededEnv;
+    const sidebar = page.locator('aside').first();
+    const spinner = sidebar.getByRole('status', {
+      name: `Building ${tenant} / ${environment}`,
+    });
+
+    // The latch, and no ending for it — the desktop is left believing a build
+    // it started is still running.
+    await emitRunningBuild(page, tenant, environment);
+    await expect(spinner).toBeVisible();
+
+    // An edge that has wedged behind a port that still answers reports no work
+    // because nobody asked it. That must not pass for the environment saying it
+    // is idle, or a row would stop spinning while the work is still running.
+    await emitEnvActivity(page, {
+      tenant,
+      environment,
+      reachable: true,
+      observed: false,
+      busy: false,
+    });
+    await expect(spinner).toBeVisible();
+
+    // The environment's own answer. The backend's sweep also runs against these
+    // inert envs and reports them unreachable, so re-drive until it converges
+    // rather than racing a single emit — a row that never clears still fails.
+    await expect(async () => {
+      await emitRunningBuild(page, tenant, environment);
+      await emitEnvActivity(page, {
+        tenant,
+        environment,
+        reachable: true,
+        observed: true,
+        busy: false,
+      });
+      await expect(spinner).toHaveCount(0, { timeout: 1_000 });
+    }).toPass({ timeout: 20_000 });
+  });
+
+  test('an environment that reports work still spins, whoever started it', async ({
+    app: _app,
+    page,
+    seededEnv,
+  }) => {
+    const { tenant, environment } = seededEnv;
+    const sidebar = page.locator('aside').first();
+
+    // Nothing was started from this desktop at all: the busy row here is
+    // entirely the environment's own report, which is the case the corrective
+    // must not be able to suppress.
+    await expect(async () => {
+      await emitEnvActivity(page, {
+        tenant,
+        environment,
+        reachable: true,
+        observed: true,
+        busy: true,
+        detail: 'holding: gradle-build',
+      });
+      await expect(
+        sidebar.getByRole('status', {
+          name: `${tenant} / ${environment} is busy — holding: gradle-build`,
+        }),
+      ).toBeVisible({ timeout: 1_000 });
+    }).toPass({ timeout: 20_000 });
+  });
+});
+
+async function emitRunningBuild(page: Page, tenant: string, environment: string): Promise<void> {
+  await page.evaluate(
+    ({ tenant, environment }) => {
+      const runtime = (
+        window as unknown as {
+          runtime: { EventsEmit: (name: string, ...args: unknown[]) => void };
+        }
+      ).runtime;
+      const now = new Date().toISOString();
+      runtime.EventsEmit('activity:state', {
+        id: 'stale-latch-spec-build',
+        command: 'build',
+        tenant,
+        environment,
+        status: 'running',
+        startedAt: now,
+        lastUpdated: now,
+        source: 'trace',
+        summary: `build ${tenant}/${environment}`,
+      });
+    },
+    { tenant, environment },
+  );
+}
+
+// Mirrors the env-activity event erun-ui/environment_activity.go emits per tick.
+async function emitEnvActivity(
+  page: Page,
+  payload: {
+    tenant: string;
+    environment: string;
+    reachable: boolean;
+    observed: boolean;
+    busy: boolean;
+    detail?: string;
+  },
+): Promise<void> {
+  await page.evaluate((event) => {
+    const runtime = (
+      window as unknown as {
+        runtime: { EventsEmit: (name: string, ...args: unknown[]) => void };
+      }
+    ).runtime;
+    runtime.EventsEmit('env-activity', event);
+  }, payload);
+}

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -73,8 +73,12 @@ type envActivityPayload struct {
 	Tenant      string `json:"tenant"`
 	Environment string `json:"environment"`
 	Reachable   bool   `json:"reachable"`
-	Busy        bool   `json:"busy"`
-	Detail      string `json:"detail,omitempty"`
+	// Observed separates "the environment answered, and said no work" from
+	// "nobody got an answer": busy is false in both, and the sidebar acts on
+	// the difference when deciding whether a row may stop spinning.
+	Observed bool   `json:"observed"`
+	Busy     bool   `json:"busy"`
+	Detail   string `json:"detail,omitempty"`
 }
 
 // uiEnvironmentStopResult is what the Runtime tab's Stop control reports back.


### PR DESCRIPTION
Closes #955.

## What was wrong

Every input to an environment row's busy state was desktop-local: set when this desktop starts something, cleared when this desktop sees it end. Any path that set one and then lost the ending — a command driven from a terminal or over MCP, a session that went away — left a latch with nothing able to release it. `frs/prod` span for over six hours while `erun idle` reported every marker idle, no leases held, and every pod `Running`.

The environment's own report was already selected by the row, already documented as authoritative regardless of who opened the environment, and already self-clearing in the slice. It reached `environmentRowIsBusy` only as an OR term, so it could add busy and never subtract it.

## What changed

The report is now a corrective as well as an addition. Precedence, in order:

1. The environment reports work → busy, whoever started it.
2. This desktop is opening or reconnecting → busy. These began a moment ago in response to a click, and the environment cannot yet have observed what has not reached it.
3. The environment answered and reports no work → **not** busy, whatever set the latch.
4. Otherwise the desktop-local latches stand, exactly as before.

### The part that is not obvious

Step 3 cannot key on reachability. `observeEnvironmentActivity` deliberately returns "reachable, no verdict" when the port answers but the edge does not — its comment says so — but `envActivityPayload` had no way to express that, so it shipped `{reachable: true, busy: false}`: byte-identical to *the environment reporting no work*. Harmless while `busy` could only add. Not harmless once `busy: false` clears a latch, because a wedged edge would then stop a row spinning while its work was still running.

So the observation now carries the verdict itself (`observed`), and only an environment that actually answered may clear anything. Silence — unreachable, or a wedged edge behind a live port — leaves the latch alone.

## Pre-existing red fixed here

`sidebar-env-activity.spec.ts › a busy env renders busy and says what is holding it` was already failing on `main` (verified at 62454512, before this branch). When `envBusy` was wired into the row, `busyLabel` started producing the row's *accessible name* — `<tenant> / <env> is busy — X` — for an env-reported busy, and that shadowed the hover card's own prose, so a card already headed with the environment name repeated it back inside its Activity row.

The row now reports which kind of label it produced (`busyFromEnvironment`), and the card falls through to the indicator prose it already owns. Per root `AGENTS.md` § "Fixing pre-existing issues is mandatory", fixed here rather than deferred.

## UX gate note (`erun-ui/AGENTS.md` § Professional UX)

- **User decision the UI must support:** "is this environment actually doing something, or has the indicator stopped telling me the truth?" — the decision behind whether to wait, to intervene, or to stop the environment.
- **States that must stay distinguishable:** busy because the environment says so (with what is holding it); busy because this desktop is mid-operation; not busy; and *unknown*, which must not be rendered as either.
- **Control:** no new control. The existing row spinner and its accessible name; the change is which source is allowed to decide.
- **Nielsen #1, visibility of system status:** an indicator that cannot go back to idle stops carrying information. #955 puts it plainly — this teaches an operator to stop believing the indicator, which is worse than having none.
- **Nielsen #2, match with the real world:** "the environment says it is idle" is the operator's own mental model of ground truth; the desktop's private latch is not.
- **WCAG 4.1.2 (name, role, value):** the spinner keeps `role="status"` and an accessible name that still identifies its environment. The hover-card fix removes a *duplicated* name from a labelled surface without removing it from the row, where a screen reader has no other context.
- **Checked against the rendered surface:** the full Playwright suite (145 passed), including the row's accessible names in `sidebar-busy-spinner`, `sidebar-env-activity` and `sidebar-open-dot`.

## Verification

- `erun-ui` Go: `go test ./...` green; `golangci-lint run` — 0 issues; `go vet` clean.
- Frontend: 27 unit tests pass; `yarn lint`, `yarn build`, `yarn shadcn:check` clean.
- **Playwright full suite: 145 passed, 0 failed** (`run.sh --build`, exit 0 captured directly off the script).
- `make integration-test`: exit 0, no failing scenario, coverage 75.9% ≥ 75.5% (unchanged — the gate scopes to `erun-cli` + `erun-common`, which this branch does not touch).

### Non-vacuity

- Reverting `environmentRowIsBusy` to the shipped rule reproduces #955 exactly: `an environment that reports itself idle clears a stale desktop latch` fails with `actual: true` — the row spinning while the environment reports idle.
- Dropping `observation.state.observed = true` fails `TestObserveEnvironmentActivityIdleEnvironmentAnswers`.
- The e2e spec discriminates both failure directions: its middle assertion fails if a row cleared on a merely-reachable port, its last fails if the row ignored the report.

### Verified against a running app, not only suites

`sidebar-env-idle-clears-latch.spec.ts` stages the reported failure whole against the real desktop binary: a running command entry whose ending never arrives — which is exactly what a CLI- or MCP-driven command looks like from the desktop — then a no-verdict observation (spinner must stay), then the environment answering idle (spinner must go).

## Known residual

An environment that becomes *unobservable* while holding a desktop latch keeps it, by design — silence must not clear. #955's second fix-direction bullet (bounding the latches themselves) is therefore only partly addressed here: `aiBusy` is already bounded by `releaseUnobservedAIActivity`'s TTL, but a `runningCommand` entry stuck `running` on an environment nobody can reach still has no expiry. The reported case (reachable, reporting idle) is fixed; that narrower one is not.
