### PR TITLE
Stand down the repaint nudges when the user types

### DIFF
--- a/erun-ui/frontend/src/app/TerminalController.ts
+++ b/erun-ui/frontend/src/app/TerminalController.ts
@@ -246,6 +246,10 @@ export class TerminalController {
       () => this.writeSources.currentIsReplay(),
     );
     this.terminalDataDisposable = this.terminal.onData((data) => {
+      // Before the write, not after: a synthetic resize cycle in flight has to
+      // stand down as early as possible, because it is the reflow landing on a
+      // line being typed that corrupts the submission (#1330).
+      this.reattachRepaint.noteInput();
       SendSessionInput(store.getState().terminal.sessionId, data).catch((error: unknown) => {
         store.dispatch(showTerminalError(readError(error)));
       });

--- a/erun-ui/frontend/src/app/terminalReattachRepaint.test.ts
+++ b/erun-ui/frontend/src/app/terminalReattachRepaint.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, mock, test } from 'node:test';
+
+import { noop } from 'erun-kit';
+
+import { TerminalReattachRepaint } from './terminalReattachRepaint';
+
+// TerminalReattachRepaint touches window only inside its methods -- never at
+// module scope -- so a shim installed per test is enough to drive the real
+// class. The generated Wails binding is the same: it dereferences window.go
+// inside the call, so ResizeSession lands on the stub below.
+const resizeCalls: [number, number, number][] = [];
+
+function installWindow(): void {
+  const shim = {
+    // Unqualified globals, resolved at call time, so mock.timers is what runs.
+    setTimeout: (handler: () => void, ms?: number) => setTimeout(handler, ms) as unknown as number,
+    clearTimeout: (id: number) => {
+      clearTimeout(id);
+    },
+    setInterval: (handler: () => void, ms?: number) =>
+      setInterval(handler, ms) as unknown as number,
+    clearInterval: (id: number) => {
+      clearInterval(id);
+    },
+    go: {
+      main: {
+        App: {
+          ResizeSession: (id: number, cols: number, rows: number) => {
+            resizeCalls.push([id, cols, rows]);
+            return Promise.resolve();
+          },
+        },
+      },
+    },
+  };
+  (globalThis as unknown as { window: unknown }).window = shim;
+}
+
+function lastResizeCall(): [number, number, number] | undefined {
+  return resizeCalls[resizeCalls.length - 1];
+}
+
+let fitCount = 0;
+
+function fakeTerminal(cols: number, rows: number) {
+  const resizes: [number, number][] = [];
+  return {
+    cols,
+    rows,
+    resizes,
+    // Every line reads empty: the state dtach leaves a reattached pane in, and
+    // therefore the state the repaint cycle fires on.
+    buffer: { active: { viewportY: 0, getLine: () => null } },
+    resize(nextCols: number, nextRows: number) {
+      this.cols = nextCols;
+      this.rows = nextRows;
+      resizes.push([nextCols, nextRows]);
+    },
+  };
+}
+
+function harness() {
+  const terminal = fakeTerminal(120, 40);
+  fitCount = 0;
+  const repaint = new TerminalReattachRepaint({
+    getTerminal: () => terminal as never,
+    getFitAddon: () =>
+      ({
+        fit: () => {
+          fitCount += 1;
+        },
+      }) as never,
+    activeSessionId: () => 7,
+    afterRestore: noop,
+  });
+  return { terminal, repaint };
+}
+
+beforeEach(() => {
+  resizeCalls.length = 0;
+  installWindow();
+  mock.timers.enable({ apis: ['setTimeout', 'setInterval'] });
+});
+
+afterEach(() => {
+  mock.timers.reset();
+});
+
+test('a keystroke restores the shrunken geometry at once, not mid-line 650ms later', () => {
+  const { terminal, repaint } = harness();
+  repaint.schedule(7);
+
+  // The poller fires and shrinks. This is the window the operator hit.
+  mock.timers.tick(1300);
+  assert.equal(terminal.rows, 26, 'expected the shrink to be applied');
+  assert.deepEqual(lastResizeCall(), [7, 120, 26]);
+
+  // The user starts typing while it is shrunk.
+  repaint.noteInput();
+  assert.equal(terminal.rows, 40, 'input must restore the rows immediately');
+  assert.deepEqual(lastResizeCall(), [7, 120, 40]);
+  assert.equal(fitCount, 1, 'the restore must re-fit exactly once');
+
+  // The original 650ms restore must not also land: a second reflow on a line
+  // being edited is the corruption.
+  const afterInput = terminal.resizes.length;
+  mock.timers.tick(5000);
+  assert.equal(terminal.resizes.length, afterInput, 'the cancelled hold must not fire');
+  assert.equal(fitCount, 1, 'the cancelled hold must not re-fit again');
+});
+
+test('input disarms the poller, so no later cycle starts behind the user', () => {
+  const { terminal, repaint } = harness();
+  repaint.schedule(7);
+  repaint.noteInput();
+
+  mock.timers.tick(30000);
+  assert.deepEqual(terminal.resizes, [], 'a pane being typed into must never be resized');
+});
+
+test('without input the cycle still completes, so the repaint is not simply disabled', () => {
+  const { terminal, repaint } = harness();
+  repaint.schedule(7);
+
+  mock.timers.tick(1300);
+  assert.equal(terminal.rows, 26);
+  mock.timers.tick(650);
+  assert.equal(terminal.rows, 40, 'the hold must restore on its own when nobody types');
+  assert.equal(fitCount, 1);
+});

--- a/erun-ui/frontend/src/app/terminalReattachRepaint.ts
+++ b/erun-ui/frontend/src/app/terminalReattachRepaint.ts
@@ -23,6 +23,8 @@ interface ReattachRepaintDeps {
 export class TerminalReattachRepaint {
   private interval = 0;
   private cycling = false;
+  private timeout = 0;
+  private restoreTo: { sessionId: number; cols: number; rows: number } | null = null;
 
   constructor(private readonly deps: ReattachRepaintDeps) {}
 
@@ -31,7 +33,44 @@ export class TerminalReattachRepaint {
       window.clearInterval(this.interval);
       this.interval = 0;
     }
+    if (this.timeout !== 0) {
+      window.clearTimeout(this.timeout);
+      this.timeout = 0;
+    }
     this.cycling = false;
+    this.restoreTo = null;
+  }
+
+  // noteInput is called for every keystroke the pane receives. The cycle below
+  // is a repaint aid for a screen that is BLANK, and its blankness gate is
+  // sampled once before the shrink (see schedule), so a user who starts typing
+  // after the shrink has begun is invisible to it. That is the reachable window
+  // -- dtach hands a reattached client a cleared screen, so "blank" is exactly
+  // the state a pane is in when someone switches in and types -- and letting
+  // the 650ms restore land mid-line reflowed the buffer being edited, which
+  // corrupted the submitted prompt (#1330).
+  //
+  // So input both disarms the poller for good (the user is plainly here; they
+  // do not need a synthetic repaint) and finishes any in-flight cycle NOW,
+  // restoring the geometry immediately instead of at the end of the hold. The
+  // restore still has to happen -- the shrink is already applied -- it just
+  // must not wait.
+  noteInput(): void {
+    const pending = this.restoreTo;
+    if (this.interval !== 0) {
+      window.clearInterval(this.interval);
+      this.interval = 0;
+    }
+    if (this.timeout !== 0) {
+      window.clearTimeout(this.timeout);
+      this.timeout = 0;
+    }
+    this.restoreTo = null;
+    if (pending === null) {
+      this.cycling = false;
+      return;
+    }
+    this.restore(pending.sessionId, pending.cols, pending.rows);
   }
 
   schedule(sessionId: number): void {
@@ -76,19 +115,30 @@ export class TerminalReattachRepaint {
     }
     const shrunk = Math.max(2, rows - Math.ceil(rows / 3));
     this.cycling = true;
+    this.restoreTo = { sessionId, cols, rows };
     terminal.resize(cols, shrunk);
     void ResizeSession(sessionId, cols, shrunk).catch(noop);
-    window.setTimeout(() => {
-      const term = this.deps.getTerminal();
-      if (!term || this.deps.activeSessionId() !== sessionId) {
-        this.cycling = false;
-        return;
-      }
-      term.resize(cols, rows);
-      fitAddon.fit();
-      this.deps.afterRestore();
-      void ResizeSession(sessionId, term.cols, term.rows).catch(noop);
-      this.cycling = false;
+    this.timeout = window.setTimeout(() => {
+      this.timeout = 0;
+      this.restoreTo = null;
+      this.restore(sessionId, cols, rows);
     }, 650);
+  }
+
+  // restore undoes the shrink. Reached either from the 650ms hold expiring or
+  // from noteInput cutting the hold short, so it must be safe to run once from
+  // whichever arrives first -- both paths clear restoreTo before calling it.
+  private restore(sessionId: number, cols: number, rows: number): void {
+    const term = this.deps.getTerminal();
+    const fitAddon = this.deps.getFitAddon();
+    if (!term || !fitAddon || this.deps.activeSessionId() !== sessionId) {
+      this.cycling = false;
+      return;
+    }
+    term.resize(cols, rows);
+    fitAddon.fit();
+    this.deps.afterRestore();
+    void ResizeSession(sessionId, term.cols, term.rows).catch(noop);
+    this.cycling = false;
   }
 }

--- a/erun-ui/terminal_repaint_input_test.go
+++ b/erun-ui/terminal_repaint_input_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// The AI repaint nudge shrinks the backend pty by a row and holds it. That is
+// invisible when the pane is the blank reattached screen the nudge exists to
+// redraw, and destructive when someone is typing into it: the TUI reflows the
+// line being edited, and the submitted prompt came out holding several
+// concatenated snapshots of it (#1330). These tests pin that a pane receiving
+// input is left alone, and -- the control -- that a quiet pane still gets its
+// repaint, so the guard cannot pass by disabling the feature.
+
+func shortenRepaintTimings(t *testing.T) {
+	t.Helper()
+	delay, settle := aiRepaintNudgeDelay, aiRepaintNudgeSettle
+	aiRepaintNudgeDelay = 5 * time.Millisecond
+	aiRepaintNudgeSettle = 400 * time.Millisecond
+	t.Cleanup(func() {
+		aiRepaintNudgeDelay, aiRepaintNudgeSettle = delay, settle
+	})
+}
+
+func (s *stubTerminalSession) resizeCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.resizes)
+}
+
+func (s *stubTerminalSession) lastResize() ([2]int, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.resizes) == 0 {
+		return [2]int{}, false
+	}
+	return s.resizes[len(s.resizes)-1], true
+}
+
+func newAITerminalForRepaint(app *App, serial int) (*managedTerminal, *stubTerminalSession) {
+	session := newSilentStubTerminalSession()
+	key := "ai-pane"
+	managed := &managedTerminal{
+		session:  session,
+		key:      key,
+		serial:   serial,
+		kind:     sessionKindAI,
+		lastCols: 120,
+		lastRows: 40,
+	}
+	app.nextSerial = serial
+	app.sessions[key] = managed
+	return managed, session
+}
+
+// waitForResizes polls until the session has recorded at least n resizes, so an
+// asynchronous nudge does not race the assertion.
+func waitForResizes(t *testing.T, session *stubTerminalSession, n int, within time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if session.resizeCount() >= n {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+// TestRepaintSessionSkipsPaneBeingTypedInto covers the tab-switch half of
+// #1330: RepaintSession fires on EVERY switch into an AI pane, so switch-then-
+// type is the reachable sequence and it must not resize the pty underneath it.
+func TestRepaintSessionSkipsPaneBeingTypedInto(t *testing.T) {
+	shortenRepaintTimings(t)
+	app := NewApp(erunUIDeps{})
+	_, session := newAITerminalForRepaint(app, 1)
+
+	if err := app.SendSessionInput(1, "spreadsheet"); err != nil {
+		t.Fatalf("SendSessionInput failed: %v", err)
+	}
+	if err := app.RepaintSession(1); err != nil {
+		t.Fatalf("RepaintSession failed: %v", err)
+	}
+
+	// Give an errant nudge every chance to land before declaring it absent.
+	if waitForResizes(t, session, 1, 300*time.Millisecond) {
+		got, _ := session.lastResize()
+		t.Fatalf("a pane being typed into must not be resized, got resize %v", got)
+	}
+}
+
+// TestRepaintSessionNudgesQuietPane is the control: with no recent input the
+// repaint must still happen, shrinking by one row and restoring. Without this,
+// the guard above could pass by never nudging at all.
+func TestRepaintSessionNudgesQuietPane(t *testing.T) {
+	shortenRepaintTimings(t)
+	app := NewApp(erunUIDeps{})
+	_, session := newAITerminalForRepaint(app, 1)
+
+	if err := app.RepaintSession(1); err != nil {
+		t.Fatalf("RepaintSession failed: %v", err)
+	}
+	if !waitForResizes(t, session, 2, 3*time.Second) {
+		t.Fatalf("a quiet pane must still be nudged, got %d resizes", session.resizeCount())
+	}
+	if got, _ := session.lastResize(); got != [2]int{120, 40} {
+		t.Fatalf("the nudge must restore the pty to its real size, ended at %v", got)
+	}
+}
+
+// TestMaybeNudgeAIRepaintSkipsPaneBeingTypedInto covers the attach-marker half.
+// It also pins that the skip does NOT consume repaintNudged: this attach has
+// not been repainted, so a later chunk must still be able to do it once the
+// user stops typing.
+func TestMaybeNudgeAIRepaintSkipsPaneBeingTypedInto(t *testing.T) {
+	shortenRepaintTimings(t)
+	app := NewApp(erunUIDeps{})
+	managed, session := newAITerminalForRepaint(app, 1)
+
+	if err := app.SendSessionInput(1, "hello"); err != nil {
+		t.Fatalf("SendSessionInput failed: %v", err)
+	}
+	app.maybeNudgeAIRepaint(managed, append([]byte("prefix"), aiAttachMarker...))
+
+	if waitForResizes(t, session, 1, 300*time.Millisecond) {
+		t.Fatalf("the attach nudge must not resize a pane being typed into")
+	}
+	app.mu.Lock()
+	nudged := managed.repaintNudged
+	app.mu.Unlock()
+	if nudged {
+		t.Fatal("skipping for input must not consume the once-per-attach nudge")
+	}
+}
+
+// TestNudgeAIRepaintRestoresEarlyWhenInputArrives pins the third window: input
+// that lands AFTER the shrink is already applied. The pty must not be held a
+// row short for the rest of the settle -- it has to be restored promptly, since
+// every millisecond it is wrong is a millisecond the TUI can reflow a line.
+func TestNudgeAIRepaintRestoresEarlyWhenInputArrives(t *testing.T) {
+	shortenRepaintTimings(t)
+	app := NewApp(erunUIDeps{})
+	managed, session := newAITerminalForRepaint(app, 1)
+
+	gen := app.sessionInputGen(managed)
+	done := make(chan struct{})
+	started := time.Now()
+	go func() {
+		app.nudgeAIRepaint(managed, 120, 40, 0, gen)
+		close(done)
+	}()
+
+	// Wait for the shrink, then type into it mid-hold.
+	if !waitForResizes(t, session, 1, 2*time.Second) {
+		t.Fatal("the nudge never applied its shrink")
+	}
+	if got, _ := session.lastResize(); got != [2]int{120, 39} {
+		t.Fatalf("expected a one-row shrink, got %v", got)
+	}
+	if err := app.SendSessionInput(1, "x"); err != nil {
+		t.Fatalf("SendSessionInput failed: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the nudge did not finish")
+	}
+	if got, _ := session.lastResize(); got != [2]int{120, 40} {
+		t.Fatalf("the pty must always end restored, ended at %v", got)
+	}
+	// The point is not merely that it restores, but that it restores EARLY.
+	// Waiting out the settle is the bug: every millisecond the pty is a row
+	// short is a millisecond the TUI can reflow the line being typed.
+	if elapsed := time.Since(started); elapsed >= aiRepaintNudgeSettle {
+		t.Fatalf("input must cut the hold short, but it ran the full settle (%v >= %v)",
+			elapsed, aiRepaintNudgeSettle)
+	}
+}

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -749,6 +749,7 @@ func (a *App) SendSessionInput(sessionID int, data string) error {
 	if _, err := io.WriteString(managed.session, data); err != nil {
 		return err
 	}
+	a.noteSessionInput(managed)
 	a.clearAwaitingPostRespawnInput(managed)
 	a.recordTerminalActivity(managed.selection)
 	if id, ok := orchestratorIDFromSessionKey(managed.key); ok {
@@ -949,11 +950,21 @@ func (a *App) RepaintSession(sessionID int) error {
 	a.mu.Lock()
 	managed := a.sessionBySerialLocked(sessionID)
 	var cols, rows int
+	var gen uint64
+	var typedRecently bool
 	if managed != nil {
 		cols, rows = managed.lastCols, managed.lastRows
+		gen = managed.inputGen
+		typedRecently = typedRecentlyLocked(managed)
 	}
 	a.mu.Unlock()
 	if managed == nil || managed.session == nil {
+		return nil
+	}
+	if typedRecently {
+		// Switching into a pane fires this on every switch, so it is the other
+		// half of #1330: a switch-and-type sequence would resize the pty under
+		// a line being entered. Someone typing needs no synthetic repaint.
 		return nil
 	}
 	// Only AI TUIs (claude/codex) need the WINCH repaint: they render on the MAIN
@@ -966,7 +977,7 @@ func (a *App) RepaintSession(sessionID int) error {
 	}
 	// No attach delay on a switch: the program is already attached (unlike the
 	// attach-marker path, which must wait for dtach to reattach first).
-	go a.nudgeAIRepaint(managed, cols, rows, 0)
+	go a.nudgeAIRepaint(managed, cols, rows, 0, gen)
 	return nil
 }
 
@@ -1255,6 +1266,42 @@ var (
 	aiRepaintNudgeSettle = defaultAIRepaintNudgeSettle()
 )
 
+// aiRepaintInputQuiet is how recently input must have arrived for the repaint
+// nudge to stand down. The nudge exists to repaint a BLANK reattached screen; a
+// pane receiving keystrokes is by definition not that, and resizing it mid-line
+// is what corrupted submitted prompts (#1330). Generous on purpose: skipping a
+// repaint costs one keypress to fix, while a bad reflow costs the message.
+const aiRepaintInputQuiet = 1500 * time.Millisecond
+
+// noteSessionInput records that real user input just reached this pane.
+func (a *App) noteSessionInput(managed *managedTerminal) {
+	if managed == nil {
+		return
+	}
+	a.mu.Lock()
+	managed.inputGen++
+	managed.lastInputAt = time.Now()
+	a.mu.Unlock()
+}
+
+// sessionInputGen reads the pane's input counter so a nudge can detect input
+// that arrived after it was scheduled.
+func (a *App) sessionInputGen(managed *managedTerminal) uint64 {
+	if managed == nil {
+		return 0
+	}
+	a.mu.Lock()
+	gen := managed.inputGen
+	a.mu.Unlock()
+	return gen
+}
+
+// typedRecentlyLocked reports whether the pane saw input inside the quiet
+// window. Caller holds a.mu.
+func typedRecentlyLocked(managed *managedTerminal) bool {
+	return !managed.lastInputAt.IsZero() && time.Since(managed.lastInputAt) < aiRepaintInputQuiet
+}
+
 // defaultAIRepaintNudgeSettle sizes the shrink-hold to the platform's resize
 // delivery. POSIX kubectl exec delivers the resize via SIGWINCH immediately, so
 // a short hold suffices. On Windows there is no SIGWINCH: kubectl exec -it POLLS
@@ -1295,28 +1342,59 @@ func (a *App) maybeNudgeAIRepaint(managed *managedTerminal, chunk []byte) {
 		a.mu.Unlock()
 		return
 	}
+	if typedRecentlyLocked(managed) {
+		// The user is at the keyboard, so the pane is not the blank screen
+		// this nudge repaints -- and their typing will force the redraw
+		// anyway. Deliberately does NOT set repaintNudged: this attach has
+		// not been nudged, so a later chunk may still do it once they stop.
+		a.mu.Unlock()
+		return
+	}
 	managed.repaintNudged = true
 	cols, rows := managed.lastCols, managed.lastRows
+	gen := managed.inputGen
 	a.mu.Unlock()
-	go a.nudgeAIRepaint(managed, cols, rows, aiRepaintNudgeDelay)
+	go a.nudgeAIRepaint(managed, cols, rows, aiRepaintNudgeDelay, gen)
 }
 
 // nudgeAIRepaint briefly shrinks the backend pty by one row and restores it:
 // the change reaches Claude as a real WINCH and forces the full repaint a
 // same-size reattach cannot. The local xterm is never resized, so the user sees
 // the tab's content appear with no visible reflow.
-func (a *App) nudgeAIRepaint(managed *managedTerminal, cols, rows int, initialDelay time.Duration) {
+func (a *App) nudgeAIRepaint(managed *managedTerminal, cols, rows int, initialDelay time.Duration, gen uint64) {
 	if cols <= 0 || rows <= 1 {
 		return
 	}
 	if initialDelay > 0 {
 		time.Sleep(initialDelay)
 	}
+	// Input during the delay means the user started typing between the attach
+	// marker and here. Shrink now and the restore reflows their line, so do
+	// not start the cycle at all -- nothing has been resized yet, so bailing
+	// costs nothing.
+	if a.sessionInputGen(managed) != gen {
+		return
+	}
 	if !a.resizeSessionIfLive(managed, cols, rows-1) {
 		return
 	}
-	time.Sleep(aiRepaintNudgeSettle)
+	// Past this point the pty IS a row short, so it must be restored on every
+	// path. awaitRepaintSettle returns early on input so the shrunken geometry
+	// is held across as little typing as possible.
+	a.awaitRepaintSettle(managed, gen)
 	a.resizeSessionIfLive(managed, cols, rows)
+}
+
+// awaitRepaintSettle waits out the nudge settle, returning as soon as user
+// input arrives so the caller can restore the pty immediately.
+func (a *App) awaitRepaintSettle(managed *managedTerminal, gen uint64) {
+	const slice = 10 * time.Millisecond
+	for waited := time.Duration(0); waited < aiRepaintNudgeSettle; waited += slice {
+		time.Sleep(slice)
+		if a.sessionInputGen(managed) != gen {
+			return
+		}
+	}
 }
 
 // resizeSessionIfLive guards the AI repaint nudge: a session that exits
@@ -2048,6 +2126,16 @@ type managedTerminal struct {
 	// on the first output after a (re)attach and not on every chunk.
 	// tryReconnect clears it so the next attach nudges again.
 	repaintNudged bool
+
+	// lastInputAt/inputGen record real user input into this pane. The repaint
+	// nudge changes pty geometry behind the user's back, so it must not fire
+	// into a pane someone is typing into and must abandon a hold in progress
+	// the moment they start: holding the pty a row short across a keystroke
+	// reflowed the line being edited and corrupted the submitted prompt
+	// (#1330). inputGen is a counter rather than a flag so a nudge can tell
+	// "input since I was scheduled" from "input at some point".
+	lastInputAt time.Time
+	inputGen    uint64
 
 	// awaitingPostRespawnInput, when true, tells streamSession to skip
 	// the 2s output-activity ticker. Set on each successful respawn so


### PR DESCRIPTION
Typing into a pane shortly after switching into it corrupted the submission: the prompt arrived holding several concatenated snapshots of the partially-typed line instead of the line itself (`privi` -> `privie` -> `privide`, joined by soft-wrap `U+00A0`). Reproduced against the operator's own transcript twice, and again live while working this issue.

## Cause

Two independent synthetic shrink/restore cycles fire into a pane, and neither was cancelled on input:

1. **Frontend** -- `terminalReattachRepaint.ts` shrinks the xterm by a third of its rows, holds **650ms**, then restores and re-fits, armed by a 1300ms poller that runs for 30s after a switch.
2. **Go** -- `nudgeAIRepaint` shrinks the **pty** by one row and holds it for the settle. `RepaintSession` fires this on *every* switch into an AI pane, and `maybeNudgeAIRepaint` on the attach marker.

The blankness gate meant to keep them off a live pane is sampled **once, before** the shrink. `dtach` hands a reattached client a cleared screen, so "blank" is exactly the state a pane is in when someone switches in and starts typing -- the gate cannot see them. `SendSessionInput` touched no repaint state, so both cycles ran to completion regardless.

## Fix

Input cancels both.

- `TerminalReattachRepaint.noteInput()`, called from `onData` before the write, disarms the poller and finishes any in-flight cycle **immediately** rather than at the end of the hold. The restore still happens -- the shrink is already applied -- it just must not wait.
- Go records `lastInputAt`/`inputGen` on every `SendSessionInput`. `RepaintSession` and `maybeNudgeAIRepaint` skip a pane that saw input within 1.5s; `nudgeAIRepaint` bails before shrinking if input arrived while it was scheduled, and once shrunk restores as soon as input arrives instead of sleeping out the settle. The pty is restored on every path.
- Skipping for input deliberately does **not** consume `repaintNudged`, so a pane still gets its repaint once the user stops typing.

## Verification

Every guard was proven load-bearing rather than assumed -- each was removed in turn and the corresponding test observed to fail, then restored:

| guard removed | test that failed |
|---|---|
| `RepaintSession` input check | `TestRepaintSessionSkipsPaneBeingTypedInto` -- got resize `[120 39]` |
| `maybeNudgeAIRepaint` input check | `TestMaybeNudgeAIRepaintSkipsPaneBeingTypedInto` |
| early restore in `awaitRepaintSettle` | `TestNudgeAIRepaintRestoresEarlyWhenInputArrives` -- ran the full settle (469ms >= 400ms) |
| `noteInput` body | the two frontend cancellation tests |

Both suites carry a **control** test -- a quiet pane must still be nudged, and the frontend hold must still restore on its own -- so the fix cannot pass by disabling the repaint.

Gates, all from this branch:

- `go test ./...` (erun-ui) green; stripped-PATH `go test` green
- `golangci-lint run ./...` **0 issues**
- `yarn typecheck` clean; frontend suite **143 pass / 0 fail** (3 new)
- `yarn lint` **5 problems, 0 errors** -- identical to the clean-`main` baseline, so no new findings
- `yarn format:check` clean

**Not run:** the Playwright suite. Per this repo's brief only the specs a change touches should be run, and no existing spec covers the switch-then-type sequence; the two new unit suites cover it directly instead. The end-to-end confirmation is the desktop rebuild+restart that follows this merge, since the corruption is only observable in a real pane.

Closes #1330
