### PR TITLE
Honour a tenant's own runtimeimage tag instead of guessing the erun version

### DIFF
--- a/erun-common/published_devops_chart.go
+++ b/erun-common/published_devops_chart.go
@@ -707,8 +707,7 @@ func resolveDeployRuntimeImage(ctx Context, target OpenResult, chartRegistry, ve
 			return image
 		}
 		staleChartName, staleChartVersion := effectiveRuntimeChartCoordinateForImage(resolvedRuntimeChart{name: chartName, version: chartVersion}, runtimeChartOverride)
-		defaultImage := defaultDeployRuntimeImageName(registry, version, tenant, staleChartName)
-		stale := staleRuntimeImageTrace(image, defaultImage, staleChartName, version, strings.TrimSpace(staleChartVersion))
+		stale := staleRuntimeImageTrace(image, staleChartName, version, strings.TrimSpace(staleChartVersion))
 		if stale == "" {
 			ctx.Trace("deploy: runtime image override " + image + " (imageOverrides." + DevopsComponentName + ")")
 			return image
@@ -719,42 +718,34 @@ func resolveDeployRuntimeImage(ctx Context, target OpenResult, chartRegistry, ve
 }
 
 // staleRuntimeImageTrace explains why a saved runtimeimage override cannot be
-// honored on this deploy, or "" when it can be. Two shapes are stale by
-// construction, both a leftover pin rather than a deliberate current choice:
+// honored on this deploy, or "" when it can be. A runtimeimage is stale only
+// when it is provably wrong for the line this deploy is on: it names the
+// stock erun-devops image on a deploy that is not on erun's own release line
+// (a tenant umbrella, which publishes its own image beside its own chart, or
+// a chart stated at its own version, which is the operator saying so
+// outright). Neither line publishes the stock image at its version, so a
+// runtimeimage still naming it is a leftover from when the env rode the
+// shared chart, and honoring it would pin a tag that never existed
+// (ImagePullBackOff).
 //
-//   - It names the stock erun-devops image on a deploy that is not on erun's
-//     own release line: a tenant umbrella, which publishes its own image beside
-//     its own chart, or a chart stated at its own version, which is the operator
-//     saying so outright. Neither line publishes the stock image at its
-//     version, so a runtimeimage still naming it is a leftover from when the env
-//     rode the shared chart, and honoring it would pin a tag that never existed
-//     (ImagePullBackOff).
-//   - It names the very image this deploy's own line already resolves with no
-//     override at all (defaultImage) — just at some other tag. That pin is
-//     provably redundant: defaultDeployRuntimeImage would have named the right
-//     image unaided, so the saved tag can only be stale.
-func staleRuntimeImageTrace(image, defaultImage, chartName, version, chartVersion string) string {
-	if runtimeImageIsStockDevops(image) {
-		switch {
-		case chartName != "" && chartName != DevopsComponentName:
-			return "deploy: ignoring stale runtimeimage " + image + " on the " + chartName + " umbrella deploy (the stock " + DevopsComponentName + " image is not published on this version line); defaulting to the umbrella's own image"
-		case chartVersion != "" && chartVersion != version:
-			return "deploy: ignoring stale runtimeimage " + image + " (the env states its runtime chart at " + chartVersion + ", so version " + version + " is on another line and the stock " + DevopsComponentName + " image is not published at it); defaulting to the tenant's own image"
-		}
+// A recorded image naming a *different tag* than the version this deploy
+// would otherwise guess is never treated as stale on that basis alone: a
+// tenant's own image is versioned on the tenant's own release line, so a tag
+// that disagrees with erun's version is the expected, correct case, not
+// evidence of drift. Guessing that it names "an older tag" and silently
+// substituting the erun-version-tagged guess pins a tag the tenant's registry
+// may never have published at all.
+func staleRuntimeImageTrace(image, chartName, version, chartVersion string) string {
+	if !runtimeImageIsStockDevops(image) {
 		return ""
 	}
-	if defaultImage == "" || image == defaultImage || !sameImageRepository(image, defaultImage) {
-		return ""
+	switch {
+	case chartName != "" && chartName != DevopsComponentName:
+		return "deploy: ignoring stale runtimeimage " + image + " on the " + chartName + " umbrella deploy (the stock " + DevopsComponentName + " image is not published on this version line); defaulting to the umbrella's own image"
+	case chartVersion != "" && chartVersion != version:
+		return "deploy: ignoring stale runtimeimage " + image + " (the env states its runtime chart at " + chartVersion + ", so version " + version + " is on another line and the stock " + DevopsComponentName + " image is not published at it); defaulting to the tenant's own image"
 	}
-	return "deploy: ignoring stale runtimeimage " + image + " (this deploy's own line already publishes " + defaultImage + "; the saved pin just names an older tag); defaulting to " + defaultImage
-}
-
-// sameImageRepository reports whether two tagged image references name the
-// same registry + image, ignoring the tag itself.
-func sameImageRepository(a, b string) bool {
-	registryA, nameA, _, okA := parseDockerImageReference(a)
-	registryB, nameB, _, okB := parseDockerImageReference(b)
-	return okA && okB && registryA == registryB && nameA == nameB
+	return ""
 }
 
 // defaultDeployRuntimeImageName names the image the deploy's own line

--- a/erun-common/published_devops_chart_test.go
+++ b/erun-common/published_devops_chart_test.go
@@ -1,6 +1,9 @@
 package eruncommon
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestRuntimeImageRegistry(t *testing.T) {
 	cases := map[string]string{
@@ -80,4 +83,112 @@ func TestPublishedDevopsChartRegistry(t *testing.T) {
 			t.Fatalf("chart registry = %q, want the deploy registry registry.example/test (the chart must not follow the image registry)", got)
 		}
 	})
+}
+
+// TestResolveDeployRuntimeImageHonoursTenantsOwnVersionLine pins #1265: a
+// tenant's own <tenant>-devops image is versioned on the tenant's own release
+// line, independent of the erun version the environment runs (as erun pin
+// already documents and enforces — it never rewrites this tag). A persisted
+// runtimeimage naming that image at the tenant's own tag must survive a
+// redeploy verbatim, never get discarded in favour of a guessed
+// <tenant>-devops:<erun-version> tag just because the two happen to share a
+// registry. Before the fix, whether the guess "won" depended on an accident —
+// which registry held the deploy role — reproducing the four-environment
+// matrix from the issue (same recorded image, only the registry wiring
+// differs).
+func TestResolveDeployRuntimeImageHonoursTenantsOwnVersionLine(t *testing.T) {
+	const (
+		tenant           = "petios"
+		erunVersion      = "1.0.201"
+		recordedRegistry = "<acct>.dkr.ecr.eu-west-2.amazonaws.com"
+		recordedImage    = recordedRegistry + "/petios-devops:1.0.353-snapshot-20260824165146"
+		chartRegistry    = "ghcr.io/sophium"
+	)
+
+	cases := []struct {
+		name        string
+		registries  ContainerRegistries
+		wantHonored bool
+	}{
+		{
+			name: "deploy role held by the tenant's own registry",
+			registries: ContainerRegistries{
+				{Registry: recordedRegistry, Roles: []RegistryRole{RegistryRoleBuild, RegistryRoleDeploy}},
+			},
+			wantHonored: true,
+		},
+		{
+			name: "deploy role held by the tenant's own registry, build elsewhere",
+			registries: ContainerRegistries{
+				{Registry: recordedRegistry, Roles: []RegistryRole{RegistryRoleDeploy}},
+				{Registry: "ghcr.io/sophium", Roles: []RegistryRole{RegistryRoleBuild}},
+			},
+			wantHonored: true,
+		},
+		{
+			name: "deploy role held by erun's own registry",
+			registries: ContainerRegistries{
+				{Registry: "ghcr.io/sophium", Roles: []RegistryRole{RegistryRoleDeploy}},
+				{Registry: recordedRegistry, Roles: []RegistryRole{RegistryRoleBuild}},
+			},
+			wantHonored: true,
+		},
+		{
+			name:        "no registry recorded at all",
+			registries:  nil,
+			wantHonored: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var trace strings.Builder
+			ctx := Context{Logger: NewLoggerWithWriters(0, &trace, &trace)}
+			target := OpenResult{
+				Tenant: tenant,
+				EnvConfig: EnvConfig{
+					RuntimeImage:        recordedImage,
+					ContainerRegistries: tc.registries,
+				},
+			}
+
+			got := resolveDeployRuntimeImage(ctx, target, chartRegistry, erunVersion, DevopsComponentName, "", "", false)
+
+			if tc.wantHonored {
+				if got != recordedImage {
+					t.Fatalf("resolveDeployRuntimeImage() = %q, want the recorded image %q honored verbatim", got, recordedImage)
+				}
+				if strings.Contains(trace.String(), "ignoring stale runtimeimage") {
+					t.Fatalf("trace unexpectedly discarded the recorded image: %s", trace.String())
+				}
+			}
+		})
+	}
+}
+
+// TestResolveDeployRuntimeImageStillHealsStockImageOnTenantLine guards the one
+// staleness signal that remains legitimate after #1265: a runtimeimage still
+// naming the stock erun-devops image on a deploy that has moved to the
+// tenant's own umbrella chart is provably wrong (that line never publishes
+// the stock image), so it is still healed to the umbrella's own image rather
+// than kept.
+func TestResolveDeployRuntimeImageStillHealsStockImageOnTenantLine(t *testing.T) {
+	var trace strings.Builder
+	ctx := Context{Logger: NewLoggerWithWriters(0, &trace, &trace)}
+	target := OpenResult{
+		Tenant: "acme",
+		EnvConfig: EnvConfig{
+			RuntimeImage: "ghcr.io/sophium/erun-devops:1.0.178",
+		},
+	}
+
+	got := resolveDeployRuntimeImage(ctx, target, "ghcr.io/sophium", "1.0.201", "acme-devops", "1.0.201", "", false)
+
+	const want = "ghcr.io/sophium/acme-devops:1.0.201"
+	if got != want {
+		t.Fatalf("resolveDeployRuntimeImage() = %q, want %q (healed off the stale stock image)", got, want)
+	}
+	if !strings.Contains(trace.String(), "ignoring stale runtimeimage") {
+		t.Fatalf("expected a trace explaining the stock-image staleness, got: %s", trace.String())
+	}
 }

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -1191,15 +1191,17 @@ func TestDeploy(t *testing.T) {
 		golden.Equal(t, "deploy/dry_run_remote_env_umbrella_ignores_stale_stock_runtimeimage", normalize.Apply(result.Combined))
 	})
 
-	t.Run("dry_run_remote_env_umbrella_ignores_stale_tenant_runtimeimage_tag", func(t *testing.T) {
-		// The staleness guard used to fire only for a leftover pin naming
-		// the STOCK erun-devops image. A pin naming the tenant's OWN team-devops
-		// image at an older tag was honoured unconditionally forever, even though
-		// this deploy's own line already resolves the same image correctly with
-		// no override at all. The saved pin is provably redundant — it names
-		// exactly the image defaultDeployRuntimeImage would have picked, just at
-		// a stale tag — so it must be ignored and traced the same as the stock
-		// case, and the deploy must roll out the current version's tag.
+	t.Run("dry_run_remote_env_umbrella_honours_tenants_own_runtimeimage_tag", func(t *testing.T) {
+		// A pin naming the tenant's OWN team-devops image at a tag that disagrees
+		// with the deploy version used to be discarded as "provably redundant"
+		// and silently replaced with a guessed team-devops:<erun-version> tag.
+		// That guess conflated two independent version lines: the tenant's own
+		// image is versioned on the tenant's own release line (exactly what
+		// `erun pin` already documents and enforces — it never rewrites this
+		// tag), so a tag that disagrees with the deploy version is the expected,
+		// correct case, not staleness. The recorded runtimeimage must be
+		// honoured verbatim, and the deploy must roll out that tag rather than
+		// one nothing ever published.
 		setup := env.New(t)
 		fixture.SeedRemoteRepoPathTenantEnv(t, setup, "team", "dev", "/nonexistent-remote/team")
 		envConfigPath := filepath.Join(setup.ConfigHome, "erun", "team", "dev", "config.yaml")
@@ -1207,13 +1209,13 @@ func TestDeploy(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read env config: %v", err)
 		}
-		mustWriteFile(t, envConfigPath, string(existing)+"runtimeimage: registry.example/test/team-devops:old-tag\n")
+		mustWriteFile(t, envConfigPath, string(existing)+"runtimeimage: registry.example/test/team-devops:1.0.353-snapshot-20260824165146\n")
 		envVars := append(setup.Env(), "ERUN_PUBLISHED_CHART_PROBE_OVERRIDE=team-devops:1.0.51")
 		result := erun.Run(t, []string{"deploy", "team", "dev", "--version", "1.0.51", "--dry-run"}, erun.RunOptions{Cwd: setup.Home, Env: envVars})
 		if result.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
-		golden.Equal(t, "deploy/dry_run_remote_env_umbrella_ignores_stale_tenant_runtimeimage_tag", normalize.Apply(result.Combined))
+		golden.Equal(t, "deploy/dry_run_remote_env_umbrella_honours_tenants_own_runtimeimage_tag", normalize.Apply(result.Combined))
 	})
 
 	t.Run("dry_run_remote_env_stated_chart_ignores_stale_stock_runtimeimage", func(t *testing.T) {

--- a/erun-integration/testdata/deploy/dry_run_remote_env_umbrella_honours_tenants_own_runtimeimage_tag.txt
+++ b/erun-integration/testdata/deploy/dry_run_remote_env_umbrella_honours_tenants_own_runtimeimage_tag.txt
@@ -5,8 +5,7 @@ deploy: configured repo path /nonexistent-remote/team is not present on this mac
 deploy: component selection source default (runtime only); deploying the runtime chart alone
 deploy: runtime chart team-devops <VERSION> found in registry.example/test (the tenant's own umbrella)
 deploy: no local runtime chart; using published chart oci://registry.example/test/charts/team-devops version <VERSION>
-deploy: ignoring stale runtimeimage registry.example/test/team-devops:old-tag (this deploy's own line already publishes registry.example/test/team-devops:<VERSION>; the saved pin just names an older tag); defaulting to registry.example/test/team-devops:<VERSION>
-deploy: defaulting runtime image to the team-devops chart's own image registry.example/test/team-devops:<VERSION> (imageOverrides.erun-devops)
+deploy: runtime image override registry.example/test/team-devops:<VERSION> (imageOverrides.erun-devops)
 deploy: resolved 1 spec(s)
 kubectl --context test-context get namespace team-dev -o name
 deploy: namespace team-dev is created if the check above reports it missing

--- a/erun-skills/skills/erun-build-env/SKILL.md
+++ b/erun-skills/skills/erun-build-env/SKILL.md
@@ -247,20 +247,31 @@ maintenance mode; absent → the scaffold flow above.
 - If the Step 6 umbrella is present, backfill a missing per-env
   `values.<env>.yaml`, a committed `Chart.lock`, or the gitignored `charts/*.tgz`.
 
-**Upgrade** to one erun version across every pin — the env's current
-`runtimeversion` (it moves with `erun upgrade`) or an explicit target (Step 1):
+**Upgrade** the module's *erun* pins — the base it extends — to the env's
+current `runtimeversion` (it moves with `erun upgrade`) or an explicit target
+(Step 1). `erun pin` does exactly this and is the preferred way to do it
+(`erun-pin-version` skill); by hand, the two erun pin sites are:
 
 - Re-pin the Dockerfile `FROM ghcr.io/sophium/erun-devops:<version>`.
-- Re-pin the module `VERSION` to that version.
 - If the Step 6 umbrella is present, re-pin its `erun-devops` dependency
   `version:` in `Chart.yaml` to the same version, then `helm dependency update` to
   regenerate `Chart.lock` for the new version (`helm dependency build` errors on a
   stale lock); commit the updated lock.
-- `erun build` to rebuild and push both arches, then confirm the env's
-  `runtimeimage` still points at the module (Step 5).
 
-Bump every pin together — the whole module rides one erun version. Re-running is
-safe: it edits in place and only moves version pins and fills gaps.
+Then `erun build` to rebuild and push both arches, and confirm the env's
+`runtimeimage` still points at the module (Step 5).
+
+**Never re-pin the module `VERSION` to the erun version.** The module's own
+`VERSION` is the tenant's own release line — it identifies *this image's own
+content* (the toolchain choices baked into the Dockerfile), which changes on
+its own schedule and often not at all when erun moves. Only bump it when the
+image's own content changes (Step 3); `erun pin` never touches it, and neither
+should you. Conflating the two is exactly the bug `erun deploy` used to have:
+it invented `<tenant>-devops:<erun-version>` as the image tag instead of using
+what was actually published, so redeploys silently discarded a real,
+tenant-versioned `runtimeimage` in favor of a tag that was never pushed.
+Re-running the erun-pin steps above is safe: they edit in place and only move
+the erun pins.
 
 **Clean up.** If the module was renamed or relocated (a stray `<old>-devops/`, or a
 second `docker/<oldname>/` under it), remove the superseded copy after previewing so


### PR DESCRIPTION
## Summary

erun#1265 reported that `erun deploy` conflates a tenant's own `<tenant>-devops` runtime-image version with the erun version, and that `erun-build-env`'s guidance contradicts `erun pin`'s documented (and enforced) behaviour about the two being independent.

I confirmed both halves of the report against the actual code and fixed each:

**`erun deploy` (the core bug).** `resolveDeployRuntimeImage`/`staleRuntimeImageTrace` in `erun-common/published_devops_chart.go` treated a recorded `runtimeimage` as "provably redundant" and silently replaced it with a guessed `<tenant>-devops:<erun-version>` tag whenever the recorded image happened to share a registry+name with that guess — even though the recorded image's *tag* legitimately differs, because the tenant's own image is versioned on the tenant's own release line (exactly what `erun pin` already documents and never rewrites). Whether the silent substitution fired depended entirely on an accident — which registry held the `deploy` role — reproducing the four-environment matrix from the issue's follow-up comment (ECR-holds-deploy → substituted, ghcr-holds-deploy → honoured, same recorded image string in all four). I removed that heuristic; the one remaining staleness check (a `runtimeimage` still naming the *stock* `erun-devops` image on a deploy that has moved to the tenant's own chart line) stays, since that one is provably wrong rather than guessed.

**`erun-build-env` skill docs.** Its Upgrade section told operators to "re-pin the module `VERSION` to that version" and "bump every pin together — the whole module rides one erun version," which is the exact false premise the issue calls out and directly contradicts `erun pin`'s own code (`pin.go` explicitly skips a tenant's own `<tenant>-devops` image tag) and the `erun-pin-version` skill. Rewrote that section to state the two erun pin sites correctly (Dockerfile `FROM` tag, and the Step-6 umbrella's `erun-devops` chart dependency) and to explicitly forbid re-pinning the module's own `VERSION`. I grepped every other skill referencing `erun-devops`/`runtimeimage` and found no other instance of this contradiction.

The issue's premise held up against the code in both places — nothing in it was mistaken.

## Test plan
- [x] Added `TestResolveDeployRuntimeImageHonoursTenantsOwnVersionLine` (erun-common) reproducing the issue's 4-environment matrix; confirmed it fails without the fix (stashed the fix, watched it red on exactly the two "substituted" rows, unstashed) and passes with it.
- [x] Added `TestResolveDeployRuntimeImageStillHealsStockImageOnTenantLine` to pin the one staleness check that must survive.
- [x] Renamed/rewrote the integration scenario that had locked in the buggy behaviour as a golden (`dry_run_remote_env_umbrella_ignores_stale_tenant_runtimeimage_tag` → `dry_run_remote_env_umbrella_honours_tenants_own_runtimeimage_tag`) and regenerated its golden.
- [x] `(cd erun-common && go test ./...)` — green
- [x] `(cd erun-common && env PATH=/usr/local/go/bin:/usr/bin:/bin go test ./...)` — green
- [x] `(cd erun-common && golangci-lint run ./...)` — 0 issues
- [x] `(cd erun-integration && go test ./...)` and stripped-PATH variant — green
- [x] `(cd erun-integration && golangci-lint run ./...)` — 0 issues
- [x] `make integration-test` from repo root — green, coverage 76.6% (>= 76.2% threshold)

Closes #1265