### PR TITLE
Default the DNS-01 webhook image from its own chart, and teach pin to catch it

### DIFF
--- a/erun-cli/cmd/pin.go
+++ b/erun-cli/cmd/pin.go
@@ -27,8 +27,9 @@ func newPinCmd(prepareContext func(common.Context) common.Context, resolveOpen f
 		Use:   "pin [TENANT] [ENVIRONMENT]",
 		Short: "Re-pin every erun version reference for an environment",
 		Long: "Re-pin every erun version reference for an environment: the Terraform module refs, " +
-			"each umbrella chart's erun dependencies, the build-env image tag, and the environment's " +
-			"own runtime version.\n\n" +
+			"an erun image reference set directly in Terraform variables (e.g. the cluster-edge " +
+			"module's dns01_webhook_image), each umbrella chart's erun dependencies, the build-env " +
+			"image tag, and the environment's own runtime version.\n\n" +
 			"Idempotent, and a no-op once aligned. It rewrites the source of truth only — realizing " +
 			"the new version (terraform apply, deploy) stays a separate explicit step.",
 		Example: "  erun pin --list\n  erun pin acme dev --dry-run\n  erun pin acme dev --version 1.0.175\n  erun pin acme dev --revert",

--- a/erun-common/pin.go
+++ b/erun-common/pin.go
@@ -12,11 +12,13 @@ import (
 )
 
 // One erun version is written down in several places in a tenant repo — the
-// Terraform module refs, every umbrella chart's erun dependencies, the build-env
-// image tag, and the environment's own runtimeversion — and they only work when
-// they agree. Nothing enforced that, so they drifted: a repo was found pinned to
-// three different versions at once, and realigning it meant editing seven files
-// by hand.
+// Terraform module refs, an erun image reference a tenant's own Terraform
+// variables set directly (e.g. the cluster-edge module's dns01_webhook_image),
+// every umbrella chart's erun dependencies, the build-env image tag, and the
+// environment's own runtimeversion — and they only work when they agree.
+// Nothing enforced that, so they drifted: a repo was found pinned to three
+// different versions at once, and realigning it meant editing seven files by
+// hand.
 //
 // The sites are found by pattern rather than by walking a fixed layout. The
 // Terraform root alone has three legitimate locations, and a tenant is free to
@@ -32,6 +34,7 @@ const (
 	PinSiteTerraformRef   PinSiteKind = "terraform-ref"
 	PinSiteHelmDependency PinSiteKind = "helm-dependency"
 	PinSiteRuntimeImage   PinSiteKind = "runtime-image"
+	PinSiteImageReference PinSiteKind = "image-reference"
 )
 
 // PinSite is one place a version is recorded, and what it would become.
@@ -92,6 +95,16 @@ var erunHelmDependencyPattern = regexp.MustCompile(`(?ms)(-\s+name:\s*(\S+)[^\n]
 
 // erunDevopsImagePattern matches a build-env base image tag.
 var erunDevopsImagePattern = regexp.MustCompile(`(erun-devops:)([0-9][^\s"']*)`)
+
+// erunImageReferencePattern matches a published erun image reference
+// (ghcr.io/sophium/erun-<component>:<version>) inside a Terraform file or
+// variables file. A tenant's own terraform can set one of these directly — the
+// cluster-edge module's dns01_webhook_image is the reported case — and it names
+// an erun release exactly like the module ref above it, just as a variable's
+// value instead of a module source string. erun-devops is excluded: a bare
+// build-env tag is already the dedicated site above, and matching it here too
+// would report the same reference twice.
+var erunImageReferencePattern = regexp.MustCompile(`(ghcr\.io/sophium/(erun-[a-zA-Z0-9_-]+):)([0-9][^\s"']*)`)
 
 // ResolvePinPlan reads every pin site under projectRoot and reports what moving
 // to target would change. It never writes, so a caller can render the plan,
@@ -225,12 +238,20 @@ func pinSitesInFile(path, relative, name, target string) ([]PinSite, error) {
 	for _, match := range erunDevopsImagePattern.FindAllStringSubmatch(content, -1) {
 		sites = append(sites, PinSite{Kind: PinSiteRuntimeImage, Path: relative, Detail: "erun-devops", Current: match[2], Target: target})
 	}
+	if pinTerraformFile(name) {
+		for _, match := range erunImageReferencePattern.FindAllStringSubmatch(content, -1) {
+			if match[2] == "erun-devops" {
+				continue
+			}
+			sites = append(sites, PinSite{Kind: PinSiteImageReference, Path: relative, Detail: match[2], Current: match[3], Target: target})
+		}
+	}
 	return sites, nil
 }
 
 func pinScannableFile(name string) bool {
 	switch {
-	case strings.HasSuffix(name, ".tf"):
+	case pinTerraformFile(name):
 		return true
 	case name == "Chart.yaml":
 		return true
@@ -238,6 +259,13 @@ func pinScannableFile(name string) bool {
 		return true
 	}
 	return false
+}
+
+// pinTerraformFile reports whether name is a Terraform configuration or
+// variables file — the two places a tenant's own terraform can carry an erun
+// image reference directly, alongside a module ref.
+func pinTerraformFile(name string) bool {
+	return strings.HasSuffix(name, ".tf") || strings.HasSuffix(name, ".tfvars")
 }
 
 // ApplyPinPlan rewrites every file site to the target. The environment's own
@@ -284,6 +312,7 @@ func rewritePinnedVersions(content, target string) string {
 	content = erunTerraformRefPattern.ReplaceAllString(content, "${1}v"+target)
 	content = erunHelmDependencyPattern.ReplaceAllString(content, "${1}"+target)
 	content = erunDevopsImagePattern.ReplaceAllString(content, "${1}"+target)
+	content = erunImageReferencePattern.ReplaceAllString(content, "${1}"+target)
 	return content
 }
 

--- a/erun-common/pin_test.go
+++ b/erun-common/pin_test.go
@@ -51,6 +51,12 @@ dependencies:
 	write("acme-devops/docker/erun-devops/Dockerfile", `FROM ghcr.io/sophium/erun-devops:1.0.102
 RUN apt-get update
 `)
+	// The reported gap: a tenant's own terraform variables set an erun-published
+	// image directly (the cluster-edge module's dns01_webhook_image), not just a
+	// module ref — and it names an erun release just as much as the ref above it.
+	write("terraform-acme/prod/prod.tfvars", `dns01_webhook_image = "ghcr.io/sophium/erun-dns01-webhook:1.0.102"
+broker_url          = "https://api.acme-prod.services.example.com/v1/dns01"
+`)
 	// A vendored copy of a pulled chart: a build artifact of a pin, not a pin.
 	write("acme-api/charts/erun-backend-api/Chart.yaml", `apiVersion: v2
 name: erun-backend-api
@@ -90,6 +96,30 @@ func TestResolvePinPlanFindsEveryErunReferenceAndLeavesTheTenantsOwnAlone(t *tes
 	}
 	if len(byKind[PinSiteRuntimeVersion]) != 1 || byKind[PinSiteRuntimeVersion][0].Current != "1.0.115" {
 		t.Fatalf("expected the env's own runtimeversion as a site, got %+v", byKind[PinSiteRuntimeVersion])
+	}
+}
+
+// The reported gap: dns01_webhook_image, set directly in a tenant's own
+// terraform variables, is an erun-published image reference just like the
+// module ref above it, and must surface as a site of its own.
+func TestResolvePinPlanFindsAnErunImageReferenceInTerraformVariables(t *testing.T) {
+	root := seedPinnedTenantRepo(t)
+	plan, err := ResolvePinPlan(root, "acme", "dev", EnvConfig{Name: "dev"}, "1.0.175")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	var found []PinSite
+	for _, site := range plan.Sites {
+		if site.Kind == PinSiteImageReference {
+			found = append(found, site)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected the dns01_webhook_image reference in the tfvars file, got %+v", found)
+	}
+	if found[0].Detail != "erun-dns01-webhook" || found[0].Current != "1.0.102" {
+		t.Fatalf("image reference = %+v, want erun-dns01-webhook at 1.0.102", found[0])
 	}
 }
 
@@ -157,6 +187,44 @@ func TestApplyPinPlanRewritesTheBuildEnvImageWithoutDisturbingTheDockerfile(t *t
 	}
 	if !strings.Contains(dockerfile, "RUN apt-get update") {
 		t.Fatalf("the Dockerfile's own content was disturbed:\n%s", dockerfile)
+	}
+}
+
+// The reported bug: a re-pin moved every other reference but left the
+// dns01_webhook_image line in a tenant's own tfvars untouched, creating exactly
+// the skew between the cluster-edge module and the shim it ships beside that
+// pin exists to prevent.
+func TestApplyPinPlanRewritesErunImageReferencesInTerraformVariableFiles(t *testing.T) {
+	tfvars := readPinFile(t, applyPinnedRepo(t), "terraform-acme/prod/prod.tfvars")
+	if !strings.Contains(tfvars, "ghcr.io/sophium/erun-dns01-webhook:1.0.175") {
+		t.Fatalf("dns01_webhook_image not re-pinned:\n%s", tfvars)
+	}
+	if !strings.Contains(tfvars, `broker_url          = "https://api.acme-prod.services.example.com/v1/dns01"`) {
+		t.Fatalf("an unrelated tfvars line was disturbed:\n%s", tfvars)
+	}
+}
+
+// erun-devops already has its own dedicated runtime-image site; a
+// registry-qualified reference to it in a tfvars file must not also be
+// reported as a second, redundant image-reference site.
+func TestResolvePinPlanDoesNotDoubleCountAnErunDevopsImageReferenceInTerraformVariables(t *testing.T) {
+	root := t.TempDir()
+	full := filepath.Join(root, "terraform-acme", "prod", "prod.tfvars")
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(`devops_image = "ghcr.io/sophium/erun-devops:1.0.102"`+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	plan, err := ResolvePinPlan(root, "acme", "dev", EnvConfig{}, "1.0.175")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	for _, site := range plan.Sites {
+		if site.Kind == PinSiteImageReference {
+			t.Fatalf("erun-devops must not also surface as an image-reference site: %+v", site)
+		}
 	}
 }
 

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/main.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/main.tf
@@ -10,7 +10,17 @@ locals {
   # install the shim for per-tenant brokered Issuers (e.g. erun expose's)
   # while its own Issuer stays on cloudflare or rfc2136.
   install_dns01_webhook = var.install_dns01_webhook != null ? var.install_dns01_webhook : local.use_broker
-  tsig_secret_name      = "${var.issuer_name}-rfc2136-tsig"
+  # The shim ships as one release with this module — chart-dns01-webhook's own
+  # Chart.yaml is stamped to the erun version at every release, the same way
+  # every umbrella chart's dependency versions are. Reading it here is this
+  # module's equivalent of a Helm template's `.Chart.AppVersion` default (see
+  # erun-zitadel's bootstrap image): the shim's image can no longer disagree
+  # with the module by construction, because they are pinned by the same file.
+  # var.dns01_webhook_image still overrides it, for testing a build ahead of a
+  # release.
+  dns01_webhook_chart_app_version = yamldecode(file("${path.module}/chart-dns01-webhook/Chart.yaml")).appVersion
+  dns01_webhook_image             = var.dns01_webhook_image != "" ? var.dns01_webhook_image : "ghcr.io/sophium/erun-dns01-webhook:${local.dns01_webhook_chart_app_version}"
+  tsig_secret_name                = "${var.issuer_name}-rfc2136-tsig"
   # Per-env wildcard: *.<env_label>.<services_zone> → Secret <env_label>-wildcard-tls
   # in the env namespace, which `erun expose` references from its Ingress.
   env_namespace       = var.env_namespace != "" ? var.env_namespace : var.env_label
@@ -137,7 +147,7 @@ resource "helm_release" "dns01_webhook" {
   }
   set {
     name  = "image"
-    value = var.dns01_webhook_image
+    value = local.dns01_webhook_image
   }
   set {
     name  = "brokerURL"
@@ -154,8 +164,8 @@ resource "helm_release" "dns01_webhook" {
 
   lifecycle {
     precondition {
-      condition     = var.broker_url != "" && var.dns01_webhook_image != ""
-      error_message = "install_dns01_webhook requires broker_url and dns01_webhook_image."
+      condition     = var.broker_url != ""
+      error_message = "install_dns01_webhook requires broker_url."
     }
   }
 

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/tests/dns01_webhook.tftest.hcl
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/tests/dns01_webhook.tftest.hcl
@@ -107,6 +107,29 @@ run "broker_mode_without_a_token_secret_is_rejected" {
   expect_failures = [helm_release.issuer]
 }
 
+# Leaving dns01_webhook_image unset must not fail, and must not leave the shim
+# on some previous erun release: the module resolves it from its own bundled
+# chart-dns01-webhook/Chart.yaml appVersion, so the shim and the module can never
+# disagree without deliberately overriding the variable.
+run "webhook_shim_image_defaults_to_the_bundled_charts_own_release" {
+  command = plan
+
+  variables {
+    dns01_provider        = "powerdns-rfc2136"
+    install_dns01_webhook = true
+    powerdns_nameserver   = "erun-powerdns.frs-prod.svc.cluster.local:53"
+    rfc2136_tsig_key_name = "erun-tsig"
+    rfc2136_tsig_secret   = "c2VjcmV0"
+    broker_url            = "https://api.frs-prod.services.example.com/v1/dns01"
+    # dns01_webhook_image is intentionally omitted.
+  }
+
+  assert {
+    condition     = length([for s in helm_release.dns01_webhook[0].set : s if s.name == "image" && startswith(s.value, "ghcr.io/sophium/erun-dns01-webhook:") && s.value != "ghcr.io/sophium/erun-dns01-webhook:"]) == 1
+    error_message = "an unset dns01_webhook_image must default the shim's image to ghcr.io/sophium/erun-dns01-webhook at this module's own chart-dns01-webhook/Chart.yaml appVersion"
+  }
+}
+
 # A private shim image needs a pull secret, and nothing renders one unless the
 # module threads it. Asserted at the module level because module charts have no
 # render harness -- see the PR for why that gap is left alone here.

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/variables.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/variables.tf
@@ -121,7 +121,7 @@ variable "dns01_webhook_group_name" {
 }
 
 variable "dns01_webhook_image" {
-  description = "Container image (repository:tag) for the DNS-01 webhook shim, e.g. \"ghcr.io/sophium/erun-dns01-webhook:1.0.150\". Required when the webhook shim is installed (install_dns01_webhook); pin to the running erun version."
+  description = "Container image (repository:tag) for the DNS-01 webhook shim, e.g. \"ghcr.io/sophium/erun-dns01-webhook:1.0.150\". Optional: left empty (the default), it resolves to ghcr.io/sophium/erun-dns01-webhook at the version chart-dns01-webhook/Chart.yaml (bundled in this module) is itself released at, so the shim can never disagree with the module it ships beside. Set it only to override that — e.g. to test a build ahead of a release."
   type        = string
   default     = ""
 }

--- a/erun-integration/pin_test.go
+++ b/erun-integration/pin_test.go
@@ -34,17 +34,43 @@ func seedDriftedPins(t *testing.T, root, rootConfigDir string) {
 			t.Fatalf("write %s: %v", relative, err)
 		}
 	}
-	// A closed port, so version discovery is deterministic and offline. An
-	// unreachable registry means "could not verify", which is what lets an
-	// explicit target still pin.
-	rootConfigFile := filepath.Join(rootConfigDir, "config.yaml")
-	if existing, err := os.ReadFile(rootConfigFile); err == nil && !strings.Contains(string(existing), "runtimeregistry") {
-		if err := os.WriteFile(rootConfigFile, append(existing, []byte("runtimeregistry:\n  baseurl: http://127.0.0.1:1\n  tokenurl: http://127.0.0.1:1\n")...), 0o644); err != nil {
-			t.Fatalf("write root config: %v", err)
-		}
-	}
+	seedUnreachableRuntimeRegistry(t, rootConfigDir)
 	write("terraform-team/dev/main.tf", "module \"edge\" {\n  source = \"git::https://github.com/sophium/erun.git//erun-devops/terraform-erun/modules/terraform-erun-cluster-edge?ref=v1.0.102\"\n}\n\nmodule \"own\" {\n  source = \"git::https://github.com/team/infra.git//modules/thing?ref=v9.9.9\"\n}\n")
 	write("team-api/Chart.yaml", "apiVersion: v2\nname: team-api\nversion: 0.1.0\ndependencies:\n  - name: erun-backend-api\n    repository: oci://ghcr.io/sophium/charts\n    version: 1.0.106\n  - name: team-internal\n    repository: oci://ghcr.io/team/charts\n    version: 3.2.1\n")
+}
+
+// seedUnreachableRuntimeRegistry points the root config's registry lookup at a
+// closed port, so version discovery is deterministic and offline. An
+// unreachable registry means "could not verify", which is what lets an
+// explicit target still pin.
+func seedUnreachableRuntimeRegistry(t *testing.T, rootConfigDir string) {
+	t.Helper()
+	rootConfigFile := filepath.Join(rootConfigDir, "config.yaml")
+	existing, err := os.ReadFile(rootConfigFile)
+	if err != nil || strings.Contains(string(existing), "runtimeregistry") {
+		return
+	}
+	if err := os.WriteFile(rootConfigFile, append(existing, []byte("runtimeregistry:\n  baseurl: http://127.0.0.1:1\n  tokenurl: http://127.0.0.1:1\n")...), 0o644); err != nil {
+		t.Fatalf("write root config: %v", err)
+	}
+}
+
+// seedDns01WebhookImageDrift writes the shape the reported issue hit: a
+// tenant's own terraform variables set the cluster-edge module's
+// dns01_webhook_image directly, pinned to an old erun release — the one
+// reference a repin left behind because nothing recognised it.
+func seedDns01WebhookImageDrift(t *testing.T, root, rootConfigDir string) {
+	t.Helper()
+	seedUnreachableRuntimeRegistry(t, rootConfigDir)
+	full := filepath.Join(root, "terraform-team", "prod", "prod.tfvars")
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := "dns01_webhook_image = \"ghcr.io/sophium/erun-dns01-webhook:1.0.102\"\n" +
+		"broker_url          = \"https://api.team-prod.services.example.com/v1/dns01\"\n"
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
 }
 
 func TestPin(t *testing.T) {
@@ -117,6 +143,41 @@ func TestPin(t *testing.T) {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
 		golden.Equal(t, "pin/skips_a_tenant_runtimeimage_tag_and_says_so", normalize.Apply(result.Combined))
+	})
+
+	// The reported gap: dns01_webhook_image, set directly in a tenant's own
+	// terraform variables, is an erun-published image reference just like the
+	// module ref above it, and pin's dry-run must name it as a site to move
+	// rather than reporting a plan that looks complete while leaving it behind.
+	t.Run("dry_run_reports_a_stale_dns01_webhook_image_reference", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		seedDns01WebhookImageDrift(t, setup.Cwd, filepath.Join(setup.ConfigHome, "erun"))
+
+		result := erun.Run(t, []string{"pin", "team", "dev", "--version", "1.0.175", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "pin/dry_run_reports_a_stale_dns01_webhook_image_reference", normalize.Apply(result.Combined))
+	})
+
+	// The real run must actually move it, not just name it.
+	t.Run("real_run_pins_the_dns01_webhook_image_reference", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		seedDns01WebhookImageDrift(t, setup.Cwd, filepath.Join(setup.ConfigHome, "erun"))
+
+		result := erun.Run(t, []string{"pin", "team", "dev", "--version", "1.0.175"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		tfvars := readPinnedFile(t, setup.Cwd, "terraform-team/prod/prod.tfvars")
+		if !strings.Contains(tfvars, "ghcr.io/sophium/erun-dns01-webhook:1.0.175") {
+			t.Fatalf("dns01_webhook_image not re-pinned:\n%s", tfvars)
+		}
+		if !strings.Contains(tfvars, `broker_url          = "https://api.team-prod.services.example.com/v1/dns01"`) {
+			t.Fatalf("an unrelated tfvars line was disturbed:\n%s", tfvars)
+		}
 	})
 
 	// Discovery answers "what can I pin to" from the registry, so choosing a

--- a/erun-integration/testdata/pin/dry_run_reports_a_stale_dns01_webhook_image_reference.txt
+++ b/erun-integration/testdata/pin/dry_run_reports_a_stale_dns01_webhook_image_reference.txt
@@ -1,0 +1,5 @@
+audit: erun pin --dry-run --version <VERSION> team dev
+could not read the published versions, so <VERSION> is pinned unverified: Get "http://<LOOPBACK>:1/token?service=ghcr.io&scope=repository:sophium/erun-devops:pull": dial tcp <LOOPBACK>:1: connect: connection refused
+pin team/dev -> <VERSION> (project root <TMP>
+  change runtime-version team/dev: <VERSION> -> <VERSION>
+  change image-reference terraform-team/prod/prod.tfvars (erun-dns01-webhook): <VERSION> -> <VERSION>

--- a/erun-integration/testdata/pin/help.txt
+++ b/erun-integration/testdata/pin/help.txt
@@ -1,4 +1,4 @@
-Re-pin every erun version reference for an environment: the Terraform module refs, each umbrella chart's erun dependencies, the build-env image tag, and the environment's own runtime version.
+Re-pin every erun version reference for an environment: the Terraform module refs, an erun image reference set directly in Terraform variables (e.g. the cluster-edge module's dns01_webhook_image), each umbrella chart's erun dependencies, the build-env image tag, and the environment's own runtime version.
 
 Idempotent, and a no-op once aligned. It rewrites the source of truth only — realizing the new version (terraform apply, deploy) stays a separate explicit step.
 

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -422,7 +422,7 @@ func registerDeliveryTools(reg toolRegistrar, runtime RuntimeConfig) {
 	}, unexposeTool(runtime))
 	addTool(reg, &mcp.Tool{
 		Name: "pin",
-		Description: "Re-pin every erun version reference for this environment in one motion: the Terraform module ?ref, each umbrella chart's erun chart dependencies, the build-env image tag, and the environment's own runtime version. " +
+		Description: "Re-pin every erun version reference for this environment in one motion: the Terraform module ?ref, an erun image reference set directly in Terraform variables (e.g. the cluster-edge module's dns01_webhook_image), each umbrella chart's erun chart dependencies, the build-env image tag, and the environment's own runtime version. " +
 			"They only work when they agree, and nothing else keeps them in step. Idempotent and a no-op once aligned. Refuses a version that is not published. Set revert to go back to the version recorded before the last re-pin. " +
 			"Set preview to return the full plan — every site, old and new — without writing. Edits the source of truth only: realizing the version (terraform apply, deploy) stays a separate explicit step.",
 	}, pinTool(runtime))

--- a/erun-skills/skills/erun-enable-hosting-edge/SKILL.md
+++ b/erun-skills/skills/erun-enable-hosting-edge/SKILL.md
@@ -139,9 +139,14 @@ terraform apply -input=false -auto-approve \
   -var "rfc2136_tsig_key_name=$KEYNAME" \
   -var install_dns01_webhook=true \
   -var "broker_url=https://api.<platform-tenant>-<platform-env>.services.<services-zone>/v1/dns01" \
-  -var "dns01_webhook_image=ghcr.io/sophium/erun-dns01-webhook:${version:-latest}" \
   -var per_env_certificate_enabled=true -var "env_label=<tenant>-<env>"
 ```
+
+`dns01_webhook_image` is left unset above on purpose: the module defaults it to
+`ghcr.io/sophium/erun-dns01-webhook` at the version its own bundled
+`chart-dns01-webhook/Chart.yaml` is released at, so the shim can never disagree
+with the module — no pin required. Pass `-var "dns01_webhook_image=..."` only to
+override that (e.g. to test a build ahead of a release).
 
 This keeps the platform's own wildcard on the proven RFC2136 path (see the TSIG
 setup above) while making the webhook shim available for every tenant's own
@@ -162,16 +167,16 @@ TOKEN=$(curl -fsS -X POST -H "Authorization: Bearer $ERUN_API_TOKEN" \
 kubectl -n "<tenant>-<env>" create secret generic "<tenant>-<env>-dns01-token" \
   --from-literal=token="$TOKEN" --dry-run=client -o yaml | kubectl apply -f -
 
-version=$(erun version --no-registry 2>/dev/null | head -n1 | awk '{print $2}')
 terraform apply -input=false -auto-approve \
   -var "services_zone=<services-zone>" -var "acme_email=<acme-email>" \
   -var dns01_provider=powerdns-broker \
   -var "broker_url=https://api.<platform-tenant>-<platform-env>.services.<services-zone>/v1/dns01" \
-  -var "dns01_webhook_image=ghcr.io/sophium/erun-dns01-webhook:${version:-latest}" \
   -var "dns01_token_secret_name=<tenant>-<env>-dns01-token" \
   -var per_env_certificate_enabled=true -var "env_label=<tenant>-<env>" \
   -var "env_namespace=<tenant>-<env>"
 ```
+
+As above, `dns01_webhook_image` is left to the module's own default.
 
 The webhook shim installs once per cluster; each tenant adds only its own Issuer +
 token Secret. Neither `cloudflare_api_token` nor the TSIG key is needed in either


### PR DESCRIPTION
## Summary

- `erun pin` re-pinned 12 references correctly but always left `dns01_webhook_image` in a tenant's `prod.tfvars` on the old version — the one reference nothing recognised, and the one that matters most: the DNS-01 webhook shim ships as one release with the `terraform-erun-cluster-edge` module, so a repin *creates* a module/shim version skew instead of preventing one. A stuck challenge from that skew looks identical to the shim never being installed (#1123), and can leave environments undeletable (#1122).
- **Chosen fix, direction 2 from the issue (module removes the need):** `terraform-erun-cluster-edge` bundles `chart-dns01-webhook`, whose `Chart.yaml` is already stamped to the erun release version at every release commit (confirmed via `git log` on that file — it moves in lockstep with every other chart, e.g. `erun-cluster-edge-issuer`). `main.tf` now reads that file's `appVersion` (`yamldecode(file("${path.module}/chart-dns01-webhook/Chart.yaml")).appVersion`) and defaults `dns01_webhook_image` to `ghcr.io/sophium/erun-dns01-webhook:<that version>` when the variable is left unset. This is the module's own equivalent of a Helm template's `.Chart.AppVersion` default (the pattern `erun-zitadel` already uses for its bootstrap image) — a terraform module can't interpolate its own `?ref=` into a variable, but it *can* read a file bundled inside itself, and that file is already release-stamped. The variable still exists purely as an override (e.g. to test a build ahead of a release); the `broker_url`-only precondition replaces the old `broker_url && dns01_webhook_image` one.
- **Direction 1 (the issue's "either way"), as the safety net:** `erun pin` now also recognises `ghcr.io/sophium/erun-*:<version>` image references inside a tenant's own `.tf`/`.tfvars` files (previously `.tfvars` wasn't even scanned), reported as a new `image-reference` pin site. This covers the case that still exists after the module fix: an existing tenant repo, or a deliberate override, that sets `dns01_webhook_image` explicitly. `erun pin --dry-run` no longer reports a plan that looks complete while leaving a stale erun image reference it can see.
- Updated the `erun-enable-hosting-edge` skill's documented `terraform apply` commands to stop passing `-var "dns01_webhook_image=..."` explicitly, since that's exactly what was seeding the stale reference into tenant tfvars in the first place (`install_dns01_webhook`, #1123, is what made a platform set this variable at all).
- Updated the CLI `Long:`, the MCP tool `Description:`, and the `pin --help` golden to name the new site kind, per the CLI/MCP help ground-truth rule.

## Pre-change failure (reproduced before the fix)

Terraform test, run against `main.tf` before the module change:

```
run "webhook_shim_image_defaults_to_the_bundled_charts_own_release"... fail
│ Error: Resource precondition failed
│
│   on main.tf line 157, in resource "helm_release" "dns01_webhook":
│  157:       condition     = var.broker_url != "" && var.dns01_webhook_image != ""
│     ├────────────────
│     │ var.broker_url is "https://api.frs-prod.services.example.com/v1/dns01"
│     │ var.dns01_webhook_image is ""
│
│ install_dns01_webhook requires broker_url and dns01_webhook_image.
```

`erun pin`'s Go side: the new `PinSiteImageReference`/`erunImageReferencePattern` test file did not compile against the pre-change `pin.go` (`undefined: PinSiteImageReference`) — because `.tfvars` files were not even in the scanned file list and no pattern recognised a registry-qualified erun image reference, so there was nothing to detect the exact reproduction from the issue (`grep -rn '1.0.196' frs-devops/` still finding `dns01_webhook_image` after a repin).

## Test plan

- [x] `terraform validate` + `terraform test` in `terraform-erun-cluster-edge` — 8/8 pass, including the new default-resolution test (fails pre-change as shown above, passes post-change)
- [x] `go test ./...` in `erun-common`, `erun-cli`, `erun-mcp` — all pass
- [x] `golangci-lint run ./...` in `erun-common`, `erun-cli`, `erun-mcp` — 0 issues
- [x] `make integration-test` from repo root — green, coverage 76.2% (>= 76.0% threshold, no threshold change needed)
- [x] New integration scenarios `pin/dry_run_reports_a_stale_dns01_webhook_image_reference` and `pin/real_run_pins_the_dns01_webhook_image_reference` reproduce the exact issue shape end-to-end through the compiled binary
- [x] `python3 -c "import json; json.load(open(...))"` on both `plugin.json` and `marketplace.json` — valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)