### PR TITLE
Resolve the shipped skills in the layout the desktop runs from

### DIFF
--- a/Formula/erun.rb
+++ b/Formula/erun.rb
@@ -58,7 +58,10 @@ class Erun < Formula
       system "go", "build",
              "-trimpath",
              "-tags", "desktop,production",
-             "-ldflags", "-s -w -X github.com/sophium/erun/erun-ui.buildVersion=#{version}",
+             # `main.`, not the module path: erun-app's build vars are declared
+             # in package main, and -X against a path no package declares is
+             # dropped in silence, leaving the binary reporting "dev".
+             "-ldflags", "-s -w -X main.buildVersion=#{version}",
              "-o", bin/"erun-app",
              "."
     end

--- a/bucket/erun.json
+++ b/bucket/erun.json
@@ -32,7 +32,7 @@
       "Pop-Location",
       "Remove-Item Env:CGO_ENABLED -ErrorAction SilentlyContinue",
       "if (-not (Get-Command gcc -ErrorAction SilentlyContinue)) { throw 'building erun-app.exe requires a C compiler such as MinGW for the Wails CGO build' }",
-      "$appLdflags = \"-s -w -H windowsgui -X github.com/sophium/erun/erun-ui.buildVersion=$version\"",
+      "$appLdflags = \"-s -w -H windowsgui -X main.buildVersion=$version\"",
       "Push-Location \"$dir\\erun-ui\"",
       "$wailsVersion = go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2",
       "if ($LASTEXITCODE -ne 0) { throw 'failed to resolve Wails version' }",

--- a/erun-docs/docs/agent-reference/skills-spec.md
+++ b/erun-docs/docs/agent-reference/skills-spec.md
@@ -91,7 +91,17 @@ The install both **installs a skill when absent and refreshes it when the baked 
 
 ### Host orchestrator (desktop)
 
-The desktop app installs the same canonical skills into the host's `~/.claude/skills/<name>/` for host-side orchestrator sessions, using the identical marker-based install-or-refresh — so a host orchestrator tracks the latest skill on each launch while preserving any host-side edits. It also writes a `SessionStart` hook into the shared orchestrators workspace's `.claude/settings.json` that **injects the operating contract** — it prints the workspace `CLAUDE.md` to the session on every session start and reopen (Claude Code's `SessionStart` fires on both a new session and a `--continue`/`--resume`) — so the contract is always already in context rather than a [`erun-orchestrate`](#erun-orchestrate) skill the model is merely asked to load and could skip. The hook prints the file directly (plain stdout, so no `additionalContext` size cap), falling back to a short directive if the `CLAUDE.md` is ever missing.
+The desktop app installs the same canonical skills into the host's `~/.claude/skills/<name>/` for host-side orchestrator sessions, using the identical marker-based install-or-refresh — so a host orchestrator tracks the latest skill on each launch while preserving any host-side edits.
+
+The source it installs from resolves in this order, first match wins:
+
+1. `ERUN_SKILLS_DIR`, if set — taken **verbatim, with no fallback**, so pointing it at an empty directory installs nothing rather than silently resolving something else.
+2. The `erun-skills/skills` directory of the checkout the desktop binary was built from, stamped into the binary by `erun-ui/build.sh` / `build.ps1`. This is what keeps a desktop that runs from outside its checkout — the usual case, since the built bundle is copied elsewhere to run — installing the skills its own build ships.
+3. `erun-skills/skills` found by walking up (max 8 levels) from the running executable, for a binary that was built without the stamp but sits inside a checkout.
+
+If none resolves, the orchestrator still launches and the skills already installed are left alone — but the condition is **reported, not silent**: a warning notification naming the checkout that was expected, where the executable looked, and the two recoveries (set `ERUN_SKILLS_DIR`, or rebuild with `erun-ui/build.sh` / `build.ps1`) is posted once per desktop run, and every occurrence is logged. A build that silently stopped refreshing skills is indistinguishable from one where the skill had not changed. A desktop installed from a package manager carries no checkout, so `ERUN_SKILLS_DIR` is its only source.
+
+The desktop also writes a `SessionStart` hook into the shared orchestrators workspace's `.claude/settings.json` that **injects the operating contract** — it prints the workspace `CLAUDE.md` to the session on every session start and reopen (Claude Code's `SessionStart` fires on both a new session and a `--continue`/`--resume`) — so the contract is always already in context rather than a [`erun-orchestrate`](#erun-orchestrate) skill the model is merely asked to load and could skip. The hook prints the file directly (plain stdout, so no `additionalContext` size cap), falling back to a short directive if the `CLAUDE.md` is ever missing.
 
 ### Laptop (plugin marketplace)
 

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -125,10 +125,14 @@ type App struct {
 	// forwardRepairs tracks, per environment, the bounded repair episode for a
 	// port-forward that holds its local port while its edge answers nothing.
 	// See environment_forward_repair.go.
-	forwardRepairs            map[string]forwardRepairEpisode
-	busyEnvs                  map[string]int
-	workspaceSyncs            map[string]*workspaceSyncWorker
-	orchestrators             map[string]*orchestratorSession
+	forwardRepairs map[string]forwardRepairEpisode
+	busyEnvs       map[string]int
+	workspaceSyncs map[string]*workspaceSyncWorker
+	orchestrators  map[string]*orchestratorSession
+	// skillsSourceReported latches the one warning a run posts when the shipped
+	// skills cannot be resolved. The condition is a property of this build, so
+	// restating it on every orchestrator launch would be noise.
+	skillsSourceReported      bool
 	credentialRefreshers      map[string]*cloudCredentialsRefresher
 	activityQueue             *activityQueueStore
 	activityStatusPoller      func(activityQueueEntry)

--- a/erun-ui/build.ps1
+++ b/erun-ui/build.ps1
@@ -85,10 +85,20 @@ try {
 
     # --- desktop binary ----------------------------------------------------
     Write-Host ">> building $([System.IO.Path]::GetFileName($Target)) ($buildVersion) ..."
+    # The skills stamp mirrors build.sh: the desktop installs these for a host
+    # orchestrator, and the binary is routinely run from outside the checkout it
+    # was built in, where no source tree sits above it. Single-quoted so a
+    # checkout path with spaces survives -ldflags splitting.
+    #
+    # `main.`, not the module path — see the same note in build.sh. A -X path no
+    # package declares is dropped in silence, so the wrong prefix stamps nothing
+    # and leaves the binary looking correctly built.
+    $skillsSource = Join-Path $RepoRoot "erun-skills\skills"
     $ldflags = "-s -w -H windowsgui " +
-               "-X github.com/sophium/erun/erun-ui.buildVersion=$buildVersion " +
-               "-X github.com/sophium/erun/erun-ui.buildCommit=$buildCommit " +
-               "-X github.com/sophium/erun/erun-ui.buildDate=$buildDate"
+               "-X main.buildVersion=$buildVersion " +
+               "-X main.buildCommit=$buildCommit " +
+               "-X main.buildDate=$buildDate " +
+               "-X 'main.buildSkillsSource=$skillsSource'"
     go build -trimpath -tags "desktop,production" -ldflags $ldflags -o $Target .
     if ($LASTEXITCODE -ne 0) { throw "failed to build erun-app.exe" }
 } finally { Pop-Location }

--- a/erun-ui/build.sh
+++ b/erun-ui/build.sh
@@ -101,7 +101,21 @@ if git -C "$SCRIPT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 	fi
 fi
 
-LDFLAGS="-s -w -X github.com/sophium/erun/erun-ui.buildVersion=${BUILD_VERSION} -X github.com/sophium/erun/erun-ui.buildCommit=${BUILD_COMMIT} -X github.com/sophium/erun/erun-ui.buildDate=${BUILD_DATE}"
+# Where this build's skills come from. The desktop installs them for a host
+# orchestrator, and the binary it runs is routinely copied out of the checkout
+# (a dev build runs from ~/.cache/erun), so nothing above the running bundle
+# names a source tree. Stamping the path is what keeps an installed skill
+# tracking the checkout this binary was built from; on a machine that does not
+# carry that checkout the resolution falls back to the layout it runs in.
+# Single-quoted so a checkout path containing spaces survives -ldflags splitting.
+SKILLS_SOURCE="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd -P)/erun-skills/skills"
+
+# `main.`, not the module path. -X addresses a symbol by package path, and these
+# vars are declared in package main, whose symbols the compiler names `main.x`
+# whatever the module is called. A path nothing declares is not an error — the
+# linker drops it in silence and the binary keeps its default, which is how the
+# desktop shipped build info and a skills source it never actually carried.
+LDFLAGS="-s -w -X main.buildVersion=${BUILD_VERSION} -X main.buildCommit=${BUILD_COMMIT} -X main.buildDate=${BUILD_DATE} -X 'main.buildSkillsSource=${SKILLS_SOURCE}'"
 if [ "$TARGET_GOOS" = "windows" ]; then
 	LDFLAGS="${LDFLAGS} -H windowsgui"
 fi

--- a/erun-ui/buildstamp_test.go
+++ b/erun-ui/buildstamp_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// desktopModulePath is erun-app's module path, which is exactly what a -X target
+// for these vars must NOT be — see the guard below.
+const desktopModulePath = "github.com/sophium/erun/erun-ui"
+
+// stampTargets are the linker-settable build vars. Referencing each var here is
+// deliberate: renaming one without updating this map stops compiling, so the
+// guard cannot quietly start checking a name nothing declares.
+var stampTargets = map[string]*string{
+	"buildVersion":      &buildVersion,
+	"buildCommit":       &buildCommit,
+	"buildDate":         &buildDate,
+	"buildSkillsSource": &buildSkillsSource,
+}
+
+// buildScriptsProducingTheDesktop is every script that builds erun-app,
+// package-manager formulae included: a stamp only the module's own scripts get
+// right still leaves every installed desktop unstamped.
+var buildScriptsProducingTheDesktop = []string{
+	"build.sh",
+	"build.ps1",
+	filepath.Join("..", "Formula", "erun.rb"),
+	filepath.Join("..", "bucket", "erun.json"),
+}
+
+// TestBuildScriptsStampSymbolsThisPackageDeclares guards the one failure mode a
+// linker stamp has: -X addresses a symbol by package path, and a path no package
+// declares is dropped in silence rather than refused. These vars live in package
+// main — whose symbols are named `main.x` whatever the module is called — so a
+// module-path prefix builds a binary that looks correctly stamped and carries
+// nothing, which is how the desktop shipped a skills source it never had.
+func TestBuildScriptsStampSymbolsThisPackageDeclares(t *testing.T) {
+	for _, script := range buildScriptsProducingTheDesktop {
+		body := readBuildScript(t, script)
+		for name := range stampTargets {
+			if strings.Contains(body, desktopModulePath+"."+name+"=") {
+				t.Errorf("%s stamps %s.%s; erun-app declares it in package main, so this stamps nothing", script, desktopModulePath, name)
+			}
+		}
+		if !strings.Contains(body, "main.buildVersion=") {
+			t.Errorf("%s builds erun-app without stamping its version", script)
+		}
+	}
+}
+
+// TestDesktopBuildScriptsStampTheSkillsSource keeps the resolution the desktop
+// depends on wired at both ends. The stamp is the only thing that names this
+// build's skills once the bundle has been copied out of its checkout, so a
+// script that drops it silently returns the desktop to installing nothing. Only
+// the module's own scripts: a package-manager build runs in a source tree it
+// then deletes, so a path stamped there would name nothing on the target.
+func TestDesktopBuildScriptsStampTheSkillsSource(t *testing.T) {
+	for _, script := range []string{"build.sh", "build.ps1"} {
+		if !strings.Contains(readBuildScript(t, script), "main.buildSkillsSource=") {
+			t.Errorf("%s does not stamp main.buildSkillsSource; a desktop built by it installs no skills once it runs outside its checkout", script)
+		}
+	}
+}
+
+func readBuildScript(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(body)
+}

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -256,9 +256,10 @@ func (a *App) ensureOrchestratorWorkspace() (string, error) {
 	// Make every erun skill available to the orchestrator by default — the
 	// operator must never have to install them by hand. Best-effort: a missing
 	// skills source (e.g. a distributed binary with no repo checkout) must not
-	// block the orchestrator from launching.
+	// block the orchestrator from launching, but it is reported rather than
+	// passed over in silence.
 	if err := ensureOrchestratorSkills(); err != nil {
-		fmt.Fprintf(os.Stderr, "erun: could not install orchestrator skills: %v\n", err)
+		a.reportSkillsNotInstalled(err)
 	}
 	// Inject the operating contract on every session start and reopen via a
 	// SessionStart hook, so an orchestrator always operates under its current
@@ -271,25 +272,86 @@ func (a *App) ensureOrchestratorWorkspace() (string, error) {
 	return dir, nil
 }
 
+// buildSkillsSource is the erun-skills/skills directory of the checkout this
+// binary was built from, stamped in by the desktop build scripts. It is what
+// lets a desktop that runs from outside its checkout still install the skills
+// its own build shipped: the bundle is routinely copied away from the source
+// tree (a dev build runs from ~/.cache/erun), and nothing above it there names a
+// checkout. Empty for a build that did not stamp it, and naming a path that
+// exists only on the machine that produced the binary — both fall through to the
+// layout the executable runs in.
+var buildSkillsSource = ""
+
+// noSkillsSourceError reports that no shipped skills resolved at all, naming
+// each layout that was tried. The install stays best-effort so a binary with no
+// source still launches, but the condition has to be legible: a build that
+// quietly stops honouring its own install contract is indistinguishable from one
+// where the skill simply had not changed, so both the author of a skill change
+// and its reader believe it landed.
+type noSkillsSourceError struct {
+	// stamped is the build's own checkout, empty when the binary carries no stamp.
+	stamped string
+	// exeDir is where the running binary lives, empty when it cannot be resolved.
+	exeDir string
+}
+
+func (e *noSkillsSourceError) Error() string {
+	built := "this build records no source checkout"
+	if e.stamped != "" {
+		built = "its build checkout " + e.stamped + " is not on this machine"
+	}
+	near := "the executable's own directory"
+	if e.exeDir != "" {
+		near = e.exeDir
+	}
+	return "no erun skills source resolved: " + built + ", and no erun-skills/skills sits above " + near
+}
+
 // hostSkillsSource resolves the directory holding the canonical erun skills
-// (erun-skills/skills/<name>/) on the host. ERUN_SKILLS_DIR overrides it (tests
-// and non-standard installs); otherwise it walks up from the erun-app executable
-// to the erun repo root, since erun-app is built from source there
-// (erun-cli/bin/erun-app). Returns "" when no source can be found, so the caller
-// skips installation instead of failing.
-func hostSkillsSource() string {
+// (erun-skills/skills/<name>/) on the host, or reports every layout it tried
+// when nothing resolves.
+//
+// ERUN_SKILLS_DIR is an exact override: it is taken verbatim with no fallback,
+// so pointing the desktop at a deliberately empty directory means exactly that.
+// Otherwise the checkout the binary was built from wins over the directory it
+// runs from, because that checkout holds the skills this build ships and — unlike
+// a walk up from the executable — it still names them wherever the bundle was
+// copied to. The walk remains for a binary built without the stamp that does sit
+// inside a checkout or a packaged layout carrying one.
+func hostSkillsSource() (string, error) {
 	if override := strings.TrimSpace(os.Getenv("ERUN_SKILLS_DIR")); override != "" {
-		return override
+		return override, nil
 	}
-	exe, err := os.Executable()
+	stamped := strings.TrimSpace(buildSkillsSource)
+	if isExistingDir(stamped) {
+		return stamped, nil
+	}
+	found, exeDir := skillsSourceNearExecutable()
+	if found != "" {
+		return found, nil
+	}
+	return "", &noSkillsSourceError{stamped: stamped, exeDir: exeDir}
+}
+
+// runningExecutable resolves the binary this process runs as. A seam because
+// the answer below depends on where that binary sits, and a test about a
+// particular layout cannot choose where the test binary was written.
+var runningExecutable = os.Executable
+
+// skillsSourceNearExecutable walks up from the running binary looking for an
+// erun-skills/skills directory, which is how one that sits inside a checkout
+// finds its skills. It also returns where it started, so an unresolved source
+// can say where it looked.
+func skillsSourceNearExecutable() (string, string) {
+	exe, err := runningExecutable()
 	if err != nil {
-		return ""
+		return "", ""
 	}
-	dir := filepath.Dir(exe)
+	exeDir := filepath.Dir(exe)
+	dir := exeDir
 	for i := 0; i < 8; i++ {
-		cand := filepath.Join(dir, "erun-skills", "skills")
-		if info, statErr := os.Stat(cand); statErr == nil && info.IsDir() {
-			return cand
+		if cand := filepath.Join(dir, "erun-skills", "skills"); isExistingDir(cand) {
+			return cand, exeDir
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
@@ -297,7 +359,42 @@ func hostSkillsSource() string {
 		}
 		dir = parent
 	}
-	return ""
+	return "", exeDir
+}
+
+func isExistingDir(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// reportSkillsNotInstalled makes a skills install that did not run observable.
+// The warning goes where the operator acts, once per run — the condition belongs
+// to the build rather than to any one orchestrator launch — while the log line is
+// written every time so a later diagnosis still finds it.
+func (a *App) reportSkillsNotInstalled(cause error) {
+	log.Printf("erun-app: orchestrator skills not installed: %v", cause)
+	a.mu.Lock()
+	reported := a.skillsSourceReported
+	a.skillsSourceReported = true
+	a.mu.Unlock()
+	if !reported {
+		a.emitAppNotification("warning", orchestratorSkillsNotInstalledNotice(cause))
+	}
+}
+
+// orchestratorSkillsNotInstalledNotice states what the operator loses — an
+// installed skill that no longer tracks its source — and the two ways to put it
+// back, since the launch itself succeeds and would otherwise look untroubled.
+// ERUN_SKILLS_DIR leads because it is the recovery that works everywhere: a
+// desktop installed from a package manager carries no checkout to rebuild from.
+func orchestratorSkillsNotInstalledNotice(cause error) string {
+	return "Orchestrator skills were not installed or refreshed: " + cause.Error() +
+		". The orchestrator still starts, but its skills stay at whatever is already in ~/.claude/skills. " +
+		"Set ERUN_SKILLS_DIR to an erun-skills/skills directory to install from, " +
+		"or rebuild the desktop from its checkout with erun-ui/build.sh (build.ps1 on Windows)."
 }
 
 // orchestratorSkillMarker records, per installed skill, the sha256 of the
@@ -312,20 +409,23 @@ const orchestratorSkillMarker = ".erun-skill-baked-sha256"
 // shipped source changed — so an orchestrator tracks the latest skill instead of
 // freezing at first install — while preserving any in-place operator edits via a
 // per-skill marker. Mirrors the pod entrypoint's install-or-refresh so host and
-// pod treat skill provenance identically. Returns nil when no skills source is
-// resolvable so a distributed binary still launches cleanly.
+// pod treat skill provenance identically. An unresolvable source is returned as
+// an error rather than skipped silently: the caller keeps launching, and says so.
 func ensureOrchestratorSkills() error {
-	root := hostSkillsSource()
-	if root == "" {
-		return nil
+	root, err := hostSkillsSource()
+	if err != nil {
+		return err
 	}
 	entries, err := os.ReadDir(root)
 	if err != nil {
-		return nil
+		return fmt.Errorf("read skills source %s: %w", root, err)
 	}
-	home, err := os.UserHomeDir()
-	if err != nil || strings.TrimSpace(home) == "" {
-		return nil
+	home, homeErr := os.UserHomeDir()
+	if strings.TrimSpace(home) == "" {
+		if homeErr == nil {
+			homeErr = errors.New("it resolved empty")
+		}
+		return fmt.Errorf("resolve the home directory to install skills into: %w", homeErr)
 	}
 	destRoot := filepath.Join(home, ".claude", "skills")
 	for _, entry := range entries {

--- a/erun-ui/orchestrator_test.go
+++ b/erun-ui/orchestrator_test.go
@@ -47,6 +47,11 @@ func orchestratorTestAppWithLocalRepo(t *testing.T) (*App, string) {
 	home := t.TempDir()
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("HOME", home)
+	// Resolve the shipped skills to an empty directory by default, so a test
+	// about something else never trips over the report a desktop posts when no
+	// skills source resolves at all. Tests that are about the skills stage their
+	// own source AFTER calling this.
+	t.Setenv("ERUN_SKILLS_DIR", t.TempDir())
 	laptopRepo := t.TempDir()
 	return NewApp(erunUIDeps{
 		store: newOrchestratorStubStore(laptopRepo),
@@ -436,6 +441,9 @@ func TestOrchestratorWorkspaceIsSharedRootWithOneClaudeMd(t *testing.T) {
 }
 
 func TestOrchestratorSkillsInstalledByDefault(t *testing.T) {
+	app := orchestratorTestApp(t) // confines $HOME to a temp dir
+	defer app.shutdown(context.Background())
+
 	// Fixture skills source standing in for the repo's erun-skills/skills.
 	srcRoot := t.TempDir()
 	for _, name := range []string{"erun-orchestrate", "erun-file-issue"} {
@@ -448,9 +456,6 @@ func TestOrchestratorSkillsInstalledByDefault(t *testing.T) {
 		}
 	}
 	t.Setenv("ERUN_SKILLS_DIR", srcRoot)
-
-	app := orchestratorTestApp(t) // confines $HOME to a temp dir
-	defer app.shutdown(context.Background())
 
 	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
 		t.Fatalf("ensureOrchestratorWorkspace failed: %v", err)
@@ -503,9 +508,9 @@ func singleSkillSource(t *testing.T, body string) string {
 }
 
 func TestOrchestratorSkillsRefreshWhenSourceChanges(t *testing.T) {
-	srcMD := singleSkillSource(t, "# v1\n")
 	app := orchestratorTestApp(t)
 	defer app.shutdown(context.Background())
+	srcMD := singleSkillSource(t, "# v1\n")
 
 	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
 		t.Fatalf("first ensureOrchestratorWorkspace: %v", err)
@@ -528,9 +533,9 @@ func TestOrchestratorSkillsRefreshWhenSourceChanges(t *testing.T) {
 }
 
 func TestOrchestratorSkillsPreserveEditAcrossSourceChange(t *testing.T) {
-	srcMD := singleSkillSource(t, "# v1\n")
 	app := orchestratorTestApp(t)
 	defer app.shutdown(context.Background())
+	srcMD := singleSkillSource(t, "# v1\n")
 
 	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
 		t.Fatalf("first ensureOrchestratorWorkspace: %v", err)
@@ -550,6 +555,265 @@ func TestOrchestratorSkillsPreserveEditAcrossSourceChange(t *testing.T) {
 	}
 	if data, _ := os.ReadFile(installed); string(data) != "# operator edit\n" {
 		t.Fatalf("expected operator edit preserved across a source change, got %q", data)
+	}
+}
+
+// clearSkillsOverride removes the exact-source override so a test exercises the
+// resolution a desktop actually runs with.
+func clearSkillsOverride(t *testing.T) {
+	t.Helper()
+	t.Setenv("ERUN_SKILLS_DIR", "")
+}
+
+// runFromBareLayout puts the running binary where the desktop actually runs
+// from: a directory with no checkout above it, so nothing but the build stamp
+// can name the skills this build ships. Pinned rather than inherited because a
+// test binary's own location is not the test's to choose — one compiled into the
+// checkout would otherwise resolve the repo's own skills and quietly stop
+// exercising the layout the test is about.
+func runFromBareLayout(t *testing.T) string {
+	t.Helper()
+	exeDir := filepath.Join(t.TempDir(), "dev-bin")
+	if err := os.MkdirAll(exeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	exe := filepath.Join(exeDir, "erun-app")
+	previous := runningExecutable
+	runningExecutable = func() (string, error) { return exe, nil }
+	t.Cleanup(func() { runningExecutable = previous })
+	return exeDir
+}
+
+// stampedSkillsCheckout stands in for the checkout a desktop build was produced
+// from, in the layout that motivated the stamp: the running binary sits nowhere
+// near a source tree, so the walk up from the executable resolves nothing and
+// only the build stamp names the skills this build shipped. Returns the source
+// SKILL.md.
+func stampedSkillsCheckout(t *testing.T, body string) string {
+	t.Helper()
+	clearSkillsOverride(t)
+	runFromBareLayout(t)
+	skillsRoot := filepath.Join(t.TempDir(), "checkout", "erun-skills", "skills")
+	skillDir := filepath.Join(skillsRoot, "erun-orchestrate")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	srcMD := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(srcMD, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stampSkillsSource(t, skillsRoot)
+	return srcMD
+}
+
+// stampSkillsSource sets the build stamp for one test and restores it after.
+func stampSkillsSource(t *testing.T, dir string) {
+	t.Helper()
+	previous := buildSkillsSource
+	buildSkillsSource = dir
+	t.Cleanup(func() { buildSkillsSource = previous })
+}
+
+// orchestratorTestAppWithEmits captures the frontend events the app posts, so a
+// test can assert what the operator is actually told.
+func orchestratorTestAppWithEmits(t *testing.T) (*App, *capturedEmits) {
+	t.Helper()
+	app := orchestratorTestApp(t)
+	emits := newCapturedEmits()
+	app.SetEmitter(emits.fn())
+	return app, emits
+}
+
+// TestOrchestratorSkillsRefreshFromBuildStampedCheckout covers the layout the
+// desktop is actually built and run from: the bundle is copied out of its
+// checkout, so nothing above the running binary names a source tree and only the
+// build stamp resolves one. An installed copy erun itself wrote must track that
+// source instead of freezing at whatever landed on first install.
+func TestOrchestratorSkillsRefreshFromBuildStampedCheckout(t *testing.T) {
+	app, emits := orchestratorTestAppWithEmits(t)
+	defer app.shutdown(context.Background())
+	srcMD := stampedSkillsCheckout(t, "# v1\n")
+
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("first ensureOrchestratorWorkspace: %v", err)
+	}
+	installed := installedOrchestrateSkill(t)
+	if data, _ := os.ReadFile(installed); string(data) != "# v1\n" {
+		t.Fatalf("expected the stamped checkout's skill installed, got %q", data)
+	}
+
+	// The source changes and the desktop is restarted: the untouched install
+	// must follow it.
+	if err := os.WriteFile(srcMD, []byte("# v2 newer\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("second ensureOrchestratorWorkspace: %v", err)
+	}
+	if data, _ := os.ReadFile(installed); string(data) != "# v2 newer\n" {
+		t.Fatalf("expected the untouched install refreshed from the stamped checkout, got %q", data)
+	}
+	// The marker moves with the refresh, so the next launch can still tell this
+	// untouched copy from an edited one.
+	marker, err := os.ReadFile(filepath.Join(filepath.Dir(installed), orchestratorSkillMarker))
+	if err != nil {
+		t.Fatalf("read skill marker: %v", err)
+	}
+	want, err := fileSHA256(srcMD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(marker)) != want {
+		t.Fatalf("marker = %q, want the refreshed source sha %q", strings.TrimSpace(string(marker)), want)
+	}
+	if notes := emits.events(appNotificationEvent); len(notes) != 0 {
+		t.Fatalf("a resolved source must report nothing, got %+v", notes)
+	}
+}
+
+// TestOrchestratorSkillsPreserveEditFromBuildStampedCheckout keeps the
+// operator's copy theirs in that same layout: resolving a source is not licence
+// to overwrite a skill edited in place.
+func TestOrchestratorSkillsPreserveEditFromBuildStampedCheckout(t *testing.T) {
+	app := orchestratorTestApp(t)
+	defer app.shutdown(context.Background())
+	srcMD := stampedSkillsCheckout(t, "# v1\n")
+
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("first ensureOrchestratorWorkspace: %v", err)
+	}
+	installed := installedOrchestrateSkill(t)
+	if err := os.WriteFile(installed, []byte("# operator edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(srcMD, []byte("# v2 newer\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("second ensureOrchestratorWorkspace: %v", err)
+	}
+	if data, _ := os.ReadFile(installed); string(data) != "# operator edit\n" {
+		t.Fatalf("expected the operator's edit preserved, got %q", data)
+	}
+}
+
+// TestOrchestratorSkillsReportUnresolvableSource locks the second half of the
+// contract: when nothing resolves, the launch still succeeds and the operator is
+// told once — a build that silently stops installing skills reads exactly like
+// one where the skill had not changed.
+func TestOrchestratorSkillsReportUnresolvableSource(t *testing.T) {
+	app, emits := orchestratorTestAppWithEmits(t)
+	defer app.shutdown(context.Background())
+
+	clearSkillsOverride(t)
+	exeDir := runFromBareLayout(t)
+	// A checkout that is not on this machine, which is what a binary built
+	// elsewhere carries.
+	moved := filepath.Join(t.TempDir(), "checkout-that-moved", "erun-skills", "skills")
+	stampSkillsSource(t, moved)
+
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("the orchestrator must still launch cleanly: %v", err)
+	}
+	notes := emits.events(appNotificationEvent)
+	if len(notes) != 1 {
+		t.Fatalf("expected exactly one report, got %+v", notes)
+	}
+	payload, ok := notes[0].(appNotificationPayload)
+	if !ok {
+		t.Fatalf("unexpected payload type: %T", notes[0])
+	}
+	if payload.Kind != "warning" {
+		t.Fatalf("kind = %q, want warning", payload.Kind)
+	}
+	// The report has to be actionable on its own: what the build expected, where
+	// the running binary looked instead, and both recoveries.
+	for _, want := range []string{moved, exeDir, "ERUN_SKILLS_DIR", "build.sh"} {
+		if !strings.Contains(payload.Message, want) {
+			t.Fatalf("report does not name %q:\n%s", want, payload.Message)
+		}
+	}
+	home, _ := os.UserHomeDir()
+	if _, err := os.Stat(filepath.Join(home, ".claude", "skills", "erun-orchestrate")); !os.IsNotExist(err) {
+		t.Fatalf("nothing resolvable must install nothing, stat err = %v", err)
+	}
+	// Once: the condition belongs to the build, so a second launch repeats it in
+	// the log only.
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("second ensureOrchestratorWorkspace: %v", err)
+	}
+	if got := emits.events(appNotificationEvent); len(got) != 1 {
+		t.Fatalf("expected the report said once, got %+v", got)
+	}
+}
+
+// TestHostSkillsSourceOverrideWinsOverBuildStamp keeps ERUN_SKILLS_DIR meaning
+// "use exactly this": it beats the build stamp, and an empty directory installs
+// nothing rather than falling back to a source the caller did not name.
+func TestHostSkillsSourceOverrideWinsOverBuildStamp(t *testing.T) {
+	app, emits := orchestratorTestAppWithEmits(t)
+	defer app.shutdown(context.Background())
+
+	stampedSkillsCheckout(t, "# stamped\n")
+	override := t.TempDir()
+	t.Setenv("ERUN_SKILLS_DIR", override)
+
+	resolved, err := hostSkillsSource()
+	if err != nil {
+		t.Fatalf("an override must resolve: %v", err)
+	}
+	if resolved != override {
+		t.Fatalf("source = %q, want the override %q", resolved, override)
+	}
+
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("ensureOrchestratorWorkspace: %v", err)
+	}
+	home, _ := os.UserHomeDir()
+	if _, err := os.Stat(filepath.Join(home, ".claude", "skills", "erun-orchestrate")); !os.IsNotExist(err) {
+		t.Fatalf("an empty override must install nothing, stat err = %v", err)
+	}
+	if notes := emits.events(appNotificationEvent); len(notes) != 0 {
+		t.Fatalf("an honoured override is not a failure to report, got %+v", notes)
+	}
+}
+
+// TestOrchestratorSkillsResolveFromCheckoutAroundExecutable keeps the layout
+// that already worked working: a binary sitting inside a checkout resolves that
+// checkout's skills even with no build stamp, which is the case a packaged
+// tree — or a binary built by anything other than these scripts — relies on.
+func TestOrchestratorSkillsResolveFromCheckoutAroundExecutable(t *testing.T) {
+	app, emits := orchestratorTestAppWithEmits(t)
+	defer app.shutdown(context.Background())
+
+	clearSkillsOverride(t)
+	stampSkillsSource(t, "")
+
+	checkout := t.TempDir()
+	skillDir := filepath.Join(checkout, "erun-skills", "skills", "erun-orchestrate")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# from the checkout\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Two levels down, the way a built binary sits under its checkout.
+	exeDir := filepath.Join(checkout, "erun-ui", "bin")
+	if err := os.MkdirAll(exeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	previous := runningExecutable
+	runningExecutable = func() (string, error) { return filepath.Join(exeDir, "erun-app"), nil }
+	t.Cleanup(func() { runningExecutable = previous })
+
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("ensureOrchestratorWorkspace: %v", err)
+	}
+	if data, _ := os.ReadFile(installedOrchestrateSkill(t)); string(data) != "# from the checkout\n" {
+		t.Fatalf("expected the surrounding checkout's skill installed, got %q", data)
+	}
+	if notes := emits.events(appNotificationEvent); len(notes) != 0 {
+		t.Fatalf("a resolved source must report nothing, got %+v", notes)
 	}
 }
 

--- a/erun-ui/playwright/tests/app-notification.spec.ts
+++ b/erun-ui/playwright/tests/app-notification.spec.ts
@@ -86,6 +86,45 @@ test.describe('app-notification toast', () => {
     await expect(pill.getByRole('button', { name: /copy/i })).toBeVisible();
   });
 
+  test('skills-not-installed warning persists and names the recovery', async ({
+    app: _app,
+    page,
+  }) => {
+    // A desktop that cannot resolve the skills it ships stops refreshing the
+    // installed copies, and the launch itself looks untroubled — so the warning
+    // has to stay readable until the operator acts on it, recovery included.
+    // The emit is owned by TestOrchestratorSkillsReportUnresolvableSource (Go):
+    // it fires while an orchestrator's workspace is prepared, which needs a real
+    // AI harness and PTY that this harness deliberately lacks.
+    const message =
+      'Orchestrator skills were not installed or refreshed: no erun skills source resolved: ' +
+      'its build checkout /Users/op/src/erun/erun-skills/skills is not on this machine, and no ' +
+      'erun-skills/skills sits above /Users/op/.cache/erun/dev-bin/ERun.app/Contents/MacOS. ' +
+      'The orchestrator still starts, but its skills stay at whatever is already in ~/.claude/skills. ' +
+      'Set ERUN_SKILLS_DIR to an erun-skills/skills directory to install from, ' +
+      'or rebuild the desktop from its checkout with erun-ui/build.sh (build.ps1 on Windows).';
+    await page.clock.install();
+    await page.evaluate(
+      (payload) => {
+        const runtime = (
+          window as unknown as {
+            runtime: { EventsEmit: (n: string, ...a: unknown[]) => void };
+          }
+        ).runtime;
+        runtime.EventsEmit('app-notification', payload);
+      },
+      { kind: 'warning', message },
+    );
+
+    const pill = page.getByRole('status').filter({ hasText: 'Orchestrator skills were not' });
+    await expect(pill).toBeVisible();
+
+    await page.clock.fastForward(5_000);
+    await expect(pill).toBeVisible();
+    await expect(pill).toContainText('Set ERUN_SKILLS_DIR');
+    await expect(pill.getByRole('button', { name: /copy/i })).toBeVisible();
+  });
+
   test('payload with empty message is ignored', async ({ app: _app, page }) => {
     // The titlebar idle-status widget also carries role=status when an env with
     // a managed cloud context is active, so an ignored payload can't be checked


### PR DESCRIPTION
## The bug

`hostSkillsSource` resolved the shipped skills only by walking up from `os.Executable()`. The desktop runs from a bundle copied out of its checkout (`~/.cache/erun/dev-bin/ERun.app/Contents/MacOS/erun-app`), where none of the eight candidates exist and nothing above the binary names a source tree. With `ERUN_SKILLS_DIR` unset, `ensureOrchestratorSkills` returned before reading a single skill: the copies in `~/.claude/skills` froze at whatever landed on first install, and no source change could ever reach the operator. Silently — which reads exactly like a skill that had not changed, so both the author of a skill change and its reader believe it landed.

## The fix

The desktop build stamps the checkout it was built from into the binary, and that stamp is what names this build's skills wherever the bundle was copied to. Resolution order, first match wins:

1. **`ERUN_SKILLS_DIR`** — verbatim, no fallback, so pointing it at a deliberately empty directory installs nothing rather than resolving something the caller did not name.
2. **The build stamp** — the `erun-skills/skills` of the checkout `build.sh` / `build.ps1` built from. This is what fixes the reported layout.
3. **The walk up from the executable** — unchanged, so a binary that does sit inside a checkout (or a packaged tree carrying one) keeps working.

An unresolvable source is no longer a silent `nil`. It is logged on every occurrence and posted **once per run** as a warning naming what the build expected, where the running binary looked instead, and both recoveries. The launch still succeeds, and an operator-edited copy is still left alone — a copy whose sha differs from its marker is the operator's.

## A pre-existing defect the stamp exposed

The stamp did not land at first, and the reason was general: every `-X` for `erun-app` named the **module path** (`github.com/sophium/erun/erun-ui.buildVersion`), but those vars are declared in package `main`, whose symbols the linker names `main.x`. A `-X` path no package declares is dropped in silence rather than refused, so `buildVersion`, `buildCommit` and `buildDate` have never been stamped either — the binary looked correctly built and carried its defaults. (`erun` and `emcp` are unaffected: their vars live in non-main packages, where the module-path form is correct.)

Fixed in `erun-ui/build.sh`, `erun-ui/build.ps1`, the Homebrew formula and the Scoop manifest, with `erun-ui/buildstamp_test.go` failing if any script stamps that dead path again or drops the skills-source stamp.

## Verification

Every gate run in full, green:

| Gate | Result |
| --- | --- |
| `make check` (repo root) | pass — coverage 75.9% ≥ 75.7% |
| `erun-integration` `go test ./...` | pass |
| `erun-ui` `go test ./...` | pass |
| `erun-ui` `golangci-lint run ./...` | 0 issues |
| `erun-ui/frontend` typecheck / lint / format:check / test / build | pass — 45 tests |
| `erun-ui/playwright` `./run.sh --build` | **156 passed** |
| `erun-docs` `yarn build` | pass |

End-to-end against **real built binaries** in the out-of-checkout layout, driven over the headless bridge with an isolated `HOME` (observable state, not traces):

- A **stale-but-untouched** `erun-orchestrate` (marker matching its own content) was refreshed to the checkout's copy, and the marker moved with it. All 13 shipped skills installed.
- An **operator-edited** `erun-file-issue` (content differing from its marker) was left byte-for-byte untouched.
- An **unstamped** binary in the same layout installed nothing, logged every occurrence (2 launches → 2 log lines), and emitted exactly **one** `app-notification` warning — the launch still succeeded.

Probe artifacts were removed; the developer's real `~/.claude/skills` was never touched.

**Not verified by me:** the operator's own desktop was not restarted, so the live macOS `ERun.app` restart from the issue's reproduction was not run here. The equivalent was driven instead — the same `build.sh` artifact, in the same out-of-checkout layout, through the same `ensureOrchestratorWorkspace` path — on Linux, so the macOS `.app` bundle nesting itself is covered only by the resolution being independent of how deep the executable sits.

Closes #1006