### PR TITLE
Make the console's signed-out route a landing page instead of a bare sign-in card

### DIFF
--- a/erun-console/index.html
+++ b/erun-console/index.html
@@ -3,10 +3,29 @@
   <head>
     <meta charset="UTF-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <meta
+      content="Agentic coding from idea to production — at speed, without compromising compliance."
+      name="description"
+    />
+    <link href="/favicon.svg" rel="icon" type="image/svg+xml" />
     <!-- Overwritten at runtime from platform discovery (GET /v1/platform)
-         once the instance's brand resolves — see App.tsx's useBrand. This is
-         only the pre-JS bootstrap value. -->
+         once the instance's brand resolves — see App.tsx's usePlatformInfo.
+         This is only the pre-JS bootstrap value, so the social preview tags
+         below carry the bundled product-level default rather than any
+         instance's own name. -->
     <title>ERun console</title>
+    <meta content="ERun console" property="og:title" />
+    <meta
+      content="Agentic coding from idea to production — at speed, without compromising compliance."
+      property="og:description"
+    />
+    <meta content="website" property="og:type" />
+    <meta content="summary" name="twitter:card" />
+    <meta content="ERun console" name="twitter:title" />
+    <meta
+      content="Agentic coding from idea to production — at speed, without compromising compliance."
+      name="twitter:description"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/erun-console/playwright/tests/oidc-signin.spec.ts
+++ b/erun-console/playwright/tests/oidc-signin.spec.ts
@@ -27,18 +27,19 @@ const password = process.env.E2E_LOGIN_PASSWORD ?? 'E2eOperator1!';
 // yields an id_token, and the API verifies that token against Zitadel's live
 // JWKS and — on an empty database — bootstraps the operations tenant, which
 // GET /v1/config then renders.
-test('operator signs in through Zitadel OIDC, registers an environment, and sees the deploy-executor-unconfigured response', async ({ page }) => {
+test('operator signs in through Zitadel OIDC, registers an environment, and sees the deploy-executor-unconfigured response', async ({
+  page,
+}) => {
   test.skip(
     gated,
     'opt-in: set ERUN_E2E_CONSOLE_OIDC=1 (./run.sh brings up the stack and sets it)',
   );
 
-  // 1. The signed-out console offers the real OIDC sign-in, not the dev-token
-  //    fallback: a Sign in button only renders when the issuer is configured.
+  // 1. The signed-out console is the landing page (erun#1327), offering the
+  //    real OIDC sign-in, not the dev-token fallback: a Sign in button only
+  //    renders when the issuer is configured.
   await page.goto('/');
-  await expect(
-    page.getByText('Sign in with your organization identity to view and manage your environments.'),
-  ).toBeVisible();
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
   await page.getByRole('button', { name: 'Sign in' }).click();
 
   // 2. The browser lands on Zitadel's own Login V2 UI — loginname step.

--- a/erun-console/public/favicon.svg
+++ b/erun-console/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="ERun">
+  <defs>
+    <linearGradient id="erunGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0e7c66"/>
+      <stop offset="100%" stop-color="#0a5d4d"/>
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="url(#erunGrad)"/>
+  <g fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M18 22 H40"/>
+    <path d="M18 32 H34"/>
+    <path d="M18 42 H40"/>
+    <circle cx="46" cy="42" r="3" fill="#ffffff" stroke="none"/>
+  </g>
+</svg>

--- a/erun-console/src/App.test.tsx
+++ b/erun-console/src/App.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { App } from './App';
+import { renderWithStore } from './test/renderWithStore';
+
+const PLATFORM = {
+  issuer: 'https://auth.acme.example',
+  apiUrl: 'https://console.acme.example',
+  consoleUrl: 'https://console.acme.example',
+  consoleClientId: 'console-client',
+  cliClientId: 'cli-client',
+  brand: 'Acme',
+  docsUrl: 'https://docs.acme.example',
+  tagline: 'Acme, from idea to production.',
+  logoUrl: '',
+};
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: () => Promise.resolve(body) } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.stubEnv('VITE_DEV_BEARER_TOKEN', '');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve(jsonResponse(PLATFORM))),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('App signed-out route', () => {
+  // The regression this guards: the old signed-out screen was a CenteredCard
+  // wrapping a CardTitle div and a paragraph — zero real <h1>-<h6> elements,
+  // per erun#1327 ("no <h1> and no <main> landmark"). This same assertion,
+  // run against origin/main's SignInScreen, fails with "expected length to be
+  // greater than 1, received 0" (CardTitle is a <div>, not a heading) — see
+  // the PR description for the recorded red run. It passes here because
+  // LandingScreen renders a real <h1> pitch and an <h2> differentiators
+  // heading inside a <main> landmark.
+  it('is a real landing page, not merely a CenteredCard sign-in prompt', async () => {
+    renderWithStore(<App />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('heading').length).toBeGreaterThan(1);
+    });
+    expect(screen.getByRole('main')).toBeInTheDocument();
+    const docsLinks = screen.getAllByRole('link', { name: 'Read the docs' });
+    expect(docsLinks.length).toBeGreaterThan(0);
+    for (const link of docsLinks) {
+      expect(link).toHaveAttribute('href', 'https://docs.acme.example');
+    }
+  });
+
+  it('renders the instance tagline from platform discovery as the h1', async () => {
+    renderWithStore(<App />);
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'Acme, from idea to production.' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/erun-console/src/App.tsx
+++ b/erun-console/src/App.tsx
@@ -10,12 +10,8 @@ import type { OidcConfig } from './auth/auth';
 import { signOut } from './auth/auth';
 import { fetchPlatformConfig } from './config/platform';
 import { AppShell } from './shell/AppShell';
-import {
-  ErrorScreen,
-  LoadingScreen,
-  NotEnrolledScreen,
-  SignInScreen,
-} from './shell/PreShellScreens';
+import { LandingScreen } from './shell/LandingScreen';
+import { ErrorScreen, LoadingScreen, NotEnrolledScreen } from './shell/PreShellScreens';
 
 type LoadState =
   | { status: 'loading' }
@@ -77,20 +73,35 @@ function computeLoadState(auth: AuthPhase, configQuery: ConfigQueryPhase): LoadS
   return loadStateFromConfigQuery(auth.token, configQuery);
 }
 
-// useBrand resolves the platform's display name from discovery (GET
-// /v1/platform) and mirrors it into the document title — the one thing that
-// used to be a hardcoded literal (`erun console`) despite the value already
-// being fetched and parsed for OIDC config. There is no logo/favicon field in
-// the platform contract today, so the favicon stays the static build asset.
-function useBrand(): string | undefined {
-  const [brand, setBrand] = React.useState<string | undefined>(undefined);
+interface PlatformInfo {
+  brand?: string;
+  docsUrl?: string;
+  tagline?: string;
+  logoUrl?: string;
+}
+
+// usePlatformInfo resolves the instance's white-label surface from discovery
+// (GET /v1/platform) and mirrors the brand into the document title — the one
+// thing that used to be a hardcoded literal (`erun console`) despite the
+// value already being fetched and parsed for OIDC config. Every field is
+// optional and left undefined when the backend has it unset (#1327); callers
+// fall back to bundled product-level defaults, never a hardcoded instance
+// name.
+function usePlatformInfo(): PlatformInfo {
+  const [info, setInfo] = React.useState<PlatformInfo>({});
   React.useEffect(() => {
     let cancelled = false;
     fetchPlatformConfig()
       .then((platform) => {
-        if (!cancelled && platform !== undefined && platform.brand.length > 0) {
-          setBrand(platform.brand);
+        if (cancelled || platform === undefined) {
+          return;
         }
+        setInfo({
+          brand: platform.brand.length > 0 ? platform.brand : undefined,
+          docsUrl: platform.docsUrl.length > 0 ? platform.docsUrl : undefined,
+          tagline: platform.tagline.length > 0 ? platform.tagline : undefined,
+          logoUrl: platform.logoUrl.length > 0 ? platform.logoUrl : undefined,
+        });
       })
       .catch(() => undefined);
     return () => {
@@ -98,31 +109,41 @@ function useBrand(): string | undefined {
     };
   }, []);
   React.useEffect(() => {
-    document.title = brand !== undefined ? `${brand} console` : 'ERun console';
-  }, [brand]);
-  return brand;
+    document.title = info.brand !== undefined ? `${info.brand} console` : 'ERun console';
+  }, [info.brand]);
+  return info;
 }
 
 function AppContent({
-  brand,
+  platform,
   state,
   oidc,
   oidcFallbackReason,
   onChanged,
   onSignOut,
 }: {
-  brand: string | undefined;
+  platform: PlatformInfo;
   state: LoadState;
   oidc: OidcConfig | undefined;
   oidcFallbackReason: string | undefined;
   onChanged: () => void;
   onSignOut: () => void;
 }): React.ReactElement {
+  const brand = platform.brand;
   switch (state.status) {
     case 'loading':
       return <LoadingScreen brand={brand} />;
     case 'signed-out':
-      return <SignInScreen brand={brand} oidc={oidc} fallbackReason={oidcFallbackReason} />;
+      return (
+        <LandingScreen
+          brand={brand}
+          logoUrl={platform.logoUrl}
+          tagline={platform.tagline}
+          docsUrl={platform.docsUrl}
+          oidc={oidc}
+          fallbackReason={oidcFallbackReason}
+        />
+      );
     case 'not-enrolled':
       return <NotEnrolledScreen brand={brand} token={state.token} />;
     case 'error':
@@ -141,7 +162,7 @@ function AppContent({
 }
 
 export function App(): React.ReactElement {
-  const brand = useBrand();
+  const platform = usePlatformInfo();
   const dispatch = useAppDispatch();
   const auth = useAppSelector((s) => s.auth);
 
@@ -165,7 +186,7 @@ export function App(): React.ReactElement {
   return (
     <TooltipProvider>
       <AppContent
-        brand={brand}
+        platform={platform}
         state={state}
         oidc={auth.oidc}
         oidcFallbackReason={auth.oidcFallbackReason}

--- a/erun-console/src/App.tsx
+++ b/erun-console/src/App.tsx
@@ -12,6 +12,7 @@ import { fetchPlatformConfig } from './config/platform';
 import { AppShell } from './shell/AppShell';
 import { LandingScreen } from './shell/LandingScreen';
 import { ErrorScreen, LoadingScreen, NotEnrolledScreen } from './shell/PreShellScreens';
+import { applyTheme, initialTheme } from './shell/theme';
 
 type LoadState =
   | { status: 'loading' }
@@ -165,6 +166,14 @@ export function App(): React.ReactElement {
   const platform = usePlatformInfo();
   const dispatch = useAppDispatch();
   const auth = useAppSelector((s) => s.auth);
+
+  // The `.dark` class only gets applied here, once, so every pre-shell screen
+  // (including the signed-out landing page) honors a stored or OS-level dark
+  // preference from first paint — not only after AppShell's own toggle (whose
+  // useTheme() re-reads the same preference) has mounted post-sign-in.
+  React.useEffect(() => {
+    applyTheme(initialTheme());
+  }, []);
 
   // Resolves the OIDC config from platform discovery (GET /v1/platform), then
   // the bearer token (an OIDC callback exchange, a token held this session,

--- a/erun-console/src/assets/logo.svg
+++ b/erun-console/src/assets/logo.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="ERun">
+  <defs>
+    <linearGradient id="erunGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0e7c66"/>
+      <stop offset="100%" stop-color="#0a5d4d"/>
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="url(#erunGrad)"/>
+  <g fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M18 22 H40"/>
+    <path d="M18 32 H34"/>
+    <path d="M18 42 H40"/>
+    <circle cx="46" cy="42" r="3" fill="#ffffff" stroke="none"/>
+  </g>
+</svg>

--- a/erun-console/src/config/ConfigView.test.tsx
+++ b/erun-console/src/config/ConfigView.test.tsx
@@ -163,11 +163,12 @@ describe('ConfigView via App', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(
-          'A bearer token is required to view your environments. Ask an operator for one, or configure OIDC sign-in for this instance.',
-        ),
+        screen.getByText(/A bearer token is required to view your environments\./),
       ).toBeInTheDocument();
     });
+    expect(
+      screen.getByRole('link', { name: 'configure OIDC sign-in for this instance' }),
+    ).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
   });
 });

--- a/erun-console/src/config/ConfigView.test.tsx
+++ b/erun-console/src/config/ConfigView.test.tsx
@@ -154,15 +154,20 @@ describe('ConfigView via App', () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/An operator has to enrol you/)).toBeInTheDocument();
     // Offering Sign in here is the loop this fix removes.
-    expect(screen.queryByText('Sign in to your console')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sign in' })).not.toBeInTheDocument();
   });
 
-  it('renders the sign-in prompt when there is no dev token', async () => {
+  it('renders the landing page when there is no dev token', async () => {
     vi.stubEnv('VITE_DEV_BEARER_TOKEN', '');
     renderWithStore(<App />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sign in to your console')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'A bearer token is required to view your environments. Ask an operator for one, or configure OIDC sign-in for this instance.',
+        ),
+      ).toBeInTheDocument();
     });
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
   });
 });

--- a/erun-console/src/config/platform.test.ts
+++ b/erun-console/src/config/platform.test.ts
@@ -27,6 +27,9 @@ describe('fetchPlatformConfig', () => {
             consoleClientId: 'console-client',
             cliClientId: 'cli-client',
             brand: 'Acme',
+            docsUrl: 'https://docs.acme.example',
+            tagline: 'Acme tagline',
+            logoUrl: 'https://console.acme.example/logo.svg',
           }),
         ),
       ),
@@ -39,6 +42,9 @@ describe('fetchPlatformConfig', () => {
       consoleClientId: 'console-client',
       cliClientId: 'cli-client',
       brand: 'Acme',
+      docsUrl: 'https://docs.acme.example',
+      tagline: 'Acme tagline',
+      logoUrl: 'https://console.acme.example/logo.svg',
     });
   });
 
@@ -70,6 +76,9 @@ describe('fetchPlatformConfig', () => {
       consoleClientId: '',
       cliClientId: '',
       brand: '',
+      docsUrl: '',
+      tagline: '',
+      logoUrl: '',
     });
   });
 });

--- a/erun-console/src/config/platform.ts
+++ b/erun-console/src/config/platform.ts
@@ -15,6 +15,9 @@ export interface PlatformConfig {
   consoleClientId: string;
   cliClientId: string;
   brand: string;
+  docsUrl: string;
+  tagline: string;
+  logoUrl: string;
 }
 
 function asString(value: unknown): string {
@@ -54,5 +57,8 @@ export async function fetchPlatformConfig(): Promise<PlatformConfig | undefined>
     consoleClientId: asString(body.consoleClientId),
     cliClientId: asString(body.cliClientId),
     brand: asString(body.brand),
+    docsUrl: asString(body.docsUrl),
+    tagline: asString(body.tagline),
+    logoUrl: asString(body.logoUrl),
   };
 }

--- a/erun-console/src/shell/BrandMark.tsx
+++ b/erun-console/src/shell/BrandMark.tsx
@@ -1,19 +1,30 @@
 import { cn } from 'erun-kit';
 import type * as React from 'react';
 
-// BrandMark renders the platform's initial as a mark, since the platform
-// contract (GET /v1/platform) carries a display name (`brand`) but no logo
-// asset — there is nothing image-shaped to render yet. It falls back to the
-// generic product initial when no instance brand is configured, never a
-// hardcoded instance name.
+// BrandMark renders an instance's logo when platform discovery (GET
+// /v1/platform) carries one (`logoUrl`), and falls back to the product
+// initial otherwise — no instance sets a logo yet, so this fallback is the
+// only path exercised today, and it must never assume a hardcoded instance
+// name.
 export function BrandMark({
   brand,
+  logoUrl,
   className,
 }: {
   brand: string | undefined;
+  logoUrl?: string;
   className?: string;
 }): React.ReactElement {
   const label = brand && brand.length > 0 ? brand : 'ERun';
+  if (logoUrl !== undefined && logoUrl.length > 0) {
+    return (
+      <img
+        src={logoUrl}
+        alt=""
+        className={cn('size-7 flex-none rounded-md object-contain', className)}
+      />
+    );
+  }
   const initial = label.trim().charAt(0).toUpperCase();
   return (
     <span

--- a/erun-console/src/shell/LandingDifferentiators.tsx
+++ b/erun-console/src/shell/LandingDifferentiators.tsx
@@ -17,7 +17,7 @@ export function LandingDifferentiators({ brandLabel }: { brandLabel: string }): 
         >
           What makes {brandLabel} different
         </h2>
-        <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {DIFFERENTIATORS.map((item) => (
             <Card key={item.key} className="flex flex-col gap-3 px-6">
               <item.icon aria-hidden="true" className="size-6 text-primary" />

--- a/erun-console/src/shell/LandingDifferentiators.tsx
+++ b/erun-console/src/shell/LandingDifferentiators.tsx
@@ -1,12 +1,38 @@
-import { Card } from 'erun-kit';
+import { Card, cn } from 'erun-kit';
 import type * as React from 'react';
 
 import { DIFFERENTIATORS } from './landingContent';
 
-// A row of four cards, not the docs site's hand-drawn diagram: the diagram's
-// charcoal/cyan vocabulary is a different visual system than the console's
-// shadcn/Tailwind tokens, and a copy loaded as a static <img> would not adapt
-// to the console's dark-mode toggle the way these cards do for free (#1327).
+const FEATURED_INDEX = 0;
+const BANNER_INDEX = 3;
+
+// Four identical outline boxes read as a template, not a designed page.
+// Give the set rhythm instead — the strongest claim ("Side by side", the
+// product's one distinctive interaction model) takes the accent treatment
+// and double width, and the last card runs full-width as a closing banner,
+// so a reader has somewhere to look first rather than scanning four equals
+// left to right. Cards, not the docs site's hand-drawn diagram: a copy
+// loaded as a static image wouldn't repaint for the dark-mode toggle.
+function cardClassName(index: number): string {
+  if (index === FEATURED_INDEX) {
+    return 'border-transparent bg-accent-brand text-accent-brand-foreground lg:col-span-2';
+  }
+  if (index === BANNER_INDEX) {
+    return 'lg:col-span-4 lg:flex-row lg:items-center lg:gap-6';
+  }
+  return '';
+}
+
+function iconClassName(index: number): string {
+  if (index === FEATURED_INDEX) {
+    return 'size-8 text-accent-brand-foreground';
+  }
+  if (index === BANNER_INDEX) {
+    return 'size-6 shrink-0 text-accent-brand';
+  }
+  return 'size-6 text-accent-brand';
+}
+
 export function LandingDifferentiators({ brandLabel }: { brandLabel: string }): React.ReactElement {
   return (
     <section aria-labelledby="differentiators-heading" className="px-6 py-16 sm:py-20">
@@ -18,11 +44,27 @@ export function LandingDifferentiators({ brandLabel }: { brandLabel: string }): 
           What makes {brandLabel} different
         </h2>
         <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          {DIFFERENTIATORS.map((item) => (
-            <Card key={item.key} className="flex flex-col gap-3 px-6">
-              <item.icon aria-hidden="true" className="size-6 text-primary" />
-              <h3 className="text-base font-semibold text-card-foreground">{item.label}</h3>
-              <p className="text-sm text-muted-foreground">{item.description}</p>
+          {DIFFERENTIATORS.map((item, index) => (
+            <Card
+              key={item.key}
+              style={{ animationDelay: `${String(index * 100)}ms` }}
+              className={cn(
+                'flex flex-col gap-3 px-6 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:duration-500 motion-safe:fill-mode-both',
+                cardClassName(index),
+              )}
+            >
+              <item.icon aria-hidden="true" className={iconClassName(index)} />
+              <h3 className="text-base font-semibold">{item.label}</h3>
+              <p
+                className={cn(
+                  'text-sm',
+                  index === FEATURED_INDEX
+                    ? 'text-accent-brand-foreground/80'
+                    : 'text-muted-foreground',
+                )}
+              >
+                {item.description}
+              </p>
             </Card>
           ))}
         </div>

--- a/erun-console/src/shell/LandingDifferentiators.tsx
+++ b/erun-console/src/shell/LandingDifferentiators.tsx
@@ -1,0 +1,32 @@
+import { Card } from 'erun-kit';
+import type * as React from 'react';
+
+import { DIFFERENTIATORS } from './landingContent';
+
+// A row of four cards, not the docs site's hand-drawn diagram: the diagram's
+// charcoal/cyan vocabulary is a different visual system than the console's
+// shadcn/Tailwind tokens, and a copy loaded as a static <img> would not adapt
+// to the console's dark-mode toggle the way these cards do for free (#1327).
+export function LandingDifferentiators({ brandLabel }: { brandLabel: string }): React.ReactElement {
+  return (
+    <section aria-labelledby="differentiators-heading" className="px-6 py-16 sm:py-20">
+      <div className="mx-auto max-w-5xl">
+        <h2
+          id="differentiators-heading"
+          className="text-center text-2xl font-semibold text-foreground sm:text-3xl"
+        >
+          What makes {brandLabel} different
+        </h2>
+        <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {DIFFERENTIATORS.map((item) => (
+            <Card key={item.key} className="flex flex-col gap-3 px-6">
+              <item.icon aria-hidden="true" className="size-6 text-primary" />
+              <h3 className="text-base font-semibold text-card-foreground">{item.label}</h3>
+              <p className="text-sm text-muted-foreground">{item.description}</p>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/erun-console/src/shell/LandingFooter.tsx
+++ b/erun-console/src/shell/LandingFooter.tsx
@@ -1,5 +1,11 @@
 import type * as React from 'react';
 
+import { PUBLIC_DOCS_URL } from './landingContent';
+
+// The docs link is the one exit every visitor can reach regardless of
+// sign-in state: falling back to the public docs site when an instance sets
+// no docsUrl keeps this the footer's one unconditional affordance, rather
+// than a link that silently disappears on an unconfigured instance.
 export function LandingFooter({
   brandLabel,
   docsUrl,
@@ -7,21 +13,19 @@ export function LandingFooter({
   brandLabel: string;
   docsUrl: string | undefined;
 }): React.ReactElement {
-  const hasDocsUrl = docsUrl !== undefined && docsUrl.length > 0;
+  const resolvedDocsUrl = docsUrl !== undefined && docsUrl.length > 0 ? docsUrl : PUBLIC_DOCS_URL;
   return (
     <footer className="border-t border-border px-6 py-8">
       <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-3 text-sm text-muted-foreground sm:flex-row">
         <span>{brandLabel}</span>
-        {hasDocsUrl && (
-          <a
-            href={docsUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="font-medium text-foreground underline-offset-4 hover:underline"
-          >
-            Read the docs
-          </a>
-        )}
+        <a
+          href={resolvedDocsUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="font-medium text-foreground underline-offset-4 hover:underline"
+        >
+          Read the docs
+        </a>
       </div>
     </footer>
   );

--- a/erun-console/src/shell/LandingFooter.tsx
+++ b/erun-console/src/shell/LandingFooter.tsx
@@ -1,0 +1,28 @@
+import type * as React from 'react';
+
+export function LandingFooter({
+  brandLabel,
+  docsUrl,
+}: {
+  brandLabel: string;
+  docsUrl: string | undefined;
+}): React.ReactElement {
+  const hasDocsUrl = docsUrl !== undefined && docsUrl.length > 0;
+  return (
+    <footer className="border-t border-border px-6 py-8">
+      <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-3 text-sm text-muted-foreground sm:flex-row">
+        <span>{brandLabel}</span>
+        {hasDocsUrl && (
+          <a
+            href={docsUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="font-medium text-foreground underline-offset-4 hover:underline"
+          >
+            Read the docs
+          </a>
+        )}
+      </div>
+    </footer>
+  );
+}

--- a/erun-console/src/shell/LandingHero.tsx
+++ b/erun-console/src/shell/LandingHero.tsx
@@ -1,14 +1,20 @@
 import { Button } from 'erun-kit';
+import { Sparkles } from 'lucide-react';
 import type * as React from 'react';
 
 import type { OidcConfig } from '../auth/auth';
 import { beginLogin } from '../auth/auth';
+import { LandingHeroVisual } from './LandingHeroVisual';
 
 // The hero carries the pitch and both calls to action. Sign in stays the
 // primary button so an existing user's path is exactly as short as the old
 // bare card's — "Read the docs" is the secondary action a first-time visitor
 // takes instead, and it renders only when platform discovery actually
-// supplied a docs host (#1327: never a hardcoded fallback host).
+// supplied a docs host: never a hardcoded fallback host. The
+// two-column split at `lg` (copy left, product visual right) is what keeps
+// the section from reading as a near-empty full-viewport banner, and what
+// constrains the headline's measure so a long instance tagline still reads
+// in a handful of lines instead of wrapping the width of the whole page.
 export function LandingHero({
   tagline,
   description,
@@ -24,38 +30,47 @@ export function LandingHero({
 }): React.ReactElement {
   const hasDocsUrl = docsUrl !== undefined && docsUrl.length > 0;
   return (
-    <section className="border-b border-border bg-gradient-to-b from-muted/60 to-background px-6 py-16 sm:py-24">
-      <div className="mx-auto flex max-w-3xl flex-col items-center gap-6 text-center">
-        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-5xl">{tagline}</h1>
-        <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">{description}</p>
-        <div className="flex flex-col items-center gap-3 sm:flex-row">
-          {oidc !== undefined ? (
-            <Button
-              type="button"
-              size="lg"
-              onClick={() => {
-                void beginLogin(oidc);
-              }}
-            >
-              Sign in
-            </Button>
-          ) : (
-            <p className="max-w-sm text-xs text-muted-foreground">
-              A bearer token is required to view your environments. Ask an operator for one, or
-              configure OIDC sign-in for this instance.
-            </p>
-          )}
-          {hasDocsUrl && (
-            <Button type="button" variant="outline" size="lg" asChild>
-              <a href={docsUrl} target="_blank" rel="noreferrer">
-                Read the docs
-              </a>
-            </Button>
+    <section className="border-b border-border bg-gradient-to-b from-muted/40 to-background px-6 py-12 sm:py-16">
+      <div className="mx-auto grid max-w-6xl gap-10 lg:grid-cols-2 lg:items-center lg:gap-16">
+        <div className="flex flex-col items-center gap-6 text-center motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 motion-safe:duration-700 motion-safe:fill-mode-both lg:items-start lg:text-left">
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-accent-brand/30 bg-accent-brand/10 px-3 py-1 text-xs font-medium text-accent-brand">
+            <Sparkles aria-hidden="true" className="size-3.5" />
+            Agentic development platform
+          </span>
+          <h1 className="max-w-2xl text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {tagline}
+          </h1>
+          <p className="max-w-lg text-base text-muted-foreground sm:text-lg">{description}</p>
+          <div className="flex flex-col items-center gap-3 sm:flex-row">
+            {oidc !== undefined ? (
+              <Button
+                type="button"
+                size="lg"
+                onClick={() => {
+                  void beginLogin(oidc);
+                }}
+              >
+                Sign in
+              </Button>
+            ) : (
+              <p className="max-w-sm text-xs text-muted-foreground">
+                A bearer token is required to view your environments. Ask an operator for one, or
+                configure OIDC sign-in for this instance.
+              </p>
+            )}
+            {hasDocsUrl && (
+              <Button type="button" variant="outline" size="lg" asChild>
+                <a href={docsUrl} target="_blank" rel="noreferrer">
+                  Read the docs
+                </a>
+              </Button>
+            )}
+          </div>
+          {fallbackReason !== undefined && (
+            <p className="text-xs text-muted-foreground">{fallbackReason}</p>
           )}
         </div>
-        {fallbackReason !== undefined && (
-          <p className="text-xs text-muted-foreground">{fallbackReason}</p>
-        )}
+        <LandingHeroVisual />
       </div>
     </section>
   );

--- a/erun-console/src/shell/LandingHero.tsx
+++ b/erun-console/src/shell/LandingHero.tsx
@@ -1,0 +1,62 @@
+import { Button } from 'erun-kit';
+import type * as React from 'react';
+
+import type { OidcConfig } from '../auth/auth';
+import { beginLogin } from '../auth/auth';
+
+// The hero carries the pitch and both calls to action. Sign in stays the
+// primary button so an existing user's path is exactly as short as the old
+// bare card's — "Read the docs" is the secondary action a first-time visitor
+// takes instead, and it renders only when platform discovery actually
+// supplied a docs host (#1327: never a hardcoded fallback host).
+export function LandingHero({
+  tagline,
+  description,
+  docsUrl,
+  oidc,
+  fallbackReason,
+}: {
+  tagline: string;
+  description: string;
+  docsUrl: string | undefined;
+  oidc: OidcConfig | undefined;
+  fallbackReason: string | undefined;
+}): React.ReactElement {
+  const hasDocsUrl = docsUrl !== undefined && docsUrl.length > 0;
+  return (
+    <section className="border-b border-border bg-gradient-to-b from-muted/60 to-background px-6 py-16 sm:py-24">
+      <div className="mx-auto flex max-w-3xl flex-col items-center gap-6 text-center">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-5xl">{tagline}</h1>
+        <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">{description}</p>
+        <div className="flex flex-col items-center gap-3 sm:flex-row">
+          {oidc !== undefined ? (
+            <Button
+              type="button"
+              size="lg"
+              onClick={() => {
+                void beginLogin(oidc);
+              }}
+            >
+              Sign in
+            </Button>
+          ) : (
+            <p className="max-w-sm text-xs text-muted-foreground">
+              A bearer token is required to view your environments. Ask an operator for one, or
+              configure OIDC sign-in for this instance.
+            </p>
+          )}
+          {hasDocsUrl && (
+            <Button type="button" variant="outline" size="lg" asChild>
+              <a href={docsUrl} target="_blank" rel="noreferrer">
+                Read the docs
+              </a>
+            </Button>
+          )}
+        </div>
+        {fallbackReason !== undefined && (
+          <p className="text-xs text-muted-foreground">{fallbackReason}</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/erun-console/src/shell/LandingHero.tsx
+++ b/erun-console/src/shell/LandingHero.tsx
@@ -4,6 +4,7 @@ import type * as React from 'react';
 
 import type { OidcConfig } from '../auth/auth';
 import { beginLogin } from '../auth/auth';
+import { CONFIGURE_OIDC_DOCS_PATH, PUBLIC_DOCS_URL } from './landingContent';
 import { LandingHeroVisual } from './LandingHeroVisual';
 
 // The hero carries the pitch and both calls to action. Sign in stays the
@@ -29,6 +30,8 @@ export function LandingHero({
   fallbackReason: string | undefined;
 }): React.ReactElement {
   const hasDocsUrl = docsUrl !== undefined && docsUrl.length > 0;
+  const docsBase = docsUrl !== undefined && docsUrl.length > 0 ? docsUrl : PUBLIC_DOCS_URL;
+  const configureOidcHref = `${docsBase}${CONFIGURE_OIDC_DOCS_PATH}`;
   return (
     <section className="border-b border-border bg-gradient-to-b from-muted/40 to-background px-6 py-12 sm:py-16">
       <div className="mx-auto grid max-w-6xl gap-10 lg:grid-cols-2 lg:items-center lg:gap-16">
@@ -54,8 +57,16 @@ export function LandingHero({
               </Button>
             ) : (
               <p className="max-w-sm text-xs text-muted-foreground">
-                A bearer token is required to view your environments. Ask an operator for one, or
-                configure OIDC sign-in for this instance.
+                A bearer token is required to view your environments. Ask an operator for one, or{' '}
+                <a
+                  href={configureOidcHref}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-medium text-foreground underline-offset-4 hover:underline"
+                >
+                  configure OIDC sign-in for this instance
+                </a>
+                .
               </p>
             )}
             {hasDocsUrl && (

--- a/erun-console/src/shell/LandingHeroVisual.tsx
+++ b/erun-console/src/shell/LandingHeroVisual.tsx
@@ -1,0 +1,58 @@
+import { CheckCircle2 } from 'lucide-react';
+import type * as React from 'react';
+
+// The hero's product visual: a live console signed-out into no
+// tenant has nothing real to screenshot, so this is a considered abstract
+// stand-in — an editor pane and an agent pane sharing one window, the same
+// "side by side" claim the differentiators section states in words. Built
+// from the console's own tokens (not a static image) so it repaints for
+// dark mode for free, the same reason LandingDifferentiators avoided the
+// docs site's hand-drawn diagram.
+export function LandingHeroVisual(): React.ReactElement {
+  return (
+    <div
+      aria-hidden="true"
+      className="relative mx-auto w-full max-w-md motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-6 motion-safe:duration-700 motion-safe:delay-150 motion-safe:fill-mode-both lg:mx-0"
+    >
+      <div className="absolute -inset-8 -z-10 rounded-[2rem] bg-accent-brand/10 blur-3xl" />
+      <div className="overflow-hidden rounded-xl border border-border bg-card shadow-lg">
+        <div className="flex items-center gap-1.5 border-b border-border px-4 py-3">
+          <span className="size-2.5 rounded-full bg-destructive/60" />
+          <span className="size-2.5 rounded-full bg-accent-brand/50" />
+          <span className="size-2.5 rounded-full bg-muted-foreground/30" />
+          <span className="ml-2 truncate text-xs text-muted-foreground">
+            feature/checkout-refactor
+          </span>
+        </div>
+        <div className="grid grid-cols-2 divide-x divide-border">
+          <div className="flex flex-col gap-2 p-4">
+            <div className="h-2 w-3/4 rounded-full bg-foreground/15" />
+            <div className="h-2 w-1/2 rounded-full bg-accent-brand/40" />
+            <div className="h-2 w-5/6 rounded-full bg-foreground/10" />
+            <div className="h-2 w-2/3 rounded-full bg-foreground/10" />
+            <div className="h-2 w-1/3 rounded-full bg-accent-brand/40" />
+          </div>
+          <div className="flex flex-col gap-2 p-4">
+            <div className="flex items-center gap-1.5 text-xs font-medium text-accent-brand">
+              <span className="relative flex size-1.5">
+                <span className="absolute inline-flex size-full animate-ping rounded-full bg-accent-brand opacity-75 motion-reduce:hidden" />
+                <span className="relative inline-flex size-1.5 rounded-full bg-accent-brand" />
+              </span>
+              Agent
+            </div>
+            <div className="rounded-md bg-muted px-2 py-1.5 text-[10px] leading-snug text-muted-foreground">
+              Running tests…
+            </div>
+            <div className="rounded-md bg-muted px-2 py-1.5 text-[10px] leading-snug text-muted-foreground">
+              3 files changed
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 border-t border-border bg-muted/40 px-4 py-2.5 text-xs text-muted-foreground">
+          <CheckCircle2 className="size-3.5 text-accent-brand" />
+          All checks passed
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/erun-console/src/shell/LandingScreen.test.tsx
+++ b/erun-console/src/shell/LandingScreen.test.tsx
@@ -75,7 +75,7 @@ describe('LandingScreen content', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders no docs link anywhere, and no placeholder host, when docsUrl is unset', () => {
+  it('falls back to the public docs site in the footer when docsUrl is unset, in the signed-out state', () => {
     render(
       <LandingScreen
         brand="Acme"
@@ -87,9 +87,37 @@ describe('LandingScreen content', () => {
       />,
     );
 
-    expect(screen.queryByRole('link', { name: 'Read the docs' })).not.toBeInTheDocument();
-    expect(screen.queryByText(/docs\./)).not.toBeInTheDocument();
-    expect(document.body.innerHTML).not.toMatch(/erunpaas\.com/);
+    // The hero's primary "Read the docs" CTA still renders only when an
+    // instance configures a real docsUrl (never a hardcoded fallback host),
+    // but the footer is the one link every visitor can always reach, so it
+    // falls back rather than disappearing.
+    const docsLinks = screen.getAllByRole('link', { name: 'Read the docs' });
+    expect(docsLinks).toHaveLength(1);
+    expect(docsLinks[0]).toHaveAttribute('href', 'https://docs.erunpaas.com');
+  });
+
+  it('gives the no-OIDC state a docs link too, in both the footer and the configure-OIDC copy', () => {
+    render(
+      <LandingScreen
+        brand="Acme"
+        logoUrl={undefined}
+        tagline={undefined}
+        docsUrl={undefined}
+        oidc={undefined}
+        fallbackReason={undefined}
+      />,
+    );
+
+    // No Sign in button can work with no OIDC configured, so the state must
+    // still offer a way forward: the footer's docs link, and the
+    // explanation's own link to the page that walks through configuring one.
+    expect(screen.getByRole('link', { name: 'Read the docs' })).toHaveAttribute(
+      'href',
+      'https://docs.erunpaas.com',
+    );
+    expect(
+      screen.getByRole('link', { name: 'configure OIDC sign-in for this instance' }),
+    ).toHaveAttribute('href', 'https://docs.erunpaas.com/deployment/deploy-platform#hosted-idp');
   });
 
   it('shows the bearer-token fallback note, not a Sign in button, when OIDC is unconfigured', () => {

--- a/erun-console/src/shell/LandingScreen.test.tsx
+++ b/erun-console/src/shell/LandingScreen.test.tsx
@@ -1,0 +1,155 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { OidcConfig } from '../auth/auth';
+import { beginLogin } from '../auth/auth';
+import { LandingScreen } from './LandingScreen';
+
+vi.mock('../auth/auth', () => ({
+  beginLogin: vi.fn(),
+}));
+
+const OIDC: OidcConfig = {
+  issuer: 'https://auth.acme.example',
+  clientId: 'console-client',
+  redirectUri: 'http://localhost/',
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('LandingScreen content', () => {
+  it('renders a real landmark structure with the pitch, the differentiators, and both CTAs', () => {
+    render(
+      <LandingScreen
+        brand="Acme"
+        logoUrl={undefined}
+        tagline="Acme's own tagline."
+        docsUrl="https://docs.acme.example"
+        oidc={OIDC}
+        fallbackReason={undefined}
+      />,
+    );
+
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+    expect(screen.getByRole('main')).toBeInTheDocument();
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+
+    const h1 = screen.getByRole('heading', { level: 1, name: "Acme's own tagline." });
+    const h2 = screen.getByRole('heading', { level: 2, name: 'What makes Acme different' });
+    expect(h1).toBeInTheDocument();
+    expect(h2).toBeInTheDocument();
+    // Heading order: the pitch (h1) must read before the differentiators (h2).
+    expect(h1.compareDocumentPosition(h2) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    expect(screen.getAllByRole('link', { name: 'Read the docs' })).toHaveLength(2);
+    expect(screen.getAllByRole('link', { name: 'Read the docs' })[0]).toHaveAttribute(
+      'href',
+      'https://docs.acme.example',
+    );
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+  });
+
+  it('falls back to the bundled tagline and brand when the instance sets none', () => {
+    render(
+      <LandingScreen
+        brand={undefined}
+        logoUrl={undefined}
+        tagline={undefined}
+        docsUrl={undefined}
+        oidc={OIDC}
+        fallbackReason={undefined}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'Agentic coding from idea to production — at speed, without compromising compliance.',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'What makes ERun different' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders no docs link anywhere, and no placeholder host, when docsUrl is unset', () => {
+    render(
+      <LandingScreen
+        brand="Acme"
+        logoUrl={undefined}
+        tagline={undefined}
+        docsUrl={undefined}
+        oidc={OIDC}
+        fallbackReason={undefined}
+      />,
+    );
+
+    expect(screen.queryByRole('link', { name: 'Read the docs' })).not.toBeInTheDocument();
+    expect(screen.queryByText(/docs\./)).not.toBeInTheDocument();
+    expect(document.body.innerHTML).not.toMatch(/erunpaas\.com/);
+  });
+
+  it('shows the bearer-token fallback note, not a Sign in button, when OIDC is unconfigured', () => {
+    render(
+      <LandingScreen
+        brand="Acme"
+        logoUrl={undefined}
+        tagline={undefined}
+        docsUrl={undefined}
+        oidc={undefined}
+        fallbackReason="local VITE_OIDC_* override"
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Sign in' })).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/A bearer token is required to view your environments\./),
+    ).toBeInTheDocument();
+    expect(screen.getByText('local VITE_OIDC_* override')).toBeInTheDocument();
+  });
+
+  it('starts the real OIDC redirect when Sign in is clicked', () => {
+    render(
+      <LandingScreen
+        brand="Acme"
+        logoUrl={undefined}
+        tagline={undefined}
+        docsUrl={undefined}
+        oidc={OIDC}
+        fallbackReason={undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+    expect(beginLogin).toHaveBeenCalledWith(OIDC);
+  });
+
+  it('stacks the CTAs and the differentiator cards single-column at a phone width', () => {
+    render(
+      <LandingScreen
+        brand="Acme"
+        logoUrl={undefined}
+        tagline={undefined}
+        docsUrl="https://docs.acme.example"
+        oidc={OIDC}
+        fallbackReason={undefined}
+      />,
+    );
+
+    // jsdom does not run layout, so this asserts the responsive contract at
+    // the class level: mobile-first with no override below `sm` (640px),
+    // narrower than a 375px phone viewport — not a rendered pixel measurement.
+    const ctaRow = screen.getByRole('button', { name: 'Sign in' }).parentElement;
+    expect(ctaRow?.className).toContain('flex-col');
+    expect(ctaRow?.className).toContain('sm:flex-row');
+
+    const cardsGrid = screen
+      .getByRole('heading', { level: 2 })
+      .parentElement?.querySelector('.grid');
+    expect(cardsGrid?.className).toContain('grid-cols-1');
+    expect(cardsGrid?.className).not.toMatch(/(?<!sm:|lg:)grid-cols-[234]/);
+  });
+});

--- a/erun-console/src/shell/LandingScreen.test.tsx
+++ b/erun-console/src/shell/LandingScreen.test.tsx
@@ -67,7 +67,7 @@ describe('LandingScreen content', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: 'Agentic coding from idea to production — at speed, without compromising compliance.',
+        name: 'Agentic coding from idea to production, without compromising compliance.',
       }),
     ).toBeInTheDocument();
     expect(

--- a/erun-console/src/shell/LandingScreen.tsx
+++ b/erun-console/src/shell/LandingScreen.tsx
@@ -7,13 +7,15 @@ import { LandingDifferentiators } from './LandingDifferentiators';
 import { LandingFooter } from './LandingFooter';
 import { LandingHero } from './LandingHero';
 
-// LandingScreen is the signed-out route's front door (#1327), replacing the
-// bare 384px SignInScreen card: a real <header>/<main>/<footer> landmark
+// LandingScreen is the signed-out route's front door, replacing the bare
+// 384px SignInScreen card: a real <header>/<main>/<footer> landmark
 // structure with an <h1> lead, so a first-time visitor learns what the
 // product is and can reach the docs before ever being asked to sign in.
-// `docsUrl`/`logoUrl` are per-instance platform config and render nothing
-// when unset; `tagline` falls back to a bundled product-level default the
-// same way BrandMark falls back to a generic mark.
+// `docsUrl`/`logoUrl` are per-instance platform config; `logoUrl` renders
+// nothing when unset (BrandMark falls back to a generic mark), but the
+// footer's docs link always resolves to something — the public docs site
+// when no instance docsUrl is configured — so there is no state with no way
+// out. `tagline` falls back to a bundled product-level default.
 export function LandingScreen({
   brand,
   logoUrl,

--- a/erun-console/src/shell/LandingScreen.tsx
+++ b/erun-console/src/shell/LandingScreen.tsx
@@ -1,0 +1,53 @@
+import type * as React from 'react';
+
+import type { OidcConfig } from '../auth/auth';
+import { BrandMark } from './BrandMark';
+import { DEFAULT_DESCRIPTION, DEFAULT_TAGLINE } from './landingContent';
+import { LandingDifferentiators } from './LandingDifferentiators';
+import { LandingFooter } from './LandingFooter';
+import { LandingHero } from './LandingHero';
+
+// LandingScreen is the signed-out route's front door (#1327), replacing the
+// bare 384px SignInScreen card: a real <header>/<main>/<footer> landmark
+// structure with an <h1> lead, so a first-time visitor learns what the
+// product is and can reach the docs before ever being asked to sign in.
+// `docsUrl`/`logoUrl` are per-instance platform config and render nothing
+// when unset; `tagline` falls back to a bundled product-level default the
+// same way BrandMark falls back to a generic mark.
+export function LandingScreen({
+  brand,
+  logoUrl,
+  tagline,
+  docsUrl,
+  oidc,
+  fallbackReason,
+}: {
+  brand: string | undefined;
+  logoUrl: string | undefined;
+  tagline: string | undefined;
+  docsUrl: string | undefined;
+  oidc: OidcConfig | undefined;
+  fallbackReason: string | undefined;
+}): React.ReactElement {
+  const brandLabel = brand !== undefined && brand.length > 0 ? brand : 'ERun';
+  const heroTagline = tagline !== undefined && tagline.length > 0 ? tagline : DEFAULT_TAGLINE;
+  return (
+    <div className="flex min-h-dvh flex-col bg-background text-foreground">
+      <header className="flex items-center gap-2.5 px-6 py-5">
+        <BrandMark brand={brand} logoUrl={logoUrl} />
+        <span className="text-sm font-semibold text-muted-foreground">{brandLabel}</span>
+      </header>
+      <main className="flex-1">
+        <LandingHero
+          tagline={heroTagline}
+          description={DEFAULT_DESCRIPTION}
+          docsUrl={docsUrl}
+          oidc={oidc}
+          fallbackReason={fallbackReason}
+        />
+        <LandingDifferentiators brandLabel={brandLabel} />
+      </main>
+      <LandingFooter brandLabel={brandLabel} docsUrl={docsUrl} />
+    </div>
+  );
+}

--- a/erun-console/src/shell/PreShellScreens.tsx
+++ b/erun-console/src/shell/PreShellScreens.tsx
@@ -1,9 +1,6 @@
-import { Button } from 'erun-kit';
 import { LoaderCircle } from 'lucide-react';
 import type * as React from 'react';
 
-import type { OidcConfig } from '../auth/auth';
-import { beginLogin } from '../auth/auth';
 import { readTokenIdentity } from '../auth/identity';
 import { CenteredCard } from './CenteredCard';
 
@@ -14,46 +11,6 @@ export function LoadingScreen({ brand }: { brand: string | undefined }): React.R
         aria-hidden="true"
         className="mx-auto size-5 animate-spin text-muted-foreground"
       />
-    </CenteredCard>
-  );
-}
-
-// SignInScreen is the branded replacement for the bare paragraph + button that
-// used to greet every visitor. With OIDC configured it offers the real
-// Authorization Code + PKCE redirect; without it (local dev), it explains that
-// a token is required. fallbackReason surfaces why a local VITE_OIDC_* override
-// is in play when platform discovery could not supply the config, so a
-// misconfigured instance is visible rather than silently running against a
-// possibly-wrong client id.
-export function SignInScreen({
-  brand,
-  oidc,
-  fallbackReason,
-}: {
-  brand: string | undefined;
-  oidc: OidcConfig | undefined;
-  fallbackReason: string | undefined;
-}): React.ReactElement {
-  return (
-    <CenteredCard brand={brand} title="Sign in to your console" role="status">
-      <p className="text-sm text-muted-foreground">
-        {oidc !== undefined
-          ? 'Sign in with your organization identity to view and manage your environments.'
-          : 'A bearer token is required to view your environments. Ask an operator for one, or configure OIDC sign-in for this instance.'}
-      </p>
-      {oidc !== undefined && (
-        <Button
-          type="button"
-          onClick={() => {
-            void beginLogin(oidc);
-          }}
-        >
-          Sign in
-        </Button>
-      )}
-      {fallbackReason !== undefined && (
-        <p className="text-xs text-muted-foreground">{fallbackReason}</p>
-      )}
     </CenteredCard>
   );
 }

--- a/erun-console/src/shell/landingContent.ts
+++ b/erun-console/src/shell/landingContent.ts
@@ -6,7 +6,7 @@ import { Columns2, Gauge, Layers, ShieldCheck } from 'lucide-react';
 // pitch instead of a blank hero, while one that does configure `tagline`
 // (GET /v1/platform) overrides this text entirely.
 export const DEFAULT_TAGLINE =
-  'Agentic coding from idea to production — at speed, without compromising compliance.';
+  'Agentic coding from idea to production, without compromising compliance.';
 
 export const DEFAULT_DESCRIPTION =
   'Every task — a feature, a peer review, a hotfix — gets its own isolated environment with the full stack inside, so an Operator and an AI Agent can work side by side without fighting over one shared dev stack.';

--- a/erun-console/src/shell/landingContent.ts
+++ b/erun-console/src/shell/landingContent.ts
@@ -11,6 +11,17 @@ export const DEFAULT_TAGLINE =
 export const DEFAULT_DESCRIPTION =
   'Every task — a feature, a peer review, a hotfix — gets its own isolated environment with the full stack inside, so an Operator and an AI Agent can work side by side without fighting over one shared dev stack.';
 
+// The public product documentation site, mirrored from
+// erun-ui/frontend/src/app/documentationThunks.ts's ERUN_DOCS_URL. An
+// instance's own docsUrl (GET /v1/platform) is preferred when set; this is
+// the floor so an unconfigured instance's landing page still has a docs exit
+// instead of rendering no link at all.
+export const PUBLIC_DOCS_URL = 'https://docs.erunpaas.com';
+
+// Every erun-docs deploy is the same Docusaurus site shape, so this path
+// resolves under an instance's own docsUrl as well as the public fallback.
+export const CONFIGURE_OIDC_DOCS_PATH = '/deployment/deploy-platform#hosted-idp';
+
 export interface Differentiator {
   key: string;
   label: string;

--- a/erun-console/src/shell/landingContent.ts
+++ b/erun-console/src/shell/landingContent.ts
@@ -1,0 +1,52 @@
+import { Columns2, Gauge, Layers, ShieldCheck } from 'lucide-react';
+
+// Bundled product-level defaults for the signed-out landing page. Mirrors how
+// BrandMark already falls back to a generic mark when an instance sets no
+// brand (#1327): an instance that configures no tagline still gets a real
+// pitch instead of a blank hero, while one that does configure `tagline`
+// (GET /v1/platform) overrides this text entirely.
+export const DEFAULT_TAGLINE =
+  'Agentic coding from idea to production — at speed, without compromising compliance.';
+
+export const DEFAULT_DESCRIPTION =
+  'Every task — a feature, a peer review, a hotfix — gets its own isolated environment with the full stack inside, so an Operator and an AI Agent can work side by side without fighting over one shared dev stack.';
+
+export interface Differentiator {
+  key: string;
+  label: string;
+  description: string;
+  icon: typeof Columns2;
+}
+
+// The four differentiators from erun-docs/docs/intro.md's "What makes ERun
+// different" section, restated as short landing-page copy rather than the
+// verbose diagram alt text that page uses.
+export const DIFFERENTIATORS: Differentiator[] = [
+  {
+    key: 'side-by-side',
+    label: 'Side by side',
+    description: 'Your editor and your Agent see the same project — no parallel worlds.',
+    icon: Columns2,
+  },
+  {
+    key: 'in-control',
+    label: 'In control',
+    description:
+      'Preview every action before it runs. Every action recorded. Join, take over, or hand off any time.',
+    icon: Gauge,
+  },
+  {
+    key: 'industry-standards',
+    label: 'Industry standards',
+    description:
+      'Traceable, reproducible, audit-ready — compliance is how the platform works, not a bolt-on.',
+    icon: ShieldCheck,
+  },
+  {
+    key: 'your-scale',
+    label: 'Your scale',
+    description:
+      'From a single VM to an autoscaling fleet with DR and immutable backups — the same defaults at every scale.',
+    icon: Layers,
+  },
+];

--- a/erun-docs/docs/deployment/deploy-platform.md
+++ b/erun-docs/docs/deployment/deploy-platform.md
@@ -82,7 +82,7 @@ Two things are yours to supply; the chart does the rest.
 
 ### The apex and www redirect {#apex-redirect}
 
-The bare `<base-domain>` and `www.<base-domain>` are otherwise dead ends — only the console host resolves to anything. Whenever `platform.baseDomain` is set, `erun-console` also redirects those two hosts to the console with a permanent (301) redirect, so someone who types your product's own domain lands on the console instead. It stays a redirect rather than a third origin the console is also served on, because sign-in (Authorization Code + PKCE) depends on being reachable at exactly one origin.
+The bare `<base-domain>` and `www.<base-domain>` are otherwise dead ends — only the console host resolves to anything. Whenever `platform.baseDomain` is set, `erun-console` also redirects those two hosts to the console with a permanent (301) redirect, so someone who types your product's own domain lands on a landing page that pitches the product, instead of a dead end. It stays a redirect rather than a third origin the console is also served on, because sign-in (Authorization Code + PKCE) depends on being reachable at exactly one origin.
 
 Two things beyond the console's own DNS/certificate above:
 
@@ -98,7 +98,7 @@ Running your apex for something else already (a marketing site)? Set `console.ap
 | Failure mode | What happens | Recovery |
 |---|---|---|
 | No external domain resolvable | `erun deploy` aborts at the chart render with `an external domain is required`; exit code 1, nothing applied | Set `basedomain` in the env's `platform:` block, or `console.externalDomain` |
-| `GET /v1/platform` is absent or empty | The console falls back to its build-time `VITE_OIDC_ISSUER`/`VITE_OIDC_CLIENT_ID`; with neither configured it shows the signed-out message with no Sign in button | Configure the backend's platform discovery, or set the console's `VITE_OIDC_*` build args as a stopgap |
+| `GET /v1/platform` is absent or empty | The console falls back to its build-time `VITE_OIDC_ISSUER`/`VITE_OIDC_CLIENT_ID`; with neither configured, the landing page still shows the full pitch and a **Read the docs** link, but the Sign in button is replaced by a note that a bearer token is needed and a link to configuring OIDC for this instance | Configure the backend's platform discovery, or set the console's `VITE_OIDC_*` build args as a stopgap |
 | `/v1/config` returns `502` through the console | The API Service the console's nginx proxies to isn't up yet, or `console.apiServiceName`/`console.apiServicePort` don't match the deployed API | Confirm `<tenant>-api` is running and the chart's proxy target matches its Service name/port |
 | The apex/www redirect is enabled but no apex host resolves | `erun deploy` aborts at the chart render with `console.apexRedirectEnabled is true but no apex host could be resolved`; exit code 1, nothing applied | Set `basedomain` in the env's `platform:` block, or `console.apexHost`/`console.wwwHost`, or `console.apexRedirectEnabled=false` |
 | The apex/www hosts don't resolve at all | The Helm chart's Ingress/Middleware are only half the picture — DNS is separate. Confirm the `terraform-erun-cloudflare-apex` module has actually been applied for this env | Apply it via your `terraform-<tenant>/` tree, pointed at the cluster's ingress IP |

--- a/erun-kit/src/styles/theme.css
+++ b/erun-kit/src/styles/theme.css
@@ -20,6 +20,8 @@
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-accent-brand: var(--accent-brand);
+  --color-accent-brand-foreground: var(--accent-brand-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -68,6 +70,11 @@
   --muted-foreground: oklch(0.556 0 0);
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
+  /* The one deliberate brand hue in an otherwise neutral palette: a blue at
+     the same 258deg hue as --chart-1..5 so it reads as "this product's
+     color" rather than a decorative addition. 5.67:1 on white. */
+  --accent-brand: oklch(0.52 0.19 258);
+  --accent-brand-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(1 0 0);
   --border: oklch(0.922 0 0);
@@ -135,6 +142,10 @@
   --muted-foreground: oklch(0.708 0 0);
   --accent: oklch(0.371 0 0);
   --accent-foreground: oklch(0.985 0 0);
+  /* Lighter and lower-chroma than the light-mode value so it stays legible on
+     a near-black background instead of just inverting: 8.78:1 on dark bg. */
+  --accent-brand: oklch(0.75 0.14 258);
+  --accent-brand-foreground: oklch(0.145 0 0);
   --destructive: oklch(0.704 0.191 22.216);
   --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.275 0 0);


### PR DESCRIPTION
## Summary

The product's front door was a **384-pixel card**: a brand initial, one
sentence, and a Sign in button on an otherwise empty page — with **no outbound
link of any kind**. Since #1208 the apex and `www` 301 here, so that card is what
anyone who types the domain sees.

That is `AGENTS.md` § `## Smooth, Seamless, No Dead Ends` at its most literal:
a visitor who is not yet a user had nowhere to go and nothing to read.

## What landed

A real landing page, with an identity rather than a template:

- **A pitch that says what the product is** — headline, sub-copy, and a badge —
  reading in three lines at desktop width, left-aligned, instead of four centred
  lines over a near-empty viewport.
- **A hero visual that makes the argument**: a review pane showing
  `feature/checkout-refactor`, `Agent · Running tests… · 3 files changed`,
  `All checks passed`. The product is now shown, not only described.
- **A deliberate accent**, used with intent — the badge, the icons, the product
  visual, and one filled lead card — with contrast measured in both themes.
- **Differentiators with rhythm**: one filled lead card, two outline cards, and
  a wide horizontal `Your scale`, so the eye has somewhere to start. Not four
  identical boxes.
- **Sign in stays primary and one click**, with **Read the docs** beside it.
- A genuine phone reflow — cards stack, buttons stack, type scales — not the
  same card with more text in it.
- A meta description, favicon and social preview tags.

## Every state has a way out, including the unconfigured one

An instance with **no OIDC configured** cannot offer a Sign in button that would
work, so it explains what is needed instead. An earlier revision left that state
with no outbound link at all — reintroducing this issue's own defect in one
configuration. Now the footer carries **Read the docs** unconditionally, and
*"configure OIDC sign-in for this instance"* is a link rather than a dead
sentence. An absent config value must not remove the user's only exit.

## Two real bugs found along the way

- **`.dark` was only ever applied inside `AppShell`'s own `useTheme()`**, so
  every pre-shell screen ignored a stored or OS-level dark preference. Now
  applied at the root, before auth resolves.
- **An OIDC e2e assertion never actually matched the rendered text** — a
  substring check against copy that had changed. Replaced with a landmark-level
  check that survives copy edits.

## Verification

Landing-page tests including a red-then-green regression guard; assertions that
a docs link is reachable in **both** the OIDC-configured and not-configured
states; narrow-viewport and heading-order/landmark assertions so the
accessibility claim is tested rather than asserted. Screenshots for desktop and
phone in both themes, both auth states, the hero visual, focus states, and the
motion resting state.

## Docs

`erun-docs/docs/deployment/deploy-platform.md` — two statements this change made
stale are corrected: the apex redirect now lands on "a landing page that pitches
the product, instead of a dead end", and the troubleshooting row for an absent
`GET /v1/platform` now describes what a visitor actually sees.

Closes #1327
