### PR TITLE
Fix golangci-lint cross-compile install broken by BUILDPLATFORM pin

### DIFF
--- a/erun-devops/docker/dockerfile-platform_test.sh
+++ b/erun-devops/docker/dockerfile-platform_test.sh
@@ -48,6 +48,15 @@ if grep -qF 'COPY --from=builder /usr/local/go' "${devops_dockerfile}"; then
     fail "${devops_dockerfile}: /usr/local/go must be sourced from the unpinned goroot stage, not the BUILDPLATFORM-pinned builder stage"
 fi
 
+# The builder stage's golangci-lint install cross-compiles like erun/emcp, so it
+# must not set an explicit GOBIN: `go install` refuses to write to GOBIN when
+# cross-compiling, which broke the arm64 pass of a BUILDPLATFORM-pinned builder
+# even though the amd64 pass, matching the host, kept working.
+if grep -qF 'GOBIN=/out go install' "${devops_dockerfile}"; then
+    fail "${devops_dockerfile}: golangci-lint install must not set GOBIN when cross-compiling (go install rejects it)"
+fi
+assert_line "${devops_dockerfile}" 'find "$(go env GOPATH)/bin" -name golangci-lint -exec cp {} /out/golangci-lint \;'
+
 # erun-backend-api and erun-dns01-webhook: single builder stage, only the
 # compiled binary is copied into the final image, so pinning is unconditional.
 assert_line "${docker_dir}/erun-backend-api/Dockerfile" 'FROM --platform=$BUILDPLATFORM golang:1.26.0 AS builder'

--- a/erun-devops/docker/erun-devops/Dockerfile
+++ b/erun-devops/docker/erun-devops/Dockerfile
@@ -83,10 +83,18 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # golangci-lint maintainers used at release time, which drifts behind
 # erun's go.mod bumps and aborts pre-commit with "go language version
 # used to build golangci-lint is lower than the targeted Go version".
+#
+# GOBIN is intentionally left unset: `go install` refuses to write to an
+# explicit GOBIN when cross-compiling, so with the stage pinned to
+# BUILDPLATFORM (TARGETARCH != host on the foreign-arch pass) the install
+# instead lands under $(go env GOPATH)/bin/, in a <GOOS>_<GOARCH>/ subdir
+# when cross-compiling or directly in bin/ when it matches the host.
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    GOBIN=/out go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
+    go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}" && \
+    mkdir -p /out && \
+    find "$(go env GOPATH)/bin" -name golangci-lint -exec cp {} /out/golangci-lint \;
 
 # Gate the artefacts on the test stage: the runtime stage copies from /out,
 # so an image can only be tagged when the integration gate passed.


### PR DESCRIPTION
## Summary

- PR #1060 pinned the `erun-devops` builder stage to `--platform=$BUILDPLATFORM` so cross-compiling Go stages run natively instead of under qemu, but its `golangci-lint` `go install` still set an explicit `GOBIN`. `go install` refuses to write to an explicit `GOBIN` when it detects it's cross-compiling, which broke only the arm64 leg of `erun release` (amd64 matches the build host, so it kept passing and the bug slipped through both a `--target test` rebuild and a local `make check`).
- Fix: drop `GOBIN` from that `go install` call and pick the installed binary up from `$(go env GOPATH)/bin/` — Go always writes there (in a `<GOOS>_<GOARCH>/` subdir when cross-compiling, or directly in `bin/` when the target matches the host) when `GOBIN` is unset.
- Audited the other two Dockerfiles #1060 pinned to `$BUILDPLATFORM` (`erun-backend-api`, `erun-dns01-webhook`): both build their own module's binary with plain `go build -o`, which carries no such restriction, so neither has the same latent bug.
- Added a regression assertion to `erun-devops/docker/dockerfile-platform_test.sh` that fails if `GOBIN=/out go install` is reintroduced for this stage, and locks in the fixed copy step.

Closes #1070

## Test plan

- [x] `sh erun-devops/docker/dockerfile-platform_test.sh` passes (new regression assertion included)
- [x] `make check` green (lint across all gated modules + integration suite, 75.8% coverage)
- [x] Built `docker build --platform linux/arm64 --target builder` for the `erun-devops` Dockerfile standalone — the previously failing golangci-lint install step now succeeds in 45.5s
- [x] Extracted the resulting `golangci-lint` binary and confirmed its ELF header (`e_machine = 0x00b7`, `EM_AARCH64`) is genuinely arm64, not a host-arch binary mislabeled
- [x] Ran a full `erun build` (both `linux/amd64` and `linux/arm64`) across all 12 images — `erun-devops` and `erun-dns01-webhook` (the two that needed rebuilding) built clean on both arches; exited 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)