### PR TITLE
Add a read-only observe command for an environment's Kubernetes state

### DIFF
--- a/erun-cli/cmd/observe.go
+++ b/erun-cli/cmd/observe.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	common "github.com/sophium/erun/erun-common"
+	"github.com/spf13/cobra"
+)
+
+func newObserveCmd(resolveOpen OpenResolver) *cobra.Command {
+	var tenant, environment string
+	var secretChecks []string
+	cmd := &cobra.Command{
+		Use:   "observe",
+		Short: "Report an environment's Kubernetes state, read-only",
+		Long: "Report pods, ResourceQuota/LimitRange usage, Ingress hosts and TLS secret\n" +
+			"names, and Certificate readiness for the environment's namespace.\n\n" +
+			"When a Certificate is not Ready, its CertificateRequest -> Order -> Challenge\n" +
+			"chain is walked automatically, so the reason issuance is stuck (for example a\n" +
+			"webhook solver's RBAC denial) comes back in this one call instead of three more.\n\n" +
+			"Every call is a kubectl get: nothing here can mutate the cluster, which is what\n" +
+			"makes this safe to grant an orchestrator that must never reach for `exec raw`.",
+		Example: "  erun observe --tenant team --environment dev\n" +
+			"  erun observe --tenant team --environment dev --secret db-credentials=password --output json",
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			checks, err := parseObserveSecretChecks(secretChecks)
+			if err != nil {
+				return err
+			}
+			return runObserveCommand(commandContext(cmd), resolveOpen, scopedOpenParams(tenant, environment), checks)
+		},
+	}
+	addDryRunFlag(cmd)
+	cmd.Flags().StringVar(&tenant, "tenant", "", "Target a specific tenant (default: the current scope)")
+	cmd.Flags().StringVar(&environment, "environment", "", "Target a specific environment; requires --tenant")
+	cmd.Flags().StringArrayVar(&secretChecks, "secret", nil, "Check a Secret for a key's presence, as name=key (repeatable); the value is never read")
+	return cmd
+}
+
+func parseObserveSecretChecks(raw []string) ([]common.ObserveSecretCheck, error) {
+	checks := make([]common.ObserveSecretCheck, 0, len(raw))
+	for _, entry := range raw {
+		name, key, found := strings.Cut(entry, "=")
+		name = strings.TrimSpace(name)
+		key = strings.TrimSpace(key)
+		if !found || name == "" || key == "" {
+			return nil, fmt.Errorf("--secret must be name=key, got %q", entry)
+		}
+		checks = append(checks, common.ObserveSecretCheck{Name: name, Key: key})
+	}
+	return checks, nil
+}
+
+func runObserveCommand(ctx common.Context, resolveOpen OpenResolver, params common.OpenParams, checks []common.ObserveSecretCheck) error {
+	result, err := resolveOpen(params)
+	if err != nil {
+		return err
+	}
+	req := common.ShellLaunchParamsFromResult(result)
+	observed, err := common.RunObservation(ctx, req, common.ObserveParams{Secrets: checks})
+	if err != nil {
+		return err
+	}
+	if ctx.DryRun {
+		return nil
+	}
+	if ctx.Output == common.OutputJSON {
+		return ctx.WriteResult(observed)
+	}
+	return writeObserveResult(ctx, observed)
+}

--- a/erun-cli/cmd/observe_render.go
+++ b/erun-cli/cmd/observe_render.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	common "github.com/sophium/erun/erun-common"
+)
+
+func writeObserveResult(ctx common.Context, result common.ObserveResult) error {
+	if _, err := fmt.Fprintf(ctx.Stdout, "Namespace: %s\n", valueOrNone(result.Namespace)); err != nil {
+		return err
+	}
+	if err := writeObservePods(ctx, result.Pods); err != nil {
+		return err
+	}
+	if err := writeObserveResourceQuotas(ctx, result.ResourceQuotas); err != nil {
+		return err
+	}
+	if err := writeObserveLimitRanges(ctx, result.LimitRanges); err != nil {
+		return err
+	}
+	if err := writeObserveIngresses(ctx, result.Ingresses); err != nil {
+		return err
+	}
+	if err := writeObserveCertificates(ctx, result.Certificates); err != nil {
+		return err
+	}
+	return writeObserveSecrets(ctx, result.Secrets)
+}
+
+func writeObservePods(ctx common.Context, pods []common.ObservedPod) error {
+	if _, err := fmt.Fprintf(ctx.Stdout, "Pods (%d):\n", len(pods)); err != nil {
+		return err
+	}
+	for _, pod := range pods {
+		status := "ready"
+		if !pod.Ready {
+			status = "not ready"
+			if pod.Reason != "" {
+				status += ": " + pod.Reason
+			}
+		}
+		if _, err := fmt.Fprintf(ctx.Stdout, "  %s: %s (phase %s, restarts %d)\n", pod.Name, status, pod.Phase, pod.RestartCount); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeObserveResourceQuotas(ctx common.Context, quotas []common.ObservedResourceQuota) error {
+	if _, err := fmt.Fprintf(ctx.Stdout, "ResourceQuotas (%d):\n", len(quotas)); err != nil {
+		return err
+	}
+	for _, quota := range quotas {
+		if _, err := fmt.Fprintf(ctx.Stdout, "  %s: used %s, hard %s\n", quota.Name, formatResourceMap(quota.Used), formatResourceMap(quota.Hard)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeObserveLimitRanges(ctx common.Context, limitRanges []common.ObservedLimitRange) error {
+	if _, err := fmt.Fprintf(ctx.Stdout, "LimitRanges (%d):\n", len(limitRanges)); err != nil {
+		return err
+	}
+	for _, lr := range limitRanges {
+		if _, err := fmt.Fprintf(ctx.Stdout, "  %s:\n", lr.Name); err != nil {
+			return err
+		}
+		for _, limit := range lr.Limits {
+			if _, err := fmt.Fprintf(ctx.Stdout, "    %s: default %s, defaultRequest %s, max %s, min %s\n",
+				limit.Type, formatResourceMap(limit.Default), formatResourceMap(limit.DefaultRequest), formatResourceMap(limit.Max), formatResourceMap(limit.Min)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeObserveIngresses(ctx common.Context, ingresses []common.ObservedIngress) error {
+	if _, err := fmt.Fprintf(ctx.Stdout, "Ingresses (%d):\n", len(ingresses)); err != nil {
+		return err
+	}
+	for _, ingress := range ingresses {
+		if _, err := fmt.Fprintf(ctx.Stdout, "  %s: hosts %s\n", ingress.Name, formatStringList(ingress.Hosts)); err != nil {
+			return err
+		}
+		for _, tls := range ingress.TLS {
+			if _, err := fmt.Fprintf(ctx.Stdout, "    tls %s -> secret %s\n", formatStringList(tls.Hosts), valueOrNone(tls.SecretName)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeObserveCertificates(ctx common.Context, certificates []common.ObservedCertificate) error {
+	if _, err := fmt.Fprintf(ctx.Stdout, "Certificates (%d):\n", len(certificates)); err != nil {
+		return err
+	}
+	for _, cert := range certificates {
+		status := "Ready"
+		if !cert.Ready {
+			status = "not Ready"
+			if cert.Reason != "" {
+				status += ": " + cert.Reason
+			}
+			if cert.Message != "" {
+				status += " (" + cert.Message + ")"
+			}
+		}
+		if _, err := fmt.Fprintf(ctx.Stdout, "  %s: %s, secret %s, dnsNames %s\n", cert.Name, status, valueOrNone(cert.SecretName), formatStringList(cert.DNSNames)); err != nil {
+			return err
+		}
+		if err := writeObserveCertificateOrders(ctx, cert.Orders); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeObserveCertificateOrders(ctx common.Context, orders []common.ObservedCertificateOrder) error {
+	for _, order := range orders {
+		if _, err := fmt.Fprintf(ctx.Stdout, "    order %s: state %s, reason %s\n", order.Name, valueOrNone(order.State), valueOrNone(order.Reason)); err != nil {
+			return err
+		}
+		for _, challenge := range order.Challenges {
+			if _, err := fmt.Fprintf(ctx.Stdout, "      challenge %s: type %s, dnsName %s, state %s, reason %s\n",
+				challenge.Name, valueOrNone(challenge.Type), valueOrNone(challenge.DNSName), valueOrNone(challenge.State), valueOrNone(challenge.Reason)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeObserveSecrets(ctx common.Context, secrets []common.ObservedSecretCheck) error {
+	if len(secrets) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintf(ctx.Stdout, "Secrets checked (%d):\n", len(secrets)); err != nil {
+		return err
+	}
+	for _, secret := range secrets {
+		line := fmt.Sprintf("  %s[%s]: exists=%t hasKey=%t", secret.Name, secret.Key, secret.Exists, secret.HasKey)
+		if secret.Error != "" {
+			line += " error=" + secret.Error
+		}
+		if _, err := fmt.Fprintln(ctx.Stdout, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func formatResourceMap(values map[string]string) string {
+	if len(values) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(values))
+	for key, value := range values {
+		parts = append(parts, key+"="+value)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ", ")
+}
+
+func formatStringList(values []string) string {
+	if len(values) == 0 {
+		return "none"
+	}
+	return strings.Join(values, ", ")
+}

--- a/erun-cli/cmd/root.go
+++ b/erun-cli/cmd/root.go
@@ -159,6 +159,7 @@ func (d rootDependencies) commands() []*cobra.Command {
 		newOutputsCmd(d.resolveOpen),
 		newInputsCmd(d.resolveOpen),
 		newDoctorCmd(d.resolveOpen, d.configStore, cloudDependencies(), common.CloudContextDependencies{}, runPrompt),
+		newObserveCmd(d.resolveOpen),
 		newDeleteCmd(d.configStore, runPrompt, common.DeleteKubernetesNamespace),
 		newExposeCmd(d.configStore, common.FindProjectRoot),
 		newUnexposeCmd(d.configStore, common.FindProjectRoot),

--- a/erun-common/mcp_capabilities.go
+++ b/erun-common/mcp_capabilities.go
@@ -38,6 +38,7 @@ var mcpReadOnlyTools = map[string]struct{}{
 	"context_list":        {},
 	"cloud_list":          {},
 	"diff":                {},
+	"observe":             {},
 	"outputs_list":        {},
 	"outputs_download":    {},
 	"job_status":          {},

--- a/erun-common/observe.go
+++ b/erun-common/observe.go
@@ -1,0 +1,133 @@
+package eruncommon
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// ObserveParams configures which named Secrets to check for key presence.
+// Pods, quotas, limit ranges, ingresses, and certificates are always reported
+// in full: enumerating them costs nothing and reveals nothing sensitive.
+type ObserveParams struct {
+	Secrets []ObserveSecretCheck
+}
+
+// ObserveSecretCheck names one Secret/key pair to check for presence. The
+// value itself is never read or reported, only whether the key exists.
+type ObserveSecretCheck struct {
+	Name string
+	Key  string
+}
+
+// ObserveResult is an environment's observed Kubernetes state: a read-only
+// snapshot an orchestrator can act on without composing kubectl by hand.
+type ObserveResult struct {
+	Tenant         string                  `json:"tenant"`
+	Environment    string                  `json:"environment"`
+	Namespace      string                  `json:"namespace"`
+	Pods           []ObservedPod           `json:"pods"`
+	ResourceQuotas []ObservedResourceQuota `json:"resourceQuotas"`
+	LimitRanges    []ObservedLimitRange    `json:"limitRanges"`
+	Ingresses      []ObservedIngress       `json:"ingresses"`
+	Certificates   []ObservedCertificate   `json:"certificates"`
+	Secrets        []ObservedSecretCheck   `json:"secrets,omitempty"`
+}
+
+// RunObservation reads pods, quota/limit usage, ingress routing, and
+// certificate readiness for one namespace, walking a Certificate's
+// CertificateRequest -> Order -> Challenge chain when it is not Ready so the
+// caller gets the failure reason without composing that walk itself. It is
+// read-only by construction: every kubectl call below is a literal `get`
+// against a fixed resource kind, never a caller-supplied verb.
+func RunObservation(ctx Context, req ShellLaunchParams, params ObserveParams) (ObserveResult, error) {
+	result := ObserveResult{Tenant: req.Tenant, Environment: req.Environment, Namespace: req.Namespace}
+
+	podArgs := observeGetArgs(req, "pods")
+	quotaArgs := observeGetArgs(req, "resourcequota")
+	limitArgs := observeGetArgs(req, "limitrange")
+	ingressArgs := observeGetArgs(req, "ingress")
+	certArgs := observeGetArgs(req, "certificates.cert-manager.io")
+
+	ctx.TraceCommand("", "kubectl", podArgs...)
+	ctx.TraceCommand("", "kubectl", quotaArgs...)
+	ctx.TraceCommand("", "kubectl", limitArgs...)
+	ctx.TraceCommand("", "kubectl", ingressArgs...)
+	ctx.TraceCommand("", "kubectl", certArgs...)
+	ctx.Trace("observe: when a certificate is not Ready, its CertificateRequest -> Order -> Challenge chain is read for the failure reason")
+
+	secretArgs := make([][]string, len(params.Secrets))
+	for i, check := range params.Secrets {
+		secretArgs[i] = observeGetArgs(req, "secret", check.Name)
+		ctx.TraceCommand("", "kubectl", secretArgs[i]...)
+	}
+
+	if ctx.DryRun {
+		return result, nil
+	}
+
+	var err error
+	if result.Pods, err = fetchObservedPods(podArgs); err != nil {
+		return ObserveResult{}, err
+	}
+	if result.ResourceQuotas, err = fetchObservedResourceQuotas(quotaArgs); err != nil {
+		return ObserveResult{}, err
+	}
+	if result.LimitRanges, err = fetchObservedLimitRanges(limitArgs); err != nil {
+		return ObserveResult{}, err
+	}
+	if result.Ingresses, err = fetchObservedIngresses(ingressArgs); err != nil {
+		return ObserveResult{}, err
+	}
+	if result.Certificates, err = fetchObservedCertificates(ctx, req, certArgs); err != nil {
+		return ObserveResult{}, err
+	}
+	for i, check := range params.Secrets {
+		result.Secrets = append(result.Secrets, fetchObservedSecretCheck(secretArgs[i], check))
+	}
+
+	return result, nil
+}
+
+// observeGetArgs builds a read-only `kubectl get <resource> [name] -o json`
+// invocation. name is optional: omitted, it lists every object of that kind in
+// the namespace.
+func observeGetArgs(req ShellLaunchParams, resource string, name ...string) []string {
+	args := kubectlTargetArgs(req)
+	args = append(args, "get", resource)
+	args = append(args, name...)
+	return append(args, "-o", "json")
+}
+
+// runObserveKubectl runs a read-only kubectl get, returning stderr alongside
+// any error so callers can distinguish "not found" and "unknown resource
+// type" from a real failure without re-parsing a wrapped error string.
+func runObserveKubectl(args []string) (stdout []byte, stderr string, err error) {
+	cmd := Command("kubectl", args...)
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	out, runErr := cmd.Output()
+	return out, strings.TrimSpace(errBuf.String()), runErr
+}
+
+func kubectlErrorMessage(err error, stderr string) error {
+	if stderr == "" {
+		return err
+	}
+	return fmt.Errorf("%w: %s", err, stderr)
+}
+
+// isKubectlUnknownResource reports whether stderr is kubectl's "this API
+// isn't installed" shape, so a cluster with no cert-manager CRDs reports zero
+// certificates instead of failing the whole observation.
+func isKubectlUnknownResource(stderr string) bool {
+	lower := strings.ToLower(stderr)
+	return strings.Contains(lower, "the server doesn't have a resource type") ||
+		strings.Contains(lower, "no matches for kind") ||
+		strings.Contains(lower, "could not find the requested resource")
+}
+
+func isKubectlNotFound(stderr string) bool {
+	return strings.Contains(strings.ToLower(stderr), "notfound") ||
+		strings.Contains(strings.ToLower(stderr), "not found")
+}

--- a/erun-common/observe_certificate.go
+++ b/erun-common/observe_certificate.go
@@ -1,0 +1,256 @@
+package eruncommon
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// ObservedCertificate is a cert-manager Certificate's readiness. Orders is
+// populated only when Ready is false: that is the failure-chain walk this
+// command exists for, so a caller never issues three more calls to reach the
+// reason a stuck issuance is stuck.
+type ObservedCertificate struct {
+	Name       string                     `json:"name"`
+	Ready      bool                       `json:"ready"`
+	Reason     string                     `json:"reason,omitempty"`
+	Message    string                     `json:"message,omitempty"`
+	SecretName string                     `json:"secretName,omitempty"`
+	DNSNames   []string                   `json:"dnsNames,omitempty"`
+	Orders     []ObservedCertificateOrder `json:"orders,omitempty"`
+}
+
+type ObservedCertificateOrder struct {
+	Name       string                         `json:"name"`
+	State      string                         `json:"state,omitempty"`
+	Reason     string                         `json:"reason,omitempty"`
+	Challenges []ObservedCertificateChallenge `json:"challenges,omitempty"`
+}
+
+type ObservedCertificateChallenge struct {
+	Name    string `json:"name"`
+	Type    string `json:"type,omitempty"`
+	DNSName string `json:"dnsName,omitempty"`
+	State   string `json:"state,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// certificateList/certificateItem is a deliberately partial parse of
+// `kubectl get certificates.cert-manager.io -o json`.
+type certificateList struct {
+	Items []certificateItem `json:"items"`
+}
+
+type certificateItem struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Spec struct {
+		SecretName string   `json:"secretName"`
+		DNSNames   []string `json:"dnsNames"`
+	} `json:"spec"`
+	Status struct {
+		Conditions []certManagerCondition `json:"conditions"`
+	} `json:"status"`
+}
+
+type certManagerCondition struct {
+	Type    string `json:"type"`
+	Status  string `json:"status"`
+	Reason  string `json:"reason"`
+	Message string `json:"message"`
+}
+
+// ownedResourceItem is shared across CertificateRequest, Order, and
+// Challenge: each has metadata/ownerReferences, and Order/Challenge share the
+// same state/reason status shape and a spec.type/dnsName (only Challenge sets
+// them). Fields the current kind does not have simply stay zero-valued.
+type ownedResourceList struct {
+	Items []ownedResourceItem `json:"items"`
+}
+
+type ownedResourceItem struct {
+	Metadata struct {
+		Name              string            `json:"name"`
+		CreationTimestamp string            `json:"creationTimestamp"`
+		Labels            map[string]string `json:"labels"`
+		OwnerReferences   []struct {
+			Kind string `json:"kind"`
+			Name string `json:"name"`
+		} `json:"ownerReferences"`
+	} `json:"metadata"`
+	Spec struct {
+		Type    string `json:"type"`
+		DNSName string `json:"dnsName"`
+	} `json:"spec"`
+	Status struct {
+		State  string `json:"state"`
+		Reason string `json:"reason"`
+	} `json:"status"`
+}
+
+func certificateReady(item certificateItem) (ready bool, reason, message string) {
+	for _, cond := range item.Status.Conditions {
+		if cond.Type == "Ready" {
+			return cond.Status == "True", cond.Reason, cond.Message
+		}
+	}
+	return false, "", ""
+}
+
+func anyCertificateNotReady(certs []certificateItem) bool {
+	for _, cert := range certs {
+		if ready, _, _ := certificateReady(cert); !ready {
+			return true
+		}
+	}
+	return false
+}
+
+func ownerReferenceName(item ownedResourceItem, kind string) (string, bool) {
+	for _, ref := range item.Metadata.OwnerReferences {
+		if ref.Kind == kind {
+			return ref.Name, true
+		}
+	}
+	return "", false
+}
+
+// latestCertificateRequestName returns the most recently created
+// CertificateRequest cert-manager made for the named Certificate — the label
+// cert-manager.io/certificate-name is how cert-manager itself links them,
+// since a Certificate's status carries no direct pointer to it. RFC3339
+// creation timestamps sort correctly as plain strings.
+func latestCertificateRequestName(requests []ownedResourceItem, certificateName string) (string, bool) {
+	var latest ownedResourceItem
+	found := false
+	for _, cr := range requests {
+		if cr.Metadata.Labels["cert-manager.io/certificate-name"] != certificateName {
+			continue
+		}
+		if !found || cr.Metadata.CreationTimestamp > latest.Metadata.CreationTimestamp {
+			latest = cr
+			found = true
+		}
+	}
+	return latest.Metadata.Name, found
+}
+
+func resourcesOwnedBy(resources []ownedResourceItem, ownerKind, ownerName string) []ownedResourceItem {
+	var owned []ownedResourceItem
+	for _, resource := range resources {
+		if name, ok := ownerReferenceName(resource, ownerKind); ok && name == ownerName {
+			owned = append(owned, resource)
+		}
+	}
+	sort.Slice(owned, func(i, j int) bool { return owned[i].Metadata.Name < owned[j].Metadata.Name })
+	return owned
+}
+
+func buildObservedCertificates(certs []certificateItem, requests, orders, challenges []ownedResourceItem) []ObservedCertificate {
+	result := make([]ObservedCertificate, 0, len(certs))
+	for _, cert := range certs {
+		ready, reason, message := certificateReady(cert)
+		observed := ObservedCertificate{
+			Name:       cert.Metadata.Name,
+			Ready:      ready,
+			Reason:     reason,
+			Message:    message,
+			SecretName: cert.Spec.SecretName,
+			DNSNames:   cert.Spec.DNSNames,
+		}
+		if !ready {
+			observed.Orders = observedOrdersForCertificate(cert.Metadata.Name, requests, orders, challenges)
+		}
+		result = append(result, observed)
+	}
+	return result
+}
+
+func observedOrdersForCertificate(certificateName string, requests, orders, challenges []ownedResourceItem) []ObservedCertificateOrder {
+	crName, ok := latestCertificateRequestName(requests, certificateName)
+	if !ok {
+		return nil
+	}
+	var result []ObservedCertificateOrder
+	for _, order := range resourcesOwnedBy(orders, "CertificateRequest", crName) {
+		oo := ObservedCertificateOrder{Name: order.Metadata.Name, State: order.Status.State, Reason: order.Status.Reason}
+		for _, challenge := range resourcesOwnedBy(challenges, "Order", order.Metadata.Name) {
+			oo.Challenges = append(oo.Challenges, ObservedCertificateChallenge{
+				Name:    challenge.Metadata.Name,
+				Type:    challenge.Spec.Type,
+				DNSName: challenge.Spec.DNSName,
+				State:   challenge.Status.State,
+				Reason:  challenge.Status.Reason,
+			})
+		}
+		result = append(result, oo)
+	}
+	return result
+}
+
+func certificateChainArgs(req ShellLaunchParams) (certificateRequests, orders, challenges []string) {
+	return observeGetArgs(req, "certificaterequests.cert-manager.io"),
+		observeGetArgs(req, "orders.acme.cert-manager.io"),
+		observeGetArgs(req, "challenges.acme.cert-manager.io")
+}
+
+func parseOwnedResourceList(raw []byte) ([]ownedResourceItem, error) {
+	var list ownedResourceList
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+func fetchOwnedResourceList(args []string, kind string) ([]ownedResourceItem, error) {
+	raw, stderr, err := runObserveKubectl(args)
+	if err != nil {
+		if isKubectlUnknownResource(stderr) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("observe: get %s: %w", kind, kubectlErrorMessage(err, stderr))
+	}
+	return parseOwnedResourceList(raw)
+}
+
+// fetchObservedCertificates reads Certificates and, only for ones that are not
+// Ready, walks CertificateRequest -> Order -> Challenge for the failure
+// reason. ctx/req are needed here (unlike the other observe fetchers) because
+// that walk is itself conditional on what the first read finds, so its
+// kubectl calls are traced only when they actually run.
+func fetchObservedCertificates(ctx Context, req ShellLaunchParams, certArgs []string) ([]ObservedCertificate, error) {
+	raw, stderr, err := runObserveKubectl(certArgs)
+	if err != nil {
+		if isKubectlUnknownResource(stderr) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("observe: get certificates: %w", kubectlErrorMessage(err, stderr))
+	}
+	var list certificateList
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("observe: parse certificates: %w", err)
+	}
+	if !anyCertificateNotReady(list.Items) {
+		return buildObservedCertificates(list.Items, nil, nil, nil), nil
+	}
+
+	crArgs, orderArgs, challengeArgs := certificateChainArgs(req)
+	ctx.TraceCommand("", "kubectl", crArgs...)
+	ctx.TraceCommand("", "kubectl", orderArgs...)
+	ctx.TraceCommand("", "kubectl", challengeArgs...)
+
+	requests, err := fetchOwnedResourceList(crArgs, "certificaterequests")
+	if err != nil {
+		return nil, err
+	}
+	orders, err := fetchOwnedResourceList(orderArgs, "orders")
+	if err != nil {
+		return nil, err
+	}
+	challenges, err := fetchOwnedResourceList(challengeArgs, "challenges")
+	if err != nil {
+		return nil, err
+	}
+	return buildObservedCertificates(list.Items, requests, orders, challenges), nil
+}

--- a/erun-common/observe_certificate_test.go
+++ b/erun-common/observe_certificate_test.go
@@ -1,0 +1,141 @@
+package eruncommon
+
+import "testing"
+
+func readyCertificate(name string) certificateItem {
+	item := certificateItem{}
+	item.Metadata.Name = name
+	item.Status.Conditions = []certManagerCondition{{Type: "Ready", Status: "True"}}
+	return item
+}
+
+func notReadyCertificate(name, reason, message string) certificateItem {
+	item := certificateItem{}
+	item.Metadata.Name = name
+	item.Status.Conditions = []certManagerCondition{{Type: "Ready", Status: "False", Reason: reason, Message: message}}
+	return item
+}
+
+func certificateRequestFor(name, certificateName, createdAt string) ownedResourceItem {
+	item := ownedResourceItem{}
+	item.Metadata.Name = name
+	item.Metadata.CreationTimestamp = createdAt
+	item.Metadata.Labels = map[string]string{"cert-manager.io/certificate-name": certificateName}
+	return item
+}
+
+func orderOwnedBy(name, certificateRequestName, state, reason string) ownedResourceItem {
+	item := ownedResourceItem{}
+	item.Metadata.Name = name
+	item.Metadata.OwnerReferences = []struct {
+		Kind string `json:"kind"`
+		Name string `json:"name"`
+	}{{Kind: "CertificateRequest", Name: certificateRequestName}}
+	item.Status.State = state
+	item.Status.Reason = reason
+	return item
+}
+
+func challengeOwnedBy(name, orderName, challengeType, dnsName, state, reason string) ownedResourceItem {
+	item := ownedResourceItem{}
+	item.Metadata.Name = name
+	item.Metadata.OwnerReferences = []struct {
+		Kind string `json:"kind"`
+		Name string `json:"name"`
+	}{{Kind: "Order", Name: orderName}}
+	item.Spec.Type = challengeType
+	item.Spec.DNSName = dnsName
+	item.Status.State = state
+	item.Status.Reason = reason
+	return item
+}
+
+// TestBuildObservedCertificatesWalksToChallengeReason is the failure-chain
+// contract this command exists for: a Certificate stuck on a webhook solver's
+// RBAC denial reports that denial directly, without the caller composing the
+// Certificate -> CertificateRequest -> Order -> Challenge walk itself.
+func TestBuildObservedCertificatesWalksToChallengeReason(t *testing.T) {
+	certs := []certificateItem{notReadyCertificate("wildcard", "Issuing", "Issuing certificate as Secret does not exist")}
+	requests := []ownedResourceItem{certificateRequestFor("wildcard-abc123", "wildcard", "2024-01-01T00:00:00Z")}
+	orders := []ownedResourceItem{orderOwnedBy("wildcard-order-1", "wildcard-abc123", "pending", "")}
+	challenges := []ownedResourceItem{
+		challengeOwnedBy("wildcard-challenge-1", "wildcard-order-1", "DNS-01", "example.services.test",
+			"invalid", `unable to create webhook solver: RBAC denied: solvers.acme.cert-manager.io is forbidden: User "system:serviceaccount:default:cert-manager" cannot create resource "challenges" in API group "acme.cert-manager.io"`),
+	}
+
+	observed := buildObservedCertificates(certs, requests, orders, challenges)
+
+	if len(observed) != 1 {
+		t.Fatalf("expected 1 observed certificate, got %d", len(observed))
+	}
+	cert := observed[0]
+	if cert.Ready {
+		t.Fatalf("expected certificate to be reported not ready")
+	}
+	if len(cert.Orders) != 1 {
+		t.Fatalf("expected 1 order in the walk, got %d", len(cert.Orders))
+	}
+	order := cert.Orders[0]
+	if len(order.Challenges) != 1 {
+		t.Fatalf("expected 1 challenge in the walk, got %d", len(order.Challenges))
+	}
+	challenge := order.Challenges[0]
+	if challenge.Reason == "" {
+		t.Fatalf("expected the challenge's RBAC-denial reason to surface, got empty string")
+	}
+	if got, want := challenge.Reason, challenges[0].Status.Reason; got != want {
+		t.Fatalf("challenge reason = %q, want %q", got, want)
+	}
+}
+
+func TestBuildObservedCertificatesReadyCertificateSkipsWalk(t *testing.T) {
+	certs := []certificateItem{readyCertificate("wildcard")}
+	// A ready certificate must never walk the chain, even when stale
+	// CertificateRequest/Order/Challenge objects for it still exist.
+	requests := []ownedResourceItem{certificateRequestFor("wildcard-old", "wildcard", "2024-01-01T00:00:00Z")}
+	orders := []ownedResourceItem{orderOwnedBy("wildcard-order-old", "wildcard-old", "valid", "")}
+
+	observed := buildObservedCertificates(certs, requests, orders, nil)
+
+	if len(observed) != 1 {
+		t.Fatalf("expected 1 observed certificate, got %d", len(observed))
+	}
+	if !observed[0].Ready {
+		t.Fatalf("expected certificate to be reported ready")
+	}
+	if observed[0].Orders != nil {
+		t.Fatalf("expected no orders for a ready certificate, got %+v", observed[0].Orders)
+	}
+}
+
+// TestLatestCertificateRequestNamePicksMostRecent covers a Certificate that
+// has been reissued: multiple CertificateRequests carry its label, and only
+// the latest one's Order/Challenge chain is the live one worth walking.
+func TestLatestCertificateRequestNamePicksMostRecent(t *testing.T) {
+	requests := []ownedResourceItem{
+		certificateRequestFor("wildcard-old", "wildcard", "2024-01-01T00:00:00Z"),
+		certificateRequestFor("wildcard-new", "wildcard", "2024-06-01T00:00:00Z"),
+		certificateRequestFor("other-cert-request", "other", "2025-01-01T00:00:00Z"),
+	}
+
+	name, ok := latestCertificateRequestName(requests, "wildcard")
+	if !ok {
+		t.Fatalf("expected a certificate request to be found")
+	}
+	if name != "wildcard-new" {
+		t.Fatalf("latestCertificateRequestName = %q, want %q", name, "wildcard-new")
+	}
+}
+
+func TestBuildObservedCertificatesNoMatchingRequestReportsNoOrders(t *testing.T) {
+	certs := []certificateItem{notReadyCertificate("wildcard", "DoesNotExist", "")}
+
+	observed := buildObservedCertificates(certs, nil, nil, nil)
+
+	if len(observed) != 1 {
+		t.Fatalf("expected 1 observed certificate, got %d", len(observed))
+	}
+	if observed[0].Orders != nil {
+		t.Fatalf("expected no orders when no certificate request matches, got %+v", observed[0].Orders)
+	}
+}

--- a/erun-common/observe_ingress.go
+++ b/erun-common/observe_ingress.go
@@ -1,0 +1,65 @@
+package eruncommon
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ObservedIngress is one Ingress's routed hosts and the TLS secret backing
+// each host group, matching `spec.rules[].host` / `spec.tls[]`.
+type ObservedIngress struct {
+	Name  string               `json:"name"`
+	Hosts []string             `json:"hosts,omitempty"`
+	TLS   []ObservedIngressTLS `json:"tls,omitempty"`
+}
+
+type ObservedIngressTLS struct {
+	Hosts      []string `json:"hosts,omitempty"`
+	SecretName string   `json:"secretName,omitempty"`
+}
+
+// ingressList is a deliberately partial parse of `kubectl get ingress -o
+// json`, matching the podStatusList idiom in deploy_pod_watch.go.
+type ingressList struct {
+	Items []ingressItem `json:"items"`
+}
+
+type ingressItem struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Spec struct {
+		Rules []struct {
+			Host string `json:"host"`
+		} `json:"rules"`
+		TLS []struct {
+			Hosts      []string `json:"hosts"`
+			SecretName string   `json:"secretName"`
+		} `json:"tls"`
+	} `json:"spec"`
+}
+
+func fetchObservedIngresses(args []string) ([]ObservedIngress, error) {
+	raw, stderr, err := runObserveKubectl(args)
+	if err != nil {
+		return nil, fmt.Errorf("observe: get ingress: %w", kubectlErrorMessage(err, stderr))
+	}
+	var list ingressList
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("observe: parse ingress: %w", err)
+	}
+	ingresses := make([]ObservedIngress, 0, len(list.Items))
+	for _, item := range list.Items {
+		ing := ObservedIngress{Name: item.Metadata.Name}
+		for _, rule := range item.Spec.Rules {
+			if rule.Host != "" {
+				ing.Hosts = append(ing.Hosts, rule.Host)
+			}
+		}
+		for _, tls := range item.Spec.TLS {
+			ing.TLS = append(ing.TLS, ObservedIngressTLS{Hosts: tls.Hosts, SecretName: tls.SecretName})
+		}
+		ingresses = append(ingresses, ing)
+	}
+	return ingresses, nil
+}

--- a/erun-common/observe_pods.go
+++ b/erun-common/observe_pods.go
@@ -1,0 +1,91 @@
+package eruncommon
+
+import "fmt"
+
+// ObservedPod is one pod's readiness as reported by the Ready condition, plus
+// the reason it is not ready when it isn't.
+type ObservedPod struct {
+	Name         string `json:"name"`
+	Phase        string `json:"phase"`
+	Ready        bool   `json:"ready"`
+	RestartCount int    `json:"restartCount"`
+	Reason       string `json:"reason,omitempty"`
+}
+
+// fetchObservedPods reuses podStatusList/podStatusItem (deploy_pod_watch.go):
+// the same deliberately partial `kubectl get pods -o json` parse deploy's
+// watcher uses, tolerating kubectl version drift the same way.
+func fetchObservedPods(args []string) ([]ObservedPod, error) {
+	raw, stderr, err := runObserveKubectl(args)
+	if err != nil {
+		return nil, fmt.Errorf("observe: get pods: %w", kubectlErrorMessage(err, stderr))
+	}
+	list, ok := parsePodStatusList(raw)
+	if !ok {
+		return nil, fmt.Errorf("observe: parse pods: unrecognized kubectl output")
+	}
+	pods := make([]ObservedPod, 0, len(list.Items))
+	for _, item := range list.Items {
+		pods = append(pods, observedPodFromStatus(item))
+	}
+	return pods, nil
+}
+
+func observedPodFromStatus(item podStatusItem) ObservedPod {
+	pod := ObservedPod{
+		Name:  item.Metadata.Name,
+		Phase: item.Status.Phase,
+		Ready: podStatusReady(item),
+	}
+	for _, cs := range item.Status.ContainerStatuses {
+		pod.RestartCount += cs.RestartCount
+	}
+	if !pod.Ready {
+		pod.Reason = podStatusNotReadyReason(item)
+	}
+	return pod
+}
+
+func podStatusReady(item podStatusItem) bool {
+	for _, cond := range item.Status.Conditions {
+		if cond.Type == "Ready" {
+			return cond.Status == "True"
+		}
+	}
+	return false
+}
+
+// podStatusNotReadyReason prefers a container-level reason (the concrete
+// image-pull/crash cause) and falls back to the pod-level conditions —
+// PodScheduled is the only place a reason exists for a pod that never got
+// admitted to a node at all.
+func podStatusNotReadyReason(item podStatusItem) string {
+	if reason := containerStatusReason(item.Status.ContainerStatuses); reason != "" {
+		return reason
+	}
+	if reason := podConditionReason(item.Status.Conditions, "PodScheduled"); reason != "" {
+		return reason
+	}
+	return podConditionReason(item.Status.Conditions, "Ready")
+}
+
+func containerStatusReason(statuses []containerStatusEntry) string {
+	for _, cs := range statuses {
+		if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
+			return cs.State.Waiting.Reason
+		}
+		if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
+			return cs.State.Terminated.Reason
+		}
+	}
+	return ""
+}
+
+func podConditionReason(conditions []podConditionEntry, conditionType string) string {
+	for _, cond := range conditions {
+		if cond.Type == conditionType && cond.Status != "True" && cond.Reason != "" {
+			return cond.Reason
+		}
+	}
+	return ""
+}

--- a/erun-common/observe_quota.go
+++ b/erun-common/observe_quota.go
@@ -1,0 +1,103 @@
+package eruncommon
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ObservedResourceQuota pairs a namespace's ResourceQuota cap with what is
+// currently consumed against it.
+type ObservedResourceQuota struct {
+	Name string            `json:"name"`
+	Hard map[string]string `json:"hard,omitempty"`
+	Used map[string]string `json:"used,omitempty"`
+}
+
+// ObservedLimitRange is a namespace's LimitRange, per constraint entry.
+type ObservedLimitRange struct {
+	Name   string                   `json:"name"`
+	Limits []ObservedLimitRangeItem `json:"limits,omitempty"`
+}
+
+type ObservedLimitRangeItem struct {
+	Type           string            `json:"type"`
+	Max            map[string]string `json:"max,omitempty"`
+	Min            map[string]string `json:"min,omitempty"`
+	Default        map[string]string `json:"default,omitempty"`
+	DefaultRequest map[string]string `json:"defaultRequest,omitempty"`
+}
+
+// resourceQuotaList/limitRangeList are deliberately partial parses of
+// `kubectl get resourcequota|limitrange -o json`, matching the podStatusList
+// idiom in deploy_pod_watch.go: unknown fields are ignored so kubectl version
+// drift does not break observe.
+type resourceQuotaList struct {
+	Items []resourceQuotaItem `json:"items"`
+}
+
+type resourceQuotaItem struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Status struct {
+		Hard map[string]string `json:"hard"`
+		Used map[string]string `json:"used"`
+	} `json:"status"`
+}
+
+type limitRangeList struct {
+	Items []limitRangeItem `json:"items"`
+}
+
+type limitRangeItem struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Spec struct {
+		Limits []limitRangeLimitEntry `json:"limits"`
+	} `json:"spec"`
+}
+
+type limitRangeLimitEntry struct {
+	Type           string            `json:"type"`
+	Max            map[string]string `json:"max"`
+	Min            map[string]string `json:"min"`
+	Default        map[string]string `json:"default"`
+	DefaultRequest map[string]string `json:"defaultRequest"`
+}
+
+func fetchObservedResourceQuotas(args []string) ([]ObservedResourceQuota, error) {
+	raw, stderr, err := runObserveKubectl(args)
+	if err != nil {
+		return nil, fmt.Errorf("observe: get resourcequota: %w", kubectlErrorMessage(err, stderr))
+	}
+	var list resourceQuotaList
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("observe: parse resourcequota: %w", err)
+	}
+	quotas := make([]ObservedResourceQuota, 0, len(list.Items))
+	for _, item := range list.Items {
+		quotas = append(quotas, ObservedResourceQuota{Name: item.Metadata.Name, Hard: item.Status.Hard, Used: item.Status.Used})
+	}
+	return quotas, nil
+}
+
+func fetchObservedLimitRanges(args []string) ([]ObservedLimitRange, error) {
+	raw, stderr, err := runObserveKubectl(args)
+	if err != nil {
+		return nil, fmt.Errorf("observe: get limitrange: %w", kubectlErrorMessage(err, stderr))
+	}
+	var list limitRangeList
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("observe: parse limitrange: %w", err)
+	}
+	ranges := make([]ObservedLimitRange, 0, len(list.Items))
+	for _, item := range list.Items {
+		lr := ObservedLimitRange{Name: item.Metadata.Name}
+		for _, l := range item.Spec.Limits {
+			lr.Limits = append(lr.Limits, ObservedLimitRangeItem(l))
+		}
+		ranges = append(ranges, lr)
+	}
+	return ranges, nil
+}

--- a/erun-common/observe_secret.go
+++ b/erun-common/observe_secret.go
@@ -1,0 +1,49 @@
+package eruncommon
+
+import "encoding/json"
+
+// ObservedSecretCheck reports whether a named Secret exists and carries a
+// named key — never the value. Error carries a non-"not found" kubectl
+// failure (for example an RBAC denial) so that case is never silently
+// reported as the secret simply not existing.
+type ObservedSecretCheck struct {
+	Name   string `json:"name"`
+	Key    string `json:"key"`
+	Exists bool   `json:"exists"`
+	HasKey bool   `json:"hasKey"`
+	Error  string `json:"error,omitempty"`
+}
+
+// observeSecretItem is a deliberately partial parse of `kubectl get secret -o
+// json`: only key names are read out of Data/StringData, never a value.
+type observeSecretItem struct {
+	Data       map[string]string `json:"data"`
+	StringData map[string]string `json:"stringData"`
+}
+
+func fetchObservedSecretCheck(args []string, check ObserveSecretCheck) ObservedSecretCheck {
+	result := ObservedSecretCheck{Name: check.Name, Key: check.Key}
+	raw, stderr, err := runObserveKubectl(args)
+	if err != nil {
+		if isKubectlNotFound(stderr) {
+			return result
+		}
+		result.Error = kubectlErrorMessage(err, stderr).Error()
+		return result
+	}
+	var secret observeSecretItem
+	if err := json.Unmarshal(raw, &secret); err != nil {
+		result.Error = "parse secret: " + err.Error()
+		return result
+	}
+	result.Exists = true
+	if check.Key == "" {
+		return result
+	}
+	if _, ok := secret.Data[check.Key]; ok {
+		result.HasKey = true
+		return result
+	}
+	_, result.HasKey = secret.StringData[check.Key]
+	return result
+}

--- a/erun-docs/docs/agent-reference/cli-flags.md
+++ b/erun-docs/docs/agent-reference/cli-flags.md
@@ -576,6 +576,74 @@ Both actions are also exposed on the [MCP `doctor` tool](/mcp/overview#doctor) v
 
 ---
 
+## `erun observe` {#erun-observe}
+
+Reports an environment's Kubernetes state, read-only: every underlying call is `kubectl [--context <ctx>] --namespace <ns> get <resource> [name] -o json`, never anything that mutates. Same operation as the MCP `observe` tool (see [MCP overview § `observe`](/mcp/overview#observe)).
+
+### Flags
+
+| Flag | Type | Default | Effect |
+|---|---|---|---|
+| `--tenant <t>` | string | current scope | Target tenant. |
+| `--environment <e>` | string | current scope | Target environment; requires `--tenant`. |
+| `--secret <name>=<key>` | string, repeatable | none | Check Secret `<name>` for key `<key>`'s presence. Malformed (missing `=`, empty name, or empty key) aborts with `--secret must be name=key, got "<value>"` (exit 1) before any `kubectl` call. |
+
+### Resolution and output shape
+
+Resolves tenant/environment/namespace the same way every other typed command does (`ResolveOpen`), then issues, in order: `get pods`, `get resourcequota`, `get limitrange`, `get ingress`, `get certificates.cert-manager.io`, then one `get secret <name>` per `--secret` check. `--output json` emits:
+
+```jsonc
+{
+  "tenant": "myapp", "environment": "prod", "namespace": "myapp-prod",
+  "pods": [ { "name": "web-0", "phase": "Running", "ready": true, "restartCount": 0, "reason": "" } ],
+  "resourceQuotas": [ { "name": "erun-quota", "hard": { "limits.cpu": "4" }, "used": { "limits.cpu": "1" } } ],
+  "limitRanges": [ { "name": "erun-limits", "limits": [
+    { "type": "Container", "max": {}, "min": {}, "default": { "cpu": "1" }, "defaultRequest": { "cpu": "100m" } }
+  ] } ],
+  "ingresses": [ { "name": "web", "hosts": ["prod.example.com"],
+    "tls": [ { "hosts": ["prod.example.com"], "secretName": "web-tls" } ] } ],
+  "certificates": [ { "name": "wildcard", "ready": false, "reason": "Issuing", "message": "…",
+    "secretName": "wildcard-tls", "dnsNames": ["*.prod.example.com"], "orders": [ /* see below */ ] } ],
+  "secrets": [ { "name": "db-credentials", "key": "password", "exists": true, "hasKey": true, "error": "" } ]
+}
+```
+
+`reason` on a pod is the container's `waiting`/`terminated` reason if present, else the `PodScheduled=False` reason (a pod never admitted to a node has no container status to read a reason from), else the `Ready=False` condition's reason. `secrets` is omitted entirely when no `--secret` was given.
+
+### The Certificate → CertificateRequest → Order → Challenge walk {#certificate-failure-chain}
+
+`certificates[].orders` is populated only when that Certificate's `status.conditions[type=Ready]` is not `True`. The walk, run once against a fresh listing of each resource kind in the namespace (not once per certificate):
+
+1. List `certificaterequests.cert-manager.io`; filter to the ones labelled `cert-manager.io/certificate-name=<certificate>`; take the one with the latest `metadata.creationTimestamp` (a Certificate can be reissued, leaving stale requests behind — only the newest one's chain is live). None matching → `orders` is empty.
+2. List `orders.acme.cert-manager.io`; keep the ones whose `ownerReferences` include `{kind: CertificateRequest, name: <request from step 1>}`.
+3. For each such Order, list `challenges.acme.cert-manager.io` and keep the ones owned (`ownerReferences`) by that Order.
+4. Each reported order carries `state`/`reason` from `status`; each challenge carries `type`/`dnsName` from `spec` and `state`/`reason` from `status` — `reason` is the field that explains a stuck issuance (e.g. a webhook solver's RBAC denial), which is otherwise three separate `kubectl get` calls away.
+
+A cluster with no cert-manager CRDs installed (`kubectl` reports "the server doesn't have a resource type" / "no matches for kind") reports `certificates: []` rather than erroring — a cluster simply has no certificates to walk.
+
+### Secret presence checks
+
+Each `--secret <name>=<key>` becomes one `kubectl get secret <name> -o json`, read only for its key names (`data`/`stringData`), never a value:
+
+| Outcome | `exists` | `hasKey` | `error` |
+|---|---|---|---|
+| Secret and key both present. | `true` | `true` | `""` |
+| Secret present, key absent. | `true` | `false` | `""` |
+| Secret not found. | `false` | `false` | `""` |
+| Any other failure (e.g. RBAC denial reading the Secret). | `false` | `false` | the kubectl error, so a permission problem is never reported indistinguishably from "does not exist" |
+
+### Error behaviour
+
+| Failure | Behaviour |
+|---|---|
+| Tenant/environment can't be resolved. | Errors before any `kubectl` call. |
+| `--secret` isn't `name=key`. | Errors before any `kubectl` call, naming the malformed value. |
+| `get pods` / `resourcequota` / `limitrange` / `ingress` fails (namespace or cluster unreachable). | Errors naming the failed call; nothing is reported. |
+| `get certificates.cert-manager.io` fails because the CRD isn't installed. | `certificates: []`; not an error. |
+| `get certificates.cert-manager.io` fails for another reason. | Errors naming the failed call. |
+
+---
+
 ## `erun outputs`
 
 `erun outputs` lists and downloads files an agent produced in an environment's runtime pod outputs directory (`$ERUN_OUTPUTS_DIR`, default `/home/erun/.erun/outputs`). Both subcommands resolve the pod from tenant/environment scope and read it over `kubectl exec`; the MCP `outputs_list`/`outputs_download` tools cover the same operations for in-pod callers (which read the filesystem directly).

--- a/erun-docs/docs/cli/mcp.md
+++ b/erun-docs/docs/cli/mcp.md
@@ -62,7 +62,7 @@ Every tool requires one of two capabilities:
 
 | Capability | Tools |
 | --- | --- |
-| `erun:read` | Observation that cannot change anything: `version`, `list`, `idle`, `idle_stop_history`, `context_list`, `cloud_list`, `diff`, `outputs_list`, `outputs_download`, `job_status`, `job_output`, `job_await` |
+| `erun:read` | Observation that cannot change anything: `version`, `list`, `idle`, `idle_stop_history`, `context_list`, `cloud_list`, `diff`, `observe`, `outputs_list`, `outputs_download`, `job_status`, `job_output`, `job_await` |
 | `erun:admin` | Everything else, including remote execution and every mutating tool |
 
 `erun:admin` implies `erun:read`, so an admin token never carries both.

--- a/erun-docs/docs/cli/observe.md
+++ b/erun-docs/docs/cli/observe.md
@@ -1,0 +1,57 @@
+---
+title: erun observe
+---
+
+# `erun observe`
+
+Report an environment's Kubernetes state. Read-only — every call it makes is a `kubectl get`, never anything that can create, change, or delete a cluster object, which is what makes it safe to grant to an orchestrator that must never be handed [`erun exec raw`](/cli/exec).
+
+## Synopsis
+
+```
+erun observe [--tenant <t>] [--environment <e>] [--secret <name>=<key>]... [flags]
+```
+
+## What it shows
+
+Pods (phase, readiness, restart count, and why a pod isn't ready), the namespace's `ResourceQuota`/`LimitRange` and what's currently consumed against them, `Ingress` hosts and their TLS secret names, and every `Certificate`'s readiness.
+
+When a `Certificate` is not Ready, `observe` walks its `CertificateRequest` → `Order` → `Challenge` chain automatically and reports the `Challenge`'s reason — the field that actually explains a stuck issuance (for example a webhook solver's RBAC denial) — instead of leaving you to run three more `kubectl` commands to find it.
+
+```bash
+erun observe --tenant my-tenant --environment prod
+erun observe --tenant my-tenant --environment prod --output json
+```
+
+## Checking a Secret without reading it
+
+`--secret <name>=<key>` (repeatable) checks whether a Secret exists and carries a given key, without ever reading or printing its value:
+
+```bash
+erun observe --tenant my-tenant --environment prod --secret db-credentials=password
+```
+
+## Flags
+
+| Flag | Description |
+|---|---|
+| `--tenant`, `--environment` | Target a specific tenant/environment; default to the current scope. |
+| `--secret <name>=<key>` | Check a Secret for a key's presence (repeatable). The value is never read. |
+| `--output json` | Emit the full result as JSON. |
+| `--dry-run` | Trace the `kubectl get` calls that would run without executing them. |
+
+The full JSON shape (every field, and the exact CertificateRequest → Order → Challenge walk) is specified in [Agent reference · `erun observe`](/agent-reference/cli-flags#erun-observe).
+
+## From an MCP-connected orchestrator
+
+The same read reaches an Agent through the `observe` MCP tool — see [MCP overview § Inspection](/mcp/overview#inspection--read-only).
+
+## Error behaviour
+
+| Failure | Behaviour |
+|---|---|
+| Tenant/environment can't be resolved. | Errors before any `kubectl` call. |
+| `--secret` isn't `name=key`. | Errors before any `kubectl` call, naming the malformed value. |
+| The namespace or cluster is unreachable. | Errors naming the failed `kubectl get`. |
+| Cert-manager isn't installed in the cluster. | Reports zero certificates rather than erroring. |
+| A checked Secret doesn't exist. | Reports `exists: false` — not an error. |

--- a/erun-docs/docs/cli/overview.md
+++ b/erun-docs/docs/cli/overview.md
@@ -37,6 +37,7 @@ The `build → release → push → deploy` commands form ERun's delivery pipeli
 | [`erun sshd`](/cli/sshd) | Enable SSH (and IDE) access to a remote environment. |
 | [`erun list`](/cli/list) | List tenants, environments, and the effective target. |
 | [`erun idle`](/cli/idle) | Show an environment's idle / auto-stop status. |
+| [`erun observe`](/cli/observe) | Report an environment's Kubernetes state, read-only — pods, quota/limit usage, ingress + TLS, certificate readiness. |
 | [`erun job`](/agent-reference/cli-flags#erun-job) | Start long work in an environment and observe it by handle — `start`, `status`, `await`, `output`, `cancel`. |
 | [`erun doctor`](/cli/doctor) | Diagnose and repair an environment's runtime and config. |
 | [`erun version`](/cli/version) | Print erun's build version (and the project's, when in one) + latest published versions. |

--- a/erun-docs/docs/mcp/overview.md
+++ b/erun-docs/docs/mcp/overview.md
@@ -125,6 +125,7 @@ Four categories. The protocol treats them all as MCP tools; the categorisation i
 | Tool | Purpose |
 |---|---|
 | `idle` | Resolved idle policy, managed-cloud flag, stop eligibility, current activity snapshot, and the activity leases currently holding the env busy. |
+| `observe` | The env's Kubernetes state: pods, `ResourceQuota`/`LimitRange` usage, `Ingress` hosts + TLS secret names, and `Certificate` readiness — walking `CertificateRequest` → `Order` → `Challenge` for the failure reason when a certificate isn't Ready. Optionally checks named Secrets for a key's presence without reading their values. Every call is a `kubectl get`; nothing here can mutate the cluster. |
 | `doctor` | In-pod health checks (config files, git checkout, SSH keys, docker daemon, workspace PVC). |
 | `list` | Same data as the CLI `erun list`, structured. |
 | `version` | Build version and commit of the MCP server. |
@@ -263,6 +264,50 @@ Resolves the env's idle policy and reports its current activity. Useful for an A
   ]
 }
 ```
+
+### `observe`
+
+Reads pods, quota/limit usage, ingress routing, and certificate readiness for the env's namespace — read-only, every underlying call is a `kubectl get`. Optional `secrets` input checks named Secret/key pairs for presence without reading their values.
+
+```jsonc
+// observe {"secrets": [{"name": "db-credentials", "key": "password"}]}
+{
+  "tenant": "myapp",
+  "environment": "prod",
+  "namespace": "myapp-prod",
+  "pods": [
+    { "name": "web-0", "phase": "Running", "ready": true, "restartCount": 0 }
+  ],
+  "resourceQuotas": [
+    { "name": "erun-quota", "hard": { "limits.cpu": "4" }, "used": { "limits.cpu": "1" } }
+  ],
+  "limitRanges": [
+    { "name": "erun-limits", "limits": [
+      { "type": "Container", "default": { "cpu": "1" }, "defaultRequest": { "cpu": "100m" } }
+    ] }
+  ],
+  "ingresses": [
+    { "name": "web", "hosts": ["prod.example.com"],
+      "tls": [{ "hosts": ["prod.example.com"], "secretName": "web-tls" }] }
+  ],
+  "certificates": [
+    { "name": "wildcard", "ready": false, "reason": "Issuing", "message": "waiting for order to complete",
+      "secretName": "wildcard-tls", "dnsNames": ["*.prod.example.com"],
+      "orders": [
+        { "name": "wildcard-order-1", "state": "pending",
+          "challenges": [
+            { "name": "wildcard-challenge-1", "type": "DNS-01", "dnsName": "*.prod.example.com",
+              "state": "invalid", "reason": "RBAC denied: solvers.acme.cert-manager.io is forbidden: cannot create resource challenges" }
+          ] }
+      ] }
+  ],
+  "secrets": [
+    { "name": "db-credentials", "key": "password", "exists": true, "hasKey": true }
+  ]
+}
+```
+
+`orders` is populated only for a Certificate that isn't `ready` — a healthy certificate reports no chain to walk. A `secrets` entry always reports `exists`/`hasKey`; a missing Secret reports `exists: false` rather than erroring, and a non-"not found" failure (e.g. an RBAC denial reading the Secret itself) is carried in an `error` field instead of being reported as absence.
 
 ### `doctor`
 

--- a/erun-docs/sidebars.ts
+++ b/erun-docs/sidebars.ts
@@ -52,6 +52,7 @@ const sidebars: SidebarsConfig = {
         'cli/outputs',
         'cli/inputs',
         'cli/idle',
+        'cli/observe',
         'cli/doctor',
         'cli/version',
         'cli/mcp',

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -12,6 +12,7 @@ import (
 	osexec "os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1324,6 +1325,38 @@ func StubBinaryWithScript(t testing.TB, dir, name, scriptBody string) string {
 		body += "\n"
 	}
 	return writeStub(t, dir, name, body)
+}
+
+// StubKubectlGetJSON writes a kubectl stub that dispatches on the resource
+// named right after "get" (e.g. "pods", "certificates.cert-manager.io",
+// "secret my-secret") to return canned JSON, for a command like `observe`
+// that issues several distinct `kubectl get <resource> -o json` calls in one
+// run. Matching on "get <resource>" as a substring of the full argv (rather
+// than parsing --context/--namespace positionally) keeps this reusable across
+// scenarios with different context/namespace flags. A call whose resource
+// isn't in responses exits 1 naming the unstubbed argv, so a scenario that
+// forgets to stub a call fails loudly instead of asserting on empty data.
+func StubKubectlGetJSON(t testing.TB, dir string, responses map[string]string) string {
+	t.Helper()
+	keys := make([]string, 0, len(responses))
+	for key := range responses {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var body strings.Builder
+	body.WriteString("args=\"$*\"\n")
+	body.WriteString("case \"$args\" in\n")
+	for _, key := range keys {
+		body.WriteString("  *" + shellSingleQuote("get "+key) + "*)\n")
+		body.WriteString("    cat <<'ERUN_STUB_KUBECTL_JSON'\n")
+		body.WriteString(strings.TrimRight(responses[key], "\n"))
+		body.WriteString("\nERUN_STUB_KUBECTL_JSON\n")
+		body.WriteString("    ;;\n")
+	}
+	body.WriteString("  *) echo \"unstubbed kubectl call: $args\" >&2; exit 1 ;;\n")
+	body.WriteString("esac\n")
+	return StubBinaryWithScript(t, dir, "kubectl", body.String())
 }
 
 // StubBinaryMergingIntoRemoteOnce writes a stub for name that, on its first

--- a/erun-integration/observe_test.go
+++ b/erun-integration/observe_test.go
@@ -1,0 +1,136 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sophium/erun/erun-integration/internal/env"
+	"github.com/sophium/erun/erun-integration/internal/erun"
+	"github.com/sophium/erun/erun-integration/internal/fixture"
+	"github.com/sophium/erun/erun-integration/internal/golden"
+	"github.com/sophium/erun/erun-integration/internal/normalize"
+)
+
+// observeStubResponses is the canned `kubectl get <resource> -o json` bodies
+// shared by the observe real-run scenarios: one pod, one quota, one limit
+// range, one ingress, and a Certificate that is not Ready. The
+// CertificateRequest -> Order -> Challenge chain resolves to a Challenge
+// whose reason is an RBAC denial on the webhook solver — the exact failure
+// class #1138 exists to surface without three more hand-built kubectl calls.
+func observeStubResponses() map[string]string {
+	return map[string]string{
+		"pods":                                `{"items":[{"metadata":{"name":"web-0"},"status":{"phase":"Running","conditions":[{"type":"Ready","status":"True"}],"containerStatuses":[{"name":"app","restartCount":0,"ready":true,"state":{"running":{"startedAt":"2024-01-01T00:00:00Z"}}}]}}]}`,
+		"resourcequota":                       `{"items":[{"metadata":{"name":"erun-quota"},"status":{"hard":{"limits.cpu":"4"},"used":{"limits.cpu":"1"}}}]}`,
+		"limitrange":                          `{"items":[{"metadata":{"name":"erun-limits"},"spec":{"limits":[{"type":"Container","default":{"cpu":"1"},"defaultRequest":{"cpu":"100m"}}]}}]}`,
+		"ingress":                             `{"items":[{"metadata":{"name":"web"},"spec":{"rules":[{"host":"dev.example.test"}],"tls":[{"hosts":["dev.example.test"],"secretName":"web-tls"}]}}]}`,
+		"certificates.cert-manager.io":        `{"items":[{"metadata":{"name":"wildcard"},"spec":{"secretName":"wildcard-tls","dnsNames":["*.dev.example.test"]},"status":{"conditions":[{"type":"Ready","status":"False","reason":"Issuing","message":"waiting for order to complete"}]}}]}`,
+		"certificaterequests.cert-manager.io": `{"items":[{"metadata":{"name":"wildcard-abc","creationTimestamp":"2024-01-01T00:00:00Z","labels":{"cert-manager.io/certificate-name":"wildcard"}}}]}`,
+		"orders.acme.cert-manager.io":         `{"items":[{"metadata":{"name":"wildcard-order-1","ownerReferences":[{"kind":"CertificateRequest","name":"wildcard-abc"}]},"status":{"state":"pending"}}]}`,
+		"challenges.acme.cert-manager.io":     `{"items":[{"metadata":{"name":"wildcard-challenge-1","ownerReferences":[{"kind":"Order","name":"wildcard-order-1"}]},"spec":{"type":"DNS-01","dnsName":"*.dev.example.test"},"status":{"state":"invalid","reason":"RBAC denied: solvers.acme.cert-manager.io is forbidden: cannot create resource challenges"}}]}`,
+	}
+}
+
+func TestObserve(t *testing.T) {
+	t.Run("help", func(t *testing.T) {
+		setup := env.New(t)
+		result := erun.Run(t, []string{"observe", "--help"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "observe/help", normalize.Apply(result.Combined))
+	})
+
+	t.Run("dry_run", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"observe", "--dry-run", "-vv"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "observe/dry_run", normalize.Apply(result.Combined))
+	})
+
+	t.Run("dry_run_with_secret", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"observe", "--secret", "db-credentials=password", "--dry-run", "-vv"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "observe/dry_run_with_secret", normalize.Apply(result.Combined))
+	})
+
+	t.Run("dry_run_missing_tenant", func(t *testing.T) {
+		// No tenant configured at all: resolution fails before any kubectl call
+		// is even planned.
+		setup := env.New(t)
+		result := erun.Run(t, []string{"observe", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected a non-zero exit with no tenant configured, got 0: %s", result.Combined)
+		}
+		golden.Equal(t, "observe/dry_run_missing_tenant", normalize.Apply(result.Combined))
+	})
+
+	t.Run("secret_flag_must_be_name_equals_key", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		result := erun.Run(t, []string{"observe", "--secret", "just-a-name", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected a non-zero exit for a malformed --secret, got 0: %s", result.Combined)
+		}
+		golden.Equal(t, "observe/secret_flag_must_be_name_equals_key", normalize.Apply(result.Combined))
+	})
+
+	// real_run_walks_certificate_failure_chain is the scenario #1138 exists
+	// for: a Certificate that is not Ready must surface the reason from the
+	// Challenge at the bottom of its CertificateRequest -> Order -> Challenge
+	// chain, in this one call, rather than requiring the caller to compose
+	// that walk from three more hand-built kubectl queries.
+	t.Run("real_run_walks_certificate_failure_chain", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubKubectlGetJSON(t, stubs, observeStubResponses())
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+		result := erun.Run(t, []string{"observe", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "observe/real_run_walks_certificate_failure_chain", normalize.Apply(result.Combined))
+	})
+
+	t.Run("real_run_secret_presence_check", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		responses := observeStubResponses()
+		responses["secret db-credentials"] = `{"data":{"password":"c2VjcmV0"}}`
+		fixture.StubKubectlGetJSON(t, stubs, responses)
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+		result := erun.Run(t, []string{"observe", "--secret", "db-credentials=password", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "observe/real_run_secret_presence_check", normalize.Apply(result.Combined))
+	})
+
+	t.Run("real_run_secret_missing_key_never_reveals_value", func(t *testing.T) {
+		// The secret exists but the checked key does not: hasKey is false and
+		// no value from the stub's canned Data ever appears in the output.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		responses := observeStubResponses()
+		responses["secret db-credentials"] = `{"data":{"password":"c2VjcmV0"}}`
+		fixture.StubKubectlGetJSON(t, stubs, responses)
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+		result := erun.Run(t, []string{"observe", "--secret", "db-credentials=other-key", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		if got := result.Combined; strings.Contains(got, "c2VjcmV0") {
+			t.Fatalf("secret value leaked into output: %s", got)
+		}
+		golden.Equal(t, "observe/real_run_secret_missing_key_never_reveals_value", normalize.Apply(result.Combined))
+	})
+}

--- a/erun-integration/testdata/build/help.txt
+++ b/erun-integration/testdata/build/help.txt
@@ -41,6 +41,7 @@ Available Commands:
   job         Start long work in the environment and observe it by handle
   list        List configured tenants and environments
   mcp         Run ERun as an MCP server over HTTP
+  observe     Report an environment's Kubernetes state, read-only
   open        Open a shell in the tenant environment
   outputs     List and download files an agent produced in the runtime pod
   pin         Re-pin every erun version reference for an environment

--- a/erun-integration/testdata/observe/dry_run.txt
+++ b/erun-integration/testdata/observe/dry_run.txt
@@ -1,0 +1,7 @@
+audit: erun observe --dry-run
+kubectl --context test-context --namespace team-dev get pods -o json
+kubectl --context test-context --namespace team-dev get resourcequota -o json
+kubectl --context test-context --namespace team-dev get limitrange -o json
+kubectl --context test-context --namespace team-dev get ingress -o json
+kubectl --context test-context --namespace team-dev get certificates.cert-manager.io -o json
+observe: when a certificate is not Ready, its CertificateRequest -> Order -> Challenge chain is read for the failure reason

--- a/erun-integration/testdata/observe/dry_run_missing_tenant.txt
+++ b/erun-integration/testdata/observe/dry_run_missing_tenant.txt
@@ -1,0 +1,2 @@
+audit: erun observe --dry-run
+default tenant is not configured

--- a/erun-integration/testdata/observe/dry_run_with_secret.txt
+++ b/erun-integration/testdata/observe/dry_run_with_secret.txt
@@ -1,0 +1,8 @@
+audit: erun observe --dry-run --secret <redacted>
+kubectl --context test-context --namespace team-dev get pods -o json
+kubectl --context test-context --namespace team-dev get resourcequota -o json
+kubectl --context test-context --namespace team-dev get limitrange -o json
+kubectl --context test-context --namespace team-dev get ingress -o json
+kubectl --context test-context --namespace team-dev get certificates.cert-manager.io -o json
+observe: when a certificate is not Ready, its CertificateRequest -> Order -> Challenge chain is read for the failure reason
+kubectl --context test-context --namespace team-dev get secret db-credentials -o json

--- a/erun-integration/testdata/observe/help.txt
+++ b/erun-integration/testdata/observe/help.txt
@@ -1,0 +1,28 @@
+Report pods, ResourceQuota/LimitRange usage, Ingress hosts and TLS secret
+names, and Certificate readiness for the environment's namespace.
+
+When a Certificate is not Ready, its CertificateRequest -> Order -> Challenge
+chain is walked automatically, so the reason issuance is stuck (for example a
+webhook solver's RBAC denial) comes back in this one call instead of three more.
+
+Every call is a kubectl get: nothing here can mutate the cluster, which is what
+makes this safe to grant an orchestrator that must never reach for `exec raw`.
+
+Usage:
+  erun observe [flags]
+
+Examples:
+  erun observe --tenant team --environment dev
+  erun observe --tenant team --environment dev --secret db-credentials=password --output json
+
+Flags:
+      --dry-run              Resolve and trace mutating actions without executing them.
+      --environment string   Target a specific environment; requires --tenant
+  -h, --help                 help for observe
+      --secret stringArray   Check a Secret for a key's presence, as name=key (repeatable); the value is never read
+      --tenant string        Target a specific tenant (default: the current scope)
+
+Global Flags:
+      --output string   Result format: text (default, human stream) or json (structured result on stdout for orchestrators). (default "text")
+      --time            Print the elapsed runtime after the command finishes.
+  -v, --verbose count   Increase verbosity: -v streams external tool output, -vv adds erun command traces.

--- a/erun-integration/testdata/observe/real_run_secret_missing_key_never_reveals_value.txt
+++ b/erun-integration/testdata/observe/real_run_secret_missing_key_never_reveals_value.txt
@@ -1,0 +1,93 @@
+{
+  "tenant": "team",
+  "environment": "dev",
+  "namespace": "team-dev",
+  "pods": [
+    {
+      "name": "web-0",
+      "phase": "Running",
+      "ready": true,
+      "restartCount": 0
+    }
+  ],
+  "resourceQuotas": [
+    {
+      "name": "erun-quota",
+      "hard": {
+        "limits.cpu": "4"
+      },
+      "used": {
+        "limits.cpu": "1"
+      }
+    }
+  ],
+  "limitRanges": [
+    {
+      "name": "erun-limits",
+      "limits": [
+        {
+          "type": "Container",
+          "default": {
+            "cpu": "1"
+          },
+          "defaultRequest": {
+            "cpu": "100m"
+          }
+        }
+      ]
+    }
+  ],
+  "ingresses": [
+    {
+      "name": "web",
+      "hosts": [
+        "dev.example.test"
+      ],
+      "tls": [
+        {
+          "hosts": [
+            "dev.example.test"
+          ],
+          "secretName": "web-tls"
+        }
+      ]
+    }
+  ],
+  "certificates": [
+    {
+      "name": "wildcard",
+      "ready": false,
+      "reason": "Issuing",
+      "message": "waiting for order to complete",
+      "secretName": "wildcard-tls",
+      "dnsNames": [
+        "*.dev.example.test"
+      ],
+      "orders": [
+        {
+          "name": "wildcard-order-1",
+          "state": "pending",
+          "challenges": [
+            {
+              "name": "wildcard-challenge-1",
+              "type": "DNS-01",
+              "dnsName": "*.dev.example.test",
+              "state": "invalid",
+              "reason": "RBAC denied: solvers.acme.cert-manager.io is forbidden: cannot create resource challenges"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "secrets": [
+    {
+      "name": "db-credentials",
+      "key": "other-key",
+      "exists": true,
+      "hasKey": false
+    }
+  ]
+}
+audit: erun observe --output json --secret <redacted>
+observe: when a certificate is not Ready, its CertificateRequest -> Order -> Challenge chain is read for the failure reason

--- a/erun-integration/testdata/observe/real_run_secret_presence_check.txt
+++ b/erun-integration/testdata/observe/real_run_secret_presence_check.txt
@@ -1,0 +1,93 @@
+{
+  "tenant": "team",
+  "environment": "dev",
+  "namespace": "team-dev",
+  "pods": [
+    {
+      "name": "web-0",
+      "phase": "Running",
+      "ready": true,
+      "restartCount": 0
+    }
+  ],
+  "resourceQuotas": [
+    {
+      "name": "erun-quota",
+      "hard": {
+        "limits.cpu": "4"
+      },
+      "used": {
+        "limits.cpu": "1"
+      }
+    }
+  ],
+  "limitRanges": [
+    {
+      "name": "erun-limits",
+      "limits": [
+        {
+          "type": "Container",
+          "default": {
+            "cpu": "1"
+          },
+          "defaultRequest": {
+            "cpu": "100m"
+          }
+        }
+      ]
+    }
+  ],
+  "ingresses": [
+    {
+      "name": "web",
+      "hosts": [
+        "dev.example.test"
+      ],
+      "tls": [
+        {
+          "hosts": [
+            "dev.example.test"
+          ],
+          "secretName": "web-tls"
+        }
+      ]
+    }
+  ],
+  "certificates": [
+    {
+      "name": "wildcard",
+      "ready": false,
+      "reason": "Issuing",
+      "message": "waiting for order to complete",
+      "secretName": "wildcard-tls",
+      "dnsNames": [
+        "*.dev.example.test"
+      ],
+      "orders": [
+        {
+          "name": "wildcard-order-1",
+          "state": "pending",
+          "challenges": [
+            {
+              "name": "wildcard-challenge-1",
+              "type": "DNS-01",
+              "dnsName": "*.dev.example.test",
+              "state": "invalid",
+              "reason": "RBAC denied: solvers.acme.cert-manager.io is forbidden: cannot create resource challenges"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "secrets": [
+    {
+      "name": "db-credentials",
+      "key": "password",
+      "exists": true,
+      "hasKey": true
+    }
+  ]
+}
+audit: erun observe --output json --secret <redacted>
+observe: when a certificate is not Ready, its CertificateRequest -> Order -> Challenge chain is read for the failure reason

--- a/erun-integration/testdata/observe/real_run_walks_certificate_failure_chain.txt
+++ b/erun-integration/testdata/observe/real_run_walks_certificate_failure_chain.txt
@@ -1,0 +1,85 @@
+{
+  "tenant": "team",
+  "environment": "dev",
+  "namespace": "team-dev",
+  "pods": [
+    {
+      "name": "web-0",
+      "phase": "Running",
+      "ready": true,
+      "restartCount": 0
+    }
+  ],
+  "resourceQuotas": [
+    {
+      "name": "erun-quota",
+      "hard": {
+        "limits.cpu": "4"
+      },
+      "used": {
+        "limits.cpu": "1"
+      }
+    }
+  ],
+  "limitRanges": [
+    {
+      "name": "erun-limits",
+      "limits": [
+        {
+          "type": "Container",
+          "default": {
+            "cpu": "1"
+          },
+          "defaultRequest": {
+            "cpu": "100m"
+          }
+        }
+      ]
+    }
+  ],
+  "ingresses": [
+    {
+      "name": "web",
+      "hosts": [
+        "dev.example.test"
+      ],
+      "tls": [
+        {
+          "hosts": [
+            "dev.example.test"
+          ],
+          "secretName": "web-tls"
+        }
+      ]
+    }
+  ],
+  "certificates": [
+    {
+      "name": "wildcard",
+      "ready": false,
+      "reason": "Issuing",
+      "message": "waiting for order to complete",
+      "secretName": "wildcard-tls",
+      "dnsNames": [
+        "*.dev.example.test"
+      ],
+      "orders": [
+        {
+          "name": "wildcard-order-1",
+          "state": "pending",
+          "challenges": [
+            {
+              "name": "wildcard-challenge-1",
+              "type": "DNS-01",
+              "dnsName": "*.dev.example.test",
+              "state": "invalid",
+              "reason": "RBAC denied: solvers.acme.cert-manager.io is forbidden: cannot create resource challenges"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+audit: erun observe --output json
+observe: when a certificate is not Ready, its CertificateRequest -> Order -> Challenge chain is read for the failure reason

--- a/erun-integration/testdata/observe/secret_flag_must_be_name_equals_key.txt
+++ b/erun-integration/testdata/observe/secret_flag_must_be_name_equals_key.txt
@@ -1,0 +1,2 @@
+audit: erun observe --dry-run --secret <redacted>
+--secret must be name=key, got "just-a-name"

--- a/erun-integration/testdata/root/help.txt
+++ b/erun-integration/testdata/root/help.txt
@@ -41,6 +41,7 @@ Available Commands:
   job         Start long work in the environment and observe it by handle
   list        List configured tenants and environments
   mcp         Run ERun as an MCP server over HTTP
+  observe     Report an environment's Kubernetes state, read-only
   open        Open a shell in the tenant environment
   outputs     List and download files an agent produced in the runtime pod
   pin         Re-pin every erun version reference for an environment

--- a/erun-mcp/capabilities_test.go
+++ b/erun-mcp/capabilities_test.go
@@ -69,7 +69,7 @@ func TestReadCapabilitySeesOnlyTheReadTools(t *testing.T) {
 	want := []string{
 		"activity_lease_list", "cloud_list", "context_list", "diff", "idle",
 		"idle_stop_history",
-		"job_await", "job_output", "job_status", "list",
+		"job_await", "job_output", "job_status", "list", "observe",
 		"outputs_download", "outputs_list", "version",
 	}
 	if !slices.Equal(got, want) {

--- a/erun-mcp/observe.go
+++ b/erun-mcp/observe.go
@@ -1,0 +1,74 @@
+package erunmcp
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+type ObserveSecretCheckInput struct {
+	Name string `json:"name" jsonschema:"Secret name to check for existence"`
+	Key  string `json:"key" jsonschema:"data key whose presence to check; the value itself is never read or returned"`
+}
+
+type ObserveInput struct {
+	Tenant      string                    `json:"tenant,omitempty" jsonschema:"tenant whose environment should be observed; defaults to the server tenant context"`
+	Environment string                    `json:"environment,omitempty" jsonschema:"environment to observe; defaults to the server environment context"`
+	Secrets     []ObserveSecretCheckInput `json:"secrets,omitempty" jsonschema:"named Secret/key pairs to check for presence, without reading their values"`
+	Preview     bool                      `json:"preview,omitempty" jsonschema:"when true, resolve and trace the kubectl calls that would run without executing them"`
+	Verbosity   int                       `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+}
+
+// observeTool is read-only by construction: RunObservation issues only
+// `kubectl get`, so this tool carries the erun:read capability rather than
+// erun:admin (see mcpReadOnlyTools), unlike raw or doctor's recovery actions.
+func observeTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, ObserveInput) (*mcp.CallToolResult, eruncommon.ObserveResult, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input ObserveInput) (*mcp.CallToolResult, eruncommon.ObserveResult, error) {
+		target, err := resolveObserveOpenResult(runtime, input)
+		if err != nil {
+			return nil, eruncommon.ObserveResult{}, err
+		}
+		req := eruncommon.ShellLaunchParamsFromResult(target)
+		runCtx := runtimeCallContext(input.Preview, input.Verbosity, nil, io.Discard, io.Discard)
+		result, err := eruncommon.RunObservation(runCtx, req, eruncommon.ObserveParams{Secrets: observeSecretChecksFromInput(input.Secrets)})
+		if err != nil {
+			return nil, eruncommon.ObserveResult{}, err
+		}
+		return nil, result, nil
+	}
+}
+
+func observeSecretChecksFromInput(inputs []ObserveSecretCheckInput) []eruncommon.ObserveSecretCheck {
+	checks := make([]eruncommon.ObserveSecretCheck, 0, len(inputs))
+	for _, in := range inputs {
+		checks = append(checks, eruncommon.ObserveSecretCheck{Name: strings.TrimSpace(in.Name), Key: strings.TrimSpace(in.Key)})
+	}
+	return checks
+}
+
+// resolveObserveOpenResult mirrors resolveDoctorOpenResult's explicit ->
+// partial -> runtime-context -> default fallback chain, so `observe` resolves
+// tenant/environment/namespace the same way every other typed MCP tool does.
+func resolveObserveOpenResult(runtime RuntimeConfig, input ObserveInput) (eruncommon.OpenResult, error) {
+	tenant := strings.TrimSpace(input.Tenant)
+	environment := strings.TrimSpace(input.Environment)
+	switch {
+	case tenant != "" && environment != "":
+		return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{Tenant: tenant, Environment: environment})
+	case tenant != "":
+		return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{Tenant: tenant, UseDefaultEnvironment: true})
+	case environment != "":
+		return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{Environment: environment, UseDefaultTenant: true})
+	}
+
+	runtimeTenant := strings.TrimSpace(runtime.Context.Tenant)
+	runtimeEnvironment := strings.TrimSpace(runtime.Context.Environment)
+	if runtimeTenant != "" && runtimeEnvironment != "" {
+		return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{Tenant: runtimeTenant, Environment: runtimeEnvironment})
+	}
+
+	return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{UseDefaultTenant: true, UseDefaultEnvironment: true})
+}

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -405,6 +405,10 @@ func registerDeliveryTools(reg toolRegistrar, runtime RuntimeConfig) {
 		Description: "Diagnose and repair the resolved environment: report why a deploy may have failed (helm release status and runtime pods, read-only); recover a failing runtime release by clearing a stuck pending helm lock or rolling back to the last successful revision; prune unused Docker images, build cache, or stopped containers; and optionally restore or repair the root erun config from a backup or by re-initializing orphaned cloud provider aliases",
 	}, doctorTool(runtime))
 	addTool(reg, &mcp.Tool{
+		Name:        "observe",
+		Description: "Report the resolved environment's Kubernetes state, read-only: pods, ResourceQuota/LimitRange usage, Ingress hosts and TLS secret names, and Certificate readiness. When a Certificate is not Ready, its CertificateRequest -> Order -> Challenge chain is walked automatically for the failure reason, so a stuck issuance (for example a webhook solver's RBAC denial) surfaces in this one call. Optionally check named Secrets for a key's presence without reading their values. Every call is a kubectl get; nothing here can mutate the cluster.",
+	}, observeTool(runtime))
+	addTool(reg, &mcp.Tool{
 		Name:        "delete",
 		Description: "Delete an environment from ERun configuration and remove its remote runtime namespace after explicit tenant-environment confirmation",
 	}, deleteTool(runtime))

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -180,6 +180,7 @@ var wantRegisteredTools = []string{
 	"job_start",
 	"job_status",
 	"list",
+	"observe",
 	"outputs_download",
 	"outputs_list",
 	"pin",


### PR DESCRIPTION
## Summary

- Adds `erun observe` (CLI) and a matching `observe` MCP tool, added to the `erun:read` capability set alongside `idle`/`diff`/`list` — a typed, read-only replacement for the largest remaining source of `raw` in orchestration (issue #1128's "granting a named operation grants that operation" argument, applied here for observation instead of edit/commit).
- Resolves tenant/environment/namespace itself (`ResolveOpen` + `ShellLaunchParamsFromResult`), exactly like every other typed command — a caller cannot address the wrong namespace by typo.
- Reports pods (phase/ready/restarts/reason), `ResourceQuota`/`LimitRange` usage, `Ingress` hosts + TLS secret names, and `Certificate` readiness, all in one structured `--output json` result.
- **Walks the failure chain by default**: when a `Certificate` is not Ready, it resolves `CertificateRequest` → `Order` → `Challenge` and surfaces the Challenge's `reason` (e.g. a webhook solver's RBAC denial) — the field that explains the failure, in this one call instead of three more hand-built `kubectl` queries.
- `--secret <name>=<key>` (repeatable) checks a Secret for a key's presence **without ever reading or returning the value** — only key names are unmarshalled out of `data`/`stringData`.
- **Read-only by construction, not a thin passthrough**: every underlying call is a literal `kubectl get <fixed-resource-kind> ... -o json`; there is no caller-supplied verb anywhere in the command, so it can't be turned into an execution primitive.
- Both transports over shared `erun-common` logic (`RunObservation`), per repo convention — no reason found for a single-transport exception.
- Docs: new Operator page `cli/observe.md`, full flag/JSON/algorithm spec in `agent-reference/cli-flags.md` (`#erun-observe`), new row + structured-schema example in `mcp/overview.md`, and `observe` added to the `erun:read` capability table in `cli/mcp.md`. `yarn build`/`yarn typecheck` clean.

## Pre-existing fixes picked up along the way

- Two `erun-mcp` tests (`TestReadCapabilitySeesOnlyTheReadTools`, `TestHTTPHandlerExposesVersionTool`) pin the exact tool list/name-set; updated to include `observe`.
- Filed #1144 for a genuinely pre-existing, unrelated `erun-mcp` test bug found while running the full suite (two `init` tool tests shelled out to real `kubectl` for a nonexistent context) — then discovered it had already been fixed independently upstream in #1139 while this branch was in flight, and closed #1144 as a confirmed duplicate fix.

## Test plan

- [x] New failing-first unit tests in `erun-common` for the Certificate → Order → Challenge walk (`observe_certificate_test.go`) — verified they fail to compile on unfixed `main` (`undefined: certificateItem` / `ownedResourceItem` / `buildObservedCertificates`, confirmed via a stash-based check), pass after the change.
- [x] New `erun-integration` scenarios (`observe_test.go`, 8 cases: help, dry-run ×3 incl. malformed `--secret`, and 3 real-run cases with a stubbed `kubectl` — including the RBAC-denial certificate-chain walk and both secret-presence outcomes). Verified they fail on unfixed `main` with `-count=1` (`erun observe` parses as `erun --dry-run observe`, an unknown environment name, since the command doesn't exist yet) before passing on the fix. Added a reusable `fixture.StubKubectlGetJSON` helper for multi-resource kubectl dispatch, per the repo's "factor non-trivial argv branching into `internal/fixture/`" rule.
- [x] `go test ./...` green in `erun-common`, `erun-cli`, `erun-mcp`.
- [x] `make lint` clean across every gated module.
- [x] `make integration-test` green, coverage 76.2% (≥ 76.0% threshold).
- [x] Manual end-to-end smoke test against a stubbed `kubectl` on PATH, both `--dry-run` and real-run, both `text` and `--output json` — confirmed the RBAC-denial reason surfaces from the Challenge automatically and no secret value ever appears in output.

Closes #1138