### PR TITLE
Say what to do when a typed tool fails

### DIFF
--- a/erun-skills/skills/erun-orchestrate/SKILL.md
+++ b/erun-skills/skills/erun-orchestrate/SKILL.md
@@ -131,6 +131,19 @@ Read what you control from erun's config store — never infer it from what happ
   orchestrator inheriting the capability and re-deriving your shell from scratch.
   Add it in both transports over shared logic, the way the repo requires of any new command, and
   state the exception explicitly if one transport genuinely cannot host it.
+- **When a typed tool fails, make the tool work and retry through it.** A failure is not a signal
+  to reach for the hatch; the hatch is what stops the tool from ever getting fixed. A fallback that
+  succeeds is worse than a failure that gets repaired, because it removes the reason to repair it,
+  and the next orchestrator inherits the same dead tool plus your workaround. Read the error for
+  the remedy it names — a tool that fails on missing setup usually says which setup, and that step
+  is often itself a typed command, one call away. Then follow the failure down: the second error is
+  usually more informative than the first, and frequently is not about the tool at all but about
+  something underneath it that nothing else was going to reveal. Distinguish what you are actually
+  looking at — no tool exists (build it), the tool is misconfigured (configure it), the tool is
+  broken (fix it), or the operation genuinely does not belong in a tool, because it needs a
+  credential a pod is deliberately denied. Only the last is a standing exception, and it is one you
+  state with the evidence that establishes it — what was reachable, what was denied, what is
+  missing — not one you assume the moment something red appears.
 - **The same rule applies to waiting.** A hand-written poll loop around a job is a shell
   reimplementation of a bounded wait that already exists, and it will be worse: it re-derives
   "finished" from whatever it can scrape, so it reads a dropped channel as an outcome and a


### PR DESCRIPTION
Closes #1136

The skill already says to prefer the typed tool over `raw`, and to build the command when it does not exist. It said nothing about the case in between: a typed tool that **exists and fails**. That gap has a default answer, and the default is wrong — fall back to the shell, which converts a fixable tool defect into a permanent shell habit and hands the next orchestrator the same dead tool plus a workaround.

## What prompted it

Driving the hosted control plane, the typed `platform_env_get` failed:

```
no erun platform cloud provider alias is configured; run `erun cloud init erun --api-url <url>` first
```

I fell back to the host CLI and explained why. Wrong twice: the error **named its own remedy**, and there is a typed tool for that remedy (`cloud_init_erun`). The fallback skipped a fix one call away.

Following the error instead was strictly more useful. `cloud_init_erun` failed with:

```
dial tcp: lookup api.erunpaas.com on 192.168.194.138:53: no such host
```

That is #1134 on a *second* cluster, which I had not looked at. Two further probes showed the pod could reach the platform edge fine (`http=200` against a pinned IP) and could not repair its own cluster DNS (`kubectl auth can-i create configmap -n kube-system` → `no`). Three facts, none of which a fallback would have produced: two are now evidence on #1134, and the third argues for where that fix belongs.

That is the general shape worth writing down. A tool failure is a measurement. Routing around it discards the measurement and leaves the tool broken.

## What the principle says

Make the tool work and retry through it. Read the error for the remedy it names. Follow the failure down, because the second error is usually more informative than the first and often is not about the tool at all. And distinguish the four cases — no tool exists (build it), misconfigured (configure it), broken (fix it), or genuinely not a tool's job because it needs a credential a pod is deliberately denied.

Only that last case is a standing exception, and the principle requires stating it *with* the evidence — what was reachable, what was denied, what is missing — rather than assuming it the moment something goes red. In this instance the exception turned out to be real: the platform login lives in the host keychain by design. But it was only legitimate to claim after the probes, not before them.

Guidance-only; no code or behaviour changes.