### PR TITLE
Fix review diff panel's periodic refresh timer never arming

### DIFF
--- a/erun-ui/frontend/src/app/reviewThunks.ts
+++ b/erun-ui/frontend/src/app/reviewThunks.ts
@@ -27,7 +27,6 @@ import {
 } from './slices/reviewSlice';
 import type { AppThunk } from './store';
 import { requireController } from './thunkExtra';
-import { selectionKey } from './versionSuggestions';
 
 const REVIEW_DIFF_REFRESH_INTERVAL_MS = 5000;
 
@@ -207,13 +206,13 @@ export const refreshReviewDiff = (): AppThunk<Promise<void>> => async (dispatch,
 function isCurrentReviewDiffRequest(
   getState: () => ReturnType<typeof import('./store').store.getState>,
   request: number,
-  selectedKey: string,
+  scopeKey: string,
 ): boolean {
   const state = getState();
-  return (
-    request === state.requestCounters.reviewDiff &&
-    selectedKey === selectionKey(state.selection.selected ?? { tenant: '', environment: '' })
-  );
+  const currentScopeKey = reviewEnvTargets(state)
+    .map((target) => target.envKey)
+    .join(',');
+  return request === state.requestCounters.reviewDiff && scopeKey === currentScopeKey;
 }
 
 function scheduleReviewDiffRefresh(


### PR DESCRIPTION
## Summary

Fixes #1223. Confirmed against the actual code: the bug is real but the description's suspected area (refresh interval / harness timing) was not quite it — the periodic refresh timer is **never armed at all**, in any environment, not just under the headless harness.

`scheduleReviewDiffRefresh` is only called after `loadReviewDiff` passes `isCurrentReviewDiffRequest`, which compared:

- the fetch's `scopeKey`, built as `targets.map(t => t.envKey).join(',')` → format `tenant/environment`
- against `selectionKey(state.selection.selected)` → a NUL-separated `tenant` + `environment` string

These two strings can never be equal, so `isCurrentReviewDiffRequest` always returned `false` and `scheduleReviewDiffRefresh` was never reached — the diff panel loads once when the review panel opens and then never refreshes again, silently, for every environment (single-selection and orchestrator alike).

The fix recomputes the current scope key the same way it was built originally (via `reviewEnvTargets(state).map(t => t.envKey).join(',')`) instead of using the unrelated `selectionKey` format, so the staleness check compares like with like. Removed the now-unused `selectionKey` import.

## How I proved the failing test fails without the fix

Per repo policy, reproduced first with the repro command from the issue:
```
cd erun-ui/playwright
./run.sh --build -- --grep "an active filter narrows the diff panel and tree to the same files"
```
Reproduced the exact 30s timeout on `nextDiffRefresh` on a clean `main`. Then added temporary `console.log` instrumentation in `scheduleReviewDiffRefresh` (not committed) and confirmed it is genuinely never invoked after the initial load — not a harness-timing issue, an always-false comparison. After applying the fix and rebuilding, the same spec passes in ~8.7s (the real time it takes for one 5s refresh interval plus settle), instead of timing out.

## What changed

- `erun-ui/frontend/src/app/reviewThunks.ts`: fixed `isCurrentReviewDiffRequest`'s scope-key comparison; removed the unused `selectionKey` import.

## UX Impact Review Checklist

1. **Affected paths:** review diff panel's periodic background refresh (silent poll every 5s while the panel is open), for both a single selected environment and an orchestrator's linked environments.
2. **User-visible sequence:** opening the review panel loads the diff once (unaffected); previously nothing refreshed it again until the panel was closed/reopened or a manual "Refresh" action ran. With the fix, the diff silently refreshes every 5s as designed, so file changes made by an agent while the panel is open now appear without user action.
3. **State-without-affordance:** n/a — this restores an existing silent background poll, no new visible state was added.
4. **Visibility of system status:** n/a — the poll is intentionally silent (`silent: true`) except for user-triggered `refreshReviewDiff` which already shows a "Diff refreshed." toast; unaffected by this fix.
5. **Success/failure feedback:** unaffected.
6. **Consistency with comparable flows:** restores existing behavior that other polling flows in this module already assume works.
7. **Heuristic pass:** Nielsen #1 (visibility of system status) is the one that matters here — the periodic refresh silently not running meant the diff panel could go stale indefinitely with no indication, which is exactly the gap this closes.
8. **Playwright coverage:** `erun-ui/playwright/tests/review-diff-tree.spec.ts` — "an active filter narrows the diff panel and tree to the same files" already exercises this via `nextDiffRefresh`; it is the spec the issue names, and it now passes for the right reason (a real periodic refresh happening) instead of timing out.

## Validation

- `erun-ui/playwright/tests/review-diff-tree.spec.ts` (all 4 specs) — green, including the previously-timing-out spec.
- `erun-ui/playwright/tests/orchestrator-cross-env-diff.spec.ts` (#1244 characterization tests) — all 7 green, unedited.
- `erun-ui/frontend` unit tests (`yarn test`, 103 tests incl. `reviewSlice.test.ts`, `useEnvDiffSlot.test.ts`, `reviewEnvTargets.test.ts`) — green.
- `yarn typecheck && yarn lint && yarn format:check && yarn build` — green.
- Full `erun-ui/playwright` suite (184 tests) — 183 passed, 1 pre-existing failure unrelated to this change: `manage-container-registries.spec.ts` "saves a build/from/to/deploy list and reloads it", which is issue #1222 (registry role checkboxes don't persist through save/reload) — confirmed by re-running the same spec with this fix stashed against the same `main` tip; it fails identically either way.
- `go test ./...` in `erun-ui` — green, both normally and under `env PATH=/usr/local/go/bin:/usr/bin:/bin`.
- `cd erun-integration && go test ./...` — green.
- No database/RLS-touching code in this change; no e2e-k3d run needed (no create/deploy/build flow touched).
- Docs plan: no `erun-docs` update needed — pure bug fix restoring existing documented/expected behavior (a background poll silently not running), no new user-facing surface, no behavior change to document beyond "it now works as originally designed."

## What I could not verify

- Did not manually drive the fix in the full desktop Wails app (only the headless Playwright harness) — the harness is the documented and sufficient verification path for this module per `erun-ui/AGENTS.md`.
