### PR TITLE
Grant the delete Job the access its challenge retraction needs, and stop it failing silently

### DIFF
--- a/erun-common/kubernetes_namespace.go
+++ b/erun-common/kubernetes_namespace.go
@@ -157,7 +157,7 @@ func DeleteKubernetesNamespace(contextName, namespace string) error {
 	// with no cert-manager, or a challenge that will not finalize, must not
 	// block the delete. If a challenge does survive this, the namespace's own
 	// conditions still name it in NamespaceTerminationBlockedError below.
-	retractACMEChallenges(contextName, namespace)
+	retractionNote := retractACMEChallenges(contextName, namespace)
 
 	args = append(args, "delete", "namespace", namespace, "--ignore-not-found", "--timeout", NamespaceDeleteTimeout.String())
 
@@ -171,7 +171,14 @@ func DeleteKubernetesNamespace(contextName, namespace string) error {
 		if !exists {
 			return nil
 		}
-		return &NamespaceTerminationBlockedError{Namespace: namespace, Detail: namespaceTerminationConditions(contextName, namespace)}
+		return &NamespaceTerminationBlockedError{
+			Namespace: namespace,
+			// The retraction note rides along here rather than being logged: if
+			// the namespace wedged AND the retraction could not run, those two
+			// facts belong together, in the one string an operator reads off
+			// the environment row.
+			Detail: joinTerminationDetail(namespaceTerminationConditions(contextName, namespace), retractionNote),
+		}
 	}
 	if message == "" {
 		return fmt.Errorf("failed to delete kubernetes namespace %q in context %q: %w", namespace, contextName, err)
@@ -190,20 +197,40 @@ const acmeRetractTimeout = 90 * time.Second
 // waits for its ACME Challenges to finalize, so a challenge's cleanup runs
 // while the DNS-01 token Secret it authenticates with still exists.
 //
-// Every failure here is deliberately swallowed. On a cluster without
-// cert-manager the CRDs do not exist and kubectl reports an unknown resource
-// type, which is the common case for a local or test cluster and is not an
-// error in any meaningful sense. The caller's contract is "delete this
-// namespace", and this function only ever makes that faster.
-func retractACMEChallenges(contextName, namespace string) {
-	if !acmeChallengesPresent(contextName, namespace) {
-		return
+// Returns a note describing why the retraction could not run, or "" when it ran
+// (or was legitimately unnecessary). The note is folded into the blocked-delete
+// error if the namespace then wedges, which is the one place an operator is
+// already looking. It is deliberately not logged: this is a library used by the
+// CLI, and writing to the CLI's own output would be both noise and a golden
+// change for every delete.
+//
+// The distinction matters. A cluster with no cert-manager has no CRDs, the read
+// fails with "the server doesn't have a resource type", and skipping is exactly
+// right at zero cost. A cluster that HAS cert-manager but refuses the read is
+// the opposite: the retraction cannot work, the namespace will wedge, and
+// treating that as "nothing to retract" is how this shipped inert the first
+// time (#1183) -- the read was Forbidden, that was read as "no challenges", and
+// the whole step was skipped with nothing to say so.
+func retractACMEChallenges(contextName, namespace string) string {
+	present, err := acmeChallengesPresent(contextName, namespace)
+	if err != nil {
+		if acmeCRDsAbsent(err.Error()) {
+			// No cert-manager on this cluster: nothing to retract, and nothing
+			// to report. The normal case for a local or test cluster.
+			return ""
+		}
+		return fmt.Sprintf("the pre-teardown ACME challenge retraction could not run (%s); if a challenge is still finalizing it will hold this namespace until the namespace delete times out", strings.TrimSpace(err.Error()))
+	}
+	if !present {
+		return ""
 	}
 
 	args := append(kubernetesContextArgs(contextName),
 		"-n", namespace, "delete", "certificates.cert-manager.io", "--all",
 		"--ignore-not-found", "--timeout", acmeRetractTimeout.String())
-	_, _ = Command("kubectl", args...).CombinedOutput()
+	if output, deleteErr := Command("kubectl", args...).CombinedOutput(); deleteErr != nil {
+		return fmt.Sprintf("deleting this namespace's cert-manager Certificates before teardown did not succeed (%s: %s); a challenge still finalizing will hold the namespace until the delete times out", deleteErr, strings.TrimSpace(string(output)))
+	}
 
 	// Wait for the challenges to actually go, rather than assuming the
 	// Certificate delete cascaded synchronously -- cert-manager removes the
@@ -211,25 +238,51 @@ func retractACMEChallenges(contextName, namespace string) {
 	// finalizer, not the Certificate's, that blocks the namespace.
 	deadline := time.Now().Add(acmeRetractTimeout)
 	for time.Now().Before(deadline) {
-		if !acmeChallengesPresent(contextName, namespace) {
-			return
+		stillPresent, waitErr := acmeChallengesPresent(contextName, namespace)
+		if waitErr != nil || !stillPresent {
+			return ""
 		}
 		time.Sleep(2 * time.Second)
 	}
+	return fmt.Sprintf("this namespace's ACME challenges had not finalized %s after its Certificates were deleted; the namespace delete may wait on their finalizer", acmeRetractTimeout)
+}
+
+// acmeCRDsAbsent reports whether a kubectl failure means cert-manager's ACME
+// CRDs are not installed, as opposed to any other failure. Matched on kubectl's
+// own wording for an unknown resource type; anything else -- Forbidden above
+// all -- is a real problem and must not be mistaken for an absent CRD.
+func acmeCRDsAbsent(message string) bool {
+	lowered := strings.ToLower(message)
+	return strings.Contains(lowered, "the server doesn't have a resource type") ||
+		strings.Contains(lowered, "server could not find the requested resource") ||
+		strings.Contains(lowered, "no matches for kind")
 }
 
 // acmeChallengesPresent reports whether the namespace currently has any ACME
-// Challenge. A read that fails for any reason -- no cert-manager CRDs, no
-// permission, apiserver unavailable -- reports false, so the caller skips the
-// retraction rather than looping on a question it cannot answer.
-func acmeChallengesPresent(contextName, namespace string) bool {
+// Challenge. The error is returned rather than folded into false, so the caller
+// can tell "cert-manager is not installed" from "the read was refused".
+func acmeChallengesPresent(contextName, namespace string) (bool, error) {
 	args := append(kubernetesContextArgs(contextName),
 		"-n", namespace, "get", "challenges.acme.cert-manager.io", "-o", "name")
-	output, err := Command("kubectl", args...).Output()
+	output, err := Command("kubectl", args...).CombinedOutput()
 	if err != nil {
-		return false
+		return false, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
 	}
-	return strings.TrimSpace(string(output)) != ""
+	return strings.TrimSpace(string(output)) != "", nil
+}
+
+// joinTerminationDetail combines the namespace's own conditions with a note
+// about the pre-teardown retraction, keeping either alone readable when the
+// other is empty.
+func joinTerminationDetail(conditions, note string) string {
+	switch {
+	case note == "":
+		return conditions
+	case conditions == "":
+		return note
+	default:
+		return conditions + "\n" + note
+	}
 }
 
 // namespaceTerminationConditions reads back a namespace's own status

--- a/erun-devops/k8s/erun-backend-api-chart_test.sh
+++ b/erun-devops/k8s/erun-backend-api-chart_test.sh
@@ -403,4 +403,26 @@ ingress "${rendered}" >"${api_ingress}"
 grep -q 'tls:' "${api_ingress}" &&
     fail "an empty tlsSecretName must render no tls block rather than a dangling secret reference"
 
-echo "PASS: erun-backend-api DBOS wiring + public API edge"
+# --- 15. The delete Job's pre-teardown challenge retraction needs read access
+#         to cert-manager's ACME chain and delete on certificates (#1183). It
+#         shipped without them, so its own reads were Forbidden, that was read
+#         as "no challenges here", and the retraction did nothing at all while
+#         reporting success. ---
+rendered=$(render --set-string api.envDeployer.enabled=true)
+provisioner="${work_root}/env-provisioner.yaml"
+awk -v want="  name: team-env-provisioner" '
+    BEGIN{RS="\n---\n"}
+    $0 ~ /(^|\n)kind: ClusterRole(\n|$)/ && $0 ~ ("(^|\n)" want "(\n|$)") {print}
+' "${rendered}" >"${provisioner}"
+[ -s "${provisioner}" ] || fail "the env-provisioner ClusterRole must render when envDeployer is enabled"
+
+grep -q 'apiGroups: \["acme.cert-manager.io"\]' "${provisioner}" ||
+    fail "the env-provisioner must be able to read acme.cert-manager.io, or the delete Job cannot see a challenge holding the namespace and the retraction is silently inert (#1183)"
+grep -A2 'apiGroups: \["acme.cert-manager.io"\]' "${provisioner}" | grep -q 'challenges' ||
+    fail "the acme.cert-manager.io grant must cover challenges -- the Challenge finalizer is what blocks the namespace"
+grep -A2 'apiGroups: \["cert-manager.io"\]' "${provisioner}" | grep -q '"delete"' ||
+    fail "the env-provisioner must be able to delete certificates, or the retraction cannot cascade to the Challenge that holds the namespace"
+grep -A2 'apiGroups: \["cert-manager.io"\]' "${provisioner}" | grep -q '"list"' ||
+    fail "the env-provisioner must be able to list certificates, since the retraction deletes them with --all"
+
+echo "PASS: erun-backend-api DBOS wiring + public API edge + retraction RBAC"

--- a/erun-devops/k8s/erun-backend-api/templates/api.yaml
+++ b/erun-devops/k8s/erun-backend-api/templates/api.yaml
@@ -364,7 +364,24 @@ rules:
          create for the same idempotent-reapply reason as the Ingress above. */}}
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "certificates"]
-    verbs: ["create", "get", "update", "patch"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  {{- /* list + delete on certificates, and read on the ACME chain, are what the
+         delete Job's pre-teardown challenge retraction needs (#1174/#1183).
+         Namespace teardown removes the env's DNS-01 token Secret as ordinary
+         content, but a still-pending Challenge's cleanup authenticates to the
+         broker with exactly that Secret -- so if the Certificate is not deleted
+         and its Challenges not waited out first, the finalizer never clears and
+         the namespace sits in Terminating for its full timeout.
+
+         Without these verbs the retraction's own reads are Forbidden and it
+         does nothing at all, which is how #1174 shipped inert: `kubectl get
+         challenges` returned Forbidden, that was read as "no challenges here",
+         and the whole step was skipped. Orders and Challenges are read-only --
+         deleting the Certificate is what cascades to them; the reads only exist
+         to wait for the cascade to finish. */}}
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges", "orders"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]

--- a/erun-integration/delete_test.go
+++ b/erun-integration/delete_test.go
@@ -248,6 +248,54 @@ exit 0
 		}
 	})
 
+	t.Run("real_run_reports_a_refused_challenge_read_instead_of_skipping_silently", func(t *testing.T) {
+		// #1183: the retraction shipped inert. Its challenge read was Forbidden
+		// (the delete Job's ServiceAccount had no access to
+		// acme.cert-manager.io), the code folded every error into "no
+		// challenges here", and the whole step was skipped with nothing to say
+		// so -- so the namespace wedged for its full timeout exactly as before.
+		//
+		// A cluster without cert-manager must still skip silently; that is the
+		// next scenario. A cluster that HAS it and refuses the read must say so,
+		// because the namespace is about to wedge and the reason is not in the
+		// namespace's own conditions.
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinaryWithScript(t, stubs, "kubectl",
+			`case "$*" in
+  *"get challenges"*)
+    printf '%s\n' 'Error from server (Forbidden): challenges.acme.cert-manager.io is forbidden: User "system:serviceaccount:team-prod:team-env-deployer" cannot list resource "challenges"' >&2
+    exit 1
+    ;;
+  *"delete namespace"*)
+    # What a wedged namespace actually does: the delete waits out its timeout
+    # and fails. That is the path the retraction note has to surface on.
+    printf '%s\n' 'error: timed out waiting for the condition on namespaces/team-dev' >&2
+    exit 1
+    ;;
+  *"get namespace"*)
+    # Still present afterwards, so the blocked-delete branch runs rather than
+    # the benign "it disappeared during the wait" one.
+    printf '%s\n' 'namespace/team-dev'
+    ;;
+esac
+exit 0
+`)
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+		result := erun.Run(t, []string{"delete", "team", "dev", "--yes"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+
+		if !strings.Contains(result.Combined, "retraction could not run") {
+			t.Fatalf("a refused challenge read must be reported, not swallowed; got:\n%s", result.Combined)
+		}
+		if !strings.Contains(result.Combined, "forbidden") && !strings.Contains(result.Combined, "Forbidden") {
+			t.Fatalf("the report must carry kubectl's own reason so the cause is actionable; got:\n%s", result.Combined)
+		}
+	})
+
 	t.Run("real_run_without_cert_manager_skips_the_retraction", func(t *testing.T) {
 		// The retraction is an optimization, so a cluster with no cert-manager
 		// (the normal case for a local or test cluster, where the CRDs do not


### PR DESCRIPTION
## Summary

Closes #1183.

**#1174's ordered teardown shipped inert.** I merged it, released it in 1.0.200, deployed it to `frs-prod`, and the end-to-end gate reproduced the original 20-minute wedge unchanged — with the right test conditions: a challenge `pending` for 22 seconds when the delete landed, and the delete Job running the correct `erun-devops:1.0.200` image.

Two causes, both mine.

**The RBAC was never granted.** The env-provisioner ClusterRole had `cert-manager.io` `issuers, certificates` with only `create, get, update, patch`, and nothing at all for `acme.cert-manager.io`:

```
kubectl auth can-i get    challenges.acme.cert-manager.io -n operations-gate1174 \
  --as=system:serviceaccount:frs-prod:frs-env-deployer   → no
kubectl auth can-i delete certificates.cert-manager.io   -n operations-gate1174 \
  --as=system:serviceaccount:frs-prod:frs-env-deployer   → no
```

**And a refused read looked identical to "nothing to retract".** `acmeChallengesPresent` folded every error into `false`, which the caller reads as "no challenges here" — so the whole step was skipped, silently, with nothing in the Job log to say it had not run.

That conflated two cases needing opposite handling:

| situation | correct | was |
|---|---|---|
| cert-manager absent (no CRDs) | skip at zero cost | skip ✓ |
| present but not permitted | **surface it** | skip, silently ✗ |

Which is precisely the apply-cleanly-and-do-nothing failure I filed #1165 about, reproduced in my own fix one day later.

## Fix

- **The ClusterRole** grants `list` + `delete` on certificates and read on `challenges, orders`. Orders and Challenges stay read-only — deleting the Certificate is what cascades to them, and the reads exist only to wait for that cascade to finish.
- **`acmeChallengesPresent` returns its error** instead of swallowing it. A genuinely absent CRD still skips silently (the normal case for a local cluster); anything else produces a note that rides into `NamespaceTerminationBlockedError.Detail`, so it lands in the `delete_error` an operator already reads off the environment row. Deliberately *not* logged: `erun-common` is a library the CLI uses, and writing there would be both noise and a golden change on every delete.

## The tests are the other half of the lesson

**Both tests I wrote for #1174 passed against code that did nothing**, because both stubbed a kubectl that *answered* the challenge read. The case that actually occurs — the read being refused — was never covered. A green suite told me nothing about the thing that mattered.

- A chart assertion on the grant itself, so the RBAC cannot regress silently.
- `real_run_reports_a_refused_challenge_read_instead_of_skipping_silently` — the read returns `Forbidden` and the namespace then wedges, which is what makes the note observable.

Verified red-then-green against the real defect:

```
pre-fix:  FAIL — a refused challenge read must be reported, not swallowed
restored: rc=0
```

My *first* version of that scenario also passed for the wrong reason: it didn't model the namespace wedging, so the blocked path never ran and the note had nowhere to appear. Worth stating, because it's the same mistake twice in one sitting.

`gofmt`, `go build`, `erun-common` tests, all four chart tests, and the full `erun-integration` suite green.

## Still not deployed

#1174's other half — the shim tolerating an already-deleted token on cleanup — is also absent from `frs-prod`, which still runs `erun-dns01-webhook:1.0.198`. The terraform module's pin only reaches a cluster on an apply that hasn't run yet, so the gate exercised **neither** half. The ordering fix is the real one; the tolerance is a fallback that abandons the DNS record. Both need to land before the wedge is actually gone, and the gate needs re-running on a release that carries both.