### PR TITLE
Stop the live-session toolset test depending on an installed erun

### DIFF
--- a/Formula/erun.rb
+++ b/Formula/erun.rb
@@ -1,7 +1,7 @@
 class Erun < Formula
   desc "Multi-tenant multi-environment deployment and management tool"
   homepage "https://github.com/sophium/erun"
-  url "https://github.com/sophium/erun/archive/refs/tags/v1.0.202.tar.gz"
+  url "https://github.com/sophium/erun/archive/refs/tags/v1.0.203.tar.gz"
   sha256 "b247f87a77800cde00cf163f24f0c5caa3d72f6744fbe3c1befe10256d7a42ba"
   license "MIT"
 

--- a/bucket/erun.json
+++ b/bucket/erun.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.202",
+  "version": "1.0.203",
   "description": "Multi-tenant multi-environment deployment and management tool",
   "homepage": "https://github.com/sophium/erun",
   "license": "MIT",
@@ -9,9 +9,9 @@
     "nodejs",
     "yarn"
   ],
-  "url": "https://github.com/sophium/erun/archive/refs/tags/v1.0.202.zip",
+  "url": "https://github.com/sophium/erun/archive/refs/tags/v1.0.203.zip",
   "hash": "83d949c94e91bffeb3224b377a1effa9a0923d5d0620fb39705fd62ea0298265",
-  "extract_dir": "erun-1.0.202",
+  "extract_dir": "erun-1.0.203",
   "installer": {
     "script": [
       "$env:CGO_ENABLED = '0'",

--- a/erun-devops/k8s/erun-backend-api/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-api/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.202
+appVersion: 1.0.203
 description: ERun backend API
 name: erun-backend-api
 type: application
-version: 1.0.202
+version: 1.0.203

--- a/erun-devops/k8s/erun-backend-db/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-db/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.202
+appVersion: 1.0.203
 description: ERun backend database migration job
 name: erun-backend-db
 type: application
-version: 1.0.202
+version: 1.0.203

--- a/erun-devops/k8s/erun-backend-postgres/Chart.yaml
+++ b/erun-devops/k8s/erun-backend-postgres/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.202
+appVersion: 1.0.203
 description: ERun backend PostgreSQL
 name: erun-backend-postgres
 type: application
-version: 1.0.202
+version: 1.0.203

--- a/erun-devops/k8s/erun-console/Chart.yaml
+++ b/erun-devops/k8s/erun-console/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.202
+appVersion: 1.0.203
 description: ERun hosted web console
 name: erun-console
 type: application
-version: 1.0.202
+version: 1.0.203

--- a/erun-devops/k8s/erun-devops/Chart.yaml
+++ b/erun-devops/k8s/erun-devops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.202
+appVersion: 1.0.203
 description: ERun DevOps
 name: erun-devops
 type: application
-version: 1.0.202
+version: 1.0.203

--- a/erun-devops/k8s/erun-docs/Chart.yaml
+++ b/erun-devops/k8s/erun-docs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.202
+appVersion: 1.0.203
 description: Publish the ERun documentation site to Cloudflare Pages
 name: erun-docs
 type: application
-version: 1.0.202
+version: 1.0.203

--- a/erun-devops/k8s/erun-oci-registry/Chart.yaml
+++ b/erun-devops/k8s/erun-oci-registry/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.202
+appVersion: 1.0.203
 description: ERun hosted OCI container registry (zot), authenticated by tenant API token
 name: erun-oci-registry
 type: application
-version: 1.0.202
+version: 1.0.203

--- a/erun-devops/k8s/erun-powerdns/Chart.yaml
+++ b/erun-devops/k8s/erun-powerdns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.202
+appVersion: 1.0.203
 description: ERun platform PowerDNS authoritative nameserver
 name: erun-powerdns
 type: application
-version: 1.0.202
+version: 1.0.203

--- a/erun-devops/k8s/erun-zitadel/Chart.yaml
+++ b/erun-devops/k8s/erun-zitadel/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.202
+appVersion: 1.0.203
 description: ERun platform hosted IdP (Zitadel)
 name: erun-zitadel
 type: application
-version: 1.0.202
+version: 1.0.203

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/chart-dns01-webhook/Chart.yaml
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/chart-dns01-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.202
+appVersion: 1.0.203
 description: cert-manager ACME DNS-01 webhook (per-cluster singleton) that forwards present/cleanup to the erun DNS-01 broker, carrying each challenge's env-scoped token. The broker authorizes the write against the token's tenant subzone, so per-tenant cert issuance is safe on a shared cluster.
 name: erun-dns01-webhook
 type: application
-version: 1.0.202
+version: 1.0.203

--- a/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/chart-issuer/Chart.yaml
+++ b/erun-devops/terraform-erun/modules/terraform-erun-cluster-edge/chart-issuer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.0.202
+appVersion: 1.0.203
 description: namespaced cert-manager Issuer (Cloudflare or PowerDNS RFC2136 DNS-01) + optional wildcard Certificate for the erun services edge. Applied by the terraform-erun-cluster-edge module after cert-manager's CRDs exist.
 name: erun-cluster-edge-issuer
 type: application
-version: 1.0.202
+version: 1.0.203

--- a/erun-ui/orchestrator_test.go
+++ b/erun-ui/orchestrator_test.go
@@ -491,6 +491,14 @@ func requireLoneOrchestratorRestartRequired(t *testing.T, app *App, want bool, l
 // RestartRequired, and ListOrchestrators keeps reporting it on every poll
 // until a restart actually re-wires the session (GREEN).
 func TestUpdateOrchestratorOnALiveSessionLeavesItsToolsetStale(t *testing.T) {
+	// Pin the executable seam, for the same reason
+	// TestWriteOrchestratorMCPConfigCarriesSkipsEvenWhenNothingWired does:
+	// StartOrchestrator resolves the erun executable before it writes the
+	// per-orchestrator MCP config, so on a host without one it writes no config
+	// at all and the on-disk assertions below read a file that was never
+	// created. The build's own test stage has no erun on PATH.
+	t.Setenv("ERUN_ERUN_BIN", filepath.Join(t.TempDir(), "erun"))
+
 	app, laptopRepo := orchestratorTestAppWithLocalRepo(t)
 	defer app.shutdown(context.Background())
 


### PR DESCRIPTION
`make check` in the `erun-devops` image build fails on `test-erun-ui`, so `erun release` cannot publish the runtime image. One test is responsible.

Closes #1452

## Cause

`StartOrchestrator` → `writeOrchestratorMCPConfig` calls `ResolveErunExecutable()` before it writes anything. With no erun resolvable it returns `errOrchestratorMCPExecutable` and writes no config, so the test's three `requireOnlyOrchestratorMCPKey` assertions read a file that was never created.

That makes the test pass wherever a developer runs it and fail in the release's image build stage, which has no erun on PATH.

## Fix

Pin the `ERUN_ERUN_BIN` seam `ResolveErunExecutable` already exposes, exactly as `orchestrator_mcp_test.go` does in three places — its comment at :536 names this same trap and the same build stage as where it last surfaced. Test-only change; no production code touched.

## Validation

Red-then-green under the build stage's own condition, in the runtime pod:

```
cd erun-ui && env PATH=/usr/local/go/bin:/usr/sbin:/usr/bin:/sbin:/bin go test ./...
```

- before — `--- FAIL: TestUpdateOrchestratorOnALiveSessionLeavesItsToolsetStale`, the only failure in the package
- after — `ok github.com/sophium/erun/erun-ui 7.607s`, exit 0

Still green with erun on PATH, and `make lint` remains `0 issues.` across all six modules.

## Follow-up left out deliberately

This is the second time this trap has been hit. Pinning the seam in the shared `orchestratorTestAppWithReachability` helper — which already pins `HOME`, `USERPROFILE`, and `ERUN_SKILLS_DIR` for the same "never trip over ambient state" reason — would close the class. It is not done here because `TestWriteOrchestratorMCPConfigFromBundledDesktop` deliberately runs with no `ERUN_ERUN_BIN` so the sibling binary is the only thing that can resolve, and that interaction deserves its own change rather than riding along on a release unblock. Noted on #1452.