### PR TITLE
Report an orchestrator's unwired environments instead of dropping them

### DIFF
--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -1279,6 +1279,33 @@ type orchestratorSpawn struct {
 	rows           int
 }
 
+// wireOrchestratorMCP writes the per-orchestrator MCP config and tells the
+// operator about anything that did not wire, returning the config path ("" when
+// there is none). Split out of spawnOrchestratorSession to keep that function
+// inside the module's complexity budget.
+//
+// Both failure shapes are non-fatal: the orchestrator still launches. What it
+// must not do is launch quietly. A session with linked environments and none of
+// their tools looks working and is not, and a session missing just ONE
+// environment's tools is worse -- it works, right up to the first call into the
+// environment that is not there, which an agent reads as "not linked" rather
+// than "failed to wire" (#1185).
+func (a *App) wireOrchestratorMCP(id, name string, envs []eruncommon.OrchestratorEnvConfig) string {
+	path, skipped, err := a.writeOrchestratorMCPConfig(id, envs)
+	for _, skip := range skipped {
+		log.Printf("erun-app: orchestrator %s: no MCP tools for %s: %s", id, skip.Label, skip.Reason)
+	}
+	if err != nil {
+		log.Printf("erun-app: write orchestrator MCP config for %s: %v", id, err)
+		a.emitAppNotification("warning", orchestratorMCPUnwiredNotice(name, err))
+		return ""
+	}
+	if len(skipped) > 0 {
+		a.emitAppNotification("warning", orchestratorMCPPartialNotice(name, len(envs)-len(skipped), skipped))
+	}
+	return path
+}
+
 // spawnOrchestratorSession launches the host AI harness in the shared
 // orchestrators root and tracks the live session.
 func (a *App) spawnOrchestratorSession(spawn orchestratorSpawn) (orchestratorInfo, error) {
@@ -1290,11 +1317,7 @@ func (a *App) spawnOrchestratorSession(spawn orchestratorSpawn) (orchestratorInf
 	// Non-fatal: the orchestrator still launches without the env MCP, but an
 	// agent with linked envs and none of their tools looks working and is not,
 	// so the operator is told why instead of discovering it tool by tool.
-	mcpConfigPath, mcpErr := a.writeOrchestratorMCPConfig(id, envs)
-	if mcpErr != nil {
-		log.Printf("erun-app: write orchestrator MCP config for %s: %v", id, mcpErr)
-		a.emitAppNotification("warning", orchestratorMCPUnwiredNotice(name, mcpErr))
-	}
+	mcpConfigPath := a.wireOrchestratorMCP(id, name, envs)
 	// A restart hand-off names the conversation that asked for it; every other
 	// launch falls back to this orchestrator's own pinned one.
 	conversationID := strings.TrimSpace(spawn.conversationID)

--- a/erun-ui/orchestrator_mcp.go
+++ b/erun-ui/orchestrator_mcp.go
@@ -30,23 +30,45 @@ type orchestratorMCPConfig struct {
 // live config store.
 type mcpPortResolver func(tenant, environment string) int
 
+// orchestratorMCPSkip is one linked environment that produced no MCP server
+// entry, and why. Carried out of the builder rather than dropped: an
+// orchestrator is told by its own operating contract to know which environments
+// are its own, so an environment silently missing from its toolset is a
+// falsehood it cannot detect from the inside (#1185).
+type orchestratorMCPSkip struct {
+	Label  string
+	Reason string
+}
+
 // buildOrchestratorMCPConfig assembles the per-env MCP server map, keyed
 // "<tenant>-<environment>". An env is skipped (not an error) when its MCP port
 // does not resolve — that env is not wired for MCP at all — so an orchestrator
-// still gets the envs it can reach.
-func buildOrchestratorMCPConfig(envs []eruncommon.OrchestratorEnvConfig, executable string, mcpPort mcpPortResolver) orchestratorMCPConfig {
+// still gets the envs it can reach. Every skip is returned alongside, so a
+// PARTIAL skip is reportable: previously only the all-envs-failed case produced
+// any signal, and a session missing one of two environments looked identical to
+// a healthy one until its first call into the missing env.
+func buildOrchestratorMCPConfig(envs []eruncommon.OrchestratorEnvConfig, executable string, mcpPort mcpPortResolver) (orchestratorMCPConfig, []orchestratorMCPSkip) {
 	servers := map[string]orchestratorMCPServer{}
+	var skipped []orchestratorMCPSkip
 	executable = strings.TrimSpace(executable)
 	if executable == "" {
-		return orchestratorMCPConfig{MCPServers: servers}
+		return orchestratorMCPConfig{MCPServers: servers}, nil
 	}
 	for _, env := range envs {
 		tenant := strings.TrimSpace(env.Tenant)
 		environment := strings.TrimSpace(env.Environment)
 		if tenant == "" || environment == "" {
+			skipped = append(skipped, orchestratorMCPSkip{
+				Label:  orchestratorEnvLabel(tenant, environment),
+				Reason: "the linked entry names no tenant or environment",
+			})
 			continue
 		}
 		if mcpPort(tenant, environment) <= 0 {
+			skipped = append(skipped, orchestratorMCPSkip{
+				Label:  orchestratorEnvLabel(tenant, environment),
+				Reason: "it resolved no MCP port",
+			})
 			continue
 		}
 		servers[tenant+"-"+environment] = orchestratorMCPServer{
@@ -55,7 +77,22 @@ func buildOrchestratorMCPConfig(envs []eruncommon.OrchestratorEnvConfig, executa
 			Args:    []string{"mcp", "proxy", "--tenant", tenant, "--environment", environment},
 		}
 	}
-	return orchestratorMCPConfig{MCPServers: servers}
+	return orchestratorMCPConfig{MCPServers: servers}, skipped
+}
+
+// orchestratorEnvLabel names an environment for an operator-facing line, staying
+// readable when the config entry itself is the thing that is malformed.
+func orchestratorEnvLabel(tenant, environment string) string {
+	switch {
+	case tenant == "" && environment == "":
+		return "an unnamed linked entry"
+	case tenant == "":
+		return "?/" + environment
+	case environment == "":
+		return tenant + "/?"
+	default:
+		return tenant + "/" + environment
+	}
 }
 
 // The two ways an orchestrator ends up with linked environments but none of
@@ -87,23 +124,41 @@ func orchestratorMCPUnwiredNotice(name string, err error) string {
 	return fmt.Sprintf("%s started without its environment tools: %s. %s", label, cause, recovery)
 }
 
+// orchestratorMCPPartialNotice is the operator-facing line for an orchestrator
+// that got SOME of its environments' tools. Distinct from the unwired notice
+// because the session is usable and will look entirely healthy: the missing
+// environment surfaces only as a tool that is not there, which an agent reads as
+// "not linked" rather than "failed to wire" (#1185).
+func orchestratorMCPPartialNotice(name string, wired int, skipped []orchestratorMCPSkip) string {
+	label := strings.TrimSpace(name)
+	if label == "" {
+		label = "The orchestrator"
+	}
+	missing := make([]string, 0, len(skipped))
+	for _, skip := range skipped {
+		missing = append(missing, fmt.Sprintf("%s (%s)", skip.Label, skip.Reason))
+	}
+	return fmt.Sprintf("%s started with tools for %d of %d linked environments. Missing: %s. Check those environments still exist, then restart the orchestrator.",
+		label, wired, wired+len(skipped), strings.Join(missing, "; "))
+}
+
 // writeOrchestratorMCPConfig writes a per-orchestrator Claude Code --mcp-config
 // file wiring each linked env's erun MCP into the orchestrator session, so it
 // drives its envs through the MCP rather than raw kubectl. Returns "" with an
 // error naming why when nothing could be wired, so the caller skips
 // --mcp-config and can tell the operator which fix applies.
-func (a *App) writeOrchestratorMCPConfig(id string, envs []eruncommon.OrchestratorEnvConfig) (string, error) {
+func (a *App) writeOrchestratorMCPConfig(id string, envs []eruncommon.OrchestratorEnvConfig) (string, []orchestratorMCPSkip, error) {
 	// An orchestrator with no linked envs has nothing to wire, and that is normal.
 	if len(envs) == 0 {
-		return "", nil
+		return "", nil, nil
 	}
 	// No erun binary means no proxy to launch, so the session launches without
 	// its envs rather than with entries that would fail on first use.
 	executable, err := eruncommon.ResolveErunExecutable()
 	if err != nil {
-		return "", fmt.Errorf("%w: %w", errOrchestratorMCPExecutable, err)
+		return "", nil, fmt.Errorf("%w: %w", errOrchestratorMCPExecutable, err)
 	}
-	config := buildOrchestratorMCPConfig(envs, executable,
+	config, skipped := buildOrchestratorMCPConfig(envs, executable,
 		func(tenant, environment string) int {
 			ports, portErr := eruncommon.ResolveEnvironmentLocalPorts(a.deps.store, tenant, environment)
 			if portErr != nil {
@@ -113,20 +168,20 @@ func (a *App) writeOrchestratorMCPConfig(id string, envs []eruncommon.Orchestrat
 		},
 	)
 	if len(config.MCPServers) == 0 {
-		return "", errOrchestratorMCPNoPort
+		return "", skipped, errOrchestratorMCPNoPort
 	}
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		return "", err
+		return "", skipped, err
 	}
 	path := orchestratorMCPConfigPath(id)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return "", err
+		return "", skipped, err
 	}
 	if err := os.WriteFile(path, data, 0o600); err != nil {
-		return "", err
+		return "", skipped, err
 	}
-	return path, nil
+	return path, skipped, nil
 }
 
 // orchestratorMCPConfigPath is a per-orchestrator sibling of

--- a/erun-ui/orchestrator_mcp_test.go
+++ b/erun-ui/orchestrator_mcp_test.go
@@ -38,7 +38,7 @@ func orchestratorTestEnvs() []eruncommon.OrchestratorEnvConfig {
 }
 
 func TestBuildOrchestratorMCPConfig(t *testing.T) {
-	config := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort)
+	config, _ := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort)
 
 	if len(config.MCPServers) != 2 {
 		t.Fatalf("expected 2 servers, got %d: %v", len(config.MCPServers), config.MCPServers)
@@ -68,7 +68,7 @@ func TestBuildOrchestratorMCPConfig(t *testing.T) {
 // place a bearer can leak from: an MCP client cannot refresh a header it was
 // configured with, so the fix for the expiry was to stop writing one at all.
 func TestBuildOrchestratorMCPConfigCarriesNoCredential(t *testing.T) {
-	config := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort)
+	config, _ := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort)
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
 		t.Fatalf("marshal config: %v", err)
@@ -84,7 +84,7 @@ func TestBuildOrchestratorMCPConfigCarriesNoCredential(t *testing.T) {
 // and the caller skips --mcp-config rather than writing entries that fail on
 // first use.
 func TestBuildOrchestratorMCPConfigSkipsEveryEnvWithoutAnExecutable(t *testing.T) {
-	config := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "  ", orchestratorTestPort)
+	config, _ := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "  ", orchestratorTestPort)
 	if len(config.MCPServers) != 0 {
 		t.Fatalf("expected no servers without an executable, got %v", config.MCPServers)
 	}
@@ -153,7 +153,7 @@ func writeBundledDesktopMCPConfig(t *testing.T, output string) {
 	app := orchestratorTestApp(t)
 	defer app.shutdown(context.Background())
 
-	path, err := app.writeOrchestratorMCPConfig("petios", []eruncommon.OrchestratorEnvConfig{
+	path, _, err := app.writeOrchestratorMCPConfig("petios", []eruncommon.OrchestratorEnvConfig{
 		{Tenant: "frs", Environment: "dev"},
 	})
 	if err != nil {
@@ -305,6 +305,99 @@ func TestSanitizeOrchestratorFileID(t *testing.T) {
 	} {
 		if got := sanitizeOrchestratorFileID(in); got != want {
 			t.Fatalf("sanitizeOrchestratorFileID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestBuildOrchestratorMCPConfigReportsEverySkip is the regression test for
+// #1185. The builder skipped an environment whose MCP port did not resolve and
+// dropped the fact on the floor, so a PARTIAL skip was silent on every channel:
+// no notification, no log line, and nothing the session itself could see. An
+// orchestrator is told by its own contract to know which environments are its
+// own, and an absent tool reads as "not linked" rather than "failed to wire" --
+// so it cannot detect this from the inside.
+//
+// The pre-existing test above asserted the skip happened and said nothing about
+// it being reported, which is exactly why nothing caught this.
+func TestBuildOrchestratorMCPConfigReportsEverySkip(t *testing.T) {
+	config, skipped := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort)
+
+	if len(config.MCPServers) != 2 {
+		t.Fatalf("wired %d servers, want 2", len(config.MCPServers))
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("reported %d skips, want 2 (the unresolved port and the blank entry): %+v", len(skipped), skipped)
+	}
+
+	byLabel := map[string]string{}
+	for _, skip := range skipped {
+		byLabel[skip.Label] = skip.Reason
+	}
+	reason, ok := byLabel["noport/x"]
+	if !ok {
+		t.Fatalf("no skip reported for the environment that resolved no port: %+v", skipped)
+	}
+	if !strings.Contains(reason, "MCP port") {
+		t.Errorf("skip reason %q does not name the cause", reason)
+	}
+	// The fixture's malformed entry names an environment but no tenant, so it
+	// labels as "?/z" -- the placeholder marks which half is missing rather than
+	// hiding the entry entirely.
+	if reason, ok := byLabel["?/z"]; !ok {
+		t.Errorf("a malformed linked entry must still be reported, not silently dropped: %+v", skipped)
+	} else if !strings.Contains(reason, "no tenant or environment") {
+		t.Errorf("skip reason %q does not name the cause", reason)
+	}
+}
+
+// TestOrchestratorMCPPartialNoticeNamesWhatIsMissing: the notice is the only
+// thing that tells an operator a usable-looking session is missing an
+// environment, so it has to name which one and why -- "some tools are missing"
+// is not actionable.
+func TestOrchestratorMCPPartialNoticeNamesWhatIsMissing(t *testing.T) {
+	notice := orchestratorMCPPartialNotice("erun-issues", 1, []orchestratorMCPSkip{
+		{Label: "petios/rihards-review", Reason: "it resolved no MCP port"},
+	})
+
+	for _, want := range []string{"erun-issues", "1 of 2", "petios/rihards-review", "resolved no MCP port", "restart"} {
+		if !strings.Contains(notice, want) {
+			t.Errorf("notice does not mention %q:\n%s", want, notice)
+		}
+	}
+}
+
+// TestWriteOrchestratorMCPConfigCarriesSkipsEvenWhenNothingWired: the total
+// failure already had a signal (errOrchestratorMCPNoPort), but it could not say
+// WHICH environments failed or why. Returning the skips alongside the error
+// means the unwired notice can name them too, not just the partial one.
+//
+// Deterministic on purpose: a test app's store resolves no ports, so every
+// environment is skipped. Asserting the partial case at this level would depend
+// on ambient store state and be flaky, which is worse than not testing it here
+// -- the builder tests above cover the partial split with an injected resolver.
+func TestWriteOrchestratorMCPConfigCarriesSkipsEvenWhenNothingWired(t *testing.T) {
+	app := orchestratorTestApp(t)
+	defer app.shutdown(context.Background())
+
+	path, skipped, err := app.writeOrchestratorMCPConfig("nothing-wirable", []eruncommon.OrchestratorEnvConfig{
+		{Tenant: "ghost", Environment: "one"},
+		{Tenant: "ghost", Environment: "two"},
+	})
+	if !errors.Is(err, errOrchestratorMCPNoPort) {
+		t.Fatalf("err = %v, want errOrchestratorMCPNoPort", err)
+	}
+	if strings.TrimSpace(path) != "" {
+		t.Errorf("path = %q, want empty when nothing wired", path)
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("reported %d skips, want 2 so the notice can name them: %+v", len(skipped), skipped)
+	}
+	for _, skip := range skipped {
+		if !strings.HasPrefix(skip.Label, "ghost/") {
+			t.Errorf("skip label %q does not name the environment", skip.Label)
+		}
+		if strings.TrimSpace(skip.Reason) == "" {
+			t.Errorf("skip for %s carries no reason", skip.Label)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1185.

`buildOrchestratorMCPConfig` skipped an environment whose MCP port did not resolve and **discarded the fact**. `writeOrchestratorMCPConfig` returned an error only when the server map ended up *empty*, and `spawnOrchestratorSession` warned only on that error — so a **partial** skip was silent on every channel: no notification, no log line, nothing the session itself could see.

**That is worse than the total failure it did report.** A session with none of its tools fails on the first environment call. A session missing *one* environment's tools works perfectly until something reaches for the environment that isn't there — and an agent reads an absent tool as "not linked" rather than "failed to wire", so it cannot detect this from the inside. The operating contract tells an orchestrator to *know which environments are its own*, which is precisely what a silent partial skip makes untrue.

Observed on this host: orchestrator `erun-issues` links `erun/ux` **and** `petios/rihards-review`, and its session had the full `mcp__erun-ux__*` set and no petios tools at all, with nothing said.

## Fix

- **Every skip is carried out of the builder with its reason**, labelled `<tenant>/<environment>` — and labelled readably when the linked entry itself is malformed, so a blank half shows as `?/z` rather than vanishing.
- **`writeOrchestratorMCPConfig` returns the skips alongside the path** — and alongside the *error* on the total-failure path too, so the unwired notice can name which environments failed rather than only that none resolved.
- **A distinct partial notice** names the count and each missing environment with its cause. "Some tools are missing" isn't actionable; `started with tools for 1 of 2 linked environments. Missing: petios/rihards-review (it resolved no MCP port)` is.
- The wiring and reporting moved into `wireOrchestratorMCP`, keeping `spawnOrchestratorSession` inside the module's complexity budget rather than suppressing the lint.

## Why nothing caught this

The pre-existing `TestBuildOrchestratorMCPConfig` asserted that `noport-x` **was** skipped and said nothing about it being reported — it encoded the silent skip as accepted behaviour. Same shape as the tests corrected in #1169 and #1167.

## Verification

`gofmt`, `go build`, `go vet`, the full `erun-ui` suite (14.8s), and `golangci-lint run` — **0 issues**.

Three new tests, confirmed to fail against the old behaviour:

```
--- FAIL: TestBuildOrchestratorMCPConfigReportsEverySkip
    reported 0 skips, want 2 (the unresolved port and the blank entry): []
--- FAIL: TestWriteOrchestratorMCPConfigCarriesSkipsEvenWhenNothingWired
    reported 0 skips, want 2 so the notice can name them: []
```

One of them was rewritten before landing. The first version asserted the partial case through `writeOrchestratorMCPConfig`, which depends on whether the ambient store resolves a port — flaky, which this repo's AGENTS.md treats as failing. It now asserts the deterministic direction (nothing wirable still carries its skips), and the partial split is covered at the builder where the port resolver is injected.

## End-to-end gate

This changes a desktop surface, so the gate is a rebuild and restart — which the orchestrate skill describes as a normal step that records where to return and resumes the conversation, not a session loss. Running it next: return note first, build from a copy outside every review directory, keep the previous bundle beside the new one, arm a detached relauncher, then confirm on resume that a partial skip actually produces the notification. `frs/local` currently resolves no MCP port, so the condition reproduces without contriving one.