### PR TITLE
Refuse an MCP tool target this server cannot reach

### DIFF
--- a/erun-docs/docs/mcp/overview.md
+++ b/erun-docs/docs/mcp/overview.md
@@ -10,6 +10,15 @@ ERun's conventions reach the Agent through a separate mechanism — [skill bundl
 
 Every open environment exposes an MCP server in its runtime pod. It runs **inside the runtime container** — the same image the in-pod Agent and an `erun open` shell use — so a tool call executes with the environment's own toolchain, including anything a custom runtime image adds. The desktop app port-forwards it to localhost so any MCP-compatible client — the Claude Code desktop app, the Codex desktop app, custom agents, any other JSON-RPC client — can connect directly.
 
+**A server acts only on its own environment.** Many tools take `tenant` and
+`environment` arguments, but those are how a caller *states* which environment it
+believes it is talking to — not a way to redirect the work. The server runs every
+tool in its own pod, against that pod's repo and that pod's `erun` binary, so a
+`tenant`/`environment` naming a different environment is **refused** rather than
+silently run locally. Omit them to accept the server's own scope, or restate that
+scope to assert it. To act on another environment, call that environment's own MCP
+edge.
+
 **Both endpoints accept any client.** SSH and MCP live in the same pod and see the same workspace. The Claude Code and Codex desktop apps typically use both — SSH for shell + filesystem, MCP for structured ERun operations. See [Desktop app](/desktop/overview).
 
 <figure className="erun-hero-figure">

--- a/erun-mcp/activity_lease.go
+++ b/erun-mcp/activity_lease.go
@@ -16,8 +16,8 @@ import (
 
 // ActivityLeaseTakeInput names the work the lease is being held for.
 type ActivityLeaseTakeInput struct {
-	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment the lease is held on; defaults to the server tenant context"`
-	Environment string `json:"environment,omitempty" jsonschema:"environment to hold; defaults to the server environment context"`
+	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment the lease is held on; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment string `json:"environment,omitempty" jsonschema:"environment to hold; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	Name        string `json:"name" jsonschema:"what the lease is holding the environment for; shown to the operator as the reason it reads as busy"`
 	ID          string `json:"id,omitempty" jsonschema:"lease id to take or renew; defaults to the name, so re-taking the same name renews rather than stacking"`
 	PID         int    `json:"pid,omitempty" jsonschema:"process id of the detached job; the lease is reclaimed once that process exits, so an abandoned lease cannot pin the environment awake"`
@@ -34,7 +34,7 @@ type ActivityLeaseResult struct {
 
 func activityLeaseTakeTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, ActivityLeaseTakeInput) (*mcp.CallToolResult, ActivityLeaseResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input ActivityLeaseTakeInput) (*mcp.CallToolResult, ActivityLeaseResult, error) {
-		tenant, environment, err := resolveActivityLeaseTarget(runtime, input.Tenant, input.Environment)
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
 		if err != nil {
 			return nil, ActivityLeaseResult{}, err
 		}
@@ -55,14 +55,14 @@ func activityLeaseTakeTool(runtime RuntimeConfig) func(context.Context, *mcp.Cal
 
 // ActivityLeaseReleaseInput selects the lease to drop.
 type ActivityLeaseReleaseInput struct {
-	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment holds the lease; defaults to the server tenant context"`
-	Environment string `json:"environment,omitempty" jsonschema:"environment to release; defaults to the server environment context"`
+	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment holds the lease; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment string `json:"environment,omitempty" jsonschema:"environment to release; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	ID          string `json:"id" jsonschema:"lease id to release; the name passed to activity_lease_take when no explicit id was given"`
 }
 
 func activityLeaseReleaseTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, ActivityLeaseReleaseInput) (*mcp.CallToolResult, ActivityLeaseResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input ActivityLeaseReleaseInput) (*mcp.CallToolResult, ActivityLeaseResult, error) {
-		tenant, environment, err := resolveActivityLeaseTarget(runtime, input.Tenant, input.Environment)
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
 		if err != nil {
 			return nil, ActivityLeaseResult{}, err
 		}
@@ -74,15 +74,6 @@ func activityLeaseReleaseTool(runtime RuntimeConfig) func(context.Context, *mcp.
 		}
 		return activityLeaseResult(tenant, environment, nil)
 	}
-}
-
-func resolveActivityLeaseTarget(runtime RuntimeConfig, tenant, environment string) (string, string, error) {
-	resolvedTenant := firstNonEmpty(tenant, runtime.Context.Tenant)
-	resolvedEnvironment := firstNonEmpty(environment, runtime.Context.Environment)
-	if strings.TrimSpace(resolvedTenant) == "" || strings.TrimSpace(resolvedEnvironment) == "" {
-		return "", "", fmt.Errorf("tenant and environment are required")
-	}
-	return resolvedTenant, resolvedEnvironment, nil
 }
 
 // activityLeaseResult always returns what is still held, so a caller sees the
@@ -100,13 +91,13 @@ func activityLeaseResult(tenant, environment string, lease *eruncommon.Environme
 
 // ActivityLeaseListInput selects the environment to read.
 type ActivityLeaseListInput struct {
-	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment to read; defaults to the server tenant context"`
-	Environment string `json:"environment,omitempty" jsonschema:"environment to read; defaults to the server environment context"`
+	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment to read; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment string `json:"environment,omitempty" jsonschema:"environment to read; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 }
 
 func activityLeaseListTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, ActivityLeaseListInput) (*mcp.CallToolResult, ActivityLeaseResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input ActivityLeaseListInput) (*mcp.CallToolResult, ActivityLeaseResult, error) {
-		tenant, environment, err := resolveActivityLeaseTarget(runtime, input.Tenant, input.Environment)
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
 		if err != nil {
 			return nil, ActivityLeaseResult{}, err
 		}

--- a/erun-mcp/idle.go
+++ b/erun-mcp/idle.go
@@ -9,15 +9,17 @@ import (
 )
 
 type IdleInput struct {
-	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment should be inspected; defaults to the server tenant context"`
-	Environment string `json:"environment,omitempty" jsonschema:"environment to inspect; defaults to the server environment context"`
+	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment should be inspected; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment string `json:"environment,omitempty" jsonschema:"environment to inspect; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	Verbosity   int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
 }
 
 func idleTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, IdleInput) (*mcp.CallToolResult, eruncommon.EnvironmentIdleStatus, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input IdleInput) (*mcp.CallToolResult, eruncommon.EnvironmentIdleStatus, error) {
-		tenant := firstNonEmpty(input.Tenant, runtime.Context.Tenant)
-		environment := firstNonEmpty(input.Environment, runtime.Context.Environment)
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
+		if err != nil {
+			return nil, eruncommon.EnvironmentIdleStatus{}, err
+		}
 		status, err := eruncommon.ResolveStoredEnvironmentIdleStatus(runtime.Store, tenant, environment, time.Now())
 		if err != nil {
 			return nil, eruncommon.EnvironmentIdleStatus{}, err

--- a/erun-mcp/idle_stop.go
+++ b/erun-mcp/idle_stop.go
@@ -2,7 +2,6 @@ package erunmcp
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -12,8 +11,8 @@ import (
 
 // IdleStopCancelInput selects the env whose armed idle-stop should be cancelled.
 type IdleStopCancelInput struct {
-	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment should have its pending stop cancelled; defaults to the server tenant context"`
-	Environment string `json:"environment,omitempty" jsonschema:"environment to cancel; defaults to the server environment context"`
+	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment should have its pending stop cancelled; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment string `json:"environment,omitempty" jsonschema:"environment to cancel; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 }
 
 // IdleStopCancelResult reports the cancel outcome. Cleared is true even when
@@ -26,10 +25,9 @@ type IdleStopCancelResult struct {
 
 func idleStopCancelTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, IdleStopCancelInput) (*mcp.CallToolResult, IdleStopCancelResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input IdleStopCancelInput) (*mcp.CallToolResult, IdleStopCancelResult, error) {
-		tenant := firstNonEmpty(input.Tenant, runtime.Context.Tenant)
-		environment := firstNonEmpty(input.Environment, runtime.Context.Environment)
-		if strings.TrimSpace(tenant) == "" || strings.TrimSpace(environment) == "" {
-			return nil, IdleStopCancelResult{}, fmt.Errorf("tenant and environment are required")
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
+		if err != nil {
+			return nil, IdleStopCancelResult{}, err
 		}
 		if err := eruncommon.ClearEnvironmentStopPending(tenant, environment); err != nil {
 			return nil, IdleStopCancelResult{}, err
@@ -44,8 +42,8 @@ func idleStopCancelTool(runtime RuntimeConfig) func(context.Context, *mcp.CallTo
 
 // IdleStopHistoryInput selects the env whose stop history to return.
 type IdleStopHistoryInput struct {
-	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment should be queried; defaults to the server tenant context"`
-	Environment string `json:"environment,omitempty" jsonschema:"environment to query; defaults to the server environment context"`
+	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment should be queried; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment string `json:"environment,omitempty" jsonschema:"environment to query; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 }
 
 // IdleStopHistoryResult wraps the entries so the MCP schema stays a stable
@@ -58,10 +56,9 @@ type IdleStopHistoryResult struct {
 
 func idleStopHistoryTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, IdleStopHistoryInput) (*mcp.CallToolResult, IdleStopHistoryResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input IdleStopHistoryInput) (*mcp.CallToolResult, IdleStopHistoryResult, error) {
-		tenant := firstNonEmpty(input.Tenant, runtime.Context.Tenant)
-		environment := firstNonEmpty(input.Environment, runtime.Context.Environment)
-		if strings.TrimSpace(tenant) == "" || strings.TrimSpace(environment) == "" {
-			return nil, IdleStopHistoryResult{}, fmt.Errorf("tenant and environment are required")
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
+		if err != nil {
+			return nil, IdleStopHistoryResult{}, err
 		}
 		entries, err := eruncommon.LoadEnvironmentStopHistory(tenant, environment)
 		if err != nil {
@@ -80,8 +77,8 @@ func idleStopHistoryTool(runtime RuntimeConfig) func(context.Context, *mcp.CallT
 // in-pod monitor's auto-stop records, keeping manual and automatic stops in
 // one history.
 type IdleStopRecordInput struct {
-	Tenant           string `json:"tenant,omitempty" jsonschema:"tenant whose environment should have a stop entry recorded; defaults to the server tenant context"`
-	Environment      string `json:"environment,omitempty" jsonschema:"environment to record against; defaults to the server environment context"`
+	Tenant           string `json:"tenant,omitempty" jsonschema:"tenant whose environment should have a stop entry recorded; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment      string `json:"environment,omitempty" jsonschema:"environment to record against; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	Reason           string `json:"reason,omitempty" jsonschema:"reason text rendered on the History row; empty falls back to a generic 'Manual stop'"`
 	CloudContextName string `json:"cloudContextName,omitempty" jsonschema:"cloud context name the stop targeted; informational"`
 }
@@ -96,10 +93,9 @@ type IdleStopRecordResult struct {
 
 func idleStopRecordTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, IdleStopRecordInput) (*mcp.CallToolResult, IdleStopRecordResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input IdleStopRecordInput) (*mcp.CallToolResult, IdleStopRecordResult, error) {
-		tenant := firstNonEmpty(input.Tenant, runtime.Context.Tenant)
-		environment := firstNonEmpty(input.Environment, runtime.Context.Environment)
-		if strings.TrimSpace(tenant) == "" || strings.TrimSpace(environment) == "" {
-			return nil, IdleStopRecordResult{}, fmt.Errorf("tenant and environment are required")
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
+		if err != nil {
+			return nil, IdleStopRecordResult{}, err
 		}
 		reason := strings.TrimSpace(input.Reason)
 		if reason == "" {

--- a/erun-mcp/job.go
+++ b/erun-mcp/job.go
@@ -3,7 +3,6 @@ package erunmcp
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -19,8 +18,8 @@ import (
 
 // JobStartInput is the work to detach in the environment.
 type JobStartInput struct {
-	Tenant          string            `json:"tenant,omitempty" jsonschema:"tenant whose environment runs the job; defaults to the server tenant context"`
-	Environment     string            `json:"environment,omitempty" jsonschema:"environment to run the job in; defaults to the server environment context"`
+	Tenant          string            `json:"tenant,omitempty" jsonschema:"tenant whose environment runs the job; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment     string            `json:"environment,omitempty" jsonschema:"environment to run the job in; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	Name            string            `json:"name" jsonschema:"what the work is; shown wherever the environment reports as busy"`
 	ID              string            `json:"id,omitempty" jsonschema:"handle to address the job by; defaults to the name, so re-running the same named work keeps one stable handle"`
 	Command         []string          `json:"command,omitempty" jsonschema:"command and arguments to run, as an argv array; pass [\"sh\",\"-c\",\"...\"] only when shell features are genuinely needed. Omit when running an agent"`
@@ -44,7 +43,7 @@ type JobResult struct {
 
 func jobStartTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, JobStartInput) (*mcp.CallToolResult, JobResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input JobStartInput) (*mcp.CallToolResult, JobResult, error) {
-		tenant, environment, err := resolveJobTarget(runtime, input.Tenant, input.Environment)
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
 		if err != nil {
 			return nil, JobResult{}, err
 		}
@@ -92,8 +91,8 @@ func jobStartTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequ
 
 // JobAttachInput registers work the caller started another way.
 type JobAttachInput struct {
-	Tenant          string `json:"tenant,omitempty" jsonschema:"tenant whose environment holds the work; defaults to the server tenant context"`
-	Environment     string `json:"environment,omitempty" jsonschema:"environment holding the work; defaults to the server environment context"`
+	Tenant          string `json:"tenant,omitempty" jsonschema:"tenant whose environment holds the work; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment     string `json:"environment,omitempty" jsonschema:"environment holding the work; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	Name            string `json:"name" jsonschema:"what the work is; shown wherever the environment reports as busy"`
 	ID              string `json:"id,omitempty" jsonschema:"handle to address the job by; defaults to the name. Re-attaching the same id renews the lease"`
 	PID             int    `json:"pid" jsonschema:"process to track; the job resolves against this pid and nothing else, and reports unknown once it is gone because erun never waited on it to observe an exit status"`
@@ -104,7 +103,7 @@ type JobAttachInput struct {
 
 func jobAttachTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, JobAttachInput) (*mcp.CallToolResult, JobResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input JobAttachInput) (*mcp.CallToolResult, JobResult, error) {
-		tenant, environment, err := resolveJobTarget(runtime, input.Tenant, input.Environment)
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
 		if err != nil {
 			return nil, JobResult{}, err
 		}
@@ -134,8 +133,8 @@ func jobAttachTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReq
 
 // JobStatusInput selects one job or every retained job.
 type JobStatusInput struct {
-	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment to query; defaults to the server tenant context"`
-	Environment string `json:"environment,omitempty" jsonschema:"environment to query; defaults to the server environment context"`
+	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment to query; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment string `json:"environment,omitempty" jsonschema:"environment to query; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	ID          string `json:"id,omitempty" jsonschema:"job to report; omit to return every retained job, newest first"`
 }
 
@@ -151,7 +150,7 @@ type JobStatusResult struct {
 
 func jobStatusTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, JobStatusInput) (*mcp.CallToolResult, JobStatusResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input JobStatusInput) (*mcp.CallToolResult, JobStatusResult, error) {
-		tenant, environment, err := resolveJobTarget(runtime, input.Tenant, input.Environment)
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
 		if err != nil {
 			return nil, JobStatusResult{}, err
 		}
@@ -179,15 +178,15 @@ func jobStatusTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReq
 
 // JobAwaitInput bounds one wait.
 type JobAwaitInput struct {
-	Tenant         string `json:"tenant,omitempty" jsonschema:"tenant whose environment holds the job; defaults to the server tenant context"`
-	Environment    string `json:"environment,omitempty" jsonschema:"environment holding the job; defaults to the server environment context"`
+	Tenant         string `json:"tenant,omitempty" jsonschema:"tenant whose environment holds the job; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment    string `json:"environment,omitempty" jsonschema:"environment holding the job; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	ID             string `json:"id" jsonschema:"job to wait for"`
 	TimeoutSeconds int64  `json:"timeoutSeconds,omitempty" jsonschema:"how long to wait before returning still-running; defaults to 30 and may not exceed 600, so no call is ever held open for the work's lifetime"`
 }
 
 func jobAwaitTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, JobAwaitInput) (*mcp.CallToolResult, eruncommon.AwaitEnvironmentJobResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input JobAwaitInput) (*mcp.CallToolResult, eruncommon.AwaitEnvironmentJobResult, error) {
-		tenant, environment, err := resolveJobTarget(runtime, input.Tenant, input.Environment)
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
 		if err != nil {
 			return nil, eruncommon.AwaitEnvironmentJobResult{}, err
 		}
@@ -206,8 +205,8 @@ func jobAwaitTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequ
 
 // JobOutputInput pages through a job's captured output.
 type JobOutputInput struct {
-	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment holds the job; defaults to the server tenant context"`
-	Environment string `json:"environment,omitempty" jsonschema:"environment holding the job; defaults to the server environment context"`
+	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment holds the job; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment string `json:"environment,omitempty" jsonschema:"environment holding the job; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	ID          string `json:"id" jsonschema:"job whose output to read"`
 	Offset      int64  `json:"offset,omitempty" jsonschema:"byte offset to read from; pass back the previous read's nextOffset so a poll continues rather than repeats"`
 	MaxBytes    int64  `json:"maxBytes,omitempty" jsonschema:"most bytes to return in this read; defaults to 65536"`
@@ -215,7 +214,7 @@ type JobOutputInput struct {
 
 func jobOutputTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, JobOutputInput) (*mcp.CallToolResult, eruncommon.EnvironmentJobOutput, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input JobOutputInput) (*mcp.CallToolResult, eruncommon.EnvironmentJobOutput, error) {
-		tenant, environment, err := resolveJobTarget(runtime, input.Tenant, input.Environment)
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
 		if err != nil {
 			return nil, eruncommon.EnvironmentJobOutput{}, err
 		}
@@ -235,8 +234,8 @@ func jobOutputTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReq
 
 // JobCancelInput selects the job to signal.
 type JobCancelInput struct {
-	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment holds the job; defaults to the server tenant context"`
-	Environment string `json:"environment,omitempty" jsonschema:"environment holding the job; defaults to the server environment context"`
+	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment holds the job; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment string `json:"environment,omitempty" jsonschema:"environment holding the job; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	ID          string `json:"id" jsonschema:"job to cancel"`
 	Signal      string `json:"signal,omitempty" jsonschema:"signal to send: TERM (default), INT, HUP, or KILL"`
 	Preview     bool   `json:"preview,omitempty" jsonschema:"when true, resolve and trace the target without signalling it"`
@@ -252,7 +251,7 @@ type JobCancelResult struct {
 
 func jobCancelTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, JobCancelInput) (*mcp.CallToolResult, JobCancelResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input JobCancelInput) (*mcp.CallToolResult, JobCancelResult, error) {
-		tenant, environment, err := resolveJobTarget(runtime, input.Tenant, input.Environment)
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
 		if err != nil {
 			return nil, JobCancelResult{}, err
 		}
@@ -274,13 +273,4 @@ func jobCancelTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReq
 			Trace:       normalizeTraceLines(trace.String()),
 		}, nil
 	}
-}
-
-func resolveJobTarget(runtime RuntimeConfig, tenant, environment string) (string, string, error) {
-	resolvedTenant := firstNonEmpty(tenant, runtime.Context.Tenant)
-	resolvedEnvironment := firstNonEmpty(environment, runtime.Context.Environment)
-	if strings.TrimSpace(resolvedTenant) == "" || strings.TrimSpace(resolvedEnvironment) == "" {
-		return "", "", fmt.Errorf("tenant and environment are required")
-	}
-	return resolvedTenant, resolvedEnvironment, nil
 }

--- a/erun-mcp/job_target_test.go
+++ b/erun-mcp/job_target_test.go
@@ -1,0 +1,68 @@
+package erunmcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Every job, lease and idle tool takes a tenant/environment, and none of them can
+// honour one that names a different environment: the work runs in this pod,
+// against this pod's repo and this pod's erun binary. Before this was enforced,
+// job_start accepted a foreign target, echoed it back in its result, and ran here
+// anyway -- so the caller was handed a handle asserting a target the work never
+// reached (#1195). Each of these must refuse.
+func TestJobLeaseAndIdleToolsRefuseAForeignEnvironment(t *testing.T) {
+	runtime := RuntimeConfig{Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"}}
+	ctx := context.Background()
+
+	// Assert on the REFUSAL, not merely on "an error". Several of these tools fail
+	// for unrelated downstream reasons when handed a foreign target -- a missing
+	// job, an unresolvable repo -- so a bare err != nil passes even against the
+	// unfixed code and proves nothing. The error has to be the one that names both
+	// scopes.
+	_, _, err := jobStartTool(runtime)(ctx, nil, JobStartInput{Tenant: "tenant-b", Environment: "prod", Name: "x"})
+	assertRefusedForeignTarget(t, "job_start", err)
+
+	_, _, err = jobStatusTool(runtime)(ctx, nil, JobStatusInput{Tenant: "tenant-b", Environment: "prod", ID: "x"})
+	assertRefusedForeignTarget(t, "job_status", err)
+
+	_, _, err = jobAwaitTool(runtime)(ctx, nil, JobAwaitInput{Tenant: "tenant-b", Environment: "prod", ID: "x"})
+	assertRefusedForeignTarget(t, "job_await", err)
+
+	_, _, err = activityLeaseTakeTool(runtime)(ctx, nil, ActivityLeaseTakeInput{Tenant: "tenant-b", Environment: "prod", Name: "x"})
+	assertRefusedForeignTarget(t, "activity_lease_take", err)
+
+	_, _, err = idleStopHistoryTool(runtime)(ctx, nil, IdleStopHistoryInput{Tenant: "tenant-b", Environment: "prod"})
+	assertRefusedForeignTarget(t, "idle_stop_history", err)
+}
+
+// assertRefusedForeignTarget insists the tool refused BECAUSE the target is not
+// this server's, naming the server's scope and the requested one. Any other
+// error -- including a plausible downstream one -- is a failure, because it means
+// the tool went on to act rather than refusing up front.
+func assertRefusedForeignTarget(t *testing.T, tool string, err error) {
+	t.Helper()
+	if err == nil {
+		t.Errorf("%s accepted a foreign environment instead of refusing it", tool)
+		return
+	}
+	if !strings.Contains(err.Error(), "tenant-a/dev") || !strings.Contains(err.Error(), "tenant-b/prod") {
+		t.Errorf("%s failed for the wrong reason -- want a refusal naming tenant-a/dev and tenant-b/prod, got: %v", tool, err)
+	}
+}
+
+// Restating the server's own scope, or omitting it, must keep working -- the
+// arguments are how a caller disambiguates, and refusing those would break every
+// existing caller.
+func TestJobToolsAcceptTheirOwnScope(t *testing.T) {
+	runtime := RuntimeConfig{Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"}}
+	ctx := context.Background()
+
+	if _, _, err := jobStatusTool(runtime)(ctx, nil, JobStatusInput{Tenant: "tenant-a", Environment: "dev"}); err != nil {
+		t.Errorf("job_status refused its own scope: %v", err)
+	}
+	if _, _, err := jobStatusTool(runtime)(ctx, nil, JobStatusInput{}); err != nil {
+		t.Errorf("job_status refused an omitted scope: %v", err)
+	}
+}

--- a/erun-mcp/local_target_test.go
+++ b/erun-mcp/local_target_test.go
@@ -1,0 +1,71 @@
+package erunmcp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveLocalTargetRefusesAForeignEnvironment(t *testing.T) {
+	runtime := RuntimeConfig{Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"}}
+
+	for _, tc := range []struct {
+		name        string
+		tenant      string
+		environment string
+	}{
+		{"foreign tenant", "tenant-b", "dev"},
+		{"foreign environment", "tenant-a", "prod"},
+		{"foreign both", "tenant-b", "prod"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := resolveLocalTarget(runtime, tc.tenant, tc.environment)
+			if err == nil {
+				t.Fatalf("expected %s/%s to be refused by a server serving tenant-a/dev", tc.tenant, tc.environment)
+			}
+			// The message must name both scopes, or the caller cannot work out which
+			// edge to call instead.
+			if !strings.Contains(err.Error(), "tenant-a/dev") {
+				t.Errorf("error should name the server's own scope, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.tenant+"/"+tc.environment) {
+				t.Errorf("error should name the requested scope, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestResolveLocalTargetAcceptsItsOwnScope(t *testing.T) {
+	runtime := RuntimeConfig{Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"}}
+
+	for _, tc := range []struct {
+		name        string
+		tenant      string
+		environment string
+	}{
+		{"omitted", "", ""},
+		{"restated", "tenant-a", "dev"},
+		{"tenant only", "tenant-a", ""},
+		{"environment only", "", "dev"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tenant, environment, err := resolveLocalTarget(runtime, tc.tenant, tc.environment)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tenant != "tenant-a" || environment != "dev" {
+				t.Errorf("got %s/%s, want tenant-a/dev", tenant, environment)
+			}
+		})
+	}
+}
+
+// A server with no scope of its own still needs both values from the caller.
+func TestResolveLocalTargetRequiresBothWhenTheServerHasNoScope(t *testing.T) {
+	runtime := RuntimeConfig{}
+	if _, _, err := resolveLocalTarget(runtime, "", ""); err == nil {
+		t.Error("expected an error when neither the server nor the caller names a target")
+	}
+	if _, _, err := resolveLocalTarget(runtime, "tenant-a", ""); err == nil {
+		t.Error("expected an error when the environment is missing entirely")
+	}
+}

--- a/erun-mcp/runtime.go
+++ b/erun-mcp/runtime.go
@@ -2,6 +2,7 @@ package erunmcp
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -177,6 +178,35 @@ func runtimeFindProjectRoot(runtime RuntimeContext, workDir string) (string, str
 		return firstNonEmpty(strings.TrimSpace(runtime.Tenant), filepath.Base(repoPath)), filepath.Clean(repoPath), nil
 	}
 	return eruncommon.FindProjectRootFromDir(workDir)
+}
+
+// resolveLocalTarget resolves the tenant/environment a tool acts on, and refuses
+// a target this server cannot reach. An MCP server serves exactly one
+// environment: its tools run in this pod, against this pod's repo and this pod's
+// erun binary, so an explicit tenant/environment naming a DIFFERENT environment
+// can never be honoured. Accepting one and acting locally anyway is worse than
+// refusing it, because the result then asserts a target the work never reached
+// and the caller is left holding written evidence that it worked (#1195).
+func resolveLocalTarget(runtime RuntimeConfig, tenant, environment string) (string, string, error) {
+	serverTenant := strings.TrimSpace(runtime.Context.Tenant)
+	serverEnvironment := strings.TrimSpace(runtime.Context.Environment)
+	requestedTenant := strings.TrimSpace(tenant)
+	requestedEnvironment := strings.TrimSpace(environment)
+	tenantMismatch := requestedTenant != "" && serverTenant != "" && requestedTenant != serverTenant
+	environmentMismatch := requestedEnvironment != "" && serverEnvironment != "" && requestedEnvironment != serverEnvironment
+	if tenantMismatch || environmentMismatch {
+		return "", "", fmt.Errorf(
+			"this MCP server serves %s/%s and runs every tool there, so it cannot act on %s/%s: call that environment's own MCP edge instead",
+			serverTenant, serverEnvironment,
+			firstNonEmpty(requestedTenant, serverTenant), firstNonEmpty(requestedEnvironment, serverEnvironment),
+		)
+	}
+	resolvedTenant := firstNonEmpty(requestedTenant, serverTenant)
+	resolvedEnvironment := firstNonEmpty(requestedEnvironment, serverEnvironment)
+	if resolvedTenant == "" || resolvedEnvironment == "" {
+		return "", "", fmt.Errorf("tenant and environment are required")
+	}
+	return resolvedTenant, resolvedEnvironment, nil
 }
 
 func firstNonEmpty(values ...string) string {


### PR DESCRIPTION
`job_start` accepted a `tenant`/`environment` naming a different environment,
echoed it back, and ran the job locally anyway.

**Why it happened.** The target was only ever a label:

```go
tenant, environment, err := resolveJobTarget(runtime, input.Tenant, input.Environment)  // caller's values
dir, err = runtimeRepoPath(runtime.Context)                                            // this pod
supervisor, err := eruncommon.ResolveErunExecutable()                                  // this pod
```

Reads were routed by the label while execution was not — which is why, against
unfixed code, `job_status` answers `no job "x" in tenant-b/prod` for work that ran
in `tenant-a/dev`.

**The fix.** An MCP server serves exactly one environment, so a foreign target can
never be honoured. `resolveLocalTarget` refuses it, naming both scopes so the
caller knows which edge to call. Omitting the arguments still accepts the server's
scope; restating that scope still works.

**The whole family shared the defect** — two near-identical resolvers plus four
inline copies of the same `firstNonEmpty` pair across `job.go`,
`activity_lease.go`, `idle_stop.go`, `idle.go`. All now share one helper.

## Proof the tests fail without the fix

The tool-level test is kept separate from the helper test precisely so it compiles
against unfixed code. Stashing only the production change:

```
job_target_test.go:25: job_start failed for the wrong reason -- want a refusal naming
                       tenant-a/dev and tenant-b/prod, got: job command is required
job_target_test.go:28: job_status failed for the wrong reason -- ... got: no job "x" in tenant-b/prod
job_target_test.go:31: job_await failed for the wrong reason -- ... got: no job "x" in tenant-b/prod
job_target_test.go:34: activity_lease_take accepted a foreign environment instead of refusing it
job_target_test.go:37: idle_stop_history accepted a foreign environment instead of refusing it
```

Worth noting for reviewers: my **first** version of this test asserted only
`err != nil`, and three of the five assertions **passed against unfixed code** —
the tools failed for unrelated downstream reasons. The test now asserts on the
refusal message, which is what makes it a real regression test.

## Docs

- `erun-docs/docs/mcp/overview.md` — new "A server acts only on its own
  environment" note (Operator + Agent facing; the surrounding section already
  covers endpoints and clients).
- 26 tool-schema descriptions corrected. They said only "defaults to the server
  environment context"; `job_start`'s read `environment to run the job in`, which
  invited exactly this misuse. The schema is the agent-facing contract, so this is
  the load-bearing half of the docs change.

## Gates

`erun-mcp` `go test ./...` green · `golangci-lint run ./...` **0 issues** ·
`erun-integration go test ./...` green (64.5s) · `erun-docs` `yarn build` clean.

Closes #1195