### PR TITLE
Add a 5s alive contract to erun jobs

### DIFF
--- a/erun-cli/cmd/job.go
+++ b/erun-cli/cmd/job.go
@@ -275,9 +275,16 @@ func newJobStatusCmd(resolveOpen OpenResolver) *cobra.Command {
 		Short: "Report one job's state and outcome, or every retained job",
 		Long: "Answers running, exited, or unknown — never a partial answer. A job whose\n" +
 			"supervisor is gone without an outcome reads as unknown rather than as\n" +
-			"success, which is what makes it safe to act on. Finished jobs stay readable\n" +
-			"for 24 hours so a caller that reconnects after the work ended can still\n" +
-			"learn what happened.",
+			"success, which is what makes it safe to act on: unknown is exactly as\n" +
+			"terminal as exited, never a reason to keep waiting. Finished jobs stay\n" +
+			"readable for 24 hours so a caller that reconnects after the work ended can\n" +
+			"still learn what happened.\n\n" +
+			"aliveAgeMs is the milliseconds since the supervisor's last ~1s beat,\n" +
+			"computed in erun's own clock so nothing subtracts a pod timestamp from a\n" +
+			"caller's clock. Once it exceeds 5000, treat the job as failed (an unknown\n" +
+			"outcome, never a success, never a tool error) even if state has not caught\n" +
+			"up yet; a silent-but-healthy command never trips this, since the beat does\n" +
+			"not depend on the work's own output.",
 		Example: "  erun job status --tenant team --environment dev\n" +
 			"  erun job status --tenant team --environment dev --id suite --output json",
 		Args: cobra.NoArgs,
@@ -392,7 +399,7 @@ func jobStatusLine(job common.EnvironmentJob) string {
 		} else if job.PID > 0 {
 			line += fmt.Sprintf(", pid %d", job.PID)
 		}
-		return line + jobAgentSuffix(job) + jobOutputSuffix(job)
+		return line + jobAliveSuffix(job) + jobAgentSuffix(job) + jobOutputSuffix(job)
 	case common.EnvironmentJobStateExited:
 		line := fmt.Sprintf("exited %d: %s", jobExitCodeOrUnset(job), job.Name)
 		if strings.TrimSpace(job.Signal) != "" {
@@ -406,6 +413,17 @@ func jobStatusLine(job common.EnvironmentJob) string {
 		}
 		return line + jobAgentSuffix(job) + jobOutputSuffix(job)
 	}
+}
+
+// jobAliveSuffix surfaces the supervisor's alive beat for a running job, so an
+// operator watching `job status` sees the same signal the 5s caller rule acts
+// on rather than only the frozen activity string a stalled beat would
+// otherwise leave on screen.
+func jobAliveSuffix(job common.EnvironmentJob) string {
+	if job.AliveAgeMs == nil {
+		return ""
+	}
+	return fmt.Sprintf(", last beat %dms ago", *job.AliveAgeMs)
 }
 
 // jobAgentSuffix reports what an agent run is doing right now. An agent job that
@@ -451,7 +469,13 @@ func newJobAwaitCmd(resolveOpen OpenResolver) *cobra.Command {
 		Long: "The wait is bounded and the call returns either an outcome or \"still\n" +
 			"running\" — it never holds a connection open for the work's lifetime, which\n" +
 			"is what drops under load and leaves a caller unable to tell a dead stream\n" +
-			"from a dead job.\n\n" +
+			"from a dead job. A job whose supervisor died reads back as unknown with\n" +
+			"timedOut false, its own third case distinct from both success and \"still\n" +
+			"running\" — never re-await it expecting a different answer.\n\n" +
+			"The reported job's aliveAgeMs is the faster of the two signals: it crosses\n" +
+			"the 5000ms caller threshold before state necessarily catches up, so a\n" +
+			"caller in a hurry can act on it directly instead of waiting for the next\n" +
+			"reconcile (see `erun job status --help`).\n\n" +
 			"Exit codes are the contract: 0 when the job exited 0, 124 when the timeout\n" +
 			"elapsed with the job still running, 125 when the outcome is unknown, and 1\n" +
 			"when the job exited non-zero (its real code is in the reported result).",
@@ -513,7 +537,7 @@ func awaitJob(ctx context.Context, commandCtx common.Context, resolveOpen OpenRe
 
 func jobAwaitLine(result common.AwaitEnvironmentJobResult) string {
 	if result.TimedOut {
-		return fmt.Sprintf("still running after %ds: %s", result.TimeoutSeconds, result.Job.Name)
+		return fmt.Sprintf("still running after %ds: %s", result.TimeoutSeconds, result.Job.Name) + jobAliveSuffix(result.Job)
 	}
 	return jobStatusLine(result.Job)
 }
@@ -545,7 +569,10 @@ func newJobOutputCmd(resolveOpen OpenResolver) *cobra.Command {
 		Short: "Read a job's captured output, including while it is still running",
 		Long: "Output is served from the job's log as it stands, so progress is visible long\n" +
 			"before the work exits. Read a page at a time and pass the reported next\n" +
-			"offset back to continue where you left off.",
+			"offset back to continue where you left off. A silent-but-healthy command\n" +
+			"(an image pull, a slow test) never advances outputBytes for minutes at a\n" +
+			"time, so use the reported job's aliveAgeMs (see `erun job status --help`),\n" +
+			"not output growth, to tell quiet-but-alive apart from actually dead.",
 		Example: "  erun job output --tenant team --environment dev --id suite --offset 4096",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/erun-common/job.go
+++ b/erun-common/job.go
@@ -92,6 +92,20 @@ const (
 	// so a caller starting many short jobs cannot grow the store without limit.
 	EnvironmentJobHistoryCap = 50
 
+	// EnvironmentJobAliveHeartbeatInterval is the fixed cadence the supervisor
+	// stamps LastAliveAt/AliveSeq at, independent of the activity lease's much
+	// coarser renewal interval (300s at the default TTL) and of an agent job's
+	// 2s progress fold. It does not depend on the work producing output, which
+	// is what lets it answer "is the supervisor still there" for a command job
+	// that is legitimately silent for minutes (an image pull, a slow test).
+	EnvironmentJobAliveHeartbeatInterval = 1 * time.Second
+	// EnvironmentJobAliveStaleMs is the documented caller rule: once AliveAgeMs
+	// exceeds this, stop waiting and treat the job as failed with an unknown
+	// outcome. It is 5x EnvironmentJobAliveHeartbeatInterval — headroom for poll
+	// jitter and scheduling delay, not for the beat itself ever being late by
+	// design.
+	EnvironmentJobAliveStaleMs int64 = 5000
+
 	// DefaultEnvironmentJobOutputReadBytes bounds one output read so a poll
 	// returns a page rather than the whole log.
 	DefaultEnvironmentJobOutputReadBytes int64 = 64 << 10
@@ -162,6 +176,25 @@ type EnvironmentJob struct {
 	// LeaseID is the activity lease the job holds for its lifetime, which is why
 	// starting one also makes the environment read as busy.
 	LeaseID string `json:"leaseId,omitempty"`
+
+	// LastAliveAt is the pod-clock timestamp of the supervisor's last alive
+	// beat, stamped on a fixed cadence independent of the work's own output
+	// (see EnvironmentJobAliveHeartbeatInterval). It is never compared against
+	// a caller's own clock — the two clocks are not the same clock — which is
+	// why every reader derives AliveAgeMs from it instead of exposing it raw
+	// for a caller to subtract against.
+	LastAliveAt time.Time `json:"lastAliveAt,omitempty"`
+	// AliveSeq is a monotonic counter bumped on every beat, so a caller can
+	// tell "still beating" from "the same timestamp read twice".
+	AliveSeq int64 `json:"aliveSeq,omitempty"`
+	// AliveAgeMs is computed fresh on every read as now-LastAliveAt, in the
+	// pod's own clock, and is nil only when the job has never beaten (an
+	// attached job, or one whose supervisor has not registered yet). A caller
+	// that sees this exceed EnvironmentJobAliveStaleMs treats the job as
+	// failed — reported as an unknown outcome, never as success and never as
+	// a tool error — rather than waiting on a beat a dead supervisor can no
+	// longer produce.
+	AliveAgeMs *int64 `json:"aliveAgeMs,omitempty"`
 }
 
 // Finished reports whether the job reached a terminal state.
@@ -243,6 +276,10 @@ func loadEnvironmentJobs(tenant, environment string, now time.Time, alive func(i
 // the job is demoted to unknown and that demotion is persisted, so every later
 // read gives the same definite answer.
 func reconcileEnvironmentJob(dir string, job EnvironmentJob, now time.Time, alive func(int) bool, hostname string) EnvironmentJob {
+	// Computed fresh on every read, in the reader's own now, and never
+	// persisted: a stale value on disk would be meaningless without the read
+	// time that produced it, exactly like OutputBytes below.
+	job.AliveAgeMs = environmentJobAliveAgeMs(job.LastAliveAt, now)
 	if job.State != EnvironmentJobStateRunning {
 		return job
 	}
@@ -271,6 +308,20 @@ func reconcileEnvironmentJob(dir string, job EnvironmentJob, now time.Time, aliv
 	job.OutputBytes = environmentJobOutputSize(job.LogPath, job.OutputBytes)
 	_ = writeEnvironmentJob(dir, job)
 	return job
+}
+
+// environmentJobAliveAgeMs is nil only when the job has never beaten, so a
+// caller never mistakes "no signal yet" for "beating zero milliseconds ago".
+func environmentJobAliveAgeMs(lastAliveAt, now time.Time) *int64 {
+	if lastAliveAt.IsZero() {
+		return nil
+	}
+	age := now.Sub(lastAliveAt)
+	if age < 0 {
+		age = 0
+	}
+	ms := age.Milliseconds()
+	return &ms
 }
 
 // currentJobHostname is the pod hostname a job supervisor stamps at start and

--- a/erun-common/job_alive_test.go
+++ b/erun-common/job_alive_test.go
@@ -1,0 +1,154 @@
+package eruncommon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// The alive contract exists because a job's supervisor can die outright (a
+// SIGTERM'd container, an OOM kill) and leave nothing to say so from the
+// inside. Simulating that in-process would only prove the reconcile logic
+// reacts correctly to a stopped ticker, not that the whole thing survives a
+// real process actually going away — so this spawns a genuine supervisor in
+// its own OS process and kills it for real, the same way TestMain already
+// re-enters this binary as a stub ssh for the workspace-sync tests.
+
+const (
+	jobAliveSupervisorHelperEnv        = "ERUN_COMMON_TEST_JOB_ALIVE_SUPERVISOR_HELPER"
+	jobAliveSupervisorHelperTenantEnv  = "ERUN_COMMON_TEST_JOB_ALIVE_TENANT"
+	jobAliveSupervisorHelperEnvNameEnv = "ERUN_COMMON_TEST_JOB_ALIVE_ENVIRONMENT"
+	jobAliveSupervisorHelperIDEnv      = "ERUN_COMMON_TEST_JOB_ALIVE_ID"
+)
+
+// runJobAliveSupervisorHelper is the re-entered process body: it runs the real
+// supervisor against a long-lived child, so killing this process is killing
+// exactly what a runtime pod's own supervisor process is.
+func runJobAliveSupervisorHelper() int {
+	id := os.Getenv(jobAliveSupervisorHelperIDEnv)
+	err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant:      os.Getenv(jobAliveSupervisorHelperTenantEnv),
+		Environment: os.Getenv(jobAliveSupervisorHelperEnvNameEnv),
+		ID:          id,
+		Name:        id,
+		Command:     []string{"sleep", "60"},
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}
+
+func TestEnvironmentJobAliveAgeMsExceedsFiveSecondsWithinSixSecondsOfSupervisorSIGKILL(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SIGKILL semantics are POSIX-only")
+	}
+	isolateActivityCache(t)
+
+	const tenant = "alive-contract"
+	const environment = "kill-test"
+	const id = "beat"
+
+	helper := startJobAliveSupervisorHelper(t, tenant, environment, id)
+	childPID := awaitFirstAliveBeat(t, tenant, environment, id)
+	killJobAliveSupervisorHelper(t, helper, childPID)
+	awaitAliveAgeExceedsStaleThreshold(t, tenant, environment, id)
+}
+
+// startJobAliveSupervisorHelper launches the re-entered process and registers
+// a cleanup that kills it, so a failing assertion never leaves it running past
+// the test.
+func startJobAliveSupervisorHelper(t *testing.T, tenant, environment, id string) *exec.Cmd {
+	t.Helper()
+	helper := exec.Command(os.Args[0])
+	helper.Env = append(os.Environ(),
+		jobAliveSupervisorHelperEnv+"=1",
+		jobAliveSupervisorHelperTenantEnv+"="+tenant,
+		jobAliveSupervisorHelperEnvNameEnv+"="+environment,
+		jobAliveSupervisorHelperIDEnv+"="+id,
+	)
+	if err := helper.Start(); err != nil {
+		t.Fatalf("start supervisor helper: %v", err)
+	}
+	t.Cleanup(func() { _ = helper.Process.Kill(); _ = helper.Wait() })
+	return helper
+}
+
+// awaitFirstAliveBeat waits for the real supervisor to register the job and
+// land its first beat, mirroring what a caller starting a job would poll for,
+// and returns the child pid the cleanup after the kill needs.
+func awaitFirstAliveBeat(t *testing.T, tenant, environment, id string) int {
+	t.Helper()
+	job, err := pollUntilEnvironmentJob(tenant, environment, id, 5*time.Second, func(job EnvironmentJob) bool {
+		return job.AliveSeq > 0 && job.AliveAgeMs != nil
+	})
+	if err != nil {
+		t.Fatalf("job never landed its first alive beat: %v", err)
+	}
+	if job.State != EnvironmentJobStateRunning {
+		t.Fatalf("job state = %q before kill, want running", job.State)
+	}
+	return job.ChildPID
+}
+
+// killJobAliveSupervisorHelper kills the supervisor for real and reaps its
+// sleep child, which sat in its own process group precisely so this can reach
+// it without touching the (now dead) supervisor.
+func killJobAliveSupervisorHelper(t *testing.T, helper *exec.Cmd, childPID int) {
+	t.Helper()
+	if err := helper.Process.Kill(); err != nil {
+		t.Fatalf("kill supervisor helper: %v", err)
+	}
+	_ = helper.Wait()
+	if childPID > 0 {
+		_ = signalEnvironmentJobProcessGroup(childPID, "KILL")
+	}
+}
+
+// awaitAliveAgeExceedsStaleThreshold is the assertion the whole test exists
+// for: a dead supervisor's silence must read as stale within the documented
+// ~6s bound, not linger as an ambiguous "still running".
+func awaitAliveAgeExceedsStaleThreshold(t *testing.T, tenant, environment, id string) {
+	t.Helper()
+	stale, err := pollUntilEnvironmentJob(tenant, environment, id, 6*time.Second, func(job EnvironmentJob) bool {
+		return job.AliveAgeMs != nil && *job.AliveAgeMs > EnvironmentJobAliveStaleMs
+	})
+	if err != nil {
+		last, _ := LoadEnvironmentJob(tenant, environment, id, time.Now())
+		t.Fatalf("aliveAgeMs never exceeded %dms within 6s of SIGKILL: %v (last seen job: %+v)", EnvironmentJobAliveStaleMs, err, last)
+	}
+	if stale.AliveAgeMs == nil || *stale.AliveAgeMs <= EnvironmentJobAliveStaleMs {
+		t.Fatalf("aliveAgeMs = %v, want > %d", stale.AliveAgeMs, EnvironmentJobAliveStaleMs)
+	}
+	// The pid-liveness reconcile already catches up by this point too — the
+	// documented caller rule's "unknown, never success, never a tool error"
+	// is backed by both signals agreeing, not aliveAgeMs alone.
+	if stale.State != EnvironmentJobStateUnknown {
+		t.Fatalf("State = %q, want unknown once the supervisor pid is confirmed gone", stale.State)
+	}
+}
+
+// pollUntilEnvironmentJob re-reads a job until it satisfies want or the
+// deadline passes, so the test reacts to the real beat cadence instead of
+// sleeping a fixed guess.
+func pollUntilEnvironmentJob(tenant, environment, id string, timeout time.Duration, want func(EnvironmentJob) bool) (EnvironmentJob, error) {
+	deadline := time.Now().Add(timeout)
+	var last EnvironmentJob
+	for {
+		job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+		if err == nil {
+			last = job
+			if want(job) {
+				return job, nil
+			}
+		}
+		if !time.Now().Before(deadline) {
+			return last, fmt.Errorf("condition not met within %s", timeout)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/erun-common/job_supervisor.go
+++ b/erun-common/job_supervisor.go
@@ -593,6 +593,8 @@ func RunEnvironmentJobSupervisor(params EnvironmentJobSupervisorParams) error {
 	}
 	beat, stop := startEnvironmentJobHeartbeat(params.Tenant, params.Environment, recorder, ttl, agent)
 	defer stop()
+	stopAlive := startEnvironmentJobAliveBeat(recorder)
+	defer stopAlive()
 
 	writer := &jobOutputWriter{file: log, limit: job.OutputLimitBytes, agent: agent, onTruncate: func() {
 		recorder.update(func(job *EnvironmentJob) { job.OutputTruncated = true })
@@ -652,6 +654,46 @@ func finishEnvironmentJob(recorder *jobRecorder, beat *jobHeartbeat, writer *job
 		job.ExitCode = &code
 	})
 	return nil
+}
+
+// startEnvironmentJobAliveBeat stamps the job's alive fields immediately and
+// then on a fixed cadence for as long as the supervisor runs, independent of
+// the lease-renewal/progress ticker below: that one backs off to a 300s
+// interval for a command job, which is 60x too slow to answer "is the
+// supervisor still there" within the 5s bound a caller applies. Stopping it is
+// best-effort like the activity lease — if the supervisor is killed outright,
+// the beat simply stops, and that silence past EnvironmentJobAliveStaleMs is
+// itself the failure signal a caller reads; nothing needs to be undone.
+func startEnvironmentJobAliveBeat(recorder *jobRecorder) func() {
+	beatOnce := func() {
+		recorder.update(func(job *EnvironmentJob) {
+			job.LastAliveAt = time.Now()
+			job.AliveSeq++
+		})
+	}
+	beatOnce()
+
+	done := make(chan struct{})
+	var once sync.Once
+	var stopped sync.WaitGroup
+	stopped.Add(1)
+	go func() {
+		defer stopped.Done()
+		ticker := time.NewTicker(EnvironmentJobAliveHeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				beatOnce()
+			}
+		}
+	}()
+	return func() {
+		once.Do(func() { close(done) })
+		stopped.Wait()
+	}
 }
 
 // agentJobProgressInterval is how often an agent job's stream is folded. It is

--- a/erun-common/job_test.go
+++ b/erun-common/job_test.go
@@ -58,3 +58,50 @@ func TestReconcileEnvironmentJobDistinguishesPodReplacedFromSupervisorGone(t *te
 		}
 	})
 }
+
+func TestReconcileEnvironmentJobComputesAliveAgeMsOnEveryRead(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 1, 1, 0, 0, 10, 0, time.UTC)
+
+	t.Run("never beaten reports nil, not zero", func(t *testing.T) {
+		job := EnvironmentJob{PID: 123, State: EnvironmentJobStateRunning}
+		resolved := reconcileEnvironmentJob(dir, job, now, alwaysAlive, "")
+		if resolved.AliveAgeMs != nil {
+			t.Fatalf("AliveAgeMs = %v, want nil for a job that never beat", resolved.AliveAgeMs)
+		}
+	})
+
+	t.Run("a healthy running job reports the elapsed time since its last beat", func(t *testing.T) {
+		lastBeat := now.Add(-3 * time.Second)
+		job := EnvironmentJob{PID: 123, State: EnvironmentJobStateRunning, LastAliveAt: lastBeat}
+		resolved := reconcileEnvironmentJob(dir, job, now, alwaysAlive, "")
+		if resolved.AliveAgeMs == nil || *resolved.AliveAgeMs != 3000 {
+			t.Fatalf("AliveAgeMs = %v, want 3000", resolved.AliveAgeMs)
+		}
+	})
+
+	t.Run("a finished job still reports its frozen alive age rather than dropping it", func(t *testing.T) {
+		lastBeat := now.Add(-1 * time.Second)
+		code := 0
+		job := EnvironmentJob{PID: 123, State: EnvironmentJobStateExited, LastAliveAt: lastBeat, ExitCode: &code}
+		resolved := reconcileEnvironmentJob(dir, job, now, alwaysAlive, "")
+		if resolved.AliveAgeMs == nil || *resolved.AliveAgeMs != 1000 {
+			t.Fatalf("AliveAgeMs = %v, want 1000", resolved.AliveAgeMs)
+		}
+	})
+
+	t.Run("a stale beat on an otherwise-alive pid still surfaces as a large age for the caller to act on", func(t *testing.T) {
+		lastBeat := now.Add(-30 * time.Second)
+		job := EnvironmentJob{PID: 123, State: EnvironmentJobStateRunning, LastAliveAt: lastBeat}
+		resolved := reconcileEnvironmentJob(dir, job, now, alwaysAlive, "")
+		if resolved.State != EnvironmentJobStateRunning {
+			t.Fatalf("State = %q, want running (reconcile does not act on staleness itself)", resolved.State)
+		}
+		if resolved.AliveAgeMs == nil || *resolved.AliveAgeMs != 30000 {
+			t.Fatalf("AliveAgeMs = %v, want 30000", resolved.AliveAgeMs)
+		}
+		if *resolved.AliveAgeMs <= EnvironmentJobAliveStaleMs {
+			t.Fatalf("AliveAgeMs = %d, want > EnvironmentJobAliveStaleMs (%d)", *resolved.AliveAgeMs, EnvironmentJobAliveStaleMs)
+		}
+	})
+}

--- a/erun-common/workspace_sync_pass_test.go
+++ b/erun-common/workspace_sync_pass_test.go
@@ -36,6 +36,11 @@ func TestMain(m *testing.M) {
 	if os.Getenv(workspaceSyncSSHStubEnv) != "" {
 		os.Exit(runWorkspaceSyncSSHStub(os.Args))
 	}
+	// Only one TestMain is allowed per test binary, so the job-alive-contract
+	// test's re-entered supervisor helper (job_alive_test.go) hooks in here too.
+	if os.Getenv(jobAliveSupervisorHelperEnv) != "" {
+		os.Exit(runJobAliveSupervisorHelper())
+	}
 	os.Exit(m.Run())
 }
 

--- a/erun-docs/docs/agent-reference/cli-flags.md
+++ b/erun-docs/docs/agent-reference/cli-flags.md
@@ -866,6 +866,20 @@ Use it instead of hand-rolling detachment, a log redirect, a polling loop, a sen
 
 The demotion to `unknown` happens on the next read and is persisted, so every later read gives the same answer. An `unknown` job is never a success: `job await` exits `125` for it, distinct from both `0` and a failure.
 
+### The alive contract {#alive-contract}
+
+`state` alone answers "did the work finish", but it can only be as fresh as the last thing that read and reconciled the record — a pid-liveness check runs only when something calls `status`/`await`/`output`. A supervisor can also die between reads (a `SIGTERM`'d container, an OOM kill) with nothing to say so from the inside until the next reconcile. To close that gap every job record carries three more fields, written by the supervisor on a fixed cadence independent of the work's own output:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `lastAliveAt` | RFC3339 timestamp | The supervisor's own clock timestamp at its last beat, stamped every ~1 second (`EnvironmentJobAliveHeartbeatInterval`) for as long as the supervisor runs — an image pull or a silent test suite beats exactly as often as a chatty one. |
+| `aliveSeq` | integer | A monotonic counter bumped on every beat, so a caller can distinguish "still beating" from "the same timestamp read twice" at second resolution. |
+| `aliveAgeMs` | integer or `null` | Computed fresh on every read as `now − lastAliveAt`, **in the reader's own process, using the same clock `lastAliveAt` was stamped with** — never a caller subtracting its own wall clock from a pod timestamp, which a few seconds of skew would turn into a false failure against a 5-second bound. `null` only when the job has never beaten: an attached job (no supervisor loop exists for it) or one whose supervisor has not registered its first beat yet. |
+
+**The caller rule:** once `aliveAgeMs` exceeds `5000`, stop waiting and treat the job as failed — report it as an `unknown` outcome, never as a success and never as the tool itself having errored — even if `state` still reads `running`. 1 second of beat cadence against a 5 second bound is 5× headroom for poll jitter and scheduling delay, not slack for the beat itself to run late by design. A silent-but-healthy command never trips this: the beat has nothing to do with `outputBytes`.
+
+In practice the two signals — `state` and `aliveAgeMs` — usually agree, because the same pid-liveness check that would demote `state` to `unknown` also stops finding a live supervisor at the same moment beats stop landing. `aliveAgeMs` matters when a caller cannot afford to wait for the next reconcile, or when a reused pid could otherwise pass a liveness probe without actually being the job's supervisor: verified end to end by killing a real supervisor process with `SIGKILL` and confirming `aliveAgeMs` exceeds `5000` within ~6 seconds of the kill, with `state` landing on `unknown` in the same window.
+
 ### `erun job start`
 
 `erun job start [flags] -- <command> [args...]`
@@ -957,8 +971,10 @@ An attached job resolves against the named pid and nothing else. It reads `runni
 For an [agent job](#agent-jobs) the text line and the record both carry the progress view, so `status` answers what the agent is doing rather than only that it is running:
 
 ```
-running: sweep, pid 4243, agent claude, editing erun-common/mcp_client.go, 12 turns, 47 tools, 91204 bytes of output
+running: sweep, pid 4243, last beat 210ms ago, agent claude, editing erun-common/mcp_client.go, 12 turns, 47 tools, 91204 bytes of output
 ```
+
+The `last beat <n>ms ago` segment is the text rendering of `aliveAgeMs` (see [The alive contract](#alive-contract)) for a running job — present whenever the record has beaten at least once.
 
 An agent job that has not emitted yet reads `agent claude, no events yet` — distinct from an idle one, and the honest answer while the tool is still starting.
 

--- a/erun-docs/docs/mcp/overview.md
+++ b/erun-docs/docs/mcp/overview.md
@@ -198,6 +198,10 @@ The job tools remove all five:
 
 A job also holds an activity lease for its lifetime, so starting one makes the env read as busy and defers auto-stop with nothing extra to call. Finished jobs stay readable for 24 hours, so an orchestrator that reconnects after the work ended still learns the outcome. Full schemas, exit-code contract, retention, and error behaviour: [Agent reference · `erun job`](/agent-reference/cli-flags#erun-job).
 
+#### The alive contract {#alive-contract}
+
+`state` alone can only be as fresh as the last read that reconciled it, so a job carries three more fields — `lastAliveAt`, `aliveSeq`, `aliveAgeMs` — written by erun's supervisor on a fixed ~1 second cadence, independent of whether the work itself is producing output. **The caller rule: once `aliveAgeMs` exceeds 5000, stop waiting and treat the job as failed — an `unknown` outcome, never a success and never the tool having errored** — even if `state` has not caught up to say so yet. A silent-but-healthy command (an image pull, a slow test) never trips this, because the beat has nothing to do with the work's own output. Field-by-field semantics and the reasoning behind the 5-second bound: [Agent reference · The alive contract](/agent-reference/cli-flags#alive-contract).
+
 #### Running an agent as a job {#agent-jobs}
 
 An AI tool run non-interactively prints nothing until it exits, so starting one through `job_start`'s `command` reports `outputBytes: 0` for the whole run while the agent is actively editing files — `job_status` can only say `running`, and there is no supported way to report progress. Pass `agent` plus `prompt` instead of `command` and erun invokes the tool in its streaming mode:
@@ -522,7 +526,10 @@ The job record is the shared shape every job tool returns. It is deliberately ex
     "logPath": "/home/erun/.cache/erun/activity/team/dev/jobs/suite.log",
     "outputBytes": 0,
     "outputLimitBytes": 4194304,
-    "leaseId": "job-suite"         // the activity lease held for the job's lifetime
+    "leaseId": "job-suite",        // the activity lease held for the job's lifetime
+    "lastAliveAt": "2026-08-07T09:14:03Z",
+    "aliveSeq": 1,
+    "aliveAgeMs": 210               // see [The alive contract](#alive-contract), above
   }
 }
 ```
@@ -531,7 +538,7 @@ The job record is the shared shape every job tool returns. It is deliberately ex
 
 ```jsonc
 // job_await {"id": "suite", "timeoutSeconds": 30} — still running
-{ "job": { "id": "suite", "state": "running", "exitCode": null, … },
+{ "job": { "id": "suite", "state": "running", "exitCode": null, "aliveAgeMs": 340, … },
   "timedOut": true, "waitedSeconds": 30, "timeoutSeconds": 30 }
 
 // job_await {"id": "suite", "timeoutSeconds": 30} — finished, and it failed
@@ -539,8 +546,10 @@ The job record is the shared shape every job tool returns. It is deliberately ex
            "endedAt": "2026-08-07T09:18:41Z", "outputBytes": 81204, … },
   "timedOut": false, "waitedSeconds": 4, "timeoutSeconds": 30 }
 
-// a job whose supervisor vanished — never reported as success
-{ "job": { "id": "suite", "state": "unknown", "exitCode": null,
+// a job whose supervisor vanished — never reported as success, and as
+// terminal as the exited case above: never re-wait on this expecting a
+// different answer
+{ "job": { "id": "suite", "state": "unknown", "exitCode": null, "aliveAgeMs": 6120,
            "reason": "job supervisor 4242 is gone without recording an exit status; the runtime pod was most likely replaced" },
   "timedOut": false, … }
 ```
@@ -562,6 +571,7 @@ An [agent job](#agent-jobs) carries three more fields on the same record. `progr
 { "job": {
     "id": "sweep", "state": "running",
     "kind": "agent", "agentTool": "claude",
+    "aliveAgeMs": 450,
     "progress": {
       "tool": "claude",
       "activity": "editing erun-common/mcp_client.go",

--- a/erun-integration/internal/normalize/normalize.go
+++ b/erun-integration/internal/normalize/normalize.go
@@ -35,6 +35,10 @@ var defaultRules = []Replacement{
 	// at print time, so they land a second either side of the ttl depending on
 	// how long the subprocess took to start.
 	{regexp.MustCompile(`expires in \d+s`), "expires in <REMAINING>"},
+	// A job's alive-beat age is milliseconds since the supervisor's last ~1s
+	// heartbeat, measured against the wall clock at print time — inherently as
+	// variable as the remaining-lease seconds above.
+	{regexp.MustCompile(`last beat \d+ms ago`), "last beat <ALIVE_AGE>ms ago"},
 	{regexp.MustCompile(`\b20\d{12}\b`), "<TS_COMPACT>"},
 	// The Terraform durable work dir (local-backend state + TF_DATA_DIR) lives
 	// under the test HOME temp dir. Collapse just its temp-path prefix to a stable

--- a/erun-integration/testdata/job/agent_progress_is_readable_while_the_agent_works.txt
+++ b/erun-integration/testdata/job/agent_progress_is_readable_while_the_agent_works.txt
@@ -3,7 +3,7 @@
 {"type":"assistant","message":{"id":"msg_1","content":[{"type":"tool_use","id":"t1","name":"Edit","input":{"file_path":"erun-common/mcp_client.go"}}]}}
 audit: erun job output --environment dev --id sweep --tenant team
 next offset: 308 (more: false, complete: false)
-running: sweep, pid <PID>, agent claude, editing erun-common/mcp_client.go, 1 turn, 1 tool, 308 bytes of output
+running: sweep, pid <PID>, last beat <ALIVE_AGE>ms ago, agent claude, editing erun-common/mcp_client.go, 1 turn, 1 tool, 308 bytes of output
 audit: erun job status --environment dev --id sweep --tenant team
   job-sweep: sweep: editing erun-common/mcp_client.go, 1 turn, 1 tool, expires in <REMAINING>, pid <PID>
 audit: erun activity lease list --environment dev --tenant team

--- a/erun-integration/testdata/job/await_help.txt
+++ b/erun-integration/testdata/job/await_help.txt
@@ -1,7 +1,14 @@
 The wait is bounded and the call returns either an outcome or "still
 running" — it never holds a connection open for the work's lifetime, which
 is what drops under load and leaves a caller unable to tell a dead stream
-from a dead job.
+from a dead job. A job whose supervisor died reads back as unknown with
+timedOut false, its own third case distinct from both success and "still
+running" — never re-await it expecting a different answer.
+
+The reported job's aliveAgeMs is the faster of the two signals: it crosses
+the 5000ms caller threshold before state necessarily catches up, so a
+caller in a hurry can act on it directly instead of waiting for the next
+reconcile (see `erun job status --help`).
 
 Exit codes are the contract: 0 when the job exited 0, 124 when the timeout
 elapsed with the job still running, 125 when the outcome is unknown, and 1

--- a/erun-integration/testdata/job/await_reports_a_timeout_distinctly_from_a_failure.txt
+++ b/erun-integration/testdata/job/await_reports_a_timeout_distinctly_from_a_failure.txt
@@ -1,3 +1,3 @@
-still running after <ELAPSED>: slow
+still running after <ELAPSED>: slow, last beat <ALIVE_AGE>ms ago
 audit: erun job await --environment dev --id slow --tenant team --timeout 1s
 job "slow" is still running after <ELAPSED>

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -227,20 +227,23 @@ func registerJobTools(reg toolRegistrar, runtime RuntimeConfig) {
 		Name: "job_status",
 		Description: "Return one job's state and outcome, or every retained job newest-first. " +
 			"The answer is always definite: running, exited with a captured exit code, or explicitly unknown with the reason (its supervisor is gone without an outcome, most often because the runtime pod was replaced). " +
-			"It is never a truncated or partial answer, so it is safe to act on. Finished jobs stay readable for 24 hours, so an orchestrator reconnecting after the work ended can still learn what happened. " +
+			"It is never a truncated or partial answer, so it is safe to act on: unknown is exactly as terminal as exited — never a reason to keep waiting, and never inferred as 'not finished yet' just because it is not a success. Finished jobs stay readable for 24 hours, so an orchestrator reconnecting after the work ended can still learn what happened. " +
+			"aliveAgeMs is the milliseconds since the supervisor's last ~1s beat, computed by erun in its own clock so a caller never subtracts a pod timestamp from its own — the two clocks are not the same clock. Once it exceeds 5000, treat the job as failed (an unknown outcome, never a success, never a tool error) even if state has not caught up to say so yet; a silent-but-healthy command never trips this, because the beat has nothing to do with the work's own output. " +
 			"An agent job also carries progress — current activity (the last tool and its target), turns, tools run, and the last thing the agent said — normalized by erun from the tool's own event stream, so the shape is the same across AI tools. Poll this to report an in-pod agent's progress; do not scrape the agent's private transcript.",
 	}, jobStatusTool(runtime))
 	addTool(reg, &mcp.Tool{
 		Name: "job_await",
 		Description: "Wait a bounded time (default 30s, max 600s) for a job to finish. " +
 			"The call always returns inside the timeout — either the outcome or timedOut=true with the job still running — so no connection is held open for the work's lifetime and a dropped stream is never confused with a dead job. " +
-			"timedOut is reported separately from every outcome, so 'not finished yet' can never be read as a failure. Call it again to keep waiting.",
+			"timedOut is reported separately from every outcome, so 'not finished yet' can never be read as a failure — but it is not the only non-outcome case: a job whose supervisor died reads back as state=unknown with timedOut=false, its own third case, distinct from both success and 'still running'. Never re-await a job already reporting unknown expecting a different answer. Call it again only while the job is genuinely still running. " +
+			"The returned job's aliveAgeMs (see job_status) is the faster of the two signals: it crosses the 5000ms caller threshold before state necessarily catches up, so a caller in a hurry can act on it directly instead of waiting for the next reconcile.",
 	}, jobAwaitTool(runtime))
 	addTool(reg, &mcp.Tool{
 		Name: "job_output",
 		Description: "Read a page of a job's captured output, including while it is still running, so progress is visible before the work exits. " +
 			"Pass the previous read's nextOffset back as offset to continue where you left off. " +
-			"complete is true only when the job has finished and you have read to the end; the job's own outputTruncated says whether output was dropped at the cap.",
+			"complete is true only when the job has finished and you have read to the end; the job's own outputTruncated says whether output was dropped at the cap. " +
+			"The returned job also carries aliveAgeMs (see job_status) — a silent-but-healthy command never advances outputBytes for minutes at a time, so use aliveAgeMs, not output growth, to tell quiet-but-alive apart from actually dead.",
 	}, jobOutputTool(runtime))
 	addTool(reg, &mcp.Tool{
 		Name: "job_cancel",


### PR DESCRIPTION
## Summary

- Adds the alive-contract slice of #1182: every job record now carries `lastAliveAt`/`aliveSeq`, stamped by the supervisor on a fixed **~1s cadence independent of the work's own output** (a dedicated ticker, separate from the existing 300s lease-renewal interval and the 2s agent-progress fold, neither of which meets the 5s bound). `job_status`/`job_await`/`job_output` return a server-computed `aliveAgeMs` so no caller ever subtracts a pod timestamp from its own clock.
- Documents the caller rule (MCP tool descriptions, CLI `--help`, `/mcp/overview`, and the canonical schema in `agent-reference/cli-flags.md`): once `aliveAgeMs` exceeds 5000ms, treat the job as failed — an `unknown` outcome, never a success, never a tool error — even if `state` hasn't caught up yet. Also names the previously-undocumented third case explicitly: a dead job is neither `timedOut` nor a captured outcome, and must not be read as "still running."
- CLI `job status`/`job await` now surface `last beat <n>ms ago` on a running job's text line, so an operator watching the CLI sees the same signal the 5s rule acts on.
- Adds a real-process regression test: spawns an actual job supervisor, `SIGKILL`s it, and asserts `aliveAgeMs` exceeds 5000 within ~6 seconds (matching #1182's acceptance criterion) with `state` landing on `unknown` in the same window.

## Why this scope

#1182 asked for two things: (a) make every MCP tool a job with a 5s alive contract, and (b) document the full tool surface and CLI. Both are large — (a) alone implies converting ~16 more synchronous tools to job envelopes, and (b) means writing schemas for 33 undocumented tools. A prior attempt tried to land all of it (plus removing `job_start` and adding a new `agent` tool) in one PR and died mid-implementation with 29+ files touched. This PR lands only the concrete, field-evidence-backed piece — the alive contract itself, prompted by three jobs killed in production today with no low-latency signal that their supervisors had died. The rest is filed as **#1246** rather than risk another unreviewable mega-PR.

## Test plan

- [x] `go test ./...` green in `erun-common` (including the new SIGKILL real-process test, 3x for flakiness), `erun-cli`, `erun-mcp`
- [x] `golangci-lint run ./...` clean in `erun-common`, `erun-cli`, `erun-mcp`, `erun-integration`
- [x] `make integration-test` green, coverage gate passes (76.5% ≥ 76.2%)
- [x] Added `<ALIVE_AGE>` normalization rule so the new non-deterministic `last beat Nms ago` CLI output doesn't flake goldens; regenerated and re-ran 3x to confirm stability
- [x] `yarn build` clean in `erun-docs`

Closes nothing by itself; #1182 stays open, tracked forward by #1246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)