### PR TITLE
Stop rendering confident state the app has not observed

### DIFF
--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -168,7 +168,7 @@ type App struct {
 	// state, not configuration), so any code path that needs "is this context
 	// running right now?" must consult this map.
 	cloudContextStatusesMu sync.RWMutex
-	cloudContextStatuses   map[string]string
+	cloudContextStatuses   map[string]cloudContextCacheEntry
 	cloudContextPollerStop chan struct{}
 
 	// workingIssueCache memoizes the resolved working issue per env so the sidebar

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -4787,7 +4787,7 @@ func TestIdleStatusToUIClearsStopErrorWhenContextIsRunning(t *testing.T) {
 		ManagedCloud: true,
 		Policy:       eruncommon.EnvironmentIdlePolicy{Timeout: 5 * time.Minute},
 		StopError:    "An error occurred (RequestExpired) when calling the StopInstances operation: Request has expired.",
-	})
+	}, true)
 
 	if ui.CloudContextStatus != eruncommon.CloudContextStatusRunning {
 		t.Fatalf("expected CloudContextStatus=%q, got %q", eruncommon.CloudContextStatusRunning, ui.CloudContextStatus)
@@ -4835,7 +4835,7 @@ func TestIdleStatusToUIKeepsStopErrorWhenContextIsStopped(t *testing.T) {
 		ManagedCloud: true,
 		Policy:       eruncommon.EnvironmentIdlePolicy{Timeout: 5 * time.Minute},
 		StopError:    "An error occurred (RequestExpired) when calling the StopInstances operation: Request has expired.",
-	})
+	}, true)
 
 	if ui.CloudContextStatus != eruncommon.CloudContextStatusStopped {
 		t.Fatalf("expected CloudContextStatus=%q, got %q", eruncommon.CloudContextStatusStopped, ui.CloudContextStatus)

--- a/erun-ui/cloud_context_cache.go
+++ b/erun-ui/cloud_context_cache.go
@@ -11,6 +11,23 @@ import (
 // against AWS describe-instances cost for a user with many contexts.
 const cloudContextStatusPollInterval = 10 * time.Second
 
+// cloudContextStatusTTL bounds how long a known-good status stays
+// authoritative once AWS stops confirming it. A single failed
+// describe-instances call surfaces as Unknown and must not blank a
+// known-good status outright — but a sustained run of them must, or a
+// context stopped an hour ago keeps reading "running" forever and the
+// Stop action keeps getting offered against it. This is the same
+// discipline session_heartbeat.go:28-32 applies to session liveness.
+const cloudContextStatusTTL = 3 * cloudContextStatusPollInterval
+
+// cloudContextCacheEntry is one context's cached status plus the last time
+// that status was actually confirmed by AWS (not merely re-asserted because a
+// later Unknown was suppressed).
+type cloudContextCacheEntry struct {
+	status      string
+	confirmedAt time.Time
+}
+
 // "" means the poller has not observed this context yet; treat it as
 // unknown, never as a real status.
 func (a *App) cloudContextStatus(name string) string {
@@ -20,11 +37,22 @@ func (a *App) cloudContextStatus(name string) string {
 	}
 	a.cloudContextStatusesMu.RLock()
 	defer a.cloudContextStatusesMu.RUnlock()
-	return a.cloudContextStatuses[name]
+	entry, ok := a.cloudContextStatuses[name]
+	if !ok {
+		return ""
+	}
+	if time.Since(entry.confirmedAt) > cloudContextStatusTTL {
+		return eruncommon.CloudContextStatusUnknown
+	}
+	return entry.status
 }
 
-// A transient AWS describe-instances failure surfaces as Unknown;
-// keeping the prior value stops it from blanking a known-good status.
+// A single transient AWS describe-instances failure surfaces as Unknown, and
+// keeping the prior value stops it alone from blanking a known-good status.
+// But that grace is bounded by cloudContextStatusTTL: once the last confirmed
+// observation is stale, the Unknown downgrade is honoured, so an AWS outage
+// that outlasts the grace window can't keep serving a status that may no
+// longer be true.
 func (a *App) applyCloudContextStatusesToCache(statuses []eruncommon.CloudContextStatus) {
 	if len(statuses) == 0 {
 		return
@@ -32,7 +60,7 @@ func (a *App) applyCloudContextStatusesToCache(statuses []eruncommon.CloudContex
 	a.cloudContextStatusesMu.Lock()
 	defer a.cloudContextStatusesMu.Unlock()
 	if a.cloudContextStatuses == nil {
-		a.cloudContextStatuses = make(map[string]string, len(statuses))
+		a.cloudContextStatuses = make(map[string]cloudContextCacheEntry, len(statuses))
 	}
 	for _, status := range statuses {
 		name := strings.TrimSpace(status.Name)
@@ -44,11 +72,11 @@ func (a *App) applyCloudContextStatusesToCache(statuses []eruncommon.CloudContex
 			continue
 		}
 		if newStatus == eruncommon.CloudContextStatusUnknown {
-			if _, ok := a.cloudContextStatuses[name]; ok {
+			if entry, ok := a.cloudContextStatuses[name]; ok && time.Since(entry.confirmedAt) <= cloudContextStatusTTL {
 				continue
 			}
 		}
-		a.cloudContextStatuses[name] = newStatus
+		a.cloudContextStatuses[name] = cloudContextCacheEntry{status: newStatus, confirmedAt: time.Now()}
 	}
 }
 
@@ -63,9 +91,9 @@ func (a *App) setCloudContextStatusInCache(name, status string) {
 	a.cloudContextStatusesMu.Lock()
 	defer a.cloudContextStatusesMu.Unlock()
 	if a.cloudContextStatuses == nil {
-		a.cloudContextStatuses = make(map[string]string, 1)
+		a.cloudContextStatuses = make(map[string]cloudContextCacheEntry, 1)
 	}
-	a.cloudContextStatuses[name] = status
+	a.cloudContextStatuses[name] = cloudContextCacheEntry{status: status, confirmedAt: time.Now()}
 }
 
 func (a *App) startCloudContextStatusPoller() {

--- a/erun-ui/cloud_context_cache_test.go
+++ b/erun-ui/cloud_context_cache_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// TestCloudContextCacheSmoothsATransientUnknown locks in the deliberate grace
+// period: a single failed describe-instances call must not blank a
+// known-good status the moment it comes in.
+func TestCloudContextCacheSmoothsATransientUnknown(t *testing.T) {
+	app := &App{}
+	app.applyCloudContextStatusesToCache([]eruncommon.CloudContextStatus{
+		{CloudContextConfig: eruncommon.CloudContextConfig{Name: "ctx"}, Status: eruncommon.CloudContextStatusRunning},
+	})
+	app.applyCloudContextStatusesToCache([]eruncommon.CloudContextStatus{
+		{CloudContextConfig: eruncommon.CloudContextConfig{Name: "ctx"}, Status: eruncommon.CloudContextStatusUnknown},
+	})
+	if got := app.cloudContextStatus("ctx"); got != eruncommon.CloudContextStatusRunning {
+		t.Fatalf("a single transient Unknown must not blank a known-good status: got %q", got)
+	}
+}
+
+// TestCloudContextCacheHonoursUnknownPastTTL is the regression for erun#1216:
+// a sustained AWS failure must downgrade the cache to Unknown rather than
+// serve a "running" that may be an hour stale — the case that let the Stop
+// button be offered against state the app could no longer verify.
+func TestCloudContextCacheHonoursUnknownPastTTL(t *testing.T) {
+	app := &App{
+		cloudContextStatuses: map[string]cloudContextCacheEntry{
+			"ctx": {status: eruncommon.CloudContextStatusRunning, confirmedAt: time.Now().Add(-2 * cloudContextStatusTTL)},
+		},
+	}
+	app.applyCloudContextStatusesToCache([]eruncommon.CloudContextStatus{
+		{CloudContextConfig: eruncommon.CloudContextConfig{Name: "ctx"}, Status: eruncommon.CloudContextStatusUnknown},
+	})
+	if got := app.cloudContextStatus("ctx"); got != eruncommon.CloudContextStatusUnknown {
+		t.Fatalf("a stale known-good status must downgrade to Unknown once its confirmation TTL has passed: got %q", got)
+	}
+}
+
+// TestCloudContextStatusReadSideAppliesTTLEvenWithoutANewPoll covers the case
+// where the poller itself stops producing results entirely (e.g.
+// RefreshCloudContextStatuses fails at the list-contexts step, before any
+// per-context Unknown is even produced): the read path must age the
+// observation out on its own, mirroring session_heartbeat.go's
+// heartbeatSaysRunning.
+func TestCloudContextStatusReadSideAppliesTTLEvenWithoutANewPoll(t *testing.T) {
+	app := &App{
+		cloudContextStatuses: map[string]cloudContextCacheEntry{
+			"ctx": {status: eruncommon.CloudContextStatusRunning, confirmedAt: time.Now().Add(-2 * cloudContextStatusTTL)},
+		},
+	}
+	if got := app.cloudContextStatus("ctx"); got != eruncommon.CloudContextStatusUnknown {
+		t.Fatalf("want Unknown for a stale observation with no fresh poll at all, got %q", got)
+	}
+}
+
+// TestCloudContextCacheRecoversImmediatelyOnAGoodReading guards against
+// over-correcting: once AWS answers again, the cache must reflect it right
+// away rather than waiting out any grace period.
+func TestCloudContextCacheRecoversImmediatelyOnAGoodReading(t *testing.T) {
+	app := &App{
+		cloudContextStatuses: map[string]cloudContextCacheEntry{
+			"ctx": {status: eruncommon.CloudContextStatusUnknown, confirmedAt: time.Now().Add(-2 * cloudContextStatusTTL)},
+		},
+	}
+	app.applyCloudContextStatusesToCache([]eruncommon.CloudContextStatus{
+		{CloudContextConfig: eruncommon.CloudContextConfig{Name: "ctx"}, Status: eruncommon.CloudContextStatusRunning},
+	})
+	if got := app.cloudContextStatus("ctx"); got != eruncommon.CloudContextStatusRunning {
+		t.Fatalf("a fresh good reading must apply immediately: got %q", got)
+	}
+}

--- a/erun-ui/config_watcher.go
+++ b/erun-ui/config_watcher.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -37,18 +38,17 @@ func (a *App) startConfigWatcher() {
 	a.mu.Unlock()
 
 	root, err := eruncommon.ERunConfigDir()
-	if err != nil || root == "" {
-		return
-	}
-	if err := os.MkdirAll(root, 0o755); err != nil {
-		return
-	}
-	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
+		a.reportConfigWatcherFailure(fmt.Errorf("resolve config directory: %w", err))
 		return
 	}
-	if err := addConfigWatchDirs(watcher, root); err != nil {
-		_ = watcher.Close()
+	if root == "" {
+		a.reportConfigWatcherFailure(fmt.Errorf("resolve config directory: no path returned"))
+		return
+	}
+	watcher, err := newFsnotifyConfigWatcher(root)
+	if err != nil {
+		a.reportConfigWatcherFailure(err)
 		return
 	}
 
@@ -64,6 +64,37 @@ func (a *App) startConfigWatcher() {
 	a.mu.Unlock()
 
 	go a.runConfigWatcher(ctx, cw, root)
+}
+
+// newFsnotifyConfigWatcher creates the fsnotify watcher rooted at root and
+// arms it on every existing subdirectory, naming which step failed so the
+// caller can surface it instead of leaving the watcher silently unstarted.
+func newFsnotifyConfigWatcher(root string) (*fsnotify.Watcher, error) {
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return nil, fmt.Errorf("create config directory %s: %w", root, err)
+	}
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("start filesystem watcher: %w", err)
+	}
+	if err := addConfigWatchDirs(watcher, root); err != nil {
+		_ = watcher.Close()
+		return nil, fmt.Errorf("watch config directory %s: %w", root, err)
+	}
+	return watcher, nil
+}
+
+// reportConfigWatcherFailure surfaces a config watcher problem as an
+// actionable notification. Swallowing it — the previous behavior, for both a
+// failed start and a runtime error from the watcher itself — left config
+// changes made outside the desktop's own PTY (a hand-edited file, `erun env
+// delete` from another terminal, `erun init` in a separate shell) silently
+// unreflected, indistinguishable from "nothing changed".
+func (a *App) reportConfigWatcherFailure(err error) {
+	a.emitAppNotification("warning", fmt.Sprintf(
+		"Could not watch the config directory for external changes: %s. Environments created or edited outside this window may not appear until you reopen the app.",
+		err.Error(),
+	))
 }
 
 func (a *App) stopConfigWatcher() {
@@ -111,10 +142,11 @@ func (a *App) runConfigWatcher(ctx context.Context, cw *configWatcher, root stri
 				return
 			}
 			handleConfigWatchEvent(cw.watcher, event, queueEmit)
-		case _, ok := <-cw.watcher.Errors:
+		case watchErr, ok := <-cw.watcher.Errors:
 			if !ok {
 				return
 			}
+			a.reportConfigWatcherFailure(fmt.Errorf("watch config directory: %w", watchErr))
 		}
 	}
 }

--- a/erun-ui/config_watcher_test.go
+++ b/erun-ui/config_watcher_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestNewFsnotifyConfigWatcherFailsWhenTheRootCannotBeCreated locks in the
+// seam startConfigWatcher now uses to surface its own startup failure
+// instead of a bare return.
+func TestNewFsnotifyConfigWatcherFailsWhenTheRootCannotBeCreated(t *testing.T) {
+	tmp := t.TempDir()
+	// A regular file sits where the watcher root needs to be a directory, so
+	// os.MkdirAll fails — the same failure shape startConfigWatcher hits when
+	// the real config directory is blocked (e.g. a stray file left by another
+	// tool, a permissions problem).
+	blocker := filepath.Join(tmp, "blocked")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(blocker, "erun")
+
+	if _, err := newFsnotifyConfigWatcher(root); err == nil {
+		t.Fatal("expected an error when the config directory cannot be created")
+	}
+}
+
+// TestStartConfigWatcherSurfacesAStartupFailure is the regression for
+// erun#1216 bug 4: a failed watcher start must reach the user as an
+// actionable notification instead of leaving config-change detection
+// silently and permanently off.
+func TestStartConfigWatcherSurfacesAStartupFailure(t *testing.T) {
+	emits := newCapturedEmits()
+	app := &App{emitFn: emits.fn()}
+
+	app.reportConfigWatcherFailure(errors.New("create config directory: mkdir: not a directory"))
+
+	events := emits.events(appNotificationEvent)
+	if len(events) != 1 {
+		t.Fatalf("want one notification, got %d: %+v", len(events), events)
+	}
+	payload, ok := events[0].(appNotificationPayload)
+	if !ok || payload.Kind != "warning" || payload.Message == "" {
+		t.Fatalf("want an actionable warning notification, got %+v", events[0])
+	}
+}
+
+// TestConfigWatcherSurfacesARuntimeError covers the second swallowed path:
+// an error the fsnotify watcher reports after it already started (e.g. an
+// overflowed event queue) must not be discarded either.
+func TestConfigWatcherSurfacesARuntimeError(t *testing.T) {
+	root := t.TempDir()
+	watcher, err := newFsnotifyConfigWatcher(root)
+	if err != nil {
+		t.Fatalf("newFsnotifyConfigWatcher: %v", err)
+	}
+
+	notified := make(chan appNotificationPayload, 1)
+	app := &App{emitFn: func(name string, args ...any) {
+		if name != appNotificationEvent || len(args) == 0 {
+			return
+		}
+		if payload, ok := args[0].(appNotificationPayload); ok {
+			notified <- payload
+		}
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cw := &configWatcher{watcher: watcher, cancel: cancel, done: make(chan struct{})}
+	go app.runConfigWatcher(ctx, cw, root)
+
+	watcher.Errors <- errors.New("boom")
+
+	select {
+	case payload := <-notified:
+		if payload.Kind != "warning" {
+			t.Fatalf("want a warning notification, got %+v", payload)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a notification for the watcher's runtime error")
+	}
+
+	cancel()
+	_ = watcher.Close()
+	<-cw.done
+}

--- a/erun-ui/environment_activity.go
+++ b/erun-ui/environment_activity.go
@@ -242,6 +242,34 @@ func (a *App) emitEnvActivityIfChanged(observation environmentActivity) {
 	a.emitEnvActivity(observation)
 }
 
+// seedEnvironmentActivitySnapshots attaches each environment's last poller
+// observation, if any, to the initial-state read model. See uiEnvironment's
+// Activity field for why this exists: emitEnvActivityIfChanged only fires on
+// a transition, so a boot that starts from a clean store (a page reload, not
+// a process restart) has no other way to learn an env is already busy.
+func (a *App) seedEnvironmentActivitySnapshots(state *uiState) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for ti := range state.Tenants {
+		tenant := &state.Tenants[ti]
+		for ei := range tenant.Environments {
+			env := &tenant.Environments[ei]
+			key := selectionKey(uiSelection{Tenant: tenant.Name, Environment: env.Name})
+			observed, ok := a.envActivity[key]
+			if !ok {
+				continue
+			}
+			env.Activity = &uiEnvironmentActivitySnapshot{
+				Reachable: observed.reachable,
+				Observed:  observed.observed,
+				Outage:    observed.outage,
+				Busy:      observed.busy,
+				Detail:    observed.detail,
+			}
+		}
+	}
+}
+
 func (a *App) emitEnvActivity(observation environmentActivity) {
 	a.emitEvent(envActivityEvent, envActivityPayload{
 		Tenant:      observation.selection.Tenant,

--- a/erun-ui/environment_activity_test.go
+++ b/erun-ui/environment_activity_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -89,5 +90,91 @@ func TestEnvironmentBusyFromIdleStatus(t *testing.T) {
 				t.Errorf("got busy=%v detail=%q, want busy=%v detail=%q", busy, detail, testCase.wantBusy, testCase.wantDetail)
 			}
 		})
+	}
+}
+
+// TestSeedEnvironmentActivitySnapshotsCarriesTheLastObservation is the
+// regression for erun#1216 bug 2: a Redux reset that does not restart the Go
+// process (the ErrorBoundary "Reload app" button) must not lose a busy
+// environment's activity — the initial-state read model has to carry the
+// poller's own memory forward, since emitEnvActivityIfChanged only re-emits
+// on a transition and a still-busy env produces none.
+func TestSeedEnvironmentActivitySnapshotsCarriesTheLastObservation(t *testing.T) {
+	app := &App{envActivity: map[string]environmentActivityState{
+		selectionKey(uiSelection{Tenant: "acme", Environment: "dev"}): {
+			reachable: true,
+			observed:  true,
+			busy:      true,
+			detail:    "an agent is driving it over MCP",
+		},
+	}}
+	state := uiState{Tenants: []uiTenant{{Name: "acme", Environments: []uiEnvironment{{Name: "dev"}}}}}
+
+	app.seedEnvironmentActivitySnapshots(&state)
+
+	activity := state.Tenants[0].Environments[0].Activity
+	if activity == nil {
+		t.Fatal("expected the busy observation to be seeded onto the env")
+	}
+	if !activity.Reachable || !activity.Observed || !activity.Busy || activity.Detail != "an agent is driving it over MCP" {
+		t.Fatalf("unexpected snapshot: %+v", activity)
+	}
+}
+
+// TestSeedEnvironmentActivitySnapshotsLeavesUnobservedEnvsNil guards the
+// other side: an env the poller has never reached (no forward established,
+// or the poller hasn't run yet) must not get a fabricated snapshot.
+func TestSeedEnvironmentActivitySnapshotsLeavesUnobservedEnvsNil(t *testing.T) {
+	app := &App{}
+	state := uiState{Tenants: []uiTenant{{Name: "acme", Environments: []uiEnvironment{{Name: "dev"}}}}}
+
+	app.seedEnvironmentActivitySnapshots(&state)
+
+	if state.Tenants[0].Environments[0].Activity != nil {
+		t.Fatalf("expected no activity snapshot, got %+v", state.Tenants[0].Environments[0].Activity)
+	}
+}
+
+// TestLoadStateSeedsEnvironmentActivityFromThePoller exercises the full
+// wiring: LoadState (what the frontend's boot() thunk actually calls) must
+// carry the poller's last observation onto the env it just reloaded from
+// disk, without waiting for the next poll tick.
+func TestLoadStateSeedsEnvironmentActivityFromThePoller(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"acme": {Name: "acme", DefaultEnvironment: "dev"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"acme/dev": {Name: "dev", LocalRepoPath: projectRoot},
+		},
+	}
+	app := NewApp(erunUIDeps{
+		store:            store,
+		findProjectRoot:  func() (string, string, error) { return "acme", projectRoot, nil },
+		resolveBuildInfo: func() eruncommon.BuildInfo { return eruncommon.BuildInfo{Version: "1.0.0"} },
+		resolveImageRegistry: func(context.Context, string, string) (eruncommon.RuntimeRegistryVersions, error) {
+			return eruncommon.RuntimeRegistryVersions{}, nil
+		},
+	})
+	app.envActivity = map[string]environmentActivityState{
+		selectionKey(uiSelection{Tenant: "acme", Environment: "dev"}): {
+			reachable: true,
+			observed:  true,
+			busy:      true,
+			detail:    "an agent is driving it over MCP",
+		},
+	}
+
+	state, err := app.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState failed: %v", err)
+	}
+	if len(state.Tenants) != 1 || len(state.Tenants[0].Environments) != 1 {
+		t.Fatalf("unexpected state shape: %+v", state)
+	}
+	activity := state.Tenants[0].Environments[0].Activity
+	if activity == nil || !activity.Busy {
+		t.Fatalf("expected LoadState to seed the busy observation, got %+v", activity)
 	}
 }

--- a/erun-ui/frontend/src/app/bootThunks.ts
+++ b/erun-ui/frontend/src/app/bootThunks.ts
@@ -1,8 +1,12 @@
+import type { UITenant } from '@/types';
+
 import { stateApi } from './api/stateApi';
+import { planEnvActivitySeed } from './envActivitySeed';
 import { readError } from './errors';
 import { showTerminalMessage } from './notificationThunks';
 import { loadOrchestrators, restoreOpenOrchestrators } from './orchestratorThunks';
 import { openSelection } from './sessionThunks';
+import { setEnvActivityForEnv } from './slices/envStatusSlice';
 import { setSelected } from './slices/selectionSlice';
 import {
   setCloudProviders,
@@ -10,11 +14,23 @@ import {
   setVersionSuggestionNotices,
   setVersionSuggestions,
 } from './slices/tenantsSlice';
-import type { AppThunk } from './store';
+import type { AppDispatch, AppThunk } from './store';
 import {
   normalizeVersionSuggestionNotices,
   normalizeVersionSuggestions,
 } from './versionSuggestions';
+
+// Seeds each env's busy/reachable row from the poller's own last observation
+// (erun#1216) — the same snapshot-seeding shape loadOrchestrators uses for
+// the orchestrator rows, needed here for the same reason: the env-activity
+// Wails event only fires on a transition, so a boot with no prior transition
+// to replay (a page reload, not a process restart) would otherwise render a
+// still-busy env as idle until its next one.
+function seedEnvActivity(dispatch: AppDispatch, tenants: UITenant[]): void {
+  for (const seed of planEnvActivitySeed(tenants)) {
+    dispatch(setEnvActivityForEnv(seed));
+  }
+}
 
 // boot deliberately does not seed the env-init dialog's kubectl context
 // list — that dialog owns and refreshes its own.
@@ -25,6 +41,7 @@ export const boot = (): AppThunk<Promise<void>> => async (dispatch, getState) =>
       stateApi.endpoints.getInitialState.initiate(undefined, { forceRefetch: true }),
     ).unwrap();
     dispatch(setTenants(loaded.tenants));
+    seedEnvActivity(dispatch, loaded.tenants);
     dispatch(setCloudProviders(loaded.cloudProviders ?? []));
     dispatch(setSelected(loaded.selected ?? null));
     dispatch(setVersionSuggestions(normalizeVersionSuggestions(loaded.versionSuggestions ?? [])));

--- a/erun-ui/frontend/src/app/envActivitySeed.test.ts
+++ b/erun-ui/frontend/src/app/envActivitySeed.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { UITenant } from '@/types';
+
+import { planEnvActivitySeed } from './envActivitySeed';
+import { selectionKey } from './versionSuggestions';
+
+function tenant(name: string, environments: UITenant['environments']): UITenant {
+  return { name, environments };
+}
+
+// The bug (erun#1216): the env-activity Wails event only fires on a
+// transition, so a boot with no prior transition to replay (a page reload
+// via ErrorBoundary's "Reload app", not a process restart) had nothing to
+// seed a still-busy env's row from. The fix is that uiEnvironment now carries
+// the poller's last observation directly, so a fetch alone reproduces the
+// correct seed with no event required — the same shape planOrchestratorBusySeed
+// already uses for orchestrator rows.
+test('an env with a busy observation seeds its activity from the snapshot alone', () => {
+  const seed = planEnvActivitySeed([
+    tenant('acme', [
+      {
+        name: 'dev',
+        activity: { reachable: true, observed: true, outage: false, busy: true, detail: 'ai' },
+      },
+    ]),
+  ]);
+  assert.deepEqual(seed, [
+    {
+      key: selectionKey({ tenant: 'acme', environment: 'dev' }),
+      activity: { reachable: true, observed: true, outage: false, busy: true, detail: 'ai' },
+    },
+  ]);
+});
+
+test('an env the poller has never observed contributes no seed', () => {
+  assert.deepEqual(planEnvActivitySeed([tenant('acme', [{ name: 'dev' }])]), []);
+});
+
+test('mixed observed and unobserved envs across tenants seed only the observed ones', () => {
+  const seed = planEnvActivitySeed([
+    tenant('acme', [
+      { name: 'dev', activity: { reachable: true, observed: true, outage: false, busy: false } },
+      { name: 'staging' },
+    ]),
+    tenant('other', [
+      { name: 'main', activity: { reachable: false, observed: false, outage: true, busy: false } },
+    ]),
+  ]);
+  assert.deepEqual(seed, [
+    {
+      key: selectionKey({ tenant: 'acme', environment: 'dev' }),
+      activity: { reachable: true, observed: true, outage: false, busy: false, detail: '' },
+    },
+    {
+      key: selectionKey({ tenant: 'other', environment: 'main' }),
+      activity: { reachable: false, observed: false, outage: true, busy: false, detail: '' },
+    },
+  ]);
+});

--- a/erun-ui/frontend/src/app/envActivitySeed.ts
+++ b/erun-ui/frontend/src/app/envActivitySeed.ts
@@ -1,0 +1,30 @@
+import type { UITenant } from '@/types';
+
+import type { EnvObservedActivity } from './slices/envStatusSlice';
+import { selectionKey } from './versionSuggestions';
+
+// planEnvActivitySeed derives the activityByEnv entries a freshly fetched
+// tenant list implies (erun#1216). The environment-activity poller only
+// re-emits its Wails event on a transition, so a Redux reset that does not
+// restart the Go process (the ErrorBoundary "Reload app" button) had nothing
+// to seed a still-busy env's row from until its next transition — which for
+// a long-running env may never come. uiEnvironment now carries the poller's
+// last observation directly, so a fetch alone reproduces the correct seed
+// with no event required, mirroring planOrchestratorBusySeed.
+export function planEnvActivitySeed(
+  tenants: UITenant[],
+): { key: string; activity: EnvObservedActivity }[] {
+  const seed: { key: string; activity: EnvObservedActivity }[] = [];
+  for (const tenant of tenants) {
+    for (const environment of tenant.environments) {
+      if (!environment.activity) {
+        continue;
+      }
+      seed.push({
+        key: selectionKey({ tenant: tenant.name, environment: environment.name }),
+        activity: { ...environment.activity, detail: environment.activity.detail ?? '' },
+      });
+    }
+  }
+  return seed;
+}

--- a/erun-ui/frontend/src/components/app/Titlebar.helpers.test.ts
+++ b/erun-ui/frontend/src/components/app/Titlebar.helpers.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  type IdleStatus,
+  idleStatusAccessibleLabel,
+  idleStatusTooltipLines,
+} from './Titlebar.helpers';
+
+function idleStatus(overrides: Partial<IdleStatus> = {}): IdleStatus {
+  return {
+    timeoutSeconds: 300,
+    secondsUntilStop: 120,
+    stopEligible: false,
+    outsideWorkingHours: false,
+    managedCloud: true,
+    fromPod: true,
+    ...overrides,
+  };
+}
+
+// Regression for erun#1216 bug 3: a reading the pod never confirmed must not
+// render with the same confidence as a live one.
+test('a host-only idle reading leads its tooltip with a provenance caveat', () => {
+  const lines = idleStatusTooltipLines(idleStatus({ fromPod: false }));
+  assert.equal(
+    lines[0],
+    'Not confirmed with the pod: showing the last known state; it may be stale.',
+  );
+});
+
+test('a pod-confirmed idle reading carries no provenance caveat', () => {
+  const lines = idleStatusTooltipLines(idleStatus({ fromPod: true }));
+  assert.ok(!lines.some((line) => line.includes('Not confirmed with the pod')));
+  assert.equal(lines[0], 'Idle timeout: 300s');
+});
+
+test('the accessible label names the same caveat for a host-only reading', () => {
+  const label = idleStatusAccessibleLabel(idleStatus({ fromPod: false }));
+  assert.ok(label.startsWith('not confirmed with the pod'));
+});
+
+test('the accessible label omits the caveat for a pod-confirmed reading', () => {
+  const label = idleStatusAccessibleLabel(idleStatus({ fromPod: true }));
+  assert.ok(!label.includes('not confirmed with the pod'));
+});

--- a/erun-ui/frontend/src/components/app/Titlebar.helpers.ts
+++ b/erun-ui/frontend/src/components/app/Titlebar.helpers.ts
@@ -135,12 +135,24 @@ function isPersistentIdleBlocker(reason: string): boolean {
 }
 
 export function idleStatusTooltipLines(idleStatus: IdleStatus): string[] {
-  const lines = idleStatusSummaryLines(idleStatus);
+  const lines: string[] = [];
+  appendIdleProvenanceLine(lines, idleStatus);
+  lines.push(...idleStatusSummaryLines(idleStatus));
   appendIdleBlockerLine(lines, idleStatus);
   appendIdleCloudContextLine(lines, idleStatus);
   lines.push(...idleStatusActiveMarkerLines(idleStatus));
   appendIdleStopOutcomeLines(lines, idleStatus);
   return lines;
+}
+
+// Leads the tooltip, ahead of the countdown itself, because a reading the
+// pod never confirmed is the caveat that changes how the rest of the tooltip
+// should be read — not a footnote after it.
+function appendIdleProvenanceLine(lines: string[], idleStatus: IdleStatus): void {
+  if (idleStatus.fromPod) {
+    return;
+  }
+  lines.push('Not confirmed with the pod: showing the last known state; it may be stale.');
 }
 
 function idleStatusSummaryLines(idleStatus: IdleStatus): string[] {
@@ -252,6 +264,7 @@ function appendIdleStopOutcomeLines(lines: string[], idleStatus: IdleStatus): vo
 
 export function idleStatusAccessibleLabel(idleStatus: IdleStatus): string {
   const parts = [
+    ...(idleStatus.fromPod ? [] : ['not confirmed with the pod, showing the last known state']),
     `Idle timeout ${String(idleStatus.timeoutSeconds)} seconds`,
     `seconds until stop ${String(idleStatus.secondsUntilStop)}`,
     `stop eligible ${idleStatus.stopEligible ? 'yes' : 'no'}`,
@@ -263,10 +276,17 @@ export function idleStatusAccessibleLabel(idleStatus: IdleStatus): string {
   if (idleStatus.stopError) {
     parts.push(`stop error: ${idleStatus.stopError}`);
   }
-  if (idleStatus.cloudContextName) {
-    parts.push(
-      `cloud environment ${idleStatus.cloudContextLabel?.trim() ? idleStatus.cloudContextLabel : (idleStatus.cloudContextName ?? '')}${idleStatus.cloudContextStatus ? ` ${idleStatus.cloudContextStatus}` : ''}`,
-    );
-  }
+  appendIdleAccessibleCloudContextPart(parts, idleStatus);
   return parts.join(', ');
+}
+
+function appendIdleAccessibleCloudContextPart(parts: string[], idleStatus: IdleStatus): void {
+  if (!idleStatus.cloudContextName) {
+    return;
+  }
+  const label = idleStatus.cloudContextLabel?.trim()
+    ? idleStatus.cloudContextLabel
+    : idleStatus.cloudContextName;
+  const status = idleStatus.cloudContextStatus ? ` ${idleStatus.cloudContextStatus}` : '';
+  parts.push(`cloud environment ${label}${status}`);
 }

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -2,6 +2,7 @@
 // probe, environment health check) live in ./uiDiagnosticsTypes, imported by
 // name where needed. This file only needs the cluster block for the entry below.
 import type { UIContainerRegistryCluster } from './uiDiagnosticsTypes';
+import type { UIEnvironmentActivity } from './uiEnvironmentActivityTypes';
 
 export type EnvironmentType = 'local-agent' | 'remote-agent' | 'runtime' | '';
 
@@ -24,6 +25,7 @@ export interface UIEnvironment {
   isActive?: boolean;
   sshdEnabled?: boolean;
   autoStart?: boolean;
+  activity?: UIEnvironmentActivity;
 }
 
 // UIWorkingIssue is the env worktree's current branch and, when the branch

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -211,6 +211,10 @@ export interface UIIdleStatus {
   stopEligible: boolean;
   outsideWorkingHours: boolean;
   managedCloud: boolean;
+  // fromPod is true only when this reading came from the pod's own idle
+  // monitor over MCP. False means it was assembled on the host because the
+  // pod could not be reached, so the countdown it carries may be stale.
+  fromPod: boolean;
   stopBlockedReason?: string;
   stopError?: string;
   cloudContextName?: string;

--- a/erun-ui/frontend/src/uiEnvironmentActivityTypes.ts
+++ b/erun-ui/frontend/src/uiEnvironmentActivityTypes.ts
@@ -1,0 +1,15 @@
+// UIEnvironmentActivity mirrors the Go uiEnvironmentActivitySnapshot: the
+// environment-activity poller's last observation for this env, seeded onto
+// the initial state so a Redux reset that does not restart the Go process
+// (the ErrorBoundary "Reload app" button) does not have to wait for the next
+// poll transition to learn a still-busy env — the poller only re-emits its
+// event on a transition, and a long-running env may never produce one.
+// Split out of `@/types` to keep that file under its line budget; re-exported
+// from there so consumers keep one import surface.
+export interface UIEnvironmentActivity {
+  reachable: boolean;
+  observed: boolean;
+  outage: boolean;
+  busy: boolean;
+  detail?: string;
+}

--- a/erun-ui/idle_status.go
+++ b/erun-ui/idle_status.go
@@ -43,7 +43,7 @@ func (a *App) LoadIdleStatus(selection uiSelection) (uiIdleStatus, error) {
 	}
 	merged := a.mergeLocalIdleActivity(result, status)
 	a.maybeStopIdleCloudEnvironment(result, merged)
-	return a.idleStatusToUI(result, merged), nil
+	return a.idleStatusToUI(result, merged, true), nil
 }
 
 type resolvedUIIdleStatus struct {
@@ -51,16 +51,22 @@ type resolvedUIIdleStatus struct {
 	status eruncommon.EnvironmentIdleStatus
 }
 
+// loadLocalIdleStatus assembles the idle status from what the host itself
+// knows, taken only when the pod could not be asked (mcp unreachable, or the
+// pod call itself failed). The resulting uiIdleStatus.FromPod is always
+// false: this reading may be stale relative to whatever the pod is actually
+// doing right now.
 func (a *App) loadLocalIdleStatus(result eruncommon.OpenResult) (resolvedUIIdleStatus, error) {
 	status, err := eruncommon.ResolveStoredEnvironmentIdleStatus(a.deps.store, result.Tenant, result.Environment, time.Now())
 	if err != nil {
 		return resolvedUIIdleStatus{}, err
 	}
-	return resolvedUIIdleStatus{ui: a.idleStatusToUI(result, status), status: status}, nil
+	return resolvedUIIdleStatus{ui: a.idleStatusToUI(result, status, false), status: status}, nil
 }
 
-func (a *App) idleStatusToUI(result eruncommon.OpenResult, status eruncommon.EnvironmentIdleStatus) uiIdleStatus {
+func (a *App) idleStatusToUI(result eruncommon.OpenResult, status eruncommon.EnvironmentIdleStatus, fromPod bool) uiIdleStatus {
 	ui := idleStatusToUI(status)
+	ui.FromPod = fromPod
 	cloudContext, ok, err := a.linkedCloudContext(result.EnvConfig)
 	if err != nil || !ok {
 		return ui

--- a/erun-ui/idle_status_test.go
+++ b/erun-ui/idle_status_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// TestIdleStatusToUICarriesFromPodProvenance is the regression for
+// erun#1216 bug 3: the idle widget rendered a confident countdown with no
+// way to tell whether the reading came from the pod's own idle monitor or
+// was assembled on the host because the pod could not be reached — the same
+// moment the sidebar might be showing the environment as unreachable.
+func TestIdleStatusToUICarriesFromPodProvenance(t *testing.T) {
+	app := &App{}
+	status := eruncommon.EnvironmentIdleStatus{StopEligible: true}
+	result := eruncommon.OpenResult{}
+
+	if ui := app.idleStatusToUI(result, status, true); !ui.FromPod {
+		t.Fatalf("a pod-backed reading must report FromPod=true, got %+v", ui)
+	}
+	if ui := app.idleStatusToUI(result, status, false); ui.FromPod {
+		t.Fatalf("a host-only reading must report FromPod=false, got %+v", ui)
+	}
+}
+
+// TestLoadLocalIdleStatusReportsHostOnlyProvenance locks in the one call site
+// that is always host-only: the local fallback path never claims a live pod
+// observation.
+func TestLoadLocalIdleStatusReportsHostOnlyProvenance(t *testing.T) {
+	store := stubUIStore{envs: map[string]eruncommon.EnvConfig{
+		"acme/dev": {Name: "dev"},
+	}}
+	app := &App{deps: erunUIDeps{store: store}}
+	result := eruncommon.OpenResult{Tenant: "acme", Environment: "dev"}
+
+	resolved, err := app.loadLocalIdleStatus(result)
+	if err != nil {
+		t.Fatalf("loadLocalIdleStatus: %v", err)
+	}
+	if resolved.ui.FromPod {
+		t.Fatalf("the host-only fallback must never report FromPod=true, got %+v", resolved.ui)
+	}
+}

--- a/erun-ui/playwright/pages/Titlebar.ts
+++ b/erun-ui/playwright/pages/Titlebar.ts
@@ -107,8 +107,12 @@ export class Titlebar {
     return banners.some((banner) => banner.includes(expected));
   }
 
-  // The pill only mounts after the first idle-status poll completes for the selected env, so callers must wait for visibility before driving it.
+  // The pill only mounts after the first idle-status poll completes for the
+  // selected env, so callers must wait for visibility before driving it. The
+  // accessible name normally starts with "Idle timeout", but a reading the
+  // pod never confirmed leads with a provenance caveat instead — match
+  // "Idle timeout" anywhere in the name so both cases resolve the same badge.
   idleStatusBadge(): Locator {
-    return this.page.getByRole('button', { name: /^Idle timeout/ });
+    return this.page.getByRole('button', { name: /Idle timeout/ });
   }
 }

--- a/erun-ui/playwright/tests/idle-widget-stop-protection.spec.ts
+++ b/erun-ui/playwright/tests/idle-widget-stop-protection.spec.ts
@@ -36,6 +36,9 @@ function managedRunningIdleStatus(ctx: IdleStatusFixture): unknown {
     stopEligible: true,
     outsideWorkingHours: false,
     managedCloud: true,
+    // These fixtures stand in for a live pod-backed reading unless a test
+    // overrides it (see the fromPod provenance test below).
+    fromPod: true,
     cloudContextName: ctx.cloudContextName,
     cloudContextStatus: ctx.cloudContextStatus,
     cloudContextLabel: ctx.cloudContextLabel,
@@ -56,6 +59,7 @@ function managedRunningIdleStatusWithPendingStop(ctx: PendingStopFixture): unkno
     stopEligible: true,
     outsideWorkingHours: false,
     managedCloud: true,
+    fromPod: true,
     cloudContextName: ctx.cloudContextName,
     cloudContextStatus: ctx.cloudContextStatus,
     cloudContextLabel: ctx.cloudContextLabel,
@@ -573,5 +577,39 @@ test.describe('idle widget stop protection', () => {
     // The widget must keep reporting reality: still running, stop still
     // offered — never a silent flip to "stopped".
     await expect(stopButton).toBeVisible();
+  });
+
+  // Regression for erun#1216 bug 3: a reading LoadIdleStatus assembled on
+  // the host (fromPod: false, taken when the pod could not be reached) must
+  // not render with the same confidence as a live pod-confirmed one.
+  test('idle badge names the pod provenance caveat for a reading the pod never confirmed', async ({
+    app,
+    page,
+  }) => {
+    const ctxName = 'mock-ctx-stale-provenance';
+    const idle: IdleStatusFixture = {
+      cloudContextName: ctxName,
+      cloudContextStatus: 'running',
+      cloudContextLabel: ctxName,
+    };
+
+    await page.route('**/__erun_invoke', async (route, request) => {
+      const body = JSON.parse(request.postData() ?? '{}') as InvokeBody;
+      if (body.method === 'LoadIdleStatus') {
+        return route.fulfill(
+          envelope({ ...(managedRunningIdleStatus(idle) as object), fromPod: false }),
+        );
+      }
+      if (body.method === 'DescribeCloudContextApiStop') {
+        return route.fulfill(envelope(apiStopStatus(ctxName, false)));
+      }
+      await route.continue();
+    });
+
+    await app.sidebar.openEnvironment(SEED_TENANT, SEED_ENV_ALPHA);
+
+    const badge = app.titlebar.idleStatusBadge();
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveAttribute('aria-label', /^not confirmed with the pod/);
   });
 });

--- a/erun-ui/playwright/tests/sidebar-env-activity-boot-snapshot.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-env-activity-boot-snapshot.spec.ts
@@ -1,0 +1,88 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+
+// erun#1216 bug 2: the env-activity Wails event only fires on a transition,
+// and the Go poller's own memory (app.envActivity) survives a page reload
+// that does not restart the Go process — but the pre-fix Redux store did not,
+// so a still-busy environment rendered idle after the ErrorBoundary "Reload
+// app" button until the next transition, which for a long agent turn can be
+// tens of minutes away.
+//
+// This spec drives the fix's frontend half directly, mirroring
+// sidebar-orchestrator-busy-snapshot.spec.ts: it stubs LoadState over
+// /__erun_invoke to answer with a busy env snapshot, reboots the app (a real
+// fresh mount via page.goto, not a simulated event), and asserts the row
+// renders busy immediately, with no env-activity event ever emitted. Before
+// the fix this would render idle, because nothing but that missing event
+// could have set it. The event path itself (env-activity flipping the dot
+// while the app is already running) is covered by sidebar-env-activity.spec.ts;
+// the Go-side seeding this snapshot depends on is covered by
+// erun-ui/environment_activity_test.go
+// (TestSeedEnvironmentActivitySnapshotsCarriesTheLastObservation,
+// TestLoadStateSeedsEnvironmentActivityFromThePoller).
+
+const TENANT = 'boot-snap';
+const ENVIRONMENT = 'dev';
+
+function loadStateWithActivity(busy: boolean): unknown {
+  return {
+    tenants: [
+      {
+        name: TENANT,
+        defaultEnvironment: ENVIRONMENT,
+        environments: [
+          {
+            name: ENVIRONMENT,
+            type: 'local-agent',
+            activity: {
+              reachable: true,
+              observed: true,
+              outage: false,
+              busy,
+              detail: busy ? 'an agent is driving it over MCP' : '',
+            },
+          },
+        ],
+      },
+    ],
+    build: { version: '0.0.0-test' },
+  };
+}
+
+async function stubLoadState(page: Page, busy: boolean): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method?: string };
+    if (body.method === 'LoadState') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: loadStateWithActivity(busy) }),
+      });
+    }
+    await route.continue();
+  });
+}
+
+test.describe('sidebar env activity renders from the boot snapshot (#1216)', () => {
+  test('a busy snapshot renders the row busy on a fresh mount, with no env-activity event ever emitted', async ({
+    app,
+    page,
+  }) => {
+    await stubLoadState(page, true);
+    await app.reboot();
+
+    const dot = app.sidebar.envOpenDot(TENANT, ENVIRONMENT);
+    await expect(dot).toHaveAttribute('data-env-state', 'busy');
+    await expect(dot).toHaveAccessibleName(
+      `${TENANT} / ${ENVIRONMENT} is busy — an agent is driving it over MCP`,
+    );
+  });
+
+  test('a non-busy snapshot renders the reachable dot, not busy', async ({ app, page }) => {
+    await stubLoadState(page, false);
+    await app.reboot();
+
+    const dot = app.sidebar.envOpenDot(TENANT, ENVIRONMENT);
+    await expect(dot).toHaveAttribute('data-env-state', 'running');
+  });
+});

--- a/erun-ui/state_handlers.go
+++ b/erun-ui/state_handlers.go
@@ -30,6 +30,7 @@ func (a *App) LoadState() (uiState, error) {
 	}
 	info := a.deps.resolveBuildInfo()
 	state := stateFromListResult(result, info)
+	a.seedEnvironmentActivitySnapshots(&state)
 	suggestionTenant := ""
 	suggestionEnv := ""
 	if state.Selected != nil {

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -30,6 +30,27 @@ type uiEnvironment struct {
 	IsActive          bool   `json:"isActive,omitempty"`
 	SSHDEnabled       bool   `json:"sshdEnabled,omitempty"`
 	AutoStart         *bool  `json:"autoStart,omitempty"`
+	// Activity is the environment-activity poller's last observation for this
+	// env, if any. The poller only emits a Wails event on a transition, so a
+	// Redux store that resets without the Go process restarting (e.g. the
+	// ErrorBoundary "Reload app" button) would otherwise have nothing to seed
+	// from and render a still-busy env as idle until its next transition —
+	// which for a long agent turn can be tens of minutes away, if it comes
+	// before the turn ends at all. nil means the poller has not observed this
+	// env yet.
+	Activity *uiEnvironmentActivitySnapshot `json:"activity,omitempty"`
+}
+
+// uiEnvironmentActivitySnapshot mirrors envActivityPayload's observation
+// fields, minus the tenant/environment identity envActivityPayload carries
+// for the event stream — here that identity is already the enclosing
+// uiEnvironment.
+type uiEnvironmentActivitySnapshot struct {
+	Reachable bool   `json:"reachable"`
+	Observed  bool   `json:"observed"`
+	Outage    bool   `json:"outage"`
+	Busy      bool   `json:"busy"`
+	Detail    string `json:"detail,omitempty"`
 }
 
 // uiWorkingIssue backs the sidebar hover card's "what is this env working on".

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -701,17 +701,23 @@ type pastedFileResult struct {
 }
 
 type uiIdleStatus struct {
-	TimeoutSeconds      int64          `json:"timeoutSeconds"`
-	SecondsUntilStop    int64          `json:"secondsUntilStop"`
-	StopEligible        bool           `json:"stopEligible"`
-	OutsideWorkingHours bool           `json:"outsideWorkingHours"`
-	ManagedCloud        bool           `json:"managedCloud"`
-	StopBlockedReason   string         `json:"stopBlockedReason,omitempty"`
-	StopError           string         `json:"stopError,omitempty"`
-	CloudContextName    string         `json:"cloudContextName,omitempty"`
-	CloudContextStatus  string         `json:"cloudContextStatus,omitempty"`
-	CloudContextLabel   string         `json:"cloudContextLabel,omitempty"`
-	Markers             []uiIdleMarker `json:"markers,omitempty"`
+	TimeoutSeconds      int64 `json:"timeoutSeconds"`
+	SecondsUntilStop    int64 `json:"secondsUntilStop"`
+	StopEligible        bool  `json:"stopEligible"`
+	OutsideWorkingHours bool  `json:"outsideWorkingHours"`
+	ManagedCloud        bool  `json:"managedCloud"`
+	// FromPod is true only when this reading came from the pod's own idle
+	// monitor over MCP. False means it was assembled on the host because the
+	// pod could not be reached — the same moment the sidebar may be showing
+	// this environment as unreachable — so the countdown it carries is a
+	// best-effort local reconstruction, not a live observation.
+	FromPod            bool           `json:"fromPod"`
+	StopBlockedReason  string         `json:"stopBlockedReason,omitempty"`
+	StopError          string         `json:"stopError,omitempty"`
+	CloudContextName   string         `json:"cloudContextName,omitempty"`
+	CloudContextStatus string         `json:"cloudContextStatus,omitempty"`
+	CloudContextLabel  string         `json:"cloudContextLabel,omitempty"`
+	Markers            []uiIdleMarker `json:"markers,omitempty"`
 	// StopPendingSince carries the RFC3339 timestamp at which this env
 	// first became StopEligible. When set, the desktop has armed the
 	// grace-period warning and the user has SecondsUntilForcedStop


### PR DESCRIPTION
Four paths presented state as known when it was not — including running billable
instances, which makes a confident wrong answer expensive rather than merely
misleading.

The fix is provenance and expiry rather than better guesses:

- a `fromPod` provenance flag on the idle-status read model, surfaced in the
  titlebar widget so the caveat travels with the number
- a TTL on the cloud-context unknown downgrade, so "unknown" cannot harden into a
  fact by simply persisting
- config-watcher startup and runtime failures surfaced instead of swallowed
- the env-activity read model seeded from the boot snapshot and the poller, so the
  sidebar stops asserting activity it has not yet observed

| check | result |
|---|---|
| `erun-ui` `go test ./...` | ok |
| same, `PATH=/usr/local/go/bin:/usr/bin:/bin` | ok |
| `golangci-lint run ./...` | 0 issues |
| frontend unit suite | **110/110** (was 103) |
| `idle-widget-stop-protection.spec.ts` | 8 passed |
| `sidebar-env-activity-boot-snapshot.spec.ts` | 2 passed |
| `orchestrator-cross-env-diff.spec.ts` (#1244 net) | 7 passed, untouched |

## Provenance

The eight commits came from an in-pod agent run that committed everything, left a
clean tree, and then ended its turn waiting on a backgrounded Playwright suite
without pushing. I reviewed the commits, ran the gates above, and pushed.

That is the eighth job today to end that way, and every one named the full
Playwright suite. This one at least committed first, so nothing needed
reconstructing. The standing instruction has since been changed to forbid
full-suite runs outright — the specs a change touches, in the foreground, are
sufficient and remove the thing agents were waiting on.

Closes #1216