### PR TITLE
Re-query the version picker when a save changes the registries it lists from

### DIFF
--- a/erun-ui/frontend/src/app/manageDialogHelpers.test.ts
+++ b/erun-ui/frontend/src/app/manageDialogHelpers.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { UIContainerRegistryEntry, UIEnvironmentConfig } from '@/types';
+
+import { versionSourceSignature } from './manageDialogHelpers';
+
+// The signature decides whether a save re-queries the version picker. It has to
+// move for every edit that changes which registries the picker lists from, and
+// stay put for every edit that does not — a false negative leaves the operator
+// looking at a list that predates their own change.
+
+function config(
+  containerRegistries: UIContainerRegistryEntry[],
+  localRepoPath = '/repo',
+): UIEnvironmentConfig {
+  return { containerRegistries, localRepoPath } as UIEnvironmentConfig;
+}
+
+test('adding a registry moves the signature', () => {
+  const before = config([{ registry: 'ghcr.io/sophium', roles: ['build', 'deploy'] }]);
+  const after = config([
+    { registry: 'ghcr.io/sophium', roles: ['build', 'deploy'] },
+    { registry: '020362606330.dkr.ecr.eu-west-2.amazonaws.com', roles: ['build', 'deploy'] },
+  ]);
+  assert.notEqual(versionSourceSignature(before), versionSourceSignature(after));
+});
+
+test('retargeting the local repo path moves the signature', () => {
+  // An env that marks no registries of its own resolves them from the project
+  // config at this path, so repointing it changes what the picker lists.
+  const before = config([], '/repo');
+  const after = config([], '/elsewhere');
+  assert.notEqual(versionSourceSignature(before), versionSourceSignature(after));
+});
+
+test('changing only a role leaves the signature put', () => {
+  // Discovery reads the hosts, not what each one is for, so a role edit cannot
+  // change the offered versions and must not spend a registry round-trip.
+  const before = config([{ registry: 'ghcr.io/sophium', roles: ['build', 'deploy'] }]);
+  const after = config([{ registry: 'ghcr.io/sophium', roles: ['from', 'deploy'] }]);
+  assert.equal(versionSourceSignature(before), versionSourceSignature(after));
+});
+
+test('an in-cluster registry names no host, so it leaves the signature put', () => {
+  const before = config([
+    {
+      registry: '',
+      cluster: {
+        service: 'erun-registry',
+        namespace: 'kube-system',
+        port: 5000,
+        insecure: true,
+        label: 'erun-registry.kube-system:5000',
+      },
+      roles: ['build', 'deploy'],
+    },
+  ]);
+  const after = config([]);
+  assert.equal(versionSourceSignature(before), versionSourceSignature(after));
+});

--- a/erun-ui/frontend/src/app/manageDialogHelpers.ts
+++ b/erun-ui/frontend/src/app/manageDialogHelpers.ts
@@ -38,6 +38,22 @@ export function aiSessionLaunchSignature(config: UIEnvironmentConfig): string {
   );
 }
 
+// versionSourceSignature captures what decides which registries the version
+// picker lists from, mirroring the backend's discovery: the env's own marked
+// registries, and — for an env that marks none — the local repo path whose
+// project config supplies them instead. Roles stay out because discovery reads
+// the hosts, not what each one is for, and a cluster entry names no host at all.
+// A save that changes this must re-query the picker, or a registry the operator
+// just added contributes neither versions nor a notice.
+export function versionSourceSignature(config: UIEnvironmentConfig): string {
+  return JSON.stringify({
+    registries: config.containerRegistries
+      .map((entry) => entry.registry.trim())
+      .filter((registry) => registry !== ''),
+    localRepoPath: config.localRepoPath,
+  });
+}
+
 // nextPendingRedeploy reports whether the pending-redeploy banner should be
 // up after a save: it stays up once raised (a later metadata-only save must
 // not clear a redeploy the user still owes the pod), and a save raises it

--- a/erun-ui/frontend/src/app/manageDialogThunks.ts
+++ b/erun-ui/frontend/src/app/manageDialogThunks.ts
@@ -1,4 +1,10 @@
-import type { ManageTab, UIEnvironmentConfig, UISelection, UIVersionSuggestion } from '@/types';
+import type {
+  ManageTab,
+  UIEnvironmentConfig,
+  UISelection,
+  UIVersionSuggestion,
+  UIVersionSuggestions,
+} from '@/types';
 
 import { environmentApi } from './api/environmentApi';
 import { readError } from './errors';
@@ -12,6 +18,7 @@ import {
   cloneEnvironmentConfig,
   compactClaudeDraft,
   nextPendingRedeploy,
+  versionSourceSignature,
 } from './manageDialogHelpers';
 import { showTerminalMessage } from './notificationThunks';
 import {
@@ -323,34 +330,6 @@ const loadManageResourceStatus =
     }
   };
 
-// applySavedConfigSideEffects runs what a save has to reconcile beyond the form:
-// the version-aware chart probe when the environment's stated chart changed, and
-// the AI tabs when a Claude launch flag did. Both are "only when it actually
-// changed" -- a metadata-only save must not re-probe a registry or churn tabs.
-function applySavedConfigSideEffects(
-  selection: UISelection,
-  priorConfig: UIEnvironmentConfig | null,
-  savedConfig: UIEnvironmentConfig,
-): AppThunk {
-  return (dispatch) => {
-    // Stating (or clearing) the runtime chart changes which chart a deploy would
-    // install, so the probe behind the panel is re-run rather than left describing
-    // the chart the environment used to ride.
-    if ((priorConfig?.runtimeChart ?? '') !== (savedConfig.runtimeChart ?? '')) {
-      void dispatch(refreshManageDeployComponents());
-    }
-    // A changed Claude launch flag only applies when the AI session's create-time
-    // program runs, so reopen the env's open AI tabs now rather than leaving a live
-    // claude on the stale flags.
-    if (
-      priorConfig &&
-      aiSessionLaunchSignature(priorConfig) !== aiSessionLaunchSignature(savedConfig)
-    ) {
-      void dispatch(relaunchAISessionsForLaunchChange(selection));
-    }
-  };
-}
-
 export const submitManageConfig = (): AppThunk<Promise<void>> => async (dispatch, getState) => {
   const dialog = getState().manageDialog;
   if (dialog.busy || dialog.configLoading) {
@@ -399,7 +378,7 @@ export const submitManageConfig = (): AppThunk<Promise<void>> => async (dispatch
         pendingRedeploy: nextPendingRedeploy(dialog.pendingRedeploy, priorConfig, displayConfig),
       }),
     );
-    dispatch(applySavedConfigSideEffects(selection, priorConfig, displayConfig));
+    dispatch(applyManageSaveConsequences(selection, priorConfig, displayConfig));
   } catch (error) {
     const message = readError(error);
     dispatch(
@@ -414,6 +393,49 @@ export const submitManageConfig = (): AppThunk<Promise<void>> => async (dispatch
   }
 };
 
+// applyManageSaveConsequences re-runs what a save invalidates beyond the config
+// it persisted — the version picker, the chart probe, and the AI tabs are all
+// computed from the pre-save values, and nothing else re-reads them while the
+// dialog stays open. Each is gated on the values it actually depends on, so an
+// unrelated save costs no registry round-trip, no re-probe, and no tab churn.
+const applyManageSaveConsequences =
+  (
+    selection: UISelection,
+    priorConfig: UIEnvironmentConfig | null,
+    savedConfig: UIEnvironmentConfig,
+  ): AppThunk =>
+  (dispatch) => {
+    // The picker lists versions from the registries the environment resolves to,
+    // and is otherwise loaded only when the dialog opens. A save that changed
+    // those registries must re-query, or the one the operator just added is
+    // absent from the list AND from the notices — indistinguishable from a
+    // registry erun cannot use, in the one place its effect is read. A missing
+    // prior config cannot be diffed, so re-query: a redundant listing is cheaper
+    // than a silently stale one.
+    if (
+      !priorConfig ||
+      versionSourceSignature(priorConfig) !== versionSourceSignature(savedConfig)
+    ) {
+      void dispatch(refreshManageVersionSuggestions(false));
+    }
+    // Stating (or clearing) the runtime chart changes which chart a deploy would
+    // install, so the probe behind the panel is re-run rather than left
+    // describing the chart the environment used to ride.
+    if ((priorConfig?.runtimeChart ?? '') !== (savedConfig.runtimeChart ?? '')) {
+      void dispatch(refreshManageDeployComponents());
+    }
+    // A changed Claude launch flag only applies when the AI session's
+    // create-time program runs, so reopen the env's open AI tabs now rather
+    // than leaving a live claude on the stale flags. A save that did not
+    // change the launch signature must not churn tabs.
+    if (
+      priorConfig &&
+      aiSessionLaunchSignature(priorConfig) !== aiSessionLaunchSignature(savedConfig)
+    ) {
+      void dispatch(relaunchAISessionsForLaunchChange(selection));
+    }
+  };
+
 const refreshManageVersionSuggestions =
   (selectDefault: boolean): AppThunk<Promise<void>> =>
   async (dispatch, getState) => {
@@ -423,15 +445,25 @@ const refreshManageVersionSuggestions =
     }
     dispatch(bumpManageDialogVersion());
     const request = getState().requestCounters.manageDialogVersion;
-    const raw = await dispatch(
-      environmentApi.endpoints.getVersionSuggestions.initiate(selection, { forceRefetch: true }),
-    ).unwrap();
+    const stale = (): boolean =>
+      request !== getState().requestCounters.manageDialogVersion || !getState().manageDialog.open;
+    let raw: UIVersionSuggestions;
+    try {
+      raw = await dispatch(
+        environmentApi.endpoints.getVersionSuggestions.initiate(selection, { forceRefetch: true }),
+      ).unwrap();
+    } catch (error) {
+      // A listing the transport could not complete leaves the picker empty, so
+      // say why here rather than letting the rejection escape unhandled and the
+      // empty list read as "this environment has no versions".
+      if (!stale()) {
+        dispatch(patchManageDialog({ error: readError(error) }));
+      }
+      return;
+    }
     const suggestions = normalizeVersionSuggestions(raw.suggestions);
     const notices = normalizeVersionSuggestionNotices(raw.notices ?? []);
-    if (
-      request !== getState().requestCounters.manageDialogVersion ||
-      !getState().manageDialog.open
-    ) {
+    if (stale()) {
       return;
     }
     dispatch(

--- a/erun-ui/frontend/src/app/versionSuggestions.test.ts
+++ b/erun-ui/frontend/src/app/versionSuggestions.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { versionNoticeMessage } from './versionSuggestions';
+
+// A notice is the only thing the picker shows for a source that produced no
+// versions, so the sign-in it names has to be the one that reaches that source's
+// own registry — naming a different registry sends the operator to authenticate
+// somewhere the image is not.
+
+test('a private ghcr image names both ghcr sign-ins', () => {
+  const message = versionNoticeMessage({ image: 'ghcr.io/sophium/pw-devops', kind: 'auth' });
+  assert.match(message, /is private/);
+  assert.match(message, /docker login ghcr\.io/);
+  assert.match(message, /gh auth login/);
+});
+
+test('a private image on another registry names that registry, not ghcr', () => {
+  const message = versionNoticeMessage({
+    image: '020362606330.dkr.ecr.eu-west-2.amazonaws.com/pw-devops',
+    kind: 'auth',
+  });
+  assert.match(message, /docker login 020362606330\.dkr\.ecr\.eu-west-2\.amazonaws\.com/);
+  assert.doesNotMatch(message, /ghcr\.io/);
+});
+
+test('a registry named with a port is a host, not a Docker Hub namespace', () => {
+  const message = versionNoticeMessage({ image: 'localhost:5000/pw-devops', kind: 'auth' });
+  assert.match(message, /docker login localhost:5000/);
+});
+
+test('a Docker Hub image names Docker Hub', () => {
+  const message = versionNoticeMessage({ image: 'sophium/pw-devops', kind: 'auth' });
+  assert.match(message, /docker login docker\.io/);
+});
+
+test('an unreachable registry names the failure and offers no sign-in', () => {
+  const message = versionNoticeMessage({
+    image: 'ghcr.io/sophium/pw-devops',
+    kind: 'unreachable',
+  });
+  assert.match(message, /couldn't reach the registry/);
+  assert.doesNotMatch(message, /docker login/);
+});

--- a/erun-ui/frontend/src/app/versionSuggestions.ts
+++ b/erun-ui/frontend/src/app/versionSuggestions.ts
@@ -53,9 +53,29 @@ export function normalizeVersionSuggestions(values: UIVersionSuggestion[]): UIVe
 // registry names the failure.
 export function versionNoticeMessage(notice: UIVersionSuggestionNotice): string {
   if (notice.kind === 'auth') {
-    return `${notice.image} is private — run docker login ghcr.io (or gh auth login) to list its versions.`;
+    return `${notice.image} is private — ${registrySignInHint(notice.image)} to list its versions.`;
   }
   return `${notice.image} — couldn't reach the registry to list its versions.`;
+}
+
+// registrySignInHint names the sign-in that reaches the image's own registry.
+// One ghcr-worded hint for every source told an operator whose image lives in a
+// private registry elsewhere to authenticate against a registry the image is
+// not in, which is worse than no hint at all.
+function registrySignInHint(image: string): string {
+  const host = registryHostFromImage(image);
+  if (host === 'ghcr.io') {
+    return 'run docker login ghcr.io (or gh auth login)';
+  }
+  return `run docker login ${host || 'docker.io'}`;
+}
+
+// registryHostFromImage returns the registry an image reference names, applying
+// the rule the backend resolves by: a first segment carrying a dot or a port is
+// a registry host of its own, anything else is a Docker Hub namespace.
+function registryHostFromImage(image: string): string {
+  const first = normalizeDialogValue(image).split('/')[0] ?? '';
+  return first.includes('.') || first.includes(':') ? first : '';
 }
 
 export function normalizeVersionSuggestionNotices(

--- a/erun-ui/playwright/tests/manage-version-picker.spec.ts
+++ b/erun-ui/playwright/tests/manage-version-picker.spec.ts
@@ -207,6 +207,85 @@ test.describe('manage dialog — version picker (#756)', () => {
     // The tenant version survives; the reload's 9.9.9 never reaches this picker.
     await expect(page.getByRole('option', { name: /1\.0\.16/ })).toBeVisible();
     await expect(page.getByRole('option', { name: /9\.9\.9/ })).toHaveCount(0);
+
+    // The app keeps reloading state on its own timer, so a later LoadState can
+    // still be inside this handler's round-trip when the context tears down —
+    // which surfaces as a failure for a test whose assertions already passed.
+    // Drain the handlers first rather than racing teardown.
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+  });
+
+  test('saving a container registry re-queries the picker so the new registry contributes (#995)', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    // Regression: the picker was loaded only when the dialog opened, and a save
+    // invalidated neither it nor the RTK tag it provides. Adding a registry on
+    // the General tab therefore left the Runtime tab listing versions from the
+    // pre-save registry set — with no entry AND no notice for the registry just
+    // added, which reads as "erun cannot use this registry" rather than "this
+    // list is stale". Visibility of system status: the save's effect must show
+    // in the place it takes effect, without reopening the dialog.
+    let calls = 0;
+    await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+      const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+      if (body.method === 'LoadVersionSuggestions') {
+        calls += 1;
+        // Before the save only the upstream line resolves; after it, the newly
+        // marked registry contributes its own version too.
+        const suggestions =
+          calls === 1
+            ? [{ label: 'Latest stable', version: '1.0.0', source: 'ERun', image: 'erun-devops' }]
+            : [
+                { label: 'Latest stable', version: '1.0.0', source: 'ERun', image: 'erun-devops' },
+                {
+                  label: 'Latest stable',
+                  version: '4.5.6',
+                  source: 'pw',
+                  image: 'registry.internal/pw/pw-devops',
+                },
+              ];
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ data: { suggestions, notices: [] } }),
+        });
+      }
+      await route.continue();
+    });
+
+    await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('Runtime');
+    await app.manageDialog.openVersionPicker();
+    await expect(page.getByRole('option', { name: /4\.5\.6/ })).toHaveCount(0);
+
+    // Add a second registry on the General tab. It is deploy-only: a second
+    // build-marked registry would be invalid, and discovery reads the host
+    // regardless of the roles it carries.
+    await app.manageDialog.selectTab('General');
+    await app.manageDialog.addRegistryButton().click();
+    await app.manageDialog.registryInput(1).fill('registry.internal/pw');
+    await page.keyboard.press('Escape');
+    await app.manageDialog.registryRoleCheckbox(1, 'build').click();
+    await expect(app.manageDialog.locator().getByRole('alert')).toHaveCount(0);
+
+    // The re-query is the save's own consequence, so wait for that response —
+    // a real signal, not a wall-clock guess. Without the fix it never arrives.
+    const requeried = page.waitForResponse(
+      (resp) =>
+        resp.url().includes('__erun_invoke') &&
+        (JSON.parse(resp.request().postData() ?? '{}') as { method?: string }).method ===
+          'LoadVersionSuggestions',
+    );
+    await app.manageDialog.save();
+    await requeried;
+
+    await app.manageDialog.selectTab('Runtime');
+    await app.manageDialog.openVersionPicker();
+    await expect(page.getByRole('option', { name: /4\.5\.6/ })).toBeVisible();
+    // The version the operator had available before the save stays offered.
+    await expect(page.getByRole('option', { name: /1\.0\.0/ })).toBeVisible();
   });
 
   test('deploying a version sends its runtime image so the deploy targets that erun-devops version (#792)', async ({

--- a/erun-ui/playwright/tests/sidebar-env-idle-clears-latch.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-env-idle-clears-latch.spec.ts
@@ -15,12 +15,30 @@ import { expect, test } from '../fixtures/erunApp.js';
 // environment_activity_observed_test.go; what only the running app can show is
 // that the spinner an orphaned latch produces actually goes away.
 
+// The backend sweeps every environment on its own timer (environmentActivityInterval
+// in environment_activity.go) and reports these inert ones unreachable, so an emit
+// this spec makes can be overwritten before the row settles. Re-driving until it
+// converges is the right shape; the two budgets below are what make it converge.
+// The settle wait has to cover a loaded emit → event → re-render round-trip: at 1s
+// a loaded machine missed it, and because every retry re-emits the latch first, no
+// later attempt inherited the previous one's progress. The outer budget is sized to
+// the sweep, not guessed: at exactly one period it passes or fails on where the tick
+// happens to land — observed doing both, converging at 20.2s once and exhausting the
+// budget once. Two full periods plus margin means a sweep landing anywhere inside
+// the window still leaves a whole period for the emits to converge.
+const SWEEP_PERIOD_MS = 20_000;
+const SETTLE_TIMEOUT_MS = 5_000;
+const CONVERGE_TIMEOUT_MS = SWEEP_PERIOD_MS * 2 + 10_000;
+
 test.describe('an idle environment clears a stale desktop latch', () => {
   test('an orphaned running entry stops spinning once the environment reports idle', async ({
     app: _app,
     page,
     seededEnv,
   }) => {
+    // Convergence is paced by the backend's own sweep, so this test outlasts the
+    // default budget by design rather than by accident.
+    test.slow();
     // A per-test environment, not the restored one: the harness auto-opens that
     // one, and an open in flight is this desktop's own operation, which stays
     // authoritative by design and would hold the row busy for an unrelated
@@ -51,13 +69,6 @@ test.describe('an idle environment clears a stale desktop latch', () => {
     // The environment's own answer. The backend's sweep also runs against these
     // inert envs and reports them unreachable, so re-drive until it converges
     // rather than racing a single emit — a row that never clears still fails.
-    //
-    // The budget is sized to that sweep, not guessed: environmentActivityInterval
-    // is 20s (erun-ui/environment_activity.go), so a window of exactly one period
-    // passes or fails on where the tick happens to land — it was observed doing
-    // both, converging at 20.2s once and exhausting the budget once. Two full
-    // periods plus margin means a sweep landing anywhere inside the window still
-    // leaves a whole period for the emits to converge.
     await expect(async () => {
       await emitRunningBuild(page, tenant, environment);
       await emitEnvActivity(page, {
@@ -67,8 +78,8 @@ test.describe('an idle environment clears a stale desktop latch', () => {
         observed: true,
         busy: false,
       });
-      await expect(spinner).toHaveCount(0, { timeout: 1_000 });
-    }).toPass({ timeout: 50_000 });
+      await expect(spinner).toHaveCount(0, { timeout: SETTLE_TIMEOUT_MS });
+    }).toPass({ timeout: CONVERGE_TIMEOUT_MS });
   });
 
   test('an environment that reports work still spins, whoever started it', async ({
@@ -76,6 +87,7 @@ test.describe('an idle environment clears a stale desktop latch', () => {
     page,
     seededEnv,
   }) => {
+    test.slow();
     const { tenant, environment } = seededEnv;
     const sidebar = page.locator('aside').first();
 
@@ -95,8 +107,8 @@ test.describe('an idle environment clears a stale desktop latch', () => {
         sidebar.getByRole('status', {
           name: `${tenant} / ${environment} is busy — holding: gradle-build`,
         }),
-      ).toBeVisible({ timeout: 1_000 });
-    }).toPass({ timeout: 20_000 });
+      ).toBeVisible({ timeout: SETTLE_TIMEOUT_MS });
+    }).toPass({ timeout: CONVERGE_TIMEOUT_MS });
   });
 });
 


### PR DESCRIPTION
## Summary

- **The bug.** The manage dialog's version picker is loaded once, in `openManageDialog`, and `saveEnvironmentConfig` invalidates `EnvironmentConfig` + `AppState` but never `VersionSuggestions` — which nothing else invalidates either. Adding a registry on the **General** tab left the **Runtime** tab listing versions resolved from the pre-save registry set. Because an environment with no configured registries falls back to the default seed, that stale result is byte-identical to a correct one: no entry for the registry just added, **and no notice for it either**. Absent from both directions reads as "erun cannot use this registry", which is what sent an operator hunting for an ECR option that was already configured and already supported.
- **The fix.** A successful save re-queries, gated on what discovery actually reads: the marked registry hosts, and the `localRepoPath` whose project config supplies them for an env that marks none. Roles stay out — `DistinctRegistries` reads hosts, not what each carries — so a role-only edit costs no registry round-trip, and a `cluster:` entry (which names no host) costs none either.
- **Notice wording.** `versionNoticeMessage` named ghcr's sign-in for *every* `auth` notice, so a private image in any other registry was answered with a login to a registry it is not in. It now names the sign-in for the image's own registry, applying the same host rule the backend resolves by (a first segment with a dot or a port is a host; anything else is a Docker Hub namespace).
- **Two adjacent gaps, folded in rather than left behind** (root `AGENTS.md` § Contributing — one body of work, one PR):
  - The suggestions fetch called `.unwrap()` with no catch at a `void dispatch(...)` call site, so a transport failure produced an empty picker plus an unhandled rejection and no reason. It now surfaces the error the way `loadManageConfig` does. This PR adds a second call site, so leaving it would have widened the exposure.
  - `sidebar-env-idle-clears-latch.spec.ts` raced the backend's own environment sweep (`environmentActivityInterval` = 20s) on a 20s `toPass` budget with a 1s settle window — it converged only when the first emit happened to land just after a sweep. It failed in the full-suite run on this branch and passed alone at 20.4s, i.e. a flake with no margin. Settle window raised to 5s (the 1s wait is exactly the below-default wait `playwright/AGENTS.md` names as a flake source), budget raised past one sweep period, and `test.slow()` makes the longer run deliberate rather than accidental.

## UX Impact Review Checklist

1. **Affected paths.** Manage dialog → General tab → Container registries → **Save**; manage dialog → Runtime tab → **Version to deploy** picker and its source-notice list.
2. **User-visible sequence.** Operator adds a registry row, ticks its roles, clicks Save → the dialog stays open, the pending-redeploy banner raises as before → the picker silently re-queries → switching to Runtime and opening the picker now lists versions from the registry just added, or a notice saying why it could not.
3. **State-without-affordance.** The new dispatch writes `versionSuggestions` / `versionSuggestionNotices`, both rendered by the picker list and `VersionNotices`. The new error path writes `manageDialog.error`, which the dialog already renders. No mutation without a rendering consequence.
4. **Visibility of system status (Nielsen #1).** This is the whole point: the save's effect now shows in the one place its effect is read, without reopening the dialog. A listing that fails is a notice, and a listing that cannot complete at all is now an error line instead of an empty list.
5. **Success and failure feedback (Nielsen #1, #9).** Success: the new registry's versions appear in the picker. Failure: a per-source notice naming the registry and the sign-in that reaches it — previously it named ghcr regardless, which is an unactionable next step for any other registry.
6. **Consistency with comparable flows (Nielsen #4).** Checked against the save path's existing consequences: `nextPendingRedeploy` (banner) and `aiSessionLaunchSignature` (AI tab relaunch). Both are signature-gated side effects of a save; this is a third, extracted alongside them into `applyManageSaveConsequences`.
7. **One-line heuristic pass.** #1 visibility — the fix. #2 match with user language — the notice now names the operator's own registry host. #3 user control — nothing runs implicitly beyond the save the operator asked for. #4 consistency — see 6. #5 error prevention — a stale list that looks authoritative is the error prevented. #6 recognition over recall — no reopening the dialog to discover the effect. #7 flexibility — n/a. #8 minimalist design — no new control. #9 recover from errors — the notice names a working sign-in. #10 help — n/a.
8. **Playwright coverage.** `erun-ui/playwright/tests/manage-version-picker.spec.ts` — new spec "saving a container registry re-queries the picker so the new registry contributes (#995)". Verified it fails on the unfixed code (the second `LoadVersionSuggestions` never arrives) and passes with the fix.

## Docs

No `erun-docs` change: this is a pure bug fix that makes the app match what the docs already state. `docs/deployment/registries.md:79` already says the desktop "asks only the environment's listed registries", and `:81` already says a failed listing shows "a notice under the version picker naming the image **and how to sign in**" — both of which were only conditionally true before this change.

## Test plan

- `cd erun-ui/frontend && yarn test` — 44 pass, including 9 new cases for `versionSourceSignature` (moves on a host add and a repo-path change; stays put on a role-only edit and a `cluster:` entry) and `versionNoticeMessage` (ghcr, ECR host, host:port, Docker Hub, and the unreachable branch that must offer no sign-in).
- `cd erun-ui/frontend && yarn typecheck && yarn lint && yarn format:check && yarn build` — clean. (`yarn typecheck` first reported eight errors from stale gitignored Wails bindings; regenerated with `wails generate module` per `erun-ui/AGENTS.md`, no hand-editing.)
- `cd erun-ui && go test ./...` — pass (no Go change; run as the module gate).
- `cd erun-ui/playwright && ./run.sh --build` — **151 passed**. The previously flaky idle-latch spec was then re-run 3× in isolation: 3/3, deterministic at 24.3s each, which is why a 20s budget could not hold it.
- Negative control: reverted `manageDialogThunks.ts` only, rebuilt, re-ran the new spec — fails as intended.
- Not covered by any harness: the Wails window's own rendering. Per `erun-ui/AGENTS.md` § End-to-end UI tests, the headless bridge runs the same React bundle against the same Go backend and reproduces the original flow (add registry → save → open picker) against the built `bin/erun-app`; it does not open a native window. A running desktop app picks the fix up on its next build.

Closes #995