### PR TITLE
Publish host-mirror files atomically

### DIFF
--- a/erun-common/workspace_sync.go
+++ b/erun-common/workspace_sync.go
@@ -152,6 +152,17 @@ func workspaceSyncPassErrorSuffix(label string, err error) string {
 // over the same paths.
 const WorkspaceSyncArtifactsSubdir = ".erun-outputs"
 
+// workspaceSyncStagingSubdir is where a pass lands bytes that are still
+// arriving. tar extracts in place, so extracting straight into the mirror let a
+// reader open a file mid-write and get a prefix that looks complete — a
+// truncated Mach-O reads as "not signed at all" rather than as truncated, which
+// is evidence for the wrong conclusion. Staging then renaming publishes each
+// file atomically, and keeps the only partial state in a directory that says so
+// by name. It sits inside the lane it serves so the rename never crosses a
+// filesystem, and both lanes skip it so staged bytes are never mistaken for
+// mirror content.
+const workspaceSyncStagingSubdir = ".erun-sync-staging"
+
 // syncOutputsArtifacts mirrors the pod's deliverables directory
 // (DefaultRuntimeOutputsDir) into artifactsLocal as a one-way,
 // read-only host mirror. Artifacts live outside the git worktree, so they escape
@@ -167,9 +178,9 @@ func syncOutputsArtifacts(ctx context.Context, hostAlias, outputsRemote, artifac
 		if err := os.MkdirAll(artifactsLocal, 0o755); err != nil {
 			return 0, fmt.Errorf("create artifacts dir %s: %w", artifactsLocal, err)
 		}
-		// Clear the read-only bit set by the previous pass so the tar extract can
-		// overwrite the mirror in place (matters on Windows, where a read-only
-		// attribute otherwise blocks the rewrite).
+		// Clear the read-only bit set by the previous pass so the refreshed file
+		// can replace it (matters on Windows, where a read-only attribute
+		// otherwise blocks the rename onto it).
 		if err := makeArtifactsWritable(artifactsLocal); err != nil {
 			return 0, err
 		}
@@ -219,7 +230,8 @@ func pruneLocalArtifacts(artifactsLocal string, remotePaths []string) error {
 }
 
 // ListLocalArtifactFiles returns the regular files under root, relative to it and
-// slash-normalized. A missing root yields no files.
+// slash-normalized. A missing root yields no files, and the staging subdir is
+// skipped so bytes still arriving are never offered as a deliverable.
 func ListLocalArtifactFiles(root string) ([]string, error) {
 	var files []string
 	err := filepath.Walk(root, func(p string, info os.FileInfo, walkErr error) error {
@@ -229,12 +241,15 @@ func ListLocalArtifactFiles(root string) ([]string, error) {
 			}
 			return walkErr
 		}
-		if info.IsDir() {
-			return nil
-		}
 		rel, relErr := filepath.Rel(root, p)
 		if relErr != nil {
 			return relErr
+		}
+		if info.IsDir() {
+			if filepath.ToSlash(rel) == workspaceSyncStagingSubdir {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		files = append(files, filepath.ToSlash(rel))
 		return nil
@@ -478,7 +493,7 @@ func localWorkspaceSourceFileMeta(root string) (map[string]workspaceFileMeta, er
 		}
 		relSlash := filepath.ToSlash(rel)
 		if info.IsDir() {
-			if relSlash == ".git" || relSlash == WorkspaceSyncArtifactsSubdir {
+			if relSlash == ".git" || relSlash == WorkspaceSyncArtifactsSubdir || relSlash == workspaceSyncStagingSubdir {
 				return filepath.SkipDir
 			}
 			return nil
@@ -561,7 +576,66 @@ func sortedWorkspaceFileMetaKeys(meta map[string]workspaceFileMeta) []string {
 	return keys
 }
 
+// extractRemoteWorkspaceFiles fetches paths from the pod into localPath. The
+// archive lands in a staging dir and each file is renamed into place afterwards,
+// so nothing reading the mirror can observe a half-written file; a pass that
+// fails, is cancelled, or is killed leaves the mirror on its previous content.
 func extractRemoteWorkspaceFiles(ctx context.Context, hostAlias, remotePath, localPath string, paths []string) error {
+	staging, err := prepareWorkspaceSyncStaging(localPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(staging) }()
+	if err := streamRemoteWorkspaceArchive(ctx, hostAlias, remotePath, staging, paths); err != nil {
+		return err
+	}
+	return publishStagedWorkspaceFiles(staging, localPath)
+}
+
+// prepareWorkspaceSyncStaging gives the pass an empty staging dir beside the
+// files it will publish, clearing whatever a killed pass left behind so staged
+// bytes are only ever this pass's.
+func prepareWorkspaceSyncStaging(localPath string) (string, error) {
+	staging := filepath.Join(localPath, workspaceSyncStagingSubdir)
+	if err := os.RemoveAll(staging); err != nil {
+		return "", fmt.Errorf("clear workspace sync staging %s: %w", staging, err)
+	}
+	if err := os.MkdirAll(staging, 0o755); err != nil {
+		return "", fmt.Errorf("create workspace sync staging %s: %w", staging, err)
+	}
+	return staging, nil
+}
+
+// publishStagedWorkspaceFiles moves each staged entry onto its final path with
+// rename(2), so a reader sees either the previous file or the complete new one.
+// Symlinks publish the same way — filepath.Walk lstats, so a link moves as a
+// link rather than being followed.
+func publishStagedWorkspaceFiles(staging, localPath string) error {
+	return filepath.Walk(staging, func(p string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(staging, p)
+		if relErr != nil {
+			return relErr
+		}
+		destination := filepath.Join(localPath, rel)
+		if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+			return fmt.Errorf("create mirror directory for %s: %w", rel, err)
+		}
+		if err := os.Rename(p, destination); err != nil {
+			return fmt.Errorf("publish %s into the mirror: %w", rel, err)
+		}
+		return nil
+	})
+}
+
+// streamRemoteWorkspaceArchive pipes the pod's tar of paths into an extract
+// rooted at destination.
+func streamRemoteWorkspaceArchive(ctx context.Context, hostAlias, remotePath, destination string, paths []string) error {
 	script := fmt.Sprintf("cd %s && tar --null --ignore-failed-read -T - -cf -", shellQuote(remotePath))
 	sshCmd := CommandContext(ctx, "ssh", workspaceSyncSSHArgs(hostAlias, script)...)
 	HideConsoleWindow(sshCmd)
@@ -573,7 +647,7 @@ func extractRemoteWorkspaceFiles(ctx context.Context, hostAlias, remotePath, loc
 	var sshStderr bytes.Buffer
 	sshCmd.Stderr = &sshStderr
 
-	tarCmd := CommandContext(ctx, "tar", "-xf", "-", "-C", localPath)
+	tarCmd := CommandContext(ctx, "tar", "-xf", "-", "-C", destination)
 	HideConsoleWindow(tarCmd)
 	tarCmd.Stdin = sshStdout
 	var tarStderr bytes.Buffer
@@ -683,12 +757,15 @@ func SafeWorkspaceSyncPath(value string) bool {
 	if cleaned != value || strings.HasPrefix(cleaned, "../") || cleaned == ".." {
 		return false
 	}
-	if cleaned == ".git" || strings.HasPrefix(cleaned, ".git/") {
-		return false
+	// Three subtrees a lane must never claim: the operator's own .git, the
+	// artifact mirror the outputs lane owns, and the staging subdir, whose
+	// contents are bytes still arriving rather than mirror content.
+	for _, reserved := range []string{".git", WorkspaceSyncArtifactsSubdir, workspaceSyncStagingSubdir} {
+		if cleaned == reserved || strings.HasPrefix(cleaned, reserved+"/") {
+			return false
+		}
 	}
-	// The source lane must ignore the artifact mirror subdir so it never prunes
-	// or lists files the outputs lane owns.
-	return cleaned != WorkspaceSyncArtifactsSubdir && !strings.HasPrefix(cleaned, WorkspaceSyncArtifactsSubdir+"/")
+	return true
 }
 
 func pathClean(value string) string {

--- a/erun-common/workspace_sync_atomic_test.go
+++ b/erun-common/workspace_sync_atomic_test.go
@@ -1,0 +1,307 @@
+package eruncommon
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// The mirror is the surface an orchestrator runs host-native artifacts from, so
+// a reader of it must never see a prefix of a file that is still arriving. These
+// tests drive a whole pass against the stub `ssh` from workspace_sync_pass_test.go
+// and park it mid-transfer, so the partial state is a fact of the test rather
+// than something it waits and hopes for.
+
+const (
+	workspaceSyncTestMTime    = 1700000000
+	workspaceSyncTestBigBytes = 8 << 20
+)
+
+// TestSyncWorkspaceOnceNeverPublishesAPartialFile parks a pass with half the
+// archive delivered and asserts the mirror still holds the previous, complete
+// file. Before staging, tar extracted in place and this is exactly the window in
+// which a copy came back short with no error from any step.
+func TestSyncWorkspaceOnceNeverPublishesAPartialFile(t *testing.T) {
+	mirror := t.TempDir()
+	previous := []byte("the previous complete artifact")
+	writeWorkspaceSyncFile(t, filepath.Join(mirror, "app", "big.bin"), previous)
+
+	incoming := bytes.Repeat([]byte{0x7f}, workspaceSyncTestBigBytes)
+	archive := writeWorkspaceSyncArchive(t, map[string][]byte{"app/big.bin": incoming})
+	gate := filepath.Join(t.TempDir(), "gate")
+
+	stubWorkspaceSyncSSH(t, []string{"app/big.bin"}, nil)
+	t.Setenv(workspaceSyncStubArchiveEnv, archive)
+	t.Setenv(workspaceSyncStubGateEnv, gate)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := SyncWorkspaceOnce(context.Background(), WorkspaceSyncParams{
+			HostAlias:  "pod",
+			RemotePath: "/workspace",
+			LocalPath:  mirror,
+		})
+		done <- err
+	}()
+
+	// The stub announces only after handing the extractor the first half, then
+	// holds the rest until the gate opens — so every assertion below runs against
+	// a transfer that has plainly started and provably cannot finish.
+	awaitWorkspaceSyncFile(t, gate+".reached")
+	if got := readWorkspaceSyncFile(t, filepath.Join(mirror, "app", "big.bin")); !bytes.Equal(got, previous) {
+		t.Fatalf("the mirror published a file that is still arriving: %d bytes at the final path, want the previous %d", len(got), len(previous))
+	}
+	// The one partial state is in a directory that says so by name, and the
+	// source lane refuses to treat it as mirror content.
+	awaitWorkspaceSyncSize(t, filepath.Join(mirror, workspaceSyncStagingSubdir, "app", "big.bin"), 1<<20)
+	if SafeWorkspaceSyncPath(workspaceSyncStagingSubdir + "/app/big.bin") {
+		t.Fatal("staged bytes must not be a path the mirror lanes accept as content")
+	}
+
+	writeWorkspaceSyncFile(t, gate, []byte("go"))
+	if err := <-done; err != nil {
+		t.Fatalf("sync pass: %v", err)
+	}
+	if got := readWorkspaceSyncFile(t, filepath.Join(mirror, "app", "big.bin")); !bytes.Equal(got, incoming) {
+		t.Fatalf("published file is %d bytes, want the complete %d", len(got), len(incoming))
+	}
+	requireNoWorkspaceSyncStaging(t, mirror)
+}
+
+// A fetch that dies mid-stream must leave the mirror on its previous content and
+// must not litter it with debris a later pass would read as content.
+func TestSyncWorkspaceOnceLeavesNoDebrisWhenTheFetchFails(t *testing.T) {
+	mirror := t.TempDir()
+	previous := []byte("the previous complete artifact")
+	writeWorkspaceSyncFile(t, filepath.Join(mirror, "app", "big.bin"), previous)
+
+	incoming := bytes.Repeat([]byte{0x7f}, workspaceSyncTestBigBytes)
+	archive := writeWorkspaceSyncArchive(t, map[string][]byte{"app/big.bin": incoming})
+
+	stubWorkspaceSyncSSH(t, []string{"app/big.bin"}, nil)
+	t.Setenv(workspaceSyncStubArchiveEnv, archive)
+	t.Setenv(workspaceSyncStubTruncateEnv, strconv.Itoa(workspaceSyncTestBigBytes/2))
+
+	_, err := SyncWorkspaceOnce(context.Background(), WorkspaceSyncParams{
+		HostAlias:  "pod",
+		RemotePath: "/workspace",
+		LocalPath:  mirror,
+	})
+	if err == nil {
+		t.Fatal("expected a fetch that ended early to surface as an error")
+	}
+	if got := readWorkspaceSyncFile(t, filepath.Join(mirror, "app", "big.bin")); !bytes.Equal(got, previous) {
+		t.Fatalf("a failed fetch corrupted the previous content: %d bytes, want %d", len(got), len(previous))
+	}
+	requireNoWorkspaceSyncStaging(t, mirror)
+	requireWorkspaceSyncMirrorFiles(t, mirror, []string{"app/big.bin"})
+}
+
+// A cancelled context kills the transfer wherever it happens to be, and the
+// mirror must come out of it the same way a failed fetch leaves it.
+func TestSyncWorkspaceOnceLeavesNoDebrisWhenTheContextIsCancelled(t *testing.T) {
+	mirror := t.TempDir()
+	previous := []byte("the previous complete artifact")
+	writeWorkspaceSyncFile(t, filepath.Join(mirror, "app", "big.bin"), previous)
+
+	incoming := bytes.Repeat([]byte{0x7f}, workspaceSyncTestBigBytes)
+	archive := writeWorkspaceSyncArchive(t, map[string][]byte{"app/big.bin": incoming})
+	gate := filepath.Join(t.TempDir(), "gate")
+
+	stubWorkspaceSyncSSH(t, []string{"app/big.bin"}, nil)
+	t.Setenv(workspaceSyncStubArchiveEnv, archive)
+	t.Setenv(workspaceSyncStubGateEnv, gate)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := SyncWorkspaceOnce(ctx, WorkspaceSyncParams{
+			HostAlias:  "pod",
+			RemotePath: "/workspace",
+			LocalPath:  mirror,
+		})
+		done <- err
+	}()
+
+	awaitWorkspaceSyncFile(t, gate+".reached")
+	awaitWorkspaceSyncSize(t, filepath.Join(mirror, workspaceSyncStagingSubdir, "app", "big.bin"), 1<<20)
+	cancel()
+
+	if err := <-done; err == nil {
+		t.Fatal("expected a cancelled pass to surface as an error")
+	}
+	if got := readWorkspaceSyncFile(t, filepath.Join(mirror, "app", "big.bin")); !bytes.Equal(got, previous) {
+		t.Fatalf("a cancelled fetch corrupted the previous content: %d bytes, want %d", len(got), len(previous))
+	}
+	requireNoWorkspaceSyncStaging(t, mirror)
+	requireWorkspaceSyncMirrorFiles(t, mirror, []string{"app/big.bin"})
+}
+
+// The outputs lane keeps its read-only marking and its pruning across the
+// staged publish, and a second pass still overwrites the read-only copy it wrote
+// itself — the rename lands on a file the previous pass stripped write access
+// from, which is what Windows would otherwise refuse.
+func TestSyncOutputsArtifactsPublishesCompletelyAndKeepsItsMarkingAndPruning(t *testing.T) {
+	mirror := t.TempDir()
+	artifacts := filepath.Join(mirror, WorkspaceSyncArtifactsSubdir)
+	writeWorkspaceSyncFile(t, filepath.Join(artifacts, "bin", "stale.bin"), []byte("no longer in the pod"))
+
+	body := bytes.Repeat([]byte{0x2a}, 1<<20)
+	archive := writeWorkspaceSyncArchive(t, map[string][]byte{"bin/tool": body})
+
+	stubWorkspaceSyncSSH(t, nil, nil)
+	t.Setenv(workspaceSyncStubOutputsEnv, "bin/tool")
+	t.Setenv(workspaceSyncStubArchiveEnv, archive)
+
+	result, err := SyncWorkspaceOnce(context.Background(), WorkspaceSyncParams{
+		HostAlias:  "pod",
+		RemotePath: "/workspace",
+		LocalPath:  mirror,
+	})
+	if err != nil {
+		t.Fatalf("sync pass: %v", err)
+	}
+	if result.ArtifactsCopied != 1 {
+		t.Fatalf("ArtifactsCopied = %d, want 1", result.ArtifactsCopied)
+	}
+	tool := filepath.Join(artifacts, "bin", "tool")
+	if got := readWorkspaceSyncFile(t, tool); !bytes.Equal(got, body) {
+		t.Fatalf("published artifact is %d bytes, want the complete %d", len(got), len(body))
+	}
+	info, statErr := os.Stat(tool)
+	if statErr != nil {
+		t.Fatalf("stat published artifact: %v", statErr)
+	}
+	if info.Mode().Perm()&0o200 != 0 {
+		t.Fatalf("the mirrored artifact must stay read-only, got mode %v", info.Mode().Perm())
+	}
+	if _, err := os.Stat(filepath.Join(artifacts, "bin", "stale.bin")); !os.IsNotExist(err) {
+		t.Fatalf("an artifact the pod no longer has was not pruned: %v", err)
+	}
+	requireNoWorkspaceSyncStaging(t, artifacts)
+
+	// A second pass republishes over the read-only copy the first one left.
+	if _, err := SyncWorkspaceOnce(context.Background(), WorkspaceSyncParams{
+		HostAlias:  "pod",
+		RemotePath: "/workspace",
+		LocalPath:  mirror,
+	}); err != nil {
+		t.Fatalf("second sync pass: %v", err)
+	}
+	if got := readWorkspaceSyncFile(t, tool); !bytes.Equal(got, body) {
+		t.Fatalf("republished artifact is %d bytes, want the complete %d", len(got), len(body))
+	}
+	requireNoWorkspaceSyncStaging(t, artifacts)
+}
+
+// writeWorkspaceSyncArchive builds the tar the stub streams. Entries carry a
+// fixed mtime because the mirror's incremental check compares it: a publish that
+// rewrote the file instead of renaming it would re-fetch on every pass.
+func writeWorkspaceSyncArchive(t *testing.T, files map[string][]byte) string {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := tar.NewWriter(&buffer)
+	for name, body := range files {
+		header := &tar.Header{
+			Name:     name,
+			Mode:     0o644,
+			Size:     int64(len(body)),
+			ModTime:  time.Unix(workspaceSyncTestMTime, 0),
+			Typeflag: tar.TypeReg,
+		}
+		if err := writer.WriteHeader(header); err != nil {
+			t.Fatalf("write archive header %s: %v", name, err)
+		}
+		if _, err := writer.Write(body); err != nil {
+			t.Fatalf("write archive body %s: %v", name, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "archive.tar")
+	if err := os.WriteFile(path, buffer.Bytes(), 0o644); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	return path
+}
+
+func writeWorkspaceSyncFile(t *testing.T, path string, body []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readWorkspaceSyncFile(t *testing.T, path string) []byte {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return body
+}
+
+// awaitWorkspaceSyncFile and awaitWorkspaceSyncSize wait on the condition the
+// test needs, never on a duration; the deadline only turns a hang into a
+// readable failure.
+func awaitWorkspaceSyncFile(t *testing.T, path string) {
+	t.Helper()
+	awaitWorkspaceSyncCondition(t, "file "+path+" to appear", func() bool {
+		_, err := os.Stat(path)
+		return err == nil
+	})
+}
+
+func awaitWorkspaceSyncSize(t *testing.T, path string, minimum int64) {
+	t.Helper()
+	awaitWorkspaceSyncCondition(t, "file "+path+" to reach "+strconv.FormatInt(minimum, 10)+" bytes", func() bool {
+		info, err := os.Stat(path)
+		return err == nil && info.Size() >= minimum
+	})
+}
+
+func awaitWorkspaceSyncCondition(t *testing.T, what string, ready func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if ready() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func requireNoWorkspaceSyncStaging(t *testing.T, root string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(root, workspaceSyncStagingSubdir)); !os.IsNotExist(err) {
+		t.Fatalf("staging debris left in %s: %v", root, err)
+	}
+}
+
+func requireWorkspaceSyncMirrorFiles(t *testing.T, root string, want []string) {
+	t.Helper()
+	meta, err := localWorkspaceSourceFileMeta(root)
+	if err != nil {
+		t.Fatalf("fingerprint mirror: %v", err)
+	}
+	got := sortedWorkspaceFileMetaKeys(meta)
+	if len(got) != len(want) {
+		t.Fatalf("mirror holds %v, want exactly %v", got, want)
+	}
+	for i, name := range want {
+		if got[i] != name {
+			t.Fatalf("mirror holds %v, want exactly %v", got, want)
+		}
+	}
+}

--- a/erun-common/workspace_sync_pass_test.go
+++ b/erun-common/workspace_sync_pass_test.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // The host mirror deletes exactly what the pod's remote listing omits, so these
@@ -15,9 +17,15 @@ import (
 // always correct, and the listing it was handed was not.
 
 const (
-	workspaceSyncSSHStubEnv     = "ERUN_COMMON_TEST_SSH_STUB"
-	workspaceSyncStubIndexEnv   = "ERUN_COMMON_TEST_SSH_STUB_INDEX"
-	workspaceSyncStubMissingEnv = "ERUN_COMMON_TEST_SSH_STUB_MISSING"
+	workspaceSyncSSHStubEnv         = "ERUN_COMMON_TEST_SSH_STUB"
+	workspaceSyncStubIndexEnv       = "ERUN_COMMON_TEST_SSH_STUB_INDEX"
+	workspaceSyncStubMissingEnv     = "ERUN_COMMON_TEST_SSH_STUB_MISSING"
+	workspaceSyncStubStatEnv        = "ERUN_COMMON_TEST_SSH_STUB_STAT"
+	workspaceSyncStubOutputsEnv     = "ERUN_COMMON_TEST_SSH_STUB_OUTPUTS"
+	workspaceSyncStubArchiveEnv     = "ERUN_COMMON_TEST_SSH_STUB_ARCHIVE"
+	workspaceSyncStubGateEnv        = "ERUN_COMMON_TEST_SSH_STUB_GATE"
+	workspaceSyncStubTruncateEnv    = "ERUN_COMMON_TEST_SSH_STUB_TRUNCATE"
+	workspaceSyncStubFetchMarkerEnv = "ERUN_COMMON_TEST_SSH_STUB_FETCH_MARKER"
 )
 
 // TestMain doubles as the stub `ssh` binary: the test executable is copied onto
@@ -37,6 +45,11 @@ func runWorkspaceSyncSSHStub(args []string) int {
 		script = args[len(args)-1]
 	}
 	switch {
+	// The fingerprint listing pipes the index listing into stat, so it has to be
+	// matched before the plain index listing it contains.
+	case strings.Contains(script, "stat -c"):
+		_, _ = os.Stdout.WriteString(os.Getenv(workspaceSyncStubStatEnv))
+		return 0
 	case strings.Contains(script, "git ls-files -coz"):
 		// The index listing, which is what a worktree deletion does not change.
 		writeNULList(os.Getenv(workspaceSyncStubIndexEnv))
@@ -46,17 +59,74 @@ func runWorkspaceSyncSSHStub(args []string) int {
 		return 0
 	case strings.Contains(script, "git ls-files -sz"):
 		return 0
-	case strings.Contains(script, "stat -c"):
-		// No fingerprints, so every remote path counts as changed and the pass
-		// reaches the fetch step.
+	case strings.Contains(script, "find . -type f"):
+		outputs := os.Getenv(workspaceSyncStubOutputsEnv)
+		if outputs == "" {
+			// `cd` into a not-yet-created outputs dir exits non-zero.
+			return 1
+		}
+		writeNULList(outputs)
 		return 0
 	case strings.Contains(script, "tar --null"):
-		// The fetch fails: deletions must still propagate.
+		return streamWorkspaceSyncStubArchive()
+	}
+	return 1
+}
+
+// streamWorkspaceSyncStubArchive plays back a prepared archive so a pass reaches
+// its extract step for real. The gate and truncate knobs place a pass at a
+// chosen point — mid-transfer, or dead mid-transfer — which is where a mirror
+// that published in place handed out a prefix.
+func streamWorkspaceSyncStubArchive() int {
+	if marker := os.Getenv(workspaceSyncStubFetchMarkerEnv); marker != "" {
+		_ = os.WriteFile(marker, []byte("fetched"), 0o644)
+	}
+	archive := os.Getenv(workspaceSyncStubArchiveEnv)
+	if archive == "" {
 		_, _ = os.Stderr.WriteString("stub: remote archive unavailable\n")
 		return 1
 	}
-	// Anything else — the outputs listing — reports "nothing there yet".
-	return 1
+	body, err := os.ReadFile(archive)
+	if err != nil {
+		_, _ = os.Stderr.WriteString("stub: " + err.Error() + "\n")
+		return 1
+	}
+	if truncate, convErr := strconv.Atoi(os.Getenv(workspaceSyncStubTruncateEnv)); convErr == nil && truncate < len(body) {
+		_, _ = os.Stdout.Write(body[:truncate])
+		_, _ = os.Stderr.WriteString("stub: remote archive ended early\n")
+		return 1
+	}
+	gate := os.Getenv(workspaceSyncStubGateEnv)
+	if gate == "" {
+		_, _ = os.Stdout.Write(body)
+		return 0
+	}
+	half := len(body) / 2
+	if _, err := os.Stdout.Write(body[:half]); err != nil {
+		return 1
+	}
+	// Announce only once the bytes are with the extractor, then hold until the
+	// test has finished looking at the mirror.
+	_ = os.WriteFile(gate+".reached", []byte("reached"), 0o644)
+	if !awaitWorkspaceSyncStubGate(gate) {
+		return 1
+	}
+	_, _ = os.Stdout.Write(body[half:])
+	return 0
+}
+
+// awaitWorkspaceSyncStubGate blocks until the test opens the gate. The interval
+// is backoff, not synchronisation: the stub proceeds on the file existing, never
+// on elapsed time.
+func awaitWorkspaceSyncStubGate(gate string) bool {
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(gate); err == nil {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return false
 }
 
 func writeNULList(commaSeparated string) {

--- a/erun-docs/docs/agent-reference/workspace-sync-spec.md
+++ b/erun-docs/docs/agent-reference/workspace-sync-spec.md
@@ -29,19 +29,36 @@ The mirror carries no git directory of its own — it is a plain directory copy,
 
 `.erun-outputs/` is the artifacts lane. Artifacts live outside the worktree, so they escape the repo's ignore rules and reach the host even when the source lane would skip them — this is how a Windows binary cross-built in a Linux pod gets to a host that can run it. Its files are written read-only, and the source lane skips the directory, so the two lanes never contend.
 
+`.erun-sync-staging/` is where a pass lands bytes that are still arriving; see [Atomic publish](#atomic-publish). Both `.erun-outputs/` and `.erun-sync-staging/` are reserved names: a pod file at either path is not mirrored.
+
 ## One pass
 
 1. List the pod's **git-visible** files (`git ls-files --exclude-standard`). The pod applies the repo's ignore rules, so the host needs no git of its own to know what belongs in the mirror.
 2. Subtract index entries whose file the pod's worktree no longer has. `git ls-files -c` reports the index, not the worktree, so without this an unstaged deletion never reaches the host and the mirror keeps the file forever.
 3. Subtract symlinks. They cannot round-trip into a plain-directory mirror on every host; the target file still syncs as a regular file, so only the redundant pointer is lost.
 4. Walk `<localpath>` for the mirror's own `{size, mtime}` fingerprints.
-5. Fetch only the files whose fingerprint differs, streamed as a tar over the SSH channel. `tar` preserves mtime, so an unchanged file matches next pass and a steady state costs one metadata listing rather than a whole-tree transfer.
+5. Fetch only the files whose fingerprint differs, streamed as a tar over the SSH channel into `<localpath>/.erun-sync-staging/`, then rename each one onto its final path. `tar` preserves mtime and `rename` keeps it, so an unchanged file matches next pass and a steady state costs one metadata listing rather than a whole-tree transfer.
 6. Delete mirror files the pod's listing omits, then prune the directories that leaves empty.
 7. Mirror the outputs directory into `.erun-outputs/` and prune artifacts the pod no longer has.
 
 A fetch failure does **not** strand step 6: deletion correctness depends only on the pod's listing, not on whether every changed file transferred. One un-fetchable file must never block every deletion.
 
 Each pass emits one bounded log line with its own inputs and counts — never one line per file.
+
+## Atomic publish
+
+A file appears at its path in the mirror only once it is whole. Both lanes fetch into `<lane>/.erun-sync-staging/` and then `rename` each file onto its final path, which is atomic on POSIX and replaces on Windows — so a reader opening a mirrored file gets either the previous version or the complete new one, never a prefix of one.
+
+This is what makes the mirror usable as the verification surface. A truncated binary is not an error: it copies cleanly, reports a plausible size, and identifies as its own format, while a signature or trailer that lives at the end of the file is simply missing. Read as evidence, that is a wrong answer rather than a failed one.
+
+Consequences an Agent can rely on:
+
+| Property | Guarantee |
+|---|---|
+| Partial state | Only ever inside `.erun-sync-staging/`, never at a final path. The directory name is the marker; there is no "is this finished?" to guess at. |
+| Staged bytes | Never mirror content: both lanes skip the directory, so it is never listed, fingerprinted, pruned, marked read-only, or offered as an artifact. |
+| Failure, cancellation, or a killed pass | The mirror keeps its previous content, and the staging directory is removed. Debris a killed process leaves is cleared at the start of the next pass before anything is staged. |
+| Peak disk | One staging copy of the files this pass is fetching, not of the whole tree. |
 
 ## Transports
 

--- a/erun-integration/internal/env/env.go
+++ b/erun-integration/internal/env/env.go
@@ -20,12 +20,15 @@ import (
 var shellUtilities = []string{"cat", "dirname", "mkdir", "sleep", "touch", "tr", "wc"}
 
 // hostTools are the host executables erun itself may resolve, forwarded through
-// their declared ERUN_<NAME>_BIN seam rather than through PATH. git is the
-// suite's one irreducible host dependency: the fixtures build real repositories
-// with it and the release/diff/exec scenarios read real git state, so no stub
-// could stand in for it. A scenario that wants a scripted git appends its own
-// ERUN_GIT_BIN after Env() (the later duplicate wins).
-var hostTools = []string{"git"}
+// their declared ERUN_<NAME>_BIN seam rather than through PATH. Both entries are
+// irreducible host dependencies: the fixtures build real repositories with git
+// and the release/diff/exec scenarios read real git state, and the workspace
+// mirror's fetch lane extracts a real archive with tar — a stub can answer a
+// listing but cannot extract, so without a real tar the lane that publishes
+// files into the mirror is unreachable from the binary. Both ship in the
+// golang image the build gate runs in. A scenario that wants a scripted tool
+// appends its own ERUN_<NAME>_BIN after Env() (the later duplicate wins).
+var hostTools = []string{"git", "tar"}
 
 // Setup is the resolved environment for a single subprocess invocation.
 type Setup struct {

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -4,6 +4,8 @@
 package fixture
 
 import (
+	"archive/tar"
+	"bytes"
 	"fmt"
 	"net"
 	"os"
@@ -828,6 +830,91 @@ exit 0
 	return StubEnv(stubsDir, "git")
 }
 
+// WorkspaceSyncSSHStubSpec answers the several different questions one
+// workspace-sync pass asks the same `ssh` — the pod's file listing, its
+// fingerprints, and the archive its fetch step streams.
+type WorkspaceSyncSSHStubSpec struct {
+	// IndexPaths is what `git ls-files -coz` reports: the pod's Git-visible files.
+	IndexPaths []string
+	// StatLines are `stat -c '%s %Y %n'` records (size, mtime, path). They are
+	// what lets a pass skip an unchanged file; with none, everything is fetched.
+	StatLines []string
+	// ArchivePath is a tar file the fetch step receives verbatim, standing in for
+	// the pod's `tar -cf -`. Empty makes the fetch fail.
+	ArchivePath string
+}
+
+// StubWorkspaceSyncSSH writes the argv-branching `ssh` stub a real sync pass
+// needs and returns its env routing. The pass's fingerprint listing pipes the
+// index listing into stat, so the stat branch has to be matched before the index
+// listing it contains.
+func StubWorkspaceSyncSSH(t testing.TB, dir string, spec WorkspaceSyncSSHStubSpec) []string {
+	t.Helper()
+	statBranch := ":"
+	if len(spec.StatLines) > 0 {
+		statBranch = `printf '%s\n' ` + shellSingleQuoteAll(spec.StatLines)
+	}
+	indexBranch := ":"
+	if len(spec.IndexPaths) > 0 {
+		indexBranch = `printf '%s\000' ` + shellSingleQuoteAll(spec.IndexPaths)
+	}
+	archiveBranch := "exit 1"
+	if spec.ArchivePath != "" {
+		archiveBranch = "cat " + shellSingleQuote(filepath.ToSlash(spec.ArchivePath))
+	}
+	// The readiness probe runs a bare `true`; everything not answered here — the
+	// outputs listing in particular — is "nothing there yet", which is exit 1.
+	StubBinaryWithScript(t, dir, "ssh", `case "$*" in
+  *' true') : ;;
+  *'stat -c'*) `+statBranch+` ;;
+  *'git ls-files -coz'*) `+indexBranch+` ;;
+  *'git ls-files -dz'*) : ;;
+  *'git ls-files -sz'*) : ;;
+  *'tar --null'*) `+archiveBranch+` ;;
+  *) exit 1 ;;
+esac
+exit 0
+`)
+	return StubEnv(dir, "ssh")
+}
+
+// TarEntry is one regular file in an archive written by WriteTarArchive.
+type TarEntry struct {
+	Path string
+	Body []byte
+}
+
+// WriteTarArchive writes the archive a stubbed pod streams back. Entries carry
+// an explicit mtime so a scenario can assert what the mirror did with the file
+// it received rather than with whatever the host clock stamped.
+func WriteTarArchive(t testing.TB, path string, entries []TarEntry, modTime time.Time) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for archive %s: %v", path, err)
+	}
+	var buffer bytes.Buffer
+	writer := tar.NewWriter(&buffer)
+	for _, entry := range entries {
+		header := &tar.Header{
+			Name:     entry.Path,
+			Mode:     0o644,
+			Size:     int64(len(entry.Body)),
+			ModTime:  modTime,
+			Typeflag: tar.TypeReg,
+		}
+		if err := writer.WriteHeader(header); err != nil {
+			t.Fatalf("write archive header %s: %v", entry.Path, err)
+		}
+		if _, err := writer.Write(entry.Body); err != nil {
+			t.Fatalf("write archive body %s: %v", entry.Path, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close archive %s: %v", path, err)
+	}
+	mustWrite(t, path, buffer.String())
+}
+
 // RunGit runs git in dir so scenarios can set up branches, tags, or remotes
 // after SeedReleaseRepo.
 func RunGit(t testing.TB, dir string, args ...string) {
@@ -1160,6 +1247,16 @@ func stubRunnerExe(t testing.TB) string {
 
 func shellSingleQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}
+
+// shellSingleQuoteAll renders values as space-separated printf operands, so one
+// format string repeats over them.
+func shellSingleQuoteAll(values []string) string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, shellSingleQuote(value))
+	}
+	return strings.Join(quoted, " ")
 }
 
 // StubBinaryWithScript writes a stub binary whose POSIX-shell body is the

--- a/erun-integration/scripts/integration-test.sh
+++ b/erun-integration/scripts/integration-test.sh
@@ -33,7 +33,7 @@
 
 set -euo pipefail
 
-threshold="${COVERAGE_THRESHOLD:-75.5}"
+threshold="${COVERAGE_THRESHOLD:-75.7}"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -threshold=*) threshold="${1#-threshold=}" ;;

--- a/erun-integration/sshd_test.go
+++ b/erun-integration/sshd_test.go
@@ -1,10 +1,14 @@
 package integration
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sophium/erun/erun-integration/internal/env"
 	"github.com/sophium/erun/erun-integration/internal/erun"
@@ -158,6 +162,60 @@ func TestSSHD(t *testing.T) {
 		}
 	})
 
+	// The fetch lane, which the listing-only scenarios above never reach. A pass
+	// used to extract straight into the mirror, so a reader could open a file that
+	// was still arriving and get a prefix of it with no error from any step. What
+	// lands must be the whole file, and nothing half-written may be left behind.
+	// The second pass is the other half of the contract: the publish has to
+	// preserve the pod's mtime, or the fingerprint misses and every pass re-fetches
+	// the whole tree.
+	t.Run("sync_real_run_publishes_complete_files_and_refetches_nothing", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnvWithWorkspaceSync(t, setup, "team", "dev", 47300)
+		mirror := filepath.Join(setup.Home, "mirror", "team-dev")
+
+		body := bytes.Repeat([]byte("erun mirror payload\n"), 4096)
+		archive := filepath.Join(setup.Cwd, "pod-archive.tar")
+		const podMTime = 1700000000
+		fixture.WriteTarArchive(t, archive, []fixture.TarEntry{{Path: "app/main.go", Body: body}}, time.Unix(podMTime, 0))
+
+		stubs := setup.Cwd + "/stubs"
+		envVars := append(setup.Env(), fixture.StubWorkspaceSyncSSH(t, stubs, fixture.WorkspaceSyncSSHStubSpec{
+			IndexPaths:  []string{"app/main.go"},
+			StatLines:   []string{fmt.Sprintf("%d %d app/main.go", len(body), podMTime)},
+			ArchivePath: archive,
+		})...)
+
+		result := erun.Run(t, []string{"sshd", "sync", "team", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		if !strings.Contains(result.Combined, "copied 1 files") {
+			t.Fatalf("the pass must report the file it fetched:\n%s", result.Combined)
+		}
+		mirrored := filepath.Join(mirror, "app", "main.go")
+		got, err := os.ReadFile(mirrored)
+		if err != nil {
+			t.Fatalf("read mirrored file: %v", err)
+		}
+		if !bytes.Equal(got, body) {
+			t.Fatalf("mirrored file is %d bytes, want the complete %d", len(got), len(body))
+		}
+		// Nothing half-written survives the pass: the mirror holds the published
+		// file and nothing else.
+		if files := mirrorFiles(t, mirror); len(files) != 1 || files[0] != "app/main.go" {
+			t.Fatalf("mirror holds %v, want exactly [app/main.go]", files)
+		}
+
+		second := erun.Run(t, []string{"sshd", "sync", "team", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if second.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", second.ExitCode, second.Combined)
+		}
+		if !strings.Contains(second.Combined, "copied 0 files") {
+			t.Fatalf("an unchanged file must not be fetched again:\n%s", second.Combined)
+		}
+	})
+
 	t.Run("init_real_run_writes_local_ssh_config", func(t *testing.T) {
 		setup := env.New(t)
 		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
@@ -301,4 +359,31 @@ func TestSSHD(t *testing.T) {
 		}
 		golden.Equal(t, "sshd/init_real_run_retries_after_pod_not_found", normalize.Apply(result.Combined))
 	})
+}
+
+// mirrorFiles lists every regular file under the host mirror, relative and
+// slash-normalized, so a scenario can assert the mirror holds exactly what the
+// pass published and no leftovers.
+func mirrorFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var files []string
+	err := filepath.Walk(root, func(p string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, p)
+		if relErr != nil {
+			return relErr
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk mirror: %v", err)
+	}
+	sort.Strings(files)
+	return files
 }


### PR DESCRIPTION
Closes #979

## The defect

Workspace sync populated the host mirror by streaming the pod's `tar -cf -` over ssh into a local `tar -xf - -C <mirror>`. tar extracts **in place**, file by file, so anything reading the mirror could open a file that was still arriving and get a prefix of it. There was no marker separating "finished" from "still arriving": the file was simply there, with a plausible size and a current mtime.

Nothing failed. `cp` succeeded, `ls` looked reasonable, `file` identified a valid `Mach-O 64-bit executable arm64`. But a Mach-O's code signature lives at the end of `__LINKEDIT`, so the truncated copy presented as `code object is not signed at all`, was SIGKILLed on exec (rc=137), and made `codesign -s -` fail with `main executable failed strict validation` — three confident and entirely wrong diagnoses, none of which mentions truncation. The failure mode is not an error; it is plausible evidence for the wrong conclusion.

The mirror is exactly the surface the erun-orchestrate contract designates for reviewing and *running* host-native artifacts, because the build pod is Linux and cannot execute what it produced.

## The fix

Both lanes (source and `.erun-outputs/`) now extract into a `.erun-sync-staging/` directory **inside the lane they serve**, then `rename(2)` each file onto its final path.

- **Same filesystem.** Staging lives inside the destination directory, so the rename is atomic (POSIX) / replacing (Windows `MoveFileEx`), never a cross-device copy.
- **Incremental behaviour preserved.** `rename` keeps the inode, so tar's preserved mtime survives the publish and the `{size, mtime}` fingerprint still matches on the next pass. An unchanged file is not re-fetched.
- **Read-only marking, pruning, symlinks.** The outputs lane still clears the write bit before the refresh and re-marks after; pruning is unchanged. `filepath.Walk` lstats, so a symlink is renamed as a link rather than followed.
- **No debris.** Staging is removed on success, on failure, on a cancelled context, and — for a process that was killed outright — at the start of the next pass, before anything is staged.
- **Peak disk stays proportionate.** Only the files the pass is actually fetching are staged, never a second copy of the tree.
- **Partial state is observable *as* partial.** `.erun-sync-staging/` is a reserved name both lanes skip, so staged bytes are never listed, fingerprinted, pruned, marked read-only, or offered as an artifact.

## Tests

| Behaviour | Test |
|---|---|
| A file being synced is never observable at its final path in a partial state | `erun-common/workspace_sync_atomic_test.go` · `TestSyncWorkspaceOnceNeverPublishesAPartialFile` |
| A failed sync leaves no temp debris and does not corrupt the previous content | `TestSyncWorkspaceOnceLeavesNoDebrisWhenTheFetchFails` |
| A cancelled sync leaves no temp debris and does not corrupt the previous content | `TestSyncWorkspaceOnceLeavesNoDebrisWhenTheContextIsCancelled` |
| Pruning and read-only marking still behave (and a republish lands on the read-only copy the previous pass wrote) | `TestSyncOutputsArtifactsPublishesCompletelyAndKeepsItsMarkingAndPruning` |
| An unchanged file is not re-fetched on the next pass; the mirror holds the complete file and nothing else | `erun-integration/sshd_test.go` · `TestSSHD/sync_real_run_publishes_complete_files_and_refetches_nothing` |

**How the partial-observability test is deterministic.** No sleeping and hoping. The stub `ssh` (the existing `workspace_sync_pass_test.go` seam — the test binary re-entered as `ssh`) writes the *first half* of a prepared 8 MiB archive to stdout, and only once those bytes have been accepted by the extractor does it create a `.reached` marker and then **block** until the test creates a gate file. The transfer therefore provably cannot finish while the assertions run: the test waits on `.reached` (an observable condition, not a duration), asserts the final path still holds the previous complete content byte-for-byte, asserts the staged copy is visibly partial, and only then opens the gate and asserts the published file is complete and staging is gone.

Verified as a real regression test: reverting just the stage-and-rename (extracting straight into the mirror again) turns all three atomicity tests red — the failed-fetch case reports `a failed fetch corrupted the previous content: 4193792 bytes, want 30`.

The integration scenario is the first one to reach the mirror's fetch lane from the compiled binary at all; the listing-only scenarios never got there. Reaching it needs a real `tar` (a stub can answer a listing but cannot extract), so `tar` joins `git` in the suite's `hostTools` — both ship in the `golang` image the build gate runs in.

## Gates

| Gate | Result |
|---|---|
| `erun-common` — build / vet / test / golangci-lint | green, 0 issues |
| `erun-cli` — build / vet / test / golangci-lint | green, 0 issues |
| `erun-mcp` — build / vet / test / golangci-lint | green, 0 issues |
| `erun-integration` — build / vet / test / golangci-lint | green, 0 issues |
| `erun-ui` — build / vet / test (consumes `ListLocalArtifactFiles` + `SafeWorkspaceSyncPath`) | green |
| `make integration-test` | green — coverage 76.0% (was 75.8% on main) |
| `cd erun-docs && yarn build` | clean |
| Race + repeat | `-race` clean; new tests green over `-count=5` |

**Goldens: none changed.** `UPDATE_GOLDEN=1 go test ./...` left `testdata/` byte-identical — no traced output moved. Adding `tar` to `hostTools` puts an `ERUN_TAR_BIN` in every scenario's env but no golden echoes it.

**Coverage floor 75.5% → 75.7%.** The new integration scenario raised the measured total from 75.8% to 76.0% by covering the previously-unreachable fetch lane; the threshold moves with it, keeping the same 0.3 margin the repo has been carrying.

## Docs

`erun-docs/docs/agent-reference/workspace-sync-spec.md` (Agent reference — the spec page for this behaviour; its Operator companions `/cli/sshd` and `/desktop/overview` already point here for the pass itself and needed no change):

- Step 5 of "One pass" now names the staging directory and the rename, and says `rename` keeps the mtime the incremental check depends on.
- New **Atomic publish** section states the guarantee, why a truncated binary is a wrong answer rather than a failed one, and a table of the properties an Agent can rely on (where partial state lives, that staged bytes are never content, what a failure/cancellation/kill leaves behind, peak disk).
- `.erun-sync-staging/` documented alongside `.erun-outputs/` as a reserved name.

## Verification

The originally failing flow — a file arriving into the mirror while a reader looks at it — is reproduced verbatim by the gated test above and watched not to happen, and the whole fetch lane is exercised end-to-end through the compiled `erun sshd sync` binary against a real `tar` and a real filesystem.

Not verified here, honestly: a live remote-agent pod over real SSH from a macOS host (no cluster reachable from this checkout — the pod side is stood in for by a stub `ssh` streaming a real tar stream), and the Windows `MoveFileEx`-over-read-only path, which the outputs-lane test covers on POSIX semantics only. The existing `makeArtifactsWritable` step that Windows depends on is unchanged and still runs before the publish.

## UX impact

1. **Affected paths.** Desktop workspace-sync poller, `erun sshd sync`, the `workspace_sync` MCP tool — all three call the same `SyncWorkspaceOnce`.
2. **User-visible sequence.** Unchanged. Same counts, same pass log line, same refusals, same dry-run. The only new observable is a transient `.erun-sync-staging/` directory in the mirror during a pass, which both lanes and the desktop's artifact list skip — an Operator's Outputs dialog will not show a half-written artifact any more.
3–7. No state mutated without an affordance; no status indicator added or removed; feedback and consistency with comparable flows unchanged, because this is a correctness fix underneath an existing surface rather than a new operation.
8. **Playwright:** not run — no component, dialog, slice, thunk, controller method, or Wails-exposed method changed. `ListLocalArtifactFiles` (which `ListHostArtifacts` calls) changes only by skipping the staging directory, which the harness has no way to stage into; the Go tests above own that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)