### PR TITLE
Give the desktop the three init options it was missing

### DIFF
--- a/erun-ui/environment_config.go
+++ b/erun-ui/environment_config.go
@@ -286,6 +286,8 @@ func (a *App) environmentConfigToUI(tenant string, config eruncommon.EnvConfig, 
 		CloudAliasSlots:              environmentCloudAliasSlots(a.deps.store, config),
 		RuntimeVersion:               strings.TrimSpace(config.RuntimeVersion),
 		RuntimeChart:                 strings.TrimSpace(config.RuntimeChart),
+		RuntimeRegistry:              strings.TrimSpace(config.RuntimeRegistry),
+		ImagePullSecrets:             trimmedNonEmpty(config.ImagePullSecrets),
 		RuntimePod:                   runtimePodConfigToUI(config.RuntimePod),
 		SSHD: uiSSHDConfig{
 			Enabled:                    config.SSHD.Enabled,
@@ -594,6 +596,11 @@ func environmentConfigFromUI(config uiEnvironmentConfig, existing eruncommon.Env
 	// four deploy coordinates; a redeploy installs it, so saving it is enough --
 	// nothing derives it.
 	existing.RuntimeChart = strings.TrimSpace(config.RuntimeChart)
+	// Both are pull-time coordinates the operator states once: the registry
+	// erun's own chart comes from, and the secrets the pod pulls its image
+	// with. An empty list clears the secrets rather than keeping a stale one.
+	existing.RuntimeRegistry = strings.TrimSpace(config.RuntimeRegistry)
+	existing.ImagePullSecrets = trimmedNonEmpty(config.ImagePullSecrets)
 	existing.PlatformAccount = config.PlatformAccount
 	existing.MountSource = config.MountSource
 	existing.RepoURL = strings.TrimSpace(config.RepoURL)
@@ -608,10 +615,16 @@ func environmentConfigFromUI(config uiEnvironmentConfig, existing eruncommon.Env
 }
 
 func trimmedComponentNames(names []string) []string {
-	out := make([]string, 0, len(names))
-	for _, raw := range names {
-		if name := strings.TrimSpace(raw); name != "" {
-			out = append(out, name)
+	return trimmedNonEmpty(names)
+}
+
+// trimmedNonEmpty drops blanks so an omitempty field clears rather than
+// persisting a list of empty strings the operator never entered.
+func trimmedNonEmpty(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, raw := range values {
+		if value := strings.TrimSpace(raw); value != "" {
+			out = append(out, value)
 		}
 	}
 	if len(out) == 0 {

--- a/erun-ui/environment_config_pull_test.go
+++ b/erun-ui/environment_config_pull_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// Both fields are pull-time coordinates the Manage dialog now edits, so an
+// edit has to survive the round trip rather than silently reverting on save.
+func TestPullCoordinatesRoundTripThroughTheEditor(t *testing.T) {
+	existing := eruncommon.EnvConfig{
+		RuntimeRegistry:  "old.example.com",
+		ImagePullSecrets: []string{"old-secret"},
+	}
+
+	saved := environmentConfigFromUI(uiEnvironmentConfig{
+		RuntimeRegistry:  "  ghcr.io/sophium  ",
+		ImagePullSecrets: []string{"ecr-pull", "", "  ghcr-pull  "},
+	}, existing)
+
+	if saved.RuntimeRegistry != "ghcr.io/sophium" {
+		t.Fatalf("runtime registry: got %q", saved.RuntimeRegistry)
+	}
+	if len(saved.ImagePullSecrets) != 2 ||
+		saved.ImagePullSecrets[0] != "ecr-pull" ||
+		saved.ImagePullSecrets[1] != "ghcr-pull" {
+		t.Fatalf("pull secrets: got %v", saved.ImagePullSecrets)
+	}
+}
+
+// Clearing the field must clear the config, not leave the previous value in
+// place -- a stale pull secret is how an env keeps failing after the operator
+// believes they fixed it.
+func TestClearingPullCoordinatesClearsTheConfig(t *testing.T) {
+	existing := eruncommon.EnvConfig{
+		RuntimeRegistry:  "old.example.com",
+		ImagePullSecrets: []string{"old-secret"},
+	}
+
+	saved := environmentConfigFromUI(uiEnvironmentConfig{}, existing)
+
+	if saved.RuntimeRegistry != "" {
+		t.Fatalf("expected the runtime registry cleared, got %q", saved.RuntimeRegistry)
+	}
+	if saved.ImagePullSecrets != nil {
+		t.Fatalf("expected the pull secrets cleared, got %v", saved.ImagePullSecrets)
+	}
+}

--- a/erun-ui/frontend/src/app/environmentDialogState.ts
+++ b/erun-ui/frontend/src/app/environmentDialogState.ts
@@ -52,7 +52,9 @@ export function missingRequiredFieldReason(dialog: EnvironmentDialogState): stri
   }
   // The in-cluster registry needs no host string — its addresses resolve from the
   // kube-context — so a container registry is only required when not using it.
-  if (!dialog.useClusterRegistry && !values.containerRegistry) {
+  // Neither the in-cluster nor the hosted registry needs a host string: the
+  // first resolves from the kube-context, the second from the tenant.
+  if (!dialog.useClusterRegistry && !dialog.useErunRegistry && !values.containerRegistry) {
     return 'Select a container registry.';
   }
   return null;

--- a/erun-ui/frontend/src/app/environmentDialogThunks.ts
+++ b/erun-ui/frontend/src/app/environmentDialogThunks.ts
@@ -53,6 +53,7 @@ export const openInitializeDialog = (): AppThunk => (dispatch, getState) => {
       containerRegistry: containerRegistryDefault,
       clusterRegistry: null,
       useClusterRegistry: false,
+      useErunRegistry: false,
       envType: 'remote-agent',
       localRepoPath: '',
       noGit: false,
@@ -208,13 +209,17 @@ function environmentDialogInitFields(
   const isLocalAgent = dialog.envType === 'local-agent';
   // When the in-cluster registry is chosen, seed a resolvable cluster: entry and
   // omit the static container-registry string (the two are mutually exclusive).
-  const useClusterRegistry = dialog.useClusterRegistry && !!dialog.clusterRegistry?.deployed;
+  const useErunRegistry = dialog.useErunRegistry;
+  const useClusterRegistry =
+    !useErunRegistry && dialog.useClusterRegistry && !!dialog.clusterRegistry?.deployed;
+  const resolvedRegistry = useErunRegistry || useClusterRegistry;
   return {
     runtimeCpu: runtimePod.cpu,
     runtimeMemory: runtimePod.memory,
     kubernetesContext: values.kubernetesContext,
-    containerRegistry: useClusterRegistry ? '' : values.containerRegistry,
+    containerRegistry: resolvedRegistry ? '' : values.containerRegistry,
     clusterRegistry: useClusterRegistry,
+    erunRegistry: useErunRegistry,
     type: dialog.envType,
     localRepoPath: isLocalAgent ? values.localRepoPath : undefined,
     setDefaultTenant: dialog.setDefaultTenant,

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -86,6 +86,9 @@ export interface EnvironmentDialogState {
   // registry entry instead of the containerRegistry string.
   clusterRegistry: UIClusterRegistryStatus | null;
   useClusterRegistry: boolean;
+  // useErunRegistry selects erun's hosted registry (registry.erunpaas.com/<tenant>),
+  // authenticated by the tenant's own API token. Exclusive with the other two.
+  useErunRegistry: boolean;
   envType: EnvironmentType;
   localRepoPath: string;
   noGit: boolean;
@@ -371,6 +374,7 @@ export const defaultEnvironmentDialog = (): EnvironmentDialogState => ({
   containerRegistry: '',
   clusterRegistry: null,
   useClusterRegistry: false,
+  useErunRegistry: false,
   envType: 'remote-agent',
   localRepoPath: '',
   noGit: false,

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.RegistryField.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.RegistryField.tsx
@@ -1,0 +1,126 @@
+import { Checkbox, EditableComboField, Label, uniqueSuggestions } from 'erun-kit';
+import * as React from 'react';
+
+import { updateEnvironmentDialog } from '@/app/environmentDialogThunks';
+import { useAppDispatch } from '@/app/hooks';
+import type { AppState } from '@/app/state';
+import { loadSavedPastContainerRegistries } from '@/app/storage';
+
+type EnvironmentDialog = AppState['environmentDialog'];
+
+// ContainerRegistryField offers the in-cluster erun-registry (resolved from the
+// selected Kubernetes context) as the default when one is detected, and falls
+// back to a free-text registry otherwise. There is no hardcoded default host —
+// the deployed cluster registry is the default, not a placeholder like erunpaas.
+export function ContainerRegistryField({
+  dialog,
+}: {
+  dialog: EnvironmentDialog;
+}): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const containerRegistrySuggestions = React.useMemo(
+    () => uniqueSuggestions([dialog.containerRegistry, ...loadSavedPastContainerRegistries()]),
+    [dialog.containerRegistry],
+  );
+  const cluster = dialog.clusterRegistry;
+  const clusterAvailable = cluster?.deployed === true;
+  const useCluster = clusterAvailable && dialog.useClusterRegistry;
+  const clusterToggle = clusterAvailable ? (
+    <label className="flex items-center gap-2 text-sm font-normal">
+      <Checkbox
+        id="environment-use-cluster-registry"
+        checked={dialog.useClusterRegistry}
+        disabled={dialog.busy}
+        onCheckedChange={(value) => {
+          dispatch(updateEnvironmentDialog({ useClusterRegistry: value === true }));
+        }}
+      />
+      Use in-cluster registry ({cluster.service ?? 'erun-registry'})
+    </label>
+  ) : null;
+
+  const hostedToggle = (
+    <label
+      htmlFor="environment-use-erun-registry"
+      className="flex items-center gap-2 text-sm font-normal"
+    >
+      <Checkbox
+        id="environment-use-erun-registry"
+        checked={dialog.useErunRegistry}
+        disabled={dialog.busy}
+        onCheckedChange={(value) => {
+          // The three choices are mutually exclusive, so selecting this one
+          // releases the cluster toggle rather than leaving both set and
+          // letting `erun init` reject the pair after the operator commits.
+          dispatch(
+            updateEnvironmentDialog({
+              useErunRegistry: value === true,
+              ...(value === true ? { useClusterRegistry: false } : {}),
+            }),
+          );
+        }}
+      />
+      Use erun&apos;s hosted registry
+    </label>
+  );
+
+  if (dialog.useErunRegistry) {
+    return (
+      <div className="grid gap-2">
+        <Label htmlFor="environment-use-erun-registry">Container registry</Label>
+        {hostedToggle}
+        <p className="text-[12px] leading-[1.4] text-muted-foreground">
+          Images push to and pull from erun&apos;s hosted registry under this tenant, authenticated
+          by the tenant&apos;s own API token — no registry address or credentials to manage.
+        </p>
+      </div>
+    );
+  }
+
+  if (useCluster) {
+    return (
+      <div className="grid gap-2">
+        <Label htmlFor="environment-use-cluster-registry">Container registry</Label>
+        {clusterToggle}
+        {hostedToggle}
+        <p className="text-[12px] leading-[1.4] text-muted-foreground">
+          Resolved from {cluster.service}.{cluster.namespace}:{cluster.port} via this
+          environment&apos;s Kubernetes context — pushed and pulled in-cluster, no host address
+          needed.
+        </p>
+      </div>
+    );
+  }
+
+  // A fresh install has no cluster registry detected and no past values to
+  // suggest, so the field would otherwise offer nothing to go on — no
+  // placeholder, no helper, no suggestions (Nielsen #6, recognition over
+  // recall). Name the format with an example and the route that detects a
+  // registry automatically instead of typing one.
+  const showRegistryHelp = !clusterAvailable && containerRegistrySuggestions.length === 0;
+  return (
+    <div className="grid gap-2">
+      <EditableComboField
+        id="environment-container-registry"
+        label="Container registry"
+        value={dialog.containerRegistry}
+        suggestions={containerRegistrySuggestions}
+        required
+        disabled={dialog.busy}
+        onValueChange={(containerRegistry) => {
+          dispatch(updateEnvironmentDialog({ containerRegistry }));
+        }}
+      />
+      {clusterToggle}
+      {hostedToggle}
+      {showRegistryHelp && (
+        <p className="text-[12px] leading-[1.4] text-muted-foreground">
+          Where images push to and pull from, e.g. ghcr.io/your-org or docker.io/your-namespace. If
+          the selected Kubernetes context has an in-cluster erun-registry, ERun detects it
+          automatically and offers it above instead — provision one via Settings → Cloud aliases →
+          Add AWS account → Cloud contexts → Init.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.tsx
@@ -27,13 +27,10 @@ import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { showTerminalError } from '@/app/notificationThunks';
 import { runtimeResourceLimitMessage } from '@/app/runtimeResources';
 import type { AppState } from '@/app/state';
-import {
-  loadSavedPastContainerRegistries,
-  loadSavedPastEnvironments,
-  loadSavedPastTenants,
-} from '@/app/storage';
+import { loadSavedPastEnvironments, loadSavedPastTenants } from '@/app/storage';
 import { useController } from '@/app/useController';
 import { findVersionSuggestion, selectedVersionSourceText } from '@/app/versionSuggestions';
+import { ContainerRegistryField } from '@/components/app/EnvironmentDialogView.RegistryField';
 
 import { EnvironmentTypeSelect, LocalRepoPathField } from './EnvironmentTypeFields';
 import { KubernetesContextSelect } from './KubernetesContextSelect';
@@ -236,79 +233,6 @@ function EnvironmentCreateFields({ dialog }: { dialog: EnvironmentDialog }): Rea
       <ContainerRegistryField dialog={dialog} />
       <EnvironmentCreateChecks dialog={dialog} />
     </>
-  );
-}
-
-// ContainerRegistryField offers the in-cluster erun-registry (resolved from the
-// selected Kubernetes context) as the default when one is detected, and falls
-// back to a free-text registry otherwise. There is no hardcoded default host —
-// the deployed cluster registry is the default, not a placeholder like erunpaas.
-function ContainerRegistryField({ dialog }: { dialog: EnvironmentDialog }): React.ReactElement {
-  const dispatch = useAppDispatch();
-  const containerRegistrySuggestions = React.useMemo(
-    () => uniqueSuggestions([dialog.containerRegistry, ...loadSavedPastContainerRegistries()]),
-    [dialog.containerRegistry],
-  );
-  const cluster = dialog.clusterRegistry;
-  const clusterAvailable = cluster?.deployed === true;
-  const useCluster = clusterAvailable && dialog.useClusterRegistry;
-  const clusterToggle = clusterAvailable ? (
-    <label className="flex items-center gap-2 text-sm font-normal">
-      <Checkbox
-        id="environment-use-cluster-registry"
-        checked={dialog.useClusterRegistry}
-        disabled={dialog.busy}
-        onCheckedChange={(value) => {
-          dispatch(updateEnvironmentDialog({ useClusterRegistry: value === true }));
-        }}
-      />
-      Use in-cluster registry ({cluster.service ?? 'erun-registry'})
-    </label>
-  ) : null;
-
-  if (useCluster) {
-    return (
-      <div className="grid gap-2">
-        <Label htmlFor="environment-use-cluster-registry">Container registry</Label>
-        {clusterToggle}
-        <p className="text-[12px] leading-[1.4] text-muted-foreground">
-          Resolved from {cluster.service}.{cluster.namespace}:{cluster.port} via this
-          environment&apos;s Kubernetes context — pushed and pulled in-cluster, no host address
-          needed.
-        </p>
-      </div>
-    );
-  }
-
-  // A fresh install has no cluster registry detected and no past values to
-  // suggest, so the field would otherwise offer nothing to go on — no
-  // placeholder, no helper, no suggestions (Nielsen #6, recognition over
-  // recall). Name the format with an example and the route that detects a
-  // registry automatically instead of typing one.
-  const showRegistryHelp = !clusterAvailable && containerRegistrySuggestions.length === 0;
-  return (
-    <div className="grid gap-2">
-      <EditableComboField
-        id="environment-container-registry"
-        label="Container registry"
-        value={dialog.containerRegistry}
-        suggestions={containerRegistrySuggestions}
-        required
-        disabled={dialog.busy}
-        onValueChange={(containerRegistry) => {
-          dispatch(updateEnvironmentDialog({ containerRegistry }));
-        }}
-      />
-      {clusterToggle}
-      {showRegistryHelp && (
-        <p className="text-[12px] leading-[1.4] text-muted-foreground">
-          Where images push to and pull from, e.g. ghcr.io/your-org or docker.io/your-namespace. If
-          the selected Kubernetes context has an in-cluster erun-registry, ERun detects it
-          automatically and offers it above instead — provision one via Settings → Cloud aliases →
-          Add AWS account → Cloud contexts → Init.
-        </p>
-      )}
-    </div>
   );
 }
 

--- a/erun-ui/frontend/src/components/app/ImagePullSecretsField.tsx
+++ b/erun-ui/frontend/src/components/app/ImagePullSecretsField.tsx
@@ -1,0 +1,80 @@
+import { Button, Input, Label } from 'erun-kit';
+import { Plus, Trash2 } from 'lucide-react';
+import * as React from 'react';
+
+// ImagePullSecretsField edits the Kubernetes secrets the runtime pod pulls its
+// image with. It matters most when the environment carries a private runtime
+// image: without a secret the pod never starts, and the empty state says so
+// rather than leaving the operator to infer why a pod they created will not
+// come up.
+export function ImagePullSecretsField({
+  secrets,
+  disabled,
+  onChange,
+}: {
+  secrets: string[];
+  disabled?: boolean;
+  onChange: (next: string[]) => void;
+}): React.ReactElement {
+  return (
+    <div className="grid gap-2">
+      <div className="flex items-center justify-between">
+        <Label>Image pull secrets</Label>
+        <Button
+          id="environment-config-add-pull-secret"
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          onClick={() => {
+            onChange([...secrets, '']);
+          }}
+          aria-label="Add image pull secret"
+        >
+          <Plus aria-hidden="true" />
+          Add secret
+        </Button>
+      </div>
+      {secrets.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          None. A runtime image in a private registry needs a{' '}
+          <code className="font-mono text-[11px]">dockerconfigjson</code> secret here, or the pod
+          cannot pull it.
+        </p>
+      ) : (
+        <div className="grid gap-2">
+          {secrets.map((secret, index) => (
+            <div key={index} className="flex items-center gap-2">
+              <Input
+                id={`environment-config-pull-secret-${String(index)}`}
+                className="min-w-0 flex-1"
+                value={secret}
+                type="text"
+                autoComplete="off"
+                spellCheck={false}
+                disabled={disabled}
+                placeholder="ecr-pull"
+                aria-label={`Image pull secret ${String(index + 1)}`}
+                onChange={(event) => {
+                  onChange(secrets.map((row, idx) => (idx === index ? event.target.value : row)));
+                }}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                disabled={disabled}
+                aria-label={`Remove image pull secret ${String(index + 1)}`}
+                onClick={() => {
+                  onChange(secrets.filter((_, idx) => idx !== index));
+                }}
+              >
+                <Trash2 aria-hidden="true" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/erun-ui/frontend/src/components/app/ManageDialogGeneralTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogGeneralTab.tsx
@@ -17,6 +17,7 @@ import { EnvironmentHealthSection } from '@/components/app/EnvironmentHealthSect
 import { cloudProviderTypeLabel } from '@/components/app/GlobalConfigDialog.helpers';
 import { LocalRepoPathInput } from '@/components/app/LocalRepoPathInput';
 import { ReadonlyField, StatusBadge } from '@/components/app/ManageDialog.fields';
+import { PullCoordinatesFields } from '@/components/app/ManageDialogPullCoordinates';
 import {
   EnvironmentTypeValues,
   type UICloudContextStatus,
@@ -42,6 +43,11 @@ export function GeneralTab(): React.ReactElement {
   // Fall back to the effective path so the field is never blank for an env
   // whose repo path is derived rather than explicitly set.
   const repoPathValue = config.localRepoPath?.trim() ? config.localRepoPath : config.repoPath;
+
+  // One statement of "the editor is not accepting input right now", so each
+  // field does not restate it.
+  const fieldsDisabled = dialog.busy || dialog.configLoading;
+
   return (
     <>
       {config.type === 'local-agent' ? (
@@ -54,7 +60,7 @@ export function GeneralTab(): React.ReactElement {
           label="Repository path"
           helper="Absolute path on this machine, mounted into the agent pod as the worktree. Applied on Save; takes effect on the next deploy."
           value={repoPathValue}
-          disabled={dialog.busy || dialog.configLoading}
+          disabled={fieldsDisabled}
           onChange={(localRepoPath) => {
             dispatch(updateManageConfig({ localRepoPath }));
           }}
@@ -75,16 +81,23 @@ export function GeneralTab(): React.ReactElement {
         entries={config.containerRegistries}
         inherited={config.containerRegistriesInherited}
         suggestions={containerRegistrySuggestions}
-        disabled={dialog.busy || dialog.configLoading}
+        disabled={fieldsDisabled}
         onChange={(containerRegistries) => {
           dispatch(updateManageConfig({ containerRegistries }));
+        }}
+      />
+      <PullCoordinatesFields
+        config={config}
+        disabled={fieldsDisabled}
+        onChange={(patch) => {
+          dispatch(updateManageConfig(patch));
         }}
       />
       <CloudAliasSlots config={config} disabled={dialog.busy} />
       <CloudContextField
         context={config.cloudContext}
         cloudProviderAlias={config.cloudProviderAlias}
-        disabled={dialog.busy || dialog.configLoading}
+        disabled={fieldsDisabled}
         loading={
           dialog.busyAction === 'cloud-context-power' &&
           dialog.busyTarget === config.cloudContext?.name
@@ -94,7 +107,7 @@ export function GeneralTab(): React.ReactElement {
       />
       <EnvironmentTypeField
         value={config.type}
-        disabled={dialog.busy || dialog.configLoading}
+        disabled={fieldsDisabled}
         onChange={(type) => {
           dispatch(updateManageConfig({ type }));
         }}

--- a/erun-ui/frontend/src/components/app/ManageDialogPullCoordinates.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogPullCoordinates.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+import { ImagePullSecretsField } from '@/components/app/ImagePullSecretsField';
+import { TextField } from '@/components/app/ManageDialog.fields';
+import type { UIEnvironmentConfig } from '@/types';
+
+// The two coordinates that decide whether the runtime pod can pull at all:
+// where erun's own chart comes from, and the secrets the image is pulled with.
+// Grouped so the General tab reads as sections rather than a flat field list.
+export function PullCoordinatesFields({
+  config,
+  disabled,
+  onChange,
+}: {
+  config: UIEnvironmentConfig;
+  disabled: boolean;
+  onChange: (patch: Partial<UIEnvironmentConfig>) => void;
+}): React.ReactElement {
+  return (
+    <>
+      <TextField
+        id="environment-config-runtimeregistry"
+        label="Runtime registry"
+        value={config.runtimeRegistry ?? ''}
+        disabled={disabled}
+        placeholder="ghcr.io/sophium"
+        helper="Where this environment resolves erun's own chart and platform images from. Set it when the registries above hold only this project's images."
+        onChange={(runtimeRegistry) => {
+          onChange({ runtimeRegistry });
+        }}
+      />
+      <ImagePullSecretsField
+        secrets={config.imagePullSecrets ?? []}
+        disabled={disabled}
+        onChange={(imagePullSecrets) => {
+          onChange({ imagePullSecrets });
+        }}
+      />
+    </>
+  );
+}

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -104,6 +104,9 @@ export interface UISelection {
   containerRegistry?: string;
   // Selects the in-cluster erun-registry instead of the containerRegistry string.
   clusterRegistry?: boolean;
+  // erunRegistry selects erun's hosted registry for the tenant. Mutually
+  // exclusive with both clusterRegistry and containerRegistry.
+  erunRegistry?: boolean;
   // Bare string to match the Wails binding, which widens the Go EnvironmentType
   // alias; use the EnvironmentType union for narrowed dropdown values.
   type?: string;
@@ -485,6 +488,13 @@ export interface UIEnvironmentConfig {
   // reference that may carry its own version. Empty means the chart published
   // with the deployed version -- right whenever chart and image ride one line.
   runtimeChart?: string;
+  // Where the environment resolves erun's own artifacts from -- the runtime
+  // chart and platform images -- as distinct from where this project's images
+  // are pushed.
+  runtimeRegistry?: string;
+  // The Kubernetes dockerconfigjson secrets the runtime pod pulls its image
+  // with. Without one, a private runtime image leaves the pod unable to start.
+  imagePullSecrets?: string[];
   runtimePod: UIRuntimePodConfig;
   sshd: UISSHDConfig;
   idle: {

--- a/erun-ui/playwright/pages/ManageDialog.ts
+++ b/erun-ui/playwright/pages/ManageDialog.ts
@@ -301,6 +301,24 @@ export class ManageDialog {
 
   // --- Container-registries editor (General tab) ---
 
+  addPullSecretButton(): Locator {
+    return this.locator().getByRole('button', { name: 'Add image pull secret' });
+  }
+
+  pullSecretInput(index: number): Locator {
+    return this.locator().getByRole('textbox', { name: `Image pull secret ${String(index + 1)}` });
+  }
+
+  removePullSecretButton(index: number): Locator {
+    return this.locator().getByRole('button', {
+      name: `Remove image pull secret ${String(index + 1)}`,
+    });
+  }
+
+  runtimeRegistryInput(): Locator {
+    return this.locator().getByLabel('Runtime registry');
+  }
+
   addRegistryButton(): Locator {
     return this.locator().getByRole('button', { name: 'Add registry' });
   }

--- a/erun-ui/playwright/tests/manage-pull-coordinates.spec.ts
+++ b/erun-ui/playwright/tests/manage-pull-coordinates.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ENV_ALPHA, SEED_TENANT } from '../fixtures/seedRoot.js';
+
+// The desktop resolved and passed a private --runtime-image but had no field
+// for the secret that image needs, so an environment created from the app went
+// ImagePullBackOff with no in-app repair. These cover the two coordinates that
+// decide whether the runtime pod can pull at all.
+
+test.describe('manage dialog pull coordinates', () => {
+  test('names why a pull secret is needed instead of showing an empty control', async ({ app }) => {
+    // No save — the seeded baseline stays untouched.
+    await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, SEED_ENV_ALPHA);
+    await app.manageDialog.waitForOpen();
+
+    // An empty state must read as an explanation, not as a disabled input.
+    await expect(
+      app.manageDialog.locator().getByText('A runtime image in a private registry needs a'),
+    ).toBeVisible();
+    await expect(app.manageDialog.pullSecretInput(0)).toHaveCount(0);
+    await expect(app.manageDialog.addPullSecretButton()).toBeEnabled();
+
+    await expect(app.manageDialog.runtimeRegistryInput()).toHaveValue('');
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+
+  test('saves both coordinates and reloads them', async ({ app, seededEnv }) => {
+    await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
+    await app.manageDialog.waitForOpen();
+
+    await app.manageDialog.runtimeRegistryInput().fill('ghcr.io/sophium');
+    await app.manageDialog.addPullSecretButton().click();
+    await app.manageDialog.pullSecretInput(0).fill('ecr-pull');
+    await app.manageDialog.addPullSecretButton().click();
+    await app.manageDialog.pullSecretInput(1).fill('ghcr-pull');
+
+    await app.manageDialog.save();
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+
+    await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
+    await app.manageDialog.waitForOpen();
+    await expect(app.manageDialog.runtimeRegistryInput()).toHaveValue('ghcr.io/sophium');
+    await expect(app.manageDialog.pullSecretInput(0)).toHaveValue('ecr-pull');
+    await expect(app.manageDialog.pullSecretInput(1)).toHaveValue('ghcr-pull');
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+
+  // The repair path the issue is about: a wrong secret is removed and the
+  // removal has to stick, or the environment keeps failing after the operator
+  // believes they fixed it.
+  test('removing a secret clears it rather than leaving a stale one', async ({
+    app,
+    seededEnv,
+  }) => {
+    await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
+    await app.manageDialog.waitForOpen();
+
+    await app.manageDialog.addPullSecretButton().click();
+    await app.manageDialog.pullSecretInput(0).fill('wrong-secret');
+    await app.manageDialog.save();
+
+    await app.manageDialog.removePullSecretButton(0).click();
+    await expect(app.manageDialog.pullSecretInput(0)).toHaveCount(0);
+    await app.manageDialog.save();
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+
+    await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
+    await app.manageDialog.waitForOpen();
+    await expect(app.manageDialog.pullSecretInput(0)).toHaveCount(0);
+    await expect(
+      app.manageDialog.locator().getByText('A runtime image in a private registry needs a'),
+    ).toBeVisible();
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+});

--- a/erun-ui/session.go
+++ b/erun-ui/session.go
@@ -433,9 +433,13 @@ func appendInitOptionalFlags(args []string, selection uiSelection) []string {
 		{"--runtime-memory", strings.TrimSpace(selection.RuntimeMemory)},
 		{"--kubernetes-context", strings.TrimSpace(selection.KubernetesContext)},
 	}
-	// The cluster registry and a static container registry are mutually exclusive
-	// (`erun init` rejects both); cluster wins when selected.
-	if !selection.ClusterRegistry {
+	// Where erun's own chart is pulled from is a separate coordinate from where
+	// the project's images go, so it is not part of the mutually exclusive set
+	// below.
+	pairs = append(pairs, struct{ flag, value string }{"--runtime-registry", strings.TrimSpace(selection.RuntimeRegistry)})
+	// The three registry choices are mutually exclusive (`erun init` rejects any
+	// pair); the explicit hosted and cluster selections win over a static string.
+	if !selection.ClusterRegistry && !selection.ErunRegistry {
 		pairs = append(pairs, struct{ flag, value string }{"--container-registry", strings.TrimSpace(selection.ContainerRegistry)})
 	}
 	for _, pair := range pairs {
@@ -443,8 +447,18 @@ func appendInitOptionalFlags(args []string, selection uiSelection) []string {
 			args = append(args, pair.flag, pair.value)
 		}
 	}
+	// Repeated rather than comma-joined: a secret name may legally contain no
+	// comma, but repeating is what the flag documents and never needs escaping.
+	for _, secret := range selection.ImagePullSecrets {
+		if name := strings.TrimSpace(secret); name != "" {
+			args = append(args, "--image-pull-secret", name)
+		}
+	}
 	if selection.ClusterRegistry {
 		args = append(args, "--cluster-registry")
+	}
+	if selection.ErunRegistry {
+		args = append(args, "--erun-registry")
 	}
 	return args
 }

--- a/erun-ui/session_init_flags_test.go
+++ b/erun-ui/session_init_flags_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func flagValue(args []string, flag string) []string {
+	var out []string
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag {
+			out = append(out, args[i+1])
+		}
+	}
+	return out
+}
+
+func hasFlag(args []string, flag string) bool {
+	for _, arg := range args {
+		if arg == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// The app resolves a private runtime image but could not name the secret that
+// image needs, so an env it created went ImagePullBackOff with no in-app repair.
+func TestInitFlagsCarryPullSecretsAndRuntimeRegistry(t *testing.T) {
+	args := appendInitOptionalFlags(nil, uiSelection{
+		RuntimeImage:     "registry.example.com/acme/devops",
+		RuntimeRegistry:  "ghcr.io/sophium",
+		ImagePullSecrets: []string{"ecr-pull", " ", "ghcr-pull"},
+	})
+
+	if got := flagValue(args, "--runtime-registry"); len(got) != 1 || got[0] != "ghcr.io/sophium" {
+		t.Fatalf("--runtime-registry: got %v", got)
+	}
+	secrets := flagValue(args, "--image-pull-secret")
+	if len(secrets) != 2 || secrets[0] != "ecr-pull" || secrets[1] != "ghcr-pull" {
+		t.Fatalf("blank secrets must be dropped and the rest repeated: got %v", secrets)
+	}
+}
+
+// `erun init` rejects any pair of the three registry choices, so the desktop
+// must never emit two.
+func TestInitFlagsKeepTheThreeRegistryChoicesExclusive(t *testing.T) {
+	hosted := appendInitOptionalFlags(nil, uiSelection{ErunRegistry: true, ContainerRegistry: "ignored.example.com"})
+	if !hasFlag(hosted, "--erun-registry") {
+		t.Fatal("hosted registry selection must emit --erun-registry")
+	}
+	if hasFlag(hosted, "--container-registry") {
+		t.Fatalf("hosted must suppress --container-registry: %s", strings.Join(hosted, " "))
+	}
+	if hasFlag(hosted, "--cluster-registry") {
+		t.Fatalf("hosted must not also select the cluster registry: %s", strings.Join(hosted, " "))
+	}
+
+	cluster := appendInitOptionalFlags(nil, uiSelection{ClusterRegistry: true, ContainerRegistry: "ignored.example.com"})
+	if !hasFlag(cluster, "--cluster-registry") || hasFlag(cluster, "--container-registry") || hasFlag(cluster, "--erun-registry") {
+		t.Fatalf("cluster selection is exclusive too: %s", strings.Join(cluster, " "))
+	}
+
+	static := appendInitOptionalFlags(nil, uiSelection{ContainerRegistry: "registry.example.com"})
+	if got := flagValue(static, "--container-registry"); len(got) != 1 || got[0] != "registry.example.com" {
+		t.Fatalf("a plain registry string still passes through: %v", got)
+	}
+}
+
+// The runtime registry is a different coordinate from where the project's
+// images are pushed, so selecting a hosted or cluster registry must not drop it.
+func TestRuntimeRegistrySurvivesAnExclusiveRegistryChoice(t *testing.T) {
+	for _, selection := range []uiSelection{
+		{ErunRegistry: true, RuntimeRegistry: "ghcr.io/sophium"},
+		{ClusterRegistry: true, RuntimeRegistry: "ghcr.io/sophium"},
+	} {
+		args := appendInitOptionalFlags(nil, selection)
+		if got := flagValue(args, "--runtime-registry"); len(got) != 1 {
+			t.Fatalf("runtime registry dropped: %s", strings.Join(args, " "))
+		}
+	}
+}

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -131,11 +131,20 @@ type uiSelection struct {
 	// ClusterRegistry selects the in-cluster erun-registry (resolved from the
 	// env's kube-context) instead of the static ContainerRegistry string; the two
 	// are mutually exclusive and ClusterRegistry wins when set.
-	ClusterRegistry  bool   `json:"clusterRegistry,omitempty"`
-	Type             string `json:"type,omitempty"`
-	LocalRepoPath    string `json:"localRepoPath,omitempty"`
-	NoGit            bool   `json:"noGit,omitempty"`
-	SetDefaultTenant bool   `json:"setDefaultTenant,omitempty"`
+	ClusterRegistry bool `json:"clusterRegistry,omitempty"`
+	// ErunRegistry selects erun's hosted registry for the tenant. Mutually
+	// exclusive with both ContainerRegistry and ClusterRegistry, matching
+	// `erun init --erun-registry`.
+	ErunRegistry bool `json:"erunRegistry,omitempty"`
+	// RuntimeRegistry and ImagePullSecrets carry `erun init`'s
+	// --runtime-registry and --image-pull-secret, without which an env created
+	// here cannot pull a private runtime image.
+	RuntimeRegistry  string   `json:"runtimeRegistry,omitempty"`
+	ImagePullSecrets []string `json:"imagePullSecrets,omitempty"`
+	Type             string   `json:"type,omitempty"`
+	LocalRepoPath    string   `json:"localRepoPath,omitempty"`
+	NoGit            bool     `json:"noGit,omitempty"`
+	SetDefaultTenant bool     `json:"setDefaultTenant,omitempty"`
 	// Components is the explicit one-shot deploy selection from the Runtime tab's
 	// "Components to deploy" checklist; empty leaves deploy to resolve the env's
 	// saved default. Values are chart directory names (plus the runtime release
@@ -472,7 +481,16 @@ type uiEnvironmentConfig struct {
 	// OCI reference that may carry its own version. Empty means "the chart
 	// published with the deployed version", which is right whenever the chart and
 	// the runtime image ride one release line. See EnvConfig.RuntimeChart.
-	RuntimeChart          string                  `json:"runtimeChart,omitempty"`
+	RuntimeChart string `json:"runtimeChart,omitempty"`
+	// RuntimeRegistry is where the env resolves erun's OWN artifacts from -- the
+	// runtime chart and platform images -- as distinct from the registry this
+	// project's images are pushed to. Set it when the deploy registry holds only
+	// the project's images, so erun's chart is not there to pull.
+	RuntimeRegistry string `json:"runtimeRegistry,omitempty"`
+	// ImagePullSecrets names the Kubernetes dockerconfigjson secrets the runtime
+	// pod pulls its image with. Without one a private runtime image leaves the
+	// pod in ImagePullBackOff, which the app could previously cause and not fix.
+	ImagePullSecrets      []string                `json:"imagePullSecrets,omitempty"`
 	RuntimePod            uiRuntimePodConfig      `json:"runtimePod"`
 	SSHD                  uiSSHDConfig            `json:"sshd"`
 	Idle                  uiIdleConfig            `json:"idle"`


### PR DESCRIPTION
Closes #1349.

The app resolved and passed a private `--runtime-image` but had no field for the secret that image needs, so an environment created from the desktop went `ImagePullBackOff` **with no in-app repair** — the worst operator cost in #1345's sweep. `runtimeRegistry` was the same shape: the desktop *read* it to pick version suggestions but could not set it, so a tenant-registry-only environment deadlocked on the chart pull at every version.

## What landed

- **Manage dialog, General tab:** a `Runtime registry` field and an `Image pull secrets` list editor, both round-tripping through `uiEnvironmentConfig` → `environmentConfigFromUI`. Clearing either clears the config rather than leaving the previous value — a stale pull secret is how an environment keeps failing after the operator believes they fixed it.
- **Create dialog:** a hosted-registry choice threading `--erun-registry`. The three registry choices (hosted / in-cluster / static string) are mutually exclusive, and the dialog now releases the other toggle when one is picked instead of letting `erun init` reject the pair after the operator commits.
- **`appendInitOptionalFlags`:** emits `--runtime-registry`, repeated `--image-pull-secret`, and `--erun-registry`. Repeated rather than comma-joined — that is what the flag documents and it never needs escaping.

## The eight-point checklist

1. **Discoverability** — both fields sit in General beside Container registries, the section they qualify.
2. **Empty state** — reads as an explanation, never a disabled input: *"None. A runtime image in a private registry needs a `dockerconfigjson` secret here, or the pod cannot pull it."*
3. **Design language** — composed from `erun-kit`; `Add secret` mirrors `Add registry` exactly, so the new rows are not identifiable as new.
4. **Accessibility** — every input and icon button carries an indexed accessible name (`Image pull secret 1`, `Remove image pull secret 1`); the hosted-registry toggle is label-associated.
5. **Long values** — the secret input is `min-w-0 flex-1`, verified by rendering a 76-character secret name: the remove button stays in place rather than being pushed out.
6. **No implementation language** — the helper names what the field decides, not the flag it maps to.
7. **Reversibility** — removing a secret persists the removal, which is the actual repair path this issue exists for.
8. **Coverage in this PR** — 3 Playwright specs and 5 Go tests.

## Tests

Playwright (3, all green, run with `--build`): the empty state explains rather than showing a control; both coordinates save and reload; **removing a secret clears it rather than leaving a stale one**.

Go (5, green): pull secrets and runtime registry reach the init flags with blanks dropped; the three registry choices stay exclusive in both directions; the runtime registry survives an exclusive choice, since it is a different coordinate from where the project's images go; and both round-trip and clear through the editor.

`erun-ui` `go test ./...` green (12.5s); frontend typecheck, lint, format:check and tests green.

## Not claimed

Screenshot evidence is of the two reachable states (empty, populated). There is **no dark-theme evidence** because the desktop has no reachable dark theme — the `dark:` utilities are class-gated with nothing setting the class (#1356). I did not fabricate a second-theme check.

`EnvironmentDialogView.tsx` crossed eslint's 500-line cap once the hosted option landed, so `ContainerRegistryField` moved to its own module rather than the cap being raised — the same accumulation class #1282 was about.
