### PR TITLE
Require the DNS-01 token secret where it is actually read

### DIFF
--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/main.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/main.tf
@@ -146,8 +146,8 @@ resource "helm_release" "dns01_webhook" {
 
   lifecycle {
     precondition {
-      condition     = var.broker_url != "" && var.dns01_webhook_image != "" && var.dns01_token_secret_name != ""
-      error_message = "install_dns01_webhook requires broker_url, dns01_webhook_image, and dns01_token_secret_name."
+      condition     = var.broker_url != "" && var.dns01_webhook_image != ""
+      error_message = "install_dns01_webhook requires broker_url and dns01_webhook_image."
     }
   }
 
@@ -263,6 +263,15 @@ resource "helm_release" "issuer" {
     precondition {
       condition     = !local.use_broker || local.install_dns01_webhook
       error_message = "dns01_provider \"powerdns-broker\" makes the platform's own Issuer solve through the DNS-01 webhook shim, but install_dns01_webhook resolved to false. Rendering that Certificate without the shim's APIService/RBAC leaves cert-manager denied at admission and the resulting namespace undeletable — leave install_dns01_webhook unset (it defaults to true here) or set it to true."
+    }
+
+    # Only the platform's own Issuer reads these, and only in broker mode. A
+    # platform that installs the shim purely so tenant Issuers can solve names
+    # no token secret of its own: those are per-env and land beside each
+    # environment, not here.
+    precondition {
+      condition     = !local.use_broker || (var.broker_url != "" && var.dns01_token_secret_name != "")
+      error_message = "dns01_provider \"powerdns-broker\" solves the platform's own Issuer through the broker, so broker_url and dns01_token_secret_name are both required."
     }
   }
 

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/tests/dns01_webhook.tftest.hcl
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/tests/dns01_webhook.tftest.hcl
@@ -12,19 +12,22 @@ variables {
 
 # The exact shape frs-prod needs: platform Issuer stays on rfc2136, but the
 # webhook shim still installs so erun-expose's per-tenant brokered Issuers can
-# solve.
+# solve. Deliberately omits dns01_token_secret_name: the shim never reads one,
+# and a platform installing it for its tenants has none of its own to name --
+# per-env token Secrets land beside each environment. This mirrors the
+# documented apply in erun-enable-hosting-edge exactly, so the two cannot
+# drift apart again.
 run "webhook_shim_installs_while_platform_issuer_stays_on_rfc2136" {
   command = plan
 
   variables {
-    dns01_provider          = "powerdns-rfc2136"
-    install_dns01_webhook   = true
-    powerdns_nameserver     = "erun-powerdns.frs-prod.svc.cluster.local:53"
-    rfc2136_tsig_key_name   = "erun-tsig"
-    rfc2136_tsig_secret     = "c2VjcmV0"
-    broker_url              = "https://api.frs-prod.services.example.com/v1/dns01"
-    dns01_webhook_image     = "ghcr.io/sophium/erun-dns01-webhook:1.0.0"
-    dns01_token_secret_name = "operations-probej-dns01-token"
+    dns01_provider        = "powerdns-rfc2136"
+    install_dns01_webhook = true
+    powerdns_nameserver   = "erun-powerdns.frs-prod.svc.cluster.local:53"
+    rfc2136_tsig_key_name = "erun-tsig"
+    rfc2136_tsig_secret   = "c2VjcmV0"
+    broker_url            = "https://api.frs-prod.services.example.com/v1/dns01"
+    dns01_webhook_image   = "ghcr.io/sophium/erun-dns01-webhook:1.0.0"
   }
 
   assert {
@@ -84,6 +87,21 @@ run "broker_platform_issuer_without_webhook_shim_is_rejected" {
     broker_url              = "https://api.example.com/v1/dns01"
     dns01_webhook_image     = "ghcr.io/sophium/erun-dns01-webhook:1.0.0"
     dns01_token_secret_name = "some-env-dns01-token"
+  }
+
+  expect_failures = [helm_release.issuer]
+}
+
+# The token secret is required where it is actually read: the platform's own
+# Issuer, in broker mode. Guarding it there rather than on the shim is what
+# lets the case above omit it.
+run "broker_mode_without_a_token_secret_is_rejected" {
+  command = plan
+
+  variables {
+    dns01_provider      = "powerdns-broker"
+    broker_url          = "https://api.frs-prod.services.example.com/v1/dns01"
+    dns01_webhook_image = "ghcr.io/sophium/erun-dns01-webhook:1.0.0"
   }
 
   expect_failures = [helm_release.issuer]


### PR DESCRIPTION
Closes #1145

Follow-up to #1123, which added `install_dns01_webhook` so a platform on RFC2136 could still install the webhook shim its tenants' Issuers need. That switch could not actually be used in the shape it was added for.

## The defect

`helm_release.dns01_webhook`'s precondition demanded three variables:

```hcl
condition = var.broker_url != "" && var.dns01_webhook_image != "" && var.dns01_token_secret_name != ""
```

but the shim passes only four values to its chart — `groupName`, `namespace`, `image`, `brokerURL` — and the chart references no token secret anywhere (`grep -rn "dns01TokenSecretName\|tokenSecret" chart-dns01-webhook/` returns nothing). So enabling the shim required supplying a variable nothing consumes.

The contradiction was visible in #1123's own documentation. `erun-enable-hosting-edge` documents the multi-tenant-on-RFC2136 apply — the shape the switch exists for — with `broker_url` and `dns01_webhook_image` and no `dns01_token_secret_name`. Followed literally, that apply failed.

Worse than the failed apply is the only way past it: supply a value nothing reads, which then sits in production tfvars looking meaningful, leaving the next operator to work out that it is inert.

## The fix

`dns01_token_secret_name` is read by `helm_release.issuer`, as `dns01TokenSecretName` — it names the Secret the **platform's own** Issuer's webhook solver reads a token from, which only applies in broker mode. Per-tenant environments do not use it: their token Secrets are per-env (`<tenant>-<env>-dns01-token`) and are provisioned by `erun expose`, not by this cluster-scoped module.

So the requirement moves to the resource that reads it, guarded on broker mode. `helm_release.issuer` previously had **no** precondition for it at all, so the genuine misconfiguration — own Issuer in broker mode with no token secret named — was unguarded while the harmless case was blocked. Both are now the right way round.

## How this got through, and the test change that stops it recurring

#1123's test suite passed. Its frs-prod scenario supplied `dns01_token_secret_name`, so the over-strict precondition was satisfied by the test and never by the documented apply. A test that configures its way around a precondition proves the precondition is satisfiable, not that it is correct.

That scenario now omits the variable, mirroring the documented apply exactly, so the test and the docs cannot drift apart again. A new scenario covers the case that genuinely needs it — broker mode with no token secret is rejected.

## Verification

Pre-change, with the new tests against the unfixed `main.tf`:

```
run "webhook_shim_installs_while_platform_issuer_stays_on_rfc2136"... fail
  Error: Resource precondition failed
    on main.tf line 149, in resource "helm_release" "dns01_webhook":
     149:  condition = var.broker_url != "" && var.dns01_webhook_image != "" && var.dns01_token_secret_name != ""
       │ var.broker_url is "https://api.frs-prod.services.example.com/v1/dns01"
       │ var.dns01_token_secret_name is ""
       │ var.dns01_webhook_image is "ghcr.io/sophium/erun-dns01-webhook:1.0.0"
Failure! 0 passed, 1 failed, 4 skipped.
```

Note what the failure shows: both variables the shim actually uses were set, and only the one it does not use was empty.

Post-change: `Success! 5 passed, 0 failed.`

Runs entirely against mocked providers — no cluster touched.