### PR TITLE
Make the deploy and delete lifecycles mutually exclusive, and bound the quota discount

### DIFF
--- a/erun-backend/erun-backend-api/internal/repository/environments.go
+++ b/erun-backend/erun-backend-api/internal/repository/environments.go
@@ -21,6 +21,17 @@ const environmentColumns = `environment_id, tenant_id, name, type, kubernetes_co
 // use.
 var environmentsMidTeardownStatuses = []string{string(model.EnvironmentStatusDeleting), string(model.EnvironmentStatusDeletionBlocked)}
 
+// maxExcludedMidTeardownEnvironments bounds how many mid-teardown rows Count
+// will discount at once. The exclusion exists so one stuck teardown cannot
+// lock a tenant out of its own allowance (#1140), but left unbounded it is the
+// opposite failure: every wedged environment still holds a live namespace and
+// real cluster capacity, so a tenant that accumulates them consumes unlimited
+// resource while its quota reports room to spare (#1163). Bounding the
+// discount keeps the #1140 property for the case it was written for — a
+// handful of stuck deletes — and restores accounting beyond that, where
+// "stuck" has become "abandoned".
+const maxExcludedMidTeardownEnvironments = 3
+
 func NewEnvironmentRepository(txs *TxManager) *EnvironmentRepository {
 	return &EnvironmentRepository{txs: txs}
 }
@@ -54,17 +65,22 @@ func (r *EnvironmentRepository) List(ctx context.Context) ([]model.Environment, 
 
 // Count returns how many environments the caller's tenant has, for enforcing
 // the tenant's environment-count quota cap. Environments mid-teardown
-// (deleting, deletion-blocked) are excluded: a delete that cannot complete
-// must not lock the tenant out of its own allowance (#1140) — the delete that
-// would free the slot is the same call that is stuck.
+// (deleting, deletion-blocked) are discounted, but only up to
+// maxExcludedMidTeardownEnvironments: a delete that cannot complete must not
+// lock the tenant out of its own allowance (#1140), while an unbounded
+// discount would let a tenant hold unlimited live namespaces that its quota
+// never sees (#1163). Both subqueries run under the caller's RLS scope, so
+// each counts only this tenant's rows.
 func (r *EnvironmentRepository) Count(ctx context.Context) (int, error) {
 	var count int
 	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
-		var err error
-		count, err = tx.NewSelect().Model((*model.Environment)(nil)).
-			Where("status NOT IN (?)", bun.List(environmentsMidTeardownStatuses)).
-			Count(ctx)
-		return err
+		return tx.NewRaw(`
+			SELECT (SELECT COUNT(*) FROM environments)
+			     - LEAST(
+			         (SELECT COUNT(*) FROM environments WHERE status IN (?)),
+			         ?
+			       )
+		`, bun.List(environmentsMidTeardownStatuses), maxExcludedMidTeardownEnvironments).Scan(ctx, &count)
 	})
 	return count, err
 }
@@ -148,6 +164,14 @@ func (r *EnvironmentRepository) MarkDeployFailed(ctx context.Context, environmen
 // the winner's. A claim that went stale past staleAfter -- a control plane that
 // crashed mid-deploy -- is re-claimable, so a wedged env is never locked out
 // permanently.
+//
+// A row mid-teardown is refused outright, and unlike the in-flight guard this
+// refusal is not relaxed by staleAfter: a delete has been requested, so
+// adopting the row into a deploy would abandon that request (#1163). Left
+// unguarded a deploy claims a `deleting` or `deletion-blocked` row, runs
+// against a namespace Kubernetes is already terminating, and writes its own
+// `failed` over the teardown state — losing the outstanding delete and
+// stranding a row that no longer matches any namespace.
 func (r *EnvironmentRepository) ClaimDeploy(ctx context.Context, environmentID string, staleAfter time.Duration) (bool, error) {
 	claimed := false
 	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
@@ -156,8 +180,9 @@ func (r *EnvironmentRepository) ClaimDeploy(ctx context.Context, environmentID s
 			   SET status = ?,
 			       provision_error = NULL
 			 WHERE environment_id = ?
+			   AND status NOT IN (?)
 			   AND (status <> ? OR updated_at < NOW() - MAKE_INTERVAL(secs => ?))
-		`, string(model.EnvironmentStatusProvisioning), environmentID, string(model.EnvironmentStatusProvisioning), staleAfter.Seconds()).Exec(ctx)
+		`, string(model.EnvironmentStatusProvisioning), environmentID, bun.List(environmentsMidTeardownStatuses), string(model.EnvironmentStatusProvisioning), staleAfter.Seconds()).Exec(ctx)
 		if err != nil {
 			return err
 		}
@@ -189,6 +214,13 @@ func (r *EnvironmentRepository) Delete(ctx context.Context, environmentID string
 // `deletion-blocked` is always reclaimable (not gated by staleAfter): that
 // status means the previous attempt already reached a terminal outcome, so
 // there is nothing in flight to race with.
+//
+// A fresh `provisioning` claim is refused, making the two lifecycles mutually
+// exclusive in both directions (#1163): claiming a row out from under a
+// running deploy leaves that deploy's terminal write to land on top of
+// `deleting` and resurrect a row whose namespace is being torn down. The guard
+// is relaxed by the same staleAfter as the deploy's own, so a control plane
+// that died mid-deploy still cannot block a teardown permanently.
 func (r *EnvironmentRepository) ClaimDelete(ctx context.Context, environmentID string, staleAfter time.Duration) (bool, error) {
 	claimed := false
 	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
@@ -198,7 +230,8 @@ func (r *EnvironmentRepository) ClaimDelete(ctx context.Context, environmentID s
 			       delete_error = NULL
 			 WHERE environment_id = ?
 			   AND (status <> ? OR updated_at < NOW() - MAKE_INTERVAL(secs => ?))
-		`, string(model.EnvironmentStatusDeleting), environmentID, string(model.EnvironmentStatusDeleting), staleAfter.Seconds()).Exec(ctx)
+			   AND (status <> ? OR updated_at < NOW() - MAKE_INTERVAL(secs => ?))
+		`, string(model.EnvironmentStatusDeleting), environmentID, string(model.EnvironmentStatusDeleting), staleAfter.Seconds(), string(model.EnvironmentStatusProvisioning), staleAfter.Seconds()).Exec(ctx)
 		if err != nil {
 			return err
 		}

--- a/erun-backend/erun-backend-api/internal/routes/environments.go
+++ b/erun-backend/erun-backend-api/internal/routes/environments.go
@@ -199,7 +199,7 @@ func (r EnvironmentRoutes) deleteEnvironment(w http.ResponseWriter, req *http.Re
 		return
 	}
 	if !claimed {
-		writeError(w, http.StatusConflict, "a delete is already in progress for this environment")
+		writeError(w, http.StatusConflict, deleteClaimRefusal(environment.Status))
 		return
 	}
 	if err := r.startDelete(ctx, environment); err != nil {
@@ -246,6 +246,32 @@ func (r EnvironmentRoutes) startDelete(ctx context.Context, environment model.En
 		PlacementServerURL:         placement.ServerURL,
 		DeleteID:                   uuid.NewString(),
 	})
+}
+
+// deployClaimRefusal names why ClaimDeploy refused, so a caller mid-teardown
+// is told that rather than the misleading "a deploy is already in progress".
+// It reads the status fetched before the claim attempt: the claim itself is
+// the authority on the outcome, so a row that changed in between yields a
+// slightly stale explanation but never a wrong decision.
+func deployClaimRefusal(status model.EnvironmentStatus) string {
+	switch status {
+	case model.EnvironmentStatusDeleting:
+		return "this environment is being deleted; it cannot be deployed until the teardown finishes"
+	case model.EnvironmentStatusDeletionBlocked:
+		return "this environment's delete is blocked and still outstanding; resolve the teardown before deploying it again"
+	default:
+		return "a deploy is already in progress for this environment"
+	}
+}
+
+// deleteClaimRefusal is deployClaimRefusal's counterpart: a delete refused
+// because a deploy holds the row is told so, since the actionable step is to
+// wait for that deploy rather than to retry immediately.
+func deleteClaimRefusal(status model.EnvironmentStatus) string {
+	if status == model.EnvironmentStatusProvisioning {
+		return "a deploy is in progress for this environment; retry the delete once it finishes"
+	}
+	return "a delete is already in progress for this environment"
 }
 
 // writeStartDeleteError marks the environment deletion-blocked and answers
@@ -353,7 +379,7 @@ func (r EnvironmentRoutes) deployEnvironment(w http.ResponseWriter, req *http.Re
 		return
 	}
 	if !claimed {
-		writeError(w, http.StatusConflict, "a deploy is already in progress for this environment")
+		writeError(w, http.StatusConflict, deployClaimRefusal(environment.Status))
 		return
 	}
 	if err := r.startDeploy(ctx, environment, version); err != nil {

--- a/erun-backend/erun-backend-api/internal/routes/environments_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/environments_test.go
@@ -1027,6 +1027,85 @@ func TestDeleteEnvironmentRejectsConcurrentDelete(t *testing.T) {
 	}
 }
 
+// The three tests below cover the refusal *messages* for #1163. The guard that
+// produces the refusal lives in ClaimDeploy/ClaimDelete's SQL, which this
+// package's stub repository cannot exercise and which no Postgres-backed
+// harness exists for here — that half is verified against a live control plane
+// instead. What these hold is the half that is testable in Go: that a refusal
+// caused by an outstanding teardown is reported as such, rather than as the
+// misleading "a deploy is already in progress" a caller used to get.
+
+// TestDeployEnvironmentRefusalNamesAnOutstandingDelete: a deploy refused
+// because the environment is mid-teardown must say so. The old message sent
+// the caller looking for a concurrent deploy that does not exist.
+func TestDeployEnvironmentRefusalNamesAnOutstandingDelete(t *testing.T) {
+	for _, tc := range []struct {
+		status model.EnvironmentStatus
+		want   string
+	}{
+		{model.EnvironmentStatusDeleting, "being deleted"},
+		{model.EnvironmentStatusDeletionBlocked, "delete is blocked"},
+	} {
+		environments := runtimeEnvironment()
+		environments.environment.Status = tc.status
+		environments.claimTaken = true
+		prov := &stubEnvironmentProvisioner{}
+		rec := postDeployEnvironment(t, environments, prov, "")
+
+		if rec.Code != http.StatusConflict {
+			t.Fatalf("status %q: code = %d, want 409 Conflict", tc.status, rec.Code)
+		}
+		if body := rec.Body.String(); !strings.Contains(body, tc.want) {
+			t.Fatalf("status %q: body %s does not mention %q", tc.status, body, tc.want)
+		}
+		if len(prov.deployed) != 0 {
+			t.Fatalf("status %q: StartDeploy ran %d times, want 0", tc.status, len(prov.deployed))
+		}
+	}
+}
+
+// TestDeleteEnvironmentRefusalNamesAnInFlightDeploy is the mirror: a delete
+// refused because a deploy holds the row should point at the deploy, since
+// waiting for it is the actionable step.
+func TestDeleteEnvironmentRefusalNamesAnInFlightDeploy(t *testing.T) {
+	environments := runtimeEnvironment()
+	environments.environment.Status = model.EnvironmentStatusProvisioning
+	environments.claimDeleteTaken = true
+	deleter := &stubEnvironmentDeleter{}
+	rec := deleteEnvironmentRequest(t, environments, deleter)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("code = %d, want 409 Conflict", rec.Code)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "a deploy is in progress") {
+		t.Fatalf("body %s does not name the in-flight deploy", body)
+	}
+	if len(deleter.started) != 0 {
+		t.Fatalf("Start ran %d times, want 0", len(deleter.started))
+	}
+}
+
+// TestClaimRefusalMessages pins each mapping directly, including that an
+// ordinary status still yields the original concurrent-lifecycle wording — the
+// teardown cases must not swallow the common one.
+func TestClaimRefusalMessages(t *testing.T) {
+	if got := deployClaimRefusal(model.EnvironmentStatusRunning); got != "a deploy is already in progress for this environment" {
+		t.Fatalf("running deploy refusal = %q, want the concurrent-deploy message", got)
+	}
+	if got := deployClaimRefusal(model.EnvironmentStatusDeleting); !strings.Contains(got, "being deleted") {
+		t.Fatalf("deleting deploy refusal = %q", got)
+	}
+	if got := deployClaimRefusal(model.EnvironmentStatusDeletionBlocked); !strings.Contains(got, "delete is blocked") {
+		t.Fatalf("deletion-blocked deploy refusal = %q", got)
+	}
+	if got := deleteClaimRefusal(model.EnvironmentStatusRunning); got != "a delete is already in progress for this environment" {
+		t.Fatalf("running delete refusal = %q, want the concurrent-delete message", got)
+	}
+	if got := deleteClaimRefusal(model.EnvironmentStatusProvisioning); !strings.Contains(got, "a deploy is in progress") {
+		t.Fatalf("provisioning delete refusal = %q", got)
+	}
+}
+
 // TestDeleteEnvironmentStartFailureMarksBlocked mirrors
 // TestDeployEnvironmentStartFailureMarksFailed: ClaimDelete already moved the
 // row to `deleting` before Start ran, so a failure to even enqueue the


### PR DESCRIPTION
## Summary

Closes #1163.

Both halves of this issue were reproduced in production today, one of them by an operator clicking **Deploy** in the console on an environment sitting in `deletion-blocked` (audit trail in [this comment](https://github.com/sophium/erun/issues/1163#issuecomment-5385858056)).

**Claims did not exclude each other.** `ClaimDeploy`'s guard was only `status <> 'provisioning'`, so it claimed a `deleting` or `deletion-blocked` row as readily as an idle one. The deploy then ran against a namespace Kubernetes was already terminating, failed on `secrets ... is forbidden: unable to create new content in namespace ... because it is being terminated`, and wrote its own `failed` over the teardown state. The end state was a self-contradictory row: `status=failed`, a 643-character `delete_error` describing a teardown that had since completed, no namespace, and one of ten quota slots consumed. `ClaimDelete` was blind in the same way to a fresh `provisioning` claim, which is the mirror failure — claiming a row out from under a running deploy lets that deploy's terminal write land on top of `deleting`.

**The quota discount was unbounded.** `Count` excluded every mid-teardown row, forever. Each one still holds a live namespace and real cluster capacity, so a tenant accumulating them consumes unlimited resource while its quota reports room to spare. I watched this live: the quota said `0 of 10` while a wedged namespace was running.

## Fix

- **`ClaimDeploy` refuses `deleting`/`deletion-blocked` outright**, and deliberately *not* relaxed by `staleAfter` — a delete has been requested, and the request going stale does not retract it. The way out is for the teardown to finish, not for a deploy to adopt the row.
- **`ClaimDelete` refuses a fresh `provisioning` claim**, relaxed by the same `staleAfter` as the deploy's own guard, so a control plane that died mid-deploy still cannot block a teardown permanently. `deletion-blocked` remains claimable and ungated by staleness, which the delete reconciler depends on.
- **`Count` caps the discount** at `maxExcludedMidTeardownEnvironments` (3). This keeps the #1140 property for the case it was written for — a handful of stuck deletes must not lock a tenant out of its own allowance — and restores accounting beyond that, where "stuck" has become "abandoned". Both subqueries run under the caller's RLS scope.
- **The 409 names the real reason.** A deploy refused because of an outstanding teardown previously reported "a deploy is already in progress for this environment", sending the caller to look for a concurrent deploy that did not exist.

## Verification

The guard is SQL, and this module has no Postgres-backed test harness, so the two halves were verified separately rather than pretending a unit test covered the SQL.

**Go suites** — `go build`, `go vet`, `gofmt -l`, `golangci-lint run` (0 issues), and `go test -count=1 ./...` across all 12 packages, all green. New tests cover the refusal-message mapping (`TestDeployEnvironmentRefusalNamesAnOutstandingDelete`, `TestDeleteEnvironmentRefusalNamesAnInFlightDeploy`, `TestClaimRefusalMessages`), including that an ordinary status still yields the original concurrent-lifecycle wording so the teardown cases cannot swallow the common one.

**SQL semantics, against a live PostgreSQL** using synthetic rows in a CTE (no table writes):

| assertion | result |
|---|---|
| discount engaged — 6 rows, 5 mid-teardown, cap 3 | `expect 3 got 3` |
| discount idle — 4 rows, 1 mid-teardown (#1140's case) | `expect 3 got 3` |
| no teardown rows — `LEAST(0,3)=0` | `expect 2 got 2` |
| deploy-claimable set | `failed, provisioning, registered, running` — both teardown states excluded |
| delete-claimable, fresh claims | `deletion-blocked, failed, running` — fresh `deleting` *and* `provisioning` refused, reconciler path intact |
| delete-claimable, stale claims | `deleting, provisioning` — no permanent lockout |

The mandatory end-to-end gate (roll into the running target, reproduce the original failure verbatim, watch it succeed) is being run against the control plane that produced the original failure: provision an environment, wedge its namespace, delete it to `deletion-blocked`, then issue the same `POST /v1/environments/{id}/deploy` and confirm it is refused with 409 naming the teardown instead of being accepted. Results will be posted here before merge.

## Note on the reconciler

This does not address #1166 (the reconciler clearing `delete_error` on every claim, its silence, or its unbounded retry). `ClaimDelete` still sets `delete_error = NULL` on claim; that is the same line, but a distinct defect with a distinct fix, and is tracked separately.