### PR TITLE
Let a wrapper module pass null for any optional cluster-edge input

### DIFF
--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/main.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/main.tf
@@ -1,9 +1,51 @@
+# Terraform does not substitute a variable's default when a caller assigns an
+# explicit null: the null reaches the variable's own validation and its uses, so
+# `length(null)` aborts outright and `null != ""` is *true*, silently selecting
+# the wrong branch of a guard. A wrapper module cannot conditionally omit an
+# argument in HCL, so "use this module's default" has to be expressible as null
+# -- otherwise every wrapper must duplicate the default and can drift from it
+# (#1161). Every optional input therefore declares `default = null` and resolves
+# its effective value exactly once here.
+#
+# The test is `== null`, deliberately not coalesce(): coalesce skips empty
+# strings as well as nulls, so it would silently replace a legitimately empty
+# input with the default -- and coalesce("", "") is a hard error, which would
+# abort every apply where an optional string is genuinely unset.
 locals {
-  cloudflare_token_secret = "${var.issuer_name}-cloudflare-token"
-  wildcard_cert_name      = "${var.issuer_name}-wildcard"
-  wildcard_secret_name    = "${var.issuer_name}-wildcard-tls"
-  use_rfc2136             = var.dns01_provider == "powerdns-rfc2136"
-  use_broker              = var.dns01_provider == "powerdns-broker"
+  arg_cloudflare_api_token             = var.cloudflare_api_token == null ? "" : var.cloudflare_api_token
+  arg_acme_server                      = var.acme_server == null ? "https://acme-v02.api.letsencrypt.org/directory" : var.acme_server
+  arg_install_ingress_controller       = var.install_ingress_controller == null ? true : var.install_ingress_controller
+  arg_install_cert_manager             = var.install_cert_manager == null ? true : var.install_cert_manager
+  arg_wildcard_certificate_enabled     = var.wildcard_certificate_enabled == null ? true : var.wildcard_certificate_enabled
+  arg_namespace                        = var.namespace == null ? "cert-manager" : var.namespace
+  arg_ingress_namespace                = var.ingress_namespace == null ? "traefik" : var.ingress_namespace
+  arg_issuer_name                      = var.issuer_name == null ? "erun-cloudflare" : var.issuer_name
+  arg_cert_manager_chart_version       = var.cert_manager_chart_version == null ? "v1.20.3" : var.cert_manager_chart_version
+  arg_traefik_chart_version            = var.traefik_chart_version == null ? "33.2.1" : var.traefik_chart_version
+  arg_dns01_provider                   = var.dns01_provider == null ? "cloudflare" : var.dns01_provider
+  arg_dns01_webhook_image_pull_secrets = var.dns01_webhook_image_pull_secrets == null ? [] : var.dns01_webhook_image_pull_secrets
+  arg_broker_url                       = var.broker_url == null ? "" : var.broker_url
+  arg_dns01_token_secret_name          = var.dns01_token_secret_name == null ? "" : var.dns01_token_secret_name
+  arg_dns01_webhook_group_name         = var.dns01_webhook_group_name == null ? "acme.erun.io" : var.dns01_webhook_group_name
+  arg_dns01_webhook_image              = var.dns01_webhook_image == null ? "" : var.dns01_webhook_image
+  arg_powerdns_nameserver              = var.powerdns_nameserver == null ? "" : var.powerdns_nameserver
+  arg_rfc2136_tsig_key_name            = var.rfc2136_tsig_key_name == null ? "" : var.rfc2136_tsig_key_name
+  arg_rfc2136_tsig_algorithm           = var.rfc2136_tsig_algorithm == null ? "HMACSHA256" : var.rfc2136_tsig_algorithm
+  arg_rfc2136_tsig_secret              = var.rfc2136_tsig_secret == null ? "" : var.rfc2136_tsig_secret
+  arg_per_env_certificate_enabled      = var.per_env_certificate_enabled == null ? false : var.per_env_certificate_enabled
+  arg_env_label                        = var.env_label == null ? "" : var.env_label
+  arg_env_namespace                    = var.env_namespace == null ? "" : var.env_namespace
+  arg_install_coredns_forward          = var.install_coredns_forward == null ? false : var.install_coredns_forward
+  arg_base_domain_name                 = var.base_domain_name == null ? "" : var.base_domain_name
+  arg_coredns_forward_upstreams        = var.coredns_forward_upstreams == null ? ["1.1.1.1", "1.0.0.1", "8.8.8.8"] : var.coredns_forward_upstreams
+}
+
+locals {
+  cloudflare_token_secret = "${local.arg_issuer_name}-cloudflare-token"
+  wildcard_cert_name      = "${local.arg_issuer_name}-wildcard"
+  wildcard_secret_name    = "${local.arg_issuer_name}-wildcard-tls"
+  use_rfc2136             = local.arg_dns01_provider == "powerdns-rfc2136"
+  use_broker              = local.arg_dns01_provider == "powerdns-broker"
   # install_dns01_webhook left unset (null) preserves the historical behavior
   # of installing the shim exactly when the platform's own Issuer uses the
   # broker solver; setting it explicitly decouples the two, so a platform can
@@ -16,32 +58,32 @@ locals {
   # module's equivalent of a Helm template's `.Chart.AppVersion` default (see
   # erun-zitadel's bootstrap image): the shim's image can no longer disagree
   # with the module by construction, because they are pinned by the same file.
-  # var.dns01_webhook_image still overrides it, for testing a build ahead of a
+  # local.arg_dns01_webhook_image still overrides it, for testing a build ahead of a
   # release.
   dns01_webhook_chart_app_version = yamldecode(file("${path.module}/chart-dns01-webhook/Chart.yaml")).appVersion
-  dns01_webhook_image             = var.dns01_webhook_image != "" ? var.dns01_webhook_image : "ghcr.io/sophium/erun-dns01-webhook:${local.dns01_webhook_chart_app_version}"
-  tsig_secret_name                = "${var.issuer_name}-rfc2136-tsig"
+  dns01_webhook_image             = local.arg_dns01_webhook_image != "" ? local.arg_dns01_webhook_image : "ghcr.io/sophium/erun-dns01-webhook:${local.dns01_webhook_chart_app_version}"
+  tsig_secret_name                = "${local.arg_issuer_name}-rfc2136-tsig"
   # Per-env wildcard: *.<env_label>.<services_zone> → Secret <env_label>-wildcard-tls
   # in the env namespace, which `erun expose` references from its Ingress.
-  env_namespace       = var.env_namespace != "" ? var.env_namespace : var.env_label
-  per_env_cert_name   = var.env_label != "" ? "${var.env_label}-wildcard" : ""
-  per_env_secret_name = var.env_label != "" ? "${var.env_label}-wildcard-tls" : ""
+  env_namespace       = local.arg_env_namespace != "" ? local.arg_env_namespace : local.arg_env_label
+  per_env_cert_name   = local.arg_env_label != "" ? "${local.arg_env_label}-wildcard" : ""
+  per_env_secret_name = local.arg_env_label != "" ? "${local.arg_env_label}-wildcard-tls" : ""
   # The namespaced Issuer, its DNS-01 credential Secret, and the apex wildcard
   # cert all live here. A namespaced Issuer only serves Certificates in its own
   # namespace, so this is the env namespace (co-locating the per-env cert with
   # its issuer); it falls back to the cert-manager namespace for an apex-only
   # edge with no env.
-  issuer_namespace = local.env_namespace != "" ? local.env_namespace : var.namespace
+  issuer_namespace = local.env_namespace != "" ? local.env_namespace : local.arg_namespace
 
   # CoreDNS custom server block for base_domain_name. File name is derived from
   # the domain (dots to dashes) rather than fixed, so it can't collide with an
   # unrelated *.server file someone else drops in the same ConfigMap.
-  coredns_forward_key   = "${replace(var.base_domain_name, ".", "-")}.server"
+  coredns_forward_key   = "${replace(local.arg_base_domain_name, ".", "-")}.server"
   coredns_forward_block = <<-EOT
-    ${var.base_domain_name}:53 {
+    ${local.arg_base_domain_name}:53 {
         errors
         cache 30
-        forward . ${join(" ", var.coredns_forward_upstreams)}
+        forward . ${join(" ", local.arg_coredns_forward_upstreams)}
     }
   EOT
 }
@@ -65,7 +107,7 @@ locals {
 # (terraform import, or delete the hand-applied copy) before the first apply
 # with install_coredns_forward = true.
 resource "kubernetes_config_map" "coredns_forward" {
-  count = var.install_coredns_forward ? 1 : 0
+  count = local.arg_install_coredns_forward ? 1 : 0
 
   metadata {
     name      = "coredns-custom"
@@ -78,7 +120,7 @@ resource "kubernetes_config_map" "coredns_forward" {
 
   lifecycle {
     precondition {
-      condition     = var.base_domain_name != ""
+      condition     = local.arg_base_domain_name != ""
       error_message = "install_coredns_forward requires base_domain_name (the platform's own apex domain, e.g. \"example.com\")."
     }
   }
@@ -91,30 +133,30 @@ resource "kubernetes_config_map" "coredns_forward" {
 # existing cert-manager elsewhere).
 resource "kubernetes_namespace" "cert_manager" {
   metadata {
-    name = var.namespace
+    name = local.arg_namespace
   }
 }
 
 # Ingress controller. Optional: skip on a cluster that already has one.
 resource "helm_release" "traefik" {
-  count = var.install_ingress_controller ? 1 : 0
+  count = local.arg_install_ingress_controller ? 1 : 0
 
   name             = "traefik"
   repository       = "https://traefik.github.io/charts"
   chart            = "traefik"
-  version          = var.traefik_chart_version
-  namespace        = var.ingress_namespace
+  version          = local.arg_traefik_chart_version
+  namespace        = local.arg_ingress_namespace
   create_namespace = true
 }
 
 # cert-manager (with its CRDs). Optional: skip when the cluster already runs it.
 resource "helm_release" "cert_manager" {
-  count = var.install_cert_manager ? 1 : 0
+  count = local.arg_install_cert_manager ? 1 : 0
 
   name       = "cert-manager"
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
-  version    = var.cert_manager_chart_version
+  version    = local.arg_cert_manager_chart_version
   namespace  = kubernetes_namespace.cert_manager.metadata[0].name
 
   set {
@@ -137,13 +179,13 @@ resource "kubernetes_secret" "cloudflare_api_token" {
     namespace = local.issuer_namespace
   }
   data = {
-    "api-token" = var.cloudflare_api_token
+    "api-token" = local.arg_cloudflare_api_token
   }
   type = "Opaque"
 
   lifecycle {
     precondition {
-      condition     = var.cloudflare_api_token != ""
+      condition     = local.arg_cloudflare_api_token != ""
       error_message = "cloudflare_api_token is required when dns01_provider is \"cloudflare\"."
     }
   }
@@ -160,13 +202,13 @@ resource "kubernetes_secret" "rfc2136_tsig" {
     namespace = local.issuer_namespace
   }
   data = {
-    "tsig-secret" = var.rfc2136_tsig_secret
+    "tsig-secret" = local.arg_rfc2136_tsig_secret
   }
   type = "Opaque"
 
   lifecycle {
     precondition {
-      condition     = var.rfc2136_tsig_secret != "" && var.powerdns_nameserver != "" && var.rfc2136_tsig_key_name != ""
+      condition     = local.arg_rfc2136_tsig_secret != "" && local.arg_powerdns_nameserver != "" && local.arg_rfc2136_tsig_key_name != ""
       error_message = "dns01_provider \"powerdns-rfc2136\" requires rfc2136_tsig_secret, powerdns_nameserver, and rfc2136_tsig_key_name."
     }
   }
@@ -183,13 +225,13 @@ resource "kubernetes_secret" "rfc2136_tsig" {
 resource "helm_release" "dns01_webhook" {
   count = local.install_dns01_webhook ? 1 : 0
 
-  name      = "${var.issuer_name}-dns01-webhook"
+  name      = "${local.arg_issuer_name}-dns01-webhook"
   chart     = "${path.module}/chart-dns01-webhook"
   namespace = kubernetes_namespace.cert_manager.metadata[0].name
 
   set {
     name  = "groupName"
-    value = var.dns01_webhook_group_name
+    value = local.arg_dns01_webhook_group_name
   }
   set {
     name  = "namespace"
@@ -201,11 +243,11 @@ resource "helm_release" "dns01_webhook" {
   }
   set {
     name  = "brokerURL"
-    value = var.broker_url
+    value = local.arg_broker_url
   }
 
   dynamic "set" {
-    for_each = var.dns01_webhook_image_pull_secrets
+    for_each = local.arg_dns01_webhook_image_pull_secrets
     content {
       name  = "imagePullSecrets[${set.key}].name"
       value = set.value
@@ -214,7 +256,7 @@ resource "helm_release" "dns01_webhook" {
 
   lifecycle {
     precondition {
-      condition     = var.broker_url != ""
+      condition     = local.arg_broker_url != ""
       error_message = "install_dns01_webhook requires broker_url."
     }
   }
@@ -230,13 +272,13 @@ resource "helm_release" "dns01_webhook" {
 # in the cert-manager namespace, but the Issuer and its certs set their own
 # metadata.namespace (issuerNamespace) so they land in the env namespace.
 resource "helm_release" "issuer" {
-  name      = "${var.issuer_name}-issuer"
+  name      = "${local.arg_issuer_name}-issuer"
   chart     = "${path.module}/chart-issuer"
   namespace = kubernetes_namespace.cert_manager.metadata[0].name
 
   set {
     name  = "issuerName"
-    value = var.issuer_name
+    value = local.arg_issuer_name
   }
   set {
     name  = "issuerNamespace"
@@ -248,7 +290,7 @@ resource "helm_release" "issuer" {
   }
   set {
     name  = "acmeServer"
-    value = var.acme_server
+    value = local.arg_acme_server
   }
   set {
     name  = "servicesZone"
@@ -264,7 +306,7 @@ resource "helm_release" "issuer" {
   }
   set {
     name  = "wildcardCertificateEnabled"
-    value = tostring(var.wildcard_certificate_enabled)
+    value = tostring(local.arg_wildcard_certificate_enabled)
   }
   set {
     name  = "wildcardCertName"
@@ -276,19 +318,19 @@ resource "helm_release" "issuer" {
   }
   set {
     name  = "dns01Provider"
-    value = var.dns01_provider
+    value = local.arg_dns01_provider
   }
   set {
     name  = "rfc2136Nameserver"
-    value = var.powerdns_nameserver
+    value = local.arg_powerdns_nameserver
   }
   set {
     name  = "rfc2136TsigKeyName"
-    value = var.rfc2136_tsig_key_name
+    value = local.arg_rfc2136_tsig_key_name
   }
   set {
     name  = "rfc2136TsigAlgorithm"
-    value = var.rfc2136_tsig_algorithm
+    value = local.arg_rfc2136_tsig_algorithm
   }
   set {
     name  = "rfc2136TsigSecretName"
@@ -296,19 +338,19 @@ resource "helm_release" "issuer" {
   }
   set {
     name  = "dns01WebhookGroupName"
-    value = var.dns01_webhook_group_name
+    value = local.arg_dns01_webhook_group_name
   }
   set {
     name  = "brokerURL"
-    value = var.broker_url
+    value = local.arg_broker_url
   }
   set {
     name  = "dns01TokenSecretName"
-    value = var.dns01_token_secret_name
+    value = local.arg_dns01_token_secret_name
   }
   set {
     name  = "perEnvCertificateEnabled"
-    value = tostring(var.per_env_certificate_enabled)
+    value = tostring(local.arg_per_env_certificate_enabled)
   }
   set {
     name  = "perEnvCertName"
@@ -324,7 +366,7 @@ resource "helm_release" "issuer" {
   }
   set {
     name  = "envLabel"
-    value = var.env_label
+    value = local.arg_env_label
   }
 
   lifecycle {
@@ -338,7 +380,7 @@ resource "helm_release" "issuer" {
     # no token secret of its own: those are per-env and land beside each
     # environment, not here.
     precondition {
-      condition     = !local.use_broker || (var.broker_url != "" && var.dns01_token_secret_name != "")
+      condition     = !local.use_broker || (local.arg_broker_url != "" && local.arg_dns01_token_secret_name != "")
       error_message = "dns01_provider \"powerdns-broker\" solves the platform's own Issuer through the broker, so broker_url and dns01_token_secret_name are both required."
     }
   }

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/outputs.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/outputs.tf
@@ -1,6 +1,6 @@
 output "issuer_name" {
   description = "Name of the namespaced cert-manager Issuer (in issuer_namespace) that issues TLS certs via the DNS-01 challenge. Reference it from a same-namespace Certificate as `issuerRef: {kind: Issuer, name: <this>}` (or the `cert-manager.io/issuer` annotation)."
-  value       = var.issuer_name
+  value       = local.arg_issuer_name
 }
 
 output "issuer_namespace" {
@@ -9,13 +9,13 @@ output "issuer_namespace" {
 }
 
 output "wildcard_certificate_secret" {
-  description = "Name of the Secret the wildcard *.<services_zone> certificate is stored in (in var.namespace), or null when wildcard_certificate_enabled is false. Mount/reference it for TLS termination."
-  value       = var.wildcard_certificate_enabled ? local.wildcard_secret_name : null
+  description = "Name of the Secret the wildcard *.<services_zone> certificate is stored in (in local.arg_namespace), or null when wildcard_certificate_enabled is false. Mount/reference it for TLS termination."
+  value       = local.arg_wildcard_certificate_enabled ? local.wildcard_secret_name : null
 }
 
 output "ingress_class" {
   description = "Ingress class to put on Ingress objects routed through this edge (\"traefik\" when this module installed it; otherwise the cluster's existing class)."
-  value       = var.install_ingress_controller ? "traefik" : null
+  value       = local.arg_install_ingress_controller ? "traefik" : null
 }
 
 output "namespace" {
@@ -30,5 +30,5 @@ output "dns01_webhook_installed" {
 
 output "coredns_forward_installed" {
   description = "Whether this apply installed the CoreDNS custom forward zone for base_domain_name (the resolved value of install_coredns_forward). True means in-cluster resolution of the platform's own published names no longer depends on the node's resolver chain."
-  value       = var.install_coredns_forward
+  value       = local.arg_install_coredns_forward
 }

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/tests/null_inputs.tftest.hcl
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/tests/null_inputs.tftest.hcl
@@ -1,0 +1,122 @@
+# Locks #1161: a wrapper module cannot conditionally omit an argument in HCL, so
+# "use this module's default" has to be expressible as an explicit null. Terraform
+# does not substitute a variable's default for a caller-assigned null -- the null
+# reaches validation and every use -- so without normalization `length(null)`
+# aborts before any plan and `null != ""` is *true*, quietly selecting the wrong
+# branch of a guard. Runs entirely against mocked providers: no real cluster.
+
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+
+variables {
+  services_zone        = "services.example.com"
+  acme_email           = "ops@example.com"
+  cloudflare_api_token = "test-token"
+}
+
+# The reported reproduction: a wrapper threading its own optional variables
+# through passes null for the ones its caller left unset. Every one of these was
+# either an abort or a wrong-branch selection before normalization.
+run "null_for_every_optional_input_resolves_the_documented_defaults" {
+  command = plan
+
+  variables {
+    install_coredns_forward          = true
+    base_domain_name                 = "erunpaas.com"
+    coredns_forward_upstreams        = null
+    acme_server                      = null
+    namespace                        = null
+    ingress_namespace                = null
+    issuer_name                      = null
+    cert_manager_chart_version       = null
+    traefik_chart_version            = null
+    dns01_provider                   = null
+    dns01_webhook_image              = null
+    dns01_webhook_image_pull_secrets = null
+    dns01_webhook_group_name         = null
+    broker_url                       = null
+    dns01_token_secret_name          = null
+    powerdns_nameserver              = null
+    rfc2136_tsig_key_name            = null
+    rfc2136_tsig_algorithm           = null
+    rfc2136_tsig_secret              = null
+    env_label                        = null
+    env_namespace                    = null
+    per_env_certificate_enabled      = null
+    install_ingress_controller       = null
+    install_cert_manager             = null
+    wildcard_certificate_enabled     = null
+  }
+
+  # The originally-reported abort: length(null) on the upstreams list.
+  assert {
+    condition     = can(regex("forward \\. 1\\.1\\.1\\.1 1\\.0\\.0\\.1 8\\.8\\.8\\.8", kubernetes_config_map.coredns_forward[0].data["erunpaas-com.server"]))
+    error_message = "coredns_forward_upstreams = null must resolve to the module's documented default resolvers, not abort on length(null)"
+  }
+
+  # The trap that cost a release: `null != ""` is true, so the guard selected
+  # null as the image and left the helm release with a valueless set block.
+  assert {
+    condition     = can(regex("^ghcr\\.io/sophium/erun-dns01-webhook:", local.dns01_webhook_image))
+    error_message = "dns01_webhook_image = null must fall back to the bundled chart's own release, not be selected as the image"
+  }
+
+  assert {
+    condition     = local.arg_namespace == "cert-manager"
+    error_message = "namespace = null must resolve to the documented default"
+  }
+
+  assert {
+    condition     = local.arg_issuer_name == "erun-cloudflare"
+    error_message = "issuer_name = null must resolve to the documented default"
+  }
+
+  assert {
+    condition     = local.arg_dns01_provider == "cloudflare"
+    error_message = "dns01_provider = null must resolve to the documented default rather than failing its contains() validation"
+  }
+
+  assert {
+    condition     = length(local.arg_dns01_webhook_image_pull_secrets) == 0
+    error_message = "a null list input must resolve to the empty default"
+  }
+
+  assert {
+    condition     = output.ingress_class == "traefik"
+    error_message = "install_ingress_controller = null must resolve to the default true, not a null condition"
+  }
+}
+
+# The normalization must test for null specifically. coalesce() is the obvious
+# reach and is wrong twice over: it skips empty strings as well as nulls, and
+# coalesce("", "") is a hard error -- so an optional string that is legitimately
+# empty would either be silently replaced by the default or abort the apply.
+run "an_explicitly_empty_input_is_not_replaced_by_the_default" {
+  command = plan
+
+  variables {
+    broker_url              = ""
+    dns01_token_secret_name = ""
+    powerdns_nameserver     = ""
+  }
+
+  assert {
+    condition     = local.arg_broker_url == ""
+    error_message = "an empty optional string must stay empty: coalesce() would abort here, since all its arguments would be empty"
+  }
+}
+
+# The mirror for booleans: an explicit false against a true default must be
+# honored, not promoted to the default.
+run "an_explicit_false_is_honored_against_a_true_default" {
+  command = plan
+
+  variables {
+    install_ingress_controller = false
+  }
+
+  assert {
+    condition     = output.ingress_class == null
+    error_message = "install_ingress_controller = false must be honored, not replaced by the true default"
+  }
+}

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/variables.tf
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/variables.tf
@@ -2,7 +2,7 @@ variable "cloudflare_api_token" {
   description = "Cloudflare API token cert-manager's DNS-01 solver uses to prove control of the services zone, when dns01_provider is \"cloudflare\". The same account-scoped token erun injects as CLOUDFLARE_API_TOKEN (Zone:Read + DNS:Edit); pass it as TF_VAR_cloudflare_api_token. Materialized into a Kubernetes Secret because cert-manager needs it in-cluster. Leave empty when dns01_provider is \"powerdns-rfc2136\" or \"powerdns-broker\" (only the cloudflare solver reads this secret; a precondition still requires it for the cloudflare provider)."
   type        = string
   sensitive   = true
-  default     = ""
+  default     = null
 }
 
 variable "acme_email" {
@@ -28,64 +28,64 @@ variable "services_zone" {
 variable "acme_server" {
   description = "ACME directory URL. Defaults to Let's Encrypt production; point at the staging directory (https://acme-staging-v02.api.letsencrypt.org/directory) while validating to avoid rate limits."
   type        = string
-  default     = "https://acme-v02.api.letsencrypt.org/directory"
+  default     = null
 }
 
 variable "install_ingress_controller" {
   description = "Install Traefik as the ingress controller. Set false on a cluster that already has one (then point routes at the existing ingressClassName)."
   type        = bool
-  default     = true
+  default     = null
 }
 
 variable "install_cert_manager" {
   description = "Install cert-manager (and its CRDs). Set false on a cluster that already runs it; the Issuer is still created."
   type        = bool
-  default     = true
+  default     = null
 }
 
 variable "wildcard_certificate_enabled" {
   description = "Issue a wildcard Certificate for *.<services_zone> from the namespaced Issuer. Leave true in production; set false for a local apply with no real DNS zone (the Issuer is still created, it just issues nothing)."
   type        = bool
-  default     = true
+  default     = null
 }
 
 variable "namespace" {
   description = "Namespace cert-manager, the Cloudflare token Secret, and the wildcard Certificate live in."
   type        = string
-  default     = "cert-manager"
+  default     = null
 }
 
 variable "ingress_namespace" {
   description = "Namespace the Traefik ingress controller is installed into."
   type        = string
-  default     = "traefik"
+  default     = null
 }
 
 variable "issuer_name" {
   description = "Name of the namespaced cert-manager Issuer this module creates."
   type        = string
-  default     = "erun-cloudflare"
+  default     = null
 }
 
 variable "cert_manager_chart_version" {
   description = "Pinned cert-manager Helm chart version. Keep >= v1.17.2: earlier versions delete the DNS-01 _acme-challenge TXT with an empty Cloudflare zone id, orphaning records and wedging issuance/renewal."
   type        = string
-  default     = "v1.20.3"
+  default     = null
 }
 
 variable "traefik_chart_version" {
   description = "Pinned Traefik Helm chart version."
   type        = string
-  default     = "33.2.1"
+  default     = null
 }
 
 variable "dns01_provider" {
   description = "cert-manager DNS-01 solver used by the platform's OWN wildcard Issuer (this module's issuer_name Issuer) — not the per-cluster webhook shim, which install_dns01_webhook controls independently. \"cloudflare\" (default, back-compat) solves in the Cloudflare zone; \"powerdns-rfc2136\" solves via DNS UPDATE + TSIG directly against the self-hosted PowerDNS (single-tenant platform cluster only — the zone-wide TSIG key is an impersonation hole on a shared cluster); \"powerdns-broker\" routes the platform's own Issuer through the same brokered webhook path a multi-tenant platform's per-tenant Issuers use, authorized against the env's own subzone. A hosted platform typically keeps its own Issuer on \"cloudflare\" or \"powerdns-rfc2136\" while still setting install_dns01_webhook = true so the per-tenant brokered Issuers erun expose provisions can solve."
   type        = string
-  default     = "cloudflare"
+  default     = null
 
   validation {
-    condition     = contains(["cloudflare", "powerdns-rfc2136", "powerdns-broker"], var.dns01_provider)
+    condition     = var.dns01_provider == null || contains(["cloudflare", "powerdns-rfc2136", "powerdns-broker"], var.dns01_provider)
     error_message = "dns01_provider must be \"cloudflare\", \"powerdns-rfc2136\", or \"powerdns-broker\"."
   }
 }
@@ -99,89 +99,89 @@ variable "install_dns01_webhook" {
 variable "dns01_webhook_image_pull_secrets" {
   description = "Names of image pull secrets for the DNS-01 webhook shim's image, in the cert-manager namespace. Empty for a public registry. Needed because the shim's image can be private while the rest of a release is not -- an unauthenticated pull leaves the APIService at MissingEndpoints, and a webhook that cannot start makes hosted environments undeletable."
   type        = list(string)
-  default     = []
+  default     = null
 }
 
 variable "broker_url" {
   description = "Base URL of the DNS-01 broker the webhook shim forwards to (the shim appends /present and /cleanup), e.g. \"https://api.frs-prod.services.example.com/v1/dns01\". Required when the webhook shim is installed (install_dns01_webhook)."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "dns01_token_secret_name" {
   description = "Name of the Secret, in the env (Issuer) namespace, holding this env's DNS-01 broker token under key \"token\" (minted by the backend's POST /v1/environments/{id}/dns01-token). The per-tenant Issuer's webhook solver references it. Required when the webhook shim is installed (install_dns01_webhook)."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "dns01_webhook_group_name" {
   description = "API group the per-cluster DNS-01 webhook shim registers under; the per-tenant Issuer's webhook solver selects it. A cluster singleton — keep stable."
   type        = string
-  default     = "acme.erun.io"
+  default     = null
 }
 
 variable "dns01_webhook_image" {
   description = "Container image (repository:tag) for the DNS-01 webhook shim, e.g. \"ghcr.io/sophium/erun-dns01-webhook:1.0.150\". Optional: left empty (the default), it resolves to ghcr.io/sophium/erun-dns01-webhook at the version chart-dns01-webhook/Chart.yaml (bundled in this module) is itself released at, so the shim can never disagree with the module it ships beside. Set it only to override that — e.g. to test a build ahead of a release."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "powerdns_nameserver" {
   description = "host:port of the PowerDNS the RFC2136 solver sends DNS UPDATE to (e.g. \"erun-powerdns.frs-prod.svc.cluster.local:53\"). Required when dns01_provider is \"powerdns-rfc2136\"."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "rfc2136_tsig_key_name" {
   description = "TSIG key name authorized for dynamic updates on the services zone (the erun-powerdns chart's tsig key-name). Required for powerdns-rfc2136."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "rfc2136_tsig_algorithm" {
   description = "TSIG algorithm in cert-manager's form (e.g. HMACSHA256). PowerDNS uses its own lowercase form (hmac-sha256) internally; keep them the same algorithm."
   type        = string
-  default     = "HMACSHA256"
+  default     = null
 }
 
 variable "rfc2136_tsig_secret" {
   description = "Base64 TSIG key material (the erun-powerdns chart's tsig-secret, read back from its Secret). Materialized into a Secret cert-manager's rfc2136 solver references. Required for powerdns-rfc2136."
   type        = string
   sensitive   = true
-  default     = ""
+  default     = null
 }
 
 variable "per_env_certificate_enabled" {
   description = "Issue a per-env wildcard Certificate *.<env_label>.<services_zone> into the env namespace, whose Secret `erun expose` references for TLS. Enable in the platform/serving env."
   type        = bool
-  default     = false
+  default     = null
 }
 
 variable "env_label" {
   description = "The <tenant>-<env> label the per-env wildcard covers (e.g. \"frs-prod\" → *.frs-prod.<services_zone>). Required when per_env_certificate_enabled."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "env_namespace" {
   description = "Namespace the per-env wildcard Certificate + its Secret live in (the env's own namespace, e.g. frs-prod), so a co-located Ingress can reference the Secret. Defaults to env_label when unset."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "install_coredns_forward" {
   description = "Install a CoreDNS custom server block that forwards base_domain_name to coredns_forward_upstreams, so in-cluster resolution of the platform's own published names does not depend on the node's resolver chain. k3s's bundled CoreDNS otherwise ends in \"forward . /etc/resolv.conf\", so a stale or wrong answer from the node's own resolver fails cert-manager's HTTP-01 self-check the same way at issuance and at every unattended renewal. Left false by default so an existing cluster's DNS behavior does not change on a module upgrade; enable it explicitly per cluster."
   type        = bool
-  default     = false
+  default     = null
 }
 
 variable "base_domain_name" {
   description = "The platform's own apex domain (the platform config's basedomain, e.g. \"example.com\"), whose published names — including the delegated services_zone subdomain — must resolve in-cluster independently of the node's resolver. Required when install_coredns_forward is true."
   type        = string
-  default     = ""
+  default     = null
 
   validation {
-    condition     = var.base_domain_name == "" || can(regex("^([a-z0-9]([a-z0-9-]*[a-z0-9])?\\.)+[a-z]{2,}$", var.base_domain_name))
+    condition     = var.base_domain_name == null || var.base_domain_name == "" || can(regex("^([a-z0-9]([a-z0-9-]*[a-z0-9])?\\.)+[a-z]{2,}$", var.base_domain_name))
     error_message = "base_domain_name must be a valid DNS domain such as \"example.com\"."
   }
 }
@@ -189,10 +189,10 @@ variable "base_domain_name" {
 variable "coredns_forward_upstreams" {
   description = "Upstream DNS resolvers CoreDNS forwards base_domain_name queries to, in CoreDNS forward-plugin argument order. Defaults to public recursive resolvers (Cloudflare + Google), matching the documented workaround; a cluster on an air-gapped or policy-constrained network should point this at its own resolvers instead. Only used when install_coredns_forward is true."
   type        = list(string)
-  default     = ["1.1.1.1", "1.0.0.1", "8.8.8.8"]
+  default     = null
 
   validation {
-    condition     = length(var.coredns_forward_upstreams) > 0
+    condition     = var.coredns_forward_upstreams == null || length(var.coredns_forward_upstreams) > 0
     error_message = "coredns_forward_upstreams must list at least one resolver."
   }
 }


### PR DESCRIPTION
## Summary

Closes #1161.

Terraform does not substitute a variable's default when a caller assigns an explicit `null` — the null reaches the variable's own validation and every use. So `length(null)` aborted before any plan could run, and `null != ""` evaluated **true**, quietly selecting the wrong branch of a guard.

A wrapper module cannot conditionally omit an argument in HCL. Its only options were to pass `null` (which broke) or to duplicate the module's default in the tenant repo — so the resolver list, image reference and every other default ended up written down in two places, free to diverge. That is the exact drift this module's own documentation warns about.

This was not hypothetical. It blocked `terraform import` on frs/prod — the step the module's own comment tells an operator to run first on a cluster that already carries a hand-applied `coredns-custom`. The documented adoption path failed at its first command. A second instance of the same trap, one line away in the same file (`dns01_webhook_image`, where `null != ""` selected `null` as the image and left the helm release with a valueless `set` block), cost a release and a deploy to discover.

## Fix

The issue asked to check the other variables for the same pattern before closing, so this covers all of them rather than the one that was reported.

- **Every optional input declares `default = null`** and resolves its effective value exactly once, in a single `locals` block. Each default now lives in one place; there is nothing for a wrapper to duplicate.
- **The resolution tests `== null`, deliberately not `coalesce()`.** This matters, and I nearly shipped the wrong version: `coalesce` skips *empty strings* as well as nulls, so `coalesce(var.broker_url, "")` would silently replace a legitimately empty input with the default — and `coalesce("", "")` is a hard error, which would have aborted every apply where an optional string is genuinely unset. Verified directly in `terraform console`:
  ```
  coalesce("", "fallback")  →  "fallback"
  coalesce("", "")          →  Call to function "coalesce" failed:
                               no non-null, non-empty-string arguments.
  ```
- **`dns01_provider`, `base_domain_name` and `coredns_forward_upstreams` validations are null-tolerant**, so a null reaches the default rather than failing validation.
- **`outputs.tf` reads the resolved values too.** Reading the raw variables there left `var.install_ingress_controller ? "traefik" : null` as a null condition — a gap the module's existing tests caught after I first patched only `main.tf`.

## Verification

`terraform fmt`, `terraform validate`, and `terraform test`: **15 passed, 0 failed** — the 12 pre-existing tests plus 3 new ones. All against mocked providers; no cluster is touched.

New `tests/null_inputs.tftest.hcl`:

1. **`null_for_every_optional_input_resolves_the_documented_defaults`** — passes `null` for all 25 optional inputs at once and asserts the documented defaults come back, including the originally-reported upstreams abort and the `dns01_webhook_image` fallback (which resolved to `ghcr.io/sophium/erun-dns01-webhook:1.0.198`, confirming the bundled chart's appVersion is still the source).
2. **`an_explicitly_empty_input_is_not_replaced_by_the_default`** — pins the first coalesce trap.
3. **`an_explicit_false_is_honored_against_a_true_default`** — pins the second.

I confirmed the new file fails against the unfixed module rather than passing vacuously. Reverting only `main.tf`/`variables.tf`/`outputs.tf` and keeping the tests reproduces the reported abort:

```
Error: Invalid function argument
Invalid value for "value" parameter: argument must not be null.
Error: Null condition          (x3)
Error: Invalid template interpolation value   (x6)
```

## Follow-up not in this PR

#1165 covers the remaining findings against this same CoreDNS resource — unvalidated upstream entries, exclusive ownership of the shared `kube-system/coredns-custom` singleton, and the silent no-op when the Corefile has no `*.server` import. Those are behavioural changes needing cluster verification, so they are deliberately not folded in here.