### PR TITLE
Finish the fake deploy a lock spec starts, so it stops polluting every spec after it

### DIFF
--- a/erun-ui/playwright/tests/activity-lock-new-terminal.spec.ts
+++ b/erun-ui/playwright/tests/activity-lock-new-terminal.spec.ts
@@ -59,5 +59,13 @@ test.describe('a terminal opened after a deploy has already started locks immedi
 
     const overlay = page.getByRole('status').filter({ hasText: 'Waiting for deploy to complete' });
     await expect(overlay).toBeVisible();
+
+    // The backend's trace scanner has no way to tell this fake deploy apart
+    // from a real one, so without a matching completion line the activity
+    // entry it started stays "running" in the shared singleton backend for
+    // every spec that runs after this one. Finish it the same way a real
+    // deploy would.
+    await runInSession(page, localSessionId, `echo '==> Deployed ${tenant}/${environment}'`);
+    await expect(overlay).toBeHidden();
   });
 });


### PR DESCRIPTION
`close-confirm.spec.ts:62` — *"an idle queue never raises the dialog"* — failed
in full-suite runs and passed in isolation, on three separate branches.

## It was never load-sensitivity

The issue (and my own framing) called this load-sensitive. It is not. It is a
**deterministic cross-spec leak**, and the ordering just made it look like load.

`activity-lock-new-terminal.spec.ts` echoes a fake `==> Deploying
<tenant>/<environment>` line into a real Local-shell PTY to drive the backend's
real trace-line scanner — which is the right way to prove the lock overlay. But
it never sends the matching `==> Deployed` completion. The backend is a
**singleton across the whole suite** (`workers: 1`), so the "running" deploy
entry it creates never finishes and pollutes the shared activity queue for every
spec that runs afterwards.

Alphabetical file order puts it before `close-confirm.spec.ts`, so the failure
was **deterministic given that ordering**, not probabilistic. "Under load" only
ever described *when full-suite runs happen to include both files*.

Proved by reproducing it with zero contention: running
`activity-lock-new-terminal.spec.ts` immediately before `close-confirm.spec.ts`
fails the idle-queue assertion every time.

The competing hypothesis was ruled out on evidence rather than by preference:
`PrepareWindowClose` reads `a.activityQueue.list()` **directly**, with no poller
involved, so the stale-observation race that caused #1440 could not apply here.

## The fix

Eight lines, in the spec that leaks: send the matching completion line and wait
for the overlay to hide — finishing the entry the same way a real deploy would.
**No production code changed**, because the production behaviour was never
wrong; the test was leaving a deploy permanently in flight.

## Verification

- isolated, `--repeat-each=5` → **15/15 green**
- full suite (371 tests) → **368 passed**; `close-confirm.spec.ts` **and**
  `sidebar-env-idle-clears-latch.spec.ts` (the other named pre-existing red)
  both passed

### Failures that are not this branch's

Three unrelated timeout-based failures appeared in that run —
`env-init-refresh.spec.ts:62`, `orchestrator-cross-env-diff.spec.ts:326`,
`review-keyboard-model.spec.ts:298` — all in areas untouched here. Filed as
**#1466, #1467, #1468**; the last was root-caused as the same fixed-timeout
pattern #1459 already fixed elsewhere, simply not applied to that file.

`make check` failed on `TestRelease/real_run_absorbs_a_base_branch_that_moved_during_the_build`.
That is **pre-existing and timing-flaky, not this branch's**, confirmed by
independent baseline: it fails on current `main` (`bdd9ac2b`) *and* on the
previous `main` (`5fe08530`), while a gate run on a branch off `5fe08530`
passed it earlier the same day. Filed as **#1469**. Everything else in
`make check` — lint, `test-erun-ui`, `test-frontend`, `helm-chart-tests` —
passed.

Closes #1460