### PR TITLE
Fix five orchestrator-observed job/port-forward/release defects

### DIFF
--- a/erun-common/build_run.go
+++ b/erun-common/build_run.go
@@ -405,27 +405,83 @@ func RunDockerPushExecution(ctx Context, execution DockerPushExecutionSpec, buil
 // upfront refusal as a release whose images are not covered by a build it will
 // publish.
 //
+// Two checks run here, and they answer different questions: VerifyGHCRPushScope
+// is a per-registry check of the credential's own write:packages scope (cheap,
+// one request per registry); VerifyGHCRCanPushImage/VerifyGHCRCanPushChart is a
+// per-artifact check of whether the registry would actually grant push for that
+// specific repository, including creating it for the first time — a token can
+// have write:packages and still be denied create_package by org policy on a
+// component nothing has ever published before, which the scope check alone
+// cannot see.
+//
 // Skipped in dry-run, which does no work and must keep the integration traces
-// stable. One check per distinct registry, not per image.
+// stable.
 func preflightRegistryPushAccess(ctx Context, execution DockerPushExecutionSpec) error {
 	if ctx.DryRun {
 		return nil
 	}
-	checked := make(map[string]struct{}, 2)
+	checker := &registryPushAccessChecker{
+		checkedRegistries: make(map[string]struct{}, 2),
+		checkedTags:       make(map[string]struct{}, len(execution.builds)+len(execution.pushes)),
+	}
+	// A build that pushes inline (buildInput.Push) and a promoted fingerprint
+	// push (execution.pushes) are both real pushes this run will make — the
+	// same union RunDockerPushExecution treats as "will be pushed" just below
+	// this preflight, so both need the same check.
+	for _, buildInput := range execution.builds {
+		if !buildInput.Push {
+			continue
+		}
+		if err := checker.checkImageTag(buildInput.Image.Tag); err != nil {
+			return err
+		}
+	}
 	for _, pushInput := range execution.pushes {
-		registry := dockerRegistryFromImageTag(pushInput.Image.Tag)
-		if registry == "" {
-			continue
+		if err := checker.checkImageTag(pushInput.Image.Tag); err != nil {
+			return err
 		}
-		if _, seen := checked[registry]; seen {
-			continue
-		}
-		checked[registry] = struct{}{}
-		if err := VerifyGHCRPushScope(context.Background(), nil, pushInput.Image.Tag); err != nil {
+	}
+	for _, chart := range execution.componentCharts {
+		if err := VerifyGHCRCanPushChart(context.Background(), nil, chart.OCIRepo, chart.ChartName); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// registryPushAccessChecker dedups the two per-image checks preflightRegistryPushAccess
+// runs, so a version with the same tag built for multiple platforms is only
+// checked once.
+type registryPushAccessChecker struct {
+	checkedRegistries map[string]struct{}
+	checkedTags       map[string]struct{}
+}
+
+func (c *registryPushAccessChecker) checkImageTag(tag string) error {
+	tag = strings.TrimSpace(tag)
+	if tag == "" {
+		return nil
+	}
+	if _, seen := c.checkedTags[tag]; seen {
+		return nil
+	}
+	c.checkedTags[tag] = struct{}{}
+	if err := c.checkRegistryScopeOnce(tag); err != nil {
+		return err
+	}
+	return VerifyGHCRCanPushImage(context.Background(), nil, tag)
+}
+
+func (c *registryPushAccessChecker) checkRegistryScopeOnce(tag string) error {
+	registry := dockerRegistryFromImageTag(tag)
+	if registry == "" {
+		return nil
+	}
+	if _, seen := c.checkedRegistries[registry]; seen {
+		return nil
+	}
+	c.checkedRegistries[registry] = struct{}{}
+	return VerifyGHCRPushScope(context.Background(), nil, tag)
 }
 
 // publishComponentCharts packages+pushes then verifies each resolved chart.

--- a/erun-common/delete.go
+++ b/erun-common/delete.go
@@ -3,9 +3,15 @@ package eruncommon
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
+
+// portForwardStateKinds are every kind of forward `erun open` can record for
+// one environment. Deleting the environment must clear all three, or whichever
+// one is skipped outlives the environment it describes.
+var portForwardStateKinds = []string{"mcp", "api", "sshd"}
 
 type (
 	NamespaceDeleterFunc func(string, string) error
@@ -68,6 +74,9 @@ func RunDeleteEnvironment(ctx Context, params DeleteEnvironmentParams, store Del
 	}
 
 	ctx.TraceCommand("", "rm", "-rf", result.ConfigDir)
+	if err := removePortForwardStateFiles(ctx, tenant, environment); err != nil {
+		return result, err
+	}
 	if ctx.DryRun {
 		return result, nil
 	}
@@ -80,6 +89,32 @@ func RunDeleteEnvironment(ctx Context, params DeleteEnvironmentParams, store Del
 	}
 
 	return result, nil
+}
+
+// removePortForwardStateFiles deletes every port-forward state file this
+// environment could have. Without it, the local port range the file names
+// keeps getting freed and reissued to whichever environment is created next,
+// while the deleted environment's file still claims it — so a stale record
+// resolves to a live forward that belongs to somebody else instead of reading
+// as "no forward" the way a missing file does.
+func removePortForwardStateFiles(ctx Context, tenant, environment string) error {
+	for _, kind := range portForwardStateKinds {
+		path, err := PortForwardStatePath(kind, tenant, environment)
+		if err != nil {
+			return err
+		}
+		if _, statErr := os.Stat(path); statErr != nil {
+			continue
+		}
+		ctx.TraceCommand("", "rm", "-f", path)
+		if ctx.DryRun {
+			continue
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 func normalizeDeleteEnvironmentDependencies(store DeleteStore, deleteNamespace NamespaceDeleterFunc) (DeleteStore, NamespaceDeleterFunc) {

--- a/erun-common/ghcr_create_package_preflight.go
+++ b/erun-common/ghcr_create_package_preflight.go
@@ -1,0 +1,246 @@
+package eruncommon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// A release that introduces a new component discovers it cannot create that
+// component's package only at the push, after every image has been built for
+// every architecture. VerifyGHCRPushScope (ghcr_push_preflight.go) already
+// checks the credential's write:packages scope up front, but that scope does
+// not by itself grant the right to CREATE a package that has never existed —
+// an org can restrict creation to its owner even for a token that pushes
+// every existing package fine. Whether creation is allowed is not knowable
+// from the token's scopes; it is knowable from the registry itself, the same
+// way `docker push`/`helm push` learn it: by asking for a token scoped to push
+// the specific repository and starting (never finishing) a blob upload. That
+// costs one small HTTP exchange and uploads nothing, so it is cheap enough to
+// run before the build spend for every resolved image and chart.
+
+// ghcrCreatePackageProbeTimeout bounds each registry round trip this preflight
+// makes, so an unreachable registry cannot hang a release; it makes the check
+// inconclusive instead.
+const ghcrCreatePackageProbeTimeout = 10 * time.Second
+
+// MissingGHCRCreatePackageError is returned when the registry has already told
+// erun a resolved artifact cannot be pushed, whether because its package does
+// not exist yet and this credential cannot create one, or for any other reason
+// the registry denies push — the registry's own denial is preserved verbatim
+// so the reader sees exactly what a real push would have hit.
+type MissingGHCRCreatePackageError struct {
+	Registry   string
+	Repository string
+	Detail     string
+}
+
+func (e *MissingGHCRCreatePackageError) Error() string {
+	detail := strings.TrimSpace(e.Detail)
+	if detail == "" {
+		detail = "the registry denied push access"
+	}
+	return fmt.Sprintf(
+		"the credential erun would push %s/%s with cannot push to it: %s\n"+
+			"Publishing is checked up front because a release that cannot push a new package would "+
+			"otherwise fail at the push, after building every image for every architecture.\n\n"+
+			"If this is the first publish of a new component, its package does not exist under this "+
+			"namespace yet, and creating one for the first time needs the namespace owner's classic PAT:\n"+
+			"  1. Sign into github.com as the account that owns the namespace.\n"+
+			"  2. Open https://github.com/settings/tokens/new (classic).\n"+
+			"  3. Generate a token with scopes: write:packages and read:packages.\n"+
+			"  4. docker logout %s\n"+
+			"  5. echo $TOKEN | docker login %s -u <owner> --password-stdin\n"+
+			"  6. Re-run erun release (or erun push).\n"+
+			"After the package exists once, the owner can grant Write access to others (per-package "+
+			"settings, or \"Inherit access from source repository\" on a linked repo); future versions "+
+			"can then be pushed by anyone with that access.",
+		e.Registry, e.Repository, detail, e.Registry, e.Registry)
+}
+
+// VerifyGHCRCanPushImage is the image-tag entry point: it answers only for
+// ghcr, and only when it can answer with certainty. An inconclusive check —
+// no credential resolved, the registry unreachable, an unexpected response —
+// returns nil rather than blocking a build on a guess; a credential that is
+// actually bad still fails at the real push exactly as it does today.
+func VerifyGHCRCanPushImage(ctx context.Context, client *http.Client, tag string) error {
+	registry := dockerRegistryFromImageTag(tag)
+	if !isGHCRRegistry(registry) {
+		return nil
+	}
+	repository := dockerRepositoryFromTag(tag)
+	if repository == "" {
+		return nil
+	}
+	auth, ok := resolveGHCRBasicAuth(DockerNamespaceFromTag(tag))
+	if !ok {
+		return nil
+	}
+	return verifyGHCRCanPushRepositoryFor(ctx, client, registry, repository, auth, "https://"+registry)
+}
+
+// VerifyGHCRCanPushChart is the chart entry point: ociRepo is the
+// `oci://<registry>/<path>` a chart publishes under and chartName is the
+// segment that names the specific chart within it.
+func VerifyGHCRCanPushChart(ctx context.Context, client *http.Client, ociRepo, chartName string) error {
+	registry, path := splitOCIChartRepo(ociRepo)
+	if !isGHCRRegistry(registry) || strings.TrimSpace(chartName) == "" {
+		return nil
+	}
+	repository := strings.TrimPrefix(strings.TrimSuffix(path, "/")+"/"+strings.TrimSpace(chartName), "/")
+	auth, ok := resolveGHCRBasicAuth(namespaceFromOCIPath(path))
+	if !ok {
+		return nil
+	}
+	return verifyGHCRCanPushRepositoryFor(ctx, client, registry, repository, auth, "https://"+registry)
+}
+
+// dockerRepositoryFromTag returns the repository path a registry addresses —
+// everything between the registry host and the tag — or "" when tag names no
+// separate registry host (a bare name docker would resolve against Docker
+// Hub, which this preflight does not apply to).
+func dockerRepositoryFromTag(tag string) string {
+	tag = strings.TrimSpace(tag)
+	registry := dockerRegistryFromImageTag(tag)
+	if registry == "" {
+		return ""
+	}
+	rest := strings.TrimPrefix(tag, registry+"/")
+	if rest == tag {
+		return ""
+	}
+	if cut := strings.LastIndexByte(rest, ':'); cut >= 0 {
+		rest = rest[:cut]
+	}
+	return rest
+}
+
+// splitOCIChartRepo splits `oci://<registry>/<path>` into its host and path.
+func splitOCIChartRepo(ociRepo string) (string, string) {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(ociRepo), "oci://")
+	registry, path, ok := strings.Cut(trimmed, "/")
+	if !ok {
+		return trimmed, ""
+	}
+	return registry, path
+}
+
+// namespaceFromOCIPath returns the first path segment, which is the owning
+// namespace for a chart OCI repo the same way it is for a docker image tag.
+func namespaceFromOCIPath(path string) string {
+	segment, _, _ := strings.Cut(strings.TrimPrefix(path, "/"), "/")
+	return segment
+}
+
+// verifyGHCRCanPushRepositoryFor is the decision, with the credential and the
+// registry API base URL as explicit inputs so it can be exercised without a
+// real credential or a live registry.
+func verifyGHCRCanPushRepositoryFor(ctx context.Context, client *http.Client, registry, repository string, auth registryBasicAuth, baseURL string) error {
+	if client == nil {
+		client = &http.Client{Timeout: ghcrCreatePackageProbeTimeout}
+	}
+	token, ok := ghcrRepositoryPushToken(ctx, client, registry, repository, auth, baseURL)
+	if !ok {
+		return nil
+	}
+	allowed, detail, conclusive := ghcrProbeBlobUploadSession(ctx, client, repository, token, baseURL)
+	if !conclusive || allowed {
+		return nil
+	}
+	return &MissingGHCRCreatePackageError{Registry: registry, Repository: repository, Detail: detail}
+}
+
+// ghcrRepositoryPushToken exchanges the resolved credential for a registry
+// token scoped to push this one repository — the same exchange a real
+// `docker push`/`helm push` performs before its first request. Getting a
+// token back is not yet proof of anything; ghcrProbeBlobUploadSession is what
+// tells push-denied apart from push-granted.
+func ghcrRepositoryPushToken(ctx context.Context, client *http.Client, registry, repository string, auth registryBasicAuth, baseURL string) (string, bool) {
+	tokenURL := fmt.Sprintf("%s/token?service=%s&scope=repository:%s:pull,push", baseURL, registry, repository)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL, nil)
+	if err != nil {
+		return "", false
+	}
+	req.SetBasicAuth(auth.username, auth.secret)
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", false
+	}
+	var payload struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", false
+	}
+	if strings.TrimSpace(payload.Token) == "" {
+		return "", false
+	}
+	return payload.Token, true
+}
+
+// ghcrProbeBlobUploadSession starts a blob upload — the first request any
+// docker/helm push makes — and never finishes it. The registry allocates the
+// session exactly when push is allowed, including creating the repository for
+// the first time, so a 202/201 is conclusive proof push would have succeeded;
+// a 401/403 is the registry's own denial, conclusive the other way, with the
+// same detail (e.g. create_package) a real push would have surfaced. Any
+// other outcome — network failure, an unexpected status — is inconclusive:
+// this preflight only ever blocks on a definite answer.
+func ghcrProbeBlobUploadSession(ctx context.Context, client *http.Client, repository, token, baseURL string) (allowed bool, detail string, conclusive bool) {
+	uploadURL := fmt.Sprintf("%s/v2/%s/blobs/uploads/", baseURL, repository)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, nil)
+	if err != nil {
+		return false, "", false
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.ContentLength = 0
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, "", false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	switch resp.StatusCode {
+	case http.StatusAccepted, http.StatusCreated:
+		abandonGHCRBlobUploadSession(ctx, client, resp.Header.Get("Location"), token, baseURL)
+		return true, "", true
+	case http.StatusUnauthorized, http.StatusForbidden:
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return false, strings.TrimSpace(string(body)), true
+	default:
+		return false, "", false
+	}
+}
+
+// abandonGHCRBlobUploadSession cancels the probe's own upload session so
+// nothing about it lingers in the registry's view of in-progress uploads.
+// Best effort: a session the registry never sees a DELETE for is garbage
+// collected on its own, so a failure here is not worth failing the release
+// over.
+func abandonGHCRBlobUploadSession(ctx context.Context, client *http.Client, location, token, baseURL string) {
+	location = strings.TrimSpace(location)
+	if location == "" {
+		return
+	}
+	cancelURL := location
+	if !strings.HasPrefix(cancelURL, "http") {
+		cancelURL = baseURL + location
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, cancelURL, nil)
+	if err != nil {
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(req)
+	if err != nil {
+		return
+	}
+	_ = resp.Body.Close()
+}

--- a/erun-common/ghcr_create_package_preflight_test.go
+++ b/erun-common/ghcr_create_package_preflight_test.go
@@ -1,0 +1,207 @@
+package eruncommon
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeGHCRRegistry answers the two requests this preflight makes: a token
+// exchange and a blob-upload-session start. It also records the DELETE the
+// probe should send to abandon a session it was granted, and the exact
+// repository path each request named, so a scenario can assert the tag/chart
+// parsing reached the registry correctly.
+type fakeGHCRRegistry struct {
+	// TokenStatus is the token endpoint's status; a non-2xx makes the whole
+	// check inconclusive before it ever reaches the upload probe.
+	TokenStatus int
+	// UploadStatus is the blob-upload-session endpoint's status.
+	UploadStatus int
+	// UploadBody is returned on a denied upload, the registry's own reason.
+	UploadBody string
+
+	mu           sync.Mutex
+	repositories []string
+	deleted      []string
+}
+
+func (r *fakeGHCRRegistry) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case strings.HasPrefix(req.URL.Path, "/token"):
+			r.handleToken(w)
+		case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/blobs/uploads/"):
+			r.handleUploadStart(w, req)
+		case req.Method == http.MethodDelete:
+			r.handleDelete(w, req)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func (r *fakeGHCRRegistry) handleToken(w http.ResponseWriter) {
+	status := r.TokenStatus
+	if status == 0 {
+		status = http.StatusOK
+	}
+	if status < 200 || status >= 300 {
+		w.WriteHeader(status)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"token":"probe-token"}`))
+}
+
+func (r *fakeGHCRRegistry) handleUploadStart(w http.ResponseWriter, req *http.Request) {
+	repo := strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/v2/"), "/blobs/uploads/")
+	r.mu.Lock()
+	r.repositories = append(r.repositories, repo)
+	r.mu.Unlock()
+	status := r.UploadStatus
+	if status == 0 {
+		status = http.StatusAccepted
+	}
+	if status == http.StatusAccepted || status == http.StatusCreated {
+		w.Header().Set("Location", "/v2/"+repo+"/blobs/uploads/probe-session")
+		w.WriteHeader(status)
+		return
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(r.UploadBody))
+}
+
+func (r *fakeGHCRRegistry) handleDelete(w http.ResponseWriter, req *http.Request) {
+	r.mu.Lock()
+	r.deleted = append(r.deleted, req.URL.Path)
+	r.mu.Unlock()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (r *fakeGHCRRegistry) sawRepository(repo string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, seen := range r.repositories {
+		if seen == repo {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *fakeGHCRRegistry) deletedCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.deleted)
+}
+
+// The failure this exists to prevent: a token that pushes every existing
+// package fine still gets denied create_package on the first brand-new one,
+// and that must be caught before the build, not after.
+func TestANewPackageDeniedByTheRegistryIsRefusedUpFront(t *testing.T) {
+	registry := &fakeGHCRRegistry{UploadStatus: http.StatusForbidden, UploadBody: `denied: permission_denied: create_package`}
+	server := registry.start(t)
+
+	err := verifyGHCRCanPushRepositoryFor(context.Background(), nil, "ghcr.io", "sophium/erun-zitadel", registryBasicAuth{username: "sophium", secret: "token"}, server.URL)
+	if err == nil {
+		t.Fatal("a repository the registry denies push to must be refused before the build")
+	}
+	var missing *MissingGHCRCreatePackageError
+	if got, ok := err.(*MissingGHCRCreatePackageError); ok {
+		missing = got
+	} else {
+		t.Fatalf("expected a MissingGHCRCreatePackageError, got %T: %v", err, err)
+	}
+	message := missing.Error()
+	for _, want := range []string{"create_package", "sophium/erun-zitadel", "classic PAT", "write:packages"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("the error must be actionable, missing %q in:\n%s", want, message)
+		}
+	}
+	if !registry.sawRepository("sophium/erun-zitadel") {
+		t.Fatal("the probe must name the exact repository it checked")
+	}
+}
+
+// An existing package, or a brand-new one this credential can actually
+// create, must not block the release — the registry granting the session is
+// conclusive proof push would have worked.
+func TestAPushableRepositoryIsAccepted(t *testing.T) {
+	registry := &fakeGHCRRegistry{UploadStatus: http.StatusAccepted}
+	server := registry.start(t)
+
+	if err := verifyGHCRCanPushRepositoryFor(context.Background(), nil, "ghcr.io", "sophium/erun-devops", registryBasicAuth{username: "sophium", secret: "token"}, server.URL); err != nil {
+		t.Fatalf("a repository the registry grants push to must be accepted: %v", err)
+	}
+	if registry.deletedCount() != 1 {
+		t.Fatalf("the probe's own upload session must be abandoned exactly once, got %d deletes", registry.deletedCount())
+	}
+}
+
+// The check converts a *known* failure into an immediate one; it must never
+// invent a new way to block a release it cannot actually judge.
+func TestGHCRCreatePackageCheckNeverBlocksOnAnInconclusiveAnswer(t *testing.T) {
+	auth := registryBasicAuth{username: "sophium", secret: "token"}
+
+	t.Run("token exchange fails", func(t *testing.T) {
+		registry := &fakeGHCRRegistry{TokenStatus: http.StatusInternalServerError}
+		server := registry.start(t)
+		if err := verifyGHCRCanPushRepositoryFor(context.Background(), nil, "ghcr.io", "sophium/erun-devops", auth, server.URL); err != nil {
+			t.Fatalf("an unresolvable token must not block the build: %v", err)
+		}
+	})
+
+	t.Run("upload probe returns an unexpected status", func(t *testing.T) {
+		registry := &fakeGHCRRegistry{UploadStatus: http.StatusServiceUnavailable}
+		server := registry.start(t)
+		if err := verifyGHCRCanPushRepositoryFor(context.Background(), nil, "ghcr.io", "sophium/erun-devops", auth, server.URL); err != nil {
+			t.Fatalf("an unexpected registry response must not block the build: %v", err)
+		}
+	})
+
+	t.Run("registry unreachable", func(t *testing.T) {
+		if err := verifyGHCRCanPushRepositoryFor(context.Background(), nil, "ghcr.io", "sophium/erun-devops", auth, "http://127.0.0.1:1"); err != nil {
+			t.Fatalf("an unreachable registry must not block the build: %v", err)
+		}
+	})
+}
+
+// Only ghcr is checked, and only when a credential resolves; neither entry
+// point may reach the network otherwise.
+func TestGHCREntryPointsSkipWhenNotApplicable(t *testing.T) {
+	if err := VerifyGHCRCanPushImage(context.Background(), nil, "020362606330.dkr.ecr.eu-west-2.amazonaws.com/acme/api:1.0.0"); err != nil {
+		t.Fatalf("a non-ghcr registry must not be probed: %v", err)
+	}
+	if err := VerifyGHCRCanPushChart(context.Background(), nil, "oci://registry.example.com/sophium/charts", "erun-zitadel"); err != nil {
+		t.Fatalf("a non-ghcr OCI repo must not be probed: %v", err)
+	}
+}
+
+func TestDockerRepositoryFromTag(t *testing.T) {
+	cases := map[string]string{
+		"ghcr.io/sophium/erun-zitadel:1.0.180":       "sophium/erun-zitadel",
+		"ghcr.io/sophium/erun-zitadel:1.0.180-amd64": "sophium/erun-zitadel",
+		"erun-zitadel:1.0.180":                       "",
+	}
+	for tag, want := range cases {
+		if got := dockerRepositoryFromTag(tag); got != want {
+			t.Errorf("dockerRepositoryFromTag(%q) = %q, want %q", tag, got, want)
+		}
+	}
+}
+
+func TestSplitOCIChartRepoAndNamespace(t *testing.T) {
+	registry, path := splitOCIChartRepo("oci://ghcr.io/sophium/charts")
+	if registry != "ghcr.io" || path != "sophium/charts" {
+		t.Fatalf("splitOCIChartRepo = (%q, %q), want (ghcr.io, sophium/charts)", registry, path)
+	}
+	if namespace := namespaceFromOCIPath(path); namespace != "sophium" {
+		t.Fatalf("namespaceFromOCIPath(%q) = %q, want sophium", path, namespace)
+	}
+}

--- a/erun-common/job.go
+++ b/erun-common/job.go
@@ -46,8 +46,12 @@ const (
 
 	// DefaultEnvironmentJobOutputLimitBytes bounds one job's captured output so a
 	// chatty run cannot fill the environment's home volume. The outcome never
-	// comes from the log, so hitting the cap costs detail, never the result.
-	DefaultEnvironmentJobOutputLimitBytes int64 = 4 << 20
+	// comes from the log, so hitting the cap costs detail, never the result. A
+	// long agent run in stream-json mode blows through 4 MiB well under an hour,
+	// so the default is wide enough to cover most single-session runs; progress
+	// itself no longer depends on this cap at all (agentProgressReader is fed
+	// directly from the process's own writes).
+	DefaultEnvironmentJobOutputLimitBytes int64 = 16 << 20
 
 	// DefaultEnvironmentJobAwaitTimeout is short enough that a caller polls
 	// rather than parks on a connection.

--- a/erun-common/job_agent.go
+++ b/erun-common/job_agent.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
+	"sync"
 	"unicode/utf8"
 )
 
@@ -123,51 +123,44 @@ func (p AgentJobProgress) Summary() string {
 	return strings.Join(parts, ", ")
 }
 
-// agentProgressReader folds an agent's event stream into progress as the log
-// grows. It keeps its own offset so the supervisor polling on a short interval
-// re-reads only what arrived rather than the whole log each time.
+// agentProgressReader folds an agent's event stream into progress as bytes
+// arrive. It is fed directly from the child process's stdout/stderr writes
+// (agentProgressReader.feed), independent of whatever the job's output log
+// retains — the byte cap that bounds the log on disk must not also silence
+// progress, since the progress fields it folds into are themselves small and
+// bounded. Two of the process's own pipe-copying goroutines can write
+// concurrently, so every method locks.
 type agentProgressReader struct {
-	tool     string
-	path     string
-	offset   int64
+	tool string
+
+	mu       sync.Mutex
 	pending  []byte
 	progress AgentJobProgress
 }
 
-func newAgentProgressReader(tool, path string) *agentProgressReader {
-	return &agentProgressReader{tool: tool, path: path, progress: AgentJobProgress{Tool: tool}}
+func newAgentProgressReader(tool string) *agentProgressReader {
+	return &agentProgressReader{tool: tool, progress: AgentJobProgress{Tool: tool}}
 }
 
-// read folds whatever arrived since the last call and returns progress as it now
-// stands. A log that is missing or unreadable yields the progress already folded
-// rather than an error: a run that has not written yet is not a failure.
-func (r *agentProgressReader) read() AgentJobProgress {
-	if strings.TrimSpace(r.path) == "" {
-		return r.progress
-	}
-	file, err := os.Open(r.path)
-	if err != nil {
-		return r.progress
-	}
-	defer func() { _ = file.Close() }()
-
-	info, err := file.Stat()
-	if err != nil || info.Size() <= r.offset {
-		return r.progress
-	}
-	chunk := make([]byte, info.Size()-r.offset)
-	read, err := file.ReadAt(chunk, r.offset)
-	if read <= 0 && err != nil {
-		return r.progress
-	}
-	r.offset += int64(read)
-	r.consume(chunk[:read])
+// snapshot returns progress as it currently stands.
+func (r *agentProgressReader) snapshot() AgentJobProgress {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.progress
 }
 
+// feed folds newly-arrived bytes into progress. It is called from the same
+// writer that captures the job's output, but it sees every byte the process
+// wrote, not only the bytes the output cap kept.
+func (r *agentProgressReader) feed(chunk []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.consume(chunk)
+}
+
 // consume splits the arrived bytes on newlines, folding complete lines and
-// carrying the partial trailing one — a poll routinely lands mid-line, and
-// re-reading it from the start would double-count everything before it.
+// carrying the partial trailing one — a feed can land mid-line, and re-reading
+// it from the start would double-count everything before it. Caller holds mu.
 func (r *agentProgressReader) consume(chunk []byte) {
 	buffer := append(r.pending, chunk...)
 	for {

--- a/erun-common/job_supervisor.go
+++ b/erun-common/job_supervisor.go
@@ -165,6 +165,60 @@ func resolveEnvironmentJobWork(agent, prompt string, command []string) (string, 
 	return tool, built, nil
 }
 
+// ensureAgentJobToolAvailable refuses an agent job before anything is spent —
+// no activity lease, no log file, no supervisor process — when the named tool
+// is not installed in this environment. That precondition is knowable up
+// front; starting anyway trades a direct, actionable refusal for the tool's
+// own failure a minute later, which for an unconfigured environment reads as
+// a credential problem with no credential fix.
+func ensureAgentJobToolAvailable(ctx Context, tool string) error {
+	if strings.TrimSpace(tool) == "" {
+		return nil
+	}
+	ctx.Trace(fmt.Sprintf("job: resolving agent tool %q in this environment", tool))
+	// cmd.Err carries Go's own exec.LookPath phrasing, which is an
+	// implementation detail rather than something to hand to the caller
+	// verbatim; the tool name and "not available" already say what happened.
+	if cmd := Command(tool); cmd.Err != nil {
+		err := fmt.Errorf("agent tool %q is not available in this environment; install and configure it here, or start the job with a different --agent", tool)
+		ctx.Trace(fmt.Sprintf("job: resolving agent tool %q failed: %v", tool, err))
+		return err
+	}
+	return nil
+}
+
+// agentAuthFailureSignatures are phrases the AI tools use for their own auth
+// failures. Matching one against a failed agent job's folded progress is what
+// turns "the tool's raw message" into "this environment's credentials for
+// that tool are missing or stale" — the actual problem, since there is often
+// no in-band way to refresh them, unlike what the raw message suggests.
+var agentAuthFailureSignatures = []string{
+	"oauth session expired",
+	"failed to authenticate",
+	"authentication_error",
+	"invalid api key",
+	"please run /login",
+	"not logged in",
+}
+
+// agentAuthFailureReason returns a clarified failure reason when a failed
+// agent job's own folded error looks like an authentication problem, and ""
+// otherwise — never guessing on a message that does not match one of the
+// tools' own known phrasings.
+func agentAuthFailureReason(tool, message string) string {
+	trimmed := strings.TrimSpace(message)
+	if trimmed == "" {
+		return ""
+	}
+	lower := strings.ToLower(trimmed)
+	for _, signature := range agentAuthFailureSignatures {
+		if strings.Contains(lower, signature) {
+			return fmt.Sprintf("%s reported an authentication failure (%s); this environment's %s credentials are missing or stale, not a problem with the work itself", tool, trimmed, tool)
+		}
+	}
+	return ""
+}
+
 // environmentJobKind names the kind a recorded tool implies, so the record and
 // every reader agree without either re-deriving it.
 func environmentJobKind(agentTool string) string {
@@ -198,6 +252,9 @@ func normalizeEnvironmentJobLeaseTTL(ttl time.Duration) (time.Duration, error) {
 func StartEnvironmentJob(ctx Context, params StartEnvironmentJobParams) (EnvironmentJob, error) {
 	params, err := params.normalize()
 	if err != nil {
+		return EnvironmentJob{}, err
+	}
+	if err := ensureAgentJobToolAvailable(ctx, params.Agent); err != nil {
 		return EnvironmentJob{}, err
 	}
 	dir, err := environmentJobDir(params.Tenant, params.Environment)
@@ -446,10 +503,17 @@ func RunEnvironmentJobSupervisor(params EnvironmentJobSupervisorParams) error {
 	if err != nil {
 		return err
 	}
-	beat, stop := startEnvironmentJobHeartbeat(params.Tenant, params.Environment, recorder, ttl)
+	// The agent reader is shared between the writer that feeds it every byte the
+	// child process writes and the heartbeat that reads its current snapshot —
+	// that sharing is what keeps progress moving after the log hits its cap.
+	var agent *agentProgressReader
+	if job.Kind == EnvironmentJobKindAgent {
+		agent = newAgentProgressReader(job.AgentTool)
+	}
+	beat, stop := startEnvironmentJobHeartbeat(params.Tenant, params.Environment, recorder, ttl, agent)
 	defer stop()
 
-	writer := &jobOutputWriter{file: log, limit: job.OutputLimitBytes, onTruncate: func() {
+	writer := &jobOutputWriter{file: log, limit: job.OutputLimitBytes, agent: agent, onTruncate: func() {
 		recorder.update(func(job *EnvironmentJob) { job.OutputTruncated = true })
 	}}
 
@@ -497,6 +561,9 @@ func finishEnvironmentJob(recorder *jobRecorder, beat *jobHeartbeat, writer *job
 		job.OutputBytes = writer.written()
 		job.OutputTruncated = writer.truncated()
 		job.Signal = signal
+		if reason == "" && code != 0 && job.Kind == EnvironmentJobKindAgent && job.Progress != nil {
+			reason = agentAuthFailureReason(job.AgentTool, job.Progress.Error)
+		}
 		job.Reason = reason
 		job.ExitCode = &code
 	})
@@ -532,12 +599,14 @@ type jobHeartbeat struct {
 // design: if this process is killed instead, the lease records this pid, so the
 // lease store reclaims it on the next read exactly as it would for any other
 // abandoned holder.
-func startEnvironmentJobHeartbeat(tenant, environment string, recorder *jobRecorder, ttl time.Duration) (*jobHeartbeat, func()) {
+//
+// agent is the same reader the output writer feeds, so the heartbeat's snapshot
+// reflects everything the process wrote, not only what the output cap retained.
+func startEnvironmentJobHeartbeat(tenant, environment string, recorder *jobRecorder, ttl time.Duration, agent *agentProgressReader) (*jobHeartbeat, func()) {
 	job := recorder.snapshot()
-	beat := &jobHeartbeat{tenant: tenant, environment: environment, ttl: ttl, recorder: recorder}
+	beat := &jobHeartbeat{tenant: tenant, environment: environment, ttl: ttl, recorder: recorder, agent: agent}
 	interval := beat.leaseInterval()
-	if job.Kind == EnvironmentJobKindAgent {
-		beat.agent = newAgentProgressReader(job.AgentTool, job.LogPath)
+	if agent != nil {
 		interval = agentJobProgressInterval
 	}
 	beat.refresh(true)
@@ -578,7 +647,7 @@ func (h *jobHeartbeat) refresh(force bool) {
 	job := h.recorder.snapshot()
 	name := job.Name
 	if h.agent != nil {
-		progress := h.agent.read()
+		progress := h.agent.snapshot()
 		if progress != h.progress {
 			h.progress = progress
 			h.recorder.update(func(job *EnvironmentJob) {
@@ -617,10 +686,13 @@ func (h *jobHeartbeat) leaseInterval() time.Duration {
 
 // jobOutputWriter captures the work's merged stdout and stderr up to the cap.
 // Past the cap it stops writing and says so once, so a bounded log can never be
-// mistaken for the whole story.
+// mistaken for the whole story. agent, when set, is fed every byte regardless
+// of the cap: an agent's progress fields are small and bounded on their own, so
+// the log's disk cap must not be what silently freezes them.
 type jobOutputWriter struct {
 	file       *os.File
 	limit      int64
+	agent      *agentProgressReader
 	onTruncate func()
 
 	mu      sync.Mutex
@@ -628,7 +700,17 @@ type jobOutputWriter struct {
 	dropped bool
 }
 
+// Write feeds the agent reader (if any) with every byte, then applies the cap
+// to what actually reaches the log file. The two are independent so the cap
+// can bound the file without also bounding progress.
 func (w *jobOutputWriter) Write(p []byte) (int, error) {
+	if w.agent != nil {
+		w.agent.feed(p)
+	}
+	return w.writeCapped(p)
+}
+
+func (w *jobOutputWriter) writeCapped(p []byte) (int, error) {
 	w.mu.Lock()
 	room := w.limit - w.count
 	if room <= 0 {

--- a/erun-common/mcp_client.go
+++ b/erun-common/mcp_client.go
@@ -8,8 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -154,8 +155,12 @@ type mcpSession struct {
 	client        *http.Client
 	sessionID     string
 	nextID        int
-	// recovering suppresses a nested re-handshake so one lost session costs at
-	// most one retry.
+	// localPort is the loopback port the endpoint names, or 0 when the endpoint
+	// is not a local port-forward (e.g. a hosted platform edge). Only a local
+	// port-forward can go stale in the way ensureTunnelLive checks for.
+	localPort int
+	// recovering suppresses a nested re-handshake or tunnel retry so one bad
+	// request costs at most one retry.
 	recovering bool
 	// notice reports a recovery the caller would otherwise never see; nil when
 	// the caller has nowhere to put diagnostics.
@@ -183,7 +188,27 @@ func newMCPSession(endpoint string, mintToken MCPTokenMinter, clientVersion stri
 		mintToken:     mintToken,
 		clientVersion: clientVersion,
 		client:        &http.Client{},
+		localPort:     localMCPEndpointPort(endpoint),
 	}, nil
+}
+
+// localMCPEndpointPort extracts the loopback port an endpoint names, or 0 for
+// any endpoint that is not a plain http://127.0.0.1:<port> or
+// http://localhost:<port> URL — the shape only a local port-forward has.
+func localMCPEndpointPort(endpoint string) int {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return 0
+	}
+	host := parsed.Hostname()
+	if host != "127.0.0.1" && host != "localhost" {
+		return 0
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil || port <= 0 {
+		return 0
+	}
+	return port
 }
 
 func openMCPSession(ctx context.Context, endpoint string, mintToken MCPTokenMinter, clientVersion string) (*mcpSession, error) {
@@ -252,15 +277,37 @@ func (s *mcpSession) post(ctx context.Context, payload mcpJSONRPCRequest) (*mcpJ
 // Bearer minting and session-id capture live here so a raw relay and a typed
 // call cannot drift apart on either.
 //
-// A session the edge has forgotten is recovered rather than surfaced: a
-// long-lived relay pins one session id for its whole lifetime, so treating the
-// edge's 404 as terminal would kill every request for the environment until the
-// relay itself was restarted. The re-handshake happens at most once per request.
+// Two failures are recovered rather than surfaced on the first attempt, each at
+// most once per request so a bad edge cannot turn into a retry loop:
+//
+// A session the edge has forgotten is re-handshaked: a long-lived relay pins
+// one session id for its whole lifetime, so treating the edge's 404 as
+// terminal would kill every request for the environment until the relay
+// itself was restarted.
+//
+// A local port-forward that drops mid-request — kubectl logs "lost connection
+// to pod" and reconnects on its own — is retried on the same session, with no
+// re-handshake: the remote MCP server process never restarted, only the local
+// tunnel blipped, so a plain resend is enough once the tunnel answers again.
+// This is what turns a stale tunnel from a hang into a fast, actionable
+// failure (or, when it self-corrects fast enough, into nothing the caller
+// notices at all) — see issue reports of a bound-but-dead forward silently
+// swallowing long-held calls.
 func (s *mcpSession) postRaw(ctx context.Context, body []byte) ([]byte, error) {
 	raw, err := s.postOnce(ctx, body)
-	if err == nil || s.recovering || !errors.Is(err, errMCPSessionLost) {
+	if err == nil || s.recovering {
 		return raw, err
 	}
+	if errors.Is(err, errMCPSessionLost) {
+		return s.recoverLostSession(ctx, body)
+	}
+	if errors.Is(err, ErrMCPEndpointUnreachable) && s.localPort > 0 && CanReachLocalMCPEndpoint(s.localPort) {
+		return s.retryAfterTunnelRecovery(ctx, body)
+	}
+	return raw, err
+}
+
+func (s *mcpSession) recoverLostSession(ctx context.Context, body []byte) ([]byte, error) {
 	s.recovering = true
 	defer func() { s.recovering = false }()
 	s.sessionID = ""
@@ -271,6 +318,13 @@ func (s *mcpSession) postRaw(ctx context.Context, body []byte) ([]byte, error) {
 	return s.postOnce(ctx, body)
 }
 
+func (s *mcpSession) retryAfterTunnelRecovery(ctx context.Context, body []byte) ([]byte, error) {
+	s.recovering = true
+	defer func() { s.recovering = false }()
+	s.report(fmt.Sprintf("the local port-forward to %s answers again after dropping mid-request; retrying", s.endpoint))
+	return s.postOnce(ctx, body)
+}
+
 func (s *mcpSession) report(message string) {
 	if s.notice == nil {
 		return
@@ -278,7 +332,16 @@ func (s *mcpSession) report(message string) {
 	s.notice(message)
 }
 
+// postOnce fails fast when the local port a session targets is bound but not
+// answering, rather than handing a request to a tunnel already known to be
+// dead: the caller's context deadline (or, with none, no bound at all) would
+// otherwise be the only thing that ever ends the wait. A port nothing holds at
+// all is a different, ordinary case (no port-forward was ever established) and
+// is left to the real request's own dial failure, unchanged.
 func (s *mcpSession) postOnce(ctx context.Context, body []byte) ([]byte, error) {
+	if s.localPort > 0 && !CanReachLocalMCPEndpoint(s.localPort) && LocalPortIsBound(s.localPort) {
+		return nil, s.staleTunnelError()
+	}
 	token, err := s.mintToken()
 	if err != nil {
 		return nil, err
@@ -321,14 +384,22 @@ func (s *mcpSession) newRequest(ctx context.Context, body []byte, token string) 
 	return req, nil
 }
 
-// A failure to dial the loopback port is reported as unreachable rather than as a
-// generic error, because the operator's fix is to bring the port-forward up.
+// staleTunnelError names a local port that is bound but not answering — the
+// preflight failure postOnce refuses to spend a request on, and the shape a
+// caller sees when the tunnel was already dead before this request started.
+func (s *mcpSession) staleTunnelError() error {
+	return fmt.Errorf("%w: %s (127.0.0.1:%d is held but the edge never answers — a stale port-forward)", ErrMCPEndpointUnreachable, s.endpoint, s.localPort)
+}
+
+// transportError covers every way client.Do can fail without an HTTP status to
+// classify: a refused dial, and — the shape a flapping local port-forward
+// leaves an in-flight request in — a connection that was accepted and then
+// dropped. Both get the operator the same fix (the port-forward is not
+// carrying traffic), so both are reported as unreachable rather than as a
+// generic error; postRaw is what tells a dial failure and a mid-request drop
+// apart when deciding whether a retry is worth attempting.
 func (s *mcpSession) transportError(err error) error {
-	var opErr *net.OpError
-	if errors.As(err, &opErr) && opErr.Op == "dial" {
-		return fmt.Errorf("%w: %s (%v)", ErrMCPEndpointUnreachable, s.endpoint, err)
-	}
-	return fmt.Errorf("call MCP endpoint %s: %w", s.endpoint, err)
+	return fmt.Errorf("%w: %s (%v)", ErrMCPEndpointUnreachable, s.endpoint, err)
 }
 
 // sessionPinned says the request carried a session id, which is what separates

--- a/erun-common/port_forward_state.go
+++ b/erun-common/port_forward_state.go
@@ -48,6 +48,15 @@ func PortForwardStatePath(kind, tenant, environment string) (string, error) {
 
 // LoadPortForwardState reads a forward's state. A missing file is reported as
 // "no forward", not an error: an environment nobody opened is the ordinary case.
+//
+// A file naming an environment no longer in the config store reads the same
+// way: deleting an environment is supposed to remove its state files (see
+// RunDeleteEnvironment), but a file that predates that cleanup, or one left by
+// a delete that failed partway, must not resolve as a live forward either. The
+// local port range a deleted environment's file names is freed and reissued to
+// whichever environment is created next, so trusting an orphaned file would
+// hand back a forward that now belongs to somebody else — a stale record has
+// to read as "no forward", not as a wrong one.
 func LoadPortForwardState(kind, tenant, environment string) (PortForwardState, bool, error) {
 	path, err := PortForwardStatePath(kind, tenant, environment)
 	if err != nil {
@@ -64,5 +73,17 @@ func LoadPortForwardState(kind, tenant, environment string) (PortForwardState, b
 	if err := json.Unmarshal(data, &state); err != nil {
 		return PortForwardState{}, false, fmt.Errorf("%s: %w", path, err)
 	}
+	if !environmentIsConfigured(tenant, environment) {
+		return PortForwardState{}, false, nil
+	}
 	return state, state.LocalPort > 0, nil
+}
+
+// environmentIsConfigured reports whether the config store still knows this
+// tenant/environment. Any error reading it — including "not initialized" —
+// is treated as "cannot confirm this is live", the same conservative reading
+// LoadPortForwardState itself gives a file it cannot read.
+func environmentIsConfigured(tenant, environment string) bool {
+	_, _, err := ConfigStore{}.LoadEnvConfig(tenant, environment)
+	return err == nil
 }

--- a/erun-integration/delete_test.go
+++ b/erun-integration/delete_test.go
@@ -234,4 +234,50 @@ func TestDelete(t *testing.T) {
 		}
 		golden.Equal(t, "delete/real_run_with_yes_flag_skips_confirmation_and_removes_config", normalize.Apply(result.Combined))
 	})
+
+	t.Run("real_run_removes_the_environments_port_forward_state", func(t *testing.T) {
+		// A port-forward state file names a local port, and that port range is
+		// freed and reissued to whichever environment is created next. Leaving
+		// the file behind after delete lets it resolve to a live forward that
+		// now belongs to somebody else, so delete must clear it the same way it
+		// clears the rest of the environment's footprint.
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		seedMCPPortForwardState(t, setup, "team", "dev", 26100)
+		statePath := portForwardStateFile(setup, "mcp", "team", "dev")
+		if _, err := os.Stat(statePath); err != nil {
+			t.Fatalf("seeded port-forward state missing before delete: %v", err)
+		}
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinary(t, stubs, "kubectl", "")
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+
+		result := erun.Run(t, []string{"delete", "team", "dev", "--yes"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		// Filesystem state — golden cannot assert this; keep the os.Stat check
+		// (mirrors real_run_with_yes_flag_skips_confirmation_and_removes_config).
+		if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+			t.Errorf("expected the port-forward state file to be removed at %s, stat err: %v", statePath, err)
+		}
+	})
+
+	t.Run("dry_run_traces_the_port_forward_state_removal_without_deleting_it", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		seedMCPPortForwardState(t, setup, "team", "dev", 26100)
+		statePath := portForwardStateFile(setup, "mcp", "team", "dev")
+
+		result := erun.Run(t, []string{"delete", "team", "dev", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: "y\n"})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		if !strings.Contains(result.Combined, statePath) {
+			t.Fatalf("expected the dry-run plan to name the port-forward state file, got:\n%s", result.Combined)
+		}
+		if _, err := os.Stat(statePath); err != nil {
+			t.Errorf("a dry run must not remove the port-forward state file, stat err: %v", err)
+		}
+	})
 }

--- a/erun-integration/job_test.go
+++ b/erun-integration/job_test.go
@@ -176,17 +176,89 @@ func TestJob(t *testing.T) {
 		// where that argv is auditable, and the streaming flags are the whole point:
 		// without them the tool prints nothing until it exits, so a multi-hour run
 		// would report no output while it is actively editing files.
+		//
+		// Both tools are stubbed present: the dry-run plan also resolves whether the
+		// named tool is available in this environment, which is a real
+		// filesystem/PATH check that runs regardless of --dry-run, the same way the
+		// job dir check does.
 		setup := env.New(t)
 		fixture.SeedTenantEnv(t, setup, "team", "dev")
-		claude := erun.Run(t, []string{"job", "start", "--tenant", "team", "--environment", "dev", "--name", "sweep", "--agent", "claude", "--dry-run", "--", "fix the failing tests"}, erun.RunOptions{Cwd: setup.Cwd, Env: inEnvironment(setup.Env())})
+		stubs := filepath.Join(setup.Cwd, "stubs")
+		fixture.StubBinary(t, stubs, "claude", "")
+		fixture.StubBinary(t, stubs, "codex", "")
+		envVars := inEnvironment(append(setup.Env(), fixture.StubEnv(stubs, "claude", "codex")...))
+		claude := erun.Run(t, []string{"job", "start", "--tenant", "team", "--environment", "dev", "--name", "sweep", "--agent", "claude", "--dry-run", "--", "fix the failing tests"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if claude.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", claude.ExitCode, claude.Combined)
 		}
-		codex := erun.Run(t, []string{"job", "start", "--tenant", "team", "--environment", "dev", "--name", "sweep", "--agent", "codex", "--dry-run", "--", "fix the failing tests"}, erun.RunOptions{Cwd: setup.Cwd, Env: inEnvironment(setup.Env())})
+		codex := erun.Run(t, []string{"job", "start", "--tenant", "team", "--environment", "dev", "--name", "sweep", "--agent", "codex", "--dry-run", "--", "fix the failing tests"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if codex.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", codex.ExitCode, codex.Combined)
 		}
 		golden.Equal(t, "job/agent_start_dry_run_plans_the_streaming_invocation", normalize.Apply(claude.Combined+codex.Combined))
+	})
+
+	t.Run("agent_start_refuses_when_the_tool_is_not_available", func(t *testing.T) {
+		// A knowable-before-spend precondition: an agent job naming a tool this
+		// environment does not have refuses before it takes a lease or starts a
+		// supervisor, rather than accepting the job and failing a minute later on
+		// the tool's own (often credential-shaped) error.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"job", "start", "--tenant", "team", "--environment", "dev", "--name", "sweep", "--agent", "claude", "--", "fix the failing tests"}, erun.RunOptions{Cwd: setup.Cwd, Env: inEnvironment(setup.Env())})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected a refusal when claude is not installed in this environment, got 0:\n%s", result.Combined)
+		}
+		if !strings.Contains(result.Combined, `agent tool "claude" is not available in this environment`) {
+			t.Fatalf("the refusal must name the tool and say it is unavailable, got:\n%s", result.Combined)
+		}
+		if _, err := os.Stat(jobRecordPath(setup, "team", "dev", "sweep")); !os.IsNotExist(err) {
+			t.Errorf("a refused start must not register a job, stat err: %v", err)
+		}
+	})
+
+	t.Run("agent_progress_reports_an_authentication_failure_as_the_reason", func(t *testing.T) {
+		// The tool is present but its credentials are stale — a real failure the
+		// preflight above cannot catch (the tool is installed). The job's own
+		// folded progress already carries the tool's raw auth message; the failed
+		// job's reason must say plainly that this looks like a credential problem
+		// in the environment, not a bug in the work, rather than leaving the raw
+		// vendor string to speak for itself.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		stubs := filepath.Join(setup.Cwd, "stubs")
+		fixture.StubBinaryWithScript(t, stubs, "claude",
+			`printf '{"type":"result","subtype":"error_during_execution","is_error":true,"num_turns":1,"result":"Failed to authenticate: OAuth session expired and could not be refreshed"}\n'`+"\n"+
+				"exit 1")
+		envVars := inEnvironment(append(setup.Env(), fixture.StubEnv(stubs, "claude")...))
+
+		start := startJob(t, setup, envVars, "sweep", "--agent", "claude", "--", "fix the failing tests")
+		if start.ExitCode != 0 {
+			t.Fatalf("start: exit %d: %s", start.ExitCode, start.Combined)
+		}
+		await := erun.Run(t, []string{"job", "await", "--tenant", "team", "--environment", "dev", "--id", "sweep", "--timeout", "30s"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if await.ExitCode != 1 {
+			t.Fatalf("await: exit %d: %s", await.ExitCode, await.Combined)
+		}
+		status := erun.Run(t, []string{"job", "status", "--tenant", "team", "--environment", "dev", "--id", "sweep", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if status.ExitCode != 0 {
+			t.Fatalf("status: exit %d: %s", status.ExitCode, status.Combined)
+		}
+		var payload struct {
+			Reason   string `json:"reason"`
+			Progress struct {
+				Error string `json:"error"`
+			} `json:"progress"`
+		}
+		if err := json.Unmarshal([]byte(status.Stdout), &payload); err != nil {
+			t.Fatalf("parse job status JSON: %v\n%s", err, status.Stdout)
+		}
+		if !strings.Contains(payload.Progress.Error, "OAuth session expired") {
+			t.Fatalf("expected the raw vendor message preserved in progress.error, got %q", payload.Progress.Error)
+		}
+		if !strings.Contains(payload.Reason, "credentials are missing or stale") {
+			t.Fatalf("expected the reason to reframe the failure as a credential problem, got %q", payload.Reason)
+		}
 	})
 
 	t.Run("agent_start_refuses_an_unsupported_tool_or_a_command", func(t *testing.T) {
@@ -681,5 +753,82 @@ func TestJob(t *testing.T) {
 			t.Fatalf("expected the captured non-zero exit to survive the output cap, got %d:\n%s", await.ExitCode, await.Combined)
 		}
 		golden.Equal(t, "job/output_past_the_cap_is_reported_as_truncated", normalize.Apply(await.Combined))
+	})
+
+	t.Run("agent_progress_keeps_moving_after_the_output_cap", func(t *testing.T) {
+		// The defect this closes: once outputTruncated flips, progress used to
+		// freeze at whatever it last read, because it was derived from the same
+		// capped log the raw output writer had stopped growing. The cap is set
+		// small enough that the very first event already exceeds it, so every
+		// later event proves progress is fed straight from the stream rather than
+		// by re-reading the (now-frozen) log file.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		flushed := filepath.Join(setup.Cwd, "flushed")
+		release := filepath.Join(setup.Cwd, "release")
+		stubs := filepath.Join(setup.Cwd, "stubs")
+		fixture.StubBinaryWithScript(t, stubs, "claude",
+			`printf '{"type":"assistant","message":{"id":"msg_1","content":[{"type":"tool_use","id":"t1","name":"Edit","input":{"file_path":"erun-common/mcp_client.go"}}]}}\n'`+"\n"+
+				"printf '"+jobStubSignal+"' > '"+flushed+"'\n"+
+				"while [ ! -f '"+release+"' ]; do sleep 0.05; done\n"+
+				`printf '{"type":"assistant","message":{"id":"msg_2","content":[{"type":"tool_use","id":"t2","name":"Bash","input":{"command":"go test ./..."}}]}}\n'`+"\n"+
+				`printf '{"type":"result","subtype":"success","is_error":false,"num_turns":2,"result":"Fixed the client."}\n'`+"\n"+
+				"exit 0")
+		envVars := inEnvironment(append(setup.Env(), fixture.StubEnv(stubs, "claude")...))
+
+		start := startJob(t, setup, envVars, "sweep", "--max-output-bytes", "8", "--agent", "claude", "--", "fix the failing tests")
+		if start.ExitCode != 0 {
+			t.Fatalf("start: exit %d: %s", start.ExitCode, start.Combined)
+		}
+		waitForFile(t, flushed, 30*time.Second)
+		waitForJobActivity(t, setup, envVars, "sweep", 30*time.Second)
+
+		midRun := erun.Run(t, []string{"job", "status", "--tenant", "team", "--environment", "dev", "--id", "sweep", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		var midPayload struct {
+			OutputTruncated bool `json:"outputTruncated"`
+			Progress        struct {
+				Activity string `json:"activity"`
+			} `json:"progress"`
+		}
+		if err := json.Unmarshal([]byte(midRun.Stdout), &midPayload); err != nil {
+			t.Fatalf("parse mid-run job status JSON: %v\n%s", err, midRun.Stdout)
+		}
+		if !midPayload.OutputTruncated {
+			t.Fatalf("expected the 8-byte cap to already be hit by the first event, got %s", midRun.Stdout)
+		}
+		if !strings.Contains(midPayload.Progress.Activity, "erun-common/mcp_client.go") {
+			t.Fatalf("expected progress to reflect the first tool call despite the cap, got %q", midPayload.Progress.Activity)
+		}
+
+		if err := os.WriteFile(release, []byte("go\n"), 0o644); err != nil {
+			t.Fatalf("release the stub: %v", err)
+		}
+		await := erun.Run(t, []string{"job", "await", "--tenant", "team", "--environment", "dev", "--id", "sweep", "--timeout", "30s"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if await.ExitCode != 0 {
+			t.Fatalf("await: exit %d: %s", await.ExitCode, await.Combined)
+		}
+		finished := erun.Run(t, []string{"job", "status", "--tenant", "team", "--environment", "dev", "--id", "sweep", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		var finishedPayload struct {
+			OutputTruncated bool `json:"outputTruncated"`
+			Progress        struct {
+				Turns  int    `json:"turns"`
+				Result string `json:"result"`
+			} `json:"progress"`
+		}
+		if err := json.Unmarshal([]byte(finished.Stdout), &finishedPayload); err != nil {
+			t.Fatalf("parse finished job status JSON: %v\n%s", err, finished.Stdout)
+		}
+		if !finishedPayload.OutputTruncated {
+			t.Fatalf("expected the job to still report outputTruncated at the end, got %s", finished.Stdout)
+		}
+		// This is the assertion the bug report's freeze would fail: the second
+		// tool call and the final result both arrived well after the 8-byte cap,
+		// so seeing them here proves progress kept moving past it.
+		if finishedPayload.Progress.Turns != 2 {
+			t.Fatalf("expected both turns folded despite the cap, got %+v", finishedPayload.Progress)
+		}
+		if finishedPayload.Progress.Result != "Fixed the client." {
+			t.Fatalf("expected the closing result folded despite the cap, got %+v", finishedPayload.Progress)
+		}
 	})
 }

--- a/erun-integration/mcp_test.go
+++ b/erun-integration/mcp_test.go
@@ -25,6 +25,29 @@ import (
 // developer's live erun session on the default 17000 range.
 const mcpEdgeLocalPort = 26100
 
+// startSilentPortForward binds port and holds every connection open without
+// ever answering it — a stale kubectl port-forward, as opposed to nothing
+// listening at all (dial refused) or an edge that answers with an error. Every
+// held connection is closed together on cleanup, once the listener itself
+// closes and the accept loop's deferred closes run.
+func startSilentPortForward(t *testing.T, port int) {
+	t.Helper()
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("listen on 127.0.0.1:%d: %v", port, err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			defer func() { _ = conn.Close() }()
+		}
+	}()
+}
+
 // fakeMCPEdge stands in for the per-env erun-mcp server: it speaks the
 // streamable-HTTP handshake (initialize, then a 202 for the initialized
 // notification, then the call) and records what each request carried, so a
@@ -52,11 +75,18 @@ type fakeMCPEdge struct {
 	// ForgetSessionAlways never accepts a session id, so a client that keeps
 	// re-handshaking would loop forever.
 	ForgetSessionAlways bool
+	// DropFirstRequest, when set, closes the raw connection for the very first
+	// request without answering it at all — a connection that was accepted and
+	// then cut, the shape a flapping local port-forward leaves an in-flight
+	// request in (as opposed to AcceptEverything, which answers but with an
+	// empty envelope).
+	DropFirstRequest bool
 
 	mu         sync.Mutex
 	requests   []fakeMCPRequest
 	handshakes int
 	forgot     bool
+	dropped    bool
 }
 
 type fakeMCPRequest struct {
@@ -82,6 +112,14 @@ func (e *fakeMCPEdge) start(t *testing.T, port int) {
 }
 
 func (e *fakeMCPEdge) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if e.DropFirstRequest && e.dropOnce() {
+		if hijacker, ok := w.(http.Hijacker); ok {
+			if conn, _, err := hijacker.Hijack(); err == nil {
+				_ = conn.Close()
+			}
+		}
+		return
+	}
 	body, _ := io.ReadAll(r.Body)
 	var request struct {
 		ID     json.RawMessage `json:"id"`
@@ -138,6 +176,16 @@ func (e *fakeMCPEdge) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = fmt.Fprintln(w, reply)
+}
+
+func (e *fakeMCPEdge) dropOnce() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.dropped {
+		return false
+	}
+	e.dropped = true
+	return true
 }
 
 func (e *fakeMCPEdge) forgetSession() bool {
@@ -669,6 +717,32 @@ exit 3`)
 		golden.Equal(t, "mcp/call_real_run_unreachable_edge_points_at_open", normalize.Apply(result.Combined))
 	})
 
+	t.Run("call_real_run_stale_forward_fails_fast_instead_of_hanging", func(t *testing.T) {
+		// A stale kubectl port-forward keeps the local port bound and accepts
+		// every connection, but never answers — the exact shape a dial-based
+		// check cannot see, and the one that used to hang a call for its full
+		// timeout (or forever, with none) instead of failing. The listener here
+		// holds every connection open and never writes to it, so the only way
+		// this scenario passes is if the client's own reachability probe — not
+		// the caller's timeout — is what ends the wait.
+		skipIfPortsBusy(t, mcpEdgeLocalPort)
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnvWithSSHDPortRange(t, setup, "team", "dev", mcpEdgeLocalPort)
+		fixture.SeedDesktopIdentity(t, setup)
+		startSilentPortForward(t, mcpEdgeLocalPort)
+
+		result := erun.Run(t, []string{"mcp", "call", "--tool", "version"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit for a stale port-forward, got 0:\n%s", result.Combined)
+		}
+		if !strings.Contains(result.Combined, "held but the edge never answers") {
+			t.Fatalf("expected the stale forward to be named as such, distinct from a missing one, got:\n%s", result.Combined)
+		}
+		if !strings.Contains(result.Combined, "erun open team dev") {
+			t.Fatalf("expected the same recovery guidance a missing forward gets, got:\n%s", result.Combined)
+		}
+	})
+
 	t.Run("proxy_dry_run_traces_the_resolved_edge", func(t *testing.T) {
 		// The plan must name the edge the relay would reach, and must neither read
 		// stdin nor touch the network.
@@ -871,6 +945,34 @@ exit 3`)
 		}
 		if lists[0].SessionID != "test-session" || lists[1].SessionID != "test-session-2" {
 			t.Fatalf("tools/list sessions = %q then %q, want the dead session then the re-established one", lists[0].SessionID, lists[1].SessionID)
+		}
+	})
+
+	t.Run("call_real_run_recovers_when_the_local_forward_drops_mid_request", func(t *testing.T) {
+		// A flapping kubectl port-forward ("lost connection to pod", then a fresh
+		// forward) drops a request that was already in flight. The remote MCP
+		// server process itself never restarted — only the local tunnel blipped —
+		// so the retry needs no re-handshake, just one resend once the tunnel
+		// answers again, which is exactly what the still-live edge below proves.
+		skipIfPortsBusy(t, mcpEdgeLocalPort)
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnvWithSSHDPortRange(t, setup, "team", "dev", mcpEdgeLocalPort)
+		fixture.SeedDesktopIdentity(t, setup)
+		edge := &fakeMCPEdge{DropFirstRequest: true, Results: map[string]string{
+			"initialize": `{"protocolVersion":"2025-06-18","capabilities":{"tools":{}}}`,
+		}}
+		edge.start(t, mcpEdgeLocalPort)
+
+		result := erun.Run(t, []string{"mcp", "call", "--tool", "version"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("expected the dropped first request to recover, got exit %d:\n%s", result.ExitCode, result.Combined)
+		}
+		// The dropped connection carries no readable request (it was hijacked and
+		// closed before any body was parsed), so exactly one *readable* initialize
+		// reaching the edge is what proves this succeeded via a plain retry, not
+		// by the edge happening to answer the doomed connection after all.
+		if handshakes := edge.requestsFor("initialize"); len(handshakes) != 1 {
+			t.Fatalf("edge saw %d readable initialize requests, want exactly one (the retry): %+v", len(handshakes), edge.recorded())
 		}
 	})
 

--- a/erun-integration/testdata/job/agent_start_dry_run_plans_the_streaming_invocation.txt
+++ b/erun-integration/testdata/job/agent_start_dry_run_plans_the_streaming_invocation.txt
@@ -1,8 +1,10 @@
 audit: erun job start --agent claude --dry-run --environment dev --name sweep --tenant team fix the failing tests
+job: resolving agent tool "claude" in this environment
 job: detaching "sweep" as job sweep, output at <TMP>
 job: holding activity lease job-sweep for the job's lifetime
-<TMP> job supervise --tenant team --environment dev --id sweep --name sweep --max-output-bytes 4194304 --lease-ttl 15m0s --agent claude -- claude -p 'fix the failing tests' --output-format stream-json --verbose
+<TMP> job supervise --tenant team --environment dev --id sweep --name sweep --max-output-bytes 16777216 --lease-ttl 15m0s --agent claude -- claude -p 'fix the failing tests' --output-format stream-json --verbose
 audit: erun job start --agent codex --dry-run --environment dev --name sweep --tenant team fix the failing tests
+job: resolving agent tool "codex" in this environment
 job: detaching "sweep" as job sweep, output at <TMP>
 job: holding activity lease job-sweep for the job's lifetime
-<TMP> job supervise --tenant team --environment dev --id sweep --name sweep --max-output-bytes 4194304 --lease-ttl 15m0s --agent codex -- codex exec --json 'fix the failing tests'
+<TMP> job supervise --tenant team --environment dev --id sweep --name sweep --max-output-bytes 16777216 --lease-ttl 15m0s --agent codex -- codex exec --json 'fix the failing tests'

--- a/erun-integration/testdata/job/off_environment_start_dry_run_traces_the_environment_call.txt
+++ b/erun-integration/testdata/job/off_environment_start_dry_run_traces_the_environment_call.txt
@@ -1,3 +1,3 @@
 audit: erun job start --dry-run --environment dev --name suite --tenant team work --all
 mcp: team/dev edge resolved to http://<LOOPBACK>:17000/mcp
-mcp tools/call http://<LOOPBACK>:17000/mcp job_start '{"command":["work","--all"],"leaseTtlSeconds":900,"maxOutputBytes":4194304,"name":"suite"}'
+mcp tools/call http://<LOOPBACK>:17000/mcp job_start '{"command":["work","--all"],"leaseTtlSeconds":900,"maxOutputBytes":16777216,"name":"suite"}'

--- a/erun-integration/testdata/job/start_dry_run_plans_the_detach.txt
+++ b/erun-integration/testdata/job/start_dry_run_plans_the_detach.txt
@@ -1,4 +1,4 @@
 audit: erun job start --dry-run --environment dev --name suite --tenant team work --all
 job: detaching "suite" as job suite, output at <TMP>
 job: holding activity lease job-suite for the job's lifetime
-<TMP> job supervise --tenant team --environment dev --id suite --name suite --max-output-bytes 4194304 --lease-ttl 15m0s -- work --all
+<TMP> job supervise --tenant team --environment dev --id suite --name suite --max-output-bytes 16777216 --lease-ttl 15m0s -- work --all

--- a/erun-integration/testdata/job/start_help.txt
+++ b/erun-integration/testdata/job/start_help.txt
@@ -34,7 +34,7 @@ Flags:
   -h, --help                   help for start
       --id string              Handle to address the job by (defaults to the name)
       --lease-ttl duration     Activity lease TTL the job renews inside while it runs (default 15m0s)
-      --max-output-bytes int   Cap on captured output; past it output is dropped and the job says so (default 4194304)
+      --max-output-bytes int   Cap on captured output; past it output is dropped and the job says so (default 16777216)
       --name string            What the work is, shown wherever the environment reports as busy
       --tenant string          Tenant whose environment the job belongs to
 

--- a/erun-mcp/job.go
+++ b/erun-mcp/job.go
@@ -27,7 +27,7 @@ type JobStartInput struct {
 	Agent           string   `json:"agent,omitempty" jsonschema:"run an AI tool instead of a command: claude or codex. erun invokes it in its streaming mode, so job_output returns events while the agent works and job_status reports its current activity rather than only running. Requires prompt and excludes command"`
 	Prompt          string   `json:"prompt,omitempty" jsonschema:"what the agent should do; only valid with agent"`
 	Dir             string   `json:"dir,omitempty" jsonschema:"working directory to run from; defaults to the runtime repo root"`
-	MaxOutputBytes  int64    `json:"maxOutputBytes,omitempty" jsonschema:"cap on captured output in bytes; past it output is dropped and the job reports outputTruncated. Defaults to 4194304"`
+	MaxOutputBytes  int64    `json:"maxOutputBytes,omitempty" jsonschema:"cap on captured output in bytes; past it output is dropped and the job reports outputTruncated. Does not affect an agent job's progress, which is folded from the tool's stream directly and keeps updating past the cap. Defaults to 16777216"`
 	LeaseTTLSeconds int64    `json:"leaseTtlSeconds,omitempty" jsonschema:"activity lease TTL the job renews inside while it runs; defaults to 900"`
 	Preview         bool     `json:"preview,omitempty" jsonschema:"when true, resolve and trace the job without starting it"`
 }


### PR DESCRIPTION
## Summary

Fixes five bugs hit while driving a real orchestration session (four first-hand, one — #1033 — reported directly by the operator).

### #1042 — job progress freezes when captured output hits `maxOutputBytes`
**Root cause:** `agentProgressReader` (erun-common/job_agent.go) derived progress by periodically re-reading the job's capped output log file. Once `jobOutputWriter` stopped writing bytes past the cap, the log file's size stopped growing, so the progress reader saw no new bytes and returned the same frozen `AgentJobProgress` forever — `outputTruncated` correctly flipped to `true`, but nothing told the reader that `progress` was now equally stale.

**Fix:** `agentProgressReader` is now push-fed directly from the child process's stdout/stderr writes (`jobOutputWriter.Write` calls `agent.feed(p)` with every byte, unconditionally, before applying the cap), so progress parsing is fully decoupled from what the output cap retains on disk. Also raised `DefaultEnvironmentJobOutputLimitBytes` from 4 MiB to 16 MiB, since a `stream-json` agent run blows through 4 MiB well under an hour — this is the default path for agent work, not an edge case.

**Evidence it's fixed:** new integration scenario `job/agent_progress_keeps_moving_after_the_output_cap` sets `--max-output-bytes 8` (small enough that the very first event already exceeds it) and proves a *second* tool call and the closing result — both emitted well after the cap — still show up in `job status`.

### #1045 — `job_start --agent` runs in an environment with no working AI tool
**Misdiagnosis correction:** the issue framed this as "the environment is configured `ai-tool: none`." I traced `erun list`'s `ai-tool: none` line and found it's rendered by a generic `valueOrNone` helper used for *any* unset optional field — there is no `"none"` sentinel value anywhere in the code, and `EnvConfig.AITool` (governing only the desktop's interactive AI-tab launch command) has no relationship at all to `job_start --agent`, which resolves its tool independently. "Working without an Agent is fine" is documented, normal behavior. So the reported environment wasn't deliberately configured to have no tool — it just had no valid `claude` credentials, and the raw OAuth error was mistaken for the config value.

**What's actually fixed:**
1. `StartEnvironmentJob` now refuses up front — before any activity lease, log file, or supervisor process — when the named `--agent` tool isn't resolvable in this environment (`exec.LookPath`-equivalent via `Command(tool).Err`), naming the tool and how to fix it. Covers the "tool genuinely not installed" case knowably, before any spend.
2. For the actually-reported case (tool present, credentials stale), the job's own already-parsed `Progress.Error` is checked against known auth-failure phrasings (`"oauth session expired"`, `"failed to authenticate"`, etc.) on a non-zero exit, and the job's `Reason` is set to explicitly reframe it as "this environment's `<tool>` credentials are missing or stale, not a problem with the work itself" — instead of leaving the raw vendor string to speak for itself.
3. Did **not** add an `erun doctor` credential-staleness check — scoped out given the corrected diagnosis narrows what's actually broken; noted as a reasonable independent follow-up.

**Evidence:** new scenarios `job/agent_start_refuses_when_the_tool_is_not_available` and `job/agent_progress_reports_an_authentication_failure_as_the_reason`.

### #1033 — a stale MCP port-forward hangs instead of failing fast
**Root cause:** `erun-common/mcp_client.go`'s `postOnce` had no way to distinguish "bound but dead" (a stale `kubectl port-forward`) from a healthy tunnel — it just handed the request to `http.Client.Do`, which blocks until the caller's context deadline (or forever, with none) on a connection that was accepted but never answered.

**Fix:**
1. `postOnce` now runs a bounded (~1.5s) reachability probe before every request, but **only** intercepts when the port is *bound* (a listener exists) yet doesn't answer — a port nothing holds at all still falls through to the original dial-failure path unchanged, so "no forward exists" keeps its existing wording.
2. `postRaw` now retries once (mirroring the existing lost-session recovery pattern) when a transport error occurs and a follow-up reachability probe shows the tunnel answering again — the shape a flapping `kubectl port-forward` ("lost connection to pod", then a fresh forward) leaves an in-flight request in. No re-handshake needed: the remote MCP server process never restarted, only the local tunnel blipped.

**Evidence:** new scenarios `mcp/call_real_run_stale_forward_fails_fast_instead_of_hanging` (a listener that accepts and never answers — completes in ~3s instead of hanging) and `mcp/call_real_run_recovers_when_the_local_forward_drops_mid_request` (a fake edge that hijacks-and-closes exactly the first connection, proving the retry works with no re-handshake).

### #1041 — port-forward state files outlive deleted environments
Fixed coherently with #1033, per the ask:
1. `RunDeleteEnvironment` now removes the mcp/api/sshd port-forward state files for the deleted environment, alongside the rest of its config-dir teardown.
2. `LoadPortForwardState` now validates the tenant/environment still exists in the config store before returning a state as live, so a pre-existing orphan (predating this fix, or left by a partial delete) reads as "no forward" rather than resolving to whatever live environment now holds the reissued port.

The second half only protects the one existing caller (`erun-ui`'s activity sweep) automatically — I did not touch `erun-ui` itself, since editing it triggers `erun-ui/AGENTS.md`'s mandatory Playwright suite requirement for any change to what the desktop observes, which is out of scope here (the fix is a pure backend function change with no new frontend surface).

**Evidence:** new scenarios `delete/real_run_removes_the_environments_port_forward_state` and `delete/dry_run_traces_the_port_forward_state_removal_without_deleting_it`.

### #1036 — a release fails after the full build spend on a knowable registry permission
**Root cause:** the existing preflight (`VerifyGHCRPushScope`) only checks whether the credential's token carries the `write:packages` *scope* — but GitHub lets an org restrict *creating* a new package to its owner even for a token that can push every existing package fine. That's not knowable from token scopes; the repro's own registry table proves it (existing packages: push succeeded; brand-new package: `create_package` denied) even though the codebase already has a scope check.

**Fix:** new `erun-common/ghcr_create_package_preflight.go`, wired into `preflightRegistryPushAccess` (which already runs before any build in `RunDockerPushExecution`) for every resolved image *and* chart. It asks the registry the exact question that matters — the same way `docker push`/`helm push` do — by requesting a push-scoped token for the specific repository and starting (never finishing) a blob-upload session:
- `202/201 Accepted` → push is allowed, including creating the repository for the first time (proven, not guessed); the probe's own session is immediately abandoned via `DELETE` so nothing lingers.
- `401/403` → the registry's own denial (e.g. `create_package`), surfaced with the existing classic-PAT bootstrap guidance, before any build.
- Anything else (unreachable registry, no credential resolved) → inconclusive, never blocks the build — matches the existing `VerifyGHCRPushScope` philosophy of converting a *known* failure into an immediate one, never inventing a new way to block a release it can't actually judge.
- Also fixed a related gap while in this code: the existing scope check only ran against `execution.pushes` (fingerprint-promoted images), missing images built fresh this run (`execution.builds` with `Push=true`) — exactly the shape of the two "quiet" new-image failures the issue reports. Both checks now cover the full set.

This is live-network code with no CLI-facing override seam (same class as the existing `VerifyGHCRPushScope`), so it's covered by direct `erun-common` unit tests (`ghcr_create_package_preflight_test.go`, against a local `httptest` server) rather than the `erun-integration` binary suite — confirmed via the full suite run that no existing/new scenario reaches the real network (no scenario resolves a usable ghcr credential in the scrubbed test harness).

## Test plan
- [x] `erun-common`: `go build ./...`, `go vet ./...`, `go test ./...` — green, including new unit tests for the create-package preflight.
- [x] `erun-cli`, `erun-mcp`: `go build ./...`, `go vet ./...`, `go test ./...` — green.
- [x] `erun-integration`: full `go test ./...` — green, including 8 new/updated scenarios covering all five fixes (job progress-after-cap, agent-tool-unavailable refusal, auth-failure reason, stale-forward fail-fast, mid-request drop retry, delete removes port-forward state x2).
- [x] `make check` (lint across all 5 gated modules + integration suite + coverage gate) run via a detached `erun job` per the task's instructions — green: `0 issues` on every module, integration suite passing, coverage 75.8% (>= the pinned 75.8% threshold).
- [x] Fixed 3 pre-existing-class lint findings (cyclomatic complexity) introduced by my own changes by refactoring (extracting helper functions/methods), not by suppressing the rule.

Closes #1042
Closes #1045
Closes #1033
Closes #1041
Closes #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)