### PR TITLE
Decide the no-ask guard on what the turn said, not on the guard's own echo

### DIFF
--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -747,12 +747,21 @@ const orchestratorNoAskStopGuardReason = "Your closing message hands the operato
 // nudged turn (stop_hook_active) is let go so a session is corrected once rather
 // than looped. Like the activity reports it is bare shell, so it keeps working
 // when erun is not on PATH.
+//
+// It reads the turn's last ASSISTANT entry, never the raw tail of the
+// transcript. A firing is itself recorded in the transcript, and the record
+// carries this command — every trigger phrase included — so a window of raw
+// lines matches the guard's own echo from then on and the session can never
+// end again. It is also what let an operator's own question ("would you like
+// me to…") refuse the reply that answered it. Only what the turn said can
+// decide whether the turn handed back a decision.
 func orchestratorNoAskStopGuardCommand() string {
 	return orchestratorNoAskGuardMarker + `; input=$(cat); ` +
 		`printf '%s' "$input" | grep -q '"stop_hook_active"[[:space:]]*:[[:space:]]*true' && exit 0; ` +
 		`transcript=$(printf '%s' "$input" | sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | sed 's/\\\\/\//g'); ` +
 		`[ -f "$transcript" ] || exit 0; ` +
-		`tail -n 5 "$transcript" | grep -qiE 'say the word|let me know if|let me know whether|shall i |do you want me to|would you like me to|next action is yours|if you.d like me to|your call' || exit 0; ` +
+		`said=$(tail -n 40 "$transcript" | grep -E '"type"[[:space:]]*:[[:space:]]*"assistant"' | tail -n 1); ` +
+		`printf '%s' "$said" | grep -qiE 'say the word|let me know if|let me know whether|shall i |do you want me to|would you like me to|next action is yours|if you.d like me to|your call' || exit 0; ` +
 		`printf '%s' '` + orchestratorNoAskStopGuardReason + `' >&2; exit 2`
 }
 

--- a/erun-ui/orchestrator_noask_guard_test.go
+++ b/erun-ui/orchestrator_noask_guard_test.go
@@ -42,6 +42,33 @@ func writeGuardTranscript(t *testing.T, dir, name, text string) string {
 	return path
 }
 
+// writeGuardTranscriptEntries writes the transcript verbatim, so a test can
+// stage what Claude Code actually records around a turn — the hook's own
+// firing, the operator's prompt — and not just the turn's own message.
+func writeGuardTranscriptEntries(t *testing.T, dir, name string, entries []map[string]any) string {
+	t.Helper()
+	var encoded []byte
+	for _, entry := range entries {
+		line, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("encode transcript entry: %v", err)
+		}
+		encoded = append(append(encoded, line...), '\n')
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+func assistantTranscriptEntry(text string) map[string]any {
+	return map[string]any{
+		"type":    "assistant",
+		"message": map[string]any{"content": []any{map[string]any{"text": text}}},
+	}
+}
+
 func guardHookInput(t *testing.T, transcript string, active bool) string {
 	t.Helper()
 	encoded, err := json.Marshal(map[string]any{"transcript_path": transcript, "stop_hook_active": active})
@@ -61,6 +88,18 @@ func TestOrchestratorNoAskStopGuardDecidesOnTheTurnsLastWords(t *testing.T) {
 	dir := t.TempDir()
 	gate := writeGuardTranscript(t, dir, "gate.jsonl", "Filed it. Say the word and I will open the PR.")
 	clean := writeGuardTranscript(t, dir, "clean.jsonl", "Filed it and opened the PR. Both are verified.")
+	// A firing is recorded in the transcript, and the record carries this
+	// command — every trigger phrase with it. Read as raw lines, the guard
+	// matches its own echo from then on and the session can never end.
+	echoed := writeGuardTranscriptEntries(t, dir, "echoed.jsonl", []map[string]any{
+		assistantTranscriptEntry("Filed it and opened the PR. Both are verified."),
+		{"type": "system", "content": "Stop hook feedback: " + orchestratorNoAskStopGuardCommand()},
+	})
+	// The operator asking a question is not the turn handing one back.
+	asked := writeGuardTranscriptEntries(t, dir, "asked.jsonl", []map[string]any{
+		{"type": "user", "message": map[string]any{"content": "would you like me to file it?"}},
+		assistantTranscriptEntry("Filed it and opened the PR. Both are verified."),
+	})
 
 	cases := []struct {
 		name  string
@@ -69,6 +108,8 @@ func TestOrchestratorNoAskStopGuardDecidesOnTheTurnsLastWords(t *testing.T) {
 	}{
 		{"a turn ending on a consent gate is refused", guardHookInput(t, gate, false), 2},
 		{"a turn that decided is let go", guardHookInput(t, clean, false), 0},
+		{"the guard's own recorded firing is not the turn's last words", guardHookInput(t, echoed, false), 0},
+		{"the operator's own question is not the turn's last words", guardHookInput(t, asked, false), 0},
 		// Corrected once, never looped.
 		{"an already nudged turn is not refused again", guardHookInput(t, gate, true), 0},
 		// Fail-open: wedging a session costs more than the stalls this prevents.


### PR DESCRIPTION
## Summary

Closes #1344.
Closes #1331 — the same defect, filed twice two hours apart.

The orchestrator Stop guard (`orchestratorNoAskStopGuardCommand`) read
`tail -n 5 "$transcript"`. A firing is itself recorded in the transcript, and
the record carries the hook's **command** — which is where the trigger phrases
live (`say the word|let me know if|…`). So from the first firing onward the
window always matched, and the guard refused every stop that followed, whatever
the turn actually said.

The window is now the turn's last **assistant** entry:

```sh
said=$(tail -n 40 "$transcript" | grep -E '"type"[[:space:]]*:[[:space:]]*"assistant"' | tail -n 1)
printf '%s' "$said" | grep -qiE '…' || exit 0
```

That also removes a second false positive the raw window had: an operator's own
question ("would you like me to file it?") refusing the reply that answered it.
Only what the turn said can decide whether the turn handed back a decision.

Everything else is unchanged — the `stop_hook_active` let-go, every
fail-open path, the marker-based block replacement, and the bare-shell
constraint (no `jq`, works in Git Bash).

## The wedge this fixes, observed

Orchestrator `erun-admin` stopped answering the operator for about an hour
after six nudges. Its own last message, at 19:53:41, had already diagnosed it:

> Task complete and verified — #1353 and #1354 filed and read back, nothing of
> mine in flight. The block is #1344 self-matching, not my wording. Stopping.

Its transcript tail confirms it — of the last five entries, the one that matches
the guard's pattern is a `system` entry carrying the guard's own command:

```
mode             | phrase False | marker False
permission-mode  | phrase False | marker False
assistant        | phrase False | marker False   <- the turn's actual words
system           | phrase True  | marker True    <- the guard's own echo
system           | phrase False | marker False
```

The assistant's closing message names no gate. The guard was firing purely on
its own reflection.

## Validation

- `erun-ui`: `go build ./... && go vet ./... && go test ./...` green;
  `golangci-lint run ./...` → 0 issues.
- New regression cases in `orchestrator_noask_guard_test.go`, which run the
  command erun actually installs through `sh`:
  - `the guard's own recorded firing is not the turn's last words` — an
    assistant entry that names no gate, followed by the `system` entry carrying
    this command.
  - `the operator's own question is not the turn's last words` — a `user` entry
    asking one, followed by a clean assistant entry.
- **Mutation-verified** (both cases are new, so stashing would not compile the
  point): restoring `tail -n 5 "$transcript"` fails both with
  `guard exited 2, want 0`, and the existing cases stay green either way.
- No Playwright: a Stop hook has no React surface. The Go test drives the real
  shell command end to end, which is the only thing that can prove the exit
  code.
- No `erun-docs` change: the guard is internal orchestrator behaviour, not a
  documented surface.

## UX Impact Review Checklist

1. **Affected paths.** No user-triggered code path in the app — this is the
   Stop hook erun writes into the orchestrator working directory's settings.
   The operator-visible consequence is an orchestrator pane that can finish a
   turn again.
2. **User-visible sequence.** A turn that decided ends. A turn that hands back
   a decision is still nudged once, and the nudge is still the same text.
3. **State-without-affordance.** None; no app state changes.
4. **Visibility of system status.** Unchanged — the busy/idle report beside it
   in the same Stop block is untouched, so the sidebar still stops spinning.
5. **Success/failure feedback.** Unchanged.
6. **Consistency.** The guard keeps every fail-open rule it had.
7. **Heuristics.** Error prevention: the guard now cannot manufacture the
   failure it exists to prevent.
8. **Playwright.** Not applicable, as above.

## Rollout

The hook is rewritten into the orchestrator settings at desktop launch, so the
fix reaches a wedged session on the next restart of the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)