### PR TITLE
Write a chained step's files before the deploy, not between it and the chain

### DIFF
--- a/erun-backend/erun-backend-api/internal/deployexec/job.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/job.go
@@ -202,8 +202,15 @@ func buildDeployCommand(params DeployJobParams) []string {
 		script += writeMCPAuthPublicKeyScript(pem)
 		deploy = append(deploy, "--mcp-auth-public-key", mcpAuthPublicKeyJobPath)
 	}
+	// Every file a chained step reads is written BEFORE the deploy command, never
+	// between it and the chain. exposeChainScript opens with " && " so exposure
+	// stays conditional on the deploy succeeding; anything appended after
+	// shellJoin(deploy) instead glues itself onto the deploy's last argument,
+	// which silently corrupted --mcp-auth-public-key into a path ending "pemcat".
+	exposeFiles, exposeChain := buildExposeChain(params)
+	script += exposeFiles
 	script += shellJoin(deploy)
-	script += buildExposeChain(params)
+	script += exposeChain
 	return []string{"sh", "-c", script}
 }
 
@@ -222,10 +229,10 @@ func writeDNS01TokenScript(token string) string {
 // buildExposeChain composes the deploy Job's chained `erun expose` step
 // (empty when ExposeTargetIP is unset), including the per-env TLS flags when
 // configured.
-func buildExposeChain(params DeployJobParams) string {
+func buildExposeChain(params DeployJobParams) (exposeFiles, chain string) {
 	ip := strings.TrimSpace(params.ExposeTargetIP)
 	if ip == "" {
-		return ""
+		return "", ""
 	}
 	expose := []string{"erun", "expose", params.Tenant, params.Environment, mcpExposeService, "--ip", ip, "--skip-if-unconfigured"}
 	if zone, ns := strings.TrimSpace(params.ExposeServicesZone), strings.TrimSpace(params.ExposePlatformNamespace); zone != "" && ns != "" {
@@ -233,7 +240,7 @@ func buildExposeChain(params DeployJobParams) string {
 	}
 	tlsScript, tlsFlags := tlsExposeFlags(params)
 	expose = append(expose, tlsFlags...)
-	return tlsScript + exposeChainScript(expose)
+	return tlsScript, exposeChainScript(expose)
 }
 
 // tlsExposeFlags returns the heredoc that writes the per-env DNS-01 broker

--- a/erun-backend/erun-backend-api/internal/deployexec/job_test.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/job_test.go
@@ -280,6 +280,43 @@ func TestBuildDeployCommandWithTLSCertProvisioning(t *testing.T) {
 	}
 }
 
+// TestBuildDeployCommandWritesChainedStepFilesBeforeTheDeploy guards the
+// script's composition rather than its contents. exposeChainScript opens with
+// " && " so exposure stays conditional on the deploy succeeding, which means
+// anything appended after shellJoin(deploy) welds itself onto the deploy's last
+// quoted argument instead of becoming its own command. That turned
+// --mcp-auth-public-key into a path ending "pemcat" and failed every hosted
+// provision, while assertions asking only whether the script *contained* each
+// piece stayed green -- the corruption is a boundary, not a missing piece.
+func TestBuildDeployCommandWritesChainedStepFilesBeforeTheDeploy(t *testing.T) {
+	params := testParams()
+	params.MCPAuthPublicKeyPEM = "-----BEGIN PUBLIC KEY-----\nAAAA\n-----END PUBLIC KEY-----"
+	params.ExposeTargetIP = "203.0.113.10"
+	params.TLSDNS01Token = "test-token"
+	params.TLSDNS01BrokerURL = "https://api.example.com/v1/dns01"
+	params.TLSACMEEmail = "admin@example.com"
+	script := buildDeployCommand(params)[2]
+
+	tokenWrite := strings.Index(script, "cat > "+dns01TokenJobPath)
+	deployRun := strings.Index(script, "\x27erun\x27 \x27deploy\x27")
+	exposeChain := strings.Index(script, "&& { expose_out=")
+	if tokenWrite < 0 || deployRun < 0 || exposeChain < 0 {
+		t.Fatalf("script must write the token, run the deploy and chain expose, got %q", script)
+	}
+	if tokenWrite > deployRun {
+		t.Errorf("the token heredoc must run before the deploy, got token at %d, deploy at %d in %q", tokenWrite, deployRun, script)
+	}
+	if exposeChain < deployRun {
+		t.Errorf("expose must chain after the deploy so it stays conditional on it, got %q", script)
+	}
+	if strings.Contains(script, "\x27cat > ") {
+		t.Errorf("a heredoc is welded onto the preceding shell word in %q", script)
+	}
+	if want := "\x27--mcp-auth-public-key\x27 \x27" + mcpAuthPublicKeyJobPath + "\x27"; !strings.Contains(script, want) {
+		t.Errorf("script %q must pass the mcp auth key path as its own shell word", script)
+	}
+}
+
 // TestBuildDeployCommandQuotesArguments guards the shell-injection surface: an
 // argument carrying a single quote must stay a single shell word — the
 // canonical way a naively-quoted value breaks out of its own quoting.


### PR DESCRIPTION
Every hosted provision on 1.0.193 failed before creating a namespace:

```
provision-error=deploy job failed for version 1.0.193:
  erun deploy ... --mcp-auth-public-key /tmp/erun-deploy-mcp-auth-public-key.pemcat --runtime-image ...
deploy: spec resolution failed: read mcp auth public key
  /tmp/erun-deploy-mcp-auth-public-key.pemcat: no such file or directory
```

## Cause

`buildDeployCommand` appended the expose chain straight after the deploy command:

```go
script += shellJoin(deploy)
script += buildExposeChain(params)
```

`exposeChainScript` opens with `" && "` so exposure stays conditional on the deploy succeeding — it
self-separates. But `buildExposeChain` returned `tlsScript + exposeChainScript(expose)`, and
`tlsScript` is a bare heredoc starting `cat > /tmp/erun-deploy-dns01-token`. Appended after
`shellJoin`'s final single-quoted argument, it became part of that argument:

```
... '--mcp-auth-public-key' '/tmp/erun-deploy-mcp-auth-public-key.pem'cat > /tmp/erun-deploy-dns01-token <<'DNS01_TOKEN_EOF'
```

Per-env TLS provisioning and MCP-auth-key injection are each fine alone. The defect needs both
configured — which is the shipped production configuration.

## Change

Write the files a chained step reads **before** the deploy, and return the two parts separately so
the boundary is explicit rather than implied:

```go
exposeFiles, exposeChain := buildExposeChain(params)
script += exposeFiles
script += shellJoin(deploy)
script += exposeChain
```

The token is written unconditionally — it is only a file — while exposure stays `&&`-conditional on
a successful deploy, which is the invariant the original ordering was protecting.

## Why the tests missed it, and what the new one does differently

`TestBuildDeployCommandWithMCPAuthPublicKey` and `TestBuildDeployCommandWithTLSCertProvisioning`
both pass on the broken code. Every assertion is a `strings.Contains`, and

```go
strings.Contains(script, "cat > "+dns01TokenJobPath+" <<'DNS01_TOKEN_EOF'")
```

is true whether or not a `'` immediately precedes the `cat`. The corruption is a **boundary**, not a
missing piece, so those tests had the broken script in their own output and could not see it.

`TestBuildDeployCommandWritesChainedStepFilesBeforeTheDeploy` asserts the composition instead: the
token heredoc precedes the deploy, the expose chain follows it, the key path is its own shell word,
and no heredoc is welded onto a preceding shell word. Verified it **fails on the unfixed code**
(reporting the `'...pem'cat > ...` splice) and passes with the fix.

## Verification

`make check` green — six modules `0 issues`, erun-ui's tests running fresh (`ok erun-ui 14.922s`),
integration suite ok, `coverage 76.5% (>= 76.0%)`.

The live provisioning gate re-runs once this is released and adopted; it is what found this in the
first place.

Closes #1117
