### PR TITLE
Bootstrap the platform's own tenant instead of a fictional operations one

### DIFF
--- a/erun-backend/erun-backend-api/cmd/eapi/main.go
+++ b/erun-backend/erun-backend-api/cmd/eapi/main.go
@@ -90,6 +90,7 @@ func run(args []string) error {
 			CLIClientID:     cfg.PlatformCLIClientID,
 			Brand:           cfg.PlatformBrand,
 		},
+		BootstrapTenantName: cfg.BootstrapTenantName,
 	})
 	if err != nil {
 		return err
@@ -277,6 +278,13 @@ type apiConfig struct {
 	PlatformConsoleClientID string
 	PlatformCLIClientID     string
 	PlatformBrand           string
+	// BootstrapTenantName is this pod's own declared tenant identity
+	// (ERUN_TENANT: the tenant this control plane runs as, e.g. "frs" on
+	// erunpaas.com). Empty-database bootstrap enrols the platform's own
+	// tenant under this name so hosted provisioning's first resolve of
+	// <tenant>-devops finds an image the platform actually publishes,
+	// instead of a synthetic placeholder falling back only when it is unset.
+	BootstrapTenantName string
 }
 
 func configFromEnv() apiConfig {
@@ -316,6 +324,8 @@ func configFromEnv() apiConfig {
 		PlatformConsoleClientID: strings.TrimSpace(os.Getenv("ERUN_PLATFORM_CONSOLE_CLIENT_ID")),
 		PlatformCLIClientID:     strings.TrimSpace(os.Getenv("ERUN_PLATFORM_CLI_CLIENT_ID")),
 		PlatformBrand:           strings.TrimSpace(os.Getenv("ERUN_PLATFORM_BRAND")),
+
+		BootstrapTenantName: strings.TrimSpace(os.Getenv("ERUN_TENANT")),
 	}
 }
 

--- a/erun-backend/erun-backend-api/internal/repository/identity.go
+++ b/erun-backend/erun-backend-api/internal/repository/identity.go
@@ -20,13 +20,22 @@ type IdentityRepository struct {
 	db      *bun.DB
 	dialect Dialect
 	orgKeys *issuerOrgKeyCache
+	// platformTenant is this instance's own declared tenant identity
+	// (ERUN_TENANT), used to name the tenant empty-database bootstrap enrols.
+	// Empty means that configuration is genuinely absent.
+	platformTenant string
 }
 
-func NewIdentityRepository(db *sql.DB, dialect Dialect) *IdentityRepository {
+func NewIdentityRepository(db *sql.DB, dialect Dialect, platformTenant string) *IdentityRepository {
 	if dialect == "" {
 		dialect = DialectPostgres
 	}
-	return &IdentityRepository{db: bun.NewDB(db, pgdialect.New()), dialect: dialect, orgKeys: newIssuerOrgKeyCache()}
+	return &IdentityRepository{
+		db:             bun.NewDB(db, pgdialect.New()),
+		dialect:        dialect,
+		orgKeys:        newIssuerOrgKeyCache(),
+		platformTenant: strings.TrimSpace(platformTenant),
+	}
 }
 
 // issuerOrgKeyCacheTTL bounds staleness so an issuer reconfigured between
@@ -249,8 +258,37 @@ func (r *IdentityRepository) bootstrapFirstIdentity(ctx context.Context, claims 
 	if err != nil {
 		return model.Tenant{}, model.User{}, err
 	}
-	log.Printf("erun api identity enrolled first tenant/user tenant=%q tenantName=%q tenantType=%q user=%q issuer=%q subject=%q username=%q", tenant.TenantID, tenant.Name, tenant.Type, user.UserID, claims.Issuer, claims.Subject, user.Username)
+	log.Printf("erun api identity enrolled first tenant/user tenant=%q tenantName=%q tenantNameSource=%q tenantType=%q user=%q issuer=%q subject=%q username=%q", tenant.TenantID, tenant.Name, bootstrapTenantNameSource(r.platformTenant), tenant.Type, user.UserID, claims.Issuer, claims.Subject, user.Username)
 	return tenant, user, nil
+}
+
+// defaultBootstrapTenantName is used when the platform's own tenant identity
+// (ERUN_TENANT) is not configured. Platforms already bootstrapped under this
+// name before ERUN_TENANT was read here keep working, since bootstrap only
+// ever runs once against an empty tenants table.
+const defaultBootstrapTenantName = "operations"
+
+// bootstrapTenantName resolves the name empty-database bootstrap enrols the
+// platform's own tenant under. The platform already declares which tenant it
+// is via ERUN_TENANT, and hosted provisioning resolves a tenant's runtime
+// image as <registry>/<tenant>-devops:<version>, so enrolling under that same
+// name is what lets the platform's first provision resolve an image it has
+// actually published instead of hunting for one nobody will ever publish.
+func bootstrapTenantName(platformTenant string) string {
+	if platformTenant != "" {
+		return platformTenant
+	}
+	return defaultBootstrapTenantName
+}
+
+// bootstrapTenantNameSource names which of the two bootstrapTenantName
+// branches produced the enrolled tenant's name, so the bootstrap log line
+// says why the name is what it is rather than just what it is.
+func bootstrapTenantNameSource(platformTenant string) string {
+	if platformTenant != "" {
+		return "ERUN_TENANT"
+	}
+	return "fallback"
 }
 
 // insertFirstIdentity creates the initial OPERATIONS tenant, its issuer, and the
@@ -266,7 +304,7 @@ func (r *IdentityRepository) insertFirstIdentity(ctx context.Context, tx bun.Tx,
 		return model.Tenant{}, model.User{}, ErrNotFound
 	}
 
-	tenant, err := r.insertTenant(ctx, tx, "operations", model.TenantTypeOperations)
+	tenant, err := r.insertTenant(ctx, tx, bootstrapTenantName(r.platformTenant), model.TenantTypeOperations)
 	if err != nil {
 		return model.Tenant{}, model.User{}, err
 	}

--- a/erun-backend/erun-backend-api/internal/repository/identity_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/identity_e2e_test.go
@@ -1,0 +1,126 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// Empty-database bootstrap runs SQL with real transaction-local RLS role
+// switches (SET LOCAL ROLE), so it is exercised against a real migrated
+// PostgreSQL rather than a fake that agrees with itself.
+func identityBootstrapDatabase(t *testing.T) *sql.DB {
+	t.Helper()
+	databaseURL := os.Getenv("ERUN_E2E_IDENTITY_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("opt-in: set ERUN_E2E_IDENTITY_DATABASE_URL to a migrated, empty-of-tenants PostgreSQL")
+	}
+	db, err := sql.Open("pgx", databaseURL)
+	mustNoErr(t, err, "open db")
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func mustNoErr(t *testing.T, err error, msg string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", msg, err)
+	}
+}
+
+func TestBootstrapFirstIdentityEnrolsPlatformTenantWhenERUNTenantSet(t *testing.T) {
+	db := identityBootstrapDatabase(t)
+	repo := NewIdentityRepository(db, DialectPostgres, "frs")
+	t.Cleanup(func() { clearIdentityBootstrap(t, db) })
+
+	tenant, user, err := repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  "https://issuer.example/frs",
+		Subject: "operator-subject",
+	})
+	mustNoErr(t, err, "bootstrap with ERUN_TENANT set")
+	if tenant.Name != "frs" {
+		t.Fatalf("expected tenant named %q, got %q", "frs", tenant.Name)
+	}
+	if tenant.Type != model.TenantTypeOperations {
+		t.Fatalf("expected OPERATIONS tenant, got %q", tenant.Type)
+	}
+	if user.UserID == "" {
+		t.Fatal("expected a bootstrapped user")
+	}
+}
+
+func TestBootstrapFirstIdentityFallsBackWhenERUNTenantAbsent(t *testing.T) {
+	db := identityBootstrapDatabase(t)
+	repo := NewIdentityRepository(db, DialectPostgres, "")
+	t.Cleanup(func() { clearIdentityBootstrap(t, db) })
+
+	tenant, _, err := repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  "https://issuer.example/fallback",
+		Subject: "operator-subject",
+	})
+	mustNoErr(t, err, "bootstrap without ERUN_TENANT")
+	if tenant.Name != defaultBootstrapTenantName {
+		t.Fatalf("expected fallback tenant name %q, got %q", defaultBootstrapTenantName, tenant.Name)
+	}
+}
+
+func TestBootstrapFirstIdentityLeavesAlreadyBootstrappedDatabaseAlone(t *testing.T) {
+	db := identityBootstrapDatabase(t)
+	t.Cleanup(func() { clearIdentityBootstrap(t, db) })
+
+	// A platform already bootstrapped under the old fictional name.
+	seeded := NewIdentityRepository(db, DialectPostgres, "")
+	original, _, err := seeded.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  "https://issuer.example/already-bootstrapped",
+		Subject: "first-operator-subject",
+	})
+	mustNoErr(t, err, "seed an already-bootstrapped tenant")
+
+	// A second caller, from an unregistered issuer, with ERUN_TENANT now set,
+	// must not rename the existing tenant or mint a second bootstrap tenant.
+	second := NewIdentityRepository(db, DialectPostgres, "frs")
+	_, _, err = second.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  "https://issuer.example/unregistered",
+		Subject: "second-subject",
+	})
+	if err == nil {
+		t.Fatal("expected the unregistered issuer to be rejected once a tenant already exists")
+	}
+
+	var tenantCount int
+	mustNoErr(t, db.QueryRow(`SELECT COUNT(*) FROM tenants`).Scan(&tenantCount), "count tenants")
+	if tenantCount != 1 {
+		t.Fatalf("expected exactly one tenant left alone, got %d", tenantCount)
+	}
+	var name string
+	mustNoErr(t, db.QueryRow(`SELECT name FROM tenants WHERE tenant_id = $1`, original.TenantID).Scan(&name), "read seeded tenant name")
+	if name != defaultBootstrapTenantName {
+		t.Fatalf("expected the seeded tenant's name untouched at %q, got %q", defaultBootstrapTenantName, name)
+	}
+}
+
+// clearIdentityBootstrap resets every table empty-database bootstrap writes to,
+// so each scenario starts from a genuinely empty tenants table.
+func clearIdentityBootstrap(t *testing.T, db *sql.DB) {
+	t.Helper()
+	for _, stmt := range []string{
+		`DELETE FROM user_roles`,
+		`DELETE FROM role_permissions`,
+		`DELETE FROM roles`,
+		`DELETE FROM user_external_ids`,
+		`DELETE FROM users`,
+		`DELETE FROM tenant_issuers`,
+		`DELETE FROM issuers`,
+		`DELETE FROM tenants`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Logf("cleanup %q: %v", stmt, err)
+		}
+	}
+}

--- a/erun-backend/erun-backend-api/internal/repository/identity_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/identity_test.go
@@ -7,9 +7,37 @@ import (
 )
 
 func TestIdentityRepositoryKeepsPostgresDialect(t *testing.T) {
-	repo := NewIdentityRepository(nil, DialectPostgres)
+	repo := NewIdentityRepository(nil, DialectPostgres, "")
 	if repo.dialect != DialectPostgres {
 		t.Fatalf("expected postgres dialect, got %q", repo.dialect)
+	}
+}
+
+func TestIdentityRepositoryTrimsPlatformTenant(t *testing.T) {
+	repo := NewIdentityRepository(nil, DialectPostgres, "  frs  ")
+	if repo.platformTenant != "frs" {
+		t.Fatalf("expected trimmed platform tenant %q, got %q", "frs", repo.platformTenant)
+	}
+}
+
+func TestBootstrapTenantNameUsesPlatformTenantWhenConfigured(t *testing.T) {
+	if got := bootstrapTenantName("frs"); got != "frs" {
+		t.Fatalf("expected platform tenant name, got %q", got)
+	}
+}
+
+func TestBootstrapTenantNameFallsBackWhenPlatformTenantAbsent(t *testing.T) {
+	if got := bootstrapTenantName(""); got != defaultBootstrapTenantName {
+		t.Fatalf("expected fallback name %q, got %q", defaultBootstrapTenantName, got)
+	}
+}
+
+func TestBootstrapTenantNameSourceReflectsWhichBranchRan(t *testing.T) {
+	if got := bootstrapTenantNameSource("frs"); got != "ERUN_TENANT" {
+		t.Fatalf("expected ERUN_TENANT source, got %q", got)
+	}
+	if got := bootstrapTenantNameSource(""); got != "fallback" {
+		t.Fatalf("expected fallback source, got %q", got)
 	}
 }
 

--- a/erun-backend/erun-backend-api/server.go
+++ b/erun-backend/erun-backend-api/server.go
@@ -64,6 +64,10 @@ type HandlerOptions struct {
 	// unauthenticated at GET /v1/platform so a client can discover it before it
 	// has a token. Unset fields render as empty strings, never as an error.
 	Platform routes.PlatformInfo
+	// BootstrapTenantName is this instance's own declared tenant identity
+	// (ERUN_TENANT), used to name the tenant empty-database bootstrap enrols
+	// instead of a generic placeholder. Empty falls back to that placeholder.
+	BootstrapTenantName string
 }
 
 func NewHandler(options HandlerOptions) (http.Handler, error) {
@@ -117,7 +121,7 @@ func resolveIdentityResolvers(options HandlerOptions) identityResolvers {
 	if options.DB == nil || resolvers.complete() {
 		return resolvers
 	}
-	resolvers.defaultTo(repository.NewIdentityRepository(options.DB, options.DBDialect))
+	resolvers.defaultTo(repository.NewIdentityRepository(options.DB, options.DBDialect, options.BootstrapTenantName))
 	return resolvers
 }
 


### PR DESCRIPTION
## What

Empty-database bootstrap (`IdentityRepository.insertFirstIdentity`) enrolled the first authenticated caller into a tenant with a hardcoded name, `"operations"`, even though the API pod already knows its own tenant identity via `ERUN_TENANT` (already wired into the pod's env by `erun-devops/k8s/erun-backend-api/templates/api.yaml`).

Now bootstrap enrols the platform's own tenant: it reads `ERUN_TENANT` (threaded as `apiConfig.BootstrapTenantName` → `HandlerOptions.BootstrapTenantName` → `IdentityRepository.platformTenant`) and, when non-empty, names the bootstrap tenant after it. When `ERUN_TENANT` is genuinely absent, it falls back to the previous generic `"operations"` name, unchanged.

## Why it matters

The operator of a hosted erun platform *is* its first tenant — it runs erun, owns the cluster, and publishes `<tenant>-devops`. Hosted provisioning resolves a tenant's own runtime image as `<registry>/<tenant>-devops:<version>`, so a synthetic bootstrap tenant (`operations`) makes the first provision on every new platform hunt for `operations-devops`, an image nobody will ever publish, when the platform's real tenant (e.g. `frs`) would have resolved `frs-devops` immediately.

## Data-model decision

The issue asks explicitly whether the platform operator should be a tenant of its own control plane, or a distinct kind of principal. This PR keeps it a tenant. Reasoning:

- The `OPERATIONS` tenant type already exists as a first-class concept in the schema, RLS (`erun_operations` role, `*_operations_access` policies), authorization, and audit logging — every backend layer already models "a tenant that also administers the platform" correctly.
- The defect was never that "tenant" is the wrong shape for the platform operator; it's that bootstrap invented a *name* for that tenant instead of using the one the platform already declares (`ERUN_TENANT`).
- Introducing a separate principal type would mean a new identity/authz/audit dimension parallel to tenants — RLS policies, permission checks, and audit events would all need a second branch — for no behavioral gain over just naming the existing tenant correctly.

So the fix is scoped to naming, not to the data model: same `OPERATIONS` tenant type, same RLS role, just enrolled under the platform's real identity instead of a fictional one.

## Already-bootstrapped platforms

No migration renames an existing `"operations"` tenant. `insertFirstIdentity` only ever runs against an empty `tenants` table (guarded by a `SELECT COUNT(*) FROM tenants` check, unchanged by this PR), so a platform bootstrapped before this fix keeps its existing tenant name — this is an explicit no-op for already-bootstrapped databases, not an oversight. Covered by `TestBootstrapFirstIdentityLeavesAlreadyBootstrappedDatabaseAlone`.

## Logging

The existing bootstrap log line already reports `tenantName=`/`tenantType=`, which is truthful automatically once the inserted name reflects `ERUN_TENANT` or the fallback. Added `tenantNameSource="ERUN_TENANT"` or `tenantNameSource="fallback"` so the log also says *why* the name is what it is, not just what it is.

## Tests

- `internal/repository/identity_test.go`: unit tests for the pure name-resolution helpers (`bootstrapTenantName`, `bootstrapTenantNameSource`) and constructor trimming — `ERUN_TENANT` set vs. absent.
- `internal/repository/identity_e2e_test.go` (new, opt-in via `ERUN_E2E_IDENTITY_DATABASE_URL`, following the existing `release_queue_sql_e2e_test.go` / `provisioning_e2e_test.go` convention since bootstrap runs real transaction-local RLS role switches): exercises `ResolveIdentity` end-to-end against a real migrated PostgreSQL for all three scenarios — bootstrap with `ERUN_TENANT` set, bootstrap without it, and an already-bootstrapped database left alone (tenant count and name unchanged).
- Ran the e2e suite locally against a throwaway `postgres:18` container with `erun-backend-db`'s Atlas migrations applied; all three scenarios pass, and the log lines show the fix (`tenantName="frs" tenantNameSource="ERUN_TENANT"` vs. `tenantName="operations" tenantNameSource="fallback"`).

## Docs

No `erun-docs` update: this is a pure bug fix that preserves the documented contract (empty-database bootstrap still creates one `OPERATIONS` tenant and its first user with `ReadAll`/`WriteAll`) — only which name gets used changes, and that was never part of the documented contract.

## Validation

- `cd erun-backend/erun-backend-api && go test ./...` — green.
- `make check` (lint + integration suite + coverage) — green, run via `erun job start`/`erun job await` per repo convention.

Closes #1063