### PR TITLE
Stop a symlinked checkout failing the desktop lint gate

### DIFF
--- a/erun-cli/run.sh
+++ b/erun-cli/run.sh
@@ -3,7 +3,10 @@
 set -eu
 
 ORIGINAL_DIR=$(pwd)
-SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+# -P so every path derived from here has one spelling, whichever symlinked
+# route the caller reached this script through — the desktop build this
+# delegates to gates on that.
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd -P)
 # Where this dev wrapper writes the binaries it builds. Defaults to the
 # in-repo bin/ (gitignored), which keeps `erun app`'s sibling-directory lookup
 # for erun-app/ERun.app working unchanged. ERUN_DEV_BIN_DIR moves them out of

--- a/erun-integration/internal/normalize/desktopidentity_test.go
+++ b/erun-integration/internal/normalize/desktopidentity_test.go
@@ -1,0 +1,25 @@
+package normalize
+
+import "testing"
+
+// TestDesktopIdentityPathIsHostIndependent locks that the desktop identity path
+// collapses to one token on every host. It resolves through os.UserConfigDir(),
+// which the harness cannot pin the way ERUN_HOST_OS_OVERRIDE pins a code branch:
+// darwin returns "$HOME/Library/Application Support" and Linux the XDG dir. The
+// generic temp-dir rule stops at that space, so before this rule the scenario
+// recorded one golden on darwin and a different one on Linux — and whichever
+// host did not record it went red. Drives Apply directly so it runs everywhere.
+func TestDesktopIdentityPathIsHostIndependent(t *testing.T) {
+	const want = "no desktop identity at <DESKTOP_IDENTITY>; open an environment from the ERun desktop app once\n"
+	cases := []struct{ name, path string }{
+		{"darwin user config dir", "/private/var/folders/ab/TestMCP/001/Library/Application Support/ERun/desktopid.key"},
+		{"linux xdg config dir", "/tmp/TestMCP/001/ERun/desktopid.key"},
+		{"macos temp root without the private prefix", "/var/folders/ab/TestMCP/001/Library/Application Support/ERun/desktopid.key"},
+	}
+	for _, c := range cases {
+		raw := "no desktop identity at " + c.path + "; open an environment from the ERun desktop app once\n"
+		if got := Apply(raw); got != want {
+			t.Errorf("%s:\n got: %q\nwant: %q", c.name, got, want)
+		}
+	}
+}

--- a/erun-integration/internal/normalize/normalize.go
+++ b/erun-integration/internal/normalize/normalize.go
@@ -41,6 +41,12 @@ var defaultRules = []Replacement{
 	// token — before the generic <TMP> rule below would swallow the whole path — so
 	// goldens still show that state lives off the (project <TMP>) playbook tree.
 	{regexp.MustCompile(`/(?:private/)?(?:var/folders|var/tmp|tmp)/[^\s'"]*?/\.erun/terraform`), "<STATE_ROOT>"},
+	// The desktop identity resolves through os.UserConfigDir(), which no test
+	// seam can pin: darwin puts it under "Library/Application Support" and Linux
+	// under the XDG dir. The generic rule below stops at the space, so the same
+	// scenario left a different remainder on each OS and its golden could only be
+	// green on whichever one recorded it. Collapse the whole path first.
+	{regexp.MustCompile(`/(?:private/)?(?:var/folders|var/tmp|tmp)/[^\s'"]*(?:/Library/Application Support)?/ERun/desktopid\.key`), "<DESKTOP_IDENTITY>"},
 	{regexp.MustCompile(`/(?:private/)?(?:var/folders|var/tmp|tmp)/[^\s'"]+`), "<TMP>"},
 	// A separate rule for temp paths whose separators are percent-escaped,
 	// which the plain-path rule above cannot match.

--- a/erun-integration/testdata/mcp/token_without_a_desktop_identity_says_where_it_comes_from.txt
+++ b/erun-integration/testdata/mcp/token_without_a_desktop_identity_says_where_it_comes_from.txt
@@ -1,3 +1,3 @@
 audit: erun mcp token
 mcp: team/dev edge resolved to http://<LOOPBACK>:17000/mcp
-no desktop identity at <TMP> open an environment from the ERun desktop app once so the identity exists and deployed runtimes trust it
+no desktop identity at <DESKTOP_IDENTITY>; open an environment from the ERun desktop app once so the identity exists and deployed runtimes trust it

--- a/erun-ui/.golangci.yml
+++ b/erun-ui/.golangci.yml
@@ -6,8 +6,11 @@ run:
 linters:
   exclusions:
     paths:
-      - ^frontend/node_modules/
-      - ^playwright/node_modules/
+      # Third-party Go vendored by npm sits inside this module, so `./...`
+      # analyses it. Match the segment, not an anchored prefix: a finding
+      # replayed from the content-keyed cache renders the path spelling of
+      # the run that cached it, which need not start at this working tree.
+      - (^|/)node_modules/
   enable:
     - errcheck
     - govet

--- a/erun-ui/build.sh
+++ b/erun-ui/build.sh
@@ -3,7 +3,9 @@
 set -eu
 
 ORIGINAL_DIR=$(pwd)
-SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+# -P so a checkout reached through a symlink resolves to the one spelling the
+# lint gate below caches its findings against.
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd -P)
 TARGET=${1:-"$SCRIPT_DIR/bin/erun-app"}
 VERSION_FILE="$SCRIPT_DIR/../erun-devops/VERSION"
 WAILS_BIN="${WAILS_BIN:-$(go env GOPATH)/bin/wails}"
@@ -65,12 +67,12 @@ if [ -d frontend ]; then
 		# rather than in the shared `make check` the image runs.
 		#
 		# The cache is scoped to this checkout because golangci-lint keys it by
-		# module, not by working tree: a second checkout of erun-ui replays the
-		# first one's results, and those carry the *other* tree's paths. Those
-		# paths no longer match .golangci.yml's anchored node_modules
-		# exclusions, so vendored third-party Go that this gate deliberately
-		# ignores comes back as findings against a tree that does not contain
-		# it. Scoping the cache makes the gate judge what it is building.
+		# module, not by working tree: a second checkout of erun-ui would
+		# otherwise replay the first one's results against a tree that never
+		# produced them. Correctness does not rest on that alone — a replayed
+		# finding still renders the path of the run that cached it, so
+		# .golangci.yml matches excluded paths by segment instead of anchoring
+		# them to a working tree.
 		(cd "$SCRIPT_DIR" && GOLANGCI_LINT_CACHE="${GOLANGCI_LINT_CACHE:-$SCRIPT_DIR/.golangci-cache}" golangci-lint run ./...)
 	fi
 	"$YARN_BIN" build


### PR DESCRIPTION
## Summary

- `erun-ui/.golangci.yml` matches its `node_modules` exclusion by **segment** (`(^|/)node_modules/`) instead of anchoring it to the module root. golangci-lint keys its cache by package content and renders each finding's path relative to the run's cwd, so one checkout reached by two spellings — its own path and a symlink pointing at it — replays findings under paths that start *outside* the working tree, which an anchored pattern cannot match. The npm-vendored Go inside `flatted` then came back as 4 findings, `build.sh` gated on it under `set -eu`, and `erun-cli/run.sh:99` reported the result as a missing wails/yarn/node toolchain — so the desktop silently kept running the previous binary.
- `erun-ui/build.sh` and `erun-cli/run.sh` resolve `SCRIPT_DIR` with `pwd -P`, so one tree only ever has one spelling. The two halves are independent: the segment match also protects `.githooks/pre-commit`, which lints `erun-ui` out of the **shared default cache** with no scoping at all, and `pwd -P` removes the mismatch at the source for the build path.
- Refreshed the now-inaccurate cache comment in `build.sh`: per-checkout cache scoping is still worth having, but it was never what made the exclusion correct.
- **Also fixes a pre-existing red** the gate surfaced (see below).

This is #940 arriving through a different door. That fix assumed the two path spellings belonged to two *different* checkouts, which per-checkout cache scoping does defend against; here both spellings are the same checkout, so they share the scoped cache and the anchored pattern is the only thing standing between a replayed finding and the gate.

## Pre-existing red fixed in the same PR

`make integration-test` is **red on `main` on macOS** — verified by stashing this branch's changes and re-running the single scenario. `TestMCP/token_without_a_desktop_identity_says_where_it_comes_from` renders the desktop identity path, which resolves through `os.UserConfigDir()`: darwin returns `$HOME/Library/Application Support`, Linux the XDG dir. The generic temp-dir rule in `internal/normalize` stops at that space, so the scenario left a different remainder on each OS and the golden — recorded on Linux — could only ever be green there. No seam pins this the way `ERUN_HOST_OS_OVERRIDE` pins a code branch, so the fix belongs in the normalizer.

- `internal/normalize/normalize.go`: one rule ahead of the generic `<TMP>` rule collapsing the whole identity path to `<DESKTOP_IDENTITY>`, following the existing `<STATE_ROOT>` precedent.
- `internal/normalize/desktopidentity_test.go` (new): drives `Apply` with the darwin and Linux shapes so the invariant is locked on every host, not just the one that records goldens.
- `testdata/mcp/token_without_a_desktop_identity_says_where_it_comes_from.txt` — the only golden changed. `no desktop identity at <TMP> open an environment…` → `no desktop identity at <DESKTOP_IDENTITY>; open an environment…`. The production message is unchanged; the old golden had also swallowed the message's `;` into the path match, and the new token stops at `desktopid.key` so it reads correctly. The `open/intellij_gateway_*` goldens also contain `<TMP> Support/…`, but that path is built by the `ERUN_HOST_OS_OVERRIDE=darwin` branch rather than by `os.UserConfigDir()`, so it is already stable on both hosts and is deliberately left alone.

## UX Impact Review Checklist (`erun-ui/AGENTS.md`)

1. **Affected paths.** No user-triggered path in the desktop app. The diff touches the developer build wrapper, the desktop build script's lint gate, its lint config, and the integration normalizer — no component, dialog, slice, thunk, controller, or Wails-exposed method. The one operator-visible effect is that `erun app` stops failing its gate on third-party code and rebuilds the desktop as asked. Remaining items therefore do not apply.

**Playwright.** Skipped under the "zero observable surface" case (`erun-ui/AGENTS.md` § End-to-end UI tests): no frontend source and no Wails-exposed Go method changed, so no rendered surface can differ.

**Docs.** No `erun-docs` change: a pure bug fix that restores intended behaviour with no public-surface or feature change (root `AGENTS.md` § Working Rules exemption).

**Windows parity.** `erun-ui/build.sh`'s counterpart `build.ps1` documents that it deliberately skips the lint/typecheck/format gates, so it has no golangci-lint invocation to keep aligned.

**No lint rule was disabled, downgraded, or threshold-bumped** (root `AGENTS.md` § Working Rules). The `node_modules` exclusion already existed as the scope boundary for npm-vendored third-party Go; this only makes its scope independent of how the path is spelled. `(^|/)node_modules/` can only ever match a path with a `node_modules` segment, and no first-party erun Go lives under one.

## Test plan

- **The original failure, reproduced and fixed.** With the cache populated from the physical path and the gate then run through a symlinked spelling of the same tree: the old anchored config reproduces the report verbatim (`../../erun-1003/erun-ui/frontend/node_modules/flatted/…`, `4 issues: gocyclo 2, govet 2`); this branch's config returns `0 issues.` under identical conditions.
- **End-to-end.** `erun app` driven through a symlink to the checkout (`<link>/erun-cli/run.sh app --help`) runs the whole flow — typecheck, eslint, prettier, frontend tests, `0 issues.`, vite build, desktop binary rebuilt — and exits 0. This is the flow that previously stopped at "skipping desktop rebuild".
- `erun-ui/build.sh` (full desktop gate, direct path): green, desktop binary produced.
- `make integration-test`: green, coverage **76.2% ≥ 75.7%**.
- `make lint`: 0 issues across `erun-common`, `erun-cli`, `erun-mcp`, `erun-integration`, `erun-backend/erun-backend-api`.
- `go test ./...` in `erun-ui`: ok.
- `go test ./internal/normalize/`: the new host-independence test passes on darwin; it drives the transform directly, so it runs on every OS.

Not verified: the Linux/Windows renderings of the normalizer rule were exercised through the unit test's literal path shapes rather than on those hosts.

Closes #1003