### PR TITLE
Add erun exec write and commit, typed alternatives to raw

### DIFF
--- a/erun-cli/cmd/exec.go
+++ b/erun-cli/cmd/exec.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 
 	common "github.com/sophium/erun/erun-common"
 	"github.com/spf13/cobra"
@@ -14,6 +15,8 @@ func newExecCmd(findProjectRoot common.ProjectFinderFunc, runGit common.GitComma
 		"Repository execution utilities",
 		newExecDiffCmd(findProjectRoot, runGit),
 		newExecRawCmd(findProjectRoot, runRaw),
+		newExecWriteCmd(findProjectRoot),
+		newExecCommitCmd(findProjectRoot),
 	)
 }
 
@@ -114,6 +117,97 @@ func extractDryRunFlag(args []string) ([]string, bool) {
 		}
 	}
 	return cleaned, dryRun
+}
+
+func newExecWriteCmd(findProjectRoot common.ProjectFinderFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "write PATH",
+		Short: "Write stdin to a file in the project working tree",
+		Long: "Write stdin to PATH inside the project working tree, byte-for-byte, creating parent directories as " +
+			"needed. Content never passes through a shell, so nothing in it is reinterpreted. The write is refused " +
+			"if PATH would resolve outside the project root.\n\n" +
+			"--dry-run resolves the path and reports the byte count it would write, without writing.",
+		Example:      "  erun exec write values.yaml < new-values.yaml\n  printf 'hello\\n' | erun exec write notes/todo.txt",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExecWriteCommand(commandContext(cmd), findProjectRoot, args[0])
+		},
+	}
+	addDryRunFlag(cmd)
+	return cmd
+}
+
+func runExecWriteCommand(ctx common.Context, findProjectRoot common.ProjectFinderFunc, path string) error {
+	if findProjectRoot == nil {
+		findProjectRoot = common.FindProjectRoot
+	}
+	_, projectRoot, err := findProjectRoot()
+	if err != nil {
+		return err
+	}
+	content, err := io.ReadAll(ctx.Stdin)
+	if err != nil {
+		return fmt.Errorf("read content from stdin: %w", err)
+	}
+	result, err := common.WriteWorkingTreeFile(ctx, projectRoot, common.WriteWorkingTreeFileParams{
+		Path:    path,
+		Content: string(content),
+	})
+	if err != nil {
+		return err
+	}
+	if ctx.DryRun {
+		return nil
+	}
+	ctx.Info(fmt.Sprintf("Wrote %s (%d bytes).", result.Path, result.Bytes))
+	return ctx.WriteResult(result)
+}
+
+func newExecCommitCmd(findProjectRoot common.ProjectFinderFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "commit BRANCH",
+		Short: "Commit every change in the project working tree",
+		Long: "Stage every change in the project working tree and commit it with a message read verbatim from " +
+			"stdin — never a shell, so nothing in the message is reinterpreted. BRANCH must match the working " +
+			"tree's actual current branch; the commit is refused, loudly, when it does not, rather than landing " +
+			"on whatever branch HEAD happens to be on.\n\n" +
+			"--dry-run verifies the branch and traces what would run, without staging or committing.",
+		Example:      "  echo 'fix the values typo' | erun exec commit main",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExecCommitCommand(commandContext(cmd), findProjectRoot, args[0])
+		},
+	}
+	addDryRunFlag(cmd)
+	return cmd
+}
+
+func runExecCommitCommand(ctx common.Context, findProjectRoot common.ProjectFinderFunc, branch string) error {
+	if findProjectRoot == nil {
+		findProjectRoot = common.FindProjectRoot
+	}
+	_, projectRoot, err := findProjectRoot()
+	if err != nil {
+		return err
+	}
+	message, err := io.ReadAll(ctx.Stdin)
+	if err != nil {
+		return fmt.Errorf("read commit message from stdin: %w", err)
+	}
+	result, err := common.CommitWorkingTree(ctx, projectRoot, common.CommitWorkingTreeParams{
+		Branch:  branch,
+		Message: string(message),
+	}, common.CommitWorkingTreeDependencies{})
+	if err != nil {
+		return err
+	}
+	if ctx.DryRun {
+		return nil
+	}
+	ctx.Info(fmt.Sprintf("Committed %d file(s) as %s on %s.", len(result.Files), result.Commit, result.Branch))
+	return ctx.WriteResult(result)
 }
 
 type execDiffOptions struct {

--- a/erun-common/exec_commit.go
+++ b/erun-common/exec_commit.go
@@ -1,0 +1,124 @@
+package eruncommon
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// CommitWorkingTreeParams names the commit an orchestrator intends: the
+// branch it believes the working tree is on, and the message to record.
+// Neither is defaulted or assumed — Branch is verified against the tree's
+// actual current branch before anything is staged.
+type CommitWorkingTreeParams struct {
+	Branch string
+	// Message is recorded verbatim as the commit message. It is data, not a
+	// shell fragment: nothing in it is interpreted, expanded, or executed.
+	Message string
+}
+
+// CommitWorkingTreeResult is what actually landed.
+type CommitWorkingTreeResult struct {
+	Branch string   `json:"branch"`
+	Commit string   `json:"commit"`
+	Files  []string `json:"files"`
+}
+
+// CommitWorkingTreeDependencies lets tests replace the git plumbing without a
+// real repository, mirroring the release flow's dependency-injection pattern.
+type CommitWorkingTreeDependencies struct {
+	CurrentBranch GitValueResolverFunc
+	CurrentCommit GitValueResolverFunc
+	RunGit        GitCommandRunnerFunc
+	StagedFiles   func(Context, string) ([]string, error)
+}
+
+func normalizeCommitWorkingTreeDependencies(deps CommitWorkingTreeDependencies) CommitWorkingTreeDependencies {
+	if deps.CurrentBranch == nil {
+		deps.CurrentBranch = GitCurrentBranch
+	}
+	if deps.CurrentCommit == nil {
+		deps.CurrentCommit = GitShortCommit
+	}
+	if deps.RunGit == nil {
+		deps.RunGit = GitCommandRunner
+	}
+	if deps.StagedFiles == nil {
+		deps.StagedFiles = gitStagedFiles
+	}
+	return deps
+}
+
+// CommitWorkingTree stages every change in root and commits it with Message.
+// Branch is verified against the tree's actual current branch, not assumed —
+// a mismatch is refused loudly before anything is staged, rather than landing
+// the commit on whichever branch HEAD happens to be on.
+func CommitWorkingTree(ctx Context, root string, params CommitWorkingTreeParams, deps CommitWorkingTreeDependencies) (CommitWorkingTreeResult, error) {
+	branch := strings.TrimSpace(params.Branch)
+	if branch == "" {
+		return CommitWorkingTreeResult{}, fmt.Errorf("branch is required")
+	}
+	if strings.TrimSpace(params.Message) == "" {
+		return CommitWorkingTreeResult{}, fmt.Errorf("message is required")
+	}
+	deps = normalizeCommitWorkingTreeDependencies(deps)
+
+	current, err := deps.CurrentBranch(ctx, root)
+	if err != nil {
+		return CommitWorkingTreeResult{}, fmt.Errorf("resolve current branch: %w", err)
+	}
+	if current != branch {
+		return CommitWorkingTreeResult{}, fmt.Errorf("refusing to commit: working tree is on branch %q, not the declared %q", current, branch)
+	}
+
+	ctx.TraceCommand(root, "git", "add", "-A")
+	ctx.TraceCommand(root, "git", "commit", "-m", "<message>")
+	if ctx.DryRun {
+		return CommitWorkingTreeResult{Branch: branch}, nil
+	}
+
+	return stageAndCommitWorkingTree(ctx, root, branch, params.Message, deps)
+}
+
+// stageAndCommitWorkingTree runs the mutating half of CommitWorkingTree,
+// isolated so the branch-verification and dry-run branching above it don't
+// inflate that function's complexity.
+func stageAndCommitWorkingTree(ctx Context, root, branch, message string, deps CommitWorkingTreeDependencies) (CommitWorkingTreeResult, error) {
+	if err := deps.RunGit(root, io.Discard, io.Discard, "add", "-A"); err != nil {
+		return CommitWorkingTreeResult{}, fmt.Errorf("git add -A: %w", err)
+	}
+
+	files, err := deps.StagedFiles(ctx, root)
+	if err != nil {
+		return CommitWorkingTreeResult{}, fmt.Errorf("resolve staged files: %w", err)
+	}
+	if len(files) == 0 {
+		return CommitWorkingTreeResult{}, fmt.Errorf("nothing to commit: the working tree has no changes")
+	}
+
+	if err := deps.RunGit(root, io.Discard, io.Discard, "commit", "-m", message); err != nil {
+		return CommitWorkingTreeResult{}, fmt.Errorf("git commit: %w", err)
+	}
+
+	commit, err := deps.CurrentCommit(ctx, root)
+	if err != nil {
+		return CommitWorkingTreeResult{}, fmt.Errorf("resolve new commit: %w", err)
+	}
+
+	return CommitWorkingTreeResult{Branch: branch, Commit: commit, Files: files}, nil
+}
+
+// gitStagedFiles lists what is about to be committed, read back after staging
+// rather than assumed, so Files always reflects what git actually staged.
+func gitStagedFiles(ctx Context, root string) ([]string, error) {
+	ctx.TraceCommand("", "git", "-C", root, "diff", "--cached", "--name-only")
+	output, err := Command("git", "-C", root, "diff", "--cached", "--name-only").Output()
+	if err != nil {
+		return nil, err
+	}
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Split(trimmed, "\n"), nil
+}

--- a/erun-common/exec_write.go
+++ b/erun-common/exec_write.go
@@ -1,0 +1,72 @@
+package eruncommon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// WriteWorkingTreeFileParams names the write explicitly: Path is never
+// defaulted, so content can never land somewhere the caller did not choose.
+type WriteWorkingTreeFileParams struct {
+	// Path is the destination, absolute or relative to the working tree root.
+	Path string
+	// Content is written verbatim. It is data, not a shell fragment: nothing
+	// in it is interpreted, expanded, or executed.
+	Content string
+}
+
+// WriteWorkingTreeFileResult is what the write actually did.
+type WriteWorkingTreeFileResult struct {
+	Path  string `json:"path"`
+	Bytes int64  `json:"bytes"`
+}
+
+// WriteWorkingTreeFile writes Content to Path inside root byte-for-byte — no
+// heredoc, no generated script, no shell anywhere in the path. The resolved
+// path is traced and the write is refused outright when it would land outside
+// root, so granting this operation can never become a path traversal into the
+// rest of the pod.
+func WriteWorkingTreeFile(ctx Context, root string, params WriteWorkingTreeFileParams) (WriteWorkingTreeFileResult, error) {
+	resolved, err := resolveWorkingTreePath(root, params.Path)
+	if err != nil {
+		return WriteWorkingTreeFileResult{}, err
+	}
+
+	content := []byte(params.Content)
+	ctx.TraceCommand("", "write-file", resolved)
+	if ctx.DryRun {
+		return WriteWorkingTreeFileResult{Path: resolved, Bytes: int64(len(content))}, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(resolved), 0o755); err != nil {
+		return WriteWorkingTreeFileResult{}, fmt.Errorf("write %q: %w", resolved, err)
+	}
+	if err := os.WriteFile(resolved, content, 0o644); err != nil {
+		return WriteWorkingTreeFileResult{}, fmt.Errorf("write %q: %w", resolved, err)
+	}
+	return WriteWorkingTreeFileResult{Path: resolved, Bytes: int64(len(content))}, nil
+}
+
+// resolveWorkingTreePath validates and resolves requested against root,
+// refusing anything that would land outside it — a "../" escape, an absolute
+// path elsewhere, or root itself (a directory, not a file to write).
+func resolveWorkingTreePath(root, requested string) (string, error) {
+	root = filepath.Clean(strings.TrimSpace(root))
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return "", fmt.Errorf("path is required")
+	}
+
+	resolved := filepath.Clean(requested)
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Clean(filepath.Join(root, resolved))
+	}
+
+	relative, err := filepath.Rel(root, resolved)
+	if err != nil || relative == "." || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q is outside the working tree %q", requested, root)
+	}
+	return resolved, nil
+}

--- a/erun-docs/docs/cli/exec.md
+++ b/erun-docs/docs/cli/exec.md
@@ -4,13 +4,15 @@ title: erun exec
 
 # `erun exec`
 
-Repository helpers that run from the project root. Two subcommands: `diff` (a structured git diff) and `raw` (run an arbitrary command).
+Repository helpers that run from the project root. Four subcommands: `diff` (a structured git diff), `raw` (run an arbitrary command), `write` (write file content), and `commit` (commit every change).
 
 ## Synopsis
 
 ```
 erun exec diff [flags]
 erun exec raw COMMAND [ARG...] [flags]
+erun exec write PATH [flags]
+erun exec commit BRANCH [flags]
 ```
 
 ## Subcommands
@@ -29,12 +31,22 @@ Shows the current git diff, including untracked files. Outputs raw diff text by 
 
 Runs an arbitrary command from the project root. The command runs **directly, not through a shell** — wrap it in `sh -c "…"` if you need shell features. `--dry-run` traces the command (with secret-looking arguments redacted) without running it. Use `--` to pass flags through to the wrapped command rather than to `erun`.
 
+### `exec write`
+
+Writes stdin to PATH inside the project working tree, byte-for-byte, creating parent directories as needed. Content is read from stdin, never a flag value, so nothing in it is ever composed into a shell command — a backtick, a `$(...)`, or a trailing newline in the content lands exactly as given. The write is refused if PATH would resolve outside the project root. `--dry-run` resolves the path and traces the write without performing it. Reports the resolved path and byte count written; add `--output json` for a structured result.
+
+### `exec commit`
+
+Stages every change in the project working tree (`git add -A`) and commits it with a message read verbatim from stdin — same shell-avoidance property as `write`. BRANCH must match the working tree's actual current branch: the commit is **refused, loudly**, when it does not, rather than landing on whatever branch HEAD happens to be on. `--dry-run` verifies the branch and traces what would run without staging or committing. Reports the branch, commit id, and files committed; add `--output json` for a structured result.
+
 ## Examples
 
 ```bash
 erun exec diff --scope all
 erun exec raw go test ./...
 erun exec raw --dry-run -- kubectl get pods --all-namespaces
+erun exec write values.yaml < new-values.yaml
+echo 'fix the values typo' | erun exec commit main
 ```
 
 ## Error behaviour
@@ -44,3 +56,6 @@ erun exec raw --dry-run -- kubectl get pods --all-namespaces
 | Not inside a git project. | Errors with "cannot find git project"; nothing runs. |
 | `--selected-commit` without `--scope=commit`. | Errors before running git. |
 | Wrapped command exits non-zero (`raw`). | Its exit code and stderr propagate; `erun` adds nothing. |
+| PATH resolves outside the project root (`write`). | Refuses with `path "..." is outside the working tree "..."`; nothing is written. |
+| BRANCH does not match the current branch (`commit`). | Refuses with `refusing to commit: working tree is on branch "X", not the declared "Y"`; nothing is staged. |
+| Nothing changed to commit (`commit`). | Refuses with `nothing to commit: the working tree has no changes`. |

--- a/erun-docs/docs/cli/overview.md
+++ b/erun-docs/docs/cli/overview.md
@@ -44,7 +44,7 @@ The `build → release → push → deploy` commands form ERun's delivery pipeli
 | [`erun mcp`](/cli/mcp) | Run the MCP server for Agents (launches `emcp`); `call` / `tools` / `token` reach an env's MCP edge. |
 | [`erun api`](/cli/api) | Run the backend API server (launches `eapi`). |
 | [`erun app`](/cli/app) | Launch the desktop app. |
-| [`erun exec`](/cli/exec) | Run repository helpers — `diff`, `raw`. |
+| [`erun exec`](/cli/exec) | Run repository helpers — `diff`, `raw`, `write`, `commit`. |
 | [`erun contribute`](/cli/contribute) | Contribute-mode helpers — clone the ERun repo locally. |
 
 ## Dry-run and verbosity

--- a/erun-docs/docs/mcp/overview.md
+++ b/erun-docs/docs/mcp/overview.md
@@ -213,6 +213,17 @@ Two things follow with no change to any other tool's contract:
 
 `cloud_inject_aws_credentials` takes the access key, secret, and session token as **tool arguments**, so **do not call it from anything that records its arguments** — an Agent transcript, a session log, an audit trail. It exists for the desktop app's credential refresher, which holds the values in memory. Everything else refreshes an environment's host credentials with [`erun cloud refresh <tenant> <environment>`](/cli/cloud#cloud-refresh), which reads the operator's own AWS profile and streams the credentials to the pod on stdin, so nothing sensitive passes through the caller.
 
+### Working tree — typed mutations, no shell
+
+The two mutations an orchestrator performs constantly on an environment's own repository — writing file content and committing — used to have no name of their own: doing either through `raw` meant composing a heredoc or a `python3 -` script and passing it through a shell, so a backtick or a `$(...)` in the content changed the meaning of the command. Neither tool below ever interprets its payload as a shell fragment.
+
+| Tool | Purpose |
+|---|---|
+| `write` | Write `content` to `path` in the runtime repo's working tree, byte-for-byte. `content` is a JSON string field, never composed into a command line, so it round-trips verbatim regardless of what it contains. Refuses if `path` would resolve outside the repo root. Reports the resolved path and byte count written. Set `preview` to trace the write without performing it. |
+| `commit` | Stage every change in the runtime repo's working tree (`git add -A`) and commit it with `message`, taken the same way as `write`'s content. `branch` is the caller's claim about the current branch, verified against `git rev-parse --abbrev-ref HEAD` rather than assumed — a mismatch is refused, loudly, instead of landing the commit on whichever branch HEAD happens to be on. Reports the branch, commit id, and files committed. Set `preview` to verify the branch and trace what would be committed without committing. |
+
+Same command as [`erun exec write`](/cli/exec#exec-write) / [`erun exec commit`](/cli/exec#exec-commit).
+
 ### Escape hatch
 
 | Tool | Purpose |
@@ -221,7 +232,7 @@ Two things follow with no change to any other tool's contract:
 
 ### Tool selection rule
 
-In order of preference: **inspection > action > jobs > raw.**
+In order of preference: **inspection > action > working tree > jobs > raw.**
 
 - If a question is "what's the state of X" — reach for an inspection tool.
 - If you're invoking a known CLI command — reach for the action wrapper, not `raw`.

--- a/erun-integration/exec_test.go
+++ b/erun-integration/exec_test.go
@@ -37,6 +37,13 @@ func captureGit(t testing.TB, dir string, args ...string) string {
 	return string(out)
 }
 
+// execDangerousContent carries the constructs a shell would reinterpret —
+// backticks, command substitution, embedded quotes, a trailing newline — so a
+// round trip through `exec write` / `exec commit` demonstrates the property
+// that justifies bypassing raw for these two operations: content and message
+// travel as data and are never shell-parsed.
+const execDangerousContent = "line one\n`echo pwned` $(echo pwned) \"quoted\" 'quoted'\ntrailing\n\n"
+
 func TestExec(t *testing.T) {
 	t.Run("help", func(t *testing.T) {
 		setup := env.New(t)
@@ -360,5 +367,155 @@ func TestExec(t *testing.T) {
 			t.Fatalf("expected non-zero exit (no git project), got 0:\n%s", result.Combined)
 		}
 		golden.Equal(t, "exec/dry_run_with_time_flag_prints_elapsed_on_error", normalize.Apply(result.Combined))
+	})
+
+	t.Run("write_help", func(t *testing.T) {
+		setup := env.New(t)
+		result := erun.Run(t, []string{"exec", "write", "--help"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "exec/write_help", normalize.Apply(result.Combined))
+	})
+
+	t.Run("write_dry_run_traces_resolved_path", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedGitRepo(t, setup.Cwd)
+		result := erun.Run(t, []string{"exec", "write", "config/values.yaml", "--dry-run"}, erun.RunOptions{
+			Cwd:   setup.Cwd,
+			Env:   setup.Env(),
+			Stdin: "hello\n",
+		})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "exec/write_dry_run_traces_resolved_path", normalize.Apply(result.Combined))
+		if _, err := os.Stat(filepath.Join(setup.Cwd, "config", "values.yaml")); !os.IsNotExist(err) {
+			t.Fatalf("dry-run must not write anything")
+		}
+	})
+
+	t.Run("write_dry_run_errors_outside_git_project", func(t *testing.T) {
+		setup := env.New(t)
+		result := erun.Run(t, []string{"exec", "write", "foo.txt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: "x"})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit outside a git project, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "exec/write_dry_run_errors_outside_git_project", normalize.Apply(result.Combined))
+	})
+
+	t.Run("write_refuses_path_outside_project_root", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedGitRepo(t, setup.Cwd)
+		result := erun.Run(t, []string{"exec", "write", "../escape.txt"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: "x"})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit for a path outside the project root, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "exec/write_refuses_path_outside_project_root", normalize.Apply(result.Combined))
+		if _, err := os.Stat(filepath.Join(filepath.Dir(setup.Cwd), "escape.txt")); !os.IsNotExist(err) {
+			t.Fatalf("expected no file to land outside the project root")
+		}
+	})
+
+	t.Run("write_content_round_trips_byte_identical_with_dangerous_shell_constructs", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedGitRepo(t, setup.Cwd)
+		result := erun.Run(t, []string{"exec", "write", "notes/todo.txt"}, erun.RunOptions{
+			Cwd:   setup.Cwd,
+			Env:   setup.Env(),
+			Stdin: execDangerousContent,
+		})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		got, err := os.ReadFile(filepath.Join(setup.Cwd, "notes", "todo.txt"))
+		if err != nil {
+			t.Fatalf("read written file: %v", err)
+		}
+		if string(got) != execDangerousContent {
+			t.Fatalf("written content = %q, want byte-identical %q", got, execDangerousContent)
+		}
+	})
+
+	t.Run("commit_help", func(t *testing.T) {
+		setup := env.New(t)
+		result := erun.Run(t, []string{"exec", "commit", "--help"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "exec/commit_help", normalize.Apply(result.Combined))
+	})
+
+	t.Run("commit_dry_run_verifies_branch_and_traces", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedGitRepo(t, setup.Cwd)
+		result := erun.Run(t, []string{"exec", "commit", "main", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: "fix the values typo\n"})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "exec/commit_dry_run_verifies_branch_and_traces", normalize.Apply(result.Combined))
+		if log := captureGit(t, setup.Cwd, "log", "--oneline"); strings.Count(strings.TrimSpace(log), "\n") != 0 {
+			t.Fatalf("dry-run must not commit anything, got log: %q", log)
+		}
+	})
+
+	t.Run("commit_dry_run_refuses_branch_mismatch", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedGitRepo(t, setup.Cwd)
+		result := erun.Run(t, []string{"exec", "commit", "not-main", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: "message\n"})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit for a branch mismatch under --dry-run, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "exec/commit_dry_run_refuses_branch_mismatch", normalize.Apply(result.Combined))
+	})
+
+	t.Run("commit_refuses_branch_mismatch", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedGitRepo(t, setup.Cwd)
+		result := erun.Run(t, []string{"exec", "commit", "not-main"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: "message\n"})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit for a branch mismatch, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "exec/commit_refuses_branch_mismatch", normalize.Apply(result.Combined))
+		if log := captureGit(t, setup.Cwd, "log", "--oneline"); strings.Count(strings.TrimSpace(log), "\n") != 0 {
+			t.Fatalf("expected no new commit after refusal, got log: %q", log)
+		}
+	})
+
+	t.Run("commit_commits_dangerous_message_and_reports_result", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedGitRepo(t, setup.Cwd)
+		mustWriteFile(t, filepath.Join(setup.Cwd, "values.yaml"), "typo: fixed\n")
+		result := erun.Run(t, []string{"exec", "commit", "main", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: execDangerousContent})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		var parsed common.CommitWorkingTreeResult
+		if err := json.Unmarshal([]byte(result.Stdout), &parsed); err != nil {
+			t.Fatalf("decode --output json: %v\n%s", err, result.Stdout)
+		}
+		if parsed.Branch != "main" || parsed.Commit == "" {
+			t.Fatalf("unexpected result: %+v", parsed)
+		}
+		if len(parsed.Files) != 1 || parsed.Files[0] != "values.yaml" {
+			t.Fatalf("expected committed files [values.yaml], got %+v", parsed.Files)
+		}
+		message := captureGit(t, setup.Cwd, "log", "-1", "--format=%B")
+		if !strings.Contains(message, "`echo pwned` $(echo pwned) \"quoted\" 'quoted'") {
+			t.Fatalf("commit message lost dangerous content verbatim: %q", message)
+		}
+		if status := captureGit(t, setup.Cwd, "status", "--porcelain"); strings.TrimSpace(status) != "" {
+			t.Fatalf("expected clean tree after commit, got: %q", status)
+		}
+	})
+
+	t.Run("commit_refuses_when_nothing_to_commit", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedGitRepo(t, setup.Cwd)
+		result := erun.Run(t, []string{"exec", "commit", "main"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: "message\n"})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit for nothing to commit, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "exec/commit_refuses_when_nothing_to_commit", normalize.Apply(result.Combined))
 	})
 }

--- a/erun-integration/testdata/exec/commit_dry_run_refuses_branch_mismatch.txt
+++ b/erun-integration/testdata/exec/commit_dry_run_refuses_branch_mismatch.txt
@@ -1,0 +1,3 @@
+audit: erun exec commit --dry-run not-main
+git -C <TMP> rev-parse --abbrev-ref HEAD
+refusing to commit: working tree is on branch "main", not the declared "not-main"

--- a/erun-integration/testdata/exec/commit_dry_run_verifies_branch_and_traces.txt
+++ b/erun-integration/testdata/exec/commit_dry_run_verifies_branch_and_traces.txt
@@ -1,0 +1,4 @@
+audit: erun exec commit --dry-run main
+git -C <TMP> rev-parse --abbrev-ref HEAD
+cd <TMP> && git add -A
+cd <TMP> && git commit -m '<message>'

--- a/erun-integration/testdata/exec/commit_help.txt
+++ b/erun-integration/testdata/exec/commit_help.txt
@@ -1,0 +1,18 @@
+Stage every change in the project working tree and commit it with a message read verbatim from stdin — never a shell, so nothing in the message is reinterpreted. BRANCH must match the working tree's actual current branch; the commit is refused, loudly, when it does not, rather than landing on whatever branch HEAD happens to be on.
+
+--dry-run verifies the branch and traces what would run, without staging or committing.
+
+Usage:
+  erun exec commit BRANCH [flags]
+
+Examples:
+  echo 'fix the values typo' | erun exec commit main
+
+Flags:
+      --dry-run   Resolve and trace mutating actions without executing them.
+  -h, --help      help for commit
+
+Global Flags:
+      --output string   Result format: text (default, human stream) or json (structured result on stdout for orchestrators). (default "text")
+      --time            Print the elapsed runtime after the command finishes.
+  -v, --verbose count   Increase verbosity: -v streams external tool output, -vv adds erun command traces.

--- a/erun-integration/testdata/exec/commit_refuses_branch_mismatch.txt
+++ b/erun-integration/testdata/exec/commit_refuses_branch_mismatch.txt
@@ -1,0 +1,2 @@
+audit: erun exec commit not-main
+refusing to commit: working tree is on branch "main", not the declared "not-main"

--- a/erun-integration/testdata/exec/commit_refuses_when_nothing_to_commit.txt
+++ b/erun-integration/testdata/exec/commit_refuses_when_nothing_to_commit.txt
@@ -1,0 +1,2 @@
+audit: erun exec commit main
+nothing to commit: the working tree has no changes

--- a/erun-integration/testdata/exec/help.txt
+++ b/erun-integration/testdata/exec/help.txt
@@ -4,8 +4,10 @@ Usage:
   erun exec [command]
 
 Available Commands:
+  commit      Commit every change in the project working tree
   diff        Show the current git diff
   raw         Run a raw command from the project root
+  write       Write stdin to a file in the project working tree
 
 Flags:
   -h, --help   help for exec

--- a/erun-integration/testdata/exec/write_dry_run_errors_outside_git_project.txt
+++ b/erun-integration/testdata/exec/write_dry_run_errors_outside_git_project.txt
@@ -1,0 +1,2 @@
+audit: erun exec write --dry-run foo.txt
+cannot find git project

--- a/erun-integration/testdata/exec/write_dry_run_traces_resolved_path.txt
+++ b/erun-integration/testdata/exec/write_dry_run_traces_resolved_path.txt
@@ -1,0 +1,2 @@
+audit: erun exec write --dry-run config/values.yaml
+write-file <TMP>

--- a/erun-integration/testdata/exec/write_help.txt
+++ b/erun-integration/testdata/exec/write_help.txt
@@ -1,0 +1,19 @@
+Write stdin to PATH inside the project working tree, byte-for-byte, creating parent directories as needed. Content never passes through a shell, so nothing in it is reinterpreted. The write is refused if PATH would resolve outside the project root.
+
+--dry-run resolves the path and reports the byte count it would write, without writing.
+
+Usage:
+  erun exec write PATH [flags]
+
+Examples:
+  erun exec write values.yaml < new-values.yaml
+  printf 'hello\n' | erun exec write notes/todo.txt
+
+Flags:
+      --dry-run   Resolve and trace mutating actions without executing them.
+  -h, --help      help for write
+
+Global Flags:
+      --output string   Result format: text (default, human stream) or json (structured result on stdout for orchestrators). (default "text")
+      --time            Print the elapsed runtime after the command finishes.
+  -v, --verbose count   Increase verbosity: -v streams external tool output, -vv adds erun command traces.

--- a/erun-integration/testdata/exec/write_refuses_path_outside_project_root.txt
+++ b/erun-integration/testdata/exec/write_refuses_path_outside_project_root.txt
@@ -1,0 +1,2 @@
+audit: erun exec write ../escape.txt
+path "../escape.txt" is outside the working tree "<TMP>"

--- a/erun-mcp/capabilities_test.go
+++ b/erun-mcp/capabilities_test.go
@@ -81,7 +81,7 @@ func TestReadCapabilitySeesOnlyTheReadTools(t *testing.T) {
 func TestReadCapabilityCannotSeeExecutionOrMutation(t *testing.T) {
 	got := listToolNames(t, connectWithCapabilities(t, string(eruncommon.MCPCapabilityRead)))
 
-	for _, forbidden := range []string{"raw", "deploy", "delete", "build", "push", "release", "context_init", "job_start"} {
+	for _, forbidden := range []string{"raw", "write", "commit", "deploy", "delete", "build", "push", "release", "context_init", "job_start"} {
 		if slices.Contains(got, forbidden) {
 			t.Fatalf("a read-only caller must not be offered %q: %v", forbidden, got)
 		}

--- a/erun-mcp/exec_commit.go
+++ b/erun-mcp/exec_commit.go
@@ -1,0 +1,38 @@
+package erunmcp
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// CommitInput takes the commit message as data — never a shell — and the
+// branch as an explicit claim to verify, mirroring `erun exec commit`.
+type CommitInput struct {
+	Branch    string `json:"branch" jsonschema:"branch the caller believes the working tree is on; verified against the actual current branch and refused, loudly, on mismatch"`
+	Message   string `json:"message" jsonschema:"commit message, recorded verbatim; never shell-interpreted"`
+	Preview   bool   `json:"preview,omitempty" jsonschema:"when true, verify the branch and trace what would be committed without staging or committing"`
+	Verbosity int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+}
+
+func commitTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, CommitInput) (*mcp.CallToolResult, CommandOutput, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input CommitInput) (*mcp.CallToolResult, CommandOutput, error) {
+		var committed *eruncommon.CommitWorkingTreeResult
+		output, err := runRuntimeCommand(runtime, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, workDir string) error {
+			result, err := eruncommon.CommitWorkingTree(runCtx, workDir, eruncommon.CommitWorkingTreeParams{
+				Branch:  input.Branch,
+				Message: input.Message,
+			}, eruncommon.CommitWorkingTreeDependencies{})
+			if err != nil {
+				return err
+			}
+			committed = &result
+			return nil
+		})
+		if err == nil && committed != nil {
+			output.Commit = committed
+		}
+		return nil, output, err
+	}
+}

--- a/erun-mcp/exec_write.go
+++ b/erun-mcp/exec_write.go
@@ -1,0 +1,38 @@
+package erunmcp
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// WriteInput takes file content as data — never a shell — mirroring `erun
+// exec write`.
+type WriteInput struct {
+	Path      string `json:"path" jsonschema:"destination path inside the runtime repo root, absolute or relative; refused if it would resolve outside the repo root"`
+	Content   string `json:"content" jsonschema:"file content, written verbatim byte-for-byte; never shell-interpreted"`
+	Preview   bool   `json:"preview,omitempty" jsonschema:"when true, resolve and trace the write without performing it"`
+	Verbosity int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
+}
+
+func writeTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, WriteInput) (*mcp.CallToolResult, CommandOutput, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input WriteInput) (*mcp.CallToolResult, CommandOutput, error) {
+		var written *eruncommon.WriteWorkingTreeFileResult
+		output, err := runRuntimeCommand(runtime, input.Preview, input.Verbosity, func(runCtx eruncommon.Context, workDir string) error {
+			result, err := eruncommon.WriteWorkingTreeFile(runCtx, workDir, eruncommon.WriteWorkingTreeFileParams{
+				Path:    input.Path,
+				Content: input.Content,
+			})
+			if err != nil {
+				return err
+			}
+			written = &result
+			return nil
+		})
+		if err == nil && written != nil {
+			output.Write = written
+		}
+		return nil, output, err
+	}
+}

--- a/erun-mcp/runtime.go
+++ b/erun-mcp/runtime.go
@@ -52,6 +52,10 @@ type CommandOutput struct {
 	// Pin carries the resolved re-pin plan so a caller sees every reference that
 	// moved without diffing the tree afterwards.
 	Pin *PinOutput `json:"pin,omitempty"`
+	// Write carries what a `write` call actually wrote.
+	Write *eruncommon.WriteWorkingTreeFileResult `json:"write,omitempty"`
+	// Commit carries what a `commit` call actually committed.
+	Commit *eruncommon.CommitWorkingTreeResult `json:"commit,omitempty"`
 }
 
 var ansiRegexp = regexp.MustCompile(`\x1b\[[0-9;]*m`)

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -442,6 +442,14 @@ func registerInspectionTools(reg toolRegistrar, runtime RuntimeConfig) {
 		Description: "Run an arbitrary command from the runtime repo root and return captured stdout, stderr, and trace output",
 	}, rawTool(runtime))
 	addTool(reg, &mcp.Tool{
+		Name:        "write",
+		Description: "Write content to a path in the runtime repo's working tree, taking the content as data — never through a shell, so nothing in it is reinterpreted. Refuses if the resolved path would land outside the repo root. Reports the resolved path and byte count written. Set preview to trace the write without performing it.",
+	}, writeTool(runtime))
+	addTool(reg, &mcp.Tool{
+		Name:        "commit",
+		Description: "Stage every change in the runtime repo's working tree and commit it with a message taken as data — never through a shell. branch must match the tree's actual current branch; the commit is refused, loudly, when it does not, rather than landing on whichever branch HEAD happens to be on. Reports the branch, commit id, and files committed. Set preview to verify the branch and trace what would be committed without committing.",
+	}, commitTool(runtime))
+	addTool(reg, &mcp.Tool{
 		Name:        "outputs_list",
 		Description: "List the files and folders an agent produced in the runtime pod's outputs directory ($ERUN_OUTPUTS_DIR, default /home/erun/.erun/outputs), newest-first. Read-only.",
 	}, outputsListTool())

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/adrg/xdg"
@@ -158,6 +159,7 @@ var wantRegisteredTools = []string{
 	"cloud_login",
 	"cloud_oidc",
 	"cloud_set",
+	"commit",
 	"context_init",
 	"context_list",
 	"context_start",
@@ -207,6 +209,7 @@ var wantRegisteredTools = []string{
 	"unexpose",
 	"upgrade",
 	"version",
+	"write",
 }
 
 func TestHTTPHandlerExposesVersionTool(t *testing.T) {
@@ -435,6 +438,99 @@ func assertStructuredDiffOutput(t *testing.T, output eruncommon.DiffResult, proj
 	}
 	if len(output.Tree) != 1 || output.Tree[0].Name != "app.txt" {
 		t.Fatalf("unexpected tree: %+v", output.Tree)
+	}
+}
+
+// dangerousExecContent carries the constructs a shell would reinterpret —
+// backticks, command substitution, embedded quotes, a trailing newline — so a
+// round trip through write/commit demonstrates the property that justifies
+// bypassing raw for these two operations: nothing here is ever shell-parsed.
+const dangerousExecContent = "line one\n`echo pwned` $(echo pwned) \"quoted\" 'quoted'\ntrailing\n\n"
+
+func TestWriteToolWritesContentByteIdenticallyAndRefusesOutsideRoot(t *testing.T) {
+	projectRoot := t.TempDir()
+
+	handler := writeTool(normalizeRuntimeConfig(RuntimeConfig{
+		Context: RuntimeContext{RepoPath: projectRoot},
+	}))
+	_, output, err := handler(context.Background(), nil, WriteInput{Path: "config/values.yaml", Content: dangerousExecContent})
+	if err != nil {
+		t.Fatalf("writeTool failed: %v", err)
+	}
+	if output.Write == nil {
+		t.Fatalf("expected Write result, got %+v", output)
+	}
+	wantPath := filepath.Join(projectRoot, "config", "values.yaml")
+	if output.Write.Path != wantPath {
+		t.Fatalf("Path = %q, want %q", output.Write.Path, wantPath)
+	}
+	if output.Write.Bytes != int64(len(dangerousExecContent)) {
+		t.Fatalf("Bytes = %d, want %d", output.Write.Bytes, len(dangerousExecContent))
+	}
+	got, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if string(got) != dangerousExecContent {
+		t.Fatalf("written content = %q, want byte-identical %q", got, dangerousExecContent)
+	}
+
+	_, _, err = handler(context.Background(), nil, WriteInput{Path: "../escape.txt", Content: "x"})
+	if err == nil {
+		t.Fatalf("expected refusal for a path outside the repo root")
+	}
+	if _, statErr := os.Stat(filepath.Join(filepath.Dir(projectRoot), "escape.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no file to land outside the repo root")
+	}
+}
+
+func TestCommitToolCommitsAndRefusesBranchMismatch(t *testing.T) {
+	projectRoot := t.TempDir()
+	runGitTestCommand(t, projectRoot, "init", "-b", "main")
+	runGitTestCommand(t, projectRoot, "config", "user.email", "codex@example.com")
+	runGitTestCommand(t, projectRoot, "config", "user.name", "Codex")
+	runGitTestCommand(t, projectRoot, "commit", "--allow-empty", "-m", "initial")
+	if err := os.WriteFile(filepath.Join(projectRoot, "app.txt"), []byte("new\n"), 0o644); err != nil {
+		t.Fatalf("write app.txt: %v", err)
+	}
+
+	handler := commitTool(normalizeRuntimeConfig(RuntimeConfig{
+		Context: RuntimeContext{RepoPath: projectRoot},
+	}))
+
+	_, _, err := handler(context.Background(), nil, CommitInput{Branch: "not-main", Message: dangerousExecContent})
+	if err == nil {
+		t.Fatalf("expected refusal when the declared branch does not match the current branch")
+	}
+
+	_, output, err := handler(context.Background(), nil, CommitInput{Branch: "main", Message: dangerousExecContent})
+	if err != nil {
+		t.Fatalf("commitTool failed: %v", err)
+	}
+	assertCommitToolOutput(t, output, projectRoot)
+}
+
+func assertCommitToolOutput(t *testing.T, output CommandOutput, projectRoot string) {
+	t.Helper()
+
+	if output.Commit == nil {
+		t.Fatalf("expected Commit result, got %+v", output)
+	}
+	if output.Commit.Branch != "main" || output.Commit.Commit == "" {
+		t.Fatalf("unexpected commit result: %+v", output.Commit)
+	}
+	if len(output.Commit.Files) != 1 || output.Commit.Files[0] != "app.txt" {
+		t.Fatalf("unexpected committed files: %+v", output.Commit.Files)
+	}
+
+	messageCmd := exec.Command("git", "log", "-1", "--format=%B")
+	messageCmd.Dir = projectRoot
+	messageOut, err := messageCmd.Output()
+	if err != nil {
+		t.Fatalf("read commit message: %v", err)
+	}
+	if !strings.Contains(string(messageOut), "`echo pwned` $(echo pwned) \"quoted\" 'quoted'") {
+		t.Fatalf("commit message lost dangerous content verbatim: %q", messageOut)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two new typed commands for the mutations an orchestrator performs constantly in an environment — writing file content and committing — available over shared `erun-common` logic in both transports: `erun exec write` / `erun exec commit` (CLI) and the `write` / `commit` MCP tools.

- **`write`** (`erun-common/exec_write.go`, `WriteWorkingTreeFile`): writes content to a path inside the project working tree, byte-for-byte. Content arrives as data — CLI reads it from stdin, MCP takes it as a JSON string field — never composed into a command line, so nothing in it is ever shell-interpreted. The resolved path is traced (`write-file <path>`); a write that would resolve outside the working tree is refused (`path "..." is outside the working tree "..."`) before anything touches disk. Reports the resolved path and byte count written.
- **`commit`** (`erun-common/exec_commit.go`, `CommitWorkingTree`): stages every change (`git add -A`) and commits with a message taken the same way — data, never shell-interpreted. The caller states the branch it believes HEAD is on; that claim is verified against `git rev-parse --abbrev-ref HEAD` rather than assumed, and a mismatch is refused loudly (`refusing to commit: working tree is on branch "X", not the declared "Y"`) — including under `--dry-run`/`preview`, since this check is a correctness property of the operation, not something a preview should skip past. Refuses just as clearly when there is nothing to commit. Reports the branch, the commit id, and the files committed, read back from git after committing rather than assumed.

### Why no append/patch mode

Considered and rejected. A write-whole-file primitive plus the existing `diff`/`raw`/`observe` for reading state is simpler to reason about than a diff applier, and matches the one motivating case in the issue (fixing a typo in a values file) — the caller reads what it needs, then writes the whole new content back.

### What makes "no shell in the path" structurally true, not just intended

- Both CLI and MCP invoke `os.WriteFile` / `exec.Command("git", "add"/"commit", ...)` directly — Go's `os/exec` passes each argv element to the kernel via `execve` untouched; there is no `sh -c` anywhere in either path, so a value can't be reinterpreted by a shell that was never invoked.
- The CLI reads content/message from **stdin**, not a flag, so the operator's own shell never has to embed dangerous bytes into a command line to invoke the CLI. MCP takes them as JSON string fields over JSON-RPC — again no shell involved end to end.
- `commit`'s message goes to `git commit -m <message>` as a single argv element (not `-F -` via a piped script), so there is no intermediate stdin-writing shell step for git either.
- The write path's outside-root refusal is a plain `filepath.Rel` containment check (same technique as `deployContextOwnsDockerBuild` in `erun-common/deploy.go`) — no `raw`/`sh -c`/arbitrary-argv anywhere in either new command, so neither can be coerced into running something other than "write this file" / "commit this message".

## Both transports

- CLI: `erun exec write PATH` / `erun exec commit BRANCH`, alongside the existing `exec diff` / `exec raw` (same project-root resolution, same `--dry-run` contract).
- MCP: `write` / `commit` tools registered next to `raw`/`diff` in `erun-mcp/server.go`, wrapping the same `erun-common` functions via `runRuntimeCommand` (the same helper `pin`/`build`/etc. use for preview + trace capture).
- Both required no exception — this is the ordinary case, not the AWS-credentials-style structural exception.

## Docs

- `erun-docs/docs/cli/exec.md`: new `exec write` / `exec commit` subsections, synopsis, examples, error-behaviour rows.
- `erun-docs/docs/cli/overview.md`: updated the one-line `erun exec` summary.
- `erun-docs/docs/mcp/overview.md`: new "Working tree — typed mutations, no shell" section, and the tool-selection-rule line updated to include it.
- `yarn build` and `yarn typecheck` both clean (confirms the new `/cli/exec#exec-write` / `#exec-commit` anchors resolve).

## Tests and pre-change failures

- `erun-common`: verified interactively against a real temp git repo (byte-identical write of content with backticks/`$(...)`/quotes/trailing newline; outside-root refusal; branch-mismatch refusal; successful commit reporting branch/commit/files) before writing the permanent tests below.
- `erun-mcp/server_test.go`: `TestWriteToolWritesContentByteIdenticallyAndRefusesOutsideRoot`, `TestCommitToolCommitsAndRefusesBranchMismatch` — call the tool handlers directly against a real repo (`os/exec` git, no stub). Updated `wantRegisteredTools` (added `commit`, `write`) and `capabilities_test.go`'s read-capability-forbidden list.
- `erun-integration/exec_test.go`: 11 new scenarios under `TestExec` — help text for both, dry-run tracing (including that the branch check still refuses under `--dry-run`), outside-git-project error, path-escape refusal, the byte-identical dangerous-content round trip, branch-mismatch refusal (dry-run and real), a successful commit verified via `--output json` + a real `git log`/`git status` read-back, and refusal when there's nothing to commit.
- **Pre-change failures** (confirmed by stashing the new code and rebuilding): `erun exec write --help` / `erun exec commit --help` printed the `exec` group's own help with exit 0 (the subcommands don't exist), and `printf 'hi' | erun-prechange exec write foo.txt --dry-run` failed with `unknown flag: --dry-run`. Every new integration scenario that invokes `exec write`/`exec commit` fails the same way pre-change; `exec/help.txt`'s golden diff (no `write`/`commit` rows) is the same signal for the `--help` scenarios.

## Gates run

- `go test ./...` — clean in `erun-common`, `erun-cli`, `erun-mcp`.
- `make lint` — 0 issues across all gated modules (`erun-common`, `erun-cli`, `erun-mcp`, `erun-integration`, `erun-backend/erun-backend-api`, `erun-ui`).
- `make integration-test` — green, coverage 76.2% (≥ 76.0% threshold, no change needed).
- `yarn build` / `yarn typecheck` in `erun-docs` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)