### PR TITLE
Report measured pacing staleness, and stop suppressing the nudge on a live shell

### DIFF
--- a/erun-docs/docs/agent-reference/skills-spec.md
+++ b/erun-docs/docs/agent-reference/skills-spec.md
@@ -158,19 +158,32 @@ The `SessionStart` hook above closes the gap at session *boundaries* (`startup`,
 
 **Staleness read.** Each orchestrator's turn-boundary activity report (the same file the busy-spinner reconciler reads, `{"busy":…,"atUnix":…}`) is read again here, independent of that reconciler's own busy/idle staleness bounds: a report not refreshed for **10 minutes** (`orchestratorPacingStaleAfter`) reads as quiet regardless of whether its last write said busy or idle. The reference point is the later of the report's own write time and the session's launch time, so a session with no report yet (its first turn hasn't reached a boundary) is not nudged before it has had ten minutes to.
 
-**Nudge.** For each live, non-transient orchestrator whose report is stale, and which is not currently reporting a background shell running (`orchestrator-shell-activity`; a backgrounded shell is expected to legitimately outlive the turn that started it), the desktop writes this text into the session's pty, then — after a short settle, as a **separate** write — a bare carriage return to submit it:
+**Nudge.** For each live, non-transient orchestrator whose report is stale, the desktop writes this text into the session's pty, then — after a short settle, as a **separate** write — a bare carriage return to submit it:
 
 > Keep pacing yourself, on connection errors wait and resume, do not exit this loop. If the assigned task is already complete and verified, say so in one line and stop.
 
-Each nudge appears in the pane as a dim marker line naming the attempt count (`── pacing nudge N/6 sent … ──`), so it is never silent.
+A background shell reported running for that orchestrator (`orchestrator-shell-activity`) no longer holds the nudge back. It used to: the reasoning was that a shell left running was evidence the orchestrator meant to be quiet, but a background shell is a fact about the *shell*, not about the turn behind it — a long-running build is the single most likely thing still running when a turn dies mid-response, so the old rule suppressed the nudge exactly when it was needed most. The shell-activity report is unchanged and still drives the shell indicator; pacing simply stopped reading it.
+
+Each nudge appears in the pane as a dim marker line naming the attempt count and the **measured** quiet period — never the ten-minute constant — so a session quiet for twenty minutes reads as twenty minutes, not as the contract having been honoured on time:
+
+```
+── pacing nudge N/6 sent — no activity report for 19m42s ──
+```
+
+If the orchestrator's last report said `busy: true` and was never followed by an idle one, the marker names that too, since a report stuck on "busy" for a full staleness period usually means the harness never reached its own turn boundary (a dropped connection, a crash) rather than a turn that finished and simply stopped reporting:
+
+```
+── pacing nudge N/6 sent — no activity report for 19m42s — last report said mid-turn, so the turn may have died without one ──
+```
 
 **Bounds.**
 
 - One nudge per orchestrator per tick, and never for a transient (Investigate) session — it has no `id` and its own bounded lifecycle belongs to the investigation registry, not this one.
-- No nudge while a background shell is reported running for that orchestrator.
 - A cap of **6** consecutive un-answered nudges (`orchestratorPacingMaxNudges`) — about an hour at the 10-minute interval. Crossing the cap posts a warning notification and a distinct pane marker instead of a 7th nudge, and the cap latches (no repeat notification on later ticks) until it is rearmed by either:
   - a fresh turn-boundary report whose own timestamp is later than the last nudge **and** says `busy: true` — evidence the session resumed on its own, or
   - real operator input sent into that same pane (`SendSessionInput`) — evidence the operator is now at the keyboard.
+
+**Every decision is logged, not just the ones that nudge.** The reconciler names the reason it did or didn't nudge — alive-but-fresh, not alive, already capped, crossing the cap, or nudging — in the desktop's durable app log, once per transition rather than once per 15-second tick. A stalled pane that never nudges (because the session itself is no longer alive) is therefore distinguishable from a healthy, ordinarily quiet one by reading that log, instead of both looking identical from outside.
 
 **Auto-resume after a crash.** An orchestrator's managed session carries a respawn closure (the same `tryReconnect` mechanism environment tabs use to recover a dropped pod session), gated so it only ever fires for a genuine failure:
 

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -82,6 +82,10 @@ type orchestratorSession struct {
 	pacingNudgeCount      int
 	pacingCapped          bool
 	pacingLastNudgeAtUnix int64
+	// pacingLastReason is the reason decideOrchestratorPacing last returned for
+	// this orchestrator, so the reconciler logs a transition rather than
+	// repeating the same line every 15s tick. See logOrchestratorPacingTransition.
+	pacingLastReason orchestratorPacingReason
 }
 
 // orchestratorEnvInput is the frontend's env selection for create/update.

--- a/erun-ui/orchestrator_pacing.go
+++ b/erun-ui/orchestrator_pacing.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"strings"
 	"time"
@@ -81,9 +82,17 @@ func readOrchestratorPacingActivity(id string) (orchestratorPacingActivity, bool
 // orchestratorPacingCandidate is one orchestrator as the reconciler decides for
 // it — gathered so the decision itself is a pure function, testable without
 // touching a file or a lock.
+//
+// This deliberately carries no background-shell fact. It used to gate the
+// nudge on one (orchestrator-shell-activity), reasoning that a shell left
+// running was evidence the orchestrator meant to be quiet — but a background
+// shell is a fact about a *shell*, not about the turn behind it, and a
+// long-running build is the single most likely thing to be in flight when a
+// turn dies mid-response. Gating on it suppressed the nudge exactly when it
+// was needed most (erun#1376). The shell-activity report stays exactly as it
+// is for the shell indicator; pacing just stops reading it.
 type orchestratorPacingCandidate struct {
 	alive        bool
-	shellRunning bool
 	lastActiveAt time.Time
 	nudgeCount   int
 	capped       bool
@@ -97,43 +106,54 @@ const (
 	orchestratorPacingCap
 )
 
+// orchestratorPacingReason names why decideOrchestratorPacing returned what it
+// did, independent of the decision itself: two candidates can both resolve to
+// orchestratorPacingNone for different reasons, and the reconciler logs the
+// reason (not just the decision) so a quiet pane and a suppressed one are
+// distinguishable from the log rather than indistinguishable from silence.
+type orchestratorPacingReason string
+
+const (
+	orchestratorPacingReasonNotAlive      orchestratorPacingReason = "not-alive"
+	orchestratorPacingReasonFresh         orchestratorPacingReason = "fresh"
+	orchestratorPacingReasonAlreadyCapped orchestratorPacingReason = "already-capped"
+	orchestratorPacingReasonCapCrossed    orchestratorPacingReason = "cap-crossed"
+	orchestratorPacingReasonNudge         orchestratorPacingReason = "nudge"
+)
+
 // decideOrchestratorPacing is the whole bound: a session the desktop cannot
-// see, one running a background shell, or one already past the cap gets no
-// nudge (a background shell is a fact independent of the turn's own busy/idle
-// state, per orchestrator_shell_activity.go — it can legitimately keep running
-// after the turn that started it ends, and nudging into it would interrupt
-// something the orchestrator deliberately left going). A candidate that is
-// stale and not yet capped gets nudged; one that just crossed the cap gets the
+// see, or one already past the cap, gets no nudge. A candidate that is stale
+// and not yet capped gets nudged; one that just crossed the cap gets the
 // one-time notice instead.
-func decideOrchestratorPacing(c orchestratorPacingCandidate, now time.Time) orchestratorPacingDecision {
-	if !c.alive || c.shellRunning {
-		return orchestratorPacingNone
+func decideOrchestratorPacing(c orchestratorPacingCandidate, now time.Time) (orchestratorPacingDecision, orchestratorPacingReason) {
+	if !c.alive {
+		return orchestratorPacingNone, orchestratorPacingReasonNotAlive
 	}
 	if now.Sub(c.lastActiveAt) < orchestratorPacingStaleAfter {
-		return orchestratorPacingNone
+		return orchestratorPacingNone, orchestratorPacingReasonFresh
 	}
 	if c.capped {
-		return orchestratorPacingNone
+		return orchestratorPacingNone, orchestratorPacingReasonAlreadyCapped
 	}
 	if c.nudgeCount >= orchestratorPacingMaxNudges {
-		return orchestratorPacingCap
+		return orchestratorPacingCap, orchestratorPacingReasonCapCrossed
 	}
-	return orchestratorPacingNudge
+	return orchestratorPacingNudge, orchestratorPacingReasonNudge
 }
 
 // orchestratorPacingRow is what the reconciler gathers under a.mu for one
 // orchestrator, before making any decision or doing any file/pty IO outside
 // the lock.
 type orchestratorPacingRow struct {
-	id              string
-	serial          int
-	name            string
-	alive           bool
-	shellRunning    bool
-	startedAt       time.Time
-	nudgeCount      int
-	capped          bool
-	lastNudgeAtUnix int64
+	id               string
+	serial           int
+	name             string
+	alive            bool
+	startedAt        time.Time
+	nudgeCount       int
+	capped           bool
+	lastNudgeAtUnix  int64
+	lastLoggedReason orchestratorPacingReason
 }
 
 // reconcileOrchestratorPacing runs on the same 15s tick that already polls
@@ -150,15 +170,15 @@ func (a *App) reconcileOrchestratorPacing() {
 		}
 		managed := a.sessions[orchestratorSessionKey(id)]
 		rows = append(rows, orchestratorPacingRow{
-			id:              id,
-			serial:          session.serial,
-			name:            session.name,
-			alive:           managed != nil && !managed.closed,
-			shellRunning:    session.shellRunning,
-			startedAt:       session.startedAt,
-			nudgeCount:      session.pacingNudgeCount,
-			capped:          session.pacingCapped,
-			lastNudgeAtUnix: session.pacingLastNudgeAtUnix,
+			id:               id,
+			serial:           session.serial,
+			name:             session.name,
+			alive:            managed != nil && !managed.closed,
+			startedAt:        session.startedAt,
+			nudgeCount:       session.pacingNudgeCount,
+			capped:           session.pacingCapped,
+			lastNudgeAtUnix:  session.pacingLastNudgeAtUnix,
+			lastLoggedReason: session.pacingLastReason,
 		})
 	}
 	a.mu.Unlock()
@@ -166,6 +186,34 @@ func (a *App) reconcileOrchestratorPacing() {
 	for _, row := range rows {
 		a.reconcileOrchestratorPacingOne(row, now)
 	}
+}
+
+// orchestratorPacingActivitySignal is what the reconciler could tell about the
+// orchestrator's last report, carried through to the marker so a session that
+// died mid-turn reads differently from one that simply went quiet after
+// finishing (erun#1376): a report has to exist and say "busy" for the marker
+// to call it a died turn, since idle-then-quiet is the ordinary, unremarkable
+// case the pacing contract expects.
+type orchestratorPacingActivitySignal int
+
+const (
+	orchestratorPacingSignalIdle orchestratorPacingActivitySignal = iota
+	orchestratorPacingSignalNoReport
+	orchestratorPacingSignalDied
+)
+
+// orchestratorPacingSignalFor classifies the last report the reconciler read,
+// independent of whether it was stale enough to nudge on: hasReport is false
+// only when no report has ever been read for this orchestrator (readOrchestratorPacingActivity's
+// ok), and lastBusy is that report's own "busy" field.
+func orchestratorPacingSignalFor(hasReport, lastBusy bool) orchestratorPacingActivitySignal {
+	if !hasReport {
+		return orchestratorPacingSignalNoReport
+	}
+	if lastBusy {
+		return orchestratorPacingSignalDied
+	}
+	return orchestratorPacingSignalIdle
 }
 
 // reconcileOrchestratorPacingOne reads this orchestrator's report, rearms it on
@@ -185,17 +233,45 @@ func (a *App) reconcileOrchestratorPacingOne(row orchestratorPacingRow, now time
 
 	candidate := orchestratorPacingCandidate{
 		alive:        row.alive,
-		shellRunning: row.shellRunning,
 		lastActiveAt: lastActiveAt,
 		nudgeCount:   row.nudgeCount,
 		capped:       row.capped,
 	}
-	switch decideOrchestratorPacing(candidate, now) {
+	elapsed := now.Sub(lastActiveAt)
+	decision, reason := decideOrchestratorPacing(candidate, now)
+	a.logOrchestratorPacingTransition(row, reason, elapsed)
+
+	switch decision {
 	case orchestratorPacingNudge:
-		a.sendOrchestratorPacingNudge(row.id, row.serial, now)
+		signal := orchestratorPacingSignalFor(ok, ok && report.activity.Busy)
+		a.sendOrchestratorPacingNudge(row.id, row.serial, now, elapsed, signal)
 	case orchestratorPacingCap:
 		a.capOrchestratorPacing(row.id, row.serial, row.name)
 	}
+}
+
+// logOrchestratorPacingTransition is the fix for the silent-suppression half of
+// erun#1376: every decision decideOrchestratorPacing can reach — not just
+// "nudge" — gets a durable, one-line record naming the orchestrator, the
+// measured quiet period, and which reason applied, so a quiet pane and a
+// suppressed one are told apart from the log rather than being indistinguishable.
+// It logs only on a transition (this orchestrator's reason changed since the
+// last tick), not on every 15s tick, since most orchestrators spend most of
+// their life in "fresh" and a per-tick line would drown the signal.
+func (a *App) logOrchestratorPacingTransition(row orchestratorPacingRow, reason orchestratorPacingReason, elapsed time.Duration) {
+	if reason == row.lastLoggedReason {
+		return
+	}
+	a.mu.Lock()
+	if session := a.orchestrators[row.id]; session != nil {
+		session.pacingLastReason = reason
+	}
+	a.mu.Unlock()
+	label := strings.TrimSpace(row.name)
+	if label == "" {
+		label = row.id
+	}
+	log.Printf("erun-app: orchestrator %s pacing decision=%s quiet=%s", label, reason, elapsed.Round(time.Second))
 }
 
 // rearmOrchestratorPacing clears the nudge count and the cap, so the next
@@ -214,7 +290,7 @@ func (a *App) rearmOrchestratorPacing(id string) {
 // sendOrchestratorPacingNudge records the attempt before writing, so a nudge
 // that fails to write still counts against the cap rather than looping forever
 // against a pty that cannot accept input.
-func (a *App) sendOrchestratorPacingNudge(id string, serial int, now time.Time) {
+func (a *App) sendOrchestratorPacingNudge(id string, serial int, now time.Time, elapsed time.Duration, signal orchestratorPacingActivitySignal) {
 	a.mu.Lock()
 	session := a.orchestrators[id]
 	managed := a.sessions[orchestratorSessionKey(id)]
@@ -230,6 +306,7 @@ func (a *App) sendOrchestratorPacingNudge(id string, serial int, now time.Time) 
 		// this does not cost against orchestratorPacingMaxNudges; the
 		// reconciler retries on its next 15s tick once they pause.
 		a.mu.Unlock()
+		log.Printf("erun-app: orchestrator %s pacing nudge deferred: pane is being typed into", id)
 		return
 	}
 	session.pacingNudgeCount++
@@ -238,9 +315,10 @@ func (a *App) sendOrchestratorPacingNudge(id string, serial int, now time.Time) 
 	a.mu.Unlock()
 
 	if !a.writeOrchestratorPacingNudge(managed) {
+		log.Printf("erun-app: orchestrator %s pacing nudge write failed", id)
 		return
 	}
-	a.emitOrchestratorPacingMarker(serial, count)
+	a.emitOrchestratorPacingMarker(serial, count, elapsed, signal)
 }
 
 // writeOrchestratorPacingNudge writes the pacing text, then — after a short
@@ -297,13 +375,38 @@ func (a *App) capOrchestratorPacing(id string, serial int, name string) {
 // the same style emitReconnectMarker already uses for terminal status lines —
 // typing into the operator's session without saying so is exactly the
 // state-without-affordance gap this exists to avoid.
-func (a *App) emitOrchestratorPacingMarker(sessionID, count int) {
-	marker := fmt.Sprintf("\r\n\x1b[2;33m── pacing nudge %d/%d sent — no activity report for %s ──\x1b[0m\r\n",
-		count, orchestratorPacingMaxNudges, orchestratorPacingStaleAfter)
+//
+// elapsed is the reconciler's own measured now.Sub(lastActiveAt), never the
+// orchestratorPacingStaleAfter constant: a session quiet for 20 minutes must
+// read as 20 minutes, not as the ten-minute contract restated back at the
+// operator as if it had been honoured (erun#1376).
+func (a *App) emitOrchestratorPacingMarker(sessionID, count int, elapsed time.Duration, signal orchestratorPacingActivitySignal) {
+	marker := fmt.Sprintf("\r\n\x1b[2;33m── pacing nudge %d/%d sent — %s ──\x1b[0m\r\n",
+		count, orchestratorPacingMaxNudges, orchestratorPacingQuietDescription(elapsed, signal))
 	a.emitEvent(terminalOutputEvent, terminalOutputPayload{
 		SessionID: sessionID,
 		Data:      base64.StdEncoding.EncodeToString([]byte(marker)),
 	})
+}
+
+// orchestratorPacingQuietDescription renders the measured quiet period, plus —
+// when the last report this orchestrator wrote said "busy" and was never
+// followed by an idle one — a distinct note that the turn behind it may have
+// died rather than simply gone quiet: a report stuck on "busy" for a full
+// staleness period is the harness never reaching its own turn boundary (a
+// dropped connection, a crash), not an orchestrator that finished and stopped
+// reporting. Without this, both look identical in the pane and the operator
+// has to go read a transcript to tell them apart (erun#1376).
+func orchestratorPacingQuietDescription(elapsed time.Duration, signal orchestratorPacingActivitySignal) string {
+	quiet := elapsed.Round(time.Second)
+	switch signal {
+	case orchestratorPacingSignalDied:
+		return fmt.Sprintf("no activity report for %s — last report said mid-turn, so the turn may have died without one", quiet)
+	case orchestratorPacingSignalNoReport:
+		return fmt.Sprintf("no activity report received in the %s since it started", quiet)
+	default:
+		return fmt.Sprintf("no activity report for %s", quiet)
+	}
 }
 
 // emitOrchestratorPacingCappedMarker names the recovery the same way the other

--- a/erun-ui/orchestrator_pacing_test.go
+++ b/erun-ui/orchestrator_pacing_test.go
@@ -72,7 +72,8 @@ func TestDecideOrchestratorPacing(t *testing.T) {
 		{"not alive (session gone) is never nudged", orchestratorPacingCandidate{alive: false, lastActiveAt: stale}, orchestratorPacingNone, orchestratorPacingReasonNotAlive},
 		{
 			"a stale session nudges even with a background shell recorded running: pacing no longer reads that fact",
-			orchestratorPacingCandidate{alive: true, lastActiveAt: stale}, orchestratorPacingNudge, orchestratorPacingReasonNudge,
+			orchestratorPacingCandidate{alive: true, lastActiveAt: stale},
+			orchestratorPacingNudge, orchestratorPacingReasonNudge,
 		},
 		{"already capped stays silent", orchestratorPacingCandidate{alive: true, lastActiveAt: stale, capped: true}, orchestratorPacingNone, orchestratorPacingReasonAlreadyCapped},
 		{"crossing the max count caps instead of nudging", orchestratorPacingCandidate{alive: true, lastActiveAt: stale, nudgeCount: orchestratorPacingMaxNudges}, orchestratorPacingCap, orchestratorPacingReasonCapCrossed},

--- a/erun-ui/orchestrator_pacing_test.go
+++ b/erun-ui/orchestrator_pacing_test.go
@@ -1,11 +1,33 @@
 package main
 
 import (
+	"bytes"
+	"encoding/base64"
+	"log"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 )
+
+// orchestratorPacingMarkerTexts decodes every terminalOutputEvent payload the
+// captured emitter saw into its raw string, in emission order, so a test can
+// assert on the exact marker text a nudge rendered.
+func orchestratorPacingMarkerTexts(emits *capturedEmits) []string {
+	var texts []string
+	for _, evt := range emits.events(terminalOutputEvent) {
+		payload, ok := evt.(terminalOutputPayload)
+		if !ok {
+			continue
+		}
+		data, err := base64.StdEncoding.DecodeString(payload.Data)
+		if err != nil {
+			continue
+		}
+		texts = append(texts, string(data))
+	}
+	return texts
+}
 
 // callRecordingSession wraps a stub session but also records each Write call
 // separately, so a test can assert the pacing text and its submitting CR
@@ -40,22 +62,30 @@ func TestDecideOrchestratorPacing(t *testing.T) {
 	stale := now.Add(-orchestratorPacingStaleAfter - time.Minute)
 
 	cases := []struct {
-		name string
-		c    orchestratorPacingCandidate
-		want orchestratorPacingDecision
+		name       string
+		c          orchestratorPacingCandidate
+		want       orchestratorPacingDecision
+		wantReason orchestratorPacingReason
 	}{
-		{"fresh activity is never nudged", orchestratorPacingCandidate{alive: true, lastActiveAt: fresh}, orchestratorPacingNone},
-		{"stale and alive is nudged", orchestratorPacingCandidate{alive: true, lastActiveAt: stale}, orchestratorPacingNudge},
-		{"not alive (session gone) is never nudged", orchestratorPacingCandidate{alive: false, lastActiveAt: stale}, orchestratorPacingNone},
-		{"a running background shell suppresses the nudge", orchestratorPacingCandidate{alive: true, shellRunning: true, lastActiveAt: stale}, orchestratorPacingNone},
-		{"already capped stays silent", orchestratorPacingCandidate{alive: true, lastActiveAt: stale, capped: true}, orchestratorPacingNone},
-		{"crossing the max count caps instead of nudging", orchestratorPacingCandidate{alive: true, lastActiveAt: stale, nudgeCount: orchestratorPacingMaxNudges}, orchestratorPacingCap},
-		{"below the max count still nudges", orchestratorPacingCandidate{alive: true, lastActiveAt: stale, nudgeCount: orchestratorPacingMaxNudges - 1}, orchestratorPacingNudge},
+		{"fresh activity is never nudged", orchestratorPacingCandidate{alive: true, lastActiveAt: fresh}, orchestratorPacingNone, orchestratorPacingReasonFresh},
+		{"stale and alive is nudged", orchestratorPacingCandidate{alive: true, lastActiveAt: stale}, orchestratorPacingNudge, orchestratorPacingReasonNudge},
+		{"not alive (session gone) is never nudged", orchestratorPacingCandidate{alive: false, lastActiveAt: stale}, orchestratorPacingNone, orchestratorPacingReasonNotAlive},
+		{
+			"a stale session nudges even with a background shell recorded running: pacing no longer reads that fact",
+			orchestratorPacingCandidate{alive: true, lastActiveAt: stale}, orchestratorPacingNudge, orchestratorPacingReasonNudge,
+		},
+		{"already capped stays silent", orchestratorPacingCandidate{alive: true, lastActiveAt: stale, capped: true}, orchestratorPacingNone, orchestratorPacingReasonAlreadyCapped},
+		{"crossing the max count caps instead of nudging", orchestratorPacingCandidate{alive: true, lastActiveAt: stale, nudgeCount: orchestratorPacingMaxNudges}, orchestratorPacingCap, orchestratorPacingReasonCapCrossed},
+		{"below the max count still nudges", orchestratorPacingCandidate{alive: true, lastActiveAt: stale, nudgeCount: orchestratorPacingMaxNudges - 1}, orchestratorPacingNudge, orchestratorPacingReasonNudge},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := decideOrchestratorPacing(tc.c, now); got != tc.want {
-				t.Fatalf("decideOrchestratorPacing(%+v) = %v, want %v", tc.c, got, tc.want)
+			gotDecision, gotReason := decideOrchestratorPacing(tc.c, now)
+			if gotDecision != tc.want {
+				t.Fatalf("decideOrchestratorPacing(%+v) decision = %v, want %v", tc.c, gotDecision, tc.want)
+			}
+			if gotReason != tc.wantReason {
+				t.Fatalf("decideOrchestratorPacing(%+v) reason = %v, want %v", tc.c, gotReason, tc.wantReason)
 			}
 		})
 	}
@@ -104,11 +134,10 @@ func TestReconcileOrchestratorPacingNudgesAQuietSession(t *testing.T) {
 	}
 }
 
-// TestReconcileOrchestratorPacingSkipsFreshBackgroundShellAndTransient locks
-// the three bounds a nudge must never cross: a session with fresh activity, one
-// running a background shell, and a transient (Investigate) session, none of
-// which have any pacing state to nudge from.
-func TestReconcileOrchestratorPacingSkipsFreshBackgroundShellAndTransient(t *testing.T) {
+// TestReconcileOrchestratorPacingSkipsFreshAndTransient locks the two bounds a
+// nudge must never cross: a session with fresh activity, and a transient
+// (Investigate) session, neither of which has any pacing state to nudge from.
+func TestReconcileOrchestratorPacingSkipsFreshAndTransient(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
 	orchestratorPacingNudgeSettle = 0
@@ -120,15 +149,6 @@ func TestReconcileOrchestratorPacingSkipsFreshBackgroundShellAndTransient(t *tes
 	app.sessions[freshKey] = &managedTerminal{session: freshSession, key: freshKey, serial: 1, kind: sessionKindOrchestrator}
 	app.orchestrators["fresh"] = &orchestratorSession{id: "fresh", serial: 1, startedAt: time.Now()}
 
-	shellSession := newCallRecordingSession()
-	shellKey := orchestratorSessionKey("shell")
-	app.sessions[shellKey] = &managedTerminal{session: shellSession, key: shellKey, serial: 2, kind: sessionKindOrchestrator}
-	app.orchestrators["shell"] = &orchestratorSession{
-		id: "shell", serial: 2,
-		startedAt:    time.Now().Add(-orchestratorPacingStaleAfter - time.Minute),
-		shellRunning: true,
-	}
-
 	transientSession := newCallRecordingSession()
 	transientKey := orchestratorSessionKey("")
 	app.sessions[transientKey] = &managedTerminal{session: transientSession, key: transientKey, serial: 3, kind: sessionKindOrchestrator}
@@ -139,10 +159,38 @@ func TestReconcileOrchestratorPacingSkipsFreshBackgroundShellAndTransient(t *tes
 
 	app.reconcileOrchestratorPacing()
 
-	for name, s := range map[string]*callRecordingSession{"fresh": freshSession, "shell": shellSession, "transient": transientSession} {
+	for name, s := range map[string]*callRecordingSession{"fresh": freshSession, "transient": transientSession} {
 		if len(s.Calls()) != 0 {
 			t.Fatalf("%s session must not be nudged, got writes %v", name, s.Calls())
 		}
+	}
+}
+
+// TestReconcileOrchestratorPacingNudgesThroughABackgroundShell is the
+// regression test for erun#1376: a stale orchestrator with a background shell
+// recorded running must still be nudged. Before the fix, `shellRunning` on the
+// candidate suppressed the nudge outright — exactly the case a long-running
+// build left going while its own turn had died mid-response, the scenario the
+// issue traced from a 20-minute silent pane.
+func TestReconcileOrchestratorPacingNudgesThroughABackgroundShell(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	orchestratorPacingNudgeSettle = 0
+
+	app := NewApp(erunUIDeps{})
+	session := newCallRecordingSession()
+	key := orchestratorSessionKey("shell")
+	app.sessions[key] = &managedTerminal{session: session, key: key, serial: 2, kind: sessionKindOrchestrator}
+	app.orchestrators["shell"] = &orchestratorSession{
+		id: "shell", serial: 2,
+		startedAt:    time.Now().Add(-orchestratorPacingStaleAfter - time.Minute),
+		shellRunning: true,
+	}
+
+	app.reconcileOrchestratorPacing()
+
+	if len(session.Calls()) != 2 {
+		t.Fatalf("expected a background shell to no longer suppress the nudge, got writes %v", session.Calls())
 	}
 }
 
@@ -228,6 +276,9 @@ func TestSendOrchestratorPacingNudgeSkipsWhilePaneBeingTypedInto(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
 	orchestratorPacingNudgeSettle = 0
+	restoreLogOutputAfter(t)
+	var logs bytes.Buffer
+	log.SetOutput(&logs)
 
 	app := NewApp(erunUIDeps{})
 	session := newCallRecordingSession()
@@ -271,6 +322,9 @@ func TestSendOrchestratorPacingNudgeSkipsWhilePaneBeingTypedInto(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("skipping for input must not consume a nudge from the cap, got count=%d", count)
 	}
+	if !strings.Contains(logs.String(), "pacing nudge deferred: pane is being typed into") {
+		t.Fatalf("expected the typing-deferred skip to be logged, got:\n%s", logs.String())
+	}
 }
 
 // TestSendSessionInputRearmsOrchestratorPacing locks the other rearm path: real
@@ -302,5 +356,154 @@ func TestSendSessionInputRearmsOrchestratorPacing(t *testing.T) {
 	}
 	if !strings.Contains(session.WrittenString(), "hello") {
 		t.Fatal("expected the input to still reach the session")
+	}
+}
+
+// TestOrchestratorPacingMarkerReportsMeasuredStaleness is the regression test
+// for erun#1376's first defect: the marker used to format the
+// orchestratorPacingStaleAfter constant (always "10m0s") regardless of how
+// long the session had actually been quiet, so a 20-minute outage rendered as
+// the ten-minute contract being honoured. This drives the reconciler with a
+// report aged ~20 minutes — double the contract — and asserts the marker
+// names the measured gap rather than the constant. Quoted both ways: on the
+// pre-fix code (marker built from orchestratorPacingStaleAfter) this fails
+// because the rendered text is always "10m0s"; post-fix it names the real gap.
+func TestOrchestratorPacingMarkerReportsMeasuredStaleness(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	orchestratorPacingNudgeSettle = 0
+
+	app := NewApp(erunUIDeps{})
+	emits := newCapturedEmits()
+	app.SetEmitter(emits.fn())
+
+	session := newCallRecordingSession()
+	key := orchestratorSessionKey("agent")
+	app.sessions[key] = &managedTerminal{session: session, key: key, serial: 7, kind: sessionKindOrchestrator}
+	app.orchestrators["agent"] = &orchestratorSession{id: "agent", serial: 7, name: "agent", startedAt: time.Now().Add(-30 * time.Minute)}
+	writeOrchestratorActivity(t, "agent", orchestratorActivity{Busy: false, AtUnix: time.Now().Add(-20 * time.Minute).Unix()})
+
+	app.reconcileOrchestratorPacing()
+
+	texts := orchestratorPacingMarkerTexts(emits)
+	if len(texts) != 1 {
+		t.Fatalf("expected exactly one marker, got %v", texts)
+	}
+	if strings.Contains(texts[0], orchestratorPacingStaleAfter.String()) {
+		t.Fatalf("marker still names the constant %s instead of the measured gap: %q", orchestratorPacingStaleAfter, texts[0])
+	}
+	if !strings.Contains(texts[0], "20m") {
+		t.Fatalf("expected the marker to name the measured ~20m gap, got %q", texts[0])
+	}
+}
+
+// TestOrchestratorPacingMarkerDistinguishesADiedTurnFromAQuietOne is the
+// regression test for erun#1376's fourth requirement: a session whose last
+// report said "busy" and was never followed by an idle one reads differently
+// from one that finished its turn and then went quiet, and differently again
+// from one that never wrote a report at all. The observed incident had a
+// report stuck on busy=true from a turn that died on a dropped connection —
+// this is what should have told the operator that from the pane alone.
+func TestOrchestratorPacingMarkerDistinguishesADiedTurnFromAQuietOne(t *testing.T) {
+	cases := []struct {
+		name        string
+		writeReport bool
+		busy        bool
+		wantSubstr  string
+	}{
+		{"last report said busy: reads as a died turn", true, true, "may have died"},
+		{"last report said idle: reads as an ordinary quiet pane", true, false, "no activity report for"},
+		{"no report was ever written: reads as never reported", false, false, "since it started"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("HOME", t.TempDir())
+			orchestratorPacingNudgeSettle = 0
+
+			app := NewApp(erunUIDeps{})
+			emits := newCapturedEmits()
+			app.SetEmitter(emits.fn())
+
+			session := newCallRecordingSession()
+			key := orchestratorSessionKey("agent")
+			app.sessions[key] = &managedTerminal{session: session, key: key, serial: 7, kind: sessionKindOrchestrator}
+			started := time.Now().Add(-orchestratorPacingStaleAfter - time.Minute)
+			app.orchestrators["agent"] = &orchestratorSession{id: "agent", serial: 7, name: "agent", startedAt: started}
+			if tc.writeReport {
+				writeOrchestratorActivity(t, "agent", orchestratorActivity{Busy: tc.busy, AtUnix: started.Unix()})
+			}
+
+			app.reconcileOrchestratorPacing()
+
+			texts := orchestratorPacingMarkerTexts(emits)
+			if len(texts) != 1 {
+				t.Fatalf("expected exactly one marker, got %v", texts)
+			}
+			if !strings.Contains(texts[0], tc.wantSubstr) {
+				t.Fatalf("marker %q does not contain %q", texts[0], tc.wantSubstr)
+			}
+		})
+	}
+}
+
+// TestOrchestratorPacingLogsEachDecisionReasonOnTransition is the fix for
+// erun#1376's second defect: every branch decideOrchestratorPacing can reach —
+// not just the ones that end in a nudge — leaves a durable, findable record of
+// the reason. Before this, a stalled pane and a healthy quiet one were
+// indistinguishable because nothing recorded which one applied. It also pins
+// that a second tick with nothing changed does not repeat any line, since a
+// per-tick log would drown the signal for orchestrators that spend most of
+// their life "fresh".
+func TestOrchestratorPacingLogsEachDecisionReasonOnTransition(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	orchestratorPacingNudgeSettle = 0
+	restoreLogOutputAfter(t)
+	var logs bytes.Buffer
+	log.SetOutput(&logs)
+
+	app := NewApp(erunUIDeps{})
+
+	freshSession := newCallRecordingSession()
+	freshKey := orchestratorSessionKey("fresh")
+	app.sessions[freshKey] = &managedTerminal{session: freshSession, key: freshKey, serial: 1, kind: sessionKindOrchestrator}
+	app.orchestrators["fresh"] = &orchestratorSession{id: "fresh", serial: 1, name: "fresh", startedAt: time.Now()}
+
+	app.orchestrators["gone"] = &orchestratorSession{id: "gone", serial: 2, name: "gone", startedAt: time.Now().Add(-orchestratorPacingStaleAfter - time.Minute)}
+
+	cappedSession := newCallRecordingSession()
+	cappedKey := orchestratorSessionKey("capped")
+	app.sessions[cappedKey] = &managedTerminal{session: cappedSession, key: cappedKey, serial: 3, kind: sessionKindOrchestrator}
+	app.orchestrators["capped"] = &orchestratorSession{
+		id: "capped", serial: 3, name: "capped",
+		startedAt:    time.Now().Add(-orchestratorPacingStaleAfter - time.Minute),
+		pacingCapped: true,
+	}
+
+	nudgedSession := newCallRecordingSession()
+	nudgedKey := orchestratorSessionKey("nudged")
+	app.sessions[nudgedKey] = &managedTerminal{session: nudgedSession, key: nudgedKey, serial: 4, kind: sessionKindOrchestrator}
+	app.orchestrators["nudged"] = &orchestratorSession{id: "nudged", serial: 4, name: "nudged", startedAt: time.Now().Add(-orchestratorPacingStaleAfter - time.Minute)}
+
+	app.reconcileOrchestratorPacing()
+
+	logged := logs.String()
+	for _, want := range []string{
+		"orchestrator fresh pacing decision=fresh",
+		"orchestrator gone pacing decision=not-alive",
+		"orchestrator capped pacing decision=already-capped",
+		"orchestrator nudged pacing decision=nudge",
+	} {
+		if !strings.Contains(logged, want) {
+			t.Fatalf("expected %q in the pacing log, got:\n%s", want, logged)
+		}
+	}
+
+	// A second tick with none of these reasons changed must not repeat any line.
+	logs.Reset()
+	app.reconcileOrchestratorPacing()
+	if logs.Len() != 0 {
+		t.Fatalf("expected no repeated pacing log lines on an unchanged reason, got:\n%s", logs.String())
 	}
 }


### PR DESCRIPTION
## Summary

A stalled orchestrator went 20m07s with no pacing message against the 10-minute contract, and the pane showed nothing throughout. Two compounding defects:

- **The marker lied.** It formatted the `orchestratorPacingStaleAfter` constant, not the reconciler's own measured `now.Sub(lastActiveAt)` — so a 20-minute outage rendered as `no activity report for 10m0s`, i.e. the contract reading as honoured when it wasn't.
- **Every suppression path was silent.** `decideOrchestratorPacing` returning "none" for not-alive, fresh, already-capped, or (previously) a running background shell left no record of which reason applied, so a stalled pane was indistinguishable from a healthy quiet one.

**Why the nudge didn't fire at the 10-minute boundary:** `decideOrchestratorPacing` suppressed the nudge outright whenever the orchestrator's background-shell report said `running: true` — a fact about a shell, not about the turn behind it. A long-running build is the single most likely thing still going when a turn dies mid-response, so the rule blocked the nudge exactly when it was needed most. Fixed by dropping `shellRunning` from the decision entirely (the recommended fix in the issue); the shell-activity report itself, and the shell indicator it drives, are untouched.

## Changes (`erun-ui`)

- `orchestrator_pacing.go`: `decideOrchestratorPacing` now returns `(decision, reason)`; the reconciler logs every transition (not every 15s tick) naming the orchestrator, the measured quiet duration, and the reason. The marker renders the measured elapsed time, and — when the last report said `busy: true` and was never followed by an idle one — names that the turn may have died mid-response rather than simply gone quiet, so a dead session reads differently from an ordinarily quiet one. The `typedRecentlyLocked` skip in `sendOrchestratorPacingNudge` is now also logged.
- `orchestrator.go`: added `pacingLastReason` to `orchestratorSession` so the reconciler can detect a transition.
- Tests: table cases for every `decideOrchestratorPacing` reason (including the shell-running-and-stale case, which now nudges); a regression test proving the marker renders the measured ~20m gap rather than the `10m0s` constant (confirmed red on the pre-fix marker, green after); a test for the died-vs-quiet-vs-never-reported marker text; a test that every decision reason is logged once per transition and not repeated on an unchanged tick; a regression test that a background shell no longer suppresses the nudge.
- `erun-docs/docs/agent-reference/skills-spec.md`: updated the pacing spec to describe the measured-duration marker, the dropped shell-running gate, the died-vs-quiet marker text, and the per-transition decision log. The Operator-facing companion page (`collaboration/workflow`) needed no change — it already said "about ten minutes" without claiming precision or naming the shell suppression.

## UX Impact Review Checklist (erun-ui/AGENTS.md)

1. **Affected paths:** the session-heartbeat 15s tick → `reconcileOrchestratorPacing` → pacing marker written into an orchestrator's terminal pane, plus the desktop's durable app log.
2. **User-visible sequence:** no dialog or new control — the change is entirely in what an existing pane marker says and what the durable log records. An operator watching a stalled orchestrator now sees the true elapsed quiet time and, when applicable, a note that the turn may have died; a background shell no longer hides the nudge.
3. **State-without-affordance:** n/a — no new state field is introduced without a rendering consequence; `pacingLastReason` is reconciler-internal bookkeeping for log dedup, not UI state.
4. **Visibility of system status (Nielsen #1):** improved — the marker text is now truthful about elapsed time and distinguishes a died turn from a quiet one.
5. **Success/failure feedback:** n/a, no new action.
6. **Consistency with comparable flows:** the marker keeps the same dim-line style as `emitReconnectMarker`/the capped notice.
7. **Heuristic pass:** visibility of system status is the one heuristic in play here and it's the thing being fixed; the rest don't apply to a log-line/marker-text change.
8. **Playwright coverage:** `erun-ui/playwright/tests/orchestrator-pacing-nudge.spec.ts` already covers the only reachable invariant in the headless harness (a created-but-never-started orchestrator has none of the reconciler's side effects) — the pacing decision itself requires a live orchestrator PTY with a real activity report aging past 10 real minutes, which the harness cannot and must not simulate (spawning a real agent process). That limitation and the Go tests covering the unreachable branches are documented in the spec file's header comment (pre-existing, still accurate). Ran with `--build` to confirm it still passes after this change.

Closes #1376

## Test plan

- [x] `cd erun-ui && timeout 900 go test -race -count=1 ./...` — green
- [x] `cd erun-ui && ./build.sh` — green (`0 issues.` from golangci-lint, frontend typecheck/lint/format/test all pass)
- [x] `cd erun-ui && ./playwright/run.sh --build -- tests/orchestrator-pacing-nudge.spec.ts` — green
- [x] `cd erun-docs && yarn build` — clean
- [x] Red-then-green for `TestOrchestratorPacingMarkerReportsMeasuredStaleness`: confirmed it fails against the pre-fix marker (prints `10m0s` for a 20-minute-aged report) and passes against the fix (names the measured ~20m gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)