### PR TITLE
Make the Diagnostics panel context-aware and let it file an erun issue

### DIFF
--- a/erun-docs/docs/desktop/overview.md
+++ b/erun-docs/docs/desktop/overview.md
@@ -37,12 +37,15 @@ For the exact files behind these two layers and how they're injected into a sess
 
 ## Diagnostics console {#diagnostics-console}
 
-When something misbehaves, the panel at the bottom of the terminal area gives you two paste-ready diagnostic surfaces — built for handing to whoever (or whatever Agent) is helping you debug:
+The panel at the bottom of the terminal area follows whatever you're looking at, so it always has real evidence rather than a blank pane:
 
-- **erun trace.** The selected environment's persistent trace log: every erun command that ran for the env, at full trace detail, timestamped — including commands that finished before you opened the console. Capture is always on; the log is capped and rotated automatically (see [where it lives](/reference/config-locations#trace-log)). For a remote environment the timeline merges two vantage points: the commands you ran from this machine and, while the environment is open, the Agent-driven ones from inside the pod — the in-pod lines are marked `[pod]`. When the pod can't be reached, the console says so and still shows your machine's side.
-- **UI trace.** The desktop's own action history — what the app just did, in order — for reporting a desktop bug rather than an environment one.
+- **An environment selected.** The env's persistent trace log: every erun command that ran for it, at full trace detail, timestamped — including commands that finished before you opened the console. Capture is always on; the log is capped and rotated automatically (see [where it lives](/reference/config-locations#trace-log)). For a remote environment the timeline merges two vantage points: the commands you ran from this machine and, while the environment is open, the Agent-driven ones from inside the pod — the in-pod lines are marked `[pod]`.
+- **An orchestrator session focused.** Its name, status, background shell (if any), and the environments it links — plus the desktop's own log, since an orchestrator fault is desktop-side, not env-side.
+- **Neither.** The desktop's own log on its own, for a fault that belongs to the app itself.
 
-Both panes have a **Copy** button for their own stream, and the console's **Copy report** button packages everything at once — app build, the selected environment's identity and state, the erun trace (or the reason there isn't one), and the UI trace — into a single paste-ready block, so a bug report carries the evidence instead of a description of it.
+**UI trace** — the desktop's own action history, what the app just did, in order — sits in a second tab next to whichever of the above is active, for reporting a desktop bug rather than an environment or orchestrator one.
+
+Both panes have a **Copy** button for their own stream, and the console's **Copy report** button packages everything at once — app build, the active context's identity and state, and the UI trace — into a single paste-ready block, so a bug report carries the evidence instead of a description of it. **Report an erun issue** goes one step further: it opens a prefilled `github.com/sophium/erun` issue in your browser (title and reproduction/environment sections filled in from the same evidence) for you to review, fill in what happened, and submit yourself — it never files anything on your behalf. The full report stays on your clipboard too, so nothing is lost even if the prefilled body is trimmed to fit the link.
 
 On a busy environment the erun trace can be a wall of scrollback. **Clear** baselines the view — it hides the lines shown so far so whatever happens next stands out — without deleting anything: the persistent log stays intact, **Show all** brings the earlier lines back, and Copy and Copy report always include the full log. The baseline is per-environment, so switching environments starts fresh.
 

--- a/erun-skills/skills/erun-file-issue/SKILL.md
+++ b/erun-skills/skills/erun-file-issue/SKILL.md
@@ -29,6 +29,15 @@ The `gh` CLI is required. It is pre-wired inside a deployed ERun environment;
 on a laptop the user must have it installed and authenticated against
 `github.com` (`gh auth status` to check).
 
+For a fault observed inside the desktop app itself (an environment, an
+orchestrator session, or the app), the desktop's own Diagnostics panel
+("Report an erun issue") is the more direct route: it already has the
+evidence loaded and opens a prefilled issue in the browser for the operator
+to review and submit. Prefer pointing the operator at that button over
+hand-assembling a report when they're already in the desktop app; use this
+skill's `gh`-driven flow otherwise (a CLI/MCP session, or the operator asking
+you directly to file one).
+
 ## File a bug
 
 The environment block at the bottom of the body adapts to context. If the

--- a/erun-ui/app_log.go
+++ b/erun-ui/app_log.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -123,4 +124,43 @@ func initDurableAppLog() func() {
 	log.SetOutput(io.MultiWriter(os.Stderr, file))
 	log.Printf("erun-app: logging to %s", path)
 	return func() { _ = file.Close() }
+}
+
+// appLogTailBytes bounds how much of the durable app log one Diagnostics
+// console read transfers, matching the env trace log's own cap.
+const appLogTailBytes = 64 * 1024
+
+// uiAppLog is the Diagnostics console's read model for the desktop's own
+// durable log: the natural evidence for an orchestrator or app-level fault,
+// neither of which has an env trace to fall back on.
+type uiAppLog struct {
+	Available bool   `json:"available"`
+	Content   string `json:"content,omitempty"`
+	Path      string `json:"path"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// LoadAppLog reads the tail of the desktop's own log for the Diagnostics
+// console's orchestrator and app contexts. Read-only, like LoadEnvTrace.
+func (a *App) LoadAppLog() (uiAppLog, error) {
+	path, err := appLogPath()
+	if err != nil {
+		return uiAppLog{}, err
+	}
+	result := uiAppLog{Path: path}
+	content, err := tailFile(path, appLogTailBytes)
+	if err != nil {
+		if os.IsNotExist(err) {
+			result.Reason = "no log captured yet"
+			return result, nil
+		}
+		return uiAppLog{}, err
+	}
+	if strings.TrimSpace(content) == "" {
+		result.Reason = "no log captured yet"
+		return result, nil
+	}
+	result.Available = true
+	result.Content = content
+	return result, nil
 }

--- a/erun-ui/app_log_test.go
+++ b/erun-ui/app_log_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"os"
 	"path/filepath"
@@ -58,6 +59,58 @@ func TestInitDurableAppLogCapturesLogPrintfCalls(t *testing.T) {
 func restoreLogOutputAfter(t *testing.T) {
 	t.Helper()
 	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+}
+
+func TestLoadAppLogReportsNoLogCapturedYetWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	app := NewApp(erunUIDeps{})
+	t.Cleanup(func() { app.shutdown(context.Background()) })
+
+	result, err := app.LoadAppLog()
+	if err != nil {
+		t.Fatalf("LoadAppLog: %v", err)
+	}
+	if result.Available {
+		t.Fatalf("expected Available=false with no log file, got %+v", result)
+	}
+	if result.Reason != "no log captured yet" {
+		t.Fatalf("expected the honest empty reason, got %q", result.Reason)
+	}
+}
+
+func TestLoadAppLogReturnsTheDurableLogTail(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	app := NewApp(erunUIDeps{})
+	t.Cleanup(func() { app.shutdown(context.Background()) })
+
+	restoreLogOutputAfter(t)
+	closeLog := initDurableAppLog()
+	log.Printf("erun-app: orchestrator erun-issues spawned session 42")
+	closeLog()
+
+	result, err := app.LoadAppLog()
+	if err != nil {
+		t.Fatalf("LoadAppLog: %v", err)
+	}
+	if !result.Available {
+		t.Fatalf("expected Available=true once the log has content, got %+v", result)
+	}
+	if !strings.Contains(result.Content, "orchestrator erun-issues spawned session 42") {
+		t.Fatalf("expected the log line in the read tail, got:\n%s", result.Content)
+	}
+	path, err := appLogPath()
+	if err != nil {
+		t.Fatalf("appLogPath: %v", err)
+	}
+	if result.Path != path {
+		t.Fatalf("expected Path %q, got %q", path, result.Path)
+	}
 }
 
 func TestBoundedLogFileRotatesPastTheCap(t *testing.T) {

--- a/erun-ui/frontend/src/app/diagnosticsIssue.test.ts
+++ b/erun-ui/frontend/src/app/diagnosticsIssue.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  buildDiagnosticsIssueURL,
+  diagnosticsIssueBody,
+  diagnosticsIssueTitle,
+} from './diagnosticsIssue';
+import type { DiagnosticsReportContext } from './diagnosticsReport';
+import type { OrchestratorInfo } from './slices/orchestratorsSlice';
+
+function orchestrator(overrides: Partial<OrchestratorInfo> = {}): OrchestratorInfo {
+  return {
+    id: 'erun-issues',
+    name: 'erun-issues',
+    environments: [],
+    tenants: [],
+    directories: [],
+    sessionId: 42,
+    status: 'running',
+    busy: false,
+    transient: false,
+    shellRunning: false,
+    shellCommand: '',
+    shellStartedAtUnix: 0,
+    ...overrides,
+  };
+}
+
+test('diagnosticsIssueTitle prefills from the failing environment rather than leaving it blank', () => {
+  const failing: DiagnosticsReportContext = {
+    kind: 'environment',
+    tenant: 'acme',
+    environment: 'dev',
+    env: null,
+    status: 'failed',
+    trace: null,
+  };
+  assert.equal(diagnosticsIssueTitle(failing), 'acme/dev: failed');
+
+  const healthy: DiagnosticsReportContext = { ...failing, status: '' };
+  assert.equal(diagnosticsIssueTitle(healthy), 'acme/dev: diagnostics');
+});
+
+test('diagnosticsIssueTitle prefills from the orchestrator, naming a non-running status', () => {
+  const running: DiagnosticsReportContext = {
+    kind: 'orchestrator',
+    orchestrator: orchestrator(),
+    linkedEnvironments: [],
+    appLog: null,
+  };
+  assert.equal(diagnosticsIssueTitle(running), 'Orchestrator erun-issues: diagnostics');
+
+  const stopped: DiagnosticsReportContext = {
+    kind: 'orchestrator',
+    orchestrator: orchestrator({ status: 'stopped' }),
+    linkedEnvironments: [],
+    appLog: null,
+  };
+  assert.equal(diagnosticsIssueTitle(stopped), 'Orchestrator erun-issues: stopped');
+});
+
+test('diagnosticsIssueTitle falls back to the app context', () => {
+  assert.equal(diagnosticsIssueTitle({ kind: 'app', appLog: null }), 'ERun desktop: diagnostics');
+});
+
+test('diagnosticsIssueBody carries a reproduction, observed-vs-expected, and environment shape', () => {
+  const body = diagnosticsIssueBody('EVIDENCE_MARKER', { version: '1.0.0', commit: 'abc123' });
+  assert.match(body, /## What happened/);
+  assert.match(body, /## What you expected/);
+  assert.match(body, /## Reproduction/);
+  assert.match(body, /## Environment/);
+  assert.match(body, /- erun version: 1\.0\.0 \(abc123\)/);
+  assert.match(body, /## Diagnostics evidence/);
+  assert.match(body, /EVIDENCE_MARKER/);
+});
+
+test('buildDiagnosticsIssueURL leaves a short body untouched', () => {
+  const { url, truncated } = buildDiagnosticsIssueURL('title', 'short body');
+  assert.equal(truncated, false);
+  assert.match(url, /^https:\/\/github\.com\/sophium\/erun\/issues\/new\?/);
+  const params = new URL(url).searchParams;
+  assert.equal(params.get('title'), 'title');
+  assert.equal(params.get('body'), 'short body');
+  assert.equal(params.get('labels'), 'bug');
+});
+
+test('buildDiagnosticsIssueURL trims an oversized body to fit the cap and says so', () => {
+  const hugeBody = 'x'.repeat(50_000);
+  const { url, truncated } = buildDiagnosticsIssueURL('title', hugeBody, 2000);
+  assert.equal(truncated, true);
+  assert.ok(url.length <= 2000, `expected url.length <= 2000, got ${String(url.length)}`);
+  const params = new URL(url).searchParams;
+  assert.match(params.get('body') ?? '', /truncated — the full report is on your clipboard/);
+});

--- a/erun-ui/frontend/src/app/diagnosticsIssue.ts
+++ b/erun-ui/frontend/src/app/diagnosticsIssue.ts
@@ -1,0 +1,112 @@
+import type { UIBuildDetails } from '@/types';
+
+import type { DiagnosticsReportContext } from './diagnosticsReport';
+
+// diagnosticsIssue turns the Diagnostics console's report into a prefilled
+// GitHub issue the operator reviews and edits before submitting — filing
+// itself stays a Submit-button action on github.com, never a silent `gh`
+// call from the desktop (no credentials, no confirmation step).
+const ERUN_ISSUE_URL = 'https://github.com/sophium/erun/issues/new';
+
+// GitHub and browsers cap a request URL in the single-digit-KB range; this
+// stays comfortably under that so the prefilled link always opens.
+export const DIAGNOSTICS_ISSUE_URL_MAX_LENGTH = 8000;
+
+const TRUNCATION_NOTICE = '\n\n… truncated — the full report is on your clipboard.';
+
+// diagnosticsIssueTitle prefills from the context's own identity rather than
+// leaving the title blank: an untitled issue is worse than no button.
+export function diagnosticsIssueTitle(context: DiagnosticsReportContext): string {
+  switch (context.kind) {
+    case 'environment': {
+      const target = `${context.tenant}/${context.environment}`;
+      return context.status ? `${target}: ${context.status}` : `${target}: diagnostics`;
+    }
+    case 'orchestrator': {
+      const { orchestrator } = context;
+      return orchestrator.status === 'running'
+        ? `Orchestrator ${orchestrator.name}: diagnostics`
+        : `Orchestrator ${orchestrator.name}: ${orchestrator.status}`;
+    }
+    case 'app':
+      return 'ERun desktop: diagnostics';
+  }
+}
+
+function buildLine(build: UIBuildDetails | null): string {
+  if (!build) {
+    return '- erun version: unknown';
+  }
+  const extras = [build.commit, build.date].filter(Boolean).join(' ');
+  return `- erun version: ${build.version}${extras ? ` (${extras})` : ''}`;
+}
+
+// diagnosticsIssueBody mirrors the erun-file-issue skill's own template (What
+// happened / What you expected / Reproduction / Environment) so a
+// desktop-filed issue reads like one a human filed by hand, with the
+// evidence the operator would otherwise have had to copy in themselves
+// attached as its own section rather than dumped in place of the narrative.
+export function diagnosticsIssueBody(report: string, build: UIBuildDetails | null): string {
+  return [
+    '## What happened',
+    '',
+    '<describe what you observed>',
+    '',
+    '## What you expected',
+    '',
+    '<describe what you expected instead>',
+    '',
+    '## Reproduction',
+    '',
+    '<steps to reproduce>',
+    '',
+    '## Environment',
+    '',
+    buildLine(build),
+    '- context: desktop app',
+    '',
+    '## Diagnostics evidence',
+    '',
+    '```',
+    report.trimEnd(),
+    '```',
+  ].join('\n');
+}
+
+function encodeIssueURL(title: string, body: string): string {
+  return `${ERUN_ISSUE_URL}?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}&labels=bug`;
+}
+
+export interface DiagnosticsIssuePrefill {
+  url: string;
+  truncated: boolean;
+}
+
+// buildDiagnosticsIssueURL trims the body — never the title — down to the
+// longest prefix whose encoded URL still fits the cap, appending a notice
+// that the untrimmed report is on the clipboard so nothing is silently lost.
+export function buildDiagnosticsIssueURL(
+  title: string,
+  body: string,
+  maxLength: number = DIAGNOSTICS_ISSUE_URL_MAX_LENGTH,
+): DiagnosticsIssuePrefill {
+  const full = encodeIssueURL(title, body);
+  if (full.length <= maxLength) {
+    return { url: full, truncated: false };
+  }
+  let lo = 0;
+  let hi = body.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    const candidate = encodeIssueURL(title, `${body.slice(0, mid)}${TRUNCATION_NOTICE}`);
+    if (candidate.length <= maxLength) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return {
+    url: encodeIssueURL(title, `${body.slice(0, lo)}${TRUNCATION_NOTICE}`),
+    truncated: true,
+  };
+}

--- a/erun-ui/frontend/src/app/diagnosticsReport.test.ts
+++ b/erun-ui/frontend/src/app/diagnosticsReport.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { formatDiagnosticsReport } from './diagnosticsReport';
+import type { OrchestratorInfo } from './slices/orchestratorsSlice';
+
+function orchestrator(overrides: Partial<OrchestratorInfo> = {}): OrchestratorInfo {
+  return {
+    id: 'erun-issues',
+    name: 'erun-issues',
+    environments: [{ tenant: 'erun', environment: 'ux', directory: '/tmp/erun-ux' }],
+    tenants: ['erun'],
+    directories: ['/tmp/erun-ux'],
+    sessionId: 42,
+    status: 'running',
+    busy: false,
+    transient: false,
+    shellRunning: false,
+    shellCommand: '',
+    shellStartedAtUnix: 0,
+    ...overrides,
+  };
+}
+
+// The defect this report exists to fix (#1241): the panel derived its context
+// from the sidebar's env selection alone, so an orchestrator session — which
+// never touches that selection — rendered the environment-shaped report's
+// "nothing selected" fallback. Every orchestrator report must carry the
+// orchestrator's own identity instead, never that string.
+test('an orchestrator context never emits "environment: none selected"', () => {
+  const report = formatDiagnosticsReport({
+    generatedAt: '2026-08-24T00:00:00.000Z',
+    build: null,
+    context: {
+      kind: 'orchestrator',
+      orchestrator: orchestrator(),
+      linkedEnvironments: [{ tenant: 'erun', environment: 'ux', status: '' }],
+      appLog: null,
+    },
+    uiTrace: [],
+  });
+
+  assert.doesNotMatch(report, /environment: none selected/);
+  assert.match(report, /orchestrator: erun-issues \(erun-issues\)/);
+  assert.match(report, /status: running/);
+  assert.match(report, /erun \/ ux/);
+});
+
+test('an orchestrator context surfaces its background shell and app log', () => {
+  const report = formatDiagnosticsReport({
+    generatedAt: '2026-08-24T00:00:00.000Z',
+    build: null,
+    context: {
+      kind: 'orchestrator',
+      orchestrator: orchestrator({ shellRunning: true, shellCommand: 'npm test' }),
+      linkedEnvironments: [],
+      appLog: { available: true, content: 'ERUN_LOG_MARKER', path: '/tmp/erun-app.log' },
+    },
+    uiTrace: [],
+  });
+
+  assert.match(report, /background shell: npm test/);
+  assert.match(report, /ERUN_LOG_MARKER/);
+  assert.match(report, /linked environments:\n {2}\(none\)/);
+});
+
+test('an environment context reports the selected env, status, and trace', () => {
+  const report = formatDiagnosticsReport({
+    generatedAt: '2026-08-24T00:00:00.000Z',
+    build: { version: '1.0.0' },
+    context: {
+      kind: 'environment',
+      tenant: 'acme',
+      environment: 'dev',
+      env: { name: 'dev', type: 'local-agent' },
+      status: 'failed',
+      trace: { available: true, content: 'deploy failed\n', path: '/trace.log' },
+    },
+    uiTrace: [],
+  });
+
+  assert.match(report, /environment: acme \/ dev \(local-agent\)/);
+  assert.match(report, /status: failed/);
+  assert.match(report, /deploy failed/);
+});
+
+test('an app context reports the desktop log when neither an env nor an orchestrator is active', () => {
+  const report = formatDiagnosticsReport({
+    generatedAt: '2026-08-24T00:00:00.000Z',
+    build: null,
+    context: { kind: 'app', appLog: { available: false, reason: 'no log captured yet', path: '' } },
+    uiTrace: [],
+  });
+
+  assert.doesNotMatch(report, /environment: none selected/);
+  assert.match(report, /no log captured yet/);
+});

--- a/erun-ui/frontend/src/app/diagnosticsReport.ts
+++ b/erun-ui/frontend/src/app/diagnosticsReport.ts
@@ -1,17 +1,44 @@
-import type { UIBuildDetails, UIEnvironment, UIEnvTrace, UISelection } from '@/types';
+import type { UIAppLog, UIBuildDetails, UIEnvironment, UIEnvTrace } from '@/types';
 
+import type { OrchestratorInfo } from './slices/orchestratorsSlice';
 import { formatUITrace, type UITraceEntry } from './uiTraceBuffer';
 
-// The Diagnostics console's one-click, paste-ready bug report. An unavailable
-// trace keeps its reason line — "unreachable" is itself evidence. Mirrors the
-// Activities drawer's "Copy failure report".
+// The Diagnostics console's one-click, paste-ready bug report. It carries
+// whatever evidence the current DiagnosticsContext resolves to, rather than a
+// single environment-shaped report: an orchestrator session used to leave
+// this reading "environment: none selected" with no trace at all (#1241),
+// which is the empty-panel bug this contract exists to fix. An unavailable
+// trace/log keeps its reason line — "unreachable" is itself evidence.
+// Mirrors the Activities drawer's "Copy failure report".
+export interface DiagnosticsLinkedEnv {
+  tenant: string;
+  environment: string;
+  // The env's real-status label ('failed' | 'stopped' | 'runtime-stopped'),
+  // or '' when nothing is known to be wrong.
+  status: string;
+}
+
+export type DiagnosticsReportContext =
+  | {
+      kind: 'environment';
+      tenant: string;
+      environment: string;
+      env: UIEnvironment | null;
+      status: string;
+      trace: UIEnvTrace | null;
+    }
+  | {
+      kind: 'orchestrator';
+      orchestrator: OrchestratorInfo;
+      linkedEnvironments: DiagnosticsLinkedEnv[];
+      appLog: UIAppLog | null;
+    }
+  | { kind: 'app'; appLog: UIAppLog | null };
+
 export interface DiagnosticsReportInput {
   generatedAt: string;
   build: UIBuildDetails | null;
-  selection: UISelection | null;
-  environment: UIEnvironment | null;
-  envStatus: string;
-  trace: UIEnvTrace | null;
+  context: DiagnosticsReportContext;
   uiTrace: UITraceEntry[];
 }
 
@@ -20,15 +47,7 @@ export function formatDiagnosticsReport(input: DiagnosticsReportInput): string {
   if (input.build) {
     lines.push(buildLine(input.build));
   }
-  lines.push(environmentLine(input.selection, input.environment));
-  if (input.envStatus) {
-    lines.push(`status: ${input.envStatus}`);
-  }
-  lines.push('', `── erun trace — ${input.trace?.path ?? 'unavailable'} ──`);
-  if (input.trace?.notice) {
-    lines.push(`note: ${input.trace.notice}`);
-  }
-  lines.push(traceBlock(input.trace));
+  lines.push(...contextLines(input.context));
   lines.push('', `── UI trace (${String(input.uiTrace.length)} entries) ──`);
   lines.push(input.uiTrace.length > 0 ? formatUITrace(input.uiTrace) : 'no UI activity recorded');
   return `${lines.join('\n')}\n`;
@@ -39,6 +58,32 @@ function buildLine(build: UIBuildDetails): string {
   return `app: ${build.version}${extras ? ` (${extras})` : ''}`;
 }
 
+function contextLines(context: DiagnosticsReportContext): string[] {
+  switch (context.kind) {
+    case 'environment':
+      return environmentContextLines(context);
+    case 'orchestrator':
+      return orchestratorContextLines(context);
+    case 'app':
+      return appLogLines(context.appLog);
+  }
+}
+
+function environmentContextLines(
+  context: Extract<DiagnosticsReportContext, { kind: 'environment' }>,
+): string[] {
+  const lines = [environmentLine(context.tenant, context.environment, context.env)];
+  if (context.status) {
+    lines.push(`status: ${context.status}`);
+  }
+  lines.push('', `── erun trace — ${context.trace?.path ?? 'unavailable'} ──`);
+  if (context.trace?.notice) {
+    lines.push(`note: ${context.trace.notice}`);
+  }
+  lines.push(traceBlock(context.trace));
+  return lines;
+}
+
 function traceBlock(trace: UIEnvTrace | null): string {
   if (trace?.available && trace.content) {
     return trace.content.trimEnd();
@@ -46,12 +91,42 @@ function traceBlock(trace: UIEnvTrace | null): string {
   return trace?.reason ?? 'no trace loaded';
 }
 
-function environmentLine(selection: UISelection | null, env: UIEnvironment | null): string {
-  if (!selection) {
-    return 'environment: none selected';
-  }
+function environmentLine(tenant: string, environment: string, env: UIEnvironment | null): string {
   const extras = [env?.type, env?.runtimeVersion ? `runtime ${env.runtimeVersion}` : '']
     .filter(Boolean)
     .join(', ');
-  return `environment: ${selection.tenant} / ${selection.environment}${extras ? ` (${extras})` : ''}`;
+  return `environment: ${tenant} / ${environment}${extras ? ` (${extras})` : ''}`;
+}
+
+function orchestratorContextLines(
+  context: Extract<DiagnosticsReportContext, { kind: 'orchestrator' }>,
+): string[] {
+  const { orchestrator } = context;
+  const lines = [
+    `orchestrator: ${orchestrator.name} (${orchestrator.id})`,
+    `status: ${orchestrator.status}${orchestrator.busy ? ', busy' : ''}`,
+  ];
+  if (orchestrator.shellRunning) {
+    lines.push(`background shell: ${orchestrator.shellCommand || '(command unknown)'}`);
+  }
+  lines.push('', 'linked environments:');
+  if (context.linkedEnvironments.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const env of context.linkedEnvironments) {
+      lines.push(`  - ${env.tenant} / ${env.environment}${env.status ? ` (${env.status})` : ''}`);
+    }
+  }
+  lines.push('', ...appLogLines(context.appLog));
+  return lines;
+}
+
+function appLogLines(appLog: UIAppLog | null): string[] {
+  const lines = [`── app log — ${appLog?.path ?? 'unavailable'} ──`];
+  if (appLog?.available && appLog.content) {
+    lines.push(appLog.content.trimEnd());
+  } else {
+    lines.push(appLog?.reason ?? 'no log loaded');
+  }
+  return lines;
 }

--- a/erun-ui/frontend/src/app/diagnosticsReportAssembly.ts
+++ b/erun-ui/frontend/src/app/diagnosticsReportAssembly.ts
@@ -1,0 +1,106 @@
+import * as React from 'react';
+
+import { stateApi } from '@/app/api/stateApi';
+import type { DiagnosticsLinkedEnv, DiagnosticsReportContext } from '@/app/diagnosticsReport';
+import { formatDiagnosticsReport } from '@/app/diagnosticsReport';
+import { useAppSelector } from '@/app/hooks';
+import type { DiagnosticsContext } from '@/app/selectors';
+import type { OrchestratorInfo } from '@/app/slices/orchestratorsSlice';
+import { uiTraceEntries } from '@/app/uiTraceBuffer';
+import { selectionKey } from '@/app/versionSuggestions';
+import type { UIBuildDetails } from '@/types';
+
+import { LoadAppLog, LoadEnvTrace } from '../../wailsjs/go/main/App';
+
+// diagnosticsReportAssembly turns a DiagnosticsContext into the read-only
+// evidence formatDiagnosticsReport needs. It is the one place the Diagnostics
+// console's Copy report and Report an erun issue actions both read from, so
+// the two can never drift into carrying different evidence for the same
+// context.
+
+// useLinkedEnvironments reads the real-status label for each of an
+// orchestrator's linked environments, so its report and title reflect an
+// actual failure rather than only the orchestrator's own running/stopped bit.
+export function useLinkedEnvironments(
+  orchestrator: OrchestratorInfo | null,
+): DiagnosticsLinkedEnv[] {
+  return useAppSelector((state) => {
+    if (!orchestrator) {
+      return [];
+    }
+    return orchestrator.environments.map((env) => ({
+      tenant: env.tenant,
+      environment: env.environment,
+      status: state.envStatus.statusByEnv[selectionKey(env)] ?? '',
+    }));
+  });
+}
+
+export function useDiagnosticsReportAssembly(context: DiagnosticsContext): {
+  build: UIBuildDetails | null;
+  assemble: () => Promise<{ report: string; reportContext: DiagnosticsReportContext }>;
+} {
+  const selectInitialState = React.useMemo(
+    () => stateApi.endpoints.getInitialState.select(undefined),
+    [],
+  );
+  const build = useAppSelector((state) => selectInitialState(state).data?.build ?? null);
+  const environment = useAppSelector((state) => {
+    if (context.kind !== 'environment') {
+      return null;
+    }
+    const tenant = state.tenants.tenants.find((entry) => entry.name === context.tenant);
+    return tenant?.environments.find((env) => env.name === context.environment) ?? null;
+  });
+  const envStatus = useAppSelector((state) =>
+    context.kind === 'environment'
+      ? (state.envStatus.statusByEnv[
+          selectionKey({ tenant: context.tenant, environment: context.environment })
+        ] ?? '')
+      : '',
+  );
+  const linkedEnvironments = useLinkedEnvironments(
+    context.kind === 'orchestrator' ? context.orchestrator : null,
+  );
+
+  const assemble = React.useCallback(async (): Promise<{
+    report: string;
+    reportContext: DiagnosticsReportContext;
+  }> => {
+    let reportContext: DiagnosticsReportContext;
+    if (context.kind === 'environment') {
+      const trace = await LoadEnvTrace({
+        tenant: context.tenant,
+        environment: context.environment,
+      }).catch(() => null);
+      reportContext = {
+        kind: 'environment',
+        tenant: context.tenant,
+        environment: context.environment,
+        env: environment,
+        status: envStatus,
+        trace,
+      };
+    } else if (context.kind === 'orchestrator') {
+      const appLog = await LoadAppLog().catch(() => null);
+      reportContext = {
+        kind: 'orchestrator',
+        orchestrator: context.orchestrator,
+        linkedEnvironments,
+        appLog,
+      };
+    } else {
+      const appLog = await LoadAppLog().catch(() => null);
+      reportContext = { kind: 'app', appLog };
+    }
+    const report = formatDiagnosticsReport({
+      generatedAt: new Date().toISOString(),
+      build,
+      context: reportContext,
+      uiTrace: uiTraceEntries(),
+    });
+    return { report, reportContext };
+  }, [context, environment, envStatus, linkedEnvironments, build]);
+
+  return { build, assemble };
+}

--- a/erun-ui/frontend/src/app/selectors.ts
+++ b/erun-ui/frontend/src/app/selectors.ts
@@ -166,6 +166,31 @@ export interface ReviewEnvTarget {
   environment: string;
 }
 
+// DiagnosticsContext names which evidence the Diagnostics console shows: an
+// orchestrator's own state, the selected environment's, or — when neither is
+// active — the desktop app itself, so the panel is never blank.
+export type DiagnosticsContext =
+  | { kind: 'orchestrator'; orchestrator: OrchestratorInfo }
+  | { kind: 'environment'; tenant: string; environment: string }
+  | { kind: 'app' };
+
+// selectDiagnosticsContext mirrors selectReviewEnvTargets' own precedence
+// (orchestrator session over sidebar selection) rather than introducing a
+// second notion of "what's active" — an orchestrator session used to leave
+// the Diagnostics panel reading "environment: none selected" with no trace,
+// because it derived its context from state.selection.selected alone (#1241).
+export const selectDiagnosticsContext = (state: RootState): DiagnosticsContext => {
+  const orchestrator = selectActiveSessionOrchestrator(state);
+  if (orchestrator) {
+    return { kind: 'orchestrator', orchestrator };
+  }
+  const selected = state.selection.selected;
+  if (selected) {
+    return { kind: 'environment', tenant: selected.tenant, environment: selected.environment };
+  }
+  return { kind: 'app' };
+};
+
 // selectReviewEnvTargets resolves which environments the diff panel shows: an
 // orchestrator session's linked environments in its configured order, else the
 // single selected environment. A single environment is the one-entry case, so

--- a/erun-ui/frontend/src/components/app/DebugPanel.AppLog.tsx
+++ b/erun-ui/frontend/src/components/app/DebugPanel.AppLog.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+
+import { useLinkedEnvironments } from '@/app/diagnosticsReportAssembly';
+import type { OrchestratorInfo } from '@/app/slices/orchestratorsSlice';
+import type { UIAppLog } from '@/types';
+
+import { LoadAppLog } from '../../../wailsjs/go/main/App';
+import { useStickToBottom } from './DebugPanel.hooks';
+import { PrimaryPaneToolbar } from './DebugPanel.shared';
+
+const APP_LOG_POLL_MS = 2000;
+
+function useAppLogPoll(): { appLog: UIAppLog | null; refresh: () => void } {
+  const [appLog, setAppLog] = React.useState<UIAppLog | null>(null);
+  const refresh = React.useCallback(() => {
+    void LoadAppLog()
+      .then((next) => {
+        setAppLog(next);
+      })
+      .catch(() => {
+        setAppLog(null);
+      });
+  }, []);
+  React.useEffect(() => {
+    refresh();
+    const timer = window.setInterval(refresh, APP_LOG_POLL_MS);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [refresh]);
+  return { appLog, refresh };
+}
+
+// AppLogPane is the desktop's own bounded log tail — evidence for the App
+// context, and the tail of the orchestrator context's own pane below it.
+export function AppLogPane({ label }: { label: string }): React.ReactElement {
+  const { appLog, refresh } = useAppLogPoll();
+  const content = appLog?.available ? (appLog.content ?? '') : '';
+  const { outputRef, handleScroll } = useStickToBottom(content);
+  return (
+    <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)]">
+      <PrimaryPaneToolbar label={appLog?.path ?? ''} content={content} onRefresh={refresh} />
+      <div
+        ref={outputRef}
+        onScroll={handleScroll}
+        className="min-h-0 overflow-auto px-3 pb-2 font-mono text-[11px] leading-[1.35] text-[oklch(0.82_0_0)]"
+        aria-label={`${label} output`}
+      >
+        {appLog ? (
+          appLog.available ? (
+            <pre className="m-0 font-mono text-[11px] leading-[1.35] break-words whitespace-pre-wrap">
+              {content}
+            </pre>
+          ) : (
+            <p className="m-0 text-[oklch(0.6_0_0)]">{appLog.reason ?? 'No log available.'}</p>
+          )
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+// OrchestratorPane is the orchestrator context: its identity and linked
+// environments up top (the evidence an env trace can't carry — an
+// orchestrator has no selection to load one for), the desktop log below,
+// since a session or shell fault is desktop-side, not env-side.
+export function OrchestratorPane({
+  orchestrator,
+}: {
+  orchestrator: OrchestratorInfo;
+}): React.ReactElement {
+  const linkedEnvironments = useLinkedEnvironments(orchestrator);
+  return (
+    <div
+      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)]"
+      aria-label="orchestrator diagnostics"
+    >
+      <div className="border-b border-[oklch(0.14_0_0)] px-3 py-1.5 text-[11px] text-[oklch(0.76_0_0)]">
+        <p className="m-0">
+          <span className="font-medium">{orchestrator.name}</span> — {orchestrator.status}
+          {orchestrator.busy ? ', busy' : ''}
+          {orchestrator.shellRunning
+            ? `, background shell: ${orchestrator.shellCommand || '(command unknown)'}`
+            : ''}
+        </p>
+        <ul className="m-0 mt-1 list-none p-0 text-[oklch(0.6_0_0)]">
+          {linkedEnvironments.length === 0 ? (
+            <li>no linked environments</li>
+          ) : (
+            linkedEnvironments.map((env) => (
+              <li key={`${env.tenant}/${env.environment}`}>
+                {env.tenant} / {env.environment}
+                {env.status ? ` — ${env.status}` : ''}
+              </li>
+            ))
+          )}
+        </ul>
+      </div>
+      <AppLogPane label="orchestrator" />
+    </div>
+  );
+}

--- a/erun-ui/frontend/src/components/app/DebugPanel.ErunTrace.tsx
+++ b/erun-ui/frontend/src/components/app/DebugPanel.ErunTrace.tsx
@@ -1,0 +1,179 @@
+import * as React from 'react';
+
+import { useErunTraceBaseline } from '@/app/erunTraceBaseline';
+import { cn } from '@/lib/utils';
+import type { UIEnvTrace } from '@/types';
+
+import { LoadEnvTrace } from '../../../wailsjs/go/main/App';
+import { useStickToBottom } from './DebugPanel.hooks';
+import { PrimaryPaneToolbar } from './DebugPanel.shared';
+
+const ERUN_TRACE_POLL_MS = 2000;
+
+function useEnvTracePoll(
+  tenant: string,
+  environment: string,
+): { trace: UIEnvTrace | null; refresh: () => void } {
+  const [trace, setTrace] = React.useState<UIEnvTrace | null>(null);
+  const refresh = React.useCallback(() => {
+    if (!tenant || !environment) {
+      setTrace(null);
+      return;
+    }
+    void LoadEnvTrace({ tenant, environment })
+      .then((next) => {
+        setTrace(next);
+      })
+      .catch(() => {
+        setTrace(null);
+      });
+  }, [tenant, environment]);
+  React.useEffect(() => {
+    refresh();
+    const timer = window.setInterval(refresh, ERUN_TRACE_POLL_MS);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [refresh]);
+  return { trace, refresh };
+}
+
+export function ErunTracePane({
+  tenant,
+  environment,
+}: {
+  tenant: string;
+  environment: string;
+}): React.ReactElement {
+  const { trace, refresh } = useEnvTracePoll(tenant, environment);
+  const content = trace?.content ?? '';
+  // Clear is view-only: Copy and Copy report read the full content, so a
+  // cleared view never truncates a bug report.
+  const { cleared, rotatedOut, visibleContent, clear, showAll } = useErunTraceBaseline(
+    `${tenant}/${environment}`,
+    content,
+  );
+  const { outputRef, handleScroll } = useStickToBottom(visibleContent);
+
+  // Toolbar and the cleared notice sit in their own grid rows, outside the
+  // scroll region, so stick-to-bottom cannot scroll the actions out of view.
+  return (
+    <div
+      className={cn(
+        'grid min-h-0',
+        cleared ? 'grid-rows-[auto_auto_minmax(0,1fr)]' : 'grid-rows-[auto_minmax(0,1fr)]',
+      )}
+    >
+      <PrimaryPaneToolbar
+        label={erunTraceLabel(tenant, environment, trace)}
+        content={content}
+        clear={{ canClear: content.trim().length > 0, onClear: clear }}
+        onRefresh={refresh}
+      />
+      {cleared && <ClearedNotice rotatedOut={rotatedOut} onShowAll={showAll} />}
+      <div
+        ref={outputRef}
+        onScroll={handleScroll}
+        className="min-h-0 overflow-auto px-3 pb-2 font-mono text-[11px] leading-[1.35] text-[oklch(0.82_0_0)]"
+        aria-label="erun trace output"
+      >
+        <ErunTraceBody
+          tenant={tenant}
+          environment={environment}
+          trace={trace}
+          visibleContent={visibleContent}
+          cleared={cleared}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ClearedNotice explains why earlier lines vanished after Clear and offers a
+// one-click return to the full view: Clear only hides scrollback, the
+// persistent log is untouched and always recoverable.
+function ClearedNotice({
+  rotatedOut,
+  onShowAll,
+}: {
+  rotatedOut: boolean;
+  onShowAll: () => void;
+}): React.ReactElement {
+  return (
+    <div className="flex items-center justify-between gap-2 border-b border-[oklch(0.14_0_0)] px-3 py-1 text-[10px] text-[oklch(0.55_0_0)]">
+      <span className="min-w-0 truncate">
+        {rotatedOut
+          ? 'Cleared entries have rotated out of the log — showing all.'
+          : 'Showing entries since you cleared.'}
+      </span>
+      <button
+        type="button"
+        className="flex-none cursor-pointer rounded border-0 bg-transparent px-1 text-[10px] text-[oklch(0.7_0_0)] underline-offset-2 hover:underline"
+        onClick={onShowAll}
+      >
+        Show all
+      </button>
+    </div>
+  );
+}
+
+function erunTraceLabel(tenant: string, environment: string, trace: UIEnvTrace | null): string {
+  if (!tenant || !environment) {
+    return '';
+  }
+  return `${tenant} / ${environment} — ${trace?.path ?? ''}`;
+}
+
+function ErunTraceBody({
+  tenant,
+  environment,
+  trace,
+  visibleContent,
+  cleared,
+}: {
+  tenant: string;
+  environment: string;
+  trace: UIEnvTrace | null;
+  visibleContent: string;
+  cleared: boolean;
+}): React.ReactElement | null {
+  if (!tenant || !environment) {
+    return (
+      <p className="m-0 text-[oklch(0.6_0_0)]">Select an environment to read its erun trace.</p>
+    );
+  }
+  if (!trace) {
+    return null;
+  }
+  if (trace.available) {
+    // When cleared and nothing new has arrived yet, say so rather than
+    // render a blank pane.
+    return (
+      <>
+        <TraceNotice notice={trace.notice} />
+        {cleared && visibleContent.length === 0 ? (
+          <p className="m-0 text-[oklch(0.6_0_0)]">No new entries since you cleared.</p>
+        ) : (
+          <pre className="m-0 font-mono text-[11px] leading-[1.35] break-words whitespace-pre-wrap">
+            {visibleContent}
+          </pre>
+        )}
+      </>
+    );
+  }
+  return (
+    <>
+      <TraceNotice notice={trace.notice} />
+      <p className="m-0 text-[oklch(0.6_0_0)]">{trace.reason ?? 'No trace available.'}</p>
+    </>
+  );
+}
+
+// TraceNotice surfaces a non-fatal caveat (e.g. a remote env's in-pod trace
+// could not be included); the content shown is still real.
+function TraceNotice({ notice }: { notice?: string }): React.ReactElement | null {
+  if (!notice) {
+    return null;
+  }
+  return <p className="m-0 mb-1 text-[oklch(0.6_0_0)] italic">{notice}</p>;
+}

--- a/erun-ui/frontend/src/components/app/DebugPanel.Report.tsx
+++ b/erun-ui/frontend/src/components/app/DebugPanel.Report.tsx
@@ -1,0 +1,105 @@
+import { Bug, CheckCircle2, ClipboardList } from 'lucide-react';
+import * as React from 'react';
+
+import {
+  buildDiagnosticsIssueURL,
+  diagnosticsIssueBody,
+  diagnosticsIssueTitle,
+} from '@/app/diagnosticsIssue';
+import { useDiagnosticsReportAssembly } from '@/app/diagnosticsReportAssembly';
+import type { DiagnosticsContext } from '@/app/selectors';
+import { Button } from '@/components/ui/button';
+
+import { BrowserOpenURL, ClipboardSetText } from '../../../wailsjs/runtime/runtime';
+
+// The Diagnostics console's two report actions: copy the context's evidence
+// as text, or open it as a prefilled github.com/sophium/erun issue. Both
+// share useDiagnosticsReportAssembly so they can never carry different
+// evidence for the same context.
+
+// CopyReportButton produces the one-click bug report. It re-reads the
+// context's evidence fresh rather than reusing a polled copy, so the report
+// stays current even between poll ticks.
+export function CopyReportButton({ context }: { context: DiagnosticsContext }): React.ReactElement {
+  const { assemble } = useDiagnosticsReportAssembly(context);
+  const [status, setStatus] = React.useState('');
+
+  const copyReport = React.useCallback(() => {
+    assemble()
+      .then(({ report }) => ClipboardSetText(report))
+      .then(() => {
+        setStatus('Copied');
+        window.setTimeout(() => {
+          setStatus('');
+        }, 1400);
+      })
+      .catch(() => {
+        setStatus('Copy failed');
+      });
+  }, [assemble]);
+
+  return (
+    <Button
+      className="h-6 px-2 text-[11px] [&_svg]:size-3.5"
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={copyReport}
+    >
+      {status === 'Copied' ? (
+        <CheckCircle2 aria-hidden="true" />
+      ) : (
+        <ClipboardList aria-hidden="true" />
+      )}
+      {status || 'Copy report'}
+    </Button>
+  );
+}
+
+// ReportIssueButton opens a prefilled github.com/sophium/erun issue in the
+// browser rather than shelling out to `gh`: the desktop holds no GitHub
+// token, and the operator reviewing and clicking Submit on github.com is the
+// consent step this needs, not a silent file-on-click. The full,
+// untruncated report is always copied to the clipboard too, so a body
+// trimmed to fit the URL length cap never silently drops evidence.
+export function ReportIssueButton({
+  context,
+}: {
+  context: DiagnosticsContext;
+}): React.ReactElement {
+  const { build, assemble } = useDiagnosticsReportAssembly(context);
+  const [status, setStatus] = React.useState('');
+
+  const reportIssue = React.useCallback(() => {
+    assemble()
+      .then(async ({ report, reportContext }) => {
+        const title = diagnosticsIssueTitle(reportContext);
+        const body = diagnosticsIssueBody(report, build);
+        const { url } = buildDiagnosticsIssueURL(title, body);
+        BrowserOpenURL(url);
+        await ClipboardSetText(report);
+      })
+      .then(() => {
+        setStatus('Opened — full report copied');
+        window.setTimeout(() => {
+          setStatus('');
+        }, 2000);
+      })
+      .catch(() => {
+        setStatus('Could not open issue');
+      });
+  }, [assemble, build]);
+
+  return (
+    <Button
+      className="h-6 px-2 text-[11px] [&_svg]:size-3.5"
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={reportIssue}
+    >
+      {status ? <CheckCircle2 aria-hidden="true" /> : <Bug aria-hidden="true" />}
+      {status || 'Report an erun issue'}
+    </Button>
+  );
+}

--- a/erun-ui/frontend/src/components/app/DebugPanel.UITrace.tsx
+++ b/erun-ui/frontend/src/components/app/DebugPanel.UITrace.tsx
@@ -1,0 +1,76 @@
+import { Trash2 } from 'lucide-react';
+import * as React from 'react';
+
+import {
+  clearUITrace,
+  formatUITrace,
+  uiTraceEntries,
+  type UITraceEntry,
+  uiTraceGeneration,
+} from '@/app/uiTraceBuffer';
+import { Button } from '@/components/ui/button';
+
+import { useCopyAction, useStickToBottom } from './DebugPanel.hooks';
+import { CopyButton } from './DebugPanel.shared';
+
+// The UI trace buffer lives outside Redux (see uiTraceBuffer.ts), so this
+// pane polls it instead of subscribing to a selector. It is context-agnostic
+// and stays available in every DiagnosticsContext.
+export function UITracePane(): React.ReactElement {
+  const [entries, setEntries] = React.useState<UITraceEntry[]>(() => uiTraceEntries());
+  const generationRef = React.useRef(uiTraceGeneration());
+
+  React.useEffect(() => {
+    const timer = window.setInterval(() => {
+      const generation = uiTraceGeneration();
+      if (generation !== generationRef.current) {
+        generationRef.current = generation;
+        setEntries(uiTraceEntries());
+      }
+    }, 500);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  const text = formatUITrace(entries);
+  const { outputRef, handleScroll } = useStickToBottom(text);
+  const { copyStatus, copy } = useCopyAction(text);
+
+  // Actions are pinned outside the scroll region — same rationale as the
+  // erun trace toolbar.
+  return (
+    <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)]">
+      <div className="flex items-center justify-end gap-1 px-3 pt-1.5 pb-1">
+        <CopyButton copyStatus={copyStatus} disabled={!text.trim()} onCopy={copy} />
+        <Button
+          className="h-6 px-2 text-[11px] [&_svg]:size-3.5"
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            clearUITrace();
+            setEntries([]);
+          }}
+        >
+          <Trash2 aria-hidden="true" />
+          Clear
+        </Button>
+      </div>
+      <div
+        ref={outputRef}
+        onScroll={handleScroll}
+        className="min-h-0 overflow-auto px-3 pb-2 font-mono text-[11px] leading-[1.35] text-[oklch(0.82_0_0)]"
+        aria-label="UI trace output"
+      >
+        {entries.length === 0 ? (
+          <p className="m-0 text-[oklch(0.6_0_0)]">No UI activity recorded yet.</p>
+        ) : (
+          <pre className="m-0 font-mono text-[11px] leading-[1.35] break-words whitespace-pre-wrap">
+            {text}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/erun-ui/frontend/src/components/app/DebugPanel.hooks.ts
+++ b/erun-ui/frontend/src/components/app/DebugPanel.hooks.ts
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+import { ClipboardSetText } from '../../../wailsjs/runtime/runtime';
+
+// Shared pane plumbing every Diagnostics console tab (erun trace,
+// orchestrator, app log, UI trace) reuses: stick-to-bottom scrolling and a
+// Copy action bound to the pane's own raw content.
+
+export function useStickToBottom(content: string): {
+  outputRef: React.RefObject<HTMLDivElement | null>;
+  handleScroll: React.UIEventHandler<HTMLDivElement>;
+} {
+  const outputRef = React.useRef<HTMLDivElement>(null);
+  const stuckToBottomRef = React.useRef(true);
+  const handleScroll = React.useCallback(() => {
+    const el = outputRef.current;
+    if (!el) {
+      return;
+    }
+    stuckToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight <= 4;
+  }, []);
+  React.useEffect(() => {
+    const el = outputRef.current;
+    if (el && stuckToBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [content]);
+  return { outputRef, handleScroll };
+}
+
+export function useCopyAction(text: string): { copyStatus: string; copy: () => void } {
+  const [copyStatus, setCopyStatus] = React.useState('');
+  const copy = React.useCallback(() => {
+    if (!text.trim()) {
+      return;
+    }
+    void ClipboardSetText(text)
+      .then(() => {
+        setCopyStatus('Copied');
+        window.setTimeout(() => {
+          setCopyStatus('');
+        }, 1400);
+      })
+      .catch(() => {
+        setCopyStatus('Copy failed');
+      });
+  }, [text]);
+  return { copyStatus, copy };
+}

--- a/erun-ui/frontend/src/components/app/DebugPanel.shared.tsx
+++ b/erun-ui/frontend/src/components/app/DebugPanel.shared.tsx
@@ -1,0 +1,84 @@
+import { CheckCircle2, Copy, RefreshCw, Trash2 } from 'lucide-react';
+import * as React from 'react';
+
+import { Button } from '@/components/ui/button';
+
+import { useCopyAction } from './DebugPanel.hooks';
+
+// Shared pane chrome every Diagnostics console tab reuses: a Copy button
+// and the toolbar row that sits outside the scroll region so it can never be
+// pushed out of view by always-on capture.
+
+export function CopyButton({
+  copyStatus,
+  disabled,
+  onCopy,
+}: {
+  copyStatus: string;
+  disabled: boolean;
+  onCopy: () => void;
+}): React.ReactElement {
+  return (
+    <Button
+      className="h-6 px-2 text-[11px] [&_svg]:size-3.5"
+      type="button"
+      variant="ghost"
+      size="sm"
+      disabled={disabled}
+      onClick={onCopy}
+    >
+      {copyStatus === 'Copied' ? <CheckCircle2 aria-hidden="true" /> : <Copy aria-hidden="true" />}
+      {copyStatus || 'Copy'}
+    </Button>
+  );
+}
+
+// clear is omitted entirely (rather than rendered disabled) for panes with no
+// clear behavior at all (the app/orchestrator log): a permanently-disabled
+// button with no explanation reads as broken, not as "not applicable here".
+export function PrimaryPaneToolbar({
+  label,
+  content,
+  clear,
+  onRefresh,
+}: {
+  label: string;
+  content: string;
+  clear?: { canClear: boolean; onClear: () => void };
+  onRefresh: () => void;
+}): React.ReactElement {
+  // Copy reads the full content, never a baselined/cleared view — a cleared
+  // pane must never produce a truncated bug report.
+  const { copyStatus, copy } = useCopyAction(content);
+  return (
+    <div className="flex items-center justify-between gap-2 px-3 pt-1.5 pb-1">
+      <span className="min-w-0 truncate text-[10px] text-[oklch(0.5_0_0)]">{label}</span>
+      <span className="flex flex-none items-center gap-1">
+        <Button
+          className="h-6 px-2 text-[11px] [&_svg]:size-3.5"
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onRefresh}
+        >
+          <RefreshCw aria-hidden="true" />
+          Refresh
+        </Button>
+        <CopyButton copyStatus={copyStatus} disabled={!content.trim()} onCopy={copy} />
+        {clear && (
+          <Button
+            className="h-6 px-2 text-[11px] [&_svg]:size-3.5"
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={!clear.canClear}
+            onClick={clear.onClear}
+          >
+            <Trash2 aria-hidden="true" />
+            Clear
+          </Button>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/erun-ui/frontend/src/components/app/DebugPanel.tsx
+++ b/erun-ui/frontend/src/components/app/DebugPanel.tsx
@@ -1,51 +1,60 @@
-import {
-  CheckCircle2,
-  ChevronDown,
-  ChevronUp,
-  ClipboardList,
-  Copy,
-  RefreshCw,
-  Trash2,
-} from 'lucide-react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import * as React from 'react';
 
-import { stateApi } from '@/app/api/stateApi';
-import { formatDiagnosticsReport } from '@/app/diagnosticsReport';
-import { useErunTraceBaseline } from '@/app/erunTraceBaseline';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { setDebugOpen, startDebugResize } from '@/app/layoutThunks';
-import {
-  clearUITrace,
-  formatUITrace,
-  uiTraceEntries,
-  type UITraceEntry,
-  uiTraceGeneration,
-} from '@/app/uiTraceBuffer';
-import { selectionKey } from '@/app/versionSuggestions';
+import { type DiagnosticsContext, selectDiagnosticsContext } from '@/app/selectors';
 import { ResizeHandle } from '@/components/app/ResizeHandle';
-import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import type { UIEnvTrace, UISelection } from '@/types';
 
-import { LoadEnvTrace } from '../../../wailsjs/go/main/App';
-import { ClipboardSetText } from '../../../wailsjs/runtime/runtime';
+import { AppLogPane, OrchestratorPane } from './DebugPanel.AppLog';
+import { ErunTracePane } from './DebugPanel.ErunTrace';
+import { CopyReportButton, ReportIssueButton } from './DebugPanel.Report';
+import { UITracePane } from './DebugPanel.UITrace';
 
-// DebugPanel is the Diagnostics console: two copyable surfaces meant to be
-// pasted into a bug report. The erun trace is always-on and covers commands
-// that ran before the console was opened (remote envs are reachability-gated);
-// the UI trace exists because the packaged WebView has no Redux DevTools.
+// DebugPanel is the Diagnostics console: it shows whatever evidence the
+// current DiagnosticsContext resolves to (an orchestrator's own state, the
+// selected environment's, or the desktop app's own log when neither is
+// active) rather than being hardwired to an environment selection — an
+// orchestrator session used to leave this panel reading "environment: none
+// selected" with no trace at all (#1241). Two copyable surfaces plus a report
+// button meant to be filed straight into the tracker: the primary pane is
+// always-on evidence for the active context, the UI trace exists because the
+// packaged WebView has no Redux DevTools and stays available in every
+// context.
 
 const debugSplitterClassName =
   'relative cursor-row-resize bg-[oklch(0.06_0_0)] before:absolute before:left-0 before:right-0 before:top-1 before:h-px before:bg-transparent before:transition-colors hover:before:bg-[oklch(0.36_0_0)] [.is-resizing-debug_&]:before:bg-[oklch(0.46_0_0)]';
 
-const ERUN_TRACE_POLL_MS = 2000;
+type DiagnosticsTab = 'primary' | 'ui';
 
-type DiagnosticsTab = 'erun' | 'ui';
+function primaryTabLabel(context: DiagnosticsContext): string {
+  switch (context.kind) {
+    case 'environment':
+      return 'erun trace';
+    case 'orchestrator':
+      return 'orchestrator';
+    case 'app':
+      return 'app log';
+  }
+}
+
+function PrimaryPane({ context }: { context: DiagnosticsContext }): React.ReactElement {
+  switch (context.kind) {
+    case 'environment':
+      return <ErunTracePane tenant={context.tenant} environment={context.environment} />;
+    case 'orchestrator':
+      return <OrchestratorPane orchestrator={context.orchestrator} />;
+    case 'app':
+      return <AppLogPane label="app log" />;
+  }
+}
 
 export function DebugPanel({ open }: { open: boolean }): React.ReactElement {
   const dispatch = useAppDispatch();
-  const [tab, setTab] = React.useState<DiagnosticsTab>('erun');
-  const selection = useAppSelector((state) => state.selection.selected);
+  const [tab, setTab] = React.useState<DiagnosticsTab>('primary');
+  const context = useAppSelector(selectDiagnosticsContext);
+  const primaryLabel = primaryTabLabel(context);
 
   return (
     <section
@@ -79,12 +88,13 @@ export function DebugPanel({ open }: { open: boolean }): React.ReactElement {
           )}
           <span>Diagnostics</span>
           <span className="text-[11px] font-normal text-[oklch(0.56_0_0)]">
-            {open ? 'erun trace + UI trace' : 'collapsed'}
+            {open ? `${primaryLabel} + UI trace` : 'collapsed'}
           </span>
         </button>
         {open && (
           <div className="flex items-center gap-2">
-            <CopyReportButton selection={selection} />
+            <CopyReportButton context={context} />
+            <ReportIssueButton context={context} />
             <div
               className="flex items-center gap-1"
               role="tablist"
@@ -92,8 +102,8 @@ export function DebugPanel({ open }: { open: boolean }): React.ReactElement {
             >
               <DiagnosticsTabButton
                 current={tab}
-                value="erun"
-                label="erun trace"
+                value="primary"
+                label={primaryLabel}
                 onSelect={setTab}
               />
               <DiagnosticsTabButton current={tab} value="ui" label="UI trace" onSelect={setTab} />
@@ -101,7 +111,7 @@ export function DebugPanel({ open }: { open: boolean }): React.ReactElement {
           </div>
         )}
       </div>
-      {open && tab === 'erun' && <ErunTracePane selection={selection} />}
+      {open && tab === 'primary' && <PrimaryPane context={context} />}
       {open && tab === 'ui' && <UITracePane />}
     </section>
   );
@@ -136,415 +146,5 @@ function DiagnosticsTabButton({
     >
       {label}
     </button>
-  );
-}
-
-function useStickToBottom(content: string): {
-  outputRef: React.RefObject<HTMLDivElement | null>;
-  handleScroll: React.UIEventHandler<HTMLDivElement>;
-} {
-  const outputRef = React.useRef<HTMLDivElement>(null);
-  const stuckToBottomRef = React.useRef(true);
-  const handleScroll = React.useCallback(() => {
-    const el = outputRef.current;
-    if (!el) {
-      return;
-    }
-    stuckToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight <= 4;
-  }, []);
-  React.useEffect(() => {
-    const el = outputRef.current;
-    if (el && stuckToBottomRef.current) {
-      el.scrollTop = el.scrollHeight;
-    }
-  }, [content]);
-  return { outputRef, handleScroll };
-}
-
-function useCopyAction(text: string): { copyStatus: string; copy: () => void } {
-  const [copyStatus, setCopyStatus] = React.useState('');
-  const copy = React.useCallback(() => {
-    if (!text.trim()) {
-      return;
-    }
-    void ClipboardSetText(text)
-      .then(() => {
-        setCopyStatus('Copied');
-        window.setTimeout(() => {
-          setCopyStatus('');
-        }, 1400);
-      })
-      .catch(() => {
-        setCopyStatus('Copy failed');
-      });
-  }, [text]);
-  return { copyStatus, copy };
-}
-
-function CopyButton({
-  copyStatus,
-  disabled,
-  onCopy,
-}: {
-  copyStatus: string;
-  disabled: boolean;
-  onCopy: () => void;
-}): React.ReactElement {
-  return (
-    <Button
-      className="h-6 px-2 text-[11px] [&_svg]:size-3.5"
-      type="button"
-      variant="ghost"
-      size="sm"
-      disabled={disabled}
-      onClick={onCopy}
-    >
-      {copyStatus === 'Copied' ? <CheckCircle2 aria-hidden="true" /> : <Copy aria-hidden="true" />}
-      {copyStatus || 'Copy'}
-    </Button>
-  );
-}
-
-// CopyReportButton produces the one-click bug report. It re-reads the erun
-// trace fresh rather than reusing the polled copy, so the report stays
-// current even between poll ticks.
-function CopyReportButton({ selection }: { selection: UISelection | null }): React.ReactElement {
-  const selectInitialState = React.useMemo(
-    () => stateApi.endpoints.getInitialState.select(undefined),
-    [],
-  );
-  const build = useAppSelector((state) => selectInitialState(state).data?.build ?? null);
-  const environment = useAppSelector((state) => {
-    if (!selection) {
-      return null;
-    }
-    const tenant = state.tenants.tenants.find((entry) => entry.name === selection.tenant);
-    return tenant?.environments.find((env) => env.name === selection.environment) ?? null;
-  });
-  const envStatus = useAppSelector((state) =>
-    selection ? (state.envStatus.statusByEnv[selectionKey(selection)] ?? '') : '',
-  );
-  const [status, setStatus] = React.useState('');
-
-  const copyReport = React.useCallback(() => {
-    const assemble = async (): Promise<void> => {
-      let trace: UIEnvTrace | null = null;
-      if (selection) {
-        trace = await LoadEnvTrace({
-          tenant: selection.tenant,
-          environment: selection.environment,
-        }).catch(() => null);
-      }
-      const report = formatDiagnosticsReport({
-        generatedAt: new Date().toISOString(),
-        build,
-        selection,
-        environment,
-        envStatus,
-        trace,
-        uiTrace: uiTraceEntries(),
-      });
-      await ClipboardSetText(report);
-    };
-    assemble()
-      .then(() => {
-        setStatus('Copied');
-        window.setTimeout(() => {
-          setStatus('');
-        }, 1400);
-      })
-      .catch(() => {
-        setStatus('Copy failed');
-      });
-  }, [selection, build, environment, envStatus]);
-
-  return (
-    <Button
-      className="h-6 px-2 text-[11px] [&_svg]:size-3.5"
-      type="button"
-      variant="ghost"
-      size="sm"
-      onClick={copyReport}
-    >
-      {status === 'Copied' ? (
-        <CheckCircle2 aria-hidden="true" />
-      ) : (
-        <ClipboardList aria-hidden="true" />
-      )}
-      {status || 'Copy report'}
-    </Button>
-  );
-}
-
-function useEnvTracePoll(
-  tenant: string,
-  environment: string,
-): { trace: UIEnvTrace | null; refresh: () => void } {
-  const [trace, setTrace] = React.useState<UIEnvTrace | null>(null);
-  const refresh = React.useCallback(() => {
-    if (!tenant || !environment) {
-      setTrace(null);
-      return;
-    }
-    void LoadEnvTrace({ tenant, environment })
-      .then((next) => {
-        setTrace(next);
-      })
-      .catch(() => {
-        setTrace(null);
-      });
-  }, [tenant, environment]);
-  React.useEffect(() => {
-    refresh();
-    const timer = window.setInterval(refresh, ERUN_TRACE_POLL_MS);
-    return () => {
-      window.clearInterval(timer);
-    };
-  }, [refresh]);
-  return { trace, refresh };
-}
-
-function ErunTracePane({ selection }: { selection: UISelection | null }): React.ReactElement {
-  const tenant = selection?.tenant ?? '';
-  const environment = selection?.environment ?? '';
-  const { trace, refresh } = useEnvTracePoll(tenant, environment);
-  const content = trace?.content ?? '';
-  // Clear is view-only: Copy and Copy report read the full content, so a
-  // cleared view never truncates a bug report.
-  const { cleared, rotatedOut, visibleContent, clear, showAll } = useErunTraceBaseline(
-    `${tenant}/${environment}`,
-    content,
-  );
-  const { outputRef, handleScroll } = useStickToBottom(visibleContent);
-
-  // Toolbar and the cleared notice sit in their own grid rows, outside the
-  // scroll region, so stick-to-bottom cannot scroll the actions out of view.
-  return (
-    <div
-      className={cn(
-        'grid min-h-0',
-        cleared ? 'grid-rows-[auto_auto_minmax(0,1fr)]' : 'grid-rows-[auto_minmax(0,1fr)]',
-      )}
-    >
-      <ErunTraceToolbar
-        label={erunTraceLabel(tenant, environment, trace)}
-        content={content}
-        canClear={content.trim().length > 0}
-        onRefresh={refresh}
-        onClear={clear}
-      />
-      {cleared && <ClearedNotice rotatedOut={rotatedOut} onShowAll={showAll} />}
-      <div
-        ref={outputRef}
-        onScroll={handleScroll}
-        className="min-h-0 overflow-auto px-3 pb-2 font-mono text-[11px] leading-[1.35] text-[oklch(0.82_0_0)]"
-        aria-label="erun trace output"
-      >
-        <ErunTraceBody
-          tenant={tenant}
-          environment={environment}
-          trace={trace}
-          visibleContent={visibleContent}
-          cleared={cleared}
-        />
-      </div>
-    </div>
-  );
-}
-
-// ClearedNotice explains why earlier lines vanished after Clear and offers a
-// one-click return to the full view: Clear only hides scrollback, the
-// persistent log is untouched and always recoverable.
-function ClearedNotice({
-  rotatedOut,
-  onShowAll,
-}: {
-  rotatedOut: boolean;
-  onShowAll: () => void;
-}): React.ReactElement {
-  return (
-    <div className="flex items-center justify-between gap-2 border-b border-[oklch(0.14_0_0)] px-3 py-1 text-[10px] text-[oklch(0.55_0_0)]">
-      <span className="min-w-0 truncate">
-        {rotatedOut
-          ? 'Cleared entries have rotated out of the log — showing all.'
-          : 'Showing entries since you cleared.'}
-      </span>
-      <button
-        type="button"
-        className="flex-none cursor-pointer rounded border-0 bg-transparent px-1 text-[10px] text-[oklch(0.7_0_0)] underline-offset-2 hover:underline"
-        onClick={onShowAll}
-      >
-        Show all
-      </button>
-    </div>
-  );
-}
-
-function erunTraceLabel(tenant: string, environment: string, trace: UIEnvTrace | null): string {
-  if (!tenant || !environment) {
-    return '';
-  }
-  return `${tenant} / ${environment} — ${trace?.path ?? ''}`;
-}
-
-function ErunTraceToolbar({
-  label,
-  content,
-  canClear,
-  onRefresh,
-  onClear,
-}: {
-  label: string;
-  content: string;
-  canClear: boolean;
-  onRefresh: () => void;
-  onClear: () => void;
-}): React.ReactElement {
-  // Copy reads the full content, never the cleared view — a baselined view
-  // must never produce a truncated bug report.
-  const { copyStatus, copy } = useCopyAction(content);
-  return (
-    <div className="flex items-center justify-between gap-2 px-3 pt-1.5 pb-1">
-      <span className="min-w-0 truncate text-[10px] text-[oklch(0.5_0_0)]">{label}</span>
-      <span className="flex flex-none items-center gap-1">
-        <Button
-          className="h-6 px-2 text-[11px] [&_svg]:size-3.5"
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={onRefresh}
-        >
-          <RefreshCw aria-hidden="true" />
-          Refresh
-        </Button>
-        <CopyButton copyStatus={copyStatus} disabled={!content.trim()} onCopy={copy} />
-        <Button
-          className="h-6 px-2 text-[11px] [&_svg]:size-3.5"
-          type="button"
-          variant="ghost"
-          size="sm"
-          disabled={!canClear}
-          onClick={onClear}
-        >
-          <Trash2 aria-hidden="true" />
-          Clear
-        </Button>
-      </span>
-    </div>
-  );
-}
-
-function ErunTraceBody({
-  tenant,
-  environment,
-  trace,
-  visibleContent,
-  cleared,
-}: {
-  tenant: string;
-  environment: string;
-  trace: UIEnvTrace | null;
-  visibleContent: string;
-  cleared: boolean;
-}): React.ReactElement | null {
-  if (!tenant || !environment) {
-    return (
-      <p className="m-0 text-[oklch(0.6_0_0)]">Select an environment to read its erun trace.</p>
-    );
-  }
-  if (!trace) {
-    return null;
-  }
-  if (trace.available) {
-    // When cleared and nothing new has arrived yet, say so rather than
-    // render a blank pane.
-    return (
-      <>
-        <TraceNotice notice={trace.notice} />
-        {cleared && visibleContent.length === 0 ? (
-          <p className="m-0 text-[oklch(0.6_0_0)]">No new entries since you cleared.</p>
-        ) : (
-          <pre className="m-0 font-mono text-[11px] leading-[1.35] break-words whitespace-pre-wrap">
-            {visibleContent}
-          </pre>
-        )}
-      </>
-    );
-  }
-  return (
-    <>
-      <TraceNotice notice={trace.notice} />
-      <p className="m-0 text-[oklch(0.6_0_0)]">{trace.reason ?? 'No trace available.'}</p>
-    </>
-  );
-}
-
-// TraceNotice surfaces a non-fatal caveat (e.g. a remote env's in-pod trace
-// could not be included); the content shown is still real.
-function TraceNotice({ notice }: { notice?: string }): React.ReactElement | null {
-  if (!notice) {
-    return null;
-  }
-  return <p className="m-0 mb-1 text-[oklch(0.6_0_0)] italic">{notice}</p>;
-}
-
-// The UI trace buffer lives outside Redux (see uiTraceBuffer.ts), so this
-// pane polls it instead of subscribing to a selector.
-function UITracePane(): React.ReactElement {
-  const [entries, setEntries] = React.useState<UITraceEntry[]>(() => uiTraceEntries());
-  const generationRef = React.useRef(uiTraceGeneration());
-
-  React.useEffect(() => {
-    const timer = window.setInterval(() => {
-      const generation = uiTraceGeneration();
-      if (generation !== generationRef.current) {
-        generationRef.current = generation;
-        setEntries(uiTraceEntries());
-      }
-    }, 500);
-    return () => {
-      window.clearInterval(timer);
-    };
-  }, []);
-
-  const text = formatUITrace(entries);
-  const { outputRef, handleScroll } = useStickToBottom(text);
-  const { copyStatus, copy } = useCopyAction(text);
-
-  // Actions are pinned outside the scroll region — same rationale as the
-  // erun trace toolbar.
-  return (
-    <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)]">
-      <div className="flex items-center justify-end gap-1 px-3 pt-1.5 pb-1">
-        <CopyButton copyStatus={copyStatus} disabled={!text.trim()} onCopy={copy} />
-        <Button
-          className="h-6 px-2 text-[11px] [&_svg]:size-3.5"
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={() => {
-            clearUITrace();
-            setEntries([]);
-          }}
-        >
-          <Trash2 aria-hidden="true" />
-          Clear
-        </Button>
-      </div>
-      <div
-        ref={outputRef}
-        onScroll={handleScroll}
-        className="min-h-0 overflow-auto px-3 pb-2 font-mono text-[11px] leading-[1.35] text-[oklch(0.82_0_0)]"
-        aria-label="UI trace output"
-      >
-        {entries.length === 0 ? (
-          <p className="m-0 text-[oklch(0.6_0_0)]">No UI activity recorded yet.</p>
-        ) : (
-          <pre className="m-0 font-mono text-[11px] leading-[1.35] break-words whitespace-pre-wrap">
-            {text}
-          </pre>
-        )}
-      </div>
-    </div>
   );
 }

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -46,6 +46,16 @@ export interface UIEnvTrace {
   notice?: string;
 }
 
+// UIAppLog is the Diagnostics console's read model for the desktop's own
+// durable log — evidence for an orchestrator or app-level fault, neither of
+// which has an env trace to fall back on.
+export interface UIAppLog {
+  available: boolean;
+  content?: string;
+  path: string;
+  reason?: string;
+}
+
 // UIUpgradeVersionCandidate is one newer version an env's registries offered,
 // tagged with the registry it came from.
 export interface UIUpgradeVersionCandidate {

--- a/erun-ui/playwright/pages/DebugPanel.ts
+++ b/erun-ui/playwright/pages/DebugPanel.ts
@@ -22,16 +22,30 @@ export class DebugPanel {
     return (await this.resizeHandle().count()) > 0 && (await this.resizeHandle().isVisible());
   }
 
-  tab(name: 'erun trace' | 'UI trace'): Locator {
+  tab(name: 'erun trace' | 'orchestrator' | 'app log' | 'UI trace'): Locator {
     return this.page.getByRole('tab', { name });
   }
 
-  async selectTab(name: 'erun trace' | 'UI trace'): Promise<void> {
+  async selectTab(name: 'erun trace' | 'orchestrator' | 'app log' | 'UI trace'): Promise<void> {
     await this.tab(name).click();
   }
 
   erunTracePane(): Locator {
     return this.page.getByLabel('erun trace output');
+  }
+
+  // The orchestrator context's own identity block (name, status, linked
+  // environments) sits above its app-log tail (orchestratorLogPane()).
+  orchestratorPane(): Locator {
+    return this.page.getByLabel('orchestrator diagnostics');
+  }
+
+  orchestratorLogPane(): Locator {
+    return this.page.getByLabel('orchestrator output');
+  }
+
+  appLogPane(): Locator {
+    return this.page.getByLabel('app log output');
   }
 
   uiTracePane(): Locator {
@@ -62,5 +76,11 @@ export class DebugPanel {
 
   copyReportButton(): Locator {
     return this.page.getByRole('button', { name: /^(Copy report|Copied|Copy failed)$/ });
+  }
+
+  reportIssueButton(): Locator {
+    return this.page.getByRole('button', {
+      name: /^(Report an erun issue|Opened — full report copied|Could not open issue)$/,
+    });
   }
 }

--- a/erun-ui/playwright/tests/diagnostics-orchestrator-context.spec.ts
+++ b/erun-ui/playwright/tests/diagnostics-orchestrator-context.spec.ts
@@ -1,0 +1,152 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ENV_ALPHA, SEED_TENANT } from '../fixtures/seedRoot.js';
+
+// The Diagnostics panel used to derive its evidence from the sidebar's
+// environment selection alone, so an orchestrator session — which never
+// touches that selection — left it reading "environment: none selected" with
+// no trace: an operator opening Diagnostics with an orchestrator focused hit
+// a blank panel in the context they spend most of their time in (#1241).
+// This spec drives the fix: an orchestrator session gets its own context
+// (identity, linked environments, its own log), and the "Report an erun
+// issue" action opens a prefilled github.com/sophium/erun issue for whatever
+// context is active.
+//
+// formatDiagnosticsReport's per-context text is covered directly by
+// diagnosticsReport.test.ts; this locks the rendered panel and the report
+// button's browser/clipboard side effects, which only a real boot can
+// exercise.
+
+const ORCHESTRATOR_ID = 'pw-orch-diag';
+const RUNNING_SESSION_ID = 9101;
+
+function orchestratorSnapshot(): unknown {
+  return {
+    id: ORCHESTRATOR_ID,
+    name: ORCHESTRATOR_ID,
+    environments: [{ tenant: SEED_TENANT, environment: SEED_ENV_ALPHA, directory: '/tmp/orch-a' }],
+    tenants: [SEED_TENANT],
+    directories: ['/tmp/orch-a'],
+    sessionId: RUNNING_SESSION_ID,
+    status: 'running',
+    busy: false,
+    transient: false,
+    shellRunning: false,
+    shellCommand: '',
+    shellStartedAtUnix: 0,
+  };
+}
+
+async function stubRunningOrchestrator(page: Page): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method?: string };
+    if (body.method === 'ListOrchestrators') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [orchestratorSnapshot()] }),
+      });
+    }
+    await route.continue();
+  });
+}
+
+test.describe('diagnostics panel — orchestrator context (#1241)', () => {
+  test.beforeEach(async ({ app }) => {
+    if (!(await app.debugPanel.isOpen())) {
+      await app.debugPanel.toggle();
+      await expect(app.debugPanel.resizeHandle()).toBeVisible();
+    }
+  });
+
+  test('an active orchestrator session gets its own tab and identity, never "environment: none selected"', async ({
+    app,
+    page,
+  }) => {
+    await stubRunningOrchestrator(page);
+    await app.reboot();
+    await app.sidebar.openOrchestratorSession(ORCHESTRATOR_ID);
+
+    await expect(app.debugPanel.tab('orchestrator')).toBeVisible();
+    await expect(app.debugPanel.tab('orchestrator')).toHaveAttribute('aria-selected', 'true');
+    await expect(app.debugPanel.tab('erun trace')).toHaveCount(0);
+    await expect(app.debugPanel.orchestratorPane()).toContainText(ORCHESTRATOR_ID);
+    await expect(app.debugPanel.orchestratorPane()).toContainText(
+      `${SEED_TENANT} / ${SEED_ENV_ALPHA}`,
+    );
+
+    const clipboardWrite = page.waitForRequest(
+      (req) =>
+        req.method() === 'POST' &&
+        req.url().endsWith('/__erun_clipboard') &&
+        (req.postData() ?? '').includes('"action":"set"'),
+    );
+    await app.debugPanel.copyReportButton().click();
+    const req = await clipboardWrite;
+    const written = req.postData() ?? '';
+    expect(written).toContain(`orchestrator: ${ORCHESTRATOR_ID}`);
+    expect(written).not.toContain('environment: none selected');
+  });
+
+  test('switching from the orchestrator back to an environment restores its erun trace', async ({
+    app,
+    page,
+  }) => {
+    await stubRunningOrchestrator(page);
+    await app.reboot();
+    await app.sidebar.openOrchestratorSession(ORCHESTRATOR_ID);
+    await expect(app.debugPanel.tab('orchestrator')).toBeVisible();
+
+    await app.sidebar.openEnvironment(SEED_TENANT, SEED_ENV_ALPHA);
+
+    await expect(app.debugPanel.tab('erun trace')).toBeVisible();
+    await expect(app.debugPanel.tab('orchestrator')).toHaveCount(0);
+    await expect(app.debugPanel.erunTracePane()).toBeVisible();
+  });
+
+  test('"Report an erun issue" opens a prefilled github.com issue and keeps the full report on the clipboard', async ({
+    app,
+    page,
+  }) => {
+    await stubRunningOrchestrator(page);
+    // The desktop must never depend on a live network call to file this --
+    // stub github.com itself rather than letting the popup hit the real
+    // (unauthenticated, redirect-to-login) site.
+    await page
+      .context()
+      .route('https://github.com/**', (route) =>
+        route.fulfill({ status: 200, contentType: 'text/html', body: '<html></html>' }),
+      );
+    await app.reboot();
+    await app.sidebar.openOrchestratorSession(ORCHESTRATOR_ID);
+
+    const clipboardWrite = page.waitForRequest(
+      (req) =>
+        req.method() === 'POST' &&
+        req.url().endsWith('/__erun_clipboard') &&
+        (req.postData() ?? '').includes('"action":"set"'),
+    );
+    const popupPromise = page.context().waitForEvent('page');
+    await app.debugPanel.reportIssueButton().click();
+
+    const popup = await popupPromise;
+    await popup.waitForLoadState();
+    const url = new URL(popup.url());
+    expect(url.origin + url.pathname).toBe('https://github.com/sophium/erun/issues/new');
+    const title = url.searchParams.get('title') ?? '';
+    const body = url.searchParams.get('body') ?? '';
+    expect(title).toBe(`Orchestrator ${ORCHESTRATOR_ID}: diagnostics`);
+    expect(body.length).toBeGreaterThan(0);
+    expect(body).toMatch(/## What happened/);
+    expect(body).toMatch(/## Reproduction/);
+    expect(body).toMatch(/## Environment/);
+    expect(popup.url().length).toBeLessThanOrEqual(8000);
+    await popup.close();
+
+    const req = await clipboardWrite;
+    const written = req.postData() ?? '';
+    expect(written).toContain(`orchestrator: ${ORCHESTRATOR_ID}`);
+
+    await expect(app.debugPanel.reportIssueButton()).toHaveText(/Opened/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1241.

- The Diagnostics panel derived its evidence from `state.selection.selected` (the sidebar's environment selection) alone. An orchestrator session never touches that selection, so focusing one left the panel reading `environment: none selected` with no trace — the empty-panel bug the issue names as the priority slice ("the orchestrator context... is the empty-panel case the operator hits daily").
- The panel now resolves a `DiagnosticsContext` (`environment` | `orchestrator` | `app`) via a new selector (`selectDiagnosticsContext`, `erun-ui/frontend/src/app/selectors.ts`) that mirrors the precedence `selectReviewEnvTargets`/`selectActiveSessionOrchestrator` already established for the orchestrator cross-env diff panel (#1178) — reused rather than re-derived, per the issue's own note that the orchestrator popover and this panel "should read from one selector rather than two."
- Each context gets its own evidence:
  - **environment** — unchanged: the env's erun trace (`ErunTracePane`).
  - **orchestrator** — its identity, status, background shell, and linked environments' real-status, plus the desktop's own log (`OrchestratorPane`).
  - **app** — the desktop's own log on its own, for a fault belonging to neither (`AppLogPane`).
  - **UI trace** stays a second tab available in every context, unchanged.
- A new Go method `LoadAppLog` (`erun-ui/app_log.go`) exposes a bounded tail of the desktop's own durable log (`erun-app.log`) to the frontend — it existed only as write-side logging infra before (issue's item 4).
- `formatDiagnosticsReport` (`erun-ui/frontend/src/app/diagnosticsReport.ts`) is rewritten to be context-aware; one unit test per context asserts an orchestrator context never emits `environment: none selected`.
- A new **"Report an erun issue"** button opens a prefilled `github.com/sophium/erun/issues/new` URL in the browser (title from the failing check/orchestrator/env, body mirroring the `erun-file-issue` skill's own template: What happened / What you expected / Reproduction / Environment / Diagnostics evidence) for the operator to review and submit themselves — never a silent `gh` call. The body is trimmed to fit GitHub's URL length cap when oversized; the clipboard always gets the full, untrimmed report regardless.

## Scope decisions (read before reviewing)

- **Landed:** contexts 1 (environment, unchanged), 2 (orchestrator, new), 4 (app/desktop log, new) from the issue's "Scope" section, plus the file-issue button (item 3). This matches the issue's own prioritization: *"Independently useful first: the orchestrator context. It is the empty-panel case the operator hits daily. The issue-filing button is next and is small once the report is context-aware."*
- **Deferred, not landed:** the **Activity/failure context** (item 3 in the issue's context list — a failed `ActivityCard`'s own captured output surfacing inside the Diagnostics panel) and **unifying `formatDiagnosticsReport` with `ActivityQueueDrawer.helpers.ts`'s `buildFailureReport`** (the issue's "Unify the report builders" item). Both are real, but neither is in the issue's own "independently useful first" cut, and folding them in risked a much larger, harder-to-review diff touching `ActivityCard.tsx`/`ActivityQueueDrawer.helpers.ts` on top of the DebugPanel rework. Filing as a fast follow is straightforward since the `DiagnosticsReportContext` union already has room for an `activity` variant.
- **Report-issue button is always visible**, not gated on "the context reports a problem" as the issue's prose suggests. There's no reliable per-context "problem" signal for the orchestrator/app contexts today (that's the whole point of #1241 — they didn't carry evidence at all before this), so a gate would have been guesswork. The operator opens Diagnostics because something's already suspect; Nielsen's user-control-and-freedom favors always offering the action over hiding it behind an imperfect heuristic.
- **No per-orchestrator log scoping.** The orchestrator context shows the *whole* bounded app-log tail rather than lines scoped to that one orchestrator, because log lines aren't tagged with an orchestrator id today. Noted as a possible follow-up, not blocking.

## Issue vs. code — confirmed accurate

Read the current code before implementing (issue cites `origin/main` `cc99e11a`; I read at `051021d1`). The issue's framing held up: `formatDiagnosticsReport`/`environmentLine` did exactly what's described, `LoadEnvTrace`'s signature is env-scoped with no orchestrator equivalent, `app_log.go` exported no `App` method, and the tab union was a closed `'erun' | 'ui'`. No corrections needed.

**#1212 status:** that issue (failures losing their cause at rendering boundaries) is still open with no PR against it — I checked `gh pr list`/`gh issue view 1212` before starting. Nothing to reuse yet; this PR's `DiagnosticsReportContext`/`UIAppLog` shapes are new and don't preclude #1212 wiring its own error detail into them later.

## Reproducing the bug on `main`

Wrote the new spec (`diagnostics-orchestrator-context.spec.ts`) first, then ran it against a build of unmodified `main` (stashed my implementation changes, kept only the test + POM additions, `./run.sh --build --port 34977`). All three new tests failed as expected:
1. `getByRole('tab', { name: 'orchestrator' })` — element not found (no orchestrator tab exists at all).
2. Same, in the "switch back to an environment" test.
3. The "Report an erun issue" button doesn't exist, so the click/popup-wait timed out.

This is the same failure shape the issue's own manual repro describes ("select an orchestrator with the Diagnostics panel open... reads 'environment: none selected' with no trace"). Restored the implementation (`git stash pop`), rebuilt, reran — all pass. Full transcript of both runs is in this session; happy to paste if wanted.

One correction to my own initial assumption while doing this: I first assumed the playwright harness boots with no environment selected (so the *default* context would be `app`), and rewrote `diagnostics-console.spec.ts` around that. Running it showed the seeded tenant's `defaultenvironment: alpha` makes `pw/alpha` auto-select and auto-open on every boot — so the existing spec's "erun trace active by default" assertion was already correct and needed **no changes**. Reverted that file to its original content; the new orchestrator/app-context coverage lives entirely in the new spec file instead.

## Tests

- **Go:** `TestLoadAppLog*` in `erun-ui/app_log_test.go` (new: no-log-yet, tail-with-content-and-path).
- **TS unit** (`node --test`, run via `yarn test`):
  - `diagnosticsReport.test.ts` — one case per context; explicitly asserts an orchestrator context never emits `environment: none selected`.
  - `diagnosticsIssue.test.ts` — title prefill per context, body shape (all four headers + evidence section), URL-cap truncation (trims the body only, appends a clipboard notice, stays under the cap) and the untrimmed case.
- **Playwright** (`erun-ui/playwright/tests/diagnostics-orchestrator-context.spec.ts`, new): orchestrator context gets its own tab/identity and never shows the old fallback string; switching back to an environment restores its erun trace; the report button opens a github.com popup with non-empty title/body under the cap and copies the full report to the clipboard. Ran with an explicit port (`--port 34977`), foreground, `--build` to pick up Go+frontend changes.
- Reran the **protected #1244 characterization specs** unmodified (did not edit them): `orchestrator-cross-env-diff.spec.ts` (7/7 pass) and the unit tests `reviewSlice.test.ts`/`useEnvDiffSlot.test.ts`/`reviewEnvTargets.test.ts` (part of the 113/113 `yarn test` pass).
- `diagnostics-console.spec.ts` and `diagnostics-erun-trace-clear.spec.ts`: unmodified, both still pass (6/6) — default-boot behavior is unaffected by this change, as explained above.

## UX Impact Review Checklist (erun-ui/AGENTS.md)

1. **Affected paths:** Diagnostics panel toggle → tab selection → Copy report / Report an erun issue buttons. Sidebar orchestrator-row click / environment-row click (no changes there; only what the panel derives from the resulting focus).
2. **User-visible sequence:** Operator clicks an orchestrator row → its terminal session focuses → Diagnostics panel (if open) re-renders its primary tab as "orchestrator" showing identity + linked envs + log, instead of staying on a stale/blank "erun trace" pane. Clicking an environment row afterward switches the tab back to "erun trace" with that env's own trace. Clicking "Report an erun issue" opens a new browser tab at a prefilled GitHub issue URL and flips the button label to "Opened — full report copied" for ~2s.
3. **State-without-affordance:** N/A — no new bare state mutations; `tab` state is local component state re-rendered every frame from the new `context` selector output, so there's no stale-mutation risk to check for.
4. **Visibility of system status:** The panel's own header label (`erun trace + UI trace` / `orchestrator + UI trace` / `app log + UI trace`) is always visible when open, naming which context is active.
5. **Success/failure feedback:** Copy/Report buttons flip label text (`Copied` / `Opened — full report copied` / `Copy failed` / `Could not open issue`) for ~1.4–2s, matching the existing Copy-button pattern in this same panel.
6. **Consistency with comparable flows:** Matches the orchestrator cross-env diff panel's own context derivation (#1178) and the existing Copy-report/Copy-button visual language already in this panel.
7. **Heuristic pass:** #1 visibility of system status — pass (context label). #2 match real world — pass (plain-language "orchestrator"/"app log" tabs, no internal jargon). #4 consistency — pass (reuses existing button/tab chrome). #9 error recovery — pass ("Copy failed"/"Could not open issue" name the failure; retry is just clicking again). Others (#3 user control, #5 error prevention, #6 recognition, #7 flexibility, #8 minimalist design, #10 help docs) don't meaningfully apply to a read-only diagnostics viewer.
8. **Playwright coverage:** `erun-ui/playwright/tests/diagnostics-orchestrator-context.spec.ts` (new). Not independently re-verified at a narrow viewport — the toolbar's three buttons (Copy report / Report an erun issue / tabs) use the same compact `h-6 px-2 text-[11px]` sizing already in production for the first two, so I'm reasonably confident but did not measure overflow below the suite's standard 1440px viewport.

## Docs (root AGENTS.md "Working Rules" gate)

- `erun-docs/docs/desktop/overview.md` § "Diagnostics console" (Operator-facing) — rewrote to describe the three contexts and the new "Report an erun issue" button (prefilled-for-review, not silent filing). Ran `cd erun-docs && yarn build` clean.
- `erun-skills/skills/erun-file-issue/SKILL.md` — added a short note pointing at the desktop's own Diagnostics panel as the more direct route for a desktop-observed fault, per the issue's docs item. No frontmatter/trigger-phrase/input/output/error-behavior change, so `agent-reference/skills-spec.md`'s catalogue entry doesn't need a corresponding edit (its contract only requires an update when one of those five fields changes).
- No Agent-reference page exists for the Diagnostics panel (it's desktop-app UI, not an MCP/API surface), so no companion Agent-reference page is needed.

## Validation run

- `go build ./...`, `go test -count=1 ./...` in `erun-ui` — green, both with normal `PATH` and the stripped `PATH=/usr/local/go/bin:/usr/bin:/bin` variant.
- `golangci-lint run ./...` in `erun-ui` — 0 issues.
- `cd erun-integration && go test ./...` — green (this PR doesn't touch erun-cli/erun-common/goldens, but ran it per the gate anyway).
- `yarn typecheck && yarn lint && yarn format:check && yarn build && yarn test` in `erun-ui/frontend` — all clean, 113/113 unit tests pass.
- Playwright: see Tests section above — all run in the foreground with an explicit port, no backgrounded suite runs.

## What I could not verify

- Real macOS/Windows `BrowserOpenURL` behavior — only exercised the headless shim's `window.open` fallback (which the harness uses specifically to make this testable without a live browser dependency). The Wails runtime binding itself (`runtime.BrowserOpenURL`) is unchanged/pre-existing plumbing used elsewhere in this module (`contribute_mode.go`), so I'm relying on that precedent rather than a fresh manual check on real desktop OSes.
- Narrow-viewport rendering of the panel's toolbar (see checklist item 8 above).