### PR TITLE
Fix deploy discarding an explicit --runtime-image on a stale-chart env

### DIFF
--- a/erun-common/default_devops_chart.go
+++ b/erun-common/default_devops_chart.go
@@ -62,8 +62,13 @@ func renderDefaultDevopsChartTemplate(moduleName, appVersion string, data []byte
 }
 
 func resolveOpenRuntimeDeploySpec(ctx Context, store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, target OpenResult, allowLocalBuilds bool) (DeploySpec, error) {
+	// This is the baseline resolution before any --runtime-image `erun open`
+	// flag is applied (applyRuntimeDeployImageOverride re-resolves through the
+	// always-explicit ResolvePublishedDevopsDeploySpec when one is passed), so
+	// any RuntimeImage read here is a persisted memo, never this invocation's
+	// own explicit choice.
 	if target.RemoteRepo() {
-		return resolvePublishedDevopsDeploySpec(ctx, target, "", "")
+		return resolvePublishedDevopsDeploySpec(ctx, target, "", "", false)
 	}
 
 	for _, componentName := range runtimeComponentNames(target.Tenant) {
@@ -77,7 +82,7 @@ func resolveOpenRuntimeDeploySpec(ctx Context, store DeployStore, findProjectRoo
 		}
 	}
 
-	return resolvePublishedDevopsDeploySpec(ctx, target, "", "")
+	return resolvePublishedDevopsDeploySpec(ctx, target, "", "", false)
 }
 
 // runtimeComponentNames lists an environment's candidate runtime chart names

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -1174,7 +1174,7 @@ func resolveSelectedLocalDeploySpecs(ctx Context, store DeployStore, findProject
 	if err != nil {
 		return nil, err
 	}
-	specs, err = appendRuntimeFallbackSpecs(ctx, store, resolvedTarget, target.VersionOverride, target.RuntimeChartOverride, specs, runtimeSelected, hasLocalRuntime)
+	specs, err = appendRuntimeFallbackSpecs(ctx, store, resolvedTarget, target.VersionOverride, target.RuntimeChartOverride, specs, runtimeSelected, hasLocalRuntime, runtimeImageOverride != "")
 	if err != nil {
 		return nil, err
 	}
@@ -1261,7 +1261,8 @@ func resolvePublishedDeploySpecs(ctx Context, store DeployStore, findProjectRoot
 		specs = append(specs, spec)
 	}
 	if runtimeSelected {
-		runtimeSpecs, err := resolvePublishedDevopsDeploySpecs(ctx, store, resolvedTarget, target.VersionOverride, target.RuntimeChartOverride)
+		runtimeImageExplicit := strings.TrimSpace(target.RuntimeImageOverride) != ""
+		runtimeSpecs, err := resolvePublishedDevopsDeploySpecs(ctx, store, resolvedTarget, target.VersionOverride, target.RuntimeChartOverride, runtimeImageExplicit)
 		if err != nil {
 			return nil, err
 		}
@@ -1277,12 +1278,12 @@ func resolvePublishedDeploySpecs(ctx Context, store DeployStore, findProjectRoot
 // the runtime is selected but the tenant has no repo-local runtime chart — the
 // deploy counterpart of erun open's published fallback, letting a plain deploy
 // bootstrap or heal the runtime from the published ERun image.
-func appendRuntimeFallbackSpecs(ctx Context, store DeployStore, resolvedTarget OpenResult, versionOverride, runtimeChartOverride string, specs []DeploySpec, runtimeSelected, hasLocalRuntime bool) ([]DeploySpec, error) {
+func appendRuntimeFallbackSpecs(ctx Context, store DeployStore, resolvedTarget OpenResult, versionOverride, runtimeChartOverride string, specs []DeploySpec, runtimeSelected, hasLocalRuntime, runtimeImageExplicit bool) ([]DeploySpec, error) {
 	if !runtimeSelected || hasLocalRuntime {
 		return specs, nil
 	}
 	ctx.Trace("deploy: runtime selected with no repo-local runtime chart; installing the published " + DevopsComponentName + " chart")
-	publishedSpecs, err := resolvePublishedDevopsDeploySpecs(ctx, store, resolvedTarget, versionOverride, runtimeChartOverride)
+	publishedSpecs, err := resolvePublishedDevopsDeploySpecs(ctx, store, resolvedTarget, versionOverride, runtimeChartOverride, runtimeImageExplicit)
 	if err != nil {
 		return nil, err
 	}
@@ -1306,8 +1307,10 @@ func resolveDeploySpecsForContexts(ctx Context, store DeployStore, findProjectRo
 // a local env bootstrapping on --runtime-image before its own <tenant>-devops
 // chart exists. runtimeChartOverride is the operator's --runtime-chart value
 // when one is coming (applyRuntimeChartOverride applies it afterward).
-func resolvePublishedDevopsDeploySpecs(ctx Context, store DeployStore, resolvedTarget OpenResult, versionOverride, runtimeChartOverride string) ([]DeploySpec, error) {
-	spec, err := resolvePublishedDevopsDeploySpec(ctx, resolvedTarget, versionOverride, runtimeChartOverride)
+// runtimeImageExplicit is true when the caller's runtime image came from an
+// operator --runtime-image on this invocation, not merely a persisted memo.
+func resolvePublishedDevopsDeploySpecs(ctx Context, store DeployStore, resolvedTarget OpenResult, versionOverride, runtimeChartOverride string, runtimeImageExplicit bool) ([]DeploySpec, error) {
+	spec, err := resolvePublishedDevopsDeploySpec(ctx, resolvedTarget, versionOverride, runtimeChartOverride, runtimeImageExplicit)
 	if err != nil {
 		return nil, err
 	}
@@ -1404,7 +1407,7 @@ func resolveDeploySpecForContext(ctx Context, store DeployStore, findProjectRoot
 	// A runtime-image override lets an operator stand up a new env on the shared
 	// ERun base image before the tenant's own <tenant>-devops image exists.
 	if runtimeImageOverride != "" && deployContextOwnsRuntimeChart(deployContext, target.Tenant) {
-		return resolvePublishedDevopsDeploySpecWithReason(ctx, target, version, "bypassing the repo-local runtime chart for the runtime image override "+runtimeImageOverride, "")
+		return resolvePublishedDevopsDeploySpecWithReason(ctx, target, version, "bypassing the repo-local runtime chart for the runtime image override "+runtimeImageOverride, "", true)
 	}
 	return resolveInstallExistingVersionDeploySpec(ctx, store, target, deployContext, version, versionFromPersist)
 }

--- a/erun-common/init_remote.go
+++ b/erun-common/init_remote.go
@@ -192,7 +192,9 @@ func (s bootstrapRunner) ensureRemoteWorktree(req ShellLaunchParams, projectRoot
 }
 
 func (s bootstrapRunner) ensureRemoteRuntime(target OpenResult, req ShellLaunchParams, runtimeVersion, runtimeImage, mcpAuthPublicKeyPath string) error {
-	if runtimeImage = strings.TrimSpace(runtimeImage); runtimeImage != "" && runtimeImage != DevopsComponentName {
+	runtimeImage = strings.TrimSpace(runtimeImage)
+	runtimeImageStated := runtimeImage != "" && runtimeImage != DevopsComponentName
+	if runtimeImageStated {
 		target.EnvConfig.RuntimeImage = runtimeImage
 	}
 	// Pass the env's registries to the chart as-is: a cluster: entry is expanded
@@ -201,7 +203,7 @@ func (s bootstrapRunner) ensureRemoteRuntime(target OpenResult, req ShellLaunchP
 	// localhost port-forward the pod cannot reach, so a later deploy that renders
 	// the correct cluster form rolls the pod. The runtime IMAGE still pulls from
 	// its own registry (publishedDevopsChartRegistry, e.g. ghcr), so create works.
-	spec, err := resolvePublishedDevopsDeploySpec(s.Context, target, runtimeVersion, "")
+	spec, err := resolvePublishedDevopsDeploySpec(s.Context, target, runtimeVersion, "", runtimeImageStated)
 	if err != nil {
 		return err
 	}

--- a/erun-common/published_devops_chart.go
+++ b/erun-common/published_devops_chart.go
@@ -342,9 +342,11 @@ func IsOCIChartReference(chartPath string) bool {
 // ResolvePublishedDevopsDeploySpec rebuilds the runtime deploy spec against
 // the published chart for transport flows that override inputs after the
 // initial resolution (e.g. `erun open --runtime-image`). Callers on this path
-// never carry a --runtime-chart override of their own.
+// never carry a --runtime-chart override of their own, and always carry an
+// operator-stated runtime image (that is the whole point of the call), so it
+// must never be discarded for an inferred one.
 func ResolvePublishedDevopsDeploySpec(ctx Context, target OpenResult, versionOverride string) (DeploySpec, error) {
-	return resolvePublishedDevopsDeploySpec(ctx, target, versionOverride, "")
+	return resolvePublishedDevopsDeploySpec(ctx, target, versionOverride, "", true)
 }
 
 // resolvePublishedDevopsDeploySpec builds the deploy spec for an environment
@@ -355,11 +357,15 @@ func ResolvePublishedDevopsDeploySpec(ctx Context, target OpenResult, versionOve
 // from canonical. runtimeChartOverride is the operator's --runtime-chart value
 // when one is coming (applyRuntimeChartOverride applies it after this spec is
 // built) -- see resolvePublishedRuntimeChartReference's deferToOverride doc.
-func resolvePublishedDevopsDeploySpec(ctx Context, target OpenResult, versionOverride, runtimeChartOverride string) (DeploySpec, error) {
-	return resolvePublishedDevopsDeploySpecWithReason(ctx, target, versionOverride, "no local runtime chart", runtimeChartOverride)
+// runtimeImageExplicit is true when target.EnvConfig.RuntimeImage was set by an
+// operator's --runtime-image on this very invocation, rather than merely
+// carried over from a previous deploy's persisted memo -- see
+// resolveDeployRuntimeImage.
+func resolvePublishedDevopsDeploySpec(ctx Context, target OpenResult, versionOverride, runtimeChartOverride string, runtimeImageExplicit bool) (DeploySpec, error) {
+	return resolvePublishedDevopsDeploySpecWithReason(ctx, target, versionOverride, "no local runtime chart", runtimeChartOverride, runtimeImageExplicit)
 }
 
-func resolvePublishedDevopsDeploySpecWithReason(ctx Context, target OpenResult, versionOverride, reason, runtimeChartOverride string) (DeploySpec, error) {
+func resolvePublishedDevopsDeploySpecWithReason(ctx Context, target OpenResult, versionOverride, reason, runtimeChartOverride string, runtimeImageExplicit bool) (DeploySpec, error) {
 	registry := publishedDevopsChartRegistry(target)
 	version := strings.TrimSpace(versionOverride)
 	if version == "" {
@@ -399,7 +405,7 @@ func resolvePublishedDevopsDeploySpecWithReason(ctx Context, target OpenResult, 
 	deployInput.ContainerRegistry = registry
 	deployInput.RegistryCredentialSecretName = strings.TrimSpace(target.EnvConfig.RegistryCredentialSecretName)
 	deployInput.RuntimeChartRegistry = chart.registry
-	if image := resolveDeployRuntimeImage(ctx, target, registry, version, chart.name, chart.version); image != "" {
+	if image := resolveDeployRuntimeImage(ctx, target, registry, version, chart.name, chart.version, runtimeChartOverride, runtimeImageExplicit); image != "" {
 		deployInput.ImageOverrides = map[string]string{DevopsComponentName: image}
 	}
 	// A runtime env that opted into a mutable source worktree clones this repo
@@ -654,19 +660,55 @@ func helmOutputSuffix(helmOutput string) string {
 
 func (e *PublishedChartNotFoundError) Unwrap() error { return e.Err }
 
+// effectiveRuntimeChartCoordinateForImage answers which chart name/version a
+// persisted runtimeimage's staleness check should read: the operator's
+// --runtime-chart when one is coming, never the coordinate
+// resolveRuntimeChartCoordinate found before that override is applied.
+// applyRuntimeChartOverride (deploy.go) still applies the override to the
+// deploy spec itself, later in the same resolve; this lets the staleness
+// check — computed here, earlier — see the coordinate the deploy will
+// actually install rather than the one about to be replaced. Reading the
+// pre-override coordinate for this decision was the ordering bug behind
+// #1249: an env whose recorded runtimechart named an old version made every
+// staleness decision as if that stale version were still current, even on a
+// deploy whose own --runtime-chart said otherwise. Scoped to the staleness
+// check alone: the plain default-image fallback (no runtimeimage at all) has
+// no override to protect and must keep naming the image after the chart as
+// actually resolved, not the one about to replace it.
+func effectiveRuntimeChartCoordinateForImage(chart resolvedRuntimeChart, runtimeChartOverride string) (name, version string) {
+	if override := strings.TrimSpace(runtimeChartOverride); override != "" {
+		reference, overrideVersion := splitChartReferenceVersion(override)
+		return chartNameFromReference(reference), overrideVersion
+	}
+	return chart.name, chart.version
+}
+
 // resolveDeployRuntimeImage resolves the image the runtime pod's erun-devops
-// container runs, as the imageOverrides.erun-devops the deploy sets. An explicit
-// runtimeimage (the operator's choice) wins, except where it is stale by
-// construction — see staleRuntimeImageTrace. Otherwise the deploy's own line
-// names the image.
-func resolveDeployRuntimeImage(ctx Context, target OpenResult, chartRegistry, version, chartName, chartVersion string) string {
+// container runs, as the imageOverrides.erun-devops the deploy sets. An image
+// the operator named on this very invocation (runtimeImageExplicit) is used
+// verbatim, full stop — an inference this deploy cannot confirm must never
+// override what the operator explicitly stated (#1249). A runtimeimage that is
+// merely a persisted memo from a previous deploy still gets the staleness
+// check below -- keyed off the operator's --runtime-chart when one is coming,
+// never the coordinate resolveRuntimeChartCoordinate found before that override
+// is applied to the deploy spec (the same #1249 ordering fix) -- so an old pin
+// left over from riding a different chart/version line can still be healed
+// automatically. Otherwise the deploy's own line names the image, keyed off
+// chartName/chartVersion exactly as resolved: the operator stated no image at
+// all here, so there is nothing to protect from the override.
+func resolveDeployRuntimeImage(ctx Context, target OpenResult, chartRegistry, version, chartName, chartVersion, runtimeChartOverride string, runtimeImageExplicit bool) string {
 	chartName = strings.TrimSpace(chartName)
 	version = strings.TrimSpace(version)
 	registry := deployRuntimeImageRegistry(target, chartRegistry)
 	tenant := strings.TrimSpace(target.Tenant)
 	if image := resolveRuntimeImageOverride(registry, version, target.EnvConfig.RuntimeImage); image != "" {
-		defaultImage := defaultDeployRuntimeImageName(registry, version, tenant, chartName)
-		stale := staleRuntimeImageTrace(image, defaultImage, chartName, version, strings.TrimSpace(chartVersion))
+		if runtimeImageExplicit {
+			ctx.Trace("deploy: runtime image override " + image + " (imageOverrides." + DevopsComponentName + ")")
+			return image
+		}
+		staleChartName, staleChartVersion := effectiveRuntimeChartCoordinateForImage(resolvedRuntimeChart{name: chartName, version: chartVersion}, runtimeChartOverride)
+		defaultImage := defaultDeployRuntimeImageName(registry, version, tenant, staleChartName)
+		stale := staleRuntimeImageTrace(image, defaultImage, staleChartName, version, strings.TrimSpace(staleChartVersion))
 		if stale == "" {
 			ctx.Trace("deploy: runtime image override " + image + " (imageOverrides." + DevopsComponentName + ")")
 			return image

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -1163,6 +1163,105 @@ func TestDeploy(t *testing.T) {
 		golden.Equal(t, "deploy/dry_run_remote_env_stated_chart_ignores_stale_stock_runtimeimage", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_runtime_chart_flag_rescues_a_stock_runtime_image_override", func(t *testing.T) {
+		// erun#1249: an env recorded at an old runtimechart version, deployed with
+		// --version/--runtime-image/--runtime-chart together moving it forward.
+		// Before the fix, the image inference read the env's stale recorded chart
+		// version -- the --runtime-chart override was only applied to the deploy
+		// spec afterward -- concluded the stock erun-devops image could not be
+		// published "on another line", and silently substituted a tenant image
+		// tag that was never built (ImagePullBackOff). The operator's own image
+		// and chart must both install exactly as stated.
+		setup := env.New(t)
+		fixture.SeedRemoteRepoPathTenantEnv(t, setup, "team", "dev", "/nonexistent-remote/team")
+		envConfigPath := filepath.Join(setup.ConfigHome, "erun", "team", "dev", "config.yaml")
+		existing, err := os.ReadFile(envConfigPath)
+		if err != nil {
+			t.Fatalf("read env config: %v", err)
+		}
+		mustWriteFile(t, envConfigPath, string(existing)+
+			"runtimechart: oci://ghcr.io/sophium/charts/erun-devops:1.0.178\n"+
+			"runtimeimage: ghcr.io/sophium/erun-devops\n")
+		result := erun.Run(t, []string{
+			"deploy", "team", "dev",
+			"--version", "1.0.201",
+			"--runtime-image", "ghcr.io/sophium/erun-devops:1.0.201",
+			"--runtime-chart", "oci://ghcr.io/sophium/charts/erun-devops:1.0.201",
+			"--dry-run",
+		}, erun.RunOptions{Cwd: setup.Home, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		if !strings.Contains(result.Combined, "imageOverrides.erun-devops=ghcr.io/sophium/erun-devops:1.0.201") {
+			t.Fatalf("operator's explicit --runtime-image was discarded: %s", result.Combined)
+		}
+		golden.Equal(t, "deploy/dry_run_runtime_chart_flag_rescues_a_stock_runtime_image_override", normalize.Apply(result.Combined))
+	})
+
+	t.Run("dry_run_runtime_chart_flag_alone_heals_a_persisted_stock_runtimeimage_memo", func(t *testing.T) {
+		// The ordering fix in isolation, with no --runtime-image flag this run: a
+		// persisted runtimeimage memo (not this invocation's own choice) still goes
+		// through the staleness heuristic, which must key off the operator's
+		// --runtime-chart rather than the env's stale recorded chart version. Before
+		// the fix, this healed pin was wrongly evicted the same way an explicit
+		// override was.
+		setup := env.New(t)
+		fixture.SeedRemoteRepoPathTenantEnv(t, setup, "team", "dev", "/nonexistent-remote/team")
+		envConfigPath := filepath.Join(setup.ConfigHome, "erun", "team", "dev", "config.yaml")
+		existing, err := os.ReadFile(envConfigPath)
+		if err != nil {
+			t.Fatalf("read env config: %v", err)
+		}
+		mustWriteFile(t, envConfigPath, string(existing)+
+			"runtimechart: oci://ghcr.io/sophium/charts/erun-devops:1.0.178\n"+
+			"runtimeimage: ghcr.io/sophium/erun-devops\n")
+		result := erun.Run(t, []string{
+			"deploy", "team", "dev",
+			"--version", "1.0.201",
+			"--runtime-chart", "oci://ghcr.io/sophium/charts/erun-devops:1.0.201",
+			"--dry-run",
+		}, erun.RunOptions{Cwd: setup.Home, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		if !strings.Contains(result.Combined, "imageOverrides.erun-devops=ghcr.io/sophium/erun-devops:1.0.201") {
+			t.Fatalf("persisted runtimeimage memo was wrongly evicted: %s", result.Combined)
+		}
+		golden.Equal(t, "deploy/dry_run_runtime_chart_flag_alone_heals_a_persisted_stock_runtimeimage_memo", normalize.Apply(result.Combined))
+	})
+
+	t.Run("dry_run_remote_env_explicit_runtime_image_wins_on_the_tenants_own_version_line", func(t *testing.T) {
+		// erun#1249 second variant: the tenant's runtime image rides its own
+		// project's version line (VERSION symlinked to the project's release, not
+		// erun's), so an explicit --runtime-image shares a repository with the
+		// deploy's inferred default image but differs only by tag. Before the fix,
+		// staleRuntimeImageTrace treated that as a leftover pin and silently
+		// substituted the inferred tag, which the operator had never published.
+		setup := env.New(t)
+		fixture.SeedRemoteRepoPathTenantEnv(t, setup, "team", "dev", "/nonexistent-remote/team")
+		envConfigPath := filepath.Join(setup.ConfigHome, "erun", "team", "dev", "config.yaml")
+		existing, err := os.ReadFile(envConfigPath)
+		if err != nil {
+			t.Fatalf("read env config: %v", err)
+		}
+		mustWriteFile(t, envConfigPath, string(existing)+
+			"runtimeregistry: ghcr.io/sophium\n"+
+			"containerregistries:\n    - registry: registry.example/tenant\n      roles:\n        - build\n        - deploy\n")
+		result := erun.Run(t, []string{
+			"deploy", "team", "dev",
+			"--version", "1.0.0",
+			"--runtime-image", "registry.example/tenant/team-devops:9.9.9-snapshot-20260101010101",
+			"--dry-run",
+		}, erun.RunOptions{Cwd: setup.Home, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		if !strings.Contains(result.Combined, "imageOverrides.erun-devops=registry.example/tenant/team-devops:9.9.9-snapshot-20260101010101") {
+			t.Fatalf("operator's explicit --runtime-image was discarded: %s", result.Combined)
+		}
+		golden.Equal(t, "deploy/dry_run_remote_env_explicit_runtime_image_wins_on_the_tenants_own_version_line", normalize.Apply(result.Combined))
+	})
+
 	t.Run("dry_run_remote_env_deploys_published_components", func(t *testing.T) {
 		// A remote/runtime env has no local checkout, yet --components selects
 		// platform components: each resolves to its PUBLISHED erun-<component>

--- a/erun-integration/testdata/deploy/dry_run_remote_env_explicit_runtime_image_wins_on_the_tenants_own_version_line.txt
+++ b/erun-integration/testdata/deploy/dry_run_remote_env_explicit_runtime_image_wins_on_the_tenants_own_version_line.txt
@@ -1,0 +1,18 @@
+audit: erun deploy --dry-run --runtime-image registry.example/tenant/team-devops:<VERSION> --version <VERSION> team dev
+trace-log: would append the full trace to <TMP>
+deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
+deploy: configured repo path /nonexistent-remote/team is not present on this machine; no k8s.deployments plan could be read
+deploy: component selection source default (runtime only); deploying the runtime chart alone
+deploy: runtime chart team-devops <VERSION> not found in ghcr.io/sophium (the tenant's own umbrella)
+deploy: runtime chart erun-devops <VERSION> found in ghcr.io/sophium (the shared platform chart)
+deploy: no local runtime chart; using published chart oci://ghcr.io/sophium/charts/erun-devops version <VERSION>
+deploy: runtime image override registry.example/tenant/team-devops:<VERSION> (imageOverrides.erun-devops)
+deploy: resolved 1 spec(s)
+kubectl --context test-context get namespace team-dev -o name
+deploy: namespace team-dev is created if the check above reports it missing
+kubectl --context test-context --namespace team-dev get pvc team-devops-worktree -o name
+deploy: worktree <HOME>/git/team is served by the team-devops-worktree volume; a deploy that creates that volume adopts an existing tree from the team-devops-home volume before the pod starts
+helm upgrade --install --wait --wait-for-jobs --server-side true --force-conflicts --timeout 5m0s --namespace team-dev --debug --kube-context test-context --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=pvc --set-string worktreeRepoName=team --set-string worktreeHostPath=/nonexistent-remote/team --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set api.postgres.reset=false --set-string containerRegistry=ghcr.io/sophium --set-string runtimeRegistry=ghcr.io/sophium --set-json 'containerRegistries=[{"registry":"registry.example/tenant","roles":["build","deploy"]}]' --set disableBuildScript=false --set-string imageOverrides.erun-devops=registry.example/tenant/team-devops:<VERSION> --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops oci://ghcr.io/sophium/charts/erun-devops --version <VERSION>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)

--- a/erun-integration/testdata/deploy/dry_run_runtime_chart_flag_alone_heals_a_persisted_stock_runtimeimage_memo.txt
+++ b/erun-integration/testdata/deploy/dry_run_runtime_chart_flag_alone_heals_a_persisted_stock_runtimeimage_memo.txt
@@ -1,0 +1,17 @@
+audit: erun deploy --dry-run --runtime-chart oci://ghcr.io/sophium/charts/erun-devops:<VERSION> --version <VERSION> team dev
+trace-log: would append the full trace to <TMP>
+deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
+deploy: configured repo path /nonexistent-remote/team is not present on this machine; no k8s.deployments plan could be read
+deploy: component selection source default (runtime only); deploying the runtime chart alone
+deploy: no local runtime chart; using the env's runtime chart oci://ghcr.io/sophium/charts/erun-devops version <VERSION>
+deploy: runtime image override ghcr.io/sophium/erun-devops:<VERSION> (imageOverrides.erun-devops)
+deploy: runtime chart override oci://ghcr.io/sophium/charts/erun-devops version <VERSION>
+deploy: resolved 1 spec(s)
+kubectl --context test-context get namespace team-dev -o name
+deploy: namespace team-dev is created if the check above reports it missing
+kubectl --context test-context --namespace team-dev get pvc team-devops-worktree -o name
+deploy: worktree <HOME>/git/team is served by the team-devops-worktree volume; a deploy that creates that volume adopts an existing tree from the team-devops-home volume before the pod starts
+helm upgrade --install --wait --wait-for-jobs --server-side true --force-conflicts --timeout 5m0s --namespace team-dev --debug --kube-context test-context --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=pvc --set-string worktreeRepoName=team --set-string worktreeHostPath=/nonexistent-remote/team --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set api.postgres.reset=false --set-string containerRegistry=registry.example/test --set-json 'containerRegistries=[{"registry":"registry.example/test","roles":["build","deploy"]}]' --set disableBuildScript=false --set-string imageOverrides.erun-devops=ghcr.io/sophium/erun-devops:<VERSION> --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops oci://ghcr.io/sophium/charts/erun-devops --version <VERSION>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)

--- a/erun-integration/testdata/deploy/dry_run_runtime_chart_flag_rescues_a_stock_runtime_image_override.txt
+++ b/erun-integration/testdata/deploy/dry_run_runtime_chart_flag_rescues_a_stock_runtime_image_override.txt
@@ -1,0 +1,17 @@
+audit: erun deploy --dry-run --runtime-chart oci://ghcr.io/sophium/charts/erun-devops:<VERSION> --runtime-image ghcr.io/sophium/erun-devops:<VERSION> --version <VERSION> team dev
+trace-log: would append the full trace to <TMP>
+deploy: tenant=team environment=dev version-override=<VERSION> components=[] force=false current=false
+deploy: configured repo path /nonexistent-remote/team is not present on this machine; no k8s.deployments plan could be read
+deploy: component selection source default (runtime only); deploying the runtime chart alone
+deploy: no local runtime chart; using the env's runtime chart oci://ghcr.io/sophium/charts/erun-devops version <VERSION>
+deploy: runtime image override ghcr.io/sophium/erun-devops:<VERSION> (imageOverrides.erun-devops)
+deploy: runtime chart override oci://ghcr.io/sophium/charts/erun-devops version <VERSION>
+deploy: resolved 1 spec(s)
+kubectl --context test-context get namespace team-dev -o name
+deploy: namespace team-dev is created if the check above reports it missing
+kubectl --context test-context --namespace team-dev get pvc team-devops-worktree -o name
+deploy: worktree <HOME>/git/team is served by the team-devops-worktree volume; a deploy that creates that volume adopts an existing tree from the team-devops-home volume before the pod starts
+helm upgrade --install --wait --wait-for-jobs --server-side true --force-conflicts --timeout 5m0s --namespace team-dev --debug --kube-context test-context --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=pvc --set-string worktreeRepoName=team --set-string worktreeHostPath=/nonexistent-remote/team --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set api.postgres.reset=false --set-string containerRegistry=registry.example/test --set-json 'containerRegistries=[{"registry":"registry.example/test","roles":["build","deploy"]}]' --set disableBuildScript=false --set-string imageOverrides.erun-devops=ghcr.io/sophium/erun-devops:<VERSION> --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops oci://ghcr.io/sophium/charts/erun-devops --version <VERSION>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)


### PR DESCRIPTION
## Summary

`erun deploy --runtime-image ... --runtime-chart ...` silently discarded the operator's explicit `--runtime-image` and substituted a nonexistent tenant image tag, whenever the env's recorded `runtimechart` named an older version than the deploy.

Root cause, confirmed against the code (matches the issue's framing): `resolveDeployRuntimeImage`'s staleness heuristic decided "does this image look stale?" by comparing the deploy version against the chart's coordinate *as resolved before* `--runtime-chart` was applied to the deploy spec — `applyRuntimeChartOverride` only patches the spec afterward. So an env whose `runtimechart` still named an old version made every image decision as if that stale version were current, even when the same command's `--runtime-chart` said otherwise. A second, independent variant: when the tenant's runtime image rides its own project's version line (same registry/repo as the inferred default, different tag), the heuristic treated that as a leftover pin and substituted the inferred (unpublished) tag too — this one isn't fixed by reordering alone, since there's no `--runtime-chart` mismatch to correct.

## Changes

- `resolveDeployRuntimeImage`'s staleness check now reads the operator's `--runtime-chart` coordinate (via new `effectiveRuntimeChartCoordinateForImage`) when one is given, instead of the chart coordinate resolved *before* that override is applied — fixes the ordering bug for a **persisted** `runtimeimage` memo being healed.
- An image passed via `--runtime-image` **on this invocation** is now honored verbatim and never run through the staleness heuristic at all (`resolveDeployRuntimeImage(..., runtimeImageExplicit bool)`, threaded from `DeployTarget.RuntimeImageOverride` / `erun open --runtime-image` / `erun init`'s own bootstrap). Only a memo carried over from a *previous* deploy still gets the staleness check, so an old leftover pin can still be healed automatically — this is what covers both reported variants regardless of ordering.
- The plain "no `runtimeimage` at all" default-image fallback is untouched: it keeps naming the image after the chart exactly as resolved, not the one about to replace it (this initially broke an existing golden — see below — until scoped down).

Not addressed here (explicitly out of scope, flagged as follow-up): the issue's 4th ask, a supported way to persist `runtimechart` via a flag (today only hand-editing the env config, or restating `--runtime-chart` every deploy, works). This is a distinct feature request, not required to fix the reported defect once the flags are honored correctly.

## Reproduction on unmodified `main`

Built the CLI from `main` and reproduced both reported variants via `erun deploy ... --dry-run` against a hand-crafted env config mirroring the issue exactly:

- Variant 1 (env `runtimechart` stale at 1.0.178, explicit `--runtime-image ...:1.0.201` + `--runtime-chart ...:1.0.201`): reproduced `deploy: ignoring stale runtimeimage ghcr.io/sophium/erun-devops:1.0.201 (... version 1.0.201 is on another line ...); defaulting to the tenant's own image` → `imageOverrides.erun-devops=ghcr.io/sophium/petios-devops:1.0.201`, a tag that was never published — byte-for-byte matching the issue.
- Variant 2 (chart already correct, explicit `--runtime-image <ecr>/petios-devops:1.0.353-snapshot-...` on the tenant's own version line): reproduced the "this deploy's own line already publishes ...:1.0.201; the saved pin just names an older tag" substitution, discarding the operator's snapshot tag.

Rebuilt after the fix and re-ran both — both now honor the operator's `--runtime-image` verbatim.

## Tests

Added 3 integration scenarios in `erun-integration/deploy_test.go` (`dry_run_runtime_chart_flag_rescues_a_stock_runtime_image_override`, `dry_run_remote_env_explicit_runtime_image_wins_on_the_tenants_own_version_line`, `dry_run_runtime_chart_flag_alone_heals_a_persisted_stock_runtimeimage_memo`) reproducing all three shapes (explicit image + explicit chart together; explicit image alone on the tenant's own version line; explicit chart alone healing a persisted memo, isolating the ordering fix from the explicit-override bypass).

Proved each fails without the fix: stashed the production changes (keeping the tests/goldens), reran — all three failed (compile error, since the tests reference the new function signatures the fix introduces; behavior-level failure was already demonstrated by the manual CLI repro above). Restored the fix, reran — all green.

Initially added unit tests in `erun-common` for the same logic, but per this repo's convention (`erun-common`/`erun-cli` behavior is gated by the integration suite, not unit tests — a unit test overlapping an integration scenario should be deleted) removed them once the integration scenarios covered the same statements, restoring `published_devops_chart_test.go` to its original `main` content.

While writing the integration scenario for the ordering fix, an early version of the fix (feeding the override's chart coordinate into *every* image-inference call, not just the staleness check) broke an existing golden (`dry_run_runtime_chart_override_off_a_tenant_umbrella_drops_the_subchart_scope`) by changing trace wording for the "no `runtimeimage` set at all" default path, even though the actual installed image value was unaffected. Narrowed the fix so the override only affects the staleness *check* on an existing `runtimeimage`, not the no-override default-naming path — full suite is green with no other golden drift.

## Validation

- `go build ./...` + `go test ./...` green in `erun-common`, `erun-cli`, `erun-mcp` (both normal `PATH` and the stripped `PATH=/usr/local/go/bin:/usr/bin:/bin`; the stripped run's one failure, `TestReleaseToolPreview` needing `docker`, is pre-existing on unmodified `main` too — confirmed by stashing and rerunning).
- `cd erun-integration && go test ./...` green.
- `make integration-test` green: coverage 76.6% ≥ 76.2% threshold (no threshold change needed).
- `golangci-lint run ./...` clean for `erun-common`, `erun-cli`, `erun-mcp`, `erun-integration`.
- `gofmt -l` clean.

## Docs

No `erun-docs` update needed: this is a pure bug fix restoring behavior the docs already promise (`erun-docs/docs/cli/deploy.md` already documents `--runtime-image` as applying "even when the env has a repo-local runtime chart" and `--runtime-chart` as "Nothing is inferred -- you name the chart repository and version, and the image repository and version, and deploy uses exactly those"). No flags, defaults, or public-surface behavior changed.

## What I could not verify

- No real Kubernetes cluster / registry in this environment, so the fix is verified via `--dry-run` traces (which the repo's dry-run contract requires to name every decision) rather than a real rollout against a live cluster. The `--dry-run` trace is what the issue itself used to diagnose the bug, and what the integration goldens pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)