### PR TITLE
Stop the orchestrator background-shell indicator from staying lit after the shell ends

### DIFF
--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -790,9 +790,13 @@ func orchestratorSessionStartHook(dir string) []any {
 	// Resetting it here to whatever id this launch actually starts with is what
 	// keeps a stale record from outliving the run that wrote it.
 	liveSession := map[string]any{"type": "command", "command": orchestratorSessionRecordHookCommand()}
+	// A background shell report has the exact same hazard: a shell the previous
+	// run started (or its clear) can outlive that run entirely, and nothing else
+	// resets it at a boundary — see orchestrator_shell_activity.go.
+	shellIdle := map[string]any{"type": "command", "command": orchestratorShellActivityResetHookCommand()}
 	return []any{map[string]any{
 		"matcher": orchestratorSessionStartMatcher,
-		"hooks":   []any{command, idle, liveSession},
+		"hooks":   []any{command, idle, liveSession, shellIdle},
 	}}
 }
 

--- a/erun-ui/orchestrator_shell_activity.go
+++ b/erun-ui/orchestrator_shell_activity.go
@@ -40,7 +40,14 @@ type orchestratorShellActivity struct {
 	Running bool   `json:"running"`
 	Command string `json:"command,omitempty"`
 	TaskID  string `json:"taskId,omitempty"`
-	AtUnix  int64  `json:"atUnix"`
+	// SessionID is the id of the session that wrote this report (the hook's own
+	// stdin session_id, the same field orchestratorSessionRecordHookCommand
+	// reads). An orchestrator id is reused across restarts, so this is what lets
+	// a later read tell a report apart from one a since-replaced session left
+	// behind, instead of trusting "running" from whichever session happens to be
+	// live for the id now.
+	SessionID string `json:"sessionId,omitempty"`
+	AtUnix    int64  `json:"atUnix"`
 }
 
 // orchestratorShellActivitySafetyBound is the outer bound on a "running"
@@ -81,7 +88,21 @@ func orchestratorShellActivityPath(id string) string {
 // staleness bound: a report from a session the desktop can no longer see ages
 // out on the short, shared bound, because nothing will ever explicitly clear
 // it for a session that is gone.
-func readOrchestratorShellActivity(id string, now time.Time, sessionAlive bool) (orchestratorShellActivity, bool) {
+//
+// An orchestrator id is reused by design on every restart, and sessionAlive is
+// computed per id — from whichever session is live for that id right now —
+// not per the session that actually wrote this report. So a "running" report
+// left behind by a session that has since been replaced would otherwise be
+// protected by its successor's liveness and get the generous bound forever,
+// which is #1274. liveSessionID is the id the desktop currently has recorded
+// as live for this orchestrator; a report naming a different one names a
+// session that is no longer live for real, and is rejected regardless of the
+// staleness bound. Neither an empty report session id (an older write, or a
+// clear which never carries one) nor an empty liveSessionID (no live-session
+// record yet) is treated as a mismatch — there is nothing to compare, and
+// rejecting on that basis alone would make every report unusable before the
+// live-session recorder has ever fired.
+func readOrchestratorShellActivity(id string, now time.Time, sessionAlive bool, liveSessionID string) (orchestratorShellActivity, bool) {
 	path := orchestratorShellActivityPath(id)
 	if path == "" {
 		return orchestratorShellActivity{}, false
@@ -94,6 +115,9 @@ func readOrchestratorShellActivity(id string, now time.Time, sessionAlive bool) 
 	if err := json.Unmarshal(data, &activity); err != nil {
 		return orchestratorShellActivity{}, false
 	}
+	if activity.Running && shellActivityNamesAReplacedSession(activity.SessionID, liveSessionID) {
+		return orchestratorShellActivity{}, false
+	}
 	bound := orchestratorActivityTTL
 	if sessionAlive {
 		bound = orchestratorShellActivitySafetyBound
@@ -102,6 +126,15 @@ func readOrchestratorShellActivity(id string, now time.Time, sessionAlive bool) 
 		return orchestratorShellActivity{}, false
 	}
 	return activity, true
+}
+
+// shellActivityNamesAReplacedSession reports whether a report's own session id
+// names a session other than the one currently recorded as live. Either side
+// being empty means there is nothing to compare, not a mismatch: an older
+// report never carried a session id at all, and a fresh orchestrator has no
+// live-session record until its recorder hook first fires.
+func shellActivityNamesAReplacedSession(reportSessionID, liveSessionID string) bool {
+	return reportSessionID != "" && liveSessionID != "" && reportSessionID != liveSessionID
 }
 
 // orchestratorShellActivityFileVar is both the environment variable the hook
@@ -141,17 +174,20 @@ func isOrchestratorShellActivityHookBlock(block any) bool {
 
 // orchestratorShellActivityStartHookCommand recognizes a Bash call that
 // backgrounded a shell (tool_response.backgroundTaskId) and records it as
-// running, with the command it is running and the task id later needed to
-// clear it. Any other Bash call — foreground, or one that never backgrounds —
-// leaves the previous report untouched: a foreground command says nothing
-// about whatever shell is already running.
+// running, with the command it is running, the task id later needed to clear
+// it, and the id of the session that started it (session_id, the same
+// top-level hook stdin field orchestratorSessionRecordHookCommand reads) —
+// what later lets a stale report be told apart from one whose session is
+// still live. Any other Bash call — foreground, or one that never
+// backgrounds — leaves the previous report untouched: a foreground command
+// says nothing about whatever shell is already running.
 func orchestratorShellActivityStartHookCommand() string {
 	dir := filepath.ToSlash(orchestratorShellActivityDir())
 	script := `let d="";process.stdin.on("data",c=>{d+=c});process.stdin.on("end",()=>{try{` +
 		`const j=JSON.parse(d);` +
 		`const id=j.tool_response&&j.tool_response.backgroundTaskId;` +
 		`if(!id)return;` +
-		`const out={running:true,command:(j.tool_input&&j.tool_input.command)||"",taskId:id,atUnix:Math.floor(Date.now()/1000)};` +
+		`const out={running:true,command:(j.tool_input&&j.tool_input.command)||"",taskId:id,sessionId:j.session_id||"",atUnix:Math.floor(Date.now()/1000)};` +
 		`require("fs").writeFileSync(process.env.` + orchestratorShellActivityFileVar + `,JSON.stringify(out));` +
 		`}catch(e){}});`
 	return `[ -n "$ERUN_ORCHESTRATOR_ID" ] && mkdir -p "` + dir + `" && ` +
@@ -178,6 +214,21 @@ func orchestratorShellActivityClearHookCommand() string {
 		`}catch(e){}});`
 	return `[ -n "$ERUN_ORCHESTRATOR_ID" ] && mkdir -p "` + dir + `" && ` +
 		orchestratorShellActivityFileVar + `="` + dir + `/$ERUN_ORCHESTRATOR_ID.json" node -e '` + script + `' || true`
+}
+
+// orchestratorShellActivityResetHookCommand clears an inherited "running"
+// report at a session boundary, the same reason orchestratorActivityHookCommand
+// (false) clears the busy report there: an orchestrator id is mutable and
+// reusable, so a report a previous run under this id left behind — including
+// one whose shell finished without either hook ever observing it — must not
+// survive into a session that has not started any shell of its own yet. A
+// bare printf, like the busy report's reset, since there is nothing to parse:
+// it always writes the same fixed shape.
+func orchestratorShellActivityResetHookCommand() string {
+	dir := filepath.ToSlash(orchestratorShellActivityDir())
+	return `[ -n "$ERUN_ORCHESTRATOR_ID" ] && mkdir -p "` + dir + `" && ` +
+		`printf '{"running":false,"atUnix":%s}' "$(date +%s)" > "` + dir + `/$ERUN_ORCHESTRATOR_ID.json"` +
+		` || true`
 }
 
 // orchestratorShellActivityHookBlocks are the two PostToolUse-only hooks the

--- a/erun-ui/orchestrator_shell_activity_test.go
+++ b/erun-ui/orchestrator_shell_activity_test.go
@@ -32,20 +32,20 @@ func TestOrchestratorShellActivityIsReadFromTheReportNotTheTerminal(t *testing.T
 	t.Setenv("HOME", t.TempDir())
 	now := time.Now()
 
-	if _, ok := readOrchestratorShellActivity("erun", now, true); ok {
+	if _, ok := readOrchestratorShellActivity("erun", now, true, ""); ok {
 		t.Fatal("an orchestrator that has reported nothing has no running shell")
 	}
 
 	writeOrchestratorShellActivity(t, "erun", orchestratorShellActivity{
 		Running: true, Command: "sleep 300", TaskID: "task-1", AtUnix: now.Unix(),
 	})
-	activity, ok := readOrchestratorShellActivity("erun", now, true)
+	activity, ok := readOrchestratorShellActivity("erun", now, true, "")
 	if !ok || !activity.Running || activity.Command != "sleep 300" {
 		t.Fatalf("a fresh running report must be believed, got %+v %v", activity, ok)
 	}
 
 	writeOrchestratorShellActivity(t, "erun", orchestratorShellActivity{Running: false, AtUnix: now.Unix()})
-	activity, ok = readOrchestratorShellActivity("erun", now, true)
+	activity, ok = readOrchestratorShellActivity("erun", now, true, "")
 	if !ok || activity.Running {
 		t.Fatalf("the clear report must read as not running, got %+v %v", activity, ok)
 	}
@@ -65,14 +65,14 @@ func TestOrchestratorShellActivitySurvivesALongRunButStillBounds(t *testing.T) {
 	writeOrchestratorShellActivity(t, "erun", orchestratorShellActivity{
 		Running: true, TaskID: "task-1", AtUnix: now.Add(-orchestratorActivityTTL - 5*time.Minute).Unix(),
 	})
-	if activity, ok := readOrchestratorShellActivity("erun", now, true); !ok || !activity.Running {
+	if activity, ok := readOrchestratorShellActivity("erun", now, true, ""); !ok || !activity.Running {
 		t.Fatalf("a live session's shell may run well past the short bound, got %+v %v", activity, ok)
 	}
 
 	writeOrchestratorShellActivity(t, "erun", orchestratorShellActivity{
 		Running: true, TaskID: "task-1", AtUnix: now.Add(-orchestratorShellActivitySafetyBound - time.Minute).Unix(),
 	})
-	if _, ok := readOrchestratorShellActivity("erun", now, true); ok {
+	if _, ok := readOrchestratorShellActivity("erun", now, true, ""); ok {
 		t.Fatal("a report nothing has renewed for hours must still age out eventually")
 	}
 }
@@ -88,7 +88,7 @@ func TestOrchestratorShellActivityExpiresQuicklyForADeadSession(t *testing.T) {
 	writeOrchestratorShellActivity(t, "erun", orchestratorShellActivity{
 		Running: true, TaskID: "task-1", AtUnix: now.Add(-orchestratorActivityTTL - time.Minute).Unix(),
 	})
-	if _, ok := readOrchestratorShellActivity("erun", now, false); ok {
+	if _, ok := readOrchestratorShellActivity("erun", now, false, ""); ok {
 		t.Fatal("a report from a session we can no longer see must not keep the indicator spinning")
 	}
 }
@@ -107,11 +107,56 @@ func TestOrchestratorShellActivityTreatsUnreadableInputAsNotRunning(t *testing.T
 	if err := os.WriteFile(path, []byte("not json"), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	if _, ok := readOrchestratorShellActivity("erun", now, true); ok {
+	if _, ok := readOrchestratorShellActivity("erun", now, true, ""); ok {
 		t.Fatal("unparseable input must not read as running")
 	}
-	if _, ok := readOrchestratorShellActivity("  ", now, true); ok {
+	if _, ok := readOrchestratorShellActivity("  ", now, true, ""); ok {
 		t.Fatal("an orchestrator with no id has no report")
+	}
+}
+
+// The defect in #1274: an orchestrator id is reused across restarts, and a
+// report a since-replaced session left behind must not borrow the id's
+// current liveness. Requiring the report's own session id to match the one
+// the desktop currently has recorded as live is what stops that borrowing —
+// independent of, and in addition to, the SessionStart reset that clears the
+// report at the boundary itself.
+func TestOrchestratorShellActivityRejectsAReportFromAReplacedSession(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	now := time.Now()
+
+	writeOrchestratorShellActivity(t, "erun", orchestratorShellActivity{
+		Running: true, Command: "sleep 300", TaskID: "task-1", SessionID: "old-session", AtUnix: now.Unix(),
+	})
+
+	if _, ok := readOrchestratorShellActivity("erun", now, true, "new-session"); ok {
+		t.Fatal("a report naming a session that is no longer live must not be honoured")
+	}
+
+	activity, ok := readOrchestratorShellActivity("erun", now, true, "old-session")
+	if !ok || !activity.Running {
+		t.Fatalf("a report naming the current live session must still be honoured, got %+v %v", activity, ok)
+	}
+}
+
+// A report with no session id (an older write, or a hook stdin that carried
+// none) and a desktop with no live-session record yet must not be rejected
+// just because there is nothing to compare — that would make every report
+// unusable before the live-session recorder has ever fired.
+func TestOrchestratorShellActivityHonoursAReportWithNoSessionIDToCompare(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	now := time.Now()
+
+	writeOrchestratorShellActivity(t, "erun", orchestratorShellActivity{
+		Running: true, TaskID: "task-1", AtUnix: now.Unix(),
+	})
+	if _, ok := readOrchestratorShellActivity("erun", now, true, "new-session"); !ok {
+		t.Fatal("a report with no recorded session id must not be rejected on that basis alone")
+	}
+	if _, ok := readOrchestratorShellActivity("erun", now, true, ""); !ok {
+		t.Fatal("no live-session record at all must not be treated as a mismatch")
 	}
 }
 
@@ -206,4 +251,25 @@ func eventCarriesShellActivityReport(blocks []any) bool {
 		}
 	}
 	return false
+}
+
+// SessionStart clears an inherited "running" shell report, the same way it
+// already clears the busy report: an orchestrator id is mutable and reusable,
+// so a report a previous run under this id left behind must not survive into
+// a new one that hasn't started any shell of its own yet.
+func TestOrchestratorShellActivityClearsAnInheritedRunningReportOnSessionStart(t *testing.T) {
+	hooks, data := orchestratorSettingsHooks(t)
+
+	if !eventRunsCommand(hooks["SessionStart"], orchestratorShellActivityResetHookCommand()) {
+		t.Fatalf("SessionStart must clear an inherited running shell report:\n%s", data)
+	}
+}
+
+// The start hook must capture the writing session's own id, not just the
+// task id and command, so a later read can tell a report apart from one a
+// since-replaced session left behind.
+func TestOrchestratorShellActivityStartHookCapturesTheSessionID(t *testing.T) {
+	if !strings.Contains(orchestratorShellActivityStartHookCommand(), "session_id") {
+		t.Fatalf("the start hook must record the writing session's id: %q", orchestratorShellActivityStartHookCommand())
+	}
 }

--- a/erun-ui/session_heartbeat.go
+++ b/erun-ui/session_heartbeat.go
@@ -126,7 +126,14 @@ func (a *App) reconcileOrchestratorActivity() {
 		// state — it can keep running after the turn that started it ends — so
 		// it gets the same re-emit-every-tick treatment on its own, not folded
 		// into the busy report above.
-		shell, shellOK := readOrchestratorShellActivity(r.id, now, r.alive)
+		//
+		// The report has to name the session that wrote it and be checked against
+		// whichever session is currently live for this id: sessionAlive alone is
+		// computed per orchestrator id, not per session, so a report a replaced
+		// session left behind would otherwise borrow its successor's liveness
+		// (#1274).
+		liveSessionID, _ := readOrchestratorLiveSessionID(r.id)
+		shell, shellOK := readOrchestratorShellActivity(r.id, now, r.alive, liveSessionID)
 		shellRunning := shellOK && shell.Running
 		a.mu.Lock()
 		if session := a.orchestrators[r.id]; session != nil {

--- a/erun-ui/session_heartbeat_test.go
+++ b/erun-ui/session_heartbeat_test.go
@@ -336,6 +336,42 @@ func TestOrchestratorShellSnapshotRendersRunningWithoutTheEvent(t *testing.T) {
 	}
 }
 
+// TestOrchestratorShellActivityDoesNotBorrowASuccessorSessionsLiveness is the
+// #1274 regression: an orchestrator id is reused across restarts, so
+// sessionAlive alone (computed per id, from whichever session is live for
+// that id right now) is not enough to trust a "running" report — the report
+// itself has to name the session that wrote it, and that name has to match
+// the session the desktop currently has recorded as live for this id.
+// Without that check, a report a dead session left behind reads as running
+// for as long as ITS SUCCESSOR keeps the id alive, which in practice is
+// indefinitely.
+func TestOrchestratorShellActivityDoesNotBorrowASuccessorSessionsLiveness(t *testing.T) {
+	app := orchestratorTestApp(t)
+	defer app.shutdown(context.Background())
+
+	created, err := app.CreateOrchestrator("agent", []orchestratorEnvInput{{Tenant: "frs", Environment: "dev"}})
+	if err != nil {
+		t.Fatalf("CreateOrchestrator failed: %v", err)
+	}
+	if _, err := app.StartOrchestrator(created.ID, 80, 24); err != nil {
+		t.Fatalf("StartOrchestrator failed: %v", err)
+	}
+
+	// The session that started the shell has since been replaced: the
+	// recorded live session is a different id from the one the report names.
+	writeOrchestratorShellActivity(t, created.ID, orchestratorShellActivity{
+		Running: true, Command: "sleep 300", TaskID: "task-1", SessionID: "dead-session", AtUnix: time.Now().Unix(),
+	})
+	stageOrchestratorLiveSession(t, created.ID, "current-session")
+
+	app.reconcileOrchestratorActivity()
+
+	listed := app.ListOrchestrators()
+	if len(listed) != 1 || listed[0].ShellRunning {
+		t.Fatalf("a report from a replaced session must not keep the indicator lit, got %+v", listed)
+	}
+}
+
 // TestReconcileOrchestratorActivityReEmitsShellStateEveryTick is the shell-report
 // half of the busy-signal re-emit lock: the shell signal is republished every
 // tick regardless of whether it changed, so a dropped or mistimed


### PR DESCRIPTION
## What was wrong

The issue's premise checked out against `erun-ui/orchestrator_shell_activity.go` and `erun-ui/session_heartbeat.go` on `main`:

1. `orchestratorShellActivityClearHookCommand` only fires on `TaskOutput|TaskStop`, but a background shell that finishes on its own is delivered to the agent as a task notification — nothing requires it to call `TaskOutput`/`TaskStop` afterwards, so the ordinary completion path clears nothing.
2. `readOrchestratorShellActivity`'s 6-hour safety bound is selected by `sessionAlive`, which `reconcileOrchestratorActivity` computes **per orchestrator id** (`managed != nil && !managed.closed`), not per the session that wrote the report. Since an orchestrator id is reused across restarts, a "running" report left behind by a session that has since been replaced gets protected by its successor's liveness and never ages out on the short bound.

## The fix

Cheapest correct combination, as the issue's "Fix shape" suggested:

- `orchestratorSessionStartHook` (`erun-ui/orchestrator.go`) now also resets the shell-activity report at every session boundary (`startup`/`resume`/`clear`/`compact`), the same way it already resets the busy report and the live-session id. A new `orchestratorShellActivityResetHookCommand()` writes `{"running":false,...}`, mirroring `orchestratorActivityHookCommand(false)`.
- The start hook now stamps the writing session's own `session_id` (the same top-level hook-stdin field `orchestratorSessionRecordHookCommand` already reads) into the report as `SessionID`.
- `readOrchestratorShellActivity` gained a `liveSessionID` parameter and rejects a `running:true` report whose `SessionID` names a session other than the one currently recorded as live for that orchestrator id (`shellActivityNamesAReplacedSession`) — so a report can no longer borrow its successor's liveness. Either side being empty (an older report with no session id, or no live-session record yet) is not treated as a mismatch, since there's nothing to compare.
- `reconcileOrchestratorActivity` (`erun-ui/session_heartbeat.go`) now reads the current live-session id via `readOrchestratorLiveSessionID` and threads it through.

I did not implement the issue's *optional* suggestion (clearing on the completion signal itself) — the reset-on-boundary + session-id-match combination is self-expiring by design (a TTL comparison, not a delivery-dependent event), matching the steering note to prefer that shape.

## Testing

New/updated tests in `orchestrator_shell_activity_test.go` and `session_heartbeat_test.go`:

- `TestOrchestratorShellActivityRejectsAReportFromAReplacedSession` / `TestOrchestratorShellActivityHonoursAReportWithNoSessionIDToCompare` — unit-level session-id matching.
- `TestOrchestratorShellActivityClearsAnInheritedRunningReportOnSessionStart` / `TestOrchestratorShellActivityStartHookCapturesTheSessionID` — hook wiring.
- `TestOrchestratorShellActivityDoesNotBorrowASuccessorSessionsLiveness` — end-to-end through `App.reconcileOrchestratorActivity()`/`ListOrchestrators()`, reproducing the exact #1274 scenario (a dead session's report, a different live session recorded for the same id).

I proved these fail without the fix: `git stash push` on the three implementation files (with the test files kept), then `go vet ./...` — the new tests reference the new `orchestratorShellActivity.SessionID` field, the new `readOrchestratorShellActivity` parameter, and `orchestratorShellActivityResetHookCommand`, none of which exist pre-fix, so the module fails to compile. Restored via `git stash pop` and all tests pass.

Gates run in `erun-ui`: `go test ./...` (normal `PATH` and stripped `PATH=/usr/local/go/bin:/usr/bin:/bin`) and `golangci-lint run ./...` are all green.

## UX Impact Review Checklist

1. **Affected paths:** sidebar orchestrator row → background-shell indicator (chip), sourced from the `orchestrator-shell-activity` report file via `App.reconcileOrchestratorActivity` → `orchestratorShellEvent` / `ListOrchestrators().ShellRunning`.
2. **User-visible sequence:** unchanged. The indicator still lights while a background shell runs and unlights on its own report clearing; this fix only corrects *when* it goes dark — promptly instead of up to 6 hours late, and never past a session boundary under a reused orchestrator id.
3. **State-without-affordance:** N/A — no new state introduced.
4. **Visibility of system status (Nielsen #1):** this *is* the fix — the indicator now matches real system state instead of lagging it by hours.
5. **Success/failure feedback:** N/A, no user-triggered operation.
6. **Consistency with comparable flows:** matches the existing busy-report and live-session-id reset pattern at `SessionStart` (`orchestrator_activity.go`, `orchestrator_live_session.go`).
7. **Heuristic pass:** Nielsen #1 (visibility of system status) is the only heuristic in play here, and it now passes; the rest are not applicable to this backend-only correctness fix.
8. **Playwright coverage:** the frontend rendering contract (`ShellRunning`/`ShellCommand` → indicator visibility) is already covered by `erun-ui/playwright/tests/sidebar-orchestrator-shell-activity-snapshot.spec.ts`, which explicitly documents deferring the backend re-emit timing and event path to the Go tests in `session_heartbeat_test.go` because the headless harness cannot wait out a real 15s poll or simulate hook-driven staleness deterministically. This PR's defect and fix live entirely in that Go-side logic (hook file writes, session-id comparison, SessionStart reset) — genuinely unreachable by the harness (no real Claude Code hooks, no orchestrator-id reuse across process restarts) — so it is covered by the new Go tests listed above instead, per the pattern already used for #331.

Docs: this is a bug fix restoring intended behavior (the indicator was always meant to reflect a real running shell), not a feature or public-surface change, so no `erun-docs` update is needed.