### PR TITLE
Make the CLI's idle-and-friends MCP reads exempt from activity accounting

### DIFF
--- a/erun-cli/cmd/activity_lease_environment.go
+++ b/erun-cli/cmd/activity_lease_environment.go
@@ -24,7 +24,7 @@ func takeLeaseInEnvironment(ctx context.Context, commandCtx common.Context, reso
 	putEnvironmentToolArgument(arguments, "id", params.ID)
 	putEnvironmentToolArgument(arguments, "pid", params.PID)
 	putEnvironmentToolArgument(arguments, "ttlSeconds", leaseTTLSeconds(params.TTL))
-	result, resolved, err := callEnvironmentTool[environmentActivityLeaseResult](ctx, commandCtx, resolveOpen, params.Tenant, params.Environment, "activity_lease_take", arguments)
+	result, resolved, err := callEnvironmentTool[environmentActivityLeaseResult](ctx, commandCtx, resolveOpen, params.Tenant, params.Environment, "activity_lease_take", arguments, false)
 	if err != nil || !resolved {
 		return common.EnvironmentActivityLease{}, resolved, err
 	}
@@ -37,11 +37,11 @@ func takeLeaseInEnvironment(ctx context.Context, commandCtx common.Context, reso
 func releaseLeaseInEnvironment(ctx context.Context, commandCtx common.Context, resolveOpen OpenResolver, tenant, environment, id string) (bool, error) {
 	arguments := map[string]any{}
 	putEnvironmentToolArgument(arguments, "id", id)
-	_, resolved, err := callEnvironmentTool[environmentActivityLeaseResult](ctx, commandCtx, resolveOpen, tenant, environment, "activity_lease_release", arguments)
+	_, resolved, err := callEnvironmentTool[environmentActivityLeaseResult](ctx, commandCtx, resolveOpen, tenant, environment, "activity_lease_release", arguments, false)
 	return resolved, err
 }
 
 func listLeasesInEnvironment(ctx context.Context, commandCtx common.Context, resolveOpen OpenResolver, tenant, environment string) ([]common.EnvironmentActivityLease, bool, error) {
-	result, resolved, err := callEnvironmentTool[environmentActivityLeaseResult](ctx, commandCtx, resolveOpen, tenant, environment, "activity_lease_list", nil)
+	result, resolved, err := callEnvironmentTool[environmentActivityLeaseResult](ctx, commandCtx, resolveOpen, tenant, environment, "activity_lease_list", nil, true)
 	return result.Held, resolved, err
 }

--- a/erun-cli/cmd/environment_call.go
+++ b/erun-cli/cmd/environment_call.go
@@ -26,7 +26,13 @@ func environmentTargetsItself() bool {
 // its structured result. The second return reports whether a call was actually
 // made: a dry run resolves and traces the plan without reaching the edge, so the
 // plan stays readable for an environment that is not currently open.
-func callEnvironmentTool[T any](ctx context.Context, commandCtx common.Context, resolveOpen OpenResolver, tenant, environment, tool string, arguments map[string]any) (T, bool, error) {
+//
+// idleProbe must be true only for a tool the caller knows is read-only (idle,
+// job_status, job_output, job_await, activity_lease_list): the probe header it
+// sets exempts the whole request from the environment's activity accounting, so
+// setting it for a tool that can mutate the environment (job_start, job_cancel,
+// activity_lease_take, ...) would let driving the environment read as idle.
+func callEnvironmentTool[T any](ctx context.Context, commandCtx common.Context, resolveOpen OpenResolver, tenant, environment, tool string, arguments map[string]any, idleProbe bool) (T, bool, error) {
 	var decoded T
 	if arguments == nil {
 		arguments = map[string]any{}
@@ -39,7 +45,7 @@ func callEnvironmentTool[T any](ctx context.Context, commandCtx common.Context, 
 	if commandCtx.DryRun {
 		return decoded, false, nil
 	}
-	result, err := callMCPToolWithReattach(ctx, commandCtx, target, tool, arguments)
+	result, err := callMCPToolWithReattach(ctx, commandCtx, target, tool, arguments, idleProbe)
 	if err != nil {
 		return decoded, false, mcpEdgeErrorWithExitCode(target, err)
 	}

--- a/erun-cli/cmd/idle.go
+++ b/erun-cli/cmd/idle.go
@@ -69,7 +69,7 @@ func resolveEnvironmentIdleStatus(ctx context.Context, commandCtx common.Context
 		status, err := common.ResolveStoredEnvironmentIdleStatus(store, tenant, environment, time.Now())
 		return status, err == nil, err
 	}
-	return callEnvironmentTool[common.EnvironmentIdleStatus](ctx, commandCtx, resolveOpen, tenant, environment, "idle", nil)
+	return callEnvironmentTool[common.EnvironmentIdleStatus](ctx, commandCtx, resolveOpen, tenant, environment, "idle", nil, true)
 }
 
 func writeIdleStatus(ctx common.Context, status common.EnvironmentIdleStatus) error {

--- a/erun-cli/cmd/job_environment.go
+++ b/erun-cli/cmd/job_environment.go
@@ -48,7 +48,7 @@ func startJobInEnvironment(ctx context.Context, commandCtx common.Context, resol
 	putEnvironmentToolArgument(arguments, "env", params.Env)
 	putEnvironmentToolArgument(arguments, "maxOutputBytes", params.MaxOutputBytes)
 	putEnvironmentToolArgument(arguments, "leaseTtlSeconds", leaseTTLSeconds(params.LeaseTTL))
-	result, resolved, err := callEnvironmentTool[environmentJobResult](ctx, commandCtx, resolveOpen, params.Tenant, params.Environment, "job_start", arguments)
+	result, resolved, err := callEnvironmentTool[environmentJobResult](ctx, commandCtx, resolveOpen, params.Tenant, params.Environment, "job_start", arguments, false)
 	return result.Job, resolved, err
 }
 
@@ -62,14 +62,14 @@ func attachJobInEnvironment(ctx context.Context, commandCtx common.Context, reso
 	putEnvironmentToolArgument(arguments, "pid", params.PID)
 	putEnvironmentToolArgument(arguments, "logPath", params.LogPath)
 	putEnvironmentToolArgument(arguments, "leaseTtlSeconds", leaseTTLSeconds(params.LeaseTTL))
-	result, resolved, err := callEnvironmentTool[environmentJobResult](ctx, commandCtx, resolveOpen, params.Tenant, params.Environment, "job_attach", arguments)
+	result, resolved, err := callEnvironmentTool[environmentJobResult](ctx, commandCtx, resolveOpen, params.Tenant, params.Environment, "job_attach", arguments, false)
 	return result.Job, resolved, err
 }
 
 func jobStatusFromEnvironment(ctx context.Context, commandCtx common.Context, resolveOpen OpenResolver, tenant, environment, id string) (environmentJobStatusResult, bool, error) {
 	arguments := map[string]any{}
 	putEnvironmentToolArgument(arguments, "id", id)
-	return callEnvironmentTool[environmentJobStatusResult](ctx, commandCtx, resolveOpen, tenant, environment, "job_status", arguments)
+	return callEnvironmentTool[environmentJobStatusResult](ctx, commandCtx, resolveOpen, tenant, environment, "job_status", arguments, true)
 }
 
 func awaitJobInEnvironment(ctx context.Context, commandCtx common.Context, resolveOpen OpenResolver, params common.AwaitEnvironmentJobParams) (common.AwaitEnvironmentJobResult, bool, error) {
@@ -79,7 +79,7 @@ func awaitJobInEnvironment(ctx context.Context, commandCtx common.Context, resol
 	arguments := map[string]any{}
 	putEnvironmentToolArgument(arguments, "id", params.ID)
 	putEnvironmentToolArgument(arguments, "timeoutSeconds", int64(params.Timeout.Seconds()))
-	return callEnvironmentTool[common.AwaitEnvironmentJobResult](ctx, commandCtx, resolveOpen, params.Tenant, params.Environment, "job_await", arguments)
+	return callEnvironmentTool[common.AwaitEnvironmentJobResult](ctx, commandCtx, resolveOpen, params.Tenant, params.Environment, "job_await", arguments, true)
 }
 
 func jobOutputFromEnvironment(ctx context.Context, commandCtx common.Context, resolveOpen OpenResolver, params common.ReadEnvironmentJobOutputParams) (common.EnvironmentJobOutput, bool, error) {
@@ -87,13 +87,13 @@ func jobOutputFromEnvironment(ctx context.Context, commandCtx common.Context, re
 	putEnvironmentToolArgument(arguments, "id", params.ID)
 	putEnvironmentToolArgument(arguments, "offset", params.Offset)
 	putEnvironmentToolArgument(arguments, "maxBytes", params.MaxBytes)
-	return callEnvironmentTool[common.EnvironmentJobOutput](ctx, commandCtx, resolveOpen, params.Tenant, params.Environment, "job_output", arguments)
+	return callEnvironmentTool[common.EnvironmentJobOutput](ctx, commandCtx, resolveOpen, params.Tenant, params.Environment, "job_output", arguments, true)
 }
 
 func cancelJobInEnvironment(ctx context.Context, commandCtx common.Context, resolveOpen OpenResolver, params common.CancelEnvironmentJobParams) (common.CancelEnvironmentJobResult, bool, error) {
 	arguments := map[string]any{}
 	putEnvironmentToolArgument(arguments, "id", params.ID)
 	putEnvironmentToolArgument(arguments, "signal", params.Signal)
-	result, resolved, err := callEnvironmentTool[environmentJobCancelResult](ctx, commandCtx, resolveOpen, params.Tenant, params.Environment, "job_cancel", arguments)
+	result, resolved, err := callEnvironmentTool[environmentJobCancelResult](ctx, commandCtx, resolveOpen, params.Tenant, params.Environment, "job_cancel", arguments, false)
 	return result.Cancel, resolved, err
 }

--- a/erun-cli/cmd/mcp_call.go
+++ b/erun-cli/cmd/mcp_call.go
@@ -29,7 +29,7 @@ const mcpChannelUnreachableExitCode = 126
 // hand-rolled retry loop falls into — probing the port binding is worthless
 // (a stale forward still accepts the connection), and a bare `erun open`
 // would silently start an environment the operator deliberately stopped.
-func callMCPToolWithReattach(ctx context.Context, commandCtx common.Context, target mcpEdgeTarget, tool string, arguments map[string]any) (common.MCPToolCallResult, error) {
+func callMCPToolWithReattach(ctx context.Context, commandCtx common.Context, target mcpEdgeTarget, tool string, arguments map[string]any, idleProbe bool) (common.MCPToolCallResult, error) {
 	call := func() (common.MCPToolCallResult, error) {
 		return common.CallMCPTool(ctx, common.MCPToolCallParams{
 			Endpoint:      target.endpoint,
@@ -37,6 +37,7 @@ func callMCPToolWithReattach(ctx context.Context, commandCtx common.Context, tar
 			ClientVersion: currentBuildInfo().Version,
 			Tool:          tool,
 			Arguments:     arguments,
+			IdleProbe:     idleProbe,
 		})
 	}
 	result, err := call()
@@ -173,7 +174,10 @@ func runMCPCallCommand(ctx context.Context, commandCtx common.Context, resolveOp
 		return nil
 	}
 
-	result, err := callMCPToolWithReattach(ctx, commandCtx, target, tool, toolArguments)
+	// Not an idle probe: this command calls a caller-named tool, and whether that
+	// tool is read-only is not something the CLI can know generically — its own
+	// help text says as much ("A tool can change the environment").
+	result, err := callMCPToolWithReattach(ctx, commandCtx, target, tool, toolArguments, false)
 	if err != nil {
 		return mcpEdgeErrorWithExitCode(target, err)
 	}
@@ -213,6 +217,7 @@ func listMCPToolsWithReattach(ctx context.Context, commandCtx common.Context, ta
 			Endpoint:      target.endpoint,
 			MintToken:     mcpEdgeTokenMinter(target),
 			ClientVersion: currentBuildInfo().Version,
+			IdleProbe:     true,
 		})
 	}
 	result, err := list()

--- a/erun-common/mcp_client.go
+++ b/erun-common/mcp_client.go
@@ -23,6 +23,13 @@ const (
 	// MCPServerPath is the HTTP path the per-env erun-mcp edge serves MCP on.
 	MCPServerPath = "/mcp"
 
+	// MCPIdleProbeHeader marks a request as a diagnostic read that must not reset
+	// the environment's idle timer. The erun-mcp edge's activity middleware skips
+	// activity recording for any request carrying it (set to "true"); every other
+	// client of this header (this package, erun-mcp, erun-ui) shares the same
+	// name so the two sides of the contract cannot drift apart.
+	MCPIdleProbeHeader = "X-Erun-Idle-Probe"
+
 	// The edge rejects a POST naming a protocol revision it does not support, so
 	// this is pinned rather than negotiated downward.
 	mcpClientProtocolVersion = "2025-06-18"
@@ -65,6 +72,11 @@ type MCPToolCallParams struct {
 	ClientVersion string
 	Tool          string
 	Arguments     map[string]any
+	// IdleProbe marks this call as a diagnostic read that must not reset the
+	// environment's idle timer. Set it only when the caller knows the tool is
+	// read-only; a tool that can mutate the environment must never be probed,
+	// since the probe header exempts the whole request from activity recording.
+	IdleProbe bool
 }
 
 type MCPToolCallResult struct {
@@ -78,6 +90,10 @@ type MCPToolListParams struct {
 	Endpoint      string
 	MintToken     MCPTokenMinter
 	ClientVersion string
+	// IdleProbe marks this call as a diagnostic read that must not reset the
+	// environment's idle timer. Listing tools is always read-only, so callers
+	// should normally set this.
+	IdleProbe bool
 }
 
 type MCPTool struct {
@@ -98,7 +114,7 @@ func CallMCPTool(ctx context.Context, params MCPToolCallParams) (MCPToolCallResu
 	if tool == "" {
 		return MCPToolCallResult{}, fmt.Errorf("MCP tool name is required")
 	}
-	session, err := openMCPSession(ctx, params.Endpoint, params.MintToken, params.ClientVersion)
+	session, err := openMCPSession(ctx, params.Endpoint, params.MintToken, params.ClientVersion, params.IdleProbe)
 	if err != nil {
 		return MCPToolCallResult{}, err
 	}
@@ -133,7 +149,7 @@ func CallMCPTool(ctx context.Context, params MCPToolCallParams) (MCPToolCallResu
 // ListMCPTools returns the tools an environment's MCP edge exposes, with their
 // input schemas.
 func ListMCPTools(ctx context.Context, params MCPToolListParams) (MCPToolListResult, error) {
-	session, err := openMCPSession(ctx, params.Endpoint, params.MintToken, params.ClientVersion)
+	session, err := openMCPSession(ctx, params.Endpoint, params.MintToken, params.ClientVersion, params.IdleProbe)
 	if err != nil {
 		return MCPToolListResult{}, err
 	}
@@ -155,6 +171,9 @@ type mcpSession struct {
 	client        *http.Client
 	sessionID     string
 	nextID        int
+	// idleProbe marks every request this session sends as a diagnostic read that
+	// must not reset the environment's idle timer.
+	idleProbe bool
 	// localPort is the loopback port the endpoint names, or 0 when the endpoint
 	// is not a local port-forward (e.g. a hosted platform edge). Only a local
 	// port-forward can go stale in the way ensureTunnelLive checks for.
@@ -170,7 +189,7 @@ type mcpSession struct {
 // newMCPSession prepares the transport without performing the handshake, so a
 // relay that forwards a client's own initialize can share the header, session,
 // and framing rules with the typed callers.
-func newMCPSession(endpoint string, mintToken MCPTokenMinter, clientVersion string) (*mcpSession, error) {
+func newMCPSession(endpoint string, mintToken MCPTokenMinter, clientVersion string, idleProbe bool) (*mcpSession, error) {
 	endpoint = strings.TrimSpace(endpoint)
 	if endpoint == "" {
 		return nil, fmt.Errorf("MCP endpoint is required")
@@ -188,6 +207,7 @@ func newMCPSession(endpoint string, mintToken MCPTokenMinter, clientVersion stri
 		mintToken:     mintToken,
 		clientVersion: clientVersion,
 		client:        &http.Client{},
+		idleProbe:     idleProbe,
 		localPort:     localMCPEndpointPort(endpoint),
 	}, nil
 }
@@ -211,8 +231,8 @@ func localMCPEndpointPort(endpoint string) int {
 	return port
 }
 
-func openMCPSession(ctx context.Context, endpoint string, mintToken MCPTokenMinter, clientVersion string) (*mcpSession, error) {
-	session, err := newMCPSession(endpoint, mintToken, clientVersion)
+func openMCPSession(ctx context.Context, endpoint string, mintToken MCPTokenMinter, clientVersion string, idleProbe bool) (*mcpSession, error) {
+	session, err := newMCPSession(endpoint, mintToken, clientVersion, idleProbe)
 	if err != nil {
 		return nil, err
 	}
@@ -380,6 +400,9 @@ func (s *mcpSession) newRequest(ctx context.Context, body []byte, token string) 
 	req.Header.Set("User-Agent", mcpClientName+"/"+s.clientVersion)
 	if s.sessionID != "" {
 		req.Header.Set(mcpSessionHeader, s.sessionID)
+	}
+	if s.idleProbe {
+		req.Header.Set(MCPIdleProbeHeader, "true")
 	}
 	return req, nil
 }

--- a/erun-common/mcp_proxy.go
+++ b/erun-common/mcp_proxy.go
@@ -48,7 +48,10 @@ func RunMCPStdioProxy(ctx context.Context, params MCPStdioProxyParams) error {
 	if params.In == nil || params.Out == nil {
 		return fmt.Errorf("MCP stdio proxy requires an input and an output stream")
 	}
-	session, err := newMCPSession(params.Endpoint, params.MintToken, params.ClientVersion)
+	// Never an idle probe: an MCP client relayed through this proxy is actively
+	// driving the environment (an agent, an operator's tool call), not asking a
+	// diagnostic question, so its calls must register as activity like any other.
+	session, err := newMCPSession(params.Endpoint, params.MintToken, params.ClientVersion, false)
 	if err != nil {
 		return err
 	}

--- a/erun-docs/docs/agent-reference/idle-policy.md
+++ b/erun-docs/docs/agent-reference/idle-policy.md
@@ -15,8 +15,8 @@ ERun watches four activity sources per env, all surfaced via the [MCP `idle` too
 | Property | Value |
 |---|---|
 | Type | RFC3339 UTC timestamp. |
-| Updated by | Any of: a keystroke on the in-pod SSH PTY; a successful in-pod `erun` invocation; any non-`idle` MCP `tools/call` against the env. |
-| **Not** updated by | the MCP edge's own `idle` polling (would self-perpetuate); file-only edits from a laptop-side IDE that doesn't open an SSH session; passive port-forward traffic without an active session. |
+| Updated by | Any of: a keystroke on the in-pod SSH PTY; a successful in-pod `erun` invocation; any MCP `tools/call` against the env that is not an **idle probe** (see below). |
+| **Not** updated by | an **idle probe** — a `tools/call` explicitly marked as a diagnostic read that must not perpetuate its own answer. `idle`, `job_status`, `job_output`, `job_await`, `activity_lease_list`, and a tools/list call are always idle probes; the host CLI and desktop mark them so regardless of who's asking or how often (#1227 — polling `erun idle` used to reset the very timer it reported). File-only edits from a laptop-side IDE that doesn't open an SSH session, and passive port-forward traffic without an active session, also don't update it. |
 | Initial value | Pod start time (so a freshly-started env is "active"). |
 | Persistence | In-memory in the runtime container's MCP server. A pod restart resets to the new start time. |
 

--- a/erun-docs/docs/mcp/overview.md
+++ b/erun-docs/docs/mcp/overview.md
@@ -262,7 +262,7 @@ The structured tools take no arguments unless noted. Outputs are typed JSON.
 
 ### `idle`
 
-Resolves the env's idle policy and reports its current activity. Useful for an Agent to decide whether to stop or keep going.
+Resolves the env's idle policy and reports its current activity. Useful for an Agent to decide whether to stop or keep going. Asking never counts as activity itself, however often it's polled — see [Agent reference · Idle policy](/agent-reference/idle-policy#last_terminal_input) for the full list of tools this applies to.
 
 ```jsonc
 {

--- a/erun-integration/environment_half_scenarios_test.go
+++ b/erun-integration/environment_half_scenarios_test.go
@@ -48,6 +48,13 @@ func TestIdleOffEnvironment(t *testing.T) {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
 		golden.Equal(t, "idle/off_environment_reports_the_environments_own_answer", normalize.Apply(result.Combined))
+
+		// #1227: asking whether the environment is idle must not itself count as
+		// activity, or polling this command holds the environment awake forever.
+		call := edge.requestFor(t, "tools/call")
+		if !call.IdleProbe {
+			t.Errorf("expected the idle call to carry the idle-probe header so it does not reset the environment's idle timer")
+		}
 	})
 
 	t.Run("unreachable_edge_is_not_reported_as_idle", func(t *testing.T) {
@@ -111,6 +118,11 @@ func TestJobOffEnvironment(t *testing.T) {
 		if call.Tool != "job_start" {
 			t.Fatalf("the environment was asked for %q, want job_start", call.Tool)
 		}
+		// job_start does real work in the environment, so it must count as
+		// activity like any other action — never carry the idle-probe header.
+		if call.IdleProbe {
+			t.Errorf("job_start must not carry the idle-probe header: it starts real work in the environment")
+		}
 	})
 
 	t.Run("start_dry_run_traces_the_environment_call", func(t *testing.T) {
@@ -156,6 +168,67 @@ func TestJobOffEnvironment(t *testing.T) {
 			t.Fatalf("exit %d, want 124 for a job still running: %s", result.ExitCode, result.Combined)
 		}
 		golden.Equal(t, "job/off_environment_await_maps_the_environments_outcome_onto_the_exit_code", normalize.Apply(result.Combined))
+
+		// #1227: waiting on a job is a read of its state, not new activity in the
+		// environment.
+		call := edge.requestFor(t, "tools/call")
+		if !call.IdleProbe {
+			t.Errorf("expected job_await to carry the idle-probe header")
+		}
+	})
+
+	t.Run("status_reads_the_environments_job_state", func(t *testing.T) {
+		// job_status is a pure read, same reasoning as idle (#1227): polling an
+		// environment's job status must not itself keep it awake.
+		skipIfPortsBusy(t, jobEdgeLocalPort)
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnvWithSSHDPortRange(t, setup, "team", "dev", jobEdgeLocalPort)
+		fixture.SeedDesktopIdentity(t, setup)
+		edge := &fakeMCPEdge{Results: map[string]string{"tools/call": `{"content":[{"type":"text","text":"status"}],` +
+			`"structuredContent":{"tenant":"team","environment":"dev",` +
+			`"job":{"id":"suite","name":"suite","state":"running","childPid":4242,"outputBytes":0},` +
+			`"jobs":[{"id":"suite","name":"suite","state":"running","childPid":4242,"outputBytes":0}]}}`}}
+		edge.start(t, jobEdgeLocalPort)
+
+		result := erun.Run(t, []string{"job", "status", "--tenant", "team", "--environment", "dev", "--id", "suite"},
+			erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+
+		call := edge.requestFor(t, "tools/call")
+		if call.Tool != "job_status" {
+			t.Fatalf("the environment was asked for %q, want job_status", call.Tool)
+		}
+		if !call.IdleProbe {
+			t.Errorf("expected job_status to carry the idle-probe header so polling it does not reset the environment's idle timer")
+		}
+	})
+
+	t.Run("output_reads_the_environments_captured_output", func(t *testing.T) {
+		// job_output is a pure read too: it serves a page of already-captured
+		// output, so reading it must not reset the environment's idle timer.
+		skipIfPortsBusy(t, jobEdgeLocalPort)
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnvWithSSHDPortRange(t, setup, "team", "dev", jobEdgeLocalPort)
+		fixture.SeedDesktopIdentity(t, setup)
+		edge := &fakeMCPEdge{Results: map[string]string{"tools/call": `{"content":[{"type":"text","text":"output"}],` +
+			`"structuredContent":{"output":"hello\n","offset":0,"nextOffset":6,"hasMore":false,"complete":true}}`}}
+		edge.start(t, jobEdgeLocalPort)
+
+		result := erun.Run(t, []string{"job", "output", "--tenant", "team", "--environment", "dev", "--id", "suite"},
+			erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+
+		call := edge.requestFor(t, "tools/call")
+		if call.Tool != "job_output" {
+			t.Fatalf("the environment was asked for %q, want job_output", call.Tool)
+		}
+		if !call.IdleProbe {
+			t.Errorf("expected job_output to carry the idle-probe header so polling it does not reset the environment's idle timer")
+		}
 	})
 }
 
@@ -185,6 +258,11 @@ func TestActivityLeaseOffEnvironment(t *testing.T) {
 		if call.Tool != "activity_lease_take" {
 			t.Fatalf("the environment was asked for %q, want activity_lease_take", call.Tool)
 		}
+		// Taking a lease is a deliberate claim on the environment's busy state, so
+		// it must count as activity, not be exempted via the idle-probe header.
+		if call.IdleProbe {
+			t.Errorf("activity_lease_take must not carry the idle-probe header")
+		}
 	})
 
 	t.Run("list_reads_the_environments_held_leases", func(t *testing.T) {
@@ -210,6 +288,11 @@ func TestActivityLeaseOffEnvironment(t *testing.T) {
 		call := edge.requestFor(t, "tools/call")
 		if call.Tool != "activity_lease_list" {
 			t.Fatalf("the environment was asked for %q, want activity_lease_list", call.Tool)
+		}
+		// #1227: listing leases only observes them, so it must not itself count as
+		// activity.
+		if !call.IdleProbe {
+			t.Errorf("expected activity_lease_list to carry the idle-probe header")
 		}
 	})
 }

--- a/erun-integration/mcp_test.go
+++ b/erun-integration/mcp_test.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"testing"
 
+	common "github.com/sophium/erun/erun-common"
 	"github.com/sophium/erun/erun-integration/internal/env"
 	"github.com/sophium/erun/erun-integration/internal/erun"
 	"github.com/sophium/erun/erun-integration/internal/fixture"
@@ -98,6 +99,10 @@ type fakeMCPRequest struct {
 	// Tool is the tool a tools/call named, which is what proves a caller reached
 	// the intended surface rather than some other one.
 	Tool string
+	// IdleProbe reports whether the request carried the header that exempts it
+	// from the environment's activity accounting — set by a diagnostic read, and
+	// never by a call that can mutate the environment.
+	IdleProbe bool
 }
 
 func (e *fakeMCPEdge) start(t *testing.T, port int) {
@@ -138,6 +143,7 @@ func (e *fakeMCPEdge) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Authbearer: strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "),
 		SessionID:  r.Header.Get("Mcp-Session-Id"),
 		Tool:       request.Params.Name,
+		IdleProbe:  r.Header.Get(common.MCPIdleProbeHeader) == "true",
 	})
 	e.mu.Unlock()
 

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -76,7 +76,7 @@ func newHTTPHandler(info eruncommon.BuildInfo, cfg HTTPConfig, runtime RuntimeCo
 
 func activityHTTPMiddleware(runtime RuntimeConfig, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.Header.Get("X-Erun-Idle-Probe") == "true" {
+		if req.Header.Get(eruncommon.MCPIdleProbeHeader) == "true" {
 			next.ServeHTTP(w, req)
 			return
 		}

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -241,7 +241,7 @@ func TestActivityHTTPMiddlewareSkipsRecordingForIdleProbe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRequest failed: %v", err)
 	}
-	req.Header.Set("X-Erun-Idle-Probe", "true")
+	req.Header.Set(eruncommon.MCPIdleProbeHeader, "true")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)

--- a/erun-ui/diff_mcp.go
+++ b/erun-ui/diff_mcp.go
@@ -16,7 +16,7 @@ type idleProbeRoundTripper struct {
 
 func (t idleProbeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
-	req.Header.Set("X-Erun-Idle-Probe", "true")
+	req.Header.Set(eruncommon.MCPIdleProbeHeader, "true")
 	base := t.base
 	if base == nil {
 		base = http.DefaultTransport


### PR DESCRIPTION
## Summary

Fixes #1227. `erun idle` was stamping the environment's `mcp` activity marker on every call, so polling it in a loop (exactly what an orchestrator does before deciding to stop an environment) reset the idle timer it was reporting on and could keep an environment awake indefinitely.

## Root cause vs. the issue's description

The issue's diagnosis and measured evidence held up exactly: the erun-mcp server's activity middleware already exempts any request carrying `X-Erun-Idle-Probe: true` (added for the desktop's own diagnostic MCP client in `erun-ui/diff_mcp.go`), but the CLI's shared MCP client (`erun-common/mcp_client.go`, used by every host-side `erun idle`/`erun job ...`/`erun activity lease ...`/`erun mcp ...` call) never sent that header at all — `git grep X-Erun-Idle-Probe` really did turn up only the server check and the desktop round-tripper.

One deviation from the issue's suggested shape: it proposed "lifting [the desktop's `idleProbeRoundTripper`] and `mcpClientTransport`'s `idleProbe` parameter into `erun-common` so both the CLI and the desktop share one client." That would pull the MCP go-sdk's `mcp.StreamableClientTransport` into `erun-common`, which `erun-common/AGENTS.md` explicitly forbids ("Keep `erun-common` usable as a standalone library... should not depend on... the MCP SDK") — the CLI's client in `mcp_client.go` deliberately implements JSON-RPC by hand for exactly that reason. Instead, this PR adds the `IdleProbe` capability to the CLI's own existing client and exports the header name as a shared `erun-common` constant (`MCPIdleProbeHeader`, no SDK dependency) that the server (`erun-mcp/server.go`) and the desktop client (`erun-ui/diff_mcp.go`) now both reference instead of duplicating the string literal — one source of truth for the contract, without merging two client implementations that exist for different, legitimate reasons.

## What changed

- `erun-common/mcp_client.go`: `MCPToolCallParams`/`MCPToolListParams` gained an `IdleProbe bool`; `CallMCPTool`/`ListMCPTools` thread it through to the session, which sets `X-Erun-Idle-Probe: true` on every request when set.
- `erun-common/mcp_proxy.go` (`erun mcp proxy`, the stdio relay a real driving MCP client connects through): explicitly never an idle probe — that channel is real work, not a diagnostic.
- `erun-cli`: `callEnvironmentTool` (shared by `idle`, `job *`, `activity lease *`) and `callMCPToolWithReattach`/`listMCPToolsWithReattach` (backing `mcp call`/`mcp tools`) now take an `idleProbe` argument, set per call site by whether that specific tool is read-only:
  - idle-probed (read-only): `idle`, `job_status`, `job_output`, `job_await`, `activity_lease_list`, `mcp tools`.
  - never idle-probed (can mutate the environment, or — for the generic `mcp call` — the CLI can't know): `job_start`, `job_attach`, `job_cancel`, `activity_lease_take`, `activity_lease_release`, `mcp call`.
- `erun-mcp/server.go` + `server_test.go`, `erun-ui/diff_mcp.go`: reference the new shared `eruncommon.MCPIdleProbeHeader` constant instead of the duplicated string literal.
- Docs: `agent-reference/idle-policy.md`'s `last_terminal_input` activity-source table (the canonical spec) now correctly lists the idle-probed tools instead of only "any non-idle MCP tools/call"; `mcp/overview.md`'s `idle` tool description links to it. `cli/idle.md` already documented the intended (now real) behavior, so it needed no change.

## Proving the tests fail without the fix

Extended the existing off-environment fake-MCP-edge integration scenarios (`erun-integration/environment_half_scenarios_test.go`) with assertions on a new `fakeMCPRequest.IdleProbe` field (captured from the header in `mcp_test.go`), and added two new scenarios (`job status`/`job output`) that didn't have off-environment coverage before:

- `idle`, `job await`, `job status`, `job output`, `activity lease list` must carry the header.
- `job start`, `activity lease take` must **not** carry it (regression guards — these mutate the environment).

Reproduced against unfixed code (production changes stashed, header capture temporarily hardcoded to the literal `"X-Erun-Idle-Probe"` string so the test file itself would still compile without the new `erun-common` constant):

```
--- FAIL: TestIdleOffEnvironment (2.89s)
    --- FAIL: TestIdleOffEnvironment/reports_the_environments_own_answer
        expected the idle call to carry the idle-probe header ...
--- FAIL: TestJobOffEnvironment
    --- FAIL: .../await_maps_the_environments_outcome_onto_the_exit_code
    --- FAIL: .../status_reads_the_environments_job_state
    --- FAIL: .../output_reads_the_environments_captured_output
--- FAIL: TestActivityLeaseOffEnvironment
    --- FAIL: .../list_reads_the_environments_held_leases
```

All five failed exactly as expected; `job_start` and `activity_lease_take` stayed green (as they should — they were never idle-probed). Restored the fix and all pass.

## Validation

- `go build ./...` + `go test ./...` green in `erun-common`, `erun-cli`, `erun-mcp`, `erun-ui` (both with the normal PATH and under `env PATH=/usr/local/go/bin:/usr/bin:/bin`; the one stripped-PATH failure I saw, `erun-mcp`'s `TestReleaseToolPreview` needing `docker`, reproduces identically on unmodified `main` and is unrelated to this change).
- `make integration-test`: green, coverage 76.5% (>= 76.2% threshold).
- `golangci-lint run ./...` clean for `erun-common`, `erun-cli`, `erun-mcp`, `erun-integration`, `erun-ui`.
- `cd erun-docs && yarn build`: clean (no broken links/anchors).
- No RLS/tenant-scoped data involved, so no e2e Postgres run was needed.
- Not run: end-to-end verification against a real deployed runtime pod (would need a live cluster + `erun open`), since this environment has none. The integration suite's fake-MCP-edge scenarios are the closest available signal, mirroring exactly the client/server header contract a real pod exercises, and the erun-mcp server-side exemption itself already has its own passing unit test (`TestActivityHTTPMiddlewareSkipsRecordingForIdleProbe`).

## Test plan

- [x] `go test ./...` in erun-common, erun-cli, erun-mcp, erun-ui
- [x] `make integration-test`
- [x] `golangci-lint run ./...` in each touched module
- [x] `yarn build` in erun-docs