### PR TITLE
Keep repainting an orchestrator pane after the operator starts typing

### DIFF
--- a/erun-ui/frontend/src/app/TerminalController.ts
+++ b/erun-ui/frontend/src/app/TerminalController.ts
@@ -520,16 +520,18 @@ export class TerminalController {
     // AI TUIs (claude/codex) render on the MAIN screen — not the alt-screen — and
     // only repaint on a real geometry change, so the trimmed replay above can't
     // reconstruct their frame and the pane is blank on switch until the app next
-    // emits a diff (the black-pane the operator hit). Nudge the backend pty on
-    // every switch to raise a genuine WINCH and force a full repaint; the Go side
-    // (RepaintSession) applies it only to AI sessions and no-ops for plain shells
-    // and alt-screen apps (which reconstruct from the replay), so this is safe to
-    // call unconditionally. The local xterm is never resized — no visible reflow.
+    // emits a diff (the black-pane the operator hit). An orchestrator pane runs
+    // the same kind of TUI. Nudge the backend pty on every switch to raise a
+    // genuine WINCH and force a full repaint; the Go side (RepaintSession)
+    // applies it only to AI and orchestrator sessions and no-ops for plain
+    // shells and alt-screen apps (which reconstruct from the replay), so this is
+    // safe to call unconditionally. The local xterm is never resized — no
+    // visible reflow.
     void RepaintSession(sessionId);
-    // A pty-only WINCH (RepaintSession above) does not reach a reattached Claude,
-    // so if this session stays blank after selection (a reattached AI tab) the
-    // reattach-repaint helper forces a real xterm+pty resize cycle. See
-    // TerminalReattachRepaint.
+    // A pty-only WINCH (RepaintSession above) does not reach a reattached
+    // main-screen TUI, so if this session stays blank after selection (a
+    // reattached AI tab or orchestrator pane) the reattach-repaint helper
+    // forces a real xterm+pty resize cycle. See TerminalReattachRepaint.
     this.reattachRepaint.schedule(sessionId);
   }
 }

--- a/erun-ui/frontend/src/app/terminalReattachRepaint.test.ts
+++ b/erun-ui/frontend/src/app/terminalReattachRepaint.test.ts
@@ -45,13 +45,24 @@ let fitCount = 0;
 
 function fakeTerminal(cols: number, rows: number) {
   const resizes: [number, number][] = [];
+  let content = '';
   return {
     cols,
     rows,
     resizes,
-    // Every line reads empty: the state dtach leaves a reattached pane in, and
+    // setContent lets a test simulate the program redrawing on its own, e.g.
+    // while typing is still within the quiet window.
+    setContent(next: string) {
+      content = next;
+    },
+    // Empty by default: the state dtach leaves a reattached pane in, and
     // therefore the state the repaint cycle fires on.
-    buffer: { active: { viewportY: 0, getLine: () => null } },
+    buffer: {
+      active: {
+        viewportY: 0,
+        getLine: () => (content === '' ? null : { translateToString: () => content }),
+      },
+    },
     resize(nextCols: number, nextRows: number) {
       this.cols = nextCols;
       this.rows = nextRows;
@@ -80,7 +91,7 @@ function harness() {
 beforeEach(() => {
   resizeCalls.length = 0;
   installWindow();
-  mock.timers.enable({ apis: ['setTimeout', 'setInterval'] });
+  mock.timers.enable({ apis: ['setTimeout', 'setInterval', 'Date'] });
 });
 
 afterEach(() => {
@@ -103,20 +114,48 @@ test('a keystroke restores the shrunken geometry at once, not mid-line 650ms lat
   assert.equal(fitCount, 1, 'the restore must re-fit exactly once');
 
   // The original 650ms restore must not also land: a second reflow on a line
-  // being edited is the corruption.
+  // being edited is the corruption. Tick less than a full poller period (1300ms)
+  // past the restore so this stays a test of the cancelled timeout, not of the
+  // (legitimate, separately covered) next poll cycle once the quiet window
+  // elapses.
   const afterInput = terminal.resizes.length;
-  mock.timers.tick(5000);
+  mock.timers.tick(700);
   assert.equal(terminal.resizes.length, afterInput, 'the cancelled hold must not fire');
   assert.equal(fitCount, 1, 'the cancelled hold must not re-fit again');
 });
 
-test('input disarms the poller, so no later cycle starts behind the user', () => {
+test('input defers the cycle through the quiet window but does not disarm it', () => {
   const { terminal, repaint } = harness();
   repaint.schedule(7);
   repaint.noteInput();
 
-  mock.timers.tick(30000);
-  assert.deepEqual(terminal.resizes, [], 'a pane being typed into must never be resized');
+  // A tick landing inside the 1500ms quiet window must not resize a pane the
+  // operator is actively typing into.
+  mock.timers.tick(1300);
+  assert.deepEqual(terminal.resizes, [], 'a tick within the quiet window must not resize');
+
+  // Once the quiet window elapses with the screen still blank, the poller must
+  // still repaint it. This is the only repaint path left for an orchestrator
+  // pane (#1332's Go-side WINCH nudge is dead code for that session kind), so
+  // permanently disarming on the first keystroke left the pane blank for the
+  // rest of the session -- exactly the defect behind the operator's blind,
+  // concatenated retype (#1330 follow-up).
+  mock.timers.tick(1300);
+  assert.equal(terminal.rows, 26, 'a still-blank pane must be repainted once typing pauses');
+  assert.deepEqual(lastResizeCall(), [7, 120, 26]);
+});
+
+test('a repainted (now visible) pane is left alone even after the quiet window elapses', () => {
+  const { terminal, repaint } = harness();
+  repaint.schedule(7);
+  repaint.noteInput();
+
+  // The screen becomes visible while the operator is still within the quiet
+  // window -- e.g. the program redrew on its own after the keystroke.
+  terminal.setContent('visible content');
+  mock.timers.tick(3000);
+
+  assert.deepEqual(terminal.resizes, [], 'a pane with visible content must never be resized');
 });
 
 test('without input the cycle still completes, so the repaint is not simply disabled', () => {

--- a/erun-ui/frontend/src/app/terminalReattachRepaint.ts
+++ b/erun-ui/frontend/src/app/terminalReattachRepaint.ts
@@ -11,6 +11,12 @@ interface ReattachRepaintDeps {
   afterRestore: () => void;
 }
 
+// QUIET_WINDOW_MS mirrors the Go side's aiRepaintInputQuiet: how recently input
+// must have arrived for the poller to stand down for one tick. Kept in sync
+// deliberately -- both exist for the same reason, resizing a line mid-edit
+// corrupted the submitted prompt (#1330).
+const QUIET_WINDOW_MS = 1500;
+
 // TerminalReattachRepaint forces a reattached main-screen TUI (Claude) to repaint.
 // dtach hands a reattached client a cleared screen and Claude only redraws on a
 // real geometry change that also resizes the LOCAL xterm — a pty-only WINCH does
@@ -25,6 +31,7 @@ export class TerminalReattachRepaint {
   private cycling = false;
   private timeout = 0;
   private restoreTo: { sessionId: number; cols: number; rows: number } | null = null;
+  private lastInputAt: number | null = null;
 
   constructor(private readonly deps: ReattachRepaintDeps) {}
 
@@ -39,6 +46,7 @@ export class TerminalReattachRepaint {
     }
     this.cycling = false;
     this.restoreTo = null;
+    this.lastInputAt = null;
   }
 
   // noteInput is called for every keystroke the pane receives. The cycle below
@@ -50,23 +58,29 @@ export class TerminalReattachRepaint {
   // the 650ms restore land mid-line reflowed the buffer being edited, which
   // corrupted the submitted prompt (#1330).
   //
-  // So input both disarms the poller for good (the user is plainly here; they
-  // do not need a synthetic repaint) and finishes any in-flight cycle NOW,
-  // restoring the geometry immediately instead of at the end of the hold. The
-  // restore still has to happen -- the shrink is already applied -- it just
-  // must not wait.
+  // So input finishes any in-flight cycle NOW, restoring the geometry
+  // immediately instead of at the end of the hold -- the restore still has to
+  // happen, it just must not wait. It does NOT disarm the poller: this pane's
+  // only repaint is this poller (an orchestrator's dtach reattach has no other
+  // path back to a visible screen), so permanently disarming it on the first
+  // keystroke left the pane blank for the rest of the session if the screen was
+  // still blank when the user started typing. Recording lastInputAt instead
+  // lets the tick defer through the quiet window and repaint once typing pauses
+  // -- hasVisibleContent() still gates it, so a pane that is already painted is
+  // never touched.
   noteInput(): void {
+    this.lastInputAt = Date.now();
     const pending = this.restoreTo;
-    if (this.interval !== 0) {
-      window.clearInterval(this.interval);
-      this.interval = 0;
-    }
     if (this.timeout !== 0) {
       window.clearTimeout(this.timeout);
       this.timeout = 0;
     }
     this.restoreTo = null;
     if (pending === null) {
+      // No cycle is in flight. Reset cycling defensively: now that input no
+      // longer disarms the poller, a cycling flag left stuck true would
+      // silently block every later repaint -- the same permanent blindness
+      // this change removes, just held in a different variable.
       this.cycling = false;
       return;
     }
@@ -82,6 +96,9 @@ export class TerminalReattachRepaint {
         return;
       }
       if (this.cycling || this.hasVisibleContent()) {
+        return;
+      }
+      if (this.lastInputAt !== null && Date.now() - this.lastInputAt < QUIET_WINDOW_MS) {
         return;
       }
       this.repaintIfBlank(sessionId);

--- a/erun-ui/orchestrator_pacing.go
+++ b/erun-ui/orchestrator_pacing.go
@@ -222,6 +222,16 @@ func (a *App) sendOrchestratorPacingNudge(id string, serial int, now time.Time) 
 		a.mu.Unlock()
 		return
 	}
+	if typedRecentlyLocked(managed) {
+		// The operator is mid-sentence in this pane. Writing the nudge text
+		// plus its submitting "\r" now would glue onto whatever they are
+		// typing, the same hazard the AI repaint nudge stands down for
+		// (#1330). Skip without touching the nudge count or timestamp so
+		// this does not cost against orchestratorPacingMaxNudges; the
+		// reconciler retries on its next 15s tick once they pause.
+		a.mu.Unlock()
+		return
+	}
 	session.pacingNudgeCount++
 	session.pacingLastNudgeAtUnix = now.Unix()
 	count := session.pacingNudgeCount

--- a/erun-ui/orchestrator_pacing_test.go
+++ b/erun-ui/orchestrator_pacing_test.go
@@ -217,6 +217,62 @@ func TestOrchestratorPacingCapsAfterRepeatedSilenceAndRearmsOnFreshBusy(t *testi
 	}
 }
 
+// TestSendOrchestratorPacingNudgeSkipsWhilePaneBeingTypedInto pins the third
+// place #1330's hazard applies: the pacing nudge writes its text, then a bare
+// carriage return 150ms later, the same shape as the AI repaint resize that
+// corrupted a submitted prompt. Firing it into a pane mid-sentence would glue
+// the pacing text onto whatever the operator is typing. The skip must not
+// cost against the nudge cap: it is deferred, not counted, so the reconciler
+// can retry once the operator pauses.
+func TestSendOrchestratorPacingNudgeSkipsWhilePaneBeingTypedInto(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	orchestratorPacingNudgeSettle = 0
+
+	app := NewApp(erunUIDeps{})
+	session := newCallRecordingSession()
+	key := orchestratorSessionKey("agent")
+	managed := &managedTerminal{session: session, key: key, serial: 5, kind: sessionKindOrchestrator}
+	app.sessions[key] = managed
+	app.orchestrators["agent"] = &orchestratorSession{
+		id:        "agent",
+		serial:    5,
+		name:      "agent",
+		startedAt: time.Now().Add(-orchestratorPacingStaleAfter - time.Minute),
+	}
+
+	// First stale tick: no recent input, so the reconciler nudges normally.
+	app.reconcileOrchestratorPacing()
+	firstCalls := session.Calls()
+	if len(firstCalls) != 2 {
+		t.Fatalf("expected the first stale tick to nudge, got %v", firstCalls)
+	}
+	app.mu.Lock()
+	count := app.orchestrators["agent"].pacingNudgeCount
+	app.mu.Unlock()
+	if count != 1 {
+		t.Fatalf("expected one recorded nudge, got %d", count)
+	}
+
+	// The operator starts typing into the pane between ticks.
+	app.mu.Lock()
+	managed.lastInputAt = time.Now()
+	app.mu.Unlock()
+
+	// A later stale tick must stand down rather than glue the nudge text onto
+	// the half-typed line, and must not consume a nudge against the cap.
+	app.reconcileOrchestratorPacing()
+	if got := session.Calls(); len(got) != len(firstCalls) {
+		t.Fatalf("a pane being typed into must not receive a pacing nudge, got extra writes %v", got[len(firstCalls):])
+	}
+	app.mu.Lock()
+	count = app.orchestrators["agent"].pacingNudgeCount
+	app.mu.Unlock()
+	if count != 1 {
+		t.Fatalf("skipping for input must not consume a nudge from the cap, got count=%d", count)
+	}
+}
+
 // TestSendSessionInputRearmsOrchestratorPacing locks the other rearm path: real
 // operator input into the pane clears the cap and the count immediately,
 // without waiting for a fresh busy report.

--- a/erun-ui/terminal_repaint_input_test.go
+++ b/erun-ui/terminal_repaint_input_test.go
@@ -109,6 +109,44 @@ func TestRepaintSessionNudgesQuietPane(t *testing.T) {
 	}
 }
 
+func newOrchestratorTerminalForRepaint(app *App, serial int) (*managedTerminal, *stubTerminalSession) {
+	session := newSilentStubTerminalSession()
+	key := "orchestrator-pane"
+	managed := &managedTerminal{
+		session:  session,
+		key:      key,
+		serial:   serial,
+		kind:     sessionKindOrchestrator,
+		lastCols: 120,
+		lastRows: 40,
+	}
+	app.nextSerial = serial
+	app.sessions[key] = managed
+	return managed, session
+}
+
+// TestRepaintSessionNudgesOrchestratorPane pins the real chain behind #1330's
+// follow-up: an orchestrator pane runs the same main-screen TUI (claude) an AI
+// tab does, but isAITabKind only recognizes sessionKindAI/sessionKindContributeAI,
+// so RepaintSession's WINCH nudge was dead code for it -- the entire Go half of
+// #1332 never ran for an orchestrator. This must fail against that code, and
+// pass once RepaintSession gates on needsWINCHRepaint instead.
+func TestRepaintSessionNudgesOrchestratorPane(t *testing.T) {
+	shortenRepaintTimings(t)
+	app := NewApp(erunUIDeps{})
+	_, session := newOrchestratorTerminalForRepaint(app, 1)
+
+	if err := app.RepaintSession(1); err != nil {
+		t.Fatalf("RepaintSession failed: %v", err)
+	}
+	if !waitForResizes(t, session, 2, 3*time.Second) {
+		t.Fatalf("an orchestrator pane must be nudged just like an AI tab, got %d resizes", session.resizeCount())
+	}
+	if got, _ := session.lastResize(); got != [2]int{120, 40} {
+		t.Fatalf("the nudge must restore the pty to its real size, ended at %v", got)
+	}
+}
+
 // TestMaybeNudgeAIRepaintSkipsPaneBeingTypedInto covers the attach-marker half.
 // It also pins that the skip does NOT consume repaintNudged: this attach has
 // not been repainted, so a later chunk must still be able to do it once the

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -967,12 +967,13 @@ func (a *App) RepaintSession(sessionID int) error {
 		// a line being entered. Someone typing needs no synthetic repaint.
 		return nil
 	}
-	// Only AI TUIs (claude/codex) need the WINCH repaint: they render on the MAIN
-	// screen and only repaint on a real geometry change, so a tab switch leaves
-	// them blank until their next diff. Plain shells and alt-screen apps
-	// reconstruct from the replayed buffer, so a nudge would just cause a needless
-	// reflow. The frontend fires this on every switch and lets this gate decide.
-	if !isAITabKind(managed) {
+	// Only main-screen TUIs (claude/codex, whether in an AI tab or an
+	// orchestrator pane) need the WINCH repaint: they only repaint on a real
+	// geometry change, so a tab switch leaves them blank until their next diff.
+	// Plain shells and alt-screen apps reconstruct from the replayed buffer, so a
+	// nudge would just cause a needless reflow. The frontend fires this on every
+	// switch and lets this gate decide.
+	if !needsWINCHRepaint(managed) {
 		return nil
 	}
 	// No attach delay on a switch: the program is already attached (unlike the
@@ -1328,13 +1329,24 @@ func isAITabKind(managed *managedTerminal) bool {
 		(managed.kind == sessionKindAI || managed.kind == sessionKindContributeAI)
 }
 
+// needsWINCHRepaint reports whether a session runs a main-screen TUI that only
+// repaints on a real pty geometry change (a WINCH), so a same-size tab switch
+// or reattach leaves it blank until one is forced. AI tabs and the orchestrator
+// both run that kind of program (claude/codex). Kept separate from isAITabKind,
+// which also drives AI-activity accounting (managedAITabFor, aiActivityKind)
+// where an orchestrator is deliberately excluded for unrelated reasons — see
+// aiActivityKind's comment.
+func needsWINCHRepaint(managed *managedTerminal) bool {
+	return isAITabKind(managed) || (managed != nil && managed.kind == sessionKindOrchestrator)
+}
+
 // maybeNudgeAIRepaint fires the AI repaint nudge when the attach marker first
 // appears. dtach hands a reattached client a cleared screen, but Claude (an Ink
 // main-screen TUI) only fully repaints on an actual geometry change — a
 // same-size reattach raises no effective WINCH, so the tab would render blank.
 // The nudge forces that geometry change once Claude is attached.
 func (a *App) maybeNudgeAIRepaint(managed *managedTerminal, chunk []byte) {
-	if !isAITabKind(managed) || !bytes.Contains(chunk, aiAttachMarker) {
+	if !needsWINCHRepaint(managed) || !bytes.Contains(chunk, aiAttachMarker) {
 		return
 	}
 	a.mu.Lock()


### PR DESCRIPTION
## Why #1332 did not fix #1330

#1332 read #1330 as a reflow corrupting a line mid-edit and stood the repaint nudges down when the user types. That diagnosis was wrong, and standing the nudges down turned an intermittent fault into a deterministic one.

The operator's first message after restarting onto b2d071ce:

```
try to restore this sesstry to restore this sess aftry to restore this session afer erun restart
```

`sess af` versus `session afer` are **different typos**, so these are three independent typing attempts, not one line duplicated by a reflow. (#1330's own report carries the same signature: `...is urg` + `...is urgnt`.) It is a person typing, seeing nothing echoed, retyping, and pressing Enter once while the whole accumulation sat in the input buffer.

## The real chain

1. `isAITabKind()` is true only for `sessionKindAI` / `sessionKindContributeAI`. An orchestrator pane is `sessionKindOrchestrator`, so `RepaintSession()` returned early at its `!isAITabKind` gate and `maybeNudgeAIRepaint()` returned immediately. **The entire Go half of #1332 was dead code for orchestrator panes.**
2. `writeTerminalBuffer()` cannot reconstruct a main-screen TUI's frame from its trimmed replay -- its own comment says so -- so an orchestrator pane genuinely is blank after a tab switch.
3. That left the frontend `TerminalReattachRepaint` poller as the pane's only repaint. `schedule()` has exactly one call site.
4. #1332's `noteInput()` cleared the poller's interval on every keystroke and never re-armed it.

So: switch in, pane blank, type within 1300ms, and the pane's only repaint is disarmed for the rest of the session. Before #1332 the poller kept cycling and the pane recovered on its own.

## What this changes

**A. `terminalReattachRepaint.ts` -- defer, do not disarm.** Input still cuts an *in-flight* shrink short so a restore never lands mid-line (the good half of #1332). The permanent disarm is replaced by a `lastInputAt` quiet window (1500ms, mirroring the Go side's `aiRepaintInputQuiet`): a tick inside the window stands down, and once typing pauses a still-blank pane is repainted. `hasVisibleContent()` already gates on blankness, so an already-painted pane is never touched. `noteInput()` also resets `cycling` on its no-cycle path -- now that the poller survives input, a `cycling` flag left stuck true would block every later repaint, which is the same permanent blindness held in a different variable.

**B. Orchestrator panes get the pty-only WINCH repaint.** New `needsWINCHRepaint()` = AI kinds + `sessionKindOrchestrator`, used only by `RepaintSession` and `maybeNudgeAIRepaint`. `isAITabKind` is deliberately left alone because it also drives AI-activity accounting, where an orchestrator is excluded for unrelated reasons. This nudge never resizes the local xterm, so it cannot reflow the line being typed -- it is the non-destructive repaint.

**C. The pacing nudge stands down while the pane is being typed into.** `writeOrchestratorPacingNudge()` writes its text and then a bare `\r` 150ms later, with no `typedRecentlyLocked` guard -- fired mid-sentence it submits the operator's half-typed line glued to the pacing text. It now skips without touching the count or timestamp, so a deferral does not cost against `orchestratorPacingMaxNudges` and the reconciler retries once they pause.

## Test evidence

Every new test was run against the unfixed code with only the production change stashed, and observed to fail:

- `input defers the cycle through the quiet window but does not disarm it` -- fails on b2d071ce: `AssertionError: a still-blank pane must be repainted once typing pauses -- 40 !== 26`. Passes with the fix (4/4 in that file).
- `TestRepaintSessionNudgesOrchestratorPane` -- fails on b2d071ce: `an orchestrator pane must be nudged just like an AI tab, got 0 resizes`.
- `TestSendOrchestratorPacingNudgeSkipsWhilePaneBeingTypedInto` -- fails on b2d071ce: `a pane being typed into must not receive a pacing nudge, got extra writes [Keep pacing yourself, on connection errors wait and resume, do not exit this loop. ... \r]` -- i.e. the unguarded nudge demonstrably writing its text plus a submitting carriage return into a pane mid-sentence.
- `a keystroke restores the shrunken geometry at once, not mid-line 650ms later` and `a repainted (now visible) pane is left alone even after the quiet window elapses` guard #1332's good half and the blankness gate against regression.

Closes #1333
