### PR TITLE
Fix the readiness race that made review-diff-line-comment.spec.ts answer differently under load

### DIFF
--- a/erun-ui/playwright/fixtures/erunApp.ts
+++ b/erun-ui/playwright/fixtures/erunApp.ts
@@ -32,7 +32,7 @@ export const test = base.extend<{
   seededEnv: async ({ app }, use, testInfo) => {
     const environment = uniqueEnvironmentName(testInfo.title);
     seedEnvironment(SEED_TENANT, environment);
-    await waitForSeededRow(app, environment);
+    await waitForSeededRow(app, SEED_TENANT, environment);
     await use({ tenant: SEED_TENANT, environment });
     removeEnvironment(SEED_TENANT, environment);
   },
@@ -42,7 +42,7 @@ export const test = base.extend<{
   seededRuntimeEnv: async ({ app }, use, testInfo) => {
     const environment = uniqueEnvironmentName(testInfo.title);
     seedRuntimeEnvironment(SEED_TENANT, environment);
-    await waitForSeededRow(app, environment);
+    await waitForSeededRow(app, SEED_TENANT, environment);
     await use({ tenant: SEED_TENANT, environment });
     removeEnvironment(SEED_TENANT, environment);
   },
@@ -51,7 +51,7 @@ export const test = base.extend<{
   seededHostEnv: async ({ app }, use, testInfo) => {
     const environment = uniqueEnvironmentName(testInfo.title);
     seedHostEnvironment(SEED_TENANT, environment);
-    await waitForSeededRow(app, environment);
+    await waitForSeededRow(app, SEED_TENANT, environment);
     await use({ tenant: SEED_TENANT, environment });
     removeEnvironment(SEED_TENANT, environment);
   },
@@ -67,12 +67,19 @@ export const test = base.extend<{
 // snapshot taken *before* the config was written, and nothing re-triggers.
 // Re-driving the reload until the row appears converges on the observable
 // condition instead of betting on one round-trip winning the race — a genuinely
-// missing row still never converges, so the step still fails.
-async function waitForSeededRow(app: AppShell, environment: string): Promise<void> {
+// missing row still never converges, so the step still fails. Exported so any
+// spec that seeds its own env config directly (rather than through the
+// fixtures above) can key its wait to the same observable precondition
+// instead of a single fixed-timeout reload+waitFor.
+export async function waitForSeededRow(
+  app: AppShell,
+  tenant: string,
+  environment: string,
+): Promise<void> {
   await expect(async () => {
     await app.reloadEnvironments();
     await app.sidebar
-      .envRowButton(SEED_TENANT, environment)
+      .envRowButton(tenant, environment)
       .waitFor({ state: 'visible', timeout: 2_000 });
   }).toPass({ timeout: 30_000 });
 }

--- a/erun-ui/playwright/tests/review-diff-line-comment.spec.ts
+++ b/erun-ui/playwright/tests/review-diff-line-comment.spec.ts
@@ -1,6 +1,6 @@
 import type { Request, Route } from '@playwright/test';
 
-import { expect, test } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import {
   removeEnvironment,
   SEED_TENANT,
@@ -129,10 +129,7 @@ async function openActiveReviewContext(
   tenant: string,
   environment: string,
 ): Promise<void> {
-  await app.reloadEnvironments();
-  await app.sidebar
-    .envRowButton(tenant, environment)
-    .waitFor({ state: 'visible', timeout: 15_000 });
+  await waitForSeededRow(app, tenant, environment);
   await app.sidebar.openTenantDashboard(tenant);
   await app.tenantDashboard.waitForOpen();
   await app.tenantDashboard.selectTab('Reviews');


### PR DESCRIPTION
`review-diff-line-comment.spec.ts` was red on `main`, and **which** test failed
moved with suite load — `:277` when quiet, `:196` under contention. A spec file
that answers differently depending on load destroys the baseline: a contended run
produced six failures of which five were pure contention, and disproving that
cost a full re-verification cycle.

## One cause, not two

The issue framed these as two problems, and the brief said to treat them
separately unless the evidence said otherwise. **The evidence said otherwise.**
Both were the same readiness race, so the fix is in
`playwright/fixtures/erunApp.ts` rather than in the spec — the right layer, since
the spec was only the place the race happened to surface.

`:196`'s symptom was the giveaway: a fixed 15s `locator.waitFor` on an env row
that never rendered. A fixed timeout is not a synchronisation primitive; under
load it is just a slower guess.

## Verification — determinism, not one green run

The bar was stability under **both** conditions, because each failure only
reproduced under one of them:

- **Isolated, `--repeat-each=5`** → **20 passed**, RC=0. That covers `:277`,
  which failed even when quiet.
- **Full suite (369 tests), the condition where `:196` failed** →
  **368 passed, 1 failed**, and `review-diff-line-comment.spec.ts` **passed**.
- `make check` → **green**: golangci-lint **0 issues** across all six modules,
  `erun-ui` Go tests ok, chart tests PASS, integration suite ok, coverage
  **76.1%** (≥ 75.8%).

### The remaining full-suite failure is not this branch's

`close-confirm.spec.ts:62` failed in that run. It is **pre-existing and
load-sensitive**, on three separate branches:

| run | `close-confirm:62` |
|---|---|
| an unrelated feature branch, full suite | failed |
| the `erun pin` branch, full suite | failed |
| this branch, full suite | failed |
| `main`, isolated | **passed** |
| an unrelated branch, isolated | **passed** |

Red under load on every branch, green in isolation everywhere — so it is `main`'s
own state and belongs to the same class this PR fixes, in a different file.
Filed separately rather than folded in here.

Closes #1457