### PR TITLE
Build the console image from the workspace root so erun-kit resolves

### DIFF
--- a/Formula/erun.rb
+++ b/Formula/erun.rb
@@ -1,7 +1,7 @@
 class Erun < Formula
   desc "Multi-tenant multi-environment deployment and management tool"
   homepage "https://github.com/sophium/erun"
-  url "https://github.com/sophium/erun/archive/refs/tags/v1.0.201.tar.gz"
+  url "https://github.com/sophium/erun/archive/refs/tags/v1.0.202.tar.gz"
   sha256 "76d0aa288f6635a0e0979efb410cfbba421c520c8c62817d127652ebc67a1c93"
   license "MIT"
 

--- a/bucket/erun.json
+++ b/bucket/erun.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.201",
+  "version": "1.0.202",
   "description": "Multi-tenant multi-environment deployment and management tool",
   "homepage": "https://github.com/sophium/erun",
   "license": "MIT",
@@ -9,9 +9,9 @@
     "nodejs",
     "yarn"
   ],
-  "url": "https://github.com/sophium/erun/archive/refs/tags/v1.0.201.zip",
+  "url": "https://github.com/sophium/erun/archive/refs/tags/v1.0.202.zip",
   "hash": "a72a0e6a74077a7226c51c58b3219d5d2267f7a7cfcc51bb9edadbd59491f582",
-  "extract_dir": "erun-1.0.201",
+  "extract_dir": "erun-1.0.202",
   "installer": {
     "script": [
       "$env:CGO_ENABLED = '0'",

--- a/erun-devops/docker/erun-console/Dockerfile
+++ b/erun-devops/docker/erun-console/Dockerfile
@@ -1,23 +1,45 @@
 ARG ERUN_VERSION=1.0.0
 
-# Stage 1: build the Vite/React SPA. Needs a newer Node 20 than erun-docs pins
-# (20.18.1) — @vitejs/plugin-react@6 requires >=20.19.0.
+# Stage 1: build the Vite/React SPA. Node 22 rather than 20: installing from the
+# workspace root (see below) resolves the whole workspace's devDependencies, and
+# @testing-library/jest-dom@6 declares engines node >=22. Pinned to the same
+# 22.14 line the erun-devops test stage already uses, so the two agree. Bumping
+# the image is the honest fix here — --ignore-engines would silently install a
+# module against an engine it rejects.
 # Pinned to the build host's platform: the bundle it emits is static assets with
 # no architecture, so building it once natively beats building it again under
 # emulation for the foreign arch every multi-arch build.
-FROM --platform=$BUILDPLATFORM node:20.19.0-alpine AS builder
+FROM --platform=$BUILDPLATFORM node:22.14-alpine AS builder
 
 WORKDIR /src
 
-# Install deps first so source edits don't bust the cache.
-COPY erun-console/package.json erun-console/yarn.lock /src/erun-console/
-
-WORKDIR /src/erun-console
+# Install from the WORKSPACE ROOT, not from erun-console alone. erun-console
+# depends on erun-kit ("erun-kit": "*"), which is a yarn workspace sibling
+# resolved through the root node_modules symlink rather than published to a
+# registry. Installing erun-console on its own makes yarn try to fetch it and
+# fail with `https://registry.yarnpkg.com/erun-kit: Not found` — which is
+# exactly how this image broke when the kit was extracted, and why no gate
+# caught it: every other check runs at the root, where the symlink exists, and
+# this image build is the only place the console is installed in isolation.
+#
+# All four workspace manifests are copied because yarn 1 resolves the whole
+# workspace set from the root lockfile; omitting one makes --frozen-lockfile
+# unsatisfiable. Manifests first, sources after, so a source edit does not bust
+# the dependency layer.
+COPY package.json yarn.lock /src/
+COPY erun-kit/package.json /src/erun-kit/
+COPY erun-console/package.json /src/erun-console/
+COPY erun-ui/frontend/package.json /src/erun-ui/frontend/
 
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn \
     yarn install --frozen-lockfile --non-interactive
 
+# erun-kit's package.json main points at ./src/index.ts, so the console's vite
+# build compiles the kit from source and the kit needs no build step of its own.
+COPY erun-kit /src/erun-kit
 COPY erun-console /src/erun-console
+
+WORKDIR /src/erun-console
 
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn \
     yarn build

--- a/erun-devops/k8s/erun-backend-api/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-api/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.201
+appVersion: 1.0.202
 description: ERun backend API
 name: erun-backend-api
 type: application
-version: 1.0.201
+version: 1.0.202

--- a/erun-devops/k8s/erun-backend-db/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-db/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.201
+appVersion: 1.0.202
 description: ERun backend database migration job
 name: erun-backend-db
 type: application
-version: 1.0.201
+version: 1.0.202

--- a/erun-devops/k8s/erun-backend-postgres/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-postgres/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.201
+appVersion: 1.0.202
 description: ERun backend PostgreSQL
 name: erun-backend-postgres
 type: application
-version: 1.0.201
+version: 1.0.202

--- a/erun-devops/k8s/erun-console/Chart.yaml
+++ b/erun-devops/k8s/erun-console/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.201
+appVersion: 1.0.202
 description: ERun hosted web console
 name: erun-console
 type: application
-version: 1.0.201
+version: 1.0.202

--- a/erun-devops/k8s/erun-devops/Chart.yaml
+++ b/erun-devops/k8s/erun-devops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.201
+appVersion: 1.0.202
 description: ERun DevOps
 name: erun-devops
 type: application
-version: 1.0.201
+version: 1.0.202

--- a/erun-devops/k8s/erun-docs/Chart.yaml
+++ b/erun-devops/k8s/erun-docs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.201
+appVersion: 1.0.202
 description: Publish the ERun documentation site to Cloudflare Pages
 name: erun-docs
 type: application
-version: 1.0.201
+version: 1.0.202

--- a/erun-devops/k8s/erun-oci-registry/Chart.yaml
+++ b/erun-devops/k8s/erun-oci-registry/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.201
+appVersion: 1.0.202
 description: ERun hosted OCI container registry (zot), authenticated by tenant API token
 name: erun-oci-registry
 type: application
-version: 1.0.201
+version: 1.0.202

--- a/erun-devops/k8s/erun-powerdns/Chart.yaml
+++ b/erun-devops/k8s/erun-powerdns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.201
+appVersion: 1.0.202
 description: ERun platform PowerDNS authoritative nameserver
 name: erun-powerdns
 type: application
-version: 1.0.201
+version: 1.0.202

--- a/erun-devops/k8s/erun-zitadel/Chart.yaml
+++ b/erun-devops/k8s/erun-zitadel/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.201
+appVersion: 1.0.202
 description: ERun platform hosted IdP (Zitadel)
 name: erun-zitadel
 type: application
-version: 1.0.201
+version: 1.0.202

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/chart-dns01-webhook/Chart.yaml
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/chart-dns01-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.201
+appVersion: 1.0.202
 description: cert-manager ACME DNS-01 webhook (per-cluster singleton) that forwards present/cleanup to the erun DNS-01 broker, carrying each challenge's env-scoped token. The broker authorizes the write against the token's tenant subzone, so per-tenant cert issuance is safe on a shared cluster.
 name: erun-dns01-webhook
 type: application
-version: 1.0.201
+version: 1.0.202

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/chart-issuer/Chart.yaml
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/chart-issuer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.201
+appVersion: 1.0.202
 description: namespaced cert-manager Issuer (Cloudflare or PowerDNS RFC2136 DNS-01) + optional wildcard Certificate for the erun services edge. Applied by the terraform-erun-cluster-edge module after cert-manager's CRDs exist.
 name: erun-cluster-edge-issuer
 type: application
-version: 1.0.201
+version: 1.0.202


### PR DESCRIPTION
The `erun-console` image build has been broken since erun-kit was extracted
(#1211). It took a release attempt to find out — the release died 1m23s in.

## Cause

The builder stage copied only `erun-console/package.json` and its own
`yarn.lock`, then installed in isolation. But `erun-console` declares
`"erun-kit": "*"`, and erun-kit is a **yarn workspace sibling** resolved through
the root `node_modules` symlink — not a published package. So yarn went to the
registry:

```
error Error: https://registry.yarnpkg.com/erun-kit: Not found
```

## Why no gate caught it

Every other check installs from the **workspace root**, where the symlink
exists: the three workspace gates, `scripts/repo-gate.sh`, and the erun-devops
test stage. This image build is the only place the console is installed on its
own, and **the only thing that runs it is a release.** So the gap was invisible
to a green `main` by construction.

Worth noting `erun-console/yarn.lock` contains zero erun-kit entries and cannot
contain them — a workspace sibling has no registry entry. That stray per-package
lockfile is now misleading and worth removing separately; anyone running
`cd erun-console && yarn install` hits the same wall.

## Fix

Install from the root. All four workspace manifests are copied, because yarn 1
resolves the whole workspace set from the root lockfile and omitting one makes
`--frozen-lockfile` unsatisfiable. Manifests before sources, so a source edit
doesn't bust the dependency layer.

That surfaced a second real constraint: resolving the whole workspace pulls in
`@testing-library/jest-dom@6`, which declares `engines: node >=22`, so the
builder's `node:20.19.0-alpine` pin no longer works. Bumped to
`node:22.14-alpine` — the same 22.14 line the erun-devops test stage already
pins, so the two agree. `--ignore-engines` would have hidden a module being
installed against an engine that rejects it.

## Verification — the image was inspected, not just built

| probe | new image | production today |
|---|---|---|
| bundle size | **454,392 B** | 219,103 B |
| `OPERATIONS` (sidebar group label) | present | absent |
| `Org settings` | present | absent |
| `Overview` | present | absent |
| `Identity` | present | absent |

So the image carries the new app shell, the Redux console and the identity
panels — not a rebuild of the old tree. A first pass at this check grepped for
component names and found nothing; that proved only that the bundle is minified.
String literals survive minification, which is why the probe uses labels.