### PR TITLE
Give the blocked diff-comment popover a way to the Reviews tab

### DIFF
--- a/erun-ui/frontend/src/components/app/DiffList.CommentAction.tsx
+++ b/erun-ui/frontend/src/components/app/DiffList.CommentAction.tsx
@@ -9,6 +9,7 @@ import {
   startReviewComment,
   submitReviewComment,
 } from '@/app/reviewDetailThunks';
+import { openTenantDashboard, setTenantDashboardTab } from '@/app/tenantDialogThunks';
 import type { DiffLine } from '@/types';
 
 import { InlineAlert } from './InlineAlert';
@@ -28,10 +29,12 @@ export function DiffLineCommentAction({
   filePath,
   line,
   commitHash,
+  tenant,
 }: {
   filePath: string;
   line: DiffLine;
   commitHash: string;
+  tenant: string;
 }): React.ReactElement | null {
   const dispatch = useAppDispatch();
   // The active commenting context is the last-opened review, which survives
@@ -85,12 +88,53 @@ export function DiffLineCommentAction({
       </PopoverAnchor>
       <PopoverContent side="right" align="start" className="w-72">
         {blockedReason ? (
-          <p className="text-[13px] text-muted-foreground">{blockedReason}</p>
+          <DiffLineCommentBlocked
+            reason={blockedReason}
+            tenant={tenant}
+            showOpenReviewsTab={!hasActiveReview}
+          />
         ) : (
           <DiffLineCommentComposer />
         )}
       </PopoverContent>
     </Popover>
+  );
+}
+
+// DiffLineCommentBlocked renders the explanatory sentence every blocked
+// reason gets, plus the one action that actually resolves a reason: the
+// no-active-review case names the Reviews tab, which lives in the tenant
+// dashboard — a different surface from this diff panel — so the popover
+// navigates there in one click rather than leaving the reader to find it on
+// their own (#1388). The other two reasons are actionable exactly where the
+// operator already stands (commit the change, request access), so they stay
+// message-only.
+function DiffLineCommentBlocked({
+  reason,
+  tenant,
+  showOpenReviewsTab,
+}: {
+  reason: string;
+  tenant: string;
+  showOpenReviewsTab: boolean;
+}): React.ReactElement {
+  const dispatch = useAppDispatch();
+  return (
+    <div className="grid gap-2">
+      <p className="text-[13px] text-muted-foreground">{reason}</p>
+      {showOpenReviewsTab && (
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => {
+            dispatch(openTenantDashboard(tenant));
+            dispatch(setTenantDashboardTab('reviews'));
+          }}
+        >
+          Open Reviews tab
+        </Button>
+      )}
+    </div>
   );
 }
 

--- a/erun-ui/frontend/src/components/app/DiffList.tsx
+++ b/erun-ui/frontend/src/components/app/DiffList.tsx
@@ -110,6 +110,7 @@ function DiffEnvSection({
             file={file}
             selected={diffPathKey(target.envKey, file.path) === selectedDiffPath}
             commitHash={commitHash}
+            tenant={target.tenant}
           />
         ))}
       </>
@@ -314,10 +315,12 @@ function DiffFileView({
   file,
   selected,
   commitHash,
+  tenant,
 }: {
   file: DiffFile;
   selected: boolean;
   commitHash: string;
+  tenant: string;
 }): React.ReactElement {
   return (
     <section
@@ -341,6 +344,7 @@ function DiffFileView({
             hunk={hunk}
             filePath={file.path}
             commitHash={commitHash}
+            tenant={tenant}
           />
         ))
       )}
@@ -352,10 +356,12 @@ function DiffHunkView({
   hunk,
   filePath,
   commitHash,
+  tenant,
 }: {
   hunk: DiffHunk;
   filePath: string;
   commitHash: string;
+  tenant: string;
 }): React.ReactElement {
   const contentWidth = Math.max(1, ...(hunk.lines ?? []).map((line) => line.content.length));
   const style = { '--diff-content-width': `${String(contentWidth + 2)}ch` } as React.CSSProperties;
@@ -385,7 +391,12 @@ function DiffHunkView({
             {/* Leads the row: a trailing column sits past the content width, so
                 on any diff wider than the panel the affordance was only
                 reachable by scrolling right. */}
-            <DiffLineCommentAction filePath={filePath} line={line} commitHash={commitHash} />
+            <DiffLineCommentAction
+              filePath={filePath}
+              line={line}
+              commitHash={commitHash}
+              tenant={tenant}
+            />
             <span className="select-none border-r border-[oklch(0_0_0/0.05)] bg-inherit px-2 text-right text-muted-foreground">
               {line.oldLine ?? ''}
             </span>

--- a/erun-ui/playwright/tests/review-diff-line-comment.spec.ts
+++ b/erun-ui/playwright/tests/review-diff-line-comment.spec.ts
@@ -94,6 +94,30 @@ function routeLoadTenantDashboard(
   });
 }
 
+// dismissAIOccupancyPromptIfShown is a defensive wait, not a feature this
+// spec is testing: opening an environment auto-spawns its AI tab
+// (ensureDefaultEnvTabs), which resolves either into an AI tab or -- if the
+// environment's activity lease is already held -- the occupancy prompt
+// (erun#1221). These tests care about the diff panel, not the AI tab, so race
+// on whichever the spawn actually produces and clear the prompt out of the
+// way rather than letting it block a later click.
+async function dismissAIOccupancyPromptIfShown(
+  app: import('../pages/index.js').AppShell,
+): Promise<void> {
+  const dialog = app.aiOccupancyPromptDialog;
+  await Promise.race([
+    dialog.waitForOpen().catch(() => undefined),
+    app.page
+      .getByRole('tab', { name: 'AI', exact: true })
+      .waitFor({ state: 'visible' })
+      .catch(() => undefined),
+  ]);
+  if (await dialog.locator().isVisible()) {
+    await dialog.cancel();
+    await dialog.waitForClosed();
+  }
+}
+
 // openActiveReviewContext opens a review from the tenant dashboard and closes
 // its (modal) dialog, establishing reviewId as the active commenting context
 // per closeReviewDetail's own comment, then returns to the environment's diff
@@ -117,6 +141,7 @@ async function openActiveReviewContext(
   await app.reviewDetailDialog.locator().getByRole('button', { name: 'Close' }).click();
   await app.reviewDetailDialog.waitForClosed();
   await app.sidebar.openEnvironment(tenant, environment);
+  await dismissAIOccupancyPromptIfShown(app);
 }
 
 test.describe('diff panel — commenting on a line (#1348, #1388)', () => {
@@ -139,6 +164,7 @@ test.describe('diff panel — commenting on a line (#1348, #1388)', () => {
     });
 
     await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    await dismissAIOccupancyPromptIfShown(app);
     await app.titlebar.toggleReviewPanel();
     await expect(app.page.getByText('package main')).toBeVisible();
 

--- a/erun-ui/playwright/tests/review-diff-line-comment.spec.ts
+++ b/erun-ui/playwright/tests/review-diff-line-comment.spec.ts
@@ -71,8 +71,56 @@ function seedDashboardEnvironment(title: string): string {
   return environment;
 }
 
-test.describe('diff panel — commenting on a line (#1348)', () => {
-  test('explains why commenting is blocked when no review is in context', async ({
+// DIFF_NO_COMMIT is DIFF with no commit for a new thread to anchor to, so
+// resolveDiffCommitHash resolves to '' and the "commit this change" blocked
+// reason renders instead of the "no active review" one.
+const DIFF_NO_COMMIT = { ...DIFF, reviewCommits: [] };
+
+function routeLoadTenantDashboard(
+  route: Route,
+  tenant: string,
+  environment: string,
+  reviews: (typeof REVIEW)[],
+): Promise<void> {
+  return fulfillJSON(route, {
+    tenant,
+    environment,
+    apiUrl: 'http://127.0.0.1:1/unreachable',
+    user: { tenantId: 't1', userId: 'u1', username: 'operator' },
+    reviews,
+    panels: [{ tab: 'users' }, { tab: 'reviews' }],
+    canCreateReview: false,
+    canAdvanceMergeQueue: false,
+  });
+}
+
+// openActiveReviewContext opens a review from the tenant dashboard and closes
+// its (modal) dialog, establishing reviewId as the active commenting context
+// per closeReviewDetail's own comment, then returns to the environment's diff
+// panel -- the same round trip the "starts a new top-level thread" test below
+// exercises, factored out so the two blocked-reason tests can set up the same
+// active-review precondition without duplicating it.
+async function openActiveReviewContext(
+  app: import('../pages/index.js').AppShell,
+  tenant: string,
+  environment: string,
+): Promise<void> {
+  await app.reloadEnvironments();
+  await app.sidebar
+    .envRowButton(tenant, environment)
+    .waitFor({ state: 'visible', timeout: 15_000 });
+  await app.sidebar.openTenantDashboard(tenant);
+  await app.tenantDashboard.waitForOpen();
+  await app.tenantDashboard.selectTab('Reviews');
+  await app.tenantDashboard.openReview('Add widget');
+  await app.reviewDetailDialog.waitForOpen();
+  await app.reviewDetailDialog.locator().getByRole('button', { name: 'Close' }).click();
+  await app.reviewDetailDialog.waitForClosed();
+  await app.sidebar.openEnvironment(tenant, environment);
+}
+
+test.describe('diff panel — commenting on a line (#1348, #1388)', () => {
+  test('offers to open the Reviews tab when no review is in context', async ({
     app,
     page,
     seededEnv,
@@ -81,6 +129,10 @@ test.describe('diff panel — commenting on a line (#1348)', () => {
       const body = invokeBody(request);
       if (body.method === 'LoadDiff') {
         await fulfillJSON(route, DIFF);
+        return;
+      }
+      if (body.method === 'LoadTenantDashboard') {
+        await routeLoadTenantDashboard(route, seededEnv.tenant, seededEnv.environment, []);
         return;
       }
       await route.continue();
@@ -102,6 +154,98 @@ test.describe('diff panel — commenting on a line (#1348)', () => {
     await expect(
       app.page.getByText('Open a review from the Reviews tab to comment on this line.'),
     ).toBeVisible();
+
+    // Unlike the other two blocked reasons (checked below), this one names a
+    // destination on a different surface -- so the popover carries a real
+    // action to get there in one click, rather than leaving the reader to
+    // find the tenant dashboard on their own (#1388).
+    const openReviewsTab = app.page.getByRole('button', { name: 'Open Reviews tab' });
+    await expect(openReviewsTab).toBeVisible();
+    await openReviewsTab.click();
+
+    await app.tenantDashboard.waitForOpen();
+    await expect(app.tenantDashboard.tab('Reviews')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('still explains — with no action — that the change needs a commit first', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('diff-comment-no-commit');
+    try {
+      await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+        const body = invokeBody(request);
+        if (body.method === 'LoadDiff') {
+          await fulfillJSON(route, DIFF_NO_COMMIT);
+          return;
+        }
+        if (body.method === 'LoadTenantDashboard') {
+          await routeLoadTenantDashboard(route, SEED_TENANT, environment, [REVIEW]);
+          return;
+        }
+        if (body.method === 'LoadReviewDetail') {
+          await fulfillJSON(route, { reviewId: REVIEW.reviewId, review: REVIEW, canComment: true });
+          return;
+        }
+        await route.continue();
+      });
+
+      // A review is the active commenting context throughout -- this blocked
+      // reason is about the diff's own commit state, not the review.
+      await openActiveReviewContext(app, SEED_TENANT, environment);
+      await app.titlebar.toggleReviewPanel();
+      await expect(page.getByText('package main')).toBeVisible();
+
+      await page.getByRole('button', { name: 'Comment on line 1 of main.go' }).click();
+      await expect(page.getByText('Commit this change before commenting on it.')).toBeVisible();
+      // This blocked reason is actionable exactly where the operator already
+      // stands (commit the change), so it stays message-only (#1388).
+      await expect(page.getByRole('button', { name: 'Open Reviews tab' })).toHaveCount(0);
+      await expect(page.getByLabel('New comment')).toHaveCount(0);
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+
+  test('still explains — with no action — a lack of comment access', async ({ app, page }) => {
+    const environment = seedDashboardEnvironment('diff-comment-no-access');
+    try {
+      await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+        const body = invokeBody(request);
+        if (body.method === 'LoadDiff') {
+          await fulfillJSON(route, DIFF);
+          return;
+        }
+        if (body.method === 'LoadTenantDashboard') {
+          await routeLoadTenantDashboard(route, SEED_TENANT, environment, [REVIEW]);
+          return;
+        }
+        if (body.method === 'LoadReviewDetail') {
+          await fulfillJSON(route, {
+            reviewId: REVIEW.reviewId,
+            review: REVIEW,
+            canComment: false,
+          });
+          return;
+        }
+        await route.continue();
+      });
+
+      await openActiveReviewContext(app, SEED_TENANT, environment);
+      await app.titlebar.toggleReviewPanel();
+      await expect(page.getByText('package main')).toBeVisible();
+
+      await page.getByRole('button', { name: 'Comment on line 1 of main.go' }).click();
+      await expect(
+        page.getByText('You do not have access to comment on this review.'),
+      ).toBeVisible();
+      // Actionable exactly where the operator stands (ask for access), so no
+      // navigation button here either (#1388).
+      await expect(page.getByRole('button', { name: 'Open Reviews tab' })).toHaveCount(0);
+      await expect(page.getByLabel('New comment')).toHaveCount(0);
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
   });
 
   test('starts a new top-level thread anchored to the clicked line', async ({ app, page }) => {
@@ -115,16 +259,7 @@ test.describe('diff panel — commenting on a line (#1348)', () => {
           return;
         }
         if (body.method === 'LoadTenantDashboard') {
-          await fulfillJSON(route, {
-            tenant: SEED_TENANT,
-            environment,
-            apiUrl: 'http://127.0.0.1:1/unreachable',
-            user: { tenantId: 't1', userId: 'u1', username: 'operator' },
-            reviews: [REVIEW],
-            panels: [{ tab: 'users' }, { tab: 'reviews' }],
-            canCreateReview: false,
-            canAdvanceMergeQueue: false,
-          });
+          await routeLoadTenantDashboard(route, SEED_TENANT, environment, [REVIEW]);
           return;
         }
         if (body.method === 'LoadReviewDetail') {
@@ -154,19 +289,7 @@ test.describe('diff panel — commenting on a line (#1348)', () => {
       // then close the (modal) dialog so the diff panel underneath it is
       // reachable — see closeReviewDetail's own comment for why this
       // survives the close.
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
-      await app.sidebar.openTenantDashboard(SEED_TENANT);
-      await app.tenantDashboard.waitForOpen();
-      await app.tenantDashboard.selectTab('Reviews');
-      await app.tenantDashboard.openReview('Add widget');
-      await app.reviewDetailDialog.waitForOpen();
-      await app.reviewDetailDialog.locator().getByRole('button', { name: 'Close' }).click();
-      await app.reviewDetailDialog.waitForClosed();
-
-      await app.sidebar.openEnvironment(SEED_TENANT, environment);
+      await openActiveReviewContext(app, SEED_TENANT, environment);
       await app.titlebar.toggleReviewPanel();
       await expect(page.getByText('package main')).toBeVisible();
 


### PR DESCRIPTION
Makes the diff-line comment affordance navigable instead of a dead end.

## The defect

Clicking the comment icon on a diff line with no review open showed:

> Open a review from the Reviews tab to comment on this line.

The Reviews tab is in the **tenant dashboard** — a different surface from the environment diff panel where that message appears, reached by clicking the *tenant* row in the sidebar. The message named it, didn't say how to reach it, and offered no way to get there.

Found the most direct way possible: an operator reading a diff in the desktop saw the tooltip and asked, unprompted, *"what is reviews tab?"*

The component's own doc comment says *"Clicking it when a precondition is unmet explains which one rather than doing nothing"* — the right instinct, and better than a silent no-op. But explaining a precondition the reader cannot act on from where they stand is still a dead end.

## The fix

The navigation already existed — `openTenantDashboard` in `tenantDialogThunks.ts` — so this wires up a destination the app could already reach. The blocked popover now renders the explanatory sentence *plus* a primary **Open Reviews tab** button that dispatches `openTenantDashboard(tenant)` then `setTenantDashboardTab('reviews')`, landing on the Reviews tab in one click.

`openTenantDashboard` alone sets `tab: 'users'` when the tenant differs from the currently-loaded one, so both dispatches are needed; one would land on the wrong tab.

`tenant` is threaded from `DiffEnvSection`'s already-resolved `target.tenant` through `DiffFileView` → `DiffHunkView` → `DiffLineCommentAction` — three one-line prop additions, no new state or context, because the value was already one level up in the render tree.

On the button label: it names a UI element, which copy guidance normally discourages. It is deliberate here. The reference "the Reviews tab" was precisely what the operator could not resolve, so making that exact phrase the thing you click resolves the ambiguity rather than restating it.

## Deliberately unchanged

The other two blocked reasons are correct as they are, because both are actionable exactly where the operator is standing:

```
if (!commitHash) return 'Commit this change before commenting on it.';
if (!canComment) return 'You do not have access to comment on this review.';
```

Only the no-active-review case pointed somewhere else. `diffLineCommentBlockedReason` remains the single source of all three strings, unchanged.

## Why the round trip actually works

Once a review is opened it stays the active commenting context even after its dialog closes — `closeReviewDetail` preserves `reviewId` deliberately, and the file's own comment explains why. So navigate → open a review → return to the diff, and the affordance is live. That is the point of the trip, so the spec asserts it rather than just asserting the button exists.

## Verification

- `erun-ui` `go test -race -count=1 ./...` — ok
- `yarn typecheck` / `format:check` / `build` — clean; `yarn lint` **0 errors** (3 pre-existing `approaching-max-lines` warnings in unrelated files); frontend unit tests **160/160**
- `./playwright/run.sh --build -- tests/review-diff-line-comment.spec.ts` — **4/4**, extending the spec that already asserted the blocked string: the button exists, clicking it lands on the Reviews tab, and the other two blocked reasons still render with no action

Complexity was kept under the lint cap by moving only the new conditional into a small `DiffLineCommentBlocked` subcomponent, rather than restructuring the existing control flow.

## One workaround, flagged rather than buried

`be6986a8` adds `dismissAIOccupancyPromptIfShown` to the spec. It is a **mitigation, not a fix**: the first `--build` run failed 3/4 because opening a fresh environment auto-spawns its AI tab, and the occupancy check found *the running agent session's own activity lease* in the same pod, popping "Another agent is already working here" and blocking a later click.

That is the harness reading real host activity rather than seeded state — **#1375** — hit independently here on a different spec than the one that issue was filed against. The helper races the AI-tab-vs-dialog outcome and cancels the dialog if it appears, so the spec is deterministic on a busy host. The underlying isolation leak stays open in #1375; this does not pretend to close it.

## Not verified

The rendered landing state beyond `aria-selected="true"` on the Reviews tab — the spec assertion covers the navigation, and the screenshot judged was the blocked-popover state, which is what this issue is about.

Closes #1388
