### PR TITLE
Give the open tenant resolution failure its operation, subject and recovery

### DIFF
--- a/erun-common/open.go
+++ b/erun-common/open.go
@@ -27,6 +27,15 @@ var (
 	ErrShellReattachDeploy             = errors.New("remote shell requested deploy handoff and reattach")
 	ErrShellPodReplaced                = errors.New("remote shell pod was replaced; reattach")
 	ErrShellSessionTakenOver           = errors.New("remote session was re-attached in another ERun window")
+	// ErrOpenTenantNotProvided is open's tenant-resolution failure for a call
+	// path that is not allowed to infer one (UseDefaultTenant is false) —
+	// distinct from ErrDefaultTenantNotConfigured, where inference was
+	// permitted but resolved to nothing, because the two have different
+	// recoveries (root AGENTS.md "Distinguish causes before writing copy").
+	ErrOpenTenantNotProvided = errors.New("no tenant given for open")
+	// ErrOpenEnvironmentNotProvided mirrors ErrOpenTenantNotProvided for the
+	// environment half of open's target resolution.
+	ErrOpenEnvironmentNotProvided = errors.New("no environment given for open")
 
 	openUserHomeDir = os.UserHomeDir
 )
@@ -349,10 +358,17 @@ func resolveOpenTenant(store OpenStore, findProjectRoot ProjectFinderFunc, param
 		}
 	}
 	if tenant == "" && params.UseDefaultTenant {
-		return loadOpenDefaultTenant(store)
+		resolved, err := loadOpenDefaultTenant(store)
+		if err != nil {
+			if errors.Is(err, ErrDefaultTenantNotConfigured) {
+				return "", fmt.Errorf("%w, and open could not infer one from the working directory either — pass a tenant explicitly, or run `erun init --tenant <name> --set-default-tenant` to set a default", err)
+			}
+			return "", err
+		}
+		return resolved, nil
 	}
 	if tenant == "" {
-		return "", fmt.Errorf("tenant is required")
+		return "", fmt.Errorf("%w: this call path does not fall back to the working directory or a configured default tenant — pass a tenant explicitly", ErrOpenTenantNotProvided)
 	}
 	return tenant, nil
 }
@@ -376,11 +392,11 @@ func resolveOpenEnvironment(params OpenParams, tenantConfig TenantConfig) (strin
 	if environment == "" && params.UseDefaultEnvironment {
 		environment = tenantConfig.DefaultEnvironment
 		if environment == "" {
-			return "", ErrDefaultEnvironmentNotConfigured
+			return "", fmt.Errorf("%w for %s, and open has no environment to fall back to — pass an environment explicitly, or run `erun init --tenant %s --environment <name>` to set one", ErrDefaultEnvironmentNotConfigured, tenantConfig.Name, tenantConfig.Name)
 		}
 	}
 	if environment == "" {
-		return "", fmt.Errorf("environment is required")
+		return "", fmt.Errorf("%w: this call path does not fall back to %s's default environment — pass an environment explicitly", ErrOpenEnvironmentNotProvided, tenantConfig.Name)
 	}
 	return environment, nil
 }

--- a/erun-common/open_tenant_resolution_test.go
+++ b/erun-common/open_tenant_resolution_test.go
@@ -1,0 +1,136 @@
+package eruncommon
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// openTenantResolutionStore is a minimal OpenStore for exercising
+// resolveOpenTenant/resolveOpenEnvironment without a real config root.
+type openTenantResolutionStore struct {
+	defaultTenant      string
+	defaultEnvironment string
+}
+
+func (s openTenantResolutionStore) LoadERunConfig() (ERunConfig, string, error) {
+	if s.defaultTenant == "" {
+		return ERunConfig{}, "", ErrNotInitialized
+	}
+	return ERunConfig{DefaultTenant: s.defaultTenant}, "", nil
+}
+
+func (s openTenantResolutionStore) LoadTenantConfig(name string) (TenantConfig, string, error) {
+	return TenantConfig{Name: name, DefaultEnvironment: s.defaultEnvironment}, "", nil
+}
+
+func (s openTenantResolutionStore) LoadEnvConfig(tenant, environment string) (EnvConfig, string, error) {
+	return EnvConfig{Name: environment}, "", nil
+}
+
+// noProjectRoot simulates running outside any tenant's project checkout, so
+// resolveOpenTenant's cwd fallback never resolves a tenant.
+func noProjectRoot() (string, string, error) {
+	return "", "", ErrNotInGitRepository
+}
+
+func TestResolveOpenTenantInferenceForbidden(t *testing.T) {
+	store := openTenantResolutionStore{}
+	_, err := resolveOpenTenant(store, noProjectRoot, OpenParams{UseDefaultTenant: false})
+	if err == nil {
+		t.Fatal("expected an error when no tenant is given and inference is not permitted")
+	}
+	if !errors.Is(err, ErrOpenTenantNotProvided) {
+		t.Fatalf("expected ErrOpenTenantNotProvided, got: %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "open") {
+		t.Fatalf("error must name the operation (open): %q", msg)
+	}
+	if !strings.Contains(msg, "pass a tenant explicitly") {
+		t.Fatalf("error must name its recovery (pass a tenant explicitly): %q", msg)
+	}
+	if errors.Is(err, ErrDefaultTenantNotConfigured) {
+		t.Fatalf("inference-forbidden case must not be mistaken for the inference-permitted-but-unresolved case: %q", msg)
+	}
+}
+
+func TestResolveOpenTenantInferencePermittedButUnresolved(t *testing.T) {
+	store := openTenantResolutionStore{}
+	_, err := resolveOpenTenant(store, noProjectRoot, OpenParams{UseDefaultTenant: true})
+	if err == nil {
+		t.Fatal("expected an error when no tenant is given and none could be inferred")
+	}
+	if !errors.Is(err, ErrDefaultTenantNotConfigured) {
+		t.Fatalf("expected ErrDefaultTenantNotConfigured, got: %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "open") {
+		t.Fatalf("error must name the operation (open): %q", msg)
+	}
+	if !strings.Contains(msg, "pass a tenant explicitly") || !strings.Contains(msg, "set-default-tenant") {
+		t.Fatalf("error must name its recovery (pass explicitly, or set a default): %q", msg)
+	}
+	if errors.Is(err, ErrOpenTenantNotProvided) {
+		t.Fatalf("inference-permitted-but-unresolved case must not be mistaken for the inference-forbidden case: %q", msg)
+	}
+}
+
+func TestResolveOpenTenantSucceedsWhenProvided(t *testing.T) {
+	store := openTenantResolutionStore{}
+	tenant, err := resolveOpenTenant(store, noProjectRoot, OpenParams{Tenant: "acme"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tenant != "acme" {
+		t.Fatalf("expected acme, got %q", tenant)
+	}
+}
+
+func TestResolveOpenTenantSucceedsFromDefault(t *testing.T) {
+	store := openTenantResolutionStore{defaultTenant: "acme"}
+	tenant, err := resolveOpenTenant(store, noProjectRoot, OpenParams{UseDefaultTenant: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tenant != "acme" {
+		t.Fatalf("expected acme, got %q", tenant)
+	}
+}
+
+func TestResolveOpenEnvironmentInferenceForbidden(t *testing.T) {
+	_, err := resolveOpenEnvironment(OpenParams{UseDefaultEnvironment: false}, TenantConfig{Name: "acme"})
+	if err == nil {
+		t.Fatal("expected an error when no environment is given and inference is not permitted")
+	}
+	if !errors.Is(err, ErrOpenEnvironmentNotProvided) {
+		t.Fatalf("expected ErrOpenEnvironmentNotProvided, got: %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "open") {
+		t.Fatalf("error must name the operation (open): %q", msg)
+	}
+	if !strings.Contains(msg, "pass an environment explicitly") {
+		t.Fatalf("error must name its recovery: %q", msg)
+	}
+}
+
+func TestResolveOpenEnvironmentInferencePermittedButUnresolved(t *testing.T) {
+	_, err := resolveOpenEnvironment(OpenParams{UseDefaultEnvironment: true}, TenantConfig{Name: "acme"})
+	if err == nil {
+		t.Fatal("expected an error when no environment is given and none could be inferred")
+	}
+	if !errors.Is(err, ErrDefaultEnvironmentNotConfigured) {
+		t.Fatalf("expected ErrDefaultEnvironmentNotConfigured, got: %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "acme") {
+		t.Fatalf("error must name the tenant it could not infer an environment for: %q", msg)
+	}
+	if !strings.Contains(msg, "pass an environment explicitly") {
+		t.Fatalf("error must name its recovery: %q", msg)
+	}
+	if errors.Is(err, ErrOpenEnvironmentNotProvided) {
+		t.Fatalf("inference-permitted-but-unresolved case must not be mistaken for the inference-forbidden case: %q", msg)
+	}
+}

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -304,13 +304,40 @@ func TestDeploy(t *testing.T) {
 	t.Run("dry_run_unresolvable_scope_failure_omits_env_pair", func(t *testing.T) {
 		// The other arm of the same header: with no tenant configured at all
 		// there is no env to name, so the header drops the tenant/environment
-		// pair entirely instead of falling back to a bare separator.
+		// pair entirely instead of falling back to a bare separator. Also locks
+		// resolveOpenTenant's inference-permitted-but-unresolved error: it must
+		// name open, not just repeat "default tenant is not configured", and
+		// state the recovery.
 		setup := env.New(t)
 		result := erun.Run(t, []string{"deploy", "--version", "1.0.0", "--dry-run"}, erun.RunOptions{Cwd: setup.Home, Env: setup.Env()})
 		if result.ExitCode == 0 {
 			t.Fatalf("expected non-zero exit with no tenant configured, got 0:\n%s", result.Combined)
 		}
 		golden.Equal(t, "deploy/dry_run_unresolvable_scope_failure_omits_env_pair", normalize.Apply(result.Combined))
+	})
+
+	t.Run("dry_run_default_environment_not_configured_names_open_and_recovery", func(t *testing.T) {
+		// Sibling of the scenario above for resolveOpenEnvironment: a tenant
+		// resolves (from the configured default), but that tenant has no
+		// default environment, so the error must name the tenant and open's
+		// recovery instead of repeating the bare "default environment is not
+		// configured".
+		setup := env.New(t)
+		root := filepath.Join(setup.ConfigHome, "erun")
+		if err := os.MkdirAll(filepath.Join(root, "team"), 0o755); err != nil {
+			t.Fatalf("mkdir tenant config dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "config.yaml"), []byte("defaulttenant: team\n"), 0o644); err != nil {
+			t.Fatalf("write root config: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "team", "config.yaml"), []byte("name: team\n"), 0o644); err != nil {
+			t.Fatalf("write tenant config: %v", err)
+		}
+		result := erun.Run(t, []string{"deploy", "--version", "1.0.0", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit with no default environment configured, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "deploy/dry_run_default_environment_not_configured_names_open_and_recovery", normalize.Apply(result.Combined))
 	})
 
 	t.Run("dry_run_no_devops_module_bootstraps_published_runtime", func(t *testing.T) {

--- a/erun-integration/testdata/deploy/dry_run_default_environment_not_configured_names_open_and_recovery.txt
+++ b/erun-integration/testdata/deploy/dry_run_default_environment_not_configured_names_open_and_recovery.txt
@@ -1,0 +1,5 @@
+audit: erun deploy --dry-run --version <VERSION>
+deploy: tenant= environment= version-override=<VERSION> components=[] force=false current=false
+deploy: spec resolution failed: default environment is not configured for team, and open has no environment to fall back to — pass an environment explicitly, or run `erun init --tenant team --environment <name>` to set one
+==> Deploy failed: default environment is not configured for team, and open has no environment to fall back to — pass an environment explicitly, or run `erun init --tenant team --environment <name>` to set one
+default environment is not configured for team, and open has no environment to fall back to — pass an environment explicitly, or run `erun init --tenant team --environment <name>` to set one

--- a/erun-integration/testdata/deploy/dry_run_unresolvable_scope_failure_omits_env_pair.txt
+++ b/erun-integration/testdata/deploy/dry_run_unresolvable_scope_failure_omits_env_pair.txt
@@ -1,5 +1,5 @@
 audit: erun deploy --dry-run --version <VERSION>
 deploy: tenant= environment= version-override=<VERSION> components=[] force=false current=false
-deploy: spec resolution failed: default tenant is not configured
-==> Deploy failed: default tenant is not configured
-default tenant is not configured
+deploy: spec resolution failed: default tenant is not configured, and open could not infer one from the working directory either — pass a tenant explicitly, or run `erun init --tenant <name> --set-default-tenant` to set a default
+==> Deploy failed: default tenant is not configured, and open could not infer one from the working directory either — pass a tenant explicitly, or run `erun init --tenant <name> --set-default-tenant` to set a default
+default tenant is not configured, and open could not infer one from the working directory either — pass a tenant explicitly, or run `erun init --tenant <name> --set-default-tenant` to set a default

--- a/erun-integration/testdata/list/empty_config.txt
+++ b/erun-integration/testdata/list/empty_config.txt
@@ -7,7 +7,7 @@ Current Directory:
   path: none
   repo: none
   configured tenant: none
-  effective target: unavailable (default tenant is not configured)
+  effective target: unavailable (default tenant is not configured, and open could not infer one from the working directory either — pass a tenant explicitly, or run `erun init --tenant <name> --set-default-tenant` to set a default)
 Cloud Providers:
   none
 Tenants:

--- a/erun-integration/testdata/observe/dry_run_missing_tenant.txt
+++ b/erun-integration/testdata/observe/dry_run_missing_tenant.txt
@@ -1,2 +1,2 @@
 audit: erun observe --dry-run
-default tenant is not configured
+default tenant is not configured, and open could not infer one from the working directory either — pass a tenant explicitly, or run `erun init --tenant <name> --set-default-tenant` to set a default

--- a/erun-integration/testdata/usage/dry_run_missing_tenant.txt
+++ b/erun-integration/testdata/usage/dry_run_missing_tenant.txt
@@ -1,2 +1,2 @@
 audit: erun usage --dry-run
-default tenant is not configured
+default tenant is not configured, and open could not infer one from the working directory either — pass a tenant explicitly, or run `erun init --tenant <name> --set-default-tenant` to set a default

--- a/erun-ui/frontend/src/app/notificationThunks.test.ts
+++ b/erun-ui/frontend/src/app/notificationThunks.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { showTerminalError, showTerminalFailure } from './notificationThunks';
+import { setTerminalCopyOutput, setTerminalMessage } from './slices/terminalStatusSlice';
+import type { AppThunk } from './store';
+
+interface RecordedAction {
+  type: string;
+  payload?: unknown;
+}
+type ThunkGetState = Parameters<AppThunk>[1];
+type ThunkExtraArg = Parameters<AppThunk>[2];
+type LooseDispatch = (action: unknown) => unknown;
+
+function collectDispatched(thunk: AppThunk): RecordedAction[] {
+  const actions: RecordedAction[] = [];
+  const getState = (() => ({})) as ThunkGetState;
+  const extra = undefined as unknown as ThunkExtraArg;
+  const dispatch: LooseDispatch = (action) => {
+    if (typeof action === 'function') {
+      return (action as (d: LooseDispatch, g: ThunkGetState, e: ThunkExtraArg) => unknown)(
+        dispatch,
+        getState,
+        extra,
+      );
+    }
+    actions.push(action as RecordedAction);
+    return undefined;
+  };
+  thunk(dispatch, getState, extra);
+  return actions;
+}
+
+// A bare backend error carries no captured command output, so the titlebar
+// must not offer a Copy action for it — copying the same sentence already
+// visible in the pill (Titlebar.Status.tsx renders the Copy button only when
+// terminalCopyOutput is non-empty) tells the operator nothing they don't
+// already see.
+test('showTerminalError sets an error status with no copyable output', () => {
+  const actions = collectDispatched(
+    showTerminalError('no tenant given for open: pass a tenant explicitly'),
+  );
+
+  const messageAction = actions.find((action) => action.type === setTerminalMessage.type);
+  assert.ok(messageAction, 'expected a terminal status message');
+  assert.deepEqual(messageAction.payload, {
+    message: 'no tenant given for open: pass a tenant explicitly',
+    busy: false,
+    kind: 'error',
+    detail: '',
+    actionKind: '',
+  });
+
+  const copyAction = actions.find((action) => action.type === setTerminalCopyOutput.type);
+  assert.ok(copyAction, 'expected a copy-output action');
+  assert.equal(
+    copyAction.payload,
+    '',
+    'a bare error must not fake a copy buffer from its own text',
+  );
+});
+
+// A caller that genuinely captured command output (a failed IDE launch, a
+// delete's namespace-cleanup warning) still gets to offer it.
+test('showTerminalFailure preserves genuinely captured output', () => {
+  const actions = collectDispatched(
+    showTerminalFailure(
+      'Deleted team / dev.',
+      'namespace cleanup failed',
+      'Deleted team / dev. namespace cleanup failed',
+      '',
+      null,
+    ),
+  );
+
+  const copyAction = actions.find((action) => action.type === setTerminalCopyOutput.type);
+  assert.ok(copyAction, 'expected a copy-output action');
+  assert.equal(copyAction.payload, 'Deleted team / dev. namespace cleanup failed');
+});

--- a/erun-ui/frontend/src/app/notificationThunks.ts
+++ b/erun-ui/frontend/src/app/notificationThunks.ts
@@ -38,6 +38,15 @@ export const showTerminalMessage =
     dispatch(setRetrySelection(null));
   };
 
+// showTerminalFailure's copyOutput is taken exactly as given: empty means the
+// caller has no captured command output to offer, and the titlebar renders
+// no Copy action for it. A bare validation/precondition message — "tenant is
+// required" and its kin — already says everything there is to say once it
+// names the operation and the recovery, so re-copying that same sentence as
+// fake "output" earns the operator nothing (root AGENTS.md "Smooth,
+// Seamless, No Dead Ends" — an affordance that does nothing is worse than no
+// affordance). A caller that genuinely captured command output (a failed IDE
+// launch, a delete's namespace-cleanup warning) passes it explicitly.
 export const showTerminalFailure =
   (
     message: string,
@@ -56,11 +65,7 @@ export const showTerminalFailure =
         actionKind: action,
       }),
     );
-    // Some errors (e.g. AWS API strings) arrive with no terminal output; copy
-    // the message itself so the operator can paste the full error — which the
-    // titlebar pill truncates — into a bug report. Nielsen #9 (recovery from errors).
-    const effectiveCopy = copyOutput || joinMessageForCopy(message, detail);
-    dispatch(setTerminalCopyOutput(effectiveCopy));
+    dispatch(setTerminalCopyOutput(copyOutput));
     dispatch(setTerminalCopyStatus(''));
     dispatch(setRetrySelection(action === 'wait-longer' ? retrySelection : null));
   };
@@ -72,28 +77,13 @@ export const showTerminalFailure =
 // neutral grey pill — polite aria-live, no role="alert", and no Copy action
 // (the terminal copy buffer only gets set by showTerminalFailure). This
 // wraps showTerminalFailure with the defaults that shape needs: no detail
-// beyond the message, the message itself as the copyable text, and no retry
-// action.
+// beyond the message, no captured output to copy (the message is already
+// fully visible in the pill/popover), and no retry action.
 export const showTerminalError =
   (message: string): AppThunk =>
   (dispatch) => {
-    dispatch(showTerminalFailure(message, '', message, '', null));
+    dispatch(showTerminalFailure(message, '', '', '', null));
   };
-
-function joinMessageForCopy(message: string, detail: string): string {
-  const trimmedMessage = message.trim();
-  const trimmedDetail = detail.trim();
-  if (!trimmedMessage && !trimmedDetail) {
-    return '';
-  }
-  if (!trimmedDetail) {
-    return trimmedMessage;
-  }
-  if (!trimmedMessage) {
-    return trimmedDetail;
-  }
-  return `${trimmedMessage}. ${trimmedDetail}`;
-}
 
 export const hideTerminalMessage = (): AppThunk => (dispatch) => {
   dispatch(clearTerminalStatus());

--- a/erun-ui/playwright/tests/close-environment-failure.spec.ts
+++ b/erun-ui/playwright/tests/close-environment-failure.spec.ts
@@ -1,15 +1,16 @@
 import { test, expect } from '../fixtures/erunApp.js';
 
 // A CloseEnvironmentSessions failure used to render as a neutral info pill
-// via showTerminalMessage — polite aria-live, no role="alert", no Copy
-// action — indistinguishable from a routine status update. Unlike a
-// Manage-dialog-scoped failure (where the dialog's own inline error already
-// carries the message while the titlebar sits behind the modal's
-// aria-hidden), closing an env's tabs is a sidebar action with no dialog in
-// the way, so the titlebar pill is the only surface — and it must be an
-// actionable error.
-test.describe('close environment — failure surfacing (#1212)', () => {
-  test('a close failure renders as an error with a Copy action, not a silent info pill', async ({
+// via showTerminalMessage — polite aria-live, no role="alert" — indistinguishable
+// from a routine status update. Unlike a Manage-dialog-scoped failure (where
+// the dialog's own inline error already carries the message while the
+// titlebar sits behind the modal's aria-hidden), closing an env's tabs is a
+// sidebar action with no dialog in the way, so the titlebar pill is the only
+// surface — and it must be an actionable error. The pill no longer offers a
+// Copy action for a bare RPC error with no captured command output: copying
+// the same sentence already visible in the pill earns the operator nothing.
+test.describe('close environment — failure surfacing', () => {
+  test('a close failure renders as an error, not a silent info pill, with no Copy action for a message with no captured output', async ({
     app,
     page,
     seededEnv,
@@ -35,7 +36,7 @@ test.describe('close environment — failure surfacing (#1212)', () => {
       .getByRole('alert')
       .filter({ hasText: 'CLOSE_ENVIRONMENT_UNREACHABLE_MARKER' });
     await expect(pill).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Copy output' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Copy output' })).not.toBeVisible();
 
     // The close never completed, so the dot must still be there — a stray
     // success side effect alongside the reported failure would itself be a bug.

--- a/erun-ui/playwright/tests/open-tenant-resolution-error.spec.ts
+++ b/erun-ui/playwright/tests/open-tenant-resolution-error.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '../fixtures/erunApp.js';
+
+// erun-common's resolveOpenTenant used to fail with a bare "tenant is
+// required" — four words with no operation, no subject, and no recovery,
+// rendered verbatim in the titlebar beside a Copy output button that had
+// nothing real to copy. It now names the operation ("open") and states the
+// recovery, and the surface no longer offers Copy output for a message with
+// no captured command output. This spec stubs the RPC layer to return that
+// exact enriched text (the same technique close-environment-failure.spec.ts
+// uses) so it exercises the rendering contract without depending on a real
+// call path that happens to reach it today.
+test.describe('open tenant-resolution error — actionable, no fake Copy action', () => {
+  test('the titlebar names the operation and the recovery, with no Copy action', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    await app.sidebar.openEnvironment(seededEnv.tenant, seededEnv.environment);
+    await expect(app.sidebar.envOpenDot(seededEnv.tenant, seededEnv.environment)).toBeVisible();
+
+    const enrichedMessage =
+      'no tenant given for open: this call path does not fall back to the working directory or a configured default tenant — pass a tenant explicitly';
+
+    await page.route('**/__erun_invoke', async (route, request) => {
+      const body = JSON.parse(request.postData() ?? '{}') as { method: string };
+      if (body.method === 'CloseEnvironmentSessions') {
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ error: enrichedMessage }),
+        });
+      }
+      await route.continue();
+    });
+
+    await app.sidebar.envOpenDot(seededEnv.tenant, seededEnv.environment).focus();
+    await app.sidebar.envOpenDot(seededEnv.tenant, seededEnv.environment).press('Enter');
+
+    const pill = page.getByRole('alert').filter({ hasText: 'no tenant given for open' });
+    await expect(pill).toBeVisible();
+    await expect(pill).toContainText('pass a tenant explicitly');
+    await expect(page.getByRole('button', { name: 'Copy output' })).not.toBeVisible();
+
+    await page.screenshot({
+      path: 'test-results/open-tenant-resolution-error-titlebar.png',
+    });
+  });
+});


### PR DESCRIPTION
`tenant is required` reached the operator as four words in a titlebar toast
beside a `Copy output` button — nothing to act on, and nothing worth copying.

## The message now names the operation, the cause and a next step

`resolveOpenTenant` held three facts it never reported: that it was resolving a
tenant *for an open*, that `UseDefaultTenant` was false so the two fallbacks
were deliberately not consulted, and that the recovery therefore differs by
cause. Collapsing those into one sentence guarantees the sentence is wrong for
most of the people who read it, so they are now distinguished:

- **inference not permitted on this path** —
  `no tenant given for open: this call path does not fall back to the working
  directory or a configured default tenant — pass a tenant explicitly`
- **inference permitted but nothing to infer** —
  `…, and open could not infer one from the working directory either — pass a
  tenant explicitly, or run `erun init --tenant <name> --set-default-tenant` to
  set a default`

Both name the operation and carry a runnable command. The same treatment is
applied to the environment case, which had the identical bare phrase.

The shape follows the local precedent rather than inventing one: the adjacent
`loadOpenTenantConfig` already wrapped as `%w: <subject>`, so the failing line
was the outlier in its own file. New sentinels `ErrOpenTenantNotProvided` and
`ErrOpenEnvironmentNotProvided` join the existing family.

## The surface stops promising output it does not have

`Copy output` is the right affordance for a command whose output explains
itself and the wrong one for a bare sentence. It is now suppressed when no
output was captured, and kept where the error genuinely carries some.

## Verification

- `make check` → **green**: golangci-lint **0 issues** across all six modules,
  `erun-ui` Go tests ok, frontend 77/77, integration suite ok including the new
  `desktopsurface` gate, coverage **76.1%** (≥ 75.8%)
- new unit tests on `resolveOpenTenant` covering both empty-tenant paths
- integration goldens updated, plus a new golden so a regression to a bare
  phrase fails the gate instead of reaching a toast
- a frontend test that the error surface renders no `Copy output` when no output
  was captured, and a new Playwright spec for the rendered message

### On the Playwright run — read before assuming this branch is red

A full-suite run on this branch reported six failures. **Five were contention
artifacts, not defects.** Re-running the same four spec files in isolation, on
the same pod, against `main` and against this branch:

| run | result |
|---|---|
| `main` `b2ff81f9` | 1 failed (`review-diff-line-comment.spec.ts:277`), 16 passed |
| this branch | 1 failed (`review-diff-line-comment.spec.ts:277`), 16 passed |

Identical. `close-confirm`, the three `manage` specs and
`orchestrator-reopen-on-launch` all pass on this branch in isolation, exactly as
they do on `main`.

The remaining failure is **pre-existing on `main`** and unrelated to this
change. Note it moves under load — the contended full run failed at `:196`
while both isolated runs fail at `:277`, so that spec file is order/state
sensitive. Filed separately rather than folded in here.

Closes #1432