### PR TITLE
Create the namespace before applying the secrets that write into it

### DIFF
--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -818,6 +818,37 @@ func runPublishedValuesPull(ctx Context, pull *publishedValuesPull, target strin
 	return cleanup, nil
 }
 
+// ensureDeployNamespace creates the deploy's namespace if it is missing. A var
+// so a test can prove it runs before the secret applies that require it --
+// trace order cannot, because the trace already claimed this order while the
+// code did not follow it.
+var ensureDeployNamespace NamespaceEnsurerFunc = EnsureKubernetesNamespace
+
+// applyPreRolloutResources creates the namespace and applies everything that
+// must exist in it before the chart rollout. Grouped rather than inline so the
+// ordering is stated in one place as this list grows.
+//
+// The namespace is ensured here and not only in the chart deployer, because the
+// secrets below are real writes into it: on a first deploy -- a freshly
+// provisioned hosted environment, where nothing has created it yet -- they fail
+// with "namespaces not found". An environment that already exists hid this,
+// which is why it only ever broke provisioning. Ensuring is idempotent, so the
+// deployer ensuring it again afterwards costs nothing.
+func applyPreRolloutResources(ctx Context, deployInput HelmDeploySpec) error {
+	if !ctx.DryRun {
+		if err := ensureDeployNamespace(deployInput.KubernetesContext, deployInput.Namespace); err != nil {
+			return err
+		}
+	}
+	if err := applyCloudflareCredentialsSecret(ctx, deployInput); err != nil {
+		return err
+	}
+	if err := applyMCPAuthSecret(ctx, deployInput); err != nil {
+		return err
+	}
+	return recordMCPAuthKeyOnEnv(ctx, deployInput)
+}
+
 func RunHelmDeploy(ctx Context, deployInput HelmDeploySpec, deploy HelmChartDeployerFunc) error {
 	if deploy == nil {
 		return fmt.Errorf("helm deployer is required")
@@ -829,13 +860,7 @@ func RunHelmDeploy(ctx Context, deployInput HelmDeploySpec, deploy HelmChartDepl
 	TraceEnsureKubernetesNamespace(ctx, deployInput.KubernetesContext, deployInput.Namespace)
 	TraceApplyKubernetesResourceQuota(ctx, deployInput.KubernetesContext, deployInput.Namespace, deployInput.NamespaceQuota)
 	announceWorktreeVolumeChange(ctx, deployInput)
-	if err := applyCloudflareCredentialsSecret(ctx, deployInput); err != nil {
-		return fmt.Errorf("deploy %s: %w", deployInput.ReleaseName, err)
-	}
-	if err := applyMCPAuthSecret(ctx, deployInput); err != nil {
-		return fmt.Errorf("deploy %s: %w", deployInput.ReleaseName, err)
-	}
-	if err := recordMCPAuthKeyOnEnv(ctx, deployInput); err != nil {
+	if err := applyPreRolloutResources(ctx, deployInput); err != nil {
 		return fmt.Errorf("deploy %s: %w", deployInput.ReleaseName, err)
 	}
 	depBuild, err := chartDependencyBuildPlan(ctx, deployInput)

--- a/erun-common/deploy_namespace_order_test.go
+++ b/erun-common/deploy_namespace_order_test.go
@@ -1,0 +1,55 @@
+package eruncommon
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestRunHelmDeployEnsuresTheNamespaceBeforeApplyingSecrets proves an ordering
+// the trace could not. RunHelmDeploy traced the namespace ensure first, then
+// applied real kubectl secrets into that namespace -- but the namespace was only
+// created later, by WrapHelmChartDeployerWithNamespaceEnsure around the chart
+// deployer RunHelmDeploy calls at the end. So a first deploy into a freshly
+// provisioned environment failed with "namespaces not found" and every hosted
+// provision broke; an environment that already existed hid it entirely.
+//
+// Swapping the ensure for one that refuses is what makes the order checkable: if
+// it runs first, RunHelmDeploy returns this sentinel; if it runs late -- or not
+// at all, as before -- the secret apply is reached first and the error differs.
+func TestRunHelmDeployEnsuresTheNamespaceBeforeApplyingSecrets(t *testing.T) {
+	sentinel := errors.New("namespace-ensure-ran-first")
+	var gotNamespace string
+	called := false
+
+	original := ensureDeployNamespace
+	ensureDeployNamespace = func(_, namespace string) error {
+		called = true
+		gotNamespace = namespace
+		return sentinel
+	}
+	t.Cleanup(func() { ensureDeployNamespace = original })
+
+	spec := HelmDeploySpec{
+		ReleaseName:         "operations-devops",
+		KubernetesContext:   "in-cluster",
+		Namespace:           "operations-probe",
+		ChartPath:           "oci://ghcr.io/sophium/charts/erun-devops",
+		MCPAuthEnabled:      true,
+		MCPAuthSecretName:   "operations-devops-mcp-auth",
+		MCPAuthPublicKeyPEM: "-----BEGIN PUBLIC KEY-----\nAAAA\n-----END PUBLIC KEY-----",
+	}
+	err := RunHelmDeploy(Context{}, spec, func(HelmDeployParams) error {
+		t.Error("the chart deployer must not run after the namespace ensure failed")
+		return nil
+	})
+
+	if !called {
+		t.Fatal("RunHelmDeploy must ensure the namespace before applying secrets into it")
+	}
+	if gotNamespace != "operations-probe" {
+		t.Errorf("ensured namespace = %q, want operations-probe", gotNamespace)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err = %v, want the namespace-ensure failure to abort before the secret apply", err)
+	}
+}


### PR DESCRIPTION
With erun#1117 fixed, hosted provisioning gets one step further and then fails. Live on 1.0.194:

```
deploy: resolved 1 spec(s)
apply mcp auth public key secret operations-devops-mcp-auth
==> Deploy failed operations/probeh: kubectl apply mcp auth secret: exit status 1:
    Error from server (NotFound): namespaces "operations-probeh" not found
```

The `--mcp-auth-public-key` value is correct now — erun#1117 did its job. This is the next defect.

## Cause

`RunHelmDeploy` *traced* the namespace ensure, then did real writes, and created the namespace only
at the end:

```go
TraceEnsureKubernetesNamespace(...)          // trace only
applyCloudflareCredentialsSecret(...)        // real kubectl apply
applyMCPAuthSecret(...)                      // real kubectl apply  <-- fails here
...
deploy(params)                               // WrapHelmChartDeployerWithNamespaceEnsure creates it
```

**Why it never bit before:** every path that existed until hosted provisioning targets an
environment that has already been initialised. Only a *freshly provisioned* hosted environment
reaches `RunHelmDeploy` with no namespace, and hosted provisioning is the only thing that does
first deploys.

The trace was honest about intent at exactly the right point; the code just did not follow it —
the same divergence class as erun#1100, where a dry run showed work the real run skipped.

## Change

Group the pre-rollout applies into `applyPreRolloutResources`, which ensures the namespace before
the secrets that write into it. Ensuring is idempotent, so the deployer wrapper ensuring it again
afterwards costs nothing.

Grouping also keeps `RunHelmDeploy` under the cyclomatic gate. It was already sitting exactly at the
limit, so adding a branch tripped `cyclop` — collapsing three inline error checks into one call is
the fix rather than suppressing the finding or raising the threshold.

## Test

`TestRunHelmDeployEnsuresTheNamespaceBeforeApplyingSecrets`.

Trace order could not catch this, because the trace already claimed the right order. So the ensure
is now a swappable `NamespaceEnsurerFunc` and the test replaces it with one that refuses: if the
ensure runs first, `RunHelmDeploy` returns that sentinel; if it runs late or not at all, the secret
apply is reached first and the error differs.

Verified both directions. With the ensure removed to reproduce the shipped behaviour the test fails,
and its output shows `apply mcp auth public key secret operations-devops-mcp-auth` reached first.
With the fix it passes.

## Verification

`make check` green: six modules `0 issues`, `ok erun-ui 14.947s`, integration suite ok,
`coverage 76.5% (>= 76.0%)`.

The live provisioning gate re-runs once this is released and adopted — it is what found both this
and erun#1117.

Closes #1120