### PR TITLE
Force the tenant dashboard to actually refetch on refresh

### DIFF
--- a/erun-ui/frontend/src/app/tenantDialogThunks.ts
+++ b/erun-ui/frontend/src/app/tenantDialogThunks.ts
@@ -285,10 +285,16 @@ export const loadTenantDashboard =
       return;
     }
     dispatch(patchTenantDashboard({ loading: true, error: '' }));
+    // forceRefetch: true, because this fires on every dashboard open and every
+    // Refresh click — without it RTK Query's cache (never invalidated here)
+    // just replays the first successful result for the life of the process.
+    // unsubscribe once consumed so the one-shot call doesn't pin that cache
+    // entry open forever either.
+    const request = dispatch(
+      tenantApi.endpoints.getTenantDashboard.initiate(input, { forceRefetch: true }),
+    );
     try {
-      const loadedData = await dispatch(
-        tenantApi.endpoints.getTenantDashboard.initiate(input),
-      ).unwrap();
+      const loadedData = await request.unwrap();
       if (getState().tenantDashboard.tenant !== target) {
         return;
       }
@@ -311,6 +317,8 @@ export const loadTenantDashboard =
           data: null,
         }),
       );
+    } finally {
+      request.unsubscribe();
     }
   };
 

--- a/erun-ui/playwright/pages/TenantDashboard.ts
+++ b/erun-ui/playwright/pages/TenantDashboard.ts
@@ -16,6 +16,10 @@ export class TenantDashboard {
     await this.page.getByRole('tab', { name }).click();
   }
 
+  async clickRefresh(): Promise<void> {
+    await this.page.getByRole('button', { name: 'Refresh', exact: true }).click();
+  }
+
   activePanel(): Locator {
     return this.page.getByRole('tabpanel');
   }

--- a/erun-ui/playwright/tests/tenant-dashboard-refresh.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-refresh.spec.ts
@@ -1,0 +1,141 @@
+import type { Route, Request } from '@playwright/test';
+
+import { test, expect } from '../fixtures/erunApp.js';
+import {
+  SEED_TENANT,
+  removeEnvironment,
+  seedEnvironment,
+  uniqueEnvironmentName,
+} from '../fixtures/seedRoot.js';
+
+// See tenant-dashboard-audit-log.spec.ts for why this stages a throwaway env
+// with an apiUrl and stubs the RPC rather than using the seeded baseline or a
+// real backend.
+function seedDashboardEnvironment(title: string): string {
+  const environment = uniqueEnvironmentName(title);
+  seedEnvironment(SEED_TENANT, environment, 'apiurl: http://127.0.0.1:1/unreachable\n');
+  return environment;
+}
+
+interface StubbedResponse {
+  data?: Record<string, unknown>;
+  error?: string;
+}
+
+// Routes LoadTenantDashboard through a mutable holder so a test can change
+// what the "server" returns between the initial load and a later Refresh
+// click, and count how many times the RPC actually fired.
+function stubLoadTenantDashboard(
+  page: import('@playwright/test').Page,
+  initial: StubbedResponse,
+): { calls: () => number; respondWith: (next: StubbedResponse) => void } {
+  let current = initial;
+  let calls = 0;
+  void page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+    if (body.method === 'LoadTenantDashboard') {
+      calls += 1;
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify(current.error ? { error: current.error } : { data: current.data }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+  return {
+    calls: () => calls,
+    respondWith: (next) => {
+      current = next;
+    },
+  };
+}
+
+test.describe('tenant dashboard — refresh (#1213)', () => {
+  test('clicking Refresh re-fetches instead of replaying the cached result', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('refresh-refetches');
+    try {
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+
+      const stub = stubLoadTenantDashboard(page, {
+        data: {
+          tenant: SEED_TENANT,
+          environment,
+          apiUrl: 'http://127.0.0.1:1/unreachable',
+          user: { tenantId: 't1', userId: 'u1', username: 'operator' },
+          builds: [{ buildId: 'build-1', successful: true, commitId: 'c1', version: '1.0.0' }],
+        },
+      });
+
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+      await app.tenantDashboard.waitForOpen();
+      await app.tenantDashboard.selectTab('Builds');
+      await expect(app.tenantDashboard.activePanel()).toContainText('build-1');
+      expect(stub.calls()).toBe(1);
+
+      // The server-side state changes after the initial load. A real refresh
+      // must observe this; a cached replay would keep showing build-1.
+      stub.respondWith({
+        data: {
+          tenant: SEED_TENANT,
+          environment,
+          apiUrl: 'http://127.0.0.1:1/unreachable',
+          user: { tenantId: 't1', userId: 'u1', username: 'operator' },
+          builds: [{ buildId: 'build-2', successful: true, commitId: 'c2', version: '1.0.1' }],
+        },
+      });
+
+      await app.tenantDashboard.clickRefresh();
+
+      await expect(app.tenantDashboard.activePanel()).toContainText('build-2');
+      await expect(app.tenantDashboard.activePanel()).not.toContainText('build-1');
+      expect(stub.calls()).toBe(2);
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+
+  test('a failing refresh reports the failure, not a success toast', async ({ app, page }) => {
+    const environment = seedDashboardEnvironment('refresh-reports-failure');
+    try {
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+
+      const stub = stubLoadTenantDashboard(page, {
+        data: {
+          tenant: SEED_TENANT,
+          environment,
+          apiUrl: 'http://127.0.0.1:1/unreachable',
+          user: { tenantId: 't1', userId: 'u1', username: 'operator' },
+          builds: [{ buildId: 'build-1', successful: true, commitId: 'c1', version: '1.0.0' }],
+        },
+      });
+
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+      await app.tenantDashboard.waitForOpen();
+
+      stub.respondWith({ error: 'backend unreachable' });
+      await app.tenantDashboard.clickRefresh();
+
+      // Wait for the failure to actually surface before checking for the
+      // toast's absence, so the check lands at a fixed point (once the
+      // error's own dispatch has landed) instead of racing the success
+      // toast's auto-dismiss timer. On the cached-replay bug this text never
+      // appears at all, since the mocked failure is never actually fetched.
+      await expect(page.getByText('backend unreachable')).toBeVisible();
+
+      const successToast = page.getByRole('status').filter({ hasText: 'Dashboard refreshed.' });
+      await expect(successToast).toHaveCount(0);
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1213's two entangled defects in `loadTenantDashboard` (`erun-ui/frontend/src/app/tenantDialogThunks.ts`):

1. **Never refreshes.** `tenantApi.endpoints.getTenantDashboard.initiate(input)` was called with no options, so `forceRefetch` defaulted to `false`. Once the first load succeeded, every later call (dashboard reopen, every Refresh click) replayed the cached RTK Query result instead of hitting the backend again — the rows never changed for the life of the process, matching every comparable one-shot load elsewhere in this app (`idleThunks.ts`, `bootThunks.ts`, `globalConfigThunks.ts`, `reloadStateAfterEnvironmentChange`), all of which already pass `forceRefetch: true`.
2. **Lies about it.** `refreshTenantDashboard` already gated the success toast on `!after.error`, so on its face the "unconditional" framing in the issue doesn't literally match current `main`. But that gate was toothless in practice: because a cache replay can never fail, `after.error` was always empty, so the (correct) check never had a chance to block anything. Fixing defect 1 is what makes the existing gate start doing real work — once a genuine refetch can fail, the success toast is correctly skipped and the error surfaces instead.

Fix: pass `{ forceRefetch: true }` and `unsubscribe()` the request once consumed (mirroring `reloadStateAfterEnvironmentChange`'s pattern), so the dashboard load is a real one-shot fetch instead of a permanent, ever-returning cache subscription.

## Scope note

Issue #1213 also raised a third, unrelated finding: the Users tab renders a single row (the caller, from `/v1/whoami`) under a plural "Users" heading instead of the real tenant roster (`/v1/users`). That's a distinct UI/data-shape decision (rename the tab vs. wire the real roster endpoint) requested separately in the issue text — the operator's restatement of this task scoped it to the two refresh defects ("it never refreshes, and it lies about having refreshed"), so it isn't touched here. Filing as a follow-up is recommended rather than folding an unrelated UI decision into this fix.

## Confirming the issue against the code

Re-read `erun-ui/frontend/src/app/tenantDialogThunks.ts` at current `main` (`1809bc24`) and at the issue's cited commit (`eb6aaad9`): the `!after.error` gate already existed at both points, so the issue's "dispatches unconditionally" phrasing is a slight overstatement of the code — but the underlying bug (never actually refetching, so the gate can never trigger) is real and unchanged. Fixed what's actually wrong: the missing `forceRefetch`, not the (already-correct) gate.

## Reproduction

New Playwright spec `erun-ui/playwright/tests/tenant-dashboard-refresh.spec.ts`, run against unmodified `main` (before any fix):

- `clicking Refresh re-fetches instead of replaying the cached result` — stubs `LoadTenantDashboard` to return `build-1`, opens the dashboard, changes the stub to return `build-2`, clicks Refresh. **Failed**: panel still showed `build-1`.
- `a failing refresh reports the failure, not a success toast` — after the initial successful load, changes the stub to return an error, clicks Refresh. **Failed**: the error text never appeared at all (`page.getByText('backend unreachable')` timed out) — proof that the caching bug prevented the failure path from ever being reached, which is the entanglement described above.

## Proving the tests fail without the fix

`git stash push -- erun-ui/frontend/src/app/tenantDialogThunks.ts`, rebuilt (`./build.sh`), reran the new spec: both tests failed with the identical errors shown above. `git stash pop`, rebuilt, reran: both passed.

## Validation

- `erun-ui/playwright/tests/tenant-dashboard-refresh.spec.ts` (new, 2 tests) — pass.
- `./erun-ui/playwright/run.sh` full default suite (186 tests) — 184 passed. The 2 failures at the tail (`ux-tooltip-rules.spec.ts`, unrelated: activity-drawer tooltip assertions) were `net::ERR_CONNECTION_REFUSED` after the headless backend received a SIGTERM mid-run (`erun-app headless: shutting down`), ~10.6 minutes into the run — re-running that spec file alone immediately passed cleanly (4/4). This looks like an environment/resource artifact of a long full-suite run on this shared pod, not a regression from this change (unrelated code area, and the spec is stable in isolation).
- `go test ./...` in `erun-ui` — pass, both under the normal `PATH` and under `env PATH=/usr/local/go/bin:/usr/bin:/bin`.
- `golangci-lint run ./...` in `erun-ui` — 0 issues.
- `yarn typecheck && yarn lint && yarn format:check` in `erun-ui/frontend` — clean.
- `yarn test` (node:test unit suite) in `erun-ui/frontend` — 103/103 pass.
- `cd erun-integration && go test ./...` — pass (change doesn't touch CLI/common/integration goldens, but ran per the gate).

## UX Impact Review Checklist (`erun-ui/AGENTS.md`)

1. **Affected paths.** Sidebar → "Open tenant dashboard" (`openTenantDashboard` → `loadTenantDashboard`), and the dashboard's Refresh button (`refreshTenantDashboard` → `loadTenantDashboard`).
2. **User-visible sequence.** Click a tenant row → dashboard opens, brief loading spinner, tab content populates from the (now-real) fetch. Click Refresh → button disables while `dashboard.loading` is true → on success, tab content updates with genuinely fresh data plus a transient "Dashboard refreshed." toast; on failure, an error message replaces the tab content and no success toast fires.
3. **State-without-affordance.** No new state mutations added; existing `patchTenantDashboard`/`showNotification` dispatches are unchanged, just now driven by a real fetch outcome instead of a cache replay.
4. **Visibility of system status (Nielsen #1).** Unchanged mechanically (`dashboard.loading` still drives the spinner/disabled state) but now meaningful — it reflects a real in-flight request instead of an instantaneous no-op.
5. **Success/failure feedback (Nielsen #1, #9).** This is the fix: success is now reported only when a refetch actually succeeds, and failure now reaches the user (error text) instead of being silently masked by a stale cache hit.
6. **Consistency with comparable flows (Nielsen #4).** Matches `idleThunks.refreshIdleStatus`, `bootThunks.boot`/`reloadStateAfterEnvironmentChange`, and `globalConfigThunks.loadGlobalConfig`/`refreshCloudProviders`, all of which already pass `forceRefetch: true`.
7. **Heuristic pass.** Visibility of system status — now correct (loading/disabled state reflects a real request). Match between system and the real world — pass ("Refresh" now means refresh). Help users recognize/diagnose/recover from errors — pass (the error path is now reachable). Others (error prevention, recognition over recall, user control, aesthetic design, help/documentation) don't apply to this change.
8. **Playwright coverage.** `erun-ui/playwright/tests/tenant-dashboard-refresh.spec.ts` (new), following the RPC-stub pattern already established in `tenant-dashboard-audit-log.spec.ts`.

## Not verified

- Did not exercise this against a real, non-stubbed erun-backend-api tenant dashboard endpoint (the spec stubs `/__erun_invoke` per existing convention in this test file, since the harness is deliberately offline/inert). The fix itself is transport-agnostic (an RTK Query option + an unsubscribe call), so this is a low-risk gap, but it's not the same as watching a real HTTP round trip.