### PR TITLE
Fix six live-platform defects found deploying erun 1.0.182

### DIFF
--- a/erun-backend/erun-backend-api/internal/repository/tenants.go
+++ b/erun-backend/erun-backend-api/internal/repository/tenants.go
@@ -69,6 +69,13 @@ func (r *TenantRepository) Create(ctx context.Context, params CreateTenantParams
 			`INSERT INTO tenant_issuers (tenant_id, issuer, org_field_value, name) VALUES (?, ?, ?, ?)`,
 			tenant.TenantID, issuer, nullIfEmpty(orgFieldValue), displayName,
 		).Exec(ctx); err != nil {
+			// (issuer, org_field_value) is the token-resolution key: a caller that
+			// repeats an already-mapped issuer with the same org discriminator (or
+			// no discriminator at all) collides here, not on (tenant_id, issuer) —
+			// this insert always mints a fresh tenant_id first.
+			if isUniqueViolation(err) {
+				return ErrConflict
+			}
 			return err
 		}
 		return nil

--- a/erun-backend/erun-backend-api/internal/routes/tenants.go
+++ b/erun-backend/erun-backend-api/internal/routes/tenants.go
@@ -2,6 +2,8 @@ package routes
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -67,10 +69,32 @@ func (r TenantRoutes) createTenant(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	params, status, msg := parseCreateTenantParams(req)
+	if msg != "" {
+		writeError(w, status, msg)
+		return
+	}
+
+	created, err := r.tenants.Create(req.Context(), params)
+	if err != nil {
+		if errors.Is(err, repository.ErrConflict) {
+			writeError(w, http.StatusConflict, duplicateIssuerMessage(params.Issuer, params.OrgFieldValue))
+			return
+		}
+		writeRepositoryError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, created)
+}
+
+// parseCreateTenantParams decodes and validates the tenant-registration body,
+// returning a non-empty message (with its HTTP status) when the input must be
+// rejected before ever reaching the repository.
+func parseCreateTenantParams(req *http.Request) (repository.CreateTenantParams, int, string) {
 	var body createTenantRequest
 	if err := decodeJSON(req, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
-		return
+		return repository.CreateTenantParams{}, http.StatusBadRequest, "invalid request body"
 	}
 
 	name := strings.TrimSpace(body.Name)
@@ -81,34 +105,36 @@ func (r TenantRoutes) createTenant(w http.ResponseWriter, req *http.Request) {
 	// cross-tenant namespace-collision/takeover vector on a public
 	// provisioning surface.
 	if err := eruncommon.ValidateTenantName(name); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
+		return repository.CreateTenantParams{}, http.StatusBadRequest, err.Error()
 	}
 	if issuer == "" {
-		writeError(w, http.StatusBadRequest, "issuer is required")
-		return
+		return repository.CreateTenantParams{}, http.StatusBadRequest, "issuer is required"
 	}
 	tenantType := model.TenantType(strings.TrimSpace(body.Type))
 	if tenantType == "" {
 		tenantType = model.TenantTypeCompany
 	}
 	if tenantType != model.TenantTypeCompany && tenantType != model.TenantTypeOperations {
-		writeError(w, http.StatusBadRequest, "type must be one of COMPANY, OPERATIONS")
-		return
+		return repository.CreateTenantParams{}, http.StatusBadRequest, "type must be one of COMPANY, OPERATIONS"
 	}
 
-	created, err := r.tenants.Create(req.Context(), repository.CreateTenantParams{
+	return repository.CreateTenantParams{
 		Name:          name,
 		Type:          tenantType,
 		Issuer:        issuer,
 		OrgFieldKey:   strings.TrimSpace(body.OrgFieldKey),
 		OrgFieldValue: strings.TrimSpace(body.OrgFieldValue),
 		DisplayName:   strings.TrimSpace(body.DisplayName),
-	})
-	if err != nil {
-		writeRepositoryError(w, err)
-		return
-	}
+	}, 0, ""
+}
 
-	writeJSON(w, http.StatusCreated, created)
+// duplicateIssuerMessage names the (issuer, org) mapping a create collided
+// with, since a caller re-registering an already-mapped issuer needs to know
+// whether to pick a different org discriminator or that the issuer is simply
+// taken.
+func duplicateIssuerMessage(issuer, orgFieldValue string) string {
+	if orgFieldValue == "" {
+		return fmt.Sprintf("issuer %q is already mapped to a tenant with no org discriminator; pass --org-field-key/--org-field-value to scope a shared issuer to a different org", issuer)
+	}
+	return fmt.Sprintf("issuer %q is already mapped for org value %q", issuer, orgFieldValue)
 }

--- a/erun-backend/erun-backend-api/internal/routes/tenants_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/tenants_test.go
@@ -125,6 +125,40 @@ func TestCreateTenantOperationsCallerPersists(t *testing.T) {
 	}
 }
 
+func TestCreateTenantDuplicateIssuerReturnsConflict(t *testing.T) {
+	tenants := &stubTenantRepository{err: repository.ErrConflict}
+	rec := postCreateTenant(t, tenants, string(model.TenantTypeOperations), `{
+		"name": "acme",
+		"type": "COMPANY",
+		"issuer": "https://idp.example"
+	}`)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("https://idp.example")) {
+		t.Fatalf("expected the conflict message to name the issuer, got %s", rec.Body.String())
+	}
+}
+
+func TestCreateTenantDuplicateOrgScopedIssuerReturnsConflict(t *testing.T) {
+	tenants := &stubTenantRepository{err: repository.ErrConflict}
+	rec := postCreateTenant(t, tenants, string(model.TenantTypeOperations), `{
+		"name": "acme",
+		"type": "COMPANY",
+		"issuer": "https://idp.example",
+		"orgFieldKey": "org_id",
+		"orgFieldValue": "42"
+	}`)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("42")) {
+		t.Fatalf("expected the conflict message to name the org value, got %s", rec.Body.String())
+	}
+}
+
 func TestListTenants(t *testing.T) {
 	want := []model.Tenant{{TenantID: "tenant-1", Name: "acme"}, {TenantID: "tenant-2", Name: "beta"}}
 	tenants := &stubTenantRepository{list: want}

--- a/erun-backend/erun-backend-api/server.go
+++ b/erun-backend/erun-backend-api/server.go
@@ -2,7 +2,9 @@ package backendapi
 
 import (
 	"database/sql"
+	"log"
 	"net/http"
+	"strings"
 
 	"github.com/dbos-inc/dbos-transact-golang/dbos"
 	"k8s.io/client-go/kubernetes"
@@ -214,15 +216,40 @@ func registerDatabaseRoutes(register routes.ProtectedRouteRegistrar, options Han
 
 // newEnvironmentProvisioner wires live env provisioning, which needs durable
 // workflows, an in-cluster client, and the full deploy placement. Anything
-// missing leaves it nil, so env creation only registers the row.
+// missing leaves it nil, so env creation only registers the row. Without a
+// startup log naming which precondition failed, an operator sees only a 501
+// at call time with no way to tell which of the five is unmet.
 func newEnvironmentProvisioner(options HandlerOptions, environments *repository.EnvironmentRepository) routes.EnvironmentProvisioner {
 	deploy := options.EnvDeploy
-	if options.DBOSContext == nil || options.KubeClient == nil ||
-		deploy.DeployerServiceAccount == "" || deploy.PlatformNamespace == "" || deploy.Registry == "" {
+	if reasons := missingEnvProvisionerConfig(options, deploy); len(reasons) > 0 {
+		log.Printf("erun api live env provisioning disabled: %s", strings.Join(reasons, "; "))
 		return nil
 	}
 	coordinator := service.NewEnvironmentProvisioner(deployexec.NewLauncher(options.KubeClient), environments)
 	return provision.NewEnvProvisioner(options.DBOSContext, coordinator, deploy)
+}
+
+// missingEnvProvisionerConfig names every unmet precondition for live env
+// provisioning, so the startup log can point at exactly what is missing
+// rather than leaving an operator to infer it from a 501 at call time.
+func missingEnvProvisionerConfig(options HandlerOptions, deploy provision.EnvDeployConfig) []string {
+	var reasons []string
+	if options.DBOSContext == nil {
+		reasons = append(reasons, "DBOS_SYSTEM_DATABASE_URL is not set")
+	}
+	if options.KubeClient == nil {
+		reasons = append(reasons, "no in-cluster Kubernetes client (the env-deployer service account is not set)")
+	}
+	if deploy.DeployerServiceAccount == "" {
+		reasons = append(reasons, "the env-deployer service account is not set")
+	}
+	if deploy.PlatformNamespace == "" {
+		reasons = append(reasons, "the platform namespace is not set")
+	}
+	if deploy.Registry == "" {
+		reasons = append(reasons, "the env-deploy image registry is not set")
+	}
+	return reasons
 }
 
 // newEnvironmentLifecycle wires live stop/delete, which needs an in-cluster

--- a/erun-backend/erun-backend-api/server_test.go
+++ b/erun-backend/erun-backend-api/server_test.go
@@ -7,7 +7,31 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/provision"
 )
+
+func TestMissingEnvProvisionerConfigReportsAllFiveWhenUnset(t *testing.T) {
+	reasons := missingEnvProvisionerConfig(HandlerOptions{}, provision.EnvDeployConfig{})
+	if len(reasons) != 5 {
+		t.Fatalf("expected all five preconditions to be reported missing, got %v", reasons)
+	}
+}
+
+func TestMissingEnvProvisionerConfigReportsOnlyDBOSWhenEverythingElseSet(t *testing.T) {
+	options := HandlerOptions{KubeClient: k8sfake.NewSimpleClientset()}
+	deploy := provision.EnvDeployConfig{
+		Registry:               "ghcr.io/sophium",
+		PlatformNamespace:      "team-devops",
+		DeployerServiceAccount: "team-env-deployer",
+	}
+	reasons := missingEnvProvisionerConfig(options, deploy)
+	if len(reasons) != 1 || !strings.Contains(reasons[0], "DBOS_SYSTEM_DATABASE_URL") {
+		t.Fatalf("expected exactly one reason naming the missing DBOS config, got %v", reasons)
+	}
+}
 
 func TestHandlerRequiresBearerTokenForAPIEndpoint(t *testing.T) {
 	handler, err := NewHandler(HandlerOptions{

--- a/erun-devops/docker/erun-docs/Dockerfile
+++ b/erun-devops/docker/erun-docs/Dockerfile
@@ -1,7 +1,10 @@
 ARG ERUN_VERSION=1.0.0
 
 # Stage 1: build the Docusaurus static site.
-FROM node:20.18.1-alpine AS builder
+# Pinned to the build host's platform: the site it emits is static assets with
+# no architecture, so building it once natively beats building it again under
+# emulation for the foreign arch every multi-arch build.
+FROM --platform=$BUILDPLATFORM node:20.18.1-alpine AS builder
 
 WORKDIR /src
 

--- a/erun-devops/k8s/erun-backend-api-chart_test.sh
+++ b/erun-devops/k8s/erun-backend-api-chart_test.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+# Locks the DBOS system-database wiring for erun-backend-api (#1047): live env
+# provisioning and the server-side release queue both require a non-nil
+# DBOSContext (server.go's newEnvironmentProvisioner/newReleaseQueue), and
+# DBOSContext is built only from the DBOS_SYSTEM_DATABASE_URL env var. Before
+# this fix the chart never rendered it under any flag, so api.envDeployer.enabled
+# could never actually enable live deploys -- POST /v1/environments/{id}/deploy
+# always answered 501, no matter what was set.
+#
+# Lives beside the chart rather than inside it, like erun-devops-chart_test.sh
+# and erun-zitadel-chart_test.sh: helm renders every file under templates/.
+
+set -eu
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+chart_dir="${script_dir}/erun-backend-api"
+
+command -v helm >/dev/null 2>&1 || {
+    echo "FAIL: helm is required to render the chart" >&2
+    exit 1
+}
+
+work_root="$(mktemp -d 2>/dev/null || mktemp -d -t erun-backend-api-chart-test)"
+trap 'rm -rf "${work_root}"' EXIT INT TERM
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+render() {
+    out="${work_root}/render.yaml"
+    helm template test "${chart_dir}" \
+        --set tenant=team \
+        --set environment=prod \
+        "$@" >"${out}" || fail "helm template failed"
+    printf '%s\n' "${out}"
+}
+
+container() {
+    awk '/^      containers:/{inside=1} inside' "$1"
+}
+
+# --- 1. Neither envDeployer nor the release queue is on: no DBOS wiring at all,
+#        byte-for-byte unchanged from before #1047 ---
+rendered=$(render)
+container "${rendered}" | grep -q 'DBOS_SYSTEM_DATABASE_URL' &&
+    fail "DBOS_SYSTEM_DATABASE_URL must not render when nothing needs DBOSContext"
+
+# --- 2. api.envDeployer.enabled must actually enable live deploys (#1047) ---
+rendered=$(render --set-string api.envDeployer.enabled=true)
+core="${work_root}/api.yaml"
+container "${rendered}" >"${core}"
+grep -q 'name: DBOS_SYSTEM_DATABASE_URL' "${core}" ||
+    fail "api.envDeployer.enabled must render DBOS_SYSTEM_DATABASE_URL, or DBOSContext stays nil and deploy always answers 501"
+grep -A1 'name: DBOS_SYSTEM_DATABASE_URL' "${core}" | grep -q 'value: "postgres://erun:\$(ERUN_POSTGRES_PASSWORD)@team-postgres:5432/erun_dbos_sys?sslmode=disable"' ||
+    fail "the DBOS database must be a separate database on the same postgres instance, not ERUN_DATABASE_URL's own database"
+grep -q 'name: ERUN_ENV_DEPLOYER_SERVICE_ACCOUNT' "${core}" ||
+    fail "envDeployer.enabled must still wire the deployer service account (unchanged by this fix)"
+
+# --- 3. The release queue needs DBOSContext too (server.go's newReleaseQueue) ---
+rendered=$(render --set-string api.releaseQueue.enabled=true --set-string api.releaseQueue.namespace=team-ux)
+container "${rendered}" >"${core}"
+grep -q 'name: DBOS_SYSTEM_DATABASE_URL' "${core}" ||
+    fail "api.releaseQueue.enabled must also render DBOS_SYSTEM_DATABASE_URL, or the release queue never dispatches"
+
+# --- 4. The DBOS database name and the full URL are overridable ---
+rendered=$(render --set-string api.envDeployer.enabled=true --set-string api.dbos.database=custom_dbos)
+container "${rendered}" >"${core}"
+grep -A1 'name: DBOS_SYSTEM_DATABASE_URL' "${core}" | grep -q '/custom_dbos?' ||
+    fail "api.dbos.database must override the DBOS database name"
+
+rendered=$(render --set-string api.envDeployer.enabled=true --set-string api.dbos.databaseURL=postgres://custom/url)
+container "${rendered}" >"${core}"
+grep -A1 'name: DBOS_SYSTEM_DATABASE_URL' "${core}" | grep -q 'value: "postgres://custom/url"' ||
+    fail "api.dbos.databaseURL must override the whole DBOS connection string"
+
+echo "PASS: erun-backend-api DBOS wiring"

--- a/erun-devops/k8s/erun-backend-api/templates/api.yaml
+++ b/erun-devops/k8s/erun-backend-api/templates/api.yaml
@@ -29,6 +29,17 @@
 {{- $postgresPasswordSecretName := default (printf "%s-backend-postgres" $tenant) $postgres.passwordSecretName -}}
 {{- $postgresPasswordSecretKey := default "password" $postgres.passwordSecretKey -}}
 {{- $databaseURL := default (printf "postgres://%s:$(ERUN_POSTGRES_PASSWORD)@%s-postgres:%v/%s?sslmode=disable" $postgresUser $tenant $postgresPort $postgresDatabase) $api.databaseURL -}}
+{{- /* DBOS (durable workflows) needs its own database, separate from
+       ERUN_DATABASE_URL -- DBOS owns and migrates its own system tables there.
+       It creates the database itself on first connect if missing, using the
+       same superuser credentials core already uses to create its own "zitadel"
+       database, so no separate bootstrap step is required. Rendered only when
+       a feature that actually needs DBOSContext is enabled (server.go's
+       newEnvironmentProvisioner/newReleaseQueue both require it); an env with
+       neither enabled stays byte-for-byte unchanged. */ -}}
+{{- $dbos := default dict $api.dbos -}}
+{{- $dbosDatabase := default (printf "%s_dbos_sys" $postgresDatabase) $dbos.database -}}
+{{- $dbosDatabaseURL := default (printf "postgres://%s:$(ERUN_POSTGRES_PASSWORD)@%s-postgres:%v/%s?sslmode=disable" $postgresUser $tenant $postgresPort $dbosDatabase) $dbos.databaseURL -}}
 {{- $imageOverrides := default dict .Values.imageOverrides -}}
 {{- $containerRegistry := default "ghcr.io/sophium" .Values.containerRegistry -}}
 {{- $backendAPIImage := default (printf "%s/erun-backend-api:%s" $containerRegistry .Chart.AppVersion) (index $imageOverrides "erun-backend-api") -}}
@@ -91,6 +102,7 @@
 {{- $_ := required "api.releaseQueue.namespace is required when the release queue is enabled: it is the agent environment's namespace the release Job runs in" $releaseNamespace }}
 {{- end }}
 {{- $apiServiceAccountNeeded := or $envDeployerEnabled $releaseQueueEnabled -}}
+{{- $dbosNeeded := or $envDeployerEnabled $releaseQueueEnabled -}}
 {{- if and $releaseQueueEnabled (not $envDeployerEnabled) }}
 apiVersion: v1
 kind: ServiceAccount
@@ -290,6 +302,10 @@ spec:
                   key: {{ $postgresPasswordSecretKey }}
             - name: ERUN_DATABASE_URL
               value: {{ $databaseURL | quote }}
+            {{- if $dbosNeeded }}
+            - name: DBOS_SYSTEM_DATABASE_URL
+              value: {{ $dbosDatabaseURL | quote }}
+            {{- end }}
             - name: ERUN_OIDC_ALLOWED_ISSUERS
               value: {{ $oidcAllowedIssuers | quote }}
             - name: ERUN_PLATFORM_ISSUER

--- a/erun-devops/k8s/erun-zitadel-chart_test.sh
+++ b/erun-devops/k8s/erun-zitadel-chart_test.sh
@@ -65,6 +65,21 @@ document() {
     awk -v want="kind: $2" 'BEGIN{RS="\n---\n"} $0 ~ ("(^|\n)" want "(\n|$)") {print}' "$1"
 }
 
+# The pod's initContainers: section only, so an assertion about restore-pats
+# cannot pass by matching a line that belongs to a regular container.
+init_containers_section() {
+    awk '/^      initContainers:/{inside=1;next} /^      containers:/{inside=0} inside' "$1"
+}
+
+# One initContainer entry as its own block.
+init_container() {
+    init_containers_section "$1" | awk -v want="        - name: $2" '
+        $0 == want {inside=1;print;next}
+        /^        - name: /{inside=0}
+        inside {print}
+    '
+}
+
 rendered=$(render)
 
 # --- 1. Three containers: core has no login UI, and a sidecar bootstraps the
@@ -258,5 +273,66 @@ container "${rendered}" oidc-bootstrap | grep -q 'image: reg.test/erun-devops:v9
 rendered=$(render --set-string platform.consoleUrl=https://console.example.test)
 container "${rendered}" oidc-bootstrap | grep -q 'value: "https://console.example.test"' ||
     fail "the console app's redirect URI must default to platform.consoleUrl"
+
+# --- 18. Every Management API call carries an explicit Host header (#1047) ---
+# Core resolves the instance a call targets from Host, not from the loopback
+# address the call is actually addressed to; a call with no Host header 404s.
+rendered=$(render)
+bootstrap="${work_root}/oidc-bootstrap.yaml"
+container "${rendered}" oidc-bootstrap >"${bootstrap}"
+grep -q 'name: EXTERNAL_DOMAIN' "${bootstrap}" ||
+    fail "the OIDC bootstrap sidecar must know the external domain to send as Host"
+grep -A1 'name: EXTERNAL_DOMAIN' "${bootstrap}" | grep -q 'value: "auth.example.test"' ||
+    fail "EXTERNAL_DOMAIN must be the platform's external domain"
+grep -q -- '-H "Host: \${EXTERNAL_DOMAIN}"' "${bootstrap}" ||
+    fail "every Management API call must carry an explicit Host header naming the external domain"
+
+# --- 19. A failed resolution never publishes an empty client id (#1047) ---
+# Publishing unconditionally would overwrite a working platform's ConfigMap
+# with empty strings the next time the Management API 404s.
+grep -q 'return 1' "${bootstrap}" ||
+    fail "reconcile must abort before touching the ConfigMap when resolution is incomplete"
+grep -B5 'kubectl create configmap' "${bootstrap}" | grep -q 'if \[ -z "\${project_id}" \] || \[ -z "\${cli_client_id}" \]' ||
+    fail "the ConfigMap publish must be guarded on the project and CLI app actually resolving"
+grep -q 'reconcile || echo "oidc-bootstrap: initial reconcile incomplete' "${bootstrap}" ||
+    fail "the initial reconcile must not exit the sidecar under set -e when resolution is incomplete"
+
+# --- 20. The bootstrap PATs survive a pod restart (#1047, sophium/erun#1047) ---
+# Core writes both PATs only once, at first-instance init, into an emptyDir
+# that does not survive a restart; without persistence a restarted pod's login
+# and oidc-bootstrap containers wait forever on files that never reappear.
+restore="${work_root}/restore-pats.yaml"
+init_container "${rendered}" restore-pats >"${restore}"
+[ -s "${restore}" ] || fail "the pod must run a restore-pats init container before core starts"
+grep -q '^              mountPath: /zitadel/bootstrap$' "${restore}" ||
+    fail "restore-pats must mount the shared bootstrap volume to seed it"
+grep -q 'name: PATS_SECRET_NAME' "${restore}" ||
+    fail "restore-pats must know which Secret durably holds the PATs"
+grep -A1 'name: PATS_SECRET_NAME' "${restore}" | grep -q 'value: "team-zitadel-pats"' ||
+    fail "the PATs Secret must default to <tenant>-zitadel-pats"
+grep -q 'kubectl get secret' "${restore}" ||
+    fail "restore-pats must read the durable PATs Secret"
+grep -q 'first-instance init will mint the PATs' "${restore}" ||
+    fail "restore-pats must no-op (not fail) when the Secret does not exist yet, i.e. on true first init"
+
+grep -q 'name: PATS_SECRET_NAME' "${bootstrap}" ||
+    fail "the OIDC bootstrap sidecar must know which Secret to persist the PATs into"
+grep -q 'persist_pats' "${bootstrap}" ||
+    fail "the OIDC bootstrap sidecar must persist both PATs into the durable Secret"
+grep -q 'kubectl create secret generic "\${PATS_SECRET_NAME}"' "${bootstrap}" ||
+    fail "persisting the PATs must target the configured Secret name"
+grep -q -- '--from-file="admin-sa.pat=' "${bootstrap}" ||
+    fail "the persisted Secret must hold the org-owner PAT"
+grep -q -- '--from-file="login-client.pat=' "${bootstrap}" ||
+    fail "the persisted Secret must hold the login-client PAT"
+
+# --- 21. Least-privilege RBAC for the durable PATs Secret ---
+role="${work_root}/pat-persist-role.yaml"
+document "${rendered}" Role | awk '/name: team-zitadel-pat-persist/{f=1} f{print} f && /^---$/{exit}' >"${role}"
+[ -s "${role}" ] || fail "a dedicated Role for the PATs Secret must render"
+grep -q 'resourceNames: \["team-zitadel-pats"\]' "${role}" ||
+    fail "get/update/patch on the PATs Secret must be scoped to its own name"
+grep -q 'verbs: \["create"\]' "${role}" ||
+    fail "create cannot be name-scoped (the object does not exist yet) so it must stay a separate rule"
 
 echo "PASS: erun-zitadel chart topology"

--- a/erun-devops/k8s/erun-zitadel/templates/zitadel.yaml
+++ b/erun-devops/k8s/erun-zitadel/templates/zitadel.yaml
@@ -20,6 +20,17 @@
     which its startupProbe on /ui/v2/login/healthy makes legible instead of a
     bare CrashLoop. One pod rather than two Deployments over a shared PVC keeps
     that handoff a local file, and this is a declared singleton anyway.
+  - Core only ever writes those PATs once, during first-instance init — a
+    restarted instance finds its database already initialised and skips that
+    step entirely, so nothing rewrites the file. An emptyDir does not survive a
+    pod restart either, so without more a restarted pod's login and
+    oidc-bootstrap containers wait forever on files that will never reappear
+    again (the pod sits at 2/3, sign-in dead). A `restore-pats` init container
+    seeds the emptyDir from a durable `<tenant>-zitadel-pats` Secret before core
+    starts — a no-op on the very first init, when the Secret does not exist yet
+    — and the oidc-bootstrap sidecar persists both PATs into that Secret the
+    same way it already publishes the OIDC client-id ConfigMap below, so first
+    init is unmodified and every later restart has both PATs immediately.
   - ONE Ingress with two paths: /ui/v2/login -> the login container, everything
     else (discovery, authorize, token, jwks, the Management API) -> core.
   - Login V2 must be switched on explicitly (LOGINV2_REQUIRED / LOGINV2_BASEURI
@@ -83,6 +94,11 @@
 {{- $loginPort := default 3000 $zitadel.loginPort -}}
 {{- $loginBasePath := "/ui/v2/login" -}}
 {{- $bootstrapDir := "/zitadel/bootstrap" -}}
+{{- /* Durable home for the two bootstrap PATs (see the file header). Chart
+       templating cannot pre-generate their value the way it does the admin
+       password — they are minted by Zitadel core itself — so this only names
+       where the runtime persists and restores them. */ -}}
+{{- $patsSecretName := default (printf "%s-zitadel-pats" $tenant) $zitadel.patsSecretName -}}
 {{- $ingressClass := default "traefik" $zitadel.ingressClass -}}
 {{- $ingressAnnotations := default dict $zitadel.ingressAnnotations -}}
 {{- /* The auth host sits in the Cloudflare-managed apex zone, not the delegated
@@ -138,8 +154,17 @@
        container's loopback, both issuing JWT access tokens (erun's bearer
        verifier rejects Zitadel's default opaque token), then publishes the
        client ids to a ConfigMap the erun-backend-api chart reads optionally
-       (absent -> empty platform.*ClientId, never a failed deploy). It
-       reconciles on a timer rather than exiting, so a ConfigMap or app deleted
+       (absent -> empty platform.*ClientId, never a failed deploy). Every call
+       carries an explicit Host header naming the external domain: Zitadel
+       resolves the instance the Management API call targets from that header,
+       not from the loopback address the call is actually addressed to, and a
+       call with no Host header 404s against every path. It never publishes a
+       result unless the project and the erun-cli app genuinely resolved —
+       the console app id is empty on purpose when platform.consoleUrl is
+       unset, but any other empty id aborts the reconcile before it touches
+       the ConfigMap, so a resolution failure leaves prior good data alone
+       instead of overwriting it with empty strings. It reconciles on a timer
+       rather than exiting, so a ConfigMap, an app, or the PATs Secret deleted
        out of band is restored without a redeploy. */ -}}
 {{- $oidc := default dict $zitadel.oidc -}}
 {{- $oidcProjectName := default (printf "%s-platform" $tenant) $oidc.projectName -}}
@@ -178,6 +203,39 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ $tenant }}-zitadel-oidc-bootstrap
+---
+# A separate least-privilege Role for the durable PATs Secret, rather than
+# widening the ConfigMap Role above: `create` cannot be scoped by
+# resourceNames (the object does not exist yet), so the two secrets verbs that
+# can be name-scoped are split from it.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $tenant }}-zitadel-pat-persist
+  labels:
+    app: {{ $tenant }}-zitadel
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ $patsSecretName | quote }}]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $tenant }}-zitadel-pat-persist
+  labels:
+    app: {{ $tenant }}-zitadel
+subjects:
+  - kind: ServiceAccount
+    name: {{ $oidcServiceAccount }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $tenant }}-zitadel-pat-persist
 ---
 apiVersion: v1
 kind: Secret
@@ -303,6 +361,36 @@ spec:
             - sh
             - -c
             - until pg_isready -q; do echo "waiting for postgres"; sleep 2; done
+        # Seeds the shared emptyDir from the durable PATs Secret before core
+        # starts, so a restarted pod's login and oidc-bootstrap containers find
+        # both PATs immediately instead of waiting forever on files core will
+        # never rewrite (see the file header). A no-op on the very first init,
+        # when the Secret does not exist yet.
+        - name: restore-pats
+          image: {{ $oidcBootstrapImage }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PATS_SECRET_NAME
+              value: {{ $patsSecretName | quote }}
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              if kubectl get secret "${PATS_SECRET_NAME}" --namespace "${POD_NAMESPACE}" >/dev/null 2>&1; then
+                echo "restore-pats: restoring bootstrap PATs from ${PATS_SECRET_NAME}"
+                kubectl get secret "${PATS_SECRET_NAME}" --namespace "${POD_NAMESPACE}" -o jsonpath='{.data.admin-sa\.pat}' | base64 -d > "{{ $bootstrapDir }}/admin-sa.pat"
+                kubectl get secret "${PATS_SECRET_NAME}" --namespace "${POD_NAMESPACE}" -o jsonpath='{.data.login-client\.pat}' | base64 -d > "{{ $bootstrapDir }}/login-client.pat"
+              else
+                echo "restore-pats: no ${PATS_SECRET_NAME} Secret yet; first-instance init will mint the PATs"
+              fi
+          volumeMounts:
+            - name: bootstrap
+              mountPath: {{ $bootstrapDir }}
       containers:
         - name: erun-zitadel
           image: {{ $zitadelImage }}
@@ -469,12 +557,16 @@ spec:
           env:
             - name: CORE_PORT
               value: {{ $corePort | quote }}
+            - name: EXTERNAL_DOMAIN
+              value: {{ $externalDomain | quote }}
             - name: PROJECT_NAME
               value: {{ $oidcProjectName | quote }}
             - name: CONSOLE_REDIRECT_URI
               value: {{ $oidcConsoleRedirectURI | quote }}
             - name: CONFIGMAP_NAME
               value: {{ $oidcConfigMapName | quote }}
+            - name: PATS_SECRET_NAME
+              value: {{ $patsSecretName | quote }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -485,13 +577,30 @@ spec:
             - |
               set -eu
               pat_file="{{ $bootstrapDir }}/admin-sa.pat"
+              login_pat_file="{{ $bootstrapDir }}/login-client.pat"
               echo "oidc-bootstrap: waiting for the org-owner PAT"
               until [ -s "$pat_file" ]; do sleep 2; done
               pat="$(cat "$pat_file")"
               base="http://localhost:${CORE_PORT}"
 
+              # Core resolves the instance a Management API call targets from
+              # the Host header, not from the loopback address the call is
+              # actually addressed to; a call with no Host header 404s against
+              # every path.
               call() {
-                curl -fsS -H "Authorization: Bearer ${pat}" -H 'Content-Type: application/json' "$@"
+                curl -fsS -H "Authorization: Bearer ${pat}" -H "Host: ${EXTERNAL_DOMAIN}" -H 'Content-Type: application/json' "$@"
+              }
+
+              persist_pats() {
+                if [ ! -s "$login_pat_file" ]; then
+                  echo "oidc-bootstrap: login-client PAT not yet written, skipping persist" >&2
+                  return 1
+                fi
+                kubectl create secret generic "${PATS_SECRET_NAME}" \
+                  --from-file="admin-sa.pat=${pat_file}" \
+                  --from-file="login-client.pat=${login_pat_file}" \
+                  --namespace "${POD_NAMESPACE}" \
+                  --dry-run=client -o yaml | kubectl apply -f -
               }
 
               find_project_id() {
@@ -560,9 +669,23 @@ spec:
               }
 
               reconcile() {
-                project_id="$(ensure_project)"
-                console_client_id="$(ensure_console_app)"
-                cli_client_id="$(ensure_cli_app)"
+                persist_pats || echo "oidc-bootstrap: PATs Secret not persisted this tick" >&2
+
+                project_id="$(ensure_project || true)"
+                console_client_id="$(ensure_console_app || true)"
+                cli_client_id="$(ensure_cli_app || true)"
+
+                # The console app id is legitimately empty when
+                # platform.consoleUrl is unset; the project and the CLI app are
+                # not optional. Publishing on a partial resolution would
+                # overwrite good client ids with empty strings on every
+                # subsequent tick, so a failed resolution leaves the ConfigMap
+                # untouched instead.
+                if [ -z "${project_id}" ] || [ -z "${cli_client_id}" ]; then
+                  echo "oidc-bootstrap: resolution incomplete (project=${project_id:-<empty>} cli=${cli_client_id:-<empty>}), leaving ${CONFIGMAP_NAME} untouched" >&2
+                  return 1
+                fi
+
                 kubectl create configmap "${CONFIGMAP_NAME}" \
                   --from-literal=consoleClientId="${console_client_id}" \
                   --from-literal=cliClientId="${cli_client_id}" \
@@ -571,9 +694,10 @@ spec:
                 echo "oidc-bootstrap: ready project=${project_id} console=${console_client_id} cli=${cli_client_id}"
               }
 
-              reconcile
-              # Reconcile periodically rather than exiting, so an app or the
-              # ConfigMap deleted out of band is restored without a redeploy.
+              reconcile || echo "oidc-bootstrap: initial reconcile incomplete, retrying next tick" >&2
+              # Reconcile periodically rather than exiting, so a ConfigMap, an
+              # app, or the PATs Secret deleted out of band is restored
+              # without a redeploy.
               while true; do
                 sleep 300
                 reconcile || echo "oidc-bootstrap: reconcile failed, retrying next tick" >&2


### PR DESCRIPTION
## Summary

Six bugs found by deploying erun 1.0.182 to a live hosted platform (erunpaas.com, tenant `frs`, env `prod`) and driving the whole operator journey. All evidence below is measured, not inferred.

**1. `erun-zitadel`'s OIDC bootstrap sidecar omitted the `Host` header, so every Management API call 404s.**
Zitadel resolves the instance from `Host`. Measured inside the live pod: `curl -X POST … http://localhost:8080/management/v1/projects/_search` → **404**; the same call plus `-H "Host: auth.erunpaas.com"` → **200** with the project list. Fix: every call now sends an explicit `Host` header naming the external domain.

**2. That sidecar published its ConfigMap even when those calls failed, destroying good data.**
Having resolved nothing, it still ran `kubectl create configmap … --from-literal=consoleClientId= --from-literal=cliClientId= | kubectl apply -f -` and logged `oidc-bootstrap: ready project= console= cli=`. Its 300s reconcile then **overwrote correct client ids with empty strings on a working platform**, taking `GET /v1/platform` from populated to empty and breaking sign-in. Fix: `reconcile()` now aborts before touching the ConfigMap unless the project and CLI app genuinely resolve, and the "ready" line no longer claims success on a partial resolution.

**3. The IdP cannot survive a pod restart — sophium/erun#1047.**
Both PATs are written only at first-instance creation into an `emptyDir`; a restarted pod gets an empty dir, core skips first-init, and the login container blocks forever on `ZITADEL_SERVICE_USER_TOKEN_FILE`. The pod sits at 2/3 with no recovery that doesn't destroy the instance. Fix (verified live shape): a `restore-pats` init container seeds the emptyDir from a durable `<tenant>-zitadel-pats` Secret before core starts (a no-op on the very first init, when the Secret doesn't exist yet), and `oidc-bootstrap` persists both PATs into that Secret once resolved — the same lookup-persist pattern the chart already uses for the admin password. First-init against an empty database is unmodified: core still writes the PAT files itself, and `restore-pats` only fires when the Secret already exists.

**4. `api.envDeployer.enabled` couldn't actually enable hosted deploys — the chart never rendered `DBOS_SYSTEM_DATABASE_URL`.**
`newEnvironmentProvisioner` (server.go) returns nil unless `DBOSContext != nil`, and `optionalDBOS` returns nil for an empty URL. `grep DBOS_SYSTEM_DATABASE_URL erun-devops/k8s/erun-backend-api/templates/api.yaml` found nothing, so `POST /v1/environments/{id}/deploy` always answered `501 the deploy executor is not configured`. Proven by discrimination: `POST …/stop` needs `KubeClient` but not DBOS and correctly returned `400`, so only DBOS was missing; setting the variable by hand produced `erun api live provisioning enabled (DBOS durable workflows)` and a real deploy Job appeared. Fix: the chart now renders `DBOS_SYSTEM_DATABASE_URL` (a separate database from `ERUN_DATABASE_URL`, on the same postgres instance — DBOS creates it itself on first connect) whenever `envDeployer` or the release queue is enabled, since `newReleaseQueue` needs the identical precondition.

**5. The provisioner was disabled silently.**
With any of its five preconditions missing it returned nil and logged nothing, so an operator saw only a 501 at call time with no way to tell which condition failed. Fix: logs exactly which precondition(s) are unmet at startup.

**6. `POST /v1/tenants` returned 500 on a duplicate issuer mapping.**
`erun platform tenant create --name acme --issuer <already-mapped-issuer>` with no org discriminator → `http 500: Internal Server Error`; adding `--org-field-key/--org-field-value` succeeded only because a distinct org value never collides with the `(issuer, org_field_value)` unique constraint — the same duplicate org value would 500 too. Fix: the `tenant_issuers` insert now translates a unique-violation into `ErrConflict`, and the route returns 409 naming the conflicting issuer (and org value, when one was given), mirroring the existing `users.go`/`users_test.go` pattern.

**Also (cheap fix):** `erun-devops/docker/erun-docs/Dockerfile`'s builder stage now pins `--platform=$BUILDPLATFORM`, like the console Dockerfile already does — its Docusaurus build produces architecture-independent output, so building it once natively beats re-running it under emulation for the foreign arch on every multi-arch build.

Closes #1047

## Test plan

- [x] `make check` — golangci-lint clean across erun-common/erun-cli/erun-mcp/erun-integration/erun-backend-api, integration suite green, coverage 75.9% (≥ 75.8% threshold)
- [x] `cd erun-backend/erun-backend-api && go test ./...` — green, including new regression tests (`TestMissingEnvProvisionerConfigReportsAllFiveWhenUnset`, `TestMissingEnvProvisionerConfigReportsOnlyDBOSWhenEverythingElseSet`, `TestCreateTenantDuplicateIssuerReturnsConflict`, `TestCreateTenantDuplicateOrgScopedIssuerReturnsConflict`)
- [x] `cd erun-docs && yarn build` — clean
- [x] `erun-devops/k8s/erun-zitadel-chart_test.sh` — extended with Host-header, publish-guard, and restore-pats/PAT-persistence assertions; passes
- [x] `erun-devops/k8s/erun-backend-api-chart_test.sh` — new, locks the `DBOS_SYSTEM_DATABASE_URL` wiring (absent by default, present under `envDeployer`/`releaseQueue`, overridable database/URL)
- [x] `erun-devops/k8s/erun-devops-chart_test.sh` — unaffected, still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)