### PR TITLE
Let exposure survive a sourceless deploy Job

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,12 @@ Probe artifacts the agent leaves behind during verification (injected files, man
 - Add regression tests for each release failure mode that was fixed. When a release bug is caused by ordering, missing metadata, or missing platform support, encode that contract in tests so the next release cannot regress silently.
 - When a change affects generated runtime charts or embedded templates, test both the shared template source and the concrete runtime chart when practical. Treat them as one contract.
 
+## Kubernetes RBAC For Server-Side Executors
+
+- **A role that lets helm install is not a role that lets helm wait.** `helm --wait` decides a Deployment is ready by walking Deployment → ReplicaSet → Pods. A role with full `apps/deployments` and no `apps/replicasets` installs fine and then times out on a healthy release, reporting a timeout rather than the Forbidden it swallowed. When adding or auditing a role that runs helm, enumerate the object graph helm traverses, not the objects the chart declares. (#1080, #1083)
+- **`kubectl auth can-i <verb> <resource>/<subresource>` gives false positives.** It answered `yes` for `patch deployments/scale` against a role granting only `deployments`, while the live call was Forbidden. Use `kubectl auth can-i --list --as=<sa> -n <ns>` and trust a real impersonated call over either. RBAC treats a subresource as a distinct resource. (#1080)
+- **A test that pins a role's rule list only confirms the rules somebody already thought of.** Two consecutive releases shipped a broken provisioner role while such a test passed. Prefer a test that exercises the operation and asserts it succeeds. (#1081, #1083)
+
 ## Refactoring Rules
 
 - Treat refactoring as behavior-preserving by default.

--- a/erun-backend/erun-backend-api/cmd/eapi/main.go
+++ b/erun-backend/erun-backend-api/cmd/eapi/main.go
@@ -70,7 +70,14 @@ func run(args []string) error {
 			PlatformNamespace:      cfg.PlatformNamespace,
 			DeployerServiceAccount: cfg.EnvDeployerServiceAccount,
 			ExposeTargetIP:         cfg.EnvExposeTargetIP,
-			ImagePullSecrets:       splitCSV(cfg.EnvDeployImagePullSecrets),
+			// The deploy Job's chained `erun expose` has no git checkout to resolve
+			// these from (#1086), so the control plane threads what it already
+			// knows for its own purposes: DNS01ServicesZone is the same services
+			// zone its DNS-01 cert issuance uses, and PlatformNamespace is where its
+			// own Jobs (and, in a self-hosted platform, the PowerDNS singleton) run.
+			ExposeServicesZone:      cfg.DNS01ServicesZone,
+			ExposePlatformNamespace: cfg.PlatformNamespace,
+			ImagePullSecrets:        splitCSV(cfg.EnvDeployImagePullSecrets),
 		},
 		Release: provision.ReleaseConfig{
 			Registry:       cfg.EnvDeployRegistry,

--- a/erun-backend/erun-backend-api/internal/deployexec/job.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/job.go
@@ -76,6 +76,22 @@ type DeployJobParams struct {
 	// tenant whose own project declares no platform block, so this only ever
 	// wires DNS+Ingress for an actual erunpaas platform deployment.
 	ExposeTargetIP string
+	// ExposeServicesZone/ExposePlatformNamespace thread expose's --services-zone/
+	// --platform-namespace: the deploy Job has no git checkout, so `erun expose`
+	// cannot resolve these from a project's .erun/config.yaml the way an
+	// interactive run does (#1086 — project resolution fails outright with
+	// "cannot find git project", which --skip-if-unconfigured cannot cover
+	// because the skip decision itself needs a resolved project). The control
+	// plane already carries both for its own purposes — ExposeServicesZone from
+	// the same services zone its DNS-01 cert issuance uses, ExposePlatformNamespace
+	// from the namespace its own Jobs (and, in a self-hosted platform, the
+	// PowerDNS singleton) run in — so this reuses that knowledge rather than
+	// inventing a second source for it. Either left empty falls the chained
+	// expose back to project-based resolution, which fails exactly as it always
+	// has for a sourceless Job; since exposure is best-effort (see
+	// exposeChainScript), that failure no longer takes the deploy down with it.
+	ExposeServicesZone      string
+	ExposePlatformNamespace string
 	// RuntimeImageOverride, when set, threads `--runtime-image <value>` to the
 	// in-Job `erun deploy` — the caller's bootstrap decision for a tenant with no
 	// published <tenant>-devops image: install the canonical published
@@ -162,9 +178,44 @@ func buildDeployCommand(params DeployJobParams) []string {
 	script := bootstrapEnvironmentScript(params.Tenant, params.Environment) + shellJoin(deploy)
 	if ip := strings.TrimSpace(params.ExposeTargetIP); ip != "" {
 		expose := []string{"erun", "expose", params.Tenant, params.Environment, mcpExposeService, "--ip", ip, "--skip-if-unconfigured"}
-		script += " && " + shellJoin(expose)
+		if zone, ns := strings.TrimSpace(params.ExposeServicesZone), strings.TrimSpace(params.ExposePlatformNamespace); zone != "" && ns != "" {
+			expose = append(expose, "--services-zone", zone, "--platform-namespace", ns)
+		}
+		script += exposeChainScript(expose)
 	}
 	return []string{"sh", "-c", script}
+}
+
+// exposeFailureMarker prefixes the line exposeChainScript prints when the
+// chained expose step does not succeed. ExposeFailureFromOutput reads it back
+// out of the Job's captured output.
+const exposeFailureMarker = "ERUN_EXPOSE_FAILED"
+
+// exposeChainScript runs expose after a successful deploy without letting its
+// failure fail the Job (#1086). Exposure (DNS + Ingress) is best-effort: the
+// deploy already landed a healthy workload, so failing the whole Job over a
+// DNS/Ingress problem would record a running environment as a failed
+// provision, exactly the misdirection the issue reported. `{ ... || printf
+// ...; }` always exits 0, so the deploy's own `&&` is the only thing that can
+// still fail the script; on a real expose failure the marker line carries
+// expose's own combined output so ExposeFailureFromOutput can recover it from
+// the Job's log after a successful run, instead of the environment silently
+// losing the reason it is not exposed.
+func exposeChainScript(expose []string) string {
+	return " && { expose_out=$(" + shellJoin(expose) + " 2>&1) || printf '" + exposeFailureMarker + ": %s\\n' \"$expose_out\"; }"
+}
+
+// ExposeFailureFromOutput extracts the chained expose step's failure detail
+// from the deploy Job's captured stdout (jobexec.Options.CaptureOutput), or ""
+// when exposure succeeded, was never attempted (ExposeTargetIP unset), or the
+// Job predates chaining an expose at all.
+func ExposeFailureFromOutput(output string) string {
+	marker := exposeFailureMarker + ": "
+	idx := strings.Index(output, marker)
+	if idx < 0 {
+		return ""
+	}
+	return strings.TrimSpace(output[idx+len(marker):])
 }
 
 // namespaceQuotaFlags appends --max-cpu/--max-memory/--max-storage when all
@@ -274,7 +325,10 @@ type Launcher struct {
 
 func NewLauncher(kube kubernetes.Interface) *Launcher {
 	return &Launcher{
-		runner:       jobexec.NewRunner(kube, jobexec.Options{Kind: "deploy", Container: deployContainerName}),
+		// CaptureOutput: a successful deploy Job's own log is where
+		// ExposeFailureFromOutput finds the chained expose step's marker, since a
+		// best-effort expose failure never turns the Job itself into a failure.
+		runner:       jobexec.NewRunner(kube, jobexec.Options{Kind: "deploy", Container: deployContainerName, CaptureOutput: true}),
 		stopRunner:   jobexec.NewRunner(kube, jobexec.Options{Kind: "stop", Container: stopContainerName}),
 		deleteRunner: jobexec.NewRunner(kube, jobexec.Options{Kind: "delete", Container: deleteContainerName}),
 	}

--- a/erun-backend/erun-backend-api/internal/deployexec/job_test.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/job_test.go
@@ -151,6 +151,66 @@ func TestBuildDeployJobSpecWithExpose(t *testing.T) {
 	}
 }
 
+// TestBuildDeployJobSpecWithExposePlatformCoordinates: when the control plane
+// supplies the services zone and platform namespace it already knows, they
+// thread onto the chained `erun expose` as --services-zone/--platform-namespace
+// so the sourceless Job can resolve a hostname without a git checkout (#1086).
+func TestBuildDeployJobSpecWithExposePlatformCoordinates(t *testing.T) {
+	params := testParams()
+	params.ExposeTargetIP = "203.0.113.10"
+	params.ExposeServicesZone = "services.erunpaas.com"
+	params.ExposePlatformNamespace = "frs-prod"
+	script := buildDeployCommand(params)[2]
+	want := "'erun' 'expose' 'acme' 'prod' 'mcp' '--ip' '203.0.113.10' '--skip-if-unconfigured' " +
+		"'--services-zone' 'services.erunpaas.com' '--platform-namespace' 'frs-prod'"
+	if !strings.Contains(script, want) {
+		t.Fatalf("script %q missing %q", script, want)
+	}
+
+	// Half the pair configured is the same as neither: expose falls back to its
+	// own project-based resolution rather than running with an incomplete
+	// override.
+	partial := testParams()
+	partial.ExposeTargetIP = "203.0.113.10"
+	partial.ExposeServicesZone = "services.erunpaas.com"
+	partialScript := buildDeployCommand(partial)[2]
+	if strings.Contains(partialScript, "--services-zone") {
+		t.Fatalf("script %q should not apply a partial platform-coordinates override", partialScript)
+	}
+}
+
+// TestExposeChainScriptIsBestEffort: the chained expose step must never fail
+// the Job it rides on (#1086) — a healthy deploy must not be recorded as a
+// failed provision just because DNS/Ingress wiring failed. On failure it
+// prints a marker line ExposeFailureFromOutput reads back out of the Job's
+// captured output.
+func TestExposeChainScriptIsBestEffort(t *testing.T) {
+	params := testParams()
+	params.ExposeTargetIP = "203.0.113.10"
+	script := buildDeployCommand(params)[2]
+	if !strings.Contains(script, "|| printf '"+exposeFailureMarker+": %s\\n' \"$expose_out\"") {
+		t.Fatalf("script %q must swallow a failing expose behind the marker", script)
+	}
+	if strings.HasSuffix(strings.TrimSpace(script), "&& "+shellJoin([]string{"erun", "expose"})) {
+		t.Fatalf("script %q must not let expose's own exit status end the script", script)
+	}
+}
+
+// TestExposeFailureFromOutput: the marker line is how a *successful* Job
+// (deploy landed, expose did not) hands back the reason, since the Job's own
+// outcome no longer reflects an expose failure.
+func TestExposeFailureFromOutput(t *testing.T) {
+	output := "==> Deployed acme/prod 1.2.3 in 4s\n" +
+		"audit: erun expose --ip 203.0.113.10 --skip-if-unconfigured acme prod mcp\n" +
+		exposeFailureMarker + ": cannot find git project\n"
+	if got := ExposeFailureFromOutput(output); got != "cannot find git project" {
+		t.Fatalf("ExposeFailureFromOutput = %q, want %q", got, "cannot find git project")
+	}
+	if got := ExposeFailureFromOutput("==> Deployed acme/prod 1.2.3 in 4s\n"); got != "" {
+		t.Fatalf("ExposeFailureFromOutput = %q, want empty when no marker is present", got)
+	}
+}
+
 // TestBuildDeployCommandQuotesArguments guards the shell-injection surface: an
 // argument carrying a single quote must stay a single shell word — the
 // canonical way a naively-quoted value breaks out of its own quoting.

--- a/erun-backend/erun-backend-api/internal/model/environment.go
+++ b/erun-backend/erun-backend-api/internal/model/environment.go
@@ -48,7 +48,14 @@ type Environment struct {
 	// installed, as opposed to RuntimeVersion, which is the declared pin. Owned
 	// by the deploy executor, so it is scan-only; a failed deploy leaves it on
 	// the version still running in the cluster.
-	DeployedVersion string    `json:"deployedVersion,omitempty" bun:"deployed_version,scanonly,nullzero"`
-	CreatedAt       time.Time `json:"createdAt" bun:"created_at,scanonly"`
-	UpdatedAt       time.Time `json:"updatedAt" bun:"updated_at,scanonly"`
+	DeployedVersion string `json:"deployedVersion,omitempty" bun:"deployed_version,scanonly,nullzero"`
+	// ExposeError carries why the deploy Job's best-effort chained exposure
+	// (DNS + Ingress) did not succeed, distinct from ProvisionError: it never
+	// moves Status away from `running`, since exposure failing does not mean
+	// the deployed workload is unhealthy (#1086). Owned by the deploy executor,
+	// so scan-only; empty means exposure succeeded, was never attempted, or the
+	// environment predates chaining an expose at all.
+	ExposeError string    `json:"exposeError,omitempty" bun:"expose_error,scanonly,nullzero"`
+	CreatedAt   time.Time `json:"createdAt" bun:"created_at,scanonly"`
+	UpdatedAt   time.Time `json:"updatedAt" bun:"updated_at,scanonly"`
 }

--- a/erun-backend/erun-backend-api/internal/provision/environments.go
+++ b/erun-backend/erun-backend-api/internal/provision/environments.go
@@ -65,6 +65,13 @@ type EnvDeployConfig struct {
 	// stays enabled without it) — it only decides whether a deploy also chains
 	// an expose.
 	ExposeTargetIP string
+	// ExposeServicesZone/ExposePlatformNamespace thread deployexec.DeployJobParams'
+	// fields of the same name — the platform coordinates the chained `erun
+	// expose` needs but the sourceless deploy Job cannot resolve on its own
+	// (#1086). See deployexec.DeployJobParams for why the control plane already
+	// carries both.
+	ExposeServicesZone      string
+	ExposePlatformNamespace string
 	// ImagePullSecrets names the dockerconfigjson Secrets in PlatformNamespace
 	// that hold the registry credentials the deploy Job pulls with. The
 	// published-image precondition probes the registry with the same credential,
@@ -150,21 +157,23 @@ func deployJobParams(config EnvDeployConfig, input EnvProvisionInput) deployexec
 		runtimeImageOverride = image
 	}
 	return deployexec.DeployJobParams{
-		Tenant:               input.Tenant,
-		Environment:          input.Environment,
-		Version:              input.Version,
-		DeployID:             input.DeployID,
-		Namespace:            config.PlatformNamespace,
-		Image:                image,
-		RuntimeImageOverride: runtimeImageOverride,
-		ServiceAccount:       config.DeployerServiceAccount,
-		ExposeTargetIP:       config.ExposeTargetIP,
-		MaxCPU:               namespaceQuotaCPUQuantity(input.MaxCPUMillicores),
-		MaxMemory:            namespaceQuotaMemoryQuantity(input.MaxMemoryMB),
-		MaxStorage:           namespaceQuotaStorageQuantity(input.MaxStorageGB),
-		MaxCPUMillicores:     input.MaxCPUMillicores,
-		MaxMemoryMB:          input.MaxMemoryMB,
-		MaxStorageGB:         input.MaxStorageGB,
+		Tenant:                  input.Tenant,
+		Environment:             input.Environment,
+		Version:                 input.Version,
+		DeployID:                input.DeployID,
+		Namespace:               config.PlatformNamespace,
+		Image:                   image,
+		RuntimeImageOverride:    runtimeImageOverride,
+		ServiceAccount:          config.DeployerServiceAccount,
+		ExposeTargetIP:          config.ExposeTargetIP,
+		ExposeServicesZone:      config.ExposeServicesZone,
+		ExposePlatformNamespace: config.ExposePlatformNamespace,
+		MaxCPU:                  namespaceQuotaCPUQuantity(input.MaxCPUMillicores),
+		MaxMemory:               namespaceQuotaMemoryQuantity(input.MaxMemoryMB),
+		MaxStorage:              namespaceQuotaStorageQuantity(input.MaxStorageGB),
+		MaxCPUMillicores:        input.MaxCPUMillicores,
+		MaxMemoryMB:             input.MaxMemoryMB,
+		MaxStorageGB:            input.MaxStorageGB,
 	}
 }
 

--- a/erun-backend/erun-backend-api/internal/provision/environments_test.go
+++ b/erun-backend/erun-backend-api/internal/provision/environments_test.go
@@ -165,3 +165,32 @@ func TestDeployJobParamsExposeTargetIP(t *testing.T) {
 		t.Fatalf("exposeTargetIP = %q, want empty when unconfigured", unset.ExposeTargetIP)
 	}
 }
+
+// TestDeployJobParamsExposePlatformCoordinates: the services zone and
+// platform namespace the control plane already knows for its own purposes
+// (DNS-01 cert issuance, Job placement) thread through so the chained expose
+// step can resolve a hostname without a git checkout (#1086).
+func TestDeployJobParamsExposePlatformCoordinates(t *testing.T) {
+	params := deployJobParams(
+		EnvDeployConfig{
+			Registry:                "ghcr.io/sophium",
+			PlatformNamespace:       "erun-prod",
+			DeployerServiceAccount:  "erun-env-deployer",
+			ExposeTargetIP:          "203.0.113.10",
+			ExposeServicesZone:      "services.erunpaas.com",
+			ExposePlatformNamespace: "frs-prod",
+		},
+		EnvProvisionInput{Tenant: "acme", Environment: "prod", Version: "1.2.3"},
+	)
+	if params.ExposeServicesZone != "services.erunpaas.com" {
+		t.Fatalf("exposeServicesZone = %q, want services.erunpaas.com", params.ExposeServicesZone)
+	}
+	if params.ExposePlatformNamespace != "frs-prod" {
+		t.Fatalf("exposePlatformNamespace = %q, want frs-prod", params.ExposePlatformNamespace)
+	}
+
+	unset := deployJobParams(EnvDeployConfig{}, EnvProvisionInput{Tenant: "acme", Environment: "prod", Version: "1.2.3"})
+	if unset.ExposeServicesZone != "" || unset.ExposePlatformNamespace != "" {
+		t.Fatalf("exposeServicesZone/exposePlatformNamespace = %q/%q, want both empty when unconfigured", unset.ExposeServicesZone, unset.ExposePlatformNamespace)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/repository/environments.go
+++ b/erun-backend/erun-backend-api/internal/repository/environments.go
@@ -12,7 +12,7 @@ type EnvironmentRepository struct {
 	txs *TxManager
 }
 
-const environmentColumns = `environment_id, tenant_id, name, type, kubernetes_context, context_id, runtime_version, status, provision_error, deployed_version, created_at, updated_at`
+const environmentColumns = `environment_id, tenant_id, name, type, kubernetes_context, context_id, runtime_version, status, provision_error, deployed_version, expose_error, created_at, updated_at`
 
 func NewEnvironmentRepository(txs *TxManager) *EnvironmentRepository {
 	return &EnvironmentRepository{txs: txs}
@@ -61,10 +61,16 @@ func (r *EnvironmentRepository) Count(ctx context.Context) (int, error) {
 // failure reason (cleared on any non-failed state), and the version that
 // actually deployed. An empty DeployedVersion leaves the recorded one alone, so
 // a failed deploy does not erase the version the cluster is still running.
+// ExposeError is distinct from ProvisionError: it names why the deploy Job's
+// best-effort chained exposure did not succeed, without moving Status away
+// from `running` — the deploy itself landed a healthy workload (#1086).
+// Cleared (like ProvisionError) whenever a write carries no expose failure, so
+// a later successful expose overwrites a stale one.
 type EnvironmentStatusUpdate struct {
 	Status          string
 	ProvisionError  string
 	DeployedVersion string
+	ExposeError     string
 }
 
 // UpdateProvisioningStatus persists an environment's provisioning-lifecycle
@@ -76,9 +82,10 @@ func (r *EnvironmentRepository) UpdateProvisioningStatus(ctx context.Context, en
 			UPDATE environments
 			   SET status = ?,
 			       provision_error = NULLIF(?, ''),
-			       deployed_version = COALESCE(NULLIF(?, ''), deployed_version)
+			       deployed_version = COALESCE(NULLIF(?, ''), deployed_version),
+			       expose_error = NULLIF(?, '')
 			 WHERE environment_id = ?
-		`, update.Status, update.ProvisionError, update.DeployedVersion, environmentID).Exec(ctx)
+		`, update.Status, update.ProvisionError, update.DeployedVersion, update.ExposeError, environmentID).Exec(ctx)
 		return err
 	})
 }

--- a/erun-backend/erun-backend-api/internal/service/environments.go
+++ b/erun-backend/erun-backend-api/internal/service/environments.go
@@ -75,9 +75,15 @@ func (p *EnvironmentProvisioner) Provision(ctx context.Context, environmentID st
 	// The env is now running this version, so record it here rather than after
 	// any later step: a run that fails past this point still leaves the cluster
 	// carrying it, and an operator recovering needs the env to name it.
+	// deployexec chains the environment's exposure onto the same Job but never
+	// lets its failure fail the Job (#1086) — the deploy already landed a
+	// healthy workload, so a DNS/Ingress problem downstream of it must not read
+	// as a failed provision. ExposeError names that failure distinctly instead,
+	// leaving Status/ProvisionError to mean exactly "did the deploy land".
 	if err := p.write(ctx, environmentID, repository.EnvironmentStatusUpdate{
 		Status:          string(model.EnvironmentStatusRunning),
 		DeployedVersion: params.Version,
+		ExposeError:     deployexec.ExposeFailureFromOutput(result.Output),
 	}); err != nil {
 		return fmt.Errorf("mark running: %w", err)
 	}

--- a/erun-backend/erun-backend-api/internal/service/environments_test.go
+++ b/erun-backend/erun-backend-api/internal/service/environments_test.go
@@ -43,11 +43,12 @@ func (w *recordingStatusWriter) UpdateProvisioningStatus(_ context.Context, _ st
 type fakeRunner struct {
 	outcome deployexec.Outcome
 	failure string
+	output  string
 	err     error
 }
 
 func (r fakeRunner) Run(context.Context, deployexec.DeployJobParams) (deployexec.Result, error) {
-	return deployexec.Result{Outcome: r.outcome, Failure: r.failure}, r.err
+	return deployexec.Result{Outcome: r.outcome, Failure: r.failure, Output: r.output}, r.err
 }
 
 func provision(t *testing.T, runner DeployRunner, status *recordingStatusWriter) error {
@@ -163,6 +164,43 @@ func TestProvisionLeavesDeployedVersionOnFailure(t *testing.T) {
 		if update.DeployedVersion != "" {
 			t.Fatalf("update[%d] recorded deployedVersion %q on a failed deploy", i, update.DeployedVersion)
 		}
+	}
+}
+
+// TestProvisionRecordsExposeErrorButStaysRunning: a deploy Job that succeeds
+// overall (deployexec's chained expose never fails the Job itself — #1086)
+// must still land the environment in `running`, with the chained expose
+// step's own failure recorded distinctly rather than as a provision failure.
+func TestProvisionRecordsExposeErrorButStaysRunning(t *testing.T) {
+	status := &recordingStatusWriter{}
+	output := "audit: erun expose --ip 203.0.113.10 --skip-if-unconfigured acme prod mcp\n" +
+		"ERUN_EXPOSE_FAILED: cannot find git project\n"
+	runner := fakeRunner{outcome: deployexec.OutcomeSucceeded, output: output}
+	if err := provisionVersion(t, runner, status, "1.2.3"); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	assertTransitions(t, status.transitions, []string{"provisioning:", "running:"})
+	last := status.updates[len(status.updates)-1]
+	if last.ExposeError != "cannot find git project" {
+		t.Fatalf("exposeError = %q, want the chained expose step's own failure", last.ExposeError)
+	}
+	if last.DeployedVersion != "1.2.3" {
+		t.Fatalf("deployedVersion = %q, want 1.2.3 despite the expose failure", last.DeployedVersion)
+	}
+}
+
+// TestProvisionLeavesExposeErrorEmptyOnCleanSuccess: no expose marker in the
+// Job's output means exposure was never attempted or fully succeeded, so
+// nothing should be recorded against it.
+func TestProvisionLeavesExposeErrorEmptyOnCleanSuccess(t *testing.T) {
+	status := &recordingStatusWriter{}
+	runner := fakeRunner{outcome: deployexec.OutcomeSucceeded, output: "==> Deployed acme/prod 1.2.3 in 4s\n"}
+	if err := provisionVersion(t, runner, status, "1.2.3"); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	last := status.updates[len(status.updates)-1]
+	if last.ExposeError != "" {
+		t.Fatalf("exposeError = %q, want empty on a clean success", last.ExposeError)
 	}
 }
 

--- a/erun-backend/erun-backend-db/migrations/default/20260821120000_env_expose_error.sql
+++ b/erun-backend/erun-backend-db/migrations/default/20260821120000_env_expose_error.sql
@@ -1,0 +1,9 @@
+-- Record why a deploy Job's chained exposure did not succeed, distinct from
+-- provision_error: exposure (DNS + Ingress) is best-effort, so a healthy
+-- deployed environment stays `running` and names its own unexposed state
+-- here instead of the whole environment being recorded `failed` for a step
+-- that left the deployed workload untouched (#1086).
+-- Hand-written column add (atlas migrate diff is login-gated on the RLS
+-- functions in the source schema); no new table/RLS, so the existing
+-- environments row-level security already covers this column.
+ALTER TABLE "environments" ADD COLUMN "expose_error" text NULL;

--- a/erun-backend/erun-backend-db/migrations/default/atlas.sum
+++ b/erun-backend/erun-backend-db/migrations/default/atlas.sum
@@ -1,4 +1,4 @@
-h1:qa+Ou2O9q+o5+eE8/Ut+QQgEmKaHhJDuWWBqBeF0wWc=
+h1:j9yGrSJfA1FRyAG+i07xDqt6j2jIrm2H6neK25SHtVU=
 20260501120000_initial_tenant_identity.sql h1:RpS03/4sFjbCggwYgcGNn6k3jNZCNTNl0BD/afOKFzo=
 20260503143000_tenant_issuer_names.sql h1:VEZjICG3/jU2YtEx0XX05l9Q8lJyWKeiRY8f4dXOkvE=
 20260503170000_audit_events.sql h1:OLjiGP/FhLTWvkx1bxS2xCcJK6tExdufnEC8R6LsKWA=
@@ -11,3 +11,4 @@ h1:qa+Ou2O9q+o5+eE8/Ut+QQgEmKaHhJDuWWBqBeF0wWc=
 20260816150000_release_queue.sql h1:scuDr9Xmf4Lrw2nLQb4vM8lkMEXQXGy1WsKYc3K4LM0=
 20260819120000_tenant_resource_quotas_and_usage_events.sql h1:CTZNZTVqG0sIoXFsjAYwDR2aViOGMc+3GsVSdJbrYZ8=
 20260820120000_tenant_quota_runtime_pod_floor.sql h1:zAiv3FCU07QJS1d/w50u9yt2xvIYA9q7DsLoy5JLHaA=
+20260821120000_env_expose_error.sql h1:BxDvAJWcbRwFmtBdw5I5mXSytdY1YNeuleNX5PJgvpg=

--- a/erun-backend/erun-backend-db/schema/tables/environments.sql
+++ b/erun-backend/erun-backend-db/schema/tables/environments.sql
@@ -9,6 +9,7 @@ CREATE TABLE environments (
   status TEXT NOT NULL DEFAULT 'registered',
   provision_error TEXT,
   deployed_version TEXT,
+  expose_error TEXT,
   created_at TIMESTAMPTZ,
   updated_at TIMESTAMPTZ,
   FOREIGN KEY (tenant_id) REFERENCES tenants (tenant_id),

--- a/erun-cli/cmd/expose.go
+++ b/erun-cli/cmd/expose.go
@@ -15,6 +15,8 @@ func newExposeCmd(store common.ExposeStore, findProjectRoot common.ProjectFinder
 	var ingressClass string
 	var tlsSecret string
 	var skipIfUnconfigured bool
+	var servicesZone string
+	var platformNamespace string
 	cmd := &cobra.Command{
 		Use:   "expose TENANT ENVIRONMENT SERVICE",
 		Short: "Expose an environment's Service at a public HTTPS hostname",
@@ -25,15 +27,17 @@ func newExposeCmd(store common.ExposeStore, findProjectRoot common.ProjectFinder
 			"real Service. Ensures the per-environment wildcard DNS record points at the env's ingress IP and applies a " +
 			"Host-routing Ingress for the Service. TLS is on by default: the Ingress references the env's per-env " +
 			"wildcard cert Secret (<tenant>-<env>-wildcard-tls, issued by the cluster edge), so the host serves https " +
-			"with no per-service cert step. Pass --no-tls for http. Requires a platform block in .erun/config.yaml; it " +
-			"mutates the platform DNS zone and applies to the env's cluster. Use --dry-run to preview the actions.",
+			"with no per-service cert step. Pass --no-tls for http. Requires a platform block in .erun/config.yaml " +
+			"unless --services-zone and --platform-namespace are both set; it mutates the platform DNS zone and " +
+			"applies to the env's cluster. Use --dry-run to preview the actions.",
 		Example: "  erun expose team dev api --ip 127.0.0.1\n" +
 			"  erun expose team prod api --ip 203.0.113.10 --port 8080\n" +
-			"  erun expose team dev api --ip 127.0.0.1 --no-tls",
+			"  erun expose team dev api --ip 127.0.0.1 --no-tls\n" +
+			"  erun expose team dev api --ip 127.0.0.1 --services-zone services.example.com --platform-namespace frs-prod",
 		Args:         cobra.ExactArgs(3),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runExposeCommand(withCloudContextPreflight(commandContext(cmd), store), store, findProjectRoot, args[0], args[1], args[2], targetIP, servicePort, noTLS, ingressClass, tlsSecret, skipIfUnconfigured)
+			return runExposeCommand(withCloudContextPreflight(commandContext(cmd), store), store, findProjectRoot, args[0], args[1], args[2], targetIP, servicePort, noTLS, ingressClass, tlsSecret, skipIfUnconfigured, servicesZone, platformNamespace)
 		},
 	}
 	addDryRunFlag(cmd)
@@ -43,16 +47,38 @@ func newExposeCmd(store common.ExposeStore, findProjectRoot common.ProjectFinder
 	cmd.Flags().StringVar(&ingressClass, "ingress-class", "", "Ingress controller class (default traefik)")
 	cmd.Flags().StringVar(&tlsSecret, "tls-secret", "", "Override the per-env wildcard cert Secret name (default <tenant>-<env>-wildcard-tls)")
 	cmd.Flags().BoolVar(&skipIfUnconfigured, "skip-if-unconfigured", false, "Succeed as a no-op instead of failing when the project declares no platform block (for scripted callers composing expose after another command)")
+	cmd.Flags().StringVar(&servicesZone, "services-zone", "", "Override the platform services zone tenant hostnames live under, so expose needs no project checkout (requires --platform-namespace too)")
+	cmd.Flags().StringVar(&platformNamespace, "platform-namespace", "", "Override the namespace running the platform's PowerDNS singleton, so expose needs no project checkout (requires --services-zone too)")
 	return cmd
 }
 
-func runExposeCommand(ctx common.Context, store common.ExposeStore, findProjectRoot common.ProjectFinderFunc, tenant, environment, service, targetIP string, servicePort int, noTLS bool, ingressClass, tlsSecret string, skipIfUnconfigured bool) error {
-	if findProjectRoot == nil {
-		findProjectRoot = common.FindProjectRoot
-	}
-	_, projectRoot, err := findProjectRoot()
-	if err != nil {
-		return err
+func runExposeCommand(ctx common.Context, store common.ExposeStore, findProjectRoot common.ProjectFinderFunc, tenant, environment, service, targetIP string, servicePort int, noTLS bool, ingressClass, tlsSecret string, skipIfUnconfigured bool, servicesZone, platformNamespace string) error {
+	servicesZone = strings.TrimSpace(servicesZone)
+	platformNamespace = strings.TrimSpace(platformNamespace)
+	// --services-zone/--platform-namespace supply what a project checkout would
+	// otherwise resolve, precisely so a caller with no checkout at all (the
+	// hosted deploy Job, which has no git repo to find — #1086) can still run
+	// expose. Skip the project lookup entirely in that case, rather than failing
+	// on it before RunExposeService even gets a chance to use the override.
+	projectRoot := ""
+	if servicesZone == "" && platformNamespace == "" {
+		if findProjectRoot == nil {
+			findProjectRoot = common.FindProjectRoot
+		}
+		_, root, err := findProjectRoot()
+		if err != nil {
+			// --skip-if-unconfigured exists to make expose a no-op when the
+			// target is not set up for exposure — no project at all is the
+			// strongest case of that, not a reason to fail before
+			// RunExposeService gets to decide (#1086). Fall through with an
+			// empty ProjectRoot: its platform-configured check on "" resolves
+			// to false, same as a project with no platform block.
+			if !skipIfUnconfigured {
+				return err
+			}
+		} else {
+			projectRoot = root
+		}
 	}
 	result, err := common.RunExposeService(ctx, common.ExposeServiceParams{
 		Tenant:             strings.TrimSpace(tenant),
@@ -65,6 +91,8 @@ func runExposeCommand(ctx common.Context, store common.ExposeStore, findProjectR
 		IngressClass:       strings.TrimSpace(ingressClass),
 		TLSSecretName:      strings.TrimSpace(tlsSecret),
 		SkipIfUnconfigured: skipIfUnconfigured,
+		ServicesZone:       servicesZone,
+		PlatformNamespace:  platformNamespace,
 	}, store, nil, nil)
 	if err != nil {
 		return err

--- a/erun-common/expose.go
+++ b/erun-common/expose.go
@@ -73,6 +73,18 @@ type ExposeServiceParams struct {
 	// the target project is a platform deployment at all — an explicit,
 	// interactive `erun expose` still fails fast on a misconfigured project.
 	SkipIfUnconfigured bool
+	// ServicesZone and PlatformNamespace, when both set, override the platform
+	// coordinates expose would otherwise read from ProjectRoot's .erun/config.yaml
+	// (platform.serviceszone and platform.env respectively) — the PowerDNS
+	// Deployment name is then derived from PlatformNamespace the same way it is
+	// derived from platform.env. A caller that already has this information (the
+	// hosted deploy Job, which runs a sourceless container with no git checkout to
+	// resolve a project from — issue #1086) supplies it directly, the same way
+	// TargetIP already carries the operator-composed --ip rather than resolving
+	// one from a project. Left empty (the default), expose resolves the platform
+	// block from ProjectRoot exactly as it always has.
+	ServicesZone      string
+	PlatformNamespace string
 }
 
 // ExposeServiceResult is the resolved exposure plan: the public hostname, the
@@ -137,7 +149,7 @@ const defaultExposeWildcardTTL = 60
 func RunExposeService(ctx Context, params ExposeServiceParams, store ExposeStore, upsertDNSRecord DNSRecordUpserterFunc, applyIngress IngressApplierFunc) (ExposeServiceResult, error) {
 	store, upsertDNSRecord, applyIngress = normalizeExposeDependencies(store, upsertDNSRecord, applyIngress)
 
-	if params.SkipIfUnconfigured && !projectHasExposablePlatform(params.ProjectRoot) {
+	if params.SkipIfUnconfigured && !exposePlatformConfigured(params) {
 		ctx.Trace("expose: skipped, no platform block configured")
 		return ExposeServiceResult{}, nil
 	}
@@ -232,6 +244,19 @@ func validateExposeTarget(params ExposeServiceParams) (tenant, environment, serv
 	return tenant, environment, service, nil
 }
 
+// exposePlatformConfigured reports whether expose has enough platform
+// information to resolve a hostname, either from the caller's explicit
+// ServicesZone/PlatformNamespace override or from ProjectRoot's platform
+// block. SkipIfUnconfigured only asks "is this a platform deployment at all",
+// so an explicit override — which by definition names a real platform deploy —
+// always counts, with no project needed to confirm it.
+func exposePlatformConfigured(params ExposeServiceParams) bool {
+	if strings.TrimSpace(params.ServicesZone) != "" && strings.TrimSpace(params.PlatformNamespace) != "" {
+		return true
+	}
+	return projectHasExposablePlatform(params.ProjectRoot)
+}
+
 // projectHasExposablePlatform reports whether projectRoot declares enough of a
 // platform block for expose to resolve a hostname: the same three conditions
 // resolveExposeServicePlan otherwise fails on (missing block, missing base
@@ -250,21 +275,9 @@ func resolveExposeServicePlan(params ExposeServiceParams, store ExposeStore) (Ex
 	if err != nil {
 		return ExposeServiceResult{}, err
 	}
-	platform := resolveProjectPlatform(params.ProjectRoot)
-	if platform.IsZero() || strings.TrimSpace(platform.ServicesZone) == "" {
-		return ExposeServiceResult{}, fmt.Errorf("expose requires a platform block with a base domain in .erun/config.yaml (the services zone tenant hostnames live under)")
-	}
-	// Fail fast on a malformed platform block (matching deploy's contract) before
-	// deriving any hostnames or zone names from it.
-	if err := platform.Validate(); err != nil {
+	servicesZone, platformNamespace, platformPowerDNS, platformContext, err := resolveExposePlatformCoordinates(params, store)
+	if err != nil {
 		return ExposeServiceResult{}, err
-	}
-	// platform.env is optional for the deploy/PowerDNS chart (it deploys into the
-	// release namespace), but expose derives the PowerDNS pod's namespace from it
-	// to exec the DNS write. Without it the write would run `kubectl -n "" exec`
-	// and silently target the current/default namespace, so require it here.
-	if strings.TrimSpace(platform.Env) == "" {
-		return ExposeServiceResult{}, fmt.Errorf("expose requires platform.env in .erun/config.yaml (the platform environment that runs the PowerDNS singleton)")
 	}
 	envConfig, _, err := store.LoadEnvConfig(tenant, environment)
 	if err != nil {
@@ -279,11 +292,6 @@ func resolveExposeServicePlan(params ExposeServiceParams, store ExposeStore) (Ex
 		servicePort = defaultExposeServicePort
 	}
 	envLabel := KubernetesNamespaceName(tenant, environment)
-	// The PowerDNS Deployment is scoped to the platform env's tenant by its chart
-	// (<tenant>-powerdns); platform.Env is that env's "<tenant>-<env>" namespace
-	// label, so its tenant prefix gives the Deployment name the exec targets.
-	platTenant, _, _ := splitTenantEnv(platform.Env)
-	platformPowerDNS := TenantResourcePrefix(platTenant) + "-powerdns"
 	tlsEnabled, ingressClass, tlsSecret, scheme := resolveExposeTLSPlan(params, envLabel)
 	result := ExposeServiceResult{
 		Tenant:                     tenant,
@@ -292,9 +300,9 @@ func resolveExposeServicePlan(params ExposeServiceParams, store ExposeStore) (Ex
 		BackendService:             fmt.Sprintf("%s-%s", TenantResourcePrefix(tenant), service),
 		Namespace:                  envLabel,
 		KubernetesContext:          strings.TrimSpace(envConfig.KubernetesContext),
-		Hostname:                   fmt.Sprintf("%s.%s.%s", service, envLabel, platform.ServicesZone),
-		ServicesZone:               platform.ServicesZone,
-		WildcardName:               fmt.Sprintf("*.%s.%s", envLabel, platform.ServicesZone),
+		Hostname:                   fmt.Sprintf("%s.%s.%s", service, envLabel, servicesZone),
+		ServicesZone:               servicesZone,
+		WildcardName:               fmt.Sprintf("*.%s.%s", envLabel, servicesZone),
 		TargetIP:                   targetIP,
 		IngressName:                fmt.Sprintf("expose-%s", service),
 		ServicePort:                servicePort,
@@ -302,11 +310,59 @@ func resolveExposeServicePlan(params ExposeServiceParams, store ExposeStore) (Ex
 		IngressClass:               ingressClass,
 		TLSSecretName:              tlsSecret,
 		TLSEnabled:                 tlsEnabled,
-		PlatformNamespace:          normalizeNamespaceName(platform.Env),
+		PlatformNamespace:          platformNamespace,
 		PlatformPowerDNSDeployment: platformPowerDNS,
-		PlatformContext:            resolvePlatformContext(store, platform.Env),
+		PlatformContext:            platformContext,
 	}
 	return result, nil
+}
+
+// resolveExposePlatformCoordinates resolves the platform coordinates expose
+// needs — the services zone tenant hostnames live under, the namespace running
+// the platform's PowerDNS singleton, the Deployment name the DNS write execs
+// into, and (best-effort) the platform cluster's own kube context — from either
+// an explicit override or ProjectRoot's platform block. See
+// ExposeServiceParams.ServicesZone/PlatformNamespace: a caller with no project
+// to resolve (the deploy Job) supplies these directly instead.
+func resolveExposePlatformCoordinates(params ExposeServiceParams, store ExposeStore) (zone, namespace, powerDNSDeployment, platformContext string, err error) {
+	zone = strings.TrimSpace(params.ServicesZone)
+	namespace = strings.TrimSpace(params.PlatformNamespace)
+	if zone != "" || namespace != "" {
+		if zone == "" || namespace == "" {
+			return "", "", "", "", fmt.Errorf("expose requires both a services zone and a platform namespace override when either is set")
+		}
+		platTenant, _, ok := splitTenantEnv(namespace)
+		if !ok {
+			return "", "", "", "", fmt.Errorf("platform namespace override %q must be a \"<tenant>-<env>\" namespace label", namespace)
+		}
+		// No platform.env to resolve a distinct platform-cluster context from, so
+		// the DNS write falls back to kubectl's current context — correct for the
+		// single-cluster hosted deployment a deploy Job (the caller this override
+		// exists for) always runs in.
+		return zone, normalizeNamespaceName(namespace), TenantResourcePrefix(platTenant) + "-powerdns", "", nil
+	}
+
+	platform := resolveProjectPlatform(params.ProjectRoot)
+	if platform.IsZero() || strings.TrimSpace(platform.ServicesZone) == "" {
+		return "", "", "", "", fmt.Errorf("expose requires a platform block with a base domain in .erun/config.yaml (the services zone tenant hostnames live under)")
+	}
+	// Fail fast on a malformed platform block (matching deploy's contract) before
+	// deriving any hostnames or zone names from it.
+	if err := platform.Validate(); err != nil {
+		return "", "", "", "", err
+	}
+	// platform.env is optional for the deploy/PowerDNS chart (it deploys into the
+	// release namespace), but expose derives the PowerDNS pod's namespace from it
+	// to exec the DNS write. Without it the write would run `kubectl -n "" exec`
+	// and silently target the current/default namespace, so require it here.
+	if strings.TrimSpace(platform.Env) == "" {
+		return "", "", "", "", fmt.Errorf("expose requires platform.env in .erun/config.yaml (the platform environment that runs the PowerDNS singleton)")
+	}
+	// The PowerDNS Deployment is scoped to the platform env's tenant by its chart
+	// (<tenant>-powerdns); platform.Env is that env's "<tenant>-<env>" namespace
+	// label, so its tenant prefix gives the Deployment name the exec targets.
+	platTenant, _, _ := splitTenantEnv(platform.Env)
+	return platform.ServicesZone, normalizeNamespaceName(platform.Env), TenantResourcePrefix(platTenant) + "-powerdns", resolvePlatformContext(store, platform.Env), nil
 }
 
 // resolveExposeTLSPlan resolves the Ingress TLS wiring: https by default,

--- a/erun-integration/expose_test.go
+++ b/erun-integration/expose_test.go
@@ -133,6 +133,64 @@ func TestExpose(t *testing.T) {
 		golden.Equal(t, "expose/skip_if_unconfigured_with_platform", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_platform_override_no_project", func(t *testing.T) {
+		// --services-zone/--platform-namespace supply what a project checkout
+		// would otherwise resolve, so expose runs from a directory with no git
+		// repo at all -- the shape a hosted deploy Job runs in, which has no
+		// checkout to read .erun/config.yaml from (#1086).
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"expose", "team", "dev", "api", "--ip", "203.0.113.10",
+			"--services-zone", "services.erunpaas.com", "--platform-namespace", "frs-prod", "--dry-run"},
+			erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "expose/dry_run_platform_override_no_project", normalize.Apply(result.Combined))
+	})
+
+	t.Run("platform_override_requires_both", func(t *testing.T) {
+		// Half the override configured is the same as neither: expose refuses
+		// rather than resolving a plan from an incomplete pair.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"expose", "team", "dev", "api", "--ip", "203.0.113.10",
+			"--services-zone", "services.erunpaas.com", "--dry-run"},
+			erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit with only --services-zone set, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "expose/platform_override_requires_both", normalize.Apply(result.Combined))
+	})
+
+	t.Run("skip_if_unconfigured_no_project", func(t *testing.T) {
+		// --skip-if-unconfigured must cover "no project at all", not just "a
+		// project with no platform block" -- the hole #1086 reported: the deploy
+		// Job's --skip-if-unconfigured could not save it because project
+		// resolution itself failed outright with "cannot find git project"
+		// before the skip decision ever ran.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"expose", "team", "dev", "api", "--ip", "127.0.0.1", "--skip-if-unconfigured", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "expose/skip_if_unconfigured_no_project", normalize.Apply(result.Combined))
+	})
+
+	t.Run("requires_project_without_override_or_skip", func(t *testing.T) {
+		// Interactive `erun expose` from a plain, non-git directory still fails
+		// fast -- the override flags and --skip-if-unconfigured are opt-in, not
+		// a silent relaxation of the default project requirement.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"expose", "team", "dev", "api", "--ip", "127.0.0.1", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit outside a git project, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "expose/requires_project_without_override_or_skip", normalize.Apply(result.Combined))
+	})
+
 	t.Run("requires_ip", func(t *testing.T) {
 		// The per-env wildcard record needs a target IP (the env's ingress IP);
 		// omitting --ip fails clearly instead of writing an empty record.

--- a/erun-integration/testdata/expose/dry_run_platform_override_no_project.txt
+++ b/erun-integration/testdata/expose/dry_run_platform_override_no_project.txt
@@ -1,0 +1,33 @@
+audit: erun expose --dry-run --ip <VERSION>.10 --platform-namespace frs-prod --services-zone services.erunpaas.com team dev api
+expose: api.team-dev.services.erunpaas.com -> service team-api.team-dev.svc:80
+expose: per-env wildcard *.team-dev.services.erunpaas.com A <VERSION>.10 ttl 60 (zone services.erunpaas.com)
+expose: ingress class traefik
+expose: tls secret team-dev-wildcard-tls (namespace team-dev) -> https
+expose: platform powerdns namespace frs-prod
+kubectl -n frs-prod exec deploy/frs-powerdns -- pdnsutil --config-dir=/etc/pdns-shared replace-rrset services.erunpaas.com '*.team-dev' A 60 <VERSION>.10
+kubectl --context test-context -n team-dev apply -f -
+expose: ingress manifest:
+  apiVersion: networking.k8s.io/v1
+  kind: Ingress
+  metadata:
+    name: expose-api
+    namespace: team-dev
+    labels:
+      app.kubernetes.io/managed-by: erun-expose
+  spec:
+    ingressClassName: traefik
+    tls:
+      - hosts:
+          - api.team-dev.services.erunpaas.com
+        secretName: team-dev-wildcard-tls
+    rules:
+      - host: api.team-dev.services.erunpaas.com
+        http:
+          paths:
+            - path: /
+              pathType: Prefix
+              backend:
+                service:
+                  name: team-api
+                  port:
+                    number: 80

--- a/erun-integration/testdata/expose/help.txt
+++ b/erun-integration/testdata/expose/help.txt
@@ -1,6 +1,6 @@
 Expose an in-namespace Service at a stable public hostname under the platform's services zone.
 
-SERVICE is the logical service name: it becomes the hostname label and routes to the tenant-scoped in-namespace Service <tenant>-<service> (the name its component chart renders, e.g. `api` -> `frs-api`), so the public host stays a clean label (api.frs-prod.services.erunpaas.com) while the Ingress targets the real Service. Ensures the per-environment wildcard DNS record points at the env's ingress IP and applies a Host-routing Ingress for the Service. TLS is on by default: the Ingress references the env's per-env wildcard cert Secret (<tenant>-<env>-wildcard-tls, issued by the cluster edge), so the host serves https with no per-service cert step. Pass --no-tls for http. Requires a platform block in .erun/config.yaml; it mutates the platform DNS zone and applies to the env's cluster. Use --dry-run to preview the actions.
+SERVICE is the logical service name: it becomes the hostname label and routes to the tenant-scoped in-namespace Service <tenant>-<service> (the name its component chart renders, e.g. `api` -> `frs-api`), so the public host stays a clean label (api.frs-prod.services.erunpaas.com) while the Ingress targets the real Service. Ensures the per-environment wildcard DNS record points at the env's ingress IP and applies a Host-routing Ingress for the Service. TLS is on by default: the Ingress references the env's per-env wildcard cert Secret (<tenant>-<env>-wildcard-tls, issued by the cluster edge), so the host serves https with no per-service cert step. Pass --no-tls for http. Requires a platform block in .erun/config.yaml unless --services-zone and --platform-namespace are both set; it mutates the platform DNS zone and applies to the env's cluster. Use --dry-run to preview the actions.
 
 Usage:
   erun expose TENANT ENVIRONMENT SERVICE [flags]
@@ -9,16 +9,19 @@ Examples:
   erun expose team dev api --ip <LOOPBACK>
   erun expose team prod api --ip <VERSION>.10 --port 8080
   erun expose team dev api --ip <LOOPBACK> --no-tls
+  erun expose team dev api --ip <LOOPBACK> --services-zone services.example.com --platform-namespace frs-prod
 
 Flags:
-      --dry-run                Resolve and trace mutating actions without executing them.
-  -h, --help                   help for expose
-      --ingress-class string   Ingress controller class (default traefik)
-      --ip string              Ingress IP the per-env wildcard record points at (e.g. <LOOPBACK> for a local cluster, the public LB IP for remote)
-      --no-tls                 Serve http instead of https (skip the tls block on the Ingress)
-      --port int               Service port to route to (default 80)
-      --skip-if-unconfigured   Succeed as a no-op instead of failing when the project declares no platform block (for scripted callers composing expose after another command)
-      --tls-secret string      Override the per-env wildcard cert Secret name (default <tenant>-<env>-wildcard-tls)
+      --dry-run                     Resolve and trace mutating actions without executing them.
+  -h, --help                        help for expose
+      --ingress-class string        Ingress controller class (default traefik)
+      --ip string                   Ingress IP the per-env wildcard record points at (e.g. <LOOPBACK> for a local cluster, the public LB IP for remote)
+      --no-tls                      Serve http instead of https (skip the tls block on the Ingress)
+      --platform-namespace string   Override the namespace running the platform's PowerDNS singleton, so expose needs no project checkout (requires --services-zone too)
+      --port int                    Service port to route to (default 80)
+      --services-zone string        Override the platform services zone tenant hostnames live under, so expose needs no project checkout (requires --platform-namespace too)
+      --skip-if-unconfigured        Succeed as a no-op instead of failing when the project declares no platform block (for scripted callers composing expose after another command)
+      --tls-secret string           Override the per-env wildcard cert Secret name (default <tenant>-<env>-wildcard-tls)
 
 Global Flags:
       --output string   Result format: text (default, human stream) or json (structured result on stdout for orchestrators). (default "text")

--- a/erun-integration/testdata/expose/platform_override_requires_both.txt
+++ b/erun-integration/testdata/expose/platform_override_requires_both.txt
@@ -1,0 +1,2 @@
+audit: erun expose --dry-run --ip <VERSION>.10 --services-zone services.erunpaas.com team dev api
+expose requires both a services zone and a platform namespace override when either is set

--- a/erun-integration/testdata/expose/requires_project_without_override_or_skip.txt
+++ b/erun-integration/testdata/expose/requires_project_without_override_or_skip.txt
@@ -1,0 +1,2 @@
+audit: erun expose --dry-run --ip <LOOPBACK> team dev api
+cannot find git project

--- a/erun-integration/testdata/expose/skip_if_unconfigured_no_project.txt
+++ b/erun-integration/testdata/expose/skip_if_unconfigured_no_project.txt
@@ -1,0 +1,2 @@
+audit: erun expose --dry-run --ip <LOOPBACK> --skip-if-unconfigured team dev api
+expose: skipped, no platform block configured

--- a/erun-mcp/expose.go
+++ b/erun-mcp/expose.go
@@ -25,6 +25,12 @@ type ExposeInput struct {
 	// an Agent composing expose after deploy without knowing whether the target
 	// is a platform deployment.
 	SkipIfUnconfigured bool `json:"skipIfUnconfigured,omitempty" jsonschema:"succeed as a no-op instead of failing when the project declares no platform block"`
+	// ServicesZone/PlatformNamespace mirror the CLI's --services-zone/
+	// --platform-namespace: an explicit override for the platform coordinates
+	// expose would otherwise read from ProjectRoot, for a caller with no project
+	// to resolve.
+	ServicesZone      string `json:"servicesZone,omitempty" jsonschema:"override the platform services zone tenant hostnames live under, so expose needs no project (requires platformNamespace too)"`
+	PlatformNamespace string `json:"platformNamespace,omitempty" jsonschema:"override the namespace running the platform's PowerDNS singleton, so expose needs no project (requires servicesZone too)"`
 }
 
 func exposeTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, ExposeInput) (*mcp.CallToolResult, CommandOutput, error) {
@@ -50,6 +56,8 @@ func exposeTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReques
 				IngressClass:       strings.TrimSpace(input.IngressClass),
 				TLSSecretName:      strings.TrimSpace(input.TLSSecret),
 				SkipIfUnconfigured: input.SkipIfUnconfigured,
+				ServicesZone:       strings.TrimSpace(input.ServicesZone),
+				PlatformNamespace:  strings.TrimSpace(input.PlatformNamespace),
 			}, exposeStore, nil, nil)
 			return err
 		})


### PR DESCRIPTION
## What broke

With #1083 in (erun 1.0.189), a fresh `erun platform env register` deploys cleanly and then fails on the chained exposure step, taking the whole provision down with it even though the environment is healthy:

```
==> Deployed operations/probec 1.0.189 in 8s
audit: erun expose --ip 212.93.120.230 --skip-if-unconfigured operations probec mcp
cannot find git project
```

Root cause: the deploy Job's container is sourceless (no git checkout). `erun expose` reads its platform coordinates — services zone, PowerDNS namespace — from a project's `.erun/config.yaml` via `FindProjectRoot()`, which fails outright with `cannot find git project` inside the Job. `--skip-if-unconfigured` couldn't save it either: the skip decision itself (`projectHasExposablePlatform`) needed a resolved `ProjectRoot`, and resolution is exactly what failed. The Job's exit code then rolled the whole provision into `status=failed` with a `provision-error` that quoted the *deploy* invocation, burying the real failing step (`erun expose`) in the last line.

## Fix 1 — expose no longer needs a project

Chose **shape (b)**: explicit `--services-zone`/`--platform-namespace` overrides on `erun expose` (and the matching `servicesZone`/`platformNamespace` MCP fields), mirroring how `--ip` already carries the operator-composed target IP rather than resolving one from a project. This fits the existing precedent better than seeding the shared `bootstrapEnvironmentScript` prelude (deploy/stop/delete's shared setup) with expose-specific business inputs — that prelude is meant to stay command-agnostic (kubeconfig + minimal tenant/env config), and `--ip` already established "the Job composes the command with resolved values" as the pattern for this primitive.

The deploy Job now threads `--services-zone`/`--platform-namespace` from configuration the control plane already carries for other purposes: `DNS01ServicesZone` (the same services zone its DNS-01 cert issuance uses) and `PlatformNamespace` (the namespace its own Jobs — and, in a self-hosted platform, the PowerDNS singleton — run in). Either left unset falls back to project-based resolution exactly as before.

Also closed the `--skip-if-unconfigured` hole for the no-override case: the CLI no longer fails outright on `cannot find git project` when `--skip-if-unconfigured` is set — no project at all is the strongest case of "not configured for exposure," not a reason to error before the skip decision runs.

## Fix 2 — exposure is best-effort

The chained `erun expose` no longer fails the deploy Job: `deploy && { expose_out=$(erun expose ...) || printf 'ERUN_EXPOSE_FAILED: %s\n' "$expose_out"; }` always exits 0 once deploy has succeeded. A new `expose_error` column (migration `20260821120000_env_expose_error.sql`) records why exposure didn't land, read back from the Job's captured output via `deployexec.ExposeFailureFromOutput`. `status`/`provision_error` now mean exactly "did the deploy land" — a healthy deployed environment stays `running`, with its own worded exposure gap recorded separately instead of misdirecting an operator into reading the deploy trace.

## Also included

- Recorded three durable lessons in the root `AGENTS.md` under a new "Kubernetes RBAC For Server-Side Executors" section: `helm --wait` needs `replicasets` RBAC beyond `deployments` (#1080/#1083), `kubectl auth can-i <verb> <resource>/<subresource>` gives false positives vs. a real impersonated call (#1080), and a role-rule-pinning test only confirms rules somebody already thought of (#1081/#1083).

## Test plan

- [x] `erun-common`: `resolveExposePlatformCoordinates` unit-level behavior via `go test ./...`
- [x] `erun-integration`: new scenarios `expose/dry_run_platform_override_no_project`, `expose/platform_override_requires_both`, `expose/skip_if_unconfigured_no_project`, `expose/requires_project_without_override_or_skip`; existing expose scenarios re-verified unchanged
- [x] `erun-backend-api`: new/updated tests in `deployexec`, `service`, `provision` covering the best-effort script shape, the `ERUN_EXPOSE_FAILED` marker round-trip, and `expose_error` staying `running` on a deploy success + expose failure
- [x] `erun-backend-db`: hand-written migration + `atlas migrate hash` regenerated
- [x] `make check` (lint over `erun-common`, `erun-cli`, `erun-mcp`, `erun-integration`, `erun-backend/erun-backend-api` + the integration suite/coverage gate) — green, coverage 75.8% (>= 75.8% threshold)

Closes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)