### PR TITLE
Codify smooth, seamless, no-dead-ends as a mandatory repo-wide UX standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,61 @@ Internal ownership and per-module conventions live in each module's `AGENTS.md`.
 - When delegating analysis to sub-agents, use a capable model — not a lightweight locator model — for substantive reasoning.
 - Once the user authorizes a body of work (e.g. "do it all" / "carry on"), carry it through to completion across commits and PRs without re-asking permission between increments; surface only genuine blockers. This does not license unrequested expansion — still get plan sign-off before multi-module or public-surface diffs the user did not ask for.
 
+## Smooth, Seamless, No Dead Ends (Mandatory)
+
+**Anything less than a smooth, seamless end-to-end experience is a failure.**
+Not a nice-to-have missed, not polish deferred — a failure, on the same footing
+as a wrong result. Basic is never enough. A change is finished when the
+experience is right, not when the code path works.
+
+**Seamless means the user never has to do the product's work for it.** They
+should not have to guess what state they are in, refresh a panel by hand to see
+the outcome of something they just did, re-enter a value the product already
+holds, leave for a terminal to finish a task they started in the app, or notice
+the seam between two subsystems at all. Anywhere the user has to think about the
+product's internals to make progress, that is a defect to be filed and fixed,
+not the cost of doing business.
+
+**Smooth means the passage of time is handled, not ignored.** Anything that can
+take more than a moment shows that it is working, keeps the surface responsive
+while it does, and lands its result without a jolt. An action that leaves the
+app — an SSO sign-in that opens a browser, a deploy, a build — is the case that
+matters most: a frozen screen during it reads as broken, and so does a screen
+that snaps to a new state with no explanation of what happened.
+
+**Every state a user can reach must offer a way forward.** A message that names
+a problem must also name — and where it can, carry — the action that resolves
+it. A surface with no next action is a defect of the same severity as a crash:
+the user is stopped, and the product has told them nothing they can do about it.
+
+Three distinct failures, all of them dead ends:
+
+1. **Advice that cannot work.** An error whose suggested remedy does not apply
+   to the actual state. Diagnose precisely enough to be right, or say plainly
+   what is unknown — never emit a confident remedy for a cause that was not
+   checked.
+2. **An action that succeeds and changes nothing on screen.** If the surface
+   still shows the failure after the remedy succeeded, the user learns that the
+   product is broken. Whatever failed must be retried and its new result shown.
+   A button that appears to do nothing is worse than no button.
+3. **A capability that exists with no way in.** If the CLI or the API can do it
+   and the user's surface cannot, that surface has a dead end wherever that
+   capability is the answer. "Use the CLI" is not a resolution inside a GUI.
+
+**Distinguish causes before writing copy.** "Unauthorized" from the platform API
+is not one condition. *Session expired*, *identity never enrolled*, *tenant
+never connected*, and *permission genuinely refused* are four different user
+situations with four different next actions; collapsing them into one sentence
+guarantees the sentence is wrong for most of the people who read it.
+
+**Onboarding is where this is judged first.** The user who is not yet connected
+to the platform, or whose identity is not yet enrolled in a tenant, is the one
+most likely to be lost and least able to help themselves. Getting from "not set
+up" to "working" must be possible from inside the product, guided, and short.
+Where a step genuinely requires an administrator, the product still owns the
+handoff: say exactly who must do what, show the exact values they need, and make
+those values copyable — never leave the user to reconstruct them by hand.
+
 ## Code Comments
 
 - Keep comments terse and abstract: explain the application behavior and intent behind the code — the "why" — not the mechanics a reader can see in the code itself.

--- a/erun-skills/skills/erun-orchestrate/SKILL.md
+++ b/erun-skills/skills/erun-orchestrate/SKILL.md
@@ -123,6 +123,16 @@ Read what you control from erun's config store — never infer it from what happ
   confirm it is impossible for the *product* and not merely absent from *that surface* — and if the
   product can do it, an unexposed capability is a dead end that belongs in the issue, not a limitation
   to be documented in the copy.
+- **An answer computed inside a pod is an answer about the pod, not about the host.** Diagnosing a
+  host-side desktop bug, an orchestrator ran `platform_whoami` through an environment's MCP edge and
+  got "no erun platform cloud provider alias is configured." It reported to the operator that their
+  tenant was not on the platform. It was not — that was the pod's config answering about the pod. The
+  host had a valid, logged-in erun platform alias all along, and `erun platform whoami` run on the
+  host returned a real tenant and user id. The mistake cost a wrong diagnosis delivered with
+  confidence, and it was caught only because the host command was run later for an unrelated reason.
+  A pod can answer questions about its own workspace, its own build, its own git tree — it cannot
+  answer a question about the operator's machine, and configuration is always a question about a
+  specific machine. When the subject of the question is the host, run the command on the host.
 
 ## Working in a pod
 

--- a/erun-skills/skills/erun-orchestrate/SKILL.md
+++ b/erun-skills/skills/erun-orchestrate/SKILL.md
@@ -103,6 +103,23 @@ Read what you control from erun's config store — never infer it from what happ
   result still fails the bar it was given. Where the bar is craft or convenience, the passing verdict
   and the quality verdict are separate judgements, and only one of them a test can make. Decide the
   second one by looking at what shipped, and be willing to send back something that works.
+- **An error message is judged against the user's state, not against the code that produced it.** A
+  tenant-dashboard identity error was well-written, correctly humanised, and traceable to a real
+  `ErrPlatformUnauthorized` — a reviewer read it and approved it. It was still a dead end, because the
+  state it was shown in was "this tenant was never connected to the platform", a state in which
+  signing in again is impossible. The message was good prose about the wrong situation. The check
+  that catches this is not "is this sentence clear" but "if I were actually in this state, could I
+  get out?" — which requires knowing what state the user is actually in, not merely which error
+  constant was returned. A single API status can stand for several genuinely different user
+  situations, and reviewing the string in isolation cannot tell them apart.
+- **Before accepting that a surface cannot offer something, check whether the product already can.**
+  A desktop had no way to connect a tenant or enrol a user, and this read as an inherent limit until
+  someone grepped for the verbs: the platform enrolment, tenant-creation, and provisioning commands
+  already existed, in both the CLI and the MCP tool set, with zero corresponding desktop bindings. The
+  gap was never capability; it was exposure. When a surface tells the user something is impossible,
+  confirm it is impossible for the *product* and not merely absent from *that surface* — and if the
+  product can do it, an unexposed capability is a dead end that belongs in the issue, not a limitation
+  to be documented in the copy.
 
 ## Working in a pod
 

--- a/erun-skills/skills/erun-orchestrate/SKILL.md
+++ b/erun-skills/skills/erun-orchestrate/SKILL.md
@@ -106,12 +106,15 @@ Read what you control from erun's config store — never infer it from what happ
 - **An error message is judged against the user's state, not against the code that produced it.** A
   tenant-dashboard identity error was well-written, correctly humanised, and traceable to a real
   `ErrPlatformUnauthorized` — a reviewer read it and approved it. It was still a dead end, because the
-  state it was shown in was "this tenant was never connected to the platform", a state in which
-  signing in again is impossible. The message was good prose about the wrong situation. The check
-  that catches this is not "is this sentence clear" but "if I were actually in this state, could I
-  get out?" — which requires knowing what state the user is actually in, not merely which error
-  constant was returned. A single API status can stand for several genuinely different user
-  situations, and reviewing the string in isolation cannot tell them apart.
+  state it was shown in was: the desktop had signed the platform with the tenant's primary cloud
+  alias — an AWS alias — instead of the erun-platform alias, so the platform refused the identity and
+  the surface said "Sign in to the tenant's cloud provider again." The operator did exactly that, the
+  AWS sign-in succeeded, and it could never help, because AWS was never an identity the platform would
+  accept. The message was good prose about the wrong situation. The check that catches this is not "is
+  this sentence clear" but "if I were actually in this state, could I get out?" — which requires
+  knowing what state the user is actually in, not merely which error constant was returned. A single
+  API status can stand for several genuinely different user situations, and reviewing the string in
+  isolation cannot tell them apart.
 - **Before accepting that a surface cannot offer something, check whether the product already can.**
   A desktop had no way to connect a tenant or enrol a user, and this read as an inherent limit until
   someone grepped for the verbs: the platform enrolment, tenant-creation, and provisioning commands


### PR DESCRIPTION
## Summary

- Adds `## Smooth, Seamless, No Dead Ends` to the repo-root `AGENTS.md` as a mandatory, repo-wide rule: anything less than a smooth, seamless end-to-end experience is a failure, not a nice-to-have. Defines *seamless* (the user never does the product's work for it) and *smooth* (elapsed time is handled, not ignored), names the three dead-end failure modes (advice that cannot work, an action that succeeds but changes nothing on screen, a capability with no way in), requires distinguishing causes before writing copy, and makes onboarding the first place the rule is judged.
- Adds three principles to `erun-skills/skills/erun-orchestrate/SKILL.md` in the file's established format, each drawn from a real incident:
  1. An error message is judged against the user's state, not against the code that produced it — illustrated by the wrong-alias identity error from #1393, where "sign in again" could never succeed because the desktop had signed the platform with the tenant's AWS cloud alias rather than the erun-platform alias.
  2. Before accepting that a surface cannot offer something, check whether the product already can — a capability gap that turned out to be an exposure gap.
  3. An answer computed inside a pod is an answer about the pod, not about the host — a `platform_whoami` call routed through an environment's MCP edge answered for the pod's own config and was wrongly reported as the host's state.

Documentation only; no behaviour change. #1392 and #1393 are the enforcement of this standard.

## Test plan
- [x] Reviewed the edited `AGENTS.md` and `SKILL.md` sections for internal consistency and format match with the existing principles
- [x] `git status --porcelain` clean after each commit

Closes #1394