### PR TITLE
Keep only the diff panel in an orchestrator's titlebar, and make it cross-env

### DIFF
--- a/erun-ui/frontend/src/app/activeSessionOrchestrator.test.ts
+++ b/erun-ui/frontend/src/app/activeSessionOrchestrator.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { selectActiveSessionOrchestrator, selectIsOrchestratorSession } from './selectors';
+import type { OrchestratorInfo } from './slices/orchestratorsSlice';
+import type { RootState } from './store';
+
+function orchestrator(id: string, sessionId: number): OrchestratorInfo {
+  return {
+    id,
+    name: id,
+    environments: [{ tenant: 'erun', environment: 'ux', directory: '/tmp/erun-ux' }],
+    tenants: ['erun'],
+    directories: ['/tmp/erun-ux'],
+    sessionId,
+    status: sessionId > 0 ? 'running' : 'stopped',
+    busy: false,
+    transient: false,
+    shellRunning: false,
+    shellCommand: '',
+    shellStartedAtUnix: 0,
+  };
+}
+
+// Only the two slices the selector reads; the rest of RootState is irrelevant to
+// it and constructing it would make the test about the store's shape instead.
+function stateWith(activeSessionId: number, items: OrchestratorInfo[]): RootState {
+  return {
+    terminal: { sessionId: activeSessionId },
+    orchestrators: { items },
+  } as unknown as RootState;
+}
+
+// The defect this selector exists to fix: the titlebar keyed its env-scoped
+// controls off state.selection.selected -- the SIDEBAR's environment selection,
+// which is independent of which terminal tab is active. So with an orchestrator
+// tab focused, "Open in VS Code" acted on an environment the orchestrator may
+// not even be linked to. The active SESSION is the thing that decides whether
+// env-scoped chrome applies, and that is what this reads.
+test('the active session being an orchestrator is decided by the session, not the sidebar', () => {
+  const state = stateWith(42, [orchestrator('erun-issues', 42), orchestrator('other', 7)]);
+
+  const active = selectActiveSessionOrchestrator(state);
+  assert.equal(active?.id, 'erun-issues');
+  assert.equal(selectIsOrchestratorSession(state), true);
+});
+
+test('an environment tab is not orchestrator mode', () => {
+  // A session id that belongs to no orchestrator: an ordinary env tab.
+  const state = stateWith(99, [orchestrator('erun-issues', 42)]);
+
+  assert.equal(selectActiveSessionOrchestrator(state), null);
+  assert.equal(selectIsOrchestratorSession(state), false);
+});
+
+// A stopped orchestrator carries sessionId 0. Without the guard, an inactive
+// terminal (also 0) would match it and the titlebar would drop its env controls
+// while no orchestrator was running at all.
+test('no active session is not orchestrator mode, even with a stopped orchestrator present', () => {
+  const state = stateWith(0, [orchestrator('stopped-one', 0)]);
+
+  assert.equal(selectActiveSessionOrchestrator(state), null);
+  assert.equal(selectIsOrchestratorSession(state), false);
+});
+
+// The selector returns the orchestrator, not a boolean, because a cross-env
+// surface needs its environment list -- the diff panel has to fetch one diff per
+// linked environment.
+test('the active orchestrator carries the environments a cross-env surface needs', () => {
+  const active = selectActiveSessionOrchestrator(stateWith(42, [orchestrator('erun-issues', 42)]));
+
+  assert.ok(active, 'expected the active session to resolve an orchestrator');
+  assert.equal(active.environments.length, 1);
+  const [env] = active.environments;
+  // assert.ok narrows: the tsconfig has noUncheckedIndexedAccess, so a
+  // destructured element is possibly-undefined, while eslint's type-aware rule
+  // reads an optional chain here as redundant. Asserting satisfies both.
+  assert.ok(env, 'expected one linked environment');
+  assert.equal(env.tenant, 'erun');
+  assert.equal(env.environment, 'ux');
+});

--- a/erun-ui/frontend/src/app/reviewThunks.ts
+++ b/erun-ui/frontend/src/app/reviewThunks.ts
@@ -1,4 +1,4 @@
-import type { DiffResult } from '@/types';
+import type { DiffResult, UISelection } from '@/types';
 
 import { reviewApi } from './api/reviewApi';
 import { sessionApi } from './api/sessionApi';
@@ -7,18 +7,22 @@ import { readError } from './errors';
 import { showNotification } from './notificationThunks';
 import { isMcpUnreachableMessage, stripMcpUnreachableMarker } from './reconnectCopy';
 import { scrollSelectedDiffIntoView } from './reviewDiffNavigation';
+import { selectReviewEnvTargets } from './selectors';
 import { setChangedFilesOpen } from './slices/layoutSlice';
 import { bumpReviewDiff } from './slices/requestCountersSlice';
-import type { ReviewState } from './slices/reviewSlice';
+import type { ReviewScope } from './slices/reviewSlice';
 import {
-  setDiff,
-  setDiffError,
+  diffPathKey,
+  emptyEnvDiffState,
+  pruneEnvDiffs,
   setDiffFilter as setDiffFilterAction,
-  setDiffLoading,
+  setEnvDiff,
+  setEnvDiffError,
+  setEnvDiffLoading,
+  setEnvReviewCommit,
+  setEnvReviewScope,
   setReconnect,
   setSelectedDiffPath,
-  setSelectedReviewCommit,
-  setSelectedReviewScope,
   toggleDiffDirCollapsed,
 } from './slices/reviewSlice';
 import type { AppThunk } from './store';
@@ -53,52 +57,109 @@ export const selectDiffPath =
     }, 0);
   };
 
+// selectReviewRange is per-environment: each linked env has its own commit
+// list, so a scope or commit chosen in one section means nothing in another.
 export const selectReviewRange =
-  (scope: ReviewState['selectedReviewScope'], hash = ''): AppThunk =>
+  (envKey: string, scope: ReviewScope, hash = ''): AppThunk =>
   (dispatch, getState) => {
-    const review = getState().review;
+    const slot = getState().review.diffByEnv[envKey] ?? emptyEnvDiffState;
     const selected = hash.trim();
-    if (
-      (scope === review.selectedReviewScope && selected === review.selectedReviewCommit) ||
-      review.diffLoading
-    ) {
+    if ((scope === slot.scope && selected === slot.commit) || slot.loading) {
       return;
     }
-    dispatch(setSelectedReviewScope(scope));
-    dispatch(setSelectedReviewCommit(selected));
+    dispatch(setEnvReviewScope({ envKey, scope }));
+    dispatch(setEnvReviewCommit({ envKey, commit: selected }));
     void dispatch(loadReviewDiff());
   };
 
 function applyReviewDiffSuccess(
   dispatch: Parameters<AppThunk>[0],
   getState: () => ReturnType<typeof import('./store').store.getState>,
+  envKey: string,
   diff: DiffResult,
 ): void {
-  dispatch(setDiff(diff));
-  dispatch(setDiffError({ error: '', reconnectable: false }));
-  dispatch(setSelectedReviewScope(diff.scope ?? 'current'));
-  dispatch(setSelectedReviewCommit(diff.selectedCommit ?? ''));
-  dispatch(setSelectedDiffPath(chooseSelectedDiffPath(diff, getState().review.selectedDiffPath)));
+  dispatch(setEnvDiff({ envKey, diff }));
+  dispatch(setEnvDiffError({ envKey, error: '', reconnectable: false }));
+  dispatch(setEnvReviewScope({ envKey, scope: diff.scope ?? 'current' }));
+  dispatch(setEnvReviewCommit({ envKey, commit: diff.selectedCommit ?? '' }));
+  const chosen = chooseSelectedDiffPath(diff, getState().review.selectedDiffPath);
+  if (chosen) {
+    dispatch(setSelectedDiffPath(diffPathKey(envKey, chosen)));
+  }
 }
 
+// applyReviewDiffFailure writes only THIS environment's slot. The single-slot
+// version cleared the one shared diff, so one stopped environment blanked every
+// other linked env's diff -- and an orchestrator's environments are rarely all
+// running at once, so that was the everyday case (#1178).
 function applyReviewDiffFailure(
   dispatch: Parameters<AppThunk>[0],
   getState: () => ReturnType<typeof import('./store').store.getState>,
+  envKey: string,
   error: unknown,
   silent: boolean,
 ): void {
-  const currentDiff = getState().review.diff;
+  const currentDiff = getState().review.diffByEnv[envKey]?.diff ?? null;
   if (silent && currentDiff) {
     return;
   }
   if (!silent || !currentDiff) {
-    dispatch(setDiff(null));
+    dispatch(setEnvDiff({ envKey, diff: null }));
   }
   const message = readError(error);
   if (isMcpUnreachableMessage(message)) {
-    dispatch(setDiffError({ error: stripMcpUnreachableMarker(message), reconnectable: true }));
+    dispatch(
+      setEnvDiffError({ envKey, error: stripMcpUnreachableMarker(message), reconnectable: true }),
+    );
   } else {
-    dispatch(setDiffError({ error: message, reconnectable: false }));
+    dispatch(setEnvDiffError({ envKey, error: message, reconnectable: false }));
+  }
+}
+
+// reviewEnvTargets is selectReviewEnvTargets shaped for the fetch: the same
+// resolution, plus the UISelection each LoadDiff call needs.
+function reviewEnvTargets(
+  state: ReturnType<typeof import('./store').store.getState>,
+): { envKey: string; selection: UISelection }[] {
+  return selectReviewEnvTargets(state).map((target) => ({
+    envKey: target.envKey,
+    selection: { tenant: target.tenant, environment: target.environment },
+  }));
+}
+
+// loadOneReviewDiff fetches and applies one environment's diff. Every failure is
+// contained here, so allSettled below cannot let one environment's error stop
+// another's fetch from being applied.
+async function loadOneReviewDiff(
+  dispatch: Parameters<AppThunk>[0],
+  getState: () => ReturnType<typeof import('./store').store.getState>,
+  target: { envKey: string; selection: UISelection },
+  options: { silent?: boolean },
+): Promise<void> {
+  const { envKey, selection } = target;
+  const slot = getState().review.diffByEnv[envKey] ?? emptyEnvDiffState;
+  const contributeTarget = getState().contribute.diffSourceByEnv[envKey] ?? 'env';
+  if (!options.silent) {
+    dispatch(setEnvDiffLoading({ envKey, loading: true }));
+    dispatch(setEnvDiffError({ envKey, error: '', reconnectable: slot.errorReconnectable }));
+  }
+  try {
+    const diff = await dispatch(
+      reviewApi.endpoints.getDiff.initiate(
+        {
+          selection,
+          options: { scope: slot.scope, selectedCommit: slot.commit, target: contributeTarget },
+        },
+        { forceRefetch: true },
+      ),
+    ).unwrap();
+    applyReviewDiffSuccess(dispatch, getState, envKey, diff);
+  } catch (error: unknown) {
+    applyReviewDiffFailure(dispatch, getState, envKey, error, Boolean(options.silent));
+  } finally {
+    if (!options.silent) {
+      dispatch(setEnvDiffLoading({ envKey, loading: false }));
+    }
   }
 }
 
@@ -106,56 +167,39 @@ export const loadReviewDiff =
   (options: { silent?: boolean } = {}): AppThunk<Promise<void>> =>
   async (dispatch, getState, extra) => {
     const controller = requireController(extra);
-    const state = getState();
-    const selection = state.selection.selected;
-    if (!selection) {
+    const targets = reviewEnvTargets(getState());
+    if (targets.length === 0) {
       return;
     }
+    // Drop sections for environments no longer in scope, so switching from a
+    // two-env orchestrator to a single env tab does not leave stale ones.
+    dispatch(pruneEnvDiffs(targets.map((target) => target.envKey)));
     dispatch(bumpReviewDiff());
     const request = getState().requestCounters.reviewDiff;
-    const selectedKey = selectionKey(selection);
-    const scope = state.review.selectedReviewScope;
-    const selectedCommit = state.review.selectedReviewCommit;
-    const contributeKey = `${selection.tenant}/${selection.environment}`;
-    const target = state.contribute.diffSourceByEnv[contributeKey] ?? 'env';
-    if (!options.silent) {
-      dispatch(setDiffLoading(true));
-      dispatch(
-        setDiffError({ error: '', reconnectable: getState().review.diffErrorReconnectable }),
-      );
+    const scopeKey = targets.map((target) => target.envKey).join(',');
+
+    // One fetch per environment, each over that env's own MCP. allSettled, not
+    // all: a stopped environment must not cancel the others, and every failure
+    // is already contained inside loadOneReviewDiff.
+    await Promise.allSettled(
+      targets.map((target) => loadOneReviewDiff(dispatch, getState, target, options)),
+    );
+
+    if (!isCurrentReviewDiffRequest(getState, request, scopeKey)) {
+      return;
     }
-    try {
-      const diff = await dispatch(
-        reviewApi.endpoints.getDiff.initiate(
-          { selection, options: { scope, selectedCommit, target } },
-          { forceRefetch: true },
-        ),
-      ).unwrap();
-      if (!isCurrentReviewDiffRequest(getState, request, selectedKey)) {
-        return;
-      }
-      applyReviewDiffSuccess(dispatch, getState, diff);
-    } catch (error: unknown) {
-      if (!isCurrentReviewDiffRequest(getState, request, selectedKey)) {
-        return;
-      }
-      applyReviewDiffFailure(dispatch, getState, error, Boolean(options.silent));
-    } finally {
-      if (request === getState().requestCounters.reviewDiff) {
-        if (!options.silent) {
-          dispatch(setDiffLoading(false));
-        }
-        scheduleReviewDiffRefresh(dispatch, getState, controller);
-      }
-    }
+    scheduleReviewDiffRefresh(dispatch, getState, controller);
   };
 
 export const refreshReviewDiff = (): AppThunk<Promise<void>> => async (dispatch, getState) => {
-  if (!getState().selection.selected) {
+  if (reviewEnvTargets(getState()).length === 0) {
     return;
   }
   await dispatch(loadReviewDiff());
-  if (!getState().review.diffError) {
+  const anyError = Object.values(getState().review.diffByEnv).some(
+    (slot) => (slot?.error ?? '') !== '',
+  );
+  if (!anyError) {
     dispatch(showNotification('success', 'Diff refreshed.'));
   }
 };
@@ -185,11 +229,17 @@ function scheduleReviewDiffRefresh(
   }
   controller.scheduleReviewDiffRefreshTimer(() => {
     const next = getState();
-    if (!next.layout.reviewOpen || !next.selection.selected) {
+    // An orchestrator session has linked environments but no sidebar selection
+    // of its own, so the timer arms off the resolved env set rather than
+    // state.selection.selected -- which would have stopped the refresh outright
+    // for exactly the cross-env case (#1178).
+    if (!next.layout.reviewOpen || reviewEnvTargets(next).length === 0) {
       controller.stopReviewDiffRefresh();
       return;
     }
-    if (next.review.diffLoading) {
+    // Skip a tick while any section is still fetching, so a slow environment
+    // does not get a second in-flight request stacked on the first.
+    if (Object.values(next.review.diffByEnv).some((slot) => slot?.loading)) {
       scheduleReviewDiffRefresh(dispatch, getState, controller);
       return;
     }

--- a/erun-ui/frontend/src/app/selectors.ts
+++ b/erun-ui/frontend/src/app/selectors.ts
@@ -1,5 +1,6 @@
 import type { UISelection } from '@/types';
 
+import type { OrchestratorInfo } from './slices/orchestratorsSlice';
 import type { RootState } from './store';
 import { findVersionSuggestion, normalizeDialogValue, selectionKey } from './versionSuggestions';
 
@@ -105,4 +106,62 @@ export const selectDialogKubernetesContext = (state: RootState, contexts: string
     return current;
   }
   return '';
+};
+
+// selectActiveSessionOrchestrator returns the orchestrator whose terminal
+// session is currently active, or null when the active session is an
+// environment tab.
+//
+// This derivation used to live inline in TerminalTabStrip, which was the only
+// component that had it. The titlebar never got it, so its right-hand cluster
+// went on acting on state.selection.selected -- the SIDEBAR's environment
+// selection, which is independent of which terminal tab is active. With an
+// orchestrator tab focused, "Open in VS Code" opened an IDE against an
+// environment the orchestrator may not even be linked to (#1178).
+//
+// It returns the orchestrator rather than a boolean because a cross-env surface
+// needs its `environments` list, not just the knowledge that one is active.
+export const selectActiveSessionOrchestrator = (state: RootState): OrchestratorInfo | null => {
+  const activeId = state.terminal.sessionId;
+  if (activeId <= 0) {
+    return null;
+  }
+  return state.orchestrators.items.find((item) => item.sessionId === activeId) ?? null;
+};
+
+// selectIsOrchestratorSession is the boolean form, for a caller that only needs
+// to know whether env-scoped chrome applies.
+export const selectIsOrchestratorSession = (state: RootState): boolean =>
+  selectActiveSessionOrchestrator(state) !== null;
+
+export interface ReviewEnvTarget {
+  envKey: string;
+  tenant: string;
+  environment: string;
+}
+
+// selectReviewEnvTargets resolves which environments the diff panel shows: an
+// orchestrator session's linked environments in its configured order, else the
+// single selected environment. A single environment is the one-entry case, so
+// the panel has one code path rather than two (#1178).
+export const selectReviewEnvTargets = (state: RootState): ReviewEnvTarget[] => {
+  const orchestrator = selectActiveSessionOrchestrator(state);
+  if (orchestrator) {
+    return orchestrator.environments.map((env) => ({
+      envKey: `${env.tenant}/${env.environment}`,
+      tenant: env.tenant,
+      environment: env.environment,
+    }));
+  }
+  const selection = state.selection.selected;
+  if (!selection) {
+    return [];
+  }
+  return [
+    {
+      envKey: `${selection.tenant}/${selection.environment}`,
+      tenant: selection.tenant,
+      environment: selection.environment,
+    },
+  ];
 };

--- a/erun-ui/frontend/src/app/sessionThunks.ts
+++ b/erun-ui/frontend/src/app/sessionThunks.ts
@@ -19,11 +19,7 @@ import { selectActiveSlotForSelection, selectEnvironmentExists } from './selecto
 import { isNewSessionSelection } from './sessionSelection';
 import { setAutoStartPrompt } from './slices/autoStartPromptSlice';
 import { setIdleStatus } from './slices/idleSlice';
-import {
-  setSelectedDiffPath,
-  setSelectedReviewCommit,
-  setSelectedReviewScope,
-} from './slices/reviewSlice';
+import { setEnvReviewCommit, setEnvReviewScope, setSelectedDiffPath } from './slices/reviewSlice';
 import { setSelected } from './slices/selectionSlice';
 import {
   clearEnvOpening,
@@ -197,8 +193,12 @@ const prepareOpenSelection =
     const previousKey = state.selection.selected ? selectionKey(state.selection.selected) : '';
     const newKey = selectionKey(selection);
     if (newKey !== previousKey) {
-      dispatch(setSelectedReviewScope('current'));
-      dispatch(setSelectedReviewCommit(''));
+      // Reset the range for the environment being opened. Scope and commit are
+      // per-env now, so resetting them globally would clear an unrelated
+      // section's selection (#1178).
+      const envKey = `${selection.tenant}/${selection.environment}`;
+      dispatch(setEnvReviewScope({ envKey, scope: 'current' }));
+      dispatch(setEnvReviewCommit({ envKey, commit: '' }));
       dispatch(setSelectedDiffPath(''));
     }
     // setSelected is observed by selectionSyncMiddleware, which reconciles

--- a/erun-ui/frontend/src/app/slices/reviewSlice.ts
+++ b/erun-ui/frontend/src/app/slices/reviewSlice.ts
@@ -4,45 +4,102 @@ import type { DiffResult } from '@/types';
 
 import { RECONNECT_LINE_BUFFER_LIMIT, type ReconnectState } from '../state';
 
-export interface ReviewState {
+export type ReviewScope = 'current' | 'commit' | 'all';
+
+// EnvDiffState is one environment's diff and everything scoped to it. An
+// orchestrator session is cross-env, so the panel holds one of these per linked
+// environment rather than one globally (#1178).
+//
+// Each carries its OWN error, which is the load-bearing part. The single-slot
+// shape cleared the one diff on any failure, so one stopped environment blanked
+// the diffs of every other linked env -- and an orchestrator's environments are
+// rarely all running at once, so that was the everyday state, not an edge case.
+//
+// scope and commit are per-env too: ReviewBase, ReviewCommits, Scope and
+// SelectedCommit are per-repository, so a commit list means nothing shared
+// across two unrelated checkouts.
+export interface EnvDiffState {
   diff: DiffResult | null;
-  diffLoading: boolean;
-  diffError: string;
-  diffErrorReconnectable: boolean;
+  loading: boolean;
+  error: string;
+  errorReconnectable: boolean;
+  scope: ReviewScope;
+  commit: string;
+}
+
+export const emptyEnvDiffState: EnvDiffState = {
+  diff: null,
+  loading: false,
+  error: '',
+  errorReconnectable: false,
+  scope: 'current',
+  commit: '',
+};
+
+export interface ReviewState {
+  // Keyed "<tenant>/<environment>". A single-environment tab is simply the
+  // one-entry case, so there is one code path rather than two.
+  //
+  // Explicitly sparse: a plain Record<string, EnvDiffState> would type a missing
+  // key as present, so every necessary undefined check would read as redundant
+  // while still being required at runtime.
+  diffByEnv: Record<string, EnvDiffState | undefined>;
   reconnect: ReconnectState;
+  // Keyed "<envKey>:<path>". Paths collide across environments -- two linked
+  // envs can both have AGENTS.md -- and this and collapsedDiffDirs are both
+  // path-keyed, so an unkeyed value silently aliases one env's file onto
+  // another's.
   selectedDiffPath: string;
-  selectedReviewScope: 'current' | 'commit' | 'all';
-  selectedReviewCommit: string;
+  // A substring match, not an identity, so it stays global across sections.
   diffFilter: string;
   collapsedDiffDirs: string[];
 }
 
 const initialState: ReviewState = {
-  diff: null,
-  diffLoading: false,
-  diffError: '',
-  diffErrorReconnectable: false,
+  diffByEnv: {},
   reconnect: { status: 'idle', tenant: '', environment: '', lines: [], error: '' },
   selectedDiffPath: '',
-  selectedReviewScope: 'current',
-  selectedReviewCommit: '',
   diffFilter: '',
   collapsedDiffDirs: [],
 };
+
+// envSlot returns the mutable slot for an environment, creating it on first
+// write so a caller never has to check.
+function envSlot(state: ReviewState, envKey: string): EnvDiffState {
+  const existing = state.diffByEnv[envKey];
+  if (existing) {
+    return existing;
+  }
+  const created = { ...emptyEnvDiffState };
+  state.diffByEnv[envKey] = created;
+  return created;
+}
 
 export const reviewSlice = createSlice({
   name: 'review',
   initialState,
   reducers: {
-    setDiff(state, action: PayloadAction<DiffResult | null>) {
-      state.diff = action.payload;
+    setEnvDiff(state, action: PayloadAction<{ envKey: string; diff: DiffResult | null }>) {
+      envSlot(state, action.payload.envKey).diff = action.payload.diff;
     },
-    setDiffLoading(state, action: PayloadAction<boolean>) {
-      state.diffLoading = action.payload;
+    setEnvDiffLoading(state, action: PayloadAction<{ envKey: string; loading: boolean }>) {
+      envSlot(state, action.payload.envKey).loading = action.payload.loading;
     },
-    setDiffError(state, action: PayloadAction<{ error: string; reconnectable: boolean }>) {
-      state.diffError = action.payload.error;
-      state.diffErrorReconnectable = action.payload.reconnectable;
+    setEnvDiffError(
+      state,
+      action: PayloadAction<{ envKey: string; error: string; reconnectable: boolean }>,
+    ) {
+      const slot = envSlot(state, action.payload.envKey);
+      slot.error = action.payload.error;
+      slot.errorReconnectable = action.payload.reconnectable;
+    },
+    // Drop the environments no longer in scope, so switching from a two-env
+    // orchestrator to a single env tab does not leave stale sections rendering.
+    pruneEnvDiffs(state, action: PayloadAction<string[]>) {
+      const keep = new Set(action.payload);
+      state.diffByEnv = Object.fromEntries(
+        Object.entries(state.diffByEnv).filter(([key]) => keep.has(key)),
+      );
     },
     setReconnect(state, action: PayloadAction<ReconnectState>) {
       state.reconnect = action.payload;
@@ -56,11 +113,11 @@ export const reviewSlice = createSlice({
     setSelectedDiffPath(state, action: PayloadAction<string>) {
       state.selectedDiffPath = action.payload;
     },
-    setSelectedReviewScope(state, action: PayloadAction<ReviewState['selectedReviewScope']>) {
-      state.selectedReviewScope = action.payload;
+    setEnvReviewScope(state, action: PayloadAction<{ envKey: string; scope: ReviewScope }>) {
+      envSlot(state, action.payload.envKey).scope = action.payload.scope;
     },
-    setSelectedReviewCommit(state, action: PayloadAction<string>) {
-      state.selectedReviewCommit = action.payload;
+    setEnvReviewCommit(state, action: PayloadAction<{ envKey: string; commit: string }>) {
+      envSlot(state, action.payload.envKey).commit = action.payload.commit;
     },
     setDiffFilter(state, action: PayloadAction<string>) {
       state.diffFilter = action.payload;
@@ -83,17 +140,26 @@ export const reviewSlice = createSlice({
 });
 
 export const {
-  setDiff,
-  setDiffLoading,
-  setDiffError,
+  setEnvDiff,
+  setEnvDiffLoading,
+  setEnvDiffError,
+  pruneEnvDiffs,
   setReconnect,
   appendReconnectLine,
   setSelectedDiffPath,
-  setSelectedReviewScope,
-  setSelectedReviewCommit,
+  setEnvReviewScope,
+  setEnvReviewCommit,
   setDiffFilter,
   toggleDiffDirCollapsed,
   clearDiffDirsCollapsed,
   setAll: setReviewAll,
 } = reviewSlice.actions;
+
+// diffPathKey namespaces a file path by its environment. Two linked
+// environments can both have AGENTS.md, and selectedDiffPath / collapsedDiffDirs
+// are both path-keyed, so an unkeyed path silently aliases one env's file onto
+// another's (#1178).
+export function diffPathKey(envKey: string, path: string): string {
+  return envKey + ':' + path;
+}
 export default reviewSlice.reducer;

--- a/erun-ui/frontend/src/app/useEnvDiffSlot.ts
+++ b/erun-ui/frontend/src/app/useEnvDiffSlot.ts
@@ -1,0 +1,11 @@
+import { useAppSelector } from './hooks';
+import { emptyEnvDiffState, type EnvDiffState } from './slices/reviewSlice';
+
+// useEnvDiffSlot returns one environment's diff state, substituting the empty
+// slot when the environment has not been fetched yet. diffByEnv is deliberately
+// sparse, so without this every consumer repeats the same fallbacks -- which is
+// both noise and, in ReviewRangeControl, enough branching to blow the module's
+// complexity budget (#1178).
+export function useEnvDiffSlot(envKey: string): EnvDiffState {
+  return useAppSelector((state) => state.review.diffByEnv[envKey] ?? emptyEnvDiffState);
+}

--- a/erun-ui/frontend/src/components/app/DiffList.tsx
+++ b/erun-ui/frontend/src/components/app/DiffList.tsx
@@ -5,57 +5,110 @@ import { compactDiffError, diffLineMark, visibleDiffFilePaths } from '@/app/diff
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { reconnectCopy } from '@/app/reconnectCopy';
 import { loadReviewDiff, requestReconnect } from '@/app/reviewThunks';
+import { type ReviewEnvTarget, selectReviewEnvTargets } from '@/app/selectors';
+import { diffPathKey } from '@/app/slices/reviewSlice';
+import { useEnvDiffSlot } from '@/app/useEnvDiffSlot';
 import { copyToClipboard } from '@/components/app/ActivityQueueDrawer.helpers';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import type { DiffFile, DiffHunk } from '@/types';
 
 export function DiffList(): React.ReactElement {
-  const dispatch = useAppDispatch();
-  const review = useAppSelector((state) => state.review);
-  if (review.diffLoading) {
-    return <ReviewStatus>Loading diff...</ReviewStatus>;
+  const targets = useAppSelector(selectReviewEnvTargets);
+  if (targets.length === 0) {
+    return <ReviewStatus>No environment selected</ReviewStatus>;
   }
-  if (review.diffError) {
-    return (
-      <DiffErrorAlert
-        message={compactDiffError(review.diffError)}
-        loading={review.diffLoading}
-        reconnectable={review.diffErrorReconnectable}
-        onRetry={() => {
-          void dispatch(loadReviewDiff());
-        }}
-        onReconnect={() => {
-          dispatch(requestReconnect());
-        }}
-      />
-    );
-  }
-  const allFiles = review.diff?.files ?? [];
-  if (allFiles.length === 0) {
-    return <ReviewStatus>No changes</ReviewStatus>;
-  }
-  // Keep the diff panel's files and their order matching the changed-files
-  // tree's visible subset; diff.files is already ordered to match the tree.
-  const visiblePaths = visibleDiffFilePaths(
-    review.diff?.tree ?? [],
-    review.diffFilter,
-    new Set(review.collapsedDiffDirs),
-  );
-  const files = allFiles.filter((file) => visiblePaths.has(file.path));
-  if (files.length === 0) {
-    return <ReviewStatus>No matching files</ReviewStatus>;
-  }
+  // One section per environment, in the orchestrator's configured order. A
+  // single environment renders exactly as before -- no header, no chrome -- so
+  // the env-tab case is visually unchanged (#1178).
+  const multi = targets.length > 1;
   return (
     <>
-      {files.map((file) => (
-        <DiffFileView
-          key={file.path}
-          file={file}
-          selected={file.path === review.selectedDiffPath}
-        />
+      {targets.map((target) => (
+        <DiffEnvSection key={target.envKey} target={target} showHeader={multi} />
       ))}
-      <span className="sr-only">{review.selectedDiffPath}</span>
+    </>
+  );
+}
+
+// DiffEnvSection renders one environment's diff, owning its own loading, error
+// and empty states. That containment is the load-bearing part: the single-slot
+// panel cleared one shared diff on any failure, so one stopped environment
+// blanked every other linked env's diff -- and an orchestrator's environments
+// are rarely all running at once, so that was the everyday state (#1178).
+function DiffEnvSection({
+  target,
+  showHeader,
+}: {
+  target: ReviewEnvTarget;
+  showHeader: boolean;
+}): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const slot = useEnvDiffSlot(target.envKey);
+  const diffFilter = useAppSelector((state) => state.review.diffFilter);
+  const collapsedDiffDirs = useAppSelector((state) => state.review.collapsedDiffDirs);
+  const selectedDiffPath = useAppSelector((state) => state.review.selectedDiffPath);
+
+  const header = showHeader ? (
+    <div className="sticky top-0 z-10 border-b border-border bg-background px-3 py-1 text-xs font-medium text-muted-foreground">
+      {target.envKey}
+    </div>
+  ) : null;
+
+  const body = ((): React.ReactElement => {
+    if (slot.loading) {
+      return <ReviewStatus>Loading diff...</ReviewStatus>;
+    }
+    if (slot.error) {
+      return (
+        <DiffErrorAlert
+          message={compactDiffError(slot.error)}
+          loading={slot.loading}
+          reconnectable={slot.errorReconnectable}
+          onRetry={() => {
+            void dispatch(loadReviewDiff());
+          }}
+          onReconnect={() => {
+            dispatch(requestReconnect());
+          }}
+        />
+      );
+    }
+    const allFiles = slot.diff?.files ?? [];
+    if (allFiles.length === 0) {
+      return <ReviewStatus>No changes</ReviewStatus>;
+    }
+    // Keep the diff panel's files and their order matching the changed-files
+    // tree's visible subset; diff.files is already ordered to match the tree.
+    // Collapsed dirs are env-keyed, so one env's collapsed directory cannot
+    // hide a same-named directory in another.
+    const collapsedForEnv = new Set(
+      collapsedDiffDirs
+        .filter((entry) => entry.startsWith(`${target.envKey}:`))
+        .map((entry) => entry.slice(target.envKey.length + 1)),
+    );
+    const visiblePaths = visibleDiffFilePaths(slot.diff?.tree ?? [], diffFilter, collapsedForEnv);
+    const files = allFiles.filter((file) => visiblePaths.has(file.path));
+    if (files.length === 0) {
+      return <ReviewStatus>No matching files</ReviewStatus>;
+    }
+    return (
+      <>
+        {files.map((file) => (
+          <DiffFileView
+            key={file.path}
+            file={file}
+            selected={diffPathKey(target.envKey, file.path) === selectedDiffPath}
+          />
+        ))}
+      </>
+    );
+  })();
+
+  return (
+    <>
+      {header}
+      {body}
     </>
   );
 }

--- a/erun-ui/frontend/src/components/app/ReviewPanel.ChangedFiles.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewPanel.ChangedFiles.tsx
@@ -1,0 +1,163 @@
+import { ChevronRight } from 'lucide-react';
+import * as React from 'react';
+
+import { compactDiffError, filterDiffTree, visibleDiffTreeNodes } from '@/app/diffUtils';
+import { useAppDispatch, useAppSelector } from '@/app/hooks';
+import {
+  loadReviewDiff,
+  requestReconnect,
+  selectDiffPath,
+  toggleDiffDirectory,
+} from '@/app/reviewThunks';
+import { selectReviewEnvTargets } from '@/app/selectors';
+import { diffPathKey } from '@/app/slices/reviewSlice';
+import { useEnvDiffSlot } from '@/app/useEnvDiffSlot';
+import { DiffErrorAlert, ReviewStatus } from '@/components/app/DiffList';
+import { FileIcon } from '@/components/app/FileIcon';
+import { cn } from '@/lib/utils';
+import type { DiffTreeNode } from '@/types';
+
+export function ChangedFileTree(): React.ReactElement {
+  const targets = useAppSelector(selectReviewEnvTargets);
+  if (targets.length === 0) {
+    return <ReviewStatus>No environment selected</ReviewStatus>;
+  }
+  const multi = targets.length > 1;
+  return (
+    <>
+      {targets.map((target) => (
+        <ChangedFileTreeSection key={target.envKey} envKey={target.envKey} showHeader={multi} />
+      ))}
+    </>
+  );
+}
+
+// ChangedFileTreeSection owns one environment's tree, loading state and error.
+// A stopped environment renders its error in its own section while every other
+// environment keeps rendering -- the single-slot version cleared the one shared
+// diff, so one unreachable env blanked them all (#1178).
+function ChangedFileTreeSection({
+  envKey,
+  showHeader,
+}: {
+  envKey: string;
+  showHeader: boolean;
+}): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const slot = useEnvDiffSlot(envKey);
+  const diffFilter = useAppSelector((state) => state.review.diffFilter);
+  const collapsedDiffDirs = useAppSelector((state) => state.review.collapsedDiffDirs);
+
+  const header = showHeader ? (
+    <div className="px-1 pt-2 pb-1 text-[11px] font-medium text-muted-foreground">{envKey}</div>
+  ) : null;
+
+  const body = ((): React.ReactElement => {
+    if (slot.loading) {
+      return <ReviewStatus>Loading...</ReviewStatus>;
+    }
+    if (slot.error) {
+      return (
+        <DiffErrorAlert
+          message={compactDiffError(slot.error)}
+          loading={slot.loading}
+          reconnectable={slot.errorReconnectable}
+          onRetry={() => {
+            void dispatch(loadReviewDiff());
+          }}
+          onReconnect={() => {
+            dispatch(requestReconnect());
+          }}
+        />
+      );
+    }
+    // Collapsed directories are env-keyed, so a collapsed "app/" in one
+    // environment cannot hide a same-named directory in another.
+    const collapsedForEnv = new Set(
+      collapsedDiffDirs
+        .filter((entry) => entry.startsWith(`${envKey}:`))
+        .map((entry) => entry.slice(envKey.length + 1)),
+    );
+    const tree = visibleDiffTreeNodes(
+      filterDiffTree(slot.diff?.tree ?? [], diffFilter),
+      collapsedForEnv,
+    );
+    if (tree.length === 0) {
+      return <ReviewStatus>{slot.diff ? 'No matching files' : 'No changes'}</ReviewStatus>;
+    }
+    return (
+      <>
+        {tree.map((node) => (
+          <ChangedFileNode key={node.path} envKey={envKey} node={node} />
+        ))}
+      </>
+    );
+  })();
+
+  return (
+    <>
+      {header}
+      {body}
+    </>
+  );
+}
+
+function ChangedFileNode({
+  envKey,
+  node,
+}: {
+  envKey: string;
+  node: DiffTreeNode;
+}): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const collapsedDiffDirs = useAppSelector((state) => state.review.collapsedDiffDirs);
+  const selectedDiffPath = useAppSelector((state) => state.review.selectedDiffPath);
+  const nodeKey = diffPathKey(envKey, node.path);
+  const style = { '--depth': String(node.depth) } as React.CSSProperties;
+
+  if (node.type === 'directory') {
+    const collapsed = collapsedDiffDirs.includes(nodeKey);
+    return (
+      <div className="flex flex-col">
+        <button
+          type="button"
+          className="flex h-[34px] w-full cursor-pointer items-center gap-2 rounded-[var(--radius)] border-0 bg-transparent py-0 pr-2.5 pl-[calc(8px+(var(--depth)*18px))] text-left text-sm leading-[1.2] font-medium text-foreground hover:bg-accent"
+          style={style}
+          aria-expanded={!collapsed}
+          aria-label={`${node.name} directory`}
+          onClick={() => {
+            dispatch(toggleDiffDirectory(nodeKey));
+          }}
+        >
+          <ChevronRight
+            className={cn('size-4 flex-none text-current', !collapsed && 'rotate-90')}
+            aria-hidden="true"
+          />
+          <span className="min-w-0 truncate">{node.name}</span>
+        </button>
+      </div>
+    );
+  }
+
+  const selected = node.path === selectedDiffPath;
+  return (
+    <div className="flex flex-col">
+      <button
+        type="button"
+        className={cn(
+          'flex h-[34px] w-full cursor-pointer items-center gap-2 rounded-[var(--radius)] border-0 bg-transparent py-0 pr-2.5 pl-[calc(8px+(var(--depth)*18px))] text-left text-sm leading-[1.2] text-foreground hover:bg-accent',
+          selected && 'bg-primary text-primary-foreground hover:bg-primary',
+        )}
+        style={style}
+        data-path={node.path}
+        aria-current={selected ? 'true' : undefined}
+        onClick={() => {
+          dispatch(selectDiffPath(nodeKey));
+        }}
+      >
+        <FileIcon filePath={node.path} />
+        <span className="min-w-0 truncate">{node.name}</span>
+      </button>
+    </div>
+  );
+}

--- a/erun-ui/frontend/src/components/app/ReviewPanel.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewPanel.tsx
@@ -1,6 +1,5 @@
 import {
   ChevronDown,
-  ChevronRight,
   FileDiff,
   GitBranch,
   GitCommitHorizontal,
@@ -10,31 +9,29 @@ import {
 import * as React from 'react';
 
 import { switchDiffSource } from '@/app/contributeThunks';
-import { compactDiffError, filterDiffTree, visibleDiffTreeNodes } from '@/app/diffUtils';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { startFilesResize } from '@/app/layoutThunks';
 import {
   loadReviewDiff,
   refreshReviewDiff,
-  requestReconnect,
-  selectDiffPath,
   selectReviewRange,
   setDiffFilter,
   toggleChangedFiles,
-  toggleDiffDirectory,
 } from '@/app/reviewThunks';
+import { selectReviewEnvTargets } from '@/app/selectors';
 import { contributeEnvKey, type DiffSource } from '@/app/slices/contributeSlice';
 import { useController } from '@/app/useController';
+import { useEnvDiffSlot } from '@/app/useEnvDiffSlot';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
-import type { DiffCommit, DiffTreeNode } from '@/types';
+import type { DiffCommit } from '@/types';
 
-import { DiffErrorAlert, DiffList, ReviewStatus } from './DiffList';
-import { FileIcon } from './FileIcon';
+import { DiffList } from './DiffList';
 import { IconTooltip } from './IconTooltip';
 import { ResizeHandle } from './ResizeHandle';
+import { ChangedFileTree } from './ReviewPanel.ChangedFiles';
 
 const filesSplitterClassName =
   'relative cursor-col-resize border-l bg-background before:absolute before:top-0 before:bottom-0 before:left-1 before:w-px before:bg-transparent before:transition-colors hover:before:bg-border [.is-resizing-files_&]:before:bg-border';
@@ -129,7 +126,7 @@ function ChangedFilesAside({ visible }: { visible: boolean }): React.ReactElemen
     >
       <ChangedFilesHeader />
       <DiffSourceControl />
-      <ReviewRangeControl />
+      <ReviewRangeControls />
       {changedFilesOpen ? (
         <>
           <Label className="box-border flex h-[38px] items-center gap-2 rounded-[var(--radius)] border border-input bg-background px-3 text-muted-foreground [&_svg]:size-[18px] [&_svg]:flex-none">
@@ -249,11 +246,13 @@ function ReviewBoundaryTrack({
   selectedReviewScope,
   diffLoading,
   dispatch,
+  envKey,
 }: {
   commits: DiffCommit[];
   selectedReviewScope: 'current' | 'commit' | 'all';
   diffLoading: boolean;
   dispatch: ReturnType<typeof useAppDispatch>;
+  envKey: string;
 }): React.ReactElement {
   return (
     <div className="relative flex min-h-0 flex-col gap-1 before:absolute before:top-4 before:bottom-4 before:left-[15px] before:w-px before:bg-border">
@@ -263,13 +262,13 @@ function ReviewBoundaryTrack({
         selected={selectedReviewScope === 'current'}
         disabled={diffLoading}
         onClick={() => {
-          dispatch(selectReviewRange('current'));
+          dispatch(selectReviewRange(envKey, 'current'));
         }}
       />
       {commits.length > 0 ? (
         <div className="flex max-h-[220px] min-h-0 flex-col gap-1 overflow-auto pr-1">
           {commits.map((commit) => (
-            <ReviewCommitButton key={commit.hash} commit={commit} />
+            <ReviewCommitButton key={commit.hash} envKey={envKey} commit={commit} />
           ))}
         </div>
       ) : null}
@@ -279,18 +278,21 @@ function ReviewBoundaryTrack({
         selected={selectedReviewScope === 'all'}
         disabled={diffLoading}
         onClick={() => {
-          dispatch(selectReviewRange('all'));
+          dispatch(selectReviewRange(envKey, 'all'));
         }}
       />
     </div>
   );
 }
 
-function ReviewRangeControl(): React.ReactElement | null {
+// ReviewRangeControl is per-environment: ReviewBase, ReviewCommits, Scope and
+// SelectedCommit are all per-repository, so a commit list or a base commit
+// shared across two unrelated checkouts would be a value that means nothing
+// (#1178).
+function ReviewRangeControl({ envKey }: { envKey: string }): React.ReactElement | null {
   const dispatch = useAppDispatch();
-  const diff = useAppSelector((state) => state.review.diff);
-  const selectedReviewScope = useAppSelector((state) => state.review.selectedReviewScope);
-  const diffLoading = useAppSelector((state) => state.review.diffLoading);
+  const slot = useEnvDiffSlot(envKey);
+  const diff = slot.diff;
   const commits = [...(diff?.reviewCommits ?? [])].reverse();
   const base = diff?.reviewBase;
   if (!base?.commit && commits.length === 0) {
@@ -307,20 +309,28 @@ function ReviewRangeControl(): React.ReactElement | null {
       </div>
       <ReviewMergeTargetRow base={base} />
       <ReviewBoundaryTrack
+        envKey={envKey}
         commits={commits}
-        selectedReviewScope={selectedReviewScope}
-        diffLoading={diffLoading}
+        selectedReviewScope={slot.scope}
+        diffLoading={slot.loading}
         dispatch={dispatch}
       />
     </div>
   );
 }
 
-function ReviewCommitButton({ commit }: { commit: DiffCommit }): React.ReactElement {
+function ReviewCommitButton({
+  envKey,
+  commit,
+}: {
+  envKey: string;
+  commit: DiffCommit;
+}): React.ReactElement {
   const dispatch = useAppDispatch();
-  const selectedReviewScope = useAppSelector((state) => state.review.selectedReviewScope);
-  const selectedReviewCommit = useAppSelector((state) => state.review.selectedReviewCommit);
-  const diffLoading = useAppSelector((state) => state.review.diffLoading);
+  const slot = useEnvDiffSlot(envKey);
+  const selectedReviewScope = slot.scope;
+  const selectedReviewCommit = slot.commit;
+  const diffLoading = slot.loading;
   return (
     <ReviewBoundaryButton
       label={commit.subject || commit.shortHash}
@@ -328,7 +338,7 @@ function ReviewCommitButton({ commit }: { commit: DiffCommit }): React.ReactElem
       selected={selectedReviewScope === 'commit' && selectedReviewCommit === commit.hash}
       disabled={diffLoading}
       onClick={() => {
-        dispatch(selectReviewRange('commit', commit.hash));
+        dispatch(selectReviewRange(envKey, 'commit', commit.hash));
       }}
     />
   );
@@ -372,11 +382,33 @@ function ReviewBoundaryButton({
   );
 }
 
+// ChangedFilesHeader is the panel's single header, so its counts are the total
+// across every environment shown. Summed rather than taken from one env: with a
+// cross-env session the header describes the whole panel (#1178).
+// ReviewRangeControls renders one range control per environment shown, since
+// each has its own commit list.
+function ReviewRangeControls(): React.ReactElement {
+  const targets = useAppSelector(selectReviewEnvTargets);
+  return (
+    <>
+      {targets.map((target) => (
+        <ReviewRangeControl key={target.envKey} envKey={target.envKey} />
+      ))}
+    </>
+  );
+}
+
 function ChangedFilesHeader(): React.ReactElement {
   const dispatch = useAppDispatch();
   const changedFilesOpen = useAppSelector((state) => state.layout.changedFilesOpen);
-  const diff = useAppSelector((state) => state.review.diff);
-  const diffLoading = useAppSelector((state) => state.review.diffLoading);
+  const diffByEnv = useAppSelector((state) => state.review.diffByEnv);
+  const slots = Object.values(diffByEnv).filter((slot) => slot !== undefined);
+  const diffLoading = slots.some((slot) => slot.loading);
+  const summary = {
+    fileCount: slots.reduce((sum, slot) => sum + (slot.diff?.summary.fileCount ?? 0), 0),
+    additions: slots.reduce((sum, slot) => sum + (slot.diff?.summary.additions ?? 0), 0),
+    deletions: slots.reduce((sum, slot) => sum + (slot.diff?.summary.deletions ?? 0), 0),
+  };
   return (
     <div className="mb-3.5 flex min-w-0 items-center justify-between gap-3">
       <button
@@ -388,8 +420,7 @@ function ChangedFilesHeader(): React.ReactElement {
         }}
       >
         <FileDiff aria-hidden="true" />
-        Changed files{' '}
-        <span className="flex-none text-muted-foreground">{diff?.summary.fileCount ?? 0}</span>
+        Changed files <span className="flex-none text-muted-foreground">{summary.fileCount}</span>
         <ChevronDown
           className={cn('transition-transform', !changedFilesOpen && '-rotate-90')}
           aria-hidden="true"
@@ -412,102 +443,10 @@ function ChangedFilesHeader(): React.ReactElement {
           </Button>
         </IconTooltip>
         <div className="flex gap-1.5 text-sm font-semibold whitespace-nowrap">
-          <span className="text-diff-add-foreground">+{diff?.summary.additions ?? 0}</span>
-          <span className="text-diff-delete-foreground">-{diff?.summary.deletions ?? 0}</span>
+          <span className="text-diff-add-foreground">+{summary.additions}</span>
+          <span className="text-diff-delete-foreground">-{summary.deletions}</span>
         </div>
       </div>
-    </div>
-  );
-}
-
-function ChangedFileTree(): React.ReactElement {
-  const dispatch = useAppDispatch();
-  const review = useAppSelector((state) => state.review);
-  if (review.diffLoading) {
-    return <ReviewStatus>Loading...</ReviewStatus>;
-  }
-  if (review.diffError) {
-    return (
-      <DiffErrorAlert
-        message={compactDiffError(review.diffError)}
-        loading={review.diffLoading}
-        reconnectable={review.diffErrorReconnectable}
-        onRetry={() => {
-          void dispatch(loadReviewDiff());
-        }}
-        onReconnect={() => {
-          dispatch(requestReconnect());
-        }}
-      />
-    );
-  }
-
-  const tree = visibleDiffTreeNodes(
-    filterDiffTree(review.diff?.tree ?? [], review.diffFilter),
-    new Set(review.collapsedDiffDirs),
-  );
-  if (tree.length === 0) {
-    return <ReviewStatus>{review.diff ? 'No matching files' : 'No changes'}</ReviewStatus>;
-  }
-
-  return (
-    <>
-      {tree.map((node) => (
-        <ChangedFileNode key={node.path} node={node} />
-      ))}
-    </>
-  );
-}
-
-function ChangedFileNode({ node }: { node: DiffTreeNode }): React.ReactElement {
-  const dispatch = useAppDispatch();
-  const collapsedDiffDirs = useAppSelector((state) => state.review.collapsedDiffDirs);
-  const selectedDiffPath = useAppSelector((state) => state.review.selectedDiffPath);
-  const style = { '--depth': String(node.depth) } as React.CSSProperties;
-
-  if (node.type === 'directory') {
-    const collapsed = collapsedDiffDirs.includes(node.path);
-    return (
-      <div className="flex flex-col">
-        <button
-          type="button"
-          className="flex h-[34px] w-full cursor-pointer items-center gap-2 rounded-[var(--radius)] border-0 bg-transparent py-0 pr-2.5 pl-[calc(8px+(var(--depth)*18px))] text-left text-sm leading-[1.2] font-medium text-foreground hover:bg-accent"
-          style={style}
-          aria-expanded={!collapsed}
-          aria-label={`${node.name} directory`}
-          onClick={() => {
-            dispatch(toggleDiffDirectory(node.path));
-          }}
-        >
-          <ChevronRight
-            className={cn('size-4 flex-none text-current', !collapsed && 'rotate-90')}
-            aria-hidden="true"
-          />
-          <span className="min-w-0 truncate">{node.name}</span>
-        </button>
-      </div>
-    );
-  }
-
-  const selected = node.path === selectedDiffPath;
-  return (
-    <div className="flex flex-col">
-      <button
-        type="button"
-        className={cn(
-          'flex h-[34px] w-full cursor-pointer items-center gap-2 rounded-[var(--radius)] border-0 bg-transparent py-0 pr-2.5 pl-[calc(8px+(var(--depth)*18px))] text-left text-sm leading-[1.2] text-foreground hover:bg-accent',
-          selected && 'bg-primary text-primary-foreground hover:bg-primary',
-        )}
-        style={style}
-        data-path={node.path}
-        aria-current={selected ? 'true' : undefined}
-        onClick={() => {
-          dispatch(selectDiffPath(node.path));
-        }}
-      >
-        <FileIcon filePath={node.path} />
-        <span className="min-w-0 truncate">{node.name}</span>
-      </button>
     </div>
   );
 }

--- a/erun-ui/frontend/src/components/app/TerminalTabStrip.tsx
+++ b/erun-ui/frontend/src/components/app/TerminalTabStrip.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { openOrchestrator, stopOrchestrator } from '@/app/orchestratorThunks';
+import { selectIsOrchestratorSession } from '@/app/selectors';
 import { addTerminalTab, closeTerminalTab, selectTerminalTab } from '@/app/sessionThunks';
 import { selectionKey } from '@/app/versionSuggestions';
 import { IconTooltip } from '@/components/app/IconTooltip';
@@ -72,7 +73,10 @@ export function TerminalTabStrip(): React.ReactElement {
   // orchestrators (they are cross-env, so the selected env's tabs would misalign
   // with what the pane actually renders). Selecting an environment row switches
   // the active session back to an env tab and the strip returns to env mode.
-  const orchestratorMode = activeId > 0 && orchestrators.some((o) => o.sessionId === activeId);
+  //
+  // Shared with the titlebar rather than re-derived: one definition of "the
+  // active session is an orchestrator" (#1178).
+  const orchestratorMode = useAppSelector(selectIsOrchestratorSession);
 
   let tabs: StripTab[];
   let showNewTerminal = false;

--- a/erun-ui/frontend/src/components/app/Titlebar.Controls.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.Controls.tsx
@@ -13,6 +13,7 @@ import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { openIDE } from '@/app/ideOpenThunks';
 import { setFilesOpen, toggleReview, toggleSidebar } from '@/app/layoutThunks';
 import { isMacPlatform } from '@/app/platform';
+import { selectIsOrchestratorSession } from '@/app/selectors';
 import { IconTooltip } from '@/components/app/IconTooltip';
 import { ContributeToggle } from '@/components/app/Titlebar.ContributeToggle';
 import {
@@ -66,18 +67,19 @@ export function TitlebarLeftControls(): React.ReactElement {
   );
 }
 
-// TitlebarRightControls renders the right titlebar cluster of IDE and panel controls.
-export function TitlebarRightControls(): React.ReactElement {
+// TitlebarEnvControls renders the controls that act on the SIDEBAR's selected
+// environment: the two IDE buttons and the contribute toggle.
+//
+// Rendered only when the active session is an environment tab. They are hidden
+// rather than disabled in orchestrator mode, following the tab strip's
+// precedent of swapping content: disabling would leave dead icons whose
+// tooltips describe an environment the operator is not working in (#1178).
+function TitlebarEnvControls(): React.ReactElement {
   const dispatch = useAppDispatch();
-  const reviewOpen = useAppSelector((state) => state.layout.reviewOpen);
-  const filesOpen = useAppSelector((state) => state.layout.filesOpen);
   const selected = useAppSelector((state) => state.selection.selected);
   const tenants = useAppSelector((state) => state.tenants.tenants);
   const idleStatus = useAppSelector((state) => state.idle.idleStatus);
-  const ReviewIcon = reviewOpen ? PanelRightClose : PanelRightOpen;
   const envRunning = isEnvOpenedAndRunning(selected, idleStatus, tenants);
-  // Diff/files toggles stay enabled even while the env is down, so the user
-  // can still hide a stale panel.
   const ideDisabled = isIdeDisabled(selected, tenants) || !envRunning;
   const vscodeTooltip = ideTooltipLabel('VS Code', selected, ideDisabled, !envRunning);
   const intellijTooltip = ideTooltipLabel('IntelliJ IDEA', selected, ideDisabled, !envRunning);
@@ -101,6 +103,30 @@ export function TitlebarRightControls(): React.ReactElement {
         dispatch={dispatch}
       />
       <ContributeToggle envRunning={envRunning} />
+    </>
+  );
+}
+
+// TitlebarRightControls renders the right titlebar cluster. In orchestrator mode
+// it keeps only the diff panel toggle: that is the one control meaningful for a
+// cross-env session, and the three env-scoped ones acted on whichever
+// environment the sidebar happened to have selected — independent of which
+// terminal tab was active, so with an orchestrator focused they targeted an
+// environment it may not even be linked to (#1178).
+//
+// The changed-files sub-toggle stays: it renders only when the diff panel is
+// open and toggles that panel's own file tree, so it is diff-panel chrome
+// rather than a fourth control.
+export function TitlebarRightControls(): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const reviewOpen = useAppSelector((state) => state.layout.reviewOpen);
+  const filesOpen = useAppSelector((state) => state.layout.filesOpen);
+  const orchestratorMode = useAppSelector(selectIsOrchestratorSession);
+  const ReviewIcon = reviewOpen ? PanelRightClose : PanelRightOpen;
+
+  return (
+    <>
+      {!orchestratorMode && <TitlebarEnvControls />}
       <IconTooltip label="Toggle diff panel">
         <Button
           className={cn(titlebarButtonClassName, reviewOpen && activeTitlebarButtonClassName)}


### PR DESCRIPTION
## Summary

Closes #1178.

The titlebar's right-hand cluster keyed off `state.selection.selected` — the **sidebar's** environment selection, which is completely independent of which terminal tab is active. So with an orchestrator tab focused, three of its four controls acted on an environment the orchestrator may not even be linked to, and the enablement logic greyed them out based on *that* env's state.

The terminal tab strip had already solved this one component over. The titlebar never got the treatment; that derivation is now one shared selector used by both.

## Part 1 — titlebar

In orchestrator mode only the diff-panel toggle remains. **Hidden, not disabled**, following the tab strip's precedent of swapping content — disabling would leave three dead icons whose tooltips describe an environment the operator isn't working in. The env-scoped controls moved into their own component, so their env-scoped hooks don't run at all in orchestrator mode.

The changed-files sub-toggle stays: it renders only when the diff panel is open and toggles that panel's own file tree, so it's diff-panel chrome rather than a fourth control. (The issue flagged this as a judgment call; happy to drop it if "only the diff panel" was meant literally — it's one line.)

## Part 2 — the diff panel goes cross-env

`review`'s single `diff`/`diffError`/`diffLoading`/`selectedReviewScope`/`selectedReviewCommit` became **`diffByEnv`**, keyed `"<tenant>/<environment>"`, with one section per environment in the orchestrator's configured order. A single environment is the one-entry case of the same code path and renders exactly as before.

**Deliberately not a single merged `DiffResult`.** `ReviewBase`, `ReviewCommits`, `Scope` and `SelectedCommit` are per-repository, so a base commit or commit list merged across two unrelated checkouts is a value that means nothing — scope and commit selection therefore moved *into* each section. And paths collide: two linked envs can both have `AGENTS.md`, and `selectedDiffPath`/`collapsedDiffDirs` are both path-keyed, so a merged list would silently alias one env's file onto another's. Those keys are now `<envKey>:<path>`. The text filter stays global — it's a substring match, not an identity.

**Per-env failure isolation was the load-bearing requirement.** `applyReviewDiffFailure` cleared the single shared diff, so carried over as-is **one stopped environment would have blanked every other linked env's diff** — and an orchestrator's environments are rarely all running at once, so that's the everyday state, not an edge case. Each section owns its error and renders it in place while the others keep rendering, and the fan-out uses `allSettled` so one unreachable env can't cancel another's fetch.

## Three things the issue didn't name

**The 5s refresh timer stopped on `!state.selection.selected`.** An orchestrator session has linked environments but no sidebar selection of its own, so the refresh would have shut off entirely for exactly the case being added. It arms off the resolved env set now.

**`Record<string, EnvDiffState>` was a real type bug**, not a style choice — it claims every key is present, so every *necessary* undefined check read as redundant to the linter while still being required at runtime. The map is declared sparse, and a shared `useEnvDiffSlot` hook removes the fallbacks from four consumers, which is also what brought `ReviewRangeControl` back under the complexity budget.

**`ReviewPanel.tsx` went over the 500-line cap**, so the changed-files tree moved to its own file rather than suppressing `max-lines`.

## No Go change needed

`LoadDiff` is already per-selection, so the fan-out is N calls from the frontend, one per env over that env's own MCP.

## Verification

0 type errors, eslint clean, prettier clean, the frontend test suite, a production vite build; and on the Go side gofmt, build, the full `erun-ui` suite, and `golangci-lint` at **0 issues**.

Four new tests on the shared selector — including that a stopped orchestrator (`sessionId` 0) does not match an inactive terminal (also 0). Without that guard the titlebar would drop its env controls with no orchestrator running at all.

One tool contradiction worth recording: `noUncheckedIndexedAccess` types a destructured array element as possibly-undefined, while eslint's `no-unnecessary-condition` calls the matching optional chain redundant. Neither is wrong; `assert.ok` narrowing satisfies both.

## End-to-end gate

This is the third of three desktop changes (#1185, #1175, #1178). Gating all three in one rebuild-and-restart next — the orchestrate skill describes restart-and-resume as a normal step that records where to return, so it's one session boundary rather than three.