### PR TITLE
Grant the env-provisioner role pods/exec and ingresses for expose

### DIFF
--- a/erun-backend/erun-backend-api/env_provisioner_rbac_e2e_test.go
+++ b/erun-backend/erun-backend-api/env_provisioner_rbac_e2e_test.go
@@ -32,6 +32,15 @@ package backendapi
 // erun-devops/AGENTS.md "Runtime SA RBAC is namespaced by default") but not
 // of a bare `go test ./...` on a laptop, so it is opt-in and skipped by
 // default.
+//
+// The same file also covers the two grants the deploy Job's post-deploy
+// `erun expose` needs and the provisioner role initially lacked: applying
+// the Host-routing Ingress into the env namespace (the cluster-wide
+// ClusterRole, like everything above), and the `kubectl exec` DNS write
+// against the platform's PowerDNS singleton (a namespaced Role scoped to
+// this chart's own release namespace, never the tenant env namespace). Both
+// follow the same real-object-graph pattern as the readiness test above
+// rather than pinning a rule list.
 
 import (
 	"bytes"
@@ -47,6 +56,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,8 +64,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/remotecommand"
 )
 
 // provisionerRBACChartDir is the chart this test renders the ClusterRole
@@ -143,10 +155,10 @@ func assertReplicaSetsObservableUnderFixedRules(t *testing.T, fixed kubernetes.I
 	t.Logf("confirmed current rules: list replicasets => observed owned ReplicaSet with readyReplicas=%d", owned.Status.ReadyReplicas)
 }
 
-// renderProvisionerClusterRoleRules renders the real chart and extracts the
-// current <tenant>-env-provisioner ClusterRole's rules, so this test can
-// never drift from what actually ships.
-func renderProvisionerClusterRoleRules(t *testing.T, tenant string) []rbacv1.PolicyRule {
+// renderProvisionerChart renders the real chart with envDeployer enabled, so
+// every rule-extraction helper below reads from one actual `helm template`
+// invocation rather than a hand-copied rule list.
+func renderProvisionerChart(t *testing.T, tenant string) []byte {
 	t.Helper()
 	chartDir, err := filepath.Abs(provisionerRBACChartDir)
 	mustNoErr(t, err, "resolve chart dir")
@@ -163,17 +175,38 @@ func renderProvisionerClusterRoleRules(t *testing.T, tenant string) []rbacv1.Pol
 	if runErr != nil {
 		t.Fatalf("helm template %s: %v\n%s", chartDir, runErr, out)
 	}
+	return out
+}
 
+// renderProvisionerClusterRoleRules renders the real chart and extracts the
+// current <tenant>-env-provisioner ClusterRole's rules, so this test can
+// never drift from what actually ships.
+func renderProvisionerClusterRoleRules(t *testing.T, tenant string) []rbacv1.PolicyRule {
+	t.Helper()
 	roleName := tenant + "-env-provisioner"
-	rules := decodeClusterRoleRules(t, out, roleName)
+	rules := decodeRulesByKind(t, renderProvisionerChart(t, tenant), "ClusterRole", roleName)
 	if len(rules) == 0 {
 		t.Fatalf("rendered chart carries no ClusterRole named %s with rules", roleName)
 	}
 	return rules
 }
 
+// renderProvisionerPlatformRoleRules renders the real chart and extracts the
+// current <tenant>-env-provisioner-platform Role's rules: the namespaced
+// pods/exec grant for the PowerDNS DNS write, scoped separately from the
+// cluster-wide env-provisioner ClusterRole above.
+func renderProvisionerPlatformRoleRules(t *testing.T, tenant string) []rbacv1.PolicyRule {
+	t.Helper()
+	roleName := tenant + "-env-provisioner-platform"
+	rules := decodeRulesByKind(t, renderProvisionerChart(t, tenant), "Role", roleName)
+	if len(rules) == 0 {
+		t.Fatalf("rendered chart carries no Role named %s with rules", roleName)
+	}
+	return rules
+}
+
 // renderedManifest is the minimal shape shared by every kind this decode
-// loop cares about: enough to find the ClusterRole by name and read its
+// loop cares about: enough to find a role by kind and name and read its
 // rules, and nothing else.
 type renderedManifest struct {
 	Kind     string `json:"kind"`
@@ -183,9 +216,9 @@ type renderedManifest struct {
 	Rules []rbacv1.PolicyRule `json:"rules,omitempty"`
 }
 
-// decodeClusterRoleRules walks helm template's multi-document YAML output
-// looking for the named ClusterRole.
-func decodeClusterRoleRules(t *testing.T, rendered []byte, roleName string) []rbacv1.PolicyRule {
+// decodeRulesByKind walks helm template's multi-document YAML output looking
+// for the named ClusterRole or Role.
+func decodeRulesByKind(t *testing.T, rendered []byte, kind, roleName string) []rbacv1.PolicyRule {
 	t.Helper()
 	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(rendered), 4096)
 	for {
@@ -196,7 +229,7 @@ func decodeClusterRoleRules(t *testing.T, rendered []byte, roleName string) []rb
 			}
 			t.Fatalf("decode rendered chart manifest: %v", err)
 		}
-		if manifest.Kind == "ClusterRole" && manifest.Metadata.Name == roleName {
+		if manifest.Kind == kind && manifest.Metadata.Name == roleName {
 			return manifest.Rules
 		}
 	}
@@ -213,24 +246,41 @@ var readinessRelevantResources = map[string]bool{
 	"events":            true,
 }
 
-// readinessRelevantRules filters the rendered ClusterRole down to the rules
-// this test exercises, so the probe identity only ever needs a subset of
-// permissions its own (namespaced-admin) identity already holds -- the full
-// ClusterRole also carries namespace-lifecycle and quota-management grants
-// that a namespaced-admin probe cannot self-grant without tripping
-// Kubernetes' RBAC escalation check, and that are irrelevant to the
-// Deployment -> ReplicaSet readiness walk under test here.
-func readinessRelevantRules(rules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
+// filterRulesByResource narrows a rendered rule set down to the rules
+// mentioning any of the given resources, so a probe identity only ever needs
+// a subset of permissions its own (namespaced-admin) identity already holds
+// -- granting the full rule set would risk tripping Kubernetes' RBAC
+// escalation check on grants (like binding the admin ClusterRole) the probe
+// itself cannot self-escalate into handing out.
+func filterRulesByResource(rules []rbacv1.PolicyRule, resources map[string]bool) []rbacv1.PolicyRule {
 	relevant := make([]rbacv1.PolicyRule, 0, len(rules))
 	for _, rule := range rules {
 		for _, resource := range rule.Resources {
-			if readinessRelevantResources[resource] {
+			if resources[resource] {
 				relevant = append(relevant, rule)
 				break
 			}
 		}
 	}
 	return relevant
+}
+
+// readinessRelevantRules filters the rendered ClusterRole down to the rules
+// this test exercises: the Deployment -> ReplicaSet readiness walk, and
+// nothing from the namespace-lifecycle or quota-management grants elsewhere
+// on the same ClusterRole.
+func readinessRelevantRules(rules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
+	return filterRulesByResource(rules, readinessRelevantResources)
+}
+
+// ingressRelevantResources is the one resource the ingress-write test cares
+// about.
+var ingressRelevantResources = map[string]bool{"ingresses": true}
+
+// ingressRelevantRules filters the rendered ClusterRole down to the
+// networking.k8s.io/ingresses grant under test.
+func ingressRelevantRules(rules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
+	return filterRulesByResource(rules, ingressRelevantResources)
 }
 
 // withoutReplicasetsGrant reproduces the pre-#1083 rule set by removing
@@ -240,6 +290,32 @@ func withoutReplicasetsGrant(rules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
 	without := make([]rbacv1.PolicyRule, 0, len(rules))
 	for _, rule := range rules {
 		if containsString(rule.APIGroups, "apps") && containsString(rule.Resources, "replicasets") {
+			continue
+		}
+		without = append(without, rule)
+	}
+	return without
+}
+
+// withoutIngressGrant reproduces the pre-fix rule set by removing exactly
+// the networking.k8s.io/ingresses rule.
+func withoutIngressGrant(rules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
+	without := make([]rbacv1.PolicyRule, 0, len(rules))
+	for _, rule := range rules {
+		if containsString(rule.APIGroups, "networking.k8s.io") && containsString(rule.Resources, "ingresses") {
+			continue
+		}
+		without = append(without, rule)
+	}
+	return without
+}
+
+// withoutPodsExecGrant reproduces the pre-fix rule set by removing exactly
+// the pods/exec rule.
+func withoutPodsExecGrant(rules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
+	without := make([]rbacv1.PolicyRule, 0, len(rules))
+	for _, rule := range rules {
+		if containsString(rule.APIGroups, "") && containsString(rule.Resources, "pods/exec") {
 			continue
 		}
 		without = append(without, rule)
@@ -381,6 +457,18 @@ func ownedReplicaSet(t *testing.T, items []appsv1.ReplicaSet, deploymentUID type
 // own live reproduction used.
 func provisionerRBACIdentity(t *testing.T, admin kubernetes.Interface, adminConfig *rest.Config, namespace, name string, rules []rbacv1.PolicyRule) kubernetes.Interface {
 	t.Helper()
+	client, _ := provisionerRBACIdentityWithConfig(t, admin, adminConfig, namespace, name, rules)
+	return client
+}
+
+// provisionerRBACIdentityWithConfig behaves like provisionerRBACIdentity but
+// also returns the impersonated rest.Config, needed by callers that must
+// negotiate a raw HTTP protocol upgrade (pods/exec) rather than a typed
+// clientset call. An empty rules set creates the ServiceAccount with no
+// Role/RoleBinding at all, reproducing a pre-fix identity that holds zero
+// permissions in this namespace.
+func provisionerRBACIdentityWithConfig(t *testing.T, admin kubernetes.Interface, adminConfig *rest.Config, namespace, name string, rules []rbacv1.PolicyRule) (kubernetes.Interface, *rest.Config) {
+	t.Helper()
 	ctx := context.Background()
 
 	sa, err := admin.CoreV1().ServiceAccounts(namespace).Create(ctx, &corev1.ServiceAccount{
@@ -391,24 +479,26 @@ func provisionerRBACIdentity(t *testing.T, admin kubernetes.Interface, adminConf
 		_ = admin.CoreV1().ServiceAccounts(namespace).Delete(context.Background(), sa.Name, metav1.DeleteOptions{})
 	})
 
-	role, err := admin.RbacV1().Roles(namespace).Create(ctx, &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Rules:      rules,
-	}, metav1.CreateOptions{})
-	mustNoErr(t, err, "create probe Role "+name)
-	t.Cleanup(func() {
-		_ = admin.RbacV1().Roles(namespace).Delete(context.Background(), role.Name, metav1.DeleteOptions{})
-	})
+	if len(rules) > 0 {
+		role, err := admin.RbacV1().Roles(namespace).Create(ctx, &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Rules:      rules,
+		}, metav1.CreateOptions{})
+		mustNoErr(t, err, "create probe Role "+name)
+		t.Cleanup(func() {
+			_ = admin.RbacV1().Roles(namespace).Delete(context.Background(), role.Name, metav1.DeleteOptions{})
+		})
 
-	binding, err := admin.RbacV1().RoleBindings(namespace).Create(ctx, &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: sa.Name, Namespace: namespace}},
-		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: role.Name},
-	}, metav1.CreateOptions{})
-	mustNoErr(t, err, "create probe RoleBinding "+name)
-	t.Cleanup(func() {
-		_ = admin.RbacV1().RoleBindings(namespace).Delete(context.Background(), binding.Name, metav1.DeleteOptions{})
-	})
+		binding, err := admin.RbacV1().RoleBindings(namespace).Create(ctx, &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: sa.Name, Namespace: namespace}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: role.Name},
+		}, metav1.CreateOptions{})
+		mustNoErr(t, err, "create probe RoleBinding "+name)
+		t.Cleanup(func() {
+			_ = admin.RbacV1().RoleBindings(namespace).Delete(context.Background(), binding.Name, metav1.DeleteOptions{})
+		})
+	}
 
 	impersonated := rest.CopyConfig(adminConfig)
 	impersonated.Impersonate = rest.ImpersonationConfig{
@@ -416,5 +506,230 @@ func provisionerRBACIdentity(t *testing.T, admin kubernetes.Interface, adminConf
 	}
 	client, err := kubernetes.NewForConfig(impersonated)
 	mustNoErr(t, err, "build impersonated kube client for "+name)
-	return client
+	return client, impersonated
+}
+
+// TestProvisionerClusterRoleGrantsIngressWrite proves the env-provisioner
+// ClusterRole's networking.k8s.io/ingresses grant against a real RBAC
+// engine: `erun expose` applies (and idempotently re-applies) a Host-routing
+// Ingress into the env namespace, and that write must succeed under the
+// current rules and be Forbidden without the grant.
+func TestProvisionerClusterRoleGrantsIngressWrite(t *testing.T) {
+	if os.Getenv("ERUN_E2E_PROVISIONER_RBAC") != "1" {
+		t.Skip("opt-in: set ERUN_E2E_PROVISIONER_RBAC=1 on a live cluster where this identity may create Roles/ServiceAccounts/RoleBindings and impersonate, to prove the provisioner ClusterRole's ingresses grant against a real RBAC engine")
+	}
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm is required to render the chart under test")
+	}
+
+	tenant := fmt.Sprintf("rbacprobe%d", time.Now().UnixNano())
+	fixedRules := ingressRelevantRules(renderProvisionerClusterRoleRules(t, tenant))
+	preFixRules := withoutIngressGrant(fixedRules)
+
+	adminConfig := provisionerRBACConfig(t)
+	namespace := provisionerRBACNamespace(t)
+	admin, err := kubernetes.NewForConfig(adminConfig)
+	mustNoErr(t, err, "build admin kube client")
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	fixed := provisionerRBACIdentity(t, admin, adminConfig, namespace, "erun-1089-ingress-fixed-"+suffix, fixedRules)
+	preFix := provisionerRBACIdentity(t, admin, adminConfig, namespace, "erun-1089-ingress-prefix-"+suffix, preFixRules)
+
+	ingressName := "erun-1089-ingress-probe-" + suffix
+	assertIngressCreateForbiddenUnderPreFixRules(t, preFix, namespace, ingressName)
+	assertIngressWriteSucceedsUnderFixedRules(t, admin, fixed, namespace, ingressName)
+}
+
+// assertIngressCreateForbiddenUnderPreFixRules reproduces the issue's own
+// live reproduction: an Ingress apply forbidden for lack of the grant.
+func assertIngressCreateForbiddenUnderPreFixRules(t *testing.T, preFix kubernetes.Interface, namespace, name string) {
+	t.Helper()
+	_, err := preFix.NetworkingV1().Ingresses(namespace).Create(context.Background(), probeIngress(name, namespace), metav1.CreateOptions{})
+	if err == nil {
+		t.Fatal("creating an Ingress succeeded under the pre-fix rule set (no networking.k8s.io/ingresses grant) -- either the premise of this test is wrong or this cluster's RBAC is not enforcing the rule set this test built")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("creating an Ingress under the pre-fix rule set failed with %v, want a Forbidden error", err)
+	}
+	t.Logf("confirmed pre-fix rules: create ingress => Forbidden (%v)", err)
+}
+
+// assertIngressWriteSucceedsUnderFixedRules performs both calls `erun
+// expose` makes: create on first exposure, update on every re-expose after
+// that, since the Host-routing Ingress apply must be idempotent.
+func assertIngressWriteSucceedsUnderFixedRules(t *testing.T, admin, fixed kubernetes.Interface, namespace, name string) {
+	t.Helper()
+	created, err := fixed.NetworkingV1().Ingresses(namespace).Create(context.Background(), probeIngress(name, namespace), metav1.CreateOptions{})
+	mustNoErr(t, err, "create ingress as the fixed provisioner identity")
+	t.Cleanup(func() {
+		_ = admin.NetworkingV1().Ingresses(namespace).Delete(context.Background(), created.Name, metav1.DeleteOptions{})
+	})
+
+	created.Spec.Rules[0].Host = "updated." + created.Spec.Rules[0].Host
+	_, err = fixed.NetworkingV1().Ingresses(namespace).Update(context.Background(), created, metav1.UpdateOptions{})
+	mustNoErr(t, err, "update ingress as the fixed provisioner identity")
+	t.Logf("confirmed current rules: create+update ingress => succeeded")
+}
+
+// probeIngress is a minimal Ingress in the shape RunExposeService renders
+// (erun-common/expose_exec.go's renderHostRoutingIngress), enough to prove
+// the RBAC write without depending on a real backend Service existing.
+func probeIngress(name, namespace string) *networkingv1.Ingress {
+	pathType := networkingv1.PathTypePrefix
+	return &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{{
+				Host: name + ".example.test",
+				IngressRuleValue: networkingv1.IngressRuleValue{
+					HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{
+							Path:     "/",
+							PathType: &pathType,
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{
+									Name: "probe",
+									Port: networkingv1.ServiceBackendPort{Number: 80},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+}
+
+// TestProvisionerPlatformRoleGrantsPowerDNSExec proves the namespaced
+// env-provisioner-platform Role's pods/exec grant against a real RBAC
+// engine: `erun expose`'s DNS write shells out to `kubectl exec` against the
+// platform's PowerDNS pod, and that call must succeed under the current
+// rules and be Forbidden without the grant.
+func TestProvisionerPlatformRoleGrantsPowerDNSExec(t *testing.T) {
+	if os.Getenv("ERUN_E2E_PROVISIONER_RBAC") != "1" {
+		t.Skip("opt-in: set ERUN_E2E_PROVISIONER_RBAC=1 on a live cluster where this identity may create Pods/ServiceAccounts/Roles/RoleBindings and impersonate, to prove the env-provisioner-platform Role's pods/exec grant against a real RBAC engine")
+	}
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm is required to render the chart under test")
+	}
+
+	tenant := fmt.Sprintf("rbacprobe%d", time.Now().UnixNano())
+	fixedRules := renderProvisionerPlatformRoleRules(t, tenant)
+	preFixRules := withoutPodsExecGrant(fixedRules)
+
+	adminConfig := provisionerRBACConfig(t)
+	namespace := provisionerRBACNamespace(t)
+	admin, err := kubernetes.NewForConfig(adminConfig)
+	mustNoErr(t, err, "build admin kube client")
+
+	image := provisionerRBACProbeImage(t, admin, namespace)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	pod := createProbePod(t, admin, namespace, "erun-1089-exec-probe-"+suffix, image)
+	waitForPodRunning(t, admin, namespace, pod.Name)
+
+	_, fixedConfig := provisionerRBACIdentityWithConfig(t, admin, adminConfig, namespace, "erun-1089-exec-fixed-"+suffix, fixedRules)
+	_, preFixConfig := provisionerRBACIdentityWithConfig(t, admin, adminConfig, namespace, "erun-1089-exec-prefix-"+suffix, preFixRules)
+
+	assertExecForbiddenUnderPreFixRules(t, preFixConfig, namespace, pod.Name)
+	assertExecSucceedsUnderFixedRules(t, fixedConfig, namespace, pod.Name)
+}
+
+// createProbePod stands up a real, minimal Pod -- standing in for the
+// platform's PowerDNS pod -- for the exec probe under test to run against.
+func createProbePod(t *testing.T, admin kubernetes.Interface, namespace, name, image string) *corev1.Pod {
+	t.Helper()
+	spec := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    "probe",
+				Image:   image,
+				Command: []string{"sleep", "3600"},
+			}},
+		},
+	}
+	created, err := admin.CoreV1().Pods(namespace).Create(context.Background(), spec, metav1.CreateOptions{})
+	mustNoErr(t, err, "create probe Pod")
+	t.Cleanup(func() {
+		_ = admin.CoreV1().Pods(namespace).Delete(context.Background(), created.Name, metav1.DeleteOptions{})
+	})
+	return created
+}
+
+// waitForPodRunning polls the admin client -- unaffected by anything under
+// test -- until the probe Pod is actually running and execable.
+func waitForPodRunning(t *testing.T, admin kubernetes.Interface, namespace, name string) {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		pod, err := admin.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		mustNoErr(t, err, "get probe Pod")
+		if pod.Status.Phase == corev1.PodRunning {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("probe Pod %s/%s never became Running (phase: %s)", namespace, name, pod.Status.Phase)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// assertExecForbiddenUnderPreFixRules reproduces the issue's own live
+// reproduction: `kubectl exec` => Forbidden for lack of the pods/exec grant.
+func assertExecForbiddenUnderPreFixRules(t *testing.T, config *rest.Config, namespace, podName string) {
+	t.Helper()
+	err := execProbeCommand(config, namespace, podName)
+	if err == nil {
+		t.Fatal("exec into the probe pod succeeded under the pre-fix rule set (no pods/exec grant) -- either the premise of this test is wrong or this cluster's RBAC is not enforcing the rule set this test built")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("exec into the probe pod under the pre-fix rule set failed with %v, want a Forbidden error", err)
+	}
+	t.Logf("confirmed pre-fix rules: pods/exec => Forbidden (%v)", err)
+}
+
+// assertExecSucceedsUnderFixedRules performs the exact call `erun expose`'s
+// PowerDNS write makes.
+func assertExecSucceedsUnderFixedRules(t *testing.T, config *rest.Config, namespace, podName string) {
+	t.Helper()
+	err := execProbeCommand(config, namespace, podName)
+	mustNoErr(t, err, "exec into the probe pod as the fixed provisioner identity")
+	t.Logf("confirmed current rules: pods/exec => succeeded")
+}
+
+// execProbeCommand runs the exact call `erun expose`'s pdnsutil write makes
+// (erun-common/expose_exec.go's upsertPowerDNSRecord): a `kubectl exec`
+// against a real pod, negotiating the same SPDY protocol upgrade kubectl
+// itself uses, so an RBAC denial surfaces the same Forbidden a real
+// replace-rrset write would hit.
+func execProbeCommand(config *rest.Config, namespace, podName string) error {
+	execConfig := rest.CopyConfig(config)
+	execConfig.APIPath = "/api"
+	execConfig.GroupVersion = &corev1.SchemeGroupVersion
+	execConfig.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+
+	restClient, err := rest.RESTClientFor(execConfig)
+	if err != nil {
+		return err
+	}
+	req := restClient.Post().
+		Resource("pods").
+		Namespace(namespace).
+		Name(podName).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Command: []string{"true"},
+			Stdout:  true,
+			Stderr:  true,
+		}, scheme.ParameterCodec)
+
+	executor, err := remotecommand.NewSPDYExecutor(execConfig, "POST", req.URL())
+	if err != nil {
+		return err
+	}
+	var stdout, stderr bytes.Buffer
+	return executor.StreamWithContext(context.Background(), remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
 }

--- a/erun-devops/k8s/erun-backend-api-chart_test.sh
+++ b/erun-devops/k8s/erun-backend-api-chart_test.sh
@@ -29,9 +29,14 @@ fail() {
     exit 1
 }
 
+# --namespace pins .Release.Namespace to a known value: helm falls back to the
+# ambient kubeconfig context's namespace otherwise, which makes any assertion
+# about a chart-rendered release-namespace value (section 12 below) depend on
+# whoever's machine runs this script.
 render() {
     out="${work_root}/render.yaml"
     helm template test "${chart_dir}" \
+        --namespace test \
         --set tenant=team \
         --set environment=prod \
         "$@" >"${out}" || fail "helm template failed"
@@ -233,5 +238,45 @@ grep -A1 'resources: \["replicasets"\]' "${provisioner_role}" | grep -q '"list"'
     fail "the replicasets grant must include list, the verb helm's readiness wait issues"
 grep -A1 'resources: \["replicasets"\]' "${provisioner_role}" | grep -q '"watch"' ||
     fail "the replicasets grant must include watch"
+
+# --- 11. the deploy Job's post-deploy `erun expose` was refused twice
+#         over by RBAC the provisioner role never granted -- creating the
+#         Host-routing Ingress in the env namespace, and the `kubectl exec`
+#         DNS write against the platform's PowerDNS singleton. The ingresses
+#         grant belongs on this same ClusterRole (it is per-env, like
+#         everything else here); the pods/exec grant does not (see the next
+#         section) ---
+grep -q 'resources: \["ingresses"\]' "${provisioner_role}" ||
+    fail "the env-provisioner ClusterRole must grant networking.k8s.io/ingresses, or erun expose's Host-routing Ingress apply is forbidden in every provisioned env namespace (#1089)"
+grep -A1 'resources: \["ingresses"\]' "${provisioner_role}" | grep -q '"create"' ||
+    fail "the ingresses grant must include create"
+grep -A1 'resources: \["ingresses"\]' "${provisioner_role}" | grep -q '"update"' ||
+    fail "the ingresses grant must include update, or re-exposing an already-exposed env fails"
+grep -A1 'resources: \["ingresses"\]' "${provisioner_role}" | grep -q '"patch"' ||
+    fail "the ingresses grant must include patch, or re-exposing an already-exposed env fails"
+
+# --- 12. pods/exec for the PowerDNS DNS write is scoped to a
+#         namespaced Role bound in this chart's own release namespace (the
+#         platform namespace), not the cluster-wide ClusterRole above -- a
+#         cluster-wide grant would hand the deployer exec into every pod in
+#         every provisioned tenant namespace ---
+platform_role="${work_root}/platform-role.yaml"
+role "${rendered}" team-env-provisioner-platform >"${platform_role}"
+[ -s "${platform_role}" ] || fail "the env-provisioner-platform Role must render when envDeployer is enabled"
+grep -q 'namespace: test' "${platform_role}" ||
+    fail "the env-provisioner-platform Role must render in this chart's own release namespace, not a tenant env namespace"
+grep -q 'resources: \["pods/exec"\]' "${platform_role}" ||
+    fail "the env-provisioner-platform Role must grant pods/exec, or erun expose's PowerDNS DNS write is forbidden (#1089)"
+grep -A1 'resources: \["pods/exec"\]' "${platform_role}" | grep -q '"create"' ||
+    fail "the pods/exec grant must include create, the verb kubectl exec issues"
+
+platform_binding="${work_root}/platform-binding.yaml"
+awk -v want="  name: team-env-provisioner-platform" '
+    BEGIN{RS="\n---\n"}
+    $0 ~ /(^|\n)kind: RoleBinding(\n|$)/ && $0 ~ ("(^|\n)" want "(\n|$)") {print}
+' "${rendered}" >"${platform_binding}"
+[ -s "${platform_binding}" ] || fail "the env-provisioner-platform RoleBinding must render when envDeployer is enabled"
+grep -q 'name: team-env-deployer' "${platform_binding}" ||
+    fail "the env-provisioner-platform RoleBinding must bind the env-deployer ServiceAccount that the deploy Job -- and its chained erun expose -- runs as"
 
 echo "PASS: erun-backend-api DBOS wiring"

--- a/erun-devops/k8s/erun-backend-api/templates/api.yaml
+++ b/erun-devops/k8s/erun-backend-api/templates/api.yaml
@@ -257,7 +257,14 @@ roleRef:
      timeout on an otherwise healthy release. This is what #1080's
      deployments/pods/events grants missed: they cover the parent object,
      the failure-diagnostics pods/events, and the scale subresource, but not
-     the one object in the middle of helm's own walk. */}}
+     the one object in the middle of helm's own walk.
+
+     networking.k8s.io/ingresses is granted here, not narrowed further: the
+     deploy Job's post-deploy `erun expose` applies the Host-routing Ingress
+     into the provisioned env's own namespace (erun-common/expose.go), which
+     is genuinely a per-env action like everything else on this ClusterRole.
+     update/patch ride alongside create because re-exposing an already-
+     exposed env must be idempotent. */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -289,6 +296,9 @@ rules:
   - apiGroups: ["apps"]
     resources: ["replicasets"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["create", "get", "update", "patch"]
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
@@ -311,6 +321,47 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ $tenant }}-env-provisioner
+---
+{{/* pods/exec is deliberately not on the ClusterRole above: the deploy Job's
+     post-deploy `erun expose` also runs `kubectl exec deploy/<powerdns> --
+     pdnsutil replace-rrset` (erun-common/expose_exec.go's
+     upsertPowerDNSRecord) to write the wildcard DNS record, but that exec
+     always targets the platform's own PowerDNS singleton in this release's
+     namespace -- never a tenant's provisioned env namespace. A cluster-wide
+     grant would hand the deployer exec into every pod in every namespace,
+     undoing much of the point of curating this role away from cluster-admin,
+     so it is a namespaced Role bound only in this namespace instead.
+     resourceNames cannot narrow it further: the PowerDNS pod's name carries
+     its ReplicaSet's generated hash and is not known at grant time, so this
+     stays a namespace-wide exec grant rather than a resourceNames list that
+     would only look tighter. */}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $tenant }}-env-provisioner-platform
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ $tenant }}-api
+rules:
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $tenant }}-env-provisioner-platform
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ $tenant }}-api
+subjects:
+  - kind: ServiceAccount
+    name: {{ $envDeployerSA }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $tenant }}-env-provisioner-platform
 ---
 {{- end }}
 apiVersion: v1


### PR DESCRIPTION
## What happened

With #1086 in (erun 1.0.190), the deploy Job's chained `erun expose` finally
ran -- and RBAC refused the DNS write:

```
Error from server (Forbidden): pods "frs-powerdns-76c6bd874d-tmpbk" is forbidden: User
"system:serviceaccount:frs-prod:frs-env-deployer" cannot create resource "pods/exec"
in API group "" in the namespace "frs-prod"
```

Granting only `pods/exec` moves the failure one line down to
`applyHostRoutingIngress` (missing `networking.k8s.io/ingresses`). Both grants
are needed; this PR adds both in one change, per the pattern #1080/#1083 asked
future authors to follow (enumerate the whole object graph, not one grant per
release).

## Grants and where they landed

| capability | namespace | where |
| --- | --- | --- |
| `create`/`get`/`update`/`patch` `ingresses.networking.k8s.io` | env (per-env) | the existing cluster-wide `<tenant>-env-provisioner` ClusterRole -- genuinely per-env, like everything else on that role |
| `create` `pods/exec` | platform (this chart's own release namespace) | a **new namespaced Role** (`<tenant>-env-provisioner-platform`) bound to the same `envDeployerSA`, in `.Release.Namespace` only |

`pods/exec` is namespaced rather than cluster-wide because it is only ever
needed against the platform's PowerDNS singleton (the `pdnsutil
replace-rrset` write in `erun-common/expose_exec.go`), never against a
tenant's provisioned env namespace. Putting it on the cluster-wide
ClusterRole would hand the deployer exec into every pod in every provisioned
namespace, undoing much of the point of curating this role away from
`cluster-admin`. `resourceNames` cannot narrow it further: the PowerDNS
pod's name carries its ReplicaSet's generated hash and isn't known at grant
time, so this is a namespace-wide exec grant, not a false-precision
`resourceNames` list.

I re-read `erun-common/expose.go`'s `powerDNSUpsertArgs` and
`applyHostRoutingIngress` end to end to enumerate every object the expose
path touches (namespaces/deployments/pods/secrets already covered by the
existing ClusterRole; only these two were missing) so this doesn't repeat
the one-grant-per-release pattern of #1080/#1083/#1086.

## Testing

- `make check` (lint across all gated modules + integration suite + coverage
  gate): **green**.
  ```
  >> golangci-lint erun-common
  0 issues.
  >> golangci-lint erun-cli
  0 issues.
  >> golangci-lint erun-mcp
  0 issues.
  >> golangci-lint erun-integration
  0 issues.
  >> golangci-lint erun-backend/erun-backend-api
  0 issues.
  ok  	github.com/sophium/erun/erun-integration	66.476s
  ok  coverage 75.8% (>= 75.8%)
  ```
- `erun-devops/k8s/erun-backend-api-chart_test.sh` (extended with new
  assertions pinning both grants and the new Role/RoleBinding shape):
  **`PASS: erun-backend-api DBOS wiring`**.
- Extended the opt-in live-cluster RBAC e2e test
  (`env_provisioner_rbac_e2e_test.go`, added in #1085) with two new tests
  that render the real chart, bind the real rules to a throwaway
  ServiceAccount, and impersonate it against a real apiserver -- the same
  pattern that test already used for the #1083 replicasets grant, rather
  than a second rule-list assertion. Ran live in this session's own runtime
  pod (which already carries namespaced admin), reproducing the issue's own
  Forbidden errors and then the fix:
  ```
  --- PASS: TestProvisionerClusterRoleGrantsHelmReadinessRead (3.41s)
  confirmed pre-fix rules: create ingress => Forbidden (ingresses.networking.k8s.io is forbidden: ...)
  confirmed current rules: create+update ingress => succeeded
  --- PASS: TestProvisionerClusterRoleGrantsIngressWrite (2.04s)
  confirmed pre-fix rules: pods/exec => Forbidden (pods "..." is forbidden: ... cannot create resource "pods/exec" ...)
  confirmed current rules: pods/exec => succeeded
  --- PASS: TestProvisionerPlatformRoleGrantsPowerDNSExec (4.02s)
  ```
  All probe objects were cleaned up by the test's own `t.Cleanup`s.

## Docs

No `erun-docs` update: this is a pure bug fix restoring RBAC that provisioning
already depended on, with no new command, flag, or public-surface behavior.

## Not weakened

#1061, #1076, #1077, #1080/#1081, #1083, #1086 are all unchanged -- this PR
only adds two new rules and one new namespaced Role/RoleBinding pair; no
existing grant was touched.