### PR TITLE
Add characterization tests for the orchestrator cross-env diff panel

### DIFF
--- a/erun-ui/frontend/src/app/reviewEnvTargets.test.ts
+++ b/erun-ui/frontend/src/app/reviewEnvTargets.test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { selectReviewEnvTargets } from './selectors';
+import type { OrchestratorInfo } from './slices/orchestratorsSlice';
+import type { RootState } from './store';
+
+function orchestrator(
+  id: string,
+  sessionId: number,
+  environments: OrchestratorInfo['environments'],
+) {
+  return {
+    id,
+    name: id,
+    environments,
+    tenants: [...new Set(environments.map((env) => env.tenant))],
+    directories: environments.map((env) => env.directory),
+    sessionId,
+    status: sessionId > 0 ? 'running' : 'stopped',
+    busy: false,
+    transient: false,
+    shellRunning: false,
+    shellCommand: '',
+    shellStartedAtUnix: 0,
+  } satisfies OrchestratorInfo;
+}
+
+// Only the three slices selectReviewEnvTargets reads.
+function stateWith(fields: {
+  sessionId?: number;
+  orchestrators?: OrchestratorInfo[];
+  selected?: { tenant: string; environment: string } | null;
+}): RootState {
+  return {
+    terminal: { sessionId: fields.sessionId ?? 0 },
+    orchestrators: { items: fields.orchestrators ?? [] },
+    selection: { selected: fields.selected ?? null },
+  } as unknown as RootState;
+}
+
+// #1178: an orchestrator session resolves the diff panel's targets from its
+// linked environments, in their configured order -- the order the diff panel
+// renders sections in, and the order ReviewRangeControls scopes its per-env
+// controls by.
+test('an active orchestrator session resolves its linked environments as targets, in order', () => {
+  const state = stateWith({
+    sessionId: 42,
+    orchestrators: [
+      orchestrator('erun-issues', 42, [
+        { tenant: 'acme', environment: 'alpha', directory: '/tmp/alpha' },
+        { tenant: 'acme', environment: 'beta', directory: '/tmp/beta' },
+      ]),
+    ],
+  });
+
+  const targets = selectReviewEnvTargets(state);
+
+  assert.deepEqual(targets, [
+    { envKey: 'acme/alpha', tenant: 'acme', environment: 'alpha' },
+    { envKey: 'acme/beta', tenant: 'acme', environment: 'beta' },
+  ]);
+});
+
+// A single-environment tab is the one-entry case of the same resolution: no
+// orchestrator session active, just the sidebar's selected environment.
+test('an environment tab (no active orchestrator) resolves the sidebar selection as the sole target', () => {
+  const state = stateWith({ selected: { tenant: 'acme', environment: 'alpha' } });
+
+  const targets = selectReviewEnvTargets(state);
+
+  assert.deepEqual(targets, [{ envKey: 'acme/alpha', tenant: 'acme', environment: 'alpha' }]);
+});
+
+test('nothing selected and no active orchestrator resolves no targets', () => {
+  const state = stateWith({});
+
+  assert.deepEqual(selectReviewEnvTargets(state), []);
+});
+
+// The active SESSION decides, not the sidebar's environment selection: with
+// an orchestrator's session active, a stale sidebar selection must not also
+// contribute a target, or the panel would show a section for an environment
+// the orchestrator isn't even linked to.
+test('an active orchestrator session ignores a stale sidebar environment selection', () => {
+  const state = stateWith({
+    sessionId: 42,
+    orchestrators: [
+      orchestrator('erun-issues', 42, [
+        { tenant: 'acme', environment: 'alpha', directory: '/tmp/alpha' },
+      ]),
+    ],
+    selected: { tenant: 'acme', environment: 'unrelated' },
+  });
+
+  const targets = selectReviewEnvTargets(state);
+
+  assert.deepEqual(targets, [{ envKey: 'acme/alpha', tenant: 'acme', environment: 'alpha' }]);
+});
+
+// A stopped orchestrator (sessionId 0) must not contribute targets even
+// though its definition still links environments.
+test('a stopped orchestrator contributes no targets', () => {
+  const state = stateWith({
+    sessionId: 0,
+    orchestrators: [
+      orchestrator('erun-issues', 0, [
+        { tenant: 'acme', environment: 'alpha', directory: '/tmp/alpha' },
+      ]),
+    ],
+  });
+
+  assert.deepEqual(selectReviewEnvTargets(state), []);
+});

--- a/erun-ui/frontend/src/app/slices/reviewSlice.test.ts
+++ b/erun-ui/frontend/src/app/slices/reviewSlice.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { DiffResult } from '@/types';
+
+import reviewReducer, {
+  emptyEnvDiffState,
+  pruneEnvDiffs,
+  type ReviewState,
+  setEnvDiff,
+  setEnvDiffError,
+  setEnvDiffLoading,
+  setEnvReviewCommit,
+  setEnvReviewScope,
+} from './reviewSlice';
+
+function initial(): ReviewState {
+  return reviewReducer(undefined, { type: '@@INIT' });
+}
+
+function diff(marker: string): DiffResult {
+  return { rawDiff: marker, summary: { fileCount: 1, additions: 1, deletions: 0 } };
+}
+
+// #1178: diffByEnv is deliberately sparse (Record<string, EnvDiffState |
+// undefined>), not a plain Record. A key that was never written must read as
+// undefined -- never emptyEnvDiffState's contents mutated in place, and never
+// another environment's slot.
+test('a never-fetched environment has no entry in diffByEnv', () => {
+  const state = initial();
+
+  assert.equal(state.diffByEnv['a/b'], undefined);
+  assert.deepEqual(state.diffByEnv, {});
+});
+
+test("setEnvDiff creates only the written environment's slot, defaulted from emptyEnvDiffState", () => {
+  const state = reviewReducer(initial(), setEnvDiff({ envKey: 'a/b', diff: diff('x') }));
+
+  assert.deepEqual(state.diffByEnv['a/b'], { ...emptyEnvDiffState, diff: diff('x') });
+  assert.equal(state.diffByEnv['c/d'], undefined);
+});
+
+// The core #1178 guarantee: writing one environment's error must never touch
+// another's slot, so a stopped environment's failure cannot blank a healthy
+// one's diff.
+test("setEnvDiffError only ever mutates the targeted environment's slot", () => {
+  let state = initial();
+  state = reviewReducer(state, setEnvDiff({ envKey: 'a/alpha', diff: diff('alpha-diff') }));
+  state = reviewReducer(state, setEnvDiff({ envKey: 'a/beta', diff: diff('beta-diff') }));
+
+  state = reviewReducer(
+    state,
+    setEnvDiffError({ envKey: 'a/alpha', error: 'unreachable', reconnectable: true }),
+  );
+
+  const alpha = state.diffByEnv['a/alpha'];
+  const beta = state.diffByEnv['a/beta'];
+  assert.ok(alpha);
+  assert.ok(beta);
+  assert.equal(alpha.error, 'unreachable');
+  assert.equal(alpha.errorReconnectable, true);
+  // beta's diff and error are untouched by alpha's failure.
+  assert.deepEqual(beta.diff, diff('beta-diff'));
+  assert.equal(beta.error, '');
+  assert.equal(beta.errorReconnectable, false);
+});
+
+test("setEnvDiffLoading only flips the targeted environment's loading flag", () => {
+  let state = initial();
+  state = reviewReducer(state, setEnvDiff({ envKey: 'a/alpha', diff: diff('alpha-diff') }));
+  state = reviewReducer(state, setEnvDiff({ envKey: 'a/beta', diff: diff('beta-diff') }));
+
+  state = reviewReducer(state, setEnvDiffLoading({ envKey: 'a/alpha', loading: true }));
+
+  assert.equal(state.diffByEnv['a/alpha']?.loading, true);
+  assert.equal(state.diffByEnv['a/beta']?.loading, false);
+});
+
+// pruneEnvDiffs drops sections no longer in scope (e.g. switching from a
+// two-env orchestrator to a single env tab) without touching the kept ones.
+test('pruneEnvDiffs drops environments outside the kept set and leaves the rest untouched', () => {
+  let state = initial();
+  state = reviewReducer(state, setEnvDiff({ envKey: 'a/alpha', diff: diff('alpha-diff') }));
+  state = reviewReducer(state, setEnvDiff({ envKey: 'a/beta', diff: diff('beta-diff') }));
+  state = reviewReducer(state, setEnvDiff({ envKey: 'a/gamma', diff: diff('gamma-diff') }));
+
+  state = reviewReducer(state, pruneEnvDiffs(['a/alpha', 'a/beta']));
+
+  assert.deepEqual(Object.keys(state.diffByEnv).sort(), ['a/alpha', 'a/beta']);
+  assert.deepEqual(state.diffByEnv['a/alpha']?.diff, diff('alpha-diff'));
+  assert.deepEqual(state.diffByEnv['a/beta']?.diff, diff('beta-diff'));
+});
+
+// ReviewBase, ReviewCommits, scope and commit are per-repository state, so a
+// scope/commit chosen for one linked environment must never appear on
+// another's slot (#1178, item 5 of the cross-env diff panel guarantee).
+test('scope and commit selection is independent per environment', () => {
+  let state = initial();
+  state = reviewReducer(state, setEnvReviewScope({ envKey: 'a/alpha', scope: 'all' }));
+  state = reviewReducer(state, setEnvReviewCommit({ envKey: 'a/alpha', commit: 'deadbeef' }));
+
+  assert.equal(state.diffByEnv['a/alpha']?.scope, 'all');
+  assert.equal(state.diffByEnv['a/alpha'].commit, 'deadbeef');
+  // beta was never touched, so it has no slot at all rather than inheriting
+  // alpha's scope/commit.
+  assert.equal(state.diffByEnv['a/beta'], undefined);
+
+  state = reviewReducer(state, setEnvReviewScope({ envKey: 'a/beta', scope: 'commit' }));
+  state = reviewReducer(state, setEnvReviewCommit({ envKey: 'a/beta', commit: 'cafebabe' }));
+
+  assert.equal(state.diffByEnv['a/alpha']?.scope, 'all');
+  assert.equal(state.diffByEnv['a/alpha'].commit, 'deadbeef');
+  assert.equal(state.diffByEnv['a/beta']?.scope, 'commit');
+  assert.equal(state.diffByEnv['a/beta'].commit, 'cafebabe');
+});

--- a/erun-ui/frontend/src/app/useEnvDiffSlot.test.ts
+++ b/erun-ui/frontend/src/app/useEnvDiffSlot.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { configureStore } from '@reduxjs/toolkit';
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Provider } from 'react-redux';
+
+import reviewReducer, {
+  emptyEnvDiffState,
+  setEnvDiff,
+  setEnvDiffError,
+} from './slices/reviewSlice';
+import { useEnvDiffSlot } from './useEnvDiffSlot';
+
+function storeWith(entries: Record<string, { diff: unknown; error?: string }>) {
+  const store = configureStore({ reducer: { review: reviewReducer } });
+  for (const [envKey, entry] of Object.entries(entries)) {
+    store.dispatch(setEnvDiff({ envKey, diff: entry.diff as never }));
+    if (entry.error) {
+      store.dispatch(setEnvDiffError({ envKey, error: entry.error, reconnectable: false }));
+    }
+  }
+  return store;
+}
+
+// renderPair mounts a component that calls the real hook -- always exactly
+// twice, unconditionally, so the loop-free call shape satisfies
+// react-hooks/rules-of-hooks -- and captures both return values, via
+// react-dom/server (no jsdom needed since the hook never touches the DOM).
+// This exercises useEnvDiffSlot itself (not a re-implemented copy of its
+// selector expression), so a change to the hook's fallback logic is caught
+// here. Every case below fits two slots: a lone lookup just repeats its key.
+function renderPair(
+  store: ReturnType<typeof storeWith>,
+  envKeyA: string,
+  envKeyB: string,
+): [unknown, unknown] {
+  let captured: [unknown, unknown] = [undefined, undefined];
+  function Probe(): React.ReactElement {
+    captured = [useEnvDiffSlot(envKeyA), useEnvDiffSlot(envKeyB)];
+    return React.createElement('div');
+  }
+  renderToStaticMarkup(
+    React.createElement(Provider, { store, children: React.createElement(Probe) }),
+  );
+  return captured;
+}
+
+test('a fetched environment returns its own slot', () => {
+  const store = storeWith({ 'a/alpha': { diff: { marker: 'alpha' } } });
+
+  const [alpha] = renderPair(store, 'a/alpha', 'a/alpha');
+
+  assert.deepEqual(alpha, { ...emptyEnvDiffState, diff: { marker: 'alpha' } });
+});
+
+// #1178: diffByEnv is sparse, so a key that was never fetched must fall back
+// to the shared empty slot rather than throwing or reading undefined fields.
+test('a never-fetched environment falls back to the empty slot without throwing', () => {
+  const store = storeWith({});
+
+  const [missing] = renderPair(store, 'a/never-fetched', 'a/never-fetched');
+
+  assert.deepEqual(missing, emptyEnvDiffState);
+});
+
+// The failure mode this hook exists to prevent: a missing key must never
+// resolve to a DIFFERENT environment's data. Probing two keys in the same
+// render -- one present, one absent -- pins that the absent one cannot
+// silently alias the present one.
+test("a missing environment never aliases a different environment's slot", () => {
+  const store = storeWith({ 'a/alpha': { diff: { marker: 'alpha-only' } } });
+
+  const [alpha, beta] = renderPair(store, 'a/alpha', 'a/beta');
+
+  assert.deepEqual(alpha, { ...emptyEnvDiffState, diff: { marker: 'alpha-only' } });
+  assert.deepEqual(beta, emptyEnvDiffState);
+  assert.notDeepEqual(beta, alpha);
+});
+
+test("one environment's error does not appear on another environment's slot", () => {
+  const store = storeWith({
+    'a/alpha': { diff: { marker: 'alpha' }, error: 'alpha unreachable' },
+    'a/beta': { diff: { marker: 'beta' } },
+  });
+
+  const [alpha, beta] = renderPair(store, 'a/alpha', 'a/beta');
+
+  assert.equal((alpha as { error: string }).error, 'alpha unreachable');
+  assert.equal((beta as { error: string }).error, '');
+});

--- a/erun-ui/playwright/pages/ReviewPanel.ts
+++ b/erun-ui/playwright/pages/ReviewPanel.ts
@@ -54,4 +54,44 @@ export class ReviewPanel {
   currentTreeNode(): Locator {
     return this.changedFilesTree().locator('[aria-current="true"]');
   }
+
+  // envSectionHeader locates the sticky per-environment header the diff panel
+  // renders above each linked environment's section once more than one target
+  // is shown (#1178). Scoped to DiffList's sticky header class combination
+  // (unique in the frontend source) rather than a plain text match: the
+  // changed-files tree renders its own per-env header with the same envKey
+  // text, and other surfaces (sidebar rows, tab labels) can also contain it.
+  envSectionHeader(envKey: string): Locator {
+    return this.page.locator('.sticky.top-0.z-10.border-b').filter({ hasText: envKey });
+  }
+
+  // The "Changed files N" collapsible header inside the aside, distinct from
+  // the titlebar's "Toggle changed files list" (which hides the whole aside).
+  // Collapsing it hides the changed-files tree's own per-env headers and error
+  // alerts, so a spec asserting on the diff list's alone can scope past the
+  // tree's duplicate rendering of the same slot.
+  changedFilesSectionToggle(): Locator {
+    return this.page.getByRole('button', { name: /^Changed files/ });
+  }
+
+  async collapseChangedFilesSection(): Promise<void> {
+    await this.changedFilesSectionToggle().click();
+  }
+
+  // The changed-files tree renders its own DiffErrorAlert for the same
+  // per-env slot (#1178), so counting alerts document-wide double-counts once
+  // both surfaces are visible. Callers that care about the diff list's own
+  // alert count should collapseChangedFilesSection() first.
+  errorAlerts(): Locator {
+    return this.page.getByRole('alert');
+  }
+
+  // reviewBoundaryButton locates a "Review layers" scope button by its visible
+  // label (e.g. "Current local changes", "All branch changes"). Each linked
+  // environment renders its own control with no per-env accessible label, so
+  // callers scope by DOM order, which matches the environments' configured
+  // order (selectReviewEnvTargets).
+  reviewBoundaryButton(label: string, index: number): Locator {
+    return this.page.getByRole('button', { name: new RegExp(label) }).nth(index);
+  }
 }

--- a/erun-ui/playwright/pages/Sidebar.ts
+++ b/erun-ui/playwright/pages/Sidebar.ts
@@ -40,10 +40,6 @@ export class Sidebar {
     await this.tenantRow(name).first().click();
   }
 
-  async openTenantDashboard(name: string): Promise<void> {
-    await this.page.getByRole('button', { name: `Open ${name} dashboard` }).click();
-  }
-
   async isTenantExpanded(name: string): Promise<boolean> {
     const value = await this.tenantRow(name).first().getAttribute('aria-expanded');
     return value === 'true';

--- a/erun-ui/playwright/pages/Titlebar.ts
+++ b/erun-ui/playwright/pages/Titlebar.ts
@@ -16,11 +16,34 @@ export class Titlebar {
   }
 
   async toggleReviewPanel(): Promise<void> {
-    await this.page.getByRole('button', { name: 'Toggle diff panel' }).click();
+    await this.diffPanelToggle().click();
+  }
+
+  diffPanelToggle(): Locator {
+    return this.page.getByRole('button', { name: 'Toggle diff panel' });
   }
 
   async toggleFilesPanel(): Promise<void> {
-    await this.page.getByRole('button', { name: 'Toggle changed files list' }).click();
+    await this.changedFilesToggle().click();
+  }
+
+  changedFilesToggle(): Locator {
+    return this.page.getByRole('button', { name: 'Toggle changed files list' });
+  }
+
+  // Env-scoped titlebar controls: the two IDE buttons and the contribute
+  // toggle. These render only when the active session is an environment tab,
+  // not an orchestrator session (#1178).
+  vscodeButton(): Locator {
+    return this.page.getByRole('button', { name: /VS Code/i });
+  }
+
+  intellijButton(): Locator {
+    return this.page.getByRole('button', { name: /IntelliJ|IDEA/i });
+  }
+
+  contributeToggleButton(): Locator {
+    return this.page.getByRole('button', { name: /Contribute to ERun|Disable contribute mode/ });
   }
 
   async openVSCode(): Promise<void> {

--- a/erun-ui/playwright/tests/orchestrator-cross-env-diff.spec.ts
+++ b/erun-ui/playwright/tests/orchestrator-cross-env-diff.spec.ts
@@ -1,0 +1,363 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ENV_ALPHA, SEED_ENV_BETA, SEED_TENANT } from '../fixtures/seedRoot.js';
+
+// The orchestrator cross-env diff panel (#1178) is the orchestrator's primary
+// code-review instrument: with a cross-env session focused, the panel shows
+// one section per LINKED environment instead of one merged diff, and each
+// section owns its own loading/error/scope state so one stopped environment
+// cannot blank another's. None of the existing diff specs (review-diff-tree,
+// diff-error-copy, erun-section) exercise a running multi-env orchestrator
+// session, so this spec fills that gap.
+
+const ORCHESTRATOR_ID = 'pw-orch-diff';
+const RUNNING_SESSION_ID = 9001;
+const ALPHA_ENV_KEY = `${SEED_TENANT}/${SEED_ENV_ALPHA}`;
+const BETA_ENV_KEY = `${SEED_TENANT}/${SEED_ENV_BETA}`;
+
+interface DiffLineStub {
+  kind: string;
+  oldLine: number | null;
+  newLine: number | null;
+  content: string;
+}
+interface DiffFileStub {
+  path: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  binary: boolean;
+  hunks: { header: string; lines: DiffLineStub[] }[];
+}
+interface DiffCommitStub {
+  hash: string;
+  shortHash: string;
+  subject: string;
+  author: string;
+  date: string;
+}
+interface DiffReviewBaseStub {
+  branch: string;
+  commit: string;
+  shortCommit: string;
+}
+
+function diffFile(path: string): DiffFileStub {
+  return {
+    path,
+    status: 'modified',
+    additions: 1,
+    deletions: 0,
+    binary: false,
+    hunks: [
+      {
+        header: '@@ -1,1 +1,1 @@',
+        lines: [{ kind: 'add', oldLine: null, newLine: 1, content: `${path}:0` }],
+      },
+    ],
+  };
+}
+
+// One success stub per environment: a single distinct file, plus optional
+// review-range state (base + commits) for the scope-isolation case. The
+// `scope`/`selectedCommit` echoed back mirror the real backend contract
+// (applyReviewDiffSuccess re-derives the slot's scope/commit from the
+// response), so a spec that selects a scope must see it round-trip.
+interface EnvDiffSuccessStub {
+  kind: 'success';
+  file: string;
+  reviewBase?: DiffReviewBaseStub;
+  reviewCommits?: DiffCommitStub[];
+}
+interface EnvDiffErrorStub {
+  kind: 'error';
+  message: string;
+}
+type EnvDiffStub = EnvDiffSuccessStub | EnvDiffErrorStub;
+
+function orchestratorSnapshot(): unknown {
+  return {
+    id: ORCHESTRATOR_ID,
+    name: ORCHESTRATOR_ID,
+    environments: [
+      { tenant: SEED_TENANT, environment: SEED_ENV_ALPHA, directory: '/tmp/orch-alpha' },
+      { tenant: SEED_TENANT, environment: SEED_ENV_BETA, directory: '/tmp/orch-beta' },
+    ],
+    tenants: [SEED_TENANT],
+    directories: ['/tmp/orch-alpha', '/tmp/orch-beta'],
+    sessionId: RUNNING_SESSION_ID,
+    status: 'running',
+    busy: false,
+    transient: false,
+    shellRunning: false,
+    shellCommand: '',
+    shellStartedAtUnix: 0,
+  };
+}
+
+// stubOrchestratorAndDiffs combines both fakes behind one route registration:
+// ListOrchestrators reports the running, multi-env orchestrator above, and
+// LoadDiff resolves per environment according to `byEnv`, keyed by
+// environment name. Everything else (and any environment missing from
+// `byEnv`) falls through to the real headless backend. `calls` records every
+// LoadDiff request's target environment, in order, so a spec can assert one
+// fetch happened per linked environment rather than one merged fetch.
+async function stubOrchestratorAndDiffs(
+  page: Page,
+  byEnv: Record<string, EnvDiffStub>,
+): Promise<{ calls: string[] }> {
+  const calls: string[] = [];
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as {
+      method?: string;
+      args?: unknown[];
+    };
+    if (body.method === 'ListOrchestrators') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [orchestratorSnapshot()] }),
+      });
+    }
+    if (body.method !== 'LoadDiff') {
+      await route.continue();
+      return;
+    }
+    const [selection, options] = (body.args ?? []) as [
+      { tenant: string; environment: string },
+      { scope?: string; selectedCommit?: string } | undefined,
+    ];
+    calls.push(selection.environment);
+    const stub = byEnv[selection.environment];
+    if (!stub) {
+      await route.continue();
+      return;
+    }
+    if (stub.kind === 'error') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ error: stub.message }),
+      });
+    }
+    return route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: {
+          rawDiff: '',
+          workingDirectory: '/seed',
+          summary: { fileCount: 1, additions: 1, deletions: 0 },
+          files: [diffFile(stub.file)],
+          tree: [{ name: stub.file, path: stub.file, type: 'file', depth: 0 }],
+          reviewBase: stub.reviewBase,
+          reviewCommits: stub.reviewCommits,
+          scope: options?.scope ?? 'current',
+          selectedCommit: options?.selectedCommit ?? '',
+          includesWorktree: true,
+        },
+      }),
+    });
+  });
+  return { calls };
+}
+
+test.describe('orchestrator cross-env diff panel (#1178)', () => {
+  test('renders one section per linked environment, not a single merged diff', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorAndDiffs(page, {
+      [SEED_ENV_ALPHA]: { kind: 'success', file: 'alpha-only.ts' },
+      [SEED_ENV_BETA]: { kind: 'success', file: 'beta-only.ts' },
+    });
+    await app.reboot();
+
+    await app.sidebar.openOrchestratorSession(ORCHESTRATOR_ID);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+
+    await expect(review.envSectionHeader(ALPHA_ENV_KEY)).toBeVisible();
+    await expect(review.envSectionHeader(BETA_ENV_KEY)).toBeVisible();
+    await expect
+      .poll(() => review.diffSectionPaths())
+      .toEqual(expect.arrayContaining(['alpha-only.ts', 'beta-only.ts']));
+  });
+
+  test('fetches each linked environment independently rather than one shared request', async ({
+    app,
+    page,
+  }) => {
+    const { calls } = await stubOrchestratorAndDiffs(page, {
+      [SEED_ENV_ALPHA]: { kind: 'success', file: 'alpha-only.ts' },
+      [SEED_ENV_BETA]: { kind: 'success', file: 'beta-only.ts' },
+    });
+    await app.reboot();
+
+    await app.sidebar.openOrchestratorSession(ORCHESTRATOR_ID);
+    await app.titlebar.toggleReviewPanel();
+    await expect
+      .poll(() => app.reviewPanel.diffSectionPaths())
+      .toEqual(expect.arrayContaining(['alpha-only.ts', 'beta-only.ts']));
+
+    await expect
+      .poll(() => calls.filter((env) => env === SEED_ENV_ALPHA).length)
+      .toBeGreaterThan(0);
+    await expect.poll(() => calls.filter((env) => env === SEED_ENV_BETA).length).toBeGreaterThan(0);
+  });
+
+  test("one environment's failure shows its own error while the other keeps rendering", async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorAndDiffs(page, {
+      [SEED_ENV_ALPHA]: { kind: 'error', message: 'ALPHA_UNREACHABLE_MARKER' },
+      [SEED_ENV_BETA]: { kind: 'success', file: 'beta-ok.ts' },
+    });
+    await app.reboot();
+
+    await app.sidebar.openOrchestratorSession(ORCHESTRATOR_ID);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+    // The changed-files tree renders its own copy of the same per-env alert;
+    // collapse it so the alert count below reflects the diff list alone.
+    await review.collapseChangedFilesSection();
+    await expect(review.changedFilesTree()).toBeHidden();
+
+    // Both sections still render (the failing environment does not disappear
+    // or blank the panel), beta's file survives alpha's failure, and exactly
+    // one alert shows -- proving alpha's error stayed in its own section
+    // instead of clearing beta's diff too.
+    await expect(review.envSectionHeader(ALPHA_ENV_KEY)).toBeVisible();
+    await expect(review.envSectionHeader(BETA_ENV_KEY)).toBeVisible();
+    await expect(review.errorAlerts()).toHaveCount(1);
+    await expect(
+      review.errorAlerts().filter({ hasText: 'ALPHA_UNREACHABLE_MARKER' }),
+    ).toBeVisible();
+    await expect.poll(() => review.diffSectionPaths()).toEqual(['beta-ok.ts']);
+  });
+
+  test('each environment carries its own distinct error independently', async ({ app, page }) => {
+    await stubOrchestratorAndDiffs(page, {
+      [SEED_ENV_ALPHA]: { kind: 'error', message: 'ALPHA_UNREACHABLE_MARKER' },
+      [SEED_ENV_BETA]: { kind: 'error', message: 'BETA_UNREACHABLE_MARKER' },
+    });
+    await app.reboot();
+
+    await app.sidebar.openOrchestratorSession(ORCHESTRATOR_ID);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+    await review.collapseChangedFilesSection();
+    await expect(review.changedFilesTree()).toBeHidden();
+
+    await expect(review.errorAlerts()).toHaveCount(2);
+    await expect(
+      review.errorAlerts().filter({ hasText: 'ALPHA_UNREACHABLE_MARKER' }),
+    ).toBeVisible();
+    await expect(review.errorAlerts().filter({ hasText: 'BETA_UNREACHABLE_MARKER' })).toBeVisible();
+  });
+
+  test("a missing/unfetched environment section never shows another environment's files", async ({
+    app,
+    page,
+  }) => {
+    // alpha never resolves (falls through to the real backend for an
+    // undeployed env, which reports unreachable/no-diff); beta resolves with
+    // a distinct file. diffByEnv is a sparse map -- useEnvDiffSlot substitutes
+    // the empty slot for a key that hasn't been fetched instead of throwing or
+    // aliasing another environment's slot -- so alpha's section must render
+    // its own empty/error state, never beta's file.
+    await stubOrchestratorAndDiffs(page, {
+      [SEED_ENV_BETA]: { kind: 'success', file: 'beta-only.ts' },
+    });
+    await app.reboot();
+
+    await app.sidebar.openOrchestratorSession(ORCHESTRATOR_ID);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+
+    await expect(review.envSectionHeader(ALPHA_ENV_KEY)).toBeVisible();
+    await expect(review.envSectionHeader(BETA_ENV_KEY)).toBeVisible();
+    await expect.poll(() => review.diffSectionPaths()).toEqual(['beta-only.ts']);
+  });
+
+  test('per-env review scope selection does not leak across environments', async ({
+    app,
+    page,
+  }) => {
+    const base: DiffReviewBaseStub = { branch: 'main', commit: 'base0', shortCommit: 'base0' };
+    await stubOrchestratorAndDiffs(page, {
+      [SEED_ENV_ALPHA]: {
+        kind: 'success',
+        file: 'alpha.ts',
+        reviewBase: base,
+        reviewCommits: [
+          { hash: 'a1', shortHash: 'a1', subject: 'Alpha commit', author: 'a', date: '2024-01-01' },
+        ],
+      },
+      [SEED_ENV_BETA]: {
+        kind: 'success',
+        file: 'beta.ts',
+        reviewBase: base,
+        reviewCommits: [
+          { hash: 'b1', shortHash: 'b1', subject: 'Beta commit', author: 'a', date: '2024-01-01' },
+        ],
+      },
+    });
+    await app.reboot();
+
+    await app.sidebar.openOrchestratorSession(ORCHESTRATOR_ID);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+    await expect
+      .poll(() => review.diffSectionPaths())
+      .toEqual(expect.arrayContaining(['alpha.ts', 'beta.ts']));
+
+    // Index 0 is alpha, index 1 is beta: ReviewRangeControls renders one
+    // control per target in selectReviewEnvTargets' order, which mirrors the
+    // orchestrator's configured environments order set up above.
+    const alphaAll = review.reviewBoundaryButton('All branch changes', 0);
+    const alphaCurrent = review.reviewBoundaryButton('Current local changes', 0);
+    const betaAll = review.reviewBoundaryButton('All branch changes', 1);
+    const betaCurrent = review.reviewBoundaryButton('Current local changes', 1);
+
+    await expect(alphaCurrent).toHaveAttribute('aria-pressed', 'true');
+    await expect(betaCurrent).toHaveAttribute('aria-pressed', 'true');
+
+    await alphaAll.click();
+
+    await expect(alphaAll).toHaveAttribute('aria-pressed', 'true');
+    await expect(alphaCurrent).toHaveAttribute('aria-pressed', 'false');
+    // beta's own scope selection is untouched by alpha's.
+    await expect(betaCurrent).toHaveAttribute('aria-pressed', 'true');
+    await expect(betaAll).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('the titlebar right cluster keeps only the diff toggle in orchestrator mode, plus the changed-files sub-toggle once the panel is open (#1190)', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorAndDiffs(page, {
+      [SEED_ENV_ALPHA]: { kind: 'success', file: 'alpha-only.ts' },
+      [SEED_ENV_BETA]: { kind: 'success', file: 'beta-only.ts' },
+    });
+    await app.reboot();
+
+    await app.sidebar.openOrchestratorSession(ORCHESTRATOR_ID);
+
+    await expect(app.titlebar.diffPanelToggle()).toBeVisible();
+    await expect(app.titlebar.vscodeButton()).toHaveCount(0);
+    await expect(app.titlebar.intellijButton()).toHaveCount(0);
+    await expect(app.titlebar.contributeToggleButton()).toHaveCount(0);
+    await expect(app.titlebar.changedFilesToggle()).toHaveCount(0);
+
+    await app.titlebar.toggleReviewPanel();
+    await expect(app.titlebar.changedFilesToggle()).toBeVisible();
+    // The env-scoped controls stay hidden even with the panel open -- the
+    // orchestrator session, not the diff panel, gates them.
+    await expect(app.titlebar.vscodeButton()).toHaveCount(0);
+    await expect(app.titlebar.intellijButton()).toHaveCount(0);
+    await expect(app.titlebar.contributeToggleButton()).toHaveCount(0);
+
+    await app.titlebar.toggleReviewPanel();
+    await expect(app.titlebar.changedFilesToggle()).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a characterization test net for the orchestrator cross-env diff panel (#1178) ahead of the #1211 shared-frontend-foundation extraction, which is the change most likely to flatten this surface silently — it is the orchestrator's primary code-review instrument.
- Unit tests (`node --import tsx --test`) pin the slice/selector/hook layer: `reviewSlice.test.ts` (sparse `diffByEnv`, per-env error/loading/scope isolation, `pruneEnvDiffs`), `reviewEnvTargets.test.ts` (`selectReviewEnvTargets` resolves an orchestrator's linked environments in order, falls back to the single sidebar selection, ignores a stale selection while an orchestrator session is active), and `useEnvDiffSlot.test.ts` (the hook itself, rendered via `react-dom/server` with a real `react-redux` `Provider` — no jsdom needed — falls back to the empty slot for a missing key and never aliases a different environment's slot).
- A new Playwright spec, `orchestrator-cross-env-diff.spec.ts`, drives a real (stubbed) running multi-env orchestrator session and asserts: one section per linked environment (not a merged diff); one `LoadDiff` fetch per environment; one environment's failure renders its own error while the other keeps rendering; two failing environments each show their own distinct error; a missing/unfetched environment's section never shows another's files; per-env review-scope selection (`selectReviewRange`) doesn't leak across environments; and the #1190 titlebar right cluster keeps only the diff toggle in orchestrator mode, gaining the changed-files sub-toggle only once the panel is open. None of the existing specs (`review-diff-tree.spec.ts`, `diff-error-copy.spec.ts`, `erun-section.spec.ts`) exercise a running multi-env orchestrator session, so this fills that gap.
- Two small Playwright POM additions to make these assertions possible: `ReviewPanel.envSectionHeader`/`errorAlerts`/`reviewBoundaryButton`/`collapseChangedFilesSection`, and `Titlebar.diffPanelToggle`/`changedFilesToggle`/`vscodeButton`/`intellijButton`/`contributeToggleButton`.
- Fixes a pre-existing bug encountered while getting this module's typecheck gate green: `playwright/pages/Sidebar.ts` had two independent `openTenantDashboard` method definitions (added by two separate, already-merged PRs — `cc99e11a` and `13e8ed90` — that didn't conflict because they touched different regions of the file), which is a TypeScript compile error. Removed the dead first definition; behavior is unchanged since the two implementations were functionally identical and JS class semantics already meant the second silently won at runtime.

This PR is tests-only: no production behavior was changed. Every behavior below was proven to have teeth by deliberately breaking the real implementation, confirming the corresponding test failed, and restoring it.

## Mutations caught (per pinned behaviour)

**Unit level**

| Mutation | Caught by |
|---|---|
| `envSlot` in `reviewSlice.ts` collapsed to a single shared slot regardless of `envKey` | 5/6 `reviewSlice.test.ts` tests, 3/4 `useEnvDiffSlot.test.ts` tests |
| `useEnvDiffSlot` made to always return `Object.values(diffByEnv)[0]` (aliasing) | the 2 aliasing-specific `useEnvDiffSlot.test.ts` tests |
| `selectReviewEnvTargets` orchestrator branch removed entirely | 2/5 `reviewEnvTargets.test.ts` tests (the orchestrator-dependent ones) |
| `selectReviewEnvTargets` reversed the linked-environments order | the order-assertion test in `reviewEnvTargets.test.ts` |

**Playwright level** (each rebuilt `bin/erun-app` from the mutated source and re-ran the spec)

| Mutation | Caught by |
|---|---|
| `DiffList.tsx`: `multi` forced to `false` (always render a single merged section, no per-env headers) | 3/7 spec tests (the ones asserting `envSectionHeader` visibility) |
| `Titlebar.Controls.tsx`: `TitlebarEnvControls` rendered unconditionally, ignoring orchestrator mode | the titlebar-cluster test (`VS Code` button count 0 → 1) |
| `Titlebar.Controls.tsx`: changed-files sub-toggle rendered unconditionally, ignoring `reviewOpen` | the same titlebar-cluster test (`Toggle changed files list` count 0 → 1 before the panel opens) |
| `ReviewPanel.tsx`: `ReviewRangeControls` made every environment share the first target's `envKey` (scope leak) | the scope-isolation test (beta's "Current local changes" flipped in lockstep with alpha's selection) |

## Pre-existing failures observed (not caused by this PR — no production code was touched)

Running the full `erun-ui/playwright` suite (184 tests) surfaced 3 failures, all pre-existing on `main`:

- **#1222** — `manage-container-registries.spec.ts` — container registry role changes don't persist through manage-dialog save/reload.
- **#1223** — `review-diff-tree.spec.ts` — filter spec times out waiting for the periodic diff refresh.
- **#1243** (newly filed) — `terminal-scroll-on-resize.spec.ts` — a different, non-timeout flake from the one #867 (closed) fixed: 5/8 isolated repeats failed with a real assertion mismatch (`viewportEverAtBottom` observed `true` when the test requires `false`), not a timeout. Filed and left for follow-up per this PR's tests-only scope.

All three are unrelated to the review/diff-panel surface this PR touches; my full diff contains no production code changes (only test files, Playwright POM additions, and the `Sidebar.ts` dead-code fix above).

## Test plan

- [x] `go test ./...` in `erun-ui` — green, both normally and under `env PATH=/usr/local/go/bin:/usr/bin:/bin`
- [x] `golangci-lint run ./...` in `erun-ui` — 0 issues
- [x] `yarn typecheck && yarn lint && yarn format:check` in `erun-ui/frontend` — clean
- [x] `node --import tsx --test "src/**/*.test.ts"` in `erun-ui/frontend` — 103/103 pass
- [x] `yarn typecheck && yarn lint && yarn format:check` in `erun-ui/playwright` — clean
- [x] Full `npx playwright test` in `erun-ui/playwright` — 181 passed, 3 pre-existing failures (see above), 0 caused by this PR
- [x] Mutation-tested every pinned behaviour against the real implementation (table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)