### PR TITLE
Stop the console offering Deploy mid-teardown, and tell an unenrolled user so

### DIFF
--- a/erun-console/src/App.tsx
+++ b/erun-console/src/App.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { beginLogin, type OidcConfig, resolveOidcConfig, resolveToken, signOut } from './auth/auth';
+import { readTokenIdentity } from './auth/identity';
 import { ConfigFetchError, fetchConfig } from './config/client';
 import { ConfigView } from './config/ConfigView';
 import type { TenantConfigView } from './config/types';
@@ -12,6 +13,11 @@ type LoadState =
   | { status: 'loading' }
   | { status: 'ready'; config: TenantConfigView }
   | { status: 'signed-out' }
+  // Signed in with the identity provider, but the API does not recognise the
+  // identity — it belongs to no tenant yet. Distinct from signed-out because
+  // the recovery is completely different: signing in again just repeats the
+  // same successful sign-in and lands here once more (#1167).
+  | { status: 'not-enrolled'; token: string }
   | { status: 'error'; message: string };
 
 // The signed-out view. With OIDC configured it offers a real Sign in button
@@ -60,6 +66,34 @@ function SignOutButton({ onSignedOut }: { onSignedOut: () => void }): React.Reac
   );
 }
 
+// The dead end a self-signed-up user hits: OIDC succeeded, so a token is held,
+// but the API rejects the identity because it is enrolled in no tenant. Showing
+// the signed-out prompt here was the bug — it offered Sign in, which succeeds
+// and returns to this same screen forever, while a Sign out button sat beside
+// it because a token did exist. This says what actually has to happen, and
+// names the identity an operator needs in order to do it.
+function NotEnrolledPrompt({ token }: { token: string }): React.ReactElement {
+  const identity = readTokenIdentity(token);
+  return (
+    <div className="message" role="status">
+      <p>You are signed in, but your account is not yet part of a tenant on this platform.</p>
+      <p>
+        An operator has to enrol you before you can see any environments. Signing in again will not
+        change this.
+      </p>
+      {(identity.email !== undefined || identity.subject !== undefined) && (
+        <p className="identity-detail">
+          Give them this identity: {identity.email ?? identity.subject}
+          {identity.email !== undefined && identity.subject !== undefined
+            ? ` (subject ${identity.subject})`
+            : ''}
+          {identity.issuer !== undefined ? ` from ${identity.issuer}` : ''}
+        </p>
+      )}
+    </div>
+  );
+}
+
 function ErrorMessage({ message }: { message: string }): React.ReactElement {
   return (
     <div className="message" role="alert">
@@ -95,12 +129,47 @@ function ActionPanels({
   );
 }
 
-function loadStateFromError(error: unknown): LoadState {
+// A 401 means two completely different things depending on whether a token was
+// held. With no token the caller is simply signed out. With a token, the
+// identity provider authenticated them and the API still said no — so the
+// identity is not enrolled, and telling them to sign in is a loop (#1167).
+function loadStateFromError(error: unknown, token: string | undefined): LoadState {
   if (error instanceof ConfigFetchError && error.status === 401) {
-    return { status: 'signed-out' };
+    return token === undefined ? { status: 'signed-out' } : { status: 'not-enrolled', token };
   }
   const message = error instanceof Error ? error.message : 'unexpected error';
   return { status: 'error', message };
+}
+
+// LoadStateView renders whichever of the load states is current. Split out of
+// App purely so App stays inside the module's max-lines-per-function budget;
+// the exhaustive switch also means a new LoadState variant is a type error here
+// rather than a silently blank screen.
+function LoadStateView({
+  state,
+  oidc,
+  fallbackReason,
+}: {
+  state: LoadState;
+  oidc: OidcConfig | undefined;
+  fallbackReason: string | undefined;
+}): React.ReactElement {
+  switch (state.status) {
+    case 'loading':
+      return (
+        <div className="message" role="status">
+          <p>Loading your environments…</p>
+        </div>
+      );
+    case 'signed-out':
+      return <SignInPrompt oidc={oidc} fallbackReason={fallbackReason} />;
+    case 'not-enrolled':
+      return <NotEnrolledPrompt token={state.token} />;
+    case 'error':
+      return <ErrorMessage message={state.message} />;
+    case 'ready':
+      return <ConfigView config={state.config} />;
+  }
 }
 
 export function App(): React.ReactElement {
@@ -160,7 +229,9 @@ export function App(): React.ReactElement {
       })
       .catch((error: unknown) => {
         if (mountedRef.current) {
-          setState(loadStateFromError(error));
+          // No token has been resolved yet on this path, so a 401 here is a
+          // genuine signed-out.
+          setState(loadStateFromError(error, undefined));
         }
       });
   }, [oidcResolved, oidc]);
@@ -177,7 +248,7 @@ export function App(): React.ReactElement {
       })
       .catch((error: unknown) => {
         if (mountedRef.current) {
-          setState(loadStateFromError(error));
+          setState(loadStateFromError(error, forToken));
         }
       });
   }, []);
@@ -190,16 +261,7 @@ export function App(): React.ReactElement {
 
   return (
     <main className="app">
-      {state.status === 'loading' && (
-        <div className="message" role="status">
-          <p>Loading your environments…</p>
-        </div>
-      )}
-      {state.status === 'signed-out' && (
-        <SignInPrompt oidc={oidc} fallbackReason={oidcFallbackReason} />
-      )}
-      {state.status === 'error' && <ErrorMessage message={state.message} />}
-      {state.status === 'ready' && <ConfigView config={state.config} />}
+      <LoadStateView state={state} oidc={oidc} fallbackReason={oidcFallbackReason} />
       {state.status === 'ready' && token !== undefined && (
         <ActionPanels
           token={token}

--- a/erun-console/src/auth/auth.test.ts
+++ b/erun-console/src/auth/auth.test.ts
@@ -155,7 +155,10 @@ describe('resolveOidcConfig', () => {
       'fetch',
       vi.fn(() =>
         Promise.resolve(
-          jsonResponse({ issuer: 'https://auth.platform.example', consoleClientId: 'platform-client' }),
+          jsonResponse({
+            issuer: 'https://auth.platform.example',
+            consoleClientId: 'platform-client',
+          }),
         ),
       ),
     );

--- a/erun-console/src/auth/identity.test.ts
+++ b/erun-console/src/auth/identity.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { readTokenIdentity } from './identity';
+
+// Builds a JWT-shaped string with the given payload. Only the payload segment
+// is ever read, so the header and signature are placeholders.
+function tokenWith(payload: Record<string, unknown>): string {
+  const encode = (value: string): string => {
+    // UTF-8 first, then base64url — what a real issuer emits. Passing the
+    // string straight to btoa would encode Latin-1 bytes and produce a token no
+    // issuer would ever mint.
+    const bytes = new TextEncoder().encode(value);
+    const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join('');
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  };
+  return `${encode('{"alg":"RS256"}')}.${encode(JSON.stringify(payload))}.signature`;
+}
+
+describe('readTokenIdentity', () => {
+  it('reads the claims an operator needs in order to enrol someone', () => {
+    const identity = readTokenIdentity(
+      tokenWith({
+        sub: '387534471668170904',
+        email: 'someone@example.com',
+        iss: 'https://auth.example.com',
+      }),
+    );
+
+    expect(identity.subject).toBe('387534471668170904');
+    expect(identity.email).toBe('someone@example.com');
+    expect(identity.issuer).toBe('https://auth.example.com');
+  });
+
+  it('falls back to preferred_username when there is no email claim', () => {
+    expect(readTokenIdentity(tokenWith({ preferred_username: 'someone@example.com' })).email).toBe(
+      'someone@example.com',
+    );
+  });
+
+  it('decodes a payload containing non-ASCII rather than mangling it', () => {
+    expect(readTokenIdentity(tokenWith({ email: 'zoë@example.com' })).email).toBe(
+      'zoë@example.com',
+    );
+  });
+
+  it('returns nothing for a token that is not a readable JWT, rather than throwing', () => {
+    // The dev-bearer fallback is an opaque string, and this runs on the screen a
+    // stuck user sees -- throwing there would replace an explanation with a
+    // blank page.
+    for (const value of ['', 'dev-token', 'a.b', 'a.b.c.d', 'not-base64.$$$.sig']) {
+      const identity = readTokenIdentity(value);
+      expect(identity.subject).toBeUndefined();
+      expect(identity.email).toBeUndefined();
+    }
+  });
+
+  it('ignores a payload that decodes to something other than an object', () => {
+    expect(
+      readTokenIdentity(tokenWith([] as unknown as Record<string, unknown>)).subject,
+    ).toBeUndefined();
+    expect(
+      readTokenIdentity(`x.${btoa('"a string"').replace(/=+$/, '')}.y`).subject,
+    ).toBeUndefined();
+  });
+});

--- a/erun-console/src/auth/identity.ts
+++ b/erun-console/src/auth/identity.ts
@@ -1,0 +1,59 @@
+// readTokenIdentity pulls the display-only claims out of a bearer token, for the
+// "authenticated but not enrolled" screen. Someone in that state has to tell an
+// operator WHICH identity to enrol, and reading it off the screen beats an
+// operator querying the database for it — which is exactly what happened the
+// first time this came up (#1167).
+//
+// This decodes without verifying, and that is safe only because the result is
+// never used for a security decision: it is text on a screen. The API remains
+// the only thing that decides what an identity may do. Do not grow this into an
+// authorization input.
+
+export interface TokenIdentity {
+  subject: string | undefined;
+  email: string | undefined;
+  issuer: string | undefined;
+}
+
+const EMPTY: TokenIdentity = { subject: undefined, email: undefined, issuer: undefined };
+
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+// decodePayload returns the JWT's middle segment as parsed JSON, or undefined
+// for anything that is not a decodable three-part JWT — an opaque token, a dev
+// bearer string, or a truncated value. A token we cannot read is not an error
+// here: the screen simply omits the identity line.
+function decodePayload(token: string): Record<string, unknown> | undefined {
+  const segments = token.split('.');
+  const payload = segments.length === 3 ? segments[1] : undefined;
+  if (payload === undefined) {
+    return undefined;
+  }
+  const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
+  try {
+    const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+    const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
+    return typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function readTokenIdentity(token: string): TokenIdentity {
+  const payload = decodePayload(token);
+  if (payload === undefined) {
+    return EMPTY;
+  }
+  return {
+    subject: asOptionalString(payload.sub),
+    // preferred_username is what Zitadel puts the sign-in address in; email is
+    // the standard claim. Either is more recognisable to a person than `sub`.
+    email: asOptionalString(payload.email) ?? asOptionalString(payload.preferred_username),
+    issuer: asOptionalString(payload.iss),
+  };
+}

--- a/erun-console/src/config/ConfigView.test.tsx
+++ b/erun-console/src/config/ConfigView.test.tsx
@@ -134,11 +134,24 @@ describe('ConfigView via App', () => {
     expect(screen.getByRole('heading', { level: 1, name: 'Acme' })).toBeInTheDocument();
   });
 
-  it('renders the sign-in prompt on a 401', async () => {
+  // A 401 *with* a token held is not a signed-out caller: the identity provider
+  // authenticated them and the API still refused, which means the identity is
+  // enrolled in no tenant. This test previously asserted the sign-in prompt,
+  // which encoded the dead end -- Sign in succeeds and lands right back here
+  // (#1167). The signed-out case is covered by the test below, which has no
+  // token at all.
+  it('tells a signed-in but unenrolled caller they need enrolling, not to sign in again', async () => {
     mockFetch(jsonResponse('invalid bearer token', 401));
     render(<App />);
 
-    expect(await screen.findByText('Sign in to view your environments.')).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'You are signed in, but your account is not yet part of a tenant on this platform.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/An operator has to enrol you/)).toBeInTheDocument();
+    // Offering Sign in here is the loop this fix removes.
+    expect(screen.queryByText('Sign in to view your environments.')).not.toBeInTheDocument();
   });
 
   it('renders the sign-in prompt when there is no dev token', async () => {

--- a/erun-console/src/config/ConfigView.tsx
+++ b/erun-console/src/config/ConfigView.tsx
@@ -102,6 +102,10 @@ const ENV_STATUS_LABELS: Record<EnvironmentStatus, string> = {
   provisioning: 'Provisioning',
   running: 'Running',
   failed: 'Failed',
+  // Without these two the lenient status parse rendered no badge at all for an
+  // environment mid-teardown, so it read as an ordinary one (#1170).
+  deleting: 'Deleting',
+  'deletion-blocked': 'Delete blocked',
 };
 
 // The badge pairs color with a text label so it reads for color-blind and

--- a/erun-console/src/config/client.ts
+++ b/erun-console/src/config/client.ts
@@ -53,7 +53,9 @@ function asEnvironmentStatus(value: unknown): EnvironmentStatus | undefined {
   return value === 'registered' ||
     value === 'provisioning' ||
     value === 'running' ||
-    value === 'failed'
+    value === 'failed' ||
+    value === 'deleting' ||
+    value === 'deletion-blocked'
     ? value
     : undefined;
 }
@@ -69,6 +71,7 @@ function parseEnvironment(raw: Record<string, unknown>): Environment {
     status: asEnvironmentStatus(raw.status),
     provisionError: asOptionalString(raw.provisionError),
     deployedVersion: asOptionalString(raw.deployedVersion),
+    deleteError: asOptionalString(raw.deleteError),
   };
 }
 
@@ -303,7 +306,10 @@ export async function createEnvironment(
 // getEnvironment fetches one environment by id; the deploy controller polls it
 // after deployEnvironment until `status` reaches running/failed.
 export async function getEnvironment(token: string, environmentId: string): Promise<Environment> {
-  const response = await authedFetch(`/v1/environments/${encodeURIComponent(environmentId)}`, token);
+  const response = await authedFetch(
+    `/v1/environments/${encodeURIComponent(environmentId)}`,
+    token,
+  );
   if (!response.ok) {
     throw new ConfigFetchError(
       `environment request failed (${String(response.status)})`,

--- a/erun-console/src/config/types.ts
+++ b/erun-console/src/config/types.ts
@@ -11,9 +11,31 @@ export interface Tenant {
 }
 
 // The provisioning lifecycle of a hosted environment: `registered` (row exists,
-// nothing deployed) → `provisioning` → `running` | `failed`. Parsed leniently so
-// an unknown future state renders no badge rather than failing the parse.
-export type EnvironmentStatus = 'registered' | 'provisioning' | 'running' | 'failed';
+// nothing deployed) → `provisioning` → `running` | `failed`, plus the teardown
+// states a delete moves through: `deleting` while an attempt is in flight and
+// `deletion-blocked` when one finished without tearing the namespace down.
+// Parsed leniently so an unknown future state renders no badge rather than
+// failing the parse — which is exactly why the teardown states had to be added
+// explicitly: without them a deleting environment rendered with no badge at
+// all, indistinguishable from an ordinary one, and the console offered Deploy
+// on it (#1170).
+export type EnvironmentStatus =
+  | 'registered'
+  | 'provisioning'
+  | 'running'
+  | 'failed'
+  | 'deleting'
+  | 'deletion-blocked';
+
+// The statuses for which a delete has been requested and is still outstanding.
+// A mutating lifecycle action on one of these is refused by the API with 409,
+// so the console must not offer it.
+export const TEARDOWN_STATUSES: readonly EnvironmentStatus[] = ['deleting', 'deletion-blocked'];
+
+// isTearingDown reports whether a delete is outstanding for this environment.
+export function isTearingDown(environment: { status?: EnvironmentStatus }): boolean {
+  return environment.status !== undefined && TEARDOWN_STATUSES.includes(environment.status);
+}
 
 export interface Environment {
   environmentId: string;
@@ -30,6 +52,11 @@ export interface Environment {
   // runtimeVersion (the declared pin) — a failed or in-flight deploy leaves
   // this on whatever version is still running in the cluster.
   deployedVersion?: string;
+  // Why a delete attempt did not tear the namespace down, when status is
+  // `deletion-blocked`: the namespace's own conditions, verbatim. Surfacing it
+  // is the whole point of showing the teardown state — it names the finalizer
+  // actually holding the namespace, which is what an operator needs.
+  deleteError?: string;
 }
 
 // The provisioning lifecycle a context moves through: `provisioning` → `running`

--- a/erun-console/src/environments/EnvironmentsPanel.test.tsx
+++ b/erun-console/src/environments/EnvironmentsPanel.test.tsx
@@ -59,7 +59,10 @@ const RUNTIME_ENV: Environment = {
 describe('EnvironmentsPanel register form', () => {
   it('POSTs the create request with only operator-authored fields (no tenant)', async () => {
     const calls = mockFetch(() =>
-      jsonResponse({ environmentId: 'env-2', name: 'staging', type: 'runtime', status: 'registered' }, 201),
+      jsonResponse(
+        { environmentId: 'env-2', name: 'staging', type: 'runtime', status: 'registered' },
+        201,
+      ),
     );
     render(
       <EnvironmentsPanel token="dev-token" contexts={[]} environments={[]} onChanged={vi.fn()} />,
@@ -82,7 +85,9 @@ describe('EnvironmentsPanel register form', () => {
   });
 
   it('calls onChanged after a successful register so the parent refreshes the read model', async () => {
-    mockFetch(() => jsonResponse({ environmentId: 'env-2', name: 'staging', type: 'runtime' }, 201));
+    mockFetch(() =>
+      jsonResponse({ environmentId: 'env-2', name: 'staging', type: 'runtime' }, 201),
+    );
     const onChanged = vi.fn();
     render(
       <EnvironmentsPanel token="dev-token" contexts={[]} environments={[]} onChanged={onChanged} />,
@@ -105,7 +110,9 @@ describe('EnvironmentsPanel register form', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Register environment' }));
 
     expect(
-      await screen.findByText('Could not register environment: register environment request failed (400)'),
+      await screen.findByText(
+        'Could not register environment: register environment request failed (400)',
+      ),
     ).toBeInTheDocument();
   });
 });
@@ -214,5 +221,63 @@ describe('EnvironmentsPanel deploy flow', () => {
       <EnvironmentsPanel token="dev-token" contexts={[]} environments={[]} onChanged={vi.fn()} />,
     );
     expect(screen.getByText('No runtime environments to deploy.')).toBeInTheDocument();
+  });
+
+  // #1170: the API refuses a deploy on a row whose delete is outstanding, so
+  // offering the button meant an operator clicked it and got a raw Kubernetes
+  // admission error back. Before the API guard existed it was worse: the deploy
+  // was accepted and overwrote the teardown state.
+  it('offers no Deploy control for an environment that is being deleted', () => {
+    render(
+      <EnvironmentsPanel
+        token="dev-token"
+        contexts={[]}
+        environments={[{ ...RUNTIME_ENV, status: 'deleting' }]}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Deploy' })).not.toBeInTheDocument();
+    expect(
+      screen.getByText('prod is being deleted, so it cannot be deployed.'),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces the recorded blocker for a deletion-blocked environment instead of a Deploy button', () => {
+    const blocker =
+      'namespace "operations-prod" did not finish terminating within 20m0s:\nNamespaceFinalizersRemaining=True  acme.cert-manager.io/finalizer in 1 resource instances';
+    render(
+      <EnvironmentsPanel
+        token="dev-token"
+        contexts={[]}
+        environments={[{ ...RUNTIME_ENV, status: 'deletion-blocked', deleteError: blocker }]}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Deploy' })).not.toBeInTheDocument();
+    expect(screen.getByText(/delete is blocked and still outstanding/)).toBeInTheDocument();
+    // The blocker is what an operator can act on -- it names the finalizer
+    // actually holding the namespace -- so it is shown whole, not summarised.
+    // Matched by substring because Testing Library collapses the newlines.
+    expect(screen.getByText(/did not finish terminating within 20m0s/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/acme\.cert-manager\.io\/finalizer in 1 resource instances/),
+    ).toBeInTheDocument();
+  });
+
+  it('still offers Deploy for every non-teardown status', () => {
+    for (const status of ['registered', 'running', 'failed'] as const) {
+      cleanup();
+      render(
+        <EnvironmentsPanel
+          token="dev-token"
+          contexts={[]}
+          environments={[{ ...RUNTIME_ENV, status }]}
+          onChanged={vi.fn()}
+        />,
+      );
+      expect(screen.getByRole('button', { name: 'Deploy' })).toBeInTheDocument();
+    }
   });
 });

--- a/erun-console/src/environments/EnvironmentsPanel.tsx
+++ b/erun-console/src/environments/EnvironmentsPanel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import type { CloudContext, Environment } from '../config/types';
+import { type CloudContext, type Environment, isTearingDown } from '../config/types';
 import type { DeployState, RegisterState } from './controller';
 import { useDeployController, useRegisterEnvironmentController } from './controller';
 
@@ -74,9 +74,22 @@ function RegisterForm({
     <form className="provision-form" onSubmit={submit} aria-labelledby="register-env-heading">
       <h3 id="register-env-heading">Register an environment</h3>
       <label htmlFor="env-name">Name</label>
-      <input id="env-name" value={name} onChange={(e) => { setName(e.target.value); }} required />
+      <input
+        id="env-name"
+        value={name}
+        onChange={(e) => {
+          setName(e.target.value);
+        }}
+        required
+      />
       <label htmlFor="env-type">Type</label>
-      <select id="env-type" value={type} onChange={(e) => { setType(e.target.value); }}>
+      <select
+        id="env-type"
+        value={type}
+        onChange={(e) => {
+          setType(e.target.value);
+        }}
+      >
         {ENV_TYPES.map((option) => (
           <option key={option} value={option}>
             {option}
@@ -87,7 +100,9 @@ function RegisterForm({
       <select
         id="env-context"
         value={contextId}
-        onChange={(e) => { setContextId(e.target.value); }}
+        onChange={(e) => {
+          setContextId(e.target.value);
+        }}
       >
         <option value="">— none —</option>
         <ContextOptions contexts={contexts} />
@@ -96,13 +111,17 @@ function RegisterForm({
       <input
         id="env-kubernetes-context"
         value={kubernetesContext}
-        onChange={(e) => { setKubernetesContext(e.target.value); }}
+        onChange={(e) => {
+          setKubernetesContext(e.target.value);
+        }}
       />
       <label htmlFor="env-runtime-version">Runtime version (optional)</label>
       <input
         id="env-runtime-version"
         value={runtimeVersion}
-        onChange={(e) => { setRuntimeVersion(e.target.value); }}
+        onChange={(e) => {
+          setRuntimeVersion(e.target.value);
+        }}
         placeholder="1.2.3"
       />
       <button type="submit" disabled={busy}>
@@ -179,6 +198,32 @@ function DeployStatus({
   );
 }
 
+// TeardownRow replaces the whole deploy control for an environment whose delete
+// is outstanding. The API refuses a deploy on these with 409, so offering the
+// button meant an operator clicked it and got a raw Kubernetes admission error
+// back (#1170) — and before the API guard existed, the deploy was accepted and
+// overwrote the teardown state. Showing the recorded blocker instead is the
+// thing an operator can actually act on: it names the finalizer holding the
+// namespace.
+function TeardownRow({ environment }: { environment: Environment }): React.ReactElement {
+  const deleting = environment.status === 'deleting';
+  return (
+    <li className="deploy-row deploy-row--tearing-down">
+      <span className="deploy-env-name">{environment.name}</span>
+      <div className="deploy-status" role="status" aria-live="polite">
+        <p>
+          {deleting
+            ? `${environment.name} is being deleted, so it cannot be deployed.`
+            : `${environment.name}'s delete is blocked and still outstanding, so it cannot be deployed. Resolve the teardown first.`}
+        </p>
+        {environment.deleteError !== undefined && (
+          <p className="context-error">{environment.deleteError}</p>
+        )}
+      </div>
+    </li>
+  );
+}
+
 function EnvironmentDeployRow({
   environment,
   state,
@@ -191,6 +236,9 @@ function EnvironmentDeployRow({
   const [version, setVersion] = React.useState('');
   const busy = state?.status === 'starting' || state?.status === 'deploying';
   const versionInputId = `deploy-version-${environment.environmentId}`;
+  if (isTearingDown(environment)) {
+    return <TeardownRow environment={environment} />;
+  }
   return (
     <li className="deploy-row">
       <span className="deploy-env-name">{environment.name}</span>
@@ -198,13 +246,17 @@ function EnvironmentDeployRow({
       <input
         id={versionInputId}
         value={version}
-        onChange={(e) => { setVersion(e.target.value); }}
+        onChange={(e) => {
+          setVersion(e.target.value);
+        }}
         placeholder={environment.runtimeVersion ?? 'pinned version'}
       />
       <button
         type="button"
         disabled={busy}
-        onClick={() => { onDeploy(environment.environmentId, version.trim()); }}
+        onClick={() => {
+          onDeploy(environment.environmentId, version.trim());
+        }}
       >
         {busy ? 'Deploying…' : 'Deploy'}
       </button>


### PR DESCRIPTION
## Summary

Closes #1170 and #1167. Both are the console asserting something untrue about state it had no model for, so they share the fix surface and the test suite.

### #1170 — Deploy offered on an environment being deleted

`EnvironmentStatus` did not include `deleting` or `deletion-blocked` **at all**. The status parse is deliberately lenient ("an unknown future state renders no badge rather than failing the parse"), so a teardown environment rendered with *no badge* — indistinguishable from an ordinary one — and the Deploy button was offered unconditionally.

An operator clicked it on `frs-prod` and got a raw Kubernetes admission error back:

```
secrets "operations-devops-mcp-auth" is forbidden: unable to create new content
in namespace operations-probel because it is being terminated
```

And before the API guard in #1163 existed, that deploy was *accepted* and overwrote the teardown state entirely, leaving a row that counted against the tenant quota with no namespace behind it.

Both states are modelled now, along with `deleteError`, and a row whose delete is outstanding shows the teardown state plus the recorded blocker **in place of** the Deploy control. The blocker is the useful part — it names the finalizer actually holding the namespace, which is what an operator can act on.

Adding the states to the union made the compiler surface a second gap: `ConfigView`'s `Record<EnvironmentStatus, string>` badge map had no labels for them, which is *why* they rendered invisibly. That is now a `Deleting` / `Delete blocked` badge like every other status.

### #1167 — a self-signed-up user stuck on a sign-in prompt forever

A 401 was always mapped to `signed-out`. But a self-signed-up user has a perfectly good token: the identity provider authenticated them, and the API refused because their identity belongs to no tenant. So they got:

> Sign in to view your environments.

…which succeeds and returns to the same screen, forever — with a **Sign out** button beside it, because a token did exist. That contradictory pair is the exact screen that was reported.

A 401 *with a token held* is now its own state. It says enrolment is what has to happen, and that signing in again will not change it. It also **names the identity to be enrolled**, read from the token's own claims — the first time this came up, the operator had to query the database to find the external subject id (`387534471668170904`), and it was on the user's screen the whole time.

`readTokenIdentity` decodes without verifying, which is safe *only* because the result is display text and never an authorization input. That constraint is documented in the module so it stays true.

## Verification

`yarn typecheck`, `yarn lint` (**0 issues, no rule disabled or downgraded**), `yarn format:check`, `yarn build`, and **44/44 tests across 7 files**.

Six new tests:

| test | holds |
|---|---|
| `offers no Deploy control for an environment that is being deleted` | no button, teardown state explained |
| `surfaces the recorded blocker for a deletion-blocked environment…` | the finalizer detail reaches the screen |
| `still offers Deploy for every non-teardown status` | the gate cannot over-reach |
| `tells a signed-in but unenrolled caller they need enrolling…` | and asserts the sign-in loop is *gone* |
| `readTokenIdentity` × 5 | claims, `preferred_username` fallback, UTF-8, unreadable tokens, non-object payloads |

I confirmed the three behavioural tests are not vacuous — reverting just the teardown gate and the 401 mapping fails exactly those three and nothing else:

```
× offers no Deploy control for an environment that is being deleted
× surfaces the recorded blocker for a deletion-blocked environment instead of a Deploy button
× tells a signed-in but unenrolled caller they need enrolling, not to sign in again
Tests  3 failed | 41 passed (44)
```

## Two notes on existing code

**One pre-existing test asserted the bug.** `renders the sign-in prompt on a 401` mocked a 401 *with* a dev token present — it encoded the dead end as expected behaviour, which is why nothing caught this. It now asserts the enrolment message. The genuine signed-out path is still covered by the adjacent `no dev token` test, so no coverage is lost.

**Prettier reformatted one over-width line in `auth/auth.test.ts`** that I did not otherwise touch. Kept, since touching this module makes every pre-existing finding in it mine per the root AGENTS.md, and `format:check` would fail otherwise.

## Not in scope

`readTokenIdentity` deliberately does not attempt to *request* enrolment (a "request access" button posting to the API). That needs a backend endpoint and an operator-facing approval surface that do not exist yet; this change makes the dead end explicable, which is what #1167 asked for.