### PR TITLE
Remove the retired session recorder from settings that already carry it

### DIFF
--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -710,6 +710,12 @@ func ensureOrchestratorSessionStartHook(dir string) error {
 	// See orchestrator_shell_activity.go.
 	hooks["PostToolUse"] = mergeOrchestratorHookBlocks(
 		hooks["PostToolUse"], orchestratorShellActivityHookBlocks(), isOrchestratorShellActivityHookBlock)
+	// Not installing the retired session recorder is not enough: every machine
+	// that ever ran an older build still carries it, and it would go on writing
+	// a file nothing reads on every turn boundary. Strip it wherever it is found.
+	for event := range hooks {
+		hooks[event] = pruneRetiredSessionRecorderHooks(hooks[event])
+	}
 	settings["hooks"] = hooks
 	out, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {

--- a/erun-ui/orchestrator_retired_hooks.go
+++ b/erun-ui/orchestrator_retired_hooks.go
@@ -1,0 +1,57 @@
+package main
+
+import "strings"
+
+// The session recorder wrote orchestrator-session/<id>.json so a resume could
+// prefer it over the derived conversation id. That override is gone: a
+// conversation is derived from the orchestrator id, so nothing reads the file.
+//
+// Ceasing to install the hook leaves it installed everywhere it already is,
+// where it keeps writing on every turn boundary. This removes it, so the
+// upgrade actually retires the mechanism instead of only stopping new ones.
+
+// pruneRetiredSessionRecorderHooks drops the recorder from one event's blocks.
+// It matches on what the command does -- writes a sessionId into the
+// orchestrator-session directory -- so a block is only removed when it is
+// provably that hook and never because it merely sits nearby.
+func pruneRetiredSessionRecorderHooks(blocks any) []any {
+	list, ok := blocks.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]any, 0, len(list))
+	for _, block := range list {
+		if !isRetiredSessionRecorderBlock(block) {
+			out = append(out, block)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func isRetiredSessionRecorderBlock(block any) bool {
+	group, ok := block.(map[string]any)
+	if !ok {
+		return false
+	}
+	hooks, ok := group["hooks"].([]any)
+	if !ok {
+		return false
+	}
+	for _, hook := range hooks {
+		entry, ok := hook.(map[string]any)
+		if !ok {
+			continue
+		}
+		command, ok := entry["command"].(string)
+		if !ok {
+			continue
+		}
+		if strings.Contains(command, "orchestrator-session") && strings.Contains(command, `"sessionId":`) {
+			return true
+		}
+	}
+	return false
+}

--- a/erun-ui/orchestrator_retired_hooks_test.go
+++ b/erun-ui/orchestrator_retired_hooks_test.go
@@ -1,0 +1,48 @@
+package main
+
+import "testing"
+
+func recorderBlock() map[string]any {
+	return map[string]any{"hooks": []any{map[string]any{
+		"type":    "command",
+		"command": `printf '{"sessionId":"%s"}' "$sid" > /x/orchestrator-session/$ERUN_ORCHESTRATOR_ID.json`,
+	}}}
+}
+
+func namedBlock(command string) map[string]any {
+	return map[string]any{"hooks": []any{map[string]any{"type": "command", "command": command}}}
+}
+
+// Ceasing to install the recorder leaves it installed on every machine that
+// already ran an older build, still writing a file nothing reads.
+func TestRetiredRecorderIsRemovedWhereverItIsInstalled(t *testing.T) {
+	out := pruneRetiredSessionRecorderHooks([]any{
+		namedBlock("echo busy > /x/orchestrator-activity/$ERUN_ORCHESTRATOR_ID.json"),
+		recorderBlock(),
+		namedBlock("the operator's own hook"),
+	})
+	if len(out) != 2 {
+		t.Fatalf("expected the recorder removed and the rest kept, got %d blocks", len(out))
+	}
+	for _, block := range out {
+		if isRetiredSessionRecorderBlock(block) {
+			t.Fatal("a recorder block survived")
+		}
+	}
+}
+
+// It matches on what the command does, so a block is never removed for merely
+// mentioning one of the two markers -- the operator's hooks live here too.
+func TestPruneKeepsBlocksThatOnlyResembleTheRecorder(t *testing.T) {
+	keep := []any{
+		namedBlock("grep orchestrator-session /tmp/notes"),
+		namedBlock(`echo '"sessionId": read only'`),
+		namedBlock("unrelated"),
+	}
+	if got := pruneRetiredSessionRecorderHooks(keep); len(got) != 3 {
+		t.Fatalf("expected all three kept, got %d", len(got))
+	}
+	if pruneRetiredSessionRecorderHooks("not a list") != nil {
+		t.Fatal("a shape it cannot read must not be rewritten into one it can")
+	}
+}


### PR DESCRIPTION
Follow-up to #1369. That PR stopped installing the session recorder but left it installed everywhere it already was — on the machine this was found on, **five entries** across `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `SessionStart` and `Stop`, still writing `orchestrator-session/<id>.json` on every turn boundary for a file nothing reads any more.\n\nThe install path now prunes it. The match is on what the command does — writes a `sessionId` into the `orchestrator-session` directory — so a block is removed only when it is provably that hook, never for sitting nearby. Two tests: one that it is removed wherever installed while the activity report and the operator own hooks survive, one that a block merely mentioning either marker is kept.\n\n`erun-ui` suite green.