### PR TITLE
Refuse the integration gate when UPDATE_GOLDEN leaks in from the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,10 @@ test-erun-ui:
 # Build, run, and coverage-gate the erun integration suite.
 # The coverage threshold defaults to the value pinned in
 # erun-integration/scripts/integration-test.sh; override with
-# COVERAGE_THRESHOLD=NN. Use UPDATE_GOLDEN=1 to refresh testdata files in
-# place.
+# COVERAGE_THRESHOLD=NN. To refresh testdata files in place, run the script
+# directly with --update-golden (./erun-integration/scripts/integration-test.sh
+# --update-golden) — gate mode refuses outright if UPDATE_GOLDEN is set in the
+# environment, so it cannot be reseeded via `make check UPDATE_GOLDEN=1`.
 integration-test:
 	./erun-integration/scripts/integration-test.sh
 

--- a/erun-integration/AGENTS.md
+++ b/erun-integration/AGENTS.md
@@ -233,7 +233,8 @@ and keep `skipIfPortsBusy` as a last-resort guard only.
 ## Goldens and normalization
 
 - `golden.Equal(t, "command/scenario", normalize.Apply(out))` is the standard assertion. Normalization strips ANSI escapes, version numbers, ISO timestamps, compact timestamps, OS temp paths, hex tokens, and home-dir prefixes. Add new rules to `internal/normalize/` if a fresh source of nondeterminism appears in output.
-- Set `UPDATE_GOLDEN=1` to (re)write the file. Default mode is read-and-compare.
+- Set `UPDATE_GOLDEN=1` to (re)write the file when invoking `go test` directly (e.g. `UPDATE_GOLDEN=1 go test -run Test<Command> ./...`). Default mode is read-and-compare.
+- The gate script (`scripts/integration-test.sh`, run by `make integration-test`/`make check`) never honors `UPDATE_GOLDEN` from the environment — it refuses outright if the variable is set, since Make exports command-line variables into recipe environments and an inherited `UPDATE_GOLDEN=1` would turn every `golden.Equal` into a silent write instead of a comparison while the gate still reports green. To reseed testdata, run `./erun-integration/scripts/integration-test.sh --update-golden` directly; it skips the coverage gate and cannot be triggered via `make check UPDATE_GOLDEN=1`.
 - Goldens are reviewed artifacts. Treat a diff in any golden file as a behavior change to inspect, not as noise. If a trace line drift reflects an intentional change, update and explain in the PR. If it doesn't, the test is doing its job.
 
 ### Whole-output snapshots vs targeted substring assertions

--- a/erun-integration/scripts/integration-test.sh
+++ b/erun-integration/scripts/integration-test.sh
@@ -4,12 +4,18 @@
 #
 # Usage:
 #   ./scripts/integration-test.sh [-threshold=NN]
+#   ./scripts/integration-test.sh --update-golden
+#
+# Gate mode (default) and golden-reseed mode are mutually exclusive. Reseeding
+# is opt-in only via the --update-golden flag, which cannot be set from a
+# parent `make`/environment invocation. If UPDATE_GOLDEN is set in the
+# environment and --update-golden was not passed, the script refuses to run
+# rather than silently comparing nothing while still reporting a green gate.
 #
 # Environment:
 #   COVERAGE_THRESHOLD   default 75 (percent). See note below.
 #   GOCOVERDIR           override the directory used for raw counter files;
 #                        defaults to ./coverage/raw under the script.
-#   UPDATE_GOLDEN=1      regenerate golden output files instead of comparing.
 #
 # Notes:
 #   - The instrumented binary is rebuilt each run so signatures stay aligned
@@ -34,14 +40,28 @@
 set -euo pipefail
 
 threshold="${COVERAGE_THRESHOLD:-76.2}"
+update_golden=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -threshold=*) threshold="${1#-threshold=}" ;;
         --threshold=*) threshold="${1#--threshold=}" ;;
+        --update-golden) update_golden=1 ;;
         *) echo "unknown arg: $1" >&2; exit 2 ;;
     esac
     shift
 done
+
+if [[ -n "${UPDATE_GOLDEN:-}" && "$update_golden" -eq 0 ]]; then
+    echo "!! UPDATE_GOLDEN is set in the environment, but this script only reseeds" >&2
+    echo "!! goldens via the explicit --update-golden flag. Gate mode and golden-" >&2
+    echo "!! reseed mode are mutually exclusive: an inherited UPDATE_GOLDEN would" >&2
+    echo "!! make every golden.Equal comparison a silent no-op write instead of a" >&2
+    echo "!! check, so the gate refuses to run rather than report a false green." >&2
+    echo "!!" >&2
+    echo "!! Unset UPDATE_GOLDEN to run the gate, or pass --update-golden explicitly" >&2
+    echo "!! to reseed testdata (this skips the coverage gate)." >&2
+    exit 2
+fi
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$here"
@@ -53,6 +73,13 @@ mkdir -p "$(dirname "$profile")"
 rm -rf "$cover_dir"/*
 
 export GOCOVERDIR="$cover_dir"
+
+if [[ "$update_golden" -eq 1 ]]; then
+    echo ">> reseeding golden files (comparisons disabled, coverage gate skipped)"
+    UPDATE_GOLDEN=1 go test -count=1 ./...
+    echo ">> golden files reseeded; inspect the testdata diff, then re-run without --update-golden to gate"
+    exit 0
+fi
 
 echo ">> running integration suite (cover dir: $cover_dir)"
 go test -count=1 ./...


### PR DESCRIPTION
## Summary

`make check UPDATE_GOLDEN=1` — an invocation `Makefile:64` itself advertised — silently disabled the entire integration suite's verification: `golden.Equal` writes the golden file and returns before comparing when `UPDATE_GOLDEN=1` is set, so every one of the ~788 `golden.Equal(` call sites became a no-op write instead of an assertion. The coverage gate still reported green (production code still executes), and the resulting testdata diff read as an intentional golden refresh, so review didn't catch it either. GNU Make exports command-line variables into recipe environments and child scripts, so `UPDATE_GOLDEN=1` reached `go test` via `integration-test.sh` without anyone typing an env var into a shell.

## Fix

- `erun-integration/scripts/integration-test.sh` now **refuses outright** when `UPDATE_GOLDEN` is set in the environment and `--update-golden` wasn't passed explicitly — gate mode and golden-reseed mode are mutually exclusive, and the script says so loudly instead of silently preferring one.
- Reseeding moved behind an explicit `--update-golden` script flag, which cannot arrive from a parent `make`/environment invocation. Reseed mode skips the coverage gate (it isn't a gate run) and prints a message telling the operator to inspect the diff and re-run without the flag to gate.
- Deleted the `Makefile:64` sentence advertising `UPDATE_GOLDEN=1` as a way to refresh testdata in place.
- Added a note to `erun-integration/AGENTS.md` under "Goldens and normalization" documenting that the gate script never honors an inherited `UPDATE_GOLDEN`, and that reseeding is `./erun-integration/scripts/integration-test.sh --update-golden`.

`golden.go`'s own `UPDATE_GOLDEN=1 go test ...` contract for direct `go test` invocations (e.g. seeding a brand-new scenario per the "Adding a new command's tests" workflow) is unchanged — the fix is scoped to the gate script that `make check`/`make integration-test` runs.

## Proof

Refusal fires on the exact reported invocation:
```
$ make integration-test UPDATE_GOLDEN=1
!! UPDATE_GOLDEN is set in the environment, but this script only reseeds
!! goldens via the explicit --update-golden flag. Gate mode and golden-
!! reseed mode are mutually exclusive: an inherited UPDATE_GOLDEN would
!! make every golden.Equal comparison a silent no-op write instead of a
!! check, so the gate refuses to run rather than report a false green.
!!
!! Unset UPDATE_GOLDEN to run the gate, or pass --update-golden explicitly
!! to reseed testdata (this skips the coverage gate).
make: *** [Makefile:69: integration-test] Error 2
```

Normal gate path still works and still compares — a clean `make integration-test` run (no env var set) passes with real comparisons and the coverage gate:
```
$ make integration-test
...
ok  coverage 76.3% (>= 76.2%)
```

`--update-golden` was also exercised directly (against the real testdata, since production code is unchanged it produced no diff, proving the write path executes without corrupting anything): `./erun-integration/scripts/integration-test.sh --update-golden` reseeds and reports "golden files reseeded; inspect the testdata diff, then re-run without --update-golden to gate", skipping the coverage step entirely.

## Test plan

- [x] `make integration-test UPDATE_GOLDEN=1` refuses with exit 2 (mechanism proven, not the destructive path — no testdata was touched by this).
- [x] `./erun-integration/scripts/integration-test.sh` (no env var) — clean gate pass, coverage 76.3% >= 76.2%.
- [x] `./erun-integration/scripts/integration-test.sh --update-golden` — reseeds, skips gate, no unintended testdata diff.
- [x] `cd erun-integration && go test ./...` — green (aside from transient host-contention flakes unrelated to this change — a real-run timing-order test and a port-forward scenario — both isolated re-runs passed cleanly; this shared pod is running several concurrent agents).
- [x] `cd erun-integration && env PATH=/usr/local/go/bin:/usr/bin:/bin go test ./...` — green.
- [x] `cd erun-integration && golangci-lint run ./...` — 0 issues.
- [x] No `.go` files changed; only the shell script, `Makefile`, and `AGENTS.md`.

Closes #1304