### PR TITLE
Fix unschedulable runtime pods: size init containers, fix LimitRange defaultRequest

### DIFF
--- a/erun-common/kubernetes_resource_quota.go
+++ b/erun-common/kubernetes_resource_quota.go
@@ -16,9 +16,13 @@ const (
 // for one namespace's cap. The LimitRange supplies a default/defaultRequest so
 // a pod that declares no resources of its own (nothing in this namespace is
 // assumed to) still gets sane values instead of the ResourceQuota rejecting it
-// outright for omitting requests. The default equals the cap itself divided
-// across a small fixed pod budget, keeping this generic rather than baking in
-// the runtime chart's own values.
+// outright for omitting requests. `default` (the limit) equals the namespace
+// cap: that only bounds an unsized container and costs nothing at scheduling
+// time. `defaultRequest` must not follow the cap the same way — a request is a
+// reservation, and a defaultRequest equal to the cap turns the quota into a
+// minimum node size for the whole namespace (#1076), so it is instead the
+// small fixed value in DefaultLimitRangeDefaultRequestCPU/Memory, independent
+// of how large the cap is configured.
 func namespaceResourceQuotaManifest(namespace string, quota NamespaceResourceQuota) string {
 	return fmt.Sprintf(`apiVersion: v1
 kind: ResourceQuota
@@ -50,7 +54,7 @@ spec:
 		quota.CPU, quota.Memory, quota.Storage,
 		limitRangeName, namespace,
 		quota.CPU, quota.Memory,
-		quota.CPU, quota.Memory,
+		DefaultLimitRangeDefaultRequestCPU, DefaultLimitRangeDefaultRequestMemory,
 	)
 }
 

--- a/erun-common/kubernetes_resource_quota_test.go
+++ b/erun-common/kubernetes_resource_quota_test.go
@@ -1,0 +1,59 @@
+package eruncommon
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNamespaceResourceQuotaManifestDefaultRequestIsFixedNotTheCap pins #1076:
+// the LimitRange's `default` (limit) tracks the namespace cap, but
+// `defaultRequest` must stay a small fixed value regardless of the cap. Before
+// the fix both fields echoed quota.CPU/Memory, so an unsized container's
+// inherited request equalled the whole namespace allowance.
+func TestNamespaceResourceQuotaManifestDefaultRequestIsFixedNotTheCap(t *testing.T) {
+	quota := NamespaceResourceQuota{CPU: "8", Memory: "17832Mi", Storage: "72Gi"}
+	manifest := namespaceResourceQuotaManifest("team-dev", quota)
+
+	limitRange := manifest[strings.Index(manifest, "kind: LimitRange"):]
+
+	defaultBlock := limitRange[strings.Index(limitRange, "default:"):strings.Index(limitRange, "defaultRequest:")]
+	if !strings.Contains(defaultBlock, `cpu: "8"`) {
+		t.Fatalf("default cpu limit should equal the namespace cap, got: %s", defaultBlock)
+	}
+	if !strings.Contains(defaultBlock, `memory: "17832Mi"`) {
+		t.Fatalf("default memory limit should equal the namespace cap, got: %s", defaultBlock)
+	}
+
+	requestBlock := limitRange[strings.Index(limitRange, "defaultRequest:"):]
+	if !strings.Contains(requestBlock, `cpu: "`+DefaultLimitRangeDefaultRequestCPU+`"`) {
+		t.Fatalf("defaultRequest cpu should be the fixed constant %q, not the cap, got: %s", DefaultLimitRangeDefaultRequestCPU, requestBlock)
+	}
+	if !strings.Contains(requestBlock, `memory: "`+DefaultLimitRangeDefaultRequestMemory+`"`) {
+		t.Fatalf("defaultRequest memory should be the fixed constant %q, not the cap, got: %s", DefaultLimitRangeDefaultRequestMemory, requestBlock)
+	}
+	if strings.Contains(requestBlock, `cpu: "8"`) {
+		t.Fatalf("defaultRequest cpu must not equal the namespace cap: %s", requestBlock)
+	}
+	if strings.Contains(requestBlock, `memory: "17832Mi"`) {
+		t.Fatalf("defaultRequest memory must not equal the namespace cap: %s", requestBlock)
+	}
+}
+
+// TestNamespaceResourceQuotaManifestDefaultRequestIndependentOfCapSize
+// changes the cap and asserts the fixed defaultRequest constants do not move
+// with it — the property that makes an unsized container's reservation stay
+// small however large an operator configures the namespace cap to be.
+func TestNamespaceResourceQuotaManifestDefaultRequestIndependentOfCapSize(t *testing.T) {
+	small := namespaceResourceQuotaManifest("team-dev", NamespaceResourceQuota{CPU: "2", Memory: "4096Mi", Storage: "20Gi"})
+	large := namespaceResourceQuotaManifest("team-prod", NamespaceResourceQuota{CPU: "32", Memory: "65536Mi", Storage: "200Gi"})
+
+	for _, manifest := range []string{small, large} {
+		requestBlock := manifest[strings.Index(manifest, "defaultRequest:"):]
+		if !strings.Contains(requestBlock, `cpu: "`+DefaultLimitRangeDefaultRequestCPU+`"`) {
+			t.Fatalf("defaultRequest cpu should stay fixed at %q regardless of cap, got: %s", DefaultLimitRangeDefaultRequestCPU, requestBlock)
+		}
+		if !strings.Contains(requestBlock, `memory: "`+DefaultLimitRangeDefaultRequestMemory+`"`) {
+			t.Fatalf("defaultRequest memory should stay fixed at %q regardless of cap, got: %s", DefaultLimitRangeDefaultRequestMemory, requestBlock)
+		}
+	}
+}

--- a/erun-common/runtime_resources.go
+++ b/erun-common/runtime_resources.go
@@ -30,6 +30,41 @@ const (
 	DefaultRuntimeDindRequestMemory = "1024Mi"
 )
 
+// DefaultLimitRangeDefaultRequestCPU/Memory size the namespace LimitRange's
+// defaultRequest (namespaceResourceQuotaManifest in
+// kubernetes_resource_quota.go) — the value an unsized container in the
+// namespace is assigned as its own request. Unlike the LimitRange's `default`
+// (a limit, which safely equals the namespace cap: it only bounds an unsized
+// container and costs nothing at scheduling time), a defaultRequest equal to
+// the cap turns the quota into a minimum node size — one unsized container
+// reserves the namespace's entire allowance. #1076 was exactly this: an
+// unsized init container inherited a request equal to the full quota width,
+// and Kubernetes schedules a pod on max(max(init container requests),
+// sum(container requests)), so the pod's effective request became the whole
+// quota and it could only land on a node at least that large. Sized to the
+// runtime container's own small fixed request rather than derived from the
+// cap, so an unsized container reserves little regardless of how large the
+// namespace quota is configured.
+const (
+	DefaultLimitRangeDefaultRequestCPU    = "0.25"
+	DefaultLimitRangeDefaultRequestMemory = "1024Mi"
+)
+
+// DefaultRuntimeInitContainerCPU/Memory and
+// DefaultRuntimeInitContainerRequestCPU/Memory size the runtime chart's init
+// containers (prepare-volumes, adopt-worktree, install-binfmt in
+// erun-devops/k8s/erun-devops/templates/service.yaml). Before #1076 none of
+// them declared resources of their own, so each depended entirely on the
+// namespace LimitRange's defaults. Each does a few seconds of chown, a file
+// copy, or qemu binary registration — none of it CPU- or memory-heavy — so a
+// small fixed budget, independent of the namespace cap, covers all three.
+const (
+	DefaultRuntimeInitContainerCPU           = "0.5"
+	DefaultRuntimeInitContainerMemory        = "256Mi"
+	DefaultRuntimeInitContainerRequestCPU    = "0.1"
+	DefaultRuntimeInitContainerRequestMemory = "64Mi"
+)
+
 // DefaultRuntimeHomePVCGi/DockerPVCGi/WorktreePVCGi mirror the erun-devops
 // chart's own PVC sizes (service.yaml's release-home, release-docker, and —
 // rendered only when worktreeStorage=pvc — release-worktree claims). Kept as

--- a/erun-devops/k8s/erun-devops-chart_test.sh
+++ b/erun-devops/k8s/erun-devops-chart_test.sh
@@ -452,4 +452,54 @@ grep -q 'install-binfmt' "${init_block}" &&
 pod_security_context "${rendered}" | grep -q 'supplementalGroups' &&
     fail "a runtime env has no docker daemon to join the group of"
 
+# --- 26. Every container and init container the template can render declares
+# both resources.limits and resources.requests. This is the structural version
+# of #1061 (the dind sidecar) and #1076 (every init container): both bugs were
+# "a container was added to the pod and nobody sized it", left to inherit
+# whatever the namespace LimitRange defaults an unsized container to — which
+# can equal the entire configured quota width. Checked across every
+# envType/worktreeStorage permutation the template supports, so the next
+# container added to the pod cannot reintroduce the pattern silently. ---
+all_container_blocks() {
+    awk '
+        /^      (initContainers|containers):$/ { insec=1; next }
+        /^      volumes:$/ { insec=0 }
+        insec && /^        #/ { next }
+        insec && /^        - image: /{ if (n>0) print "\f"; n++ }
+        insec && n { print }
+    ' "$1"
+}
+
+assert_every_container_sized() {
+    file="$1"
+    label="$2"
+    all_container_blocks "${file}" | awk -v label="${label}" '
+        BEGIN { RS="\f"; failed=0 }
+        NF==0 { next }
+        {
+            name="(unnamed)"
+            if (match($0, /\n          name: [^\n]+/)) {
+                name = substr($0, RSTART+17, RLENGTH-17)
+            }
+            has_resources = ($0 ~ /\n          resources:\n/)
+            has_limits = ($0 ~ /\n            limits:\n/)
+            has_requests = ($0 ~ /\n            requests:\n/)
+            if (!has_resources || !has_limits || !has_requests) {
+                printf "FAIL: %s container %s is missing resources.limits/requests\n", label, name > "/dev/stderr"
+                failed=1
+            }
+        }
+        END { exit failed }
+    ' || fail "${label}: a container renders without both resources.limits and resources.requests"
+}
+
+for storage_args in \
+    "--set worktreeStorage=pvc --set worktreeRepoName=petios" \
+    "--set worktreeStorage=host --set-string worktreeHostPath=/host/git/petios" \
+    "--set worktreeStorage=none"; do
+    # shellcheck disable=SC2086
+    rendered=$(render ${storage_args})
+    assert_every_container_sized "${rendered}" "storage(${storage_args})"
+done
+
 echo "PASS: erun-devops chart pod shape"

--- a/erun-devops/k8s/erun-devops/templates/service.yaml
+++ b/erun-devops/k8s/erun-devops/templates/service.yaml
@@ -101,6 +101,24 @@ emitted; type is the single source of truth.
 {{- $dindMemory := default "8916Mi" $dindLimits.memory -}}
 {{- $dindRequestCPU := default "0.25" $dindRequests.cpu -}}
 {{- $dindRequestMemory := default "1024Mi" $dindRequests.memory -}}
+{{- /* Every init container below (prepare-volumes, adopt-worktree,
+       install-binfmt) declares the same small explicit resources rather than
+       relying on the namespace LimitRange's default: Kubernetes admits a pod
+       on max(max(init container requests), sum(container requests)), so one
+       unsized init container's inherited request can become the pod's entire
+       effective request (#1076 — this is what #1061 already fixed for the
+       dind sidecar above). Each does a few seconds of chown, file copy, or
+       qemu binary registration, so one shared budget covers all three.
+       Defaults mirror eruncommon.DefaultRuntimeInitContainerCPU/Memory in
+       erun-common/runtime_resources.go — keep the two in sync. */ -}}
+{{- $initContainers := default dict $runtime.initContainers -}}
+{{- $initContainerResources := default dict $initContainers.resources -}}
+{{- $initContainerLimits := default dict $initContainerResources.limits -}}
+{{- $initContainerRequests := default dict $initContainerResources.requests -}}
+{{- $initContainerCPU := default "0.5" $initContainerLimits.cpu -}}
+{{- $initContainerMemory := default "256Mi" $initContainerLimits.memory -}}
+{{- $initContainerRequestCPU := default "0.1" $initContainerRequests.cpu -}}
+{{- $initContainerRequestMemory := default "64Mi" $initContainerRequests.memory -}}
 {{- $managedCloud := default false .Values.managedCloud -}}
 {{- $imageOverrides := default dict .Values.imageOverrides -}}
 {{- $containerRegistry := default "ghcr.io/sophium" .Values.containerRegistry -}}
@@ -448,6 +466,13 @@ spec:
           securityContext:
             runAsUser: 0
             runAsGroup: 0
+          resources:
+            limits:
+              cpu: {{ $initContainerCPU | quote }}
+              memory: {{ $initContainerMemory | quote }}
+            requests:
+              cpu: {{ $initContainerRequestCPU | quote }}
+              memory: {{ $initContainerRequestMemory | quote }}
           command:
             - sh
             - -c
@@ -479,6 +504,13 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
+          resources:
+            limits:
+              cpu: {{ $initContainerCPU | quote }}
+              memory: {{ $initContainerMemory | quote }}
+            requests:
+              cpu: {{ $initContainerRequestCPU | quote }}
+              memory: {{ $initContainerRequestMemory | quote }}
           command:
             - sh
             - -c
@@ -507,6 +539,13 @@ spec:
             - amd64,arm64
           securityContext:
             privileged: true
+          resources:
+            limits:
+              cpu: {{ $initContainerCPU | quote }}
+              memory: {{ $initContainerMemory | quote }}
+            requests:
+              cpu: {{ $initContainerRequestCPU | quote }}
+              memory: {{ $initContainerRequestMemory | quote }}
         {{- end }}
       containers:
         - image: {{ $devopsImage }}


### PR DESCRIPTION
## Summary

A hosted environment provisioned on shipped defaults never scheduled — it sat `Pending` forever with `Insufficient cpu, Insufficient memory`. Kubernetes admits a pod on `max(max(initContainer requests), sum(container requests))`, and two bugs combined to make that maximum equal the entire namespace quota:

1. **`erun-common/kubernetes_resource_quota.go`** — `namespaceResourceQuotaManifest` passed the same cap value to both the LimitRange's `default` (a limit) and `defaultRequest`. A default *limit* equal to the cap is fine — it only bounds an unsized container and costs nothing at scheduling time. A default *request* equal to the cap is not: requests are reservations, so this turned the quota into a minimum node size.
2. **`erun-devops/k8s/erun-devops/templates/service.yaml`** — the three init containers (`prepare-volumes`, `adopt-worktree`, `install-binfmt`) declared no `resources` at all, so each inherited that inflated default request. One unsized init container's inherited request became the pod's entire effective request.

Observed live: `prepare-volumes` requesting `cpu:8, memory:17832Mi` against a 4 CPU / 15.6Gi node — unschedulable by construction, on defaults, with no operator error. This is the same shape of bug as #1061 (the dind sidecar), just on the init containers this time.

## Changes

- `erun-common/runtime_resources.go` — added `DefaultLimitRangeDefaultRequestCPU/Memory` (0.25 / 1024Mi, the runtime container's own request) for the LimitRange's `defaultRequest`, and `DefaultRuntimeInitContainerCPU/Memory` + `...RequestCPU/Memory` (0.5 CPU / 256Mi limit, 0.1 CPU / 64Mi request) sizing the three init containers, which each do a few seconds of chown, file copy, or qemu binary registration.
- `erun-common/kubernetes_resource_quota.go` — `namespaceResourceQuotaManifest`'s LimitRange now sets `default` to the cap (unchanged) and `defaultRequest` to the new fixed constant, independent of the cap.
- `erun-devops/k8s/erun-devops/templates/service.yaml` — `prepare-volumes`, `adopt-worktree`, and `install-binfmt` now declare explicit `resources.limits`/`requests`, chart-value-driven the same way the dind sidecar is (`runtime.initContainers.resources`), defaulting to the new constants.
- `erun-devops/k8s/erun-devops-chart_test.sh` — added a structural assertion that renders the chart across every `worktreeStorage` permutation (`pvc`, `host`, `none`) and asserts that **every** container and init container declares both `resources.limits` and `resources.requests`. This class of bug has shipped twice (#1061 the sidecar, #1076 the init containers) — the point of a structural check over a third hand-written per-container assertion is that the next container added to the pod fails the gate instead of silently reproducing the pattern. Verified it actually catches a regression by rendering a copy of the chart with one container's `resources` stripped and confirming the assertion fails.
- `erun-common/kubernetes_resource_quota_test.go` — new unit test pinning the `default` vs `defaultRequest` distinction (limit tracks the cap, request stays fixed regardless of cap size). No prior test covered this function; it's package-private and not exercised by the integration suite (only the `kubectl apply` command line is traced, not the manifest body), so a unit test is the right layer.

## `MinimumRuntimeNamespaceQuota` — unchanged, confirmed

`MinimumRuntimeNamespaceQuota` sums only the runtime + dind containers' **limits** (the ResourceQuota's `limits.cpu`/`limits.memory` hard cap) plus PVC storage — it has no dependency on requests or init-container sizing. With init containers sized small (0.1 CPU / 64Mi request each) and `sum(container requests)` = 0.5 CPU / 2048Mi (main + dind) dominating `max(init requests)` = 0.1 CPU / 64Mi, the floor this function computes is unaffected. No code change needed here.

## Constraints honored

- Did not change the quota cap values or `repository.DefaultMax*` (#1065's deliberate sizing).
- Did not weaken the dind sidecar's sizing from #1061.

Closes #1076

## Test plan

- [x] `make check` (golangci-lint over 5 modules + integration suite): green, see verdict below.
- [x] `erun-devops/k8s/erun-devops-chart_test.sh` run directly: green.
- [x] New unit test `erun-common/kubernetes_resource_quota_test.go` passes.
- [x] Manually verified the new structural chart assertion catches a regression (stripped `resources` from `prepare-volumes` in a throwaway copy of the chart, confirmed the assertion fails with a clear message, then discarded the copy).

### `make check` verdict (verbatim tail)
```
>> golangci-lint erun-common
0 issues.
>> golangci-lint erun-cli
0 issues.
>> golangci-lint erun-mcp
0 issues.
>> golangci-lint erun-integration
0 issues.
>> golangci-lint erun-backend/erun-backend-api
0 issues.
./erun-integration/scripts/integration-test.sh
>> running integration suite (cover dir: ...)
ok  	github.com/sophium/erun/erun-integration	69.869s
...
ok  coverage 75.8% (>= 75.8%)
```

### Chart test verdict
```
PASS: erun-devops chart pod shape
```