### PR TITLE
Confirm before revoking a user's access in the console

### DIFF
--- a/erun-console/src/identity/UsersPanel.test.tsx
+++ b/erun-console/src/identity/UsersPanel.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { renderWithStore } from '../test/renderWithStore';
@@ -172,7 +172,110 @@ describe('UsersPanel', () => {
     expect(await screen.findByText(/could not be enrolled as an erun user/)).toBeInTheDocument();
   });
 
-  it('deactivates an active user and refreshes the list', async () => {
+  it('does not deactivate a user on a single click', async () => {
+    let deactivateCalled = false;
+    mockFetch((req) => {
+      if (req.method === 'POST' && req.url === '/v1/identity/users/idp-1/deactivate') {
+        deactivateCalled = true;
+        return jsonResponse({});
+      }
+      if (req.url === '/v1/identity/users') {
+        return jsonResponse([{ id: 'idp-1', username: 'alice', state: 'USER_STATE_ACTIVE' }]);
+      }
+      return jsonResponse({}, 404);
+    });
+    renderWithStore(<UsersPanel token="dev-token" />);
+    await screen.findByText('USER_STATE_ACTIVE');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deactivate' }));
+
+    expect(deactivateCalled).toBe(false);
+    expect(screen.getByText('USER_STATE_ACTIVE')).toBeInTheDocument();
+  });
+
+  it('names the user and the consequence in the deactivate confirmation', async () => {
+    mockFetch((req) => {
+      if (req.url === '/v1/identity/users') {
+        return jsonResponse([{ id: 'idp-1', username: 'alice', state: 'USER_STATE_ACTIVE' }]);
+      }
+      return jsonResponse({}, 404);
+    });
+    renderWithStore(<UsersPanel token="dev-token" />);
+    await screen.findByText('USER_STATE_ACTIVE');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deactivate' }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByRole('heading', { name: /alice/ })).toBeInTheDocument();
+    expect(within(dialog).getByText(/next sign-in/)).toBeInTheDocument();
+  });
+
+  it('leaves the user active when the deactivate confirmation is cancelled', async () => {
+    let deactivateCalled = false;
+    mockFetch((req) => {
+      if (req.method === 'POST' && req.url === '/v1/identity/users/idp-1/deactivate') {
+        deactivateCalled = true;
+        return jsonResponse({});
+      }
+      if (req.url === '/v1/identity/users') {
+        return jsonResponse([{ id: 'idp-1', username: 'alice', state: 'USER_STATE_ACTIVE' }]);
+      }
+      return jsonResponse({}, 404);
+    });
+    renderWithStore(<UsersPanel token="dev-token" />);
+    await screen.findByText('USER_STATE_ACTIVE');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deactivate' }));
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(deactivateCalled).toBe(false);
+    expect(screen.getByText('USER_STATE_ACTIVE')).toBeInTheDocument();
+  });
+
+  it('disables cancel and confirm while the deactivate request is in flight', async () => {
+    let resolveDeactivate: (() => void) | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: string | URL, init?: RequestInit) => {
+        const url = requestUrl(input);
+        const method = init?.method ?? 'GET';
+        if (method === 'POST' && url === '/v1/identity/users/idp-1/deactivate') {
+          return new Promise<Response>((resolve) => {
+            resolveDeactivate = () => {
+              resolve(jsonResponse({}));
+            };
+          });
+        }
+        if (url === '/v1/identity/users') {
+          return Promise.resolve(
+            jsonResponse([{ id: 'idp-1', username: 'alice', state: 'USER_STATE_ACTIVE' }]),
+          );
+        }
+        return Promise.resolve(jsonResponse({}, 404));
+      }),
+    );
+
+    renderWithStore(<UsersPanel token="dev-token" />);
+    await screen.findByText('USER_STATE_ACTIVE');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deactivate' }));
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Deactivate' }));
+
+    expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(within(dialog).getByRole('button', { name: /Deactivate/ })).toBeDisabled();
+
+    resolveDeactivate?.();
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('deactivates an active user through the confirmation dialog and refreshes the list', async () => {
     let deactivateCalled = false;
     let listCount = 0;
     mockFetch((req) => {
@@ -191,8 +294,35 @@ describe('UsersPanel', () => {
     await screen.findByText('USER_STATE_ACTIVE');
 
     fireEvent.click(screen.getByRole('button', { name: 'Deactivate' }));
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Deactivate' }));
 
     await screen.findByText('USER_STATE_INACTIVE');
     expect(deactivateCalled).toBe(true);
+  });
+
+  it('reactivates an inactive user on a single click, with no confirmation gate', async () => {
+    let reactivateCalled = false;
+    let listCount = 0;
+    mockFetch((req) => {
+      if (req.method === 'POST' && req.url === '/v1/identity/users/idp-1/reactivate') {
+        reactivateCalled = true;
+        return jsonResponse({});
+      }
+      if (req.url === '/v1/identity/users') {
+        listCount += 1;
+        const state = listCount === 1 ? 'USER_STATE_INACTIVE' : 'USER_STATE_ACTIVE';
+        return jsonResponse([{ id: 'idp-1', username: 'alice', state }]);
+      }
+      return jsonResponse({}, 404);
+    });
+    renderWithStore(<UsersPanel token="dev-token" />);
+    await screen.findByText('USER_STATE_INACTIVE');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reactivate' }));
+
+    await screen.findByText('USER_STATE_ACTIVE');
+    expect(reactivateCalled).toBe(true);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/erun-console/src/identity/UsersPanel.tsx
+++ b/erun-console/src/identity/UsersPanel.tsx
@@ -20,7 +20,7 @@ import {
   TableHeader,
   TableRow,
 } from 'erun-kit';
-import { Users } from 'lucide-react';
+import { LoaderCircle, Users } from 'lucide-react';
 import * as React from 'react';
 
 import type { EnrollIdentityUserInput, IdentityUser } from '../app/api/identityApi';
@@ -214,12 +214,68 @@ function EnrollForm({
   );
 }
 
+// DeactivateUserDialog gates the access-revoking half of the toggle behind an
+// explicit confirmation (erun-ui/AGENTS.md's design-language record, #1419):
+// deactivating blocks the user's next sign-in immediately, and the row it was
+// clicked from looks identical to every other row, so a misclick is easy and
+// its consequence is invisible until the person locked out reports it.
+// Reactivating restores access rather than revoking it, so it stays a single
+// click — only the deactivate half needs this gate.
+function DeactivateUserDialog({
+  user,
+  onCancel,
+  onConfirm,
+}: {
+  user: IdentityUser;
+  onCancel: () => void;
+  onConfirm: (externalId: string, active: boolean) => Promise<void>;
+}): React.ReactElement {
+  const [busy, setBusy] = React.useState(false);
+
+  const confirm = (): void => {
+    setBusy(true);
+    void onConfirm(user.id, false).then(onCancel);
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open && !busy) {
+          onCancel();
+        }
+      }}
+    >
+      <DialogContent aria-labelledby="deactivate-user-heading">
+        <DialogHeader>
+          <DialogTitle id="deactivate-user-heading">Deactivate {user.username}?</DialogTitle>
+          <DialogDescription>
+            {user.username} will not be able to sign in again until reactivated. This takes effect
+            on their next sign-in.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" disabled={busy} onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button type="button" variant="destructive" disabled={busy} onClick={confirm}>
+            {busy && <LoaderCircle className="animate-spin" aria-hidden="true" />}
+            Deactivate
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function UserRow({
   user,
   onSetActive,
+  onRequestDeactivate,
 }: {
   user: IdentityUser;
-  onSetActive: (externalId: string, active: boolean) => void;
+  onSetActive: (externalId: string, active: boolean) => Promise<void>;
+  onRequestDeactivate: (user: IdentityUser) => void;
 }): React.ReactElement {
   const active = user.state === 'USER_STATE_ACTIVE';
   const canToggle = active || user.state === 'USER_STATE_INACTIVE';
@@ -235,7 +291,11 @@ function UserRow({
             variant="outline"
             size="sm"
             onClick={() => {
-              onSetActive(user.id, !active);
+              if (active) {
+                onRequestDeactivate(user);
+              } else {
+                void onSetActive(user.id, true);
+              }
             }}
           >
             {active ? 'Deactivate' : 'Reactivate'}
@@ -249,9 +309,11 @@ function UserRow({
 function UsersTable({
   users,
   onSetActive,
+  onRequestDeactivate,
 }: {
   users: IdentityUser[];
-  onSetActive: (externalId: string, active: boolean) => void;
+  onSetActive: (externalId: string, active: boolean) => Promise<void>;
+  onRequestDeactivate: (user: IdentityUser) => void;
 }): React.ReactElement {
   if (users.length === 0) {
     return <EmptyState icon={<Users />} heading="No users enrolled yet." />;
@@ -268,7 +330,12 @@ function UsersTable({
       </TableHeader>
       <TableBody>
         {users.map((user) => (
-          <UserRow key={user.id} user={user} onSetActive={onSetActive} />
+          <UserRow
+            key={user.id}
+            user={user}
+            onSetActive={onSetActive}
+            onRequestDeactivate={onRequestDeactivate}
+          />
         ))}
       </TableBody>
     </Table>
@@ -278,9 +345,11 @@ function UsersTable({
 function UsersBody({
   usersState,
   onSetActive,
+  onRequestDeactivate,
 }: {
   usersState: UsersState;
-  onSetActive: (externalId: string, active: boolean) => void;
+  onSetActive: (externalId: string, active: boolean) => Promise<void>;
+  onRequestDeactivate: (user: IdentityUser) => void;
 }): React.ReactElement {
   if (usersState.status === 'loading') {
     return (
@@ -296,7 +365,13 @@ function UsersBody({
       </p>
     );
   }
-  return <UsersTable users={usersState.users} onSetActive={onSetActive} />;
+  return (
+    <UsersTable
+      users={usersState.users}
+      onSetActive={onSetActive}
+      onRequestDeactivate={onRequestDeactivate}
+    />
+  );
 }
 
 // UsersPanel is the console's IdP-identity administration surface (issue
@@ -308,13 +383,20 @@ export function UsersPanel({ token }: { token: string }): React.ReactElement {
     useUsersController(token);
   const temporaryPassword =
     enrollState.status === 'enrolled' ? enrollState.result.temporaryPassword : undefined;
+  const [pendingDeactivate, setPendingDeactivate] = React.useState<IdentityUser | undefined>(
+    undefined,
+  );
   return (
     <Card aria-labelledby="identity-users-heading">
       <CardHeader>
         <CardTitle id="identity-users-heading">Users</CardTitle>
       </CardHeader>
       <CardContent className="grid gap-6">
-        <UsersBody usersState={usersState} onSetActive={setActive} />
+        <UsersBody
+          usersState={usersState}
+          onSetActive={setActive}
+          onRequestDeactivate={setPendingDeactivate}
+        />
         <EnrollForm enroll={enrollState} onEnroll={enroll} />
       </CardContent>
       {temporaryPassword !== undefined && enrollState.status === 'enrolled' && (
@@ -322,6 +404,15 @@ export function UsersPanel({ token }: { token: string }): React.ReactElement {
           username={enrollState.result.idpUser.username}
           password={temporaryPassword}
           onDismiss={dismissTemporaryPassword}
+        />
+      )}
+      {pendingDeactivate !== undefined && (
+        <DeactivateUserDialog
+          user={pendingDeactivate}
+          onCancel={() => {
+            setPendingDeactivate(undefined);
+          }}
+          onConfirm={setActive}
         />
       )}
     </Card>

--- a/erun-console/src/identity/controller.ts
+++ b/erun-console/src/identity/controller.ts
@@ -45,7 +45,7 @@ export interface UsersController {
   enrollState: EnrollState;
   refresh: () => void;
   enroll: (input: EnrollIdentityUserInput) => void;
-  setActive: (externalId: string, active: boolean) => void;
+  setActive: (externalId: string, active: boolean) => Promise<void>;
   dismissTemporaryPassword: () => void;
 }
 
@@ -98,11 +98,15 @@ export function useUsersController(token: string): UsersController {
     [token, activeRef, createIdentityUser],
   );
 
+  // setActive resolves once the request settles, whether it succeeded or
+  // failed, so a caller gating the call behind a confirmation dialog can
+  // await it to know when to stop showing the in-flight state.
   const setActive = React.useCallback(
-    (externalId: string, active: boolean) => {
+    (externalId: string, active: boolean): Promise<void> => {
       setActionError(undefined);
-      setIdentityUserActive({ token, externalId, active })
+      return setIdentityUserActive({ token, externalId, active })
         .unwrap()
+        .then(() => undefined)
         .catch((error: unknown) => {
           if (activeRef.current) {
             setActionError(queryErrorMessage(error));

--- a/erun-docs/docs/collaboration/identity-administration.md
+++ b/erun-docs/docs/collaboration/identity-administration.md
@@ -16,7 +16,7 @@ Signed in as an Operator on an **OPERATIONS** tenant, the console's **Users** vi
   - **When outbound mail is configured** (see below), enrolling emails the new person a sign-in link, the normal invite flow.
   - **When it is not**, there is no mail path for that link to travel, so the backend does not pretend to send one: it generates a temporary password instead and returns it once. This is deliberate — an invite that silently waited on an email that could never arrive would look successful and never resolve. The console shows this password in a dialog right after enrollment, copyable in one click, and says plainly it will not be shown again. Hand it to the new person before closing the dialog — closing it drops the password from the console's own state for good.
 - **List every identity** the platform's IdP knows about, with its current state.
-- **Deactivate** a user, which blocks their next sign-in immediately.
+- **Deactivate** a user, which blocks their next sign-in immediately. The console asks you to confirm before it takes effect, naming the person and the consequence.
 - **Reactivate** a deactivated user.
 
 The **Org settings** view lets you read and change:


### PR DESCRIPTION
## Summary

Deactivating a user in the console's Identity panel was a **single click**, and deactivation blocks their next sign-in immediately. The rows are visually identical, so a misplaced click locks out a colleague and nothing surfaces it until they cannot sign in.

Found by the cross-surface UX pass (#1316), and the decision it landed is what settles it:

> **Every destructive or access-revoking action confirms before it runs.** … This applies to the console with the same weight it applies to the desktop — a single-click toggle is never acceptable for an action with real consequences.

## What changed

A confirm dialog matching the **desktop's** destructive-action footer rather than a console-local invention: cancel/outline first, destructive second, both disabled while in flight with a spinner on the primary. The confirmation **names the user and the consequence** — that it takes effect on their next sign-in — instead of a bare "are you sure?".

Reactivation is deliberately not gated the same way: it restores access rather than revoking it, so it is not a destructive action.

## Verification

Three assertions, including the one most likely to be skipped:

- `does not deactivate a user on a single click` — red before, green after
- `names the user and the consequence in the deactivate confirmation`
- `leaves the user active when the deactivate confirmation is cancelled`

Closes #1419