### PR TITLE
Pace yourself so your picture does not go stale

### DIFF
--- a/erun-skills/skills/erun-orchestrate/SKILL.md
+++ b/erun-skills/skills/erun-orchestrate/SKILL.md
@@ -73,6 +73,17 @@ Read what you control from erun's config store — never infer it from what happ
   substituted, and say which of the above you tried. A gap that names no
   attempted mechanism is a stop wearing an honest face.
 - **Bound your waits.** Every gate, build, and e2e gets an explicit timeout so a hang fails fast.
+- **Pace yourself: come back roughly every five minutes and check nothing has gone stale.** A long
+  single wait is not patience, it is blindness — while you block, the work you are waiting on
+  settles, a channel drops, a pod is replaced, and another actor moves a branch or a HEAD you were
+  reasoning about. Everything you believed at the start of the wait is a claim about a world that
+  has since changed, and the longer the wait the more of it is wrong.
+  On each pass re-read the things that go stale rather than the thing you are waiting for: the
+  job's own state, the channel, the tree's HEAD and cleanliness, and whether anything you were told
+  earlier is still true. Two failures come specifically from not doing this — declaring work stalled
+  that had already finished, and acting on a branch someone else had moved — and both read, at the
+  time, like careful diagnosis.
+  Short repeated checks also keep the operator informed, which a single silent block does not.
 - **On completion, list the assumptions you took** in place of asking. This is what keeps "don't ask" accountable.
 
 ## Working in a pod


### PR DESCRIPTION
Documentation only — `erun-skills/skills/erun-orchestrate/SKILL.md`, next to "Bound your waits". No
behaviour change.

Bounding a wait stops a hang. It does not stop the *other* failure: blocking for ten minutes and then
acting on what you believed ten minutes ago.

> A long single wait is not patience, it is blindness — while you block, the work you are waiting on
> settles, a channel drops, a pod is replaced, and another actor moves a branch or a HEAD you were
> reasoning about.

Two failures in one session came directly from this, and both read at the time like careful
diagnosis:

- A release was declared **stalled and self-inflicted** on the strength of a docker cache showing
  zero images. It had actually **succeeded** — that was the post-success state, and the tool's own
  verdict (`Released … RC=0`) was in the log the whole time.
- Work was committed and a HEAD moved in a build host's tree that looked idle but belonged to a job
  still running.

So the guidance now says: come back roughly every five minutes, and on each pass re-read the things
that *go stale* — the job's own state, the channel, the tree's HEAD and cleanliness, whether anything
learned earlier is still true — rather than re-reading the thing being waited for. It also notes that
short repeated checks keep the operator informed, which a single silent block does not.

Filed alongside a gap this same session exposed, tracked in the issue rather than fixed here: there
is **no typed command for editing a file or committing in an environment**, so every repository
change an orchestrator makes goes through `raw` with a script on stdin — the pattern #1126 says to
stop treating as normal. See #1128 for the shape that would close it.

Closes #1128