### PR TITLE
Point the doctor spec at the renamed Access tab so main type-checks again

### DIFF
--- a/erun-ui/playwright/tests/sidebar-run-doctor.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-run-doctor.spec.ts
@@ -67,14 +67,14 @@ test.describe('sidebar Run Doctor reachability (#1217)', () => {
   // replaces both with the `doctor-completed` Wails event; this drives that
   // event the way the CLI's `==> Doctor done` / `==> Doctor failed` trace
   // lines do (see handleDoctorTraceLine in erun-ui/activity_queue_app.go).
-  test('records the last-run outcome the Manage dialog SSH tab renders', async ({
+  test('records the last-run outcome the Manage dialog Access tab renders', async ({
     app,
     page,
     seededEnv,
   }) => {
     await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
     await app.manageDialog.waitForOpen();
-    await app.manageDialog.tab('SSH').click();
+    await app.manageDialog.tab('Access').click();
 
     const lastRun = page.getByRole('status').filter({ hasText: 'all checks passed' });
     const lastRunFailed = page.getByRole('alert').filter({ hasText: 'kubectl not reachable' });


### PR DESCRIPTION
`main` is red. The Playwright package's typecheck fails:

```
tests/sidebar-run-doctor.spec.ts(77,32): error TS2345:
Argument of type '"SSH"' is not assignable to parameter of type 'ManageTab'
```

`run.sh` does typecheck + lint + format:check before any spec, so this blocks
**every** environment's Playwright run, not just this file.

## Cause

#1268 added this spec calling `manageDialog.tab('SSH')`. #1281 then relabelled
that tab from "SSH" to "Access" (`value="ssh" label="Access"`) and updated the
page object's label union to match. **Both PRs were green on their own** — the
break exists only in their combination. That is the second time today `main` broke
from two independently-green PRs interacting, after #1282.

## Why not lowercase it

Worth stating, because `'ssh'` is the obvious-looking fix and it is wrong twice:

- The page object's `ManageTab` is a **label** union
  (`'General' | 'Runtime' | 'AI' | 'Ports' | 'Access' | 'History'`), not the
  frontend's **id** union in `types.ts`
  (`'general' | … | 'ssh' | …`). `'ssh'` is not in it either, so it would not
  compile.
- Even if it did, `tab()` builds `new RegExp('^' + name + '(,|$)')` against the
  tab's *accessible name*. `^ssh(,|$)` would never match the rendered "Access" —
  a green build with a dead assertion.

## Verification

- playwright `tsc --noEmit` — clean
- `sidebar-run-doctor.spec.ts` — **3 passed**, including the renamed
  "records the last-run outcome the Manage dialog Access tab renders"

Running the spec is the part that matters here: it proves the locator resolves at
runtime, not just that the types line up.