### PR TITLE
Collapse the duplicate orchestrator SessionStart hook blocks

### DIFF
--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -640,7 +640,8 @@ func ensureOrchestratorRoleFile(dir, id string) error {
 
 // ensureOrchestratorSessionStartHook writes a SessionStart hook into the shared
 // orchestrators root's .claude/settings.json, merging so it never clobbers other
-// keys or hook events already there. SessionStart fires on a new session
+// keys, hook events, or hook blocks already there -- including a SessionStart
+// block the operator added themselves. SessionStart fires on a new session
 // (startup) and a reopened one (resume), so every orchestrator has its contract
 // injected both on start and on reopen.
 func ensureOrchestratorSessionStartHook(dir string) error {
@@ -657,7 +658,8 @@ func ensureOrchestratorSessionStartHook(dir string) error {
 	if hooks == nil {
 		hooks = map[string]any{}
 	}
-	hooks["SessionStart"] = orchestratorSessionStartHook(dir)
+	hooks["SessionStart"] = mergeOrchestratorHookBlocks(
+		hooks["SessionStart"], orchestratorSessionStartHook(dir), isOrchestratorSessionStartHookBlock)
 	// The agent reports its own turn boundaries. Whether it is working cannot be
 	// read off its terminal: an agent TUI repaints continuously, so an
 	// output-driven latch never clears.
@@ -756,6 +758,15 @@ func isOrchestratorNoAskStopGuardBlock(block any) bool {
 	return false
 }
 
+// orchestratorSessionStartMatcher is a single pattern matching both sources
+// this hook cares about, rather than two separate matcher blocks carrying the
+// same three commands: SessionStart's matcher is tested as a regex against the
+// event's source, and alternation is already how this file scopes a matcher to
+// more than one value (see orchestratorShellActivityHookBlocks' "TaskOutput|
+// TaskStop"). Two blocks with identical hooks would mean every SessionStart
+// command is stored twice on disk for no behavioral gain.
+const orchestratorSessionStartMatcher = "startup|resume"
+
 // orchestratorSessionStartHook is the SessionStart hook block: the contract-
 // injecting command runs on both new starts (startup) and reopens (resume).
 func orchestratorSessionStartHook(dir string) []any {
@@ -769,10 +780,37 @@ func orchestratorSessionStartHook(dir string) []any {
 	// Resetting it here to whatever id this launch actually starts with is what
 	// keeps a stale record from outliving the run that wrote it.
 	liveSession := map[string]any{"type": "command", "command": orchestratorSessionRecordHookCommand()}
-	matcher := func(source string) map[string]any {
-		return map[string]any{"matcher": source, "hooks": []any{command, idle, liveSession}}
+	return []any{map[string]any{
+		"matcher": orchestratorSessionStartMatcher,
+		"hooks":   []any{command, idle, liveSession},
+	}}
+}
+
+// isOrchestratorSessionStartHookBlock reports whether a settings hook block is
+// one of ours, so a rewrite recognizes and replaces any block(s) it previously
+// wrote -- whether that is today's single combined-matcher block or the pair of
+// per-source blocks an earlier version of this file installed -- instead of
+// stacking another copy beside them. The contract-injection command's fallback
+// text is unique to us and present regardless of which shape wrote it.
+func isOrchestratorSessionStartHookBlock(block any) bool {
+	group, ok := block.(map[string]any)
+	if !ok {
+		return false
 	}
-	return []any{matcher("startup"), matcher("resume")}
+	hooks, ok := group["hooks"].([]any)
+	if !ok {
+		return false
+	}
+	for _, hook := range hooks {
+		entry, ok := hook.(map[string]any)
+		if !ok {
+			continue
+		}
+		if command, ok := entry["command"].(string); ok && strings.Contains(command, orchestratorContractFallback) {
+			return true
+		}
+	}
+	return false
 }
 
 // copyDirTree recursively copies src into dst (files + subdirectories), portable

--- a/erun-ui/orchestrator_test.go
+++ b/erun-ui/orchestrator_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -852,6 +853,87 @@ func TestOrchestratorSkillsResolveFromCheckoutAroundExecutable(t *testing.T) {
 	}
 }
 
+// sessionStartHookEntry and sessionStartGroup decode one SessionStart hook
+// block from settings.json, shared by the tests below.
+type sessionStartHookEntry struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+type sessionStartGroup struct {
+	Matcher string                  `json:"matcher"`
+	Hooks   []sessionStartHookEntry `json:"hooks"`
+}
+
+// readSessionStartGroups decodes the SessionStart hook blocks currently
+// written to settings.json at path, returning the raw bytes too so callers can
+// include them in failure messages.
+func readSessionStartGroups(t *testing.T, path string) ([]sessionStartGroup, []byte) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	var settings struct {
+		Hooks struct {
+			SessionStart []sessionStartGroup `json:"SessionStart"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal settings.json: %v\n%s", err, data)
+	}
+	return settings.Hooks.SessionStart, data
+}
+
+// sessionStartCommandCounts flattens every command across the given groups
+// into a command -> occurrence-count map.
+func sessionStartCommandCounts(groups []sessionStartGroup) map[string]int {
+	seen := map[string]int{}
+	for _, group := range groups {
+		for _, hook := range group.Hooks {
+			seen[hook.Command]++
+		}
+	}
+	return seen
+}
+
+// assertSessionStartCommandsUnique fails if any SessionStart command appears
+// more than once across all groups: two matcher blocks ("startup", "resume")
+// carrying the same three commands would mean every SessionStart command,
+// including the ~5.5KB contract injection, is installed (and so read into
+// every session's context) twice.
+func assertSessionStartCommandsUnique(t *testing.T, groups []sessionStartGroup, data []byte) {
+	t.Helper()
+	for cmd, count := range sessionStartCommandCounts(groups) {
+		if count != 1 {
+			t.Fatalf("SessionStart command installed %d times, want 1:\n%s\nfull settings:\n%s", count, cmd, data)
+		}
+	}
+}
+
+// assertSessionStartMatchersCover fails unless every source is matched by
+// some group's matcher, tested the same way Claude Code itself resolves a
+// SessionStart matcher: as a regex against the event's source.
+func assertSessionStartMatchersCover(t *testing.T, groups []sessionStartGroup, data []byte, sources ...string) {
+	t.Helper()
+	for _, source := range sources {
+		matched := false
+		for _, group := range groups {
+			re, err := regexp.Compile(group.Matcher)
+			if err != nil {
+				t.Fatalf("SessionStart matcher %q does not compile as a regex: %v", group.Matcher, err)
+			}
+			if re.MatchString(source) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Fatalf("no SessionStart matcher covers source %q:\n%s", source, data)
+		}
+	}
+}
+
 func TestOrchestratorSessionStartHookInjectsContract(t *testing.T) {
 	app := orchestratorTestApp(t)
 	defer app.shutdown(context.Background())
@@ -860,27 +942,9 @@ func TestOrchestratorSessionStartHookInjectsContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensureOrchestratorWorkspace: %v", err)
 	}
-	data, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
-	if err != nil {
-		t.Fatalf("read orchestrator settings.json: %v", err)
-	}
-	var settings struct {
-		Hooks struct {
-			SessionStart []struct {
-				Matcher string `json:"matcher"`
-				Hooks   []struct {
-					Type    string `json:"type"`
-					Command string `json:"command"`
-				} `json:"hooks"`
-			} `json:"SessionStart"`
-		} `json:"hooks"`
-	}
-	if err := json.Unmarshal(data, &settings); err != nil {
-		t.Fatalf("unmarshal settings.json: %v\n%s", err, data)
-	}
-	matchers := map[string]bool{}
-	for _, group := range settings.Hooks.SessionStart {
-		matchers[group.Matcher] = true
+	groups, data := readSessionStartGroups(t, filepath.Join(dir, ".claude", "settings.json"))
+
+	for _, group := range groups {
 		if len(group.Hooks) == 0 || group.Hooks[0].Type != "command" {
 			t.Fatalf("SessionStart matcher %q missing a command hook:\n%s", group.Matcher, data)
 		}
@@ -888,9 +952,89 @@ func TestOrchestratorSessionStartHookInjectsContract(t *testing.T) {
 			t.Fatalf("SessionStart command does not inject the contract (print CLAUDE.md):\n%s", group.Hooks[0].Command)
 		}
 	}
-	for _, want := range []string{"startup", "resume"} {
-		if !matchers[want] {
-			t.Fatalf("SessionStart hook missing matcher %q:\n%s", want, data)
+	assertSessionStartCommandsUnique(t, groups, data)
+	assertSessionStartMatchersCover(t, groups, data, "startup", "resume")
+}
+
+// TestOrchestratorSessionStartHookPrunesEarlierDuplicatesAndPreservesForeignHooks
+// seeds settings.json with the shape an earlier release left on disk -- two
+// matcher blocks, each carrying the full three-command SessionStart payload --
+// alongside an operator-owned SessionStart hook the installer has never seen.
+// Installing on top of that must collapse the
+// duplicate blocks down to one clean copy, leave the operator's own hook alone,
+// and stay exactly that size across a second install (simulating a further
+// desktop restart), never growing.
+func TestOrchestratorSessionStartHookPrunesEarlierDuplicatesAndPreservesForeignHooks(t *testing.T) {
+	app := orchestratorTestApp(t)
+	defer app.shutdown(context.Background())
+
+	dir := orchestratorsRoot()
+	claudeDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+
+	staleContractCommand := orchestratorSkillHookCommand(dir)
+	stale := map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{"matcher": "startup", "hooks": []any{
+					map[string]any{"type": "command", "command": staleContractCommand},
+				}},
+				map[string]any{"matcher": "resume", "hooks": []any{
+					map[string]any{"type": "command", "command": staleContractCommand},
+				}},
+				map[string]any{"matcher": "clear", "hooks": []any{
+					map[string]any{"type": "command", "command": "echo operator-owned"},
+				}},
+			},
+		},
+	}
+	raw, err := json.Marshal(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("ensureOrchestratorWorkspace: %v", err)
+	}
+	groupsAfterFirst, data := readSessionStartGroups(t, settingsPath)
+	assertSessionStartContractCommandPrunedToOne(t, groupsAfterFirst, data)
+	if !strings.Contains(string(data), "echo operator-owned") {
+		t.Fatalf("expected the operator's own SessionStart hook preserved:\n%s", data)
+	}
+
+	// A further install (another desktop restart) against the now-clean file
+	// must not grow the count.
+	if _, err := app.ensureOrchestratorWorkspace(); err != nil {
+		t.Fatalf("ensureOrchestratorWorkspace (second run): %v", err)
+	}
+	groupsAfterSecond, data2 := readSessionStartGroups(t, settingsPath)
+	if got, want := sessionStartTotalCommands(groupsAfterSecond), sessionStartTotalCommands(groupsAfterFirst); got != want {
+		t.Fatalf("SessionStart command count changed across a second install: got %d, want %d (unchanged):\n%s", got, want, data2)
+	}
+}
+
+// sessionStartTotalCommands counts every hook entry across all groups.
+func sessionStartTotalCommands(groups []sessionStartGroup) int {
+	n := 0
+	for _, group := range groups {
+		n += len(group.Hooks)
+	}
+	return n
+}
+
+// assertSessionStartContractCommandPrunedToOne fails if the contract-injection
+// command (identified by its fallback text) appears more than once.
+func assertSessionStartContractCommandPrunedToOne(t *testing.T, groups []sessionStartGroup, data []byte) {
+	t.Helper()
+	for cmd, count := range sessionStartCommandCounts(groups) {
+		if strings.Contains(cmd, orchestratorContractFallback) && count != 1 {
+			t.Fatalf("expected the earlier duplicate contract-injection blocks pruned to one, found %d:\n%s", count, data)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1236, but the real shape differs from the issue's diagnosis, so this PR fixes the actual defect rather than the hypothesized one.

**What the issue claimed:** `ensureOrchestratorSessionStartHook` "appends a new group rather than recognising that an equivalent group is already present, so the set grows by one each time the condition to write it is met" — i.e. duplicate groups accumulate across repeated installs (desktop restarts).

**What the code actually does:** `hooks["SessionStart"] = orchestratorSessionStartHook(dir)` is a plain, unconditional overwrite — it has been since the hook was introduced (#876) and has never used append/merge semantics. I verified directly: calling `ensureOrchestratorSessionStartHook` against the same settings file twice (and five times) produces exactly the same 2 groups / 6 commands every time — it does not grow with repeated installs.

**What is actually wrong**, and matches the numbers in the issue's own repro script (`.claude/settings.json` in the orchestrators root holding "2 SessionStart hook groups... 6 total commands... 3 duplicate"): `orchestratorSessionStartHook` was, by design, building **two** matcher blocks (`"startup"` and `"resume"`), each carrying the identical 3-command payload (contract injection, idle-activity reset, live-session reset). That's not growth from restarts — it's redundant duplicate content produced by a single install, because Claude Code's SessionStart matcher supports regex alternation (confirmed: this same file already uses `"TaskOutput|TaskStop"` for a PostToolUse matcher, and Claude Code docs confirm `"startup|resume"` is valid for SessionStart). Two blocks with the same hooks means the ~5.5KB shared contract and the other two commands are stored (and installed) twice for no behavioral gain.

Separately — and worth fixing in the same PR since it is the exact function the issue is about — the SessionStart install was a blind overwrite of the whole array, which silently deletes anything an operator might add there themselves, contradicting the function's own doc comment ("merging so it never clobbers other keys or hook events already there"). Every *other* event this function touches (`UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`) already uses `mergeOrchestratorHookBlocks` + an `isOurs` predicate to recognize-and-replace only its own blocks. `SessionStart` was the one holdout still doing a full overwrite.

## Changes

- Collapsed `orchestratorSessionStartHook` to return **one** block with matcher `"startup|resume"` instead of two blocks with separate `"startup"`/`"resume"` matchers carrying identical hooks.
- Added `isOrchestratorSessionStartHookBlock`, recognizing a SessionStart block as "ours" by the unique contract-fallback text in its command, matching the pattern every sibling hook installer in this file already uses.
- Switched `ensureOrchestratorSessionStartHook` from `hooks["SessionStart"] = orchestratorSessionStartHook(dir)` to `mergeOrchestratorHookBlocks(...)`, so a re-install (i) never duplicates our own commands, (ii) prunes any stale duplicate blocks an earlier release left on disk (including the old two-block shape), and (iii) leaves an operator's own SessionStart hooks alone.

## Tests

- `TestOrchestratorSessionStartHookInjectsContract` (updated): asserts every SessionStart command is installed exactly once (mirrors the issue's own `len(cmds) == len(set(cmds))` check) and that `"startup"` and `"resume"` are still both covered, testing the matcher as the regex Claude Code itself uses.
- `TestOrchestratorSessionStartHookPrunesEarlierDuplicatesAndPreservesForeignHooks` (new): seeds settings.json with the pre-fix two-block duplicate shape plus an unrelated operator-owned SessionStart hook, installs once and asserts the duplicate contract command collapses to one copy while the operator's hook survives, then installs a second time (simulating another desktop restart) and asserts the command count is unchanged — the exact regression property #1236 asked to be tested.

**Proved both new/changed tests fail against the pre-fix code**: stashed `erun-ui/orchestrator.go` only, ran `go test ./... -run TestOrchestratorSessionStartHook -v`. Both failed for the right reason:
- `TestOrchestratorSessionStartHookInjectsContract`: `SessionStart command installed 2 times, want 1`
- `TestOrchestratorSessionStartHookPrunesEarlierDuplicatesAndPreservesForeignHooks`: `expected the earlier duplicate contract-injection blocks pruned to one, found 2`

Restored the fix afterward and both pass, along with the pre-existing `TestOrchestratorSessionStartHookPreservesExistingSettings`.

## Validation

- `go test ./...` in `erun-ui`: green, both with the normal PATH and under `env PATH=/usr/local/go/bin:/usr/bin:/bin`.
- `golangci-lint run ./...` in `erun-ui`: 0 issues.
- No e2e/RLS-gated suites apply — this touches no tenant-scoped data or backend/db code.
- `erun-integration`: not run — this change is confined to `erun-ui` (a desktop-local `.claude/settings.json` hook installer) and touches no `erun-cli`, `erun-common`, runtime entrypoint, chart deploy plumbing, or integration golden.

## UX Impact Review Checklist

1. **Affected paths:** none — `ensureOrchestratorSessionStartHook` is backend config-writing invoked when the orchestrator workspace is ensured; it has no Wails-exported surface and renders nothing in the React tree.
2. No user-triggered path affected; stopping here per the checklist's own instruction.
8. **Playwright coverage:** intentionally none, consistent with the sibling hook installers in this same file (`orchestrator_activity.go`, `orchestrator_shell_activity.go`, `orchestrator_live_session.go`) — none of them have Playwright specs either, since they only affect Claude Code session hooks running host-side and are invisible to the rendered desktop UI. Covered by the Go unit tests above.

## Docs plan

Not a feature addition or feature-changing PR — it's a bug fix that preserves observable behavior (the contract is still injected on both startup and resume; the activity and live-session hooks are unchanged) with no public-surface change. Exempt per AGENTS.md's docs-affecting-change rule.

## What I could not verify

I could not drive an actual Claude Code SessionStart event end-to-end (that requires a real Claude Code session invoking the hook, which isn't reachable from this environment) to observe the injected context directly. I relied on: (a) direct unit-level exercise of the installer function against real settings.json files, (b) Claude Code's own hooks documentation confirming `matcher` is tested as a regex supporting pipe alternation for SessionStart, and (c) this same codebase's existing precedent (`"TaskOutput|TaskStop"`) for that alternation syntax working with Claude Code's hook matcher.