### PR TITLE
Restore every orchestrator that was open, not just one

### DIFF
--- a/erun-ui/app_restart.go
+++ b/erun-ui/app_restart.go
@@ -69,14 +69,20 @@ type orchestratorRestoreState struct {
 	ResumePrompt string `json:"resumePrompt,omitempty"`
 }
 
-// relaunchTarget is the JSON-safe view the frontend reads on boot: which
-// orchestrator to reopen, which of its conversations, the prompt to auto-run on
-// resume, and — when the hand-off was refused — why nothing is being continued.
+// relaunchTarget is the JSON-safe view the frontend reads on boot. OrchestratorID
+// is the one this launch resumes and that OWNS THE TERMINAL PANE — the pane is
+// single, so exactly one orchestrator gets it. AlsoReopen lists every other
+// orchestrator that was open and comes back too, started idle alongside it with
+// no conversation named and no prompt: only the pane-owning orchestrator can
+// carry a resume prompt, by construction, because ConversationID/ResumePrompt
+// are fields of this one target, not of each id in AlsoReopen. Notice explains,
+// when non-empty, why the pane owner is not continuing a task it asked to.
 type relaunchTarget struct {
-	OrchestratorID string `json:"orchestratorId"`
-	ConversationID string `json:"conversationId"`
-	ResumePrompt   string `json:"resumePrompt"`
-	Notice         string `json:"notice"`
+	OrchestratorID string   `json:"orchestratorId"`
+	ConversationID string   `json:"conversationId"`
+	ResumePrompt   string   `json:"resumePrompt"`
+	AlsoReopen     []string `json:"alsoReopen,omitempty"`
+	Notice         string   `json:"notice"`
 }
 
 // defaultOrchestratorRestoreDir is the directory beside window-state.json under
@@ -196,31 +202,53 @@ func readAndClearOrchestratorRestoreTarget(path string) (orchestratorRestoreStat
 	return state, true
 }
 
-// ResolveOrchestratorToReopen returns the orchestrator this launch should reopen,
-// which of its conversations, and any prompt to auto-run on resume. The frontend
-// calls it on boot (after loading the orchestrator list) and, if the id still
-// resolves to a persisted orchestrator, starts it — resuming the named
-// conversation, or that orchestrator's own pinned one when none is named, so the
-// operator lands back where they were.
+// ResolveOrchestratorToReopen returns every orchestrator this launch should
+// reopen: one that OWNS THE TERMINAL PANE (OrchestratorID), plus any others that
+// were open too (AlsoReopen). The frontend calls it on boot (after loading the
+// orchestrator list); for each id that still resolves to a persisted
+// orchestrator it starts a session, resuming that orchestrator's own pinned
+// conversation — except the pane owner, which resumes the named conversation
+// when the hand-off supplies one — so the operator lands back where they were,
+// with everything else they had open still running behind it.
 //
-// A pending restart hand-off wins: it is the more specific intent and the only
-// source of a resume prompt, and it is consumed as it is read so it fires once.
-// Otherwise the durable record of what was open answers, carrying no prompt — so
-// a plain quit-and-relaunch, a crash or a reboot comes back to the same
-// orchestrator, idle at its prompt with nothing auto-run.
+// Which orchestrator owns the pane is answered in one of two ways:
 //
-// A hand-off that cannot be honored still reopens the orchestrator; it just
-// arrives idle, carrying the notice that says why nothing was continued. So does
-// a hand-off from an orchestrator this launch does not reopen at all: only one
-// orchestrator owns the pane, and the ones left mid-task are named in the same
-// notice rather than dropped.
+//   - A pending restart hand-off wins outright: it names the exact orchestrator
+//     the operator just restarted from, it is the only source of a resume
+//     prompt, and it is consumed as it is read so it fires once. A hand-off that
+//     cannot be honored still makes that orchestrator the pane owner; it just
+//     arrives idle, carrying the notice that says why nothing was continued. A
+//     hand-off from an orchestrator this launch does not choose as pane owner at
+//     all (a second restart racing the first) is named in the same notice
+//     instead — it still comes back, but via AlsoReopen, not as the owner.
+//   - Otherwise the durable record of what was open decides: the most recently
+//     (re)started orchestrator owns the pane (see orchestrator_open_state.go for
+//     why the record keeps that order), and it carries no prompt — so a plain
+//     quit-and-relaunch, a crash or a reboot comes back to the same session,
+//     idle, with nothing auto-run.
+//
+// Every other orchestrator the durable record names — everyone but the pane
+// owner — is returned in AlsoReopen and comes back too, idle, so the tab strip
+// and the live sessions agree instead of a tab surviving with no session behind
+// it.
 func (a *App) ResolveOrchestratorToReopen() relaunchTarget {
 	state, notReopened := consumeOrchestratorRestoreTargets(a.deps.orchestratorRestoreDir, time.Now())
 	notice := orchestratorHandoffsNotReopenedNotice(notReopened)
+	openIDs := readOpenOrchestrators(a.deps.orchestratorOpenPath)
+
 	if state.OrchestratorID == "" {
-		return relaunchTarget{OrchestratorID: readOpenOrchestrator(a.deps.orchestratorOpenPath), Notice: notice}
+		if len(openIDs) == 0 {
+			return relaunchTarget{Notice: notice}
+		}
+		owner := openIDs[len(openIDs)-1]
+		return relaunchTarget{OrchestratorID: owner, AlsoReopen: removeOrchestratorID(openIDs, owner), Notice: notice}
 	}
-	target := relaunchTarget{OrchestratorID: state.OrchestratorID, Notice: notice}
+
+	target := relaunchTarget{
+		OrchestratorID: state.OrchestratorID,
+		AlsoReopen:     removeOrchestratorID(openIDs, state.OrchestratorID),
+		Notice:         notice,
+	}
 	if state.ResumePrompt == "" {
 		return target
 	}
@@ -231,6 +259,20 @@ func (a *App) ResolveOrchestratorToReopen() relaunchTarget {
 	target.ConversationID = state.ConversationID
 	target.ResumePrompt = state.ResumePrompt
 	return target
+}
+
+// removeOrchestratorID returns ids without id, preserving order.
+func removeOrchestratorID(ids []string, id string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(ids))
+	for _, existing := range ids {
+		if existing != id {
+			out = append(out, existing)
+		}
+	}
+	return out
 }
 
 // orchestratorHandoffsNotReopenedNotice names the orchestrators that restarted

--- a/erun-ui/frontend/src/app/bootThunks.ts
+++ b/erun-ui/frontend/src/app/bootThunks.ts
@@ -1,7 +1,7 @@
 import { stateApi } from './api/stateApi';
 import { readError } from './errors';
 import { showTerminalMessage } from './notificationThunks';
-import { loadOrchestrators, restoreOpenOrchestrator } from './orchestratorThunks';
+import { loadOrchestrators, restoreOpenOrchestrators } from './orchestratorThunks';
 import { openSelection } from './sessionThunks';
 import { setSelected } from './slices/selectionSlice';
 import {
@@ -38,12 +38,12 @@ export const boot = (): AppThunk<Promise<void>> => async (dispatch, getState) =>
       return;
     }
 
-    // The orchestrator that was open when the desktop last ran — or the one a
-    // rebuild+restart handed off — is where the operator left off, and it owns
-    // the pane, so honor it before — and instead of — the default environment
-    // selection.
+    // Every orchestrator that was open when the desktop last ran — plus the one
+    // a rebuild+restart handed off, if any — is where the operator left off, so
+    // honor all of it before — and instead of — the default environment
+    // selection. One of them ends up owning the pane; the rest come back idle.
     await dispatch(loadOrchestrators());
-    if (await dispatch(restoreOpenOrchestrator())) {
+    if (await dispatch(restoreOpenOrchestrators())) {
       return;
     }
 

--- a/erun-ui/frontend/src/app/orchestratorRestore.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorRestore.test.ts
@@ -18,62 +18,135 @@ function orchestrator(id: string, transient = false): OrchestratorInfo {
   };
 }
 
-const persisted = [orchestrator('agent-1')];
+const persisted = [orchestrator('agent-1'), orchestrator('agent-2')];
 
 // The defect: a plain quit-and-relaunch had no target at all, so boot fell
 // through to the default environment selection. The durable record now answers,
 // and it answers without a prompt — the launch resumes idle.
 test('a plain launch reopens the orchestrator that was open, running nothing', () => {
-  const plan = planOrchestratorRestore({ orchestratorId: 'agent-1', resumePrompt: '' }, persisted);
-  assert.deepEqual(plan, { id: 'agent-1', conversationId: '', resumePrompt: '' });
+  const outcome = planOrchestratorRestore(
+    { orchestratorId: 'agent-1', resumePrompt: '' },
+    persisted,
+  );
+  assert.deepEqual(outcome, {
+    primary: { id: 'agent-1', conversationId: '', resumePrompt: '' },
+    alsoReopen: [],
+  });
+});
+
+// The bug this issue fixes: the durable record was a scalar, so only one
+// orchestrator ever came back. Every id in alsoReopen must be restored too.
+test('every orchestrator that was open is restored, not just the pane owner', () => {
+  const outcome = planOrchestratorRestore(
+    { orchestratorId: 'agent-2', resumePrompt: '', alsoReopen: ['agent-1'] },
+    persisted,
+  );
+  assert.deepEqual(outcome, {
+    primary: { id: 'agent-2', conversationId: '', resumePrompt: '' },
+    alsoReopen: ['agent-1'],
+  });
 });
 
 // The hand-off names the conversation that asked for the restart, not just the
 // orchestrator it belongs to: an id is reusable, so several conversations answer
 // to it and continuing the wrong one wakes a session in a scope it never had.
+// Only the pane owner can carry it — alsoReopen ids are always idle.
 test('a restart hand-off carries the conversation and the prompt it auto-runs', () => {
-  const plan = planOrchestratorRestore(
-    { orchestratorId: 'agent-1', conversationId: 'conv-1', resumePrompt: 'finish the task' },
+  const outcome = planOrchestratorRestore(
+    {
+      orchestratorId: 'agent-1',
+      conversationId: 'conv-1',
+      resumePrompt: 'finish the task',
+      alsoReopen: ['agent-2'],
+    },
     persisted,
   );
-  assert.deepEqual(plan, {
-    id: 'agent-1',
-    conversationId: 'conv-1',
-    resumePrompt: 'finish the task',
+  assert.deepEqual(outcome, {
+    primary: { id: 'agent-1', conversationId: 'conv-1', resumePrompt: 'finish the task' },
+    alsoReopen: ['agent-2'],
   });
 });
 
 test('nothing to reopen leaves boot on the default environment selection', () => {
-  assert.equal(planOrchestratorRestore({ orchestratorId: '' }, persisted), null);
-  assert.equal(planOrchestratorRestore(null, persisted), null);
-  assert.equal(planOrchestratorRestore(undefined, persisted), null);
-  assert.equal(planOrchestratorRestore({ orchestratorId: '   ' }, persisted), null);
+  assert.deepEqual(planOrchestratorRestore({ orchestratorId: '' }, persisted), {
+    primary: null,
+    alsoReopen: [],
+  });
+  assert.deepEqual(planOrchestratorRestore(null, persisted), { primary: null, alsoReopen: [] });
+  assert.deepEqual(planOrchestratorRestore(undefined, persisted), {
+    primary: null,
+    alsoReopen: [],
+  });
+  assert.deepEqual(planOrchestratorRestore({ orchestratorId: '   ' }, persisted), {
+    primary: null,
+    alsoReopen: [],
+  });
 });
 
-// An orchestrator deleted since the record was written has no definition to
-// resume, so the launch must not try to start it.
-test('a target that no longer exists restores nothing', () => {
-  assert.equal(planOrchestratorRestore({ orchestratorId: 'agent-gone' }, persisted), null);
-});
-
-// Investigate sessions are not persisted, so they are never reopened.
-test('a transient orchestrator is never restored', () => {
-  assert.equal(
-    planOrchestratorRestore({ orchestratorId: 'investigate-1' }, [
-      orchestrator('investigate-1', true),
-    ]),
-    null,
+// A pane owner deleted since the record was written cannot be reopened, but the
+// rest of the set is not thrown away with it — the next most-recently-opened
+// survivor takes the pane instead.
+test('a pane owner that no longer exists is dropped and a survivor is promoted', () => {
+  const outcome = planOrchestratorRestore(
+    { orchestratorId: 'agent-gone', alsoReopen: ['agent-1', 'agent-2'] },
+    persisted,
   );
+  assert.deepEqual(outcome, {
+    primary: { id: 'agent-2', conversationId: '', resumePrompt: '' },
+    alsoReopen: ['agent-1'],
+  });
+});
+
+// When nothing in the whole set survives, boot has nothing to fall back to but
+// the default environment selection.
+test('a target that no longer exists anywhere restores nothing', () => {
+  assert.deepEqual(planOrchestratorRestore({ orchestratorId: 'agent-gone' }, persisted), {
+    primary: null,
+    alsoReopen: [],
+  });
+});
+
+// Investigate sessions are not persisted, so they are never reopened, whether
+// named as the pane owner or listed in alsoReopen.
+test('a transient orchestrator is never restored', () => {
+  const transientOnly = [orchestrator('investigate-1', true)];
+  assert.deepEqual(planOrchestratorRestore({ orchestratorId: 'investigate-1' }, transientOnly), {
+    primary: null,
+    alsoReopen: [],
+  });
+  assert.deepEqual(
+    planOrchestratorRestore({ orchestratorId: 'agent-1', alsoReopen: ['investigate-1'] }, [
+      ...persisted,
+      ...transientOnly,
+    ]),
+    { primary: { id: 'agent-1', conversationId: '', resumePrompt: '' }, alsoReopen: [] },
+  );
+});
+
+// A duplicate or an id that also happens to be the pane owner must not spawn a
+// second session for the same orchestrator.
+test('alsoReopen drops duplicates and the pane owner itself', () => {
+  const outcome = planOrchestratorRestore(
+    { orchestratorId: 'agent-1', alsoReopen: ['agent-1', 'agent-2', 'agent-2'] },
+    persisted,
+  );
+  assert.deepEqual(outcome, {
+    primary: { id: 'agent-1', conversationId: '', resumePrompt: '' },
+    alsoReopen: ['agent-2'],
+  });
 });
 
 // A prompt that is only whitespace is no prompt: it must not push the launch
 // down the auto-run branch.
 test('a whitespace-only resume prompt resumes idle', () => {
-  const plan = planOrchestratorRestore(
+  const outcome = planOrchestratorRestore(
     { orchestratorId: 'agent-1', resumePrompt: '  \n ' },
     persisted,
   );
-  assert.deepEqual(plan, { id: 'agent-1', conversationId: '', resumePrompt: '' });
+  assert.deepEqual(outcome, {
+    primary: { id: 'agent-1', conversationId: '', resumePrompt: '' },
+    alsoReopen: [],
+  });
 });
 
 // The target crosses a process boundary, so a payload without the field must

--- a/erun-ui/frontend/src/app/orchestratorRestore.ts
+++ b/erun-ui/frontend/src/app/orchestratorRestore.ts
@@ -1,30 +1,37 @@
 import type { OrchestratorInfo } from './slices/orchestratorsSlice';
 
-// What the backend answers when boot asks which orchestrator to reopen: the one
-// that was open when the desktop last ran, or the one a restart handed off —
-// only the hand-off names a conversation and carries a prompt to auto-run. A
-// notice means the hand-off was refused: the orchestrator still reopens, idle,
-// and the notice says why nothing is being continued.
+// What the backend answers when boot asks which orchestrators to reopen:
+// orchestratorId is the one that OWNS THE TERMINAL PANE — the pane is single,
+// so exactly one orchestrator gets it — and alsoReopen lists every other
+// orchestrator that was open too, restored alongside it but idle. Only the
+// pane owner can carry a conversation/prompt to resume; that is why those
+// fields live on the target itself rather than per id in alsoReopen. A notice
+// means a hand-off was refused: the pane owner still reopens, idle, and the
+// notice says why nothing is being continued.
 export interface OrchestratorReopenTarget {
   orchestratorId?: string;
   conversationId?: string;
   resumePrompt?: string;
+  alsoReopen?: string[];
   notice?: string;
 }
 
-// How boot should reopen an orchestrator: which one, which of its conversations,
-// and whether that conversation is handed a task on resume.
+// How boot should reopen one orchestrator: which one, which of its
+// conversations, and whether that conversation is handed a task on resume.
 export interface OrchestratorRestorePlan {
   id: string;
   conversationId: string;
   resumePrompt: string;
 }
 
-// planOrchestratorRestore decides what a launch actually restores, given the
-// target and the definitions that exist right now. A target naming an
-// orchestrator that has since been deleted restores nothing, and neither does a
-// transient (Investigate) session, which has no definition to resume — in both
-// cases boot falls through to the default environment selection instead.
+// OrchestratorRestoreOutcome is what a launch actually restores: the
+// orchestrator that ends up owning the pane (or null if there is nothing valid
+// to reopen), and every other orchestrator that comes back idle beside it.
+export interface OrchestratorRestoreOutcome {
+  primary: OrchestratorRestorePlan | null;
+  alsoReopen: string[];
+}
+
 const trimmed = (value: string | undefined): string => value?.trim() ?? '';
 
 // readRestoreNotice is the refusal the backend attached to the target, if any.
@@ -35,21 +42,57 @@ export function readRestoreNotice(target: OrchestratorReopenTarget | null | unde
   return trimmed(target?.notice);
 }
 
+// planOrchestratorRestore decides what a launch actually restores, given the
+// target and the definitions that exist right now. A candidate naming an
+// orchestrator that has since been deleted restores nothing for that
+// candidate, and neither does a transient (Investigate) session, which has no
+// definition to resume — both are dropped rather than starting a session for
+// an id that cannot come back.
+//
+// If the backend's chosen pane owner cannot be honored this way (deleted
+// between shutdown and this launch), the next most-recently-opened surviving
+// orchestrator takes the pane instead — the same recency rule the backend used
+// to pick a pane owner, just re-applied to the ones still around — rather than
+// silently dropping to the default environment selection while other
+// orchestrators still start up in the background. Only when nothing in the
+// whole set survives does boot fall through to that default.
 export function planOrchestratorRestore(
   target: OrchestratorReopenTarget | null | undefined,
   orchestrators: readonly OrchestratorInfo[],
-): OrchestratorRestorePlan | null {
+): OrchestratorRestoreOutcome {
   const source: OrchestratorReopenTarget = target ?? {};
-  const id = trimmed(source.orchestratorId);
-  if (!id) {
-    return null;
+  const exists = (id: string): boolean =>
+    orchestrators.some((orchestrator) => orchestrator.id === id && !orchestrator.transient);
+
+  const primaryID = trimmed(source.orchestratorId);
+  const seen = new Set<string>();
+  const survivingAlso = (source.alsoReopen ?? []).reduce<string[]>((kept, raw) => {
+    const id = trimmed(raw);
+    if (id === '' || id === primaryID || seen.has(id) || !exists(id)) {
+      return kept;
+    }
+    seen.add(id);
+    kept.push(id);
+    return kept;
+  }, []);
+
+  if (primaryID && exists(primaryID)) {
+    return {
+      primary: {
+        id: primaryID,
+        conversationId: trimmed(source.conversationId),
+        resumePrompt: trimmed(source.resumePrompt),
+      },
+      alsoReopen: survivingAlso,
+    };
   }
-  if (!orchestrators.some((orchestrator) => orchestrator.id === id && !orchestrator.transient)) {
-    return null;
+  const rest = [...survivingAlso];
+  const promoted = rest.pop();
+  if (promoted === undefined) {
+    return { primary: null, alsoReopen: [] };
   }
   return {
-    id,
-    conversationId: trimmed(source.conversationId),
-    resumePrompt: trimmed(source.resumePrompt),
+    primary: { id: promoted, conversationId: '', resumePrompt: '' },
+    alsoReopen: rest,
   };
 }

--- a/erun-ui/frontend/src/app/orchestratorThunks.ts
+++ b/erun-ui/frontend/src/app/orchestratorThunks.ts
@@ -130,18 +130,24 @@ export const restartApp =
     }
   };
 
-// restoreOpenOrchestrator reopens the orchestrator this launch should come back
-// to — the one that was open when the desktop last ran, or the one a restart
-// handed off — and returns whether it did, so the caller (boot) can skip the
-// default environment selection. Only a restart hand-off carries a resume
-// prompt, so a plain launch resumes the conversation idle and auto-runs nothing.
-// A refused hand-off still reopens the orchestrator and surfaces the backend's
-// notice beside the orchestrator list, so a resume that declined to continue is
-// never silent. The restored orchestrator OWNS the pane, so the env selection is
-// cleared — otherwise boot's default selection and the selection-sync middleware
-// reconcile the terminal back to an environment and the operator never lands in
-// the resumed session.
-export const restoreOpenOrchestrator =
+// restoreOpenOrchestrators reopens every orchestrator this launch should come
+// back to — everything that was open when the desktop last ran, or a restart's
+// hand-off plus everything else that was open alongside it — and returns
+// whether one of them ended up owning the terminal pane, so the caller (boot)
+// can skip the default environment selection. The pane is single but the
+// restored set is not: exactly one orchestrator (the restart hand-off's target,
+// or the most recently (re)started one) owns it, resumes its conversation and
+// clears the env selection — otherwise boot's default selection and the
+// selection-sync middleware would reconcile the terminal back to an
+// environment — while every other orchestrator in the set is started too but
+// left idle, off the pane, so the tab strip and the live sessions agree instead
+// of a tab surviving with no session behind it. Only the pane owner can carry a
+// resume prompt, so a plain launch resumes every restored orchestrator idle; a
+// restart hand-off's prompt auto-runs for the one orchestrator it named, never
+// for the rest of the set. A refused hand-off still reopens its orchestrator
+// and surfaces the backend's notice beside the orchestrator list, so a resume
+// that declined to continue is never silent.
+export const restoreOpenOrchestrators =
   (): AppThunk<Promise<boolean>> => async (dispatch, getState) => {
     try {
       const target = await ResolveOrchestratorToReopen();
@@ -149,21 +155,43 @@ export const restoreOpenOrchestrator =
       if (notice) {
         dispatch(setOrchestratorsError(notice));
       }
-      const plan = planOrchestratorRestore(target, getState().orchestrators.items);
-      if (!plan) {
+      const { primary, alsoReopen } = planOrchestratorRestore(
+        target,
+        getState().orchestrators.items,
+      );
+      if (!primary && alsoReopen.length === 0) {
         return false;
       }
-      // With a resume prompt, resume the conversation that asked for the restart
-      // AND hand it the task so a rebuild+restart continues on its own instead of
-      // idling at the prompt; without one, just resume the orchestrator's own
-      // pinned conversation.
-      const info = plan.resumePrompt
-        ? await StartOrchestratorWithResume(plan.id, plan.conversationId, plan.resumePrompt, 80, 24)
-        : await StartOrchestrator(plan.id, 80, 24);
-      dispatch(setSelected(null));
-      dispatch(setSessionId(info.sessionId));
+
+      for (const id of alsoReopen) {
+        try {
+          await StartOrchestrator(id, 80, 24);
+        } catch (error) {
+          dispatch(setOrchestratorsError(readError(error)));
+        }
+      }
+
+      let restoredPane = false;
+      if (primary) {
+        // With a resume prompt, resume the conversation that asked for the
+        // restart AND hand it the task so a rebuild+restart continues on its own
+        // instead of idling at the prompt; without one, just resume the
+        // orchestrator's own pinned conversation.
+        const info = primary.resumePrompt
+          ? await StartOrchestratorWithResume(
+              primary.id,
+              primary.conversationId,
+              primary.resumePrompt,
+              80,
+              24,
+            )
+          : await StartOrchestrator(primary.id, 80, 24);
+        dispatch(setSelected(null));
+        dispatch(setSessionId(info.sessionId));
+        restoredPane = true;
+      }
       await dispatch(loadOrchestrators());
-      return true;
+      return restoredPane;
     } catch (error) {
       dispatch(setOrchestratorsError(readError(error)));
       return false;

--- a/erun-ui/orchestrator_open_state.go
+++ b/erun-ui/orchestrator_open_state.go
@@ -10,7 +10,7 @@ import (
 // The desktop keeps two separate records of which orchestrator a launch should
 // reopen, because they answer different questions and must not share a lifetime.
 //
-// This file owns the DURABLE one: which orchestrator is open. It is written the
+// This file owns the DURABLE one: which orchestrators are open. It is written the
 // moment a session starts and cleared the moment the operator stops it — never
 // at shutdown, because a crash, a `pkill` or a reboot takes the desktop away
 // without running any hook, and a record only a clean quit could write would be
@@ -18,7 +18,14 @@ import (
 // orchestrator the operator left open is still the one they were in, however
 // long ago that was.
 //
-// app_restart.go owns the OTHER one: the one-shot hand-off an in-app restart
+// The record is a SET, not a single id: every orchestrator the operator had
+// open comes back, not just the last one started. It is kept in recency order —
+// each (re)start moves its id to the end — because that order is also how
+// app_restart.go picks which one owns the terminal pane when no restart
+// hand-off names one: the most recently (re)started orchestrator, on the theory
+// that starting one is also how the operator ends up looking at it.
+//
+// app_restart.go owns the OTHER record: the one-shot hand-off an in-app restart
 // writes, which carries the prompt the resumed session should auto-run. That one
 // stays one-shot and age-bounded, so a rebuild+restart continues its task while
 // a plain launch resumes the conversation idle at the prompt.
@@ -26,7 +33,14 @@ import (
 const orchestratorOpenFileName = "orchestrator-open.json"
 
 type orchestratorOpenState struct {
-	OrchestratorID string `json:"orchestratorId"`
+	// OrchestratorIDs is the set of orchestrators open when the desktop was last
+	// running, oldest first.
+	OrchestratorIDs []string `json:"orchestratorIds,omitempty"`
+	// OrchestratorID is the shape this file had before it could hold more than
+	// one id. Only read, never written again: an operator upgrading from a
+	// release that only ever wrote this field must not lose the one
+	// orchestrator they had open.
+	OrchestratorID string `json:"orchestratorId,omitempty"`
 }
 
 // defaultOrchestratorOpenPath is a sibling of window-state.json under
@@ -39,12 +53,104 @@ func defaultOrchestratorOpenPath() string {
 	return filepath.Join(configDir, "ERun", orchestratorOpenFileName)
 }
 
+// recordOpenOrchestrator adds an orchestrator to the open set, or moves it to
+// the end (most recent) if it was already there.
 func recordOpenOrchestrator(path, orchestratorID string) error {
 	orchestratorID = strings.TrimSpace(orchestratorID)
 	if path == "" || orchestratorID == "" {
 		return nil
 	}
-	data, err := json.Marshal(orchestratorOpenState{OrchestratorID: orchestratorID})
+	ids := readOpenOrchestrators(path)
+	out := make([]string, 0, len(ids)+1)
+	for _, id := range ids {
+		if id != orchestratorID {
+			out = append(out, id)
+		}
+	}
+	out = append(out, orchestratorID)
+	return writeOpenOrchestrators(path, out)
+}
+
+// clearOpenOrchestrator forgets one orchestrator when the operator stops it,
+// which is what keeps an explicitly stopped orchestrator closed on every later
+// launch. Every other id in the set is left exactly as recorded: stopping one
+// orchestrator must not forget that the rest are still open.
+func clearOpenOrchestrator(path, orchestratorID string) error {
+	orchestratorID = strings.TrimSpace(orchestratorID)
+	if path == "" || orchestratorID == "" {
+		return nil
+	}
+	ids := readOpenOrchestrators(path)
+	out := make([]string, 0, len(ids))
+	removed := false
+	for _, id := range ids {
+		if id == orchestratorID {
+			removed = true
+			continue
+		}
+		out = append(out, id)
+	}
+	if !removed {
+		return nil
+	}
+	return writeOpenOrchestrators(path, out)
+}
+
+// readOpenOrchestrators returns the orchestrators that were open when the
+// desktop last ran, oldest first, or nil when none were. Reading does not clear
+// the record: it is durable, so every launch reopens the same set until an
+// entry is stopped. A legacy single-id file is understood as a one-element set.
+func readOpenOrchestrators(path string) []string {
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var state orchestratorOpenState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(state.OrchestratorIDs)+1)
+	ids := make([]string, 0, len(state.OrchestratorIDs)+1)
+	add := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	// The legacy scalar is the sole open orchestrator on a file no launch has
+	// rewritten into the set shape yet, so it takes the oldest position.
+	add(state.OrchestratorID)
+	for _, id := range state.OrchestratorIDs {
+		add(id)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	return ids
+}
+
+// writeOpenOrchestrators persists the open set, migrating a legacy scalar file
+// to the set shape the first time anything changes. An empty set removes the
+// file rather than leaving a durable record with nothing durable to say.
+func writeOpenOrchestrators(path string, ids []string) error {
+	if path == "" {
+		return nil
+	}
+	if len(ids) == 0 {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	data, err := json.Marshal(orchestratorOpenState{OrchestratorIDs: ids})
 	if err != nil {
 		return err
 	}
@@ -52,36 +158,4 @@ func recordOpenOrchestrator(path, orchestratorID string) error {
 		return err
 	}
 	return os.WriteFile(path, append(data, '\n'), 0o644)
-}
-
-// clearOpenOrchestrator forgets the open orchestrator when the operator stops
-// the one that is recorded, which is what keeps an explicitly stopped
-// orchestrator closed on every later launch. Stopping some other orchestrator
-// leaves the record alone: it still names the one that owns the pane.
-func clearOpenOrchestrator(path, orchestratorID string) error {
-	if path == "" || readOpenOrchestrator(path) != strings.TrimSpace(orchestratorID) {
-		return nil
-	}
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	return nil
-}
-
-// readOpenOrchestrator returns the orchestrator that was open when the desktop
-// last ran, or "" when none was. Reading does not clear it: the record is
-// durable, so every launch reopens the same orchestrator until it is stopped.
-func readOpenOrchestrator(path string) string {
-	if path == "" {
-		return ""
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return ""
-	}
-	var state orchestratorOpenState
-	if err := json.Unmarshal(data, &state); err != nil {
-		return ""
-	}
-	return strings.TrimSpace(state.OrchestratorID)
 }

--- a/erun-ui/orchestrator_open_state_test.go
+++ b/erun-ui/orchestrator_open_state_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -67,8 +68,125 @@ func TestPlainLaunchReopensTheOrchestratorThatWasOpen(t *testing.T) {
 	if again := app.ResolveOrchestratorToReopen(); again.OrchestratorID != id {
 		t.Fatalf("expected the record to survive being read, got %q", again.OrchestratorID)
 	}
-	if got := readOpenOrchestrator(openPath); got != id {
-		t.Fatalf("expected %q on disk, got %q", id, got)
+	if got := readOpenOrchestrators(openPath); len(got) != 1 || got[0] != id {
+		t.Fatalf("expected [%q] on disk, got %v", id, got)
+	}
+}
+
+// createAndStartNamedOrchestrator is createAndStartOrchestrator for a second
+// orchestrator definition, so multi-orchestrator tests can start two distinct
+// ones without colliding ids.
+func createAndStartNamedOrchestrator(t *testing.T, app *App, name, environment string) string {
+	t.Helper()
+	created, err := app.CreateOrchestrator(name, []orchestratorEnvInput{{Tenant: "frs", Environment: environment}})
+	if err != nil {
+		t.Fatalf("CreateOrchestrator failed: %v", err)
+	}
+	if _, err := app.StartOrchestrator(created.ID, 80, 24); err != nil {
+		t.Fatalf("StartOrchestrator failed: %v", err)
+	}
+	return created.ID
+}
+
+// The defect this issue fixes: the durable record was a scalar, so starting a
+// second orchestrator discarded the record that the first was open, and a
+// launch restored exactly one. Both must come back — one owning the pane, the
+// other reopened alongside it — and the tab strip and the live sessions must
+// agree about it.
+func TestTwoOpenOrchestratorsAreBothRestoredOnPlainLaunch(t *testing.T) {
+	app, openPath, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	first := createAndStartOrchestrator(t, app)
+	second := createAndStartNamedOrchestrator(t, app, "other", "laptop")
+
+	target := app.ResolveOrchestratorToReopen()
+	// The most recently started owns the pane; see app_restart.go for why.
+	if target.OrchestratorID != second {
+		t.Fatalf("expected %q (started last) to own the pane, got %q", second, target.OrchestratorID)
+	}
+	if len(target.AlsoReopen) != 1 || target.AlsoReopen[0] != first {
+		t.Fatalf("expected %q to also be reopened, got %v", first, target.AlsoReopen)
+	}
+	if got := readOpenOrchestrators(openPath); len(got) != 2 || got[0] != first || got[1] != second {
+		t.Fatalf("expected both ids recorded oldest-first, got %v", got)
+	}
+}
+
+// Stopping one orchestrator must not forget that the other is still open —
+// the second, quieter bug the scalar shape caused: stopping the one currently
+// recorded emptied the file entirely.
+func TestStoppingOneOrchestratorLeavesTheOtherRecordedAndRestored(t *testing.T) {
+	app, _, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	first := createAndStartOrchestrator(t, app)
+	second := createAndStartNamedOrchestrator(t, app, "other", "laptop")
+
+	if err := app.StopOrchestrator(second); err != nil {
+		t.Fatalf("StopOrchestrator failed: %v", err)
+	}
+
+	target := app.ResolveOrchestratorToReopen()
+	if target.OrchestratorID != first {
+		t.Fatalf("expected %q to still be recorded and reopened, got %q", first, target.OrchestratorID)
+	}
+	if len(target.AlsoReopen) != 0 {
+		t.Fatalf("expected nothing else to reopen, got %v", target.AlsoReopen)
+	}
+}
+
+// An operator upgrading from a release that only ever wrote the single-id shape
+// must not lose the one orchestrator they had open: the legacy scalar field is
+// still understood, not discarded for being the wrong shape.
+func TestLegacySingleIDFileIsHonoured(t *testing.T) {
+	app, openPath, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	id := createAndStartOrchestrator(t, app)
+	if err := os.WriteFile(openPath, []byte(`{"orchestratorId":"`+id+`"}`), 0o644); err != nil {
+		t.Fatalf("write legacy open file: %v", err)
+	}
+
+	target := app.ResolveOrchestratorToReopen()
+	if target.OrchestratorID != id {
+		t.Fatalf("expected the legacy scalar id to be reopened, got %q", target.OrchestratorID)
+	}
+	if len(target.AlsoReopen) != 0 {
+		t.Fatalf("expected no others alongside a single legacy id, got %v", target.AlsoReopen)
+	}
+}
+
+// The restart hand-off still names exactly one orchestrator to hand a prompt
+// to, even when several were open: the rest of the set comes back too, but idle.
+func TestRestartHandOffOverASetOfOpenOrchestratorsLeavesTheRestIdle(t *testing.T) {
+	app, openPath, restoreDir := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	const prompt = "verify the rebuild is live, then finish the task"
+	first := createAndStartOrchestrator(t, app)
+	second := createAndStartNamedOrchestrator(t, app, "other", "laptop")
+	conversationID := orchestratorSessionID(second)
+	stageOrchestratorConversation(t, conversationID)
+	handOff := orchestratorRestoreState{
+		OrchestratorID: second,
+		ConversationID: conversationID,
+		Environments:   []string{"frs/laptop"},
+		ResumePrompt:   prompt,
+	}
+	if err := writeOrchestratorRestoreTarget(restoreDir, handOff, time.Now()); err != nil {
+		t.Fatalf("write restart hand-off: %v", err)
+	}
+
+	target := app.ResolveOrchestratorToReopen()
+	if target.OrchestratorID != second || target.ResumePrompt != prompt {
+		t.Fatalf("expected %q to own the pane with its prompt, got %+v", second, target)
+	}
+	if len(target.AlsoReopen) != 1 || target.AlsoReopen[0] != first {
+		t.Fatalf("expected %q to reopen idle alongside it, got %v", first, target.AlsoReopen)
+	}
+	if got := readOpenOrchestrators(openPath); len(got) != 2 {
+		t.Fatalf("expected both still recorded open, got %v", got)
 	}
 }
 

--- a/erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts
+++ b/erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts
@@ -14,33 +14,44 @@ import { SEED_ORCHESTRATOR } from '../fixtures/seedRoot.js';
 // without a real Claude process, which the inert harness deliberately lacks.
 
 const RESTORED_SESSION_ID = 4242;
+const SEED_ORCHESTRATOR_2 = 'pw-orch-2';
 
-const runningOrchestrator = {
-  id: SEED_ORCHESTRATOR,
-  name: SEED_ORCHESTRATOR,
-  environments: [],
-  tenants: [],
-  directories: [],
-  sessionId: RESTORED_SESSION_ID,
-  status: 'running',
-  transient: false,
-};
+function runningOrchestratorInfo(id: string, sessionId: number) {
+  return {
+    id,
+    name: id,
+    environments: [],
+    tenants: [],
+    directories: [],
+    sessionId,
+    status: 'running',
+    transient: false,
+  };
+}
+
+const runningOrchestrator = runningOrchestratorInfo(SEED_ORCHESTRATOR, RESTORED_SESSION_ID);
 
 // stubReopen answers the boot restore round-trip and records every method the
 // frontend invoked, so a spec can assert which start call the launch made — and
-// that it made none at all when there is nothing to reopen.
+// that it made none at all when there is nothing to reopen. `running` maps every
+// orchestrator id the launch may start to the session it comes back with, so a
+// multi-orchestrator restore can give each one its own answer.
 async function stubReopen(
   page: Page,
   target: {
     orchestratorId: string;
     conversationId?: string;
     resumePrompt: string;
+    alsoReopen?: string[];
     notice?: string;
   },
   calls: string[],
+  running: Record<string, ReturnType<typeof runningOrchestratorInfo>> = {
+    [SEED_ORCHESTRATOR]: runningOrchestrator,
+  },
 ): Promise<void> {
   await page.route('**/__erun_invoke', async (route, request) => {
-    const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+    const body = JSON.parse(request.postData() ?? '{}') as { method: string; args?: unknown[] };
     calls.push(body.method);
     if (body.method === 'ResolveOrchestratorToReopen') {
       return route.fulfill({
@@ -48,21 +59,23 @@ async function stubReopen(
         body: JSON.stringify({ data: target }),
       });
     }
-    if (target.orchestratorId === '') {
+    if (target.orchestratorId === '' && !target.alsoReopen?.length) {
       return route.continue();
+    }
+    if (body.method === 'ListOrchestrators') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: Object.values(running) }),
+      });
     }
     // Once a restore is expected, the orchestrator has to read as running for
     // the pane to be its own — the strip keys off the live session id.
-    if (
-      body.method === 'ListOrchestrators' ||
-      body.method === 'StartOrchestrator' ||
-      body.method === 'StartOrchestratorWithResume'
-    ) {
-      const data =
-        body.method === 'ListOrchestrators' ? [runningOrchestrator] : runningOrchestrator;
+    if (body.method === 'StartOrchestrator' || body.method === 'StartOrchestratorWithResume') {
+      const rawId = body.args?.[0];
+      const id = typeof rawId === 'string' ? rawId : '';
       return route.fulfill({
         contentType: 'application/json',
-        body: JSON.stringify({ data }),
+        body: JSON.stringify({ data: running[id] ?? runningOrchestrator }),
       });
     }
     await route.continue();
@@ -175,6 +188,48 @@ test.describe('reopening the orchestrator that was open', () => {
     await expect(app.tabStrip.orchestratorMode()).toBeHidden();
     expect(calls).toContain('ResolveOrchestratorToReopen');
     expect(calls).not.toContain('StartOrchestrator');
+    expect(calls).not.toContain('StartOrchestratorWithResume');
+  });
+});
+
+// The durable record used to be a single id, so starting a second orchestrator
+// silently discarded the record that the first was open, and a launch restored
+// exactly one — every other tab came back with no session behind it. The Go
+// side owns the durable set and the recency rule that picks a pane owner when
+// there is no restart hand-off (erun-ui/orchestrator_open_state_test.go); what
+// only the rendered app can show is that every id the backend names actually
+// gets a live session and that exactly one of them ends up owning the pane.
+test.describe('restoring every orchestrator that was open', () => {
+  test('every orchestrator that was open is restored; only the pane owner is selected', async ({
+    app,
+    page,
+  }) => {
+    const calls: string[] = [];
+    const owner = runningOrchestratorInfo(SEED_ORCHESTRATOR_2, RESTORED_SESSION_ID + 1);
+    await stubReopen(
+      page,
+      { orchestratorId: SEED_ORCHESTRATOR_2, resumePrompt: '', alsoReopen: [SEED_ORCHESTRATOR] },
+      calls,
+      { [SEED_ORCHESTRATOR]: runningOrchestrator, [SEED_ORCHESTRATOR_2]: owner },
+    );
+    await app.reboot();
+
+    // Both orchestrators are live sessions, not just tabs — the tab strip and
+    // the sidebar's running dots have to agree with each other.
+    await expect(app.tabStrip.tab(SEED_ORCHESTRATOR)).toBeVisible();
+    await expect(app.tabStrip.tab(SEED_ORCHESTRATOR_2)).toBeVisible();
+    await expect(app.sidebar.orchestratorStatusDot(SEED_ORCHESTRATOR, 'running')).toBeVisible();
+    await expect(app.sidebar.orchestratorStatusDot(SEED_ORCHESTRATOR_2, 'running')).toBeVisible();
+
+    // Only the named pane owner is selected; the other reopened idle, off the
+    // pane.
+    await expect(app.tabStrip.tab(SEED_ORCHESTRATOR_2)).toHaveAttribute('aria-selected', 'true');
+    await expect(app.tabStrip.tab(SEED_ORCHESTRATOR)).toHaveAttribute('aria-selected', 'false');
+
+    // Both were started — an idle StartOrchestrator for the one alongside, and
+    // for the pane owner too, since a plain launch (no restart hand-off) carries
+    // no prompt to auto-run.
+    expect(calls).toContain('StartOrchestrator');
     expect(calls).not.toContain('StartOrchestratorWithResume');
   });
 });


### PR DESCRIPTION
Closes #1095

## The defect

This is a defect in the fix for #971 (PR #972). `orchestrator_open_state.go` modeled "which orchestrator is open" as a scalar:

```go
type orchestratorOpenState struct {
    OrchestratorID string `json:"orchestratorId"`
}
```

`recordOpenOrchestrator` overwrote the file on every spawn, so starting a second orchestrator discarded the record that the first was open — a launch restored exactly one, the most recently started, while every other tab came back with no session behind it. `clearOpenOrchestrator` only cleared when the recorded id matched the one being stopped, so start A, start B, stop B emptied the file entirely and forgot A too, even though A was still open.

## The fix

The durable record is now an ordered **set** of orchestrator ids, kept in recency order — each (re)start moves its id to the end. A legacy single-id file is still understood (folded in as a one-element set) so an operator upgrading from a release that only ever wrote the scalar shape does not lose the orchestrator they had open; the first write after that migrates the file to the set shape.

`ResolveOrchestratorToReopen` now answers with two things: `OrchestratorID`, the one orchestrator that **owns the terminal pane**, and `AlsoReopen`, every other orchestrator that was open and comes back too — started, but idle, off the pane. Only the pane owner's target can carry a `ConversationID`/`ResumePrompt`, by construction (those fields live on the single target, not per id in `AlsoReopen`), so a restart hand-off's prompt still auto-runs for exactly one orchestrator and the rest of the set resumes idle — the safety property from #971 that "only one orchestrator can be handed a prompt" survives unchanged.

All of #971's other safety properties survive unchanged too:
- Written on spawn, never at shutdown (a crash/`pkill` cannot lose it).
- No freshness window.
- An explicitly stopped orchestrator stays closed — clearing now removes only that one id from the set, leaving the rest exactly as recorded.
- A transient (Investigate) orchestrator is never recorded.
- The restart hand-off in `app_restart.go` keeps its own one-shot, age-bounded, single-prompt semantics.

## Which orchestrator owns the pane

The pane is single; the restored set is not. Two rules, in priority order:

1. **A pending restart hand-off wins outright.** It names the exact orchestrator the operator just restarted from and is the only source of a resume prompt.
2. **Otherwise, the most recently (re)started orchestrator owns it.** The durable record's recency order is also the tiebreaker: starting (or restarting) an orchestrator is also how the operator typically ends up looking at it, so "most recently started" is a reasonable proxy for "most recently focused" without needing a second file to track pane focus separately. This was the field's *accidental* behavior before this fix (the scalar file only ever held the last-started id); it is now the intentional rule, generalized to fall back correctly when the hand-off's target isn't a valid pane owner.

On the frontend, `planOrchestratorRestore` additionally handles the case where the backend's named pane owner no longer exists (e.g. deleted between shutdown and this launch): it promotes the next most-recently-opened survivor from `alsoReopen` to the pane instead of dropping straight to the default environment selection while other orchestrators are still starting in the background.

## Tests

- `erun-ui/orchestrator_open_state_test.go`:
  - `TestTwoOpenOrchestratorsAreBothRestoredOnPlainLaunch` — both come back; the most recently started owns the pane, the other is in `AlsoReopen`.
  - `TestStoppingOneOrchestratorLeavesTheOtherRecordedAndRestored` — stopping one leaves the other recorded and restored alone.
  - `TestLegacySingleIDFileIsHonoured` — a hand-authored legacy scalar file is still reopened.
  - `TestRestartHandOffOverASetOfOpenOrchestratorsLeavesTheRestIdle` — a restart hand-off still names exactly one orchestrator for the prompt; the rest of the set reopens idle.
  - Existing tests (explicitly-stopped stays closed, deleted is not reopened, restart keeps recorded, transient never recorded, hand-off one-shot/age-bounded) pass unchanged — the primary/`AlsoReopen` split kept their assertions valid.
- `erun-ui/frontend/src/app/orchestratorRestore.test.ts` — rewritten for the `{primary, alsoReopen}` outcome shape: every orchestrator that was open is restored (not just the pane owner), a deleted pane owner promotes a survivor, duplicates/self-references in `alsoReopen` are dropped, transients are never restored.
- `erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts` — new `restoring every orchestrator that was open` describe block: two orchestrators both come back as live sessions (tab strip + sidebar dots agree), only the named pane owner is selected. Existing single-orchestrator scenarios (plain launch, hand-off resume, refused hand-off, hand-offs-not-reopened notice, nothing to reopen) pass unchanged.

## UX impact review

1. **Affected paths.** Desktop boot (`getInitialState` → `loadOrchestrators` → `restoreOpenOrchestrators`), and the same start/stop/restart orchestrator flows #971 already covered.
2. **User-visible sequence.** Launching the desktop now lands the operator back in *every* orchestrator they left open — not just the last one started — with the tab strip showing a live, running tab for each, and exactly one of them selected and owning the pane.
3. **State-without-affordance.** No new state without a rendered consequence: every restored id gets a real session, visible as a running tab and a running sidebar dot.
4. **Visibility of system status (#1).** The bug this fixes *was* a visibility violation — a tab claiming to be open with a dead session behind it. The fix makes the tab strip and the live sessions agree.
5. **Success/failure feedback (#1, #9).** Unchanged from #971: a restore that cannot start surfaces through the existing orchestrators error path.
6. **Consistency (#4).** Matches #971's precedent (durable session restore) and now extends it to the actually-common case of more than one orchestrator.
7. **Heuristic pass.** Same as #971's: #1 visibility and #4 consistency drive the change; #3 user control (stopped stays stopped) still holds per-id now instead of for the whole record.
8. **Playwright coverage.** `erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts`, new `restoring every orchestrator that was open` block.

## Docs

No `erun-docs` change — same reasoning as #971: no new operator-facing control, flag, or command; this corrects how many orchestrators a launch restores, not what the desktop lets an operator do.

## Gates

| Gate | Result |
| --- | --- |
| `cd erun-ui && go build ./... && go vet ./... && go test ./... -count=1` | pass |
| `golangci-lint run ./...` (erun-ui) | 0 issues |
| `cd erun-ui/frontend && yarn typecheck && yarn lint && yarn format:check && yarn test` | pass (70 tests) |
| `cd erun-ui/playwright && ./run.sh --build` | 168 passed |
| `make integration-test` | pass, coverage 75.8% (>= 75.8%) |

Wails bindings regenerated (`go run github.com/wailsapp/wails/v2/cmd/wails generate module`) for `relaunchTarget`'s new `alsoReopen` field; `frontend/wailsjs/` is generated and gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)