### PR TITLE
Give a working orchestrator's sidebar spinner a hover explanation

### DIFF
--- a/erun-ui/frontend/src/components/app/Sidebar.BusyRowSpinner.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.BusyRowSpinner.tsx
@@ -1,19 +1,32 @@
 import { LoaderCircle } from 'lucide-react';
 import * as React from 'react';
 
+import { cn } from '@/lib/utils';
+
 // BusyRowSpinner is the shared "this row is working" indicator for sidebar
 // rows. Shared by AI-orchestrator and environment rows so both report activity
 // identically — an orchestrator driving its envs is working in exactly the
 // sense an env's AI tab is, and a row that looks idle while it works is the
 // worse failure. Independent of the status dot, which carries the row's
 // condition rather than its activity. The caller owns the accessible label.
-export function BusyRowSpinner({ label }: { label: string }): React.ReactElement {
+//
+// Forwards ref and every other prop to the underlying icon, not just
+// `label`: a caller wrapping this in IconTooltip's `asChild` Slot merges in
+// the pointer/focus handlers and ref that make the trigger actually work, and
+// a component that drops them renders a tooltip that never opens on hover —
+// silently, since the icon still looks and spins the same either way.
+export const BusyRowSpinner = React.forwardRef<
+  SVGSVGElement,
+  React.SVGProps<SVGSVGElement> & { label: string }
+>(function BusyRowSpinner({ label, className, ...props }, ref) {
   return (
     <LoaderCircle
-      className="size-3.5 flex-none animate-spin text-current opacity-75"
+      ref={ref}
+      className={cn('size-3.5 flex-none animate-spin text-current opacity-75', className)}
       aria-label={label || undefined}
       aria-hidden={label ? undefined : true}
       role={label ? 'status' : undefined}
+      {...props}
     />
   );
-}
+});

--- a/erun-ui/frontend/src/components/app/Sidebar.ErunSection.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.ErunSection.tsx
@@ -222,12 +222,26 @@ function OrchestratorRow({
       >
         <span className="min-w-0 truncate">{orchestrator.name}</span>
       </button>
-      {busy && <BusyRowSpinner label={`${orchestrator.name} is working`} />}
+      {busy && <OrchestratorBusyIndicator name={orchestrator.name} />}
       {!busy && shellActivity?.running && (
         <OrchestratorShellIndicator name={orchestrator.name} activity={shellActivity} />
       )}
       <OrchestratorRowActions orchestrator={orchestrator} running={running} active={active} />
     </li>
+  );
+}
+
+// OrchestratorBusyIndicator is the turn-busy sibling of OrchestratorShellIndicator
+// below, wrapped in the same IconTooltip so a working orchestrator explains
+// itself on hover exactly like every other spinner in the sidebar — the
+// aria-label alone reached only screen readers, leaving a sighted mouse user
+// with an inert spin.
+function OrchestratorBusyIndicator({ name }: { name: string }): React.ReactElement {
+  const label = `${name} is working`;
+  return (
+    <IconTooltip label={label}>
+      <BusyRowSpinner label={label} />
+    </IconTooltip>
   );
 }
 

--- a/erun-ui/playwright/pages/Sidebar.ts
+++ b/erun-ui/playwright/pages/Sidebar.ts
@@ -268,6 +268,23 @@ export class Sidebar {
     return this.erunSection().getByRole('status', { name: `${name} is working` });
   }
 
+  // Hovering the busy spinner raises the same IconTooltip popper every other
+  // spinner in the sidebar uses. The trigger is the spinning icon itself
+  // (`animate-spin`), whose continuously-changing bounding box never
+  // satisfies Playwright's hover "stable" actionability check — so the
+  // animation is frozen first. That is a test-only workaround for the
+  // Chromium/Playwright interaction, not a product concern.
+  async hoverOrchestratorBusySpinner(name: string): Promise<void> {
+    const spinner = this.orchestratorBusySpinner(name);
+    await spinner.waitFor({ state: 'visible' });
+    await this.page.addStyleTag({ content: '.animate-spin { animation: none !important; }' });
+    await spinner.hover();
+  }
+
+  orchestratorBusyTooltip(name: string): Locator {
+    return this.page.getByRole('tooltip', { name: `${name} is working` });
+  }
+
   // The row's background-shell indicator, rendered whenever the store's
   // orchestratorShellActivity.bySession has this orchestrator's session
   // flagged running — from the orchestrator-shell-activity event or from the

--- a/erun-ui/playwright/tests/sidebar-orchestrator-busy-snapshot.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-orchestrator-busy-snapshot.spec.ts
@@ -69,4 +69,19 @@ test.describe('orchestrator busy renders from the list snapshot (#1087)', () => 
     await expect(app.sidebar.orchestratorStatusDot(SEED_ORCHESTRATOR, 'running')).toBeVisible();
     await expect(app.sidebar.orchestratorBusySpinner(SEED_ORCHESTRATOR)).toHaveCount(0);
   });
+
+  // Hovering the busy spinner used to reveal nothing, unlike every other
+  // spinner in the sidebar (the shell indicator three lines below it, and
+  // every environment row's own activity popover).
+  test('hovering the busy spinner reveals a tooltip naming the orchestrator', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(page, true);
+    await app.reboot();
+
+    await app.sidebar.hoverOrchestratorBusySpinner(SEED_ORCHESTRATOR);
+
+    await expect(app.sidebar.orchestratorBusyTooltip(SEED_ORCHESTRATOR)).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1228. The turn-busy spinner in `Sidebar.ErunSection.tsx` (`OrchestratorRow`) rendered a bare `<BusyRowSpinner>` with no `IconTooltip`, unlike its shell-indicator sibling three lines below. Wraps it the same way, via a small `OrchestratorBusyIndicator` component that mirrors `OrchestratorShellIndicator`.

**Scope note:** issue #1228 has a later comment proposing a much larger redesign (a popover listing every linked environment, engaged-first, plus resource usage from #1233). Per explicit direction for this task, this PR implements only the original, small item 1 from the issue body ("wrap the busy spinner in the same IconTooltip the shell indicator uses... land it first") — not the popover redesign, which depends on #1233 and is a separate body of work.

**What the issue got wrong:** the issue's own description says the shell indicator "does it correctly," citing it as the working sibling. It doesn't. `BusyRowSpinner` (`Sidebar.BusyRowSpinner.tsx`) only destructured its `label` prop and dropped everything else. `IconTooltip` wraps its child in Radix's `asChild` `Slot`, which clones the child and merges in the `ref` and pointer/focus event handlers that make a tooltip trigger actually work — but `BusyRowSpinner` never forwarded those onto the underlying `<LoaderCircle>` SVG, so they were silently discarded. The shell indicator's tooltip has never opened on hover; nothing had exercised a real hover against it before this PR (no existing spec did). Fixed `BusyRowSpinner` to forward `ref` and the rest of its props, which fixes both indicators at once — mine and its pre-existing sibling.

## UX Impact Review Checklist

1. **Affected paths:** Sidebar → AI Orchestrators row → turn-busy spinner (hover).
2. **User-visible sequence:** an orchestrator's turn goes busy → its row spinner starts (unchanged) → hovering the spinner now raises a tooltip reading "`<name>` is working" (same text already used for the spinner's own aria-label) → moving away closes it.
3. **State-without-affordance:** N/A, no new state — reuses the existing `busy` boolean and its existing label string.
4. **Visibility of system status (Nielsen #1):** the persistent spinner itself is unchanged; the fix adds the missing on-demand explanation for it.
5. **Success/failure feedback:** N/A, purely an informational hover affordance, not an action.
6. **Consistency with comparable flows (Nielsen #4):** matches the orchestrator's own shell indicator (`OrchestratorShellIndicator`, same file) and the sidebar's other icon tooltips (row action buttons, env status dot) — all use `IconTooltip`.
7. **Heuristic pass:** #1 (visibility of system status) is the one this fixes; the rest are unaffected — no new control, no new error path, no new destructive action.
8. **Playwright coverage:** extended `erun-ui/playwright/tests/sidebar-orchestrator-busy-snapshot.spec.ts` with a new case that hovers the busy spinner and asserts the tooltip appears, plus a `hoverOrchestratorBusySpinner`/`orchestratorBusyTooltip` pair in `pages/Sidebar.ts`.

## How I verified

- **Reproduced on unmodified `main`:** built `erun-app`, ran the new Playwright case against the unmodified sidebar — hovering the busy spinner never raised a tooltip (`getByRole('tooltip')` timed out, element not found).
- **Diagnosed root cause:** traced it to `BusyRowSpinner` dropping the props Radix's `Slot` merges in for the trigger. Verified this by hovering the *pre-existing, unmodified* shell indicator's spinner with a throwaway debug spec — it also raised no tooltip, confirming the issue's "the sibling already does this correctly" premise was wrong.
- **Proved the new test fails without the fix:** stashed only the two component files (`Sidebar.BusyRowSpinner.tsx`, `Sidebar.ErunSection.tsx`), rebuilt, reran the new case — it failed the same way (`toBeVisible()` timeout, tooltip not found). Restored the fix, rebuilt, reran — passes.
- Ran the full `erun-ui/playwright` suite (`./run.sh --build`) — all 187 tests pass, no regressions (the untouchable diff-panel characterization specs from #1244 were not modified and are part of that green run).
- `yarn typecheck && yarn lint && yarn format:check && yarn build` in `erun-ui/frontend` — clean.
- `go test ./...` in `erun-ui` — clean, both with the normal PATH and under `env PATH=/usr/local/go/bin:/usr/bin:/bin`.
- `golangci-lint run ./...` in `erun-ui` — 0 issues (no Go source changed, but the module gate is clean).
- `go test ./...` in `erun-integration` — clean.

## Docs

No `erun-docs` change — pure sidebar affordance parity between two indicators whose own code comments already document the intended behavior; nothing about the product contract moves.

## Not verified

- Real macOS/Windows desktop rendering (validated only in the headless Playwright harness on Linux, per the harness this repo uses for CI-equivalent gating).