### PR TITLE
Bound the delete reconciler's retries and stop it stranding rows

### DIFF
--- a/erun-backend/erun-backend-api/internal/model/environment.go
+++ b/erun-backend/erun-backend-api/internal/model/environment.go
@@ -67,8 +67,17 @@ type Environment struct {
 	// DeleteError carries why a delete attempt did not tear the namespace down
 	// (the namespace's own conditions, verbatim, when it's stuck on an
 	// unsatisfiable finalizer) when Status is `deletion-blocked`. Owned by the
-	// delete executor, so scan-only; cleared on a fresh delete attempt.
-	DeleteError string    `json:"deleteError,omitempty" bun:"delete_error,scanonly,nullzero"`
-	CreatedAt   time.Time `json:"createdAt" bun:"created_at,scanonly"`
-	UpdatedAt   time.Time `json:"updatedAt" bun:"updated_at,scanonly"`
+	// delete executor, so scan-only. It is NOT cleared when a retry claims the
+	// row: an attempt's outcome overwrites it, so the recorded blocker stays
+	// readable for the whole time a teardown is stuck rather than blinking out
+	// on every reconciler tick (#1166).
+	DeleteError string `json:"deleteError,omitempty" bun:"delete_error,scanonly,nullzero"`
+	// DeleteAttempts counts how many delete attempts have claimed this row.
+	// Incremented by the claim, so it survives an attempt that dies without
+	// reporting. It is what bounds the reconciler's retries: past a cap the
+	// environment needs intervention, and re-attempting it forever only hides
+	// that. Owned by the claim, so scan-only.
+	DeleteAttempts int       `json:"deleteAttempts,omitempty" bun:"delete_attempts,scanonly"`
+	CreatedAt      time.Time `json:"createdAt" bun:"created_at,scanonly"`
+	UpdatedAt      time.Time `json:"updatedAt" bun:"updated_at,scanonly"`
 }

--- a/erun-backend/erun-backend-api/internal/provision/delete_reconciler.go
+++ b/erun-backend/erun-backend-api/internal/provision/delete_reconciler.go
@@ -20,6 +20,11 @@ import (
 type EnvDeleteReconcilerEnvironments interface {
 	ListByStatuses(ctx context.Context, statuses []model.EnvironmentStatus) ([]model.Environment, error)
 	ClaimDelete(ctx context.Context, environmentID string, staleAfter time.Duration) (bool, error)
+	// MarkDeleteBlocked is what keeps a claim from stranding a row: the claim
+	// has already moved it to `deleting`, so any failure between the claim and
+	// the workflow actually starting must record why, or the row is left
+	// claiming an in-flight delete that does not exist (#1166).
+	MarkDeleteBlocked(ctx context.Context, environmentID, reason string) error
 }
 
 // EnvDeleteReconcilerTenants resolves tenant identity for the reconciler's
@@ -42,6 +47,53 @@ type EnvDeleteReconcilerContexts interface {
 // *EnvDeleter.
 type EnvDeleteStarter interface {
 	Start(input EnvDeleteInput) error
+}
+
+// MaxDeleteAttempts bounds how many times the reconciler re-attempts one
+// environment's teardown. Past it the row is left alone: a teardown that has
+// failed this many times is not going to succeed on its own, and re-attempting
+// it forever buries that fact under identical ticks instead of surfacing it.
+// The row stays `deletion-blocked` with its recorded blocker and a visible
+// DeleteAttempts count, which together are the terminal "needs intervention"
+// state.
+const MaxDeleteAttempts = 8
+
+// deleteRetryFirstBackoff and deleteRetryMaxBackoff shape the wait between
+// re-attempts of a blocked teardown, doubling per attempt. Without a backoff
+// every blocked row was re-attempted on every tick, which for a namespace
+// wedged on an unsatisfiable finalizer is pure load with no chance of
+// progress.
+const (
+	deleteRetryFirstBackoff = 5 * time.Minute
+	deleteRetryMaxBackoff   = 2 * time.Hour
+)
+
+// deleteRetryBackoff is how long a row must sit after its previous attempt
+// before another is worth making: exponential in the attempt count, capped.
+func deleteRetryBackoff(attempts int) time.Duration {
+	if attempts < 1 {
+		return 0
+	}
+	backoff := deleteRetryFirstBackoff
+	for i := 1; i < attempts; i++ {
+		backoff *= 2
+		if backoff >= deleteRetryMaxBackoff {
+			return deleteRetryMaxBackoff
+		}
+	}
+	return backoff
+}
+
+// deleteRetryDue reports whether a blocked row has waited out its backoff.
+// Only `deletion-blocked` rows are held back: a stale `deleting` row means the
+// attempt behind it can no longer be live (DeleteClaimStaleAfter is already
+// longer than the Job's own deadline), so delaying that one further would just
+// leave a dead attempt sitting.
+func deleteRetryDue(environment model.Environment, now time.Time) bool {
+	if environment.Status != model.EnvironmentStatusDeletionBlocked {
+		return true
+	}
+	return !now.Before(environment.UpdatedAt.Add(deleteRetryBackoff(environment.DeleteAttempts)))
 }
 
 // EnvDeleteReconciler periodically re-attempts every environment whose
@@ -71,7 +123,10 @@ func NewEnvDeleteReconciler(dbosCtx dbos.DBOSContext, environments EnvDeleteReco
 // separate so reconcile itself is a plain function a test can call directly
 // against fakes without a live DBOS scheduler.
 func (r *EnvDeleteReconciler) tick(dctx dbos.DBOSContext, _ time.Time) (int, error) {
-	ctx := security.WithContext(context.Background(), security.Context{TenantType: string(model.TenantTypeOperations)})
+	// Rooted in the DBOS context, not context.Background(): a scan on a
+	// background context is uncancellable and keeps running straight through a
+	// shutdown (#1166).
+	ctx := security.WithContext(dctx, security.Context{TenantType: string(model.TenantTypeOperations)})
 	return r.reconcile(ctx)
 }
 
@@ -84,6 +139,10 @@ func (r *EnvDeleteReconciler) tick(dctx dbos.DBOSContext, _ time.Time) (int, err
 func (r *EnvDeleteReconciler) reconcile(ctx context.Context) (int, error) {
 	environments, err := r.environments.ListByStatuses(ctx, []model.EnvironmentStatus{model.EnvironmentStatusDeleting, model.EnvironmentStatusDeletionBlocked})
 	if err != nil {
+		// A reconciler failing every tick must not be indistinguishable from
+		// one with nothing to do -- silence is what let the original bug hide
+		// behind a successful-looking deploy (#1166).
+		log.Printf("erun api env delete reconciler: scan failed: %v", err)
 		return 0, err
 	}
 	if len(environments) == 0 {
@@ -92,6 +151,7 @@ func (r *EnvDeleteReconciler) reconcile(ctx context.Context) (int, error) {
 
 	tenants, err := r.tenants.List(ctx)
 	if err != nil {
+		log.Printf("erun api env delete reconciler: tenant scan failed with %d environment(s) mid-teardown: %v", len(environments), err)
 		return 0, err
 	}
 	tenantsByID := make(map[string]model.Tenant, len(tenants))
@@ -99,18 +159,64 @@ func (r *EnvDeleteReconciler) reconcile(ctx context.Context) (int, error) {
 		tenantsByID[tenant.TenantID] = tenant
 	}
 
-	restarted := 0
+	counts := r.reconcileEach(ctx, environments, tenantsByID)
+	// One line per tick that did something, so a reconciler doing work and a
+	// reconciler silently achieving nothing are distinguishable in the log.
+	if counts.restarted > 0 || counts.failed > 0 || counts.exhausted > 0 {
+		log.Printf("erun api env delete reconciler: %d mid-teardown environment(s): %d re-attempted, %d failed to start, %d exhausted, %d waiting on backoff",
+			len(environments), counts.restarted, counts.failed, counts.exhausted, counts.waiting)
+	}
+	return counts.restarted, nil
+}
+
+// reconcileCounts is one tick's tally, so the summary log can distinguish work
+// done from work deliberately skipped.
+type reconcileCounts struct {
+	restarted int
+	failed    int
+	exhausted int
+	waiting   int
+}
+
+// reconcileEach walks one tick's environments, applying the attempt cap and the
+// backoff before spending a claim on any of them. Split out of reconcile so
+// that function stays a readable scan-then-report.
+func (r *EnvDeleteReconciler) reconcileEach(ctx context.Context, environments []model.Environment, tenantsByID map[string]model.Tenant) reconcileCounts {
+	var counts reconcileCounts
+	now := time.Now()
 	for _, environment := range environments {
-		didRestart, err := r.reconcileOne(ctx, environment, tenantsByID)
-		if err != nil {
-			log.Printf("erun api env delete reconciler: environment=%q: %v", environment.EnvironmentID, err)
+		if environment.DeleteAttempts >= MaxDeleteAttempts {
+			counts.exhausted++
+			log.Printf("erun api env delete reconciler: environment=%q has failed %d delete attempts and needs intervention; not re-attempting. Recorded blocker: %s",
+				environment.EnvironmentID, environment.DeleteAttempts, firstLine(environment.DeleteError))
 			continue
 		}
-		if didRestart {
-			restarted++
+		if !deleteRetryDue(environment, now) {
+			counts.waiting++
+			continue
+		}
+		didRestart, err := r.reconcileOne(ctx, environment, tenantsByID)
+		switch {
+		case err != nil:
+			counts.failed++
+			log.Printf("erun api env delete reconciler: environment=%q: %v", environment.EnvironmentID, err)
+		case didRestart:
+			counts.restarted++
 		}
 	}
-	return restarted, nil
+	return counts
+}
+
+// firstLine trims a recorded blocker to its first line for a log message; the
+// full text stays on the row for anyone who needs it.
+func firstLine(s string) string {
+	if s == "" {
+		return "(none recorded)"
+	}
+	if i := strings.IndexByte(s, 0x0a); i >= 0 {
+		return s[:i]
+	}
+	return s
 }
 
 // reconcileOne reports whether it actually restarted a delete attempt, not
@@ -128,13 +234,15 @@ func (r *EnvDeleteReconciler) reconcileOne(ctx context.Context, environment mode
 		return false, nil
 	}
 
+	// Past this point the row is claimed and reads `deleting`, so every exit
+	// must either start a workflow or record why it could not (#1166).
 	tenant, ok := tenantsByID[environment.TenantID]
 	if !ok {
-		return false, fmt.Errorf("tenant %q not found", environment.TenantID)
+		return false, r.unclaim(ctx, environment.EnvironmentID, fmt.Errorf("tenant %q not found", environment.TenantID))
 	}
 	placement, err := r.resolvePlacement(ctx, environment.ContextID)
 	if err != nil {
-		return false, err
+		return false, r.unclaim(ctx, environment.EnvironmentID, fmt.Errorf("resolve placement: %w", err))
 	}
 
 	if err := r.deleter.Start(EnvDeleteInput{
@@ -149,9 +257,22 @@ func (r *EnvDeleteReconciler) reconcileOne(ctx context.Context, environment mode
 		PlacementServerURL:         placement.ServerURL,
 		DeleteID:                   uuid.NewString(),
 	}); err != nil {
-		return false, err
+		return false, r.unclaim(ctx, environment.EnvironmentID, fmt.Errorf("start delete workflow: %w", err))
 	}
 	return true, nil
+}
+
+// unclaim records why a claimed row's attempt never started, moving it back out
+// of `deleting` to `deletion-blocked` with a reason. Without this the reconciler
+// leaves the row claiming an in-flight delete that does not exist -- strictly
+// worse than not having ticked at all, and exactly the misreporting #1140 was
+// about. Returns the original cause so the caller still logs it; a failure to
+// record is folded in rather than replacing it.
+func (r *EnvDeleteReconciler) unclaim(ctx context.Context, environmentID string, cause error) error {
+	if err := r.environments.MarkDeleteBlocked(ctx, environmentID, cause.Error()); err != nil {
+		return fmt.Errorf("%w (and recording it did not persist: %v)", cause, err)
+	}
+	return cause
 }
 
 // runningVersion mirrors routes.EnvironmentRoutes.lifecycleInput's choice: the

--- a/erun-backend/erun-backend-api/internal/provision/delete_reconciler_test.go
+++ b/erun-backend/erun-backend-api/internal/provision/delete_reconciler_test.go
@@ -3,6 +3,7 @@ package provision
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,6 +23,18 @@ type fakeReconcilerEnvironments struct {
 	// successful claim; missing entries default to true (claimed).
 	claimResults map[string]bool
 	claimErr     error
+	// blocked records MarkDeleteBlocked calls: environmentID -> reason. This
+	// is what proves a claimed row is never left stranded in `deleting`.
+	blocked    map[string]string
+	blockedErr error
+}
+
+func (f *fakeReconcilerEnvironments) MarkDeleteBlocked(_ context.Context, environmentID, reason string) error {
+	if f.blocked == nil {
+		f.blocked = map[string]string{}
+	}
+	f.blocked[environmentID] = reason
+	return f.blockedErr
 }
 
 func (f *fakeReconcilerEnvironments) ListByStatuses(_ context.Context, _ []model.EnvironmentStatus) ([]model.Environment, error) {
@@ -204,5 +217,169 @@ func TestReconcilePropagatesAListError(t *testing.T) {
 
 	if _, err := r.reconcile(context.Background()); err == nil {
 		t.Fatal("expected the list error to propagate")
+	}
+}
+
+// TestReconcileRecordsAReasonWhenAClaimedAttemptCannotStart is the regression
+// test for #1166's worst path. The claim has already moved the row to
+// `deleting`, so a failure between the claim and the workflow starting used to
+// leave the row claiming an in-flight delete that did not exist -- strictly
+// less information than before the tick ran, which is exactly the misreporting
+// #1140 was about.
+func TestReconcileRecordsAReasonWhenAClaimedAttemptCannotStart(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		tenants     *fakeReconcilerTenants
+		deleter     *fakeDeleteStarter
+		wantInError string
+	}{
+		{
+			name:        "tenant cannot be resolved",
+			tenants:     &fakeReconcilerTenants{}, // no tenants, so the lookup misses
+			deleter:     &fakeDeleteStarter{},
+			wantInError: "tenant",
+		},
+		{
+			name:        "the workflow will not enqueue",
+			tenants:     &fakeReconcilerTenants{tenants: []model.Tenant{{TenantID: "tenant-1", Name: "acme", Type: model.TenantTypeCompany}}},
+			deleter:     &fakeDeleteStarter{err: errors.New("dbos unavailable")},
+			wantInError: "start delete workflow",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			environments := &fakeReconcilerEnvironments{environments: []model.Environment{
+				{EnvironmentID: "env-1", TenantID: "tenant-1", Name: "prod", Status: model.EnvironmentStatusDeletionBlocked},
+			}}
+			restarted, err := testReconciler(environments, tc.tenants, &fakeReconcilerContexts{}, tc.deleter).reconcile(context.Background())
+			if err != nil {
+				t.Fatalf("reconcile returned %v; one environment failing must not fail the scan", err)
+			}
+			if restarted != 0 {
+				t.Fatalf("restarted = %d, want 0", restarted)
+			}
+			reason, ok := environments.blocked["env-1"]
+			if !ok {
+				t.Fatal("the claimed row was left in `deleting` with no reason recorded")
+			}
+			if !strings.Contains(reason, tc.wantInError) {
+				t.Fatalf("recorded reason %q does not name the cause (%q)", reason, tc.wantInError)
+			}
+		})
+	}
+}
+
+// TestReconcileStopsReAttemptingPastTheAttemptCap: a teardown that has failed
+// MaxDeleteAttempts times is not going to succeed on its own, and re-attempting
+// it forever buries that under identical ticks instead of surfacing it.
+func TestReconcileStopsReAttemptingPastTheAttemptCap(t *testing.T) {
+	environments := &fakeReconcilerEnvironments{environments: []model.Environment{
+		{
+			EnvironmentID: "env-capped", TenantID: "tenant-1", Status: model.EnvironmentStatusDeletionBlocked,
+			DeleteAttempts: MaxDeleteAttempts, DeleteError: "namespace did not finish terminating",
+		},
+		{EnvironmentID: "env-fresh", TenantID: "tenant-1", Status: model.EnvironmentStatusDeletionBlocked},
+	}}
+	tenants := &fakeReconcilerTenants{tenants: []model.Tenant{{TenantID: "tenant-1", Name: "acme", Type: model.TenantTypeCompany}}}
+	deleter := &fakeDeleteStarter{}
+
+	restarted, err := testReconciler(environments, tenants, &fakeReconcilerContexts{}, deleter).reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if restarted != 1 {
+		t.Fatalf("restarted = %d, want 1 (only the uncapped environment)", restarted)
+	}
+	for _, claim := range environments.claims {
+		if claim.environmentID == "env-capped" {
+			t.Fatal("an environment past the attempt cap must not be claimed again")
+		}
+	}
+	if len(deleter.started) != 1 || deleter.started[0].EnvironmentID != "env-fresh" {
+		t.Fatalf("started = %+v, want only env-fresh", deleter.started)
+	}
+}
+
+// TestReconcileHoldsABlockedRowThroughItsBackoff: without a backoff every
+// blocked row was re-attempted on every tick, which for a namespace wedged on
+// an unsatisfiable finalizer is pure load with no chance of progress.
+func TestReconcileHoldsABlockedRowThroughItsBackoff(t *testing.T) {
+	// One attempt already made, updated a moment ago: its 5-minute backoff has
+	// not elapsed.
+	environments := &fakeReconcilerEnvironments{environments: []model.Environment{
+		{
+			EnvironmentID: "env-waiting", TenantID: "tenant-1", Status: model.EnvironmentStatusDeletionBlocked,
+			DeleteAttempts: 1, UpdatedAt: time.Now().Add(-30 * time.Second),
+		},
+	}}
+	tenants := &fakeReconcilerTenants{tenants: []model.Tenant{{TenantID: "tenant-1", Name: "acme", Type: model.TenantTypeCompany}}}
+	deleter := &fakeDeleteStarter{}
+
+	restarted, err := testReconciler(environments, tenants, &fakeReconcilerContexts{}, deleter).reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if restarted != 0 || len(environments.claims) != 0 {
+		t.Fatalf("a row inside its backoff was re-attempted: restarted=%d claims=%v", restarted, environments.claims)
+	}
+
+	// Past the backoff it is attempted again.
+	environments.environments[0].UpdatedAt = time.Now().Add(-10 * time.Minute)
+	environments.claims = nil
+	restarted, err = testReconciler(environments, tenants, &fakeReconcilerContexts{}, deleter).reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if restarted != 1 {
+		t.Fatalf("restarted = %d, want 1 once the backoff has elapsed", restarted)
+	}
+}
+
+// TestReconcileDoesNotBackOffAStaleDeletingRow: a stale `deleting` row means the
+// attempt behind it can no longer be live, so holding it back would just leave a
+// dead attempt sitting. Only `deletion-blocked` rows wait.
+func TestReconcileDoesNotBackOffAStaleDeletingRow(t *testing.T) {
+	environments := &fakeReconcilerEnvironments{environments: []model.Environment{
+		{
+			EnvironmentID: "env-stale", TenantID: "tenant-1", Status: model.EnvironmentStatusDeleting,
+			DeleteAttempts: 3, UpdatedAt: time.Now(),
+		},
+	}}
+	tenants := &fakeReconcilerTenants{tenants: []model.Tenant{{TenantID: "tenant-1", Name: "acme", Type: model.TenantTypeCompany}}}
+	deleter := &fakeDeleteStarter{}
+
+	restarted, err := testReconciler(environments, tenants, &fakeReconcilerContexts{}, deleter).reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if restarted != 1 {
+		t.Fatalf("restarted = %d, want 1: a stale deleting row is claimed without waiting on a backoff", restarted)
+	}
+}
+
+// TestDeleteRetryBackoffGrowsAndCaps pins the schedule itself, so a change to
+// it is a deliberate edit rather than an accident.
+func TestDeleteRetryBackoffGrowsAndCaps(t *testing.T) {
+	if got := deleteRetryBackoff(0); got != 0 {
+		t.Fatalf("backoff(0) = %v, want 0 — a never-attempted row waits for nothing", got)
+	}
+	if got := deleteRetryBackoff(1); got != deleteRetryFirstBackoff {
+		t.Fatalf("backoff(1) = %v, want %v", got, deleteRetryFirstBackoff)
+	}
+	if got := deleteRetryBackoff(2); got != 2*deleteRetryFirstBackoff {
+		t.Fatalf("backoff(2) = %v, want %v", got, 2*deleteRetryFirstBackoff)
+	}
+	previous := time.Duration(0)
+	for attempts := 1; attempts <= MaxDeleteAttempts+4; attempts++ {
+		got := deleteRetryBackoff(attempts)
+		if got > deleteRetryMaxBackoff {
+			t.Fatalf("backoff(%d) = %v, over the %v cap", attempts, got, deleteRetryMaxBackoff)
+		}
+		if got < previous {
+			t.Fatalf("backoff(%d) = %v, went backwards from %v", attempts, got, previous)
+		}
+		previous = got
+	}
+	if deleteRetryBackoff(MaxDeleteAttempts+4) != deleteRetryMaxBackoff {
+		t.Fatal("backoff must reach and stay at its cap")
 	}
 }

--- a/erun-backend/erun-backend-api/internal/provision/lifecycle.go
+++ b/erun-backend/erun-backend-api/internal/provision/lifecycle.go
@@ -198,7 +198,16 @@ func (l *EnvLifecycle) Delete(ctx context.Context, input EnvLifecycleInput) erro
 		}
 	}
 	l.recordUsage(ctx, input.EnvironmentID, model.UsageEventEnvironmentDeleted)
-	return l.rows.Delete(ctx, input.EnvironmentID)
+	// The namespace is gone but the row is not yet: a failure here would leave
+	// the row in `deleting` with no reason, contradicting this method's own
+	// contract that every non-success outcome names why (#1166). Record it, so
+	// a retry has something to act on -- the namespace teardown is already
+	// done, so the retry's own delete is a no-op and only the row removal is
+	// re-attempted.
+	if err := l.rows.Delete(ctx, input.EnvironmentID); err != nil {
+		return l.blockDelete(ctx, input.EnvironmentID, fmt.Errorf("namespace torn down but removing the environment row failed: %w", err))
+	}
+	return nil
 }
 
 // blockDelete records why a delete attempt did not tear the namespace down

--- a/erun-backend/erun-backend-api/internal/repository/environments.go
+++ b/erun-backend/erun-backend-api/internal/repository/environments.go
@@ -12,7 +12,7 @@ type EnvironmentRepository struct {
 	txs *TxManager
 }
 
-const environmentColumns = `environment_id, tenant_id, name, type, kubernetes_context, context_id, runtime_version, status, provision_error, deployed_version, expose_error, delete_error, created_at, updated_at`
+const environmentColumns = `environment_id, tenant_id, name, type, kubernetes_context, context_id, runtime_version, status, provision_error, deployed_version, expose_error, delete_error, delete_attempts, created_at, updated_at`
 
 // environmentsMidTeardownStatuses are the statuses Count excludes: a delete
 // has been requested for these rows, so they must not lock a tenant out of
@@ -178,7 +178,8 @@ func (r *EnvironmentRepository) ClaimDeploy(ctx context.Context, environmentID s
 		result, err := tx.NewRaw(`
 			UPDATE environments
 			   SET status = ?,
-			       provision_error = NULL
+			       provision_error = NULL,
+			       delete_error = NULL
 			 WHERE environment_id = ?
 			   AND status NOT IN (?)
 			   AND (status <> ? OR updated_at < NOW() - MAKE_INTERVAL(secs => ?))
@@ -221,13 +222,25 @@ func (r *EnvironmentRepository) Delete(ctx context.Context, environmentID string
 // `deleting` and resurrect a row whose namespace is being torn down. The guard
 // is relaxed by the same staleAfter as the deploy's own, so a control plane
 // that died mid-deploy still cannot block a teardown permanently.
+//
+// The claim does NOT clear delete_error (#1166). Clearing it on claim meant the
+// recorded blocker vanished for as long as the new attempt took to reach the
+// same conclusion -- up to NamespaceDeleteTimeout, on a five-minute reconcile
+// cycle -- so an operator, the console, or an orchestrator polling during that
+// window saw `deleting` with no reason at all for an environment that had been
+// stuck for hours. The attempt's own outcome overwrites it instead, so the row
+// is never less informative after a tick than it was before.
+//
+// It does increment delete_attempts, which is what lets the reconciler back off
+// per attempt and eventually stop, rather than re-attempting a teardown that
+// cannot succeed for as long as the row exists.
 func (r *EnvironmentRepository) ClaimDelete(ctx context.Context, environmentID string, staleAfter time.Duration) (bool, error) {
 	claimed := false
 	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 		result, err := tx.NewRaw(`
 			UPDATE environments
 			   SET status = ?,
-			       delete_error = NULL
+			       delete_attempts = delete_attempts + 1
 			 WHERE environment_id = ?
 			   AND (status <> ? OR updated_at < NOW() - MAKE_INTERVAL(secs => ?))
 			   AND (status <> ? OR updated_at < NOW() - MAKE_INTERVAL(secs => ?))

--- a/erun-backend/erun-backend-db/migrations/default/20260823130000_env_delete_attempts.sql
+++ b/erun-backend/erun-backend-db/migrations/default/20260823130000_env_delete_attempts.sql
@@ -1,0 +1,10 @@
+-- The delete reconciler re-attempted a blocked teardown forever: no attempt
+-- counter, no backoff, and no terminal state for "this cannot be torn down
+-- without intervention" (#1166). delete_attempts is what bounds it -- the
+-- claim increments it, so the reconciler can back off per attempt and stop
+-- re-attempting past a cap, instead of clearing and re-recording the same
+-- blocker on a five-minute timer indefinitely.
+-- Hand-written column add (atlas migrate diff is login-gated on the RLS
+-- functions in the source schema); no new table/RLS, so the existing
+-- environments row-level security already covers this column.
+ALTER TABLE "environments" ADD COLUMN "delete_attempts" integer NOT NULL DEFAULT 0;

--- a/erun-backend/erun-backend-db/migrations/default/atlas.sum
+++ b/erun-backend/erun-backend-db/migrations/default/atlas.sum
@@ -1,4 +1,4 @@
-h1:ZL9FGQFBrp0FRHUXSRhcbWbjErQpIYfFD/+cPFlWg84=
+h1:KSLn9aCnT0csaRzmg7rggc4Y77BuWbB2g5wUSQ7wg20=
 20260501120000_initial_tenant_identity.sql h1:RpS03/4sFjbCggwYgcGNn6k3jNZCNTNl0BD/afOKFzo=
 20260503143000_tenant_issuer_names.sql h1:VEZjICG3/jU2YtEx0XX05l9Q8lJyWKeiRY8f4dXOkvE=
 20260503170000_audit_events.sql h1:OLjiGP/FhLTWvkx1bxS2xCcJK6tExdufnEC8R6LsKWA=
@@ -15,3 +15,4 @@ h1:ZL9FGQFBrp0FRHUXSRhcbWbjErQpIYfFD/+cPFlWg84=
 20260822120000_context_capacity.sql h1:ikj1rgfZkq5CtPgONEBPslkborUO5F6mlzl0j5no9jw=
 20260822130000_tenant_aggregate_resource_quota.sql h1:Z8CsWA9EieJQB75vJUeh1nGlmI7nr6PWCYrWxr8933s=
 20260822140000_env_delete_lifecycle.sql h1:WI2uVp2KQ09TTu8qalKttAXUnYq0yWaYEV85R+aSaXs=
+20260823130000_env_delete_attempts.sql h1:8mnU/ltMH4FeLhVWEfjWPsSm1vzgWBulPhcn9gLFkew=

--- a/erun-backend/erun-backend-db/schema/tables/environments.sql
+++ b/erun-backend/erun-backend-db/schema/tables/environments.sql
@@ -11,6 +11,7 @@ CREATE TABLE environments (
   deployed_version TEXT,
   expose_error TEXT,
   delete_error TEXT,
+  delete_attempts INTEGER NOT NULL DEFAULT 0,
   created_at TIMESTAMPTZ,
   updated_at TIMESTAMPTZ,
   FOREIGN KEY (tenant_id) REFERENCES tenants (tenant_id),


### PR DESCRIPTION
## Summary

Closes #1166 — all six defects.

**1. A claimed row could be left stranded.** The claim moves the row to `deleting`, so any failure between the claim and the workflow starting left it claiming an in-flight delete that did not exist. That is strictly less information than before the tick ran, and exactly the misreporting #1140 was about. Every post-claim exit now records why: an unresolvable tenant, a placement read that fails, and a workflow that will not enqueue.

**2. Retry was unbounded.** No attempt counter, no backoff, no terminal state. A new `delete_attempts` column — incremented by the claim, so it survives an attempt that dies without reporting — bounds it:

| attempts | wait before the next try |
|---|---|
| 1 | 5m |
| 2 | 10m |
| 3 | 20m |
| … | doubling |
| ≥ 6 | 2h (cap) |
| ≥ `MaxDeleteAttempts` (8) | never — needs intervention |

Past the cap the row is left alone. `deletion-blocked` plus a visible attempt count *is* the terminal state; re-attempting forever buried that fact under identical ticks. A stale `deleting` row is deliberately exempt from the backoff — `DeleteClaimStaleAfter` is already longer than the Job's own deadline, so its attempt cannot still be live and delaying it would only leave a dead attempt sitting.

**The claim also no longer clears `delete_error`.** This is the item I had to correct my own reporting on: it is a *visibility window*, not data loss. Clearing on claim meant the recorded blocker vanished for as long as the new attempt took to reach the same conclusion — up to `NamespaceDeleteTimeout`, on a five-minute cycle — so an operator, the console, or an orchestrator polling in that window saw `deleting` with no reason at all for an environment stuck for hours. The attempt's own outcome overwrites it instead, so the row is never less informative after a tick than before it.

**3. It was entirely silent.** A failed scan, a failed tenant read, each exhausted row (with its recorded blocker's first line), and a per-tick summary are logged now:

```
erun api env delete reconciler: 3 mid-teardown environment(s): 1 re-attempted,
0 failed to start, 1 exhausted, 1 waiting on backoff
```

A reconciler failing every tick is no longer indistinguishable from one with nothing to do — which #1140 asked for explicitly, on the grounds that silence is what turned the original bug into an outage hidden behind a successful-looking deploy.

**4. `tick` ran on `context.Background()`**, so the scan was uncancellable and kept running through a shutdown. Rooted in the DBOS context now.

**5. `delete_error` was never cleared outside `ClaimDelete`**, so a row that left teardown carried a stale blocker. `ClaimDeploy` clears it — which is where it belongs now that #1163 stops a deploy claiming a row still *in* teardown, and where a `failed` row really can carry one. That combination was observed live on `operations/probel`: `status=failed` with a 643-character `delete_error` and no namespace.

**6. `EnvLifecycle.Delete`'s final row removal returned bare**, leaving the row in `deleting` with no reason and contradicting the method's own documented contract that every non-success outcome names why.

## Migration

`delete_attempts` is added by `20260823130000_env_delete_attempts.sql` and is read by `environmentColumns`, so **the backend-db release must land before the API**. It does — `frs-prod`'s deploy order puts `frs-backend-db` ahead of `frs-backend-api` — but the dependency is real rather than incidental, so it is worth stating.

Hand-written column add, following the convention the previous migration set (`atlas migrate diff` is login-gated on the RLS functions in the source schema). No new table or RLS, so the existing `environments` row-level security already covers the column. `atlas.sum` rehashed, `atlas migrate validate` clean, and `schema/tables/environments.sql` updated to match so the declarative schema does not drift.

## Verification

`go build`, `go vet`, `gofmt -l`, and `golangci-lint run` (**0 issues**) clean; **12/12 packages green**.

Six new tests:

- `TestReconcileRecordsAReasonWhenAClaimedAttemptCannotStart` — both causes (unresolvable tenant, workflow will not enqueue), asserting a reason is recorded and that one environment failing does not fail the scan.
- `TestReconcileStopsReAttemptingPastTheAttemptCap` — the capped row is not even *claimed*, while an uncapped one alongside it still runs.
- `TestReconcileHoldsABlockedRowThroughItsBackoff` — held inside the window, attempted once past it.
- `TestReconcileDoesNotBackOffAStaleDeletingRow` — the exemption above.
- `TestDeleteRetryBackoffGrowsAndCaps` — pins the schedule so changing it is deliberate: monotonic, never over the cap, and reaching it.

I confirmed the item-1 test is not vacuous. Reverting only the two recording call sites and re-running reproduces the defect:

```
--- FAIL: TestReconcileRecordsAReasonWhenAClaimedAttemptCannotStart/tenant_cannot_be_resolved
    the claimed row was left in `deleting` with no reason recorded
--- FAIL: TestReconcileRecordsAReasonWhenAClaimedAttemptCannotStart/the_workflow_will_not_enqueue
    the claimed row was left in `deleting` with no reason recorded
```

## Related

#1174 removes a major *source* of blocked teardowns — an in-flight ACME Challenge whose cleanup credential namespace teardown deletes first — so the two are complementary: this bounds the reconciler's response to a wedged namespace, that one stops manufacturing them on the ordinary delete path.