### PR TITLE
Key the delete Job by attempt, not by tenant and environment

### DIFF
--- a/erun-backend/erun-backend-api/internal/deployexec/lifecycle_job.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/lifecycle_job.go
@@ -45,6 +45,10 @@ type DeleteJobParams struct {
 	Namespace      string
 	Image          string
 	ServiceAccount string
+	// DeleteID identifies one explicit delete attempt, mirroring
+	// DeployJobParams.DeployID: it is what lets DeleteJobName give a retried
+	// delete a new Job instead of watching a prior attempt's terminal one.
+	DeleteID string
 	// Placement names the cluster this delete targets (#1112); see
 	// DeployJobParams.Placement.
 	Placement PlacementParams
@@ -61,21 +65,30 @@ type DeleteJobParams struct {
 // StopJobName is deterministic in its inputs, so a retried stop watches the
 // Job it already created rather than starting a second one.
 func StopJobName(tenant, environment string) string {
-	return lifecycleJobName(stopJobNamePrefix, tenant, environment)
+	return lifecycleJobName(stopJobNamePrefix, tenant, environment, "")
 }
 
-// DeleteJobName is deterministic in its inputs, so a retried delete watches
-// the Job it already created rather than starting a second one.
-func DeleteJobName(tenant, environment string) string {
-	return lifecycleJobName(deleteJobNamePrefix, tenant, environment)
+// DeleteJobName appends a per-attempt suffix, mirroring DeployJobName: a
+// name keyed only on tenant+environment would make a retried delete watch a
+// prior attempt's already-terminal Job and replay its cached outcome instead
+// of actually running again. deleteID empty keeps the bare tenant+environment
+// name.
+func DeleteJobName(tenant, environment, deleteID string) string {
+	return lifecycleJobName(deleteJobNamePrefix, tenant, environment, deleteID)
 }
 
-func lifecycleJobName(prefix, tenant, environment string) string {
+func lifecycleJobName(prefix, tenant, environment, attemptID string) string {
 	name := jobexec.SanitizeName(tenant + "-" + environment)
-	if budget := jobexec.MaxJobNameLength - len(prefix); len(name) > budget {
+	suffix := ""
+	if attemptID != "" {
+		suffix = "-" + jobexec.ShortID(attemptID)
+	}
+	// Kubernetes caps an object name at 63 characters; trim the descriptive
+	// middle rather than the attempt suffix, which is what keeps attempts apart.
+	if budget := jobexec.MaxJobNameLength - len(prefix) - len(suffix); len(name) > budget {
 		name = strings.Trim(name[:budget], "-")
 	}
-	return prefix + name
+	return prefix + name + suffix
 }
 
 func lifecycleJobSpec(container corev1.Container, serviceAccount string) batchv1.JobSpec {
@@ -140,7 +153,7 @@ func buildStopJob(params StopJobParams) *batchv1.Job {
 func buildDeleteJob(params DeleteJobParams) *batchv1.Job {
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      DeleteJobName(params.Tenant, params.Environment),
+			Name:      DeleteJobName(params.Tenant, params.Environment, params.DeleteID),
 			Namespace: params.Namespace,
 			Labels:    lifecycleJobLabels(params.Tenant, params.Environment),
 		},

--- a/erun-backend/erun-backend-api/internal/deployexec/lifecycle_job_test.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/lifecycle_job_test.go
@@ -222,17 +222,21 @@ func TestAllLifecycleJobsShareTheBootstrapPrelude(t *testing.T) {
 
 // TestLauncherRunsStopAndDelete holds the launcher to creating and watching
 // each lifecycle Job under its own Kind/Container; the watch and
-// failure-read-back machinery itself is jobexec's, covered there.
+// failure-read-back machinery itself is jobexec's, covered there. The delete
+// side is given an explicit attempt id (as every real caller supplies one),
+// so this exercises the same DeleteJobName path a live delete takes rather
+// than the bare tenant+environment name.
 func TestLauncherRunsStopAndDelete(t *testing.T) {
 	stopParams := testStopParams()
 	deleteParams := testDeleteParams()
+	deleteParams.DeleteID = "3f2a91cc-1111-2222-3333-444455556666"
 	kube := fake.NewSimpleClientset(
 		&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{Name: StopJobName(stopParams.Tenant, stopParams.Environment), Namespace: stopParams.Namespace},
 			Status:     batchv1.JobStatus{Succeeded: 1},
 		},
 		&batchv1.Job{
-			ObjectMeta: metav1.ObjectMeta{Name: DeleteJobName(deleteParams.Tenant, deleteParams.Environment), Namespace: deleteParams.Namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: DeleteJobName(deleteParams.Tenant, deleteParams.Environment, deleteParams.DeleteID), Namespace: deleteParams.Namespace},
 			Status:     batchv1.JobStatus{Succeeded: 1},
 		},
 	)
@@ -256,13 +260,109 @@ func TestLauncherRunsStopAndDelete(t *testing.T) {
 	}
 }
 
+// TestLauncherDeleteAttemptsGetDistinctJobs is the regression test for the
+// replay this Job name once had: two delete attempts against the same
+// environment must land on two distinct Jobs, and the second attempt must
+// surface its own outcome rather than a still-live prior attempt's cached
+// terminal result. Each attempt's Job is seeded with a different outcome
+// specifically so a wrongly-shared name would be caught by the assertion on
+// the second result, not just by the name comparison.
+func TestLauncherDeleteAttemptsGetDistinctJobs(t *testing.T) {
+	params := testDeleteParams()
+	firstID := "3f2a91cc-1111-2222-3333-444455556666"
+	secondID := "9b7d40aa-1111-2222-3333-444455556666"
+
+	firstName := DeleteJobName(params.Tenant, params.Environment, firstID)
+	secondName := DeleteJobName(params.Tenant, params.Environment, secondID)
+	if firstName == secondName {
+		t.Fatalf("two delete attempts share the job name %q", firstName)
+	}
+
+	kube := fake.NewSimpleClientset(
+		&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: firstName, Namespace: params.Namespace},
+			Status:     batchv1.JobStatus{Failed: 1},
+		},
+		&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: secondName, Namespace: params.Namespace},
+			Status:     batchv1.JobStatus{Succeeded: 1},
+		},
+	)
+	launcher := NewLauncher(kube)
+	launcher.PollEvery(0)
+
+	first := params
+	first.DeleteID = firstID
+	firstResult, err := launcher.RunDelete(context.Background(), first)
+	if err != nil {
+		t.Fatalf("run first delete: %v", err)
+	}
+	if firstResult.Outcome != OutcomeFailed {
+		t.Fatalf("first delete outcome = %q, want failed", firstResult.Outcome)
+	}
+
+	second := params
+	second.DeleteID = secondID
+	secondResult, err := launcher.RunDelete(context.Background(), second)
+	if err != nil {
+		t.Fatalf("run second delete: %v", err)
+	}
+	if secondResult.Outcome != OutcomeSucceeded {
+		t.Fatalf("second delete outcome = %q, want succeeded — got the first attempt's cached outcome instead of running its own Job", secondResult.Outcome)
+	}
+
+	jobs, err := kube.BatchV1().Jobs(params.Namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	if len(jobs.Items) != 2 {
+		t.Fatalf("jobs in namespace = %d, want 2 (one per attempt)", len(jobs.Items))
+	}
+}
+
+// TestDeleteJobNameSeparatesAttempts mirrors TestDeployJobNameSeparatesAttempts:
+// a retried delete must be a new Job, otherwise it would re-read the previous
+// attempt's terminal outcome instead of running.
+func TestDeleteJobNameSeparatesAttempts(t *testing.T) {
+	first := DeleteJobName("acme", "prod", "3f2a91cc-1111-2222-3333-444455556666")
+	second := DeleteJobName("acme", "prod", "9b7d40aa-1111-2222-3333-444455556666")
+	if first == second {
+		t.Fatalf("two attempts share the job name %q", first)
+	}
+	// The create path passes no attempt id and keeps its stable name, so a
+	// resumed workflow still re-watches the Job it already created.
+	if got := DeleteJobName("acme", "prod", ""); got != "erun-delete-acme-prod" {
+		t.Fatalf("name without an attempt id = %q", got)
+	}
+	if !strings.HasPrefix(first, "erun-delete-acme-prod-") {
+		t.Fatalf("attempt name %q lost its readable prefix", first)
+	}
+}
+
+// TestDeleteJobNameFitsKubernetesLimit mirrors TestDeployJobNameFitsKubernetesLimit:
+// names are trimmed in the descriptive middle, never in the attempt suffix
+// that keeps two deletes apart.
+func TestDeleteJobNameFitsKubernetesLimit(t *testing.T) {
+	longEnv := strings.Repeat("e", 63)
+	first := DeleteJobName("verylongtenantname", longEnv, "3f2a91cc-aaaa")
+	second := DeleteJobName("verylongtenantname", longEnv, "9b7d40aa-bbbb")
+	for _, name := range []string{first, second} {
+		if len(name) > 63 {
+			t.Fatalf("job name %q is %d characters, over the 63 Kubernetes allows", name, len(name))
+		}
+	}
+	if first == second {
+		t.Fatal("truncation collapsed two attempts onto one job name")
+	}
+}
+
 func TestLifecycleJobNameSanitizesAndTruncates(t *testing.T) {
 	long := "a-very-long-tenant-name-that-pushes-past-the-kubernetes-object-name-limit"
 	name := StopJobName(long, "prod")
 	if len(name) > 63 {
 		t.Fatalf("job name length = %d, want <= 63", len(name))
 	}
-	deleteName := DeleteJobName(long, "prod")
+	deleteName := DeleteJobName(long, "prod", "3f2a91cc-1111-2222-3333-444455556666")
 	if len(deleteName) > 63 {
 		t.Fatalf("job name length = %d, want <= 63", len(deleteName))
 	}

--- a/erun-backend/erun-backend-api/internal/provision/delete.go
+++ b/erun-backend/erun-backend-api/internal/provision/delete.go
@@ -47,6 +47,7 @@ func (input EnvDeleteInput) lifecycleInput() EnvLifecycleInput {
 		ContextID:                  input.ContextID,
 		PlacementKubernetesContext: input.PlacementKubernetesContext,
 		PlacementServerURL:         input.PlacementServerURL,
+		DeleteID:                   input.DeleteID,
 	}
 }
 

--- a/erun-backend/erun-backend-api/internal/provision/lifecycle.go
+++ b/erun-backend/erun-backend-api/internal/provision/lifecycle.go
@@ -54,6 +54,11 @@ type EnvLifecycleInput struct {
 	ContextID                  string
 	PlacementKubernetesContext string
 	PlacementServerURL         string
+	// DeleteID identifies one explicit delete attempt (see
+	// EnvDeleteInput.DeleteID) and is threaded only into the delete Job's
+	// name, never into stop's — a stop request carries no attempt id and
+	// stays keyed on tenant+environment.
+	DeleteID string
 }
 
 // EnvLifecycle runs a hosted env's stop/delete Job to a terminal outcome and
@@ -166,6 +171,7 @@ func (l *EnvLifecycle) Delete(ctx context.Context, input EnvLifecycleInput) erro
 			Namespace:               l.config.PlatformNamespace,
 			Image:                   l.image(ctx, input.Tenant, input.RunningVersion),
 			ServiceAccount:          l.config.DeployerServiceAccount,
+			DeleteID:                input.DeleteID,
 			ExposeServicesZone:      l.config.ExposeServicesZone,
 			ExposePlatformNamespace: l.config.ExposePlatformNamespace,
 			Placement:               placement,


### PR DESCRIPTION
## Summary

`DeleteJobName` was keyed on tenant+environment only, so a retried delete (a reconciler tick or an operator retry) watched a still-live prior attempt's terminal Job and replayed its cached outcome and pod log instead of running a new teardown — the same replay shape `erun-backend-api/AGENTS.md` § "Server-Side Executors" already warns against, and the deploy path already avoids via a per-attempt suffix.

`DeleteJobParams` had no field to carry an attempt id at all, even though `EnvDeleteInput.DeleteID` already existed and its own doc comment asserted the guard was in place — `lifecycleInput()` silently dropped it on the way to the Job.

## Fix

- `DeleteJobParams` gains `DeleteID`; `DeleteJobName(tenant, environment, deleteID)` appends `jobexec.ShortID(deleteID)`, mirroring `DeployJobName` exactly (trims the descriptive middle, never the attempt suffix, on the 63-char Kubernetes cap).
- `lifecycleJobName` takes an `attemptID` parameter; `StopJobName` still calls it with `""`, so stop's name is unchanged.
- `EnvLifecycleInput` gains `DeleteID`, threaded from `EnvDeleteInput.lifecycleInput()` (which already carried it) through to `DeleteJobParams`.
- The workflow id DBOS uses to resume (`"delete-env-" + environmentID + "-" + deleteID`) is unchanged — it was already correct and is a separate string from the Job name.

## Test changes

- `TestLauncherRunsStopAndDelete` previously pre-seeded a single terminal Job at the deterministic name and asserted `RunDelete` returned it — i.e. it encoded the replay as accepted behaviour, which is why nothing caught this. It now gives the delete side an explicit attempt id (as every real caller supplies) and asserts against the attempt-scoped name.
- New `TestLauncherDeleteAttemptsGetDistinctJobs`: seeds two attempts' Jobs with different outcomes (failed vs. succeeded) and asserts each `RunDelete` call returns its own attempt's outcome, plus that two Jobs exist. Verified this fails to even compile against the pre-fix code (`DeleteJobParams.DeleteID undefined`, `too many arguments in call to DeleteJobName`).
- New `TestDeleteJobNameSeparatesAttempts` / `TestDeleteJobNameFitsKubernetesLimit` mirror the existing deploy-side tests of the same name.

I also reproduced the issue's executable proof directly against the pre-fix code (temporarily, not committed): seeding attempt 1's terminal Job, then calling `RunDelete` again with the same (attempt-less) params reported `jobs in namespace after attempt 2: 1` and `attempt 2 outcome="succeeded"` — the replay, byte for byte what the issue describes.

## Stop path

`StopJobName`/`StopJobParams` have the exact same shape (deterministic on tenant+environment, no attempt id at all) and are not fixed here — that's out of scope for this issue. Two things make it lower-severity in practice, not exempt from the underlying pattern: stop runs synchronously from the HTTP handler with no reconciler retrying it, and its operation (scale to zero) is idempotent on success, so a replayed *successful* outcome is harmless. A replayed *failure* would still short-circuit an actual retry the same way delete's did. Flagging for a follow-up rather than fixing here, per the issue's scope.

Closes #1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)