### PR TITLE
Add a read API and desktop view for the audit trail

### DIFF
--- a/erun-backend/erun-backend-api/audit_events_e2e_test.go
+++ b/erun-backend/erun-backend-api/audit_events_e2e_test.go
@@ -1,0 +1,394 @@
+package backendapi
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+)
+
+// Row-level security is the entire authorization boundary for reading audit
+// events, so it is exercised against a real migrated PostgreSQL rather than a
+// fake that would just agree with itself about which rows a tenant may see.
+func auditEventDatabase(t *testing.T) (*repository.AuditEventRepository, *sql.DB) {
+	t.Helper()
+	databaseURL := os.Getenv("ERUN_E2E_AUDIT_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("opt-in: set ERUN_E2E_AUDIT_DATABASE_URL to a migrated PostgreSQL")
+	}
+	db, err := sql.Open("pgx", databaseURL)
+	mustNoErr(t, err, "open db")
+	t.Cleanup(func() { _ = db.Close() })
+	return repository.NewAuditEventRepository(repository.NewTxManager(db, repository.DialectPostgres)), db
+}
+
+// seedAuditTenant creates a tenant and one user of its own for the scenario,
+// so a run never disturbs rows another tenant owns and RLS is actually
+// exercised. audit_events.erun_user_id foreign-keys (tenant_id, user_id), so a
+// user row is required before an audit event can be logged for it.
+func seedAuditTenant(t *testing.T, db *sql.DB) (tenantID string, userID string) {
+	t.Helper()
+	stamp := time.Now().Format("20060102150405.000000")
+	err := db.QueryRow(
+		`INSERT INTO tenants (name, type) VALUES ($1, 'COMPANY') RETURNING tenant_id`,
+		"audit-e2e-"+stamp,
+	).Scan(&tenantID)
+	mustNoErr(t, err, "seed tenant")
+	err = db.QueryRow(
+		`INSERT INTO users (tenant_id, username) VALUES ($1, $2) RETURNING user_id`,
+		tenantID, "audit-e2e-user-"+stamp,
+	).Scan(&userID)
+	mustNoErr(t, err, "seed user")
+	t.Cleanup(func() {
+		if _, err := db.Exec(`DELETE FROM audit_events WHERE tenant_id = $1`, tenantID); err != nil {
+			t.Logf("clearing the test tenant's audit events: %v", err)
+		}
+		if _, err := db.Exec(`DELETE FROM users WHERE tenant_id = $1`, tenantID); err != nil {
+			t.Logf("clearing the test tenant's users: %v", err)
+		}
+		if _, err := db.Exec(`DELETE FROM tenants WHERE tenant_id = $1`, tenantID); err != nil {
+			t.Logf("clearing the test tenant: %v", err)
+		}
+	})
+	return tenantID, userID
+}
+
+// seedAuditUser adds a second user to an already-seeded tenant, for scenarios
+// that need two distinct erun_user_id values within one tenant.
+func seedAuditUser(t *testing.T, db *sql.DB, tenantID string) string {
+	t.Helper()
+	var userID string
+	err := db.QueryRow(
+		`INSERT INTO users (tenant_id, username) VALUES ($1, $2) RETURNING user_id`,
+		tenantID, "audit-e2e-user-"+time.Now().Format("20060102150405.000000000"),
+	).Scan(&userID)
+	mustNoErr(t, err, "seed second user")
+	return userID
+}
+
+func auditContext(tenantID, userID string) context.Context {
+	return security.WithContext(context.Background(), security.Context{
+		TenantID: tenantID, TenantType: "COMPANY", ErunUserID: userID,
+	})
+}
+
+func logAuditEvent(t *testing.T, repo *repository.AuditEventRepository, ctx context.Context, event model.AuditEvent) {
+	t.Helper()
+	mustNoErr(t, repo.LogAuditEvent(ctx, event), "log audit event")
+}
+
+// TestAuditEventListIsScopedByTenant is the invariant the whole read API rests
+// on: a caller from one tenant must never see another tenant's audit rows,
+// even though both are simple SELECTs behind the same endpoint.
+func TestAuditEventListIsScopedByTenant(t *testing.T) {
+	repo, db := auditEventDatabase(t)
+	tenantA, userA := seedAuditTenant(t, db)
+	ctxA := auditContext(tenantA, userA)
+	logAuditEvent(t, repo, ctxA, model.AuditEvent{
+		TenantID: tenantA, ErunUserID: userA, ExternalUserID: "ext-a", ExternalIssuerID: "https://issuer.example/a",
+		Type: model.AuditEventTypeAPI, APIMethod: "GET", APIPath: "/v1/reviews",
+	})
+
+	tenantB, userB := seedAuditTenant(t, db)
+	ctxB := auditContext(tenantB, userB)
+	logAuditEvent(t, repo, ctxB, model.AuditEvent{
+		TenantID: tenantB, ErunUserID: userB, ExternalUserID: "ext-b", ExternalIssuerID: "https://issuer.example/b",
+		Type: model.AuditEventTypeAPI, APIMethod: "GET", APIPath: "/v1/reviews",
+	})
+
+	pageA, err := repo.List(ctxA, repository.AuditEventFilter{})
+	mustNoErr(t, err, "list tenant A")
+	if len(pageA.Events) != 1 || pageA.Events[0].TenantID != tenantA {
+		t.Fatalf("tenant A saw %+v, want exactly its own one event", pageA.Events)
+	}
+
+	pageB, err := repo.List(ctxB, repository.AuditEventFilter{})
+	mustNoErr(t, err, "list tenant B")
+	if len(pageB.Events) != 1 || pageB.Events[0].TenantID != tenantB {
+		t.Fatalf("tenant B saw %+v, want exactly its own one event", pageB.Events)
+	}
+	if pageA.Events[0].AuditEventID == pageB.Events[0].AuditEventID {
+		t.Fatal("both tenants resolved to the same audit event id")
+	}
+}
+
+// TestAuditEventListNeverExposesParameterPayloads proves the read path holds
+// even when a row does carry recorded arguments: an MCP tool such as
+// cloud_inject_aws_credentials takes credentials as arguments, and this is
+// where a future MCP audit caller would have serialized them.
+func TestAuditEventListNeverExposesParameterPayloads(t *testing.T) {
+	repo, db := auditEventDatabase(t)
+	tenantID, userID := seedAuditTenant(t, db)
+	ctx := auditContext(tenantID, userID)
+	logAuditEvent(t, repo, ctx, model.AuditEvent{
+		TenantID: tenantID, ErunUserID: userID, ExternalUserID: "ext", ExternalIssuerID: "https://issuer.example",
+		Type: model.AuditEventTypeMCP, MCPTool: "cloud_inject_aws_credentials",
+		MCPToolParameters: `{"accessKeyId":"AKIAEXAMPLE","secretAccessKey":"super-secret"}`,
+	})
+
+	page, err := repo.List(ctx, repository.AuditEventFilter{})
+	mustNoErr(t, err, "list")
+	if len(page.Events) != 1 {
+		t.Fatalf("got %d events, want 1", len(page.Events))
+	}
+	event := page.Events[0]
+	if event.MCPTool != "cloud_inject_aws_credentials" {
+		t.Fatalf("mcpTool = %q, want the tool name preserved", event.MCPTool)
+	}
+	if event.MCPToolParameters != "" {
+		t.Fatalf("MCPToolParameters leaked through List: %q", event.MCPToolParameters)
+	}
+}
+
+// TestAuditEventListFiltersMatchTheirIndexedColumns exercises the filters the
+// three audit_events indexes exist for: erun_user_id and (api_method, api_path).
+func TestAuditEventListFiltersMatchTheirIndexedColumns(t *testing.T) {
+	repo, db := auditEventDatabase(t)
+	tenantID, userA := seedAuditTenant(t, db)
+	userB := seedAuditUser(t, db, tenantID)
+	ctxA := auditContext(tenantID, userA)
+	ctxB := auditContext(tenantID, userB)
+
+	logAuditEvent(t, repo, ctxA, model.AuditEvent{
+		TenantID: tenantID, ErunUserID: userA, ExternalUserID: "a", ExternalIssuerID: "https://issuer.example",
+		Type: model.AuditEventTypeAPI, APIMethod: "GET", APIPath: "/v1/reviews",
+	})
+	logAuditEvent(t, repo, ctxB, model.AuditEvent{
+		TenantID: tenantID, ErunUserID: userB, ExternalUserID: "b", ExternalIssuerID: "https://issuer.example",
+		Type: model.AuditEventTypeAPI, APIMethod: "POST", APIPath: "/v1/reviews",
+	})
+	logAuditEvent(t, repo, ctxB, model.AuditEvent{
+		TenantID: tenantID, ErunUserID: userB, ExternalUserID: "b", ExternalIssuerID: "https://issuer.example",
+		Type: model.AuditEventTypeCLI, CLICommand: "erun build",
+	})
+
+	byUser, err := repo.List(ctxA, repository.AuditEventFilter{ErunUserID: userA})
+	mustNoErr(t, err, "list by erun user id")
+	if len(byUser.Events) != 1 || byUser.Events[0].ErunUserID != userA {
+		t.Fatalf("filter by erunUserId = %+v, want exactly userA's event", byUser.Events)
+	}
+
+	byMethodPath, err := repo.List(ctxA, repository.AuditEventFilter{APIMethod: "POST", APIPath: "/v1/reviews"})
+	mustNoErr(t, err, "list by api method/path")
+	if len(byMethodPath.Events) != 1 || byMethodPath.Events[0].ErunUserID != userB {
+		t.Fatalf("filter by apiMethod/apiPath = %+v, want exactly the POST event", byMethodPath.Events)
+	}
+
+	byType, err := repo.List(ctxA, repository.AuditEventFilter{Type: model.AuditEventTypeCLI})
+	mustNoErr(t, err, "list by type")
+	if len(byType.Events) != 1 || byType.Events[0].CLICommand != "erun build" {
+		t.Fatalf("filter by type=CLI = %+v, want exactly the CLI event", byType.Events)
+	}
+
+	all, err := repo.List(ctxA, repository.AuditEventFilter{})
+	mustNoErr(t, err, "list unfiltered")
+	if len(all.Events) != 3 {
+		t.Fatalf("unfiltered list returned %d events, want all 3 for the tenant", len(all.Events))
+	}
+}
+
+// TestAuditEventListPaginatesStablyAcrossInserts is the DOS-shaped concern the
+// issue calls out: audit_events is append-only and unbounded, so paging must
+// use the (created_at, audit_event_id) keyset rather than an offset that a
+// concurrent insert would shift under the caller.
+func TestAuditEventListPaginatesStablyAcrossInserts(t *testing.T) {
+	repo, db := auditEventDatabase(t)
+	tenantID, userID := seedAuditTenant(t, db)
+	ctx := auditContext(tenantID, userID)
+
+	const total = 5
+	for i := 0; i < total; i++ {
+		logAuditEvent(t, repo, ctx, model.AuditEvent{
+			TenantID: tenantID, ErunUserID: userID, ExternalUserID: "u", ExternalIssuerID: "https://issuer.example",
+			Type: model.AuditEventTypeCLI, CLICommand: "erun build",
+		})
+	}
+	seeded := auditEventIDs(t, repo, ctx)
+	if len(seeded) != total {
+		t.Fatalf("seeded listing returned %d events, want %d", len(seeded), total)
+	}
+
+	seen := pageThroughInsertingBetweenPages(t, repo, ctx, tenantID, userID, total)
+	if len(seen) != total {
+		t.Fatalf("paged through %d distinct events, want exactly the original %d", len(seen), total)
+	}
+	for _, id := range seeded {
+		if !seen[id] {
+			t.Fatalf("original event %s was skipped by pagination", id)
+		}
+	}
+}
+
+func auditEventIDs(t *testing.T, repo *repository.AuditEventRepository, ctx context.Context) []string {
+	t.Helper()
+	page, err := repo.List(ctx, repository.AuditEventFilter{})
+	mustNoErr(t, err, "list")
+	ids := make([]string, 0, len(page.Events))
+	for _, e := range page.Events {
+		ids = append(ids, e.AuditEventID)
+	}
+	return ids
+}
+
+// pageThroughInsertingBetweenPages pages one row at a time, inserting a new
+// row after each page is fetched — the shape of a table receiving writes while
+// a caller is still paging through it — and returns the audit event ids seen.
+func pageThroughInsertingBetweenPages(
+	t *testing.T, repo *repository.AuditEventRepository, ctx context.Context, tenantID, userID string, total int,
+) map[string]bool {
+	t.Helper()
+	seen := make(map[string]bool)
+	cursor := repository.AuditEventCursor{}
+	for i := 0; i < total; i++ { // bounded: one row per page can never need more pages than rows.
+		page, err := repo.List(ctx, repository.AuditEventFilter{Limit: 1, Cursor: cursor})
+		mustNoErr(t, err, "page")
+		if len(page.Events) != 1 {
+			t.Fatalf("page %d returned %d events, want 1", i, len(page.Events))
+		}
+
+		// A new row lands mid-pagination. It sorts newest-first, ahead of
+		// every page already handed out, so it must not appear in — or shift
+		// — any page still to come.
+		logAuditEvent(t, repo, ctx, model.AuditEvent{
+			TenantID: tenantID, ErunUserID: userID, ExternalUserID: "u", ExternalIssuerID: "https://issuer.example",
+			Type: model.AuditEventTypeCLI, CLICommand: "erun build (inserted mid-page)",
+		})
+
+		id := page.Events[0].AuditEventID
+		if seen[id] {
+			t.Fatalf("page %d repeated audit event %s", i, id)
+		}
+		seen[id] = true
+
+		if page.NextCursor == "" {
+			if i != total-1 {
+				t.Fatalf("page %d reported no next page after only %d of %d rows", i, i+1, total)
+			}
+			break
+		}
+		cursor, err = repository.ParseAuditEventCursor(page.NextCursor)
+		mustNoErr(t, err, "parse next cursor")
+	}
+	return seen
+}
+
+// TestAuditEventListReportsNextCursorOnlyWhenMoreRemain guards the boundary of
+// the limit+1 lookahead: the last real page must not claim a next page exists.
+func TestAuditEventListReportsNextCursorOnlyWhenMoreRemain(t *testing.T) {
+	repo, db := auditEventDatabase(t)
+	tenantID, userID := seedAuditTenant(t, db)
+	ctx := auditContext(tenantID, userID)
+	logAuditEvent(t, repo, ctx, model.AuditEvent{
+		TenantID: tenantID, ErunUserID: userID, ExternalUserID: "u", ExternalIssuerID: "https://issuer.example",
+		Type: model.AuditEventTypeCLI, CLICommand: "erun build",
+	})
+
+	page, err := repo.List(ctx, repository.AuditEventFilter{Limit: 5})
+	mustNoErr(t, err, "list")
+	if len(page.Events) != 1 {
+		t.Fatalf("got %d events, want 1", len(page.Events))
+	}
+	if page.NextCursor != "" {
+		t.Fatalf("nextCursor = %q, want empty: there is exactly one row and the page held it", page.NextCursor)
+	}
+}
+
+// TestAuditEventListFiltersUseTheirDedicatedIndex proves the filters List
+// exposes are the ones the three audit_events indexes were actually built for,
+// not filters that would force a sequential scan as the trail grows. It seeds
+// enough rows with real selectivity for PostgreSQL's planner to prefer the
+// dedicated composite index over the plain tenant/created_at one, rather than
+// forcing the choice with enable_seqscan.
+func TestAuditEventListFiltersUseTheirDedicatedIndex(t *testing.T) {
+	_, db := auditEventDatabase(t)
+	tenantID, _ := seedAuditTenant(t, db)
+	userIDs := make([]string, 6)
+	for i := range userIDs {
+		userIDs[i] = seedAuditUser(t, db, tenantID)
+	}
+	seedBulkAuditEvents(t, db, tenantID, userIDs, 4000)
+
+	targetUser := userIDs[0]
+	explainByErunUser := explainAuditEventList(t, db, tenantID,
+		`erun_user_id = $1`, []any{targetUser})
+	if !strings.Contains(explainByErunUser, "audit_events_tenant_user_created_at_idx") {
+		t.Fatalf("erunUserId filter did not use its dedicated index:\n%s", explainByErunUser)
+	}
+
+	explainByAPIMethodPath := explainAuditEventList(t, db, tenantID,
+		`api_method = $1 AND api_path = $2`, []any{"POST", "/v1/reviews"})
+	if !strings.Contains(explainByAPIMethodPath, "audit_events_tenant_api_created_at_idx") {
+		t.Fatalf("apiMethod/apiPath filter did not use its dedicated index:\n%s", explainByAPIMethodPath)
+	}
+
+	explainUnfiltered := explainAuditEventList(t, db, tenantID, `TRUE`, nil)
+	if strings.Contains(explainUnfiltered, "Seq Scan") {
+		t.Fatalf("unfiltered list fell back to a sequential scan:\n%s", explainUnfiltered)
+	}
+}
+
+// seedBulkAuditEvents inserts n rows directly (bypassing LogAuditEvent, which
+// would take one round trip per row) spread across userIDs and two API
+// methods, so erun_user_id and api_method actually narrow the row set instead
+// of every value being equally represented.
+func seedBulkAuditEvents(t *testing.T, db *sql.DB, tenantID string, userIDs []string, n int) {
+	t.Helper()
+	_, err := db.Exec(`
+		INSERT INTO audit_events (
+			tenant_id, erun_user_id, external_user_id, external_issuer_id, type, api_method, api_path, created_at
+		)
+		SELECT
+			$1,
+			($2::uuid[])[1 + (s.n % array_length($2::uuid[], 1))],
+			'ext', 'https://issuer.example', 'API',
+			(ARRAY['GET', 'POST'])[1 + (s.n % 2)],
+			'/v1/reviews',
+			NOW() - (s.n || ' seconds')::interval
+		FROM generate_series(1, $3) AS s(n)
+	`, tenantID, postgresUUIDArrayLiteral(userIDs), n)
+	mustNoErr(t, err, "seed bulk audit events")
+	_, err = db.Exec(`ANALYZE audit_events`)
+	mustNoErr(t, err, "analyze audit_events")
+}
+
+// postgresUUIDArrayLiteral formats a Go string slice as a PostgreSQL array literal. The
+// values are test-controlled UUIDs from seedAuditUser, never external input.
+func postgresUUIDArrayLiteral(values []string) string {
+	return "{" + strings.Join(values, ",") + "}"
+}
+
+// explainAuditEventList runs EXPLAIN for the same shape of query List builds
+// (tenant-scoped by RLS, ordered newest first) inside a transaction with the
+// tenant's real security context, and returns the plan as text.
+func explainAuditEventList(t *testing.T, db *sql.DB, tenantID string, where string, extraArgs []any) string {
+	t.Helper()
+	tx, err := db.Begin()
+	mustNoErr(t, err, "begin explain tx")
+	t.Cleanup(func() { _ = tx.Rollback() })
+	_, err = tx.Exec(`SET LOCAL ROLE erun_tenant`)
+	mustNoErr(t, err, "set role")
+	_, err = tx.Exec(`SELECT set_config('erun.tenant_id', $1, true)`, tenantID)
+	mustNoErr(t, err, "set tenant context")
+	query := `EXPLAIN SELECT audit_event_id FROM audit_events WHERE ` + where +
+		` ORDER BY created_at DESC, audit_event_id DESC LIMIT 51`
+	rows, err := tx.Query(query, extraArgs...)
+	mustNoErr(t, err, "explain")
+	defer func() { _ = rows.Close() }()
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		mustNoErr(t, rows.Scan(&line), "scan explain line")
+		plan.WriteString(line)
+		plan.WriteString("\n")
+	}
+	mustNoErr(t, rows.Err(), "read explain plan")
+	return plan.String()
+}

--- a/erun-backend/erun-backend-api/internal/model/audit_event.go
+++ b/erun-backend/erun-backend-api/internal/model/audit_event.go
@@ -2,6 +2,8 @@ package model
 
 import (
 	"time"
+
+	"github.com/uptrace/bun"
 )
 
 type AuditEventType string
@@ -13,19 +15,29 @@ const (
 )
 
 type AuditEvent struct {
-	TenantID         string `json:"tenantId"`
-	ErunUserID       string `json:"erunUserId"`
-	ExternalUserID   string `json:"externalUserId"`
-	ExternalIssuerID string `json:"externalIssuerId"`
+	bun.BaseModel `bun:"table:audit_events,alias:ae"`
+	// AuditEventID is populated only by List; the write path inserts by raw SQL
+	// and never reads it back.
+	AuditEventID     string `json:"auditEventId,omitempty" bun:"audit_event_id,pk,scanonly"`
+	TenantID         string `json:"tenantId" bun:"tenant_id,scanonly"`
+	ErunUserID       string `json:"erunUserId" bun:"erun_user_id,scanonly"`
+	ExternalUserID   string `json:"externalUserId" bun:"external_user_id,scanonly"`
+	ExternalIssuerID string `json:"externalIssuerId" bun:"external_issuer_id,scanonly"`
 	// ExternalOrgID is the org claim value that resolved the tenant for an
 	// org-scoped issuer; empty/omitted for single-tenant issuers.
-	ExternalOrgID     string         `json:"externalOrgId,omitempty"`
-	Type              AuditEventType `json:"type"`
-	APIMethod         string         `json:"apiMethod,omitempty"`
-	APIPath           string         `json:"apiPath,omitempty"`
-	CLICommand        string         `json:"cliCommand,omitempty"`
-	CLIParameters     string         `json:"cliParameters,omitempty"`
-	MCPTool           string         `json:"mcpTool,omitempty"`
-	MCPToolParameters string         `json:"mcpToolParameters,omitempty"`
-	CreatedAt         time.Time      `json:"createdAt"`
+	ExternalOrgID string         `json:"externalOrgId,omitempty" bun:"external_org_id,scanonly"`
+	Type          AuditEventType `json:"type" bun:"type,scanonly"`
+	APIMethod     string         `json:"apiMethod,omitempty" bun:"api_method,scanonly"`
+	APIPath       string         `json:"apiPath,omitempty" bun:"api_path,scanonly"`
+	CLICommand    string         `json:"cliCommand,omitempty" bun:"cli_command,scanonly"`
+	// CLIParameters and MCPToolParameters are write-only and deliberately never
+	// tagged for Bun to populate: a tool such as cloud_inject_aws_credentials
+	// takes credentials as arguments, and this column is where a future MCP
+	// audit caller would serialize them. The read API must not become the way
+	// those secrets leak back out, so no query against this model may select
+	// either column, ever.
+	CLIParameters     string    `json:"-" bun:"-"`
+	MCPTool           string    `json:"mcpTool,omitempty" bun:"mcp_tool,scanonly"`
+	MCPToolParameters string    `json:"-" bun:"-"`
+	CreatedAt         time.Time `json:"createdAt" bun:"created_at,scanonly"`
 }

--- a/erun-backend/erun-backend-api/internal/repository/audit_events.go
+++ b/erun-backend/erun-backend-api/internal/repository/audit_events.go
@@ -2,10 +2,22 @@ package repository
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	"github.com/uptrace/bun"
+)
+
+// auditEventColumns deliberately omits cli_parameters and mcp_tool_parameters:
+// those columns are where a future CLI/MCP audit caller would serialize tool
+// arguments, and a tool such as cloud_inject_aws_credentials takes credentials
+// as arguments. The read path must never select them.
+const auditEventColumns = `audit_event_id, tenant_id, erun_user_id, external_user_id, external_issuer_id, external_org_id, type, api_method, api_path, cli_command, mcp_tool, created_at`
+
+const (
+	defaultAuditEventLimit = 50
+	maxAuditEventLimit     = 200
 )
 
 type AuditEventRepository struct {
@@ -14,6 +26,70 @@ type AuditEventRepository struct {
 
 func NewAuditEventRepository(txs *TxManager) *AuditEventRepository {
 	return &AuditEventRepository{txs: txs}
+}
+
+// AuditEventCursor identifies a row's position in the newest-first
+// (created_at DESC, audit_event_id DESC) ordering that List always uses. The
+// zero value means "start from the newest row" — audit_events is append-only
+// and unbounded, so offset pagination would degrade as it grows and would
+// skip or repeat rows as new events are appended ahead of a later page.
+type AuditEventCursor struct {
+	CreatedAt    time.Time
+	AuditEventID string
+}
+
+func (c AuditEventCursor) isZero() bool {
+	return c.CreatedAt.IsZero() && c.AuditEventID == ""
+}
+
+// String encodes the cursor as an opaque token for a caller to hand back to
+// resume after the last row it saw.
+func (c AuditEventCursor) String() string {
+	if c.isZero() {
+		return ""
+	}
+	return c.CreatedAt.UTC().Format(time.RFC3339Nano) + "," + c.AuditEventID
+}
+
+// ParseAuditEventCursor decodes a token previously returned by List. An empty
+// token decodes to the zero cursor.
+func ParseAuditEventCursor(token string) (AuditEventCursor, error) {
+	if token == "" {
+		return AuditEventCursor{}, nil
+	}
+	createdAt, auditEventID, ok := strings.Cut(token, ",")
+	if !ok || auditEventID == "" {
+		return AuditEventCursor{}, ErrInvalidInput
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, createdAt)
+	if err != nil {
+		return AuditEventCursor{}, ErrInvalidInput
+	}
+	return AuditEventCursor{CreatedAt: parsed, AuditEventID: auditEventID}, nil
+}
+
+// AuditEventFilter narrows a page of the caller's tenant audit trail. Every
+// field is optional; the zero filter lists the newest page of the tenant's
+// whole trail. Since/Until/ErunUserID and the (Type, APIMethod, APIPath)
+// combination are the filters the three audit_events indexes were built for.
+type AuditEventFilter struct {
+	Since      time.Time
+	Until      time.Time
+	ErunUserID string
+	Type       model.AuditEventType
+	APIMethod  string
+	APIPath    string
+	Cursor     AuditEventCursor
+	// Limit caps the page size; non-positive defaults to defaultAuditEventLimit
+	// and any value above maxAuditEventLimit is capped there.
+	Limit int
+}
+
+// AuditEventPage is one newest-first page of a tenant's audit trail.
+// NextCursor is empty when the page reached the end of the trail.
+type AuditEventPage struct {
+	Events     []model.AuditEvent
+	NextCursor string
 }
 
 func (r *AuditEventRepository) LogAuditEvent(ctx context.Context, event model.AuditEvent) error {
@@ -55,6 +131,76 @@ func (r *AuditEventRepository) LogAuditEvent(ctx context.Context, event model.Au
 		).Exec(ctx)
 		return err
 	})
+}
+
+// List returns one page of the caller's tenant audit trail, newest first.
+// RLS scopes rows to the tenant (or, under erun_operations, every tenant); the
+// filters and cursor here are the same tenant-owned SQL every other repository
+// runs through TxManager.
+func (r *AuditEventRepository) List(ctx context.Context, filter AuditEventFilter) (AuditEventPage, error) {
+	limit := filter.Limit
+	switch {
+	case limit <= 0:
+		limit = defaultAuditEventLimit
+	case limit > maxAuditEventLimit:
+		limit = maxAuditEventLimit
+	}
+
+	query, args := auditEventListQuery(filter, limit)
+	var events []model.AuditEvent
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		return tx.NewRaw(query, args...).Scan(ctx, &events)
+	})
+	if err != nil {
+		return AuditEventPage{}, err
+	}
+
+	page := AuditEventPage{Events: events}
+	if len(events) > limit {
+		page.Events = events[:limit]
+		last := page.Events[len(page.Events)-1]
+		page.NextCursor = AuditEventCursor{CreatedAt: last.CreatedAt, AuditEventID: last.AuditEventID}.String()
+	}
+	return page, nil
+}
+
+// auditEventListQuery builds the SELECT for List. It fetches one row beyond
+// limit so a next page can be reported without a second round trip; List
+// trims that extra row back off.
+func auditEventListQuery(filter AuditEventFilter, limit int) (string, []any) {
+	query := `SELECT ` + auditEventColumns + ` FROM audit_events WHERE TRUE`
+	var args []any
+	if !filter.Since.IsZero() {
+		query += ` AND created_at >= ?`
+		args = append(args, filter.Since)
+	}
+	if !filter.Until.IsZero() {
+		query += ` AND created_at <= ?`
+		args = append(args, filter.Until)
+	}
+	if filter.ErunUserID != "" {
+		query += ` AND erun_user_id = ?`
+		args = append(args, filter.ErunUserID)
+	}
+	if filter.Type != "" {
+		query += ` AND type = ?`
+		args = append(args, string(filter.Type))
+	}
+	if filter.APIMethod != "" {
+		query += ` AND api_method = ?`
+		args = append(args, filter.APIMethod)
+	}
+	if filter.APIPath != "" {
+		query += ` AND api_path = ?`
+		args = append(args, filter.APIPath)
+	}
+	if !filter.Cursor.isZero() {
+		query += ` AND (created_at, audit_event_id) < (?, ?)`
+		args = append(args, filter.Cursor.CreatedAt, filter.Cursor.AuditEventID)
+	}
+	query += ` ORDER BY created_at DESC, audit_event_id DESC LIMIT ?`
+	args = append(args, limit+1)
+	return query, args
 }
 
 func nullString(value string) any {

--- a/erun-backend/erun-backend-api/internal/routes/audit_events.go
+++ b/erun-backend/erun-backend-api/internal/routes/audit_events.go
@@ -1,0 +1,89 @@
+package routes
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+)
+
+// AuditEventRepository lists the caller's tenant audit trail. Read-only: audit
+// events are written by authentication middleware for every authorized
+// request, never by a route.
+type AuditEventRepository interface {
+	List(ctx context.Context, filter repository.AuditEventFilter) (repository.AuditEventPage, error)
+}
+
+type AuditEventRoutes struct {
+	events AuditEventRepository
+}
+
+func RegisterAuditEventRoutes(register ProtectedRouteRegistrar, events AuditEventRepository) {
+	routes := AuditEventRoutes{events: events}
+	register(http.MethodGet, "/v1/audit-events", http.HandlerFunc(routes.listAuditEvents))
+}
+
+type auditEventsResponse struct {
+	Events     []model.AuditEvent `json:"events"`
+	NextCursor string             `json:"nextCursor,omitempty"`
+}
+
+func (r AuditEventRoutes) listAuditEvents(w http.ResponseWriter, req *http.Request) {
+	filter, err := parseAuditEventFilter(req.URL.Query())
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	page, err := r.events.List(req.Context(), filter)
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, auditEventsResponse{Events: page.Events, NextCursor: page.NextCursor})
+}
+
+func parseAuditEventFilter(query url.Values) (repository.AuditEventFilter, error) {
+	get := func(key string) string { return strings.TrimSpace(query.Get(key)) }
+
+	filter := repository.AuditEventFilter{
+		ErunUserID: get("erunUserId"),
+		Type:       model.AuditEventType(get("type")),
+		APIMethod:  get("apiMethod"),
+		APIPath:    get("apiPath"),
+	}
+
+	var err error
+	if filter.Since, err = parseAuditEventTime(get("since")); err != nil {
+		return repository.AuditEventFilter{}, err
+	}
+	if filter.Until, err = parseAuditEventTime(get("until")); err != nil {
+		return repository.AuditEventFilter{}, err
+	}
+	if filter.Cursor, err = repository.ParseAuditEventCursor(get("cursor")); err != nil {
+		return repository.AuditEventFilter{}, err
+	}
+	if limit := get("limit"); limit != "" {
+		parsed, err := strconv.Atoi(limit)
+		if err != nil {
+			return repository.AuditEventFilter{}, repository.ErrInvalidInput
+		}
+		filter.Limit = parsed
+	}
+	return filter, nil
+}
+
+func parseAuditEventTime(value string) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, repository.ErrInvalidInput
+	}
+	return parsed, nil
+}

--- a/erun-backend/erun-backend-api/internal/routes/audit_events_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/audit_events_test.go
@@ -1,0 +1,116 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+)
+
+type stubAuditEventRepository struct {
+	filter repository.AuditEventFilter
+	page   repository.AuditEventPage
+	err    error
+}
+
+func (r *stubAuditEventRepository) List(_ context.Context, filter repository.AuditEventFilter) (repository.AuditEventPage, error) {
+	r.filter = filter
+	return r.page, r.err
+}
+
+func getAuditEvents(t *testing.T, routes AuditEventRoutes, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/v1/audit-events"+query, nil)
+	rec := httptest.NewRecorder()
+	routes.listAuditEvents(rec, req)
+	return rec
+}
+
+func TestListAuditEventsParsesEveryFilter(t *testing.T) {
+	stub := &stubAuditEventRepository{}
+	routes := AuditEventRoutes{events: stub}
+	rec := getAuditEvents(t, routes,
+		"?since=2026-01-01T00:00:00Z&until=2026-01-02T00:00:00Z&erunUserId=user-1"+
+			"&type=API&apiMethod=GET&apiPath=%2Fv1%2Freviews&cursor=2026-01-01T00%3A00%3A00Z%2Ce1&limit=10")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+	if stub.filter.ErunUserID != "user-1" {
+		t.Fatalf("erunUserId = %q", stub.filter.ErunUserID)
+	}
+	if stub.filter.Type != model.AuditEventTypeAPI {
+		t.Fatalf("type = %q", stub.filter.Type)
+	}
+	if stub.filter.APIMethod != "GET" || stub.filter.APIPath != "/v1/reviews" {
+		t.Fatalf("apiMethod/apiPath = %q/%q", stub.filter.APIMethod, stub.filter.APIPath)
+	}
+	if stub.filter.Limit != 10 {
+		t.Fatalf("limit = %d, want 10", stub.filter.Limit)
+	}
+	if stub.filter.Cursor.AuditEventID != "e1" {
+		t.Fatalf("cursor = %+v, want audit event id e1", stub.filter.Cursor)
+	}
+	if stub.filter.Since.IsZero() || stub.filter.Until.IsZero() {
+		t.Fatalf("since/until not parsed: %+v", stub.filter)
+	}
+}
+
+func TestListAuditEventsRejectsAnUnparsableCursor(t *testing.T) {
+	stub := &stubAuditEventRepository{}
+	routes := AuditEventRoutes{events: stub}
+	rec := getAuditEvents(t, routes, "?cursor=not-a-cursor")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestListAuditEventsRejectsAnUnparsableTimeRange(t *testing.T) {
+	stub := &stubAuditEventRepository{}
+	routes := AuditEventRoutes{events: stub}
+	rec := getAuditEvents(t, routes, "?since=not-a-time")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestListAuditEventsResponseNeverSerializesParameterPayloads guards the
+// response shape even if a future bug ever got a parameter payload as far as
+// an in-memory model.AuditEvent: a tool such as cloud_inject_aws_credentials
+// takes credentials as arguments, and the JSON the caller receives must not
+// carry them regardless of how they got into the struct.
+func TestListAuditEventsResponseNeverSerializesParameterPayloads(t *testing.T) {
+	stub := &stubAuditEventRepository{page: repository.AuditEventPage{Events: []model.AuditEvent{{
+		AuditEventID: "e1",
+		Type:         model.AuditEventTypeMCP,
+		MCPTool:      "cloud_inject_aws_credentials",
+		// Set directly on the struct (bypassing the DB) to prove the JSON
+		// encoding itself is the guard, not just "List never populates it".
+		MCPToolParameters: `{"secretAccessKey":"super-secret"}`,
+		CLIParameters:     `{"token":"also-secret"}`,
+	}}}}
+	routes := AuditEventRoutes{events: stub}
+	rec := getAuditEvents(t, routes, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "secret") {
+		t.Fatalf("response body leaked a parameter payload: %s", body)
+	}
+
+	var decoded auditEventsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(decoded.Events) != 1 {
+		t.Fatalf("got %d events, want 1", len(decoded.Events))
+	}
+	if decoded.Events[0].MCPTool != "cloud_inject_aws_credentials" {
+		t.Fatalf("mcpTool = %q, want the tool name preserved", decoded.Events[0].MCPTool)
+	}
+}

--- a/erun-backend/erun-backend-api/server.go
+++ b/erun-backend/erun-backend-api/server.go
@@ -183,6 +183,7 @@ func registerDatabaseRoutes(register routes.ProtectedRouteRegistrar, options Han
 	contexts := repository.NewContextRepository(txManager)
 	tenantQuotas := repository.NewTenantQuotaRepository(txManager)
 	usageEvents := repository.NewUsageEventRepository(txManager)
+	auditEvents := repository.NewAuditEventRepository(txManager)
 	releases := repository.NewReleaseRepository(txManager)
 	// contextCredentials resolves a placed environment's live admin token
 	// (#1112). nil without a cipher (the same precondition context
@@ -210,6 +211,7 @@ func registerDatabaseRoutes(register routes.ProtectedRouteRegistrar, options Han
 	routes.RegisterEnvironmentRoutes(register, environments, tenantQuotas, tenants, contexts, newEnvironmentProvisioner(options, environments, usageEvents, placementCredentials), newEnvironmentLifecycle(options, environments, usageEvents, placementCredentials), deleter)
 	newEnvironmentDeleteReconciler(options, environments, tenants, contexts, deleter)
 	routes.RegisterUsageEventRoutes(register, usageEvents)
+	routes.RegisterAuditEventRoutes(register, auditEvents)
 	routes.RegisterMCPTokenRoutes(register, environments, tenants, options.MCPSigner)
 	routes.RegisterDNS01TokenRoutes(register, environments, tenants, options.MCPSigner)
 	var contextProvisioner routes.ContextProvisioner

--- a/erun-docs/docs/agent-reference/audit-log.md
+++ b/erun-docs/docs/agent-reference/audit-log.md
@@ -4,160 +4,89 @@ title: Audit log format
 
 # Audit log format
 
-The exact event shape, retention windows, and security-event catalogue. For the Operator-facing view ("what the audit trail is for, and how it's used"), see [Operator in the loop · The audit trail](/collaboration/operator-in-the-loop#the-audit-trail).
+The audit event shape and the hosted API's read contract. For the Operator-facing view ("what the audit trail is for, and how it's used"), see [Operator in the loop · The audit trail](/collaboration/operator-in-the-loop#the-audit-trail).
 
-## Three layers
+## What's captured today
 
-| Layer | What it captures | Retention |
-|---|---|---|
-| In-environment trace | Every `erun` invocation; per-action `docker` / `helm` / `git` commands; `--dry-run` plans. | Pod lifetime (`/var/log/erun/audit.log`). Idle-stop wipes. |
-| Per-environment MCP events | Every `tools/call` with `argv` / `cwd` / exit code; `idle.activity` snapshots; `doctor` outcomes. | 30 days inside the pod. |
-| Hosted erun API events | Every review, comment, status transition, recorded build, security event. | Durable. Lifetime of the tenant. |
+Every successfully authorized hosted-API request writes one row to the tenant's audit trail: authentication middleware logs it after token verification, tenant resolution, user resolution, and endpoint authorization all succeed. A request rejected before that point — missing or invalid token, unknown issuer, unknown user, denied permission — is never logged, so the trail records what happened, not every attempt.
+
+The schema also carries columns for CLI and MCP activity (`type: "CLI"` / `type: "MCP"`, `cliCommand`, `mcpTool`), but no CLI or MCP caller writes those rows yet. **(Planned.)** Every row today has `type: "API"`.
 
 ## Event shape
 
-All three layers emit a common JSON-lines event:
-
 ```jsonc
 {
-  "timestamp": "2026-05-25T14:31:02Z",
-  "tenant": "myapp",
-  "environment": "feature-a",                // omitted for cross-env API events
-  "actor": {
-    "id": "usr_01H...",                       // or "agent-bot-a" for service accounts
-    "kind": "operator",                        // "operator" | "agent"
-    "source": "cli"                            // "cli" | "mcp" | "api"
-  },
-  "action": "erun.build",                     // verb in dotted form
-  "target": { "kind": "image", "name": "myapp-api", "version": "1.0.77" },
-  "result": "ok",                              // "ok" | "dry_run" | "error"
-  "details": {
-    "argv": ["docker","build","-t","myapp-api:1.0.77",".",
-             "--build-arg","TARGETOS=linux"]
-  }
+  "auditEventId": "01973f9e-2f10-7c31-8f2a-1234567890ab", // UUIDv7
+  "tenantId": "01973f00-0000-7000-8000-000000000001",
+  "erunUserId": "01973f01-0000-7000-8000-000000000002", // the resolved ERun user, not the raw external subject
+  "externalUserId": "auth0|abc123",                      // the OIDC subject the identity provider presented
+  "externalIssuerId": "https://issuer.example.com/",
+  "externalOrgId": "org_123",                            // org/resource-owner claim, org-scoped issuers only; omitted otherwise
+  "type": "API",                                          // "API" | "MCP" | "CLI"
+  "apiMethod": "GET",                                     // set when type is "API"
+  "apiPath": "/v1/reviews/{review_id}",                   // the canonical route template, never a concrete URL
+  "createdAt": "2026-05-25T14:31:02Z"
 }
 ```
 
-A `--dry-run` invocation records the same event with `result: "dry_run"` and the same `details` it would produce on a real run — that's what makes dry-run a true preview.
+A `CLI` row would carry `cliCommand` instead of `apiMethod`/`apiPath`; an `MCP` row would carry `mcpTool`. **(Planned.)**
 
 ### Field semantics
 
 | Field | Constraints |
 |---|---|
-| `timestamp` | RFC3339 UTC. |
-| `tenant` | Tenant name, always set. |
-| `environment` | Set for in-pod and MCP events; omitted for cross-env API events. |
-| `actor.id` | The resolved `creator_user_id` from the OIDC `sub` claim. Service-account IDs follow `agent-<name>` or `bot-<name>` conventions. |
-| `actor.kind` | Lowercase enum: `operator` or `agent`. |
-| `actor.source` | Lowercase enum: `cli`, `mcp`, or `api`. |
-| `action` | Dotted verb — see [Action verb catalogue](#action-verb-catalogue). |
-| `target` | Object with `kind` (required) + per-kind fields — see [Target shapes](#target-shapes). |
-| `result` | Lowercase enum: `ok`, `dry_run`, or `error`. Errors include `details.error` with a one-line message. |
-| `details` | Free-form action-specific payload. |
+| `auditEventId` | UUIDv7, unique per event. |
+| `tenantId` | The tenant the event belongs to. |
+| `erunUserId` | The resolved ERun user id — not the external identity provider's subject. |
+| `externalUserId` | The external subject the identity provider presented. |
+| `externalIssuerId` | The OIDC `iss` claim that resolved the tenant. |
+| `externalOrgId` | The org/resource-owner claim for an org-scoped (shared) issuer; omitted for a single-tenant issuer. |
+| `type` | `API`, `MCP`, or `CLI`. |
+| `apiMethod` | HTTP method; set when `type` is `API`. |
+| `apiPath` | The canonical route template registered for the endpoint (e.g. `/v1/reviews/{review_id}`), matching the same template `role_permissions` uses for authorization — never a concrete URL with resolved IDs or a query string. |
+| `createdAt` | RFC3339 UTC. |
 
-### Action verb catalogue
+### What the read API never returns
 
-Verbs are dotted, lowercase, and stable. The complete enumeration:
+The write path also has `cliParameters` and `mcpToolParameters` columns for serialized call arguments, but `GET /v1/audit-events` (below) never selects them and the response has no field for them, regardless of what a write path stores there. An MCP tool such as `cloud_inject_aws_credentials` takes credentials as call arguments — the tool name (`mcpTool`) is exactly the kind of thing an audit trail should surface, but the argument payload is exactly the kind of thing it must not leak back out through a read endpoint. The same holds for `cliParameters` once CLI audit logging lands.
 
-| Source | Verb pattern | Specific values |
+## Query API
+
+`GET /v1/audit-events` — authorized the same way every other list endpoint is: the caller's `ReadAll` permission plus PostgreSQL row-level security scope the response to the caller's own tenant. There is no separate "audit admin" permission — a company tenant's caller with `ReadAll` reads that tenant's own rows; an operations-tenant caller reads across every tenant's rows, the same cross-tenant reach `ReadAll` already grants that role for every other resource.
+
+| Query parameter | Type | Effect |
 |---|---|---|
-| CLI | `erun.<command>` | `erun.init`, `erun.open`, `erun.add`, `erun.list`, `erun.build`, `erun.push`, `erun.deploy`, `erun.doctor`, `erun.mcp`, `erun.release`, `erun.delete`, `erun.version` |
-| MCP | `mcp.<tool>` | `mcp.idle`, `mcp.doctor`, `mcp.list`, `mcp.version`, `mcp.logs`, `mcp.build`, `mcp.push`, `mcp.deploy`, `mcp.release`, `mcp.open`, `mcp.init`, `mcp.delete`, `mcp.raw` |
-| API | `api.<resource>.<verb>` | `api.reviews.create`, `api.reviews.list`, `api.reviews.get`, `api.reviews.status.update`, `api.comments.create`, `api.comments.list`, `api.comments.status.update`, `api.builds.create`, `api.builds.list`, `api.builds.get`, `api.merge-queue.list`, `api.merge-queue.advance`, `api.whoami`, `api.tenant-issuers.list`, `api.tenant-issuers.update`, `api.audit-events.list` |
-
-New verbs require an entry in this enumeration; clients can rely on the closed set.
-
-### Target shapes
-
-The `target` object's per-kind fields:
-
-| `target.kind` | Required fields | Notes |
-|---|---|---|
-| `image` | `name`, `version` | The OCI image. `name` is the un-prefixed component name (e.g. `myapp-api`); the registry is implicit from env config. |
-| `chart` | `name`, `revision` | Helm chart name + the release revision after the action. |
-| `review` | `id`, `name`, `targetBranch` | Review resource. |
-| `comment` | `id`, `reviewId` | Comment resource. |
-| `build` | `id`, `reviewId`, `commitId` | Build resource. |
-| `tenant-issuer` | `issuerUrl` | Trusted-issuer entry. |
-| `environment` | `name` | Env name; the action's `tenant` field carries the tenant. |
-| `merge-queue` | `targetBranch` | Per-target-branch queue. |
-| `audit-events` | (none beyond `kind`) | Used for the meta-action of listing audit events. |
-
-Unknown kinds are reserved; clients should treat them as opaque (forward-compatible).
-
-## Security events
-
-Alongside the action log, the hosted API maintains a separate `audit-events` table for security-relevant events. These are durable, queryable, and tenant-admin-visible. The minimum captured set:
-
-| Event | When | Why it matters |
-|---|---|---|
-| `signin.success` | OIDC sign-in passes verification. | Establishes who connected from where. |
-| `signin.failure` | OIDC token fails verification (signature, audience, expiry, subject not allowed). | Probes and misconfiguration land here. |
-| `tenant-issuer.add` | Admin adds a trusted OIDC issuer via `PATCH /v1/tenant-issuers`. | New trust roots are security-critical. |
-| `tenant-issuer.remove` | Admin removes a trusted issuer. | Detects accidental removal of the only active issuer. |
-| `review.status.transition` | `PATCH /v1/reviews/{id}/status` changes the status. | The merge path is auditable end-to-end. |
-| `mergequeue.advance` | `POST /v1/reviews/merge-queue/advance` promotes a head. | Promotions are the moment a branch reaches main. |
-| `release.tag.push` | A release-tagged image is published to the registry. | The artefact-promotion boundary. |
-| `release.tag.delete` | A previously-published release tag is removed (`erun build --release --force` or registry-side). | Tag rewrites mutate "immutable" history; visible at the audit boundary. |
-| `env.delete` | An environment is removed. | Namespace tear-down captured. |
-| `ratelimit.exceeded` | Caller hits a per-token or per-tenant limit. | Surfaces agents that hammer the API. |
-
-Each event carries: `eventId`, `timestamp`, `tenant`, `actor` (same shape as the action log), `event` (string), `details` (event-specific). The schema is append-only — events are never edited or deleted.
-
-### Query API
-
-`GET /v1/audit-events` — admin-only. Returns durable audit events for the caller's tenant.
-
-| Query parameter | Type | Default | Effect |
-|---|---|---|---|
-| `from` | RFC3339 | — | Inclusive lower bound. Required. |
-| `to` | RFC3339 | now | Exclusive upper bound. |
-| `event` | string | — | Filter by `event` value (`signin.failure`, `mergequeue.advance`, …). Repeatable. |
-| `actor` | string | — | Filter by `actor.id`. |
-| `pageToken` | opaque | — | Continuation from a prior response. |
+| `since` | RFC3339 | Inclusive lower bound on `createdAt`. |
+| `until` | RFC3339 | Inclusive upper bound on `createdAt`. |
+| `erunUserId` | UUID | Filter to one resolved ERun user. |
+| `type` | `API` \| `MCP` \| `CLI` | Filter by source. |
+| `apiMethod` | string | Filter by HTTP method (meaningful with `type=API`). |
+| `apiPath` | string | Filter by the canonical route template, not a concrete URL. |
+| `cursor` | opaque | Continuation token from a prior response's `nextCursor`. |
+| `limit` | integer | Page size; defaults to 50, capped at 200. |
 
 Response:
 
 ```jsonc
 {
-  "items": [
-    {
-      "eventId": "evt_01H...",
-      "timestamp": "2026-05-25T14:31:02Z",
-      "tenant": "myapp",
-      "actor": { "id": "agent-bot-a", "kind": "agent", "source": "api" },
-      "event": "signin.success",
-      "details": { "issuer": "https://issuer.example.com/oauth2/default", "ip": "203.0.113.42" }
-    }
-  ],
-  "nextPageToken": "eyJvZmZzZXQiOjEwMH0="
+  "events": [ /* event objects, newest first */ ],
+  "nextCursor": "2026-05-25T14:31:02.000000000Z,01973f9e-2f10-7c31-8f2a-1234567890ab"
 }
 ```
 
-Max **100 items per page**; pagination follows the [common rules](/agent-reference/api-protocol#pagination). Rate-limit bucket: per-token read endpoints.
+`nextCursor` encodes the `(createdAt, auditEventId)` of the last row in the page — a keyset, not an offset. `audit_events` is append-only and unbounded, so an offset would skip or repeat rows as new events are appended ahead of a page still being read; the keyset can't. `nextCursor` is omitted once a page reaches the end of the trail.
 
-| Status | `code` | When |
-|---|---|---|
-| `400` | `MISSING_FROM` | `from` parameter absent. |
-| `400` | `INVALID_TIMESTAMP` | `from` or `to` is not RFC3339. |
-| `400` | `EXPIRED_PAGE_TOKEN` | `pageToken` is stale or malformed. |
-| `403` | `NOT_TENANT_ADMIN` | Caller is a tenant member but not an admin. |
+Filters map onto the table's indexes: no filter (or `since`/`until` alone) uses the tenant/time index, `erunUserId` uses the tenant/user/time index, and `apiMethod`/`apiPath` together use the tenant/api/time index — every filter this endpoint exposes has a matching index, rather than falling back to a sequential scan as the trail grows.
 
-### Layer-level format differences
-
-| Layer | Format |
+| Status | When |
 |---|---|
-| In-pod trace (`/var/log/erun/audit.log`) | JSON-lines, one event per line, no envelope. |
-| MCP per-env events (in-pod, 30-day retention) | JSON-lines, identical shape to the in-pod trace; same file rotated by date. |
-| Hosted API response | JSON object `{ items: [...], nextPageToken }` wrapping the same event shape. |
+| `400` | A query parameter fails to parse — `since`/`until` not RFC3339, `cursor` malformed, `limit` not an integer. |
+| `403` | The caller's role has no read permission for `GET` on this path. |
 
-A consumer reading both surfaces deserialises each line of JSON-lines, or each element of `items`, with the same schema.
+## Security events
 
-## Retention guarantees
-
-Plan for security-sensitive history accordingly: anything you need to reconstruct after a pod restart belongs on the API side. The in-pod trace is for live debugging; the durable record lives in the hosted API.
+There is no separate, curated table of security-relevant events (sign-in failures, issuer changes, release-tag rewrites, and so on) distinct from the generic trail above. **(Planned.)** Today, a security-relevant action is auditable only in the same way as any other request: it is one more row in `audit_events`, filterable by `apiMethod`/`apiPath` like any other API call.
 
 ## See also
 
-- [erun API protocol](/agent-reference/api-protocol) — rate limits, pagination, OIDC sign-in.
 - [Operator in the loop](/collaboration/operator-in-the-loop) — the Operator-facing view of audit.

--- a/erun-docs/docs/concepts/observability.md
+++ b/erun-docs/docs/concepts/observability.md
@@ -12,7 +12,7 @@ What can you see when something goes wrong (or right). ERun doesn't ship a built
 |---|---|---|
 | **In-pod** | Stdout/stderr of every container, plus files under `/var/log/erun/` (CLI audit traces). | `kubectl logs`, `erun open` + shell, MCP `raw`. |
 | **Cluster** | Aggregated logs / metrics / traces across all envs on the cluster. | Whatever stack you've installed — Prometheus + Grafana + Loki, OpenTelemetry Collector, Datadog, …. |
-| **Durable** | Reviews, comments, builds, audit events — anything posted to the erun API. | erun API endpoints (admin-only for audit events; see [Audit log · Security events](/agent-reference/audit-log#security-events)). |
+| **Durable** | Reviews, comments, builds, audit events — anything posted to the erun API. | erun API endpoints (`GET /v1/audit-events` for the audit trail; see [Audit log · Query API](/agent-reference/audit-log#query-api)). |
 
 The first layer is always there. The other two are admin-opt-in.
 

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -1799,6 +1799,8 @@ func tenantDashboardHandler(t *testing.T, jwt string, requests *[]string) http.H
 			_, _ = w.Write([]byte(`[{"reviewId":"review-1","tenantId":"tenant-1","name":"Review 1","targetBranch":"main","sourceBranch":"feature","status":"READY"}]`))
 		case "/v1/reviews/review-1/builds":
 			_, _ = w.Write([]byte(`[{"buildId":"build-1","tenantId":"tenant-1","reviewId":"review-1","successful":true,"commitId":"abc","version":"1.2.3"}]`))
+		case "/v1/audit-events":
+			_, _ = w.Write([]byte(`{"events":[{"auditEventId":"event-1","tenantId":"tenant-1","erunUserId":"user-1","externalUserId":"subject-1","externalIssuerId":"https://sts.aws.example","type":"API","apiMethod":"GET","apiPath":"/v1/reviews","createdAt":"2026-01-01T00:00:00Z"}]}`))
 		default:
 			http.NotFound(w, req)
 		}
@@ -1811,8 +1813,16 @@ func assertPrimaryCloudDashboard(t *testing.T, dashboard uiTenantDashboard, requ
 	if dashboard.User == nil || dashboard.User.Username != "Rihards.Freimanis" || len(dashboard.User.Roles) != 2 || len(dashboard.MergeQueue) != 1 || len(dashboard.Builds) != 1 || dashboard.Builds[0].ReviewName != "Review 1" {
 		t.Fatalf("unexpected dashboard: %+v", dashboard)
 	}
-	if strings.Join(requests, ",") != "/v1/whoami,/v1/reviews,/v1/reviews/merge-queue,/v1/reviews/review-1/builds" {
+	assertPrimaryCloudDashboardAuditEvents(t, dashboard.AuditEvents)
+	if strings.Join(requests, ",") != "/v1/whoami,/v1/reviews,/v1/reviews/merge-queue,/v1/reviews/review-1/builds,/v1/audit-events" {
 		t.Fatalf("unexpected API requests: %+v", requests)
+	}
+}
+
+func assertPrimaryCloudDashboardAuditEvents(t *testing.T, events []uiTenantDashboardAudit) {
+	t.Helper()
+	if len(events) != 1 || events[0].Actor != "subject-1" || events[0].Action != "GET /v1/reviews" {
+		t.Fatalf("unexpected audit events: %+v", events)
 	}
 }
 

--- a/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type {
   UITenant,
+  UITenantDashboardAudit,
   UITenantDashboardBuild,
   UITenantDashboardReview,
   UITenantDashboardUser,
@@ -116,12 +117,7 @@ function TenantDashboardTabContent({
         <BuildsTable builds={view.builds} apiError={view.apiError} />
       </TabsContent>
       <TabsContent value="audit" className="min-h-0 overflow-auto">
-        <div className="mt-4">
-          <EmptyState
-            heading="Audit log coming soon"
-            body="Tenant audit events will surface here once the backend ships them. Check back in a future release."
-          />
-        </div>
+        <AuditEventsTable events={view.auditEvents} apiError={view.apiError} />
       </TabsContent>
       <TabsContent value="api-log" className="min-h-0 overflow-auto">
         <APILogPanel log={view.apiLog} error={view.apiLogError} apiError={view.apiError} />
@@ -136,7 +132,7 @@ interface TenantDashboardViewData {
   hasAPIError: boolean;
   mergeQueue: UITenantDashboardReview[];
   builds: UITenantDashboardBuild[];
-  auditLogMessage: string;
+  auditEvents: UITenantDashboardAudit[];
   apiLog: string;
   apiLogError: string;
 }
@@ -147,7 +143,7 @@ const emptyTenantDashboardViewData: TenantDashboardViewData = {
   hasAPIError: false,
   mergeQueue: [],
   builds: [],
-  auditLogMessage: 'No audit events',
+  auditEvents: [],
   apiLog: '',
   apiLogError: '',
 };
@@ -165,7 +161,7 @@ function tenantDashboardViewData(
     hasAPIError: apiError.length > 0,
     mergeQueue: data.mergeQueue ?? [],
     builds: data.builds ?? [],
-    auditLogMessage: data.auditLogMessage ?? 'No audit events',
+    auditEvents: data.auditEvents ?? [],
     apiLog: data.apiLog ?? '',
     apiLogError: data.apiLogError ?? '',
   };
@@ -252,6 +248,40 @@ function BuildsTable({
           <DataCell>{build.commitId}</DataCell>
           <DataCell>{build.version}</DataCell>
           <DataCell>{formatDate(build.createdAt)}</DataCell>
+        </tr>
+      ))}
+    </DataTable>
+  );
+}
+
+function AuditEventsTable({
+  events,
+  apiError,
+}: {
+  events: UITenantDashboardAudit[];
+  apiError: string;
+}): React.ReactElement {
+  if (events.length === 0) {
+    if (apiError) {
+      return <DashboardMessage message={apiError} destructive />;
+    }
+    return (
+      <div className="mt-4">
+        <EmptyState
+          heading="No audit events"
+          body="Tenant activity will appear here as API, CLI, and MCP calls are made."
+        />
+      </div>
+    );
+  }
+  return (
+    <DataTable headers={['Time', 'Type', 'Actor', 'Action']}>
+      {events.map((event, index) => (
+        <tr key={`${event.createdAt ?? ''}-${String(index)}`}>
+          <DataCell>{formatDate(event.createdAt)}</DataCell>
+          <DataCell>{event.type}</DataCell>
+          <DataCell>{event.actor}</DataCell>
+          <DataCell strong>{event.action}</DataCell>
         </tr>
       ))}
     </DataTable>

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -159,7 +159,6 @@ export interface UITenantDashboard {
   mergeQueue?: UITenantDashboardReview[];
   builds?: UITenantDashboardBuild[];
   auditEvents?: UITenantDashboardAudit[];
-  auditLogMessage?: string;
 }
 
 export interface UITenantDashboardUser {

--- a/erun-ui/playwright/pages/AppShell.ts
+++ b/erun-ui/playwright/pages/AppShell.ts
@@ -9,6 +9,7 @@ import { OrchestratorDialog } from './OrchestratorDialog';
 import { OutputsDialog } from './OutputsDialog';
 import { ReviewPanel } from './ReviewPanel';
 import { Sidebar } from './Sidebar';
+import { TenantDashboard } from './TenantDashboard';
 import { TenantDialog } from './TenantDialog';
 import { TerminalPane } from './TerminalPane';
 import { TerminalTabStrip } from './TerminalTabStrip';
@@ -84,6 +85,10 @@ export class AppShell {
 
   get tenantDialog(): TenantDialog {
     return new TenantDialog(this.page);
+  }
+
+  get tenantDashboard(): TenantDashboard {
+    return new TenantDashboard(this.page);
   }
 
   get debugPanel(): DebugPanel {

--- a/erun-ui/playwright/pages/Sidebar.ts
+++ b/erun-ui/playwright/pages/Sidebar.ts
@@ -40,6 +40,10 @@ export class Sidebar {
     await this.tenantRow(name).first().click();
   }
 
+  async openTenantDashboard(name: string): Promise<void> {
+    await this.page.getByRole('button', { name: `Open ${name} dashboard` }).click();
+  }
+
   async isTenantExpanded(name: string): Promise<boolean> {
     const value = await this.tenantRow(name).first().getAttribute('aria-expanded');
     return value === 'true';

--- a/erun-ui/playwright/pages/TenantDashboard.ts
+++ b/erun-ui/playwright/pages/TenantDashboard.ts
@@ -1,0 +1,34 @@
+import type { Locator, Page } from '@playwright/test';
+
+export type TenantDashboardTab = 'Users' | 'Merge queue' | 'Builds' | 'Audit log' | 'API log';
+
+// TenantDashboard POM. Unlike the dialogs, this view replaces the main pane
+// content (MainPane.tsx) rather than rendering inside a Radix dialog, so
+// waitForOpen anchors on the tab list rather than a role="dialog".
+export class TenantDashboard {
+  constructor(public readonly page: Page) {}
+
+  async waitForOpen(): Promise<void> {
+    await this.page.getByRole('tab', { name: 'Audit log' }).waitFor({ state: 'visible' });
+  }
+
+  async selectTab(name: TenantDashboardTab): Promise<void> {
+    await this.page.getByRole('tab', { name }).click();
+  }
+
+  activePanel(): Locator {
+    return this.page.getByRole('tabpanel');
+  }
+
+  auditTable(): Locator {
+    return this.activePanel().getByRole('table');
+  }
+
+  auditRows(): Locator {
+    return this.auditTable().locator('tbody tr');
+  }
+
+  auditEmptyState(): Locator {
+    return this.activePanel().getByText('No audit events', { exact: true });
+  }
+}

--- a/erun-ui/playwright/pages/index.ts
+++ b/erun-ui/playwright/pages/index.ts
@@ -4,6 +4,7 @@ export { Titlebar } from './Titlebar';
 export { GlobalConfigDialog } from './GlobalConfigDialog';
 export { EnvironmentInitDialog } from './EnvironmentInitDialog';
 export { ManageDialog, type ManageTab } from './ManageDialog';
+export { TenantDashboard, type TenantDashboardTab } from './TenantDashboard';
 export { TenantDialog } from './TenantDialog';
 export { ReviewPanel } from './ReviewPanel';
 export { DebugPanel } from './DebugPanel';

--- a/erun-ui/playwright/tests/tenant-dashboard-audit-log.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-audit-log.spec.ts
@@ -1,0 +1,126 @@
+import type { Route, Request } from '@playwright/test';
+
+import { test, expect } from '../fixtures/erunApp.js';
+import {
+  SEED_TENANT,
+  removeEnvironment,
+  seedEnvironment,
+  uniqueEnvironmentName,
+} from '../fixtures/seedRoot.js';
+
+// The tenant dashboard only calls LoadTenantDashboard once it can resolve both
+// an API URL (from an environment) and a primary cloud alias (from the tenant
+// config, which the seeded `pw` tenant already normalizes to pw-aws — see
+// erun-common's NormalizeTenantCloudProviderAliases). None of the baseline
+// envs carry an apiUrl, so this stages one throwaway env that does, purely to
+// satisfy that gate; the RPC itself is stubbed below rather than hitting a
+// real backend, per playwright/AGENTS.md's "stub the RPC over /__erun_invoke"
+// guidance for state the seeded baseline does not carry.
+function seedDashboardEnvironment(title: string): string {
+  const environment = uniqueEnvironmentName(title);
+  seedEnvironment(SEED_TENANT, environment, 'apiurl: http://127.0.0.1:1/unreachable\n');
+  return environment;
+}
+
+async function stubLoadTenantDashboard(
+  page: import('@playwright/test').Page,
+  data: Record<string, unknown>,
+): Promise<void> {
+  await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+    if (body.method === 'LoadTenantDashboard') {
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ data }) });
+      return;
+    }
+    await route.continue();
+  });
+}
+
+test.describe('tenant dashboard — audit log tab (#1205)', () => {
+  test('renders returned audit events with time, type, actor, and action', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('audit-log-populated');
+    try {
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+
+      await stubLoadTenantDashboard(page, {
+        tenant: SEED_TENANT,
+        environment,
+        apiUrl: 'http://127.0.0.1:1/unreachable',
+        user: { tenantId: 't1', userId: 'u1', username: 'operator' },
+        auditEvents: [
+          {
+            type: 'API',
+            actor: 'subject-1',
+            action: 'GET /v1/reviews',
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+          {
+            type: 'CLI',
+            actor: 'subject-2',
+            action: 'erun build',
+            createdAt: '2026-01-02T00:00:00Z',
+          },
+          {
+            type: 'MCP',
+            actor: 'subject-3',
+            action: 'cloud_inject_aws_credentials',
+            createdAt: '2026-01-03T00:00:00Z',
+          },
+        ],
+      });
+
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+      await app.tenantDashboard.waitForOpen();
+      await app.tenantDashboard.selectTab('Audit log');
+
+      await expect(app.tenantDashboard.auditRows()).toHaveCount(3);
+      const firstRow = app.tenantDashboard.auditRows().first();
+      await expect(firstRow).toContainText('API');
+      await expect(firstRow).toContainText('subject-1');
+      await expect(firstRow).toContainText('GET /v1/reviews');
+      // The MCP tool name renders, but never a recorded argument payload — a
+      // tool such as cloud_inject_aws_credentials takes credentials as
+      // arguments, and the read API never returns that column.
+      await expect(app.tenantDashboard.auditTable()).toContainText('cloud_inject_aws_credentials');
+      await expect(app.tenantDashboard.auditTable()).not.toContainText('secret');
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+
+  test('shows a purpose-built empty state, not an input-styled box, when there are no events', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('audit-log-empty');
+    try {
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+
+      await stubLoadTenantDashboard(page, {
+        tenant: SEED_TENANT,
+        environment,
+        apiUrl: 'http://127.0.0.1:1/unreachable',
+        user: { tenantId: 't1', userId: 'u1', username: 'operator' },
+        auditEvents: [],
+      });
+
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+      await app.tenantDashboard.waitForOpen();
+      await app.tenantDashboard.selectTab('Audit log');
+
+      await expect(app.tenantDashboard.auditEmptyState()).toBeVisible();
+      await expect(app.tenantDashboard.auditTable()).toHaveCount(0);
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+});

--- a/erun-ui/tenant_dashboard.go
+++ b/erun-ui/tenant_dashboard.go
@@ -22,10 +22,9 @@ func (a *App) LoadTenantDashboard(input uiTenantDashboardInput) (uiTenantDashboa
 		return uiTenantDashboard{}, fmt.Errorf("tenant API URL is required")
 	}
 	dashboard := uiTenantDashboard{
-		Tenant:          tenant,
-		Environment:     strings.TrimSpace(input.Environment),
-		APIURL:          apiURL,
-		AuditLogMessage: "Audit log listing is not exposed by the ERun API yet.",
+		Tenant:      tenant,
+		Environment: strings.TrimSpace(input.Environment),
+		APIURL:      apiURL,
 	}
 	ctx := a.ctx
 	if ctx == nil {
@@ -85,6 +84,56 @@ func loadTenantDashboardData(ctx context.Context, client *http.Client, apiURL, b
 		return
 	}
 	dashboard.Builds = builds
+	auditEvents, err := loadTenantDashboardJSON[uiAuditEventsResponse](ctx, client, apiURL, "/v1/audit-events", bearer, usernameHint)
+	if err != nil {
+		dashboard.APIError = err.Error()
+		return
+	}
+	dashboard.AuditEvents = tenantDashboardAuditEvents(auditEvents.Events)
+}
+
+// uiAuditEventsResponse mirrors the GET /v1/audit-events response shape.
+// cliParameters and mcpToolParameters are deliberately absent: the API never
+// returns them, since a tool such as cloud_inject_aws_credentials takes
+// credentials as arguments.
+type uiAuditEventsResponse struct {
+	Events []uiAuditEvent `json:"events"`
+}
+
+type uiAuditEvent struct {
+	Type           string `json:"type"`
+	ExternalUserID string `json:"externalUserId"`
+	APIMethod      string `json:"apiMethod,omitempty"`
+	APIPath        string `json:"apiPath,omitempty"`
+	CLICommand     string `json:"cliCommand,omitempty"`
+	MCPTool        string `json:"mcpTool,omitempty"`
+	CreatedAt      string `json:"createdAt"`
+}
+
+func tenantDashboardAuditEvents(events []uiAuditEvent) []uiTenantDashboardAudit {
+	converted := make([]uiTenantDashboardAudit, 0, len(events))
+	for _, event := range events {
+		converted = append(converted, uiTenantDashboardAudit{
+			Type:      event.Type,
+			Actor:     event.ExternalUserID,
+			Action:    tenantDashboardAuditAction(event),
+			CreatedAt: event.CreatedAt,
+		})
+	}
+	return converted
+}
+
+func tenantDashboardAuditAction(event uiAuditEvent) string {
+	switch event.Type {
+	case "API":
+		return strings.TrimSpace(event.APIMethod + " " + event.APIPath)
+	case "CLI":
+		return event.CLICommand
+	case "MCP":
+		return event.MCPTool
+	default:
+		return ""
+	}
 }
 
 func (a *App) tenantDashboardUsernameHint(alias string) string {

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -186,18 +186,17 @@ type uiTenantDashboardInput struct {
 }
 
 type uiTenantDashboard struct {
-	Tenant          string                    `json:"tenant"`
-	Environment     string                    `json:"environment,omitempty"`
-	APIURL          string                    `json:"apiUrl,omitempty"`
-	APIError        string                    `json:"apiError,omitempty"`
-	APILog          string                    `json:"apiLog,omitempty"`
-	APILogError     string                    `json:"apiLogError,omitempty"`
-	User            *uiTenantDashboardUser    `json:"user,omitempty"`
-	Reviews         []uiTenantDashboardReview `json:"reviews,omitempty"`
-	MergeQueue      []uiTenantDashboardReview `json:"mergeQueue,omitempty"`
-	Builds          []uiTenantDashboardBuild  `json:"builds,omitempty"`
-	AuditEvents     []uiTenantDashboardAudit  `json:"auditEvents,omitempty"`
-	AuditLogMessage string                    `json:"auditLogMessage,omitempty"`
+	Tenant      string                    `json:"tenant"`
+	Environment string                    `json:"environment,omitempty"`
+	APIURL      string                    `json:"apiUrl,omitempty"`
+	APIError    string                    `json:"apiError,omitempty"`
+	APILog      string                    `json:"apiLog,omitempty"`
+	APILogError string                    `json:"apiLogError,omitempty"`
+	User        *uiTenantDashboardUser    `json:"user,omitempty"`
+	Reviews     []uiTenantDashboardReview `json:"reviews,omitempty"`
+	MergeQueue  []uiTenantDashboardReview `json:"mergeQueue,omitempty"`
+	Builds      []uiTenantDashboardBuild  `json:"builds,omitempty"`
+	AuditEvents []uiTenantDashboardAudit  `json:"auditEvents,omitempty"`
 }
 
 type uiTenantDashboardUser struct {


### PR DESCRIPTION
Closes #1205

## Confirming the issue's premise against the code

The core claim held: `AuditEventRepository` had exactly one method (`LogAuditEvent`), no service or route existed, and the three indexes / RLS policies / `role_permissions.api_path` convention were all already in place waiting for a reader. One thing the issue implied but the code doesn't yet do: **audit events are not actually recorded for MCP or CLI activity today.** `erun-backend-api/AGENTS.md` frames CLI/MCP audit callers as "future" work, and the only place `LogAuditEvent` is ever called is the API auth middleware (`auth.go`), always with `type: API`. The schema and model already carry `cli_command`/`mcp_tool`/`cli_parameters`/`mcp_tool_parameters` columns for when that lands, and the read endpoint below is built to serve all three types generically, but as of this PR every row in the table has `type: "API"`. I corrected the docs to say this plainly instead of describing a three-source trail that doesn't exist yet (see "Docs" below).

## What changed

**erun-backend-api**
- `AuditEventRepository.List` (`internal/repository/audit_events.go`): filters on `since`/`until`/`erunUserId`/`type`/`apiMethod`/`apiPath`, keyset-paginated on `(created_at, audit_event_id)` — not offset, since the table is append-only and unbounded and an offset would skip/repeat rows as new events land mid-page.
- `GET /v1/audit-events` (`internal/routes/audit_events.go`), wired in `server.go`. No new permission: it's a `GET`, so it falls under the same `ReadAll` pattern (and RLS scoping) every other list endpoint already uses — a company tenant reads its own rows, an operations tenant reads across tenants via `erun_operations`, exactly like every other resource.
- **Security-sensitive design decision:** `cli_parameters`/`mcp_tool_parameters` are never selected by `List` and the response model has no field for them (`json:"-"`, `bun:"-"`) — checked how `cloud_inject_aws_credentials` (`erun-mcp/server.go`) is invoked: its input carries `accessKeyId`/`secretAccessKey`, and that's exactly the payload a future MCP audit write would serialize into `mcp_tool_parameters`. The read API must never become the leak path for that.

**erun-ui**
- The tenant dashboard's Audit log tab (`erun-ui/tenant_dashboard.go`, `TenantDashboardView.tsx`) now fetches `/v1/audit-events` and renders a real table (time/type/actor/action), replacing the "coming soon" placeholder. Empty state uses `EmptyState` (not an error box); a fetch error uses the same destructive `DashboardMessage` every other tab uses.
- Removed the now-dead `AuditLogMessage` field (Go + TS) that was scaffolded for the placeholder and nothing populates or reads anymore. Regenerated `wailsjs` bindings via `wails generate module` (no diff — `./run.sh --build` had already regenerated them in the normal build).

**erun-docs**
- Rewrote `agent-reference/audit-log.md`'s event shape and Query API section to match the real implementation (real query params, real response envelope, real auth model), and marked the still-unimplemented parts (CLI/MCP capture, a curated security-event catalogue) `(Planned.)` instead of describing them as if they existed. Kept the `#event-shape`/`#security-events` anchor IDs stable since three other pages link into them. Fixed one directly-false "(admin-only for audit events)" claim in `concepts/observability.md`.
- **Found but did not fix:** the pre-existing docs describe a much larger three-layer audit vision (in-pod trace files, MCP `tools/call` logging, a fictional `pageToken`-based pagination scheme in `api-protocol.md`) that doesn't match *any* current implementation, not just this endpoint's. That's a pre-existing, repo-wide docs/code gap outside this issue's scope — I only corrected the page directly describing what I built.

## Tests, and how I confirmed they fail without the fix

`erun-backend/erun-backend-api/audit_events_e2e_test.go` (real migrated PostgreSQL, opt-in via `ERUN_E2E_AUDIT_DATABASE_URL`) and `internal/routes/audit_events_test.go` (fast, stubbed). Confirmed failure-before-fix by physically moving the implementation files aside (`internal/model/audit_event.go`, `internal/repository/audit_events.go`, `internal/routes/audit_events.go`, `server.go` back to their `main` content) and re-running: both files fail to *compile* (`repo.List undefined`, `undefined: repository.AuditEventFilter`, `undefined: AuditEventRoutes`) — there's no partial-pass possible since the method didn't exist. Restored and re-verified green.

- **Tenant isolation** (the explicit ask): `TestAuditEventListIsScopedByTenant` seeds two real tenants+users, logs one event each, and asserts each tenant's `List` sees only its own row — enforced by PostgreSQL RLS + the same `SET LOCAL ROLE` / `erun.tenant_id` transaction wiring every other repository uses (`TxManager`), not a parallel path.
- **The credential-leak guard**: `TestAuditEventListNeverExposesParameterPayloads` logs an event with `mcpTool: "cloud_inject_aws_credentials"` and a fake secret in `mcpToolParameters`, then asserts `List` returns the tool name but not the payload. `TestListAuditEventsResponseNeverSerializesParameterPayloads` (routes, no DB) does the same at the JSON-encoding layer.
- **Filters map to their indexes**: `TestAuditEventListFiltersUseTheirDedicatedIndex` seeds 4,000 rows across 6 users and two methods, runs `ANALYZE`, and checks `EXPLAIN` output *without* forcing the planner — confirms `erunUserId` genuinely picks `audit_events_tenant_user_created_at_idx` and `apiMethod`+`apiPath` genuinely picks `audit_events_tenant_api_created_at_idx` on cost alone, not a forced hint.
- **Pagination under concurrent inserts**: `TestAuditEventListPaginatesStablyAcrossInserts` pages one row at a time, inserting a new row after every page fetched, and asserts no page repeats or skips a row from the original set.

Validation performed, all green:
- `erun-backend-api`: `go build ./...`, `go test ./...` (normal and `PATH=/usr/local/go/bin:/usr/bin:/bin`), `golangci-lint run ./...`, plus the opt-in e2e suite against a locally-migrated PostgreSQL 18 container (applied via the module's own `migrations/default/*.sql`, in order).
- `erun-ui`: `go test ./...`, `golangci-lint run ./...`, frontend `yarn typecheck && yarn lint && yarn format:check && yarn build`, and two focused Playwright specs (populated + empty audit tab) plus the **full** `erun-ui/playwright` suite (172 passed).
- `erun-docs`: `yarn build` (onBrokenLinks: throw) and `yarn typecheck`, both clean; anchor and canonical-terminology sweeps on the touched pages.
- No `erun-cli`/`erun-common`/runtime-entrypoint/chart/golden changes, so `erun-integration` wasn't in scope per the root gate's trigger list.

## Playwright coverage for the new UI surface

No spec covered the tenant dashboard at all before this PR. Added `pages/TenantDashboard.ts` + `Sidebar.openTenantDashboard()`, and `tests/tenant-dashboard-audit-log.spec.ts` covering populated and empty states. `LoadTenantDashboard` requires an env with an `apiUrl` (none of the seeded baseline envs have one) and a primary cloud alias (the seeded tenant already normalizes to one), so the spec stages a throwaway env for the `apiUrl` gate and **stubs the `LoadTenantDashboard` RPC** over `/__erun_invoke` rather than requiring a live backend — the sanctioned pattern in `playwright/AGENTS.md` for state the baseline doesn't carry.

## Two pre-existing failures found, not fixed

Running the full suite surfaced two failures unrelated to this change. Confirmed both reproduce identically with none of my changes applied (stashed everything, rebuilt, re-ran):
- #1222 — a container-registry role toggle (`from`) doesn't survive a manage-dialog save/reload round trip.
- #1223 — a review diff/tree filter spec times out waiting for the panel's periodic diff refresh.

Filed and linked rather than silently skipped, per this repo's "fix pre-existing issues" rule — but genuinely unrelated subsystems (env-config persistence, review-panel refresh timing) that need their own investigation rather than a fix bundled into this PR.

## What I could not verify

No live cluster or deployed backend was available in this sandbox, so I could not run the full end-to-end verification gate (roll into a real deployed API, hit it from a real desktop build against a real Postgres-backed tenant). I substituted the closest available equivalents: a locally-migrated real PostgreSQL 18 for every backend claim (RLS, indexes, pagination), and the Playwright RPC-stub pattern for the desktop UI. `wails`/`docker`/`atlas` all happened to be available in this environment, so bindings regeneration and the Postgres e2e harness were not blocked — flagging in case that's not a given elsewhere.