### PR TITLE
Resume the live conversation after compaction, and don't hide MCP wiring gaps

### DIFF
--- a/erun-ui/app_log.go
+++ b/erun-ui/app_log.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// The desktop is normally launched via `open` (macOS) or the equivalent
+// detached launch on other platforms, which gives it no controlling terminal
+// -- its stderr goes nowhere. Every log.Printf in this module writes only to
+// the default logger's stderr output, so a partial-wiring skip logged that
+// way leaves no trace any later investigation can find. This gives
+// the default logger a second, durable destination: log.SetOutput is the one
+// place that has to change for every existing and future log.Printf call
+// site to survive.
+
+// appLogFileName is the durable log every log.Printf call in this module ends
+// up writing to, beside the other per-install state under UserConfigDir()/ERun.
+const appLogFileName = "erun-app.log"
+
+// appLogMaxBytes bounds the log so a process that runs for weeks cannot grow
+// it without limit. Matches the cap erun-common's per-env trace log uses for
+// the same reason.
+const appLogMaxBytes = 5 * 1024 * 1024
+
+// appLogPath resolves the durable log file's path.
+func appLogPath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, "ERun", appLogFileName), nil
+}
+
+// boundedLogFile is an io.Writer over a size-capped file: once a write would
+// push it past maxBytes, the current file is rotated to a single ".1" backup
+// and a fresh one started, so the log never grows without bound across a
+// desktop process that can run for weeks.
+type boundedLogFile struct {
+	mu       sync.Mutex
+	path     string
+	maxBytes int64
+	file     *os.File
+	written  int64
+}
+
+// newBoundedLogFile opens path for append, creating its directory if needed,
+// and picks up the current size so rotation accounts for bytes a previous
+// process already wrote.
+func newBoundedLogFile(path string, maxBytes int64) (*boundedLogFile, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	written := int64(0)
+	if info, statErr := file.Stat(); statErr == nil {
+		written = info.Size()
+	}
+	return &boundedLogFile{path: path, maxBytes: maxBytes, file: file, written: written}, nil
+}
+
+func (b *boundedLogFile) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.written+int64(len(p)) > b.maxBytes {
+		if err := b.rotate(); err != nil {
+			return 0, err
+		}
+	}
+	n, err := b.file.Write(p)
+	b.written += int64(n)
+	return n, err
+}
+
+// rotate replaces the current file with a fresh one, keeping exactly one
+// backup -- the same one-backup-pair shape erun-common's env trace log uses.
+func (b *boundedLogFile) rotate() error {
+	if err := b.file.Close(); err != nil {
+		return err
+	}
+	backup := b.path + ".1"
+	_ = os.Remove(backup)
+	if err := os.Rename(b.path, backup); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(b.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	b.file = file
+	b.written = 0
+	return nil
+}
+
+func (b *boundedLogFile) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.file.Close()
+}
+
+// initDurableAppLog redirects the default logger so every log.Printf call in
+// this module writes to stderr AND the bounded durable log file. Best-effort:
+// if the file cannot be opened, the app still runs with stderr-only logging
+// rather than failing to start over a diagnostics nicety. The returned func
+// closes the file; call it on shutdown.
+func initDurableAppLog() func() {
+	path, err := appLogPath()
+	if err != nil {
+		log.Printf("erun-app: could not resolve the durable log path: %v", err)
+		return func() {}
+	}
+	file, err := newBoundedLogFile(path, appLogMaxBytes)
+	if err != nil {
+		log.Printf("erun-app: could not open the durable log %s: %v", path, err)
+		return func() {}
+	}
+	log.SetOutput(io.MultiWriter(os.Stderr, file))
+	log.Printf("erun-app: logging to %s", path)
+	return func() { _ = file.Close() }
+}

--- a/erun-ui/app_log_test.go
+++ b/erun-ui/app_log_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAppLogPathIsUnderTheERunSupportDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	path, err := appLogPath()
+	if err != nil {
+		t.Fatalf("appLogPath: %v", err)
+	}
+	if filepath.Base(path) != appLogFileName || filepath.Base(filepath.Dir(path)) != "ERun" {
+		t.Fatalf("expected .../ERun/%s, got %q", appLogFileName, path)
+	}
+}
+
+// The bug: the desktop is launched via `open`, which gives it no
+// controlling terminal, so a log.Printf that only reaches stderr is invisible
+// the moment the process is not run from a shell. initDurableAppLog gives it
+// a second, durable destination every existing log.Printf call already writes
+// to via the default logger.
+func TestInitDurableAppLogCapturesLogPrintfCalls(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	restoreLogOutputAfter(t)
+
+	closeLog := initDurableAppLog()
+	log.Printf("erun-app: a partial-wiring skip that must survive")
+	closeLog()
+
+	path, err := appLogPath()
+	if err != nil {
+		t.Fatalf("appLogPath: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read durable log: %v", err)
+	}
+	if !strings.Contains(string(data), "a partial-wiring skip that must survive") {
+		t.Fatalf("expected the log line in the durable file, got:\n%s", data)
+	}
+}
+
+// restoreLogOutputAfter points the default logger back at its previous output
+// once the test ends, so this test cannot leak its file handle into the rest
+// of the suite (log.SetOutput is process-global state).
+func restoreLogOutputAfter(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+}
+
+func TestBoundedLogFileRotatesPastTheCap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bounded.log")
+
+	file, err := newBoundedLogFile(path, 32)
+	if err != nil {
+		t.Fatalf("newBoundedLogFile: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	first := bytes.Repeat([]byte("a"), 20)
+	if _, err := file.Write(first); err != nil {
+		t.Fatalf("write first: %v", err)
+	}
+	second := bytes.Repeat([]byte("b"), 20)
+	if _, err := file.Write(second); err != nil {
+		t.Fatalf("write second: %v", err)
+	}
+
+	current, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read current: %v", err)
+	}
+	if string(current) != string(second) {
+		t.Fatalf("expected the current file to hold only the write that triggered rotation, got %q", current)
+	}
+	backup, err := os.ReadFile(path + ".1")
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(backup) != string(first) {
+		t.Fatalf("expected the backup to hold what was there before rotation, got %q", backup)
+	}
+}
+
+func TestBoundedLogFilePicksUpExistingSizeOnOpen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bounded.log")
+	if err := os.WriteFile(path, bytes.Repeat([]byte("x"), 25), 0o600); err != nil {
+		t.Fatalf("seed existing file: %v", err)
+	}
+
+	file, err := newBoundedLogFile(path, 32)
+	if err != nil {
+		t.Fatalf("newBoundedLogFile: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	// 25 already on disk + 10 more crosses the 32-byte cap, so this write must
+	// rotate rather than silently growing the file past its bound.
+	if _, err := file.Write(bytes.Repeat([]byte("y"), 10)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Fatalf("expected a rotation given the pre-existing size, stat err: %v", err)
+	}
+}

--- a/erun-ui/app_restart.go
+++ b/erun-ui/app_restart.go
@@ -507,13 +507,20 @@ func (a *App) RestartApp(returnToOrchestratorID string) error {
 // with the scope it is wired to: without those, a restart has nothing it can
 // safely tell to carry on, so the launch reopens the orchestrator idle rather
 // than handing a task to whichever conversation its id happens to resolve to.
+//
+// The conversation id itself is not simply the one the session was spawned
+// with: Claude Code forks the transcript to a new session id when a resumed
+// conversation compacts, so the spawn-time id can name a conversation that has
+// stopped growing. preferLiveOrchestratorSessionID prefers whatever id the
+// orchestrator's own hooks last saw live, validated against disk, over that
+// stale spawn-time id.
 func (a *App) restartHandoff(orchestratorID string) orchestratorRestoreState {
 	state := orchestratorRestoreState{OrchestratorID: strings.TrimSpace(orchestratorID)}
 	conversationID, scope := a.runningOrchestratorConversation(state.OrchestratorID)
 	if conversationID == "" {
 		return state
 	}
-	state.ConversationID = conversationID
+	state.ConversationID = preferLiveOrchestratorSessionID(state.OrchestratorID, conversationID)
 	state.Environments = scope
 	state.ResumePrompt = orchestratorRestartResumePrompt(state.OrchestratorID)
 	return state

--- a/erun-ui/app_restart_test.go
+++ b/erun-ui/app_restart_test.go
@@ -55,6 +55,27 @@ func stageOrchestratorConversation(t *testing.T, conversationID string) {
 	}
 }
 
+// stageOrchestratorLiveSession writes the file an orchestrator's own hooks
+// would have written, recording sessionID as the live conversation — standing
+// in for a hook firing after Claude Code forks the transcript on compaction.
+func stageOrchestratorLiveSession(t *testing.T, orchestratorID, sessionID string) {
+	t.Helper()
+	path := orchestratorLiveSessionPath(orchestratorID)
+	if path == "" {
+		t.Fatalf("no live-session slot for %q", orchestratorID)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create live-session dir: %v", err)
+	}
+	data, err := json.Marshal(orchestratorLiveSession{SessionID: sessionID, AtUnix: time.Now().Unix()})
+	if err != nil {
+		t.Fatalf("encode live session: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write live session: %v", err)
+	}
+}
+
 // readRestoreState reads the hand-off staged in one orchestrator's own slot,
 // asserting the persisted file rather than what the resolver reports about it.
 func readRestoreState(t *testing.T, dir, orchestratorID string) orchestratorRestoreState {
@@ -173,6 +194,54 @@ func TestRestartAppRecordsTheLiveConversationAndResumesIt(t *testing.T) {
 	// shared, so "the note you wrote here" is satisfied by anyone's.
 	assertNamesOwnNote(t, "the resume prompt", id, target.ResumePrompt)
 	assertNoHandOffsLeftStaged(t, restoreDir)
+}
+
+// The bug: Claude Code forks the transcript to a new session id when a
+// resumed conversation compacts, so the id erun spawned the session with names
+// a conversation that has stopped growing by the time a restart is triggered.
+// A restart taken after a compaction must record the live id the
+// orchestrator's own hooks last saw, not the stale spawn-time id.
+func TestRestartHandoffPrefersTheLiveSessionAfterCompaction(t *testing.T) {
+	app, restoreDir := restartTestApp(t)
+	id := createAndStartOrchestrator(t, app)
+	spawnID := orchestratorSessionID(id)
+
+	liveID := "11111111-1111-1111-1111-111111111111"
+	stageOrchestratorLiveSession(t, id, liveID)
+	stageOrchestratorConversation(t, liveID)
+
+	if err := app.RestartApp(id); err != nil {
+		t.Fatalf("RestartApp failed: %v", err)
+	}
+
+	state := readRestoreState(t, restoreDir, id)
+	if state.ConversationID == spawnID {
+		t.Fatalf("expected the post-compaction live session %q to be recorded instead of the stale spawn id %q", liveID, spawnID)
+	}
+	if state.ConversationID != liveID {
+		t.Fatalf("expected the live conversation %q to be recorded, got %+v", liveID, state)
+	}
+}
+
+// A live-session record naming a conversation that never made it to disk
+// cannot be trusted, so the restart falls back to the spawn-time id rather
+// than resuming a session that does not exist.
+func TestRestartHandoffIgnoresALiveRecordWhoseTranscriptIsGone(t *testing.T) {
+	app, restoreDir := restartTestApp(t)
+	id := createAndStartOrchestrator(t, app)
+	spawnID := orchestratorSessionID(id)
+
+	stageOrchestratorLiveSession(t, id, "99999999-9999-9999-9999-999999999999")
+	// Note: no stageOrchestratorConversation for that id -- it never existed.
+
+	if err := app.RestartApp(id); err != nil {
+		t.Fatalf("RestartApp failed: %v", err)
+	}
+
+	state := readRestoreState(t, restoreDir, id)
+	if state.ConversationID != spawnID {
+		t.Fatalf("expected the spawn id to be used when the recorded live session does not exist on disk, got %+v", state)
+	}
 }
 
 // assertNamesOwnNote fails unless text points at the return note belonging to

--- a/erun-ui/main.go
+++ b/erun-ui/main.go
@@ -24,6 +24,7 @@ const defaultHeadlessPort = 34123
 
 func main() {
 	setAppIdentity("ERun")
+	defer initDurableAppLog()()
 
 	headless, port, leftover := parseHeadlessFlags(os.Args[1:])
 	// Strip recognized flags from os.Args before Wails parses them, so the

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -669,10 +669,16 @@ func ensureOrchestratorSessionStartHook(dir string) error {
 	// tool-call events in particular are somewhere they are likely to have hooks
 	// of their own, which an assignment would silently delete.
 	busyHook, idleHook := orchestratorActivityHooks()
+	// The live-session recorder rides the same turn-boundary events as the
+	// busy/idle reports: whichever fires next after a compaction forks the
+	// transcript picks up the new session_id from its own stdin.
+	liveSessionHook := orchestratorLiveSessionHookBlock()
 	for _, event := range []string{"UserPromptSubmit", "PreToolUse", "PostToolUse"} {
 		hooks[event] = mergeOrchestratorHookBlocks(hooks[event], busyHook, isOrchestratorActivityHookBlock)
+		hooks[event] = mergeOrchestratorHookBlocks(hooks[event], liveSessionHook, isOrchestratorLiveSessionHookBlock)
 	}
 	stop := mergeOrchestratorHookBlocks(hooks["Stop"], idleHook, isOrchestratorActivityHookBlock)
+	stop = mergeOrchestratorHookBlocks(stop, liveSessionHook, isOrchestratorLiveSessionHookBlock)
 	hooks["Stop"] = mergeOrchestratorHookBlocks(stop, orchestratorNoAskStopGuardBlock(), isOrchestratorNoAskStopGuardBlock)
 	// A background shell's start and its completion are both only visible in a
 	// tool call's own result, which PreToolUse never carries — so unlike the
@@ -758,8 +764,13 @@ func orchestratorSessionStartHook(dir string) []any {
 	// would inherit the previous run's "working" and spin on arrival with nothing
 	// running. Clearing it here is what makes that guarantee real.
 	idle := map[string]any{"type": "command", "command": orchestratorActivityHookCommand(false)}
+	// An orchestrator id is mutable and reusable, so a live-session record left
+	// over from a previous run under this id must not survive into this one.
+	// Resetting it here to whatever id this launch actually starts with is what
+	// keeps a stale record from outliving the run that wrote it.
+	liveSession := map[string]any{"type": "command", "command": orchestratorSessionRecordHookCommand()}
 	matcher := func(source string) map[string]any {
-		return map[string]any{"matcher": source, "hooks": []any{command, idle}}
+		return map[string]any{"matcher": source, "hooks": []any{command, idle, liveSession}}
 	}
 	return []any{matcher("startup"), matcher("resume")}
 }
@@ -1372,7 +1383,7 @@ type orchestratorSpawn struct {
 // environment that is not there, which an agent reads as "not linked" rather
 // than "failed to wire" (#1185).
 func (a *App) wireOrchestratorMCP(id, name string, envs []eruncommon.OrchestratorEnvConfig) string {
-	path, skipped, err := a.writeOrchestratorMCPConfig(id, envs)
+	path, skipped, unreachable, err := a.writeOrchestratorMCPConfig(id, envs)
 	for _, skip := range skipped {
 		log.Printf("erun-app: orchestrator %s: no MCP tools for %s: %s", id, skip.Label, skip.Reason)
 	}
@@ -1383,6 +1394,14 @@ func (a *App) wireOrchestratorMCP(id, name string, envs []eruncommon.Orchestrato
 	}
 	if len(skipped) > 0 {
 		a.emitAppNotification("warning", orchestratorMCPPartialNotice(name, len(envs)-len(skipped), skipped))
+	}
+	// An unreachable edge is wired anyway: the proxy already recovers a
+	// transient outage per call, so this is reported, never treated as a skip.
+	for _, env := range unreachable {
+		log.Printf("erun-app: orchestrator %s: wired %s but its edge is not answering", id, env.Label)
+	}
+	if len(unreachable) > 0 {
+		a.emitAppNotification("warning", orchestratorMCPUnreachableNotice(name, unreachable))
 	}
 	return path
 }

--- a/erun-ui/orchestrator_live_session.go
+++ b/erun-ui/orchestrator_live_session.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// A restart hand-off names the conversation to resume by id. The id erun
+// SPAWNED the session with is not reliably that conversation: Claude Code
+// forks the transcript to a NEW session id when a resumed conversation
+// compacts, so after any compaction the spawn-time id names a conversation
+// that has stopped growing. The forked transcript carries no structural
+// parent pointer back to the id it forked from, so there is no reading it
+// off disk after the fact — the only reliable source is the live session
+// telling us its own id as it goes, which is exactly what a hook's stdin JSON
+// carries on every invocation.
+//
+// The hooks installed by ensureOrchestratorSessionStartHook keep one file per
+// orchestrator current with that id: reset to the spawn id at SessionStart
+// (startup/resume), then refreshed from every turn-boundary hook afterward, so
+// a fork is reflected the moment the next hook fires. Resetting at
+// SessionStart matters because an orchestrator id is mutable and reusable —
+// without the reset, a leftover record from a previous run under the same id
+// would outlive it.
+
+// orchestratorLiveSessionDirName holds one file per orchestrator recording the
+// session id its own hooks last saw live.
+const orchestratorLiveSessionDirName = "orchestrator-session"
+
+// orchestratorLiveSession is what one orchestrator's file carries.
+type orchestratorLiveSession struct {
+	SessionID string `json:"sessionId"`
+	AtUnix    int64  `json:"atUnix,omitempty"`
+}
+
+// orchestratorLiveSessionDir is the directory the hooks write into and the
+// desktop reads from, beside the other per-orchestrator state under
+// UserConfigDir()/ERun.
+func orchestratorLiveSessionDir() string {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		configDir = os.TempDir()
+	}
+	return filepath.Join(configDir, "ERun", orchestratorLiveSessionDirName)
+}
+
+// orchestratorLiveSessionPath is one orchestrator's own file.
+func orchestratorLiveSessionPath(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ""
+	}
+	return filepath.Join(orchestratorLiveSessionDir(), id+".json")
+}
+
+// readOrchestratorLiveSessionID reads the session id an orchestrator's own
+// hooks last recorded as live. Unreadable, unparseable, or blank all answer
+// false: the caller falls back to the id it already trusts rather than acting
+// on a record that cannot be trusted.
+func readOrchestratorLiveSessionID(id string) (string, bool) {
+	path := orchestratorLiveSessionPath(id)
+	if path == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	var record orchestratorLiveSession
+	if err := json.Unmarshal(data, &record); err != nil {
+		return "", false
+	}
+	record.SessionID = strings.TrimSpace(record.SessionID)
+	if record.SessionID == "" {
+		return "", false
+	}
+	return record.SessionID, true
+}
+
+// preferLiveOrchestratorSessionID returns the session id an orchestrator's own
+// hooks last recorded as live, falling back to the id it was spawned with when
+// the record is absent, names the same id (nothing to prefer), or names a
+// conversation that no longer exists on disk. It never trusts a live record
+// over a spawn-time id it cannot verify: resuming nothing is safer than
+// resuming the wrong conversation.
+func preferLiveOrchestratorSessionID(orchestratorID, spawnConversationID string) string {
+	live, ok := readOrchestratorLiveSessionID(orchestratorID)
+	if !ok || live == "" || live == spawnConversationID {
+		return spawnConversationID
+	}
+	if !orchestratorSessionExists(live) {
+		return spawnConversationID
+	}
+	return live
+}
+
+// orchestratorSessionRecordHookCommand is the hook command that keeps one
+// orchestrator's live-session file current. It reads the hook's own stdin JSON
+// for session_id — the same field every Claude Code hook invocation carries,
+// which Claude Code updates the moment it forks the transcript on compaction —
+// and writes it under $ERUN_ORCHESTRATOR_ID, resolved at run time for the same
+// reason the activity hooks resolve it at run time: the orchestrators
+// workspace is shared, so a baked-in id would have every orchestrator
+// overwriting the same file.
+//
+// Bare shell, like the activity hooks and the no-ask guard, so it keeps
+// working when erun is not on PATH. Every failure path is `|| true`: a hook
+// that could wedge a session costs more than a missed record.
+func orchestratorSessionRecordHookCommand() string {
+	dir := filepath.ToSlash(orchestratorLiveSessionDir())
+	return `input=$(cat); ` +
+		`sid=$(printf '%s' "$input" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'); ` +
+		`[ -n "$ERUN_ORCHESTRATOR_ID" ] && [ -n "$sid" ] && mkdir -p "` + dir + `" && ` +
+		`printf '{"sessionId":"%s","atUnix":%s}' "$sid" "$(date +%s)" > "` + dir + `/$ERUN_ORCHESTRATOR_ID.json"` +
+		` || true`
+}
+
+// orchestratorLiveSessionHookMarker identifies a hook this file wrote, so a
+// rewrite replaces its own previous block instead of stacking another copy,
+// and merging into an event leaves everyone else's hooks alone.
+func orchestratorLiveSessionHookMarker() string {
+	return filepath.ToSlash(orchestratorLiveSessionDir())
+}
+
+// isOrchestratorLiveSessionHookBlock reports whether a settings hook block is
+// one of ours. Anything it cannot read is somebody else's and is kept.
+func isOrchestratorLiveSessionHookBlock(block any) bool {
+	group, ok := block.(map[string]any)
+	if !ok {
+		return false
+	}
+	hooks, ok := group["hooks"].([]any)
+	if !ok {
+		return false
+	}
+	marker := orchestratorLiveSessionHookMarker()
+	for _, hook := range hooks {
+		entry, ok := hook.(map[string]any)
+		if !ok {
+			continue
+		}
+		command, ok := entry["command"].(string)
+		if !ok {
+			continue
+		}
+		if strings.Contains(command, marker) && strings.Contains(command, `"sessionId":`) {
+			return true
+		}
+	}
+	return false
+}
+
+// orchestratorLiveSessionHookBlock is the recorder bound to whichever event it
+// is installed on.
+func orchestratorLiveSessionHookBlock() []any {
+	return []any{map[string]any{
+		"hooks": []any{map[string]any{"type": "command", "command": orchestratorSessionRecordHookCommand()}},
+	}}
+}

--- a/erun-ui/orchestrator_live_session_test.go
+++ b/erun-ui/orchestrator_live_session_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runOrchestratorSessionRecordHook runs the command erun actually installs
+// against a POSIX shell, feeding it hook stdin the way Claude Code would.
+func runOrchestratorSessionRecordHook(t *testing.T, shell, orchestratorID, input string) {
+	t.Helper()
+	cmd := exec.Command(shell, "-c", orchestratorSessionRecordHookCommand())
+	cmd.Stdin = strings.NewReader(input)
+	if orchestratorID != "" {
+		cmd.Env = append(os.Environ(), "ERUN_ORCHESTRATOR_ID="+orchestratorID)
+	} else {
+		cmd.Env = os.Environ()
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run session-record hook: %v\n%s", err, out)
+	}
+}
+
+// The hook is a shell one-liner, so asserting on its text would prove nothing
+// about what it does. This runs it against real hook-shaped stdin.
+func TestOrchestratorSessionRecordHookWritesTheLiveSessionID(t *testing.T) {
+	shell, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("no POSIX shell on this host")
+	}
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	runOrchestratorSessionRecordHook(t, shell, "agent-1", `{"session_id":"live-123","hook_event_name":"PostToolUse"}`)
+
+	got, ok := readOrchestratorLiveSessionID("agent-1")
+	if !ok || got != "live-123" {
+		t.Fatalf("expected the live session id to be recorded, got %q ok=%v", got, ok)
+	}
+}
+
+// A transient session (Investigate) carries no orchestrator id and must write
+// nothing rather than a file named for nobody.
+func TestOrchestratorSessionRecordHookSkipsASessionWithNoID(t *testing.T) {
+	shell, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("no POSIX shell on this host")
+	}
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	runOrchestratorSessionRecordHook(t, shell, "", `{"session_id":"live-123"}`)
+
+	if _, err := os.Stat(orchestratorLiveSessionDir()); !os.IsNotExist(err) {
+		t.Fatalf("expected no live-session dir written without an orchestrator id, stat err %v", err)
+	}
+}
+
+// Unparseable hook input must not wedge or crash the hook -- same fail-open
+// discipline as the no-ask guard and the activity reports.
+func TestOrchestratorSessionRecordHookIgnoresUnparseableInput(t *testing.T) {
+	shell, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("no POSIX shell on this host")
+	}
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	runOrchestratorSessionRecordHook(t, shell, "agent-1", "not json at all")
+
+	if _, ok := readOrchestratorLiveSessionID("agent-1"); ok {
+		t.Fatal("expected no live session id recorded from unparseable input")
+	}
+}
+
+// A later hook firing overwrites the file with whatever session_id it sees --
+// the mechanism that lets the record catch up the moment Claude Code forks the
+// transcript on compaction.
+func TestOrchestratorSessionRecordHookOverwritesOnEachFire(t *testing.T) {
+	shell, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("no POSIX shell on this host")
+	}
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	runOrchestratorSessionRecordHook(t, shell, "agent-1", `{"session_id":"before-compact"}`)
+	runOrchestratorSessionRecordHook(t, shell, "agent-1", `{"session_id":"after-compact"}`)
+
+	got, ok := readOrchestratorLiveSessionID("agent-1")
+	if !ok || got != "after-compact" {
+		t.Fatalf("expected the most recent session id to win, got %q ok=%v", got, ok)
+	}
+}
+
+func TestReadOrchestratorLiveSessionIDTreatsUnreadableInputAsAbsent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	if _, ok := readOrchestratorLiveSessionID("nobody-wrote-this"); ok {
+		t.Fatal("expected no live session id for an id nothing wrote")
+	}
+
+	path := orchestratorLiveSessionPath("agent-1")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create live session dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("not json"), 0o644); err != nil {
+		t.Fatalf("write malformed live session: %v", err)
+	}
+	if _, ok := readOrchestratorLiveSessionID("agent-1"); ok {
+		t.Fatal("expected unparseable live session file to read as absent")
+	}
+}
+
+// preferLiveOrchestratorSessionID must never trust a live record it cannot
+// tell apart from the spawn id it already has, or verify against disk.
+func TestPreferLiveOrchestratorSessionIDFallsBackAppropriately(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	if got := preferLiveOrchestratorSessionID("agent-1", "spawn-id"); got != "spawn-id" {
+		t.Fatalf("no record at all: got %q, want the spawn id", got)
+	}
+
+	stageOrchestratorLiveSession(t, "agent-1", "spawn-id")
+	if got := preferLiveOrchestratorSessionID("agent-1", "spawn-id"); got != "spawn-id" {
+		t.Fatalf("record matches the spawn id: got %q, want the spawn id", got)
+	}
+
+	stageOrchestratorLiveSession(t, "agent-1", "forked-but-not-on-disk")
+	if got := preferLiveOrchestratorSessionID("agent-1", "spawn-id"); got != "spawn-id" {
+		t.Fatalf("record names a conversation absent from disk: got %q, want the spawn id", got)
+	}
+
+	stageOrchestratorConversation(t, "forked-but-not-on-disk")
+	if got := preferLiveOrchestratorSessionID("agent-1", "spawn-id"); got != "forked-but-not-on-disk" {
+		t.Fatalf("record names a real, different conversation: got %q, want it preferred", got)
+	}
+}
+
+// The settings file must carry the recorder on SessionStart (both matchers)
+// and every turn-boundary event the activity reports already ride, so a fork
+// is caught whichever fires next.
+func TestOrchestratorSessionRecordHookIsWiredOnSessionStart(t *testing.T) {
+	hooks, data := orchestratorSettingsHooks(t)
+
+	for _, matcherBlock := range hooks["SessionStart"] {
+		block, ok := matcherBlock.(map[string]any)
+		if !ok {
+			t.Fatalf("unexpected SessionStart block: %+v", matcherBlock)
+		}
+		if !hookGroupContainsMarker(t, block, orchestratorLiveSessionHookMarker()) {
+			t.Fatalf("SessionStart matcher %v missing the live-session recorder:\n%s", block["matcher"], data)
+		}
+	}
+}
+
+// The recorder rides every turn-boundary event the activity reports already
+// use, so a compaction fork is caught whichever fires next.
+func TestOrchestratorSessionRecordHookIsWiredOnEveryTurnBoundaryEvent(t *testing.T) {
+	hooks, data := orchestratorSettingsHooks(t)
+
+	for _, event := range []string{"UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop"} {
+		if !anyOrchestratorLiveSessionHookBlock(hooks[event]) {
+			t.Fatalf("%s missing the live-session recorder:\n%s", event, data)
+		}
+	}
+}
+
+func anyOrchestratorLiveSessionHookBlock(events []any) bool {
+	for _, block := range events {
+		if isOrchestratorLiveSessionHookBlock(block) {
+			return true
+		}
+	}
+	return false
+}
+
+// hookGroupContainsMarker checks a matcher-keyed hook group (used only by
+// SessionStart) for a command containing marker.
+func hookGroupContainsMarker(t *testing.T, block map[string]any, marker string) bool {
+	t.Helper()
+	hooks, ok := block["hooks"].([]any)
+	if !ok {
+		return false
+	}
+	for _, hook := range hooks {
+		entry, ok := hook.(map[string]any)
+		if !ok {
+			continue
+		}
+		if command, ok := entry["command"].(string); ok && strings.Contains(command, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/erun-ui/orchestrator_mcp.go
+++ b/erun-ui/orchestrator_mcp.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	eruncommon "github.com/sophium/erun/erun-common"
 )
@@ -30,6 +31,12 @@ type orchestratorMCPConfig struct {
 // live config store.
 type mcpPortResolver func(tenant, environment string) int
 
+// mcpReachabilityProber reports whether a local MCP edge answers right now.
+// The same shape as App.deps.canReachMCPEndpoint, so writeOrchestratorMCPConfig
+// passes that seam straight through and this stays unit testable without a
+// live port-forward.
+type mcpReachabilityProber func(port int) bool
+
 // orchestratorMCPSkip is one linked environment that produced no MCP server
 // entry, and why. Carried out of the builder rather than dropped: an
 // orchestrator is told by its own operating contract to know which environments
@@ -40,6 +47,27 @@ type orchestratorMCPSkip struct {
 	Reason string
 }
 
+// orchestratorMCPUnreachable is one linked environment that got a wired MCP
+// server entry — it is NOT skipped — even though its edge did not answer a
+// quick probe at launch time. Reported separately from orchestratorMCPSkip
+// because the environment IS wired: erun-common/mcp_proxy.go already recovers
+// a transient edge outage per request ("a transient edge outage must not kill
+// the session"), so dropping the environment here would strand it for the
+// whole session even after the edge recovers. What is missing without this is
+// only that an orchestrator whose env has no tools right now cannot tell "not
+// linked" apart from "linked but the edge was down at launch".
+type orchestratorMCPUnreachable struct {
+	Label string
+}
+
+// orchestratorMCPWiredEnv is one environment buildOrchestratorMCPConfig wired,
+// carried alongside its resolved port so the reachability probe below can
+// check it after the server map is assembled.
+type orchestratorMCPWiredEnv struct {
+	Label string
+	Port  int
+}
+
 // buildOrchestratorMCPConfig assembles the per-env MCP server map, keyed
 // "<tenant>-<environment>". An env is skipped (not an error) when its MCP port
 // does not resolve — that env is not wired for MCP at all — so an orchestrator
@@ -47,13 +75,18 @@ type orchestratorMCPSkip struct {
 // PARTIAL skip is reportable: previously only the all-envs-failed case produced
 // any signal, and a session missing one of two environments looked identical to
 // a healthy one until its first call into the missing env.
-func buildOrchestratorMCPConfig(envs []eruncommon.OrchestratorEnvConfig, executable string, mcpPort mcpPortResolver) (orchestratorMCPConfig, []orchestratorMCPSkip) {
+//
+// An env whose port resolves but whose edge does not answer a quick probe is
+// wired anyway and reported as unreachable rather than skipped — see
+// orchestratorMCPUnreachable.
+func buildOrchestratorMCPConfig(envs []eruncommon.OrchestratorEnvConfig, executable string, mcpPort mcpPortResolver, reachable mcpReachabilityProber) (orchestratorMCPConfig, []orchestratorMCPSkip, []orchestratorMCPUnreachable) {
 	servers := map[string]orchestratorMCPServer{}
 	var skipped []orchestratorMCPSkip
 	executable = strings.TrimSpace(executable)
 	if executable == "" {
-		return orchestratorMCPConfig{MCPServers: servers}, nil
+		return orchestratorMCPConfig{MCPServers: servers}, nil, nil
 	}
+	var wired []orchestratorMCPWiredEnv
 	for _, env := range envs {
 		tenant := strings.TrimSpace(env.Tenant)
 		environment := strings.TrimSpace(env.Environment)
@@ -64,7 +97,8 @@ func buildOrchestratorMCPConfig(envs []eruncommon.OrchestratorEnvConfig, executa
 			})
 			continue
 		}
-		if mcpPort(tenant, environment) <= 0 {
+		port := mcpPort(tenant, environment)
+		if port <= 0 {
 			skipped = append(skipped, orchestratorMCPSkip{
 				Label:  orchestratorEnvLabel(tenant, environment),
 				Reason: "it resolved no MCP port",
@@ -76,8 +110,37 @@ func buildOrchestratorMCPConfig(envs []eruncommon.OrchestratorEnvConfig, executa
 			Command: executable,
 			Args:    []string{"mcp", "proxy", "--tenant", tenant, "--environment", environment},
 		}
+		wired = append(wired, orchestratorMCPWiredEnv{Label: orchestratorEnvLabel(tenant, environment), Port: port})
 	}
-	return orchestratorMCPConfig{MCPServers: servers}, skipped
+	return orchestratorMCPConfig{MCPServers: servers}, skipped, probeOrchestratorMCPEdges(wired, reachable)
+}
+
+// probeOrchestratorMCPEdges checks every wired env's edge concurrently, so N
+// environments cost about one probe's worth of latency rather than N in
+// series — this runs on every orchestrator launch and must never noticeably
+// delay it. A nil prober (no seam wired) or nothing wired both answer "nothing
+// unreachable" rather than probing.
+func probeOrchestratorMCPEdges(wired []orchestratorMCPWiredEnv, reachable mcpReachabilityProber) []orchestratorMCPUnreachable {
+	if len(wired) == 0 || reachable == nil {
+		return nil
+	}
+	answered := make([]bool, len(wired))
+	var wg sync.WaitGroup
+	for i, env := range wired {
+		wg.Add(1)
+		go func(i, port int) {
+			defer wg.Done()
+			answered[i] = reachable(port)
+		}(i, env.Port)
+	}
+	wg.Wait()
+	var unreachable []orchestratorMCPUnreachable
+	for i, env := range wired {
+		if !answered[i] {
+			unreachable = append(unreachable, orchestratorMCPUnreachable{Label: env.Label})
+		}
+	}
+	return unreachable
 }
 
 // orchestratorEnvLabel names an environment for an operator-facing line, staying
@@ -142,23 +205,47 @@ func orchestratorMCPPartialNotice(name string, wired int, skipped []orchestrator
 		label, wired, wired+len(skipped), strings.Join(missing, "; "))
 }
 
+// orchestratorMCPUnreachableNotice is the operator-facing line for an
+// orchestrator that wired an environment's tools even though its edge is not
+// answering right now. Distinct from the partial notice above: that one names
+// an environment left OUT of the toolset, this one names environments that ARE
+// in it and will recover on their own once the edge comes back — the point is
+// telling an orchestrator that finds an env's tools missing "linked, but the
+// edge was down at launch" rather than leaving it to read as "not linked".
+func orchestratorMCPUnreachableNotice(name string, unreachable []orchestratorMCPUnreachable) string {
+	if len(unreachable) == 0 {
+		return ""
+	}
+	label := strings.TrimSpace(name)
+	if label == "" {
+		label = "The orchestrator"
+	}
+	names := make([]string, 0, len(unreachable))
+	for _, env := range unreachable {
+		names = append(names, env.Label)
+	}
+	return fmt.Sprintf("%s wired tools for %s, but its edge is not answering right now. "+
+		"Calls will recover automatically once the edge comes back; if it stays down, deploy or reopen that environment.",
+		label, strings.Join(names, ", "))
+}
+
 // writeOrchestratorMCPConfig writes a per-orchestrator Claude Code --mcp-config
 // file wiring each linked env's erun MCP into the orchestrator session, so it
 // drives its envs through the MCP rather than raw kubectl. Returns "" with an
 // error naming why when nothing could be wired, so the caller skips
 // --mcp-config and can tell the operator which fix applies.
-func (a *App) writeOrchestratorMCPConfig(id string, envs []eruncommon.OrchestratorEnvConfig) (string, []orchestratorMCPSkip, error) {
+func (a *App) writeOrchestratorMCPConfig(id string, envs []eruncommon.OrchestratorEnvConfig) (string, []orchestratorMCPSkip, []orchestratorMCPUnreachable, error) {
 	// An orchestrator with no linked envs has nothing to wire, and that is normal.
 	if len(envs) == 0 {
-		return "", nil, nil
+		return "", nil, nil, nil
 	}
 	// No erun binary means no proxy to launch, so the session launches without
 	// its envs rather than with entries that would fail on first use.
 	executable, err := eruncommon.ResolveErunExecutable()
 	if err != nil {
-		return "", nil, fmt.Errorf("%w: %w", errOrchestratorMCPExecutable, err)
+		return "", nil, nil, fmt.Errorf("%w: %w", errOrchestratorMCPExecutable, err)
 	}
-	config, skipped := buildOrchestratorMCPConfig(envs, executable,
+	config, skipped, unreachable := buildOrchestratorMCPConfig(envs, executable,
 		func(tenant, environment string) int {
 			ports, portErr := eruncommon.ResolveEnvironmentLocalPorts(a.deps.store, tenant, environment)
 			if portErr != nil {
@@ -166,22 +253,23 @@ func (a *App) writeOrchestratorMCPConfig(id string, envs []eruncommon.Orchestrat
 			}
 			return ports.MCP
 		},
+		a.deps.canReachMCPEndpoint,
 	)
 	if len(config.MCPServers) == 0 {
-		return "", skipped, errOrchestratorMCPNoPort
+		return "", skipped, nil, errOrchestratorMCPNoPort
 	}
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		return "", skipped, err
+		return "", skipped, unreachable, err
 	}
 	path := orchestratorMCPConfigPath(id)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return "", skipped, err
+		return "", skipped, unreachable, err
 	}
 	if err := os.WriteFile(path, data, 0o600); err != nil {
-		return "", skipped, err
+		return "", skipped, unreachable, err
 	}
-	return path, skipped, nil
+	return path, skipped, unreachable, nil
 }
 
 // orchestratorMCPConfigPath is a per-orchestrator sibling of

--- a/erun-ui/orchestrator_mcp_test.go
+++ b/erun-ui/orchestrator_mcp_test.go
@@ -37,8 +37,13 @@ func orchestratorTestEnvs() []eruncommon.OrchestratorEnvConfig {
 	}
 }
 
+// orchestratorTestAlwaysReachable stands in for a.deps.canReachMCPEndpoint in
+// tests that are not themselves about reachability, so every wired env probes
+// as reachable rather than depending on a real port-forward.
+func orchestratorTestAlwaysReachable(int) bool { return true }
+
 func TestBuildOrchestratorMCPConfig(t *testing.T) {
-	config, _ := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort)
+	config, _, _ := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort, orchestratorTestAlwaysReachable)
 
 	if len(config.MCPServers) != 2 {
 		t.Fatalf("expected 2 servers, got %d: %v", len(config.MCPServers), config.MCPServers)
@@ -68,7 +73,7 @@ func TestBuildOrchestratorMCPConfig(t *testing.T) {
 // place a bearer can leak from: an MCP client cannot refresh a header it was
 // configured with, so the fix for the expiry was to stop writing one at all.
 func TestBuildOrchestratorMCPConfigCarriesNoCredential(t *testing.T) {
-	config, _ := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort)
+	config, _, _ := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort, orchestratorTestAlwaysReachable)
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
 		t.Fatalf("marshal config: %v", err)
@@ -84,7 +89,7 @@ func TestBuildOrchestratorMCPConfigCarriesNoCredential(t *testing.T) {
 // and the caller skips --mcp-config rather than writing entries that fail on
 // first use.
 func TestBuildOrchestratorMCPConfigSkipsEveryEnvWithoutAnExecutable(t *testing.T) {
-	config, _ := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "  ", orchestratorTestPort)
+	config, _, _ := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "  ", orchestratorTestPort, orchestratorTestAlwaysReachable)
 	if len(config.MCPServers) != 0 {
 		t.Fatalf("expected no servers without an executable, got %v", config.MCPServers)
 	}
@@ -153,7 +158,7 @@ func writeBundledDesktopMCPConfig(t *testing.T, output string) {
 	app := orchestratorTestApp(t)
 	defer app.shutdown(context.Background())
 
-	path, _, err := app.writeOrchestratorMCPConfig("petios", []eruncommon.OrchestratorEnvConfig{
+	path, _, _, err := app.writeOrchestratorMCPConfig("petios", []eruncommon.OrchestratorEnvConfig{
 		{Tenant: "frs", Environment: "dev"},
 	})
 	if err != nil {
@@ -320,7 +325,7 @@ func TestSanitizeOrchestratorFileID(t *testing.T) {
 // The pre-existing test above asserted the skip happened and said nothing about
 // it being reported, which is exactly why nothing caught this.
 func TestBuildOrchestratorMCPConfigReportsEverySkip(t *testing.T) {
-	config, skipped := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort)
+	config, skipped, _ := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort, orchestratorTestAlwaysReachable)
 
 	if len(config.MCPServers) != 2 {
 		t.Fatalf("wired %d servers, want 2", len(config.MCPServers))
@@ -347,6 +352,92 @@ func TestBuildOrchestratorMCPConfigReportsEverySkip(t *testing.T) {
 		t.Errorf("a malformed linked entry must still be reported, not silently dropped: %+v", skipped)
 	} else if !strings.Contains(reason, "no tenant or environment") {
 		t.Errorf("skip reason %q does not name the cause", reason)
+	}
+}
+
+// TestBuildOrchestratorMCPConfigStillWiresAnUnreachableEdge is the regression
+// test for the corrected scope of a retracted design. The originally filed issue would have
+// counted a dead port-forward as unwired and dropped the environment for the
+// whole session -- retracted after reading erun-common/mcp_proxy.go, which
+// already recovers a transient edge outage per call. The corrected behaviour:
+// an env whose edge does not answer a probe at launch is wired anyway, and
+// reported as unreachable, never as skipped.
+func TestBuildOrchestratorMCPConfigStillWiresAnUnreachableEdge(t *testing.T) {
+	unreachableAlways := func(int) bool { return false }
+	config, skipped, unreachable := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort, unreachableAlways)
+
+	if len(config.MCPServers) != 2 {
+		t.Fatalf("expected both resolvable envs still wired despite an unreachable edge, got %d: %v", len(config.MCPServers), config.MCPServers)
+	}
+	if _, ok := config.MCPServers["erun-main"]; !ok {
+		t.Fatalf("expected erun-main still wired even though its edge is unreachable: %v", config.MCPServers)
+	}
+	if _, ok := config.MCPServers["petios-rihards-win-develop"]; !ok {
+		t.Fatalf("expected petios still wired even though its edge is unreachable: %v", config.MCPServers)
+	}
+	// The pre-existing skip count (unresolved port, blank tenant) must be
+	// unaffected by reachability -- those two never had a port to probe.
+	if len(skipped) != 2 {
+		t.Fatalf("expected the pre-existing skip count unaffected by reachability, got %d: %+v", len(skipped), skipped)
+	}
+	if len(unreachable) != 2 {
+		t.Fatalf("expected both wired envs reported unreachable, got %d: %+v", len(unreachable), unreachable)
+	}
+}
+
+// A reachable edge must not be reported as unreachable -- otherwise every
+// orchestrator launch would carry a spurious warning.
+func TestBuildOrchestratorMCPConfigReportsNoUnreachableEdgeWhenAllAnswer(t *testing.T) {
+	_, _, unreachable := buildOrchestratorMCPConfig(orchestratorTestEnvs(), "/opt/erun/bin/erun", orchestratorTestPort, orchestratorTestAlwaysReachable)
+	if len(unreachable) != 0 {
+		t.Fatalf("expected no unreachable envs when every edge answers, got %+v", unreachable)
+	}
+}
+
+func TestOrchestratorMCPUnreachableNoticeNamesTheEnvironments(t *testing.T) {
+	if got := orchestratorMCPUnreachableNotice("Petios", nil); got != "" {
+		t.Fatalf("expected no notice when nothing is unreachable, got %q", got)
+	}
+	notice := orchestratorMCPUnreachableNotice("Petios", []orchestratorMCPUnreachable{{Label: "frs/dev"}})
+	for _, want := range []string{"Petios", "frs/dev", "not answering"} {
+		if !strings.Contains(notice, want) {
+			t.Fatalf("notice does not mention %q: %q", want, notice)
+		}
+	}
+}
+
+// TestWireOrchestratorMCPWiresAnUnreachableEnvAndSaysSo exercises the full
+// wiring path: the written config still carries the unreachable env, and the
+// operator gets a notice distinct from the partial-skip one.
+func TestWireOrchestratorMCPWiresAnUnreachableEnvAndSaysSo(t *testing.T) {
+	t.Setenv("ERUN_ERUN_BIN", filepath.Join(t.TempDir(), "erun"))
+	app, _ := orchestratorTestAppWithReachability(t, func(int) bool { return false })
+	defer app.shutdown(context.Background())
+	emits := newCapturedEmits()
+	app.emitFn = emits.fn()
+
+	path := app.wireOrchestratorMCP("petios", "Petios", []eruncommon.OrchestratorEnvConfig{{Tenant: "frs", Environment: "dev"}})
+	if strings.TrimSpace(path) == "" {
+		t.Fatal("expected an MCP config path even though the edge is unreachable")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written config: %v", err)
+	}
+	if !strings.Contains(string(data), "frs-dev") {
+		t.Fatalf("expected the unreachable env still wired into the config:\n%s", data)
+	}
+
+	events := emits.events(appNotificationEvent)
+	if len(events) != 1 {
+		t.Fatalf("expected exactly one notice about the unreachable edge, got %+v", events)
+	}
+	payload, ok := events[0].(appNotificationPayload)
+	if !ok {
+		t.Fatalf("unexpected payload type: %T", events[0])
+	}
+	if !strings.Contains(payload.Message, "frs/dev") || !strings.Contains(payload.Message, "not answering") {
+		t.Fatalf("notice does not name the environment and the reason: %q", payload.Message)
 	}
 }
 
@@ -379,7 +470,7 @@ func TestWriteOrchestratorMCPConfigCarriesSkipsEvenWhenNothingWired(t *testing.T
 	app := orchestratorTestApp(t)
 	defer app.shutdown(context.Background())
 
-	path, skipped, err := app.writeOrchestratorMCPConfig("nothing-wirable", []eruncommon.OrchestratorEnvConfig{
+	path, skipped, _, err := app.writeOrchestratorMCPConfig("nothing-wirable", []eruncommon.OrchestratorEnvConfig{
 		{Tenant: "ghost", Environment: "one"},
 		{Tenant: "ghost", Environment: "two"},
 	})

--- a/erun-ui/orchestrator_noask_guard_test.go
+++ b/erun-ui/orchestrator_noask_guard_test.go
@@ -85,7 +85,7 @@ func TestOrchestratorNoAskStopGuardDecidesOnTheTurnsLastWords(t *testing.T) {
 }
 
 // countStopHookBlocks tallies the Stop event by owner.
-func countStopHookBlocks(t *testing.T, path string) (guards, idles, foreign int) {
+func countStopHookBlocks(t *testing.T, path string) (guards, idles, liveSessions, foreign int) {
 	t.Helper()
 	raw, err := os.ReadFile(path)
 	if err != nil {
@@ -105,11 +105,13 @@ func countStopHookBlocks(t *testing.T, path string) (guards, idles, foreign int)
 			guards++
 		case isOrchestratorActivityHookBlock(block):
 			idles++
+		case isOrchestratorLiveSessionHookBlock(block):
+			liveSessions++
 		default:
 			foreign++
 		}
 	}
-	return guards, idles, foreign
+	return guards, idles, liveSessions, foreign
 }
 
 func seedOperatorStopHook(t *testing.T, dir string) string {
@@ -141,9 +143,10 @@ func TestOrchestratorSettingsKeepTheStopGuardBesideTheIdleReport(t *testing.T) {
 		}
 	}
 
-	guards, idles, foreign := countStopHookBlocks(t, settingsPath)
+	guards, idles, liveSessions, foreign := countStopHookBlocks(t, settingsPath)
 	// The settings file is shared with the operator, so theirs has to survive.
-	if guards != 1 || idles != 1 || foreign != 1 {
-		t.Fatalf("Stop must carry one guard, one idle report and the operator's hook, got guards=%d idles=%d foreign=%d", guards, idles, foreign)
+	if guards != 1 || idles != 1 || liveSessions != 1 || foreign != 1 {
+		t.Fatalf("Stop must carry one guard, one idle report, one live-session recorder and the operator's hook, got guards=%d idles=%d liveSessions=%d foreign=%d",
+			guards, idles, liveSessions, foreign)
 	}
 }

--- a/erun-ui/orchestrator_test.go
+++ b/erun-ui/orchestrator_test.go
@@ -61,6 +61,16 @@ Error: UPGRADE FAILED: timed out waiting for the condition`
 // path, for the assertions that care where that env is reviewed.
 func orchestratorTestAppWithLocalRepo(t *testing.T) (*App, string) {
 	t.Helper()
+	return orchestratorTestAppWithReachability(t, orchestratorTestAlwaysReachable)
+}
+
+// orchestratorTestAppWithReachability is orchestratorTestAppWithLocalRepo with
+// an injectable MCP-edge reachability probe, so a test about the unreachable-
+// edge notice can simulate a down edge without a real port-forward,
+// while every other orchestrator test gets a deterministic "always reachable"
+// default instead of depending on a real network dial.
+func orchestratorTestAppWithReachability(t *testing.T, reachable func(int) bool) (*App, string) {
+	t.Helper()
 	home := t.TempDir()
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("HOME", home)
@@ -78,6 +88,7 @@ func orchestratorTestAppWithLocalRepo(t *testing.T) (*App, string) {
 		resolveOrchestratorLaunch: func(string, string, string, string) (string, []string, error) {
 			return "claude-stub", nil, nil
 		},
+		canReachMCPEndpoint: reachable,
 	})
 	// Stage failure reports inside the test's own directory. Left at the default
 	// they land in the shared host temp dir, which is how a suite that spawns


### PR DESCRIPTION
## Summary

**#1191 — restart resumes a stale, pre-compaction conversation.** `restartHandoff` recorded `session.conversationID`, the id erun *spawned* the session with. Claude Code forks the transcript to a new session id when a resumed conversation compacts, so after any compaction that id names a conversation that has stopped growing — a restart resumed it anyway, silently dropping everything since.

Fix: `ensureOrchestratorSessionStartHook` now also installs a hook (`orchestrator_live_session.go`) that keeps `orchestrator-session/<id>.json` current with whatever `session_id` a hook invocation's own stdin carries — reset to the spawn id at `SessionStart` (startup/resume, so a reused orchestrator id never inherits a previous run's stale record), then refreshed from every turn-boundary hook afterward, so a compaction fork is picked up the moment the next hook fires. `restartHandoff` now calls `preferLiveOrchestratorSessionID`, which prefers that recorded id over the spawn-time one, but only once it is validated against disk (`orchestratorSessionExists`) — falling back to the spawn id when the record is absent, unchanged, or names a conversation that never made it to disk.

**#1192 — a partial wiring failure left no durable trace, and the originally filed second half was retracted.** Two parts, per the issue's own correcting comment:

- (a) **Valid and verified.** `wireOrchestratorMCP`'s skip was reported only via `log.Printf` to stderr plus a transient toast. The desktop is normally launched via `open`, which gives it a null stderr, so nothing outside the source tree ever recorded it. `main.go` now redirects the default logger (`initDurableAppLog`, `app_log.go`) to a bounded, size-capped file under the ERun support dir *in addition to* stderr — every existing and future `log.Printf` in this module survives without touching each call site.
- (b) **Corrected scope, replacing the retracted "count a dead port-forward as unwired."** `erun-common/mcp_proxy.go` deliberately treats a dead edge as recoverable per call, not a wiring failure — skipping an env whose forward was down at launch would drop it for the whole session even after the forward recovered. The corrected fix: `buildOrchestratorMCPConfig` now probes every wired env's edge concurrently (reusing the existing `a.deps.canReachMCPEndpoint` seam) and, when an edge doesn't answer, still wires it and reports it distinctly (`orchestratorMCPUnreachableNotice`) rather than skipping it — so an orchestrator with no tools for an env can tell "not linked" apart from "linked, edge was down at launch."

## UX Impact Review Checklist

1. **Affected paths.** Restart hand-off (`RestartApp` → `ResolveOrchestratorToReopen`, consumed on the next boot); orchestrator spawn's MCP wiring (`wireOrchestratorMCP` → the existing `app-notification` warning toast).
2. **User-visible sequence.** Restart: unchanged externally — the resumed conversation is now the *correct* live one instead of a stale one; the hand-off shape (`relaunchTarget`) is unchanged. MCP wiring: an existing warning toast now also fires for "wired but edge not answering", worded distinctly from the pre-existing "partial skip" and "fully unwired" toasts.
3. **State-without-affordance.** None added — reuses the existing `emitAppNotification("warning", …)` → toast affordance already wired for the sibling skip/unwired notices.
4/5. **Visibility of status / success-failure feedback.** Same persistent-toast channel as the pre-existing partial/unwired notices (#1185); no new channel.
6. **Consistency with comparable flows.** Matches `orchestratorMCPPartialNotice`/`orchestratorMCPUnwiredNotice` exactly (same call site, same "warning" kind).
7. **Heuristic pass.** Visibility of system status: satisfied by the existing toast channel now also covering this case; no other heuristic is implicated by an internal wiring/logging fix.
8. **Playwright coverage.** None added, intentionally. `ResolveOrchestratorToReopen`'s Go-side decision (including which conversation to resume) is already stubbed at the HTTP boundary in `playwright/tests/orchestrator-reopen-on-launch.spec.ts`, whose own header names the Go suite (`orchestrator_open_state_test.go`, and now `app_restart_test.go`) as the place that decision is covered — this PR's fix lives entirely inside that stubbed decision. The MCP-unreachable toast reuses the exact rendering path already covered generically by `playwright/tests/app-notification.spec.ts`; reaching the *business logic* that fires it needs a real edge that's allocated but not answering, which is live infrastructure the headless harness deliberately lacks (the same "genuinely cluster-bound" carve-out `erun-ui/AGENTS.md` already documents for comparable cases). New Go unit tests cover both branches instead.

## Docs plan

No `erun-docs` update needed: both fixes are internal desktop bug fixes with no new command, flag, MCP tool, or config surface — the restart hand-off's JSON shape and the wiring notice's trigger conditions were already undocumented internals, and existing toast wording is only being made more specific, not changed in kind.

## What I verified

- `go test ./...` in `erun-ui` (full suite, `-count=1`), `golangci-lint run ./...` in `erun-ui` (0 issues), `go build ./...`.
- `go test ./...` in `erun-integration` (green — this PR touches no `erun-cli`/`erun-common`/runtime-entrypoint code, so the suite is unaffected but confirmed green per the mandatory gate).
- Every new test proven to fail against the unfixed code before being called done:
  - `TestRestartHandoffPrefersTheLiveSessionAfterCompaction` fails (asserts the stale spawn id) when `restartHandoff` is reverted to the pre-fix behavior — confirmed via `git stash` on `app_restart.go`.
  - `TestInitDurableAppLogCapturesLogPrintfCalls` fails when `log.SetOutput` is disabled — confirmed by temporarily neutering the call.
  - `TestBuildOrchestratorMCPConfigStillWiresAnUnreachableEdge` and `TestWireOrchestratorMCPWiresAnUnreachableEnvAndSaysSo` both fail against a hand-rolled reproduction of the *retracted* design (treating an unreachable edge as a skip) — confirmed by patching that variant in temporarily and reverting.

## What I could not verify

- The actual Claude Code hook-firing behavior on a real compaction (i.e., that `session_id` in a real hook's stdin JSON really does flip to the forked id the moment Claude Code forks the transcript) is taken from the issue's own diagnosis, not independently reproduced here — there's no live Claude Code session in this sandbox to compact. The hook shell command itself is executed directly against a POSIX shell in tests (`orchestrator_live_session_test.go`), and the read/fallback logic is covered end-to-end, but the upstream Claude Code behavior it depends on is external.
- No live macOS `open`-launched desktop to confirm the durable log file is the actual fix for the original symptom (nothing under `~/Library/Logs` etc.) — verified the mechanism (`log.SetOutput` redirection + bounded rotation) directly instead.
- No real port-forward/cluster to exercise the MCP-unreachable probe against a genuinely flaky edge; verified via the injected `canReachMCPEndpoint` seam instead, consistent with how the rest of the module tests this dependency.

Closes #1191
Closes #1192