### PR TITLE
Format the console identity panels so main passes format:check again

### DIFF
--- a/erun-console/src/identity/OrgSettingsPanel.tsx
+++ b/erun-console/src/identity/OrgSettingsPanel.tsx
@@ -169,7 +169,9 @@ function OrgSettingsBody({
       </p>
     );
   }
-  return <SettingsForm settings={state.settings} saving={state.status === 'saving'} onSave={onSave} />;
+  return (
+    <SettingsForm settings={state.settings} saving={state.status === 'saving'} onSave={onSave} />
+  );
 }
 
 // OrgSettingsPanel is the console's view of the platform IdP org settings an

--- a/erun-console/src/identity/UsersPanel.test.tsx
+++ b/erun-console/src/identity/UsersPanel.test.tsx
@@ -54,7 +54,12 @@ describe('UsersPanel', () => {
     mockFetch((req) => {
       if (req.url === '/v1/identity/users') {
         return jsonResponse([
-          { id: 'idp-1', username: 'alice', state: 'USER_STATE_ACTIVE', email: 'alice@example.com' },
+          {
+            id: 'idp-1',
+            username: 'alice',
+            state: 'USER_STATE_ACTIVE',
+            email: 'alice@example.com',
+          },
         ]);
       }
       return jsonResponse({}, 404);

--- a/erun-console/src/identity/UsersPanel.tsx
+++ b/erun-console/src/identity/UsersPanel.tsx
@@ -10,7 +10,8 @@ function EnrollFeedback({ enroll }: { enroll: EnrollState }): React.ReactElement
       return (
         <p className="identity-feedback identity-feedback--error" role="alert">
           {enroll.result.idpUser.username} was created in the identity provider (id{' '}
-          {enroll.result.idpUser.id}), but could not be enrolled as an erun user: {enroll.result.error}
+          {enroll.result.idpUser.id}), but could not be enrolled as an erun user:{' '}
+          {enroll.result.error}
         </p>
       );
     }


### PR DESCRIPTION
`main` fails `yarn format:check` in `erun-console` on three files from #1292:
`OrgSettingsPanel.tsx`, `UsersPanel.tsx`, `UsersPanel.test.tsx`.

**This one is mine, not the PR's.** Prettier listed five unformatted files; my
check output was truncated to two, I formatted those, and merged without
re-running the check to see the remaining three. Formatting the whole package
(`prettier --write .`) rather than a hand-picked list is both the fix and the
lesson — a truncated failure list is not a complete one.

Verified: `format:check` clean in all three workspaces — `erun-kit`,
`erun-ui/frontend`, `erun-console`.