### PR TITLE
Point the tenant dashboard's API log at the API deployment, not the runtime

### DIFF
--- a/erun-cli/cmd/api_port_forward.go
+++ b/erun-cli/cmd/api_port_forward.go
@@ -35,7 +35,7 @@ func ensureAPIPortForward(ctx common.Context, result common.OpenResult) (int, er
 		LocalPort:         localPort,
 	}
 
-	apiDeployment := common.TenantResourcePrefix(result.Tenant) + "-api"
+	apiDeployment := common.APIDeploymentName(result.Tenant)
 	checkArgs := kubectlAPIDeploymentCheckArgs(expectedState.KubernetesContext, expectedState.Namespace, apiDeployment)
 	ctx.TraceCommand("", "kubectl", checkArgs...)
 
@@ -86,7 +86,7 @@ func ensureAPIPortForwardDryRun(ctx common.Context, result common.OpenResult, lo
 	if previewed, port := previewAdoptOrConflict(ctx, "api", localPort, args, canReachLocalAPIEndpoint); previewed {
 		return port, nil
 	}
-	apiDeployment := common.TenantResourcePrefix(result.Tenant) + "-api"
+	apiDeployment := common.APIDeploymentName(result.Tenant)
 	ctx.Trace(fmt.Sprintf("open: port-forwarding service/%s if the check above finds the deployment present", apiDeployment))
 	return localPort, nil
 }
@@ -197,7 +197,7 @@ func kubectlAPIPortForwardArgs(result common.OpenResult, localPort int) []string
 	}
 	args = append(args,
 		"port-forward",
-		fmt.Sprintf("service/%s-api", common.TenantResourcePrefix(result.Tenant)),
+		fmt.Sprintf("service/%s", common.APIDeploymentName(result.Tenant)),
 		// The API service is a standalone component chart, published on the
 		// canonical APIServicePort in every namespace; only the local side is
 		// per-env, so concurrent forwards for different environments don't collide

--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -678,6 +678,16 @@ func TenantResourcePrefix(tenant string) string {
 	return strings.TrimSuffix(RuntimeReleaseName(tenant), "-devops")
 }
 
+// APIDeploymentName is the erun-backend-api chart's Deployment/Service resource
+// name (<prefix>-api, per TenantResourcePrefix). It is templated from
+// `.Values.tenant`, not from the chart's Helm release name
+// (publishedComponentReleaseName's `<tenant>-backend-api`), so callers that
+// need to address the running pod or service must derive it from here rather
+// than from the release name.
+func APIDeploymentName(tenant string) string {
+	return TenantResourcePrefix(tenant) + "-api"
+}
+
 func kubectlDeploymentWaitArgs(req ShellLaunchParams) []string {
 	args := kubectlTargetArgs(req)
 	args = append(args, "wait", "--for=condition=Available", "--timeout", defaultShellLaunchWaitTimeout, "deployment/"+RuntimeReleaseName(req.Tenant))

--- a/erun-ui/api_log.go
+++ b/erun-ui/api_log.go
@@ -24,10 +24,14 @@ func loadAPILog(ctx context.Context, input uiTenantDashboardInput) (string, erro
 
 func loadAPILogFromKubernetes(ctx context.Context, kubernetesContext, tenant, environment string) (string, error) {
 	namespace := eruncommon.KubernetesNamespaceName(tenant, environment)
+	// A selector (rather than deployment/<name>) names which replica the log
+	// came from instead of quietly picking one; the API Deployment's
+	// Recreate strategy means a rollout transiently has two pods matching.
 	return kubectlText(ctx, kubernetesContext,
 		"--namespace", namespace,
 		"logs",
-		"deployment/"+eruncommon.RuntimeReleaseName(tenant),
+		"-l", "app="+eruncommon.APIDeploymentName(tenant),
+		"--prefix",
 		"-c", "erun-backend-api",
 		"--tail", "400",
 	)

--- a/erun-ui/api_log_test.go
+++ b/erun-ui/api_log_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type fakeRawInput struct {
+	Command []string `json:"command"`
+}
+
+type fakeRawOutput struct {
+	Stdout string `json:"stdout"`
+	Stderr string `json:"stderr"`
+}
+
+// TestLoadAPILogFromMCPTargetsAPIDeployment pins the MCP `raw` fallback (used
+// when the desktop has no local Kubernetes context) to the erun-backend-api
+// chart's own Deployment/Service name. Before #1197's fix this shelled out to
+// "deployment/${ERUN_TENANT:-erun}-devops" -- the runtime Deployment, which
+// never runs an erun-backend-api container -- so the API log tab could never
+// load through this path either.
+func TestLoadAPILogFromMCPTargetsAPIDeployment(t *testing.T) {
+	var capturedCommand []string
+	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+		server := mcp.NewServer(&mcp.Implementation{Name: "fake-runtime", Version: "v0.0.1"}, nil)
+		mcp.AddTool(server, &mcp.Tool{Name: "raw"}, func(_ context.Context, _ *mcp.CallToolRequest, input fakeRawInput) (*mcp.CallToolResult, fakeRawOutput, error) {
+			capturedCommand = input.Command
+			return nil, fakeRawOutput{Stdout: "api log from pod\n"}, nil
+		})
+		return server
+	}, &mcp.StreamableHTTPOptions{JSONResponse: true})
+
+	httpServer := httptest.NewServer(handler)
+	t.Cleanup(httpServer.Close)
+
+	log, err := loadAPILogFromMCP(context.Background(), httpServer.URL, "")
+	if err != nil {
+		t.Fatalf("loadAPILogFromMCP failed: %v", err)
+	}
+	if log != "api log from pod" {
+		t.Fatalf("unexpected log: %q", log)
+	}
+
+	if len(capturedCommand) != 3 || capturedCommand[0] != "sh" || capturedCommand[1] != "-lc" {
+		t.Fatalf("unexpected raw command: %+v", capturedCommand)
+	}
+	script := capturedCommand[2]
+	if !strings.Contains(script, `-l app="${ERUN_TENANT:-erun}-api"`) {
+		t.Fatalf("script does not select the API chart's deployment: %s", script)
+	}
+	if strings.Contains(script, "-devops") {
+		t.Fatalf("script still targets the runtime deployment: %s", script)
+	}
+}

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -1866,7 +1866,10 @@ func TestLoadTenantDashboardReturnsAPILogWhenAPIAuthFails(t *testing.T) {
 func TestLoadAPILogPrefersKubernetesLogs(t *testing.T) {
 	t.Setenv("PATH", fakeKubectl(t, func(args []string) (string, int) {
 		got := strings.Join(args, "\n")
-		want := "--context\ncluster-dev\n--namespace\nfrs-prod\nlogs\ndeployment/frs-devops\n-c\nerun-backend-api\n--tail\n400"
+		// The erun-backend-api chart's Deployment/Service is <tenant>-api
+		// (eruncommon.APIDeploymentName), not the runtime's <tenant>-devops
+		// Deployment: the erun-backend-api container never exists there (#1197).
+		want := "--context\ncluster-dev\n--namespace\nfrs-prod\nlogs\n-l\napp=frs-api\n--prefix\n-c\nerun-backend-api\n--tail\n400"
 		if got != want {
 			t.Fatalf("unexpected kubectl args:\n%s", got)
 		}
@@ -1894,7 +1897,7 @@ func fakeKubectl(t *testing.T, handler func([]string) (string, int)) string {
 	outputPath := filepath.Join(dir, "kubectl.output")
 	exitPath := filepath.Join(dir, "kubectl.exit")
 	writeFakeKubectlStub(t, dir, argsPath, outputPath, exitPath)
-	output, code := handler([]string{"--context", "cluster-dev", "--namespace", "frs-prod", "logs", "deployment/frs-devops", "-c", "erun-backend-api", "--tail", "400"})
+	output, code := handler([]string{"--context", "cluster-dev", "--namespace", "frs-prod", "logs", "-l", "app=frs-api", "--prefix", "-c", "erun-backend-api", "--tail", "400"})
 	if err := os.WriteFile(outputPath, []byte(output), 0o644); err != nil {
 		t.Fatalf("write fake kubectl output failed: %v", err)
 	}

--- a/erun-ui/diff_mcp.go
+++ b/erun-ui/diff_mcp.go
@@ -198,6 +198,16 @@ func loadIdleStatusFromMCP(ctx context.Context, endpoint, bearer string) (erunco
 	return status, nil
 }
 
+// apiLogMCPRawCommand mirrors loadAPILogFromKubernetes's kubectl invocation
+// for the MCP `raw` fallback (used when the desktop has no local Kubernetes
+// context): the runtime pod resolves its own namespace since the caller has
+// no --namespace to pass in from outside. The target is the erun-backend-api
+// chart's Deployment/Service name (<tenant>-api, per
+// eruncommon.APIDeploymentName) selected with -l/--prefix rather than
+// deployment/<name>, so a transient multi-pod rollout names which replica the
+// log came from instead of kubectl quietly picking one.
+const apiLogMCPRawCommand = `namespace=${ERUN_NAMESPACE:-}; if [ -z "$namespace" ] && [ -r /var/run/secrets/kubernetes.io/serviceaccount/namespace ]; then namespace=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace); fi; kubectl --context "${ERUN_KUBERNETES_CONTEXT:-in-cluster}" --namespace "$namespace" logs -l app="${ERUN_TENANT:-erun}-api" --prefix -c erun-backend-api --tail 400`
+
 func loadAPILogFromMCP(ctx context.Context, endpoint, bearer string) (string, error) {
 	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
 	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, false), nil)
@@ -211,7 +221,7 @@ func loadAPILogFromMCP(ctx context.Context, endpoint, bearer string) (string, er
 	result, err := session.CallTool(ctx, &mcp.CallToolParams{
 		Name: "raw",
 		Arguments: map[string]any{
-			"command": []string{"sh", "-lc", "namespace=${ERUN_NAMESPACE:-}; if [ -z \"$namespace\" ] && [ -r /var/run/secrets/kubernetes.io/serviceaccount/namespace ]; then namespace=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace); fi; kubectl --context \"${ERUN_KUBERNETES_CONTEXT:-in-cluster}\" --namespace \"$namespace\" logs \"deployment/${ERUN_TENANT:-erun}-devops\" -c erun-backend-api --tail 400"},
+			"command": []string{"sh", "-lc", apiLogMCPRawCommand},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Closes #1197

## What was actually wrong

Confirmed against the code: both API log loaders shelled out to `deployment/<tenant>-devops` (`eruncommon.RuntimeReleaseName`), the agent runtime Deployment, asking it for an `erun-backend-api` container — a container that only exists in the `erun-backend-api` chart's own Deployment. Exactly as the issue describes; every reproduction step checked out.

One correction to the issue's suggested fix: it proposed reusing `publishedComponentReleaseName(tenant, "erun-backend-api")`, which returns `<tenant>-backend-api` — the chart's **Helm release name**. That is not the same string as the chart's **Deployment/Service resource name**, which the chart templates from `.Values.tenant` as `<tenant>-api` (`erun-devops/k8s/erun-backend-api/templates/api.yaml:507`), independent of the release it was installed under. Using the release name would have "fixed" the bug into a different wrong deployment. `erun-cli/cmd/api_port_forward.go` already derives the correct resource name for its own API port-forward as `TenantResourcePrefix(tenant) + "-api"` — I extracted that into a shared `eruncommon.APIDeploymentName(tenant)` and pointed both erun-ui loaders (and the three existing api_port_forward.go call sites) at it, so the chart's naming and every caller's expectation of it live in one place.

Namespace (issue point 3): already correct on both paths — `KubernetesNamespaceName(tenant, environment)` is exactly where `resolvePublishedComponentDeploySpec` deploys the API chart (`erun-common/deploy.go:2009`). No change needed there.

Pod selection (issue point 4): both loaders now use `-l app=<deployment> --prefix` instead of `deployment/<name>`, so a rollout that transiently shows two pods (the chart's `Recreate` strategy) names which replica a line came from instead of `kubectl` quietly picking one.

Deferred, not fixed here: the issue's "worth deciding" section (making the MCP route primary, giving it a typed tool instead of a hand-assembled `kubectl` argv in a `raw` `sh -lc` string) is a larger design change, out of scope for this bug fix. I did pull the MCP fallback's shell string into a named `apiLogMCPRawCommand` constant so it's directly testable and reviewable, without changing its shape.

## Changes

- `erun-common/open.go`: add `APIDeploymentName(tenant)` beside `TenantResourcePrefix`.
- `erun-ui/api_log.go`: `loadAPILogFromKubernetes` targets `APIDeploymentName` via `-l`/`--prefix` instead of `deployment/<runtime>`.
- `erun-ui/diff_mcp.go`: the MCP `raw` fallback's shell command does the same; extracted to `apiLogMCPRawCommand`.
- `erun-cli/cmd/api_port_forward.go`: reuse `APIDeploymentName` at its three existing call sites instead of concatenating `TenantResourcePrefix(...) + "-api"` locally (identical output, one less place this can drift).

## Tests — proved failing before the fix

- `erun-ui/app_test.go` `TestLoadAPILogPrefersKubernetesLogs` previously asserted the **buggy** kubectl args (`deployment/frs-devops`) — it was passing *because* it encoded the bug. Updated it to assert the correct args (`-l app=frs-api --prefix`).
- `erun-ui/api_log_test.go` `TestLoadAPILogFromMCPTargetsAPIDeployment` (new): spins up a real in-process MCP `StreamableHTTPHandler` with a fake `raw` tool, calls `loadAPILogFromMCP`, and asserts the captured shell script targets `${ERUN_TENANT:-erun}-api` and does not contain `-devops`.

To confirm both fail against unfixed code: I `git stash`ed the source fix (keeping the new test file, since it's untracked and stash leaves untracked files alone) and reran `go test -run ...`:
- `TestLoadAPILogFromMCPTargetsAPIDeployment` **failed** — captured script still said `deployment/${ERUN_TENANT:-erun}-devops`.
- `TestLoadAPILogPrefersKubernetesLogs` **passed** in that state, because `git stash` also reverted the test file's assertion back to the original (bug-matching) expectation — i.e. the pre-fix repo's own test suite was green precisely because that test asserted the bug. Restoring the fix (`git stash pop`) makes both pass.

## Gates

- `go build ./...` and `go test ./...` green in `erun-common`, `erun-cli`, `erun-ui` — both normal and with `PATH=/usr/local/go/bin:/usr/bin:/bin` (no ambient `erun`/other tools on PATH; the new MCP test spins up its own in-process HTTP server and the kubectl test writes its own fake binary to a temp dir, so neither depends on ambient host state).
- `cd erun-integration && go test ./...` green.
- `golangci-lint run ./...` clean (0 issues) in `erun-common`, `erun-cli`, `erun-ui`.
- No `//nolint`, no skips, no threshold changes.

## erun-ui AGENTS.md checklists

**UX Impact Review:**
1. Affected path: Tenant dashboard → API log tab data loading.
2. User-visible sequence: unchanged rendering — `TenantDashboardView.tsx` is untouched; only which command populates `dashboard.APILog`/`APILogError` changes (previously always the `container ... is not valid for pod ...` error; now the real log, or a real error, from the actual API pod).
3–7: no `AppState` shape or affordance changes; no new field/button/dialog.
8. Playwright coverage: not added. `LoadTenantDashboard` requires a live cloud-provider bearer token exchange *and* either a live Kubernetes context or a live MCP session backed by a real runtime pod (`erun-ui/tenant_dashboard.go:34,44-55`) — the exact "real runtime pod" / "stopped EC2 cloud context" live-infrastructure exception AGENTS.md names. The dashboard has no existing Playwright spec today for this reason, predating this PR; this fix touches zero frontend files and adds no new observable UI state, so there's no new surface for a spec to reach. The corrected branch is locked down by the two Go tests above.

**Docs plan:** none needed — pure bug fix restoring already-existing, already-documented dashboard behavior; no new command, flag, or public contract.

## Not verified

Did not verify against a real Kubernetes cluster / real `erun-backend-api` pod (no live cluster available in this environment) — the fix is proven via the unit tests above, which pin the exact `kubectl`/MCP arguments issued, plus the pre-existing `erun-cli/cmd/api_port_forward.go` precedent that already reaches the same `<tenant>-api` resource successfully for port-forwarding.