### PR TITLE
Give four action-less error messages the control that resolves them

### DIFF
--- a/erun-ui/activity_queue_app.go
+++ b/erun-ui/activity_queue_app.go
@@ -507,7 +507,7 @@ func (a *App) surfaceDeployFailure(tenant, environment, reason string) {
 	if reason != "" {
 		message = fmt.Sprintf("Deploy of %s/%s failed: %s", tenant, environment, reason)
 	}
-	a.emitEnvNotification("error", tenant, environment, notificationSourceDeployFailed, message)
+	a.emitEnvNotification("error", tenant, environment, notificationSourceDeployFailed, message, "")
 }
 
 // handleDoctorTraceLine dispatches the `erun doctor` lifecycle trace lines,

--- a/erun-ui/config_handlers.go
+++ b/erun-ui/config_handlers.go
@@ -402,11 +402,24 @@ const notificationSourceForwardOutage = "port-forward-outage"
 // runtime becomes reachable.
 const notificationSourceDeployFailed = "deploy-failed"
 
+// notificationSourceOrchestratorEdgeUnreachable tags the "wired tools for …,
+// but its edge is not answering" warning an orchestrator launch posts when
+// exactly one linked environment's edge failed its reachability probe — the
+// only case with an unambiguous env to attach the deploy action to (#1390).
+const notificationSourceOrchestratorEdgeUnreachable = "orchestrator-edge-unreachable"
+
+// notificationActionDeploy tags a notification whose remedy the frontend can
+// perform directly — opening the tagged env's deploy dialog. Passed as the
+// action to emitEnvNotification; "" means the notification carries no action.
+const notificationActionDeploy = "deploy"
+
 // emitEnvNotification posts a notification tagged with the env it describes and
 // a stable source, so a later emitClearEnvNotification for the same
 // (source, tenant, environment) can dismiss it. Use it for env-scoped, state-
-// backed notifications (not one-shot toasts).
-func (a *App) emitEnvNotification(kind, tenant, environment, source, message string) {
+// backed notifications (not one-shot toasts). action names a control the
+// frontend can render to perform the message's own remedy directly ("" for
+// none — see notificationActionDeploy).
+func (a *App) emitEnvNotification(kind, tenant, environment, source, message, action string) {
 	if strings.TrimSpace(message) == "" {
 		return
 	}
@@ -416,6 +429,7 @@ func (a *App) emitEnvNotification(kind, tenant, environment, source, message str
 		Tenant:      tenant,
 		Environment: environment,
 		Source:      source,
+		Action:      action,
 	})
 }
 

--- a/erun-ui/env_ensure.go
+++ b/erun-ui/env_ensure.go
@@ -156,7 +156,7 @@ func (a *App) surfaceEnvRuntimeEnsureFailure(selection uiSelection, err error) {
 	a.emitEnvNotification("warning", selection.Tenant, selection.Environment, notificationSourceRuntimeUnreachable, fmt.Sprintf(
 		"Could not reach the runtime for %s/%s: %s. Deploy the environment to bring it up.",
 		selection.Tenant, selection.Environment, strings.TrimSpace(err.Error()),
-	))
+	), notificationActionDeploy)
 }
 
 // surfaceEnvRuntimeStopped renders a stopped environment as stopped and names
@@ -170,7 +170,7 @@ func (a *App) surfaceEnvRuntimeStopped(selection uiSelection) {
 	a.emitEnvNotification("info", selection.Tenant, selection.Environment, notificationSourceRuntimeUnreachable, fmt.Sprintf(
 		"%s/%s is stopped, so its sessions did not reconnect. Open it to start it again.",
 		selection.Tenant, selection.Environment,
-	))
+	), "")
 }
 
 // ensureFailureAlreadyNotified latches one notification per failure episode and

--- a/erun-ui/env_ensure_test.go
+++ b/erun-ui/env_ensure_test.go
@@ -275,6 +275,12 @@ func TestSurfaceEnsureFailureSuppressedWhileDeployInFlight(t *testing.T) {
 	if note.Kind != "warning" || note.Source != notificationSourceRuntimeUnreachable {
 		t.Fatalf("notification = %+v, want kind=warning source=%q", note, notificationSourceRuntimeUnreachable)
 	}
+	// The message names "Deploy the environment ..." as the fix, and the app
+	// can perform it, so the notification must carry the action the frontend
+	// renders a button for (#1390) rather than leaving the remedy unreachable.
+	if note.Action != notificationActionDeploy {
+		t.Fatalf("notification action = %q, want %q", note.Action, notificationActionDeploy)
+	}
 }
 
 // TestSurfaceEnsureFailureRendersAStoppedRuntimeAsStopped locks the outcome an
@@ -307,6 +313,12 @@ func TestSurfaceEnsureFailureRendersAStoppedRuntimeAsStopped(t *testing.T) {
 	}
 	if !strings.Contains(note.Message, "Open it to start it again") {
 		t.Fatalf("notification must name the way back, got %q", note.Message)
+	}
+	// The remedy here is opening the env, which the row itself already offers
+	// on click — not a deploy — so this notification must carry no action
+	// (#1390: an action-less remedy must not get a manufactured button).
+	if note.Action != "" {
+		t.Fatalf("notification action = %q, want none", note.Action)
 	}
 }
 

--- a/erun-ui/environment_forward_repair.go
+++ b/erun-ui/environment_forward_repair.go
@@ -115,7 +115,8 @@ func (a *App) repairInterruptedPortForward(selection uiSelection, port int, heal
 		a.recordForwardRepairReported(selection)
 		a.emitEnvNotification("warning", selection.Tenant, selection.Environment,
 			notificationSourceForwardOutage,
-			eruncommon.DescribeUnrepairedPortForward(selection.Tenant, selection.Environment, port, episode.attempts, health))
+			eruncommon.DescribeUnrepairedPortForward(selection.Tenant, selection.Environment, port, episode.attempts, health),
+			"")
 	}
 	return true
 }

--- a/erun-ui/frontend/src/app/model/appNotificationPayload.ts
+++ b/erun-ui/frontend/src/app/model/appNotificationPayload.ts
@@ -10,6 +10,10 @@ export interface AppNotificationPayload {
   tenant?: string;
   environment?: string;
   source?: string;
+  // Action names a control the titlebar can render that performs the
+  // message's own remedy directly, e.g. "deploy" opens the tagged env's
+  // deploy dialog. Undefined means the message carries no action (#1390).
+  action?: AppNotification['action'];
 }
 
 // AppNotificationClearPayload dismisses an env-tagged notification only when all

--- a/erun-ui/frontend/src/app/notificationThunks.ts
+++ b/erun-ui/frontend/src/app/notificationThunks.ts
@@ -122,7 +122,12 @@ export const showNotification =
   (
     kind: AppNotification['kind'],
     message: string,
-    meta?: { tenant?: string; environment?: string; source?: string },
+    meta?: {
+      tenant?: string;
+      environment?: string;
+      source?: string;
+      action?: AppNotification['action'];
+    },
   ): AppThunk =>
   (dispatch) => {
     const trimmed = message.trim();
@@ -138,6 +143,7 @@ export const showNotification =
         tenant: meta?.tenant,
         environment: meta?.environment,
         source: meta?.source,
+        action: meta?.action,
       }),
     );
     if (kind === 'success' || kind === 'info') {

--- a/erun-ui/frontend/src/app/platformSignIn.test.ts
+++ b/erun-ui/frontend/src/app/platformSignIn.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { UITenant } from '@/types';
+
+import {
+  resolveTenantCloudAlias,
+  TENANT_IDENTITY_SIGN_IN_MESSAGE,
+  TENANT_SIGN_IN_AGAIN_MESSAGE,
+  tenantNeedsSignIn,
+} from './platformSignIn';
+
+// These pin the exact two sentences the four dead-end error messages in
+// #1390 resolve to a sign-in action, and that every other message — the
+// "ask an administrator" permission notices included — stays action-less.
+
+test('the two known stale-identity sentences need a sign-in action', () => {
+  assert.equal(tenantNeedsSignIn(TENANT_IDENTITY_SIGN_IN_MESSAGE), true);
+  assert.equal(tenantNeedsSignIn(TENANT_SIGN_IN_AGAIN_MESSAGE), true);
+});
+
+test('an unrelated message, including a permission refusal, needs no action', () => {
+  assert.equal(
+    tenantNeedsSignIn(
+      'You do not have access to this tenant’s dashboard. Ask an administrator for access.',
+    ),
+    false,
+  );
+  assert.equal(tenantNeedsSignIn('load tenant dashboard GET /v1/reviews: network error'), false);
+  assert.equal(tenantNeedsSignIn(''), false);
+});
+
+const tenants: UITenant[] = [
+  {
+    name: 'frs',
+    environments: [],
+    defaultEnvironment: '',
+    primaryCloudProviderAlias: 'frs-aws',
+  },
+];
+
+test('resolveTenantCloudAlias finds the named tenant’s primary alias', () => {
+  assert.equal(resolveTenantCloudAlias(tenants, 'frs'), 'frs-aws');
+});
+
+test('resolveTenantCloudAlias returns empty for an unknown tenant', () => {
+  assert.equal(resolveTenantCloudAlias(tenants, 'unknown'), '');
+});

--- a/erun-ui/frontend/src/app/platformSignIn.ts
+++ b/erun-ui/frontend/src/app/platformSignIn.ts
@@ -1,0 +1,26 @@
+import type { UITenant } from '@/types';
+
+// The exact operator-facing sentences erun-ui's Go side returns for an
+// identity the platform no longer accepts — tenant_dashboard.go's
+// tenantDashboardIdentityError (whole-dashboard/whole-detail load) and
+// tenant_platform_error.go's operatorPlatformError (a write that discovers
+// the same thing). Kept as an explicit contract here, rather than inferred
+// from error shape, because a failed Wails call surfaces as a bare string
+// with no room for a machine-readable reason to ride along (#1390).
+export const TENANT_IDENTITY_SIGN_IN_MESSAGE =
+  "This tenant's platform did not accept the signed-in identity. Sign in to the tenant's cloud provider again.";
+export const TENANT_SIGN_IN_AGAIN_MESSAGE =
+  'Your sign-in is no longer valid for this tenant. Sign in again and retry.';
+
+export function tenantNeedsSignIn(message: string): boolean {
+  return message === TENANT_IDENTITY_SIGN_IN_MESSAGE || message === TENANT_SIGN_IN_AGAIN_MESSAGE;
+}
+
+// resolveTenantCloudAlias finds the cloud alias loginPrimaryCloudProvider
+// needs to actually perform the sign-in a message like the ones above names.
+export function resolveTenantCloudAlias(tenants: UITenant[], tenantName: string): string {
+  return (
+    tenants.find((candidate) => candidate.name === tenantName)?.primaryCloudProviderAlias?.trim() ??
+    ''
+  );
+}

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -177,6 +177,10 @@ export interface AppNotification {
   tenant?: string;
   environment?: string;
   source?: string;
+  // Action names a control TitlebarStatus can render beside the message that
+  // performs the message's own remedy directly — currently only 'deploy'
+  // (open the tagged env's deploy dialog). Undefined means no action (#1390).
+  action?: 'deploy';
 }
 
 export type TerminalStatusKind = 'info' | 'warning' | 'error';

--- a/erun-ui/frontend/src/app/wailsEventThunks.ts
+++ b/erun-ui/frontend/src/app/wailsEventThunks.ts
@@ -168,6 +168,7 @@ export const handleAppNotification =
         tenant: payload.tenant,
         environment: payload.environment,
         source: payload.source,
+        action: payload.action,
       }),
     );
   };

--- a/erun-ui/frontend/src/components/app/CreateReviewDialog.tsx
+++ b/erun-ui/frontend/src/components/app/CreateReviewDialog.tsx
@@ -22,10 +22,12 @@ import {
   updateCreateReviewDialog,
 } from '@/app/createReviewDialogThunks';
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
+import { resolveTenantCloudAlias } from '@/app/platformSignIn';
 import type { CreateReviewDialogState } from '@/app/reviewWriteState';
 import { selectReviewTargetBranches } from '@/app/selectors';
 
 import { InlineAlert } from './InlineAlert';
+import { PlatformErrorAlert } from './PlatformSignInAlert';
 
 // CreateReviewDialog opens a review from the desktop. Push is the precondition
 // of create — the platform can only reference a sourceBranch that already
@@ -205,6 +207,9 @@ function PushBranchActions({ dialog }: { dialog: CreateReviewDialogState }): Rea
 function ReviewDetailsStep({ dialog }: { dialog: CreateReviewDialogState }): React.ReactElement {
   const dispatch = useAppDispatch();
   const targetBranches = useAppSelector(selectReviewTargetBranches);
+  const cloudProviderAlias = useAppSelector((state) =>
+    resolveTenantCloudAlias(state.tenants.tenants, dialog.tenant),
+  );
   return (
     <StepShell label="Review details">
       <div className="grid gap-2">
@@ -232,7 +237,9 @@ function ReviewDetailsStep({ dialog }: { dialog: CreateReviewDialogState }): Rea
           dispatch(updateCreateReviewDialog({ targetBranch: next }));
         }}
       />
-      {dialog.createError && <InlineAlert>{dialog.createError}</InlineAlert>}
+      {dialog.createError && (
+        <PlatformErrorAlert message={dialog.createError} alias={cloudProviderAlias} />
+      )}
     </StepShell>
   );
 }

--- a/erun-ui/frontend/src/components/app/DiffList.CommentAction.tsx
+++ b/erun-ui/frontend/src/components/app/DiffList.CommentAction.tsx
@@ -12,7 +12,7 @@ import {
 import { openTenantDashboard, setTenantDashboardTab } from '@/app/tenantDialogThunks';
 import type { DiffLine } from '@/types';
 
-import { InlineAlert } from './InlineAlert';
+import { PlatformErrorAlert } from './PlatformSignInAlert';
 
 // DiffLineCommentAction starts a new top-level review thread anchored to this
 // diff line — the gap ReviewDetailDialog.Comments.tsx used to call out as
@@ -143,6 +143,7 @@ function DiffLineCommentComposer(): React.ReactElement {
   const draft = useAppSelector((state) => state.reviewDetail.newCommentDraft);
   const submitting = useAppSelector((state) => state.reviewDetail.newCommentSubmitting);
   const submitError = useAppSelector((state) => state.reviewDetail.newCommentSubmitError);
+  const cloudProviderAlias = useAppSelector((state) => state.reviewDetail.callerCloudProviderAlias);
   return (
     <div className="grid gap-2">
       <Textarea
@@ -154,7 +155,7 @@ function DiffLineCommentComposer(): React.ReactElement {
           dispatch(setReviewCommentDraft(event.target.value));
         }}
       />
-      {submitError && <InlineAlert>{submitError}</InlineAlert>}
+      {submitError && <PlatformErrorAlert message={submitError} alias={cloudProviderAlias} />}
       <div className="flex justify-end gap-2">
         <Button
           type="button"

--- a/erun-ui/frontend/src/components/app/PlatformSignInAlert.tsx
+++ b/erun-ui/frontend/src/components/app/PlatformSignInAlert.tsx
@@ -1,0 +1,59 @@
+import { Button } from 'erun-kit';
+import { LoaderCircle, LogIn } from 'lucide-react';
+import * as React from 'react';
+
+import { loginPrimaryCloudProvider } from '@/app/cloudProviderThunks';
+import { useAppDispatch, useAppSelector } from '@/app/hooks';
+import { tenantNeedsSignIn } from '@/app/platformSignIn';
+
+import { InlineAlert } from './InlineAlert';
+
+// PlatformErrorAlert is InlineAlert plus the one thing #1390 found four
+// separate dead ends missing: when the platform reports the signed-in
+// identity is no longer good, the fix is a "Log in" click away — the same
+// control the sidebar's cloud alias row already offers (#1390) — so it
+// renders right beside the message instead of leaving the operator to find
+// that control on their own. Every other message stays exactly what it was:
+// InlineAlert with no action, which is correct for a remedy only a person can
+// carry out (e.g. "ask an administrator").
+export function PlatformErrorAlert({
+  message,
+  alias,
+}: {
+  message: string;
+  alias: string;
+}): React.ReactElement {
+  return (
+    <div className="grid gap-2">
+      <InlineAlert>{message}</InlineAlert>
+      {tenantNeedsSignIn(message) && alias !== '' && <SignInAction alias={alias} />}
+    </div>
+  );
+}
+
+// SignInAction dispatches the exact same thunk the sidebar's cloud alias
+// login button uses, so a re-authenticated alias updates every surface
+// reading it — sidebar included — not just the one that prompted the login.
+function SignInAction({ alias }: { alias: string }): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const busy = useAppSelector(
+    (state) => (state.sidebar.sidebarCloudAliasBusyByAlias[alias] ?? '') !== '',
+  );
+  return (
+    <Button
+      type="button"
+      size="sm"
+      disabled={busy}
+      onClick={() => {
+        void dispatch(loginPrimaryCloudProvider(alias));
+      }}
+    >
+      {busy ? (
+        <LoaderCircle className="animate-spin" aria-hidden="true" />
+      ) : (
+        <LogIn aria-hidden="true" />
+      )}
+      {busy ? 'Logging in...' : 'Log in'}
+    </Button>
+  );
+}

--- a/erun-ui/frontend/src/components/app/ReviewDetailDialog.Comments.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewDetailDialog.Comments.tsx
@@ -15,6 +15,7 @@ import type { ReviewDetailState } from '@/app/state';
 import type { UIReviewComment } from '@/types';
 
 import { InlineAlert } from './InlineAlert';
+import { PlatformErrorAlert } from './PlatformSignInAlert';
 import { RelativeTime } from './TenantDashboardMessage';
 
 // commentAuthorDisplay prefers the resolved tenant-user-directory username
@@ -207,7 +208,7 @@ function ThreadResolveError({
   }
   return (
     <div className="mt-2">
-      <InlineAlert>{detail.resolveError}</InlineAlert>
+      <PlatformErrorAlert message={detail.resolveError} alias={detail.callerCloudProviderAlias} />
     </div>
   );
 }
@@ -287,7 +288,9 @@ function ReplyComposer({ detail }: { detail: ReviewDetailState }): React.ReactEl
           }
         }}
       />
-      {detail.submitError && <InlineAlert>{detail.submitError}</InlineAlert>}
+      {detail.submitError && (
+        <PlatformErrorAlert message={detail.submitError} alias={detail.callerCloudProviderAlias} />
+      )}
       <div className="flex justify-end gap-2">
         <Button
           type="button"

--- a/erun-ui/frontend/src/components/app/ReviewDetailDialog.tsx
+++ b/erun-ui/frontend/src/components/app/ReviewDetailDialog.tsx
@@ -27,6 +27,7 @@ import {
 import type { UITenantDashboardBuild, UITenantDashboardReview } from '@/types';
 
 import { InlineAlert, PermissionNotice } from './InlineAlert';
+import { PlatformErrorAlert } from './PlatformSignInAlert';
 import { ReviewDetailComments } from './ReviewDetailDialog.Comments';
 import { BranchArrow, RelativeTime } from './TenantDashboardMessage';
 
@@ -76,7 +77,7 @@ function ReviewDetailBody({ detail }: { detail: ReviewDetailState }): React.Reac
   if (data.apiError) {
     return (
       <div className="py-4">
-        <InlineAlert>{data.apiError}</InlineAlert>
+        <PlatformErrorAlert message={data.apiError} alias={detail.callerCloudProviderAlias} />
       </div>
     );
   }
@@ -208,7 +209,9 @@ function CloseReviewAction({
             Confirm close
           </Button>
         </div>
-        {detail.closeError && <InlineAlert>{detail.closeError}</InlineAlert>}
+        {detail.closeError && (
+          <PlatformErrorAlert message={detail.closeError} alias={detail.callerCloudProviderAlias} />
+        )}
       </div>
     );
   }

--- a/erun-ui/frontend/src/components/app/TenantDashboardPanels.Reviews.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardPanels.Reviews.tsx
@@ -12,6 +12,7 @@ import {
   confirmAdvanceMergeQueue,
   submitAdvanceMergeQueue,
 } from '@/app/mergeQueueThunks';
+import { resolveTenantCloudAlias } from '@/app/platformSignIn';
 import { openReviewDetail } from '@/app/reviewDetailThunks';
 import {
   reviewAuthorInitials,
@@ -22,7 +23,8 @@ import {
 import { setReviewFilter } from '@/app/tenantDialogThunks';
 import type { UITenantDashboardReview } from '@/types';
 
-import { InlineAlert, PermissionNotice } from './InlineAlert';
+import { PermissionNotice } from './InlineAlert';
+import { PlatformErrorAlert } from './PlatformSignInAlert';
 import {
   BranchArrow,
   DataCell,
@@ -265,6 +267,9 @@ function AdvanceMergeQueueAction({
 }): React.ReactElement | null {
   const dispatch = useAppDispatch();
   const action = useAppSelector((state) => state.mergeQueueAction);
+  const cloudProviderAlias = useAppSelector((state) =>
+    resolveTenantCloudAlias(state.tenants.tenants, data?.tenant ?? ''),
+  );
   if (!data) {
     return null;
   }
@@ -304,7 +309,7 @@ function AdvanceMergeQueueAction({
       )}
       {action.error && (
         <div className="max-w-sm">
-          <InlineAlert>{action.error}</InlineAlert>
+          <PlatformErrorAlert message={action.error} alias={cloudProviderAlias} />
         </div>
       )}
     </div>

--- a/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
@@ -12,6 +12,7 @@ import {
 import { refreshTenantDashboard, setTenantDashboardTab } from '@/app/tenantDialogThunks';
 import type { UITenant } from '@/types';
 
+import { PlatformErrorAlert } from './PlatformSignInAlert';
 import { DashboardMessage } from './TenantDashboardMessage';
 import { TenantDashboardPanels } from './TenantDashboardPanels';
 export function TenantDashboardView(): React.ReactElement | null {
@@ -22,6 +23,7 @@ export function TenantDashboardView(): React.ReactElement | null {
     return null;
   }
   const tenant = tenants.find((candidate) => candidate.name === dashboard.tenant);
+  const cloudProviderAlias = tenant?.primaryCloudProviderAlias?.trim() ?? '';
   const environmentName = tenantDashboardEnvironmentName(tenant, dashboard.data?.environment);
   const visibleTabs = visibleTenantDashboardTabs(dashboard.data);
   return (
@@ -70,7 +72,7 @@ export function TenantDashboardView(): React.ReactElement | null {
             </TabsList>
             <RestrictedAccessNote missing={restrictedTenantDashboardReads(dashboard.data)} />
           </div>
-          <TenantDashboardBody dashboard={dashboard} />
+          <TenantDashboardBody dashboard={dashboard} cloudProviderAlias={cloudProviderAlias} />
         </Tabs>
       </div>
     </section>
@@ -79,8 +81,10 @@ export function TenantDashboardView(): React.ReactElement | null {
 
 function TenantDashboardBody({
   dashboard,
+  cloudProviderAlias,
 }: {
   dashboard: AppState['tenantDashboard'];
+  cloudProviderAlias: string;
 }): React.ReactElement {
   if (dashboard.loading) {
     return (
@@ -95,9 +99,29 @@ function TenantDashboardBody({
   }
   const apiError = dashboard.data?.apiError ?? '';
   if (apiError) {
-    return <DashboardMessage message={apiError} destructive />;
+    return <TenantDashboardFailure message={apiError} alias={cloudProviderAlias} />;
   }
   return <TenantDashboardPanels data={dashboard.data} />;
+}
+
+// TenantDashboardFailure is the whole-dashboard failure's own layout: centered
+// in the panel's full height instead of DashboardMessage's small top-anchored
+// row, which used to leave the message adrift over a large empty area beneath
+// it (#1390). Carries the sign-in action when the failure is a stale identity.
+function TenantDashboardFailure({
+  message,
+  alias,
+}: {
+  message: string;
+  alias: string;
+}): React.ReactElement {
+  return (
+    <div className="flex h-full min-h-0 items-center justify-center">
+      <div className="w-full max-w-sm">
+        <PlatformErrorAlert message={message} alias={alias} />
+      </div>
+    </div>
+  );
 }
 
 // RestrictedAccessNote is why a short tab strip is not an empty tenant. Hiding

--- a/erun-ui/frontend/src/components/app/Titlebar.Status.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.Status.tsx
@@ -13,6 +13,7 @@ import { AlertCircle, CheckCircle2, Copy, Info, LoaderCircle, X } from 'lucide-r
 import * as React from 'react';
 
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
+import { openManageDialog, setManageTab } from '@/app/manageDialogThunks';
 import {
   copyTerminalOutput,
   dismissNotification,
@@ -46,6 +47,13 @@ interface TitlebarStatusValue {
   // is, so dismissing it removes exactly this one even if another has been
   // queued behind it since render.
   notificationId?: string;
+  // envAction/envTenant/envEnvironment carry a notification's own remedy
+  // action (currently only 'deploy'), set only when the notification named
+  // one and an unambiguous env to target — see AppNotification['action']
+  // (#1390).
+  envAction?: AppNotification['action'];
+  envTenant?: string;
+  envEnvironment?: string;
 }
 
 const statusBorderClassNames: Record<TitlebarStatusKind, string> = {
@@ -90,6 +98,13 @@ export function TitlebarStatus(): React.ReactElement | null {
         <StatusIcon status={status} />
         <StatusMessage status={status} />
         {status.action === 'wait-longer' && <StatusWaitAction />}
+        {status.envAction === 'deploy' && status.envTenant && status.envEnvironment && (
+          <StatusDeployAction
+            status={status}
+            tenant={status.envTenant}
+            environment={status.envEnvironment}
+          />
+        )}
         {status.copyOutput &&
           (status.source === 'notification' ? (
             <NotificationCopyAction text={status.copyOutput} />
@@ -130,6 +145,9 @@ function computeTitlebarStatus(
           : '',
       copyStatus: '',
       action: '',
+      envAction: notification.action,
+      envTenant: notification.tenant,
+      envEnvironment: notification.environment,
     };
   }
   if (terminal.terminalBusy && terminal.terminalMessage) {
@@ -250,6 +268,42 @@ function StatusWaitAction(): React.ReactElement {
       }}
     >
       Wait longer
+    </Button>
+  );
+}
+
+// StatusDeployAction is the toast's own version of #1390's rule: a runtime-
+// unreachable notification names "deploy" as its remedy, and the app already
+// has a control for that — the Manage dialog's Runtime tab, where the
+// operator picks a version and clicks Deploy. Opening straight to that tab
+// (rather than guessing a version and deploying blind) mirrors #1389's
+// navigate-to-the-control pattern. Dismisses the notification on click since
+// the operator is now looking at its actual recovery surface.
+function StatusDeployAction({
+  status,
+  tenant,
+  environment,
+}: {
+  status: TitlebarStatusValue;
+  tenant: string;
+  environment: string;
+}): React.ReactElement {
+  const dispatch = useAppDispatch();
+  return (
+    <Button
+      className="h-6 flex-none rounded-md px-2 text-[12px] text-foreground hover:bg-accent hover:text-accent-foreground"
+      type="button"
+      variant="ghost"
+      size="xs"
+      onClick={() => {
+        dispatch(openManageDialog({ tenant, environment }));
+        dispatch(setManageTab('runtime'));
+        if (status.notificationId) {
+          dispatch(dismissNotification(status.notificationId));
+        }
+      }}
+    >
+      Deploy
     </Button>
   );
 }

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -1512,7 +1512,15 @@ func (a *App) wireOrchestratorMCP(id, name string, envs []eruncommon.Orchestrato
 		log.Printf("erun-app: orchestrator %s: wired %s but its edge is not answering", id, env.Label)
 	}
 	if len(unreachable) > 0 {
-		a.emitAppNotification("warning", orchestratorMCPUnreachableNotice(name, unreachable))
+		notice := orchestratorMCPUnreachableNotice(name, unreachable)
+		// A combined notice naming several environments has no single env to
+		// attach a deploy action to; only the common single-env case gets one.
+		if tenant, environment, ok := singleOrchestratorMCPUnreachableEnv(unreachable); ok {
+			a.emitEnvNotification("warning", tenant, environment,
+				notificationSourceOrchestratorEdgeUnreachable, notice, notificationActionDeploy)
+		} else {
+			a.emitAppNotification("warning", notice)
+		}
 	}
 	return path
 }

--- a/erun-ui/orchestrator_mcp.go
+++ b/erun-ui/orchestrator_mcp.go
@@ -229,6 +229,22 @@ func orchestratorMCPUnreachableNotice(name string, unreachable []orchestratorMCP
 		label, strings.Join(names, ", "))
 }
 
+// singleOrchestratorMCPUnreachableEnv reports the one environment a deploy
+// action can unambiguously target: exactly one unreachable env, whose Label
+// is guaranteed "<tenant>/<environment>" (orchestratorEnvLabel's well-formed
+// case — the only shape probeOrchestratorMCPEdges ever wires). More than one
+// unreachable env has no single env to attach the action to.
+func singleOrchestratorMCPUnreachableEnv(unreachable []orchestratorMCPUnreachable) (tenant, environment string, ok bool) {
+	if len(unreachable) != 1 {
+		return "", "", false
+	}
+	tenant, environment, found := strings.Cut(unreachable[0].Label, "/")
+	if !found || tenant == "" || environment == "" {
+		return "", "", false
+	}
+	return tenant, environment, true
+}
+
 // writeOrchestratorMCPConfig writes a per-orchestrator Claude Code --mcp-config
 // file wiring each linked env's erun MCP into the orchestrator session, so it
 // drives its envs through the MCP rather than raw kubectl. Returns "" with an

--- a/erun-ui/orchestrator_mcp_test.go
+++ b/erun-ui/orchestrator_mcp_test.go
@@ -457,14 +457,10 @@ func TestWireOrchestratorMCPWiresAnUnreachableEnvAndSaysSo(t *testing.T) {
 	// Exactly one unreachable env is the unambiguous case: the notice can only
 	// mean this env, so it carries the deploy action and is tagged with it
 	// (#1390) rather than leaving the "deploy or reopen" remedy unreachable.
-	if payload.Tenant != "frs" || payload.Environment != "dev" {
-		t.Fatalf("notice tenant/environment = %q/%q, want frs/dev", payload.Tenant, payload.Environment)
-	}
-	if payload.Source != notificationSourceOrchestratorEdgeUnreachable {
-		t.Fatalf("notice source = %q, want %q", payload.Source, notificationSourceOrchestratorEdgeUnreachable)
-	}
-	if payload.Action != notificationActionDeploy {
-		t.Fatalf("notice action = %q, want %q", payload.Action, notificationActionDeploy)
+	wantTag := [4]string{"frs", "dev", notificationSourceOrchestratorEdgeUnreachable, notificationActionDeploy}
+	gotTag := [4]string{payload.Tenant, payload.Environment, payload.Source, payload.Action}
+	if gotTag != wantTag {
+		t.Fatalf("notice tenant/environment/source/action = %+v, want %+v", gotTag, wantTag)
 	}
 }
 

--- a/erun-ui/orchestrator_mcp_test.go
+++ b/erun-ui/orchestrator_mcp_test.go
@@ -394,6 +394,21 @@ func TestBuildOrchestratorMCPConfigReportsNoUnreachableEdgeWhenAllAnswer(t *test
 	}
 }
 
+func TestSingleOrchestratorMCPUnreachableEnv(t *testing.T) {
+	if _, _, ok := singleOrchestratorMCPUnreachableEnv(nil); ok {
+		t.Fatal("expected no match for zero unreachable envs")
+	}
+	if _, _, ok := singleOrchestratorMCPUnreachableEnv([]orchestratorMCPUnreachable{
+		{Label: "frs/dev"}, {Label: "frs/staging"},
+	}); ok {
+		t.Fatal("expected no match for more than one unreachable env")
+	}
+	tenant, environment, ok := singleOrchestratorMCPUnreachableEnv([]orchestratorMCPUnreachable{{Label: "frs/dev"}})
+	if !ok || tenant != "frs" || environment != "dev" {
+		t.Fatalf("got tenant=%q environment=%q ok=%v, want frs/dev/true", tenant, environment, ok)
+	}
+}
+
 func TestOrchestratorMCPUnreachableNoticeNamesTheEnvironments(t *testing.T) {
 	if got := orchestratorMCPUnreachableNotice("Petios", nil); got != "" {
 		t.Fatalf("expected no notice when nothing is unreachable, got %q", got)
@@ -438,6 +453,47 @@ func TestWireOrchestratorMCPWiresAnUnreachableEnvAndSaysSo(t *testing.T) {
 	}
 	if !strings.Contains(payload.Message, "frs/dev") || !strings.Contains(payload.Message, "not answering") {
 		t.Fatalf("notice does not name the environment and the reason: %q", payload.Message)
+	}
+	// Exactly one unreachable env is the unambiguous case: the notice can only
+	// mean this env, so it carries the deploy action and is tagged with it
+	// (#1390) rather than leaving the "deploy or reopen" remedy unreachable.
+	if payload.Tenant != "frs" || payload.Environment != "dev" {
+		t.Fatalf("notice tenant/environment = %q/%q, want frs/dev", payload.Tenant, payload.Environment)
+	}
+	if payload.Source != notificationSourceOrchestratorEdgeUnreachable {
+		t.Fatalf("notice source = %q, want %q", payload.Source, notificationSourceOrchestratorEdgeUnreachable)
+	}
+	if payload.Action != notificationActionDeploy {
+		t.Fatalf("notice action = %q, want %q", payload.Action, notificationActionDeploy)
+	}
+}
+
+// TestWireOrchestratorMCPMultipleUnreachableEnvsCarryNoAction locks the
+// ambiguous case: when more than one linked env's edge is unreachable, no
+// single env can own the notice's action, so it falls back to the plain
+// app-level notice with no action rather than guessing which env to deploy.
+func TestWireOrchestratorMCPMultipleUnreachableEnvsCarryNoAction(t *testing.T) {
+	t.Setenv("ERUN_ERUN_BIN", filepath.Join(t.TempDir(), "erun"))
+	app, _ := orchestratorTestAppWithReachability(t, func(int) bool { return false })
+	defer app.shutdown(context.Background())
+	emits := newCapturedEmits()
+	app.emitFn = emits.fn()
+
+	app.wireOrchestratorMCP("petios", "Petios", []eruncommon.OrchestratorEnvConfig{
+		{Tenant: "frs", Environment: "dev"},
+		{Tenant: "frs", Environment: "laptop"},
+	})
+
+	events := emits.events(appNotificationEvent)
+	if len(events) != 1 {
+		t.Fatalf("expected exactly one notice about the unreachable edges, got %+v", events)
+	}
+	payload, ok := events[0].(appNotificationPayload)
+	if !ok {
+		t.Fatalf("unexpected payload type: %T", events[0])
+	}
+	if payload.Tenant != "" || payload.Environment != "" || payload.Action != "" {
+		t.Fatalf("notice = %+v, want no tenant/environment/action tag when several envs are unreachable", payload)
 	}
 }
 

--- a/erun-ui/playwright/tests/runtime-unreachable-banner-clear.spec.ts
+++ b/erun-ui/playwright/tests/runtime-unreachable-banner-clear.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect } from '../fixtures/erunApp.js';
+import { SEED_ENV_ALPHA, SEED_TENANT } from '../fixtures/seedRoot.js';
+import { ManageDialog } from '../pages/ManageDialog.js';
 import type { Page } from '@playwright/test';
 
 // The runtime-unreachable warning used to linger while a deploy for that env was
@@ -66,6 +68,81 @@ test.describe('runtime-unreachable banner clears with the deploy lifecycle (#713
 
     await dismiss.click();
     await expect(banner(page)).toBeHidden();
+  });
+
+  // #1390: the message names "Deploy the environment" as its fix, and the
+  // app already has a control for that — the Manage dialog's Runtime tab,
+  // where the operator picks a version and clicks Deploy. The banner must
+  // offer that control directly rather than leaving the operator to find it
+  // themselves. Backed by a real seeded env (not the fabricated frs/prod
+  // used above) so opening the Manage dialog resolves real config instead of
+  // erroring on an unknown tenant/environment. The orchestrator's own
+  // "deploy or reopen that environment" edge-unreachable notice (#1390,
+  // wireOrchestratorMCP) renders through this exact same action field and
+  // component, covered on the Go side by
+  // TestWireOrchestratorMCPWiresAnUnreachableEnvAndSaysSo; this is the one
+  // rendering path both share.
+  test('a "Deploy" action opens the Manage dialog straight to Runtime, and dismisses the banner', async ({
+    app,
+  }) => {
+    const { page } = app;
+    const message = `Could not reach the runtime for ${SEED_TENANT}/${SEED_ENV_ALPHA}: timed out. Deploy the environment to bring it up.`;
+    await page.evaluate(
+      ({ msg, tenant, environment }) => {
+        (window as unknown as RuntimeShim).runtime.EventsEmit('app-notification', {
+          kind: 'warning',
+          message: msg,
+          tenant,
+          environment,
+          source: 'runtime-unreachable',
+          action: 'deploy',
+        });
+      },
+      { msg: message, tenant: SEED_TENANT, environment: SEED_ENV_ALPHA },
+    );
+
+    const deployBanner = page
+      .getByRole('status')
+      .filter({ hasText: 'Could not reach the runtime' });
+    await expect(deployBanner).toBeVisible();
+    // exact: true — the message itself contains the substring "Deploy" (the
+    // long-message trigger's accessible name is the whole sentence), which
+    // would otherwise also match this query.
+    const deployAction = deployBanner.getByRole('button', { name: 'Deploy', exact: true });
+    await expect(deployAction).toBeVisible();
+    await deployAction.click();
+
+    const dialog = new ManageDialog(page, `${SEED_TENANT}-${SEED_ENV_ALPHA}`);
+    await dialog.waitForOpen();
+    await expect.poll(() => dialog.getActiveTab()).toBe('Runtime');
+    await expect(deployBanner).toBeHidden();
+  });
+
+  // A message with no unambiguous env to target (the orchestrator's own
+  // multi-env case, or any other warning) must render with no Deploy
+  // control — manufacturing one would offer a click that cannot know which
+  // environment to open.
+  test('a runtime-unreachable-shaped message with no deploy action offers no Deploy button', async ({
+    app,
+  }) => {
+    const { page } = app;
+    const message = `Could not reach the runtime for ${SEED_TENANT}/${SEED_ENV_ALPHA}: timed out. Deploy the environment to bring it up.`;
+    await page.evaluate(
+      ({ msg, tenant, environment }) => {
+        (window as unknown as RuntimeShim).runtime.EventsEmit('app-notification', {
+          kind: 'warning',
+          message: msg,
+          tenant,
+          environment,
+          source: 'runtime-unreachable',
+        });
+      },
+      { msg: message, tenant: SEED_TENANT, environment: SEED_ENV_ALPHA },
+    );
+
+    const banner = page.getByRole('status').filter({ hasText: 'Could not reach the runtime' });
+    await expect(banner).toBeVisible();
+    await expect(banner.getByRole('button', { name: 'Deploy', exact: true })).toHaveCount(0);
   });
 });
 

--- a/erun-ui/playwright/tests/tenant-dashboard-permissions.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-permissions.spec.ts
@@ -196,3 +196,107 @@ test.describe('tenant dashboard — permission-derived surfaces (#1210)', () => 
     }
   });
 });
+
+// #1390: a stale signed-in identity fails the dashboard's own precondition
+// read (whoami) before any panel is even attempted, so it blocks the whole
+// dashboard — apiError, not a per-panel error. That message names "sign in"
+// as its fix, and the app already has a control for it (the same cloud-alias
+// login the sidebar offers), so it must render with that control rather than
+// as inert text in an empty panel.
+test.describe('tenant dashboard — a stale identity blocks the whole dashboard (#1390)', () => {
+  test('offers to sign in, and clicking it dispatches the login for the tenant primary alias', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('identity-stale');
+    try {
+      let loginAlias = '';
+      await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+        const body = JSON.parse(request.postData() ?? '{}') as { method: string; args?: string[] };
+        if (body.method === 'LoadTenantDashboard') {
+          await route.fulfill({
+            contentType: 'application/json',
+            body: JSON.stringify({
+              data: {
+                tenant: SEED_TENANT,
+                environment,
+                apiUrl: 'http://127.0.0.1:1/unreachable',
+                apiError:
+                  "This tenant's platform did not accept the signed-in identity. Sign in to the tenant's cloud provider again.",
+              },
+            }),
+          });
+          return;
+        }
+        if (body.method === 'LoginCloudProvider') {
+          loginAlias = body.args?.[0] ?? '';
+          await route.fulfill({
+            contentType: 'application/json',
+            body: JSON.stringify({ data: { alias: 'pw-aws', provider: 'aws', status: 'active' } }),
+          });
+          return;
+        }
+        await route.continue();
+      });
+
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+
+      const alert = page
+        .getByRole('alert')
+        .filter({ hasText: 'did not accept the signed-in identity' });
+      await expect(alert).toBeVisible();
+
+      const signIn = alert.locator('..').getByRole('button', { name: 'Log in' });
+      await expect(signIn).toBeVisible();
+      await signIn.click();
+      await expect.poll(() => loginAlias).toBe('pw-aws');
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+
+  test('a permission refusal blocking the whole dashboard offers no button', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('identity-forbidden');
+    try {
+      await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+        const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+        if (body.method === 'LoadTenantDashboard') {
+          await route.fulfill({
+            contentType: 'application/json',
+            body: JSON.stringify({
+              data: {
+                tenant: SEED_TENANT,
+                environment,
+                apiUrl: 'http://127.0.0.1:1/unreachable',
+                apiError:
+                  "You do not have access to this tenant's dashboard. Ask an administrator for access.",
+              },
+            }),
+          });
+          return;
+        }
+        await route.continue();
+      });
+
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+
+      await expect(
+        page.getByRole('alert').filter({ hasText: 'Ask an administrator for access' }),
+      ).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Log in' })).toHaveCount(0);
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+});

--- a/erun-ui/playwright/tests/tenant-dashboard-review-write.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-review-write.spec.ts
@@ -227,6 +227,137 @@ test.describe('tenant dashboard — opening a review (#1348)', () => {
     }
   });
 
+  // #1390: operatorPlatformError's "sign-in expired" sentence used to be a
+  // dead end wherever a review write surfaced it. The alert must now offer
+  // the same "Log in" the sidebar's cloud alias row already uses, and
+  // clicking it must actually dispatch LoginCloudProvider for the tenant's
+  // primary alias — not just render inert text.
+  test('a stale-identity error on create offers to sign in, and clicking it does', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('review-create-stale-identity');
+    try {
+      let loginAlias = '';
+      await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+        const body = invokeBody(request);
+        if (body.method === 'LoadTenantDashboard') {
+          await fulfillJSON(route, dashboardResponse(environment, { canCreateReview: true }));
+          return;
+        }
+        if (body.method === 'EnvironmentWorkingIssue') {
+          await fulfillJSON(route, { available: true, branch: 'feature/1348-x' });
+          return;
+        }
+        if (body.method === 'ExecCommit') {
+          await fulfillJSON(route, { branch: 'feature/1348-x', commit: 'abc123', files: ['a.go'] });
+          return;
+        }
+        if (body.method === 'ExecPush') {
+          await fulfillJSON(route, {
+            branch: 'feature/1348-x',
+            remote: 'origin',
+            commit: 'abc123',
+          });
+          return;
+        }
+        if (body.method === 'CreateReview') {
+          await route.fulfill({
+            contentType: 'application/json',
+            body: JSON.stringify({
+              error: 'Your sign-in is no longer valid for this tenant. Sign in again and retry.',
+            }),
+          });
+          return;
+        }
+        if (body.method === 'LoginCloudProvider') {
+          const args = (JSON.parse(request.postData() ?? '{}') as { args?: string[] }).args ?? [];
+          loginAlias = args[0] ?? '';
+          await fulfillJSON(route, { alias: 'pw-aws', provider: 'aws', status: 'active' });
+          return;
+        }
+        await route.continue();
+      });
+
+      await openDashboardReviewsTab(app, environment);
+      await app.tenantDashboard.newReviewButton().click();
+      const dialog = app.createReviewDialog;
+      await dialog.waitForOpen();
+      await dialog.fillCommitMessage('describe the change');
+      await dialog.commit();
+      await dialog.push();
+      await dialog.fillName('Add widget');
+      await dialog.create();
+
+      const alert = dialog
+        .locator()
+        .getByRole('alert')
+        .filter({ hasText: 'sign-in is no longer valid' });
+      await expect(alert).toBeVisible();
+      const signIn = dialog.locator().getByRole('button', { name: 'Log in' });
+      await expect(signIn).toBeVisible();
+      await signIn.click();
+      await expect.poll(() => loginAlias).toBe('pw-aws');
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+
+  // The regression this action must not create: an unrelated create failure
+  // (not the stale-identity sentence) must render as before — message only,
+  // no manufactured button.
+  test('an unrelated create failure offers no sign-in action', async ({ app, page }) => {
+    const environment = seedDashboardEnvironment('review-create-other-error');
+    try {
+      await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+        const body = invokeBody(request);
+        if (body.method === 'LoadTenantDashboard') {
+          await fulfillJSON(route, dashboardResponse(environment, { canCreateReview: true }));
+          return;
+        }
+        if (body.method === 'EnvironmentWorkingIssue') {
+          await fulfillJSON(route, { available: true, branch: 'feature/1348-x' });
+          return;
+        }
+        if (body.method === 'ExecCommit') {
+          await fulfillJSON(route, { branch: 'feature/1348-x', commit: 'abc123', files: ['a.go'] });
+          return;
+        }
+        if (body.method === 'ExecPush') {
+          await fulfillJSON(route, {
+            branch: 'feature/1348-x',
+            remote: 'origin',
+            commit: 'abc123',
+          });
+          return;
+        }
+        if (body.method === 'CreateReview') {
+          await route.fulfill({
+            contentType: 'application/json',
+            body: JSON.stringify({ error: 'load tenant dashboard POST /v1/reviews: http 500' }),
+          });
+          return;
+        }
+        await route.continue();
+      });
+
+      await openDashboardReviewsTab(app, environment);
+      await app.tenantDashboard.newReviewButton().click();
+      const dialog = app.createReviewDialog;
+      await dialog.waitForOpen();
+      await dialog.fillCommitMessage('describe the change');
+      await dialog.commit();
+      await dialog.push();
+      await dialog.fillName('Add widget');
+      await dialog.create();
+
+      await expect(dialog.locator().getByRole('alert')).toContainText('http 500');
+      await expect(dialog.locator().getByRole('button', { name: 'Log in' })).toHaveCount(0);
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+
   test('hides the New review action and names the missing access when the caller cannot create one', async ({
     app,
     page,

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -972,6 +972,12 @@ type appNotificationPayload struct {
 	Tenant      string `json:"tenant,omitempty"`
 	Environment string `json:"environment,omitempty"`
 	Source      string `json:"source,omitempty"`
+	// Action names a control the frontend can render beside the message that
+	// actually performs the remedy the message names, e.g. "deploy" opens the
+	// tagged env's deploy dialog. Empty means the message carries no action the
+	// app can perform — the operator-facing text is the whole of the recovery
+	// (#1390).
+	Action string `json:"action,omitempty"`
 }
 
 // appNotificationClearPayload dismisses an env-tagged notification. The frontend


### PR DESCRIPTION
Applies one rule, stated by the operator after hitting the third instance of it in a session: **any error message that names a remedy must offer the control that performs it.**

#1389 established the pattern on the diff-comment popover. This is the rest of the inventory.

## What was wrong

Two messages, live on screen: a toast saying *"…if it stays down, deploy or reopen that environment"* offering only **Copy** and dismiss, and the tenant dashboard's Reviews panel saying *"Sign in to the tenant's cloud provider again"* as **bare red text floating in a large empty bordered box** with no control at all.

Each named a remedy the desktop already had a binding for. The action existed; the message just never offered it.

## Fixed

| message | now |
|---|---|
| whole-dashboard identity failure (`tenant_dashboard.go`) | designed alert, centred rather than adrift, with a **Log in** button dispatching `loginPrimaryCloudProvider` for the tenant's primary alias |
| "sign-in is no longer valid" | same alert + **Log in**, at **all six** write call sites — create review, close review, advance merge queue, comment, resolve, unresolve |
| "Could not reach the runtime for `<tenant>/<env>`… Deploy the environment to bring it up." | toast now carries a **Deploy** button that opens the Manage dialog on the Runtime tab |
| `orchestrator_mcp.go` "deploy or reopen that environment" | tenant/environment-tagged and carries the same **Deploy** action |

## Two corrections to the issue's own analysis, worth recording

**The surfaces were misidentified.** The issue assumed the runtime-unreachable message was panel-rendered and only the orchestrator notice was a toast. Both are the *same* toast (`emitEnvNotification` / `TitlebarStatus`); the runtime warning was never panel-rendered. And the toast **can** host an action — `StatusWaitAction` already proved the pattern — so it was extended with a generic `envAction` / `envTenant` / `envEnvironment` field set plus a `StatusDeployAction` button, shared by both messages, rather than redesigning notifications.

**The inventory was incomplete.** The sign-in sentence is returned by six write call sites, not the one the issue named. All six now render through the same component.

## Deliberately still action-less

"You do not have access to this tenant's dashboard. Ask an administrator for access." and the reviewer-role variant keep the designed alert and get **no button** — that remedy is a conversation with a human, not something the app can perform. Regression-tested at both the whole-dashboard and write-error levels, because a blanket button-everywhere is the way this rule would degrade.

Same discipline for ambiguity: when **more than one** linked environment is unreachable, no single environment can be targeted, so the notice renders with no button rather than guessing which one to deploy. Pinned by `TestWireOrchestratorMCPMultipleUnreachableEnvsCarryNoAction`.

## Verification

- `erun-ui` `go test -race -count=1 ./...` — pass
- `yarn typecheck` / `format:check` / `test` (164/164) — pass; `yarn lint` 0 errors (3 pre-existing `approaching-max-lines` warnings in untouched files)
- Playwright with `--build` on the three touched specs — **19/19**
- Plus seven adjacent specs exercising the shared components that were edited (`app-notification`, `titlebar-status-overflow`, `deploy-failure-toolbar`, `review-diff-line-comment`, `tenant-dashboard-reviews`, `-long-values`, `orchestrator-cross-env-diff`) — **35/35**, no regressions from the shared-component changes

Four screenshots were produced and each was opened and judged: the dashboard alert with **Log in**, the create-review failure with the alert sitting under the field that failed, the toast with **Deploy** beside Copy, and the permission refusal correctly button-free.

## Not verified

- No real cloud login was driven to success or failure — the harness's `aws` stub is inert by design. The click was verified to dispatch `LoginCloudProvider` with the correct alias by intercepting the RPC, which is the deterministic signal this harness offers.
- Five of the six write-error sites share the identical component and are covered by a unit test on the predicate plus one full Playwright round trip (create review); the other four were not each driven end-to-end individually.

## Worth a follow-up, not scope-crept here

Three instances found by three separate glances suggests the class is not exhausted by an inventory taken on one day. A gate that fails when an operator-facing string contains an imperative remedy without an accompanying action would catch the next one at authoring time — the repo's own preference for a structural gate over a remembered convention.

Closes #1390
