### PR TITLE
Let erun-backend-api publish its own endpoint

### DIFF
--- a/erun-devops/k8s/erun-backend-api-chart_test.sh
+++ b/erun-devops/k8s/erun-backend-api-chart_test.sh
@@ -328,4 +328,79 @@ container "${rendered}" >"${core}"
 grep -q 'ERUN_ACME_EMAIL' "${core}" &&
     fail "acmeEmail must not render when the dns01 broker itself is disabled -- there is no broker for the webhook shim to call"
 
-echo "PASS: erun-backend-api DBOS wiring"
+# --- 14. The API's own public HTTPS edge (#1141). Every other externally
+#         reachable component declares its own Ingress; the API could not, so
+#         the endpoint every client actually holds a login record against was
+#         the one thing nothing in the repo declared. ---
+
+# The Ingress manifest, as its own block, so an assertion cannot pass by
+# matching a line that belongs to the Service or the Deployment.
+ingress() {
+    awk '
+        BEGIN{RS="\n---\n"}
+        $0 ~ /(^|\n)kind: Ingress(\n|$)/ {print}
+    ' "$1"
+}
+
+# Off by default: an existing deployment must not gain a public endpoint just by
+# upgrading the chart.
+rendered=$(render)
+[ -z "$(ingress "${rendered}")" ] ||
+    fail "the API Ingress must not render unless api.externalDomain is set -- an upgrade must never silently publish the API"
+
+rendered=$(render --set-string api.externalDomain=api.example.com)
+api_ingress="${work_root}/api-ingress.yaml"
+ingress "${rendered}" >"${api_ingress}"
+[ -s "${api_ingress}" ] || fail "api.externalDomain must render an Ingress for the API"
+grep -q 'name: team-api' "${api_ingress}" ||
+    fail "the Ingress must be named for the tenant's API, matching the Service it fronts"
+grep -q 'host: api.example.com' "${api_ingress}" ||
+    fail "api.externalDomain must become the Ingress host"
+grep -q 'ingressClassName: traefik' "${api_ingress}" ||
+    fail "the Ingress class must default to traefik, as erun-console's does"
+grep -q 'secretName: team-api-tls' "${api_ingress}" ||
+    fail "TLS must default to its own per-host secret, mirroring erun-console"
+grep -q 'name: api' "${api_ingress}" ||
+    fail "the Ingress backend must target the API Service's named port"
+grep -q 'cert-manager.io/issuer' "${api_ingress}" &&
+    fail "no issuer annotation must appear unless api.certManagerIssuer is set"
+
+# An issuer annotation is how the certificate actually gets minted.
+rendered=$(render \
+    --set-string api.externalDomain=api.example.com \
+    --set-string api.certManagerIssuer=frs-letsencrypt-http01)
+ingress "${rendered}" >"${api_ingress}"
+grep -q 'cert-manager.io/issuer: "frs-letsencrypt-http01"' "${api_ingress}" ||
+    fail "api.certManagerIssuer must render the cert-manager issuer annotation"
+
+# Reusing a wildcard the edge already issued, rather than minting a second
+# certificate for a name the wildcard already covers.
+rendered=$(render \
+    --set-string api.externalDomain=api.team-prod.services.example.com \
+    --set-string api.tlsSecretName=team-prod-wildcard-tls)
+ingress "${rendered}" >"${api_ingress}"
+grep -q 'secretName: team-prod-wildcard-tls' "${api_ingress}" ||
+    fail "api.tlsSecretName must let an existing wildcard secret be reused"
+grep -q 'cert-manager.io/issuer' "${api_ingress}" &&
+    fail "reusing a wildcard must not also request issuance"
+
+# An operator-supplied annotation (middleware, rate limits, auth) must pass
+# through, like the console's.
+rendered=$(render \
+    --set-string api.externalDomain=api.example.com \
+    --set-string 'api.ingressAnnotations.traefik\.ingress\.kubernetes\.io/router\.entrypoints=websecure')
+ingress "${rendered}" >"${api_ingress}"
+grep -q 'traefik.ingress.kubernetes.io/router.entrypoints: "websecure"' "${api_ingress}" ||
+    fail "api.ingressAnnotations must pass through to the Ingress"
+
+# Explicitly empty TLS secret: plain HTTP, for an edge terminating TLS ahead of
+# the ingress. The Ingress must still render, without a tls block.
+rendered=$(render \
+    --set-string api.externalDomain=api.example.com \
+    --set-string api.tlsSecretName="")
+ingress "${rendered}" >"${api_ingress}"
+[ -s "${api_ingress}" ] || fail "an empty tlsSecretName must still render the Ingress"
+grep -q 'tls:' "${api_ingress}" &&
+    fail "an empty tlsSecretName must render no tls block rather than a dangling secret reference"
+
+echo "PASS: erun-backend-api DBOS wiring + public API edge"

--- a/erun-devops/k8s/erun-backend-api/templates/api.yaml
+++ b/erun-devops/k8s/erun-backend-api/templates/api.yaml
@@ -43,6 +43,44 @@
 {{- $imageOverrides := default dict .Values.imageOverrides -}}
 {{- $containerRegistry := default "ghcr.io/sophium" .Values.containerRegistry -}}
 {{- $backendAPIImage := default (printf "%s/erun-backend-api:%s" $containerRegistry .Chart.AppVersion) (index $imageOverrides "erun-backend-api") -}}
+{{- /* Opt-in public HTTPS edge for the API itself, mirroring erun-console's
+       and erun-zitadel's own Ingresses in shape and value naming (#1141). Every
+       other externally-reachable component of a platform declares its own
+       endpoint; the API could not, so the one component a tenant must reach in
+       order to use the platform at all was the only one the platform could not
+       publish. The result was an Ingress nothing declared, which cannot be
+       reviewed, reproduced on a second instance, or recovered if deleted --
+       while CLI login records are keyed to that hostname.
+
+       Off unless api.externalDomain is set, so no existing deployment gains a
+       public endpoint on upgrade. Unlike erun-console's, this one has no
+       default derived from platform.baseDomain: the API's public address is a
+       deployment decision (an instance may deliberately keep it in-cluster
+       only), and silently publishing it on a version bump is exactly what the
+       opt-in exists to prevent.
+
+       This does not make the API browser-callable from another origin -- it
+       still sets no CORS headers by design, and erun-console still reaches it
+       same-origin through its own nginx proxy. What it publishes is the
+       endpoint non-browser clients already use: the CLI, orchestrators, CI. */ -}}
+{{- $externalDomain := default "" $api.externalDomain -}}
+{{- $ingressClass := default "traefik" $api.ingressClass -}}
+{{- $ingressAnnotations := default dict $api.ingressAnnotations -}}
+{{- $certManagerIssuer := default "" $api.certManagerIssuer -}}
+{{- /* Defaults to its own per-host secret, like the console's. Point it at an
+       existing wildcard secret (e.g. <tenant>-<env>-wildcard-tls) to reuse a
+       certificate the edge already issued instead of minting a second one, or
+       set it explicitly empty to render no tls block at all -- which is what an
+       edge terminating TLS ahead of the ingress wants.
+
+       hasKey rather than `default`: Helm's default() treats "" as absent and
+       substitutes, so an explicitly empty secret name would silently come back
+       as the default and the Ingress would reference a Secret that does not
+       exist. Same shape as Terraform's coalesce() skipping empty strings. */ -}}
+{{- $tlsSecretName := printf "%s-api-tls" $tenant -}}
+{{- if hasKey $api "tlsSecretName" -}}
+{{- $tlsSecretName = $api.tlsSecretName -}}
+{{- end -}}
 {{- /* Opt-in backend MCP-signing identity: a mounted Ed25519 key the
        API signs per-env MCP and DNS-01 broker tokens with. Off by default — the
        mint endpoints report 501 and the DNS-01 broker is unregistered — so
@@ -407,6 +445,45 @@ spec:
       port: {{ $apiPort }}
       targetPort: api
 ---
+{{- if $externalDomain }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $tenant }}-api
+  labels:
+    app: {{ $tenant }}-api
+  {{- if or $certManagerIssuer $ingressAnnotations }}
+  annotations:
+    {{- if $certManagerIssuer }}
+    cert-manager.io/issuer: {{ $certManagerIssuer | quote }}
+    {{- end }}
+    {{- range $key, $value := $ingressAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if $ingressClass }}
+  ingressClassName: {{ $ingressClass }}
+  {{- end }}
+  {{- if $tlsSecretName }}
+  tls:
+    - hosts:
+        - {{ $externalDomain }}
+      secretName: {{ $tlsSecretName }}
+  {{- end }}
+  rules:
+    - host: {{ $externalDomain }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $tenant }}-api
+                port:
+                  name: api
+---
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/erun-devops/k8s/erun-console/templates/console.yaml
+++ b/erun-devops/k8s/erun-console/templates/console.yaml
@@ -20,7 +20,15 @@
 {{- $ingressClass := default "traefik" $console.ingressClass -}}
 {{- $ingressAnnotations := default dict $console.ingressAnnotations -}}
 {{- $certManagerIssuer := default "" $console.certManagerIssuer -}}
-{{- $tlsSecretName := default (printf "%s-console-tls" $tenant) $console.tlsSecretName -}}
+{{- /* hasKey rather than `default`: Helm's default() treats "" as absent, so an
+       explicitly empty secret name silently came back as the default and the
+       Ingress referenced a Secret that does not exist. Kept identical to
+       erun-backend-api's, since #1141's whole point is that an operator who has
+       configured one knows how to configure the other. */ -}}
+{{- $tlsSecretName := printf "%s-console-tls" $tenant -}}
+{{- if hasKey $console "tlsSecretName" -}}
+{{- $tlsSecretName = $console.tlsSecretName -}}
+{{- end -}}
 {{- $nginxPort := default 8080 $console.port -}}
 {{- $apiServiceName := default (printf "%s-api" $tenant) $console.apiServiceName -}}
 {{- $apiPort := default 17033 .Values.apiPort -}}


### PR DESCRIPTION
## Summary

Closes #1141.

Every other externally reachable component of a hosted platform owns its own Ingress. `erun-backend-api` had neither a template nor a value, so **the one component a tenant must reach in order to use the platform at all was the only one the platform could not publish.**

The consequence was visible on `frs-prod` — an `expose-api` Ingress with `MANAGED-BY erun-expose` sitting beside Helm- and terraform-owned rows, declared by nothing:

| chart | renders an Ingress | after this change |
|---|---|---|
| `erun-console` | yes, from `console.externalDomain` | unchanged |
| `erun-zitadel` | yes, from `zitadel.externalDomain` | unchanged |
| `erun-backend-api` | **no** | yes, from `api.externalDomain` |

It could not be reviewed, reproduced on a second instance, or recovered if deleted — and it is load-bearing, since CLI login records are keyed to that hostname (`accountid: api.frs-prod.services.erunpaas.com`). It also made the asymmetry concrete: the API's *default* address ended up declared in a tenant's terraform while the console's and the IdP's are declared in their own charts. Two mechanisms for one job, purely because the API chart could not do it.

## Shape

The chart renders an Ingress from `api.externalDomain`, mirroring `erun-console`'s value naming exactly — `externalDomain`, `ingressClass`, `ingressAnnotations`, `certManagerIssuer`, `tlsSecretName` — so an operator who has configured one knows how to configure the other, which is what the acceptance criteria asked for.

**Off unless `api.externalDomain` is set**, and deliberately with *no* default derived from `platform.baseDomain`, unlike `erun-console`'s. The API's public address is a deployment decision — an instance may keep it in-cluster only — so defaulting it would publish an endpoint on a version bump, which is exactly what the opt-in exists to prevent.

**This does not make the API browser-callable cross-origin.** It still sets no CORS headers by design, and `erun-console` still reaches it same-origin through its own nginx proxy — the design the console's own template comment describes. What this publishes is the endpoint non-browser clients already use: the CLI, orchestrators, CI.

## One trap worth calling out

`tlsSecretName` uses `hasKey` rather than Helm's `default()`, because **`default()` treats `""` as absent** — so an explicitly empty secret name silently came back as the default and the Ingress referenced a Secret that does not exist. That matters here because "terminate TLS ahead of the ingress" is a real configuration.

The same trap was already in `erun-console`'s template. Since this issue's whole point is that the two should be configured identically, I fixed it there too rather than leaving a difference between the file being copied and the copy. Verified the console's default render is **byte-for-byte identical** afterwards, and that an explicit empty now yields no `tls` block.

(This is the same shape as Terraform's `coalesce()` skipping empty strings, which bit the cluster-edge module in #1161 — worth remembering as a class.)

## Verification

`erun-backend-api-chart_test.sh` grows assertions for:

- **no Ingress at all without `externalDomain`** — an upgrade must never silently publish the API
- host, default `ingressClassName: traefik`, default `team-api-tls` secret, backend targeting the Service's *named* port
- no `cert-manager.io/issuer` annotation unless asked; the annotation present when asked
- **reusing an existing wildcard secret** without also requesting issuance
- operator annotation passthrough
- an explicitly empty `tlsSecretName` rendering the Ingress with **no** `tls` block

`PASS: erun-backend-api DBOS wiring + public API edge`, and the `erun-devops`, `erun-zitadel` and `erun-docs` chart tests still pass.

## Not in this change

Switching frs's terraform-declared `public-api` Ingress over to the chart. That needs an erun release carrying this first, and it is the tenant repo's call — the point of this change is that the option now exists.