### PR TITLE
Pin the executable seam in the MCP-config skip test

### DIFF
--- a/erun-ui/orchestrator_mcp_test.go
+++ b/erun-ui/orchestrator_mcp_test.go
@@ -467,6 +467,14 @@ func TestOrchestratorMCPPartialNoticeNamesWhatIsMissing(t *testing.T) {
 // on ambient store state and be flaky, which is worse than not testing it here
 // -- the builder tests above cover the partial split with an injected resolver.
 func TestWriteOrchestratorMCPConfigCarriesSkipsEvenWhenNothingWired(t *testing.T) {
+	// Pin the executable seam. Without it this test only passes where an erun
+	// binary happens to sit on PATH: writeOrchestratorMCPConfig resolves the
+	// executable BEFORE it reaches the no-port path, so on a host without one it
+	// returns errOrchestratorMCPExecutable and the assertion below never sees the
+	// skips it exists to check. The build's own test stage has no erun on PATH,
+	// which is where that surfaced.
+	t.Setenv("ERUN_ERUN_BIN", filepath.Join(t.TempDir(), "erun"))
+
 	app := orchestratorTestApp(t)
 	defer app.shutdown(context.Background())
 


### PR DESCRIPTION
`erun build` failed on `make check` → `test-erun-ui`:

```
erun-app: write orchestrator MCP config for agent: the erun executable could not be
resolved: the erun executable was not found beside this program or on PATH
--- FAIL: TestWriteOrchestratorMCPConfigCarriesSkipsEvenWhenNothingWired
```

`writeOrchestratorMCPConfig` resolves the executable **before** it reaches the
no-port path, so without an `erun` on PATH it returns
`errOrchestratorMCPExecutable` and the assertion never sees the skips the test
exists to check. The Dockerfile's test stage has no `erun` on PATH — so this was
red in the one gate that runs tests the way a release does, while passing in any
pod that happens to have the binary.

Reproduced deterministically both ways in a single environment:

| condition | result |
|---|---|
| `erun` on PATH | `ok github.com/sophium/erun/erun-ui 14.083s` |
| `PATH=/usr/local/go/bin:/usr/bin:/bin` | `--- FAIL: TestWriteOrchestratorMCPConfigCarriesSkipsEvenWhenNothingWired` |

After the fix, both are `ok`, and `erun build` completes: **12 images in 2 waves,
8 charts packaged, built in 2m2s**.

The fix follows the convention already in this file — `orchestrator_mcp_test.go:249`
and `:413` both pin `ERUN_ERUN_BIN` via `t.Setenv` for the same reason. This test
omitted it. Its comment also claimed it was "deterministic on purpose" while
depending on ambient PATH, which is why it read as safe; the comment now states
what it pins.

Mine to own: I added this test in #1185/#1192 and verified it by running the
erun-ui suite inside a pod where `erun` *is* on PATH — an environment that masked
the defect — and reported the gates green. The authoritative gate is the build.