### PR TITLE
Drop legacy config keys on save so a completed migration cannot re-migrate

### DIFF
--- a/erun-common/config_roundtrip.go
+++ b/erun-common/config_roundtrip.go
@@ -243,9 +243,21 @@ func mappingValue(mapping *yaml.Node, key string) *yaml.Node {
 	return nil
 }
 
+// legacyYAMLKeys is implemented by config types whose UnmarshalYAML migrates
+// one or more legacy scalar keys into current fields (see container_registry.go).
+// Without this, knownYAMLFields never learns those keys exist, so
+// mergeConfigNode treats a legacy key surviving in the old document as
+// "unknown" and copies it through untouched forever — defeating the
+// documented one-way migration: the value keeps re-migrating on every load,
+// clobbering whatever the current fields were actually set to.
+type legacyYAMLKeys interface {
+	legacyYAMLKeys() []string
+}
+
 // knownYAMLFields returns the yaml key -> field-type map t declares, inlining
-// embedded/",inline" fields so their keys count as t's own. Non-struct types
-// (including the zero reflect.Type) declare no keys.
+// embedded/",inline" fields so their keys count as t's own, plus any legacy
+// keys t declares via legacyYAMLKeys. Non-struct types (including the zero
+// reflect.Type) declare no keys.
 func knownYAMLFields(t reflect.Type) map[string]reflect.Type {
 	fields := map[string]reflect.Type{}
 	if t == nil {
@@ -274,7 +286,25 @@ func knownYAMLFields(t reflect.Type) map[string]reflect.Type {
 		}
 		fields[name] = field.Type
 	}
+	addLegacyYAMLKeys(fields, t)
 	return fields
+}
+
+// addLegacyYAMLKeys adds t's legacy keys (if it declares any via
+// legacyYAMLKeys) to fields, mapped to a nil type. A legacy key is always
+// fully migrated into other fields, so the fresh marshal never re-emits it;
+// mergeConfigNode's own "known field with no current value" rule then drops
+// it, and that path never consults the type, so nil is safe here.
+func addLegacyYAMLKeys(fields map[string]reflect.Type, t reflect.Type) {
+	legacy, ok := reflect.New(t).Elem().Interface().(legacyYAMLKeys)
+	if !ok {
+		return
+	}
+	for _, key := range legacy.legacyYAMLKeys() {
+		if _, exists := fields[key]; !exists {
+			fields[key] = nil
+		}
+	}
 }
 
 // parseYAMLFieldTag mirrors yaml.v3's own field-name resolution closely enough

--- a/erun-common/config_roundtrip_test.go
+++ b/erun-common/config_roundtrip_test.go
@@ -139,6 +139,48 @@ func TestMarshalConfigPreservingUnknownFieldsSurvivesUnknownTopLevelKey(t *testi
 	}
 }
 
+// TestMarshalConfigPreservingUnknownFieldsDropsMigratedLegacyKey guards the
+// one-way migration documented on migrateLegacyContainerRegistry (erun#1222):
+// a legacy scalar key an UnmarshalYAML migrated into a current field must
+// actually disappear on the next save, not survive as an "unknown" field the
+// plain struct has no name for. Left unfixed, the desktop's own save (which
+// clears EnvConfig.ContainerRegistries to route a local-agent env's marked
+// list into the project config instead) writes a merged file that still
+// carries the legacy key, so the very next load re-migrates it and clobbers
+// whatever roles the operator just set.
+func TestMarshalConfigPreservingUnknownFieldsDropsMigratedLegacyKey(t *testing.T) {
+	existing := []byte("name: alpha\ncontainerregistry: registry.example/test\ntype: local-agent\n")
+
+	var loaded EnvConfig
+	if err := yaml.Unmarshal(existing, &loaded); err != nil {
+		t.Fatalf("seed unmarshal: %v", err)
+	}
+	if loaded.ContainerRegistries.IsZero() {
+		t.Fatalf("legacy scalar did not migrate: %+v", loaded)
+	}
+
+	// Mirrors what the desktop does for a local-agent env: the marked list
+	// moves to the project config, so the env's own ContainerRegistries clears.
+	cleared := loaded
+	cleared.ContainerRegistries = nil
+
+	out, err := marshalConfigPreservingUnknownFields(existing, cleared)
+	if err != nil {
+		t.Fatalf("marshalConfigPreservingUnknownFields: %v", err)
+	}
+	if strings.Contains(string(out), "containerregistry:") {
+		t.Fatalf("output still carries the migrated legacy key:\n%s", out)
+	}
+
+	var roundTripped EnvConfig
+	if err := yaml.Unmarshal(out, &roundTripped); err != nil {
+		t.Fatalf("unmarshal merged output: %v", err)
+	}
+	if !roundTripped.ContainerRegistries.IsZero() {
+		t.Fatalf("legacy key re-migrated after save: %+v", roundTripped.ContainerRegistries)
+	}
+}
+
 // TestMarshalConfigPreservingUnknownFieldsNoExistingFile covers the plain
 // first-write path: with nothing to preserve, the output is just the ordinary
 // marshal of config.

--- a/erun-common/container_registry.go
+++ b/erun-common/container_registry.go
@@ -428,6 +428,13 @@ func (c *ProjectConfig) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
+// legacyYAMLKeys implements config_roundtrip.go's legacyYAMLKeys, so a save
+// actually drops the migrated key instead of preserving it forever as an
+// unrecognized field.
+func (ProjectConfig) legacyYAMLKeys() []string {
+	return []string{"containerregistry"}
+}
+
 // UnmarshalYAML migrates an env's legacy fields on read so configs written by
 // older binaries keep working after those fields were removed from the struct.
 func (c *EnvConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -458,6 +465,13 @@ func (c *EnvConfig) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
+// legacyYAMLKeys implements config_roundtrip.go's legacyYAMLKeys, so a save
+// actually drops these migrated keys instead of preserving them forever as
+// unrecognized fields.
+func (EnvConfig) legacyYAMLKeys() []string {
+	return []string{"containerregistry", "remote", "snapshot", "repopath"}
+}
+
 // UnmarshalYAML migrates the per-env legacy `containerregistry` scalar the same
 // way as the project default.
 func (c *ProjectEnvironmentConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -472,6 +486,13 @@ func (c *ProjectEnvironmentConfig) UnmarshalYAML(value *yaml.Node) error {
 	*c = ProjectEnvironmentConfig(aux.plain)
 	c.ContainerRegistries = migrateLegacyContainerRegistry(c.ContainerRegistries, aux.LegacyContainerRegistry)
 	return nil
+}
+
+// legacyYAMLKeys implements config_roundtrip.go's legacyYAMLKeys, so a save
+// actually drops the migrated key instead of preserving it forever as an
+// unrecognized field.
+func (ProjectEnvironmentConfig) legacyYAMLKeys() []string {
+	return []string{"containerregistry"}
 }
 
 // ContainerRegistriesForEnvironment resolves the marked list for an


### PR DESCRIPTION
## Summary

Fixes #1222. The issue's title says container-registry role changes (e.g. `from`) don't survive a manage-dialog save/reload for a local-agent env; the actual root cause is broader than the container-registries code path itself.

**Root cause:** `marshalConfigPreservingUnknownFields` (the merge every `config.yaml` writer routes through) preserves any YAML key the current struct doesn't declare a field for — that's its whole point, for forward-compat with newer binaries. But `EnvConfig`/`ProjectConfig`/`ProjectEnvironmentConfig` also use this exact mechanism for a *different* purpose: migrating an old scalar key (`containerregistry`, plus `remote`/`snapshot`/`repopath` on `EnvConfig`) into current fields, one-way, on load. Since the plain struct genuinely has no field for those keys, the merge treated them as "unknown" and preserved them forever instead of ever dropping them.

Concretely, for a local-agent env whose `config.yaml` still carries the legacy `containerregistry: <host>` scalar (every env seeded before the marked-registries feature): the desktop's `SaveEnvironmentConfig` clears `EnvConfig.ContainerRegistries` and routes the marked list into the project's `.erun/config.yaml` instead (that's how local-agent envs are meant to store it). The legacy `containerregistry` key never actually left the env's own file, though, so the very next load re-migrated it back into `ContainerRegistries` and that stale value won every read — the manage dialog always showed the ancient build+deploy default and could never show (or keep) anything else, `from` included.

**Fix:** `legacyYAMLKeys() []string`, implemented by the three types, tells the merge which keys it fully migrates. `knownYAMLFields` now includes those as known-but-never-refreshed, so `mergeConfigNode`'s existing "known field with no current value → drop it" rule actually fires for them, same as it already does for a real field the operator cleared.

## Confirming the issue against the code

The reported symptom (only `from` observed as lost) matches, but the mechanism is a general config-persistence bug, not something specific to `RegistryRole` or to the container-registries feature — `repopath` (superseded by `localrepopath`) has the identical latent bug, confirmed in the same repro. Scoped this PR to the shared merge fix plus regression coverage at that layer, since that's the one change that closes the whole bug class, including the one from the issue.

## How I proved the new test fails without the fix

Added `TestMarshalConfigPreservingUnknownFieldsDropsMigratedLegacyKey` in `erun-common/config_roundtrip_test.go`. Stashed `config_roundtrip.go` + `container_registry.go` (keeping only the new test), ran it:

```
config_roundtrip_test.go:172: output still carries the migrated legacy key:
    name: alpha
    containerregistry: registry.example/test
    type: local-agent
    kubernetescontext: ""
--- FAIL: TestMarshalConfigPreservingUnknownFieldsDropsMigratedLegacyKey (0.00s)
```

Restored the fix — the test and the full `erun-common` suite pass.

Also reproduced the desktop-level symptom directly: built `erun-app` on unmodified `main` and ran the *existing* Playwright spec `erun-ui/playwright/tests/manage-container-registries.spec.ts` (`saves a build/from/to/deploy list and reloads it`) — it fails deterministically:

```
Expected: checked
Received: unchecked
Locator: ...getByLabel('from role for registry 1')
```

Rebuilt with the fix in place — both specs in that file pass.

## Validation

- `go test ./...` in `erun-common`, `erun-cli`, `erun-mcp`, `erun-ui`, `erun-integration` — all green.
- `go test ./...` in `erun-common` under `env PATH=/usr/local/go/bin:/usr/bin:/bin` (stripped PATH, no docker) — green.
- `golangci-lint run ./...` in `erun-common`, `erun-cli`, `erun-mcp`, `erun-ui` — 0 issues (fixed one `cyclop` complexity finding the new code introduced, by extracting `addLegacyYAMLKeys`).
- Full `erun-ui/playwright` suite (`./run.sh`) twice with the fix built in: 183/184 pass. The one red, `review-diff-tree.spec.ts` › "an active filter narrows the diff panel and tree to the same files", reproduces identically on unmodified `main` (confirmed by stashing this change and re-running) and is the pre-existing, already-tracked #1223 — not a regression from this change.

## UX Impact Review Checklist (erun-ui/AGENTS.md)

1. **Affected paths:** Manage dialog → General tab → Container registries field → Save → dialog reload, for a local-agent env whose `config.yaml` still carries the legacy `containerregistry` scalar.
2. **User-visible sequence:** Operator edits registry roles, clicks Save (dialog shows the pending-redeploy banner, stays open per existing behavior), closes and reopens the dialog. Before the fix, the pre-existing registry's roles silently revert to the stale legacy build+deploy default. After the fix, the dialog shows exactly what was saved.
3. **State-without-affordance:** N/A — no new state; a persistence bug that silently discarded existing state is fixed.
4. **Visibility of system status:** unchanged — same banner/close behavior as before.
5. **Success/failure feedback:** unchanged; the failure mode being fixed was silent data loss with no error surfaced, not a missing status affordance.
6. **Consistency with comparable flows:** N/A — persistence-layer correctness fix, not a new flow.
7. **One-line heuristic pass:** Error prevention and user control both improve (edits no longer silently discarded); the other 8 heuristics are unaffected/N/A for this change.
8. **Playwright coverage:** the existing spec `erun-ui/playwright/tests/manage-container-registries.spec.ts` ("saves a build/from/to/deploy list and reloads it") already encodes this exact regression end-to-end; no new spec needed. Confirmed failing pre-fix and passing post-fix above.

## Docs plan

No docs update needed — pure bug fix restoring already-documented one-way-migration behavior (the code comments already claimed this), no public-surface or behavior change beyond "the bug stops happening."

## What I could not verify

Did not exercise the `remote`/`snapshot`/`repopath` legacy-key paths through the desktop UI (only through the `erun-common` unit test) — no UI surface reads/writes those directly; the fix for them rides the same shared mechanism validated for `containerregistry`.