### PR TITLE
Say what each environment is doing on the orchestrator hover card

### DIFF
--- a/erun-docs/docs/desktop/overview.md
+++ b/erun-docs/docs/desktop/overview.md
@@ -29,6 +29,8 @@ For CI/CD pipelines and headless workflows, use the [CLI](/cli/overview) instead
 
 Above your environments, the sidebar's **ERUN** section lists your host-side orchestrators — AI sessions that coordinate work across the environments you link to them, reviewing each one's code on your machine and delegating every change to the Agent inside it. Open an orchestrator's **…** menu to manage it: restart, delete, or reveal the guidance it operates under.
 
+**Orchestrator details on hover.** Hover a running orchestrator's row to see what it's doing and, for each linked environment, its own state rather than just its name: busy (naming the holder when it's known), idle, in outage, or not open from this desktop — the same activity this environment's own hover card reports, so the two can never disagree. A **Nudges** line reports whether ERun has had to restate its pacing contract to a quiet session, how many times, and whether it has stopped nudging after repeated attempts — a capped session needs your reply or a restart, since ERun has stopped acting on its behalf.
+
 Each orchestrator runs under two layers of guidance, and the dialog opens either one in your editor (VS Code or IntelliJ):
 
 - **Role** — what this orchestrator does. Yours to edit; ERun creates it once and never overwrites it.

--- a/erun-ui/environment_activity.go
+++ b/erun-ui/environment_activity.go
@@ -251,6 +251,23 @@ func (a *App) seedEnvironmentActivitySnapshots(state *uiState) {
 	}
 }
 
+// envActivitySnapshot copies the poller's per-environment observations under
+// lock, for callers assembling a read model outside any a.mu section of their
+// own (a.mu is not reentrant, so a caller already holding it must read
+// a.envActivity directly instead of calling this).
+func (a *App) envActivitySnapshot() map[string]environmentActivityState {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.envActivity) == 0 {
+		return nil
+	}
+	out := make(map[string]environmentActivityState, len(a.envActivity))
+	for k, v := range a.envActivity {
+		out[k] = v
+	}
+	return out
+}
+
 func (a *App) emitEnvActivity(observation environmentActivity) {
 	a.emitEvent(envActivityEvent, envActivityPayload{
 		Tenant:      observation.selection.Tenant,

--- a/erun-ui/environment_activity_test.go
+++ b/erun-ui/environment_activity_test.go
@@ -135,6 +135,32 @@ func TestSeedEnvironmentActivitySnapshotsLeavesUnobservedEnvsNil(t *testing.T) {
 	}
 }
 
+// TestEnvActivitySnapshotCopiesRatherThanAliases guards the reason this
+// method exists at all: a caller assembling a read model outside any a.mu
+// section of its own (orchestratorInfoFor's unlocked call sites) must not
+// hold a live reference into a.envActivity, or a concurrent poller write
+// would race with that caller's later reads.
+func TestEnvActivitySnapshotCopiesRatherThanAliases(t *testing.T) {
+	key := selectionKey(uiSelection{Tenant: "acme", Environment: "dev"})
+	app := &App{envActivity: map[string]environmentActivityState{key: {busy: true, detail: "gradle-build"}}}
+
+	snapshot := app.envActivitySnapshot()
+	if len(snapshot) != 1 || !snapshot[key].busy {
+		t.Fatalf("expected the snapshot to carry the observation, got %+v", snapshot)
+	}
+	app.envActivity[key] = environmentActivityState{}
+	if !snapshot[key].busy {
+		t.Fatalf("expected the snapshot to be a copy, unaffected by a later mutation of a.envActivity")
+	}
+}
+
+func TestEnvActivitySnapshotNilWhenEmpty(t *testing.T) {
+	app := &App{}
+	if snapshot := app.envActivitySnapshot(); snapshot != nil {
+		t.Fatalf("expected a nil snapshot for an empty poller state, got %+v", snapshot)
+	}
+}
+
 // TestLoadStateSeedsEnvironmentActivityFromThePoller exercises the full
 // wiring: LoadState (what the frontend's boot() thunk actually calls) must
 // carry the poller's last observation onto the env it just reloaded from

--- a/erun-ui/frontend/src/app/activeSessionOrchestrator.test.ts
+++ b/erun-ui/frontend/src/app/activeSessionOrchestrator.test.ts
@@ -19,6 +19,8 @@ function orchestrator(id: string, sessionId: number): OrchestratorInfo {
     shellRunning: false,
     shellCommand: '',
     shellStartedAtUnix: 0,
+    nudgeCount: 0,
+    nudgeCapped: false,
   };
 }
 

--- a/erun-ui/frontend/src/app/diagnosticsIssue.test.ts
+++ b/erun-ui/frontend/src/app/diagnosticsIssue.test.ts
@@ -23,6 +23,8 @@ function orchestrator(overrides: Partial<OrchestratorInfo> = {}): OrchestratorIn
     shellRunning: false,
     shellCommand: '',
     shellStartedAtUnix: 0,
+    nudgeCount: 0,
+    nudgeCapped: false,
     ...overrides,
   };
 }

--- a/erun-ui/frontend/src/app/diagnosticsReport.test.ts
+++ b/erun-ui/frontend/src/app/diagnosticsReport.test.ts
@@ -18,6 +18,8 @@ function orchestrator(overrides: Partial<OrchestratorInfo> = {}): OrchestratorIn
     shellRunning: false,
     shellCommand: '',
     shellStartedAtUnix: 0,
+    nudgeCount: 0,
+    nudgeCapped: false,
     ...overrides,
   };
 }

--- a/erun-ui/frontend/src/app/orchestratorBusySeed.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorBusySeed.test.ts
@@ -18,6 +18,8 @@ function orchestrator(sessionId: number, busy: boolean): OrchestratorInfo {
     shellRunning: false,
     shellCommand: '',
     shellStartedAtUnix: 0,
+    nudgeCount: 0,
+    nudgeCapped: false,
   };
 }
 

--- a/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { orchestratorEnvironmentLine } from './orchestratorEnvironmentActivity';
+import type { OrchestratorEnvRef } from './slices/orchestratorsSlice';
+
+function env(overrides: Partial<OrchestratorEnvRef> = {}): OrchestratorEnvRef {
+  return { tenant: 'petios', environment: 'rihards-review', directory: '/tmp/dir', ...overrides };
+}
+
+// This is the join the hover card renders straight from -- red-then-green
+// against origin/main means "petios / rihards-review" alone, with nothing
+// else on the line. Each case below asserts the state renders as its own
+// distinct line rather than collapsing into a neighbour.
+
+test('busy with a detail names the holder verbatim, not a bare "busy"', () => {
+  const line = orchestratorEnvironmentLine(
+    env({
+      activity: {
+        reachable: true,
+        observed: true,
+        outage: false,
+        busy: true,
+        detail: 'holding: gradle-build',
+      },
+    }),
+  );
+  assert.equal(line.state, 'busy');
+  assert.equal(line.status, 'Busy — holding: gradle-build');
+  assert.equal(line.dot, 'busy');
+});
+
+test('busy with no detail still reads busy', () => {
+  const line = orchestratorEnvironmentLine(
+    env({ activity: { reachable: true, observed: true, outage: false, busy: true } }),
+  );
+  assert.equal(line.status, 'Busy');
+});
+
+test('reachable and observed and not busy reads idle', () => {
+  const line = orchestratorEnvironmentLine(
+    env({ activity: { reachable: true, observed: true, outage: false, busy: false } }),
+  );
+  assert.equal(line.state, 'idle');
+  assert.equal(line.status, 'Idle');
+});
+
+test('reachable but not yet observed does not collapse into idle', () => {
+  const line = orchestratorEnvironmentLine(
+    env({ activity: { reachable: true, observed: false, outage: false, busy: false } }),
+  );
+  assert.notEqual(line.state, 'idle');
+  assert.equal(line.state, 'unknown');
+});
+
+test('an outage reads as outage even while otherwise reachable and busy', () => {
+  const line = orchestratorEnvironmentLine(
+    env({
+      activity: { reachable: true, observed: true, outage: true, busy: true, detail: 'holding: x' },
+    }),
+  );
+  assert.equal(line.state, 'outage');
+  assert.notEqual(line.status, 'Idle');
+  assert.notEqual(line.status, 'Busy — holding: x');
+});
+
+test('never observed (no activity at all) reads unreachable, not idle', () => {
+  const line = orchestratorEnvironmentLine(env());
+  assert.equal(line.state, 'unreachable');
+  assert.notEqual(line.state, 'idle');
+});
+
+test('a long environment name and a long detail survive verbatim for the caller to truncate', () => {
+  const longName = 'a'.repeat(120);
+  const longDetail = 'holding: ' + 'b'.repeat(120);
+  const line = orchestratorEnvironmentLine(
+    env({
+      environment: longName,
+      activity: { reachable: true, observed: true, outage: false, busy: true, detail: longDetail },
+    }),
+  );
+  assert.ok(line.name.includes(longName));
+  assert.ok(line.status.includes(longDetail));
+});

--- a/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.ts
+++ b/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.ts
@@ -1,0 +1,49 @@
+import type { OrchestratorEnvRef } from '@/app/slices/orchestratorsSlice';
+import type { StatusDotState } from '@/components/app/Sidebar.StatusDot';
+
+// orchestratorEnvironmentLine reduces one linked environment's joined
+// activity (environment_activity.go's poller, via OrchestratorEnvRef.activity)
+// to the one line the hover card renders for it. The reduction is deliberately
+// not a single boolean: outage and unreachable read as the same "nothing here"
+// to a naive summary, but they are different operator situations (a forward
+// that died vs. one that was never opened), and observed=false must not
+// collapse into idle just because busy is also false -- that would report a
+// state nobody actually confirmed.
+export type OrchestratorEnvironmentState = 'outage' | 'unreachable' | 'unknown' | 'busy' | 'idle';
+
+export interface OrchestratorEnvironmentLine {
+  key: string;
+  name: string;
+  state: OrchestratorEnvironmentState;
+  status: string;
+  // dot is omitted for the two states with no shared StatusDotGlyph shape
+  // (unreachable, unknown) rather than reusing 'stopped' or 'failed' for them
+  // and losing the distinction those two exist to preserve.
+  dot?: StatusDotState;
+}
+
+export function orchestratorEnvironmentLine(env: OrchestratorEnvRef): OrchestratorEnvironmentLine {
+  const key = `${env.tenant}/${env.environment}`;
+  const name = `${env.tenant} / ${env.environment}`;
+  const activity = env.activity;
+
+  if (activity?.outage) {
+    return { key, name, state: 'outage', status: 'Lost connection', dot: 'failed' };
+  }
+  if (!activity?.reachable) {
+    return { key, name, state: 'unreachable', status: 'Not open here' };
+  }
+  if (!activity.observed) {
+    return { key, name, state: 'unknown', status: 'Connected — activity unknown' };
+  }
+  if (activity.busy) {
+    return {
+      key,
+      name,
+      state: 'busy',
+      status: activity.detail ? `Busy — ${activity.detail}` : 'Busy',
+      dot: 'busy',
+    };
+  }
+  return { key, name, state: 'idle', status: 'Idle', dot: 'running' };
+}

--- a/erun-ui/frontend/src/app/orchestratorNudgeSummary.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorNudgeSummary.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { orchestratorNudgeSummary } from './orchestratorNudgeSummary';
+
+test('never nudged is distinct from capped', () => {
+  const summary = orchestratorNudgeSummary(
+    { nudgeCount: 0, nudgeCapped: false, lastNudgeAtUnix: 0 },
+    Date.now(),
+  );
+  assert.equal(summary, 'Not nudged');
+});
+
+test('a nudge count with no cap names the count and how long ago', () => {
+  const now = Date.now();
+  const lastNudgeAtUnix = Math.floor(now / 1000) - 65;
+  const summary = orchestratorNudgeSummary(
+    { nudgeCount: 2, nudgeCapped: false, lastNudgeAtUnix },
+    now,
+  );
+  assert.match(summary, /^Nudged 2x, last .+ ago$/);
+});
+
+test('a capped session names the attempt count and the recovery, not just "quiet"', () => {
+  const summary = orchestratorNudgeSummary(
+    { nudgeCount: 6, nudgeCapped: true, lastNudgeAtUnix: 0 },
+    Date.now(),
+  );
+  assert.match(summary, /^Stopped nudging after 6 attempts/);
+  assert.match(summary, /reply or restart/);
+});

--- a/erun-ui/frontend/src/app/orchestratorNudgeSummary.ts
+++ b/erun-ui/frontend/src/app/orchestratorNudgeSummary.ts
@@ -1,0 +1,23 @@
+import { orchestratorBusyElapsed } from '@/app/orchestratorBusyLabel';
+import type { OrchestratorInfo } from '@/app/slices/orchestratorsSlice';
+
+// orchestratorNudgeSummary names the pacing state orchestrator_pacing.go
+// already tracks per session: whether erun has had to restate the pacing
+// contract into a quiet pane, and whether it gave up after the cap. Capped and
+// never-nudged both read as "quiet" without this -- and a capped session is
+// the one an operator most needs to notice, since erun has stopped acting on
+// its behalf.
+export function orchestratorNudgeSummary(
+  orchestrator: Pick<OrchestratorInfo, 'nudgeCount' | 'nudgeCapped' | 'lastNudgeAtUnix'>,
+  nowMs: number,
+): string {
+  if (orchestrator.nudgeCapped) {
+    return `Stopped nudging after ${String(orchestrator.nudgeCount)} attempts — reply or restart`;
+  }
+  if (orchestrator.nudgeCount > 0) {
+    const count = String(orchestrator.nudgeCount);
+    const elapsed = orchestratorBusyElapsed(orchestrator.lastNudgeAtUnix, nowMs);
+    return elapsed ? `Nudged ${count}x, last ${elapsed} ago` : `Nudged ${count}x`;
+  }
+  return 'Not nudged';
+}

--- a/erun-ui/frontend/src/app/orchestratorRestore.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorRestore.test.ts
@@ -18,6 +18,8 @@ function orchestrator(id: string, transient = false): OrchestratorInfo {
     shellRunning: false,
     shellCommand: '',
     shellStartedAtUnix: 0,
+    nudgeCount: 0,
+    nudgeCapped: false,
   };
 }
 

--- a/erun-ui/frontend/src/app/orchestratorShellActivitySeed.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorShellActivitySeed.test.ts
@@ -23,6 +23,8 @@ function orchestrator(
     shellRunning,
     shellCommand,
     shellStartedAtUnix,
+    nudgeCount: 0,
+    nudgeCapped: false,
   };
 }
 

--- a/erun-ui/frontend/src/app/reviewEnvTargets.test.ts
+++ b/erun-ui/frontend/src/app/reviewEnvTargets.test.ts
@@ -23,6 +23,8 @@ function orchestrator(
     shellRunning: false,
     shellCommand: '',
     shellStartedAtUnix: 0,
+    nudgeCount: 0,
+    nudgeCapped: false,
   } satisfies OrchestratorInfo;
 }
 

--- a/erun-ui/frontend/src/app/sidebarFocus.test.ts
+++ b/erun-ui/frontend/src/app/sidebarFocus.test.ts
@@ -19,6 +19,8 @@ function orchestrator(id: string, sessionId: number): OrchestratorInfo {
     shellRunning: false,
     shellCommand: '',
     shellStartedAtUnix: 0,
+    nudgeCount: 0,
+    nudgeCapped: false,
   };
 }
 

--- a/erun-ui/frontend/src/app/slices/orchestratorsSlice.ts
+++ b/erun-ui/frontend/src/app/slices/orchestratorsSlice.ts
@@ -1,9 +1,17 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
+import type { UIEnvironmentActivity } from '@/uiEnvironmentActivityTypes';
+
 export interface OrchestratorEnvRef {
   tenant: string;
   environment: string;
   directory: string;
+  // activity is the environment-activity poller's last observation for this
+  // env (see uiEnvironment.Activity), joined onto the link rather than
+  // collected separately — the same reused shape, so this card and the
+  // sidebar row for the same environment can never disagree about what
+  // "busy" or "outage" means. Undefined until the poller has observed it.
+  activity?: UIEnvironmentActivity;
 }
 
 // OrchestratorInfo mirrors the Go orchestratorInfo JSON contract: a host-side
@@ -38,6 +46,14 @@ export interface OrchestratorInfo {
   shellRunning: boolean;
   shellCommand: string;
   shellStartedAtUnix: number;
+  // nudgeCount/nudgeCapped/lastNudgeAtUnix mirror orchestratorSession's own
+  // pacing state (orchestrator_pacing.go): how many consecutive un-answered
+  // pacing nudges erun has sent this session, and whether it gave up after
+  // the cap. Zero/false for a stopped orchestrator, whose pacing state does
+  // not survive past its session.
+  nudgeCount: number;
+  nudgeCapped: boolean;
+  lastNudgeAtUnix?: number;
 }
 
 export interface OrchestratorsState {

--- a/erun-ui/frontend/src/components/app/Sidebar.OrchestratorHoverCard.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.OrchestratorHoverCard.tsx
@@ -97,7 +97,11 @@ export function OrchestratorHoverCard({
           <HoverRow label="Doing">
             <OrchestratorDoing orchestrator={orchestrator} running={running} />
           </HoverRow>
-          <HoverRow label="Environments">
+          {/* wide: an environment's busy detail names a real holder ("held by
+              gradle-build"), which needs the card's full content width to read
+              without eliding -- the narrow value column every other row shares
+              with the "Environments" label leaves too little room for it. */}
+          <HoverRow label="Environments" wide>
             <OrchestratorEnvironments environments={orchestrator.environments} />
           </HoverRow>
           {running && (
@@ -224,15 +228,36 @@ function OrchestratorNudges({
 
 function HoverRow({
   label,
+  wide = false,
   children,
 }: {
   label: string;
+  // wide stacks the label above the value across both grid columns, for a
+  // value that needs the card's full content width rather than sharing it
+  // with the label column.
+  wide?: boolean;
   children: React.ReactNode;
 }): React.ReactElement {
   return (
     <>
-      <dt className="text-[12px] text-muted-foreground">{label}</dt>
-      <dd className="min-w-0 break-words text-foreground">{children}</dd>
+      <dt
+        className={
+          wide
+            ? 'col-span-2 text-[12px] text-muted-foreground'
+            : 'text-[12px] text-muted-foreground'
+        }
+      >
+        {label}
+      </dt>
+      <dd
+        className={
+          wide
+            ? 'col-span-2 min-w-0 break-words text-foreground'
+            : 'min-w-0 break-words text-foreground'
+        }
+      >
+        {children}
+      </dd>
     </>
   );
 }

--- a/erun-ui/frontend/src/components/app/Sidebar.OrchestratorHoverCard.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.OrchestratorHoverCard.tsx
@@ -1,9 +1,13 @@
 import { Popover, PopoverAnchor, PopoverContent } from 'erun-kit';
+import { TriangleAlert } from 'lucide-react';
 import * as React from 'react';
 
 import { formatElapsed } from '@/app/activityQueueState';
 import { orchestratorBusyElapsed } from '@/app/orchestratorBusyLabel';
+import { orchestratorEnvironmentLine } from '@/app/orchestratorEnvironmentActivity';
+import { orchestratorNudgeSummary } from '@/app/orchestratorNudgeSummary';
 import type { OrchestratorInfo } from '@/app/slices/orchestratorsSlice';
+import { StatusDotGlyph } from '@/components/app/Sidebar.StatusDot';
 
 // OrchestratorHoverCard gives an orchestrator row the same hover treatment the
 // environment row has had since EnvHoverCard: a Popover, not a tooltip, because
@@ -96,6 +100,11 @@ export function OrchestratorHoverCard({
           <HoverRow label="Environments">
             <OrchestratorEnvironments environments={orchestrator.environments} />
           </HoverRow>
+          {running && (
+            <HoverRow label="Nudges">
+              <OrchestratorNudges orchestrator={orchestrator} />
+            </HoverRow>
+          )}
         </dl>
       </PopoverContent>
     </Popover>
@@ -146,6 +155,13 @@ function OrchestratorDoing({
   );
 }
 
+// Each linked environment renders what it is doing, joined from the
+// environment-activity poller rather than collected here (see
+// orchestratorEnvironmentActivity.ts) -- this is the fix for the defect that
+// motivated the whole card: it used to name two environments and say nothing
+// about either. min-w-0 on both the row and its text column is required for
+// truncate to engage on a grid/flex child (a long environment name or a long
+// busy detail elides instead of blowing out the card's fixed w-72).
 function OrchestratorEnvironments({
   environments,
 }: {
@@ -157,14 +173,53 @@ function OrchestratorEnvironments({
     return <Muted>None linked</Muted>;
   }
   return (
-    <span className="grid gap-0.5">
-      {environments.map((env) => (
-        <span key={`${env.tenant}/${env.environment}`} className="truncate">
-          {env.tenant} / {env.environment}
-        </span>
-      ))}
+    <span className="grid gap-1.5">
+      {environments.map((env) => {
+        const line = orchestratorEnvironmentLine(env);
+        return (
+          <span key={line.key} className="flex min-w-0 items-start gap-1.5">
+            <span
+              className="mt-0.5 flex w-2.5 flex-none items-center justify-center"
+              aria-hidden="true"
+            >
+              {line.dot && <StatusDotGlyph state={line.dot} />}
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate font-medium">{line.name}</span>
+              <span className="block truncate text-[12px] text-muted-foreground">
+                {line.status}
+              </span>
+            </span>
+          </span>
+        );
+      })}
     </span>
   );
+}
+
+// Whether erun has been nudging this orchestrator (orchestrator_pacing.go):
+// a session that has gone quiet gets restated the pacing contract every 15s
+// tick once it is stale, capped after orchestratorPacingMaxNudges. Rendered
+// only while running -- a stopped orchestrator's pacing state does not
+// survive past its session, so there is nothing to report.
+function OrchestratorNudges({
+  orchestrator,
+}: {
+  orchestrator: OrchestratorInfo;
+}): React.ReactElement {
+  const summary = orchestratorNudgeSummary(orchestrator, Date.now());
+  if (orchestrator.nudgeCapped) {
+    return (
+      <span className="flex items-start gap-1.5 text-amber-600">
+        <TriangleAlert aria-hidden="true" className="mt-0.5 size-3.5 flex-none" />
+        <span>{summary}</span>
+      </span>
+    );
+  }
+  if (orchestrator.nudgeCount > 0) {
+    return <span>{summary}</span>;
+  }
+  return <Muted>{summary}</Muted>;
 }
 
 function HoverRow({

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -97,10 +97,17 @@ type orchestratorEnvCandidate struct {
 	Mirrored         bool   `json:"mirrored"`
 }
 
+// orchestratorEnvInfo is the JSON-safe view of one linked environment.
+// Activity is nil until the environment-activity poller (environment_activity.go)
+// has observed this environment at least once — the same "nil means not yet
+// observed" contract uiEnvironment.Activity already carries, reused here
+// rather than duplicated so the two surfaces cannot drift on what "not yet
+// observed" means.
 type orchestratorEnvInfo struct {
-	Tenant      string `json:"tenant"`
-	Environment string `json:"environment"`
-	Directory   string `json:"directory"`
+	Tenant      string                         `json:"tenant"`
+	Environment string                         `json:"environment"`
+	Directory   string                         `json:"directory"`
+	Activity    *uiEnvironmentActivitySnapshot `json:"activity,omitempty"`
 }
 
 // orchestratorInfo is the JSON-safe view the frontend renders and attaches to.
@@ -118,6 +125,12 @@ type orchestratorEnvInfo struct {
 // running shell was reported started, unix seconds, 0 when ShellRunning is
 // false — the frontend derives elapsed time from it rather than the desktop
 // formatting a string that immediately goes stale.
+//
+// NudgeCount/NudgeCapped/LastNudgeAtUnix carry orchestratorSession's pacing
+// state (orchestrator_pacing.go) the same way: read directly rather than left
+// to the operator to infer from the pane, so a hover can tell a session erun
+// has given up nudging from one that has never needed a nudge. Zero/false for
+// a stopped orchestrator, whose pacing state does not survive past its session.
 type orchestratorInfo struct {
 	ID                 string                `json:"id"`
 	Name               string                `json:"name"`
@@ -132,6 +145,9 @@ type orchestratorInfo struct {
 	ShellRunning       bool                  `json:"shellRunning"`
 	ShellCommand       string                `json:"shellCommand,omitempty"`
 	ShellStartedAtUnix int64                 `json:"shellStartedAtUnix,omitempty"`
+	NudgeCount         int                   `json:"nudgeCount"`
+	NudgeCapped        bool                  `json:"nudgeCapped"`
+	LastNudgeAtUnix    int64                 `json:"lastNudgeAtUnix,omitempty"`
 }
 
 func orchestratorSessionKey(id string) string {
@@ -883,10 +899,26 @@ func copyDirTree(src, dst string) error {
 	})
 }
 
-func envInfos(envs []eruncommon.OrchestratorEnvConfig) []orchestratorEnvInfo {
+// envInfos joins each linked env against the environment-activity poller's
+// last observation for it, keyed the same way the poller itself keys the
+// sidebar's per-env state (selectionKey) — so an orchestrator's card and the
+// sidebar row for the same environment can never disagree about what "busy"
+// or "outage" means, because both read the one map the poller writes.
+func envInfos(envs []eruncommon.OrchestratorEnvConfig, envActivity map[string]environmentActivityState) []orchestratorEnvInfo {
 	out := make([]orchestratorEnvInfo, 0, len(envs))
 	for _, env := range envs {
-		out = append(out, orchestratorEnvInfo{Tenant: env.Tenant, Environment: env.Environment, Directory: env.Directory})
+		info := orchestratorEnvInfo{Tenant: env.Tenant, Environment: env.Environment, Directory: env.Directory}
+		key := selectionKey(uiSelection{Tenant: env.Tenant, Environment: env.Environment})
+		if state, ok := envActivity[key]; ok {
+			info.Activity = &uiEnvironmentActivitySnapshot{
+				Reachable: state.reachable,
+				Observed:  state.observed,
+				Outage:    state.outage,
+				Busy:      state.busy,
+				Detail:    state.detail,
+			}
+		}
+		out = append(out, info)
 	}
 	return out
 }
@@ -933,11 +965,22 @@ type orchestratorBusySnapshot struct {
 	AtUnix int64
 }
 
-func orchestratorInfoFor(id, name string, envs []eruncommon.OrchestratorEnvConfig, status string, sessionID int, busy orchestratorBusySnapshot, transient bool, shell orchestratorShellSnapshot) orchestratorInfo {
+// orchestratorPacingSnapshot is the pacing/nudge half of orchestratorInfo,
+// grouped for the same reason orchestratorBusySnapshot and
+// orchestratorShellSnapshot are: read from orchestratorSession's own pacing
+// fields (orchestrator_pacing.go) rather than left for the frontend to infer
+// from the pane.
+type orchestratorPacingSnapshot struct {
+	NudgeCount      int
+	Capped          bool
+	LastNudgeAtUnix int64
+}
+
+func orchestratorInfoFor(id, name string, envs []eruncommon.OrchestratorEnvConfig, status string, sessionID int, busy orchestratorBusySnapshot, transient bool, shell orchestratorShellSnapshot, pacing orchestratorPacingSnapshot, envActivity map[string]environmentActivityState) orchestratorInfo {
 	return orchestratorInfo{
 		ID:                 id,
 		Name:               name,
-		Environments:       envInfos(envs),
+		Environments:       envInfos(envs, envActivity),
 		Tenants:            tenantsFromEnvs(envs),
 		Directories:        directoriesFromEnvs(envs),
 		SessionID:          sessionID,
@@ -948,6 +991,9 @@ func orchestratorInfoFor(id, name string, envs []eruncommon.OrchestratorEnvConfi
 		ShellCommand:       shell.Command,
 		ShellStartedAtUnix: shell.StartedAtUnix,
 		Transient:          transient,
+		NudgeCount:         pacing.NudgeCount,
+		NudgeCapped:        pacing.Capped,
+		LastNudgeAtUnix:    pacing.LastNudgeAtUnix,
 	}
 }
 
@@ -1289,7 +1335,7 @@ func (a *App) CreateOrchestrator(name string, envs []orchestratorEnvInput) (orch
 	if err := a.saveOrchestratorConfigs(append(configs, def)); err != nil {
 		return orchestratorInfo{}, err
 	}
-	return orchestratorInfoFor(id, displayName, refs, "stopped", 0, orchestratorBusySnapshot{}, false, orchestratorShellSnapshot{}), nil
+	return orchestratorInfoFor(id, displayName, refs, "stopped", 0, orchestratorBusySnapshot{}, false, orchestratorShellSnapshot{}, orchestratorPacingSnapshot{}, a.envActivitySnapshot()), nil
 }
 
 // UpdateOrchestrator edits an existing orchestrator's linked environments and
@@ -1328,13 +1374,15 @@ func (a *App) UpdateOrchestrator(id, name string, envs []orchestratorEnvInput) (
 	sessionID := 0
 	busy := orchestratorBusySnapshot{}
 	shell := orchestratorShellSnapshot{}
+	pacing := orchestratorPacingSnapshot{}
 	if info, ok := a.runningOrchestratorInfo(id); ok {
 		status = "running"
 		sessionID = info.SessionID
 		busy = orchestratorBusySnapshot{Busy: info.Busy, AtUnix: info.BusyAtUnix}
 		shell = orchestratorShellSnapshot{Running: info.ShellRunning, Command: info.ShellCommand, StartedAtUnix: info.ShellStartedAtUnix}
+		pacing = orchestratorPacingSnapshot{NudgeCount: info.NudgeCount, Capped: info.NudgeCapped, LastNudgeAtUnix: info.LastNudgeAtUnix}
 	}
-	return orchestratorInfoFor(id, displayName, refs, status, sessionID, busy, false, shell), nil
+	return orchestratorInfoFor(id, displayName, refs, status, sessionID, busy, false, shell, pacing, a.envActivitySnapshot()), nil
 }
 
 // StartOrchestrator spawns the session for a persisted orchestrator definition,
@@ -1423,7 +1471,8 @@ func (a *App) runningOrchestratorInfo(id string) (orchestratorInfo, bool) {
 		return orchestratorInfo{}, false
 	}
 	shell := orchestratorShellSnapshot{Running: session.shellRunning, Command: session.shellCommand, StartedAtUnix: session.shellStartedAtUnix}
-	return orchestratorInfoFor(session.id, session.name, session.envs, "running", session.serial, orchestratorBusySnapshot{Busy: session.aiBusy, AtUnix: session.aiBusyAtUnix}, session.transient, shell), true
+	pacing := orchestratorPacingSnapshot{NudgeCount: session.pacingNudgeCount, Capped: session.pacingCapped, LastNudgeAtUnix: session.pacingLastNudgeAtUnix}
+	return orchestratorInfoFor(session.id, session.name, session.envs, "running", session.serial, orchestratorBusySnapshot{Busy: session.aiBusy, AtUnix: session.aiBusyAtUnix}, session.transient, shell, pacing, a.envActivity), true
 }
 
 // runningOrchestratorConversation returns the conversation a live session is
@@ -1623,7 +1672,7 @@ func (a *App) spawnOrchestratorSession(spawn orchestratorSpawn) (orchestratorInf
 			log.Printf("erun-app: record open orchestrator %s: %v", id, err)
 		}
 	}
-	return orchestratorInfoFor(id, name, envs, "running", serial, orchestratorBusySnapshot{}, transient, orchestratorShellSnapshot{}), nil
+	return orchestratorInfoFor(id, name, envs, "running", serial, orchestratorBusySnapshot{}, transient, orchestratorShellSnapshot{}, orchestratorPacingSnapshot{}, a.envActivitySnapshot()), nil
 }
 
 // orchestratorRespawnFunc builds the closure tryReconnect calls when this
@@ -1681,15 +1730,17 @@ func (a *App) ListOrchestrators() []orchestratorInfo {
 		sessionID := 0
 		busy := orchestratorBusySnapshot{}
 		shell := orchestratorShellSnapshot{}
+		pacing := orchestratorPacingSnapshot{}
 		if session := a.orchestrators[config.ID]; session != nil {
 			if managed := a.sessions[orchestratorSessionKey(config.ID)]; managed != nil && !managed.closed {
 				status = "running"
 				sessionID = session.serial
 				busy = orchestratorBusySnapshot{Busy: session.aiBusy, AtUnix: session.aiBusyAtUnix}
 				shell = orchestratorShellSnapshot{Running: session.shellRunning, Command: session.shellCommand, StartedAtUnix: session.shellStartedAtUnix}
+				pacing = orchestratorPacingSnapshot{NudgeCount: session.pacingNudgeCount, Capped: session.pacingCapped, LastNudgeAtUnix: session.pacingLastNudgeAtUnix}
 			}
 		}
-		out = append(out, orchestratorInfoFor(config.ID, config.Name, config.Environments, status, sessionID, busy, false, shell))
+		out = append(out, orchestratorInfoFor(config.ID, config.Name, config.Environments, status, sessionID, busy, false, shell, pacing, a.envActivity))
 		seen[config.ID] = struct{}{}
 	}
 	for id, session := range a.orchestrators {
@@ -1701,7 +1752,8 @@ func (a *App) ListOrchestrators() []orchestratorInfo {
 			continue
 		}
 		shell := orchestratorShellSnapshot{Running: session.shellRunning, Command: session.shellCommand, StartedAtUnix: session.shellStartedAtUnix}
-		out = append(out, orchestratorInfoFor(id, session.name, session.envs, "running", session.serial, orchestratorBusySnapshot{Busy: session.aiBusy, AtUnix: session.aiBusyAtUnix}, true, shell))
+		pacing := orchestratorPacingSnapshot{NudgeCount: session.pacingNudgeCount, Capped: session.pacingCapped, LastNudgeAtUnix: session.pacingLastNudgeAtUnix}
+		out = append(out, orchestratorInfoFor(id, session.name, session.envs, "running", session.serial, orchestratorBusySnapshot{Busy: session.aiBusy, AtUnix: session.aiBusyAtUnix}, true, shell, pacing, a.envActivity))
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out

--- a/erun-ui/orchestrator_hover_state_test.go
+++ b/erun-ui/orchestrator_hover_state_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"testing"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// These cover the join orchestratorInfoFor performs against the
+// environment-activity poller's own state (environment_activity.go) and
+// against an orchestrator session's pacing state (orchestrator_pacing.go) —
+// the two sources the hover card renders without collecting anything new.
+
+func TestEnvInfosJoinsActivityByTenantAndEnvironment(t *testing.T) {
+	envs := []eruncommon.OrchestratorEnvConfig{
+		{Tenant: "petios", Environment: "rihards-review"},
+		{Tenant: "erun", Environment: "local-ideas"},
+	}
+	activity := map[string]environmentActivityState{
+		selectionKey(uiSelection{Tenant: "petios", Environment: "rihards-review"}): {
+			reachable: true, observed: true, busy: true, detail: "holding: gradle-build",
+		},
+	}
+	out := envInfos(envs, activity)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 envs, got %d", len(out))
+	}
+	if out[0].Activity == nil {
+		t.Fatalf("expected petios/rihards-review to carry a joined activity snapshot")
+	}
+	if !out[0].Activity.Busy || out[0].Activity.Detail != "holding: gradle-build" {
+		t.Fatalf("expected the busy detail to survive the join, got %+v", out[0].Activity)
+	}
+	if out[1].Activity != nil {
+		t.Fatalf("expected erun/local-ideas to have no observation yet, got %+v", out[1].Activity)
+	}
+}
+
+func TestEnvInfosDistinguishesOutageFromIdleAndUnobserved(t *testing.T) {
+	key := selectionKey(uiSelection{Tenant: "frs", Environment: "dev"})
+	envs := []eruncommon.OrchestratorEnvConfig{{Tenant: "frs", Environment: "dev"}}
+
+	outage := envInfos(envs, map[string]environmentActivityState{key: {outage: true}})
+	if outage[0].Activity == nil || !outage[0].Activity.Outage {
+		t.Fatalf("expected an outage observation to render as outage, got %+v", outage[0].Activity)
+	}
+
+	idle := envInfos(envs, map[string]environmentActivityState{key: {reachable: true, observed: true, busy: false}})
+	if idle[0].Activity == nil || idle[0].Activity.Outage || idle[0].Activity.Busy {
+		t.Fatalf("expected a reachable, observed, non-busy env to render idle, got %+v", idle[0].Activity)
+	}
+
+	unobserved := envInfos(envs, map[string]environmentActivityState{key: {reachable: true, observed: false}})
+	if unobserved[0].Activity == nil || unobserved[0].Activity.Observed {
+		t.Fatalf("expected reachable-but-unobserved to stay distinct from idle, got %+v", unobserved[0].Activity)
+	}
+}
+
+func TestOrchestratorInfoForCarriesThePacingSnapshotVerbatim(t *testing.T) {
+	info := orchestratorInfoFor("id", "name", nil, "running", 1, orchestratorBusySnapshot{}, false,
+		orchestratorShellSnapshot{}, orchestratorPacingSnapshot{NudgeCount: 3, Capped: true, LastNudgeAtUnix: 42}, nil)
+	if info.NudgeCount != 3 || !info.NudgeCapped || info.LastNudgeAtUnix != 42 {
+		t.Fatalf("expected the pacing snapshot to pass through unchanged, got %+v", info)
+	}
+}
+
+func TestOrchestratorInfoForStoppedOrchestratorReportsNeverNudged(t *testing.T) {
+	info := orchestratorInfoFor("id", "name", nil, "stopped", 0, orchestratorBusySnapshot{}, false,
+		orchestratorShellSnapshot{}, orchestratorPacingSnapshot{}, nil)
+	if info.NudgeCount != 0 || info.NudgeCapped {
+		t.Fatalf("expected a stopped orchestrator to report never-nudged, got %+v", info)
+	}
+}

--- a/erun-ui/playwright/tests/sidebar-orchestrator-hover-card-activity.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-orchestrator-hover-card-activity.spec.ts
@@ -1,0 +1,328 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ORCHESTRATOR } from '../fixtures/seedRoot.js';
+
+// #1383: the orchestrator hover card named its linked environments and said
+// nothing about either one — `Environments: petios / rihards-review, erun /
+// local-ideas`, two names, no state. Both missing signals (each environment's
+// own activity, and the orchestrator's own pacing/nudge state) are already
+// computed elsewhere in the backend (environment_activity.go's poller,
+// orchestrator_pacing.go's session state); this spec locks in the join, not
+// a new collection path — see orchestratorEnvironmentActivity.ts and
+// orchestratorNudgeSummary.ts for the reduction under test.
+//
+// Against origin/main every assertion below that checks for more than the
+// bare "tenant / environment" text fails, because orchestratorEnvInfo carried
+// no activity field at all and the card rendered nothing else.
+
+const RUNNING_SESSION_ID = 4242;
+
+function snapshot(overrides: Record<string, unknown>) {
+  return {
+    id: SEED_ORCHESTRATOR,
+    name: SEED_ORCHESTRATOR,
+    environments: [],
+    tenants: [],
+    directories: [],
+    sessionId: RUNNING_SESSION_ID,
+    status: 'running',
+    busy: false,
+    transient: false,
+    shellRunning: false,
+    shellCommand: '',
+    shellStartedAtUnix: 0,
+    nudgeCount: 0,
+    nudgeCapped: false,
+    ...overrides,
+  };
+}
+
+async function stubOrchestratorList(page: Page, body: unknown): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const parsed = JSON.parse(request.postData() ?? '{}') as { method?: string };
+    if (parsed.method === 'ListOrchestrators') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [body] }),
+      });
+    }
+    await route.continue();
+  });
+}
+
+function card(page: Page) {
+  return page.getByRole('dialog', { name: `${SEED_ORCHESTRATOR} details` });
+}
+
+test.describe('orchestrator hover card environment and pacing state (#1383)', () => {
+  test('a linked environment names what it is doing, not just its name (red-then-green)', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(
+      page,
+      snapshot({
+        environments: [
+          {
+            tenant: 'acme',
+            environment: 'build',
+            directory: '/tmp/a',
+            activity: {
+              reachable: true,
+              observed: true,
+              outage: false,
+              busy: true,
+              detail: 'holding: gradle-build',
+            },
+          },
+        ],
+      }),
+    );
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+
+    await expect(card(page)).toBeVisible();
+    await expect(card(page)).toContainText('acme / build');
+    // This is the part that fails on origin/main: the row there is just the
+    // name, with no rendered activity at all.
+    await expect(card(page)).toContainText('Busy — holding: gradle-build');
+
+    await card(page).screenshot({
+      path: '/home/erun/.erun/outputs/1383-visual/one-environment-busy.png',
+    });
+  });
+
+  test('two environments render distinct states side by side', async ({ app, page }) => {
+    await stubOrchestratorList(
+      page,
+      snapshot({
+        environments: [
+          {
+            tenant: 'acme',
+            environment: 'build',
+            directory: '/tmp/a',
+            activity: {
+              reachable: true,
+              observed: true,
+              outage: false,
+              busy: true,
+              detail: 'holding: gradle-build',
+            },
+          },
+          {
+            tenant: 'acme',
+            environment: 'prod',
+            directory: '/tmp/b',
+            activity: { reachable: true, observed: true, outage: false, busy: false },
+          },
+        ],
+      }),
+    );
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+
+    await expect(card(page)).toBeVisible();
+    await expect(card(page)).toContainText('Busy — holding: gradle-build');
+    await expect(card(page)).toContainText('Idle');
+
+    await card(page).screenshot({
+      path: '/home/erun/.erun/outputs/1383-visual/two-environments.png',
+    });
+  });
+
+  test('three environments stay scannable and each state reads distinctly, including nudge state', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(
+      page,
+      snapshot({
+        nudgeCount: 3,
+        nudgeCapped: false,
+        lastNudgeAtUnix: Math.floor(Date.now() / 1000) - 125,
+        environments: [
+          {
+            tenant: 'acme',
+            environment: 'build',
+            directory: '/tmp/a',
+            activity: {
+              reachable: true,
+              observed: true,
+              outage: false,
+              busy: true,
+              detail: 'holding: gradle-build',
+            },
+          },
+          {
+            tenant: 'acme',
+            environment: 'prod',
+            directory: '/tmp/b',
+            activity: { reachable: true, observed: true, outage: false, busy: false },
+          },
+          {
+            tenant: 'acme',
+            environment: 'staging',
+            directory: '/tmp/c',
+            activity: { reachable: true, observed: true, outage: true, busy: false },
+          },
+        ],
+      }),
+    );
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+
+    const dialog = card(page);
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Busy — holding: gradle-build');
+    await expect(dialog).toContainText('Idle');
+    await expect(dialog).toContainText('Lost connection');
+    // Nudged more than once, and not capped, is its own distinguishable state.
+    await expect(dialog).toContainText('Nudged 3x');
+
+    await card(page).screenshot({
+      path: '/home/erun/.erun/outputs/1383-visual/three-environments-and-nudges.png',
+    });
+  });
+
+  test('an environment never opened from this desktop reads unreachable, not idle', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(
+      page,
+      snapshot({
+        environments: [{ tenant: 'acme', environment: 'never-opened', directory: '/tmp/a' }],
+      }),
+    );
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+
+    const dialog = card(page);
+    await expect(dialog).toBeVisible();
+    // Scoped to the environment's own row: the card's unrelated "Doing" row
+    // legitimately says "Idle, waiting for input" about the orchestrator's
+    // own turn state, which must not be confused with this environment's
+    // activity state.
+    const environmentRow = dialog.locator('dd').filter({ hasText: 'acme / never-opened' });
+    await expect(environmentRow).toContainText('Not open here');
+    await expect(environmentRow).not.toContainText('Idle');
+
+    await dialog.screenshot({
+      path: '/home/erun/.erun/outputs/1383-visual/unreachable-environment.png',
+    });
+  });
+
+  test('an environment in outage reads distinctly from idle and unreachable', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(
+      page,
+      snapshot({
+        environments: [
+          {
+            tenant: 'acme',
+            environment: 'build',
+            directory: '/tmp/a',
+            activity: { reachable: false, observed: false, outage: true, busy: false },
+          },
+        ],
+      }),
+    );
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+
+    const dialog = card(page);
+    await expect(dialog).toBeVisible();
+    const environmentRow = dialog.locator('dd').filter({ hasText: 'acme / build' });
+    await expect(environmentRow).toContainText('Lost connection');
+    await expect(environmentRow).not.toContainText('Not open here');
+    await expect(environmentRow).not.toContainText('Idle');
+
+    await dialog.screenshot({
+      path: '/home/erun/.erun/outputs/1383-visual/outage-environment.png',
+    });
+  });
+
+  test('a long environment name and a long busy detail elide instead of blowing out the card', async ({
+    app,
+    page,
+  }) => {
+    const longEnvironment = 'a-very-long-environment-name-that-keeps-going-and-going';
+    const longDetail =
+      'holding: ' +
+      'gradle-build-with-an-unusually-long-task-name-attached-to-it '.repeat(3).trim();
+    await stubOrchestratorList(
+      page,
+      snapshot({
+        environments: [
+          {
+            tenant: 'acme',
+            environment: longEnvironment,
+            directory: '/tmp/a',
+            activity: {
+              reachable: true,
+              observed: true,
+              outage: false,
+              busy: true,
+              detail: longDetail,
+            },
+          },
+        ],
+      }),
+    );
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+
+    const dialog = card(page);
+    await expect(dialog).toBeVisible();
+    // The full strings are in the DOM (rendered, not dropped) — truncation is
+    // a CSS ellipsis, not a data loss — so the card's fixed width must not
+    // grow past the popover's own w-72.
+    await expect(dialog).toContainText(longEnvironment);
+    const cardBox = await dialog.boundingBox();
+    expect(cardBox?.width).toBeLessThan(320);
+
+    await dialog.screenshot({ path: '/home/erun/.erun/outputs/1383-visual/long-values.png' });
+  });
+
+  test('a capped orchestrator names the recovery, distinct from a session that was never nudged', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(
+      page,
+      snapshot({
+        nudgeCount: 6,
+        nudgeCapped: true,
+        lastNudgeAtUnix: Math.floor(Date.now() / 1000) - 60,
+      }),
+    );
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+
+    const dialog = card(page);
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Stopped nudging after 6 attempts');
+    await expect(dialog).toContainText('reply or restart');
+  });
+
+  test('a stopped orchestrator reports no nudge row at all', async ({ app, page }) => {
+    await stubOrchestratorList(page, snapshot({ status: 'stopped', sessionId: 0 }));
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+
+    const dialog = card(page);
+    await expect(dialog).toBeVisible();
+    await expect(dialog).not.toContainText('Nudges');
+  });
+});

--- a/erun-ui/playwright/tests/sidebar-orchestrator-hover-card-activity.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-orchestrator-hover-card-activity.spec.ts
@@ -3,7 +3,7 @@ import type { Page } from '@playwright/test';
 import { expect, test } from '../fixtures/erunApp.js';
 import { SEED_ORCHESTRATOR } from '../fixtures/seedRoot.js';
 
-// #1383: the orchestrator hover card named its linked environments and said
+// The orchestrator hover card named its linked environments and said
 // nothing about either one — `Environments: petios / rihards-review, erun /
 // local-ideas`, two names, no state. Both missing signals (each environment's
 // own activity, and the orchestrator's own pacing/nudge state) are already
@@ -55,7 +55,7 @@ function card(page: Page) {
   return page.getByRole('dialog', { name: `${SEED_ORCHESTRATOR} details` });
 }
 
-test.describe('orchestrator hover card environment and pacing state (#1383)', () => {
+test.describe('orchestrator hover card environment and pacing state', () => {
   test('a linked environment names what it is doing, not just its name (red-then-green)', async ({
     app,
     page,
@@ -313,6 +313,8 @@ test.describe('orchestrator hover card environment and pacing state (#1383)', ()
     await expect(dialog).toBeVisible();
     await expect(dialog).toContainText('Stopped nudging after 6 attempts');
     await expect(dialog).toContainText('reply or restart');
+
+    await dialog.screenshot({ path: '/home/erun/.erun/outputs/1383-visual/capped-nudge.png' });
   });
 
   test('a stopped orchestrator reports no nudge row at all', async ({ app, page }) => {


### PR DESCRIPTION
## Summary

The one surface an operator hovers to answer *"is anything actually happening?"*
could not answer it. It listed environment names and stopped:

```tsx
{env.tenant} / {env.environment}
```

This was a **join, not new collection** — the state was already being computed
and simply never reached the card.

## What the card shows now

```
Status        Running
Doing         Idle, waiting for input
Environments  ◉ acme / build      Busy — holding: gradle-build
              ● acme / prod       Idle
              ⚠ acme / staging    Lost connection
Nudges        Nudged 3x, last 2m5s ago
```

`environment_activity.go`'s `detail` field is now used for exactly what its own
comment said it existed for — *"names what is keeping the environment busy, in
the operator's language, so the row can say 'held by gradle-build' rather than
'busy'"*. Nothing new is collected; the existing 20s sweep already produced all
of it.

Unreachable reads as **Lost connection**, distinct from **Idle** — collapsing
those two was the specific way the old card lied by omission. Every row carries
an icon *and* a text label, so colour is never the only signal, and long
environment names and long `detail` strings elide rather than blow out the card.

## What is deliberately not on the card, and why

**Live CPU/memory usage.** The issue listed it as already computed, and that is
true of the *value* but not of its cost: `LoadRuntimeUsage`
(`erun-ui/runtime_usage.go:33`) is an **on-demand probe bounded at 10 seconds,
per environment**, not a maintained figure from a sweep. Joining it would fire
one bounded pod probe per listed environment every time an operator hovers an
orchestrator row — turning a glance into a fan-out, and making the hover slow
exactly when the environments are unhealthy.

A hover card is a glance. Putting usage here honestly requires a cached or
swept usage value first, which is a different change; it is not something to
half-do behind a spinner in a popover.

## Verification

Red-then-green for the join; each state asserted to render distinctly, in
particular that unreachable does not read as idle; long-value behaviour asserted
for both a long environment name and a long `detail`. Playwright coverage in
this PR. Screenshots for one, two and three environments, busy-with-named-holder,
unreachable, outage, capped nudges, and long values.

## Docs

`erun-docs/docs/desktop/overview.md`, in this PR per `AGENTS.md` § Working Rules.

## A note on how this branch went

The first run of this work backgrounded its gate and ended its turn — *"I'll
wait for the background task notification before continuing"* — recording
**exit 0** with nothing gated and nothing pushed, while its three commits sat in
the clone. That is precisely the false-success mode #1374 was filed for, and it
happened while the fix for it (`68327f8c`) was merging. Worth recording as
evidence that the detection landing today is not theoretical.

Closes #1383
