### PR TITLE
Reopen the orchestrator that was open on the next launch

### DIFF
--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -88,6 +88,7 @@ type erunUIDeps struct {
 	cloneERun                 func(context.Context, string, string) error
 	contributeStatePath       string
 	orchestratorRestorePath   string
+	orchestratorOpenPath      string
 	relaunchApp               func() error
 	quitApp                   func()
 }
@@ -424,6 +425,9 @@ func withDefaultWindowAndContributeDeps(deps erunUIDeps) erunUIDeps {
 	}
 	if deps.orchestratorRestorePath == "" {
 		deps.orchestratorRestorePath = defaultOrchestratorRestorePath()
+	}
+	if deps.orchestratorOpenPath == "" {
+		deps.orchestratorOpenPath = defaultOrchestratorOpenPath()
 	}
 	return deps
 }

--- a/erun-ui/app_restart.go
+++ b/erun-ui/app_restart.go
@@ -15,9 +15,12 @@ import (
 
 const orchestratorRestoreFileName = "orchestrator-restore.json"
 
-// orchestratorRestoreMaxAge bounds how long a persisted restore target stays
-// valid, so a deliberate restart restores the orchestrator while a plain launch
-// long afterwards never resurrects a stale one.
+// orchestratorRestoreMaxAge bounds how long the restart hand-off stays valid.
+// It is deliberately short because what the hand-off carries is a task to run
+// unattended: a rebuild+restart should continue its work, but a prompt fired at
+// a launch hours later would run against a world the operator has moved on
+// from. Which orchestrator to reopen is durable session state and is NOT bound
+// this way — see orchestrator_open_state.go for why the two are separate.
 const orchestratorRestoreMaxAge = 10 * time.Minute
 
 type orchestratorRestoreState struct {
@@ -90,15 +93,22 @@ func consumeOrchestratorRestoreTarget(path string, now time.Time) relaunchTarget
 	return relaunchTarget{OrchestratorID: id, ResumePrompt: strings.TrimSpace(state.ResumePrompt)}
 }
 
-// ConsumeRelaunchTarget returns the orchestrator a restart asked to reopen (and
-// any prompt to auto-run on resume), clearing it so it fires once. The frontend
-// calls this on boot (after loading the orchestrator list) and, if the id still
-// resolves to a persisted orchestrator, re-starts it — spawnOrchestratorSession
-// resumes that orchestrator's own pinned conversation, so the operator lands back
-// where they were. When ResumePrompt is set, the resumed session runs it
-// immediately so a rebuild+restart continues its task itself.
-func (a *App) ConsumeRelaunchTarget() relaunchTarget {
-	return consumeOrchestratorRestoreTarget(a.deps.orchestratorRestorePath, time.Now())
+// ResolveOrchestratorToReopen returns the orchestrator this launch should reopen
+// and any prompt to auto-run on resume. The frontend calls it on boot (after
+// loading the orchestrator list) and, if the id still resolves to a persisted
+// orchestrator, starts it — spawnOrchestratorSession resumes that orchestrator's
+// own pinned conversation, so the operator lands back where they were.
+//
+// A pending restart hand-off wins: it is the more specific intent and the only
+// source of a resume prompt, and it is consumed as it is read so it fires once.
+// Otherwise the durable record of what was open answers, carrying no prompt — so
+// a plain quit-and-relaunch, a crash or a reboot comes back to the same
+// orchestrator, idle at its prompt with nothing auto-run.
+func (a *App) ResolveOrchestratorToReopen() relaunchTarget {
+	if target := consumeOrchestratorRestoreTarget(a.deps.orchestratorRestorePath, time.Now()); target.OrchestratorID != "" {
+		return target
+	}
+	return relaunchTarget{OrchestratorID: readOpenOrchestrator(a.deps.orchestratorOpenPath)}
 }
 
 // RestartApp persists the orchestrator to return to, launches a fresh desktop

--- a/erun-ui/app_restart_test.go
+++ b/erun-ui/app_restart_test.go
@@ -17,6 +17,7 @@ func TestRestartAppPersistsTargetRelaunchesAndQuits(t *testing.T) {
 	app := NewApp(erunUIDeps{
 		store:                   newOrchestratorStubStore(t.TempDir()),
 		orchestratorRestorePath: restorePath,
+		orchestratorOpenPath:    filepath.Join(home, "orchestrator-open.json"),
 		relaunchApp:             func() error { relaunched = true; return nil },
 		quitApp:                 func() { quit = true },
 	})
@@ -28,12 +29,13 @@ func TestRestartAppPersistsTargetRelaunchesAndQuits(t *testing.T) {
 	if !relaunched || !quit {
 		t.Fatalf("expected relaunch and quit to fire, got relaunched=%v quit=%v", relaunched, quit)
 	}
-	// The target is restored once, then cleared — the restore is one-shot.
-	if got := app.ConsumeRelaunchTarget(); got.OrchestratorID != "agent-1" {
+	// The hand-off is honored once, then cleared. Nothing was open here, so with
+	// it gone there is no durable record to fall back to either.
+	if got := app.ResolveOrchestratorToReopen(); got.OrchestratorID != "agent-1" {
 		t.Fatalf("expected restore target agent-1, got %q", got.OrchestratorID)
 	}
-	if got := app.ConsumeRelaunchTarget(); got.OrchestratorID != "" {
-		t.Fatalf("expected the restore target to be consumed exactly once, got %q", got.OrchestratorID)
+	if got := app.ResolveOrchestratorToReopen(); got.OrchestratorID != "" {
+		t.Fatalf("expected the restart hand-off to be consumed exactly once, got %q", got.OrchestratorID)
 	}
 }
 

--- a/erun-ui/frontend/src/app/bootThunks.ts
+++ b/erun-ui/frontend/src/app/bootThunks.ts
@@ -1,7 +1,7 @@
 import { stateApi } from './api/stateApi';
 import { readError } from './errors';
 import { showTerminalMessage } from './notificationThunks';
-import { loadOrchestrators, restoreOrchestratorAfterRestart } from './orchestratorThunks';
+import { loadOrchestrators, restoreOpenOrchestrator } from './orchestratorThunks';
 import { openSelection } from './sessionThunks';
 import { setSelected } from './slices/selectionSlice';
 import {
@@ -38,11 +38,12 @@ export const boot = (): AppThunk<Promise<void>> => async (dispatch, getState) =>
       return;
     }
 
-    // A rebuild+restart asks the desktop to reopen a specific orchestrator and
-    // resume its conversation. When that target is pending it owns the pane, so
-    // honor it before — and instead of — the default environment selection.
+    // The orchestrator that was open when the desktop last ran — or the one a
+    // rebuild+restart handed off — is where the operator left off, and it owns
+    // the pane, so honor it before — and instead of — the default environment
+    // selection.
     await dispatch(loadOrchestrators());
-    if (await dispatch(restoreOrchestratorAfterRestart())) {
+    if (await dispatch(restoreOpenOrchestrator())) {
       return;
     }
 

--- a/erun-ui/frontend/src/app/orchestratorRestore.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorRestore.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { planOrchestratorRestore } from './orchestratorRestore';
+import type { OrchestratorInfo } from './slices/orchestratorsSlice';
+
+function orchestrator(id: string, transient = false): OrchestratorInfo {
+  return {
+    id,
+    name: id,
+    environments: [],
+    tenants: [],
+    directories: [],
+    sessionId: 0,
+    status: 'stopped',
+    transient,
+  };
+}
+
+const persisted = [orchestrator('agent-1')];
+
+// The defect: a plain quit-and-relaunch had no target at all, so boot fell
+// through to the default environment selection. The durable record now answers,
+// and it answers without a prompt — the launch resumes idle.
+test('a plain launch reopens the orchestrator that was open, running nothing', () => {
+  const plan = planOrchestratorRestore({ orchestratorId: 'agent-1', resumePrompt: '' }, persisted);
+  assert.deepEqual(plan, { id: 'agent-1', resumePrompt: '' });
+});
+
+test('a restart hand-off carries the prompt the resumed session auto-runs', () => {
+  const plan = planOrchestratorRestore(
+    { orchestratorId: 'agent-1', resumePrompt: 'finish the task' },
+    persisted,
+  );
+  assert.deepEqual(plan, { id: 'agent-1', resumePrompt: 'finish the task' });
+});
+
+test('nothing to reopen leaves boot on the default environment selection', () => {
+  assert.equal(planOrchestratorRestore({ orchestratorId: '' }, persisted), null);
+  assert.equal(planOrchestratorRestore(null, persisted), null);
+  assert.equal(planOrchestratorRestore(undefined, persisted), null);
+  assert.equal(planOrchestratorRestore({ orchestratorId: '   ' }, persisted), null);
+});
+
+// An orchestrator deleted since the record was written has no definition to
+// resume, so the launch must not try to start it.
+test('a target that no longer exists restores nothing', () => {
+  assert.equal(planOrchestratorRestore({ orchestratorId: 'agent-gone' }, persisted), null);
+});
+
+// Investigate sessions are not persisted, so they are never reopened.
+test('a transient orchestrator is never restored', () => {
+  assert.equal(
+    planOrchestratorRestore({ orchestratorId: 'investigate-1' }, [
+      orchestrator('investigate-1', true),
+    ]),
+    null,
+  );
+});
+
+// A prompt that is only whitespace is no prompt: it must not push the launch
+// down the auto-run branch.
+test('a whitespace-only resume prompt resumes idle', () => {
+  const plan = planOrchestratorRestore(
+    { orchestratorId: 'agent-1', resumePrompt: '  \n ' },
+    persisted,
+  );
+  assert.deepEqual(plan, { id: 'agent-1', resumePrompt: '' });
+});

--- a/erun-ui/frontend/src/app/orchestratorRestore.ts
+++ b/erun-ui/frontend/src/app/orchestratorRestore.ts
@@ -1,0 +1,35 @@
+import type { OrchestratorInfo } from './slices/orchestratorsSlice';
+
+// What the backend answers when boot asks which orchestrator to reopen: the one
+// that was open when the desktop last ran, or the one a restart handed off —
+// only the hand-off carries a prompt to auto-run.
+export interface OrchestratorReopenTarget {
+  orchestratorId?: string;
+  resumePrompt?: string;
+}
+
+// How boot should reopen an orchestrator: which one, and whether the session is
+// handed a task on resume.
+export interface OrchestratorRestorePlan {
+  id: string;
+  resumePrompt: string;
+}
+
+// planOrchestratorRestore decides what a launch actually restores, given the
+// target and the definitions that exist right now. A target naming an
+// orchestrator that has since been deleted restores nothing, and neither does a
+// transient (Investigate) session, which has no definition to resume — in both
+// cases boot falls through to the default environment selection instead.
+export function planOrchestratorRestore(
+  target: OrchestratorReopenTarget | null | undefined,
+  orchestrators: readonly OrchestratorInfo[],
+): OrchestratorRestorePlan | null {
+  const id = target?.orchestratorId?.trim() ?? '';
+  if (!id) {
+    return null;
+  }
+  if (!orchestrators.some((orchestrator) => orchestrator.id === id && !orchestrator.transient)) {
+    return null;
+  }
+  return { id, resumePrompt: target?.resumePrompt?.trim() ?? '' };
+}

--- a/erun-ui/frontend/src/app/orchestratorThunks.ts
+++ b/erun-ui/frontend/src/app/orchestratorThunks.ts
@@ -1,9 +1,9 @@
 import {
-  ConsumeRelaunchTarget,
   CreateOrchestrator,
   DeleteOrchestrator,
   InvestigateFailure,
   ListOrchestrators,
+  ResolveOrchestratorToReopen,
   RestartApp,
   RestartOrchestrator,
   StartOrchestrator,
@@ -12,6 +12,7 @@ import {
   UpdateOrchestrator,
 } from '../../wailsjs/go/main/App';
 import { readError } from './errors';
+import { planOrchestratorRestore } from './orchestratorRestore';
 import {
   closeOrchestratorDialog,
   type OrchestratorEnvRef,
@@ -116,32 +117,31 @@ export const restartApp =
     }
   };
 
-// restoreOrchestratorAfterRestart reopens the orchestrator a restart asked to
-// return to, if it still exists as a persisted definition, and returns whether
-// it did so the caller (boot) can skip the default environment selection.
-// One-shot: the backend clears the target on read, so a plain launch never
-// auto-starts anything. The restored orchestrator OWNS the pane, so the env
-// selection is cleared — otherwise boot's default selection and the
-// selection-sync middleware reconcile the terminal back to an environment and
-// the operator never lands in the resumed session.
-export const restoreOrchestratorAfterRestart =
+// restoreOpenOrchestrator reopens the orchestrator this launch should come back
+// to — the one that was open when the desktop last ran, or the one a restart
+// handed off — and returns whether it did, so the caller (boot) can skip the
+// default environment selection. Only a restart hand-off carries a resume
+// prompt, so a plain launch resumes the conversation idle and auto-runs nothing.
+// The restored orchestrator OWNS the pane, so the env selection is cleared —
+// otherwise boot's default selection and the selection-sync middleware reconcile
+// the terminal back to an environment and the operator never lands in the
+// resumed session.
+export const restoreOpenOrchestrator =
   (): AppThunk<Promise<boolean>> => async (dispatch, getState) => {
     try {
-      const relaunch = await ConsumeRelaunchTarget();
-      const id = relaunch.orchestratorId;
-      if (!id) {
-        return false;
-      }
-      const target = getState().orchestrators.items.find((o) => o.id === id && !o.transient);
-      if (!target) {
+      const plan = planOrchestratorRestore(
+        await ResolveOrchestratorToReopen(),
+        getState().orchestrators.items,
+      );
+      if (!plan) {
         return false;
       }
       // With a resume prompt, resume the conversation AND hand it the task so a
       // rebuild+restart continues on its own instead of idling at the prompt;
-      // without one, just resume via --continue.
-      const info = relaunch.resumePrompt
-        ? await StartOrchestratorWithResume(id, relaunch.resumePrompt, 80, 24)
-        : await StartOrchestrator(id, 80, 24);
+      // without one, just resume the orchestrator's own pinned conversation.
+      const info = plan.resumePrompt
+        ? await StartOrchestratorWithResume(plan.id, plan.resumePrompt, 80, 24)
+        : await StartOrchestrator(plan.id, 80, 24);
       dispatch(setSelected(null));
       dispatch(setSessionId(info.sessionId));
       await dispatch(loadOrchestrators());

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -1102,6 +1102,15 @@ func (a *App) spawnOrchestratorSession(id, name string, envs []eruncommon.Orches
 	a.mu.Unlock()
 
 	go a.streamSession(managed)
+	// Record what is open now rather than on the way out: the desktop is just as
+	// likely to be killed or to crash as to be quit cleanly, and only a record
+	// written here survives that. A transient (Investigate) session has no
+	// persisted definition to reopen, so it is deliberately not recorded.
+	if !transient {
+		if err := recordOpenOrchestrator(a.deps.orchestratorOpenPath, id); err != nil {
+			log.Printf("erun-app: record open orchestrator %s: %v", id, err)
+		}
+	}
 	return orchestratorInfoFor(id, name, envs, "running", serial, transient), nil
 }
 
@@ -1169,6 +1178,12 @@ func (a *App) stopOrchestratorSession(id string) bool {
 	a.mu.Unlock()
 	if managed != nil {
 		_ = managed.Close()
+	}
+	// Stopping is the operator saying this orchestrator should not come back, so
+	// it stays closed on every later launch. A restart clears and re-records in
+	// the same breath, which is the same statement about what is open.
+	if err := clearOpenOrchestrator(a.deps.orchestratorOpenPath, id); err != nil {
+		log.Printf("erun-app: clear open orchestrator %s: %v", id, err)
 	}
 	return session != nil || managed != nil
 }

--- a/erun-ui/orchestrator_open_state.go
+++ b/erun-ui/orchestrator_open_state.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// The desktop keeps two separate records of which orchestrator a launch should
+// reopen, because they answer different questions and must not share a lifetime.
+//
+// This file owns the DURABLE one: which orchestrator is open. It is written the
+// moment a session starts and cleared the moment the operator stops it — never
+// at shutdown, because a crash, a `pkill` or a reboot takes the desktop away
+// without running any hook, and a record only a clean quit could write would be
+// missing exactly when it is most needed. It carries no timestamp either: an
+// orchestrator the operator left open is still the one they were in, however
+// long ago that was.
+//
+// app_restart.go owns the OTHER one: the one-shot hand-off an in-app restart
+// writes, which carries the prompt the resumed session should auto-run. That one
+// stays one-shot and age-bounded, so a rebuild+restart continues its task while
+// a plain launch resumes the conversation idle at the prompt.
+
+const orchestratorOpenFileName = "orchestrator-open.json"
+
+type orchestratorOpenState struct {
+	OrchestratorID string `json:"orchestratorId"`
+}
+
+// defaultOrchestratorOpenPath is a sibling of window-state.json under
+// UserConfigDir()/ERun: desktop session state the app restores itself with.
+func defaultOrchestratorOpenPath() string {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(configDir, "ERun", orchestratorOpenFileName)
+}
+
+func recordOpenOrchestrator(path, orchestratorID string) error {
+	orchestratorID = strings.TrimSpace(orchestratorID)
+	if path == "" || orchestratorID == "" {
+		return nil
+	}
+	data, err := json.Marshal(orchestratorOpenState{OrchestratorID: orchestratorID})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
+}
+
+// clearOpenOrchestrator forgets the open orchestrator when the operator stops
+// the one that is recorded, which is what keeps an explicitly stopped
+// orchestrator closed on every later launch. Stopping some other orchestrator
+// leaves the record alone: it still names the one that owns the pane.
+func clearOpenOrchestrator(path, orchestratorID string) error {
+	if path == "" || readOpenOrchestrator(path) != strings.TrimSpace(orchestratorID) {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// readOpenOrchestrator returns the orchestrator that was open when the desktop
+// last ran, or "" when none was. Reading does not clear it: the record is
+// durable, so every launch reopens the same orchestrator until it is stopped.
+func readOpenOrchestrator(path string) string {
+	if path == "" {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var state orchestratorOpenState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(state.OrchestratorID)
+}

--- a/erun-ui/orchestrator_open_state_test.go
+++ b/erun-ui/orchestrator_open_state_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// openStateTestApp is orchestratorTestApp with both restore records pinned to a
+// temp dir, so a test can assert on each half of the split independently.
+func openStateTestApp(t *testing.T) (*App, string, string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOME", home)
+	state := t.TempDir()
+	openPath := filepath.Join(state, orchestratorOpenFileName)
+	restorePath := filepath.Join(state, orchestratorRestoreFileName)
+	app := NewApp(erunUIDeps{
+		store: newOrchestratorStubStore(t.TempDir()),
+		startTerminal: func(startTerminalSessionParams) (terminalSession, error) {
+			return newStubTerminalSession(), nil
+		},
+		resolveOrchestratorLaunch: func(string, string, string, string) (string, []string, error) {
+			return "claude-stub", nil, nil
+		},
+		orchestratorOpenPath:    openPath,
+		orchestratorRestorePath: restorePath,
+	})
+	return app, openPath, restorePath
+}
+
+func createAndStartOrchestrator(t *testing.T, app *App) string {
+	t.Helper()
+	created, err := app.CreateOrchestrator("agent", []orchestratorEnvInput{{Tenant: "frs", Environment: "dev"}})
+	if err != nil {
+		t.Fatalf("CreateOrchestrator failed: %v", err)
+	}
+	if _, err := app.StartOrchestrator(created.ID, 80, 24); err != nil {
+		t.Fatalf("StartOrchestrator failed: %v", err)
+	}
+	return created.ID
+}
+
+// The defect this fixes: a plain quit-and-relaunch (no restart hand-off, so no
+// restore file at all) came back with nothing open. Starting an orchestrator is
+// what records it, so the next launch has something to reopen — and it reopens
+// with no prompt, so the conversation resumes idle rather than re-running a task.
+func TestPlainLaunchReopensTheOrchestratorThatWasOpen(t *testing.T) {
+	app, openPath, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	id := createAndStartOrchestrator(t, app)
+
+	target := app.ResolveOrchestratorToReopen()
+	if target.OrchestratorID != id {
+		t.Fatalf("expected a plain launch to reopen %q, got %q", id, target.OrchestratorID)
+	}
+	if target.ResumePrompt != "" {
+		t.Fatalf("expected no prompt to auto-run on a plain launch, got %q", target.ResumePrompt)
+	}
+	// Durable, not one-shot: every later launch reopens it too, and it survives a
+	// desktop that never got to run a shutdown hook.
+	if again := app.ResolveOrchestratorToReopen(); again.OrchestratorID != id {
+		t.Fatalf("expected the record to survive being read, got %q", again.OrchestratorID)
+	}
+	if got := readOpenOrchestrator(openPath); got != id {
+		t.Fatalf("expected %q on disk, got %q", id, got)
+	}
+}
+
+// Stopping is the operator saying the orchestrator should not come back.
+func TestExplicitlyStoppedOrchestratorStaysClosed(t *testing.T) {
+	app, _, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	id := createAndStartOrchestrator(t, app)
+	if err := app.StopOrchestrator(id); err != nil {
+		t.Fatalf("StopOrchestrator failed: %v", err)
+	}
+
+	if target := app.ResolveOrchestratorToReopen(); target.OrchestratorID != "" {
+		t.Fatalf("expected a stopped orchestrator to stay closed, got %q", target.OrchestratorID)
+	}
+}
+
+// Deleting the definition takes the record with it, so a launch never tries to
+// reopen an orchestrator that no longer exists.
+func TestDeletedOrchestratorIsNotReopened(t *testing.T) {
+	app, _, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	id := createAndStartOrchestrator(t, app)
+	if err := app.DeleteOrchestrator(id); err != nil {
+		t.Fatalf("DeleteOrchestrator failed: %v", err)
+	}
+
+	if target := app.ResolveOrchestratorToReopen(); target.OrchestratorID != "" {
+		t.Fatalf("expected a deleted orchestrator not to be reopened, got %q", target.OrchestratorID)
+	}
+}
+
+// A restart re-records what it just respawned, so recycling a stuck agent does
+// not read as the operator closing it.
+func TestRestartKeepsTheOrchestratorRecordedAsOpen(t *testing.T) {
+	app, _, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	id := createAndStartOrchestrator(t, app)
+	if _, err := app.RestartOrchestrator(id, 80, 24); err != nil {
+		t.Fatalf("RestartOrchestrator failed: %v", err)
+	}
+
+	if target := app.ResolveOrchestratorToReopen(); target.OrchestratorID != id {
+		t.Fatalf("expected %q to still be recorded as open after a restart, got %q", id, target.OrchestratorID)
+	}
+}
+
+// Stopping one orchestrator must not close the one that owns the pane.
+func TestStoppingAnotherOrchestratorLeavesTheOpenOneRecorded(t *testing.T) {
+	app, _, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	id := createAndStartOrchestrator(t, app)
+	if err := app.StopOrchestrator("some-other-orchestrator"); err == nil {
+		t.Fatal("expected stopping an unknown orchestrator to error")
+	}
+
+	if target := app.ResolveOrchestratorToReopen(); target.OrchestratorID != id {
+		t.Fatalf("expected %q to stay recorded as open, got %q", id, target.OrchestratorID)
+	}
+}
+
+// The Investigate flow spawns a session with no persisted definition, so there is
+// nothing for a later launch to reopen.
+func TestTransientOrchestratorIsNotRecordedAsOpen(t *testing.T) {
+	app, _, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	if _, err := app.InvestigateFailure("deploy blew up", "frs", "dev", 80, 24); err != nil {
+		t.Fatalf("InvestigateFailure failed: %v", err)
+	}
+
+	if target := app.ResolveOrchestratorToReopen(); target.OrchestratorID != "" {
+		t.Fatalf("expected a transient orchestrator not to be recorded, got %q", target.OrchestratorID)
+	}
+}
+
+// The restart hand-off keeps its own semantics on top of the durable record: it
+// wins while it is fresh, carries the prompt that makes a rebuild+restart
+// continue its task, fires exactly once, and expires — after which the durable
+// record still reopens the orchestrator, just idle at its prompt.
+func TestRestartHandOffStaysOneShotAndAgeBoundedOverTheDurableRecord(t *testing.T) {
+	app, openPath, restorePath := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	const prompt = "verify the rebuild is live, then finish the task"
+	if err := recordOpenOrchestrator(openPath, "agent-1"); err != nil {
+		t.Fatalf("record open orchestrator: %v", err)
+	}
+	if err := writeOrchestratorRestoreTarget(restorePath, "agent-1", prompt, time.Now()); err != nil {
+		t.Fatalf("write restart hand-off: %v", err)
+	}
+
+	first := app.ResolveOrchestratorToReopen()
+	if first.OrchestratorID != "agent-1" || first.ResumePrompt != prompt {
+		t.Fatalf("expected the restart hand-off to win with its prompt, got %+v", first)
+	}
+	// One-shot: the next launch falls back to the durable record, which runs nothing.
+	second := app.ResolveOrchestratorToReopen()
+	if second.OrchestratorID != "agent-1" || second.ResumePrompt != "" {
+		t.Fatalf("expected the hand-off to fire once and the durable record to answer idle, got %+v", second)
+	}
+
+	// Age-bounded: a hand-off older than the bound is discarded, and the durable
+	// record still reopens the orchestrator without auto-running the prompt.
+	if err := writeOrchestratorRestoreTarget(restorePath, "agent-1", prompt, time.Now().Add(-2*orchestratorRestoreMaxAge)); err != nil {
+		t.Fatalf("write stale restart hand-off: %v", err)
+	}
+	stale := app.ResolveOrchestratorToReopen()
+	if stale.OrchestratorID != "agent-1" || stale.ResumePrompt != "" {
+		t.Fatalf("expected a stale hand-off to be dropped and the durable record to answer, got %+v", stale)
+	}
+}

--- a/erun-ui/playwright/pages/AppShell.ts
+++ b/erun-ui/playwright/pages/AppShell.ts
@@ -10,6 +10,7 @@ import { OutputsDialog } from './OutputsDialog';
 import { ReviewPanel } from './ReviewPanel';
 import { Sidebar } from './Sidebar';
 import { TenantDialog } from './TenantDialog';
+import { TerminalTabStrip } from './TerminalTabStrip';
 import { Titlebar } from './Titlebar';
 
 // AppShell is the tests' entry point into the rendered app.
@@ -36,6 +37,17 @@ export class AppShell {
       )
       .first()
       .waitFor({ state: 'visible' });
+  }
+
+  // reboot re-runs the boot sequence and hands control back as soon as the app
+  // chrome is up, for callers that assert on a specific surface boot produces
+  // (which session ends up owning the terminal pane). Waiting on that surface is
+  // both stricter and faster than open()'s generic settle, whose overlay wait
+  // clears only once the pane's session streams its first output.
+  async reboot(): Promise<void> {
+    await this.page.goto('/');
+    await this.page.waitForLoadState('domcontentloaded');
+    await this.titlebar.toggleButton().waitFor({ state: 'visible' });
   }
 
   // reloadEnvironments surfaces a freshly-seeded env deterministically instead
@@ -95,5 +107,9 @@ export class AppShell {
 
   get outputsDialog(): OutputsDialog {
     return new OutputsDialog(this.page);
+  }
+
+  get tabStrip(): TerminalTabStrip {
+    return new TerminalTabStrip(this.page);
   }
 }

--- a/erun-ui/playwright/pages/TerminalTabStrip.ts
+++ b/erun-ui/playwright/pages/TerminalTabStrip.ts
@@ -1,0 +1,21 @@
+import type { Locator, Page } from '@playwright/test';
+
+// TerminalTabStrip is the strip above the terminal pane. Which of its two modes
+// is mounted is the rendered answer to "what owns the pane": an orchestrator
+// session (cross-env, so the strip lists orchestrators) or the selected
+// environment's terminals.
+export class TerminalTabStrip {
+  constructor(private readonly page: Page) {}
+
+  orchestratorMode(): Locator {
+    return this.page.getByRole('tablist', { name: 'Orchestrators' });
+  }
+
+  environmentMode(): Locator {
+    return this.page.getByRole('tablist', { name: 'Open terminals' });
+  }
+
+  tab(label: string): Locator {
+    return this.page.getByRole('tab', { name: label, exact: true });
+  }
+}

--- a/erun-ui/playwright/pages/index.ts
+++ b/erun-ui/playwright/pages/index.ts
@@ -11,3 +11,4 @@ export { ActivityQueueDrawer } from './ActivityQueueDrawer';
 export { AutoStartPromptDialog } from './AutoStartPromptDialog';
 export { OrchestratorDialog } from './OrchestratorDialog';
 export { OutputsDialog } from './OutputsDialog';
+export { TerminalTabStrip } from './TerminalTabStrip';

--- a/erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts
+++ b/erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts
@@ -1,0 +1,116 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ORCHESTRATOR } from '../fixtures/seedRoot.js';
+
+// The desktop reopens the orchestrator that was open when it last ran. The Go
+// side owns the durable record of what that orchestrator is
+// (erun-ui/orchestrator_open_state_test.go covers a plain launch, an explicitly
+// stopped orchestrator, and the one-shot restart hand-off); what only the
+// rendered app can show is what boot does with the answer — whether the
+// orchestrator ends up owning the terminal pane instead of the default
+// environment selection, and which start call the launch makes. The backend
+// answer is stubbed over /__erun_invoke so the boot decision is exercised
+// without a real Claude process, which the inert harness deliberately lacks.
+
+const RESTORED_SESSION_ID = 4242;
+
+const runningOrchestrator = {
+  id: SEED_ORCHESTRATOR,
+  name: SEED_ORCHESTRATOR,
+  environments: [],
+  tenants: [],
+  directories: [],
+  sessionId: RESTORED_SESSION_ID,
+  status: 'running',
+  transient: false,
+};
+
+// stubReopen answers the boot restore round-trip and records every method the
+// frontend invoked, so a spec can assert which start call the launch made — and
+// that it made none at all when there is nothing to reopen.
+async function stubReopen(
+  page: Page,
+  target: { orchestratorId: string; resumePrompt: string },
+  calls: string[],
+): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+    calls.push(body.method);
+    if (body.method === 'ResolveOrchestratorToReopen') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: target }),
+      });
+    }
+    if (target.orchestratorId === '') {
+      return route.continue();
+    }
+    // Once a restore is expected, the orchestrator has to read as running for
+    // the pane to be its own — the strip keys off the live session id.
+    if (
+      body.method === 'ListOrchestrators' ||
+      body.method === 'StartOrchestrator' ||
+      body.method === 'StartOrchestratorWithResume'
+    ) {
+      const data =
+        body.method === 'ListOrchestrators' ? [runningOrchestrator] : runningOrchestrator;
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data }),
+      });
+    }
+    await route.continue();
+  });
+}
+
+test.describe('reopening the orchestrator that was open', () => {
+  test('a plain launch lands in the orchestrator, running no prompt', async ({ app, page }) => {
+    const calls: string[] = [];
+    await stubReopen(page, { orchestratorId: SEED_ORCHESTRATOR, resumePrompt: '' }, calls);
+    await app.reboot();
+
+    // The restored orchestrator owns the pane: the strip is in orchestrator
+    // mode with its tab selected, rather than the selected environment's
+    // terminals. Before the fix this only ever happened after the in-app
+    // Restart button; a plain launch fell through to the default environment.
+    await expect(app.tabStrip.orchestratorMode()).toBeVisible();
+    await expect(app.tabStrip.tab(SEED_ORCHESTRATOR)).toHaveAttribute('aria-selected', 'true');
+    await expect(app.tabStrip.environmentMode()).toBeHidden();
+    await expect(app.sidebar.orchestratorStatusDot(SEED_ORCHESTRATOR, 'running')).toBeVisible();
+
+    // Idle at the prompt: a plain launch resumes the conversation and hands it
+    // no task. The prompt-carrying call belongs to the restart hand-off alone.
+    expect(calls).toContain('StartOrchestrator');
+    expect(calls).not.toContain('StartOrchestratorWithResume');
+  });
+
+  test('a restart hand-off resumes with its prompt', async ({ app, page }) => {
+    const calls: string[] = [];
+    await stubReopen(
+      page,
+      { orchestratorId: SEED_ORCHESTRATOR, resumePrompt: 'finish the task' },
+      calls,
+    );
+    await app.reboot();
+
+    await expect(app.tabStrip.orchestratorMode()).toBeVisible();
+    expect(calls).toContain('StartOrchestratorWithResume');
+    expect(calls).not.toContain('StartOrchestrator');
+  });
+
+  test('with nothing to reopen the launch starts no orchestrator', async ({ app, page }) => {
+    const calls: string[] = [];
+    await stubReopen(page, { orchestratorId: '', resumePrompt: '' }, calls);
+    // app.open() returns only once boot has settled (the loading overlay is
+    // gone and the sidebar has rendered), so the negative assertions below are
+    // bounded by a real event rather than a guessed delay.
+    await app.open();
+
+    await expect(app.sidebar.orchestratorStatusDot(SEED_ORCHESTRATOR, 'stopped')).toBeVisible();
+    await expect(app.tabStrip.orchestratorMode()).toBeHidden();
+    expect(calls).toContain('ResolveOrchestratorToReopen');
+    expect(calls).not.toContain('StartOrchestrator');
+    expect(calls).not.toContain('StartOrchestratorWithResume');
+  });
+});


### PR DESCRIPTION
Closes #971

## The defect

The desktop kept a single record of "which orchestrator to reopen", and it was a **restart hand-off**: written only by the in-app Restart button (`RestartApp`), deleted on read, and honoured for ten minutes. Every other route back into the app — a plain quit-and-relaunch, a crash, a reboot, `erun app` from another bundle, or an in-app restart whose new instance booted late — had nothing to restore, so boot fell through to the default environment selection and the operator reopened the orchestrator by hand.

## The split

The two concerns that file conflated are now separate, because they have different lifetimes.

**Durable session state** — `erun-ui/orchestrator_open_state.go`, `orchestrator-open.json` beside `window-state.json`. It records which orchestrator is open. It is written the moment a session starts and cleared the moment the operator stops it, **never at shutdown**: a crash, a `pkill` or a reboot runs no hook, and a record only a clean quit could write would be missing exactly when it is most needed. It carries **no freshness window** — an orchestrator left open is still the one the operator was in, however long ago. Stopping some *other* orchestrator leaves it alone; deleting the definition takes it with it; a transient (Investigate) session is never recorded.

**The one-shot restart hand-off** — `app_restart.go`, unchanged in behaviour. It still wins while it is fresh, still carries the `resumePrompt` a rebuild+restart auto-runs, still fires exactly once, and still expires after 10 minutes. After it expires the durable record still reopens the orchestrator, **idle at its prompt, running nothing**.

`ConsumeRelaunchTarget` becomes `ResolveOrchestratorToReopen` — it no longer only consumes — and answers from the hand-off first, then the durable record. Resume still goes through the orchestrator's own deterministic `orchestratorSessionID`, so it lands on its own conversation, and the restored orchestrator still owns the pane (`setSelected(null)`) so boot's default selection cannot reconcile the terminal back to an environment.

## Tests

- `erun-ui/orchestrator_open_state_test.go` — plain-launch reopen with no restart target and no prompt; explicitly stopped stays closed; deleted is not reopened; restart re-records; stopping another orchestrator does not close this one; transient not recorded; the hand-off still wins, still fires once, still expires (and the durable record answers idle behind it).
- `erun-ui/frontend/src/app/orchestratorRestore.test.ts` — the boot restore decision: reopen with no prompt, hand-off with its prompt, nothing to reopen, a target that no longer exists, a transient target, a whitespace-only prompt.
- `erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts` — boot in the rendered app: the restored orchestrator owns the pane (tab strip in orchestrator mode, its tab selected, env mode gone) and the launch calls `StartOrchestrator`, never `StartOrchestratorWithResume`; a hand-off calls the prompt-carrying one; with nothing to reopen the launch starts no orchestrator. The backend answer is stubbed over `/__erun_invoke` because the inert harness deliberately has no real Claude; the Go tests above own the durable-record branches.

## End-to-end verification

Driven against the built `bin/erun-app --headless` in an isolated config root, with a stub `claude` that stays alive:

1. `CreateOrchestrator` + `StartOrchestrator` → `orchestrator-open.json` on disk immediately (`{"orchestratorId":"agent"}`), session running.
2. `kill -9` the desktop (a crash — no shutdown hook runs) → relaunch → `ResolveOrchestratorToReopen` returns `{"orchestratorId":"agent","resumePrompt":""}`, with no restart hand-off file present at all.
3. `StopOrchestrator` → `kill -9` → relaunch → `ResolveOrchestratorToReopen` returns `{"orchestratorId":"","resumePrompt":""}`.

Not verified here: the macOS/Windows GUI launch path and real Claude conversation resume — no desktop session available in this environment. The closest signals are the Playwright boot spec (which drives the real React boot sequence) and the unchanged `orchestratorSessionID` resume wiring.

Probe artifacts (temp root, stub binaries, headless processes) were removed.

## Gates

| Gate | Result |
| --- | --- |
| `cd erun-ui && go build ./... && go vet ./... && go test ./... -count=1` | pass |
| `golangci-lint run ./...` (erun-ui) | 0 issues |
| `cd erun-ui/frontend && yarn typecheck && yarn lint && yarn format:check && yarn test` | pass (33 tests) |
| `cd erun-ui/playwright && ./run.sh --build` | 148 passed |
| `make integration-test` | pass, coverage 75.8% (>= 75.5%) |

Wails bindings regenerated (`wails generate module`) for the renamed exported method; `frontend/wailsjs/` is generated and gitignored.

## UX impact review

1. **Affected paths.** Desktop boot (`getInitialState` → `loadOrchestrators` → `restoreOpenOrchestrator`), the ERUN section's orchestrator row start/stop, and the in-app Restart button.
2. **User-visible sequence.** Launching the desktop lands the operator back in the orchestrator they left open — tab strip in orchestrator mode with its tab selected, sidebar row running — instead of the default environment. Stopping an orchestrator and relaunching lands on the default environment, as before.
3. **State-without-affordance.** The only new state is on disk; its consequence is rendered (the restored session owns the pane, the row reads running).
4. **Visibility of system status (Nielsen #1).** The restored session renders in the pane and on the row; nothing is set and then cleared by the next lifecycle step.
5. **Success and failure feedback (Nielsen #1, #9).** A restore that cannot start surfaces through the existing orchestrators error path, and boot falls through to the default environment rather than leaving a blank pane.
6. **Consistency with comparable flows (Nielsen #4).** Matches `window-state.json`, the desktop's other durable restore-what-you-left state, and how a terminal or editor returns to the workspace you left.
7. **Heuristic pass.** #1 visibility and #4 consistency drive the change; #3 user control is why an explicitly stopped orchestrator stays closed; #5 error prevention is why a deleted or transient target restores nothing. Match with the real world, recognition over recall, flexibility, aesthetics, error recovery and help do not apply — no new control, label or copy.
8. **Playwright coverage.** `erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts` (new).

## Docs

No `erun-docs` change. The desktop page does not document the orchestrator lifecycle, and this adds no operator-facing control, flag or command — it makes a launch restore the session the operator left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
