### PR TITLE
Stop persisting a conversation id that is derived

### DIFF
--- a/erun-ui/app_restart.go
+++ b/erun-ui/app_restart.go
@@ -294,21 +294,14 @@ func (a *App) ResolveOrchestratorToReopen() relaunchTarget {
 }
 
 // resolveReopenSessionID decides which conversation a reopened orchestrator
-// resumes: the one durably recorded as live for it, but only when that
-// conversation still exists on disk — never a re-derivation from the
-// orchestrator id, which can land on a different, older conversation that
-// happens to share the derived id. Absent or stale, it mints a fresh
-// id instead of guessing: resuming nothing is safer than resuming the wrong
-// conversation, and the fresh session gets recorded correctly the moment it
-// spawns.
+// resumes: its own, derived from its id. Nothing is read, because nothing is
+// stored -- a derivation is the same answer on every launch, so a second copy
+// on disk could only ever disagree with it. A transient orchestrator has no id
+// to derive from and gets a fresh conversation.
 func resolveReopenSessionID(entry orchestratorOpenEntry) string {
-	if entry.SessionID != "" && orchestratorSessionExists(entry.SessionID) {
-		return entry.SessionID
+	if id := strings.TrimSpace(entry.OrchestratorID); id != "" {
+		return orchestratorSessionID(id)
 	}
-	// A record that names a conversation which is gone, and a legacy record that
-	// names none, both start fresh on purpose: an orchestrator id is reusable, so
-	// silence must not be read as permission to resume whatever the derived id
-	// happens to name from an unrelated earlier run.
 	return uuid.NewString()
 }
 

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -1611,7 +1611,7 @@ func (a *App) spawnOrchestratorSession(spawn orchestratorSpawn) (orchestratorInf
 	// written here survives that. A transient (Investigate) session has no
 	// persisted definition to reopen, so it is deliberately not recorded.
 	if !transient {
-		if err := recordOpenOrchestrator(a.deps.orchestratorOpenPath, id, conversationID, orchestratorScopeOf(envs)); err != nil {
+		if err := recordOpenOrchestrator(a.deps.orchestratorOpenPath, id, orchestratorScopeOf(envs)); err != nil {
 			log.Printf("erun-app: record open orchestrator %s: %v", id, err)
 		}
 	}

--- a/erun-ui/orchestrator_open_state.go
+++ b/erun-ui/orchestrator_open_state.go
@@ -43,14 +43,14 @@ import (
 
 const orchestratorOpenFileName = "orchestrator-open.json"
 
-// orchestratorOpenEntry is one orchestrator in the durable open set: its id and
-// the conversation last known to be running under it. SessionID is empty for an
-// entry migrated from a release that predates this file (see
-// orchestratorOpenState), which restore treats as "no live session recorded"
-// rather than a session pinned to nothing.
+// orchestratorOpenEntry is one orchestrator in the durable open set: which
+// orchestrators to reopen, and the scope each was wired to. It deliberately
+// carries NO conversation id -- that is derived from the orchestrator id, so
+// persisting it would only create a second answer that can disagree with the
+// first. A field written on every launch and read on every restore is a field
+// that can be written by the wrong session; a derivation cannot.
 type orchestratorOpenEntry struct {
 	OrchestratorID string `json:"orchestratorId"`
-	SessionID      string `json:"sessionId,omitempty"`
 	// Environments is the scope (sorted tenant/environment pairs, see
 	// orchestratorScopeOf) the recorded session was actually wired to when this
 	// entry was written. An orchestrator id is mutable and reusable, so restore
@@ -95,29 +95,20 @@ func defaultOrchestratorOpenPath() string {
 // recent) with that conversation id if it was already there. Called every time
 // a session is spawned, so the record always names the conversation this
 // launch is actually running rather than one a restore would have to derive.
-func recordOpenOrchestrator(path, orchestratorID, sessionID string, scope []string) error {
+func recordOpenOrchestrator(path, orchestratorID string, scope []string) error {
 	orchestratorID = strings.TrimSpace(orchestratorID)
 	if path == "" || orchestratorID == "" {
 		return nil
 	}
-	sessionID = strings.TrimSpace(sessionID)
 	entries := readOpenOrchestrators(path)
 	out := make([]orchestratorOpenEntry, 0, len(entries)+1)
 	for _, entry := range entries {
 		if entry.OrchestratorID == orchestratorID {
 			continue
 		}
-		// A conversation belongs to one orchestrator. If another entry already
-		// names the session this launch is running, it is a stale claim by
-		// definition — this launch is the one with the conversation open now —
-		// so release it rather than leaving the id under two owners, which is
-		// what made a crossing stick across every later restart.
-		if sessionID != "" && strings.TrimSpace(entry.SessionID) == sessionID {
-			entry.SessionID = ""
-		}
 		out = append(out, entry)
 	}
-	out = append(out, orchestratorOpenEntry{OrchestratorID: orchestratorID, SessionID: sessionID, Environments: scope})
+	out = append(out, orchestratorOpenEntry{OrchestratorID: orchestratorID, Environments: scope})
 	return writeOpenOrchestrators(path, out)
 }
 
@@ -194,42 +185,12 @@ func dedupOrchestratorEntries(entries []orchestratorOpenEntry) []orchestratorOpe
 			continue
 		}
 		seen[id] = struct{}{}
-		out = append(out, orchestratorOpenEntry{OrchestratorID: id, SessionID: strings.TrimSpace(entry.SessionID), Environments: entry.Environments})
+		out = append(out, orchestratorOpenEntry{OrchestratorID: id, Environments: entry.Environments})
 	}
 	if len(out) == 0 {
 		return nil
 	}
-	return dropDuplicateSessionClaims(out)
-}
-
-// dropDuplicateSessionClaims enforces the invariant the rest of restore assumes
-// but nothing used to check: a conversation belongs to exactly ONE orchestrator.
-//
-// Deduping by orchestrator id alone let one session id sit under two ids at
-// once, and every later launch then resolved both of them to the same
-// conversation — so one orchestrator was handed the other's history, complete
-// with the other's scope and return note, and the crossing was self-reinforcing
-// because each launch recorded it again.
-//
-// Entries are oldest-first, so the walk runs backwards and the MOST RECENT claim
-// on a session keeps it. An older entry that named the same conversation stays
-// open — the operator had it open, and closing it would lose more than it fixes
-// — but comes back with no session id, which restore already treats as "start
-// this one fresh" rather than guessing.
-func dropDuplicateSessionClaims(entries []orchestratorOpenEntry) []orchestratorOpenEntry {
-	claimed := make(map[string]string, len(entries))
-	for i := len(entries) - 1; i >= 0; i-- {
-		session := strings.TrimSpace(entries[i].SessionID)
-		if session == "" {
-			continue
-		}
-		if owner, ok := claimed[session]; ok && owner != entries[i].OrchestratorID {
-			entries[i].SessionID = ""
-			continue
-		}
-		claimed[session] = entries[i].OrchestratorID
-	}
-	return entries
+	return out
 }
 
 // writeOpenOrchestrators persists the open set, migrating a legacy file to the

--- a/erun-ui/orchestrator_open_state_test.go
+++ b/erun-ui/orchestrator_open_state_test.go
@@ -286,7 +286,7 @@ func TestRestartHandOffStaysOneShotAndAgeBoundedOverTheDurableRecord(t *testing.
 		Environments:   []string{"frs/dev"},
 		ResumePrompt:   prompt,
 	}
-	if err := recordOpenOrchestrator(openPath, id, conversationID, []string{"frs/dev"}); err != nil {
+	if err := recordOpenOrchestrator(openPath, id, []string{"frs/dev"}); err != nil {
 		t.Fatalf("record open orchestrator: %v", err)
 	}
 	if err := writeOrchestratorRestoreTarget(restoreDir, handOff, time.Now()); err != nil {
@@ -311,84 +311,6 @@ func TestRestartHandOffStaysOneShotAndAgeBoundedOverTheDurableRecord(t *testing.
 	stale := app.ResolveOrchestratorToReopen()
 	if stale.OrchestratorID != id || stale.ResumePrompt != "" {
 		t.Fatalf("expected a stale hand-off to be dropped and the durable record to answer, got %+v", stale)
-	}
-}
-
-// The bug: a plain launch used to re-derive a session id from the
-// orchestrator id (uuid5(namespace, id)) and resume THAT, rather than the
-// conversation actually recorded as running. A stale transcript that happens
-// to sit at the derived id — left over from before the live session diverged
-// from it, e.g. a resume that fell through to an unpinned launch — was
-// silently resumed while the real, divergent conversation was left behind.
-func TestPlainLaunchResumesTheRecordedConversationNotADerivedOne(t *testing.T) {
-	app, openPath, _ := openStateTestApp(t)
-	defer app.shutdown(context.Background())
-
-	id := createAndStartOrchestrator(t, app)
-	staleDerived := orchestratorSessionID(id)
-	stageOrchestratorConversation(t, staleDerived)
-	liveConversation := "diverged-session-actually-running"
-	stageOrchestratorConversation(t, liveConversation)
-	if err := recordOpenOrchestrator(openPath, id, liveConversation, []string{"frs/dev"}); err != nil {
-		t.Fatalf("record open orchestrator: %v", err)
-	}
-
-	target := app.ResolveOrchestratorToReopen()
-	if target.OrchestratorID != id {
-		t.Fatalf("expected %q to be reopened, got %q", id, target.OrchestratorID)
-	}
-	if target.ConversationID != liveConversation {
-		t.Fatalf("expected the recorded live conversation %q to be resumed, not the derived id %q, got %q",
-			liveConversation, staleDerived, target.ConversationID)
-	}
-}
-
-// An orchestrator whose recorded conversation no longer exists on disk (pruned,
-// deleted, never actually staged) starts fresh instead of falling back to
-// whatever the derived id happens to already name — resuming nothing is safer
-// than resuming a stale conversation.
-func TestPlainLaunchStartsFreshWhenTheRecordedConversationIsGone(t *testing.T) {
-	app, openPath, _ := openStateTestApp(t)
-	defer app.shutdown(context.Background())
-
-	id := createAndStartOrchestrator(t, app)
-	staleDerived := orchestratorSessionID(id)
-	stageOrchestratorConversation(t, staleDerived)
-	if err := recordOpenOrchestrator(openPath, id, "vanished-session", []string{"frs/dev"}); err != nil {
-		t.Fatalf("record open orchestrator: %v", err)
-	}
-
-	target := app.ResolveOrchestratorToReopen()
-	if target.OrchestratorID != id {
-		t.Fatalf("expected %q to be reopened, got %q", id, target.OrchestratorID)
-	}
-	if target.ConversationID == "" || target.ConversationID == staleDerived || target.ConversationID == "vanished-session" {
-		t.Fatalf("expected a fresh conversation, neither the stale derived id nor the vanished one, got %q",
-			target.ConversationID)
-	}
-}
-
-// An operator upgrading from a release that recorded only the orchestrator id
-// (an earlier shape, or the scalar one before it) must not have that silence
-// read as permission to resume whatever the derived id names. The very first
-// restore under the new record starts every such orchestrator fresh.
-func TestUpgradingFromARecordWithNoSessionIDStartsFresh(t *testing.T) {
-	app, openPath, _ := openStateTestApp(t)
-	defer app.shutdown(context.Background())
-
-	id := createAndStartOrchestrator(t, app)
-	staleDerived := orchestratorSessionID(id)
-	stageOrchestratorConversation(t, staleDerived)
-	if err := os.WriteFile(openPath, []byte(`{"orchestratorIds":["`+id+`"]}`), 0o644); err != nil {
-		t.Fatalf("write legacy open file: %v", err)
-	}
-
-	target := app.ResolveOrchestratorToReopen()
-	if target.OrchestratorID != id {
-		t.Fatalf("expected %q to be reopened, got %q", id, target.OrchestratorID)
-	}
-	if target.ConversationID == "" || target.ConversationID == staleDerived {
-		t.Fatalf("expected a fresh conversation rather than the stale derived id, got %q", target.ConversationID)
 	}
 }
 
@@ -457,72 +379,47 @@ func TestAlsoReopenSurfacesANoticeWhenScopeChanged(t *testing.T) {
 	}
 }
 
-// A conversation belongs to exactly one orchestrator. Recording a launch must
-// release any other orchestrator's claim on the same session, or every later
-// restart resolves both ids to one conversation and hands one orchestrator the
-// other's history, scope and return note.
-func TestRecordingALaunchReleasesAnotherOrchestratorsClaimOnTheSameSession(t *testing.T) {
-	path := filepath.Join(t.TempDir(), orchestratorOpenFileName)
+// The record says WHICH orchestrators to reopen; it does not say which
+// conversation each resumes, because that is derived from the orchestrator id.
+// A launch therefore lands on the same conversation every time, and there is no
+// stored copy that can disagree -- which is how three orchestrators previously
+// ended up on conversations that were not theirs and stayed there.
+func TestPlainLaunchResumesTheDerivedConversation(t *testing.T) {
+	app, openPath, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
 
-	if err := recordOpenOrchestrator(path, "petios-admin", "shared-conversation", []string{"petios/rihards-develop"}); err != nil {
-		t.Fatalf("record petios-admin: %v", err)
-	}
-	if err := recordOpenOrchestrator(path, "erun", "shared-conversation", []string{"erun/build"}); err != nil {
-		t.Fatalf("record erun: %v", err)
+	id := createAndStartOrchestrator(t, app)
+	if err := recordOpenOrchestrator(openPath, id, []string{"frs/dev"}); err != nil {
+		t.Fatalf("record open orchestrator: %v", err)
 	}
 
-	entries := readOpenOrchestrators(path)
-	if len(entries) != 2 {
-		t.Fatalf("both orchestrators must stay open, got %d entries: %+v", len(entries), entries)
+	target := app.ResolveOrchestratorToReopen()
+	if target.OrchestratorID != id {
+		t.Fatalf("expected %q reopened, got %q", id, target.OrchestratorID)
 	}
-	claims := map[string]string{}
-	for _, entry := range entries {
-		claims[entry.OrchestratorID] = entry.SessionID
-	}
-	if claims["erun"] != "shared-conversation" {
-		t.Fatalf("the launch that just happened keeps the session, got %q", claims["erun"])
-	}
-	if claims["petios-admin"] != "" {
-		t.Fatalf("the stale claim must be released so that orchestrator starts fresh, got %q", claims["petios-admin"])
+	if target.ConversationID != orchestratorSessionID(id) {
+		t.Fatalf("expected the derived conversation %q, got %q", orchestratorSessionID(id), target.ConversationID)
 	}
 }
 
-// An already-crossed file heals on read: the operator hit this before the write
-// path was fixed, and a restart must not keep replaying the crossing.
-func TestReadingAnAlreadyCrossedOpenRecordReleasesTheOlderClaim(t *testing.T) {
-	path := filepath.Join(t.TempDir(), orchestratorOpenFileName)
-	crossed := `{"orchestrators":[` +
-		`{"orchestratorId":"petios-admin","sessionId":"b40e4de0","environments":["petios/rihards-develop"]},` +
-		`{"orchestratorId":"erun","sessionId":"b40e4de0","environments":["erun/build"]}]}`
-	if err := os.WriteFile(path, []byte(crossed), 0o644); err != nil {
-		t.Fatalf("write crossed record: %v", err)
+// Nothing a stray writer puts in the file can move an orchestrator off its own
+// conversation, because the conversation is not read from the file at all.
+func TestAForeignSessionIdInTheRecordIsIgnored(t *testing.T) {
+	app, openPath, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	id := createAndStartOrchestrator(t, app)
+	stranger := orchestratorSessionID("some-other-orchestrator")
+	stageOrchestratorConversation(t, stranger)
+	if err := os.WriteFile(openPath, []byte(`{"orchestrators":[{"orchestratorId":"`+id+`","sessionId":"`+stranger+`"}]}`), 0o644); err != nil {
+		t.Fatalf("write record: %v", err)
 	}
 
-	entries := readOpenOrchestrators(path)
-	if len(entries) != 2 {
-		t.Fatalf("expected both orchestrators, got %+v", entries)
+	target := app.ResolveOrchestratorToReopen()
+	if target.ConversationID == stranger {
+		t.Fatal("resumed a conversation the record named for someone else")
 	}
-	if entries[0].OrchestratorID != "petios-admin" || entries[0].SessionID != "" {
-		t.Fatalf("older claim must be released, got %+v", entries[0])
-	}
-	if entries[1].OrchestratorID != "erun" || entries[1].SessionID != "b40e4de0" {
-		t.Fatalf("most recent claim keeps the conversation, got %+v", entries[1])
-	}
-}
-
-// One orchestrator legitimately moving between conversations (a compaction fork
-// re-recorded under the same id) must not be mistaken for a crossing.
-func TestOneOrchestratorMovingConversationsKeepsItsOwnLatestSession(t *testing.T) {
-	path := filepath.Join(t.TempDir(), orchestratorOpenFileName)
-
-	for _, session := range []string{"before-compact", "after-compact"} {
-		if err := recordOpenOrchestrator(path, "agent-1", session, []string{"frs/dev"}); err != nil {
-			t.Fatalf("record %s: %v", session, err)
-		}
-	}
-
-	entries := readOpenOrchestrators(path)
-	if len(entries) != 1 || entries[0].SessionID != "after-compact" {
-		t.Fatalf("expected the one orchestrator to hold its newest session, got %+v", entries)
+	if target.ConversationID != orchestratorSessionID(id) {
+		t.Fatalf("expected its own derived conversation, got %q", target.ConversationID)
 	}
 }


### PR DESCRIPTION
Follow-up to #1369, and the part that actually ends the drift.

#1369 removed the shell hook that recorded a conversation id and made the restart/respawn paths derive it. It missed the path that runs on a plain launch: `resolveReopenSessionID` read `orchestrator-open.json`. So after #1369 shipped, was rolled out, and the stale records were deleted, a restart still resumed the wrong conversation — the open record had said `erun → b40e4de0-…` (petios-admin's derived id) for three days, and still did.

The cause was the same one twice: **a derived value was also stored.** A conversation id is `uuid.NewSHA1(namespace, orchestratorID)` — the same answer on every launch, on every machine. Storing it creates a second answer that can disagree, and the stored copy is the one a stray writer can reach.

## The change

`orchestratorOpenEntry` no longer has a `SessionID` field. The open record says only **which** orchestrators to reopen and the scope each was wired to — neither of which is derivable, so both still belong on disk. The conversation is computed at the point of use.

`recordOpenOrchestrator` loses its `sessionID` parameter. `dropDuplicateSessionClaims` is deleted: nothing can claim a session twice when no session is written. An unknown `sessionId` left in an existing file is simply ignored, so old files need no migration.

**198 lines deleted, 49 added.**

## Tests

Six removed, two added.

Three were mine from #1358 and tested the guard this deletes — the duplicate-claim release, the crossed-record heal, and one-orchestrator-moving-conversations. They were guarding a field that no longer exists.

Three were pre-existing and encoded the opposite contract: `TestPlainLaunchResumesTheRecordedConversationNotADerivedOne` says in its name that the record wins over derivation, and two more asserted a fresh conversation when the record was stale or legacy. **Those were deliberate decisions and I am reversing them on the operator's explicit instruction** — do not persist a deterministic value, and do not read it back; calculate it. Their reason (an orchestrator id is reusable, so a derived id might name an unrelated older run) is real but is addressed by the derivation being stable rather than by refusing to use it.

The two replacements assert the new contract directly: a plain launch resumes the derived conversation, and a `sessionId` left in the file naming another orchestrator's conversation is ignored rather than adopted.

`go vet` clean, `erun-ui` suite green (16.1s).
