### PR TITLE
Say why a platform write was refused, not how it failed

### DIFF
--- a/erun-ui/tenant_platform_error.go
+++ b/erun-ui/tenant_platform_error.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// A platform refusal reaches the operator beside the control they just used,
+// so it has to read as a reason they can act on rather than as the exchange
+// that produced it. The client already distinguishes the refusals that mean
+// something distinct, so the mapping is on those; anything else keeps its
+// original text, which is better than a sentence that guesses wrong.
+//
+// The wire form is not discarded, only moved: it is logged, where a diagnosis
+// needs it, instead of shown, where it only tells the operator that software
+// was involved.
+
+// platformAction names the attempt in the sentence the operator reads. It is
+// a verb phrase completing "You do not have permission to ...".
+type platformAction string
+
+const (
+	actionCreateReview  platformAction = "open a review"
+	actionCloseReview   platformAction = "close this review"
+	actionAdvanceQueue  platformAction = "advance the merge queue"
+	actionCommentReview platformAction = "comment on this review"
+)
+
+// operatorPlatformError turns a platform failure into what the operator needs
+// to know. Anything unrecognised is returned unchanged.
+func operatorPlatformError(action platformAction, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var sentence string
+	switch {
+	case errors.Is(err, eruncommon.ErrPlatformForbidden):
+		sentence = fmt.Sprintf("You do not have permission to %s.", action)
+	case errors.Is(err, eruncommon.ErrPlatformUnauthorized):
+		sentence = "Your sign-in is no longer valid for this tenant. Sign in again and retry."
+	case errors.Is(err, eruncommon.ErrPlatformNotFound):
+		sentence = "That review no longer exists. Refresh to see the current list."
+	case errors.Is(err, eruncommon.ErrPlatformConflict):
+		// A conflict is the one refusal that is usually transient and usually
+		// somebody else's write, so it says what to do rather than what broke.
+		sentence = fmt.Sprintf("Someone else changed this while you were working, so erun did not %s. Refresh and try again.", action)
+	case errors.Is(err, eruncommon.ErrPlatformNotImplemented):
+		sentence = fmt.Sprintf("This control plane cannot %s.", action)
+	default:
+		return err
+	}
+
+	log.Printf("erun-app: %s refused: %v", action, err)
+	return errors.New(sentence)
+}

--- a/erun-ui/tenant_platform_error_test.go
+++ b/erun-ui/tenant_platform_error_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// A refusal is shown beside the control the operator just used, so it must
+// read as a reason rather than as the exchange that produced it.
+func TestOperatorPlatformErrorNamesTheReasonNotTheWire(t *testing.T) {
+	wire := fmt.Errorf("platform api PATCH /v1/reviews/r1/status: http 409: conflict: %w", eruncommon.ErrPlatformConflict)
+
+	got := operatorPlatformError(actionAdvanceQueue, wire)
+	if got == nil {
+		t.Fatal("expected an error")
+	}
+	message := got.Error()
+	for _, leak := range []string{"http 409", "/v1/reviews", "PATCH", "platform api"} {
+		if strings.Contains(message, leak) {
+			t.Errorf("operator message leaks the wire form %q: %s", leak, message)
+		}
+	}
+	if !strings.Contains(message, "advance the merge queue") {
+		t.Errorf("message should name the attempt: %s", message)
+	}
+}
+
+func TestOperatorPlatformErrorMapsEachDistinctRefusal(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		sentinel error
+		expect   string
+	}{
+		{"forbidden", eruncommon.ErrPlatformForbidden, "do not have permission"},
+		{"unauthorized", eruncommon.ErrPlatformUnauthorized, "Sign in again"},
+		{"not found", eruncommon.ErrPlatformNotFound, "no longer exists"},
+		{"conflict", eruncommon.ErrPlatformConflict, "Refresh and try again"},
+		{"not implemented", eruncommon.ErrPlatformNotImplemented, "cannot"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := operatorPlatformError(actionCloseReview, fmt.Errorf("wrapped: %w", tc.sentinel))
+			if got == nil || !strings.Contains(got.Error(), tc.expect) {
+				t.Fatalf("expected a message containing %q, got %v", tc.expect, got)
+			}
+		})
+	}
+}
+
+// A failure erun cannot classify keeps its own text: a sentence that guesses
+// wrong is worse than one that is merely technical.
+func TestOperatorPlatformErrorPassesThroughWhatItCannotClassify(t *testing.T) {
+	original := errors.New("dial tcp 127.0.0.1:1: connect: connection refused")
+	if got := operatorPlatformError(actionCreateReview, original); got != original {
+		t.Fatalf("expected the original error unchanged, got %v", got)
+	}
+	if operatorPlatformError(actionCreateReview, nil) != nil {
+		t.Fatal("nil must stay nil")
+	}
+}

--- a/erun-ui/tenant_review_detail.go
+++ b/erun-ui/tenant_review_detail.go
@@ -164,7 +164,7 @@ func (a *App) CreateReviewReply(input uiCreateReviewReplyInput) (uiReviewComment
 		ParentCommentID: parentCommentID,
 	})
 	if err != nil {
-		return uiReviewComment{}, err
+		return uiReviewComment{}, operatorPlatformError(actionCommentReview, err)
 	}
 	return tenantDashboardComment(comment), nil
 }

--- a/erun-ui/tenant_review_write.go
+++ b/erun-ui/tenant_review_write.go
@@ -58,7 +58,7 @@ func (a *App) CreateReview(input uiCreateReviewInput) (uiTenantDashboardReview, 
 		Name: name, TargetBranch: targetBranch, SourceBranch: sourceBranch,
 	})
 	if err != nil {
-		return uiTenantDashboardReview{}, err
+		return uiTenantDashboardReview{}, operatorPlatformError(actionCreateReview, err)
 	}
 	return tenantDashboardReview(review), nil
 }
@@ -96,7 +96,7 @@ func (a *App) CloseReview(input uiCloseReviewInput) (uiTenantDashboardReview, er
 
 	review, err := client.UpdateReviewStatus(requestCtx, reviewID, eruncommon.PlatformUpdateReviewStatusParams{Status: "CLOSED"})
 	if err != nil {
-		return uiTenantDashboardReview{}, err
+		return uiTenantDashboardReview{}, operatorPlatformError(actionCloseReview, err)
 	}
 	return tenantDashboardReview(review), nil
 }
@@ -132,7 +132,7 @@ func (a *App) AdvanceMergeQueue(input uiAdvanceMergeQueueInput) (uiTenantDashboa
 
 	review, err := client.AdvanceMergeQueue(requestCtx, targetBranch)
 	if err != nil {
-		return uiTenantDashboardReview{}, err
+		return uiTenantDashboardReview{}, operatorPlatformError(actionAdvanceQueue, err)
 	}
 	return tenantDashboardReview(review), nil
 }
@@ -195,7 +195,7 @@ func (a *App) CreateReviewComment(input uiCreateReviewCommentInput) (uiReviewCom
 		Body:     body,
 	})
 	if err != nil {
-		return uiReviewComment{}, err
+		return uiReviewComment{}, operatorPlatformError(actionCommentReview, err)
 	}
 	return tenantDashboardComment(comment), nil
 }


### PR DESCRIPTION
Fixes #1364 for the review write surface.

A refusal is shown beside the control the operator just used, so it has to read as a reason they can act on. Today a conflict renders as:

```
call platform api PATCH /v1/reviews/review-1/status: http 409: conflict
```

`PlatformClient` already wraps the refusals that mean something distinct (`ErrPlatformForbidden`, `ErrPlatformUnauthorized`, `ErrPlatformNotFound`, `ErrPlatformConflict`, `ErrPlatformNotImplemented`) with `%w`, so `errors.Is` is all the mapping needs. Each becomes a sentence naming the attempt; a conflict says what to do about it, since it is usually transient and usually somebody else's write.

The wire form is not discarded, only moved — it is logged, where a diagnosis needs it, instead of shown, where it only tells the operator that software was involved. Anything unclassified keeps its own text: a sentence that guesses wrong is worse than one that is merely technical.

Applied at all five review write call sites: create, close, advance queue, comment, reply.

**Why now:** #1359 added three of those five paths and merged before review. Write failures are the ones an operator hits while trying to act, and the raw path had no coverage at all — the only failure its specs exercise is an already-humanised message from the exec layer, which is why the surface pass did not catch it.

Three tests: that the mapped message leaks none of `http 409` / `/v1/reviews` / `PATCH` / `platform api` while still naming the attempt, that each sentinel maps, and that an unclassifiable error and `nil` pass through untouched.

`go test ./...` green in `erun-ui` (32.8s).
