### PR TITLE
Log the activation stack publicly so the trace is not redacted

### DIFF
--- a/erun-ui/app_activation_darwin.go
+++ b/erun-ui/app_activation_darwin.go
@@ -8,6 +8,7 @@ package main
 #include <stdlib.h>
 #import <Foundation/Foundation.h>
 #import <AppKit/AppKit.h>
+#import <os/log.h>
 
 // erunObserveActivation records every time this app becomes the frontmost
 // application, with the in-process call stack at that moment.
@@ -31,8 +32,15 @@ static void erunObserveActivation(void) {
 		                 queue:nil
 		            usingBlock:^(NSNotification *note) {
 			            (void)note;
-			            NSLog(@"erun-activation: became frontmost; stack=%@",
-			                  [NSThread callStackSymbols]);
+			            // %{public}@, not NSLog: os_log treats every dynamic
+			            // argument as private by default, so the stack this
+			            // trace exists to capture came out as
+			            // "stack=<private>" and told us nothing. Un-redacting
+			            // afterwards needs a configuration profile, so the
+			            // only thing that works is marking it public here.
+			            os_log(OS_LOG_DEFAULT,
+			                   "erun-activation: became frontmost; stack=%{public}@",
+			                   [NSThread callStackSymbols]);
 		            }];
 	}
 }


### PR DESCRIPTION
## The trace #1340 added was useless as shipped

`app_activation_darwin.go` logs the call stack whenever the app becomes frontmost, so an activation erun caused can be told from one the operator caused. It used `NSLog`, and **os_log treats every dynamic argument as private by default**, so every line came out as:

```
erun-app[6076] erun-activation: became frontmost; stack=<private>
```

The stack -- the entire reason the trace exists -- was redacted. Un-redacting after the fact needs a configuration profile, so the only thing that works is marking the argument public at the call site.

Switched to `os_log(OS_LOG_DEFAULT, "... stack=%{public}@", [NSThread callStackSymbols])`.

## Note on what this no longer needs to find

The focus theft that motivated #1338 has since been root-caused, and it was **not** erun: four leftover `launchctl submit` relaunch jobs (`com.erun.relaunch1333`, `1335`, `1339`, and `3` from a session three days earlier) were resurrecting the desktop. `launchctl submit` is KeepAlive by default, so each rebuild+restart relauncher became a permanent supervisor -- the app restarted whenever the operator quit it, and every relaunch brought it to the front. Removing the four jobs stopped it; the tell-tale burst of four app starts in twenty seconds (18:26:41/:45/:51/18:27:01) ceased. Filed as #1341, since the absence of a programmatic restart trigger is what forces an orchestrator to hand-roll such a relauncher in the first place.

The trace is kept anyway: it is cheap, and "who raised this window" is a question worth being able to answer without a three-restart investigation.

## Gating note

`app_activation_darwin.go` is `//go:build darwin`, so the Linux repo-gate cannot compile it. Compile-checked by building the macOS desktop from this branch on the host: exit 0, `erun-activation` present in the binary.

Refs #1338
