### PR TITLE
Make the desktop review loop usable, and give comment resolution a client

### DIFF
--- a/erun-cli/cmd/review.go
+++ b/erun-cli/cmd/review.go
@@ -25,6 +25,8 @@ func newReviewCmd(store common.CloudReadStore, deps common.CloudDependencies) *c
 		newReviewShowCmd(store, &alias, deps),
 		newReviewCreateCmd(store, &alias, deps),
 		newReviewCommentCmd(store, &alias, deps),
+		newReviewResolveCmd(store, &alias, deps),
+		newReviewUnresolveCmd(store, &alias, deps),
 		newReviewCloseCmd(store, &alias, deps),
 		newReviewMergeQueueCmd(store, &alias, deps),
 	)
@@ -126,7 +128,7 @@ func writeReviewDetail(ctx common.Context, detail common.ReviewDetail) error {
 	if err := writeReviewLine(ctx, detail.Review); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(ctx.Stdout, "  builds: %d, comments: %d\n", len(detail.Builds), len(detail.Comments)); err != nil {
+	if _, err := fmt.Fprintf(ctx.Stdout, "  builds: %d, comments: %d, unresolved threads: %d\n", len(detail.Builds), len(detail.Comments), detail.UnresolvedThreads); err != nil {
 		return err
 	}
 	for _, comment := range detail.Comments {
@@ -137,12 +139,15 @@ func writeReviewDetail(ctx common.Context, detail common.ReviewDetail) error {
 	return nil
 }
 
+// writeReviewCommentLine renders one comment. A thread's status lives on its
+// root comment only (a reply's own status is never separately settable), so
+// only root lines carry status=.
 func writeReviewCommentLine(ctx common.Context, comment common.PlatformComment) error {
-	prefix := "  "
 	if strings.TrimSpace(comment.ParentCommentID) != "" {
-		prefix = "    ↳ "
+		_, err := fmt.Fprintf(ctx.Stdout, "    ↳ [%s] %s:%d %s\n", comment.CommentID, comment.FilePath, comment.Line, comment.Body)
+		return err
 	}
-	_, err := fmt.Fprintf(ctx.Stdout, "%s[%s] %s:%d %s\n", prefix, comment.CommentID, comment.FilePath, comment.Line, comment.Body)
+	_, err := fmt.Fprintf(ctx.Stdout, "  [%s] status=%s %s:%d %s\n", comment.CommentID, comment.Status, comment.FilePath, comment.Line, comment.Body)
 	return err
 }
 
@@ -234,6 +239,72 @@ func newReviewCommentCmd(store common.CloudReadStore, alias *string, deps common
 	cmd.Flags().StringVar(&filePath, "file", "", "File path the comment is anchored to")
 	cmd.Flags().IntVar(&line, "line", 0, "Line number the comment is anchored to")
 	cmd.Flags().StringVar(&replyTo, "reply-to", "", "Comment id to reply to, making this a reply in that thread")
+	addDryRunFlag(cmd)
+	return cmd
+}
+
+func newReviewResolveCmd(store common.CloudReadStore, alias *string, deps common.CloudDependencies) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "resolve REVIEW_ID COMMENT_ID",
+		Short: "Resolve a comment thread by closing its root comment",
+		Long: "Resolve a comment thread on a review by closing its root comment.\n\n" +
+			"COMMENT_ID must be the thread's root comment — the first comment posted at a " +
+			"file/line, not one made with --reply-to. Addressing a reply fails, naming the " +
+			"root comment to retry against. A real, immediate write, not a preview.",
+		Args:         cobra.ExactArgs(2),
+		SilenceUsage: true,
+		Example:      "  erun review resolve 018f... 018g...",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := commandContext(cmd)
+			comment, err := common.RunReviewResolve(ctx, store, *alias, args[0], args[1], deps)
+			if err != nil {
+				return err
+			}
+			if ctx.DryRun {
+				_, err := fmt.Fprintln(ctx.Stdout, "Dry run: erun review resolve planned.")
+				return err
+			}
+			if ctx.Output != common.OutputJSON {
+				if err := writeReviewCommentLine(ctx, comment); err != nil {
+					return err
+				}
+			}
+			return ctx.WriteResult(comment)
+		},
+	}
+	addDryRunFlag(cmd)
+	return cmd
+}
+
+func newReviewUnresolveCmd(store common.CloudReadStore, alias *string, deps common.CloudDependencies) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unresolve REVIEW_ID COMMENT_ID",
+		Short: "Reopen a comment thread by marking its root comment OPEN",
+		Long: "Reopen a comment thread on a review by marking its root comment OPEN again.\n\n" +
+			"COMMENT_ID must be the thread's root comment — the first comment posted at a " +
+			"file/line, not one made with --reply-to. Addressing a reply fails, naming the " +
+			"root comment to retry against. A real, immediate write, not a preview.",
+		Args:         cobra.ExactArgs(2),
+		SilenceUsage: true,
+		Example:      "  erun review unresolve 018f... 018g...",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := commandContext(cmd)
+			comment, err := common.RunReviewUnresolve(ctx, store, *alias, args[0], args[1], deps)
+			if err != nil {
+				return err
+			}
+			if ctx.DryRun {
+				_, err := fmt.Fprintln(ctx.Stdout, "Dry run: erun review unresolve planned.")
+				return err
+			}
+			if ctx.Output != common.OutputJSON {
+				if err := writeReviewCommentLine(ctx, comment); err != nil {
+					return err
+				}
+			}
+			return ctx.WriteResult(comment)
+		},
+	}
 	addDryRunFlag(cmd)
 	return cmd
 }

--- a/erun-common/mcp_tools.go
+++ b/erun-common/mcp_tools.go
@@ -107,6 +107,8 @@ var mcpToolDescriptors = map[string]MCPToolDescriptor{
 	"review_create":                {Family: "review", CLIPath: []string{"review", "create"}, Title: "Open a review", ReadOnly: false, Destructive: false, Idempotent: false, OpenWorld: true},
 	"review_comment":               {Family: "review", CLIPath: []string{"review", "comment"}, Title: "Comment on a review", ReadOnly: false, Destructive: false, Idempotent: false, OpenWorld: true},
 	"review_close":                 {Family: "review", CLIPath: []string{"review", "close"}, Title: "Close a review", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
+	"review_resolve":               {Family: "review", CLIPath: []string{"review", "resolve"}, Title: "Resolve a comment thread", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
+	"review_unresolve":             {Family: "review", CLIPath: []string{"review", "unresolve"}, Title: "Reopen a comment thread", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
 	"review_queue_list":            {Family: "review", CLIPath: []string{"review", "queue", "list"}, Title: "List a merge queue", ReadOnly: true, Destructive: false, Idempotent: false, OpenWorld: true},
 	"review_queue_advance":         {Family: "review", CLIPath: []string{"review", "queue", "advance"}, Title: "Advance a merge queue", ReadOnly: false, Destructive: false, Idempotent: false, OpenWorld: true},
 	"idle":                         {Family: "idle", CLIPath: []string{"idle"}, Title: "Report an environment's idle and auto-stop state", ReadOnly: true, Destructive: false, Idempotent: false, OpenWorld: false},

--- a/erun-common/platform_client_reviews.go
+++ b/erun-common/platform_client_reviews.go
@@ -184,6 +184,20 @@ func (c *PlatformClient) CreateComment(ctx context.Context, reviewID string, par
 	return comment, err
 }
 
+// PlatformUpdateCommentStatusParams is the comment status-transition input.
+type PlatformUpdateCommentStatusParams struct {
+	Status string `json:"status"`
+}
+
+// UpdateCommentStatus transitions a comment thread's status (OPEN/CLOSED).
+// Only a thread's root comment carries a meaningful status; the backend
+// refuses a status change addressed to a reply.
+func (c *PlatformClient) UpdateCommentStatus(ctx context.Context, reviewID, commentID string, params PlatformUpdateCommentStatusParams) (PlatformComment, error) {
+	var comment PlatformComment
+	err := c.do(ctx, http.MethodPatch, "/v1/reviews/"+url.PathEscape(reviewID)+"/comments/"+url.PathEscape(commentID)+"/status", params, true, &comment)
+	return comment, err
+}
+
 // ListBuilds lists the builds recorded against a review.
 func (c *PlatformClient) ListBuilds(ctx context.Context, reviewID string) ([]PlatformBuild, error) {
 	var builds []PlatformBuild

--- a/erun-common/review_commands.go
+++ b/erun-common/review_commands.go
@@ -138,13 +138,15 @@ func RunReviewShow(ctx Context, store CloudReadStore, alias, reviewID string, de
 	if err != nil {
 		return ReviewDetail{}, err
 	}
-	return ReviewDetail{Review: review, Comments: comments, Builds: builds, UnresolvedThreads: countUnresolvedThreads(comments)}, nil
+	return ReviewDetail{Review: review, Comments: comments, Builds: builds, UnresolvedThreads: CountUnresolvedThreads(comments)}, nil
 }
 
-// countUnresolvedThreads counts root comments (parentCommentId unset) whose
+// CountUnresolvedThreads counts root comments (parentCommentId unset) whose
 // status is still OPEN. A thread's status lives entirely on its root; replies
 // never carry their own (comments_validate in erun-backend-db enforces this).
-func countUnresolvedThreads(comments []PlatformComment) int {
+// Exported so other transports (erun-ui's tenant dashboard) can compute the
+// same count from a comment list without re-deriving the rule.
+func CountUnresolvedThreads(comments []PlatformComment) int {
 	count := 0
 	for _, comment := range comments {
 		if strings.TrimSpace(comment.ParentCommentID) == "" && comment.Status == "OPEN" {

--- a/erun-common/review_commands.go
+++ b/erun-common/review_commands.go
@@ -105,10 +105,13 @@ func resolveReviewListCallerFilters(client *PlatformClient, params ReviewListPar
 // ReviewDetail is the combined result of `erun review show`: the review
 // itself alongside its comment threads and recorded builds, so a caller sees
 // everything needed to read and act on a review from one command.
+// UnresolvedThreads counts root comments (threads) still OPEN; a thread's
+// status is its root comment's Status, since replies never carry their own.
 type ReviewDetail struct {
-	Review   PlatformReview    `json:"review"`
-	Comments []PlatformComment `json:"comments"`
-	Builds   []PlatformBuild   `json:"builds"`
+	Review            PlatformReview    `json:"review"`
+	Comments          []PlatformComment `json:"comments"`
+	Builds            []PlatformBuild   `json:"builds"`
+	UnresolvedThreads int               `json:"unresolvedThreads"`
 }
 
 // RunReviewShow fetches one review together with its comments and builds.
@@ -135,7 +138,74 @@ func RunReviewShow(ctx Context, store CloudReadStore, alias, reviewID string, de
 	if err != nil {
 		return ReviewDetail{}, err
 	}
-	return ReviewDetail{Review: review, Comments: comments, Builds: builds}, nil
+	return ReviewDetail{Review: review, Comments: comments, Builds: builds, UnresolvedThreads: countUnresolvedThreads(comments)}, nil
+}
+
+// countUnresolvedThreads counts root comments (parentCommentId unset) whose
+// status is still OPEN. A thread's status lives entirely on its root; replies
+// never carry their own (comments_validate in erun-backend-db enforces this).
+func countUnresolvedThreads(comments []PlatformComment) int {
+	count := 0
+	for _, comment := range comments {
+		if strings.TrimSpace(comment.ParentCommentID) == "" && comment.Status == "OPEN" {
+			count++
+		}
+	}
+	return count
+}
+
+// threadRootCommentID reports commentID's thread root when commentID is a
+// reply (parentCommentId set), so a resolve/unresolve call addressed to a
+// reply can be refused with the root id the caller should retry against
+// instead. A commentID absent from comments (e.g. a wrong review id) is
+// reported as not-a-reply and left to the backend's own not-found error.
+func threadRootCommentID(comments []PlatformComment, commentID string) (string, bool) {
+	for _, comment := range comments {
+		if comment.CommentID != commentID {
+			continue
+		}
+		if root := strings.TrimSpace(comment.ParentCommentID); root != "" {
+			return root, true
+		}
+		return "", false
+	}
+	return "", false
+}
+
+// runReviewCommentStatus is the shared implementation behind RunReviewResolve
+// and RunReviewUnresolve: it lists the review's comments (both to trace the
+// lookup and to enforce that only a thread's root, never a reply, is
+// addressable) before issuing the status PATCH.
+func runReviewCommentStatus(ctx Context, store CloudReadStore, alias, reviewID, commentID, status string, deps CloudDependencies) (PlatformComment, error) {
+	client, provider, err := newPlatformClientForAlias(ctx, store, alias, deps)
+	if err != nil {
+		return PlatformComment{}, err
+	}
+	tracePlatformCall(ctx, provider, "GET", "/v1/reviews/"+reviewID+"/comments")
+	tracePlatformCall(ctx, provider, "PATCH", "/v1/reviews/"+reviewID+"/comments/"+commentID+"/status", "status="+status)
+	if ctx.DryRun {
+		return PlatformComment{}, nil
+	}
+	comments, err := client.ListComments(context.Background(), reviewID)
+	if err != nil {
+		return PlatformComment{}, err
+	}
+	if rootID, isReply := threadRootCommentID(comments, commentID); isReply {
+		return PlatformComment{}, fmt.Errorf("comment %s is a reply; only a thread's root comment can be resolved or unresolved — retry against root comment %s", commentID, rootID)
+	}
+	return client.UpdateCommentStatus(context.Background(), reviewID, commentID, PlatformUpdateCommentStatusParams{Status: status})
+}
+
+// RunReviewResolve marks a comment thread CLOSED (resolved). commentID must
+// be a thread's root comment; addressing a reply is refused.
+func RunReviewResolve(ctx Context, store CloudReadStore, alias, reviewID, commentID string, deps CloudDependencies) (PlatformComment, error) {
+	return runReviewCommentStatus(ctx, store, alias, reviewID, commentID, "CLOSED", deps)
+}
+
+// RunReviewUnresolve reopens a comment thread (marks it OPEN). commentID must
+// be a thread's root comment; addressing a reply is refused.
+func RunReviewUnresolve(ctx Context, store CloudReadStore, alias, reviewID, commentID string, deps CloudDependencies) (PlatformComment, error) {
+	return runReviewCommentStatus(ctx, store, alias, reviewID, commentID, "OPEN", deps)
 }
 
 // RunReviewCreate opens a review.

--- a/erun-docs/docs/cli/review.md
+++ b/erun-docs/docs/cli/review.md
@@ -4,7 +4,7 @@ title: erun review
 
 # `erun review`
 
-Review code on a hosted erun platform from a terminal or an Agent — the client for the [collaboration API](/collaboration/reviews) — using the **erun-type cloud alias** [`erun cloud init erun`](/cli/cloud) and `erun cloud login` set up. List reviews, open one, comment on a line (or reply to an existing comment), close it, and inspect or advance a target branch's merge queue.
+Review code on a hosted erun platform from a terminal or an Agent — the client for the [collaboration API](/collaboration/reviews) — using the **erun-type cloud alias** [`erun cloud init erun`](/cli/cloud) and `erun cloud login` set up. List reviews, open one, comment on a line (or reply to an existing comment), resolve or reopen a comment thread, close a review, and inspect or advance a target branch's merge queue.
 
 Starting a review needs the source branch to already exist on the remote — push it first with [`erun exec push`](/cli/exec#exec-push).
 
@@ -17,6 +17,8 @@ erun review list [flags]
 erun review show REVIEW_ID [flags]
 erun review create --name <name> --source-branch <branch> --target-branch <branch> [flags]
 erun review comment REVIEW_ID --commit <hash> --file <path> --line <n> [flags]
+erun review resolve REVIEW_ID COMMENT_ID [flags]
+erun review unresolve REVIEW_ID COMMENT_ID [flags]
 erun review close REVIEW_ID [flags]
 erun review queue list --target-branch <branch> [flags]
 erun review queue advance --target-branch <branch> [flags]
@@ -57,6 +59,10 @@ Comments on a line of a review, or replies to an existing comment with `--reply-
 | `--line` | Line number the comment is anchored to. |
 | `--reply-to` | Comment id to reply to, making this a reply in that thread. |
 
+### `review resolve` / `review unresolve` {#review-resolve--review-unresolve}
+
+Resolve a comment thread by closing its root comment, or reopen one by marking its root comment `OPEN` again. A thread's status lives entirely on its root comment — `COMMENT_ID` must be the thread's root (the first comment posted at a file/line, not one made with `--reply-to`); addressing a reply fails, naming the root comment to retry against.
+
 ### `review close`
 
 Closes a review without merging it.
@@ -83,6 +89,8 @@ echo 'nit: rename this' | erun review comment 018f... --commit abc123 --file mai
 echo 'good catch, fixed' | erun review comment 018f... --commit abc123 --file main.go --line 42 --reply-to 018g...
 
 erun review show 018f...
+erun review resolve 018f... 018h...
+erun review unresolve 018f... 018h...
 erun review close 018f...
 
 erun review queue list --target-branch main
@@ -99,4 +107,5 @@ erun review queue advance --target-branch main
 | `create` with a `--name` that collides with an existing review. | `409 Conflict`. |
 | `create` with a `--source-branch` that already has a live (non-`MERGED`/`CLOSED`) review proposing it onto the same `--target-branch`. | `409 Conflict` — see [branch uniqueness](/collaboration/reviews#author-reviewers-and-discovery). |
 | `show`/`comment`/`close` on an unknown review id. | `404 Not Found`. |
+| `resolve`/`unresolve` addressed to a reply rather than its thread's root comment. | Aborts before the status change, naming the root comment id to retry against. |
 | `queue advance` on an empty queue, or whose head is not `READY`. | `409 Conflict`. |

--- a/erun-docs/docs/collaboration/comments.md
+++ b/erun-docs/docs/collaboration/comments.md
@@ -4,7 +4,7 @@ title: Comments
 
 # Comments
 
-> For the Operator view, see [`erun review comment`](/cli/review#review-comment).
+> For the Operator view, see [`erun review comment`](/cli/review#review-comment) and [`erun review resolve` / `erun review unresolve`](/cli/review#review-resolve--review-unresolve).
 
 Comments are how agents and humans discuss specific code on a review. Each comment is anchored to a commit, a file, and a line number, supports threaded replies, and has an open/closed status that resolves the conversation.
 

--- a/erun-docs/docs/mcp/overview.md
+++ b/erun-docs/docs/mcp/overview.md
@@ -294,11 +294,13 @@ Drives the erun platform's review flow: open a review against a pushed branch, c
 | `review_show` | Read | Fetch one review together with its comment threads and recorded builds. |
 | `review_create` | Work | Open a review. `name` is the eventual squash-merge message and must be unique per tenant. `sourceBranch` must already be pushed (`exec_push`) — the platform can only fetch what has actually landed on the remote. |
 | `review_comment` | Work | Comment on a review line, or reply to an existing comment via `parentCommentId`. |
+| `review_resolve` | Work (idempotent) | Resolve a comment thread by closing its root comment. `commentId` must be the thread's root — resolving a reply fails, naming the root to retry against. |
+| `review_unresolve` | Work (idempotent) | Reopen a comment thread by marking its root comment `OPEN` again. Same root-only restriction as `review_resolve`. |
 | `review_close` | Work (idempotent) | Close a review without merging it. |
 | `review_queue_list` | Read | List a target branch's merge queue, in queue order. |
 | `review_queue_advance` | Work | Advance a target branch's merge queue head to `MERGED` — a real, immediate mutation of shared control-plane state. Fails if the queue is empty or its head is not `READY`. |
 
-All seven support `preview` except the immediate writes (`review_create`, `review_comment`, `review_close`, `review_queue_advance`), which run for real unless `preview` is set. All are agent-callable and `openWorld: true`.
+All nine support `preview` except the immediate writes (`review_create`, `review_comment`, `review_resolve`, `review_unresolve`, `review_close`, `review_queue_advance`), which run for real unless `preview` is set. All are agent-callable and `openWorld: true`.
 
 ### Idle & auto-stop history {#idle-stop-tools}
 
@@ -418,6 +420,8 @@ Every tool the server can register, one row each, grouped by `_meta.family` and 
 | review | `review_show` | `erun review show` | Read |
 | review | `review_create` | `erun review create` | Work |
 | review | `review_comment` | `erun review comment` | Work |
+| review | `review_resolve` | `erun review resolve` | Work |
+| review | `review_unresolve` | `erun review unresolve` | Work |
 | review | `review_close` | `erun review close` | Work |
 | review | `review_queue_list` | `erun review queue list` | Read |
 | review | `review_queue_advance` | `erun review queue advance` | Work |

--- a/erun-integration/review_test.go
+++ b/erun-integration/review_test.go
@@ -179,6 +179,29 @@ func reviewAPIStubServer(t testing.TB) *httptest.Server {
 		_ = json.NewEncoder(w).Encode(comments[r.PathValue("review_id")])
 	})
 
+	mux.HandleFunc("PATCH /v1/reviews/{review_id}/comments/{comment_id}/status", func(w http.ResponseWriter, r *http.Request) {
+		if !requireBearer(w, r) {
+			return
+		}
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		mu.Lock()
+		defer mu.Unlock()
+		for _, comment := range comments[r.PathValue("review_id")] {
+			if comment["commentId"] != r.PathValue("comment_id") {
+				continue
+			}
+			if parent, ok := comment["parentCommentId"].(string); ok && parent != "" {
+				http.Error(w, "only the root comment of a thread can have its status updated", http.StatusBadRequest)
+				return
+			}
+			comment["status"] = body["status"]
+			_ = json.NewEncoder(w).Encode(comment)
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
 	mux.HandleFunc("POST /v1/reviews/{review_id}/comments", func(w http.ResponseWriter, r *http.Request) {
 		if !requireBearer(w, r) {
 			return
@@ -218,6 +241,52 @@ func reviewAPIStubServer(t testing.TB) *httptest.Server {
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 	return server
+}
+
+// createReviewJSON runs `review create --output json` against the stub
+// server and decodes the resulting reviewId, for scenarios that need a real
+// review to act on rather than a --dry-run trace.
+func createReviewJSON(t testing.TB, setup env.Setup, name, sourceBranch, targetBranch string) struct{ ReviewID string } {
+	t.Helper()
+	result := erun.Run(t, []string{
+		"review", "create", "--name", name, "--source-branch", sourceBranch, "--target-branch", targetBranch, "--output", "json",
+	}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+	if result.ExitCode != 0 {
+		t.Fatalf("review create exit %d: %s", result.ExitCode, result.Combined)
+	}
+	var decoded struct{ ReviewID string }
+	if err := json.Unmarshal([]byte(result.Stdout), &decoded); err != nil {
+		t.Fatalf("decode review create --output json: %v\n%s", err, result.Stdout)
+	}
+	if decoded.ReviewID == "" {
+		t.Fatalf("expected a non-empty reviewId, got:\n%s", result.Stdout)
+	}
+	return decoded
+}
+
+// postCommentJSON runs `review comment --output json` against the stub
+// server and decodes the resulting commentId. parentCommentID is passed as
+// --reply-to when non-empty, making the posted comment a reply.
+func postCommentJSON(t testing.TB, setup env.Setup, reviewID, commitID, filePath string, line int, body, parentCommentID string) string {
+	t.Helper()
+	args := []string{
+		"review", "comment", reviewID, "--commit", commitID, "--file", filePath, "--line", strconv.Itoa(line), "--output", "json",
+	}
+	if parentCommentID != "" {
+		args = append(args, "--reply-to", parentCommentID)
+	}
+	result := erun.Run(t, args, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env(), Stdin: body + "\n"})
+	if result.ExitCode != 0 {
+		t.Fatalf("review comment exit %d: %s", result.ExitCode, result.Combined)
+	}
+	var decoded struct{ CommentID string }
+	if err := json.Unmarshal([]byte(result.Stdout), &decoded); err != nil {
+		t.Fatalf("decode review comment --output json: %v\n%s", err, result.Stdout)
+	}
+	if decoded.CommentID == "" {
+		t.Fatalf("expected a non-empty commentId, got:\n%s", result.Stdout)
+	}
+	return decoded.CommentID
 }
 
 func TestReview(t *testing.T) {
@@ -375,6 +444,82 @@ func TestReview(t *testing.T) {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
 		golden.Equal(t, "review/comment_reply_dry_run", normalize.Apply(result.Combined))
+	})
+
+	t.Run("resolve_dry_run_traces_resolved_call", func(t *testing.T) {
+		setup := env.New(t)
+		seedERunCloudProviderAlias(t, setup, "erun+test@erun", "https://api.example.test", "cli-test-client")
+		result := erun.Run(t, []string{"review", "resolve", "review-1", "comment-1", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "review/resolve_dry_run", normalize.Apply(result.Combined))
+	})
+
+	t.Run("unresolve_dry_run_traces_resolved_call", func(t *testing.T) {
+		setup := env.New(t)
+		seedERunCloudProviderAlias(t, setup, "erun+test@erun", "https://api.example.test", "cli-test-client")
+		result := erun.Run(t, []string{"review", "unresolve", "review-1", "comment-1", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "review/unresolve_dry_run", normalize.Apply(result.Combined))
+	})
+
+	t.Run("resolve_and_unresolve_root_real_run", func(t *testing.T) {
+		// create -> comment (root) -> resolve -> show (unresolved: 0, status=CLOSED)
+		// -> unresolve -> show (unresolved: 1, status=OPEN), covering
+		// PlatformClient.UpdateCommentStatus's request/response handling and
+		// ReviewDetail.UnresolvedThreads end to end.
+		setup := env.New(t)
+		server := reviewAPIStubServer(t)
+		platformAlias(t, setup, server)
+
+		created := createReviewJSON(t, setup, "Resolve test", "feature/resolve", "main")
+		rootID := postCommentJSON(t, setup, created.ReviewID, "abc123", "main.go", 1, "root note", "")
+
+		resolve := erun.Run(t, []string{"review", "resolve", created.ReviewID, rootID}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if resolve.ExitCode != 0 || !strings.Contains(resolve.Combined, "status=CLOSED") {
+			t.Fatalf("resolve exit %d: %s", resolve.ExitCode, resolve.Combined)
+		}
+
+		afterResolve := erun.Run(t, []string{"review", "show", created.ReviewID}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if afterResolve.ExitCode != 0 || !strings.Contains(afterResolve.Combined, "unresolved threads: 0") {
+			t.Fatalf("expected zero unresolved threads after resolve, got:\n%s", afterResolve.Combined)
+		}
+		if !strings.Contains(afterResolve.Combined, "status=CLOSED") {
+			t.Fatalf("expected the root comment's status=CLOSED in show output, got:\n%s", afterResolve.Combined)
+		}
+
+		unresolve := erun.Run(t, []string{"review", "unresolve", created.ReviewID, rootID}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if unresolve.ExitCode != 0 || !strings.Contains(unresolve.Combined, "status=OPEN") {
+			t.Fatalf("unresolve exit %d: %s", unresolve.ExitCode, unresolve.Combined)
+		}
+
+		afterUnresolve := erun.Run(t, []string{"review", "show", created.ReviewID}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if afterUnresolve.ExitCode != 0 || !strings.Contains(afterUnresolve.Combined, "unresolved threads: 1") {
+			t.Fatalf("expected one unresolved thread after unresolve, got:\n%s", afterUnresolve.Combined)
+		}
+	})
+
+	t.Run("resolve_reply_refused_names_root_real_run", func(t *testing.T) {
+		// A status change addressed to a reply must be refused, naming the
+		// thread's root comment id so the caller can retry against it.
+		setup := env.New(t)
+		server := reviewAPIStubServer(t)
+		platformAlias(t, setup, server)
+
+		created := createReviewJSON(t, setup, "Reply refusal test", "feature/reply-refusal", "main")
+		rootID := postCommentJSON(t, setup, created.ReviewID, "abc123", "main.go", 1, "root note", "")
+		replyID := postCommentJSON(t, setup, created.ReviewID, "abc123", "main.go", 1, "reply note", rootID)
+
+		result := erun.Run(t, []string{"review", "resolve", created.ReviewID, replyID}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected resolving a reply to fail, got 0:\n%s", result.Combined)
+		}
+		if !strings.Contains(result.Combined, rootID) {
+			t.Fatalf("expected the refusal to name root comment %s, got:\n%s", rootID, result.Combined)
+		}
 	})
 
 	t.Run("show_not_found_real_run", func(t *testing.T) {

--- a/erun-integration/testdata/review/help.txt
+++ b/erun-integration/testdata/review/help.txt
@@ -9,7 +9,9 @@ Available Commands:
   create      Open a review on the erun platform
   list        List reviews on the erun platform
   queue       Inspect and advance a target branch's merge queue
+  resolve     Resolve a comment thread by closing its root comment
   show        Show a review, its comment threads, and its recorded builds
+  unresolve   Reopen a comment thread by marking its root comment OPEN
 
 Flags:
       --erun-alias string   erun platform cloud alias to target (defaults to the sole configured erun-type alias)

--- a/erun-integration/testdata/review/resolve_dry_run.txt
+++ b/erun-integration/testdata/review/resolve_dry_run.txt
@@ -1,0 +1,4 @@
+Dry run: erun review resolve planned.
+audit: erun review resolve --dry-run review-1 comment-1
+platform: GET https://api.example.test/v1/reviews/review-1/comments
+platform: PATCH https://api.example.test/v1/reviews/review-1/comments/comment-1/status (status=CLOSED)

--- a/erun-integration/testdata/review/unresolve_dry_run.txt
+++ b/erun-integration/testdata/review/unresolve_dry_run.txt
@@ -1,0 +1,4 @@
+Dry run: erun review unresolve planned.
+audit: erun review unresolve --dry-run review-1 comment-1
+platform: GET https://api.example.test/v1/reviews/review-1/comments
+platform: PATCH https://api.example.test/v1/reviews/review-1/comments/comment-1/status (status=OPEN)

--- a/erun-mcp/review.go
+++ b/erun-mcp/review.go
@@ -158,6 +158,42 @@ func reviewCloseTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolR
 	}
 }
 
+type ReviewCommentStatusInput struct {
+	platformAliasInput
+	ReviewID  string `json:"reviewId" jsonschema:"review id the comment belongs to"`
+	CommentID string `json:"commentId" jsonschema:"comment id to change status on; must be a thread's root comment, not a reply"`
+}
+
+func reviewResolveTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, ReviewCommentStatusInput) (*mcp.CallToolResult, ReviewCommentResult, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input ReviewCommentStatusInput) (*mcp.CallToolResult, ReviewCommentResult, error) {
+		if strings.TrimSpace(input.ReviewID) == "" || strings.TrimSpace(input.CommentID) == "" {
+			return nil, ReviewCommentResult{}, fmt.Errorf("reviewId and commentId are required")
+		}
+		traceOutput := strings.Builder{}
+		ctx := runtimeCallContext(input.Preview, input.Verbosity, nil, &traceOutput, &traceOutput)
+		comment, err := eruncommon.RunReviewResolve(ctx, runtime.Store, input.Alias, input.ReviewID, input.CommentID, cloudDependencies())
+		if err != nil {
+			return nil, ReviewCommentResult{}, err
+		}
+		return nil, ReviewCommentResult{Preview: input.Preview, Comment: comment, Trace: normalizeTraceLines(traceOutput.String())}, nil
+	}
+}
+
+func reviewUnresolveTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, ReviewCommentStatusInput) (*mcp.CallToolResult, ReviewCommentResult, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input ReviewCommentStatusInput) (*mcp.CallToolResult, ReviewCommentResult, error) {
+		if strings.TrimSpace(input.ReviewID) == "" || strings.TrimSpace(input.CommentID) == "" {
+			return nil, ReviewCommentResult{}, fmt.Errorf("reviewId and commentId are required")
+		}
+		traceOutput := strings.Builder{}
+		ctx := runtimeCallContext(input.Preview, input.Verbosity, nil, &traceOutput, &traceOutput)
+		comment, err := eruncommon.RunReviewUnresolve(ctx, runtime.Store, input.Alias, input.ReviewID, input.CommentID, cloudDependencies())
+		if err != nil {
+			return nil, ReviewCommentResult{}, err
+		}
+		return nil, ReviewCommentResult{Preview: input.Preview, Comment: comment, Trace: normalizeTraceLines(traceOutput.String())}, nil
+	}
+}
+
 type ReviewMergeQueueListInput struct {
 	platformAliasInput
 	TargetBranch string `json:"targetBranch" jsonschema:"target branch to list the merge queue for"`

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -432,6 +432,14 @@ func registerReviewTools(reg toolRegistrar, runtime RuntimeConfig) {
 		Description: "Comment on a line of a review on the erun platform, or reply to an existing comment with parentCommentId. A real, immediate write, not a preview, unless preview is set.",
 	}, reviewCommentTool(runtime))
 	addTool(reg, &mcp.Tool{
+		Name:        "review_resolve",
+		Description: "Resolve a comment thread on a review by closing its root comment. commentId must be the thread's root comment (the first comment posted at a file/line, not one created with parentCommentId set); addressing a reply fails, naming the root comment to retry against. A real, immediate write, not a preview, unless preview is set.",
+	}, reviewResolveTool(runtime))
+	addTool(reg, &mcp.Tool{
+		Name:        "review_unresolve",
+		Description: "Reopen a comment thread on a review by marking its root comment OPEN again. commentId must be the thread's root comment (the first comment posted at a file/line, not one created with parentCommentId set); addressing a reply fails, naming the root comment to retry against. A real, immediate write, not a preview, unless preview is set.",
+	}, reviewUnresolveTool(runtime))
+	addTool(reg, &mcp.Tool{
 		Name:        "review_close",
 		Description: "Close a review on the erun platform without merging it. A real, immediate write, not a preview, unless preview is set.",
 	}, reviewCloseTool(runtime))

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -168,8 +168,8 @@ var wantRegisteredTools = []string{
 	"platform_tenant_create", "platform_tenant_list", "platform_user_enroll",
 	"platform_user_list", "platform_whoami", "publish", "push", "raw",
 	"release", "review_close", "review_comment", "review_create", "review_list",
-	"review_queue_advance", "review_queue_list", "review_show",
-	"terraform", "unexpose", "upgrade", "usage", "version", "write",
+	"review_queue_advance", "review_queue_list", "review_resolve", "review_show",
+	"review_unresolve", "terraform", "unexpose", "upgrade", "usage", "version", "write",
 }
 
 func TestHTTPHandlerExposesVersionTool(t *testing.T) {

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -1860,6 +1860,8 @@ func tenantDashboardHandler(t *testing.T, jwt string, requests *[]string) http.H
 			_, _ = w.Write([]byte(`[{"buildId":"build-1","tenantId":"tenant-1","reviewId":"review-1","successful":true,"commitId":"abc","version":"1.2.3"}]`))
 		case "/v1/audit-events":
 			_, _ = w.Write([]byte(`{"events":[{"auditEventId":"event-1","tenantId":"tenant-1","erunUserId":"user-1","externalUserId":"subject-1","externalIssuerId":"https://sts.aws.example","type":"API","apiMethod":"GET","apiPath":"/v1/reviews","createdAt":"2026-01-01T00:00:00Z"}]}`))
+		case "/v1/users":
+			_, _ = w.Write([]byte(`[]`))
 		default:
 			http.NotFound(w, req)
 		}
@@ -1873,8 +1875,9 @@ func assertPrimaryCloudDashboard(t *testing.T, dashboard uiTenantDashboard, requ
 		t.Fatalf("unexpected dashboard: %+v", dashboard)
 	}
 	assertPrimaryCloudDashboardAuditEvents(t, dashboard.AuditEvents)
-	if strings.Join(requests, ",") != "/v1/whoami,/v1/reviews,/v1/reviews/merge-queue,/v1/reviews/review-1/builds,/v1/reviews/review-1/comments,/v1/audit-events" {
-		t.Fatalf("unexpected API requests: %+v", requests)
+	want := "/v1/whoami,/v1/users,/v1/reviews,/v1/reviews/merge-queue,/v1/reviews/review-1/builds,/v1/reviews/review-1/comments,/v1/reviews,/v1/reviews,/v1/audit-events"
+	if strings.Join(requests, ",") != want {
+		t.Fatalf("unexpected API requests: %+v, want %q", requests, want)
 	}
 }
 

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -1873,7 +1873,7 @@ func assertPrimaryCloudDashboard(t *testing.T, dashboard uiTenantDashboard, requ
 		t.Fatalf("unexpected dashboard: %+v", dashboard)
 	}
 	assertPrimaryCloudDashboardAuditEvents(t, dashboard.AuditEvents)
-	if strings.Join(requests, ",") != "/v1/whoami,/v1/reviews,/v1/reviews/merge-queue,/v1/reviews/review-1/builds,/v1/audit-events" {
+	if strings.Join(requests, ",") != "/v1/whoami,/v1/reviews,/v1/reviews/merge-queue,/v1/reviews/review-1/builds,/v1/reviews/review-1/comments,/v1/audit-events" {
 		t.Fatalf("unexpected API requests: %+v", requests)
 	}
 }

--- a/erun-ui/frontend/src/app/api/reviewDetailApi.ts
+++ b/erun-ui/frontend/src/app/api/reviewDetailApi.ts
@@ -6,6 +6,7 @@ import type {
   UIReviewDetail,
   UIReviewDetailInput,
   UITenantDashboardReview,
+  UIUpdateReviewCommentStatusInput,
 } from '@/types';
 
 import {
@@ -13,6 +14,8 @@ import {
   CreateReviewComment,
   CreateReviewReply,
   LoadReviewDetail,
+  ResolveReviewComment,
+  UnresolveReviewComment,
 } from '../../../wailsjs/go/main/App';
 import { wailsApi } from './wailsApi';
 import { wailsQueryFn } from './wailsBaseQuery';
@@ -49,6 +52,24 @@ export const reviewDetailApi = wailsApi.injectEndpoints({
         { type: 'TenantDashboard', id: input.tenant },
       ],
     }),
+    resolveReviewComment: builder.mutation<UIReviewComment, UIUpdateReviewCommentStatusInput>({
+      queryFn: wailsQueryFn<UIUpdateReviewCommentStatusInput, UIReviewComment>((input) =>
+        ResolveReviewComment(input),
+      ),
+      invalidatesTags: (_result, _error, input) => [
+        { type: 'ReviewDetail', id: input.reviewId },
+        { type: 'TenantDashboard', id: input.tenant },
+      ],
+    }),
+    unresolveReviewComment: builder.mutation<UIReviewComment, UIUpdateReviewCommentStatusInput>({
+      queryFn: wailsQueryFn<UIUpdateReviewCommentStatusInput, UIReviewComment>((input) =>
+        UnresolveReviewComment(input),
+      ),
+      invalidatesTags: (_result, _error, input) => [
+        { type: 'ReviewDetail', id: input.reviewId },
+        { type: 'TenantDashboard', id: input.tenant },
+      ],
+    }),
   }),
 });
 
@@ -58,4 +79,6 @@ export const {
   useCreateReviewReplyMutation,
   useCreateReviewCommentMutation,
   useCloseReviewMutation,
+  useResolveReviewCommentMutation,
+  useUnresolveReviewCommentMutation,
 } = reviewDetailApi;

--- a/erun-ui/frontend/src/app/reviewDetailState.ts
+++ b/erun-ui/frontend/src/app/reviewDetailState.ts
@@ -1,0 +1,109 @@
+// Reviews-tab and review-detail state, split out of state.ts because that
+// file crossed eslint's 500-line max-lines cap. Nothing here changes shape;
+// state.ts re-exports the whole module so every existing `from './state'`
+// import keeps working.
+import type { UIReviewDetail, UITenantDashboard } from '@/types';
+
+export type TenantDashboardTab = 'users' | 'reviews' | 'queue' | 'builds' | 'audit' | 'api-log';
+
+// ReviewFilterState backs the Reviews tab's one-click discovery filters.
+// Both can be on at once (author=me AND reviewer=me is a valid, if narrow,
+// combination the platform already supports).
+export interface ReviewFilterState {
+  mine: boolean;
+  waitingOnMe: boolean;
+}
+
+export interface TenantDashboardState {
+  tenant: string;
+  tab: TenantDashboardTab;
+  loading: boolean;
+  error: string;
+  data: UITenantDashboard | null;
+  reviewFilter: ReviewFilterState;
+}
+
+// ReviewDetailState backs the dialog a Reviews-tab row opens. draftBody
+// survives a failed reply submit (Nielsen #3, user control) — a submit error
+// clears submitError but never the text the operator already typed.
+export interface ReviewDetailState {
+  open: boolean;
+  reviewId: string;
+  loading: boolean;
+  error: string;
+  data: UIReviewDetail | null;
+  // callerTenant/callerApiUrl/callerCloudProviderAlias are the caller context
+  // resolved when the review loaded, captured here rather than re-derived
+  // from state.tenantDashboard on every write: closing this dialog keeps the
+  // review as the diff panel's active commenting context (see
+  // closeReviewDetail), and by then the operator may have navigated away
+  // from the tenant dashboard entirely.
+  callerTenant: string;
+  callerApiUrl: string;
+  callerCloudProviderAlias: string;
+  replyingTo: string;
+  draftBody: string;
+  submitting: boolean;
+  submitError: string;
+  // closeConfirming is the inline "are you sure" step Close goes through
+  // before the write fires — the same cancel-before-commitment boundary every
+  // other side-effecting dashboard action gets.
+  closeConfirming: boolean;
+  closing: boolean;
+  closeError: string;
+  // resolvingCommentId is the thread root currently being resolved/unresolved
+  // ('' when idle), so only that thread's action shows a busy state.
+  resolvingCommentId: string;
+  // resolveError/resolveErrorCommentId are kept apart from resolvingCommentId
+  // (which clears once the request settles, success or failure) so a failed
+  // resolve still shows its error against the right thread instead of no
+  // thread at all.
+  resolveError: string;
+  resolveErrorCommentId: string;
+  // newCommentAnchor is the diff line the operator clicked to start a new
+  // top-level thread (as opposed to replyingTo, which continues an existing
+  // one). Null means no diff-line composer is open.
+  newCommentAnchor: { commitId: string; filePath: string; line: number } | null;
+  newCommentDraft: string;
+  newCommentSubmitting: boolean;
+  newCommentSubmitError: string;
+}
+
+export const defaultReviewFilter = (): ReviewFilterState => ({
+  mine: false,
+  waitingOnMe: false,
+});
+
+export const defaultTenantDashboard = (): TenantDashboardState => ({
+  tenant: '',
+  tab: 'users',
+  loading: false,
+  error: '',
+  data: null,
+  reviewFilter: defaultReviewFilter(),
+});
+
+export const defaultReviewDetail = (): ReviewDetailState => ({
+  open: false,
+  reviewId: '',
+  loading: false,
+  error: '',
+  data: null,
+  callerTenant: '',
+  callerApiUrl: '',
+  callerCloudProviderAlias: '',
+  replyingTo: '',
+  draftBody: '',
+  submitting: false,
+  submitError: '',
+  closeConfirming: false,
+  closing: false,
+  closeError: '',
+  resolvingCommentId: '',
+  resolveError: '',
+  resolveErrorCommentId: '',
+  newCommentAnchor: null,
+  newCommentDraft: '',
+  newCommentSubmitting: false,
+  newCommentSubmitError: '',
+});

--- a/erun-ui/frontend/src/app/reviewDetailThunks.ts
+++ b/erun-ui/frontend/src/app/reviewDetailThunks.ts
@@ -240,6 +240,66 @@ export const submitCloseReview = (): AppThunk<Promise<void>> => async (dispatch,
   }
 };
 
+// submitResolveComment/submitUnresolveComment resolve or reopen a thread by
+// its root comment id. The dialog only ever offers this on a root — never a
+// reply — so there is no reply-rejection error to translate here, unlike the
+// CLI/MCP paths that accept any comment id.
+export const submitResolveComment = (commentId: string): AppThunk<Promise<void>> =>
+  submitCommentStatus(commentId, 'resolveReviewComment');
+
+export const submitUnresolveComment = (commentId: string): AppThunk<Promise<void>> =>
+  submitCommentStatus(commentId, 'unresolveReviewComment');
+
+function submitCommentStatus(
+  commentId: string,
+  endpoint: 'resolveReviewComment' | 'unresolveReviewComment',
+): AppThunk<Promise<void>> {
+  return async (dispatch, getState) => {
+    const state = getState();
+    const { reviewId } = state.reviewDetail;
+    const input = reviewCallerContext(state, reviewId);
+    if (!input) {
+      dispatch(
+        patchReviewDetail({
+          resolveError: 'Resolving requires an API URL and a primary cloud alias.',
+          resolveErrorCommentId: commentId,
+        }),
+      );
+      return;
+    }
+    dispatch(
+      patchReviewDetail({
+        resolvingCommentId: commentId,
+        resolveError: '',
+        resolveErrorCommentId: '',
+      }),
+    );
+    try {
+      await dispatch(
+        reviewDetailApi.endpoints[endpoint].initiate({
+          tenant: input.tenant,
+          apiUrl: input.apiUrl,
+          cloudProviderAlias: input.cloudProviderAlias,
+          reviewId,
+          commentId,
+        }),
+      ).unwrap();
+      dispatch(
+        patchReviewDetail({ resolvingCommentId: '', resolveError: '', resolveErrorCommentId: '' }),
+      );
+      await dispatch(loadReviewDetail(reviewId));
+    } catch (error) {
+      dispatch(
+        patchReviewDetail({
+          resolvingCommentId: '',
+          resolveError: readError(error),
+          resolveErrorCommentId: commentId,
+        }),
+      );
+    }
+  };
+}
+
 // startReviewComment/cancelReviewComment/setReviewCommentDraft/
 // submitReviewComment mirror the reply flow above, but for opening a brand
 // new top-level thread anchored to a diff line the operator clicked — the

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -9,12 +9,10 @@ import type {
   UIEnvironmentLease,
   UIERunConfig,
   UIIdleStatus,
-  UIReviewDetail,
   UIRuntimeResourceStatus,
   UISelection,
   UITenant,
   UITenantConfig,
-  UITenantDashboard,
   UIVersionSuggestion,
   UIVersionSuggestionNotice,
 } from '@/types';
@@ -22,6 +20,9 @@ import type { UIClusterRegistryStatus, UIEnvironmentHealth } from '@/uiDiagnosti
 import type { UIRuntimeChartPlan } from '@/uiRuntimeChartTypes';
 
 import type { ReachabilityKind } from './reconnectCopy';
+import type { TenantDashboardState } from './reviewDetailState';
+
+export * from './reviewDetailState';
 
 export const MIN_SIDEBAR_WIDTH = 248;
 export const MAX_SIDEBAR_WIDTH = 520;
@@ -144,53 +145,6 @@ export interface TenantDialogState {
   busyAction: '' | 'save' | 'cloud-oidc';
   busyTarget: string;
   error: string;
-}
-
-export type TenantDashboardTab = 'users' | 'reviews' | 'queue' | 'builds' | 'audit' | 'api-log';
-
-export interface TenantDashboardState {
-  tenant: string;
-  tab: TenantDashboardTab;
-  loading: boolean;
-  error: string;
-  data: UITenantDashboard | null;
-}
-
-// ReviewDetailState backs the dialog a Reviews-tab row opens. draftBody
-// survives a failed reply submit (Nielsen #3, user control) — a submit error
-// clears submitError but never the text the operator already typed.
-export interface ReviewDetailState {
-  open: boolean;
-  reviewId: string;
-  loading: boolean;
-  error: string;
-  data: UIReviewDetail | null;
-  // callerTenant/callerApiUrl/callerCloudProviderAlias are the caller context
-  // resolved when the review loaded, captured here rather than re-derived
-  // from state.tenantDashboard on every write: closing this dialog keeps the
-  // review as the diff panel's active commenting context (see
-  // closeReviewDetail), and by then the operator may have navigated away
-  // from the tenant dashboard entirely.
-  callerTenant: string;
-  callerApiUrl: string;
-  callerCloudProviderAlias: string;
-  replyingTo: string;
-  draftBody: string;
-  submitting: boolean;
-  submitError: string;
-  // closeConfirming is the inline "are you sure" step Close goes through
-  // before the write fires — the same cancel-before-commitment boundary every
-  // other side-effecting dashboard action gets.
-  closeConfirming: boolean;
-  closing: boolean;
-  closeError: string;
-  // newCommentAnchor is the diff line the operator clicked to start a new
-  // top-level thread (as opposed to replyingTo, which continues an existing
-  // one). Null means no diff-line composer is open.
-  newCommentAnchor: { commitId: string; filePath: string; line: number } | null;
-  newCommentDraft: string;
-  newCommentSubmitting: boolean;
-  newCommentSubmitError: string;
 }
 
 export interface GlobalConfigDialogState {
@@ -422,36 +376,6 @@ export const defaultTenantDialog = (): TenantDialogState => ({
   busyAction: '',
   busyTarget: '',
   error: '',
-});
-
-export const defaultTenantDashboard = (): TenantDashboardState => ({
-  tenant: '',
-  tab: 'users',
-  loading: false,
-  error: '',
-  data: null,
-});
-
-export const defaultReviewDetail = (): ReviewDetailState => ({
-  open: false,
-  reviewId: '',
-  loading: false,
-  error: '',
-  data: null,
-  callerTenant: '',
-  callerApiUrl: '',
-  callerCloudProviderAlias: '',
-  replyingTo: '',
-  draftBody: '',
-  submitting: false,
-  submitError: '',
-  closeConfirming: false,
-  closing: false,
-  closeError: '',
-  newCommentAnchor: null,
-  newCommentDraft: '',
-  newCommentSubmitting: false,
-  newCommentSubmitError: '',
 });
 
 export const defaultGlobalConfigDialog = (): GlobalConfigDialogState => ({

--- a/erun-ui/frontend/src/app/tenantDashboardPanels.test.ts
+++ b/erun-ui/frontend/src/app/tenantDashboardPanels.test.ts
@@ -5,7 +5,10 @@ import type { UITenantDashboard, UITenantDashboardPanel } from '@/types';
 
 import {
   activeTenantDashboardTab,
+  middleEllipsis,
+  relativeDashboardDate,
   restrictedTenantDashboardReads,
+  reviewAuthorInitials,
   visibleTenantDashboardTabs,
 } from './tenantDashboardPanels';
 
@@ -73,4 +76,29 @@ test('a selected tab the user may not open falls back to one they can', () => {
 test('a selected tab the user may open is kept', () => {
   const data = dashboard([{ tab: 'users' }, { tab: 'queue' }]);
   assert.equal(activeTenantDashboardTab(data, 'queue'), 'queue');
+});
+
+test('relativeDashboardDate reads as a scannable relative phrase, not a raw timestamp', () => {
+  const anHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  assert.match(relativeDashboardDate(anHourAgo), /ago$/);
+  assert.equal(relativeDashboardDate(undefined), '-');
+  assert.equal(relativeDashboardDate('not a date'), 'not a date');
+});
+
+test('reviewAuthorInitials derives up to two letters from a display name', () => {
+  assert.equal(reviewAuthorInitials('You'), 'Y');
+  assert.equal(reviewAuthorInitials('reviewer-1'), 'R1');
+  assert.equal(reviewAuthorInitials('operator'), 'OP');
+  assert.equal(reviewAuthorInitials(''), '?');
+});
+
+test('middleEllipsis keeps both ends of a long identifier visible', () => {
+  const longBranch =
+    'feature/1378-desktop-review-loop-usability-and-craft-pass-for-the-tenant-dashboard-reviews-tab';
+  const shortened = middleEllipsis(longBranch);
+  assert.ok(shortened.startsWith('feature/1378-desktop'));
+  assert.ok(shortened.endsWith('reviews-tab'));
+  assert.ok(shortened.includes('…'));
+  assert.ok(shortened.length < longBranch.length);
+  assert.equal(middleEllipsis('main'), 'main');
 });

--- a/erun-ui/frontend/src/app/tenantDashboardPanels.ts
+++ b/erun-ui/frontend/src/app/tenantDashboardPanels.ts
@@ -99,7 +99,9 @@ export function unresolvedThreadsLabel(count: number): string {
 
 // formatDashboardDate renders a timestamp in the operator's own locale, and
 // falls back to the raw value rather than hiding one the API sent in a shape
-// this build does not recognise.
+// this build does not recognise. Used as the absolute value behind
+// relativeDashboardDate's hover/title, and directly wherever a full
+// timestamp (not a scannable relative one) is what's needed.
 export function formatDashboardDate(value: string | undefined): string {
   if (!value) {
     return '-';
@@ -109,4 +111,64 @@ export function formatDashboardDate(value: string | undefined): string {
     return value;
   }
   return date.toLocaleString();
+}
+
+const relativeTimeFormatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+const relativeTimeUnits: { unit: Intl.RelativeTimeFormatUnit; ms: number }[] = [
+  { unit: 'year', ms: 365 * 24 * 60 * 60 * 1000 },
+  { unit: 'month', ms: 30 * 24 * 60 * 60 * 1000 },
+  { unit: 'day', ms: 24 * 60 * 60 * 1000 },
+  { unit: 'hour', ms: 60 * 60 * 1000 },
+  { unit: 'minute', ms: 60 * 1000 },
+];
+
+// relativeDashboardDate renders "2 days ago" instead of a raw locale string —
+// nobody scans absolute timestamps in a column of rows (#1378). Callers pair
+// this with formatDashboardDate as the hover/title value so the exact moment
+// is still one hover away, never lost.
+export function relativeDashboardDate(value: string | undefined): string {
+  if (!value) {
+    return '-';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  const diffMs = date.getTime() - Date.now();
+  for (const { unit, ms } of relativeTimeUnits) {
+    if (Math.abs(diffMs) >= ms) {
+      return relativeTimeFormatter.format(Math.round(diffMs / ms), unit);
+    }
+  }
+  return relativeTimeFormatter.format(Math.round(diffMs / 1000), 'second');
+}
+
+// reviewAuthorInitials derives an avatar's letters from a display name (a
+// resolved username, "You", or a raw id fallback) — up to two characters, so
+// the avatar is still a meaningful scan key when no username resolved.
+export function reviewAuthorInitials(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return '?';
+  }
+  if (trimmed === 'You') {
+    return 'Y';
+  }
+  const tokens = trimmed.split(/[\s._-]+/).filter(Boolean);
+  const first = tokens[0]?.[0] ?? '';
+  const second = tokens[1]?.[0] ?? tokens[0]?.[1] ?? '';
+  const initials = (first + second).toUpperCase();
+  return initials || '?';
+}
+
+// middleEllipsis keeps both ends of an identifier visible — a branch name's
+// prefix and suffix both carry meaning, unlike prose, where a trailing "…"
+// would drop the more identifying half (#1378).
+export function middleEllipsis(value: string, keep = 20): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= keep * 2 + 1) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, keep)}…${trimmed.slice(-keep)}`;
 }

--- a/erun-ui/frontend/src/app/tenantDashboardPanels.ts
+++ b/erun-ui/frontend/src/app/tenantDashboardPanels.ts
@@ -83,6 +83,20 @@ export function reviewStatusTone(status: string): StatusBadgeTone {
   return reviewStatusTones[status.trim().toUpperCase()] ?? 'warning';
 }
 
+// unresolvedThreadsTone renders the count as a quantity, not just a colour:
+// zero reads as done (success), any other count as still-open (warning) —
+// WCAG 1.4.1 again, so the label carries the fact even without colour.
+export function unresolvedThreadsTone(count: number): StatusBadgeTone {
+  return count === 0 ? 'success' : 'warning';
+}
+
+export function unresolvedThreadsLabel(count: number): string {
+  if (count === 0) {
+    return 'All resolved';
+  }
+  return count === 1 ? '1 unresolved' : `${String(count)} unresolved`;
+}
+
 // formatDashboardDate renders a timestamp in the operator's own locale, and
 // falls back to the raw value rather than hiding one the API sent in a shape
 // this build does not recognise.

--- a/erun-ui/frontend/src/app/tenantDialogThunks.ts
+++ b/erun-ui/frontend/src/app/tenantDialogThunks.ts
@@ -11,7 +11,13 @@ import { setSelected } from './slices/selectionSlice';
 import { patchTenantDashboard, setTenantDashboard } from './slices/tenantDashboardSlice';
 import { patchTenantDialog, setTenantDialog } from './slices/tenantDialogSlice';
 import { setCloudProviders, setTenants } from './slices/tenantsSlice';
-import { defaultTenantDialog, type TenantDashboardTab, type TenantDialogState } from './state';
+import {
+  defaultReviewFilter,
+  defaultTenantDialog,
+  type ReviewFilterState,
+  type TenantDashboardTab,
+  type TenantDialogState,
+} from './state';
 import type { AppThunk } from './store';
 import { requireController } from './thunkExtra';
 
@@ -242,15 +248,17 @@ export const openTenantDashboard =
       return;
     }
     const currentDashboard = getState().tenantDashboard;
+    const sameTenant = currentDashboard.tenant === tenant;
     dispatch(setSelected(null));
     dispatch(setIdleStatus(null));
     dispatch(
       setTenantDashboard({
         tenant,
-        tab: currentDashboard.tenant === tenant ? currentDashboard.tab : 'users',
+        tab: sameTenant ? currentDashboard.tab : 'users',
         loading: true,
         error: '',
         data: null,
+        reviewFilter: sameTenant ? currentDashboard.reviewFilter : defaultReviewFilter(),
       }),
     );
     dispatch(setReviewOpen(false));
@@ -264,6 +272,18 @@ export const setTenantDashboardTab =
     dispatch(patchTenantDashboard({ tab }));
   };
 
+// setReviewFilter applies a Reviews-tab discovery filter and reloads the
+// dashboard so the new filter reaches the platform read, not just local
+// state — matching every other tenant-dashboard filter's the-list-is-the-
+// state-of-the-world contract.
+export const setReviewFilter =
+  (next: Partial<ReviewFilterState>): AppThunk<Promise<void>> =>
+  async (dispatch, getState) => {
+    const reviewFilter = { ...getState().tenantDashboard.reviewFilter, ...next };
+    dispatch(patchTenantDashboard({ reviewFilter }));
+    await dispatch(loadTenantDashboard());
+  };
+
 export const loadTenantDashboard =
   (tenant?: string): AppThunk<Promise<void>> =>
   async (dispatch, getState) => {
@@ -273,7 +293,7 @@ export const loadTenantDashboard =
       return;
     }
     const tenantState = state.tenants.tenants.find((candidate) => candidate.name === target);
-    const input = tenantDashboardInput(tenantState);
+    const input = tenantDashboardInput(tenantState, state.tenantDashboard.reviewFilter);
     if (!input) {
       dispatch(
         patchTenantDashboard({
@@ -331,7 +351,10 @@ export const refreshTenantDashboard = (): AppThunk<Promise<void>> => async (disp
   }
 };
 
-function tenantDashboardInput(tenant: UITenant | undefined): UITenantDashboardInput | null {
+function tenantDashboardInput(
+  tenant: UITenant | undefined,
+  reviewFilter: ReviewFilterState,
+): UITenantDashboardInput | null {
   if (!tenant) {
     return null;
   }
@@ -348,6 +371,8 @@ function tenantDashboardInput(tenant: UITenant | undefined): UITenantDashboardIn
     mcpUrl: trimOptional(environment?.mcpUrl),
     kubernetesContext: trimOptional(environment?.kubernetesContext),
     cloudProviderAlias,
+    reviewFilterMine: reviewFilter.mine,
+    reviewFilterWaitingOnMe: reviewFilter.waitingOnMe,
   };
 }
 

--- a/erun-ui/frontend/src/components/app/DiffList.tsx
+++ b/erun-ui/frontend/src/components/app/DiffList.tsx
@@ -13,6 +13,7 @@ import { copyToClipboard } from '@/components/app/ActivityQueueDrawer.helpers';
 import type { DiffFile, DiffHunk, DiffResult } from '@/types';
 
 import { DiffLineCommentAction } from './DiffList.CommentAction';
+import { ReviewEnvLabel } from './ReviewPanel.EnvLabel';
 
 export function DiffList(): React.ReactElement {
   const targets = useAppSelector(selectReviewEnvTargets);
@@ -50,9 +51,15 @@ function DiffEnvSection({
   const collapsedDiffDirs = useAppSelector((state) => state.review.collapsedDiffDirs);
   const selectedDiffPath = useAppSelector((state) => state.review.selectedDiffPath);
 
+  // The same ReviewEnvLabel treatment the review-layers block and the
+  // changed-files tree use (#1314), so all three per-environment surfaces
+  // read as one group instead of three independently-labelled ones. The
+  // sticky wrapper stays: it is a real functional need (this header keeps the
+  // active environment identity visible while a long diff scrolls), unlike
+  // the label styling it wraps.
   const header = showHeader ? (
-    <div className="sticky top-0 z-10 border-b border-border bg-background px-3 py-1 text-xs font-medium text-muted-foreground">
-      {target.envKey}
+    <div className="sticky top-0 z-10 border-b border-border bg-background px-3 py-1">
+      <ReviewEnvLabel tenant={target.tenant} environment={target.environment} />
     </div>
   ) : null;
 

--- a/erun-ui/frontend/src/components/app/InlineAlert.tsx
+++ b/erun-ui/frontend/src/components/app/InlineAlert.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle } from 'lucide-react';
+import { AlertCircle, Lock } from 'lucide-react';
 import * as React from 'react';
 
 // InlineAlert is the shared surface for a write that was attempted and
@@ -14,6 +14,24 @@ export function InlineAlert({ children }: { children: React.ReactNode }): React.
       className="flex w-full items-start gap-2 rounded-[var(--radius)] border border-[color-mix(in_oklch,var(--destructive)_36%,transparent)] bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] px-[11px] py-[9px] text-[13px] leading-[1.35] text-destructive [overflow-wrap:anywhere]"
     >
       <AlertCircle className="mt-px size-3.5 shrink-0" aria-hidden="true" />
+      <span className="min-w-0">{children}</span>
+    </div>
+  );
+}
+
+// PermissionNotice is the shared "you may not see/do this" surface: a caller
+// missing access is a state, not a fault, so it gets a neutral treatment and
+// role="status" rather than InlineAlert's destructive role="alert" — the same
+// distinction ReviewPanel.ts's reachabilityStatuses draws for "not a fault".
+// Replaces a permission note dropped in a layout gap as plain muted text,
+// which reads as inert body copy beside the control it explains (#1378).
+export function PermissionNotice({ children }: { children: React.ReactNode }): React.ReactElement {
+  return (
+    <div
+      role="status"
+      className="flex w-full items-start gap-2 rounded-[var(--radius)] border border-border bg-muted/40 px-[11px] py-[9px] text-[13px] leading-[1.35] text-muted-foreground [overflow-wrap:anywhere]"
+    >
+      <Lock className="mt-px size-3.5 shrink-0" aria-hidden="true" />
       <span className="min-w-0">{children}</span>
     </div>
   );

--- a/erun-ui/frontend/src/components/app/ReviewDetailDialog.Comments.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewDetailDialog.Comments.tsx
@@ -12,10 +12,30 @@ import {
   submitUnresolveComment,
 } from '@/app/reviewDetailThunks';
 import type { ReviewDetailState } from '@/app/state';
-import { formatDashboardDate } from '@/app/tenantDashboardPanels';
 import type { UIReviewComment } from '@/types';
 
 import { InlineAlert } from './InlineAlert';
+import { RelativeTime } from './TenantDashboardMessage';
+
+// commentAuthorDisplay prefers the resolved tenant-user-directory username
+// over the raw creator id (#1378) — the same fallback order
+// displayReviewAuthor uses in the reviews list, minus the "You" special case:
+// the dialog has no signed-in user id threaded down to it, and the raw id is
+// still a meaningful fallback rather than nothing.
+function commentAuthorDisplay(comment: UIReviewComment): string {
+  const id = comment.creatorUserId?.trim() ?? '';
+  if (!id) {
+    return 'Unknown';
+  }
+  return comment.creatorUsername?.trim() ?? id;
+}
+
+// COMMENT_PREVIEW_LENGTH bounds a comment body before it needs an explicit
+// "Show more" — long enough that ordinary comments never see it, short
+// enough that a very long one doesn't push Reply/Resolve off without warning
+// (#1378: a review tool that cannot display a long comment has failed at its
+// core job).
+const COMMENT_PREVIEW_LENGTH = 400;
 
 // ReviewDetailComments renders the review's threads (root comments with their
 // replies nested under them) and, per thread, a reply composer. Starting a
@@ -153,10 +173,15 @@ function ResolveThreadAction({
     return null;
   }
   const busy = detail.resolvingCommentId === root.commentId;
+  // Resolving is the action that moves the review forward, so it carries the
+  // primary button weight — Reply stays outline (secondary) beside it,
+  // matching how the repo already distinguishes primary from secondary
+  // actions elsewhere (#1378). Reopening a thread is a correction, not the
+  // forward action, so it keeps the outline treatment.
   return (
     <Button
       type="button"
-      variant="outline"
+      variant={resolved ? 'outline' : 'default'}
       disabled={busy}
       onClick={() => {
         void dispatch(
@@ -192,18 +217,50 @@ function CommentLine({ comment }: { comment: UIReviewComment }): React.ReactElem
     <div className="min-w-0">
       <div className="flex min-w-0 items-center gap-2 text-[13px]">
         <span className="flex-none font-medium text-foreground">
-          {comment.creatorUserId ?? 'Unknown'}
+          {commentAuthorDisplay(comment)}
         </span>
-        <span className="min-w-0 truncate text-muted-foreground">
-          {comment.filePath}:{comment.line}
+        {/* The anchor is commit + file + line — the line stays flex-none so it
+            is never the part truncation eats; only the file path shrinks. */}
+        <span className="flex-none font-mono text-muted-foreground">
+          {comment.commitId.slice(0, 7)}
         </span>
-        <span className="flex-none text-muted-foreground">
-          {formatDashboardDate(comment.createdAt)}
+        <span className="min-w-0 truncate text-muted-foreground" title={comment.filePath}>
+          {comment.filePath}
         </span>
+        <span className="flex-none font-mono text-muted-foreground">:{comment.line}</span>
+        <RelativeTime value={comment.createdAt} className="flex-none text-muted-foreground" />
       </div>
-      <p className="mt-1 max-h-48 overflow-y-auto whitespace-pre-wrap text-foreground">
-        {comment.body}
-      </p>
+      <CommentBody body={comment.body} />
+    </div>
+  );
+}
+
+// CommentBody gives a long comment a visible way to read the rest instead of
+// relying on an invisible scroll region (#1378): a native scrollbar inside a
+// max-height box gave no affordance that more text existed, so a long
+// comment read as silently clipped. Collapsed text still shows a preview
+// (not just "click to reveal a blank box"), and the toggle is a real control
+// rather than a hover-only scrollbar a keyboard user cannot discover.
+function CommentBody({ body }: { body: string }): React.ReactElement {
+  const [expanded, setExpanded] = React.useState(false);
+  const isLong = body.length > COMMENT_PREVIEW_LENGTH;
+  const shown = !isLong || expanded ? body : `${body.slice(0, COMMENT_PREVIEW_LENGTH)}…`;
+  return (
+    <div className="mt-1">
+      <p className="max-w-[640px] whitespace-pre-wrap text-foreground">{shown}</p>
+      {isLong && (
+        <Button
+          type="button"
+          variant="link"
+          size="xs"
+          className="h-auto px-0"
+          onClick={() => {
+            setExpanded((value) => !value);
+          }}
+        >
+          {expanded ? 'Show less' : 'Show more'}
+        </Button>
+      )}
     </div>
   );
 }

--- a/erun-ui/frontend/src/components/app/ReviewDetailDialog.Comments.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewDetailDialog.Comments.tsx
@@ -1,4 +1,4 @@
-import { Button, EmptyState, Input } from 'erun-kit';
+import { Button, EmptyState, Input, StatusBadge } from 'erun-kit';
 import { LoaderCircle } from 'lucide-react';
 import * as React from 'react';
 
@@ -7,7 +7,9 @@ import {
   cancelReviewReply,
   setReviewReplyDraft,
   setReviewReplyTarget,
+  submitResolveComment,
   submitReviewReply,
+  submitUnresolveComment,
 } from '@/app/reviewDetailThunks';
 import type { ReviewDetailState } from '@/app/state';
 import { formatDashboardDate } from '@/app/tenantDashboardPanels';
@@ -69,46 +71,137 @@ function CommentThread({
   replies: UIReviewComment[];
   detail: ReviewDetailState;
 }): React.ReactElement {
-  const dispatch = useAppDispatch();
-  const replyingHere = detail.replyingTo === root.commentId;
+  const resolved = root.status === 'CLOSED';
   return (
     <div className="rounded-[var(--radius)] border border-border px-3 py-2.5 text-sm">
-      <CommentLine comment={root} />
+      <div className="flex items-start justify-between gap-2">
+        <CommentLine comment={root} />
+        <StatusBadge
+          tone={resolved ? 'success' : 'warning'}
+          label={resolved ? 'Resolved' : 'Unresolved'}
+        />
+      </div>
       {replies.map((reply) => (
         <div key={reply.commentId} className="mt-2 border-t border-border pt-2 pl-3">
           <CommentLine comment={reply} />
         </div>
       ))}
-      {detail.data?.canComment &&
-        (replyingHere ? (
-          <ReplyComposer detail={detail} />
-        ) : (
-          <Button
-            type="button"
-            variant="outline"
-            className="mt-2"
-            onClick={() => {
-              dispatch(setReviewReplyTarget(root.commentId));
-            }}
-          >
-            Reply
-          </Button>
-        ))}
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <ReplyAction root={root} detail={detail} />
+        <ResolveThreadAction root={root} resolved={resolved} detail={detail} />
+      </div>
+      <ThreadReplyComposer root={root} detail={detail} />
+      <ThreadResolveError root={root} detail={detail} />
+    </div>
+  );
+}
+
+// ReplyAction is hidden once this thread is already being replied to (the
+// composer takes its place) and whenever the caller may not comment at all.
+function ReplyAction({
+  root,
+  detail,
+}: {
+  root: UIReviewComment;
+  detail: ReviewDetailState;
+}): React.ReactElement | null {
+  const dispatch = useAppDispatch();
+  if (!detail.data?.canComment || detail.replyingTo === root.commentId) {
+    return null;
+  }
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      onClick={() => {
+        dispatch(setReviewReplyTarget(root.commentId));
+      }}
+    >
+      Reply
+    </Button>
+  );
+}
+
+function ThreadReplyComposer({
+  root,
+  detail,
+}: {
+  root: UIReviewComment;
+  detail: ReviewDetailState;
+}): React.ReactElement | null {
+  if (detail.replyingTo !== root.commentId || !detail.data?.canComment) {
+    return null;
+  }
+  return <ReplyComposer detail={detail} />;
+}
+
+// ResolveThreadAction is offered only on a thread's root — never a reply —
+// so the surface cannot ask for a status change the platform will refuse.
+// Hidden entirely when the caller lacks the write permission (degrade by
+// permission, not by a failed submit).
+function ResolveThreadAction({
+  root,
+  resolved,
+  detail,
+}: {
+  root: UIReviewComment;
+  resolved: boolean;
+  detail: ReviewDetailState;
+}): React.ReactElement | null {
+  const dispatch = useAppDispatch();
+  if (!detail.data?.canResolveComments) {
+    return null;
+  }
+  const busy = detail.resolvingCommentId === root.commentId;
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      disabled={busy}
+      onClick={() => {
+        void dispatch(
+          resolved ? submitUnresolveComment(root.commentId) : submitResolveComment(root.commentId),
+        );
+      }}
+    >
+      {busy && <LoaderCircle className="animate-spin" aria-hidden="true" />}
+      {resolved ? 'Reopen' : 'Resolve'}
+    </Button>
+  );
+}
+
+function ThreadResolveError({
+  root,
+  detail,
+}: {
+  root: UIReviewComment;
+  detail: ReviewDetailState;
+}): React.ReactElement | null {
+  if (detail.resolveErrorCommentId !== root.commentId || !detail.resolveError) {
+    return null;
+  }
+  return (
+    <div className="mt-2">
+      <InlineAlert>{detail.resolveError}</InlineAlert>
     </div>
   );
 }
 
 function CommentLine({ comment }: { comment: UIReviewComment }): React.ReactElement {
   return (
-    <div>
-      <div className="flex items-center gap-2 text-[13px]">
+    <div className="min-w-0">
+      <div className="flex min-w-0 items-center gap-2 text-[13px]">
         <span className="font-medium text-foreground">{comment.creatorUserId ?? 'Unknown'}</span>
-        <span className="text-muted-foreground">
+        <span className="min-w-0 truncate text-muted-foreground">
           {comment.filePath}:{comment.line}
         </span>
-        <span className="text-muted-foreground">{formatDashboardDate(comment.createdAt)}</span>
+        <span className="flex-none text-muted-foreground">
+          {formatDashboardDate(comment.createdAt)}
+        </span>
       </div>
-      <p className="mt-1 whitespace-pre-wrap text-foreground">{comment.body}</p>
+      <p className="mt-1 max-h-48 overflow-y-auto whitespace-pre-wrap text-foreground">
+        {comment.body}
+      </p>
     </div>
   );
 }

--- a/erun-ui/frontend/src/components/app/ReviewDetailDialog.Comments.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewDetailDialog.Comments.tsx
@@ -191,7 +191,9 @@ function CommentLine({ comment }: { comment: UIReviewComment }): React.ReactElem
   return (
     <div className="min-w-0">
       <div className="flex min-w-0 items-center gap-2 text-[13px]">
-        <span className="font-medium text-foreground">{comment.creatorUserId ?? 'Unknown'}</span>
+        <span className="flex-none font-medium text-foreground">
+          {comment.creatorUserId ?? 'Unknown'}
+        </span>
         <span className="min-w-0 truncate text-muted-foreground">
           {comment.filePath}:{comment.line}
         </span>

--- a/erun-ui/frontend/src/components/app/ReviewDetailDialog.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewDetailDialog.tsx
@@ -19,7 +19,12 @@ import {
   submitCloseReview,
 } from '@/app/reviewDetailThunks';
 import type { ReviewDetailState } from '@/app/state';
-import { formatDashboardDate, reviewStatusTone } from '@/app/tenantDashboardPanels';
+import {
+  formatDashboardDate,
+  reviewStatusTone,
+  unresolvedThreadsLabel,
+  unresolvedThreadsTone,
+} from '@/app/tenantDashboardPanels';
 import type { UITenantDashboardBuild, UITenantDashboardReview } from '@/types';
 
 import { InlineAlert } from './InlineAlert';
@@ -114,12 +119,40 @@ function ReviewDetailLoaded({
           {data.queuePosition ? ` · queue position ${String(data.queuePosition)}` : ''}
         </DialogDescription>
       </DialogHeader>
+      <ReviewDetailThreadStatus data={data} />
       <CloseReviewAction review={review} data={data} detail={detail} />
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
         <ReviewDetailBuilds data={data} />
         <ReviewDetailComments detail={detail} />
       </div>
     </>
+  );
+}
+
+// ReviewDetailThreadStatus is the "is this review actually finished" signal
+// at the top of the dialog, visible without scrolling into the comments
+// list. Rendered only once at least one thread exists — a review with no
+// comments yet has nothing to call "all resolved".
+function ReviewDetailThreadStatus({
+  data,
+}: {
+  data: NonNullable<ReviewDetailState['data']>;
+}): React.ReactElement | null {
+  if (data.commentsRestricted || data.commentsError) {
+    return null;
+  }
+  const roots = (data.comments ?? []).filter((comment) => !comment.parentCommentId);
+  if (roots.length === 0) {
+    return null;
+  }
+  const unresolved = data.unresolvedThreads ?? 0;
+  return (
+    <div>
+      <StatusBadge
+        tone={unresolvedThreadsTone(unresolved)}
+        label={unresolvedThreadsLabel(unresolved)}
+      />
+    </div>
   );
 }
 

--- a/erun-ui/frontend/src/components/app/ReviewDetailDialog.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewDetailDialog.tsx
@@ -20,15 +20,15 @@ import {
 } from '@/app/reviewDetailThunks';
 import type { ReviewDetailState } from '@/app/state';
 import {
-  formatDashboardDate,
   reviewStatusTone,
   unresolvedThreadsLabel,
   unresolvedThreadsTone,
 } from '@/app/tenantDashboardPanels';
 import type { UITenantDashboardBuild, UITenantDashboardReview } from '@/types';
 
-import { InlineAlert } from './InlineAlert';
+import { InlineAlert, PermissionNotice } from './InlineAlert';
 import { ReviewDetailComments } from './ReviewDetailDialog.Comments';
+import { BranchArrow, RelativeTime } from './TenantDashboardMessage';
 
 // ReviewDetailDialog is the review object's own detail surface, opened from a
 // row in the tenant dashboard's Reviews tab. Named "review detail" — not
@@ -46,7 +46,7 @@ export function ReviewDetailDialog(): React.ReactElement {
         }
       }}
     >
-      <DialogContent className="flex max-h-[85vh] flex-col overflow-hidden sm:max-w-lg">
+      <DialogContent className="flex max-h-[85vh] flex-col overflow-hidden sm:max-w-3xl">
         <ReviewDetailBody detail={detail} />
       </DialogContent>
     </Dialog>
@@ -114,9 +114,11 @@ function ReviewDetailLoaded({
           {review.name || review.reviewId}
           <StatusBadge tone={reviewStatusTone(review.status)} label={review.status} />
         </DialogTitle>
-        <DialogDescription>
-          {review.sourceBranch} → {review.targetBranch}
-          {data.queuePosition ? ` · queue position ${String(data.queuePosition)}` : ''}
+        <DialogDescription className="flex min-w-0 items-center gap-1.5">
+          <BranchArrow source={review.sourceBranch} target={review.targetBranch} />
+          {data.queuePosition ? (
+            <span className="flex-none">· queue position {data.queuePosition}</span>
+          ) : null}
         </DialogDescription>
       </DialogHeader>
       <ReviewDetailThreadStatus data={data} />
@@ -176,11 +178,7 @@ function CloseReviewAction({
     return null;
   }
   if (!data.canClose) {
-    return (
-      <p className="text-[13px] text-muted-foreground">
-        You do not have access to close this review.
-      </p>
-    );
+    return <PermissionNotice>You do not have access to close this review.</PermissionNotice>;
   }
   if (detail.closeConfirming) {
     return (
@@ -269,7 +267,7 @@ function ReviewDetailBuildRow({ build }: { build: UITenantDashboardBuild }): Rea
       />
       <span className="text-muted-foreground">{build.commitId}</span>
       {build.version && <span className="text-muted-foreground">v{build.version}</span>}
-      <span className="ml-auto text-muted-foreground">{formatDashboardDate(build.createdAt)}</span>
+      <RelativeTime value={build.createdAt} className="ml-auto text-muted-foreground" />
     </li>
   );
 }

--- a/erun-ui/frontend/src/components/app/ReviewPanel.ChangedFiles.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewPanel.ChangedFiles.tsx
@@ -11,6 +11,8 @@ import { useEnvDiffSlot } from '@/app/useEnvDiffSlot';
 import { ReviewStatus } from '@/components/app/DiffList';
 import type { DiffTreeNode } from '@/types';
 
+import { ReviewEnvLabel } from './ReviewPanel.EnvLabel';
+
 export function ChangedFileTree(): React.ReactElement {
   const targets = useAppSelector(selectReviewEnvTargets);
   if (targets.length === 0) {
@@ -20,7 +22,13 @@ export function ChangedFileTree(): React.ReactElement {
   return (
     <>
       {targets.map((target) => (
-        <ChangedFileTreeSection key={target.envKey} envKey={target.envKey} showHeader={multi} />
+        <ChangedFileTreeSection
+          key={target.envKey}
+          envKey={target.envKey}
+          tenant={target.tenant}
+          environment={target.environment}
+          showHeader={multi}
+        />
       ))}
     </>
   );
@@ -39,9 +47,13 @@ export function ChangedFileTree(): React.ReactElement {
 // panel, which keeps the one actionable report.
 function ChangedFileTreeSection({
   envKey,
+  tenant,
+  environment,
   showHeader,
 }: {
   envKey: string;
+  tenant: string;
+  environment: string;
   showHeader: boolean;
 }): React.ReactElement {
   const slot = useEnvDiffSlot(envKey);
@@ -49,7 +61,9 @@ function ChangedFileTreeSection({
   const collapsedDiffDirs = useAppSelector((state) => state.review.collapsedDiffDirs);
 
   const header = showHeader ? (
-    <div className="px-1 pt-2 pb-1 text-[11px] font-medium text-muted-foreground">{envKey}</div>
+    <div className="px-1 pt-2 pb-1">
+      <ReviewEnvLabel tenant={tenant} environment={environment} />
+    </div>
   ) : null;
 
   const body = ((): React.ReactElement => {

--- a/erun-ui/frontend/src/components/app/ReviewPanel.EnvLabel.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewPanel.EnvLabel.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+// ReviewEnvLabel is the one label treatment shared by the review-layers block
+// (ReviewPanel.tsx) and the changed-files tree section (ReviewPanel.ChangedFiles.tsx)
+// for the same environment (#1314): both render this exact component when
+// more than one environment is in scope, so the two read as one group instead
+// of two independently-labelled lists. "tenant / environment" (spaced) reads
+// as the app's existing environment presentation, matching the format
+// sidebar/aria-label text already uses, rather than the raw
+// `tenant/environment` envKey.
+export function ReviewEnvLabel({
+  tenant,
+  environment,
+}: {
+  tenant: string;
+  environment: string;
+}): React.ReactElement {
+  return (
+    <div className="min-w-0 truncate text-sm font-semibold text-foreground">
+      {tenant} / {environment}
+    </div>
+  );
+}

--- a/erun-ui/frontend/src/components/app/ReviewPanel.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewPanel.tsx
@@ -28,6 +28,7 @@ import type { DiffCommit } from '@/types';
 
 import { DiffList } from './DiffList';
 import { ChangedFileTree } from './ReviewPanel.ChangedFiles';
+import { ReviewEnvLabel } from './ReviewPanel.EnvLabel';
 
 const filesSplitterClassName =
   'relative cursor-col-resize border-l bg-background before:absolute before:top-0 before:bottom-0 before:left-1 before:w-px before:bg-transparent before:transition-colors hover:before:bg-border [.is-resizing-files_&]:before:bg-border';
@@ -299,7 +300,17 @@ function ReviewBoundaryTrack({
 // SelectedCommit are all per-repository, so a commit list or a base commit
 // shared across two unrelated checkouts would be a value that means nothing
 // (#1178).
-function ReviewRangeControl({ envKey }: { envKey: string }): React.ReactElement | null {
+function ReviewRangeControl({
+  envKey,
+  tenant,
+  environment,
+  showEnvLabel,
+}: {
+  envKey: string;
+  tenant: string;
+  environment: string;
+  showEnvLabel: boolean;
+}): React.ReactElement | null {
   const dispatch = useAppDispatch();
   const slot = useEnvDiffSlot(envKey);
   const diff = slot.diff;
@@ -308,9 +319,9 @@ function ReviewRangeControl({ envKey }: { envKey: string }): React.ReactElement 
   if (!base?.commit && commits.length === 0) {
     return null;
   }
-
   return (
     <div className="mb-3.5 flex min-h-0 flex-col gap-2 border-b border-border pb-3.5">
+      {showEnvLabel && <ReviewEnvLabel tenant={tenant} environment={environment} />}
       <div className="flex min-w-0 flex-col gap-0.5">
         <div className="text-xs font-semibold text-foreground">Review layers</div>
         <div className="text-[11px] leading-4 text-muted-foreground">
@@ -399,10 +410,17 @@ function ReviewBoundaryButton({
 // each has its own commit list.
 function ReviewRangeControls(): React.ReactElement {
   const targets = useAppSelector(selectReviewEnvTargets);
+  const multi = targets.length > 1;
   return (
     <>
       {targets.map((target) => (
-        <ReviewRangeControl key={target.envKey} envKey={target.envKey} />
+        <ReviewRangeControl
+          key={target.envKey}
+          envKey={target.envKey}
+          tenant={target.tenant}
+          environment={target.environment}
+          showEnvLabel={multi}
+        />
       ))}
     </>
   );

--- a/erun-ui/frontend/src/components/app/TenantDashboardMessage.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardMessage.tsx
@@ -68,12 +68,21 @@ export function DashboardMessage({
 export function DataTable({
   headers,
   children,
+  minWidthClassName,
 }: {
   headers: string[];
   children: React.ReactNode;
+  // minWidthClassName floors a wide table (many columns, e.g. the reviews
+  // table's Review/Status/Author/Target/Source/Updated/Threads) so a narrow
+  // viewport scrolls the table horizontally (the panel around it is already
+  // overflow-auto) instead of table-fixed shrinking every column past
+  // readability — a status badge missing its last letter is unreadable, not
+  // truncated. Omitted for narrower tables (Users, Builds, Audit), which fit
+  // without it.
+  minWidthClassName?: string;
 }): React.ReactElement {
   return (
-    <table className="mt-4 w-full table-fixed border-collapse text-sm">
+    <table className={`mt-4 w-full table-fixed border-collapse text-sm ${minWidthClassName ?? ''}`}>
       <thead>
         <tr className="border-b border-border text-left text-xs font-medium uppercase text-muted-foreground">
           {headers.map((header) => (

--- a/erun-ui/frontend/src/components/app/TenantDashboardMessage.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardMessage.tsx
@@ -1,4 +1,47 @@
+import { EmptyState } from 'erun-kit';
 import * as React from 'react';
+
+import type { AppState } from '@/app/state';
+import { tenantDashboardPanel } from '@/app/tenantDashboardPanels';
+
+export type TenantDashboardData = AppState['tenantDashboard']['data'];
+
+// PanelBody renders one panel's three distinguishable outcomes: it failed,
+// there is nothing in it, or here it is. "You may not read this" never
+// reaches here — a restricted panel has no tab to open. Shared by every
+// TenantDashboardPanels* file rather than duplicated per panel, and kept in
+// this message-focused module (not TenantDashboardPanels.tsx) so the panel
+// files can both depend on it without importing each other.
+export function PanelBody({
+  data,
+  tab,
+  empty,
+  children,
+}: {
+  data: TenantDashboardData;
+  tab: 'users' | 'reviews' | 'queue' | 'builds' | 'audit';
+  empty: React.ReactElement;
+  children: React.ReactNode;
+}): React.ReactElement {
+  const panel = tenantDashboardPanel(data, tab);
+  if (panel?.restricted) {
+    return (
+      <div className="mt-4">
+        <EmptyState
+          heading="You do not have access to this panel"
+          body={`It needs ${panel.restricted}. Ask an administrator for access.`}
+        />
+      </div>
+    );
+  }
+  if (panel?.error) {
+    return <DashboardMessage message={panel.error} destructive />;
+  }
+  if (!children) {
+    return <div className="mt-4">{empty}</div>;
+  }
+  return <>{children}</>;
+}
 
 // DashboardMessage carries a status line or a failure for one dashboard surface.
 // It is deliberately not input-shaped: an empty panel uses EmptyState instead,

--- a/erun-ui/frontend/src/components/app/TenantDashboardMessage.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardMessage.tsx
@@ -1,8 +1,13 @@
-import { EmptyState } from 'erun-kit';
+import { cn, EmptyState } from 'erun-kit';
 import * as React from 'react';
 
 import type { AppState } from '@/app/state';
-import { tenantDashboardPanel } from '@/app/tenantDashboardPanels';
+import {
+  formatDashboardDate,
+  middleEllipsis,
+  relativeDashboardDate,
+  tenantDashboardPanel,
+} from '@/app/tenantDashboardPanels';
 
 export type TenantDashboardData = AppState['tenantDashboard']['data'];
 
@@ -69,6 +74,7 @@ export function DataTable({
   headers,
   children,
   minWidthClassName,
+  columnWidths,
 }: {
   headers: string[];
   children: React.ReactNode;
@@ -80,13 +86,19 @@ export function DataTable({
   // truncated. Omitted for narrower tables (Users, Builds, Audit), which fit
   // without it.
   minWidthClassName?: string;
+  // columnWidths sets each header's width class, same length/order as
+  // headers; a header left without one shares the width table-fixed leaves
+  // over once the sized columns are subtracted. Lets a table give most of its
+  // width to one dominant column (the reviews table's Review cell) instead of
+  // table-fixed's default equal split.
+  columnWidths?: string[];
 }): React.ReactElement {
   return (
     <table className={`mt-4 w-full table-fixed border-collapse text-sm ${minWidthClassName ?? ''}`}>
       <thead>
         <tr className="border-b border-border text-left text-xs font-medium uppercase text-muted-foreground">
-          {headers.map((header) => (
-            <th key={header} className="px-2 py-2">
+          {headers.map((header, index) => (
+            <th key={header} className={cn('px-2 py-2', columnWidths?.[index])}>
               {header}
             </th>
           ))}
@@ -94,6 +106,53 @@ export function DataTable({
       </thead>
       <tbody className="divide-y divide-border">{children}</tbody>
     </table>
+  );
+}
+
+// RelativeTime renders a scannable relative phrase ("2 days ago") with the
+// exact timestamp one hover away — nobody scans a column of absolute
+// timestamps, but the exact moment still matters and must not be lost (#1378).
+export function RelativeTime({
+  value,
+  className,
+}: {
+  value: string | undefined;
+  className?: string;
+}): React.ReactElement {
+  return (
+    <span className={className} title={formatDashboardDate(value)}>
+      {relativeDashboardDate(value)}
+    </span>
+  );
+}
+
+// BranchArrow is the review object's "where it's headed" line — source →
+// target — shared by the reviews list row and the review detail dialog's
+// header (#1378) so the two read as one treatment. Each side middle-ellipses
+// on its own (keeping both the identifying prefix and suffix, unlike a
+// trailing "…") with the full value one hover away, so a long branch name
+// never pushes the arrow off-row or wraps the header into several lines.
+export function BranchArrow({
+  source,
+  target,
+  className,
+}: {
+  source: string;
+  target: string;
+  className?: string;
+}): React.ReactElement {
+  return (
+    <span className={cn('inline-flex min-w-0 items-center gap-1.5', className)}>
+      <span className="min-w-0 truncate" title={source}>
+        {middleEllipsis(source)}
+      </span>
+      <span aria-hidden="true" className="flex-none text-muted-foreground/70">
+        →
+      </span>
+      <span className="min-w-0 truncate" title={target}>
+        {middleEllipsis(target)}
+      </span>
+    </span>
   );
 }
 

--- a/erun-ui/frontend/src/components/app/TenantDashboardPanels.Reviews.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardPanels.Reviews.tsx
@@ -1,8 +1,7 @@
 // Reviews and merge-queue panels, split out of TenantDashboardPanels.tsx
-// because that file crossed eslint's 500-line max-lines cap. Nothing here
-// changes shape or behaviour — the two tabs still share PanelBody and
-// TenantDashboardData from the main file.
-import { Button, EmptyState, StatusBadge, TabsContent } from 'erun-kit';
+// because that file crossed eslint's 500-line max-lines cap. The two tabs
+// still share PanelBody and TenantDashboardData from the main file.
+import { Button, cn, EmptyState, StatusBadge, TabsContent } from 'erun-kit';
 import { LoaderCircle, Plus } from 'lucide-react';
 import * as React from 'react';
 
@@ -15,7 +14,7 @@ import {
 } from '@/app/mergeQueueThunks';
 import { openReviewDetail } from '@/app/reviewDetailThunks';
 import {
-  formatDashboardDate,
+  reviewAuthorInitials,
   reviewStatusTone,
   unresolvedThreadsLabel,
   unresolvedThreadsTone,
@@ -23,8 +22,15 @@ import {
 import { setReviewFilter } from '@/app/tenantDialogThunks';
 import type { UITenantDashboardReview } from '@/types';
 
-import { InlineAlert } from './InlineAlert';
-import { DataCell, DataTable, PanelBody, type TenantDashboardData } from './TenantDashboardMessage';
+import { InlineAlert, PermissionNotice } from './InlineAlert';
+import {
+  BranchArrow,
+  DataCell,
+  DataTable,
+  PanelBody,
+  RelativeTime,
+  type TenantDashboardData,
+} from './TenantDashboardMessage';
 
 // ReviewsPanel is the review object's own home: status, branches, and — via
 // each row — its builds, comment threads, and merge-queue position. The
@@ -37,21 +43,19 @@ export function ReviewsPanel({ data }: { data: TenantDashboardData }): React.Rea
   return (
     <TabsContent value="reviews" className="min-h-0 overflow-auto">
       <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-center gap-3">
           <span className="text-[13px] text-muted-foreground">
             {reviews.length} review{reviews.length === 1 ? '' : 's'}
           </span>
-          <ReviewFilterToggle
-            label="Mine"
-            active={reviewFilter.mine}
-            onClick={() => {
+          <ReviewFilterSegmentedControl
+            mine={reviewFilter.mine}
+            waitingOnMe={reviewFilter.waitingOnMe}
+            mineCount={data?.mineReviewCount}
+            waitingOnMeCount={data?.waitingOnMeReviewCount}
+            onToggleMine={() => {
               void dispatch(setReviewFilter({ mine: !reviewFilter.mine }));
             }}
-          />
-          <ReviewFilterToggle
-            label="Waiting on me"
-            active={reviewFilter.waitingOnMe}
-            onClick={() => {
+            onToggleWaitingOnMe={() => {
               void dispatch(setReviewFilter({ waitingOnMe: !reviewFilter.waitingOnMe }));
             }}
           />
@@ -78,29 +82,81 @@ export function ReviewsPanel({ data }: { data: TenantDashboardData }): React.Rea
   );
 }
 
+// ReviewFilterSegmentedControl is one grouped control, not two independent
+// buttons (#1378): Mine and Waiting-on-me visually merge into a single pill,
+// matching the DiffSourceButton segmented-toggle pattern the review panel's
+// Env/ERun source switch already uses (Nielsen #4, consistency). Each side
+// still toggles independently — a review can be both — so this is a grouped
+// filter chip pair, not a mutually-exclusive tab strip. The count on each
+// side is the discovery signal itself: which pile has work in it is visible
+// before either is clicked, rather than only after.
+function ReviewFilterSegmentedControl({
+  mine,
+  waitingOnMe,
+  mineCount,
+  waitingOnMeCount,
+  onToggleMine,
+  onToggleWaitingOnMe,
+}: {
+  mine: boolean;
+  waitingOnMe: boolean;
+  mineCount: number | undefined;
+  waitingOnMeCount: number | undefined;
+  onToggleMine: () => void;
+  onToggleWaitingOnMe: () => void;
+}): React.ReactElement {
+  return (
+    <div className="flex items-center gap-1 rounded-[var(--radius)] border border-input bg-background p-1 text-[13px]">
+      <ReviewFilterToggle label="Mine" count={mineCount} active={mine} onClick={onToggleMine} />
+      <ReviewFilterToggle
+        label="Waiting on me"
+        count={waitingOnMeCount}
+        active={waitingOnMe}
+        onClick={onToggleWaitingOnMe}
+      />
+    </div>
+  );
+}
+
 // ReviewFilterToggle is a one-click discovery affordance, not a form field:
-// clicking answers "which are mine" or "which are waiting on me" directly,
-// matching the DiffSourceButton toggle-button pattern already used for the
-// review panel's Env/ERun source switch.
+// clicking answers "which are mine" or "which are waiting on me" directly.
+// The count renders inside the button's own accessible name (e.g. "Mine 2")
+// so a screen reader announces the same distribution a sighted operator sees.
 function ReviewFilterToggle({
   label,
+  count,
   active,
   onClick,
 }: {
   label: string;
+  count: number | undefined;
   active: boolean;
   onClick: () => void;
 }): React.ReactElement {
   return (
-    <Button
+    <button
       type="button"
-      size="sm"
-      variant={active ? 'default' : 'outline'}
       aria-pressed={active}
       onClick={onClick}
+      className={cn(
+        'flex cursor-pointer items-center gap-1.5 rounded-[calc(var(--radius)-2px)] px-2.5 py-1 transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-none',
+        active
+          ? 'bg-primary text-primary-foreground'
+          : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+      )}
     >
       {label}
-    </Button>
+      {count !== undefined && (
+        <span
+          className={cn(
+            'inline-flex min-w-[1.25rem] items-center justify-center rounded-full px-1 text-[11px] leading-4 font-semibold',
+            active ? 'bg-primary-foreground/20' : 'bg-muted text-foreground',
+          )}
+        >
+          {count}
+        </span>
+      )}
+    </button>
   );
 }
 
@@ -147,9 +203,9 @@ function NewReviewAction({ data }: { data: TenantDashboardData }): React.ReactEl
   }
   if (!data.canCreateReview) {
     return (
-      <span className="text-[13px] text-muted-foreground">
-        You do not have access to open reviews.
-      </span>
+      <div className="max-w-sm">
+        <PermissionNotice>You do not have access to create reviews.</PermissionNotice>
+      </div>
     );
   }
   return (
@@ -214,9 +270,9 @@ function AdvanceMergeQueueAction({
   }
   if (!data.canAdvanceMergeQueue) {
     return (
-      <span className="text-[13px] text-muted-foreground">
-        You do not have access to advance the merge queue.
-      </span>
+      <div className="max-w-sm">
+        <PermissionNotice>You do not have access to advance the merge queue.</PermissionNotice>
+      </div>
     );
   }
   if (mergeQueue.length === 0) {
@@ -297,22 +353,51 @@ function AdvanceMergeQueueConfirm({
   );
 }
 
-// displayReviewAuthor renders "You" for the signed-in user's own reviews and
-// the raw author id otherwise — the same treatment the Audit panel's Actor
-// column already gives an external user id, since the desktop has no user
-// directory to resolve a name from (Nielsen #4, consistency with a
-// comparable flow already in this dashboard).
+// displayReviewAuthor renders "You" for the signed-in user's own reviews,
+// then the resolved tenant-user-directory username, then the raw author id
+// as a last resort (#1378) — never a bare implementation-facing id when a
+// human name is available.
 function displayReviewAuthor(
-  authorUserId: string | undefined,
+  review: UITenantDashboardReview,
   currentUserId: string | undefined,
 ): string {
-  const author = authorUserId?.trim() ?? '';
+  const author = review.authorUserId?.trim() ?? '';
   if (!author) {
     return '-';
   }
-  return currentUserId && author === currentUserId ? 'You' : author;
+  if (currentUserId && author === currentUserId) {
+    return 'You';
+  }
+  return review.authorUsername?.trim() ?? author;
 }
 
+// ReviewAuthorAvatar is the row's fastest scan key: an initials avatar for
+// the author display name already computed for the row, styled filled for
+// the signed-in user's own reviews so "mine" is recognizable at a glance
+// even before reading the text next to it.
+function ReviewAuthorAvatar({ name }: { name: string }): React.ReactElement {
+  const isSelf = name === 'You';
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        'flex size-7 flex-none items-center justify-center rounded-full text-[11px] font-semibold',
+        isSelf ? 'bg-primary text-primary-foreground' : 'bg-primary/10 text-primary',
+      )}
+    >
+      {reviewAuthorInitials(name)}
+    </span>
+  );
+}
+
+// ReviewsTable renders one row per review. The Review column is deliberately
+// the only one DataTable's shared truncate/DataCell treatment doesn't own: it
+// carries the avatar plus a two-line title/metadata stack so the title can
+// dominate the row (larger, heavier, full-strength foreground) while author,
+// branches, updated time, and thread count read as a subordinate second line
+// — a dense grid of eight equal columns gave nothing for the eye to land on
+// (#1378). Status and Threads stay their own narrow columns so their badges
+// keep a fixed, predictable width.
 function ReviewsTable({
   reviews,
   currentUserId,
@@ -324,51 +409,79 @@ function ReviewsTable({
   showThreads?: boolean;
   onSelect?: (review: UITenantDashboardReview) => void;
 }): React.ReactElement {
-  const headers = ['Review', 'Status', 'Author', 'Target', 'Source', 'Updated'];
+  const headers = ['Review', 'Status'];
+  const columnWidths = ['', 'w-[110px]'];
   if (showThreads) {
     headers.push('Threads');
+    columnWidths.push('w-[130px]');
   }
   return (
-    <DataTable headers={headers} minWidthClassName="min-w-[820px]">
-      {reviews.map((review) => (
-        <tr key={review.reviewId}>
-          <DataCell strong>
-            {onSelect ? (
-              <button
-                type="button"
-                className="text-left text-foreground underline-offset-2 hover:underline focus-visible:underline"
-                onClick={() => {
-                  onSelect(review);
-                }}
-                aria-label={`Open review ${review.name || review.reviewId}`}
-              >
-                {review.name || review.reviewId}
-              </button>
-            ) : (
-              review.name || review.reviewId
-            )}
-          </DataCell>
-          <DataCell>
-            <StatusBadge tone={reviewStatusTone(review.status)} label={review.status} />
-          </DataCell>
-          <DataCell>{displayReviewAuthor(review.authorUserId, currentUserId)}</DataCell>
-          <DataCell>{review.targetBranch}</DataCell>
-          <DataCell>{review.sourceBranch}</DataCell>
-          <DataCell>{formatDashboardDate(review.updatedAt)}</DataCell>
-          {showThreads && (
+    <DataTable headers={headers} columnWidths={columnWidths} minWidthClassName="min-w-[760px]">
+      {reviews.map((review) => {
+        const title = review.name || review.reviewId;
+        const author = displayReviewAuthor(review, currentUserId);
+        return (
+          <tr key={review.reviewId}>
+            <td className="px-2 py-2.5">
+              <div className="flex min-w-0 items-center gap-2.5">
+                <ReviewAuthorAvatar name={author} />
+                <div className="flex min-w-0 flex-col gap-0.5">
+                  {onSelect ? (
+                    <button
+                      type="button"
+                      title={title}
+                      className="min-w-0 truncate text-left text-[14px] font-semibold text-foreground underline-offset-2 hover:underline focus-visible:underline"
+                      onClick={() => {
+                        onSelect(review);
+                      }}
+                      aria-label={`Open review ${title}`}
+                    >
+                      {title}
+                    </button>
+                  ) : (
+                    <span
+                      title={title}
+                      className="min-w-0 truncate text-[14px] font-semibold text-foreground"
+                    >
+                      {title}
+                    </span>
+                  )}
+                  <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+                    <span className="flex-none">{author}</span>
+                    <span aria-hidden="true" className="flex-none">
+                      ·
+                    </span>
+                    <BranchArrow
+                      source={review.sourceBranch}
+                      target={review.targetBranch}
+                      className="min-w-0 flex-1"
+                    />
+                    <span aria-hidden="true" className="flex-none">
+                      ·
+                    </span>
+                    <RelativeTime value={review.updatedAt} className="flex-none" />
+                  </div>
+                </div>
+              </div>
+            </td>
             <DataCell>
-              {review.unresolvedThreads === undefined ? (
-                '-'
-              ) : (
-                <StatusBadge
-                  tone={unresolvedThreadsTone(review.unresolvedThreads)}
-                  label={unresolvedThreadsLabel(review.unresolvedThreads)}
-                />
-              )}
+              <StatusBadge tone={reviewStatusTone(review.status)} label={review.status} />
             </DataCell>
-          )}
-        </tr>
-      ))}
+            {showThreads && (
+              <DataCell>
+                {review.unresolvedThreads === undefined ? (
+                  '-'
+                ) : (
+                  <StatusBadge
+                    tone={unresolvedThreadsTone(review.unresolvedThreads)}
+                    label={unresolvedThreadsLabel(review.unresolvedThreads)}
+                  />
+                )}
+              </DataCell>
+            )}
+          </tr>
+        );
+      })}
     </DataTable>
   );
 }

--- a/erun-ui/frontend/src/components/app/TenantDashboardPanels.Reviews.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardPanels.Reviews.tsx
@@ -329,7 +329,7 @@ function ReviewsTable({
     headers.push('Threads');
   }
   return (
-    <DataTable headers={headers}>
+    <DataTable headers={headers} minWidthClassName="min-w-[820px]">
       {reviews.map((review) => (
         <tr key={review.reviewId}>
           <DataCell strong>

--- a/erun-ui/frontend/src/components/app/TenantDashboardPanels.Reviews.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardPanels.Reviews.tsx
@@ -1,0 +1,374 @@
+// Reviews and merge-queue panels, split out of TenantDashboardPanels.tsx
+// because that file crossed eslint's 500-line max-lines cap. Nothing here
+// changes shape or behaviour — the two tabs still share PanelBody and
+// TenantDashboardData from the main file.
+import { Button, EmptyState, StatusBadge, TabsContent } from 'erun-kit';
+import { LoaderCircle, Plus } from 'lucide-react';
+import * as React from 'react';
+
+import { openCreateReviewDialog } from '@/app/createReviewDialogThunks';
+import { useAppDispatch, useAppSelector } from '@/app/hooks';
+import {
+  cancelAdvanceMergeQueue,
+  confirmAdvanceMergeQueue,
+  submitAdvanceMergeQueue,
+} from '@/app/mergeQueueThunks';
+import { openReviewDetail } from '@/app/reviewDetailThunks';
+import {
+  formatDashboardDate,
+  reviewStatusTone,
+  unresolvedThreadsLabel,
+  unresolvedThreadsTone,
+} from '@/app/tenantDashboardPanels';
+import { setReviewFilter } from '@/app/tenantDialogThunks';
+import type { UITenantDashboardReview } from '@/types';
+
+import { InlineAlert } from './InlineAlert';
+import { DataCell, DataTable, PanelBody, type TenantDashboardData } from './TenantDashboardMessage';
+
+// ReviewsPanel is the review object's own home: status, branches, and — via
+// each row — its builds, comment threads, and merge-queue position. The
+// merge-queue tab stays a queue-shaped view of the same reviews.
+export function ReviewsPanel({ data }: { data: TenantDashboardData }): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const reviewFilter = useAppSelector((state) => state.tenantDashboard.reviewFilter);
+  const reviews = data?.reviews ?? [];
+  const filterActive = reviewFilter.mine || reviewFilter.waitingOnMe;
+  return (
+    <TabsContent value="reviews" className="min-h-0 overflow-auto">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-[13px] text-muted-foreground">
+            {reviews.length} review{reviews.length === 1 ? '' : 's'}
+          </span>
+          <ReviewFilterToggle
+            label="Mine"
+            active={reviewFilter.mine}
+            onClick={() => {
+              void dispatch(setReviewFilter({ mine: !reviewFilter.mine }));
+            }}
+          />
+          <ReviewFilterToggle
+            label="Waiting on me"
+            active={reviewFilter.waitingOnMe}
+            onClick={() => {
+              void dispatch(setReviewFilter({ waitingOnMe: !reviewFilter.waitingOnMe }));
+            }}
+          />
+        </div>
+        <NewReviewAction data={data} />
+      </div>
+      <PanelBody
+        data={data}
+        tab="reviews"
+        empty={<ReviewsEmptyState filterActive={filterActive} />}
+      >
+        {reviews.length > 0 ? (
+          <ReviewsTable
+            reviews={reviews}
+            currentUserId={data?.user?.userId}
+            showThreads
+            onSelect={(review) => {
+              void dispatch(openReviewDetail(review.reviewId));
+            }}
+          />
+        ) : null}
+      </PanelBody>
+    </TabsContent>
+  );
+}
+
+// ReviewFilterToggle is a one-click discovery affordance, not a form field:
+// clicking answers "which are mine" or "which are waiting on me" directly,
+// matching the DiffSourceButton toggle-button pattern already used for the
+// review panel's Env/ERun source switch.
+function ReviewFilterToggle({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}): React.ReactElement {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant={active ? 'default' : 'outline'}
+      aria-pressed={active}
+      onClick={onClick}
+    >
+      {label}
+    </Button>
+  );
+}
+
+// ReviewsEmptyState keeps "nothing exists yet" and "nothing matches this
+// filter" visually and textually distinct, per the repo's three-empty-states
+// rule — a filtered zero must not read as "this tenant has no reviews".
+function ReviewsEmptyState({ filterActive }: { filterActive: boolean }): React.ReactElement {
+  const dispatch = useAppDispatch();
+  if (filterActive) {
+    return (
+      <EmptyState
+        heading="No reviews match this filter"
+        body="Nothing is both Mine and Waiting on me right now, whichever you've turned on."
+        action={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              void dispatch(setReviewFilter({ mine: false, waitingOnMe: false }));
+            }}
+          >
+            Clear filter
+          </Button>
+        }
+      />
+    );
+  }
+  return (
+    <EmptyState
+      heading="No reviews yet"
+      body="A review appears here once someone opens one from the CLI's erun review create or the New review button above."
+    />
+  );
+}
+
+// NewReviewAction degrades by permission: the button renders only when the
+// caller may create a review, and a caller who cannot is told so rather than
+// left to discover it from a failed submit.
+function NewReviewAction({ data }: { data: TenantDashboardData }): React.ReactElement | null {
+  const dispatch = useAppDispatch();
+  if (!data) {
+    return null;
+  }
+  if (!data.canCreateReview) {
+    return (
+      <span className="text-[13px] text-muted-foreground">
+        You do not have access to open reviews.
+      </span>
+    );
+  }
+  return (
+    <Button
+      type="button"
+      size="sm"
+      onClick={() => {
+        void dispatch(openCreateReviewDialog());
+      }}
+    >
+      <Plus aria-hidden="true" />
+      New review
+    </Button>
+  );
+}
+
+export function MergeQueuePanel({ data }: { data: TenantDashboardData }): React.ReactElement {
+  const mergeQueue = data?.mergeQueue ?? [];
+  return (
+    <TabsContent value="queue" className="min-h-0 overflow-auto">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <span className="text-[13px] text-muted-foreground">{mergeQueue.length} queued</span>
+        <AdvanceMergeQueueAction data={data} mergeQueue={mergeQueue} />
+      </div>
+      <PanelBody
+        data={data}
+        tab="queue"
+        empty={
+          <EmptyState
+            heading="No reviews are waiting in the merge queue"
+            body="A review joins the queue once a build has passed for it."
+          />
+        }
+      >
+        {mergeQueue.length > 0 ? <ReviewsTable reviews={mergeQueue} /> : null}
+      </PanelBody>
+    </TabsContent>
+  );
+}
+
+// mergeQueueTargetBranch reports the target branch to advance only when the
+// whole visible queue shares one — advancing is a single-queue-head write, so
+// a mixed-branch queue has no single unambiguous head to name from here.
+function mergeQueueTargetBranch(mergeQueue: UITenantDashboardReview[]): string {
+  const branches = [...new Set(mergeQueue.map((review) => review.targetBranch.trim()))].filter(
+    Boolean,
+  );
+  return branches.length === 1 ? (branches[0] ?? '') : '';
+}
+
+function AdvanceMergeQueueAction({
+  data,
+  mergeQueue,
+}: {
+  data: TenantDashboardData;
+  mergeQueue: UITenantDashboardReview[];
+}): React.ReactElement | null {
+  const dispatch = useAppDispatch();
+  const action = useAppSelector((state) => state.mergeQueueAction);
+  if (!data) {
+    return null;
+  }
+  if (!data.canAdvanceMergeQueue) {
+    return (
+      <span className="text-[13px] text-muted-foreground">
+        You do not have access to advance the merge queue.
+      </span>
+    );
+  }
+  if (mergeQueue.length === 0) {
+    return null;
+  }
+  const targetBranch = mergeQueueTargetBranch(mergeQueue);
+  if (!targetBranch) {
+    return (
+      <span className="max-w-xs text-right text-[13px] text-muted-foreground">
+        These reviews target more than one branch, so there is no single queue head to advance.
+      </span>
+    );
+  }
+  return (
+    <div className="flex min-w-0 flex-col items-end gap-2">
+      {action.confirming ? (
+        <AdvanceMergeQueueConfirm targetBranch={targetBranch} busy={action.busy} />
+      ) : (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            dispatch(confirmAdvanceMergeQueue());
+          }}
+        >
+          Advance queue
+        </Button>
+      )}
+      {action.error && (
+        <div className="max-w-sm">
+          <InlineAlert>{action.error}</InlineAlert>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// The confirm step is its own row so the question reads left-to-right into the
+// two answers, and a failure lands under it rather than shouldering its way
+// into the middle of the sentence.
+function AdvanceMergeQueueConfirm({
+  targetBranch,
+  busy,
+}: {
+  targetBranch: string;
+  busy: boolean;
+}): React.ReactElement {
+  const dispatch = useAppDispatch();
+  return (
+    <div className="flex flex-wrap items-center justify-end gap-2">
+      <span className="text-[13px] text-foreground">
+        Merge the queue head into <span className="font-mono">{targetBranch}</span>?
+      </span>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={busy}
+        onClick={() => {
+          dispatch(cancelAdvanceMergeQueue());
+        }}
+      >
+        Cancel
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        disabled={busy}
+        onClick={() => {
+          void dispatch(submitAdvanceMergeQueue(targetBranch));
+        }}
+      >
+        {busy && <LoaderCircle className="animate-spin" aria-hidden="true" />}
+        Confirm
+      </Button>
+    </div>
+  );
+}
+
+// displayReviewAuthor renders "You" for the signed-in user's own reviews and
+// the raw author id otherwise — the same treatment the Audit panel's Actor
+// column already gives an external user id, since the desktop has no user
+// directory to resolve a name from (Nielsen #4, consistency with a
+// comparable flow already in this dashboard).
+function displayReviewAuthor(
+  authorUserId: string | undefined,
+  currentUserId: string | undefined,
+): string {
+  const author = authorUserId?.trim() ?? '';
+  if (!author) {
+    return '-';
+  }
+  return currentUserId && author === currentUserId ? 'You' : author;
+}
+
+function ReviewsTable({
+  reviews,
+  currentUserId,
+  showThreads = false,
+  onSelect,
+}: {
+  reviews: UITenantDashboardReview[];
+  currentUserId?: string;
+  showThreads?: boolean;
+  onSelect?: (review: UITenantDashboardReview) => void;
+}): React.ReactElement {
+  const headers = ['Review', 'Status', 'Author', 'Target', 'Source', 'Updated'];
+  if (showThreads) {
+    headers.push('Threads');
+  }
+  return (
+    <DataTable headers={headers}>
+      {reviews.map((review) => (
+        <tr key={review.reviewId}>
+          <DataCell strong>
+            {onSelect ? (
+              <button
+                type="button"
+                className="text-left text-foreground underline-offset-2 hover:underline focus-visible:underline"
+                onClick={() => {
+                  onSelect(review);
+                }}
+                aria-label={`Open review ${review.name || review.reviewId}`}
+              >
+                {review.name || review.reviewId}
+              </button>
+            ) : (
+              review.name || review.reviewId
+            )}
+          </DataCell>
+          <DataCell>
+            <StatusBadge tone={reviewStatusTone(review.status)} label={review.status} />
+          </DataCell>
+          <DataCell>{displayReviewAuthor(review.authorUserId, currentUserId)}</DataCell>
+          <DataCell>{review.targetBranch}</DataCell>
+          <DataCell>{review.sourceBranch}</DataCell>
+          <DataCell>{formatDashboardDate(review.updatedAt)}</DataCell>
+          {showThreads && (
+            <DataCell>
+              {review.unresolvedThreads === undefined ? (
+                '-'
+              ) : (
+                <StatusBadge
+                  tone={unresolvedThreadsTone(review.unresolvedThreads)}
+                  label={unresolvedThreadsLabel(review.unresolvedThreads)}
+                />
+              )}
+            </DataCell>
+          )}
+        </tr>
+      ))}
+    </DataTable>
+  );
+}

--- a/erun-ui/frontend/src/components/app/TenantDashboardPanels.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardPanels.tsx
@@ -1,32 +1,21 @@
-import { Button, EmptyState, StatusBadge, TabsContent } from 'erun-kit';
-import { LoaderCircle, Plus } from 'lucide-react';
+import { EmptyState, StatusBadge, TabsContent } from 'erun-kit';
 import * as React from 'react';
 
-import { openCreateReviewDialog } from '@/app/createReviewDialogThunks';
-import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import {
-  cancelAdvanceMergeQueue,
-  confirmAdvanceMergeQueue,
-  submitAdvanceMergeQueue,
-} from '@/app/mergeQueueThunks';
-import { openReviewDetail } from '@/app/reviewDetailThunks';
-import type { AppState } from '@/app/state';
-import {
-  formatDashboardDate,
-  reviewStatusTone,
-  tenantDashboardPanel,
-} from '@/app/tenantDashboardPanels';
+import { formatDashboardDate } from '@/app/tenantDashboardPanels';
 import type {
   UITenantDashboardAudit,
   UITenantDashboardBuild,
-  UITenantDashboardReview,
   UITenantDashboardUser,
 } from '@/types';
 
-import { InlineAlert } from './InlineAlert';
-import { DashboardMessage, DataCell, DataTable } from './TenantDashboardMessage';
-
-type TenantDashboardData = AppState['tenantDashboard']['data'];
+import {
+  DashboardMessage,
+  DataCell,
+  DataTable,
+  PanelBody,
+  type TenantDashboardData,
+} from './TenantDashboardMessage';
+import { MergeQueuePanel, ReviewsPanel } from './TenantDashboardPanels.Reviews';
 
 export function TenantDashboardPanels({ data }: { data: TenantDashboardData }): React.ReactElement {
   return (
@@ -43,72 +32,6 @@ export function TenantDashboardPanels({ data }: { data: TenantDashboardData }): 
   );
 }
 
-// ReviewsPanel is the review object's own home: status, branches, and — via
-// each row — its builds, comment threads, and merge-queue position. The
-// merge-queue tab stays a queue-shaped view of the same reviews.
-function ReviewsPanel({ data }: { data: TenantDashboardData }): React.ReactElement {
-  const dispatch = useAppDispatch();
-  const reviews = data?.reviews ?? [];
-  return (
-    <TabsContent value="reviews" className="min-h-0 overflow-auto">
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <span className="text-[13px] text-muted-foreground">
-          {reviews.length} review{reviews.length === 1 ? '' : 's'}
-        </span>
-        <NewReviewAction data={data} />
-      </div>
-      <PanelBody
-        data={data}
-        tab="reviews"
-        empty={
-          <EmptyState
-            heading="No reviews yet"
-            body="A review appears here once someone opens one from the CLI's erun review create or the New review button above."
-          />
-        }
-      >
-        {reviews.length > 0 ? (
-          <ReviewsTable
-            reviews={reviews}
-            onSelect={(review) => {
-              void dispatch(openReviewDetail(review.reviewId));
-            }}
-          />
-        ) : null}
-      </PanelBody>
-    </TabsContent>
-  );
-}
-
-// NewReviewAction degrades by permission: the button renders only when the
-// caller may create a review, and a caller who cannot is told so rather than
-// left to discover it from a failed submit.
-function NewReviewAction({ data }: { data: TenantDashboardData }): React.ReactElement | null {
-  const dispatch = useAppDispatch();
-  if (!data) {
-    return null;
-  }
-  if (!data.canCreateReview) {
-    return (
-      <span className="text-[13px] text-muted-foreground">
-        You do not have access to open reviews.
-      </span>
-    );
-  }
-  return (
-    <Button
-      type="button"
-      size="sm"
-      onClick={() => {
-        void dispatch(openCreateReviewDialog());
-      }}
-    >
-      <Plus aria-hidden="true" />
-      New review
-    </Button>
-  );
-}
-
 function UsersPanel({ data }: { data: TenantDashboardData }): React.ReactElement {
   const user = data?.user;
   return (
@@ -117,137 +40,6 @@ function UsersPanel({ data }: { data: TenantDashboardData }): React.ReactElement
         {user ? <UsersTable users={[user]} /> : null}
       </PanelBody>
     </TabsContent>
-  );
-}
-
-function MergeQueuePanel({ data }: { data: TenantDashboardData }): React.ReactElement {
-  const mergeQueue = data?.mergeQueue ?? [];
-  return (
-    <TabsContent value="queue" className="min-h-0 overflow-auto">
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <span className="text-[13px] text-muted-foreground">{mergeQueue.length} queued</span>
-        <AdvanceMergeQueueAction data={data} mergeQueue={mergeQueue} />
-      </div>
-      <PanelBody
-        data={data}
-        tab="queue"
-        empty={
-          <EmptyState
-            heading="No reviews are waiting in the merge queue"
-            body="A review joins the queue once a build has passed for it."
-          />
-        }
-      >
-        {mergeQueue.length > 0 ? <ReviewsTable reviews={mergeQueue} /> : null}
-      </PanelBody>
-    </TabsContent>
-  );
-}
-
-// mergeQueueTargetBranch reports the target branch to advance only when the
-// whole visible queue shares one — advancing is a single-queue-head write, so
-// a mixed-branch queue has no single unambiguous head to name from here.
-function mergeQueueTargetBranch(mergeQueue: UITenantDashboardReview[]): string {
-  const branches = [...new Set(mergeQueue.map((review) => review.targetBranch.trim()))].filter(
-    Boolean,
-  );
-  return branches.length === 1 ? (branches[0] ?? '') : '';
-}
-
-function AdvanceMergeQueueAction({
-  data,
-  mergeQueue,
-}: {
-  data: TenantDashboardData;
-  mergeQueue: UITenantDashboardReview[];
-}): React.ReactElement | null {
-  const dispatch = useAppDispatch();
-  const action = useAppSelector((state) => state.mergeQueueAction);
-  if (!data) {
-    return null;
-  }
-  if (!data.canAdvanceMergeQueue) {
-    return (
-      <span className="text-[13px] text-muted-foreground">
-        You do not have access to advance the merge queue.
-      </span>
-    );
-  }
-  if (mergeQueue.length === 0) {
-    return null;
-  }
-  const targetBranch = mergeQueueTargetBranch(mergeQueue);
-  if (!targetBranch) {
-    return (
-      <span className="max-w-xs text-right text-[13px] text-muted-foreground">
-        These reviews target more than one branch, so there is no single queue head to advance.
-      </span>
-    );
-  }
-  return (
-    <div className="flex min-w-0 flex-col items-end gap-2">
-      {action.confirming ? (
-        <AdvanceMergeQueueConfirm targetBranch={targetBranch} busy={action.busy} />
-      ) : (
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => {
-            dispatch(confirmAdvanceMergeQueue());
-          }}
-        >
-          Advance queue
-        </Button>
-      )}
-      {action.error && (
-        <div className="max-w-sm">
-          <InlineAlert>{action.error}</InlineAlert>
-        </div>
-      )}
-    </div>
-  );
-}
-
-// The confirm step is its own row so the question reads left-to-right into the
-// two answers, and a failure lands under it rather than shouldering its way
-// into the middle of the sentence.
-function AdvanceMergeQueueConfirm({
-  targetBranch,
-  busy,
-}: {
-  targetBranch: string;
-  busy: boolean;
-}): React.ReactElement {
-  const dispatch = useAppDispatch();
-  return (
-    <div className="flex flex-wrap items-center justify-end gap-2">
-      <span className="text-[13px] text-foreground">
-        Merge the queue head into <span className="font-mono">{targetBranch}</span>?
-      </span>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        disabled={busy}
-        onClick={() => {
-          dispatch(cancelAdvanceMergeQueue());
-        }}
-      >
-        Cancel
-      </Button>
-      <Button
-        type="button"
-        size="sm"
-        disabled={busy}
-        onClick={() => {
-          void dispatch(submitAdvanceMergeQueue(targetBranch));
-        }}
-      >
-        {busy && <LoaderCircle className="animate-spin" aria-hidden="true" />}
-        Confirm
-      </Button>
-    </div>
   );
 }
 
@@ -291,40 +83,6 @@ function AuditPanel({ data }: { data: TenantDashboardData }): React.ReactElement
   );
 }
 
-// PanelBody renders one panel's three distinguishable outcomes: it failed, there
-// is nothing in it, or here it is. "You may not read this" never reaches here —
-// a restricted panel has no tab to open.
-function PanelBody({
-  data,
-  tab,
-  empty,
-  children,
-}: {
-  data: TenantDashboardData;
-  tab: 'users' | 'reviews' | 'queue' | 'builds' | 'audit';
-  empty: React.ReactElement;
-  children: React.ReactNode;
-}): React.ReactElement {
-  const panel = tenantDashboardPanel(data, tab);
-  if (panel?.restricted) {
-    return (
-      <div className="mt-4">
-        <EmptyState
-          heading="You do not have access to this panel"
-          body={`It needs ${panel.restricted}. Ask an administrator for access.`}
-        />
-      </div>
-    );
-  }
-  if (panel?.error) {
-    return <DashboardMessage message={panel.error} destructive />;
-  }
-  if (!children) {
-    return <div className="mt-4">{empty}</div>;
-  }
-  return <>{children}</>;
-}
-
 function UsersTable({ users }: { users: UITenantDashboardUser[] }): React.ReactElement {
   return (
     <DataTable headers={['Username', 'Roles']}>
@@ -332,45 +90,6 @@ function UsersTable({ users }: { users: UITenantDashboardUser[] }): React.ReactE
         <tr key={user.userId || (user.username ?? '') || (user.subject ?? '')}>
           <DataCell strong>{displayUsername(user)}</DataCell>
           <DataCell>{formatRoles(user.roles)}</DataCell>
-        </tr>
-      ))}
-    </DataTable>
-  );
-}
-
-function ReviewsTable({
-  reviews,
-  onSelect,
-}: {
-  reviews: UITenantDashboardReview[];
-  onSelect?: (review: UITenantDashboardReview) => void;
-}): React.ReactElement {
-  return (
-    <DataTable headers={['Review', 'Status', 'Target', 'Source', 'Updated']}>
-      {reviews.map((review) => (
-        <tr key={review.reviewId}>
-          <DataCell strong>
-            {onSelect ? (
-              <button
-                type="button"
-                className="text-left text-foreground underline-offset-2 hover:underline focus-visible:underline"
-                onClick={() => {
-                  onSelect(review);
-                }}
-                aria-label={`Open review ${review.name || review.reviewId}`}
-              >
-                {review.name || review.reviewId}
-              </button>
-            ) : (
-              review.name || review.reviewId
-            )}
-          </DataCell>
-          <DataCell>
-            <StatusBadge tone={reviewStatusTone(review.status)} label={review.status} />
-          </DataCell>
-          <DataCell>{review.targetBranch}</DataCell>
-          <DataCell>{review.sourceBranch}</DataCell>
-          <DataCell>{formatDashboardDate(review.updatedAt)}</DataCell>
         </tr>
       ))}
     </DataTable>

--- a/erun-ui/frontend/src/components/app/TenantDashboardPanels.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardPanels.tsx
@@ -1,7 +1,6 @@
 import { EmptyState, StatusBadge, TabsContent } from 'erun-kit';
 import * as React from 'react';
 
-import { formatDashboardDate } from '@/app/tenantDashboardPanels';
 import type {
   UITenantDashboardAudit,
   UITenantDashboardBuild,
@@ -13,6 +12,7 @@ import {
   DataCell,
   DataTable,
   PanelBody,
+  RelativeTime,
   type TenantDashboardData,
 } from './TenantDashboardMessage';
 import { MergeQueuePanel, ReviewsPanel } from './TenantDashboardPanels.Reviews';
@@ -111,7 +111,9 @@ function BuildsTable({ builds }: { builds: UITenantDashboardBuild[] }): React.Re
           </DataCell>
           <DataCell>{build.commitId}</DataCell>
           <DataCell>{build.version}</DataCell>
-          <DataCell>{formatDashboardDate(build.createdAt)}</DataCell>
+          <DataCell>
+            <RelativeTime value={build.createdAt} />
+          </DataCell>
         </tr>
       ))}
     </DataTable>
@@ -123,7 +125,9 @@ function AuditEventsTable({ events }: { events: UITenantDashboardAudit[] }): Rea
     <DataTable headers={['Time', 'Type', 'Actor', 'Action']}>
       {events.map((event, index) => (
         <tr key={`${event.createdAt ?? ''}-${String(index)}`}>
-          <DataCell>{formatDashboardDate(event.createdAt)}</DataCell>
+          <DataCell>
+            <RelativeTime value={event.createdAt} />
+          </DataCell>
           <DataCell>{event.type}</DataCell>
           <DataCell>{event.actor}</DataCell>
           <DataCell strong>{event.action}</DataCell>

--- a/erun-ui/frontend/src/reviewTypes.ts
+++ b/erun-ui/frontend/src/reviewTypes.ts
@@ -30,11 +30,17 @@ export interface UIReviewDetail {
   buildsError?: string;
   // queuePosition is 1-based; 0 means the review is not queued right now.
   queuePosition?: number;
+  // unresolvedThreads counts root comments still OPEN; valid whenever
+  // comments loaded (commentsRestricted and commentsError both unset).
+  unresolvedThreads?: number;
   // canComment reports whether the signed-in user may reply at all, so the
   // composer can be hidden rather than rendered to fail on submit.
   canComment: boolean;
   // canClose mirrors canComment for the close action.
   canClose: boolean;
+  // canResolveComments mirrors canComment for the resolve/unresolve action —
+  // a distinct write route on the platform, gated separately.
+  canResolveComments: boolean;
 }
 
 export interface UIReviewComment {
@@ -81,6 +87,17 @@ export interface UICloseReviewInput {
   apiUrl: string;
   cloudProviderAlias: string;
   reviewId: string;
+}
+
+// UIUpdateReviewCommentStatusInput resolves or unresolves a comment thread.
+// commentId must be a thread's root — the dialog only ever offers the action
+// there, never on a reply.
+export interface UIUpdateReviewCommentStatusInput {
+  tenant: string;
+  apiUrl: string;
+  cloudProviderAlias: string;
+  reviewId: string;
+  commentId: string;
 }
 
 export interface UIAdvanceMergeQueueInput {

--- a/erun-ui/frontend/src/reviewTypes.ts
+++ b/erun-ui/frontend/src/reviewTypes.ts
@@ -46,6 +46,10 @@ export interface UIReviewDetail {
 export interface UIReviewComment {
   commentId: string;
   creatorUserId?: string;
+  // creatorUsername mirrors UITenantDashboardReview.authorUsername: the
+  // tenant user directory's display name for creatorUserId, resolved
+  // best-effort. Undefined when it could not be resolved.
+  creatorUsername?: string;
   status: string;
   parentCommentId?: string;
   commitId: string;

--- a/erun-ui/frontend/src/tenantDashboardTypes.ts
+++ b/erun-ui/frontend/src/tenantDashboardTypes.ts
@@ -1,0 +1,107 @@
+// Tenant dashboard read-model types, split out of types.ts to keep that file
+// under eslint's 500-line max-lines cap (see reviewTypes.ts/diffTypes.ts for
+// the same pattern). Nothing here changes shape; types.ts re-exports the
+// whole module so every existing `from './types'` import keeps working.
+
+export interface UITenantDashboardInput {
+  tenant: string;
+  environment?: string;
+  apiUrl: string;
+  mcpUrl?: string;
+  kubernetesContext?: string;
+  cloudProviderAlias: string;
+  // reviewFilterMine/reviewFilterWaitingOnMe are the Reviews tab's one-click
+  // discovery filters, resolved server-side to the signed-in user's own id.
+  reviewFilterMine?: boolean;
+  reviewFilterWaitingOnMe?: boolean;
+}
+
+export interface UITenantDashboard {
+  tenant: string;
+  environment?: string;
+  apiUrl?: string;
+  // apiError is a whole-dashboard failure (the caller's identity could not be
+  // read). A single panel's own failure lives on that panel.
+  apiError?: string;
+  apiLog?: string;
+  apiLogError?: string;
+  user?: UITenantDashboardUser;
+  reviews?: UITenantDashboardReview[];
+  mergeQueue?: UITenantDashboardReview[];
+  builds?: UITenantDashboardBuild[];
+  auditEvents?: UITenantDashboardAudit[];
+  panels?: UITenantDashboardPanel[];
+  // canCreateReview and canAdvanceMergeQueue report whether the signed-in user
+  // may attempt those writes at all, so the composing actions can be hidden
+  // rather than rendered to fail on submit.
+  canCreateReview: boolean;
+  canAdvanceMergeQueue: boolean;
+  // mineReviewCount/waitingOnMeReviewCount are the Reviews tab's Mine /
+  // Waiting-on-me filter buttons' own discovery signal — how many reviews
+  // match each, visible before either is clicked. Undefined when the caller
+  // cannot read reviews, or has no signed-in user id to filter by.
+  mineReviewCount?: number;
+  waitingOnMeReviewCount?: number;
+}
+
+// UITenantDashboardPanel is one panel's own outcome: `restricted` names the API
+// read the signed-in user lacks, so a panel they may not see is never rendered
+// as an empty one.
+export interface UITenantDashboardPanel {
+  tab: string;
+  restricted?: string;
+  error?: string;
+}
+
+export interface UITenantDashboardUser {
+  tenantId: string;
+  userId: string;
+  username?: string;
+  roles?: string[];
+  issuer?: string;
+  subject?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface UITenantDashboardReview {
+  reviewId: string;
+  tenantId: string;
+  authorUserId?: string;
+  // authorUsername is the tenant user directory's display name for
+  // authorUserId, resolved best-effort. Undefined when it could not be
+  // resolved, so the caller falls back to the raw id.
+  authorUsername?: string;
+  name: string;
+  targetBranch: string;
+  sourceBranch: string;
+  status: string;
+  // unresolvedThreads is undefined when it was not computed for this row
+  // (e.g. the caller cannot read comments) — distinct from 0, which means
+  // every thread is resolved.
+  unresolvedThreads?: number;
+  lastFailedBuildId?: string;
+  lastReadyBuildId?: string;
+  lastMergedBuildId?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface UITenantDashboardBuild {
+  buildId: string;
+  tenantId: string;
+  reviewId: string;
+  reviewName?: string;
+  successful: boolean;
+  commitId: string;
+  version: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface UITenantDashboardAudit {
+  type: string;
+  actor?: string;
+  action: string;
+  createdAt?: string;
+}

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -161,99 +161,6 @@ export interface UIState {
   cloudProviders?: UICloudProviderStatus[];
 }
 
-export interface UITenantDashboardInput {
-  tenant: string;
-  environment?: string;
-  apiUrl: string;
-  mcpUrl?: string;
-  kubernetesContext?: string;
-  cloudProviderAlias: string;
-  // reviewFilterMine/reviewFilterWaitingOnMe are the Reviews tab's one-click
-  // discovery filters, resolved server-side to the signed-in user's own id.
-  reviewFilterMine?: boolean;
-  reviewFilterWaitingOnMe?: boolean;
-}
-
-export interface UITenantDashboard {
-  tenant: string;
-  environment?: string;
-  apiUrl?: string;
-  // apiError is a whole-dashboard failure (the caller's identity could not be
-  // read). A single panel's own failure lives on that panel.
-  apiError?: string;
-  apiLog?: string;
-  apiLogError?: string;
-  user?: UITenantDashboardUser;
-  reviews?: UITenantDashboardReview[];
-  mergeQueue?: UITenantDashboardReview[];
-  builds?: UITenantDashboardBuild[];
-  auditEvents?: UITenantDashboardAudit[];
-  panels?: UITenantDashboardPanel[];
-  // canCreateReview and canAdvanceMergeQueue report whether the signed-in user
-  // may attempt those writes at all, so the composing actions can be hidden
-  // rather than rendered to fail on submit.
-  canCreateReview: boolean;
-  canAdvanceMergeQueue: boolean;
-}
-
-// UITenantDashboardPanel is one panel's own outcome: `restricted` names the API
-// read the signed-in user lacks, so a panel they may not see is never rendered
-// as an empty one.
-export interface UITenantDashboardPanel {
-  tab: string;
-  restricted?: string;
-  error?: string;
-}
-
-export interface UITenantDashboardUser {
-  tenantId: string;
-  userId: string;
-  username?: string;
-  roles?: string[];
-  issuer?: string;
-  subject?: string;
-  createdAt?: string;
-  updatedAt?: string;
-}
-
-export interface UITenantDashboardReview {
-  reviewId: string;
-  tenantId: string;
-  authorUserId?: string;
-  name: string;
-  targetBranch: string;
-  sourceBranch: string;
-  status: string;
-  // unresolvedThreads is undefined when it was not computed for this row
-  // (e.g. the caller cannot read comments) — distinct from 0, which means
-  // every thread is resolved.
-  unresolvedThreads?: number;
-  lastFailedBuildId?: string;
-  lastReadyBuildId?: string;
-  lastMergedBuildId?: string;
-  createdAt?: string;
-  updatedAt?: string;
-}
-
-export interface UITenantDashboardBuild {
-  buildId: string;
-  tenantId: string;
-  reviewId: string;
-  reviewName?: string;
-  successful: boolean;
-  commitId: string;
-  version: string;
-  createdAt?: string;
-  updatedAt?: string;
-}
-
-export interface UITenantDashboardAudit {
-  type: string;
-  actor?: string;
-  action: string;
-  createdAt?: string;
-}
-
 export interface UIIdleStatus {
   timeoutSeconds: number;
   secondsUntilStop: number;
@@ -673,6 +580,10 @@ export * from './diffTypes';
 
 // Review-detail types live in ./reviewTypes for the same reason.
 export * from './reviewTypes';
+
+// Tenant dashboard read-model types live in ./tenantDashboardTypes for the
+// same reason.
+export * from './tenantDashboardTypes';
 
 // A retained job in an environment's job store. exitCode is null unless the job
 // reached exited, so a missing outcome is never read as a successful zero, and

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -168,6 +168,10 @@ export interface UITenantDashboardInput {
   mcpUrl?: string;
   kubernetesContext?: string;
   cloudProviderAlias: string;
+  // reviewFilterMine/reviewFilterWaitingOnMe are the Reviews tab's one-click
+  // discovery filters, resolved server-side to the signed-in user's own id.
+  reviewFilterMine?: boolean;
+  reviewFilterWaitingOnMe?: boolean;
 }
 
 export interface UITenantDashboard {
@@ -215,10 +219,15 @@ export interface UITenantDashboardUser {
 export interface UITenantDashboardReview {
   reviewId: string;
   tenantId: string;
+  authorUserId?: string;
   name: string;
   targetBranch: string;
   sourceBranch: string;
   status: string;
+  // unresolvedThreads is undefined when it was not computed for this row
+  // (e.g. the caller cannot read comments) — distinct from 0, which means
+  // every thread is resolved.
+  unresolvedThreads?: number;
   lastFailedBuildId?: string;
   lastReadyBuildId?: string;
   lastMergedBuildId?: string;

--- a/erun-ui/playwright/pages/ReviewDetailDialog.ts
+++ b/erun-ui/playwright/pages/ReviewDetailDialog.ts
@@ -43,6 +43,17 @@ export class ReviewDetailDialog {
     await this.locator().getByRole('button', { name: 'Cancel' }).click();
   }
 
+  // resolveButton/reopenButton are offered only on a thread's root; `threadIndex`
+  // is the thread's position among rendered threads (roots), matching reply()'s
+  // own indexing convention.
+  resolveButton(threadIndex: number): Locator {
+    return this.locator().getByRole('button', { name: 'Resolve' }).nth(threadIndex);
+  }
+
+  reopenButton(threadIndex: number): Locator {
+    return this.locator().getByRole('button', { name: 'Reopen' }).nth(threadIndex);
+  }
+
   closeReviewButton(): Locator {
     return this.locator().getByRole('button', { name: 'Close review' });
   }

--- a/erun-ui/playwright/pages/ReviewPanel.ts
+++ b/erun-ui/playwright/pages/ReviewPanel.ts
@@ -52,6 +52,24 @@ export class ReviewPanel {
     return this.page.getByLabel('Changed files tree');
   }
 
+  // changedFilesEnvLabel locates the changed-files tree's own copy of the
+  // shared ReviewEnvLabel (#1314) — scoped to the tree container so it can't
+  // also match the diff panel's or the review-layers block's copy of the same
+  // "tenant / environment" text.
+  changedFilesEnvLabel(envKey: string): Locator {
+    const [tenant, environment] = envKey.split('/');
+    return this.changedFilesTree().getByText(`${tenant} / ${environment}`, { exact: true });
+  }
+
+  // envLabels locates every rendered copy of the shared ReviewEnvLabel for
+  // one environment across the whole review surface (review-layers block,
+  // changed-files tree, and diff panel section header) — three when more
+  // than one environment is in scope, proving all three share one treatment.
+  envLabels(envKey: string): Locator {
+    const [tenant, environment] = envKey.split('/');
+    return this.page.getByText(`${tenant} / ${environment}`, { exact: true });
+  }
+
   async treeFilePaths(): Promise<string[]> {
     return this.changedFilesTree()
       .locator('[data-path]')
@@ -76,10 +94,16 @@ export class ReviewPanel {
   // renders above each linked environment's section once more than one target
   // is shown (#1178). Scoped to DiffList's sticky header class combination
   // (unique in the frontend source) rather than a plain text match: the
-  // changed-files tree renders its own per-env header with the same envKey
-  // text, and other surfaces (sidebar rows, tab labels) can also contain it.
+  // changed-files tree renders its own per-env header with the same label
+  // text (#1314 made the two share one ReviewEnvLabel treatment), and other
+  // surfaces (sidebar rows, tab labels) can also contain it. envKey is the
+  // internal `tenant/environment` form; the rendered label spaces the slash
+  // ("tenant / environment"), so this reformats before matching.
   envSectionHeader(envKey: string): Locator {
-    return this.page.locator('.sticky.top-0.z-10.border-b').filter({ hasText: envKey });
+    const [tenant, environment] = envKey.split('/');
+    return this.page
+      .locator('.sticky.top-0.z-10.border-b')
+      .filter({ hasText: `${tenant} / ${environment}` });
   }
 
   // The "Changed files N" collapsible header inside the aside, distinct from

--- a/erun-ui/playwright/pages/TenantDashboard.ts
+++ b/erun-ui/playwright/pages/TenantDashboard.ts
@@ -83,8 +83,10 @@ export class TenantDashboard {
     return this.activePanel().getByRole('button', { name: 'Clear filter' });
   }
 
+  // Mine's accessible name gains a count badge (e.g. "Mine 2"), so this
+  // matches the prefix rather than the exact former label (#1378).
   mineFilterButton(): Locator {
-    return this.activePanel().getByRole('button', { name: 'Mine', exact: true });
+    return this.activePanel().getByRole('button', { name: /^Mine\b/ });
   }
 
   waitingOnMeFilterButton(): Locator {
@@ -100,7 +102,7 @@ export class TenantDashboard {
   }
 
   reviewsRestrictedNote(): Locator {
-    return this.activePanel().getByText('You do not have access to open reviews.');
+    return this.activePanel().getByText('You do not have access to create reviews.');
   }
 
   mergeQueueTable(): Locator {

--- a/erun-ui/playwright/pages/TenantDashboard.ts
+++ b/erun-ui/playwright/pages/TenantDashboard.ts
@@ -72,6 +72,25 @@ export class TenantDashboard {
     return this.activePanel().getByText('No reviews yet', { exact: true });
   }
 
+  // reviewsFilteredEmptyState is the distinct "nothing matches this filter"
+  // empty state (as opposed to reviewsEmptyState's "nothing exists yet") —
+  // the repo's three-empty-states rule requires the two read differently.
+  reviewsFilteredEmptyState(): Locator {
+    return this.activePanel().getByText('No reviews match this filter', { exact: true });
+  }
+
+  clearReviewFilterButton(): Locator {
+    return this.activePanel().getByRole('button', { name: 'Clear filter' });
+  }
+
+  mineFilterButton(): Locator {
+    return this.activePanel().getByRole('button', { name: 'Mine', exact: true });
+  }
+
+  waitingOnMeFilterButton(): Locator {
+    return this.activePanel().getByRole('button', { name: 'Waiting on me' });
+  }
+
   async openReview(name: string): Promise<void> {
     await this.page.getByRole('button', { name: `Open review ${name}` }).click();
   }

--- a/erun-ui/playwright/tests/orchestrator-cross-env-diff.spec.ts
+++ b/erun-ui/playwright/tests/orchestrator-cross-env-diff.spec.ts
@@ -182,6 +182,50 @@ test.describe('orchestrator cross-env diff panel (#1178)', () => {
       .toEqual(expect.arrayContaining(['alpha-only.ts', 'beta-only.ts']));
   });
 
+  test('the review-layers block, changed-files tree, and diff panel share one env label treatment (#1314)', async ({
+    app,
+    page,
+  }) => {
+    const base: DiffReviewBaseStub = { branch: 'main', commit: 'base0', shortCommit: 'base0' };
+    await stubOrchestratorAndDiffs(page, {
+      [SEED_ENV_ALPHA]: {
+        kind: 'success',
+        file: 'alpha-only.ts',
+        reviewBase: base,
+        reviewCommits: [
+          { hash: 'a1', shortHash: 'a1', subject: 'Alpha commit', author: 'a', date: '2024-01-01' },
+        ],
+      },
+      [SEED_ENV_BETA]: { kind: 'success', file: 'beta-only.ts', reviewBase: base },
+    });
+    await app.reboot();
+
+    await app.sidebar.openOrchestratorSession(ORCHESTRATOR_ID);
+    await app.titlebar.toggleReviewPanel();
+    const review = app.reviewPanel;
+    await expect
+      .poll(() => review.diffSectionPaths())
+      .toEqual(expect.arrayContaining(['alpha-only.ts', 'beta-only.ts']));
+
+    // Three surfaces render "pw / alpha" (review layers, changed-files tree,
+    // diff panel section header) — the raw "pw/alpha" envKey never reaches
+    // the DOM, and every occurrence uses the same spaced, app-native format.
+    await expect(review.envLabels(ALPHA_ENV_KEY)).toHaveCount(3);
+    await expect(review.envLabels(BETA_ENV_KEY)).toHaveCount(3);
+    await expect(review.changedFilesEnvLabel(ALPHA_ENV_KEY)).toBeVisible();
+    await expect(review.envSectionHeader(ALPHA_ENV_KEY)).toBeVisible();
+    await expect(page.getByText(ALPHA_ENV_KEY, { exact: true })).toHaveCount(0);
+  });
+
+  test('a single linked environment renders no redundant env label', async ({ app }) => {
+    await app.sidebar.openEnvironment(SEED_TENANT, SEED_ENV_ALPHA);
+    await app.titlebar.toggleReviewPanel();
+
+    // Single-env sessions must not gain the multi-env label (#1314) — the
+    // review panel here has exactly one target, so no surface names it.
+    await expect(app.reviewPanel.envLabels(ALPHA_ENV_KEY)).toHaveCount(0);
+  });
+
   test('fetches each linked environment independently rather than one shared request', async ({
     app,
     page,

--- a/erun-ui/playwright/tests/tenant-dashboard-reviews-long-values.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-reviews-long-values.spec.ts
@@ -1,0 +1,246 @@
+import type { Request, Route } from '@playwright/test';
+
+import { boundingBoxOf } from '../fixtures/boundingBox.js';
+import { expect, test } from '../fixtures/erunApp.js';
+import {
+  removeEnvironment,
+  SEED_TENANT,
+  seedEnvironment,
+  uniqueEnvironmentName,
+} from '../fixtures/seedRoot.js';
+
+// #1378 (#1350 precedent): a fixture that never resembles real data hides
+// real overflow bugs — #1350's own fixtures shipped a green gate twice while
+// a 5.3KB job command flooded the row. These specs stage genuinely long
+// values (long titles, long branch names, many threads, a long comment body)
+// and assert the CSS that is supposed to bound them actually engages
+// (scrollWidth > clientWidth, not just "the element exists").
+function seedDashboardEnvironment(title: string): string {
+  const environment = uniqueEnvironmentName(title);
+  seedEnvironment(SEED_TENANT, environment, 'apiurl: http://127.0.0.1:1/unreachable\n');
+  return environment;
+}
+
+function invokeBody(request: Request): { method: string } {
+  return JSON.parse(request.postData() ?? '{}') as { method: string };
+}
+
+async function fulfillJSON(route: Route, data: unknown): Promise<void> {
+  await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ data }) });
+}
+
+const LONG_TITLE =
+  'Add the widget rendering pipeline for the dashboard export flow so operators can review every generated artifact before it ships to the tenant runtime';
+const LONG_BRANCH =
+  'feature/1378-desktop-review-loop-usability-and-craft-pass-for-the-tenant-dashboard-reviews-tab';
+const LONG_BODY =
+  'This is a very long review comment. '.repeat(60) + 'End of the long comment body.';
+
+const LONG_REVIEW = {
+  reviewId: 'review-long',
+  tenantId: 't1',
+  authorUserId: 'u1',
+  name: LONG_TITLE,
+  targetBranch: `main-${LONG_BRANCH}`,
+  sourceBranch: LONG_BRANCH,
+  status: 'FAILED',
+  unresolvedThreads: 12,
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+function manyThreads(count: number): unknown[] {
+  return Array.from({ length: count }, (_, i) => ({
+    commentId: `thread-${String(i)}`,
+    creatorUserId: `reviewer-${String(i)}`,
+    status: 'OPEN',
+    commitId: 'abc123',
+    filePath: `pkg/file-${String(i)}.go`,
+    line: i + 1,
+    body: i === 0 ? LONG_BODY : `Thread ${String(i)} comment`,
+    createdAt: '2026-01-01T00:00:00Z',
+  }));
+}
+
+test.describe('tenant dashboard reviews — long values render bounded, not overflowing (#1378)', () => {
+  test('a long title and long branch names truncate in the reviews table instead of blowing out the row', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('reviews-long-title');
+    try {
+      await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+        const body = invokeBody(request);
+        if (body.method === 'LoadTenantDashboard') {
+          await fulfillJSON(route, {
+            tenant: SEED_TENANT,
+            environment,
+            apiUrl: 'http://127.0.0.1:1/unreachable',
+            user: { tenantId: 't1', userId: 'u1', username: 'operator' },
+            reviews: [LONG_REVIEW],
+            panels: [{ tab: 'users' }, { tab: 'reviews' }],
+          });
+          return;
+        }
+        await route.continue();
+      });
+
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+      await app.tenantDashboard.waitForOpen();
+      await app.tenantDashboard.selectTab('Reviews');
+
+      const row = app.tenantDashboard.reviewsRows().first();
+      await expect(row).toBeVisible();
+      const rowBox = await boundingBoxOf(row, 'review row');
+
+      // table-fixed + truncate: the cell's full text is wider than what is
+      // shown, proving the long title/branch clip instead of wrapping the
+      // table wide or tall.
+      const titleCell = row.locator('td').first();
+      const { clientWidth: titleClientWidth, scrollWidth: titleScrollWidth } =
+        await titleCell.evaluate((el) => ({
+          clientWidth: el.clientWidth,
+          scrollWidth: el.scrollWidth,
+        }));
+      expect(titleClientWidth).toBeGreaterThan(0);
+      expect(titleScrollWidth).toBeGreaterThan(titleClientWidth);
+
+      // A single row of a table-fixed table stays roughly one line tall
+      // (~40px per DataCell's own padding) even though the underlying values
+      // are hundreds of characters long.
+      expect(rowBox.height).toBeLessThan(80);
+
+      await expect(row).toContainText('FAILED');
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+
+  test('many threads and a long comment body stay inside the dialog, which scrolls instead of growing without bound', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('reviews-long-threads');
+    try {
+      await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+        const body = invokeBody(request);
+        if (body.method === 'LoadTenantDashboard') {
+          await fulfillJSON(route, {
+            tenant: SEED_TENANT,
+            environment,
+            apiUrl: 'http://127.0.0.1:1/unreachable',
+            user: { tenantId: 't1', userId: 'u1', username: 'operator' },
+            reviews: [LONG_REVIEW],
+            panels: [{ tab: 'users' }, { tab: 'reviews' }],
+          });
+          return;
+        }
+        if (body.method === 'LoadReviewDetail') {
+          await fulfillJSON(route, {
+            reviewId: LONG_REVIEW.reviewId,
+            review: LONG_REVIEW,
+            comments: manyThreads(30),
+            unresolvedThreads: 30,
+            builds: [],
+            canComment: true,
+          });
+          return;
+        }
+        await route.continue();
+      });
+
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+      await app.tenantDashboard.waitForOpen();
+      await app.tenantDashboard.selectTab('Reviews');
+      await app.tenantDashboard.openReview(LONG_TITLE);
+      await app.reviewDetailDialog.waitForOpen();
+
+      // The dialog's own frame (DialogContent's max-h-[85vh]) caps the whole
+      // surface regardless of how many threads it holds. The suite's config
+      // viewport is 1440x1200 and this test never changes it.
+      const dialogBox = await boundingBoxOf(
+        app.reviewDetailDialog.locator(),
+        'review detail dialog',
+      );
+      expect(dialogBox.height).toBeLessThanOrEqual(1200 * 0.85 + 2);
+
+      // 30 threads is far more than fits in that frame, so the comments list
+      // itself must be the thing scrolling, not the dialog growing past its cap.
+      const commentsScroll = app.reviewDetailDialog.locator().locator('.overflow-y-auto').first();
+      const { scrollHeight, clientHeight } = await commentsScroll.evaluate((el) => ({
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+      }));
+      expect(scrollHeight).toBeGreaterThan(clientHeight);
+
+      // The long comment body on the first thread is bounded by its own
+      // max-h-48 overflow-y-auto rather than pushing every later thread off
+      // the fold.
+      const longBody = app.reviewDetailDialog.locator().getByText('End of the long comment body.');
+      await expect(longBody).toBeVisible();
+      const bodyBox = await longBody.evaluate((el) => {
+        const scrollBox = el.closest('p');
+        if (!scrollBox) {
+          throw new Error('comment body paragraph not found');
+        }
+        return { scrollHeight: scrollBox.scrollHeight, clientHeight: scrollBox.clientHeight };
+      });
+      expect(bodyBox.scrollHeight).toBeGreaterThan(bodyBox.clientHeight);
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+
+  test('a narrow viewport keeps the reviews tab usable: no horizontal overflow, actions still reachable', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('reviews-narrow-viewport');
+    try {
+      await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+        const body = invokeBody(request);
+        if (body.method === 'LoadTenantDashboard') {
+          await fulfillJSON(route, {
+            tenant: SEED_TENANT,
+            environment,
+            apiUrl: 'http://127.0.0.1:1/unreachable',
+            user: { tenantId: 't1', userId: 'u1', username: 'operator' },
+            reviews: [LONG_REVIEW],
+            panels: [{ tab: 'users' }, { tab: 'reviews' }],
+            canCreateReview: true,
+          });
+          return;
+        }
+        await route.continue();
+      });
+
+      await page.setViewportSize({ width: 640, height: 900 });
+
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+      await app.tenantDashboard.waitForOpen();
+      await app.tenantDashboard.selectTab('Reviews');
+
+      await expect(app.tenantDashboard.newReviewButton()).toBeVisible();
+      await expect(app.tenantDashboard.mineFilterButton()).toBeVisible();
+
+      const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+      expect(scrollWidth).toBeLessThanOrEqual(641);
+
+      // Restore the config default viewport for later specs in the singleton backend.
+      await page.setViewportSize({ width: 1440, height: 1200 });
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+});

--- a/erun-ui/playwright/tests/tenant-dashboard-reviews-long-values.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-reviews-long-values.spec.ts
@@ -96,21 +96,23 @@ test.describe('tenant dashboard reviews — long values render bounded, not over
       await expect(row).toBeVisible();
       const rowBox = await boundingBoxOf(row, 'review row');
 
-      // table-fixed + truncate: the cell's full text is wider than what is
-      // shown, proving the long title/branch clip instead of wrapping the
-      // table wide or tall.
-      const titleCell = row.locator('td').first();
+      // The title carries a `title` attribute with the untruncated text
+      // (#1378) — getByTitle finds it whether or not it is visually clipped,
+      // and the element's own scrollWidth > clientWidth proves it actually is.
+      const titleElement = row.getByTitle(LONG_TITLE);
+      await expect(titleElement).toBeVisible();
       const { clientWidth: titleClientWidth, scrollWidth: titleScrollWidth } =
-        await titleCell.evaluate((el) => ({
+        await titleElement.evaluate((el) => ({
           clientWidth: el.clientWidth,
           scrollWidth: el.scrollWidth,
         }));
       expect(titleClientWidth).toBeGreaterThan(0);
       expect(titleScrollWidth).toBeGreaterThan(titleClientWidth);
 
-      // A single row of a table-fixed table stays roughly one line tall
-      // (~40px per DataCell's own padding) even though the underlying values
-      // are hundreds of characters long.
+      // The row stays a compact two-line block (title + metadata) even
+      // though the underlying values are hundreds of characters long —
+      // proof the branch names middle-ellipsis rather than wrapping the row
+      // tall.
       expect(rowBox.height).toBeLessThan(80);
 
       await expect(row).toContainText('FAILED');
@@ -180,19 +182,17 @@ test.describe('tenant dashboard reviews — long values render bounded, not over
       }));
       expect(scrollHeight).toBeGreaterThan(clientHeight);
 
-      // The long comment body on the first thread is bounded by its own
-      // max-h-48 overflow-y-auto rather than pushing every later thread off
-      // the fold.
-      const longBody = app.reviewDetailDialog.locator().getByText('End of the long comment body.');
-      await expect(longBody).toBeVisible();
-      const bodyBox = await longBody.evaluate((el) => {
-        const scrollBox = el.closest('p');
-        if (!scrollBox) {
-          throw new Error('comment body paragraph not found');
-        }
-        return { scrollHeight: scrollBox.scrollHeight, clientHeight: scrollBox.clientHeight };
-      });
-      expect(bodyBox.scrollHeight).toBeGreaterThan(bodyBox.clientHeight);
+      // The long comment body on the first thread is bounded by a preview
+      // plus an explicit "Show more" control (#1378) — never an invisible
+      // scroll region with no affordance that more text exists — so the tail
+      // of the body is absent until the control is used, then present.
+      const dialog = app.reviewDetailDialog.locator();
+      await expect(dialog.getByText('End of the long comment body.')).toHaveCount(0);
+      const showMore = dialog.getByRole('button', { name: 'Show more' }).first();
+      await expect(showMore).toBeVisible();
+      await showMore.click();
+      await expect(dialog.getByText('End of the long comment body.')).toBeVisible();
+      await expect(dialog.getByRole('button', { name: 'Show less' }).first()).toBeVisible();
     } finally {
       removeEnvironment(SEED_TENANT, environment);
     }

--- a/erun-ui/playwright/tests/tenant-dashboard-reviews-long-values.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-reviews-long-values.spec.ts
@@ -221,7 +221,15 @@ test.describe('tenant dashboard reviews — long values render bounded, not over
         await route.continue();
       });
 
-      await page.setViewportSize({ width: 640, height: 900 });
+      // 1000px, not narrower: the shell's sidebar has a fixed 338px default
+      // width (DEFAULT_SIDEBAR_WIDTH, erun-ui/frontend/src/app/state.ts) plus
+      // a 10px divider, with no viewport-responsive collapse — below roughly
+      // 900-950px the main pane's own remaining width goes negative against
+      // its content's fixed minimums regardless of anything the Reviews tab
+      // does. That is a structural desktop-shell gap (filed as a follow-up),
+      // not something this tab can route around, so this spec picks a width
+      // the shell actually supports and asserts real reachability there.
+      await page.setViewportSize({ width: 1000, height: 900 });
 
       await app.reloadEnvironments();
       await app.sidebar
@@ -231,11 +239,29 @@ test.describe('tenant dashboard reviews — long values render bounded, not over
       await app.tenantDashboard.waitForOpen();
       await app.tenantDashboard.selectTab('Reviews');
 
-      await expect(app.tenantDashboard.newReviewButton()).toBeVisible();
-      await expect(app.tenantDashboard.mineFilterButton()).toBeVisible();
+      // toBeVisible() alone would pass even for an element positioned past the
+      // right edge of the viewport with no scrollbar to reach it (the exact
+      // #1350-class false green this suite's fixtures exist to avoid) — so
+      // reachability is asserted from the element's own viewport-relative
+      // geometry, not just its CSS visibility.
+      const newReview = await boundingBoxOf(app.tenantDashboard.newReviewButton(), 'New review');
+      expect(newReview.x + newReview.width).toBeLessThanOrEqual(1000);
+      const mine = await boundingBoxOf(app.tenantDashboard.mineFilterButton(), 'Mine filter');
+      expect(mine.x + mine.width).toBeLessThanOrEqual(1000);
 
       const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
-      expect(scrollWidth).toBeLessThanOrEqual(641);
+      expect(scrollWidth).toBeLessThanOrEqual(1001);
+
+      // The table itself is intentionally wider than the panel at this width
+      // (DataTable's minWidthClassName on the reviews table, #1378) so a
+      // narrow reviews tab scrolls its table horizontally instead of
+      // table-fixed squeezing every column — including the status badge —
+      // below legibility. Confirm the panel actually offers that scroll.
+      const panelOverflow = await app.tenantDashboard.activePanel().evaluate((el) => ({
+        scrollWidth: el.scrollWidth,
+        clientWidth: el.clientWidth,
+      }));
+      expect(panelOverflow.scrollWidth).toBeGreaterThan(panelOverflow.clientWidth);
 
       // Restore the config default viewport for later specs in the singleton backend.
       await page.setViewportSize({ width: 1440, height: 1200 });

--- a/erun-ui/playwright/tests/tenant-dashboard-reviews.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-reviews.spec.ts
@@ -1,5 +1,6 @@
 import type { Page, Route, Request } from '@playwright/test';
 
+import { boundingBoxOf } from '../fixtures/boundingBox.js';
 import { test, expect } from '../fixtures/erunApp.js';
 import type { AppShell } from '../pages/index.js';
 import {
@@ -430,6 +431,98 @@ test.describe('tenant dashboard — resolving a comment thread (#1378)', () => {
       await expect(app.reviewDetailDialog.locator()).toContainText('Resolved');
       await expect(app.reviewDetailDialog.reopenButton(0)).toBeVisible();
       await expect(app.reviewDetailDialog.resolveButton(0)).toHaveCount(0);
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+
+  test('the row shows an avatar and resolved author name, the filter buttons show counts, and the dialog gives the branch line and Resolve their own treatment', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('reviews-craft-pass');
+    const longBranch =
+      'feature/1378-desktop-review-loop-usability-and-craft-pass-for-the-tenant-dashboard-reviews-tab';
+    try {
+      await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+        const body = invokeBody(request);
+        if (body.method === 'LoadTenantDashboard') {
+          await fulfillJSON(route, {
+            tenant: SEED_TENANT,
+            environment,
+            apiUrl: 'http://127.0.0.1:1/unreachable',
+            user: { tenantId: 't1', userId: 'u1', username: 'operator' },
+            reviews: [
+              {
+                ...REVIEW,
+                authorUserId: 'u2',
+                authorUsername: 'Pat Reviewer',
+                unresolvedThreads: 1,
+              },
+            ],
+            mineReviewCount: 3,
+            waitingOnMeReviewCount: 5,
+            panels: [{ tab: 'users' }, { tab: 'reviews' }],
+          });
+          return;
+        }
+        if (body.method === 'LoadReviewDetail') {
+          await fulfillJSON(route, {
+            reviewId: REVIEW.reviewId,
+            review: { ...REVIEW, sourceBranch: longBranch, targetBranch: `main-${longBranch}` },
+            comments: [ROOT_COMMENT],
+            unresolvedThreads: 1,
+            builds: [],
+            canComment: true,
+            canResolveComments: true,
+          });
+          return;
+        }
+        await route.continue();
+      });
+
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+      await app.tenantDashboard.waitForOpen();
+      await app.tenantDashboard.selectTab('Reviews');
+
+      // C: a resolved username, not the raw "u2" id.
+      const row = app.tenantDashboard.reviewsRows().first();
+      await expect(row).toContainText('Pat Reviewer');
+      await expect(row).not.toContainText('u2');
+      // D: an initials avatar renders beside it (decorative, so a structural
+      // locator — no accessible name exists to query by design).
+      await expect(row.locator('span[aria-hidden="true"]').filter({ hasText: 'PR' })).toBeVisible();
+
+      // E: counts are visible on the filter buttons before either is clicked.
+      await expect(app.tenantDashboard.mineFilterButton()).toContainText('3');
+      await expect(app.tenantDashboard.waitingOnMeFilterButton()).toContainText('5');
+
+      await app.tenantDashboard.openReview('Add widget');
+      await app.reviewDetailDialog.waitForOpen();
+      const dialog = app.reviewDetailDialog.locator();
+
+      // K: the dialog gets a diff-discussion-appropriate width, not ~510px.
+      const dialogBox = await boundingBoxOf(dialog, 'review detail dialog');
+      expect(dialogBox.width).toBeGreaterThan(700);
+
+      // M: the branch line middle-ellipses rather than running three lines
+      // unbounded, with the full value still reachable via title.
+      await expect(dialog.getByText(longBranch, { exact: true })).toHaveCount(0);
+      await expect(dialog.locator(`[title="${longBranch}"]`)).toHaveCount(1);
+
+      // I: Resolve carries the primary button weight; Reply stays secondary.
+      await expect(dialog.getByRole('button', { name: 'Resolve' }).first()).toHaveAttribute(
+        'data-variant',
+        'default',
+      );
+      await expect(dialog.getByRole('button', { name: 'Reply' }).first()).toHaveAttribute(
+        'data-variant',
+        'outline',
+      );
     } finally {
       removeEnvironment(SEED_TENANT, environment);
     }

--- a/erun-ui/playwright/tests/tenant-dashboard-reviews.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-reviews.spec.ts
@@ -258,3 +258,117 @@ test.describe('tenant dashboard — reviews tab and detail dialog (#1199)', () =
     }
   });
 });
+
+// Discovery (#1378): an author column and unresolved-thread count readable
+// from the row, plus the Mine/Waiting-on-me one-click filters and their own
+// distinct "nothing matches this filter" empty state.
+test.describe('tenant dashboard — reviews discovery (#1378)', () => {
+  test('the row shows the signed-in author as "You" and the unresolved-thread count without opening the review', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('reviews-author-threads');
+    try {
+      await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+        const body = invokeBody(request);
+        if (body.method === 'LoadTenantDashboard') {
+          await fulfillJSON(route, {
+            tenant: SEED_TENANT,
+            environment,
+            apiUrl: 'http://127.0.0.1:1/unreachable',
+            user: { tenantId: 't1', userId: 'u1', username: 'operator' },
+            reviews: [{ ...REVIEW, authorUserId: 'u1', unresolvedThreads: 2 }],
+            panels: [{ tab: 'users' }, { tab: 'reviews' }],
+          });
+          return;
+        }
+        await route.continue();
+      });
+
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+      await app.tenantDashboard.waitForOpen();
+      await app.tenantDashboard.selectTab('Reviews');
+
+      const row = app.tenantDashboard.reviewsRows().first();
+      await expect(row).toContainText('You');
+      await expect(row).toContainText('2 unresolved');
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+
+  test('Mine and Waiting on me apply as one-click filters and reload the dashboard with them', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('reviews-filter');
+    try {
+      const filterCalls: { authorUserId?: string; reviewerUserId?: string }[] = [];
+      await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+        const body = JSON.parse(request.postData() ?? '{}') as {
+          method: string;
+          args?: [{ reviewFilterMine?: boolean; reviewFilterWaitingOnMe?: boolean }];
+        };
+        if (body.method === 'LoadTenantDashboard') {
+          const input = body.args?.[0];
+          const mine = Boolean(input?.reviewFilterMine);
+          const waitingOnMe = Boolean(input?.reviewFilterWaitingOnMe);
+          filterCalls.push({
+            authorUserId: mine ? 'u1' : undefined,
+            reviewerUserId: waitingOnMe ? 'u1' : undefined,
+          });
+          await fulfillJSON(route, {
+            tenant: SEED_TENANT,
+            environment,
+            apiUrl: 'http://127.0.0.1:1/unreachable',
+            user: { tenantId: 't1', userId: 'u1', username: 'operator' },
+            // Filtering is proven by the request the desktop makes (the
+            // stub cannot re-filter server-side), not by which reviews come
+            // back — so it always returns the same review and the assertion
+            // is on filterCalls plus the distinct empty state below.
+            reviews: mine || waitingOnMe ? [] : [REVIEW],
+            panels: [{ tab: 'users' }, { tab: 'reviews' }],
+          });
+          return;
+        }
+        await route.continue();
+      });
+
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+      await app.tenantDashboard.waitForOpen();
+      await app.tenantDashboard.selectTab('Reviews');
+      await expect(app.tenantDashboard.reviewsRows()).toHaveCount(1);
+
+      await app.tenantDashboard.mineFilterButton().click();
+      await expect(app.tenantDashboard.reviewsFilteredEmptyState()).toBeVisible();
+      await expect(app.tenantDashboard.reviewsEmptyState()).toHaveCount(0);
+      await expect(app.tenantDashboard.mineFilterButton()).toHaveAttribute('aria-pressed', 'true');
+
+      await app.tenantDashboard.clearReviewFilterButton().click();
+      await expect(app.tenantDashboard.reviewsRows()).toHaveCount(1);
+      await expect(app.tenantDashboard.mineFilterButton()).toHaveAttribute('aria-pressed', 'false');
+
+      await app.tenantDashboard.waitingOnMeFilterButton().click();
+      await expect(app.tenantDashboard.reviewsFilteredEmptyState()).toBeVisible();
+
+      expect(filterCalls).toEqual(
+        expect.arrayContaining([
+          { authorUserId: 'u1', reviewerUserId: undefined },
+          { authorUserId: undefined, reviewerUserId: undefined },
+          { authorUserId: undefined, reviewerUserId: 'u1' },
+        ]),
+      );
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+});
+

--- a/erun-ui/playwright/tests/tenant-dashboard-reviews.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-reviews.spec.ts
@@ -372,3 +372,113 @@ test.describe('tenant dashboard — reviews discovery (#1378)', () => {
   });
 });
 
+// Resolution (#1378): a thread's status is visible and actionable from the
+// review detail dialog, offered only on a thread's root.
+test.describe('tenant dashboard — resolving a comment thread (#1378)', () => {
+  test('resolving a thread flips its status, the action to Reopen, and the header count', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('reviews-resolve');
+    try {
+      let resolved = false;
+      await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+        const body = invokeBody(request);
+        if (body.method === 'LoadTenantDashboard') {
+          await fulfillJSON(route, {
+            tenant: SEED_TENANT,
+            environment,
+            apiUrl: 'http://127.0.0.1:1/unreachable',
+            user: { tenantId: 't1', userId: 'u1', username: 'operator' },
+            reviews: [REVIEW],
+            panels: [{ tab: 'users' }, { tab: 'reviews' }],
+          });
+          return;
+        }
+        if (body.method === 'LoadReviewDetail') {
+          await fulfillJSON(route, {
+            ...reviewDetail([{ ...ROOT_COMMENT, status: resolved ? 'CLOSED' : 'OPEN' }]),
+            unresolvedThreads: resolved ? 0 : 1,
+            canResolveComments: true,
+          });
+          return;
+        }
+        if (body.method === 'ResolveReviewComment') {
+          resolved = true;
+          await fulfillJSON(route, { ...ROOT_COMMENT, status: 'CLOSED' });
+          return;
+        }
+        await route.continue();
+      });
+
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+      await app.tenantDashboard.waitForOpen();
+      await app.tenantDashboard.selectTab('Reviews');
+      await app.tenantDashboard.openReview('Add widget');
+      await app.reviewDetailDialog.waitForOpen();
+
+      await expect(app.reviewDetailDialog.locator()).toContainText('1 unresolved');
+      await expect(app.reviewDetailDialog.locator()).toContainText('Unresolved');
+
+      await app.reviewDetailDialog.resolveButton(0).click();
+
+      await expect(app.reviewDetailDialog.locator()).toContainText('All resolved');
+      await expect(app.reviewDetailDialog.locator()).toContainText('Resolved');
+      await expect(app.reviewDetailDialog.reopenButton(0)).toBeVisible();
+      await expect(app.reviewDetailDialog.resolveButton(0)).toHaveCount(0);
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+
+  test('hides the resolve action and names the missing access when the caller cannot resolve threads', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('reviews-resolve-restricted');
+    try {
+      await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+        const body = invokeBody(request);
+        if (body.method === 'LoadTenantDashboard') {
+          await fulfillJSON(route, {
+            tenant: SEED_TENANT,
+            environment,
+            apiUrl: 'http://127.0.0.1:1/unreachable',
+            user: { tenantId: 't1', userId: 'u1', username: 'operator' },
+            reviews: [REVIEW],
+            panels: [{ tab: 'users' }, { tab: 'reviews' }],
+          });
+          return;
+        }
+        if (body.method === 'LoadReviewDetail') {
+          await fulfillJSON(route, {
+            ...reviewDetail([ROOT_COMMENT]),
+            unresolvedThreads: 1,
+            canResolveComments: false,
+          });
+          return;
+        }
+        await route.continue();
+      });
+
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+      await app.tenantDashboard.waitForOpen();
+      await app.tenantDashboard.selectTab('Reviews');
+      await app.tenantDashboard.openReview('Add widget');
+      await app.reviewDetailDialog.waitForOpen();
+
+      await expect(app.reviewDetailDialog.locator()).toContainText('Unresolved');
+      await expect(app.reviewDetailDialog.resolveButton(0)).toHaveCount(0);
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+});

--- a/erun-ui/tenant_dashboard.go
+++ b/erun-ui/tenant_dashboard.go
@@ -48,7 +48,7 @@ func (a *App) LoadTenantDashboard(input uiTenantDashboardInput) (uiTenantDashboa
 		return dashboard, nil
 	}
 	defer cancel()
-	loadTenantDashboardData(requestCtx, client, &dashboard)
+	loadTenantDashboardData(requestCtx, client, &dashboard, input)
 	return dashboard, nil
 }
 
@@ -101,7 +101,7 @@ const (
 // loadTenantDashboardData resolves every panel independently. One panel the
 // caller may not read, or one call that fails, must not blank the panels that
 // worked — and a panel the caller may not read must not read as an empty one.
-func loadTenantDashboardData(ctx context.Context, client *eruncommon.PlatformClient, dashboard *uiTenantDashboard) {
+func loadTenantDashboardData(ctx context.Context, client *eruncommon.PlatformClient, dashboard *uiTenantDashboard, input uiTenantDashboardInput) {
 	whoami, err := client.Whoami(ctx)
 	if err != nil {
 		// Identity is the dashboard's own precondition: without it there is no
@@ -119,9 +119,17 @@ func loadTenantDashboardData(ctx context.Context, client *eruncommon.PlatformCli
 	}
 	dashboard.Panels = []uiTenantDashboardPanel{{Tab: tenantDashboardTabUsers}}
 	capabilities := whoami.Capabilities
-	reviewsOutcome := loadTenantDashboardReviews(ctx, client, capabilities, dashboard)
+	reviewFilter := eruncommon.PlatformReviewFilter{}
+	if input.ReviewFilterMine {
+		reviewFilter.AuthorUserID = whoami.UserID
+	}
+	if input.ReviewFilterWaitingOnMe {
+		reviewFilter.ReviewerUserID = whoami.UserID
+	}
+	reviewsOutcome := loadTenantDashboardReviews(ctx, client, capabilities, dashboard, reviewFilter)
 	loadTenantDashboardMergeQueue(ctx, client, capabilities, dashboard)
 	loadTenantDashboardBuilds(ctx, client, capabilities, dashboard, reviewsOutcome)
+	loadTenantDashboardReviewThreadCounts(ctx, client, capabilities, dashboard, reviewsOutcome)
 	loadTenantDashboardAuditEvents(ctx, client, capabilities, dashboard)
 	dashboard.CanCreateReview = restrictedTenantDashboardRead(capabilities, tenantDashboardWriteCreateReview) == ""
 	dashboard.CanAdvanceMergeQueue = restrictedTenantDashboardRead(capabilities, tenantDashboardWriteAdvanceMergeQueue) == ""
@@ -137,14 +145,14 @@ type reviewsLoadOutcome struct {
 	restricted string
 }
 
-func loadTenantDashboardReviews(ctx context.Context, client *eruncommon.PlatformClient, capabilities eruncommon.PlatformCapabilities, dashboard *uiTenantDashboard) reviewsLoadOutcome {
+func loadTenantDashboardReviews(ctx context.Context, client *eruncommon.PlatformClient, capabilities eruncommon.PlatformCapabilities, dashboard *uiTenantDashboard, filter eruncommon.PlatformReviewFilter) reviewsLoadOutcome {
 	panel := uiTenantDashboardPanel{Tab: tenantDashboardTabReviews}
 	if restricted := restrictedTenantDashboardRead(capabilities, tenantDashboardReadReviews); restricted != "" {
 		panel.Restricted = restricted
 		dashboard.Panels = append(dashboard.Panels, panel)
 		return reviewsLoadOutcome{restricted: restricted}
 	}
-	reviews, err := client.ListReviews(ctx, eruncommon.PlatformReviewFilter{})
+	reviews, err := client.ListReviews(ctx, filter)
 	if err != nil {
 		panel.Error = tenantDashboardReadError(tenantDashboardReadReviews, err)
 		dashboard.Panels = append(dashboard.Panels, panel)
@@ -199,6 +207,67 @@ func loadTenantDashboardBuilds(ctx context.Context, client *eruncommon.PlatformC
 		}
 	}
 	dashboard.Panels = append(dashboard.Panels, panel)
+}
+
+// loadTenantDashboardReviewThreadCounts enriches each review row with its
+// unresolved-thread count, so "is this review actually finished" is readable
+// from the list itself, not only inside the detail dialog. A review is left
+// without a count (rather than a false zero) when the caller cannot read
+// comments at all, or when its own comment read failed — supplemental detail
+// on a row, not worth a panel error the way the Reviews/Builds panels get.
+func loadTenantDashboardReviewThreadCounts(ctx context.Context, client *eruncommon.PlatformClient, capabilities eruncommon.PlatformCapabilities, dashboard *uiTenantDashboard, reviewsOutcome reviewsLoadOutcome) {
+	if reviewsOutcome.restricted != "" || reviewsOutcome.err != nil {
+		return
+	}
+	if restrictedTenantDashboardRead(capabilities, tenantDashboardReadComments) != "" {
+		return
+	}
+	counts := fetchReviewThreadCountsConcurrently(ctx, client, reviewsOutcome.reviews)
+	for i := range dashboard.Reviews {
+		count, ok := counts[dashboard.Reviews[i].ReviewID]
+		if !ok {
+			continue
+		}
+		dashboard.Reviews[i].UnresolvedThreads = &count
+	}
+}
+
+// maxConcurrentReviewCommentReads mirrors maxConcurrentReviewBuildReads for
+// the same reason: bound the per-review /comments reads a big tenant's
+// listing pays for, inside the one dashboard load's shared timeout.
+const maxConcurrentReviewCommentReads = 8
+
+// fetchReviewThreadCountsConcurrently reads every review's comments in
+// parallel, bounded by maxConcurrentReviewCommentReads, mirroring
+// fetchReviewBuildsConcurrently's shape. A review whose comment read fails is
+// simply absent from the returned map rather than reported as zero.
+func fetchReviewThreadCountsConcurrently(ctx context.Context, client *eruncommon.PlatformClient, reviews []eruncommon.PlatformReview) map[string]int {
+	counts := make(map[string]int, len(reviews))
+	semaphore := make(chan struct{}, maxConcurrentReviewCommentReads)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	for _, review := range reviews {
+		reviewID := strings.TrimSpace(review.ReviewID)
+		if reviewID == "" {
+			continue
+		}
+		wg.Add(1)
+		semaphore <- struct{}{}
+		go func(reviewID string) {
+			defer wg.Done()
+			defer func() { <-semaphore }()
+			comments, err := client.ListComments(ctx, reviewID)
+			if err != nil {
+				return
+			}
+			count := eruncommon.CountUnresolvedThreads(comments)
+			mu.Lock()
+			counts[reviewID] = count
+			mu.Unlock()
+		}(reviewID)
+	}
+	wg.Wait()
+	return counts
 }
 
 // maxConcurrentReviewBuildReads bounds how many /builds requests run at once,
@@ -325,6 +394,7 @@ func tenantDashboardReview(review eruncommon.PlatformReview) uiTenantDashboardRe
 	return uiTenantDashboardReview{
 		ReviewID:          review.ReviewID,
 		TenantID:          review.TenantID,
+		AuthorUserID:      review.AuthorUserID,
 		Name:              review.Name,
 		TargetBranch:      review.TargetBranch,
 		SourceBranch:      review.SourceBranch,

--- a/erun-ui/tenant_dashboard.go
+++ b/erun-ui/tenant_dashboard.go
@@ -96,6 +96,7 @@ const (
 	tenantDashboardReadComments    = "GET /v1/reviews/{review_id}/comments"
 	tenantDashboardWriteComment    = "POST /v1/reviews/{review_id}/comments"
 	tenantDashboardReadAuditEvents = "GET /v1/audit-events"
+	tenantDashboardReadUsers       = "GET /v1/users"
 )
 
 // loadTenantDashboardData resolves every panel independently. One panel the
@@ -119,6 +120,7 @@ func loadTenantDashboardData(ctx context.Context, client *eruncommon.PlatformCli
 	}
 	dashboard.Panels = []uiTenantDashboardPanel{{Tab: tenantDashboardTabUsers}}
 	capabilities := whoami.Capabilities
+	usernames := tenantDashboardUsernames(ctx, client, capabilities)
 	reviewFilter := eruncommon.PlatformReviewFilter{}
 	if input.ReviewFilterMine {
 		reviewFilter.AuthorUserID = whoami.UserID
@@ -126,13 +128,59 @@ func loadTenantDashboardData(ctx context.Context, client *eruncommon.PlatformCli
 	if input.ReviewFilterWaitingOnMe {
 		reviewFilter.ReviewerUserID = whoami.UserID
 	}
-	reviewsOutcome := loadTenantDashboardReviews(ctx, client, capabilities, dashboard, reviewFilter)
-	loadTenantDashboardMergeQueue(ctx, client, capabilities, dashboard)
+	reviewsOutcome := loadTenantDashboardReviews(ctx, client, capabilities, dashboard, reviewFilter, usernames)
+	loadTenantDashboardMergeQueue(ctx, client, capabilities, dashboard, usernames)
 	loadTenantDashboardBuilds(ctx, client, capabilities, dashboard, reviewsOutcome)
 	loadTenantDashboardReviewThreadCounts(ctx, client, capabilities, dashboard, reviewsOutcome)
+	loadTenantDashboardReviewFilterCounts(ctx, client, capabilities, dashboard, whoami.UserID)
 	loadTenantDashboardAuditEvents(ctx, client, capabilities, dashboard)
 	dashboard.CanCreateReview = restrictedTenantDashboardRead(capabilities, tenantDashboardWriteCreateReview) == ""
 	dashboard.CanAdvanceMergeQueue = restrictedTenantDashboardRead(capabilities, tenantDashboardWriteAdvanceMergeQueue) == ""
+}
+
+// tenantDashboardUsernames resolves every tenant user id to its display
+// username, best effort: a caller who cannot read /v1/users, or a read that
+// fails, gets back an empty map rather than failing the dashboard load — every
+// caller of the map already falls back to the raw id it was given (#1378).
+func tenantDashboardUsernames(ctx context.Context, client *eruncommon.PlatformClient, capabilities eruncommon.PlatformCapabilities) map[string]string {
+	names := make(map[string]string)
+	if restrictedTenantDashboardRead(capabilities, tenantDashboardReadUsers) != "" {
+		return names
+	}
+	users, err := client.ListUsers(ctx, eruncommon.PlatformListUsersParams{})
+	if err != nil {
+		return names
+	}
+	for _, user := range users {
+		userID := strings.TrimSpace(user.UserID)
+		username := strings.TrimSpace(user.Username)
+		if userID == "" || username == "" {
+			continue
+		}
+		names[userID] = username
+	}
+	return names
+}
+
+// loadTenantDashboardReviewFilterCounts reports how many reviews are Mine and
+// how many are Waiting on me, independent of whichever filter the caller
+// currently has applied: the Reviews tab's filter buttons need the
+// distribution visible before the caller clicks either one (#1378), not only
+// after. Best effort like the other row-enrichment reads: a restricted or
+// failing count simply leaves the corresponding field unset rather than
+// reporting a false zero.
+func loadTenantDashboardReviewFilterCounts(ctx context.Context, client *eruncommon.PlatformClient, capabilities eruncommon.PlatformCapabilities, dashboard *uiTenantDashboard, userID string) {
+	if strings.TrimSpace(userID) == "" || restrictedTenantDashboardRead(capabilities, tenantDashboardReadReviews) != "" {
+		return
+	}
+	if mine, err := client.ListReviews(ctx, eruncommon.PlatformReviewFilter{AuthorUserID: userID}); err == nil {
+		count := len(mine)
+		dashboard.MineReviewCount = &count
+	}
+	if waiting, err := client.ListReviews(ctx, eruncommon.PlatformReviewFilter{ReviewerUserID: userID}); err == nil {
+		count := len(waiting)
+		dashboard.WaitingOnMeReviewCount = &count
+	}
 }
 
 // reviewsLoadOutcome carries the Reviews panel's own result forward to the
@@ -145,7 +193,7 @@ type reviewsLoadOutcome struct {
 	restricted string
 }
 
-func loadTenantDashboardReviews(ctx context.Context, client *eruncommon.PlatformClient, capabilities eruncommon.PlatformCapabilities, dashboard *uiTenantDashboard, filter eruncommon.PlatformReviewFilter) reviewsLoadOutcome {
+func loadTenantDashboardReviews(ctx context.Context, client *eruncommon.PlatformClient, capabilities eruncommon.PlatformCapabilities, dashboard *uiTenantDashboard, filter eruncommon.PlatformReviewFilter, usernames map[string]string) reviewsLoadOutcome {
 	panel := uiTenantDashboardPanel{Tab: tenantDashboardTabReviews}
 	if restricted := restrictedTenantDashboardRead(capabilities, tenantDashboardReadReviews); restricted != "" {
 		panel.Restricted = restricted
@@ -158,12 +206,12 @@ func loadTenantDashboardReviews(ctx context.Context, client *eruncommon.Platform
 		dashboard.Panels = append(dashboard.Panels, panel)
 		return reviewsLoadOutcome{err: err}
 	}
-	dashboard.Reviews = tenantDashboardReviews(reviews)
+	dashboard.Reviews = tenantDashboardReviews(reviews, usernames)
 	dashboard.Panels = append(dashboard.Panels, panel)
 	return reviewsLoadOutcome{reviews: reviews}
 }
 
-func loadTenantDashboardMergeQueue(ctx context.Context, client *eruncommon.PlatformClient, capabilities eruncommon.PlatformCapabilities, dashboard *uiTenantDashboard) {
+func loadTenantDashboardMergeQueue(ctx context.Context, client *eruncommon.PlatformClient, capabilities eruncommon.PlatformCapabilities, dashboard *uiTenantDashboard, usernames map[string]string) {
 	panel := uiTenantDashboardPanel{Tab: tenantDashboardTabQueue}
 	if restricted := restrictedTenantDashboardRead(capabilities, tenantDashboardReadMergeQueue); restricted != "" {
 		panel.Restricted = restricted
@@ -176,7 +224,7 @@ func loadTenantDashboardMergeQueue(ctx context.Context, client *eruncommon.Platf
 	if err != nil {
 		panel.Error = tenantDashboardReadError(tenantDashboardReadMergeQueue, err)
 	} else {
-		dashboard.MergeQueue = tenantDashboardReviews(reviews)
+		dashboard.MergeQueue = tenantDashboardReviews(reviews, usernames)
 	}
 	dashboard.Panels = append(dashboard.Panels, panel)
 }
@@ -382,11 +430,22 @@ func tenantDashboardIdentityError(err error) string {
 	}
 }
 
-func tenantDashboardReviews(reviews []eruncommon.PlatformReview) []uiTenantDashboardReview {
+func tenantDashboardReviews(reviews []eruncommon.PlatformReview, usernames map[string]string) []uiTenantDashboardReview {
 	converted := make([]uiTenantDashboardReview, 0, len(reviews))
 	for _, review := range reviews {
-		converted = append(converted, tenantDashboardReview(review))
+		converted = append(converted, tenantDashboardReviewWithUsername(review, usernames))
 	}
+	return converted
+}
+
+// tenantDashboardReviewWithUsername mirrors tenantDashboardCommentWithUsername:
+// the read paths (listings, single-review load) have a resolved user
+// directory to enrich with; the write paths in tenant_review_write.go return
+// the review the caller themselves just acted on and use the base converter
+// directly, unresolved (#1378).
+func tenantDashboardReviewWithUsername(review eruncommon.PlatformReview, usernames map[string]string) uiTenantDashboardReview {
+	converted := tenantDashboardReview(review)
+	converted.AuthorUsername = usernames[review.AuthorUserID]
 	return converted
 }
 

--- a/erun-ui/tenant_dashboard_test.go
+++ b/erun-ui/tenant_dashboard_test.go
@@ -30,6 +30,8 @@ func tenantDashboardAPI(t *testing.T, capabilities string, forbidden map[string]
 			_, _ = w.Write([]byte(`[{"buildId":"build-1","tenantId":"tenant-1","reviewId":"review-1","successful":true,"commitId":"abc","version":"1.2.3"}]`))
 		case "/v1/audit-events":
 			_, _ = w.Write([]byte(`{"events":[{"type":"API","externalUserId":"subject-1","apiMethod":"GET","apiPath":"/v1/audit-events","createdAt":"2026-01-01T00:00:00Z"}]}`))
+		case "/v1/users":
+			_, _ = w.Write([]byte(`[]`))
 		default:
 			http.NotFound(w, req)
 		}
@@ -162,13 +164,52 @@ func TestTenantDashboardAttemptsEveryReadWhenCapabilitiesAreUnknown(t *testing.T
 
 	dashboard := loadTenantDashboardFrom(t, tenantDashboardApp(t), server.URL)
 
-	if got := strings.Join(requests, ","); got != "/v1/whoami,/v1/reviews,/v1/reviews/merge-queue,/v1/reviews/review-1/builds,/v1/reviews/review-1/comments,/v1/audit-events" {
-		t.Fatalf("expected every read to be attempted, got %q", got)
+	want := "/v1/whoami,/v1/users,/v1/reviews,/v1/reviews/merge-queue,/v1/reviews/review-1/builds,/v1/reviews/review-1/comments,/v1/reviews,/v1/reviews,/v1/audit-events"
+	if got := strings.Join(requests, ","); got != want {
+		t.Fatalf("expected every read to be attempted, got %q, want %q", got, want)
 	}
 	for _, panel := range dashboard.Panels {
 		if panel.Restricted != "" {
 			t.Fatalf("expected no panel to be hidden on an unknown capability set, got %+v", panel)
 		}
+	}
+	if dashboard.MineReviewCount == nil || *dashboard.MineReviewCount != 1 {
+		t.Fatalf("expected the Mine filter count to be computed, got %+v", dashboard.MineReviewCount)
+	}
+	if dashboard.WaitingOnMeReviewCount == nil || *dashboard.WaitingOnMeReviewCount != 1 {
+		t.Fatalf("expected the Waiting-on-me filter count to be computed, got %+v", dashboard.WaitingOnMeReviewCount)
+	}
+}
+
+// TestTenantDashboardResolvesReviewAuthorUsernames is the "u2 in the UI" bug
+// fixed for #1378: a review's raw authorUserId is enriched with the tenant
+// user directory's display name whenever the caller can read /v1/users.
+func TestTenantDashboardResolvesReviewAuthorUsernames(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests = append(requests, req.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch req.URL.Path {
+		case "/v1/whoami":
+			_, _ = w.Write([]byte(`{"tenantId":"tenant-1","userId":"user-1","username":"reader","capabilities":null}`))
+		case "/v1/users":
+			_, _ = w.Write([]byte(`[{"userId":"user-2","tenantId":"tenant-1","username":"pat"}]`))
+		case "/v1/reviews", "/v1/reviews/merge-queue":
+			_, _ = w.Write([]byte(`[{"reviewId":"review-1","tenantId":"tenant-1","authorUserId":"user-2","name":"Review 1","targetBranch":"main","sourceBranch":"feature","status":"READY"}]`))
+		case "/v1/reviews/review-1/builds", "/v1/reviews/review-1/comments":
+			_, _ = w.Write([]byte(`[]`))
+		case "/v1/audit-events":
+			_, _ = w.Write([]byte(`{"events":[]}`))
+		default:
+			http.NotFound(w, req)
+		}
+	}))
+	defer server.Close()
+
+	dashboard := loadTenantDashboardFrom(t, tenantDashboardApp(t), server.URL)
+
+	if len(dashboard.Reviews) != 1 || dashboard.Reviews[0].AuthorUsername != "pat" {
+		t.Fatalf("expected the review's author to resolve to its username, got %+v", dashboard.Reviews)
 	}
 }
 

--- a/erun-ui/tenant_dashboard_test.go
+++ b/erun-ui/tenant_dashboard_test.go
@@ -162,7 +162,7 @@ func TestTenantDashboardAttemptsEveryReadWhenCapabilitiesAreUnknown(t *testing.T
 
 	dashboard := loadTenantDashboardFrom(t, tenantDashboardApp(t), server.URL)
 
-	if got := strings.Join(requests, ","); got != "/v1/whoami,/v1/reviews,/v1/reviews/merge-queue,/v1/reviews/review-1/builds,/v1/audit-events" {
+	if got := strings.Join(requests, ","); got != "/v1/whoami,/v1/reviews,/v1/reviews/merge-queue,/v1/reviews/review-1/builds,/v1/reviews/review-1/comments,/v1/audit-events" {
 		t.Fatalf("expected every read to be attempted, got %q", got)
 	}
 	for _, panel := range dashboard.Panels {

--- a/erun-ui/tenant_platform_error.go
+++ b/erun-ui/tenant_platform_error.go
@@ -23,10 +23,12 @@ import (
 type platformAction string
 
 const (
-	actionCreateReview  platformAction = "open a review"
-	actionCloseReview   platformAction = "close this review"
-	actionAdvanceQueue  platformAction = "advance the merge queue"
-	actionCommentReview platformAction = "comment on this review"
+	actionCreateReview     platformAction = "open a review"
+	actionCloseReview      platformAction = "close this review"
+	actionAdvanceQueue     platformAction = "advance the merge queue"
+	actionCommentReview    platformAction = "comment on this review"
+	actionResolveComment   platformAction = "resolve this comment thread"
+	actionUnresolveComment platformAction = "reopen this comment thread"
 )
 
 // operatorPlatformError turns a platform failure into what the operator needs

--- a/erun-ui/tenant_review_detail.go
+++ b/erun-ui/tenant_review_detail.go
@@ -71,6 +71,7 @@ func (a *App) LoadReviewDetail(input uiReviewDetailInput) (uiReviewDetail, error
 	detail.QueuePosition = loadReviewDetailQueuePosition(requestCtx, client, capabilities, review, reviewID)
 	detail.CanComment = restrictedTenantDashboardRead(capabilities, tenantDashboardWriteComment) == ""
 	detail.CanClose = restrictedTenantDashboardRead(capabilities, tenantDashboardWriteReviewStatus) == ""
+	detail.CanResolveComments = restrictedTenantDashboardRead(capabilities, tenantDashboardWriteCommentStatus) == ""
 	return detail, nil
 }
 
@@ -85,6 +86,7 @@ func loadReviewDetailComments(ctx context.Context, client *eruncommon.PlatformCl
 		return
 	}
 	detail.Comments = tenantDashboardComments(comments)
+	detail.UnresolvedThreads = eruncommon.CountUnresolvedThreads(comments)
 }
 
 func loadReviewDetailBuilds(ctx context.Context, client *eruncommon.PlatformClient, capabilities eruncommon.PlatformCapabilities, reviewID, reviewName string, detail *uiReviewDetail) {

--- a/erun-ui/tenant_review_detail.go
+++ b/erun-ui/tenant_review_detail.go
@@ -53,6 +53,7 @@ func (a *App) LoadReviewDetail(input uiReviewDetailInput) (uiReviewDetail, error
 		return detail, nil
 	}
 	capabilities := whoami.Capabilities
+	usernames := tenantDashboardUsernames(requestCtx, client, capabilities)
 
 	if restricted := restrictedTenantDashboardRead(capabilities, tenantDashboardReadReview); restricted != "" {
 		detail.Restricted = restricted
@@ -63,10 +64,10 @@ func (a *App) LoadReviewDetail(input uiReviewDetailInput) (uiReviewDetail, error
 		detail.Error = tenantDashboardReadError(tenantDashboardReadReview, err)
 		return detail, nil
 	}
-	converted := tenantDashboardReview(review)
+	converted := tenantDashboardReviewWithUsername(review, usernames)
 	detail.Review = &converted
 
-	loadReviewDetailComments(requestCtx, client, capabilities, reviewID, &detail)
+	loadReviewDetailComments(requestCtx, client, capabilities, reviewID, usernames, &detail)
 	loadReviewDetailBuilds(requestCtx, client, capabilities, reviewID, review.Name, &detail)
 	detail.QueuePosition = loadReviewDetailQueuePosition(requestCtx, client, capabilities, review, reviewID)
 	detail.CanComment = restrictedTenantDashboardRead(capabilities, tenantDashboardWriteComment) == ""
@@ -75,7 +76,7 @@ func (a *App) LoadReviewDetail(input uiReviewDetailInput) (uiReviewDetail, error
 	return detail, nil
 }
 
-func loadReviewDetailComments(ctx context.Context, client *eruncommon.PlatformClient, capabilities eruncommon.PlatformCapabilities, reviewID string, detail *uiReviewDetail) {
+func loadReviewDetailComments(ctx context.Context, client *eruncommon.PlatformClient, capabilities eruncommon.PlatformCapabilities, reviewID string, usernames map[string]string, detail *uiReviewDetail) {
 	if restricted := restrictedTenantDashboardRead(capabilities, tenantDashboardReadComments); restricted != "" {
 		detail.CommentsRestricted = restricted
 		return
@@ -85,7 +86,7 @@ func loadReviewDetailComments(ctx context.Context, client *eruncommon.PlatformCl
 		detail.CommentsError = tenantDashboardReadError(tenantDashboardReadComments, err)
 		return
 	}
-	detail.Comments = tenantDashboardComments(comments)
+	detail.Comments = tenantDashboardComments(comments, usernames)
 	detail.UnresolvedThreads = eruncommon.CountUnresolvedThreads(comments)
 }
 
@@ -189,11 +190,17 @@ func tenantDashboardBuildsForReview(builds []eruncommon.PlatformBuild, reviewNam
 	return converted
 }
 
-func tenantDashboardComments(comments []eruncommon.PlatformComment) []uiReviewComment {
+func tenantDashboardComments(comments []eruncommon.PlatformComment, usernames map[string]string) []uiReviewComment {
 	converted := make([]uiReviewComment, 0, len(comments))
 	for _, comment := range comments {
-		converted = append(converted, tenantDashboardComment(comment))
+		converted = append(converted, tenantDashboardCommentWithUsername(comment, usernames))
 	}
+	return converted
+}
+
+func tenantDashboardCommentWithUsername(comment eruncommon.PlatformComment, usernames map[string]string) uiReviewComment {
+	converted := tenantDashboardComment(comment)
+	converted.CreatorUsername = usernames[comment.CreatorUserID]
 	return converted
 }
 

--- a/erun-ui/tenant_review_detail_test.go
+++ b/erun-ui/tenant_review_detail_test.go
@@ -149,6 +149,54 @@ func TestCreateReviewReplyRequiresABody(t *testing.T) {
 	}
 }
 
+// usernameResolutionFixedResponses backs
+// TestLoadReviewDetailResolvesAuthorAndCommenterUsernames: user-2 (the
+// review's author and comment-1's creator) resolves to "pat"; user-1 (the
+// signed-in caller, comment-2's creator) is deliberately absent, so it stays
+// unresolved.
+var usernameResolutionFixedResponses = map[string]string{
+	"/v1/whoami":                  `{"tenantId":"tenant-1","userId":"user-1","username":"reader","capabilities":null}`,
+	"/v1/users":                   `[{"userId":"user-2","tenantId":"tenant-1","username":"pat"}]`,
+	"/v1/reviews/review-1":        `{"reviewId":"review-1","tenantId":"tenant-1","authorUserId":"user-2","name":"Review 1","targetBranch":"main","sourceBranch":"feature","status":"READY"}`,
+	reviewDetailCommentsPath:      reviewDetailThreadJSON,
+	"/v1/reviews/review-1/builds": `[]`,
+	"/v1/reviews/merge-queue":     `[]`,
+}
+
+func usernameResolutionAPI(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body, ok := usernameResolutionFixedResponses[req.URL.Path]
+		if !ok {
+			http.NotFound(w, req)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// TestLoadReviewDetailResolvesAuthorAndCommenterUsernames is the review
+// detail dialog's half of the #1378 "u2 in the UI" fix: the review's author
+// and each comment's creator resolve to the tenant user directory's display
+// name when the caller can read /v1/users.
+func TestLoadReviewDetailResolvesAuthorAndCommenterUsernames(t *testing.T) {
+	server := usernameResolutionAPI(t)
+	defer server.Close()
+
+	detail := loadReviewDetailFrom(t, tenantDashboardApp(t), server.URL)
+
+	if detail.Review == nil || detail.Review.AuthorUsername != "pat" {
+		t.Fatalf("expected the review's author to resolve to its username, got %+v", detail.Review)
+	}
+	if len(detail.Comments) != 2 || detail.Comments[0].CreatorUsername != "pat" {
+		t.Fatalf("expected comment-1's creator (user-2) to resolve to its username, got %+v", detail.Comments)
+	}
+	if detail.Comments[1].CreatorUsername != "" {
+		t.Fatalf("expected comment-2's creator (user-1, absent from the /v1/users stub) to stay unresolved, got %+v", detail.Comments[1])
+	}
+}
+
 // TestFetchReviewBuildsConcurrentlyReturnsPartialResultsOnFailure locks the
 // concurrency fix's behavior: a failing review's builds read must not lose
 // the builds already fetched for the reviews that succeeded, matching the

--- a/erun-ui/tenant_review_write.go
+++ b/erun-ui/tenant_review_write.go
@@ -20,6 +20,7 @@ const (
 	tenantDashboardWriteCreateReview      = "POST /v1/reviews"
 	tenantDashboardWriteReviewStatus      = "PATCH /v1/reviews/{review_id}/status"
 	tenantDashboardWriteAdvanceMergeQueue = "POST /v1/reviews/merge-queue/advance"
+	tenantDashboardWriteCommentStatus     = "PATCH /v1/reviews/{review_id}/comments/{comment_id}/status"
 )
 
 // CreateReview opens a review. It is a real, immediate write — there is no
@@ -196,6 +197,62 @@ func (a *App) CreateReviewComment(input uiCreateReviewCommentInput) (uiReviewCom
 	})
 	if err != nil {
 		return uiReviewComment{}, operatorPlatformError(actionCommentReview, err)
+	}
+	return tenantDashboardComment(comment), nil
+}
+
+// ResolveReviewComment marks a comment thread CLOSED (resolved). The
+// dashboard only ever offers this on a thread's root comment — never a reply —
+// so, unlike the CLI/MCP paths, there is no reply-addressed-to-root rejection
+// to surface here.
+func (a *App) ResolveReviewComment(input uiUpdateReviewCommentStatusInput) (uiReviewComment, error) {
+	return a.updateReviewCommentStatus(input, "CLOSED")
+}
+
+// UnresolveReviewComment reopens a comment thread (marks it OPEN).
+func (a *App) UnresolveReviewComment(input uiUpdateReviewCommentStatusInput) (uiReviewComment, error) {
+	return a.updateReviewCommentStatus(input, "OPEN")
+}
+
+func (a *App) updateReviewCommentStatus(input uiUpdateReviewCommentStatusInput, status string) (uiReviewComment, error) {
+	tenant := strings.TrimSpace(input.Tenant)
+	if tenant == "" {
+		return uiReviewComment{}, fmt.Errorf("tenant is required")
+	}
+	apiURL := strings.TrimSpace(input.APIURL)
+	if apiURL == "" {
+		return uiReviewComment{}, fmt.Errorf("tenant API URL is required")
+	}
+	alias := strings.TrimSpace(input.CloudProviderAlias)
+	if alias == "" {
+		return uiReviewComment{}, fmt.Errorf("tenant primary cloud alias is required")
+	}
+	reviewID := strings.TrimSpace(input.ReviewID)
+	if reviewID == "" {
+		return uiReviewComment{}, fmt.Errorf("review id is required")
+	}
+	commentID := strings.TrimSpace(input.CommentID)
+	if commentID == "" {
+		return uiReviewComment{}, fmt.Errorf("comment id is required")
+	}
+
+	ctx := a.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	client, requestCtx, cancel, err := a.tenantDashboardBearerClient(ctx, apiURL, alias)
+	if err != nil {
+		return uiReviewComment{}, err
+	}
+	defer cancel()
+
+	action := actionResolveComment
+	if status == "OPEN" {
+		action = actionUnresolveComment
+	}
+	comment, err := client.UpdateCommentStatus(requestCtx, reviewID, commentID, eruncommon.PlatformUpdateCommentStatusParams{Status: status})
+	if err != nil {
+		return uiReviewComment{}, operatorPlatformError(action, err)
 	}
 	return tenantDashboardComment(comment), nil
 }

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -243,6 +243,13 @@ type uiTenantDashboard struct {
 	// already gives the reply composer.
 	CanCreateReview      bool `json:"canCreateReview"`
 	CanAdvanceMergeQueue bool `json:"canAdvanceMergeQueue"`
+	// MineReviewCount/WaitingOnMeReviewCount are the Reviews tab's filter
+	// buttons' own discovery signal: how many reviews match each filter,
+	// visible before the caller clicks either one. Unset (rather than 0) when
+	// the caller cannot read reviews at all, or has no signed-in user id to
+	// filter by.
+	MineReviewCount        *int `json:"mineReviewCount,omitempty"`
+	WaitingOnMeReviewCount *int `json:"waitingOnMeReviewCount,omitempty"`
 }
 
 // uiTenantDashboardPanel is one panel's own outcome. It is what lets the tab
@@ -272,10 +279,15 @@ type uiTenantDashboardReview struct {
 	ReviewID     string `json:"reviewId"`
 	TenantID     string `json:"tenantId"`
 	AuthorUserID string `json:"authorUserId,omitempty"`
-	Name         string `json:"name"`
-	TargetBranch string `json:"targetBranch"`
-	SourceBranch string `json:"sourceBranch"`
-	Status       string `json:"status"`
+	// AuthorUsername is the tenant user directory's display name for
+	// AuthorUserID, resolved best-effort (see tenant_dashboard.go's
+	// tenantDashboardUsernames). Empty when it could not be resolved, so the
+	// frontend falls back to the raw id rather than showing nothing (#1378).
+	AuthorUsername string `json:"authorUsername,omitempty"`
+	Name           string `json:"name"`
+	TargetBranch   string `json:"targetBranch"`
+	SourceBranch   string `json:"sourceBranch"`
+	Status         string `json:"status"`
 	// UnresolvedThreads is the review's "still being discussed" signal at a
 	// glance, from the row rather than only inside the detail dialog. Left
 	// unset (rather than 0) when it was not computed for this listing (see
@@ -352,8 +364,12 @@ type uiReviewDetail struct {
 }
 
 type uiReviewComment struct {
-	CommentID       string `json:"commentId"`
-	CreatorUserID   string `json:"creatorUserId,omitempty"`
+	CommentID     string `json:"commentId"`
+	CreatorUserID string `json:"creatorUserId,omitempty"`
+	// CreatorUsername mirrors uiTenantDashboardReview.AuthorUsername: the
+	// tenant user directory's display name for CreatorUserID, resolved
+	// best-effort, empty when it could not be resolved (#1378).
+	CreatorUsername string `json:"creatorUsername,omitempty"`
 	Status          string `json:"status"`
 	ParentCommentID string `json:"parentCommentId,omitempty"`
 	CommitID        string `json:"commitId"`

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -208,6 +208,12 @@ type uiTenantDashboardInput struct {
 	MCPURL             string `json:"mcpUrl,omitempty"`
 	KubernetesContext  string `json:"kubernetesContext,omitempty"`
 	CloudProviderAlias string `json:"cloudProviderAlias"`
+	// ReviewFilterMine/ReviewFilterWaitingOnMe are the Reviews tab's one-click
+	// discovery filters. Both resolve to the signed-in user's own id (already
+	// known from this same load's whoami call) rather than asking the
+	// frontend to carry a user id it has no other reason to know.
+	ReviewFilterMine        bool `json:"reviewFilterMine,omitempty"`
+	ReviewFilterWaitingOnMe bool `json:"reviewFilterWaitingOnMe,omitempty"`
 
 	// mcpBearer is the per-env MCP edge token for the dashboard's MCP API-log
 	// read. Set server-side from the desktop identity, never by the frontend;
@@ -263,12 +269,19 @@ type uiTenantDashboardUser struct {
 }
 
 type uiTenantDashboardReview struct {
-	ReviewID          string `json:"reviewId"`
-	TenantID          string `json:"tenantId"`
-	Name              string `json:"name"`
-	TargetBranch      string `json:"targetBranch"`
-	SourceBranch      string `json:"sourceBranch"`
-	Status            string `json:"status"`
+	ReviewID     string `json:"reviewId"`
+	TenantID     string `json:"tenantId"`
+	AuthorUserID string `json:"authorUserId,omitempty"`
+	Name         string `json:"name"`
+	TargetBranch string `json:"targetBranch"`
+	SourceBranch string `json:"sourceBranch"`
+	Status       string `json:"status"`
+	// UnresolvedThreads is the review's "still being discussed" signal at a
+	// glance, from the row rather than only inside the detail dialog. Left
+	// unset (rather than 0) when it was not computed for this listing (see
+	// tenant_dashboard.go's reviewThreadCounts) so a caller can tell "zero
+	// unresolved" apart from "not read for this row".
+	UnresolvedThreads *int   `json:"unresolvedThreads,omitempty"`
 	LastFailedBuildID string `json:"lastFailedBuildId,omitempty"`
 	LastReadyBuildID  string `json:"lastReadyBuildId,omitempty"`
 	LastMergedBuildID string `json:"lastMergedBuildId,omitempty"`
@@ -324,11 +337,18 @@ type uiReviewDetail struct {
 	// QueuePosition is 1-based; 0 means the review is not in its target
 	// branch's merge queue right now.
 	QueuePosition int `json:"queuePosition,omitempty"`
+	// UnresolvedThreads counts root comments still OPEN, valid whenever
+	// Comments loaded (CommentsRestricted and CommentsError both empty).
+	UnresolvedThreads int `json:"unresolvedThreads,omitempty"`
 	// CanComment reports whether the signed-in user may reply at all, so the
 	// composer can be hidden rather than rendered to fail on submit.
 	CanComment bool `json:"canComment"`
 	// CanClose mirrors CanComment for the close action.
 	CanClose bool `json:"canClose"`
+	// CanResolveComments mirrors CanComment for the resolve/unresolve action,
+	// gated on its own write route since resolving a thread and posting to it
+	// are different permissions on the platform.
+	CanResolveComments bool `json:"canResolveComments"`
 }
 
 type uiReviewComment struct {
@@ -341,6 +361,17 @@ type uiReviewComment struct {
 	Line            int    `json:"line"`
 	Body            string `json:"body"`
 	CreatedAt       string `json:"createdAt,omitempty"`
+}
+
+// uiUpdateReviewCommentStatusInput resolves or unresolves a comment thread.
+// CommentID must be a thread's root; the frontend never offers the action on
+// a reply, so there is no reply-rejection path to surface here.
+type uiUpdateReviewCommentStatusInput struct {
+	Tenant             string `json:"tenant"`
+	APIURL             string `json:"apiUrl"`
+	CloudProviderAlias string `json:"cloudProviderAlias"`
+	ReviewID           string `json:"reviewId"`
+	CommentID          string `json:"commentId"`
 }
 
 // uiCreateReviewReplyInput replies to an existing comment thread. CommitID,


### PR DESCRIPTION
Makes the desktop's review → build → comment loop usable, and gives comment resolution a client for the first time.

## Resolution had no client anywhere

`PATCH /v1/reviews/{review_id}/comments/{comment_id}/status` was registered (`internal/routes/comments.go:30`) over `CommentService.UpdateStatus`, with `comments.status` enforced by `comments_status_check` — and `grep -rn UpdateCommentStatus erun-common erun-cli erun-mcp erun-ui` returned **zero hits**. Raw HTTP was the only way to close a comment, which is the escape hatch `PlatformClient` exists to remove.

Now: `PlatformClient.UpdateCommentStatus`, plus **both** transports as root `AGENTS.md` § "Command primitives vs orchestration" requires — `erun review resolve|unresolve REVIEW_ID COMMENT_ID` and the `review_resolve` / `review_unresolve` MCP tools. `erun review show` gained each thread's status and the review's unresolved count.

Resolution is a property of the **thread**: the root comment's status *is* the thread's status. The backend already refused a reply's status change via the `comments_validate` trigger, but its message did not name the root, so the client names it — the trigger stays as the real enforcement rather than being duplicated.

## Discovery was unfiltered and could not render an author

`erun-ui/tenant_dashboard.go:145` fetched with a zero-value `PlatformReviewFilter{}` while that struct already carried `Status`, `AuthorUserID`, `ReviewerUserID`, `SourceBranch`, `TargetBranch` — and `UITenantDashboardReview` mirrored every `PlatformReview` field *except* `AuthorUserID`. So the two questions that decide what an operator does next, *what is mine* and *what is waiting on me*, were CLI flags and nothing in the app.

## Per-environment sections did not name their environment (#1314)

N identical `Review layers` blocks with different merge targets and nothing saying which environment each belonged to, while the changed-files tree labelled its sections only with a raw `tenant/environment` key in 11px muted text — a different treatment, so the two could not be matched by eye. A shared `ReviewPanel.EnvLabel` now serves both, and `pw / alpha` / `pw / beta` head the diff sections and the layers blocks identically.

## The craft pass, and why there was one

The first version of this surface passed every gate and was still rejected: it was a correct data table. Fourteen defects were found by opening the rendered screenshots rather than reading the code, and all fourteen are fixed:

| | defect | now |
|---|---|---|
| A | review title **hard-clipped mid-word** ("Add widget renderin") while the branch cells beside it elided correctly | renders fully; elides with `…` |
| B | no hierarchy — title, author, branches, timestamp all the same size, weight and colour | two-line row; title dominates, metadata subordinate in size *and* colour |
| C | `u2` rendered as the author — implementation language `erun-ui/AGENTS.md` forbids | resolved through the read model: "Pat Reviewer" |
| D | no author avatar | circular initials, filled for you and muted for others |
| E | `Mine` / `Waiting on me` carried no counts, so you clicked to find where the work was | `Mine 1` / `Waiting on me 1`, grouped as one segmented control |
| F | timestamps were truncated raw locale strings (`1/1/2026, 12:00:...`) | relative — "8 months ago" |
| G | permission notices were muted prose dropped in layout gaps, and "open reviews" was ambiguous between *create* and *view* | bordered alert with a lock icon; copy says "create reviews" |
| H | the comment anchor was the most truncated thing on screen and its **line number was absent entirely** | `abc123  main.go  :42` — commit, file and line |
| I | `Reply` and `Resolve` were identical outline buttons | `Resolve` primary, `Reply` secondary |
| J | `reviewer-1` wrapped mid-token to `reviewer-\n1` | one line |
| K | the detail dialog was ~510px on a 1440px viewport, so the comment measure was cramped | ~768px with a comfortable measure |
| M | the dialog's branch line ran to three unbounded lines of raw branch names | middle-elided, keeping both ends — which is what identifies a branch |
| N | **a long comment body was clipped with no scroll and no expand — the text was unreachable** | full body with a Show more/less toggle, asserted in a spec |
| O | the restricted notice read "you do not have access to **GET /v1/reviews**" | "It needs the reviewer role. Ask an administrator for access." |

Also improved without being asked: where a fixture has no author, the row renders a `?` avatar and `-` rather than blank or `undefined` — absent data designed rather than defaulted.

**Not fully fixed, and filed rather than glossed:** at 640px the panel's own overflow is gone (asserted), but content still clips because the **app shell's sidebar keeps its full 337px width at every viewport**, leaving ~300px for any panel. That is a shell defect affecting every tab equally, not a reviews-tab one — filed as #1387.

## Already at the bar before the craft pass, deliberately untouched

The status and thread badges (`READY` / `FAILED` / `All resolved` / `3 unresolved` — each icon + label + colour, so colour is never the only signal), the `feature/widget → main` arrow, the designed "No build yet" panel, and all three empty states: *"No reviews yet"* with how one appears, *"No reviews match this filter"* with a **Clear filter** action, and the restricted case hiding the tab entirely per the repo's own "a tab the user may not open does not render" rule.

## Scoped out, deliberately

The rest of #1317: the migration making a comment's anchor an all-or-nothing triple, reviewer verdict columns, and the merge-queue gate refusing to advance a review with unresolved threads. Those are schema work, and the gate is only meaningful once resolution has a client — which is what this delivers. #1317 stays open for them.

## Verification

Gated in a pod (`erun-common`/`erun-mcp` are host-dependent — #1361, #1363):

- `erun-common`, `erun-cli`, `erun-mcp`, `erun-integration` — all `ok`; integration coverage **76.4% ≥ 76.2%** with no threshold change
- `erun-ui` `go test -race -count=1 ./...` — ok, both packages
- frontend typecheck / format clean, tests `fail 0`; `yarn lint` **0 errors** (3 `approaching-max-lines` warnings, all pre-existing and including a file this branch never touched)
- Playwright with `--build` — **20/20**, including *"a long comment body stays inside the dialog, which scrolls instead of growing without bound"* and *"a narrow viewport keeps the reviews tab usable: no horizontal overflow, actions still reachable"*
- `make lint` **0 issues across all six modules** on the prospective merge onto `1db28dfc`, verified against a separately-measured baseline

That last one mattered: #1313 landed mid-flight and **made lint stricter** by removing `uniq-by-line` suppression, so this branch's earlier green could have been an artifact. It was checked rather than assumed — including confirming the strict config is genuinely active (`uniq-by-line: false` present in every module's `.golangci.yml`, `funlen`/`gocyclo`/`cyclop` enabled at real thresholds) so that "0 findings" could not mean "config inert".

`--dry-run` trace for the new verbs, from `erun-integration/testdata/review/resolve_dry_run.txt`:

```
Dry run: erun review resolve planned.
audit: erun review resolve --dry-run review-1 comment-1
platform: GET https://api.example.test/v1/reviews/review-1/comments
platform: PATCH https://api.example.test/v1/reviews/review-1/comments/comment-1/status (status=CLOSED)
```

The GET is real — it is the lookup backing the reply-rejection check.

## Not verified

- **Screen-reader announcement** of the badges and inline alerts. `aria-label` / `role` presence confirmed in code and via accessibility-tree queries; no real screen reader was run.
- **The native Wails webview's own rendering.** Every screenshot here comes from the headless harness driving the same binary; that covers the bindings, the state and the React tree, not the webview's paint.
- `review-panel-reachability.spec.ts` → *"clicking Open surfaces honest copy for the stopped case"* is excluded: it times out deterministically on a lingering dialog overlay, reproduces on unmodified `main`, and is filed as #1381.

The desktop is **single-theme**; every `dark:` utility here is inert pending #1356, so this claims one theme checked, not two.

Closes #1378
