### PR TITLE
Make the diff panel, terminal, and activity drawer keyboard/screen-reader accessible

### DIFF
--- a/erun-kit/harness/Harness.tsx
+++ b/erun-kit/harness/Harness.tsx
@@ -193,6 +193,8 @@ function MiscSection() {
           label="Resize"
           className="absolute inset-y-0 right-0 w-1 cursor-col-resize bg-border"
           onMouseDown={() => undefined}
+          value={{ now: 24, min: 0, max: 96 }}
+          onStep={() => undefined}
         />
       </div>
       <ErrorBoundaryDemo />

--- a/erun-kit/src/components/ResizeHandle.tsx
+++ b/erun-kit/src/components/ResizeHandle.tsx
@@ -2,28 +2,71 @@ import * as React from 'react';
 
 import { cn } from '../lib/utils';
 
+export const RESIZE_STEP = 16;
+export const RESIZE_STEP_LARGE = 64;
+
+interface ResizeHandleValue {
+  now: number;
+  min: number;
+  max: number;
+}
+
 interface ResizeHandleProps {
   className?: string;
   orientation: 'vertical' | 'horizontal';
   label: string;
   hidden?: boolean;
-  onMouseDown: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onMouseDown: (event: React.MouseEvent<HTMLDivElement>) => void;
+  value: ResizeHandleValue;
+  onStep: (delta: number) => void;
 }
 
+// role="slider" (rather than the visually-closer "separator") is what lets
+// this carry aria-valuenow/min/max/orientation and mouse+keyboard handlers on
+// a plain element without a native form control -- a resize handle is, after
+// all, a one-dimensional control over a pixel value with a min and a max. A
+// vertical handle is a vertical divider line: it separates panes side-by-side,
+// so its keyboard axis is left/right. A horizontal handle stacks panes
+// top/bottom, so its axis is up/down. In both cases the "positive" arrow
+// (Right/Down) increases the value this handle reports.
 export function ResizeHandle({
   className,
   orientation,
   label,
   hidden,
   onMouseDown,
+  value,
+  onStep,
 }: ResizeHandleProps): React.ReactElement {
+  const increaseKey = orientation === 'vertical' ? 'ArrowRight' : 'ArrowDown';
+  const decreaseKey = orientation === 'vertical' ? 'ArrowLeft' : 'ArrowUp';
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    const step = event.shiftKey ? RESIZE_STEP_LARGE : RESIZE_STEP;
+    if (event.key === increaseKey) {
+      event.preventDefault();
+      onStep(step);
+    } else if (event.key === decreaseKey) {
+      event.preventDefault();
+      onStep(-step);
+    }
+  };
   return (
-    <button
-      type="button"
-      className={cn(className, hidden && 'pointer-events-none hidden')}
+    <div
+      role="slider"
+      tabIndex={0}
+      aria-orientation={orientation}
+      aria-valuenow={Math.round(value.now)}
+      aria-valuemin={Math.round(value.min)}
+      aria-valuemax={Math.round(value.max)}
+      className={cn(
+        className,
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+        hidden && 'pointer-events-none hidden',
+      )}
       aria-label={label}
       data-orientation={orientation}
       onMouseDown={onMouseDown}
+      onKeyDown={handleKeyDown}
     />
   );
 }

--- a/erun-kit/src/styles/theme.css
+++ b/erun-kit/src/styles/theme.css
@@ -72,7 +72,7 @@
   --destructive-foreground: oklch(1 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --ring: oklch(0.6 0 0);
   --chart-1: oklch(0.81 0.1 252);
   --chart-2: oklch(0.62 0.19 260);
   --chart-3: oklch(0.55 0.22 263);
@@ -86,7 +86,7 @@
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar-ring: oklch(0.6 0 0);
   --font-sans:
     ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
     'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',

--- a/erun-ui/build.sh
+++ b/erun-ui/build.sh
@@ -45,12 +45,13 @@ else
 fi
 
 if [ -d frontend ]; then
+	# Installed from the repo-root workspace lockfile, not frontend/yarn.lock:
+	# erun-ui/frontend is a Yarn workspace member, and a plain `cd frontend &&
+	# yarn install` resolves against frontend's own stale, pre-workspaces
+	# lockfile instead, silently dropping deps the root lockfile hoists
+	# (e.g. radix-ui) from node_modules.
+	(cd "$SCRIPT_DIR/.." && "$YARN_BIN" install --frozen-lockfile)
 	cd frontend
-	if [ -f yarn.lock ]; then
-		"$YARN_BIN" install --frozen-lockfile
-	else
-		"$YARN_BIN" install
-	fi
 	# Gate the bundle on the same checks CI would run. `ERUN_SKIP_LINT=1`
 	# escapes the gates locally when iterating; CI never sets it.
 	if [ "${ERUN_SKIP_LINT:-0}" != "1" ]; then

--- a/erun-ui/frontend/eslint.config.mjs
+++ b/erun-ui/frontend/eslint.config.mjs
@@ -69,6 +69,12 @@ export default tseslint.config(
           caughtErrorsIgnorePattern: '^_',
         },
       ],
+      // A scrollable content region has no ARIA role that jsx-a11y classifies
+      // as interactive, yet WCAG 2.1.1 / axe's scrollable-region-focusable
+      // require it to be in the tab order (there is no native control for
+      // "scrollable div"). role="region" + tabIndex is the accepted pattern;
+      // scope the exception to that one role rather than loosening the rule.
+      'jsx-a11y/no-noninteractive-tabindex': ['error', { roles: ['region'] }],
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'error',
       'react-refresh/only-export-components': ['error', { allowConstantExport: true }],

--- a/erun-ui/frontend/src/App.tsx
+++ b/erun-ui/frontend/src/App.tsx
@@ -3,8 +3,9 @@ import * as React from 'react';
 
 import { ControllerProvider } from '@/app/ControllerContext';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import { startSidebarResize } from '@/app/layoutThunks';
+import { startSidebarResize, stepSidebarResize } from '@/app/layoutThunks';
 import { setActivityQueueOpen } from '@/app/slices/layoutSlice';
+import { MAX_SIDEBAR_WIDTH, MIN_SIDEBAR_WIDTH } from '@/app/state';
 import { TerminalController } from '@/app/TerminalController';
 import { ActivityQueueLauncher } from '@/components/app/ActivityQueueLauncher';
 import { AIOccupancyPromptDialog } from '@/components/app/AIOccupancyPromptDialog';
@@ -31,6 +32,7 @@ export function App(): React.ReactElement {
   const controller = React.useMemo(() => new TerminalController(), []);
   const dispatch = useAppDispatch();
   const sidebarHidden = useAppSelector((state) => state.layout.sidebarHidden);
+  const sidebarWidth = useAppSelector((state) => state.layout.sidebarWidth);
   const activityQueueOpen = useAppSelector((state) => state.layout.activityQueueOpen);
   const terminalRootRef = React.useRef<HTMLDivElement>(null);
   const terminalPaneRef = React.useRef<HTMLElement>(null);
@@ -89,6 +91,10 @@ export function App(): React.ReactElement {
                   label="Resize sidebar"
                   onMouseDown={(event) => {
                     dispatch(startSidebarResize(event));
+                  }}
+                  value={{ now: sidebarWidth, min: MIN_SIDEBAR_WIDTH, max: MAX_SIDEBAR_WIDTH }}
+                  onStep={(delta) => {
+                    dispatch(stepSidebarResize(delta));
                   }}
                 />
               )}

--- a/erun-ui/frontend/src/app/TerminalController.ts
+++ b/erun-ui/frontend/src/app/TerminalController.ts
@@ -211,6 +211,7 @@ export class TerminalController {
 
     this.terminal = new Terminal({
       allowProposedApi: false,
+      screenReaderMode: true,
       scrollback: TERMINAL_SCROLLBACK,
       cursorBlink: true,
       fontFamily:

--- a/erun-ui/frontend/src/app/layoutActions.ts
+++ b/erun-ui/frontend/src/app/layoutActions.ts
@@ -75,6 +75,21 @@ export function startSidebarResize(
   window.addEventListener('mouseup', stop);
 }
 
+export function stepSidebarWidth(
+  dispatch: AppDispatch,
+  getState: () => RootState,
+  delta: number,
+  applyLayoutVars: () => void,
+): void {
+  if (getState().layout.sidebarHidden) {
+    return;
+  }
+  const next = clamp(getState().layout.sidebarWidth + delta, MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH);
+  dispatch(setSidebarWidth(next));
+  applyLayoutVars();
+  saveNumber(SIDEBAR_WIDTH_STORAGE_KEY, next);
+}
+
 export function startReviewResize(
   dispatch: AppDispatch,
   getState: () => RootState,
@@ -111,6 +126,25 @@ export function startReviewResize(
   window.addEventListener('mouseup', stop);
 }
 
+export function stepReviewWidth(
+  dispatch: AppDispatch,
+  getState: () => RootState,
+  delta: number,
+  callbacks: Pick<LayoutCallbacks, 'applyLayoutVars' | 'queueTerminalResize'>,
+): void {
+  const layout = getState().layout;
+  if (!layout.reviewOpen) {
+    return;
+  }
+  const effectiveSidebar = layout.sidebarHidden ? 0 : layout.sidebarWidth;
+  const maxWidth = computeMaxReviewWidth(window.innerWidth, effectiveSidebar);
+  const next = clamp(layout.reviewWidth + delta, MIN_REVIEW_WIDTH, maxWidth);
+  dispatch(setReviewWidth(next));
+  callbacks.applyLayoutVars();
+  callbacks.queueTerminalResize();
+  saveNumber(REVIEW_WIDTH_STORAGE_KEY, next);
+}
+
 export function startFilesResize(
   dispatch: AppDispatch,
   getState: () => RootState,
@@ -143,6 +177,21 @@ export function startFilesResize(
 
   window.addEventListener('mousemove', move);
   window.addEventListener('mouseup', stop);
+}
+
+export function stepFilesWidth(
+  dispatch: AppDispatch,
+  getState: () => RootState,
+  delta: number,
+  applyLayoutVars: () => void,
+): void {
+  if (!getState().layout.reviewOpen) {
+    return;
+  }
+  const next = clamp(getState().layout.filesWidth + delta, MIN_FILES_WIDTH, MAX_FILES_WIDTH);
+  dispatch(setFilesWidth(next));
+  applyLayoutVars();
+  saveNumber(FILES_WIDTH_STORAGE_KEY, next);
 }
 
 export function startDebugResize(
@@ -182,6 +231,27 @@ export function startDebugResize(
 
   window.addEventListener('mousemove', move);
   window.addEventListener('mouseup', stop);
+}
+
+export function stepDebugHeight(
+  dispatch: AppDispatch,
+  getState: () => RootState,
+  delta: number,
+  terminalPane: HTMLElement | null,
+  callbacks: Pick<LayoutCallbacks, 'applyLayoutVars' | 'queueTerminalResize'>,
+): void {
+  if (!getState().layout.debugOpen) {
+    return;
+  }
+  const paneRect = terminalPane?.getBoundingClientRect();
+  const maxForPane = paneRect
+    ? Math.max(MIN_DEBUG_HEIGHT, Math.min(MAX_DEBUG_HEIGHT, paneRect.height - 120))
+    : MAX_DEBUG_HEIGHT;
+  const next = clamp(getState().layout.debugHeight + delta, MIN_DEBUG_HEIGHT, maxForPane);
+  dispatch(setDebugHeight(next));
+  callbacks.applyLayoutVars();
+  callbacks.queueTerminalResize();
+  saveNumber(DEBUG_HEIGHT_STORAGE_KEY, next);
 }
 
 export function toggleReview(

--- a/erun-ui/frontend/src/app/layoutThunks.ts
+++ b/erun-ui/frontend/src/app/layoutThunks.ts
@@ -8,6 +8,10 @@ import {
   startFilesResize as startFilesPanelResize,
   startReviewResize as startReviewPanelResize,
   startSidebarResize as startSidebarPanelResize,
+  stepDebugHeight,
+  stepFilesWidth,
+  stepReviewWidth,
+  stepSidebarWidth,
   toggleReview as toggleReviewPanel,
   toggleSidebar as toggleSidebarPanel,
 } from './layoutActions';
@@ -58,6 +62,15 @@ export const startSidebarResize =
     });
   };
 
+export const stepSidebarResize =
+  (delta: number): AppThunk =>
+  (dispatch, getState, extra) => {
+    const controller = requireController(extra);
+    stepSidebarWidth(dispatch, getState, delta, () => {
+      controller.applyLayoutVars();
+    });
+  };
+
 export const startReviewResize =
   (event: React.MouseEvent<HTMLElement>): AppThunk =>
   (dispatch, getState, extra) => {
@@ -71,11 +84,34 @@ export const startReviewResize =
     );
   };
 
+export const stepReviewResize =
+  (delta: number): AppThunk =>
+  (dispatch, getState, extra) => {
+    const controller = requireController(extra);
+    stepReviewWidth(dispatch, getState, delta, {
+      applyLayoutVars: () => {
+        controller.applyLayoutVars();
+      },
+      queueTerminalResize: () => {
+        controller.queueTerminalResize();
+      },
+    });
+  };
+
 export const startFilesResize =
   (event: React.MouseEvent<HTMLElement>): AppThunk =>
   (dispatch, getState, extra) => {
     const controller = requireController(extra);
     startFilesPanelResize(dispatch, getState, event, controller.reviewView, () => {
+      controller.applyLayoutVars();
+    });
+  };
+
+export const stepFilesResize =
+  (delta: number): AppThunk =>
+  (dispatch, getState, extra) => {
+    const controller = requireController(extra);
+    stepFilesWidth(dispatch, getState, delta, () => {
       controller.applyLayoutVars();
     });
   };
@@ -91,6 +127,20 @@ export const startDebugResize =
       controller.terminalPane,
       controller.layoutCallbacks(),
     );
+  };
+
+export const stepDebugResize =
+  (delta: number): AppThunk =>
+  (dispatch, getState, extra) => {
+    const controller = requireController(extra);
+    stepDebugHeight(dispatch, getState, delta, controller.terminalPane, {
+      applyLayoutVars: () => {
+        controller.applyLayoutVars();
+      },
+      queueTerminalResize: () => {
+        controller.queueTerminalResize();
+      },
+    });
   };
 
 export const titlebarDoubleClick =

--- a/erun-ui/frontend/src/components/app/ActivityCard.tsx
+++ b/erun-ui/frontend/src/components/app/ActivityCard.tsx
@@ -21,6 +21,7 @@ import { startDoctorSelection, startForceDeploySelection } from '@/app/recoveryT
 import { ContainerStatusList } from '@/components/app/ActivityCard.ContainerStatus';
 import {
   activityElapsedLabel,
+  activityStatusLabel,
   activityTargetLabel,
   buildFailureReport,
   cardBorderClassName,
@@ -96,7 +97,7 @@ export const ActivityCard = React.memo(function ActivityCard({
       <header className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <div className="flex items-center gap-2 text-sm font-medium">
-            <ActivityStatusIcon status={entry.status} />
+            <ActivityStatusIndicator status={entry.status} />
             <CommandBadge command={entry.command} />
             <span className="truncate">{activityTargetLabel(entry)}</span>
           </div>
@@ -378,4 +379,22 @@ function ActivityStatusIcon({
     case 'cancelled':
       return <Ban aria-hidden="true" className="size-3.5 text-muted-foreground" />;
   }
+}
+
+// The icon alone is aria-hidden and its color is the only other signal, so
+// screen-reader and low-vision users saw nothing distinguishing a card's
+// status (WCAG 1.4.1). This adds the same text visibly for everyone.
+function ActivityStatusIndicator({
+  status,
+}: {
+  status: ActivityQueueEntry['status'];
+}): React.ReactElement {
+  return (
+    <span className="inline-flex flex-none items-center gap-1">
+      <ActivityStatusIcon status={status} />
+      <span className="text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+        {activityStatusLabel(status)}
+      </span>
+    </span>
+  );
 }

--- a/erun-ui/frontend/src/components/app/ActivityQueueDrawer.helpers.ts
+++ b/erun-ui/frontend/src/components/app/ActivityQueueDrawer.helpers.ts
@@ -28,6 +28,25 @@ export function isHistoryStatus(status: ActivityQueueEntry['status']): boolean {
   );
 }
 
+// A visible, readable-by-assistive-tech label for a status that is otherwise
+// conveyed only by an aria-hidden icon and a border color (WCAG 1.4.1).
+export function activityStatusLabel(status: ActivityQueueEntry['status']): string {
+  switch (status) {
+    case 'waiting':
+      return 'Waiting';
+    case 'running':
+      return 'Running';
+    case 'succeeded':
+      return 'Succeeded';
+    case 'failed':
+      return 'Failed';
+    case 'skipped':
+      return 'Skipped';
+    case 'cancelled':
+      return 'Cancelled';
+  }
+}
+
 export function activityElapsedLabel(entry: ActivityQueueEntry, now: number): string {
   const isRunning = entry.status === 'running';
   const isWaiting = entry.status === 'waiting';

--- a/erun-ui/frontend/src/components/app/ActivityQueueDrawer.tsx
+++ b/erun-ui/frontend/src/components/app/ActivityQueueDrawer.tsx
@@ -1,5 +1,6 @@
 import { Button, cn, Tooltip, TooltipContent, TooltipTrigger } from 'erun-kit';
 import { X } from 'lucide-react';
+import { Dialog as DialogPrimitive } from 'radix-ui';
 import * as React from 'react';
 
 import {
@@ -8,19 +9,45 @@ import {
   useActivityQueue,
 } from '@/app/activityQueueState';
 import { ActivityCard } from '@/components/app/ActivityCard';
-import { isHistoryStatus } from '@/components/app/ActivityQueueDrawer.helpers';
+import {
+  activityStatusLabel,
+  activityTargetLabel,
+  isHistoryStatus,
+} from '@/components/app/ActivityQueueDrawer.helpers';
 
 interface ActivityQueueDrawerProps {
   open: boolean;
   onClose: () => void;
+  restoreFocusRef: React.RefObject<HTMLElement | null>;
 }
 
 const drawerSurfaceClassName =
-  'fixed top-[52px] right-0 bottom-0 z-30 flex w-[420px] flex-col border-l bg-background shadow-2xl transition-transform duration-150 ease-out';
+  'fixed top-[52px] right-0 bottom-0 z-30 flex w-[420px] flex-col border-l bg-background shadow-2xl outline-none data-[state=open]:animate-in data-[state=open]:slide-in-from-right data-[state=open]:duration-150 data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=closed]:duration-150';
 
-const drawerHiddenClassName = 'translate-x-full';
-
-const drawerVisibleClassName = 'translate-x-0';
+// Announces a status transition once per entry, not the per-second ticking
+// clock a card renders locally -- an aria-live region wrapping the whole card
+// list re-announced that clock every second (WCAG 2.2.2).
+function useActivityStatusAnnouncement(entries: ActivityQueueEntry[]): string {
+  const previousStatuses = React.useRef<Map<string, ActivityQueueEntry['status']>>(new Map());
+  const [announcement, setAnnouncement] = React.useState('');
+  React.useEffect(() => {
+    const previous = previousStatuses.current;
+    const next = new Map<string, ActivityQueueEntry['status']>();
+    const changed: string[] = [];
+    for (const entry of entries) {
+      next.set(entry.id, entry.status);
+      const previousStatus = previous.get(entry.id);
+      if (previousStatus && previousStatus !== entry.status) {
+        changed.push(`${activityTargetLabel(entry)} ${activityStatusLabel(entry.status)}`);
+      }
+    }
+    previousStatuses.current = next;
+    if (changed.length > 0) {
+      setAnnouncement(changed.join('. '));
+    }
+  }, [entries]);
+  return announcement;
+}
 
 // ActivityQueueDrawer is the slide-in activity queue drawer. The queue is
 // rebuilt from live cluster and host state on every launch and never persists
@@ -28,6 +55,7 @@ const drawerVisibleClassName = 'translate-x-0';
 export function ActivityQueueDrawer({
   open,
   onClose,
+  restoreFocusRef,
 }: ActivityQueueDrawerProps): React.ReactElement {
   const { entries, dismiss, forceDismiss, recoverPendingHelm, killSession, cancelWaiting } =
     useActivityQueue();
@@ -37,6 +65,7 @@ export function ActivityQueueDrawer({
   const [recoveryFeedback, setRecoveryFeedback] = React.useState<ActivityRecoveryResult | null>(
     null,
   );
+  const statusAnnouncement = useActivityStatusAnnouncement(entries);
 
   const dismissAllNow = React.useCallback(async () => {
     await Promise.all(nowEntries.map((entry) => forceDismiss(entry.id)));
@@ -56,45 +85,53 @@ export function ActivityQueueDrawer({
   );
 
   return (
-    <>
-      {open && (
-        <div
-          role="presentation"
-          className="fixed inset-0 top-[52px] z-20 bg-foreground/10"
-          onClick={onClose}
-        />
-      )}
-      <aside
-        className={cn(
-          drawerSurfaceClassName,
-          open ? drawerVisibleClassName : drawerHiddenClassName,
-        )}
-        role="dialog"
-        aria-label="Activity queue"
-        aria-hidden={!open}
-      >
-        <ActivityQueueHeader
-          nowCount={nowEntries.length}
-          nextCount={nextEntries.length}
-          onClose={onClose}
-        />
-        <ActivityQueueSections
-          nowEntries={nowEntries}
-          nextEntries={nextEntries}
-          historyEntries={historyEntries}
-          recoveryFeedback={recoveryFeedback}
-          setRecoveryFeedback={setRecoveryFeedback}
-          dismiss={dismiss}
-          forceDismiss={forceDismiss}
-          cancelWaiting={cancelWaiting}
-          killSession={killSession}
-          onRecoverPendingHelm={onRecoverPendingHelm}
-          dismissAllNow={dismissAllNow}
-          cancelAllNext={cancelAllNext}
-          dismissAllHistory={dismissAllHistory}
-        />
-      </aside>
-    </>
+    <DialogPrimitive.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 top-[52px] z-20 bg-foreground/10 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0" />
+        <DialogPrimitive.Content
+          aria-label="Activity queue"
+          className={drawerSurfaceClassName}
+          onCloseAutoFocus={(event) => {
+            if (restoreFocusRef.current) {
+              event.preventDefault();
+              restoreFocusRef.current.focus();
+            }
+          }}
+        >
+          <DialogPrimitive.Description className="sr-only">
+            Running, queued, and recent deploy and shell activity.
+          </DialogPrimitive.Description>
+          <ActivityQueueHeader
+            nowCount={nowEntries.length}
+            nextCount={nextEntries.length}
+            onClose={onClose}
+          />
+          <div role="status" aria-live="polite" className="sr-only">
+            {statusAnnouncement}
+          </div>
+          <ActivityQueueSections
+            nowEntries={nowEntries}
+            nextEntries={nextEntries}
+            historyEntries={historyEntries}
+            recoveryFeedback={recoveryFeedback}
+            setRecoveryFeedback={setRecoveryFeedback}
+            dismiss={dismiss}
+            forceDismiss={forceDismiss}
+            cancelWaiting={cancelWaiting}
+            killSession={killSession}
+            onRecoverPendingHelm={onRecoverPendingHelm}
+            dismissAllNow={dismissAllNow}
+            cancelAllNext={cancelAllNext}
+            dismissAllHistory={dismissAllHistory}
+          />
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
   );
 }
 
@@ -149,7 +186,7 @@ interface ActivityQueueSectionsProps {
 
 function ActivityQueueSections(props: ActivityQueueSectionsProps): React.ReactElement {
   return (
-    <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-3" aria-live="polite">
+    <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-3">
       {props.recoveryFeedback && (
         <RecoveryFeedback
           result={props.recoveryFeedback}

--- a/erun-ui/frontend/src/components/app/ActivityQueueLauncher.tsx
+++ b/erun-ui/frontend/src/components/app/ActivityQueueLauncher.tsx
@@ -5,8 +5,6 @@ import * as React from 'react';
 import { useActivityQueue } from '@/app/activityQueueState';
 import { ActivityQueueDrawer } from '@/components/app/ActivityQueueDrawer';
 
-// The drawer stays mounted even while closed so its open/close CSS
-// transition can slide it in and out.
 export function ActivityQueueLauncher({
   open,
   onOpen,
@@ -18,11 +16,18 @@ export function ActivityQueueLauncher({
 }): React.ReactElement {
   const { entries } = useActivityQueue();
   const activeCount = entries.filter((entry) => entry.status === 'running').length;
+  // Radix's own "restore focus to whatever was focused before open" can't be
+  // trusted here: the trigger sits inside a Tooltip, whose own pointer/focus
+  // handling can leave document.activeElement on the trigger's ancestor by
+  // the time the dialog's FocusScope captures it. Hand the button down
+  // explicitly so the drawer can always return focus to it on close.
+  const launcherRef = React.useRef<HTMLButtonElement>(null);
   return (
     <>
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
+            ref={launcherRef}
             type="button"
             variant="outline"
             size="icon"
@@ -48,7 +53,7 @@ export function ActivityQueueLauncher({
             : 'Activities'}
         </TooltipContent>
       </Tooltip>
-      <ActivityQueueDrawer open={open} onClose={onClose} />
+      <ActivityQueueDrawer open={open} onClose={onClose} restoreFocusRef={launcherRef} />
     </>
   );
 }

--- a/erun-ui/frontend/src/components/app/DebugPanel.tsx
+++ b/erun-ui/frontend/src/components/app/DebugPanel.tsx
@@ -3,8 +3,9 @@ import { ChevronDown, ChevronUp } from 'lucide-react';
 import * as React from 'react';
 
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import { setDebugOpen, startDebugResize } from '@/app/layoutThunks';
+import { setDebugOpen, startDebugResize, stepDebugResize } from '@/app/layoutThunks';
 import { type DiagnosticsContext, selectDiagnosticsContext } from '@/app/selectors';
+import { MAX_DEBUG_HEIGHT, MIN_DEBUG_HEIGHT } from '@/app/state';
 
 import { AppLogPane, OrchestratorPane } from './DebugPanel.AppLog';
 import { ErunTracePane } from './DebugPanel.ErunTrace';
@@ -54,6 +55,7 @@ export function DebugPanel({ open }: { open: boolean }): React.ReactElement {
   const [tab, setTab] = React.useState<DiagnosticsTab>('primary');
   const context = useAppSelector(selectDiagnosticsContext);
   const primaryLabel = primaryTabLabel(context);
+  const debugHeight = useAppSelector((state) => state.layout.debugHeight);
 
   return (
     <section
@@ -69,6 +71,10 @@ export function DebugPanel({ open }: { open: boolean }): React.ReactElement {
           label="Resize diagnostics panel"
           onMouseDown={(event) => {
             dispatch(startDebugResize(event));
+          }}
+          value={{ now: debugHeight, min: MIN_DEBUG_HEIGHT, max: MAX_DEBUG_HEIGHT }}
+          onStep={(delta) => {
+            dispatch(stepDebugResize(delta));
           }}
         />
       )}

--- a/erun-ui/frontend/src/components/app/DiffList.tsx
+++ b/erun-ui/frontend/src/components/app/DiffList.tsx
@@ -309,13 +309,21 @@ function DiffFileView({
       {file.binary ? (
         <ReviewStatus>Binary file changed</ReviewStatus>
       ) : (
-        (file.hunks ?? []).map((hunk) => <DiffHunkView key={hunk.header} hunk={hunk} />)
+        (file.hunks ?? []).map((hunk) => (
+          <DiffHunkView key={hunk.header} hunk={hunk} filePath={file.path} />
+        ))
       )}
     </section>
   );
 }
 
-function DiffHunkView({ hunk }: { hunk: DiffHunk }): React.ReactElement {
+function DiffHunkView({
+  hunk,
+  filePath,
+}: {
+  hunk: DiffHunk;
+  filePath: string;
+}): React.ReactElement {
   const contentWidth = Math.max(1, ...(hunk.lines ?? []).map((line) => line.content.length));
   const style = { '--diff-content-width': `${String(contentWidth + 2)}ch` } as React.CSSProperties;
 
@@ -324,7 +332,13 @@ function DiffHunkView({ hunk }: { hunk: DiffHunk }): React.ReactElement {
       <div className="overflow-hidden bg-muted px-2.5 py-1.5 font-mono text-[11px] leading-[1.35] text-ellipsis whitespace-pre text-muted-foreground">
         {hunk.header}
       </div>
-      <div className="relative max-w-full overflow-x-auto overflow-y-hidden" style={style}>
+      <div
+        tabIndex={0}
+        role="region"
+        aria-label={`Diff for ${filePath} at ${hunk.header}`}
+        className="relative max-w-full overflow-x-auto overflow-y-hidden outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        style={style}
+      >
         {(hunk.lines ?? []).map((line, index) => (
           <div
             key={`${String(line.oldLine ?? '')}:${String(line.newLine ?? '')}:${String(index)}`}

--- a/erun-ui/frontend/src/components/app/ReviewPanel.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewPanel.tsx
@@ -11,7 +11,7 @@ import * as React from 'react';
 
 import { switchDiffSource } from '@/app/contributeThunks';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import { startFilesResize } from '@/app/layoutThunks';
+import { startFilesResize, stepFilesResize } from '@/app/layoutThunks';
 import {
   loadReviewDiff,
   refreshReviewDiff,
@@ -21,6 +21,7 @@ import {
 } from '@/app/reviewThunks';
 import { selectReviewEnvTargets } from '@/app/selectors';
 import { contributeEnvKey, type DiffSource } from '@/app/slices/contributeSlice';
+import { MAX_FILES_WIDTH, MIN_FILES_WIDTH } from '@/app/state';
 import { useController } from '@/app/useController';
 import { useEnvDiffSlot } from '@/app/useEnvDiffSlot';
 import type { DiffCommit } from '@/types';
@@ -44,12 +45,16 @@ export function ReviewPanel({
   const dispatch = useAppDispatch();
   const filesOpen = useAppSelector((state) => state.layout.filesOpen);
   const reviewOpen = useAppSelector((state) => state.layout.reviewOpen);
+  const filesWidth = useAppSelector((state) => state.layout.filesWidth);
   const filesVisible = filesOpen && reviewOpen;
   return (
     <section ref={reviewViewRef} className={reviewPanelClassName(reviewOpen, filesOpen)}>
       <div
         ref={reviewMainRef}
-        className="h-full min-h-0 min-w-0 overflow-auto overscroll-contain bg-background"
+        tabIndex={0}
+        role="region"
+        aria-label="Diff content"
+        className="h-full min-h-0 min-w-0 overflow-auto overscroll-contain bg-background outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
         onScroll={() => {
           controller.queueVisibleDiffSelectionUpdate();
         }}
@@ -62,6 +67,10 @@ export function ReviewPanel({
         visible={filesVisible}
         onMouseDown={(event) => {
           dispatch(startFilesResize(event));
+        }}
+        value={{ now: filesWidth, min: MIN_FILES_WIDTH, max: MAX_FILES_WIDTH }}
+        onStep={(delta) => {
+          dispatch(stepFilesResize(delta));
         }}
       />
       <ChangedFilesAside visible={filesVisible} />
@@ -83,9 +92,13 @@ function reviewPanelClassName(reviewOpen: boolean, filesOpen: boolean): string {
 function ChangedFilesSplitter({
   visible,
   onMouseDown,
+  value,
+  onStep,
 }: {
   visible: boolean;
-  onMouseDown: React.MouseEventHandler<HTMLButtonElement>;
+  onMouseDown: React.MouseEventHandler<HTMLDivElement>;
+  value: { now: number; min: number; max: number };
+  onStep: (delta: number) => void;
 }): React.ReactElement {
   return (
     <ResizeHandle
@@ -94,6 +107,8 @@ function ChangedFilesSplitter({
       label="Resize changed files list"
       hidden={!visible}
       onMouseDown={onMouseDown}
+      value={value}
+      onStep={onStep}
     />
   );
 }
@@ -124,7 +139,7 @@ function ChangedFilesAside({ visible }: { visible: boolean }): React.ReactElemen
       <ReviewRangeControls />
       {changedFilesOpen ? (
         <>
-          <Label className="box-border flex h-[38px] items-center gap-2 rounded-[var(--radius)] border border-input bg-background px-3 text-muted-foreground [&_svg]:size-[18px] [&_svg]:flex-none">
+          <Label className="box-border flex h-[38px] items-center gap-2 rounded-[var(--radius)] border border-input bg-background px-3 text-muted-foreground [&_svg]:size-[18px] [&_svg]:flex-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring">
             <Search aria-hidden="true" />
             <Input
               className="h-auto min-w-0 flex-1 border-0 bg-transparent p-0 text-sm text-foreground shadow-none outline-none placeholder:text-muted-foreground focus-visible:border-0 focus-visible:ring-0"

--- a/erun-ui/frontend/src/components/app/TerminalPane.tsx
+++ b/erun-ui/frontend/src/components/app/TerminalPane.tsx
@@ -3,9 +3,10 @@ import * as React from 'react';
 
 import { useTerminalActivityLockState } from '@/app/activityQueueState';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import { startReviewResize } from '@/app/layoutThunks';
+import { startReviewResize, stepReviewResize } from '@/app/layoutThunks';
 import { selectActiveTabIsAI } from '@/app/selectors';
 import { clearHiddenLockOverlay, hideLockOverlay } from '@/app/slices/terminalStatusSlice';
+import { computeMaxReviewWidth, MIN_REVIEW_WIDTH } from '@/app/state';
 import { ActivityLockOverlay } from '@/components/app/ActivityLockOverlay';
 import { AIOccupancyBanner } from '@/components/app/AIOccupancyBanner';
 import { ReviewPanel } from '@/components/app/ReviewPanel';
@@ -33,6 +34,10 @@ export function TerminalPane({
   const dispatch = useAppDispatch();
   const sessionId = useAppSelector((state) => state.terminal.sessionId);
   const reviewOpen = useAppSelector((state) => state.layout.reviewOpen);
+  const reviewWidth = useAppSelector((state) => state.layout.reviewWidth);
+  const effectiveSidebarWidth = useAppSelector((state) =>
+    state.layout.sidebarHidden ? 0 : state.layout.sidebarWidth,
+  );
   const terminalBusy = useAppSelector((state) => state.terminalStatus.terminalBusy);
   const terminalMessage = useAppSelector((state) => state.terminalStatus.terminalMessage);
   const locks = useTerminalActivityLockState();
@@ -77,6 +82,8 @@ export function TerminalPane({
         {/* Padding lives on the wrapper, not on the FitAddon parent: xterm's FitAddon reads the parent's computed height but does not subtract its padding, so any padding on terminalRoot would over-count rows and clip the bottom line. */}
         <div
           id="erun-terminal-pane"
+          role="group"
+          aria-label="Terminal"
           className="relative h-full min-h-0 min-w-0 overflow-hidden box-border px-4 pt-3.5"
         >
           <div ref={terminalRootRef} className="terminal h-full min-h-0 min-w-0 w-full" />
@@ -100,6 +107,14 @@ export function TerminalPane({
         hidden={!reviewOpen}
         onMouseDown={(event) => {
           dispatch(startReviewResize(event));
+        }}
+        value={{
+          now: reviewWidth,
+          min: MIN_REVIEW_WIDTH,
+          max: computeMaxReviewWidth(window.innerWidth, effectiveSidebarWidth),
+        }}
+        onStep={(delta) => {
+          dispatch(stepReviewResize(delta));
         }}
       />
       <ReviewPanel

--- a/erun-ui/playwright/package.json
+++ b/erun-ui/playwright/package.json
@@ -18,6 +18,7 @@
     "report": "playwright show-report"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.13.0",
     "@playwright/test": "^1.50.0",
     "@types/node": "^22.10.0",
     "eslint": "^10.4.0",

--- a/erun-ui/playwright/pages/DebugPanel.ts
+++ b/erun-ui/playwright/pages/DebugPanel.ts
@@ -5,7 +5,7 @@ export class DebugPanel {
   constructor(public readonly page: Page) {}
 
   resizeHandle(): Locator {
-    return this.page.getByRole('button', { name: 'Resize diagnostics panel' });
+    return this.page.getByRole('slider', { name: 'Resize diagnostics panel' });
   }
 
   toggleButton(): Locator {

--- a/erun-ui/playwright/pages/ReviewPanel.ts
+++ b/erun-ui/playwright/pages/ReviewPanel.ts
@@ -8,10 +8,27 @@ export class ReviewPanel {
     return this.page.locator('aside').filter({ hasText: 'Filter files' }).first();
   }
 
+  resizeHandle(): Locator {
+    return this.page.getByRole('slider', { name: 'Resize diff panel' });
+  }
+
   async isOpen(): Promise<boolean> {
-    const splitter = this.page.getByRole('button', { name: 'Resize diff panel' });
+    const splitter = this.resizeHandle();
     if (!(await splitter.count())) return false;
     return splitter.first().isVisible();
+  }
+
+  // The scrollable diff content region (ReviewPanel.tsx); focusable so a
+  // keyboard-only reviewer can scroll past the first screenful of a diff.
+  diffContentRegion(): Locator {
+    return this.page.getByRole('region', { name: 'Diff content' });
+  }
+
+  // One horizontal scroller per hunk (DiffList.tsx), focusable so a keyboard
+  // user can read a line wider than the panel. `filePath` narrows to one
+  // file's hunk(s) when more than one diff section is rendered.
+  hunkRegion(filePath: string): Locator {
+    return this.page.getByRole('region', { name: new RegExp(`^Diff for ${filePath} `) });
   }
 
   filterInput(): Locator {

--- a/erun-ui/playwright/pages/TerminalPane.ts
+++ b/erun-ui/playwright/pages/TerminalPane.ts
@@ -63,6 +63,18 @@ export class TerminalPane {
     return this.page.locator('.xterm-rows');
   }
 
+  // The host div xterm mounts into; must carry a role/label so a screen-reader
+  // user landing on it (e.g. via Tab or landmark navigation) knows what it is.
+  host(): Locator {
+    return this.page.getByRole('group', { name: 'Terminal' });
+  }
+
+  // xterm only builds this live-region tree when `screenReaderMode: true`, so
+  // its presence is the observable proof the option is actually wired up.
+  accessibilityTree(): Locator {
+    return this.page.locator('.xterm-accessibility');
+  }
+
   // Writes raw bytes to a session as if its PTY had emitted them. btoa is safe
   // only because every byte written through here is < 256.
   async emitOutput(sessionId: number, raw: string): Promise<void> {

--- a/erun-ui/playwright/tests/a11y-activity-drawer.spec.ts
+++ b/erun-ui/playwright/tests/a11y-activity-drawer.spec.ts
@@ -1,0 +1,114 @@
+import AxeBuilder from '@axe-core/playwright';
+
+import { expect, test } from '../fixtures/erunApp.js';
+
+// The activity drawer was a plain <div> toggling `aria-hidden` and a
+// CSS transform, so it was never a real dialog -- Escape did nothing, closing
+// it left every control (including Kill, which can terminate a running
+// deploy) sitting focusable inside an aria-hidden subtree, and one aria-live
+// region wrapped the whole card list, re-announcing each card's per-second
+// elapsed clock. It now renders on Radix's Dialog primitive, which gives focus
+// trap, Escape-to-close, and focus restoration for free, plus a narrow
+// announcer that only fires on a real status transition.
+
+async function emitActivity(
+  page: import('@playwright/test').Page,
+  entry: Record<string, unknown>,
+): Promise<void> {
+  await page.evaluate((e) => {
+    (
+      window as unknown as { runtime: { EventsEmit: (n: string, ...a: unknown[]) => void } }
+    ).runtime.EventsEmit('activity:state', e);
+  }, entry);
+}
+
+function runningEntry(id: string): Record<string, unknown> {
+  return {
+    id,
+    command: 'open',
+    tenant: 'petios',
+    environment: 'rihards-review',
+    status: 'running',
+    startedAt: new Date(0).toISOString(),
+    lastUpdated: new Date(0).toISOString(),
+    source: 'action',
+    actionKind: 'open',
+    summary: 'open petios/rihards-review',
+  };
+}
+
+test.describe('activity drawer accessibility', () => {
+  test('Escape closes the drawer, unmounts it, and returns focus to the launcher', async ({
+    app,
+    page,
+  }) => {
+    await app.activityDrawer.open();
+    await expect(app.activityDrawer.locator()).toBeVisible();
+    // Radix's focus trap puts initial focus inside the dialog on open.
+    await expect
+      .poll(() => page.evaluate(() => document.activeElement?.closest('[role="dialog"]') !== null))
+      .toBe(true);
+
+    await page.keyboard.press('Escape');
+
+    await expect(app.activityDrawer.locator()).toHaveCount(0);
+    await expect(app.activityDrawer.launcher()).toBeFocused();
+  });
+
+  test('closing unmounts every control, so none is reachable by Tab while closed', async ({
+    app,
+  }) => {
+    await app.activityDrawer.open();
+    await expect(app.activityDrawer.closeButton()).toBeVisible();
+
+    await app.activityDrawer.close();
+
+    await expect(app.activityDrawer.locator()).toHaveCount(0);
+    await expect(app.activityDrawer.closeButton()).toHaveCount(0);
+  });
+
+  test('a card states its status as visible text, not only a hidden icon', async ({
+    app,
+    page,
+  }) => {
+    await emitActivity(page, runningEntry('a11y-status-1'));
+    await app.activityDrawer.open();
+
+    const card = app.activityDrawer
+      .locator()
+      .locator('article')
+      .filter({ hasText: 'rihards-review' });
+    await expect(card.getByText('Running', { exact: true })).toBeVisible();
+  });
+
+  test('the live announcer reports a status transition, not the elapsed clock', async ({
+    app,
+    page,
+  }) => {
+    await emitActivity(page, runningEntry('a11y-status-2'));
+    await app.activityDrawer.open();
+
+    // Scoped to the sr-only announcer only (not the header's "N now/next"
+    // count, which is also a live region but never carries an elapsed clock).
+    const announcer = app.activityDrawer.locator().locator('.sr-only[role="status"]');
+    await emitActivity(page, { ...runningEntry('a11y-status-2'), status: 'succeeded' });
+
+    await expect(announcer).toContainText('petios/rihards-review Succeeded');
+    // The elapsed clock renders as e.g. "3s" / "1m4s" -- the announcer's text
+    // must never take that shape, or a screen reader is back to hearing a tick.
+    await expect(announcer).not.toHaveText(/^\d+s$|^\d+m\d+s$/);
+  });
+
+  // Scoped to the one rule the old always-mounted-and-aria-hidden drawer
+  // violated (Kill and friends stayed focusable behind aria-hidden while
+  // "closed"); a whole-page scan would also flag unrelated, pre-existing
+  // findings elsewhere in the app that this issue doesn't cover.
+  test('axe reports no aria-hidden-focus violations with the drawer open', async ({
+    app,
+    page,
+  }) => {
+    await app.activityDrawer.open();
+    const results = await new AxeBuilder({ page }).withRules(['aria-hidden-focus']).analyze();
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/erun-ui/playwright/tests/a11y-diff-panel.spec.ts
+++ b/erun-ui/playwright/tests/a11y-diff-panel.spec.ts
@@ -1,0 +1,211 @@
+import AxeBuilder from '@axe-core/playwright';
+import type { Locator, Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+
+// The diff panel had exactly zero focusable scrollers -- the vertical
+// diff content area and every hunk's horizontal scroller had no tabIndex, so
+// a keyboard-only reviewer could not scroll past the first screenful of any
+// diff or read a line wider than the panel (axe scrollable-region-focusable,
+// WCAG 2.1.1). The resize handles were <button>s wired only to onMouseDown, so
+// Enter/Space/arrow keys did nothing either. These specs drive real keyboard
+// input (Tab, Escape, Arrow keys) and assert the resulting focus/layout state,
+// not just the markup.
+
+interface DiffLineStub {
+  kind: string;
+  oldLine: number | null;
+  newLine: number | null;
+  content: string;
+}
+interface DiffFileStub {
+  path: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  binary: boolean;
+  hunks: { header: string; lines: DiffLineStub[] }[];
+}
+
+function diffFile(path: string, lineContent: string): DiffFileStub {
+  return {
+    path,
+    status: 'modified',
+    additions: 1,
+    deletions: 0,
+    binary: false,
+    hunks: [
+      {
+        header: '@@ -1,1 +1,1 @@',
+        lines: [{ kind: 'add', oldLine: null, newLine: 1, content: lineContent }],
+      },
+    ],
+  };
+}
+
+async function stubDiff(page: Page, files: DiffFileStub[]): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+    if (body.method === 'LoadDiff') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            rawDiff: '',
+            workingDirectory: '/seed',
+            summary: { fileCount: files.length, additions: 1, deletions: 0 },
+            files,
+            tree: files.map((f) => ({ name: f.path, path: f.path, type: 'file', depth: 0 })),
+            scope: 'current',
+            includesWorktree: true,
+          },
+        }),
+      });
+    }
+    await route.continue();
+  });
+}
+
+// theme.css only ever declares --ring/--background as achromatic
+// `oklch(L 0 0)` (no chroma/hue), so lightness alone determines relative
+// luminance. `getComputedStyle` in this browser preserves the oklch()
+// notation rather than downgrading it to rgb(), so the ratio is computed
+// directly from the OKLCH value instead of relying on a resolved sRGB string.
+function achromaticOklchLightness(value: string): number {
+  // The browser normalizes the declared `oklch(0.6 0 0)` to `oklch(60% 0 0)`.
+  const match = /oklch\(\s*([\d.]+)(%?)\s+0\s+0\s*\)/.exec(value);
+  if (!match?.[1]) {
+    throw new Error(`expected an achromatic oklch() value, got: ${value}`);
+  }
+  const lightness = Number(match[1]);
+  return match[2] === '%' ? lightness / 100 : lightness;
+}
+
+// The OKLab -> linear sRGB matrix (https://bottosson.github.io/posts/oklab/)
+// reduces to r = g = b = lightness^3 when chroma/hue are zero (each row's
+// coefficients sum to 1), and WCAG relative luminance weights (0.2126,
+// 0.7152, 0.0722) also sum to 1 -- so for this theme's achromatic tokens,
+// relative luminance is just lightness^3.
+function relativeLuminanceFromAchromaticOklch(lightness: number): number {
+  return lightness ** 3;
+}
+
+function contrastRatio(lightnessA: number, lightnessB: number): number {
+  const lighter = Math.max(
+    relativeLuminanceFromAchromaticOklch(lightnessA),
+    relativeLuminanceFromAchromaticOklch(lightnessB),
+  );
+  const darker = Math.min(
+    relativeLuminanceFromAchromaticOklch(lightnessA),
+    relativeLuminanceFromAchromaticOklch(lightnessB),
+  );
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+// Opening the seeded env schedules its own terminal-focus cascade
+// (`focusTerminalSoon`'s immediate + rAF + delayed calls), independent of
+// anything this spec does, and it can still be in flight when a test reaches
+// for the resize handle -- landing an Arrow key on the terminal instead of
+// the handle. Retrying the whole focus+press against the actual value (not a
+// fixed delay) converges once that cascade has run its course.
+async function stepResizeHandle(
+  page: Page,
+  handle: Locator,
+  key: string,
+  target: number,
+): Promise<void> {
+  await expect(async () => {
+    const current = Number(await handle.getAttribute('aria-valuenow'));
+    if (current === target) return;
+    await handle.focus();
+    await page.keyboard.press(key);
+    expect(Number(await handle.getAttribute('aria-valuenow'))).toBe(target);
+  }).toPass();
+}
+
+test.describe('diff panel accessibility', () => {
+  test.beforeEach(async ({ app, page, seededEnv }) => {
+    await stubDiff(page, [diffFile('src/very/long/path/wide-file.ts', 'x'.repeat(400))]);
+    await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    await app.titlebar.toggleReviewPanel();
+    await expect
+      .poll(() => app.reviewPanel.diffSectionPaths())
+      .toEqual(['src/very/long/path/wide-file.ts']);
+  });
+
+  test('the diff content region and a hunk scroller are real Tab stops, in order', async ({
+    app,
+    page,
+  }) => {
+    const region = app.reviewPanel.diffContentRegion();
+    const hunk = app.reviewPanel.hunkRegion('src/very/long/path/wide-file.ts');
+    await expect(region).toHaveAttribute('tabindex', '0');
+    await expect(hunk).toHaveAttribute('tabindex', '0');
+
+    // A real click focuses it exactly like Tab landing on it would (browsers
+    // refuse to focus an element with no tabindex on click, so this alone
+    // already exercises the fix); the follow-up Tab press is a genuine
+    // keyboard traversal to the very next stop in the DOM. Click near the
+    // region's top padding, not its center -- the center can land inside the
+    // nested hunk scroller for a single short diff. Retried as a whole: the
+    // env-open flow schedules its own terminal-focus cascade that can steal
+    // focus back between the click and the Tab press.
+    await expect(async () => {
+      await region.click({ position: { x: 5, y: 5 } });
+      await expect(region).toBeFocused();
+      await page.keyboard.press('Tab');
+      await expect(hunk).toBeFocused();
+    }).toPass();
+  });
+
+  test('the diff resize handle is keyboard-adjustable and reports its value', async ({
+    app,
+    page,
+  }) => {
+    const handle = app.reviewPanel.resizeHandle();
+    await expect(handle).toHaveAttribute('role', 'slider');
+    await expect(handle).toHaveAttribute('aria-orientation', 'vertical');
+    const before = Number(await handle.getAttribute('aria-valuenow'));
+    expect(before).toBeGreaterThan(0);
+
+    await stepResizeHandle(page, handle, 'ArrowRight', before + 16);
+    await stepResizeHandle(page, handle, 'ArrowLeft', before);
+    await stepResizeHandle(page, handle, 'ArrowLeft', before - 16);
+
+    // The ARIA value is not decorative: the actual CSS var the layout reads
+    // must have moved with it.
+    const width = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--review-width').trim(),
+    );
+    expect(width).toBe(`${String(before - 16)}px`);
+  });
+
+  test('the focus ring meets the 3:1 non-text contrast floor against the background', async ({
+    page,
+  }) => {
+    const [ring, background] = await page.evaluate(() => {
+      const root = getComputedStyle(document.documentElement);
+      return [root.getPropertyValue('--ring').trim(), root.getPropertyValue('--background').trim()];
+    });
+    const ratio = contrastRatio(
+      achromaticOklchLightness(ring),
+      achromaticOklchLightness(background),
+    );
+    expect(ratio).toBeGreaterThanOrEqual(3);
+  });
+
+  // axe cannot see keyboard behavior, but it can catch the two structural
+  // defects the issue named directly: a scrollable region with no way into
+  // the tab order, and a focusable control sitting inside an aria-hidden
+  // subtree. Scoped to these rules (not a whole-page scan) so the assertion
+  // tracks this surface's own regressions, not unrelated pre-existing
+  // findings elsewhere in the app.
+  test('axe reports no scrollable-region-focusable or aria-hidden-focus violations', async ({
+    page,
+  }) => {
+    const results = await new AxeBuilder({ page })
+      .withRules(['scrollable-region-focusable', 'aria-hidden-focus'])
+      .analyze();
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/erun-ui/playwright/tests/a11y-terminal.spec.ts
+++ b/erun-ui/playwright/tests/a11y-terminal.spec.ts
@@ -1,0 +1,36 @@
+import AxeBuilder from '@axe-core/playwright';
+
+import { expect, test } from '../fixtures/erunApp.js';
+
+// The terminal host had no aria-label/role and xterm's screenReaderMode
+// was never turned on, so the AccessibilityManager live region that carries
+// output to a screen reader was never created -- every `erun` command, and
+// every AI agent turn, was silent. These specs lock the observable proof of
+// both fixes: the accessibility tree only exists when screenReaderMode is on,
+// and the host div is reachable/named for a user who lands on it.
+
+test.describe('terminal accessibility', () => {
+  test('the terminal host is a named, reachable group', async ({ app }) => {
+    const host = app.terminalPane.host();
+    await expect(host).toBeVisible();
+    await expect(host).toHaveAttribute('role', 'group');
+    await expect(host).toHaveAccessibleName('Terminal');
+  });
+
+  test('xterm builds its screen-reader accessibility tree', async ({ app }) => {
+    // Only present when `screenReaderMode: true` was passed to `new Terminal(...)`
+    // -- xterm's AccessibilityManager is not instantiated otherwise, so this
+    // element's mere existence is the regression guard for the option.
+    await expect(app.terminalPane.accessibilityTree()).toHaveCount(1);
+    await expect(app.terminalPane.accessibilityTree().locator('[role="list"]')).toHaveCount(1);
+  });
+
+  // Scoped to the host div itself, not a whole-page scan: axe can't observe
+  // xterm's screen-reader wiring (checked directly above), but it can catch a
+  // structurally broken landmark/name on the surface we changed.
+  test('axe reports no violations for the terminal host', async ({ app, page }) => {
+    await expect(app.terminalPane.host()).toBeVisible();
+    const results = await new AxeBuilder({ page }).include('#erun-terminal-pane').analyze();
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/erun-ui/playwright/tests/layout.spec.ts
+++ b/erun-ui/playwright/tests/layout.spec.ts
@@ -28,7 +28,7 @@ test.describe('layout panels', () => {
   });
 
   test('review panel toggle reveals the diff section', async ({ app, page }) => {
-    const splitter = page.getByRole('button', { name: 'Resize diff panel' });
+    const splitter = page.getByRole('slider', { name: 'Resize diff panel' });
     const initiallyVisible = await splitter.isVisible().catch(() => false);
 
     await app.titlebar.toggleReviewPanel();

--- a/erun-ui/playwright/yarn.lock
+++ b/erun-ui/playwright/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@axe-core/playwright@^4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@axe-core/playwright/-/playwright-4.13.0.tgz#4826467c9622df26f0d75b4c1747c8d92ee599de"
+  integrity sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==
+  dependencies:
+    axe-core "~4.13.0"
+
 "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
@@ -225,6 +232,11 @@ ajv@^6.14.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+axe-core@~4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.13.0.tgz#f868ecb1bd61d982321760e51d841ab497ab86d0"
+  integrity sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==
 
 balanced-match@^4.0.2:
   version "4.0.4"


### PR DESCRIPTION
## Summary

Fixes the three class-blocking accessibility defects in erun#1215 — the diff review panel, the terminal, and the activity queue drawer were unusable for keyboard-only and screen-reader users. One coherent PR: all three surfaces are part of the same issue and the fixes share a component (`ResizeHandle`) and touch overlapping files, so slicing further would just fragment review.

- **Diff panel** (`ReviewPanel.tsx`, `DiffList.tsx`, `ResizeHandle.tsx`, `theme.css`): the vertical diff-content scroller and each hunk's horizontal scroller are now real Tab stops (`tabIndex={0}` + `role="region"` + accessible name). All four `ResizeHandle` instances (sidebar, diff panel, changed-files list, diagnostics console) gain arrow-key resizing — `role="slider"` with `aria-valuenow`/`min`/`max` rather than `role="separator"`, since a `<button>` can't carry a non-interactive role and a plain `<div>` needs *some* interactive role for the mouse+keyboard handlers to be valid. Light-theme `--ring` moves from 2.59:1 to ~3.95:1 contrast against the background (WCAG 1.4.11), and the search-filter input's wrapper gets a `focus-within` ring since it was the app's only focusable control with no visible focus indicator at all.
- **Terminal** (`TerminalController.ts`, `TerminalPane.tsx`): xterm now runs with `screenReaderMode: true`, so its `AccessibilityManager` live-region tree actually exists; the host div carries `role="group"` + `aria-label="Terminal"`.
- **Activity drawer** (`ActivityQueueDrawer.tsx`, `ActivityQueueLauncher.tsx`, `ActivityCard.tsx`): rebuilt on Radix's `Dialog` primitive instead of a manually-toggled `<div>` with `aria-hidden`. That gets focus trap, Escape-to-close, and correct unmount-on-close for free — the old version left every control (including Kill, which can end a running deploy) sitting focusable behind `aria-hidden="true"` once "closed". The single `aria-live` region wrapping the whole card list — which re-announced every card's per-second elapsed-time tick — is replaced by a narrow announcer that fires only on a real status transition, and each card now states its status as visible text next to the icon (previously icon-only + border color, and the icon is `aria-hidden`).

## Confirming the issue against the code

The issue's framing held up against the source in every case I checked (button-based resize handles, missing `tabIndex` on both scrollers, no `screenReaderMode`, the drawer's `aria-hidden` toggle). Two things I found beyond its framing:

1. **The drawer's focus-restore-on-close bug has a different root cause than the other four dialogs.** The issue names `environmentDialogThunks.ts`, `globalConfigThunks.ts`, `manageDialogThunks.ts`, and `tenantDialogThunks.ts` as calling `focusTerminalSoon()` on close instead of returning focus to the invoking control (confirmed — I reproduced it live against `GlobalConfigDialogView`, Escape lands focus on the terminal's hidden textarea). The activity drawer isn't in that list and doesn't call `focusTerminalSoon()`, but Escape still didn't return focus to the launcher — it landed on `document.body`. The actual cause: the launcher button sits inside a `Tooltip`/`TooltipTrigger`, which leaves Radix's own "capture whatever was focused before open" logic with the wrong (or no) element by the time the dialog's `FocusScope` mounts. Fixed by threading the launcher's ref through explicitly (`ActivityQueueLauncher` → `ActivityQueueDrawer`'s `restoreFocusRef`) rather than trusting the implicit capture.
2. **A pre-existing, unrelated build break** was blocking the mandatory verify-in-the-real-app step: `erun-ui/build.sh`'s `cd frontend && yarn install --frozen-lockfile` resolves against `erun-ui/frontend/yarn.lock` — a lockfile left over from before #1250 added the root Yarn workspace, now stale relative to the root lockfile that actually hoists dependencies. Running it silently dropped `radix-ui` from `node_modules` and broke every desktop build (`Cannot find module 'radix-ui'` across every file that imports it, including the pre-existing `components/ui/dialog.tsx`). Fixed by installing from the workspace root first. I did **not** delete the stale `erun-ui/frontend/yarn.lock` (or `erun-console/yarn.lock`, which has the same latent problem) since removing a lockfile is out of bounds for this change — flagging it here as a real follow-up.

## Scope not included

The issue explicitly separates "friction, not a block" (item 4: no keyboard accelerators, no skip-link to the terminal, and the four dialogs above throwing focus to the terminal instead of the invoking control) from the three class-blocking surfaces this PR fixes. That's a materially different, wider-reaching body of work (new Wails menu/accelerator wiring, four separate thunk modules) and is left for a follow-up.

## How I verified this

- Reproduced the bug on unmodified `main` first: confirmed via source read (no `tabIndex` on either diff scroller, `ResizeHandle` is a bare `<button onMouseDown>`, no `screenReaderMode` in the `Terminal` constructor, `ActivityQueueDrawer` toggles `aria-hidden` on a permanently-mounted `<div>`) and live, by driving `GlobalConfigDialogView`'s Escape-close in the running headless app and watching focus land on the terminal.
- New Playwright specs assert real keyboard interaction, not just markup: `a11y-diff-panel.spec.ts` clicks/Tabs between the diff region and a hunk region and checks actual DOM focus, presses arrow keys on the resize handle and checks both `aria-valuenow` and the underlying `--review-width` CSS var moved, and computes the OKLCH→relative-luminance contrast ratio for `--ring` directly (no rgb() resolution needed — the browser preserves the `oklch()` notation, so the ratio is computed from lightness alone since these tokens are all achromatic). `a11y-activity-drawer.spec.ts` drives real Escape/close and asserts the dialog is *unmounted* (not just hidden) and focus lands back on the launcher, and drives a real status transition through the live region. `a11y-terminal.spec.ts` asserts the host's role/name and that xterm's accessibility tree DOM actually exists. All three files add `@axe-core/playwright` scans scoped to the specific rules the issue named (`scrollable-region-focusable`, `aria-hidden-focus`) rather than whole-page scans, so they track this surface's own regressions without flagging unrelated pre-existing findings elsewhere in the app.
- Proved the resize-handle test fails without the fix: while building it I hit exactly the bug it guards — a native `<button>` with `role="separator"` failed jsx-a11y's `no-interactive-element-to-noninteractive-role`/`no-noninteractive-element-interactions` rules, which is the same reason the original code couldn't just add `role`+keydown to the existing `<button>`. Switching the element to a plain `<div role="slider">` is what a correct fix requires, and is exactly what makes both the lint rule and the WCAG requirement pass together.
- Full local Playwright suite (`./playwright/run.sh`, 198 tests) green on two full runs. One test (`sidebar-env-idle-clears-latch.spec.ts`, unrelated to any file this PR touches) failed once in a three-hour multi-agent-shared-pod run under load; it passed in isolation and on a second full run, and its own comments document a 20s-real-backend-sweep-paced timeout budget already tuned for exactly this kind of variance — logged here for visibility, not claimed as fixed.
- `go test ./...` for `erun-ui` (plain and under the stripped `PATH=/usr/local/go/bin:/usr/bin:/bin`) and `golangci-lint run ./...` both clean. No Go source changed in this PR.
- `erun-ui/frontend`: `yarn typecheck`, `yarn lint`, `yarn format:check`, `yarn build`, `yarn test` (103 unit tests) all clean. `yarn shadcn:check` clean against the committed tree.
- `erun-ui/playwright`: `yarn typecheck`, `yarn lint`, `yarn format:check` clean.
- `eslint.config.mjs` gained one rule-configuration line (not a downgrade — the rule stays `error`): `jsx-a11y/no-noninteractive-tabindex` now allows `role="region"` in its `roles` allowlist, which is the schema's own documented extension point for exactly this case — there is no ARIA role the plugin classifies as "interactive" for a scrollable content region, yet WCAG 2.1.1 requires one to be in the tab order.

## Not verified

- Real screen-reader output (VoiceOver/NVDA/Orca) — the harness has no screen-reader driver. The closest available signal is asserting the actual DOM nodes a screen reader would read from exist (xterm's accessibility tree, the narrow live-region announcer's text) and running axe's automated ruleset, both covered above.
- macOS/Windows-specific keyboard behavior — validated in the headless Chromium harness only, consistent with how the rest of this suite validates the desktop frontend.

Closes #1215