### PR TITLE
Consolidate onto one status badge and one inline-failure family, and enforce it

### DIFF
--- a/erun-ui/frontend/src/components/app/ActivityQueueDrawer.tsx
+++ b/erun-ui/frontend/src/components/app/ActivityQueueDrawer.tsx
@@ -1,4 +1,4 @@
-import { Button, cn, Tooltip, TooltipContent, TooltipTrigger } from 'erun-kit';
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from 'erun-kit';
 import { X } from 'lucide-react';
 import { Dialog as DialogPrimitive } from 'radix-ui';
 import * as React from 'react';
@@ -14,6 +14,7 @@ import {
   activityTargetLabel,
   isHistoryStatus,
 } from '@/components/app/ActivityQueueDrawer.helpers';
+import { InlineAlert } from '@/components/app/InlineAlert';
 
 interface ActivityQueueDrawerProps {
   open: boolean;
@@ -235,34 +236,43 @@ function RecoveryFeedback({
   result: ActivityRecoveryResult;
   onDismiss: () => void;
 }): React.ReactElement {
+  const header = (
+    <div className="flex w-full items-start justify-between gap-2">
+      <p className="font-medium">{result.ok ? 'Recovery succeeded' : 'Recovery failed'}</p>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label="Dismiss recovery message"
+        onClick={onDismiss}
+      >
+        <X aria-hidden="true" className="size-3.5" />
+      </Button>
+    </div>
+  );
+  const output = result.output && (
+    <pre className="mt-1 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-sm bg-background/40 p-2 font-mono text-[10.5px] text-foreground">
+      {result.output}
+    </pre>
+  );
+  if (!result.ok) {
+    return (
+      <InlineAlert>
+        <div className="grid w-full gap-1 text-xs">
+          {header}
+          {result.error && <p className="break-words font-mono text-[10.5px]">{result.error}</p>}
+          {output}
+        </div>
+      </InlineAlert>
+    );
+  }
   return (
     <section
       role="status"
-      className={cn(
-        'rounded-md border px-3 py-2 text-xs',
-        result.ok
-          ? 'border-green-600/35 bg-green-600/10 text-foreground'
-          : 'border-[color-mix(in_oklch,var(--destructive)_35%,var(--border))] bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] text-destructive',
-      )}
+      className="rounded-md border border-green-600/35 bg-green-600/10 px-3 py-2 text-xs text-foreground"
     >
-      <div className="flex items-start justify-between gap-2">
-        <p className="font-medium">{result.ok ? 'Recovery succeeded' : 'Recovery failed'}</p>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label="Dismiss recovery message"
-          onClick={onDismiss}
-        >
-          <X aria-hidden="true" className="size-3.5" />
-        </Button>
-      </div>
-      {result.error && <p className="mt-1 break-words font-mono text-[10.5px]">{result.error}</p>}
-      {result.output && (
-        <pre className="mt-1 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-sm bg-background/40 p-2 font-mono text-[10.5px] text-foreground">
-          {result.output}
-        </pre>
-      )}
+      {header}
+      {output}
     </section>
   );
 }

--- a/erun-ui/frontend/src/components/app/ManageDialog.fields.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialog.fields.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, cn, Input, Label } from 'erun-kit';
+import { Checkbox, Input, Label } from 'erun-kit';
 import * as React from 'react';
 
 export function ReadonlyField({
@@ -112,25 +112,5 @@ export function TextField({
         </div>
       )}
     </div>
-  );
-}
-
-export function StatusBadge({ status }: { status: string }): React.ReactElement {
-  const normalized = status.trim() || 'unknown';
-  const className =
-    normalized === 'running'
-      ? 'border-green-600/35 bg-green-600/10 text-green-700 dark:text-green-400'
-      : normalized === 'stopped'
-        ? 'border-border bg-muted/40 text-muted-foreground'
-        : 'border-[color-mix(in_oklch,var(--destructive)_35%,var(--border))] bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] text-destructive';
-  return (
-    <span
-      className={cn(
-        'shrink-0 rounded-[calc(var(--radius)-2px)] border px-1.5 py-0.5 text-[11px] leading-none font-medium',
-        className,
-      )}
-    >
-      {normalized.replace(/_/g, ' ')}
-    </span>
   );
 }

--- a/erun-ui/frontend/src/components/app/ManageDialog.helpers.test.ts
+++ b/erun-ui/frontend/src/components/app/ManageDialog.helpers.test.ts
@@ -3,7 +3,7 @@ import { test } from 'node:test';
 
 import { workspaceSyncStatusTone } from './ManageDialog.helpers';
 
-// Before #1418, ManageDialog.fields.tsx's own StatusBadge only distinguished
+// ManageDialog.fields.tsx's own StatusBadge used to only distinguish
 // 'running' (green) and 'stopped' (muted); every other workspaceSyncStatus
 // value -- including 'starting' and 'syncing', which are in-progress rather
 // than failed -- fell into its catch-all destructive (red) branch. The

--- a/erun-ui/frontend/src/components/app/ManageDialog.helpers.test.ts
+++ b/erun-ui/frontend/src/components/app/ManageDialog.helpers.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { workspaceSyncStatusTone } from './ManageDialog.helpers';
+
+// Before #1418, ManageDialog.fields.tsx's own StatusBadge only distinguished
+// 'running' (green) and 'stopped' (muted); every other workspaceSyncStatus
+// value -- including 'starting' and 'syncing', which are in-progress rather
+// than failed -- fell into its catch-all destructive (red) branch. The
+// canonical erun-kit StatusBadge this now renders through needs a tone for
+// every value workspace_sync.go actually sets.
+test('a sync in progress reads as in-progress, not destructive', () => {
+  assert.equal(workspaceSyncStatusTone('starting'), 'in-progress');
+  assert.equal(workspaceSyncStatusTone('syncing'), 'in-progress');
+});
+
+test('a sync failure reads as destructive', () => {
+  assert.equal(workspaceSyncStatusTone('error'), 'destructive');
+});
+
+test('a stopped sync reads as muted, not destructive', () => {
+  assert.equal(workspaceSyncStatusTone('stopped'), 'muted');
+});
+
+test('an unrecognized status falls back to warning rather than defaulting to destructive', () => {
+  assert.equal(workspaceSyncStatusTone('mystery'), 'warning');
+});

--- a/erun-ui/frontend/src/components/app/ManageDialog.helpers.ts
+++ b/erun-ui/frontend/src/components/app/ManageDialog.helpers.ts
@@ -1,3 +1,5 @@
+import type { StatusBadgeTone } from 'erun-kit';
+
 import type { UIEnvironmentConfig } from '@/types';
 
 export const dialogErrorClassName =
@@ -37,6 +39,18 @@ export function portRangeValue(rangeStart: number, rangeEnd: number): string {
 export function parseIdleTrafficBytes(value: string): number {
   const parsed = Number(value.trim() || 0);
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 0;
+}
+
+// Keys are the workspaceSyncStatus values set by App.setWorkspaceSyncStatus (erun-ui/workspace_sync.go).
+const workspaceSyncStatusTones: Record<string, StatusBadgeTone> = {
+  error: 'destructive',
+  stopped: 'muted',
+  starting: 'in-progress',
+  syncing: 'in-progress',
+};
+
+export function workspaceSyncStatusTone(status: string): StatusBadgeTone {
+  return workspaceSyncStatusTones[status.trim()] ?? 'warning';
 }
 
 export function relativeTimeFromNow(timestamp: number): string {

--- a/erun-ui/frontend/src/components/app/ManageDialogGeneralTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogGeneralTab.tsx
@@ -15,8 +15,9 @@ import { loadSavedPastContainerRegistries } from '@/app/storage';
 import { ContainerRegistriesField } from '@/components/app/ContainerRegistriesField';
 import { EnvironmentHealthSection } from '@/components/app/EnvironmentHealthSection';
 import { cloudProviderTypeLabel } from '@/components/app/GlobalConfigDialog.helpers';
+import { CloudStatusBadge } from '@/components/app/GlobalConfigDialog.shared';
 import { LocalRepoPathInput } from '@/components/app/LocalRepoPathInput';
-import { ReadonlyField, StatusBadge } from '@/components/app/ManageDialog.fields';
+import { ReadonlyField } from '@/components/app/ManageDialog.fields';
 import { PullCoordinatesFields } from '@/components/app/ManageDialogPullCoordinates';
 import {
   EnvironmentTypeValues,
@@ -326,7 +327,7 @@ function CloudContextField({
           <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
             <Server className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
             <span className="truncate">{context.kubernetesContext || context.name}</span>
-            <StatusBadge status={context.status} />
+            <CloudStatusBadge status={context.status} />
           </div>
           <div className="truncate text-xs text-muted-foreground">
             {[context.cloudProviderAlias, context.region, context.instanceType, context.instanceId]

--- a/erun-ui/frontend/src/components/app/ManageDialogSSHTab.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogSSHTab.tsx
@@ -1,4 +1,4 @@
-import { Button, cn, Input, Label } from 'erun-kit';
+import { Button, cn, Input, Label, StatusBadge } from 'erun-kit';
 import { FolderOpen, Server, Stethoscope } from 'lucide-react';
 import * as React from 'react';
 
@@ -14,8 +14,11 @@ import {
 import { showTerminalError } from '@/app/notificationThunks';
 import type { AppState } from '@/app/state';
 import { selectionKey } from '@/app/versionSuggestions';
-import { CheckboxField, ReadonlyField, StatusBadge } from '@/components/app/ManageDialog.fields';
-import { relativeTimeFromNow } from '@/components/app/ManageDialog.helpers';
+import { CheckboxField, ReadonlyField } from '@/components/app/ManageDialog.fields';
+import {
+  relativeTimeFromNow,
+  workspaceSyncStatusTone,
+} from '@/components/app/ManageDialog.helpers';
 
 type ManageDialog = AppState['manageDialog'];
 
@@ -194,7 +197,7 @@ function WorkspaceSyncStatus({
       className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-2 rounded-[var(--radius)] border border-border bg-muted/35 px-3 py-2 text-[13px] leading-[1.35]"
       role={status === 'error' ? 'alert' : 'status'}
     >
-      <StatusBadge status={status} />
+      <StatusBadge tone={workspaceSyncStatusTone(status)} label={status.replace(/_/g, ' ')} />
       <span
         className={cn(
           'min-w-0 [overflow-wrap:anywhere]',

--- a/erun-ui/frontend/src/components/app/TenantDashboardMessage.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardMessage.tsx
@@ -8,6 +8,7 @@ import {
   relativeDashboardDate,
   tenantDashboardPanel,
 } from '@/app/tenantDashboardPanels';
+import { InlineAlert } from '@/components/app/InlineAlert';
 
 export type TenantDashboardData = AppState['tenantDashboard']['data'];
 
@@ -40,7 +41,11 @@ export function PanelBody({
     );
   }
   if (panel?.error) {
-    return <DashboardMessage message={panel.error} destructive />;
+    return (
+      <div className="mt-4">
+        <InlineAlert>{panel.error}</InlineAlert>
+      </div>
+    );
   }
   if (!children) {
     return <div className="mt-4">{empty}</div>;
@@ -48,21 +53,20 @@ export function PanelBody({
   return <>{children}</>;
 }
 
-// DashboardMessage carries a status line or a failure for one dashboard surface.
-// It is deliberately not input-shaped: an empty panel uses EmptyState instead,
-// so nothing reads as a disabled field.
+// DashboardMessage is the one case an inline dashboard message isn't a
+// failure or a permission state: a transient loading line. Failures route
+// through InlineAlert instead (see PanelBody and GenericLoadFailure).
 export function DashboardMessage({
   message,
   icon,
-  destructive,
 }: {
   message: string;
   icon?: React.ReactElement;
-  destructive?: boolean;
 }): React.ReactElement {
   return (
     <div
-      className={`mt-4 flex items-center gap-2 rounded-[var(--radius)] border px-3 py-2.5 text-sm ${destructive ? 'border-destructive/35 text-destructive' : 'border-border text-muted-foreground'}`}
+      role="status"
+      className="mt-4 flex items-center gap-2 rounded-[var(--radius)] border border-border px-3 py-2.5 text-sm text-muted-foreground"
     >
       {icon}
       <span>{message}</span>

--- a/erun-ui/frontend/src/components/app/TenantDashboardPanels.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardPanels.tsx
@@ -7,8 +7,8 @@ import type {
   UITenantDashboardUser,
 } from '@/types';
 
+import { InlineAlert } from './InlineAlert';
 import {
-  DashboardMessage,
   DataCell,
   DataTable,
   PanelBody,
@@ -139,7 +139,11 @@ function AuditEventsTable({ events }: { events: UITenantDashboardAudit[] }): Rea
 
 function APILogPanel({ log, error }: { log: string; error: string }): React.ReactElement {
   if (error) {
-    return <DashboardMessage message={error} destructive />;
+    return (
+      <div className="mt-4">
+        <InlineAlert>{error}</InlineAlert>
+      </div>
+    );
   }
   if (!log.trim()) {
     return (

--- a/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/app/tenantDialogThunks';
 import type { UITenant } from '@/types';
 
+import { InlineAlert } from './InlineAlert';
 import { DashboardMessage } from './TenantDashboardMessage';
 import { TenantDashboardPanels } from './TenantDashboardPanels';
 import { TenantPlatformStateCard } from './TenantPlatformState';
@@ -155,7 +156,7 @@ function GenericLoadFailure({
 }): React.ReactElement {
   return (
     <div className="grid gap-3">
-      <DashboardMessage message={message} destructive />
+      <InlineAlert>{message}</InlineAlert>
       <Button
         type="button"
         variant="outline"

--- a/erun-ui/frontend/src/designLanguageVocabulary.test.ts
+++ b/erun-ui/frontend/src/designLanguageVocabulary.test.ts
@@ -6,9 +6,9 @@ import { fileURLToPath } from 'node:url';
 
 // erun-ui/AGENTS.md § "Design-Language Decision Record" names two collisions
 // this repository decided to close for good: a second component named
-// StatusBadge that hand-rolled its own status colors (#1418), and inline
-// failure surfaces that rendered without going through InlineAlert /
-// PermissionNotice (#1420). These tests fail the moment either regresses,
+// StatusBadge that hand-rolled its own status colors, and inline failure
+// surfaces that rendered without going through InlineAlert / PermissionNotice.
+// These tests fail the moment either regresses,
 // rather than relying on a reviewer noticing a new hand-rolled color mapping.
 
 const frontendSrc = fileURLToPath(new URL('.', import.meta.url));
@@ -49,8 +49,8 @@ test('the desktop no longer hand-rolls a destructive color mapping outside Inlin
   // TenantDashboardMessage.tsx's DashboardMessage and ActivityQueueDrawer.tsx's
   // RecoveryFeedback both used to branch their own border/background/text
   // classes on a destructive flag, with no ARIA role naming the failure. Both
-  // now render a refused write through InlineAlert instead (see #1420). Scoped
-  // to the raw Tailwind utility classes rather than the bare word
+  // now render a refused write through InlineAlert instead. Scoped to the
+  // raw Tailwind utility classes rather than the bare word
   // "destructive" so a legitimate `variant="destructive"` Button elsewhere in
   // these files would not false-positive this check.
   const offenders = [

--- a/erun-ui/frontend/src/designLanguageVocabulary.test.ts
+++ b/erun-ui/frontend/src/designLanguageVocabulary.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+// erun-ui/AGENTS.md § "Design-Language Decision Record" names two collisions
+// this repository decided to close for good: a second component named
+// StatusBadge that hand-rolled its own status colors (#1418), and inline
+// failure surfaces that rendered without going through InlineAlert /
+// PermissionNotice (#1420). These tests fail the moment either regresses,
+// rather than relying on a reviewer noticing a new hand-rolled color mapping.
+
+const frontendSrc = fileURLToPath(new URL('.', import.meta.url));
+const erunKitSrc = join(frontendSrc, '../../../erun-kit/src');
+
+function collectSourceFiles(root: string): string[] {
+  const files: string[] = [];
+  for (const name of readdirSync(root)) {
+    if (name === 'node_modules' || name === 'ui') continue;
+    const full = join(root, name);
+    const stats = statSync(full);
+    if (stats.isDirectory()) {
+      files.push(...collectSourceFiles(full));
+      continue;
+    }
+    if (/\.(ts|tsx)$/.test(name) && !name.endsWith('.test.ts')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const statusBadgeDefinition =
+  /\b(?:export\s+)?function\s+StatusBadge\s*\(|\bconst\s+StatusBadge\s*[:=]/;
+
+test('StatusBadge is defined in exactly one place: erun-kit', () => {
+  const definitions = [...collectSourceFiles(frontendSrc), ...collectSourceFiles(erunKitSrc)]
+    .filter((file) => statusBadgeDefinition.test(readFileSync(file, 'utf8')))
+    .map((file) => relative(join(frontendSrc, '../../..'), file));
+
+  assert.deepEqual(definitions, ['erun-kit/src/components/StatusBadge.tsx']);
+});
+
+const handRolledDestructiveStyling =
+  /\btext-destructive\b|\bborder-destructive\b|\bbg-destructive\b/;
+
+test('the desktop no longer hand-rolls a destructive color mapping outside InlineAlert', () => {
+  // TenantDashboardMessage.tsx's DashboardMessage and ActivityQueueDrawer.tsx's
+  // RecoveryFeedback both used to branch their own border/background/text
+  // classes on a destructive flag, with no ARIA role naming the failure. Both
+  // now render a refused write through InlineAlert instead (see #1420). Scoped
+  // to the raw Tailwind utility classes rather than the bare word
+  // "destructive" so a legitimate `variant="destructive"` Button elsewhere in
+  // these files would not false-positive this check.
+  const offenders = [
+    'components/app/TenantDashboardMessage.tsx',
+    'components/app/ActivityQueueDrawer.tsx',
+  ]
+    .map((relPath) => join(frontendSrc, relPath))
+    .filter((file) => handRolledDestructiveStyling.test(readFileSync(file, 'utf8')));
+
+  assert.deepEqual(offenders, []);
+});

--- a/erun-ui/playwright/tests/activity-recovery-feedback.spec.ts
+++ b/erun-ui/playwright/tests/activity-recovery-feedback.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '../fixtures/erunApp.js';
+
+// Before #1420, RecoveryFeedback rendered its outer <section role="status">
+// regardless of outcome, so a failed recovery -- a write the backend refused --
+// was announced no more urgently than a success. It now routes a failure
+// through InlineAlert (role="alert"), matched here via the accessibility tree
+// rather than an attribute string match.
+//
+// The synthetic entry below is never pushed into the backend's real activity
+// queue (it only exists in the frontend's Redux state via EventsEmit), so
+// clicking "Clear pending helm release" hits App.resolveRecoverableHelmEntry's
+// id-not-found guard and returns deterministically before touching any real
+// helm/kubectl binary -- unlike "Run doctor"/"Rebuild & redeploy" on the same
+// card, which pipe real commands into the shared Local shell and must not be
+// clicked in this harness (see activity-failure-details.spec.ts).
+test('a failed pending-helm recovery announces as an alert, not a status update', async ({
+  app,
+  page,
+}) => {
+  await app.activityDrawer.open();
+  await expect(app.activityDrawer.locator()).toBeVisible();
+
+  await page.evaluate(() => {
+    const now = new Date().toISOString();
+    const entry = {
+      id: 'recovery-alert-1',
+      command: 'deploy',
+      tenant: 'petios',
+      environment: 'rihards-recovery',
+      version: '1.0.80',
+      release: 'petios-devops',
+      namespace: 'petios-rihards-recovery',
+      status: 'failed',
+      startedAt: now,
+      endedAt: now,
+      lastUpdated: now,
+      source: 'trace',
+      error: '==> Deploy failed after 4s',
+    };
+    (
+      window as unknown as { runtime: { EventsEmit: (n: string, ...a: unknown[]) => void } }
+    ).runtime.EventsEmit('activity:state', entry);
+  });
+
+  const drawer = app.activityDrawer.locator();
+  const card = drawer.locator('article').filter({ hasText: 'petios/rihards-recovery' }).first();
+  const recoverButton = card.getByRole('button', { name: 'Clear pending helm release' });
+  await expect(recoverButton).toBeVisible();
+  await recoverButton.click();
+
+  const alert = drawer.getByRole('alert').filter({ hasText: 'Recovery failed' });
+  await expect(alert).toBeVisible();
+  await expect(alert).toContainText('activity not found');
+  // The drawer's other role="status" region (the live status announcer) must
+  // not also claim this message -- it is an alert, not a status update.
+  await expect(drawer.getByRole('status').filter({ hasText: 'Recovery failed' })).toHaveCount(0);
+
+  await page.screenshot({ path: 'test-results/recovery-feedback-alert-light.png' });
+  // The theme toggle button lives in the titlebar, behind the drawer's own
+  // overlay while open, and the recovery feedback is ephemeral component
+  // state that a close/reopen would lose -- so the dark capture flips the
+  // same `.dark` class the toggle button applies (root AGENTS.md's
+  // Design-Language Decision Record: both apps share one class-based
+  // light/dark mechanism) directly, without exercising the toggle control.
+  await page.evaluate(() => {
+    document.documentElement.classList.add('dark');
+  });
+  await page.screenshot({ path: 'test-results/recovery-feedback-alert-dark.png' });
+});

--- a/erun-ui/playwright/tests/activity-recovery-feedback.spec.ts
+++ b/erun-ui/playwright/tests/activity-recovery-feedback.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '../fixtures/erunApp.js';
 
-// Before #1420, RecoveryFeedback rendered its outer <section role="status">
-// regardless of outcome, so a failed recovery -- a write the backend refused --
-// was announced no more urgently than a success. It now routes a failure
+// RecoveryFeedback used to render its outer <section role="status"> regardless
+// of outcome, so a failed recovery -- a write the backend refused -- was
+// announced no more urgently than a success. It now routes a failure
 // through InlineAlert (role="alert"), matched here via the accessibility tree
 // rather than an attribute string match.
 //

--- a/erun-ui/playwright/tests/manage-dialog-status-badge.spec.ts
+++ b/erun-ui/playwright/tests/manage-dialog-status-badge.spec.ts
@@ -1,0 +1,109 @@
+import type { Request, Route } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+
+// erun-kit's StatusBadge is the one canonical status badge in the product
+// (#1418). Before this fix, ManageDialog.fields.tsx defined a second,
+// same-named component that hand-branched 'running'/'stopped' into raw
+// Tailwind colors and rendered no icon at all, so any other status --
+// including an in-progress one like 'starting' -- fell into its destructive
+// catch-all. Both sites below now render through the canonical component;
+// the always-rendered icon is the visible proof, since a hand-rolled
+// StatusBadge with the exact same text and no icon would otherwise pass a
+// text-only assertion.
+
+async function mutateInvokeResponse(
+  page: import('@playwright/test').Page,
+  method: string,
+  mutate: (data: Record<string, unknown>) => void,
+): Promise<void> {
+  await page.route('**/__erun_invoke', async (route: Route, request: Request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+    if (body.method !== method) {
+      await route.continue();
+      return;
+    }
+    const response = await route.fetch();
+    const json = (await response.json()) as { data?: Record<string, unknown> };
+    if (json.data) mutate(json.data);
+    await route.fulfill({ response, json });
+  });
+}
+
+// Applies the app's own class-based light/dark mechanism directly (root
+// AGENTS.md's Design-Language Decision Record: one shared `.dark` class
+// mechanism) rather than clicking the titlebar toggle, which sits behind the
+// manage dialog's own overlay while it is open.
+async function forceDarkTheme(page: import('@playwright/test').Page): Promise<void> {
+  await page.evaluate(() => {
+    document.documentElement.classList.add('dark');
+  });
+}
+
+test('a workspace sync in progress reads as in-progress, with an icon, through the canonical StatusBadge', async ({
+  app,
+  page,
+  seededEnv,
+}) => {
+  await mutateInvokeResponse(page, 'LoadEnvironmentConfig', (data) => {
+    const sshd = data.sshd as Record<string, unknown>;
+    sshd.enabled = true;
+    sshd.workspaceSyncEnabled = true;
+    sshd.workspaceSyncStatus = 'starting';
+    sshd.workspaceSyncStatusMessage = 'Starting workspace sync';
+  });
+
+  await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
+  await app.manageDialog.waitForOpen();
+  await app.manageDialog.selectTab('Access');
+
+  const dialog = app.manageDialog.locator();
+  const badgeLabel = dialog.getByText('starting', { exact: true });
+  await expect(badgeLabel).toBeVisible();
+  await expect(badgeLabel.locator('xpath=..').locator('svg')).toHaveCount(1);
+  await badgeLabel.scrollIntoViewIfNeeded();
+  await page.screenshot({ path: 'test-results/status-badge-workspace-sync-light.png' });
+
+  await forceDarkTheme(page);
+  await page.screenshot({ path: 'test-results/status-badge-workspace-sync-dark.png' });
+
+  await app.manageDialog.cancel();
+  await app.manageDialog.waitForClosed();
+});
+
+test('a pending cloud context reads as in-progress, with an icon, through the canonical StatusBadge', async ({
+  app,
+  page,
+  seededEnv,
+}) => {
+  await mutateInvokeResponse(page, 'LoadEnvironmentConfig', (data) => {
+    data.cloudContext = {
+      name: 'pw-aws',
+      provider: 'aws',
+      cloudProviderAlias: 'pw-aws',
+      region: 'us-east-1',
+      instanceType: 't3.medium',
+      diskType: 'gp3',
+      diskSizeGb: 40,
+      kubernetesContext: 'pw-aws-context',
+      status: 'pending',
+    };
+  });
+
+  await app.sidebar.openManageDialogViaKeyboard(seededEnv.tenant, seededEnv.environment);
+  await app.manageDialog.waitForOpen();
+  await app.manageDialog.selectTab('General');
+
+  const dialog = app.manageDialog.locator();
+  const badgeLabel = dialog.getByText('Pending', { exact: true });
+  await expect(badgeLabel).toBeVisible();
+  await expect(badgeLabel.locator('xpath=..').locator('svg')).toHaveCount(1);
+  await badgeLabel.scrollIntoViewIfNeeded();
+  await page.screenshot({ path: 'test-results/status-badge-cloud-context-light.png' });
+
+  await forceDarkTheme(page);
+  await page.screenshot({ path: 'test-results/status-badge-cloud-context-dark.png' });
+
+  await app.manageDialog.cancel();
+  await app.manageDialog.waitForClosed();
+});

--- a/erun-ui/playwright/tests/manage-dialog-status-badge.spec.ts
+++ b/erun-ui/playwright/tests/manage-dialog-status-badge.spec.ts
@@ -2,9 +2,9 @@ import type { Request, Route } from '@playwright/test';
 
 import { expect, test } from '../fixtures/erunApp.js';
 
-// erun-kit's StatusBadge is the one canonical status badge in the product
-// (#1418). Before this fix, ManageDialog.fields.tsx defined a second,
-// same-named component that hand-branched 'running'/'stopped' into raw
+// erun-kit's StatusBadge is the one canonical status badge in the product.
+// ManageDialog.fields.tsx used to define a second, same-named component that
+// hand-branched 'running'/'stopped' into raw
 // Tailwind colors and rendered no icon at all, so any other status --
 // including an in-progress one like 'starting' -- fell into its destructive
 // catch-all. Both sites below now render through the canonical component;

--- a/erun-ui/playwright/tests/tenant-dashboard-permissions.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-permissions.spec.ts
@@ -145,7 +145,7 @@ test.describe('tenant dashboard — permission-derived surfaces (#1210)', () => 
       // hidden the way a missing permission is.
       await app.tenantDashboard.selectTab('Builds');
       await expect(app.tenantDashboard.activePanel()).toContainText('http 500');
-      // Before #1420, PanelBody's error branch rendered through a bespoke
+      // PanelBody's error branch used to render through a bespoke
       // DashboardMessage <div> with no ARIA role at all, so a screen reader
       // never announced it. It now renders through InlineAlert (role="alert"),
       // queried here via the accessibility tree rather than an attribute match.

--- a/erun-ui/playwright/tests/tenant-dashboard-permissions.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-permissions.spec.ts
@@ -145,6 +145,15 @@ test.describe('tenant dashboard — permission-derived surfaces (#1210)', () => 
       // hidden the way a missing permission is.
       await app.tenantDashboard.selectTab('Builds');
       await expect(app.tenantDashboard.activePanel()).toContainText('http 500');
+      // Before #1420, PanelBody's error branch rendered through a bespoke
+      // DashboardMessage <div> with no ARIA role at all, so a screen reader
+      // never announced it. It now renders through InlineAlert (role="alert"),
+      // queried here via the accessibility tree rather than an attribute match.
+      await expect(app.tenantDashboard.activePanel().getByRole('alert')).toContainText('http 500');
+      await page.screenshot({ path: 'test-results/dashboard-panel-error-alert-light.png' });
+      await app.titlebar.toggleTheme();
+      await page.screenshot({ path: 'test-results/dashboard-panel-error-alert-dark.png' });
+      await app.titlebar.toggleTheme();
 
       await app.tenantDashboard.selectTab('Audit log');
       await expect(app.tenantDashboard.auditRows()).toHaveCount(1);


### PR DESCRIPTION
## Summary

Two findings from the cross-surface UX pass (#1316), fixed together because they
are one defect: **a decided component with drifted duplicates.**

- **#1418** — the desktop defined **two components named `StatusBadge`** with
  incompatible contracts, one hand-rolling its own status colours and bypassing
  the shared five-tone vocabulary entirely.
- **#1420** — inline-failure rendering had drifted into **four
  implementations**, and **two of them rendered with no ARIA role at all**.

That second part is not a consistency nit. A failure a screen reader never
announces is invisible, not merely inconsistent — `TenantDashboardMessage`'s
`DashboardMessage` and `ActivityQueueDrawer`'s `RecoveryFeedback` both branched
their own border/background/text classes on a destructive flag with nothing
naming the failure to assistive technology.

## Applying decisions, not making them

Both were already settled by the decision record that landed hours earlier
(`6d0a0c00`, `erun-ui/AGENTS.md` § "Design-Language Decision Record"):

> **One status-badge component.** … Never define a second component with the
> same name or shape that hand-rolls its own color mapping.

> **One inline failure/notice family.** `InlineAlert` (`role="alert"`) for a
> write that was attempted and refused; `PermissionNotice` (`role="status"`) for
> "you may not do/see this" — a state, not a fault.

Every call site now goes through `erun-kit`'s canonical `StatusBadge` with a
named tone helper, and every inline failure through `InlineAlert` /
`PermissionNotice`.

## The part that makes it stick

`designLanguageVocabulary.test.ts` scans source and fails if either collision
returns:

- *"StatusBadge is defined in exactly one place: erun-kit"*
- *"the desktop no longer hand-rolls a destructive color mapping outside
  InlineAlert"* — scoped to the raw Tailwind utilities rather than the bare word
  "destructive", so a legitimate `variant="destructive"` Button does not
  false-positive.

Its own comment states the point: these fail *"the moment either regresses,
rather than relying on a reviewer noticing a new hand-rolled color mapping."*

A decision record that depends on reviewers remembering it decays. This turns
two of its entries into enforced invariants.

## Verification

Red-then-green for both collisions. The consolidated surfaces are asserted to
render the correct role — `alert` for a refused write, `status` for a permission
state — through accessibility-tree queries rather than attribute matching, so
the announcement itself is verified. Playwright coverage added for the manage
dialog's status badges and the activity-recovery feedback path.

Closes #1418
Closes #1420
