### PR TITLE
Make the lint gate green on main so a release can build the runtime image

### DIFF
--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -39,6 +39,45 @@ func refuseOpenForHostEnvironment(result common.OpenResult) error {
 	return fmt.Errorf("open %s/%s: %s is a host environment — it has no pod and no cluster to open a shell into; its worktree is already %s, so open that directory directly", result.Tenant, result.Environment, result.Environment, result.RepoPath)
 }
 
+// resolveOpenTarget runs the resolution chain that must complete before a
+// runtime can be opened: flag validation, parameter resolution, the init
+// hand-off, the host-environment refusal, and persisting the local port range.
+// done reports that init already handled the request, so the caller returns
+// without opening anything.
+func resolveOpenTarget(
+	ctx common.Context,
+	args []string,
+	target common.OpenParams,
+	vscode bool,
+	intellij bool,
+	resolveOpen func(common.OpenParams) (common.OpenResult, error),
+	runInitForOpen func(common.Context, common.OpenParams) error,
+	saveEnvConfig func(string, common.EnvConfig) error,
+) (common.OpenResult, bool, error) {
+	if vscode && intellij {
+		return common.OpenResult{}, false, fmt.Errorf("--vscode and --intellij cannot be used together")
+	}
+	params, err := resolveOpenParams(args, target)
+	if err != nil {
+		return common.OpenResult{}, false, err
+	}
+	result, initRan, err := resolveOpenWithInitStopForParams(ctx, params, shouldRunInitForOpenCommand, resolveOpen, runInitForOpen)
+	if err != nil {
+		return common.OpenResult{}, false, err
+	}
+	if initRan {
+		return common.OpenResult{}, true, nil
+	}
+	if err := refuseOpenForHostEnvironment(result); err != nil {
+		return common.OpenResult{}, false, err
+	}
+	result, err = common.EnsureLocalPortRangePersisted(ctx, saveEnvConfig, result)
+	if err != nil {
+		return common.OpenResult{}, false, err
+	}
+	return result, false, nil
+}
+
 func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen func(common.OpenParams) (common.OpenResult, error), saveEnvConfig func(string, common.EnvConfig) error, runInitForOpen func(common.Context, common.OpenParams) error, promptRunner PromptRunner, openShell OpenShellRunner, runManagedDeploy func(common.Context, common.OpenResult) error, checkKubernetesDeployment common.KubernetesDeploymentCheckerFunc, resolveRuntimeDeploySpec func(common.Context, common.OpenResult, bool) (common.DeploySpec, error), deployHelmChart common.HelmChartDeployerFunc, activateMCP MCPForwarder, activateAPI APIForwarder, activateSSHD SSHDActivator, launchVSCode VSCodeLauncher, launchIntelliJ IntelliJLauncher) *cobra.Command {
 	var noShell bool
 	var vscode bool
@@ -75,26 +114,12 @@ func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen 
 			if prepareContext != nil {
 				ctx = prepareContext(ctx)
 			}
-			if vscode && intellij {
-				return fmt.Errorf("--vscode and --intellij cannot be used together")
-			}
-			params, err := resolveOpenParams(args, target)
+			result, done, err := resolveOpenTarget(ctx, args, target, vscode, intellij, resolveOpen, runInitForOpen, saveEnvConfig)
 			if err != nil {
 				return err
 			}
-			result, initRan, err := resolveOpenWithInitStopForParams(ctx, params, shouldRunInitForOpenCommand, resolveOpen, runInitForOpen)
-			if err != nil {
-				return err
-			}
-			if initRan {
+			if done {
 				return nil
-			}
-			if err := refuseOpenForHostEnvironment(result); err != nil {
-				return err
-			}
-			result, err = common.EnsureLocalPortRangePersisted(ctx, saveEnvConfig, result)
-			if err != nil {
-				return err
 			}
 			allowLocalBuilds := result.EnvConfig.BuildsHere()
 			return runResolvedOpenCommandWithAPI(ctx, result, openOptions{

--- a/erun-cli/cmd/resize.go
+++ b/erun-cli/cmd/resize.go
@@ -84,12 +84,14 @@ func writeResizeResult(ctx common.Context, result common.RuntimeResizeResult) er
 		return nil
 	}
 	if result.Plan.NoOp {
-		fmt.Fprintf(ctx.Stdout, "%s/%s is already sized at cpu=%s memory=%s; no change\n", result.Plan.Tenant, result.Plan.Environment, result.Plan.Current.CPU, result.Plan.Current.Memory)
-		return nil
+		_, err := fmt.Fprintf(ctx.Stdout, "%s/%s is already sized at cpu=%s memory=%s; no change\n", result.Plan.Tenant, result.Plan.Environment, result.Plan.Current.CPU, result.Plan.Current.Memory)
+		return err
 	}
 	for _, action := range result.Plan.Actions {
-		fmt.Fprintf(ctx.Stdout, "%s: %s -> %s\n", action.Resource, action.From, action.To)
+		if _, err := fmt.Fprintf(ctx.Stdout, "%s: %s -> %s\n", action.Resource, action.From, action.To); err != nil {
+			return err
+		}
 	}
-	fmt.Fprintf(ctx.Stdout, "==> Resized %s/%s\n", result.Plan.Tenant, result.Plan.Environment)
-	return nil
+	_, err := fmt.Fprintf(ctx.Stdout, "==> Resized %s/%s\n", result.Plan.Tenant, result.Plan.Environment)
+	return err
 }

--- a/erun-common/runtime_resize.go
+++ b/erun-common/runtime_resize.go
@@ -61,41 +61,75 @@ type RuntimeResizePlan struct {
 // the runtime container gets anything — the same accounting
 // boundRuntimeMemorySuggestion already applies to a recommendation's own
 // suggested value).
-func ResolveRuntimeResizePlan(tenant, environment string, current RuntimePodResources, ceiling NamespaceResourceQuota, input RuntimeResizeInput, recommendation *RuntimeSizingRecommendation) (RuntimeResizePlan, error) {
-	current = NormalizeRuntimePodResources(current)
-	explicitCPU := strings.TrimSpace(input.CPU)
-	explicitMemory := strings.TrimSpace(input.Memory)
-
+// validateRuntimeResizeInput rejects the two input shapes a resize can never
+// act on: naming the standing recommendation and explicit values at once, and
+// naming neither.
+func validateRuntimeResizeInput(input RuntimeResizeInput, explicitCPU, explicitMemory string) error {
 	if input.ApplyRecommendation && (explicitCPU != "" || explicitMemory != "") {
-		return RuntimeResizePlan{}, fmt.Errorf("resize: pass either apply-recommendation or explicit cpu/memory values, not both")
+		return fmt.Errorf("resize: pass either apply-recommendation or explicit cpu/memory values, not both")
 	}
 	if !input.ApplyRecommendation && explicitCPU == "" && explicitMemory == "" {
-		return RuntimeResizePlan{}, fmt.Errorf("resize: pass cpu and/or memory, or apply-recommendation to size from the environment's standing recommendation")
+		return fmt.Errorf("resize: pass cpu and/or memory, or apply-recommendation to size from the environment's standing recommendation")
 	}
+	return nil
+}
 
+// resolveRuntimeResizeTarget applies either the standing recommendation or the
+// explicit values on top of the current sizing, leaving whatever the input does
+// not name unchanged.
+func resolveRuntimeResizeTarget(tenant, environment string, current RuntimePodResources, input RuntimeResizeInput, recommendation *RuntimeSizingRecommendation, explicitCPU, explicitMemory string) (RuntimePodResources, error) {
 	target := current
-	if input.ApplyRecommendation {
-		if recommendation == nil {
-			return RuntimeResizePlan{}, fmt.Errorf("resize: no standing recommendation is available for %s/%s yet — it needs retained usage history, which is only readable from inside the environment's own runtime pod (its resize tool over MCP), not from the host; run `erun usage` a few times first, or resize with explicit --cpu/--memory instead", tenant, environment)
-		}
-		for _, verdict := range recommendation.Verdicts {
-			if verdict.Action != RuntimeSizingRaise && verdict.Action != RuntimeSizingLower {
-				continue
-			}
-			switch verdict.Resource {
-			case "cpu":
-				target.CPU = verdict.Suggested
-			case "memory":
-				target.Memory = verdict.Suggested
-			}
-		}
-	} else {
+	if !input.ApplyRecommendation {
 		if explicitCPU != "" {
 			target.CPU = explicitCPU
 		}
 		if explicitMemory != "" {
 			target.Memory = explicitMemory
 		}
+		return target, nil
+	}
+	if recommendation == nil {
+		return RuntimePodResources{}, fmt.Errorf("resize: no standing recommendation is available for %s/%s yet — it needs retained usage history, which is only readable from inside the environment's own runtime pod (its resize tool over MCP), not from the host; run `erun usage` a few times first, or resize with explicit --cpu/--memory instead", tenant, environment)
+	}
+	for _, verdict := range recommendation.Verdicts {
+		if verdict.Action != RuntimeSizingRaise && verdict.Action != RuntimeSizingLower {
+			continue
+		}
+		switch verdict.Resource {
+		case "cpu":
+			target.CPU = verdict.Suggested
+		case "memory":
+			target.Memory = verdict.Suggested
+		}
+	}
+	return target, nil
+}
+
+// runtimeResizeActions lists only the resources whose limit actually moves, so
+// an unchanged one never reads as a change.
+func runtimeResizeActions(current, target RuntimePodResources) []RuntimeResizeAction {
+	var actions []RuntimeResizeAction
+	if target.CPU != current.CPU {
+		actions = append(actions, RuntimeResizeAction{Resource: "cpu", From: current.CPU, To: target.CPU})
+	}
+	if target.Memory != current.Memory {
+		actions = append(actions, RuntimeResizeAction{Resource: "memory", From: current.Memory, To: target.Memory})
+	}
+	return actions
+}
+
+func ResolveRuntimeResizePlan(tenant, environment string, current RuntimePodResources, ceiling NamespaceResourceQuota, input RuntimeResizeInput, recommendation *RuntimeSizingRecommendation) (RuntimeResizePlan, error) {
+	current = NormalizeRuntimePodResources(current)
+	explicitCPU := strings.TrimSpace(input.CPU)
+	explicitMemory := strings.TrimSpace(input.Memory)
+
+	if err := validateRuntimeResizeInput(input, explicitCPU, explicitMemory); err != nil {
+		return RuntimeResizePlan{}, err
+	}
+
+	target, err := resolveRuntimeResizeTarget(tenant, environment, current, input, recommendation, explicitCPU, explicitMemory)
+	if err != nil {
+		return RuntimeResizePlan{}, err
 	}
 	target = NormalizeRuntimePodResources(target)
 	if err := ValidateRuntimePodResources(target); err != nil {
@@ -105,13 +139,7 @@ func ResolveRuntimeResizePlan(tenant, environment string, current RuntimePodReso
 		return RuntimeResizePlan{}, err
 	}
 
-	var actions []RuntimeResizeAction
-	if target.CPU != current.CPU {
-		actions = append(actions, RuntimeResizeAction{Resource: "cpu", From: current.CPU, To: target.CPU})
-	}
-	if target.Memory != current.Memory {
-		actions = append(actions, RuntimeResizeAction{Resource: "memory", From: current.Memory, To: target.Memory})
-	}
+	actions := runtimeResizeActions(current, target)
 
 	return RuntimeResizePlan{
 		Tenant:      tenant,
@@ -223,6 +251,51 @@ type RuntimeResizeResult struct {
 // the same deploy composition `erun deploy` uses. Dry-run traces every
 // decision (current/target per resource, held leases, whether an override was
 // needed) and performs no write, per the repository's dry-run contract.
+// traceRuntimeResizePlanActions narrates each limit that moves, then states
+// plainly what a resize does and does not touch, so a ceiling change is never
+// mistaken for a scheduler reservation or for resizing the sidecar or a PVC.
+func traceRuntimeResizePlanActions(ctx Context, tenant, environment string, plan RuntimeResizePlan) {
+	for _, action := range plan.Actions {
+		ctx.Trace(fmt.Sprintf("resize: %s/%s %s %s -> %s", tenant, environment, action.Resource, action.From, action.To))
+	}
+	ctx.Trace(fmt.Sprintf("resize: %s/%s this moves the runtime container's throttle/OOM ceiling and its namespace quota draw; it does not change what the scheduler reserves (a fixed request independent of runtimepod) and it does not resize the erun-dind sidecar or any PVC", tenant, environment))
+}
+
+// traceRuntimeResizeOverriddenLeases names every holder the resize is about to
+// roll through, so an override is never silent.
+func traceRuntimeResizeOverriddenLeases(ctx Context, tenant, environment string, leases []EnvironmentActivityLease) {
+	if len(leases) == 0 {
+		return
+	}
+	holders := make([]string, 0, len(leases))
+	for _, lease := range leases {
+		holders = append(holders, fmt.Sprintf("%s (lease %q)", lease.Holder.String(), lease.Name))
+	}
+	ctx.Trace(fmt.Sprintf("resize: %s/%s overriding %d held lease(s): %s", tenant, environment, len(leases), strings.Join(holders, "; ")))
+}
+
+// applyRuntimeResize persists the new sizing and rolls the runtime pod onto it.
+func applyRuntimeResize(ctx Context, deps RuntimeResizeDependencies, tenant, environment string, target OpenResult, plan RuntimeResizePlan) error {
+	updatedConfig := target.EnvConfig
+	updatedConfig.RuntimePod = plan.Target
+	if err := deps.SaveEnvConfig(tenant, updatedConfig); err != nil {
+		return fmt.Errorf("resize: saving the new runtime pod size: %w", err)
+	}
+
+	specs, err := ResolveCurrentDeploySpecs(ctx, deps.Store, deps.FindProjectRoot, deps.ResolveDockerBuildContext, deps.ResolveKubernetesDeployContext, deps.Now, DeployTarget{
+		Tenant:      tenant,
+		Environment: environment,
+		RepoPath:    target.RepoPath,
+	})
+	if err != nil {
+		return err
+	}
+	if err := RunDeploySpecs(ctx, specs, deps.DeployHelmChart); err != nil {
+		return err
+	}
+	return PersistRuntimeVersionFromDeploySpecs(ctx, specs, deps.SaveEnvConfig, ResolveDeployedHelmReleaseVersion)
+}
+
 func RunRuntimeResize(ctx Context, deps RuntimeResizeDependencies, params RuntimeResizeParams) (RuntimeResizeResult, error) {
 	target, err := ResolveOpen(deps.Store, OpenParams{
 		Tenant:                strings.TrimSpace(params.Tenant),
@@ -244,10 +317,7 @@ func RunRuntimeResize(ctx Context, deps RuntimeResizeDependencies, params Runtim
 		ctx.Trace(fmt.Sprintf("resize: %s/%s is already sized at cpu=%s memory=%s; no change", tenant, environment, plan.Current.CPU, plan.Current.Memory))
 		return RuntimeResizeResult{Plan: plan}, nil
 	}
-	for _, action := range plan.Actions {
-		ctx.Trace(fmt.Sprintf("resize: %s/%s %s %s -> %s", tenant, environment, action.Resource, action.From, action.To))
-	}
-	ctx.Trace(fmt.Sprintf("resize: %s/%s this moves the runtime container's throttle/OOM ceiling and its namespace quota draw; it does not change what the scheduler reserves (a fixed request independent of runtimepod) and it does not resize the erun-dind sidecar or any PVC", tenant, environment))
+	traceRuntimeResizePlanActions(ctx, tenant, environment, plan)
 
 	now := time.Now()
 	if deps.Now != nil {
@@ -257,13 +327,7 @@ func RunRuntimeResize(ctx Context, deps RuntimeResizeDependencies, params Runtim
 	if err != nil {
 		return RuntimeResizeResult{}, err
 	}
-	if len(leases) > 0 {
-		holders := make([]string, 0, len(leases))
-		for _, lease := range leases {
-			holders = append(holders, fmt.Sprintf("%s (lease %q)", lease.Holder.String(), lease.Name))
-		}
-		ctx.Trace(fmt.Sprintf("resize: %s/%s overriding %d held lease(s): %s", tenant, environment, len(leases), strings.Join(holders, "; ")))
-	}
+	traceRuntimeResizeOverriddenLeases(ctx, tenant, environment, leases)
 
 	ctx.TraceCommand("", "resize", tenant, environment, "cpu="+plan.Target.CPU, "memory="+plan.Target.Memory)
 	ctx.Trace(fmt.Sprintf("resize: %s/%s will roll the runtime pod once to apply the new limits", tenant, environment))
@@ -281,24 +345,7 @@ func RunRuntimeResize(ctx Context, deps RuntimeResizeDependencies, params Runtim
 		_ = ReleaseExclusiveEnvironmentActivityLease(tenant, environment, lease.Scope, lease.ID)
 	}()
 
-	updatedConfig := target.EnvConfig
-	updatedConfig.RuntimePod = plan.Target
-	if err := deps.SaveEnvConfig(tenant, updatedConfig); err != nil {
-		return RuntimeResizeResult{}, fmt.Errorf("resize: saving the new runtime pod size: %w", err)
-	}
-
-	specs, err := ResolveCurrentDeploySpecs(ctx, deps.Store, deps.FindProjectRoot, deps.ResolveDockerBuildContext, deps.ResolveKubernetesDeployContext, deps.Now, DeployTarget{
-		Tenant:      tenant,
-		Environment: environment,
-		RepoPath:    target.RepoPath,
-	})
-	if err != nil {
-		return RuntimeResizeResult{}, err
-	}
-	if err := RunDeploySpecs(ctx, specs, deps.DeployHelmChart); err != nil {
-		return RuntimeResizeResult{}, err
-	}
-	if err := PersistRuntimeVersionFromDeploySpecs(ctx, specs, deps.SaveEnvConfig, ResolveDeployedHelmReleaseVersion); err != nil {
+	if err := applyRuntimeResize(ctx, deps, tenant, environment, target, plan); err != nil {
 		return RuntimeResizeResult{}, err
 	}
 

--- a/erun-common/terraform.go
+++ b/erun-common/terraform.go
@@ -291,6 +291,33 @@ func executeTerraformSteps(ctx Context, result TerraformResult, steps []terrafor
 	return nil
 }
 
+// resolveTerraformTargetEnvironment resolves the tenant and environment the run
+// targets and confirms the environment can host one at all. Confirming the env
+// is configured before its root is derived turns a typo into a named error
+// rather than an opaque "no such directory".
+func resolveTerraformTargetEnvironment(params TerraformParams, store TerraformStore) (string, string, error) {
+	tenant, environment, err := resolveTerraformScope(store, params)
+	if err != nil {
+		return "", "", err
+	}
+	if err := ValidateTenantName(tenant); err != nil {
+		return "", "", err
+	}
+	envConfig, _, err := store.LoadEnvConfig(tenant, environment)
+	if err != nil {
+		return "", "", err
+	}
+	// terraform apply/plan/destroy read back cluster state (e.g. an RFC2136
+	// TSIG secret) and apply/destroy target the runtime pod's own cluster; a
+	// host env has neither. Checked against ResolvedType, not the broader
+	// !HasPod(), so a legacy env with an unresolved type keeps working exactly
+	// as it did before host existed.
+	if envConfig.ResolvedType() == EnvironmentTypeHost {
+		return "", "", fmt.Errorf("terraform %s/%s: %s is a host environment — it has no pod and no cluster to run terraform against", tenant, environment, environment)
+	}
+	return tenant, environment, nil
+}
+
 func resolveTerraformPlan(params TerraformParams, store TerraformStore) (TerraformResult, []terraformStep, error) {
 	op := params.Operation
 	if err := validateTerraformOperation(op); err != nil {
@@ -301,26 +328,9 @@ func resolveTerraformPlan(params TerraformParams, store TerraformStore) (Terrafo
 		return TerraformResult{}, nil, fmt.Errorf("project root is required")
 	}
 
-	tenant, environment, err := resolveTerraformScope(store, params)
+	tenant, environment, err := resolveTerraformTargetEnvironment(params, store)
 	if err != nil {
 		return TerraformResult{}, nil, err
-	}
-	if err := ValidateTenantName(tenant); err != nil {
-		return TerraformResult{}, nil, err
-	}
-	// Confirm the env is configured before deriving its root, so a typo fails
-	// here rather than with an opaque "no such directory".
-	envConfig, _, err := store.LoadEnvConfig(tenant, environment)
-	if err != nil {
-		return TerraformResult{}, nil, err
-	}
-	// terraform apply/plan/destroy read back cluster state (e.g. an RFC2136
-	// TSIG secret) and apply/destroy target the runtime pod's own cluster; a
-	// host env has neither. Checked against ResolvedType, not the broader
-	// !HasPod(), so a legacy env with an unresolved type keeps working exactly
-	// as it did before host existed.
-	if envConfig.ResolvedType() == EnvironmentTypeHost {
-		return TerraformResult{}, nil, fmt.Errorf("terraform %s/%s: %s is a host environment — it has no pod and no cluster to run terraform against", tenant, environment, environment)
 	}
 
 	paths, err := loadProjectPaths(projectRoot)


### PR DESCRIPTION
`make lint` is red on `main`, and the `erun-devops` image build runs `make check`, so `erun release` fails at the publish stage and no version can be cut. This brings all six modules to `0 issues`.

Closes #1449

## erun-cli

- `writeResizeResult` dropped the return of three `fmt.Fprintf` calls (errcheck). It already returns `error`, and `doctor_env_config.go` / `doctor_root_config.go` already propagate their writes to `ctx.Stdout`, so these now do the same rather than being silenced with `_, _ =`.
- `newOpenCmd` carried its whole resolution chain inline in the `RunE` closure (cyclop 11). Flag validation, parameter resolution, the init hand-off, the host-environment refusal, and persisting the local port range move into `resolveOpenTarget`, which returns a `done` flag for the case where init already handled the request.

## erun-common

- `ResolveRuntimeResizePlan` was cyclop 20 and gocyclo 20 — the one function tripping two linters on the same line that #1313's `uniq-by-line: false` exists to surface. Split into `validateRuntimeResizeInput`, `resolveRuntimeResizeTarget`, and `runtimeResizeActions`.
- `RunRuntimeResize` was cyclop 15. Its plan narration, its overridden-lease narration, and its persist-and-roll step move into `traceRuntimeResizePlanActions`, `traceRuntimeResizeOverriddenLeases`, and `applyRuntimeResize`.
- `resolveTerraformPlan` was cyclop 11. Resolving and validating the target environment moves into `resolveTerraformTargetEnvironment`.

No `//nolint` suppressions: #1313 hardened this gate specifically so findings stop being hidden, so the complexity is reduced rather than silenced.

## Behaviour

Behaviour-preserving per AGENTS.md § Refactoring Rules. Every error string, trace string, and stdout string is carried over verbatim, and the only semantic change is the intended one — `writeResizeResult` now reports a stdout write failure instead of returning `nil` over it.

## Validation

- `make lint` — exits 0, `0 issues.` for all six modules (golangci-lint v2.2.2, matching `GOLANGCI_LINT_VERSION`)
- `go test ./...` in `erun-common` — ok, 16.2s
- `go test ./...` in `erun-cli` — ok
- `go test ./...` in `erun-mcp` — ok, both packages