### PR TITLE
Retract ACME challenges before tearing the namespace down

### DIFF
--- a/erun-common/kubernetes_namespace.go
+++ b/erun-common/kubernetes_namespace.go
@@ -112,8 +112,20 @@ func TraceDeleteKubernetesNamespace(ctx Context, contextName, namespace string) 
 	if contextName != "" {
 		args = append(args, "--context", contextName)
 	}
+	traceRetractACMEChallenges(ctx, contextName, namespace)
+
 	args = append(args, "delete", "namespace", namespace, "--ignore-not-found", "--timeout", NamespaceDeleteTimeout.String())
 	ctx.TraceCommand("", "kubectl", args...)
+}
+
+// traceRetractACMEChallenges mirrors retractACMEChallenges for a dry run, so
+// the traced sequence is the one a real delete runs.
+func traceRetractACMEChallenges(ctx Context, contextName, namespace string) {
+	ctx.TraceCommand("", "kubectl", append(kubernetesContextArgs(contextName),
+		"-n", namespace, "delete", "certificates.cert-manager.io", "--all",
+		"--ignore-not-found", "--timeout", acmeRetractTimeout.String())...)
+	ctx.TraceCommand("", "kubectl", append(kubernetesContextArgs(contextName),
+		"-n", namespace, "get", "challenges.acme.cert-manager.io", "-o", "name")...)
 }
 
 // DeleteKubernetesNamespace deletes a namespace and waits up to
@@ -135,6 +147,18 @@ func DeleteKubernetesNamespace(contextName, namespace string) error {
 	if contextName != "" {
 		args = append(args, "--context", contextName)
 	}
+	// Retract any in-flight ACME challenge before the namespace teardown that
+	// would remove the credential its cleanup needs (#1174). Deleting the
+	// namespace first removes the env's DNS-01 token Secret as ordinary
+	// content, and Kubernetes gives no ordering guarantee against cert-manager
+	// finalizing a still-pending Challenge in the same namespace -- so the
+	// finalizer would never clear and the namespace would sit in Terminating
+	// for the full NamespaceDeleteTimeout. Best-effort by design: a cluster
+	// with no cert-manager, or a challenge that will not finalize, must not
+	// block the delete. If a challenge does survive this, the namespace's own
+	// conditions still name it in NamespaceTerminationBlockedError below.
+	retractACMEChallenges(contextName, namespace)
+
 	args = append(args, "delete", "namespace", namespace, "--ignore-not-found", "--timeout", NamespaceDeleteTimeout.String())
 
 	output, err := Command("kubectl", args...).CombinedOutput()
@@ -153,6 +177,59 @@ func DeleteKubernetesNamespace(contextName, namespace string) error {
 		return fmt.Errorf("failed to delete kubernetes namespace %q in context %q: %w", namespace, contextName, err)
 	}
 	return fmt.Errorf("failed to delete kubernetes namespace %q in context %q: %w: %s", namespace, contextName, err, message)
+}
+
+// acmeRetractTimeout bounds the pre-teardown challenge retraction. Short on
+// purpose: it is an optimization that avoids a 20-minute wedge, so it must
+// never itself become a long wait. A challenge that has not finalized by then
+// is left to the namespace delete, where the webhook shim's own tolerance for
+// an already-deleted token Secret clears the finalizer instead.
+const acmeRetractTimeout = 90 * time.Second
+
+// retractACMEChallenges deletes the namespace's cert-manager Certificates and
+// waits for its ACME Challenges to finalize, so a challenge's cleanup runs
+// while the DNS-01 token Secret it authenticates with still exists.
+//
+// Every failure here is deliberately swallowed. On a cluster without
+// cert-manager the CRDs do not exist and kubectl reports an unknown resource
+// type, which is the common case for a local or test cluster and is not an
+// error in any meaningful sense. The caller's contract is "delete this
+// namespace", and this function only ever makes that faster.
+func retractACMEChallenges(contextName, namespace string) {
+	if !acmeChallengesPresent(contextName, namespace) {
+		return
+	}
+
+	args := append(kubernetesContextArgs(contextName),
+		"-n", namespace, "delete", "certificates.cert-manager.io", "--all",
+		"--ignore-not-found", "--timeout", acmeRetractTimeout.String())
+	_, _ = Command("kubectl", args...).CombinedOutput()
+
+	// Wait for the challenges to actually go, rather than assuming the
+	// Certificate delete cascaded synchronously -- cert-manager removes the
+	// Order and its Challenges asynchronously, and it is the Challenge's
+	// finalizer, not the Certificate's, that blocks the namespace.
+	deadline := time.Now().Add(acmeRetractTimeout)
+	for time.Now().Before(deadline) {
+		if !acmeChallengesPresent(contextName, namespace) {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// acmeChallengesPresent reports whether the namespace currently has any ACME
+// Challenge. A read that fails for any reason -- no cert-manager CRDs, no
+// permission, apiserver unavailable -- reports false, so the caller skips the
+// retraction rather than looping on a question it cannot answer.
+func acmeChallengesPresent(contextName, namespace string) bool {
+	args := append(kubernetesContextArgs(contextName),
+		"-n", namespace, "get", "challenges.acme.cert-manager.io", "-o", "name")
+	output, err := Command("kubectl", args...).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(output)) != ""
 }
 
 // namespaceTerminationConditions reads back a namespace's own status

--- a/erun-devops/dns01-webhook/solver.go
+++ b/erun-devops/dns01-webhook/solver.go
@@ -10,13 +10,16 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/cert-manager/cert-manager/pkg/acme/webhook/apis/acme/v1alpha1"
 	extapi "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -57,8 +60,28 @@ func (s *brokerSolver) Present(ch *v1alpha1.ChallengeRequest) error {
 	return s.forward(ch, "present")
 }
 
+// CleanUp retracts the challenge record. A token Secret that no longer exists
+// is treated as nothing left to retract rather than an error, because that is
+// exactly what an environment delete produces: namespace teardown removes the
+// env's DNS-01 token Secret as ordinary content, and Kubernetes gives no
+// ordering guarantee against cert-manager finalizing a still-pending Challenge
+// in the same namespace. Returning an error there is unrecoverable -- nothing
+// will ever recreate the Secret, so every retry fails identically, the
+// acme.cert-manager.io finalizer never clears, and the namespace sits in
+// Terminating until its 20-minute timeout (#1174).
+//
+// Present deliberately does not tolerate this: a missing token when presenting
+// is a real misconfiguration and must surface.
 func (s *brokerSolver) CleanUp(ch *v1alpha1.ChallengeRequest) error {
-	return s.forward(ch, "cleanup")
+	err := s.forward(ch, "cleanup")
+	if errors.Is(err, errTokenSecretGone) {
+		// The record may be left behind in the zone; that is the lesser
+		// failure, and the delete path retracts challenges before tearing the
+		// namespace down precisely so this branch stays rare.
+		log.Printf("dns01 webhook: cleanup for %s: %v; treating as nothing left to retract", ch.ResolvedFQDN, err)
+		return nil
+	}
+	return err
 }
 
 func (s *brokerSolver) forward(ch *v1alpha1.ChallengeRequest, action string) error {
@@ -92,9 +115,19 @@ func (s *brokerSolver) forward(ch *v1alpha1.ChallengeRequest, action string) err
 	return nil
 }
 
+// errTokenSecretGone marks the one token-read failure a cleanup may ignore:
+// the Secret is absent, so there is no credential to retract with and never
+// will be. Every other read failure (RBAC, apiserver unavailable, a Secret
+// present but missing its key) is transient or a real misconfiguration and
+// must keep failing so cert-manager retries.
+var errTokenSecretGone = errors.New("dns01 token secret does not exist")
+
 func (s *brokerSolver) readToken(namespace string, cfg solverConfig) (string, error) {
 	secret, err := s.kube.CoreV1().Secrets(namespace).Get(context.Background(), cfg.TokenSecretRef.Name, metav1.GetOptions{})
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("read dns01 token secret %s/%s: %w", namespace, cfg.TokenSecretRef.Name, errTokenSecretGone)
+		}
 		return "", fmt.Errorf("read dns01 token secret %s/%s: %w", namespace, cfg.TokenSecretRef.Name, err)
 	}
 	key := cfg.TokenSecretRef.Key

--- a/erun-devops/dns01-webhook/solver_test.go
+++ b/erun-devops/dns01-webhook/solver_test.go
@@ -112,3 +112,75 @@ func TestLoadConfigRejectsIncomplete(t *testing.T) {
 		t.Fatal("expected an error when tokenSecretRef is missing")
 	}
 }
+
+// TestCleanUpToleratesADeletedTokenSecret is the regression test for #1174.
+// An environment delete removes the env's DNS-01 token Secret as ordinary
+// namespace content, with no ordering guarantee against cert-manager
+// finalizing a still-pending Challenge in the same namespace. If cleanup
+// errors there it errors forever -- nothing recreates the Secret -- so the
+// acme.cert-manager.io finalizer never clears and the namespace sits in
+// Terminating for its full 20-minute timeout.
+func TestCleanUpToleratesADeletedTokenSecret(t *testing.T) {
+	// No Secret at all: exactly the state namespace teardown leaves behind.
+	solver := &brokerSolver{kube: fake.NewSimpleClientset(), http: http.DefaultClient}
+	ch := &v1alpha1.ChallengeRequest{
+		ResourceNamespace: "acme-prod",
+		ResolvedFQDN:      "_acme-challenge.acme-prod.services.example.com.",
+		Key:               "challenge-value",
+		Config:            mustConfigJSON(t, "http://broker.invalid/v1/dns01"),
+	}
+
+	if err := solver.CleanUp(ch); err != nil {
+		t.Fatalf("cleanup with a deleted token secret = %v, want nil so the challenge finalizer can clear", err)
+	}
+
+	// Present must NOT tolerate it: a missing token when presenting is a real
+	// misconfiguration, and swallowing it would hand back a certificate that
+	// silently never gets a record.
+	if err := solver.Present(ch); err == nil {
+		t.Fatal("present with a missing token secret returned nil; a missing credential must surface when presenting")
+	}
+}
+
+// TestCleanUpStillFailsWhenTheSecretExistsButTheBrokerIsUnreachable holds the
+// tolerance to the one case it is for. A reachable-but-broken broker, or any
+// other cleanup failure, must keep returning an error so cert-manager retries
+// rather than dropping the record on the floor.
+func TestCleanUpStillFailsWhenTheSecretExistsButTheBrokerIsUnreachable(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "acme-prod-dns01-token", Namespace: "acme-prod"},
+		Data:       map[string][]byte{"token": []byte("env-token-xyz")},
+	}
+	solver := &brokerSolver{kube: fake.NewSimpleClientset(secret), http: http.DefaultClient}
+	ch := &v1alpha1.ChallengeRequest{
+		ResourceNamespace: "acme-prod",
+		ResolvedFQDN:      "_acme-challenge.acme-prod.services.example.com.",
+		Key:               "challenge-value",
+		Config:            mustConfigJSON(t, "http://127.0.0.1:1/v1/dns01"),
+	}
+
+	if err := solver.CleanUp(ch); err == nil {
+		t.Fatal("cleanup with a live token but an unreachable broker returned nil; that record is still in the zone")
+	}
+}
+
+// TestCleanUpDoesNotTolerateASecretMissingItsKey: a Secret that exists but has
+// no token key is a misconfiguration, not a deleted environment, so it must
+// not take the tolerance path.
+func TestCleanUpDoesNotTolerateASecretMissingItsKey(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "acme-prod-dns01-token", Namespace: "acme-prod"},
+		Data:       map[string][]byte{"not-the-token": []byte("x")},
+	}
+	solver := &brokerSolver{kube: fake.NewSimpleClientset(secret), http: http.DefaultClient}
+	ch := &v1alpha1.ChallengeRequest{
+		ResourceNamespace: "acme-prod",
+		ResolvedFQDN:      "_acme-challenge.acme-prod.services.example.com.",
+		Key:               "challenge-value",
+		Config:            mustConfigJSON(t, "http://broker.invalid/v1/dns01"),
+	}
+
+	if err := solver.CleanUp(ch); err == nil {
+		t.Fatal("cleanup with a Secret missing its token key returned nil; that is a misconfiguration and must surface")
+	}
+}

--- a/erun-integration/delete_test.go
+++ b/erun-integration/delete_test.go
@@ -189,6 +189,104 @@ func TestDelete(t *testing.T) {
 		}
 	})
 
+	t.Run("real_run_retracts_challenges_before_deleting_the_namespace", func(t *testing.T) {
+		// #1174: namespace teardown removes the env's DNS-01 token Secret as
+		// ordinary content, and Kubernetes gives no ordering guarantee against
+		// cert-manager finalizing a still-pending Challenge in the same
+		// namespace. The Challenge's cleanup needs that Secret to retract its
+		// record, so if the namespace goes first the finalizer never clears and
+		// the namespace sits in Terminating for the full 20-minute timeout.
+		// The delete must therefore retract challenges FIRST, while the
+		// credential still exists. This asserts that ordering directly.
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		callLog := filepath.Join(setup.Cwd, "kubectl-calls.log")
+		counter := filepath.Join(setup.Cwd, "challenge-gets")
+		fixture.StubBinaryWithScript(t, stubs, "kubectl",
+			`printf '%s\n' "$*" >> '`+filepath.ToSlash(callLog)+`'
+case "$*" in
+  *"get challenges"*)
+    # Present on the first look, gone once the Certificate delete has been
+    # processed -- the real asynchronous shape, so the wait loop is exercised
+    # rather than short-circuited.
+    if [ -f '`+filepath.ToSlash(counter)+`' ]; then
+      exit 0
+    fi
+    printf '%s\n' 'challenge.acme.cert-manager.io/team-dev-wildcard-1-x'
+    ;;
+  *"delete certificates.cert-manager.io"*)
+    : > '`+filepath.ToSlash(counter)+`'
+    ;;
+esac
+exit 0
+`)
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+		result := erun.Run(t, []string{"delete", "team", "dev", "--yes"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+
+		logged, err := os.ReadFile(callLog)
+		if err != nil {
+			t.Fatalf("read kubectl call log: %v", err)
+		}
+		calls := string(logged)
+		certDelete := strings.Index(calls, "delete certificates.cert-manager.io")
+		nsDelete := strings.Index(calls, "delete namespace team-dev")
+		if certDelete < 0 {
+			t.Fatalf("no certificate delete was issued; challenges would never be retracted:\n%s", calls)
+		}
+		if nsDelete < 0 {
+			t.Fatalf("the namespace was never deleted:\n%s", calls)
+		}
+		if certDelete > nsDelete {
+			t.Fatalf("certificates were deleted AFTER the namespace, which is the bug:\n%s", calls)
+		}
+		if !strings.Contains(calls, "get challenges.acme.cert-manager.io") {
+			t.Fatalf("the retraction never waited for the challenges to finalize:\n%s", calls)
+		}
+	})
+
+	t.Run("real_run_without_cert_manager_skips_the_retraction", func(t *testing.T) {
+		// The retraction is an optimization, so a cluster with no cert-manager
+		// (the normal case for a local or test cluster, where the CRDs do not
+		// exist and kubectl reports an unknown resource type) must pay nothing
+		// for it: no certificate delete, no waiting, and the namespace delete
+		// unaffected.
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		callLog := filepath.Join(setup.Cwd, "kubectl-calls.log")
+		fixture.StubBinaryWithScript(t, stubs, "kubectl",
+			`printf '%s\n' "$*" >> '`+filepath.ToSlash(callLog)+`'
+case "$*" in
+  *"get challenges"*)
+    printf '%s\n' 'error: the server doesn'"'"'t have a resource type "challenges"' >&2
+    exit 1
+    ;;
+esac
+exit 0
+`)
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+		result := erun.Run(t, []string{"delete", "team", "dev", "--yes"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+
+		logged, err := os.ReadFile(callLog)
+		if err != nil {
+			t.Fatalf("read kubectl call log: %v", err)
+		}
+		calls := string(logged)
+		if strings.Contains(calls, "delete certificates.cert-manager.io") {
+			t.Fatalf("a cluster without cert-manager must not be asked to delete certificates:\n%s", calls)
+		}
+		if !strings.Contains(calls, "delete namespace team-dev") {
+			t.Fatalf("the namespace delete must still happen:\n%s", calls)
+		}
+	})
+
 	t.Run("real_run_namespace_delete_failure_warns_and_continues", func(t *testing.T) {
 		// A failed namespace delete is non-fatal: kubectl's error is surfaced
 		// as a warning on stderr and the local config delete still proceeds.

--- a/erun-integration/testdata/delete/dry_run_with_remote_env_traces_namespace_delete.txt
+++ b/erun-integration/testdata/delete/dry_run_with_remote_env_traces_namespace_delete.txt
@@ -1,3 +1,5 @@
 audit: erun delete --dry-run team dev
+kubectl --context test-context -n team-dev delete certificates.cert-manager.io --all --ignore-not-found --timeout 1m30s
+kubectl --context test-context -n team-dev get challenges.acme.cert-manager.io -o name
 kubectl --context test-context delete namespace team-dev --ignore-not-found --timeout 20m0s
 rm -rf <TMP>

--- a/erun-integration/testdata/delete/dry_run_with_runtime_type_traces_namespace_delete.txt
+++ b/erun-integration/testdata/delete/dry_run_with_runtime_type_traces_namespace_delete.txt
@@ -1,3 +1,5 @@
 audit: erun delete --dry-run team prod
+kubectl --context test-context -n team-prod delete certificates.cert-manager.io --all --ignore-not-found --timeout 1m30s
+kubectl --context test-context -n team-prod get challenges.acme.cert-manager.io -o name
 kubectl --context test-context delete namespace team-prod --ignore-not-found --timeout 20m0s
 rm -rf <TMP>


### PR DESCRIPTION
## Summary

Closes #1174.

Deleting an environment while its per-env certificate was still being issued wedged the namespace for the full 20-minute `NamespaceDeleteTimeout`, then drove the row to `deletion-blocked`. Found on `frs-prod` while running the end-to-end gate for #1163, on an environment about a minute old:

```
Error cleaning up challenge: read dns01 token secret
operations-gate1163/operations-gate1163-dns01-token: secrets
"operations-gate1163-dns01-token" not found
```

Namespace teardown removes the env's DNS-01 token Secret as ordinary content, and Kubernetes gives no ordering guarantee against cert-manager finalizing a still-pending Challenge in the same namespace — but that Challenge's cleanup authenticates to the broker with exactly that Secret. So cleanup failed, and failed *identically on every retry*, because nothing would ever recreate the Secret. `acme.cert-manager.io/finalizer` stayed set until the timeout.

This is not a narrow race. The Secret is essentially always removed first, so any Challenge still `processing` at delete time is unrecoverable — which for a short-lived environment is the common case, not an edge case. It also manufactures the very condition #1140, #1162 and #1166 exist to cope with, and orphans one `_acme-challenge` TXT record per occurrence since cleanup never runs.

## Fix

Two complementary changes, as sketched on the issue.

**`erun-common` — order the teardown.** `DeleteKubernetesNamespace` now deletes the namespace's cert-manager Certificates and waits for its Challenges to finalize *before* deleting the namespace, so cleanup runs while the credential still exists and the record is properly retracted. Deliberately best-effort and short-bounded (90s):

- A cluster with no cert-manager has no CRDs, so the challenge read fails and the retraction is skipped at zero cost. That is the normal case for a local or test cluster and is not an error in any meaningful sense.
- It waits for the Challenges rather than assuming the Certificate delete cascaded synchronously — cert-manager removes the Order and its Challenges asynchronously, and it is the *Challenge's* finalizer, not the Certificate's, that blocks the namespace.
- A challenge that will not finalize is left to the namespace delete rather than becoming a long wait of its own. If one does survive, the namespace's own conditions still name it in `NamespaceTerminationBlockedError`, which is the diagnostic path that already works.

**`dns01-webhook` — tolerate the credential being gone on cleanup.** `CleanUp` treats an absent token Secret as nothing left to retract, so the finalizer clears even when the ordering fix is bypassed. Kept deliberately narrow via a sentinel error, so the tolerance covers only the one unrecoverable case:

| situation | behaviour |
|---|---|
| Secret deleted (namespace teardown) | cleanup returns nil, finalizer clears |
| `Present` with a missing token | still fails — a missing credential is a real misconfiguration |
| Secret exists but has no token key | still fails — misconfiguration, not a deleted env |
| live token, unreachable broker | still fails — that record is still in the zone |

The first change makes the normal path correct; the second keeps a missed case from costing 20 minutes. Neither alone is sufficient: without the ordering fix the record is silently abandoned, and without the tolerance any gap in the ordering still wedges a namespace.

## Verification

**Shim unit tests (3 new).** `TestCleanUpToleratesADeletedTokenSecret` also asserts `Present` still fails, so the tolerance cannot leak to the presenting path. Confirmed the new test fails against the unfixed shim, reproducing the production error verbatim:

```
cleanup with a deleted token secret = read dns01 token secret
acme-prod/acme-prod-dns01-token: secrets "acme-prod-dns01-token" not found,
want nil so the challenge finalizer can clear
```

**Integration scenarios (2 new)**, since AGENTS.md gates `erun-common` coverage on this suite:

- `real_run_retracts_challenges_before_deleting_the_namespace` — a stub kubectl that reports a challenge until the Certificate delete is processed, then none. Asserts the certificate delete is issued **before** the namespace delete (the whole point), and that the wait actually polls rather than short-circuiting.
- `real_run_without_cert_manager_skips_the_retraction` — the challenge read fails with `the server doesn't have a resource type`, as a cluster with no cert-manager does. Asserts **no** certificate delete is issued and the namespace delete is unaffected.

**Full `erun-integration` suite green at 69s.** The two pre-existing delete goldens gain exactly the two new trace lines, in the correct order:

```
kubectl --context test-context -n team-prod delete certificates.cert-manager.io --all --ignore-not-found --timeout 1m30s
kubectl --context test-context -n team-prod get challenges.acme.cert-manager.io -o name
kubectl --context test-context delete namespace team-prod --ignore-not-found --timeout 20m0s
```

`gofmt`, `go build`, `go vet` clean on both modules.

## Not covered

The orphaned `_acme-challenge` records already left in the zone by past occurrences are not cleaned up by this change. Worth a sweep, but it is a data-repair task rather than part of the fix.