### PR TITLE
Stop imposing xterm's screenReaderMode, which re-emits typed input

### DIFF
--- a/erun-ui/frontend/src/app/TerminalController.ts
+++ b/erun-ui/frontend/src/app/TerminalController.ts
@@ -13,6 +13,7 @@ import type { MountElements, TerminalDataDisposable, TerminalWriteData } from '.
 import { showTerminalError } from './notificationThunks';
 import { scrollSelectedTreeNodeIntoView, visibleDiffPath } from './reviewDiffNavigation';
 import { setSelectedDiffPath } from './slices/reviewSlice';
+import { loadSavedTerminalScreenReaderMode } from './storage';
 import { store } from './store';
 import {
   bufferCursorVisibility,
@@ -211,7 +212,7 @@ export class TerminalController {
 
     this.terminal = new Terminal({
       allowProposedApi: false,
-      screenReaderMode: true,
+      screenReaderMode: loadSavedTerminalScreenReaderMode(),
       scrollback: TERMINAL_SCROLLBACK,
       cursorBlink: true,
       fontFamily:

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -54,6 +54,12 @@ export const REVIEW_WIDTH_STORAGE_KEY = 'erun.reviewWidth';
 export const FILES_WIDTH_STORAGE_KEY = 'erun.filesWidth';
 export const FILES_OPEN_STORAGE_KEY = 'erun.filesOpen';
 export const DEBUG_OPEN_STORAGE_KEY = 'erun.debugOpen';
+// Opt-in, and deliberately OFF by default: xterm's screenReaderMode makes the
+// AccessibilityManager rewrite the same hidden helper textarea that captures
+// keystrokes, so a focus transition mid-line made the next input event re-emit
+// the whole accumulated buffer into the pty (#1335). It stays available for
+// anyone who needs it; it must not be imposed on everyone who types.
+export const TERMINAL_SCREEN_READER_MODE_STORAGE_KEY = 'erun.terminal.screenReaderMode';
 export const DEBUG_HEIGHT_STORAGE_KEY = 'erun.debugHeight';
 export const PAST_TENANTS_STORAGE_KEY = 'erun.pastTenants';
 export const PAST_ENVIRONMENTS_STORAGE_KEY = 'erun.pastEnvironments';

--- a/erun-ui/frontend/src/app/storage.ts
+++ b/erun-ui/frontend/src/app/storage.ts
@@ -20,6 +20,7 @@ import {
   PAST_TENANTS_STORAGE_KEY,
   REVIEW_WIDTH_STORAGE_KEY,
   SIDEBAR_WIDTH_STORAGE_KEY,
+  TERMINAL_SCREEN_READER_MODE_STORAGE_KEY,
 } from './state';
 
 const MAX_SAVED_STRING_LIST_ITEMS = 20;
@@ -71,6 +72,14 @@ export function loadSavedFilesOpen(): boolean {
 export function loadSavedDebugOpen(): boolean {
   try {
     return window.localStorage.getItem(DEBUG_OPEN_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function loadSavedTerminalScreenReaderMode(): boolean {
+  try {
+    return window.localStorage.getItem(TERMINAL_SCREEN_READER_MODE_STORAGE_KEY) === 'true';
   } catch {
     return false;
   }

--- a/erun-ui/playwright/tests/a11y-terminal.spec.ts
+++ b/erun-ui/playwright/tests/a11y-terminal.spec.ts
@@ -17,8 +17,23 @@ test.describe('terminal accessibility', () => {
     await expect(host).toHaveAccessibleName('Terminal');
   });
 
-  test('xterm builds its screen-reader accessibility tree', async ({ app }) => {
-    // Only present when `screenReaderMode: true` was passed to `new Terminal(...)`
+  // #1335: screenReaderMode must be OFF unless asked for. xterm's
+  // AccessibilityManager rewrites the same hidden helper textarea that captures
+  // keystrokes, so with it on a focus transition mid-line made the next input
+  // event re-emit the whole accumulated buffer -- the operator's sentence
+  // arrived as several concatenated, progressively longer copies of itself.
+  // The absence of the tree by default IS the guard: this fails against the
+  // hardcoded `screenReaderMode: true` #1291 shipped.
+  test('the screen-reader accessibility tree is absent by default', async ({ app }) => {
+    await expect(app.terminalPane.accessibilityTree()).toHaveCount(0);
+  });
+
+  test('xterm builds its screen-reader accessibility tree when opted in', async ({ app, page }) => {
+    await page.evaluate(() => {
+      window.localStorage.setItem('erun.terminal.screenReaderMode', 'true');
+    });
+    await page.reload();
+    // Only present when `screenReaderMode: true` reached `new Terminal(...)`
     // -- xterm's AccessibilityManager is not instantiated otherwise, so this
     // element's mere existence is the regression guard for the option.
     await expect(app.terminalPane.accessibilityTree()).toHaveCount(1);


### PR DESCRIPTION
## What was happening

Typing a sentence into an orchestrator pane submitted **several progressively longer copies of the input buffer, concatenated**. Three samples from the same operator, raw from the transcript:

```
try to restore this sesstry to restore this sess aftry to restore this session afer erun restart
jibberish is still happejibberish is still happeing
erun desktop keeps captuerun desktop keeps captu focus for some rerun desktop keeps capturing focus for some raerun desktop keeps capturing focus for some rea
```

Segmented, the third is unmistakable -- each segment **extends** the previous one, including an in-place correction (`captu` -> `capturing`):

- `erun desktop keeps captu`
- `erun desktop keeps captu focus for some r`
- `erun desktop keeps capturing focus for some ra`
- `erun desktop keeps capturing focus for some rea`

That is one growing buffer emitted repeatedly from the start, not a user retyping.

## Cause

#1291 turned on xterm's `screenReaderMode` unconditionally. In that mode xterm instantiates its `AccessibilityManager`, which rewrites the **same hidden helper textarea that captures keystrokes**. When that rewrite interleaves with typing, the next input event delivers the whole accumulated value rather than the delta, and `SendSessionInput` writes all of it to the pty -- so the corruption lands in what the program actually receives, not merely in what is drawn.

Two independent observations pin it:

- **Timeline.** #1291 merged `2026-08-24 23:30`; #1330 -- the first report of this symptom -- was filed `2026-08-25 13:24`.
- **The operator's own note: "small sentences were always ok."** Exactly what this predicts: a short line is submitted before an accessibility refresh lands, a longer one spans one or more, and each refresh costs another copy.

## The change

`screenReaderMode` becomes an explicit opt-in, stored under `erun.terminal.screenReaderMode` and **off by default**. It stays fully available to anyone who needs it -- and the opt-in path is covered -- but it is no longer imposed on everyone who types.

This deliberately does **not** suppress some subsystem while the user is typing. That is what #1332 tried for #1330, and it converted an intermittent fault into a permanent one (#1333): the guard it added disarmed an orchestrator pane's only repaint on the first keystroke. A focus/refresh transition has to be non-destructive, not raced.

## Test evidence

`a11y-terminal.spec.ts`, run both ways against real Chromium:

- **On unfixed code** (production change stashed, spec kept): `the screen-reader accessibility tree is absent by default` **FAILED** -- `1 failed, 3 passed`. The guard genuinely fails without the fix.
- **With the fix**: `4 passed`, including `xterm builds its screen-reader accessibility tree when opted in`, so #1291's accessibility affordance still works when actually requested.

Frontend: `tsc --noEmit` clean, 144/144 unit tests pass.

## Follow-up worth doing separately

The operator also reports the desktop "keeps capturing focus". `erun-ui` makes no `WindowShow`/`WindowSetAlwaysOnTop` call and its `focusTerminalSoon()` calls are all user-action triggered, so that trigger is still unexplained -- though `focusTerminalSoon()` focusing three times in quick succession (immediate, rAF, +80ms) is worth a look as an amplifier. Default-off `screenReaderMode` removes the mechanism that turned those transitions into corrupted input, but the focus stealing itself is still worth chasing.

Closes #1335
