### PR TITLE
Give the platform outbound mail, and make enrollment work whether or not it has any

### DIFF
--- a/erun-backend/erun-backend-api/internal/routes/identity.go
+++ b/erun-backend/erun-backend-api/internal/routes/identity.go
@@ -22,6 +22,8 @@ type IdentityAdminClient interface {
 	ReactivateUser(ctx context.Context, userID string) error
 	GetOrgSettings(ctx context.Context) (zitadel.OrgSettings, error)
 	UpdateOrgSettings(ctx context.Context, params zitadel.UpdateOrgSettingsParams) (zitadel.OrgSettings, error)
+	GetSMTPStatus(ctx context.Context) (zitadel.SMTPStatus, error)
+	UpdateSMTPConfig(ctx context.Context, params zitadel.SetSMTPConfigParams) (zitadel.SMTPStatus, error)
 }
 
 // IdentityEnroller creates an IdP identity and its erun user mapping as one
@@ -54,6 +56,12 @@ func RegisterIdentityRoutes(register ProtectedRouteRegistrar, admin IdentityAdmi
 	register(http.MethodPost, "/v1/identity/users/{external_id}/reactivate", http.HandlerFunc(routes.reactivateUser))
 	register(http.MethodGet, "/v1/identity/org-settings", http.HandlerFunc(routes.getOrgSettings))
 	register(http.MethodPatch, "/v1/identity/org-settings", http.HandlerFunc(routes.updateOrgSettings))
+	// The platform's honest answer to "can this instance send mail at all"
+	// (issue #1168): every flow that reaches a user out of band -- signup
+	// verification, password reset, invitation -- depends on it, and until
+	// this the only signal was Zitadel's own unhandled 404.
+	register(http.MethodGet, "/v1/identity/smtp-settings", http.HandlerFunc(routes.getSMTPSettings))
+	register(http.MethodPatch, "/v1/identity/smtp-settings", http.HandlerFunc(routes.updateSMTPSettings))
 }
 
 var errIdentityAdminForbidden = errors.New("identity administration is restricted to an operations tenant")
@@ -107,10 +115,37 @@ type enrollIdentityUserRequest struct {
 // failed after the IdP user was created — the "which half landed" report
 // the enrollment flow must give rather than either silently swallowing the
 // failure or claiming full success.
+//
+// MailDeliveryConfigured/TemporaryPassword/Warning report the other half of
+// what actually landed (issue #1168): a caller cannot tell "invited, check
+// your inbox" apart from "invited, but nothing could ever be sent" from
+// IdPUser alone, and the difference is exactly which action the operator
+// needs to take next.
 type enrollIdentityUserResponse struct {
-	IdPUser  zitadel.User `json:"idpUser"`
-	ErunUser *model.User  `json:"erunUser,omitempty"`
-	Error    string       `json:"error,omitempty"`
+	IdPUser                zitadel.User `json:"idpUser"`
+	ErunUser               *model.User  `json:"erunUser,omitempty"`
+	Error                  string       `json:"error,omitempty"`
+	MailDeliveryConfigured bool         `json:"mailDeliveryConfigured"`
+	TemporaryPassword      string       `json:"temporaryPassword,omitempty"`
+	Warning                string       `json:"warning,omitempty"`
+}
+
+// newEnrollIdentityUserResponse fills the mail-delivery half of the
+// response from an EnrollIdentityResult. When mail delivery was not
+// configured, Enroll already minted a temporary password instead of the
+// usual invite email; this is what tells the caller the invite link they
+// might otherwise expect will never arrive, and gives them the credential
+// to hand over instead.
+func newEnrollIdentityUserResponse(result service.EnrollIdentityResult) enrollIdentityUserResponse {
+	resp := enrollIdentityUserResponse{
+		IdPUser:                result.IdPUser,
+		MailDeliveryConfigured: result.MailDeliveryConfigured,
+		TemporaryPassword:      result.TemporaryPassword,
+	}
+	if !result.MailDeliveryConfigured {
+		resp.Warning = "This platform's identity provider has no SMTP configured, so no invitation email was sent. Share temporaryPassword with " + result.IdPUser.Username + " directly; they must sign in and change it."
+	}
+	return resp
 }
 
 func (r IdentityRoutes) createUser(w http.ResponseWriter, req *http.Request) {
@@ -143,13 +178,17 @@ func (r IdentityRoutes) createUser(w http.ResponseWriter, req *http.Request) {
 			// both halves rather than a bare 500, so the operator can see the
 			// orphaned IdP user id and retry the mapping (POST /v1/users with
 			// that id as subject) instead of enrolling a duplicate.
-			writeJSON(w, http.StatusCreated, enrollIdentityUserResponse{IdPUser: result.IdPUser, Error: err.Error()})
+			resp := newEnrollIdentityUserResponse(result)
+			resp.Error = err.Error()
+			writeJSON(w, http.StatusCreated, resp)
 			return
 		}
 		writeIdentityAdminError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusCreated, enrollIdentityUserResponse{IdPUser: result.IdPUser, ErunUser: &result.ErunUser})
+	resp := newEnrollIdentityUserResponse(result)
+	resp.ErunUser = &result.ErunUser
+	writeJSON(w, http.StatusCreated, resp)
 }
 
 func (r IdentityRoutes) deactivateUser(w http.ResponseWriter, req *http.Request) {
@@ -221,6 +260,66 @@ func (r IdentityRoutes) updateOrgSettings(w http.ResponseWriter, req *http.Reque
 		return
 	}
 	writeJSON(w, http.StatusOK, settings)
+}
+
+// getSMTPSettings answers "can this instance send mail at all" (issue
+// #1168) directly, rather than leaving Zitadel's own unhandled 404 as the
+// only signal.
+func (r IdentityRoutes) getSMTPSettings(w http.ResponseWriter, req *http.Request) {
+	if _, ok := r.securityContext(w, req); !ok {
+		return
+	}
+	status, err := r.admin.GetSMTPStatus(req.Context())
+	if err != nil {
+		writeIdentityAdminError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, status)
+}
+
+// updateSMTPSettingsRequest is the declarative desired state for the
+// platform's outbound mail (issue #1168), provider-agnostic and sourced
+// from wherever the operator holds the credential out of band; Password is
+// omitted on an update that only changes non-secret fields.
+type updateSMTPSettingsRequest struct {
+	Host           string `json:"host"`
+	Username       string `json:"username"`
+	Password       string `json:"password,omitempty"`
+	SenderAddress  string `json:"senderAddress"`
+	SenderName     string `json:"senderName,omitempty"`
+	ReplyToAddress string `json:"replyToAddress,omitempty"`
+	TLS            bool   `json:"tls"`
+}
+
+func (r IdentityRoutes) updateSMTPSettings(w http.ResponseWriter, req *http.Request) {
+	if _, ok := r.securityContext(w, req); !ok {
+		return
+	}
+	var body updateSMTPSettingsRequest
+	if err := decodeJSON(req, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	host := strings.TrimSpace(body.Host)
+	senderAddress := strings.TrimSpace(body.SenderAddress)
+	if host == "" || senderAddress == "" {
+		writeError(w, http.StatusBadRequest, "host and senderAddress are required")
+		return
+	}
+	status, err := r.admin.UpdateSMTPConfig(req.Context(), zitadel.SetSMTPConfigParams{
+		Host:           host,
+		User:           strings.TrimSpace(body.Username),
+		Password:       body.Password,
+		SenderAddress:  senderAddress,
+		SenderName:     strings.TrimSpace(body.SenderName),
+		ReplyToAddress: strings.TrimSpace(body.ReplyToAddress),
+		TLS:            body.TLS,
+	})
+	if err != nil {
+		writeIdentityAdminError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, status)
 }
 
 // writeIdentityAdminError forwards a Zitadel Management API error's real

--- a/erun-backend/erun-backend-api/internal/routes/identity_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/identity_test.go
@@ -24,6 +24,10 @@ type stubIdentityAdminClient struct {
 	getSettingsErr    error
 	updateSettingsErr error
 	gotUpdateParams   zitadel.UpdateOrgSettingsParams
+	smtpStatus        zitadel.SMTPStatus
+	getSMTPErr        error
+	updateSMTPErr     error
+	gotSMTPParams     zitadel.SetSMTPConfigParams
 }
 
 func (s *stubIdentityAdminClient) ListUsers(context.Context) ([]zitadel.User, error) {
@@ -47,6 +51,15 @@ func (s *stubIdentityAdminClient) GetOrgSettings(context.Context) (zitadel.OrgSe
 func (s *stubIdentityAdminClient) UpdateOrgSettings(_ context.Context, params zitadel.UpdateOrgSettingsParams) (zitadel.OrgSettings, error) {
 	s.gotUpdateParams = params
 	return s.settings, s.updateSettingsErr
+}
+
+func (s *stubIdentityAdminClient) GetSMTPStatus(context.Context) (zitadel.SMTPStatus, error) {
+	return s.smtpStatus, s.getSMTPErr
+}
+
+func (s *stubIdentityAdminClient) UpdateSMTPConfig(_ context.Context, params zitadel.SetSMTPConfigParams) (zitadel.SMTPStatus, error) {
+	s.gotSMTPParams = params
+	return s.smtpStatus, s.updateSMTPErr
 }
 
 type stubIdentityEnroller struct {
@@ -196,5 +209,106 @@ func TestUpdateOrgSettingsPassesOnlyProvidedFields(t *testing.T) {
 	}
 	if admin.gotUpdateParams.MinPasswordLength != nil {
 		t.Fatalf("gotUpdateParams.MinPasswordLength = %v, want nil when not provided", admin.gotUpdateParams.MinPasswordLength)
+	}
+}
+
+// TestCreateUserReportsMailNotConfiguredWithATemporaryPassword locks the
+// honest-failure behaviour (issue #1168): when Enroll reports mail delivery
+// as unconfigured, the response must carry the temporary password and a
+// warning explaining why, not silently look identical to a normal invite.
+func TestCreateUserReportsMailNotConfiguredWithATemporaryPassword(t *testing.T) {
+	enroller := &stubIdentityEnroller{result: service.EnrollIdentityResult{
+		IdPUser:                zitadel.User{ID: "idp-5", Username: "erin"},
+		ErunUser:               model.User{UserID: "erun-5", Username: "erin"},
+		MailDeliveryConfigured: false,
+		TemporaryPassword:      "Ertemp12345!",
+	}}
+	routes := IdentityRoutes{enroller: enroller}
+	rec := httptest.NewRecorder()
+	routes.createUser(rec, identityRequest(http.MethodPost, "/v1/identity/users", `{"username":"erin","email":"erin@example.com"}`, string(model.TenantTypeOperations)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("Ertemp12345!")) {
+		t.Fatalf("body = %s, want the temporary password reported", rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("\"mailDeliveryConfigured\":false")) {
+		t.Fatalf("body = %s, want mailDeliveryConfigured:false reported", rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("warning")) {
+		t.Fatalf("body = %s, want a warning explaining no invitation email was sent", rec.Body.String())
+	}
+}
+
+// TestCreateUserReportsMailConfiguredWithNoWarning is the positive-path
+// counterpart: a normal invite carries no warning and no password.
+func TestCreateUserReportsMailConfiguredWithNoWarning(t *testing.T) {
+	enroller := &stubIdentityEnroller{result: service.EnrollIdentityResult{
+		IdPUser:                zitadel.User{ID: "idp-6", Username: "frank"},
+		ErunUser:               model.User{UserID: "erun-6", Username: "frank"},
+		MailDeliveryConfigured: true,
+	}}
+	routes := IdentityRoutes{enroller: enroller}
+	rec := httptest.NewRecorder()
+	routes.createUser(rec, identityRequest(http.MethodPost, "/v1/identity/users", `{"username":"frank","email":"frank@example.com"}`, string(model.TenantTypeOperations)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	if bytes.Contains(rec.Body.Bytes(), []byte("warning")) {
+		t.Fatalf("body = %s, want no warning when mail delivery is configured", rec.Body.String())
+	}
+	if bytes.Contains(rec.Body.Bytes(), []byte("temporaryPassword")) {
+		t.Fatalf("body = %s, want no temporaryPassword field when mail delivery is configured", rec.Body.String())
+	}
+}
+
+func TestGetSMTPSettingsForbidsNonOperationsTenant(t *testing.T) {
+	admin := &stubIdentityAdminClient{}
+	routes := IdentityRoutes{admin: admin}
+	rec := httptest.NewRecorder()
+	routes.getSMTPSettings(rec, identityRequest(http.MethodGet, "/v1/identity/smtp-settings", "", string(model.TenantTypeCompany)))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+// TestGetSMTPSettingsReportsUnconfigured locks the visibility fix (issue
+// #1168): the platform must be able to report "mail is not configured"
+// through this surface, cleanly, rather than only via Zitadel's own
+// unhandled 404.
+func TestGetSMTPSettingsReportsUnconfigured(t *testing.T) {
+	admin := &stubIdentityAdminClient{smtpStatus: zitadel.SMTPStatus{Configured: false}}
+	routes := IdentityRoutes{admin: admin}
+	rec := httptest.NewRecorder()
+	routes.getSMTPSettings(rec, identityRequest(http.MethodGet, "/v1/identity/smtp-settings", "", string(model.TenantTypeOperations)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("\"configured\":false")) {
+		t.Fatalf("body = %s, want configured:false reported", rec.Body.String())
+	}
+}
+
+func TestUpdateSMTPSettingsRejectsMissingFields(t *testing.T) {
+	admin := &stubIdentityAdminClient{}
+	routes := IdentityRoutes{admin: admin}
+	rec := httptest.NewRecorder()
+	routes.updateSMTPSettings(rec, identityRequest(http.MethodPatch, "/v1/identity/smtp-settings", `{"username":"erun"}`, string(model.TenantTypeOperations)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for a missing host/senderAddress", rec.Code)
+	}
+}
+
+func TestUpdateSMTPSettingsPassesDeclaredFields(t *testing.T) {
+	admin := &stubIdentityAdminClient{smtpStatus: zitadel.SMTPStatus{Configured: true}}
+	routes := IdentityRoutes{admin: admin}
+	rec := httptest.NewRecorder()
+	body := `{"host":"smtp.example.com:587","username":"erun","password":"s3cret","senderAddress":"noreply@example.com","senderName":"Erun Platform","tls":true}`
+	routes.updateSMTPSettings(rec, identityRequest(http.MethodPatch, "/v1/identity/smtp-settings", body, string(model.TenantTypeOperations)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if admin.gotSMTPParams.Host != "smtp.example.com:587" || admin.gotSMTPParams.Password != "s3cret" || !admin.gotSMTPParams.TLS {
+		t.Fatalf("gotSMTPParams = %+v, want the declared fields passed through", admin.gotSMTPParams)
 	}
 }

--- a/erun-backend/erun-backend-api/internal/service/identity.go
+++ b/erun-backend/erun-backend-api/internal/service/identity.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	cryptorand "crypto/rand"
 	"errors"
 	"fmt"
 
@@ -14,6 +15,7 @@ import (
 // needs. *zitadel.Client satisfies it; tests supply a stub.
 type IdentityAdmin interface {
 	CreateHumanUser(ctx context.Context, params zitadel.CreateHumanUserParams) (zitadel.User, error)
+	GetSMTPStatus(ctx context.Context) (zitadel.SMTPStatus, error)
 }
 
 // IdentityUserCreator is the erun-side half of enrollment: creating the
@@ -61,9 +63,20 @@ type EnrollIdentityParams struct {
 // value when the erun-side mapping failed after the IdP user was created;
 // IdPUser is still populated so the caller can report the orphaned IdP
 // identity precisely rather than as an opaque failure.
+//
+// MailDeliveryConfigured and TemporaryPassword report the other half of
+// what actually landed (issue #1168): when the platform's IdP has no SMTP
+// configured, Zitadel's own invitation email can never arrive, so Enroll
+// does not create the usual passwordless, email-pending account -- it mints
+// a random initial password instead and reports it here, once, for the
+// caller to hand to the enrollee out of band. TemporaryPassword is empty
+// whenever MailDeliveryConfigured is true (the normal invite-email flow
+// ran instead).
 type EnrollIdentityResult struct {
-	IdPUser  zitadel.User
-	ErunUser model.User
+	IdPUser                zitadel.User
+	ErunUser               model.User
+	MailDeliveryConfigured bool
+	TemporaryPassword      string
 }
 
 // Enroll creates the IdP identity first — the erun mapping needs the
@@ -72,13 +85,34 @@ type EnrollIdentityResult struct {
 // external-identity mapping using that subject. A failure after the IdP
 // user exists is reported as ErrIdentityMappingFailed with the created
 // IdPUser still attached, rather than as an opaque enrollment failure.
+//
+// Before creating the IdP identity, it checks whether the platform can
+// actually send mail at all (issue #1168). When it cannot, Zitadel's usual
+// invite-by-email flow would create an account stuck in USER_STATE_INITIAL
+// forever, waiting on a link nothing will ever send -- a success response
+// that silently does nothing, exactly the dead end this checks for. A
+// failed or inconclusive SMTP status check is treated the same as
+// "unconfigured": assuming mail works when it might not risks the exact
+// same dead end, while the temporary-password fallback always leaves the
+// account usable regardless.
 func (s *IdentityService) Enroll(ctx context.Context, params EnrollIdentityParams) (EnrollIdentityResult, error) {
-	idpUser, err := s.admin.CreateHumanUser(ctx, zitadel.CreateHumanUserParams{
+	mailStatus, _ := s.admin.GetSMTPStatus(ctx)
+
+	createParams := zitadel.CreateHumanUserParams{
 		Username:  params.Username,
 		Email:     params.Email,
 		FirstName: params.FirstName,
 		LastName:  params.LastName,
-	})
+	}
+	if !mailStatus.Configured {
+		temporaryPassword, err := generateTemporaryPassword()
+		if err != nil {
+			return EnrollIdentityResult{}, fmt.Errorf("generate temporary password for a no-mail enrollment: %w", err)
+		}
+		createParams.InitialPassword = temporaryPassword
+	}
+
+	idpUser, err := s.admin.CreateHumanUser(ctx, createParams)
 	if err != nil {
 		return EnrollIdentityResult{}, fmt.Errorf("create identity provider user: %w", err)
 	}
@@ -89,7 +123,34 @@ func (s *IdentityService) Enroll(ctx context.Context, params EnrollIdentityParam
 		Subject:  idpUser.ID,
 	})
 	if err != nil {
-		return EnrollIdentityResult{IdPUser: idpUser}, fmt.Errorf("%w: idp user id %s: %w", ErrIdentityMappingFailed, idpUser.ID, err)
+		return EnrollIdentityResult{IdPUser: idpUser, MailDeliveryConfigured: mailStatus.Configured, TemporaryPassword: createParams.InitialPassword}, fmt.Errorf("%w: idp user id %s: %w", ErrIdentityMappingFailed, idpUser.ID, err)
 	}
-	return EnrollIdentityResult{IdPUser: idpUser, ErunUser: erunUser}, nil
+	return EnrollIdentityResult{
+		IdPUser:                idpUser,
+		ErunUser:               erunUser,
+		MailDeliveryConfigured: mailStatus.Configured,
+		TemporaryPassword:      createParams.InitialPassword,
+	}, nil
+}
+
+// temporaryPasswordAlphabet excludes visually ambiguous characters (0/O,
+// 1/l/I) since this password is meant to be read aloud or retyped by an
+// operator handing it to an enrollee out of band.
+const temporaryPasswordAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789"
+
+// generateTemporaryPassword mints a random password satisfying Zitadel's
+// default complexity policy (upper, lower, digit, symbol), the same shape
+// the erun-zitadel chart already generates for its own bootstrap admin
+// password.
+func generateTemporaryPassword() (string, error) {
+	const randomLength = 20
+	raw := make([]byte, randomLength)
+	if _, err := cryptorand.Read(raw); err != nil {
+		return "", fmt.Errorf("read random bytes: %w", err)
+	}
+	chars := make([]byte, randomLength)
+	for i, b := range raw {
+		chars[i] = temporaryPasswordAlphabet[int(b)%len(temporaryPasswordAlphabet)]
+	}
+	return fmt.Sprintf("Er%s!", string(chars)), nil
 }

--- a/erun-backend/erun-backend-api/internal/service/identity_test.go
+++ b/erun-backend/erun-backend-api/internal/service/identity_test.go
@@ -11,9 +11,11 @@ import (
 )
 
 type stubIdentityAdmin struct {
-	created   zitadel.User
-	err       error
-	gotParams zitadel.CreateHumanUserParams
+	created       zitadel.User
+	err           error
+	gotParams     zitadel.CreateHumanUserParams
+	smtpStatus    zitadel.SMTPStatus
+	smtpStatusErr error
 }
 
 func (s *stubIdentityAdmin) CreateHumanUser(_ context.Context, params zitadel.CreateHumanUserParams) (zitadel.User, error) {
@@ -22,6 +24,10 @@ func (s *stubIdentityAdmin) CreateHumanUser(_ context.Context, params zitadel.Cr
 		return zitadel.User{}, s.err
 	}
 	return s.created, nil
+}
+
+func (s *stubIdentityAdmin) GetSMTPStatus(context.Context) (zitadel.SMTPStatus, error) {
+	return s.smtpStatus, s.smtpStatusErr
 }
 
 type stubIdentityUserCreator struct {
@@ -39,7 +45,10 @@ func (s *stubIdentityUserCreator) Create(_ context.Context, params repository.Cr
 }
 
 func TestIdentityServiceEnrollHappyPath(t *testing.T) {
-	admin := &stubIdentityAdmin{created: zitadel.User{ID: "idp-1", Username: "alice", Email: "alice@example.com"}}
+	admin := &stubIdentityAdmin{
+		created:    zitadel.User{ID: "idp-1", Username: "alice", Email: "alice@example.com"},
+		smtpStatus: zitadel.SMTPStatus{Configured: true},
+	}
 	users := &stubIdentityUserCreator{created: model.User{UserID: "erun-1", Username: "alice"}}
 	svc := NewIdentityService(admin, users)
 
@@ -52,8 +61,64 @@ func TestIdentityServiceEnrollHappyPath(t *testing.T) {
 	if result.IdPUser.ID != "idp-1" || result.ErunUser.UserID != "erun-1" {
 		t.Fatalf("result = %+v", result)
 	}
+	if !result.MailDeliveryConfigured || result.TemporaryPassword != "" {
+		t.Fatalf("result = %+v, want mail delivery reported configured and no temporary password", result)
+	}
+	if admin.gotParams.InitialPassword != "" {
+		t.Fatalf("gotParams.InitialPassword = %q, want empty when mail delivery is configured (the normal invite-email flow)", admin.gotParams.InitialPassword)
+	}
 	if users.gotParams.Subject != "idp-1" || users.gotParams.Issuer != "https://auth.example.com" {
 		t.Fatalf("erun user create params = %+v, want the IdP's own id as subject and the caller's issuer", users.gotParams)
+	}
+}
+
+// TestIdentityServiceEnrollFallsBackToATemporaryPasswordWithNoMail locks the
+// no-SMTP fallback (issue #1168): the platform's IdP cannot send the usual
+// invite email, so Enroll must not create the usual passwordless account --
+// stuck in USER_STATE_INITIAL forever, waiting on a link nothing will ever
+// send -- and must instead report a temporary password the caller can hand
+// to the enrollee directly.
+func TestIdentityServiceEnrollFallsBackToATemporaryPasswordWithNoMail(t *testing.T) {
+	admin := &stubIdentityAdmin{
+		created:    zitadel.User{ID: "idp-3", Username: "carol", Email: "carol@example.com"},
+		smtpStatus: zitadel.SMTPStatus{Configured: false},
+	}
+	users := &stubIdentityUserCreator{created: model.User{UserID: "erun-3", Username: "carol"}}
+	svc := NewIdentityService(admin, users)
+
+	result, err := svc.Enroll(context.Background(), EnrollIdentityParams{Username: "carol", Email: "carol@example.com"})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if result.MailDeliveryConfigured {
+		t.Fatalf("result.MailDeliveryConfigured = true, want false when SMTP is unconfigured")
+	}
+	if result.TemporaryPassword == "" {
+		t.Fatal("result.TemporaryPassword is empty, want a generated password to hand to the enrollee")
+	}
+	if admin.gotParams.InitialPassword != result.TemporaryPassword {
+		t.Fatalf("gotParams.InitialPassword = %q, want it to match the password reported to the caller (%q)", admin.gotParams.InitialPassword, result.TemporaryPassword)
+	}
+}
+
+// TestIdentityServiceEnrollTreatsAnUncheckableSMTPStatusAsUnconfigured locks
+// that a failed status check defaults to the safe fallback rather than
+// assuming mail works: claiming success on an invite email that was never
+// actually confirmed deliverable is the exact dead end this issue is about.
+func TestIdentityServiceEnrollTreatsAnUncheckableSMTPStatusAsUnconfigured(t *testing.T) {
+	admin := &stubIdentityAdmin{
+		created:       zitadel.User{ID: "idp-4", Username: "dave", Email: "dave@example.com"},
+		smtpStatusErr: errors.New("zitadel admin api unreachable"),
+	}
+	users := &stubIdentityUserCreator{created: model.User{UserID: "erun-4", Username: "dave"}}
+	svc := NewIdentityService(admin, users)
+
+	result, err := svc.Enroll(context.Background(), EnrollIdentityParams{Username: "dave", Email: "dave@example.com"})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if result.TemporaryPassword == "" {
+		t.Fatal("result.TemporaryPassword is empty, want the safe fallback when SMTP status could not be checked")
 	}
 }
 

--- a/erun-backend/erun-backend-api/internal/zitadel/client.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/client.go
@@ -220,17 +220,30 @@ func (c *Client) ListUsers(ctx context.Context) ([]User, error) {
 }
 
 // CreateHumanUserParams is the enrollment input for a new IdP identity.
+// InitialPassword is empty for Zitadel's normal invite flow: no password is
+// set, so Zitadel emails the enrollee a verification/initialization link
+// rather than this client (or its caller) ever handling a credential for
+// someone else's account. When the platform cannot send that email at all
+// (issue #1168), the caller sets InitialPassword instead -- verified live
+// against a real Zitadel v4.15.3 instance that AddHumanUser only sends the
+// initialization email "if either the email address is not marked as
+// verified or no password is set" (its own API doc comment), so a set
+// password alone still leaves the account in USER_STATE_INITIAL waiting on
+// a link that will never arrive; CreateHumanUser accordingly marks the email
+// verified in that case too, and only in that case, which is what actually
+// lands the account in USER_STATE_ACTIVE with the password usable
+// immediately.
 type CreateHumanUserParams struct {
-	Username  string
-	Email     string
-	FirstName string
-	LastName  string
+	Username        string
+	Email           string
+	FirstName       string
+	LastName        string
+	InitialPassword string
 }
 
-// CreateHumanUser creates a new human user via Zitadel's invite flow: no
-// password is set here, so Zitadel emails the enrollee a verification/
-// initialization link rather than this client (or its caller) ever handling
-// a credential for someone else's account.
+// CreateHumanUser creates a new human user in Zitadel. See
+// CreateHumanUserParams.InitialPassword for the two distinct outcomes this
+// produces.
 func (c *Client) CreateHumanUser(ctx context.Context, params CreateHumanUserParams) (User, error) {
 	username := strings.TrimSpace(params.Username)
 	email := strings.TrimSpace(params.Email)
@@ -245,6 +258,7 @@ func (c *Client) CreateHumanUser(ctx context.Context, params CreateHumanUserPara
 	if lastName == "" {
 		lastName = username
 	}
+	hasInitialPassword := params.InitialPassword != ""
 	body := map[string]any{
 		"userName": username,
 		"profile": map[string]any{
@@ -253,8 +267,11 @@ func (c *Client) CreateHumanUser(ctx context.Context, params CreateHumanUserPara
 		},
 		"email": map[string]any{
 			"email":           email,
-			"isEmailVerified": false,
+			"isEmailVerified": hasInitialPassword,
 		},
+	}
+	if hasInitialPassword {
+		body["initialPassword"] = params.InitialPassword
 	}
 	var resp struct {
 		UserID string `json:"userId"`
@@ -262,13 +279,17 @@ func (c *Client) CreateHumanUser(ctx context.Context, params CreateHumanUserPara
 	if err := c.call(ctx, http.MethodPost, "/management/v1/users/human", body, &resp); err != nil {
 		return User{}, err
 	}
+	state := "USER_STATE_INITIAL"
+	if hasInitialPassword {
+		state = "USER_STATE_ACTIVE"
+	}
 	return User{
 		ID:        resp.UserID,
 		Username:  username,
 		Email:     email,
 		FirstName: firstName,
 		LastName:  lastName,
-		State:     "USER_STATE_INITIAL",
+		State:     state,
 	}, nil
 }
 

--- a/erun-backend/erun-backend-api/internal/zitadel/client_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/client_e2e_test.go
@@ -200,6 +200,15 @@ func e2eConfiguresSMTPAndSkipsTheEmailFlow(t *testing.T, ctx context.Context, cl
 		t.Fatal("GetSMTPStatus never reported the just-activated config within the deadline")
 	}
 
+	e2eVerifiesSMTPSinkDelivery(t, ctx, client)
+}
+
+// e2eVerifiesSMTPSinkDelivery proves an actual message was produced and
+// accepted, not merely that a config object was written: it creates a real
+// invite and polls the sink's own message API for the resulting message.
+// Skips cleanly when ERUN_E2E_ZITADEL_SMTP_SINK_API is unset.
+func e2eVerifiesSMTPSinkDelivery(t *testing.T, ctx context.Context, client *Client) {
+	t.Helper()
 	sinkAPI := strings.TrimSpace(os.Getenv("ERUN_E2E_ZITADEL_SMTP_SINK_API"))
 	if sinkAPI == "" {
 		t.Log("ERUN_E2E_ZITADEL_SMTP_SINK_API unset; not verifying actual message delivery")

--- a/erun-backend/erun-backend-api/internal/zitadel/client_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/client_e2e_test.go
@@ -2,7 +2,9 @@ package zitadel
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -58,6 +60,15 @@ import (
 //	ERUN_E2E_ZITADEL_EXTERNAL_DOMAIN=localhost \
 //	ERUN_E2E_ZITADEL_PAT_PATH=/tmp/admin-sa.pat \
 //	  go test ./internal/zitadel/... -run TestClientAgainstRealZitadel -v
+//
+// Two more variables (issue #1168) additionally exercise the SMTP
+// configuration path against a real local SMTP sink, e.g. mailhog on the
+// same docker network as the Zitadel core container above:
+//
+//	docker run -d --name mailhog --network erun-zitadel-e2e-net mailhog/mailhog
+//	ERUN_E2E_ZITADEL_SMTP_HOST=mailhog:1025 \
+//	ERUN_E2E_ZITADEL_SMTP_SINK_API=http://localhost:8025 \
+//	  go test ./internal/zitadel/... -run TestClientAgainstRealZitadel -v
 func TestClientAgainstRealZitadel(t *testing.T) {
 	baseURL := strings.TrimSpace(os.Getenv("ERUN_E2E_ZITADEL_BASE_URL"))
 	externalDomain := strings.TrimSpace(os.Getenv("ERUN_E2E_ZITADEL_EXTERNAL_DOMAIN"))
@@ -76,6 +87,7 @@ func TestClientAgainstRealZitadel(t *testing.T) {
 	created := e2eCreateAndListUser(t, ctx, client)
 	e2eRefusesDeactivatingAnInitialUser(t, ctx, client, created.ID)
 	e2eUpdatesOrgSettings(t, ctx, client)
+	e2eConfiguresSMTPAndSkipsTheEmailFlow(t, ctx, client)
 }
 
 func e2eCreateAndListUser(t *testing.T, ctx context.Context, client *Client) User {
@@ -139,6 +151,116 @@ func e2eUpdatesOrgSettings(t *testing.T, ctx context.Context, client *Client) {
 	if _, err := client.UpdateOrgSettings(ctx, UpdateOrgSettingsParams{ForceMFA: &forceMFA}); err != nil {
 		t.Fatalf("UpdateOrgSettings (restore): %v", err)
 	}
+}
+
+// e2eConfiguresSMTPAndSkipsTheEmailFlow proves GetSMTPStatus/UpdateSMTPConfig
+// against a real Zitadel Admin API (issue #1168): the instance this test
+// runs against starts with no SMTP config at all (Zitadel's own 404, the
+// issue's exact starting point), so this converges one against
+// ERUN_E2E_ZITADEL_SMTP_HOST (point it at a local SMTP sink such as
+// mailhog, e.g. "localhost:1025") and confirms GetSMTPStatus reports it
+// active. When ERUN_E2E_ZITADEL_SMTP_SINK_API also names that sink's own
+// message API (mailhog's "http://localhost:8025"), it additionally proves an
+// actual message was produced and accepted -- not merely that a config
+// object was written -- by creating a real invite and polling the sink for
+// the resulting message. Both are optional and skip cleanly when unset,
+// matching this repository's convention for a gate that needs real
+// infrastructure.
+func e2eConfiguresSMTPAndSkipsTheEmailFlow(t *testing.T, ctx context.Context, client *Client) {
+	t.Helper()
+	smtpHost := strings.TrimSpace(os.Getenv("ERUN_E2E_ZITADEL_SMTP_HOST"))
+	if smtpHost == "" {
+		t.Log("ERUN_E2E_ZITADEL_SMTP_HOST unset; skipping the SMTP configuration e2e step")
+		return
+	}
+
+	if _, err := client.GetSMTPStatus(ctx); err != nil {
+		t.Fatalf("GetSMTPStatus (initial): %v", err)
+	}
+
+	updated, err := client.UpdateSMTPConfig(ctx, SetSMTPConfigParams{
+		Host: smtpHost, User: "erun", Password: "unused-by-a-local-sink",
+		SenderAddress: "noreply@erun.local", SenderName: "Erun Platform E2E", TLS: false,
+	})
+	if err != nil {
+		t.Fatalf("UpdateSMTPConfig: %v", err)
+	}
+	if !updated.Configured || updated.Config.Host != smtpHost {
+		t.Fatalf("UpdateSMTPConfig result = %+v, want Configured with host %q", updated, smtpHost)
+	}
+
+	// Zitadel's query side is eventually consistent with the command that
+	// just activated this config (confirmed live: a read immediately after
+	// activation can still 404 for a few seconds), so this polls rather than
+	// asserting on the first read.
+	if !e2ePollUntil(t, 15*time.Second, func() bool {
+		status, err := client.GetSMTPStatus(ctx)
+		return err == nil && status.Configured
+	}) {
+		t.Fatal("GetSMTPStatus never reported the just-activated config within the deadline")
+	}
+
+	sinkAPI := strings.TrimSpace(os.Getenv("ERUN_E2E_ZITADEL_SMTP_SINK_API"))
+	if sinkAPI == "" {
+		t.Log("ERUN_E2E_ZITADEL_SMTP_SINK_API unset; not verifying actual message delivery")
+		return
+	}
+	username := fmt.Sprintf("erun-e2e-smtp-%d", time.Now().UnixNano())
+	recipient := username + "@erun.local"
+	if _, err := client.CreateHumanUser(ctx, CreateHumanUserParams{
+		Username: username, Email: recipient, FirstName: "Erun", LastName: "SMTP",
+	}); err != nil {
+		t.Fatalf("CreateHumanUser: %v", err)
+	}
+	if !e2ePollUntil(t, 20*time.Second, func() bool { return e2eSinkReceivedMessageFor(t, sinkAPI, recipient) }) {
+		t.Fatalf("no message for %s arrived at the SMTP sink within the deadline", recipient)
+	}
+}
+
+// e2ePollUntil polls condition every 500ms until it reports true or timeout
+// elapses, returning whether it ever did.
+func e2ePollUntil(t *testing.T, timeout time.Duration, condition func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if condition() {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// e2eSinkReceivedMessageFor queries a mailhog-shaped sink's v2 message API
+// for any message addressed to recipient.
+func e2eSinkReceivedMessageFor(t *testing.T, sinkAPI string, recipient string) bool {
+	t.Helper()
+	resp, err := http.Get(strings.TrimRight(sinkAPI, "/") + "/api/v2/messages")
+	if err != nil {
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var decoded struct {
+		Items []struct {
+			To []struct {
+				Mailbox string `json:"Mailbox"`
+				Domain  string `json:"Domain"`
+			} `json:"To"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return false
+	}
+	for _, item := range decoded.Items {
+		for _, to := range item.To {
+			if to.Mailbox+"@"+to.Domain == recipient {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func containsUserID(users []User, id string) bool {

--- a/erun-backend/erun-backend-api/internal/zitadel/client_test.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/client_test.go
@@ -189,6 +189,39 @@ func TestCreateHumanUserSendsInviteWithNoPassword(t *testing.T) {
 	}
 }
 
+// TestCreateHumanUserWithInitialPasswordSkipsTheEmailFlow locks the
+// no-SMTP fallback (issue #1168): Zitadel only skips its initialization
+// email when the email is marked verified AND a password is set (confirmed
+// live -- either alone still leaves the account in USER_STATE_INITIAL
+// waiting on a link nothing will ever send), so a caller-supplied
+// InitialPassword must mark the email verified too, and the returned user
+// must report USER_STATE_ACTIVE, not the invite-flow INITIAL state.
+func TestCreateHumanUserWithInitialPasswordSkipsTheEmailFlow(t *testing.T) {
+	var gotBody map[string]any
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatal(err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"userId": "u3"})
+	})
+	user, err := client.CreateHumanUser(context.Background(), CreateHumanUserParams{
+		Username: "carol", Email: "carol@example.com", InitialPassword: "Er7hK2mQ9xL4nP6z!",
+	})
+	if err != nil {
+		t.Fatalf("CreateHumanUser: %v", err)
+	}
+	if user.State != "USER_STATE_ACTIVE" {
+		t.Fatalf("user.State = %q, want USER_STATE_ACTIVE", user.State)
+	}
+	if gotBody["initialPassword"] != "Er7hK2mQ9xL4nP6z!" {
+		t.Fatalf("request body = %+v, want the initial password carried", gotBody)
+	}
+	email, _ := gotBody["email"].(map[string]any)
+	if email["isEmailVerified"] != true {
+		t.Fatalf("email.isEmailVerified = %v, want true -- otherwise Zitadel still emails an init link nothing can deliver", email["isEmailVerified"])
+	}
+}
+
 func TestDeactivateAndReactivateUser(t *testing.T) {
 	var gotPaths []string
 	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/erun-backend/erun-backend-api/internal/zitadel/smtp.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/smtp.go
@@ -133,18 +133,24 @@ func (c *Client) UpdateSMTPConfig(ctx context.Context, params SetSMTPConfigParam
 		return smtpStatusFromParams(params), nil
 	}
 
+	// Activate before writing the password: Zitadel's password-update command
+	// refuses an inactive config with the same "SMTP configuration not
+	// found" error GetSMTPStatus's 404 uses, even though the same config
+	// happily accepts a plain field update while inactive (confirmed live
+	// against a real v4.15.3 instance) -- so activation has to come first,
+	// not last, whenever the existing config is not already active.
 	current := existing[0]
+	if current.State != "SMTP_CONFIG_ACTIVE" {
+		if err := c.activateSMTPConfig(ctx, current.ID); err != nil {
+			return SMTPStatus{}, fmt.Errorf("activate zitadel smtp config: %w", err)
+		}
+	}
 	if err := c.updateSMTPConfigFields(ctx, current.ID, params); err != nil {
 		return SMTPStatus{}, fmt.Errorf("update zitadel smtp config: %w", err)
 	}
 	if strings.TrimSpace(params.Password) != "" {
 		if err := c.updateSMTPConfigPassword(ctx, current.ID, params.Password); err != nil {
 			return SMTPStatus{}, fmt.Errorf("update zitadel smtp password: %w", err)
-		}
-	}
-	if current.State != "SMTP_CONFIG_ACTIVE" {
-		if err := c.activateSMTPConfig(ctx, current.ID); err != nil {
-			return SMTPStatus{}, fmt.Errorf("activate zitadel smtp config: %w", err)
 		}
 	}
 	return smtpStatusFromParams(params), nil

--- a/erun-backend/erun-backend-api/internal/zitadel/smtp.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/smtp.go
@@ -108,9 +108,7 @@ type smtpConfigSearchResponse struct {
 // no-op SMTP PUT without a "NotChanged" error (also confirmed live), so this
 // does not need that convergence guard.
 func (c *Client) UpdateSMTPConfig(ctx context.Context, params SetSMTPConfigParams) (SMTPStatus, error) {
-	host := strings.TrimSpace(params.Host)
-	senderAddress := strings.TrimSpace(params.SenderAddress)
-	if host == "" || senderAddress == "" {
+	if strings.TrimSpace(params.Host) == "" || strings.TrimSpace(params.SenderAddress) == "" {
 		return SMTPStatus{}, fmt.Errorf("smtp host and sender address are required")
 	}
 
@@ -120,40 +118,53 @@ func (c *Client) UpdateSMTPConfig(ctx context.Context, params SetSMTPConfigParam
 	}
 
 	if len(existing) == 0 {
-		if strings.TrimSpace(params.Password) == "" {
-			return SMTPStatus{}, fmt.Errorf("smtp password is required to configure mail delivery for the first time")
-		}
-		id, err := c.createSMTPConfig(ctx, params)
-		if err != nil {
-			return SMTPStatus{}, fmt.Errorf("create zitadel smtp config: %w", err)
-		}
-		if err := c.activateSMTPConfig(ctx, id); err != nil {
-			return SMTPStatus{}, fmt.Errorf("activate zitadel smtp config: %w", err)
+		if err := c.createAndActivateSMTPConfig(ctx, params); err != nil {
+			return SMTPStatus{}, err
 		}
 		return smtpStatusFromParams(params), nil
 	}
+	if err := c.convergeExistingSMTPConfig(ctx, existing[0], params); err != nil {
+		return SMTPStatus{}, err
+	}
+	return smtpStatusFromParams(params), nil
+}
 
-	// Activate before writing the password: Zitadel's password-update command
-	// refuses an inactive config with the same "SMTP configuration not
-	// found" error GetSMTPStatus's 404 uses, even though the same config
-	// happily accepts a plain field update while inactive (confirmed live
-	// against a real v4.15.3 instance) -- so activation has to come first,
-	// not last, whenever the existing config is not already active.
-	current := existing[0]
+func (c *Client) createAndActivateSMTPConfig(ctx context.Context, params SetSMTPConfigParams) error {
+	if strings.TrimSpace(params.Password) == "" {
+		return fmt.Errorf("smtp password is required to configure mail delivery for the first time")
+	}
+	id, err := c.createSMTPConfig(ctx, params)
+	if err != nil {
+		return fmt.Errorf("create zitadel smtp config: %w", err)
+	}
+	if err := c.activateSMTPConfig(ctx, id); err != nil {
+		return fmt.Errorf("activate zitadel smtp config: %w", err)
+	}
+	return nil
+}
+
+// convergeExistingSMTPConfig activates before writing the password:
+// Zitadel's password-update command refuses an inactive config with the
+// same "SMTP configuration not found" error GetSMTPStatus's 404 uses, even
+// though the same config happily accepts a plain field update while
+// inactive (confirmed live against a real v4.15.3 instance) -- so
+// activation has to come first, not last, whenever the existing config is
+// not already active.
+func (c *Client) convergeExistingSMTPConfig(ctx context.Context, current smtpConfigSearchResult, params SetSMTPConfigParams) error {
 	if current.State != "SMTP_CONFIG_ACTIVE" {
 		if err := c.activateSMTPConfig(ctx, current.ID); err != nil {
-			return SMTPStatus{}, fmt.Errorf("activate zitadel smtp config: %w", err)
+			return fmt.Errorf("activate zitadel smtp config: %w", err)
 		}
 	}
 	if err := c.updateSMTPConfigFields(ctx, current.ID, params); err != nil {
-		return SMTPStatus{}, fmt.Errorf("update zitadel smtp config: %w", err)
+		return fmt.Errorf("update zitadel smtp config: %w", err)
 	}
 	if strings.TrimSpace(params.Password) != "" {
 		if err := c.updateSMTPConfigPassword(ctx, current.ID, params.Password); err != nil {
-			return SMTPStatus{}, fmt.Errorf("update zitadel smtp password: %w", err)
+			return fmt.Errorf("update zitadel smtp password: %w", err)
 		}
 	}
-	return smtpStatusFromParams(params), nil
+	return nil
 }
 
 func smtpStatusFromParams(params SetSMTPConfigParams) SMTPStatus {

--- a/erun-backend/erun-backend-api/internal/zitadel/smtp.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/smtp.go
@@ -1,0 +1,214 @@
+package zitadel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// SMTPConfig is the non-secret half of the platform's outbound-mail
+// configuration -- everything Zitadel's Admin API returns from a read. The
+// password is never included: Zitadel does not return it either, and this
+// client only ever writes it.
+type SMTPConfig struct {
+	Host           string `json:"host"`
+	User           string `json:"user"`
+	SenderAddress  string `json:"senderAddress"`
+	SenderName     string `json:"senderName"`
+	ReplyToAddress string `json:"replyToAddress,omitempty"`
+	TLS            bool   `json:"tls"`
+}
+
+// SMTPStatus is the platform's honest answer to "can this instance send mail
+// at all" (issue #1168). Every flow that reaches a user out of band --
+// signup verification, password reset, invitation -- depends on it, and
+// today the only signal is a 404 nobody checks. Configured reports whether
+// an ACTIVE Zitadel SMTP config exists; Config is the zero value otherwise.
+type SMTPStatus struct {
+	Configured bool       `json:"configured"`
+	Config     SMTPConfig `json:"config"`
+}
+
+type smtpConfigResponse struct {
+	SMTPConfig struct {
+		ID             string `json:"id"`
+		Host           string `json:"host"`
+		User           string `json:"user"`
+		SenderAddress  string `json:"senderAddress"`
+		SenderName     string `json:"senderName"`
+		ReplyToAddress string `json:"replyToAddress"`
+		TLS            bool   `json:"tls"`
+		State          string `json:"state"`
+	} `json:"smtpConfig"`
+}
+
+// GetSMTPStatus reads the platform's active outbound-mail configuration.
+// Zitadel answers 404 ("SMTP configuration not found") when no config is
+// active -- verified live against a real instance -- which this reports as
+// SMTPStatus{Configured: false}, not as an error.
+func (c *Client) GetSMTPStatus(ctx context.Context) (SMTPStatus, error) {
+	var resp smtpConfigResponse
+	if err := c.call(ctx, http.MethodGet, "/admin/v1/smtp", nil, &resp); err != nil {
+		var apiErr *APIError
+		if errors.As(err, &apiErr) && apiErr.NotFound() {
+			return SMTPStatus{}, nil
+		}
+		return SMTPStatus{}, err
+	}
+	return SMTPStatus{
+		Configured: true,
+		Config: SMTPConfig{
+			Host:           resp.SMTPConfig.Host,
+			User:           resp.SMTPConfig.User,
+			SenderAddress:  resp.SMTPConfig.SenderAddress,
+			SenderName:     resp.SMTPConfig.SenderName,
+			ReplyToAddress: resp.SMTPConfig.ReplyToAddress,
+			TLS:            resp.SMTPConfig.TLS,
+		},
+	}, nil
+}
+
+// SetSMTPConfigParams is the declarative desired state for the platform's
+// outbound mail (issue #1168): provider-agnostic host (including port,
+// e.g. "smtp.example.com:587"), username, sender identity, and TLS, plus
+// Password -- sourced by the caller from wherever it holds the credential
+// out of band, never generated or invented here. Password empty on an
+// update leaves Zitadel's existing password untouched; it is required the
+// first time a config is created, since there is nothing yet to leave
+// untouched.
+type SetSMTPConfigParams struct {
+	Host           string
+	User           string
+	Password       string
+	SenderAddress  string
+	SenderName     string
+	ReplyToAddress string
+	TLS            bool
+}
+
+type smtpConfigSearchResult struct {
+	ID    string `json:"id"`
+	State string `json:"state"`
+}
+
+type smtpConfigSearchResponse struct {
+	Result []smtpConfigSearchResult `json:"result"`
+}
+
+// UpdateSMTPConfig converges the platform's outbound-mail configuration to
+// params. Zitadel's SMTP API is id-addressed and a freshly created config
+// defaults to SMTP_CONFIG_INACTIVE (invisible to GetSMTPStatus until
+// activated) -- confirmed live -- so this creates-and-activates the
+// platform's first config when none exists, or read-modify-writes the
+// existing one otherwise, the same create-vs-update split UpdateOrgSettings
+// uses for org policy. Unlike the login/password policies, Zitadel accepts a
+// no-op SMTP PUT without a "NotChanged" error (also confirmed live), so this
+// does not need that convergence guard.
+func (c *Client) UpdateSMTPConfig(ctx context.Context, params SetSMTPConfigParams) (SMTPStatus, error) {
+	host := strings.TrimSpace(params.Host)
+	senderAddress := strings.TrimSpace(params.SenderAddress)
+	if host == "" || senderAddress == "" {
+		return SMTPStatus{}, fmt.Errorf("smtp host and sender address are required")
+	}
+
+	existing, err := c.searchSMTPConfigs(ctx)
+	if err != nil {
+		return SMTPStatus{}, fmt.Errorf("search zitadel smtp configs: %w", err)
+	}
+
+	if len(existing) == 0 {
+		if strings.TrimSpace(params.Password) == "" {
+			return SMTPStatus{}, fmt.Errorf("smtp password is required to configure mail delivery for the first time")
+		}
+		id, err := c.createSMTPConfig(ctx, params)
+		if err != nil {
+			return SMTPStatus{}, fmt.Errorf("create zitadel smtp config: %w", err)
+		}
+		if err := c.activateSMTPConfig(ctx, id); err != nil {
+			return SMTPStatus{}, fmt.Errorf("activate zitadel smtp config: %w", err)
+		}
+		return smtpStatusFromParams(params), nil
+	}
+
+	current := existing[0]
+	if err := c.updateSMTPConfigFields(ctx, current.ID, params); err != nil {
+		return SMTPStatus{}, fmt.Errorf("update zitadel smtp config: %w", err)
+	}
+	if strings.TrimSpace(params.Password) != "" {
+		if err := c.updateSMTPConfigPassword(ctx, current.ID, params.Password); err != nil {
+			return SMTPStatus{}, fmt.Errorf("update zitadel smtp password: %w", err)
+		}
+	}
+	if current.State != "SMTP_CONFIG_ACTIVE" {
+		if err := c.activateSMTPConfig(ctx, current.ID); err != nil {
+			return SMTPStatus{}, fmt.Errorf("activate zitadel smtp config: %w", err)
+		}
+	}
+	return smtpStatusFromParams(params), nil
+}
+
+func smtpStatusFromParams(params SetSMTPConfigParams) SMTPStatus {
+	return SMTPStatus{
+		Configured: true,
+		Config: SMTPConfig{
+			Host:           strings.TrimSpace(params.Host),
+			User:           strings.TrimSpace(params.User),
+			SenderAddress:  strings.TrimSpace(params.SenderAddress),
+			SenderName:     strings.TrimSpace(params.SenderName),
+			ReplyToAddress: strings.TrimSpace(params.ReplyToAddress),
+			TLS:            params.TLS,
+		},
+	}
+}
+
+func (c *Client) searchSMTPConfigs(ctx context.Context) ([]smtpConfigSearchResult, error) {
+	var resp smtpConfigSearchResponse
+	if err := c.call(ctx, http.MethodPost, "/admin/v1/smtp/_search", map[string]any{}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Result, nil
+}
+
+func (c *Client) createSMTPConfig(ctx context.Context, params SetSMTPConfigParams) (string, error) {
+	var resp struct {
+		ID string `json:"id"`
+	}
+	if err := c.call(ctx, http.MethodPost, "/admin/v1/smtp", smtpConfigBody(params, true), &resp); err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+func (c *Client) updateSMTPConfigFields(ctx context.Context, id string, params SetSMTPConfigParams) error {
+	return c.call(ctx, http.MethodPut, fmt.Sprintf("/admin/v1/smtp/%s", url.PathEscape(id)), smtpConfigBody(params, false), nil)
+}
+
+func (c *Client) updateSMTPConfigPassword(ctx context.Context, id string, password string) error {
+	return c.call(ctx, http.MethodPut, fmt.Sprintf("/admin/v1/smtp/%s/password", url.PathEscape(id)), map[string]any{"password": password}, nil)
+}
+
+func (c *Client) activateSMTPConfig(ctx context.Context, id string) error {
+	return c.call(ctx, http.MethodPost, fmt.Sprintf("/admin/v1/smtp/%s/_activate", url.PathEscape(id)), map[string]any{}, nil)
+}
+
+// smtpConfigBody builds the AddSMTPConfig/UpdateSMTPConfig request body.
+// includePassword is false for the update-fields PUT: Zitadel exposes
+// password changes through its own dedicated endpoint
+// (updateSMTPConfigPassword), so the update-fields body never carries one.
+func smtpConfigBody(params SetSMTPConfigParams, includePassword bool) map[string]any {
+	body := map[string]any{
+		"senderAddress":  strings.TrimSpace(params.SenderAddress),
+		"senderName":     strings.TrimSpace(params.SenderName),
+		"tls":            params.TLS,
+		"host":           strings.TrimSpace(params.Host),
+		"user":           strings.TrimSpace(params.User),
+		"replyToAddress": strings.TrimSpace(params.ReplyToAddress),
+	}
+	if includePassword {
+		body["password"] = params.Password
+	}
+	return body
+}

--- a/erun-backend/erun-backend-api/internal/zitadel/smtp_test.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/smtp_test.go
@@ -152,3 +152,37 @@ func TestUpdateSMTPConfigActivatesAnInactiveExistingConfig(t *testing.T) {
 		t.Fatalf("activated = %q, want the inactive existing config reactivated", activated)
 	}
 }
+
+// TestUpdateSMTPConfigActivatesBeforeWritingThePassword locks a real
+// Zitadel business rule found live against a v4.15.3 instance: the
+// password-update command refuses an inactive config with the same "SMTP
+// configuration not found" error GetSMTPStatus's 404 uses, even though a
+// plain field update on the same inactive config succeeds -- so an inactive
+// existing config must be activated before its password is written, not
+// after.
+func TestUpdateSMTPConfigActivatesBeforeWritingThePassword(t *testing.T) {
+	var order []string
+	client := routedTestClient(t, []jsonRoute{
+		{method: http.MethodPost, path: "/admin/v1/smtp/_search", body: map[string]any{
+			"result": []map[string]any{{"id": "smtp-3", "state": "SMTP_CONFIG_INACTIVE"}},
+		}},
+		{method: http.MethodPost, path: "/admin/v1/smtp/smtp-3/_activate", record: func(map[string]any) { order = append(order, "activate") }},
+		{method: http.MethodPut, path: "/admin/v1/smtp/smtp-3", record: func(map[string]any) { order = append(order, "fields") }},
+		{method: http.MethodPut, path: "/admin/v1/smtp/smtp-3/password", record: func(map[string]any) { order = append(order, "password") }},
+	})
+
+	if _, err := client.UpdateSMTPConfig(context.Background(), SetSMTPConfigParams{
+		Host: "smtp.example.com:587", SenderAddress: "noreply@example.com", Password: "s3cret",
+	}); err != nil {
+		t.Fatalf("UpdateSMTPConfig: %v", err)
+	}
+	want := []string{"activate", "fields", "password"}
+	if len(order) != len(want) {
+		t.Fatalf("order = %v, want %v", order, want)
+	}
+	for i, step := range want {
+		if order[i] != step {
+			t.Fatalf("order = %v, want %v", order, want)
+		}
+	}
+}

--- a/erun-backend/erun-backend-api/internal/zitadel/smtp_test.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/smtp_test.go
@@ -1,0 +1,154 @@
+package zitadel
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestGetSMTPStatusReportsUnconfiguredOn404 locks the exact shape this issue
+// started from: a real Zitadel instance with no SMTP provider answers 404
+// with {"code":5,"message":"SMTP configuration not found (QUERY-fwofw)"}
+// (verified live against a real v4.15.3 instance), which must read as
+// SMTPStatus{Configured: false}, not propagate as an error.
+func TestGetSMTPStatusReportsUnconfiguredOn404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"code":5, "message":"SMTP configuration not found (QUERY-fwofw)"}`))
+	}))
+	t.Cleanup(server.Close)
+	client := newClient(server.URL, "auth.example.com", "test-pat")
+
+	status, err := client.GetSMTPStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetSMTPStatus: %v", err)
+	}
+	if status.Configured {
+		t.Fatalf("status = %+v, want Configured=false on a 404", status)
+	}
+}
+
+func TestGetSMTPStatusReportsConfiguredConfig(t *testing.T) {
+	client := routedTestClient(t, []jsonRoute{
+		{method: http.MethodGet, path: "/admin/v1/smtp", body: map[string]any{
+			"smtpConfig": map[string]any{
+				"id": "smtp-1", "host": "smtp.example.com:587", "user": "erun",
+				"senderAddress": "noreply@example.com", "senderName": "Erun Platform",
+				"tls": true, "state": "SMTP_CONFIG_ACTIVE",
+			},
+		}},
+	})
+
+	status, err := client.GetSMTPStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetSMTPStatus: %v", err)
+	}
+	want := SMTPStatus{Configured: true, Config: SMTPConfig{
+		Host: "smtp.example.com:587", User: "erun",
+		SenderAddress: "noreply@example.com", SenderName: "Erun Platform", TLS: true,
+	}}
+	if status != want {
+		t.Fatalf("status = %+v, want %+v", status, want)
+	}
+}
+
+// TestUpdateSMTPConfigCreatesAndActivatesWhenNoneExists locks the
+// first-configuration path: Zitadel has no smtp config at all (the issue's
+// exact starting state), so this must create one and then explicitly
+// activate it -- a created-but-inactive config never becomes deliverable
+// (confirmed live: a fresh AddSMTPConfig defaults to SMTP_CONFIG_INACTIVE).
+func TestUpdateSMTPConfigCreatesAndActivatesWhenNoneExists(t *testing.T) {
+	var createBody map[string]any
+	activated := ""
+	client := routedTestClient(t, []jsonRoute{
+		{method: http.MethodPost, path: "/admin/v1/smtp/_search", body: map[string]any{"result": []map[string]any{}}},
+		{method: http.MethodPost, path: "/admin/v1/smtp", body: map[string]any{"id": "smtp-new"}, record: func(body map[string]any) {
+			createBody = body
+		}},
+		{method: http.MethodPost, path: "/admin/v1/smtp/smtp-new/_activate", record: func(map[string]any) { activated = "smtp-new" }},
+	})
+
+	status, err := client.UpdateSMTPConfig(context.Background(), SetSMTPConfigParams{
+		Host: "smtp.example.com:587", User: "erun", Password: "s3cret",
+		SenderAddress: "noreply@example.com", SenderName: "Erun Platform", TLS: true,
+	})
+	if err != nil {
+		t.Fatalf("UpdateSMTPConfig: %v", err)
+	}
+	if activated != "smtp-new" {
+		t.Fatalf("activated = %q, want the newly created config to be activated", activated)
+	}
+	if createBody["password"] != "s3cret" {
+		t.Fatalf("create body = %+v, want the password included on first create", createBody)
+	}
+	if !status.Configured || status.Config.Host != "smtp.example.com:587" {
+		t.Fatalf("status = %+v, want the converged config reported", status)
+	}
+}
+
+func TestUpdateSMTPConfigRequiresPasswordOnFirstCreate(t *testing.T) {
+	client := routedTestClient(t, []jsonRoute{
+		{method: http.MethodPost, path: "/admin/v1/smtp/_search", body: map[string]any{"result": []map[string]any{}}},
+	})
+
+	if _, err := client.UpdateSMTPConfig(context.Background(), SetSMTPConfigParams{
+		Host: "smtp.example.com:587", SenderAddress: "noreply@example.com",
+	}); err == nil {
+		t.Fatal("want an error when no config exists yet and no password was supplied")
+	}
+}
+
+// TestUpdateSMTPConfigUpdatesExistingConfigWithoutTouchingPassword locks that
+// an update with no Password leaves Zitadel's stored password alone -- the
+// only way it can be, since Zitadel never returns it to diff against.
+func TestUpdateSMTPConfigUpdatesExistingConfigWithoutTouchingPassword(t *testing.T) {
+	fieldPuts, passwordPuts, activates := 0, 0, 0
+	client := routedTestClient(t, []jsonRoute{
+		{method: http.MethodPost, path: "/admin/v1/smtp/_search", body: map[string]any{
+			"result": []map[string]any{{"id": "smtp-1", "state": "SMTP_CONFIG_ACTIVE"}},
+		}},
+		{method: http.MethodPut, path: "/admin/v1/smtp/smtp-1", record: func(map[string]any) { fieldPuts++ }},
+		{method: http.MethodPut, path: "/admin/v1/smtp/smtp-1/password", record: func(map[string]any) { passwordPuts++ }},
+		{method: http.MethodPost, path: "/admin/v1/smtp/smtp-1/_activate", record: func(map[string]any) { activates++ }},
+	})
+
+	if _, err := client.UpdateSMTPConfig(context.Background(), SetSMTPConfigParams{
+		Host: "smtp.example.com:587", SenderAddress: "noreply@example.com",
+	}); err != nil {
+		t.Fatalf("UpdateSMTPConfig: %v", err)
+	}
+	if fieldPuts != 1 {
+		t.Fatalf("fieldPuts = %d, want the existing config's fields updated", fieldPuts)
+	}
+	if passwordPuts != 0 {
+		t.Fatalf("passwordPuts = %d, want no password write when none was supplied", passwordPuts)
+	}
+	if activates != 0 {
+		t.Fatalf("activates = %d, want no re-activation of a config that is already active", activates)
+	}
+}
+
+// TestUpdateSMTPConfigActivatesAnInactiveExistingConfig locks the
+// re-activation half: an existing-but-inactive config (e.g. deactivated by
+// an operator, or left over from an earlier failed converge) must be
+// activated again, not just have its fields updated.
+func TestUpdateSMTPConfigActivatesAnInactiveExistingConfig(t *testing.T) {
+	activated := ""
+	client := routedTestClient(t, []jsonRoute{
+		{method: http.MethodPost, path: "/admin/v1/smtp/_search", body: map[string]any{
+			"result": []map[string]any{{"id": "smtp-2", "state": "SMTP_CONFIG_INACTIVE"}},
+		}},
+		{method: http.MethodPut, path: "/admin/v1/smtp/smtp-2"},
+		{method: http.MethodPost, path: "/admin/v1/smtp/smtp-2/_activate", record: func(map[string]any) { activated = "smtp-2" }},
+	})
+
+	if _, err := client.UpdateSMTPConfig(context.Background(), SetSMTPConfigParams{
+		Host: "smtp.example.com:587", SenderAddress: "noreply@example.com",
+	}); err != nil {
+		t.Fatalf("UpdateSMTPConfig: %v", err)
+	}
+	if activated != "smtp-2" {
+		t.Fatalf("activated = %q, want the inactive existing config reactivated", activated)
+	}
+}

--- a/erun-console/playwright/tests/oidc-signin.spec.ts
+++ b/erun-console/playwright/tests/oidc-signin.spec.ts
@@ -36,7 +36,9 @@ test('operator signs in through Zitadel OIDC, registers an environment, and sees
   // 1. The signed-out console offers the real OIDC sign-in, not the dev-token
   //    fallback: a Sign in button only renders when the issuer is configured.
   await page.goto('/');
-  await expect(page.getByText('Sign in to view your environments.')).toBeVisible();
+  await expect(
+    page.getByText('Sign in with your organization identity to view and manage your environments.'),
+  ).toBeVisible();
   await page.getByRole('button', { name: 'Sign in' }).click();
 
   // 2. The browser lands on Zitadel's own Login V2 UI — loginname step.
@@ -56,36 +58,57 @@ test('operator signs in through Zitadel OIDC, registers an environment, and sees
   //    resolves to. Asserting the rendered read model — not merely that a
   //    redirect happened — is what makes this an authenticated-session proof.
   await expect(page).toHaveURL(/^http:\/\/localhost:5173\/$/);
-  await expect(page.getByRole('heading', { name: /operations/i })).toBeVisible();
+  // The tenant *name* bootstrap enrols under follows ERUN_TENANT when the API
+  // process has one set (e.g. this repo's own agent env exports one for its
+  // own tenant) and falls back to "operations" otherwise — so the header is
+  // asserted structurally (a level-2 heading rendered at all) rather than by
+  // a literal name, and the actual invariant under test (an OPERATIONS-type
+  // tenant bootstrapped) is the type text on the next line.
+  await expect(page.getByRole('heading', { level: 2 })).toBeVisible();
   await expect(page.getByText('Tenant · OPERATIONS')).toBeVisible();
-  // exact: true — the "Register and deploy environments" panel's own heading
-  // (below) also contains "environments" as a substring, which a non-exact
-  // match would ambiguously match too.
-  await expect(page.getByRole('heading', { name: 'Environments', exact: true })).toBeVisible();
+  // erun-kit's CardTitle renders a styled <div>, not a semantic heading
+  // element, so the section title is asserted via the Card's own
+  // role="region" + aria-labelledby (its accessible name), not getByRole
+  // 'heading'. name: 'Environments' (not a substring match) disambiguates
+  // from the "Register and deploy environments" panel on the nav's
+  // Environments section, which also contains "Environments" as a substring.
+  await expect(page.getByRole('region', { name: 'Environments' })).toBeVisible();
 
   // 5. The session is real, not a one-shot render: a reload resolves the held
   //    token and re-authenticates against the API without another sign-in.
   await page.reload();
   await expect(page.getByText('Tenant · OPERATIONS')).toBeVisible();
 
-  // 6. Register an environment against the real API (not a mock) and confirm
-  //    it appears in the read view. `getByLabel('Name', { exact: true })`
-  //    disambiguates from the alias/context forms' "Alias name"/"Context name"
-  //    fields below, which a substring match on "Name" would also match.
+  // 6. The app shell renders exactly one section at a time (#1207): the
+  //    register/deploy forms live under the "Environments" nav entry, not the
+  //    read-only Overview landed on above.
+  await page
+    .getByRole('navigation', { name: 'Console sections' })
+    .getByRole('button', { name: 'Environments' })
+    .click();
+
+  // 7. Register an environment against the real API (not a mock) and confirm
+  //    it appears in the read view. `exact: false` because FieldLabel folds a
+  //    visually-hidden "(required)" into the accessible name of every
+  //    required field (WCAG 1.4.1) — this section has no "Alias name"/"Context
+  //    name" field to disambiguate from, so the substring match stays
+  //    unambiguous. A freshly registered "runtime"-type environment (the
+  //    form's default) also appears in the deploy list right below, on the
+  //    same section.
   const envName = `e2e-${Date.now()}`;
-  await page.getByLabel('Name', { exact: true }).fill(envName);
+  await page.getByLabel('Name', { exact: false }).fill(envName);
   await page.getByRole('button', { name: 'Register environment' }).click();
   await expect(page.getByText(`Environment ${envName} registered.`)).toBeVisible();
-  await expect(page.getByRole('cell', { name: envName })).toBeVisible();
+  const deployRow = page.locator('li', { hasText: envName });
+  await expect(deployRow).toBeVisible();
 
-  // 7. Deploying it hits the real control plane's honest answer when no
+  // 8. Deploying it hits the real control plane's honest answer when no
   //    deploy executor is configured (run.sh's eapi sets no
   //    ERUN_ENV_DEPLOYER_SERVICE_ACCOUNT) — a real 501 rendered as the plain,
   //    actionable message, not a generic failure. Standing up a real deploy
   //    executor (a cluster, a runtime image registry) is out of scope for this
   //    e2e; the 409/501/success paths are unit-tested against a mocked fetch
   //    in EnvironmentsPanel.test.tsx.
-  const deployRow = page.locator('.deploy-row', { hasText: envName });
   await deployRow.getByRole('button', { name: 'Deploy' }).click();
   await expect(
     page.getByText('The deploy executor is not configured on this control plane.'),

--- a/erun-console/src/app/api/identityApi.ts
+++ b/erun-console/src/app/api/identityApi.ts
@@ -20,6 +20,14 @@ export interface IdentityUser {
   lastName?: string;
 }
 
+function asNumber(value: unknown): number {
+  return typeof value === 'number' ? value : 0;
+}
+
+function asBoolean(value: unknown): boolean {
+  return value === true;
+}
+
 function parseIdentityUser(raw: Record<string, unknown>): IdentityUser {
   return {
     id: asString(raw.id),
@@ -57,10 +65,19 @@ export interface ErunUserRef {
 // erun-side mapping failed after the IdP identity was created — see
 // service.IdentityService.Enroll on the backend for why that half-landed
 // state is reported rather than swallowed.
+//
+// mailDeliveryConfigured/temporaryPassword/warning report which of the two
+// enrollment paths the backend actually took: with mail configured, the IdP
+// emails the invite itself; without it, the backend mints temporaryPassword
+// once instead so the account is usable immediately rather than stuck
+// waiting on an email that can never arrive.
 export interface EnrollIdentityUserResult {
   idpUser: IdentityUser;
   erunUser?: ErunUserRef;
   error?: string;
+  mailDeliveryConfigured: boolean;
+  temporaryPassword?: string;
+  warning?: string;
 }
 
 function parseEnrollResult(raw: unknown): EnrollIdentityUserResult {
@@ -75,6 +92,9 @@ function parseEnrollResult(raw: unknown): EnrollIdentityUserResult {
         ? { userId: asString(erunUserRaw.userId), username: asString(erunUserRaw.username) }
         : undefined,
     error: asOptionalString(raw.error),
+    mailDeliveryConfigured: asBoolean(raw.mailDeliveryConfigured),
+    temporaryPassword: asOptionalString(raw.temporaryPassword),
+    warning: asOptionalString(raw.warning),
   };
 }
 
@@ -89,14 +109,6 @@ export interface OrgSettings {
   passwordRequiresNumber: boolean;
   passwordRequiresSymbol: boolean;
   verifiedDomains: string[];
-}
-
-function asNumber(value: unknown): number {
-  return typeof value === 'number' ? value : 0;
-}
-
-function asBoolean(value: unknown): boolean {
-  return value === true;
 }
 
 function parseOrgSettings(raw: unknown): OrgSettings {
@@ -125,6 +137,61 @@ export interface UpdateOrgSettingsInput {
   passwordRequiresLowercase?: boolean;
   passwordRequiresNumber?: boolean;
   passwordRequiresSymbol?: boolean;
+}
+
+// The platform's outbound-mail configuration. Password is never part of the
+// read shape — Zitadel does not return it, and this contract only ever
+// writes it.
+export interface SmtpConfig {
+  host: string;
+  username: string;
+  senderAddress: string;
+  senderName: string;
+  replyToAddress?: string;
+  tls: boolean;
+}
+
+// The platform's honest answer to "can this instance send mail at all".
+// configured: false means no active config exists yet — the default for a
+// freshly deployed platform.
+export interface SmtpStatus {
+  configured: boolean;
+  config: SmtpConfig;
+}
+
+function parseSmtpConfig(raw: unknown): SmtpConfig {
+  if (!isRecord(raw)) {
+    return { host: '', username: '', senderAddress: '', senderName: '', tls: false };
+  }
+  return {
+    host: asString(raw.host),
+    username: asString(raw.user),
+    senderAddress: asString(raw.senderAddress),
+    senderName: asString(raw.senderName),
+    replyToAddress: asOptionalString(raw.replyToAddress),
+    tls: asBoolean(raw.tls),
+  };
+}
+
+function parseSmtpStatus(raw: unknown): SmtpStatus {
+  if (!isRecord(raw)) {
+    throw new Error('smtp settings response was not in the expected shape');
+  }
+  return { configured: asBoolean(raw.configured), config: parseSmtpConfig(raw.config) };
+}
+
+// UpdateSmtpSettingsInput is the declarative desired state the operator
+// submits. password is omitted on an update that only changes non-secret
+// fields — the backend leaves Zitadel's stored password untouched — and is
+// required only the first time a config is created.
+export interface UpdateSmtpSettingsInput {
+  host: string;
+  username?: string;
+  password?: string;
+  senderAddress: string;
+  senderName?: string;
+  replyToAddress?: string;
+  tls: boolean;
 }
 
 export const identityApi = platformApi.injectEndpoints({
@@ -191,6 +258,31 @@ export const identityApi = platformApi.injectEndpoints({
       transformResponse: parseOrgSettings,
       invalidatesTags: ['OrgSettings'],
     }),
+
+    // getSmtpSettings reads the platform's active outbound-mail
+    // configuration — configured: false, not an error, when none exists yet.
+    getSmtpSettings: builder.query<SmtpStatus, string>({
+      query: (token) => ({ url: '/v1/identity/smtp-settings', token, label: 'get smtp settings' }),
+      transformResponse: parseSmtpStatus,
+      providesTags: ['SmtpSettings'],
+    }),
+
+    // updateSmtpSettings converges the configuration to input and returns
+    // the resulting status, same shape as the GET above.
+    updateSmtpSettings: builder.mutation<
+      SmtpStatus,
+      { token: string; input: UpdateSmtpSettingsInput }
+    >({
+      query: ({ token, input }) => ({
+        url: '/v1/identity/smtp-settings',
+        method: 'PATCH',
+        body: input,
+        token,
+        label: 'update smtp settings',
+      }),
+      transformResponse: parseSmtpStatus,
+      invalidatesTags: ['SmtpSettings'],
+    }),
   }),
 });
 
@@ -200,4 +292,6 @@ export const {
   useSetIdentityUserActiveMutation,
   useGetOrgSettingsQuery,
   useUpdateOrgSettingsMutation,
+  useGetSmtpSettingsQuery,
+  useUpdateSmtpSettingsMutation,
 } = identityApi;

--- a/erun-console/src/app/api/platformApi.ts
+++ b/erun-console/src/app/api/platformApi.ts
@@ -15,6 +15,6 @@ export type NoValue = ReturnType<_VoidReturning>;
 export const platformApi = createApi({
   reducerPath: 'platformApi',
   baseQuery: httpBaseQuery,
-  tagTypes: ['Config', 'Environment', 'Context', 'IdentityUsers', 'OrgSettings'],
+  tagTypes: ['Config', 'Environment', 'Context', 'IdentityUsers', 'OrgSettings', 'SmtpSettings'],
   endpoints: () => ({}),
 });

--- a/erun-console/src/identity/SmtpSettingsPanel.test.tsx
+++ b/erun-console/src/identity/SmtpSettingsPanel.test.tsx
@@ -1,0 +1,169 @@
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithStore } from '../test/renderWithStore';
+import { SmtpSettingsPanel } from './SmtpSettingsPanel';
+
+interface MockReq {
+  method: string;
+  url: string;
+  body?: unknown;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function requestUrl(input: string | URL): string {
+  return input instanceof URL ? input.href : input;
+}
+
+function mockFetch(handler: (req: MockReq) => Response): MockReq[] {
+  const calls: MockReq[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: string | URL, init?: RequestInit) => {
+      const req: MockReq = {
+        method: init?.method ?? 'GET',
+        url: requestUrl(input),
+        body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+      };
+      calls.push(req);
+      return Promise.resolve(handler(req));
+    }),
+  );
+  return calls;
+}
+
+const NOT_CONFIGURED = { configured: false, config: {} };
+
+const CONFIGURED = {
+  configured: true,
+  config: {
+    host: 'smtp.example.com:587',
+    user: 'erun',
+    senderAddress: 'noreply@example.com',
+    senderName: 'Erun Platform',
+    replyToAddress: '',
+    tls: true,
+  },
+};
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('SmtpSettingsPanel', () => {
+  it('defaults to not configured on a fresh platform', async () => {
+    mockFetch(() => jsonResponse(NOT_CONFIGURED));
+    renderWithStore(<SmtpSettingsPanel token="dev-token" />);
+
+    expect(await screen.findByText('Not configured')).toBeInTheDocument();
+    expect(screen.getByLabelText<HTMLInputElement>('Host', { exact: false }).value).toBe('');
+    expect(screen.getByLabelText('Password', { exact: false })).toHaveAttribute('required');
+  });
+
+  it('renders the current configuration split into host and port', async () => {
+    mockFetch(() => jsonResponse(CONFIGURED));
+    renderWithStore(<SmtpSettingsPanel token="dev-token" />);
+
+    expect(await screen.findByText('Configured')).toBeInTheDocument();
+    expect(screen.getByLabelText<HTMLInputElement>('Host', { exact: false }).value).toBe(
+      'smtp.example.com',
+    );
+    expect(screen.getByLabelText<HTMLInputElement>('Port').value).toBe('587');
+    expect(screen.getByLabelText<HTMLInputElement>('Username').value).toBe('erun');
+    expect(screen.getByLabelText<HTMLInputElement>('From address', { exact: false }).value).toBe(
+      'noreply@example.com',
+    );
+    // Once configured, the password is optional — the operator only supplies
+    // it again to change it.
+    expect(screen.getByLabelText('Password')).not.toHaveAttribute('required');
+  });
+
+  it('PATCHes the joined host:port and reports the saved state', async () => {
+    const calls = mockFetch((req) => {
+      if (req.method === 'PATCH') {
+        return jsonResponse({
+          configured: true,
+          config: {
+            host: 'smtp.newprovider.com:465',
+            user: 'erun',
+            senderAddress: 'noreply@example.com',
+            senderName: '',
+            replyToAddress: '',
+            tls: true,
+          },
+        });
+      }
+      return jsonResponse(NOT_CONFIGURED);
+    });
+    renderWithStore(<SmtpSettingsPanel token="dev-token" />);
+    await screen.findByText('Not configured');
+
+    fireEvent.change(screen.getByLabelText('Host', { exact: false }), {
+      target: { value: 'smtp.newprovider.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Port'), { target: { value: '465' } });
+    fireEvent.change(screen.getByLabelText('Password', { exact: false }), {
+      target: { value: 'super-secret' },
+    });
+    fireEvent.change(screen.getByLabelText('From address', { exact: false }), {
+      target: { value: 'noreply@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
+
+    await waitFor(() => {
+      expect(calls.some((c) => c.method === 'PATCH')).toBe(true);
+    });
+    const patch = calls.find((c) => c.method === 'PATCH');
+    expect(patch?.url).toBe('/v1/identity/smtp-settings');
+    expect(patch?.body).toMatchObject({
+      host: 'smtp.newprovider.com:465',
+      senderAddress: 'noreply@example.com',
+      password: 'super-secret',
+    });
+    await screen.findByText('Configured');
+  });
+
+  it('reports the provider error from a failed save and keeps the form editable', async () => {
+    mockFetch((req) => {
+      if (req.method === 'PATCH') {
+        return jsonResponse('smtp handshake failed: connection refused', 502);
+      }
+      return jsonResponse(NOT_CONFIGURED);
+    });
+    renderWithStore(<SmtpSettingsPanel token="dev-token" />);
+    await screen.findByText('Not configured');
+
+    fireEvent.change(screen.getByLabelText('Host', { exact: false }), {
+      target: { value: 'smtp.example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password', { exact: false }), {
+      target: { value: 'wrong-secret' },
+    });
+    fireEvent.change(screen.getByLabelText('From address', { exact: false }), {
+      target: { value: 'noreply@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
+
+    expect(await screen.findByText(/Could not save mail settings/)).toBeInTheDocument();
+    // The form survives the failure — the operator's input is still there and
+    // the Save button is still present to retry, not a dead-end error page.
+    expect(screen.getByLabelText<HTMLInputElement>('Host', { exact: false }).value).toBe(
+      'smtp.example.com',
+    );
+    expect(screen.getByRole('button', { name: 'Save settings' })).toBeInTheDocument();
+  });
+
+  it('surfaces a load error', async () => {
+    mockFetch(() => jsonResponse('forbidden', 403));
+    renderWithStore(<SmtpSettingsPanel token="dev-token" />);
+    expect(await screen.findByText(/Could not load mail settings/)).toBeInTheDocument();
+  });
+});

--- a/erun-console/src/identity/SmtpSettingsPanel.tsx
+++ b/erun-console/src/identity/SmtpSettingsPanel.tsx
@@ -1,0 +1,322 @@
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Checkbox,
+  FieldLabel,
+  Input,
+  Label,
+  StatusBadge,
+} from 'erun-kit';
+import * as React from 'react';
+
+import type { SmtpConfig, SmtpStatus, UpdateSmtpSettingsInput } from '../app/api/identityApi';
+import type { SmtpSettingsState } from './controller';
+import { useSmtpSettingsController } from './controller';
+
+// The backend's `host` field carries "host:port" as one string (e.g.
+// "smtp.example.com:587"); the form splits it into two inputs for the
+// operator and rejoins them on submit.
+function splitHostPort(hostPort: string): { host: string; port: string } {
+  const separatorIndex = hostPort.lastIndexOf(':');
+  if (separatorIndex <= 0 || separatorIndex === hostPort.length - 1) {
+    return { host: hostPort, port: '' };
+  }
+  const port = hostPort.slice(separatorIndex + 1);
+  if (!/^\d+$/.test(port)) {
+    return { host: hostPort, port: '' };
+  }
+  return { host: hostPort.slice(0, separatorIndex), port };
+}
+
+function joinHostPort(host: string, port: string): string {
+  const trimmedHost = host.trim();
+  const trimmedPort = port.trim();
+  return trimmedPort === '' ? trimmedHost : `${trimmedHost}:${trimmedPort}`;
+}
+
+interface SmtpFormFields {
+  host: string;
+  port: string;
+  username: string;
+  password: string;
+  senderAddress: string;
+  senderName: string;
+  replyToAddress: string;
+  tls: boolean;
+  setHost: (value: string) => void;
+  setPort: (value: string) => void;
+  setUsername: (value: string) => void;
+  setPassword: (value: string) => void;
+  setSenderAddress: (value: string) => void;
+  setSenderName: (value: string) => void;
+  setReplyToAddress: (value: string) => void;
+  setTls: (value: boolean) => void;
+}
+
+// useSmtpFormFields seeds one local field per config value the first time
+// this form instance renders. Like OrgSettingsPanel's equivalent hook, it
+// deliberately does not resync on every parent re-render — a failed save
+// keeps the operator's own edits on screen (see SmtpSettingsState's
+// 'error' case) instead of snapping back to the last-saved value.
+function useSmtpFormFields(config: SmtpConfig): SmtpFormFields {
+  const initial = splitHostPort(config.host);
+  const [host, setHost] = React.useState(initial.host);
+  const [port, setPort] = React.useState(initial.port);
+  const [username, setUsername] = React.useState(config.username);
+  const [password, setPassword] = React.useState('');
+  const [senderAddress, setSenderAddress] = React.useState(config.senderAddress);
+  const [senderName, setSenderName] = React.useState(config.senderName);
+  const [replyToAddress, setReplyToAddress] = React.useState(config.replyToAddress ?? '');
+  const [tls, setTls] = React.useState(config.tls);
+  return {
+    host,
+    port,
+    username,
+    password,
+    senderAddress,
+    senderName,
+    replyToAddress,
+    tls,
+    setHost,
+    setPort,
+    setUsername,
+    setPassword,
+    setSenderAddress,
+    setSenderName,
+    setReplyToAddress,
+    setTls,
+  };
+}
+
+function ConfiguredStatus({ configured }: { configured: boolean }): React.ReactElement {
+  return configured ? (
+    <StatusBadge tone="success" label="Configured" />
+  ) : (
+    <StatusBadge tone="muted" label="Not configured" />
+  );
+}
+
+function HostFields({ fields }: { fields: SmtpFormFields }): React.ReactElement {
+  return (
+    <div className="grid grid-cols-[2fr_1fr] gap-2">
+      <div className="grid gap-2">
+        <FieldLabel htmlFor="smtp-host" required>
+          Host
+        </FieldLabel>
+        <Input
+          id="smtp-host"
+          value={fields.host}
+          onChange={(e) => {
+            fields.setHost(e.target.value);
+          }}
+          required
+        />
+      </div>
+      <div className="grid gap-2">
+        <FieldLabel htmlFor="smtp-port">Port</FieldLabel>
+        <Input
+          id="smtp-port"
+          inputMode="numeric"
+          placeholder="587"
+          value={fields.port}
+          onChange={(e) => {
+            fields.setPort(e.target.value);
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CredentialFields({
+  fields,
+  configured,
+}: {
+  fields: SmtpFormFields;
+  configured: boolean;
+}): React.ReactElement {
+  return (
+    <>
+      <div className="grid gap-2">
+        <FieldLabel htmlFor="smtp-username">Username</FieldLabel>
+        <Input
+          id="smtp-username"
+          value={fields.username}
+          onChange={(e) => {
+            fields.setUsername(e.target.value);
+          }}
+        />
+      </div>
+      <div className="grid gap-2">
+        <FieldLabel htmlFor="smtp-password" required={!configured}>
+          Password
+        </FieldLabel>
+        <Input
+          id="smtp-password"
+          type="password"
+          autoComplete="new-password"
+          placeholder={configured ? 'Leave blank to keep the current password' : ''}
+          value={fields.password}
+          onChange={(e) => {
+            fields.setPassword(e.target.value);
+          }}
+          required={!configured}
+        />
+      </div>
+    </>
+  );
+}
+
+function SenderFields({ fields }: { fields: SmtpFormFields }): React.ReactElement {
+  return (
+    <>
+      <div className="grid gap-2">
+        <FieldLabel htmlFor="smtp-sender-address" required>
+          From address
+        </FieldLabel>
+        <Input
+          id="smtp-sender-address"
+          type="email"
+          value={fields.senderAddress}
+          onChange={(e) => {
+            fields.setSenderAddress(e.target.value);
+          }}
+          required
+        />
+      </div>
+      <div className="grid gap-2">
+        <FieldLabel htmlFor="smtp-sender-name">From name</FieldLabel>
+        <Input
+          id="smtp-sender-name"
+          value={fields.senderName}
+          onChange={(e) => {
+            fields.setSenderName(e.target.value);
+          }}
+        />
+      </div>
+      <div className="grid gap-2">
+        <FieldLabel htmlFor="smtp-reply-to">Reply-to address</FieldLabel>
+        <Input
+          id="smtp-reply-to"
+          type="email"
+          value={fields.replyToAddress}
+          onChange={(e) => {
+            fields.setReplyToAddress(e.target.value);
+          }}
+        />
+      </div>
+    </>
+  );
+}
+
+function SmtpForm({
+  status,
+  saving,
+  onSave,
+}: {
+  status: SmtpStatus;
+  saving: boolean;
+  onSave: (input: UpdateSmtpSettingsInput) => void;
+}): React.ReactElement {
+  const fields = useSmtpFormFields(status.config);
+
+  const submit = (event: React.SyntheticEvent): void => {
+    event.preventDefault();
+    onSave({
+      host: joinHostPort(fields.host, fields.port),
+      username: fields.username.trim() || undefined,
+      password: fields.password.trim() || undefined,
+      senderAddress: fields.senderAddress.trim(),
+      senderName: fields.senderName.trim() || undefined,
+      replyToAddress: fields.replyToAddress.trim() || undefined,
+      tls: fields.tls,
+    });
+  };
+
+  return (
+    <form className="grid max-w-md gap-3" onSubmit={submit} aria-labelledby="smtp-form-heading">
+      <div className="flex items-center justify-between">
+        <h3 id="smtp-form-heading" className="text-sm font-semibold text-foreground">
+          Mail server
+        </h3>
+        <ConfiguredStatus configured={status.configured} />
+      </div>
+      <HostFields fields={fields} />
+      <CredentialFields fields={fields} configured={status.configured} />
+      <SenderFields fields={fields} />
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="smtp-tls"
+          checked={fields.tls}
+          onCheckedChange={(value) => {
+            fields.setTls(value === true);
+          }}
+        />
+        <Label htmlFor="smtp-tls">Use TLS</Label>
+      </div>
+      <Button type="submit" disabled={saving} className="justify-self-start">
+        {saving ? 'Saving…' : 'Save settings'}
+      </Button>
+    </form>
+  );
+}
+
+function SmtpSettingsBody({
+  state,
+  onSave,
+}: {
+  state: SmtpSettingsState;
+  onSave: (input: UpdateSmtpSettingsInput) => void;
+}): React.ReactElement {
+  if (state.status === 'loading') {
+    return (
+      <p className="text-sm text-muted-foreground" role="status">
+        Loading mail settings…
+      </p>
+    );
+  }
+  if (state.status === 'load-error') {
+    return (
+      <p className="text-sm text-destructive" role="alert">
+        Could not load mail settings: {state.message}
+      </p>
+    );
+  }
+  return (
+    <div className="grid gap-3">
+      {state.status === 'error' && (
+        <p className="text-sm text-destructive" role="alert">
+          Could not save mail settings: {state.message}
+        </p>
+      )}
+      <SmtpForm status={state.settings} saving={state.status === 'saving'} onSave={onSave} />
+    </div>
+  );
+}
+
+// SmtpSettingsPanel is the console's view of the platform's outbound-mail
+// configuration (issue #1168): every flow that reaches a person out of band
+// (signup verification, password reset, the enrollment invite in
+// UsersPanel) depends on it, and a freshly deployed platform starts with
+// none configured. Only rendered for an OPERATIONS tenant — see App.tsx.
+export function SmtpSettingsPanel({ token }: { token: string }): React.ReactElement {
+  const { state, save } = useSmtpSettingsController(token);
+  return (
+    <Card aria-labelledby="smtp-settings-heading">
+      <CardHeader>
+        <CardTitle id="smtp-settings-heading">Outbound mail (SMTP)</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="mb-4 text-sm text-muted-foreground">
+          Bring your own provider&apos;s credentials — ERun does not supply a mail provider on your
+          behalf. Until this is configured, enrolling a user falls back to a temporary password
+          instead of an invite email.
+        </p>
+        <SmtpSettingsBody state={state} onSave={save} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/erun-console/src/identity/UsersPanel.test.tsx
+++ b/erun-console/src/identity/UsersPanel.test.tsx
@@ -71,13 +71,14 @@ describe('UsersPanel', () => {
     expect(screen.getByText('USER_STATE_ACTIVE')).toBeInTheDocument();
   });
 
-  it('enrolls a user and reports the erun mapping', async () => {
+  it('enrolls a user and reports the erun mapping, mail path: invite email', async () => {
     let listedAfterEnroll = false;
     mockFetch((req) => {
       if (req.method === 'POST' && req.url === '/v1/identity/users') {
         return jsonResponse({
           idpUser: { id: 'idp-2', username: 'bob', state: 'USER_STATE_INITIAL' },
           erunUser: { userId: 'erun-2', username: 'bob' },
+          mailDeliveryConfigured: true,
         });
       }
       if (req.url === '/v1/identity/users') {
@@ -98,7 +99,53 @@ describe('UsersPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Enroll user' }));
 
     expect(await screen.findByText(/Enrolled bob/)).toBeInTheDocument();
+    expect(screen.getByText(/An invite email is on its way/)).toBeInTheDocument();
     expect(listedAfterEnroll).toBe(true);
+    // The invite-email path never mints a credential to show.
+    expect(screen.queryByText(/Temporary password/)).not.toBeInTheDocument();
+  });
+
+  it('shows a one-time, copyable temporary password when mail is not configured', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    mockFetch((req) => {
+      if (req.method === 'POST' && req.url === '/v1/identity/users') {
+        return jsonResponse({
+          idpUser: { id: 'idp-4', username: 'dana', state: 'USER_STATE_ACTIVE' },
+          erunUser: { userId: 'erun-4', username: 'dana' },
+          mailDeliveryConfigured: false,
+          temporaryPassword: 'Er7hK2mQ9xL4nP6z!',
+          warning: "This platform's identity provider has no SMTP configured.",
+        });
+      }
+      return jsonResponse([]);
+    });
+    renderWithStore(<UsersPanel token="dev-token" />);
+    await screen.findByText('No users enrolled yet.');
+
+    fireEvent.change(screen.getByLabelText('Username', { exact: false }), {
+      target: { value: 'dana' },
+    });
+    fireEvent.change(screen.getByLabelText('Email', { exact: false }), {
+      target: { value: 'dana@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Enroll user' }));
+
+    expect(await screen.findByText(/Outbound mail is not configured/)).toBeInTheDocument();
+    expect(screen.getByText('Temporary password for dana')).toBeInTheDocument();
+    const passwordField = screen.getByLabelText<HTMLInputElement>('Temporary password');
+    expect(passwordField.value).toBe('Er7hK2mQ9xL4nP6z!');
+    expect(screen.getByText(/shown once and will not be shown again/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(writeText).toHaveBeenCalledWith('Er7hK2mQ9xL4nP6z!');
+    expect(await screen.findByRole('button', { name: 'Copied' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(screen.queryByText('Temporary password for dana')).not.toBeInTheDocument();
+    // The enrolled-user status message stays; only the one-time credential
+    // itself is gone from the controller's state.
+    expect(screen.getByText(/Enrolled dana/)).toBeInTheDocument();
   });
 
   it('reports the orphaned IdP identity when the erun mapping fails', async () => {

--- a/erun-console/src/identity/UsersPanel.tsx
+++ b/erun-console/src/identity/UsersPanel.tsx
@@ -4,6 +4,12 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   EmptyState,
   FieldLabel,
   Input,
@@ -21,6 +27,11 @@ import type { EnrollIdentityUserInput, IdentityUser } from '../app/api/identityA
 import type { EnrollState, UsersState } from './controller';
 import { useUsersController } from './controller';
 
+// EnrollFeedback tells the operator which of the two enrollment paths the
+// backend actually took: with mail configured, the identity provider emails
+// the invite itself; without it, there is no mail path for that link to
+// travel, so the temporary password shown below is the only way the new
+// person signs in.
 function EnrollFeedback({ enroll }: { enroll: EnrollState }): React.ReactElement | null {
   if (enroll.status === 'enrolled') {
     if (enroll.result.error !== undefined) {
@@ -32,9 +43,18 @@ function EnrollFeedback({ enroll }: { enroll: EnrollState }): React.ReactElement
         </p>
       );
     }
+    if (enroll.result.mailDeliveryConfigured) {
+      return (
+        <p className="text-sm text-muted-foreground" role="status">
+          Enrolled {enroll.result.idpUser.username}. An invite email is on its way to complete
+          sign-in.
+        </p>
+      );
+    }
     return (
       <p className="text-sm text-muted-foreground" role="status">
-        Enrolled {enroll.result.idpUser.username}. They will receive an email to complete sign-in.
+        Enrolled {enroll.result.idpUser.username}. Outbound mail is not configured, so no invite
+        email was sent — hand them the temporary password shown below.
       </p>
     );
   }
@@ -46,6 +66,69 @@ function EnrollFeedback({ enroll }: { enroll: EnrollState }): React.ReactElement
     );
   }
   return null;
+}
+
+// TemporaryPasswordDialog shows the one-time credential enrollment returns
+// when mail delivery is not configured. It never leaves a trace once closed:
+// onDismiss (wired to both the "Done" button and clicking outside/the X)
+// strips the password out of the controller's own state, so nothing keeps
+// holding it after the operator has copied or noted it down.
+function TemporaryPasswordDialog({
+  username,
+  password,
+  onDismiss,
+}: {
+  username: string;
+  password: string;
+  onDismiss: () => void;
+}): React.ReactElement {
+  const [copied, setCopied] = React.useState(false);
+
+  const copy = (): void => {
+    void navigator.clipboard.writeText(password).then(() => {
+      setCopied(true);
+    });
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          onDismiss();
+        }
+      }}
+    >
+      <DialogContent aria-labelledby="temp-password-heading">
+        <DialogHeader>
+          <DialogTitle id="temp-password-heading">Temporary password for {username}</DialogTitle>
+          <DialogDescription>
+            This is shown once and will not be shown again. Share it with {username} directly; they
+            must sign in and change it.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex items-center gap-2">
+          <Input
+            readOnly
+            value={password}
+            aria-label="Temporary password"
+            className="font-mono"
+            onFocus={(e) => {
+              e.target.select();
+            }}
+          />
+          <Button type="button" variant="outline" onClick={copy}>
+            {copied ? 'Copied' : 'Copy'}
+          </Button>
+        </div>
+        <DialogFooter>
+          <Button type="button" onClick={onDismiss}>
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 function EnrollForm({
@@ -221,7 +304,10 @@ function UsersBody({
 // mapping in one action) and deactivate/reactivate an existing one. Only
 // rendered for an OPERATIONS tenant — see App.tsx.
 export function UsersPanel({ token }: { token: string }): React.ReactElement {
-  const { usersState, enrollState, enroll, setActive } = useUsersController(token);
+  const { usersState, enrollState, enroll, setActive, dismissTemporaryPassword } =
+    useUsersController(token);
+  const temporaryPassword =
+    enrollState.status === 'enrolled' ? enrollState.result.temporaryPassword : undefined;
   return (
     <Card aria-labelledby="identity-users-heading">
       <CardHeader>
@@ -231,6 +317,13 @@ export function UsersPanel({ token }: { token: string }): React.ReactElement {
         <UsersBody usersState={usersState} onSetActive={setActive} />
         <EnrollForm enroll={enrollState} onEnroll={enroll} />
       </CardContent>
+      {temporaryPassword !== undefined && enrollState.status === 'enrolled' && (
+        <TemporaryPasswordDialog
+          username={enrollState.result.idpUser.username}
+          password={temporaryPassword}
+          onDismiss={dismissTemporaryPassword}
+        />
+      )}
     </Card>
   );
 }

--- a/erun-console/src/identity/controller.ts
+++ b/erun-console/src/identity/controller.ts
@@ -5,12 +5,16 @@ import {
   type EnrollIdentityUserResult,
   type IdentityUser,
   type OrgSettings,
+  type SmtpStatus,
   type UpdateOrgSettingsInput,
+  type UpdateSmtpSettingsInput,
   useCreateIdentityUserMutation,
   useGetOrgSettingsQuery,
+  useGetSmtpSettingsQuery,
   useListIdentityUsersQuery,
   useSetIdentityUserActiveMutation,
   useUpdateOrgSettingsMutation,
+  useUpdateSmtpSettingsMutation,
 } from '../app/api/identityApi';
 import { queryErrorMessage } from '../app/queryError';
 
@@ -42,6 +46,7 @@ export interface UsersController {
   refresh: () => void;
   enroll: (input: EnrollIdentityUserInput) => void;
   setActive: (externalId: string, active: boolean) => void;
+  dismissTemporaryPassword: () => void;
 }
 
 // useUsersController lists, enrolls, deactivates and reactivates identities.
@@ -107,7 +112,19 @@ export function useUsersController(token: string): UsersController {
     [token, activeRef, setIdentityUserActive],
   );
 
-  return { usersState, enrollState, refresh, enroll, setActive };
+  // dismissTemporaryPassword strips the one-time credential out of the held
+  // result once the operator has closed the dialog showing it, so it stops
+  // sitting in this controller's state — the enrolled/error messaging above
+  // it stays, only the secret itself is dropped.
+  const dismissTemporaryPassword = React.useCallback(() => {
+    setEnrollState((prev) =>
+      prev.status === 'enrolled' && prev.result.temporaryPassword !== undefined
+        ? { status: 'enrolled', result: { ...prev.result, temporaryPassword: undefined } }
+        : prev,
+    );
+  }, []);
+
+  return { usersState, enrollState, refresh, enroll, setActive, dismissTemporaryPassword };
 }
 
 export type OrgSettingsState =
@@ -146,6 +163,53 @@ export function useOrgSettingsController(token: string): OrgSettingsController {
     const settings = updateResult.data ?? query.data;
     if (settings === undefined) {
       return { status: 'loading' };
+    }
+    return updateResult.isLoading ? { status: 'saving', settings } : { status: 'ready', settings };
+  })();
+
+  return { state, save };
+}
+
+// SmtpSettingsState keeps a failed save's settings around (status 'error'
+// still carries the last-known settings) rather than replacing the form with
+// a bare error message: the operator's inputs stay editable and resubmitting
+// is the recovery path, instead of a dead end that only a page reload fixes.
+export type SmtpSettingsState =
+  | { status: 'loading' }
+  | { status: 'load-error'; message: string }
+  | { status: 'ready'; settings: SmtpStatus }
+  | { status: 'saving'; settings: SmtpStatus }
+  | { status: 'error'; settings: SmtpStatus; message: string };
+
+export interface SmtpSettingsController {
+  state: SmtpSettingsState;
+  save: (input: UpdateSmtpSettingsInput) => void;
+}
+
+// useSmtpSettingsController reads the platform's outbound-mail configuration
+// and applies updates, mirroring useOrgSettingsController's precedence rule
+// (the update result's own data wins over the read query's while a save is
+// settling).
+export function useSmtpSettingsController(token: string): SmtpSettingsController {
+  const query = useGetSmtpSettingsQuery(token);
+  const [updateSmtpSettings, updateResult] = useUpdateSmtpSettingsMutation();
+
+  const save = React.useCallback(
+    (input: UpdateSmtpSettingsInput) => {
+      void updateSmtpSettings({ token, input });
+    },
+    [token, updateSmtpSettings],
+  );
+
+  const state: SmtpSettingsState = (() => {
+    const settings = updateResult.data ?? query.data;
+    if (settings === undefined) {
+      return query.error !== undefined
+        ? { status: 'load-error', message: queryErrorMessage(query.error) }
+        : { status: 'loading' };
+    }
+    if (updateResult.isError) {
+      return { status: 'error', settings, message: queryErrorMessage(updateResult.error) };
     }
     return updateResult.isLoading ? { status: 'saving', settings } : { status: 'ready', settings };
   })();

--- a/erun-console/src/shell/AppShell.test.tsx
+++ b/erun-console/src/shell/AppShell.test.tsx
@@ -14,9 +14,9 @@ function jsonResponse(body: unknown, status = 200): Response {
   } as unknown as Response;
 }
 
-// Only the identity panels fetch on mount (Users, Org settings); every other
-// section fetches only on submit. A blanket 200-empty response is enough to
-// let navigating into either without erroring.
+// Only the identity panels fetch on mount (Users, Org settings, Outbound
+// mail); every other section fetches only on submit. A blanket 200-empty
+// response is enough to let navigating into any of them without erroring.
 function stubFetch(): void {
   vi.stubGlobal(
     'fetch',
@@ -70,6 +70,7 @@ describe('AppShell navigation', () => {
     const nav = within(screen.getByRole('navigation', { name: 'Console sections' }));
     expect(nav.getByRole('button', { name: /Users/ })).toBeInTheDocument();
     expect(nav.getByRole('button', { name: /Org settings/ })).toBeInTheDocument();
+    expect(nav.getByRole('button', { name: /Outbound mail/ })).toBeInTheDocument();
   });
 
   it('hides the identity sections for a non-OPERATIONS tenant', () => {
@@ -78,6 +79,7 @@ describe('AppShell navigation', () => {
     const nav = within(screen.getByRole('navigation', { name: 'Console sections' }));
     expect(nav.queryByRole('button', { name: /Users/ })).not.toBeInTheDocument();
     expect(nav.queryByRole('button', { name: /Org settings/ })).not.toBeInTheDocument();
+    expect(nav.queryByRole('button', { name: /Outbound mail/ })).not.toBeInTheDocument();
   });
 
   it('switches the main pane and keeps exactly one nav item current', () => {

--- a/erun-console/src/shell/AppShell.tsx
+++ b/erun-console/src/shell/AppShell.tsx
@@ -5,6 +5,7 @@ import { readTokenIdentity } from '../auth/identity';
 import { ConfigView } from '../config/ConfigView';
 import { EnvironmentsPanel } from '../environments/EnvironmentsPanel';
 import { OrgSettingsPanel } from '../identity/OrgSettingsPanel';
+import { SmtpSettingsPanel } from '../identity/SmtpSettingsPanel';
 import { UsersPanel } from '../identity/UsersPanel';
 import { MCPAccessPanel } from '../mcp/MCPAccessPanel';
 import { ProvisionPanel } from '../provision/ProvisionPanel';
@@ -48,6 +49,8 @@ function SectionContent({
       return <UsersPanel token={token} />;
     case 'org-settings':
       return <OrgSettingsPanel token={token} />;
+    case 'smtp-settings':
+      return <SmtpSettingsPanel token={token} />;
   }
 }
 

--- a/erun-console/src/shell/sections.ts
+++ b/erun-console/src/shell/sections.ts
@@ -1,5 +1,5 @@
 import type { TenantConfigView } from 'erun-kit';
-import { Cloud, KeyRound, LayoutDashboard, Server, Settings, Users } from 'lucide-react';
+import { Cloud, KeyRound, LayoutDashboard, Mail, Server, Settings, Users } from 'lucide-react';
 
 // Identity administration (issue #1209) is restricted server-side to an
 // OPERATIONS tenant; gating the nav entries here too keeps a COMPANY-tenant
@@ -12,7 +12,8 @@ export type ConsoleSectionId =
   | 'provisioning'
   | 'mcp-access'
   | 'users'
-  | 'org-settings';
+  | 'org-settings'
+  | 'smtp-settings';
 
 export interface ConsoleSection {
   id: ConsoleSectionId;
@@ -30,6 +31,7 @@ const BASE_SECTIONS: ConsoleSection[] = [
 const OPERATIONS_SECTIONS: ConsoleSection[] = [
   { id: 'users', label: 'Users', icon: Users },
   { id: 'org-settings', label: 'Org settings', icon: Settings },
+  { id: 'smtp-settings', label: 'Outbound mail', icon: Mail },
 ];
 
 // The nav mirrors the backend's own OPERATIONS-only restriction on identity

--- a/erun-docs/docs/agent-reference/identity-administration.md
+++ b/erun-docs/docs/agent-reference/identity-administration.md
@@ -6,7 +6,7 @@ title: Identity administration
 
 > For the Operator view, see [Administering identity](/collaboration/identity-administration).
 
-`/v1/identity/*` drives the platform's own IdP (Zitadel) Management API server-side, using an org-owner service-account credential the `erun-zitadel` chart provisions on every deployment and never exposes to a browser. It is the console's IdP-identity administration surface (issue #1209): enroll, list, deactivate, and reactivate identities, and read/update the org's login and password policy.
+`/v1/identity/*` drives the platform's own IdP (Zitadel) Management/Admin API server-side, using an org-owner service-account credential the `erun-zitadel` chart provisions on every deployment and never exposes to a browser. It is the console's IdP-identity administration surface (issue #1209): enroll, list, deactivate, and reactivate identities, read/update the org's login and password policy, and read/update the platform's outbound-mail (SMTP) configuration.
 
 ## Restricted to an OPERATIONS tenant
 
@@ -42,7 +42,12 @@ Lists every identity (human and machine) the platform's IdP knows about.
 
 ## `POST /v1/identity/users`
 
-Enrolls a new identity: creates it in the IdP (Zitadel's invite flow — no password is set here, so the enrollee receives an email to complete sign-in) and, only once that succeeds, creates the matching erun user and its `user_external_ids` mapping using the IdP's own returned id as `subject` and the caller's own token issuer as `issuer`.
+Enrolls a new identity, and creates it differently depending on whether the platform can actually send mail (issue #1168):
+
+- **Mail delivery configured** (see [`GET /v1/identity/smtp-settings`](#smtp-settings-get) below): the identity is created via Zitadel's invite flow — no password is set, so the enrollee receives an email to complete sign-in, and the IdP identity starts `USER_STATE_INITIAL`.
+- **Mail delivery not configured** (including when the check itself fails — treated the same as unconfigured, since assuming mail works when it might not risks the same dead end): Zitadel would still create the identity, but the invite email it depends on can never arrive, leaving the account stuck in `USER_STATE_INITIAL` forever. Instead, the identity is created with a random, generated password and its email marked verified (both required together — Zitadel only skips its own initialization email when *both* conditions hold), landing it `USER_STATE_ACTIVE` immediately. The generated password is returned once, in `temporaryPassword`, for the operator to hand to the enrollee out of band; it is never stored or logged.
+
+Only once the IdP half succeeds does this create the matching erun user and its `user_external_ids` mapping, using the IdP's own returned id as `subject` and the caller's own token issuer as `issuer`.
 
 ```jsonc
 // request body
@@ -53,20 +58,31 @@ Enrolls a new identity: creates it in the IdP (Zitadel's invite flow — no pass
   "lastName": "Operator"        // optional
 }
 
-// 201 response — both halves landed
+// 201 response — mail delivery configured, both halves landed
 {
   "idpUser": { "id": "387728445393600515", "username": "bob", "state": "USER_STATE_INITIAL" },
-  "erunUser": { "userId": "019a…", "username": "bob" }
+  "erunUser": { "userId": "019a…", "username": "bob" },
+  "mailDeliveryConfigured": true
+}
+
+// 201 response — mail delivery NOT configured: a temporary password stands in for the invite email
+{
+  "idpUser": { "id": "387728445393600515", "username": "bob", "state": "USER_STATE_ACTIVE" },
+  "erunUser": { "userId": "019a…", "username": "bob" },
+  "mailDeliveryConfigured": false,
+  "temporaryPassword": "Er7hK2mQ9xL4nP6z!",
+  "warning": "This platform's identity provider has no SMTP configured, so no invitation email was sent. Share temporaryPassword with bob directly; they must sign in and change it."
 }
 
 // 201 response — the IdP identity was created, but the erun mapping failed
 {
   "idpUser": { "id": "387728445393600515", "username": "bob", "state": "USER_STATE_INITIAL" },
+  "mailDeliveryConfigured": true,
   "error": "identity created in the identity provider but the erun user mapping failed: idp user id 387728445393600515: a user with this username already exists in the target tenant"
 }
 ```
 
-The IdP half is created first, since the erun mapping needs the subject the IdP assigns; a failure there means nothing was created and the response is an error (below), not a `201`. A failure in the erun half after the IdP identity exists is **not** an error response — it is a `201` with `error` set and no `erunUser`, naming the orphaned IdP user id so the operator can retry the mapping (`POST /v1/users` with that id as `subject`) rather than enroll a duplicate identity.
+The IdP half is created first, since the erun mapping needs the subject the IdP assigns; a failure there means nothing was created and the response is an error (below), not a `201`. A failure in the erun half after the IdP identity exists is **not** an error response — it is a `201` with `error` set and no `erunUser`, naming the orphaned IdP user id so the operator can retry the mapping (`POST /v1/users` with that id as `subject`) rather than enroll a duplicate identity. `mailDeliveryConfigured`/`temporaryPassword`/`warning` are reported the same way regardless of which of the two failure/success shapes above applies.
 
 **Error behaviour.**
 
@@ -123,6 +139,66 @@ Applies only the fields present in the body; every other current value is preser
 | `400` | Body is not valid JSON. | Send a valid JSON object; every field is optional. |
 | `403` | Caller's tenant is not `OPERATIONS`. | Call from an operations-tenant token. |
 | Forwarded from Zitadel | The policy write itself failed. | The response body carries Zitadel's own message. |
+
+## `GET /v1/identity/smtp-settings` {#smtp-settings-get}
+
+Reports whether the platform's IdP can send mail at all (issue #1168) — every flow that reaches a person out of band (signup verification, password reset, the invitation flow above) depends on it. Zitadel answers a plain `404` when no SMTP config is active; this translates that into an explicit, checkable field rather than leaving the `404` as the only signal.
+
+```jsonc
+// 200 response — configured
+{
+  "configured": true,
+  "config": {
+    "host": "smtp.example.com:587",
+    "user": "erun",
+    "senderAddress": "noreply@example.com",
+    "senderName": "Erun Platform",
+    "replyToAddress": "",
+    "tls": true
+  }
+}
+
+// 200 response — not configured
+{ "configured": false, "config": {} }
+```
+
+The password is never included, in either direction — Zitadel does not return it, and this endpoint only ever forwards what Zitadel itself reports.
+
+**Error behaviour.**
+
+| Status | Condition | Recovery |
+|---|---|---|
+| `403` | Caller's tenant is not `OPERATIONS`. | Call from an operations-tenant token. |
+| Forwarded from Zitadel | A transport-level failure reaching Zitadel (not the same as "no config" above, which is `200`). | The response body carries Zitadel's own message. |
+
+## `PATCH /v1/identity/smtp-settings` {#smtp-settings-patch}
+
+Converges the platform's outbound-mail configuration to the request body — provider-agnostic (any SMTP host), declarative (send the full desired state, not a diff). `host` and `senderAddress` are required; `password` is sourced by the caller from wherever it holds the mail provider's credential out of band, and is required the first time (there is nothing yet to leave unchanged), optional afterward (omit it to leave Zitadel's stored password untouched — there is no way to read it back to diff against).
+
+```jsonc
+// request body — first-time configuration
+{
+  "host": "smtp.example.com:587",
+  "username": "erun",
+  "password": "the-provider-issued-credential",
+  "senderAddress": "noreply@example.com",
+  "senderName": "Erun Platform",
+  "tls": true
+}
+
+// 200 response, same shape as GET /v1/identity/smtp-settings above
+{ "configured": true, "config": { "host": "smtp.example.com:587", "...": "..." } }
+```
+
+Internally this creates-and-activates Zitadel's SMTP config when none exists yet (a freshly created config defaults to inactive and is invisible to the `GET` above until explicitly activated), or read-modify-writes the existing one otherwise — always activating before writing a changed password, since Zitadel's password-update command refuses an inactive config.
+
+**Error behaviour.**
+
+| Status | Condition | Recovery |
+|---|---|---|
+| `400` | `host`/`senderAddress` empty, the body is not valid JSON, or no config exists yet and `password` was omitted. | Send `host`, `senderAddress`, and (for a first-time configuration) `password`. |
+| `403` | Caller's tenant is not `OPERATIONS`. | Call from an operations-tenant token. |
+| Forwarded from Zitadel | The config write itself failed. | The response body carries Zitadel's own message. |
 
 ## Audit
 

--- a/erun-docs/docs/collaboration/identity-administration.md
+++ b/erun-docs/docs/collaboration/identity-administration.md
@@ -12,7 +12,9 @@ For the full route/schema spec, see [Agent reference · Identity administration]
 
 Signed in as an Operator on an **OPERATIONS** tenant, the console's **Users** view lets you:
 
-- **Enroll a user.** Give a username and email; the console creates the identity in the platform's IdP (which emails them a sign-in link) and the matching erun user in one action. If the erun-side half fails after the identity provider half succeeds, the console tells you the identity provider id it created so you can retry the mapping rather than enrolling a duplicate.
+- **Enroll a user.** Give a username and email; the console creates the identity in the platform's IdP and the matching erun user in one action. If the erun-side half fails after the identity provider half succeeds, the console tells you the identity provider id it created so you can retry the mapping rather than enrolling a duplicate.
+  - **When outbound mail is configured** (see below), enrolling emails the new person a sign-in link, the normal invite flow.
+  - **When it is not**, there is no mail path for that link to travel, so the backend does not pretend to send one: it generates a temporary password instead and returns it once. This is deliberate — an invite that silently waited on an email that could never arrive would look successful and never resolve. **(Planned.)** A console view for handing that temporary password to you is landing alongside the backend work this depends on; until it does, ask an Agent to enroll the user for you and relay the password it gets back.
 - **List every identity** the platform's IdP knows about, with its current state.
 - **Deactivate** a user, which blocks their next sign-in immediately.
 - **Reactivate** a deactivated user.
@@ -22,6 +24,21 @@ The **Org settings** view lets you read and change:
 - Whether multi-factor authentication is required to sign in.
 - The password complexity policy (minimum length, and whether an uppercase letter, lowercase letter, number, or symbol is required).
 - The org's verified domains (read-only here — verifying a new domain is a DNS/HTTP challenge flow this view does not drive).
+
+## Outbound mail (SMTP)
+
+Signup verification, password reset, and the invite email above all depend on the platform's IdP actually being able to send mail — and by default, a freshly deployed platform cannot: no mail provider is configured. The platform can now report that state, and be told how to fix it (issue #1168):
+
+- **Host** — your provider's SMTP host and port, e.g. `smtp.yourprovider.com:587`.
+- **Username** and **Password** — the credential your mail provider issued you. Get this from your provider (or wherever your organization stores that kind of credential) before you start; the platform never generates or invents one.
+- **From address** and **From name** — what recipients see as the sender, e.g. `noreply@yourdomain.com` / `Your Company`.
+- **Use TLS** — leave this on unless your provider explicitly tells you otherwise.
+
+**(Planned.)** A console view for reading and setting this is landing alongside the backend work this depends on; until it does, ask an Agent to configure it for you — give it the values above and it drives the underlying API (see [Agent reference · Identity administration](/agent-reference/identity-administration#smtp-settings-get)).
+
+There is no way around supplying those values yourself — ERun cannot supply a mail provider on your behalf, and self-service password reset and signup verification simply cannot work without one. Until it's configured, the platform says so plainly rather than staying silent, and inviting a colleague falls back to the temporary-password flow described above rather than pretending an email went out.
+
+**To verify it worked:** once mail delivery is configured, enroll a throwaway test user (see above) — with mail configured, that enrollment emails a real sign-in link to the address you gave it, so receiving it is the proof. If nothing arrives, double check the host/port and credential with your mail provider; the error reported back is whatever your provider's server returned.
 
 ## What still requires Zitadel's own console
 

--- a/erun-docs/docs/collaboration/identity-administration.md
+++ b/erun-docs/docs/collaboration/identity-administration.md
@@ -14,7 +14,7 @@ Signed in as an Operator on an **OPERATIONS** tenant, the console's **Users** vi
 
 - **Enroll a user.** Give a username and email; the console creates the identity in the platform's IdP and the matching erun user in one action. If the erun-side half fails after the identity provider half succeeds, the console tells you the identity provider id it created so you can retry the mapping rather than enrolling a duplicate.
   - **When outbound mail is configured** (see below), enrolling emails the new person a sign-in link, the normal invite flow.
-  - **When it is not**, there is no mail path for that link to travel, so the backend does not pretend to send one: it generates a temporary password instead and returns it once. This is deliberate — an invite that silently waited on an email that could never arrive would look successful and never resolve. **(Planned.)** A console view for handing that temporary password to you is landing alongside the backend work this depends on; until it does, ask an Agent to enroll the user for you and relay the password it gets back.
+  - **When it is not**, there is no mail path for that link to travel, so the backend does not pretend to send one: it generates a temporary password instead and returns it once. This is deliberate — an invite that silently waited on an email that could never arrive would look successful and never resolve. The console shows this password in a dialog right after enrollment, copyable in one click, and says plainly it will not be shown again. Hand it to the new person before closing the dialog — closing it drops the password from the console's own state for good.
 - **List every identity** the platform's IdP knows about, with its current state.
 - **Deactivate** a user, which blocks their next sign-in immediately.
 - **Reactivate** a deactivated user.
@@ -27,14 +27,14 @@ The **Org settings** view lets you read and change:
 
 ## Outbound mail (SMTP)
 
-Signup verification, password reset, and the invite email above all depend on the platform's IdP actually being able to send mail — and by default, a freshly deployed platform cannot: no mail provider is configured. The platform can now report that state, and be told how to fix it (issue #1168):
+Signup verification, password reset, and the invite email above all depend on the platform's IdP actually being able to send mail — and by default, a freshly deployed platform cannot: no mail provider is configured. The console's **Outbound mail** view (next to Users and Org settings, same OPERATIONS-only visibility) reports that state plainly — a badge reading "Not configured" or "Configured" — and lets you set:
 
-- **Host** — your provider's SMTP host and port, e.g. `smtp.yourprovider.com:587`.
-- **Username** and **Password** — the credential your mail provider issued you. Get this from your provider (or wherever your organization stores that kind of credential) before you start; the platform never generates or invents one.
+- **Host** and **Port** — your provider's SMTP host and port, e.g. `smtp.yourprovider.com` / `587`.
+- **Username** and **Password** — the credential your mail provider issued you. Get this from your provider (or wherever your organization stores that kind of credential) before you start; the platform never generates or invents one. Password is required the first time you configure mail; leave it blank on a later edit to keep the one already stored.
 - **From address** and **From name** — what recipients see as the sender, e.g. `noreply@yourdomain.com` / `Your Company`.
 - **Use TLS** — leave this on unless your provider explicitly tells you otherwise.
 
-**(Planned.)** A console view for reading and setting this is landing alongside the backend work this depends on; until it does, ask an Agent to configure it for you — give it the values above and it drives the underlying API (see [Agent reference · Identity administration](/agent-reference/identity-administration#smtp-settings-get)).
+Saving drives the same underlying API an Agent would call directly (see [Agent reference · Identity administration](/agent-reference/identity-administration#smtp-settings-get)); a failed save reports your mail provider's own error next to the form, and your entries stay in place so you can fix the value and retry.
 
 There is no way around supplying those values yourself — ERun cannot supply a mail provider on your behalf, and self-service password reset and signup verification simply cannot work without one. Until it's configured, the platform says so plainly rather than staying silent, and inviting a colleague falls back to the temporary-password flow described above rather than pretending an email went out.
 


### PR DESCRIPTION
## Summary

The platform's IdP had **no mail provider at all**:

```
GET admin/v1/smtp -> 404
{"code":5, "message":"SMTP configuration not found (QUERY-fwofw)"}
```

So nothing that reaches a person out-of-band worked: signup verification,
password reset, and **invitation links — the mechanism the platform's
operator-driven enrollment actually needs**. Invisible for an admin bootstrapped
out-of-band; load-bearing the moment a second person is meant to use the
platform.

## Enrollment no longer waits on mail that cannot arrive

`IdentityService.Enroll` now checks SMTP status **before** creating the identity:

- **Mail configured** → the existing passwordless invite-email flow, unchanged.
- **Unconfigured, or unknown** — deliberately treated alike, to avoid assuming
  mail works — → a random temporary password, so the account is
  `USER_STATE_ACTIVE` and usable immediately rather than stranded in
  `USER_STATE_INITIAL` waiting on a link nothing can send.

That does not merely fail honestly; it removes the dead end. Enrollment succeeds
either way.

## And the operator can act on both, in the console

An earlier revision of this branch shipped the backend with docs that said
*"(Planned.)"* twice and told the reader to *"ask an Agent"* — which is
`AGENTS.md` § `## Smooth, Seamless, No Dead Ends` failure mode 3 with a
different noun, and would have left an operator unable to configure mail or to
retrieve the password the backend mints. Both are now built:

- **Outbound mail** — a console section to read and set host, port, username,
  password, from-address, from-name and TLS via `GET`/`PATCH
  /v1/identity/smtp-settings`, including the *not configured* default every
  fresh platform starts in, and a failed save that reports the provider's own
  error.
- **The temporary password is surfaced once**, in a dialog that says so
  plainly — *"This is shown once and will not be shown again. Share it with
  them directly; they must sign in and change it."* — with one-click copy. It
  never persists: closing strips it from controller state.
- **Enrollment names which path it took**, so the operator never has to infer
  it: *"An invite email is on its way"* versus *"Outbound mail is not
  configured, so no invite email was sent — hand them the temporary password
  shown below."*

## Verification

A Zitadel SMTP client with unit and e2e coverage against a local SMTP sink —
proving a message is produced and accepted, not merely that a config object was
written. Console tests for the settings view including the not-configured
default and a failed save, and for the password dialog appearing only when mail
is unconfigured and not persisting after close. Screenshots for all five states.

Not verified: delivery through a real production mail provider. That requires
credentials the product cannot invent, and supplying them is the operator's one
genuine step — documented precisely, with how to confirm it worked.

## Docs

`erun-docs/docs/collaboration/identity-administration.md` and
`erun-docs/docs/agent-reference/identity-administration.md`, in this PR. Both
"(Planned.)" paragraphs are gone, replaced by what actually exists.

Closes #1168
