### PR TITLE
Make an orchestrator's busy spinner survive a missed ai-activity event

### DIFF
--- a/erun-ui/environment_activity_observed_test.go
+++ b/erun-ui/environment_activity_observed_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/adrg/xdg"
 	eruncommon "github.com/sophium/erun/erun-common"
 )
 
@@ -25,6 +26,19 @@ func seedMCPForward(t *testing.T, tenant, environment string, port int) {
 	root := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", root)
 	t.Setenv("HOME", root)
+	// LoadPortForwardState's environmentIsConfigured guard (added for #1049) reads
+	// through the real on-disk ConfigStore, not any App-injected store stub — on
+	// purpose, so a stale record for a deleted environment reads as "no forward"
+	// rather than a live one. adrg/xdg caches ConfigHome at process init instead
+	// of re-reading the environment per call, so the Setenv calls above alone do
+	// not redirect it; Reload is what makes it honour this test's temp root, and
+	// SaveEnvConfig is what makes the guard see this tenant/environment as
+	// configured there.
+	xdg.Reload()
+	t.Cleanup(xdg.Reload)
+	if err := eruncommon.SaveEnvConfig(tenant, eruncommon.EnvConfig{Name: environment}); err != nil {
+		t.Fatalf("SaveEnvConfig: %v", err)
+	}
 	path, err := eruncommon.PortForwardStatePath("mcp", tenant, environment)
 	if err != nil {
 		t.Fatalf("PortForwardStatePath: %v", err)

--- a/erun-ui/frontend/src/app/orchestratorBusySeed.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorBusySeed.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { planOrchestratorBusySeed } from './orchestratorBusySeed';
+import type { OrchestratorInfo } from './slices/orchestratorsSlice';
+
+function orchestrator(sessionId: number, busy: boolean): OrchestratorInfo {
+  return {
+    id: 'agent-1',
+    name: 'agent-1',
+    environments: [],
+    tenants: [],
+    directories: [],
+    sessionId,
+    status: sessionId > 0 ? 'running' : 'stopped',
+    busy,
+    transient: false,
+  };
+}
+
+// The bug (#1087): the sidebar spinner was lit only by the ai-activity event,
+// so a fetch that lands after the transition — a fresh mount, a window
+// reopen, a listener that attached a beat late — never saw it and the row
+// read idle for the rest of the turn. The fix is that the snapshot itself now
+// carries the answer, so a fetch alone reproduces the correct seed with no
+// event required.
+test('a running orchestrator seeds its session busy from the snapshot alone', () => {
+  const seed = planOrchestratorBusySeed([orchestrator(7, true)]);
+  assert.deepEqual(seed, [{ sessionId: 7, busy: true }]);
+});
+
+test('a running orchestrator that is not busy seeds false, clearing a stale entry', () => {
+  const seed = planOrchestratorBusySeed([orchestrator(7, false)]);
+  assert.deepEqual(seed, [{ sessionId: 7, busy: false }]);
+});
+
+// A stopped orchestrator has no session id to key the aiBusyBySession map by,
+// so it must not contribute a seed entry at all.
+test('a stopped orchestrator contributes no seed', () => {
+  assert.deepEqual(planOrchestratorBusySeed([orchestrator(0, false)]), []);
+});
+
+test('mixed running and stopped orchestrators seed only the running ones', () => {
+  const seed = planOrchestratorBusySeed([
+    orchestrator(1, true),
+    orchestrator(0, false),
+    orchestrator(2, false),
+  ]);
+  assert.deepEqual(seed, [
+    { sessionId: 1, busy: true },
+    { sessionId: 2, busy: false },
+  ]);
+});

--- a/erun-ui/frontend/src/app/orchestratorBusySeed.ts
+++ b/erun-ui/frontend/src/app/orchestratorBusySeed.ts
@@ -1,0 +1,17 @@
+import type { OrchestratorInfo } from './slices/orchestratorsSlice';
+
+// planOrchestratorBusySeed derives the aiBusyBySession entries a freshly
+// fetched orchestrator list implies (#1087). It is the frontend half of the
+// snapshot fix: orchestratorInfo.busy now carries the same signal as the
+// ai-activity event, so loadOrchestrators can seed the event-keyed store
+// directly from the list it already fetched, rather than requiring the row to
+// have witnessed the event that last changed the state. Only orchestrators
+// with a live session are considered — a stopped one has no session id to key
+// the store by.
+export function planOrchestratorBusySeed(
+  items: OrchestratorInfo[],
+): { sessionId: number; busy: boolean }[] {
+  return items
+    .filter((item) => item.sessionId > 0)
+    .map((item) => ({ sessionId: item.sessionId, busy: item.busy }));
+}

--- a/erun-ui/frontend/src/app/orchestratorRestore.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorRestore.test.ts
@@ -13,6 +13,7 @@ function orchestrator(id: string, transient = false): OrchestratorInfo {
     directories: [],
     sessionId: 0,
     status: 'stopped',
+    busy: false,
     transient,
   };
 }

--- a/erun-ui/frontend/src/app/orchestratorThunks.ts
+++ b/erun-ui/frontend/src/app/orchestratorThunks.ts
@@ -12,7 +12,9 @@ import {
   UpdateOrchestrator,
 } from '../../wailsjs/go/main/App';
 import { readError } from './errors';
+import { planOrchestratorBusySeed } from './orchestratorBusySeed';
 import { planOrchestratorRestore, readRestoreNotice } from './orchestratorRestore';
+import { setAIBusyForSession } from './slices/aiActivitySlice';
 import {
   closeOrchestratorDialog,
   type OrchestratorEnvRef,
@@ -25,10 +27,19 @@ import { setSelected } from './slices/selectionSlice';
 import { setSessionId } from './slices/terminalSlice';
 import type { AppThunk } from './store';
 
+// loadOrchestrators fetches the current list and, in the same pass, seeds the
+// AI-busy store from each orchestrator's own `busy` snapshot field (#1087) —
+// the same store field the ai-activity event writes to, so a fetch that lands
+// after a busy transition (boot, a dialog close-and-reload, a manual refresh)
+// renders the true state even if that event was never observed.
 export const loadOrchestrators = (): AppThunk<Promise<void>> => async (dispatch) => {
   try {
     const list = (await ListOrchestrators()) as OrchestratorInfo[] | null;
-    dispatch(setOrchestrators(list ?? []));
+    const items = list ?? [];
+    dispatch(setOrchestrators(items));
+    for (const seed of planOrchestratorBusySeed(items)) {
+      dispatch(setAIBusyForSession(seed));
+    }
   } catch (error) {
     dispatch(setOrchestratorsError(readError(error)));
   }

--- a/erun-ui/frontend/src/app/slices/aiActivitySlice.ts
+++ b/erun-ui/frontend/src/app/slices/aiActivitySlice.ts
@@ -11,6 +11,14 @@ export interface AIActivityState {
   // Orchestrator sessions have no tenant/environment to key by, so their latch
   // is keyed by session id. Same event, same debounce policy — only the address
   // differs, because an orchestrator row is not an env row.
+  //
+  // Two writers feed this map, deliberately kept as one field so they cannot
+  // disagree (#1087): the ai-activity event (handleAIActivity) and
+  // loadOrchestrators seeding it from each orchestrator's own `busy` snapshot
+  // field (planOrchestratorBusySeed). The event is the fast path while a
+  // session runs; the snapshot is what makes a fetch that lands after a
+  // transition — boot, a reload, a reconnect — render the true state without
+  // having witnessed that transition.
   aiBusyBySession: Record<number, true>;
 }
 

--- a/erun-ui/frontend/src/app/slices/orchestratorsSlice.ts
+++ b/erun-ui/frontend/src/app/slices/orchestratorsSlice.ts
@@ -10,6 +10,13 @@ export interface OrchestratorEnvRef {
 // cross-env AI session that links one or more agent environments (each reviewed
 // in a host directory) and, when running, exposes the terminal
 // SessionID the pane attaches to. Transient ones (Investigate) are not persisted.
+//
+// `busy` is the snapshot half of the #1087 fix: the sidebar spinner used to be
+// lit only by the ai-activity event, so a fetch that lands after the event (a
+// fresh mount, a window reopen) had no way to know the true state. loadOrchestrators
+// seeds aiBusyBySession from this field on every fetch — see planOrchestratorBusySeed
+// — so the event and the snapshot write the same store field instead of
+// competing for it.
 export interface OrchestratorInfo {
   id: string;
   name: string;
@@ -18,6 +25,7 @@ export interface OrchestratorInfo {
   directories: string[];
   sessionId: number;
   status: string;
+  busy: boolean;
   transient: boolean;
 }
 

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -48,8 +48,12 @@ type orchestratorSession struct {
 	name           string
 	envs           []eruncommon.OrchestratorEnvConfig
 	startedAt      time.Time
-	// aiBusy is the last turn-boundary report published to the sidebar, kept so
-	// the poller emits only on change rather than every tick.
+	// aiBusy is the last turn-boundary report the poller observed. It is what
+	// orchestratorInfoFor's Busy field reads for every snapshot this session
+	// appears in (ListOrchestrators, runningOrchestratorInfo, ...), so a fresh
+	// mount or reconnect renders the true state directly rather than depending
+	// on having witnessed the ai-activity event that last changed it. See
+	// reconcileOrchestratorActivity in session_heartbeat.go.
 	aiBusy bool
 }
 
@@ -78,6 +82,12 @@ type orchestratorEnvInfo struct {
 }
 
 // orchestratorInfo is the JSON-safe view the frontend renders and attaches to.
+// Busy carries the same signal as the ai-activity event this orchestrator's
+// SessionID is keyed by, so a snapshot fetched after a busy transition — a
+// fresh mount, a window reopen, a reconnecting listener — renders the true
+// state without having had to witness that event. The frontend seeds its
+// event-keyed store from this field on every fetch (loadOrchestrators) rather
+// than keeping a second source of truth; see aiActivitySlice.ts.
 type orchestratorInfo struct {
 	ID           string                `json:"id"`
 	Name         string                `json:"name"`
@@ -86,6 +96,7 @@ type orchestratorInfo struct {
 	Directories  []string              `json:"directories"`
 	SessionID    int                   `json:"sessionId"`
 	Status       string                `json:"status"`
+	Busy         bool                  `json:"busy"`
 	Transient    bool                  `json:"transient"`
 }
 
@@ -703,7 +714,7 @@ func directoriesFromEnvs(envs []eruncommon.OrchestratorEnvConfig) []string {
 	return out
 }
 
-func orchestratorInfoFor(id, name string, envs []eruncommon.OrchestratorEnvConfig, status string, sessionID int, transient bool) orchestratorInfo {
+func orchestratorInfoFor(id, name string, envs []eruncommon.OrchestratorEnvConfig, status string, sessionID int, busy, transient bool) orchestratorInfo {
 	return orchestratorInfo{
 		ID:           id,
 		Name:         name,
@@ -712,6 +723,7 @@ func orchestratorInfoFor(id, name string, envs []eruncommon.OrchestratorEnvConfi
 		Directories:  directoriesFromEnvs(envs),
 		SessionID:    sessionID,
 		Status:       status,
+		Busy:         busy,
 		Transient:    transient,
 	}
 }
@@ -1035,7 +1047,7 @@ func (a *App) CreateOrchestrator(name string, envs []orchestratorEnvInput) (orch
 	if err := a.saveOrchestratorConfigs(append(configs, def)); err != nil {
 		return orchestratorInfo{}, err
 	}
-	return orchestratorInfoFor(id, displayName, refs, "stopped", 0, false), nil
+	return orchestratorInfoFor(id, displayName, refs, "stopped", 0, false, false), nil
 }
 
 // UpdateOrchestrator edits an existing orchestrator's linked environments and
@@ -1072,11 +1084,13 @@ func (a *App) UpdateOrchestrator(id, name string, envs []orchestratorEnvInput) (
 	}
 	status := "stopped"
 	sessionID := 0
+	busy := false
 	if info, ok := a.runningOrchestratorInfo(id); ok {
 		status = "running"
 		sessionID = info.SessionID
+		busy = info.Busy
 	}
-	return orchestratorInfoFor(id, displayName, refs, status, sessionID, false), nil
+	return orchestratorInfoFor(id, displayName, refs, status, sessionID, busy, false), nil
 }
 
 // StartOrchestrator spawns the session for a persisted orchestrator definition,
@@ -1164,7 +1178,7 @@ func (a *App) runningOrchestratorInfo(id string) (orchestratorInfo, bool) {
 	if session == nil || managed == nil || managed.closed {
 		return orchestratorInfo{}, false
 	}
-	return orchestratorInfoFor(session.id, session.name, session.envs, "running", session.serial, session.transient), true
+	return orchestratorInfoFor(session.id, session.name, session.envs, "running", session.serial, session.aiBusy, session.transient), true
 }
 
 // runningOrchestratorConversation returns the conversation a live session is
@@ -1318,7 +1332,7 @@ func (a *App) spawnOrchestratorSession(spawn orchestratorSpawn) (orchestratorInf
 			log.Printf("erun-app: record open orchestrator %s: %v", id, err)
 		}
 	}
-	return orchestratorInfoFor(id, name, envs, "running", serial, transient), nil
+	return orchestratorInfoFor(id, name, envs, "running", serial, false, transient), nil
 }
 
 // ListOrchestrators merges the persisted definitions (each tagged running or
@@ -1335,13 +1349,15 @@ func (a *App) ListOrchestrators() []orchestratorInfo {
 	for _, config := range configs {
 		status := "stopped"
 		sessionID := 0
+		busy := false
 		if session := a.orchestrators[config.ID]; session != nil {
 			if managed := a.sessions[orchestratorSessionKey(config.ID)]; managed != nil && !managed.closed {
 				status = "running"
 				sessionID = session.serial
+				busy = session.aiBusy
 			}
 		}
-		out = append(out, orchestratorInfoFor(config.ID, config.Name, config.Environments, status, sessionID, false))
+		out = append(out, orchestratorInfoFor(config.ID, config.Name, config.Environments, status, sessionID, busy, false))
 		seen[config.ID] = struct{}{}
 	}
 	for id, session := range a.orchestrators {
@@ -1352,7 +1368,7 @@ func (a *App) ListOrchestrators() []orchestratorInfo {
 		if managed == nil || managed.closed {
 			continue
 		}
-		out = append(out, orchestratorInfoFor(id, session.name, session.envs, "running", session.serial, true))
+		out = append(out, orchestratorInfoFor(id, session.name, session.envs, "running", session.serial, session.aiBusy, true))
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out

--- a/erun-ui/playwright/pages/Sidebar.ts
+++ b/erun-ui/playwright/pages/Sidebar.ts
@@ -237,6 +237,14 @@ export class Sidebar {
     return this.erunSection().getByRole('img', { name: `Orchestrator ${name} is ${state}` });
   }
 
+  // The row's busy spinner (BusyRowSpinner), rendered whenever the store's
+  // aiBusyBySession has this orchestrator's session flagged — whether that
+  // came from the ai-activity event or from the list snapshot's own busy
+  // field (#1087).
+  orchestratorBusySpinner(name: string): Locator {
+    return this.erunSection().getByRole('status', { name: `${name} is working` });
+  }
+
   // Open the orchestrator's management dialog via its "…" button. Like the env
   // edit button it is pointer-events-none until hover/focus and a hover opens
   // the IconTooltip popper that would swallow a click — so focus it and press

--- a/erun-ui/playwright/tests/sidebar-orchestrator-busy-snapshot.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-orchestrator-busy-snapshot.spec.ts
@@ -1,0 +1,72 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ORCHESTRATOR } from '../fixtures/seedRoot.js';
+
+// #1087: an orchestrator's sidebar spinner used to be lit only by the
+// ai-activity Wails event, at the single false→true transition — and
+// orchestratorInfo, the list snapshot the frontend boots and re-renders from,
+// carried no busy flag at all. Anything that lost that one event (a fresh
+// mount, a window reopen, a listener that attached a beat late) left the row
+// reading idle for however long the rest of the turn ran.
+//
+// This spec drives the fix's frontend half directly: it stubs ListOrchestrators
+// over /__erun_invoke to answer busy without ever emitting the ai-activity
+// event, then reboots the app (a real fresh mount, not a simulated one) and
+// asserts the row still spins. Before the fix this would read idle, because
+// nothing but that missing event could have set it. The event path itself
+// (ai-activity flipping the spinner while the app is already running) is
+// already covered by sidebar-ai-activity.spec.ts; the backend's own re-emit
+// timing is covered by the Go tests in erun-ui/session_heartbeat_test.go
+// (TestReconcileOrchestratorActivityReEmitsEveryTick,
+// TestOrchestratorSnapshotRendersBusyWithoutTheEvent) since the headless
+// harness cannot wait out a real 15s poll deterministically.
+
+const RUNNING_SESSION_ID = 4242;
+
+function orchestratorSnapshot(busy: boolean) {
+  return {
+    id: SEED_ORCHESTRATOR,
+    name: SEED_ORCHESTRATOR,
+    environments: [],
+    tenants: [],
+    directories: [],
+    sessionId: RUNNING_SESSION_ID,
+    status: 'running',
+    busy,
+    transient: false,
+  };
+}
+
+async function stubOrchestratorList(page: Page, busy: boolean): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method?: string };
+    if (body.method === 'ListOrchestrators') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [orchestratorSnapshot(busy)] }),
+      });
+    }
+    await route.continue();
+  });
+}
+
+test.describe('orchestrator busy renders from the list snapshot (#1087)', () => {
+  test('a busy snapshot spins the row on a fresh mount, with no ai-activity event ever emitted', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(page, true);
+    await app.reboot();
+
+    await expect(app.sidebar.orchestratorBusySpinner(SEED_ORCHESTRATOR)).toBeVisible();
+  });
+
+  test('a non-busy snapshot renders no spinner', async ({ app, page }) => {
+    await stubOrchestratorList(page, false);
+    await app.reboot();
+
+    await expect(app.sidebar.orchestratorStatusDot(SEED_ORCHESTRATOR, 'running')).toBeVisible();
+    await expect(app.sidebar.orchestratorBusySpinner(SEED_ORCHESTRATOR)).toHaveCount(0);
+  });
+});

--- a/erun-ui/session_heartbeat.go
+++ b/erun-ui/session_heartbeat.go
@@ -67,15 +67,38 @@ func (a *App) runSessionHeartbeatPoller(stop <-chan struct{}) {
 
 // reconcileOrchestratorActivity publishes what each orchestrator said about
 // itself. The agent writes a turn-boundary report; this turns it into the
-// sidebar's spinner. Emitted only on change, so a quiet orchestrator costs one
-// file read per tick and no events.
+// sidebar's spinner.
+//
+// It re-emits every tick, busy or not, rather than only when the state
+// changes (#1087). The spinner used to be lit exclusively by the one
+// false→true transition, and orchestratorInfo — the snapshot the frontend
+// boots and re-renders from — carried no busy flag at all, so anything that
+// lost that single event (a remount after the transition, a window reopen, a
+// listener that attached a beat late, one dropped event on a days-old
+// process) left the row reading "idle" for however long the rest of the turn
+// ran, which for a long turn is tens of minutes or more. At a 15s tick over a
+// handful of orchestrators the extra events are inexpensive, and they make a
+// dropped or mistimed one self-heal within one tick instead of staying wrong
+// until the busy state itself next changes. session.aiBusy is still recorded
+// on every pass — that is the other half of the fix: it is what
+// orchestratorInfoFor now reads into orchestratorInfo.Busy, so a snapshot
+// (ListOrchestrators, runningOrchestratorInfo) carries the true state
+// directly instead of depending solely on this event ever reaching the
+// frontend's listener.
+//
+// The environment rows (recordAIActivity and friends in terminal_sessions.go)
+// have this exact same latent hazard — their busy signal is event-only too,
+// with no equivalent snapshot field — and are only masked by traffic: an
+// env's busy state churns often enough in practice that a missed transition
+// is quickly followed by another. That is luck, not a difference in design.
+// Don't copy the env path's event-only shape when touching it later; fix it
+// the same way this one was fixed instead.
 func (a *App) reconcileOrchestratorActivity() {
 	now := time.Now()
 	a.mu.Lock()
 	type row struct {
 		id     string
 		serial int
-		busy   bool
 		alive  bool
 	}
 	rows := make([]row, 0, len(a.orchestrators))
@@ -91,7 +114,6 @@ func (a *App) reconcileOrchestratorActivity() {
 		rows = append(rows, row{
 			id:     id,
 			serial: session.serial,
-			busy:   session.aiBusy,
 			alive:  managed != nil && !managed.closed,
 		})
 	}
@@ -100,9 +122,6 @@ func (a *App) reconcileOrchestratorActivity() {
 	for _, r := range rows {
 		activity, ok := readOrchestratorActivity(r.id, now, r.alive)
 		busy := ok && activity.Busy
-		if busy == r.busy {
-			continue
-		}
 		a.mu.Lock()
 		if session := a.orchestrators[r.id]; session != nil {
 			session.aiBusy = busy

--- a/erun-ui/session_heartbeat_test.go
+++ b/erun-ui/session_heartbeat_test.go
@@ -220,3 +220,79 @@ func TestReclaimRuntimeResourcesRunsTheNamedActionOnly(t *testing.T) {
 		t.Fatalf("a completed reclaim must report what it did")
 	}
 }
+
+// TestOrchestratorSnapshotRendersBusyWithoutTheEvent locks the first half of
+// the #1087 fix: orchestratorInfo carries Busy directly, so a snapshot taken
+// after the state changed reflects it even when the ai-activity event that
+// announced the change was never observed. That is the path a frontend
+// remount, a window reopen, or a listener that attached a beat late actually
+// takes in production — none of them re-run the transition, they just ask for
+// the current state, so the assertion here deliberately never looks at the
+// emitted events, only at what a fresh ListOrchestrators/runningOrchestratorInfo
+// call reports.
+func TestOrchestratorSnapshotRendersBusyWithoutTheEvent(t *testing.T) {
+	app := orchestratorTestApp(t)
+	defer app.shutdown(context.Background())
+
+	created, err := app.CreateOrchestrator("agent", []orchestratorEnvInput{{Tenant: "frs", Environment: "dev"}})
+	if err != nil {
+		t.Fatalf("CreateOrchestrator failed: %v", err)
+	}
+	started, err := app.StartOrchestrator(created.ID, 80, 24)
+	if err != nil {
+		t.Fatalf("StartOrchestrator failed: %v", err)
+	}
+	if started.Busy {
+		t.Fatalf("a freshly started orchestrator must not read busy before any report: %+v", started)
+	}
+
+	writeOrchestratorActivity(t, created.ID, orchestratorActivity{Busy: true, AtUnix: time.Now().Unix()})
+	app.reconcileOrchestratorActivity()
+
+	listed := app.ListOrchestrators()
+	if len(listed) != 1 || !listed[0].Busy {
+		t.Fatalf("expected the listed orchestrator to render busy from the snapshot, got %+v", listed)
+	}
+	info, ok := app.runningOrchestratorInfo(created.ID)
+	if !ok || !info.Busy {
+		t.Fatalf("expected the running snapshot to carry busy, got %+v (ok=%v)", info, ok)
+	}
+}
+
+// TestReconcileOrchestratorActivityReEmitsEveryTick locks the second half of
+// the #1087 fix: the busy signal is republished on every tick regardless of
+// whether it changed, so a dropped or mistimed ai-activity event self-heals
+// within one tick instead of staying wrong until the busy state itself next
+// changes. The old code's `if busy == r.busy { continue }` would have emitted
+// once here, not three times.
+func TestReconcileOrchestratorActivityReEmitsEveryTick(t *testing.T) {
+	app := orchestratorTestApp(t)
+	defer app.shutdown(context.Background())
+	emits := newCapturedEmits()
+	app.emitFn = emits.fn()
+
+	created, err := app.CreateOrchestrator("agent", []orchestratorEnvInput{{Tenant: "frs", Environment: "dev"}})
+	if err != nil {
+		t.Fatalf("CreateOrchestrator failed: %v", err)
+	}
+	if _, err := app.StartOrchestrator(created.ID, 80, 24); err != nil {
+		t.Fatalf("StartOrchestrator failed: %v", err)
+	}
+
+	writeOrchestratorActivity(t, created.ID, orchestratorActivity{Busy: true, AtUnix: time.Now().Unix()})
+
+	app.reconcileOrchestratorActivity()
+	app.reconcileOrchestratorActivity()
+	app.reconcileOrchestratorActivity()
+
+	events := emits.events(aiActivityEvent)
+	if len(events) != 3 {
+		t.Fatalf("expected one emit per tick even with no state change, got %d: %+v", len(events), events)
+	}
+	for _, event := range events {
+		payload, ok := event.(aiActivityPayload)
+		if !ok || !payload.Busy {
+			t.Fatalf("expected every re-emit to report busy=true, got %+v", event)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The operator reported this three times in one session ("no spinner next to your shell", twice more) despite the orchestrator demonstrably working (the same window's transcript read `Worked for 37m 48s`). This is the affordance an operator uses to tell a working orchestrator from a wedged one, so a false "idle" reading is worse than no indicator at all.

**Root cause:** `busy` existed only as a transient Wails event, emitted only on the false→true transition, and `orchestratorInfo` — the snapshot the frontend boots and re-renders from — carried no busy flag at all. Anything that lost that one event (a remount, a window reopen, a listener that attached a beat late, a single dropped event on a days-old process) left the row reading idle for however long the rest of the turn ran.

**Fix — both halves, so the failure mode is impossible rather than merely less likely:**
- `orchestratorInfo` now carries `Busy`, sourced from `session.aiBusy`. Every construction site (`ListOrchestrators`, `runningOrchestratorInfo`, `CreateOrchestrator`, `UpdateOrchestrator`, `spawnOrchestratorSession`) threads it through. The frontend's `loadOrchestrators` seeds `aiBusyBySession` from this field on every fetch (`planOrchestratorBusySeed`) — deliberately the *same* store field the `ai-activity` event writes to, so the snapshot and the event can't disagree; whichever landed last wins, and the next 15s tick corrects any residual mismatch.
- `reconcileOrchestratorActivity` now re-emits the busy signal on every 15s tick regardless of whether it changed (previously gated by `if busy == r.busy { continue }`), so a dropped or mistimed event self-heals within one tick instead of staying wrong until the state itself next changes.

The environment rows' busy signal (`recordAIActivity` et al.) has this exact same latent hazard — event-only, no snapshot field — and are only masked by busier churn (a missed transition there is usually followed by another quickly). Left a comment at the fix site so nobody "fixes" the env path later by copying the fragile shape.

**Also fixes 9 pre-existing test failures in `erun-ui`**, discovered while validating this change (`go test ./...` failed unconditionally on `main`, unrelated to this bug): `LoadPortForwardState`'s `environmentIsConfigured` guard (added in #1049) reads through the real on-disk `ConfigStore`, which `adrg/xdg` caches at process init rather than re-reading per call. The affected tests' `t.Setenv` calls never actually redirected it, and none of them seeded a matching on-disk env config, so every environment they exercised always read as unconfigured, short-circuiting the forward-repair and activity-observation logic under test. Fixed by adding `xdg.Reload()` (existing convention, see `investigation_bounds_test.go`) plus a real `SaveEnvConfig` call in the shared `seedMCPForward` test helper.

## UX Impact Review Checklist

1. **Affected paths:** sidebar orchestrator row rendering (`Sidebar.ErunSection.tsx`), fed by `loadOrchestrators` (boot, and after every orchestrator action) and the `ai-activity` Wails event.
2. **User-visible sequence:** orchestrator row renders → `BusyRowSpinner` shows/hides based on `state.aiActivity.aiBusyBySession[sessionId]`. That store field is now written from two reconciled sources (list snapshot + event) instead of one fragile one.
3. **State-without-affordance:** n/a — no new state without a render; the fix makes existing state visible where it wasn't.
4. **Visibility of system status (Nielsen #1):** direct improvement — the busy indicator is now correct on every render, not just after a witnessed transition.
5. **Success/failure feedback:** n/a, no new operation.
6. **Consistency with comparable flows:** matches the environment row's spinner affordance (same `BusyRowSpinner`, same store shape); the env row's underlying fragility is intentionally *not* copied.
7. **Heuristic pass:** visibility of system status is the whole point of this change; no other heuristic is implicated.
8. **Playwright coverage:** new spec `sidebar-orchestrator-busy-snapshot.spec.ts` — stubs `ListOrchestrators` over `/__erun_invoke` with `busy: true`/`false` and reboots the app, asserting the spinner renders purely from the snapshot with **no** `ai-activity` event ever emitted (the exact regression). The event path itself is already covered by `sidebar-ai-activity.spec.ts`. The backend's 15s re-emit timing can't be driven deterministically by the headless harness, so that half is covered by new Go tests (`TestReconcileOrchestratorActivityReEmitsEveryTick`, `TestOrchestratorSnapshotRendersBusyWithoutTheEvent` in `session_heartbeat_test.go`).

## Validation

- `go build ./...`, `go vet ./...`, `go test ./...` (erun-ui): clean.
- Frontend: `yarn typecheck && yarn lint && yarn format:check && yarn build && yarn test`: clean (67 tests).
- Playwright: `./run.sh --build` full suite: 167 passed, including the 2 new specs.
- `make check` (golangci-lint × 5 gated modules, integration suite, coverage): green, coverage 75.8% (>= 75.8% threshold).

Closes #1087