### PR TITLE
Give jobs a desktop surface, and read them from the environment that ran them

### DIFF
--- a/erun-common/job.go
+++ b/erun-common/job.go
@@ -632,3 +632,15 @@ func normalizeJobNow(now time.Time) time.Time {
 func environmentJobLeaseID(id string) string {
 	return environmentJobLeasePrefix + id
 }
+
+// EnvironmentJobIDFromLeaseID recovers the job a lease is held for, and reports
+// false for a lease held by anything else. Callers that want to act on the job
+// behind a lease need the inverse of the id scheme, and re-deriving the prefix
+// at each call site is how the two drift apart.
+func EnvironmentJobIDFromLeaseID(leaseID string) (string, bool) {
+	id := strings.TrimPrefix(leaseID, environmentJobLeasePrefix)
+	if id == leaseID || strings.TrimSpace(id) == "" {
+		return "", false
+	}
+	return id, true
+}

--- a/erun-common/job_lease_id_test.go
+++ b/erun-common/job_lease_id_test.go
@@ -1,0 +1,16 @@
+package eruncommon
+
+import "testing"
+
+// A lease held for a job must be resolvable back to that job, and a lease held
+// for anything else must not be mistaken for one.
+func TestEnvironmentJobIDFromLeaseID(t *testing.T) {
+	if id, ok := EnvironmentJobIDFromLeaseID(environmentJobLeaseID("gate-1")); !ok || id != "gate-1" {
+		t.Fatalf("round trip: got %q ok=%v", id, ok)
+	}
+	for _, other := range []string{"", "orchestrator-erun", "job-", "deploy"} {
+		if id, ok := EnvironmentJobIDFromLeaseID(other); ok {
+			t.Fatalf("%q must not resolve to a job, got %q", other, id)
+		}
+	}
+}

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -79,6 +79,9 @@ type erunUIDeps struct {
 	execCommit                func(ctx context.Context, endpoint, bearer, branch, message string) (eruncommon.CommitWorkingTreeResult, error)
 	execPush                  func(ctx context.Context, endpoint, bearer, branch, remote string) (eruncommon.PushWorkingTreeBranchResult, error)
 	loadIdleStatus            func(context.Context, string, string) (eruncommon.EnvironmentIdleStatus, error)
+	loadEnvironmentJobs       func(context.Context, string, string) ([]eruncommon.EnvironmentJob, error)
+	readEnvironmentJobOutput  func(context.Context, string, string, eruncommon.ReadEnvironmentJobOutputParams) (eruncommon.EnvironmentJobOutput, error)
+	cancelEnvironmentJob      func(context.Context, string, string, eruncommon.CancelEnvironmentJobParams) (eruncommon.CancelEnvironmentJobResult, error)
 	loadAPILog                func(context.Context, uiTenantDashboardInput) (string, error)
 	workspaceSyncReady        func(context.Context, string) error
 	syncWorkspace             func(context.Context, eruncommon.WorkspaceSyncParams) (eruncommon.WorkspaceSyncResult, error)
@@ -415,6 +418,7 @@ func withDefaultWorkspaceDeps(deps erunUIDeps) erunUIDeps {
 	if deps.loadIdleStatus == nil {
 		deps.loadIdleStatus = loadIdleStatusFromMCP
 	}
+	deps = withDefaultEnvironmentJobDeps(deps)
 	if deps.loadAPILog == nil {
 		deps.loadAPILog = loadAPILog
 	}
@@ -426,6 +430,19 @@ func withDefaultWorkspaceDeps(deps erunUIDeps) erunUIDeps {
 	}
 	if deps.workspaceSyncInterval <= 0 {
 		deps.workspaceSyncInterval = defaultWorkspaceSyncInterval
+	}
+	return deps
+}
+
+func withDefaultEnvironmentJobDeps(deps erunUIDeps) erunUIDeps {
+	if deps.loadEnvironmentJobs == nil {
+		deps.loadEnvironmentJobs = loadEnvironmentJobsFromMCP
+	}
+	if deps.readEnvironmentJobOutput == nil {
+		deps.readEnvironmentJobOutput = readEnvironmentJobOutputFromMCP
+	}
+	if deps.cancelEnvironmentJob == nil {
+		deps.cancelEnvironmentJob = cancelEnvironmentJobFromMCP
 	}
 	return deps
 }

--- a/erun-ui/environment_jobs.go
+++ b/erun-ui/environment_jobs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -16,6 +17,18 @@ import (
 // Output is paged rather than streamed: a page is what the operator's scroll
 // position can absorb, and an offset the caller passes back is what makes a
 // second read continue rather than repeat.
+//
+// A remote-agent/runtime environment's jobs run in its pod, not on the host,
+// so these reads go through the env's own MCP edge whenever it is reachable —
+// the same branch LoadIdleStatus already uses to tell a pod-backed answer from
+// a locally-guessed one. The local store is still consulted when the edge is
+// not reachable: it is where the desktop's own Investigate job is recorded
+// (that job runs on the host regardless of the environment's type), and for an
+// environment nobody has opened yet it is the only truthful answer there is —
+// no pod is running to have missed any jobs. A stale forward (the port is
+// held but the edge never answers) is different: a pod may well be running
+// jobs behind it, so that case is reported as unreachable rather than
+// silently read as empty.
 
 // LoadEnvironmentJobs lists an environment's retained jobs, newest first.
 func (a *App) LoadEnvironmentJobs(tenant, environment string) ([]uiEnvironmentJob, error) {
@@ -24,15 +37,22 @@ func (a *App) LoadEnvironmentJobs(tenant, environment string) ([]uiEnvironmentJo
 	if tenant == "" || environment == "" {
 		return nil, fmt.Errorf("tenant and environment are required")
 	}
-	jobs, err := eruncommon.LoadEnvironmentJobs(tenant, environment, time.Now())
+	result, useMCP, err := a.jobsReachability(tenant, environment)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]uiEnvironmentJob, 0, len(jobs))
-	for _, job := range jobs {
-		out = append(out, environmentJobToUI(job))
+	if !useMCP {
+		jobs, err := eruncommon.LoadEnvironmentJobs(tenant, environment, time.Now())
+		if err != nil {
+			return nil, err
+		}
+		return environmentJobsToUI(jobs), nil
 	}
-	return out, nil
+	jobs, err := a.deps.loadEnvironmentJobs(a.backgroundContext(), mcpEndpointForOpenResult(result), a.mcpBearer(tenant, environment))
+	if err != nil {
+		return nil, a.wrapJobMCPErr(result, err)
+	}
+	return environmentJobsToUI(jobs), nil
 }
 
 // ReadEnvironmentJobOutput returns one page of a job's captured output.
@@ -47,24 +67,29 @@ func (a *App) ReadEnvironmentJobOutput(input uiJobOutputInput) (uiEnvironmentJob
 	if maxBytes <= 0 {
 		maxBytes = defaultJobOutputPageBytes
 	}
-	page, err := eruncommon.ReadEnvironmentJobOutput(eruncommon.ReadEnvironmentJobOutputParams{
+	params := eruncommon.ReadEnvironmentJobOutputParams{
 		Tenant:      tenant,
 		Environment: environment,
 		ID:          id,
 		Offset:      input.Offset,
 		MaxBytes:    maxBytes,
-	})
+	}
+	result, useMCP, err := a.jobsReachability(tenant, environment)
 	if err != nil {
 		return uiEnvironmentJobOutput{}, err
 	}
-	return uiEnvironmentJobOutput{
-		Job:        environmentJobToUI(page.Job),
-		Offset:     page.Offset,
-		NextOffset: page.NextOffset,
-		Output:     page.Output,
-		HasMore:    page.HasMore,
-		Complete:   page.Complete,
-	}, nil
+	if !useMCP {
+		page, err := eruncommon.ReadEnvironmentJobOutput(params)
+		if err != nil {
+			return uiEnvironmentJobOutput{}, err
+		}
+		return jobOutputToUI(page), nil
+	}
+	page, err := a.deps.readEnvironmentJobOutput(a.backgroundContext(), mcpEndpointForOpenResult(result), a.mcpBearer(tenant, environment), params)
+	if err != nil {
+		return uiEnvironmentJobOutput{}, a.wrapJobMCPErr(result, err)
+	}
+	return jobOutputToUI(page), nil
 }
 
 // CancelEnvironmentJob signals a running job's work. The supervisor is left
@@ -77,21 +102,91 @@ func (a *App) CancelEnvironmentJob(input uiCancelJobInput) (uiEnvironmentJob, er
 	if tenant == "" || environment == "" || id == "" {
 		return uiEnvironmentJob{}, fmt.Errorf("tenant, environment, and job id are required")
 	}
-	result, err := eruncommon.CancelEnvironmentJob(eruncommon.Context{}, eruncommon.CancelEnvironmentJobParams{
+	params := eruncommon.CancelEnvironmentJobParams{
 		Tenant:      tenant,
 		Environment: environment,
 		ID:          id,
 		Signal:      strings.TrimSpace(input.Signal),
-	})
+	}
+	result, useMCP, err := a.jobsReachability(tenant, environment)
 	if err != nil {
 		return uiEnvironmentJob{}, err
 	}
-	return environmentJobToUI(result.Job), nil
+	if !useMCP {
+		cancel, err := eruncommon.CancelEnvironmentJob(eruncommon.Context{}, params)
+		if err != nil {
+			return uiEnvironmentJob{}, err
+		}
+		return environmentJobToUI(cancel.Job), nil
+	}
+	cancel, err := a.deps.cancelEnvironmentJob(a.backgroundContext(), mcpEndpointForOpenResult(result), a.mcpBearer(tenant, environment), params)
+	if err != nil {
+		return uiEnvironmentJob{}, a.wrapJobMCPErr(result, err)
+	}
+	return environmentJobToUI(cancel.Job), nil
+}
+
+// jobsReachability decides how a job read or write should reach its answer:
+// through the environment's own MCP edge when it is reachable, or through the
+// local store when the environment is legitimately not running -- no pod is
+// there to have missed anything, and the local store is also where the
+// desktop's own Investigate job is recorded regardless of the environment's
+// type. A stale forward (the port is held but the edge never answers) is
+// neither: a pod may well be running jobs behind it that the local store
+// cannot see, so that case is reported as unreachable rather than read as
+// empty.
+func (a *App) jobsReachability(tenant, environment string) (eruncommon.OpenResult, bool, error) {
+	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
+		Tenant:      tenant,
+		Environment: environment,
+	})
+	if err != nil {
+		return eruncommon.OpenResult{}, false, err
+	}
+	mcpPort := eruncommon.MCPPortForResult(result)
+	if a.deps.canReachMCPEndpoint(mcpPort) {
+		return result, true, nil
+	}
+	if kind := a.classifyMCPUnreachable(mcpPort); kind == eruncommon.LocalMCPStaleForward {
+		return eruncommon.OpenResult{}, false, wrapMCPUnreachableErrorWithKind(kind, errors.New(eruncommon.DescribeLocalMCPUnreachable(tenant, environment, mcpPort)))
+	}
+	return result, false, nil
+}
+
+// wrapJobMCPErr classifies a failure from a pod-backed job call: a dial
+// failure means the edge dropped mid-call, reported the same way an
+// upfront-unreachable read is; any other failure (including "this runtime
+// image predates the job_* tools") passes through unchanged.
+func (a *App) wrapJobMCPErr(result eruncommon.OpenResult, err error) error {
+	if err == nil || !isMCPDialFailure(err) {
+		return err
+	}
+	mcpPort := eruncommon.MCPPortForResult(result)
+	return wrapMCPUnreachableErrorWithKind(a.classifyMCPUnreachable(mcpPort), err)
 }
 
 // defaultJobOutputPageBytes is one screenful and then some, so the first read
 // of a finished job is usually its whole output.
 const defaultJobOutputPageBytes = 65536
+
+func environmentJobsToUI(jobs []eruncommon.EnvironmentJob) []uiEnvironmentJob {
+	out := make([]uiEnvironmentJob, 0, len(jobs))
+	for _, job := range jobs {
+		out = append(out, environmentJobToUI(job))
+	}
+	return out
+}
+
+func jobOutputToUI(page eruncommon.EnvironmentJobOutput) uiEnvironmentJobOutput {
+	return uiEnvironmentJobOutput{
+		Job:        environmentJobToUI(page.Job),
+		Offset:     page.Offset,
+		NextOffset: page.NextOffset,
+		Output:     page.Output,
+		HasMore:    page.HasMore,
+		Complete:   page.Complete,
+	}
+}
 
 func environmentJobToUI(job eruncommon.EnvironmentJob) uiEnvironmentJob {
 	out := uiEnvironmentJob{

--- a/erun-ui/environment_jobs.go
+++ b/erun-ui/environment_jobs.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// The desktop writes into the job store — Investigate starts a job there — and
+// until now could not display the job it had just created. These bindings give
+// the Jobs surface the same three reads the CLI and MCP already have, plus the
+// one write that matters while a job is running.
+//
+// Output is paged rather than streamed: a page is what the operator's scroll
+// position can absorb, and an offset the caller passes back is what makes a
+// second read continue rather than repeat.
+
+// LoadEnvironmentJobs lists an environment's retained jobs, newest first.
+func (a *App) LoadEnvironmentJobs(tenant, environment string) ([]uiEnvironmentJob, error) {
+	tenant = strings.TrimSpace(tenant)
+	environment = strings.TrimSpace(environment)
+	if tenant == "" || environment == "" {
+		return nil, fmt.Errorf("tenant and environment are required")
+	}
+	jobs, err := eruncommon.LoadEnvironmentJobs(tenant, environment, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	out := make([]uiEnvironmentJob, 0, len(jobs))
+	for _, job := range jobs {
+		out = append(out, environmentJobToUI(job))
+	}
+	return out, nil
+}
+
+// ReadEnvironmentJobOutput returns one page of a job's captured output.
+func (a *App) ReadEnvironmentJobOutput(input uiJobOutputInput) (uiEnvironmentJobOutput, error) {
+	tenant := strings.TrimSpace(input.Tenant)
+	environment := strings.TrimSpace(input.Environment)
+	id := strings.TrimSpace(input.ID)
+	if tenant == "" || environment == "" || id == "" {
+		return uiEnvironmentJobOutput{}, fmt.Errorf("tenant, environment, and job id are required")
+	}
+	maxBytes := input.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultJobOutputPageBytes
+	}
+	page, err := eruncommon.ReadEnvironmentJobOutput(eruncommon.ReadEnvironmentJobOutputParams{
+		Tenant:      tenant,
+		Environment: environment,
+		ID:          id,
+		Offset:      input.Offset,
+		MaxBytes:    maxBytes,
+	})
+	if err != nil {
+		return uiEnvironmentJobOutput{}, err
+	}
+	return uiEnvironmentJobOutput{
+		Job:        environmentJobToUI(page.Job),
+		Offset:     page.Offset,
+		NextOffset: page.NextOffset,
+		Output:     page.Output,
+		HasMore:    page.HasMore,
+		Complete:   page.Complete,
+	}, nil
+}
+
+// CancelEnvironmentJob signals a running job's work. The supervisor is left
+// alone so it survives to record the outcome, which is why a cancelled job
+// still reads back as a normal exited job rather than vanishing.
+func (a *App) CancelEnvironmentJob(input uiCancelJobInput) (uiEnvironmentJob, error) {
+	tenant := strings.TrimSpace(input.Tenant)
+	environment := strings.TrimSpace(input.Environment)
+	id := strings.TrimSpace(input.ID)
+	if tenant == "" || environment == "" || id == "" {
+		return uiEnvironmentJob{}, fmt.Errorf("tenant, environment, and job id are required")
+	}
+	result, err := eruncommon.CancelEnvironmentJob(eruncommon.Context{}, eruncommon.CancelEnvironmentJobParams{
+		Tenant:      tenant,
+		Environment: environment,
+		ID:          id,
+		Signal:      strings.TrimSpace(input.Signal),
+	})
+	if err != nil {
+		return uiEnvironmentJob{}, err
+	}
+	return environmentJobToUI(result.Job), nil
+}
+
+// defaultJobOutputPageBytes is one screenful and then some, so the first read
+// of a finished job is usually its whole output.
+const defaultJobOutputPageBytes = 65536
+
+func environmentJobToUI(job eruncommon.EnvironmentJob) uiEnvironmentJob {
+	out := uiEnvironmentJob{
+		ID:        job.ID,
+		Name:      job.Name,
+		State:     job.State,
+		Kind:      job.Kind,
+		AgentTool: job.AgentTool,
+		Command:   job.Command,
+		Dir:       job.Dir,
+		ExitCode:  job.ExitCode,
+	}
+	if !job.StartedAt.IsZero() {
+		out.StartedAtUnix = job.StartedAt.Unix()
+	}
+	if !job.EndedAt.IsZero() {
+		out.EndedAtUnix = job.EndedAt.Unix()
+	}
+	if job.Progress != nil {
+		out.Progress = &uiEnvironmentJobProgress{
+			Activity:    job.Progress.Activity,
+			LastMessage: job.Progress.LastMessage,
+			Turns:       job.Progress.Turns,
+			ToolsRun:    job.Progress.ToolsRun,
+		}
+	}
+	return out
+}

--- a/erun-ui/environment_jobs_mcp.go
+++ b/erun-ui/environment_jobs_mcp.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// loadEnvironmentJobsFromMCP lists an environment's retained jobs from its own
+// pod, the only place a remote-agent/runtime env's jobs actually run. Reads
+// are idle-probed so watching the Jobs tab never holds an otherwise-idle env
+// awake.
+func loadEnvironmentJobsFromMCP(ctx context.Context, endpoint, bearer string) ([]eruncommon.EnvironmentJob, error) {
+	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
+	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, true), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = session.Close()
+	}()
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "job_status"})
+	if err != nil {
+		return nil, formatJobMCPError("job_status", err)
+	}
+
+	data, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Jobs []eruncommon.EnvironmentJob `json:"jobs"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, err
+	}
+	if payload.Jobs == nil {
+		return []eruncommon.EnvironmentJob{}, nil
+	}
+	return payload.Jobs, nil
+}
+
+// readEnvironmentJobOutputFromMCP pages through one job's captured output on
+// the pod that ran it.
+func readEnvironmentJobOutputFromMCP(ctx context.Context, endpoint, bearer string, params eruncommon.ReadEnvironmentJobOutputParams) (eruncommon.EnvironmentJobOutput, error) {
+	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
+	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, true), nil)
+	if err != nil {
+		return eruncommon.EnvironmentJobOutput{}, err
+	}
+	defer func() {
+		_ = session.Close()
+	}()
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "job_output",
+		Arguments: map[string]any{
+			"id":       params.ID,
+			"offset":   params.Offset,
+			"maxBytes": params.MaxBytes,
+		},
+	})
+	if err != nil {
+		return eruncommon.EnvironmentJobOutput{}, formatJobMCPError("job_output", err)
+	}
+
+	data, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		return eruncommon.EnvironmentJobOutput{}, err
+	}
+	var output eruncommon.EnvironmentJobOutput
+	if err := json.Unmarshal(data, &output); err != nil {
+		return eruncommon.EnvironmentJobOutput{}, err
+	}
+	return output, nil
+}
+
+// cancelEnvironmentJobFromMCP signals the job's work on the pod that runs it.
+// Not idle-probed: cancelling a job is a real action, not a diagnostic read.
+func cancelEnvironmentJobFromMCP(ctx context.Context, endpoint, bearer string, params eruncommon.CancelEnvironmentJobParams) (eruncommon.CancelEnvironmentJobResult, error) {
+	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
+	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, false), nil)
+	if err != nil {
+		return eruncommon.CancelEnvironmentJobResult{}, err
+	}
+	defer func() {
+		_ = session.Close()
+	}()
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "job_cancel",
+		Arguments: map[string]any{
+			"id":     params.ID,
+			"signal": params.Signal,
+		},
+	})
+	if err != nil {
+		return eruncommon.CancelEnvironmentJobResult{}, formatJobMCPError("job_cancel", err)
+	}
+
+	data, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		return eruncommon.CancelEnvironmentJobResult{}, err
+	}
+	var payload struct {
+		Cancel eruncommon.CancelEnvironmentJobResult `json:"cancel"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return eruncommon.CancelEnvironmentJobResult{}, err
+	}
+	return payload.Cancel, nil
+}
+
+// formatJobMCPError translates the "runtime image predates the job_* MCP
+// tools" failure into one user-facing line pointing at the fix, mirroring
+// formatIdleStopMCPError. Any other error passes through raw so a real
+// cluster-side failure still reaches the user.
+func formatJobMCPError(tool string, err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "method not found"),
+		strings.Contains(lower, "unknown method"),
+		strings.Contains(lower, "unknown tool"),
+		strings.Contains(lower, "tool not found"),
+		strings.Contains(lower, "-32601"),
+		strings.Contains(lower, "no such tool"):
+		return fmt.Errorf(
+			"%s: this environment's runtime image is too old to list jobs. "+
+				"Rebuild and redeploy the env (erun deploy <tenant> <env>) so the pod runs "+
+				"a runtime image that includes the job_* MCP tools",
+			tool,
+		)
+	}
+	return fmt.Errorf("%s: %s", tool, msg)
+}

--- a/erun-ui/environment_jobs_test.go
+++ b/erun-ui/environment_jobs_test.go
@@ -1,12 +1,146 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/adrg/xdg"
 	eruncommon "github.com/sophium/erun/erun-common"
 )
+
+// isolateJobsCache points the job store at a temp dir for one test, so a test
+// job never lands in the operator's real activity cache. t.Setenv alone is
+// not enough: the xdg package resolves XDG_CACHE_HOME once at package init,
+// before any test runs, so a later change needs an explicit Reload.
+func isolateJobsCache(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	xdg.Reload()
+	t.Cleanup(xdg.Reload)
+}
+
+// jobsTestStore resolves one tenant/env so eruncommon.ResolveOpen succeeds; the
+// exact port only needs to be deterministic, not any particular value.
+func jobsTestStore(t *testing.T) stubUIStore {
+	t.Helper()
+	return stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"erun": {Name: "erun", DefaultEnvironment: "ux"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"erun/ux": {
+				Name:              "ux",
+				LocalRepoPath:     t.TempDir(),
+				KubernetesContext: "orbstack",
+			},
+		},
+	}
+}
+
+// TestLoadEnvironmentJobsReadsThroughAReachablePodEdge is the regression test
+// for the desktop reading only its own host's job store: a remote-agent
+// environment's jobs run in its pod, so when the pod is reachable the job the
+// pod itself reports must be what the Jobs tab sees, not an empty local
+// directory that has nothing to do with that pod. Before the fix this failed
+// because LoadEnvironmentJobs never consulted the MCP edge at all -- it always
+// read the (here, empty) local store and returned no jobs.
+func TestLoadEnvironmentJobsReadsThroughAReachablePodEdge(t *testing.T) {
+	isolateJobsCache(t)
+	var gotEndpoint string
+	app := NewApp(erunUIDeps{
+		store: jobsTestStore(t),
+		canReachMCPEndpoint: func(int) bool {
+			return true
+		},
+		loadEnvironmentJobs: func(_ context.Context, endpoint, _ string) ([]eruncommon.EnvironmentJob, error) {
+			gotEndpoint = endpoint
+			return []eruncommon.EnvironmentJob{
+				{ID: "finish-1350", Name: "Finish #1350 desktop jobs surface", State: eruncommon.EnvironmentJobStateRunning},
+			}, nil
+		},
+	})
+
+	jobs, err := app.LoadEnvironmentJobs("erun", "ux")
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJobs failed: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ID != "finish-1350" {
+		t.Fatalf("expected the pod's own job to be reported, got %+v", jobs)
+	}
+	if gotEndpoint == "" {
+		t.Fatalf("expected the pod-backed reader to be used")
+	}
+}
+
+// TestLoadEnvironmentJobsReportsStaleForwardInsteadOfEmpty is the sibling
+// regression: a stale port-forward (something holds the port, the edge never
+// answers) means a pod may well be running jobs that cannot currently be
+// asked about. Silently falling back to the (here, empty) local store would
+// render the same "No jobs yet" the operator cannot distinguish from a
+// genuinely idle environment, so this must surface as an unreachable error
+// instead.
+func TestLoadEnvironmentJobsReportsStaleForwardInsteadOfEmpty(t *testing.T) {
+	isolateJobsCache(t)
+	app := NewApp(erunUIDeps{
+		store: jobsTestStore(t),
+		canReachMCPEndpoint: func(int) bool {
+			return false
+		},
+		canConnectLocalPort: func(int) bool {
+			return true
+		},
+	})
+
+	jobs, err := app.LoadEnvironmentJobs("erun", "ux")
+	if err == nil {
+		t.Fatalf("expected an unreachable error for a stale forward, got jobs=%+v", jobs)
+	}
+	if !errors.Is(err, errMCPUnreachable) {
+		t.Fatalf("expected errMCPUnreachable, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "ERUN_MCP_UNREACHABLE_STALE: ") {
+		t.Fatalf("expected the stale-forward reachability marker, got %v", err)
+	}
+}
+
+// TestLoadEnvironmentJobsFallsBackToLocalWhenNotOpen preserves the case the
+// fix must not break: an environment nobody has opened has no pod running, so
+// the local store -- where the desktop's own Investigate job for that
+// environment is recorded, regardless of the environment's type -- is the
+// real (not a consolation) answer.
+func TestLoadEnvironmentJobsFallsBackToLocalWhenNotOpen(t *testing.T) {
+	isolateJobsCache(t)
+	if _, err := eruncommon.AttachEnvironmentJob(eruncommon.Context{}, eruncommon.AttachEnvironmentJobParams{
+		Tenant:      "erun",
+		Environment: "ux",
+		Name:        "Investigate ux",
+		PID:         os.Getpid(),
+	}); err != nil {
+		t.Fatalf("attach investigate job: %v", err)
+	}
+
+	app := NewApp(erunUIDeps{
+		store: jobsTestStore(t),
+		canReachMCPEndpoint: func(int) bool {
+			return false
+		},
+		canConnectLocalPort: func(int) bool {
+			return false
+		},
+	})
+
+	jobs, err := app.LoadEnvironmentJobs("erun", "ux")
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJobs failed: %v", err)
+	}
+	if len(jobs) != 1 || !strings.Contains(jobs[0].Name, "Investigate") {
+		t.Fatalf("expected the host-recorded investigate job to survive the fallback, got %+v", jobs)
+	}
+}
 
 // A missing outcome must never be readable as a successful zero, and an agent
 // that has not emitted must never render a made-up progress row.

--- a/erun-ui/environment_jobs_test.go
+++ b/erun-ui/environment_jobs_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// A missing outcome must never be readable as a successful zero, and an agent
+// that has not emitted must never render a made-up progress row.
+func TestJobToUIKeepsAbsentOutcomesAbsent(t *testing.T) {
+	running := environmentJobToUI(eruncommon.EnvironmentJob{
+		ID: "j1", Name: "build", State: "running", Kind: "command",
+		StartedAt: time.Unix(1700000000, 0),
+	})
+	if running.ExitCode != nil {
+		t.Fatalf("a running job has no exit code, got %v", *running.ExitCode)
+	}
+	if running.Progress != nil {
+		t.Fatal("a command job has no agent progress")
+	}
+	if running.EndedAtUnix != 0 {
+		t.Fatalf("a running job has not ended, got %d", running.EndedAtUnix)
+	}
+	if running.StartedAtUnix != 1700000000 {
+		t.Fatalf("start time: got %d", running.StartedAtUnix)
+	}
+
+	code := 0
+	exited := environmentJobToUI(eruncommon.EnvironmentJob{
+		ID: "j2", State: "exited", ExitCode: &code,
+		StartedAt: time.Unix(1700000000, 0), EndedAt: time.Unix(1700000042, 0),
+	})
+	if exited.ExitCode == nil || *exited.ExitCode != 0 {
+		t.Fatalf("a real zero exit must survive, got %v", exited.ExitCode)
+	}
+	if exited.EndedAtUnix != 1700000042 {
+		t.Fatalf("end time: got %d", exited.EndedAtUnix)
+	}
+}
+
+func TestJobReadsRequireTheirIdentifiers(t *testing.T) {
+	app := &App{}
+	if _, err := app.LoadEnvironmentJobs(" ", "build"); err == nil ||
+		!strings.Contains(err.Error(), "tenant and environment are required") {
+		t.Fatalf("blank tenant: %v", err)
+	}
+	if _, err := app.ReadEnvironmentJobOutput(uiJobOutputInput{Tenant: "t", Environment: "e"}); err == nil ||
+		!strings.Contains(err.Error(), "job id are required") {
+		t.Fatalf("blank job id: %v", err)
+	}
+	if _, err := app.CancelEnvironmentJob(uiCancelJobInput{Tenant: "t", Environment: "e"}); err == nil {
+		t.Fatal("cancel without a job id must be refused")
+	}
+}

--- a/erun-ui/frontend/src/app/manageDialogHelpers.ts
+++ b/erun-ui/frontend/src/app/manageDialogHelpers.ts
@@ -121,44 +121,48 @@ export function manageDialogTabHasUnsavedChanges(
   }
   const compare = (...keys: (keyof UIEnvironmentConfig)[]): boolean =>
     keys.some((key) => JSON.stringify(config[key]) !== JSON.stringify(initial[key]));
-  switch (tab) {
-    case 'general':
-      return compare(
-        'localRepoPath',
-        'containerRegistries',
-        'cloudProviderAlias',
-        'cloudAliasSlots',
-        'remoteHostCredentials',
-        'type',
-      );
-    case 'runtime':
-      return compare(
-        'runtimePod',
-        'idle',
-        'autoStart',
-        'autoUpgrade',
-        'upgradeChannel',
-        'disableBuildScript',
-        'runtimeChart',
-        'platformAccount',
-        'mountSource',
-        'repoURL',
-      );
-    case 'ai':
-      return compare('claude');
-    case 'ports':
-      return false;
-    case 'ssh':
-      return (
-        JSON.stringify(config.sshd.workspaceSyncEnabled) !==
-          JSON.stringify(initial.sshd.workspaceSyncEnabled) ||
-        JSON.stringify(config.sshd.workspaceSyncLocalPath) !==
-          JSON.stringify(initial.sshd.workspaceSyncLocalPath)
-      );
-    case 'history':
-      // History is read-only — no edits, no save, never dirty.
-      return false;
-    case 'delete':
-      return false;
+  // A table rather than a switch: every tab that edits config names the keys it
+  // owns, and a tab absent from the table is read-only by construction. Adding a
+  // tab is then a data change, not another branch.
+  const editedKeys: Partial<Record<ManageTab, (keyof UIEnvironmentConfig)[]>> = {
+    general: [
+      'localRepoPath',
+      'containerRegistries',
+      'runtimeRegistry',
+      'imagePullSecrets',
+      'cloudProviderAlias',
+      'cloudAliasSlots',
+      'remoteHostCredentials',
+      'type',
+    ],
+    runtime: [
+      'runtimePod',
+      'idle',
+      'autoStart',
+      'autoUpgrade',
+      'upgradeChannel',
+      'disableBuildScript',
+      'runtimeChart',
+      'platformAccount',
+      'mountSource',
+      'repoURL',
+    ],
+    ai: ['claude'],
+    // Only the two workspace-sync values are editable here; the rest of the SSH
+    // section is applied by its own actions rather than the dialog's Save.
+    ssh: ['sshd'],
+  };
+  const keys = editedKeys[tab];
+  if (!keys) {
+    return false;
   }
+  if (tab === 'ssh') {
+    return (
+      JSON.stringify(config.sshd.workspaceSyncEnabled) !==
+        JSON.stringify(initial.sshd.workspaceSyncEnabled) ||
+      JSON.stringify(config.sshd.workspaceSyncLocalPath) !==
+        JSON.stringify(initial.sshd.workspaceSyncLocalPath)
+    );
+  }
+  return compare(...keys);
 }

--- a/erun-ui/frontend/src/app/reconnectCopy.ts
+++ b/erun-ui/frontend/src/app/reconnectCopy.ts
@@ -17,7 +17,9 @@ const MCP_UNREACHABLE_MARKERS: Record<ReachabilityKind, string> = {
 };
 
 interface ReachabilityCopy {
-  // DiffErrorAlert / ChangedFilesAside status card.
+  // DiffErrorAlert / ChangedFilesAside / JobsTab status card. Kept
+  // surface-neutral (no "diff", no "jobs") so it reads correctly wherever a
+  // consumer shows it verbatim.
   errorTitle: string;
   errorBody: string;
   action: string;
@@ -30,12 +32,12 @@ interface ReachabilityCopy {
   errorStatusTitle: string;
 }
 
-// staleForward keeps the original #1178 copy verbatim: this is the genuine
-// fault case, and "Cannot reach the environment runtime" / "Reconnect…" was
-// never wrong for it.
+// staleForward is the genuine fault case: the port is held but the edge
+// never answers. "Cannot reach the environment runtime" / "Reconnect…" holds
+// regardless of which surface (diff, jobs) triggered the read.
 const STALE_FORWARD_COPY: ReachabilityCopy = {
   errorTitle: 'Cannot reach the environment runtime',
-  errorBody: 'The diff could not be loaded because the connection to your environment is down.',
+  errorBody: 'The connection to your environment is down.',
   action: 'Reconnect…',
   dialogTitle: 'Reconnect to environment?',
   dialogBody:
@@ -51,7 +53,7 @@ const STALE_FORWARD_COPY: ReachabilityCopy = {
 // probe never actually checked (#1230).
 const NOT_OPEN_COPY: ReachabilityCopy = {
   errorTitle: 'Environment not running',
-  errorBody: 'This environment is stopped — start it to review this diff.',
+  errorBody: 'This environment is stopped — open it to continue.',
   action: 'Open',
   dialogTitle: 'Open environment?',
   dialogBody: 'This runs `erun open` to start the environment.',

--- a/erun-ui/frontend/src/components/app/AIOccupancyBanner.tsx
+++ b/erun-ui/frontend/src/components/app/AIOccupancyBanner.tsx
@@ -1,10 +1,13 @@
+import { Button } from 'erun-kit';
 import { UserRound } from 'lucide-react';
 import * as React from 'react';
 
-import type { UIEnvironmentLease } from '@/types';
+import type { UIEnvironmentLease, UISelection } from '@/types';
 
 interface AIOccupancyBannerProps {
   leases: UIEnvironmentLease[];
+  selection: UISelection | null;
+  onShowJobs?: () => void;
 }
 
 // AIOccupancyBanner is the "while in the tab" half of erun#1221: a persistent,
@@ -12,8 +15,16 @@ interface AIOccupancyBannerProps {
 // working in this environment while the operator's own AI tab is open.
 // Visually mirrors ActivityLockOverlay so a comparable "something else is
 // happening here" condition reads the same way across the terminal pane.
-export function AIOccupancyBanner({ leases }: AIOccupancyBannerProps): React.ReactElement {
+export function AIOccupancyBanner({
+  leases,
+  selection,
+  onShowJobs,
+}: AIOccupancyBannerProps): React.ReactElement {
   const names = leases.map((lease) => lease.name).join(', ');
+  // Only a lease a job holds can be acted on; anything else has no job behind
+  // it to stop, so the banner names the occupancy and offers nothing it cannot
+  // deliver.
+  const cancellable = leases.filter((lease) => !!lease.jobId);
   return (
     <div
       className="pointer-events-none absolute top-3 right-3 z-10 flex max-w-[min(360px,calc(100%_-_1.5rem))] flex-col items-end gap-1"
@@ -29,6 +40,19 @@ export function AIOccupancyBanner({ leases }: AIOccupancyBannerProps): React.Rea
           <span className="font-medium text-foreground">{names}</span> is also running in this
           environment and competing for the same pod resources.
         </p>
+        {selection && cancellable.length > 0 && onShowJobs && (
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onShowJobs}
+              aria-label={`Show the jobs running in ${selection.environment}`}
+            >
+              View jobs
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/erun-ui/frontend/src/components/app/ManageDialogJobCancel.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogJobCancel.tsx
@@ -1,0 +1,103 @@
+import { Button } from 'erun-kit';
+import { LoaderCircle } from 'lucide-react';
+import * as React from 'react';
+
+import { readError } from '@/app/errors';
+import { InlineAlert } from '@/components/app/InlineAlert';
+import type { JobView } from '@/components/app/ManageDialogJobs.helpers';
+import type { UISelection } from '@/types';
+
+import { CancelEnvironmentJob } from '../../../wailsjs/go/main/App';
+
+// Cancelling is destructive to work in flight, so it takes a deliberate second
+// press rather than a single click, and the confirm step says what will happen
+// to the job record -- it stays listed with its outcome instead of vanishing,
+// which is the part an operator cannot guess.
+//
+// The label is "Cancel job", not "Cancel": the dialog's own footer already has a
+// Cancel that closes it, and two buttons reading the same word while meaning
+// opposite things is ambiguous to anyone scanning and to a screen reader
+// listing the buttons.
+export function JobCancelAction({
+  job,
+  selection,
+  onCancelled,
+}: {
+  job: JobView;
+  selection: UISelection;
+  onCancelled: () => void;
+}): React.ReactElement | null {
+  const [confirming, setConfirming] = React.useState(false);
+  const [cancelling, setCancelling] = React.useState(false);
+  const [error, setError] = React.useState('');
+  const label = job.name || job.id;
+
+  if (job.state !== 'running') {
+    return null;
+  }
+
+  const cancel = (): void => {
+    setCancelling(true);
+    setError('');
+    CancelEnvironmentJob({
+      tenant: selection.tenant,
+      environment: selection.environment,
+      id: job.id,
+      signal: 'TERM',
+    })
+      .then(() => {
+        setConfirming(false);
+        onCancelled();
+      })
+      .catch((err: unknown) => {
+        setError(readError(err));
+      })
+      .finally(() => {
+        setCancelling(false);
+      });
+  };
+
+  if (!confirming) {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          setConfirming(true);
+        }}
+        aria-label={`Cancel job ${label}`}
+      >
+        Cancel job
+      </Button>
+    );
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="destructive"
+        size="sm"
+        disabled={cancelling}
+        onClick={cancel}
+        aria-label={`Confirm cancelling ${label}`}
+      >
+        {cancelling && <LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />}
+        Confirm cancel
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        disabled={cancelling}
+        onClick={() => {
+          setConfirming(false);
+        }}
+      >
+        Keep running
+      </Button>
+      {error && <InlineAlert>{error}</InlineAlert>}
+    </>
+  );
+}

--- a/erun-ui/frontend/src/components/app/ManageDialogJobOutput.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogJobOutput.tsx
@@ -1,0 +1,104 @@
+import { Button } from 'erun-kit';
+import * as React from 'react';
+
+import { readError } from '@/app/errors';
+import { InlineAlert } from '@/components/app/InlineAlert';
+import type { JobView } from '@/components/app/ManageDialogJobs.helpers';
+import type { UISelection } from '@/types';
+
+import { ReadEnvironmentJobOutput } from '../../../wailsjs/go/main/App';
+
+// Output is read a page at a time and continued from the offset the previous
+// read returned, so a long-running job's log does not have to be held whole in
+// memory to be readable, and a second read continues rather than repeats.
+export function JobOutputView({
+  job,
+  selection,
+}: {
+  job: JobView;
+  selection: UISelection;
+}): React.ReactElement {
+  const [text, setText] = React.useState('');
+  const [nextOffset, setNextOffset] = React.useState(0);
+  const [hasMore, setHasMore] = React.useState(false);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState('');
+  const [loaded, setLoaded] = React.useState(false);
+
+  const read = React.useCallback(
+    (offset: number) => {
+      setLoading(true);
+      setError('');
+      ReadEnvironmentJobOutput({
+        tenant: selection.tenant,
+        environment: selection.environment,
+        id: job.id,
+        offset,
+        maxBytes: 0,
+      })
+        .then((page) => {
+          setText((previous) => (offset === 0 ? page.output : previous + page.output));
+          setNextOffset(page.nextOffset);
+          setHasMore(page.hasMore);
+          setLoaded(true);
+        })
+        .catch((err: unknown) => {
+          setError(readError(err));
+        })
+        .finally(() => {
+          setLoading(false);
+        });
+    },
+    [job.id, selection],
+  );
+
+  React.useEffect(() => {
+    read(0);
+  }, [read]);
+
+  if (error) {
+    return <InlineAlert>Could not read this job&apos;s output. {error}</InlineAlert>;
+  }
+  if (!loaded && loading) {
+    return (
+      <p className="text-[12px] text-muted-foreground" data-testid="manage-jobs-output-loading">
+        Reading output…
+      </p>
+    );
+  }
+  if (loaded && text === '') {
+    // Distinct from "not read yet" and from an error: the job genuinely printed
+    // nothing, which for a quiet successful job is the expected case.
+    return (
+      <p className="text-[12px] text-muted-foreground" data-testid="manage-jobs-output-empty">
+        This job produced no output.
+      </p>
+    );
+  }
+  return (
+    <div className="grid gap-1.5">
+      <pre
+        className="max-h-64 overflow-auto rounded-[var(--radius)] border border-border bg-muted/40 px-2.5 py-2 font-mono text-[12px] leading-[1.45] whitespace-pre-wrap [overflow-wrap:anywhere]"
+        data-testid="manage-jobs-output"
+      >
+        {text}
+      </pre>
+      {hasMore && (
+        <div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={loading}
+            onClick={() => {
+              read(nextOffset);
+            }}
+            aria-label={`Read more output for ${job.name || job.id}`}
+          >
+            {loading ? 'Reading…' : 'Read more'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/erun-ui/frontend/src/components/app/ManageDialogJobs.helpers.ts
+++ b/erun-ui/frontend/src/components/app/ManageDialogJobs.helpers.ts
@@ -1,0 +1,89 @@
+// The generated Wails model types exitCode as a plain number because Go's
+// *int maps to one, but the wire value is null for every job without an
+// outcome. This is the shape the helpers actually receive.
+export interface JobView {
+  id: string;
+  name: string;
+  state: string;
+  command?: string[];
+  dir?: string;
+  exitCode: number | null;
+  startedAtUnix?: number;
+  endedAtUnix?: number;
+  progress?: { activity?: string };
+}
+
+// How a job's outcome reads to an operator. A job that is gone without an
+// outcome is its own case: reporting it as success would be a lie, and
+// reporting it as failure would blame work that may well have finished.
+export type JobOutcome = 'running' | 'succeeded' | 'failed' | 'signalled' | 'unknown';
+
+export function jobOutcome(job: JobView): JobOutcome {
+  if (job.state === 'running') {
+    return 'running';
+  }
+  if (job.state === 'unknown') {
+    return 'unknown';
+  }
+  if (job.exitCode === null) {
+    return 'unknown';
+  }
+  if (job.exitCode === 0) {
+    return 'succeeded';
+  }
+  // The supervisor records -1 when the work was terminated by a signal, which
+  // is what a cancel produces -- distinct from work that ran and failed.
+  return job.exitCode === -1 ? 'signalled' : 'failed';
+}
+
+export function jobOutcomeLabel(job: JobView): string {
+  switch (jobOutcome(job)) {
+    case 'running':
+      return 'Running';
+    case 'succeeded':
+      return 'Succeeded';
+    case 'signalled':
+      return 'Cancelled';
+    case 'failed':
+      return `Failed (exit ${String(job.exitCode)})`;
+    default:
+      return 'Outcome unknown';
+  }
+}
+
+// A duration, not a formatted instant: what the operator wants to know about a
+// job is how long it has been going or how long it took.
+export function jobDurationLabel(job: JobView, nowUnix: number): string {
+  if (!job.startedAtUnix) {
+    return '';
+  }
+  const end = job.endedAtUnix ?? 0;
+  const seconds = Math.max(0, (end > 0 ? end : nowUnix) - job.startedAtUnix);
+  return formatDuration(seconds);
+}
+
+export function formatDuration(seconds: number): string {
+  if (seconds < 60) {
+    return `${String(seconds)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    const rest = seconds % 60;
+    return rest === 0 ? `${String(minutes)}m` : `${String(minutes)}m${String(rest)}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const restMinutes = minutes % 60;
+  return restMinutes === 0 ? `${String(hours)}h` : `${String(hours)}h${String(restMinutes)}m`;
+}
+
+// What the row shows as the job's own description. An agent job's current
+// activity is more useful than its argv, which is always the same tool.
+export function jobDetailLine(job: JobView): string {
+  if (job.progress?.activity) {
+    return job.progress.activity;
+  }
+  if (job.command && job.command.length > 0) {
+    return job.command.join(' ');
+  }
+  return job.dir ?? '';
+}

--- a/erun-ui/frontend/src/components/app/ManageDialogJobs.helpers.ts
+++ b/erun-ui/frontend/src/components/app/ManageDialogJobs.helpers.ts
@@ -5,12 +5,14 @@ export interface JobView {
   id: string;
   name: string;
   state: string;
+  kind?: string;
+  agentTool?: string;
   command?: string[];
   dir?: string;
   exitCode: number | null;
   startedAtUnix?: number;
   endedAtUnix?: number;
-  progress?: { activity?: string };
+  progress?: { activity?: string; lastMessage?: string; turns: number; toolsRun: number };
 }
 
 // How a job's outcome reads to an operator. A job that is gone without an
@@ -76,9 +78,35 @@ export function formatDuration(seconds: number): string {
   return restMinutes === 0 ? `${String(hours)}h` : `${String(hours)}h${String(restMinutes)}m`;
 }
 
-// What the row shows as the job's own description. An agent job's current
-// activity is more useful than its argv, which is always the same tool.
+function agentToolLabel(tool: string | undefined): string {
+  if (tool === 'claude') {
+    return 'Claude';
+  }
+  if (tool === 'codex') {
+    return 'Codex';
+  }
+  return 'Agent';
+}
+
+// An agent job's argv is always the same tool invocation carrying the whole
+// prompt as an argument, so it is never shown -- the operator-readable answer
+// is what the agent is doing (its current activity, or its last reported
+// message), falling back to naming the tool when neither has arrived yet.
+function agentJobDetailLine(job: JobView): string {
+  if (job.progress?.activity) {
+    return job.progress.activity;
+  }
+  if (job.progress?.lastMessage) {
+    return job.progress.lastMessage;
+  }
+  return `${agentToolLabel(job.agentTool)} agent`;
+}
+
+// What the row shows as the job's own description.
 export function jobDetailLine(job: JobView): string {
+  if (job.kind === 'agent') {
+    return agentJobDetailLine(job);
+  }
   if (job.progress?.activity) {
     return job.progress.activity;
   }

--- a/erun-ui/frontend/src/components/app/ManageDialogJobsTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogJobsTab.tsx
@@ -149,7 +149,7 @@ function OutcomeBadge({ job }: { job: JobView }): React.ReactElement {
   if (outcome === 'unknown') {
     return (
       <span
-        className={`${shared} text-amber-600 dark:text-amber-400`}
+        className={`${shared} text-amber-700 dark:text-amber-400`}
         data-testid="manage-jobs-row-outcome"
       >
         <AlertTriangle className="size-3.5" aria-hidden="true" />

--- a/erun-ui/frontend/src/components/app/ManageDialogJobsTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogJobsTab.tsx
@@ -1,8 +1,24 @@
 import { Button } from 'erun-kit';
-import { AlertTriangle, Ban, CheckCircle2, ListChecks, LoaderCircle, XCircle } from 'lucide-react';
+import {
+  AlertTriangle,
+  Ban,
+  CheckCircle2,
+  ListChecks,
+  LoaderCircle,
+  PlugZap,
+  XCircle,
+} from 'lucide-react';
 import * as React from 'react';
 
 import { readError } from '@/app/errors';
+import { useAppDispatch, useAppSelector } from '@/app/hooks';
+import {
+  mcpUnreachableKind,
+  reachabilityCopy,
+  type ReachabilityKind,
+  stripMcpUnreachableMarker,
+} from '@/app/reconnectCopy';
+import { requestReconnect } from '@/app/reviewThunks';
 import { InlineAlert } from '@/components/app/InlineAlert';
 import { JobCancelAction } from '@/components/app/ManageDialogJobCancel';
 import { JobOutputView } from '@/components/app/ManageDialogJobOutput';
@@ -30,6 +46,7 @@ export function JobsTab({
   const [jobs, setJobs] = React.useState<JobView[]>([]);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState('');
+  const [unreachable, setUnreachable] = React.useState<UnreachableJobsState | null>(null);
   const [nowUnix, setNowUnix] = React.useState(() => Math.floor(Date.now() / 1000));
 
   const reload = React.useCallback(() => {
@@ -38,13 +55,20 @@ export function JobsTab({
     }
     setLoading(true);
     setError('');
+    setUnreachable(null);
     LoadEnvironmentJobs(selection.tenant, selection.environment)
       .then((next) => {
         // The generated model claims a non-null exitCode; the wire sends null.
         setJobs(next as unknown as JobView[]);
       })
       .catch((err: unknown) => {
-        setError(readError(err));
+        const message = readError(err);
+        const kind = mcpUnreachableKind(message);
+        if (kind) {
+          setUnreachable({ kind, message: stripMcpUnreachableMarker(message) });
+        } else {
+          setError(message);
+        }
       })
       .finally(() => {
         setLoading(false);
@@ -80,6 +104,20 @@ export function JobsTab({
   if (loading && jobs.length === 0) {
     return <JobsEmptyState message="Loading jobs…" />;
   }
+  // Distinct from "no jobs yet": the pod that would answer is not reachable
+  // right now, so an empty list here would read as "nothing is running" when
+  // the truth is "cannot tell" -- a stopped environment's own jobs still read
+  // as empty above, since a stopped pod genuinely has none to miss.
+  if (unreachable) {
+    return (
+      <JobsUnreachableAlert
+        kind={unreachable.kind}
+        message={unreachable.message}
+        selection={selection}
+        onRetry={reload}
+      />
+    );
+  }
   if (error) {
     return <InlineAlert>Could not read this environment&apos;s jobs. {error}</InlineAlert>;
   }
@@ -96,6 +134,82 @@ export function JobsTab({
       {jobs.map((job) => (
         <JobRow key={job.id} job={job} selection={selection} nowUnix={nowUnix} onChanged={reload} />
       ))}
+    </div>
+  );
+}
+
+interface UnreachableJobsState {
+  kind: ReachabilityKind;
+  message: string;
+}
+
+// JobsUnreachableAlert names the same two reachability shapes the sidebar and
+// diff panel already distinguish (#1230): a stale port-forward is a fault
+// worth reconnecting, told apart from an environment nobody has opened. The
+// action reuses the shared reconnect flow (confirm dialog, then the same MCP
+// reconnect call) so recovering from here behaves exactly like recovering
+// from the diff panel.
+function JobsUnreachableAlert({
+  kind,
+  message,
+  selection,
+  onRetry,
+}: {
+  kind: UnreachableJobsState['kind'];
+  message: string;
+  selection: UISelection;
+  onRetry: () => void;
+}): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const reconnect = useAppSelector((state) => state.review.reconnect);
+  const wasRunningRef = React.useRef(false);
+  const copy = reachabilityCopy[kind];
+  const targetingThis =
+    reconnect.tenant === selection.tenant && reconnect.environment === selection.environment;
+
+  React.useEffect(() => {
+    if (targetingThis && reconnect.status === 'running') {
+      wasRunningRef.current = true;
+      return;
+    }
+    if (wasRunningRef.current && reconnect.status === 'idle') {
+      wasRunningRef.current = false;
+      onRetry();
+    }
+  }, [reconnect.status, targetingThis, onRetry]);
+
+  return (
+    <div
+      role="status"
+      className="flex flex-col gap-2 rounded-[var(--radius)] border border-border bg-muted/40 px-3 py-3 text-[13px]"
+      data-testid="manage-jobs-unreachable"
+    >
+      <div className="flex items-center gap-2 font-medium text-foreground">
+        <PlugZap className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        {copy.errorTitle}
+      </div>
+      <p className="text-muted-foreground">{copy.errorBody}</p>
+      {message && (
+        <p className="font-mono text-[12px] text-muted-foreground [overflow-wrap:anywhere]">
+          {message}
+        </p>
+      )}
+      <div className="flex justify-end gap-1.5">
+        <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+          Retry
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          data-testid="manage-jobs-unreachable-reconnect"
+          onClick={() => {
+            dispatch(requestReconnect(selection.tenant, selection.environment, kind));
+          }}
+        >
+          {copy.action}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/erun-ui/frontend/src/components/app/ManageDialogJobsTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogJobsTab.tsx
@@ -186,7 +186,7 @@ function JobRow({
       className="grid gap-1.5 rounded-[var(--radius)] border border-border bg-background px-3 py-2.5"
       data-testid="manage-jobs-row"
     >
-      <header className="flex items-baseline justify-between gap-3">
+      <header className="flex min-w-0 items-baseline justify-between gap-3">
         <span
           className="min-w-0 truncate text-[13px] font-medium text-foreground"
           data-testid="manage-jobs-row-name"

--- a/erun-ui/frontend/src/components/app/ManageDialogJobsTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogJobsTab.tsx
@@ -1,0 +1,237 @@
+import { Button } from 'erun-kit';
+import { AlertTriangle, Ban, CheckCircle2, ListChecks, LoaderCircle, XCircle } from 'lucide-react';
+import * as React from 'react';
+
+import { readError } from '@/app/errors';
+import { InlineAlert } from '@/components/app/InlineAlert';
+import { JobCancelAction } from '@/components/app/ManageDialogJobCancel';
+import { JobOutputView } from '@/components/app/ManageDialogJobOutput';
+import type { JobView } from '@/components/app/ManageDialogJobs.helpers';
+import {
+  jobDetailLine,
+  jobDurationLabel,
+  jobOutcome,
+  jobOutcomeLabel,
+} from '@/components/app/ManageDialogJobs.helpers';
+import type { UISelection } from '@/types';
+
+import { LoadEnvironmentJobs } from '../../../wailsjs/go/main/App';
+
+// The desktop already writes into the job store -- Investigate starts a job
+// there -- and could not show the job it had just created. This is the missing
+// lifecycle half: what ran, how it ended, what it printed, and a way to stop it.
+export function JobsTab({
+  selection,
+  open,
+}: {
+  selection: UISelection | null;
+  open: boolean;
+}): React.ReactElement {
+  const [jobs, setJobs] = React.useState<JobView[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState('');
+  const [nowUnix, setNowUnix] = React.useState(() => Math.floor(Date.now() / 1000));
+
+  const reload = React.useCallback(() => {
+    if (!selection) {
+      return;
+    }
+    setLoading(true);
+    setError('');
+    LoadEnvironmentJobs(selection.tenant, selection.environment)
+      .then((next) => {
+        // The generated model claims a non-null exitCode; the wire sends null.
+        setJobs(next as unknown as JobView[]);
+      })
+      .catch((err: unknown) => {
+        setError(readError(err));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [selection]);
+
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+    reload();
+  }, [open, reload]);
+
+  // A running job's duration would otherwise freeze at whatever it was when the
+  // tab opened. One tick a second, and only while the tab is open and something
+  // is actually running, so nothing animates on a closed dialog.
+  const hasRunning = jobs.some((job) => job.state === 'running');
+  React.useEffect(() => {
+    if (!open || !hasRunning) {
+      return;
+    }
+    const timer = setInterval(() => {
+      setNowUnix(Math.floor(Date.now() / 1000));
+    }, 1000);
+    return () => {
+      clearInterval(timer);
+    };
+  }, [open, hasRunning]);
+
+  if (!selection) {
+    return <JobsEmptyState message="Select an environment to see its jobs." />;
+  }
+  if (loading && jobs.length === 0) {
+    return <JobsEmptyState message="Loading jobs…" />;
+  }
+  if (error) {
+    return <InlineAlert>Could not read this environment&apos;s jobs. {error}</InlineAlert>;
+  }
+  if (jobs.length === 0) {
+    return (
+      <JobsEmptyState message="No jobs yet. Detached work — a build, a test run, an agent — is recorded here with its outcome and output, and stays readable for 24 hours after it ends." />
+    );
+  }
+  return (
+    <div className="flex flex-col gap-2" data-testid="manage-jobs-list">
+      <p className="text-[13px] text-muted-foreground">
+        {jobs.length === 1 ? '1 job' : `${String(jobs.length)} jobs`}, newest first.
+      </p>
+      {jobs.map((job) => (
+        <JobRow key={job.id} job={job} selection={selection} nowUnix={nowUnix} onChanged={reload} />
+      ))}
+    </div>
+  );
+}
+
+function JobsEmptyState({ message }: { message: string }): React.ReactElement {
+  return (
+    <div
+      className="flex items-center gap-3 rounded-[var(--radius)] border border-border bg-muted/40 px-3 py-3 text-[13px] text-muted-foreground"
+      data-testid="manage-jobs-empty"
+    >
+      <ListChecks className="size-4 shrink-0" aria-hidden="true" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+// Colour never carries the outcome on its own: each state has its own icon and
+// its own words, so the row reads the same to someone who cannot separate the
+// green from the red.
+function OutcomeBadge({ job }: { job: JobView }): React.ReactElement {
+  const outcome = jobOutcome(job);
+  const label = jobOutcomeLabel(job);
+  const shared = 'inline-flex items-center gap-1.5 text-[12px] font-medium';
+  if (outcome === 'running') {
+    return (
+      <span className={`${shared} text-foreground`} data-testid="manage-jobs-row-outcome">
+        <LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />
+        {label}
+      </span>
+    );
+  }
+  if (outcome === 'succeeded') {
+    return (
+      <span
+        className={`${shared} text-green-700 dark:text-green-400`}
+        data-testid="manage-jobs-row-outcome"
+      >
+        <CheckCircle2 className="size-3.5" aria-hidden="true" />
+        {label}
+      </span>
+    );
+  }
+  if (outcome === 'signalled') {
+    return (
+      <span className={`${shared} text-muted-foreground`} data-testid="manage-jobs-row-outcome">
+        <Ban className="size-3.5" aria-hidden="true" />
+        {label}
+      </span>
+    );
+  }
+  if (outcome === 'unknown') {
+    return (
+      <span
+        className={`${shared} text-amber-600 dark:text-amber-400`}
+        data-testid="manage-jobs-row-outcome"
+      >
+        <AlertTriangle className="size-3.5" aria-hidden="true" />
+        {label}
+      </span>
+    );
+  }
+  return (
+    <span className={`${shared} text-destructive`} data-testid="manage-jobs-row-outcome">
+      <XCircle className="size-3.5" aria-hidden="true" />
+      {label}
+    </span>
+  );
+}
+
+function JobRow({
+  job,
+  selection,
+  nowUnix,
+  onChanged,
+}: {
+  job: JobView;
+  selection: UISelection;
+  nowUnix: number;
+  onChanged: () => void;
+}): React.ReactElement {
+  const [showOutput, setShowOutput] = React.useState(false);
+  const duration = jobDurationLabel(job, nowUnix);
+  const detail = jobDetailLine(job);
+  const label = job.name || job.id;
+
+  return (
+    <article
+      className="grid gap-1.5 rounded-[var(--radius)] border border-border bg-background px-3 py-2.5"
+      data-testid="manage-jobs-row"
+    >
+      <header className="flex items-baseline justify-between gap-3">
+        <span
+          className="min-w-0 truncate text-[13px] font-medium text-foreground"
+          data-testid="manage-jobs-row-name"
+        >
+          {label}
+        </span>
+        <OutcomeBadge job={job} />
+      </header>
+      {detail && (
+        <div
+          className="text-[12px] leading-[1.4] text-muted-foreground [overflow-wrap:anywhere]"
+          data-testid="manage-jobs-row-detail"
+        >
+          {detail}
+        </div>
+      )}
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-[12px] text-muted-foreground" data-testid="manage-jobs-row-duration">
+          {jobTimingLabel(job.state, duration)}
+        </span>
+        <div className="flex items-center gap-1.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setShowOutput((shown) => !shown);
+            }}
+            aria-expanded={showOutput}
+            aria-label={`${showOutput ? 'Hide' : 'Show'} output for ${label}`}
+          >
+            {showOutput ? 'Hide output' : 'Show output'}
+          </Button>
+          <JobCancelAction job={job} selection={selection} onCancelled={onChanged} />
+        </div>
+      </div>
+      {showOutput && <JobOutputView job={job} selection={selection} />}
+    </article>
+  );
+}
+
+// Running work reads as elapsed; finished work reads as how long it took.
+function jobTimingLabel(state: string, duration: string): string {
+  if (!duration) {
+    return '';
+  }
+  return state === 'running' ? `Running for ${duration}` : `Took ${duration}`;
+}

--- a/erun-ui/frontend/src/components/app/ManageDialogJobsTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogJobsTab.tsx
@@ -311,8 +311,9 @@ function JobRow({
       </header>
       {detail && (
         <div
-          className="text-[12px] leading-[1.4] text-muted-foreground [overflow-wrap:anywhere]"
+          className="min-w-0 truncate text-[12px] leading-[1.4] text-muted-foreground"
           data-testid="manage-jobs-row-detail"
+          title={detail}
         >
           {detail}
         </div>

--- a/erun-ui/frontend/src/components/app/ManageDialogTabs.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogTabs.tsx
@@ -17,6 +17,7 @@ import { ClaudeSettingsSection } from '@/components/app/ManageDialogAITab';
 import { DeleteConfirmationFields } from '@/components/app/ManageDialogDeleteTab';
 import { GeneralTab } from '@/components/app/ManageDialogGeneralTab';
 import { HistoryTab } from '@/components/app/ManageDialogHistoryTab';
+import { JobsTab } from '@/components/app/ManageDialogJobsTab';
 import { PortsTab } from '@/components/app/ManageDialogPortsTab';
 import { RuntimeTab } from '@/components/app/ManageDialogRuntimeTab';
 import {
@@ -76,6 +77,7 @@ export function ManageDialogContent({
           <DirtyAwareTabsTrigger value="ai" label="AI" dialog={dialog} />
           <DirtyAwareTabsTrigger value="ports" label="Ports" dialog={dialog} />
           <DirtyAwareTabsTrigger value="ssh" label="Access" dialog={dialog} />
+          <DirtyAwareTabsTrigger value="jobs" label="Jobs" dialog={dialog} />
           <DirtyAwareTabsTrigger value="history" label="History" dialog={dialog} />
         </TabsList>
         <div className="-mx-1 min-h-0 flex-1 overflow-auto px-1 pb-1">
@@ -95,6 +97,9 @@ export function ManageDialogContent({
             <SSHAccessSection dialog={dialog} />
             <WorkspaceSyncSection dialog={dialog} />
             <DiagnosticsSection dialog={dialog} />
+          </TabsContent>
+          <TabsContent value="jobs" className="grid gap-3">
+            <JobsTab selection={dialog.selection} open={dialog.open && editTab === 'jobs'} />
           </TabsContent>
           <TabsContent value="history" className="grid gap-3">
             <HistoryTab selection={dialog.selection} open={dialog.open && editTab === 'history'} />

--- a/erun-ui/frontend/src/components/app/TerminalPane.tsx
+++ b/erun-ui/frontend/src/components/app/TerminalPane.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useTerminalActivityLockState } from '@/app/activityQueueState';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
 import { startReviewResize, stepReviewResize } from '@/app/layoutThunks';
+import { openManageDialog, setManageTab } from '@/app/manageDialogThunks';
 import { selectActiveTabIsAI } from '@/app/selectors';
 import { clearHiddenLockOverlay, hideLockOverlay } from '@/app/slices/terminalStatusSlice';
 import { computeMaxReviewWidth, MIN_REVIEW_WIDTH } from '@/app/state';
@@ -12,6 +13,7 @@ import { AIOccupancyBanner } from '@/components/app/AIOccupancyBanner';
 import { ReviewPanel } from '@/components/app/ReviewPanel';
 import { TerminalBusyOverlay } from '@/components/app/TerminalBusyOverlay';
 import { TerminalTabStrip } from '@/components/app/TerminalTabStrip';
+import type { UIEnvironmentLease, UISelection } from '@/types';
 
 const reviewSplitterClassName =
   'relative cursor-col-resize border-l bg-background before:absolute before:top-0 before:bottom-0 before:left-1 before:w-px before:bg-transparent before:transition-colors hover:before:bg-border [.is-resizing-review_&]:before:bg-border';
@@ -47,6 +49,9 @@ export function TerminalPane({
   const liveLock = locks.get(sessionId) ?? null;
   const activeTabIsAI = useAppSelector(selectActiveTabIsAI);
   const occupancyLeases = useAppSelector((state) => state.idle.idleStatus?.leases ?? []);
+  // The same selection the leases were loaded for, so the banner acts on the
+  // environment it is describing rather than whatever tab happens to be active.
+  const occupancySelection = useAppSelector((state) => state.selection.selected);
   // The user can dismiss the overlay locally for a session if it's
   // covering output they need to read or input they need to provide
   // (e.g. the in-pod CLI's helm-recovery prompt). Backend keeps the
@@ -96,7 +101,9 @@ export function TerminalPane({
             />
           ) : (
             activeTabIsAI &&
-            occupancyLeases.length > 0 && <AIOccupancyBanner leases={occupancyLeases} />
+            occupancyLeases.length > 0 && (
+              <OccupancyBanner leases={occupancyLeases} selection={occupancySelection} />
+            )
           )}
         </div>
       </div>
@@ -123,5 +130,31 @@ export function TerminalPane({
         diffListRef={diffListRef}
       />
     </div>
+  );
+}
+
+// The banner needs its own dispatch to route to the jobs surface, and keeping
+// it out of TerminalPane keeps that component within its line budget.
+function OccupancyBanner({
+  leases,
+  selection,
+}: {
+  leases: UIEnvironmentLease[];
+  selection: UISelection | null;
+}): React.ReactElement {
+  const dispatch = useAppDispatch();
+  return (
+    <AIOccupancyBanner
+      leases={leases}
+      selection={selection}
+      onShowJobs={
+        selection
+          ? () => {
+              dispatch(openManageDialog(selection));
+              dispatch(setManageTab('jobs'));
+            }
+          : undefined
+      }
+    />
   );
 }

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -90,7 +90,15 @@ export interface UITenant {
   environments: UIEnvironment[];
 }
 
-export type ManageTab = 'general' | 'runtime' | 'ai' | 'ports' | 'ssh' | 'history' | 'delete';
+export type ManageTab =
+  | 'general'
+  | 'runtime'
+  | 'ai'
+  | 'ports'
+  | 'ssh'
+  | 'jobs'
+  | 'history'
+  | 'delete';
 export type ManageEditTab = Exclude<ManageTab, 'delete'>;
 
 export interface UISelection {
@@ -653,3 +661,36 @@ export * from './diffTypes';
 
 // Review-detail types live in ./reviewTypes for the same reason.
 export * from './reviewTypes';
+
+// A retained job in an environment's job store. exitCode is null unless the job
+// reached exited, so a missing outcome is never read as a successful zero, and
+// progress is absent for a command job rather than a fabricated zero state.
+export interface UIEnvironmentJob {
+  id: string;
+  name: string;
+  state: string;
+  kind?: string;
+  agentTool?: string;
+  command?: string[];
+  dir?: string;
+  exitCode: number | null;
+  startedAtUnix?: number;
+  endedAtUnix?: number;
+  progress?: UIEnvironmentJobProgress;
+}
+
+export interface UIEnvironmentJobProgress {
+  activity?: string;
+  lastMessage?: string;
+  turns: number;
+  toolsRun: number;
+}
+
+export interface UIEnvironmentJobOutput {
+  job: UIEnvironmentJob;
+  offset: number;
+  nextOffset: number;
+  output: string;
+  hasMore: boolean;
+  complete: boolean;
+}

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -332,6 +332,9 @@ export interface UIIdleMarkerClient {
 export interface UIEnvironmentLease {
   name: string;
   secondsHeld?: number;
+  // Set only when a job holds the lease, so a surface that names the occupancy
+  // can also act on it. Absent for every other holder.
+  jobId?: string;
 }
 
 export interface UIVersionSuggestion {

--- a/erun-ui/go.mod
+++ b/erun-ui/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/ActiveState/termtest/conpty v0.5.0
+	github.com/adrg/xdg v0.5.3
 	github.com/creack/pty v1.1.21
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/uuid v1.6.0
@@ -15,7 +16,6 @@ require (
 require (
 	git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
-	github.com/adrg/xdg v0.5.3 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/coreos/go-oidc/v3 v3.18.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect

--- a/erun-ui/idle_status.go
+++ b/erun-ui/idle_status.go
@@ -122,6 +122,9 @@ func environmentLeasesToUI(leases []eruncommon.EnvironmentActivityLease, now tim
 	out := make([]uiEnvironmentLease, 0, len(leases))
 	for _, lease := range leases {
 		entry := uiEnvironmentLease{Name: strings.TrimSpace(lease.Name)}
+		if jobID, ok := eruncommon.EnvironmentJobIDFromLeaseID(lease.ID); ok {
+			entry.JobID = jobID
+		}
 		if !lease.StartedAt.IsZero() && now.After(lease.StartedAt) {
 			entry.SecondsHeld = int64(now.Sub(lease.StartedAt) / time.Second)
 		}

--- a/erun-ui/idle_status_job_lease_test.go
+++ b/erun-ui/idle_status_job_lease_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// The banner that names an occupancy can only offer to stop it if it knows
+// which job is behind the lease -- and must not offer that for a lease held by
+// anything else.
+func TestLeasesCarryTheirJobOnlyWhenAJobHoldsThem(t *testing.T) {
+	now := time.Unix(1700000100, 0)
+	out := environmentLeasesToUI([]eruncommon.EnvironmentActivityLease{
+		{ID: "job-gate-1", Name: "repo gate", StartedAt: time.Unix(1700000000, 0)},
+		{ID: "orchestrator-erun", Name: "erun", StartedAt: time.Unix(1700000000, 0)},
+	}, now)
+
+	if len(out) != 2 {
+		t.Fatalf("expected both leases, got %d", len(out))
+	}
+	if out[0].JobID != "gate-1" {
+		t.Fatalf("a job lease must name its job, got %q", out[0].JobID)
+	}
+	if out[1].JobID != "" {
+		t.Fatalf("a non-job lease must name no job, got %q", out[1].JobID)
+	}
+	if out[0].SecondsHeld != 100 {
+		t.Fatalf("held seconds: got %d", out[0].SecondsHeld)
+	}
+}

--- a/erun-ui/playwright/pages/ManageDialog.ts
+++ b/erun-ui/playwright/pages/ManageDialog.ts
@@ -281,7 +281,7 @@ export class ManageDialog {
   }
 
   async cancel(): Promise<void> {
-    const button = this.locator().getByRole('button', { name: 'Cancel' });
+    const button = this.locator().getByRole('button', { name: 'Cancel', exact: true });
     await button.scrollIntoViewIfNeeded();
     await button.click();
   }
@@ -300,6 +300,44 @@ export class ManageDialog {
   }
 
   // --- Container-registries editor (General tab) ---
+
+  // --- Jobs tab ---
+
+  jobsTabTrigger(): Locator {
+    return this.locator().getByRole('tab', { name: 'Jobs' });
+  }
+
+  jobsEmptyState(): Locator {
+    return this.locator().getByTestId('manage-jobs-empty');
+  }
+
+  jobRows(): Locator {
+    return this.locator().getByTestId('manage-jobs-row');
+  }
+
+  jobOutcome(index: number): Locator {
+    return this.locator().getByTestId('manage-jobs-row-outcome').nth(index);
+  }
+
+  jobShowOutputButton(name: string): Locator {
+    return this.locator().getByRole('button', { name: `Show output for ${name}` });
+  }
+
+  jobOutput(): Locator {
+    return this.locator().getByTestId('manage-jobs-output');
+  }
+
+  jobOutputEmpty(): Locator {
+    return this.locator().getByTestId('manage-jobs-output-empty');
+  }
+
+  jobCancelButton(name: string): Locator {
+    return this.locator().getByRole('button', { name: `Cancel job ${name}` });
+  }
+
+  jobConfirmCancelButton(name: string): Locator {
+    return this.locator().getByRole('button', { name: `Confirm cancelling ${name}` });
+  }
 
   addPullSecretButton(): Locator {
     return this.locator().getByRole('button', { name: 'Add image pull secret' });

--- a/erun-ui/playwright/pages/ManageDialog.ts
+++ b/erun-ui/playwright/pages/ManageDialog.ts
@@ -327,6 +327,10 @@ export class ManageDialog {
     return this.locator().getByTestId('manage-jobs-row-name').nth(index);
   }
 
+  jobRowDetail(index: number): Locator {
+    return this.locator().getByTestId('manage-jobs-row-detail').nth(index);
+  }
+
   jobOutcome(index: number): Locator {
     return this.locator().getByTestId('manage-jobs-row-outcome').nth(index);
   }

--- a/erun-ui/playwright/pages/ManageDialog.ts
+++ b/erun-ui/playwright/pages/ManageDialog.ts
@@ -311,8 +311,20 @@ export class ManageDialog {
     return this.locator().getByTestId('manage-jobs-empty');
   }
 
+  jobsUnreachable(): Locator {
+    return this.locator().getByTestId('manage-jobs-unreachable');
+  }
+
+  jobsUnreachableReconnectButton(): Locator {
+    return this.locator().getByTestId('manage-jobs-unreachable-reconnect');
+  }
+
   jobRows(): Locator {
     return this.locator().getByTestId('manage-jobs-row');
+  }
+
+  jobRowName(index: number): Locator {
+    return this.locator().getByTestId('manage-jobs-row-name').nth(index);
   }
 
   jobOutcome(index: number): Locator {

--- a/erun-ui/playwright/tests/manage-jobs-tab.spec.ts
+++ b/erun-ui/playwright/tests/manage-jobs-tab.spec.ts
@@ -1,0 +1,166 @@
+import type { Page, Request, Route } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ENV_ALPHA, SEED_TENANT } from '../fixtures/seedRoot.js';
+
+// The desktop writes into the job store — Investigate starts a job there — and
+// could not display the job it had just created. The job store itself is the
+// pod's, so these drive the bindings over a stubbed RPC; the Go side is covered
+// by erun-ui/environment_jobs_test.go.
+
+function invokeMethod(request: Request): string {
+  return (JSON.parse(request.postData() ?? '{}') as { method?: string }).method ?? '';
+}
+
+async function fulfillJSON(route: Route, data: unknown): Promise<void> {
+  await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ data }) });
+}
+
+const RUNNING_JOB = {
+  id: 'gate-1',
+  name: 'repo gate',
+  state: 'running',
+  kind: 'command',
+  command: ['scripts/gate.sh', 'main'],
+  exitCode: null,
+  startedAtUnix: Math.floor(Date.now() / 1000) - 125,
+};
+
+const FAILED_JOB = {
+  id: 'build-9',
+  name: 'build',
+  state: 'exited',
+  kind: 'command',
+  exitCode: 2,
+  startedAtUnix: 1700000000,
+  endedAtUnix: 1700000075,
+};
+
+// A job whose supervisor is gone without an outcome. Reporting it as success
+// would be a lie and reporting it as failure would blame work that may have
+// finished, so it has to read as neither.
+const UNKNOWN_JOB = {
+  id: 'agent-3',
+  name: 'agent run',
+  state: 'unknown',
+  kind: 'agent',
+  agentTool: 'claude',
+  exitCode: null,
+  startedAtUnix: 1700000000,
+  endedAtUnix: 1700003600,
+};
+
+async function stubJobs(
+  page: Page,
+  jobs: unknown[],
+  extra?: Record<string, unknown>,
+): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const method = invokeMethod(request);
+    if (method === 'LoadEnvironmentJobs') {
+      return fulfillJSON(route, jobs);
+    }
+    if (extra && method in extra) {
+      return fulfillJSON(route, extra[method]);
+    }
+    await route.continue();
+  });
+}
+
+test.describe('manage dialog jobs tab', () => {
+  test('an empty store explains what the surface is for', async ({ app, page }) => {
+    await stubJobs(page, []);
+    await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, SEED_ENV_ALPHA);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.jobsTabTrigger().click();
+
+    await expect(app.manageDialog.jobsEmptyState()).toContainText('No jobs yet');
+    await expect(app.manageDialog.jobRows()).toHaveCount(0);
+
+    await app.manageDialog.cancel();
+  });
+
+  test('each outcome reads distinctly, and a missing one is never a success', async ({
+    app,
+    page,
+  }) => {
+    await stubJobs(page, [RUNNING_JOB, FAILED_JOB, UNKNOWN_JOB]);
+    await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, SEED_ENV_ALPHA);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.jobsTabTrigger().click();
+
+    await expect(app.manageDialog.jobRows()).toHaveCount(3);
+    await expect(app.manageDialog.jobOutcome(0)).toContainText('Running');
+    // The exit code is named, not just "failed" — 2 is actionable, "failed" is not.
+    await expect(app.manageDialog.jobOutcome(1)).toContainText('Failed (exit 2)');
+    await expect(app.manageDialog.jobOutcome(2)).toContainText('Outcome unknown');
+    await expect(app.manageDialog.jobOutcome(2)).not.toContainText('Succeeded');
+
+    // The finished job's duration is derived from two fixed timestamps, so it is
+    // asserted exactly. The running one is elapsed-from-now by definition, so
+    // only its shape is asserted -- pinning a wall-clock value would make this
+    // spec fail whenever the render lands a second later than the fixture.
+    await expect(app.manageDialog.locator().getByText('Took 1m15s')).toBeVisible();
+    await expect(app.manageDialog.locator().getByText(/^Running for \d+m\d*s?$/)).toBeVisible();
+
+    await app.manageDialog.cancel();
+  });
+
+  test('output is read on demand, and no output says so', async ({ app, page }) => {
+    await stubJobs(page, [FAILED_JOB], {
+      ReadEnvironmentJobOutput: {
+        job: FAILED_JOB,
+        offset: 0,
+        nextOffset: 0,
+        output: '',
+        hasMore: false,
+        complete: true,
+      },
+    });
+    await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, SEED_ENV_ALPHA);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.jobsTabTrigger().click();
+
+    await expect(app.manageDialog.jobOutput()).toHaveCount(0);
+    await app.manageDialog.jobShowOutputButton('build').click();
+    // Distinct from "not read yet" and from an error.
+    await expect(app.manageDialog.jobOutputEmpty()).toContainText('produced no output');
+
+    await app.manageDialog.cancel();
+  });
+
+  // The failure path: a refused cancel must say so beside the control and leave
+  // the job listed, rather than silently doing nothing.
+  test('a refused cancel is reported beside the job', async ({ app, page }) => {
+    await page.route('**/__erun_invoke', async (route, request) => {
+      const method = invokeMethod(request);
+      if (method === 'LoadEnvironmentJobs') {
+        return fulfillJSON(route, [RUNNING_JOB]);
+      }
+      if (method === 'CancelEnvironmentJob') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'the job is no longer running' }),
+        });
+      }
+      await route.continue();
+    });
+
+    await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, SEED_ENV_ALPHA);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.jobsTabTrigger().click();
+
+    await app.manageDialog.jobCancelButton('repo gate').click();
+    // Cancelling work in flight takes a deliberate second press.
+    await expect(app.manageDialog.jobConfirmCancelButton('repo gate')).toBeVisible();
+    await app.manageDialog.jobConfirmCancelButton('repo gate').click();
+
+    await expect(app.manageDialog.locator().getByRole('alert')).toContainText(
+      'the job is no longer running',
+    );
+    await expect(app.manageDialog.jobRows()).toHaveCount(1);
+
+    await app.manageDialog.cancel();
+  });
+});

--- a/erun-ui/playwright/tests/manage-jobs-tab.spec.ts
+++ b/erun-ui/playwright/tests/manage-jobs-tab.spec.ts
@@ -1,5 +1,6 @@
 import type { Page, Request, Route } from '@playwright/test';
 
+import { boundingBoxOf } from '../fixtures/boundingBox.js';
 import { expect, test } from '../fixtures/erunApp.js';
 import { SEED_ENV_ALPHA, SEED_TENANT } from '../fixtures/seedRoot.js';
 
@@ -48,6 +49,23 @@ const UNKNOWN_JOB = {
   exitCode: null,
   startedAtUnix: 1700000000,
   endedAtUnix: 1700003600,
+};
+
+// Every orchestrator-driven job is an agent job, and an agent job's argv
+// always carries the whole prompt as one argument -- this is the shape a real
+// `claude -p '<prompt>' --output-format stream-json --verbose` job takes.
+const LONG_PROMPT = 'Investigate the flaky occupancy banner test and land a fix. '.repeat(90);
+
+const AGENT_JOB_WITH_LONG_PROMPT = {
+  id: 'agent-42',
+  name: 'automated fix',
+  state: 'exited',
+  kind: 'agent',
+  agentTool: 'claude',
+  command: ['claude', '-p', LONG_PROMPT, '--output-format', 'stream-json', '--verbose'],
+  exitCode: 0,
+  startedAtUnix: 1700000000,
+  endedAtUnix: 1700000600,
 };
 
 async function stubJobs(
@@ -151,6 +169,35 @@ test.describe('manage dialog jobs tab', () => {
     }));
     expect(clientWidth).toBeGreaterThan(0);
     expect(scrollWidth).toBeGreaterThan(clientWidth);
+
+    await app.manageDialog.cancel();
+  });
+
+  // An agent job's argv always carries the full prompt as one argument, so
+  // rendering it raw would flood the row and push every other job below the
+  // fold. The row must show an operator-readable summary instead, bounded to
+  // one line, regardless of how long the underlying command is.
+  test('an agent job with a multi-kilobyte prompt does not flood the row', async ({
+    app,
+    page,
+  }) => {
+    expect(AGENT_JOB_WITH_LONG_PROMPT.command.join(' ').length).toBeGreaterThan(5000);
+
+    await stubJobs(page, [AGENT_JOB_WITH_LONG_PROMPT]);
+    await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, SEED_ENV_ALPHA);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.jobsTabTrigger().click();
+
+    const row = app.manageDialog.jobRows().nth(0);
+    await expect(row).toBeVisible();
+
+    const rowText = await row.innerText();
+    expect(rowText.length).toBeLessThan(500);
+    expect(rowText).not.toContain('flaky occupancy banner');
+    expect(rowText).toContain('Claude agent');
+
+    const box = await boundingBoxOf(row, 'agent job row');
+    expect(box.height).toBeLessThan(150);
 
     await app.manageDialog.cancel();
   });

--- a/erun-ui/playwright/tests/manage-jobs-tab.spec.ts
+++ b/erun-ui/playwright/tests/manage-jobs-tab.spec.ts
@@ -129,6 +129,84 @@ test.describe('manage dialog jobs tab', () => {
     await app.manageDialog.cancel();
   });
 
+  // A row's header is a fixed-width flex line (name + outcome badge); an
+  // unbounded name would push the badge off, or wrap and blow out row height.
+  // erun-ui/AGENTS.md requires evidence the CSS actually engages, not just
+  // that the element renders.
+  test('an extremely long job name truncates instead of overflowing the row', async ({
+    app,
+    page,
+  }) => {
+    const longName = 'extremely-long-job-name-'.repeat(20);
+    await stubJobs(page, [{ ...RUNNING_JOB, name: longName }]);
+    await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, SEED_ENV_ALPHA);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.jobsTabTrigger().click();
+
+    const name = app.manageDialog.jobRowName(0);
+    await expect(name).toBeVisible();
+    const { clientWidth, scrollWidth } = await name.evaluate((el) => ({
+      clientWidth: el.clientWidth,
+      scrollWidth: el.scrollWidth,
+    }));
+    expect(clientWidth).toBeGreaterThan(0);
+    expect(scrollWidth).toBeGreaterThan(clientWidth);
+
+    await app.manageDialog.cancel();
+  });
+
+  // #4aecd83e darkened this badge's amber for WCAG AA contrast; pin the class
+  // so a future style pass cannot quietly lighten it back.
+  test('the unknown-outcome badge keeps its darkened, contrast-safe color', async ({
+    app,
+    page,
+  }) => {
+    await stubJobs(page, [UNKNOWN_JOB]);
+    await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, SEED_ENV_ALPHA);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.jobsTabTrigger().click();
+
+    await expect(app.manageDialog.jobOutcome(0)).toHaveClass(/\btext-amber-700\b/);
+    await expect(app.manageDialog.jobOutcome(0)).not.toHaveClass(/\btext-amber-600\b/);
+  });
+
+  // The desktop's job store is host-local; a remote-agent/runtime env's jobs
+  // run in its pod. A stale port-forward means a job may well be running
+  // behind it right now, so this must read as "cannot tell", never silently
+  // fall through to the same empty state a genuinely idle environment shows
+  // (erun-ui/environment_jobs_test.go covers the Go-side branch this drives).
+  test('a stale port-forward is reported as unreachable, never as no jobs', async ({
+    app,
+    page,
+  }) => {
+    const staleMessage =
+      'ERUN_MCP_UNREACHABLE_STALE: mcp unreachable: the port-forward for ' +
+      `${SEED_TENANT}/${SEED_ENV_ALPHA} on 127.0.0.1:17999 is not carrying traffic ` +
+      '(the local port is held but the edge never answers) — re-establishing it';
+    await page.route('**/__erun_invoke', async (route, request) => {
+      const method = invokeMethod(request);
+      if (method === 'LoadEnvironmentJobs') {
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ error: staleMessage }),
+        });
+      }
+      await route.continue();
+    });
+
+    await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, SEED_ENV_ALPHA);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.jobsTabTrigger().click();
+
+    const unreachable = app.manageDialog.jobsUnreachable();
+    await expect(unreachable).toBeVisible();
+    await expect(unreachable).toContainText('Cannot reach the environment runtime');
+    await expect(app.manageDialog.jobsUnreachableReconnectButton()).toContainText('Reconnect…');
+    await expect(app.manageDialog.jobsEmptyState()).toHaveCount(0);
+
+    await app.manageDialog.cancel();
+  });
+
   // The failure path: a refused cancel must say so beside the control and leave
   // the job listed, rather than silently doing nothing.
   test('a refused cancel is reported beside the job', async ({ app, page }) => {

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -852,6 +852,11 @@ type startSessionResult struct {
 type uiEnvironmentLease struct {
 	Name        string `json:"name"`
 	SecondsHeld int64  `json:"secondsHeld,omitempty"`
+	// JobID is set only when the lease is held by a job, so the surface that
+	// names the occupancy can also act on it. Empty for every other holder,
+	// which is what keeps a non-job lease from rendering a cancel that cannot
+	// work.
+	JobID string `json:"jobId,omitempty"`
 }
 
 type deleteEnvironmentResult struct {

--- a/erun-ui/ui_model_jobs.go
+++ b/erun-ui/ui_model_jobs.go
@@ -1,0 +1,55 @@
+package main
+
+// The job surface's models. Times cross the boundary as unix seconds because
+// the frontend renders a duration, not a formatted instant, and a zero means
+// "not yet" rather than the epoch.
+
+type uiEnvironmentJob struct {
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	State     string   `json:"state"`
+	Kind      string   `json:"kind,omitempty"`
+	AgentTool string   `json:"agentTool,omitempty"`
+	Command   []string `json:"command,omitempty"`
+	Dir       string   `json:"dir,omitempty"`
+	// ExitCode is nil unless the job reached exited, so a missing outcome can
+	// never be read as a successful zero.
+	ExitCode      *int                      `json:"exitCode"`
+	StartedAtUnix int64                     `json:"startedAtUnix,omitempty"`
+	EndedAtUnix   int64                     `json:"endedAtUnix,omitempty"`
+	Progress      *uiEnvironmentJobProgress `json:"progress,omitempty"`
+}
+
+// uiEnvironmentJobProgress is the agent-run view, nil for a command job and for
+// an agent that has not emitted yet -- never a made-up zero state.
+type uiEnvironmentJobProgress struct {
+	Activity    string `json:"activity,omitempty"`
+	LastMessage string `json:"lastMessage,omitempty"`
+	Turns       int    `json:"turns"`
+	ToolsRun    int    `json:"toolsRun"`
+}
+
+type uiEnvironmentJobOutput struct {
+	Job        uiEnvironmentJob `json:"job"`
+	Offset     int64            `json:"offset"`
+	NextOffset int64            `json:"nextOffset"`
+	Output     string           `json:"output"`
+	HasMore    bool             `json:"hasMore"`
+	Complete   bool             `json:"complete"`
+}
+
+type uiJobOutputInput struct {
+	Tenant      string `json:"tenant"`
+	Environment string `json:"environment"`
+	ID          string `json:"id"`
+	Offset      int64  `json:"offset"`
+	MaxBytes    int64  `json:"maxBytes"`
+}
+
+type uiCancelJobInput struct {
+	Tenant      string `json:"tenant"`
+	Environment string `json:"environment"`
+	ID          string `json:"id"`
+	// Signal is TERM, INT, HUP, or KILL; empty means TERM.
+	Signal string `json:"signal,omitempty"`
+}


### PR DESCRIPTION
## Summary

Gives jobs a desktop surface — list, outcome, exit status, output, cancel — and makes it read the environment that actually ran them.

`erun job start|status|output|cancel` and the matching MCP tools have existed for a while; the desktop wrote into the job store (its own Investigate job) and then could not display the job it had just created. `grep -i job erun-ui/frontend/wailsjs/go/main/App.d.ts` returned **0 hits across all 113 bindings**. It now returns three, out of 123:

```
CancelEnvironmentJob
LoadEnvironmentJobs
ReadEnvironmentJobOutput
```

## What landed

- **A Jobs tab on the Manage dialog** — every retained job newest-first, with outcome, duration, paged output on demand, and cancel behind a two-step confirm that matches the Delete tab's existing destructive pattern.
- **A route from the AI occupancy banner** to the job it names, so "another agent is working here" is actionable instead of merely informative. A lease carries its job id only when a job holds it, so a lease held by anything else still offers nothing.
- **Reads go through the environment's own MCP edge** (`job_status` / `job_output` / `job_cancel`) whenever it is reachable, falling back to the local store when it is not.

## Why the pod-backed read is part of this, not a follow-up

The first version of this branch read the job store from a **local** directory. `os.ReadDir` on a missing directory returns `nil, nil`, so for a remote-agent environment — where jobs actually run in the pod, and the only kind an orchestrator drives — the tab rendered its "No jobs yet" empty state. A host-only list is not a jobs surface for the environments this feature exists to serve, so it was fixed here rather than deferred.

Measured on the running desktop, same environment, same instant, before the fix:

| call | result |
|---|---|
| `LoadIdleStatus({tenant:'erun',environment:'ux'})` | `fromPod: true`, lease held 1070s, **`jobId: "finish-1350"`** |
| `LoadEnvironmentJobs('erun','ux')` | **`[]`** → tab rendered "No jobs yet." |

The occupancy banner therefore offered "View jobs" for a job the list could not show — the new route was dead by construction on exactly the environments it was built for.

For contrast, the CLI already reaches the pod for these verbs and fails loudly rather than silently: `erun job status --tenant erun --environment ux` resolves the edge and then reports `unknown tool "exec_job_status"` on an older runtime. The desktop was the outlier, so it now follows `LoadIdleStatus`'s existing reachability branch instead of inventing a pattern.

The fallback is a real path, not a consolation prize, and the two unreachable cases are deliberately not the same:

- **not open** — the local store is the truthful answer. No pod is running, so there are no pod-side jobs to have missed.
- **stale forward** — the port is held but the edge never answers. A pod may well be running jobs behind it, so this reports *unreachable*, never *empty*.

After the fix, the same call against the same environment returns six real jobs, including the desktop's own `Investigate_ux` (state `unknown`) and a genuinely failed `gate-1358` (`exit -1`).

## Eight-point UX checklist

1. **Affected paths.** Manage dialog → new Jobs tab (list / output / cancel); AI-tab occupancy banner → "View jobs" → Manage dialog opened on the Jobs tab.
2. **User-visible sequence.** Open Manage → Jobs: a loading placeholder, then the list newest-first — name, outcome badge, detail, duration, actions. "Show output" expands a scrollable log with "Read more" paging. "Cancel job" needs a second "Confirm cancel"; "Keep running" backs out. A refused cancel shows an inline alert beside the row and the job stays listed.
3. **State without an affordance.** None. Every job-store field surfaces as badge, detail, duration or output; the `confirming` cancel state is rendered rather than dropped.
4. **Visibility of system status.** Running jobs carry a spinner and a live elapsed duration that ticks while the tab is open — persistent, not a toast.
5. **Success and failure feedback.** Succeeded / Failed (exit N) / Cancelled / Outcome unknown are four distinct icon+label pairs; a missing outcome is never rendered as success.
6. **Consistency.** Matches the History tab's read-only list and the Delete tab's two-step destructive confirm; composed from the shared `Button` / `InlineAlert` / tab primitives.
7. **Nielsen pass.** Status visible; real-world language ("Outcome unknown", not an enum); user control (an escape from the confirm step); error prevention (destructive action double-gated); recognition over recall (all state inline on the row); minimalist (detail rendered only when present); error recovery (load and cancel failures both named inline, neither swallowed).
8. **Playwright coverage.** `erun-ui/playwright/tests/manage-jobs-tab.spec.ts`, landing in this PR.

**Theme:** the desktop is single-theme. Every `dark:` utility here is inert pending #1356, so this claims a one-theme check, not two.

## Accessibility and long-value defects found by the visual pass

- **Contrast.** The "Outcome unknown" badge measured **~3.2:1** against the card at 12px — under the WCAG 2.2 AA 4.5:1 floor. Measured by rendering the computed colour to a canvas and computing luminance contrast; the other three outcome colours measured 4.7–4.9:1 and were left alone. Now ~5.0:1.
- **Long job name.** The row `<header>` is a grid item, and without `min-w-0` its implicit `min-width: auto` followed the unshrunk name, so a 312-character name rendered **2001px** wide and overflowed the dialog instead of eliding — the `truncate` class was present but structurally unable to engage.
- **Shared reachability copy.** The unreachable alert read "The **diff** could not be loaded…" on the Jobs tab, because the shared `reachabilityCopy.errorBody` hardcoded diff-specific wording. Generalised so the same copy reads correctly wherever it is reused.
- **Agent-job detail line.** An agent job's argv is `["claude","-p","<the whole prompt>",…]`, so the row's detail rendered **5303 characters** and buried every other job below the fold. Every orchestrator-driven job is an agent job, so this was the common case, not the edge case.

## Verification

Gated in a pod (`erun-common` and `erun-mcp` fail on a macOS host and pass in-pod on the same commit — #1361, #1363 — so the host is not the baseline here):

- `erun-common go test ./...` — ok
- `erun-ui go test -race -count=1 ./...` — ok
- `yarn typecheck` / `lint` / `format:check` / `test` — clean; 157/157. The 4 `approaching-max-lines` lint warnings reproduce on a clean `origin/main` worktree and are pre-existing.
- `playwright/run.sh --build -- --grep manage-jobs-tab` — green (`--build` is mandatory or the harness tests the previous binary's embedded frontend)
- `erun-integration go test ./...` — ok

**Regression tests confirmed red before green**, since a path whose failure mode is silence proves nothing until it has been seen to fail. Against the pre-fix blob:

```
--- FAIL: TestLoadEnvironmentJobsReadsThroughAReachablePodEdge
    expected the pod's own job to be reported, got []
--- FAIL: TestLoadEnvironmentJobsReportsStaleForwardInsteadOfEmpty
    expected an unreachable error for a stale forward, got jobs=[]
--- PASS: TestLoadEnvironmentJobsFallsBackToLocalWhenNotOpen
```

and after: all three PASS. The third passing in both directions is the point — the not-open fallback is unchanged behaviour.

**End-to-end, in the running desktop, against a real pod** — not the harness: the rebuilt bundle was launched headless against a single-environment config root and driven through the real Manage dialog. `LoadEnvironmentJobs('erun','ux')` returned the six jobs above and the tab rendered "6 jobs, newest first." The pre-fix bundle, same call, returned `[]`.

## Not verified

- **Screen-reader announcement** of the outcome badges and inline alerts. `aria-label` and `role="alert"` presence was confirmed in code and via accessibility-tree `getByRole` queries; no real screen reader was run.
- **`review-panel-reachability.spec.ts` → "clicking Open surfaces honest copy for the stopped case"** hangs on a host where an agent is genuinely active: the occupancy check reads a real activity lease rather than a seeded one. Confirmed to reproduce on unmodified committed code, so it is not caused by this branch; filed separately as #1375. The other tests in that file pass.

Closes #1350

## Live end-to-end evidence (the rebuilt bundle, real pod, not the harness)

The bundle was rebuilt from this branch and driven through the real Manage dialog against `erun/ux`.

**Before the pod-backed read** — `LoadEnvironmentJobs('erun','ux')` → `[]`, tab rendered "No jobs yet", while `LoadIdleStatus` on the same environment reported `fromPod: true` and `jobId: "finish-1350"`.

**After** — 7 real jobs, including the desktop's own `Investigate_ux` (`Outcome unknown`) and a genuinely failed `gate-1358` (`exit -1`).

**Before the detail clamp** — one agent row rendered 5356 characters and pushed the other five jobs below the fold.

**After** — measured per-row text lengths `305, 318, 53, 202, 327, 304, 323`; whole dialog 2054 characters; every detail line clamped (`clientWidth 596` vs `scrollWidth` up to 1441) with the full text on `title`; five rows above the fold.

Agent jobs now summarise rather than dump argv. One of the rows reads *"I'll pause here and wait for the background suite to finish — no further action needed until the monitor notifies me."* — a real agent run that exited 0 having promised a report it could never deliver. The surface makes that legible at a glance, which previously required tailing a 2 MB log.
