### PR TITLE
Seed env config for the stop and delete lifecycle Jobs

### DIFF
--- a/erun-backend/erun-backend-api/internal/deployexec/job.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/job.go
@@ -149,7 +149,7 @@ func buildDeployJob(params DeployJobParams) *batchv1.Job {
 // in-cluster kubeconfig (entrypoint.sh's write_kubeconfig) and no
 // ~/.config/erun/<tenant>/<environment>/config.yaml for `erun deploy` to
 // resolve — a freshly-registered environment was never baked into any image,
-// so nothing on disk describes it. bootstrapDeployEnvironmentScript seeds both
+// so nothing on disk describes it. bootstrapEnvironmentScript seeds both
 // explicitly before `erun deploy` runs, keeping `deploy` itself an unchanged
 // pure primitive: the Job (this caller) supplies the environment's shape, the
 // primitive still only consumes on-disk config exactly as it always has.
@@ -159,7 +159,7 @@ func buildDeployCommand(params DeployJobParams) []string {
 		deploy = append(deploy, "--runtime-image", override)
 	}
 	deploy = append(deploy, namespaceQuotaFlags(params)...)
-	script := bootstrapDeployEnvironmentScript(params) + shellJoin(deploy)
+	script := bootstrapEnvironmentScript(params.Tenant, params.Environment) + shellJoin(deploy)
 	if ip := strings.TrimSpace(params.ExposeTargetIP); ip != "" {
 		expose := []string{"erun", "expose", params.Tenant, params.Environment, mcpExposeService, "--ip", ip, "--skip-if-unconfigured"}
 		script += " && " + shellJoin(expose)
@@ -178,14 +178,22 @@ func namespaceQuotaFlags(params DeployJobParams) []string {
 	return []string{"--max-cpu", cpu, "--max-memory", memory, "--max-storage", storage}
 }
 
-// bootstrapDeployEnvironmentScript seeds the in-cluster kubeconfig context
+// bootstrapEnvironmentScript seeds the in-cluster kubeconfig context
 // (mirroring entrypoint.sh's write_kubeconfig, from the ServiceAccount token
 // Kubernetes auto-mounts into every pod) and a minimal tenant/env config for
-// `erun deploy` to resolve, then chains the real command with `&&`. Tenant,
-// environment, and version are DNS-1123-label/semver-shaped values already
-// validated upstream (routes.decodeCreateEnvironmentInput et al.), so they are
-// safe to interpolate directly into the generated YAML.
-func bootstrapDeployEnvironmentScript(params DeployJobParams) string {
+// erun's CLI verbs to resolve, then chains the real command with `&&`. Every
+// lifecycle Job — deploy, stop, delete — sets `command`, which replaces the
+// image's entrypoint, so none of the entrypoint's usual setup runs; this is
+// the one seeding path all three share, so a Job that skips it is a caller
+// bug, not a second copy that can drift out of sync. It deliberately does not
+// carry a runtime version: nothing this seeds it for reads it back (deploy
+// gets its version from the explicit `--version` this seeds a command line
+// for, never from the config it writes), so a version here would just be a
+// second, unused place to keep in sync. Tenant and environment are
+// DNS-1123-label-shaped values already validated upstream
+// (routes.decodeCreateEnvironmentInput et al.), so they are safe to
+// interpolate directly into the generated YAML.
+func bootstrapEnvironmentScript(tenant, environment string) string {
 	return fmt.Sprintf(`set -e
 mkdir -p "$HOME/.kube"
 erun_deploy_ns="$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
@@ -218,9 +226,8 @@ cat > "$HOME/.config/erun/%[1]s/%[2]s/config.yaml" <<ENV_EOF
 name: %[2]s
 type: runtime
 kubernetescontext: in-cluster
-runtimeversion: %[3]s
 ENV_EOF
-`, params.Tenant, params.Environment, params.Version)
+`, tenant, environment)
 }
 
 // shellJoin renders argv as a POSIX shell command line, single-quoting every

--- a/erun-backend/erun-backend-api/internal/deployexec/job_test.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/job_test.go
@@ -66,7 +66,6 @@ func assertDeployBootstrapScript(t *testing.T, command []string) {
 		"$HOME/.config/erun/acme/prod/config.yaml",
 		"type: runtime",
 		"kubernetescontext: in-cluster",
-		"runtimeversion: 1.0.149",
 		"'erun' 'deploy' 'acme' 'prod' '--version' '1.0.149'",
 	} {
 		if !strings.Contains(script, want) {

--- a/erun-backend/erun-backend-api/internal/deployexec/lifecycle_job.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/lifecycle_job.go
@@ -88,6 +88,15 @@ func lifecycleJobLabels(tenant, environment string) map[string]string {
 	}
 }
 
+// buildLifecycleCommand wraps a non-interactive erun verb the same way
+// buildDeployCommand wraps `erun deploy`: seed the in-cluster kubeconfig and
+// on-disk env config first, then run the real command. Deploy composes extra
+// flags and an optional chained `erun expose`, so it builds its own `sh -c`
+// string; stop and delete need nothing beyond one command and share this.
+func buildLifecycleCommand(tenant, environment string, argv []string) []string {
+	return []string{"sh", "-c", bootstrapEnvironmentScript(tenant, environment) + shellJoin(argv)}
+}
+
 // buildStopJob's container runs a non-interactive `erun stop <tenant> <env>`.
 func buildStopJob(params StopJobParams) *batchv1.Job {
 	return &batchv1.Job{
@@ -99,7 +108,7 @@ func buildStopJob(params StopJobParams) *batchv1.Job {
 		Spec: lifecycleJobSpec(corev1.Container{
 			Name:    stopContainerName,
 			Image:   params.Image,
-			Command: []string{"erun", "stop", params.Tenant, params.Environment},
+			Command: buildLifecycleCommand(params.Tenant, params.Environment, []string{"erun", "stop", params.Tenant, params.Environment}),
 		}, params.ServiceAccount),
 	}
 }
@@ -117,7 +126,7 @@ func buildDeleteJob(params DeleteJobParams) *batchv1.Job {
 		Spec: lifecycleJobSpec(corev1.Container{
 			Name:    deleteContainerName,
 			Image:   params.Image,
-			Command: []string{"erun", "delete", params.Tenant, params.Environment, "-y"},
+			Command: buildLifecycleCommand(params.Tenant, params.Environment, []string{"erun", "delete", params.Tenant, params.Environment, "-y"}),
 		}, params.ServiceAccount),
 	}
 }

--- a/erun-backend/erun-backend-api/internal/deployexec/lifecycle_job_test.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/lifecycle_job_test.go
@@ -2,6 +2,7 @@ package deployexec
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -46,7 +47,7 @@ func TestBuildStopJobSpec(t *testing.T) {
 	if pod.RestartPolicy != corev1.RestartPolicyNever {
 		t.Fatalf("restart policy = %q, want Never", pod.RestartPolicy)
 	}
-	assertCommand(t, pod.Containers[0].Command, []string{"erun", "stop", "acme", "prod"})
+	assertLifecycleBootstrapScript(t, "stop", pod.Containers[0].Command, "'erun' 'stop' 'acme' 'prod'")
 }
 
 func TestBuildDeleteJobSpec(t *testing.T) {
@@ -58,7 +59,64 @@ func TestBuildDeleteJobSpec(t *testing.T) {
 	pod := job.Spec.Template.Spec
 	// -y skips the CLI's interactive confirmation: the Job has no terminal to
 	// answer a prompt on.
-	assertCommand(t, pod.Containers[0].Command, []string{"erun", "delete", "acme", "prod", "-y"})
+	assertLifecycleBootstrapScript(t, "delete", pod.Containers[0].Command, "'erun' 'delete' 'acme' 'prod' '-y'")
+}
+
+// assertLifecycleBootstrapScript checks a lifecycle Job's command seeds the
+// in-cluster kubeconfig and the environment's config before running the real
+// command — the same prelude assertDeployBootstrapScript checks for deploy,
+// since #1077 was exactly this prelude missing from stop and delete.
+func assertLifecycleBootstrapScript(t *testing.T, name string, command []string, wantCommand string) {
+	t.Helper()
+	assertCommand(t, command[:2], []string{"sh", "-c"})
+	if len(command) != 3 {
+		t.Fatalf("%s command = %v, want sh -c '<script>'", name, command)
+	}
+	script := command[2]
+	for _, want := range []string{
+		"$HOME/.kube/config",
+		"name: in-cluster",
+		"$HOME/.config/erun/acme/config.yaml",
+		"$HOME/.config/erun/acme/prod/config.yaml",
+		"kubernetescontext: in-cluster",
+		wantCommand,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("%s script %q missing %q", name, script, want)
+		}
+	}
+}
+
+// TestAllLifecycleJobsShareTheBootstrapPrelude is the structural regression
+// test for #1077: every Job builder's command must be `sh -c` carrying the
+// bootstrap prelude, checked generically over the builders rather than one
+// hand-written assertion per Job, so a lifecycle Job added later cannot ship
+// without it.
+func TestAllLifecycleJobsShareTheBootstrapPrelude(t *testing.T) {
+	builders := []struct {
+		name    string
+		command []string
+	}{
+		{"deploy", buildDeployJob(testParams()).Spec.Template.Spec.Containers[0].Command},
+		{"stop", buildStopJob(testStopParams()).Spec.Template.Spec.Containers[0].Command},
+		{"delete", buildDeleteJob(testDeleteParams()).Spec.Template.Spec.Containers[0].Command},
+	}
+	for _, b := range builders {
+		assertCommand(t, b.command[:2], []string{"sh", "-c"})
+		if len(b.command) != 3 {
+			t.Fatalf("%s command = %v, want sh -c '<script>'", b.name, b.command)
+		}
+		script := b.command[2]
+		if !strings.Contains(script, "$HOME/.kube/config") || !strings.Contains(script, "$HOME/.config/erun/acme/prod/config.yaml") {
+			t.Fatalf("%s script %q missing the bootstrap prelude", b.name, script)
+		}
+		// The seed script carries no version: nothing it seeds a config for
+		// reads RuntimeVersion back, so it stays out to avoid a second,
+		// unused place to keep in sync.
+		if strings.Contains(script, "runtimeversion") {
+			t.Fatalf("%s script %q should not seed a runtime version", b.name, script)
+		}
+	}
 }
 
 // TestLauncherRunsStopAndDelete holds the launcher to creating and watching

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -1533,7 +1533,7 @@ func TestDeploy(t *testing.T) {
 	t.Run("dry_run_remote_env_no_repo_path_deploys_published_chart", func(t *testing.T) {
 		// A control-plane-provisioned tenant with no project has no repopath at
 		// all (fixture.SeedRuntimeTenantEnvNoRepoPath mirrors the backend's
-		// bootstrapDeployEnvironmentScript seed exactly). `--runtime-image` must
+		// bootstrapEnvironmentScript seed exactly). `--runtime-image` must
 		// still install the canonical published erun-devops chart by reference:
 		// resolveOpenRepoPath must not require a repo path for a runtime env with
 		// no mounted source worktree, or this fails with "repo path is not

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -497,13 +497,14 @@ func SeedRuntimeTenantEnvNoVersion(t testing.TB, setup env.Setup, tenant, enviro
 }
 
 // SeedRuntimeTenantEnvNoRepoPath writes a runtime-type env tree with NO
-// repopath at all, reproducing the shape the backend's provisioning deploy Job
-// seeds for a control-plane-created tenant with no project
-// (deployexec.bootstrapDeployEnvironmentScript writes exactly this: type,
-// kubernetescontext, and runtimeversion — never repopath, since nothing on the
-// tenant's side was ever `erun init`ed). Every other runtime fixture pins a
-// repopath, so this is the single fixture that locks the repo-path-optional
-// resolution for a genuinely projectless env.
+// repopath at all, reproducing the shape the backend's provisioning deploy,
+// stop, and delete Jobs seed for a control-plane-created tenant with no
+// project (deployexec.bootstrapEnvironmentScript writes exactly this: type
+// and kubernetescontext — never repopath, since nothing on the tenant's side
+// was ever `erun init`ed, and never a runtime version, which nothing on this
+// path reads back). Every other runtime fixture pins a repopath, so this is
+// the single fixture that locks the repo-path-optional resolution for a
+// genuinely projectless env.
 func SeedRuntimeTenantEnvNoRepoPath(t testing.TB, setup env.Setup, tenant, environment string) {
 	t.Helper()
 	root := filepath.Join(setup.ConfigHome, "erun")
@@ -523,8 +524,7 @@ func SeedRuntimeTenantEnvNoRepoPath(t testing.TB, setup env.Setup, tenant, envir
 	mustWrite(t, filepath.Join(envDir, "config.yaml"),
 		"name: "+environment+"\n"+
 			"type: runtime\n"+
-			"kubernetescontext: test-context\n"+
-			"runtimeversion: 1.0.0\n",
+			"kubernetescontext: test-context\n",
 	)
 }
 


### PR DESCRIPTION
## Summary

Closes #1077

A hosted environment could be created but not torn down:

```
erun platform env delete <id> -y
  -> http 502: delete job failed: audit: erun delete --yes operations probe9
     not initialized

erun platform env stop <id>
  -> http 502: stop job failed: audit: erun stop operations probe9
     no such tenant exists: operations
```

A Kubernetes Job's `command` replaces the image's entrypoint, so none of the
entrypoint's usual setup runs: no in-cluster kubeconfig
(`entrypoint.sh`'s `write_kubeconfig`) and no
`~/.config/erun/<tenant>/<environment>/config.yaml` for `erun stop`/`erun
delete` to resolve. `buildDeployJob` already solved this for deploy
(`bootstrapDeployEnvironmentScript` seeds both before `erun deploy` runs,
wrapped in `sh -c`), but `buildStopJob`/`buildDeleteJob` set `Command`
directly and skipped it — the two observed errors are the same absence,
surfacing at whichever lookup each command reaches first (delete: no config
directory at all; stop: the tenant lookup).

## Changes

- Lifted the seeding script off `DeployJobParams` to `bootstrapEnvironmentScript(tenant, environment string)` — it never needed a version (deploy's own `--version` flag supplies that on the command line; nothing reads the seeded config's `runtimeversion` back), so dropping it means one shared prelude with no leftover unused field to drift.
- `buildStopJob`/`buildDeleteJob` now wrap their command the same way deploy does: `sh -c "<bootstrap> && <command>"`, via a small shared `buildLifecycleCommand` helper.
- Added a structural test (`TestAllLifecycleJobsShareTheBootstrapPrelude`) that iterates over all three Job builders and asserts each command is `sh -c` carrying the bootstrap prelude, so a future lifecycle Job cannot ship without it.
- Updated `erun-integration`'s `SeedRuntimeTenantEnvNoRepoPath` fixture and its comments to match the seed script's real shape (no `runtimeversion`) — it exists to mirror the backend's seeding exactly.

## Test plan

- [x] `make check` (golangci-lint over all 5 modules + integration suite): green, 0 issues in every module, integration suite passed, coverage 75.8% (>= threshold).
- [x] `go test ./...` in `erun-backend-api/internal/deployexec` — all tests pass, including the new structural regression test.