### PR TITLE
A disk mount has capacity, not a limit

### DIFF
--- a/erun-ui/frontend/src/components/app/ManageDialogRuntimeUsage.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogRuntimeUsage.tsx
@@ -202,7 +202,7 @@ function MemoryMeters({ memory }: { memory: UIRuntimeMemoryUsage }): React.React
         valueText={`${memory.current ?? '—'} of ${memory.limit ?? '—'}`}
         percent={memory.percentOfLimit}
         warnAt={MEMORY_WARN_PERCENT}
-        detail={percentDetail(memory.percentOfLimit)}
+        detail={percentDetail(memory.percentOfLimit, 'of the limit')}
       />
       <MemoryPeakAndKills memory={memory} />
     </div>
@@ -257,7 +257,7 @@ function DiskMeter({ disk }: { disk: UIRuntimeDiskUsage }): React.ReactElement {
       valueText={`${disk.used ?? '—'} of ${disk.total ?? '—'}`}
       percent={disk.percentUsed}
       warnAt={DISK_WARN_PERCENT}
-      detail={percentDetail(disk.percentUsed)}
+      detail={percentDetail(disk.percentUsed, 'used')}
     />
   );
 }
@@ -289,8 +289,11 @@ function percentText(value: number | undefined): string {
   return value === undefined || !Number.isFinite(value) ? '—' : `${value.toFixed(0)}%`;
 }
 
-function percentDetail(value: number | undefined): string | undefined {
+// The qualifier is the caller's, because the noun differs by resource and the
+// wrong one is user-facing nonsense: memory is a fraction "of the limit" it was
+// given, while a disk mount has capacity, not a limit, and is simply "used".
+function percentDetail(value: number | undefined, qualifier: string): string | undefined {
   return value === undefined || !Number.isFinite(value)
     ? undefined
-    : `${value.toFixed(0)}% of the limit`;
+    : `${value.toFixed(0)}% ${qualifier}`;
 }

--- a/erun-ui/playwright/tests/manage-runtime-usage.spec.ts
+++ b/erun-ui/playwright/tests/manage-runtime-usage.spec.ts
@@ -81,7 +81,7 @@ test.describe('manage dialog runtime usage panel', () => {
     await expect(panel).toContainText('75% of the limit');
     await expect(panel).toContainText('1.8 GiB');
     await expect(panel).toContainText('90.0 GiB of 100.0 GiB');
-    await expect(panel).toContainText('90% of the limit');
+    await expect(panel).toContainText('90% used');
 
     // A percentage against a limit is a magnitude, so each measured field
     // renders a meter carrying its own value -- CPU, memory and the one disk


### PR DESCRIPTION
Found by looking at the rendered panel rather than by a test — which is the point of #1345's closing protocol.

`percentDetail` was shared between memory and disk and hardcoded the memory noun, so the disk row read **"34% of the limit"**. A disk mount has capacity, not a limit; "of the limit" is memory's language leaking into a resource that has none. That is the user-language rule in `erun-ui/AGENTS.md` § Professional UX ("Labels and messages must use user-language, not implementation-language") and #1345 criterion 7.

The qualifier now belongs to the caller — memory is a fraction "of the limit" it was given, disk is simply "used".

Every assertion still passed with the wrong noun, because the tests asserted the string the code produced rather than the string a reader needs. Only the screenshot caught it.

Verified: `manage-runtime-usage.spec.ts` green 2/2 against a rebuilt binary (`--build`; without it the run silently tests the previous binary's embedded frontend, which is how the stale wording first appeared to survive the fix), plus a scratch screenshot spec re-rendered in the normal / threshold-crossed / nothing-measurable states and read back to confirm the panel now says "34% used".

Refs #1336, #1345