### PR TITLE
Tell an orchestrator how a delegated run actually fails

### DIFF
--- a/erun-skills/skills/erun-orchestrate/SKILL.md
+++ b/erun-skills/skills/erun-orchestrate/SKILL.md
@@ -94,6 +94,15 @@ Read what you control from erun's config store — never infer it from what happ
   contract, not a reason to lean on it instead of pacing yourself.
   Short repeated checks also keep the operator informed, which a single silent block does not.
 - **On completion, list the assumptions you took** in place of asking. This is what keeps "don't ask" accountable.
+- **Waiting is not working.** Pacing yourself is the floor, not the job. While delegated work is in
+  flight there is almost always work that needs no worktree at all — reading the artifacts it has
+  already produced, judging rendered output, preparing the next brief, driving an independent
+  environment. An orchestrator that only polls is idle, and from the outside idle is
+  indistinguishable from blocked.
+- **Correct is not the same as good.** A green gate and a working surface can both hold while the
+  result still fails the bar it was given. Where the bar is craft or convenience, the passing verdict
+  and the quality verdict are separate judgements, and only one of them a test can make. Decide the
+  second one by looking at what shipped, and be willing to send back something that works.
 
 ## Working in a pod
 
@@ -192,6 +201,22 @@ Read what you control from erun's config store — never infer it from what happ
   running, exited, or unreachable.
 - **Wake a stopped environment from the host.** A stopped env has no pod, so its MCP edge cannot answer and cannot start itself; that silence is not a broken env. Open it from the host CLI, then resume over MCP.
 - **When you hand an agent a long gate, tell it how to wait.** An agent left to invent its own waiting starts the work in a background shell and then spends its turns re-reading an empty output file — hundreds of turns that buy nothing and can exhaust it before the work it is waiting for even finishes. Have it run the gate as a detached job and block on that job's own completion, so waiting costs one call rather than one per poll.
+- **A delegated run's progress is not its committed state.** Coherent narration, advancing turn
+  counts and a busy lease say nothing about whether anything was saved. Read the tree, not the
+  report: work can sit uncommitted behind hundreds of turns of confident progress, and a run that
+  dies then loses all of it. Ask for commits after each coherent chunk, then verify they exist.
+- **Telling an agent not to background its gate is not a control.** It will do it anyway, including
+  when told first, told as a rule, and told what it cost last time. Treat that as a property of the
+  medium rather than a lapse to instruct away: what actually protects the work is verifying commits
+  and being ready to take the tree over and finish the gate yourself.
+- **Someone else's reading of an artifact is not the artifact.** A delegated "pass" against a
+  screenshot, a log or a report is a claim about evidence, not evidence — and it fails in a
+  characteristic way, by asserting something weaker than what mattered ("the tab opened" for "the
+  operator can see the job"). Open the artifact yourself before believing a verdict about it.
+- **A long bounded wait loses to a recycling channel.** The bounded wait is built for repeated short
+  calls; stretched toward its maximum it holds one request open across a channel that may not live
+  that long, so it fails for reasons that have nothing to do with the work. Poll short, and prefer
+  the path that self-heals a dropped hop over one that only reports it.
 
 ## Fixing erun itself
 


### PR DESCRIPTION
Four failure shapes from driving two features through in-pod agent jobs today, none of which the skill covered. Each is a general property of delegating to a one-shot agent, not a one-off.

## Added to § "Working in a pod"

- **A delegated run's progress is not its committed state.** An agent job narrated coherent progress for 250 turns — reading files, running gates, describing fixes — with 31 files uncommitted and no commits past the ones it started with. Its brief told it to commit after each chunk. Nothing in `job_status`, `job_output` or the lease name distinguishes "working and committing" from "working and losing"; only `git status` in the pod does.
- **Telling an agent not to background its gate is not a control.** Two runs pushed a long gate into a background shell and moved on. The second did it *after* a prohibition placed first in its prompt, written as a rule, citing the previous failure by name. One exited 0 saying it would report when "the monitor notifies me" — there is no monitor. The skill already says "a one-shot agent has no later" and "tell it how to wait"; what was missing is that telling it does not hold, so the orchestrator's actual control is verifying commits and being ready to take the tree over.
- **Someone else's reading of an artifact is not the artifact.** An agent asked to screenshot a surface, read the PNGs and report per-screenshot findings graded as "pass" a screenshot showing its own new route landing on an empty list — the exact defect the change existed to remove. It had asserted the tab *opened*, which is weaker than what mattered. Separately, fourteen real defects came out of opening the same PNGs it had already graded.
- **A long bounded wait loses to a recycling channel.** An environment's port-forward recycled every few minutes; every 300–600s `job_await` died while 30–120s polls returned normally. The bounded wait is built for repeated short calls, and the host CLI self-heals one hop where the desktop's proxy only reports the drop.

## Added to § "Operating mode"

- **Waiting is not working.** The existing pacing guidance is good but reads as permission to poll. In practice a delegated run leaves substantial work that needs no worktree — reading artifacts already produced, judging rendered output, preparing the next brief, driving an independent environment. An orchestrator that only polls is idle, and idle is indistinguishable from blocked from the outside.
- **Correct is not the same as good.** A green gate and a working surface can both hold while the result fails the bar it was given. Where the bar is craft or convenience, the passing verdict and the quality verdict are separate judgements and only one of them is a test's to make.

## Why the skill and not a note

The installed copy under `~/.claude/skills/` is a baked artifact; editing it would be erased by the next bake, which is the same mistake as editing a mirror. `erun-skills/skills/` is the source every orchestrator's copy is built from.

Kept to the file's own rule — state the principle, not the instance — so each is a few lines rather than a war story, with only as much specific evidence as makes the principle believable.

## Verification

`erun-ui go test ./...` and `erun-integration go test ./...` both green (`erun-ui/orchestrator_pacing.go`, `orchestrator_test.go` and `erun-integration/internal/fixture/fixture.go` all reference this skill, so it is gated rather than free-text). Gated on `erun/build`, whose architecture matches, rather than on the busy 8GiB env.

Closes #1384