### PR TITLE
Recommend a right-sized runtime pod for each environment from its own observed usage

### DIFF
--- a/erun-cli/cmd/activity_lease.go
+++ b/erun-cli/cmd/activity_lease.go
@@ -294,28 +294,32 @@ func formatLeaseRemaining(lease common.EnvironmentActivityLease, now time.Time) 
 
 // newActivitySampleCmd is the uninstrumented-work half. The environment monitor
 // calls it on its tick; work that took no lease still registers because the
-// processes doing it burned CPU since the previous tick.
+// processes doing it burned CPU since the previous tick. The same tick retains a
+// resource-usage reading, so an environment accumulates the history its sizing
+// recommendation is derived from without a second scheduled job.
 func newActivitySampleCmd() *cobra.Command {
 	var tenant string
 	var environment string
 	var procRoot string
+	var cgroupRoot string
 	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "sample",
-		Short: "Sample resident build and agent processes and record activity when they are working",
-		Long:  "Records activity only when a matched process burned CPU since the previous\nsample, so an agent parked at a prompt does not keep the environment awake.",
+		Short: "Sample resident build and agent processes and record activity and resource usage",
+		Long:  "Records activity only when a matched process burned CPU since the previous\nsample, so an agent parked at a prompt does not keep the environment awake.\nAlso retains the container's own cgroup CPU and memory counters, which is what\nlets erun recommend a size for this environment from what it has actually done.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runActivitySample(cmd, tenant, environment, procRoot, jsonOutput)
+			return runActivitySample(cmd, tenant, environment, procRoot, cgroupRoot, jsonOutput)
 		},
 	}
 	addActivityTargetFlags(cmd, &tenant, &environment)
 	cmd.Flags().StringVar(&procRoot, "proc-root", common.DefaultProcRoot, "Process filesystem to sample")
+	cmd.Flags().StringVar(&cgroupRoot, "cgroup-root", common.DefaultCgroupRoot, "Cgroup filesystem to read this container's own CPU and memory counters from")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Write the sample verdict as JSON")
 	return cmd
 }
 
-func runActivitySample(cmd *cobra.Command, tenant, environment, procRoot string, jsonOutput bool) error {
+func runActivitySample(cmd *cobra.Command, tenant, environment, procRoot, cgroupRoot string, jsonOutput bool) error {
 	if err := validateActivityTarget(tenant, environment); err != nil {
 		return err
 	}
@@ -328,6 +332,9 @@ func runActivitySample(cmd *cobra.Command, tenant, environment, procRoot string,
 		return err
 	}
 	if err := common.SaveResidentActivitySample(tenant, environment, result.Sample); err != nil {
+		return err
+	}
+	if err := retainRuntimeUsage(tenant, environment, cgroupRoot); err != nil {
 		return err
 	}
 	if result.Busy {
@@ -349,6 +356,22 @@ func runActivitySample(cmd *cobra.Command, tenant, environment, procRoot string,
 	}
 	_, err = fmt.Fprintf(ctx.Stdout, "working: %s\n", strings.Join(result.Processes, ", "))
 	return err
+}
+
+// retainRuntimeUsage folds this tick's cgroup reading into the environment's
+// retained history. A host that supplies no counters records nothing: a history
+// of empty samples would only ever support "no evidence", and this runs on a
+// laptop as readily as in a container.
+func retainRuntimeUsage(tenant, environment, cgroupRoot string) error {
+	sample := common.ReadLocalRuntimeUsage(cgroupRoot)
+	if !sample.HasCounters() {
+		return nil
+	}
+	history, err := common.LoadRuntimeUsageHistory(tenant, environment)
+	if err != nil {
+		return err
+	}
+	return common.SaveRuntimeUsageHistory(tenant, environment, common.AppendRuntimeUsageSample(history, sample, time.Now()))
 }
 
 func validateActivityTarget(tenant, environment string) error {

--- a/erun-cli/cmd/list.go
+++ b/erun-cli/cmd/list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	common "github.com/sophium/erun/erun-common"
 	"github.com/spf13/cobra"
@@ -256,11 +257,14 @@ func environmentDetailLines(env common.ListEnvironmentResult) []string {
 		indent + "container-registries: " + containerRegistriesLabel(env.ContainerRegistries),
 		indent + "runtime-version: " + valueOrNone(env.RuntimeVersion),
 		indent + "runtime-pod: " + runtimePodLabel(env.RuntimePod),
+	}
+	lines = append(lines, runtimeSizingLines(env.Sizing, indent)...)
+	lines = append(lines, []string{
 		indent + "managed-cloud: " + enabledDisabledLabel(env.ManagedCloud),
 		indent + "ai-tool: " + valueOrNone(env.AITool),
 		indent + "claude: " + claudeLabel(env.Claude),
 		indent + "idle: " + idleLabel(env.Idle),
-	}
+	}...)
 	if env.DisableBuildScript {
 		lines = append(lines, indent+"disable-build-script: enabled")
 	}
@@ -286,6 +290,44 @@ func environmentSSHDetailLines(ssh common.ListSSHResult, indent string) []string
 		indent + "ssh-workspace-sync: " + enabledDisabledLabel(ssh.WorkspaceSyncEnabled),
 		indent + "ssh-workspace-sync-local-path: " + valueOrNone(ssh.WorkspaceSyncLocalPath),
 	}
+}
+
+// runtimeSizingLines render the standing recommendation under `runtime-pod:`,
+// which is the setting an operator would change to act on it. Two lines: the
+// verdicts, then the evidence they rest on. The evidence line is not optional
+// detail — a recommendation whose window and counters are invisible cannot be
+// argued with, and this one has to be argued with before anyone shrinks an
+// environment.
+func runtimeSizingLines(sizing *common.RuntimeSizingRecommendation, indent string) []string {
+	if sizing == nil {
+		return nil
+	}
+	verdicts := make([]string, 0, len(sizing.Verdicts))
+	for _, verdict := range sizing.Verdicts {
+		verdicts = append(verdicts, runtimeSizingVerdictLabel(verdict))
+	}
+	evidence := sizing.Evidence
+	return []string{
+		indent + "sizing: " + strings.Join(verdicts, "; "),
+		indent + fmt.Sprintf("sizing-evidence: %s observed, %d samples, %d restarts, knob=%s, from %s (not loadavg)",
+			common.FormatObservedWindow(time.Duration(evidence.ObservedSeconds)*time.Second),
+			evidence.Samples, evidence.Restarts, sizing.Knob, strings.Join(evidence.Signals, ", ")),
+	}
+}
+
+func runtimeSizingVerdictLabel(verdict common.RuntimeSizingVerdict) string {
+	label := verdict.Resource + " " + string(verdict.Action)
+	if suggested := strings.TrimSpace(verdict.Suggested); suggested != "" {
+		label += " to " + suggested
+	}
+	if current := strings.TrimSpace(verdict.Current); current != "" {
+		label += " from " + current
+	}
+	label += " (" + verdict.Reason
+	if verdict.Confidence != "" {
+		label += ", " + string(verdict.Confidence) + " confidence"
+	}
+	return label + ")"
 }
 
 func runtimePodLabel(pod common.RuntimePodResources) string {

--- a/erun-common/list.go
+++ b/erun-common/list.go
@@ -59,29 +59,35 @@ type ListTenantResult struct {
 }
 
 type ListEnvironmentResult struct {
-	Name                string                  `json:"name"`
-	Type                EnvironmentType         `json:"type,omitempty"`
-	APIURL              string                  `json:"apiUrl,omitempty"`
-	KubernetesContext   string                  `json:"kubernetesContext,omitempty"`
-	CloudProviderAlias  string                  `json:"cloudProviderAlias,omitempty"`
-	RepoPath            string                  `json:"repoPath,omitempty"`
-	LocalRepoPath       string                  `json:"localRepoPath,omitempty"`
-	ContainerRegistries ContainerRegistries     `json:"containerRegistries,omitempty"`
-	RuntimeVersion      string                  `json:"runtimeVersion,omitempty"`
-	RuntimePod          RuntimePodResources     `json:"runtimePod,omitempty"`
-	ManagedCloud        bool                    `json:"managedCloud,omitempty"`
-	DisableBuildScript  bool                    `json:"disableBuildScript,omitempty"`
-	PlatformAccount     bool                    `json:"platformAccount,omitempty"`
-	AITool              string                  `json:"aiTool,omitempty"`
-	Claude              EnvironmentClaudeConfig `json:"claude,omitempty"`
-	Idle                EnvironmentIdleConfig   `json:"idle,omitempty"`
-	Deploy              EnvironmentDeployConfig `json:"deploy,omitempty"`
-	IsActive            bool                    `json:"isActive,omitempty"`
-	LocalPorts          EnvironmentLocalPorts   `json:"localPorts,omitempty"`
-	IsDefault           bool                    `json:"isDefault,omitempty"`
-	IsEffective         bool                    `json:"isEffective,omitempty"`
-	SSH                 ListSSHResult           `json:"ssh,omitempty"`
-	AutoStart           *bool                   `json:"autoStart,omitempty"`
+	Name                string              `json:"name"`
+	Type                EnvironmentType     `json:"type,omitempty"`
+	APIURL              string              `json:"apiUrl,omitempty"`
+	KubernetesContext   string              `json:"kubernetesContext,omitempty"`
+	CloudProviderAlias  string              `json:"cloudProviderAlias,omitempty"`
+	RepoPath            string              `json:"repoPath,omitempty"`
+	LocalRepoPath       string              `json:"localRepoPath,omitempty"`
+	ContainerRegistries ContainerRegistries `json:"containerRegistries,omitempty"`
+	RuntimeVersion      string              `json:"runtimeVersion,omitempty"`
+	RuntimePod          RuntimePodResources `json:"runtimePod,omitempty"`
+	// Sizing is the environment's standing recommendation, derived from the usage
+	// history the in-pod monitor retains. Nil where erun has never observed this
+	// environment — which is every environment seen from a host other than its
+	// own runtime container, since the history is written by the container that
+	// produced it.
+	Sizing             *RuntimeSizingRecommendation `json:"sizing,omitempty"`
+	ManagedCloud       bool                         `json:"managedCloud,omitempty"`
+	DisableBuildScript bool                         `json:"disableBuildScript,omitempty"`
+	PlatformAccount    bool                         `json:"platformAccount,omitempty"`
+	AITool             string                       `json:"aiTool,omitempty"`
+	Claude             EnvironmentClaudeConfig      `json:"claude,omitempty"`
+	Idle               EnvironmentIdleConfig        `json:"idle,omitempty"`
+	Deploy             EnvironmentDeployConfig      `json:"deploy,omitempty"`
+	IsActive           bool                         `json:"isActive,omitempty"`
+	LocalPorts         EnvironmentLocalPorts        `json:"localPorts,omitempty"`
+	IsDefault          bool                         `json:"isDefault,omitempty"`
+	IsEffective        bool                         `json:"isEffective,omitempty"`
+	SSH                ListSSHResult                `json:"ssh,omitempty"`
+	AutoStart          *bool                        `json:"autoStart,omitempty"`
 }
 
 type ListSSHResult struct {
@@ -209,6 +215,7 @@ func listEnvironmentResult(store ListStore, tenant TenantConfig, env EnvConfig, 
 		ContainerRegistries: EffectiveEnvironmentContainerRegistries(env),
 		RuntimeVersion:      strings.TrimSpace(env.RuntimeVersion),
 		RuntimePod:          env.RuntimePod,
+		Sizing:              listEnvironmentSizing(tenant.Name, env),
 		ManagedCloud:        env.ManagedCloud,
 		DisableBuildScript:  env.DisableBuildScript,
 		PlatformAccount:     env.PlatformAccount,
@@ -223,6 +230,21 @@ func listEnvironmentResult(store ListStore, tenant TenantConfig, env EnvConfig, 
 		SSH:                 listSSHResult(listEnvironmentOpenResult(tenant, env, localPorts)),
 		AutoStart:           copyAutoStartPtr(env.AutoStart),
 	}
+}
+
+// listEnvironmentSizing attaches the standing recommendation when there is one.
+// A read failure is silence rather than an error: `erun list` is the fleet's
+// orientation command and must not fail over an advisory line.
+func listEnvironmentSizing(tenant string, env EnvConfig) *RuntimeSizingRecommendation {
+	history, err := LoadRuntimeUsageHistory(tenant, env.Name)
+	if err != nil {
+		return nil
+	}
+	recommendation, ok := RecommendRuntimeSizing(RuntimeSizingParams{History: history, Ceiling: env.NamespaceQuota})
+	if !ok {
+		return nil
+	}
+	return &recommendation
 }
 
 func copyAutoStartPtr(value *bool) *bool {

--- a/erun-common/runtime_sizing.go
+++ b/erun-common/runtime_sizing.go
@@ -1,0 +1,455 @@
+package eruncommon
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+// Sizing has always been a guess made once. A recommendation turns it into an
+// answer the environment produced itself — but the two ways of being wrong cost
+// very different amounts, and that asymmetry is the design rather than a detail
+// of it. An over-provisioned environment quietly consumes cluster capacity; an
+// under-provisioned one kills a running agent, which is the failure erun
+// currently explains after the fact with "likely out of memory". So erun raises
+// on modest evidence and shrinks only on a long, quiet window, never below a
+// healthy multiple of the peak it actually observed.
+
+const (
+	// runtimeSizingRaiseMemoryFraction is the share of the limit an observed
+	// peak has to reach before erun says raise. Set well below 1.0 on purpose:
+	// the sample interval means the true peak is always at least the peak
+	// observed, so an environment already touching 90% has plausibly touched
+	// more between two reads.
+	runtimeSizingRaiseMemoryFraction = 0.90
+
+	// runtimeSizingMemoryHeadroom is the multiple of the observed peak every
+	// memory recommendation targets and no shrink may cross — the whole safety
+	// margin of the shrink direction. 1.5 rather than 2.0 because 2.0 makes the
+	// recommender useless in practice: an environment can only be shrunk when
+	// its peak is under half the limit, and the two real over-provisioned
+	// environments this was measured against sat at 48% and 52% — so a doubling
+	// rule declares one of them fine and offers the other a rounding error. 1.5
+	// leaves 50% headroom above the worst moment ever recorded across a day or
+	// more, and the raise directions remain the backstop if that is ever wrong.
+	//
+	// It also cannot oscillate against runtimeSizingRaiseMemoryFraction: a
+	// shrink needs the peak under 1/1.5 of the limit and a raise needs it over
+	// 0.90, so the band between is hold, and a shrink lands exactly on the
+	// shrink boundary rather than past it.
+	runtimeSizingMemoryHeadroom = 1.5
+
+	// runtimeSizingCPUHeadroom plays the same role for CPU, and is deliberately
+	// larger than the memory multiple. memory.peak is a true instantaneous
+	// high-water the kernel recorded; the CPU figure is an average over the
+	// sample interval, so it flattens exactly the bursts a quota would throttle.
+	// A figure that understates its own peak needs more slack, not less.
+	runtimeSizingCPUHeadroom = 2.0
+
+	// runtimeSizingCPURaiseMultiple is how much more CPU a throttled
+	// environment is offered. Throttling proves demand exceeded the quota but
+	// not by how much — the quota itself censors that — so the raise is a
+	// deliberate half-step rather than the doubling a shrink's headroom uses.
+	runtimeSizingCPURaiseMultiple = 1.5
+
+	// runtimeSizingThrottleRatio is the share of scheduling periods that must
+	// be throttled before erun says raise CPU. Measured on a live environment,
+	// an ordinary week of work sat at 0.14% throttled — present but harmless —
+	// so a threshold anywhere near zero would recommend growing every
+	// environment in the fleet forever.
+	runtimeSizingThrottleRatio = 0.05
+
+	// runtimeSizingShrinkWindow is how long an environment must have been
+	// watched before erun will suggest making it smaller. A day covers a normal
+	// working cycle; anything shorter can miss the nightly build or the one
+	// heavy agent run that sets the real peak.
+	runtimeSizingShrinkWindow = 24 * time.Hour
+
+	// runtimeSizingShrinkSamples guards the other way a window can lie. A
+	// history whose first and last reading are a day apart but which holds four
+	// samples watched almost nothing; the span alone is not coverage.
+	runtimeSizingShrinkSamples = 120
+
+	// runtimeSizingThrottlePeriods is the minimum number of scheduling periods
+	// a throttle ratio must be computed over. A container seconds old has a few
+	// hundred periods and a ratio that swings wildly.
+	runtimeSizingThrottlePeriods = 10000
+
+	// runtimeSizingMemoryGraduationMi rounds a memory suggestion up to a round
+	// number of MiB. A recommendation of "18173Mi" implies a precision the
+	// evidence does not have; rounding up also keeps the headroom guarantee.
+	runtimeSizingMemoryGraduationMi = 256
+)
+
+// RuntimeSizingAction is the direction a recommendation points.
+type RuntimeSizingAction string
+
+const (
+	RuntimeSizingHold  RuntimeSizingAction = "hold"
+	RuntimeSizingRaise RuntimeSizingAction = "raise"
+	RuntimeSizingLower RuntimeSizingAction = "lower"
+	// RuntimeSizingUnknown is the honest answer when the window is too short or
+	// the counter was unavailable. It is not the same as hold: hold means erun
+	// looked and the size is right.
+	RuntimeSizingUnknown RuntimeSizingAction = "insufficient-evidence"
+)
+
+// RuntimeSizingConfidence separates "evidence of harm" from "absence of harm".
+// Only the raise directions are ever high: an OOM kill or sustained throttling
+// is a fact about damage already done, while a quiet window is an argument from
+// silence.
+type RuntimeSizingConfidence string
+
+const (
+	RuntimeSizingConfidenceHigh RuntimeSizingConfidence = "high"
+	RuntimeSizingConfidenceLow  RuntimeSizingConfidence = "low"
+)
+
+// RuntimeSizingVerdict is one resource's standing recommendation.
+type RuntimeSizingVerdict struct {
+	Resource   string                  `json:"resource"`
+	Action     RuntimeSizingAction     `json:"action"`
+	Current    string                  `json:"current,omitempty"`
+	Suggested  string                  `json:"suggested,omitempty"`
+	Confidence RuntimeSizingConfidence `json:"confidence,omitempty"`
+	Reason     string                  `json:"reason"`
+}
+
+// RuntimeSizingRecommendation is an environment's standing answer to "how
+// should this be sized". It recommends and never applies: resizing means a
+// deploy, and an environment silently resized mid-run is a worse failure than
+// any this prevents.
+type RuntimeSizingRecommendation struct {
+	// Knob is the setting an operator changes to act on this, and it is always
+	// runtimepod — the one that sizes the runtime container. NamespaceQuota is a
+	// different setting that caps the whole namespace; sending an operator there
+	// makes them change something that resizes nothing.
+	Knob     string                 `json:"knob"`
+	Verdicts []RuntimeSizingVerdict `json:"verdicts"`
+	Evidence RuntimeSizingEvidence  `json:"evidence"`
+}
+
+// RuntimeSizingEvidence is what the recommendation was derived from, carried
+// with it so a reader can disagree with the conclusion on the merits.
+type RuntimeSizingEvidence struct {
+	// ObservedSeconds and Samples are the evidence window. A recommendation
+	// that does not state its window cannot be judged.
+	ObservedSeconds int64 `json:"observedSeconds"`
+	Samples         int   `json:"samples"`
+	// Restarts matters because memory.peak resets on each one. A peak that
+	// survived restarts was retained by erun, not read from the counter.
+	Restarts int `json:"restarts"`
+
+	MemoryLimitBytes        int64 `json:"memoryLimitBytes,omitempty"`
+	ObservedPeakMemoryBytes int64 `json:"observedPeakMemoryBytes,omitempty"`
+	ObservedOOMKills        int64 `json:"observedOomKills"`
+
+	CPUQuotaMilli            int64 `json:"cpuQuotaMilli,omitempty"`
+	ObservedPeakCPUMilli     int64 `json:"observedPeakCpuMilli,omitempty"`
+	ObservedPeriods          int64 `json:"observedPeriods,omitempty"`
+	ObservedThrottledPeriods int64 `json:"observedThrottledPeriods,omitempty"`
+
+	// Signals names the counter behind every figure above. It exists because the
+	// obvious substitute is a host loadavg, and a loadavg answers a different
+	// question: it counts the machine's runnable queue, so a 12-core
+	// environment sitting at a load of 10 looks saturated while cpu.stat
+	// reports not one throttled period. Nothing here is loadavg-derived.
+	Signals []string `json:"signals,omitempty"`
+	// Unavailable names counters the host did not supply, e.g. PSI, which is
+	// absent on some kernels and which nothing here depends on.
+	Unavailable []string `json:"unavailable,omitempty"`
+}
+
+// RuntimeSizingParams is the recommender's whole input, so it is a pure
+// function of retained history and configuration.
+type RuntimeSizingParams struct {
+	History RuntimeUsageHistory
+	// Ceiling bounds a raise. A namespace ResourceQuota is a hard admission
+	// limit, so a runtimepod above what it can admit is a recommendation that
+	// cannot be deployed. Zero means no quota is configured and no ceiling is
+	// known here.
+	Ceiling NamespaceResourceQuota
+}
+
+// RecommendRuntimeSizing derives an environment's standing recommendation from
+// its retained history. Pure, so every direction is testable without a cluster.
+// Reports false when there is no observation at all — an environment erun has
+// never watched gets silence, not a guess.
+//
+// Note what it does *not* read: the environment's configured runtimepod. That
+// value is the knob to change, not the size to reason from. The in-pod config
+// carries no runtimepod at all (the chart injects the container's limits), so
+// scoring the live container against the declared value would score it against
+// NormalizeRuntimePodResources' defaults — on a 12-core, 23552Mi environment
+// whose config is silent, that reads as a 8916Mi limit and turns a 2x
+// over-provision into a recommendation to grow. The cgroup limit is the size
+// the container is actually running under, so it is the size that is scored.
+func RecommendRuntimeSizing(params RuntimeSizingParams) (RuntimeSizingRecommendation, bool) {
+	history := params.History
+	latest, ok := history.Latest()
+	if !ok {
+		return RuntimeSizingRecommendation{}, false
+	}
+
+	evidence := RuntimeSizingEvidence{
+		ObservedSeconds:          int64(history.ObservedWindow() / time.Second),
+		Samples:                  len(history.Samples),
+		Restarts:                 history.Restarts,
+		MemoryLimitBytes:         latest.Memory.LimitBytes,
+		ObservedPeakMemoryBytes:  history.ObservedPeakMemoryBytes,
+		ObservedOOMKills:         history.ObservedOOMKills,
+		CPUQuotaMilli:            runtimeQuotaMilli(latest.CPU.QuotaCores),
+		ObservedPeakCPUMilli:     history.ObservedPeakCPUMilli,
+		ObservedPeriods:          history.ObservedPeriods,
+		ObservedThrottledPeriods: history.ObservedThrottledPeriods,
+		Signals:                  []string{"cgroup memory.peak", "cgroup memory.events oom_kill", "cgroup cpu.stat usage_usec/nr_throttled"},
+		Unavailable:              runtimeUsageUnavailable(latest),
+	}
+
+	return RuntimeSizingRecommendation{
+		Knob: "runtimepod",
+		Verdicts: []RuntimeSizingVerdict{
+			recommendRuntimeMemory(history, latest, params.Ceiling),
+			recommendRuntimeCPU(history, latest),
+		},
+		Evidence: evidence,
+	}, true
+}
+
+func recommendRuntimeMemory(history RuntimeUsageHistory, latest RuntimeUsage, ceiling NamespaceResourceQuota) RuntimeSizingVerdict {
+	verdict := RuntimeSizingVerdict{Resource: "memory"}
+	limit := latest.Memory.LimitBytes
+	if limit <= 0 {
+		verdict.Action = RuntimeSizingUnknown
+		verdict.Reason = "memory.max reports no limit, so there is nothing to size against"
+		return verdict
+	}
+	verdict.Current = formatBytesAsMi(limit)
+	peak := history.ObservedPeakMemoryBytes
+
+	if history.ObservedOOMKills > 0 {
+		// A kill is evidence of harm, and one is enough. The observed peak is
+		// also the wrong basis after a kill: the allocation that triggered it
+		// was refused, so it never landed in memory.peak. Size from the limit
+		// that proved too small instead.
+		verdict.Action = RuntimeSizingRaise
+		verdict.Confidence = RuntimeSizingConfidenceHigh
+		suggested, bounded := boundRuntimeMemorySuggestion(scaleBytesToMi(limit, runtimeSizingMemoryHeadroom), ceiling)
+		verdict.Suggested = suggested
+		verdict.Reason = fmt.Sprintf("%d oom kill(s) at %s%s", history.ObservedOOMKills, formatBytesAsMi(limit), bounded)
+		return verdict
+	}
+
+	if float64(peak) >= float64(limit)*runtimeSizingRaiseMemoryFraction {
+		verdict.Action = RuntimeSizingRaise
+		verdict.Confidence = RuntimeSizingConfidenceHigh
+		suggested, bounded := boundRuntimeMemorySuggestion(scaleBytesToMi(peak, runtimeSizingMemoryHeadroom), ceiling)
+		verdict.Suggested = suggested
+		verdict.Reason = fmt.Sprintf("peak %s of %s (%s) is within the raise margin%s", formatBytesAsMi(peak), formatBytesAsMi(limit), formatPercent(peak, limit), bounded)
+		return verdict
+	}
+
+	if reason, ok := runtimeSizingShrinkWindowShortfall(history); !ok {
+		verdict.Action = RuntimeSizingUnknown
+		verdict.Reason = fmt.Sprintf("peak %s of %s (%s), but %s", formatBytesAsMi(peak), formatBytesAsMi(limit), formatPercent(peak, limit), reason)
+		return verdict
+	}
+
+	suggested := scaleBytesToMi(peak, runtimeSizingMemoryHeadroom)
+	if suggested >= limit {
+		verdict.Action = RuntimeSizingHold
+		verdict.Reason = fmt.Sprintf("peak %s of %s (%s) leaves no room to shrink at %gx headroom", formatBytesAsMi(peak), formatBytesAsMi(limit), formatPercent(peak, limit), runtimeSizingMemoryHeadroom)
+		return verdict
+	}
+	verdict.Action = RuntimeSizingLower
+	// Low, always. A quiet window is an argument from silence: it says erun saw
+	// no harm, not that none is possible.
+	verdict.Confidence = RuntimeSizingConfidenceLow
+	verdict.Suggested = formatBytesAsMi(suggested)
+	verdict.Reason = fmt.Sprintf("peak %s of %s (%s), no oom kills, keeping %gx headroom", formatBytesAsMi(peak), formatBytesAsMi(limit), formatPercent(peak, limit), runtimeSizingMemoryHeadroom)
+	return verdict
+}
+
+func recommendRuntimeCPU(history RuntimeUsageHistory, latest RuntimeUsage) RuntimeSizingVerdict {
+	verdict := RuntimeSizingVerdict{Resource: "cpu"}
+	quota := runtimeQuotaMilli(latest.CPU.QuotaCores)
+	if quota <= 0 {
+		verdict.Action = RuntimeSizingUnknown
+		verdict.Reason = "cpu.max reports no quota, so there is nothing to size against"
+		return verdict
+	}
+	verdict.Current = FormatKubernetesCPUFromMilli(quota)
+	periods := history.ObservedPeriods
+	throttled := history.ObservedThrottledPeriods
+
+	if periods >= runtimeSizingThrottlePeriods && float64(throttled) >= float64(periods)*runtimeSizingThrottleRatio {
+		verdict.Action = RuntimeSizingRaise
+		verdict.Confidence = RuntimeSizingConfidenceHigh
+		verdict.Suggested = FormatKubernetesCPUFromMilli(scaleMilliToWholeCores(quota, runtimeSizingCPURaiseMultiple))
+		verdict.Reason = fmt.Sprintf("%s of scheduling periods throttled (%d of %d)", formatThrottleRatio(throttled, periods), throttled, periods)
+		return verdict
+	}
+
+	throttleLabel := fmt.Sprintf("%s of scheduling periods throttled (%d of %d)", formatThrottleRatio(throttled, periods), throttled, periods)
+	if reason, ok := runtimeSizingShrinkWindowShortfall(history); !ok {
+		verdict.Action = RuntimeSizingUnknown
+		verdict.Reason = fmt.Sprintf("%s, but %s", throttleLabel, reason)
+		return verdict
+	}
+	if periods < runtimeSizingThrottlePeriods {
+		verdict.Action = RuntimeSizingUnknown
+		verdict.Reason = fmt.Sprintf("only %d scheduling periods observed, too few to read a throttle ratio from", periods)
+		return verdict
+	}
+	if throttled > 0 {
+		// Below the raise threshold but not at zero: the quota already binds
+		// sometimes. That is not grounds to grow, and it is emphatically not
+		// grounds to shrink — a ratio under the threshold is "tolerable", not
+		// "unused". frs/local's measured 0.14% is exactly this case.
+		verdict.Action = RuntimeSizingHold
+		verdict.Reason = throttleLabel + ", tolerable but not unused"
+		return verdict
+	}
+	if history.ObservedPeakCPUMilli <= 0 {
+		verdict.Action = RuntimeSizingUnknown
+		verdict.Reason = "no cpu rate observed between samples"
+		return verdict
+	}
+
+	suggested := scaleMilliToWholeCores(history.ObservedPeakCPUMilli, runtimeSizingCPUHeadroom)
+	peakLabel := fmt.Sprintf("busiest interval %s of %s", FormatKubernetesCPUFromMilli(history.ObservedPeakCPUMilli), FormatKubernetesCPUFromMilli(quota))
+	if suggested >= quota {
+		verdict.Action = RuntimeSizingHold
+		verdict.Reason = fmt.Sprintf("%s, %s", peakLabel, throttleLabel)
+		return verdict
+	}
+	verdict.Action = RuntimeSizingLower
+	verdict.Confidence = RuntimeSizingConfidenceLow
+	verdict.Suggested = FormatKubernetesCPUFromMilli(suggested)
+	verdict.Reason = fmt.Sprintf("%s, %s, keeping %gx headroom", peakLabel, throttleLabel, runtimeSizingCPUHeadroom)
+	return verdict
+}
+
+// runtimeSizingShrinkWindowShortfall gates every shrink on the same two window
+// tests, and returns the shortfall as prose so the reason a recommendation was
+// withheld is as visible as one that was made.
+func runtimeSizingShrinkWindowShortfall(history RuntimeUsageHistory) (string, bool) {
+	if window := history.ObservedWindow(); window < runtimeSizingShrinkWindow {
+		return fmt.Sprintf("only %s observed of the %s a shrink needs", FormatObservedWindow(window), FormatObservedWindow(runtimeSizingShrinkWindow)), false
+	}
+	if len(history.Samples) < runtimeSizingShrinkSamples {
+		return fmt.Sprintf("only %d samples retained of the %d a shrink needs", len(history.Samples), runtimeSizingShrinkSamples), false
+	}
+	return "", true
+}
+
+// boundRuntimeMemorySuggestion clamps a raise to what the namespace can admit,
+// returning the clamped value and a note for the verdict's reason when it bit.
+// A ResourceQuota counts every container in the pod, so the erun-dind sidecar's
+// own limit is spent before the runtime container gets anything, and a
+// suggestion above the remainder is one Kubernetes would refuse to schedule.
+// This is a bound, not the knob: raising the quota is a separate decision from
+// resizing the pod.
+func boundRuntimeMemorySuggestion(suggested int64, ceiling NamespaceResourceQuota) (string, string) {
+	quotaMi, err := ParseKubernetesMemoryToMi(ceiling.Memory)
+	if err != nil {
+		return formatBytesAsMi(suggested), ""
+	}
+	dindMi, err := ParseKubernetesMemoryToMi(DefaultRuntimeDindMemory)
+	if err != nil {
+		return formatBytesAsMi(suggested), ""
+	}
+	const mi = 1024 * 1024
+	available := (quotaMi - dindMi) * mi
+	if available <= 0 || suggested <= available {
+		return formatBytesAsMi(suggested), ""
+	}
+	graduation := int64(runtimeSizingMemoryGraduationMi) * mi
+	note := fmt.Sprintf("; bounded by the %s namespace quota less the dind sidecar's %s", ceiling.Memory, DefaultRuntimeDindMemory)
+	return formatBytesAsMi(available - available%graduation), note
+}
+
+// scaleBytesToMi multiplies a byte figure and rounds it up to a round number of
+// MiB. Rounding up, never down, is what keeps the headroom guarantee intact
+// after graduation.
+func scaleBytesToMi(bytes int64, multiple float64) int64 {
+	const mi = 1024 * 1024
+	graduation := int64(runtimeSizingMemoryGraduationMi) * mi
+	scaled := int64(math.Ceil(float64(bytes) * multiple))
+	steps := (scaled + graduation - 1) / graduation
+	if steps < 1 {
+		steps = 1
+	}
+	return steps * graduation
+}
+
+// scaleMilliToWholeCores multiplies a millicore figure and rounds up to a whole
+// core. Every environment in the fleet is sized in whole cores, and a
+// fractional suggestion derived from sampled intervals claims a precision the
+// samples do not have.
+func scaleMilliToWholeCores(milli int64, multiple float64) int64 {
+	scaled := int64(math.Ceil(float64(milli) * multiple))
+	cores := (scaled + 999) / 1000
+	if cores < 1 {
+		cores = 1
+	}
+	return cores * 1000
+}
+
+func formatBytesAsMi(bytes int64) string {
+	return fmt.Sprintf("%dMi", (bytes+1024*1024-1)/(1024*1024))
+}
+
+// formatThrottleRatio keeps two decimals because the interesting throttle
+// ratios are fractions of a percent: a measured 425 of 308631 periods rounds to
+// "0%" at whole-number precision, which reads as "never throttled" when the
+// point of the figure is that it was, a little.
+func formatThrottleRatio(throttled, periods int64) string {
+	if periods <= 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.2f%%", float64(throttled)/float64(periods)*100)
+}
+
+func formatPercent(part, whole int64) string {
+	if whole <= 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.0f%%", float64(part)/float64(whole)*100)
+}
+
+// runtimeQuotaMilli converts RuntimeCPUUsage's cores-based quota into the
+// millicore unit every sizing figure and NamespaceResourceQuota comparison in
+// this file uses.
+func runtimeQuotaMilli(quotaCores float64) int64 {
+	return int64(math.Round(quotaCores * 1000))
+}
+
+// runtimeUsageUnavailable collects the latest reading's per-resource
+// unavailability into the flat list RuntimeSizingEvidence reports, since
+// RuntimeUsage names each gap on its own CPU/Memory reading rather than in one
+// shared list.
+func runtimeUsageUnavailable(latest RuntimeUsage) []string {
+	var unavailable []string
+	if latest.Memory.Unavailable != "" {
+		unavailable = append(unavailable, latest.Memory.Unavailable)
+	}
+	if latest.CPU.Unavailable != "" {
+		unavailable = append(unavailable, latest.CPU.Unavailable)
+	}
+	return unavailable
+}
+
+// FormatObservedWindow renders an evidence window at minute resolution. Whole
+// minutes keep the figure stable between two readings taken moments apart,
+// which a seconds-resolution figure would not be.
+func FormatObservedWindow(window time.Duration) string {
+	if window < 0 {
+		window = 0
+	}
+	minutes := int64(window / time.Minute)
+	if minutes < 60 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	return fmt.Sprintf("%dh%dm", minutes/60, minutes%60)
+}

--- a/erun-common/runtime_sizing_test.go
+++ b/erun-common/runtime_sizing_test.go
@@ -1,0 +1,504 @@
+package eruncommon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const (
+	testMi = int64(1024 * 1024)
+	testGi = 1024 * testMi
+)
+
+// usageHistory builds a history with the aggregates a recommendation reads, plus
+// a sample count and window, without running the sampler.
+func usageHistory(window time.Duration, samples int, latest RuntimeUsage) RuntimeUsageHistory {
+	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	history := RuntimeUsageHistory{FirstObservedAt: start, LastObservedAt: start.Add(window)}
+	for i := 0; i < samples; i++ {
+		history.Samples = append(history.Samples, latest)
+	}
+	if samples == 0 {
+		history.Samples = append(history.Samples, latest)
+	}
+	return history
+}
+
+func verdictFor(t *testing.T, recommendation RuntimeSizingRecommendation, resource string) RuntimeSizingVerdict {
+	t.Helper()
+	for _, verdict := range recommendation.Verdicts {
+		if verdict.Resource == resource {
+			return verdict
+		}
+	}
+	t.Fatalf("no %s verdict in %+v", resource, recommendation.Verdicts)
+	return RuntimeSizingVerdict{}
+}
+
+type memoryDirectionCase struct {
+	name           string
+	history        RuntimeUsageHistory
+	ceiling        NamespaceResourceQuota
+	wantAction     RuntimeSizingAction
+	wantConfidence RuntimeSizingConfidence
+	wantSuggested  string
+}
+
+// runMemoryDirectionCases asserts one verdict per case and, on every one, that
+// the recommendation names runtimepod and carries a reason.
+func runMemoryDirectionCases(t *testing.T, cases []memoryDirectionCase) {
+	t.Helper()
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			recommendation, ok := RecommendRuntimeSizing(RuntimeSizingParams{History: testCase.history, Ceiling: testCase.ceiling})
+			if !ok {
+				t.Fatal("expected a recommendation")
+			}
+			if recommendation.Knob != "runtimepod" {
+				t.Fatalf("knob = %q, want runtimepod: naming namespacequota sends the operator to a setting that resizes nothing", recommendation.Knob)
+			}
+			verdict := verdictFor(t, recommendation, "memory")
+			if verdict.Action != testCase.wantAction {
+				t.Fatalf("action = %q, want %q (reason: %s)", verdict.Action, testCase.wantAction, verdict.Reason)
+			}
+			if verdict.Confidence != testCase.wantConfidence {
+				t.Fatalf("confidence = %q, want %q", verdict.Confidence, testCase.wantConfidence)
+			}
+			if verdict.Suggested != testCase.wantSuggested {
+				t.Fatalf("suggested = %q, want %q", verdict.Suggested, testCase.wantSuggested)
+			}
+			if verdict.Reason == "" {
+				t.Fatal("a verdict with no reason cannot be argued with")
+			}
+		})
+	}
+}
+
+// TestRecommendRuntimeSizingRaisesMemory covers the directions taken on
+// evidence of harm, which need no long window.
+func TestRecommendRuntimeSizingRaisesMemory(t *testing.T) {
+	quietWindow := 26 * time.Hour
+	quietSamples := 200
+
+	runMemoryDirectionCases(t, []memoryDirectionCase{
+		{
+			name: "peak at 95 percent of limit raises on high confidence",
+			history: func() RuntimeUsageHistory {
+				h := usageHistory(quietWindow, quietSamples, RuntimeUsage{Memory: RuntimeMemoryUsage{LimitBytes: 2 * testGi}})
+				h.ObservedPeakMemoryBytes = 2*testGi - 100*testMi
+				return h
+			}(),
+			wantAction:     RuntimeSizingRaise,
+			wantConfidence: RuntimeSizingConfidenceHigh,
+			wantSuggested:  "3072Mi",
+		},
+		{
+			// One kill is enough, and it outranks a comfortable-looking peak:
+			// the allocation that was refused never reached memory.peak.
+			name: "a single oom kill raises even though the peak looks comfortable",
+			history: func() RuntimeUsageHistory {
+				h := usageHistory(time.Minute, 2, RuntimeUsage{Memory: RuntimeMemoryUsage{LimitBytes: 2 * testGi}})
+				h.ObservedPeakMemoryBytes = 512 * testMi
+				h.ObservedOOMKills = 1
+				return h
+			}(),
+			wantAction:     RuntimeSizingRaise,
+			wantConfidence: RuntimeSizingConfidenceHigh,
+			wantSuggested:  "3072Mi",
+		},
+		{
+			// The quota counts every container in the pod, so a raise above what
+			// it can admit is a size Kubernetes would refuse to schedule.
+			name: "a raise is bounded by the namespace quota",
+			history: func() RuntimeUsageHistory {
+				h := usageHistory(quietWindow, quietSamples, RuntimeUsage{Memory: RuntimeMemoryUsage{LimitBytes: 20 * testGi}})
+				h.ObservedOOMKills = 2
+				return h
+			}(),
+			ceiling:        NamespaceResourceQuota{CPU: "8", Memory: "32Gi", Storage: "80Gi"},
+			wantAction:     RuntimeSizingRaise,
+			wantConfidence: RuntimeSizingConfidenceHigh,
+			wantSuggested:  "23808Mi",
+		},
+	})
+}
+
+// TestRecommendRuntimeSizingShrinksOrWithholdsMemory covers the directions that
+// rest on an absence of harm, and the window gates that must withhold them.
+func TestRecommendRuntimeSizingShrinksOrWithholdsMemory(t *testing.T) {
+	quietWindow := 26 * time.Hour
+	quietSamples := 200
+
+	runMemoryDirectionCases(t, []memoryDirectionCase{
+		{
+			name: "peak at 20 percent lowers to the headroom multiple",
+			history: func() RuntimeUsageHistory {
+				h := usageHistory(quietWindow, quietSamples, RuntimeUsage{Memory: RuntimeMemoryUsage{LimitBytes: 10 * testGi}})
+				h.ObservedPeakMemoryBytes = 2 * testGi
+				return h
+			}(),
+			wantAction:     RuntimeSizingLower,
+			wantConfidence: RuntimeSizingConfidenceLow,
+			wantSuggested:  "3072Mi",
+		},
+		{
+			name: "a short window recommends nothing",
+			history: func() RuntimeUsageHistory {
+				h := usageHistory(time.Hour, 100, RuntimeUsage{Memory: RuntimeMemoryUsage{LimitBytes: 10 * testGi}})
+				h.ObservedPeakMemoryBytes = 1 * testGi
+				return h
+			}(),
+			wantAction: RuntimeSizingUnknown,
+		},
+		{
+			// A day of wall time holding a handful of readings watched almost
+			// nothing. The span alone is not coverage.
+			name: "a long window with too few samples recommends nothing",
+			history: func() RuntimeUsageHistory {
+				h := usageHistory(quietWindow, 4, RuntimeUsage{Memory: RuntimeMemoryUsage{LimitBytes: 10 * testGi}})
+				h.ObservedPeakMemoryBytes = 1 * testGi
+				return h
+			}(),
+			wantAction: RuntimeSizingUnknown,
+		},
+		{
+			name: "no limit is reported as unmeasurable, not as zero",
+			history: usageHistory(quietWindow, quietSamples, RuntimeUsage{
+				CPU:    RuntimeCPUUsage{QuotaCores: 1},
+				Memory: RuntimeMemoryUsage{Unavailable: "memory.max was not readable"},
+			}),
+			wantAction: RuntimeSizingUnknown,
+		},
+		{
+			name: "a peak just under the raise margin holds rather than shrinking",
+			history: func() RuntimeUsageHistory {
+				h := usageHistory(quietWindow, quietSamples, RuntimeUsage{Memory: RuntimeMemoryUsage{LimitBytes: 10 * testGi}})
+				h.ObservedPeakMemoryBytes = 8 * testGi
+				return h
+			}(),
+			wantAction: RuntimeSizingHold,
+		},
+	})
+}
+
+func TestRecommendRuntimeSizingCPUDirections(t *testing.T) {
+	quietWindow := 26 * time.Hour
+	quietSamples := 200
+
+	cases := []struct {
+		name          string
+		history       RuntimeUsageHistory
+		wantAction    RuntimeSizingAction
+		wantSuggested string
+	}{
+		{
+			// The false-positive check the issue names: frs/local's measured
+			// 425/308631 throttled periods must not grow the environment.
+			name: "a 0.14 percent throttle ratio does not raise cpu",
+			history: func() RuntimeUsageHistory {
+				h := usageHistory(quietWindow, quietSamples, RuntimeUsage{CPU: RuntimeCPUUsage{QuotaCores: 1}, Memory: RuntimeMemoryUsage{LimitBytes: 2 * testGi}})
+				h.ObservedPeriods = 308631
+				h.ObservedThrottledPeriods = 425
+				h.ObservedPeakCPUMilli = 200
+				return h
+			}(),
+			wantAction: RuntimeSizingHold,
+		},
+		{
+			// The same ratio on a quota roomy enough that the busiest-interval
+			// figure would otherwise propose a shrink. Sub-threshold throttling
+			// means "tolerable", not "unused", so it must block the shrink — the
+			// frs/local case above cannot prove this on its own, because a
+			// one-core quota leaves no room to shrink into either way.
+			name: "sub-threshold throttling disqualifies a shrink",
+			history: func() RuntimeUsageHistory {
+				h := usageHistory(quietWindow, quietSamples, RuntimeUsage{CPU: RuntimeCPUUsage{QuotaCores: 4}, Memory: RuntimeMemoryUsage{LimitBytes: 2 * testGi}})
+				h.ObservedPeriods = 308631
+				h.ObservedThrottledPeriods = 425
+				h.ObservedPeakCPUMilli = 200
+				return h
+			}(),
+			wantAction: RuntimeSizingHold,
+		},
+		{
+			name: "a sustained throttle ratio raises cpu",
+			history: func() RuntimeUsageHistory {
+				h := usageHistory(quietWindow, quietSamples, RuntimeUsage{CPU: RuntimeCPUUsage{QuotaCores: 2}, Memory: RuntimeMemoryUsage{LimitBytes: 2 * testGi}})
+				h.ObservedPeriods = 100000
+				h.ObservedThrottledPeriods = 12000
+				h.ObservedPeakCPUMilli = 1900
+				return h
+			}(),
+			wantAction:    RuntimeSizingRaise,
+			wantSuggested: "3",
+		},
+		{
+			// erun/build's real shape: twelve cores, not one throttled period,
+			// and a busiest interval well under half the quota.
+			name: "an unthrottled quota well above the busiest interval lowers cpu",
+			history: func() RuntimeUsageHistory {
+				h := usageHistory(quietWindow, quietSamples, RuntimeUsage{CPU: RuntimeCPUUsage{QuotaCores: 12}, Memory: RuntimeMemoryUsage{LimitBytes: 23 * testGi}})
+				h.ObservedPeriods = 376556
+				h.ObservedThrottledPeriods = 0
+				h.ObservedPeakCPUMilli = 4567
+				return h
+			}(),
+			wantAction:    RuntimeSizingLower,
+			wantSuggested: "10",
+		},
+		{
+			name: "too few scheduling periods recommends nothing",
+			history: func() RuntimeUsageHistory {
+				h := usageHistory(quietWindow, quietSamples, RuntimeUsage{CPU: RuntimeCPUUsage{QuotaCores: 1}, Memory: RuntimeMemoryUsage{LimitBytes: 2 * testGi}})
+				h.ObservedPeriods = 500
+				h.ObservedPeakCPUMilli = 100
+				return h
+			}(),
+			wantAction: RuntimeSizingUnknown,
+		},
+		{
+			name: "no quota is reported as unmeasurable",
+			history: usageHistory(quietWindow, quietSamples, RuntimeUsage{
+				Memory: RuntimeMemoryUsage{LimitBytes: 2 * testGi},
+				CPU:    RuntimeCPUUsage{Unavailable: "cpu.max reports no quota (unlimited or not readable); utilisation needs a quota to measure against"},
+			}),
+			wantAction: RuntimeSizingUnknown,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			recommendation, ok := RecommendRuntimeSizing(RuntimeSizingParams{History: testCase.history})
+			if !ok {
+				t.Fatal("expected a recommendation")
+			}
+			verdict := verdictFor(t, recommendation, "cpu")
+			if verdict.Action != testCase.wantAction {
+				t.Fatalf("action = %q, want %q (reason: %s)", verdict.Action, testCase.wantAction, verdict.Reason)
+			}
+			if verdict.Suggested != testCase.wantSuggested {
+				t.Fatalf("suggested = %q, want %q", verdict.Suggested, testCase.wantSuggested)
+			}
+		})
+	}
+}
+
+// TestRecommendRuntimeSizingNeverShrinksBelowHeadroom is the asymmetry gate. A
+// recommender tested only on comfortable inputs is untested: the failure that
+// matters is a shrink that lands close enough to the observed peak to start
+// killing agents, so no input may produce one.
+func TestRecommendRuntimeSizingNeverShrinksBelowHeadroom(t *testing.T) {
+	limits := []int64{512 * testMi, 2 * testGi, 8704 * testMi, 23552 * testMi, 64 * testGi}
+	peakFractions := []float64{0.001, 0.01, 0.09, 0.17, 0.33, 0.4999, 0.5, 0.7, 0.89}
+	windows := []time.Duration{0, time.Hour, 23 * time.Hour, 24 * time.Hour, 200 * time.Hour}
+	sampleCounts := []int{1, 119, 120, 5000}
+
+	for _, limit := range limits {
+		for _, fraction := range peakFractions {
+			for _, window := range windows {
+				for _, samples := range sampleCounts {
+					peak := int64(float64(limit) * fraction)
+					history := usageHistory(window, samples, RuntimeUsage{Memory: RuntimeMemoryUsage{LimitBytes: limit}, CPU: RuntimeCPUUsage{QuotaCores: 4}})
+					history.ObservedPeakMemoryBytes = peak
+					recommendation, ok := RecommendRuntimeSizing(RuntimeSizingParams{History: history})
+					if !ok {
+						t.Fatal("expected a recommendation")
+					}
+					verdict := verdictFor(t, recommendation, "memory")
+					if verdict.Action != RuntimeSizingLower {
+						continue
+					}
+					suggestedMi, err := ParseKubernetesMemoryToMi(verdict.Suggested)
+					if err != nil {
+						t.Fatalf("unparseable suggestion %q: %v", verdict.Suggested, err)
+					}
+					floor := int64(float64(peak) * runtimeSizingMemoryHeadroom)
+					if suggestedMi*testMi < floor {
+						t.Fatalf("limit=%d peak=%d: suggested %s is below %.0fx the observed peak", limit, peak, verdict.Suggested, runtimeSizingMemoryHeadroom)
+					}
+					if suggestedMi*testMi >= limit {
+						t.Fatalf("limit=%d peak=%d: shrink to %s is not smaller than the current limit", limit, peak, verdict.Suggested)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestRecommendRuntimeSizingAnyOOMKillRaises is the other half of the gate: a
+// single kill must be enough, whatever else the history says.
+func TestRecommendRuntimeSizingAnyOOMKillRaises(t *testing.T) {
+	for _, window := range []time.Duration{0, time.Minute, 500 * time.Hour} {
+		for _, samples := range []int{1, 240} {
+			for _, peakFraction := range []float64{0.0, 0.05, 0.5, 0.99} {
+				limit := 8 * testGi
+				history := usageHistory(window, samples, RuntimeUsage{Memory: RuntimeMemoryUsage{LimitBytes: limit}, CPU: RuntimeCPUUsage{QuotaCores: 4}})
+				history.ObservedPeakMemoryBytes = int64(float64(limit) * peakFraction)
+				history.ObservedOOMKills = 1
+				recommendation, ok := RecommendRuntimeSizing(RuntimeSizingParams{History: history})
+				if !ok {
+					t.Fatal("expected a recommendation")
+				}
+				verdict := verdictFor(t, recommendation, "memory")
+				if verdict.Action != RuntimeSizingRaise || verdict.Confidence != RuntimeSizingConfidenceHigh {
+					t.Fatalf("window=%s samples=%d peak=%.2f: got %q/%q, want raise/high", window, samples, peakFraction, verdict.Action, verdict.Confidence)
+				}
+			}
+		}
+	}
+}
+
+func TestRecommendRuntimeSizingWithoutHistoryStaysSilent(t *testing.T) {
+	if _, ok := RecommendRuntimeSizing(RuntimeSizingParams{}); ok {
+		t.Fatal("an environment erun has never observed must get silence, not a guess")
+	}
+}
+
+// TestAppendRuntimeUsageSampleRetainsPeakAcrossARestart is the retention
+// contract. memory.peak resets when the container restarts, so a history that
+// trusted the live counter would forget the pre-restart high-water — the exact
+// failure that would under-size an environment.
+func TestAppendRuntimeUsageSampleRetainsPeakAcrossARestart(t *testing.T) {
+	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	history := RuntimeUsageHistory{}
+	history = AppendRuntimeUsageSample(history, RuntimeUsage{
+		Memory: RuntimeMemoryUsage{LimitBytes: 8 * testGi, PeakBytes: 6 * testGi, OOMKills: 1},
+		CPU:    RuntimeCPUUsage{UsageUsec: 1_000_000, Periods: 5000, ThrottledPeriods: 10},
+	}, base)
+	// A restart: every cumulative counter starts over, and the new peak is
+	// lower than the one already observed.
+	history = AppendRuntimeUsageSample(history, RuntimeUsage{
+		Memory: RuntimeMemoryUsage{LimitBytes: 8 * testGi, PeakBytes: 1 * testGi},
+		CPU:    RuntimeCPUUsage{UsageUsec: 100, Periods: 3},
+	}, base.Add(time.Hour))
+
+	if history.Restarts != 1 {
+		t.Fatalf("restarts = %d, want 1", history.Restarts)
+	}
+	if history.ObservedPeakMemoryBytes != 6*testGi {
+		t.Fatalf("observed peak = %d, want the pre-restart %d", history.ObservedPeakMemoryBytes, 6*testGi)
+	}
+	if history.ObservedOOMKills != 1 {
+		t.Fatalf("oom kills = %d, want the pre-restart kill retained", history.ObservedOOMKills)
+	}
+	if history.ObservedPeriods != 5003 {
+		t.Fatalf("periods = %d, want both lifetimes accumulated", history.ObservedPeriods)
+	}
+
+	// And the recommender must size from the retained peak, not the live one:
+	// 6Gi of 8Gi is within the raise margin, while the post-restart 1Gi would
+	// look like a shrink candidate.
+	recommendation, ok := RecommendRuntimeSizing(RuntimeSizingParams{History: history})
+	if !ok {
+		t.Fatal("expected a recommendation")
+	}
+	if verdict := verdictFor(t, recommendation, "memory"); verdict.Action != RuntimeSizingRaise {
+		t.Fatalf("memory action = %q, want raise from the retained peak (reason: %s)", verdict.Action, verdict.Reason)
+	}
+}
+
+// TestAppendRuntimeUsageSampleBoundsTheWindow pins that a long-running
+// environment cannot grow the history without bound, and — the point of the
+// bound coexisting with the aggregates — that the high-water survives the
+// eviction of the sample that recorded it. Here the peak is set in the very
+// first sample, the container then restarts and runs quietly for long enough to
+// push that sample out of the window entirely.
+func TestAppendRuntimeUsageSampleBoundsTheWindow(t *testing.T) {
+	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	history := AppendRuntimeUsageSample(RuntimeUsageHistory{}, RuntimeUsage{
+		Memory: RuntimeMemoryUsage{LimitBytes: 8 * testGi, PeakBytes: 7 * testGi},
+		CPU:    RuntimeCPUUsage{UsageUsec: 900_000_000, Periods: 90000},
+	}, base)
+	for i := 1; i < runtimeUsageHistorySampleCap*3; i++ {
+		history = AppendRuntimeUsageSample(history, RuntimeUsage{
+			Memory: RuntimeMemoryUsage{LimitBytes: 8 * testGi, PeakBytes: 1 * testGi},
+			CPU:    RuntimeCPUUsage{UsageUsec: int64(i) * 1_000_000, Periods: int64(i) * 30},
+		}, base.Add(time.Duration(i)*30*time.Second))
+	}
+	if len(history.Samples) != runtimeUsageHistorySampleCap {
+		t.Fatalf("samples = %d, want the cap %d", len(history.Samples), runtimeUsageHistorySampleCap)
+	}
+	if history.ObservedPeakMemoryBytes != 7*testGi {
+		t.Fatalf("observed peak = %d, want the evicted sample's %d", history.ObservedPeakMemoryBytes, 7*testGi)
+	}
+	if history.Restarts != 1 {
+		t.Fatalf("restarts = %d, want the single counter reset", history.Restarts)
+	}
+	if !history.FirstObservedAt.Equal(base) {
+		t.Fatalf("first observed = %s, want the window anchor %s", history.FirstObservedAt, base)
+	}
+	if window := history.ObservedWindow(); window < 5*time.Hour {
+		t.Fatalf("observed window = %s, want the full span the evicted samples covered", window)
+	}
+}
+
+func TestReadLocalRuntimeUsageReadsCgroupV2(t *testing.T) {
+	root := t.TempDir()
+	writeCgroupFixture(t, root, map[string]string{
+		"cpu.max":        "1200000 100000\n",
+		"cpu.stat":       "usage_usec 27551234478\nnr_periods 376556\nnr_throttled 0\nthrottled_usec 0\n",
+		"memory.max":     "24696061952\n",
+		"memory.current": "4773695488\n",
+		"memory.peak":    "12742377472\n",
+		"memory.events":  "low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\n",
+	})
+	usage := ReadLocalRuntimeUsage(root)
+	if got := runtimeQuotaMilli(usage.CPU.QuotaCores); got != 12000 {
+		t.Fatalf("cpu quota = %d milli, want 12000", got)
+	}
+	if usage.Memory.LimitBytes != 24696061952 || usage.Memory.PeakBytes != 12742377472 {
+		t.Fatalf("memory = %+v", usage.Memory)
+	}
+	if usage.CPU.Periods != 376556 || usage.CPU.ThrottledPeriods != 0 {
+		t.Fatalf("cpu = %+v", usage.CPU)
+	}
+	if !usage.HasCounters() {
+		t.Fatal("a full cgroup v2 read must count as counters")
+	}
+}
+
+// TestReadLocalRuntimeUsageTreatsUnlimitedAsUnavailable pins the distinction
+// that matters to every consumer: "no limit configured" is not "a limit of
+// zero".
+func TestReadLocalRuntimeUsageTreatsUnlimitedAsUnavailable(t *testing.T) {
+	root := t.TempDir()
+	writeCgroupFixture(t, root, map[string]string{
+		"cpu.max":        "max 100000\n",
+		"memory.max":     "max\n",
+		"memory.current": "1024\n",
+	})
+	usage := ReadLocalRuntimeUsage(root)
+	if usage.Memory.LimitBytes != 0 || usage.CPU.QuotaCores != 0 {
+		t.Fatalf("an unlimited cgroup must report no limit, got %+v", usage)
+	}
+	if !usage.Memory.Unlimited {
+		t.Fatal("memory.max=max must set Unlimited, not just leave the limit at zero")
+	}
+	if usage.CPU.Unavailable == "" {
+		t.Fatal("an unreadable cpu quota must be named unavailable")
+	}
+}
+
+// TestReadLocalRuntimeUsageNeverFailsOnAbsentCounters covers cgroup v1 and any
+// host without the files. The reader runs on the monitor's tick, so it must
+// degrade rather than break the loop.
+func TestReadLocalRuntimeUsageNeverFailsOnAbsentCounters(t *testing.T) {
+	usage := ReadLocalRuntimeUsage(t.TempDir() + "/missing")
+	if usage.HasCounters() {
+		t.Fatal("a host with no cgroup v2 files must report no counters")
+	}
+	if usage.Memory.Unavailable == "" || usage.CPU.Unavailable == "" {
+		t.Fatalf("every field must name its own unavailability, got %+v", usage)
+	}
+}
+
+func writeCgroupFixture(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+}

--- a/erun-common/runtime_usage.go
+++ b/erun-common/runtime_usage.go
@@ -2,6 +2,8 @@ package eruncommon
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -25,6 +27,31 @@ import (
 // are all normal, matching the fail-soft posture runtime_resources.go already
 // takes for kubectl-top-less clusters. Only a kubectl/exec failure to reach
 // the pod at all is a hard error.
+//
+// Two limits of this data are load-bearing enough to state here, because a
+// consumer that does not know them will draw the wrong conclusion:
+//
+//  1. memory.peak resets when the container restarts, so a single reading is a
+//     high-water mark for the current container lifetime, not for the
+//     environment. RuntimeUsageHistory (runtime_usage_history.go) retains the
+//     true peak across restarts; nothing may treat one reading as a lifetime
+//     maximum.
+//  2. PSI is absent on some kernels -- memory.pressure and cpu.pressure simply
+//     do not exist in every runtime container's cgroup, so nothing here or
+//     downstream may depend on pressure stall information. nr_throttled over
+//     nr_periods (RuntimeCPUUsage.ThrottledPeriods / .Periods) is the
+//     CPU-starvation signal that is actually available wherever cgroup v2 is.
+//
+// RunRuntimeUsage is the one reader. It is reached two ways: exec'ing the
+// script below into the container over kubectl, for an on-demand `erun usage`
+// report from any namespace the caller's kubeconfig reaches; or
+// ReadLocalRuntimeUsage reading the same cgroup files directly, for the in-pod
+// monitor tick that already runs inside the container being measured, where
+// kubectl-exec'ing into itself every 30s would trade a local file read for a
+// Kubernetes API round trip to reach data already on its own filesystem. Both
+// acquisition paths feed the same parsing and threshold logic below, so a
+// remote read and a local read of the same container agree on what the
+// numbers mean.
 
 const (
 	// runtimeUsageContainer is the pod's main container -- the one whose
@@ -49,6 +76,11 @@ const (
 	// v2 host; anything else (a v1 hierarchy, or the path missing) means the
 	// files this reader depends on do not exist.
 	cgroupV2FSType = "cgroup2fs"
+
+	// DefaultCgroupRoot is the container's own cgroup v2 directory, read
+	// directly by ReadLocalRuntimeUsage. Overridable so a test can point the
+	// reader at a fixture tree.
+	DefaultCgroupRoot = "/sys/fs/cgroup"
 
 	// Thresholds below are the values #1233 measured and fixed as named
 	// constants with the reasoning attached, per the issue's own ask.
@@ -91,6 +123,13 @@ type RuntimeUsage struct {
 	Warnings []string `json:"warnings,omitempty"`
 }
 
+// HasCounters reports whether the read found anything worth retaining. A host
+// without cgroup v2 yields a reading of nothing, and recording that would
+// build a history that can only ever answer "no evidence".
+func (u RuntimeUsage) HasCounters() bool {
+	return u.Memory.LimitBytes > 0 || u.Memory.PeakBytes > 0 || u.CPU.QuotaCores > 0 || u.CPU.Periods > 0
+}
+
 // RuntimeCPUUsage reports quota-relative utilisation. Unavailable is set,
 // and every other field left zero, when cgroup v2 is absent or cpu.max
 // reports no quota to divide by (an unlimited container has no ceiling to be
@@ -99,7 +138,16 @@ type RuntimeCPUUsage struct {
 	QuotaCores         float64 `json:"quotaCores,omitempty"`
 	UtilizationPercent float64 `json:"utilizationPercent,omitempty"`
 	IntervalSeconds    float64 `json:"intervalSeconds,omitempty"`
-	Unavailable        string  `json:"unavailable,omitempty"`
+	// UsageUsec, Periods and ThrottledPeriods are cpu.stat's cumulative
+	// counters for the current container lifetime (usage_usec, nr_periods,
+	// nr_throttled), carried alongside the interval-based UtilizationPercent
+	// above so a consumer that retains readings over time -- RuntimeUsageHistory
+	// -- can derive its own rates and throttle ratio from the deltas between
+	// two readings, without a second reader.
+	UsageUsec        int64  `json:"usageUsec,omitempty"`
+	Periods          int64  `json:"periods,omitempty"`
+	ThrottledPeriods int64  `json:"throttledPeriods,omitempty"`
+	Unavailable      string `json:"unavailable,omitempty"`
 }
 
 // RuntimeMemoryUsage mirrors what erun-common/ai_launch.go's post-mortem OOM
@@ -180,6 +228,8 @@ printf 'cpu_usage_before=%s\n' "$cpu_usage_before"
 printf 'cpu_usage_after=%s\n' "$cpu_usage_after"
 printf 'cpu_time_before_ns=%s\n' "$time_before"
 printf 'cpu_time_after_ns=%s\n' "$time_after"
+printf 'cpu_periods=%s\n' "$(awk '$1=="nr_periods"{print $2}' $cg/cpu.stat 2>/dev/null || true)"
+printf 'cpu_throttled_periods=%s\n' "$(awk '$1=="nr_throttled"{print $2}' $cg/cpu.stat 2>/dev/null || true)"
 printf 'disk_workspace=%s\n' "$(df -Pk ` + runtimeUsageWatchedMount + ` 2>/dev/null | tail -n1 || true)"
 `
 
@@ -249,18 +299,52 @@ func runtimeMemoryUsageFromValues(v map[string]string) RuntimeMemoryUsage {
 	return m
 }
 
+// runtimeCPUCounters is cpu.max/cpu.stat's cumulative counters, shared by the
+// interval-based reading below and ReadLocalRuntimeUsage's point-in-time
+// local reading -- both need the same quota and the same raw cpu.stat fields,
+// and reading them once keeps a remote read and a local read of the same
+// container agreeing on what the numbers mean.
+type runtimeCPUCounters struct {
+	QuotaCores       float64
+	UsageUsec        int64
+	Periods          int64
+	ThrottledPeriods int64
+}
+
+func runtimeCPUCountersFromValues(v map[string]string) (runtimeCPUCounters, bool) {
+	var counters runtimeCPUCounters
+	if usage, ok := parseRuntimeInt64(v["cpu_usage_after"]); ok {
+		counters.UsageUsec = usage
+	}
+	if periods, ok := parseRuntimeInt64(v["cpu_periods"]); ok {
+		counters.Periods = periods
+	}
+	if throttled, ok := parseRuntimeInt64(v["cpu_throttled_periods"]); ok {
+		counters.ThrottledPeriods = throttled
+	}
+	quotaUsec, periodUsec, ok := parseRuntimeCPUMax(v["cpu_max"])
+	if !ok {
+		return counters, false
+	}
+	counters.QuotaCores = float64(quotaUsec) / float64(periodUsec)
+	return counters, true
+}
+
 func runtimeCPUUsageFromValues(v map[string]string, interval time.Duration) RuntimeCPUUsage {
 	c := RuntimeCPUUsage{IntervalSeconds: interval.Seconds()}
 	if !runtimeCgroupV2Available(v) {
 		c.Unavailable = "cgroup v2 not detected under /sys/fs/cgroup; CPU usage needs cpu.max/cpu.stat"
 		return c
 	}
-	quotaUsec, periodUsec, ok := parseRuntimeCPUMax(v["cpu_max"])
+	counters, ok := runtimeCPUCountersFromValues(v)
+	c.UsageUsec = counters.UsageUsec
+	c.Periods = counters.Periods
+	c.ThrottledPeriods = counters.ThrottledPeriods
 	if !ok {
 		c.Unavailable = "cpu.max reports no quota (unlimited or not readable); utilisation needs a quota to measure against"
 		return c
 	}
-	c.QuotaCores = float64(quotaUsec) / float64(periodUsec)
+	c.QuotaCores = counters.QuotaCores
 
 	before, beforeOk := parseRuntimeInt64(v["cpu_usage_before"])
 	after, afterOk := parseRuntimeInt64(v["cpu_usage_after"])
@@ -375,4 +459,92 @@ func runtimeUsageWarnings(u RuntimeUsage) []string {
 
 func formatMebibytes(bytes int64) string {
 	return fmt.Sprintf("%.0fMi", float64(bytes)/(1<<20))
+}
+
+// ReadLocalRuntimeUsage reads the container's own cgroup v2 files directly,
+// for the in-pod monitor tick that already runs inside the container being
+// measured -- see the file-level comment for why that tick does not kubectl-exec
+// into itself. It shares runtimeMemoryUsageFromValues and the cumulative CPU
+// counters with RunRuntimeUsage's script-based parser, so this is a second
+// acquisition path for the same reader, not a second reader: a local read and
+// a kubectl-exec'd read of the same container agree on what the numbers mean.
+// It never fails -- an absent or unparseable file reports its field as
+// unavailable, because cgroup v1 and a missing mount are ordinary states and a
+// caller on the monitor's tick must not be broken by either.
+func ReadLocalRuntimeUsage(cgroupRoot string) RuntimeUsage {
+	root := strings.TrimSpace(cgroupRoot)
+	if root == "" {
+		root = DefaultCgroupRoot
+	}
+	values := readLocalCgroupValues(root)
+	return RuntimeUsage{
+		CPU:    localRuntimeCPUUsage(values),
+		Memory: runtimeMemoryUsageFromValues(values),
+	}
+}
+
+// readLocalCgroupValues builds a values map matching the shape the
+// kubectl-exec'd script prints, so both acquisition paths run through the
+// exact same parser. A file that cannot be read yields an empty value, which
+// the parser already treats as unavailable.
+func readLocalCgroupValues(root string) map[string]string {
+	return map[string]string{
+		"cgroup_type":           cgroupV2FSType,
+		"memory_current":        readLocalCgroupFile(filepath.Join(root, "memory.current")),
+		"memory_max":            readLocalCgroupFile(filepath.Join(root, "memory.max")),
+		"memory_peak":           readLocalCgroupFile(filepath.Join(root, "memory.peak")),
+		"memory_oom_kill":       localCgroupStatValue(filepath.Join(root, "memory.events"), "oom_kill"),
+		"cpu_max":               readLocalCgroupFile(filepath.Join(root, "cpu.max")),
+		"cpu_usage_after":       localCgroupStatValue(filepath.Join(root, "cpu.stat"), "usage_usec"),
+		"cpu_periods":           localCgroupStatValue(filepath.Join(root, "cpu.stat"), "nr_periods"),
+		"cpu_throttled_periods": localCgroupStatValue(filepath.Join(root, "cpu.stat"), "nr_throttled"),
+	}
+}
+
+func readLocalCgroupFile(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// localCgroupStatValue reads one "<key> <value>" line out of a cgroup keyed
+// file (cpu.stat, memory.events), mirroring the awk lookups the exec'd script
+// runs against the same files.
+func localCgroupStatValue(path, key string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[0] == key {
+			return fields[1]
+		}
+	}
+	return ""
+}
+
+// localRuntimeCPUUsage is runtimeCPUUsageFromValues without the interval-rate
+// half: a local read is a single point in time, so there is no before/after
+// pair to diff into a utilisation rate. It still reports the same cumulative
+// counters (quota, usage_usec, periods, throttled periods) that
+// RuntimeUsageHistory needs to derive its own rates from consecutive ticks.
+func localRuntimeCPUUsage(v map[string]string) RuntimeCPUUsage {
+	c := RuntimeCPUUsage{}
+	if !runtimeCgroupV2Available(v) {
+		c.Unavailable = "cgroup v2 not detected under /sys/fs/cgroup; CPU usage needs cpu.max/cpu.stat"
+		return c
+	}
+	counters, ok := runtimeCPUCountersFromValues(v)
+	c.UsageUsec = counters.UsageUsec
+	c.Periods = counters.Periods
+	c.ThrottledPeriods = counters.ThrottledPeriods
+	if !ok {
+		c.Unavailable = "cpu.max reports no quota (unlimited or not readable); utilisation needs a quota to measure against"
+		return c
+	}
+	c.QuotaCores = counters.QuotaCores
+	return c
 }

--- a/erun-common/runtime_usage_history.go
+++ b/erun-common/runtime_usage_history.go
@@ -1,0 +1,221 @@
+package eruncommon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	runtimeUsageHistoryFileName = "usage-history.json"
+
+	// runtimeUsageHistorySampleCap bounds the rolling window of raw samples.
+	// The monitor ticks every 30s, so this is roughly two hours of readings —
+	// enough to see recent rates, and a fixed cost rather than a log that grows
+	// for as long as the environment lives. EnvironmentActivitySnapshot's
+	// Clients map is bounded for the same reason.
+	runtimeUsageHistorySampleCap = 240
+)
+
+// RuntimeUsageHistory retains what a single read cannot know. Its aggregates
+// are the point of the type: memory.peak resets when the container restarts and
+// the rolling window drops its oldest sample, so neither the kernel counter nor
+// the window can be the memory of record for an environment's high-water mark.
+// The aggregates below are monotonic and are never rolled off; Samples is the
+// bounded window kept for recency.
+type RuntimeUsageHistory struct {
+	// FirstObservedAt anchors the evidence window. A recommendation that cannot
+	// say how long it watched is not evidence, and the shrink direction is
+	// gated on this span.
+	FirstObservedAt time.Time `json:"firstObservedAt,omitempty"`
+	LastObservedAt  time.Time `json:"lastObservedAt,omitempty"`
+
+	// ObservedPeakMemoryBytes is the highest memory reading across every
+	// container lifetime observed, which is the figure a shrink must keep clear
+	// of. An environment whose real peak happened before the last restart would
+	// otherwise be sized from a counter that no longer remembers it.
+	ObservedPeakMemoryBytes int64 `json:"observedPeakMemoryBytes,omitempty"`
+	// ObservedOOMKills accumulates the kernel's own kill count across restarts.
+	// memory.events resets with the container, so a total needs the deltas.
+	ObservedOOMKills int64 `json:"observedOomKills,omitempty"`
+
+	// ObservedPeakCPUMilli is the highest per-interval CPU rate seen, derived
+	// from consecutive readings' cumulative cpu.stat usage_usec over the wall
+	// time between them. It is not a loadavg figure and must not be compared
+	// with one: a loadavg counts the host's runnable queue, so a busy neighbour
+	// raises it while this container's own consumption is unchanged.
+	//
+	// It is an average over the interval between two ticks, so a burst shorter
+	// than that interval is flattened into it — which is why the shrink
+	// direction keeps a multiple of this figure rather than treating it as the
+	// true peak, and why any throttling at all disqualifies a shrink.
+	ObservedPeakCPUMilli int64 `json:"observedPeakCpuMilli,omitempty"`
+	// ObservedPeriods / ObservedThrottledPeriods accumulate cpu.stat's
+	// scheduling-period counters across restarts, so the throttle ratio spans
+	// the whole observation rather than the current container lifetime.
+	ObservedPeriods          int64 `json:"observedPeriods,omitempty"`
+	ObservedThrottledPeriods int64 `json:"observedThrottledPeriods,omitempty"`
+
+	// Restarts counts the container restarts inferred from a counter going
+	// backwards. It is reported alongside a recommendation because a history
+	// spanning restarts is stronger evidence than one that does not, and a
+	// reader needs to know the peak survived them.
+	Restarts int `json:"restarts,omitempty"`
+
+	// Samples is a rolling window of the raw readings RunRuntimeUsage /
+	// ReadLocalRuntimeUsage produced, kept for recency rather than for the
+	// aggregates above (which are derived once, at append time, and never
+	// recomputed from this window).
+	Samples []RuntimeUsage `json:"samples,omitempty"`
+}
+
+// Latest returns the newest retained sample.
+func (h RuntimeUsageHistory) Latest() (RuntimeUsage, bool) {
+	if len(h.Samples) == 0 {
+		return RuntimeUsage{}, false
+	}
+	return h.Samples[len(h.Samples)-1], true
+}
+
+// ObservedWindow is how long this environment has been watched.
+func (h RuntimeUsageHistory) ObservedWindow() time.Duration {
+	if h.FirstObservedAt.IsZero() || h.LastObservedAt.IsZero() {
+		return 0
+	}
+	window := h.LastObservedAt.Sub(h.FirstObservedAt)
+	if window < 0 {
+		return 0
+	}
+	return window
+}
+
+// AppendRuntimeUsageSample folds one reading into the history. Pure, so the
+// retention rules are testable without a container: the caller persists the
+// result. now is the time the reading was taken, threaded in explicitly rather
+// than read from the sample, since RuntimeUsage (a reading also returned
+// verbatim by `erun usage`) carries no timestamp of its own.
+func AppendRuntimeUsageSample(history RuntimeUsageHistory, sample RuntimeUsage, now time.Time) RuntimeUsageHistory {
+	previous, hasPrevious := history.Latest()
+	// A cumulative counter that went backwards can only mean the container was
+	// replaced. Inferring the restart from the data needs no second source of
+	// truth, and the pod hostname could not supply one anyway: a container
+	// restarted in place keeps its pod's name.
+	restarted := hasPrevious && runtimeUsageCountersReset(previous, sample)
+	if restarted {
+		history.Restarts++
+	}
+
+	if history.FirstObservedAt.IsZero() {
+		history.FirstObservedAt = now
+	}
+	var elapsed time.Duration
+	if !history.LastObservedAt.IsZero() {
+		elapsed = now.Sub(history.LastObservedAt)
+	}
+	if now.After(history.LastObservedAt) {
+		history.LastObservedAt = now
+	}
+
+	history.ObservedPeakMemoryBytes = max(history.ObservedPeakMemoryBytes, sample.Memory.PeakBytes, sample.Memory.CurrentBytes)
+
+	continuous := hasPrevious && !restarted
+	history.ObservedOOMKills += runtimeUsageCounterDelta(previous.Memory.OOMKills, sample.Memory.OOMKills, continuous)
+	history.ObservedPeriods += runtimeUsageCounterDelta(previous.CPU.Periods, sample.CPU.Periods, continuous)
+	history.ObservedThrottledPeriods += runtimeUsageCounterDelta(previous.CPU.ThrottledPeriods, sample.CPU.ThrottledPeriods, continuous)
+	if continuous && elapsed > 0 {
+		if milli, ok := runtimeUsageIntervalCPUMilli(previous, sample, elapsed); ok {
+			history.ObservedPeakCPUMilli = max(history.ObservedPeakCPUMilli, milli)
+		}
+	}
+
+	history.Samples = appendBoundedUsageSamples(history.Samples, sample)
+	return history
+}
+
+// runtimeUsageCounterDelta advances an accumulated total. Across a restart (or
+// on the first sample) the counter began at zero, so its whole value is new.
+func runtimeUsageCounterDelta(previous, current int64, continuous bool) int64 {
+	if !continuous {
+		return current
+	}
+	if current <= previous {
+		return 0
+	}
+	return current - previous
+}
+
+func runtimeUsageCountersReset(previous, current RuntimeUsage) bool {
+	return current.Memory.PeakBytes < previous.Memory.PeakBytes ||
+		current.CPU.UsageUsec < previous.CPU.UsageUsec ||
+		current.CPU.Periods < previous.CPU.Periods
+}
+
+// runtimeUsageIntervalCPUMilli converts the CPU time burned between two
+// readings into millicores over the wall time that elapsed between them.
+func runtimeUsageIntervalCPUMilli(previous, current RuntimeUsage, elapsed time.Duration) (int64, bool) {
+	usec := current.CPU.UsageUsec - previous.CPU.UsageUsec
+	if usec <= 0 {
+		return 0, false
+	}
+	return usec * 1000 / elapsed.Microseconds(), true
+}
+
+// appendBoundedUsageSamples keeps the newest samples up to the cap. It copies
+// rather than resliceing so the trimmed prefix is not retained by the backing
+// array for the life of a long-running monitor.
+func appendBoundedUsageSamples(samples []RuntimeUsage, sample RuntimeUsage) []RuntimeUsage {
+	next := append(samples, sample)
+	if len(next) <= runtimeUsageHistorySampleCap {
+		return next
+	}
+	trimmed := make([]RuntimeUsage, runtimeUsageHistorySampleCap)
+	copy(trimmed, next[len(next)-runtimeUsageHistorySampleCap:])
+	return trimmed
+}
+
+// LoadRuntimeUsageHistory reads an environment's retained usage. A missing or
+// unreadable history is "nothing observed yet", not an error: the monitor tick
+// that writes it must never fail over its own bookkeeping, and every consumer
+// already has to handle an environment with no evidence.
+func LoadRuntimeUsageHistory(tenant, environment string) (RuntimeUsageHistory, error) {
+	path, err := runtimeUsageHistoryPath(tenant, environment)
+	if err != nil {
+		return RuntimeUsageHistory{}, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return RuntimeUsageHistory{}, nil
+	}
+	var history RuntimeUsageHistory
+	if err := json.Unmarshal(data, &history); err != nil {
+		return RuntimeUsageHistory{}, nil
+	}
+	return history, nil
+}
+
+func SaveRuntimeUsageHistory(tenant, environment string, history RuntimeUsageHistory) error {
+	path, err := runtimeUsageHistoryPath(tenant, environment)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(history)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
+}
+
+// runtimeUsageHistoryPath keeps the history beside the activity markers. It has
+// to outlive the container that produced it, which is the whole reason it is a
+// store and not a live read.
+func runtimeUsageHistoryPath(tenant, environment string) (string, error) {
+	dir, err := EnvironmentActivityDir(tenant, environment)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, runtimeUsageHistoryFileName), nil
+}

--- a/erun-docs/docs/cli/list.md
+++ b/erun-docs/docs/cli/list.md
@@ -40,6 +40,84 @@ Tenants:
 
 The full per-env field set (local port allocations, API URL, SSH details, …) prints under each tenant; the example abbreviates. See [Configuration](/reference/configuration) for what each value means.
 
+## The sizing recommendation
+
+`runtime-pod:` prints the size an environment was *given*. Under it, when ERun has watched the
+environment long enough to have an opinion, two more lines print what that size should be — derived
+from what the environment has actually done, not from what anyone guessed when they created it:
+
+```
+runtime-pod: cpu=12 memory=23552Mi
+sizing: memory lower to 18432Mi from 23552Mi (peak 12153Mi of 23552Mi (52%), no oom kills, keeping 1.5x headroom, low confidence); cpu lower to 10 from 12 (busiest interval 4.567 of 12, 0.00% of scheduling periods throttled (0 of 376556), keeping 2x headroom, low confidence)
+sizing-evidence: 31h12m observed, 240 samples, 1 restarts, knob=runtimepod, from cgroup memory.peak, cgroup memory.events oom_kill, cgroup cpu.stat usage_usec/nr_throttled (not loadavg)
+```
+
+The lines are advisory. ERun never resizes an environment for you: acting on a recommendation means
+changing `runtimepod` and running [`erun deploy`](/cli/deploy), which restarts the pod, and that is
+a decision for you to make and time.
+
+### Where the figures come from
+
+The runtime container's own cgroup counters, read from inside the container. **No metrics-server is
+required** — that is deliberate, because `kubectl top` answers "Metrics API not available" on local
+clusters, which are the ones you iterate in all day. The counters are sampled on the same tick the
+[idle monitor](/agent-reference/idle-policy) already runs, and retained per environment.
+
+### What each signal says
+
+| Signal | Direction | Why |
+|---|---|---|
+| `memory.events` `oom_kill` above zero | **raise memory**, high confidence | Something was already killed. One kill is enough. The suggestion is sized from the limit that proved too small, not from the observed peak — the allocation that triggered the kill was refused, so it never reached `memory.peak`. |
+| Observed memory peak at 90% of the limit or more | **raise memory**, high confidence | Sampling means the true peak is at least the peak observed. An environment already this close has plausibly gone further between two reads. |
+| Observed memory peak below about two-thirds of the limit, over a long quiet window, no kills | **lower memory**, low confidence | The suggestion keeps 1.5× the observed peak. |
+| 5% or more of scheduling periods throttled | **raise CPU**, high confidence | `nr_throttled`/`nr_periods` is real starvation: the container wanted CPU and the quota refused it. |
+| Any throttling below that threshold | **hold CPU** | Tolerable, but not unused — the quota does bind sometimes, so this is not grounds to shrink. |
+| No throttling at all, over a long quiet window, busiest interval below half the quota | **lower CPU**, low confidence | The suggestion keeps 2× the busiest interval measured. |
+
+`insufficient-evidence` is a distinct answer from `hold`. `hold` means ERun looked and the size is
+right; `insufficient-evidence` means it has not watched long enough, or the counter was unavailable,
+and the line says which.
+
+### Why raising and shrinking are not symmetric
+
+Being wrong in the two directions does not cost the same. An over-provisioned environment quietly
+consumes cluster capacity. An under-provisioned one kills a running agent — the failure behind
+*"was killed (exit 137) — likely out of memory"*. So ERun raises on modest evidence and shrinks only
+on a long, quiet window, never below 1.5× the peak it actually observed, and never at better than low
+confidence. A quiet window is an argument from silence, and it is labelled as one.
+
+A raise is also bounded by what the environment's namespace quota can admit, where one is
+configured: a `ResourceQuota` counts every container in the pod, so the `erun-dind` sidecar's own
+limit is spent before the runtime container gets anything, and a suggestion above the remainder is a
+size Kubernetes would refuse to schedule. Raising the quota is a separate decision from resizing the
+pod, so ERun clamps and says it clamped rather than silently recommending both.
+
+### Two limits worth knowing
+
+Without these, the output reads wrong:
+
+- **`memory.peak` resets when the container restarts.** It is a high-water mark for the current
+  container lifetime, not for the environment. This is exactly why ERun retains a history instead of
+  reading the counter live — `sizing-evidence` reports how many restarts the history spans, and the
+  peak it quotes survived them.
+- **PSI is unavailable on some kernels.** `memory.pressure` and `cpu.pressure` are simply absent in
+  the runtime container's cgroup on some hosts, so nothing here depends on pressure stall
+  information. `nr_throttled`/`nr_periods` is the CPU-starvation signal that is actually available.
+
+And one thing the figures are *not*: a host loadavg. A loadavg counts the machine's runnable queue,
+so a 12-core environment sitting at a load of 10 looks saturated while `cpu.stat` reports not one
+throttled period — which is why the evidence line names its counters and says `not loadavg`.
+
+### When the lines do not print
+
+The history is written by the container that produced it, so it exists on that environment's own
+runtime pod. Running `erun list` from your laptop shows no sizing lines for a remote environment —
+there is no history there to read. Ask the environment (over
+[MCP](/mcp/overview) or an [`erun open`](/cli/open) shell) and it answers about itself; the MCP
+`list` tool carries the same recommendation as a structured `sizing` field on each environment.
+
+A newly created environment prints nothing either, until its monitor has taken a sample.
+
 ## Common usages
 
 ```bash

--- a/erun-docs/docs/concepts/runtime-pods.md
+++ b/erun-docs/docs/concepts/runtime-pods.md
@@ -97,6 +97,19 @@ Two cases the number alone cannot explain, so the tab spells them out:
   cluster without metrics its real consumption — Testcontainers, the build cache — is invisible to
   the reading and the tab warns that the true usage is higher than shown.
 
+## What the environment thinks it should be sized as
+
+The figures above describe the node. The environment also has an opinion about *itself*: every
+environment accumulates a standing recommendation — raise memory, drop memory, raise CPU, or leave
+it alone — from its own container's cgroup counters, and [`erun list`](/cli/list#the-sizing-recommendation)
+prints it under `runtime-pod:`. Nothing is applied automatically; resizing means a deploy, and that
+is your call to time.
+
+It matters because sizing is otherwise set once and never revisited, and both ways of being wrong
+are live. Under-provisioning shows up as a killed agent. Over-provisioning shows up as nothing at
+all — it just quietly holds capacity that the free figure above then reports as unavailable to
+everyone else on the node.
+
 ## What is holding the environment's resources
 
 A build leaves things running. Gradle keeps its daemons alive for the next build, Testcontainers

--- a/erun-docs/docs/mcp/overview.md
+++ b/erun-docs/docs/mcp/overview.md
@@ -367,6 +367,7 @@ Every tool the server can register, one row each, grouped by `_meta.family` and 
 | *(top-level)* | `terraform` | `erun terraform` | Work |
 | *(top-level)* | `doctor` | `erun doctor` | Work |
 | *(top-level)* | `observe` | `erun observe` | Read |
+| *(top-level)* | `usage` | `erun usage` | Read |
 | *(top-level)* | `delete` | `erun delete` | Work |
 | exec | `exec_diff` | `erun exec diff` | Read |
 | exec | `exec_raw` | `erun exec raw` | Work |
@@ -427,7 +428,7 @@ Every tool the server can register, one row each, grouped by `_meta.family` and 
 | sshd | `sshd_sync` | `erun sshd sync` | Work |
 | contribute | `contribute_clone` | `erun contribute clone` | Work |
 
-74 tools in total. `inputs_upload` and `sshd_sync` are [host-served](#host-served): answered by `erun mcp proxy` on the operator's machine, not relayed to the pod edge.
+75 tools in total. `inputs_upload` and `sshd_sync` are [host-served](#host-served): answered by `erun mcp proxy` on the operator's machine, not relayed to the pod edge.
 
 ## Why typed tools
 

--- a/erun-integration/activity_test.go
+++ b/erun-integration/activity_test.go
@@ -112,6 +112,50 @@ func writeSampleProcess(t *testing.T, root string, pid int, comm string, cpuTick
 	}
 }
 
+// writeCgroupFixture lays down a cgroup v2 tree so the usage reader's verdict
+// comes from the fixture. The real /sys/fs/cgroup says something different on
+// every machine, and on a cgroup v1 host it says nothing at all.
+func writeCgroupFixture(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", root, err)
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s/%s: %v", root, name, err)
+		}
+	}
+}
+
+// cgroupV2Fixture is the shape measured in a live runtime container: a 12-core
+// quota, a 23552Mi limit, and a high-water mark at roughly half of it.
+func cgroupV2Fixture(usageUsec, periods, throttled, peakBytes, oomKills int64) map[string]string {
+	return map[string]string{
+		"cpu.max":        "1200000 100000\n",
+		"cpu.stat":       fmt.Sprintf("usage_usec %d\nnr_periods %d\nnr_throttled %d\nthrottled_usec 0\n", usageUsec, periods, throttled),
+		"memory.max":     "24696061952\n",
+		"memory.current": "4773695488\n",
+		"memory.peak":    fmt.Sprintf("%d\n", peakBytes),
+		"memory.events":  fmt.Sprintf("low 0\nhigh 0\nmax 0\noom 0\noom_kill %d\n", oomKills),
+	}
+}
+
+// readUsageHistory reads the retained usage store. It is a side effect outside
+// the captured streams, so a golden cannot assert it.
+func readUsageHistory(t *testing.T, cacheHome, tenant, environment string) map[string]any {
+	t.Helper()
+	path := filepath.Join(cacheHome, "erun", "activity", tenant, environment, "usage-history.json")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var history map[string]any
+	if err := json.Unmarshal(body, &history); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return history
+}
+
 func TestActivity(t *testing.T) {
 	t.Run("touch_records_cli_activity", func(t *testing.T) {
 		setup := env.New(t)
@@ -905,7 +949,10 @@ func TestActivity(t *testing.T) {
 		fixture.SeedTenantEnv(t, setup, "team", "dev")
 		procRoot := filepath.Join(setup.Cwd, "proc")
 		writeSampleProcess(t, procRoot, 101, "java", 500, 900)
-		sampleArgs := []string{"activity", "sample", "--tenant", "team", "--environment", "dev", "--proc-root", procRoot}
+		// The same tick also retains a usage reading. Point it at an absent
+		// cgroup root so this scenario stays about the process sampler and reads
+		// nothing ambient from the host that ran it.
+		sampleArgs := []string{"activity", "sample", "--tenant", "team", "--environment", "dev", "--proc-root", procRoot, "--cgroup-root", filepath.Join(setup.Cwd, "no-cgroup")}
 
 		first := erun.Run(t, sampleArgs, erun.RunOptions{Cwd: setup.Cwd, Env: inEnvironment(setup.Env())})
 		writeSampleProcess(t, procRoot, 101, "java", 900, 900)
@@ -918,6 +965,84 @@ func TestActivity(t *testing.T) {
 		// lives outside the captured streams.
 		if _, err := os.Stat(filepath.Join(setup.CacheHome, "erun", "activity", "team", "dev", "process.json")); err != nil {
 			t.Errorf("expected the working sample to record process activity: %v", err)
+		}
+	})
+
+	t.Run("sample_retains_runtime_usage_from_cgroup_counters", func(t *testing.T) {
+		// The collection half of the sizing recommendation. The monitor's tick
+		// already runs this command, so the history accumulates with no second
+		// scheduled job.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		procRoot := filepath.Join(setup.Cwd, "proc")
+		cgroupRoot := filepath.Join(setup.Cwd, "cgroup")
+		writeCgroupFixture(t, cgroupRoot, cgroupV2Fixture(27551234478, 376556, 0, 12742377472, 0))
+		sampleArgs := []string{"activity", "sample", "--tenant", "team", "--environment", "dev", "--proc-root", procRoot, "--cgroup-root", cgroupRoot}
+
+		first := erun.Run(t, sampleArgs, erun.RunOptions{Cwd: setup.Cwd, Env: inEnvironment(setup.Env())})
+		writeCgroupFixture(t, cgroupRoot, cgroupV2Fixture(28551234478, 386556, 0, 12742377472, 0))
+		second := erun.Run(t, sampleArgs, erun.RunOptions{Cwd: setup.Cwd, Env: inEnvironment(setup.Env())})
+		golden.Equal(t, "activity/sample_retains_runtime_usage_from_cgroup_counters", normalize.Apply(first.Combined+second.Combined))
+
+		history := readUsageHistory(t, setup.CacheHome, "team", "dev")
+		if got := history["observedPeakMemoryBytes"]; got != float64(12742377472) {
+			t.Errorf("observedPeakMemoryBytes = %v, want the cgroup high-water 12742377472", got)
+		}
+		if got := history["observedPeriods"]; got != float64(386556) {
+			t.Errorf("observedPeriods = %v, want the first lifetime's total plus the delta", got)
+		}
+		if samples, ok := history["samples"].([]any); !ok || len(samples) != 2 {
+			t.Errorf("samples = %v, want both ticks retained", history["samples"])
+		}
+	})
+
+	t.Run("sample_retains_the_peak_across_a_container_restart", func(t *testing.T) {
+		// memory.peak resets when the container restarts, which is exactly why
+		// this is a store and not a live read: without retention the pre-restart
+		// high-water is simply gone, and an environment gets sized from whatever
+		// it happens to have done since.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		procRoot := filepath.Join(setup.Cwd, "proc")
+		cgroupRoot := filepath.Join(setup.Cwd, "cgroup")
+		sampleArgs := []string{"activity", "sample", "--tenant", "team", "--environment", "dev", "--proc-root", procRoot, "--cgroup-root", cgroupRoot}
+
+		writeCgroupFixture(t, cgroupRoot, cgroupV2Fixture(27551234478, 376556, 12, 22000000000, 1))
+		erun.Run(t, sampleArgs, erun.RunOptions{Cwd: setup.Cwd, Env: inEnvironment(setup.Env())})
+		// Every cumulative counter starts over, and the fresh peak is far below
+		// the one already observed.
+		writeCgroupFixture(t, cgroupRoot, cgroupV2Fixture(4000, 40, 0, 900000000, 0))
+		erun.Run(t, sampleArgs, erun.RunOptions{Cwd: setup.Cwd, Env: inEnvironment(setup.Env())})
+
+		history := readUsageHistory(t, setup.CacheHome, "team", "dev")
+		if got := history["restarts"]; got != float64(1) {
+			t.Errorf("restarts = %v, want 1 inferred from the counters going backwards", got)
+		}
+		if got := history["observedPeakMemoryBytes"]; got != float64(22000000000) {
+			t.Errorf("observedPeakMemoryBytes = %v, want the pre-restart high-water 22000000000", got)
+		}
+		if got := history["observedOomKills"]; got != float64(1) {
+			t.Errorf("observedOomKills = %v, want the pre-restart kill retained", got)
+		}
+		if got := history["observedThrottledPeriods"]; got != float64(12) {
+			t.Errorf("observedThrottledPeriods = %v, want the pre-restart throttling retained", got)
+		}
+	})
+
+	t.Run("sample_records_no_usage_when_the_host_supplies_no_counters", func(t *testing.T) {
+		// cgroup v1, or a laptop. A history of empty samples could only ever
+		// support "no evidence", so nothing is written at all.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		procRoot := filepath.Join(setup.Cwd, "proc")
+		result := erun.Run(t, []string{"activity", "sample", "--tenant", "team", "--environment", "dev", "--proc-root", procRoot, "--cgroup-root", filepath.Join(setup.Cwd, "absent")},
+			erun.RunOptions{Cwd: setup.Cwd, Env: inEnvironment(setup.Env())})
+		if result.ExitCode != 0 {
+			t.Fatalf("an absent cgroup must not fail the monitor tick: exit %d\n%s", result.ExitCode, result.Combined)
+		}
+		path := filepath.Join(setup.CacheHome, "erun", "activity", "team", "dev", "usage-history.json")
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("expected no usage history without counters, stat err = %v", err)
 		}
 	})
 

--- a/erun-integration/list_test.go
+++ b/erun-integration/list_test.go
@@ -1,9 +1,12 @@
 package integration
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/sophium/erun/erun-integration/internal/env"
 	"github.com/sophium/erun/erun-integration/internal/erun"
@@ -230,6 +233,187 @@ func TestList(t *testing.T) {
 		}
 		golden.Equal(t, "list/with_claude_config", normalize.Apply(result.Combined))
 	})
+
+	// The sizing recommendation's four directions, driven from a retained
+	// history rather than from a live container. The history is the recommender's
+	// whole input, so seeding it is what makes each direction reachable — a real
+	// 26-hour observation window is not something a scenario can wait for, and
+	// the shrink gate exists precisely to require one.
+	//
+	// Each seeds an env whose declared runtimepod is deliberately absent, which
+	// is the in-pod reality: the chart injects the container's limits and the
+	// pod's own config never learns them. The lines must therefore score against
+	// the cgroup limit in the history, not against the defaults an empty
+	// runtimepod normalizes to.
+
+	t.Run("runtime_sizing_lowers_memory_on_a_long_quiet_window", func(t *testing.T) {
+		// erun/build's measured shape: a 23552Mi limit whose high-water sat at
+		// roughly half, with no kills and not one throttled period.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		seedUsageHistory(t, setup, "team", "dev", usageHistorySpec{
+			windowHours: 31, samples: 240,
+			peakMemoryBytes: 12742377472, limitBytes: 24696061952,
+			quotaMilli: 12000, periods: 376556, throttled: 0, peakCPUMilli: 4567,
+		})
+		result := erun.Run(t, []string{"list"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "list/runtime_sizing_lowers_memory_on_a_long_quiet_window", normalize.Apply(result.Combined))
+	})
+
+	t.Run("runtime_sizing_raises_memory_on_an_oom_kill", func(t *testing.T) {
+		// One kill outranks a comfortable-looking peak and needs no window: this
+		// history has watched a single minute.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		seedUsageHistory(t, setup, "team", "dev", usageHistorySpec{
+			windowHours: 0, samples: 2,
+			peakMemoryBytes: 1073741824, limitBytes: 2147483648, oomKills: 1,
+			quotaMilli: 1000, periods: 5000, throttled: 0, peakCPUMilli: 300,
+		})
+		result := erun.Run(t, []string{"list"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "list/runtime_sizing_raises_memory_on_an_oom_kill", normalize.Apply(result.Combined))
+	})
+
+	t.Run("runtime_sizing_raises_cpu_on_sustained_throttling", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		seedUsageHistory(t, setup, "team", "dev", usageHistorySpec{
+			windowHours: 31, samples: 240,
+			peakMemoryBytes: 1073741824, limitBytes: 8589934592,
+			quotaMilli: 2000, periods: 100000, throttled: 12000, peakCPUMilli: 1900,
+		})
+		result := erun.Run(t, []string{"list"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "list/runtime_sizing_raises_cpu_on_sustained_throttling", normalize.Apply(result.Combined))
+	})
+
+	t.Run("runtime_sizing_raises_memory_when_the_peak_nears_the_limit", func(t *testing.T) {
+		// No kill yet, but the high-water is inside the raise margin. Sampling
+		// means the true peak is at least this, so the raise is high confidence
+		// without waiting for the environment to be killed first.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		seedUsageHistory(t, setup, "team", "dev", usageHistorySpec{
+			windowHours: 5, samples: 30,
+			peakMemoryBytes: 2040109465, limitBytes: 2147483648,
+			quotaMilli: 1000, periods: 50000, throttled: 0, peakCPUMilli: 600,
+		})
+		result := erun.Run(t, []string{"list"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "list/runtime_sizing_raises_memory_when_the_peak_nears_the_limit", normalize.Apply(result.Combined))
+	})
+
+	t.Run("runtime_sizing_bounds_a_raise_by_the_namespace_quota", func(t *testing.T) {
+		// A namespace ResourceQuota counts every container in the pod, so a raise
+		// past the quota less the dind sidecar's own limit is a size nothing
+		// would schedule. The verdict says it clamped rather than quietly
+		// recommending a quota change too.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		envConfigPath := filepath.Join(setup.ConfigHome, "erun", "team", "dev", "config.yaml")
+		existing, err := os.ReadFile(envConfigPath)
+		if err != nil {
+			t.Fatalf("read env config: %v", err)
+		}
+		mustWriteFile(t, envConfigPath, string(existing)+"namespacequota:\n  cpu: \"8\"\n  memory: 32Gi\n  storage: 80Gi\n")
+		seedUsageHistory(t, setup, "team", "dev", usageHistorySpec{
+			windowHours: 5, samples: 30,
+			peakMemoryBytes: 21474836480, limitBytes: 21474836480, oomKills: 3,
+			quotaMilli: 4000, periods: 50000, throttled: 0, peakCPUMilli: 1000,
+		})
+		result := erun.Run(t, []string{"list"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "list/runtime_sizing_bounds_a_raise_by_the_namespace_quota", normalize.Apply(result.Combined))
+	})
+
+	t.Run("runtime_sizing_holds_cpu_on_tolerable_throttling", func(t *testing.T) {
+		// frs/local's measured 425 of 308631 periods. Sub-threshold throttling is
+		// tolerable, not unused: it must neither grow the environment nor license
+		// a shrink. This is the false-positive check.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		seedUsageHistory(t, setup, "team", "dev", usageHistorySpec{
+			windowHours: 31, samples: 240,
+			peakMemoryBytes: 1027301376, limitBytes: 2147483648,
+			quotaMilli: 4000, periods: 308631, throttled: 425, peakCPUMilli: 300,
+		})
+		result := erun.Run(t, []string{"list"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "list/runtime_sizing_holds_cpu_on_tolerable_throttling", normalize.Apply(result.Combined))
+	})
+
+	t.Run("runtime_sizing_withholds_a_shrink_on_a_short_window", func(t *testing.T) {
+		// The same comfortable peak as the shrink scenario, watched for an hour.
+		// The verdict must be `insufficient-evidence` naming the shortfall, not a
+		// shrink and not a silent hold.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		seedUsageHistory(t, setup, "team", "dev", usageHistorySpec{
+			windowHours: 1, samples: 120,
+			peakMemoryBytes: 12742377472, limitBytes: 24696061952,
+			quotaMilli: 12000, periods: 376556, throttled: 0, peakCPUMilli: 4567,
+		})
+		result := erun.Run(t, []string{"list"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "list/runtime_sizing_withholds_a_shrink_on_a_short_window", normalize.Apply(result.Combined))
+	})
+}
+
+type usageHistorySpec struct {
+	windowHours     int
+	samples         int
+	peakMemoryBytes int64
+	limitBytes      int64
+	oomKills        int64
+	quotaMilli      int64
+	periods         int64
+	throttled       int64
+	peakCPUMilli    int64
+}
+
+// seedUsageHistory writes the retained usage store directly. The on-disk shape
+// is the contract between the in-pod monitor that writes it and every reader, so
+// spelling the JSON out here pins that shape rather than round-tripping through
+// the same structs it is meant to check.
+func seedUsageHistory(t testing.TB, setup env.Setup, tenant, environment string, spec usageHistorySpec) {
+	t.Helper()
+	dir := filepath.Join(setup.CacheHome, "erun", "activity", tenant, environment)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	// Fixed instants, so the observed window is a property of the fixture rather
+	// than of when the suite happened to run.
+	first := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	last := first.Add(time.Duration(spec.windowHours)*time.Hour + 12*time.Minute)
+	sample := fmt.Sprintf(
+		`{"cpu":{"quotaCores":%g,"usageUsec":%d,"periods":%d,"throttledPeriods":%d},"memory":{"limitBytes":%d,"currentBytes":%d,"peakBytes":%d,"oomKills":%d}}`,
+		float64(spec.quotaMilli)/1000, spec.periods*100, spec.periods, spec.throttled,
+		spec.limitBytes, spec.peakMemoryBytes/2, spec.peakMemoryBytes, spec.oomKills)
+	samples := make([]string, 0, spec.samples)
+	for i := 0; i < spec.samples; i++ {
+		samples = append(samples, sample)
+	}
+	body := fmt.Sprintf(
+		`{"firstObservedAt":%q,"lastObservedAt":%q,"observedPeakMemoryBytes":%d,"observedOomKills":%d,"observedPeakCpuMilli":%d,"observedPeriods":%d,"observedThrottledPeriods":%d,"samples":[%s]}`,
+		first.Format(time.RFC3339Nano), last.Format(time.RFC3339Nano), spec.peakMemoryBytes,
+		spec.oomKills, spec.peakCPUMilli, spec.periods, spec.throttled, strings.Join(samples, ","))
+	mustWrite(t, filepath.Join(dir, "usage-history.json"), body+"\n")
 }
 
 // seedExplicitTypeEnv is shared by list and delete scenarios that assert the resolver honors an explicit `type:`.

--- a/erun-integration/testdata/activity/sample_retains_runtime_usage_from_cgroup_counters.txt
+++ b/erun-integration/testdata/activity/sample_retains_runtime_usage_from_cgroup_counters.txt
@@ -1,6 +1,4 @@
 no working build or agent processes
 audit: erun activity sample --cgroup-root <TMP> --environment dev --proc-root <TMP> --tenant team
-working: java
-audit: erun activity sample --cgroup-root <TMP> --environment dev --proc-root <TMP> --tenant team
 no working build or agent processes
 audit: erun activity sample --cgroup-root <TMP> --environment dev --proc-root <TMP> --tenant team

--- a/erun-integration/testdata/list/runtime_sizing_bounds_a_raise_by_the_namespace_quota.txt
+++ b/erun-integration/testdata/list/runtime_sizing_bounds_a_raise_by_the_namespace_quota.txt
@@ -1,0 +1,45 @@
+Configuration:
+  directory: <TMP>
+Defaults:
+  tenant: team
+  environment: dev
+Current Directory:
+  path: none
+  repo: none
+  configured tenant: none
+  effective target: team/dev
+  kubernetes context: test-context
+  type: local-agent
+  assigned local port range: 17000-17099
+  assigned mcp local port: 17000 (when MCP is running or forwarded)
+  assigned api local port: 17033 (when API is running or forwarded)
+  api url: http://<LOOPBACK>:17033
+  assigned ssh local port: 17022 (when SSH port-forward is active)
+  assigned contribute-app local port: 17050 (when contribute mode is active and `erun app --headless` is running)
+  repo path: <TMP>
+Cloud Providers:
+  none
+Tenants:
+  team [default, effective]
+    default environment: dev
+    environments:
+      - dev [default, effective] context=test-context
+          type: local-agent
+          repo: <TMP>
+          ports: 17000-17099
+          mcp-port: 17000
+          api-port: 17033
+          api-url: http://<LOOPBACK>:17033
+          ssh-port: 17022
+          contribute-app-port: 17050
+          container-registries: registry.example/test[build,deploy]
+          runtime-version: <VERSION>
+          runtime-pod: none
+          sizing: memory raise to 23808Mi from 20480Mi (3 oom kill(s) at 20480Mi; bounded by the 32Gi namespace quota less the dind sidecar's 8916Mi, high confidence); cpu insufficient-evidence from 4 (0.00% of scheduling periods throttled (0 of 50000), but only 5h12m observed of the 24h0m a shrink needs)
+          sizing-evidence: 5h12m observed, 30 samples, 0 restarts, knob=runtimepod, from cgroup memory.peak, cgroup memory.events oom_kill, cgroup cpu.stat usage_usec/nr_throttled (not loadavg)
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: off
+audit: erun list

--- a/erun-integration/testdata/list/runtime_sizing_holds_cpu_on_tolerable_throttling.txt
+++ b/erun-integration/testdata/list/runtime_sizing_holds_cpu_on_tolerable_throttling.txt
@@ -1,0 +1,45 @@
+Configuration:
+  directory: <TMP>
+Defaults:
+  tenant: team
+  environment: dev
+Current Directory:
+  path: none
+  repo: none
+  configured tenant: none
+  effective target: team/dev
+  kubernetes context: test-context
+  type: local-agent
+  assigned local port range: 17000-17099
+  assigned mcp local port: 17000 (when MCP is running or forwarded)
+  assigned api local port: 17033 (when API is running or forwarded)
+  api url: http://<LOOPBACK>:17033
+  assigned ssh local port: 17022 (when SSH port-forward is active)
+  assigned contribute-app local port: 17050 (when contribute mode is active and `erun app --headless` is running)
+  repo path: <TMP>
+Cloud Providers:
+  none
+Tenants:
+  team [default, effective]
+    default environment: dev
+    environments:
+      - dev [default, effective] context=test-context
+          type: local-agent
+          repo: <TMP>
+          ports: 17000-17099
+          mcp-port: 17000
+          api-port: 17033
+          api-url: http://<LOOPBACK>:17033
+          ssh-port: 17022
+          contribute-app-port: 17050
+          container-registries: registry.example/test[build,deploy]
+          runtime-version: <VERSION>
+          runtime-pod: none
+          sizing: memory lower to 1536Mi from 2048Mi (peak 980Mi of 2048Mi (48%), no oom kills, keeping 1.5x headroom, low confidence); cpu hold from 4 (0.14% of scheduling periods throttled (425 of 308631), tolerable but not unused)
+          sizing-evidence: 31h12m observed, 240 samples, 0 restarts, knob=runtimepod, from cgroup memory.peak, cgroup memory.events oom_kill, cgroup cpu.stat usage_usec/nr_throttled (not loadavg)
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: off
+audit: erun list

--- a/erun-integration/testdata/list/runtime_sizing_lowers_memory_on_a_long_quiet_window.txt
+++ b/erun-integration/testdata/list/runtime_sizing_lowers_memory_on_a_long_quiet_window.txt
@@ -1,0 +1,45 @@
+Configuration:
+  directory: <TMP>
+Defaults:
+  tenant: team
+  environment: dev
+Current Directory:
+  path: none
+  repo: none
+  configured tenant: none
+  effective target: team/dev
+  kubernetes context: test-context
+  type: local-agent
+  assigned local port range: 17000-17099
+  assigned mcp local port: 17000 (when MCP is running or forwarded)
+  assigned api local port: 17033 (when API is running or forwarded)
+  api url: http://<LOOPBACK>:17033
+  assigned ssh local port: 17022 (when SSH port-forward is active)
+  assigned contribute-app local port: 17050 (when contribute mode is active and `erun app --headless` is running)
+  repo path: <TMP>
+Cloud Providers:
+  none
+Tenants:
+  team [default, effective]
+    default environment: dev
+    environments:
+      - dev [default, effective] context=test-context
+          type: local-agent
+          repo: <TMP>
+          ports: 17000-17099
+          mcp-port: 17000
+          api-port: 17033
+          api-url: http://<LOOPBACK>:17033
+          ssh-port: 17022
+          contribute-app-port: 17050
+          container-registries: registry.example/test[build,deploy]
+          runtime-version: <VERSION>
+          runtime-pod: none
+          sizing: memory lower to 18432Mi from 23552Mi (peak 12153Mi of 23552Mi (52%), no oom kills, keeping 1.5x headroom, low confidence); cpu lower to 10 from 12 (busiest interval 4.567 of 12, 0.00% of scheduling periods throttled (0 of 376556), keeping 2x headroom, low confidence)
+          sizing-evidence: 31h12m observed, 240 samples, 0 restarts, knob=runtimepod, from cgroup memory.peak, cgroup memory.events oom_kill, cgroup cpu.stat usage_usec/nr_throttled (not loadavg)
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: off
+audit: erun list

--- a/erun-integration/testdata/list/runtime_sizing_raises_cpu_on_sustained_throttling.txt
+++ b/erun-integration/testdata/list/runtime_sizing_raises_cpu_on_sustained_throttling.txt
@@ -1,0 +1,45 @@
+Configuration:
+  directory: <TMP>
+Defaults:
+  tenant: team
+  environment: dev
+Current Directory:
+  path: none
+  repo: none
+  configured tenant: none
+  effective target: team/dev
+  kubernetes context: test-context
+  type: local-agent
+  assigned local port range: 17000-17099
+  assigned mcp local port: 17000 (when MCP is running or forwarded)
+  assigned api local port: 17033 (when API is running or forwarded)
+  api url: http://<LOOPBACK>:17033
+  assigned ssh local port: 17022 (when SSH port-forward is active)
+  assigned contribute-app local port: 17050 (when contribute mode is active and `erun app --headless` is running)
+  repo path: <TMP>
+Cloud Providers:
+  none
+Tenants:
+  team [default, effective]
+    default environment: dev
+    environments:
+      - dev [default, effective] context=test-context
+          type: local-agent
+          repo: <TMP>
+          ports: 17000-17099
+          mcp-port: 17000
+          api-port: 17033
+          api-url: http://<LOOPBACK>:17033
+          ssh-port: 17022
+          contribute-app-port: 17050
+          container-registries: registry.example/test[build,deploy]
+          runtime-version: <VERSION>
+          runtime-pod: none
+          sizing: memory lower to 1536Mi from 8192Mi (peak 1024Mi of 8192Mi (12%), no oom kills, keeping 1.5x headroom, low confidence); cpu raise to 3 from 2 (12.00% of scheduling periods throttled (12000 of 100000), high confidence)
+          sizing-evidence: 31h12m observed, 240 samples, 0 restarts, knob=runtimepod, from cgroup memory.peak, cgroup memory.events oom_kill, cgroup cpu.stat usage_usec/nr_throttled (not loadavg)
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: off
+audit: erun list

--- a/erun-integration/testdata/list/runtime_sizing_raises_memory_on_an_oom_kill.txt
+++ b/erun-integration/testdata/list/runtime_sizing_raises_memory_on_an_oom_kill.txt
@@ -1,0 +1,45 @@
+Configuration:
+  directory: <TMP>
+Defaults:
+  tenant: team
+  environment: dev
+Current Directory:
+  path: none
+  repo: none
+  configured tenant: none
+  effective target: team/dev
+  kubernetes context: test-context
+  type: local-agent
+  assigned local port range: 17000-17099
+  assigned mcp local port: 17000 (when MCP is running or forwarded)
+  assigned api local port: 17033 (when API is running or forwarded)
+  api url: http://<LOOPBACK>:17033
+  assigned ssh local port: 17022 (when SSH port-forward is active)
+  assigned contribute-app local port: 17050 (when contribute mode is active and `erun app --headless` is running)
+  repo path: <TMP>
+Cloud Providers:
+  none
+Tenants:
+  team [default, effective]
+    default environment: dev
+    environments:
+      - dev [default, effective] context=test-context
+          type: local-agent
+          repo: <TMP>
+          ports: 17000-17099
+          mcp-port: 17000
+          api-port: 17033
+          api-url: http://<LOOPBACK>:17033
+          ssh-port: 17022
+          contribute-app-port: 17050
+          container-registries: registry.example/test[build,deploy]
+          runtime-version: <VERSION>
+          runtime-pod: none
+          sizing: memory raise to 3072Mi from 2048Mi (1 oom kill(s) at 2048Mi, high confidence); cpu insufficient-evidence from 1 (0.00% of scheduling periods throttled (0 of 5000), but only 12m observed of the 24h0m a shrink needs)
+          sizing-evidence: 12m observed, 2 samples, 0 restarts, knob=runtimepod, from cgroup memory.peak, cgroup memory.events oom_kill, cgroup cpu.stat usage_usec/nr_throttled (not loadavg)
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: off
+audit: erun list

--- a/erun-integration/testdata/list/runtime_sizing_raises_memory_when_the_peak_nears_the_limit.txt
+++ b/erun-integration/testdata/list/runtime_sizing_raises_memory_when_the_peak_nears_the_limit.txt
@@ -1,0 +1,45 @@
+Configuration:
+  directory: <TMP>
+Defaults:
+  tenant: team
+  environment: dev
+Current Directory:
+  path: none
+  repo: none
+  configured tenant: none
+  effective target: team/dev
+  kubernetes context: test-context
+  type: local-agent
+  assigned local port range: 17000-17099
+  assigned mcp local port: 17000 (when MCP is running or forwarded)
+  assigned api local port: 17033 (when API is running or forwarded)
+  api url: http://<LOOPBACK>:17033
+  assigned ssh local port: 17022 (when SSH port-forward is active)
+  assigned contribute-app local port: 17050 (when contribute mode is active and `erun app --headless` is running)
+  repo path: <TMP>
+Cloud Providers:
+  none
+Tenants:
+  team [default, effective]
+    default environment: dev
+    environments:
+      - dev [default, effective] context=test-context
+          type: local-agent
+          repo: <TMP>
+          ports: 17000-17099
+          mcp-port: 17000
+          api-port: 17033
+          api-url: http://<LOOPBACK>:17033
+          ssh-port: 17022
+          contribute-app-port: 17050
+          container-registries: registry.example/test[build,deploy]
+          runtime-version: <VERSION>
+          runtime-pod: none
+          sizing: memory raise to 3072Mi from 2048Mi (peak 1946Mi of 2048Mi (95%) is within the raise margin, high confidence); cpu insufficient-evidence from 1 (0.00% of scheduling periods throttled (0 of 50000), but only 5h12m observed of the 24h0m a shrink needs)
+          sizing-evidence: 5h12m observed, 30 samples, 0 restarts, knob=runtimepod, from cgroup memory.peak, cgroup memory.events oom_kill, cgroup cpu.stat usage_usec/nr_throttled (not loadavg)
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: off
+audit: erun list

--- a/erun-integration/testdata/list/runtime_sizing_withholds_a_shrink_on_a_short_window.txt
+++ b/erun-integration/testdata/list/runtime_sizing_withholds_a_shrink_on_a_short_window.txt
@@ -1,0 +1,45 @@
+Configuration:
+  directory: <TMP>
+Defaults:
+  tenant: team
+  environment: dev
+Current Directory:
+  path: none
+  repo: none
+  configured tenant: none
+  effective target: team/dev
+  kubernetes context: test-context
+  type: local-agent
+  assigned local port range: 17000-17099
+  assigned mcp local port: 17000 (when MCP is running or forwarded)
+  assigned api local port: 17033 (when API is running or forwarded)
+  api url: http://<LOOPBACK>:17033
+  assigned ssh local port: 17022 (when SSH port-forward is active)
+  assigned contribute-app local port: 17050 (when contribute mode is active and `erun app --headless` is running)
+  repo path: <TMP>
+Cloud Providers:
+  none
+Tenants:
+  team [default, effective]
+    default environment: dev
+    environments:
+      - dev [default, effective] context=test-context
+          type: local-agent
+          repo: <TMP>
+          ports: 17000-17099
+          mcp-port: 17000
+          api-port: 17033
+          api-url: http://<LOOPBACK>:17033
+          ssh-port: 17022
+          contribute-app-port: 17050
+          container-registries: registry.example/test[build,deploy]
+          runtime-version: <VERSION>
+          runtime-pod: none
+          sizing: memory insufficient-evidence from 23552Mi (peak 12153Mi of 23552Mi (52%), but only 1h12m observed of the 24h0m a shrink needs); cpu insufficient-evidence from 12 (0.00% of scheduling periods throttled (0 of 376556), but only 1h12m observed of the 24h0m a shrink needs)
+          sizing-evidence: 1h12m observed, 120 samples, 0 restarts, knob=runtimepod, from cgroup memory.peak, cgroup memory.events oom_kill, cgroup cpu.stat usage_usec/nr_throttled (not loadavg)
+          managed-cloud: off
+          ai-tool: none
+          claude: none
+          idle: none
+          sshd: off
+audit: erun list

--- a/erun-integration/testdata/usage/dry_run.txt
+++ b/erun-integration/testdata/usage/dry_run.txt
@@ -21,4 +21,6 @@ usage:
   printf 'cpu_usage_after=%s\n' "$cpu_usage_after"
   printf 'cpu_time_before_ns=%s\n' "$time_before"
   printf 'cpu_time_after_ns=%s\n' "$time_after"
+  printf 'cpu_periods=%s\n' "$(awk '$1=="nr_periods"{print $2}' $cg/cpu.stat 2>/dev/null || true)"
+  printf 'cpu_throttled_periods=%s\n' "$(awk '$1=="nr_throttled"{print $2}' $cg/cpu.stat 2>/dev/null || true)"
   printf 'disk_workspace=%s\n' "$(df -Pk <HOME> 2>/dev/null | tail -n1 || true)"

--- a/erun-integration/testdata/usage/dry_run_custom_interval.txt
+++ b/erun-integration/testdata/usage/dry_run_custom_interval.txt
@@ -21,4 +21,6 @@ usage:
   printf 'cpu_usage_after=%s\n' "$cpu_usage_after"
   printf 'cpu_time_before_ns=%s\n' "$time_before"
   printf 'cpu_time_after_ns=%s\n' "$time_after"
+  printf 'cpu_periods=%s\n' "$(awk '$1=="nr_periods"{print $2}' $cg/cpu.stat 2>/dev/null || true)"
+  printf 'cpu_throttled_periods=%s\n' "$(awk '$1=="nr_throttled"{print $2}' $cg/cpu.stat 2>/dev/null || true)"
   printf 'disk_workspace=%s\n' "$(df -Pk <HOME> 2>/dev/null | tail -n1 || true)"

--- a/erun-integration/testdata/usage/real_run_reports_cgroup_v2_usage.txt
+++ b/erun-integration/testdata/usage/real_run_reports_cgroup_v2_usage.txt
@@ -4,7 +4,10 @@
   "cpu": {
     "quotaCores": 1,
     "utilizationPercent": 10,
-    "intervalSeconds": 1
+    "intervalSeconds": 1,
+    "usageUsec": 581611501,
+    "periods": 376556,
+    "throttledPeriods": 425
   },
   "memory": {
     "currentBytes": 413589504,

--- a/erun-integration/usage_test.go
+++ b/erun-integration/usage_test.go
@@ -79,6 +79,8 @@ func TestUsage(t *testing.T) {
 			"cpu_usage_after=581611501",
 			"cpu_time_before_ns=1000000000",
 			"cpu_time_after_ns=2000000000",
+			"cpu_periods=376556",
+			"cpu_throttled_periods=425",
 			"disk_workspace=overlay 198234112 89006592 99117056 45% /home/erun",
 		})
 		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
@@ -92,6 +94,12 @@ func TestUsage(t *testing.T) {
 		// directory. Assert the literal, un-normalized value once here.
 		if !strings.Contains(result.Combined, `"mount": "/home/erun"`) {
 			t.Fatalf("expected the watched mount to be the literal /home/erun, got:\n%s", result.Combined)
+		}
+		// nr_periods/nr_throttled are the CPU-starvation signal
+		// RuntimeUsageHistory derives its throttle ratio from; assert them here
+		// since they carry no threshold of their own to warn on.
+		if !strings.Contains(result.Combined, `"periods": 376556`) || !strings.Contains(result.Combined, `"throttledPeriods": 425`) {
+			t.Fatalf("expected cpu.periods/throttledPeriods parsed from cpu.stat, got:\n%s", result.Combined)
 		}
 		golden.Equal(t, "usage/real_run_reports_cgroup_v2_usage", normalize.Apply(result.Combined))
 	})


### PR DESCRIPTION
Closes #1234

Every environment now carries a standing, evidence-backed sizing recommendation derived from what that environment has actually done. It prints under `erun list`'s existing `runtime-pod:` line and rides along as a structured `sizing` field on each environment in the MCP `list` tool's result, so an orchestrator picks it up from a read it already makes.

```
runtime-pod: cpu=12 memory=23552Mi
sizing: memory lower to 18432Mi from 23552Mi (peak 12153Mi of 23552Mi (52%), no oom kills, keeping 1.5x headroom, low confidence); cpu lower to 10 from 12 (busiest interval 4.567 of 12, 0.00% of scheduling periods throttled (0 of 376556), keeping 2x headroom, low confidence)
sizing-evidence: 31h12m observed, 240 samples, 1 restarts, knob=runtimepod, from cgroup memory.peak, cgroup memory.events oom_kill, cgroup cpu.stat usage_usec/nr_throttled (not loadavg)
```

## Three places the issue's framing was wrong

**1. #1233 does not exist.** The issue says "Build #1233 first. This issue consumes its reader and adds nothing to the collection surface," and I was told to build on its live CPU/memory/disk read rather than duplicate it. There is no branch, no PR, and nothing on `main`: `grep -rn RuntimeUsage --include=*.go` returns nothing and `erun-cli/cmd/usage.go` does not exist. So this PR necessarily contains the minimal collection it needs — a cgroup v2 reader in `erun-common` — shaped as #1233 item 1 specifies (per-field unavailability, no metrics-server, fail-soft) so #1233 becomes "expose it over `erun usage` / MCP / `observe` / the orchestrate skill" rather than having to rework it. **Disk is deliberately not read here**, which is a scope correction rather than an omission: disk is sized by the chart's PVC claims, not by `runtimepod`, so a disk verdict on a `runtimepod` recommendation would name the wrong knob — exactly what issue item 5 forbids. It needs its own verdict shape and belongs with #1233's reader.

**2. The declared `runtimepod` is the wrong thing to compare against, and comparing against it produces a concretely wrong answer.** The issue frames this as "compare `EnvConfig.RuntimePod` to consumption". But the runtime pod's own config never learns its limits — the chart injects them. On the live `erun/build` container, `erun list` built from unmodified `main` prints:

```
runtime-pod: none
```

while the container is actually running under `cpu.max: 1200000 100000` (12 cores) and `memory.max: 24696061952` (23552Mi exactly). An empty `runtimepod` normalizes to the 4 / 8916Mi defaults, so a recommender scoring the observed 12153Mi peak against the *declared* size would see 12153Mi against an 8916Mi limit and **recommend raising memory on an environment that is over-provisioned 2×**. The recommender therefore scores against the cgroup limit — the size the container is really running under — and uses `runtimepod` only as the name of the knob to change. An integration scenario seeds an env with no `runtimepod` for exactly this reason.

**3. A 2× shrink headroom makes the recommender useless, which the first golden caught.** I initially wrote `runtimeSizingMemoryHeadroom = 2.0` as the "healthy multiple". Generating the goldens showed the shrink scenario producing `memory hold ... leaves no room to shrink at 2x headroom`: a 2× rule can only shrink an environment whose peak is under half its limit, and the two real over-provisioned environments in the issue sit at 48% (`frs/local`) and 52% (`erun/build`) — so a doubling rule declares one of them fine and offers the other a rounding error. It is set to 1.5, which produces `frs/local` → 1536Mi and `erun/build` → 18432Mi, and cannot oscillate against the 0.90 raise margin (the band between is `hold`). CPU keeps 2× on purpose and the constant says why: `memory.peak` is a true instantaneous high-water the kernel recorded, while the CPU figure is an average over the sample interval, so it flattens the very bursts a quota would throttle and needs more slack, not less.

## What is in it

- **`erun-common/runtime_usage.go`** — cgroup v2 reader: `cpu.max`, `cpu.stat`, `memory.current/peak/max`, `memory.events` `oom_kill`. Never returns an error; each absent counter is named in `Unavailable`. cgroup v1, an unlimited `memory.max`, and absent PSI are ordinary host states, not failures. PSI is not read at all — it is empty on this kernel, and nothing may depend on it.
- **`erun-common/runtime_usage_history.go`** — the retention store, under `~/.cache/erun/activity/<tenant>/<env>/usage-history.json` (on the home PVC, so it survives pod restarts). Its design point: the monotonic aggregates (observed peak, accumulated OOM kills, accumulated scheduling periods, restart count, first-observed) live **outside** the bounded 240-sample rolling window, because `memory.peak` resets on restart *and* the window evicts its oldest sample — neither the counter nor the window can be the memory of record. A restart is inferred from a cumulative counter going backwards, which needs no second source of truth (a container restarted in place keeps its pod's hostname, so the hostname cannot supply one).
- **`erun-common/runtime_sizing.go`** — the recommender, a pure function of history plus the namespace quota. Asymmetric by construction: `oom_kill > 0` or a peak inside the 90% raise margin raises at high confidence with no window requirement; a shrink needs ≥24h *and* ≥120 samples *and* lands at 1.5× the observed peak rounded **up** to 256Mi; it is never better than low confidence, because a quiet window is an argument from silence. Sub-threshold CPU throttling is `hold`, not licence to shrink — tolerable is not unused. A raise is clamped to what the namespace `ResourceQuota` can admit less the `erun-dind` sidecar's own limit, and says when it clamped.
- **Collection rides the monitor's existing tick.** `erun activity sample` — which the entrypoint's 30s loop already runs in-pod — now also retains a usage sample. No new scheduled job, no entrypoint change. A `--cgroup-root` flag mirrors the existing `--proc-root`. A host that supplies no counters records nothing, so a laptop does not accumulate a history of empty samples.
- **Nothing is ever auto-applied**, per item 7.

## Not delivered from the issue's scope

- **Node-capacity bounding (item 4).** The issue says to reuse the node accounting in `erun-ui/runtime_resources.go`, but that is desktop-only and `erun-common` must not import `erun-ui` (root AGENTS.md § "Architecture And Module Boundaries"). A raise is bounded by the namespace `ResourceQuota` instead, which is reachable from `EnvConfig` and is a real hard admission limit. Lifting the node accounting into `erun-common` so both can share it is a separate refactor.
- **Disk**, for the knob reason above.

## How I reproduced the gap on unmodified `main`

Built `main` at `051021d1` (`cd erun-cli && go build`) and ran it inside the live `erun/build` runtime container:

- `erun list` printed `runtime-pod: none` and nothing comparing any size to any consumption.
- The counters that settle it were readable the whole time, with no cluster add-on: `memory.max` 24696061952 (= 23552Mi exactly), `memory.peak` 12742377472 (12152Mi, **52%**), `memory.events` `oom_kill 0`, `cpu.max` `1200000 100000` (12 cores), `cpu.stat` `nr_periods 376556` / `nr_throttled 0`.
- `stat -fc %T /sys/fs/cgroup` → `cgroup2fs`; `memory.pressure` and `cpu.pressure` → **No such file or directory**, confirming the issue's PSI premise on this kernel.
- `grep -rn RuntimeUsage --include=*.go` → no matches, confirming #1233 is absent.

So the honest verdict — memory over-provisioned, CPU adequate — was fully determined by data `main` could read and had no way to say.

**Live end-to-end with the change** (same container, same vantage point, real `/sys/fs/cgroup`): three `erun activity sample` runs retained a history, and `erun list` rendered it, reporting `insufficient-evidence` naming the 0m-of-24h shortfall — the evidence-window honesty working, not a stub. I removed the probe history file afterwards.

**The loadavg point, demonstrated live rather than asserted.** At the moment of the run, `/proc/loadavg` read `11.91` against a 12-core quota — 99% saturation by the obvious reading, and grounds to raise CPU — while `cpu.stat` reported **1 throttled period out of 394,286**. loadavg counts the *host's* runnable queue, and this pod shares its node. Nothing in the recommender is loadavg-derived, the evidence line names its counters and ends `(not loadavg)`, and the docs say why.

## How I proved the new tests fail without the fix

The tests cover new code, so "stash it and run" only proves it does not compile. I mutated each guarantee individually in the production code instead and recorded what the tests said:

| Mutation | Result |
|---|---|
| `runtimeUsageCountersReset` → `return false` (a peak reset read as a real decline) | **FAIL** `TestAppendRuntimeUsageSampleRetainsPeakAcrossARestart: restarts = 0, want 1` and `...BoundsTheWindow: restarts = 0, want the single counter reset` |
| `if history.ObservedOOMKills > 0` → `if false` | **FAIL** `a_single_oom_kill_raises_even_though_the_peak_looks_comfortable: action = "insufficient-evidence", want "raise"`, plus `TestRecommendRuntimeSizingAnyOOMKillRaises` |
| `steps := (scaled + graduation - 1) / graduation` → `scaled / graduation` (round down) | **FAIL** `TestRecommendRuntimeSizingNeverShrinksBelowHeadroom: limit=536870912 peak=177167400: suggested 256Mi is below 1.5x the observed peak` |
| `if throttled > 0` → `if false` (sub-threshold throttling permitted to shrink) | **PASSED — the test was not load-bearing.** |

That last row is the useful one. The `frs/local` case (1-core quota, 425/308631 throttled) passed with the guard removed because a one-core quota leaves no room to shrink into anyway — it was green for the wrong reason and would never have caught a regression. I added `sub-threshold throttling disqualifies a shrink` with a 4-core quota, where the busiest-interval figure *would* otherwise propose a shrink; re-running the same mutation then gives **FAIL** `action = "lower", want "hold"`.

Also fixed while writing the tests: `%.0fx headroom` rendered a 1.5 multiple as `2x` in user-facing output (now `%g`), and the throttle ratio rendered `425 of 308631` as `0%`, which reads as "never throttled" when the whole point is that it was, a little (now two decimals, `0.14%`).

## Goldens

Every `testdata/` file, as AGENTS.md requires:

- **Modified** `activity/sample_records_activity_only_when_work_advances.txt` — one added flag in the audit line. The scenario now passes `--cgroup-root` at a declared-absent path so it stays about the process sampler and reads nothing ambient from whichever host ran it.
- **New** `activity/sample_retains_runtime_usage_from_cgroup_counters.txt` — collection against a cgroup fixture.
- **New**, seven `list/runtime_sizing_*.txt` — one per direction: memory lower, memory raise on an OOM kill, memory raise on the peak margin, a raise clamped by the namespace quota, CPU raise on sustained throttling, CPU hold on tolerable throttling (the false-positive check, at `frs/local`'s measured 0.14%), and a withheld shrink naming its window shortfall. Each seeds a history because a real 26-hour window is not something a scenario can wait for — which is the shrink gate working as designed.

`list/runtime_sizing_holds_cpu_on_tolerable_throttling.txt` is the issue's own end-to-end expectation, both halves: `memory lower to 1536Mi from 2048Mi (peak 980Mi of 2048Mi (48%), no oom kills...)` and `cpu hold from 4 (0.14% of scheduling periods throttled (425 of 308631), tolerable but not unused)`.

## Docs plan

Feature-shaped, so the docs are in this PR.

- **`erun-docs/docs/cli/list.md`** (Operator) — new "The sizing recommendation" section: where the figures come from and that no metrics-server is required, a signal/direction/why table, why raising and shrinking are not symmetric, the namespace-quota bound, the two limits stated explicitly (`memory.peak` resets on restart; PSI unavailable on some kernels), that nothing is loadavg-derived, and when the lines do not print. #1233's `erun usage` page does not exist to extend, so this page carries it; when #1233 lands, `usage` should link here rather than restate it.
- **`erun-docs/docs/concepts/runtime-pods.md`** (Operator) — short subsection in "Reading the resource figures", which already warns that the node reading is a snapshot and that over-provisioning shows up as nothing. Links to the `list` anchor.
- No Agent-reference page: this adds no MCP tool (the existing `list` tool carries the field), so `mcpToolDescriptors` and the MCP tool tables are untouched and there is no `describeTool` panic risk. No docs page enumerates `ListResult`'s per-env fields.
- Validated: `cd erun-docs && yarn build` clean; the `/cli/list#the-sizing-recommendation` anchor confirmed against the heading.

## Gates

- `go test ./...` green in `erun-common`, `erun-cli`, `erun-mcp`, both normally and under `env PATH=/usr/local/go/bin:/usr/bin:/bin`.
- `cd erun-integration && go test ./...` green, and green again under the stripped PATH.
- `make integration-test` green: **coverage 76.7% (>= 76.2%)**. The three extra scenarios (raise-on-margin, quota bound, tolerable-throttle hold) were added specifically so those arms are reachable from the binary rather than only from unit tests, which do not count toward the gate.
- `golangci-lint run ./...` → `0 issues` for all six gated modules (`erun-common`, `erun-cli`, `erun-mcp`, `erun-integration`, `erun-backend/erun-backend-api`, `erun-ui`). Three findings on my own new code were fixed by restructuring, not suppressed: a `gofumpt` realignment of `ListEnvironmentResult` (mechanically forced by the longer field type — the 45-line diff there is pure realignment), a `funlen` on the memory table (split into a raise-directions test and a shrink/withhold-directions test sharing one assertion helper), and a `cyclop` on the reader test (split into three named tests). No `//nolint`, no skips, no threshold change.
- No migrations, no tenant-scoped data, so no `ERUN_E2E_*_DATABASE_URL` suite applies. No Playwright spec touched — this change has no desktop surface.

## What I could not verify

- **The `lower` and `raise` verdicts against a real ≥24h observation window.** The shrink gate requires a day of samples by design, so a live confirmation needs a day. Those directions are verified from the binary against seeded histories (the seven goldens) and by the unit tables; what I confirmed live is the collection, the retention, the render, and the honest short-window refusal.
- **A real OOM kill and a real sustained-throttle event.** `memory.events` `oom_kill` was 0 and throttling was 1-in-394,286 on this container for the whole session, so the raise directions are covered by fixtures rather than by a live incident. `#1233`'s validation plan proposes driving a memory-heavy build to make a threshold fire; that is the right home for it.
- **cgroup v1 and a cgroup-less host.** Covered by fixture trees, not by a real such host — this container is `cgroup2fs`.
- **The desktop.** No `erun-ui` surface was added, so the recommendation is not shown in the desktop's Runtime tab. Doing that is a follow-on, and the docs do not claim otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
