### PR TITLE
Stop the review dialog re-deriving a capability its caller already resolved

### DIFF
--- a/erun-ui/frontend/src/app/createReviewDialogThunks.ts
+++ b/erun-ui/frontend/src/app/createReviewDialogThunks.ts
@@ -21,10 +21,18 @@ import type { AppThunk, RootState } from './store';
 // New review button has neither — it derives tenant/environment from the
 // tenant dashboard the way it always has, and target branch defaults to
 // 'main' the way it always has.
+// knownCapability lets a caller that already resolved canCreateReview from a
+// loaded tenant dashboard (the Reviews tab's own New review button, gated on
+// that same field — TenantDashboardPanels.Reviews.tsx) skip the dialog's
+// independent network probe entirely. Without it, opening the dialog re-runs
+// TenantReviewCreateCapability's own platform resolution on every open, which
+// can disagree with the dashboard's already-current answer (and did, for the
+// two write flows this broke — see tenant-dashboard-review-write.spec.ts).
 export interface CreateReviewDialogContext {
-  tenant: string;
-  environment: string;
+  tenant?: string;
+  environment?: string;
   targetBranch?: string;
+  knownCapability?: boolean;
 }
 
 // resolveCreateReviewDialogContext fills in whatever the caller did not
@@ -64,6 +72,7 @@ export const openCreateReviewDialog =
       context,
       getState(),
     );
+    const knownCapability = context?.knownCapability ?? false;
     dispatch(
       patchCreateReviewDialog({
         ...resetCreateReviewDialogState(),
@@ -72,11 +81,13 @@ export const openCreateReviewDialog =
         environment,
         targetBranch,
         branchLoading: Boolean(environment),
-        capabilityLoading: Boolean(tenant),
+        capabilityLoading: !knownCapability && Boolean(tenant),
       }),
     );
     await Promise.all([
-      tenant ? dispatch(loadCreateReviewDialogCapability(tenant)) : Promise.resolve(),
+      knownCapability || !tenant
+        ? Promise.resolve()
+        : dispatch(loadCreateReviewDialogCapability(tenant)),
       environment ? dispatch(loadCreateReviewDialogBranch(tenant, environment)) : Promise.resolve(),
     ]);
   };

--- a/erun-ui/frontend/src/components/app/TenantDashboardPanels.Reviews.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardPanels.Reviews.tsx
@@ -217,7 +217,7 @@ function NewReviewAction({ data }: { data: TenantDashboardData }): React.ReactEl
       type="button"
       size="sm"
       onClick={() => {
-        void dispatch(openCreateReviewDialog());
+        void dispatch(openCreateReviewDialog({ knownCapability: true }));
       }}
     >
       <Plus aria-hidden="true" />


### PR DESCRIPTION
`main` was red: **360 passed / 3 failed**, all three in
`tenant-dashboard-review-write.spec.ts` (:86, :240, :321), on a serial,
uncontended full run.

## The failure

All three were the same timeout, in `CreateReviewDialog.create()`:

```
Test timeout of 30000ms exceeded.
Error: locator.click: Test timeout of 30000ms exceeded.
  - waiting for getByRole('dialog').getByRole('button', { name: 'Create review' })
    - locator resolved to <button disabled ...>Create review</button>
    - element is not enabled
```

The page snapshot named the cause: a `role="status"` banner reading *"This
tenant's platform connection isn't ready. Open the Reviews tab to connect or
sign in."* — with the name filled, the branch pushed and a target branch already
selected.

## Root cause

#1315 added `TenantReviewCreateCapability`, an independent RPC that re-resolves
the tenant's platform connection every time the dialog opens. That is correct
for the diff panel, which can open the dialog before the tenant dashboard has
ever loaded and genuinely does not know the answer.

But `openCreateReviewDialog()` fired it **unconditionally** — including from the
Reviews tab's New review button, which **only renders once the loaded dashboard
has already resolved `canCreateReview: true`**. So the dialog re-derived an
answer its caller already held, and whenever the fresh probe disagreed, a stale
"not ready" disabled Create.

That disagreement is not hypothetical in the harness: the RPC layer is stubbed
at `/__erun_invoke`, `TenantReviewCreateCapability` was not among the stubbed
methods, so it fell through to the real Go implementation and resolved against
the deliberately-unreachable `apiurl: http://127.0.0.1:1/unreachable`.

One cause behind all three failures, as expected from one surface.

## Why this also closes #1427

#1427 reports Create staying disabled after picking a target branch from the
choices popover. Same mechanism: the New review button cannot render unless the
dashboard already said the operator can create a review, so any subsequent "not
ready" from the redundant probe contradicts a decision already made. Removing
the redundant probe removes the contradiction.

If the capability genuinely changes between dashboard load and the click, the
create now fails into the existing `PlatformErrorAlert` sign-in recovery — a
named problem carrying its next action, rather than a dead button with no
explanation.

## What changed

- `createReviewDialogThunks.ts` — `CreateReviewDialogContext` gains an optional
  `knownCapability`; when set, the dialog skips the independent probe instead of
  re-deriving what the caller resolved.
- `TenantDashboardPanels.Reviews.tsx` — the New review button passes
  `{ knownCapability: true }`.
- `DiffList.StartReviewAction.tsx` — **unchanged**; that entry point still
  probes, because it genuinely does not know.

No test was weakened or modified. The assertions already encoded the correct
behaviour; the product now honours them.

## Gates

- `go test -race -count=1 ./...` → `ok` (`erun-ui`, `erun-ui/headlessserver`)
- `erun-ui/build.sh` (golangci-lint) → **0 issues**, exits 0
- frontend `yarn typecheck`, `yarn format:check` → clean; `yarn lint` → 5
  warnings, all **pre-existing on `main`** (confirmed via `git stash`), 0 errors
  introduced; `yarn test` → 241/241
- `playwright/run.sh --build -- tenant-dashboard-review-write` → 10/10
- full Playwright suite → **363 passed, 0 failed, 0 skipped** (20.8 min)

Closes #1427