### PR TITLE
Build the typed command instead of living in raw

### DIFF
--- a/erun-skills/skills/erun-orchestrate/SKILL.md
+++ b/erun-skills/skills/erun-orchestrate/SKILL.md
@@ -108,7 +108,23 @@ Read what you control from erun's config store — never infer it from what happ
 - **Observe a mounted environment from the host, not from inside it.** Probing a pod on a short interval spends the capacity you are trying to measure, and the resulting timeouts look like a broken channel. Where the worktree lives on this machine, its files answer for free; where it does not, use the environment's own progress reporting rather than reaching in.
 - **A one-shot agent has no "later".** Work it starts in the background and promises to report is work nobody reports. Require the result in the run that produced it.
 - **Name a kill pattern for what it must not match.** A pattern aimed at a process will also match any path or argument that merely contains its name, and the collateral is somebody's live session.
-- **Prefer the typed tool over the general escape hatch.**
+- **Prefer the typed tool over the general escape hatch — and when the tool does not exist, build
+  it rather than living in the hatch.** `raw` is an escape hatch, not a workspace. Reaching for it
+  twice for the same operation is the signal that a command is missing, not that shell is the
+  answer. A typed command validates its inputs, records what it did in terms an operator can read
+  afterwards, composes its argv directly instead of through a shell that will expand what it should
+  not, and — the part that matters most on a shared or hosted environment — **can be authorized on
+  its own**. Granting `raw` grants arbitrary execution in the pod; granting a named operation grants
+  that operation, so fine-grained access to exactly the commands an environment needs to be managed
+  is only possible once those commands exist as commands. It is also the difference between the next
+  orchestrator inheriting the capability and re-deriving your shell from scratch.
+  Add it in both transports over shared logic, the way the repo requires of any new command, and
+  state the exception explicitly if one transport genuinely cannot host it.
+- **The same rule applies to waiting.** A hand-written poll loop around a job is a shell
+  reimplementation of a bounded wait that already exists, and it will be worse: it re-derives
+  "finished" from whatever it can scrape, so it reads a dropped channel as an outcome and a
+  frozen counter as a hang. Use the bounded wait the environment offers and let it tell you
+  running, exited, or unreachable.
 - **Wake a stopped environment from the host.** A stopped env has no pod, so its MCP edge cannot answer and cannot start itself; that silence is not a broken env. Open it from the host CLI, then resume over MCP.
 - **When you hand an agent a long gate, tell it how to wait.** An agent left to invent its own waiting starts the work in a background shell and then spends its turns re-reading an empty output file — hundreds of turns that buy nothing and can exhaust it before the work it is waiting for even finishes. Have it run the gate as a detached job and block on that job's own completion, so waiting costs one call rather than one per poll.
 


### PR DESCRIPTION
Documentation only — `erun-skills/skills/erun-orchestrate/SKILL.md`. No behaviour change.

The skill said "Prefer the typed tool over the general escape hatch" and stopped. It did not say what
to do when the typed tool **does not exist**, so the practical reading was "use `raw`". This says:
build the command.

## Why, in priority order

**Authorization.** Granting `raw` grants arbitrary execution inside the pod. Granting a named
operation grants that operation. So an environment can only be managed under least privilege once
the operations it needs *are* commands — per-tool authorization has nothing to attach to while every
action is spelled `raw`. That is the difference between "this orchestrator may restart the runtime"
and "this orchestrator may run anything".

**A safe argv.** A typed command composes arguments directly; a shell one-liner passes through an
expansion layer that will interpret what it should not. This repo has paid for that twice already —
a heredoc welded onto a command's last argument, and a quoted value that needed its own test to
defend.

**A legible trail, and reuse.** Named commands read back as what was done; a series of `raw` calls
reads back as shell. And a capability added as a command is inherited by the next orchestrator
instead of being re-derived, differently, each session.

Precedent already exists: rather than base64-ing a file through `raw --stdin`, inbound transfer
became a real command (#1044) — which is why it can be verified byte-identical and refuse clearly,
instead of being an incantation per caller.

## Also: the same rule applies to waiting

A hand-written poll loop around a job is a shell reimplementation of a bounded wait that already
exists, and strictly worse, because it re-derives "finished" from whatever it can scrape. In one
session such a loop reported a job **FINISHED** when the channel had merely dropped, and separately
read a frozen progress counter as a hang — both because it could not distinguish *running*,
*exited* and *unreachable*, which the bounded wait states directly.

I wrote those loops having already read the existing guidance, which is the argument for naming the
failure and not just the preference.

Edited in `erun-skills/` — the source the runtime image and marketplace bake from — not an installed
copy, per the skill's own guardrail.

Closes #1126