### PR TITLE
Give the sidebar one source of truth for focus

### DIFF
--- a/erun-ui/frontend/src/app/model/index.ts
+++ b/erun-ui/frontend/src/app/model/index.ts
@@ -12,6 +12,7 @@ export type { IdleCloudContextAction } from './idleCloudContextAction';
 export type { MountElements } from './mountElements';
 export type { NormalizedEnvironmentDialogValues } from './normalizedEnvironmentDialogValues';
 export type { OrchestratorShellActivityPayload } from './orchestratorShellActivityPayload';
+export type { SidebarFocus } from './sidebarFocus';
 export type { TerminalDataDisposable } from './terminalDataDisposable';
 export type { TerminalExitSelections } from './terminalExitSelections';
 export type { TerminalWriteData } from './terminalWriteData';

--- a/erun-ui/frontend/src/app/model/sidebarFocus.ts
+++ b/erun-ui/frontend/src/app/model/sidebarFocus.ts
@@ -1,0 +1,11 @@
+// SidebarFocus names the one thing that currently owns the terminal pane and
+// the sidebar's highlight — the tenant dashboard, an orchestrator's session,
+// or an environment's session. Every sidebar row derives its own highlight
+// from this single value instead of computing an overlapping "active"
+// condition from a different state slice, so at most one row is ever
+// highlighted at a time.
+export type SidebarFocus =
+  | { kind: 'dashboard'; tenant: string }
+  | { kind: 'orchestrator'; sessionId: number }
+  | { kind: 'environment'; tenant: string; environment: string }
+  | { kind: 'none' };

--- a/erun-ui/frontend/src/app/orchestratorThunks.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorThunks.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { openOrchestrator } from './orchestratorThunks';
+import { setSelected } from './slices/selectionSlice';
+import { resetTenantDashboard } from './slices/tenantDashboardSlice';
+import { setSessionId } from './slices/terminalSlice';
+import type { AppThunk } from './store';
+
+interface RecordedAction {
+  type: string;
+  payload?: unknown;
+}
+type ThunkGetState = Parameters<AppThunk>[1];
+type ThunkExtraArg = Parameters<AppThunk>[2];
+type LooseDispatch = (action: unknown) => unknown;
+
+// A minimal thunk harness: no real store or Wails bindings, since
+// openOrchestrator dispatches only plain actions and nested thunks, never a
+// Wails call. Nested thunk dispatches are unwrapped the same way redux-thunk
+// middleware would, so a helper thunk composed of several dispatches (e.g.
+// focusOrchestratorSession) reports every action it dispatches, not itself.
+function collectDispatched(thunk: AppThunk): RecordedAction[] {
+  const actions: RecordedAction[] = [];
+  const getState = (() => ({})) as ThunkGetState;
+  const extra = undefined as unknown as ThunkExtraArg;
+  const dispatch: LooseDispatch = (action) => {
+    if (typeof action === 'function') {
+      return (action as (d: LooseDispatch, g: ThunkGetState, e: ThunkExtraArg) => unknown)(
+        dispatch,
+        getState,
+        extra,
+      );
+    }
+    actions.push(action as RecordedAction);
+    return undefined;
+  };
+  thunk(dispatch, getState, extra);
+  return actions;
+}
+
+// #1204: clicking a running orchestrator while the tenant dashboard was open
+// attached its session but never showed it, because openOrchestrator only
+// ever dispatched setSessionId — the pane stayed hidden behind
+// state.tenantDashboard.tenant, which nothing on this path cleared.
+test('opening a running orchestrator clears the tenant dashboard, not just the session id', () => {
+  const actions = collectDispatched(openOrchestrator(42));
+  const types = actions.map((action) => action.type);
+
+  assert.ok(
+    types.includes(resetTenantDashboard.type),
+    `expected the tenant dashboard to be cleared so the pane can show the orchestrator; dispatched: ${types.join(', ')}`,
+  );
+  assert.ok(types.includes(setSelected.type), 'expected the stale environment selection to clear');
+  const sessionAction = actions.find((action) => action.type === setSessionId.type);
+  assert.ok(sessionAction, 'expected the session to be focused');
+  assert.equal(sessionAction.payload, 42);
+});
+
+test('opening a stopped orchestrator (sessionId 0) dispatches nothing', () => {
+  const actions = collectDispatched(openOrchestrator(0));
+  assert.deepEqual(actions, []);
+});

--- a/erun-ui/frontend/src/app/orchestratorThunks.ts
+++ b/erun-ui/frontend/src/app/orchestratorThunks.ts
@@ -26,8 +26,26 @@ import {
   setOrchestratorsError,
 } from './slices/orchestratorsSlice';
 import { setSelected } from './slices/selectionSlice';
+import { resetTenantDashboard } from './slices/tenantDashboardSlice';
 import { setSessionId } from './slices/terminalSlice';
 import type { AppThunk } from './store';
+
+// focusOrchestratorSession makes an orchestrator's session own the terminal
+// pane. The pane and the sidebar highlight are each derived from whichever of
+// the tenant dashboard, an orchestrator's session, or an environment
+// selection currently applies (see selectSidebarFocus in ./selectors), so
+// handing an orchestrator the pane must clear the other two here, once,
+// rather than at every call site that starts, opens, or restarts one — a
+// caller that dispatched setSessionId directly used to leave the tenant
+// dashboard painted over the session the sidebar now highlighted as focused
+// (#1204).
+const focusOrchestratorSession =
+  (sessionId: number): AppThunk =>
+  (dispatch) => {
+    dispatch(resetTenantDashboard());
+    dispatch(setSelected(null));
+    dispatch(setSessionId(sessionId));
+  };
 
 // loadOrchestrators fetches the current list and, in the same pass, seeds the
 // AI-busy store from each orchestrator's own `busy` snapshot field,
@@ -100,7 +118,7 @@ export const startOrchestrator =
   async (dispatch) => {
     try {
       const info = await StartOrchestrator(id, 80, 24);
-      dispatch(setSessionId(info.sessionId));
+      dispatch(focusOrchestratorSession(info.sessionId));
       await dispatch(loadOrchestrators());
     } catch (error) {
       dispatch(setOrchestratorsError(readError(error)));
@@ -112,7 +130,7 @@ export const openOrchestrator =
   (sessionId: number): AppThunk =>
   (dispatch) => {
     if (sessionId > 0) {
-      dispatch(setSessionId(sessionId));
+      dispatch(focusOrchestratorSession(sessionId));
     }
   };
 
@@ -125,7 +143,7 @@ export const restartOrchestrator =
   async (dispatch) => {
     try {
       const info = await RestartOrchestrator(id, 80, 24);
-      dispatch(setSessionId(info.sessionId));
+      dispatch(focusOrchestratorSession(info.sessionId));
       await dispatch(loadOrchestrators());
     } catch (error) {
       dispatch(setOrchestratorsError(readError(error)));
@@ -214,8 +232,7 @@ export const restoreOpenOrchestrators =
               24,
             )
           : await StartOrchestrator(primary.id, 80, 24);
-        dispatch(setSelected(null));
-        dispatch(setSessionId(info.sessionId));
+        dispatch(focusOrchestratorSession(info.sessionId));
         restoredPane = true;
       }
       await dispatch(loadOrchestrators());
@@ -262,7 +279,7 @@ export const investigateFailure =
   async (dispatch) => {
     try {
       const info = await InvestigateFailure(report, tenant, environment, 80, 24);
-      dispatch(setSessionId(info.sessionId));
+      dispatch(focusOrchestratorSession(info.sessionId));
       await dispatch(loadOrchestrators());
     } catch (error) {
       dispatch(setOrchestratorsError(readError(error)));

--- a/erun-ui/frontend/src/app/selectors.ts
+++ b/erun-ui/frontend/src/app/selectors.ts
@@ -1,5 +1,6 @@
 import type { UISelection } from '@/types';
 
+import type { SidebarFocus } from './model';
 import type { OrchestratorInfo } from './slices/orchestratorsSlice';
 import type { RootState } from './store';
 import { findVersionSuggestion, normalizeDialogValue, selectionKey } from './versionSuggestions';
@@ -133,6 +134,31 @@ export const selectActiveSessionOrchestrator = (state: RootState): OrchestratorI
 // to know whether env-scoped chrome applies.
 export const selectIsOrchestratorSession = (state: RootState): boolean =>
   selectActiveSessionOrchestrator(state) !== null;
+
+// selectSidebarFocus names the one thing the sidebar highlights and the main
+// pane shows. The tenant dashboard, an orchestrator's session, and an
+// environment's session each used to compute their own "active" condition
+// from a different state slice, so a tenant dashboard row and an orchestrator
+// row could both render selected at once while the pane showed only one of
+// them (#1204). Every sidebar row derives its highlight from this single
+// value instead. The tenant dashboard takes priority regardless of a stale
+// terminal.sessionId left over from before it opened; an orchestrator session
+// takes priority over an environment selection for the same reason.
+export const selectSidebarFocus = (state: RootState): SidebarFocus => {
+  const dashboardTenant = state.tenantDashboard.tenant;
+  if (dashboardTenant) {
+    return { kind: 'dashboard', tenant: dashboardTenant };
+  }
+  const orchestrator = selectActiveSessionOrchestrator(state);
+  if (orchestrator) {
+    return { kind: 'orchestrator', sessionId: orchestrator.sessionId };
+  }
+  const selected = state.selection.selected;
+  if (selected) {
+    return { kind: 'environment', tenant: selected.tenant, environment: selected.environment };
+  }
+  return { kind: 'none' };
+};
 
 export interface ReviewEnvTarget {
   envKey: string;

--- a/erun-ui/frontend/src/app/sessionThunks.ts
+++ b/erun-ui/frontend/src/app/sessionThunks.ts
@@ -27,7 +27,7 @@ import {
   resetEnvOpening,
   trackOpenSession,
 } from './slices/sessionsSlice';
-import { setTenantDashboard } from './slices/tenantDashboardSlice';
+import { resetTenantDashboard } from './slices/tenantDashboardSlice';
 import { setSelectedSessionForEnv, setSessionId } from './slices/terminalSlice';
 import { setTerminalCopyOutput, setTerminalCopyStatus } from './slices/terminalStatusSlice';
 import type { TerminalTab, TerminalTabKind } from './state';
@@ -259,9 +259,7 @@ export const openSelection =
   (selection: UISelection): AppThunk<Promise<void>> =>
   async (dispatch, getState, extra) => {
     const controller = requireController(extra);
-    dispatch(
-      setTenantDashboard({ tenant: '', tab: 'users', loading: false, error: '', data: null }),
-    );
+    dispatch(resetTenantDashboard());
     const runSelection = { ...selection };
     const key = selectionKey(runSelection);
     const previousSessionId = getState().terminal.sessionId;

--- a/erun-ui/frontend/src/app/sidebarFocus.test.ts
+++ b/erun-ui/frontend/src/app/sidebarFocus.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { selectSidebarFocus } from './selectors';
+import type { OrchestratorInfo } from './slices/orchestratorsSlice';
+import type { RootState } from './store';
+
+function orchestrator(id: string, sessionId: number): OrchestratorInfo {
+  return {
+    id,
+    name: id,
+    environments: [],
+    tenants: [],
+    directories: [],
+    sessionId,
+    status: sessionId > 0 ? 'running' : 'stopped',
+    busy: false,
+    transient: false,
+    shellRunning: false,
+    shellCommand: '',
+    shellStartedAtUnix: 0,
+  };
+}
+
+// Only the four slices selectSidebarFocus reads; the rest of RootState is
+// irrelevant here and constructing it would make the test about the store's
+// shape instead of the derivation.
+function stateWith(fields: {
+  dashboardTenant?: string;
+  sessionId?: number;
+  orchestrators?: OrchestratorInfo[];
+  selected?: { tenant: string; environment: string } | null;
+}): RootState {
+  return {
+    tenantDashboard: { tenant: fields.dashboardTenant ?? '' },
+    terminal: { sessionId: fields.sessionId ?? 0 },
+    orchestrators: { items: fields.orchestrators ?? [] },
+    selection: { selected: fields.selected ?? null },
+  } as unknown as RootState;
+}
+
+// #1204: the tenant dashboard, an orchestrator's session, and an
+// environment's session used to be three independently-computed "active"
+// booleans across three components. selectSidebarFocus is the single value
+// they must all derive from instead, so at most one of them is ever true.
+
+test('an open tenant dashboard wins even over a stale active session', () => {
+  // A dashboard opened while an orchestrator's session was still the last
+  // thing focused: terminal.sessionId still matches that orchestrator, but
+  // the dashboard must still be what's reported as focused.
+  const state = stateWith({
+    dashboardTenant: 'acme',
+    sessionId: 42,
+    orchestrators: [orchestrator('erun-issues', 42)],
+  });
+
+  assert.deepEqual(selectSidebarFocus(state), { kind: 'dashboard', tenant: 'acme' });
+});
+
+test('an orchestrator session wins over a stale environment selection', () => {
+  const state = stateWith({
+    sessionId: 42,
+    orchestrators: [orchestrator('erun-issues', 42)],
+    selected: { tenant: 'acme', environment: 'prod' },
+  });
+
+  assert.deepEqual(selectSidebarFocus(state), { kind: 'orchestrator', sessionId: 42 });
+});
+
+test('an environment selection is reported once no dashboard or orchestrator applies', () => {
+  const state = stateWith({ selected: { tenant: 'acme', environment: 'prod' } });
+
+  assert.deepEqual(selectSidebarFocus(state), {
+    kind: 'environment',
+    tenant: 'acme',
+    environment: 'prod',
+  });
+});
+
+test('nothing focused reports none', () => {
+  assert.deepEqual(selectSidebarFocus(stateWith({})), { kind: 'none' });
+});
+
+test('a terminal session that matches no orchestrator is not orchestrator focus', () => {
+  const state = stateWith({
+    sessionId: 99,
+    orchestrators: [orchestrator('erun-issues', 42)],
+    selected: { tenant: 'acme', environment: 'prod' },
+  });
+
+  assert.deepEqual(selectSidebarFocus(state), {
+    kind: 'environment',
+    tenant: 'acme',
+    environment: 'prod',
+  });
+});

--- a/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
@@ -6,6 +6,7 @@ import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { openManageDialog } from '@/app/manageEnvironmentThunks';
 import { showTerminalMessage } from '@/app/notificationThunks';
 import { openOutputs } from '@/app/outputsThunks';
+import { selectSidebarFocus } from '@/app/selectors';
 import { closeEnvironment, openSelection } from '@/app/sessionThunks';
 import { envKey } from '@/app/slices/sessionsSlice';
 import { selectionKey } from '@/app/versionSuggestions';
@@ -346,17 +347,18 @@ function useEnvironmentRowState(
     envBusyDetail,
     envObserved,
   );
-  // While an orchestrator owns the terminal pane, no environment is the focused
-  // thing — suppress the env's selected highlight so the sidebar matches what the
-  // pane renders (the orchestrator row carries the active highlight instead).
-  const orchestratorActive = useAppSelector(
-    (state) =>
-      state.terminal.sessionId > 0 &&
-      state.orchestrators.items.some((o) => o.sessionId === state.terminal.sessionId),
-  );
+  // The sidebar's single source of truth for "this row is the pane's focus"
+  // — the tenant dashboard and an orchestrator's session both take priority
+  // over an environment selection (see selectSidebarFocus), so a stale
+  // selection.selected left over from before either took the pane can never
+  // paint this row as selected too (#1204).
+  const focus = useAppSelector(selectSidebarFocus);
   return {
     ...derived,
-    selected: derived.selected && !orchestratorActive,
+    selected:
+      focus.kind === 'environment' &&
+      focus.tenant === tenantName &&
+      focus.environment === environmentName,
     envState,
     indicator: environmentIndicator({
       name: `${tenantName} / ${environmentName}`,

--- a/erun-ui/frontend/src/components/app/Sidebar.ErunSection.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.ErunSection.tsx
@@ -20,6 +20,7 @@ import {
   startOrchestrator,
 } from '@/app/orchestratorThunks';
 import { openOutputs } from '@/app/outputsThunks';
+import { selectSidebarFocus } from '@/app/selectors';
 import type { OrchestratorShellActivity } from '@/app/slices/orchestratorShellActivitySlice';
 import type { OrchestratorInfo } from '@/app/slices/orchestratorsSlice';
 import { openOrchestratorDialog } from '@/app/slices/orchestratorsSlice';
@@ -112,7 +113,7 @@ function OrchestratorsArea(): React.ReactElement {
   const dispatch = useAppDispatch();
   const items = useAppSelector((state) => state.orchestrators.items);
   const error = useAppSelector((state) => state.orchestrators.error);
-  const activeSessionId = useAppSelector((state) => state.terminal.sessionId);
+  const focus = useAppSelector(selectSidebarFocus);
 
   // The orchestrator a rebuild+restart returns to is restored by boot(), which
   // owns the initial pane selection; here we only load the list for the sidebar.
@@ -155,7 +156,7 @@ function OrchestratorsArea(): React.ReactElement {
             <OrchestratorRow
               key={orchestrator.id}
               orchestrator={orchestrator}
-              active={orchestrator.sessionId === activeSessionId && activeSessionId > 0}
+              active={focus.kind === 'orchestrator' && focus.sessionId === orchestrator.sessionId}
             />
           ))}
         </ul>
@@ -210,6 +211,7 @@ function OrchestratorRow({
           active ? 'font-medium' : 'font-normal',
         )}
         aria-label={`${running ? 'Open' : 'Start'} orchestrator ${orchestrator.name}`}
+        aria-current={active ? 'page' : undefined}
         onClick={() => {
           if (running) {
             dispatch(openOrchestrator(orchestrator.sessionId));

--- a/erun-ui/frontend/src/components/app/Sidebar.TenantGroup.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.TenantGroup.tsx
@@ -2,6 +2,7 @@ import { Folder, FolderOpen, MoreHorizontal } from 'lucide-react';
 import * as React from 'react';
 
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
+import { selectSidebarFocus } from '@/app/selectors';
 import { toggleTenantCollapsed } from '@/app/slices/sidebarSlice';
 import { openTenantDashboard, openTenantDialog } from '@/app/tenantDialogThunks';
 import { IconTooltip } from '@/components/app/IconTooltip';
@@ -21,11 +22,10 @@ export function TenantGroup({
   pending: UISelection | null;
 }): React.ReactElement {
   const collapsedTenants = useAppSelector((state) => state.sidebar.collapsedTenants);
-  const dashboardTenant = useAppSelector((state) => state.tenantDashboard.tenant);
-  const selected = useAppSelector((state) => state.selection.selected);
+  const focus = useAppSelector(selectSidebarFocus);
   const collapsed = collapsedTenants.includes(tenant.name);
-  const active = dashboardTenant === tenant.name;
-  const related = active || selected?.tenant === tenant.name;
+  const active = focus.kind === 'dashboard' && focus.tenant === tenant.name;
+  const related = active || (focus.kind === 'environment' && focus.tenant === tenant.name);
 
   return (
     <div className={cn('flex flex-col', spaced && 'mt-2.5')}>

--- a/erun-ui/playwright/pages/Sidebar.ts
+++ b/erun-ui/playwright/pages/Sidebar.ts
@@ -219,6 +219,29 @@ export class Sidebar {
     return this.erunSection().getByRole('button', { name: `Edit orchestrator ${name} settings` });
   }
 
+  // The row's main click target — labelled "Open" once running, "Start"
+  // otherwise — carries aria-current so a spec can assert it is (or is not)
+  // the sidebar's single focused row (#1204), mirroring envRowButton().
+  orchestratorRowButton(name: string): Locator {
+    return this.erunSection().getByRole('button', {
+      name: new RegExp(`^(Open|Start) orchestrator ${name}$`),
+    });
+  }
+
+  async openOrchestratorSession(name: string): Promise<void> {
+    await this.orchestratorRowButton(name).click();
+  }
+
+  // The tenant name button that opens its dashboard, carrying aria-current
+  // when the dashboard is the sidebar's focused row (#1204).
+  tenantDashboardButton(tenant: string): Locator {
+    return this.page.getByRole('button', { name: `Open ${tenant} dashboard` });
+  }
+
+  async openTenantDashboard(tenant: string): Promise<void> {
+    await this.tenantDashboardButton(tenant).click();
+  }
+
   // The orchestrator's Outputs button, mirroring the env row's. Like the other
   // row actions it is pointer-events-none until hover/focus and a hover raises
   // the IconTooltip popper that would swallow a click, so it is driven by

--- a/erun-ui/playwright/tests/sidebar-focus-exclusive.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-focus-exclusive.spec.ts
@@ -1,0 +1,137 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ENV_ALPHA, SEED_ORCHESTRATOR, SEED_TENANT } from '../fixtures/seedRoot.js';
+
+// #1204: the tenant dashboard, an orchestrator's session, and an environment's
+// session each used to compute their own "active"/"selected" sidebar
+// highlight from a different state slice, with nothing enforcing that only
+// one applied. Opening an orchestrator while the tenant dashboard was open
+// attached its session but never showed it (the dashboard stayed painted
+// over the terminal pane) while both rows rendered selected at once. The fix
+// is a single derived focus value every row reads from, and this spec
+// exercises all three pairings of the invariant it restores: at most one of
+// the tenant dashboard, an orchestrator row, and an environment row is ever
+// the sidebar's focused row, and the main pane always agrees with it.
+
+const RUNNING_SESSION_ID = 4242;
+
+function runningOrchestratorSnapshot() {
+  return {
+    id: SEED_ORCHESTRATOR,
+    name: SEED_ORCHESTRATOR,
+    environments: [],
+    tenants: [],
+    directories: [],
+    sessionId: RUNNING_SESSION_ID,
+    status: 'running',
+    busy: false,
+    transient: false,
+  };
+}
+
+// Stubs ListOrchestrators so the seeded orchestrator reads as already
+// running with a fixed session id — clicking its row then dispatches the
+// synchronous "open" path (openOrchestrator), not a real orchestrator spawn,
+// which the isolated harness has no credentials to perform.
+async function stubRunningOrchestrator(page: Page): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method?: string };
+    if (body.method === 'ListOrchestrators') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [runningOrchestratorSnapshot()] }),
+      });
+    }
+    await route.continue();
+  });
+}
+
+function tenantDashboardHeading(app: { page: Page }) {
+  return app.page.getByRole('heading', { level: 1, name: SEED_TENANT, exact: true });
+}
+
+test.describe('sidebar focus is mutually exclusive across dashboard, orchestrator, and environment (#1204)', () => {
+  test('opening a running orchestrator while the tenant dashboard is open replaces it and swaps the highlight', async ({
+    app,
+    page,
+  }) => {
+    await stubRunningOrchestrator(page);
+    await app.reboot();
+
+    await app.sidebar.openTenantDashboard(SEED_TENANT);
+    await expect(tenantDashboardHeading(app)).toBeVisible();
+    await expect(app.sidebar.tenantDashboardButton(SEED_TENANT)).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+
+    await app.sidebar.openOrchestratorSession(SEED_ORCHESTRATOR);
+
+    // The dashboard is gone — not just deselected in the sidebar — and the
+    // orchestrator's session is what the pane actually shows instead.
+    await expect(tenantDashboardHeading(app)).toHaveCount(0);
+    await expect(app.tabStrip.orchestratorMode()).toBeVisible();
+    await expect(app.tabStrip.environmentMode()).toBeHidden();
+
+    // Exactly one row is highlighted.
+    await expect(app.sidebar.tenantDashboardButton(SEED_TENANT)).not.toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    await expect(app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR)).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+  });
+
+  test('opening the tenant dashboard while an orchestrator is focused replaces it and swaps the highlight', async ({
+    app,
+    page,
+  }) => {
+    await stubRunningOrchestrator(page);
+    await app.reboot();
+
+    await app.sidebar.openOrchestratorSession(SEED_ORCHESTRATOR);
+    await expect(app.tabStrip.orchestratorMode()).toBeVisible();
+    await expect(app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR)).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+
+    await app.sidebar.openTenantDashboard(SEED_TENANT);
+
+    await expect(tenantDashboardHeading(app)).toBeVisible();
+    await expect(app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR)).not.toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    await expect(app.sidebar.tenantDashboardButton(SEED_TENANT)).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+  });
+
+  test('opening an environment while an orchestrator is focused replaces it and swaps the highlight', async ({
+    app,
+    page,
+  }) => {
+    await stubRunningOrchestrator(page);
+    await app.reboot();
+
+    await app.sidebar.openOrchestratorSession(SEED_ORCHESTRATOR);
+    await expect(app.tabStrip.orchestratorMode()).toBeVisible();
+
+    await app.openEnvironmentTerminal(SEED_TENANT, SEED_ENV_ALPHA);
+
+    await expect(app.tabStrip.environmentMode()).toBeVisible();
+    await expect(app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR)).not.toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    await expect(app.sidebar.envRowButton(SEED_TENANT, SEED_ENV_ALPHA)).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+  });
+});


### PR DESCRIPTION
Selecting an orchestrator while a tenant dashboard was open attached the session
but never showed it, and two sidebar rows rendered selected at once.

Both symptoms are the same cause: focus was derived independently in several
places, so nothing guaranteed they agreed or that only one could win. Rather than
adding a flag to suppress the second highlight, this names the focused thing once
— `sidebarFocus` — and routes the thunks, selectors and the three sidebar row
components through it. Opening any one **replaces** the focus, and the attached
session renders because the focus that selected it is the focus the view reads.

## Evidence

| check | result |
|---|---|
| frontend suite, wiring reverted | **6 of 88 fail** |
| frontend suite, wiring restored | **88 pass** |
| Playwright, real Chromium vs headless erun-app | **3 passed (13.0s)** |
| `erun-ui` `go test ./...` | green |
| same, `PATH=/usr/local/go/bin:/usr/bin:/bin` | green |
| `golangci-lint run ./...` | 0 issues |

The Playwright spec covers all three swap directions — dashboard→orchestrator,
orchestrator→dashboard, orchestrator→environment — so the exclusivity is asserted
against the rendered UI, not only the store.

## Provenance, since it is unusual

The implementation was produced by an in-pod agent job that then exited `0`
without committing — twice, both times ending on a "wait for the background
monitor" message with the work left uncommitted in the tree. I reviewed the
inherited diff, ran every gate, proved the tests fail without the fix, ran
Playwright, and landed it. Recording it because "exit code 0" is not evidence a
job finished, and the work itself was sound and worth finishing rather than
discarding.

Closes #1204