### PR TITLE
Construct the absence of ERUN_ORCHESTRATOR_ID instead of assuming it

### DIFF
--- a/erun-ui/orchestrator_live_session_test.go
+++ b/erun-ui/orchestrator_live_session_test.go
@@ -14,10 +14,20 @@ func runOrchestratorSessionRecordHook(t *testing.T, shell, orchestratorID, input
 	t.Helper()
 	cmd := exec.Command(shell, "-c", orchestratorSessionRecordHookCommand())
 	cmd.Stdin = strings.NewReader(input)
+	// Absence has to be CONSTRUCTED, not assumed. Passing os.Environ() through
+	// unchanged let the ambient ERUN_ORCHESTRATOR_ID leak into the very test that
+	// asserts what happens without one -- and every orchestrator host exports it,
+	// so "no id" silently became "the operator's id" and the no-write assertion
+	// failed on exactly the machines that run this code.
+	cmd.Env = make([]string, 0, len(os.Environ())+1)
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "ERUN_ORCHESTRATOR_ID=") {
+			continue
+		}
+		cmd.Env = append(cmd.Env, kv)
+	}
 	if orchestratorID != "" {
-		cmd.Env = append(os.Environ(), "ERUN_ORCHESTRATOR_ID="+orchestratorID)
-	} else {
-		cmd.Env = os.Environ()
+		cmd.Env = append(cmd.Env, "ERUN_ORCHESTRATOR_ID="+orchestratorID)
 	}
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("run session-record hook: %v\n%s", err, out)


### PR DESCRIPTION
`TestOrchestratorSessionRecordHookSkipsASessionWithNoID` asserts that a session
carrying no orchestrator id writes nothing. Its helper passed `os.Environ()`
through unchanged whenever the id was empty:

```go
if orchestratorID != "" {
    cmd.Env = append(os.Environ(), "ERUN_ORCHESTRATOR_ID="+orchestratorID)
} else {
    cmd.Env = os.Environ()   // <- the ambient value survives
}
```

**Every orchestrator host exports `ERUN_ORCHESTRATOR_ID`.** So on exactly the
machines that run this code, "no id" silently became "the operator's id", the hook
wrote a file, and the no-write assertion failed — presenting as a real regression
in unrelated work.

The helper now strips the variable from the child environment and re-adds it only
when a test asks for one. Absence is constructed rather than assumed.

## Verification, both directions

| | result |
|---|---|
| with fix, `ERUN_ORCHESTRATOR_ID=erun` exported | ok |
| with fix, variable unset | ok |
| **fix stashed**, variable exported | **FAIL** |
| full `erun-ui` suite, variable exported | ok (14.6s) |
| `gofmt -l` | clean |

The stashed run is the part that matters: it confirms the change is load-bearing
rather than incidental.

## How this was found

A six-lens audit for latent whole-repo hazards, after `main` broke three times in
one day. This is the same class as a bug I introduced myself earlier today — a test
that passes or fails depending on the environment it happens to run in, which is
indistinguishable from a real defect at the moment you hit it.

Four related hazards from the same audit are filed as #1301, #1302, #1303 and
#1304. This one was small enough to just fix.