### PR TITLE
Fix the errcheck violation that made main unbuildable

### DIFF
--- a/erun-ui/restart_control_test.go
+++ b/erun-ui/restart_control_test.go
@@ -22,7 +22,7 @@ func postRestartControl(t *testing.T, port int, orchestratorID string) restartCo
 	if err != nil {
 		t.Fatalf("POST restart control: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	var decoded restartControlResponse
 	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
 		t.Fatalf("decode response: %v", err)


### PR DESCRIPTION
## Summary

`main` was lint-red and the host desktop build failed outright:

```
erun-ui/restart_control_test.go:25:23: Error return value of `resp.Body.Close` is not checked (errcheck)
```

It arrived with `76f1b1a1` (#1341) and reached `main` because that branch's gate list covered `go test` but not lint. `erun-ui/build.sh` runs golangci-lint, so a branch can pass every test and still make the desktop unbuildable — which is exactly what happened, and it was caught by attempting a real rebuild rather than by any gate.

## Fix

`defer resp.Body.Close()` → `defer func() { _ = resp.Body.Close() }()`, matching the repo's existing idiom for a deferred, intentionally-ignored `Close`. No `//nolint`, no behaviour change.

A sweep for sibling violations introduced by today's other merges found none.

## Verification

golangci-lint clean per module; `erun-ui` and `erun-integration` test suites green; the desktop build gate reaches the end.