### PR TITLE
Copy the paths the gated tests read, and stop the cache hiding it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,17 @@ lint:
 # erun-ui's own Go tests. See the LINT_MODULES comment above for why this is
 # a separate step rather than folded into integration-test or a contributor's
 # ordinary `go test ./...`.
+#
+# -count=1 is load-bearing, not belt-and-braces. The build-stamp guard here
+# reads build.sh, build.ps1 and the package-manager formulae with os.ReadFile at
+# run time, and Go's test cache keys on compiled inputs only -- it does not
+# track a file a test opens itself. So editing one of those scripts leaves a
+# recorded PASS that is no longer true, and the gate reports `(cached)` while
+# the thing it guards is broken. That is exactly how a release-breaking
+# regression reached main once.
 test-erun-ui:
 	@echo ">> go test erun-ui"
-	@(cd erun-ui && go test ./...)
+	@(cd erun-ui && go test -count=1 ./...)
 
 # Build, run, and coverage-gate the erun integration suite.
 # The coverage threshold defaults to the value pinned in

--- a/erun-devops/docker/erun-devops/Dockerfile
+++ b/erun-devops/docker/erun-devops/Dockerfile
@@ -26,9 +26,17 @@ COPY erun-common /src/erun-common
 COPY erun-mcp /src/erun-mcp
 COPY erun-integration /src/erun-integration
 # Every module in the Makefile's LINT_MODULES must land here or `make check`
-# cannot cd into it.
+# cannot cd into it -- and so must every path those modules' tests read at run
+# time, which is not the same set. erun-ui's build-stamp guard deliberately
+# checks the package-manager formulae as well as the module's own scripts,
+# because a stamp corrected only in build.sh still leaves every installed
+# desktop unstamped; it reads them with os.ReadFile and treats a missing file as
+# fatal, so omitting them here fails the gate inside the build while a full
+# checkout passes.
 COPY erun-backend/erun-backend-api /src/erun-backend/erun-backend-api
 COPY erun-ui /src/erun-ui
+COPY Formula /src/Formula
+COPY bucket /src/bucket
 
 # `make check` runs golangci-lint across the Go modules then the integration
 # suite + coverage gate. A failing lint or test fails the build, the builder


### PR DESCRIPTION
Gating `erun-ui` (#1092) broke every release. The 1.0.193 attempt failed at the in-build test stage
on exactly one test, `TestBuildScriptsStampSymbolsThisPackageDeclares`.

## Cause

That guard walks every script that produces the desktop — including the package-manager formulae,
deliberately, because a stamp corrected only in `build.sh` still leaves every *installed* desktop
unstamped:

```go
var buildScriptsProducingTheDesktop = []string{
	"build.sh", "build.ps1",
	filepath.Join("..", "Formula", "erun.rb"),
	filepath.Join("..", "bucket", "erun.json"),
}
```

`readBuildScript` treats a missing file as fatal. The image test stage copies only the Go modules,
so inside the build the test cannot read `../Formula/erun.rb` and dies. The `COPY erun-ui` line was
correct — the module landed; what did not land were two repo files that module's *tests* read.

The stage's comment stated a necessary condition that was not sufficient: not only "every module in
`LINT_MODULES` must land here", but **every path those modules' tests read**, which for `erun-ui`
reaches outside its own module by design.

## Why it reached main

The pre-merge gate was green on a **stale test cache**:

```
>> golangci-lint erun-ui
0 issues.
ok  	github.com/sophium/erun/erun-ui	(cached)
```

`(cached)` is the tell. This test opens those scripts with `os.ReadFile` at run time, and Go's test
cache keys on compiled inputs — it does not track a file a test opens itself. So editing
`erun-cli/run.sh` and the formulae left a recorded PASS that was no longer true, while a fresh
container ran it for real and failed.

Confirmed both directions before fixing: mounting the whole checkout into `golang:1.26.0` passes
(`ok github.com/sophium/erun/erun-ui 4.438s`); replicating the stage's exact `COPY` set fails on
that one test.

## Change

- `COPY Formula /src/Formula` and `COPY bucket /src/bucket` into the test stage, and widen the
  comment so the next module added to the gate does not reintroduce this.
- Run erun-ui's tests with `-count=1`, with the reason recorded at the target. Without it the gate
  can report `(cached)` while the thing it guards is broken — which is how this regression got in.

## Verification

Built the real stage the release runs (`docker build --target test`), which now passes:

```
=== docker build rc=0 ===
>> golangci-lint erun-common / erun-cli / erun-mcp / erun-integration /
   erun-backend/erun-backend-api / erun-ui     0 issues. (all six)
>> go test erun-ui
ok  	github.com/sophium/erun/erun-ui	4.608s
ok  	github.com/sophium/erun/erun-ui/headlessserver	0.009s
ok  	github.com/sophium/erun/erun-integration	75.542s
ok  coverage 76.5% (>= 76.0%)
```

Note `ok erun-ui 4.608s` rather than `(cached)` — the tests now actually run in the gate.

Closes #1114
