### PR TITLE
Pin the node stage to BUILDPLATFORM so multi-arch release builds work

### DIFF
--- a/erun-devops/docker/erun-devops/Dockerfile
+++ b/erun-devops/docker/erun-devops/Dockerfile
@@ -2,7 +2,13 @@
 # of — see the node COPY below. No RUN of its own, so it needs no emulation
 # even though the test stage is pinned to BUILDPLATFORM (matches the `goroot`
 # stage's reasoning further down).
-FROM node:22.14-bookworm AS node
+# Pinned to $BUILDPLATFORM because its only consumer is the `test` stage below,
+# which is itself $BUILDPLATFORM: this toolchain runs `make test-frontend` at
+# build time and never ships in the final image. Left unpinned it resolves to
+# the TARGET platform, so a multi-arch release copied an amd64 `node` into an
+# arm64 stage and died with "running an x86 program on an arm64 OS". Only a
+# release builds both arches, so a native build never showed it.
+FROM --platform=$BUILDPLATFORM node:22.14-bookworm AS node
 
 # Run the repository test gate inside the build, per the delivery-pipeline
 # convention (docs /pipeline, "How you set it up — and where tests run"):


### PR DESCRIPTION
The `erun-devops` image cannot build for a foreign architecture. A release does
exactly that, and died on it:

```
running an x86 program on an arm64 OS without multi-arch libraries
Dockerfile:36  npm install -g yarn@1.22.22
```

## Cause

The node stage was `FROM node:22.14-bookworm AS node` with **no platform pin**, so
it resolves to the **target** platform. Its only consumer is the `test` stage,
which is pinned to `$BUILDPLATFORM`. Building `linux/amd64` on an arm64 host thus
copied an amd64 `node` binary into an arm64 stage, and the first thing to exec it
failed.

## Fix

Pin the node stage to `$BUILDPLATFORM`. That's the correct answer rather than a
workaround: this toolchain exists to run `make test-frontend` at build time and
**never ships in the final image**, which is exactly why the stage consuming it is
already `$BUILDPLATFORM`.

## The pattern worth noting

Only a release builds both architectures, so a native `erun build` never showed
this. It's the same blind spot that hid the erun-console workspace-install break
(#1318): **image builds are gated by nothing except an actual release.** Two
release-blocking image defects in a row, both introduced by work that was
individually green, both invisible to `repo-gate.sh` — which does not build images.

That's worth a follow-up: the gate could build each image for one foreign arch
(`--target test`, no push) to catch this class without a full release.

## Verification

Built the failing combination directly rather than assuming the pin fixed it:
`docker build --platform linux/amd64 --target test` now succeeds, and the test
stage runs the suite to completion inside the image — **coverage 76.3% (>= 76.2%)**.