### PR TITLE
Rename desktop activity launcher and relabel internal-name surfaces

### DIFF
--- a/erun-ui/frontend/src/components/app/ActivityQueueDrawer.helpers.test.ts
+++ b/erun-ui/frontend/src/components/app/ActivityQueueDrawer.helpers.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { ActivityQueueEntry } from '@/app/activityQueueState';
+
+import { activityElapsedLabel } from './ActivityQueueDrawer.helpers';
+
+// A running entry that spent real time queued must show elapsed time since it
+// started RUNNING, not since it was enqueued -- otherwise the card inflates
+// the duration by however long the entry sat waiting for a slot.
+
+function entry(overrides: Partial<ActivityQueueEntry>): ActivityQueueEntry {
+  return {
+    id: 'entry-1',
+    command: 'deploy',
+    tenant: 'acme',
+    environment: 'prod',
+    status: 'running',
+    startedAt: '2026-08-24T00:00:00.000Z',
+    lastUpdated: '2026-08-24T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+test('a running entry that waited before starting anchors elapsed on startedRunningAt', () => {
+  const queued = entry({
+    status: 'running',
+    enqueuedAt: '2026-08-24T00:00:00.000Z',
+    startedAt: '2026-08-24T00:00:00.000Z',
+    startedRunningAt: '2026-08-24T00:06:40.000Z',
+  });
+  const now = Date.parse('2026-08-24T00:06:50.000Z');
+  // 10 real seconds of running, not the 6m50s since enqueue/startedAt.
+  assert.equal(activityElapsedLabel(queued, now), '   10s');
+});
+
+test('a running entry with no queue wait falls back to startedAt', () => {
+  const immediate = entry({
+    status: 'running',
+    startedAt: '2026-08-24T00:00:00.000Z',
+  });
+  const now = Date.parse('2026-08-24T00:00:05.000Z');
+  assert.equal(activityElapsedLabel(immediate, now), '    5s');
+});
+
+test('a waiting entry still anchors on enqueuedAt', () => {
+  const waiting = entry({
+    status: 'waiting',
+    enqueuedAt: '2026-08-24T00:00:00.000Z',
+    startedAt: '2026-08-24T00:00:00.000Z',
+  });
+  const now = Date.parse('2026-08-24T00:00:03.000Z');
+  assert.equal(activityElapsedLabel(waiting, now), '    3s');
+});

--- a/erun-ui/frontend/src/components/app/ActivityQueueDrawer.helpers.ts
+++ b/erun-ui/frontend/src/components/app/ActivityQueueDrawer.helpers.ts
@@ -32,7 +32,9 @@ export function activityElapsedLabel(entry: ActivityQueueEntry, now: number): st
   const isRunning = entry.status === 'running';
   const isWaiting = entry.status === 'waiting';
   if (isRunning || isWaiting) {
-    const elapsedAnchor = isWaiting && entry.enqueuedAt ? entry.enqueuedAt : entry.startedAt;
+    const elapsedAnchor = isWaiting
+      ? (entry.enqueuedAt ?? entry.startedAt)
+      : (entry.startedRunningAt ?? entry.startedAt);
     return formatElapsed(elapsedAnchor, now);
   }
   if (entry.endedAt) {

--- a/erun-ui/frontend/src/components/app/ActivityQueueLauncher.tsx
+++ b/erun-ui/frontend/src/components/app/ActivityQueueLauncher.tsx
@@ -1,4 +1,4 @@
-import { Rocket } from 'lucide-react';
+import { ListChecks } from 'lucide-react';
 import * as React from 'react';
 
 import { useActivityQueue } from '@/app/activityQueueState';
@@ -30,12 +30,12 @@ export function ActivityQueueLauncher({
             className="fixed bottom-5 right-5 z-20 size-10 rounded-full shadow-lg"
             aria-label={
               activeCount > 0
-                ? `Open deploy queue (${String(activeCount)} active)`
-                : 'Open deploy queue'
+                ? `Open activities (${String(activeCount)} active)`
+                : 'Open activities'
             }
             onClick={onOpen}
           >
-            <Rocket aria-hidden="true" className="size-4" />
+            <ListChecks aria-hidden="true" className="size-4" />
             {activeCount > 0 && (
               <span className="absolute -top-1 -right-1 inline-flex size-4 items-center justify-center rounded-full bg-blue-500 text-[10px] font-medium text-white">
                 {activeCount}
@@ -45,8 +45,8 @@ export function ActivityQueueLauncher({
         </TooltipTrigger>
         <TooltipContent side="left">
           {activeCount > 0
-            ? `${String(activeCount)} deploy${activeCount > 1 ? 's' : ''} in progress`
-            : 'Deploys'}
+            ? `${String(activeCount)} activit${activeCount > 1 ? 'ies' : 'y'} in progress`
+            : 'Activities'}
         </TooltipContent>
       </Tooltip>
       <ActivityQueueDrawer open={open} onClose={onClose} />

--- a/erun-ui/frontend/src/components/app/ContainerRegistriesField.tsx
+++ b/erun-ui/frontend/src/components/app/ContainerRegistriesField.tsx
@@ -2,6 +2,7 @@ import { Boxes, Plus, Trash2 } from 'lucide-react';
 import * as React from 'react';
 
 import { EditableComboField } from '@/components/app/EditableComboField';
+import { IconTooltip } from '@/components/app/IconTooltip';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
@@ -178,23 +179,23 @@ function RegistryRoleCheckboxes({
       {REGISTRY_ROLES.map((role) => {
         const checkboxId = `environment-config-registry-${String(index)}-role-${role}`;
         return (
-          <label
-            key={role}
-            htmlFor={checkboxId}
-            className="flex items-center gap-1.5 text-xs text-muted-foreground"
-            title={ROLE_HINT[role]}
-          >
-            <Checkbox
-              id={checkboxId}
-              checked={entry.roles.includes(role)}
-              disabled={disabled}
-              aria-label={`${role} role for registry ${String(index + 1)}`}
-              onCheckedChange={(checked) => {
-                onToggle(role, checked === true);
-              }}
-            />
-            {role}
-          </label>
+          <IconTooltip key={role} label={ROLE_HINT[role]}>
+            <label
+              htmlFor={checkboxId}
+              className="flex items-center gap-1.5 text-xs text-muted-foreground"
+            >
+              <Checkbox
+                id={checkboxId}
+                checked={entry.roles.includes(role)}
+                disabled={disabled}
+                aria-label={`${role} role for registry ${String(index + 1)}`}
+                onCheckedChange={(checked) => {
+                  onToggle(role, checked === true);
+                }}
+              />
+              {role}
+            </label>
+          </IconTooltip>
         );
       })}
     </div>

--- a/erun-ui/frontend/src/components/app/ManageDialogPortsTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogPortsTab.tsx
@@ -19,11 +19,27 @@ export function PortsTab({ dialog }: { dialog: ManageDialog }): React.ReactEleme
       />
       <PortStatusTable
         rows={[
-          { service: 'mcp', port: config.localPorts.mcp, status: config.localPorts.mcpStatus },
-          { service: 'api', port: config.localPorts.api, status: config.localPorts.apiStatus },
-          { service: 'ssh', port: config.localPorts.ssh, status: config.localPorts.sshStatus },
           {
-            service: 'contribute-app',
+            key: 'mcp',
+            service: 'AI agent connection',
+            port: config.localPorts.mcp,
+            status: config.localPorts.mcpStatus,
+          },
+          {
+            key: 'api',
+            service: 'Environment API',
+            port: config.localPorts.api,
+            status: config.localPorts.apiStatus,
+          },
+          {
+            key: 'ssh',
+            service: 'SSH access',
+            port: config.localPorts.ssh,
+            status: config.localPorts.sshStatus,
+          },
+          {
+            key: 'contribute-app',
+            service: 'Contribute app preview',
             port: config.localPorts.contributeApp,
             status: config.localPorts.contributeAppStatus,
           },
@@ -36,7 +52,7 @@ export function PortsTab({ dialog }: { dialog: ManageDialog }): React.ReactEleme
 function PortStatusTable({
   rows,
 }: {
-  rows: { service: string; port: number; status: UIPortStatus }[];
+  rows: { key: string; service: string; port: number; status: UIPortStatus }[];
 }): React.ReactElement {
   return (
     <div className="grid gap-2">
@@ -49,7 +65,7 @@ function PortStatusTable({
         </div>
         {rows.map((row) => (
           <div
-            key={row.service}
+            key={row.key}
             className="grid min-h-8 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 border-b border-border px-3 py-1 last:border-b-0"
           >
             <div className="font-mono text-xs text-foreground">

--- a/erun-ui/frontend/src/components/app/ManageDialogSSHTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogSSHTab.tsx
@@ -23,10 +23,7 @@ import { cn } from '@/lib/utils';
 type ManageDialog = AppState['manageDialog'];
 
 export function SSHAccessSection({ dialog }: { dialog: ManageDialog }): React.ReactElement {
-  const dispatch = useAppDispatch();
   const config = dialog.config;
-  const syncPathRequired =
-    config.sshd.workspaceSyncEnabled && !(config.sshd.workspaceSyncLocalPath ?? '').trim();
   return (
     <div className="grid gap-3 rounded-[var(--radius)] border border-border p-3">
       <SSHAccessHeader dialog={dialog} />
@@ -35,24 +32,6 @@ export function SSHAccessSection({ dialog }: { dialog: ManageDialog }): React.Re
         label="SSHD"
         value={config.sshd.enabled ? 'Enabled' : 'Disabled'}
       />
-      <CheckboxField
-        id="environment-config-sshd-sync-enabled"
-        label="Enable workspace sync"
-        checked={config.sshd.workspaceSyncEnabled}
-        disabled={dialog.busy || dialog.configLoading || !config.sshd.enabled}
-        onChange={(workspaceSyncEnabled) => {
-          dispatch(updateManageSSHDConfig({ workspaceSyncEnabled }));
-        }}
-      />
-      {config.sshd.workspaceSyncEnabled && (
-        <>
-          <WorkspaceSyncStatus sshd={config.sshd} />
-          <LocalSyncFolderField
-            dialog={dialog}
-            error={syncPathRequired ? 'Choose a local Git folder before saving.' : ''}
-          />
-        </>
-      )}
       <ReadonlyField
         id="environment-config-sshd-localport"
         label="Local port"
@@ -63,6 +42,47 @@ export function SSHAccessSection({ dialog }: { dialog: ManageDialog }): React.Re
         label="Public key"
         value={config.sshd.publicKeyPath}
       />
+    </div>
+  );
+}
+
+// Workspace sync rides over the SSH connection, but it is a distinct user
+// concept (mirroring a local Git folder into the pod's worktree) from SSH
+// shell access itself, so it gets its own titled section rather than sitting
+// as an unlabeled checkbox inside "SSH access" (recognition over recall).
+export function WorkspaceSyncSection({ dialog }: { dialog: ManageDialog }): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const config = dialog.config;
+  const syncPathRequired =
+    config.sshd.workspaceSyncEnabled && !(config.sshd.workspaceSyncLocalPath ?? '').trim();
+  return (
+    <div className="grid gap-3 rounded-[var(--radius)] border border-border p-3">
+      <div className="text-xs leading-[1.2] font-semibold tracking-normal text-muted-foreground uppercase">
+        Workspace sync
+      </div>
+      <CheckboxField
+        id="environment-config-sshd-sync-enabled"
+        label="Enable workspace sync"
+        checked={config.sshd.workspaceSyncEnabled}
+        disabled={dialog.busy || dialog.configLoading || !config.sshd.enabled}
+        onChange={(workspaceSyncEnabled) => {
+          dispatch(updateManageSSHDConfig({ workspaceSyncEnabled }));
+        }}
+      />
+      {!config.sshd.enabled && (
+        <div className="text-[13px] leading-[1.35] text-muted-foreground">
+          Requires SSH access to be enabled.
+        </div>
+      )}
+      {config.sshd.workspaceSyncEnabled && (
+        <>
+          <WorkspaceSyncStatus sshd={config.sshd} />
+          <LocalSyncFolderField
+            dialog={dialog}
+            error={syncPathRequired ? 'Choose a local Git folder before saving.' : ''}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -23,7 +23,11 @@ import { GeneralTab } from '@/components/app/ManageDialogGeneralTab';
 import { HistoryTab } from '@/components/app/ManageDialogHistoryTab';
 import { PortsTab } from '@/components/app/ManageDialogPortsTab';
 import { RuntimeTab } from '@/components/app/ManageDialogRuntimeTab';
-import { DiagnosticsSection, SSHAccessSection } from '@/components/app/ManageDialogSSHTab';
+import {
+  DiagnosticsSection,
+  SSHAccessSection,
+  WorkspaceSyncSection,
+} from '@/components/app/ManageDialogSSHTab';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -154,7 +158,7 @@ function ManageDialogContent({
           <DirtyAwareTabsTrigger value="runtime" label="Runtime" dialog={dialog} />
           <DirtyAwareTabsTrigger value="ai" label="AI" dialog={dialog} />
           <DirtyAwareTabsTrigger value="ports" label="Ports" dialog={dialog} />
-          <DirtyAwareTabsTrigger value="ssh" label="SSH" dialog={dialog} />
+          <DirtyAwareTabsTrigger value="ssh" label="Access" dialog={dialog} />
           <DirtyAwareTabsTrigger value="history" label="History" dialog={dialog} />
         </TabsList>
         <div className="-mx-1 min-h-0 flex-1 overflow-auto px-1 pb-1">
@@ -172,6 +176,7 @@ function ManageDialogContent({
           </TabsContent>
           <TabsContent value="ssh" className="grid gap-3">
             <SSHAccessSection dialog={dialog} />
+            <WorkspaceSyncSection dialog={dialog} />
             <DiagnosticsSection dialog={dialog} />
           </TabsContent>
           <TabsContent value="history" className="grid gap-3">

--- a/erun-ui/frontend/src/components/app/Sidebar.TenantGroup.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.TenantGroup.tsx
@@ -1,4 +1,4 @@
-import { Folder, FolderOpen, MoreHorizontal } from 'lucide-react';
+import { Folder, FolderOpen, LayoutDashboard, MoreHorizontal } from 'lucide-react';
 import * as React from 'react';
 
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
@@ -117,6 +117,7 @@ function TenantSelectButton({
             dispatch(openTenantDashboard(tenantName));
           }}
         >
+          <LayoutDashboard aria-hidden="true" className="mr-1.5 size-3.5 shrink-0 opacity-70" />
           <span className="truncate">{tenantName}</span>
         </button>
       </TooltipTrigger>

--- a/erun-ui/playwright/pages/ActivityQueueDrawer.ts
+++ b/erun-ui/playwright/pages/ActivityQueueDrawer.ts
@@ -1,7 +1,7 @@
 import type { Locator, Page } from '@playwright/test';
 
 // ActivityQueueDrawer POM. The drawer slides in from the right when its
-// launcher (fixed floating button labelled "Open deploy queue") is clicked.
+// launcher (fixed floating button labelled "Open activities") is clicked.
 export class ActivityQueueDrawer {
   constructor(public readonly page: Page) {}
 
@@ -10,7 +10,7 @@ export class ActivityQueueDrawer {
   }
 
   launcher(): Locator {
-    return this.page.getByRole('button', { name: /^Open deploy queue/ });
+    return this.page.getByRole('button', { name: /^Open activities/ });
   }
 
   closeButton(): Locator {

--- a/erun-ui/playwright/pages/ManageDialog.ts
+++ b/erun-ui/playwright/pages/ManageDialog.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from '@playwright/test';
 
-export type ManageTab = 'General' | 'Runtime' | 'AI' | 'Ports' | 'SSH' | 'History';
+export type ManageTab = 'General' | 'Runtime' | 'AI' | 'Ports' | 'Access' | 'History';
 
 // ManageDialog POM. The dialog title is "<tenant>-<environment>".
 export class ManageDialog {

--- a/erun-ui/playwright/tests/activity-events.spec.ts
+++ b/erun-ui/playwright/tests/activity-events.spec.ts
@@ -26,3 +26,33 @@ test('activity:state events populate the queue drawer', async ({ app }) => {
     app.activityDrawer.locator().getByText('open petios/rihards-review', { exact: false }),
   ).toBeVisible();
 });
+
+// The launcher is named for what the drawer holds (every recovery-relevant
+// action: init/build/release/open/deploy), not for one command among them
+// (#1218 — it was previously labelled "Open deploy queue" with a Rocket icon).
+test('activity launcher is labelled for the drawer it opens, not one command', async ({ app }) => {
+  await expect(app.activityDrawer.launcher()).toHaveAttribute('aria-label', 'Open activities');
+
+  await app.page.evaluate(() => {
+    const ts = new Date().toISOString();
+    (
+      window as unknown as { runtime: { EventsEmit: (n: string, ...a: unknown[]) => void } }
+    ).runtime.EventsEmit('activity:state', {
+      id: 'launcher-label-spec-1',
+      command: 'init',
+      tenant: 'launcher-label-spec',
+      environment: 'env-a',
+      status: 'running',
+      startedAt: ts,
+      lastUpdated: ts,
+      source: 'action',
+      actionKind: 'init',
+      summary: 'init launcher-label-spec/env-a',
+    });
+  });
+
+  await expect(app.activityDrawer.launcher()).toHaveAttribute(
+    'aria-label',
+    'Open activities (1 active)',
+  );
+});

--- a/erun-ui/playwright/tests/manage-container-registries.spec.ts
+++ b/erun-ui/playwright/tests/manage-container-registries.spec.ts
@@ -12,6 +12,11 @@ test.describe('manage dialog container registries', () => {
     await expect(app.manageDialog.registryRoleCheckbox(0, 'deploy')).toBeChecked();
     await expect(app.manageDialog.registryRoleCheckbox(0, 'from')).not.toBeChecked();
 
+    // The role meaning (e.g. "erun build/push target") rides the IconTooltip
+    // primitive, not a native `title` (AGENTS.md bans `title` for meaningful UI).
+    const buildRoleLabel = app.manageDialog.registryRoleCheckbox(0, 'build').locator('xpath=..');
+    await expect(buildRoleLabel).not.toHaveAttribute('title', /.*/);
+
     // A new row defaults to build+deploy, so a second registry with a host makes two build-marked registries — invalid.
     await app.manageDialog.addRegistryButton().click();
     await app.manageDialog.registryInput(1).fill('registry.internal/pw');

--- a/erun-ui/playwright/tests/manage.spec.ts
+++ b/erun-ui/playwright/tests/manage.spec.ts
@@ -7,11 +7,52 @@ test.describe('manage dialog', () => {
     await app.sidebar.openManageDialogFor(SEED_TENANT, SEED_ENV_ALPHA);
     await app.manageDialog.waitForOpen();
 
-    const tabs: ManageTab[] = ['General', 'Runtime', 'AI', 'Ports', 'SSH'];
+    const tabs: ManageTab[] = ['General', 'Runtime', 'AI', 'Ports', 'Access'];
     for (const tab of tabs) {
       await app.manageDialog.selectTab(tab);
       await expect.poll(() => app.manageDialog.getActiveTab()).toBe(tab);
     }
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+
+  // The Ports tab's Service column names the user-facing purpose of each
+  // port, not the internal protocol/service key (#1218).
+  test('Ports tab labels services by purpose, not internal name', async ({ app }) => {
+    await app.sidebar.openManageDialogFor(SEED_TENANT, SEED_ENV_ALPHA);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('Ports');
+
+    const dialog = app.manageDialog.locator();
+    await expect(dialog.getByText('AI agent connection', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('Environment API', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('Contribute app preview', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('mcp', { exact: true })).toHaveCount(0);
+    await expect(dialog.getByText('contribute-app', { exact: true })).toHaveCount(0);
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+
+  // Workspace sync is a distinct concept from SSH shell access (#1218): it
+  // gets its own titled section on the Access tab instead of hiding as an
+  // unlabeled checkbox nested inside "SSH access".
+  test('Access tab separates SSH access from workspace sync', async ({ app }) => {
+    await app.sidebar.openManageDialogFor(SEED_TENANT, SEED_ENV_ALPHA);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('Access');
+
+    const dialog = app.manageDialog.locator();
+    await expect(dialog.getByText('SSH access', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('Workspace sync', { exact: true })).toBeVisible();
+
+    const syncCheckbox = dialog.getByRole('checkbox', { name: 'Enable workspace sync' });
+    await expect(syncCheckbox).toBeVisible();
+    // The seeded env has SSHD disabled, so workspace sync stays disabled and
+    // explains why rather than leaving the user to guess.
+    await expect(syncCheckbox).toBeDisabled();
+    await expect(dialog.getByText('Requires SSH access to be enabled.')).toBeVisible();
 
     await app.manageDialog.cancel();
     await app.manageDialog.waitForClosed();

--- a/erun-ui/playwright/tests/sidebar.spec.ts
+++ b/erun-ui/playwright/tests/sidebar.spec.ts
@@ -11,6 +11,15 @@ test.describe('sidebar', () => {
     await app.sidebar.toggleTenant(SEED_TENANT);
   });
 
+  // The tenant row's only prior affordance was the folder-group header
+  // (#1218): nothing indicated the name itself opens a dashboard. It now
+  // carries a visible icon alongside the name.
+  test('tenant row carries a visible affordance for opening the dashboard', async ({ app }) => {
+    const icon = app.sidebar.tenantDashboardButton(SEED_TENANT).locator('svg');
+    await expect(icon).toBeVisible();
+    await expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+
   test('opening an environment surfaces status feedback', async ({ app, page }) => {
     // The opening status is inherently transient — it lives only for the open
     // itself (a few hundred ms): the titlebar "Opening …" message clears the


### PR DESCRIPTION
## What this fixes from #1218

Issue #1218 bundles four largely independent problems. I verified each claim against current source before fixing it — all of them held up, they were not fictional premises. This PR lands the first bucket in full ("mostly rename and relabel", the issue's own words) plus one precisely-diagnosed elapsed-timer bug, and explicitly defers the other three (see below).

**Fixed and tested in this PR:**

1. **Activity launcher naming.** `ActivityQueueLauncher.tsx` was labelled `aria-label="Open deploy queue"`, tooltip `"Deploys"`, with a `<Rocket>` icon — but the drawer it opens (`aria-label="Activity queue"`, `<h2>Activities</h2>`) holds init/build/release/open failures and every recovery action, and `erun-docs/docs/desktop/overview.md:13` already calls it the "Activities panel". Renamed the launcher's aria-label to `"Open activities"`, tooltip to `"Activities"`, icon to `ListChecks`. Updated the Playwright POM regex that pinned the old string.
2. **Workspace sync relabeled off the SSH tab.** It was an unlabeled checkbox nested inside a box titled "SSH access", gated behind "Enable SSHD" with no separate identity. It now gets its own titled "Workspace sync" section (still on the same tab, since it does require SSH access functionally — the CheckboxField's disabled state now says why), and the tab itself is renamed from "SSH" to "Access" since it covers both concepts.
3. **Ports tab Service column relabeled by purpose.** `mcp`/`api`/`ssh`/`contribute-app` were the literal internal port keys shown as the primary label. Now shows "AI agent connection" / "Environment API" / "SSH access" / "Contribute app preview" (looked up each port's actual purpose in `erun-common/ports.go` and its callers before choosing wording).
4. **Tenant row visible affordance.** The tenant row's name button opens a full dashboard on click but carried no icon or visual cue that it was interactive — added a `LayoutDashboard` icon.
5. **Container registry role hint moved off `title`.** `ContainerRegistriesField.tsx`'s per-role checkbox label used a native `title` attribute for the role meaning, the exact pattern `erun-ui/AGENTS.md` bans for meaningful product UI. Moved to the existing `IconTooltip` primitive.
6. **Activity elapsed-timer bug (issue section 4).** `activityElapsedLabel` anchored a *running* entry's elapsed time on `entry.startedAt` (stamped at enqueue time), not `entry.startedRunningAt` (stamped when it actually left the queue) — so a card that waited before running showed elapsed time inflated by its queue wait. Fixed to prefer `startedRunningAt` for running entries; `waiting` entries still anchor on `enqueuedAt` as before. I stashed the fix, watched the new test fail (`0s` off by the simulated 6m40s queue wait), then unstashed.

**Playwright coverage:** extended `activity-events.spec.ts`, `sidebar.spec.ts`, `manage.spec.ts`, `manage-container-registries.spec.ts`; updated `pages/ActivityQueueDrawer.ts` and `pages/ManageDialog.ts` POMs for the renamed labels. Added a new unit test file for the elapsed-timer fix. All specs I touched pass individually; `go test ./...` (normal PATH and stripped PATH), `golangci-lint run ./...` for `erun-ui`, and `yarn typecheck`/`lint`/`format:check` + the full frontend unit suite for the frontend all pass.

## What I left out, and why

Issue #1218 also calls for three more substantial, independent features that I did not attempt in this PR, to avoid shipping shallow, undertested versions of each:

- **Section 2 — expose/unexpose desktop surface.** The CLI/MCP already have `expose`/`unexpose`, but the desktop has zero matching concept (no component renders a service address anywhere). This needs new backend wiring, a new dialog/rendering surface, and Playwright coverage — a full net-new feature, not a relabel.
- **Section 3 (partial) — idle polling scoped to every running environment, and lease visibility/release.** I confirmed both gaps are real: `idleThunks.ts` polls only `state.selection.selected` into a single nullable slot (no per-env map), and `uiIdleStatus` never carries `Leases` (only an opaque "lease" marker with no name/pid/holder/expiry, no release action). Backend data and CLI/MCP release functions already exist and are reusable, but wiring this into the desktop requires a new Wails method, a store shape change from single-slot to per-env map, and new sidebar-wide UI for showing another environment's pending stop — a genuine architecture change, not a bounded fix.
- **Section 4 (partial) — phase field fed by CLI trace lines, and OS-level notifications.** `activityQueueEntry` has no phase field and the store's own comment says "No generic update-fields method exists" by design; adding one, threading new `==> ...` trace lines through `erun-common`/`erun-cli`, and wiring a cross-platform OS notification (nothing in the repo calls `beeep`/`osascript`/`go-toast`/`Notification()` today, though `go-toast` already rides in as an indirect Wails dependency) is a multi-part feature in its own right.

Happy to pick any of these up as a follow-on if that's preferred over closing the issue here.

Closes #1218