### PR TITLE
Restore terminal focus only inside an already-active window

### DIFF
--- a/erun-ui/frontend/src/app/TerminalController.ts
+++ b/erun-ui/frontend/src/app/TerminalController.ts
@@ -23,6 +23,7 @@ import {
   SHOW_CURSOR_SEQUENCE,
 } from './terminalBuffers';
 import { TerminalClipboard } from './terminalClipboard';
+import { scheduleTerminalFocus } from './terminalFocus';
 import { applyTerminalLayoutVars } from './terminalLayoutVars';
 import { registerTerminalQueryResponseHandlers } from './terminalQueryResponses';
 import { TerminalReattachRepaint } from './terminalReattachRepaint';
@@ -317,11 +318,10 @@ export class TerminalController {
   }
 
   focusTerminalSoon(): void {
-    window.setTimeout(() => {
-      this.terminal?.focus();
-      window.requestAnimationFrame(() => this.terminal?.focus());
-      window.setTimeout(() => this.terminal?.focus(), 80);
-    }, 0);
+    scheduleTerminalFocus({
+      getTerminal: () => this.terminal,
+      windowIsActive: () => document.hasFocus(),
+    });
   }
 
   scheduleIdleStatusPoll(delay = 1000): void {

--- a/erun-ui/frontend/src/app/terminalFocus.test.ts
+++ b/erun-ui/frontend/src/app/terminalFocus.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, mock, test } from 'node:test';
+
+import { scheduleTerminalFocus } from './terminalFocus';
+
+// scheduleTerminalFocus touches window only inside its body, never at module
+// scope, so a per-test shim is enough to drive the real function.
+let rafQueue: (() => void)[] = [];
+
+function installWindow(): void {
+  const shim = {
+    setTimeout: (handler: () => void, ms?: number) => setTimeout(handler, ms) as unknown as number,
+    clearTimeout: (id: number) => {
+      clearTimeout(id);
+    },
+    requestAnimationFrame: (handler: () => void) => {
+      rafQueue.push(handler);
+      return rafQueue.length;
+    },
+  };
+  (globalThis as unknown as { window: unknown }).window = shim;
+}
+
+function flushRaf(): void {
+  const queued = rafQueue;
+  rafQueue = [];
+  for (const handler of queued) {
+    handler();
+  }
+}
+
+beforeEach(() => {
+  rafQueue = [];
+  installWindow();
+  mock.timers.enable({ apis: ['setTimeout'] });
+});
+
+afterEach(() => {
+  mock.timers.reset();
+});
+
+function harness(windowIsActive: () => boolean) {
+  let focusCount = 0;
+  scheduleTerminalFocus({
+    getTerminal: () => ({
+      focus: () => {
+        focusCount += 1;
+      },
+    }),
+    windowIsActive,
+  });
+  return {
+    count: () => focusCount,
+  };
+}
+
+test('focus is restored when the window is already active', () => {
+  const h = harness(() => true);
+  mock.timers.tick(0);
+  flushRaf();
+  mock.timers.tick(80);
+  assert.equal(h.count(), 3, 'all three attempts should focus an active window');
+});
+
+// #1338: a tab respawn fires whenever a session drops -- on every env stop,
+// idle-stop and pod replacement -- and it calls this. Focusing a DOM element in
+// a Wails webview raises the native window, so an unguarded restore pulled the
+// desktop in front of whatever the operator was actually using. This must fail
+// against the unguarded `this.terminal?.focus()` it replaces.
+test('focus is never taken while another application is frontmost', () => {
+  const h = harness(() => false);
+  mock.timers.tick(0);
+  flushRaf();
+  mock.timers.tick(80);
+  assert.equal(h.count(), 0, 'an inactive window must never pull focus');
+});
+
+// The later attempts exist to land after a re-render, so the guard has to be
+// re-read each time rather than sampled once when the work was scheduled.
+test('the guard is re-checked, so focus leaving the window mid-sequence stops it', () => {
+  let active = true;
+  const h = harness(() => active);
+  mock.timers.tick(0);
+  assert.equal(h.count(), 1);
+  active = false;
+  flushRaf();
+  mock.timers.tick(80);
+  assert.equal(h.count(), 1, 'attempts after focus left the window must stand down');
+});

--- a/erun-ui/frontend/src/app/terminalFocus.ts
+++ b/erun-ui/frontend/src/app/terminalFocus.ts
@@ -1,0 +1,41 @@
+interface TerminalFocusTarget {
+  focus: () => void;
+}
+
+interface TerminalFocusDeps {
+  getTerminal: () => TerminalFocusTarget | null;
+  // windowIsActive is false exactly when another application is frontmost.
+  windowIsActive: () => boolean;
+}
+
+// scheduleTerminalFocus restores focus to the terminal after something moved it
+// -- closing a dialog, toggling a panel, respawning a tab.
+//
+// It only ever RESTORES focus inside a window that is already active; it must
+// never PULL the window forward. Several of its callers are machine-initiated
+// rather than user-initiated: a tab respawn fires whenever a session drops, and
+// a session drops on every env stop, idle-stop and pod replacement. Without the
+// guard erun yanks the desktop in front of whatever the operator was actually
+// using, mid-sentence (#1338).
+//
+// The guard is re-checked before each of the three attempts rather than once up
+// front. The later two exist to land after a re-render, and focus can leave the
+// window in between -- checking only at schedule time would let the 80ms
+// attempt steal focus the user had already moved elsewhere.
+export function scheduleTerminalFocus(deps: TerminalFocusDeps): void {
+  const focusIfWindowActive = (): void => {
+    if (!deps.windowIsActive()) {
+      return;
+    }
+    deps.getTerminal()?.focus();
+  };
+  window.setTimeout(() => {
+    focusIfWindowActive();
+    window.requestAnimationFrame(() => {
+      focusIfWindowActive();
+    });
+    window.setTimeout(() => {
+      focusIfWindowActive();
+    }, 80);
+  }, 0);
+}


### PR DESCRIPTION
## What the operator hit

> "erun desktop keeps capturing focus for some reason" ... "nothing is fixed, erun is still stealing focus"

Measured on the host: the frontmost application flipped to ERun with nothing in the app log at that instant.

## Cause

`focusTerminalSoon()` unconditionally called `this.terminal?.focus()` three times in quick succession (immediately, on the next `requestAnimationFrame`, then again 80ms later). Focusing a DOM element inside a Wails webview raises the native window, so each call could pull the desktop in front of whatever was actually being used.

That would be tolerable if every caller were a user action, but several are **machine-initiated**. The clearest is `tabRespawnThunks.ts`: the desktop respawns a tab whenever its session drops, and a session drops on every env stop, idle-stop and pod replacement. `sessionThunks.ts` calls it from async completions too. So the window could be yanked forward at moments the operator never triggered.

Ruled out while finding this, audited at `1d68b11c`: no `WindowShow` / `WindowUnminimise` / `WindowSetAlwaysOnTop` / `WindowFocus` call exists anywhere in `erun-ui`; the only AppKit use is `app_identity_darwin.go` setting the process name and menu title at startup; `main.go` sets no activation policy; there is no `autoFocus` anywhere; and the app was not crashing or relaunching (stable PID, no crash reports).

## The change

The focus scheduling moves into `terminalFocus.ts` -- its own module, mirroring `terminalReattachRepaint.ts` -- and gains one guard: **only restore focus when the window is already active.** `document.hasFocus()` is false exactly when another application is frontmost, so the guard reads as "are we already where the user is looking".

Deliberately minimal: behaviour inside an active window is unchanged, so every legitimate restore (closing a dialog, toggling a panel) still works exactly as before. The guard only removes erun's ability to *pull* the window forward.

The guard is re-checked before each of the three attempts rather than sampled once at schedule time. The later two exist to land after a re-render, and focus can leave the window in between -- checking once would let the 80ms attempt steal focus the user had already moved elsewhere.

## Test evidence

New `terminalFocus.test.ts`, verified both ways by removing the guard to reproduce the unguarded original:

- **Unguarded**: `1 pass, 2 fail` -- `an inactive window must never pull focus` and `attempts after focus left the window must stand down` both fail.
- **Guarded**: `3 passed`.

Frontend `tsc --noEmit` clean.

## Related

- #1335 / #1337 removed what made this destructive rather than merely disruptive: with `screenReaderMode` on, a focus transition mid-typing made xterm re-emit its whole helper-textarea buffer into the pty, so a stolen focus corrupted the submitted prompt.
- This PR addresses the stealing itself.

Closes #1338
