### PR TITLE
Grant provisioner ClusterRole deployments/scale, pods, and events

### DIFF
--- a/erun-devops/k8s/erun-backend-api-chart_test.sh
+++ b/erun-devops/k8s/erun-backend-api-chart_test.sh
@@ -179,4 +179,41 @@ require_role_resource '.BatchV1().Jobs(' jobs "${queue_role}"
 require_role_resource '.CoreV1().Pods(' pods "${queue_role}"
 require_role_resource '.GetLogs(' 'pods/log' "${queue_role}"
 
+cluster_role() {
+    awk -v want="  name: $2" '
+        BEGIN{RS="\n---\n"}
+        $0 ~ /(^|\n)kind: ClusterRole(\n|$)/ && $0 ~ ("(^|\n)" want "(\n|$)") {print}
+    ' "$1"
+}
+
+# --- 9. The env-provisioner ClusterRole backs the ServiceAccount that the
+#        deploy/stop/delete Jobs run the `erun` binary as -- a different
+#        identity from api.envDeployer's own Role above, and one that this
+#        chart test previously never asserted anything about. That gap is
+#        exactly how #1080 shipped: erun stop's `kubectl scale
+#        deployment/... --replicas=0` (erun-common/stop.go) and erun deploy's
+#        early-failure pod watch (erun-common/deploy_pod_watch.go) both shell
+#        out to kubectl rather than calling client-go, so the require_role_
+#        resource pattern above (grep a literal client-go call in
+#        erun-backend-api's own Go source) does not apply here -- kubectl argv
+#        text has no comparably stable literal to grep for without inventing a
+#        brittle mapping. Pin the three grants #1080 asks for directly instead. ---
+rendered=$(render --set-string api.envDeployer.enabled=true)
+provisioner_role="${work_root}/provisioner-role.yaml"
+cluster_role "${rendered}" team-env-provisioner >"${provisioner_role}"
+[ -s "${provisioner_role}" ] || fail "the env-provisioner ClusterRole must render when envDeployer is enabled"
+
+grep -q 'resources: \["deployments/scale"\]' "${provisioner_role}" ||
+    fail "the env-provisioner ClusterRole must grant deployments/scale, or erun stop's kubectl scale is forbidden in every provisioned namespace (#1080)"
+grep -A1 'resources: \["deployments/scale"\]' "${provisioner_role}" | grep -q '"patch"' ||
+    fail "the deployments/scale grant must include patch, the verb kubectl scale issues"
+
+grep -q 'resources: \["pods"\]' "${provisioner_role}" ||
+    fail "the env-provisioner ClusterRole must grant pods read, or erun deploy's early-failure pod watch and erun stop's desktop-session listing stay silently inert (#1080)"
+grep -A1 'resources: \["pods"\]' "${provisioner_role}" | grep -q '"watch"' ||
+    fail "the pods grant must include watch"
+
+grep -q 'resources: \["events"\]' "${provisioner_role}" ||
+    fail "the env-provisioner ClusterRole must grant events read, or a stuck pod's reason never reaches the recorded provision error (#1080)"
+
 echo "PASS: erun-backend-api DBOS wiring"

--- a/erun-devops/k8s/erun-backend-api/templates/api.yaml
+++ b/erun-devops/k8s/erun-backend-api/templates/api.yaml
@@ -233,8 +233,13 @@ roleRef:
      lifecycle, the ResourceQuota/LimitRange a provisioned namespace gets
      (tenant_quotas, #605), the runtime chart's own resources (Deployment,
      PVCs, ServiceAccount, Service, its Secrets/ConfigMaps, and Helm's own
-     release-state Secrets), and RoleBindings. Binding the runtime SA to the
-     built-in admin ClusterRole is what the chart renders for every env (see
+     release-state Secrets), RoleBindings, scaling the runtime Deployment to
+     0/1 (erun stop/erun platform env wake, #1080 -- RBAC treats
+     deployments/scale as a distinct resource from deployments, so patch on
+     the parent does not carry it), and reading pods/events so erun deploy's
+     early-failure pod watch and erun stop's desktop-session listing are not
+     silently inert (#1080). Binding the runtime SA to the built-in admin
+     ClusterRole is what the chart renders for every env (see
      erun-devops/AGENTS.md "Runtime SA RBAC is namespaced by default");
      granting only bind on that one named ClusterRole (not the verbs admin
      itself carries) is the RBAC escalation-check's documented way to let a
@@ -258,9 +263,18 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims", "serviceaccounts", "services", "secrets", "configmaps"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "update", "patch"]
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]


### PR DESCRIPTION
## Summary

- `erun platform env stop` was refused by RBAC after erun#1077 got it as far as the real operation:

  ```
  Error from server (Forbidden): deployments.apps "operations-devops" is forbidden:
    User "system:serviceaccount:frs-prod:frs-env-deployer" cannot patch resource
    "deployments/scale" in API group "apps" in the namespace "operations-probe9"
  ```

  RBAC treats `deployments/scale` as a distinct resource from `deployments`, so the existing `patch` grant on `deployments` never covered it.

- The `<tenant>-env-provisioner` ClusterRole also granted no `pods` or `events` read at all. That leaves `erun deploy`'s early-failure pod watch (`erun-common/deploy_pod_watch.go`, traced as `deploy: watching pods in <ns> … for early container failure`) and `erun stop`'s desktop-session listing silently inert — a permanently unschedulable pod rode out the full 5-minute helm timeout instead of aborting early.

- Adds the three missing grants to the ClusterRole: `apps/deployments/scale` (`get`, `update`, `patch`), `""/pods` (`get`, `list`, `watch`), `""/events` (`get`, `list`, `watch`).

**Note for reviewers:** `kubectl auth can-i patch deployments/scale` answers **yes** against this role and is misleading — it doesn't account for the subresource split correctly in all client paths people try. Trust `kubectl auth can-i --list` for the bound ServiceAccount (it showed no `deployments/scale`, no `pods` at all) and the live `Forbidden` from the Job, not a one-off `can-i` check.

**Known residual gap, out of scope for this PR:** even with the `pods` grant, `erun-common/deploy_pod_watch.go`'s `classifyTerminalFailure` only inspects `pod.status.containerStatuses`/`initContainerStatuses`. An unschedulable pod (the exact scenario in erun#1076/erun#1080's example) never gets container statuses at all — the failure reason lives in `pod.status.conditions` (`PodScheduled=False`, `Insufficient cpu, Insufficient memory`), which this code doesn't read yet, and it never calls the Events API either. So this fix makes the pod watch functional again for container-level failures (crash loops, bad images, config errors), but does not by itself make an unschedulable pod abort early with its scheduling reason — that needs a follow-up to `classifyTerminalFailure`. Filed as a natural next step; happy to take it in a follow-up issue if preferred.

## Test plan

- [x] Added a chart test (`erun-devops/k8s/erun-backend-api-chart_test.sh`, section 9) pinning the three grants on the rendered `<tenant>-env-provisioner` ClusterRole. erun-common shells out to `kubectl` for these calls rather than calling client-go directly, so the existing `require_role_resource` pattern (grep a literal client-go call site) doesn't apply to this role; pinned the three grants directly instead and said so in the test comment.
- [x] `sh erun-devops/k8s/erun-backend-api-chart_test.sh` passes.
- [x] `make check` — green (lint clean across all Go modules, integration suite passing, coverage 75.8% >= 75.8% threshold).
- [x] Rendered the chart and confirmed the `<tenant>-env-provisioner` ClusterRole shape:
  ```yaml
  rules:
    - apiGroups: [""]
      resources: ["namespaces"]
      verbs: ["create", "get", "list", "watch", "delete"]
    - apiGroups: [""]
      resources: ["resourcequotas", "limitranges"]
      verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
    - apiGroups: [""]
      resources: ["persistentvolumeclaims", "serviceaccounts", "services", "secrets", "configmaps"]
      verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
    - apiGroups: [""]
      resources: ["pods"]
      verbs: ["get", "list", "watch"]
    - apiGroups: [""]
      resources: ["events"]
      verbs: ["get", "list", "watch"]
    - apiGroups: ["apps"]
      resources: ["deployments"]
      verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
    - apiGroups: ["apps"]
      resources: ["deployments/scale"]
      verbs: ["get", "update", "patch"]
    - apiGroups: ["rbac.authorization.k8s.io"]
      resources: ["rolebindings"]
      verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
    - apiGroups: ["rbac.authorization.k8s.io"]
      resources: ["clusterroles"]
      resourceNames: ["admin"]
      verbs: ["bind"]
  ```

Closes #1080