### PR TITLE
Deploy an already-registered hosted environment

### DIFF
--- a/erun-backend/erun-backend-api/env_deploy_e2e_test.go
+++ b/erun-backend/erun-backend-api/env_deploy_e2e_test.go
@@ -125,7 +125,41 @@ func TestDeployEnvironmentEndToEnd(t *testing.T) {
 
 	awaitEnvironmentRunning(t, srv.URL, environmentID, config.version)
 	assertRuntimeChartInstalled(t, kube, tenant)
+	assertRedeployReruns(t, kube, srv.URL, config, environmentID)
 	assertDeployRejectedWhileInFlight(t, db, srv.URL, environmentID, config.version)
+}
+
+// assertRedeployReruns is the reason the endpoint exists: deploying the same
+// version again must actually run again. An environment-keyed Job and workflow
+// would both be terminal by now, so a replay would report the old outcome
+// without touching the cluster — this holds the second deploy to producing its
+// own Job.
+func assertRedeployReruns(t *testing.T, kube kubernetes.Interface, baseURL string, config envDeployE2E, environmentID string) {
+	t.Helper()
+	before := deployJobNames(t, kube, config.namespace)
+	code, body := e2eRequest(t, baseURL, http.MethodPost, "/v1/environments/"+environmentID+"/deploy",
+		map[string]any{"version": config.version})
+	if code != http.StatusAccepted {
+		t.Fatalf("re-deploy: HTTP %d (want 202): %s", code, body)
+	}
+	awaitEnvironmentRunning(t, baseURL, environmentID, config.version)
+	after := deployJobNames(t, kube, config.namespace)
+	if len(after) <= len(before) {
+		t.Fatalf("re-deploy ran no new job: jobs before %v, after %v", before, after)
+	}
+}
+
+func deployJobNames(t *testing.T, kube kubernetes.Interface, namespace string) []string {
+	t.Helper()
+	jobs, err := kube.BatchV1().Jobs(namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/managed-by=erun-deploy-executor",
+	})
+	mustNoErr(t, err, "list deploy jobs")
+	names := make([]string, 0, len(jobs.Items))
+	for _, job := range jobs.Items {
+		names = append(names, job.Name)
+	}
+	return names
 }
 
 // assertDeployRejectedWhileInFlight holds the claim directly rather than racing
@@ -145,6 +179,11 @@ func assertDeployRejectedWhileInFlight(t *testing.T, db *sql.DB, baseURL, enviro
 	if code != http.StatusConflict {
 		t.Fatalf("deploy while one is in flight: HTTP %d (want 409): %s", code, body)
 	}
+	// Hand the claim back, so the test does not leave behind an environment that
+	// looks wedged mid-deploy.
+	mustNoErr(t, environments.UpdateProvisioningStatus(ctx, environmentID, repository.EnvironmentStatusUpdate{
+		Status: "running",
+	}), "release the held claim")
 }
 
 // e2eTenantName reads the tenant the bootstrap identity resolved to. It decides

--- a/erun-backend/erun-backend-api/env_deploy_e2e_test.go
+++ b/erun-backend/erun-backend-api/env_deploy_e2e_test.go
@@ -1,0 +1,282 @@
+package backendapi
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dbos-inc/dbos-transact-golang/dbos"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/provision"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+)
+
+// envDeployE2E is the opt-in environment for the live env-deploy gate. It needs
+// a real Kubernetes cluster (any conformant one — a local k3d/kind cluster is
+// enough, no virtualization required), a migrated Postgres, and a tenant runtime
+// image the cluster can run, because the deploy executor's whole job is to
+// launch that image as a Job and watch it install the runtime chart.
+type envDeployE2E struct {
+	databaseURL    string
+	dbosURL        string
+	kubeconfig     string
+	registry       string
+	version        string
+	namespace      string
+	serviceAccount string
+}
+
+func envDeployE2EFromEnv(t *testing.T) envDeployE2E {
+	t.Helper()
+	if os.Getenv("ERUN_E2E_ENV_DEPLOY") != "1" {
+		t.Skip("opt-in: set ERUN_E2E_ENV_DEPLOY=1 (+ a Kubernetes cluster, a migrated Postgres, and a tenant runtime image)")
+	}
+	config := envDeployE2E{
+		databaseURL:    os.Getenv("ERUN_E2E_ENV_DEPLOY_DATABASE_URL"),
+		dbosURL:        os.Getenv("DBOS_SYSTEM_DATABASE_URL"),
+		kubeconfig:     os.Getenv("ERUN_E2E_ENV_DEPLOY_KUBECONFIG"),
+		registry:       os.Getenv("ERUN_E2E_ENV_DEPLOY_REGISTRY"),
+		version:        os.Getenv("ERUN_E2E_ENV_DEPLOY_VERSION"),
+		namespace:      os.Getenv("ERUN_E2E_ENV_DEPLOY_NAMESPACE"),
+		serviceAccount: os.Getenv("ERUN_E2E_ENV_DEPLOY_SERVICE_ACCOUNT"),
+	}
+	for name, value := range map[string]string{
+		"ERUN_E2E_ENV_DEPLOY_DATABASE_URL":    config.databaseURL,
+		"DBOS_SYSTEM_DATABASE_URL":            config.dbosURL,
+		"ERUN_E2E_ENV_DEPLOY_KUBECONFIG":      config.kubeconfig,
+		"ERUN_E2E_ENV_DEPLOY_REGISTRY":        config.registry,
+		"ERUN_E2E_ENV_DEPLOY_VERSION":         config.version,
+		"ERUN_E2E_ENV_DEPLOY_NAMESPACE":       config.namespace,
+		"ERUN_E2E_ENV_DEPLOY_SERVICE_ACCOUNT": config.serviceAccount,
+	} {
+		if value == "" {
+			t.Skipf("%s is required", name)
+		}
+	}
+	return config
+}
+
+// TestDeployEnvironmentEndToEnd drives the deploy endpoint against a live
+// cluster: the durable workflow must launch a real deploy Job, watch it install
+// the runtime chart into the per-env namespace, and land the environment on
+// `running` naming the version it deployed.
+func TestDeployEnvironmentEndToEnd(t *testing.T) {
+	config := envDeployE2EFromEnv(t)
+
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", config.kubeconfig)
+	mustNoErr(t, err, "build kube config")
+	kube, err := kubernetes.NewForConfig(kubeConfig)
+	mustNoErr(t, err, "kube client")
+
+	db, err := sql.Open("pgx", config.databaseURL)
+	mustNoErr(t, err, "open db")
+	t.Cleanup(func() { _ = db.Close() })
+	dbosCtx, err := dbos.NewDBOSContext(context.Background(), dbos.Config{AppName: "erun-env-deploy-e2e", DatabaseURL: config.dbosURL})
+	mustNoErr(t, err, "dbos context")
+
+	handler, err := NewHandler(HandlerOptions{
+		TokenVerifier: TokenVerifierFunc(func(_ context.Context, token string) (Claims, error) {
+			if token != e2eDevToken {
+				return Claims{}, errors.New("invalid dev token")
+			}
+			return Claims{Issuer: "https://dev.local", Subject: "dev-user", Username: "dev"}, nil
+		}),
+		IdentityCache: NewIdentityResolutionCache(IdentityCacheOptions{}),
+		DB:            db,
+		DBDialect:     repository.DialectPostgres,
+		DBOSContext:   dbosCtx,
+		KubeClient:    kube,
+		EnvDeploy: provision.EnvDeployConfig{
+			Registry:               config.registry,
+			PlatformNamespace:      config.namespace,
+			DeployerServiceAccount: config.serviceAccount,
+		},
+	})
+	mustNoErr(t, err, "new handler")
+	mustNoErr(t, dbos.Launch(dbosCtx), "dbos launch")
+	t.Cleanup(func() { dbos.Shutdown(dbosCtx, 5*time.Second) })
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	tenant := e2eTenantName(t, srv.URL)
+	// Registered without a pinned version, so nothing deploys on create and the
+	// explicit endpoint is unambiguously what performs the deploy.
+	environmentID := e2eRegisterEnvironment(t, srv.URL)
+
+	assertDeployClaimIsExclusive(t, db, environmentID)
+
+	code, body := e2eRequest(t, srv.URL, http.MethodPost, "/v1/environments/"+environmentID+"/deploy",
+		map[string]any{"version": config.version})
+	if code != http.StatusAccepted {
+		t.Fatalf("deploy: HTTP %d (want 202): %s", code, body)
+	}
+
+	awaitEnvironmentRunning(t, srv.URL, environmentID, config.version)
+	assertRuntimeChartInstalled(t, kube, tenant)
+	assertDeployRejectedWhileInFlight(t, db, srv.URL, environmentID, config.version)
+}
+
+// assertDeployRejectedWhileInFlight holds the claim directly rather than racing
+// two real deploys, so the conflict the endpoint must report is observed
+// deterministically over HTTP.
+func assertDeployRejectedWhileInFlight(t *testing.T, db *sql.DB, baseURL, environmentID, version string) {
+	t.Helper()
+	environments := repository.NewEnvironmentRepository(repository.NewTxManager(db, repository.DialectPostgres))
+	ctx := e2eOperationsContext(t, db)
+	claimed, err := environments.ClaimDeploy(ctx, environmentID, time.Hour)
+	mustNoErr(t, err, "hold the claim")
+	if !claimed {
+		t.Fatal("could not hold the claim on a running environment")
+	}
+	code, body := e2eRequest(t, baseURL, http.MethodPost, "/v1/environments/"+environmentID+"/deploy",
+		map[string]any{"version": version})
+	if code != http.StatusConflict {
+		t.Fatalf("deploy while one is in flight: HTTP %d (want 409): %s", code, body)
+	}
+}
+
+// e2eTenantName reads the tenant the bootstrap identity resolved to. It decides
+// both the deploy namespace and the tenant runtime image, so the test asserts
+// against the real one rather than assuming it.
+func e2eTenantName(t *testing.T, baseURL string) string {
+	t.Helper()
+	code, body := e2eRequest(t, baseURL, http.MethodGet, "/v1/config", nil)
+	if code != http.StatusOK {
+		t.Fatalf("read config: HTTP %d: %s", code, body)
+	}
+	var config struct {
+		Tenant struct {
+			Name string `json:"name"`
+		} `json:"tenant"`
+	}
+	mustNoErr(t, json.Unmarshal([]byte(body), &config), "parse config response")
+	if config.Tenant.Name == "" {
+		t.Fatalf("config carries no tenant name: %s", body)
+	}
+	return config.Tenant.Name
+}
+
+func e2eRegisterEnvironment(t *testing.T, baseURL string) string {
+	t.Helper()
+	code, body := e2eRequest(t, baseURL, http.MethodPost, "/v1/environments",
+		map[string]any{"name": "prod", "type": "runtime"})
+	if code != http.StatusCreated {
+		t.Fatalf("register environment: HTTP %d (want 201): %s", code, body)
+	}
+	var created struct {
+		EnvironmentID string `json:"environmentId"`
+		Status        string `json:"status"`
+	}
+	mustNoErr(t, json.Unmarshal([]byte(body), &created), "parse register response")
+	if created.Status != "registered" {
+		t.Fatalf("registered status = %q, want registered", created.Status)
+	}
+	return created.EnvironmentID
+}
+
+// assertDeployClaimIsExclusive exercises the claim against the real database,
+// which is where its correctness actually lives: the concurrency guard is one
+// conditional UPDATE, and a stale claim must stay re-claimable so a control
+// plane that crashed mid-deploy never locks an environment out. Run before the
+// deploy, then handed back so the deploy under test starts from `registered`.
+func assertDeployClaimIsExclusive(t *testing.T, db *sql.DB, environmentID string) {
+	t.Helper()
+	environments := repository.NewEnvironmentRepository(repository.NewTxManager(db, repository.DialectPostgres))
+	ctx := e2eOperationsContext(t, db)
+
+	claimed, err := environments.ClaimDeploy(ctx, environmentID, time.Hour)
+	mustNoErr(t, err, "first claim")
+	if !claimed {
+		t.Fatal("first claim was refused on a registered environment")
+	}
+	claimed, err = environments.ClaimDeploy(ctx, environmentID, time.Hour)
+	mustNoErr(t, err, "second claim")
+	if claimed {
+		t.Fatal("second claim succeeded, so two concurrent deploys could run into the same release")
+	}
+	// A zero window makes every claim stale, which is the wedged-deploy recovery.
+	claimed, err = environments.ClaimDeploy(ctx, environmentID, 0)
+	mustNoErr(t, err, "stale claim")
+	if !claimed {
+		t.Fatal("a stale claim was refused, so a crashed deploy would lock the environment out permanently")
+	}
+	mustNoErr(t, environments.UpdateProvisioningStatus(ctx, environmentID, repository.EnvironmentStatusUpdate{
+		Status: "registered",
+	}), "reset status")
+}
+
+// e2eOperationsContext rebuilds the request-scoped security context the
+// repositories' row-level-security wiring needs, bound to the bootstrap tenant.
+func e2eOperationsContext(t *testing.T, db *sql.DB) context.Context {
+	t.Helper()
+	var tenantID, tenantType string
+	err := db.QueryRow(`SELECT tenant_id, type FROM tenants ORDER BY created_at ASC LIMIT 1`).Scan(&tenantID, &tenantType)
+	mustNoErr(t, err, "read bootstrap tenant")
+	return security.WithContext(context.Background(), security.Context{TenantID: tenantID, TenantType: tenantType})
+}
+
+// awaitEnvironmentRunning polls the environment until the durable workflow
+// reports a terminal state, and holds it to naming the version it deployed.
+func awaitEnvironmentRunning(t *testing.T, baseURL, environmentID, version string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Minute)
+	for time.Now().Before(deadline) {
+		code, body := e2eRequest(t, baseURL, http.MethodGet, "/v1/environments/"+environmentID, nil)
+		if code != http.StatusOK {
+			t.Fatalf("get environment: HTTP %d: %s", code, body)
+		}
+		var got struct {
+			Status          string `json:"status"`
+			ProvisionError  string `json:"provisionError"`
+			DeployedVersion string `json:"deployedVersion"`
+		}
+		mustNoErr(t, json.Unmarshal([]byte(body), &got), "parse environment response")
+		switch got.Status {
+		case "running":
+			if got.DeployedVersion != version {
+				t.Fatalf("deployedVersion = %q, want the deployed %q", got.DeployedVersion, version)
+			}
+			return
+		case "failed":
+			t.Fatalf("deploy failed: %s", got.ProvisionError)
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Fatal("timed out waiting for the deploy to reach running")
+}
+
+// assertRuntimeChartInstalled proves the deploy reached the cluster, not just
+// the database: the per-env namespace exists, it carries the runtime workload,
+// and Helm recorded a release under the runtime release name.
+func assertRuntimeChartInstalled(t *testing.T, kube kubernetes.Interface, tenant string) {
+	t.Helper()
+	ctx := context.Background()
+	namespace := tenant + "-prod"
+	if _, err := kube.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{}); err != nil {
+		t.Fatalf("per-env namespace %s: %v", namespace, err)
+	}
+	deployments, err := kube.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+	mustNoErr(t, err, "list deployments")
+	if len(deployments.Items) == 0 {
+		t.Fatalf("no workload landed in %s", namespace)
+	}
+	releases, err := kube.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "owner=helm,name=" + tenant + "-devops",
+	})
+	mustNoErr(t, err, "list helm releases")
+	if len(releases.Items) == 0 {
+		t.Fatalf("helm recorded no %s-devops release in %s", tenant, namespace)
+	}
+}

--- a/erun-backend/erun-backend-api/go.mod
+++ b/erun-backend/erun-backend-api/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
@@ -53,6 +54,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/erun-backend/erun-backend-api/go.sum
+++ b/erun-backend/erun-backend-api/go.sum
@@ -48,6 +48,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
+github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6 h1:D/V0gu4zQ3cL2WKeVNVM4r2gLxGGf6McLwgXzRTo2RQ=
 github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/erun-backend/erun-backend-api/internal/deployexec/job.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/job.go
@@ -45,6 +45,12 @@ type DeployJobParams struct {
 	Tenant      string
 	Environment string
 	Version     string
+	// DeployID scopes the Job to one deploy attempt. It is carried in the durable
+	// workflow input, so a resumed workflow rebuilds the same Job name and
+	// re-watches its in-flight Job, while a fresh attempt gets its own Job rather
+	// than re-reading the previous attempt's terminal outcome. Empty keeps the
+	// version-scoped name the create path has always used.
+	DeployID string
 	// Namespace the Job runs in (the platform namespace where the backend lives).
 	Namespace string
 	// Image is the erun-devops runtime image carrying erun + helm + kubectl.
@@ -63,7 +69,7 @@ func buildDeployJob(params DeployJobParams) *batchv1.Job {
 	ttl := jobTTLSecondsAfterFinished
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      DeployJobName(params.Tenant, params.Environment, params.Version),
+			Name:      DeployJobName(params.Tenant, params.Environment, params.Version, params.DeployID),
 			Namespace: params.Namespace,
 			Labels: map[string]string{
 				"app.kubernetes.io/managed-by": "erun-deploy-executor",
@@ -90,11 +96,39 @@ func buildDeployJob(params DeployJobParams) *batchv1.Job {
 	}
 }
 
-// DeployJobName is deterministic and version-scoped, so re-deploying the same
-// version reuses the Job (a create conflict is treated as "watch the existing
-// one"), while a new version gets its own Job.
-func DeployJobName(tenant, environment, version string) string {
-	return "erun-deploy-" + sanitizeLabel(tenant+"-"+environment+"-"+version)
+// DeployJobName is deterministic in its inputs, so a resumed workflow watches
+// the Job it already created (a create conflict is treated as "watch the
+// existing one") rather than starting a second rollout. An explicit deploy
+// passes a per-attempt deployID so a retry of the same version is a new Job
+// instead of a re-read of the previous attempt's outcome.
+func DeployJobName(tenant, environment, version, deployID string) string {
+	name := sanitizeLabel(tenant + "-" + environment + "-" + version)
+	suffix := ""
+	if deployID != "" {
+		suffix = "-" + shortID(deployID)
+	}
+	// Kubernetes caps an object name at 63 characters; trim the descriptive
+	// middle rather than the attempt suffix, which is what keeps attempts apart.
+	if budget := maxJobNameLength - len(jobNamePrefix) - len(suffix); len(name) > budget {
+		name = strings.Trim(name[:budget], "-")
+	}
+	return jobNamePrefix + name + suffix
+}
+
+const (
+	jobNamePrefix    = "erun-deploy-"
+	maxJobNameLength = 63
+	// Enough of a random attempt id to keep concurrent and successive attempts
+	// apart without crowding out the readable tenant/env/version part.
+	shortIDLength = 8
+)
+
+func shortID(deployID string) string {
+	id := sanitizeLabel(deployID)
+	if len(id) > shortIDLength {
+		id = id[:shortIDLength]
+	}
+	return id
 }
 
 // sanitizeLabel lowercases and replaces every character outside [a-z0-9-] so the

--- a/erun-backend/erun-backend-api/internal/deployexec/job_test.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/job_test.go
@@ -2,6 +2,7 @@ package deployexec
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -85,13 +86,47 @@ func TestJobOutcome(t *testing.T) {
 	}
 }
 
+// TestDeployJobNameSeparatesAttempts: a re-deploy must be a new Job, otherwise
+// it would re-read the previous attempt's terminal outcome instead of running.
+func TestDeployJobNameSeparatesAttempts(t *testing.T) {
+	first := DeployJobName("acme", "prod", "1.0.149", "3f2a91cc-1111-2222-3333-444455556666")
+	second := DeployJobName("acme", "prod", "1.0.149", "9b7d40aa-1111-2222-3333-444455556666")
+	if first == second {
+		t.Fatalf("two attempts share the job name %q", first)
+	}
+	// The create path passes no attempt id and keeps its stable name, so a
+	// resumed workflow still re-watches the Job it already created.
+	if got := DeployJobName("acme", "prod", "1.0.149", ""); got != "erun-deploy-acme-prod-1-0-149" {
+		t.Fatalf("name without an attempt id = %q", got)
+	}
+	if !strings.HasPrefix(first, "erun-deploy-acme-prod-1-0-149-") {
+		t.Fatalf("attempt name %q lost its readable prefix", first)
+	}
+}
+
+// TestDeployJobNameFitsKubernetesLimit: names are trimmed in the descriptive
+// middle, never in the attempt suffix that keeps two deploys apart.
+func TestDeployJobNameFitsKubernetesLimit(t *testing.T) {
+	longEnv := strings.Repeat("e", 63)
+	first := DeployJobName("verylongtenantname", longEnv, "1.0.149-rc.20260816", "3f2a91cc-aaaa")
+	second := DeployJobName("verylongtenantname", longEnv, "1.0.149-rc.20260816", "9b7d40aa-bbbb")
+	for _, name := range []string{first, second} {
+		if len(name) > 63 {
+			t.Fatalf("job name %q is %d characters, over the 63 Kubernetes allows", name, len(name))
+		}
+	}
+	if first == second {
+		t.Fatal("truncation collapsed two attempts onto one job name")
+	}
+}
+
 // seededJob is the deploy Job as it would be after the cluster ran it, with a
 // terminal status, so Run's watch returns immediately (the fake client has no
 // Job controller to move status on its own).
 func seededJob(status batchv1.JobStatus) *batchv1.Job {
 	p := testParams()
 	return &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{Name: DeployJobName(p.Tenant, p.Environment, p.Version), Namespace: p.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: DeployJobName(p.Tenant, p.Environment, p.Version, p.DeployID), Namespace: p.Namespace},
 		Status:     status,
 	}
 }
@@ -164,7 +199,7 @@ func TestRunCreatesWhenAbsent(t *testing.T) {
 	if created == nil {
 		t.Fatal("deploy job was not created")
 	}
-	if want := DeployJobName(p.Tenant, p.Environment, p.Version); created.Name != want {
+	if want := DeployJobName(p.Tenant, p.Environment, p.Version, p.DeployID); created.Name != want {
 		t.Fatalf("created job name = %q, want %q", created.Name, want)
 	}
 	if created.Namespace != p.Namespace {

--- a/erun-backend/erun-backend-api/internal/model/environment.go
+++ b/erun-backend/erun-backend-api/internal/model/environment.go
@@ -44,6 +44,11 @@ type Environment struct {
 	// when Status is `failed`.
 	Status         EnvironmentStatus `json:"status" bun:"status,scanonly"`
 	ProvisionError string            `json:"provisionError,omitempty" bun:"provision_error,scanonly,nullzero"`
-	CreatedAt      time.Time         `json:"createdAt" bun:"created_at,scanonly"`
-	UpdatedAt      time.Time         `json:"updatedAt" bun:"updated_at,scanonly"`
+	// DeployedVersion is the version the last successful deploy actually
+	// installed, as opposed to RuntimeVersion, which is the declared pin. Owned
+	// by the deploy executor, so it is scan-only; a failed deploy leaves it on
+	// the version still running in the cluster.
+	DeployedVersion string    `json:"deployedVersion,omitempty" bun:"deployed_version,scanonly,nullzero"`
+	CreatedAt       time.Time `json:"createdAt" bun:"created_at,scanonly"`
+	UpdatedAt       time.Time `json:"updatedAt" bun:"updated_at,scanonly"`
 }

--- a/erun-backend/erun-backend-api/internal/provision/environments.go
+++ b/erun-backend/erun-backend-api/internal/provision/environments.go
@@ -21,6 +21,11 @@ type EnvProvisionInput struct {
 	Tenant        string `json:"tenant"`
 	Environment   string `json:"environment"`
 	Version       string `json:"version"`
+	// DeployID identifies one explicit deploy attempt. Being part of the
+	// checkpointed input is what lets a resumed workflow rebuild the same Job
+	// name and re-watch its own run. Empty on the create path, which deploys an
+	// environment exactly once.
+	DeployID string `json:"deployId,omitempty"`
 }
 
 // EnvCoordinator runs an env deploy to a terminal status — the service
@@ -66,6 +71,17 @@ func (p *EnvProvisioner) Start(input EnvProvisionInput) error {
 	return err
 }
 
+// StartDeploy runs the same durable workflow for an explicit deploy of an
+// already-registered environment. It is keyed by the attempt rather than the
+// environment: an environment-keyed id is terminal after the first deploy, which
+// would make a retry after a failure — or a re-deploy at another version — a
+// silent no-op. Concurrency is guarded by the environment's deploy claim, not by
+// the workflow id.
+func (p *EnvProvisioner) StartDeploy(input EnvProvisionInput) error {
+	_, err := dbos.RunWorkflow(p.dbosCtx, p.workflowFn, input, dbos.WithWorkflowID("deploy-env-"+input.EnvironmentID+"-"+input.DeployID))
+	return err
+}
+
 // deployJobParams renders the placement for one env-deploy Job. The env deploys
 // with the tenant's own <tenant>-devops runtime image, which carries its baked
 // deploy config (the image-baked config model), pulled from the configured
@@ -75,6 +91,7 @@ func deployJobParams(config EnvDeployConfig, input EnvProvisionInput) deployexec
 		Tenant:         input.Tenant,
 		Environment:    input.Environment,
 		Version:        input.Version,
+		DeployID:       input.DeployID,
 		Namespace:      config.PlatformNamespace,
 		Image:          fmt.Sprintf("%s/%s-devops:%s", config.Registry, input.Tenant, input.Version),
 		ServiceAccount: config.DeployerServiceAccount,

--- a/erun-backend/erun-backend-api/internal/repository/environments.go
+++ b/erun-backend/erun-backend-api/internal/repository/environments.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"time"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	"github.com/uptrace/bun"
@@ -11,7 +12,7 @@ type EnvironmentRepository struct {
 	txs *TxManager
 }
 
-const environmentColumns = `environment_id, tenant_id, name, type, kubernetes_context, context_id, runtime_version, status, provision_error, created_at, updated_at`
+const environmentColumns = `environment_id, tenant_id, name, type, kubernetes_context, context_id, runtime_version, status, provision_error, deployed_version, created_at, updated_at`
 
 func NewEnvironmentRepository(txs *TxManager) *EnvironmentRepository {
 	return &EnvironmentRepository{txs: txs}
@@ -56,20 +57,60 @@ func (r *EnvironmentRepository) Count(ctx context.Context) (int, error) {
 	return count, err
 }
 
+// EnvironmentStatusUpdate is one deploy-lifecycle write: the new status, the
+// failure reason (cleared on any non-failed state), and the version that
+// actually deployed. An empty DeployedVersion leaves the recorded one alone, so
+// a failed deploy does not erase the version the cluster is still running.
+type EnvironmentStatusUpdate struct {
+	Status          string
+	ProvisionError  string
+	DeployedVersion string
+}
+
 // UpdateProvisioningStatus persists an environment's provisioning-lifecycle
-// transition (registered → provisioning → running/failed), clearing the error
-// on any non-failed state. Mirrors the contexts provisioning-result update; RLS
-// keeps the write scoped to the caller's tenant.
-func (r *EnvironmentRepository) UpdateProvisioningStatus(ctx context.Context, environmentID, status, provisionError string) error {
+// transition (registered → provisioning → running/failed). Mirrors the contexts
+// provisioning-result update; RLS keeps the write scoped to the caller's tenant.
+func (r *EnvironmentRepository) UpdateProvisioningStatus(ctx context.Context, environmentID string, update EnvironmentStatusUpdate) error {
 	return r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 		_, err := tx.NewRaw(`
 			UPDATE environments
 			   SET status = ?,
-			       provision_error = NULLIF(?, '')
+			       provision_error = NULLIF(?, ''),
+			       deployed_version = COALESCE(NULLIF(?, ''), deployed_version)
 			 WHERE environment_id = ?
-		`, status, provisionError, environmentID).Exec(ctx)
+		`, update.Status, update.ProvisionError, update.DeployedVersion, environmentID).Exec(ctx)
 		return err
 	})
+}
+
+// ClaimDeploy takes exclusive ownership of an environment's deploy slot,
+// returning false when another deploy already holds it. This is what makes a
+// double-submit safe: two concurrent requests would otherwise both launch a
+// rollout into the same release, and the loser's terminal write could clobber
+// the winner's. A claim that went stale past staleAfter -- a control plane that
+// crashed mid-deploy -- is re-claimable, so a wedged env is never locked out
+// permanently.
+func (r *EnvironmentRepository) ClaimDeploy(ctx context.Context, environmentID string, staleAfter time.Duration) (bool, error) {
+	claimed := false
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		result, err := tx.NewRaw(`
+			UPDATE environments
+			   SET status = ?,
+			       provision_error = NULL
+			 WHERE environment_id = ?
+			   AND (status <> ? OR updated_at < NOW() - MAKE_INTERVAL(secs => ?))
+		`, string(model.EnvironmentStatusProvisioning), environmentID, string(model.EnvironmentStatusProvisioning), staleAfter.Seconds()).Exec(ctx)
+		if err != nil {
+			return err
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		claimed = affected > 0
+		return nil
+	})
+	return claimed, err
 }
 
 func (r *EnvironmentRepository) Get(ctx context.Context, environmentID string) (model.Environment, error) {

--- a/erun-backend/erun-backend-api/internal/routes/config_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/config_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
@@ -29,6 +30,19 @@ type stubEnvironmentRepository struct {
 	count        int
 	countErr     error
 	err          error
+	// claimTaken makes ClaimDeploy report the deploy slot as already held, the
+	// shape a concurrent deploy produces.
+	claimTaken bool
+	claimErr   error
+	claimCalls int
+}
+
+func (r *stubEnvironmentRepository) ClaimDeploy(context.Context, string, time.Duration) (bool, error) {
+	r.claimCalls++
+	if r.claimErr != nil {
+		return false, r.claimErr
+	}
+	return !r.claimTaken, nil
 }
 
 func (r *stubEnvironmentRepository) List(context.Context) ([]model.Environment, error) {

--- a/erun-backend/erun-backend-api/internal/routes/environments.go
+++ b/erun-backend/erun-backend-api/internal/routes/environments.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/provision"
@@ -17,14 +21,22 @@ type EnvironmentRepository interface {
 	Get(ctx context.Context, environmentID string) (model.Environment, error)
 	Create(ctx context.Context, environment model.Environment) (model.Environment, error)
 	Count(ctx context.Context) (int, error)
+	ClaimDeploy(ctx context.Context, environmentID string, staleAfter time.Duration) (bool, error)
 }
 
-// EnvironmentProvisioner starts the durable server-side deploy of a
-// freshly-created environment. Optional: when nil, POST /v1/environments only
-// registers the row (no live deploy), matching the pre-executor behavior.
+// EnvironmentProvisioner starts the durable server-side deploy of an
+// environment — once on create, and again for each explicit deploy. Optional:
+// when nil, the environment routes only register rows (no live deploy),
+// matching the pre-executor behavior.
 type EnvironmentProvisioner interface {
 	Start(provision.EnvProvisionInput) error
+	StartDeploy(provision.EnvProvisionInput) error
 }
+
+// deployClaimStaleAfter bounds how long a deploy may hold its environment's
+// claim. It is longer than the deploy Job's own 30-minute deadline, so a claim
+// only looks stale once the run behind it cannot still be live.
+const deployClaimStaleAfter = 45 * time.Minute
 
 // TenantQuotaRepository reports the caller's environment-count cap. When the
 // tenant has no quota row the repository returns the default cap, so the route
@@ -59,6 +71,74 @@ func RegisterEnvironmentRoutes(register ProtectedRouteRegistrar, environments En
 	register(http.MethodGet, "/v1/environments", http.HandlerFunc(routes.listEnvironments))
 	register(http.MethodPost, "/v1/environments", http.HandlerFunc(routes.createEnvironment))
 	register(http.MethodGet, "/v1/environments/{environment_id}", http.HandlerFunc(routes.getEnvironment))
+	register(http.MethodPost, "/v1/environments/{environment_id}/deploy", http.HandlerFunc(routes.deployEnvironment))
+}
+
+// deployEnvironmentRequest re-deploys at an explicit version; omitted, the
+// environment's own pinned runtimeVersion is deployed.
+type deployEnvironmentRequest struct {
+	Version string `json:"version"`
+}
+
+// deployEnvironment deploys an already-registered environment, which is what
+// makes the runtime version an environment runs changeable after creation: a
+// retry of a failed deploy, or a move to another published version. It composes
+// the pure deploy primitive — the version must already be published, and this
+// never builds or pushes.
+func (r EnvironmentRoutes) deployEnvironment(w http.ResponseWriter, req *http.Request) {
+	if r.provisioner == nil {
+		writeError(w, http.StatusNotImplemented, "the deploy executor is not configured")
+		return
+	}
+	ctx := req.Context()
+	environment, err := r.environments.Get(ctx, req.PathValue("environment_id"))
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	version, err := resolveDeployVersion(req, environment)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// Claiming before starting the workflow is what keeps a double-submit from
+	// running two rollouts into the same release.
+	claimed, err := r.environments.ClaimDeploy(ctx, environment.EnvironmentID, deployClaimStaleAfter)
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	if !claimed {
+		writeError(w, http.StatusConflict, "a deploy is already in progress for this environment")
+		return
+	}
+	if err := r.startDeploy(ctx, environment, version); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to start deploy")
+		return
+	}
+	writeJSON(w, http.StatusAccepted, environment)
+}
+
+// resolveDeployVersion picks the version to deploy and rejects the requests that
+// have nothing deployable. Its error message is the operator-facing 400 reason.
+func resolveDeployVersion(req *http.Request, environment model.Environment) (string, error) {
+	if environment.Type != model.EnvironmentTypeRuntime {
+		return "", errors.New("only a runtime environment can be deployed")
+	}
+	var body deployEnvironmentRequest
+	// A body-less deploy is the common case (deploy what the env is pinned to),
+	// so only a malformed body is an error.
+	if err := decodeJSON(req, &body); err != nil && !errors.Is(err, io.EOF) {
+		return "", errors.New("invalid request body")
+	}
+	version := strings.TrimSpace(body.Version)
+	if version == "" {
+		version = environment.RuntimeVersion
+	}
+	if version == "" {
+		return "", errors.New("version is required: the environment has no pinned runtimeVersion to deploy")
+	}
+	return version, nil
 }
 
 func (r EnvironmentRoutes) listEnvironments(w http.ResponseWriter, req *http.Request) {
@@ -185,26 +265,48 @@ func (r EnvironmentRoutes) createEnvironment(w http.ResponseWriter, req *http.Re
 	writeJSON(w, http.StatusAccepted, created)
 }
 
-// startProvisioning kicks off the durable deploy workflow for a runtime env. The
-// deploy needs the tenant name (RLS-scoped to the caller, so always the caller's
-// own) plus the request-scoped identity so the workflow's status writes rebind
-// to the right tenant.
+// startProvisioning kicks off the durable deploy workflow for a newly-created
+// runtime env, keyed by the environment so a retried create never double-deploys.
 func (r EnvironmentRoutes) startProvisioning(ctx context.Context, created model.Environment) error {
-	tenant, err := r.tenants.Current(ctx)
+	input, err := r.deployInput(ctx, created, created.RuntimeVersion)
 	if err != nil {
 		return err
 	}
+	return r.provisioner.Start(input)
+}
+
+// startDeploy kicks off the durable deploy workflow for an explicit deploy,
+// tagged with a fresh attempt id so it is a real re-run rather than a replay of
+// the environment's first deploy.
+func (r EnvironmentRoutes) startDeploy(ctx context.Context, environment model.Environment, version string) error {
+	input, err := r.deployInput(ctx, environment, version)
+	if err != nil {
+		return err
+	}
+	input.DeployID = uuid.NewString()
+	return r.provisioner.StartDeploy(input)
+}
+
+// deployInput assembles the durable workflow input. The deploy needs the tenant
+// name (RLS-scoped to the caller, so always the caller's own) plus the
+// request-scoped identity so the workflow's status writes rebind to the right
+// tenant.
+func (r EnvironmentRoutes) deployInput(ctx context.Context, environment model.Environment, version string) (provision.EnvProvisionInput, error) {
+	tenant, err := r.tenants.Current(ctx)
+	if err != nil {
+		return provision.EnvProvisionInput{}, err
+	}
 	securityContext, ok := security.FromContext(ctx)
 	if !ok {
-		return fmt.Errorf("missing security context")
+		return provision.EnvProvisionInput{}, fmt.Errorf("missing security context")
 	}
-	return r.provisioner.Start(provision.EnvProvisionInput{
+	return provision.EnvProvisionInput{
 		TenantID:      securityContext.TenantID,
 		TenantType:    securityContext.TenantType,
 		ErunUserID:    securityContext.ErunUserID,
-		EnvironmentID: created.EnvironmentID,
+		EnvironmentID: environment.EnvironmentID,
 		Tenant:        strings.TrimSpace(tenant.Name),
-		Environment:   created.Name,
-		Version:       created.RuntimeVersion,
-	})
+		Environment:   environment.Name,
+		Version:       version,
+	}, nil
 }

--- a/erun-backend/erun-backend-api/internal/routes/environments_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/environments_test.go
@@ -21,12 +21,18 @@ func postCreateEnvironment(t *testing.T, environments *stubEnvironmentRepository
 }
 
 type stubEnvironmentProvisioner struct {
-	started []provision.EnvProvisionInput
-	err     error
+	started  []provision.EnvProvisionInput
+	deployed []provision.EnvProvisionInput
+	err      error
 }
 
 func (s *stubEnvironmentProvisioner) Start(in provision.EnvProvisionInput) error {
 	s.started = append(s.started, in)
+	return s.err
+}
+
+func (s *stubEnvironmentProvisioner) StartDeploy(in provision.EnvProvisionInput) error {
+	s.deployed = append(s.deployed, in)
 	return s.err
 }
 
@@ -202,6 +208,163 @@ func TestCreateEnvironmentRegistersOnlyForNonRuntime(t *testing.T) {
 	}
 	if len(prov.started) != 0 {
 		t.Fatalf("Start called %d times, want 0 (non-runtime env)", len(prov.started))
+	}
+}
+
+// postDeployEnvironment posts to the explicit deploy endpoint through a
+// fully-wired route with a request-scoped security context.
+func postDeployEnvironment(t *testing.T, environments *stubEnvironmentRepository, prov EnvironmentProvisioner, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/environments/env-1/deploy", bytes.NewBufferString(body))
+	req.SetPathValue("environment_id", "env-1")
+	req = req.WithContext(security.WithContext(req.Context(), security.Context{
+		TenantID:   "t1",
+		TenantType: string(model.TenantTypeCompany),
+		ErunUserID: "u1",
+	}))
+	rec := httptest.NewRecorder()
+	routes := EnvironmentRoutes{
+		environments: environments,
+		quotas:       underCapQuota,
+		tenants:      stubConfigTenantRepository{tenant: model.Tenant{Name: "acme"}},
+	}
+	if prov != nil {
+		routes.provisioner = prov
+	}
+	routes.deployEnvironment(rec, req)
+	return rec
+}
+
+func runtimeEnvironment() *stubEnvironmentRepository {
+	return &stubEnvironmentRepository{environment: model.Environment{
+		EnvironmentID: "env-1", Name: "prod", Type: model.EnvironmentTypeRuntime, RuntimeVersion: "1.2.3",
+	}}
+}
+
+// TestDeployEnvironmentDeploysPinnedVersion: a body-less deploy is the common
+// case — deploy what the environment is already pinned to.
+func TestDeployEnvironmentDeploysPinnedVersion(t *testing.T) {
+	environments := runtimeEnvironment()
+	prov := &stubEnvironmentProvisioner{}
+	rec := postDeployEnvironment(t, environments, prov, "")
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d (body %s), want 202 Accepted", rec.Code, rec.Body.String())
+	}
+	if len(prov.deployed) != 1 {
+		t.Fatalf("StartDeploy called %d times, want 1", len(prov.deployed))
+	}
+	got := prov.deployed[0]
+	if got.Version != "1.2.3" || got.EnvironmentID != "env-1" || got.Tenant != "acme" || got.Environment != "prod" {
+		t.Fatalf("deploy input = %+v", got)
+	}
+	if got.DeployID == "" {
+		t.Fatal("deploy input carries no attempt id, so a retry would replay the previous deploy")
+	}
+}
+
+// TestDeployEnvironmentDeploysRequestedVersion: an explicit version is how an
+// environment moves between published runtime versions after creation.
+func TestDeployEnvironmentDeploysRequestedVersion(t *testing.T) {
+	prov := &stubEnvironmentProvisioner{}
+	rec := postDeployEnvironment(t, runtimeEnvironment(), prov, `{"version":"1.3.0"}`)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", rec.Code)
+	}
+	if prov.deployed[0].Version != "1.3.0" {
+		t.Fatalf("deployed version = %q, want the requested 1.3.0", prov.deployed[0].Version)
+	}
+}
+
+// TestDeployEnvironmentGivesEachAttemptItsOwnID: two deploys must not collapse
+// onto one workflow, or the second would be a silent no-op.
+func TestDeployEnvironmentGivesEachAttemptItsOwnID(t *testing.T) {
+	prov := &stubEnvironmentProvisioner{}
+	postDeployEnvironment(t, runtimeEnvironment(), prov, "")
+	postDeployEnvironment(t, runtimeEnvironment(), prov, "")
+
+	if len(prov.deployed) != 2 {
+		t.Fatalf("StartDeploy called %d times, want 2", len(prov.deployed))
+	}
+	if prov.deployed[0].DeployID == prov.deployed[1].DeployID {
+		t.Fatalf("both deploys share attempt id %q", prov.deployed[0].DeployID)
+	}
+}
+
+// TestDeployEnvironmentRejectsConcurrentDeploy: the claim is what keeps a
+// double-submit from running two rollouts into the same release.
+func TestDeployEnvironmentRejectsConcurrentDeploy(t *testing.T) {
+	environments := runtimeEnvironment()
+	environments.claimTaken = true
+	prov := &stubEnvironmentProvisioner{}
+	rec := postDeployEnvironment(t, environments, prov, "")
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 Conflict", rec.Code)
+	}
+	if len(prov.deployed) != 0 {
+		t.Fatalf("StartDeploy called %d times, want 0 when the claim is held", len(prov.deployed))
+	}
+}
+
+// TestDeployEnvironmentClaimsBeforeStarting: the claim must precede the
+// workflow, otherwise the race it exists to prevent is still open.
+func TestDeployEnvironmentClaimsBeforeStarting(t *testing.T) {
+	environments := runtimeEnvironment()
+	postDeployEnvironment(t, environments, &stubEnvironmentProvisioner{}, "")
+	if environments.claimCalls != 1 {
+		t.Fatalf("ClaimDeploy called %d times, want 1", environments.claimCalls)
+	}
+}
+
+func TestDeployEnvironmentRejectsInvalidRequests(t *testing.T) {
+	cases := map[string]struct {
+		environment model.Environment
+		body        string
+		want        int
+	}{
+		"non-runtime env": {
+			model.Environment{EnvironmentID: "env-1", Name: "agents", Type: model.EnvironmentTypeRemoteAgent, RuntimeVersion: "1.2.3"},
+			"", http.StatusBadRequest,
+		},
+		"no version anywhere": {
+			model.Environment{EnvironmentID: "env-1", Name: "prod", Type: model.EnvironmentTypeRuntime},
+			"", http.StatusBadRequest,
+		},
+		"malformed body": {
+			model.Environment{EnvironmentID: "env-1", Name: "prod", Type: model.EnvironmentTypeRuntime, RuntimeVersion: "1.2.3"},
+			`{`, http.StatusBadRequest,
+		},
+	}
+	for label, tc := range cases {
+		t.Run(label, func(t *testing.T) {
+			environments := &stubEnvironmentRepository{environment: tc.environment}
+			prov := &stubEnvironmentProvisioner{}
+			rec := postDeployEnvironment(t, environments, prov, tc.body)
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d (body %s), want %d", rec.Code, rec.Body.String(), tc.want)
+			}
+			if environments.claimCalls != 0 {
+				t.Fatal("an invalid request must not claim the environment's deploy slot")
+			}
+			if len(prov.deployed) != 0 {
+				t.Fatalf("StartDeploy called %d times, want 0", len(prov.deployed))
+			}
+		})
+	}
+}
+
+// TestDeployEnvironmentReportsUnconfiguredExecutor: without a wired executor the
+// endpoint says so, rather than accepting a deploy nothing will run.
+func TestDeployEnvironmentReportsUnconfiguredExecutor(t *testing.T) {
+	environments := runtimeEnvironment()
+	rec := postDeployEnvironment(t, environments, nil, "")
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501 Not Implemented", rec.Code)
+	}
+	if environments.claimCalls != 0 {
+		t.Fatal("an unconfigured executor must not claim the environment's deploy slot")
 	}
 }
 

--- a/erun-backend/erun-backend-api/internal/service/environments.go
+++ b/erun-backend/erun-backend-api/internal/service/environments.go
@@ -3,15 +3,18 @@ package service
 import (
 	"context"
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/deployexec"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
 )
 
 // EnvironmentStatusWriter persists an environment's provisioning-lifecycle
 // transitions (the repository).
 type EnvironmentStatusWriter interface {
-	UpdateProvisioningStatus(ctx context.Context, environmentID, status, provisionError string) error
+	UpdateProvisioningStatus(ctx context.Context, environmentID string, update repository.EnvironmentStatusUpdate) error
 }
 
 // DeployRunner runs a hosted-env deploy to a terminal outcome — satisfied by the
@@ -20,24 +23,35 @@ type DeployRunner interface {
 	Run(ctx context.Context, params deployexec.DeployJobParams) (deployexec.Outcome, error)
 }
 
+const (
+	// A lifecycle write that loses to a transient database blip would strand the
+	// env in `provisioning` under a workflow that has already run to a terminal
+	// state, so the write is worth a few attempts before giving up.
+	statusWriteAttempts = 3
+	statusWriteBackoff  = 200 * time.Millisecond
+)
+
 // EnvironmentProvisioner drives a hosted env's deploy: it marks the env
 // provisioning, runs the deploy (a Job in the runtime image), and records the
 // terminal running/failed status. The durable DBOS workflow wraps this; keeping
 // the state transitions here makes them unit-testable without a cluster.
 type EnvironmentProvisioner struct {
-	runner DeployRunner
-	status EnvironmentStatusWriter
+	runner  DeployRunner
+	status  EnvironmentStatusWriter
+	backoff time.Duration
 }
 
 func NewEnvironmentProvisioner(runner DeployRunner, status EnvironmentStatusWriter) *EnvironmentProvisioner {
-	return &EnvironmentProvisioner{runner: runner, status: status}
+	return &EnvironmentProvisioner{runner: runner, status: status, backoff: statusWriteBackoff}
 }
 
 // Provision moves the env → provisioning → running/failed. A run error or a
 // non-succeeded deploy Job both land it in failed with the reason; only a
-// succeeded Job marks it running.
+// succeeded Job marks it running, recording the version that actually deployed.
 func (p *EnvironmentProvisioner) Provision(ctx context.Context, environmentID string, params deployexec.DeployJobParams) error {
-	if err := p.status.UpdateProvisioningStatus(ctx, environmentID, string(model.EnvironmentStatusProvisioning), ""); err != nil {
+	if err := p.write(ctx, environmentID, repository.EnvironmentStatusUpdate{
+		Status: string(model.EnvironmentStatusProvisioning),
+	}); err != nil {
 		return fmt.Errorf("mark provisioning: %w", err)
 	}
 	outcome, runErr := p.runner.Run(ctx, params)
@@ -47,15 +61,49 @@ func (p *EnvironmentProvisioner) Provision(ctx context.Context, environmentID st
 	if outcome != deployexec.OutcomeSucceeded {
 		return p.fail(ctx, environmentID, fmt.Sprintf("deploy job %s", outcome), fmt.Errorf("deploy job outcome %q", outcome))
 	}
-	if err := p.status.UpdateProvisioningStatus(ctx, environmentID, string(model.EnvironmentStatusRunning), ""); err != nil {
+	// The env is now running this version, so record it here rather than after
+	// any later step: a run that fails past this point still leaves the cluster
+	// carrying it, and an operator recovering needs the env to name it.
+	if err := p.write(ctx, environmentID, repository.EnvironmentStatusUpdate{
+		Status:          string(model.EnvironmentStatusRunning),
+		DeployedVersion: params.Version,
+	}); err != nil {
 		return fmt.Errorf("mark running: %w", err)
 	}
 	return nil
 }
 
 // fail records the failed status best-effort and returns the underlying cause,
-// so a status-write hiccup never masks the real provisioning failure.
+// so a status-write hiccup never masks the real provisioning failure. The write
+// error is logged rather than dropped, because a lost failure write is what
+// leaves an env stranded in `provisioning`.
 func (p *EnvironmentProvisioner) fail(ctx context.Context, environmentID, reason string, cause error) error {
-	_ = p.status.UpdateProvisioningStatus(ctx, environmentID, string(model.EnvironmentStatusFailed), reason)
+	update := repository.EnvironmentStatusUpdate{
+		Status:         string(model.EnvironmentStatusFailed),
+		ProvisionError: reason,
+	}
+	if err := p.write(ctx, environmentID, update); err != nil {
+		log.Printf("erun api env deploy: recording failed status for environment=%q did not persist: %v (deploy failure: %v)", environmentID, err, cause)
+	}
 	return cause
+}
+
+// write applies one lifecycle transition, retrying a transient failure a bounded
+// number of times.
+func (p *EnvironmentProvisioner) write(ctx context.Context, environmentID string, update repository.EnvironmentStatusUpdate) error {
+	var err error
+	for attempt := range statusWriteAttempts {
+		if err = p.status.UpdateProvisioningStatus(ctx, environmentID, update); err == nil {
+			return nil
+		}
+		if attempt == statusWriteAttempts-1 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(p.backoff):
+		}
+	}
+	return err
 }

--- a/erun-backend/erun-backend-api/internal/service/environments_test.go
+++ b/erun-backend/erun-backend-api/internal/service/environments_test.go
@@ -6,15 +6,25 @@ import (
 	"testing"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/deployexec"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
 )
 
 type recordingStatusWriter struct {
 	transitions []string // "status:error" per call
+	updates     []repository.EnvironmentStatusUpdate
 	err         error
+	// failFirst makes the first n calls fail, exercising the bounded retry.
+	failFirst int
+	calls     int
 }
 
-func (w *recordingStatusWriter) UpdateProvisioningStatus(_ context.Context, _, status, provisionError string) error {
-	w.transitions = append(w.transitions, status+":"+provisionError)
+func (w *recordingStatusWriter) UpdateProvisioningStatus(_ context.Context, _ string, update repository.EnvironmentStatusUpdate) error {
+	w.calls++
+	if w.calls <= w.failFirst {
+		return errors.New("database unavailable")
+	}
+	w.transitions = append(w.transitions, update.Status+":"+update.ProvisionError)
+	w.updates = append(w.updates, update)
 	return w.err
 }
 
@@ -29,7 +39,16 @@ func (r fakeRunner) Run(context.Context, deployexec.DeployJobParams) (deployexec
 
 func provision(t *testing.T, runner DeployRunner, status *recordingStatusWriter) error {
 	t.Helper()
-	return NewEnvironmentProvisioner(runner, status).Provision(context.Background(), "env-1", deployexec.DeployJobParams{})
+	return provisionVersion(t, runner, status, "")
+}
+
+// provisionVersion drives one deploy with the retry backoff removed, so the
+// bounded-retry path costs no wall-clock in tests.
+func provisionVersion(t *testing.T, runner DeployRunner, status *recordingStatusWriter, version string) error {
+	t.Helper()
+	provisioner := NewEnvironmentProvisioner(runner, status)
+	provisioner.backoff = 0
+	return provisioner.Provision(context.Background(), "env-1", deployexec.DeployJobParams{Version: version})
 }
 
 func TestProvisionMarksRunningOnSuccess(t *testing.T) {
@@ -63,6 +82,57 @@ func TestProvisionMarksFailedOnRunError(t *testing.T) {
 	}
 	if status.transitions[len(status.transitions)-1] != "failed:cluster unreachable" {
 		t.Fatalf("last transition = %q, want failed:cluster unreachable", status.transitions[len(status.transitions)-1])
+	}
+}
+
+// TestProvisionRecordsDeployedVersionOnSuccess: reaching running is what makes
+// the version live, so that is where the env records what it is running.
+func TestProvisionRecordsDeployedVersionOnSuccess(t *testing.T) {
+	status := &recordingStatusWriter{}
+	if err := provisionVersion(t, fakeRunner{outcome: deployexec.OutcomeSucceeded}, status, "1.2.3"); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	if got := status.updates[0].DeployedVersion; got != "" {
+		t.Fatalf("deployed version recorded while still provisioning: %q", got)
+	}
+	if got := status.updates[1].DeployedVersion; got != "1.2.3" {
+		t.Fatalf("running update deployedVersion = %q, want 1.2.3", got)
+	}
+}
+
+// TestProvisionLeavesDeployedVersionOnFailure: a failed deploy does not change
+// what the cluster is running, so it must not claim a new deployed version.
+func TestProvisionLeavesDeployedVersionOnFailure(t *testing.T) {
+	status := &recordingStatusWriter{}
+	if err := provisionVersion(t, fakeRunner{outcome: deployexec.OutcomeFailed}, status, "1.2.3"); err == nil {
+		t.Fatal("expected an error when the deploy job fails")
+	}
+	for i, update := range status.updates {
+		if update.DeployedVersion != "" {
+			t.Fatalf("update[%d] recorded deployedVersion %q on a failed deploy", i, update.DeployedVersion)
+		}
+	}
+}
+
+// TestProvisionRetriesTransientStatusWrite: a lost lifecycle write strands the
+// env in provisioning under an already-terminal workflow, so the write retries.
+func TestProvisionRetriesTransientStatusWrite(t *testing.T) {
+	status := &recordingStatusWriter{failFirst: 2}
+	if err := provisionVersion(t, fakeRunner{outcome: deployexec.OutcomeSucceeded}, status, "1.2.3"); err != nil {
+		t.Fatalf("provision should survive a transient status-write failure: %v", err)
+	}
+	assertTransitions(t, status.transitions, []string{"provisioning:", "running:"})
+}
+
+// TestProvisionFailsWhenStatusWriteNeverSucceeds: retries are bounded, so a
+// database that stays down surfaces the error rather than looping.
+func TestProvisionFailsWhenStatusWriteNeverSucceeds(t *testing.T) {
+	status := &recordingStatusWriter{failFirst: statusWriteAttempts}
+	if err := provisionVersion(t, fakeRunner{outcome: deployexec.OutcomeSucceeded}, status, "1.2.3"); err == nil {
+		t.Fatal("expected the exhausted status write to surface an error")
+	}
+	if status.calls != statusWriteAttempts {
+		t.Fatalf("status write attempted %d times, want %d", status.calls, statusWriteAttempts)
 	}
 }
 

--- a/erun-backend/erun-backend-db/migrations/default/20260816120000_env_deployed_version.sql
+++ b/erun-backend/erun-backend-db/migrations/default/20260816120000_env_deployed_version.sql
@@ -1,0 +1,9 @@
+-- Record which runtime version an environment is actually running, distinct
+-- from `runtime_version` (the operator's declared pin). The deploy executor
+-- writes it when the deploy lands, so an env can always name what it is running
+-- -- which is exactly what recovery needs after a later deploy of a different
+-- version fails.
+-- Hand-written column add (atlas migrate diff is login-gated on the RLS
+-- functions in the source schema); no new table/RLS, so the existing
+-- environments row-level security already covers this column.
+ALTER TABLE "environments" ADD COLUMN "deployed_version" text NULL;

--- a/erun-backend/erun-backend-db/migrations/default/atlas.sum
+++ b/erun-backend/erun-backend-db/migrations/default/atlas.sum
@@ -1,4 +1,4 @@
-h1:jYX5902nDn04ImMdLfJL1P9t0DAgJRrIKl+sx5TEL50=
+h1:9XNM0fWNGbjYm+zbX7tPNv2mW4MXO9JCovrDfiJTDsk=
 20260501120000_initial_tenant_identity.sql h1:RpS03/4sFjbCggwYgcGNn6k3jNZCNTNl0BD/afOKFzo=
 20260503143000_tenant_issuer_names.sql h1:VEZjICG3/jU2YtEx0XX05l9Q8lJyWKeiRY8f4dXOkvE=
 20260503170000_audit_events.sql h1:OLjiGP/FhLTWvkx1bxS2xCcJK6tExdufnEC8R6LsKWA=
@@ -7,3 +7,4 @@ h1:jYX5902nDn04ImMdLfJL1P9t0DAgJRrIKl+sx5TEL50=
 20260624160330_tenant_env_quota.sql h1:kezgTEMk6MOalPbJen2uoucMm8jxJQ4nowGCnreYNGk=
 20260625120000_context_provisioning.sql h1:VzIUJx9vdNEzADuxKONvZiDODahI3S9Urf9liLvtCVY=
 20260714120000_env_provision_status.sql h1:OwYEmbnFhj3ycSmNmQU2DG+TD2WwIaLIS3Pz8BdeQQM=
+20260816120000_env_deployed_version.sql h1:MfvNx33/xZFayTf38nj0MlXhzmI+sqW+EydVLt9Tk90=

--- a/erun-backend/erun-backend-db/schema/tables/environments.sql
+++ b/erun-backend/erun-backend-db/schema/tables/environments.sql
@@ -8,6 +8,7 @@ CREATE TABLE environments (
   runtime_version TEXT,
   status TEXT NOT NULL DEFAULT 'registered',
   provision_error TEXT,
+  deployed_version TEXT,
   created_at TIMESTAMPTZ,
   updated_at TIMESTAMPTZ,
   FOREIGN KEY (tenant_id) REFERENCES tenants (tenant_id),

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -100,6 +100,7 @@ The `(iss, org) → tenant` resolution model and first-identity bootstrap above 
 | `GET` | `/v1/environments` | List the tenant's environments. | Tenant member |
 | `POST` | `/v1/environments` | Register an environment in the caller's tenant, bound to a referenced context; when the deploy executor is configured, a runtime env with a pinned version also starts its durable server-side deploy (`202`). Body below. | Tenant member (write) |
 | `GET` | `/v1/environments/{environment_id}` | Fetch one environment by id. | Tenant member |
+| `POST` | `/v1/environments/{environment_id}/deploy` | Deploy an already-registered runtime env at a published version — the retry and version-change path (`202`). Body below. | Tenant member (write) |
 | `POST` | `/v1/environments/{environment_id}/mcp-token` | Mint a per-env MCP bearer token (`{token, audience}`) for the caller to present to the env's `erun-mcp` edge. Body-less. Response below. | Tenant member (write) |
 | `POST` | `/v1/environments/{environment_id}/dns01-token` | Mint a per-env DNS-01 broker token (`{token, audience}`), the credential the cluster's cert-manager DNS-01 webhook presents to the [DNS-01 broker](#dns01-broker). Body-less. Response below. | Tenant member (write) |
 | `GET` | `/v1/contexts` | List the tenant's cloud contexts (managed clusters). | Tenant member |
@@ -195,18 +196,23 @@ On success the endpoint persists the row and returns it. The status code tells t
   "contextId": "019a7fa5-c2c0-7c55-bc70-714873a71f20",
   "runtimeVersion": "1.2.3",
   "status": "registered",       // provisioning lifecycle: registered → provisioning → running/failed
+  "deployedVersion": "1.2.2",   // omitted until a deploy has landed; see below
   "createdAt": "2026-06-24T10:00:00Z",
   "updatedAt": "2026-06-24T10:00:00Z"
 }
 ```
 
-A newly-registered environment is `registered` — the row exists but nothing is deployed. The server-side deploy executor (#605) then moves it `provisioning` → `running`/`failed` and sets `provisionError` on failure; the same `status`/`provisionError` appear on `GET /v1/environments/{id}` and in the `GET /v1/config` read model.
+A newly-registered environment is `registered` — the row exists but nothing is deployed. The server-side deploy executor then moves it `provisioning` → `running`/`failed` and sets `provisionError` on failure; the same `status`/`provisionError` appear on `GET /v1/environments/{id}` and in the `GET /v1/config` read model.
+
+**`runtimeVersion` vs `deployedVersion`.** `runtimeVersion` is the version the environment is **pinned** to — operator-authored, set at registration. `deployedVersion` is the version a deploy **actually installed**, written when that deploy reaches `running`. They are equal in the steady state and diverge in exactly two cases: a [`POST /v1/environments/{id}/deploy`](#deploy-endpoint) that named a different version, and a failed deploy — which leaves `deployedVersion` on the version the cluster is still running, because a deploy that failed did not remove what was already there. `deployedVersion` is omitted until the environment's first successful deploy.
 
 **Per-tenant environment-count quota.** After validating the body and before persisting, the endpoint enforces the tenant's environment-count cap: it compares how many environments the tenant already has against the cap and rejects the registration with HTTP `409` once the tenant is at or over it. The cap defaults to **10** and is overridden per tenant by a `tenant_quotas.max_environments` row. That override row is set by the operations-only [`PUT /v1/tenants/{tenant_id}/quota`](#put-v1tenantstenant_idquota) endpoint (below). Both the count and the cap are read under row-level security, so each is scoped to the caller's own tenant.
 
 **Server-side deploy executor.** When configured, the backend deploys the runtime chart itself: it runs the deploy as a Kubernetes `Job` in the tenant's `<tenant>-devops` runtime image (which carries `erun` + `helm` + `kubectl`) under a cluster-admin ServiceAccount, invoking `erun deploy <tenant> <env> --version <runtimeVersion>`, and watches the Job to completion — succeeded → `running`, failed → `failed` with the reason on `provisionError`. A durable workflow (DBOS) wraps this, keyed by environment id, so a control-plane restart resumes an in-flight deploy rather than double-deploying. The deploy image is `<registry>/<tenant>-devops:<runtimeVersion>` (image-baked config model).
 
 The executor is **opt-in and off by default** — it requires the backend to run in-cluster with a durable-workflow database, a kube client, and the deployer ServiceAccount configured (chart value `api.envDeployer.enabled`, which also provisions the SA and its cluster-admin binding). When it is off, or the env is not a `runtime` env, or no `runtimeVersion` is pinned, the endpoint is register-only (`201`) exactly as before.
+
+Registration deploys an environment **once**. To deploy it again — retrying a failure, or moving it to another published version — use [`POST /v1/environments/{id}/deploy`](#deploy-endpoint).
 
 **Error behaviour.** Today the API returns a bare HTTP status with a plain-text body (no JSON envelope):
 
@@ -216,6 +222,36 @@ The executor is **opt-in and off by default** — it requires the backend to run
 | `401` / `403` | Standard auth failures (see [Errors](#errors)). The `WriteAll` permission covers `POST /v1/environments`. | Send a valid token whose roles permit the write. |
 | `409` | The tenant is at its environment-count cap (default `10` unless a `tenant_quotas` row overrides it); the body is `environment quota reached: this tenant already has N of N environments`. | Delete an unused environment, or raise the tenant's cap via [`PUT /v1/tenants/{tenant_id}/quota`](#put-v1tenantstenant_idquota) (operations-only). |
 | `500` | Persistence failed — e.g. `contextId` references a context that is not the caller's (the composite `(tenant_id, context_id)` foreign key is violated), or the request-scoped security context is missing (an internal wiring error). The row is persisted **before** the deploy is started, so a `failed to start provisioning` `500` (the deploy executor could not enqueue the durable workflow) leaves the environment registered — re-create is a no-op conflict; poll `GET /v1/environments/{id}` to confirm the row exists. | Reference a context owned by the caller's tenant; if it persists with a valid context, it is a server bug. |
+
+### `POST /v1/environments/{environment_id}/deploy` {#deploy-endpoint}
+
+Deploys an **already-registered** runtime environment. [`POST /v1/environments`](#post-v1environments) deploys an environment once, as a side effect of registering it; this endpoint is how an environment is deployed *again* — to retry a deploy that failed, or to move the environment to a different published runtime version. The environment is resolved from `{environment_id}` under row-level security, so a token can only deploy its own tenant's environments.
+
+It composes the **pure `deploy` primitive**: the version must already be published, and the endpoint never builds or pushes. Nothing here mints a version.
+
+```jsonc
+// POST /v1/environments/{environment_id}/deploy body — optional in full
+{
+  "version": "1.3.0"   // optional — defaults to the environment's pinned runtimeVersion
+}
+```
+
+A body-less request (no body at all, or `{}`) deploys the environment's own `runtimeVersion`. On success the endpoint returns **`202 Accepted`** with the environment row as it was read, having flipped it to `provisioning` and started the durable workflow. Poll `GET /v1/environments/{id}` (or the `GET /v1/config` read model) to follow it to `running`/`failed`; on `running`, `deployedVersion` names the version that landed.
+
+**One deploy at a time.** Before starting the workflow the endpoint takes an atomic **claim** on the environment — a conditional write that sets `provisioning` only when the environment is not already deploying. A second request while one is in flight gets `409` rather than launching a second rollout into the same Helm release, where the loser's terminal status write could clobber the winner's. A claim left behind by a control plane that crashed mid-deploy goes **stale after 45 minutes** (longer than the deploy Job's own 30-minute deadline, so a claim is only stale once the run behind it cannot still be live) and becomes re-claimable, so an environment is never locked out permanently.
+
+**Every deploy is a real re-run.** The deploy Job and its durable workflow are keyed by *attempt*, not by environment: each request mints an attempt id that names the Job (`erun-deploy-<tenant>-<env>-<version>-<attempt>`) and the workflow. Keying by environment would make both terminal after the first deploy, so a retry would silently replay the old outcome instead of running. The attempt id is part of the checkpointed workflow input, so a control-plane restart still resumes by re-watching the Job that attempt already created rather than starting a second one.
+
+**Error behaviour.** Bare HTTP status with a plain-text body (no JSON envelope):
+
+| Status | Condition | Recovery |
+|---|---|---|
+| `400` | The environment is not a `runtime` env (`only a runtime environment can be deployed`); no version resolves — the body omitted one and the environment has no pinned `runtimeVersion` (`version is required: …`); or the body is present but not valid JSON (`invalid request body`). | Deploy a runtime env, and name a published `version` when the environment has no pin. |
+| `401` / `403` | Standard auth failures (see [Errors](#errors)). The `WriteAll` permission covers this write. | Send a valid token whose roles permit the write. |
+| `404` | No environment with `{environment_id}` in the caller's tenant (row-level security returns not-found for another tenant's env, never leaking its existence). | Deploy an environment id the caller's tenant owns. |
+| `409` | A deploy is already in flight for this environment (`a deploy is already in progress for this environment`); the claim is held. | Poll `GET /v1/environments/{id}` until it leaves `provisioning`, or wait out the 45-minute stale window if the holder crashed. |
+| `501` | The deploy executor is not configured (`the deploy executor is not configured`) — the backend has no durable-workflow database, kube client, or deployer ServiceAccount. | Enable `api.envDeployer.enabled` on the backend chart. |
+| `500` | The claim write failed, or the durable workflow could not be enqueued (`failed to start deploy`). The claim is taken **before** the workflow starts, so this leaves the environment at `provisioning` with nothing running; it becomes re-deployable once the stale window elapses. | Retry after the stale window; if it persists, it is a server bug. |
 
 ### `POST /v1/environments/{environment_id}/mcp-token` {#mcp-token-endpoint}
 


### PR DESCRIPTION
Completes the hosted control plane's deploy half by making a registered environment deployable **on demand**, not only once as a side effect of registration.

## What was already on `main`

Worth stating up front, because #680's own description is stale. The `TODO(#660 live)` the issue points at is **gone**: the env-deploy executor landed on `main` between June and now, in a different shape than PR #681 proposed —

- `internal/deployexec` runs the deploy as a Kubernetes `Job` in the tenant's `<tenant>-devops` runtime image (which carries `erun` + `helm` + `kubectl`) under a cluster-admin ServiceAccount, and watches it to a terminal outcome.
- `internal/provision.EnvProvisioner` wraps that in a durable DBOS workflow.
- `POST /v1/environments` returns `202` and starts it for a runtime env with a pinned version.
- `environments` already carries `status` (`registered`/`provisioning`/`running`/`failed`) + `provision_error`.

So this PR does **not** re-land that. It lands the part of #680 that is genuinely still missing, on `main`'s architecture.

## What this adds

**`POST /v1/environments/{environment_id}/deploy`** — deploy an already-registered runtime environment at a published version. Until now an environment could only ever be deployed once; a failed deploy had no retry, and moving to another runtime version had no path at all. The version comes from the body, or defaults to the environment's own pin. It composes the pure `deploy` primitive: the version must already be published, and this never builds or pushes.

Two things had to become genuinely re-runnable for that to be real, and both were latent bugs:

- **Concurrency.** The deploy slot is now claimed atomically (`EnvironmentRepository.ClaimDeploy`) before the workflow starts, so a double-submit gets `409` instead of a second rollout into the same Helm release whose terminal write could clobber the first one's. A claim left by a control plane that crashed mid-deploy goes stale after 45 minutes (longer than the Job's own 30-minute deadline), so an environment is never locked out permanently.
- **Replay.** The deploy Job *and* its workflow were both keyed by environment, so both were terminal after the first deploy — a retry would have silently replayed the old outcome without touching the cluster. Both are now keyed by attempt. The attempt id rides in the checkpointed workflow input, so a resumed workflow still re-watches its own Job rather than starting a second one. `DeployJobName` also gained a length guard: it could previously exceed Kubernetes' 63-character object-name limit.

**`environments.deployed_version`** — the version a deploy actually installed, as distinct from `runtime_version`, the declared pin. Written when the deploy lands, so an environment can name what it is running; a failed deploy leaves it on the version the cluster still has. This follows the repo rule about recording what has been applied to a cluster *when* it is applied.

**Lifecycle-write hardening** — status writes retry a transient database failure instead of stranding an environment in `provisioning` under a workflow that has already finished, and a lost failure write is logged rather than dropped.

## Carried from PR #681, and what was dropped

| Commit | Carried |
|---|---|
| `f06a17fa` | The deploy endpoint, the deploy lifecycle addition + migration + declarative schema, and the docs. Adapted to `main`'s `status`/`provision_error` naming rather than adding a parallel `deploy_status`, and to the Job-based executor rather than a new `internal/deploy`. |
| `d9f60632` | The substance: the atomic deploy claim + `409`, the stale-claim window, the status-write retry, the logged (not discarded) failure write, and the fresh-per-attempt workflow id. |
| `e3c419c1` | **Dropped.** It replaced `RunHelmDeploy` with in-process Helm + Kubernetes SDKs. `main` has since chosen the opposite for the same no-binaries reason: the API pod stays executable-free by launching a Job in the runtime image rather than by embedding helm. Carrying it would reverse a deliberate later decision and add `helm.sh/helm/v3` + the k8s cli-runtime to the API. The invariant it exists to protect is satisfied by `main`'s design. |
| `5d43e2a1` | **Dropped.** `noexec_test.go` fails on `main` today: `internal/provision/provisioner.go` imports `os/exec` and shells the `aws` binary. Making it pass means replacing that with aws-sdk-go-v2 — that is #682, explicitly out of scope here. Landing the test would have meant either a red gate or an exemption, and an exemption is exactly the suppression the repo rules forbid. Worth landing with #682. |

Also deliberately out of scope, not carried and not closed: #682, #683, #684, #606, #686. **No console change** — the executor is the deliverable; a console deploy affordance is a separate concern and #681's version of it depended on a `RegisterEnvPanel` that only exists on that branch.

The hosted executor still resolves the runtime image from a single `ERUN_RUNTIME_REGISTRY` with no resolution ladder. That is #683 and is untouched here — neither fixed nor regressed.

## Migration

`20260816120000_env_deployed_version.sql`, placed after `20260714120000_env_provision_status.sql` (the current tip; #681's June-dated file would have sorted before three migrations that have since landed). `atlas.sum` regenerated with `atlas migrate hash`, not hand-edited. `atlas migrate validate` is clean and all 9 migrations apply cleanly to a real PostgreSQL 18.

## Verification

The opt-in e2e (`ERUN_E2E_ENV_DEPLOY=1`, skipped by default) needs only a conformant Kubernetes cluster — **no Lima, no virtualization** — so it runs in-pod against k3d or kind. It was run against a real k3d k3s cluster with a real migrated PostgreSQL:

- Registered an environment with no pinned version, so the explicit endpoint is unambiguously what deployed it.
- `POST .../deploy` → `202` → real Job `erun-deploy-operations-prod-1-0-149-<attempt>` in the platform namespace → helm installed release `operations-devops` into namespace `operations-prod` → Deployment, ReplicaSet, running Pod and ConfigMap landed → environment reached `running` with `deployedVersion: 1.0.149`.
- Deployed again at the same version: a **second, distinct** Job ran to completion and Helm recorded revision `v2` — the replay bug, proven fixed against a real cluster rather than a fake client.
- `ClaimDeploy` exercised against real PostgreSQL: second claim refused, stale claim re-granted.
- `409` observed over HTTP by holding the claim rather than racing two deploys, so the assertion is deterministic.

The tenant runtime image was stood in for by a fixture image that really runs `helm upgrade --install` into `<tenant>-<env>`, since no published tenant `<tenant>-devops` image exists in this environment. So what is verified is the backend's contract end-to-end — endpoint → claim → durable workflow → real Job → real helm release → recorded lifecycle. What is **not** verified is `erun deploy`'s own chart resolution inside a real tenant runtime image, which needs a published tenant image and is that command's own contract.

Every cluster, container, image and binary created for the run was removed afterwards.

## Gates

| Gate | Result |
|---|---|
| `make check` (lint × 5 modules + integration suite) | pass — 0 issues; coverage 76.0% ≥ 75.7% |
| `erun-backend-api` `go test ./...` | pass |
| `erun-backend-api` `golangci-lint run ./...` | pass — 0 issues |
| `erun-backend-db` — `atlas migrate hash` / `validate` / apply to real PostgreSQL 18 | pass — 9 migrations, 151 statements |
| `erun-docs` `yarn build` | pass — clean, no broken links or anchors |
| Every Go module linted (pre-commit hook's broader set, incl. `erun-ui`) | pass — 0 issues |
| Opt-in env-deploy e2e against live k3d + PostgreSQL | pass |

## On PR #681

#681 is superseded in part by this PR. It is 400 commits behind `main`, `mergeable: false`, and bundles six issues. It should be **re-cut for its remaining issues (#682, #683, #684, #606, #686), not rebased** — the deploy work it carried is either already on `main` or landed here, and its in-process-Helm commit contradicts the architecture `main` settled on.

Closes #680
