### PR TITLE
Carry the cause of a failure through to the surface that reports it

### DIFF
--- a/erun-common/deploy_worktree_adoption.go
+++ b/erun-common/deploy_worktree_adoption.go
@@ -89,7 +89,7 @@ func worktreeClaimExists(args []string) (bool, error) {
 		return true, nil
 	}
 	message := strings.TrimSpace(string(output))
-	if kubernetesResourceNotFound(message) {
+	if KubernetesResourceNotFound(message) {
 		return false, nil
 	}
 	if message == "" {

--- a/erun-common/kubernetes_namespace.go
+++ b/erun-common/kubernetes_namespace.go
@@ -368,7 +368,7 @@ func kubernetesNamespaceExists(contextName, namespace string) (bool, error) {
 	}
 
 	message := strings.TrimSpace(string(output))
-	if kubernetesResourceNotFound(message) {
+	if KubernetesResourceNotFound(message) {
 		return false, nil
 	}
 	if message == "" {
@@ -377,9 +377,12 @@ func kubernetesNamespaceExists(contextName, namespace string) (bool, error) {
 	return false, fmt.Errorf("failed to check kubernetes namespace %q in context %q: %w: %s", namespace, contextName, err, message)
 }
 
-// kubernetesResourceNotFound matches kubectl's absent-resource message for any
-// kind, so a caller can tell "not there" apart from "could not ask".
-func kubernetesResourceNotFound(message string) bool {
+// KubernetesResourceNotFound matches kubectl's absent-resource message for any
+// kind, so a caller can tell "not there" apart from "could not ask". Exported
+// so callers outside this package (erun-ui's out-of-pod health probes) can
+// make the same distinction instead of collapsing every kubectl failure to a
+// plain negative.
+func KubernetesResourceNotFound(message string) bool {
 	message = strings.ToLower(strings.TrimSpace(message))
 	return strings.Contains(message, "notfound") || strings.Contains(message, "not found")
 }

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -2119,6 +2119,40 @@ func TestDeploy(t *testing.T) {
 		golden.Equal(t, "deploy/real_run_via_stubs", normalize.Apply(result.Combined))
 	})
 
+	t.Run("real_run_failure_shows_deploy_failed_header_at_default_verbosity", func(t *testing.T) {
+		// A report claimed the "==> Deploy failed tenant/env: reason" header
+		// (activityDeployFailedLineRe's contract in the desktop) went through
+		// ctx.Trace and was invisible below -vv, making the parser dead code.
+		// That does not hold against this codebase: common.Context.Trace
+		// has aliased Logger.Info (visible at default verbosity; only
+		// TraceCommand's raw argv is gated to -vv) since the primitives split in
+		// #559, well before this issue was filed. This scenario locks that
+		// contract in — the header must appear at default verbosity (no
+		// --dry-run, no -v/-vv) on a real helm failure — as a regression guard,
+		// not a fix. A whole-output golden is deliberately not used here: the
+		// helm stub's stderr capture through cmd.Run()'s buffer is not always
+		// flushed by the time the process exits, so the detail after "reason:"
+		// is not reliably reproducible; the header itself is.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinary(t, stubs, "kubectl", "")
+		fixture.StubBinaryAdvanced(t, stubs, "helm", fixture.StubBinarySpec{
+			Stderr:   "Error: UPGRADE FAILED: post-upgrade hooks failed: timed out waiting for the condition",
+			ExitCode: 1,
+		})
+		fixture.StubBinary(t, stubs, "docker", "")
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl", "helm", "docker")...)
+		result := erun.Run(t, []string{"deploy", "team", "dev", "--version", "1.0.0"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit for a failing helm upgrade, got 0:\n%s", result.Combined)
+		}
+		if !strings.Contains(result.Combined, "==> Deploy failed team/dev:") {
+			t.Fatalf("expected the header at default verbosity (no -vv), got:\n%s", result.Combined)
+		}
+	})
+
 	t.Run("real_run_persists_runtime_version_and_registry_to_env_config", func(t *testing.T) {
 		// Regression: `erun deploy --version X` updates helm's release
 		// appVersion but used to leave EnvConfig.RuntimeVersion at the

--- a/erun-ui/activity_queue.go
+++ b/erun-ui/activity_queue.go
@@ -278,31 +278,35 @@ func (s *activityQueueStore) updateContainers(id string, containers []activityQu
 	s.notifyLocked(snapshot)
 }
 
-// recordOutputLine buffers command output for the active entry matching
+// recordOutputLine buffers command output for every active entry matching
 // (tenant, environment), feeding entry.Detail if that entry later fails. A
-// no-op when nothing matches: output before the entry registers (e.g. before
-// "==> Deploying") or after it finishes is not failure context.
+// no-op when nothing matches: output before any entry registers (e.g. before
+// "==> Deploying") or after all of them finish is not failure context.
+//
+// A caller cannot always name which command a given line belongs to (the
+// build/push/deploy trace lines a subprocess or PTY interleaves are matched
+// after the fact, not before), so this buffers into every active entry for
+// the tenant/env rather than picking one arbitrarily. Normally only one entry
+// is active at a time, so this is a no-op difference; when a build and a
+// deploy are briefly active together for the same env, both get the shared
+// context rather than the ambiguous single pick silently attaching it to the
+// wrong one (the same map-iteration-order class of bug findActive had).
 func (s *activityQueueStore) recordOutputLine(tenant, environment, line string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	id := ""
-	for _, entry := range s.active {
-		if entry.Tenant == tenant && entry.Environment == environment {
-			id = entry.ID
-			break
-		}
-	}
-	if id == "" {
-		return
-	}
 	if len(line) > activityQueueOutputLineMaxChars {
 		line = line[:activityQueueOutputLineMaxChars]
 	}
-	buf := append(s.outputByID[id], line)
-	if len(buf) > activityQueueOutputBufferLines {
-		buf = buf[len(buf)-activityQueueOutputBufferLines:]
+	for _, entry := range s.active {
+		if entry.Tenant != tenant || entry.Environment != environment {
+			continue
+		}
+		buf := append(s.outputByID[entry.ID], line)
+		if len(buf) > activityQueueOutputBufferLines {
+			buf = buf[len(buf)-activityQueueOutputBufferLines:]
+		}
+		s.outputByID[entry.ID] = buf
 	}
-	s.outputByID[id] = buf
 }
 
 // finish moves an active entry into history. It is idempotent — returning false

--- a/erun-ui/activity_queue_app.go
+++ b/erun-ui/activity_queue_app.go
@@ -103,11 +103,19 @@ func (a *App) FindActiveDeployForSelection(selection uiSelection) activityQueueE
 	return activityQueueEntry{}
 }
 
+// finishActivityTracking finalizes the active "deploy" entry for the
+// selection. Both callers observe a deploy-failure trace line that carries no
+// tenant/env (a bare "==> Deploy failed after <elapsed>", or a
+// "==> Deployed"/"==> Deploy failed" line finishDeployByTenantEnv could not
+// parse tenant/env out of), so the command is always "deploy" here — keyed by
+// command, like finishCommandBySelection, rather than plain findActive, whose
+// Go map iteration order picks an arbitrary entry when a build and a deploy
+// are both active for the same tenant/env — the wrong card finalizing.
 func (a *App) finishActivityTracking(selection uiSelection, status activityQueueStatus, errMsg string) {
 	if a.activityQueue == nil {
 		return
 	}
-	entry, ok := a.activityQueue.findActive(strings.TrimSpace(selection.Tenant), strings.TrimSpace(selection.Environment))
+	entry, ok := a.activityQueue.findActiveByCommand("deploy", strings.TrimSpace(selection.Tenant), strings.TrimSpace(selection.Environment))
 	if !ok {
 		return
 	}
@@ -364,6 +372,22 @@ var (
 	activityPushFailedLineRe = regexp.MustCompile(`^==> Push failed\b`)
 )
 
+// activityFailureElapsedClauseRe strips the trailing " after <duration>"
+// clause the build/push/release/deploy failure traces carry (e.g. "after
+// 3m12s"). It is timing information for the log, not part of what failed.
+var activityFailureElapsedClauseRe = regexp.MustCompile(`\s+after\s+\S+\s*$`)
+
+// cleanActivityFailureLine turns a raw `==> ... failed [after <elapsed>]`
+// trace line into a short human label for entry.Error — e.g. "==> Build
+// failed after 3m12s" becomes "Build failed". The raw marker is still fully
+// captured in entry.Detail via recordOutputLine; this only cleans the
+// one-line summary the activity card headlines.
+func cleanActivityFailureLine(line string) string {
+	cleaned := strings.TrimPrefix(strings.TrimSpace(line), "==> ")
+	cleaned = activityFailureElapsedClauseRe.ReplaceAllString(cleaned, "")
+	return strings.TrimSpace(cleaned)
+}
+
 // newActivityTraceLineHandler scans PTY output for trace lines emitted by
 // erun deploy and updates the activity queue accordingly.
 //
@@ -401,13 +425,24 @@ func newActivityTraceLineHandler(app *App, selection uiSelection, kind sessionKi
 	initTraceHonored := kind == sessionKindLocal
 	return func(line string) {
 		line = strings.TrimSpace(line)
+		// Buffer every line for the active entry before dispatching it, so the
+		// "==> Deploy failed"/"==> Build failed" line that finalizes the entry
+		// (and the tool output preceding it) is already captured when finish()
+		// snapshots the buffer into entry.Detail. This must run for every caller
+		// of this handler, not just the PTY reader — a subprocess-captured
+		// orchestration (no PTY involved) has no other path into Detail, and
+		// without it the failed card shows only the raw "==> Build failed after
+		// 3m12s" marker with the actual compiler/tool error nowhere to be found.
+		if app.activityQueue != nil {
+			app.activityQueue.recordOutputLine(selection.Tenant, selection.Environment, line)
+		}
 		switch {
 		case app.handleDeployTraceLine(selection, line):
 		case initTraceHonored && app.handleInitTraceLine(selection, line):
 		case app.handleCommandTraceLine(selection, line):
 		case app.handleDoctorTraceLine(selection, line):
 		case failedRe.MatchString(line):
-			app.finishActivityTracking(selection, activityQueueStatusFailed, line)
+			app.finishActivityTracking(selection, activityQueueStatusFailed, cleanActivityFailureLine(line))
 		case errorRe.MatchString(line):
 			app.captureActivityErrorIfRunning(selection, line)
 		}
@@ -489,7 +524,7 @@ func (a *App) handleInitTraceLine(selection uiSelection, line string) bool {
 		return true
 	}
 	if match := activityInitFailedLineRe.FindStringSubmatch(line); match != nil {
-		a.finishInitByTenantEnv(match[1], match[2], activityQueueStatusFailed, line)
+		a.finishInitByTenantEnv(match[1], match[2], activityQueueStatusFailed, cleanActivityFailureLine(line))
 		a.emitEnvironmentInitFailed(match[1], match[2])
 		return true
 	}
@@ -509,7 +544,7 @@ func (a *App) handleCommandTraceLine(selection uiSelection, line string) bool {
 		return true
 	}
 	if activityBuildFailedLineRe.MatchString(line) {
-		a.finishCommandBySelection(selection, "build", activityQueueStatusFailed, line)
+		a.finishCommandBySelection(selection, "build", activityQueueStatusFailed, cleanActivityFailureLine(line))
 		return true
 	}
 	if activityReleasingLineRe.MatchString(line) {
@@ -521,7 +556,7 @@ func (a *App) handleCommandTraceLine(selection uiSelection, line string) bool {
 		return true
 	}
 	if activityReleaseFailedLineRe.MatchString(line) {
-		a.finishCommandBySelection(selection, "release", activityQueueStatusFailed, line)
+		a.finishCommandBySelection(selection, "release", activityQueueStatusFailed, cleanActivityFailureLine(line))
 		return true
 	}
 	if activityPushingLineRe.MatchString(line) {
@@ -533,7 +568,7 @@ func (a *App) handleCommandTraceLine(selection uiSelection, line string) bool {
 		return true
 	}
 	if activityPushFailedLineRe.MatchString(line) {
-		a.finishCommandBySelection(selection, "push", activityQueueStatusFailed, line)
+		a.finishCommandBySelection(selection, "push", activityQueueStatusFailed, cleanActivityFailureLine(line))
 		return true
 	}
 	return false
@@ -818,12 +853,33 @@ func (a *App) resolveActivityKubeContext(selection uiSelection, tenant, environm
 	return strings.TrimSpace(envConfig.KubernetesContext)
 }
 
+// activityCommandErrorPriority orders the commands captureActivityErrorIfRunning
+// tries when attaching a bare "Error: ..." line to the entry it belongs to. A
+// generic error line carries no command of its own, so when more than one
+// entry is active for the same tenant/env (e.g. a lingering build entry
+// beside a just-started deploy) the choice must be deterministic — not
+// plain findActive's Go map iteration order, which let a helm failure land on
+// the build card instead of the deploy card roughly half the time. Deploy is
+// checked first because it is the longest-running step and the one most
+// likely still active when a generic tool error line (e.g. "Error: UPGRADE
+// FAILED: ...") appears.
+var activityCommandErrorPriority = []string{"deploy", "push", "build", "release", "init"}
+
 func (a *App) captureActivityErrorIfRunning(selection uiSelection, line string) {
 	if a.activityQueue == nil {
 		return
 	}
-	entry, ok := a.activityQueue.findActive(strings.TrimSpace(selection.Tenant), strings.TrimSpace(selection.Environment))
-	if !ok {
+	tenant := strings.TrimSpace(selection.Tenant)
+	environment := strings.TrimSpace(selection.Environment)
+	var entry activityQueueEntry
+	found := false
+	for _, command := range activityCommandErrorPriority {
+		if e, ok := a.activityQueue.findActiveByCommand(command, tenant, environment); ok {
+			entry, found = e, true
+			break
+		}
+	}
+	if !found {
 		return
 	}
 	if strings.TrimSpace(entry.Error) != "" {
@@ -1026,11 +1082,9 @@ func (a *App) feedActivityTraceFromTerminal(managed *managedTerminal, chunk []by
 	}
 	handler := newActivityTraceLineHandler(a, managed.selection, managed.kind)
 	for _, line := range lines {
-		// Buffer the line for the active entry before dispatching it, so the
-		// "==> Deploy failed" line that finalizes the entry (and the error
-		// output preceding it) is already captured when finish() snapshots
-		// the buffer into entry.Detail.
-		a.activityQueue.recordOutputLine(managed.selection.Tenant, managed.selection.Environment, line)
+		// newActivityTraceLineHandler itself buffers the line into entry.Detail
+		// before dispatching, so every caller (this PTY reader and the
+		// subprocess-captured orchestration path) gets the same Detail capture.
 		handler(line)
 		signalSessionReadyOnLine(managed, line)
 		// The CLI's taken-over notice is a public contract line (see

--- a/erun-ui/activity_queue_app_test.go
+++ b/erun-ui/activity_queue_app_test.go
@@ -397,6 +397,77 @@ func TestActivityTraceLineHandlerFinalizesBuildOnFailure(t *testing.T) {
 	}
 }
 
+// TestActivityTraceLineHandlerRecordsDetailWithoutAPTY locks down that
+// recordOutputLine's only caller used to be the PTY reader
+// (feedActivityTraceFromTerminal), so the desktop's subprocess-captured
+// build/push/deploy orchestration (deploy_orchestration.go, which has no PTY
+// and calls the trace handler directly) never populated entry.Detail. The
+// handler itself must record every line it sees, regardless of caller.
+func TestActivityTraceLineHandlerRecordsDetailWithoutAPTY(t *testing.T) {
+	app := newTestAppForActivityQueue(t)
+	selection := uiSelection{Tenant: "erun", Environment: "local"}
+	handler := newActivityTraceLineHandler(app, selection, sessionKindLocal)
+
+	// Call the handler directly, exactly as runErunCaptured's onLine callback
+	// does for the desktop's orchestrated build — no managedTerminal, no PTY.
+	handler("==> Building")
+	handler("./main.go:12:2: undefined: fmt.Sprintfff")
+	handler("==> Build failed after 3m12s")
+
+	all := app.activityQueue.list()
+	if len(all) != 1 || all[0].Status != activityQueueStatusFailed {
+		t.Fatalf("expected one failed entry, got %+v", all)
+	}
+	if !strings.Contains(all[0].Detail, "undefined: fmt.Sprintfff") {
+		t.Fatalf("Detail missing the actual compiler error, got %q", all[0].Detail)
+	}
+	if strings.Contains(all[0].Error, "==>") || strings.Contains(all[0].Error, "after 3m12s") {
+		t.Fatalf("Error should be cleaned of the trace marker and elapsed clause, got %q", all[0].Error)
+	}
+}
+
+// TestActivityTraceLineHandlerFinalizesCorrectCardWhenBuildAndDeployBothActive
+// locks down that the wrong card cannot fail: a bare deploy-failure line (no
+// tenant/env, e.g. "==> Deploy failed after 4s") must finalize the deploy
+// entry specifically, never a same-tenant/env build entry that is still
+// running. Before the fix this used findActive, whose plain map iteration
+// picks an arbitrary entry when both are active — this test is deterministic
+// under the fix (findActiveByCommand) regardless of Go's map iteration order.
+func TestActivityTraceLineHandlerFinalizesCorrectCardWhenBuildAndDeployBothActive(t *testing.T) {
+	app := newTestAppForActivityQueue(t)
+	selection := uiSelection{Tenant: "erun", Environment: "local"}
+	handler := newActivityTraceLineHandler(app, selection, sessionKindLocal)
+
+	handler("==> Building")
+	if _, ok := app.activityQueue.findActiveByCommand("build", "erun", "local"); !ok {
+		t.Fatal("expected an active build entry")
+	}
+	app.activityQueue.start(activityQueueEntry{Command: "deploy", Tenant: "erun", Environment: "local"})
+
+	handler("Error: UPGRADE FAILED: timeout")
+	handler("==> Deploy failed after 4s")
+
+	if _, ok := app.activityQueue.findActiveByCommand("build", "erun", "local"); !ok {
+		t.Fatal("the still-running build entry must not have been finalized by the deploy failure")
+	}
+	if _, ok := app.activityQueue.findActiveByCommand("deploy", "erun", "local"); ok {
+		t.Fatal("the deploy entry should have been finalized")
+	}
+	all := app.activityQueue.list()
+	var deployEntry *activityQueueEntry
+	for i := range all {
+		if all[i].Command == "deploy" {
+			deployEntry = &all[i]
+		}
+	}
+	if deployEntry == nil || deployEntry.Status != activityQueueStatusFailed {
+		t.Fatalf("expected a failed deploy entry in history, got %+v", all)
+	}
+	if !strings.Contains(deployEntry.Error, "UPGRADE FAILED") && !strings.Contains(deployEntry.Detail, "UPGRADE FAILED") {
+		t.Fatalf("expected the captured tool error on the deploy entry, got %+v", deployEntry)
+	}
+}
+
 func TestActivityTraceLineHandlerSkipsBuildWithoutSelection(t *testing.T) {
 	// A generic Local shell at the repo root has no tenant/env bound to
 	// it. Build traces observed there must NOT register an entry — a

--- a/erun-ui/deploy_orchestration.go
+++ b/erun-ui/deploy_orchestration.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -139,21 +140,36 @@ func (a *App) maybeStartDeployOrchestration(selection uiSelection, force bool) (
 	return startSessionResult{Selection: selection, Orchestrated: true}, true
 }
 
+// deployOrchestrationFailureReasonMaxLen caps the single-line reason surfaced
+// in the failure notification; the full captured output is still available in
+// the activity card's Detail (see recordOutputLine).
+const deployOrchestrationFailureReasonMaxLen = 300
+
 // deployOrchestrationFailureReason condenses a background build/push/deploy error
-// into a single-line notification reason.
+// into a single-line notification reason. For an *erunCommandError it drops
+// erun's own "==> ..." progress markers — captured stderr's first line is
+// always one, since erun routes Info to stderr, and it carries no diagnostic
+// value — and keeps the actual compiler/tool output that follows, which used
+// to be discarded by truncating to that first line.
 func deployOrchestrationFailureReason(err error) string {
 	if err == nil {
 		return ""
 	}
-	msg := strings.TrimSpace(err.Error())
-	if i := strings.IndexByte(msg, '\n'); i >= 0 {
-		msg = strings.TrimSpace(msg[:i])
+	var cmdErr *erunCommandError
+	if errors.As(err, &cmdErr) {
+		return truncateFailureReasonTail(cmdErr.meaningfulReason(), deployOrchestrationFailureReasonMaxLen)
 	}
-	const maxLen = 300
-	if len(msg) > maxLen {
-		msg = msg[:maxLen] + "..."
+	return truncateFailureReasonTail(strings.TrimSpace(err.Error()), deployOrchestrationFailureReasonMaxLen)
+}
+
+// truncateFailureReasonTail keeps the tail of an over-long reason rather than
+// the head: the actionable content (the actual error) sits at the end of
+// captured tool output, after any preceding log noise.
+func truncateFailureReasonTail(msg string, maxLen int) string {
+	if len(msg) <= maxLen {
+		return msg
 	}
-	return msg
+	return "..." + msg[len(msg)-maxLen:]
 }
 
 // runErunCaptured runs `erun <args>` in dir and returns its captured stdout. erun
@@ -199,12 +215,52 @@ func runErunCaptured(ctx context.Context, cliPath, dir string, onLine func(strin
 	<-done
 
 	if err := cmd.Wait(); err != nil {
-		if detail := strings.TrimSpace(lastErr.String()); detail != "" {
-			return stdoutBuf.String(), fmt.Errorf("erun %s: %w: %s", args[0], err, detail)
+		return stdoutBuf.String(), &erunCommandError{
+			Command: args[0],
+			Err:     err,
+			Detail:  strings.TrimSpace(lastErr.String()),
 		}
-		return stdoutBuf.String(), fmt.Errorf("erun %s: %w", args[0], err)
 	}
 	return stdoutBuf.String(), nil
+}
+
+// erunCommandError reports a failed `erun <Command>` subprocess invocation
+// alongside its full captured stderr, so a caller can pick the meaningful
+// content out of Detail (see meaningfulReason) instead of string-parsing an
+// already-flattened error message.
+type erunCommandError struct {
+	Command string
+	Err     error
+	Detail  string
+}
+
+func (e *erunCommandError) Error() string {
+	if e.Detail == "" {
+		return fmt.Sprintf("erun %s: %v", e.Command, e.Err)
+	}
+	return fmt.Sprintf("erun %s: %v: %s", e.Command, e.Err, e.Detail)
+}
+
+func (e *erunCommandError) Unwrap() error { return e.Err }
+
+// meaningfulReason drops erun's own "==> ..." progress markers from Detail —
+// each one is routed to stderr via Info — and joins what remains, which is
+// the actual compiler/tool output a build/push/deploy failure produced. Falls
+// back to the bare exec error when Detail carried nothing but markers (e.g. a
+// process that exited non-zero before producing any tool output).
+func (e *erunCommandError) meaningfulReason() string {
+	var kept []string
+	for _, line := range strings.Split(e.Detail, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "==> ") {
+			continue
+		}
+		kept = append(kept, trimmed)
+	}
+	if len(kept) == 0 {
+		return fmt.Sprintf("erun %s: %v", e.Command, e.Err)
+	}
+	return fmt.Sprintf("erun %s: %v: %s", e.Command, e.Err, strings.Join(kept, " "))
 }
 
 func scanErunStderr(stderrPipe io.Reader, onLine func(string), lastErr *strings.Builder) {

--- a/erun-ui/deploy_orchestration_test.go
+++ b/erun-ui/deploy_orchestration_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	eruncommon "github.com/sophium/erun/erun-common"
@@ -35,6 +37,51 @@ func TestDeployNeedsBuildOrchestration(t *testing.T) {
 					tc.result.EnvConfig.Type, tc.version, tc.force, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestDeployOrchestrationFailureReasonKeepsCompilerErrorNotTraceMarker locks
+// down that erun routes Info to stderr, so the captured stderr's first line
+// is always a progress marker like "==> Building" — never the actual
+// failure. The reason surfaced in the failure notification must keep the
+// compiler/tool error that follows it, not the marker.
+func TestDeployOrchestrationFailureReasonKeepsCompilerErrorNotTraceMarker(t *testing.T) {
+	err := &erunCommandError{
+		Command: "build",
+		Err:     errors.New("exit status 1"),
+		Detail:  "==> Building\n./main.go:12:2: undefined: fmt.Sprintfff",
+	}
+	got := deployOrchestrationFailureReason(err)
+	if strings.Contains(got, "==> Building") {
+		t.Fatalf("reason still carries the trace marker instead of the real error: %q", got)
+	}
+	if !strings.Contains(got, "undefined: fmt.Sprintfff") {
+		t.Fatalf("reason dropped the compiler error entirely: %q", got)
+	}
+}
+
+// TestDeployOrchestrationFailureReasonFallsBackWithNoDetail covers a process
+// that exited non-zero before producing any captured stderr at all.
+func TestDeployOrchestrationFailureReasonFallsBackWithNoDetail(t *testing.T) {
+	err := &erunCommandError{Command: "deploy", Err: errors.New("exit status 1")}
+	got := deployOrchestrationFailureReason(err)
+	if !strings.Contains(got, "erun deploy") || !strings.Contains(got, "exit status 1") {
+		t.Fatalf("reason = %q, want it to name the command and the exec error", got)
+	}
+}
+
+// TestDeployOrchestrationFailureReasonTruncatesTail covers the length cap:
+// the cap must keep the tail (where the actual error sits) rather than the
+// head, mirroring the marker-stripping behavior above.
+func TestDeployOrchestrationFailureReasonTruncatesTail(t *testing.T) {
+	long := strings.Repeat("x", 400) + " THE_REAL_ERROR_AT_THE_END"
+	err := &erunCommandError{Command: "build", Err: errors.New("exit status 1"), Detail: long}
+	got := deployOrchestrationFailureReason(err)
+	if !strings.Contains(got, "THE_REAL_ERROR_AT_THE_END") {
+		t.Fatalf("truncated reason dropped the tail content: %q", got)
+	}
+	if len(got) > deployOrchestrationFailureReasonMaxLen+3 {
+		t.Fatalf("reason not capped: len=%d, got=%q", len(got), got)
 	}
 }
 

--- a/erun-ui/environment_health.go
+++ b/erun-ui/environment_health.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os/exec"
 	"strings"
 
 	eruncommon "github.com/sophium/erun/erun-common"
@@ -110,16 +112,29 @@ func (a *App) runtimeDeployedHealthCheck(tenant, environment string, config erun
 
 // checkRuntimeDeployed reports whether a pod running the erun-devops runtime
 // container exists in the env's namespace on the given context. kubectl exits
-// non-zero when the namespace or cluster is absent — the not-deployed state —
-// which is treated as "not deployed", not an error, mirroring the convention
-// loadClusterRegistry uses for a missing Service.
+// non-zero both when the namespace is genuinely absent (the not-deployed
+// state, mirroring the convention loadClusterRegistry uses for a missing
+// Service) and when the probe itself could not be answered — a VPN down, a
+// rotated token, an unreachable API server. Collapsing both to a plain "not
+// deployed" hands the operator a Deploy button that will fail identically,
+// and the health check's own honest "could not check" branch
+// (runtimeDeployedHealthCheck's healthCheckStatusUnknown) never fires. Only a
+// genuine NotFound is a negative answer; anything else is propagated as an
+// error.
 func checkRuntimeDeployed(ctx context.Context, kubeContext, tenant, environment string) (bool, error) {
 	namespace := eruncommon.KubernetesNamespaceName(tenant, environment)
 	output, err := kubectlJSON(ctx, kubeContext,
 		"get", "pods", "-n", namespace,
 		"-o", `jsonpath={range .items[*]}{range .spec.containers[*]}{.name}{"\n"}{end}{end}`)
 	if err != nil {
-		return false, nil
+		// A missing kubectl binary reads as "not found" text too (`exec:
+		// "kubectl": executable file not found in $PATH`), which would
+		// otherwise be misclassified as an absent namespace rather than the
+		// "could not check" it actually is.
+		if !errors.Is(err, exec.ErrNotFound) && eruncommon.KubernetesResourceNotFound(err.Error()) {
+			return false, nil
+		}
+		return false, err
 	}
 	for _, name := range strings.Split(string(output), "\n") {
 		if strings.TrimSpace(name) == eruncommon.DevopsComponentName {

--- a/erun-ui/environment_health_test.go
+++ b/erun-ui/environment_health_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// TestRuntimeDeployedHealthCheckPropagatesProbeError locks down that a real
+// probe failure (VPN down, rotated token, unreachable API server) must land
+// on the honest "could not check" branch, not the "not deployed" negative
+// that hands the operator a Deploy button which would fail identically.
+func TestRuntimeDeployedHealthCheckPropagatesProbeError(t *testing.T) {
+	app := &App{
+		deps: erunUIDeps{
+			checkRuntimeDeployed: func(context.Context, string, string, string) (bool, error) {
+				return false, errors.New("Unable to connect to the server: dial tcp: i/o timeout")
+			},
+		},
+	}
+	config := eruncommon.EnvConfig{KubernetesContext: "team-context"}
+	check := app.runtimeDeployedHealthCheck("team", "dev", config)
+	if check.Status != healthCheckStatusUnknown {
+		t.Fatalf("status = %q, want %q (unknown/could-not-check)", check.Status, healthCheckStatusUnknown)
+	}
+	if check.Fix == healthCheckFixDeploy {
+		t.Fatal("a probe failure must not offer a Deploy fix — the deploy would fail identically")
+	}
+	if !strings.Contains(check.Detail, "Could not check") {
+		t.Fatalf("detail should say the check could not run, got %q", check.Detail)
+	}
+}
+
+// TestRuntimeDeployedHealthCheckReportsNotDeployedOnGenuineNotFound covers the
+// legitimate negative: a real NotFound (no such namespace) still reports "not
+// deployed" with the Deploy fix offered.
+func TestRuntimeDeployedHealthCheckReportsNotDeployedOnGenuineNotFound(t *testing.T) {
+	app := &App{
+		deps: erunUIDeps{
+			checkRuntimeDeployed: func(context.Context, string, string, string) (bool, error) {
+				return false, nil
+			},
+		},
+	}
+	config := eruncommon.EnvConfig{KubernetesContext: "team-context"}
+	check := app.runtimeDeployedHealthCheck("team", "dev", config)
+	if check.Status != healthCheckStatusError {
+		t.Fatalf("status = %q, want %q", check.Status, healthCheckStatusError)
+	}
+	if check.Fix != healthCheckFixDeploy {
+		t.Fatalf("expected the Deploy fix for a genuine not-deployed state, got %q", check.Fix)
+	}
+}
+
+// TestCheckRuntimeDeployedDistinguishesNotFoundFromRealErrors exercises the
+// package-level probe function directly against kubectl's actual message
+// shapes, via the ERUN_KUBECTL_BIN seam.
+func TestCheckRuntimeDeployedDistinguishesNotFoundFromRealErrors(t *testing.T) {
+	cases := []struct {
+		name       string
+		stubStderr string
+		stubExit   int
+		wantErr    bool
+	}{
+		{"namespace not found is a negative, not an error", `Error from server (NotFound): namespaces "team-dev" not found`, 1, false},
+		{"server unreachable propagates as an error", "Unable to connect to the server: dial tcp: i/o timeout", 1, true},
+		{"forbidden propagates as an error", `Error from server (Forbidden): pods is forbidden: User "x" cannot list resource "pods"`, 1, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stubKubectlForTest(t, tc.stubStderr, tc.stubExit)
+			deployed, err := checkRuntimeDeployed(context.Background(), "some-context", "team", "dev")
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected an error, got deployed=%v", deployed)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error (a negative, not a failure), got %v", err)
+			}
+			if !tc.wantErr && deployed {
+				t.Fatal("expected not-deployed (false), got true")
+			}
+		})
+	}
+}
+
+// stubKubectlForTest replaces the kubectl binary on PATH for the duration of
+// the test with a script that writes stderrMsg and exits exitCode.
+// environment_health.go's kubectlJSON shells out to "kubectl" directly (not
+// through an ERUN_KUBECTL_BIN seam), so the stub must sit on PATH.
+func stubKubectlForTest(t *testing.T, stderrMsg string, exitCode int) {
+	t.Helper()
+	dir := t.TempDir()
+	script := fmt.Sprintf("#!/bin/sh\necho %s 1>&2\nexit %d\n", shellQuote(stderrMsg), exitCode)
+	path := dir + "/kubectl"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub kubectl: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}

--- a/erun-ui/frontend/src/app/TerminalController.ts
+++ b/erun-ui/frontend/src/app/TerminalController.ts
@@ -10,7 +10,7 @@ import { decodeBase64Bytes } from './clipboard';
 import { readError } from './errors';
 import { refreshIdleStatus } from './idleThunks';
 import type { MountElements, TerminalDataDisposable, TerminalWriteData } from './model';
-import { showTerminalMessage } from './notificationThunks';
+import { showTerminalError } from './notificationThunks';
 import { scrollSelectedTreeNodeIntoView, visibleDiffPath } from './reviewDiffNavigation';
 import { setSelectedDiffPath } from './slices/reviewSlice';
 import { store } from './store';
@@ -186,7 +186,7 @@ export class TerminalController {
     }
     this.pasteHandler = (event: ClipboardEvent) => {
       void this.clipboard.handlePaste(event).catch((error: unknown) => {
-        store.dispatch(showTerminalMessage(readError(error)));
+        store.dispatch(showTerminalError(readError(error)));
       });
     };
     root.addEventListener('paste', this.pasteHandler, true);
@@ -237,7 +237,7 @@ export class TerminalController {
       (data) =>
         SendSessionInput(this.writeSources.current(store.getState().terminal.sessionId), data),
       (error) => {
-        store.dispatch(showTerminalMessage(readError(error)));
+        store.dispatch(showTerminalError(readError(error)));
       },
       // Suppress replies to queries re-parsed from a replayed display buffer:
       // the asking tool consumed the live reply long ago, so a second reply
@@ -246,7 +246,7 @@ export class TerminalController {
     );
     this.terminalDataDisposable = this.terminal.onData((data) => {
       SendSessionInput(store.getState().terminal.sessionId, data).catch((error: unknown) => {
-        store.dispatch(showTerminalMessage(readError(error)));
+        store.dispatch(showTerminalError(readError(error)));
       });
     });
 

--- a/erun-ui/frontend/src/app/bootThunks.ts
+++ b/erun-ui/frontend/src/app/bootThunks.ts
@@ -3,7 +3,7 @@ import type { UITenant } from '@/types';
 import { stateApi } from './api/stateApi';
 import { planEnvActivitySeed } from './envActivitySeed';
 import { readError } from './errors';
-import { showTerminalMessage } from './notificationThunks';
+import { showTerminalError, showTerminalMessage } from './notificationThunks';
 import { loadOrchestrators, restoreOpenOrchestrators } from './orchestratorThunks';
 import { openSelection } from './sessionThunks';
 import { setEnvActivityForEnv } from './slices/envStatusSlice';
@@ -87,7 +87,7 @@ export const boot = (): AppThunk<Promise<void>> => async (dispatch, getState) =>
 
     dispatch(showTerminalMessage(noSelectionBootMessage(getState().tenants.tenants)));
   } catch (error: unknown) {
-    dispatch(showTerminalMessage(readError(error)));
+    dispatch(showTerminalError(readError(error)));
   }
 };
 

--- a/erun-ui/frontend/src/app/closeEnvironmentThunks.ts
+++ b/erun-ui/frontend/src/app/closeEnvironmentThunks.ts
@@ -2,7 +2,7 @@ import type { UISelection } from '@/types';
 
 import { CloseEnvironmentSessions } from '../../wailsjs/go/main/App';
 import { readError } from './errors';
-import { showTerminalMessage } from './notificationThunks';
+import { showTerminalError } from './notificationThunks';
 import { setAIBusyForEnv } from './slices/aiActivitySlice';
 import { setSelected } from './slices/selectionSlice';
 import { clearEnvOpening } from './slices/sessionsSlice';
@@ -27,7 +27,7 @@ export const closeEnvironment =
     try {
       await CloseEnvironmentSessions({ tenant, environment });
     } catch (error: unknown) {
-      dispatch(showTerminalMessage(readError(error)));
+      dispatch(showTerminalError(readError(error)));
       return;
     }
     const key = selectionKey({ tenant, environment });

--- a/erun-ui/frontend/src/app/cloudProviderThunks.ts
+++ b/erun-ui/frontend/src/app/cloudProviderThunks.ts
@@ -4,7 +4,7 @@ import { ClipboardSetText } from '../../wailsjs/runtime/runtime';
 import { cloudApi } from './api/cloudApi';
 import { replaceCloudProvider } from './cloudContextState';
 import { readError } from './errors';
-import { showNotification, showTerminalMessage } from './notificationThunks';
+import { showNotification, showTerminalError, showTerminalMessage } from './notificationThunks';
 import { setSidebarCloudAliasBusy } from './slices/sidebarSlice';
 import { setCloudProviders } from './slices/tenantsSlice';
 import type { AppThunk, RootState } from './store';
@@ -60,7 +60,7 @@ export const getPrimaryCloudProviderBearerToken =
     } catch (error) {
       const message = readError(error);
       dispatch(setSidebarCloudAliasBusy({ alias, busy: false, action: '' }));
-      dispatch(showTerminalMessage(message));
+      dispatch(showTerminalError(message));
       dispatch(showNotification('error', message));
     }
   };
@@ -91,7 +91,7 @@ const updatePrimaryCloudProvider =
     } catch (error) {
       const message = readError(error);
       dispatch(setSidebarCloudAliasBusy({ alias, busy: false, action: '' }));
-      dispatch(showTerminalMessage(message));
+      dispatch(showTerminalError(message));
       dispatch(showNotification('error', message));
     }
   };

--- a/erun-ui/frontend/src/app/dialogContextsThunks.ts
+++ b/erun-ui/frontend/src/app/dialogContextsThunks.ts
@@ -95,11 +95,17 @@ export const refreshDialogClusterRegistry =
           useClusterRegistry: deployed,
         }),
       );
-    } catch {
+    } catch (error) {
       if (!getState().environmentDialog.open) {
         return;
       }
-      dispatch(patchEnvironmentDialog({ clusterRegistry: null, useClusterRegistry: false }));
+      dispatch(
+        patchEnvironmentDialog({
+          clusterRegistry: null,
+          useClusterRegistry: false,
+          error: readError(error),
+        }),
+      );
     }
   };
 

--- a/erun-ui/frontend/src/app/environmentDialogThunks.ts
+++ b/erun-ui/frontend/src/app/environmentDialogThunks.ts
@@ -8,7 +8,7 @@ import {
   rememberEnvironmentDialogSelection,
 } from './environmentDialogState';
 import { readError } from './errors';
-import { showTerminalMessage } from './notificationThunks';
+import { showTerminalError } from './notificationThunks';
 import {
   runtimePodConfigToKubernetes,
   runtimeResourceLimitMessage,
@@ -175,7 +175,7 @@ export const submitEnvironmentDialog =
           error: message,
         }),
       );
-      dispatch(showTerminalMessage(message));
+      dispatch(showTerminalError(message));
     }
   };
 

--- a/erun-ui/frontend/src/app/globalConfigThunks.ts
+++ b/erun-ui/frontend/src/app/globalConfigThunks.ts
@@ -22,7 +22,12 @@ import { refreshKubernetesContexts } from './dialogContextsThunks';
 import { readError } from './errors';
 import { refreshIdleStatus } from './idleThunks';
 import type { CloudInitProvider } from './model';
-import { hideTerminalMessage, showNotification, showTerminalMessage } from './notificationThunks';
+import {
+  hideTerminalMessage,
+  showNotification,
+  showTerminalError,
+  showTerminalMessage,
+} from './notificationThunks';
 import { openSelection } from './sessionThunks';
 import { patchGlobalConfigDialog, setGlobalConfigDialog } from './slices/globalConfigDialogSlice';
 import { setIdleCloudContextBusy, setIdleStatus } from './slices/idleSlice';
@@ -158,7 +163,7 @@ export const refreshCloudProviders = (): AppThunk<Promise<void>> => async (dispa
   } catch (error) {
     const message = readError(error);
     dispatch(patchGlobalConfigDialog({ error: message }));
-    dispatch(showTerminalMessage(message));
+    dispatch(showTerminalError(message));
   }
 };
 
@@ -182,7 +187,7 @@ export const refreshCloudContexts = (): AppThunk<Promise<void>> => async (dispat
   } catch (error) {
     const message = readError(error);
     dispatch(patchGlobalConfigDialog({ error: message }));
-    dispatch(showTerminalMessage(message));
+    dispatch(showTerminalError(message));
   }
 };
 
@@ -233,7 +238,7 @@ export const initGlobalCloudContext = (): AppThunk<Promise<void>> => async (disp
         error: message,
       }),
     );
-    dispatch(showTerminalMessage(message));
+    dispatch(showTerminalError(message));
   }
 };
 
@@ -291,7 +296,7 @@ export const toggleIdleCloudContext = (): AppThunk<Promise<void>> => async (disp
     const message = readError(error);
     dispatch(setIdleCloudContextBusy(false));
     dispatch(showNotification('error', message));
-    dispatch(showTerminalMessage(message));
+    dispatch(showTerminalError(message));
   }
 };
 
@@ -340,7 +345,7 @@ const startCloudInitSession =
           error: message,
         }),
       );
-      dispatch(showTerminalMessage(message));
+      dispatch(showTerminalError(message));
     }
   };
 
@@ -397,7 +402,7 @@ export const loginGlobalCloudProvider =
           error: message,
         }),
       );
-      dispatch(showTerminalMessage(message));
+      dispatch(showTerminalError(message));
     }
   };
 
@@ -432,7 +437,7 @@ export const submitGlobalConfig = (): AppThunk<Promise<void>> => async (dispatch
         error: message,
       }),
     );
-    dispatch(showTerminalMessage(message));
+    dispatch(showTerminalError(message));
   }
 };
 
@@ -510,6 +515,6 @@ const updateCloudContextPower =
           error: message,
         }),
       );
-      dispatch(showTerminalMessage(message));
+      dispatch(showTerminalError(message));
     }
   };

--- a/erun-ui/frontend/src/app/manageCloudContextThunks.ts
+++ b/erun-ui/frontend/src/app/manageCloudContextThunks.ts
@@ -3,7 +3,7 @@ import type { UICloudContextStatus } from '@/types';
 import { cloudApi } from './api/cloudApi';
 import { refreshKubernetesContexts } from './dialogContextsThunks';
 import { readError } from './errors';
-import { showTerminalMessage } from './notificationThunks';
+import { showTerminalError, showTerminalMessage } from './notificationThunks';
 import { patchManageDialog } from './slices/manageDialogSlice';
 import type { AppThunk } from './store';
 import { normalizeDialogValue } from './versionSuggestions';
@@ -78,6 +78,6 @@ const updateManageCloudContextPower =
           error: message,
         }),
       );
-      dispatch(showTerminalMessage(message));
+      dispatch(showTerminalError(message));
     }
   };

--- a/erun-ui/frontend/src/app/manageDeleteThunks.ts
+++ b/erun-ui/frontend/src/app/manageDeleteThunks.ts
@@ -4,7 +4,7 @@ import { environmentApi } from './api/environmentApi';
 import { reloadStateAfterEnvironmentChange } from './bootThunks';
 import { readError } from './errors';
 import { closeManageDialog } from './manageDialogThunks';
-import { showTerminalMessage } from './notificationThunks';
+import { showTerminalError, showTerminalFailure, showTerminalMessage } from './notificationThunks';
 import { patchManageDialog, setManageDialog } from './slices/manageDialogSlice';
 import { setSelected } from './slices/selectionSlice';
 import { setSessionId } from './slices/terminalSlice';
@@ -54,6 +54,7 @@ export const submitManageDelete =
       dispatch(setManageDialog(defaultManageDialog()));
       dispatch(setTerminalCopyOutput(''));
       dispatch(setTerminalCopyStatus(''));
+      const deletedLabel = `Deleted ${result.tenant} / ${result.environment}.`;
       const warnings = [
         result.namespaceDeleteError
           ? `Namespace deletion failed: ${result.namespaceDeleteError}`
@@ -64,8 +65,19 @@ export const submitManageDelete =
       ]
         .filter(Boolean)
         .join(' ');
-      const warning = warnings ? ` ${warnings}` : '';
-      dispatch(showTerminalMessage(`Deleted ${result.tenant} / ${result.environment}.${warning}`));
+      // A delete that left a live namespace or cloud context running is a
+      // failure, even though the environment record itself is gone — it must
+      // render as an error with the failure clause visible and a Copy
+      // action, not the plain success pill (which used to append the
+      // warning as an afterthought after the copy buffer had already been
+      // cleared, so there was nothing to copy).
+      if (warnings) {
+        dispatch(
+          showTerminalFailure(deletedLabel, warnings, `${deletedLabel} ${warnings}`, '', null),
+        );
+      } else {
+        dispatch(showTerminalMessage(deletedLabel));
+      }
     } catch (error) {
       const message = readError(error);
       dispatch(
@@ -76,12 +88,6 @@ export const submitManageDelete =
           error: message,
         }),
       );
-      dispatch(
-        setTerminalCopyOutput(
-          `Failed to delete ${selection.tenant} / ${selection.environment}: ${message}`,
-        ),
-      );
-      dispatch(setTerminalCopyStatus(''));
-      dispatch(showTerminalMessage(message));
+      dispatch(showTerminalError(message));
     }
   };

--- a/erun-ui/frontend/src/app/manageDeployComponentsThunks.ts
+++ b/erun-ui/frontend/src/app/manageDeployComponentsThunks.ts
@@ -8,7 +8,7 @@ import {
   toggleDeployComponentName,
 } from './deployComponentsSelection';
 import { readError } from './errors';
-import { showTerminalMessage } from './notificationThunks';
+import { showTerminalError } from './notificationThunks';
 import { runtimePodConfigToKubernetes } from './runtimeResources';
 import { patchManageDialog } from './slices/manageDialogSlice';
 import type { AppState } from './state';
@@ -172,6 +172,6 @@ export const saveManageDeployComponents =
     } catch (error) {
       const message = readError(error);
       dispatch(patchManageDialog({ busy: false, busyAction: '', busyTarget: '', error: message }));
-      dispatch(showTerminalMessage(message));
+      dispatch(showTerminalError(message));
     }
   };

--- a/erun-ui/frontend/src/app/manageDialogThunks.ts
+++ b/erun-ui/frontend/src/app/manageDialogThunks.ts
@@ -20,7 +20,7 @@ import {
   nextPendingRedeploy,
   versionSourceSignature,
 } from './manageDialogHelpers';
-import { showTerminalMessage } from './notificationThunks';
+import { showTerminalError } from './notificationThunks';
 import {
   runtimePodConfigToDisplay,
   runtimePodConfigToKubernetes,
@@ -389,7 +389,7 @@ export const submitManageConfig = (): AppThunk<Promise<void>> => async (dispatch
         error: message,
       }),
     );
-    dispatch(showTerminalMessage(message));
+    dispatch(showTerminalError(message));
   }
 };
 

--- a/erun-ui/frontend/src/app/manageHealthThunks.ts
+++ b/erun-ui/frontend/src/app/manageHealthThunks.ts
@@ -2,7 +2,7 @@ import { environmentApi } from './api/environmentApi';
 import { readError } from './errors';
 import { submitManageDeploy } from './manageDeployThunks';
 import { setManageTab } from './manageDialogThunks';
-import { showTerminalMessage } from './notificationThunks';
+import { showTerminalError } from './notificationThunks';
 import { patchManageDialog } from './slices/manageDialogSlice';
 import type { AppThunk } from './store';
 
@@ -32,7 +32,7 @@ export const checkManageEnvironmentHealth =
       }
       const message = readError(error);
       dispatch(patchManageDialog({ healthLoading: false, error: message }));
-      dispatch(showTerminalMessage(message));
+      dispatch(showTerminalError(message));
     }
   };
 

--- a/erun-ui/frontend/src/app/manageStopThunks.ts
+++ b/erun-ui/frontend/src/app/manageStopThunks.ts
@@ -2,7 +2,7 @@ import type { UIEnvironmentStopResult } from '@/uiLifecycleTypes';
 
 import { environmentApi } from './api/environmentApi';
 import { readError } from './errors';
-import { showTerminalMessage } from './notificationThunks';
+import { showTerminalError, showTerminalMessage } from './notificationThunks';
 import { patchManageDialog } from './slices/manageDialogSlice';
 import type { AppThunk } from './store';
 
@@ -36,7 +36,7 @@ export const submitManageStop = (): AppThunk<Promise<void>> => async (dispatch, 
   } catch (error) {
     const message = readError(error);
     dispatch(patchManageDialog({ busy: false, busyAction: '', busyTarget: '', error: message }));
-    dispatch(showTerminalMessage(message));
+    dispatch(showTerminalError(message));
   }
 };
 

--- a/erun-ui/frontend/src/app/notificationThunks.ts
+++ b/erun-ui/frontend/src/app/notificationThunks.ts
@@ -17,7 +17,14 @@ import {
 import type { AppNotification, TerminalStatusAction } from './state';
 import type { AppThunk } from './store';
 
-let notificationTimer = 0;
+// notificationIdCounter mints a unique id per queued notification within this
+// session so a specific entry's auto-dismiss timer or explicit dismiss click
+// can target it without disturbing sibling entries queued before or after it.
+let notificationIdCounter = 0;
+function nextNotificationId(): string {
+  notificationIdCounter += 1;
+  return `notification-${notificationIdCounter.toString()}`;
+}
 let terminalCopyStatusTimer = 0;
 
 export const showTerminalMessage =
@@ -56,6 +63,21 @@ export const showTerminalFailure =
     dispatch(setTerminalCopyOutput(effectiveCopy));
     dispatch(setTerminalCopyStatus(''));
     dispatch(setRetrySelection(action === 'wait-longer' ? retrySelection : null));
+  };
+
+// showTerminalError is the one-argument shorthand for the common
+// `catch (error) { dispatch(showTerminalError(readError(error))) }` shape.
+// Dozens of catch blocks used to call showTerminalMessage (kind: 'info',
+// unconditional) with the caught error's text, so failures rendered as a
+// neutral grey pill — polite aria-live, no role="alert", and no Copy action
+// (the terminal copy buffer only gets set by showTerminalFailure). This
+// wraps showTerminalFailure with the defaults that shape needs: no detail
+// beyond the message, the message itself as the copyable text, and no retry
+// action.
+export const showTerminalError =
+  (message: string): AppThunk =>
+  (dispatch) => {
+    dispatch(showTerminalFailure(message, '', message, '', null));
   };
 
 function joinMessageForCopy(message: string, detail: string): string {
@@ -107,9 +129,10 @@ export const showNotification =
     if (!trimmed) {
       return;
     }
-    window.clearTimeout(notificationTimer);
+    const id = nextNotificationId();
     dispatch(
       showNotificationAction({
+        id,
         kind,
         message: trimmed,
         tenant: meta?.tenant,
@@ -118,19 +141,28 @@ export const showNotification =
       }),
     );
     if (kind === 'success' || kind === 'info') {
-      notificationTimer = window.setTimeout(() => {
-        dispatch(dismissNotification());
+      // Bound to this entry's own id, not a shared timer: a second toast
+      // queued before this one auto-dismisses must not have its timer
+      // clobbered (and must not, in turn, dismiss this one early).
+      window.setTimeout(() => {
+        dispatch(dismissNotificationAction(id));
       }, 3200);
     }
   };
 
-export const dismissNotification = (): AppThunk => (dispatch, getState) => {
-  window.clearTimeout(notificationTimer);
-  if (!getState().notification.notification) {
-    return;
-  }
-  dispatch(dismissNotificationAction());
-};
+// dismissNotification dismisses a specific queued entry by id, or — from the
+// titlebar's dismiss button, which only ever shows the front of the queue —
+// the oldest entry when no id is given.
+export const dismissNotification =
+  (id?: string): AppThunk =>
+  (dispatch, getState) => {
+    const notifications = getState().notification.notifications;
+    const target = id ?? notifications[0]?.id;
+    if (!target) {
+      return;
+    }
+    dispatch(dismissNotificationAction(target));
+  };
 
 export const waitLongerForTerminalStatus =
   (): AppThunk<Promise<void>> => async (dispatch, getState) => {

--- a/erun-ui/frontend/src/app/sessionThunks.ts
+++ b/erun-ui/frontend/src/app/sessionThunks.ts
@@ -12,7 +12,7 @@ import {
 import { startAITabOrPrompt } from './aiOccupancyThunks';
 import { resolveAutoStartGate } from './autoStartGate';
 import { readError } from './errors';
-import { hideTerminalMessage, showTerminalMessage } from './notificationThunks';
+import { hideTerminalMessage, showTerminalError, showTerminalMessage } from './notificationThunks';
 import { reattachRemoteTerminalTabs } from './remoteSessionTabsThunks';
 import { loadReviewDiff } from './reviewThunks';
 import { selectActiveSlotForSelection, selectEnvironmentExists } from './selectors';
@@ -332,7 +332,7 @@ export const openSelection =
     } catch (error: unknown) {
       if (isCurrentSelection()) {
         dispatch(setSelected(previousSelected));
-        dispatch(showTerminalMessage(readError(error)));
+        dispatch(showTerminalError(readError(error)));
       }
       throw error;
     } finally {
@@ -528,7 +528,7 @@ export const addTerminalTab = (): AppThunk<Promise<void>> => async (dispatch, ge
     controller.focusTerminalSoon();
     controller.queueTerminalResize();
   } catch (error: unknown) {
-    dispatch(showTerminalMessage(readError(error)));
+    dispatch(showTerminalError(readError(error)));
   }
 };
 
@@ -581,7 +581,7 @@ export const closeTerminalTab =
     try {
       await CloseSession(sessionId);
     } catch (error: unknown) {
-      dispatch(showTerminalMessage(readError(error)));
+      dispatch(showTerminalError(readError(error)));
       return;
     }
     const remaining = dispatch(removeTab(key, sessionId));

--- a/erun-ui/frontend/src/app/slices/notificationSlice.ts
+++ b/erun-ui/frontend/src/app/slices/notificationSlice.ts
@@ -2,12 +2,18 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import type { AppNotification } from '../state';
 
+// This used to be a single `notification: AppNotification | null` slot, so a
+// burst of concurrent failures (e.g. several "Upgrade all" members failing
+// within milliseconds of each other) silently overwrote one another — only
+// the last write survived. notifications is a small FIFO queue instead: every
+// failure gets its own entry, and the titlebar renders (and dismisses) the
+// oldest one first.
 export interface NotificationState {
-  notification: AppNotification | null;
+  notifications: AppNotification[];
 }
 
 const initialState: NotificationState = {
-  notification: null,
+  notifications: [],
 };
 
 export interface NotificationEnvMatch {
@@ -16,31 +22,37 @@ export interface NotificationEnvMatch {
   source: string;
 }
 
+// notificationQueueCapacity caps in-memory queue length. Success/info entries
+// auto-dismiss quickly, so only a pile of undismissed errors/warnings could
+// approach this; dropping the oldest keeps the newest failures visible rather
+// than growing unbounded over a long desktop session.
+const notificationQueueCapacity = 20;
+
 export const notificationSlice = createSlice({
   name: 'notification',
   initialState,
   reducers: {
     showNotification(state, action: PayloadAction<AppNotification>) {
-      state.notification = action.payload;
+      state.notifications.push(action.payload);
+      if (state.notifications.length > notificationQueueCapacity) {
+        state.notifications.splice(0, state.notifications.length - notificationQueueCapacity);
+      }
     },
-    dismissNotification(state) {
-      state.notification = null;
+    dismissNotification(state, action: PayloadAction<string>) {
+      state.notifications = state.notifications.filter((n) => n.id !== action.payload);
     },
     // Lets the deploy lifecycle retire the warning it raised without clobbering
     // an unrelated toast. Empty `source` is a wildcard so a deploy start can
     // retire both the runtime-unreachable warning and a prior deploy-failed
-    // error at once.
+    // error at once. Matches (and removes) every queued entry for the env, not
+    // just the front of the queue.
     dismissNotificationForEnv(state, action: PayloadAction<NotificationEnvMatch>) {
-      const current = state.notification;
-      if (!current) {
-        return;
-      }
       const { tenant, environment, source } = action.payload;
-      const envMatches = current.tenant === tenant && current.environment === environment;
-      const sourceMatches = source === '' || current.source === source;
-      if (envMatches && sourceMatches) {
-        state.notification = null;
-      }
+      state.notifications = state.notifications.filter((n) => {
+        const envMatches = n.tenant === tenant && n.environment === environment;
+        const sourceMatches = source === '' || n.source === source;
+        return !(envMatches && sourceMatches);
+      });
     },
   },
 });

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -166,6 +166,10 @@ export interface GlobalConfigDialogState {
 }
 
 export interface AppNotification {
+  // Unique per queued entry so a specific one can be dismissed (auto-dismiss
+  // timer, explicit dismiss click) without disturbing sibling entries queued
+  // before or after it.
+  id: string;
   kind: 'success' | 'warning' | 'error' | 'info';
   message: string;
   // Optional tags so a notification can be dismissed later by the state that raised it.

--- a/erun-ui/frontend/src/app/tabRespawnThunks.ts
+++ b/erun-ui/frontend/src/app/tabRespawnThunks.ts
@@ -9,7 +9,7 @@ import {
 } from '../../wailsjs/go/main/App';
 import { startAITabOrPrompt } from './aiOccupancyThunks';
 import { readError } from './errors';
-import { hideTerminalMessage, showTerminalMessage } from './notificationThunks';
+import { hideTerminalMessage, showTerminalError, showTerminalMessage } from './notificationThunks';
 import { selectEnvHasFailedDeploy } from './selectors';
 import { trackOpenSession } from './slices/sessionsSlice';
 import { setSelectedSessionForEnv, setSessionId } from './slices/terminalSlice';
@@ -111,7 +111,7 @@ const respawnDefaultTab =
         result = await startSessionForKind(runSelection, tab, cols, rows);
       }
     } catch (error: unknown) {
-      dispatch(showTerminalMessage(readError(error)));
+      dispatch(showTerminalError(readError(error)));
       return;
     }
     if (!result) {
@@ -192,7 +192,7 @@ export const relaunchAISessionsForLaunchChange =
         controller.queueTerminalResize();
       }
     } catch (error: unknown) {
-      dispatch(showTerminalMessage(readError(error)));
+      dispatch(showTerminalError(readError(error)));
     }
   };
 

--- a/erun-ui/frontend/src/app/tenantDialogThunks.ts
+++ b/erun-ui/frontend/src/app/tenantDialogThunks.ts
@@ -4,7 +4,7 @@ import { cloudApi } from './api/cloudApi';
 import { tenantApi } from './api/tenantApi';
 import { replaceCloudProvider } from './cloudContextState';
 import { readError } from './errors';
-import { showNotification, showTerminalMessage } from './notificationThunks';
+import { showNotification, showTerminalError, showTerminalMessage } from './notificationThunks';
 import { setIdleStatus } from './slices/idleSlice';
 import { setReviewOpen } from './slices/layoutSlice';
 import { setSelected } from './slices/selectionSlice';
@@ -151,7 +151,7 @@ export const submitTenantConfig = (): AppThunk<Promise<void>> => async (dispatch
         error: message,
       }),
     );
-    dispatch(showTerminalMessage(message));
+    dispatch(showTerminalError(message));
   }
 };
 
@@ -198,7 +198,7 @@ export const setupTenantCloudProviderOIDC =
           error: message,
         }),
       );
-      dispatch(showTerminalMessage(message));
+      dispatch(showTerminalError(message));
       dispatch(showNotification('error', message));
     }
   };

--- a/erun-ui/frontend/src/app/terminalClipboard.ts
+++ b/erun-ui/frontend/src/app/terminalClipboard.ts
@@ -13,7 +13,7 @@ import {
   terminalCopyOutcome,
 } from './clipboard';
 import { readError } from './errors';
-import { showTerminalMessage } from './notificationThunks';
+import { showTerminalError } from './notificationThunks';
 import { store } from './store';
 
 export interface TerminalClipboardDeps {
@@ -181,6 +181,6 @@ export class TerminalClipboard {
   }
 
   private reportError(error: unknown): void {
-    store.dispatch(showTerminalMessage(readError(error)));
+    store.dispatch(showTerminalError(readError(error)));
   }
 }

--- a/erun-ui/frontend/src/app/wailsEventThunks.ts
+++ b/erun-ui/frontend/src/app/wailsEventThunks.ts
@@ -17,6 +17,7 @@ import type {
 import {
   hideTerminalMessage,
   showNotification,
+  showTerminalError,
   showTerminalFailure,
   showTerminalMessage,
 } from './notificationThunks';
@@ -234,7 +235,7 @@ export const handleEnvironmentInitialized =
       try {
         await dispatch(openSelection({ tenant, environment }));
       } catch (error) {
-        dispatch(showTerminalMessage(readError(error)));
+        dispatch(showTerminalError(readError(error)));
       }
       return;
     }
@@ -245,7 +246,7 @@ export const handleEnvironmentInitialized =
       await dispatch(startInitialDeploySelection({ tenant, environment }));
     } catch (error) {
       dispatch(clearPendingOpenAfterDeploy());
-      dispatch(showTerminalMessage(readError(error)));
+      dispatch(showTerminalError(readError(error)));
     }
   };
 
@@ -269,7 +270,7 @@ export const handleEnvironmentDeployed =
     try {
       await dispatch(openSelection({ tenant, environment }));
     } catch (error) {
-      dispatch(showTerminalMessage(readError(error)));
+      dispatch(showTerminalError(readError(error)));
     }
   };
 

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/app/environmentDialogThunks';
 import { readError } from '@/app/errors';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import { showTerminalMessage } from '@/app/notificationThunks';
+import { showTerminalError } from '@/app/notificationThunks';
 import { runtimeResourceLimitMessage } from '@/app/runtimeResources';
 import type { AppState } from '@/app/state';
 import {
@@ -97,7 +97,7 @@ export function EnvironmentDialogView(): React.ReactElement {
           onSubmit={(event) => {
             event.preventDefault();
             void dispatch(submitEnvironmentDialog(event.currentTarget)).catch((error: unknown) => {
-              dispatch(showTerminalMessage(readError(error)));
+              dispatch(showTerminalError(readError(error)));
             });
           }}
         >

--- a/erun-ui/frontend/src/components/app/EnvironmentHealthSection.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentHealthSection.tsx
@@ -16,7 +16,7 @@ import {
   deployFromHealthCheck,
   focusRegistryFieldFromHealthCheck,
 } from '@/app/manageEnvironmentThunks';
-import { showTerminalMessage } from '@/app/notificationThunks';
+import { showTerminalError } from '@/app/notificationThunks';
 import type { AppState } from '@/app/state';
 import type { UIEnvironmentHealthCheck } from '@/uiDiagnosticsTypes';
 
@@ -45,7 +45,7 @@ export function EnvironmentHealthSection({ dialog }: { dialog: ManageDialog }): 
           disabled={dialog.busy || dialog.configLoading || loading}
           onClick={() =>
             void dispatch(checkManageEnvironmentHealth()).catch((error: unknown) => {
-              dispatch(showTerminalMessage(readError(error)));
+              dispatch(showTerminalError(readError(error)));
             })
           }
         >
@@ -127,7 +127,7 @@ function HealthCheckFix({
         disabled={disabled}
         onClick={() =>
           void dispatch(deployFromHealthCheck()).catch((error: unknown) => {
-            dispatch(showTerminalMessage(readError(error)));
+            dispatch(showTerminalError(readError(error)));
           })
         }
       >

--- a/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
@@ -19,7 +19,7 @@ import {
   updateGlobalConfig,
 } from '@/app/globalConfigThunks';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import { showTerminalMessage } from '@/app/notificationThunks';
+import { showTerminalError } from '@/app/notificationThunks';
 import type { AppState } from '@/app/state';
 import { useController } from '@/app/useController';
 import { CloudAliasesSection } from '@/components/app/GlobalConfigDialog.CloudAliases';
@@ -53,7 +53,7 @@ export function GlobalConfigDialogView(): React.ReactElement {
           onSubmit={(event) => {
             event.preventDefault();
             void dispatch(submitGlobalConfig()).catch((error: unknown) => {
-              dispatch(showTerminalMessage(readError(error)));
+              dispatch(showTerminalError(readError(error)));
             });
           }}
         >

--- a/erun-ui/frontend/src/components/app/LocalRepoPathInput.tsx
+++ b/erun-ui/frontend/src/components/app/LocalRepoPathInput.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { useChooseLocalRepoPathMutation } from '@/app/api/environmentApi';
 import { readError } from '@/app/errors';
 import { useAppDispatch } from '@/app/hooks';
-import { showTerminalMessage } from '@/app/notificationThunks';
+import { showTerminalError } from '@/app/notificationThunks';
 
 // LocalRepoPathInput is the shared host-worktree-path field for the init dialog
 // and the env-settings General tab, so both edit the path identically. Free-text
@@ -38,7 +38,7 @@ export function LocalRepoPathInput({
         onChange(picked);
       }
     } catch (error) {
-      dispatch(showTerminalMessage(readError(error)));
+      dispatch(showTerminalError(readError(error)));
     }
   };
   return (

--- a/erun-ui/frontend/src/components/app/ManageDialogDeployComponents.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogDeployComponents.tsx
@@ -11,7 +11,7 @@ import {
   saveManageDeployComponents,
   toggleManageDeployComponent,
 } from '@/app/manageEnvironmentThunks';
-import { showTerminalMessage } from '@/app/notificationThunks';
+import { showTerminalError } from '@/app/notificationThunks';
 import type { AppState } from '@/app/state';
 import { CheckboxField } from '@/components/app/ManageDialog.fields';
 
@@ -72,7 +72,7 @@ export function DeployComponentsField({ dialog }: { dialog: ManageDialog }): Rea
           }
           onClick={() =>
             void dispatch(saveManageDeployComponents()).catch((error: unknown) => {
-              dispatch(showTerminalMessage(readError(error)));
+              dispatch(showTerminalError(readError(error)));
             })
           }
         >

--- a/erun-ui/frontend/src/components/app/ManageDialogRuntimePower.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogRuntimePower.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { readError } from '@/app/errors';
 import { useAppDispatch } from '@/app/hooks';
 import { submitManageStop } from '@/app/manageEnvironmentThunks';
-import { showTerminalMessage } from '@/app/notificationThunks';
+import { showTerminalError } from '@/app/notificationThunks';
 import type { AppState } from '@/app/state';
 
 // RuntimePowerField sits directly under Deploy because that is where the
@@ -35,7 +35,7 @@ export function RuntimePowerField({
         disabled={dialog.busy || dialog.configLoading}
         onClick={() =>
           void dispatch(submitManageStop()).catch((error: unknown) => {
-            dispatch(showTerminalMessage(readError(error)));
+            dispatch(showTerminalError(readError(error)));
           })
         }
       >

--- a/erun-ui/frontend/src/components/app/ManageDialogRuntimeTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogRuntimeTab.tsx
@@ -17,7 +17,7 @@ import {
   updateManageConfig,
   updateManageDialog,
 } from '@/app/manageEnvironmentThunks';
-import { showTerminalMessage } from '@/app/notificationThunks';
+import { showTerminalError } from '@/app/notificationThunks';
 import { RUNTIME_CHART_NOTICE_ID, runtimeChartBlocksDeploy } from '@/app/runtimeChartPlan';
 import type { AppState } from '@/app/state';
 import { CheckboxField, TextField } from '@/components/app/ManageDialog.fields';
@@ -67,12 +67,12 @@ export function RuntimeTab(): React.ReactElement {
         }}
         onDeploy={() =>
           void dispatch(submitManageDeploy()).catch((error: unknown) => {
-            dispatch(showTerminalMessage(readError(error)));
+            dispatch(showTerminalError(readError(error)));
           })
         }
         onCreateVersion={() =>
           void dispatch(submitCreateVersion()).catch((error: unknown) => {
-            dispatch(showTerminalMessage(readError(error)));
+            dispatch(showTerminalError(readError(error)));
           })
         }
       />

--- a/erun-ui/frontend/src/components/app/ManageDialogSSHTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogSSHTab.tsx
@@ -11,7 +11,7 @@ import {
   startManageDoctor,
   updateManageSSHDConfig,
 } from '@/app/manageEnvironmentThunks';
-import { showTerminalMessage } from '@/app/notificationThunks';
+import { showTerminalError } from '@/app/notificationThunks';
 import type { AppState } from '@/app/state';
 import { selectionKey } from '@/app/versionSuggestions';
 import { CheckboxField, ReadonlyField, StatusBadge } from '@/components/app/ManageDialog.fields';
@@ -102,7 +102,7 @@ function SSHAccessHeader({ dialog }: { dialog: ManageDialog }): React.ReactEleme
           }
           onClick={() =>
             void dispatch(enableManageSSHD()).catch((error: unknown) => {
-              dispatch(showTerminalMessage(readError(error)));
+              dispatch(showTerminalError(readError(error)));
             })
           }
         >
@@ -150,7 +150,7 @@ function LocalSyncFolderField({
           disabled={disabled}
           onClick={() =>
             void dispatch(chooseWorkspaceSyncLocalFolder()).catch((error: unknown) => {
-              dispatch(showTerminalMessage(readError(error)));
+              dispatch(showTerminalError(readError(error)));
             })
           }
         >
@@ -219,7 +219,7 @@ export function DiagnosticsSection({ dialog }: { dialog: ManageDialog }): React.
           disabled={dialog.busy || dialog.configLoading}
           onClick={() =>
             void dispatch(startManageDoctor()).catch((error: unknown) => {
-              dispatch(showTerminalMessage(readError(error)));
+              dispatch(showTerminalError(readError(error)));
             })
           }
         >

--- a/erun-ui/frontend/src/components/app/ManageDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogView.tsx
@@ -25,7 +25,7 @@ import {
   submitManageDelete,
   submitManageDeploy,
 } from '@/app/manageEnvironmentThunks';
-import { showTerminalMessage } from '@/app/notificationThunks';
+import { showTerminalError } from '@/app/notificationThunks';
 import { runtimeResourceValidation } from '@/app/runtimeResources';
 import type { AppState } from '@/app/state';
 import { useController } from '@/app/useController';
@@ -269,7 +269,7 @@ function RedeployBanner({ dialog }: { dialog: ManageDialog }): React.ReactElemen
           disabled={deploying}
           onClick={() =>
             void dispatch(submitManageDeploy()).catch((error: unknown) => {
-              dispatch(showTerminalMessage(readError(error)));
+              dispatch(showTerminalError(readError(error)));
             })
           }
         >
@@ -445,7 +445,7 @@ function EditActions({
         aria-describedby={hasSaveStatus ? saveStatusId : undefined}
         onClick={() =>
           void dispatch(submitManageConfig()).catch((error: unknown) => {
-            dispatch(showTerminalMessage(readError(error)));
+            dispatch(showTerminalError(readError(error)));
           })
         }
       >

--- a/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { readError } from '@/app/errors';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { openManageDialog } from '@/app/manageEnvironmentThunks';
-import { showTerminalMessage } from '@/app/notificationThunks';
+import { showTerminalError } from '@/app/notificationThunks';
 import { openOutputs } from '@/app/outputsThunks';
 import { selectSidebarFocus } from '@/app/selectors';
 import { closeEnvironment, openSelection } from '@/app/sessionThunks';
@@ -166,7 +166,7 @@ function EnvStatusIndicator({
         onClick={(event) => {
           event.stopPropagation();
           void dispatch(closeEnvironment(selection)).catch((error: unknown) => {
-            dispatch(showTerminalMessage(readError(error)));
+            dispatch(showTerminalError(readError(error)));
           });
         }}
       >
@@ -206,7 +206,7 @@ function EnvironmentRowOpenButton({
       aria-current={selected ? 'page' : undefined}
       onClick={() => {
         void dispatch(openSelection(selection)).catch((error: unknown) => {
-          dispatch(showTerminalMessage(readError(error)));
+          dispatch(showTerminalError(readError(error)));
         });
       }}
     >

--- a/erun-ui/frontend/src/components/app/Sidebar.helpers.test.ts
+++ b/erun-ui/frontend/src/components/app/Sidebar.helpers.test.ts
@@ -91,14 +91,34 @@ test('an unhealthy environment reads failed, never busy', () => {
   assert.equal(indicator.activity, 'Deploy failed — recover from Activities');
 });
 
-test('a sticky condition does not outlive the session that produced it', () => {
+test('a stopped sticky condition does not outlive the session that produced it', () => {
   // Closing an environment can leave a last-known condition behind. With no
   // tabs there is no session for it to describe and no way to act on it, so the
-  // row goes quiet rather than flying a stale stopped ring or failure triangle.
-  for (const envState of ['stopped', 'runtime-stopped', 'failed']) {
+  // row goes quiet rather than flying a stale stopped ring. A failed deploy is
+  // the exception — see the next test.
+  for (const envState of ['stopped', 'runtime-stopped']) {
     const indicator = environmentIndicator({ ...base, envState });
     assert.equal(indicator.visible, false, envState);
   }
+});
+
+test('a failed deploy stays visible after its session closes, unless the environment is reachable again', () => {
+  // Unlike stopped/runtime-stopped, a failed deploy describes the environment
+  // itself (its runtime is broken), not the session that watched it fail —
+  // closing the tabs that observed the failure does not fix it. Before this,
+  // the row went silently blank, indistinguishable from one nobody had ever
+  // opened.
+  const stillBroken = environmentIndicator({ ...base, envState: 'failed' });
+  assert.equal(stillBroken.visible, true);
+  assert.equal(stillBroken.dot, 'failed');
+  assert.equal(stillBroken.opened, false);
+  assert.match(stillBroken.condition, /deploy failed — /);
+  assert.equal(stillBroken.activity, 'Deploy failed — recover from Activities');
+
+  // Once the environment answers again, the stale flag no longer wins — see
+  // 'a reachable environment is reported on its own terms' below.
+  const recovered = environmentIndicator({ ...base, envState: 'failed', reachable: true });
+  assert.equal(recovered.dot, 'running');
 });
 
 test('a bound-but-dead forward is reported as an outage, not as a quiet row', () => {

--- a/erun-ui/frontend/src/components/app/Sidebar.helpers.ts
+++ b/erun-ui/frontend/src/components/app/Sidebar.helpers.ts
@@ -377,12 +377,23 @@ export function environmentIndicator(raw: EnvironmentIndicatorInputs): Environme
   // The sticky condition describes a desktop session. Once the desktop holds no
   // tabs for the environment it no longer describes anything current, so it is
   // dropped rather than left to outlive the session that produced it — a closed
-  // row must not keep flying a failure triangle for a session that is gone.
-  const input = raw.isOpen ? raw : { ...raw, envState: '' };
+  // row must not keep flying a stale stopped ring for a session that is gone.
+  //
+  // A failed deploy is the one exception: it is not a property of the session
+  // that observed it, it is a property of the environment (its runtime is
+  // broken), and closing the tabs that watched it fail does not fix it. As long
+  // as the environment stays unreachable, the row must keep naming the failure
+  // — the alternative is a closed, failed environment going silently blank,
+  // indistinguishable from one nobody has ever opened. Reachability still wins
+  // once it comes back: an environment that answers again is reported on its
+  // own terms (below), not by a stale flag from before it recovered.
+  const keepFailedWhenClosed = raw.envState === ENV_STATE_FAILED && !raw.reachable;
+  const input = raw.isOpen || keepFailedWhenClosed ? raw : { ...raw, envState: '' };
   const dot = environmentStatusDot(input.envState, input.busy, input.outage);
   // What keeps a closed row visible is the environment itself: its edge
-  // answering, work in flight, or an outage it cannot report any other way.
-  const visible = input.isOpen || input.reachable || input.busy || input.outage;
+  // answering, work in flight, a failure it cannot report any other way once
+  // its session is gone, or an outage.
+  const visible = input.isOpen || input.reachable || input.busy || input.outage || dot === 'failed';
   return {
     visible,
     dot,

--- a/erun-ui/frontend/src/components/app/TenantDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDialogView.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 
 import { readError } from '@/app/errors';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import { showTerminalMessage } from '@/app/notificationThunks';
+import { showTerminalError } from '@/app/notificationThunks';
 import type { AppState } from '@/app/state';
 import type { AppDispatch } from '@/app/store';
 import {
@@ -63,7 +63,7 @@ export function TenantDialogView(): React.ReactElement {
           onSubmit={(event) => {
             event.preventDefault();
             void dispatch(submitTenantConfig()).catch((error: unknown) => {
-              dispatch(showTerminalMessage(readError(error)));
+              dispatch(showTerminalError(readError(error)));
             });
           }}
         >
@@ -286,7 +286,7 @@ function CloudAliasOIDCButton({
         disabled={busy || !alias}
         onClick={() => {
           void dispatch(setupTenantCloudProviderOIDC(alias)).catch((error: unknown) => {
-            dispatch(showTerminalMessage(readError(error)));
+            dispatch(showTerminalError(readError(error)));
           });
         }}
       >

--- a/erun-ui/frontend/src/components/app/Titlebar.Status.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.Status.tsx
@@ -19,7 +19,7 @@ import {
   dismissTerminalStatus,
   waitLongerForTerminalStatus,
 } from '@/app/notificationThunks';
-import type { AppState } from '@/app/state';
+import type { AppNotification, AppState } from '@/app/state';
 import type { AppDispatch } from '@/app/store';
 
 import { ClipboardSetText } from '../../../wailsjs/runtime/runtime';
@@ -42,6 +42,10 @@ interface TitlebarStatusValue {
   copyOutput: string;
   copyStatus: string;
   action: AppState['terminalStatusAction'];
+  // Set only for source: 'notification' — identifies which queued entry this
+  // is, so dismissing it removes exactly this one even if another has been
+  // queued behind it since render.
+  notificationId?: string;
 }
 
 const statusBorderClassNames: Record<TitlebarStatusKind, string> = {
@@ -59,7 +63,10 @@ const statusIconClassNames: Record<TitlebarStatusKind, string> = {
 };
 
 export function TitlebarStatus(): React.ReactElement | null {
-  const notification = useAppSelector((state) => state.notification.notification);
+  // The queue can hold several concurrent failures; the titlebar has room for
+  // one pill, so it always shows (and dismisses) the oldest — the others stay
+  // queued behind it rather than being silently overwritten.
+  const notification = useAppSelector((state) => state.notification.notifications[0]);
   const terminalStatus = useAppSelector((state) => state.terminalStatus);
   const status = computeTitlebarStatus(notification, terminalStatus);
   if (!status) {
@@ -96,7 +103,7 @@ export function TitlebarStatus(): React.ReactElement | null {
 }
 
 function computeTitlebarStatus(
-  notification: AppState['notification'],
+  notification: AppNotification | undefined,
   terminal: {
     terminalMessage: string;
     terminalStatusKind: AppState['terminalStatusKind'];
@@ -109,7 +116,9 @@ function computeTitlebarStatus(
 ): TitlebarStatusValue | null {
   if (notification) {
     return {
-      ...notification,
+      kind: notification.kind,
+      message: notification.message,
+      notificationId: notification.id,
       source: 'notification',
       detail: '',
       busy: false,
@@ -317,7 +326,7 @@ function StatusDismissAction({ status }: { status: TitlebarStatusValue }): React
 
 function dismissTitlebarStatus(dispatch: AppDispatch, status: TitlebarStatusValue): void {
   if (status.source === 'notification') {
-    dispatch(dismissNotification());
+    dispatch(dismissNotification(status.notificationId));
     return;
   }
   dispatch(dismissTerminalStatus());

--- a/erun-ui/playwright/pages/ManageDialog.ts
+++ b/erun-ui/playwright/pages/ManageDialog.ts
@@ -14,10 +14,13 @@ export class ManageDialog {
       return this.page.getByRole('dialog', { name: this.expectedTitle });
     }
     // Disambiguate from other open dialogs (e.g. the activity drawer) by the
-    // General tab that only the manage surface has.
+    // description text unique to the manage surface. The General tab used to
+    // serve this purpose, but it — along with every other tab — is replaced
+    // by the delete-confirmation view while dialog.tab === 'delete', which
+    // made every locator scoped under this one resolve to nothing mid-delete.
     return this.page
       .getByRole('dialog')
-      .filter({ has: this.page.getByRole('tab', { name: /^General/ }) })
+      .filter({ hasText: 'Edit environment configuration' })
       .first();
   }
 
@@ -278,7 +281,7 @@ export class ManageDialog {
   async confirmDelete(expected: string): Promise<void> {
     await this.page.locator('#manage-confirmation').fill(expected);
     await this.locator()
-      .getByRole('button', { name: /^Delete/ })
+      .getByRole('button', { name: /^Confirm delete/ })
       .click();
   }
 

--- a/erun-ui/playwright/tests/app-notification.spec.ts
+++ b/erun-ui/playwright/tests/app-notification.spec.ts
@@ -149,4 +149,45 @@ test.describe('app-notification toast', () => {
     await expect(page.locator('[role="status"]')).toHaveCount(statusBefore);
     await expect(page.locator('[role="alert"]')).toHaveCount(alertBefore + 1);
   });
+
+  // The notification slot used to be a single `AppNotification | null` value,
+  // so a burst of concurrent failures (e.g. several "Upgrade all" members
+  // failing within milliseconds of each other) silently overwrote one
+  // another — only the last dispatch survived. Five concurrent error toasts
+  // must all remain readable: the titlebar shows one at a time, and
+  // dismissing it reveals a still-queued one rather than it having been lost.
+  // Delivery order across the fake-backend event bridge isn't guaranteed (it
+  // interleaves these five arbitrarily), so this asserts the set of five is
+  // fully seen — not that they arrive in a specific order.
+  test('five concurrent error notifications all remain readable, none overwritten', async ({
+    app: _app,
+    page,
+  }) => {
+    const messages = Array.from({ length: 5 }, (_, i) => `Concurrent failure marker ${String(i)}`);
+    await page.evaluate((msgs) => {
+      const runtime = (
+        window as unknown as {
+          runtime: { EventsEmit: (n: string, ...a: unknown[]) => void };
+        }
+      ).runtime;
+      for (const message of msgs) {
+        runtime.EventsEmit('app-notification', { kind: 'error', message });
+      }
+    }, messages);
+
+    const seen = new Set<string>();
+    for (let i = 0; i < messages.length; i++) {
+      const pill = page.getByRole('alert').filter({ hasText: /Concurrent failure marker \d/ });
+      await expect(pill).toBeVisible();
+      const text = (await pill.textContent()) ?? '';
+      seen.add((/Concurrent failure marker \d/.exec(text) ?? [''])[0]);
+      await pill.getByRole('button', { name: 'Dismiss status' }).click();
+    }
+    // All five distinct failures were shown at some point across the dismiss
+    // sequence — none silently dropped by an overwrite.
+    expect([...seen].sort()).toEqual(messages.slice().sort());
+    await expect(
+      page.getByRole('alert').filter({ hasText: /Concurrent failure marker/ }),
+    ).toHaveCount(0);
+  });
 });

--- a/erun-ui/playwright/tests/close-environment-failure.spec.ts
+++ b/erun-ui/playwright/tests/close-environment-failure.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '../fixtures/erunApp.js';
+
+// A CloseEnvironmentSessions failure used to render as a neutral info pill
+// via showTerminalMessage — polite aria-live, no role="alert", no Copy
+// action — indistinguishable from a routine status update. Unlike a
+// Manage-dialog-scoped failure (where the dialog's own inline error already
+// carries the message while the titlebar sits behind the modal's
+// aria-hidden), closing an env's tabs is a sidebar action with no dialog in
+// the way, so the titlebar pill is the only surface — and it must be an
+// actionable error.
+test.describe('close environment — failure surfacing (#1212)', () => {
+  test('a close failure renders as an error with a Copy action, not a silent info pill', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    await expect(app.sidebar.envOpenDot(seededEnv.tenant, seededEnv.environment)).toBeVisible();
+
+    await page.route('**/__erun_invoke', async (route, request) => {
+      const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+      if (body.method === 'CloseEnvironmentSessions') {
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'CLOSE_ENVIRONMENT_UNREACHABLE_MARKER' }),
+        });
+      }
+      await route.continue();
+    });
+
+    await app.sidebar.envOpenDot(seededEnv.tenant, seededEnv.environment).focus();
+    await app.sidebar.envOpenDot(seededEnv.tenant, seededEnv.environment).press('Enter');
+
+    const pill = page
+      .getByRole('alert')
+      .filter({ hasText: 'CLOSE_ENVIRONMENT_UNREACHABLE_MARKER' });
+    await expect(pill).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Copy output' })).toBeVisible();
+
+    // The close never completed, so the dot must still be there — a stray
+    // success side effect alongside the reported failure would itself be a bug.
+    await expect(app.sidebar.envOpenDot(seededEnv.tenant, seededEnv.environment)).toBeVisible();
+  });
+});

--- a/erun-ui/playwright/tests/env-init.spec.ts
+++ b/erun-ui/playwright/tests/env-init.spec.ts
@@ -10,7 +10,14 @@ import { SEED_TENANT } from '../fixtures/seedRoot.js';
 // available resource status clears the capacity blocker, leaving the value
 // requirements (environment name, container registry) as the only blockers —
 // which is exactly what this spec exercises.
-async function stubDialogCluster(page: Page): Promise<void> {
+// clusterRegistryFailure, when set, makes the LoadClusterRegistry stub return
+// this error instead of the endpoint's usual pass-through — used by
+// stubDialogClusterWithRegistryFailure below. A single page.route handler (not
+// two stacked registrations) is required: Playwright runs the most-recently
+// registered handler first, and its route.continue() sends the request to the
+// real backend rather than falling through to an earlier handler, so stacking
+// silently defeated the first stub instead of composing with it.
+async function stubDialogCluster(page: Page, clusterRegistryFailure?: string): Promise<void> {
   await page.route('**/__erun_invoke', async (route, request) => {
     const body = JSON.parse(request.postData() ?? '{}') as { method: string };
     if (body.method === 'LoadKubernetesContexts') {
@@ -46,8 +53,25 @@ async function stubDialogCluster(page: Page): Promise<void> {
         }),
       });
     }
+    if (body.method === 'LoadClusterRegistry' && clusterRegistryFailure) {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ error: clusterRegistryFailure }),
+      });
+    }
     await route.continue();
   });
+}
+
+// stubDialogClusterWithRegistryFailure makes a context resolve and its
+// capacity load, but the cluster-registry probe (LoadClusterRegistry) fail —
+// a VPN hiccup or an RBAC gap, not a real "no registry deployed" answer. This
+// used to be a bare `catch { ... }` that silently reset
+// clusterRegistry/useClusterRegistry with no error surfaced anywhere,
+// indistinguishable from "no in-cluster registry found". The dialog must show
+// the probe failure instead.
+async function stubDialogClusterWithRegistryFailure(page: Page): Promise<void> {
+  await stubDialogCluster(page, 'CLUSTER_REGISTRY_PROBE_UNREACHABLE_MARKER');
 }
 
 test.describe('environment init dialog', () => {
@@ -417,6 +441,25 @@ test.describe('environment init dialog', () => {
     await expect(help).toBeVisible();
     await expect(help).toContainText('ghcr.io/your-org');
     await expect(help).toContainText('Cloud aliases');
+
+    await app.envInitDialog.cancel();
+    await app.envInitDialog.waitForClosed();
+  });
+
+  test('a cluster-registry probe failure shows the failure, not a silent reset (#1212)', async ({
+    app,
+    page,
+  }) => {
+    await stubDialogClusterWithRegistryFailure(page);
+    await app.sidebar.openInitDialog();
+    await app.envInitDialog.waitForOpen();
+
+    // Selecting the context fires refreshDialogClusterRegistry, which fails.
+    await app.envInitDialog.selectKubernetesContext('orbstack');
+
+    await expect(app.envInitDialog.locator().getByRole('alert')).toContainText(
+      'CLUSTER_REGISTRY_PROBE_UNREACHABLE_MARKER',
+    );
 
     await app.envInitDialog.cancel();
     await app.envInitDialog.waitForClosed();

--- a/erun-ui/playwright/tests/manage-delete-partial-failure.spec.ts
+++ b/erun-ui/playwright/tests/manage-delete-partial-failure.spec.ts
@@ -1,0 +1,47 @@
+import type { Page } from '@playwright/test';
+
+import { test, expect } from '../fixtures/erunApp.js';
+
+// A delete whose namespace cleanup fails must render as an error with the
+// failure clause visible and a Copy action — not the plain success pill it
+// used to be (the copy buffer had already been cleared, and the warning was
+// just appended to the "Deleted ..." text as an afterthought).
+async function stubDeleteWithNamespaceFailure(page: Page): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method: string; args?: unknown[] };
+    if (body.method === 'DeleteEnvironment') {
+      const selection = (body.args?.[0] ?? {}) as { tenant?: string; environment?: string };
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            tenant: selection.tenant,
+            environment: selection.environment,
+            namespaceDeleteError: 'NAMESPACE_DELETE_UNREACHABLE_MARKER',
+          },
+        }),
+      });
+    }
+    await route.continue();
+  });
+}
+
+test.describe('manage dialog delete — partial failure (#1212)', () => {
+  test('a namespace cleanup failure renders as an error with a Copy action, not a silent success pill', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    await stubDeleteWithNamespaceFailure(page);
+    await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
+    await app.manageDialog.waitForOpen();
+
+    await app.manageDialog.openDelete();
+    await app.manageDialog.confirmDelete(`${seededEnv.tenant}-${seededEnv.environment}`);
+
+    const pill = page.getByRole('alert').filter({ hasText: 'NAMESPACE_DELETE_UNREACHABLE_MARKER' });
+    await expect(pill).toBeVisible();
+    await expect(pill).toContainText(`Deleted ${seededEnv.tenant} / ${seededEnv.environment}.`);
+    await expect(page.getByRole('button', { name: 'Copy output' })).toBeVisible();
+  });
+});

--- a/erun-ui/playwright/tests/manage-environment-health.spec.ts
+++ b/erun-ui/playwright/tests/manage-environment-health.spec.ts
@@ -1,13 +1,30 @@
+import type { Page } from '@playwright/test';
+
 import { test, expect } from '../fixtures/erunApp.js';
 import { SEED_ENV_ALPHA, SEED_TENANT } from '../fixtures/seedRoot.js';
 
+async function stubCheckEnvironmentHealth(
+  page: Page,
+  body: Record<string, unknown>,
+): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const parsed = JSON.parse(request.postData() ?? '{}') as { method: string };
+    if (parsed.method === 'CheckEnvironmentHealth') {
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify(body) });
+    }
+    await route.continue();
+  });
+}
+
 test.describe('manage dialog environment health check', () => {
-  test('shows the effective registry and runs an explicit health check with a recovery action', async ({
+  test('shows the effective registry and runs an explicit health check reporting the harness cluster as unreachable', async ({
     app,
   }) => {
-    // No save — the seeded baseline stays untouched. The seeded env is a
-    // local-agent env that is never deployed, so the health check surfaces the
-    // not-deployed state (or, if the stubbed cluster reports it up, an all-clear).
+    // No save — the seeded baseline stays untouched. The isolated harness's
+    // kubectl stub always answers "no cluster in the Playwright harness" (see
+    // fixtures/seedRoot.ts), which is a real probe failure, not a genuine
+    // NotFound — so the fixed checkRuntimeDeployed always reports "could not
+    // check" here, never a false "not deployed" or a false all-clear.
     await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, SEED_ENV_ALPHA);
     await app.manageDialog.waitForOpen();
     const dialog = app.manageDialog.locator();
@@ -24,13 +41,86 @@ test.describe('manage dialog environment health check', () => {
     await checkButton.click();
 
     // After the out-of-pod round-trip a result renders (visibility of system
-    // status): either a not-deployed issue with a named Deploy recovery, or an
-    // all-clear. Both are valid; a result MUST appear.
+    // status): the harness cluster is unreachable, so the check reports it
+    // could not run — and, critically, offers no Deploy button that would
+    // fail identically.
+    await expect(dialog.getByText(/Could not check the runtime deployment/)).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(dialog.getByRole('button', { name: 'Deploy' })).toHaveCount(0);
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+
+  // A probe failure (VPN down, rotated token, unreachable API server) must
+  // report "could not check", never a false "not deployed" that hands the
+  // operator a Deploy button that would fail identically. This mirrors the
+  // shape checkRuntimeDeployed now returns for a real kubectl error
+  // (erun-ui/environment_health_test.go covers the Go side; this spec locks
+  // the frontend contract that an "unknown" check renders no Deploy fix).
+  test('a probe that could not run reports "could not check" and offers no Deploy button (#1212)', async ({
+    app,
+    page,
+  }) => {
+    await stubCheckEnvironmentHealth(page, {
+      data: {
+        tenant: SEED_TENANT,
+        environment: SEED_ENV_ALPHA,
+        healthy: false,
+        checks: [
+          {
+            id: 'registry',
+            status: 'ok',
+            title: 'Container registry',
+            detail: 'Using registry.example/test.',
+          },
+          {
+            id: 'runtime-deployed',
+            status: 'unknown',
+            title: 'Runtime deployment',
+            detail:
+              'Could not check the runtime deployment on orbstack: Unable to connect to the server: dial tcp: i/o timeout',
+          },
+        ],
+      },
+    });
+    await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, SEED_ENV_ALPHA);
+    await app.manageDialog.waitForOpen();
+    const dialog = app.manageDialog.locator();
+
+    await dialog.getByRole('button', { name: 'Check environment' }).click();
+
+    await expect(dialog.getByText(/Could not check the runtime deployment/)).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Deploy' })).toHaveCount(0);
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+
+  // A health-check round-trip that fails outright (the Wails call itself
+  // rejects, not a computed "unknown" result) renders inline in the dialog —
+  // the same surface a save failure uses (Nielsen #4, consistency with
+  // comparable flows) — since the modal makes the titlebar pill behind it
+  // aria-hidden and therefore inaccessible while open regardless. The
+  // catch itself now also routes through showTerminalError rather than
+  // showTerminalMessage for the surface that *is* reachable once the dialog
+  // closes; close-environment-failure.spec.ts covers a non-modal flow where
+  // that distinction is directly observable.
+  test('a health-check RPC failure surfaces inline in the dialog, not silently', async ({
+    app,
+    page,
+  }) => {
+    await stubCheckEnvironmentHealth(page, { error: 'HEALTH_CHECK_RPC_UNREACHABLE_MARKER' });
+    await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, SEED_ENV_ALPHA);
+    await app.manageDialog.waitForOpen();
+    const dialog = app.manageDialog.locator();
+
+    await dialog.getByRole('button', { name: 'Check environment' }).click();
+
     await expect(
-      dialog
-        .getByRole('button', { name: 'Deploy' })
-        .or(dialog.getByText('All checks passed.', { exact: true })),
-    ).toBeVisible({ timeout: 20_000 });
+      dialog.getByRole('alert').filter({ hasText: 'HEALTH_CHECK_RPC_UNREACHABLE_MARKER' }),
+    ).toBeVisible();
 
     await app.manageDialog.cancel();
     await app.manageDialog.waitForClosed();

--- a/erun-ui/playwright/tests/sidebar-open-dot.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-open-dot.spec.ts
@@ -128,6 +128,39 @@ test.describe('sidebar env open dot', () => {
     // closeEnvironment already asserts the row went quiet and stayed quiet.
     await app.sidebar.closeEnvironment(tenant, environment);
   });
+
+  // A failed deploy describes the environment's own broken runtime, not the
+  // desktop session that watched it fail — closing the tabs that observed the
+  // failure does not fix it. Before this the row went blank on close,
+  // indistinguishable from one nobody had ever opened, discarding the only
+  // signal that something needs attention.
+  test('a failed deploy stays visible after the env is closed', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    const { tenant, environment } = seededEnv;
+    await app.sidebar.openEnvironment(tenant, environment);
+    await app.sidebar.closeEnvironment(tenant, environment);
+
+    const row = app.sidebar.envRowButton(tenant, environment).locator('..');
+    const dot = row.getByTestId('env-open-dot');
+    await expect(dot).toHaveCount(0);
+
+    await expect(async () => {
+      await emitEnvStatus(page, tenant, environment, 'failed');
+      await expect(dot).toHaveAttribute('data-env-state', 'failed', { timeout: 1_000 });
+      await expect(dot).toHaveAttribute('data-env-opened', 'false', { timeout: 1_000 });
+      await expect(dot).toHaveAccessibleName(/deploy failed/, { timeout: 1_000 });
+    }).toPass({ timeout: 20_000 });
+
+    // A passive light, not a control: there is no tab left to close.
+    await expect(dot).not.toHaveAccessibleName(new RegExp(`^Close ${tenant} / ${environment}`));
+
+    // Clear the sticky flag so the singleton backend returns to its
+    // pre-test shape for later specs.
+    await emitEnvStatus(page, tenant, environment, '');
+  });
 });
 
 // Mirrors the env-status event the Go side emits from tryReconnect's refusal paths


### PR DESCRIPTION
A failure lost its cause at four separate rendering boundaries, so a failed build
or deploy could report success — or worse, report a confident negative.

The health probe is the clearest case: a real probe failure (VPN down, rotated
token, unreachable API server) rendered as **"not deployed"** rather than "could
not check", which hands the operator a Deploy button that will fail in exactly the
same way for exactly the same reason.

That is the same conflation — a failed probe becoming a definite absence — that has
now produced **five** separate issues in this repo, so the new Go test pins the
honest branch rather than trusting the convention to hold:
`TestRuntimeDeployedHealthCheckPropagatesProbeError`.

Most of the loss happened in the thunk layer: a rejected call resolved to a shape
indistinguishable from an empty success, so the reducer had nothing to render a
cause from. The error now travels with the rejection through the notification
slice to the surfaces that display it.

| check | result |
|---|---|
| `erun-common` / `erun-integration` / `erun-ui` `go test ./...` | ok (each also under a stripped PATH) |
| `golangci-lint` (all three) | 0 issues |
| erun-kit / erun-ui/frontend / erun-console — typecheck, lint, format:check, test | all clean |
| frontend units | **139/139** |
| playwright `tsc --noEmit` | clean |
| `app-notification.spec.ts` | 6 passed |
| `env-init.spec.ts` | 14 passed |
| `sidebar-open-dot.spec.ts` | 4 passed |
| `manage-environment-health.spec.ts` | 3 passed |
| `manage-delete-partial-failure.spec.ts` | 1 passed |
| `close-environment-failure.spec.ts` | 1 passed |

## Provenance and honesty about the verification

The implementation came from an in-pod agent run that ended its turn with **52
files uncommitted and no commit at all**. Nothing was lost; I reviewed the diff,
committed it, rebased it twice (once for #1268's specs, once for #1211's erun-kit
extraction), and ran the gates above.

Two things I had to fix while landing it, both mine rather than the original work's:

- My first conflict resolution in `env-init.spec.ts` concatenated both sides' test
  blocks and left one test unterminated (`TS1005: '}' expected`). The two sides
  shared a closing brace.
- `LocalRepoPathInput.tsx` conflicted on imports. Resolved by keeping only
  `showTerminalError` — `Button`, `Input` and `FieldLabel` now come from `erun-kit`
  on line 1 after #1211, so the branch's versions were duplicates, and
  `showTerminalMessage` had no remaining usage.

One note on flakiness: `close-environment-failure.spec.ts` failed once when I ran
it alongside four other Playwright gates on the same box, and passes on its own.
I am reporting it as passing on that basis rather than claiming it never failed.

Closes #1212