### PR TITLE
Let the DNS-01 webhook shim pull a private image

### DIFF
--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/chart-dns01-webhook/templates/webhook.yaml
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/chart-dns01-webhook/templates/webhook.yaml
@@ -47,6 +47,10 @@ spec:
         app: {{ .Values.name }}
     spec:
       serviceAccountName: {{ .Values.name }}
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
       containers:
         - name: webhook
           image: {{ required "image is required" .Values.image }}

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/chart-dns01-webhook/values.yaml
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/chart-dns01-webhook/values.yaml
@@ -16,6 +16,12 @@ namespace: cert-manager
 image: ""
 imagePullPolicy: IfNotPresent
 
+# Pull secrets for the image above, by name, in this chart's namespace. Empty for
+# a public registry. The Secret itself is provisioned out of band -- note it must
+# live in the cert-manager namespace, which is not where an operator expects to
+# put a registry credential.
+imagePullSecrets: []
+
 # The broker endpoint the shim forwards to, and the Secret key the per-env token
 # is delivered under. brokerURL is the base; the shim appends /present /cleanup.
 brokerURL: ""

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/main.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/main.tf
@@ -144,6 +144,14 @@ resource "helm_release" "dns01_webhook" {
     value = var.broker_url
   }
 
+  dynamic "set" {
+    for_each = var.dns01_webhook_image_pull_secrets
+    content {
+      name  = "imagePullSecrets[${set.key}].name"
+      value = set.value
+    }
+  }
+
   lifecycle {
     precondition {
       condition     = var.broker_url != "" && var.dns01_webhook_image != ""

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/tests/dns01_webhook.tftest.hcl
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/tests/dns01_webhook.tftest.hcl
@@ -106,3 +106,46 @@ run "broker_mode_without_a_token_secret_is_rejected" {
 
   expect_failures = [helm_release.issuer]
 }
+
+# A private shim image needs a pull secret, and nothing renders one unless the
+# module threads it. Asserted at the module level because module charts have no
+# render harness -- see the PR for why that gap is left alone here.
+run "webhook_shim_threads_image_pull_secrets" {
+  command = plan
+
+  variables {
+    dns01_provider                   = "powerdns-rfc2136"
+    install_dns01_webhook            = true
+    powerdns_nameserver              = "erun-powerdns.frs-prod.svc.cluster.local:53"
+    rfc2136_tsig_key_name            = "erun-tsig"
+    rfc2136_tsig_secret              = "c2VjcmV0"
+    broker_url                       = "https://api.frs-prod.services.example.com/v1/dns01"
+    dns01_webhook_image              = "ghcr.io/sophium/erun-dns01-webhook:1.0.0"
+    dns01_webhook_image_pull_secrets = ["ghcr-pull"]
+  }
+
+  assert {
+    condition     = length([for s in helm_release.dns01_webhook[0].set : s if s.name == "imagePullSecrets[0].name" && s.value == "ghcr-pull"]) == 1
+    error_message = "the shim must receive its image pull secrets, or a private image leaves the APIService at MissingEndpoints"
+  }
+}
+
+# Default stays empty so a public-registry install is unchanged.
+run "webhook_shim_sets_no_pull_secrets_by_default" {
+  command = plan
+
+  variables {
+    dns01_provider        = "powerdns-rfc2136"
+    install_dns01_webhook = true
+    powerdns_nameserver   = "erun-powerdns.frs-prod.svc.cluster.local:53"
+    rfc2136_tsig_key_name = "erun-tsig"
+    rfc2136_tsig_secret   = "c2VjcmV0"
+    broker_url            = "https://api.frs-prod.services.example.com/v1/dns01"
+    dns01_webhook_image   = "ghcr.io/sophium/erun-dns01-webhook:1.0.0"
+  }
+
+  assert {
+    condition     = length([for s in helm_release.dns01_webhook[0].set : s if strcontains(s.name, "imagePullSecrets")]) == 0
+    error_message = "no pull secrets must be set when none are configured"
+  }
+}

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/variables.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/variables.tf
@@ -96,6 +96,12 @@ variable "install_dns01_webhook" {
   default     = null
 }
 
+variable "dns01_webhook_image_pull_secrets" {
+  description = "Names of image pull secrets for the DNS-01 webhook shim's image, in the cert-manager namespace. Empty for a public registry. Needed because the shim's image can be private while the rest of a release is not -- an unauthenticated pull leaves the APIService at MissingEndpoints, and a webhook that cannot start makes hosted environments undeletable."
+  type        = list(string)
+  default     = []
+}
+
 variable "broker_url" {
   description = "Base URL of the DNS-01 broker the webhook shim forwards to (the shim appends /present and /cleanup), e.g. \"https://api.frs-prod.services.example.com/v1/dns01\". Required when the webhook shim is installed (install_dns01_webhook)."
   type        = string


### PR DESCRIPTION
Closes #1150

Installing the shim on frs-prod failed at the only step that matters — the pod:

```
Failed to pull image "ghcr.io/sophium/erun-dns01-webhook:1.0.196": failed to authorize:
failed to fetch anonymous token: ... 401 Unauthorized
  → ErrImagePull → ImagePullBackOff
```

Everything else the chart provisions worked: serving certificate issued, CA verified, `APIService` registered. It sat at `False (MissingEndpoints)` purely because the image could not be pulled. The chart rendered a Deployment with no `imagePullSecrets` and no values to set them, while `erun-zitadel` has supported exactly this for its bootstrap image all along.

The asymmetry that hid it: `erun-dns01-webhook` is **private** on ghcr while `erun-devops`, `erun-backend-api` and `erun-powerdns` are public. It has been published since 1.0.192 and never pulled, because installing the shim was impossible until #1123 separated it from `dns01_provider`. The first real install found the gap.

Making the package public would also unblock it, but that is a registry-visibility decision and it would not fix the chart — any platform on a private registry hits this regardless.

## Why this blocked applying rather than just being noted

I unblocked production by copying the cluster's existing `ghcr-pull` secret into `cert-manager` and patching the shim's ServiceAccount; the APIService went `True / Passed`. But **helm owns that ServiceAccount**, so the next `terraform apply` reverts it. The running pod survives — its image is already pulled and its spec unchanged — which makes the failure *latent*: the cluster is then one pod restart (a drain, an eviction, a rollout) away from a webhook that cannot start, and a webhook that cannot start reproduces #1122 exactly, where every hosted environment becomes undeletable because its Challenge can be neither presented nor cleaned up.

So I held the remaining plan rather than applying it. A hand-patched ServiceAccount that terraform will silently undo is worse than an unapplied plan.

## Verification

`helm template` with the value set renders it on the pod spec, ahead of the containers:

```yaml
      imagePullSecrets:
        - name: ghcr-pull
      containers:
        - name: webhook
```

and without it, zero occurrences — so a public-registry install is byte-identical to before.

Module tests, pre-change (new tests against the unfixed `main.tf`):

```
run "webhook_shim_threads_image_pull_secrets"... fail
  │ --- actual
  │ +++ expected
  │ - 0
  │ + 1
  │ the shim must receive its image pull secrets, or a private image leaves the
  │ APIService at MissingEndpoints
Failure! 6 passed, 1 failed.
```

Post-change: `Success! 7 passed, 0 failed.` `terraform fmt -check -recursive` clean. Runs against mocked providers; no cluster touched.

## One gap left deliberately

The chart's *rendering* is verified here by running `helm template` by hand, not by a committed test. `erun-devops/k8s/` has chart test scripts for the top-level charts (`erun-zitadel-chart_test.sh` and friends) but nothing covers the charts vendored inside terraform modules, and adding that harness is a larger change than this fix. The module-level tests do lock the threading, which is the part that was actually broken. Flagging it rather than quietly leaving it.