### PR TITLE
Tell a stopped environment apart from an unreachable one in the review panel

### DIFF
--- a/erun-common/mcp_reachability.go
+++ b/erun-common/mcp_reachability.go
@@ -59,12 +59,37 @@ func LocalPortIsBound(port int) bool {
 	return true
 }
 
+// LocalMCPUnreachableKind names which of the two locally observable failure
+// shapes explains why an environment's MCP edge cannot be reached, so a caller
+// can act on the distinction directly instead of re-deriving it by
+// pattern-matching DescribeLocalMCPUnreachable's prose (#1230).
+type LocalMCPUnreachableKind string
+
+const (
+	// LocalMCPNotOpen means nothing holds the local port — the ordinary shape
+	// of an environment nobody has opened, or one that was stopped.
+	LocalMCPNotOpen LocalMCPUnreachableKind = "not-open"
+	// LocalMCPStaleForward means the local port is held but the edge behind it
+	// never answers — a forward that needs re-establishing, not starting.
+	LocalMCPStaleForward LocalMCPUnreachableKind = "stale-forward"
+)
+
+// ClassifyLocalMCPUnreachable reports which of the two locally observable
+// failure shapes applies for a port that CanReachLocalMCPEndpoint has already
+// reported unreachable.
+func ClassifyLocalMCPUnreachable(port int) LocalMCPUnreachableKind {
+	if LocalPortIsBound(port) {
+		return LocalMCPStaleForward
+	}
+	return LocalMCPNotOpen
+}
+
 // DescribeLocalMCPUnreachable names which of the two failures happened, so the
 // reader is not left weighing a busy pod against a dead tunnel. A stale forward
 // presents as a timeout with a live listener, which reads exactly like an
 // overloaded environment and has cost real debugging time.
 func DescribeLocalMCPUnreachable(tenant, environment string, port int) string {
-	if LocalPortIsBound(port) {
+	if ClassifyLocalMCPUnreachable(port) == LocalMCPStaleForward {
 		return fmt.Sprintf("the port-forward for %s/%s on 127.0.0.1:%d is not carrying traffic (the local port is held but the edge never answers) — re-establishing it", tenant, environment, port)
 	}
 	return fmt.Sprintf("no port-forward is listening for %s/%s on 127.0.0.1:%d", tenant, environment, port)

--- a/erun-common/mcp_reachability_test.go
+++ b/erun-common/mcp_reachability_test.go
@@ -66,6 +66,32 @@ func TestCanReachLocalMCPEndpointAcceptsAnyAnswer(t *testing.T) {
 	}
 }
 
+// ClassifyLocalMCPUnreachable is what DescribeLocalMCPUnreachable's own branch
+// reduces to; pinning it directly means a caller that needs the kind on its
+// own (to pick a UI treatment, say) does not have to parse the sentence for it.
+func TestClassifyLocalMCPUnreachableNamesTheKind(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	boundPort := listener.Addr().(*net.TCPAddr).Port
+	defer func() { _ = listener.Close() }()
+
+	freeListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	freePort := freeListener.Addr().(*net.TCPAddr).Port
+	_ = freeListener.Close()
+
+	if got := ClassifyLocalMCPUnreachable(boundPort); got != LocalMCPStaleForward {
+		t.Fatalf("a held port must classify as stale-forward, got %q", got)
+	}
+	if got := ClassifyLocalMCPUnreachable(freePort); got != LocalMCPNotOpen {
+		t.Fatalf("a free port must classify as not-open, got %q", got)
+	}
+}
+
 // Nothing listening is a different problem from a forward that has gone stale,
 // and the operator's next move differs, so the two must not share wording.
 func TestDescribeLocalMCPUnreachableSeparatesMissingFromStale(t *testing.T) {

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -577,8 +577,61 @@ func TestLoadDiffReturnsUnreachableWhenPortClosed(t *testing.T) {
 	if !errors.Is(err, errMCPUnreachable) {
 		t.Fatalf("expected errMCPUnreachable, got %v", err)
 	}
+	// A closed local port is the "nobody opened it" shape (#1230), not a stale
+	// forward — the review panel needs the two apart to stop presenting a
+	// stopped environment as a broken connection.
+	if !strings.Contains(err.Error(), "ERUN_MCP_UNREACHABLE_NOT_OPEN: ") {
+		t.Fatalf("expected the not-open reachability marker, got %v", err)
+	}
 	if ensureCalls != 0 || loadCalls != 0 {
 		t.Fatalf("LoadDiff must not run erun open or attempt the dial when the port is closed; got ensure=%d load=%d", ensureCalls, loadCalls)
+	}
+}
+
+// TestLoadDiffReturnsStaleForwardKindWhenPortHeldButEdgeDead is the sibling
+// case to the not-open one above: the local port is still held (a live
+// listener), but the edge behind it never answers, so the review panel must
+// treat this as an actual fault worth reconnecting rather than an
+// informational "not running" state (#1230).
+func TestLoadDiffReturnsStaleForwardKindWhenPortHeldButEdgeDead(t *testing.T) {
+	projectRoot := t.TempDir()
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {
+				Name:               "erun",
+				DefaultEnvironment: "test",
+			},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/test": {
+				Name:              "test",
+				LocalRepoPath:     projectRoot,
+				KubernetesContext: "orbstack",
+			},
+		},
+	}
+	app := NewApp(erunUIDeps{
+		store: store,
+		canConnectLocalPort: func(int) bool {
+			return true
+		},
+		canReachMCPEndpoint: func(int) bool {
+			return false
+		},
+		loadDiff: func(_ context.Context, _, _ string, _ uiDiffOptions) (eruncommon.DiffResult, error) {
+			return eruncommon.DiffResult{}, nil
+		},
+	})
+
+	_, err := app.LoadDiff(uiSelection{Tenant: "erun", Environment: "test"}, uiDiffOptions{})
+	if err == nil {
+		t.Fatalf("expected unreachable error when the edge never answers")
+	}
+	if !errors.Is(err, errMCPUnreachable) {
+		t.Fatalf("expected errMCPUnreachable, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "ERUN_MCP_UNREACHABLE_STALE: ") {
+		t.Fatalf("expected the stale-forward reachability marker, got %v", err)
 	}
 }
 
@@ -623,6 +676,12 @@ func TestLoadDiffWrapsDialFailureAsUnreachable(t *testing.T) {
 	}
 	if !errors.Is(err, errMCPUnreachable) {
 		t.Fatalf("expected errMCPUnreachable, got %v", err)
+	}
+	// The port is still held here (canConnectLocalPort returns true) — the RPC
+	// dial failed mid-call, not the initial reachability probe — so this is
+	// the stale-forward shape, not not-open.
+	if !strings.Contains(err.Error(), "ERUN_MCP_UNREACHABLE_STALE: ") {
+		t.Fatalf("expected the stale-forward reachability marker, got %v", err)
 	}
 	if ensureCalls != 0 {
 		t.Fatalf("LoadDiff must not implicitly run erun open after a dial failure; got ensureCalls=%d", ensureCalls)

--- a/erun-ui/frontend/src/app/reconnectCopy.test.ts
+++ b/erun-ui/frontend/src/app/reconnectCopy.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { mcpUnreachableKind, reachabilityCopy, stripMcpUnreachableMarker } from './reconnectCopy';
+
+// #1230: the backend now names which of the two locally-observable
+// reachability failures it hit, carried as one of two opaque marker prefixes.
+// mcpUnreachableKind is the one place that decodes them; every other call site
+// works from the returned kind, not the marker text.
+test('mcpUnreachableKind recognizes the not-open marker', () => {
+  const message = 'ERUN_MCP_UNREACHABLE_NOT_OPEN: mcp unreachable: no port-forward is listening';
+  assert.equal(mcpUnreachableKind(message), 'not-open');
+});
+
+test('mcpUnreachableKind recognizes the stale-forward marker', () => {
+  const message = 'ERUN_MCP_UNREACHABLE_STALE: mcp unreachable: not carrying traffic';
+  assert.equal(mcpUnreachableKind(message), 'stale-forward');
+});
+
+// An ordinary diff-loading error (no reachability marker at all) must not be
+// misread as one of the two reachability kinds -- that is the
+// reconnectable=false path, which shows the raw message rather than the fixed
+// reachability copy.
+test('mcpUnreachableKind returns null for an unrelated error', () => {
+  assert.equal(mcpUnreachableKind('git rev-parse failed: not a git repository'), null);
+});
+
+test('stripMcpUnreachableMarker removes only the matched marker, leaving the rest of the message', () => {
+  const message = 'ERUN_MCP_UNREACHABLE_NOT_OPEN: mcp unreachable: no port-forward is listening';
+  assert.equal(stripMcpUnreachableMarker(message), 'mcp unreachable: no port-forward is listening');
+});
+
+test('stripMcpUnreachableMarker leaves a message with no marker untouched', () => {
+  assert.equal(stripMcpUnreachableMarker('some other error'), 'some other error');
+});
+
+// The two reachability kinds must render genuinely distinct treatments -- a
+// stopped environment is informational ("Open"), a stale forward is a fault
+// ("Reconnect…") -- so a caller that mixed them up would be caught here
+// rather than only in a UI screenshot.
+test('the two reachability kinds carry distinct action labels and titles', () => {
+  assert.notEqual(reachabilityCopy['not-open'].action, reachabilityCopy['stale-forward'].action);
+  assert.notEqual(
+    reachabilityCopy['not-open'].errorTitle,
+    reachabilityCopy['stale-forward'].errorTitle,
+  );
+  assert.equal(reachabilityCopy['not-open'].action, 'Open');
+  assert.equal(reachabilityCopy['stale-forward'].action, 'Reconnect…');
+});

--- a/erun-ui/frontend/src/app/reconnectCopy.ts
+++ b/erun-ui/frontend/src/app/reconnectCopy.ts
@@ -1,34 +1,94 @@
 // Shared copy for the runtime-reconnect flow, reused across the review panel
 // and manage dialog so recovery reads as one consistent action.
 //
-// The marker mirrors the opaque prefix the Go backend puts on MCP-unreachable
-// errors; it is a machine token and must never be shown to users.
-export const MCP_UNREACHABLE_MARKER = 'ERUN_MCP_UNREACHABLE: ';
+// ReachabilityKind mirrors eruncommon.LocalMCPUnreachableKind: a stopped/
+// never-opened environment (informational, "Open") is a different situation
+// from a stale port-forward (a fault, "Reconnect…"), and the backend already
+// tells the two apart -- the review panel used to flatten them into one
+// "connection is down" error regardless (#1230).
+export type ReachabilityKind = 'not-open' | 'stale-forward';
 
-export const reconnectCopy = {
+// The markers mirror the opaque prefixes the Go backend puts on
+// MCP-unreachable errors (mcpUnreachableKindMarkers in erun-ui/mcp_errors.go);
+// they are machine tokens and must never be shown to users.
+const MCP_UNREACHABLE_MARKERS: Record<ReachabilityKind, string> = {
+  'not-open': 'ERUN_MCP_UNREACHABLE_NOT_OPEN: ',
+  'stale-forward': 'ERUN_MCP_UNREACHABLE_STALE: ',
+};
+
+interface ReachabilityCopy {
+  // DiffErrorAlert / ChangedFilesAside status card.
+  errorTitle: string;
+  errorBody: string;
+  action: string;
+  // ReconnectDialog confirmation.
+  dialogTitle: string;
+  dialogBody: string;
+  dialogConfirm: string;
+  // ReconnectStatusPanel while the action runs / after it fails.
+  runningStatus: string;
+  errorStatusTitle: string;
+}
+
+// staleForward keeps the original #1178 copy verbatim: this is the genuine
+// fault case, and "Cannot reach the environment runtime" / "Reconnect…" was
+// never wrong for it.
+const STALE_FORWARD_COPY: ReachabilityCopy = {
   errorTitle: 'Cannot reach the environment runtime',
   errorBody: 'The diff could not be loaded because the connection to your environment is down.',
-  retryAction: 'Retry',
-  reconnectAction: 'Reconnect…',
+  action: 'Reconnect…',
   dialogTitle: 'Reconnect to environment?',
   dialogBody:
     'This runs `erun open` to restore the connection. If the environment runtime is not currently running, it will be redeployed.',
-  dialogCancel: 'Cancel',
   dialogConfirm: 'Reconnect',
   runningStatus: 'Reconnecting…',
-  runningHint: 'Latest output will appear below.',
   errorStatusTitle: 'Reconnect failed',
+};
+
+// notOpen is the ordinary resting state of an environment nobody has started
+// (or that was stopped) -- not a fault, so the copy neither claims a
+// connection existed to lose nor promises a redeploy for a runtime the local
+// probe never actually checked (#1230).
+const NOT_OPEN_COPY: ReachabilityCopy = {
+  errorTitle: 'Environment not running',
+  errorBody: 'This environment is stopped — start it to review this diff.',
+  action: 'Open',
+  dialogTitle: 'Open environment?',
+  dialogBody: 'This runs `erun open` to start the environment.',
+  dialogConfirm: 'Open',
+  runningStatus: 'Opening…',
+  errorStatusTitle: 'Open failed',
+};
+
+export const reachabilityCopy: Record<ReachabilityKind, ReachabilityCopy> = {
+  'stale-forward': STALE_FORWARD_COPY,
+  'not-open': NOT_OPEN_COPY,
+};
+
+export const reconnectCopy = {
+  retryAction: 'Retry',
+  dialogCancel: 'Cancel',
+  runningHint: 'Latest output will appear below.',
   retry: 'Retry',
   dismiss: 'Dismiss',
 } as const;
 
 export function stripMcpUnreachableMarker(message: string): string {
-  if (message.startsWith(MCP_UNREACHABLE_MARKER)) {
-    return message.slice(MCP_UNREACHABLE_MARKER.length);
+  const kind = mcpUnreachableKind(message);
+  if (!kind) {
+    return message;
   }
-  return message;
+  return message.slice(MCP_UNREACHABLE_MARKERS[kind].length);
 }
 
-export function isMcpUnreachableMessage(message: string): boolean {
-  return message.startsWith(MCP_UNREACHABLE_MARKER);
+// mcpUnreachableKind reports which reachability shape the message names, or
+// null when the message is not one of the MCP-unreachable markers at all
+// (an ordinary diff-loading error, unrelated to reachability).
+export function mcpUnreachableKind(message: string): ReachabilityKind | null {
+  for (const kind of Object.keys(MCP_UNREACHABLE_MARKERS) as ReachabilityKind[]) {
+    if (message.startsWith(MCP_UNREACHABLE_MARKERS[kind])) {
+      return kind;
+    }
+  }
+  return null;
 }

--- a/erun-ui/frontend/src/app/reviewThunks.ts
+++ b/erun-ui/frontend/src/app/reviewThunks.ts
@@ -5,7 +5,11 @@ import { sessionApi } from './api/sessionApi';
 import { chooseSelectedDiffPath } from './diffUtils';
 import { readError } from './errors';
 import { showNotification } from './notificationThunks';
-import { isMcpUnreachableMessage, stripMcpUnreachableMarker } from './reconnectCopy';
+import {
+  mcpUnreachableKind,
+  type ReachabilityKind,
+  stripMcpUnreachableMarker,
+} from './reconnectCopy';
 import { scrollSelectedDiffIntoView } from './reviewDiffNavigation';
 import { selectReviewEnvTargets } from './selectors';
 import { setChangedFilesOpen } from './slices/layoutSlice';
@@ -106,9 +110,15 @@ function applyReviewDiffFailure(
     dispatch(setEnvDiff({ envKey, diff: null }));
   }
   const message = readError(error);
-  if (isMcpUnreachableMessage(message)) {
+  const kind = mcpUnreachableKind(message);
+  if (kind) {
     dispatch(
-      setEnvDiffError({ envKey, error: stripMcpUnreachableMarker(message), reconnectable: true }),
+      setEnvDiffError({
+        envKey,
+        error: stripMcpUnreachableMarker(message),
+        reconnectable: true,
+        kind,
+      }),
     );
   } else {
     dispatch(setEnvDiffError({ envKey, error: message, reconnectable: false }));
@@ -250,25 +260,31 @@ const idleReconnect = () => ({
   status: 'idle' as const,
   tenant: '',
   environment: '',
+  kind: 'stale-forward' as const,
   lines: [] as string[],
   error: '',
 });
 
-export const requestReconnect = (): AppThunk => (dispatch, getState) => {
-  const selection = getState().selection.selected;
-  if (!selection) {
-    return;
-  }
-  dispatch(
-    setReconnect({
-      status: 'confirm',
-      tenant: selection.tenant,
-      environment: selection.environment,
-      lines: [],
-      error: '',
-    }),
-  );
-};
+// requestReconnect takes its target explicitly from the caller (the specific
+// linked environment whose card was clicked) rather than the sidebar's
+// globally-selected environment. An orchestrator session shows one card per
+// linked environment, and the selected env is rarely the one that failed, so
+// deriving the target from selection.selected reconnected the wrong
+// environment (#1230).
+export const requestReconnect =
+  (tenant: string, environment: string, kind: ReachabilityKind): AppThunk =>
+  (dispatch) => {
+    dispatch(
+      setReconnect({
+        status: 'confirm',
+        tenant,
+        environment,
+        kind,
+        lines: [],
+        error: '',
+      }),
+    );
+  };
 
 export const cancelReconnect = (): AppThunk => (dispatch, getState) => {
   if (getState().review.reconnect.status === 'running') {
@@ -278,22 +294,22 @@ export const cancelReconnect = (): AppThunk => (dispatch, getState) => {
 };
 
 export const confirmReconnect = (): AppThunk<Promise<void>> => async (dispatch, getState) => {
-  const state = getState();
-  const selection = state.selection.selected;
-  if (!selection || state.review.reconnect.status === 'running') {
+  const { tenant, environment, kind, status } = getState().review.reconnect;
+  if (!tenant || !environment || status === 'running') {
     return;
   }
   dispatch(
     setReconnect({
       status: 'running',
-      tenant: selection.tenant,
-      environment: selection.environment,
+      tenant,
+      environment,
+      kind,
       lines: [],
       error: '',
     }),
   );
   try {
-    await dispatch(sessionApi.endpoints.reconnectMCP.initiate(selection)).unwrap();
+    await dispatch(sessionApi.endpoints.reconnectMCP.initiate({ tenant, environment })).unwrap();
     dispatch(setReconnect(idleReconnect()));
     await dispatch(loadReviewDiff());
   } catch (error: unknown) {
@@ -305,6 +321,7 @@ export const confirmReconnect = (): AppThunk<Promise<void>> => async (dispatch, 
         status: 'error',
         tenant: reconnect.tenant,
         environment: reconnect.environment,
+        kind: reconnect.kind,
         lines: reconnect.lines,
         error: readError(error),
       }),

--- a/erun-ui/frontend/src/app/slices/reviewSlice.errorKind.test.ts
+++ b/erun-ui/frontend/src/app/slices/reviewSlice.errorKind.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import reviewReducer, { emptyEnvDiffState, type ReviewState, setEnvDiffError } from './reviewSlice';
+
+// #1230: errorKind is the discriminator the review panel branches its copy
+// on (informational "not-open" vs a fault "stale-forward"). This is a
+// separate file from reviewSlice.test.ts (the #1244 characterization spec for
+// this slice) rather than an edit to it, per the mandate to leave that file
+// untouched.
+
+function initial(): ReviewState {
+  return reviewReducer(undefined, { type: '@@INIT' });
+}
+
+test('emptyEnvDiffState defaults errorKind to stale-forward', () => {
+  assert.equal(emptyEnvDiffState.errorKind, 'stale-forward');
+});
+
+test('setEnvDiffError without a kind defaults to stale-forward, preserving pre-#1230 always-a-fault callers', () => {
+  const state = reviewReducer(
+    initial(),
+    setEnvDiffError({ envKey: 'a/alpha', error: 'unreachable', reconnectable: true }),
+  );
+
+  assert.equal(state.diffByEnv['a/alpha']?.errorKind, 'stale-forward');
+});
+
+test('setEnvDiffError threads an explicit not-open kind onto the targeted slot only', () => {
+  let state = initial();
+  state = reviewReducer(
+    state,
+    setEnvDiffError({
+      envKey: 'a/alpha',
+      error: 'not open',
+      reconnectable: true,
+      kind: 'not-open',
+    }),
+  );
+  state = reviewReducer(
+    state,
+    setEnvDiffError({
+      envKey: 'a/beta',
+      error: 'stale',
+      reconnectable: true,
+      kind: 'stale-forward',
+    }),
+  );
+
+  assert.equal(state.diffByEnv['a/alpha']?.errorKind, 'not-open');
+  assert.equal(state.diffByEnv['a/beta']?.errorKind, 'stale-forward');
+});

--- a/erun-ui/frontend/src/app/slices/reviewSlice.ts
+++ b/erun-ui/frontend/src/app/slices/reviewSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import type { DiffResult } from '@/types';
 
+import type { ReachabilityKind } from '../reconnectCopy';
 import { RECONNECT_LINE_BUFFER_LIMIT, type ReconnectState } from '../state';
 
 export type ReviewScope = 'current' | 'commit' | 'all';
@@ -23,6 +24,12 @@ export interface EnvDiffState {
   loading: boolean;
   error: string;
   errorReconnectable: boolean;
+  // Only meaningful while errorReconnectable is true: which of the two
+  // reachability shapes this is, so the panel can render a stopped
+  // environment as informational rather than a fault (#1230). Defaults to
+  // 'stale-forward', the always-a-fault behavior every caller had before the
+  // kind existed.
+  errorKind: ReachabilityKind;
   scope: ReviewScope;
   commit: string;
 }
@@ -32,6 +39,7 @@ export const emptyEnvDiffState: EnvDiffState = {
   loading: false,
   error: '',
   errorReconnectable: false,
+  errorKind: 'stale-forward',
   scope: 'current',
   commit: '',
 };
@@ -57,7 +65,14 @@ export interface ReviewState {
 
 const initialState: ReviewState = {
   diffByEnv: {},
-  reconnect: { status: 'idle', tenant: '', environment: '', lines: [], error: '' },
+  reconnect: {
+    status: 'idle',
+    tenant: '',
+    environment: '',
+    kind: 'stale-forward',
+    lines: [],
+    error: '',
+  },
   selectedDiffPath: '',
   diffFilter: '',
   collapsedDiffDirs: [],
@@ -87,11 +102,17 @@ export const reviewSlice = createSlice({
     },
     setEnvDiffError(
       state,
-      action: PayloadAction<{ envKey: string; error: string; reconnectable: boolean }>,
+      action: PayloadAction<{
+        envKey: string;
+        error: string;
+        reconnectable: boolean;
+        kind?: ReachabilityKind;
+      }>,
     ) {
       const slot = envSlot(state, action.payload.envKey);
       slot.error = action.payload.error;
       slot.errorReconnectable = action.payload.reconnectable;
+      slot.errorKind = action.payload.kind ?? 'stale-forward';
     },
     // Drop the environments no longer in scope, so switching from a two-env
     // orchestrator to a single env tab does not leave stale sections rendering.

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -19,6 +19,8 @@ import type {
 import type { UIClusterRegistryStatus, UIEnvironmentHealth } from '@/uiDiagnosticsTypes';
 import type { UIRuntimeChartPlan } from '@/uiRuntimeChartTypes';
 
+import type { ReachabilityKind } from './reconnectCopy';
+
 export const MIN_SIDEBAR_WIDTH = 248;
 export const MAX_SIDEBAR_WIDTH = 520;
 export const DEFAULT_SIDEBAR_WIDTH = 338;
@@ -203,6 +205,10 @@ export interface ReconnectState {
   // interactive while this one is running. Empty when status === 'idle'.
   tenant: string;
   environment: string;
+  // Which reachability shape triggered this reconnect, so the dialog and
+  // status panel can say "Open" for a stopped environment and "Reconnect" for
+  // a stale forward instead of one fixed script for both (#1230).
+  kind: ReachabilityKind;
   // Rolling buffer of the latest reconnect output lines, not the full transcript.
   lines: string[];
   error: string;

--- a/erun-ui/frontend/src/components/app/DiffList.tsx
+++ b/erun-ui/frontend/src/components/app/DiffList.tsx
@@ -1,9 +1,9 @@
-import { AlertCircle, CheckCircle2, Copy, PlugZap, RefreshCw } from 'lucide-react';
+import { AlertCircle, CheckCircle2, Copy, Info, Play, PlugZap, RefreshCw } from 'lucide-react';
 import * as React from 'react';
 
 import { compactDiffError, diffLineMark, visibleDiffFilePaths } from '@/app/diffUtils';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import { reconnectCopy } from '@/app/reconnectCopy';
+import { reachabilityCopy, type ReachabilityKind, reconnectCopy } from '@/app/reconnectCopy';
 import { loadReviewDiff, requestReconnect } from '@/app/reviewThunks';
 import { type ReviewEnvTarget, selectReviewEnvTargets } from '@/app/selectors';
 import { diffPathKey } from '@/app/slices/reviewSlice';
@@ -65,11 +65,12 @@ function DiffEnvSection({
           message={compactDiffError(slot.error)}
           loading={slot.loading}
           reconnectable={slot.errorReconnectable}
+          kind={slot.errorKind}
           onRetry={() => {
             void dispatch(loadReviewDiff());
           }}
           onReconnect={() => {
-            dispatch(requestReconnect());
+            dispatch(requestReconnect(target.tenant, target.environment, slot.errorKind));
           }}
         />
       );
@@ -113,57 +114,144 @@ function DiffEnvSection({
   );
 }
 
+// diffErrorCopy resolves the title/body/technical-detail text and whether this
+// is the informational not-running case, as one pure step so DiffErrorAlert
+// itself only has layout branching left (#1230 pushed the complexity here).
+function diffErrorCopy(
+  message: string,
+  reconnectable: boolean | undefined,
+  kind: ReachabilityKind | undefined,
+): { notRunning: boolean; title: string; body: string; technicalMessage: string; action: string } {
+  const notRunning = Boolean(reconnectable) && kind === 'not-open';
+  const copy = reachabilityCopy[kind ?? 'stale-forward'];
+  const title = reconnectable ? copy.errorTitle : 'Could not load diff';
+  const body = reconnectable ? copy.errorBody : message;
+  const technicalMessage = reconnectable && message && message !== body ? message : '';
+  return { notRunning, title, body, technicalMessage, action: copy.action };
+}
+
 export function DiffErrorAlert({
   message,
   loading,
   reconnectable,
+  kind,
   onRetry,
   onReconnect,
 }: {
   message: string;
   loading: boolean;
   reconnectable?: boolean;
+  kind?: ReachabilityKind;
   onRetry: () => void;
   onReconnect?: () => void;
 }): React.ReactElement {
-  const title = reconnectable ? reconnectCopy.errorTitle : 'Could not load diff';
-  const body = reconnectable ? reconnectCopy.errorBody : message;
-  const technicalMessage = reconnectable && message && message !== body ? message : '';
-  const clipboardText = [title, body, technicalMessage].filter(Boolean).join('\n');
+  // A stopped/never-opened environment is the ordinary resting state, not a
+  // fault -- it renders as an informational status, not a red alert, with
+  // "Open" as the primary action instead of "Reconnect…" (#1230).
+  const { notRunning, title, body, technicalMessage, action } = diffErrorCopy(
+    message,
+    reconnectable,
+    kind,
+  );
   return (
     <div
-      role="alert"
-      className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3 rounded-[var(--radius)] border border-destructive/40 bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] px-3 py-2.5 text-[13px] leading-[1.4]"
+      role={notRunning ? 'status' : 'alert'}
+      className={cn(
+        'grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3 rounded-[var(--radius)] border px-3 py-2.5 text-[13px] leading-[1.4]',
+        notRunning
+          ? 'border-border bg-muted/40'
+          : 'border-destructive/40 bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)]',
+      )}
     >
-      <AlertCircle className="mt-px size-[18px] flex-none text-destructive" aria-hidden="true" />
-      <div className="min-w-0 [overflow-wrap:anywhere] text-foreground">
-        <div className="font-semibold text-destructive">{title}</div>
-        <div className="text-muted-foreground">{body}</div>
-        {technicalMessage && (
-          <div className="mt-1 font-mono text-[12px] break-words whitespace-pre-wrap text-muted-foreground select-text">
-            {technicalMessage}
-          </div>
-        )}
+      <DiffErrorIcon notRunning={notRunning} />
+      <DiffErrorBody
+        notRunning={notRunning}
+        title={title}
+        body={body}
+        technical={technicalMessage}
+      />
+      <DiffErrorActions
+        notRunning={notRunning}
+        reconnectable={reconnectable}
+        loading={loading}
+        actionLabel={action}
+        onRetry={onRetry}
+        onReconnect={onReconnect}
+        clipboardText={[title, body, technicalMessage].filter(Boolean).join('\n')}
+      />
+    </div>
+  );
+}
+
+function DiffErrorIcon({ notRunning }: { notRunning: boolean }): React.ReactElement {
+  if (notRunning) {
+    return (
+      <Info className="mt-px size-[18px] flex-none text-muted-foreground" aria-hidden="true" />
+    );
+  }
+  return (
+    <AlertCircle className="mt-px size-[18px] flex-none text-destructive" aria-hidden="true" />
+  );
+}
+
+function DiffErrorBody({
+  notRunning,
+  title,
+  body,
+  technical,
+}: {
+  notRunning: boolean;
+  title: string;
+  body: string;
+  technical: string;
+}): React.ReactElement {
+  return (
+    <div className="min-w-0 [overflow-wrap:anywhere] text-foreground">
+      <div className={cn('font-semibold', notRunning ? 'text-foreground' : 'text-destructive')}>
+        {title}
       </div>
-      <div className="flex flex-col items-end gap-1.5">
+      <div className="text-muted-foreground">{body}</div>
+      {technical && (
+        <div className="mt-1 font-mono text-[12px] break-words whitespace-pre-wrap text-muted-foreground select-text">
+          {technical}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DiffErrorActions({
+  notRunning,
+  reconnectable,
+  loading,
+  actionLabel,
+  onRetry,
+  onReconnect,
+  clipboardText,
+}: {
+  notRunning: boolean;
+  reconnectable?: boolean;
+  loading: boolean;
+  actionLabel: string;
+  onRetry: () => void;
+  onReconnect?: () => void;
+  clipboardText: string;
+}): React.ReactElement {
+  return (
+    <div className="flex flex-col items-end gap-1.5">
+      {!notRunning && (
         <Button type="button" variant="outline" size="sm" disabled={loading} onClick={onRetry}>
           <RefreshCw aria-hidden="true" />
           {reconnectCopy.retryAction}
         </Button>
-        {reconnectable && onReconnect && (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={loading}
-            onClick={onReconnect}
-          >
-            <PlugZap aria-hidden="true" />
-            {reconnectCopy.reconnectAction}
-          </Button>
-        )}
-        <CopyErrorButton text={clipboardText} />
-      </div>
+      )}
+      {reconnectable && onReconnect && (
+        <Button type="button" variant="outline" size="sm" disabled={loading} onClick={onReconnect}>
+          {notRunning ? <Play aria-hidden="true" /> : <PlugZap aria-hidden="true" />}
+          {actionLabel}
+        </Button>
+      )}
+      {!notRunning && <CopyErrorButton text={clipboardText} />}
     </div>
   );
 }

--- a/erun-ui/frontend/src/components/app/ReconnectDialog.tsx
+++ b/erun-ui/frontend/src/components/app/ReconnectDialog.tsx
@@ -1,8 +1,8 @@
-import { RefreshCw } from 'lucide-react';
+import { Play, RefreshCw } from 'lucide-react';
 import * as React from 'react';
 
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import { reconnectCopy } from '@/app/reconnectCopy';
+import { reachabilityCopy, reconnectCopy } from '@/app/reconnectCopy';
 import { cancelReconnect, confirmReconnect } from '@/app/reviewThunks';
 import { Button } from '@/components/ui/button';
 import {
@@ -19,6 +19,8 @@ import {
 export function ReconnectDialog(): React.ReactElement {
   const dispatch = useAppDispatch();
   const status = useAppSelector((state) => state.review.reconnect.status);
+  const kind = useAppSelector((state) => state.review.reconnect.kind);
+  const copy = reachabilityCopy[kind];
   const open = status === 'confirm';
   return (
     <Dialog
@@ -31,8 +33,8 @@ export function ReconnectDialog(): React.ReactElement {
     >
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{reconnectCopy.dialogTitle}</DialogTitle>
-          <DialogDescription>{reconnectCopy.dialogBody}</DialogDescription>
+          <DialogTitle>{copy.dialogTitle}</DialogTitle>
+          <DialogDescription>{copy.dialogBody}</DialogDescription>
         </DialogHeader>
         <DialogFooter>
           <Button
@@ -50,8 +52,8 @@ export function ReconnectDialog(): React.ReactElement {
               void dispatch(confirmReconnect());
             }}
           >
-            <RefreshCw aria-hidden="true" />
-            {reconnectCopy.dialogConfirm}
+            {kind === 'not-open' ? <Play aria-hidden="true" /> : <RefreshCw aria-hidden="true" />}
+            {copy.dialogConfirm}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/erun-ui/frontend/src/components/app/ReconnectStatusPanel.tsx
+++ b/erun-ui/frontend/src/components/app/ReconnectStatusPanel.tsx
@@ -2,7 +2,7 @@ import { AlertCircle, LoaderCircle, RefreshCw, X } from 'lucide-react';
 import * as React from 'react';
 
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import { reconnectCopy } from '@/app/reconnectCopy';
+import { reachabilityCopy, type ReachabilityKind, reconnectCopy } from '@/app/reconnectCopy';
 import { confirmReconnect, dismissReconnect } from '@/app/reviewThunks';
 import { setSelected } from '@/app/slices/selectionSlice';
 import { Button } from '@/components/ui/button';
@@ -17,6 +17,7 @@ export function ReconnectStatusPanel(): React.ReactElement | null {
   const status = useAppSelector((state) => state.review.reconnect.status);
   const tenant = useAppSelector((state) => state.review.reconnect.tenant);
   const environment = useAppSelector((state) => state.review.reconnect.environment);
+  const kind = useAppSelector((state) => state.review.reconnect.kind);
   const lines = useAppSelector((state) => state.review.reconnect.lines);
   const error = useAppSelector((state) => state.review.reconnect.error);
 
@@ -25,6 +26,7 @@ export function ReconnectStatusPanel(): React.ReactElement | null {
   }
 
   const failed = status === 'error';
+  const copy = reachabilityCopy[kind];
   const targetLabel = formatEnvLabel(tenant, environment);
 
   return (
@@ -32,14 +34,12 @@ export function ReconnectStatusPanel(): React.ReactElement | null {
       role="status"
       aria-live="polite"
       aria-label={
-        failed
-          ? `${reconnectCopy.errorStatusTitle} ${targetLabel}`
-          : `${reconnectCopy.runningStatus} ${targetLabel}`
+        failed ? `${copy.errorStatusTitle} ${targetLabel}` : `${copy.runningStatus} ${targetLabel}`
       }
       data-reconnect-status={status}
       className="fixed bottom-4 right-4 z-50 flex w-96 max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-md border bg-background shadow-lg"
     >
-      <ReconnectStatusHeader failed={failed} targetLabel={targetLabel} />
+      <ReconnectStatusHeader failed={failed} kind={kind} targetLabel={targetLabel} />
       <ReconnectStatusLines lines={lines} />
       {failed && (
         <ReconnectStatusErrorFooter error={error} tenant={tenant} environment={environment} />
@@ -50,12 +50,15 @@ export function ReconnectStatusPanel(): React.ReactElement | null {
 
 function ReconnectStatusHeader({
   failed,
+  kind,
   targetLabel,
 }: {
   failed: boolean;
+  kind: ReachabilityKind;
   targetLabel: string;
 }): React.ReactElement {
   const dispatch = useAppDispatch();
+  const copy = reachabilityCopy[kind];
   return (
     <header className="flex items-center gap-2 border-b px-3 py-2">
       {failed ? (
@@ -68,7 +71,7 @@ function ReconnectStatusHeader({
       )}
       <div className="min-w-0 flex-1">
         <div className={failed ? 'text-sm font-medium text-destructive' : 'text-sm font-medium'}>
-          {failed ? reconnectCopy.errorStatusTitle : reconnectCopy.runningStatus}
+          {failed ? copy.errorStatusTitle : copy.runningStatus}
         </div>
         {targetLabel && (
           <div className="truncate text-xs text-muted-foreground" title={targetLabel}>

--- a/erun-ui/frontend/src/components/app/ReviewPanel.ChangedFiles.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewPanel.ChangedFiles.tsx
@@ -1,18 +1,13 @@
 import { ChevronRight } from 'lucide-react';
 import * as React from 'react';
 
-import { compactDiffError, filterDiffTree, visibleDiffTreeNodes } from '@/app/diffUtils';
+import { filterDiffTree, visibleDiffTreeNodes } from '@/app/diffUtils';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import {
-  loadReviewDiff,
-  requestReconnect,
-  selectDiffPath,
-  toggleDiffDirectory,
-} from '@/app/reviewThunks';
+import { selectDiffPath, toggleDiffDirectory } from '@/app/reviewThunks';
 import { selectReviewEnvTargets } from '@/app/selectors';
 import { diffPathKey } from '@/app/slices/reviewSlice';
 import { useEnvDiffSlot } from '@/app/useEnvDiffSlot';
-import { DiffErrorAlert, ReviewStatus } from '@/components/app/DiffList';
+import { ReviewStatus } from '@/components/app/DiffList';
 import { FileIcon } from '@/components/app/FileIcon';
 import { cn } from '@/lib/utils';
 import type { DiffTreeNode } from '@/types';
@@ -32,10 +27,17 @@ export function ChangedFileTree(): React.ReactElement {
   );
 }
 
-// ChangedFileTreeSection owns one environment's tree, loading state and error.
-// A stopped environment renders its error in its own section while every other
-// environment keeps rendering -- the single-slot version cleared the one shared
-// diff, so one unreachable env blanked them all (#1178).
+// ChangedFileTreeSection owns one environment's tree and loading state. A
+// stopped environment renders its own empty state in its own section while
+// every other environment keeps rendering -- the single-slot version cleared
+// the one shared diff, so one unreachable env blanked them all (#1178).
+//
+// It deliberately does NOT duplicate DiffList's actionable DiffErrorAlert: the
+// two surfaces render the same env slot, and rendering the full alert (with
+// its own Retry/Reconnect/Open buttons) in both the tree aside and the main
+// diff panel at once read as two unrelated reports of the same outage
+// (#1230). The tree shows a short status line instead and points at the diff
+// panel, which keeps the one actionable report.
 function ChangedFileTreeSection({
   envKey,
   showHeader,
@@ -43,7 +45,6 @@ function ChangedFileTreeSection({
   envKey: string;
   showHeader: boolean;
 }): React.ReactElement {
-  const dispatch = useAppDispatch();
   const slot = useEnvDiffSlot(envKey);
   const diffFilter = useAppSelector((state) => state.review.diffFilter);
   const collapsedDiffDirs = useAppSelector((state) => state.review.collapsedDiffDirs);
@@ -57,18 +58,13 @@ function ChangedFileTreeSection({
       return <ReviewStatus>Loading...</ReviewStatus>;
     }
     if (slot.error) {
+      const notRunning = slot.errorReconnectable && slot.errorKind === 'not-open';
       return (
-        <DiffErrorAlert
-          message={compactDiffError(slot.error)}
-          loading={slot.loading}
-          reconnectable={slot.errorReconnectable}
-          onRetry={() => {
-            void dispatch(loadReviewDiff());
-          }}
-          onReconnect={() => {
-            dispatch(requestReconnect());
-          }}
-        />
+        <ReviewStatus>
+          {notRunning
+            ? 'Environment not running — open it from the diff panel.'
+            : 'Diff unavailable — see the diff panel for details.'}
+        </ReviewStatus>
       );
     }
     // Collapsed directories are env-keyed, so a collapsed "app/" in one

--- a/erun-ui/mcp_errors.go
+++ b/erun-ui/mcp_errors.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"strings"
 	"syscall"
+
+	eruncommon "github.com/sophium/erun/erun-common"
 )
 
 // errMCPUnreachable signals the frontend to render an unreachable state with a
@@ -18,11 +20,37 @@ var errMCPUnreachable = errors.New("mcp unreachable")
 // underlying error text. The marker is opaque; it is never shown to users.
 const mcpUnreachableMarker = "ERUN_MCP_UNREACHABLE: "
 
+// mcpUnreachableKindMarkers give the review panel the reachability kind
+// DescribeLocalMCPUnreachable already computed, rather than asking it to
+// pattern-match the sentence (#1230): a never-opened/stopped environment reads
+// as informational, a stale forward reads as a fault, and the frontend cannot
+// tell those apart from prose alone. Both are still recognised as "MCP
+// unreachable" the same way the plain marker is.
+var mcpUnreachableKindMarkers = map[eruncommon.LocalMCPUnreachableKind]string{
+	eruncommon.LocalMCPNotOpen:      "ERUN_MCP_UNREACHABLE_NOT_OPEN: ",
+	eruncommon.LocalMCPStaleForward: "ERUN_MCP_UNREACHABLE_STALE: ",
+}
+
 func wrapMCPUnreachableError(err error) error {
 	if err == nil {
 		return nil
 	}
 	return fmt.Errorf("%s%w: %w", mcpUnreachableMarker, errMCPUnreachable, err)
+}
+
+// wrapMCPUnreachableErrorWithKind is wrapMCPUnreachableError plus the
+// reachability kind the caller already classified, so the review panel can
+// tell a stopped environment (informational, "Open") from a stale forward (a
+// fault, "Reconnect…") without re-deriving it from the message text.
+func wrapMCPUnreachableErrorWithKind(kind eruncommon.LocalMCPUnreachableKind, err error) error {
+	if err == nil {
+		return nil
+	}
+	marker, ok := mcpUnreachableKindMarkers[kind]
+	if !ok {
+		return wrapMCPUnreachableError(err)
+	}
+	return fmt.Errorf("%s%w: %w", marker, errMCPUnreachable, err)
 }
 
 func isMCPDialFailure(err error) bool {

--- a/erun-ui/playwright/pages/ReviewPanel.ts
+++ b/erun-ui/playwright/pages/ReviewPanel.ts
@@ -67,9 +67,6 @@ export class ReviewPanel {
 
   // The "Changed files N" collapsible header inside the aside, distinct from
   // the titlebar's "Toggle changed files list" (which hides the whole aside).
-  // Collapsing it hides the changed-files tree's own per-env headers and error
-  // alerts, so a spec asserting on the diff list's alone can scope past the
-  // tree's duplicate rendering of the same slot.
   changedFilesSectionToggle(): Locator {
     return this.page.getByRole('button', { name: /^Changed files/ });
   }
@@ -78,12 +75,20 @@ export class ReviewPanel {
     await this.changedFilesSectionToggle().click();
   }
 
-  // The changed-files tree renders its own DiffErrorAlert for the same
-  // per-env slot (#1178), so counting alerts document-wide double-counts once
-  // both surfaces are visible. Callers that care about the diff list's own
-  // alert count should collapseChangedFilesSection() first.
+  // The changed-files tree renders a short status line rather than its own
+  // copy of the diff panel's alert for the same per-env slot (#1230) — the
+  // diff panel is the one place a linked environment's outage renders as an
+  // actionable alert, so this locator only ever matches once per environment.
   errorAlerts(): Locator {
     return this.page.getByRole('alert');
+  }
+
+  // reachabilityStatuses locates the informational "environment not running"
+  // status DiffErrorAlert renders for the not-open reachability kind (#1230).
+  // Unlike errorAlerts() this is role="status", not role="alert": it is not a
+  // fault, so it must not be announced as one (WCAG 4.1.3 / Nielsen #1).
+  reachabilityStatuses(): Locator {
+    return this.page.getByRole('status');
   }
 
   // reviewBoundaryButton locates a "Review layers" scope button by its visible

--- a/erun-ui/playwright/tests/review-panel-reachability.spec.ts
+++ b/erun-ui/playwright/tests/review-panel-reachability.spec.ts
@@ -1,0 +1,250 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ENV_ALPHA, SEED_ENV_BETA, SEED_TENANT } from '../fixtures/seedRoot.js';
+
+// #1230: the review panel used to flatten every MCP-unreachable LoadDiff
+// failure into one fixed "Cannot reach the environment runtime / connection
+// is down" red alert with a "Reconnect…" action, discarding the distinction
+// DescribeLocalMCPUnreachable already computes between a never-opened/stopped
+// environment (informational, "Open") and a genuinely stale port-forward (a
+// fault, "Reconnect…"). It also rendered that alert twice at once -- once in
+// the diff panel, once in the changed-files aside -- for the same env slot.
+//
+// These specs stub LoadDiff's error message with the two marker prefixes
+// erun-ui/mcp_errors.go now emits (mcpUnreachableKindMarkers) rather than
+// driving a real unreachable MCP edge, matching the stubbing pattern already
+// used by orchestrator-cross-env-diff.spec.ts for this same RPC.
+
+const NOT_OPEN_MESSAGE =
+  'ERUN_MCP_UNREACHABLE_NOT_OPEN: mcp unreachable: no port-forward is listening for pw/env on 127.0.0.1:17999';
+const STALE_MESSAGE =
+  'ERUN_MCP_UNREACHABLE_STALE: mcp unreachable: the port-forward for pw/env on 127.0.0.1:17999 is not carrying traffic (the local port is held but the edge never answers) — re-establishing it';
+
+async function stubLoadDiffError(page: Page, message: string): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method?: string };
+    if (body.method !== 'LoadDiff') {
+      await route.continue();
+      return;
+    }
+    return route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ error: message }),
+    });
+  });
+}
+
+test.describe('review panel reachability framing (#1230)', () => {
+  test('a stopped/never-opened environment renders informationally, with Open as the action', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    await stubLoadDiffError(page, NOT_OPEN_MESSAGE);
+    await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+
+    // Not a fault: no role="alert" anywhere, and the informational status
+    // names the real situation instead of claiming a connection was lost.
+    await expect(review.errorAlerts()).toHaveCount(0);
+    const status = review.reachabilityStatuses().filter({ hasText: 'Environment not running' });
+    await expect(status).toBeVisible();
+    await expect(status.getByRole('button', { name: 'Open' })).toBeVisible();
+    await expect(status.getByRole('button', { name: 'Reconnect…' })).toHaveCount(0);
+  });
+
+  test('a stale port-forward renders as an actionable fault with Reconnect…', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    await stubLoadDiffError(page, STALE_MESSAGE);
+    await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+
+    const alert = review.errorAlerts();
+    await expect(alert).toHaveCount(1);
+    await expect(alert.getByText('Cannot reach the environment runtime')).toBeVisible();
+    await expect(alert.getByRole('button', { name: 'Reconnect…' })).toBeVisible();
+    await expect(alert.getByRole('button', { name: 'Open' })).toHaveCount(0);
+  });
+
+  test("the changed-files aside does not duplicate the diff panel's alert for the same environment", async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    await stubLoadDiffError(page, STALE_MESSAGE);
+    await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+
+    // Both surfaces are visible at once here -- no collapseChangedFilesSection()
+    // -- which is exactly the layout that used to render two copies of the
+    // same alert (#1230).
+    await expect(review.changedFilesTree()).toBeVisible();
+    await expect(review.errorAlerts()).toHaveCount(1);
+  });
+
+  test('the changed-files aside does not duplicate the informational not-open status either', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    await stubLoadDiffError(page, NOT_OPEN_MESSAGE);
+    await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+
+    await expect(review.changedFilesTree()).toBeVisible();
+    await expect(
+      review.reachabilityStatuses().filter({ hasText: 'Environment not running' }),
+    ).toHaveCount(1);
+  });
+
+  test('clicking Open surfaces honest copy for the stopped case, not the "restore the connection" fault script', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    await stubLoadDiffError(page, NOT_OPEN_MESSAGE);
+    await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+
+    await review
+      .reachabilityStatuses()
+      .filter({ hasText: 'Environment not running' })
+      .getByRole('button', { name: 'Open' })
+      .click();
+
+    const dialog = page.getByRole('dialog', { name: 'Open environment?' });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('This runs `erun open` to start the environment.')).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Open' })).toBeVisible();
+  });
+});
+
+test.describe('review panel reconnect targeting in an orchestrator session (#1230)', () => {
+  const ORCHESTRATOR_ID = 'pw-orch-reachability';
+  const RUNNING_SESSION_ID = 9101;
+  const ALPHA_ENV_KEY = `${SEED_TENANT}/${SEED_ENV_ALPHA}`;
+  const BETA_ENV_KEY = `${SEED_TENANT}/${SEED_ENV_BETA}`;
+
+  function orchestratorSnapshot(): unknown {
+    return {
+      id: ORCHESTRATOR_ID,
+      name: ORCHESTRATOR_ID,
+      environments: [
+        { tenant: SEED_TENANT, environment: SEED_ENV_ALPHA, directory: '/tmp/orch-alpha' },
+        { tenant: SEED_TENANT, environment: SEED_ENV_BETA, directory: '/tmp/orch-beta' },
+      ],
+      tenants: [SEED_TENANT],
+      directories: ['/tmp/orch-alpha', '/tmp/orch-beta'],
+      sessionId: RUNNING_SESSION_ID,
+      status: 'running',
+      busy: false,
+      transient: false,
+      shellRunning: false,
+      shellCommand: '',
+      shellStartedAtUnix: 0,
+    };
+  }
+
+  // stubOrchestratorNotOpenAlpha reports alpha as stopped (not-open) and beta
+  // as reachable, and records every ReconnectMCP call's target so the spec can
+  // assert which environment an "Open" click actually reconnects.
+  async function stubOrchestratorNotOpenAlpha(page: Page): Promise<{ reconnectCalls: unknown[] }> {
+    const reconnectCalls: unknown[] = [];
+    await page.route('**/__erun_invoke', async (route, request) => {
+      const body = JSON.parse(request.postData() ?? '{}') as { method?: string; args?: unknown[] };
+      if (body.method === 'ListOrchestrators') {
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ data: [orchestratorSnapshot()] }),
+        });
+      }
+      if (body.method === 'LoadDiff') {
+        const [selection] = (body.args ?? []) as [{ environment: string }];
+        if (selection.environment === SEED_ENV_ALPHA) {
+          return route.fulfill({
+            contentType: 'application/json',
+            body: JSON.stringify({ error: NOT_OPEN_MESSAGE }),
+          });
+        }
+        // beta must resolve as a genuine success, not fall through to the real
+        // backend: the seeded baseline envs are never actually running, so an
+        // un-stubbed beta would also report not-open and make "Environment not
+        // running" ambiguous between the two sections.
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: {
+              rawDiff: '',
+              workingDirectory: '/seed',
+              summary: { fileCount: 1, additions: 1, deletions: 0 },
+              files: [
+                {
+                  path: 'beta.ts',
+                  status: 'modified',
+                  additions: 1,
+                  deletions: 0,
+                  binary: false,
+                  hunks: [],
+                },
+              ],
+              tree: [{ name: 'beta.ts', path: 'beta.ts', type: 'file', depth: 0 }],
+              scope: 'current',
+              includesWorktree: true,
+            },
+          }),
+        });
+      }
+      if (body.method === 'ReconnectMCP') {
+        reconnectCalls.push(body.args?.[0]);
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ data: null }),
+        });
+      }
+      await route.continue();
+    });
+    return { reconnectCalls };
+  }
+
+  test('opening the linked (unselected) environment targets that environment, not a no-op on the sidebar selection', async ({
+    app,
+    page,
+  }) => {
+    // Opening an orchestrator session clears the sidebar's own selection
+    // (selection.selected = null): the pre-#1230 reconnect thunks read their
+    // target from that selection, so clicking a linked env's action was a
+    // silent no-op whenever it did not match -- which for an orchestrator
+    // session was always, since there was no sidebar selection at all.
+    const { reconnectCalls } = await stubOrchestratorNotOpenAlpha(page);
+    await app.reboot();
+    await app.sidebar.openOrchestratorSession(ORCHESTRATOR_ID);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+
+    await expect(review.envSectionHeader(ALPHA_ENV_KEY)).toBeVisible();
+    await expect(review.envSectionHeader(BETA_ENV_KEY)).toBeVisible();
+
+    const alphaStatus = review
+      .reachabilityStatuses()
+      .filter({ hasText: 'Environment not running' });
+    await expect(alphaStatus).toBeVisible();
+    await alphaStatus.getByRole('button', { name: 'Open' }).click();
+
+    const dialog = page.getByRole('dialog', { name: 'Open environment?' });
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole('button', { name: 'Open' }).click();
+
+    await expect
+      .poll(() => reconnectCalls)
+      .toEqual([{ tenant: SEED_TENANT, environment: SEED_ENV_ALPHA }]);
+  });
+});

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -810,15 +810,29 @@ func (a *App) LoadDiff(selection uiSelection, options uiDiffOptions) (eruncommon
 	}
 	mcpPort := eruncommon.MCPPortForResult(result)
 	if a.deps.canReachMCPEndpoint != nil && !a.deps.canReachMCPEndpoint(mcpPort) {
-		return eruncommon.DiffResult{}, wrapMCPUnreachableError(errors.New(eruncommon.DescribeLocalMCPUnreachable(result.Tenant, result.EnvConfig.Name, mcpPort)))
+		return eruncommon.DiffResult{}, wrapMCPUnreachableErrorWithKind(
+			a.classifyMCPUnreachable(mcpPort),
+			errors.New(eruncommon.DescribeLocalMCPUnreachable(result.Tenant, result.EnvConfig.Name, mcpPort)),
+		)
 	}
 	endpoint := mcpEndpointForOpenResult(result)
 	bearer := a.mcpBearer(result.Tenant, result.EnvConfig.Name)
 	diff, err := a.deps.loadDiff(ctx, endpoint, bearer, options)
 	if err != nil && isMCPDialFailure(err) {
-		return eruncommon.DiffResult{}, wrapMCPUnreachableError(err)
+		return eruncommon.DiffResult{}, wrapMCPUnreachableErrorWithKind(a.classifyMCPUnreachable(mcpPort), err)
 	}
 	return diff, err
+}
+
+// classifyMCPUnreachable reports which locally observable shape of
+// unreachability the review panel is looking at, through the same injectable
+// port-bound check the rest of erun-ui uses (so it stays testable without a
+// real dial).
+func (a *App) classifyMCPUnreachable(port int) eruncommon.LocalMCPUnreachableKind {
+	if a.deps.canConnectLocalPort != nil && a.deps.canConnectLocalPort(port) {
+		return eruncommon.LocalMCPStaleForward
+	}
+	return eruncommon.LocalMCPNotOpen
 }
 
 func (a *App) ensureMCPAvailable(ctx context.Context, result eruncommon.OpenResult) error {


### PR DESCRIPTION
The review panel gave one answer to two different questions. An environment
nobody had opened and an environment whose port-forward was held but no longer
carrying traffic both rendered as a downed connection — and the second presents
as a timeout behind a live listener, which reads exactly like a busy pod. The
copy then sent the operator to restart something that was already running.

- `LocalMCPUnreachableKind` (`not-open` / `stale-forward`) with
  `ClassifyLocalMCPUnreachable` in `erun-common`, so callers act on the
  distinction instead of pattern-matching `DescribeLocalMCPUnreachable`'s prose.
  That function now derives both its messages from the classifier rather than
  repeating the port check.
- The kind is threaded through `erun-ui`'s MCP error mapping and terminal
  sessions into the review slice, so `DiffList`, `ReconnectDialog`,
  `ReconnectStatusPanel` and `ReviewPanel.ChangedFiles` each name what happened
  and offer the matching action — reopen a stale forward, start one that was
  never opened.

| check | result |
|---|---|
| `erun-common` `go test ./...` | ok (also stripped PATH) |
| `erun-ui` `go test ./...` | ok (also stripped PATH) |
| `golangci-lint` both modules | 0 issues |
| `yarn typecheck` | clean |
| frontend units | **112/112** (was 110) |
| `review-panel-reachability.spec.ts` (new) | 6 passed |

## Provenance

The implementation came from an in-pod agent run that ended its turn with the
work uncommitted — 14 modified files and 3 new test files, nothing lost. I
reviewed the diff, committed it, ran the gates above, and pushed.

Closes #1230