### PR TITLE
Inject the RFC2136 TSIG secret for erun terraform, like Cloudflare's token

### DIFF
--- a/erun-common/terraform.go
+++ b/erun-common/terraform.go
@@ -79,9 +79,15 @@ type TerraformResult struct {
 	LockReadonly bool `json:"lockReadonly,omitempty"`
 	// LegacyStateInTree flags a pre-relocation terraform.tfstate left in the root;
 	// it is ignored (state now lives at StateFile) and surfaced as a warning.
-	LegacyStateInTree    bool       `json:"legacyStateInTree,omitempty"`
-	Commands             [][]string `json:"commands"`
-	RequiresConfirmation bool       `json:"requiresConfirmation"`
+	LegacyStateInTree bool `json:"legacyStateInTree,omitempty"`
+	// RFC2136SecretName and RFC2136SecretNamespace name the Kubernetes Secret
+	// TF_VAR_rfc2136_tsig_secret was read from when the resolved dns01_provider
+	// is "powerdns-rfc2136"; empty otherwise. The secret's value never appears
+	// here or anywhere else erun logs or serializes.
+	RFC2136SecretName      string     `json:"rfc2136SecretName,omitempty"`
+	RFC2136SecretNamespace string     `json:"rfc2136SecretNamespace,omitempty"`
+	Commands               [][]string `json:"commands"`
+	RequiresConfirmation   bool       `json:"requiresConfirmation"`
 }
 
 // terraformRootSource records which candidate location the per-env Terraform
@@ -116,14 +122,47 @@ func RunTerraform(ctx Context, params TerraformParams, store TerraformStore, con
 		return TerraformResult{}, err
 	}
 
+	rfc2136Secret, err := prepareTerraformRFC2136Secret(&result)
+	if err != nil {
+		return TerraformResult{}, err
+	}
+
 	traceTerraformPlan(ctx, result, steps)
 	if ctx.DryRun {
 		return result, nil
 	}
-	if err := executeTerraformSteps(ctx, result, steps, confirm); err != nil {
+	if err := executeTerraformSteps(ctx, result, steps, confirm, rfc2136Secret); err != nil {
 		return result, err
 	}
 	return result, nil
+}
+
+// prepareTerraformRFC2136Secret resolves whether this env's dns01_provider
+// needs the RFC2136 TSIG secret and, if so, reads it back from its Kubernetes
+// Secret before anything is traced — the "fail up front" half of the
+// contract, so a missing secret is reported by name instead of surfacing as
+// terraform's own mid-plan precondition after a partial plan is already
+// printed. init never uses a var file, so it is exempt. The returned value is
+// never stored on result (which --output json can serialize); only the
+// Secret's name/namespace ride there.
+func prepareTerraformRFC2136Secret(result *TerraformResult) (string, error) {
+	if result.Operation == string(TerraformInit) {
+		return "", nil
+	}
+	requirement, err := resolveTerraformRFC2136Requirement(result.Directory, result.VarFile)
+	if err != nil {
+		return "", err
+	}
+	if !requirement.Needed {
+		return "", nil
+	}
+	secret, err := readTerraformRFC2136Secret(requirement)
+	if err != nil {
+		return "", err
+	}
+	result.RFC2136SecretName = requirement.SecretName
+	result.RFC2136SecretNamespace = requirement.Namespace
+	return secret, nil
 }
 
 func traceTerraformPlan(ctx Context, result TerraformResult, steps []terraformStep) {
@@ -152,6 +191,10 @@ func traceTerraformPlan(ctx Context, result TerraformResult, steps []terraformSt
 	traceTerraformInitLock(ctx, result)
 	if cloudflareTokenPresent() {
 		ctx.Trace("terraform: injecting TF_VAR_cloudflare_api_token from CLOUDFLARE_API_TOKEN")
+	}
+	if result.RFC2136SecretName != "" {
+		ctx.Trace(fmt.Sprintf("terraform: injecting TF_VAR_rfc2136_tsig_secret from Secret %s/%s (key %s)",
+			result.RFC2136SecretNamespace, result.RFC2136SecretName, terraformRFC2136SecretKey))
 	}
 	ctx.TraceCommand("", "mkdir", "-p", result.WorkDir)
 	for _, step := range steps {
@@ -217,7 +260,7 @@ func traceTerraformInitLock(ctx Context, result TerraformResult) {
 	ctx.Trace("terraform: no .terraform.lock.hcl yet — init will generate it and record provider hashes for " + strings.Join(terraformLockPlatforms, ", ") + "; commit it so read-only envs can init with -lockfile=readonly")
 }
 
-func executeTerraformSteps(ctx Context, result TerraformResult, steps []terraformStep, confirm TerraformConfirmFunc) error {
+func executeTerraformSteps(ctx Context, result TerraformResult, steps []terraformStep, confirm TerraformConfirmFunc, rfc2136Secret string) error {
 	// The durable state + data dir live on the home PVC; create it before init so
 	// terraform can write the local-backend state and TF_DATA_DIR there.
 	if err := os.MkdirAll(result.WorkDir, 0o755); err != nil {
@@ -231,7 +274,7 @@ func executeTerraformSteps(ctx Context, result TerraformResult, steps []terrafor
 			return err
 		}
 	}
-	extraEnv := terraformExtraEnv(result.DataDir)
+	extraEnv := terraformExtraEnv(result.DataDir, rfc2136Secret)
 	for _, step := range steps {
 		if step.confirm {
 			if confirm == nil {
@@ -479,12 +522,16 @@ func cloudflareTokenPresent() bool {
 
 // terraformExtraEnv sets TF_DATA_DIR to the durable home-PVC data dir (so
 // providers/modules/backend record survive a pod restart) and supplies the
-// Cloudflare API token the edge module's cert-manager DNS-01 solver needs. The
-// token rides in the environment, never in argv, so it never lands in the trace.
-func terraformExtraEnv(dataDir string) []string {
+// Cloudflare API token and, when the resolved dns01_provider needs it, the
+// RFC2136 TSIG secret the edge module's cert-manager DNS-01 solver needs.
+// Both ride in the environment, never in argv, so neither lands in the trace.
+func terraformExtraEnv(dataDir, rfc2136Secret string) []string {
 	env := []string{"TF_DATA_DIR=" + dataDir}
 	if token := strings.TrimSpace(os.Getenv("CLOUDFLARE_API_TOKEN")); token != "" {
 		env = append(env, "TF_VAR_cloudflare_api_token="+token)
+	}
+	if rfc2136Secret != "" {
+		env = append(env, "TF_VAR_rfc2136_tsig_secret="+rfc2136Secret)
 	}
 	return env
 }

--- a/erun-common/terraform_rfc2136.go
+++ b/erun-common/terraform_rfc2136.go
@@ -1,0 +1,271 @@
+package eruncommon
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// terraformDNS01ProviderRFC2136 is the cluster-edge module's dns01_provider
+// value that switches cert-manager's DNS-01 solver to RFC2136 (DNS UPDATE +
+// TSIG) against the platform's own PowerDNS, instead of the Cloudflare API.
+const terraformDNS01ProviderRFC2136 = "powerdns-rfc2136"
+
+// terraformRFC2136DefaultIssuerName, terraformRFC2136SecretSuffix, and
+// terraformRFC2136SecretKey mirror terraform-erun-cluster-edge's own locals
+// (variables.tf's issuer_name default, and
+// `tsig_secret_name = "${var.issuer_name}-rfc2136-tsig"` / key "tsig-secret"
+// in main.tf) — the module's own materialized Secret that the rendered Issuer
+// references, not the erun-powerdns chart's source secret. Reading it back is
+// what lets a repeat plan/apply resupply the same value the module last wrote.
+const (
+	terraformRFC2136DefaultIssuerName      = "erun-cloudflare"
+	terraformRFC2136SecretSuffix           = "-rfc2136-tsig"
+	terraformRFC2136SecretKey              = "tsig-secret"
+	terraformRFC2136DefaultIssuerNamespace = "cert-manager"
+)
+
+// terraformRFC2136Requirement is what a resolved <env>.tfvars says about the
+// cluster-edge module's RFC2136 TSIG secret: whether this env's dns01_provider
+// needs it, and where erun should read it from.
+type terraformRFC2136Requirement struct {
+	Needed     bool
+	Namespace  string
+	SecretName string
+	SecretKey  string
+}
+
+// resolveTerraformRFC2136Requirement reads the resolved var file — the same
+// file erun already locates for -var-file — to learn whether this env's
+// dns01_provider is "powerdns-rfc2136". PlatformConfig carries no such field:
+// dns01_provider is purely a terraform-module input, so the tfvars file is the
+// only place erun can learn it. It is parsed with a small literal-string
+// scanner (parseTerraformTFVarsStrings) that walks tokens and skips comments
+// properly, rather than a regex matched against the raw text, so a value
+// sitting in a comment or a differently-quoted line can't produce a false
+// negative on what is otherwise a security-relevant decision. A var file that
+// can't be parsed as simple attributes is a real error; one that parses but
+// carries no dns01_provider (or a non-literal expression for it) resolves to
+// the module's own default ("cloudflare" — not needed), matching current
+// behavior for every env that isn't using powerdns-rfc2136.
+func resolveTerraformRFC2136Requirement(dir, varFile string) (terraformRFC2136Requirement, error) {
+	if strings.TrimSpace(varFile) == "" {
+		return terraformRFC2136Requirement{}, nil
+	}
+	attrs, err := parseTerraformTFVarsStrings(filepath.Join(dir, varFile))
+	if err != nil {
+		return terraformRFC2136Requirement{}, fmt.Errorf("terraform: reading %s: %w", varFile, err)
+	}
+	if attrs["dns01_provider"] != terraformDNS01ProviderRFC2136 {
+		return terraformRFC2136Requirement{}, nil
+	}
+
+	issuerName := strings.TrimSpace(attrs["issuer_name"])
+	if issuerName == "" {
+		issuerName = terraformRFC2136DefaultIssuerName
+	}
+
+	// Mirrors the module's own locals: env_namespace falls back to env_label,
+	// and the issuer namespace falls back to the cert-manager namespace var
+	// (default "cert-manager") when neither is set.
+	namespace := strings.TrimSpace(attrs["env_namespace"])
+	if namespace == "" {
+		namespace = strings.TrimSpace(attrs["env_label"])
+	}
+	if namespace == "" {
+		namespace = strings.TrimSpace(attrs["namespace"])
+	}
+	if namespace == "" {
+		namespace = terraformRFC2136DefaultIssuerNamespace
+	}
+
+	return terraformRFC2136Requirement{
+		Needed:     true,
+		Namespace:  namespace,
+		SecretName: issuerName + terraformRFC2136SecretSuffix,
+		SecretKey:  terraformRFC2136SecretKey,
+	}, nil
+}
+
+// readTerraformRFC2136Secret reads the RFC2136 TSIG key material back from
+// its Kubernetes Secret so the operator never has to export it by hand. It
+// fails naming the Secret and key so the operator can fix the actual gap
+// (mint it via the erun-powerdns chart / apply once with it supplied
+// directly) instead of hitting terraform's own precondition after a partial
+// plan.
+func readTerraformRFC2136Secret(requirement terraformRFC2136Requirement) (string, error) {
+	jsonPath := "jsonpath={.data." + strings.ReplaceAll(requirement.SecretKey, ".", `\.`) + "}"
+	output, err := Command("kubectl", "-n", requirement.Namespace, "get", "secret", requirement.SecretName, "-o", jsonPath).Output()
+	if err != nil {
+		return "", fmt.Errorf("terraform: dns01_provider %q requires the RFC2136 TSIG secret, but Kubernetes Secret %s/%s could not be read (key %q): %w",
+			terraformDNS01ProviderRFC2136, requirement.Namespace, requirement.SecretName, requirement.SecretKey, err)
+	}
+	encoded := strings.TrimSpace(string(output))
+	if encoded == "" {
+		return "", fmt.Errorf("terraform: dns01_provider %q requires the RFC2136 TSIG secret, but Kubernetes Secret %s/%s has no value at key %q",
+			terraformDNS01ProviderRFC2136, requirement.Namespace, requirement.SecretName, requirement.SecretKey)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil || strings.TrimSpace(string(decoded)) == "" {
+		return "", fmt.Errorf("terraform: dns01_provider %q requires the RFC2136 TSIG secret, but Kubernetes Secret %s/%s holds no readable value at key %q",
+			terraformDNS01ProviderRFC2136, requirement.Namespace, requirement.SecretName, requirement.SecretKey)
+	}
+	return string(decoded), nil
+}
+
+// parseTerraformTFVarsStrings scans a resolved .tfvars file for top-level
+// `identifier = "value"` assignments — the whole grammar the cluster-edge
+// module's string variables need. It correctly skips "#"/"//" line comments
+// and "/* */" block comments, and honors backslash escapes inside quoted
+// strings, so it can't be fooled by a value that only appears in a comment or
+// on a differently-formatted line. An attribute whose value isn't a plain
+// quoted string (a list, a heredoc, an expression) is simply absent from the
+// result; callers treat that as "could not determine" rather than guess.
+func parseTerraformTFVarsStrings(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return scanTerraformTFVarsStrings(string(data)), nil
+}
+
+func scanTerraformTFVarsStrings(src string) map[string]string {
+	result := make(map[string]string)
+	n := len(src)
+	i := 0
+	for i < n {
+		i = skipTerraformTFVarsTrivia(src, i)
+		if i >= n {
+			break
+		}
+		name, i2 := scanTerraformTFVarsIdentifier(src, i)
+		if name == "" {
+			// Not the start of an identifier (e.g. a stray `[`/`{`); skip one
+			// byte so the scanner always makes progress.
+			i++
+			continue
+		}
+		i = skipTerraformTFVarsTrivia(src, i2)
+		if i >= n || src[i] != '=' {
+			i = i2
+			continue
+		}
+		i = skipTerraformTFVarsTrivia(src, i+1) // consume '=' then its trivia
+		if value, next, ok := scanTerraformTFVarsStringValue(src, i); ok {
+			result[name] = value
+			i = next
+			continue
+		}
+		// Not a plain string literal: skip to end of line rather than guess.
+		i = skipTerraformTFVarsLine(src, i)
+	}
+	return result
+}
+
+// scanTerraformTFVarsIdentifier reads the identifier starting at src[i].
+// name=="" means src[i] isn't an identifier character at all.
+func scanTerraformTFVarsIdentifier(src string, i int) (name string, next int) {
+	n := len(src)
+	start := i
+	for i < n && isTerraformTFVarsIdentChar(src[i]) {
+		i++
+	}
+	return src[start:i], i
+}
+
+// scanTerraformTFVarsStringValue reads a quoted-string value at src[i], the
+// only value shape this scanner resolves.
+func scanTerraformTFVarsStringValue(src string, i int) (value string, next int, ok bool) {
+	if i >= len(src) || src[i] != '"' {
+		return "", i, false
+	}
+	return readTerraformTFVarsQuotedString(src, i)
+}
+
+func skipTerraformTFVarsLine(src string, i int) int {
+	for i < len(src) && src[i] != '\n' {
+		i++
+	}
+	return i
+}
+
+func isTerraformTFVarsIdentChar(b byte) bool {
+	return b == '_' || b == '-' ||
+		(b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
+// skipTerraformTFVarsTrivia advances past whitespace and comments —
+// everything HCL treats as insignificant between tokens — repeating until a
+// pass makes no further progress (a comment can be followed by more
+// whitespace, another comment, and so on).
+func skipTerraformTFVarsTrivia(src string, i int) int {
+	for {
+		start := i
+		i = skipTerraformTFVarsWhitespace(src, i)
+		i = skipTerraformTFVarsLineComment(src, i)
+		i = skipTerraformTFVarsBlockComment(src, i)
+		if i == start {
+			return i
+		}
+	}
+}
+
+func skipTerraformTFVarsWhitespace(src string, i int) int {
+	n := len(src)
+	for i < n && isTerraformTFVarsSpace(src[i]) {
+		i++
+	}
+	return i
+}
+
+func isTerraformTFVarsSpace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\r' || b == '\n'
+}
+
+func skipTerraformTFVarsLineComment(src string, i int) int {
+	if !strings.HasPrefix(src[i:], "#") && !strings.HasPrefix(src[i:], "//") {
+		return i
+	}
+	return skipTerraformTFVarsLine(src, i)
+}
+
+// skipTerraformTFVarsBlockComment skips a "/* ... */" comment. An
+// unterminated comment runs to the end of the file, matching HCL.
+func skipTerraformTFVarsBlockComment(src string, i int) int {
+	if !strings.HasPrefix(src[i:], "/*") {
+		return i
+	}
+	if end := strings.Index(src[i+2:], "*/"); end >= 0 {
+		return i + 2 + end + 2
+	}
+	return len(src)
+}
+
+// readTerraformTFVarsQuotedString reads a double-quoted string literal
+// starting at src[i] (which must be '"'), honoring backslash escapes.
+// ok=false on an unterminated or multi-line string.
+func readTerraformTFVarsQuotedString(src string, i int) (value string, next int, ok bool) {
+	n := len(src)
+	i++ // consume opening quote
+	var b strings.Builder
+	for i < n {
+		switch src[i] {
+		case '"':
+			return b.String(), i + 1, true
+		case '\\':
+			if i+1 >= n {
+				return "", 0, false
+			}
+			b.WriteByte(src[i+1])
+			i += 2
+		case '\n':
+			return "", 0, false
+		default:
+			b.WriteByte(src[i])
+			i++
+		}
+	}
+	return "", 0, false
+}

--- a/erun-docs/docs/cli/terraform.md
+++ b/erun-docs/docs/cli/terraform.md
@@ -38,6 +38,8 @@ Run `erun terraform init <tenant> <env>` **once** first (and again after you cha
 
 When the env has a Cloudflare alias, its `CLOUDFLARE_API_TOKEN` is forwarded to Terraform as `TF_VAR_cloudflare_api_token` (so the edge module's cert-manager DNS-01 solver can prove control of the zone). The token rides in the environment — it never appears in the command line or the trace.
 
+When the env's `<env>.tfvars` sets `dns01_provider = "powerdns-rfc2136"`, erun reads the cluster-edge module's own RFC2136 TSIG secret back from its Kubernetes Secret and forwards it as `TF_VAR_rfc2136_tsig_secret` — you never export or type it yourself. Before running any `terraform` command, erun checks that the Secret exists and holds a value; if it doesn't, the command aborts up front naming the missing Secret and key, instead of letting Terraform print a partial plan and fail its own precondition mid-run.
+
 ## Flags
 
 | Flag | Description |
@@ -58,6 +60,7 @@ When the env has a Cloudflare alias, its `CLOUDFLARE_API_TOKEN` is forwarded to 
 | Confirmation doesn't match the env name | Aborts before the apply step: `confirmation "…" does not match environment "…"; aborting <operation>`; exit 1. The earlier read-only steps (`plan`, plus `fmt` for `apply`) have already run; only the apply is gated. | Re-run and type the exact environment name (or pass `--confirm-environment <env>`). |
 | Providers not initialized (`init` not run) | A `plan`/`apply`/`destroy` `terraform` step stops with Terraform's *"Module not installed / please run terraform init"* error; exit 1. | Run `erun terraform init <tenant> <env>` first — once per environment, and again after changing providers. |
 | `init` on a read-only tree with no committed lock | `erun terraform init` aborts before running Terraform: the playbook tree is not writable and has no `.terraform.lock.hcl` to init read-only from; exit 1. | Run `erun terraform init` on a writable env (e.g. `<tenant>-local`), commit the generated `.terraform.lock.hcl`, and rebuild/redeploy so it bakes into the image. |
+| `dns01_provider` is `powerdns-rfc2136` but its RFC2136 TSIG Secret is missing or empty | Aborts before any `terraform` command runs, naming the Secret and key it looked for; exit 1. | Apply once with the TSIG secret supplied directly (see [`erun-enable-hosting-edge`](/agent-reference/skills-spec#erun-enable-hosting-edge)) so the module materializes its Secret, then re-run. |
 | A `terraform` step fails (live run) | Surfaces the underlying `terraform` error and stops at that step; exit 1. | Fix the reported Terraform/cloud issue and re-run — `init`/`plan`/`apply` are safe to repeat. |
 
 ## See also

--- a/erun-integration/terraform_test.go
+++ b/erun-integration/terraform_test.go
@@ -303,6 +303,58 @@ func TestTerraform(t *testing.T) {
 		golden.Equal(t, "terraform/apply_real_run_via_stub", normalize.Apply(result.Combined))
 	})
 
+	t.Run("apply_dry_run_rfc2136_injects_tsig_secret", func(t *testing.T) {
+		// A resolved dns01_provider of "powerdns-rfc2136" makes erun read the
+		// cluster-edge module's own materialized TSIG Secret back and inject it as
+		// TF_VAR_rfc2136_tsig_secret, the same way it already injects the Cloudflare
+		// token — so the operator never has to export it by hand. The Secret name is
+		// derived from issuer_name (default "erun-cloudflare"), never hardcoded.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedGitRepo(t, setup.Cwd)
+		fixture.SeedTerraformEnvRoot(t, setup, "team", "dev")
+		tfvars := filepath.Join(setup.Cwd, "terraform-team", "dev", "dev.tfvars")
+		if err := os.WriteFile(tfvars, []byte("base_domain = \"erunpaas.com\"\ndns01_provider = \"powerdns-rfc2136\"\nenv_label = \"team-dev\"\n"), 0o644); err != nil {
+			t.Fatalf("write tfvars: %v", err)
+		}
+		stubs := setup.Cwd + "/stubs"
+		// base64 of "supersecret", read back from data.tsig-secret.
+		fixture.StubBinaryAdvanced(t, stubs, "kubectl", fixture.StubBinarySpec{Stdout: "c3VwZXJzZWNyZXQ="})
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+		result := erun.Run(t, []string{"terraform", "apply", "team", "dev", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "terraform/apply_dry_run_rfc2136_injects_tsig_secret", normalize.Apply(result.Combined))
+	})
+
+	t.Run("apply_dry_run_rfc2136_missing_secret_fails_up_front", func(t *testing.T) {
+		// terraform itself would only fail this precondition mid-plan, after
+		// printing a partial plan whose "N to add" summary omits every module it
+		// never reached — reviewing that summary reviews an incomplete plan. erun
+		// must fail before tracing or running any terraform command at all, naming
+		// the Secret and key that are missing.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedGitRepo(t, setup.Cwd)
+		fixture.SeedTerraformEnvRoot(t, setup, "team", "dev")
+		tfvars := filepath.Join(setup.Cwd, "terraform-team", "dev", "dev.tfvars")
+		if err := os.WriteFile(tfvars, []byte("base_domain = \"erunpaas.com\"\ndns01_provider = \"powerdns-rfc2136\"\nenv_label = \"team-dev\"\n"), 0o644); err != nil {
+			t.Fatalf("write tfvars: %v", err)
+		}
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinaryAdvanced(t, stubs, "kubectl", fixture.StubBinarySpec{
+			Stderr:   `Error from server (NotFound): secrets "erun-cloudflare-rfc2136-tsig" not found`,
+			ExitCode: 1,
+		})
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+		result := erun.Run(t, []string{"terraform", "plan", "team", "dev", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit for a missing RFC2136 TSIG secret, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "terraform/apply_dry_run_rfc2136_missing_secret_fails_up_front", normalize.Apply(result.Combined))
+	})
+
 	t.Run("apply_confirm_mismatch", func(t *testing.T) {
 		// A confirm value that doesn't match the target env aborts before the
 		// mutating apply.

--- a/erun-integration/testdata/terraform/apply_dry_run_rfc2136_injects_tsig_secret.txt
+++ b/erun-integration/testdata/terraform/apply_dry_run_rfc2136_injects_tsig_secret.txt
@@ -1,0 +1,11 @@
+audit: erun terraform apply --dry-run team dev
+terraform: apply in <TMP> (env team/dev, namespace team-dev)
+terraform: var file dev.tfvars
+terraform: state <STATE_ROOT>/team/dev/terraform.tfstate (local backend on the home PVC — survives pod restarts)
+terraform: TF_DATA_DIR <STATE_ROOT>/team/dev/data
+terraform: injecting TF_VAR_rfc2136_tsig_secret from Secret team-dev/erun-cloudflare-rfc2136-tsig (key tsig-secret)
+mkdir -p <STATE_ROOT>/team/dev
+cd <TMP> && terraform fmt -check -recursive ..
+cd <TMP> && terraform plan -input=false -var-file=dev.tfvars -out <STATE_ROOT>/team/dev/apply.tfplan
+terraform: confirmation gate — the apply below runs only after you type the environment name "dev"; a mismatch or empty entry aborts before anything is applied
+cd <TMP> && terraform apply -input=false <STATE_ROOT>/team/dev/apply.tfplan

--- a/erun-integration/testdata/terraform/apply_dry_run_rfc2136_missing_secret_fails_up_front.txt
+++ b/erun-integration/testdata/terraform/apply_dry_run_rfc2136_missing_secret_fails_up_front.txt
@@ -1,0 +1,2 @@
+audit: erun terraform plan --dry-run team dev
+terraform: dns01_provider "powerdns-rfc2136" requires the RFC2136 TSIG secret, but Kubernetes Secret team-dev/erun-cloudflare-rfc2136-tsig could not be read (key "tsig-secret"): exit status 1

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -749,7 +749,26 @@ func TestInitToolReturnsInteractionWhenSharedInitNeedsInput(t *testing.T) {
 	}
 }
 
+// stubKubectlAlwaysSucceeds points the ERUN_KUBECTL_BIN seam (eruncommon.Command)
+// at a script that exits 0 unconditionally, so eruncommon.RunHelmDeploy's own
+// namespace-ensure — which runs before the pre-rollout secret applies and is not
+// reachable through RuntimeConfig.EnsureKubernetesNamespace (see
+// eruncommon.WrapHelmChartDeployerWithNamespaceEnsure and
+// TestRunHelmDeployEnsuresTheNamespaceBeforeApplyingSecrets) — never shells out to
+// a real cluster. Without it, these tests depend on the host's kubeconfig
+// happening to have a context named "cluster-remote"/"cluster-dev", which no real
+// machine does.
+func stubKubectlAlwaysSucceeds(t *testing.T) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "kubectl")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+	t.Setenv("ERUN_KUBECTL_BIN", path)
+}
+
 func TestInitToolReturnsRepositoryInteractionForRemoteInit(t *testing.T) {
+	stubKubectlAlwaysSucceeds(t)
 	handler := initTool(normalizeRuntimeConfig(RuntimeConfig{
 		Context: RuntimeContext{},
 		Store:   initInteractionStore{},
@@ -790,6 +809,7 @@ func TestInitToolReturnsRepositoryInteractionForRemoteInit(t *testing.T) {
 }
 
 func TestInitToolUsesExplicitRuntimeVersionOverride(t *testing.T) {
+	stubKubectlAlwaysSucceeds(t)
 	var deployedVersion string
 	handler := initTool(normalizeRuntimeConfig(RuntimeConfig{
 		Context: RuntimeContext{},


### PR DESCRIPTION
## Summary

- `erun terraform` already injects `TF_VAR_cloudflare_api_token` from `CLOUDFLARE_API_TOKEN`, but supplies nothing for the cluster-edge module's `dns01_provider = "powerdns-rfc2136"` path. Every operation through the typed command (`plan`/`apply`) on such an environment died on Terraform's own `rfc2136_tsig` precondition mid-plan — after a partial plan had already printed a misleadingly small change summary (my own repro: partial `4 to add, 0 to change` vs. the true `4 to add, 1 to change`, the missing change being the cluster-edge issuer `helm_release`). The only workaround was dropping into `raw` and hand-rebuilding the whole invocation, exporting the secret from the cluster myself — arbitrary in-pod execution to do one narrow, well-understood thing, and it made me hand-reconstruct the state path, `TF_DATA_DIR`, and var file erun already knows.
- Now, when the resolved `<env>.tfvars` sets `dns01_provider = "powerdns-rfc2136"`, `erun terraform` reads the cluster-edge module's own materialized TSIG Secret back (name derived from `issuer_name`, default `erun-cloudflare`, plus the module's own `-rfc2136-tsig` suffix and `tsig-secret` key — never hardcoded) and injects `TF_VAR_rfc2136_tsig_secret`, exactly the way it already injects the Cloudflare token. The value never passes through the operator.
- If the Secret is absent or has no value at that key, `erun terraform` now fails **up front** — before tracing or running any `terraform` command at all — naming the Secret and key it looked for. This is deliberately stricter than "let Terraform fail": Terraform's own failure happens mid-plan, after a partial plan is already printed, so an operator who trusts that plan's "N to add" summary is reviewing an incomplete plan.
- The injection is reported in the trace (`terraform: injecting TF_VAR_rfc2136_tsig_secret from Secret <namespace>/<name> (key tsig-secret)`), mirroring the existing Cloudflare-token trace line. The secret's value is never logged, traced, or placed in `TerraformResult` (only its Secret name/namespace, which is safe to serialize via `--output json`).

### How dns01_provider is detected

`PlatformConfig` carries no `dns01_provider` field — it is purely a terraform-module input, so the resolved `<env>.tfvars` file (the same file erun already locates for `-var-file`) is the only place erun can learn it. Per the issue's guidance to prefer a robust signal over fragile HCL text-scraping, this is parsed with a small dedicated scanner (`erun-common/terraform_rfc2136.go`) that correctly walks tokens, skips `#`/`//`/`/* */` comments, and handles quoted strings — not a single regex against raw text, so a value sitting in a comment or on a differently-formatted line can't produce a false negative on this security-relevant decision. I deliberately did not add the `hashicorp/hcl` library for this: it would pull ~8 new transitive dependencies (`cty`, `x/tools`, etc.) into `erun-common`, which the module's own `AGENTS.md` asks to keep small, dependency-light, and usable as a standalone library — a disproportionate cost for extracting a handful of literal string attributes from a conventionally-simple `.tfvars` file. An attribute using a non-literal expression (rare/invalid for `.tfvars`) is simply treated as absent, falling back to the module's own default ("cloudflare" — not needed), matching current behavior.

### Also fixed: two pre-existing erun-mcp test failures

While validating this change across `erun-cli`/`erun-common`/`erun-mcp` per the repo's release-adjacent validation guidance, `go test ./...` in `erun-mcp` failed on two pre-existing tests (`TestInitToolReturnsRepositoryInteractionForRemoteInit`, `TestInitToolUsesExplicitRuntimeVersionOverride`) — confirmed still failing identically on `origin/main`, unrelated to this change. Root cause: `eruncommon.RunHelmDeploy` ensures the deploy namespace via a hardcoded call (needed *before* pre-rollout secrets apply — see `TestRunHelmDeployEnsuresTheNamespaceBeforeApplyingSecrets`), which is not reachable through `RuntimeConfig.EnsureKubernetesNamespace` or `WrapHelmChartDeployerWithNamespaceEnsure` — so these tests always shelled out to a real `kubectl` against contexts (`cluster-remote`/`cluster-dev`) that don't exist on any real machine. Fixed by stubbing `ERUN_KUBECTL_BIN` in both tests (the same seam `eruncommon.Command` already honors everywhere else), making them fully hermetic without touching production code.

Closes #1130

## Test plan

- [x] Added `erun-integration/terraform_test.go` scenarios: `apply_dry_run_rfc2136_injects_tsig_secret` (secret found → injected + traced) and `apply_dry_run_rfc2136_missing_secret_fails_up_front` (secret missing → fails before any terraform command traces).
- [x] Verified both new scenarios fail against the pre-fix code (confirmed by temporarily reverting the `erun-common` change and re-running): the "injects" scenario golden-mismatches with the injection trace line and the two `terraform` steps present but no injection; the "missing secret" scenario got exit 0 instead of the expected non-zero, with the full terraform command sequence (including the real `terraform plan` command) run to completion — i.e., pre-fix, the command happily proceeds using the vulnerable var file with no TSIG at all, right up to the real `terraform plan` invocation.
- [x] `make lint` — 0 issues across all modules.
- [x] `go test ./...` — green in `erun-common`, `erun-cli`, `erun-mcp`.
- [x] `make integration-test` — green, coverage 76.5% (≥ 76.0% threshold).
- [x] `cd erun-docs && yarn build` — clean.
- [x] Updated `erun-docs/docs/cli/terraform.md` (Operator-facing CLI reference): new injection behavior in "What it does", new row in "Error behaviour" for the missing-secret failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)