### PR TITLE
Keep one conversation to one orchestrator

### DIFF
--- a/erun-ui/app_restart.go
+++ b/erun-ui/app_restart.go
@@ -305,6 +305,18 @@ func resolveReopenSessionID(entry orchestratorOpenEntry) string {
 	if entry.SessionID != "" && orchestratorSessionExists(entry.SessionID) {
 		return entry.SessionID
 	}
+	// The durable record has no usable conversation for this orchestrator:
+	// either it never recorded one, or its claim was released because another
+	// orchestrator held the same session. Its OWN hooks may still know which
+	// conversation is really its, so prefer that over minting a fresh id and
+	// orphaning a live transcript — the release exists to end a crossing, not
+	// to cost the loser its history. Still refused if a different orchestrator
+	// claims it, which is the crossing this would otherwise re-create.
+	if live, ok := readOrchestratorLiveSessionID(entry.OrchestratorID); ok &&
+		orchestratorSessionExists(live) &&
+		!orchestratorLiveSessionClaimedByOther(entry.OrchestratorID, live) {
+		return live
+	}
 	return uuid.NewString()
 }
 

--- a/erun-ui/orchestrator_live_session.go
+++ b/erun-ui/orchestrator_live_session.go
@@ -96,7 +96,43 @@ func preferLiveOrchestratorSessionID(orchestratorID, spawnConversationID string)
 	if !orchestratorSessionExists(live) {
 		return spawnConversationID
 	}
+	// A conversation belongs to one orchestrator. The recorder hook keys purely
+	// on $ERUN_ORCHESTRATOR_ID, so a session that ever ran under the wrong id
+	// leaves a record claiming somebody else's conversation — and adopting it
+	// here would hand this orchestrator the other's history and return note.
+	if orchestratorLiveSessionClaimedByOther(orchestratorID, live) {
+		return spawnConversationID
+	}
 	return live
+}
+
+// orchestratorLiveSessionClaimedByOther reports whether some OTHER
+// orchestrator's live-session record already names this conversation. Read
+// errors answer false: the guard exists to refuse a provable conflict, and a
+// directory it cannot list is not proof of one.
+func orchestratorLiveSessionClaimedByOther(orchestratorID, sessionID string) bool {
+	orchestratorID = strings.TrimSpace(orchestratorID)
+	sessionID = strings.TrimSpace(sessionID)
+	if orchestratorID == "" || sessionID == "" {
+		return false
+	}
+	entries, err := os.ReadDir(orchestratorLiveSessionDir())
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		other := strings.TrimSuffix(entry.Name(), ".json")
+		if other == orchestratorID {
+			continue
+		}
+		if claimed, ok := readOrchestratorLiveSessionID(other); ok && claimed == sessionID {
+			return true
+		}
+	}
+	return false
 }
 
 // orchestratorSessionRecordHookCommand is the hook command that keeps one

--- a/erun-ui/orchestrator_live_session_test.go
+++ b/erun-ui/orchestrator_live_session_test.go
@@ -214,3 +214,26 @@ func hookGroupContainsMarker(t *testing.T, block map[string]any, marker string) 
 	}
 	return false
 }
+
+// The recorder hook keys purely on $ERUN_ORCHESTRATOR_ID, so a conversation
+// that ever ran under the wrong id leaves a record claiming another
+// orchestrator's session. Adopting it would resume somebody else's history.
+func TestPreferLiveOrchestratorSessionIDRefusesAConversationAnotherOrchestratorClaims(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	stageOrchestratorConversation(t, "shared-conversation")
+	stageOrchestratorLiveSession(t, "petios-admin", "shared-conversation")
+	stageOrchestratorLiveSession(t, "erun", "shared-conversation")
+
+	if got := preferLiveOrchestratorSessionID("erun", "erun-spawn"); got != "erun-spawn" {
+		t.Fatalf("a conversation another orchestrator claims must not be adopted: got %q", got)
+	}
+
+	// Once the other orchestrator moves on, the conversation is adoptable.
+	stageOrchestratorLiveSession(t, "petios-admin", "petios-own-conversation")
+	if got := preferLiveOrchestratorSessionID("erun", "erun-spawn"); got != "shared-conversation" {
+		t.Fatalf("with the conflict gone the live record should win: got %q", got)
+	}
+}

--- a/erun-ui/orchestrator_open_state.go
+++ b/erun-ui/orchestrator_open_state.go
@@ -100,14 +100,24 @@ func recordOpenOrchestrator(path, orchestratorID, sessionID string, scope []stri
 	if path == "" || orchestratorID == "" {
 		return nil
 	}
+	sessionID = strings.TrimSpace(sessionID)
 	entries := readOpenOrchestrators(path)
 	out := make([]orchestratorOpenEntry, 0, len(entries)+1)
 	for _, entry := range entries {
-		if entry.OrchestratorID != orchestratorID {
-			out = append(out, entry)
+		if entry.OrchestratorID == orchestratorID {
+			continue
 		}
+		// A conversation belongs to one orchestrator. If another entry already
+		// names the session this launch is running, it is a stale claim by
+		// definition — this launch is the one with the conversation open now —
+		// so release it rather than leaving the id under two owners, which is
+		// what made a crossing stick across every later restart.
+		if sessionID != "" && strings.TrimSpace(entry.SessionID) == sessionID {
+			entry.SessionID = ""
+		}
+		out = append(out, entry)
 	}
-	out = append(out, orchestratorOpenEntry{OrchestratorID: orchestratorID, SessionID: strings.TrimSpace(sessionID), Environments: scope})
+	out = append(out, orchestratorOpenEntry{OrchestratorID: orchestratorID, SessionID: sessionID, Environments: scope})
 	return writeOpenOrchestrators(path, out)
 }
 
@@ -189,7 +199,37 @@ func dedupOrchestratorEntries(entries []orchestratorOpenEntry) []orchestratorOpe
 	if len(out) == 0 {
 		return nil
 	}
-	return out
+	return dropDuplicateSessionClaims(out)
+}
+
+// dropDuplicateSessionClaims enforces the invariant the rest of restore assumes
+// but nothing used to check: a conversation belongs to exactly ONE orchestrator.
+//
+// Deduping by orchestrator id alone let one session id sit under two ids at
+// once, and every later launch then resolved both of them to the same
+// conversation — so one orchestrator was handed the other's history, complete
+// with the other's scope and return note, and the crossing was self-reinforcing
+// because each launch recorded it again.
+//
+// Entries are oldest-first, so the walk runs backwards and the MOST RECENT claim
+// on a session keeps it. An older entry that named the same conversation stays
+// open — the operator had it open, and closing it would lose more than it fixes
+// — but comes back with no session id, which restore already treats as "start
+// this one fresh" rather than guessing.
+func dropDuplicateSessionClaims(entries []orchestratorOpenEntry) []orchestratorOpenEntry {
+	claimed := make(map[string]string, len(entries))
+	for i := len(entries) - 1; i >= 0; i-- {
+		session := strings.TrimSpace(entries[i].SessionID)
+		if session == "" {
+			continue
+		}
+		if owner, ok := claimed[session]; ok && owner != entries[i].OrchestratorID {
+			entries[i].SessionID = ""
+			continue
+		}
+		claimed[session] = entries[i].OrchestratorID
+	}
+	return entries
 }
 
 // writeOpenOrchestrators persists the open set, migrating a legacy file to the

--- a/erun-ui/orchestrator_open_state_test.go
+++ b/erun-ui/orchestrator_open_state_test.go
@@ -526,3 +526,31 @@ func TestOneOrchestratorMovingConversationsKeepsItsOwnLatestSession(t *testing.T
 		t.Fatalf("expected the one orchestrator to hold its newest session, got %+v", entries)
 	}
 }
+
+// Releasing a duplicate claim must not cost the loser its history: its own
+// hooks still know which conversation is really its, and reopen should prefer
+// that over minting a fresh id. This is the other half of
+// TestRecordingALaunchReleasesAnotherOrchestratorsClaimOnTheSameSession.
+func TestAReleasedClaimRecoversTheOrchestratorsOwnLiveConversation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", home)
+	t.Setenv("HOME", home)
+
+	stageOrchestratorConversation(t, "its-own-conversation")
+	stageOrchestratorLiveSession(t, "petios-admin", "its-own-conversation")
+
+	entry := orchestratorOpenEntry{OrchestratorID: "petios-admin", SessionID: ""}
+	if got := resolveReopenSessionID(entry); got != "its-own-conversation" {
+		t.Fatalf("expected the orchestrator's own live conversation, got %q", got)
+	}
+
+	// But never one another orchestrator claims — that is the crossing again.
+	stageOrchestratorLiveSession(t, "erun", "its-own-conversation")
+	got := resolveReopenSessionID(entry)
+	if got == "its-own-conversation" {
+		t.Fatal("a conversation another orchestrator claims must not be adopted on reopen")
+	}
+	if got == "" {
+		t.Fatal("expected a freshly minted conversation id")
+	}
+}

--- a/erun-ui/orchestrator_open_state_test.go
+++ b/erun-ui/orchestrator_open_state_test.go
@@ -456,3 +456,73 @@ func TestAlsoReopenSurfacesANoticeWhenScopeChanged(t *testing.T) {
 		t.Fatalf("expected the notice to name %q and both scopes, got %q", stale, target.Notice)
 	}
 }
+
+// A conversation belongs to exactly one orchestrator. Recording a launch must
+// release any other orchestrator's claim on the same session, or every later
+// restart resolves both ids to one conversation and hands one orchestrator the
+// other's history, scope and return note.
+func TestRecordingALaunchReleasesAnotherOrchestratorsClaimOnTheSameSession(t *testing.T) {
+	path := filepath.Join(t.TempDir(), orchestratorOpenFileName)
+
+	if err := recordOpenOrchestrator(path, "petios-admin", "shared-conversation", []string{"petios/rihards-develop"}); err != nil {
+		t.Fatalf("record petios-admin: %v", err)
+	}
+	if err := recordOpenOrchestrator(path, "erun", "shared-conversation", []string{"erun/build"}); err != nil {
+		t.Fatalf("record erun: %v", err)
+	}
+
+	entries := readOpenOrchestrators(path)
+	if len(entries) != 2 {
+		t.Fatalf("both orchestrators must stay open, got %d entries: %+v", len(entries), entries)
+	}
+	claims := map[string]string{}
+	for _, entry := range entries {
+		claims[entry.OrchestratorID] = entry.SessionID
+	}
+	if claims["erun"] != "shared-conversation" {
+		t.Fatalf("the launch that just happened keeps the session, got %q", claims["erun"])
+	}
+	if claims["petios-admin"] != "" {
+		t.Fatalf("the stale claim must be released so that orchestrator starts fresh, got %q", claims["petios-admin"])
+	}
+}
+
+// An already-crossed file heals on read: the operator hit this before the write
+// path was fixed, and a restart must not keep replaying the crossing.
+func TestReadingAnAlreadyCrossedOpenRecordReleasesTheOlderClaim(t *testing.T) {
+	path := filepath.Join(t.TempDir(), orchestratorOpenFileName)
+	crossed := `{"orchestrators":[` +
+		`{"orchestratorId":"petios-admin","sessionId":"b40e4de0","environments":["petios/rihards-develop"]},` +
+		`{"orchestratorId":"erun","sessionId":"b40e4de0","environments":["erun/build"]}]}`
+	if err := os.WriteFile(path, []byte(crossed), 0o644); err != nil {
+		t.Fatalf("write crossed record: %v", err)
+	}
+
+	entries := readOpenOrchestrators(path)
+	if len(entries) != 2 {
+		t.Fatalf("expected both orchestrators, got %+v", entries)
+	}
+	if entries[0].OrchestratorID != "petios-admin" || entries[0].SessionID != "" {
+		t.Fatalf("older claim must be released, got %+v", entries[0])
+	}
+	if entries[1].OrchestratorID != "erun" || entries[1].SessionID != "b40e4de0" {
+		t.Fatalf("most recent claim keeps the conversation, got %+v", entries[1])
+	}
+}
+
+// One orchestrator legitimately moving between conversations (a compaction fork
+// re-recorded under the same id) must not be mistaken for a crossing.
+func TestOneOrchestratorMovingConversationsKeepsItsOwnLatestSession(t *testing.T) {
+	path := filepath.Join(t.TempDir(), orchestratorOpenFileName)
+
+	for _, session := range []string{"before-compact", "after-compact"} {
+		if err := recordOpenOrchestrator(path, "agent-1", session, []string{"frs/dev"}); err != nil {
+			t.Fatalf("record %s: %v", session, err)
+		}
+	}
+
+	entries := readOpenOrchestrators(path)
+	if len(entries) != 1 || entries[0].SessionID != "after-compact" {
+		t.Fatalf("expected the one orchestrator to hold its newest session, got %+v", entries)
+	}
+}


### PR DESCRIPTION
Fixes #1357.

## What went wrong

`orchestrator-open.json` on the operator's machine held one conversation under two orchestrators:

```json
{"orchestratorId":"petios-admin","sessionId":"b40e4de0-…","environments":["petios/rihards-develop"]}
{"orchestratorId":"erun",        "sessionId":"b40e4de0-…","environments":["erun/build","erun/ux","frs/local"]}
```

`erun`'s restart hand-off was delivered into what had been `petios-admin`'s conversation all evening. That session read `RESUME-NOTE.erun.md`, adopted erun's scope, and worked erun's in-flight task while carrying petios-admin's context; petios-admin got a fresh session two seconds earlier and lost continuity with its own 2.5 MB of history.

## Root cause

`recordOpenOrchestrator` and `dedupOrchestratorEntries` both keyed only on `OrchestratorID`. Nothing enforced the invariant the rest of restore assumes — **a conversation belongs to exactly one orchestrator** — so once two entries named one session, `runningOrchestratorConversation` handed both the same id, `restartHandoff` resolved both to it, and the next launch wrote the pair back. That is why it kept recurring rather than being a one-off.

`preferLiveOrchestratorSessionID` had the matching hole on the read side: the recorder hook keys purely on `$ERUN_ORCHESTRATOR_ID`, so a session that ever runs under the wrong id leaves a live record claiming another orchestrator's conversation, and the function adopted it after checking only that the transcript existed on disk.

## The change

- **`recordOpenOrchestrator`** releases any other entry's claim on the session being recorded. The launch that has the conversation open now is its owner; the loser keeps its entry (the operator had it open) with no session id, which restore already treats as "start fresh".
- **`dropDuplicateSessionClaims`**, applied by `dedupOrchestratorEntries`, heals an already-crossed file on read. Entries are oldest-first so the walk runs backwards and the most recent claim keeps the conversation. Existing corrupt files self-heal rather than replaying the crossing — which matters, because the operator already has one.
- **`preferLiveOrchestratorSessionID`** refuses a live record naming a conversation another orchestrator's live file claims, via `orchestratorLiveSessionClaimedByOther`. Read errors answer false: the guard refuses a provable conflict, and an unlistable directory is not proof.

## Tests

Four added, and I verified the three regression guards fail without the fix rather than assuming they would:

```
--- FAIL: TestPreferLiveOrchestratorSessionIDRefusesAConversationAnotherOrchestratorClaims
    a conversation another orchestrator claims must not be adopted: got "shared-conversation"
--- FAIL: TestRecordingALaunchReleasesAnotherOrchestratorsClaimOnTheSameSession
    the stale claim must be released so that orchestrator starts fresh, got "shared-conversation"
--- FAIL: TestReadingAnAlreadyCrossedOpenRecordReleasesTheOlderClaim
    older claim must be released, got {OrchestratorID:petios-admin SessionID:b40e4de0 …}
```

The fourth, `TestOneOrchestratorMovingConversationsKeepsItsOwnLatestSession`, pins the case the guard must *not* catch: one orchestrator legitimately moving between conversations when a compaction forks the transcript.

`go vet` clean, `go test ./...` green in `erun-ui` (11.6s) on this branch cut from current `main`.

## Not a UI change

No surface is added or altered, so #1345's visual-craft bar and the UX checklist do not apply. The observable behaviour is which conversation a restart resumes.
