### PR TITLE
Give each orchestrator its own CLAUDE.md, layered on the shared contract

### DIFF
--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -303,6 +303,27 @@ func (a *App) ensureOrchestratorWorkspace() (string, error) {
 	return dir, nil
 }
 
+// ensureOrchestratorWorkspaceFor is ensureOrchestratorWorkspace plus this
+// orchestrator's own role file. Separate from it rather than an extra parameter
+// on it: the workspace itself is id-independent, and the shared root is ensured
+// from a dozen places that have no id to give.
+//
+// Seeding here rather than at creation means an orchestrator that already
+// existed gets a role file on its next launch too, not only newly created ones.
+func (a *App) ensureOrchestratorWorkspaceFor(id string) (string, error) {
+	dir, err := a.ensureOrchestratorWorkspace()
+	if err != nil {
+		return "", err
+	}
+	// Best-effort, like the skills install and the SessionStart hook: a role
+	// file that could not be seeded must not stop the orchestrator launching,
+	// but it is reported rather than passed over in silence.
+	if roleErr := ensureOrchestratorRoleFile(dir, id); roleErr != nil {
+		fmt.Fprintf(os.Stderr, "erun: could not seed orchestrator role file for %s: %v\n", id, roleErr)
+	}
+	return dir, nil
+}
+
 // buildSkillsSource is the erun-skills/skills directory of the checkout this
 // binary was built from, stamped in by the desktop build scripts. It is what
 // lets a desktop that runs from outside its checkout still install the skills
@@ -554,7 +575,67 @@ const orchestratorContractFallback = "You are a host-side erun orchestrator. Rea
 // fallback if the file is ever missing.
 func orchestratorSkillHookCommand(dir string) string {
 	claudeMd := filepath.ToSlash(filepath.Join(dir, "CLAUDE.md"))
-	return `cat "` + claudeMd + `" 2>/dev/null || echo '` + orchestratorContractFallback + `'`
+	// The per-orchestrator layer, injected AFTER the shared contract so the
+	// ordering is the precedence rule: a role file can add to the common
+	// contract or override a line of it, and a reader can see which won (#1175).
+	//
+	// $ERUN_ORCHESTRATOR_ID is set at launch and is already proven visible to
+	// SessionStart hook commands on both host OSes -- the activity hook in this
+	// same block interpolates it into a path one line down. A transient
+	// (Investigate) session has an empty id by design, so the guard skips it and
+	// it gets the shared contract only.
+	//
+	// Absent file is a silent no-op: most orchestrators will not have one, and a
+	// missing file must neither fail the hook nor write to stderr. Same quoting
+	// discipline as above -- forward-slashed, double-quoted path, and no file
+	// body ever passes through the shell -- so sh and Git Bash both work.
+	roleMd := filepath.ToSlash(filepath.Join(dir, "CLAUDE.$ERUN_ORCHESTRATOR_ID.md"))
+	return `cat "` + claudeMd + `" 2>/dev/null || echo '` + orchestratorContractFallback + `'` + "\n" +
+		`[ -n "$ERUN_ORCHESTRATOR_ID" ] && cat "` + roleMd + `" 2>/dev/null || true`
+}
+
+// orchestratorRoleFileSeed is written once into CLAUDE.<id>.md and never
+// rewritten. Deliberately the inverse of the shared CLAUDE.md, which erun
+// overwrites on every launch: one layer is erun's and always current, the other
+// is the operator's and always preserved. That asymmetry is the feature.
+const orchestratorRoleFileSeed = `<!--
+This file is yours. erun creates it once and never overwrites it, unlike the
+shared CLAUDE.md in this directory, which erun rewrites on every launch.
+
+It is injected on every session start and resume, immediately AFTER the shared
+contract -- so anything here can add to that contract or override a line of it.
+
+Put this orchestrator's standing role here: what it owns, what it must not do,
+how it should report. A role is standing, so it belongs here rather than in
+RESUME-NOTE.<id>.md, which is a task hand-off that is read once and superseded.
+
+Do NOT list this orchestrator's environments here. The shared contract requires
+knowing scope from erun's config and never from disk; a list baked in here would
+contradict it and go stale the next time the orchestrator's links change.
+-->
+`
+
+// ensureOrchestratorRoleFile creates the per-orchestrator role file if it is
+// absent and leaves it strictly alone otherwise. Called on every launch rather
+// than only at creation, so an orchestrator that already existed gets one too.
+// An empty id (a transient session) seeds nothing.
+//
+// The id is slugified to [a-z0-9-] by orchestratorIDStem, so for any id erun
+// mints the filename is safe by construction; it is still resolved with an exact
+// filepath.Join and never a glob, so a hand-edited config.yaml id cannot widen
+// what gets read.
+func ensureOrchestratorRoleFile(dir, id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil
+	}
+	path := filepath.Join(dir, "CLAUDE."+id+".md")
+	if _, err := os.Stat(path); err == nil {
+		return nil // the operator's file; never rewritten
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	return os.WriteFile(path, []byte(orchestratorRoleFileSeed), 0o644)
 }
 
 // ensureOrchestratorSessionStartHook writes a SessionStart hook into the shared
@@ -1330,7 +1411,7 @@ func (a *App) spawnOrchestratorSession(spawn orchestratorSpawn) (orchestratorInf
 	}
 	// Every orchestrator launches in the shared $HOME/orchestrators root, which
 	// carries the one CLAUDE.md and the `<tenant>-<env>` mirror subdirectories.
-	dir, err := a.ensureOrchestratorWorkspace()
+	dir, err := a.ensureOrchestratorWorkspaceFor(id)
 	if err != nil {
 		return orchestratorInfo{}, err
 	}

--- a/erun-ui/orchestrator_role_file_test.go
+++ b/erun-ui/orchestrator_role_file_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestOrchestratorRoleFileIsSeededOnceAndNeverRewritten is the whole contract of
+// #1175, and it is the inverse of the shared CLAUDE.md's. erun overwrites the
+// shared file on every launch, which is why an edit there is silently discarded;
+// the role file must survive every launch instead, or it is the same dead end.
+func TestOrchestratorRoleFileIsSeededOnceAndNeverRewritten(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := ensureOrchestratorRoleFile(dir, "erun"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	path := filepath.Join(dir, "CLAUDE.erun.md")
+	seeded, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("role file was not created: %v", err)
+	}
+	if len(seeded) == 0 {
+		t.Fatal("role file seeded empty")
+	}
+
+	// What the operator writes must survive every subsequent launch.
+	operator := []byte("# my standing role\nOnly ever open issues; never write code.\n")
+	if err := os.WriteFile(path, operator, 0o644); err != nil {
+		t.Fatalf("simulate an operator edit: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := ensureOrchestratorRoleFile(dir, "erun"); err != nil {
+			t.Fatalf("re-seed pass %d: %v", i, err)
+		}
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after re-seeding: %v", err)
+	}
+	if string(after) != string(operator) {
+		t.Fatalf("the operator's role file was rewritten by a later launch:\n%s", after)
+	}
+}
+
+// TestOrchestratorRoleFileSeedDoesNotBakeInScope: the shared contract requires
+// knowing scope from erun's config and never from disk, so a seed that invited an
+// environment list would contradict it and go stale the moment the orchestrator's
+// links changed.
+func TestOrchestratorRoleFileSeedDoesNotBakeInScope(t *testing.T) {
+	if !strings.Contains(orchestratorRoleFileSeed, "Do NOT list this orchestrator's environments") {
+		t.Error("the seed must tell the operator not to bake an environment list into it")
+	}
+	if !strings.Contains(orchestratorRoleFileSeed, "never overwrites it") {
+		t.Error("the seed must say erun will not overwrite the file, or the operator cannot trust it")
+	}
+}
+
+// TestOrchestratorRoleFileSkipsATransientSession: a transient (Investigate)
+// session has an empty id by design and gets the shared contract only. Seeding
+// "CLAUDE..md" for it would litter the shared root.
+func TestOrchestratorRoleFileSkipsATransientSession(t *testing.T) {
+	dir := t.TempDir()
+	for _, id := range []string{"", "   "} {
+		if err := ensureOrchestratorRoleFile(dir, id); err != nil {
+			t.Fatalf("empty id must be a no-op, got %v", err)
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("an empty id seeded %v; it must seed nothing", names)
+	}
+}
+
+// TestOrchestratorSkillHookInjectsTheRoleFileAfterTheSharedContract: the
+// ordering IS the precedence rule, so it is worth asserting rather than assuming.
+// The guard matters too -- without it a transient session's empty id would make
+// the hook cat a path ending in "CLAUDE..md".
+func TestOrchestratorSkillHookInjectsTheRoleFileAfterTheSharedContract(t *testing.T) {
+	command := orchestratorSkillHookCommand("/tmp/orchestrators")
+
+	shared := strings.Index(command, "CLAUDE.md")
+	role := strings.Index(command, "CLAUDE.$ERUN_ORCHESTRATOR_ID.md")
+	if shared < 0 {
+		t.Fatalf("hook does not read the shared contract:\n%s", command)
+	}
+	if role < 0 {
+		t.Fatalf("hook does not read the per-orchestrator role file:\n%s", command)
+	}
+	if role < shared {
+		t.Errorf("the role file is read BEFORE the shared contract, inverting precedence:\n%s", command)
+	}
+	if !strings.Contains(command, `[ -n "$ERUN_ORCHESTRATOR_ID" ]`) {
+		t.Errorf("no guard on the id, so a transient session would cat CLAUDE..md:\n%s", command)
+	}
+	// A missing role file is the common case and must not fail the hook or write
+	// to stderr.
+	if !strings.Contains(command, "|| true") {
+		t.Errorf("a missing role file must be a silent no-op:\n%s", command)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1175.

There was exactly one `CLAUDE.md` for every orchestrator, and erun **rewrites it on every launch** — so an edit meant to give one orchestrator a standing role was silently discarded on the next start, and until then it applied to every *other* orchestrator too. The one durable per-orchestrator channel, `RESUME-NOTE.<id>.md`, is the wrong shape: a task hand-off read once and superseded, where a role is standing.

Orchestrators aren't interchangeable in practice — one is a planning agent whose only output is an issue and which must not write code, one owns a tenant's devops, one drives releases. Conversation was the only channel for saying so, restated by the operator after every restart.

## The mechanism was already there

The contract isn't auto-loaded; it's injected by a SessionStart hook that `cat`s the file to stdout. And the **sibling hook in that same block already guards on `$ERUN_ORCHESTRATOR_ID` and interpolates it into a path** — so the id is proven visible to hook commands on both host OSes, and this layer is a second `cat` in a hook that already does the trick one line down.

- Reads `CLAUDE.$ERUN_ORCHESTRATOR_ID.md` **after** the shared contract, so **the ordering is the precedence rule**: a role file can add to the contract or override a line of it, and a reader can see which won.
- Guarded on a non-empty id, so a transient Investigate session gets the shared contract only rather than `cat`ting a path ending `CLAUDE..md`.
- Absent file is a silent no-op — the common case must not fail the hook or write to stderr.
- **Seeded once and never rewritten** — the exact inverse of the shared file's unconditional overwrite. That asymmetry is the feature: one layer is erun's and always current, the other is the operator's and always preserved.
- Seeded on **every launch** rather than at creation, so an orchestrator that already existed gets one too.
- The seed tells the operator the file is theirs, that it's injected after the shared contract, and **not** to list environments in it — the shared contract requires knowing scope from config and never from disk, so a baked-in list would contradict it and go stale on the next link change.

Naming is `CLAUDE.<id>.md`, beside `RESUME-NOTE.<id>.md` — the same `<thing>.<id>.md` shape the contract's existing rule already covers. Ids are slugified to `[a-z0-9-]`, so the filename is safe by construction; still resolved with an exact `filepath.Join` and never a glob, so a hand-edited `config.yaml` id cannot widen what gets read.

## One structural choice

Seeding lives in `ensureOrchestratorWorkspaceFor` rather than as a parameter on `ensureOrchestratorWorkspace`. The workspace is id-independent and is ensured from ~20 places with no id to give, so threading one through would have churned every one of those call sites for no benefit. It also keeps `spawnOrchestratorSession` inside the module's complexity budget instead of suppressing the lint.

## Verification

`gofmt`, `go build`, `go vet`, the full `erun-ui` suite (14.8s), and `golangci-lint run` — **0 issues**.

Four new tests. The central one is confirmed to fail against an unconditional write:

```
--- FAIL: TestOrchestratorRoleFileIsSeededOnceAndNeverRewritten
    the operator's role file was rewritten by a later launch
```

The others pin the parts that are easy to get wrong silently: the hook's **ordering** (role after shared, since that ordering *is* precedence), the id guard, the `|| true` no-op, that an empty id seeds nothing at all, and that the seed text warns against baking in scope.

## End-to-end gate

Batched with #1185 and #1178 into one rebuild-and-restart rather than three — the orchestrate skill describes restart-and-resume as a normal step that records where to return, so the cost is one session boundary, not three.