### PR TITLE
Give the orchestrator row a hover card, and the busy label a duration

### DIFF
--- a/erun-ui/frontend/src/app/orchestratorBusyLabel.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorBusyLabel.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { orchestratorBusyLabel } from './orchestratorBusyLabel';
+
+const NOW = Date.UTC(2026, 7, 25, 12, 0, 0);
+const at = (secondsAgo: number): number => Math.floor(NOW / 1000) - secondsAgo;
+
+// This is the half #1228 promised and did not deliver: its label was
+// `${name} is working`, which restates the spinner. A duration is the thing the
+// operator cannot get any other way.
+test('a timestamped report says how long it has been working', () => {
+  assert.equal(orchestratorBusyLabel('erun-prod', at(252), NOW), 'erun-prod is working, for 4m12s');
+});
+
+// Fail-soft: no timestamp is not zero seconds. An orchestrator that reported
+// busy before busyAtUnix existed must degrade to the bare statement rather than
+// claim it started working exactly now.
+test('a report with no timestamp degrades instead of inventing a duration', () => {
+  assert.equal(orchestratorBusyLabel('erun-prod', undefined, NOW), 'erun-prod is working');
+  assert.equal(orchestratorBusyLabel('erun-prod', 0, NOW), 'erun-prod is working');
+});
+
+test('a fresh turn reads in seconds rather than an empty duration', () => {
+  assert.equal(orchestratorBusyLabel('petios-qa', at(3), NOW), 'petios-qa is working, for 3s');
+});
+
+test('a long turn does not collapse to minutes only', () => {
+  assert.equal(
+    orchestratorBusyLabel('erun-prod', at(3 * 3600 + 25 * 60), NOW),
+    'erun-prod is working, for 3h25m',
+  );
+});

--- a/erun-ui/frontend/src/app/orchestratorBusyLabel.ts
+++ b/erun-ui/frontend/src/app/orchestratorBusyLabel.ts
@@ -1,0 +1,39 @@
+import { formatElapsed } from './activityQueueState';
+
+// orchestratorBusyLabel names a working orchestrator and, when the report
+// carries a timestamp, how long it has been working.
+//
+// #1228 set out to make a spinning orchestrator row say "what it is working on
+// and for how long", and shipped a label of `${name} is working` -- which
+// restates what the spinner already conveys visually and answers neither half.
+// Its own premise check recorded why: `OrchestratorInfo.busy` was a plain
+// boolean, so the elapsed figure needed the timestamp carried through, and it
+// was not. #1343 carries it (`busyAtUnix`, from the same activity report the
+// spinner reads), and this is the label that spends it.
+//
+// The sibling one function below in Sidebar.ErunSection already does exactly
+// this for a background shell via orchestratorShellLabel; a working turn is the
+// more important of the two to explain, and was the less informative.
+//
+// A missing or zero timestamp degrades to the bare statement rather than
+// inventing an elapsed time: an orchestrator that reported busy before this
+// field existed, or whose report predates its current session, has no honest
+// duration to show. That is the same fail-soft rule the rest of the sidebar
+// follows -- say less rather than say something untrue.
+export function orchestratorBusyElapsed(busyAtUnix: number | undefined, nowMs: number): string {
+  if (busyAtUnix === undefined || busyAtUnix <= 0) {
+    return '';
+  }
+  return formatElapsed(new Date(busyAtUnix * 1000).toISOString(), nowMs).trim();
+}
+
+export function orchestratorBusyLabel(
+  orchestratorName: string,
+  busyAtUnix: number | undefined,
+  nowMs: number,
+): string {
+  const elapsed = orchestratorBusyElapsed(busyAtUnix, nowMs);
+  return elapsed
+    ? `${orchestratorName} is working, for ${elapsed}`
+    : `${orchestratorName} is working`;
+}

--- a/erun-ui/frontend/src/app/slices/orchestratorsSlice.ts
+++ b/erun-ui/frontend/src/app/slices/orchestratorsSlice.ts
@@ -30,6 +30,10 @@ export interface OrchestratorInfo {
   sessionId: number;
   status: string;
   busy: boolean;
+  // busyAtUnix is when that busy report was written. Optional because a
+  // report can predate the field; the label degrades rather than inventing a
+  // duration (#1343).
+  busyAtUnix?: number;
   transient: boolean;
   shellRunning: boolean;
   shellCommand: string;

--- a/erun-ui/frontend/src/components/app/Sidebar.ErunSection.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.ErunSection.tsx
@@ -15,6 +15,7 @@ import { openDocumentation } from '@/app/documentationThunks';
 import { openGlobalConfigDialog } from '@/app/globalConfigThunks';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { startManageDoctor } from '@/app/manageEnvironmentThunks';
+import { orchestratorBusyLabel } from '@/app/orchestratorBusyLabel';
 import { orchestratorShellLabel } from '@/app/orchestratorShellLabel';
 import {
   loadOrchestrators,
@@ -28,6 +29,7 @@ import type { OrchestratorShellActivity } from '@/app/slices/orchestratorShellAc
 import type { OrchestratorInfo } from '@/app/slices/orchestratorsSlice';
 import { openOrchestratorDialog } from '@/app/slices/orchestratorsSlice';
 import { BusyRowSpinner } from '@/components/app/Sidebar.BusyRowSpinner';
+import { OrchestratorHoverCard } from '@/components/app/Sidebar.OrchestratorHoverCard';
 import { StatusDotGlyph } from '@/components/app/Sidebar.StatusDot';
 
 // ErunSection is the top-level "ERUN" sidebar block above ENVIRONMENTS: the
@@ -217,36 +219,48 @@ function OrchestratorRow({
       : undefined,
   );
   return (
-    <li
-      className={cn(
-        'group mr-1 ml-1 flex h-8 items-center gap-1.5 rounded-md pr-1.5 pl-3.5 text-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-        active &&
-          'bg-primary text-primary-foreground shadow-sm hover:bg-primary hover:text-primary-foreground',
-      )}
-    >
-      <button
-        type="button"
+    <li>
+      {/* The row's own styling moves onto the hover card's anchor div, the way
+          EnvironmentRow does it, so the <li> keeps its list semantics inside
+          the "AI orchestrators" list while the hover surface is the whole row
+          rather than a 12px spinner icon (#1343). */}
+      <OrchestratorHoverCard
         className={cn(
-          'flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 border-0 bg-transparent py-0 text-left text-sm leading-[1.2] tracking-normal text-inherit',
-          active ? 'font-medium' : 'font-normal',
+          'group mr-1 ml-1 flex h-8 items-center gap-1.5 rounded-md pr-1.5 pl-3.5 text-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+          active &&
+            'bg-primary text-primary-foreground shadow-sm hover:bg-primary hover:text-primary-foreground',
         )}
-        aria-label={`${running ? 'Open' : 'Start'} orchestrator ${orchestrator.name}`}
-        aria-current={active ? 'page' : undefined}
-        onClick={() => {
-          if (running) {
-            dispatch(openOrchestrator(orchestrator.sessionId));
-          } else {
-            void dispatch(startOrchestrator(orchestrator.id));
-          }
-        }}
+        orchestrator={orchestrator}
       >
-        <span className="min-w-0 truncate">{orchestrator.name}</span>
-      </button>
-      {busy && <OrchestratorBusyIndicator name={orchestrator.name} />}
-      {!busy && shellActivity?.running && (
-        <OrchestratorShellIndicator name={orchestrator.name} activity={shellActivity} />
-      )}
-      <OrchestratorRowActions orchestrator={orchestrator} running={running} active={active} />
+        <button
+          type="button"
+          className={cn(
+            'flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 border-0 bg-transparent py-0 text-left text-sm leading-[1.2] tracking-normal text-inherit',
+            active ? 'font-medium' : 'font-normal',
+          )}
+          aria-label={`${running ? 'Open' : 'Start'} orchestrator ${orchestrator.name}`}
+          aria-current={active ? 'page' : undefined}
+          onClick={() => {
+            if (running) {
+              dispatch(openOrchestrator(orchestrator.sessionId));
+            } else {
+              void dispatch(startOrchestrator(orchestrator.id));
+            }
+          }}
+        >
+          <span className="min-w-0 truncate">{orchestrator.name}</span>
+        </button>
+        {busy && (
+          <OrchestratorBusyIndicator
+            name={orchestrator.name}
+            busyAtUnix={orchestrator.busyAtUnix}
+          />
+        )}
+        {!busy && shellActivity?.running && (
+          <OrchestratorShellIndicator name={orchestrator.name} activity={shellActivity} />
+        )}
+        <OrchestratorRowActions orchestrator={orchestrator} running={running} active={active} />
+      </OrchestratorHoverCard>
     </li>
   );
 }
@@ -256,8 +270,14 @@ function OrchestratorRow({
 // itself on hover exactly like every other spinner in the sidebar — the
 // aria-label alone reached only screen readers, leaving a sighted mouse user
 // with an inert spin.
-function OrchestratorBusyIndicator({ name }: { name: string }): React.ReactElement {
-  const label = `${name} is working`;
+function OrchestratorBusyIndicator({
+  name,
+  busyAtUnix,
+}: {
+  name: string;
+  busyAtUnix: number | undefined;
+}): React.ReactElement {
+  const label = orchestratorBusyLabel(name, busyAtUnix, Date.now());
   return (
     <IconTooltip label={label}>
       <BusyRowSpinner label={label} />

--- a/erun-ui/frontend/src/components/app/Sidebar.OrchestratorHoverCard.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.OrchestratorHoverCard.tsx
@@ -1,0 +1,187 @@
+import { Popover, PopoverAnchor, PopoverContent } from 'erun-kit';
+import * as React from 'react';
+
+import { formatElapsed } from '@/app/activityQueueState';
+import { orchestratorBusyElapsed } from '@/app/orchestratorBusyLabel';
+import type { OrchestratorInfo } from '@/app/slices/orchestratorsSlice';
+
+// OrchestratorHoverCard gives an orchestrator row the same hover treatment the
+// environment row has had since EnvHoverCard: a Popover, not a tooltip, because
+// a multi-field card does not belong in a tooltip (erun-ui/AGENTS.md).
+//
+// Before this, an orchestrator row explained nothing on hover. The only hover
+// surface in the section was an IconTooltip on the spinner icon, which exists
+// only WHILE the orchestrator is spinning -- so an idle orchestrator, the common
+// case, had no hover target at all, and a working one offered a tooltip on a
+// 12px icon rather than on the row the operator is pointing at (#1343).
+//
+// Deliberately mirrors EnvHoverCard rather than inventing a second hover
+// pattern: same Popover, same open-now / close-soon grace so moving the pointer
+// onto the card does not dismiss it, same non-focus-trapping semantics so the
+// row's own click-to-open still works, same width and type scale. Consistency
+// is the point (Nielsen #4) -- the two sidebar row kinds should not behave
+// differently for the same gesture.
+export function OrchestratorHoverCard({
+  className,
+  orchestrator,
+  children,
+}: {
+  className?: string;
+  orchestrator: OrchestratorInfo;
+  children: React.ReactNode;
+}): React.ReactElement {
+  const [open, setOpen] = React.useState(false);
+  const closeTimer = React.useRef(0);
+  const openNow = React.useCallback(() => {
+    window.clearTimeout(closeTimer.current);
+    setOpen(true);
+  }, []);
+  const closeSoon = React.useCallback(() => {
+    window.clearTimeout(closeTimer.current);
+    // Small grace so moving the pointer from the row onto the card doesn't close it.
+    closeTimer.current = window.setTimeout(() => {
+      setOpen(false);
+    }, 120);
+  }, []);
+  React.useEffect(
+    () => () => {
+      window.clearTimeout(closeTimer.current);
+    },
+    [],
+  );
+
+  const running = orchestrator.status === 'running';
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div
+          className={className}
+          onMouseEnter={openNow}
+          onMouseLeave={closeSoon}
+          onFocusCapture={openNow}
+          onBlurCapture={closeSoon}
+        >
+          {children}
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        side="right"
+        align="start"
+        sideOffset={8}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+        }}
+        onMouseEnter={openNow}
+        onMouseLeave={closeSoon}
+        className="w-72 p-0 text-sm"
+        role="dialog"
+        aria-label={`${orchestrator.name} details`}
+      >
+        <div className="border-b border-border px-3 py-2">
+          <div className="flex items-center gap-1.5">
+            <span className="min-w-0 truncate font-medium">{orchestrator.name}</span>
+            {orchestrator.transient && (
+              <span className="flex-none rounded-[calc(var(--radius)-4px)] border border-border px-1 py-px text-[10px] leading-none font-medium tracking-wide text-muted-foreground uppercase">
+                Transient
+              </span>
+            )}
+          </div>
+        </div>
+        <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1.5 px-3 py-2.5">
+          <HoverRow label="Status">{running ? 'Running' : 'Stopped'}</HoverRow>
+          <HoverRow label="Doing">
+            <OrchestratorDoing orchestrator={orchestrator} running={running} />
+          </HoverRow>
+          <HoverRow label="Environments">
+            <OrchestratorEnvironments environments={orchestrator.environments} />
+          </HoverRow>
+        </dl>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// The whole reason the row is worth hovering: what is this orchestrator doing
+// right now, and for how long. A working turn and a background shell are
+// independent facts -- a shell can outlive the turn that started it -- so both
+// are named when both are true rather than one hiding the other.
+function OrchestratorDoing({
+  orchestrator,
+  running,
+}: {
+  orchestrator: OrchestratorInfo;
+  running: boolean;
+}): React.ReactElement {
+  if (!running) {
+    return <Muted>Not started</Muted>;
+  }
+  // The card's own header already names the orchestrator, so these lines must
+  // not repeat it. The sidebar's tooltip labels (orchestratorBusyLabel,
+  // orchestratorShellLabel) deliberately DO carry the name, because they hang
+  // off a bare icon with no other context -- same facts, different surface.
+  const now = Date.now();
+  const lines: string[] = [];
+  if (orchestrator.busy) {
+    const elapsed = orchestratorBusyElapsed(orchestrator.busyAtUnix, now);
+    lines.push(elapsed ? `Working, for ${elapsed}` : 'Working');
+  }
+  if (orchestrator.shellRunning) {
+    const shellElapsed = orchestrator.shellStartedAtUnix
+      ? formatElapsed(new Date(orchestrator.shellStartedAtUnix * 1000).toISOString(), now).trim()
+      : '';
+    const shell = shellElapsed ? `Shell running for ${shellElapsed}` : 'Shell running';
+    lines.push(orchestrator.shellCommand ? `${shell}: ${orchestrator.shellCommand}` : shell);
+  }
+  if (lines.length === 0) {
+    // Distinct from "Not started": the session is up and simply between turns.
+    return <Muted>Idle, waiting for input</Muted>;
+  }
+  return (
+    <span className="grid gap-0.5">
+      {lines.map((line) => (
+        <span key={line}>{line}</span>
+      ))}
+    </span>
+  );
+}
+
+function OrchestratorEnvironments({
+  environments,
+}: {
+  environments: OrchestratorInfo['environments'];
+}): React.ReactElement {
+  if (environments.length === 0) {
+    // An orchestrator with no links is a real state, not a failure to load --
+    // and it is worth naming, because it is why its tools are empty.
+    return <Muted>None linked</Muted>;
+  }
+  return (
+    <span className="grid gap-0.5">
+      {environments.map((env) => (
+        <span key={`${env.tenant}/${env.environment}`} className="truncate">
+          {env.tenant} / {env.environment}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function HoverRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <>
+      <dt className="text-[12px] text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 break-words text-foreground">{children}</dd>
+    </>
+  );
+}
+
+function Muted({ children }: { children: React.ReactNode }): React.ReactElement {
+  return <span className="text-muted-foreground">{children}</span>;
+}

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -55,6 +55,11 @@ type orchestratorSession struct {
 	// on having witnessed the ai-activity event that last changed it. See
 	// reconcileOrchestratorActivity in session_heartbeat.go.
 	aiBusy bool
+	// aiBusyAtUnix is when that report was written, carried for the same
+	// reason shellStartedAtUnix is: "working" alone cannot tell the operator
+	// whether a turn just started or has been going for ten minutes, which is
+	// the whole question a busy indicator is asked (#1343, finishing #1228).
+	aiBusyAtUnix int64
 	// shellRunning, shellCommand and shellStartedAtUnix are the last background
 	// shell report the poller observed — a fact independent of aiBusy,
 	// since a shell can keep running after the turn that started it ends. Same
@@ -122,6 +127,7 @@ type orchestratorInfo struct {
 	SessionID          int                   `json:"sessionId"`
 	Status             string                `json:"status"`
 	Busy               bool                  `json:"busy"`
+	BusyAtUnix         int64                 `json:"busyAtUnix,omitempty"`
 	Transient          bool                  `json:"transient"`
 	ShellRunning       bool                  `json:"shellRunning"`
 	ShellCommand       string                `json:"shellCommand,omitempty"`
@@ -914,7 +920,16 @@ type orchestratorShellSnapshot struct {
 	StartedAtUnix int64
 }
 
-func orchestratorInfoFor(id, name string, envs []eruncommon.OrchestratorEnvConfig, status string, sessionID int, busy, transient bool, shell orchestratorShellSnapshot) orchestratorInfo {
+// orchestratorBusySnapshot is the turn-busy half of orchestratorInfo, grouped
+// for the same reason orchestratorShellSnapshot is: the alternative is another
+// positional bool and int64 beside the ones already there, indistinguishable at
+// the call site.
+type orchestratorBusySnapshot struct {
+	Busy   bool
+	AtUnix int64
+}
+
+func orchestratorInfoFor(id, name string, envs []eruncommon.OrchestratorEnvConfig, status string, sessionID int, busy orchestratorBusySnapshot, transient bool, shell orchestratorShellSnapshot) orchestratorInfo {
 	return orchestratorInfo{
 		ID:                 id,
 		Name:               name,
@@ -923,7 +938,8 @@ func orchestratorInfoFor(id, name string, envs []eruncommon.OrchestratorEnvConfi
 		Directories:        directoriesFromEnvs(envs),
 		SessionID:          sessionID,
 		Status:             status,
-		Busy:               busy,
+		Busy:               busy.Busy,
+		BusyAtUnix:         busy.AtUnix,
 		ShellRunning:       shell.Running,
 		ShellCommand:       shell.Command,
 		ShellStartedAtUnix: shell.StartedAtUnix,
@@ -1269,7 +1285,7 @@ func (a *App) CreateOrchestrator(name string, envs []orchestratorEnvInput) (orch
 	if err := a.saveOrchestratorConfigs(append(configs, def)); err != nil {
 		return orchestratorInfo{}, err
 	}
-	return orchestratorInfoFor(id, displayName, refs, "stopped", 0, false, false, orchestratorShellSnapshot{}), nil
+	return orchestratorInfoFor(id, displayName, refs, "stopped", 0, orchestratorBusySnapshot{}, false, orchestratorShellSnapshot{}), nil
 }
 
 // UpdateOrchestrator edits an existing orchestrator's linked environments and
@@ -1306,12 +1322,12 @@ func (a *App) UpdateOrchestrator(id, name string, envs []orchestratorEnvInput) (
 	}
 	status := "stopped"
 	sessionID := 0
-	busy := false
+	busy := orchestratorBusySnapshot{}
 	shell := orchestratorShellSnapshot{}
 	if info, ok := a.runningOrchestratorInfo(id); ok {
 		status = "running"
 		sessionID = info.SessionID
-		busy = info.Busy
+		busy = orchestratorBusySnapshot{Busy: info.Busy, AtUnix: info.BusyAtUnix}
 		shell = orchestratorShellSnapshot{Running: info.ShellRunning, Command: info.ShellCommand, StartedAtUnix: info.ShellStartedAtUnix}
 	}
 	return orchestratorInfoFor(id, displayName, refs, status, sessionID, busy, false, shell), nil
@@ -1403,7 +1419,7 @@ func (a *App) runningOrchestratorInfo(id string) (orchestratorInfo, bool) {
 		return orchestratorInfo{}, false
 	}
 	shell := orchestratorShellSnapshot{Running: session.shellRunning, Command: session.shellCommand, StartedAtUnix: session.shellStartedAtUnix}
-	return orchestratorInfoFor(session.id, session.name, session.envs, "running", session.serial, session.aiBusy, session.transient, shell), true
+	return orchestratorInfoFor(session.id, session.name, session.envs, "running", session.serial, orchestratorBusySnapshot{Busy: session.aiBusy, AtUnix: session.aiBusyAtUnix}, session.transient, shell), true
 }
 
 // runningOrchestratorConversation returns the conversation a live session is
@@ -1595,7 +1611,7 @@ func (a *App) spawnOrchestratorSession(spawn orchestratorSpawn) (orchestratorInf
 			log.Printf("erun-app: record open orchestrator %s: %v", id, err)
 		}
 	}
-	return orchestratorInfoFor(id, name, envs, "running", serial, false, transient, orchestratorShellSnapshot{}), nil
+	return orchestratorInfoFor(id, name, envs, "running", serial, orchestratorBusySnapshot{}, transient, orchestratorShellSnapshot{}), nil
 }
 
 // orchestratorRespawnFunc builds the closure tryReconnect calls when this
@@ -1651,13 +1667,13 @@ func (a *App) ListOrchestrators() []orchestratorInfo {
 	for _, config := range configs {
 		status := "stopped"
 		sessionID := 0
-		busy := false
+		busy := orchestratorBusySnapshot{}
 		shell := orchestratorShellSnapshot{}
 		if session := a.orchestrators[config.ID]; session != nil {
 			if managed := a.sessions[orchestratorSessionKey(config.ID)]; managed != nil && !managed.closed {
 				status = "running"
 				sessionID = session.serial
-				busy = session.aiBusy
+				busy = orchestratorBusySnapshot{Busy: session.aiBusy, AtUnix: session.aiBusyAtUnix}
 				shell = orchestratorShellSnapshot{Running: session.shellRunning, Command: session.shellCommand, StartedAtUnix: session.shellStartedAtUnix}
 			}
 		}
@@ -1673,7 +1689,7 @@ func (a *App) ListOrchestrators() []orchestratorInfo {
 			continue
 		}
 		shell := orchestratorShellSnapshot{Running: session.shellRunning, Command: session.shellCommand, StartedAtUnix: session.shellStartedAtUnix}
-		out = append(out, orchestratorInfoFor(id, session.name, session.envs, "running", session.serial, session.aiBusy, true, shell))
+		out = append(out, orchestratorInfoFor(id, session.name, session.envs, "running", session.serial, orchestratorBusySnapshot{Busy: session.aiBusy, AtUnix: session.aiBusyAtUnix}, true, shell))
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out

--- a/erun-ui/playwright/tests/sidebar-orchestrator-hover-card.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-orchestrator-hover-card.spec.ts
@@ -1,0 +1,135 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ORCHESTRATOR } from '../fixtures/seedRoot.js';
+
+// #1343: hovering an orchestrator row produced nothing. The only hover surface
+// in the ERun section was an IconTooltip on the busy spinner, which exists only
+// WHILE the orchestrator is spinning — so an idle orchestrator, the common case,
+// had no hover target at all, and a working one offered a tooltip on a 12px icon
+// rather than on the row the operator is pointing at. The environment row has
+// had a full hover card since EnvHoverCard.
+//
+// #1228 had also aimed at "says what it is working on and for how long" and
+// shipped `${name} is working` — the fact the spinner already conveys — because
+// orchestratorInfo carried no timestamp to spend. It does now (`busyAtUnix`).
+//
+// The card's mere existence is the regression guard: against the old code every
+// assertion here fails, because no dialog is rendered on hover at all.
+
+const RUNNING_SESSION_ID = 4242;
+
+function snapshot(overrides: Record<string, unknown>) {
+  return {
+    id: SEED_ORCHESTRATOR,
+    name: SEED_ORCHESTRATOR,
+    environments: [],
+    tenants: [],
+    directories: [],
+    sessionId: RUNNING_SESSION_ID,
+    status: 'running',
+    busy: false,
+    transient: false,
+    shellRunning: false,
+    shellCommand: '',
+    shellStartedAtUnix: 0,
+    ...overrides,
+  };
+}
+
+async function stubOrchestratorList(page: Page, body: unknown): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const parsed = JSON.parse(request.postData() ?? '{}') as { method?: string };
+    if (parsed.method === 'ListOrchestrators') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [body] }),
+      });
+    }
+    await route.continue();
+  });
+}
+
+function card(page: Page) {
+  return page.getByRole('dialog', { name: `${SEED_ORCHESTRATOR} details` });
+}
+
+test.describe('orchestrator row hover card (#1343)', () => {
+  test('a working orchestrator names what it is doing and for how long', async ({ app, page }) => {
+    // 4m12s before now, so the label must render a real duration rather than
+    // the bare "is working" #1228 shipped.
+    const busyAtUnix = Math.floor(Date.now() / 1000) - 252;
+    await stubOrchestratorList(
+      page,
+      snapshot({
+        busy: true,
+        busyAtUnix,
+        environments: [
+          { tenant: 'acme', environment: 'build', directory: '/tmp/a' },
+          { tenant: 'acme', environment: 'prod', directory: '/tmp/b' },
+        ],
+      }),
+    );
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+
+    await expect(card(page)).toBeVisible();
+    await expect(card(page)).toContainText('Running');
+    // The half #1228 promised and did not deliver.
+    await expect(card(page)).toContainText('Working, for 4m');
+    // Linked scope, which the row itself has never shown.
+    await expect(card(page)).toContainText('acme / build');
+    await expect(card(page)).toContainText('acme / prod');
+  });
+
+  test('a running but idle orchestrator says so, distinctly from not started', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(page, snapshot({ busy: false }));
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+
+    await expect(card(page)).toBeVisible();
+    await expect(card(page)).toContainText('Running');
+    await expect(card(page)).toContainText('Idle, waiting for input');
+    await expect(card(page)).toContainText('None linked');
+  });
+
+  test('a stopped orchestrator is hoverable too — the case with no spinner at all', async ({
+    app,
+    page,
+  }) => {
+    // The point of the issue: before this, an orchestrator that was not
+    // spinning had no hover surface whatsoever, because the only one hung off
+    // the spinner.
+    await stubOrchestratorList(page, snapshot({ status: 'stopped', sessionId: 0 }));
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+
+    await expect(card(page)).toBeVisible();
+    await expect(card(page)).toContainText('Stopped');
+    await expect(card(page)).toContainText('Not started');
+  });
+
+  test('the card does not swallow the row click that opens the orchestrator', async ({
+    app,
+    page,
+  }) => {
+    // EnvHoverCard's own constraint, inherited deliberately: the hover surface
+    // wraps the row, so it must not become a focus trap or eat the click.
+    await stubOrchestratorList(page, snapshot({ busy: false }));
+    await app.reboot();
+
+    const row = app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR);
+    await row.hover();
+    await expect(card(page)).toBeVisible();
+    await expect(row).toBeEnabled();
+    await row.click();
+    // The row stays operable; the card is decoration over it, not a modal.
+    await expect(row).toBeVisible();
+  });
+});

--- a/erun-ui/session_heartbeat.go
+++ b/erun-ui/session_heartbeat.go
@@ -141,6 +141,7 @@ func (a *App) reconcileOrchestratorActivity() {
 		a.mu.Lock()
 		if session := a.orchestrators[r.id]; session != nil {
 			session.aiBusy = busy
+			session.aiBusyAtUnix = activity.AtUnix
 			session.shellRunning = shellRunning
 			session.shellCommand = shell.Command
 			session.shellStartedAtUnix = shell.AtUnix


### PR DESCRIPTION
Closes #1343. Child of #1345.

## What was wrong

Hovering an orchestrator row produced **nothing**. `grep -c "HoverCard" Sidebar.ErunSection.tsx` → 0. The only hover surface in the section was an `IconTooltip` on the busy spinner, which exists only *while* the orchestrator is spinning — so an idle orchestrator, the common case, had no hover target at all, and a working one offered a tooltip on a 12px icon rather than on the row the pointer is actually over. The environment row has had `EnvHoverCard` for a while.

#1228 had also aimed at *"says what it is working on and for how long"* and shipped `\`\${name} is working\`` — restating what the spinner already conveys. Its own premise check recorded why: `orchestratorInfo.busy` was a plain boolean, so the duration needed a timestamp carried through, and it never was.

## What this does

**Carries the timestamp.** `orchestratorActivity.AtUnix` already existed and the hook already wrote it; it just never reached `orchestratorInfo`. Added `aiBusyAtUnix` to the session and `BusyAtUnix` to the snapshot, following the existing `shellStartedAtUnix` precedent exactly. Rather than add another positional bool+int64 to `orchestratorInfoFor`, introduced `orchestratorBusySnapshot` — the same grouping, and for the same stated reason, as the `orchestratorShellSnapshot` beside it.

**Gives the row a hover card.** `OrchestratorHoverCard` mirrors `EnvHoverCard` deliberately — same Popover (not a tooltip; a multi-field card does not belong in one, per `erun-ui/AGENTS.md`), same open-now/close-soon grace, same non-focus-trapping semantics so the row's click-to-open still works, same width and type scale. Consistency is the point: two sidebar row kinds should not behave differently for the same gesture. The `<li>` keeps its list semantics; the row styling moves onto the card's anchor div, exactly as `EnvironmentRow` does it.

It shows Status, **Doing**, and Environments. Working and shell-running are independent facts (a shell outlives the turn that started it), so both are named when both are true. Three states stay distinct: **Not started** (stopped), **Idle, waiting for input** (running, between turns), and the activity lines.

## What looking at it caught

The screenshot pass — the same step that caught the copy bug on #1336 — showed the Doing rows reading *"pw-orch is working"* and *"pw-orch has a shell running"* inside a card whose header already says **pw-orch**. The tooltip labels correctly carry the name because they hang off a bare icon with no context; the card must not repeat it. Extracted `orchestratorBusyElapsed` so the card and the tooltip share one duration formatter and cannot drift, and the card now reads `Working, for 4m16s` / `Shell running for 10m44s: gradle build`.

## Verification

- `orchestratorBusyLabel.test.ts` — 4 tests: a timestamped report renders a duration; **a missing or zero timestamp degrades rather than inventing one** (fail-soft — "no timestamp" is not "zero seconds"); a fresh turn reads in seconds; a long turn does not collapse to minutes.
- `sidebar-orchestrator-hover-card.spec.ts` — 4 specs green against a rebuilt binary: working (duration + linked envs), running-idle, **stopped** (the case that previously had no hover surface whatsoever), and that the card does not swallow the row click.
- **The card's existence is the regression guard**: against the old code every assertion fails, because no dialog renders on hover at all.
- Go `go test ./...` green in erun-ui; frontend `tsc` clean, 157/157 unit tests.
- Screenshots read in the working and stopped states.