### PR TITLE
Fix the terminal-scroll-on-resize test flake

### DIFF
--- a/erun-ui/playwright/tests/terminal-scroll-on-resize.spec.ts
+++ b/erun-ui/playwright/tests/terminal-scroll-on-resize.spec.ts
@@ -185,12 +185,35 @@ async function viewportEverAtBottom(page: Page, duration: number): Promise<boole
 
 // setViewportScrollTop drives a user-style scroll: assigning scrollTop fires
 // the viewport's scroll event, which xterm syncs into its buffer position.
+// xterm ignores exactly one native 'scroll' event after it writes scrollTop
+// itself (e.g. the pin-to-bottom write that follows a resize's reflow), so it
+// can tell its own write apart from a real user scroll. Issuing this write
+// immediately after such an app-driven one risks the browser coalescing both
+// into a single dispatched event — which xterm then discards as the one it
+// was expecting from its own write, silently dropping this position change
+// while the DOM still shows it. Waiting two animation frames first lets any
+// such pending write's event fire and be consumed on its own before this one
+// is issued, so the two can never be mistaken for each other.
 async function setViewportScrollTop(page: Page, top: number): Promise<void> {
-  await page.evaluate((value) => {
+  await page.evaluate(async (value) => {
     const viewport = document.querySelector<HTMLElement>('.xterm-viewport');
-    if (viewport) {
-      viewport.scrollTop = value;
+    if (!viewport) {
+      return;
     }
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+    const before = viewport.scrollTop;
+    const settled = new Promise<void>((resolve) => {
+      viewport.addEventListener('scroll', () => resolve(), { once: true });
+    });
+    viewport.scrollTop = value;
+    if (viewport.scrollTop === before) {
+      // The assignment landed on the same (possibly clamped) value already in
+      // place, so no scroll event will fire — don't wait for one.
+      return;
+    }
+    await settled;
   }, top);
 }
 


### PR DESCRIPTION
## Summary

Closes #1243.

- `erun-ui/playwright/tests/terminal-scroll-on-resize.spec.ts` flaked with a real assertion mismatch (not the earlier #867 timeout). Root cause confirmed against the actual code, not just the issue's speculation: the spec's `setViewportScrollTop` helper wrote `viewport.scrollTop` directly to stage a scrolled-up reader. xterm's `Viewport` class arms a one-shot `_ignoreNextScrollEvent` flag whenever it writes `scrollTop` itself (e.g. the pin-to-bottom write that follows the review-panel-open resize's reflow), so it can tell its own write apart from a real user scroll. When the test's own `scrollTop = 0` write landed close enough after that internal write, the browser coalesced both into a single dispatched `scroll` event, which xterm discarded as the one it was expecting from its own write — silently dropping the test's scroll-to-top while the DOM still showed it applied (`scrollTop === 0`). The *next* resize's reflow then ran against xterm's stale, still-"at bottom" internal position and correctly (per that stale state) re-anchored there for real — which is exactly the assertion mismatch reported.
- This is a test-harness race, not a reintroduced application force-scroll bug: a real user never assigns `element.scrollTop` programmatically, so the specific two-back-to-back-scripted-writes collision this fix guards against isn't reachable through real mouse/trackpad scrolling.
- Fix: `setViewportScrollTop` now waits two animation frames before writing (so any pending scroll-event/ignore-flag cycle from an app-driven write settles first) and then waits for the resulting native `scroll` event before returning — an observable condition, not a wall-clock sleep.

## Root-cause verification

Instrumented `runTerminalResize` (temporarily, not part of this diff) to log `terminal.buffer.active.{viewportY,baseY}` alongside the real DOM `scrollTop` around each resize. Confirmed the divergence directly: after staging a scroll-to-top, the DOM read `scrollTop: 0` while xterm's internal `viewportY`/`baseY` were still `1451` (unrelated leftover "at bottom" state) — the closing resize's reflow then forced the DOM back to that stale bottom position.

## Test plan

- Confirmed the spec fails against unfixed code: `--repeat-each=10` → 3/10 failed with the exact reported mismatch (`expect(await viewportEverAtBottom(...)).toBe(false)` receiving `true`), matching the issue's ~5/8 flake rate.
- With the fix: `--repeat-each=10` → 10/10 passed, and a second `--repeat-each=20` run → 20/20 passed (30/30 total).
- Full default suite (`./playwright/run.sh`): 182 passed, 2 failed — both pre-existing, unrelated, already-filed issues (#1222 open, #1223) per `erun-ui/playwright/AGENTS.md`'s known-flake list; neither touches this spec.
- `go test ./...` in `erun-ui` and `erun-integration`: green.
- `yarn typecheck && yarn lint && yarn format:check` in `erun-ui/playwright`: clean.

Docs plan: not applicable — this is a test-only determinism fix with no behavior, feature, or public-surface change.