### PR TITLE
Stop the env hover card asserting Stopped beside a spinning row

### DIFF
--- a/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx
@@ -15,6 +15,7 @@ import { BusyRowSpinner } from '@/components/app/Sidebar.BusyRowSpinner';
 import { EnvHoverCard } from '@/components/app/Sidebar.EnvHoverCard';
 import {
   deriveEnvironmentRow,
+  environmentCardActivityLabel,
   type EnvironmentIndicator,
   environmentIndicator,
   type EnvironmentRowDerived,
@@ -428,7 +429,12 @@ export function EnvironmentRow({
       isLocal={isLocal}
       isHost={isHost}
       runtimeVersion={runtimeVersion}
-      activityLabel={busy && !busyFromEnvironment ? busyLabel : ''}
+      activityLabel={environmentCardActivityLabel(
+        busy,
+        busyFromEnvironment,
+        busyLabel,
+        indicator.dot,
+      )}
       indicator={indicator}
     >
       <EnvironmentRowOpenButton

--- a/erun-ui/frontend/src/components/app/Sidebar.helpers.test.ts
+++ b/erun-ui/frontend/src/components/app/Sidebar.helpers.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { deriveEnvironmentRow, environmentIndicator } from './Sidebar.helpers';
+import {
+  deriveEnvironmentRow,
+  environmentCardActivityLabel,
+  environmentIndicator,
+} from './Sidebar.helpers';
 
 // One derived row state from three inputs: the sticky condition the desktop set,
 // what the environment reports about itself, and whether the desktop owns tabs.
@@ -307,4 +311,89 @@ test('a label describing an operation this desktop is running is not', () => {
 
   assert.equal(row({ isOpening: true, envBusy: true }).busyFromEnvironment, false);
   assert.equal(row({ reconnecting: true, envBusy: true }).busyFromEnvironment, false);
+});
+
+// The card either repeats the row's busy reason or defers to the condition
+// indicator — never neither. busyFromEnvironment blanks the row's own label on
+// the assumption the indicator will say 'busy' on its own, which is only true
+// when no sticky condition outranks it.
+function indicatorDot(envState: string, busy: boolean) {
+  return environmentIndicator({
+    name: 'team / dev',
+    envState,
+    isOpen: true,
+    reachable: false,
+    outage: false,
+    busy,
+    detail: '',
+  }).dot;
+}
+
+test('environmentCardActivityLabel repeats the row label unless the indicator already will', () => {
+  assert.equal(environmentCardActivityLabel(false, false, 'unused', 'running'), '');
+  assert.equal(
+    environmentCardActivityLabel(true, false, 'Building team / dev', 'running'),
+    'Building team / dev',
+  );
+  assert.equal(environmentCardActivityLabel(true, true, 'team / dev is busy', 'busy'), '');
+  assert.equal(
+    environmentCardActivityLabel(true, true, 'team / dev is busy — a lease', 'stopped'),
+    'team / dev is busy — a lease',
+  );
+  assert.equal(
+    environmentCardActivityLabel(true, true, 'team / dev is busy — a lease', 'failed'),
+    'team / dev is busy — a lease',
+  );
+});
+
+// The defect: the activity poller that sets envBusy and the lifecycle
+// event that sets the sticky envState run on separate cycles, so a fresh
+// "the environment is busy" observation can land while envState still reads
+// stopped/failed from before. environmentStatusDot gives that sticky
+// condition priority over busy, so the indicator alone would say "Stopped" —
+// and blanking the row's own label handed that stale answer to the card while
+// the row kept spinning for a real, current reason right beside it.
+test('the card never asserts a bare Stopped/Failed while the row spins from a fresh envBusy', () => {
+  for (const envState of ['stopped', 'runtime-stopped', 'failed']) {
+    const derived = row({
+      envBusy: true,
+      envBusyDetail: 'holding: gradle-build',
+      envObserved: true,
+    });
+    const dot = indicatorDot(envState, true);
+    assert.equal(derived.busy, true, envState);
+    const cardLabel = environmentCardActivityLabel(
+      derived.busy,
+      derived.busyFromEnvironment,
+      derived.busyLabel,
+      dot,
+    );
+    assert.equal(cardLabel, derived.busyLabel, envState);
+    assert.doesNotMatch(cardLabel, /^(Stopped|Deploy failed)/, envState);
+  }
+});
+
+// isOpening/reconnecting were suspected of the same class of bug (an
+// envObserved-stopped row with a lingering desktop-local flag), but they
+// cannot reproduce it: environmentRowCommandLabel always names them directly,
+// so the label handed to the row's spinner and the card is the same string
+// whether or not the flag is stale. They are also, independently, always
+// cleared on the failure path rather than left stale — openSelection's
+// `finally` clears openingByEnv even when StartSession throws
+// (sessionThunks.ts), and confirmReconnect's catch moves reconnect.status to
+// 'error' rather than leaving it on 'running' (reviewThunks.ts) — so this
+// pins the agreement rather than a hypothetical staleness fix.
+test('a lingering isOpening/reconnecting flag never disagrees with the card', () => {
+  for (const overrides of [{ isOpening: true }, { reconnecting: true }]) {
+    const derived = row({ ...overrides, envObserved: true });
+    const dot = indicatorDot('stopped', false);
+    assert.equal(derived.busy, true, JSON.stringify(overrides));
+    const cardLabel = environmentCardActivityLabel(
+      derived.busy,
+      derived.busyFromEnvironment,
+      derived.busyLabel,
+      dot,
+    );
+    assert.equal(cardLabel, derived.busyLabel, JSON.stringify(overrides));
+  }
 });

--- a/erun-ui/frontend/src/components/app/Sidebar.helpers.ts
+++ b/erun-ui/frontend/src/components/app/Sidebar.helpers.ts
@@ -194,6 +194,32 @@ function environmentRowBusyLabel(
   return '';
 }
 
+// environmentCardActivityLabel decides whether the hover card repeats the
+// row's busy reason or defers to the condition indicator. busyFromEnvironment
+// assumes the indicator will say so on its own — but environmentStatusDot
+// gives a sticky stopped/failed condition priority over busy, and that
+// condition can still be the last one recorded while a fresher observation
+// has already reported real work (the two are set by separate pollers on
+// separate cycles). Blanking the label in that window let the card assert a
+// bare "Stopped" — telling the operator to start something already busy —
+// while the row kept spinning with the true reason right beside it. Blank
+// only when the indicator will actually read 'busy', so the two surfaces can
+// never name different things for the same spinner.
+export function environmentCardActivityLabel(
+  busy: boolean,
+  busyFromEnvironment: boolean,
+  busyLabel: string,
+  dot: StatusDotState,
+): string {
+  if (!busy) {
+    return '';
+  }
+  if (busyFromEnvironment && dot === 'busy') {
+    return '';
+  }
+  return busyLabel;
+}
+
 // The operations this desktop is running itself, in the order that decides
 // which one names the row. Split out from the label so a caller can ask whether
 // there is one at all without re-deriving the precedence.

--- a/erun-ui/playwright/tests/sidebar-env-hover.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-env-hover.spec.ts
@@ -95,7 +95,97 @@ test.describe('sidebar env hover card', () => {
     // closeEnvironment already asserts the row went quiet and stayed quiet.
     await app.sidebar.closeEnvironment(tenant, environment);
   });
+
+  // The activity poller (env-activity) and the sticky-condition setter
+  // (env-status) run on separate cycles, so a fresh "the environment is busy"
+  // observation can land while env-status still says stopped from before —
+  // the row's spinner is honest about it, but the card fell back to a bare
+  // "Stopped — start it from the titlebar" because the indicator's dot gives
+  // the sticky stopped condition priority over busy. The row and the card must
+  // never say different things about the same spinner.
+  test('a fresh busy observation never lets the card say a bare Stopped', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    const { tenant, environment } = seededEnv;
+
+    await app.sidebar.openEnvironment(tenant, environment);
+    const dot = app.sidebar.envOpenDot(tenant, environment);
+    await expect(dot).toBeVisible();
+
+    const card = app.sidebar.envHoverCard(tenant, environment);
+    const activity = card.locator('dd').nth(2);
+    const activitySettlesTo = async (matcher: RegExp | string): Promise<void> => {
+      await expect(async () => {
+        await page.mouse.move(0, 0);
+        await app.sidebar.hoverEnvironmentRow(tenant, environment);
+        await expect(card).toBeVisible({ timeout: 1_000 });
+        await expect(activity).toContainText(matcher, { timeout: 1_000 });
+      }).toPass();
+    };
+
+    await activitySettlesTo('Idle');
+    await emitEnvStatusEvent(page, tenant, environment, 'stopped');
+    await activitySettlesTo('Stopped');
+
+    // The backend's own sweep runs on a timer against this inert (never
+    // deployed) env and will legitimately overwrite the injected busy
+    // observation with "unreachable" — re-drive it until the assertion holds,
+    // bounded by a real timeout rather than a guessed delay.
+    await expect(async () => {
+      await emitEnvActivityEvent(page, {
+        tenant,
+        environment,
+        reachable: true,
+        observed: true,
+        busy: true,
+        detail: 'holding: gradle-build',
+      });
+      await page.mouse.move(0, 0);
+      await app.sidebar.hoverEnvironmentRow(tenant, environment);
+      await expect(card).toBeVisible({ timeout: 1_000 });
+      await expect(activity).toContainText('holding: gradle-build', { timeout: 1_000 });
+      await expect(activity).not.toContainText('Stopped');
+    }).toPass({ timeout: 20_000 });
+
+    // Reset the injected state so it doesn't leak into later specs (shared backend).
+    await emitEnvActivityEvent(page, {
+      tenant,
+      environment,
+      reachable: false,
+      observed: false,
+      busy: false,
+    });
+    await emitEnvStatusEvent(page, tenant, environment, '');
+    await app.sidebar.closeEnvironment(tenant, environment);
+  });
 });
+
+interface EnvActivityEvent {
+  tenant: string;
+  environment: string;
+  reachable: boolean;
+  observed: boolean;
+  outage?: boolean;
+  busy: boolean;
+  detail?: string;
+}
+
+// Mirrors the env-activity event erun-ui/environment_activity.go emits per tick.
+async function emitEnvActivityEvent(
+  page: import('@playwright/test').Page,
+  event: EnvActivityEvent,
+): Promise<void> {
+  await page.evaluate((payload) => {
+    const runtime = (
+      window as unknown as {
+        runtime: { EventsEmit: (name: string, ...args: unknown[]) => void };
+      }
+    ).runtime;
+    runtime.EventsEmit('env-activity', payload);
+  }, event);
+}
 
 // Injecting env-status is a faithful stand-in: the Go side emits the same event
 // from tryReconnect's refusal paths and the open/respawn clears.


### PR DESCRIPTION
An environment row spins while its own hover card says `Stopped — start it from
the titlebar`, telling the operator to start something that is already busy.

## The hypothesis in the issue was wrong, and the evidence says why

The issue supposed a stale `isOpening`/`reconnecting` outranking an observed
`stopped`. Driving `deriveEnvironmentRow` / `environmentIndicator` / the card's
fallback directly, across three scenarios:

| scenario | row spinner label | card activity line | agree? |
|---|---|---|---|
| stale `isOpening`, `envState='stopped'` | `Opening team / dev` | `Opening team / dev` | agree |
| stale `aiBusy`, never observed, `envState='stopped'` | `AI tab working on team / dev` | `AI tab working on team / dev` | agree |
| `envBusy`, `envState='stopped'` | `team / dev is busy — holding: gradle-build` | `Stopped — start it from the titlebar` | **contradiction** |

`isOpening`/`reconnecting` always self-name through
`environmentRowCommandLabel`, which feeds **both** the row's label and the
card's — so those two can never disagree, stale or not.

They are also never left stale on failure: `openSelection`'s `finally` clears
`openingByEnv` even when `StartSession` throws
(`sessionThunks.ts:338-340`), and `confirmReconnect`'s `catch` moves
`reconnect.status` to `'error'` rather than leaving `'running'`
(`reviewThunks.ts:315-329`). That asymmetry is deliberate and correct, so this
PR **pins it with a test** instead of changing it.

## The actual defect

`busyFromEnvironment` blanks the card's line whenever `envBusy` alone is driving
`busy`, on the assumption that the indicator dot will say "busy" by itself. But
`environmentStatusDot` gives a sticky `stopped`/`failed` condition **priority**
over busy, and that sticky condition can still be the last one recorded while a
fresher `env-activity` observation has already reported real work — the two are
set by separate pollers on separate cycles.

In that window the card asserts a bare `Stopped` while the row spins with the
true reason beside it. A real race, not a hypothetical, and it reproduces the
issue's screenshot verbatim.

## Fix

`environmentCardActivityLabel(busy, busyFromEnvironment, busyLabel, dot)` blanks
the card's line only when the indicator will **actually** read `'busy'` — never
when a sticky `stopped`/`failed` condition would otherwise swallow a live busy
reason. The two surfaces can no longer name different things for one spinner.

Verified visually: the card now reads `pw / <env> is busy — holding:
gradle-build` where it previously read `Stopped — start it from the titlebar`,
with the row still spinning.

## Gates

- frontend `yarn typecheck` / `yarn lint` / `yarn format:check` → clean (only
  pre-existing line-count warnings in untouched files)
- frontend `yarn test` → **244/244**, including 3 new derivation tests; one was
  confirmed failing against the old blanking logic before the fix was restored
- `erun-ui` `go test ./...` / `go build ./...` → clean (no Go touched)
- `erun-ui/build.sh` (golangci-lint) → **0 issues**
- full Playwright → **364/364** (21.4 min), including the new
  `sidebar-env-hover.spec.ts › a fresh busy observation never lets the card say
  a bare Stopped`

Closes #1429