### PR TITLE
Resume the session that was running and show a background shell as activity

### DIFF
--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -22,6 +22,7 @@ const (
 	environmentDeployedEvent    = "environment-deployed"
 	environmentsChangedEvent    = "environments-changed"
 	aiActivityEvent             = "ai-activity"
+	orchestratorShellEvent      = "orchestrator-shell-activity"
 	envStatusEvent              = "env-status"
 	envActivityEvent            = "env-activity"
 	appSessionEnvVar            = "ERUN_UI_SESSION"

--- a/erun-ui/app_restart.go
+++ b/erun-ui/app_restart.go
@@ -78,7 +78,7 @@ type orchestratorRestoreState struct {
 // because ResumePrompt is a field of this one target, not of each entry in
 // AlsoReopen — but every entry, owner included, carries the conversation id it
 // should resume: see resolveReopenSessionID for how that id is decided, which
-// is never a re-derivation from the orchestrator id (#1096). Notice explains,
+// is never a re-derivation from the orchestrator id. Notice explains,
 // when non-empty, why the pane owner is not continuing a task it asked to.
 type relaunchTarget struct {
 	OrchestratorID string                  `json:"orchestratorId"`
@@ -277,7 +277,7 @@ func (a *App) ResolveOrchestratorToReopen() relaunchTarget {
 	// No prompt to deliver, or the hand-off was refused: still resume the exact
 	// conversation the durable record last saw running for this orchestrator,
 	// rather than leaving it for a re-derivation that can land on a different,
-	// older one (#1096).
+	// older one.
 	target.ConversationID = resolveReopenSessionID(orchestratorEntryOrEmpty(openEntries, state.OrchestratorID))
 	return target
 }
@@ -286,7 +286,7 @@ func (a *App) ResolveOrchestratorToReopen() relaunchTarget {
 // resumes: the one durably recorded as live for it, but only when that
 // conversation still exists on disk — never a re-derivation from the
 // orchestrator id, which can land on a different, older conversation that
-// happens to share the derived id (#1096). Absent or stale, it mints a fresh
+// happens to share the derived id. Absent or stale, it mints a fresh
 // id instead of guessing: resuming nothing is safer than resuming the wrong
 // conversation, and the fresh session gets recorded correctly the moment it
 // spawns.

--- a/erun-ui/app_restart.go
+++ b/erun-ui/app_restart.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	eruncommon "github.com/sophium/erun/erun-common"
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
@@ -72,17 +73,26 @@ type orchestratorRestoreState struct {
 // relaunchTarget is the JSON-safe view the frontend reads on boot. OrchestratorID
 // is the one this launch resumes and that OWNS THE TERMINAL PANE — the pane is
 // single, so exactly one orchestrator gets it. AlsoReopen lists every other
-// orchestrator that was open and comes back too, started idle alongside it with
-// no conversation named and no prompt: only the pane-owning orchestrator can
-// carry a resume prompt, by construction, because ConversationID/ResumePrompt
-// are fields of this one target, not of each id in AlsoReopen. Notice explains,
+// orchestrator that was open and comes back too, started idle alongside it.
+// Only the pane-owning orchestrator can carry a resume PROMPT, by construction,
+// because ResumePrompt is a field of this one target, not of each entry in
+// AlsoReopen — but every entry, owner included, carries the conversation id it
+// should resume: see resolveReopenSessionID for how that id is decided, which
+// is never a re-derivation from the orchestrator id (#1096). Notice explains,
 // when non-empty, why the pane owner is not continuing a task it asked to.
 type relaunchTarget struct {
-	OrchestratorID string   `json:"orchestratorId"`
-	ConversationID string   `json:"conversationId"`
-	ResumePrompt   string   `json:"resumePrompt"`
-	AlsoReopen     []string `json:"alsoReopen,omitempty"`
-	Notice         string   `json:"notice"`
+	OrchestratorID string                  `json:"orchestratorId"`
+	ConversationID string                  `json:"conversationId"`
+	ResumePrompt   string                  `json:"resumePrompt"`
+	AlsoReopen     []orchestratorReopenRef `json:"alsoReopen,omitempty"`
+	Notice         string                  `json:"notice"`
+}
+
+// orchestratorReopenRef is one orchestrator in AlsoReopen: its id and the
+// conversation it resumes, resolved the same way the pane owner's is.
+type orchestratorReopenRef struct {
+	OrchestratorID string `json:"orchestratorId"`
+	ConversationID string `json:"conversationId,omitempty"`
 }
 
 // defaultOrchestratorRestoreDir is the directory beside window-state.json under
@@ -205,11 +215,12 @@ func readAndClearOrchestratorRestoreTarget(path string) (orchestratorRestoreStat
 // ResolveOrchestratorToReopen returns every orchestrator this launch should
 // reopen: one that OWNS THE TERMINAL PANE (OrchestratorID), plus any others that
 // were open too (AlsoReopen). The frontend calls it on boot (after loading the
-// orchestrator list); for each id that still resolves to a persisted
-// orchestrator it starts a session, resuming that orchestrator's own pinned
-// conversation — except the pane owner, which resumes the named conversation
-// when the hand-off supplies one — so the operator lands back where they were,
-// with everything else they had open still running behind it.
+// orchestrator list); for each entry it starts a session resuming the exact
+// conversation this method names for it — the pane owner resumes the hand-off's
+// named conversation when one is delivered, otherwise every entry (owner and
+// AlsoReopen alike) resumes what resolveReopenSessionID resolves — so the
+// operator lands back where they were, with everything else they had open still
+// running behind it.
 //
 // Which orchestrator owns the pane is answered in one of two ways:
 //
@@ -234,43 +245,97 @@ func readAndClearOrchestratorRestoreTarget(path string) (orchestratorRestoreStat
 func (a *App) ResolveOrchestratorToReopen() relaunchTarget {
 	state, notReopened := consumeOrchestratorRestoreTargets(a.deps.orchestratorRestoreDir, time.Now())
 	notice := orchestratorHandoffsNotReopenedNotice(notReopened)
-	openIDs := readOpenOrchestrators(a.deps.orchestratorOpenPath)
+	openEntries := readOpenOrchestrators(a.deps.orchestratorOpenPath)
 
 	if state.OrchestratorID == "" {
-		if len(openIDs) == 0 {
+		if len(openEntries) == 0 {
 			return relaunchTarget{Notice: notice}
 		}
-		owner := openIDs[len(openIDs)-1]
-		return relaunchTarget{OrchestratorID: owner, AlsoReopen: removeOrchestratorID(openIDs, owner), Notice: notice}
+		owner := openEntries[len(openEntries)-1]
+		return relaunchTarget{
+			OrchestratorID: owner.OrchestratorID,
+			ConversationID: resolveReopenSessionID(owner),
+			AlsoReopen:     reopenRefs(removeOrchestratorEntry(openEntries, owner.OrchestratorID)),
+			Notice:         notice,
+		}
 	}
 
 	target := relaunchTarget{
 		OrchestratorID: state.OrchestratorID,
-		AlsoReopen:     removeOrchestratorID(openIDs, state.OrchestratorID),
+		AlsoReopen:     reopenRefs(removeOrchestratorEntry(openEntries, state.OrchestratorID)),
 		Notice:         notice,
 	}
-	if state.ResumePrompt == "" {
-		return target
-	}
-	if refusal := a.resumeRefusal(state); refusal != "" {
+	if state.ResumePrompt != "" {
+		refusal := a.resumeRefusal(state)
+		if refusal == "" {
+			target.ConversationID = state.ConversationID
+			target.ResumePrompt = state.ResumePrompt
+			return target
+		}
 		target.Notice = joinOrchestratorNotices(refusal, notice)
-		return target
 	}
-	target.ConversationID = state.ConversationID
-	target.ResumePrompt = state.ResumePrompt
+	// No prompt to deliver, or the hand-off was refused: still resume the exact
+	// conversation the durable record last saw running for this orchestrator,
+	// rather than leaving it for a re-derivation that can land on a different,
+	// older one (#1096).
+	target.ConversationID = resolveReopenSessionID(orchestratorEntryOrEmpty(openEntries, state.OrchestratorID))
 	return target
 }
 
-// removeOrchestratorID returns ids without id, preserving order.
-func removeOrchestratorID(ids []string, id string) []string {
-	if len(ids) == 0 {
+// resolveReopenSessionID decides which conversation a reopened orchestrator
+// resumes: the one durably recorded as live for it, but only when that
+// conversation still exists on disk — never a re-derivation from the
+// orchestrator id, which can land on a different, older conversation that
+// happens to share the derived id (#1096). Absent or stale, it mints a fresh
+// id instead of guessing: resuming nothing is safer than resuming the wrong
+// conversation, and the fresh session gets recorded correctly the moment it
+// spawns.
+func resolveReopenSessionID(entry orchestratorOpenEntry) string {
+	if entry.SessionID != "" && orchestratorSessionExists(entry.SessionID) {
+		return entry.SessionID
+	}
+	return uuid.NewString()
+}
+
+// orchestratorEntryOrEmpty finds id's entry in entries, or a zero-value entry
+// (no recorded session) when it is not there.
+func orchestratorEntryOrEmpty(entries []orchestratorOpenEntry, id string) orchestratorOpenEntry {
+	for _, entry := range entries {
+		if entry.OrchestratorID == id {
+			return entry
+		}
+	}
+	return orchestratorOpenEntry{OrchestratorID: id}
+}
+
+// removeOrchestratorEntry returns entries without id, preserving order.
+func removeOrchestratorEntry(entries []orchestratorOpenEntry, id string) []orchestratorOpenEntry {
+	if len(entries) == 0 {
 		return nil
 	}
-	out := make([]string, 0, len(ids))
-	for _, existing := range ids {
-		if existing != id {
-			out = append(out, existing)
+	out := make([]orchestratorOpenEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.OrchestratorID != id {
+			out = append(out, entry)
 		}
+	}
+	return out
+}
+
+// reopenRefs resolves each entry's conversation the same way the pane owner's
+// is, so every orchestrator AlsoReopen names arrives at the exact conversation
+// that was really running for it rather than one the frontend would otherwise
+// have to derive.
+func reopenRefs(entries []orchestratorOpenEntry) []orchestratorReopenRef {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]orchestratorReopenRef, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, orchestratorReopenRef{
+			OrchestratorID: entry.OrchestratorID,
+			ConversationID: resolveReopenSessionID(entry),
+		})
 	}
 	return out
 }

--- a/erun-ui/app_restart_test.go
+++ b/erun-ui/app_restart_test.go
@@ -341,7 +341,10 @@ func TestRestoreSlotRejectsAnIDThatIsNotAPlainFileName(t *testing.T) {
 
 // The bug: an orchestrator id is mutable and reusable, so a hand-off recorded
 // under one scope must not wake a conversation into another. The refusal is
-// visible — the orchestrator still reopens, idle, carrying the reason.
+// visible — the orchestrator still reopens, idle, carrying the reason. It still
+// resumes its own last-recorded conversation rather than nothing: the refusal
+// is about not auto-running a task into the wrong scope, not about whether the
+// conversation itself is safe to reopen idle.
 func TestResumeIsRefusedWhenTheScopeChanged(t *testing.T) {
 	app, restoreDir := restartTestApp(t)
 	id := createAndStartOrchestrator(t, app)
@@ -349,7 +352,8 @@ func TestResumeIsRefusedWhenTheScopeChanged(t *testing.T) {
 	if err := app.RestartApp(id); err != nil {
 		t.Fatalf("RestartApp failed: %v", err)
 	}
-	stageOrchestratorConversation(t, readRestoreState(t, restoreDir, id).ConversationID)
+	liveConversation := readRestoreState(t, restoreDir, id).ConversationID
+	stageOrchestratorConversation(t, liveConversation)
 	if _, err := app.UpdateOrchestrator(id, "agent", []orchestratorEnvInput{{Tenant: "frs", Environment: "laptop"}}); err != nil {
 		t.Fatalf("UpdateOrchestrator failed: %v", err)
 	}
@@ -358,8 +362,11 @@ func TestResumeIsRefusedWhenTheScopeChanged(t *testing.T) {
 	if target.OrchestratorID != id {
 		t.Fatalf("expected the orchestrator to still be reopened, got %+v", target)
 	}
-	if target.ResumePrompt != "" || target.ConversationID != "" {
+	if target.ResumePrompt != "" {
 		t.Fatalf("expected no task to be delivered into a changed scope, got %+v", target)
+	}
+	if target.ConversationID != liveConversation {
+		t.Fatalf("expected the orchestrator's own conversation to still be resumed idle, got %+v", target)
 	}
 	if !strings.Contains(target.Notice, "frs/dev") || !strings.Contains(target.Notice, "frs/laptop") {
 		t.Fatalf("expected the notice to name both scopes, got %q", target.Notice)

--- a/erun-ui/frontend/src/app/model/index.ts
+++ b/erun-ui/frontend/src/app/model/index.ts
@@ -11,6 +11,7 @@ export type { IDEKind } from './ideKind';
 export type { IdleCloudContextAction } from './idleCloudContextAction';
 export type { MountElements } from './mountElements';
 export type { NormalizedEnvironmentDialogValues } from './normalizedEnvironmentDialogValues';
+export type { OrchestratorShellActivityPayload } from './orchestratorShellActivityPayload';
 export type { TerminalDataDisposable } from './terminalDataDisposable';
 export type { TerminalExitSelections } from './terminalExitSelections';
 export type { TerminalWriteData } from './terminalWriteData';

--- a/erun-ui/frontend/src/app/model/orchestratorShellActivityPayload.ts
+++ b/erun-ui/frontend/src/app/model/orchestratorShellActivityPayload.ts
@@ -1,5 +1,5 @@
 // OrchestratorShellActivityPayload drives the sidebar's "shell running"
-// indicator (#1068): a background shell an orchestrator started can outlive
+// indicator: a background shell an orchestrator started can outlive
 // the turn that started it, so this is independent of AIActivityPayload's
 // busy signal, not a variant of it. StartedAtUnix is only meaningful while
 // running is true.

--- a/erun-ui/frontend/src/app/model/orchestratorShellActivityPayload.ts
+++ b/erun-ui/frontend/src/app/model/orchestratorShellActivityPayload.ts
@@ -1,0 +1,11 @@
+// OrchestratorShellActivityPayload drives the sidebar's "shell running"
+// indicator (#1068): a background shell an orchestrator started can outlive
+// the turn that started it, so this is independent of AIActivityPayload's
+// busy signal, not a variant of it. StartedAtUnix is only meaningful while
+// running is true.
+export interface OrchestratorShellActivityPayload {
+  sessionId: number;
+  running: boolean;
+  command: string;
+  startedAtUnix: number;
+}

--- a/erun-ui/frontend/src/app/orchestratorBusySeed.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorBusySeed.test.ts
@@ -15,6 +15,9 @@ function orchestrator(sessionId: number, busy: boolean): OrchestratorInfo {
     status: sessionId > 0 ? 'running' : 'stopped',
     busy,
     transient: false,
+    shellRunning: false,
+    shellCommand: '',
+    shellStartedAtUnix: 0,
   };
 }
 

--- a/erun-ui/frontend/src/app/orchestratorRestore.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorRestore.test.ts
@@ -15,7 +15,17 @@ function orchestrator(id: string, transient = false): OrchestratorInfo {
     status: 'stopped',
     busy: false,
     transient,
+    shellRunning: false,
+    shellCommand: '',
+    shellStartedAtUnix: 0,
   };
+}
+
+// ref builds an alsoReopen entry the way the backend does: an id plus the
+// conversation it resolved for that orchestrator (see resolveReopenSessionID
+// in app_restart.go), never left for the frontend to derive.
+function ref(orchestratorId: string, conversationId = '') {
+  return { orchestratorId, conversationId };
 }
 
 const persisted = [orchestrator('agent-1'), orchestrator('agent-2')];
@@ -25,45 +35,51 @@ const persisted = [orchestrator('agent-1'), orchestrator('agent-2')];
 // and it answers without a prompt — the launch resumes idle.
 test('a plain launch reopens the orchestrator that was open, running nothing', () => {
   const outcome = planOrchestratorRestore(
-    { orchestratorId: 'agent-1', resumePrompt: '' },
+    { orchestratorId: 'agent-1', conversationId: 'conv-1', resumePrompt: '' },
     persisted,
   );
   assert.deepEqual(outcome, {
-    primary: { id: 'agent-1', conversationId: '', resumePrompt: '' },
+    primary: { id: 'agent-1', conversationId: 'conv-1', resumePrompt: '' },
     alsoReopen: [],
   });
 });
 
-// The bug this issue fixes: the durable record was a scalar, so only one
+// The bug #1098 fixed: the durable record was a scalar, so only one
 // orchestrator ever came back. Every id in alsoReopen must be restored too.
 test('every orchestrator that was open is restored, not just the pane owner', () => {
   const outcome = planOrchestratorRestore(
-    { orchestratorId: 'agent-2', resumePrompt: '', alsoReopen: ['agent-1'] },
+    {
+      orchestratorId: 'agent-2',
+      conversationId: 'conv-2',
+      resumePrompt: '',
+      alsoReopen: [ref('agent-1', 'conv-1')],
+    },
     persisted,
   );
   assert.deepEqual(outcome, {
-    primary: { id: 'agent-2', conversationId: '', resumePrompt: '' },
-    alsoReopen: ['agent-1'],
+    primary: { id: 'agent-2', conversationId: 'conv-2', resumePrompt: '' },
+    alsoReopen: [ref('agent-1', 'conv-1')],
   });
 });
 
 // The hand-off names the conversation that asked for the restart, not just the
 // orchestrator it belongs to: an id is reusable, so several conversations answer
 // to it and continuing the wrong one wakes a session in a scope it never had.
-// Only the pane owner can carry it — alsoReopen ids are always idle.
+// Only the pane owner can carry the auto-run prompt — alsoReopen entries are
+// always idle, but still each resume their own resolved conversation.
 test('a restart hand-off carries the conversation and the prompt it auto-runs', () => {
   const outcome = planOrchestratorRestore(
     {
       orchestratorId: 'agent-1',
       conversationId: 'conv-1',
       resumePrompt: 'finish the task',
-      alsoReopen: ['agent-2'],
+      alsoReopen: [ref('agent-2', 'conv-2')],
     },
     persisted,
   );
   assert.deepEqual(outcome, {
     primary: { id: 'agent-1', conversationId: 'conv-1', resumePrompt: 'finish the task' },
-    alsoReopen: ['agent-2'],
+    alsoReopen: [ref('agent-2', 'conv-2')],
   });
 });
 
@@ -85,15 +101,19 @@ test('nothing to reopen leaves boot on the default environment selection', () =>
 
 // A pane owner deleted since the record was written cannot be reopened, but the
 // rest of the set is not thrown away with it — the next most-recently-opened
-// survivor takes the pane instead.
+// survivor takes the pane instead, carrying the conversation the backend
+// already resolved for it rather than losing it on promotion.
 test('a pane owner that no longer exists is dropped and a survivor is promoted', () => {
   const outcome = planOrchestratorRestore(
-    { orchestratorId: 'agent-gone', alsoReopen: ['agent-1', 'agent-2'] },
+    {
+      orchestratorId: 'agent-gone',
+      alsoReopen: [ref('agent-1', 'conv-1'), ref('agent-2', 'conv-2')],
+    },
     persisted,
   );
   assert.deepEqual(outcome, {
-    primary: { id: 'agent-2', conversationId: '', resumePrompt: '' },
-    alsoReopen: ['agent-1'],
+    primary: { id: 'agent-2', conversationId: 'conv-2', resumePrompt: '' },
+    alsoReopen: [ref('agent-1', 'conv-1')],
   });
 });
 
@@ -115,11 +135,15 @@ test('a transient orchestrator is never restored', () => {
     alsoReopen: [],
   });
   assert.deepEqual(
-    planOrchestratorRestore({ orchestratorId: 'agent-1', alsoReopen: ['investigate-1'] }, [
-      ...persisted,
-      ...transientOnly,
-    ]),
-    { primary: { id: 'agent-1', conversationId: '', resumePrompt: '' }, alsoReopen: [] },
+    planOrchestratorRestore(
+      {
+        orchestratorId: 'agent-1',
+        conversationId: 'conv-1',
+        alsoReopen: [ref('investigate-1', 'conv-x')],
+      },
+      [...persisted, ...transientOnly],
+    ),
+    { primary: { id: 'agent-1', conversationId: 'conv-1', resumePrompt: '' }, alsoReopen: [] },
   );
 });
 
@@ -127,12 +151,16 @@ test('a transient orchestrator is never restored', () => {
 // second session for the same orchestrator.
 test('alsoReopen drops duplicates and the pane owner itself', () => {
   const outcome = planOrchestratorRestore(
-    { orchestratorId: 'agent-1', alsoReopen: ['agent-1', 'agent-2', 'agent-2'] },
+    {
+      orchestratorId: 'agent-1',
+      conversationId: 'conv-1',
+      alsoReopen: [ref('agent-1', 'conv-1'), ref('agent-2', 'conv-2'), ref('agent-2', 'conv-2')],
+    },
     persisted,
   );
   assert.deepEqual(outcome, {
-    primary: { id: 'agent-1', conversationId: '', resumePrompt: '' },
-    alsoReopen: ['agent-2'],
+    primary: { id: 'agent-1', conversationId: 'conv-1', resumePrompt: '' },
+    alsoReopen: [ref('agent-2', 'conv-2')],
   });
 });
 
@@ -140,7 +168,22 @@ test('alsoReopen drops duplicates and the pane owner itself', () => {
 // down the auto-run branch.
 test('a whitespace-only resume prompt resumes idle', () => {
   const outcome = planOrchestratorRestore(
-    { orchestratorId: 'agent-1', resumePrompt: '  \n ' },
+    { orchestratorId: 'agent-1', conversationId: 'conv-1', resumePrompt: '  \n ' },
+    persisted,
+  );
+  assert.deepEqual(outcome, {
+    primary: { id: 'agent-1', conversationId: 'conv-1', resumePrompt: '' },
+    alsoReopen: [],
+  });
+});
+
+// The backend may resolve nothing safe to resume (#1096: no live session was
+// ever recorded, or the recorded one is gone) — the plan must carry that
+// through as an empty conversationId rather than inventing one, so the caller
+// starts the orchestrator fresh instead of resuming a guess.
+test('no resolved conversation plans a fresh start, not a guessed one', () => {
+  const outcome = planOrchestratorRestore(
+    { orchestratorId: 'agent-1', resumePrompt: '' },
     persisted,
   );
   assert.deepEqual(outcome, {

--- a/erun-ui/frontend/src/app/orchestratorRestore.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorRestore.test.ts
@@ -44,8 +44,8 @@ test('a plain launch reopens the orchestrator that was open, running nothing', (
   });
 });
 
-// The bug #1098 fixed: the durable record was a scalar, so only one
-// orchestrator ever came back. Every id in alsoReopen must be restored too.
+// The bug an earlier fix addressed: the durable record was a scalar, so only
+// one orchestrator ever came back. Every id in alsoReopen must be restored too.
 test('every orchestrator that was open is restored, not just the pane owner', () => {
   const outcome = planOrchestratorRestore(
     {
@@ -177,10 +177,10 @@ test('a whitespace-only resume prompt resumes idle', () => {
   });
 });
 
-// The backend may resolve nothing safe to resume (#1096: no live session was
-// ever recorded, or the recorded one is gone) — the plan must carry that
-// through as an empty conversationId rather than inventing one, so the caller
-// starts the orchestrator fresh instead of resuming a guess.
+// The backend may resolve nothing safe to resume (no live session was ever
+// recorded, or the recorded one is gone) — the plan must carry that through as
+// an empty conversationId rather than inventing one, so the caller starts the
+// orchestrator fresh instead of resuming a guess.
 test('no resolved conversation plans a fresh start, not a guessed one', () => {
   const outcome = planOrchestratorRestore(
     { orchestratorId: 'agent-1', resumePrompt: '' },

--- a/erun-ui/frontend/src/app/orchestratorRestore.ts
+++ b/erun-ui/frontend/src/app/orchestratorRestore.ts
@@ -4,7 +4,7 @@ import type { OrchestratorInfo } from './slices/orchestratorsSlice';
 // backend resolves conversationId the same way for every entry, owner
 // included — the exact conversation last known to be running for that
 // orchestrator, never a re-derivation from its id, which can land on a
-// different, older conversation (#1096). Empty only when the backend found
+// different, older conversation. Empty only when the backend found
 // nothing safe to resume, in which case the orchestrator starts fresh.
 export interface OrchestratorReopenRef {
   orchestratorId: string;

--- a/erun-ui/frontend/src/app/orchestratorRestore.ts
+++ b/erun-ui/frontend/src/app/orchestratorRestore.ts
@@ -1,18 +1,29 @@
 import type { OrchestratorInfo } from './slices/orchestratorsSlice';
 
+// One orchestrator in alsoReopen: its id and the conversation it resumes. The
+// backend resolves conversationId the same way for every entry, owner
+// included — the exact conversation last known to be running for that
+// orchestrator, never a re-derivation from its id, which can land on a
+// different, older conversation (#1096). Empty only when the backend found
+// nothing safe to resume, in which case the orchestrator starts fresh.
+export interface OrchestratorReopenRef {
+  orchestratorId: string;
+  conversationId?: string;
+}
+
 // What the backend answers when boot asks which orchestrators to reopen:
 // orchestratorId is the one that OWNS THE TERMINAL PANE — the pane is single,
 // so exactly one orchestrator gets it — and alsoReopen lists every other
 // orchestrator that was open too, restored alongside it but idle. Only the
-// pane owner can carry a conversation/prompt to resume; that is why those
-// fields live on the target itself rather than per id in alsoReopen. A notice
-// means a hand-off was refused: the pane owner still reopens, idle, and the
-// notice says why nothing is being continued.
+// pane owner can carry a resume PROMPT; that is why resumePrompt lives on the
+// target itself rather than per id in alsoReopen. A notice means a hand-off
+// was refused: the pane owner still reopens, idle, and the notice says why
+// nothing is being continued.
 export interface OrchestratorReopenTarget {
   orchestratorId?: string;
   conversationId?: string;
   resumePrompt?: string;
-  alsoReopen?: string[];
+  alsoReopen?: OrchestratorReopenRef[];
   notice?: string;
 }
 
@@ -26,10 +37,11 @@ export interface OrchestratorRestorePlan {
 
 // OrchestratorRestoreOutcome is what a launch actually restores: the
 // orchestrator that ends up owning the pane (or null if there is nothing valid
-// to reopen), and every other orchestrator that comes back idle beside it.
+// to reopen), and every other orchestrator that comes back idle beside it,
+// each with the conversation it resumes.
 export interface OrchestratorRestoreOutcome {
   primary: OrchestratorRestorePlan | null;
-  alsoReopen: string[];
+  alsoReopen: OrchestratorReopenRef[];
 }
 
 const trimmed = (value: string | undefined): string => value?.trim() ?? '';
@@ -66,13 +78,13 @@ export function planOrchestratorRestore(
 
   const primaryID = trimmed(source.orchestratorId);
   const seen = new Set<string>();
-  const survivingAlso = (source.alsoReopen ?? []).reduce<string[]>((kept, raw) => {
-    const id = trimmed(raw);
+  const survivingAlso = (source.alsoReopen ?? []).reduce<OrchestratorReopenRef[]>((kept, raw) => {
+    const id = trimmed(raw.orchestratorId);
     if (id === '' || id === primaryID || seen.has(id) || !exists(id)) {
       return kept;
     }
     seen.add(id);
-    kept.push(id);
+    kept.push({ orchestratorId: id, conversationId: trimmed(raw.conversationId) });
     return kept;
   }, []);
 
@@ -92,7 +104,14 @@ export function planOrchestratorRestore(
     return { primary: null, alsoReopen: [] };
   }
   return {
-    primary: { id: promoted, conversationId: '', resumePrompt: '' },
+    // The promoted survivor carries the conversation the backend already
+    // resolved for it as an alsoReopen entry — it must not be dropped just
+    // because this orchestrator is now taking the pane instead.
+    primary: {
+      id: promoted.orchestratorId,
+      conversationId: promoted.conversationId ?? '',
+      resumePrompt: '',
+    },
     alsoReopen: rest,
   };
 }

--- a/erun-ui/frontend/src/app/orchestratorShellActivitySeed.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorShellActivitySeed.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { planOrchestratorShellSeed } from './orchestratorShellActivitySeed';
+import type { OrchestratorInfo } from './slices/orchestratorsSlice';
+
+function orchestrator(
+  sessionId: number,
+  shellRunning: boolean,
+  shellCommand = '',
+  shellStartedAtUnix = 0,
+): OrchestratorInfo {
+  return {
+    id: 'agent-1',
+    name: 'agent-1',
+    environments: [],
+    tenants: [],
+    directories: [],
+    sessionId,
+    status: sessionId > 0 ? 'running' : 'stopped',
+    busy: false,
+    transient: false,
+    shellRunning,
+    shellCommand,
+    shellStartedAtUnix,
+  };
+}
+
+// The point of the snapshot half of the fix (#1068, the same #1087 treatment):
+// a fetch that lands after the shell started (boot, a reload) must render the
+// running shell without ever having witnessed the orchestrator-shell-activity
+// event that announced it.
+test('a running orchestrator seeds its shell activity from the snapshot alone', () => {
+  const seed = planOrchestratorShellSeed([orchestrator(7, true, 'sleep 300', 1_700_000_000)]);
+  assert.deepEqual(seed, [
+    { sessionId: 7, running: true, command: 'sleep 300', startedAtUnix: 1_700_000_000 },
+  ]);
+});
+
+test('an orchestrator with no running shell seeds not-running, clearing a stale entry', () => {
+  const seed = planOrchestratorShellSeed([orchestrator(7, false)]);
+  assert.deepEqual(seed, [{ sessionId: 7, running: false, command: '', startedAtUnix: 0 }]);
+});
+
+// A stopped orchestrator has no session id to key the shell-activity map by,
+// so it must not contribute a seed entry at all.
+test('a stopped orchestrator contributes no seed', () => {
+  assert.deepEqual(planOrchestratorShellSeed([orchestrator(0, false)]), []);
+});
+
+test('mixed running and stopped orchestrators seed only the running ones', () => {
+  const seed = planOrchestratorShellSeed([
+    orchestrator(1, true, 'sleep 300', 1_700_000_000),
+    orchestrator(0, false),
+    orchestrator(2, false),
+  ]);
+  assert.deepEqual(seed, [
+    { sessionId: 1, running: true, command: 'sleep 300', startedAtUnix: 1_700_000_000 },
+    { sessionId: 2, running: false, command: '', startedAtUnix: 0 },
+  ]);
+});

--- a/erun-ui/frontend/src/app/orchestratorShellActivitySeed.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorShellActivitySeed.test.ts
@@ -26,10 +26,10 @@ function orchestrator(
   };
 }
 
-// The point of the snapshot half of the fix (#1068, the same #1087 treatment):
-// a fetch that lands after the shell started (boot, a reload) must render the
-// running shell without ever having witnessed the orchestrator-shell-activity
-// event that announced it.
+// The point of the snapshot half of the fix (the same treatment the busy
+// signal already gets): a fetch that lands after the shell started (boot, a
+// reload) must render the running shell without ever having witnessed the
+// orchestrator-shell-activity event that announced it.
 test('a running orchestrator seeds its shell activity from the snapshot alone', () => {
   const seed = planOrchestratorShellSeed([orchestrator(7, true, 'sleep 300', 1_700_000_000)]);
   assert.deepEqual(seed, [

--- a/erun-ui/frontend/src/app/orchestratorShellActivitySeed.ts
+++ b/erun-ui/frontend/src/app/orchestratorShellActivitySeed.ts
@@ -1,0 +1,23 @@
+import type { OrchestratorInfo } from './slices/orchestratorsSlice';
+
+// planOrchestratorShellSeed derives the shell-activity-by-session entries a
+// freshly fetched orchestrator list implies (#1068), the same snapshot
+// treatment planOrchestratorBusySeed applies to the busy signal: the
+// orchestratorInfo shell fields carry the same signal as the
+// orchestrator-shell-activity event, so loadOrchestrators can seed the
+// event-keyed store directly from the list it already fetched rather than
+// requiring the row to have witnessed the event that last changed the state.
+// Only orchestrators with a live session are considered — a stopped one has
+// no session id to key the store by.
+export function planOrchestratorShellSeed(
+  items: OrchestratorInfo[],
+): { sessionId: number; running: boolean; command: string; startedAtUnix: number }[] {
+  return items
+    .filter((item) => item.sessionId > 0)
+    .map((item) => ({
+      sessionId: item.sessionId,
+      running: item.shellRunning,
+      command: item.shellCommand,
+      startedAtUnix: item.shellStartedAtUnix,
+    }));
+}

--- a/erun-ui/frontend/src/app/orchestratorShellActivitySeed.ts
+++ b/erun-ui/frontend/src/app/orchestratorShellActivitySeed.ts
@@ -1,7 +1,7 @@
 import type { OrchestratorInfo } from './slices/orchestratorsSlice';
 
 // planOrchestratorShellSeed derives the shell-activity-by-session entries a
-// freshly fetched orchestrator list implies (#1068), the same snapshot
+// freshly fetched orchestrator list implies, the same snapshot
 // treatment planOrchestratorBusySeed applies to the busy signal: the
 // orchestratorInfo shell fields carry the same signal as the
 // orchestrator-shell-activity event, so loadOrchestrators can seed the

--- a/erun-ui/frontend/src/app/orchestratorShellLabel.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorShellLabel.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { orchestratorShellLabel } from './orchestratorShellLabel';
+
+const START = 1_700_000_000; // unix seconds
+const NOW = (START + 332) * 1000; // 5m32s later, ms
+
+test('names the command and the elapsed time', () => {
+  const label = orchestratorShellLabel('agent', 'sleep 600', START, NOW);
+  assert.equal(label, 'agent has a shell running for 5m32s: sleep 600');
+});
+
+test('still names elapsed time when the command is unknown', () => {
+  const label = orchestratorShellLabel('agent', '', START, NOW);
+  assert.equal(label, 'agent has a shell running for 5m32s');
+});

--- a/erun-ui/frontend/src/app/orchestratorShellLabel.ts
+++ b/erun-ui/frontend/src/app/orchestratorShellLabel.ts
@@ -1,7 +1,7 @@
 import { formatElapsed } from './activityQueueState';
 
 // orchestratorShellLabel names what a running background shell is doing and
-// for how long (#1068): the operator asked for a spinner four times over one
+// for how long: the operator asked for a spinner four times over one
 // session because "1 shell still running" said a process existed without
 // saying whether it was still doing anything useful. Elapsed time plus the
 // command it is running answers that at a glance instead of requiring a trip

--- a/erun-ui/frontend/src/app/orchestratorShellLabel.ts
+++ b/erun-ui/frontend/src/app/orchestratorShellLabel.ts
@@ -1,0 +1,20 @@
+import { formatElapsed } from './activityQueueState';
+
+// orchestratorShellLabel names what a running background shell is doing and
+// for how long (#1068): the operator asked for a spinner four times over one
+// session because "1 shell still running" said a process existed without
+// saying whether it was still doing anything useful. Elapsed time plus the
+// command it is running answers that at a glance instead of requiring a trip
+// to the process table.
+export function orchestratorShellLabel(
+  orchestratorName: string,
+  command: string,
+  startedAtUnix: number,
+  nowMs: number,
+): string {
+  const elapsed = formatElapsed(new Date(startedAtUnix * 1000).toISOString(), nowMs).trim();
+  const suffix = elapsed ? ` for ${elapsed}` : '';
+  return command
+    ? `${orchestratorName} has a shell running${suffix}: ${command}`
+    : `${orchestratorName} has a shell running${suffix}`;
+}

--- a/erun-ui/frontend/src/app/orchestratorThunks.ts
+++ b/erun-ui/frontend/src/app/orchestratorThunks.ts
@@ -14,7 +14,9 @@ import {
 import { readError } from './errors';
 import { planOrchestratorBusySeed } from './orchestratorBusySeed';
 import { planOrchestratorRestore, readRestoreNotice } from './orchestratorRestore';
+import { planOrchestratorShellSeed } from './orchestratorShellActivitySeed';
 import { setAIBusyForSession } from './slices/aiActivitySlice';
+import { setShellActivityForSession } from './slices/orchestratorShellActivitySlice';
 import {
   closeOrchestratorDialog,
   type OrchestratorEnvRef,
@@ -28,10 +30,12 @@ import { setSessionId } from './slices/terminalSlice';
 import type { AppThunk } from './store';
 
 // loadOrchestrators fetches the current list and, in the same pass, seeds the
-// AI-busy store from each orchestrator's own `busy` snapshot field (#1087) —
-// the same store field the ai-activity event writes to, so a fetch that lands
-// after a busy transition (boot, a dialog close-and-reload, a manual refresh)
-// renders the true state even if that event was never observed.
+// AI-busy store from each orchestrator's own `busy` snapshot field (#1087),
+// and the shell-activity store from its shellRunning/shellCommand/
+// shellStartedAtUnix fields (#1068) — the same store fields the ai-activity and
+// orchestrator-shell-activity events write to, so a fetch that lands after a
+// transition (boot, a dialog close-and-reload, a manual refresh) renders the
+// true state even if that event was never observed.
 export const loadOrchestrators = (): AppThunk<Promise<void>> => async (dispatch) => {
   try {
     const list = (await ListOrchestrators()) as OrchestratorInfo[] | null;
@@ -39,6 +43,18 @@ export const loadOrchestrators = (): AppThunk<Promise<void>> => async (dispatch)
     dispatch(setOrchestrators(items));
     for (const seed of planOrchestratorBusySeed(items)) {
       dispatch(setAIBusyForSession(seed));
+    }
+    for (const seed of planOrchestratorShellSeed(items)) {
+      dispatch(
+        setShellActivityForSession({
+          sessionId: seed.sessionId,
+          activity: {
+            running: seed.running,
+            command: seed.command,
+            startedAtUnix: seed.startedAtUnix,
+          },
+        }),
+      );
     }
   } catch (error) {
     dispatch(setOrchestratorsError(readError(error)));
@@ -146,7 +162,10 @@ export const restartApp =
 // restart hand-off's prompt auto-runs for the one orchestrator it named, never
 // for the rest of the set. A refused hand-off still reopens its orchestrator
 // and surfaces the backend's notice beside the orchestrator list, so a resume
-// that declined to continue is never silent.
+// that declined to continue is never silent. Which conversation each
+// orchestrator resumes is the backend's call, not a re-derivation here (#1096):
+// this thunk just resumes whatever conversationId the target names, or starts
+// fresh when none was resolved.
 export const restoreOpenOrchestrators =
   (): AppThunk<Promise<boolean>> => async (dispatch, getState) => {
     try {
@@ -163,9 +182,16 @@ export const restoreOpenOrchestrators =
         return false;
       }
 
-      for (const id of alsoReopen) {
+      for (const ref of alsoReopen) {
         try {
-          await StartOrchestrator(id, 80, 24);
+          // A resolved conversation id resumes exactly that conversation; its
+          // absence means the backend found nothing safe to resume (#1096), so
+          // this orchestrator starts fresh instead.
+          if (ref.conversationId) {
+            await StartOrchestratorWithResume(ref.orchestratorId, ref.conversationId, '', 80, 24);
+          } else {
+            await StartOrchestrator(ref.orchestratorId, 80, 24);
+          }
         } catch (error) {
           dispatch(setOrchestratorsError(readError(error)));
         }
@@ -173,11 +199,13 @@ export const restoreOpenOrchestrators =
 
       let restoredPane = false;
       if (primary) {
-        // With a resume prompt, resume the conversation that asked for the
-        // restart AND hand it the task so a rebuild+restart continues on its own
-        // instead of idling at the prompt; without one, just resume the
-        // orchestrator's own pinned conversation.
-        const info = primary.resumePrompt
+        // A resolved conversation id resumes exactly that conversation — with
+        // the resume prompt handed to it so a rebuild+restart continues on its
+        // own instead of idling, or with none for a plain launch that just
+        // lands the operator back where they were. Its absence means the
+        // backend found nothing safe to resume, so this orchestrator starts
+        // fresh instead of a re-derivation that could land on the wrong one.
+        const info = primary.conversationId
           ? await StartOrchestratorWithResume(
               primary.id,
               primary.conversationId,

--- a/erun-ui/frontend/src/app/orchestratorThunks.ts
+++ b/erun-ui/frontend/src/app/orchestratorThunks.ts
@@ -30,9 +30,9 @@ import { setSessionId } from './slices/terminalSlice';
 import type { AppThunk } from './store';
 
 // loadOrchestrators fetches the current list and, in the same pass, seeds the
-// AI-busy store from each orchestrator's own `busy` snapshot field (#1087),
+// AI-busy store from each orchestrator's own `busy` snapshot field,
 // and the shell-activity store from its shellRunning/shellCommand/
-// shellStartedAtUnix fields (#1068) — the same store fields the ai-activity and
+// shellStartedAtUnix fields — the same store fields the ai-activity and
 // orchestrator-shell-activity events write to, so a fetch that lands after a
 // transition (boot, a dialog close-and-reload, a manual refresh) renders the
 // true state even if that event was never observed.
@@ -163,8 +163,8 @@ export const restartApp =
 // for the rest of the set. A refused hand-off still reopens its orchestrator
 // and surfaces the backend's notice beside the orchestrator list, so a resume
 // that declined to continue is never silent. Which conversation each
-// orchestrator resumes is the backend's call, not a re-derivation here (#1096):
-// this thunk just resumes whatever conversationId the target names, or starts
+// orchestrator resumes is the backend's call, not a re-derivation here: this
+// thunk just resumes whatever conversationId the target names, or starts
 // fresh when none was resolved.
 export const restoreOpenOrchestrators =
   (): AppThunk<Promise<boolean>> => async (dispatch, getState) => {
@@ -185,8 +185,8 @@ export const restoreOpenOrchestrators =
       for (const ref of alsoReopen) {
         try {
           // A resolved conversation id resumes exactly that conversation; its
-          // absence means the backend found nothing safe to resume (#1096), so
-          // this orchestrator starts fresh instead.
+          // absence means the backend found nothing safe to resume, so this
+          // orchestrator starts fresh instead.
           if (ref.conversationId) {
             await StartOrchestratorWithResume(ref.orchestratorId, ref.conversationId, '', 80, 24);
           } else {

--- a/erun-ui/frontend/src/app/slices/orchestratorShellActivitySlice.ts
+++ b/erun-ui/frontend/src/app/slices/orchestratorShellActivitySlice.ts
@@ -1,13 +1,13 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-// Per-orchestrator-session "background shell running" state (#1068), driven
+// Per-orchestrator-session "background shell running" state, driven
 // passively from the Go side (the orchestrator-shell-activity Wails event).
 // Independent of aiActivitySlice's busy latch: a background shell can outlive
 // the turn that started it, so the sidebar row needs to spin on this even
 // while the orchestrator itself reads idle.
 //
 // Two writers feed this map, deliberately kept as one field so they cannot
-// disagree (the same #1087 treatment aiActivitySlice documents): the
+// disagree (the same treatment aiActivitySlice documents): the
 // orchestrator-shell-activity event (handleOrchestratorShellActivity) and
 // loadOrchestrators seeding it from each orchestrator's own
 // shellRunning/shellCommand/shellStartedAtUnix snapshot fields

--- a/erun-ui/frontend/src/app/slices/orchestratorShellActivitySlice.ts
+++ b/erun-ui/frontend/src/app/slices/orchestratorShellActivitySlice.ts
@@ -1,0 +1,55 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+// Per-orchestrator-session "background shell running" state (#1068), driven
+// passively from the Go side (the orchestrator-shell-activity Wails event).
+// Independent of aiActivitySlice's busy latch: a background shell can outlive
+// the turn that started it, so the sidebar row needs to spin on this even
+// while the orchestrator itself reads idle.
+//
+// Two writers feed this map, deliberately kept as one field so they cannot
+// disagree (the same #1087 treatment aiActivitySlice documents): the
+// orchestrator-shell-activity event (handleOrchestratorShellActivity) and
+// loadOrchestrators seeding it from each orchestrator's own
+// shellRunning/shellCommand/shellStartedAtUnix snapshot fields
+// (planOrchestratorShellSeed). The event is the fast path while a session
+// runs; the snapshot is what makes a fetch that lands after a transition —
+// boot, a reload, a reconnect — render the true state without having
+// witnessed that transition.
+export interface OrchestratorShellActivity {
+  running: boolean;
+  command: string;
+  startedAtUnix: number;
+}
+
+export interface OrchestratorShellActivityState {
+  bySession: Record<number, OrchestratorShellActivity>;
+}
+
+const initialState: OrchestratorShellActivityState = {
+  bySession: {},
+};
+
+export const orchestratorShellActivitySlice = createSlice({
+  name: 'orchestratorShellActivity',
+  initialState,
+  reducers: {
+    setShellActivityForSession(
+      state,
+      action: PayloadAction<{ sessionId: number; activity: OrchestratorShellActivity }>,
+    ) {
+      const { sessionId, activity } = action.payload;
+      if (activity.running) {
+        state.bySession[sessionId] = activity;
+      } else {
+        Reflect.deleteProperty(state.bySession, sessionId);
+      }
+    },
+    clearOrchestratorShellActivity(state) {
+      state.bySession = {};
+    },
+  },
+});
+
+export const { setShellActivityForSession, clearOrchestratorShellActivity } =
+  orchestratorShellActivitySlice.actions;
+export default orchestratorShellActivitySlice.reducer;

--- a/erun-ui/frontend/src/app/slices/orchestratorsSlice.ts
+++ b/erun-ui/frontend/src/app/slices/orchestratorsSlice.ts
@@ -17,6 +17,10 @@ export interface OrchestratorEnvRef {
 // seeds aiBusyBySession from this field on every fetch — see planOrchestratorBusySeed
 // — so the event and the snapshot write the same store field instead of
 // competing for it.
+//
+// `shellRunning`/`shellCommand`/`shellStartedAtUnix` are the same treatment for
+// a background shell (#1068), independent of `busy`: a shell can outlive the
+// turn that started it. See planOrchestratorShellSeed.
 export interface OrchestratorInfo {
   id: string;
   name: string;
@@ -27,6 +31,9 @@ export interface OrchestratorInfo {
   status: string;
   busy: boolean;
   transient: boolean;
+  shellRunning: boolean;
+  shellCommand: string;
+  shellStartedAtUnix: number;
 }
 
 export interface OrchestratorsState {

--- a/erun-ui/frontend/src/app/slices/orchestratorsSlice.ts
+++ b/erun-ui/frontend/src/app/slices/orchestratorsSlice.ts
@@ -19,7 +19,7 @@ export interface OrchestratorEnvRef {
 // competing for it.
 //
 // `shellRunning`/`shellCommand`/`shellStartedAtUnix` are the same treatment for
-// a background shell (#1068), independent of `busy`: a shell can outlive the
+// a background shell, independent of `busy`: a shell can outlive the
 // turn that started it. See planOrchestratorShellSeed.
 export interface OrchestratorInfo {
   id: string;

--- a/erun-ui/frontend/src/app/store.ts
+++ b/erun-ui/frontend/src/app/store.ts
@@ -30,6 +30,7 @@ import idleReducer from './slices/idleSlice';
 import layoutReducer from './slices/layoutSlice';
 import manageDialogReducer from './slices/manageDialogSlice';
 import notificationReducer from './slices/notificationSlice';
+import orchestratorShellActivityReducer from './slices/orchestratorShellActivitySlice';
 import orchestratorsReducer from './slices/orchestratorsSlice';
 import outputsDialogReducer from './slices/outputsDialogSlice';
 import pinVersionReducer from './slices/pinVersionSlice';
@@ -74,6 +75,7 @@ export const store = configureStore({
     outputsDialog: outputsDialogReducer,
     pinVersion: pinVersionReducer,
     orchestrators: orchestratorsReducer,
+    orchestratorShellActivity: orchestratorShellActivityReducer,
     [wailsApi.reducerPath]: wailsApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>

--- a/erun-ui/frontend/src/app/terminalWailsEvents.ts
+++ b/erun-ui/frontend/src/app/terminalWailsEvents.ts
@@ -9,6 +9,7 @@ import type {
   EnvActivityPayload,
   EnvironmentInitializedPayload,
   EnvStatusPayload,
+  OrchestratorShellActivityPayload,
 } from './model';
 import { store } from './store';
 import {
@@ -20,6 +21,7 @@ import {
   handleEnvironmentInitFailed,
   handleEnvironmentInitialized,
   handleEnvStatus,
+  handleOrchestratorShellActivity,
   handleReconnectLine,
   handleTerminalExit,
 } from './wailsEventThunks';
@@ -50,6 +52,9 @@ export class TerminalWailsEvents {
       }),
       EventsOn('ai-activity', (payload: AIActivityPayload) => {
         store.dispatch(handleAIActivity(payload));
+      }),
+      EventsOn('orchestrator-shell-activity', (payload: OrchestratorShellActivityPayload) => {
+        store.dispatch(handleOrchestratorShellActivity(payload));
       }),
       EventsOn('env-status', (payload: EnvStatusPayload) => {
         store.dispatch(handleEnvStatus(payload));

--- a/erun-ui/frontend/src/app/wailsEventThunks.ts
+++ b/erun-ui/frontend/src/app/wailsEventThunks.ts
@@ -10,6 +10,7 @@ import type {
   EnvActivityPayload,
   EnvironmentInitializedPayload,
   EnvStatusPayload,
+  OrchestratorShellActivityPayload,
   TerminalExitSelections,
 } from './model';
 import {
@@ -28,6 +29,7 @@ import { openSelection, selectTerminalTab, startInitialDeploySelection } from '.
 import { setAIBusyForEnv, setAIBusyForSession } from './slices/aiActivitySlice';
 import { setDoctorAll } from './slices/doctorSlice';
 import { setEnvActivityForEnv, setEnvStatusForEnv } from './slices/envStatusSlice';
+import { setShellActivityForSession } from './slices/orchestratorShellActivitySlice';
 import { appendReconnectLine } from './slices/reviewSlice';
 import {
   clearPendingOpenAfterDeploy,
@@ -70,6 +72,28 @@ export const handleAIActivity =
     }
     const key = selectionKey({ tenant, environment });
     dispatch(setAIBusyForEnv({ key, busy: payload.busy }));
+  };
+
+// handleOrchestratorShellActivity surfaces that an orchestrator has a
+// background shell running even after its own turn has gone idle (#1068) —
+// the case a plain busy spinner cannot show, since backgrounding a shell is
+// what lets the turn end without waiting for it.
+export const handleOrchestratorShellActivity =
+  (payload: OrchestratorShellActivityPayload): AppThunk =>
+  (dispatch) => {
+    if (payload.sessionId <= 0) {
+      return;
+    }
+    dispatch(
+      setShellActivityForSession({
+        sessionId: payload.sessionId,
+        activity: {
+          running: payload.running,
+          command: payload.command,
+          startedAtUnix: payload.startedAtUnix,
+        },
+      }),
+    );
   };
 
 // handleEnvStatus keeps the sidebar's open dot reflecting the env's real

--- a/erun-ui/frontend/src/app/wailsEventThunks.ts
+++ b/erun-ui/frontend/src/app/wailsEventThunks.ts
@@ -75,9 +75,9 @@ export const handleAIActivity =
   };
 
 // handleOrchestratorShellActivity surfaces that an orchestrator has a
-// background shell running even after its own turn has gone idle (#1068) —
-// the case a plain busy spinner cannot show, since backgrounding a shell is
-// what lets the turn end without waiting for it.
+// background shell running even after its own turn has gone idle — the case a
+// plain busy spinner cannot show, since backgrounding a shell is what lets the
+// turn end without waiting for it.
 export const handleOrchestratorShellActivity =
   (payload: OrchestratorShellActivityPayload): AppThunk =>
   (dispatch) => {

--- a/erun-ui/frontend/src/components/app/Sidebar.ErunSection.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.ErunSection.tsx
@@ -185,7 +185,7 @@ function OrchestratorRow({
       orchestrator.sessionId > 0 &&
       state.aiActivity.aiBusyBySession[orchestrator.sessionId] === true,
   );
-  // A background shell (#1068) is independent of the turn's own busy state —
+  // A background shell is independent of the turn's own busy state —
   // it can keep running after the turn that started it goes idle, which is
   // exactly the case that had no affordance at all before this. Shown only
   // when the turn itself is not already spinning, so the row never carries
@@ -234,8 +234,8 @@ function OrchestratorRow({
 // turn or a busy environment (Nielsen #4, consistency). The aria-label — and
 // the hover tooltip, since elapsed time and the command are worth seeing at a
 // glance, not just to a screen reader — name what is running and for how
-// long, which is the whole point of #1068: "1 shell" alone cannot tell the
-// operator whether it is doing something or just spinning its wheels.
+// long, which is the whole point of this indicator: "1 shell" alone cannot
+// tell the operator whether it is doing something or just spinning its wheels.
 function OrchestratorShellIndicator({
   name,
   activity,

--- a/erun-ui/frontend/src/components/app/Sidebar.ErunSection.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.ErunSection.tsx
@@ -12,6 +12,7 @@ import * as React from 'react';
 import { openGlobalConfigDialog } from '@/app/globalConfigThunks';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { startManageDoctor } from '@/app/manageEnvironmentThunks';
+import { orchestratorShellLabel } from '@/app/orchestratorShellLabel';
 import {
   loadOrchestrators,
   openOrchestrator,
@@ -19,6 +20,7 @@ import {
   startOrchestrator,
 } from '@/app/orchestratorThunks';
 import { openOutputs } from '@/app/outputsThunks';
+import type { OrchestratorShellActivity } from '@/app/slices/orchestratorShellActivitySlice';
 import type { OrchestratorInfo } from '@/app/slices/orchestratorsSlice';
 import { openOrchestratorDialog } from '@/app/slices/orchestratorsSlice';
 import { EmptyState } from '@/components/app/EmptyState';
@@ -183,6 +185,16 @@ function OrchestratorRow({
       orchestrator.sessionId > 0 &&
       state.aiActivity.aiBusyBySession[orchestrator.sessionId] === true,
   );
+  // A background shell (#1068) is independent of the turn's own busy state —
+  // it can keep running after the turn that started it goes idle, which is
+  // exactly the case that had no affordance at all before this. Shown only
+  // when the turn itself is not already spinning, so the row never carries
+  // two motion cues fighting for the same attention.
+  const shellActivity = useAppSelector((state) =>
+    orchestrator.sessionId > 0
+      ? state.orchestratorShellActivity.bySession[orchestrator.sessionId]
+      : undefined,
+  );
   return (
     <li
       className={cn(
@@ -209,8 +221,33 @@ function OrchestratorRow({
         <span className="min-w-0 truncate">{orchestrator.name}</span>
       </button>
       {busy && <BusyRowSpinner label={`${orchestrator.name} is working`} />}
+      {!busy && shellActivity?.running && (
+        <OrchestratorShellIndicator name={orchestrator.name} activity={shellActivity} />
+      )}
       <OrchestratorRowActions orchestrator={orchestrator} running={running} active={active} />
     </li>
+  );
+}
+
+// OrchestratorShellIndicator is BusyRowSpinner's own icon, reused rather than
+// a one-off, so a running shell reports activity identically to a working
+// turn or a busy environment (Nielsen #4, consistency). The aria-label — and
+// the hover tooltip, since elapsed time and the command are worth seeing at a
+// glance, not just to a screen reader — name what is running and for how
+// long, which is the whole point of #1068: "1 shell" alone cannot tell the
+// operator whether it is doing something or just spinning its wheels.
+function OrchestratorShellIndicator({
+  name,
+  activity,
+}: {
+  name: string;
+  activity: OrchestratorShellActivity;
+}): React.ReactElement {
+  const label = orchestratorShellLabel(name, activity.command, activity.startedAtUnix, Date.now());
+  return (
+    <IconTooltip label={label}>
+      <BusyRowSpinner label={label} />
+    </IconTooltip>
   );
 }
 

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -55,6 +55,15 @@ type orchestratorSession struct {
 	// on having witnessed the ai-activity event that last changed it. See
 	// reconcileOrchestratorActivity in session_heartbeat.go.
 	aiBusy bool
+	// shellRunning, shellCommand and shellStartedAtUnix are the last background
+	// shell report the poller observed (#1068) — a fact independent of aiBusy,
+	// since a shell can keep running after the turn that started it ends. Same
+	// snapshot treatment as aiBusy and for the same reason: orchestratorInfoFor
+	// reads these directly so a fresh mount or reconnect renders the true state
+	// without depending on the orchestrator-shell-activity event.
+	shellRunning       bool
+	shellCommand       string
+	shellStartedAtUnix int64
 }
 
 // orchestratorEnvInput is the frontend's env selection for create/update.
@@ -88,16 +97,27 @@ type orchestratorEnvInfo struct {
 // state without having had to witness that event. The frontend seeds its
 // event-keyed store from this field on every fetch (loadOrchestrators) rather
 // than keeping a second source of truth; see aiActivitySlice.ts.
+//
+// ShellRunning/ShellCommand/ShellStartedAtUnix are the same treatment for a
+// background shell (#1068): independent of Busy, since a shell can outlive the
+// turn that started it, and carried directly rather than left to the
+// orchestrator-shell-activity event alone. ShellStartedAtUnix is when the
+// running shell was reported started, unix seconds, 0 when ShellRunning is
+// false — the frontend derives elapsed time from it rather than the desktop
+// formatting a string that immediately goes stale.
 type orchestratorInfo struct {
-	ID           string                `json:"id"`
-	Name         string                `json:"name"`
-	Environments []orchestratorEnvInfo `json:"environments"`
-	Tenants      []string              `json:"tenants"`
-	Directories  []string              `json:"directories"`
-	SessionID    int                   `json:"sessionId"`
-	Status       string                `json:"status"`
-	Busy         bool                  `json:"busy"`
-	Transient    bool                  `json:"transient"`
+	ID                 string                `json:"id"`
+	Name               string                `json:"name"`
+	Environments       []orchestratorEnvInfo `json:"environments"`
+	Tenants            []string              `json:"tenants"`
+	Directories        []string              `json:"directories"`
+	SessionID          int                   `json:"sessionId"`
+	Status             string                `json:"status"`
+	Busy               bool                  `json:"busy"`
+	Transient          bool                  `json:"transient"`
+	ShellRunning       bool                  `json:"shellRunning"`
+	ShellCommand       string                `json:"shellCommand,omitempty"`
+	ShellStartedAtUnix int64                 `json:"shellStartedAtUnix,omitempty"`
 }
 
 func orchestratorSessionKey(id string) string {
@@ -573,6 +593,12 @@ func ensureOrchestratorSessionStartHook(dir string) error {
 	}
 	stop := mergeOrchestratorHookBlocks(hooks["Stop"], idleHook, isOrchestratorActivityHookBlock)
 	hooks["Stop"] = mergeOrchestratorHookBlocks(stop, orchestratorNoAskStopGuardBlock(), isOrchestratorNoAskStopGuardBlock)
+	// A background shell's start and its completion are both only visible in a
+	// tool call's own result, which PreToolUse never carries — so unlike the
+	// turn-boundary busy report above, this one lives on PostToolUse alone.
+	// See orchestrator_shell_activity.go.
+	hooks["PostToolUse"] = mergeOrchestratorHookBlocks(
+		hooks["PostToolUse"], orchestratorShellActivityHookBlocks(), isOrchestratorShellActivityHookBlock)
 	settings["hooks"] = hooks
 	out, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {
@@ -714,17 +740,30 @@ func directoriesFromEnvs(envs []eruncommon.OrchestratorEnvConfig) []string {
 	return out
 }
 
-func orchestratorInfoFor(id, name string, envs []eruncommon.OrchestratorEnvConfig, status string, sessionID int, busy, transient bool) orchestratorInfo {
+// orchestratorShellSnapshot is the background-shell half of orchestratorInfo
+// (#1068), grouped into one value so orchestratorInfoFor's call sites read as
+// "this session's shell state" rather than three more positional bools and
+// strings indistinguishable from the ones beside them.
+type orchestratorShellSnapshot struct {
+	Running       bool
+	Command       string
+	StartedAtUnix int64
+}
+
+func orchestratorInfoFor(id, name string, envs []eruncommon.OrchestratorEnvConfig, status string, sessionID int, busy, transient bool, shell orchestratorShellSnapshot) orchestratorInfo {
 	return orchestratorInfo{
-		ID:           id,
-		Name:         name,
-		Environments: envInfos(envs),
-		Tenants:      tenantsFromEnvs(envs),
-		Directories:  directoriesFromEnvs(envs),
-		SessionID:    sessionID,
-		Status:       status,
-		Busy:         busy,
-		Transient:    transient,
+		ID:                 id,
+		Name:               name,
+		Environments:       envInfos(envs),
+		Tenants:            tenantsFromEnvs(envs),
+		Directories:        directoriesFromEnvs(envs),
+		SessionID:          sessionID,
+		Status:             status,
+		Busy:               busy,
+		ShellRunning:       shell.Running,
+		ShellCommand:       shell.Command,
+		ShellStartedAtUnix: shell.StartedAtUnix,
+		Transient:          transient,
 	}
 }
 
@@ -1047,7 +1086,7 @@ func (a *App) CreateOrchestrator(name string, envs []orchestratorEnvInput) (orch
 	if err := a.saveOrchestratorConfigs(append(configs, def)); err != nil {
 		return orchestratorInfo{}, err
 	}
-	return orchestratorInfoFor(id, displayName, refs, "stopped", 0, false, false), nil
+	return orchestratorInfoFor(id, displayName, refs, "stopped", 0, false, false, orchestratorShellSnapshot{}), nil
 }
 
 // UpdateOrchestrator edits an existing orchestrator's linked environments and
@@ -1085,12 +1124,14 @@ func (a *App) UpdateOrchestrator(id, name string, envs []orchestratorEnvInput) (
 	status := "stopped"
 	sessionID := 0
 	busy := false
+	shell := orchestratorShellSnapshot{}
 	if info, ok := a.runningOrchestratorInfo(id); ok {
 		status = "running"
 		sessionID = info.SessionID
 		busy = info.Busy
+		shell = orchestratorShellSnapshot{Running: info.ShellRunning, Command: info.ShellCommand, StartedAtUnix: info.ShellStartedAtUnix}
 	}
-	return orchestratorInfoFor(id, displayName, refs, status, sessionID, busy, false), nil
+	return orchestratorInfoFor(id, displayName, refs, status, sessionID, busy, false, shell), nil
 }
 
 // StartOrchestrator spawns the session for a persisted orchestrator definition,
@@ -1178,7 +1219,8 @@ func (a *App) runningOrchestratorInfo(id string) (orchestratorInfo, bool) {
 	if session == nil || managed == nil || managed.closed {
 		return orchestratorInfo{}, false
 	}
-	return orchestratorInfoFor(session.id, session.name, session.envs, "running", session.serial, session.aiBusy, session.transient), true
+	shell := orchestratorShellSnapshot{Running: session.shellRunning, Command: session.shellCommand, StartedAtUnix: session.shellStartedAtUnix}
+	return orchestratorInfoFor(session.id, session.name, session.envs, "running", session.serial, session.aiBusy, session.transient, shell), true
 }
 
 // runningOrchestratorConversation returns the conversation a live session is
@@ -1328,11 +1370,11 @@ func (a *App) spawnOrchestratorSession(spawn orchestratorSpawn) (orchestratorInf
 	// written here survives that. A transient (Investigate) session has no
 	// persisted definition to reopen, so it is deliberately not recorded.
 	if !transient {
-		if err := recordOpenOrchestrator(a.deps.orchestratorOpenPath, id); err != nil {
+		if err := recordOpenOrchestrator(a.deps.orchestratorOpenPath, id, conversationID); err != nil {
 			log.Printf("erun-app: record open orchestrator %s: %v", id, err)
 		}
 	}
-	return orchestratorInfoFor(id, name, envs, "running", serial, false, transient), nil
+	return orchestratorInfoFor(id, name, envs, "running", serial, false, transient, orchestratorShellSnapshot{}), nil
 }
 
 // ListOrchestrators merges the persisted definitions (each tagged running or
@@ -1350,14 +1392,16 @@ func (a *App) ListOrchestrators() []orchestratorInfo {
 		status := "stopped"
 		sessionID := 0
 		busy := false
+		shell := orchestratorShellSnapshot{}
 		if session := a.orchestrators[config.ID]; session != nil {
 			if managed := a.sessions[orchestratorSessionKey(config.ID)]; managed != nil && !managed.closed {
 				status = "running"
 				sessionID = session.serial
 				busy = session.aiBusy
+				shell = orchestratorShellSnapshot{Running: session.shellRunning, Command: session.shellCommand, StartedAtUnix: session.shellStartedAtUnix}
 			}
 		}
-		out = append(out, orchestratorInfoFor(config.ID, config.Name, config.Environments, status, sessionID, busy, false))
+		out = append(out, orchestratorInfoFor(config.ID, config.Name, config.Environments, status, sessionID, busy, false, shell))
 		seen[config.ID] = struct{}{}
 	}
 	for id, session := range a.orchestrators {
@@ -1368,7 +1412,8 @@ func (a *App) ListOrchestrators() []orchestratorInfo {
 		if managed == nil || managed.closed {
 			continue
 		}
-		out = append(out, orchestratorInfoFor(id, session.name, session.envs, "running", session.serial, session.aiBusy, true))
+		shell := orchestratorShellSnapshot{Running: session.shellRunning, Command: session.shellCommand, StartedAtUnix: session.shellStartedAtUnix}
+		out = append(out, orchestratorInfoFor(id, session.name, session.envs, "running", session.serial, session.aiBusy, true, shell))
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -56,7 +56,7 @@ type orchestratorSession struct {
 	// reconcileOrchestratorActivity in session_heartbeat.go.
 	aiBusy bool
 	// shellRunning, shellCommand and shellStartedAtUnix are the last background
-	// shell report the poller observed (#1068) — a fact independent of aiBusy,
+	// shell report the poller observed — a fact independent of aiBusy,
 	// since a shell can keep running after the turn that started it ends. Same
 	// snapshot treatment as aiBusy and for the same reason: orchestratorInfoFor
 	// reads these directly so a fresh mount or reconnect renders the true state
@@ -99,7 +99,7 @@ type orchestratorEnvInfo struct {
 // than keeping a second source of truth; see aiActivitySlice.ts.
 //
 // ShellRunning/ShellCommand/ShellStartedAtUnix are the same treatment for a
-// background shell (#1068): independent of Busy, since a shell can outlive the
+// background shell: independent of Busy, since a shell can outlive the
 // turn that started it, and carried directly rather than left to the
 // orchestrator-shell-activity event alone. ShellStartedAtUnix is when the
 // running shell was reported started, unix seconds, 0 when ShellRunning is
@@ -740,10 +740,10 @@ func directoriesFromEnvs(envs []eruncommon.OrchestratorEnvConfig) []string {
 	return out
 }
 
-// orchestratorShellSnapshot is the background-shell half of orchestratorInfo
-// (#1068), grouped into one value so orchestratorInfoFor's call sites read as
-// "this session's shell state" rather than three more positional bools and
-// strings indistinguishable from the ones beside them.
+// orchestratorShellSnapshot is the background-shell half of orchestratorInfo,
+// grouped into one value so orchestratorInfoFor's call sites read as "this
+// session's shell state" rather than three more positional bools and strings
+// indistinguishable from the ones beside them.
 type orchestratorShellSnapshot struct {
 	Running       bool
 	Command       string

--- a/erun-ui/orchestrator_open_state.go
+++ b/erun-ui/orchestrator_open_state.go
@@ -34,7 +34,7 @@ import (
 // transcript, can leave the live conversation at a different id than the one
 // derived from the orchestrator's own. Recording the conversation id at spawn
 // time (see recordOpenOrchestrator's caller) is what lets a restore resume the
-// conversation that was actually there instead of guessing (#1096).
+// conversation that was actually there instead of guessing.
 //
 // app_restart.go owns the OTHER record: the one-shot hand-off an in-app restart
 // writes, which carries the prompt the resumed session should auto-run. That one
@@ -58,14 +58,16 @@ type orchestratorOpenState struct {
 	// running, oldest first, each carrying the conversation id it was actually
 	// spawned with.
 	Orchestrators []orchestratorOpenEntry `json:"orchestrators,omitempty"`
-	// OrchestratorIDs is the shape this file had under #1098, before an entry
-	// carried a session id at all. Only read, never written again: an operator
-	// upgrading from that release must not lose the orchestrators they had
-	// open — they come back with no recorded session, so restore starts each of
-	// them on a fresh conversation rather than guessing which one was theirs.
+	// OrchestratorIDs is the shape this file had under an earlier release,
+	// before an entry carried a session id at all. Only read, never written
+	// again: an operator upgrading from that release must not lose the
+	// orchestrators they had open — they come back with no recorded session,
+	// so restore starts each of them on a fresh conversation rather than
+	// guessing which one was theirs.
 	OrchestratorIDs []string `json:"orchestratorIds,omitempty"`
-	// OrchestratorID is the shape from #971, before the file could hold more
-	// than one id at all. Same treatment: read, never written again.
+	// OrchestratorID is the shape from a release before that, before the file
+	// could hold more than one id at all. Same treatment: read, never written
+	// again.
 	OrchestratorID string `json:"orchestratorId,omitempty"`
 }
 
@@ -145,10 +147,10 @@ func readOpenOrchestrators(path string) []orchestratorOpenEntry {
 	if entries := dedupOrchestratorEntries(state.Orchestrators); len(entries) > 0 {
 		return entries
 	}
-	// A legacy file (the #971 scalar, or the #1098 id-only set) never recorded a
-	// session id, so every id it names comes back with none — restore must
-	// start each of them fresh rather than resolving to whatever its derived id
-	// happens to already name on disk.
+	// A legacy file (the older scalar shape, or the later id-only set) never
+	// recorded a session id, so every id it names comes back with none —
+	// restore must start each of them fresh rather than resolving to whatever
+	// its derived id happens to already name on disk.
 	legacy := make([]orchestratorOpenEntry, 0, len(state.OrchestratorIDs)+1)
 	if id := strings.TrimSpace(state.OrchestratorID); id != "" {
 		legacy = append(legacy, orchestratorOpenEntry{OrchestratorID: id})

--- a/erun-ui/orchestrator_open_state.go
+++ b/erun-ui/orchestrator_open_state.go
@@ -10,9 +10,10 @@ import (
 // The desktop keeps two separate records of which orchestrator a launch should
 // reopen, because they answer different questions and must not share a lifetime.
 //
-// This file owns the DURABLE one: which orchestrators are open. It is written the
-// moment a session starts and cleared the moment the operator stops it — never
-// at shutdown, because a crash, a `pkill` or a reboot takes the desktop away
+// This file owns the DURABLE one: which orchestrators are open, and which
+// conversation each was last known to be running. It is written the moment a
+// session starts and cleared the moment the operator stops it — never at
+// shutdown, because a crash, a `pkill` or a reboot takes the desktop away
 // without running any hook, and a record only a clean quit could write would be
 // missing exactly when it is most needed. It carries no timestamp either: an
 // orchestrator the operator left open is still the one they were in, however
@@ -20,10 +21,20 @@ import (
 //
 // The record is a SET, not a single id: every orchestrator the operator had
 // open comes back, not just the last one started. It is kept in recency order —
-// each (re)start moves its id to the end — because that order is also how
+// each (re)start moves its entry to the end — because that order is also how
 // app_restart.go picks which one owns the terminal pane when no restart
 // hand-off names one: the most recently (re)started orchestrator, on the theory
 // that starting one is also how the operator ends up looking at it.
+//
+// Each entry carries the conversation id it was actually spawned with, not just
+// the orchestrator id. A restore that only had the orchestrator id used to
+// re-derive a session id from it (uuid5(namespace, id)) and resume THAT — which
+// is only correct while the live session's id is always the derived one. It is
+// not: a resume that falls through to an unpinned launch, or a corrupted
+// transcript, can leave the live conversation at a different id than the one
+// derived from the orchestrator's own. Recording the conversation id at spawn
+// time (see recordOpenOrchestrator's caller) is what lets a restore resume the
+// conversation that was actually there instead of guessing (#1096).
 //
 // app_restart.go owns the OTHER record: the one-shot hand-off an in-app restart
 // writes, which carries the prompt the resumed session should auto-run. That one
@@ -32,14 +43,29 @@ import (
 
 const orchestratorOpenFileName = "orchestrator-open.json"
 
+// orchestratorOpenEntry is one orchestrator in the durable open set: its id and
+// the conversation last known to be running under it. SessionID is empty for an
+// entry migrated from a release that predates this file (see
+// orchestratorOpenState), which restore treats as "no live session recorded"
+// rather than a session pinned to nothing.
+type orchestratorOpenEntry struct {
+	OrchestratorID string `json:"orchestratorId"`
+	SessionID      string `json:"sessionId,omitempty"`
+}
+
 type orchestratorOpenState struct {
-	// OrchestratorIDs is the set of orchestrators open when the desktop was last
-	// running, oldest first.
+	// Orchestrators is the set of orchestrators open when the desktop was last
+	// running, oldest first, each carrying the conversation id it was actually
+	// spawned with.
+	Orchestrators []orchestratorOpenEntry `json:"orchestrators,omitempty"`
+	// OrchestratorIDs is the shape this file had under #1098, before an entry
+	// carried a session id at all. Only read, never written again: an operator
+	// upgrading from that release must not lose the orchestrators they had
+	// open — they come back with no recorded session, so restore starts each of
+	// them on a fresh conversation rather than guessing which one was theirs.
 	OrchestratorIDs []string `json:"orchestratorIds,omitempty"`
-	// OrchestratorID is the shape this file had before it could hold more than
-	// one id. Only read, never written again: an operator upgrading from a
-	// release that only ever wrote this field must not lose the one
-	// orchestrator they had open.
+	// OrchestratorID is the shape from #971, before the file could hold more
+	// than one id at all. Same treatment: read, never written again.
 	OrchestratorID string `json:"orchestratorId,omitempty"`
 }
 
@@ -53,42 +79,45 @@ func defaultOrchestratorOpenPath() string {
 	return filepath.Join(configDir, "ERun", orchestratorOpenFileName)
 }
 
-// recordOpenOrchestrator adds an orchestrator to the open set, or moves it to
-// the end (most recent) if it was already there.
-func recordOpenOrchestrator(path, orchestratorID string) error {
+// recordOpenOrchestrator adds an orchestrator to the open set together with the
+// conversation id it was just spawned with, or moves it to the end (most
+// recent) with that conversation id if it was already there. Called every time
+// a session is spawned, so the record always names the conversation this
+// launch is actually running rather than one a restore would have to derive.
+func recordOpenOrchestrator(path, orchestratorID, sessionID string) error {
 	orchestratorID = strings.TrimSpace(orchestratorID)
 	if path == "" || orchestratorID == "" {
 		return nil
 	}
-	ids := readOpenOrchestrators(path)
-	out := make([]string, 0, len(ids)+1)
-	for _, id := range ids {
-		if id != orchestratorID {
-			out = append(out, id)
+	entries := readOpenOrchestrators(path)
+	out := make([]orchestratorOpenEntry, 0, len(entries)+1)
+	for _, entry := range entries {
+		if entry.OrchestratorID != orchestratorID {
+			out = append(out, entry)
 		}
 	}
-	out = append(out, orchestratorID)
+	out = append(out, orchestratorOpenEntry{OrchestratorID: orchestratorID, SessionID: strings.TrimSpace(sessionID)})
 	return writeOpenOrchestrators(path, out)
 }
 
 // clearOpenOrchestrator forgets one orchestrator when the operator stops it,
 // which is what keeps an explicitly stopped orchestrator closed on every later
-// launch. Every other id in the set is left exactly as recorded: stopping one
-// orchestrator must not forget that the rest are still open.
+// launch. Every other entry in the set is left exactly as recorded: stopping
+// one orchestrator must not forget that the rest are still open.
 func clearOpenOrchestrator(path, orchestratorID string) error {
 	orchestratorID = strings.TrimSpace(orchestratorID)
 	if path == "" || orchestratorID == "" {
 		return nil
 	}
-	ids := readOpenOrchestrators(path)
-	out := make([]string, 0, len(ids))
+	entries := readOpenOrchestrators(path)
+	out := make([]orchestratorOpenEntry, 0, len(entries))
 	removed := false
-	for _, id := range ids {
-		if id == orchestratorID {
+	for _, entry := range entries {
+		if entry.OrchestratorID == orchestratorID {
 			removed = true
 			continue
 		}
-		out = append(out, id)
+		out = append(out, entry)
 	}
 	if !removed {
 		return nil
@@ -97,10 +126,11 @@ func clearOpenOrchestrator(path, orchestratorID string) error {
 }
 
 // readOpenOrchestrators returns the orchestrators that were open when the
-// desktop last ran, oldest first, or nil when none were. Reading does not clear
-// the record: it is durable, so every launch reopens the same set until an
-// entry is stopped. A legacy single-id file is understood as a one-element set.
-func readOpenOrchestrators(path string) []string {
+// desktop last ran, oldest first, each with the conversation id it was last
+// known to be running (empty when a restore must not assume one — see
+// orchestratorOpenState). Reading does not clear the record: it is durable, so
+// every launch reopens the same set until an entry is stopped.
+func readOpenOrchestrators(path string) []orchestratorOpenEntry {
 	if path == "" {
 		return nil
 	}
@@ -112,45 +142,59 @@ func readOpenOrchestrators(path string) []string {
 	if err := json.Unmarshal(data, &state); err != nil {
 		return nil
 	}
-	seen := make(map[string]struct{}, len(state.OrchestratorIDs)+1)
-	ids := make([]string, 0, len(state.OrchestratorIDs)+1)
-	add := func(id string) {
-		id = strings.TrimSpace(id)
-		if id == "" {
-			return
-		}
-		if _, ok := seen[id]; ok {
-			return
-		}
-		seen[id] = struct{}{}
-		ids = append(ids, id)
+	if entries := dedupOrchestratorEntries(state.Orchestrators); len(entries) > 0 {
+		return entries
 	}
-	// The legacy scalar is the sole open orchestrator on a file no launch has
-	// rewritten into the set shape yet, so it takes the oldest position.
-	add(state.OrchestratorID)
+	// A legacy file (the #971 scalar, or the #1098 id-only set) never recorded a
+	// session id, so every id it names comes back with none — restore must
+	// start each of them fresh rather than resolving to whatever its derived id
+	// happens to already name on disk.
+	legacy := make([]orchestratorOpenEntry, 0, len(state.OrchestratorIDs)+1)
+	if id := strings.TrimSpace(state.OrchestratorID); id != "" {
+		legacy = append(legacy, orchestratorOpenEntry{OrchestratorID: id})
+	}
 	for _, id := range state.OrchestratorIDs {
-		add(id)
+		legacy = append(legacy, orchestratorOpenEntry{OrchestratorID: id})
 	}
-	if len(ids) == 0 {
-		return nil
-	}
-	return ids
+	return dedupOrchestratorEntries(legacy)
 }
 
-// writeOpenOrchestrators persists the open set, migrating a legacy scalar file
-// to the set shape the first time anything changes. An empty set removes the
-// file rather than leaving a durable record with nothing durable to say.
-func writeOpenOrchestrators(path string, ids []string) error {
+// dedupOrchestratorEntries trims, drops empties, and keeps the first occurrence
+// of each id, preserving order.
+func dedupOrchestratorEntries(entries []orchestratorOpenEntry) []orchestratorOpenEntry {
+	seen := make(map[string]struct{}, len(entries))
+	out := make([]orchestratorOpenEntry, 0, len(entries))
+	for _, entry := range entries {
+		id := strings.TrimSpace(entry.OrchestratorID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, orchestratorOpenEntry{OrchestratorID: id, SessionID: strings.TrimSpace(entry.SessionID)})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// writeOpenOrchestrators persists the open set, migrating a legacy file to the
+// current shape the first time anything changes. An empty set removes the file
+// rather than leaving a durable record with nothing durable to say.
+func writeOpenOrchestrators(path string, entries []orchestratorOpenEntry) error {
 	if path == "" {
 		return nil
 	}
-	if len(ids) == 0 {
+	if len(entries) == 0 {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 		return nil
 	}
-	data, err := json.Marshal(orchestratorOpenState{OrchestratorIDs: ids})
+	data, err := json.Marshal(orchestratorOpenState{Orchestrators: entries})
 	if err != nil {
 		return err
 	}

--- a/erun-ui/orchestrator_open_state_test.go
+++ b/erun-ui/orchestrator_open_state_test.go
@@ -313,7 +313,7 @@ func TestRestartHandOffStaysOneShotAndAgeBoundedOverTheDurableRecord(t *testing.
 	}
 }
 
-// The bug (#1096): a plain launch used to re-derive a session id from the
+// The bug: a plain launch used to re-derive a session id from the
 // orchestrator id (uuid5(namespace, id)) and resume THAT, rather than the
 // conversation actually recorded as running. A stale transcript that happens
 // to sit at the derived id — left over from before the live session diverged
@@ -368,9 +368,9 @@ func TestPlainLaunchStartsFreshWhenTheRecordedConversationIsGone(t *testing.T) {
 }
 
 // An operator upgrading from a release that recorded only the orchestrator id
-// (#1098's shape, or #971's before it) must not have that silence read as
-// permission to resume whatever the derived id names. The very first restore
-// under the new record starts every such orchestrator fresh.
+// (an earlier shape, or the scalar one before it) must not have that silence
+// read as permission to resume whatever the derived id names. The very first
+// restore under the new record starts every such orchestrator fresh.
 func TestUpgradingFromARecordWithNoSessionIDStartsFresh(t *testing.T) {
 	app, openPath, _ := openStateTestApp(t)
 	defer app.shutdown(context.Background())

--- a/erun-ui/orchestrator_open_state_test.go
+++ b/erun-ui/orchestrator_open_state_test.go
@@ -68,7 +68,7 @@ func TestPlainLaunchReopensTheOrchestratorThatWasOpen(t *testing.T) {
 	if again := app.ResolveOrchestratorToReopen(); again.OrchestratorID != id {
 		t.Fatalf("expected the record to survive being read, got %q", again.OrchestratorID)
 	}
-	if got := readOpenOrchestrators(openPath); len(got) != 1 || got[0] != id {
+	if got := readOpenOrchestrators(openPath); len(got) != 1 || got[0].OrchestratorID != id {
 		t.Fatalf("expected [%q] on disk, got %v", id, got)
 	}
 }
@@ -105,10 +105,10 @@ func TestTwoOpenOrchestratorsAreBothRestoredOnPlainLaunch(t *testing.T) {
 	if target.OrchestratorID != second {
 		t.Fatalf("expected %q (started last) to own the pane, got %q", second, target.OrchestratorID)
 	}
-	if len(target.AlsoReopen) != 1 || target.AlsoReopen[0] != first {
+	if len(target.AlsoReopen) != 1 || target.AlsoReopen[0].OrchestratorID != first {
 		t.Fatalf("expected %q to also be reopened, got %v", first, target.AlsoReopen)
 	}
-	if got := readOpenOrchestrators(openPath); len(got) != 2 || got[0] != first || got[1] != second {
+	if got := readOpenOrchestrators(openPath); len(got) != 2 || got[0].OrchestratorID != first || got[1].OrchestratorID != second {
 		t.Fatalf("expected both ids recorded oldest-first, got %v", got)
 	}
 }
@@ -182,7 +182,7 @@ func TestRestartHandOffOverASetOfOpenOrchestratorsLeavesTheRestIdle(t *testing.T
 	if target.OrchestratorID != second || target.ResumePrompt != prompt {
 		t.Fatalf("expected %q to own the pane with its prompt, got %+v", second, target)
 	}
-	if len(target.AlsoReopen) != 1 || target.AlsoReopen[0] != first {
+	if len(target.AlsoReopen) != 1 || target.AlsoReopen[0].OrchestratorID != first {
 		t.Fatalf("expected %q to reopen idle alongside it, got %v", first, target.AlsoReopen)
 	}
 	if got := readOpenOrchestrators(openPath); len(got) != 2 {
@@ -285,7 +285,7 @@ func TestRestartHandOffStaysOneShotAndAgeBoundedOverTheDurableRecord(t *testing.
 		Environments:   []string{"frs/dev"},
 		ResumePrompt:   prompt,
 	}
-	if err := recordOpenOrchestrator(openPath, id); err != nil {
+	if err := recordOpenOrchestrator(openPath, id, conversationID); err != nil {
 		t.Fatalf("record open orchestrator: %v", err)
 	}
 	if err := writeOrchestratorRestoreTarget(restoreDir, handOff, time.Now()); err != nil {
@@ -310,5 +310,83 @@ func TestRestartHandOffStaysOneShotAndAgeBoundedOverTheDurableRecord(t *testing.
 	stale := app.ResolveOrchestratorToReopen()
 	if stale.OrchestratorID != id || stale.ResumePrompt != "" {
 		t.Fatalf("expected a stale hand-off to be dropped and the durable record to answer, got %+v", stale)
+	}
+}
+
+// The bug (#1096): a plain launch used to re-derive a session id from the
+// orchestrator id (uuid5(namespace, id)) and resume THAT, rather than the
+// conversation actually recorded as running. A stale transcript that happens
+// to sit at the derived id — left over from before the live session diverged
+// from it, e.g. a resume that fell through to an unpinned launch — was
+// silently resumed while the real, divergent conversation was left behind.
+func TestPlainLaunchResumesTheRecordedConversationNotADerivedOne(t *testing.T) {
+	app, openPath, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	id := createAndStartOrchestrator(t, app)
+	staleDerived := orchestratorSessionID(id)
+	stageOrchestratorConversation(t, staleDerived)
+	liveConversation := "diverged-session-actually-running"
+	stageOrchestratorConversation(t, liveConversation)
+	if err := recordOpenOrchestrator(openPath, id, liveConversation); err != nil {
+		t.Fatalf("record open orchestrator: %v", err)
+	}
+
+	target := app.ResolveOrchestratorToReopen()
+	if target.OrchestratorID != id {
+		t.Fatalf("expected %q to be reopened, got %q", id, target.OrchestratorID)
+	}
+	if target.ConversationID != liveConversation {
+		t.Fatalf("expected the recorded live conversation %q to be resumed, not the derived id %q, got %q",
+			liveConversation, staleDerived, target.ConversationID)
+	}
+}
+
+// An orchestrator whose recorded conversation no longer exists on disk (pruned,
+// deleted, never actually staged) starts fresh instead of falling back to
+// whatever the derived id happens to already name — resuming nothing is safer
+// than resuming a stale conversation.
+func TestPlainLaunchStartsFreshWhenTheRecordedConversationIsGone(t *testing.T) {
+	app, openPath, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	id := createAndStartOrchestrator(t, app)
+	staleDerived := orchestratorSessionID(id)
+	stageOrchestratorConversation(t, staleDerived)
+	if err := recordOpenOrchestrator(openPath, id, "vanished-session"); err != nil {
+		t.Fatalf("record open orchestrator: %v", err)
+	}
+
+	target := app.ResolveOrchestratorToReopen()
+	if target.OrchestratorID != id {
+		t.Fatalf("expected %q to be reopened, got %q", id, target.OrchestratorID)
+	}
+	if target.ConversationID == "" || target.ConversationID == staleDerived || target.ConversationID == "vanished-session" {
+		t.Fatalf("expected a fresh conversation, neither the stale derived id nor the vanished one, got %q",
+			target.ConversationID)
+	}
+}
+
+// An operator upgrading from a release that recorded only the orchestrator id
+// (#1098's shape, or #971's before it) must not have that silence read as
+// permission to resume whatever the derived id names. The very first restore
+// under the new record starts every such orchestrator fresh.
+func TestUpgradingFromARecordWithNoSessionIDStartsFresh(t *testing.T) {
+	app, openPath, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	id := createAndStartOrchestrator(t, app)
+	staleDerived := orchestratorSessionID(id)
+	stageOrchestratorConversation(t, staleDerived)
+	if err := os.WriteFile(openPath, []byte(`{"orchestratorIds":["`+id+`"]}`), 0o644); err != nil {
+		t.Fatalf("write legacy open file: %v", err)
+	}
+
+	target := app.ResolveOrchestratorToReopen()
+	if target.OrchestratorID != id {
+		t.Fatalf("expected %q to be reopened, got %q", id, target.OrchestratorID)
+	}
+	if target.ConversationID == "" || target.ConversationID == staleDerived {
+		t.Fatalf("expected a fresh conversation rather than the stale derived id, got %q", target.ConversationID)
 	}
 }

--- a/erun-ui/orchestrator_shell_activity.go
+++ b/erun-ui/orchestrator_shell_activity.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// A background shell an orchestrator starts (Bash with run_in_background) can
+// legitimately keep running after the turn that started it ends — that is the
+// whole point of backgrounding it. orchestratorActivity (this orchestrator's
+// own turn) cannot answer "is a shell still running" for that reason: the turn
+// can read idle while a shell it started keeps going, and the desktop had no
+// affordance at all for that case (#1068).
+//
+// Like orchestratorActivity, this is a report the agent's hooks write, not
+// something read off its terminal — the same reason applies here: a
+// background shell that finishes leaves nothing in the terminal for the
+// desktop to notice on its own, and scanning rendered text for a specific
+// phrase would be exactly the output-driven latch orchestratorActivity's
+// header explains was removed and must not return.
+//
+// A Bash call that backgrounds a shell reports a task id in its own
+// tool_response (backgroundTaskId); checking on it later (TaskOutput) or
+// killing it (TaskStop) reports the same id back with a status. Two hooks,
+// installed on PostToolUse only (tool_response does not exist before a call
+// completes), turn that into the report: one matched to "Bash" starts it, one
+// matched to "TaskOutput|TaskStop" clears it when the id it names matches what
+// is currently recorded and the reported status is no longer "running".
+//
+// Node, not a bare shell redirect, does the parsing: the report needs actual
+// fields out of the hook's JSON stdin (the command, the background task id,
+// the polled status), which a printf-only one-liner cannot read at all. Node
+// is guaranteed present without depending on erun being on PATH — the
+// orchestrator session could not have started without it, since the AI
+// harness invoked to launch it is itself an npm package.
+type orchestratorShellActivity struct {
+	Running bool   `json:"running"`
+	Command string `json:"command,omitempty"`
+	TaskID  string `json:"taskId,omitempty"`
+	AtUnix  int64  `json:"atUnix"`
+}
+
+// orchestratorShellActivitySafetyBound is the outer bound on a "running"
+// report from a session the desktop can still see. It is generous — hours,
+// not minutes — because a legitimate background shell (a build, a long poll
+// loop) can run that long, and showing the operator its real elapsed time
+// rather than hiding it past some short cutoff is the point of this report.
+// It exists only so a shell ended by some path neither hook observes (a bare
+// `kill` run from inside the shell itself, an orchestrator that exits without
+// ever checking on it) cannot pin the indicator on forever; the explicit clear
+// hook is expected to beat it in the ordinary case. A session the desktop can
+// no longer see ages out on the short orchestratorActivityTTL instead, the
+// same asymmetry readOrchestratorActivity applies and for the same reason:
+// nothing will ever explicitly clear a report for a session that is gone.
+const orchestratorShellActivitySafetyBound = 6 * time.Hour
+
+// orchestratorShellActivityDir is the directory the reports live in, a
+// sibling of orchestrator-activity.
+func orchestratorShellActivityDir() string {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		configDir = os.TempDir()
+	}
+	return filepath.Join(configDir, "ERun", "orchestrator-shell-activity")
+}
+
+// orchestratorShellActivityPath is the file one orchestrator's hooks write.
+func orchestratorShellActivityPath(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ""
+	}
+	return filepath.Join(orchestratorShellActivityDir(), id+".json")
+}
+
+// readOrchestratorShellActivity reports whether this orchestrator says a
+// background shell it started is still running. sessionAlive picks the
+// staleness bound: a report from a session the desktop can no longer see ages
+// out on the short, shared bound, because nothing will ever explicitly clear
+// it for a session that is gone.
+func readOrchestratorShellActivity(id string, now time.Time, sessionAlive bool) (orchestratorShellActivity, bool) {
+	path := orchestratorShellActivityPath(id)
+	if path == "" {
+		return orchestratorShellActivity{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return orchestratorShellActivity{}, false
+	}
+	var activity orchestratorShellActivity
+	if err := json.Unmarshal(data, &activity); err != nil {
+		return orchestratorShellActivity{}, false
+	}
+	bound := orchestratorActivityTTL
+	if sessionAlive {
+		bound = orchestratorShellActivitySafetyBound
+	}
+	if activity.AtUnix <= 0 || now.Sub(time.Unix(activity.AtUnix, 0)) > bound {
+		return orchestratorShellActivity{}, false
+	}
+	return activity, true
+}
+
+// orchestratorShellActivityFileVar is both the environment variable the hook
+// commands resolve their report path through and the marker
+// isOrchestratorShellActivityHookBlock looks for, so a rewrite recognizes and
+// replaces its own previous blocks instead of stacking another copy beside
+// them.
+const orchestratorShellActivityFileVar = "ERUN_SHELL_ACTIVITY_FILE"
+
+// isOrchestratorShellActivityHookBlock reports whether a settings hook block
+// is one of ours — either the start or the clear block, which share the
+// marker.
+func isOrchestratorShellActivityHookBlock(block any) bool {
+	group, ok := block.(map[string]any)
+	if !ok {
+		return false
+	}
+	hooks, ok := group["hooks"].([]any)
+	if !ok {
+		return false
+	}
+	for _, hook := range hooks {
+		entry, ok := hook.(map[string]any)
+		if !ok {
+			continue
+		}
+		command, ok := entry["command"].(string)
+		if !ok {
+			continue
+		}
+		if strings.Contains(command, orchestratorShellActivityFileVar) {
+			return true
+		}
+	}
+	return false
+}
+
+// orchestratorShellActivityStartHookCommand recognizes a Bash call that
+// backgrounded a shell (tool_response.backgroundTaskId) and records it as
+// running, with the command it is running and the task id later needed to
+// clear it. Any other Bash call — foreground, or one that never backgrounds —
+// leaves the previous report untouched: a foreground command says nothing
+// about whatever shell is already running.
+func orchestratorShellActivityStartHookCommand() string {
+	dir := filepath.ToSlash(orchestratorShellActivityDir())
+	script := `let d="";process.stdin.on("data",c=>{d+=c});process.stdin.on("end",()=>{try{` +
+		`const j=JSON.parse(d);` +
+		`const id=j.tool_response&&j.tool_response.backgroundTaskId;` +
+		`if(!id)return;` +
+		`const out={running:true,command:(j.tool_input&&j.tool_input.command)||"",taskId:id,atUnix:Math.floor(Date.now()/1000)};` +
+		`require("fs").writeFileSync(process.env.` + orchestratorShellActivityFileVar + `,JSON.stringify(out));` +
+		`}catch(e){}});`
+	return `[ -n "$ERUN_ORCHESTRATOR_ID" ] && mkdir -p "` + dir + `" && ` +
+		orchestratorShellActivityFileVar + `="` + dir + `/$ERUN_ORCHESTRATOR_ID.json" node -e '` + script + `' || true`
+}
+
+// orchestratorShellActivityClearHookCommand recognizes a TaskOutput or
+// TaskStop call that reports the SAME task id the start hook recorded as no
+// longer running, and clears the report. A call naming a different task id
+// (the orchestrator is watching something else entirely) or one still
+// reporting "running" leaves the report untouched.
+func orchestratorShellActivityClearHookCommand() string {
+	dir := filepath.ToSlash(orchestratorShellActivityDir())
+	script := `let d="";process.stdin.on("data",c=>{d+=c});process.stdin.on("end",()=>{try{` +
+		`const j=JSON.parse(d);` +
+		`const task=(j.tool_response&&j.tool_response.task)||{};` +
+		`const id=task.task_id||(j.tool_input&&(j.tool_input.task_id||j.tool_input.shell_id))||"";` +
+		`if(!id||task.status==="running")return;` +
+		`const path=process.env.` + orchestratorShellActivityFileVar + `;` +
+		`let prev={};` +
+		`try{prev=JSON.parse(require("fs").readFileSync(path,"utf8"));}catch(e){}` +
+		`if(prev.taskId!==id)return;` +
+		`require("fs").writeFileSync(path,JSON.stringify({running:false,atUnix:Math.floor(Date.now()/1000)}));` +
+		`}catch(e){}});`
+	return `[ -n "$ERUN_ORCHESTRATOR_ID" ] && mkdir -p "` + dir + `" && ` +
+		orchestratorShellActivityFileVar + `="` + dir + `/$ERUN_ORCHESTRATOR_ID.json" node -e '` + script + `' || true`
+}
+
+// orchestratorShellActivityHookBlocks are the two PostToolUse-only hooks the
+// settings file installs, each matcher-scoped so it fires only for the calls
+// it needs to see rather than every tool call.
+func orchestratorShellActivityHookBlocks() []any {
+	return []any{
+		map[string]any{
+			"matcher": "Bash",
+			"hooks":   []any{map[string]any{"type": "command", "command": orchestratorShellActivityStartHookCommand()}},
+		},
+		map[string]any{
+			"matcher": "TaskOutput|TaskStop",
+			"hooks":   []any{map[string]any{"type": "command", "command": orchestratorShellActivityClearHookCommand()}},
+		},
+	}
+}

--- a/erun-ui/orchestrator_shell_activity.go
+++ b/erun-ui/orchestrator_shell_activity.go
@@ -13,7 +13,7 @@ import (
 // whole point of backgrounding it. orchestratorActivity (this orchestrator's
 // own turn) cannot answer "is a shell still running" for that reason: the turn
 // can read idle while a shell it started keeps going, and the desktop had no
-// affordance at all for that case (#1068).
+// affordance at all for that case.
 //
 // Like orchestratorActivity, this is a report the agent's hooks write, not
 // something read off its terminal — the same reason applies here: a

--- a/erun-ui/orchestrator_shell_activity_test.go
+++ b/erun-ui/orchestrator_shell_activity_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeOrchestratorShellActivity(t *testing.T, id string, activity orchestratorShellActivity) {
+	t.Helper()
+	path := orchestratorShellActivityPath(id)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data, err := json.Marshal(activity)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// The whole point of the report: a background shell can outlive the turn that
+// started it, so the desktop must be able to say "still running" from a report
+// alone, independent of whatever orchestratorActivity says about the turn.
+func TestOrchestratorShellActivityIsReadFromTheReportNotTheTerminal(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	now := time.Now()
+
+	if _, ok := readOrchestratorShellActivity("erun", now, true); ok {
+		t.Fatal("an orchestrator that has reported nothing has no running shell")
+	}
+
+	writeOrchestratorShellActivity(t, "erun", orchestratorShellActivity{
+		Running: true, Command: "sleep 300", TaskID: "task-1", AtUnix: now.Unix(),
+	})
+	activity, ok := readOrchestratorShellActivity("erun", now, true)
+	if !ok || !activity.Running || activity.Command != "sleep 300" {
+		t.Fatalf("a fresh running report must be believed, got %+v %v", activity, ok)
+	}
+
+	writeOrchestratorShellActivity(t, "erun", orchestratorShellActivity{Running: false, AtUnix: now.Unix()})
+	activity, ok = readOrchestratorShellActivity("erun", now, true)
+	if !ok || activity.Running {
+		t.Fatalf("the clear report must read as not running, got %+v %v", activity, ok)
+	}
+}
+
+// The defect this whole file exists to avoid resurrecting: a report from an
+// orchestrator that has genuinely turned idle in the ordinary way (its turn
+// ended, no shell survives it) must not keep spinning past a long safety
+// bound — hours, since a legitimate background build or poll loop can
+// reasonably run that long, and the operator seeing the real elapsed time is
+// the point (#1068) — but it must still eventually age out if nothing ever
+// clears it.
+func TestOrchestratorShellActivitySurvivesALongRunButStillBounds(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	now := time.Now()
+
+	writeOrchestratorShellActivity(t, "erun", orchestratorShellActivity{
+		Running: true, TaskID: "task-1", AtUnix: now.Add(-orchestratorActivityTTL - 5*time.Minute).Unix(),
+	})
+	if activity, ok := readOrchestratorShellActivity("erun", now, true); !ok || !activity.Running {
+		t.Fatalf("a live session's shell may run well past the short bound, got %+v %v", activity, ok)
+	}
+
+	writeOrchestratorShellActivity(t, "erun", orchestratorShellActivity{
+		Running: true, TaskID: "task-1", AtUnix: now.Add(-orchestratorShellActivitySafetyBound - time.Minute).Unix(),
+	})
+	if _, ok := readOrchestratorShellActivity("erun", now, true); ok {
+		t.Fatal("a report nothing has renewed for hours must still age out eventually")
+	}
+}
+
+// A session the desktop can no longer see is the killed-mid-run case: nothing
+// will ever write its clear, so it ages out on the short bound instead of the
+// generous live one.
+func TestOrchestratorShellActivityExpiresQuicklyForADeadSession(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	now := time.Now()
+
+	writeOrchestratorShellActivity(t, "erun", orchestratorShellActivity{
+		Running: true, TaskID: "task-1", AtUnix: now.Add(-orchestratorActivityTTL - time.Minute).Unix(),
+	})
+	if _, ok := readOrchestratorShellActivity("erun", now, false); ok {
+		t.Fatal("a report from a session we can no longer see must not keep the indicator spinning")
+	}
+}
+
+// Unreadable input answers "not running": the report may keep the indicator
+// spinning, never invent a spin.
+func TestOrchestratorShellActivityTreatsUnreadableInputAsNotRunning(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	now := time.Now()
+
+	path := orchestratorShellActivityPath("erun")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("not json"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, ok := readOrchestratorShellActivity("erun", now, true); ok {
+		t.Fatal("unparseable input must not read as running")
+	}
+	if _, ok := readOrchestratorShellActivity("  ", now, true); ok {
+		t.Fatal("an orchestrator with no id has no report")
+	}
+}
+
+// The start hook only fires for Bash and only writes when the call actually
+// backgrounded a shell (its own reasoning, not asserted here); the clear hook
+// only fires for TaskOutput/TaskStop. Both resolve their own orchestrator at
+// run time, the same way the busy report does, since the workspace settings
+// file is shared by every orchestrator.
+func TestOrchestratorShellActivityHooksResolveTheirOwnOrchestrator(t *testing.T) {
+	blocks := orchestratorShellActivityHookBlocks()
+	if len(blocks) != 2 {
+		t.Fatalf("expected a start block and a clear block, got %d: %+v", len(blocks), blocks)
+	}
+	start := shellHookBlockCommand(t, blocks[0], "Bash")
+	clear := shellHookBlockCommand(t, blocks[1], "TaskOutput|TaskStop")
+
+	for _, command := range []string{start, clear} {
+		if !strings.Contains(command, "$ERUN_ORCHESTRATOR_ID") {
+			t.Fatalf("the hook must resolve its orchestrator at run time: %q", command)
+		}
+		if !strings.Contains(command, `[ -n "$ERUN_ORCHESTRATOR_ID" ]`) {
+			t.Fatalf("the hook must skip a session with no id: %q", command)
+		}
+		if !strings.Contains(command, "node -e") {
+			t.Fatalf("the hook must parse structured JSON, not scan text: %q", command)
+		}
+	}
+}
+
+func shellHookBlockCommand(t *testing.T, block any, wantMatcher string) string {
+	t.Helper()
+	group, ok := block.(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected block shape: %+v", block)
+	}
+	if matcher, _ := group["matcher"].(string); matcher != wantMatcher {
+		t.Fatalf("expected matcher %q, got %q", wantMatcher, matcher)
+	}
+	hooks, ok := group["hooks"].([]any)
+	if !ok || len(hooks) != 1 {
+		t.Fatalf("expected one command, got %+v", group["hooks"])
+	}
+	entry, ok := hooks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected hook shape: %+v", hooks[0])
+	}
+	command, _ := entry["command"].(string)
+	return command
+}
+
+// Installing our two blocks on an event must not delete what the operator
+// already bound to it, and must stay idempotent across restarts.
+func TestOrchestratorShellActivityHookMergePreservesOtherHooks(t *testing.T) {
+	theirs := map[string]any{
+		"matcher": "Write",
+		"hooks":   []any{map[string]any{"type": "command", "command": "echo keep"}},
+	}
+	ours := orchestratorShellActivityHookBlocks()
+
+	merged := mergeOrchestratorHookBlocks([]any{theirs}, ours, isOrchestratorShellActivityHookBlock)
+	if len(merged) != 3 {
+		t.Fatalf("expected theirs kept and both of ours appended, got %d: %+v", len(merged), merged)
+	}
+	again := mergeOrchestratorHookBlocks(merged, ours, isOrchestratorShellActivityHookBlock)
+	if len(again) != 3 {
+		t.Fatalf("re-installing must replace our own blocks, not stack them: %+v", again)
+	}
+	if isOrchestratorShellActivityHookBlock(again[0]) {
+		t.Fatalf("the operator's hook must survive and stay theirs: %+v", again)
+	}
+}
+
+// Both PostToolUse hooks — the start matcher and the clear matcher — must be
+// installed, since the report needs both halves to ever clear itself promptly.
+func TestOrchestratorShellActivityHooksInstallOnPostToolUseOnly(t *testing.T) {
+	hooks, data := orchestratorSettingsHooks(t)
+
+	if !eventCarriesShellActivityReport(hooks["PostToolUse"]) {
+		t.Fatalf("PostToolUse is missing the shell activity report:\n%s", data)
+	}
+	for _, event := range []string{"UserPromptSubmit", "PreToolUse", "Stop"} {
+		if eventCarriesShellActivityReport(hooks[event]) {
+			t.Fatalf("%s must not carry the shell activity report: tool_response does not exist before a call completes:\n%s", event, data)
+		}
+	}
+}
+
+func eventCarriesShellActivityReport(blocks []any) bool {
+	for _, block := range blocks {
+		if isOrchestratorShellActivityHookBlock(block) {
+			return true
+		}
+	}
+	return false
+}

--- a/erun-ui/orchestrator_shell_activity_test.go
+++ b/erun-ui/orchestrator_shell_activity_test.go
@@ -56,8 +56,7 @@ func TestOrchestratorShellActivityIsReadFromTheReportNotTheTerminal(t *testing.T
 // ended, no shell survives it) must not keep spinning past a long safety
 // bound — hours, since a legitimate background build or poll loop can
 // reasonably run that long, and the operator seeing the real elapsed time is
-// the point (#1068) — but it must still eventually age out if nothing ever
-// clears it.
+// the point — but it must still eventually age out if nothing ever clears it.
 func TestOrchestratorShellActivitySurvivesALongRunButStillBounds(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())

--- a/erun-ui/playwright/pages/Sidebar.ts
+++ b/erun-ui/playwright/pages/Sidebar.ts
@@ -245,10 +245,10 @@ export class Sidebar {
     return this.erunSection().getByRole('status', { name: `${name} is working` });
   }
 
-  // The row's background-shell indicator (#1068), rendered whenever the
-  // store's orchestratorShellActivity.bySession has this orchestrator's
-  // session flagged running — from the orchestrator-shell-activity event or
-  // from the list snapshot's own shellRunning field, the same #1087 treatment
+  // The row's background-shell indicator, rendered whenever the store's
+  // orchestratorShellActivity.bySession has this orchestrator's session
+  // flagged running — from the orchestrator-shell-activity event or from the
+  // list snapshot's own shellRunning field, the same treatment
   // orchestratorBusySpinner gets. Matched by prefix since the label carries a
   // live elapsed time.
   orchestratorShellSpinner(name: string): Locator {

--- a/erun-ui/playwright/pages/Sidebar.ts
+++ b/erun-ui/playwright/pages/Sidebar.ts
@@ -245,6 +245,18 @@ export class Sidebar {
     return this.erunSection().getByRole('status', { name: `${name} is working` });
   }
 
+  // The row's background-shell indicator (#1068), rendered whenever the
+  // store's orchestratorShellActivity.bySession has this orchestrator's
+  // session flagged running — from the orchestrator-shell-activity event or
+  // from the list snapshot's own shellRunning field, the same #1087 treatment
+  // orchestratorBusySpinner gets. Matched by prefix since the label carries a
+  // live elapsed time.
+  orchestratorShellSpinner(name: string): Locator {
+    return this.erunSection().getByRole('status', {
+      name: new RegExp(`^${name} has a shell running`),
+    });
+  }
+
   // Open the orchestrator's management dialog via its "…" button. Like the env
   // edit button it is pointer-events-none until hover/focus and a hover opens
   // the IconTooltip popper that would swallow a click — so focus it and press

--- a/erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts
+++ b/erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts
@@ -83,7 +83,7 @@ async function stubReopen(
 }
 
 test.describe('reopening the orchestrator that was open', () => {
-  // #1096: a plain launch must resume the exact conversation the backend
+  // A plain launch must resume the exact conversation the backend
   // resolved as live for this orchestrator, never a blind StartOrchestrator
   // that would leave the CLI to derive (or mis-derive) a session id itself.
   test('a plain launch resumes the recorded conversation, running no prompt', async ({
@@ -114,7 +114,7 @@ test.describe('reopening the orchestrator that was open', () => {
     expect(calls).not.toContain('StartOrchestrator');
   });
 
-  // #1096: when the backend has nothing safe to resume (no live session was
+  // When the backend has nothing safe to resume (no live session was
   // ever recorded, or the recorded one no longer exists), it answers with no
   // conversationId — and the launch must start the orchestrator fresh rather
   // than resuming whatever the frontend, or the CLI, would otherwise guess.
@@ -268,9 +268,9 @@ test.describe('restoring every orchestrator that was open', () => {
     await expect(app.tabStrip.tab(SEED_ORCHESTRATOR_2)).toHaveAttribute('aria-selected', 'true');
     await expect(app.tabStrip.tab(SEED_ORCHESTRATOR)).toHaveAttribute('aria-selected', 'false');
 
-    // Both were resumed explicitly, idle, at their own recorded conversation
-    // (#1096) — the pane owner's and the one alongside it, since a plain
-    // launch (no restart hand-off) carries no prompt to auto-run.
+    // Both were resumed explicitly, idle, at their own recorded conversation —
+    // the pane owner's and the one alongside it, since a plain launch (no
+    // restart hand-off) carries no prompt to auto-run.
     expect(calls).toContain('StartOrchestratorWithResume');
     expect(calls).not.toContain('StartOrchestrator');
   });

--- a/erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts
+++ b/erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts
@@ -42,7 +42,7 @@ async function stubReopen(
     orchestratorId: string;
     conversationId?: string;
     resumePrompt: string;
-    alsoReopen?: string[];
+    alsoReopen?: { orchestratorId: string; conversationId?: string }[];
     notice?: string;
   },
   calls: string[],
@@ -83,9 +83,19 @@ async function stubReopen(
 }
 
 test.describe('reopening the orchestrator that was open', () => {
-  test('a plain launch lands in the orchestrator, running no prompt', async ({ app, page }) => {
+  // #1096: a plain launch must resume the exact conversation the backend
+  // resolved as live for this orchestrator, never a blind StartOrchestrator
+  // that would leave the CLI to derive (or mis-derive) a session id itself.
+  test('a plain launch resumes the recorded conversation, running no prompt', async ({
+    app,
+    page,
+  }) => {
     const calls: string[] = [];
-    await stubReopen(page, { orchestratorId: SEED_ORCHESTRATOR, resumePrompt: '' }, calls);
+    await stubReopen(
+      page,
+      { orchestratorId: SEED_ORCHESTRATOR, conversationId: 'conv-recorded', resumePrompt: '' },
+      calls,
+    );
     await app.reboot();
 
     // The restored orchestrator owns the pane: the strip is in orchestrator
@@ -97,8 +107,27 @@ test.describe('reopening the orchestrator that was open', () => {
     await expect(app.tabStrip.environmentMode()).toBeHidden();
     await expect(app.sidebar.orchestratorStatusDot(SEED_ORCHESTRATOR, 'running')).toBeVisible();
 
-    // Idle at the prompt: a plain launch resumes the conversation and hands it
-    // no task. The prompt-carrying call belongs to the restart hand-off alone.
+    // Resumed explicitly, idle: a plain launch resumes the recorded
+    // conversation and hands it no task. The prompt-carrying call belongs to
+    // the restart hand-off alone.
+    expect(calls).toContain('StartOrchestratorWithResume');
+    expect(calls).not.toContain('StartOrchestrator');
+  });
+
+  // #1096: when the backend has nothing safe to resume (no live session was
+  // ever recorded, or the recorded one no longer exists), it answers with no
+  // conversationId — and the launch must start the orchestrator fresh rather
+  // than resuming whatever the frontend, or the CLI, would otherwise guess.
+  test('with no recorded conversation the launch starts the orchestrator fresh', async ({
+    app,
+    page,
+  }) => {
+    const calls: string[] = [];
+    await stubReopen(page, { orchestratorId: SEED_ORCHESTRATOR, resumePrompt: '' }, calls);
+    await app.reboot();
+
+    await expect(app.tabStrip.orchestratorMode()).toBeVisible();
+    await expect(app.tabStrip.tab(SEED_ORCHESTRATOR)).toHaveAttribute('aria-selected', 'true');
     expect(calls).toContain('StartOrchestrator');
     expect(calls).not.toContain('StartOrchestratorWithResume');
   });
@@ -123,21 +152,29 @@ test.describe('reopening the orchestrator that was open', () => {
 
   // A hand-off the backend refuses — the orchestrator was re-scoped, or the
   // conversation that asked can no longer be identified — must never be silent.
-  // The orchestrator still reopens, idle, and the reason is on screen beside the
-  // orchestrator list, where the operator acts on it. Which hand-offs get refused
-  // is the Go side's call (erun-ui/app_restart_test.go); what only the rendered
-  // app can show is that a refusal is visible and runs no task.
-  test('a refused hand-off reopens idle and says why', async ({ app, page }) => {
+  // The orchestrator still reopens idle, resuming its own recorded conversation
+  // rather than the one the refused hand-off named, and the reason is on screen
+  // beside the orchestrator list, where the operator acts on it. Which hand-offs
+  // get refused is the Go side's call (erun-ui/app_restart_test.go); what only
+  // the rendered app can show is that a refusal is visible and runs no task.
+  test('a refused hand-off reopens idle, resuming its own conversation, and says why', async ({
+    app,
+    page,
+  }) => {
     const calls: string[] = [];
     const notice =
       'Reopened pw-orch without continuing its task: its environments changed (was pw/alpha, now pw/beta). ' +
       'Check RESUME-NOTE.pw-orch.md in the orchestrators working directory before telling it to carry on.';
-    await stubReopen(page, { orchestratorId: SEED_ORCHESTRATOR, resumePrompt: '', notice }, calls);
+    await stubReopen(
+      page,
+      { orchestratorId: SEED_ORCHESTRATOR, conversationId: 'conv-own', resumePrompt: '', notice },
+      calls,
+    );
     await app.reboot();
 
     await expect(app.sidebar.orchestratorsAlert()).toContainText(notice);
-    expect(calls).toContain('StartOrchestrator');
-    expect(calls).not.toContain('StartOrchestratorWithResume');
+    expect(calls).toContain('StartOrchestratorWithResume');
+    expect(calls).not.toContain('StartOrchestrator');
   });
 
   // Several orchestrators can restart at once and only one owns the pane, so
@@ -208,7 +245,12 @@ test.describe('restoring every orchestrator that was open', () => {
     const owner = runningOrchestratorInfo(SEED_ORCHESTRATOR_2, RESTORED_SESSION_ID + 1);
     await stubReopen(
       page,
-      { orchestratorId: SEED_ORCHESTRATOR_2, resumePrompt: '', alsoReopen: [SEED_ORCHESTRATOR] },
+      {
+        orchestratorId: SEED_ORCHESTRATOR_2,
+        conversationId: 'conv-owner',
+        resumePrompt: '',
+        alsoReopen: [{ orchestratorId: SEED_ORCHESTRATOR, conversationId: 'conv-also' }],
+      },
       calls,
       { [SEED_ORCHESTRATOR]: runningOrchestrator, [SEED_ORCHESTRATOR_2]: owner },
     );
@@ -226,10 +268,10 @@ test.describe('restoring every orchestrator that was open', () => {
     await expect(app.tabStrip.tab(SEED_ORCHESTRATOR_2)).toHaveAttribute('aria-selected', 'true');
     await expect(app.tabStrip.tab(SEED_ORCHESTRATOR)).toHaveAttribute('aria-selected', 'false');
 
-    // Both were started — an idle StartOrchestrator for the one alongside, and
-    // for the pane owner too, since a plain launch (no restart hand-off) carries
-    // no prompt to auto-run.
-    expect(calls).toContain('StartOrchestrator');
-    expect(calls).not.toContain('StartOrchestratorWithResume');
+    // Both were resumed explicitly, idle, at their own recorded conversation
+    // (#1096) — the pane owner's and the one alongside it, since a plain
+    // launch (no restart hand-off) carries no prompt to auto-run.
+    expect(calls).toContain('StartOrchestratorWithResume');
+    expect(calls).not.toContain('StartOrchestrator');
   });
 });

--- a/erun-ui/playwright/tests/sidebar-orchestrator-shell-activity-snapshot.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-orchestrator-shell-activity-snapshot.spec.ts
@@ -1,0 +1,100 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ORCHESTRATOR } from '../fixtures/seedRoot.js';
+
+// #1068: a running background shell had no activity affordance at all — the
+// desktop rendered it as static text, so working and wedged looked identical.
+// The fix follows the exact #1087 pattern this mirrors: orchestratorInfo
+// carries shellRunning/shellCommand/shellStartedAtUnix directly, so a snapshot
+// taken after the shell started reflects it even when the
+// orchestrator-shell-activity event that announced it was never observed —
+// and it is independent of the turn's own busy state, since a background
+// shell can keep running after the turn that started it goes idle.
+//
+// This spec drives the fix's frontend half directly: it stubs
+// ListOrchestrators over /__erun_invoke to answer a running shell without
+// ever emitting the orchestrator-shell-activity event, then reboots the app
+// (a real fresh mount) and asserts the indicator still shows. The event path
+// itself and the backend's own re-emit timing are covered by the Go tests in
+// erun-ui/session_heartbeat_test.go
+// (TestReconcileOrchestratorActivityReEmitsShellStateEveryTick,
+// TestOrchestratorShellSnapshotRendersRunningWithoutTheEvent), since the
+// headless harness cannot wait out a real 15s poll deterministically.
+
+const RUNNING_SESSION_ID = 4242;
+const SHELL_COMMAND = 'sleep 300';
+const SHELL_STARTED_AT_UNIX = 1_700_000_000;
+
+function orchestratorSnapshot(shellRunning: boolean, busy = false) {
+  return {
+    id: SEED_ORCHESTRATOR,
+    name: SEED_ORCHESTRATOR,
+    environments: [],
+    tenants: [],
+    directories: [],
+    sessionId: RUNNING_SESSION_ID,
+    status: 'running',
+    busy,
+    transient: false,
+    shellRunning,
+    shellCommand: shellRunning ? SHELL_COMMAND : '',
+    shellStartedAtUnix: shellRunning ? SHELL_STARTED_AT_UNIX : 0,
+  };
+}
+
+async function stubOrchestratorList(
+  page: Page,
+  shellRunning: boolean,
+  busy = false,
+): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method?: string };
+    if (body.method === 'ListOrchestrators') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [orchestratorSnapshot(shellRunning, busy)] }),
+      });
+    }
+    await route.continue();
+  });
+}
+
+test.describe('orchestrator background shell renders from the list snapshot (#1068)', () => {
+  test('a running-shell snapshot shows the indicator on a fresh mount, with no event ever emitted', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(page, true);
+    await app.reboot();
+
+    await expect(app.sidebar.orchestratorShellSpinner(SEED_ORCHESTRATOR)).toBeVisible();
+    // The whole point: not just a bare spinner, but what is running.
+    await expect(app.sidebar.orchestratorShellSpinner(SEED_ORCHESTRATOR)).toHaveAccessibleName(
+      new RegExp(SHELL_COMMAND),
+    );
+  });
+
+  test('no running shell renders no indicator', async ({ app, page }) => {
+    await stubOrchestratorList(page, false);
+    await app.reboot();
+
+    await expect(app.sidebar.orchestratorStatusDot(SEED_ORCHESTRATOR, 'running')).toBeVisible();
+    await expect(app.sidebar.orchestratorShellSpinner(SEED_ORCHESTRATOR)).toHaveCount(0);
+  });
+
+  // The turn's own busy spinner and the shell indicator are independent
+  // facts, but the row shows only one motion cue at a time: a turn that is
+  // actively busy already spins, so the shell indicator stays hidden rather
+  // than doubling up.
+  test('an actively busy turn shows only the busy spinner, not the shell indicator too', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(page, true, true);
+    await app.reboot();
+
+    await expect(app.sidebar.orchestratorBusySpinner(SEED_ORCHESTRATOR)).toBeVisible();
+    await expect(app.sidebar.orchestratorShellSpinner(SEED_ORCHESTRATOR)).toHaveCount(0);
+  });
+});

--- a/erun-ui/playwright/tests/sidebar-orchestrator-shell-activity-snapshot.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-orchestrator-shell-activity-snapshot.spec.ts
@@ -3,9 +3,9 @@ import type { Page } from '@playwright/test';
 import { expect, test } from '../fixtures/erunApp.js';
 import { SEED_ORCHESTRATOR } from '../fixtures/seedRoot.js';
 
-// #1068: a running background shell had no activity affordance at all — the
+// A running background shell had no activity affordance at all — the
 // desktop rendered it as static text, so working and wedged looked identical.
-// The fix follows the exact #1087 pattern this mirrors: orchestratorInfo
+// The fix follows the exact busy-snapshot pattern this mirrors: orchestratorInfo
 // carries shellRunning/shellCommand/shellStartedAtUnix directly, so a snapshot
 // taken after the shell started reflects it even when the
 // orchestrator-shell-activity event that announced it was never observed —
@@ -60,7 +60,7 @@ async function stubOrchestratorList(
   });
 }
 
-test.describe('orchestrator background shell renders from the list snapshot (#1068)', () => {
+test.describe('orchestrator background shell renders from the list snapshot', () => {
   test('a running-shell snapshot shows the indicator on a fresh mount, with no event ever emitted', async ({
     app,
     page,

--- a/erun-ui/session_heartbeat.go
+++ b/erun-ui/session_heartbeat.go
@@ -122,13 +122,37 @@ func (a *App) reconcileOrchestratorActivity() {
 	for _, r := range rows {
 		activity, ok := readOrchestratorActivity(r.id, now, r.alive)
 		busy := ok && activity.Busy
+		// A background shell (#1068) is a fact independent of the turn's own
+		// busy/idle state — it can keep running after the turn that started it
+		// ends — so it gets the same re-emit-every-tick treatment on its own,
+		// not folded into the busy report above.
+		shell, shellOK := readOrchestratorShellActivity(r.id, now, r.alive)
+		shellRunning := shellOK && shell.Running
 		a.mu.Lock()
 		if session := a.orchestrators[r.id]; session != nil {
 			session.aiBusy = busy
+			session.shellRunning = shellRunning
+			session.shellCommand = shell.Command
+			session.shellStartedAtUnix = shell.AtUnix
 		}
 		a.mu.Unlock()
 		a.emitAIActivity(r.serial, uiSelection{}, busy)
+		a.emitOrchestratorShellActivity(r.serial, shellRunning, shell.Command, shell.AtUnix)
 	}
+}
+
+// emitOrchestratorShellActivity publishes what an orchestrator's background
+// shell report says. startedAtUnix is only meaningful while running is true;
+// the caller (reconcileOrchestratorActivity) always passes the report's own
+// AtUnix, which is the report's write time either way and harmless to send
+// when not running since the frontend only reads it alongside Running.
+func (a *App) emitOrchestratorShellActivity(sessionID int, running bool, command string, startedAtUnix int64) {
+	a.emitEvent(orchestratorShellEvent, orchestratorShellActivityPayload{
+		SessionID:     sessionID,
+		Running:       running,
+		Command:       command,
+		StartedAtUnix: startedAtUnix,
+	})
 }
 
 // reconcileSessionHeartbeatsOnce probes every environment with a live pod

--- a/erun-ui/session_heartbeat.go
+++ b/erun-ui/session_heartbeat.go
@@ -122,10 +122,10 @@ func (a *App) reconcileOrchestratorActivity() {
 	for _, r := range rows {
 		activity, ok := readOrchestratorActivity(r.id, now, r.alive)
 		busy := ok && activity.Busy
-		// A background shell (#1068) is a fact independent of the turn's own
-		// busy/idle state — it can keep running after the turn that started it
-		// ends — so it gets the same re-emit-every-tick treatment on its own,
-		// not folded into the busy report above.
+		// A background shell is a fact independent of the turn's own busy/idle
+		// state — it can keep running after the turn that started it ends — so
+		// it gets the same re-emit-every-tick treatment on its own, not folded
+		// into the busy report above.
 		shell, shellOK := readOrchestratorShellActivity(r.id, now, r.alive)
 		shellRunning := shellOK && shell.Running
 		a.mu.Lock()

--- a/erun-ui/session_heartbeat_test.go
+++ b/erun-ui/session_heartbeat_test.go
@@ -296,3 +296,80 @@ func TestReconcileOrchestratorActivityReEmitsEveryTick(t *testing.T) {
 		}
 	}
 }
+
+// TestOrchestratorShellSnapshotRendersRunningWithoutTheEvent is the shell-report
+// half of the #1087 treatment (#1068): orchestratorInfo carries ShellRunning
+// directly, so a snapshot taken after the state changed reflects it even when
+// the orchestrator-shell-activity event that announced the change was never
+// observed — the same remount/reopen/late-listener path
+// TestOrchestratorSnapshotRendersBusyWithoutTheEvent locks for the turn's own
+// busy signal, but for a fact that is independent of it: a shell can be
+// running while the turn itself already reads idle.
+func TestOrchestratorShellSnapshotRendersRunningWithoutTheEvent(t *testing.T) {
+	app := orchestratorTestApp(t)
+	defer app.shutdown(context.Background())
+
+	created, err := app.CreateOrchestrator("agent", []orchestratorEnvInput{{Tenant: "frs", Environment: "dev"}})
+	if err != nil {
+		t.Fatalf("CreateOrchestrator failed: %v", err)
+	}
+	started, err := app.StartOrchestrator(created.ID, 80, 24)
+	if err != nil {
+		t.Fatalf("StartOrchestrator failed: %v", err)
+	}
+	if started.ShellRunning {
+		t.Fatalf("a freshly started orchestrator must not read a running shell before any report: %+v", started)
+	}
+
+	writeOrchestratorShellActivity(t, created.ID, orchestratorShellActivity{
+		Running: true, Command: "sleep 300", TaskID: "task-1", AtUnix: time.Now().Unix(),
+	})
+	app.reconcileOrchestratorActivity()
+
+	listed := app.ListOrchestrators()
+	if len(listed) != 1 || !listed[0].ShellRunning || listed[0].ShellCommand != "sleep 300" {
+		t.Fatalf("expected the listed orchestrator to render the running shell from the snapshot, got %+v", listed)
+	}
+	info, ok := app.runningOrchestratorInfo(created.ID)
+	if !ok || !info.ShellRunning || info.ShellCommand != "sleep 300" {
+		t.Fatalf("expected the running snapshot to carry the shell state, got %+v (ok=%v)", info, ok)
+	}
+}
+
+// TestReconcileOrchestratorActivityReEmitsShellStateEveryTick is the shell-report
+// half of #1087's other lock: the shell signal is republished every tick
+// regardless of whether it changed, so a dropped or mistimed
+// orchestrator-shell-activity event self-heals within one tick.
+func TestReconcileOrchestratorActivityReEmitsShellStateEveryTick(t *testing.T) {
+	app := orchestratorTestApp(t)
+	defer app.shutdown(context.Background())
+	emits := newCapturedEmits()
+	app.emitFn = emits.fn()
+
+	created, err := app.CreateOrchestrator("agent", []orchestratorEnvInput{{Tenant: "frs", Environment: "dev"}})
+	if err != nil {
+		t.Fatalf("CreateOrchestrator failed: %v", err)
+	}
+	if _, err := app.StartOrchestrator(created.ID, 80, 24); err != nil {
+		t.Fatalf("StartOrchestrator failed: %v", err)
+	}
+
+	writeOrchestratorShellActivity(t, created.ID, orchestratorShellActivity{
+		Running: true, Command: "sleep 300", TaskID: "task-1", AtUnix: time.Now().Unix(),
+	})
+
+	app.reconcileOrchestratorActivity()
+	app.reconcileOrchestratorActivity()
+	app.reconcileOrchestratorActivity()
+
+	events := emits.events(orchestratorShellEvent)
+	if len(events) != 3 {
+		t.Fatalf("expected one emit per tick even with no state change, got %d: %+v", len(events), events)
+	}
+	for _, event := range events {
+		payload, ok := event.(orchestratorShellActivityPayload)
+		if !ok || !payload.Running || payload.Command != "sleep 300" {
+			t.Fatalf("expected every re-emit to report the running shell, got %+v", event)
+		}
+	}
+}

--- a/erun-ui/session_heartbeat_test.go
+++ b/erun-ui/session_heartbeat_test.go
@@ -298,10 +298,10 @@ func TestReconcileOrchestratorActivityReEmitsEveryTick(t *testing.T) {
 }
 
 // TestOrchestratorShellSnapshotRendersRunningWithoutTheEvent is the shell-report
-// half of the #1087 treatment (#1068): orchestratorInfo carries ShellRunning
-// directly, so a snapshot taken after the state changed reflects it even when
-// the orchestrator-shell-activity event that announced the change was never
-// observed — the same remount/reopen/late-listener path
+// half of the same busy-snapshot treatment: orchestratorInfo carries
+// ShellRunning directly, so a snapshot taken after the state changed reflects
+// it even when the orchestrator-shell-activity event that announced the
+// change was never observed — the same remount/reopen/late-listener path
 // TestOrchestratorSnapshotRendersBusyWithoutTheEvent locks for the turn's own
 // busy signal, but for a fact that is independent of it: a shell can be
 // running while the turn itself already reads idle.
@@ -337,8 +337,8 @@ func TestOrchestratorShellSnapshotRendersRunningWithoutTheEvent(t *testing.T) {
 }
 
 // TestReconcileOrchestratorActivityReEmitsShellStateEveryTick is the shell-report
-// half of #1087's other lock: the shell signal is republished every tick
-// regardless of whether it changed, so a dropped or mistimed
+// half of the busy-signal re-emit lock: the shell signal is republished every
+// tick regardless of whether it changed, so a dropped or mistimed
 // orchestrator-shell-activity event self-heals within one tick.
 func TestReconcileOrchestratorActivityReEmitsShellStateEveryTick(t *testing.T) {
 	app := orchestratorTestApp(t)

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -643,6 +643,22 @@ type aiActivityPayload struct {
 	Busy        bool   `json:"busy"`
 }
 
+// orchestratorShellActivityPayload carries whether an orchestrator's
+// background shell is running, its command and when it started, so the
+// sidebar can spin and show elapsed time for a shell the orchestrator's own
+// turn may already have gone idle around (#1068). Emitted every heartbeat
+// tick, busy or not, the same re-emit-regardless-of-change treatment
+// aiActivityPayload was given in #1087 and for the same reason: a snapshot
+// field (orchestratorInfo.ShellRunning) carries the same signal so a missed
+// or mistimed event self-heals within one tick instead of staying wrong until
+// the state itself next changes.
+type orchestratorShellActivityPayload struct {
+	SessionID     int    `json:"sessionId"`
+	Running       bool   `json:"running"`
+	Command       string `json:"command,omitempty"`
+	StartedAtUnix int64  `json:"startedAtUnix,omitempty"`
+}
+
 type appStatusPayload struct {
 	Message string `json:"message"`
 	Busy    bool   `json:"busy"`

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -646,11 +646,11 @@ type aiActivityPayload struct {
 // orchestratorShellActivityPayload carries whether an orchestrator's
 // background shell is running, its command and when it started, so the
 // sidebar can spin and show elapsed time for a shell the orchestrator's own
-// turn may already have gone idle around (#1068). Emitted every heartbeat
-// tick, busy or not, the same re-emit-regardless-of-change treatment
-// aiActivityPayload was given in #1087 and for the same reason: a snapshot
-// field (orchestratorInfo.ShellRunning) carries the same signal so a missed
-// or mistimed event self-heals within one tick instead of staying wrong until
+// turn may already have gone idle around. Emitted every heartbeat tick, busy
+// or not, the same re-emit-regardless-of-change treatment aiActivityPayload
+// was given earlier and for the same reason: a snapshot field
+// (orchestratorInfo.ShellRunning) carries the same signal so a missed or
+// mistimed event self-heals within one tick instead of staying wrong until
 // the state itself next changes.
 type orchestratorShellActivityPayload struct {
 	SessionID     int    `json:"sessionId"`


### PR DESCRIPTION
## Summary

Two fixes to the desktop, both landing in one PR per repo policy:

**#1096 — restore resumed a derived session id, not the session that was running.** `orchestrator-open.json` now records the exact conversation id each orchestrator was spawned with (not just the orchestrator id), and restore resumes that recorded conversation explicitly — for the pane owner and every `AlsoReopen` entry alike — instead of re-deriving `uuid5(namespace, id)` and hoping it still names the live session. When no live session was ever recorded, or the recorded one no longer exists on disk, restore mints a fresh conversation instead of falling back to the derived id: resuming nothing is safer than silently resurrecting a stale, wrong conversation.

**#1068 — a running background shell had no activity affordance.** The orchestrator's own turn-boundary busy report (`orchestrator-activity`) can't answer "is a shell still running", since a background shell (`Bash` with `run_in_background`) can keep running after the turn that started it goes idle. A new `orchestrator-shell-activity` report, written by two new PostToolUse-only hooks (`Bash` starts it, `TaskOutput|TaskStop` clears it by matching task id), tracks this independently. Following the exact snapshot + heartbeat-re-emit pattern from #1087 (`orchestratorInfo` carries `ShellRunning`/`ShellCommand`/`ShellStartedAtUnix` directly, and the heartbeat re-emits every tick regardless of change), the sidebar now shows a spinner with elapsed time and the running command whenever a shell is running and the turn itself isn't already spinning.

## How restore resolves the real session (#1096)

- `recordOpenOrchestrator` now stores `{orchestratorId, sessionId}` per entry (was just an id), written every time a session spawns with whatever conversation id it actually used.
- `resolveReopenSessionID` resumes that recorded id only when `orchestratorSessionExists` confirms the transcript is still on disk; otherwise it mints a fresh `uuid.NewString()`.
- Applies uniformly: the pane owner (`OrchestratorID`/`ConversationID`) and every `AlsoReopen` entry (`orchestratorReopenRef.ConversationID`) are resolved the same way — the earlier PR (#1098) fixed *how many* orchestrators come back, this fixes *which conversation* each one resumes.
- **No live session recorded** (first launch, a crash before anything was recorded, or upgrading from a release that only ever wrote the orchestrator id): treated identically to "recorded but stale" — starts fresh rather than resolving to whatever the derived id happens to already name on disk. This is a deliberate, one-time continuity cost on the first restart after this ships (nothing was recorded under the new scheme yet) traded for never resurrecting a wrong conversation again.
- Frontend (`orchestratorThunks.ts`) now calls `StartOrchestratorWithResume` whenever a `conversationId` is resolved (owner or `AlsoReopen`), not just when a restart hand-off supplies a prompt — closing the gap where a plain quit-and-relaunch always called blind `StartOrchestrator`.

## How the shell affordance survives a remount (#1068)

Same delivery shape as #1087, applied to a new, independent signal:
- `session.shellRunning`/`shellCommand`/`shellStartedAtUnix` live on the in-memory orchestrator session and are read directly into every `orchestratorInfo` snapshot (`ListOrchestrators`, `runningOrchestratorInfo`) — not just carried by an event.
- `reconcileOrchestratorActivity`'s heartbeat tick (15s) re-emits `orchestrator-shell-activity` every pass regardless of whether the state changed, so a dropped or mistimed event self-heals within one tick instead of staying wrong.
- Frontend seeds the same store field from both the snapshot (`planOrchestratorShellSeed`, on every `loadOrchestrators`) and the event (`handleOrchestratorShellActivity`), so a remount, reload, or reconnect never depends on having witnessed the transition.
- No terminal-output scanning anywhere: the signal comes from two new hooks parsing the *structured* JSON Claude Code's own hooks receive on `PostToolUse` (`tool_response.backgroundTaskId` to start, `tool_response.task.status`/`task_id` to clear) — empirically verified against a real `claude` session in this sandbox, not assumed from docs. `node -e` does the JSON parsing (guaranteed present since the AI harness itself needs it), matching the existing hook's "no dependency on tools that might be missing" design.
- A generous 6-hour safety bound (vs. the short 2-minute one when the session is no longer visible) prevents an eternal false-positive if a shell is ended by some path neither hook observes, without falsely aging out a legitimately long-running build or poll loop.

## Constraints honored

- No terminal-output-based latching reintroduced for either fix.
- `erun-ui` is not in `make check`'s module list, so its own Go and frontend gates were run explicitly (see below).

## UX Impact Review Checklist

1. **Affected paths:** Sidebar orchestrator row (spinner + shell indicator); boot's `restoreOpenOrchestrators` flow.
2. **User-visible sequence:** On restore, the orchestrator tab reopens attached to the actual live conversation (or starts fresh with a visible idle state, never silently resurrecting a stale one). On the sidebar, a running background shell now shows a spinner with elapsed time and the command, in place of no affordance at all.
3. **State-without-affordance:** N/A — every new state field (`shellRunning`, `ConversationID` resolution) has a corresponding render.
4. **Visibility of system status:** The shell indicator persists in the sidebar row, independent of the busy spinner, driven by the same durable snapshot+event pattern as the busy signal.
5. **Success/failure feedback:** A refused restart hand-off still surfaces its existing notice; the shell indicator has no failure state (only running/not-running).
6. **Consistency with comparable flows:** Reuses `BusyRowSpinner` exactly as the orchestrator/env busy rows do (Nielsen #4).
7. **Heuristic pass:** Visibility of system status — the core of both fixes. Recognition over recall — the shell tooltip names the command instead of requiring a trip to the process table.
8. **Playwright coverage:** `orchestrator-reopen-on-launch.spec.ts` (extended) and the new `sidebar-orchestrator-shell-activity-snapshot.spec.ts`.

## Test plan

- [x] `make check` — green (see verdict below)
- [x] `go test ./...` in `erun-ui` — green
- [x] `golangci-lint run ./...` in `erun-ui` — 0 issues
- [x] `yarn typecheck && yarn lint && yarn format:check && yarn test` in `erun-ui/frontend` — all green
- [x] `./run.sh --build` (full Playwright suite, 172 specs) — all green
- [x] Empirically verified the Claude Code hook JSON payload shapes (`tool_response.backgroundTaskId`, `TaskOutput`/`TaskStop` response shapes) against a real `claude` session rather than assuming them from third-party docs

Closes #1096
Closes #1068

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>