### PR TITLE
Do not steal focus from a control the user chose, and trace who raises the window

### DIFF
--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -485,6 +485,7 @@ func (a *App) startup(ctx context.Context) {
 	// state the user's terminal does.
 	importLoginShellEnv()
 	configureAppIdentity("ERun")
+	observeAppActivation()
 	a.startActivityPollers()
 	a.startCloudContextStatusPoller()
 	a.startConfigWatcher()

--- a/erun-ui/app_activation_darwin.go
+++ b/erun-ui/app_activation_darwin.go
@@ -1,0 +1,47 @@
+//go:build darwin
+
+package main
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Foundation -framework AppKit
+#include <stdlib.h>
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+
+// erunObserveActivation records every time this app becomes the frontmost
+// application, with the in-process call stack at that moment.
+//
+// Why a backtrace and not a counter: macOS attributes a front-process change to
+// WindowServer and launchservicesd in the unified log whether the user clicked
+// the app or the app asked to be raised, so the system log alone cannot tell
+// "the operator switched to us" from "we stole focus". The call stack can: an
+// activation we caused runs on our own thread with our frames underneath it,
+// while one the user caused arrives with nothing of ours below AppKit.
+//
+// This exists because erun was observed taking focus back roughly two seconds
+// after the operator switched away, repeatedly, and nothing in erun's own
+// source raises the window -- no WindowShow, no activateIgnoringOtherApps, no
+// bell handler. Rather than keep guessing, make the app say who did it.
+static void erunObserveActivation(void) {
+	@autoreleasepool {
+		[[NSNotificationCenter defaultCenter]
+		    addObserverForName:NSApplicationDidBecomeActiveNotification
+		                object:nil
+		                 queue:nil
+		            usingBlock:^(NSNotification *note) {
+			            (void)note;
+			            NSLog(@"erun-activation: became frontmost; stack=%@",
+			                  [NSThread callStackSymbols]);
+		            }];
+	}
+}
+*/
+import "C"
+
+// observeAppActivation installs the frontmost-activation trace. Darwin only:
+// it is the only platform where the focus theft was reported, and the only one
+// with an AppKit notification to hang it on.
+func observeAppActivation() {
+	C.erunObserveActivation()
+}

--- a/erun-ui/app_activation_other.go
+++ b/erun-ui/app_activation_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package main
+
+// observeAppActivation is darwin-only; elsewhere there is no AppKit
+// frontmost-activation notification to observe.
+func observeAppActivation() {}

--- a/erun-ui/frontend/src/app/TerminalController.ts
+++ b/erun-ui/frontend/src/app/TerminalController.ts
@@ -321,6 +321,13 @@ export class TerminalController {
     scheduleTerminalFocus({
       getTerminal: () => this.terminal,
       windowIsActive: () => document.hasFocus(),
+      focusIsFree: () => {
+        const active = document.activeElement;
+        if (!active || active === document.body) {
+          return true;
+        }
+        return this.terminalRoot?.contains(active) ?? false;
+      },
     });
   }
 

--- a/erun-ui/frontend/src/app/terminalFocus.test.ts
+++ b/erun-ui/frontend/src/app/terminalFocus.test.ts
@@ -39,7 +39,7 @@ afterEach(() => {
   mock.timers.reset();
 });
 
-function harness(windowIsActive: () => boolean) {
+function harness(windowIsActive: () => boolean, focusIsFree: () => boolean = () => true) {
   let focusCount = 0;
   scheduleTerminalFocus({
     getTerminal: () => ({
@@ -48,6 +48,7 @@ function harness(windowIsActive: () => boolean) {
       },
     }),
     windowIsActive,
+    focusIsFree,
   });
   return {
     count: () => focusCount,
@@ -86,4 +87,35 @@ test('the guard is re-checked, so focus leaving the window mid-sequence stops it
   flushRaf();
   mock.timers.tick(80);
   assert.equal(h.count(), 1, 'attempts after focus left the window must stand down');
+});
+
+// The other half of #1338, and the one document.hasFocus() cannot see: the
+// window IS active, so nothing crosses an application boundary, but the user
+// has deliberately clicked into another control. A restore exists to undo focus
+// an action destroyed, not to overrule a live choice -- yanking the caret back
+// to the terminal reads as the app stealing focus just the same.
+test('focus is never taken off a control the user deliberately focused', () => {
+  const h = harness(
+    () => true,
+    () => false,
+  );
+  mock.timers.tick(0);
+  flushRaf();
+  mock.timers.tick(80);
+  assert.equal(h.count(), 0, 'a control holding focus must not be overruled');
+});
+
+test('a restore still happens when nothing else holds focus', () => {
+  let free = true;
+  const h = harness(
+    () => true,
+    () => free,
+  );
+  mock.timers.tick(0);
+  assert.equal(h.count(), 1, 'a dialog close leaves focus free, so the restore must run');
+  // The user clicks into something before the trailing attempts land.
+  free = false;
+  flushRaf();
+  mock.timers.tick(80);
+  assert.equal(h.count(), 1, 'later attempts must stand down once a control takes focus');
 });

--- a/erun-ui/frontend/src/app/terminalFocus.ts
+++ b/erun-ui/frontend/src/app/terminalFocus.ts
@@ -6,6 +6,10 @@ interface TerminalFocusDeps {
   getTerminal: () => TerminalFocusTarget | null;
   // windowIsActive is false exactly when another application is frontmost.
   windowIsActive: () => boolean;
+  // focusIsFree is false when some other control deliberately holds focus --
+  // an input the user clicked into, a button they tabbed to. Restoring focus
+  // to the terminal is only ever correct when nothing else is holding it.
+  focusIsFree: () => boolean;
 }
 
 // scheduleTerminalFocus restores focus to the terminal after something moved it
@@ -23,19 +27,30 @@ interface TerminalFocusDeps {
 // window in between -- checking only at schedule time would let the 80ms
 // attempt steal focus the user had already moved elsewhere.
 export function scheduleTerminalFocus(deps: TerminalFocusDeps): void {
-  const focusIfWindowActive = (): void => {
+  const focusIfSafe = (): void => {
+    // Cross-application: never PULL the window forward (#1338).
     if (!deps.windowIsActive()) {
+      return;
+    }
+    // Within the window: never take focus off a control the user deliberately
+    // put it on. A restore exists to undo focus that an action DESTROYED (a
+    // dialog closing removes the focused node, so focus falls back to body),
+    // not to overrule a live choice. Without this the 80ms attempt lands after
+    // the user has already clicked into something else and yanks the caret to
+    // the terminal, which reads as the app stealing focus even though the
+    // window never changed.
+    if (!deps.focusIsFree()) {
       return;
     }
     deps.getTerminal()?.focus();
   };
   window.setTimeout(() => {
-    focusIfWindowActive();
+    focusIfSafe();
     window.requestAnimationFrame(() => {
-      focusIfWindowActive();
+      focusIfSafe();
     });
     window.setTimeout(() => {
-      focusIfWindowActive();
+      focusIfSafe();
     }, 80);
   }, 0);
 }


### PR DESCRIPTION
## Why this exists

#1339 guarded `focusTerminalSoon()` with `document.hasFocus()`, so erun can no longer PULL its window in front of another application. The operator reports the focus theft continuing, so that was not the path -- or not the only one. This does two things: closes the other half of the guard, and stops the guessing.

## 1. Do not steal focus from a control the user chose

`document.hasFocus()` is true whenever the ERun window is active, so the #1339 guard is inert for focus moving *within* the window. A restore exists to undo focus that an action **destroyed** -- a closing dialog removes the focused node, so focus falls back to `body` -- not to overrule a live choice. Without this guard the trailing 80ms attempt lands after the user has already clicked into another control and yanks the caret to the terminal, which reads as the app stealing focus even though the window never changed.

`focusIsFree()` reports whether anything other than the terminal holds focus. A restore now runs only when focus is on `body` or already inside the terminal.

Verified both ways: with the guard, `5 passed`; with only the `focusIsFree` check removed, `3 pass, 2 fail` -- `a control holding focus must not be overruled` and `later attempts must stand down once a control takes focus`.

## 2. Make the app say who raises it

Nothing in erun's source raises the window: no `WindowShow`, `WindowUnminimise`, `WindowSetAlwaysOnTop`, `WindowFocus`, no `activateIgnoringOtherApps`, no bell handler, no native notification. The only Wails runtime calls in the whole app are `Quit`, two file dialogs, `EventsEmit` and `BrowserOpenURL`. Yet the host system log shows the pattern clearly -- Chrome frontmost, then ERun taking it back ~2s later, twice with that same gap, then ERun re-fronting at 18:19:10, :21, :24 and :31.

macOS attributes a front-process change to WindowServer and launchservicesd whether the user clicked the app or the app asked to be raised, so the system log alone cannot separate "the operator switched to us" from "we stole focus".

`app_activation_darwin.go` observes `NSApplicationDidBecomeActiveNotification` and logs the in-process call stack. That distinction is exactly what the stack carries: an activation we caused runs on our own thread with our frames underneath it; one the user caused arrives with nothing of ours below AppKit. Darwin-only, because that is the only platform where this was reported and the only one with the notification.

This is a diagnostic, and deliberately so -- three restarts have now been spent on hypotheses. The next one produces evidence either way.

## Gating note

`app_activation_darwin.go` is `//go:build darwin`, so the Linux repo-gate cannot compile it. It was compile-checked by building the macOS desktop from this branch on the host: build exit 0, `erun-activation` present in the resulting binary.

Refs #1338
