### PR TITLE
Strip the issue ID from the test-frontend Makefile comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,10 @@ test-erun-ui:
 # The shared frontend kit (erun-kit) and the hosted console (erun-console) —
 # the two Yarn-workspace members outside erun-ui/frontend (in the workspace,
 # so `yarn install` here resolves all three, but its own gate stays in
-# erun-ui/build.sh; see that target's comment for why). This is what erun#1207
-# added to close the gap the issue named: the console's own gates
-# (`erun-console/AGENTS.md`) previously ran "by hand or not at all", so the
-# module drifted from the desktop's design system by default.
+# erun-ui/build.sh; see that target's comment for why). Closes the gap where
+# the console's own gates (`erun-console/AGENTS.md`) previously ran "by hand
+# or not at all", so the module drifted from the desktop's design system by
+# default.
 #
 # `yarn shadcn:check` (erun-kit) is deliberately excluded here: it fetches
 # component definitions from ui.shadcn.com on every invocation, a third-party


### PR DESCRIPTION
## Summary

#1298 asked to add `erun-kit` and `erun-console` to `make check`. That work already landed on `main` by the time this branch was cut, via #1300 (which closed #1207 — the issue that tracked the same scope item, filed and worked concurrently with #1298 in this pod). Confirmed on `main` at `328e4e7c`:

- `Makefile`'s `test-frontend` target runs both workspaces' `typecheck && lint && format:check && build` (plus `yarn test` for `erun-console`), wired into `check: lint test-erun-ui test-frontend integration-test` — the same one-step weight `test-erun-ui` gives the desktop.
- The `erun-devops` test-stage Dockerfile now carries a pinned Node/Yarn toolchain (copied out of a pinned `node:22.14-bookworm` stage, same pattern as `golangci-lint`/`goroot`), so `make check` genuinely has node/yarn wherever it runs — the image build included — rather than needing to degrade.

So #1298's premise ("erun-kit and erun-console are not in `make check`") no longer holds; it's a duplicate of already-merged work, not open scope. This PR is the independent re-verification of that work plus the one real defect it surfaced.

## What I found and fixed

`test-frontend`'s Makefile comment embedded an issue ID (`This is what erun#1207 added...`), which `AGENTS.md`'s "Code Comments" section explicitly forbids for source comments (provenance belongs in git history, not the comment). Stripped the ID, kept the explanatory text.

## Verification

Independently re-ran the full gate, not just trusted the prior merge:

- `yarn install` from repo root — clean, `yarn.lock` unchanged.
- `cd erun-ui && ./build.sh /tmp/verify-1298` — regenerates the gitignored `wailsjs/` bindings; green.
- `erun-kit`: `yarn typecheck && yarn lint && yarn format:check && yarn build && yarn test` — clean (0 tests currently, per `erun-kit/AGENTS.md`'s own validation list, which doesn't list `yarn test` yet either since the module has none).
- `erun-console`: `yarn typecheck && yarn lint && yarn format:check && yarn build && yarn test` — clean, 57 tests passing.
- `erun-ui/frontend`: `yarn typecheck && yarn lint && yarn format:check && yarn test` — clean, 139 tests passing.
- `erun-ui/playwright`: `yarn tsc --noEmit` — clean (needed a local `yarn install` first; stale `node_modules` in my clone, unrelated to this change).
- **Deliberate-break check**, exactly what #1298's own scope asked for as acceptance evidence: appended an unused top-level `const` to `erun-kit/src/index.ts` and ran `make test-frontend` — failed immediately and clearly at the `erun-kit` typecheck step (`TS6133: 'unusedDeliberateBreak' is declared but its value is never read`), `make: *** [Makefile:81: test-frontend] Error 2`. Reverted.
- Built the actual `erun-devops` Dockerfile `test` stage end-to-end (`docker build --target test`), not just on the host: golangci-lint across all Go modules, `erun-ui`'s Go tests, `make test-frontend` (both workspaces, node/yarn resolved from the baked toolchain), then the integration suite at 76.3% coverage — all green inside the real image build. Removed the resulting probe image afterward.

No Go module was touched by this change, so the Go test/lint gates weren't independently re-run outside of what the Docker test-stage build above already exercised (which covers every `LINT_MODULES` entry).

## Docs

No `erun-docs` update: this is internal build-tooling/comment cleanup with no product-facing behavior change.

Closes #1298